### PR TITLE
Show short .sageox/ symlink paths in ox status

### DIFF
--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -535,6 +535,11 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 	if !teamSymlinkCheck.skipped {
 		gitRepoChecks = append(gitRepoChecks, teamSymlinkCheck)
 	}
+	// ensure .sageox/ledger and .sageox/teams/primary symlinks exist
+	projectSymlinkCheck := checkProjectSymlinks(opts.shouldFix(CheckSlugProjectSymlinks))
+	if !projectSymlinkCheck.skipped {
+		gitRepoChecks = append(gitRepoChecks, projectSymlinkCheck)
+	}
 	categories = append(categories, checkCategory{
 		name:   "Git Repository Health",
 		checks: gitRepoChecks,

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -285,6 +285,15 @@ func init() {
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugProjectSymlinks,
+		Name:        "Project symlinks",
+		Category:    "Git Repository Health",
+		FixLevel:    FixLevelAuto,
+		Description: "Ensures .sageox/ledger and .sageox/teams/primary symlinks exist for short path display",
+		Run:         checkProjectSymlinks,
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
 		Slug:        CheckSlugLegacyStructure,
 		Name:        "Legacy structure",
 		Category:    "Git Repository Health",

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -1843,6 +1843,95 @@ func checkLedgerStructureMigration() checkResult {
 	return SkippedCheck("Ledger structure", "no ledger configured", "")
 }
 
+// checkProjectSymlinks ensures .sageox/ledger and .sageox/teams/primary symlinks exist
+// and point to the actual configured paths (not just the XDG defaults).
+func checkProjectSymlinks(fix bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Project symlinks", "not in git repo", "")
+	}
+	if !config.IsInitialized(gitRoot) {
+		return SkippedCheck("Project symlinks", "not initialized", "")
+	}
+
+	projectCfg, err := config.LoadProjectConfig(gitRoot)
+	if err != nil || projectCfg == nil {
+		return SkippedCheck("Project symlinks", "no project config", "")
+	}
+	ep := projectCfg.GetEndpoint()
+	if ep == "" {
+		return SkippedCheck("Project symlinks", "no endpoint", "")
+	}
+
+	localCfg, _ := config.LoadLocalConfig(gitRoot)
+
+	// determine the actual ledger path: prefer config.local.toml, fall back to XDG default
+	var ledgerTarget string
+	if localCfg != nil && localCfg.Ledger != nil && localCfg.Ledger.Path != "" {
+		ledgerTarget = localCfg.Ledger.Path
+	} else if projectCfg.RepoID != "" {
+		ledgerTarget = config.DefaultLedgerPath(projectCfg.RepoID, ep)
+	}
+
+	// determine the actual team context path
+	var teamTarget string
+	if projectCfg.TeamID != "" {
+		teamTarget = paths.TeamContextDir(projectCfg.TeamID, ep)
+	}
+
+	// checkSymlink returns true if the symlink exists and points to the expected target
+	checkSymlink := func(rel, expectedTarget string) bool {
+		if expectedTarget == "" {
+			return true // nothing to check
+		}
+		abs := filepath.Join(gitRoot, rel)
+		target, err := os.Readlink(abs)
+		if err != nil {
+			return false // missing or not a symlink
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(abs), target)
+		}
+		return filepath.Clean(target) == filepath.Clean(expectedTarget)
+	}
+
+	var issues []string
+	if ledgerTarget != "" && !checkSymlink(".sageox/ledger", ledgerTarget) {
+		issues = append(issues, ".sageox/ledger")
+	}
+	if teamTarget != "" && !checkSymlink(".sageox/teams/primary", teamTarget) {
+		issues = append(issues, ".sageox/teams/primary")
+	}
+
+	if len(issues) == 0 {
+		return PassedCheck("Project symlinks", "ok")
+	}
+
+	if !fix {
+		return WarningCheck("Project symlinks",
+			fmt.Sprintf("%d need repair: %s", len(issues), strings.Join(issues, ", ")),
+			"Run `ox doctor --fix` to create project symlinks")
+	}
+
+	// fix: create or update symlinks to point to actual configured paths
+	var fixed int
+	if ledgerTarget != "" {
+		if err := config.CreateOrUpdateProjectSymlink(gitRoot, ".sageox/ledger", ledgerTarget); err == nil {
+			fixed++
+		}
+	}
+	if teamTarget != "" {
+		if err := config.CreateProjectTeamSymlinks(gitRoot, projectCfg.TeamID, ep); err == nil {
+			fixed++
+		}
+	}
+
+	if fixed > 0 {
+		return PassedCheck("Project symlinks", fmt.Sprintf("fixed %d symlinks", fixed))
+	}
+	return WarningCheck("Project symlinks", "could not create symlinks", "")
+}
+
 // checkTeamContextSymlinks validates all team context symlinks in centralized location.
 // Returns a single check result summarizing symlink health.
 func checkTeamContextSymlinks() checkResult {

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -125,6 +125,7 @@ const (
 	CheckSlugLedgerRemote       = "ledger-remote"
 	CheckSlugTeamContextPath    = "team-context-path"
 	CheckSlugTeamSymlink        = "team-symlink"
+	CheckSlugProjectSymlinks    = "project-symlinks"
 	CheckSlugLegacyStructure    = "legacy-structure"
 	CheckSlugGitConfig          = "git-config"
 	CheckSlugGitRemotes         = "git-remotes"

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -527,6 +527,29 @@ func fetchRemoteURLs(client *api.RepoClient, teamContexts []config.TeamContext) 
 }
 
 // renderGitReposSection renders the git repositories status section
+// shortenPathViaSymlink returns a short relative path (e.g. ".sageox/ledger")
+// if a .sageox/ symlink in projectRoot resolves to fullPath.
+// Checks candidates in order and returns the first match, or fullPath unchanged.
+func shortenPathViaSymlink(projectRoot, fullPath string, candidates ...string) string {
+	if projectRoot == "" || fullPath == "" {
+		return fullPath
+	}
+	for _, rel := range candidates {
+		abs := filepath.Join(projectRoot, rel)
+		target, err := os.Readlink(abs)
+		if err != nil {
+			continue
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(abs), target)
+		}
+		if filepath.Clean(target) == filepath.Clean(fullPath) {
+			return rel
+		}
+	}
+	return fullPath
+}
+
 // Shows ledger and team contexts grouped by endpoint
 // Always renders both sections, showing "(none)" if not configured
 func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, daemonStatus *daemon.StatusData) string {
@@ -644,7 +667,7 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 		}
 
 		b.WriteString(statusLabelStyle.Render("  Path"))
