### PR TITLE
fix(lfs): strip lfs config from ledger repos to prevent push 403

### DIFF
--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -296,6 +296,10 @@ func pushLedger(ctx context.Context, ledgerPath string) error {
 		return fmt.Errorf("ledger blocked: %w", err)
 	}
 
+	// pre-flight: strip lfs.repositoryformatversion if set by git-lfs
+	// (causes HTTP 403 on push when filter.lfs.required=true is global)
+	gitutil.StripLFSConfig(ledgerPath)
+
 	// ensure remote has current credentials before pushing
 	ep := endpoint.GetForProject(findGitRoot())
 	if ep != "" {

--- a/internal/gitserver/checkout.go
+++ b/internal/gitserver/checkout.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/logger"
 )
 
@@ -150,6 +151,10 @@ func cloneRepo(ctx context.Context, repoURL, path string, creds *GitCredentials,
 		}
 		return fmt.Errorf("%w: %w\n  debug: git %s", ErrCloneFailed, err, strings.Join(safeArgs, " "))
 	}
+
+	// strip lfs config that git-lfs may have injected during clone
+	// (prevents HTTP 403 on push when filter.lfs.required=true is global)
+	gitutil.StripLFSConfig(path)
 
 	logger.Info("repository cloned", "path", path)
 	return nil

--- a/internal/gitutil/safety.go
+++ b/internal/gitutil/safety.go
@@ -64,6 +64,51 @@ func IsSafeForGitOps(repoPath string) error {
 	return nil
 }
 
+// StripLFSConfig removes lfs.repositoryformatversion from local git config.
+// This config is set by git-lfs when filter.lfs.required=true is global, but
+// it causes HTTP 403 on push to GitLab when the server-side ALB doesn't
+// expect LFS-aware clients. Safe to call on any repo — no-op if not set.
+func StripLFSConfig(repoPath string) {
+	configPath := filepath.Join(repoPath, ".git", "config")
+	if _, err := os.Stat(configPath); err != nil {
+		return
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "[lfs]") {
+		return
+	}
+
+	// remove the [lfs] section and its contents
+	var lines []string
+	inLFS := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "[lfs]" {
+			inLFS = true
+			continue
+		}
+		if inLFS {
+			if strings.HasPrefix(trimmed, "[") {
+				inLFS = false
+			} else {
+				continue
+			}
+		}
+		lines = append(lines, line)
+	}
+
+	cleaned := strings.Join(lines, "\n")
+	if cleaned != content {
+		_ = os.WriteFile(configPath, []byte(cleaned), 0644)
+	}
+}
+
 // FetchHeadAge returns how long ago FETCH_HEAD was last modified.
 // Returns (0, false) if FETCH_HEAD doesn't exist or can't be read.
 func FetchHeadAge(repoPath string) (time.Duration, bool) {

--- a/internal/gitutil/safety_test.go
+++ b/internal/gitutil/safety_test.go
@@ -126,6 +126,57 @@ func TestIsSafeForGitOps(t *testing.T) {
 	})
 }
 
+func TestStripLFSConfig(t *testing.T) {
+	t.Run("removes lfs section", func(t *testing.T) {
+		repo := t.TempDir()
+		gitDir := filepath.Join(repo, ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+
+		config := `[core]
+	repositoryformatversion = 0
+	bare = false
+[lfs]
+	repositoryformatversion = 0
+[remote "origin"]
+	url = https://example.com/repo.git
+`
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0644))
+
+		StripLFSConfig(repo)
+
+		data, err := os.ReadFile(filepath.Join(gitDir, "config"))
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "[lfs]")
+		assert.NotContains(t, string(data), "lfs")
+		assert.Contains(t, string(data), "[core]")
+		assert.Contains(t, string(data), "[remote \"origin\"]")
+	})
+
+	t.Run("no-op without lfs section", func(t *testing.T) {
+		repo := t.TempDir()
+		gitDir := filepath.Join(repo, ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+
+		config := `[core]
+	repositoryformatversion = 0
+[remote "origin"]
+	url = https://example.com/repo.git
+`
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0644))
+
+		StripLFSConfig(repo)
+
+		data, err := os.ReadFile(filepath.Join(gitDir, "config"))
+		require.NoError(t, err)
+		assert.Equal(t, config, string(data))
+	})
+
+	t.Run("no-op without .git dir", func(t *testing.T) {
+		repo := t.TempDir()
+		StripLFSConfig(repo) // should not panic
+	})
+}
+
 func TestFetchHeadAge(t *testing.T) {
 	t.Run("no FETCH_HEAD", func(t *testing.T) {
 		repo := t.TempDir()


### PR DESCRIPTION
## Summary

- **Fixes HTTP 403 on ledger push** caused by `lfs.repositoryformatversion=0` being injected into the ledger's local `.git/config` by the git-lfs binary
- Adds `StripLFSConfig()` to `internal/gitutil/safety.go` that removes the `[lfs]` section from local git config
- Calls it in two places: pre-flight before `pushLedger()` and post-clone in `cloneRepo()`

## Root Cause

When a user has `filter.lfs.required=true` in their global git config (set by `git lfs install`), any `git pull` or `git clone` triggers the git-lfs filter, which writes `lfs.repositoryformatversion=0` into the repo's local `.git/config`. This modifies the push transport in a way that the AWS ALB rejects with HTTP 403.

ox does **not** use the git-lfs binary for LFS operations — it uses direct GitLab LFS Batch API calls (`internal/lfs/`). The `[lfs]` section in local config is unnecessary and actively harmful.

```mermaid
sequenceDiagram
    participant CLI as ox CLI
    participant Git as git push
    participant ALB as AWS ALB
    participant GL as GitLab

    Note over Git: With [lfs] in local config
    Git->>ALB: GET /info/refs?service=git-receive-pack
    ALB->>GL: Forward
    GL-->>ALB: 200 OK
    ALB-->>Git: 200 OK
    Git->>ALB: POST /git-receive-pack (LFS-modified)
    ALB-->>Git: 403 Forbidden ❌

    Note over Git: After StripLFSConfig()
    Git->>ALB: GET /info/refs?service=git-receive-pack
    ALB->>GL: Forward
    GL-->>ALB: 200 OK
    ALB-->>Git: 200 OK
    Git->>ALB: POST /git-receive-pack (standard)
    ALB->>GL: Forward
    GL-->>ALB: 200 OK
    ALB-->>Git: 200 OK ✅
```

## Test plan

- [x] `StripLFSConfig` removes `[lfs]` section and its contents
- [x] `StripLFSConfig` is a no-op when no `[lfs]` section exists
- [x] `StripLFSConfig` is a no-op when `.git/` doesn't exist
- [x] Existing `gitutil` tests pass
- [x] `make lint` clean
- [x] Verified manually: ledger push succeeds after fix

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP 403 errors that could occur when pushing to repositories with Git LFS configuration enabled. LFS-related configuration is now properly handled during repository operations to ensure smooth push and clone workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->