### PR TITLE
test(testguard): add test environment isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for ox CLI tool
 
-.PHONY: help build install clean dev run test test-all test-slow test-integration test-benchmark test-sequential test-profile test-watch coverage smoke-test lint format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version
+.PHONY: help build install clean dev run test test-all test-slow test-integration test-benchmark test-sequential test-profile test-watch coverage smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version
 
 # Variables
 GO := go
@@ -86,9 +86,20 @@ smoke-test: build ## Run smoke tests against SageOx cloud (requires SAGEOX_CI_PA
 	@./scripts/smoketest/smoke-test.sh
 
 # Code quality
-lint: ## Run golangci-lint
+lint: lint-test-env ## Run golangci-lint
 	@which golangci-lint > /dev/null || (echo "golangci-lint not found. Install from https://golangci-lint.run/usage/install/" && exit 1)
 	golangci-lint run -c .config/golangci.yml ./...
+
+lint-test-env: ## Check that test files use testguard instead of os.Environ()
+	@echo "Checking for os.Environ() in test files..."
+	@if grep -rn 'os\.Environ()' --include='*_test.go' . | grep -v '// safe:' | grep -v 'internal/testguard/' > /dev/null 2>&1; then \
+		echo "ERROR: os.Environ() found in test files without '// safe:' annotation:"; \
+		grep -rn 'os\.Environ()' --include='*_test.go' . | grep -v '// safe:' | grep -v 'internal/testguard/'; \
+		echo ""; \
+		echo "Use testguard.RunOx() for ox subprocesses, or add '// safe: <reason>' comment."; \
+		exit 1; \
+	fi
+	@echo "OK: no unguarded os.Environ() in test files"
 
 format: ## Format code with gofmt and goimports
 	@echo "Formatting code..."

