### PR TITLE
fix(agentx): improve Amp agent detection and accuracy

### DIFF
--- a/pkg/agentx/agents/amp.go
+++ b/pkg/agentx/agents/amp.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sageox/ox/pkg/agentx"
 )
 
-// AmpAgent implements Agent for Amp by Sourcegraph (https://ampcode.io).
+// AmpAgent implements Agent for Amp by Sourcegraph (https://ampcode.com).
 type AmpAgent struct {
 	hookManager    agentx.HookManager
 	commandManager agentx.CommandManager
@@ -27,8 +27,7 @@ func (a *AmpAgent) Name() string {
 }
 
 func (a *AmpAgent) URL() string {
-	return "https://github.com/sourcegraph/amp"
-
+	return "https://ampcode.com"
 }
 
 func (a *AmpAgent) Role() agentx.AgentRole { return agentx.RoleAgent }
@@ -37,10 +36,16 @@ func (a *AmpAgent) Role() agentx.AgentRole { return agentx.RoleAgent }
 //
 // Detection methods:
 //   - AMP_AGENT=1 or AMP=1
+//   - AMP_THREAD_URL is set (present in all Amp sessions)
 //   - AGENT_ENV=amp
 func (a *AmpAgent) Detect(ctx context.Context, env agentx.Environment) (bool, error) {
 	// Check AMP env vars
 	if env.GetEnv("AMP") == "1" || env.GetEnv("AMP_AGENT") == "1" {
+		return true, nil
+	}
+
+	// AMP_THREAD_URL is set by Amp in all sessions
+	if env.GetEnv("AMP_THREAD_URL") != "" {
 		return true, nil
 	}
 
@@ -52,13 +57,13 @@ func (a *AmpAgent) Detect(ctx context.Context, env agentx.Environment) (bool, er
 	return false, nil
 }
 
-// UserConfigPath returns the Amp user configuration directory (~/.amp).
+// UserConfigPath returns the Amp user configuration directory (~/.config/amp).
 func (a *AmpAgent) UserConfigPath(env agentx.Environment) (string, error) {
-	home, err := env.HomeDir()
+	configDir, err := env.ConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".amp"), nil
+	return filepath.Join(configDir, "amp"), nil
 }
 
 // ProjectConfigPath returns empty as Amp is primarily user-level configuration.
@@ -71,9 +76,9 @@ func (a *AmpAgent) ContextFiles() []string {
 	return []string{"AGENTS.md"}
 }
 
-// SupportsXDGConfig returns false as Amp uses ~/.amp instead of XDG paths.
+// SupportsXDGConfig returns true as Amp uses ~/.config/amp (XDG-compliant).
 func (a *AmpAgent) SupportsXDGConfig() bool {
-	return false
+	return true
 }
 
 // Capabilities returns Amp's supported features.
@@ -83,7 +88,7 @@ func (a *AmpAgent) Capabilities() agentx.Capabilities {
 		MCPServers:     true,  // supports MCP
 		SystemPrompt:   true,  // custom instructions
 		ProjectContext: true,  // AGENTS.md
-		CustomCommands: false, // TBD
+		CustomCommands: true,  // toolboxes and skills
 		MinVersion:     "",
 	}
 }