-		b.WriteString(statusMutedStyle.Render(localCfg.Ledger.Path))
+		b.WriteString(statusMutedStyle.Render(shortenPathViaSymlink(projectRoot, localCfg.Ledger.Path, ".sageox/ledger")))
 		b.WriteString("\n")
 
 		// check if ledger doesn't exist locally and user doesn't have access (ErrLedgerNotFound)
@@ -693,7 +716,7 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 		}
 		b.WriteString("\n")
 		b.WriteString(statusLabelStyle.Render("  Path"))
-		b.WriteString(statusMutedStyle.Render(expectedPath))
+		b.WriteString(statusMutedStyle.Render(shortenPathViaSymlink(projectRoot, expectedPath, ".sageox/ledger")))
 		b.WriteString("\n")
 		b.WriteString(statusLabelStyle.Render("  Remote"))
 		b.WriteString(statusMutedStyle.Render(cloudLedgerURL))
@@ -857,7 +880,7 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 		b.WriteString("\n")
 
 		b.WriteString(statusLabelStyle.Render("  Path"))
-		b.WriteString(statusMutedStyle.Render(expectedPath))
+		b.WriteString(statusMutedStyle.Render(shortenPathViaSymlink(projectRoot, expectedPath, ".sageox/teams/primary", ".sageox/teams/"+cloudTC.StableID())))
 		b.WriteString("\n")
 
 		gitDir := filepath.Join(expectedPath, ".git")
@@ -930,7 +953,7 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 		b.WriteString(renderVisibilityWithAccess(detailVisibility, detailTC.AccessLevel))
 		b.WriteString("\n")
 		b.WriteString(statusLabelStyle.Render("  Path"))
-		b.WriteString(statusMutedStyle.Render(expectedPath))
+		b.WriteString(statusMutedStyle.Render(shortenPathViaSymlink(projectRoot, expectedPath, ".sageox/teams/primary", ".sageox/teams/"+detailTC.StableID())))
 		b.WriteString("\n")
 
 		gitDir := filepath.Join(expectedPath, ".git")