--- a/cmd/ox/doctor_e2e_helpers_test.go
+++ b/cmd/ox/doctor_e2e_helpers_test.go
@@ -1,0 +1,417 @@
+//go:build integration
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/testguard"
+	"github.com/stretchr/testify/require"
+)
+
+// FreshInstallReport captures everything doctor finds after a fresh ox init.
+// This is the primary deliverable -- it tells us exactly what breaks.
+type FreshInstallReport struct {
+	InitOutput   string
+	InitExitCode int
+	InitDuration time.Duration
+
+	DoctorOutput   string
+	DoctorExitCode int
+	DoctorDuration time.Duration
+
+	DoctorJSON *JSONDoctorOutput
+
+	Warnings []ReportCheck
+	Failures []ReportCheck
+	Skipped  []ReportCheck
+	Passed   []ReportCheck
+}
+
+// ReportCheck is a single doctor check result for the report.
+type ReportCheck struct {
+	Category string
+	Name     string
+	Status   string
+	Priority string
+	FixLevel string
+	Message  string
+	Detail   string
+}
+
+// buildOxBinary compiles the ox binary from source and returns its path.
+func buildOxBinary(t *testing.T) string {
+	t.Helper()
+
+	// find project root by walking up from the test file
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "failed to get caller info")
+	cmdOxDir := filepath.Dir(thisFile)
+	projectRoot := filepath.Dir(filepath.Dir(cmdOxDir))
+
+	return testguard.BuildOxBinary(t, projectRoot)
+}
+
+// cloneTestRepo does a shallow clone of a public git repo and returns the path.
+func cloneTestRepo(t *testing.T, repoURL string) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+
+	cmd := testguard.OxCmd(t, "git", tmpDir, nil, "clone", "--depth=1", repoURL, repoDir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "failed to clone %s: %s", repoURL, string(out))
+
+	return repoDir
+}
+
+// setupIsolatedAuth creates an isolated auth environment for subprocess tests.
+// Returns environment variables to pass to testguard.RunOx.
+func setupIsolatedAuth(t *testing.T, endpointURL string) []string {
+	t.Helper()
+
+	// create isolated config directory structure
+	configDir := filepath.Join(t.TempDir(), "sageox-config")
+	require.NoError(t, os.MkdirAll(configDir, 0700))
+
+	// write a mock auth token
+	authDir := filepath.Join(configDir, "sageox")
+	require.NoError(t, os.MkdirAll(authDir, 0700))
+
+	token := map[string]any{
+		"tokens": map[string]any{
+			endpointURL: map[string]any{
+				"access_token":  "test-access-token-fresh-install",
+				"refresh_token": "test-refresh-token",
+				"expires_at":    time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+				"token_type":    "Bearer",
+				"scope":         "user:profile sageox:write",
+				"user_info": map[string]any{
+					"user_id": "user_test123",
+					"email":   "test@example.com",
+					"name":    "Test User",
+				},
+			},
+		},
+	}
+	tokenBytes, err := json.Marshal(token)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(authDir, "auth.json"), tokenBytes, 0600))
+
+	// XDG overrides isolate from real config; testguard.MinimalEnv adds OX_NO_DAEMON=1
+	return []string{
+		"OX_XDG_ENABLE=1",
+		fmt.Sprintf("XDG_CONFIG_HOME=%s", configDir),
+		fmt.Sprintf("XDG_DATA_HOME=%s", filepath.Join(t.TempDir(), "data")),
+		fmt.Sprintf("XDG_STATE_HOME=%s", filepath.Join(t.TempDir(), "state")),
+		fmt.Sprintf("XDG_CACHE_HOME=%s", filepath.Join(t.TempDir(), "cache")),
+		fmt.Sprintf("XDG_RUNTIME_DIR=%s", filepath.Join(t.TempDir(), "run")),
+		fmt.Sprintf("SAGEOX_ENDPOINT=%s", endpointURL),
+	}
+}
+
+// setupRealAuth creates auth environment using a real test token.
+// Returns environment variables to pass to testguard.RunOx.
+func setupRealAuth(t *testing.T, endpointURL, accessToken string) []string {
+	t.Helper()
+
+	configDir := filepath.Join(t.TempDir(), "sageox-config")
+	require.NoError(t, os.MkdirAll(configDir, 0700))
+
+	authDir := filepath.Join(configDir, "sageox")
+	require.NoError(t, os.MkdirAll(authDir, 0700))
+
+	token := map[string]any{
+		"tokens": map[string]any{
+			endpointURL: map[string]any{
+				"access_token":  accessToken,
+				"refresh_token": "",
+				"expires_at":    time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+				"token_type":    "Bearer",
+				"scope":         "user:profile sageox:write",
+				"user_info": map[string]any{
+					"user_id": "user_test",
+					"email":   "test@example.com",
+					"name":    "Test User",
+				},
+			},
+		},
+	}
+	tokenBytes, err := json.Marshal(token)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(authDir, "auth.json"), tokenBytes, 0600))
+
+	return []string{
+		"OX_XDG_ENABLE=1",
+		fmt.Sprintf("XDG_CONFIG_HOME=%s", configDir),
+		fmt.Sprintf("XDG_DATA_HOME=%s", filepath.Join(t.TempDir(), "data")),
+		fmt.Sprintf("XDG_STATE_HOME=%s", filepath.Join(t.TempDir(), "state")),
+		fmt.Sprintf("XDG_CACHE_HOME=%s", filepath.Join(t.TempDir(), "cache")),
+		fmt.Sprintf("XDG_RUNTIME_DIR=%s", filepath.Join(t.TempDir(), "run")),
+		fmt.Sprintf("SAGEOX_ENDPOINT=%s", endpointURL),
+	}
+}
+
+// startMockSageoxAPI creates a mock server that handles the API endpoints
+// needed for ox init and ox doctor. Uses testguard.SafeMockServer to validate
+// that responses never contain production URLs.
+func startMockSageoxAPI(t *testing.T) *testguard.MockServer {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	// POST /api/v1/repo/init -- repo registration
+	mux.HandleFunc("/api/v1/repo/init", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"repo_id":      "repo_01test000000000000000000",
+			"team_id":      "team_test123",
+			"web_base_url": "",
+		})
+	})
+
+	// GET /api/v1/cli/repos -- team context repos + git credentials
+	// git URLs use localhost:1 (unreachable) to avoid hitting real hosts
+	mux.HandleFunc("/api/v1/cli/repos", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"token":      "mock-git-token",
+			"server_url": "https://localhost:1",
+			"username":   "test-user",
+			"expires_at": time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+			"repos": map[string]any{
+				"test-team-context": map[string]any{
+					"name":    "test-team-context",
+					"url":     "https://localhost:1/test-team-context.git",
+					"type":    "team-context",
+					"team_id": "team_test123",
+				},
+			},
+			"teams": []map[string]any{
+				{
+					"id":   "team_test123",
+					"name": "Test Team",
+					"role": "owner",
+				},
+			},
+		})
+	})
+
+	// GET /api/v1/cli/repos/{repo_id} -- repo detail
+	mux.HandleFunc("/api/v1/cli/repos/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"visibility":   "private",
+			"access_level": "member",
+			"ledger": map[string]any{
+				"status":   "ready",
+				"repo_url": "https://localhost:1/ledger-test.git",
+			},
+			"team_contexts": []map[string]any{
+				{
+					"team_id":  "team_test123",
+					"name":     "test-team-context",
+					"repo_url": "https://localhost:1/test-team-context.git",
+				},
+			},
+		})
+	})
+
+	// GET /api/v1/repo/{repo_id}/doctor -- cloud doctor
+	mux.HandleFunc("/api/v1/repo/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/doctor") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"issues":     []any{},
+				"checked_at": time.Now().Format(time.RFC3339),
+			})
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	// GET /api/v1/teams/{id} -- team info
+	mux.HandleFunc("/api/v1/teams/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":   "team_test123",
+			"name": "Test Team",
+			"slug": "test-team",
+		})
+	})
+
+	return testguard.SafeMockServer(t, mux)
+}
+
+// parseDoctorJSON parses the JSON output from ox doctor --json.
+// Output may include non-JSON lines (debug logs), so we try multiple strategies.
+func parseDoctorJSON(t *testing.T, output string) *JSONDoctorOutput {
+	t.Helper()
+
+	// fast path: full output is clean JSON
+	var result JSONDoctorOutput
+	if err := json.Unmarshal([]byte(output), &result); err == nil {
+		return &result
+	}
+
+	// fallback: scan line by line for a JSON object
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "{") {
+			continue
+		}
+		if err := json.Unmarshal([]byte(trimmed), &result); err == nil {
+			return &result
+		}
+	}
+
+	// last resort: json.Decoder for streaming/multiline JSON
+	dec := json.NewDecoder(strings.NewReader(output))
+	for dec.More() {
+		if err := dec.Decode(&result); err == nil {
+			return &result
+		} else {
+			break // avoid infinite loop on malformed input
+		}
+	}
+
+	t.Logf("no valid JSON found in doctor output:\n%s", output)
+	return nil
+}
+
+// catalogReport categorizes all checks from the doctor JSON output into a report.
+func catalogReport(doctorJSON *JSONDoctorOutput) *FreshInstallReport {
+	report := &FreshInstallReport{
+		DoctorJSON: doctorJSON,
+	}
+
+	if doctorJSON == nil {
+		return report
+	}
+
+	for _, cat := range doctorJSON.Categories {
+		catalogChecks(cat.Name, cat.Checks, report)
+	}
+
+	return report
+}
+
+// catalogChecks recursively categorizes checks into the report.
+func catalogChecks(category string, checks []JSONCheckResult, report *FreshInstallReport) {
+	for _, check := range checks {
+		rc := ReportCheck{
+			Category: category,
+			Name:     check.Name,
+			Status:   check.Status,
+			Priority: check.Priority,
+			FixLevel: check.FixLevel,
+			Message:  check.Message,
+			Detail:   check.Detail,
+		}
+
+		switch check.Status {
+		case "passed":
+			report.Passed = append(report.Passed, rc)
+		case "warning":
+			report.Warnings = append(report.Warnings, rc)
+		case "failed":
+			report.Failures = append(report.Failures, rc)
+		case "skipped":
+			report.Skipped = append(report.Skipped, rc)
+		}
+
+		if len(check.Children) > 0 {
+			catalogChecks(category, check.Children, report)
+		}
+	}
+}
+
+// logReport logs a human-readable fresh install doctor report.
+func logReport(t *testing.T, report *FreshInstallReport) {
+	t.Helper()
+
+	var b strings.Builder
+
+	b.WriteString("\n")
+	b.WriteString("========================================\n")
+	b.WriteString("  FRESH INSTALL DOCTOR REPORT\n")
+	b.WriteString("========================================\n")
+	b.WriteString(fmt.Sprintf("  Init: exit=%d duration=%s\n", report.InitExitCode, report.InitDuration))
+	b.WriteString(fmt.Sprintf("  Doctor: exit=%d duration=%s\n", report.DoctorExitCode, report.DoctorDuration))
+	b.WriteString("========================================\n")
+
+	if len(report.Failures) > 0 {
+		b.WriteString(fmt.Sprintf("\nFAILURES (%d):\n", len(report.Failures)))
+		for _, f := range report.Failures {
+			b.WriteString(fmt.Sprintf("  [%s] %s > %s\n", f.Priority, f.Category, f.Name))
+			b.WriteString(fmt.Sprintf("    message: %s\n", f.Message))
+			if f.FixLevel != "" {
+				b.WriteString(fmt.Sprintf("    fix: %s\n", f.FixLevel))
+			}
+			if f.Detail != "" {
+				b.WriteString(fmt.Sprintf("    detail: %s\n", f.Detail))
+			}
+		}
+	}
+
+	if len(report.Warnings) > 0 {
+		b.WriteString(fmt.Sprintf("\nWARNINGS (%d):\n", len(report.Warnings)))
+		for _, w := range report.Warnings {
+			b.WriteString(fmt.Sprintf("  [%s] %s > %s\n", w.Priority, w.Category, w.Name))
+			b.WriteString(fmt.Sprintf("    message: %s\n", w.Message))
+			if w.FixLevel != "" {
+				b.WriteString(fmt.Sprintf("    fix: %s\n", w.FixLevel))
+			}
+			if w.Detail != "" {
+				b.WriteString(fmt.Sprintf("    detail: %s\n", w.Detail))
+			}
+		}
+	}
+
+	if len(report.Skipped) > 0 {
+		b.WriteString(fmt.Sprintf("\nSKIPPED (%d):\n", len(report.Skipped)))
+		for _, s := range report.Skipped {
+			b.WriteString(fmt.Sprintf("  %s > %s: %s\n", s.Category, s.Name, s.Message))
+		}
+	}
+
+	b.WriteString(fmt.Sprintf("\nPASSED (%d):\n", len(report.Passed)))
+	for _, p := range report.Passed {
+		b.WriteString(fmt.Sprintf("  %s > %s: %s\n", p.Category, p.Name, p.Message))
+	}
+
+	b.WriteString("\n========================================\n")
+	b.WriteString(fmt.Sprintf("  Summary: %d passed, %d warnings, %d failures, %d skipped\n",
+		len(report.Passed), len(report.Warnings), len(report.Failures), len(report.Skipped)))
+	b.WriteString("========================================\n")
+
+	t.Log(b.String())
+
+	if report.InitOutput != "" {
+		t.Logf("\n--- RAW INIT OUTPUT ---\n%s\n--- END INIT OUTPUT ---\n", report.InitOutput)
+	}
+	if report.DoctorOutput != "" {
+		t.Logf("\n--- RAW DOCTOR OUTPUT ---\n%s\n--- END DOCTOR OUTPUT ---\n", report.DoctorOutput)
+	}
+}

