### PR TITLE
fix: replace underscores with dashes in cloud code project hash (FSD #45)

### DIFF
--- a/internal/session/adapters/claude_code.go
+++ b/internal/session/adapters/claude_code.go
@@ -108,9 +108,10 @@ func (a *ClaudeCodeAdapter) FindSessionFile(agentID string, since time.Time) (st
 		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	// convert cwd to Claude's project hash format: path separators become dashes
-	// e.g., /Users/ryan/Code/project -> -Users-ryan-Code-project
+	// convert cwd to Claude's project hash format: path separators and underscores become dashes
+	// e.g., /Users/ryan/Code/my_project -> -Users-ryan-Code-my-project
 	projectHash := strings.ReplaceAll(cwd, string(os.PathSeparator), "-")
+	projectHash = strings.ReplaceAll(projectHash, "_", "-")
 	projectDir := filepath.Join(projectsDir, projectHash)
 
 	// check if project-specific directory exists


### PR DESCRIPTION
## Summary
Paths with underscores in the working directory produced incorrect project hashes. Only path separators were converted to dashes, but Claude Code also converts underscores to dashes in its project directory naming. Added a second `strings.ReplaceAll` to convert underscores to dashes and updated the comment.

One line added, one comment updated. All existing tests pass.

## Source
- Transcript: https://www.sageox.ai/team/team_jihjpfkt8b/media/recordings/rec_019c8bfe-8985-7d35-8429-3c3ae659cd48
- Issue: #45

## FSD Agent
This PR was autonomously generated from a team voice transcript.
Assigned to @port8080 (Ajit Banerjee) for review.

---
Generated by FSD agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in how project identifiers are generated to ensure more reliable internal project handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->