--- a/cmd/ox/status_test.go
+++ b/cmd/ox/status_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -251,6 +254,79 @@ func TestBuildStatusJSON_VisibilityAccessLevelCombinations(t *testing.T) {
 			require.NotNil(t, output.Ledger)
 			assert.Equal(t, tt.visibility, output.Ledger.Visibility)
 			assert.Equal(t, tt.accessLevel, output.Ledger.AccessLevel)
+		})
+	}
+}
+
+func TestShortenPathViaSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require Developer Mode on Windows")
+	}
+	t.Parallel()
+
+	target := filepath.Join(t.TempDir(), "data", "ledger")
+	require.NoError(t, os.MkdirAll(target, 0755))
+
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0755))
+	require.NoError(t, os.Symlink(target, filepath.Join(sageoxDir, "ledger")))
+
+	tests := []struct {
+		name       string
+		root       string
+		fullPath   string
+		candidates []string
+		want       string
+	}{
+		{
+			name:       "symlink matches",
+			root:       projectRoot,
+			fullPath:   target,
+			candidates: []string{".sageox/ledger"},
+			want:       ".sageox/ledger",
+		},
+		{
+			name:       "no match returns full path",
+			root:       projectRoot,
+			fullPath:   "/some/other/path",
+			candidates: []string{".sageox/ledger"},
+			want:       "/some/other/path",
+		},
+		{
+			name:       "empty root returns full path",
+			root:       "",
+			fullPath:   target,
+			candidates: []string{".sageox/ledger"},
+			want:       target,
+		},
+		{
+			name:       "empty fullPath returns empty",
+			root:       projectRoot,
+			fullPath:   "",
+			candidates: []string{".sageox/ledger"},
+			want:       "",
+		},
+		{
+			name:       "nonexistent symlink returns full path",
+			root:       projectRoot,
+			fullPath:   target,
+			candidates: []string{".sageox/teams/primary"},
+			want:       target,
+		},
+		{
+			name:       "first matching candidate wins",
+			root:       projectRoot,
+			fullPath:   target,
+			candidates: []string{".sageox/teams/primary", ".sageox/ledger"},
+			want:       ".sageox/ledger",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shortenPathViaSymlink(tt.root, tt.fullPath, tt.candidates...)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/config/local_config.go
+++ b/internal/config/local_config.go
@@ -648,6 +648,16 @@ func createOrUpdateSymlink(symlinkPath, targetPath string) error {
 	return os.Symlink(targetPath, symlinkPath)
 }
 
+// CreateOrUpdateProjectSymlink creates or updates a symlink inside the project root.
+// The rel path is relative to projectRoot (e.g. ".sageox/ledger").
+// If the symlink already points to targetPath, this is a no-op.
+func CreateOrUpdateProjectSymlink(projectRoot, rel, targetPath string) error {
+	if projectRoot == "" || rel == "" || targetPath == "" {
+		return nil
+	}
+	return createOrUpdateSymlink(filepath.Join(projectRoot, rel), targetPath)
+}
+
 // CreateProjectLedgerSymlink creates .sageox/ledger -> user-dir ledger path.
 func CreateProjectLedgerSymlink(projectRoot, repoID, ep string) error {
 	if projectRoot == "" || repoID == "" || ep == "" {


### PR DESCRIPTION
## Summary

Shorten displayed paths in `ox status` by showing `.sageox/ledger` and `.sageox/teams/primary` instead of full XDG paths when the symlinks exist and match the configured paths. This makes paths more discoverable and actionable for users.

## Changes

- **`shortenPathViaSymlink()` helper in status.go**: Checks if a `.sageox/` symlink points to the displayed path; returns the short relative form if so
- **Applied at 4 display sites**: Ledger path (cloned and not-cloned), cloud team context, detail-only team context
- **`checkProjectSymlinks()` in doctor**: Creates `.sageox/ledger` and `.sageox/teams/primary` symlinks, ensuring they point to the actual configured paths (not just defaults)
- **Doctor registration**: Registered as `FixLevelAuto`, runs automatically to create/repair symlinks

## Before/After

```
# Before
Path      /Users/ryan/.local/share/sageox/sageox.ai/ledgers/repo-abc/

# After
Path      .sageox/ledger
```

Co-Authored-By: SageOx <ox@sageox.ai>