### PR TITLE
add 5 pre-release smoke tests and release gate

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -26,6 +26,14 @@ make test
 
 If tests or lint fail, fix issues before proceeding.
 
+### Step 1b: Smoke Tests (requires SAGEOX_CI_PASSWORD)
+
+```bash
+make smoke-test
+```
+
+This runs end-to-end tests against test.sageox.ai: auth, init, doctor, status, re-init, agent prime, session list, and clone-without-ox. If smoke tests fail, investigate before proceeding — these verify ox works in a real environment.
+
 ### Step 2: Analyze Changes Since Last Release
 
 ```bash

--- a/scripts/smoketest/smoke-test-clone-no-ox.sh
+++ b/scripts/smoketest/smoke-test-clone-no-ox.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# smoke-test-clone-no-ox.sh - Verify git clone of a repo with .sageox/ works without ox installed
+#
+# Tests that users who clone a repo with .sageox/ committed don't see
+# warnings or errors from .gitattributes, hooks, or LFS filters.
+#
+# Required environment variables (set by smoke-test.sh):
+#   SMOKE_TEST_WORKDIR - Temp directory for test
+#   OX - Path to ox binary (used to determine what to exclude from PATH)
+
+set -euo pipefail
+
+: "${SMOKE_TEST_WORKDIR:?SMOKE_TEST_WORKDIR is required}"
+: "${OX:?OX is required}"
+
+SOURCE_REPO="$SMOKE_TEST_WORKDIR/test-clone-source"
+CLONE_TARGET="$SMOKE_TEST_WORKDIR/test-clone-target"
+
+echo "Testing git clone of repo with .sageox/ (without ox in PATH)..."
+
+# create a source repo with .sageox/ committed
+mkdir -p "$SOURCE_REPO"
+cd "$SOURCE_REPO"
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test User"
+echo "# Test Repo" > README.md
+
+# simulate what ox init creates (minimal .sageox/)
+mkdir -p .sageox
+cat > .sageox/config.json << 'JSON'
+{"version":"1","repo_id":"test-repo-id","endpoint":"https://test.sageox.ai"}
+JSON
+touch ".sageox/.repo_00000000-0000-0000-0000-000000000000"
+
+# add .gitattributes like ox init would
+cat > .gitattributes << 'ATTRS'
+.sageox/** linguist-language=SageOx
+*.ox linguist-language=SageOx
+ATTRS
+
+git add README.md .sageox/ .gitattributes
+git commit -q -m "initial commit with sageox"
+
+# clone with ox removed from PATH
+OX_DIR=$(dirname "$(readlink -f "$OX" 2>/dev/null || echo "$OX")")
+CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "^${OX_DIR}$" | tr '\n' ':' | sed 's/:$//')
+
+echo "Cloning without ox in PATH..."
+set +e
+clone_stderr=$(PATH="$CLEAN_PATH" git clone "$SOURCE_REPO" "$CLONE_TARGET" 2>&1 >/dev/null)
+clone_exit=$?
+set -e
+
+if [[ $clone_exit -ne 0 ]]; then
+    echo "error: git clone failed with exit code $clone_exit"
+    echo "$clone_stderr"
+    exit 1
+fi
+
+# check stderr for unexpected warnings (filter out normal "Cloning into" message)
+if echo "$clone_stderr" | grep -iE "error|warning|filter" | grep -vi "Cloning into"; then
+    echo "error: git clone produced warnings/errors:"
+    echo "$clone_stderr"
+    exit 1
+fi
+
+# verify clone has .sageox/
+if [[ ! -d "$CLONE_TARGET/.sageox" ]]; then
+    echo "error: cloned repo missing .sageox/"
+    exit 1
+fi
+
+# verify git status is clean in clone
+cd "$CLONE_TARGET"
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "error: cloned repo has dirty git status"
+    git status
+    exit 1
+fi
+
+echo "git clone without ox test passed"
+exit 0

--- a/scripts/smoketest/smoke-test-prime.sh
+++ b/scripts/smoketest/smoke-test-prime.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# smoke-test-prime.sh - Test ox agent prime returns valid JSON with expected fields
+#
+# Required environment variables (set by smoke-test.sh):
+#   SAGEOX_ENDPOINT - API endpoint
+#   SMOKE_TEST_WORKDIR - Temp directory for test
+#   OX - Path to ox binary
+
+set -euo pipefail
+
+: "${SAGEOX_ENDPOINT:?SAGEOX_ENDPOINT is required}"
+: "${SMOKE_TEST_WORKDIR:?SMOKE_TEST_WORKDIR is required}"
+: "${OX:?OX is required}"
+
+TEST_REPO="$SMOKE_TEST_WORKDIR/test-init-repo"
+
+if [[ ! -d "$TEST_REPO/.sageox" ]]; then
+    echo "error: test-init-repo not initialized (run init test first)"
+    exit 1
+fi
+
+cd "$TEST_REPO"
+
+echo "Testing ox agent prime (JSON mode)..."
+
+# AGENT_ENV=claude-code simulates running inside a coding agent
+# this is required by agentx.RequireAgent()
+set +e
+output=$(AGENT_ENV=claude-code $OX agent prime 2>&1)
+exit_code=$?
+set -e
+
+if [[ $exit_code -ne 0 ]]; then
+    echo "error: ox agent prime failed with exit code $exit_code"
+    echo "$output"
+    exit 1
+fi
+
+# validate JSON
+if ! echo "$output" | jq . > /dev/null 2>&1; then
+    echo "error: output is not valid JSON"
+    echo "$output"
+    exit 1
+fi
+
+# check status field
+status=$(echo "$output" | jq -r '.status')
+if [[ "$status" != "fresh" && "$status" != "unavailable" ]]; then
+    echo "error: unexpected status: $status (expected 'fresh' or 'unavailable')"
+    exit 1
+fi
+
+# check agent_id (required for fresh status)
+agent_id=$(echo "$output" | jq -r '.agent_id // empty')
+if [[ -z "$agent_id" && "$status" == "fresh" ]]; then
+    echo "error: missing agent_id in fresh status"
+    exit 1
+fi
+
+# check agent_supported field exists
+if ! echo "$output" | jq -e 'has("agent_supported")' > /dev/null 2>&1; then
+    echo "error: missing agent_supported field"
+    exit 1
+fi
+
+# check attribution object exists
+if ! echo "$output" | jq -e '.attribution' > /dev/null 2>&1; then
+    echo "error: missing attribution field"
+    exit 1
+fi
+
+echo "JSON valid: status=$status agent_id=$agent_id"
+echo "ox agent prime test passed"
+exit 0

--- a/scripts/smoketest/smoke-test-reinit.sh
+++ b/scripts/smoketest/smoke-test-reinit.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# smoke-test-reinit.sh - Test ox init on an already-initialized repo (upgrade path)
+#
+# Required environment variables (set by smoke-test.sh):
+#   SAGEOX_ENDPOINT - API endpoint
+#   SMOKE_TEST_WORKDIR - Temp directory for test
+#   OX - Path to ox binary
+
+set -euo pipefail
+
+: "${SAGEOX_ENDPOINT:?SAGEOX_ENDPOINT is required}"
+: "${SMOKE_TEST_WORKDIR:?SMOKE_TEST_WORKDIR is required}"
+: "${OX:?OX is required}"
+
+TEST_REPO="$SMOKE_TEST_WORKDIR/test-reinit-repo"
+
+if [[ ! -d "$SMOKE_TEST_WORKDIR/test-init-repo/.sageox" ]]; then
+    echo "error: test-init-repo not initialized (run init test first)"
+    exit 1
+fi
+
+echo "Testing ox init re-initialization..."
+
+# copy the init'd repo to avoid polluting the shared one
+cp -r "$SMOKE_TEST_WORKDIR/test-init-repo" "$TEST_REPO"
+cd "$TEST_REPO"
+
+# record state before reinit
+repo_marker_before=$(find .sageox -name ".repo_*" -type f 2>/dev/null | head -1)
+
+echo "Running ox init --quiet on already-initialized repo..."
+if ! $OX init --quiet; then
+    echo "error: ox init failed on re-init"
+    exit 1
+fi
+
+# verify .sageox still exists
+if [[ ! -d ".sageox" ]]; then
+    echo "error: .sageox directory missing after re-init"
+    exit 1
+fi
+
+# verify config.json still exists and is valid JSON
+if [[ -f ".sageox/config.json" ]]; then
+    if ! jq . ".sageox/config.json" > /dev/null 2>&1; then
+        echo "error: config.json is not valid JSON after re-init"
+        exit 1
+    fi
+    echo "config.json preserved and valid"
+else
+    echo "warning: no config.json found after re-init"
+fi
+
+# verify repo marker still exists
+repo_marker_after=$(find .sageox -name ".repo_*" -type f 2>/dev/null | head -1)
+if [[ -z "$repo_marker_after" ]]; then
+    echo "error: repo marker file missing after re-init"
+    exit 1
+fi
+
+echo "ox init re-initialization test passed"
+exit 0

--- a/scripts/smoketest/smoke-test-sessions.sh
+++ b/scripts/smoketest/smoke-test-sessions.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# smoke-test-sessions.sh - Test ox session list runs without errors
+#
+# Required environment variables (set by smoke-test.sh):
+#   SAGEOX_ENDPOINT - API endpoint
+#   SMOKE_TEST_WORKDIR - Temp directory for test
+#   OX - Path to ox binary
+
+set -euo pipefail
+
+: "${SAGEOX_ENDPOINT:?SAGEOX_ENDPOINT is required}"
+: "${SMOKE_TEST_WORKDIR:?SMOKE_TEST_WORKDIR is required}"
+: "${OX:?OX is required}"
+
+TEST_REPO="$SMOKE_TEST_WORKDIR/test-init-repo"
+
+if [[ ! -d "$TEST_REPO/.sageox" ]]; then
+    echo "error: test-init-repo not initialized (run init test first)"
+    exit 1
+fi
+
+cd "$TEST_REPO"
+
+echo "Testing ox session list..."
+
+set +e
+output=$($OX session list 2>&1)
+exit_code=$?
+set -e
+
+if [[ $exit_code -ne 0 ]]; then
+    echo "error: ox session list failed with exit code $exit_code"
+    echo "$output"
+    exit 1
+fi
+
+# check for panics
+if echo "$output" | grep -qi "panic\|goroutine\|stack trace"; then
+    echo "error: ox session list produced a panic"
+    echo "$output"
+    exit 1
+fi
+
+# output should contain either "No sessions" or session data
+if echo "$output" | grep -qi "no sessions"; then
+    echo "No sessions found (expected for fresh test repo)"
+else
+    echo "Session list output received (${#output} bytes)"
+fi
+
+echo "ox session list test passed"
+exit 0

--- a/scripts/smoketest/smoke-test-status.sh
+++ b/scripts/smoketest/smoke-test-status.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# smoke-test-status.sh - Test ox status command (text and JSON modes)
+#
+# Required environment variables (set by smoke-test.sh):
+#   SAGEOX_ENDPOINT - API endpoint
+#   SMOKE_TEST_WORKDIR - Temp directory for test
+#   OX - Path to ox binary
+
+set -euo pipefail
+
+: "${SAGEOX_ENDPOINT:?SAGEOX_ENDPOINT is required}"
+: "${SMOKE_TEST_WORKDIR:?SMOKE_TEST_WORKDIR is required}"
+: "${OX:?OX is required}"
+
+TEST_REPO="$SMOKE_TEST_WORKDIR/test-init-repo"
+
+if [[ ! -d "$TEST_REPO/.sageox" ]]; then
+    echo "error: test-init-repo not initialized (run init test first)"
+    exit 1
+fi
+
+cd "$TEST_REPO"
+
+echo "Testing ox status..."
+set +e
+output=$($OX status 2>&1)
+exit_code=$?
+set -e
+
+if [[ $exit_code -ne 0 ]]; then
+    echo "error: ox status failed with exit code $exit_code"
+    echo "$output"
+    exit 1
+fi
+
+echo "Status output received (${#output} bytes)"
+
+echo "Testing ox status --json..."
+set +e
+json_output=$($OX status --json 2>&1)
+json_exit=$?
+set -e
+
+if [[ $json_exit -ne 0 ]]; then
+    echo "error: ox status --json failed with exit code $json_exit"
+    echo "$json_output"
+    exit 1
+fi
+
+# validate JSON
+if ! echo "$json_output" | jq . > /dev/null 2>&1; then
+    echo "error: --json output is not valid JSON"
+    echo "$json_output"
+    exit 1
+fi
+
+# check auth.authenticated
+auth_val=$(echo "$json_output" | jq -r '.auth.authenticated')
+if [[ "$auth_val" != "true" ]]; then
+    echo "error: auth.authenticated is not true (got: $auth_val)"
+    exit 1
+fi
+
+# check project.initialized
+init_val=$(echo "$json_output" | jq -r '.project.initialized')
+if [[ "$init_val" != "true" ]]; then
+    echo "error: project.initialized is not true (got: $init_val)"
+    exit 1
+fi
+
+echo "JSON validated: authenticated=true, initialized=true"
+echo "ox status test passed"
+exit 0

--- a/scripts/smoketest/smoke-test.sh
+++ b/scripts/smoketest/smoke-test.sh
@@ -129,6 +129,11 @@ main() {
     run_test "Authentication" "smoke-test-auth.sh" || true
     run_test "ox init" "smoke-test-init.sh" || true
     run_test "ox doctor cloud" "smoke-test-doctor.sh" || true
+    run_test "ox status" "smoke-test-status.sh" || true
+    run_test "ox init (re-init)" "smoke-test-reinit.sh" || true
+    run_test "ox agent prime" "smoke-test-prime.sh" || true
+    run_test "ox session list" "smoke-test-sessions.sh" || true
+    run_test "Clone without ox" "smoke-test-clone-no-ox.sh" || true
     # skip checkout test for now - requires team setup
     # run_test "ox team context add" "smoke-test-checkout.sh" || true
 


### PR DESCRIPTION
## Summary

Expands pre-release verification with 5 new smoke test scripts covering critical user flows:
- `ox status` (text + JSON validation)
- `ox init` re-initialization (upgrade path)
- `ox agent prime` (agent context bootstrapping)
- `ox session list` (discussion discovery)
- `git clone` without ox in PATH (dependency-free checkout)

Updates `/release` skill to include smoke test gate between pre-flight checks and changelog analysis, closing the gap between unit tests and real-environment verification against test.sageox.ai.

## Test Plan

- `make smoke-test` runs all 8 tests (3 existing + 5 new) against test.sageox.ai
- New tests are dependent on init test and auth being set up first
- Clone-no-ox test is self-contained (creates its own repos)
- All scripts follow existing bash patterns: validate env vars, exit 0/1, log progress

## Files

- 5 new scripts: smoke-test-{status,reinit,prime,sessions,clone-no-ox}.sh
- Updated orchestrator: smoke-test.sh (8 tests total)
- Updated release skill: .claude/commands/release.md (Step 1b smoke test gate)

Co-Authored-By: SageOx <ox@sageox.ai>