### PR TITLE
fix(agent): make team-ctx discoverable and list recent discussions

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -142,6 +142,7 @@ type teamContextInfo struct {
 	AgentContextPath    string `json:"agent_context_path,omitempty"`     // full path to distilled-discussions.md
 	AgentContextRelPath string `json:"agent_context_rel_path,omitempty"` // relative path within team context
 	AgentContextHash    string `json:"agent_context_hash,omitempty"`     // content hash for deduplication
+	ReadCommand         string `json:"read_command,omitempty"`           // command to read team discussions
 }
 
 // teamClaudeInstructions holds paths to team instruction files.
@@ -1016,10 +1017,11 @@ func outputAgentPrimeText(cmd *cobra.Command, output agentPrimeOutput) error {
 
 		// always emit team context guidance — discussions may sync after prime runs
 		fmt.Fprintln(cmd.OutOrStdout())
-		fmt.Fprintln(cmd.OutOrStdout(), "**Team context available** — distilled from recorded team meetings and discussions")
-		fmt.Fprintln(cmd.OutOrStdout(), "(architecture, conventions, product direction). Organized under `discussions/`")
-		fmt.Fprintln(cmd.OutOrStdout(), "by date (e.g., `discussions/2026-02-17*`). This is your source for team knowledge.")
-		fmt.Fprintf(cmd.OutOrStdout(), "Path: `%s`\n", shortenPath(output.TeamContext.Path))
+		fmt.Fprintln(cmd.OutOrStdout(), "**Team context available** — recorded team meetings and discussions")
+		fmt.Fprintln(cmd.OutOrStdout(), "(architecture, conventions, product direction).")
+		fmt.Fprintln(cmd.OutOrStdout())
+		fmt.Fprintln(cmd.OutOrStdout(), "  Read SageOx team discussions:  ox agent team-ctx")
+		fmt.Fprintln(cmd.OutOrStdout())
 		if !output.TeamContext.HasAgentContext {
 			fmt.Fprintln(cmd.OutOrStdout(), "Not yet synced — may appear shortly as the daemon syncs in the background.")
 		}
@@ -1136,9 +1138,10 @@ func discoverTeamContext(projectRoot string) *teamContextInfo {
 	tc := localCfg.TeamContexts[0]
 
 	info := &teamContextInfo{
-		TeamID:   tc.TeamID,
-		TeamName: tc.TeamName,
-		Path:     tc.Path,
+		TeamID:      tc.TeamID,
+		TeamName:    tc.TeamName,
+		Path:        tc.Path,
+		ReadCommand: "ox agent team-ctx",
 	}
 
 	// if team context directory hasn't synced yet, return partial info

--- a/cmd/ox/agent_team_ctx.go
+++ b/cmd/ox/agent_team_ctx.go
@@ -3,20 +3,24 @@ package main
 import (
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/spf13/cobra"
 )
 
+const recentDiscussionLimit = 15
+
 var agentTeamCtxCmd = &cobra.Command{
 	Use:   "team-ctx",
 	Short: "Output team context for AI agent planning",
-	Long: `Output distilled team discussions and decisions for AI agent planning.
+	Long: `Output team discussions and distilled context for AI agent planning.
 
-This command reads the team's agent-context/distilled-discussions.md file
-and outputs it with context for the AI agent to use during planning.
+Lists the 15 most recent discussion files (read them for full detail),
+then outputs the distilled summary from agent-context/distilled-discussions.md.
 
 Output includes a content hash (team-ctx:<hash>) - if this marker is already
 in your context, you don't need to re-run this command.`,
@@ -39,24 +43,96 @@ func runAgentTeamCtx(cmd *cobra.Command, args []string) error {
 	}
 
 	tc := localCfg.TeamContexts[0]
+	out := cmd.OutOrStdout()
+
+	// list recent discussion files
+	discussionsDir := filepath.Join(tc.Path, "discussions")
+	hasDiscussions := listRecentDiscussions(out, discussionsDir)
+
+	// output distilled summary
 	agentContextPath := filepath.Join(tc.Path, "agent-context", "distilled-discussions.md")
-	content, err := os.ReadFile(agentContextPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("no team context available: %s does not exist", agentContextPath)
-		}
-		return fmt.Errorf("failed to read agent context: %w", err)
+	hasDistilled := outputDistilledContext(out, agentContextPath)
+
+	if !hasDiscussions && !hasDistilled {
+		return fmt.Errorf("no team context available: no discussions or distilled context found in %s", tc.Path)
 	}
 
-	// compute content hash for deduplication
-	hash := sha256.Sum256(content)
-	hashStr := fmt.Sprintf("%x", hash[:4]) // first 8 hex chars
-
-	// output with hash marker for context deduplication
-	fmt.Fprintf(cmd.OutOrStdout(), "<!-- team-ctx:%s -->\n", hashStr)
-	fmt.Fprintln(cmd.OutOrStdout(), "Use this team context during planning:")
-	fmt.Fprintln(cmd.OutOrStdout())
-	fmt.Fprint(cmd.OutOrStdout(), string(content))
-
 	return nil
+}
+
+// listRecentDiscussions scans the discussions/ directory and outputs
+// the 15 most recent files (by name, which are date-prefixed).
+// Returns true if any discussions were found.
+func listRecentDiscussions(out io.Writer, discussionsDir string) bool {
+	entries, err := os.ReadDir(discussionsDir)
+	if err != nil {
+		return false
+	}
+
+	// collect all files recursively from discussions/
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// scan subdirectory for files
+			subDir := filepath.Join(discussionsDir, entry.Name())
+			subEntries, err := os.ReadDir(subDir)
+			if err != nil {
+				continue
+			}
+			for _, sub := range subEntries {
+				if !sub.IsDir() {
+					files = append(files, filepath.Join(subDir, sub.Name()))
+				}
+			}
+		} else {
+			files = append(files, filepath.Join(discussionsDir, entry.Name()))
+		}
+	}
+
+	if len(files) == 0 {
+		return false
+	}
+
+	// sort reverse-alphabetically (date-prefixed names = newest first)
+	sort.Sort(sort.Reverse(sort.StringSlice(files)))
+
+	limit := recentDiscussionLimit
+	if len(files) < limit {
+		limit = len(files)
+	}
+
+	fmt.Fprintln(out, "## Recent Discussions")
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Read these files for full discussion details (%d most recent):\n", limit)
+	fmt.Fprintln(out)
+	for _, f := range files[:limit] {
+		fmt.Fprintf(out, "- %s\n", f)
+	}
+
+	if len(files) > limit {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "For older discussions, list files in: %s\n", discussionsDir)
+	}
+	fmt.Fprintln(out)
+
+	return true
+}
+
+// outputDistilledContext reads and outputs the distilled discussions file.
+// Returns true if the file was found and output.
+func outputDistilledContext(out io.Writer, path string) bool {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	hash := sha256.Sum256(content)
+	hashStr := fmt.Sprintf("%x", hash[:4])
+
+	fmt.Fprintf(out, "<!-- team-ctx:%s -->\n", hashStr)
+	fmt.Fprintln(out, "## Distilled Team Context")
+	fmt.Fprintln(out)
+	fmt.Fprint(out, string(content))
+
+	return true
 }


### PR DESCRIPTION
## Summary

Agents couldn't find `ox agent team-ctx` and had to make multiple wrong CLI calls. Additionally, the command only read the distilled summary which is often incomplete or missing entirely.

**Changes:**
- `ox agent team-ctx` now lists the 15 most recent discussion files (by date) so agents can read full details
- Added explicit command guidance in `ox agent prime` output: `Read SageOx team discussions:  ox agent team-ctx`
- Added `ReadCommand` field to JSON output for machine parsing
- Restructured text guidance to be actionable instead of vague about filesystem organization

**Result:** Agents can now discover the command immediately from prime output and get both raw discussions and distilled summary in one call.