### PR TITLE
Add session guidance to CLI output, fix session path mismatch

### DIFF
--- a/.claude/commands/ox-session-start.md
+++ b/.claude/commands/ox-session-start.md
@@ -23,10 +23,10 @@ Keywords: session start, record, capture, begin, log, track, ledger, start recor
 **Symptom:** No SageOx configuration found
 **Solution:** Run `ox init` to initialize SageOx in this repository
 
-## Post-Command: Show Notice (REQUIRED)
+## Post-Command (REQUIRED)
 
-After the command completes, check the JSON output for a `notice` field.
-If present, you MUST display the notice text to the user verbatim. This is a one-time
-transparency notice about session recording that the user needs to see.
+After the command completes, check the JSON output:
+- **`notice`**: If present, display the notice text to the user verbatim. This is a one-time transparency notice about session recording.
+- **`guidance`**: Follow this guidance throughout the session. It contains instructions about plan capture and session boundaries.
 
 $ox agent session start

--- a/.claude/commands/ox-session-stop.md
+++ b/.claude/commands/ox-session-stop.md
@@ -23,17 +23,6 @@ Keywords: session stop, save, finish, end, done, wrap up, stop recording, upload
 **Symptom:** Command hangs during "Generating summary..."
 **Solution:** Summarization runs client-side. Wait for completion or check network if it stalls
 
-## Pre-Command: Capture Plan (if applicable)
-
-Before running the session stop command, check if you used plan mode during this session:
-
-1. Look for your plan file in `~/.claude/plans/` (the most recently modified `.md` file)
-2. If a plan file exists and was used in this session, save it with the session:
-   ```bash
-   cat ~/.claude/plans/<plan-file>.md | ox agent <id> session plan
-   ```
-3. This ensures the plan is preserved alongside the session in the ledger
-
 ## Post-Command: Generate and Push Summary (REQUIRED)
 
 After the command completes, check the JSON output for a `summary_prompt` field.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,7 @@ make bump-version NEW_VERSION=0.10.0
 - Utilize modern 2025 TUI best practices when changing or adding UX.
 - Let Edward Tufte inspire data visualization ideas.
 - While `ox` is designed with Agent UX in mind for agentic work, UX output and tool ergonomics optimized for human delight and understanding are extremely important.
+- Agent behavioral guidance belongs in CLI JSON output (e.g., `guidance` field), not in agent-specific skill files — skills should be thin wrappers that relay CLI output.
 - Do not use Terraform tools from HashiCorp, use OpenTufu, due to BSL licensing issues.
 - Don't do git push.
 - Make sure CLI docs version always matches the CLI version.

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -40,6 +40,13 @@ import (
 //   2. --text: outputs human-readable text only
 //   3. default: outputs full JSON
 
+// sessionStartGuidance is behavioral guidance for agents during a recorded session.
+// Returned in the session start JSON so all coding agents (not just Claude Code) receive it.
+const sessionStartGuidance = `During this recorded session:
+1. Plan capture: After creating or revising a plan, immediately save it with: cat <plan-file> | ox agent <id> session plan
+2. After stopping: Check the session stop output for plan_path. If empty and you created a plan, save it now with: cat <plan-file> | ox agent <id> session plan
+3. Session boundaries: One plan per session. If work shifts to an unrelated feature, suggest stopping this session and starting a new one.`
+
 // sessionStartOutput is the JSON output format for session start.
 type sessionStartOutput struct {
 	Success bool   `json:"success"`
@@ -48,8 +55,9 @@ type sessionStartOutput struct {
 	Title   string `json:"title,omitempty"`
 	Adapter string `json:"adapter"`
 	Started string `json:"started"`
-	Hint    string `json:"hint,omitempty"`   // suggests how to end recording
-	Notice  string `json:"notice,omitempty"` // one-time notice the agent MUST show to the user
+	Hint     string `json:"hint,omitempty"`     // suggests how to end recording
+	Notice   string `json:"notice,omitempty"`   // one-time notice the agent MUST show to the user
+	Guidance string `json:"guidance,omitempty"` // behavioral guidance for the agent during the session
 }
 
 // runAgentSessionStart starts recording a session for the agent.
@@ -111,6 +119,7 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 		AdapterName: adapterName,
 		SessionFile: sessionFile,
 		Title:       title,
+		Username:    getSessionUsername(),
 	}
 
 	state, err := session.StartRecording(projectRoot, opts)
@@ -141,14 +150,15 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 		fmt.Println()
 		fmt.Println("--- Machine Output ---")
 		output := sessionStartOutput{
-			Success: true,
-			Type:    "session_start",
-			AgentID: inst.AgentID,
-			Title:   title,
-			Adapter: adapterName,
-			Started: state.StartedAt.Format(time.RFC3339),
-			Hint:    "Run /ox-session-stop to end recording",
-			Notice:  notice,
+			Success:  true,
+			Type:     "session_start",
+			AgentID:  inst.AgentID,
+			Title:    title,
+			Adapter:  adapterName,
+			Started:  state.StartedAt.Format(time.RFC3339),
+			Hint:     "Run /ox-session-stop to end recording",
+			Notice:   notice,
+			Guidance: sessionStartGuidance,
 		}
 		jsonOut, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
@@ -176,14 +186,15 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 
 	// default: JSON output (or explicit --json)
 	output := sessionStartOutput{
-		Success: true,
-		Type:    "session_start",
-		AgentID: inst.AgentID,
-		Title:   title,
-		Adapter: adapterName,
-		Started: state.StartedAt.Format(time.RFC3339),
-		Hint:    "Run /ox-session-stop to end recording",
-		Notice:  notice,
+		Success:  true,
+		Type:     "session_start",
+		AgentID:  inst.AgentID,
+		Title:    title,
+		Adapter:  adapterName,
+		Started:  state.StartedAt.Format(time.RFC3339),
+		Hint:     "Run /ox-session-stop to end recording",
+		Notice:   notice,
+		Guidance: sessionStartGuidance,
 	}
 	jsonOut, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
@@ -460,9 +471,6 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 	}
 	result.EntryCount = len(rawEntries)
 
