### PR TITLE
fix(session): filter tool noise and check write access (#26, #2, #47, #39)

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -83,6 +83,14 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 		return fmt.Errorf("not logged in to SageOx\nRun 'ox login' first to authenticate")
 	}
 
+	// check write access before recording — fail fast if user is a viewer
+	if err := checkUploadAccess(projectRoot); err != nil {
+		if errors.Is(err, api.ErrReadOnly) {
+			return fmt.Errorf("you have read-only access to this repo — sessions cannot be uploaded to the ledger\nTo upload sessions, request team membership from an admin")
+		}
+		// non-ErrReadOnly errors fall through (fail-open)
+	}
+
 	// one-time session recording notice (returned to caller via JSON)
 	notice := getSessionTermsNotice()
 

--- a/cmd/ox/session_resummary.go
+++ b/cmd/ox/session_resummary.go
@@ -118,6 +118,11 @@ func buildResummaryPrompt(entries []map[string]any, inputPath string, compact bo
 			continue
 		}
 
+		// filter out read-only tool noise
+		if isResummaryNoiseEntry(entry) {
+			continue
+		}
+
 		// extract message info
 		msgType := getEntryType(entry)
 		content := getEntryContent(entry)
@@ -204,4 +209,50 @@ func truncateForPrompt(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// isResummaryNoiseEntry returns true for tool entries that are read-only
+// exploration (read, glob, grep) and should be filtered from resummary prompts.
+func isResummaryNoiseEntry(entry map[string]any) bool {
+	entryType, _ := entry["type"].(string)
+	if entryType != "tool" {
+		return false
+	}
+
+	toolName, _ := entry["tool_name"].(string)
+	toolLower := strings.ToLower(toolName)
+
+	// read-only tools are noise unless they failed
+	readOnlyTools := map[string]bool{
+		"read": true, "glob": true, "grep": true,
+		"webfetch": true, "websearch": true,
+	}
+	if readOnlyTools[toolLower] {
+		// keep if output indicates an error
+		output, _ := entry["tool_output"].(string)
+		if output == "" {
+			output, _ = entry["content"].(string)
+		}
+		if session.IsNoiseCommand(output) {
+			return true
+		}
+		// simple heuristic: if no error keywords, it's noise
+		outputLower := strings.ToLower(output)
+		for _, errWord := range []string{"error:", "failed", "fatal:", "panic:", "not found"} {
+			if strings.Contains(outputLower, errWord) {
+				return false // keep errors
+			}
+		}
+		return true
+	}
+
+	// noise bash commands
+	if toolLower == "bash" || toolLower == "execute" {
+		input, _ := entry["tool_input"].(string)
+		if session.IsNoiseCommand(input) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/session/summarize.go
+++ b/internal/session/summarize.go
@@ -203,15 +203,18 @@ func Summarize(entries []Entry, agentID, agentType, model, endpointURL string) (
 }
 
 // buildSummarizeRequest converts entries to the API request format.
+// Filters out low-value exploratory tool calls to reduce noise for the LLM.
 func buildSummarizeRequest(entries []Entry, agentID, agentType, model string) *SummarizeRequest {
+	filtered := FilterForSummarization(entries)
+
 	req := &SummarizeRequest{
 		AgentID:   agentID,
 		AgentType: agentType,
 		Model:     model,
-		Entries:   make([]SummarizeEntry, 0, len(entries)),
+		Entries:   make([]SummarizeEntry, 0, len(filtered)),
 	}
 
-	for _, e := range entries {
+	for _, e := range filtered {
 		se := SummarizeEntry{
 			Type:     string(e.Type),
 			Content:  e.Content,
@@ -224,6 +227,85 @@ func buildSummarizeRequest(entries []Entry, agentID, agentType, model string) *S
 	}
 
 	return req
+}
+
+// readOnlyTools are tools that only read/search without modifying state.
+// Successful calls to these are low-value noise for summarization.
+var readOnlyTools = map[string]bool{
+	"read":      true,
+	"Read":      true,
+	"glob":      true,
+	"Glob":      true,
+	"grep":      true,
+	"Grep":      true,
+	"WebFetch":  true,
+	"WebSearch": true,
+	"webfetch":  true,
+	"websearch": true,
+}
+
+// FilterForSummarization removes low-value tool entries from session data
+// before sending to the LLM summarizer. Keeps raw.jsonl complete for
+// auditability while reducing noise in the summarization input.
+//
+// Filtered out (when successful):
+//   - Read-only tools: Read, Glob, Grep, WebFetch, WebSearch
+//   - Bash commands that are noise: ls, pwd, cat, head, tail, etc.
+//
+// Always kept:
+//   - All user and assistant messages (the human-AI dialog)
+//   - System messages
+//   - Write/Edit tool calls (actual changes)
+//   - Failed tool calls (important for understanding debugging)
+//   - Bash commands that modify state
+func FilterForSummarization(entries []Entry) []Entry {
+	if len(entries) == 0 {
+		return entries
+	}
+
+	filtered := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		if e.Type != EntryTypeTool {
+			filtered = append(filtered, e)
+			continue
+		}
+
+		// keep tool entries that errored (useful for understanding debugging)
+		if hasToolError(e) {
+			filtered = append(filtered, e)
+			continue
+		}
+
+		// filter read-only tools
+		if readOnlyTools[e.ToolName] {
+			continue
+		}
+
+		// filter noise bash/Bash commands
+		toolLower := strings.ToLower(e.ToolName)
+		if toolLower == "bash" || toolLower == "execute" {
+			if IsNoiseCommand(e.ToolInput) {
+				continue
+			}
+		}
+
+		filtered = append(filtered, e)
+	}
+
+	return filtered
+}
+
+// hasToolError checks if a tool entry indicates a failure.
+func hasToolError(e Entry) bool {
+	output := e.ToolOutput
+	if output == "" {
+		output = e.Content
+	}
+	if output == "" {
+		return false
+	}
+	hasErr, _ := eventLogDetectError(output)
+	return hasErr
 }
 
 // BuildSummaryPrompt builds a prompt for the calling agent to generate a session summary.
@@ -245,7 +327,8 @@ func BuildSummaryPrompt(entries []Entry, rawPath, ledgerSessionDir string) strin
 	// (the agent already has the session in its context window)
 	sb.WriteString("## Session to Analyze\n\n")
 	fmt.Fprintf(&sb, "Read the session recording at: `%s`\n\n", rawPath)
-	fmt.Fprintf(&sb, "The file is JSONL format with %d entries. Each line is a JSON object with `type`, `content`, and optional `tool_name` fields.\n\n", len(entries))
+	fmt.Fprintf(&sb, "The file is JSONL format with %d entries. Each line is a JSON object with `type`, `content`, and optional `tool_name` fields.\n", len(entries))
+	sb.WriteString("Focus on user/assistant dialog and write/edit tool calls. Skip read/glob/grep tool entries — they are exploratory noise.\n\n")
 
 	// save-to path
 	summaryPath := filepath.Join(filepath.Dir(rawPath), "summary.json")

--- a/internal/session/summarize_test.go
+++ b/internal/session/summarize_test.go
@@ -136,6 +136,145 @@ func TestLocalSummary_SkillInvocations(t *testing.T) {
 	}
 }
 
+func TestFilterForSummarization(t *testing.T) {
+	tests := []struct {
+		name       string
+		entries    []Entry
+		wantCount  int
+		wantTypes  []EntryType // expected types of remaining entries
+		wantTools  []string    // expected tool names of remaining tool entries
+	}{
+		{
+			name:      "empty entries",
+			entries:   nil,
+			wantCount: 0,
+		},
+		{
+			name: "keeps user and assistant messages",
+			entries: []Entry{
+				{Type: EntryTypeUser, Content: "Fix the bug"},
+				{Type: EntryTypeAssistant, Content: "I'll fix it"},
+			},
+			wantCount: 2,
+			wantTypes: []EntryType{EntryTypeUser, EntryTypeAssistant},
+		},
+		{
+			name: "filters successful read-only tools",
+			entries: []Entry{
+				{Type: EntryTypeUser, Content: "Fix the bug"},
+				{Type: EntryTypeTool, ToolName: "Read", ToolInput: "/path/to/file.go", ToolOutput: "file contents here"},
+				{Type: EntryTypeTool, ToolName: "Glob", ToolInput: "**/*.go", ToolOutput: "main.go\nutil.go"},
+				{Type: EntryTypeTool, ToolName: "Grep", ToolInput: "pattern", ToolOutput: "match found"},
+				{Type: EntryTypeAssistant, Content: "Found the issue"},
+			},
+			wantCount: 2,
+			wantTypes: []EntryType{EntryTypeUser, EntryTypeAssistant},
+		},
+		{
+			name: "keeps write and edit tools",
+			entries: []Entry{
+				{Type: EntryTypeTool, ToolName: "Write", ToolInput: "/path/to/file.go", Content: "new content"},
+				{Type: EntryTypeTool, ToolName: "Edit", ToolInput: "/path/to/file.go", Content: "edited"},
+			},
+			wantCount: 2,
+			wantTools: []string{"Write", "Edit"},
+		},
+		{
+			name: "keeps failed read tools",
+			entries: []Entry{
+				{Type: EntryTypeTool, ToolName: "Read", ToolInput: "/nonexistent", ToolOutput: "Error: file not found"},
+				{Type: EntryTypeTool, ToolName: "Grep", ToolInput: "pattern", ToolOutput: "fatal: not a git repo"},
+			},
+			wantCount: 2,
+			wantTools: []string{"Read", "Grep"},
+		},
+		{
+			name: "filters noise bash commands",
+			entries: []Entry{
+				{Type: EntryTypeTool, ToolName: "Bash", ToolInput: "ls -la", ToolOutput: "file1 file2"},
+				{Type: EntryTypeTool, ToolName: "Bash", ToolInput: "pwd", ToolOutput: "/home/user"},
+				{Type: EntryTypeTool, ToolName: "Bash", ToolInput: "cat README.md", ToolOutput: "readme content"},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "keeps meaningful bash commands",
+			entries: []Entry{
+				{Type: EntryTypeTool, ToolName: "Bash", ToolInput: "make test", ToolOutput: "PASS"},
+				{Type: EntryTypeTool, ToolName: "Bash", ToolInput: "git commit -m 'fix'", ToolOutput: "committed"},
+				{Type: EntryTypeTool, ToolName: "Bash", ToolInput: "npm install", ToolOutput: "added 5 packages"},
+			},
+			wantCount: 3,
+			wantTools: []string{"Bash", "Bash", "Bash"},
+		},
+		{
+			name: "keeps system entries",
+			entries: []Entry{
+				{Type: EntryTypeSystem, Content: "Session started"},
+			},
+			wantCount: 1,
+			wantTypes: []EntryType{EntryTypeSystem},
+		},
+		{
+			name: "realistic session with mixed entries",
+			entries: []Entry{
+				{Type: EntryTypeUser, Content: "Add authentication to the API"},
+				{Type: EntryTypeTool, ToolName: "Read", ToolInput: "main.go", ToolOutput: "package main"},
+				{Type: EntryTypeTool, ToolName: "Glob", ToolInput: "**/*.go", ToolOutput: "main.go"},
+				{Type: EntryTypeTool, ToolName: "Grep", ToolInput: "auth", ToolOutput: "no matches"},
+				{Type: EntryTypeTool, ToolName: "Bash", ToolInput: "ls src/", ToolOutput: "api/ models/"},
+				{Type: EntryTypeAssistant, Content: "I'll add JWT auth middleware"},
+				{Type: EntryTypeTool, ToolName: "Write", ToolInput: "auth.go", Content: "package auth"},
+				{Type: EntryTypeTool, ToolName: "Edit", ToolInput: "main.go", Content: "import auth"},
+				{Type: EntryTypeTool, ToolName: "Bash", ToolInput: "go test ./...", ToolOutput: "PASS"},
+				{Type: EntryTypeAssistant, Content: "Authentication added and tests pass"},
+			},
+			wantCount: 6, // user + 2 assistant + write + edit + go test
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterForSummarization(tt.entries)
+			assert.Len(t, result, tt.wantCount)
+
+			if tt.wantTypes != nil {
+				for i, wantType := range tt.wantTypes {
+					if i < len(result) {
+						assert.Equal(t, wantType, result[i].Type, "entry %d type", i)
+					}
+				}
+			}
+
+			if tt.wantTools != nil {
+				var gotTools []string
+				for _, e := range result {
+					if e.Type == EntryTypeTool {
+						gotTools = append(gotTools, e.ToolName)
+					}
+				}
+				assert.Equal(t, tt.wantTools, gotTools)
+			}
+		})
+	}
+}
+
+func TestFilterForSummarization_PreservesOrder(t *testing.T) {
+	entries := []Entry{
+		{Type: EntryTypeUser, Content: "first"},
+		{Type: EntryTypeTool, ToolName: "Read", ToolOutput: "contents"},
+		{Type: EntryTypeAssistant, Content: "second"},
+		{Type: EntryTypeTool, ToolName: "Write", Content: "new file"},
+		{Type: EntryTypeUser, Content: "third"},
+	}
+	result := FilterForSummarization(entries)
+	assert.Len(t, result, 4)
+	assert.Equal(t, "first", result[0].Content)
+	assert.Equal(t, "second", result[1].Content)
+	assert.Equal(t, "Write", result[2].ToolName)
+	assert.Equal(t, "third", result[3].Content)
+}
+
 func TestIsSkillInvocation(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -11,6 +11,7 @@ package testguard
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -60,7 +61,8 @@ func RunOx(t *testing.T, oxBin, dir string, envVars []string, args ...string) (s
 
 	exitCode := 0
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitCode()
 		} else {
 			t.Logf("warning: command error (not exit code): %v", err)

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -22,6 +22,8 @@ func TestString_WithoutAgentType(t *testing.T) {
 
 func TestString_WithAgentType(t *testing.T) {
 	ResetForTesting()
+	t.Setenv("AGENT_ENV", "")
+	t.Setenv("AGENT_VERSION", "")
 	SetAgentType("claude-code")
 
 	ua := String()


### PR DESCRIPTION
## Summary

Closes #47, #39, #26, #2. Addresses three issues and fixes two pre-existing test/lint failures:

**#47 & #39**: Already fixed by PR #49 and #40 (closed with comments linking them)

**#26 - Session output noise**: Added `FilterForSummarization()` to strip read-only tools (Read, Glob, Grep, WebFetch, WebSearch) and noise bash commands from session input before sending to LLM summarizer. Keeps raw.jsonl complete for auditability. Applied in both API summarization path and resummary CLI command.

**#2 - Write access check**: Added `checkUploadAccess()` call in `runAgentSessionStart()` to fail fast when read-only viewers try to record sessions, instead of recording a full session and failing at upload time.

**Test fixes**: Fixed `TestString_WithAgentType` env var leakage (local Claude Code 2.1.50 was leaking AGENT_VERSION). Fixed testguard lint: replaced type assertion with `errors.As()`.

## Test Plan

- [x] Unit tests: 4996 pass, 0 failures
- [x] Lint: 0 issues (fixed all)
- [x] Session filtering tested: 11 test cases covering read-only tools, failed tools, noise bash, meaningful bash, system entries, and mixed realistic sessions
- [x] All session-related tests pass

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pre-flight access validation before session recording to prevent errors when operating in read-only environments, with clear and helpful error messaging

* **Bug Fixes**
  * Reduced noise in session resummaries and summarization by intelligently filtering out non-actionable read-only operations and unnecessary commands for improved focus and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->