### PR TITLE
improve agent ID error messages

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sageox/ox/internal/agentinstance"
 	"github.com/sageox/ox/internal/daemon"
-	oxerrors "github.com/sageox/ox/internal/errors"
 	"github.com/sageox/ox/internal/repotools"
 	"github.com/spf13/cobra"
 )
@@ -138,7 +137,10 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no agent ID: %q requires an agent ID (run 'ox agent prime' first)", firstArg)
 	}
 
-	// unknown argument
+	// unknown argument — check for common wrong-format patterns
+	if msg := agentinstance.ClassifyBadID(firstArg); msg != "" {
+		return fmt.Errorf("%s", msg)
+	}
 	return fmt.Errorf("unknown command or invalid agent_id: %s\nRun 'ox agent --help' for usage", firstArg)
 }
 
@@ -237,10 +239,6 @@ func resolveInstance(agentID string) (*agentinstance.Instance, error) {
 	inst, err := store.Get(agentID)
 	if err != nil {
 		return nil, fmt.Errorf("instance not found: %s\nRun 'ox agent prime' to create a new instance", agentID)
-	}
-
-	if inst.IsExpired() {
-		return nil, fmt.Errorf("%w %s\nRun 'ox agent prime' to create a new instance", oxerrors.ErrInvalidSession, agentID)
 	}
 
 	return inst, nil

--- a/internal/agentinstance/agentid.go
+++ b/internal/agentinstance/agentid.go
@@ -118,6 +118,33 @@ func isAlphanumeric(ch rune) bool {
 		(ch >= 'a' && ch <= 'z')
 }
 
+// ClassifyBadID returns a diagnostic message explaining why id is not a valid
+// agent ID. Returns empty string if id is valid or doesn't match a known
+// wrong-format pattern (caller should use generic error).
+func ClassifyBadID(id string) string {
+	if IsValidAgentID(id) {
+		return ""
+	}
+	if looksLikeUUID(id) {
+		return fmt.Sprintf("%q looks like a UUID, not an ox agent ID\nRun 'ox agent prime' to get your Ox<4-char> agent ID", id)
+	}
+	if strings.HasPrefix(id, "oxsid_") {
+		return fmt.Sprintf("%q is a server session ID, not an agent ID\nRun 'ox agent prime' to get your Ox<4-char> agent ID", id)
+	}
+	if len(id) >= 2 && strings.EqualFold(id[:2], "ox") {
+		return fmt.Sprintf("invalid agent ID format %q — expected Ox<4-char> (e.g., OxA1b2)\nRun 'ox agent prime' to get your agent ID", id)
+	}
+	return ""
+}
+
+// looksLikeUUID checks for standard 8-4-4-4-12 UUID structure.
+func looksLikeUUID(id string) bool {
+	if len(id) != 36 {
+		return false
+	}
+	return id[8] == '-' && id[13] == '-' && id[18] == '-' && id[23] == '-'
+}
+
 // ParseAgentID extracts the 4-char suffix from an agent ID.
 // Returns error if format is invalid.
 //

--- a/internal/agentinstance/agentid_test.go
+++ b/internal/agentinstance/agentid_test.go
@@ -1,0 +1,78 @@
+package agentinstance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLooksLikeUUID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"019568a5-e1e2-7cd1-8da8-b2d7440e3aab", true},
+		{"00000000-0000-0000-0000-000000000000", true},
+		{"ffffffff-ffff-ffff-ffff-ffffffffffff", true},
+		{"019568a5e1e27cd18da8b2d7440e3aab", false},  // no hyphens
+		{"019568a5-e1e2-7cd1-8da8-b2d7440e3aa", false}, // too short (35)
+		{"019568a5-e1e2-7cd1-8da8-b2d7440e3aabb", false}, // too long (37)
+		{"019568a5-e1e27cd1-8da8-b2d7440e3aab", false}, // wrong hyphen positions (missing at 13)
+		{"OxA1b2", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := looksLikeUUID(tt.input); got != tt.want {
+				t.Errorf("looksLikeUUID(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyBadID(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantSubstr  string
+		wantEmpty   bool
+	}{
+		// valid agent ID — returns empty
+		{"OxA1b2", "", true},
+
+		// UUID — targeted message
+		{"019568a5-e1e2-7cd1-8da8-b2d7440e3aab", "looks like a UUID", false},
+
+		// server session ID
+		{"oxsid_01KCJECKEGETGX6HC80NRYVZ3P", "server session ID", false},
+
+		// wrong Ox format (wrong case)
+		{"ox1234", "invalid agent ID format", false},
+		{"OX1234", "invalid agent ID format", false},
+
+		// wrong Ox format (wrong length)
+		{"Ox12345", "invalid agent ID format", false},
+		{"Ox123", "invalid agent ID format", false},
+
+		// truly unknown — returns empty (caller uses generic message)
+		{"foobar", "", true},
+		{"session", "", true},
+		{"", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ClassifyBadID(tt.input)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("ClassifyBadID(%q) = %q, want empty", tt.input, got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantSubstr) {
+				t.Errorf("ClassifyBadID(%q) = %q, want substring %q", tt.input, got, tt.wantSubstr)
+			}
+			// all non-empty messages should mention ox agent prime
+			if !strings.Contains(got, "ox agent prime") {
+				t.Errorf("ClassifyBadID(%q) = %q, should mention 'ox agent prime'", tt.input, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When an AI agent passes a UUID or wrong-format string as the agent ID (e.g., its own conversation ID), the CLI returns a generic "unknown command or invalid agent_id" error with no actionable recovery path.

This fix detects common wrong-format patterns and provides targeted guidance:
- **UUID format** (8-4-4-4-12): "looks like a UUID, not an ox agent ID"
- **oxsid format** (server session ID): "is a server session ID, not an agent ID"
- **Wrong case/length**: "invalid agent ID format — expected Ox<4-char>"

All messages direct users to `ox agent prime` to get the correct agent ID.

## Changes

- Add `ClassifyBadID()` and `looksLikeUUID()` to `internal/agentinstance/agentid.go`
- Update dispatcher in `cmd/ox/agent.go` to use these for better error messages
- Remove dead `IsExpired()` check in `resolveInstance()` (filtered by `store.Get()` already)
- Add comprehensive tests in `internal/agentinstance/agentid_test.go`

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added diagnostic feedback for invalid agent IDs, providing specific guidance on why certain identifiers are not accepted.

* **Bug Fixes**
  * Improved error messages for unknown arguments to identify invalid ID formats (UUID-like patterns, server session IDs, malformed identifiers).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->