### PR TITLE
feat(status): show version update notice when newer release available

### DIFF
--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/tips"
+	"github.com/sageox/ox/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,13 @@ type statusJSONOutput struct {
 	Ledger       *statusLedgerJSON       `json:"ledger,omitempty"`
 	TeamContexts []statusTeamContextJSON `json:"team_contexts,omitempty"`
 	Daemon       *statusDaemonJSON       `json:"daemon,omitempty"`
+	Version      *statusVersionJSON      `json:"version,omitempty"`
+}
+
+type statusVersionJSON struct {
+	Current         string `json:"current"`
+	Latest          string `json:"latest,omitempty"`
+	UpdateAvailable bool   `json:"update_available"`
 }
 
 type statusAuthJSON struct {
@@ -1562,6 +1570,14 @@ daemon health, and a tree view of all SageOx directory locations.`,
 			fmt.Print(renderDaemonSyncSection(daemonStatus, syncHistory, false, projectInitialized))
 		}
 
+		// show version update notice if available
+		if vResult := checkVersionFromCache(); vResult != nil {
+			fmt.Printf("\n%s  %s\n",
+				statusWarningStyle.Render("Update available"),
+				fmt.Sprintf("v%s → v%s — brew upgrade sageox", vResult.CurrentVersion, vResult.LatestVersion),
+			)
+		}
+
 		// show contextual tip
 		userCfg, _ := config.LoadUserConfig("")
 		tips.MaybeShow("status", tips.AlwaysShow, cfg.Quiet, !userCfg.AreTipsEnabled(), cfg.JSON)
@@ -1667,6 +1683,15 @@ func buildStatusJSON(authenticated bool, token *auth.StoredToken, endpointSlug, 
 			}
 		}
 	}
+
+	// version section
+	currentVersion := strings.TrimPrefix(version.Version, "v")
+	vJSON := &statusVersionJSON{Current: currentVersion}
+	if vResult := checkVersionFromCache(); vResult != nil {
+		vJSON.Latest = vResult.LatestVersion
+		vJSON.UpdateAvailable = true
+	}
+	output.Version = vJSON
 
 	return output
 }


### PR DESCRIPTION
## Summary

Add version section to `ox status` output that displays the current version and notifies users when a newer release is available. Reuses existing `checkVersionFromCache()` to read the daemon-populated version cache, providing a passive discovery mechanism for new releases.

## Changes

- **Human-readable output**: Single-line warning notice (`Update available v0.1.1 → v0.2.0 — brew upgrade sageox`) appears only when a newer version is detected in the cache
- **JSON output**: Always includes `version.current`; adds `latest` and `update_available: true` when an update exists
- **Graceful degradation**: Shows nothing if the version cache is missing or the current version is already the latest

## Motivation

v0.1.1 users have limited passive discovery paths for new releases. `ox doctor` checks GitHub but requires manual invocation. `ox status` — a natural place users check their setup — now surfaces version updates alongside existing project status information.

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version information to status output, displaying current and latest versions
  * Displays update availability notification when a newer version is detected
  * Version data available in both human-readable and JSON output formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->