### PR TITLE
feat(tips): add user and agent tips to ox agent prime

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/teamdocs"
 	"github.com/sageox/ox/internal/telemetry"
+	"github.com/sageox/ox/internal/tips"
 	"github.com/sageox/ox/internal/tokens"
 	"github.com/sageox/ox/internal/ui"
 	"github.com/sageox/ox/internal/useragent"
@@ -228,6 +229,7 @@ type agentPrimeOutput struct {
 	TeamContext       *teamContextInfo `json:"team_context,omitempty"`        // team context if configured
 	TeamContextStatus string           `json:"team_context_status,omitempty"` // "synced", "syncing", or empty; set when team_context is null but sync is expected
 	UserNotification  string           `json:"user_notification,omitempty"`   // pre-built status summary for agent to relay to user
+	AgentTip          string           `json:"agent_tip,omitempty"`           // contextual tip for the agent itself (not for the user)
 	// Prime call tracking
 	PrimeCallCount       int    `json:"prime_call_count,omitempty"`       // number of prime calls this session
 	PrimeExcessiveNotice string `json:"prime_excessive_notice,omitempty"` // warning if prime called excessively
@@ -938,6 +940,16 @@ func detectAgentSessionFile(agent agentx.Agent) string {
 //
 // Default (no flags): Pure JSON output optimized for agent consumption.
 func outputAgentPrime(cmd *cobra.Command, textMode, reviewMode bool, output agentPrimeOutput) error {
+	// always include tips: one for the agent, one for the agent to relay to the user
+	output.AgentTip = tips.GetTip("prime")
+	if userTip := tips.GetPrimeUserTip(output.AgentType); userTip != "" {
+		if output.UserNotification != "" {
+			output.UserNotification += "\n\nTip: " + userTip
+		} else {
+			output.UserNotification = "Tip: " + userTip
+		}
+	}
+
 	// --review takes precedence: show both human summary and JSON
 	if reviewMode {
 		humanSummary := buildHumanSummary(output)

--- a/internal/tips/content.go
+++ b/internal/tips/content.go
@@ -1,6 +1,12 @@
 // internal/tips/content.go
 package tips
 
+import (
+	"fmt"
+	"math/rand" //nolint:gosec // G404: tip selection doesn't need crypto-secure randomness
+	"strings"
+)
+
 // Tips are organized into two audiences:
 //
 // 1. Human Tips (humanContextualTips, humanGeneralTips)
@@ -73,6 +79,58 @@ var agentGeneralTips = []string{
 	"Sessions are recorded to the project ledger for team visibility",
 	"Run `ox status` to check daemon sync and project state",
 	"Use `ox config` to view and manage settings",
+}
+
+// primeUserTips are product tips shown to the user via the agent after ox agent prime.
+// Tips containing %s will have the agent name substituted (e.g., "Claude Code").
+var primeUserTips = []string{
+	`Try asking %s: "Tell me recent major decisions from our SageOx team discussions"`,
+	"Sessions are auto-recorded and shared with your team. To disable: `ox config set session_recording disabled`",
+	"View your team's sessions and discussions in the browser with `ox view team`",
+	"SageOx team context updates automatically — decisions from one session inform every future session",
+	"Record team discussions at sageox.ai to give all AI coworkers shared context",
+}
+
+// agentNameMap maps agent type strings to friendly display names.
+var agentNameMap = map[string]string{
+	"Claude Code": "Claude Code",
+	"claude-code": "Claude Code",
+	"claude":      "Claude Code",
+	"Cursor":      "Cursor",
+	"cursor":      "Cursor",
+	"Windsurf":    "Windsurf",
+	"windsurf":    "Windsurf",
+	"Copilot":     "Copilot",
+	"copilot":     "Copilot",
+	"Amp":         "Amp",
+	"amp":         "Amp",
+	"OpenCode":    "OpenCode",
+	"opencode":    "OpenCode",
+	"Gemini":      "Gemini",
+	"gemini":      "Gemini",
+	"Conductor":   "Conductor",
+	"conductor":   "Conductor",
+}
+
+// friendlyAgentName returns a human-readable agent name for tip text.
+func friendlyAgentName(agentType string) string {
+	if name, ok := agentNameMap[agentType]; ok {
+		return name
+	}
+	// capitalize first letter if non-empty
+	if agentType != "" {
+		return strings.ToUpper(agentType[:1]) + agentType[1:]
+	}
+	return "your AI coworker"
+}
+
+// GetPrimeUserTip returns a random product tip for the user, with agent name substituted.
+func GetPrimeUserTip(agentType string) string {
+	tip := primeUserTips[rand.Intn(len(primeUserTips))]
+	if strings.Contains(tip, "%s") {
+		return fmt.Sprintf(tip, friendlyAgentName(agentType))
+	}
+	return tip
 }
 
 // isAgentCommand returns true if the command is part of the agent UX.

--- a/internal/tips/tips_test.go
+++ b/internal/tips/tips_test.go
@@ -2,6 +2,7 @@
 package tips
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,4 +97,61 @@ func TestGetTip_AgentCommands(t *testing.T) {
 func TestMaybeShow_IntegratesWithCLI(t *testing.T) {
 	// verify it doesn't panic when called
 	MaybeShow("login", AlwaysShow, false, false, false)
+}
+
+func TestGetPrimeUserTip_ReturnsNonEmpty(t *testing.T) {
+	tip := GetPrimeUserTip("Claude Code")
+	assert.NotEmpty(t, tip, "expected a non-empty tip")
+}
+
+func TestGetPrimeUserTip_SubstitutesAgentName(t *testing.T) {
+	// run enough times to hit the %s tip
+	found := false
+	for i := 0; i < 100; i++ {
+		tip := GetPrimeUserTip("Claude Code")
+		if strings.Contains(tip, "Claude Code") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected at least one tip containing 'Claude Code'")
+}
+
+func TestGetPrimeUserTip_EmptyAgentType(t *testing.T) {
+	found := false
+	for i := 0; i < 100; i++ {
+		tip := GetPrimeUserTip("")
+		if strings.Contains(tip, "your AI coworker") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected fallback to 'your AI coworker' for empty agent type")
+}
+
+func TestFriendlyAgentName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Claude Code", "Claude Code"},
+		{"claude-code", "Claude Code"},
+		{"cursor", "Cursor"},
+		{"Windsurf", "Windsurf"},
+		{"", "your AI coworker"},
+		{"custom-agent", "Custom-agent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, friendlyAgentName(tt.input))
+		})
+	}
+}
+
+func TestPrimeUserTips_NotEmpty(t *testing.T) {
+	assert.NotEmpty(t, primeUserTips, "primeUserTips pool should not be empty")
+	for i, tip := range primeUserTips {
+		assert.NotEmpty(t, tip, "primeUserTips[%d] should not be empty", i)
+	}
 }


### PR DESCRIPTION
## Summary

Adds two tip channels to `ox agent prime` output:
- **`agent_tip`**: contextual tips for the agent itself (e.g., "Use \`ox session start\` to begin recording")
- **`user_notification`**: appended with human-facing product tips agents relay to users (e.g., "View your team's sessions with \`ox view team\`")

User tips are randomly selected from a 5-tip pool with dynamic agent name substitution. Tips appear in all output paths: happy path, unavailable, and unauthenticated states. Agents can discover SageOx features without extra documentation.

## Test plan

- All existing and new tests pass: `make test`
- Lint passes: `make lint`
- Verified `ox agent prime` includes both `agent_tip` and `user_notification` fields in JSON output
- Agent tips come from existing "prime" contextual pool
- User tips include dynamic agent names (Claude Code, Cursor, Windsurf, etc.)

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Prime output now displays contextual tips for both agents and users. Tips include dynamic substitution based on the selected agent type.

* **Tests**
  * Added comprehensive test coverage for the new tip functionality, verifying dynamic substitution, fallback behavior, and agent name mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->