### PR TITLE
fix(daemon): prevent config cache from clobbering ledger path

### DIFF
--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -1405,8 +1405,8 @@ daemon health, and a tree view of all SageOx directory locations.`,
 				// load local config for git repos section
 				localCfg, _ = config.LoadLocalConfig(gitRoot)
 
-				// if no ledger in config, try to get info from cloud API or default path
-				if localCfg.Ledger == nil {
+				// if no ledger path in config, try to get info from cloud API or default path
+				if localCfg.Ledger == nil || localCfg.Ledger.Path == "" {
 					ledgerPath, _ := ledger.DefaultPath()
 
 					// first check if ledger exists locally at default path

--- a/internal/config/local_config.go
+++ b/internal/config/local_config.go
@@ -274,9 +274,10 @@ func (c *LocalConfig) SetLedgerPath(path string) {
 }
 
 // UpdateLedgerLastSync updates the last sync time for the ledger.
+// No-ops if Ledger is nil (consistent with UpdateTeamContextLastSync behavior).
 func (c *LocalConfig) UpdateLedgerLastSync() {
 	if c.Ledger == nil {
-		c.Ledger = &LedgerConfig{}
+		return
 	}
 	c.Ledger.LastSync = time.Now().UTC()
 }

--- a/internal/config/local_config_test.go
+++ b/internal/config/local_config_test.go
@@ -380,17 +380,25 @@ func TestLocalConfig_SetLedgerPath(t *testing.T) {
 }
 
 func TestLocalConfig_UpdateLedgerLastSync(t *testing.T) {
-	cfg := &LocalConfig{}
-	before := time.Now().UTC()
+	t.Run("no-ops when ledger is nil", func(t *testing.T) {
+		cfg := &LocalConfig{}
+		cfg.UpdateLedgerLastSync()
+		assert.Nil(t, cfg.Ledger, "should not create lossy LedgerConfig when nil")
+	})
 
-	cfg.UpdateLedgerLastSync()
+	t.Run("updates existing ledger and preserves path", func(t *testing.T) {
+		cfg := &LocalConfig{
+			Ledger: &LedgerConfig{Path: "/some/path"},
+		}
+		before := time.Now().UTC()
+		cfg.UpdateLedgerLastSync()
+		after := time.Now().UTC()
 
-	after := time.Now().UTC()
-
-	require.NotNil(t, cfg.Ledger, "expected ledger to be created")
-	require.True(t, cfg.Ledger.HasLastSync(), "expected last_sync to be set")
-	assert.True(t, !cfg.Ledger.LastSync.Before(before) && !cfg.Ledger.LastSync.After(after),
-		"last_sync %v not in range [%v, %v]", cfg.Ledger.LastSync, before, after)
+		require.True(t, cfg.Ledger.HasLastSync(), "expected last_sync to be set")
+		assert.Equal(t, "/some/path", cfg.Ledger.Path, "path must be preserved")
+		assert.True(t, !cfg.Ledger.LastSync.Before(before) && !cfg.Ledger.LastSync.After(after),
+			"last_sync %v not in range [%v, %v]", cfg.Ledger.LastSync, before, after)
+	})
 }
 
 func TestLocalConfig_GetTeamContext(t *testing.T) {

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/auth"
-	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/version"
@@ -1068,25 +1067,14 @@ func (s *SyncScheduler) fetchLedgerURLFromAPI() {
 }
 
 // persistLedgerPath saves the ledger path to config.local.toml for persistence across daemon restarts.
+// Uses the workspace registry's config cache to avoid stale-cache overwrites from UpdateConfigLastSync.
 func (s *SyncScheduler) persistLedgerPath() {
 	ledger := s.workspaceRegistry.GetLedger()
 	if ledger == nil || ledger.Path == "" {
 		return
 	}
-	localCfg, err := config.LoadLocalConfig(s.config.ProjectRoot)
-	if err != nil {
-		s.logger.Warn("failed to load local config for ledger persistence", "error", err)
-		return
-	}
-	if localCfg.Ledger == nil || localCfg.Ledger.Path == "" {
-		localCfg.Ledger = &config.LedgerConfig{
-			Path: ledger.Path,
-		}
-		if err := config.SaveLocalConfig(s.config.ProjectRoot, localCfg); err != nil {
-			s.logger.Warn("failed to persist ledger to config.local.toml", "error", err)
-		} else {
-			s.logger.Info("persisted ledger path to config.local.toml", "path", ledger.Path)
-		}
+	if err := s.workspaceRegistry.PersistLedgerPath(ledger.Path); err != nil {
+		s.logger.Warn("failed to persist ledger to config.local.toml", "error", err)
 	}
 	// trigger clone if ledger doesn't exist on disk (self-healing)
 	if !ledger.Exists && ledger.CloneURL != "" {

--- a/internal/daemon/workspace_registry.go
+++ b/internal/daemon/workspace_registry.go
@@ -59,6 +59,11 @@ type WorkspaceState struct {
 // - Caches loaded config to avoid repeated disk reads
 // - Adds runtime state (Exists, LastErr, SyncInProgress) on top of config
 // - Thread-safe for concurrent access from daemon goroutines
+//
+// INVARIANT: WorkspaceRegistry is the sole writer to config.local.toml within the daemon.
+// All config writes must go through registry methods (UpdateConfigLastSync, PersistLedgerPath, etc.)
+// to prevent cache/disk divergence. Never call config.SaveLocalConfig directly from sync.go
+// or other daemon code.
 type WorkspaceRegistry struct {
 	mu sync.RWMutex
 
@@ -78,7 +83,6 @@ type WorkspaceRegistry struct {
 	localConfigCache    *config.LocalConfig
 	localConfigLoadedAt time.Time
 	configCacheDuration time.Duration
-	configLoading       bool // prevents redundant concurrent loads
 }
 
 // NewWorkspaceRegistry creates a new workspace registry for the given project.
@@ -106,14 +110,6 @@ func (r *WorkspaceRegistry) loadFromConfigLocked() error {
 	if r.localConfigCache != nil && time.Since(r.localConfigLoadedAt) < r.configCacheDuration {
 		return nil // use cached config
 	}
-
-	// if another goroutine is loading, use stale cache (other goroutine is refreshing)
-	if r.configLoading {
-		return nil
-	}
-
-	r.configLoading = true
-	defer func() { r.configLoading = false }()
 
 	// load fresh config
 	localCfg, err := config.LoadLocalConfig(r.projectRoot)
@@ -493,6 +489,31 @@ func (r *WorkspaceRegistry) UpdateConfigLastSync(id string) error {
 	}
 
 	return config.SaveLocalConfig(r.projectRoot, r.localConfigCache)
+}
+
+// PersistLedgerPath saves the ledger path to the config cache and disk.
+// This keeps the cache in sync so UpdateConfigLastSync doesn't overwrite it.
+func (r *WorkspaceRegistry) PersistLedgerPath(path string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.localConfigCache == nil {
+		return nil
+	}
+
+	if r.localConfigCache.Ledger == nil {
+		r.localConfigCache.Ledger = &config.LedgerConfig{Path: path}
+	} else if r.localConfigCache.Ledger.Path == "" {
+		r.localConfigCache.Ledger.Path = path
+	} else {
+		return nil // already has a path
+	}
+
+	if err := config.SaveLocalConfig(r.projectRoot, r.localConfigCache); err != nil {
+		return err
+	}
+	slog.Info("persisted ledger path to config.local.toml", "path", path)
+	return nil
 }
 
 // GetLedgerPath returns the ledger path for quick access.

--- a/internal/daemon/workspace_registry_test.go
+++ b/internal/daemon/workspace_registry_test.go
@@ -5,8 +5,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -431,4 +433,49 @@ func TestIsCheckoutClean(t *testing.T) {
 	t.Run("nonexistent path returns false", func(t *testing.T) {
 		assert.False(t, isCheckoutClean("/nonexistent/path/xyz"), "nonexistent path should return false")
 	})
+}
+
+// TestUpdateConfigLastSync_PreservesLedgerPath verifies that UpdateConfigLastSync
+// does not clobber the ledger path when writing last_sync to disk.
+// This was the root cause of the "daemon synced but ox status shows not cloned" bug:
+// UpdateConfigLastSync used an in-memory cache with Path="" and overwrote the path
+// that persistLedgerPath had just written to disk.
+func TestUpdateConfigLastSync_PreservesLedgerPath(t *testing.T) {
+	projectDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, ".sageox"), 0755))
+
+	// seed config.local.toml with an empty-path ledger (the broken state)
+	localCfg := &config.LocalConfig{
+		Ledger: &config.LedgerConfig{Path: ""},
+	}
+	require.NoError(t, config.SaveLocalConfig(projectDir, localCfg))
+
+	// build registry and load the empty-path config into cache
+	reg := NewWorkspaceRegistry(projectDir, "test-repo")
+	reg.configCacheDuration = 1 * time.Hour // keep cache warm
+	require.NoError(t, reg.LoadFromConfig())
+
+	// simulate daemon discovering ledger via API and registering it
+	ledgerPath := filepath.Join(t.TempDir(), "ledger")
+	require.NoError(t, os.MkdirAll(filepath.Join(ledgerPath, ".git"), 0755))
+	reg.workspaces["ledger"] = &WorkspaceState{
+		ID:   "ledger",
+		Type: WorkspaceTypeLedger,
+		Path: ledgerPath,
+	}
+
+	// persist the discovered path (writes through the cache)
+	require.NoError(t, reg.PersistLedgerPath(ledgerPath))
+
+	// UpdateConfigLastSync writes last_sync through the same cache
+	require.NoError(t, reg.UpdateConfigLastSync("ledger"))
+
+	// reload from disk and verify the path survived
+	reloaded, err := config.LoadLocalConfig(projectDir)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.Ledger)
+	assert.Equal(t, ledgerPath, reloaded.Ledger.Path,
+		"UpdateConfigLastSync must not clobber ledger path set by PersistLedgerPath")
+	assert.True(t, reloaded.Ledger.HasLastSync(),
+		"last_sync should be set after UpdateConfigLastSync")
 }


### PR DESCRIPTION
## Symptom

`ox status` reports the ledger as "not cloned" even though the daemon is actively syncing it.

## Root Cause

Race condition between `persistLedgerPath()` and `UpdateConfigLastSync()` — both write `config.local.toml` but use different config objects. The stale in-memory cache overwrites the path that `persistLedgerPath` just wrote to disk.

## Changes

- **workspace_registry.go**: Added `PersistLedgerPath()` method that writes through the registry's config cache (same as `UpdateConfigLastSync`), preventing the cache from overwriting it
- **sync.go**: `persistLedgerPath()` now delegates to the registry instead of bypassing the cache
- **local_config.go**: `UpdateLedgerLastSync()` no-ops when Ledger is nil (defensive fix; consistent with `UpdateTeamContextLastSync`)
- **status.go**: Defensive fallback when `Ledger.Path == ""`; treats empty path same as nil
- **workspace_registry_test.go**: Regression test verifying the path survives both writes

Also removed dead `configLoading` flag and documented the single-writer invariant.

Fixes #17