### PR TITLE
fix: register --force flag on agentCmd for cobra parsing

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -93,6 +93,11 @@ func init() {
 	agentCmd.PersistentFlags().Bool("text", false,
 		"human-readable text output (overrides JSON default)")
 
+	// force flag - skip confirmation for destructive operations (e.g., session abort)
+	agentCmd.PersistentFlags().Bool("force", false,
+		"skip confirmation for destructive operations")
+	_ = agentCmd.PersistentFlags().MarkHidden("force")
+
 	// initialize prime command flags
 	initAgentPrimeCmd()
 
@@ -207,7 +212,7 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 		case "recover":
 			return runAgentSessionRecover(inst)
 		case "abort":
-			return runAgentSessionAbort(inst, sessionArgs)
+			return runAgentSessionAbort(inst, cmd)
 		default:
 			return fmt.Errorf("unknown session command: %s\nAvailable: start, stop, abort, remind, summarize, html, record, plan, import, capture-prior, subagent-complete, subagent-list, recover", sessionCmd)
 		}

--- a/cmd/ox/agent_session_abort.go
+++ b/cmd/ox/agent_session_abort.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sageox/ox/internal/agentinstance"
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/session"
+	"github.com/spf13/cobra"
 )
 
 // sessionAbortOutput is the JSON output format for session abort.