-	// get user info for filename
-	username := getSessionUsername()
-
 	// get repo ID for context path
 	repoID := getRepoIDOrDefault(projectRoot)
 
@@ -477,8 +485,10 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 		return nil, fmt.Errorf("failed to create store: %w", err)
 	}
 
-	// generate filename
-	filename := session.GenerateFilename(username, state.AgentID)
+	// use session name from recording state (created at start time)
+	// instead of generating a new name, which would have a different timestamp and
+	// potentially different username, causing path mismatches
+	filename := session.GetSessionName(state.SessionPath)
 
 	// create redactor for secret scrubbing
 	redactor := session.NewRedactor()


### PR DESCRIPTION
## Summary

- Add `guidance` field to `ox agent <id> session start` JSON output so all coding agents (not just Claude Code) receive plan capture and session boundary instructions
- Fix session path mismatch bug where stop-time session name differed from start-time name (timestamp + username both mismatched)
- Slim down skill files to thin wrappers that relay CLI output

## Motivation

Based on [team discussion between Ryan and Ajit (Feb 16)](https://sageox.ai/team/team_jihjpfkt8b/media/recordings/rec_019c688c-9515-704c-bca8-5a085c957547):

- Plans were only captured at session-stop time, meaning Ctrl-C / aborted sessions lost the plan entirely
- Plan capture instructions lived in Claude Code skill files, so non-Claude agents never received them
- Session stop regenerated the session name with `time.Now()` instead of reusing the name from start, causing path mismatches

## Design principle

Agent behavioral guidance belongs in CLI JSON output (`guidance` field), not in agent-specific skill files. Skills should be thin wrappers that relay CLI output. This ensures all coding agents receive the same instructions.

```mermaid
flowchart LR
    A[ox agent session start] -->|JSON with guidance| B[Any Coding Agent]
    B -->|reads guidance| C[Captures plan mid-session]
    B -->|reads guidance| D[Suggests stop/start on topic shift]
    B -->|belt & suspenders| E[Checks plan_path at stop time]
```

## Changes

| File | Change |
|------|--------|
| `cmd/ox/agent_session.go` | Add `Guidance` field to `sessionStartOutput`, fix session path reuse at stop time, pass username at start time |
| `.claude/commands/ox-session-start.md` | Slim to thin wrapper relaying `notice` + `guidance` from JSON |
| `.claude/commands/ox-session-stop.md` | Remove pre-command plan capture section (now driven by start guidance) |
| `CLAUDE.md` | Add design principle about guidance in CLI output |

## Test plan

- [ ] `make lint && make test` pass
- [ ] `ox agent <id> session start` JSON output contains `guidance` field
- [ ] Non-Claude agent reads JSON and receives same plan capture + session boundary instructions
- [ ] Session stop reuses the session name from start (no timestamp/username mismatch)
- [ ] Plan capture works mid-session (primary path) and as fallback at stop time (belt & suspenders)