--- a/pkg/agentx/agents/amp_test.go
+++ b/pkg/agentx/agents/amp_test.go
@@ -1,0 +1,121 @@
+package agents
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sageox/ox/pkg/agentx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAmpDetect(t *testing.T) {
+	ctx := context.Background()
+	agent := NewAmpAgent()
+
+	tests := []struct {
+		name     string
+		envVars  map[string]string
+		expected bool
+	}{
+		{"AMP=1", map[string]string{"AMP": "1"}, true},
+		{"AMP_AGENT=1", map[string]string{"AMP_AGENT": "1"}, true},
+		{"AMP_THREAD_URL set", map[string]string{"AMP_THREAD_URL": "https://ampcode.com/threads/abc123"}, true},
+		{"AGENT_ENV=amp", map[string]string{"AGENT_ENV": "amp"}, true},
+		{"no env vars", map[string]string{}, false},
+		{"unrelated env", map[string]string{"CURSOR_AGENT": "1"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := agentx.NewMockEnvironment(tt.envVars)
+			detected, err := agent.Detect(ctx, env)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, detected)
+		})
+	}
+}
+
+func TestAmpMetadata(t *testing.T) {
+	agent := NewAmpAgent()
+
+	assert.Equal(t, agentx.AgentTypeAmp, agent.Type())
+	assert.Equal(t, "Amp", agent.Name())
+	assert.Equal(t, "https://ampcode.com", agent.URL())
+	assert.Equal(t, agentx.RoleAgent, agent.Role())
+	assert.True(t, agent.SupportsXDGConfig())
+	assert.Contains(t, agent.ContextFiles(), "AGENTS.md")
+}
+
+func TestAmpCapabilities(t *testing.T) {
+	agent := NewAmpAgent()
+	caps := agent.Capabilities()
+
+	assert.True(t, caps.MCPServers)
+	assert.True(t, caps.SystemPrompt)
+	assert.True(t, caps.ProjectContext)
+	assert.True(t, caps.CustomCommands)
+}
+
+func TestAmpUserConfigPath(t *testing.T) {
+	agent := NewAmpAgent()
+
+	env := &agentx.MockEnvironment{
+		Config: "/home/test/.config",
+	}
+	path, err := agent.UserConfigPath(env)
+	require.NoError(t, err)
+	assert.Equal(t, "/home/test/.config/amp", path)
+}
+
+func TestAmpDetectVersion(t *testing.T) {
+	ctx := context.Background()
+	agent := NewAmpAgent()
+
+	t.Run("detects version from cli", func(t *testing.T) {
+		env := &agentx.MockEnvironment{
+			ExecOutputs: map[string][]byte{
+				"amp": []byte("0.3.1\n"),
+			},
+		}
+		assert.Equal(t, "0.3.1", agent.DetectVersion(ctx, env))
+	})
+
+	t.Run("binary not found", func(t *testing.T) {
+		env := &agentx.MockEnvironment{}
+		assert.Equal(t, "", agent.DetectVersion(ctx, env))
+	})
+}
+
+func TestAmpIsInstalled(t *testing.T) {
+	ctx := context.Background()
+	agent := NewAmpAgent()
+
+	t.Run("found in PATH", func(t *testing.T) {
+		env := &agentx.MockEnvironment{
+			PathBinaries: map[string]string{"amp": "/usr/local/bin/amp"},
+		}
+		installed, err := agent.IsInstalled(ctx, env)
+		require.NoError(t, err)
+		assert.True(t, installed)
+	})
+
+	t.Run("config dir exists", func(t *testing.T) {
+		env := &agentx.MockEnvironment{
+			Config:       "/home/test/.config",
+			ExistingDirs: map[string]bool{"/home/test/.config/amp": true},
+		}
+		installed, err := agent.IsInstalled(ctx, env)
+		require.NoError(t, err)
+		assert.True(t, installed)
+	})
+
+	t.Run("not installed", func(t *testing.T) {
+		env := &agentx.MockEnvironment{
+			Config: "/home/test/.config",
+		}
+		installed, err := agent.IsInstalled(ctx, env)
+		require.NoError(t, err)
+		assert.False(t, installed)
+	})
+}


### PR DESCRIPTION
## Summary

Amp sessions can now be correctly identified by `ox agent prime` instead of being misidentified as Claude Code.

**Changes:**
- Add `AMP_THREAD_URL` detection: the environment variable Amp actually sets in all sessions
- Fix URL from GitHub repo link to `ampcode.com`
- Fix user config path from `~/.amp` to `~/.config/amp` (XDG-compliant)
- Update capabilities to reflect actual Amp features (MCP, custom commands/toolboxes)
- Add comprehensive test coverage for detection and agent functionality

## Test plan

- All 5140 tests pass
- 12 new Amp-specific tests cover detection, metadata, capabilities, config paths, version detection, and installation checks
- Lint passes with 0 issues

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Amp agent now detects AMP_THREAD_URL environment variable as a trigger
  * Custom commands support enabled for Amp agent
  * XDG-compliant configuration directory paths now supported

* **Updates**
  * Configuration path migrated to standard XDG directory structure
  * Updated Amp project URL reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->