@@ -27,7 +28,7 @@ type sessionAbortOutput struct {
 //   - Non-interactive (agent/pipe): requires --force flag
 //
 // Usage: ox agent <id> session abort [--force]
-func runAgentSessionAbort(inst *agentinstance.Instance, args []string) error {
+func runAgentSessionAbort(inst *agentinstance.Instance, cmd *cobra.Command) error {
 	projectRoot, err := findProjectRoot()
 	if err != nil {
 		return fmt.Errorf("could not find project root: %w", err)
@@ -42,7 +43,8 @@ func runAgentSessionAbort(inst *agentinstance.Instance, args []string) error {
 	}
 
 	// confirmation: interactive terminal prompts, non-interactive requires --force
-	if !hasFlag(args, "--force") {
+	forceFlag := cmd.Flag("force") != nil && cmd.Flag("force").Value.String() == "true"
+	if !forceFlag {
 		if cli.IsInteractive() {
 			if !cli.ConfirmYesNo("Abort and discard active session? This cannot be undone", false) {
 				fmt.Println("Canceled.")
@@ -96,12 +98,3 @@ func runAgentSessionAbort(inst *agentinstance.Instance, args []string) error {
 	return nil
 }
 
-// hasFlag checks if a flag is present in args.
-func hasFlag(args []string, flag string) bool {
-	for _, arg := range args {
-		if arg == flag {
-			return true
-		}
-	}
-	return false
-}

--- a/cmd/ox/agent_session_abort_test.go
+++ b/cmd/ox/agent_session_abort_test.go
@@ -40,6 +40,13 @@ func setupAbortTest(t *testing.T) (string, *session.RecordingState) {
 	return projectRoot, state
 }
 
+// setForceFlag sets the --force flag on agentCmd for testing and resets it on cleanup.
+func setForceFlag(t *testing.T, value bool) {
+	t.Helper()
+	require.NoError(t, agentCmd.PersistentFlags().Set("force", fmt.Sprintf("%t", value)))
+	t.Cleanup(func() { _ = agentCmd.PersistentFlags().Set("force", "false") })
+}
+
 func TestAbortNotRecording(t *testing.T) {
 	cfg = &config.Config{}
 	projectRoot := setupSessionTestProject(t)
@@ -48,8 +55,10 @@ func TestAbortNotRecording(t *testing.T) {
 	require.NoError(t, os.Chdir(projectRoot))
 	defer os.Chdir(origDir)
 
+	setForceFlag(t, true)
+
 	inst := &agentinstance.Instance{AgentID: "OxTest"}
-	err := runAgentSessionAbort(inst, []string{"--force"})
+	err := runAgentSessionAbort(inst, agentCmd)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no active session")
 }
@@ -59,8 +68,10 @@ func TestAbortClearsRecordingState(t *testing.T) {
 
 	require.True(t, session.IsRecording(projectRoot))
 
+	setForceFlag(t, true)
+
 	inst := &agentinstance.Instance{AgentID: "OxAbrt"}
-	err := runAgentSessionAbort(inst, []string{"--force"})
+	err := runAgentSessionAbort(inst, agentCmd)
 	require.NoError(t, err)
 
 	// if .recording.json survives, next session start fails with "already recording"
@@ -73,8 +84,10 @@ func TestAbortRemovesSessionFolder(t *testing.T) {
 	_, err := os.Stat(state.SessionPath)
 	require.NoError(t, err)
 
+	setForceFlag(t, true)
+
 	inst := &agentinstance.Instance{AgentID: "OxAbrt"}
-	err = runAgentSessionAbort(inst, []string{"--force"})
+	err = runAgentSessionAbort(inst, agentCmd)
 	require.NoError(t, err)
 
 	// entire folder must be gone so doctor doesn't detect orphaned data
@@ -91,8 +104,10 @@ func TestAbortEmptySessionPathDoesNotDeleteCwd(t *testing.T) {
 	recordingPath := filepath.Join(state.SessionPath, ".recording.json")
 	require.NoError(t, os.WriteFile(recordingPath, []byte(corruptState), 0644))
 
+	setForceFlag(t, true)
+
 	inst := &agentinstance.Instance{AgentID: "OxAbrt"}
-	err := runAgentSessionAbort(inst, []string{"--force"})
+	err := runAgentSessionAbort(inst, agentCmd)
 	// abort may succeed or error — either is fine, but cwd must survive
 	_ = err
 
@@ -108,8 +123,30 @@ func TestAbortRequiresForce(t *testing.T) {
 	cli.SetNoInteractive(true)
 	t.Cleanup(func() { cli.SetNoInteractive(false) })
 
+	// --force defaults to false, so no need to set it
 	inst := &agentinstance.Instance{AgentID: "OxAbrt"}
-	err := runAgentSessionAbort(inst, nil)
+	err := runAgentSessionAbort(inst, agentCmd)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "destructive")
+}
+
+// TestAbortForceViaCobraFlag is a regression test for the bug where --force
+// was rejected by cobra before reaching the abort handler. The flag must be
+// registered on agentCmd and readable via cobra's flag API.
+func TestAbortForceViaCobraFlag(t *testing.T) {
+	projectRoot, _ := setupAbortTest(t)
+
+	cli.SetNoInteractive(true)
+	t.Cleanup(func() { cli.SetNoInteractive(false) })
+
+	require.True(t, session.IsRecording(projectRoot))
+
+	// set --force via cobra flag (simulates what cobra does when parsing CLI args)
+	setForceFlag(t, true)
+
+	inst := &agentinstance.Instance{AgentID: "OxAbrt"}
+	err := runAgentSessionAbort(inst, agentCmd)
+	require.NoError(t, err, "--force via cobra flag should skip confirmation")
+
+	assert.False(t, session.IsRecording(projectRoot), "session should be aborted")
 }


### PR DESCRIPTION
## Summary

Fixed `ox agent <id> session abort --force` failing with "unknown flag" error. Cobra was intercepting the flag before the abort handler could read it via custom `hasFlag()`.

## Changes

- Register `--force` as a persistent flag on `agentCmd` so cobra recognizes it
- Update abort handler to read flag via `cmd.Flag()` instead of custom `hasFlag()`
- Remove unused `hasFlag()` helper
- Add regression test (`TestAbortForceViaCobraFlag`) ensuring flag works through cobra's API in non-interactive mode

## Friction Telemetry

No impact — other unknown flags still trigger `FailureUnknownFlag` friction events for agent learning.

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--force` flag to the agent session abort command, enabling non-interactive destructive operations without confirmation prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->