### PR TITLE
fix(hooks): check project-level settings for installed hooks

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -1361,11 +1361,7 @@ func ensureClaudeHooks(projectRoot string) bool {
 	if !detectClaudeCode() {
 		return false
 	}
-	status, err := listClaudeHooks()
-	if err != nil {
-		return false
-	}
-	if status[claudeSessionStart] && status[claudePreCompact] {
+	if HasProjectClaudeHooks(projectRoot) {
 		return false // already installed
 	}
 	if err := InstallProjectClaudeHooks(projectRoot); err != nil {

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -426,6 +426,11 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		if !hookCmdCheck.skipped {
 			integrationChecks = append(integrationChecks, hookCmdCheck)
 		}
+		// check project-level hook completeness (all required events present)
+		completenessCheck := checkProjectHookCompleteness(opts.shouldFix(CheckSlugHookCompleteness))
+		if !completenessCheck.skipped {
+			integrationChecks = append(integrationChecks, completenessCheck)
+		}
 		// also check project-level hooks if present
 		projectHookCheck := checkProjectHookCommands()
 		if !projectHookCheck.skipped {

--- a/cmd/ox/doctor_hooks.go
+++ b/cmd/ox/doctor_hooks.go
@@ -9,6 +9,19 @@ import (
 	"strings"
 )
 
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugHookCompleteness,
+		Name:        "Hook completeness",
+		Category:    "Integration",
+		FixLevel:    FixLevelSuggested,
+		Description: "Verifies project hooks have ox prime for all required events",
+		Run: func(fix bool) checkResult {
+			return checkProjectHookCompleteness(fix)
+		},
+	})
+}
+
 // checkSessionStartHookBug warns about Claude Code bug #10373 where SessionStart
 // hook output is discarded for new sessions.
 //
@@ -382,4 +395,53 @@ func checkProjectHookCommands() checkResult {
 	return WarningCheck("Project hook commands",
 		fmt.Sprintf("%d invalid command(s)", len(invalidCommands)),
 		detail)
+}
+
+// checkProjectHookCompleteness verifies that project-level hooks have ox prime
+// hooks for ALL required events (SessionStart and PreCompact). Detects partial
+// installations and can auto-repair by re-running InstallProjectClaudeHooks.
+func checkProjectHookCompleteness(fix bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Hook completeness", "not in git repo", "")
+	}
+
+	settings, err := readProjectClaudeSettings(gitRoot)
+	if err != nil {
+		return SkippedCheck("Hook completeness", "no project settings", "")
+	}
+
+	if len(settings.Hooks) == 0 {
+		return SkippedCheck("Hook completeness", "no hooks configured", "")
+	}
+
+	// check each required event has ox prime hooks
+	var missing []string
+	for _, event := range []string{claudeSessionStart, claudePreCompact} {
+		found := false
+		for _, entry := range settings.Hooks[event] {
+			if hasOxPrimeHook(entry) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, event)
+		}
+	}
+
+	if len(missing) == 0 {
+		return PassedCheck("Hook completeness", "all events configured")
+	}
+
+	if fix {
+		if err := InstallProjectClaudeHooks(gitRoot); err != nil {
+			return FailedCheck("Hook completeness", "repair failed", err.Error())
+		}
+		return PassedCheck("Hook completeness", "repaired (re-installed hooks)")
+	}
+
+	return FailedCheck("Hook completeness",
+		fmt.Sprintf("missing hooks for: %s", strings.Join(missing, ", ")),
+		"Run `ox doctor --fix` to repair")
 }

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -156,8 +156,9 @@ const (
 	CheckSlugGeminiHooks         = "gemini-hooks"
 	CheckSlugCodexHooks          = "codex-hooks"
 	CheckSlugCodePuppyHooks      = "code-puppy-hooks"
-	CheckSlugHookCommands        = "hook-commands"
-	CheckSlugSessionStartHookBug = "session-start-hook-bug"
+	CheckSlugHookCommands          = "hook-commands"
+	CheckSlugHookCompleteness      = "hook-completeness"
+	CheckSlugSessionStartHookBug   = "session-start-hook-bug"
 
 	// Team Context checks
 	CheckSlugTeamRegistration = "team-registration"

--- a/cmd/ox/hooks_agent.go
+++ b/cmd/ox/hooks_agent.go
@@ -75,11 +75,16 @@ func (a *ClaudeAgent) HasHooks(user bool) bool {
 }
 
 func (a *ClaudeAgent) List() map[string]bool {
-	status, err := listClaudeHooks()
-	if err != nil {
-		return make(map[string]bool)
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		// fall back to user-level if not in a git repo
+		status, err := listClaudeHooks()
+		if err != nil {
+			return make(map[string]bool)
+		}
+		return status
 	}
-	return status
+	return listProjectClaudeHooks(gitRoot)
 }
 
 func (a *ClaudeAgent) Detect() bool {

--- a/cmd/ox/hooks_claude.go
+++ b/cmd/ox/hooks_claude.go
@@ -371,7 +371,8 @@ func mergeHookEntries(existing, new []ClaudeHookEntry) []ClaudeHookEntry {
 	return result
 }
 
-// HasProjectClaudeHooks checks if ox prime hooks are already in .claude/settings.local.json
+// HasProjectClaudeHooks checks if ox prime hooks are already in .claude/settings.local.json.
+// Returns true only if BOTH SessionStart AND PreCompact have at least one ox prime hook.
 func HasProjectClaudeHooks(gitRoot string) bool {
 	settings, err := readProjectClaudeSettings(gitRoot)
 	if err != nil {
@@ -379,12 +380,34 @@ func HasProjectClaudeHooks(gitRoot string) bool {
 	}
 
 	for _, eventName := range []string{claudeSessionStart, claudePreCompact} {
-		entries := settings.Hooks[eventName]
-		for _, entry := range entries {
+		found := false
+		for _, entry := range settings.Hooks[eventName] {
 			if hasOxPrimeHook(entry) {
-				return true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// listProjectClaudeHooks returns per-event hook status from project-level settings.
+func listProjectClaudeHooks(gitRoot string) map[string]bool {
+	settings, err := readProjectClaudeSettings(gitRoot)
+	if err != nil {
+		return make(map[string]bool)
+	}
+	status := make(map[string]bool)
+	for _, eventName := range []string{claudeSessionStart, claudePreCompact} {
+		for _, entry := range settings.Hooks[eventName] {
+			if hasOxPrimeHook(entry) {
+				status[eventName] = true
+				break
 			}
 		}
 	}
-	return false
+	return status
 }


### PR DESCRIPTION
## Summary

Fixes #34 — `ensureClaudeHooks()` checked user-level `~/.claude/settings.json` but installed to project-level `<project>/.claude/settings.local.json`, causing a false "hooks just installed" restart notice on every `ox agent prime` call.

- **Fix `ensureClaudeHooks()`** to use `HasProjectClaudeHooks(projectRoot)` instead of `listClaudeHooks()` (core bug)
- **Fix `HasProjectClaudeHooks()`** to verify BOTH `SessionStart` AND `PreCompact` events have hooks (was returning true on any single match)
- **Fix `ClaudeAgent.List()`** to read project-level hooks first, falling back to user-level outside git repos
- **Add `checkProjectHookCompleteness()`** doctor check with `--fix` support to detect and repair partial hook installations

```mermaid
flowchart LR
    A[ox agent prime] --> B{ensureClaudeHooks}
    B -->|Before| C[listClaudeHooks\n~/.claude/settings.json\nuser-level ❌]
    B -->|After| D[HasProjectClaudeHooks\n.claude/settings.local.json\nproject-level ✅]
    C -->|always false| E[re-install + restart notice]
    D -->|true when installed| F[skip — no noise]
```

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 4961 tests pass (1 pre-existing failure in useragent unrelated to this change)
- [x] `TestHasProjectClaudeHooks` — passes with completeness verification
- [x] `TestPartialInitPrimingMatrix` — all cases pass
- [ ] Manual: `ox agent prime` twice — second call should NOT emit `hooks_restart_notice`
- [ ] Manual: delete PreCompact from `settings.local.json`, `ox doctor` reports missing, `ox doctor --fix` repairs

## Session

[SageOx session recording](https://sageox.ai/repo/repo_019c5812-01e9-7b7d-b5b1-321c471c9777/sessions/2026-02-23T11-28-ryan-OxUt59)