### PR TITLE
Extract git safety primitives into internal/gitutil

### DIFF
--- a/cmd/ox/session_push_summary.go
+++ b/cmd/ox/session_push_summary.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -165,7 +166,7 @@ func pushSummaryToLedger(filePath, sessionDir string) *pushSummaryOutput {
 
 	// push using existing retry logic
 	slog.Info("pushing summary to ledger", "session", sessionName)
-	if err := pushLedger(ledgerPath); err != nil {
+	if err := pushLedger(context.Background(), ledgerPath); err != nil {
 		return &pushSummaryOutput{
 			Success: false,
 			Type:    "push_summary",

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/lfs"
 )
 
@@ -232,7 +234,7 @@ func commitAndPushLedger(ledgerPath, sessionName string) error {
 	}
 
 	// push with pull --rebase retry (up to 3 attempts)
-	return pushLedger(ledgerPath)
+	return pushLedger(context.Background(), ledgerPath)
 }
 
 // commitAndPushLedgerWithExtras commits meta.json, .gitignore, and optionally summary.json,
@@ -265,7 +267,7 @@ func commitAndPushLedgerWithExtras(ledgerPath, sessionName string, includeSummar
 		return fmt.Errorf("git commit failed: %s: %w", string(output), err)
 	}
 
-	return pushLedger(ledgerPath)
+	return pushLedger(context.Background(), ledgerPath)
 }
 
 // resolveLedgerPath returns the ledger git repo path for the project.
@@ -287,7 +289,13 @@ func resolveLedgerPath() (string, error) {
 // pushLedger pushes ledger changes to remote with conflict retry.
 // Retries on transient failures (network, rejection). Fails fast on permanent errors
 // (auth, config) to avoid wasting time on retries that will never succeed.
-func pushLedger(ledgerPath string) error {
+// Uses context for timeout control (60s per git operation).
+func pushLedger(ctx context.Context, ledgerPath string) error {
+	// pre-flight: check for lock files and broken rebase state
+	if err := gitutil.IsSafeForGitOps(ledgerPath); err != nil {
+		return fmt.Errorf("ledger blocked: %w", err)
+	}
+
 	// ensure remote has current credentials before pushing
 	ep := endpoint.GetForProject(findGitRoot())
 	if ep != "" {
@@ -297,6 +305,7 @@ func pushLedger(ledgerPath string) error {
 	}
 
 	const maxRetries = 3
+	const opTimeout = 60 * time.Second
 
 	// Errors that indicate a permanent failure — retrying won't help.
 	permanentPatterns := []string{
@@ -308,35 +317,44 @@ func pushLedger(ledgerPath string) error {
 	}
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		pushCmd := exec.Command("git", "-C", ledgerPath, "push", "--quiet")
-		output, err := pushCmd.CombinedOutput()
+		attemptCtx, cancel := context.WithTimeout(ctx, opTimeout)
+		outStr, err := gitutil.RunGit(attemptCtx, ledgerPath, "push", "--quiet")
+		cancel()
 		if err == nil {
 			return nil // success
 		}
 
-		outStr := string(output)
-
 		// fail fast on permanent errors
 		for _, pattern := range permanentPatterns {
 			if strings.Contains(outStr, pattern) {
-				return fmt.Errorf("git push failed (not retryable): %s: %w", outStr, err)
+				return fmt.Errorf("git push failed (not retryable): %s", outStr)
 			}
 		}
 
 		if attempt == maxRetries {
-			return fmt.Errorf("git push failed after %d attempts: %s: %w", maxRetries, outStr, err)
+			return fmt.Errorf("git push failed after %d attempts: %s", maxRetries, outStr)
 		}
 
 		slog.Info("push failed, retrying", "attempt", attempt, "output", outStr)
 
 		// pull --rebase to handle non-fast-forward (most common retry case)
 		if strings.Contains(outStr, "non-fast-forward") || strings.Contains(outStr, "rejected") {
-			pullCmd := exec.Command("git", "-C", ledgerPath, "pull", "--rebase", "--quiet")
-			if pullOutput, pullErr := pullCmd.CombinedOutput(); pullErr != nil {
+			// check rebase state before pulling
+			if gitutil.IsRebaseInProgress(ledgerPath) {
+				abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
+				_, _ = gitutil.RunGit(abortCtx, ledgerPath, "rebase", "--abort")
+				abortCancel()
+			}
+
+			pullCtx, pullCancel := context.WithTimeout(ctx, opTimeout)
+			pullOut, pullErr := gitutil.RunGit(pullCtx, ledgerPath, "pull", "--rebase", "--quiet")
+			pullCancel()
+			if pullErr != nil {
 				// abort rebase to avoid leaving repo in broken state
-				abortCmd := exec.Command("git", "-C", ledgerPath, "rebase", "--abort")
-				_ = abortCmd.Run() // best-effort cleanup
-				return fmt.Errorf("git pull --rebase failed during retry: %s: %w", string(pullOutput), pullErr)
+				abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)
+				_, _ = gitutil.RunGit(abortCtx, ledgerPath, "rebase", "--abort")
+				abortCancel()
+				return fmt.Errorf("git pull --rebase failed during retry: %s", pullOut)
 			}
 		}
 

--- a/cmd/ox/session_upload_push_test.go
+++ b/cmd/ox/session_upload_push_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -153,7 +154,7 @@ func TestPushLedger_ConflictWithDivergedRemote(t *testing.T) {
 	runGit(t, otherClone, "push")
 
 	// now push from local — should handle the non-fast-forward with rebase retry
-	err := pushLedger(clonePath)
+	err := pushLedger(context.Background(), clonePath)
 	require.NoError(t, err, "pushLedger should succeed after rebase retry on diverged remote")
 
 	// verify both commits exist on remote
@@ -187,7 +188,7 @@ func TestPushLedger_AuthFailureSurfacesClearError(t *testing.T) {
 	// also set GIT_TERMINAL_PROMPT=0 to prevent interactive prompt
 	t.Setenv("GIT_TERMINAL_PROMPT", "0")
 
-	err := pushLedger(clonePath)
+	err := pushLedger(context.Background(), clonePath)
 	require.Error(t, err, "should fail on auth error")
 	assert.Contains(t, err.Error(), "not retryable",
 		"auth errors should be flagged as not retryable")
@@ -212,7 +213,7 @@ func TestPushLedger_RetryExhaustion(t *testing.T) {
 	// error ("does not appear to be a git repository") that doesn't match permanent patterns
 	runGit(t, clonePath, "remote", "set-url", "origin", "/nonexistent/bare/repo.git")
 
-	err := pushLedger(clonePath)
+	err := pushLedger(context.Background(), clonePath)
 	require.Error(t, err, "should fail after retry exhaustion")
 	assert.Contains(t, err.Error(), "failed after 3 attempts",
 		"error should indicate retry exhaustion")

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -27,13 +27,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
@@ -42,10 +42,6 @@ import (
 
 // Sync timing constants - extracted for clarity and testability.
 const (
-	// minFetchHeadAge is the minimum age of FETCH_HEAD before we'll fetch again.
-	// Prevents redundant fetches if another process (e.g., user or another daemon) fetched recently.
-	minFetchHeadAge = 2 * time.Minute
-
 	// minTeamContextFetchAge is the minimum age before re-fetching a team context.
 	// Team contexts are shared across repos, so we use a longer interval to reduce redundant fetches.
 	minTeamContextFetchAge = 5 * time.Minute
@@ -59,16 +55,6 @@ const (
 	// 100 team contexts shouldn't spawn 100 concurrent git clones.
 	maxConcurrentClones = 3
 )
-
-// credentialPattern matches oauth2:TOKEN@ patterns in git output.
-// Used to sanitize credentials before logging.
-var credentialPattern = regexp.MustCompile(`oauth2:[^@]+@`)
-
-// sanitizeGitOutput removes credentials from git command output.
-// Replaces oauth2:TOKEN@ patterns with oauth2:***@ to prevent credential leaks in logs.
-func sanitizeGitOutput(output string) string {
-	return credentialPattern.ReplaceAllString(output, "oauth2:***@")
-}
 
 // ErrInvalidRepoPath indicates the repo path failed security validation.
 var ErrInvalidRepoPath = errors.New("invalid repo path: path traversal or unsafe location detected")
@@ -236,26 +222,6 @@ func p95Duration(durations []time.Duration) time.Duration {
 		idx = len(sorted) - 1
 	}
 	return sorted[idx]
-}
-
-// hasLockFiles checks for stale git lock files that indicate crashed processes.
-// These files block all git operations and must be manually removed.
-// Returns a slice of lock file names found (e.g., "index.lock").
-func hasLockFiles(gitDir string) []string {
-	lockFiles := []string{
-		"index.lock",
-		"shallow.lock",
-		"config.lock",
-		"HEAD.lock",
-	}
-	var found []string
-	for _, lock := range lockFiles {
-		path := filepath.Join(gitDir, lock)
-		if _, err := os.Stat(path); err == nil {
-			found = append(found, lock)
-		}
-	}
-	return found
 }
 
 // SyncScheduler manages periodic sync operations.
@@ -723,20 +689,14 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 	}
 
 	// skip if repo stuck in broken rebase state
-	rebaseMerge := filepath.Join(s.config.LedgerPath, ".git", "rebase-merge")
-	rebaseApply := filepath.Join(s.config.LedgerPath, ".git", "rebase-apply")
-	if _, err := os.Stat(rebaseMerge); err == nil {
+	if gitutil.IsRebaseInProgress(s.config.LedgerPath) {
 		s.logger.Debug("repo in rebase state, skipping pull", "path", s.config.LedgerPath)
-		return nil
-	}
-	if _, err := os.Stat(rebaseApply); err == nil {
-		s.logger.Debug("repo in rebase-apply state, skipping pull", "path", s.config.LedgerPath)
 		return nil
 	}
 
 	// check for stale lock files from crashed git processes
 	gitDir := filepath.Join(s.config.LedgerPath, ".git")
-	if locks := hasLockFiles(gitDir); len(locks) > 0 {
+	if locks := gitutil.HasLockFiles(gitDir); len(locks) > 0 {
 		s.logger.Warn("git lock files detected, skipping pull",
 			"path", s.config.LedgerPath,
 			"locks", strings.Join(locks, ", "))
@@ -808,11 +768,10 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 
 	// FETCH_HEAD mtime dedup (secondary: cross-daemon coordination, crash loop protection).
 	// Kept as fallback for when ls-remote can't run (credential issues, etc).
-	fetchHead := filepath.Join(s.config.LedgerPath, ".git", "FETCH_HEAD")
-	if info, err := os.Stat(fetchHead); err == nil {
-		threshold := max(s.config.SyncIntervalRead/2, minFetchHeadAge)
-		if time.Since(info.ModTime()) < threshold {
-			s.logger.Debug("ledger recently fetched, skipping", "age", time.Since(info.ModTime()))
+	if age, ok := gitutil.FetchHeadAge(s.config.LedgerPath); ok {
+		threshold := max(s.config.SyncIntervalRead/2, gitutil.MinFetchHeadAge)
+		if age < threshold {
+			s.logger.Debug("ledger recently fetched, skipping", "age", age)
 			// persist sync timestamp — another daemon recently fetched, ledger is current
 			if err := s.workspaceRegistry.UpdateConfigLastSync("ledger"); err != nil {
 				s.logger.Warn("failed to update ledger config last sync", "error", err)
@@ -839,7 +798,7 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 	// git fetch (capture stderr for diagnosable error messages)
 	fetchCmd := exec.CommandContext(ctx, "git", "-C", s.config.LedgerPath, "fetch", "--quiet")
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
-		detail := sanitizeGitOutput(strings.TrimSpace(string(output)))
+		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
 		s.logger.Warn("fetch failed", "error", err, "output", detail)
 		if detail != "" {
 			s.recordError(fmt.Sprintf("fetch failed: %s (%v)", detail, err))
@@ -855,7 +814,7 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 	}
 
 	// track FETCH_HEAD mtime to record when remote had new content
-	if info, err := os.Stat(fetchHead); err == nil {
+	if info, err := os.Stat(filepath.Join(s.config.LedgerPath, ".git", "FETCH_HEAD")); err == nil {
 		s.recordRemoteChange(s.config.LedgerPath, info.ModTime())
 	}
 
@@ -884,7 +843,7 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 	// git pull --rebase (capture stderr for diagnosable error messages)
 	pullCmd := exec.CommandContext(ctx, "git", "-C", s.config.LedgerPath, "pull", "--rebase", "--quiet")
 	if output, err := pullCmd.CombinedOutput(); err != nil {
-		detail := sanitizeGitOutput(strings.TrimSpace(string(output)))
+		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
 		s.logger.Warn("pull failed", "error", err, "output", detail)
 		if detail != "" {
 			s.recordError(fmt.Sprintf("pull failed: %s (%v)", detail, err))
@@ -1536,7 +1495,7 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 	cloneCmd := exec.CommandContext(ctx, "git", "clone", "--quiet", cloneURL, payload.RepoPath)
 	if output, err := cloneCmd.CombinedOutput(); err != nil {
 		// sanitize output to prevent credential leaks (clone URL may contain PAT token)
-		sanitizedOutput := sanitizeGitOutput(string(output))
+		sanitizedOutput := gitutil.SanitizeOutput(string(output))
 		s.logger.Error("checkout: clone failed", "error", err, "output", sanitizedOutput)
 		s.recordError(fmt.Sprintf("clone %s failed: %v", payload.RepoType, err))
 		// include sanitized output in error for better debugging
@@ -1967,20 +1926,14 @@ func (s *SyncScheduler) cloneInBackground(cloneURL, repoPath, repoType, workspac
 // so that CLI commands can "whisper" updates to agents.
 func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error {
 	// skip if repo stuck in broken rebase state
-	rebaseMerge := filepath.Join(path, ".git", "rebase-merge")
-	rebaseApply := filepath.Join(path, ".git", "rebase-apply")
-	if _, err := os.Stat(rebaseMerge); err == nil {
+	if gitutil.IsRebaseInProgress(path) {
 		s.logger.Debug("repo in rebase state, skipping pull", "path", path)
-		return nil
-	}
-	if _, err := os.Stat(rebaseApply); err == nil {
-		s.logger.Debug("repo in rebase-apply state, skipping pull", "path", path)
 		return nil
 	}
 
 	// check for stale lock files from crashed git processes
 	gitDir := filepath.Join(path, ".git")
-	if locks := hasLockFiles(gitDir); len(locks) > 0 {
+	if locks := gitutil.HasLockFiles(gitDir); len(locks) > 0 {
 		repoName := filepath.Base(path)
 		s.logger.Warn("git lock files detected, skipping pull",
 			"path", path,
@@ -2012,11 +1965,10 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 
 	// FETCH_HEAD mtime dedup (secondary: multi-daemon dedup on shared team context paths).
 	// Kept as fallback for when ls-remote can't run (credential issues, etc).
-	fetchHead := filepath.Join(path, ".git", "FETCH_HEAD")
-	if info, err := os.Stat(fetchHead); err == nil {
+	if age, ok := gitutil.FetchHeadAge(path); ok {
 		threshold := max(s.config.TeamContextSyncInterval/2, minTeamContextFetchAge)
-		if time.Since(info.ModTime()) < threshold {
-			s.logger.Debug("team context recently fetched, skipping", "path", path, "age", time.Since(info.ModTime()))
+		if age < threshold {
+			s.logger.Debug("team context recently fetched, skipping", "path", path, "age", age)
 			return nil
 		}
 	}
@@ -2031,7 +1983,7 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 	// git fetch (capture stderr for diagnosable error messages)
 	fetchCmd := exec.CommandContext(ctx, "git", "-C", path, "fetch", "--quiet")
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
-		detail := sanitizeGitOutput(strings.TrimSpace(string(output)))
+		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
 		if detail != "" {
 			return fmt.Errorf("fetch failed: %s (%w)", detail, err)
 		}
@@ -2039,14 +1991,14 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 	}
 
 	// track FETCH_HEAD mtime for team context repos
-	if info, err := os.Stat(fetchHead); err == nil {
+	if info, err := os.Stat(filepath.Join(path, ".git", "FETCH_HEAD")); err == nil {
 		s.recordRemoteChange(path, info.ModTime())
 	}
 
 	// git pull --rebase (capture stderr for diagnosable error messages)
 	pullCmd := exec.CommandContext(ctx, "git", "-C", path, "pull", "--rebase", "--quiet")
 	if output, err := pullCmd.CombinedOutput(); err != nil {
-		detail := sanitizeGitOutput(strings.TrimSpace(string(output)))
+		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
 
 		// check if it's a merge conflict
 		statusCmd := exec.CommandContext(ctx, "git", "-C", path, "status", "--porcelain")

--- a/internal/daemon/sync_network_test.go
+++ b/internal/daemon/sync_network_test.go
@@ -10,6 +10,8 @@ import (
 
 	"log/slog"
 
+	"github.com/sageox/ox/internal/gitutil"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -309,7 +311,7 @@ func TestDoPull_AlreadyCanceledContext(t *testing.T) {
 
 	// verify no lock files were left behind
 	gitDir := filepath.Join(ledgerDir, ".git")
-	locks := hasLockFiles(gitDir)
+	locks := gitutil.HasLockFiles(gitDir)
 	assert.Empty(t, locks, "no lock files should remain after canceled context")
 
 	// verify pullInProgress was reset
@@ -364,7 +366,7 @@ func TestDoPull_ContextCancellationDuringFetch(t *testing.T) {
 
 	// verify no lock files were left behind
 	gitDir := filepath.Join(ledgerDir, ".git")
-	locks := hasLockFiles(gitDir)
+	locks := gitutil.HasLockFiles(gitDir)
 	assert.Empty(t, locks, "no lock files should remain after fetch failure")
 }
 
@@ -498,7 +500,7 @@ func TestHasLockFiles_Unit(t *testing.T) {
 	require.NoError(t, os.MkdirAll(gitDir, 0755))
 
 	// no lock files initially
-	assert.Empty(t, hasLockFiles(gitDir))
+	assert.Empty(t, gitutil.HasLockFiles(gitDir))
 
 	// create each type of lock file and verify detection
 	knownLocks := []string{"index.lock", "shallow.lock", "config.lock", "HEAD.lock"}
@@ -506,7 +508,7 @@ func TestHasLockFiles_Unit(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(gitDir, lock), []byte{}, 0644))
 	}
 
-	found := hasLockFiles(gitDir)
+	found := gitutil.HasLockFiles(gitDir)
 	assert.Len(t, found, len(knownLocks))
 	for _, lock := range knownLocks {
 		assert.Contains(t, found, lock)
@@ -514,14 +516,14 @@ func TestHasLockFiles_Unit(t *testing.T) {
 
 	// remove one and verify partial detection
 	require.NoError(t, os.Remove(filepath.Join(gitDir, "index.lock")))
-	found = hasLockFiles(gitDir)
+	found = gitutil.HasLockFiles(gitDir)
 	assert.Len(t, found, len(knownLocks)-1)
 	assert.NotContains(t, found, "index.lock")
 }
 
 // TestHasLockFiles_NonexistentDir verifies no panic on missing .git directory.
 func TestHasLockFiles_NonexistentDir(t *testing.T) {
-	found := hasLockFiles("/nonexistent/path/.git")
+	found := gitutil.HasLockFiles("/nonexistent/path/.git")
 	assert.Empty(t, found)
 }
 

--- a/internal/daemon/sync_test.go
+++ b/internal/daemon/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1439,7 +1440,7 @@ func TestSanitizeGitOutput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeGitOutput(tt.input)
+			result := gitutil.SanitizeOutput(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/gitutil/run.go
+++ b/internal/gitutil/run.go
@@ -1,0 +1,28 @@
+package gitutil
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// RunGit executes a git command with context for timeout/cancellation.
+// Output is auto-sanitized to remove credentials. Use repoPath="" for
+// commands that don't need -C.
+func RunGit(ctx context.Context, repoPath string, args ...string) (string, error) {
+	var cmdArgs []string
+	if repoPath != "" {
+		cmdArgs = append(cmdArgs, "-C", repoPath)
+	}
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	sanitized := SanitizeOutput(strings.TrimSpace(string(output)))
+
+	if err != nil {
+		return sanitized, fmt.Errorf("git %s: %s: %w", args[0], sanitized, err)
+	}
+	return sanitized, nil
+}

--- a/internal/gitutil/run_test.go
+++ b/internal/gitutil/run_test.go
@@ -1,0 +1,110 @@
+package gitutil
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+
+	t.Run("git version succeeds", func(t *testing.T) {
+		output, err := RunGit(context.Background(), "", "version")
+		assert.NoError(t, err)
+		assert.Contains(t, output, "git version")
+	})
+
+	t.Run("invalid command returns error", func(t *testing.T) {
+		_, err := RunGit(context.Background(), "", "not-a-real-command")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "git not-a-real-command")
+	})
+
+	t.Run("canceled context returns error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately
+
+		_, err := RunGit(ctx, "", "version")
+		assert.Error(t, err)
+	})
+
+	t.Run("timeout context returns error", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+		defer cancel()
+		time.Sleep(1 * time.Millisecond) // ensure timeout fires
+
+		_, err := RunGit(ctx, "", "version")
+		assert.Error(t, err)
+	})
+
+	t.Run("with repo path", func(t *testing.T) {
+		repo := t.TempDir()
+		cmd := exec.Command("git", "-C", repo, "init", "--quiet")
+		require.NoError(t, cmd.Run())
+
+		output, err := RunGit(context.Background(), repo, "status", "--porcelain")
+		assert.NoError(t, err)
+		// fresh repo has no output
+		assert.Empty(t, output)
+	})
+
+	t.Run("without repo path omits -C flag", func(t *testing.T) {
+		// git version works without -C
+		output, err := RunGit(context.Background(), "", "version")
+		assert.NoError(t, err)
+		assert.Contains(t, output, "git version")
+	})
+
+	t.Run("output is auto-sanitized", func(t *testing.T) {
+		// create a repo with a remote that has credentials embedded
+		repo := t.TempDir()
+		cmd := exec.Command("git", "-C", repo, "init", "--quiet")
+		require.NoError(t, cmd.Run())
+
+		// set a remote with embedded credentials
+		cmd = exec.Command("git", "-C", repo, "remote", "add", "origin",
+			"https://oauth2:secret-token@gitlab.com/org/repo.git")
+		require.NoError(t, cmd.Run())
+
+		// git remote -v will show the credential URL
+		output, err := RunGit(context.Background(), repo, "remote", "-v")
+		assert.NoError(t, err)
+		assert.NotContains(t, output, "secret-token")
+		assert.Contains(t, output, "oauth2:***@")
+	})
+
+	t.Run("error output is also sanitized", func(t *testing.T) {
+		// create a repo pointing to a nonexistent remote with credentials
+		repo := t.TempDir()
+		cmd := exec.Command("git", "-C", repo, "init", "--quiet")
+		require.NoError(t, cmd.Run())
+		cmd = exec.Command("git", "-C", repo, "remote", "add", "origin",
+			"https://oauth2:secret-token@nonexistent.example.com/repo.git")
+		require.NoError(t, cmd.Run())
+
+		// create a file and commit so we have something to push
+		require.NoError(t, os.WriteFile(filepath.Join(repo, "file.txt"), []byte("test"), 0644))
+		cmd = exec.Command("git", "-C", repo, "add", "file.txt")
+		require.NoError(t, cmd.Run())
+		cmd = exec.Command("git", "-C", repo, "commit", "-m", "init", "--no-verify")
+		require.NoError(t, cmd.Run())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, err := RunGit(ctx, repo, "push", "--quiet")
+		if err != nil {
+			// the error message should not contain the token
+			assert.NotContains(t, err.Error(), "secret-token")
+		}
+	})
+}

--- a/internal/gitutil/safety.go
+++ b/internal/gitutil/safety.go
@@ -1,0 +1,76 @@
+// Package gitutil provides shared git safety primitives used by both the daemon
+// (pull/fetch) and CLI (push/commit) code paths.
+package gitutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// MinFetchHeadAge is the minimum age of FETCH_HEAD before we'll fetch again.
+// Prevents redundant fetches if another process fetched recently.
+const MinFetchHeadAge = 2 * time.Minute
+
+// knownLockFiles are git lock files that indicate a crashed or in-progress git process.
+var knownLockFiles = []string{
+	"index.lock",
+	"shallow.lock",
+	"config.lock",
+	"HEAD.lock",
+}
+
+// HasLockFiles checks .git/ for stale lock files that block git operations.
+// Returns the names of lock files found (empty slice = safe to proceed).
+func HasLockFiles(gitDir string) []string {
+	var found []string
+	for _, lock := range knownLockFiles {
+		path := filepath.Join(gitDir, lock)
+		if _, err := os.Stat(path); err == nil {
+			found = append(found, lock)
+		}
+	}
+	return found
+}
+
+// IsRebaseInProgress checks whether the repo is stuck in a broken rebase state.
+// Returns true if .git/rebase-merge or .git/rebase-apply exists.
+func IsRebaseInProgress(repoPath string) bool {
+	gitDir := filepath.Join(repoPath, ".git")
+	for _, dir := range []string{"rebase-merge", "rebase-apply"} {
+		if _, err := os.Stat(filepath.Join(gitDir, dir)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSafeForGitOps combines lock file and rebase state checks into a single
+// pre-flight check. Returns nil if safe to proceed, or an error describing
+// why the repo is blocked.
+func IsSafeForGitOps(repoPath string) error {
+	gitDir := filepath.Join(repoPath, ".git")
+
+	if locks := HasLockFiles(gitDir); len(locks) > 0 {
+		return fmt.Errorf("git lock files detected: %s (remove stale locks or wait for in-progress operation)", strings.Join(locks, ", "))
+	}
+
+	if IsRebaseInProgress(repoPath) {
+		return fmt.Errorf("repo in broken rebase state (run 'git rebase --abort' in %s)", repoPath)
+	}
+
+	return nil
+}
+
+// FetchHeadAge returns how long ago FETCH_HEAD was last modified.
+// Returns (0, false) if FETCH_HEAD doesn't exist or can't be read.
+func FetchHeadAge(repoPath string) (time.Duration, bool) {
+	fetchHead := filepath.Join(repoPath, ".git", "FETCH_HEAD")
+	info, err := os.Stat(fetchHead)
+	if err != nil {
+		return 0, false
+	}
+	return time.Since(info.ModTime()), true
+}

--- a/internal/gitutil/safety_test.go
+++ b/internal/gitutil/safety_test.go
@@ -1,0 +1,164 @@
+package gitutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasLockFiles(t *testing.T) {
+	t.Run("no lock files", func(t *testing.T) {
+		gitDir := filepath.Join(t.TempDir(), ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+
+		assert.Empty(t, HasLockFiles(gitDir))
+	})
+
+	t.Run("all lock types present", func(t *testing.T) {
+		gitDir := filepath.Join(t.TempDir(), ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+
+		for _, lock := range knownLockFiles {
+			require.NoError(t, os.WriteFile(filepath.Join(gitDir, lock), []byte{}, 0644))
+		}
+
+		found := HasLockFiles(gitDir)
+		assert.Len(t, found, len(knownLockFiles))
+		for _, lock := range knownLockFiles {
+			assert.Contains(t, found, lock)
+		}
+	})
+
+	t.Run("partial locks", func(t *testing.T) {
+		gitDir := filepath.Join(t.TempDir(), ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+
+		// create all, then remove one
+		for _, lock := range knownLockFiles {
+			require.NoError(t, os.WriteFile(filepath.Join(gitDir, lock), []byte{}, 0644))
+		}
+		require.NoError(t, os.Remove(filepath.Join(gitDir, "index.lock")))
+
+		found := HasLockFiles(gitDir)
+		assert.Len(t, found, len(knownLockFiles)-1)
+		assert.NotContains(t, found, "index.lock")
+	})
+
+	t.Run("nonexistent directory", func(t *testing.T) {
+		found := HasLockFiles("/nonexistent/path/.git")
+		assert.Empty(t, found)
+	})
+}
+
+func TestIsRebaseInProgress(t *testing.T) {
+	t.Run("clean repo", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0755))
+
+		assert.False(t, IsRebaseInProgress(repo))
+	})
+
+	t.Run("rebase-merge exists", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git", "rebase-merge"), 0755))
+
+		assert.True(t, IsRebaseInProgress(repo))
+	})
+
+	t.Run("rebase-apply exists", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git", "rebase-apply"), 0755))
+
+		assert.True(t, IsRebaseInProgress(repo))
+	})
+
+	t.Run("both exist", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git", "rebase-merge"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git", "rebase-apply"), 0755))
+
+		assert.True(t, IsRebaseInProgress(repo))
+	})
+}
+
+func TestIsSafeForGitOps(t *testing.T) {
+	t.Run("clean repo", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0755))
+
+		assert.NoError(t, IsSafeForGitOps(repo))
+	})
+
+	t.Run("lock files present", func(t *testing.T) {
+		repo := t.TempDir()
+		gitDir := filepath.Join(repo, ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "index.lock"), []byte{}, 0644))
+
+		err := IsSafeForGitOps(repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "index.lock")
+	})
+
+	t.Run("rebase in progress", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git", "rebase-merge"), 0755))
+
+		err := IsSafeForGitOps(repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "rebase")
+	})
+
+	t.Run("both lock and rebase", func(t *testing.T) {
+		repo := t.TempDir()
+		gitDir := filepath.Join(repo, ".git")
+		require.NoError(t, os.MkdirAll(filepath.Join(gitDir, "rebase-merge"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "index.lock"), []byte{}, 0644))
+
+		// lock check runs first, so error should mention locks
+		err := IsSafeForGitOps(repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "lock")
+	})
+}
+
+func TestFetchHeadAge(t *testing.T) {
+	t.Run("no FETCH_HEAD", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0755))
+
+		age, ok := FetchHeadAge(repo)
+		assert.False(t, ok)
+		assert.Zero(t, age)
+	})
+
+	t.Run("recent FETCH_HEAD", func(t *testing.T) {
+		repo := t.TempDir()
+		gitDir := filepath.Join(repo, ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "FETCH_HEAD"), []byte("ref"), 0644))
+
+		age, ok := FetchHeadAge(repo)
+		assert.True(t, ok)
+		assert.Less(t, age, 2*time.Second) // just created
+	})
+
+	t.Run("old FETCH_HEAD", func(t *testing.T) {
+		repo := t.TempDir()
+		gitDir := filepath.Join(repo, ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+
+		fetchHead := filepath.Join(gitDir, "FETCH_HEAD")
+		require.NoError(t, os.WriteFile(fetchHead, []byte("ref"), 0644))
+		oldTime := time.Now().Add(-5 * time.Minute)
+		require.NoError(t, os.Chtimes(fetchHead, oldTime, oldTime))
+
+		age, ok := FetchHeadAge(repo)
+		assert.True(t, ok)
+		assert.Greater(t, age, 4*time.Minute)
+	})
+}

--- a/internal/gitutil/sanitize.go
+++ b/internal/gitutil/sanitize.go
@@ -1,0 +1,12 @@
+package gitutil
+
+import "regexp"
+
+// credentialPattern matches oauth2:TOKEN@ patterns in git output.
+var credentialPattern = regexp.MustCompile(`oauth2:[^@]+@`)
+
+// SanitizeOutput removes credentials from git command output.
+// Replaces oauth2:TOKEN@ patterns with oauth2:***@ to prevent credential leaks in logs.
+func SanitizeOutput(output string) string {
+	return credentialPattern.ReplaceAllString(output, "oauth2:***@")
+}

--- a/internal/gitutil/sanitize_test.go
+++ b/internal/gitutil/sanitize_test.go
@@ -1,0 +1,57 @@
+package gitutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "standard oauth2 token",
+			input:    "https://oauth2:glpat-xxxx@gitlab.com/org/repo.git",
+			expected: "https://oauth2:***@gitlab.com/org/repo.git",
+		},
+		{
+			name:     "multiple tokens in one string",
+			input:    "remote: https://oauth2:tok1@host1.com failed, fallback https://oauth2:tok2@host2.com",
+			expected: "remote: https://oauth2:***@host1.com failed, fallback https://oauth2:***@host2.com",
+		},
+		{
+			name:     "no credentials",
+			input:    "fatal: repository 'https://github.com/org/repo.git' not found",
+			expected: "fatal: repository 'https://github.com/org/repo.git' not found",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "long PAT",
+			input:    "https://oauth2:glpat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@gitlab.com/repo.git",
+			expected: "https://oauth2:***@gitlab.com/repo.git",
+		},
+		{
+			name:     "token with special characters",
+			input:    "https://oauth2:abc123!#$%^&*()_+-=xyz@host.com/repo.git",
+			expected: "https://oauth2:***@host.com/repo.git",
+		},
+		{
+			name:     "non-oauth2 URL unchanged",
+			input:    "https://user:password@host.com/repo.git",
+			expected: "https://user:password@host.com/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SanitizeOutput(tt.input))
+		})
+	}
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -15,6 +15,7 @@
 package ledger
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/repotools"
 )
@@ -271,19 +273,22 @@ func GetStatusForEndpoint(endpointURL string) *Status {
 
 // checkSyncStatus checks the ahead/behind status with remote.
 func checkSyncStatus(path string, status *Status) {
-	// fetch to update tracking info (quiet, ignore errors)
-	fetchCmd := exec.Command("git", "-C", path, "fetch", "--quiet")
-	_ = fetchCmd.Run()
+	// skip fetch if daemon already fetched recently (prevents redundant network calls)
+	if age, ok := gitutil.FetchHeadAge(path); ok && age < gitutil.MinFetchHeadAge {
+		// use cached state — daemon keeps ledger current via its sync loop
+	} else {
+		// fetch with timeout to avoid hanging on network issues
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_, _ = gitutil.RunGit(ctx, path, "fetch", "--quiet")
+		cancel()
+	}
 
 	// check ahead/behind
-	cmd := exec.Command("git", "-C", path, "status", "--porcelain", "-b")
-	output, err := cmd.Output()
+	outputStr, err := gitutil.RunGit(context.Background(), path, "status", "--porcelain", "-b")
 	if err != nil {
 		status.SyncStatus = "unknown"
 		return
 	}
-
-	outputStr := string(output)
 
 	// parse branch line for ahead/behind: ## branch...origin/branch [ahead N, behind M]
 	if strings.Contains(outputStr, "[") {
@@ -302,13 +307,12 @@ func checkSyncStatus(path string, status *Status) {
 
 // countPendingChanges counts uncommitted changes in the ledger.
 func countPendingChanges(path string, status *Status) {
-	cmd := exec.Command("git", "-C", path, "status", "--porcelain")
-	output, err := cmd.Output()
+	output, err := gitutil.RunGit(context.Background(), path, "status", "--porcelain")
 	if err != nil {
 		return
 	}
 
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	lines := strings.Split(output, "\n")
 	for _, line := range lines {
 		if line != "" {
 			status.PendingChanges++


### PR DESCRIPTION
## Summary

Issue #476: daemon and CLI duplicate git safety logic. Extract into shared `internal/gitutil/` package (100% test coverage).

**New package:**
- Safety checks: lock files, rebase state, FETCH_HEAD dedup
- `RunGit`: context-aware git runner with auto-sanitized output
- No retry/logging logic — callers handle policy

**Daemon refactoring:**
- Deleted private `hasLockFiles`, `sanitizeGitOutput`, `minFetchHeadAge`
- Both ledger and team context sync use `gitutil.*` functions
- Behavior identical, 100+ tests pass

**CLI improvements:**
- `pushLedger`: pre-flight `IsSafeForGitOps` check, 60s operation timeout
- `checkSyncStatus`: FETCH_HEAD dedup prevents redundant fetches, consistency via `RunGit`
- All 5047 tests pass, lint clean

## Test Plan

- [x] All tests pass: 5047 passed, 345 skipped
- [x] Lint: 0 issues
- [x] Code review: confirmed behavior preservation, no regressions

Fixes #476

Co-Authored-By: SageOx <ox@sageox.ai>