### PR TITLE
Add prime efficiency benchmark with multi-phrasing support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,9 @@ test-integration: ## Run integration tests (build tag: integration) - full E2E w
 	@echo "Running integration tests (requires claude CLI and ANTHROPIC_API_KEY)..."
 	@time $(GOTESTSUM) --format pkgname-and-test-fails -- -tags=integration -race -timeout=10m ./...
 
-test-benchmark: ## Run prime efficiency benchmarks (requires claude CLI) - ~36 min, ~18 API calls
+test-benchmark: ## Run prime efficiency benchmarks (requires claude CLI) - ~80 min, ~40 API calls
 	@echo "Running prime efficiency benchmarks..."
-	@time $(GOTESTSUM) --format pkgname-and-test-fails -- -tags=integration -run TestPrimeEfficiency -timeout=45m ./tests/integration/agents/benchmark/...
+	@time $(GOTESTSUM) --format pkgname-and-test-fails -- -tags=integration -run TestPrimeEfficiency -timeout=90m ./tests/integration/agents/benchmark/...
 
 test-sequential: ## Run tests sequentially (for debugging race conditions)
 	@echo "Running tests sequentially..."

--- a/tests/integration/agents/benchmark/benchmark.go
+++ b/tests/integration/agents/benchmark/benchmark.go
@@ -37,6 +37,8 @@ type BenchmarkRun struct {
 type QueryResult struct {
 	QueryID             string        `json:"query_id"`
 	Iteration           int           `json:"iteration"`
+	PromptVariant       int           `json:"prompt_variant"`        // index into Texts slice
+	PromptText          string        `json:"prompt_text,omitempty"` // actual prompt used
 	FoundCorrectSource  bool          `json:"found_correct_source"`
 	ToolCallsTotal      int           `json:"tool_calls_total"`
 	ToolCallsUntilFound int           `json:"tool_calls_until_found"` // -1 if not found

--- a/tests/integration/agents/benchmark/benchmark_test.go
+++ b/tests/integration/agents/benchmark/benchmark_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	iterationsPerQuery = 3
+	iterationsPerQuery = 5 // covers all prompt variants per query
 	queryTimeout       = 3 * time.Minute
 	maxRetries         = 2
 )
@@ -21,7 +21,8 @@ const (
 // TestPrimeEfficiencyBenchmark runs all benchmark queries against installed agents
 // and measures tool call efficiency.
 //
-// Cost: ~18 API calls per agent (~$0.50-1.00, ~36 min wall time for Claude).
+// Cost: ~40 API calls per agent (~$1.10-2.20, ~80 min wall time for Claude).
+// Each of 8 queries runs 5 iterations, cycling through prompt variants.
 func TestPrimeEfficiencyBenchmark(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping benchmark in short mode")
@@ -38,7 +39,10 @@ func TestPrimeEfficiencyBenchmark(t *testing.T) {
 		query := query
 		t.Run(query.ID, func(t *testing.T) {
 			for iter := 0; iter < iterationsPerQuery; iter++ {
-				result := runWithRetry(t, env, agent, query.Text, maxRetries)
+				variantIdx := iter % len(query.Texts)
+				prompt := query.Texts[variantIdx]
+
+				result := runWithRetry(t, env, agent, prompt, maxRetries)
 				if result == nil {
 					continue
 				}
@@ -51,6 +55,8 @@ func TestPrimeEfficiencyBenchmark(t *testing.T) {
 
 				qr := scoreQuery(calls, query)
 				qr.Iteration = iter
+				qr.PromptVariant = variantIdx
+				qr.PromptText = prompt
 				qr.Duration = result.Duration
 
 				// handle 0-tool-call case via response validation
@@ -63,8 +69,8 @@ func TestPrimeEfficiencyBenchmark(t *testing.T) {
 
 				run.Queries = append(run.Queries, qr)
 
-				t.Logf("  iter=%d found=%v calls_until=%d total=%d extraneous=%d duration=%v",
-					iter, qr.FoundCorrectSource, qr.ToolCallsUntilFound,
+				t.Logf("  iter=%d variant=%d found=%v calls_until=%d total=%d extraneous=%d duration=%v",
+					iter, variantIdx, qr.FoundCorrectSource, qr.ToolCallsUntilFound,
 					qr.ToolCallsTotal, qr.ExtraneousCalls, qr.Duration.Round(time.Second))
 			}
 		})
@@ -214,8 +220,8 @@ func TestParseClaudeToolCallsInvalid(t *testing.T) {
 
 func TestScoreQuery(t *testing.T) {
 	query := BenchmarkQuery{
-		ID:   "test",
-		Text: "test query",
+		ID:    "test",
+		Texts: []string{"test query"},
 		Validate: func(call ToolCall) bool {
 			return call.Name == "Bash" && containsCI(call.Input, "ox doctor")
 		},

--- a/tests/integration/agents/benchmark/queries.go
+++ b/tests/integration/agents/benchmark/queries.go
@@ -11,8 +11,10 @@ type BenchmarkQuery struct {
 	// ID is a short identifier for this query (e.g., "team-discussions").
 	ID string
 
-	// Text is the prompt sent to the AI coworker.
-	Text string
+	// Texts contains multiple prompt phrasings for the same query.
+	// Iterations cycle through them: iteration i uses Texts[i % len(Texts)].
+	// Must have at least one entry.
+	Texts []string
 
 	// Validate checks if a tool call indicates the agent found the correct source.
 	// Returns true if this tool call represents correct navigation.
@@ -29,11 +31,18 @@ type BenchmarkQuery struct {
 }
 
 // DefaultQueries returns the benchmark query corpus.
+// Each query has 4-5 prompt variants that iterations cycle through.
 func DefaultQueries() []BenchmarkQuery {
 	return []BenchmarkQuery{
 		{
-			ID:   "team-discussions",
-			Text: "Based on recent SageOx team discussions, what should we implement next?",
+			ID: "team-discussions",
+			Texts: []string{
+				"Based on recent SageOx team discussions, what should we implement next?",
+				"What has the team been talking about lately?",
+				"Catch me up on team discussions — what priorities came out of recent meetings?",
+				"What are the current team priorities I should know about before I start coding?",
+				"Pull up the latest team context so I know what direction we're heading.",
+			},
 			Validate: func(call ToolCall) bool {
 				input := strings.ToLower(call.Input)
 				// ideal: ox command
@@ -50,45 +59,49 @@ func DefaultQueries() []BenchmarkQuery {
 			},
 			ValidateResponse: func(output string) bool {
 				lower := strings.ToLower(output)
-				// if answering from context, should mention implementation priorities
 				return strings.Contains(lower, "implement") ||
 					strings.Contains(lower, "priority") ||
 					strings.Contains(lower, "next")
 			},
 		},
 		{
-			ID:   "arch-decisions",
-			Text: "What were the key decisions from our last architecture discussion?",
+			ID: "project-guidance",
+			Texts: []string{
+				"What project-specific instructions should I follow in this repo?",
+				"Is there an AGENTS.md or project guidance file I should read?",
+				"What does this project expect from AI coworkers?",
+				"Before I start working, what project-level rules apply here?",
+				"Show me the project's agent instructions.",
+			},
 			Validate: func(call ToolCall) bool {
 				input := strings.ToLower(call.Input)
-				// ideal: ox command
-				if strings.Contains(input, "ox agent team-ctx") ||
-					strings.Contains(input, "team-ctx") {
+				// ideal: reads project AGENTS.md
+				if strings.Contains(input, "agents.md") {
 					return true
 				}
-				// acceptable: reads discussion or team context files
-				if strings.Contains(input, "distilled-discussions") ||
-					strings.Contains(input, "team-context") {
-					return true
-				}
-				// acceptable: searches for ADR/architecture docs
-				if call.Name == "Glob" &&
-					(strings.Contains(input, "adr") || strings.Contains(input, "architecture") || strings.Contains(input, "decision")) {
+				// acceptable: reads .sageox/ config or project guidance
+				if strings.Contains(input, ".sageox/") {
 					return true
 				}
 				return false
 			},
 			ValidateResponse: func(output string) bool {
 				lower := strings.ToLower(output)
-				// if answering from context, should mention decisions or architecture
-				return strings.Contains(lower, "decision") ||
-					strings.Contains(lower, "architecture") ||
-					strings.Contains(lower, "design")
+				return strings.Contains(lower, "agent") ||
+					strings.Contains(lower, "instruction") ||
+					strings.Contains(lower, "guidance") ||
+					strings.Contains(lower, "command")
 			},
 		},
 		{
-			ID:   "session-history",
-			Text: "Show me the session history for this project.",
+			ID: "session-history",
+			Texts: []string{
+				"Show me the session history for this project.",
+				"What has the AI been working on in this repo recently?",
+				"Give me a summary of recent coding sessions.",
+				"What was worked on in the last few sessions here?",
+				"Can you show me what previous AI coworkers did in this project?",
+			},
 			Validate: func(call ToolCall) bool {
 				input := strings.ToLower(call.Input)
 				// ideal: ox session command
@@ -100,28 +113,29 @@ func DefaultQueries() []BenchmarkQuery {
 				if call.Name == "Bash" && strings.Contains(input, "git log") {
 					return true
 				}
-				// acceptable: reads .sageox/ session data or ledger
-				if strings.Contains(input, ".sageox") ||
-					strings.Contains(input, "session") ||
-					strings.Contains(input, "ledger") {
+				// acceptable: reads session data or ledger session paths
+				if strings.Contains(input, ".sageox/sessions") ||
+					strings.Contains(input, "ledger/sessions") {
 					return true
 				}
 				return false
 			},
 		},
 		{
-			ID:   "team-conventions",
-			Text: "What team conventions should I follow for this codebase?",
-			// correct navigation: answer directly from prime output (team_instructions),
-			// or read team instruction files
+			ID: "team-conventions",
+			Texts: []string{
+				"What team conventions should I follow for this codebase?",
+				"How does this team write code? What are the style rules?",
+				"Before I write any code, what conventions and standards apply here?",
+				"What would a code review catch me on if I don't follow team norms?",
+				"Tell me the rules: naming, patterns, what to avoid in this codebase.",
+			},
 			Validate: func(call ToolCall) bool {
 				input := strings.ToLower(call.Input)
-				// reading team CLAUDE.md or AGENTS.md is the expected path
 				if strings.Contains(input, "claude.md") ||
 					strings.Contains(input, "agents.md") {
 					return true
 				}
-				// reading team context files
 				if strings.Contains(input, "team-context") ||
 					strings.Contains(input, "conventions") {
 					return true
@@ -130,7 +144,6 @@ func DefaultQueries() []BenchmarkQuery {
 			},
 			ValidateResponse: func(output string) bool {
 				lower := strings.ToLower(output)
-				// should contain convention-like content from team instructions
 				return strings.Contains(lower, "convention") ||
 					strings.Contains(lower, "style") ||
 					strings.Contains(lower, "pattern") ||
@@ -138,15 +151,21 @@ func DefaultQueries() []BenchmarkQuery {
 			},
 		},
 		{
-			ID:   "sageox-issues",
-			Text: "Are there any known issues with the SageOx setup?",
+			ID: "sageox-issues",
+			Texts: []string{
+				"Are there any known issues with the SageOx setup?",
+				"Is ox configured correctly for this project?",
+				"Run a health check on the ox integration.",
+				"Something seems off with ox — can you diagnose it?",
+				"Check if there are any problems with how ox is set up here.",
+			},
 			Validate: func(call ToolCall) bool {
 				input := strings.ToLower(call.Input)
 				// ideal: ox doctor
 				if strings.Contains(input, "ox doctor") {
 					return true
 				}
-				// acceptable: ox status (also shows health info)
+				// acceptable: ox status (weaker signal but still relevant)
 				if strings.Contains(input, "ox status") {
 					return true
 				}
@@ -154,13 +173,74 @@ func DefaultQueries() []BenchmarkQuery {
 			},
 		},
 		{
-			ID:   "sageox-sync",
-			Text: "Has SageOx synchronized?",
+			ID: "sageox-sync",
+			Texts: []string{
+				"Has SageOx synchronized?",
+				"Is the team context up to date?",
+				"When did ox last sync?",
+				"Are we seeing the latest team discussions or is the sync stale?",
+				"Check whether ox is pulling in the latest team context.",
+			},
 			Validate: func(call ToolCall) bool {
 				input := strings.ToLower(call.Input)
-				// ideal: ox status or ox sync
 				return strings.Contains(input, "ox status") ||
 					strings.Contains(input, "ox sync")
+			},
+		},
+		{
+			ID: "attribution-guidance",
+			Texts: []string{
+				"How should I attribute ox when I make commits based on its guidance?",
+				"What do I put in commit messages when SageOx influenced my work?",
+				"Are there attribution requirements for commits in this project?",
+				"What footer should I add to plans that were guided by SageOx?",
+			},
+			Validate: func(call ToolCall) bool {
+				input := strings.ToLower(call.Input)
+				if strings.Contains(input, "attribution") {
+					return true
+				}
+				if strings.Contains(input, "claude.md") ||
+					strings.Contains(input, "agents.md") {
+					return true
+				}
+				if strings.Contains(input, "ox agent prime") {
+					return true
+				}
+				return false
+			},
+			ValidateResponse: func(output string) bool {
+				lower := strings.ToLower(output)
+				return strings.Contains(lower, "attribution") ||
+					strings.Contains(lower, "footer") ||
+					strings.Contains(lower, "commit")
+			},
+		},
+		{
+			ID: "subagent-discovery",
+			Texts: []string{
+				"What specialist subagents are available on this team?",
+				"Are there any Claude agents configured for this project I should know about?",
+				"Show me what AI coworkers or subagents this team has set up.",
+				"Can I delegate work to a subagent? What's available?",
+			},
+			Validate: func(call ToolCall) bool {
+				input := strings.ToLower(call.Input)
+				if strings.Contains(input, "agents/") ||
+					strings.Contains(input, "coworkers/ai") {
+					return true
+				}
+				if strings.Contains(input, "team-ctx") ||
+					strings.Contains(input, "ox agent team-ctx") {
+					return true
+				}
+				return false
+			},
+			ValidateResponse: func(output string) bool {
+				lower := strings.ToLower(output)
+				return strings.Contains(lower, "agent") ||
+					strings.Contains(lower, "subagent") ||
+					strings.Contains(lower, "specialist")
 			},
 		},
 	}

--- a/tests/integration/agents/benchmark/report.go
+++ b/tests/integration/agents/benchmark/report.go
@@ -61,6 +61,29 @@ func generateReport(run BenchmarkRun) string {
 	fmt.Fprintf(&b, "\nOverall: median calls-until-found=%d  found=%d/%d\n",
 		allMedian, totalFound, len(run.Queries))
 
+	// per-variant breakdown
+	fmt.Fprintf(&b, "\n=== Variant Breakdown ===\n")
+	for _, qid := range queryOrder() {
+		results, ok := grouped[qid]
+		if !ok {
+			continue
+		}
+
+		byVariant := groupByVariant(results)
+		for variant, vResults := range byVariant {
+			found := 0
+			for _, r := range vResults {
+				if r.FoundCorrectSource {
+					found++
+				}
+			}
+			med := medianFromResults(vResults)
+			prompt := truncatePrompt(vResults[0].PromptText, 50)
+			fmt.Fprintf(&b, "%-20s  v%d %-52s  %d/%d found  med: %d\n",
+				qid, variant, prompt, found, len(vResults), med)
+		}
+	}
+
 	return b.String()
 }
 
@@ -110,11 +133,13 @@ func checkRegression(t *testing.T, current, previous *BenchmarkRun) {
 func queryOrder() []string {
 	return []string{
 		"team-discussions",
-		"arch-decisions",
+		"project-guidance",
 		"session-history",
 		"team-conventions",
 		"sageox-issues",
 		"sageox-sync",
+		"attribution-guidance",
+		"subagent-discovery",
 	}
 }
 
@@ -150,6 +175,21 @@ func median(vals []int) int {
 		}
 	}
 	return sorted[len(sorted)/2]
+}
+
+func groupByVariant(results []QueryResult) map[int][]QueryResult {
+	grouped := make(map[int][]QueryResult)
+	for _, r := range results {
+		grouped[r.PromptVariant] = append(grouped[r.PromptVariant], r)
+	}
+	return grouped
+}
+
+func truncatePrompt(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
 }
 
 func intsToStr(vals []int) string {


### PR DESCRIPTION
## Summary

Adds multi-phrasing support to the prime efficiency benchmark to test robustness across different ways customers might phrase similar questions. Also replaces the redundant arch-decisions query with project-guidance and adds two new queries (attribution-guidance, subagent-discovery) to cover previously untested prime output fields.

## Changes

- **Benchmark structure**: `BenchmarkQuery.Text` → `Texts[]string` to support 4-5 variants per query
- **Queries**: Expanded from 6 to 8; each cycles through variants across 5 iterations (40 total API calls)
- **Query replacements**: arch-decisions → project-guidance (tests AGENTS.md directly)
- **New queries**: attribution-guidance, subagent-discovery (cover missing prime output fields)
- **Reporting**: Per-variant breakdown shows which phrasings succeed/fail
- **Makefile**: Updated cost/time comment (~36min/18 calls → ~80min/40 calls)

## Test Results

Ran full benchmark (40 API calls, ~80 min): **32/40 found (80% success), median 1 call**

**Winners**: project-guidance (5/5, 1 call), team-conventions (5/5), attribution-guidance (5/5, mostly 0 calls), subagent-discovery (5/5)

**Needs work**: team-discussions (0/5 — agent never runs `ox agent team-ctx`), sageox-issues (5/5 but slow: 3-5 calls), sageox-sync (3/5 — vague phrasings fail)

The benchmark directly exposes where prime output guidance is insufficient or where agent behavior diverges across phrasings.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended benchmark test timeout from 45 to 90 minutes and increased iterations from 3 to 5.
  * Added support for multiple prompt variants per query, enabling more comprehensive testing scenarios.
  * Introduced new benchmark test scenarios for attribution guidance and subagent discovery.
  * Enhanced benchmark reporting with variant-specific breakdowns showing results grouped by prompt variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->