### PR TITLE
fix(doctor,status): improve output when run outside a git repo

### DIFF
--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -166,6 +166,25 @@ common issues, or --fix-slug to target specific checks.`,
 		// check if project is initialized (only relevant if in a git repo)
 		projectInitialized := gitRoot != "" && config.IsInitialized(gitRoot)
 
+		// short-circuit: not in a git repo
+		if gitRoot == "" {
+			w := cmd.OutOrStdout()
+			renderDoctorHeader(w, false)
+
+			var steps []string
+			steps = append(steps,
+				fmt.Sprintf("%s  Not inside a git repository",
+					ui.FailStyle.Render(ui.TimelineDot)),
+				fmt.Sprintf("%s  Run %s from a git repo to diagnose project issues",
+					ui.MutedStyle.Render(ui.TimelineBar),
+					cli.StyleCommand.Render("ox doctor")),
+			)
+			content := strings.Join(steps, "\n")
+			fmt.Fprintln(w, ui.RenderBox("No Git Repository", content, ui.BoxWarning))
+			fmt.Fprintln(w)
+			return nil
+		}
+
 		// short-circuit with setup guidance if not ready
 		if !authenticated || !projectInitialized {
 			w := cmd.OutOrStdout()
@@ -190,13 +209,7 @@ common issues, or --fix-slug to target specific checks.`,
 				)
 			}
 
-			if gitRoot == "" {
-				steps = append(steps,
-					fmt.Sprintf("%s  Step 2: Run %s inside a git repo",
-						ui.MutedStyle.Render(ui.TimelineCircle),
-						cli.StyleCommand.Render("ox init")),
-				)
-			} else if !projectInitialized {
+			if !projectInitialized {
 				steps = append(steps,
 					fmt.Sprintf("%s  Step 2: Run %s to initialize this project",
 						ui.MutedStyle.Render(ui.TimelineCircle),

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -1546,10 +1546,11 @@ daemon health, and a tree view of all SageOx directory locations.`,
 			cli.PrintActionHint("ox init", "Initialize project for AI agent context", 2)
 		}
 
-		// fetch daemon status once, pass to both git repos and daemon sync sections
-		var daemonStatus *daemon.StatusData
-		var syncHistory []daemon.SyncEvent
+		// skip ledger/daemon sections when not in a git repo — nothing to show
 		if gitRoot != "" {
+			// fetch daemon status once, pass to both git repos and daemon sync sections
+			var daemonStatus *daemon.StatusData
+			var syncHistory []daemon.SyncEvent
 			client := daemon.TryConnectOrDirect()
 			if client != nil {
 				if ds, err := client.Status(); err == nil {
@@ -1557,16 +1558,12 @@ daemon health, and a tree view of all SageOx directory locations.`,
 					syncHistory, _ = client.SyncHistory()
 				}
 			}
-		}
 
-		// Ledger and Team Context sections - shows repos from cloud API
-		// Only displays repos that are actually provisioned
-		fmt.Print(renderGitReposSection(localCfg, gitRoot, daemonStatus))
+			// Ledger and Team Context sections - shows repos from cloud API
+			// Only displays repos that are actually provisioned
+			fmt.Print(renderGitReposSection(localCfg, gitRoot, daemonStatus))
 
-		// show daemon sync section - always show so user knows daemon status
-		if gitRoot == "" {
-			fmt.Print(renderDaemonSyncSection(nil, nil, true, projectInitialized))
-		} else {
+			// show daemon sync section
 			fmt.Print(renderDaemonSyncSection(daemonStatus, syncHistory, false, projectInitialized))
 		}
 


### PR DESCRIPTION
## Summary

Fixes confusing output from `ox doctor` and `ox status` when run outside a git repository.

### `ox doctor` (before)
Showed "Setup Required" with login/init steps — didn't clearly indicate it must be run inside a git repo.

### `ox doctor` (after)
Shows "No Git Repository" with a clear message: "Not inside a git repository" and tells the user to run `ox doctor` from a git repo.

### `ox status` (before)
Showed redundant information after already telling the user "not a git repo":
- Ledger section with "n/a (not in a git repo)"
- Daemon sync section with "not configured"

### `ox status` (after)
Stops after the project status section when not in a git repo. No ledger or daemon sync sections are shown since there's no project to report on.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — 5,155 tests pass, 0 failures
- [ ] Manual: run `ox doctor` outside a git repo
- [ ] Manual: run `ox status` outside a git repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `ox doctor` command now displays a clear message directing users to run it within a Git repository.
  * `ox status` command streamlined to only display daemon and ledger information when inside a Git repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->