--- a/cmd/ox/doctor_e2e_test.go
+++ b/cmd/ox/doctor_e2e_test.go
@@ -1,0 +1,332 @@
+//go:build integration
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/testguard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFreshInstall_MockServer_InitThenDoctor simulates the exact flow a new user follows:
+//
+//  1. Has an existing repo (git repo with commits)
+//  2. Runs ox init --quiet --team <id>
+//  3. Immediately runs ox doctor --json (NO ox sync in between)
+//
+// Uses a mock API server so this test runs without credentials.
+// The test captures and logs EVERY warning/failure that doctor reports.
+// This is the diagnostic test -- the report IS the deliverable.
+func TestFreshInstall_MockServer_InitThenDoctor(t *testing.T) {
+	oxBin := buildOxBinary(t)
+	mockServer := startMockSageoxAPI(t)
+	repoDir := testGitRepo(t)
+	envVars := setupIsolatedAuth(t, mockServer.URL)
+
+	testguard.StopDaemonCleanup(t, oxBin, repoDir, envVars)
+
+	// === STEP 1: ox init ===
+	initOutput, initExit, initDuration := testguard.RunOx(t, oxBin, repoDir, envVars,
+		"init", "--quiet", "--team", "team_test123")
+
+	t.Logf("ox init completed: exit=%d duration=%s", initExit, initDuration)
+
+	if initExit != 0 {
+		t.Logf("WARNING: ox init exited with code %d\nOutput:\n%s", initExit, initOutput)
+	}
+
+	// === STEP 2: ox doctor (immediately, NO ox sync) ===
+	doctorOutput, doctorExit, doctorDuration := testguard.RunOx(t, oxBin, repoDir, envVars,
+		"doctor", "--json", "--verbose")
+
+	t.Logf("ox doctor completed: exit=%d duration=%s", doctorExit, doctorDuration)
+
+	// === STEP 3: parse and report ===
+	doctorJSON := parseDoctorJSON(t, doctorOutput)
+
+	report := catalogReport(doctorJSON)
+	report.InitOutput = initOutput
+	report.InitExitCode = initExit
+	report.InitDuration = initDuration
+	report.DoctorOutput = doctorOutput
+	report.DoctorExitCode = doctorExit
+	report.DoctorDuration = doctorDuration
+
+	logReport(t, report)
+
+	// === ASSERTIONS ===
+	if doctorJSON != nil {
+		assert.Greater(t, len(doctorJSON.Categories), 0, "doctor should return at least one category")
+
+		t.Logf("Doctor summary: passed=%d warnings=%d failed=%d skipped=%d",
+			doctorJSON.Summary.Passed, doctorJSON.Summary.Warnings,
+			doctorJSON.Summary.Failed, doctorJSON.Summary.Skipped)
+	}
+
+	// assert the bootstrapping grace period is working:
+	// git repo paths should NOT be a failure right after init (it should be info/warning)
+	for _, f := range report.Failures {
+		if strings.Contains(f.Name, "git repo paths") {
+			t.Errorf("git repo paths should not be a failure right after init; got: %s (priority=%s)", f.Message, f.Priority)
+		}
+	}
+
+	// filter out expected test-environment issues (no real daemon, no real API connectivity beyond mock)
+	// NOTE: category-level exclusions are broad. A regression inside an excluded
+	// category will not be caught by this test. The real-infra test
+	// (TestFreshInstall_RealRepo_InitThenDoctor) covers them.
+	unexpectedFailures := filterExpectedE2EIssues(report.Failures)
+	unexpectedWarnings := filterExpectedE2EIssues(report.Warnings)
+
+	if len(unexpectedFailures) > 0 {
+		t.Errorf("unexpected failures after fresh install (%d):", len(unexpectedFailures))
+		for _, f := range unexpectedFailures {
+			t.Errorf("  %s > %s: %s [fix: %s]", f.Category, f.Name, f.Message, f.FixLevel)
+		}
+	}
+
+	if len(unexpectedWarnings) > 0 {
+		t.Errorf("unexpected warnings after fresh install (%d):", len(unexpectedWarnings))
+		for _, w := range unexpectedWarnings {
+			t.Errorf("  %s > %s: %s [fix: %s]", w.Category, w.Name, w.Message, w.FixLevel)
+		}
+	}
+}
+
+// TestFreshInstall_RealRepo_InitThenDoctor runs the same flow against real
+// infrastructure using steveyegge/beads as the test repo.
+//
+// Requires environment variables:
+//
+//	SAGEOX_TEST_TOKEN    - a valid API access token for the test endpoint
+//	SAGEOX_TEST_ENDPOINT - the SageOx API endpoint (default: https://test.sageox.ai)
+//	SAGEOX_TEST_TEAM_ID  - team ID to associate the repo with
+//
+// This test captures what a REAL customer would see.
+func TestFreshInstall_RealRepo_InitThenDoctor(t *testing.T) {
+	token := os.Getenv("SAGEOX_TEST_TOKEN")
+	if token == "" {
+		t.Skip("SAGEOX_TEST_TOKEN not set; skipping real infrastructure test")
+	}
+
+	endpointURL := os.Getenv("SAGEOX_TEST_ENDPOINT")
+	if endpointURL == "" {
+		endpointURL = "https://test.sageox.ai"
+	}
+
+	teamID := os.Getenv("SAGEOX_TEST_TEAM_ID")
+	if teamID == "" {
+		t.Skip("SAGEOX_TEST_TEAM_ID not set; skipping real infrastructure test")
+	}
+
+	oxBin := buildOxBinary(t)
+	repoDir := cloneTestRepo(t, "https://github.com/steveyegge/beads.git")
+	t.Logf("cloned steveyegge/beads to %s", repoDir)
+
+	envVars := setupRealAuth(t, endpointURL, token)
+
+	testguard.StopDaemonCleanup(t, oxBin, repoDir, envVars)
+
+	// === STEP 1: ox init ===
+	initOutput, initExit, initDuration := testguard.RunOx(t, oxBin, repoDir, envVars,
+		"init", "--quiet", "--team", teamID)
+
+	t.Logf("ox init completed: exit=%d duration=%s", initExit, initDuration)
+
+	if initExit != 0 {
+		t.Logf("WARNING: ox init exited with code %d\nOutput:\n%s", initExit, initOutput)
+	}
+
+	// === STEP 2: ox doctor (immediately, NO ox sync) ===
+	doctorOutput, doctorExit, doctorDuration := testguard.RunOx(t, oxBin, repoDir, envVars,
+		"doctor", "--json", "--verbose")
+
+	t.Logf("ox doctor completed: exit=%d duration=%s", doctorExit, doctorDuration)
+
+	// === STEP 3: parse and report ===
+	doctorJSON := parseDoctorJSON(t, doctorOutput)
+
+	report := catalogReport(doctorJSON)
+	report.InitOutput = initOutput
+	report.InitExitCode = initExit
+	report.InitDuration = initDuration
+	report.DoctorOutput = doctorOutput
+	report.DoctorExitCode = doctorExit
+	report.DoctorDuration = doctorDuration
+
+	logReport(t, report)
+
+	// === ASSERTIONS ===
+	require.NotNil(t, doctorJSON, "doctor should produce valid JSON output")
+	assert.Greater(t, len(doctorJSON.Categories), 0, "doctor should return categories")
+
+	t.Logf("Doctor summary: passed=%d warnings=%d failed=%d skipped=%d",
+		doctorJSON.Summary.Passed, doctorJSON.Summary.Warnings,
+		doctorJSON.Summary.Failed, doctorJSON.Summary.Skipped)
+
+	// for real infra test, log ALL issues without filtering -- purely diagnostic
+	if len(report.Failures) > 0 {
+		t.Logf("REAL INFRA: %d failures found (this is diagnostic, not necessarily a test failure)", len(report.Failures))
+	}
+	if len(report.Warnings) > 0 {
+		t.Logf("REAL INFRA: %d warnings found (this is diagnostic, not necessarily a test failure)", len(report.Warnings))
+	}
+}
+
+// TestFreshInstall_MockServer_InitThenSyncThenDoctor is a comparison test.
+// It runs the same flow but WITH ox sync between init and doctor.
+// By comparing reports from this test vs the no-sync test, we can see
+// exactly which issues are caused by missing sync.
+func TestFreshInstall_MockServer_InitThenSyncThenDoctor(t *testing.T) {
+	oxBin := buildOxBinary(t)
+	mockServer := startMockSageoxAPI(t)
+	repoDir := testGitRepo(t)
+	envVars := setupIsolatedAuth(t, mockServer.URL)
+
+	testguard.StopDaemonCleanup(t, oxBin, repoDir, envVars)
+
+	// step 1: init
+	initOutput, initExit, initDuration := testguard.RunOx(t, oxBin, repoDir, envVars,
+		"init", "--quiet", "--team", "team_test123")
+
+	t.Logf("ox init: exit=%d duration=%s", initExit, initDuration)
+	if initExit != 0 {
+		t.Logf("WARNING: ox init exited with code %d\nOutput:\n%s", initExit, initOutput)
+	}
+
+	// step 2: ox sync (this is what users SHOULD do but often don't)
+	syncOutput, syncExit, syncDuration := testguard.RunOx(t, oxBin, repoDir, envVars, "sync")
+	t.Logf("ox sync: exit=%d duration=%s output:\n%s", syncExit, syncDuration, syncOutput)
+
+	// step 3: doctor
+	doctorOutput, doctorExit, doctorDuration := testguard.RunOx(t, oxBin, repoDir, envVars,
+		"doctor", "--json", "--verbose")
+
+	doctorJSON := parseDoctorJSON(t, doctorOutput)
+	report := catalogReport(doctorJSON)
+	report.InitOutput = initOutput
+	report.InitExitCode = initExit
+	report.InitDuration = initDuration
+	report.DoctorOutput = doctorOutput
+	report.DoctorExitCode = doctorExit
+	report.DoctorDuration = doctorDuration
+
+	t.Log("=== WITH SYNC (comparison test) ===")
+	logReport(t, report)
+
+	if doctorJSON != nil {
+		t.Logf("With-sync summary: passed=%d warnings=%d failed=%d skipped=%d",
+			doctorJSON.Summary.Passed, doctorJSON.Summary.Warnings,
+			doctorJSON.Summary.Failed, doctorJSON.Summary.Skipped)
+	}
+}
+
+// filterExpectedE2EIssues removes issues that are expected in an E2E test
+// environment with mock server (no real daemon, no real git repos to clone).
+func filterExpectedE2EIssues(checks []ReportCheck) []ReportCheck {
+	var unexpected []ReportCheck
+	for _, check := range checks {
+		if isExpectedE2EIssue(check) {
+			continue
+		}
+		unexpected = append(unexpected, check)
+	}
+	return unexpected
+}
+
+// isExpectedE2EIssue returns true if the check is expected to fail/warn
+// in the E2E test environment.
+func isExpectedE2EIssue(check ReportCheck) bool {
+	cat := check.Category
+	msg := check.Message
+	name := check.Name
+
+	// daemon not running -- expected in E2E test (we don't start one)
+	if cat == "Daemon" {
+		return true
+	}
+
+	// authentication issues -- mock server token may not pass all checks
+	if cat == "Authentication" {
+		return true
+	}
+
+	// no real git remotes in test repo
+	if containsAny(name, "Git remotes", "remotes") ||
+		containsAny(msg, "no remotes configured") {
+		return true
+	}
+
+	// no real ledger/team context cloned
+	if cat == "Ledger Git Health" {
+		return true
+	}
+	if cat == "Team Context" {
+		return true
+	}
+
+	// git repo paths: repos syncing (info-level, expected right after init)
+	if containsAny(msg, "syncing", "no repos configured") {
+		return true
+	}
+
+	// uncommitted .sageox/ changes are expected right after init
+	if containsAny(msg, "unstaged") && containsAny(name, ".sageox/") {
+		return true
+	}
+
+	// uncommitted changes from init-created files
+	if containsAny(msg, "uncommitted change") {
+		return true
+	}
+
+	// sessions/ledger not provisioned locally
+	if containsAny(name, "ledger for sessions") && containsAny(msg, "not provisioned") {
+		return true
+	}
+
+	// ox in PATH -- not expected in isolated test
+	if containsAny(name, "ox in PATH") {
+		return true
+	}
+
+	// discovery not run -- optional
+	if containsAny(name, "discovery") {
+		return true
+	}
+
+	// API connectivity -- mock server may not serve all endpoints
+	if containsAny(msg, "API unavailable", "unreachable", "not registered") {
+		return true
+	}
+
+	// SageOx service checks -- mock may not cover all
+	if cat == "SageOx Service" {
+		return true
+	}
+
+	// cloud diagnostics
+	if cat == "Cloud Diagnostics" {
+		return true
+	}
+
+	// version/update checks
+	if cat == "Updates" {
+		return true
+	}
+
+	return false
+}
+
+func containsAny(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/ox/doctor_fresh_install_test.go
+++ b/cmd/ox/doctor_fresh_install_test.go
@@ -335,9 +335,10 @@ func filterTestEnvironmentIssues(issues []string) []string {
 			strings.Contains(issue, "Git remotes") {
 			continue
 		}
-		// skip repo paths when no ledger/team contexts configured
+		// skip repo paths when no ledger/team contexts configured or syncing
 		if strings.Contains(issue, "git repo paths") &&
-			strings.Contains(issue, "no repos configured") {
+			(strings.Contains(issue, "no repos configured") ||
+				strings.Contains(issue, "repos syncing")) {
 			continue
 		}
 		// skip ox in PATH - not expected in test environment

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -703,8 +703,12 @@ func checkGitRepoPaths(fix bool) checkResult {
 			if _, err := os.Stat(sageoxDir); err == nil {
 				// .sageox exists - check if authenticated
 				if authenticated, _ := auth.IsAuthenticated(); authenticated {
-					// authenticated + .sageox exists but no repos configured yet
-					// expected on fresh checkout — warn, don't fail
+					// recently initialized? daemon may not have synced yet
+					if isRecentlyInitialized(gitRoot) {
+						return InfoCheck("git repo paths", "repos syncing",
+							"Background sync is cloning repos. Run `ox doctor` again in a minute.")
+					}
+					// authenticated + .sageox exists but no repos configured = problem
 					if fix {
 						return fixMissingRepos(gitRoot, localCfg)
 					}
@@ -724,6 +728,22 @@ func checkGitRepoPaths(fix bool) checkResult {
 	// issues found
 	if fix {
 		return fixRepoPathIssues(gitRoot, localCfg, issues)
+	}
+
+	// check if all issues are "missing" and the project was just initialized.
+	// after ox init, the daemon may not have cloned repos yet -- this is expected,
+	// not a failure. downgrade to info so users don't see scary errors on first run.
+	allMissing := true
+	for _, issue := range issues {
+		if issue.issue != "missing" {
+			allMissing = false
+			break
+		}
+	}
+	if allMissing && isRecentlyInitialized(gitRoot) {
+		return InfoCheck("git repo paths",
+			fmt.Sprintf("%d repo(s) syncing", len(issues)),
+			"Background sync is cloning repos. Run `ox doctor` again in a minute.")
 	}
 
 	// build detail message listing issues
@@ -2290,4 +2310,22 @@ func saveGitCredentialsFromRepos(repos *api.ReposResponse, projectEndpoint strin
 		ep = endpoint.Get()
 	}
 	return gitserver.SaveCredentialsForEndpoint(ep, *creds)
+}
+
+// bootstrapGracePeriod is the window after ox init during which missing repos
+// are expected (daemon is still cloning). Chosen to be longer than typical clone
+// time for small team context repos on a fast connection.
+// Caveat: mtime-based detection is unreliable on NFS and CI cache-restore scenarios
+// where file timestamps may not reflect actual write time.
+const bootstrapGracePeriod = 5 * time.Minute
+
+// isRecentlyInitialized checks if the project was initialized within the grace period.
+// Uses config.json modification time as a proxy for init time.
+func isRecentlyInitialized(gitRoot string) bool {
+	configPath := filepath.Join(gitRoot, ".sageox", "config.json")
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return false
+	}
+	return time.Since(info.ModTime()) < bootstrapGracePeriod
 }

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -612,6 +612,9 @@ func runInit() error {
 		regClient.WithAuthToken(token.AccessToken)
 	}
 
+	// tracks whether daemon sync was confirmed (used for next-steps guidance)
+	daemonSynced := false
+
 	// call API
 	resp, err := regClient.RegisterRepo(req)
 	if err != nil {
@@ -666,12 +669,41 @@ func runInit() error {
 			}
 		}
 
-		// trigger daemon to sync (clone missing team contexts and ledger)
+		// start daemon and trigger sync (clone team contexts and ledger)
+		// per IPC architecture: init starts daemon if not running
 		if daemon.IsRunning() {
-			go func() {
-				client := daemon.NewClient()
-				_ = client.RequestSync()
-			}()
+			client := daemon.NewClient()
+			if err := client.RequestSync(); err != nil {
+				slog.Debug("failed to request sync from running daemon", "error", err)
+			} else {
+				daemonSynced = true
+			}
+		} else {
+			if err := autoStartDaemon(); err != nil {
+				slog.Debug("failed to auto-start daemon", "error", err)
+			} else {
+				// wait up to 2s for daemon to be ready, then request sync.
+				// on slow machines or under Gatekeeper verification this may
+				// not be enough -- the daemon's own timer will sync later.
+				healthy := false
+				for i := 0; i < 20; i++ {
+					time.Sleep(100 * time.Millisecond)
+					if daemon.IsHealthy() == nil {
+						healthy = true
+						break
+					}
+				}
+				if healthy {
+					client := daemon.NewClient()
+					if err := client.RequestSync(); err != nil {
+						slog.Debug("failed to request sync after daemon start", "error", err)
+					} else {
+						daemonSynced = true
+					}
+				} else {
+					slog.Debug("daemon did not become healthy within 2s after auto-start; sync deferred to daemon timer")
+				}
+			}
 		}
 
 		// re-stage .sageox/ files after API registration updated config.json
@@ -695,37 +727,47 @@ func runInit() error {
 		fmt.Println(ui.RenderCategory("Next Steps"))
 		fmt.Println()
 
-		// step 1: commit and push (files are already staged by ForceAddSageoxFiles)
+		// next steps use a counter so numbering adjusts based on daemon status
+		step := 1
+
+		// step N: commit and push (files are already staged by ForceAddSageoxFiles)
 		// NOTE: do NOT suggest -a flag — we explicitly staged only .sageox/ files.
 		// Using -a could accidentally commit unrelated working tree changes.
-		fmt.Printf("  1. Commit and push SageOx files:\n")
+		fmt.Printf("  %d. Commit and push SageOx files:\n", step)
 		fmt.Printf("     %s\n", cli.StyleCommand.Render("git commit -m 'SageOx init' && git push"))
+		step++
 
-		// step 2: start background sync (clones ledger + team contexts, starts daemon if needed)
-		fmt.Printf("  2. Run %s to start background sync\n", cli.StyleCommand.Render("ox sync"))
+		// step N (conditional): if daemon sync was not confirmed, tell user to run ox sync
+		if !daemonSynced {
+			fmt.Printf("  %d. Run %s to start background sync\n", step, cli.StyleCommand.Render("ox sync"))
+			step++
+		}
 
-		// step 3: invite teammates (show dashboard URL if team info available)
+		// step N: invite teammates (show dashboard URL if team info available)
 		if cfg.TeamID != "" && cfg.Endpoint != "" {
 			teamDashURL := strings.TrimSuffix(cfg.Endpoint, "/") + "/team/" + cfg.TeamID
 			teamLabel := cfg.TeamName
 			if teamLabel == "" {
 				teamLabel = cfg.TeamID
 			}
-			fmt.Printf("  3. Invite teammates (%s):\n", teamLabel)
+			fmt.Printf("  %d. Invite teammates (%s):\n", step, teamLabel)
 			fmt.Printf("     Run %s or visit %s to get invite link\n", cli.StyleCommand.Render("ox view team"), teamDashURL)
 		} else {
-			fmt.Println("  3. Invite teammates from your team dashboard")
+			fmt.Printf("  %d. Invite teammates from your team dashboard\n", step)
 		}
+		step++
 
-		// step 4: health check
-		fmt.Printf("  4. Run %s to confirm everything is working properly\n", cli.StyleCommand.Render("ox doctor"))
+		// step N: health check
+		fmt.Printf("  %d. Run %s to confirm everything is working properly\n", step, cli.StyleCommand.Render("ox doctor"))
+		step++
 
-		// step 5: try session recording
-		fmt.Printf("  5. Start Claude Code in this repo\n")
+		// step N: try session recording
+		fmt.Printf("  %d. Start Claude Code in this repo\n", step)
 		fmt.Printf("     Run %s to try session recording\n", cli.StyleCommand.Render("/ox-session-start"))
+		step++
 
-		// step 6: agent bootstrap
-		fmt.Printf("  6. Claude Code should auto-run: %s\n", cli.StyleCommand.Render("ox agent prime"))
+		// step N: agent bootstrap
+		fmt.Printf("  %d. Claude Code should auto-run: %s\n", step, cli.StyleCommand.Render("ox agent prime"))
 
 		// show contextual tip
 		userCfg, _ := config.LoadUserConfig("")

--- a/cmd/ox/sync.go
+++ b/cmd/ox/sync.go
@@ -283,6 +283,11 @@ func syncPathExists(path string) bool {
 // This mirrors the logic in daemon.go:startDaemonBackground but is self-contained
 // to avoid circular dependencies.
 func autoStartDaemon() error {
+	// OX_NO_DAEMON=1 prevents daemon start (integration tests)
+	if os.Getenv("OX_NO_DAEMON") == "1" {
+		return fmt.Errorf("daemon start disabled: OX_NO_DAEMON=1")
+	}
+
 	// get the path to the current executable
 	exe, err := os.Executable()
 	if err != nil {

--- a/internal/doctor/session_test.go
+++ b/internal/doctor/session_test.go
@@ -177,7 +177,7 @@ func TestSessionIncompleteCheck_CompleteSessions(t *testing.T) {
 	_ = cmd.Run()
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "test")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	_ = cmd.Run()
 
 	check := &SessionIncompleteCheck{gitRoot: ""}
@@ -211,7 +211,7 @@ func TestSessionIncompleteCheck_MissingHTML(t *testing.T) {
 	_ = cmd.Run()
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "test")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	_ = cmd.Run()
 
 	check := &SessionIncompleteCheck{gitRoot: ""}
@@ -247,7 +247,7 @@ func TestSessionIncompleteCheck_MissingSummary(t *testing.T) {
 	_ = cmd.Run()
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "test")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	_ = cmd.Run()
 
 	check := &SessionIncompleteCheck{gitRoot: ""}
@@ -280,7 +280,7 @@ func TestSessionIncompleteCheck_UntrackedSession(t *testing.T) {
 	_ = cmd.Run()
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "init")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	_ = cmd.Run()
 
 	// create complete session but don't add to git (untracked)
@@ -320,7 +320,7 @@ func TestSessionIncompleteCheck_StagedSession(t *testing.T) {
 	_ = cmd.Run()
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "init")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	_ = cmd.Run()
 
 	// create complete session and stage it
@@ -363,7 +363,7 @@ func TestSessionIncompleteCheck_MultipleIssues(t *testing.T) {
 	_ = cmd.Run()
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "init")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	_ = cmd.Run()
 
 	// session 1: missing HTML (committed)
@@ -376,7 +376,7 @@ func TestSessionIncompleteCheck_MultipleIssues(t *testing.T) {
 	_ = cmd.Run()
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "session1")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	_ = cmd.Run()
 
 	// session 2: missing summary (untracked)
@@ -430,7 +430,7 @@ func TestSessionIncompleteCheck_RunResult(t *testing.T) {
 	_ = cmd.Run()
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "init")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	_ = cmd.Run()
 
 	// create incomplete session (missing both HTML and summary, untracked)
@@ -586,7 +586,7 @@ func TestSessionAutoStageCheck_StagesUntrackedFiles(t *testing.T) {
 	require.NoError(t, cmd.Run())
 	cmd = exec.Command("git", "-C", ledgerPath, "commit", "-m", "init")
 	cmd.Dir = ledgerPath
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com") // safe: local git commit in temp dir
 	require.NoError(t, cmd.Run())
 
 	// create untracked session files

--- a/internal/session/integration_test.go
+++ b/internal/session/integration_test.go
@@ -83,7 +83,7 @@ func buildOxCLI(t *testing.T) string {
 
 	cmd := exec.Command("go", "build", "-o", oxBinary, "./cmd/ox")
 	cmd.Dir = projectRoot
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0") // safe: go build only
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -173,7 +173,7 @@ func runClaudeSession(t *testing.T, claudePath, oxPath, workspace string) string
 			prompt,
 		)
 		cmd.Dir = workspace
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(os.Environ(), // safe: claude CLI subprocess, not ox
 			// CLAUDE_TRANSCRIPT_DIR is Claude Code's env var for session recording output
 			"CLAUDE_TRANSCRIPT_DIR="+sessionDir,
 		)

--- a/internal/testguard/AGENTS.md
+++ b/internal/testguard/AGENTS.md
@@ -1,0 +1,39 @@
+<!-- doc-audience: ai -->
+
+# testguard: Test Environment Isolation
+
+Tests that run `ox` as a subprocess MUST use `testguard.RunOx` or `testguard.OxCmd`. **NEVER** use `exec.Command` + `os.Environ()` to run `ox` in tests -- this leaks the developer's real auth tokens, daemon sockets, and `SAGEOX_ENDPOINT`, causing tests to hit production infrastructure.
+
+## Rules
+
+- `testguard.RunOx(t, oxBin, dir, envVars, args...)` for running ox subprocesses
+- `testguard.SafeMockServer(t, handler)` for mock API servers (validates responses don't contain production URLs)
+- `testguard.BuildOxBinary(t, projectRoot)` for building the ox binary in tests
+- `make lint-test-env` checks for unguarded `os.Environ()` in test files
+- If `os.Environ()` is genuinely needed (e.g., `go build`), annotate with `// safe: <reason>`
+
+```go
+// WRONG: leaks developer's real environment
+cmd := exec.Command(oxBin, "doctor")
+cmd.Env = append(os.Environ(), "EXTRA=val")
+
+// RIGHT: isolated environment, production URLs blocked
+output, exitCode, dur := testguard.RunOx(t, oxBin, dir, envVars, "doctor")
+```
+
+## What testguard provides
+
+| Function | Purpose |
+|----------|---------|
+| `RunOx` | Execute ox subprocess with isolated env, 60s timeout |
+| `OxCmd` / `OxCmdContext` | Build isolated `exec.Cmd` for ox |
+| `MinimalEnv` | Allowlisted env vars + `OX_NO_DAEMON=1` |
+| `SafeMockServer` | Mock HTTP server that rejects production URLs in responses |
+| `BuildOxBinary` | Compile ox binary (only place `os.Environ()` is acceptable) |
+| `StopDaemonCleanup` | Register t.Cleanup to stop any test daemon |
+
+## Production URL validation
+
+- Env values are checked against `productionHostPatterns` (`sageox.ai`)
+- `test.sageox.ai` and `localhost` are exempted via `allowedTestHostPatterns`
+- Mock server responses are NOT exempted -- mocks must use `localhost` URLs

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -1,0 +1,229 @@
+// Package testguard provides test isolation primitives that prevent
+// ox subprocesses from hitting production endpoints during tests.
+//
+// All test code that runs ox as a subprocess MUST use RunOx or OxCmd
+// instead of exec.Command + os.Environ(). This ensures:
+//   - minimal environment (no leaked auth, daemon sockets, or SAGEOX_ENDPOINT)
+//   - OX_NO_DAEMON=1 always injected
+//   - production hostnames in env values cause immediate test failure
+//   - mock server responses are validated for production URL leaks
+package testguard
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// allowedBaseEnv is the allowlist of environment variables inherited from
+// the developer's shell. Everything else is blocked.
+var allowedBaseEnv = []string{
+	"PATH", "HOME", "TMPDIR", "USER", "LANG", "LC_ALL",
+	"GOPATH", "GOROOT",
+	// git needs these for commits
+	"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+	"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+}
+
+// productionHostPatterns are substrings that must NEVER appear in test
+// env values or mock server responses unless exempted by allowedTestHostPatterns.
+var productionHostPatterns = []string{
+	"sageox.ai",
+}
+
+// allowedTestHostPatterns exempt specific hosts from the production block.
+// Values containing these patterns are considered safe test infrastructure.
+var allowedTestHostPatterns = []string{
+	"test.sageox.ai",
+	"localhost",
+}
+
+// RunOx executes an ox subprocess with isolated environment.
+// Returns combined output, exit code, and duration.
+// Uses a 60-second timeout to prevent hangs.
+func RunOx(t *testing.T, oxBin, dir string, envVars []string, args ...string) (string, int, time.Duration) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := OxCmdContext(t, ctx, oxBin, dir, envVars, args...)
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	dur := time.Since(start)
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Logf("warning: command error (not exit code): %v", err)
+			exitCode = -1
+		}
+	}
+
+	return string(out), exitCode, dur
+}
+
+// OxCmd builds an isolated exec.Cmd for running the ox binary in tests.
+func OxCmd(t *testing.T, oxBin, dir string, envVars []string, args ...string) *exec.Cmd {
+	t.Helper()
+	return OxCmdContext(t, context.Background(), oxBin, dir, envVars, args...)
+}
+
+// OxCmdContext builds an isolated exec.Cmd with an explicit context.
+// Validates that no env value contains production hostnames.
+func OxCmdContext(t *testing.T, ctx context.Context, oxBin, dir string, envVars []string, args ...string) *exec.Cmd {
+	t.Helper()
+
+	env := MinimalEnv(envVars)
+	validateEnv(t, env)
+
+	cmd := exec.CommandContext(ctx, oxBin, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	return cmd
+}
+
+// MinimalEnv builds a clean environment from the allowlist + caller overrides.
+// Always injects OX_NO_DAEMON=1.
+func MinimalEnv(testVars []string) []string {
+	var env []string
+	for _, key := range allowedBaseEnv {
+		if val := os.Getenv(key); val != "" {
+			env = append(env, key+"="+val)
+		}
+	}
+	env = append(env, "OX_NO_DAEMON=1")
+	env = append(env, testVars...)
+	return env
+}
+
+// validateEnv checks that no env value contains production hostnames.
+// Values matching allowedTestHostPatterns are exempted.
+func validateEnv(t *testing.T, env []string) {
+	t.Helper()
+	for _, kv := range env {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, val := parts[0], parts[1]
+		lower := strings.ToLower(val)
+		for _, pattern := range productionHostPatterns {
+			if !strings.Contains(lower, pattern) {
+				continue
+			}
+			// check if exempted by a test host pattern
+			exempted := false
+			for _, allowed := range allowedTestHostPatterns {
+				if strings.Contains(lower, allowed) {
+					exempted = true
+					break
+				}
+			}
+			if !exempted {
+				t.Fatalf("testguard: env var %s contains production host %q (value: %s); "+
+					"use localhost or test.sageox.ai URLs in test fixtures", key, pattern, val)
+			}
+		}
+	}
+}
+
+// MockServer is an alias for httptest.Server, returned by SafeMockServer.
+type MockServer = httptest.Server
+
+// SafeMockServer wraps an http.Handler to validate that response bodies
+// never contain production URLs. If detected, the test fails immediately.
+func SafeMockServer(t *testing.T, handler http.Handler) *MockServer {
+	t.Helper()
+	wrapped := &responseValidator{t: t, handler: handler}
+	server := httptest.NewServer(wrapped)
+	t.Cleanup(func() {
+		server.CloseClientConnections()
+		server.Close()
+	})
+	return server
+}
+
+// testReporter is the subset of testing.T needed by responseValidator.
+type testReporter interface {
+	Errorf(format string, args ...any)
+	Helper()
+}
+
+type responseValidator struct {
+	t       testReporter
+	handler http.Handler
+}
+
+func (rv *responseValidator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rec := &responseTee{ResponseWriter: w, body: &strings.Builder{}}
+	rv.handler.ServeHTTP(rec, r)
+
+	body := rec.body.String()
+	lower := strings.ToLower(body)
+	for _, pattern := range productionHostPatterns {
+		if !strings.Contains(lower, pattern) {
+			continue
+		}
+		// mock responses should use localhost, not even test.sageox.ai
+		// (test infra URLs belong in env vars, not mock responses)
+		rv.t.Errorf("testguard: mock response for %s %s contains production host %q; "+
+			"use localhost URLs instead. Body: %s",
+			r.Method, r.URL.Path, pattern, truncate(body, 500))
+	}
+}
+
+type responseTee struct {
+	http.ResponseWriter
+	body *strings.Builder
+}
+
+func (rt *responseTee) Write(b []byte) (int, error) {
+	rt.body.Write(b)
+	return rt.ResponseWriter.Write(b)
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// StopDaemonCleanup registers a cleanup that stops any daemon in the test env.
+func StopDaemonCleanup(t *testing.T, oxBin, repoDir string, envVars []string) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cmd := OxCmdContext(t, ctx, oxBin, repoDir, envVars, "daemon", "stop")
+		_ = cmd.Run()
+	})
+}
+
+// BuildOxBinary compiles the ox binary and returns its path.
+// This is the one place where os.Environ() is acceptable (go build only).
+func BuildOxBinary(t *testing.T, projectRoot string) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	binPath := fmt.Sprintf("%s/ox", binDir)
+
+	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/ox")
+	cmd.Dir = projectRoot
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0") // safe: go-build only, no credentials
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build ox binary: %s", string(out))
+	}
+
+	return binPath
+}

--- a/internal/testguard/testguard_test.go
+++ b/internal/testguard/testguard_test.go
@@ -1,0 +1,139 @@
+package testguard
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinimalEnv_InjectsNoDaemon(t *testing.T) {
+	env := MinimalEnv(nil)
+
+	found := false
+	for _, kv := range env {
+		if kv == "OX_NO_DAEMON=1" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "MinimalEnv should always inject OX_NO_DAEMON=1")
+}
+
+func TestMinimalEnv_ExcludesSageoxEndpoint(t *testing.T) {
+	// even if SAGEOX_ENDPOINT is in the real env, MinimalEnv should NOT inherit it
+	t.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
+
+	env := MinimalEnv(nil)
+
+	for _, kv := range env {
+		parts := strings.SplitN(kv, "=", 2)
+		assert.NotEqual(t, "SAGEOX_ENDPOINT", parts[0],
+			"MinimalEnv should not inherit SAGEOX_ENDPOINT from real environment")
+	}
+}
+
+func TestMinimalEnv_AllowsTestOverrides(t *testing.T) {
+	env := MinimalEnv([]string{
+		"SAGEOX_ENDPOINT=http://localhost:12345",
+		"OX_XDG_ENABLE=1",
+	})
+
+	found := false
+	for _, kv := range env {
+		if kv == "SAGEOX_ENDPOINT=http://localhost:12345" {
+			found = true
+		}
+	}
+	assert.True(t, found, "test overrides should be included")
+}
+
+func TestValidateEnv_AllowsTestInfra(t *testing.T) {
+	// test.sageox.ai should be allowed (it's test infrastructure)
+	validateEnv(t, []string{
+		"SAGEOX_ENDPOINT=https://test.sageox.ai",
+	})
+	// if we get here without Fatalf, the test passes
+}
+
+func TestValidateEnv_RejectsProductionHost(t *testing.T) {
+	// production sageox.ai (without test. prefix) should be detected
+	env := []string{
+		"SAGEOX_ENDPOINT=https://sageox.ai",
+	}
+
+	for _, kv := range env {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		val := parts[1]
+		lower := strings.ToLower(val)
+		for _, pattern := range productionHostPatterns {
+			if !strings.Contains(lower, pattern) {
+				continue
+			}
+			exempted := false
+			for _, allowed := range allowedTestHostPatterns {
+				if strings.Contains(lower, allowed) {
+					exempted = true
+					break
+				}
+			}
+			if !exempted {
+				return // test passes: production URL detected and not exempted
+			}
+		}
+	}
+	t.Error("should have detected production hostname in env value")
+}
+
+func TestSafeMockServer_PassesCleanResponses(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"url": "https://localhost:1/repo.git"}`))
+	})
+
+	server := SafeMockServer(t, handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/test")
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func TestResponseValidator_DetectsProductionURL(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"url": "https://git.test.sageox.ai/repo.git"}`))
+	})
+
+	// use httptest directly to avoid SafeMockServer's cleanup interfering
+	fakeT := &captureT{}
+	wrapped := &responseValidator{t: fakeT, handler: handler}
+	server := httptest.NewServer(wrapped)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/test")
+	assert.NoError(t, err)
+	resp.Body.Close()
+
+	assert.True(t, fakeT.errored, "should have reported error for production URL in response")
+	assert.Contains(t, fakeT.msg, "sageox.ai")
+}
+
+// captureT captures Errorf calls without stopping execution
+type captureT struct {
+	testing.T
+	errored bool
+	msg     string
+}
+
+func (c *captureT) Errorf(format string, args ...any) {
+	c.errored = true
+	c.msg = fmt.Sprintf(format, args...)
+}
+
+func (c *captureT) Helper() {}


### PR DESCRIPTION
## Summary

Adds test environment isolation infrastructure and E2E tests for the fresh `ox init` + `ox doctor` flow.
New `testguard` package ensures test subprocesses never leak real credentials or production endpoints.
Includes daemon auto-start in init, 5-minute bootstrap grace period for fresh installs, and lint checks to enforce isolation.

## Test plan

- E2E mock server tests pass (fresh install flow)
- E2E real infrastructure tests runnable with credentials
- All unit tests pass with race detection
- `make lint-test-env` verifies no unguarded `os.Environ()` in test files