### PR TITLE
refactor: compact session HTML tool calls, remove noise

### DIFF
--- a/cmd/ox/session_html.go
+++ b/cmd/ox/session_html.go
@@ -132,11 +132,6 @@ func buildTemplateData(t *session.StoredSession, summary *session.SummarizeRespo
 			if parsed, err := time.Parse(time.RFC3339Nano, closedAt); err == nil {
 				if data.Metadata != nil {
 					data.Metadata.EndedAt = parsed
-					// calculate duration if we have start time
-					if t.Meta != nil && !t.Meta.CreatedAt.IsZero() {
-						duration := parsed.Sub(t.Meta.CreatedAt)
-						data.Metadata.Duration = sessionhtml.FormatDuration(duration)
-					}
 				}
 			}
 		}
@@ -155,7 +150,7 @@ func buildTemplateData(t *session.StoredSession, summary *session.SummarizeRespo
 	}
 
 	// build messages from entries
-	var userMessages, toolCalls int
+	var userMessages int
 	for i, entry := range t.Entries {
 		msg := buildMessageView(i+1, entry, userLabel, agentLabel)
 
@@ -168,26 +163,8 @@ func buildTemplateData(t *session.StoredSession, summary *session.SummarizeRespo
 
 		data.Messages = append(data.Messages, msg)
 
-		// count for statistics
-		switch msg.Type {
-		case "user":
+		if msg.Type == "user" {
 			userMessages++
-		case "tool":
-			toolCalls++
-		}
-	}
-
-	// fallback: compute duration from entry timestamps when meta times are missing
-	if data.Metadata != nil && data.Metadata.Duration == "" && len(data.Messages) > 0 {
-		dur, first, last := sessionhtml.ComputeFallbackDuration(data.Messages)
-		if dur > 0 {
-			data.Metadata.Duration = sessionhtml.FormatDuration(dur)
-			if data.Metadata.StartedAt.IsZero() {
-				data.Metadata.StartedAt = first
-			}
-			if data.Metadata.EndedAt.IsZero() {
-				data.Metadata.EndedAt = last
-			}
 		}
 	}
 
@@ -195,10 +172,6 @@ func buildTemplateData(t *session.StoredSession, summary *session.SummarizeRespo
 	data.Statistics = &sessionhtml.StatsView{
 		TotalMessages: len(t.Entries),
 		UserMessages:  userMessages,
-		ToolCalls:     toolCalls,
-	}
-	if data.Metadata != nil && data.Metadata.Duration != "" {
-		data.Statistics.Duration = data.Metadata.Duration
 	}
 
 	return data
@@ -850,7 +823,6 @@ const htmlTemplate = `<!DOCTYPE html>
                     {{if .Metadata.Username}}<div class="meta-item"><span class="meta-label">User:</span> <span class="meta-value">{{.Metadata.Username}}</span></div>{{end}}
                     {{if not .Metadata.StartedAt.IsZero}}<div class="meta-item"><span class="meta-label">Started:</span> <time class="meta-value">{{.Metadata.StartedAt.Format "2006-01-02 15:04:05"}}</time></div>{{end}}
                     {{if not .Metadata.EndedAt.IsZero}}<div class="meta-item"><span class="meta-label">Ended:</span> <time class="meta-value">{{.Metadata.EndedAt.Format "2006-01-02 15:04:05"}}</time></div>{{end}}
-                    {{if .Metadata.Duration}}<div class="meta-item"><span class="meta-label">Duration:</span> <span class="meta-value">{{.Metadata.Duration}}</span></div>{{end}}
                 </div>
                 {{end}}
             </div>
@@ -865,16 +837,6 @@ const htmlTemplate = `<!DOCTYPE html>
                 <span class="stat-value">{{.Statistics.UserMessages}}</span>
                 <span class="stat-label">User Messages</span>
             </div>
-            <div class="stat-item">
-                <span class="stat-value">{{.Statistics.ToolCalls}}</span>
-                <span class="stat-label">Tool Calls</span>
-            </div>
-            {{if .Statistics.Duration}}
-            <div class="stat-item">
-                <span class="stat-value">{{.Statistics.Duration}}</span>
-                <span class="stat-label">Session Duration</span>
-            </div>
-            {{end}}
         </div>
         {{end}}
     </header>

--- a/cmd/ox/session_html_test.go
+++ b/cmd/ox/session_html_test.go
@@ -74,7 +74,7 @@ func TestBuildTemplateData_WithMetadata(t *testing.T) {
 	assert.Equal(t, "claude-code", data.Metadata.AgentType)
 	assert.Equal(t, "claude-sonnet-4", data.Metadata.Model)
 	assert.Equal(t, "testuser", data.Metadata.Username)
-	assert.Equal(t, "30m", data.Metadata.Duration)
+	// duration was removed from MetadataView
 }
 
 func TestBuildTemplateData_WithToolCalls(t *testing.T) {
@@ -115,7 +115,7 @@ func TestBuildTemplateData_WithToolCalls(t *testing.T) {
 	assert.Equal(t, "Read", data.Messages[1].ToolCall.Name)
 	assert.Equal(t, "file contents here", data.Messages[1].ToolCall.Output)
 
-	assert.Equal(t, 2, data.Statistics.ToolCalls)
+	// ToolCalls was removed from StatsView
 }
 
 func TestGenerateHTML_CreatesFile(t *testing.T) {
@@ -323,13 +323,13 @@ func TestBuildTemplateData_FallbackDuration(t *testing.T) {
 	data := buildTemplateData(st, nil)
 
 	require.NotNil(t, data.Metadata)
-	assert.Equal(t, "5m 30s", data.Metadata.Duration, "should compute duration from entry timestamps")
-	assert.False(t, data.Metadata.StartedAt.IsZero(), "should backfill StartedAt from first entry")
-	assert.False(t, data.Metadata.EndedAt.IsZero(), "should backfill EndedAt from last entry")
+	// duration was removed from MetadataView; with zero CreatedAt and no footer,
+	// StartedAt/EndedAt remain zero (no entry-based backfill without Duration)
+	assert.True(t, data.Metadata.StartedAt.IsZero(), "StartedAt should be zero when CreatedAt is zero")
 }
 
 func TestBuildTemplateData_MetaDurationTakesPrecedence(t *testing.T) {
-	// session where meta duration is already computed — fallback should NOT override
+	// session where meta CreatedAt + footer closed_at are set
 	createdAt := time.Date(2026, 1, 14, 10, 0, 0, 0, time.UTC)
 	st := &session.StoredSession{
 		Info: session.SessionInfo{Filename: "test.jsonl"},
@@ -344,13 +344,15 @@ func TestBuildTemplateData_MetaDurationTakesPrecedence(t *testing.T) {
 			{
 				"type":      "user",
 				"content":   "Hello",
-				"timestamp": "2026-01-14T10:05:00Z", // first entry is 5min after start
+				"timestamp": "2026-01-14T10:05:00Z",
 			},
 		},
 	}
 
 	data := buildTemplateData(st, nil)
-	assert.Equal(t, "30m", data.Metadata.Duration, "meta duration should take precedence over entry fallback")
+	// duration was removed from MetadataView; verify StartedAt uses meta.CreatedAt
+	require.NotNil(t, data.Metadata)
+	assert.Equal(t, createdAt, data.Metadata.StartedAt, "StartedAt should use meta.CreatedAt")
 }
 
 func TestBuildMessageView_SkillExpansionCollapsed(t *testing.T) {

--- a/cmd/ox/session_regression_test.go
+++ b/cmd/ox/session_regression_test.go
@@ -167,8 +167,10 @@ func TestRegression_Path2_StandardSession_Duration(t *testing.T) {
 	sess := buildRegressionStandardSession()
 	data := buildTemplateData(sess, nil)
 
+	// duration was removed from MetadataView; verify times are still populated
 	require.NotNil(t, data.Metadata)
-	assert.Equal(t, "30m", data.Metadata.Duration, "duration should be 30m (14:00 to 14:30)")
+	assert.False(t, data.Metadata.StartedAt.IsZero(), "StartedAt should be set")
+	assert.False(t, data.Metadata.EndedAt.IsZero(), "EndedAt should be set")
 }
 
 func TestRegression_Path2_GenerateHTML_CreatesFile(t *testing.T) {
@@ -339,8 +341,10 @@ func TestRegression_Path3_Duration(t *testing.T) {
 	sess := buildRegressionImportedSession()
 	data := viewHTMLBuildTemplateData(sess)
 
+	// duration was removed from MetadataView; verify times are still populated
 	require.NotNil(t, data.Metadata)
-	assert.Equal(t, "30m", data.Metadata.Duration, "Path 3 duration should be 30m")
+	assert.False(t, data.Metadata.StartedAt.IsZero(), "StartedAt should be set")
+	assert.False(t, data.Metadata.EndedAt.IsZero(), "EndedAt should be set")
 }
 
 // ============================================================

--- a/cmd/ox/session_view_html.go
+++ b/cmd/ox/session_view_html.go
@@ -190,11 +190,6 @@ func viewHTMLBuildTemplateData(t *session.StoredSession) *sessionhtml.TemplateDa
 			if parsed, err := time.Parse(time.RFC3339Nano, closedAt); err == nil {
 				if data.Metadata != nil {
 					data.Metadata.EndedAt = parsed
-					// calculate duration if we have start time
-					if t.Meta != nil && !t.Meta.CreatedAt.IsZero() {
-						duration := parsed.Sub(t.Meta.CreatedAt)
-						data.Metadata.Duration = sessionhtml.FormatDuration(duration)
-					}
 				}
 			}
 		}
@@ -213,31 +208,13 @@ func viewHTMLBuildTemplateData(t *session.StoredSession) *sessionhtml.TemplateDa
 	}
 
 	// build messages from entries
-	var userMessages, toolCalls int
+	var userMessages int
 	for i, entry := range t.Entries {
 		msg := viewHTMLBuildMessageView(i+1, entry, userLabel, agentLabel)
 		data.Messages = append(data.Messages, msg)
 
-		// count for statistics
-		switch msg.Type {
-		case "user":
+		if msg.Type == "user" {
 			userMessages++
-		case "tool":
-			toolCalls++
-		}
-	}
-
-	// fallback: compute duration from entry timestamps when meta times are missing
-	if data.Metadata != nil && data.Metadata.Duration == "" && len(data.Messages) > 0 {
-		dur, first, last := sessionhtml.ComputeFallbackDuration(data.Messages)
-		if dur > 0 {
-			data.Metadata.Duration = sessionhtml.FormatDuration(dur)
-			if data.Metadata.StartedAt.IsZero() {
-				data.Metadata.StartedAt = first
-			}
-			if data.Metadata.EndedAt.IsZero() {
-				data.Metadata.EndedAt = last
-			}
 		}
 	}
 
@@ -245,10 +222,6 @@ func viewHTMLBuildTemplateData(t *session.StoredSession) *sessionhtml.TemplateDa
 	data.Statistics = &sessionhtml.StatsView{
 		TotalMessages: len(t.Entries),
 		UserMessages:  userMessages,
-		ToolCalls:     toolCalls,
-	}
-	if data.Metadata != nil && data.Metadata.Duration != "" {
-		data.Statistics.Duration = data.Metadata.Duration
 	}
 
 	return data
@@ -941,7 +914,6 @@ const viewHTMLTemplate = `<!DOCTYPE html>
                     {{if .Metadata.Username}}<div class="meta-item"><span class="meta-label">User:</span> <span class="meta-value">{{.Metadata.Username}}</span></div>{{end}}
                     {{if not .Metadata.StartedAt.IsZero}}<div class="meta-item"><span class="meta-label">Started:</span> <time class="meta-value">{{.Metadata.StartedAt.Format "2006-01-02 15:04:05"}}</time></div>{{end}}
                     {{if not .Metadata.EndedAt.IsZero}}<div class="meta-item"><span class="meta-label">Ended:</span> <time class="meta-value">{{.Metadata.EndedAt.Format "2006-01-02 15:04:05"}}</time></div>{{end}}
-                    {{if .Metadata.Duration}}<div class="meta-item"><span class="meta-label">Duration:</span> <span class="meta-value">{{.Metadata.Duration}}</span></div>{{end}}
                 </div>
                 {{end}}
             </div>
@@ -956,16 +928,6 @@ const viewHTMLTemplate = `<!DOCTYPE html>
                 <span class="stat-value">{{.Statistics.UserMessages}}</span>
                 <span class="stat-label">User Messages</span>
             </div>
-            <div class="stat-item">
-                <span class="stat-value">{{.Statistics.ToolCalls}}</span>
-                <span class="stat-label">Tool Calls</span>
-            </div>
-            {{if .Statistics.Duration}}
-            <div class="stat-item">
-                <span class="stat-value">{{.Statistics.Duration}}</span>
-                <span class="stat-label">Session Duration</span>
-            </div>
-            {{end}}
         </div>
         {{end}}
     </header>

--- a/internal/session/html/assets/styles.css
+++ b/internal/session/html/assets/styles.css
@@ -326,52 +326,182 @@ body.embed .messages-container { padding-top: var(--spacing-md); }
   color: var(--color-secondary);
 }
 
-/* Tool Details */
+/* ============================================================
+   Tool Calls — terminal transcript aesthetic
+
+   Design: tool calls are "stage directions" in a conversation.
+   They should be legible when looked at, invisible when not.
+   A left border "rail" groups consecutive calls visually.
+   ============================================================ */
+
+/* Shared base: left gutter rail groups tool calls */
+.tool-inline,
 .tool-details {
-  margin-top: var(--spacing-lg);
-  background-color: var(--color-bg);
-  border-radius: var(--border-radius);
+  margin: 2px 0;
+  border-left: 2px solid rgba(122, 143, 120, 0.25);
+  padding-left: 10px;
+  margin-left: 4px;
+}
+
+/* Consecutive tool calls collapse into a tight block */
+.tool-inline + .tool-inline,
+.tool-inline + .tool-details,
+.tool-details + .tool-inline,
+.tool-details + .tool-details {
+  margin-top: 0;
+}
+
+/* The command line: bare monospace, no background pill */
+.tool-cmd {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  letter-spacing: -0.01em;
+  color: var(--color-text-dim);
+  background: none;
+  padding: 0.15em 0;
+  border: none;
+  border-radius: 0;
+  display: inline;
+}
+
+/* Prompt glyph: structural marker, not a highlight */
+.tool-prompt {
+  color: rgba(122, 143, 120, 0.5);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  display: inline-block;
+  width: 1.8em;
+  text-align: right;
+  margin-right: 6px;
+  user-select: none;
+}
+
+/* Tool name: the ONE scanning token per line */
+.tool-name-label {
+  color: var(--color-accent);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  display: inline-block;
+  min-width: 3.5em;
+}
+
+/* Tool arguments: secondary context, truncate gracefully */
+.tool-args {
+  max-width: 60ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+/* Per-tool color accents for fast visual scanning */
+.tool-cmd[data-tool="Bash"] .tool-name-label { color: #E0A56A; }
+.tool-cmd[data-tool="Write"] .tool-name-label,
+.tool-cmd[data-tool="Edit"] .tool-name-label,
+.tool-cmd[data-tool="MultiEdit"] .tool-name-label { color: #C4A882; }
+.tool-cmd[data-tool="Grep"] .tool-name-label,
+.tool-cmd[data-tool="Glob"] .tool-name-label { color: #7FA7C8; }
+
+/* Collapsible tool details */
+.tool-details {
+  background-color: transparent;
+  border-radius: 0;
   overflow: hidden;
 }
 
 .tool-details summary {
-  padding: var(--spacing-md);
+  padding: 1px 0;
   cursor: pointer;
   user-select: none;
-  font-weight: 600;
-  color: var(--color-info);
-  background-color: rgba(127, 167, 200, 0.1);
-  transition: background-color 0.2s ease;
+  list-style: none;
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: 0;
+  line-height: 1.6;
+  border-radius: 3px;
+  transition: background-color 0.12s ease;
 }
 
-.tool-details summary:hover {
-  background-color: rgba(127, 167, 200, 0.2);
+.tool-details summary::-webkit-details-marker { display: none; }
+
+/* Expansion hint: subtle ellipsis after the command */
+.tool-details summary::after {
+  content: '\2026';
+  color: rgba(126, 135, 132, 0.4);
+  font-size: 0.7rem;
+  margin-left: 6px;
+  letter-spacing: 0.1em;
+  transition: opacity 0.12s ease;
 }
 
-.tool-details summary::marker {
-  color: var(--color-info);
+.tool-details[open] summary::after { content: ''; }
+
+/* Hover: only brighten the ellipsis hint */
+.tool-details summary:hover::after {
+  color: rgba(126, 135, 132, 0.7);
 }
 
 .tool-details[open] summary {
-  border-bottom: 1px solid rgba(127, 167, 200, 0.2);
+  border-bottom: 1px solid rgba(127, 167, 200, 0.08);
 }
 
-.tool-input,
+/* Tool output: indented, contained */
+.tool-io {
+  margin-left: 28px;
+  padding: 6px 0 6px 10px;
+  border-left: 1px solid rgba(122, 143, 120, 0.15);
+}
+
 .tool-output {
-  padding: var(--spacing-md);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  color: #6B7370;
+  max-height: 300px;
+  overflow-y: auto;
+  overflow-x: auto;
+  margin: 0;
+  padding: 0;
+  background: none;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
-.tool-section-title {
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-text-dim);
-  margin-bottom: var(--spacing-sm);
+.tool-output::-webkit-scrollbar { width: 4px; height: 4px; }
+.tool-output::-webkit-scrollbar-track { background: transparent; }
+.tool-output::-webkit-scrollbar-thumb { background: rgba(122, 143, 120, 0.2); border-radius: 2px; }
+
+/* Light theme overrides */
+@media (prefers-color-scheme: light) {
+  .tool-inline, .tool-details { border-left-color: rgba(90, 110, 88, 0.2); }
+  .tool-prompt { color: rgba(90, 110, 88, 0.4); }
+  .tool-name-label { color: #5A7A55; }
+  .tool-cmd { color: #8A928E; }
+  .tool-cmd[data-tool="Bash"] .tool-name-label { color: #B8824A; }
+  .tool-cmd[data-tool="Write"] .tool-name-label,
+  .tool-cmd[data-tool="Edit"] .tool-name-label,
+  .tool-cmd[data-tool="MultiEdit"] .tool-name-label { color: #9A7A52; }
+  .tool-cmd[data-tool="Grep"] .tool-name-label,
+  .tool-cmd[data-tool="Glob"] .tool-name-label { color: #4A7A9C; }
+  .tool-io { border-left-color: rgba(90, 110, 88, 0.12); }
+  .tool-output { color: #9AA09D; }
+  .tool-output::-webkit-scrollbar-thumb { background: rgba(90, 110, 88, 0.15); }
 }
+
+body.light-theme .tool-inline, body.light-theme .tool-details { border-left-color: rgba(90, 110, 88, 0.2); }
+body.light-theme .tool-prompt { color: rgba(90, 110, 88, 0.4); }
+body.light-theme .tool-name-label { color: #5A7A55; }
+body.light-theme .tool-cmd { color: #8A928E; }
+body.light-theme .tool-cmd[data-tool="Bash"] .tool-name-label { color: #B8824A; }
+body.light-theme .tool-cmd[data-tool="Write"] .tool-name-label,
+body.light-theme .tool-cmd[data-tool="Edit"] .tool-name-label,
+body.light-theme .tool-cmd[data-tool="MultiEdit"] .tool-name-label { color: #9A7A52; }
+body.light-theme .tool-cmd[data-tool="Grep"] .tool-name-label,
+body.light-theme .tool-cmd[data-tool="Glob"] .tool-name-label { color: #4A7A9C; }
+body.light-theme .tool-io { border-left-color: rgba(90, 110, 88, 0.12); }
+body.light-theme .tool-output { color: #9AA09D; }
 
 /* Code Blocks */
 pre {
@@ -617,20 +747,6 @@ body.light-theme .tool-output .diff-header { color: #3a6a94; font-weight: 600; }
   font-size: var(--font-size-sm);
   font-weight: 500;
   border: 1px solid var(--color-accent);
-}
-
-/* Tool Icon */
-.tool-icon {
-  width: 16px;
-  height: 16px;
-  max-width: 16px;
-  max-height: 16px;
-  flex-shrink: 0;
-  transition: transform 0.2s ease;
-}
-
-details[open] .tool-icon {
-  transform: rotate(90deg);
 }
 
 /* Footer */

--- a/internal/session/html/assets/template.html
+++ b/internal/session/html/assets/template.html
@@ -33,7 +33,6 @@
                     {{if .Metadata.Username}}<div class="meta-item"><span class="meta-label">User:</span> <span class="meta-value">{{.Metadata.Username}}</span></div>{{end}}
                     {{if .Metadata.StartedAt}}<div class="meta-item"><span class="meta-label">Started:</span> <time class="meta-value">{{.Metadata.StartedAt.Format "2006-01-02 15:04:05"}}</time></div>{{end}}
                     {{if .Metadata.EndedAt}}<div class="meta-item"><span class="meta-label">Ended:</span> <time class="meta-value">{{.Metadata.EndedAt.Format "2006-01-02 15:04:05"}}</time></div>{{end}}
-                    {{if .Metadata.Duration}}<div class="meta-item"><span class="meta-label">Duration:</span> <span class="meta-value">{{.Metadata.Duration}}</span></div>{{end}}
                 </div>
             </div>
         </div>
@@ -47,16 +46,6 @@
                 <span class="stat-value">{{.Statistics.UserMessages}}</span>
                 <span class="stat-label">User Messages</span>
             </div>
-            <div class="stat-item">
-                <span class="stat-value">{{.Statistics.ToolCalls}}</span>
-                <span class="stat-label">Tool Calls</span>
-            </div>
-            {{if .Statistics.Duration}}
-            <div class="stat-item">
-                <span class="stat-value">{{.Statistics.Duration}}</span>
-                <span class="stat-label">Session Duration</span>
-            </div>
-            {{end}}
         </div>
         {{end}}
     </header>
@@ -100,28 +89,18 @@
             </div>
             <div class="message-content">{{.Content}}</div>
             {{if .ToolCall}}
+            {{if .ToolCall.IsSimple}}
+            <div class="tool-inline"><code class="tool-cmd" data-tool="{{.ToolCall.Name}}">{{.ToolCall.FormattedInput}}</code></div>
+            {{else}}
             <details class="tool-details">
-                <summary class="tool-summary">
-                    <svg class="tool-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M13 3L8 8L13 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                    <span class="tool-name">{{if .ToolCall.Summary}}{{.ToolCall.Summary}}{{else}}{{.ToolCall.Name}}{{end}}</span>
-                </summary>
+                <summary class="tool-summary"><code class="tool-cmd" data-tool="{{.ToolCall.Name}}">{{.ToolCall.FormattedInput}}</code></summary>
                 <div class="tool-io">
-                    {{if .ToolCall.Input}}
-                    <div class="tool-section">
-                        <h4 class="tool-section-title">Input</h4>
-                        <pre class="tool-input">{{.ToolCall.Input}}</pre>
-                    </div>
-                    {{end}}
                     {{if .ToolCall.Output}}
-                    <div class="tool-section">
-                        <h4 class="tool-section-title">Output</h4>
-                        <pre class="tool-output">{{.ToolCall.Output}}</pre>
-                    </div>
+                    <pre class="tool-output">{{.ToolCall.Output}}</pre>
                     {{end}}
                 </div>
             </details>
+            {{end}}
             {{end}}
         </article>
         {{end}}

--- a/internal/session/html/generator.go
+++ b/internal/session/html/generator.go
@@ -154,7 +154,7 @@ func convertToTemplateData(t *session.StoredSession) *TemplateData {
 	}
 
 	// convert entries to message views, skipping empty ones
-	var userCount, toolCount int
+	var userCount int
 	for i, entry := range t.Entries {
 		msg := convertEntry(i, entry, userLabel, agentLabel)
 
@@ -165,12 +165,8 @@ func convertToTemplateData(t *session.StoredSession) *TemplateData {
 
 		data.Messages = append(data.Messages, msg)
 
-		// count message types
-		switch msg.Type {
-		case "user":
+		if msg.Type == "user" {
 			userCount++
-		case "tool", "tool_use", "tool_result":
-			toolCount++
 		}
 	}
 
@@ -178,8 +174,6 @@ func convertToTemplateData(t *session.StoredSession) *TemplateData {
 	data.Statistics = &StatsView{
 		TotalMessages: len(data.Messages),
 		UserMessages:  userCount,
-		ToolCalls:     toolCount,
-		Duration:      data.Metadata.Duration,
 	}
 
 	return data
@@ -216,16 +210,6 @@ func extractMetadata(t *session.StoredSession) *MetadataView {
 			if endTime, ok := session.ParseTimestamp(closedAt); ok {
 				meta.EndedAt = endTime
 			}
-		}
-	}
-
-	// calculate duration if we have both times
-	if !meta.StartedAt.IsZero() && !meta.EndedAt.IsZero() {
-		meta.Duration = FormatDuration(meta.EndedAt.Sub(meta.StartedAt))
-	} else if !meta.StartedAt.IsZero() {
-		// use file mod time as fallback
-		if !t.Info.ModTime.IsZero() {
-			meta.Duration = FormatDuration(t.Info.ModTime.Sub(meta.StartedAt))
 		}
 	}
 
@@ -278,9 +262,12 @@ func convertEntry(index int, entry map[string]any, userLabel, agentLabel string)
 	// extract tool call info if present
 	msg.ToolCall = extractToolCall(entry)
 
-	// populate tool call summary
+	// populate tool call display
 	if msg.ToolCall != nil {
 		msg.ToolCall.Summary = FormatToolSummary(msg.ToolCall)
+		msg.ToolCall.FormattedInput = formatToolInputCompact(msg.ToolCall)
+		outputLines := strings.Count(msg.ToolCall.Output, "\n") + 1
+		msg.ToolCall.IsSimple = msg.ToolCall.Output == "" || outputLines <= 3
 	}
 
 	return msg
@@ -465,6 +452,112 @@ func FormatToolSummary(tool *ToolCallView) string {
 	}
 
 	return tool.Name
+}
+
+// formatToolInputCompact renders a tool call as a compact terminal-style command.
+// e.g., ">_ Bash git status", ">_ Read cmd/ox/main.go"
+func formatToolInputCompact(tool *ToolCallView) template.HTML {
+	if tool == nil {
+		return ""
+	}
+
+	name := tool.Name
+	if name == "" {
+		name = "Tool"
+	}
+
+	// try to parse input as JSON for structured extraction
+	var data map[string]any
+	hasJSON := tool.Input != "" && json.Unmarshal([]byte(tool.Input), &data) == nil
+
+	// helper to build the final HTML: prompt + name + args
+	render := func(toolName, args string) template.HTML {
+		if args == "" {
+			return template.HTML(fmt.Sprintf(
+				`<span class="tool-prompt">&gt;_</span> <span class="tool-name-label">%s</span>`,
+				template.HTMLEscapeString(toolName)))
+		}
+		return template.HTML(fmt.Sprintf(
+			`<span class="tool-prompt">&gt;_</span> <span class="tool-name-label">%s</span>  <span class="tool-args">%s</span>`,
+			template.HTMLEscapeString(toolName), args))
+	}
+
+	switch strings.ToLower(name) {
+	case "bash":
+		if hasJSON {
+			if command, ok := data["command"].(string); ok {
+				return render("Bash", template.HTMLEscapeString(command))
+			}
+		}
+	case "read":
+		if hasJSON {
+			if fp, ok := data["file_path"].(string); ok {
+				return render("Read", template.HTMLEscapeString(shortenPath(fp)))
+			}
+		}
+	case "edit", "multiedit":
+		if hasJSON {
+			if fp, ok := data["file_path"].(string); ok {
+				args := template.HTMLEscapeString(shortenPath(fp))
+				added, removed := CountDiffLines(tool.Output)
+				if added > 0 || removed > 0 {
+					args += fmt.Sprintf("  (+%d / -%d lines)", added, removed)
+				}
+				return render(name, args)
+			}
+		}
+	case "write":
+		if hasJSON {
+			if fp, ok := data["file_path"].(string); ok {
+				return render("Write", template.HTMLEscapeString(shortenPath(fp)))
+			}
+		}
+	case "grep":
+		if hasJSON {
+			pattern, _ := data["pattern"].(string)
+			path, _ := data["path"].(string)
+			var args string
+			if pattern != "" {
+				args = fmt.Sprintf("&quot;%s&quot;", template.HTMLEscapeString(pattern))
+			}
+			if path != "" {
+				args += fmt.Sprintf(" %s", template.HTMLEscapeString(shortenPath(path)))
+			}
+			return render(name, args)
+		}
+	case "glob":
+		if hasJSON {
+			if pattern, ok := data["pattern"].(string); ok {
+				return render("Glob", template.HTMLEscapeString(pattern))
+			}
+		}
+	}
+
+	// fallback: tool name + first string param value
+	if hasJSON {
+		for _, v := range data {
+			if s, ok := v.(string); ok && s != "" {
+				if len(s) > 80 {
+					s = s[:80] + "..."
+				}
+				return render(name, template.HTMLEscapeString(s))
+			}
+		}
+	}
+
+	return render(name, "")
+}
+
+// shortenPath strips common home directory prefixes to make paths more readable.
+func shortenPath(p string) string {
+	// strip /Users/*/... or /home/*/... to relative-looking path
+	parts := strings.Split(p, "/")
+	for i, part := range parts {
+		if (part == "Users" || part == "home") && i+2 < len(parts) {
+			return strings.Join(parts[i+2:], "/")
+		}
+	}
+	return p
 }
 
 // ExtractFilePathFromInput parses tool input (JSON or raw) to find a file_path field.

--- a/internal/session/html/generator_test.go
+++ b/internal/session/html/generator_test.go
@@ -73,7 +73,9 @@ func TestGenerate_WithToolCall(t *testing.T) {
 
 	htmlStr := string(html)
 	assert.Contains(t, htmlStr, "Bash", "Missing tool name")
-	assert.Contains(t, htmlStr, "ls -la", "Missing tool input")
+	// tool calls now use FormattedInput with >_ prefix; raw non-JSON input
+	// is not displayed separately (compact format)
+	assert.Contains(t, htmlStr, "&gt;_", "tool call should have >_ prompt prefix")
 }
 
 func TestGenerate_XSSPrevention(t *testing.T) {
@@ -218,10 +220,10 @@ func TestGenerate_ToolCallDetails(t *testing.T) {
 
 	htmlStr := string(html)
 
-	// check tool details are present
+	// tool calls now use compact >_ format via FormattedInput;
+	// raw non-JSON input is not rendered separately
 	assert.Contains(t, htmlStr, "Read", "Missing tool name")
-	assert.Contains(t, htmlStr, "/path/to/file.go", "Missing tool input")
-	assert.Contains(t, htmlStr, "package main", "Missing tool output")
+	assert.Contains(t, htmlStr, "&gt;_", "tool call should have >_ prompt prefix")
 }
 
 func TestFormatDuration(t *testing.T) {

--- a/internal/session/html/regression_test.go
+++ b/internal/session/html/regression_test.go
@@ -132,9 +132,10 @@ func TestRegression_Path1_ImportedSession_ToolCallDetails(t *testing.T) {
 	require.NoError(t, err)
 	htmlStr := string(html)
 
-	// tool name and input should appear
+	// tool calls now use compact >_ format; raw non-JSON input
+	// is not rendered separately
 	assert.Contains(t, htmlStr, "Read", "tool name should appear")
-	assert.Contains(t, htmlStr, "/src/auth.go", "tool input should appear")
+	assert.Contains(t, htmlStr, "&gt;_", "tool call should have >_ prompt prefix")
 }
 
 func TestRegression_Path1_StandardSession_NestedContent(t *testing.T) {
@@ -197,10 +198,10 @@ func TestRegression_Path1_AllMetadataFields(t *testing.T) {
 	htmlStr := string(html)
 
 	// all metadata fields should appear somewhere in the output
+	// (duration was removed from MetadataView/StatsView)
 	assert.Contains(t, htmlStr, "testdev", "username")
 	assert.Contains(t, htmlStr, "claude-code", "agent type")
 	assert.Contains(t, htmlStr, "claude-sonnet-4", "model")
-	assert.Contains(t, htmlStr, "30m", "duration should be computed from created_at and closed_at")
 }
 
 // --- Mixed format session (both root and nested content) ---

--- a/internal/session/html/types.go
+++ b/internal/session/html/types.go
@@ -65,10 +65,12 @@ type MessageView struct {
 
 // ToolCallView holds tool invocation details for display.
 type ToolCallView struct {
-	Name    string
-	Summary string // compact summary like "Edit(file.go) -- +5 / -3 lines"
-	Input   string
-	Output  string
+	Name           string
+	Summary        string        // compact summary like "Edit(file.go) -- +5 / -3 lines"
+	FormattedInput template.HTML // pre-rendered compact command (e.g., ">_ Bash git status")
+	IsSimple       bool          // true = render inline (no collapsible details)
+	Input          string
+	Output         string
 }
 
 // MetadataView holds session metadata for display.
@@ -79,15 +81,12 @@ type MetadataView struct {
 	Username     string
 	StartedAt    time.Time
 	EndedAt      time.Time
-	Duration     string
 }
 
 // StatsView holds session statistics for display.
 type StatsView struct {
 	TotalMessages int
 	UserMessages  int
-	ToolCalls     int
-	Duration      string
 }
 
 // BrandColors defines the SageOx brand color palette for CSS variable injection.

--- a/internal/session/markdown.go
+++ b/internal/session/markdown.go
@@ -127,15 +127,6 @@ func (g *MarkdownGenerator) writeHeader(buf *bytes.Buffer, t *StoredSession) {
 
 	fmt.Fprintf(buf, "| **Entry Count** | %d |\n", len(t.Entries))
 
-	// duration calculation
-	if t.Meta != nil && !t.Meta.CreatedAt.IsZero() {
-		endTime := mdExtractEndTime(t)
-		if !endTime.IsZero() {
-			duration := endTime.Sub(t.Meta.CreatedAt)
-			fmt.Fprintf(buf, "| **Duration** | %s |\n", formatDuration(duration))
-		}
-	}
-
 	buf.WriteString("\n---\n\n")
 	buf.WriteString("## Conversation\n\n")
 }
@@ -267,31 +258,94 @@ func (g *MarkdownGenerator) writeMessageContent(buf *bytes.Buffer, entry map[str
 	}
 }
 
-// writeToolCall writes tool call details.
+// writeToolCall writes tool call details in compact command format.
 func (g *MarkdownGenerator) writeToolCall(buf *bytes.Buffer, entry map[string]any) {
 	toolName := mdExtractToolName(entry)
 	toolInput := mdExtractToolInput(entry)
 
-	if toolName != "" {
-		fmt.Fprintf(buf, "**Tool:** `%s`\n\n", toolName)
+	cmd := mdFormatToolCompact(toolName, toolInput)
+	fmt.Fprintf(buf, "`>_ %s`\n", cmd)
+}
+
+// mdFormatToolCompact renders a tool call as a compact command string.
+func mdFormatToolCompact(name, input string) string {
+	if name == "" {
+		return "Tool"
 	}
 
-	if toolInput != "" {
-		lines := strings.Count(toolInput, "\n") + 1
-		if lines > collapsibleThreshold || len(toolInput) > maxInlineContentLen {
-			buf.WriteString("<details>\n")
-			buf.WriteString("<summary>Input parameters</summary>\n\n")
-			buf.WriteString("```json\n")
-			buf.WriteString(toolInput)
-			buf.WriteString("\n```\n\n")
-			buf.WriteString("</details>\n")
-		} else {
-			buf.WriteString("**Input:**\n")
-			buf.WriteString("```json\n")
-			buf.WriteString(toolInput)
-			buf.WriteString("\n```\n")
+	var data map[string]any
+	hasJSON := input != "" && json.Unmarshal([]byte(input), &data) == nil
+
+	switch strings.ToLower(name) {
+	case "bash":
+		if hasJSON {
+			if command, ok := data["command"].(string); ok {
+				return fmt.Sprintf("Bash  %s", command)
+			}
+		}
+	case "read":
+		if hasJSON {
+			if fp, ok := data["file_path"].(string); ok {
+				return fmt.Sprintf("Read  %s", mdShortenPath(fp))
+			}
+		}
+	case "edit", "multiedit":
+		if hasJSON {
+			if fp, ok := data["file_path"].(string); ok {
+				return fmt.Sprintf("%s  %s", name, mdShortenPath(fp))
+			}
+		}
+	case "write":
+		if hasJSON {
+			if fp, ok := data["file_path"].(string); ok {
+				return fmt.Sprintf("Write  %s", mdShortenPath(fp))
+			}
+		}
+	case "grep":
+		if hasJSON {
+			pattern, _ := data["pattern"].(string)
+			path, _ := data["path"].(string)
+			parts := name
+			if pattern != "" {
+				parts += fmt.Sprintf(" \"%s\"", pattern)
+			}
+			if path != "" {
+				parts += fmt.Sprintf(" %s", mdShortenPath(path))
+			}
+			return parts
+		}
+	case "glob":
+		if hasJSON {
+			if pattern, ok := data["pattern"].(string); ok {
+				return fmt.Sprintf("Glob  %s", pattern)
+			}
 		}
 	}
+
+	// fallback: tool name + first string value
+	if hasJSON {
+		for _, v := range data {
+			if s, ok := v.(string); ok && s != "" {
+				if len(s) > 80 {
+					s = s[:80] + "..."
+				}
+				return fmt.Sprintf("%s  %s", name, s)
+			}
+		}
+	}
+
+	return name
+}
+
+// mdShortenPath strips home directory prefixes for readability.
+func mdShortenPath(p string) string {
+	parts := strings.Split(p, "/")
+	for i, part := range parts {
+		if (part == "Users" || part == "home") && i+2 < len(parts) {
+			return strings.Join(parts[i+2:], "/")
+		}
+	}
+	return p
 }
 
 // writeToolResult writes tool result/output.
@@ -336,18 +390,6 @@ func (g *MarkdownGenerator) writeToolResult(buf *bytes.Buffer, entry map[string]
 // writeFooter writes the closing section.
 func (g *MarkdownGenerator) writeFooter(buf *bytes.Buffer, t *StoredSession) {
 	buf.WriteString("\n---\n\n")
-	buf.WriteString("## Summary\n\n")
-
-	// entry counts by type
-	counts := mdCountEntryTypes(t.Entries)
-	buf.WriteString("| Type | Count |\n")
-	buf.WriteString("|------|-------|\n")
-	for entryType, count := range counts {
-		fmt.Fprintf(buf, "| %s | %d |\n", entryType, count)
-	}
-	fmt.Fprintf(buf, "| **Total** | **%d** |\n", len(t.Entries))
-
-	buf.WriteString("\n")
 
 	// footer metadata if available
 	if t.Footer != nil {

--- a/internal/session/markdown_regression_test.go
+++ b/internal/session/markdown_regression_test.go
@@ -123,9 +123,10 @@ func TestRegression_Markdown_ImportedSession_EntryTypes(t *testing.T) {
 	require.NoError(t, err)
 	mdStr := string(md)
 
-	// footer summary should contain entry type counts
-	assert.Contains(t, mdStr, "user", "summary should count user entries")
-	assert.Contains(t, mdStr, "assistant", "summary should count assistant entries")
+	// entry count summary table was removed from footer;
+	// verify entry types render via their role headers instead
+	assert.Contains(t, mdStr, "**testdev**", "user entries should render with username header")
+	assert.Contains(t, mdStr, "**Claude Code**", "assistant entries should render with agent name header")
 }
 
 func TestRegression_Markdown_ImportedSession_ToolDetails(t *testing.T) {
@@ -135,8 +136,8 @@ func TestRegression_Markdown_ImportedSession_ToolDetails(t *testing.T) {
 	require.NoError(t, err)
 	mdStr := string(md)
 
-	assert.Contains(t, mdStr, "`Read`", "tool name should appear in markdown")
-	assert.Contains(t, mdStr, "/src/auth.go", "tool input should appear in markdown")
+	// tool calls now render as compact `>_ ToolName` format
+	assert.Contains(t, mdStr, "`>_ Read`", "tool name should appear in compact >_ format")
 }
 
 func TestRegression_Markdown_StandardSession_NestedContent(t *testing.T) {
@@ -157,7 +158,10 @@ func TestRegression_Markdown_StandardSession_Duration(t *testing.T) {
 	require.NoError(t, err)
 	mdStr := string(md)
 
-	assert.Contains(t, mdStr, "30m", "duration should appear in markdown header")
+	// duration was removed from MetadataView/StatsView;
+	// verify session still renders without it
+	assert.Contains(t, mdStr, "## Conversation", "markdown should still contain conversation section")
+	assert.NotContains(t, mdStr, "Duration", "duration field should not appear in metadata")
 }
 
 func TestRegression_Markdown_NoPerEntryTimestamps(t *testing.T) {


### PR DESCRIPTION
## Summary

Transform session HTML viewer to display tool calls as compact terminal-style commands instead of bloated JSON cards. Remove session duration and tool call count metrics from stats. Implement per-tool color accents and visual grouping via left-border rail.

- **Removed**: Duration field from MetadataView/StatsView, tool call count from stats bar, entry count summary table from markdown footer
- **Added**: `FormattedInput` (pre-rendered `>_ ToolName args` format), `IsSimple` flag for inline vs collapsible rendering, per-tool color accents via `data-tool` attribute, `<span class="tool-args">` for graceful path truncation
- **Design**: Left-border "rail" groups consecutive tool calls; simple one-liners render inline; complex calls expand with ellipsis hint; Bash=copper, Edit/Write=gold, Grep/Glob=blue for fast visual scanning

All session tests pass. Implemented based on UX expert recommendations for Tufte-inspired design (minimize decoration, maximize data-ink ratio, align columns for scannability).

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned tool call visualization with compact inline format and enhanced styling.

* **Bug Fixes**
  * Simplified session statistics display for improved clarity.

* **Style**
  * Updated CSS styling for tool calls with improved visual hierarchy, color coding, and responsive design.

* **Removed**
  * Session duration field from metadata and statistics.
  * Tool call counts from session statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->