### PR TITLE
fix(doctor): remove unused merge API, use local-only cleanup for duplicates

### DIFF
--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -371,6 +371,15 @@ func init() {
 		Run:         checkEndpointNormalization,
 	})
 
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugDuplicateRepoMarkers,
+		Name:        "Duplicate repo registrations",
+		Category:    "SageOx Configuration",
+		FixLevel:    FixLevelConfirm,
+		Description: "Detects multiple repo registrations from the same endpoint",
+		Run:         checkDuplicateRepoMarkers,
+	})
+
 	// ============================================================
 	// Team Context checks
 	// ============================================================

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -8,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
@@ -20,6 +23,7 @@ const (
 	CheckSlugLedgerBranchStatus    = "ledger-branch-status"
 	CheckSlugLedgerCleanWorkdir    = "ledger-clean-workdir"
 	CheckSlugLedgerRemoteURLMatch  = "ledger-remote-url-match"
+	CheckSlugLedgerURLAPIMatch     = "ledger-url-api-match"
 )
 
 func init() {
@@ -61,6 +65,15 @@ func init() {
 		FixLevel:    FixLevelAuto,
 		Description: "Validates ledger remote credentials match current login",
 		Run:         func(fix bool) checkResult { return checkLedgerRemoteURLMatch(fix) },
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugLedgerURLAPIMatch,
+		Name:        "Ledger remote URL vs API",
+		Category:    "Ledger Git Health",
+		FixLevel:    FixLevelConfirm,
+		Description: "Verifies local ledger remote URL matches the API-authoritative URL",
+		Run:         checkLedgerURLAPIMatch,
 	})
 }
 
@@ -512,4 +525,121 @@ func fixLedgerStalePAT(ledgerPath, ep string) checkResult {
 	}
 
 	return PassedCheck("Ledger remote URL match", "credentials updated")
+}
+
+// stripURLCredentials removes userinfo (credentials) from a URL for safe comparison.
+// Returns the original string if parsing fails.
+func stripURLCredentials(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	parsed.User = nil
+	return parsed.String()
+}
+
+// checkLedgerURLAPIMatch compares the local ledger's git remote URL path against
+// the authoritative URL from the API. This catches cases where the ledger was
+// cloned with an old or incorrect URL that still authenticates but points to the
+// wrong repository.
+func checkLedgerURLAPIMatch(fix bool) checkResult {
+	const checkName = "Ledger remote URL vs API"
+
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(checkName, "no ledger found", "")
+	}
+
+	if !isGitRepo(ledgerPath) {
+		return SkippedCheck(checkName, "ledger not a git repo", "")
+	}
+
+	// get local remote URL
+	localCmd := exec.Command("git", "-C", ledgerPath, "remote", "get-url", "origin")
+	localOutput, err := localCmd.Output()
+	if err != nil {
+		return SkippedCheck(checkName, "no origin remote", "")
+	}
+	localURL := strings.TrimSpace(string(localOutput))
+
+	// get repo_id from project config
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(checkName, "not in git repo", "")
+	}
+
+	cfg, err := config.LoadProjectConfig(gitRoot)
+	if err != nil || cfg.RepoID == "" {
+		return SkippedCheck(checkName, "no repo_id configured", "")
+	}
+
+	// create API client with auth
+	projectEndpoint := endpoint.GetForProject(gitRoot)
+	client := api.NewRepoClientForProject(gitRoot)
+	if token, tokenErr := auth.GetTokenForEndpoint(projectEndpoint); tokenErr == nil && token != nil && token.AccessToken != "" {
+		client.WithAuthToken(token.AccessToken)
+	}
+
+	// call API for authoritative ledger URL
+	ledgerStatus, apiErr := client.GetLedgerStatus(cfg.RepoID)
+	if apiErr != nil {
+		// don't fail doctor for network issues
+		return SkippedCheck(checkName, "API unavailable", "")
+	}
+	if ledgerStatus == nil || ledgerStatus.RepoURL == "" {
+		return SkippedCheck(checkName, "no API URL available", "")
+	}
+
+	// strip credentials from both URLs for comparison
+	localStripped := stripURLCredentials(localURL)
+	apiStripped := stripURLCredentials(ledgerStatus.RepoURL)
+
+	if localStripped == apiStripped {
+		return PassedCheck(checkName, "URLs match")
+	}
+
+	// URLs differ
+	if !fix {
+		return FailedCheck(checkName, "URL mismatch",
+			fmt.Sprintf("Local:    %s\n       Expected: %s\n       Run `ox doctor --fix` to update",
+				localStripped, apiStripped))
+	}
+
+	// fix: build correct URL with current PAT embedded
+	ep := endpoint.GetForProject(gitRoot)
+	creds, credErr := gitserver.LoadCredentialsForEndpoint(ep)
+	if credErr != nil || creds == nil || creds.Token == "" {
+		return WarningCheck(checkName, "cannot fix (no credentials)",
+			"Run `ox login` first, then `ox doctor --fix`")
+	}
+
+	parsed, parseErr := url.Parse(ledgerStatus.RepoURL)
+	if parseErr != nil {
+		return WarningCheck(checkName, "cannot fix (invalid API URL)", parseErr.Error())
+	}
+	parsed.User = url.UserPassword("oauth2", creds.Token)
+	correctURL := parsed.String()
+
+	// update the remote URL
+	setCmd := exec.Command("git", "-C", ledgerPath, "remote", "set-url", "origin", correctURL)
+	if output, setErr := setCmd.CombinedOutput(); setErr != nil {
+		// sanitize output — git may echo the URL with embedded credentials
+		safeOutput := stripURLCredentials(strings.TrimSpace(string(output)))
+		return FailedCheck(checkName, "set-url failed",
+			fmt.Sprintf("git remote set-url error: %s", safeOutput))
+	}
+
+	// verify connectivity with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	verifyCmd := exec.CommandContext(ctx, "git", "-C", ledgerPath, "ls-remote", "--heads", "origin")
+	if verifyErr := verifyCmd.Run(); verifyErr != nil {
+		if ctx.Err() != nil {
+			return WarningCheck(checkName, "URL updated (verification timed out)",
+				"Remote URL was updated but connectivity check timed out after 5s")
+		}
+		return WarningCheck(checkName, "URL updated but verification failed",
+			"Remote URL was updated but could not verify connectivity")
+	}
+	return PassedCheck(checkName, "URL updated and verified")
 }

--- a/cmd/ox/doctor_ledger_git_test.go
+++ b/cmd/ox/doctor_ledger_git_test.go
@@ -1,0 +1,75 @@
+//go:build !short
+
+package main
+
+import (
+	"testing"
+)
+
+func TestCheckLedgerURLAPIMatch_Skip_NoLedger(t *testing.T) {
+	// run in a temp dir with no ledger configured
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+
+	result := checkLedgerURLAPIMatch(false)
+
+	if !result.skipped {
+		t.Errorf("expected skipped=true when no ledger found, got: %+v", result)
+	}
+}
+
+func TestStripURLCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL with oauth2 credentials",
+			input:    "https://oauth2:some-token@gitlab.example.com/group/repo.git",
+			expected: "https://gitlab.example.com/group/repo.git",
+		},
+		{
+			name:     "URL without credentials",
+			input:    "https://gitlab.example.com/group/repo.git",
+			expected: "https://gitlab.example.com/group/repo.git",
+		},
+		{
+			name:     "URL with username only",
+			input:    "https://user@gitlab.example.com/group/repo.git",
+			expected: "https://gitlab.example.com/group/repo.git",
+		},
+		{
+			name:     "URL with port and credentials",
+			input:    "https://oauth2:token@gitlab.example.com:8443/group/repo.git",
+			expected: "https://gitlab.example.com:8443/group/repo.git",
+		},
+		{
+			name:     "invalid URL returns as-is",
+			input:    "://not-a-valid-url",
+			expected: "://not-a-valid-url",
+		},
+		{
+			name:     "empty string returns empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "SSH-style URL returns as-is (not a parseable URL)",
+			input:    "git@github.com:org/repo.git",
+			expected: "git@github.com:org/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripURLCredentials(tt.input)
+			if got != tt.expected {
+				t.Errorf("stripURLCredentials(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/cmd/ox/doctor_sageox.go
+++ b/cmd/ox/doctor_sageox.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -335,6 +336,25 @@ func (m *repoMarkerData) GetEndpoint() string {
 		return m.Endpoint
 	}
 	return m.APIEndpoint // fallback to legacy field
+}
+
+// repoMarkerFullData extends repoMarkerData with optional init metadata fields
+// used by checkDuplicateRepoMarkers for display purposes.
+type repoMarkerFullData struct {
+	RepoID      string `json:"repo_id"`
+	Endpoint    string `json:"endpoint"`
+	APIEndpoint string `json:"api_endpoint,omitempty"`
+	InitAt      string `json:"init_at,omitempty"`
+	InitByEmail string `json:"init_by_email,omitempty"`
+	InitByName  string `json:"init_by_name,omitempty"`
+}
+
+// GetEndpoint returns the endpoint, preferring new field over legacy
+func (m *repoMarkerFullData) GetEndpoint() string {
+	if m.Endpoint != "" {
+		return m.Endpoint
+	}
+	return m.APIEndpoint
 }
 
 // checkMultipleEndpoints detects if there are multiple .repo_* files from different endpoints.
@@ -1259,4 +1279,194 @@ func checkSiblingWithoutInit() checkResult {
 
 	// neither exists - skip (normal state before init)
 	return SkippedCheck("Sibling directory", "not present", "")
+}
+
+// duplicateMarker holds a parsed .repo_* marker and its raw JSON for the merge API.
+type duplicateMarker struct {
+	filename string
+	data     repoMarkerFullData
+	raw      json.RawMessage
+}
+
+// checkDuplicateRepoMarkers detects when 2+ .repo_* marker files exist for the
+// same endpoint, indicating two independent `ox init` runs created separate
+// registrations. With fix=true, prompts the user to choose which registration
+// to keep and calls the merge API.
+func checkDuplicateRepoMarkers(fix bool) checkResult {
+	const checkName = "Duplicate repo registrations"
+
+	repoRoot := findRepoRoot()
+	if repoRoot == "" {
+		return SkippedCheck(checkName, "not in a repository", "")
+	}
+
+	sageoxDir := filepath.Join(repoRoot, ".sageox")
+	if _, err := os.Stat(sageoxDir); os.IsNotExist(err) {
+		return SkippedCheck(checkName, ".sageox/ not initialized", "")
+	}
+
+	// read all .repo_* files
+	entries, err := os.ReadDir(sageoxDir)
+	if err != nil {
+		return WarningCheck(checkName, "read error", err.Error())
+	}
+
+	// parse each marker and group by normalized endpoint
+	endpointMarkers := make(map[string][]duplicateMarker)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), ".repo_") {
+			continue
+		}
+
+		markerPath := filepath.Join(sageoxDir, entry.Name())
+		rawData, readErr := os.ReadFile(markerPath)
+		if readErr != nil {
+			continue
+		}
+
+		var m repoMarkerFullData
+		if json.Unmarshal(rawData, &m) != nil {
+			continue
+		}
+
+		ep := m.GetEndpoint()
+		if ep == "" {
+			ep = "(unknown)"
+		}
+		normalizedEP := endpoint.NormalizeEndpoint(ep)
+
+		endpointMarkers[normalizedEP] = append(endpointMarkers[normalizedEP], duplicateMarker{
+			filename: entry.Name(),
+			data:     m,
+			raw:      rawData,
+		})
+	}
+
+	// find endpoints with 2+ markers (duplicates)
+	var duplicateEndpoints []string
+	for ep, markers := range endpointMarkers {
+		if len(markers) >= 2 {
+			duplicateEndpoints = append(duplicateEndpoints, ep)
+		}
+	}
+
+	if len(duplicateEndpoints) == 0 {
+		return SkippedCheck(checkName, "no duplicates", "")
+	}
+
+	// sort for deterministic output
+	sort.Strings(duplicateEndpoints)
+
+	// load current config.json to identify which marker is "current"
+	cfg, _ := config.LoadProjectConfig(repoRoot)
+	currentRepoID := ""
+	if cfg != nil {
+		currentRepoID = cfg.RepoID
+	}
+
+	// build detail table for each endpoint with duplicates
+	var detailLines []string
+	var totalDuplicates int
+
+	for _, ep := range duplicateEndpoints {
+		markers := endpointMarkers[ep]
+		totalDuplicates += len(markers)
+		detailLines = append(detailLines, fmt.Sprintf("Endpoint: %s (%d registrations)", ep, len(markers)))
+
+		for _, m := range markers {
+			creator := m.data.InitByName
+			if creator == "" {
+				creator = m.data.InitByEmail
+			}
+			if creator == "" {
+				creator = "(unknown)"
+			}
+
+			createdAt := m.data.InitAt
+			if createdAt == "" {
+				createdAt = "(unknown)"
+			}
+
+			current := ""
+			if m.data.RepoID == currentRepoID {
+				current = " <- current"
+			}
+
+			detailLines = append(detailLines,
+				fmt.Sprintf("  %s  repo_id=%s  by=%s  at=%s%s",
+					m.filename, m.data.RepoID, creator, createdAt, current))
+		}
+	}
+
+	detail := strings.Join(detailLines, "\n       ")
+
+	if !fix {
+		return FailedCheck(checkName,
+			fmt.Sprintf("%d registrations across %d endpoint(s)", totalDuplicates, len(duplicateEndpoints)),
+			detail+"\n       Run `ox doctor --fix` to merge")
+	}
+
+	// fix mode: for each endpoint with duplicates, ask which to keep and merge
+	for _, ep := range duplicateEndpoints {
+		markers := endpointMarkers[ep]
+
+		// display the registrations
+		fmt.Println()
+		cli.PrintWarning(fmt.Sprintf("Duplicate registrations for %s", ep))
+		fmt.Println()
+
+		var options []string
+		for _, m := range markers {
+			creator := m.data.InitByName
+			if creator == "" {
+				creator = m.data.InitByEmail
+			}
+			if creator == "" {
+				creator = "(unknown)"
+			}
+
+			label := fmt.Sprintf("%s (by %s, %s)", m.data.RepoID, creator, m.data.InitAt)
+			if m.data.RepoID == currentRepoID {
+				label += " [current]"
+			}
+			options = append(options, label)
+		}
+
+		// default to current config's repo_id if found
+		defaultIdx := 0
+		for i, m := range markers {
+			if m.data.RepoID == currentRepoID {
+				defaultIdx = i
+				break
+			}
+		}
+
+		idx, selectErr := cli.SelectOne("Which registration to keep?", options, defaultIdx)
+		if selectErr != nil {
+			return WarningCheck(checkName, "selection canceled", selectErr.Error())
+		}
+
+		selectedMarker := markers[idx]
+
+		// local cleanup: update config.json and remove unchosen markers
+		cleanupDuplicateMarkers(repoRoot, sageoxDir, cfg, selectedMarker, markers)
+	}
+
+	return PassedCheck(checkName, "merged duplicate registrations")
+}
+
+// cleanupDuplicateMarkers performs local cleanup after a merge selection:
+// updates config.json repo_id to the selected marker and removes unchosen marker files.
+func cleanupDuplicateMarkers(repoRoot, sageoxDir string, cfg *config.ProjectConfig, selected duplicateMarker, all []duplicateMarker) {
+	if cfg != nil && cfg.RepoID != selected.data.RepoID {
+		cfg.RepoID = selected.data.RepoID
+		_ = config.SaveProjectConfig(repoRoot, cfg)
+	}
+	for _, m := range all {
+		if m.filename == selected.filename {
+			continue
+		}
+		_ = os.Remove(filepath.Join(sageoxDir, m.filename))
+	}
 }

--- a/cmd/ox/doctor_sageox_test.go
+++ b/cmd/ox/doctor_sageox_test.go
@@ -2264,3 +2264,253 @@ func TestCheckEndpointNormalization_MultipleIssues(t *testing.T) {
 		t.Errorf("expected message to mention 'normalized', got: %s", result.message)
 	}
 }
+
+// --- Duplicate repo markers tests ---
+
+// writeMarkerFile creates a .repo_* marker JSON file in the .sageox/ directory.
+func writeMarkerFile(t *testing.T, sageoxDir, filename string, data map[string]string) {
+	t.Helper()
+	markerJSON, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sageoxDir, filename), markerJSON, 0644); err != nil {
+		t.Fatalf("failed to write marker %s: %v", filename, err)
+	}
+}
+
+func TestCheckDuplicateRepoMarkers_SingleMarker(t *testing.T) {
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+
+	requireSageoxDir(t, gitRoot)
+	sageoxDir := filepath.Join(gitRoot, ".sageox")
+
+	writeMarkerFile(t, sageoxDir, ".repo_abc123", map[string]string{
+		"repo_id":       "repo_abc123",
+		"endpoint":      "https://sageox.ai",
+		"init_at":       "2026-02-20T10:00:00Z",
+		"init_by_email": "alice@example.com",
+	})
+
+	result := checkDuplicateRepoMarkers(false)
+
+	if !result.skipped {
+		t.Errorf("expected skipped for single marker, got: passed=%v warning=%v message=%s",
+			result.passed, result.warning, result.message)
+	}
+}
+
+func TestCheckDuplicateRepoMarkers_TwoSameEndpoint_Detected(t *testing.T) {
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+
+	requireSageoxDir(t, gitRoot)
+	sageoxDir := filepath.Join(gitRoot, ".sageox")
+
+	// config.json points to repo A (the "current" one)
+	cfg := &config.ProjectConfig{
+		RepoID:        "repo_aaa111",
+		Endpoint:      "https://sageox.ai",
+		ConfigVersion: config.CurrentConfigVersion,
+	}
+	if err := config.SaveProjectConfig(gitRoot, cfg); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	// marker A: the current user's registration
+	writeMarkerFile(t, sageoxDir, ".repo_aaa111", map[string]string{
+		"repo_id":       "repo_aaa111",
+		"endpoint":      "https://sageox.ai",
+		"init_at":       "2026-02-20T10:00:00Z",
+		"init_by_email": "alice@example.com",
+		"init_by_name":  "Person A",
+	})
+
+	// marker B: a teammate's registration
+	writeMarkerFile(t, sageoxDir, ".repo_bbb222", map[string]string{
+		"repo_id":       "repo_bbb222",
+		"endpoint":      "https://sageox.ai",
+		"init_at":       "2026-02-22T14:00:00Z",
+		"init_by_email": "bob@example.com",
+		"init_by_name":  "Person B",
+	})
+
+	result := checkDuplicateRepoMarkers(false)
+
+	if result.passed || result.skipped {
+		t.Fatalf("expected failed check, got: passed=%v skipped=%v", result.passed, result.skipped)
+	}
+	if !strings.Contains(result.message, "2 registrations") {
+		t.Errorf("expected message to mention '2 registrations', got: %s", result.message)
+	}
+	if !strings.Contains(result.detail, "repo_aaa111") {
+		t.Errorf("expected detail to contain repo_aaa111, got: %s", result.detail)
+	}
+	if !strings.Contains(result.detail, "repo_bbb222") {
+		t.Errorf("expected detail to contain repo_bbb222, got: %s", result.detail)
+	}
+	if !strings.Contains(result.detail, "current") {
+		t.Errorf("expected detail to mark current registration, got: %s", result.detail)
+	}
+	if !strings.Contains(result.detail, "Person A") {
+		t.Errorf("expected detail to show creator name, got: %s", result.detail)
+	}
+}
+
+func TestCheckDuplicateRepoMarkers_TwoDifferentEndpoints_Skipped(t *testing.T) {
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+
+	requireSageoxDir(t, gitRoot)
+	sageoxDir := filepath.Join(gitRoot, ".sageox")
+
+	writeMarkerFile(t, sageoxDir, ".repo_aaa111", map[string]string{
+		"repo_id":  "repo_aaa111",
+		"endpoint": "https://sageox.ai",
+	})
+
+	writeMarkerFile(t, sageoxDir, ".repo_bbb222", map[string]string{
+		"repo_id":  "repo_bbb222",
+		"endpoint": "https://staging.sageox.ai",
+	})
+
+	result := checkDuplicateRepoMarkers(false)
+
+	// different endpoints = not a duplicate (handled by checkMultipleEndpoints)
+	if !result.skipped {
+		t.Errorf("expected skipped for different endpoints, got: passed=%v message=%s",
+			result.passed, result.message)
+	}
+}
+
+func TestCleanupDuplicateMarkers_KeepCurrentRepo(t *testing.T) {
+	// scenario: user picks THEIR repo (the one in config.json) as primary
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+
+	requireSageoxDir(t, gitRoot)
+	sageoxDir := filepath.Join(gitRoot, ".sageox")
+
+	// config initially points to repo A
+	cfg := &config.ProjectConfig{
+		RepoID:        "repo_aaa111",
+		Endpoint:      "https://sageox.ai",
+		ConfigVersion: config.CurrentConfigVersion,
+	}
+	if err := config.SaveProjectConfig(gitRoot, cfg); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	writeMarkerFile(t, sageoxDir, ".repo_aaa111", map[string]string{
+		"repo_id":  "repo_aaa111",
+		"endpoint": "https://sageox.ai",
+		"init_at":  "2026-02-20T10:00:00Z",
+	})
+	writeMarkerFile(t, sageoxDir, ".repo_bbb222", map[string]string{
+		"repo_id":  "repo_bbb222",
+		"endpoint": "https://sageox.ai",
+		"init_at":  "2026-02-22T14:00:00Z",
+	})
+
+	// user picks their own repo (A) as primary
+	selected := duplicateMarker{
+		filename: ".repo_aaa111",
+		data:     repoMarkerFullData{RepoID: "repo_aaa111", Endpoint: "https://sageox.ai"},
+	}
+	all := []duplicateMarker{
+		{filename: ".repo_aaa111", data: repoMarkerFullData{RepoID: "repo_aaa111"}},
+		{filename: ".repo_bbb222", data: repoMarkerFullData{RepoID: "repo_bbb222"}},
+	}
+
+	cleanupDuplicateMarkers(gitRoot, sageoxDir, cfg, selected, all)
+
+	// config.json should still have repo A (unchanged)
+	updatedCfg, err := config.LoadProjectConfig(gitRoot)
+	if err != nil {
+		t.Fatalf("failed to load config after cleanup: %v", err)
+	}
+	if updatedCfg.RepoID != "repo_aaa111" {
+		t.Errorf("expected config repo_id=repo_aaa111, got: %s", updatedCfg.RepoID)
+	}
+
+	// marker A should still exist
+	if _, err := os.Stat(filepath.Join(sageoxDir, ".repo_aaa111")); os.IsNotExist(err) {
+		t.Error("expected .repo_aaa111 to still exist after cleanup")
+	}
+
+	// marker B should be removed
+	if _, err := os.Stat(filepath.Join(sageoxDir, ".repo_bbb222")); !os.IsNotExist(err) {
+		t.Error("expected .repo_bbb222 to be removed after cleanup")
+	}
+}
+
+func TestCleanupDuplicateMarkers_KeepOtherRepo(t *testing.T) {
+	// scenario: user picks the OTHER person's repo as primary
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+
+	requireSageoxDir(t, gitRoot)
+	sageoxDir := filepath.Join(gitRoot, ".sageox")
+
+	// config initially points to repo A (our repo)
+	cfg := &config.ProjectConfig{
+		RepoID:        "repo_aaa111",
+		Endpoint:      "https://sageox.ai",
+		ConfigVersion: config.CurrentConfigVersion,
+	}
+	if err := config.SaveProjectConfig(gitRoot, cfg); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	writeMarkerFile(t, sageoxDir, ".repo_aaa111", map[string]string{
+		"repo_id":  "repo_aaa111",
+		"endpoint": "https://sageox.ai",
+		"init_at":  "2026-02-20T10:00:00Z",
+	})
+	writeMarkerFile(t, sageoxDir, ".repo_bbb222", map[string]string{
+		"repo_id":  "repo_bbb222",
+		"endpoint": "https://sageox.ai",
+		"init_at":  "2026-02-22T14:00:00Z",
+	})
+
+	// user picks the OTHER repo (B) as primary
+	selected := duplicateMarker{
+		filename: ".repo_bbb222",
+		data:     repoMarkerFullData{RepoID: "repo_bbb222", Endpoint: "https://sageox.ai"},
+	}
+	all := []duplicateMarker{
+		{filename: ".repo_aaa111", data: repoMarkerFullData{RepoID: "repo_aaa111"}},
+		{filename: ".repo_bbb222", data: repoMarkerFullData{RepoID: "repo_bbb222"}},
+	}
+
+	cleanupDuplicateMarkers(gitRoot, sageoxDir, cfg, selected, all)
+
+	// config.json should now point to repo B
+	updatedCfg, err := config.LoadProjectConfig(gitRoot)
+	if err != nil {
+		t.Fatalf("failed to load config after cleanup: %v", err)
+	}
+	if updatedCfg.RepoID != "repo_bbb222" {
+		t.Errorf("expected config repo_id=repo_bbb222 after picking other repo, got: %s", updatedCfg.RepoID)
+	}
+
+	// marker B should still exist
+	if _, err := os.Stat(filepath.Join(sageoxDir, ".repo_bbb222")); os.IsNotExist(err) {
+		t.Error("expected .repo_bbb222 to still exist after cleanup")
+	}
+
+	// marker A should be removed
+	if _, err := os.Stat(filepath.Join(sageoxDir, ".repo_aaa111")); !os.IsNotExist(err) {
+		t.Error("expected .repo_aaa111 to be removed after cleanup")
+	}
+}

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -169,6 +169,7 @@ const (
 	// SageOx Configuration checks
 	CheckSlugEndpointConsistency   = "endpoint-consistency"
 	CheckSlugEndpointNormalization = "endpoint-normalization"
+	CheckSlugDuplicateRepoMarkers  = "duplicate-repo-markers"
 
 	// Agent Health checks
 	CheckSlugInstanceStale       = "instance-stale"

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -29,6 +29,7 @@ import (
 
 var initQuiet bool
 var initTeamFlag string
+var initForce bool
 
 // LegacyOxPrimeLine is the old multi-line block format.
 // Kept temporarily for upgrade detection during migration to single-line format.
@@ -130,6 +131,7 @@ Use --team to specify a team ID directly, or let ox init prompt you.`,
 func init() {
 	initCmd.Flags().BoolVarP(&initQuiet, "quiet", "q", false, "suppress non-essential output (default: false)")
 	initCmd.Flags().StringVar(&initTeamFlag, "team", "", "team ID to associate this repo with")
+	initCmd.Flags().BoolVar(&initForce, "force", false, "initialize even if .sageox/ exists on remote")
 }
 
 // initialCommitReadmeContent is the README placed in .sageox/ when creating
@@ -199,6 +201,92 @@ func ensureInitialCommit(gitRoot string) error {
 	return nil
 }
 
+// treeHasDir checks whether a git tree-ish contains a directory named dirName.
+// git ls-tree exits 0 even when the path is absent (it just produces no output),
+// so we must inspect the output rather than the exit code.
+func treeHasDir(gitRoot, treeish, dirName string) bool {
+	cmd := exec.Command("git", "-C", gitRoot, "ls-tree", "-d", treeish, dirName)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return len(strings.TrimSpace(string(out))) > 0
+}
+
+// checkRemoteSageoxExists checks if .sageox/ already exists on the remote default branch.
+// Returns (found, stale, error):
+//   - found=true: .sageox/ confirmed on remote
+//   - stale=true: local tracking refs are behind remote, can't verify
+//   - error: on any failure (no remote, etc.) -- caller should silently continue
+func checkRemoteSageoxExists(gitRoot string) (found bool, stale bool, err error) {
+	// tier 1: check local tracking refs (free, no network)
+	for _, ref := range []string{"origin/main", "origin/master"} {
+		if treeHasDir(gitRoot, ref, ".sageox") {
+			return true, false, nil
+		}
+	}
+
+	// tier 2: use git ls-remote to check if local refs are stale
+	cmd := exec.Command("git", "-C", gitRoot, "ls-remote", "--heads", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return false, false, fmt.Errorf("ls-remote failed: %w", err)
+	}
+
+	// parse ls-remote output: "<sha>\trefs/heads/<branch>"
+	remoteBranches := make(map[string]string) // branch name -> SHA
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		sha := parts[0]
+		refPath := parts[1]
+		branch := strings.TrimPrefix(refPath, "refs/heads/")
+		remoteBranches[branch] = sha
+	}
+
+	// check main and master branches
+	for _, branch := range []string{"main", "master"} {
+		remoteSHA, ok := remoteBranches[branch]
+		if !ok {
+			continue
+		}
+
+		// get local tracking ref SHA
+		localRef := "origin/" + branch
+		localCmd := exec.Command("git", "-C", gitRoot, "rev-parse", localRef)
+		localOut, localErr := localCmd.Output()
+		if localErr != nil {
+			// no local tracking ref at all -- we're behind
+			return false, true, nil
+		}
+		localSHA := strings.TrimSpace(string(localOut))
+
+		if localSHA == remoteSHA {
+			// local is up to date with remote; tier 1 already checked and found nothing
+			continue
+		}
+
+		// local tracking ref differs from remote -- check if we have the remote commit locally
+		catCmd := exec.Command("git", "-C", gitRoot, "cat-file", "-e", remoteSHA)
+		if catCmd.Run() != nil {
+			// we don't have the remote commit locally; user is behind origin
+			return false, true, nil
+		}
+
+		// we have the commit object locally; check if it contains .sageox/
+		if treeHasDir(gitRoot, remoteSHA, ".sageox") {
+			return true, false, nil
+		}
+	}
+
+	return false, false, nil
+}
+
 func runInit() error {
 	// warn if using non-default endpoint (subtle, informational)
 	if endpoint.Get() != endpoint.Default {
@@ -236,6 +324,31 @@ func runInit() error {
 	// add remote URL hashes to fingerprint
 	if hashErr := fingerprint.WithRemoteHashes(); hashErr != nil {
 		cli.PrintWarning(fmt.Sprintf("Could not add remote hashes: %v", hashErr))
+	}
+
+	// check if remote already has .sageox/ (prevents duplicate init race condition)
+	if !initForce {
+		found, stale, err := checkRemoteSageoxExists(gitRoot)
+		if err != nil {
+			slog.Debug("remote sageox check skipped", "error", err)
+		} else if found {
+			fmt.Println()
+			cli.PrintWarning("This repo is already initialized on the remote")
+			fmt.Println()
+			fmt.Println(cli.StyleDim.Render("A teammate has already run 'ox init'. Pull their changes first:"))
+			fmt.Printf("  %s\n", cli.StyleCommand.Render("git pull"))
+			fmt.Println()
+			fmt.Printf("To initialize with a new team anyway: %s\n", cli.StyleCommand.Render("ox init --force"))
+			return cli.ErrSilent
+		} else if stale {
+			fmt.Println()
+			cli.PrintWarning("Your branch may be behind the remote")
+			fmt.Println()
+			fmt.Println(cli.StyleDim.Render("There may be new changes (including initialization) on the remote."))
+			fmt.Println(cli.StyleDim.Render("Consider pulling before running 'ox init':"))
+			fmt.Printf("  %s\n", cli.StyleCommand.Render("git pull"))
+			fmt.Println()
+		}
 	}
 
 	// === ENDPOINT SELECTION ===

--- a/cmd/ox/init_remote_check_test.go
+++ b/cmd/ox/init_remote_check_test.go
@@ -1,0 +1,157 @@
+//go:build !short
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupBareRemote creates a bare git repo that can serve as a remote origin.
+// Returns the path to the bare repo.
+func setupBareRemote(t *testing.T) string {
+	t.Helper()
+	bareDir := filepath.Join(t.TempDir(), "remote.git")
+
+	cmd := exec.Command("git", "init", "--bare", bareDir)
+	require.NoError(t, cmd.Run(), "failed to create bare remote")
+
+	return bareDir
+}
+
+// cloneFromBare clones the bare remote into a new working directory.
+// Returns the path to the clone.
+func cloneFromBare(t *testing.T, bareDir string) string {
+	t.Helper()
+	cloneDir := filepath.Join(t.TempDir(), "clone")
+
+	cmd := exec.Command("git", "clone", bareDir, cloneDir)
+	require.NoError(t, cmd.Run(), "failed to clone bare remote")
+
+	// configure git identity in the clone
+	for _, args := range [][]string{
+		{"config", "user.name", "Test User"},
+		{"config", "user.email", "test@example.com"},
+	} {
+		c := exec.Command("git", args...)
+		c.Dir = cloneDir
+		require.NoError(t, c.Run())
+	}
+
+	return cloneDir
+}
+
+// commitFile creates a file, stages it, and commits in the given repo dir.
+func commitFile(t *testing.T, repoDir, filename, content, message string) {
+	t.Helper()
+
+	if dir := filepath.Dir(filepath.Join(repoDir, filename)); dir != repoDir {
+		require.NoError(t, os.MkdirAll(dir, 0755))
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, filename), []byte(content), 0644))
+
+	cmd := exec.Command("git", "add", filename)
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.Command("git", "commit", "-m", message)
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run())
+}
+
+// pushToRemote pushes the current branch to origin.
+func pushToRemote(t *testing.T, repoDir string) {
+	t.Helper()
+
+	// detect the current branch name
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	branch := string(out[:len(out)-1]) // trim newline
+
+	cmd = exec.Command("git", "push", "origin", branch)
+	cmd.Dir = repoDir
+	require.NoError(t, cmd.Run(), "failed to push to remote")
+}
+
+func TestCheckRemoteSageoxExists_FoundOnTracking(t *testing.T) {
+	skipIntegration(t)
+
+	bareDir := setupBareRemote(t)
+	cloneDir := cloneFromBare(t, bareDir)
+
+	// create .sageox/ dir in the clone and push it
+	commitFile(t, cloneDir, ".sageox/config.json", `{"version":"1"}`, "add sageox config")
+	pushToRemote(t, cloneDir)
+
+	// clone again to get a fresh clone with up-to-date tracking refs
+	freshClone := cloneFromBare(t, bareDir)
+
+	found, stale, err := checkRemoteSageoxExists(freshClone)
+	require.NoError(t, err)
+	assert.True(t, found, "expected .sageox/ to be found on remote tracking ref")
+	assert.False(t, stale, "expected tracking refs to be up to date")
+}
+
+func TestCheckRemoteSageoxExists_NotFound(t *testing.T) {
+	skipIntegration(t)
+
+	bareDir := setupBareRemote(t)
+	cloneDir := cloneFromBare(t, bareDir)
+
+	// push something that is NOT .sageox/
+	commitFile(t, cloneDir, "README.md", "# Hello", "add readme")
+	pushToRemote(t, cloneDir)
+
+	freshClone := cloneFromBare(t, bareDir)
+
+	found, stale, err := checkRemoteSageoxExists(freshClone)
+	require.NoError(t, err)
+	assert.False(t, found, "expected .sageox/ to NOT be found on remote")
+	assert.False(t, stale, "expected tracking refs to be up to date")
+}
+
+func TestCheckRemoteSageoxExists_NoRemote(t *testing.T) {
+	skipIntegration(t)
+
+	// create a repo with no remote
+	repoDir := testGitRepo(t)
+
+	_, _, err := checkRemoteSageoxExists(repoDir)
+	assert.Error(t, err, "expected error when no remote configured")
+}
+
+func TestCheckRemoteSageoxExists_Stale(t *testing.T) {
+	skipIntegration(t)
+
+	bareDir := setupBareRemote(t)
+
+	// first clone: push initial content
+	firstClone := cloneFromBare(t, bareDir)
+	commitFile(t, firstClone, "README.md", "# Hello", "initial commit")
+	pushToRemote(t, firstClone)
+
+	// second clone: this one will go stale
+	staleClone := cloneFromBare(t, bareDir)
+
+	// push .sageox/ from first clone WITHOUT fetching in staleClone
+	commitFile(t, firstClone, ".sageox/config.json", `{"version":"1"}`, "add sageox config")
+	pushToRemote(t, firstClone)
+
+	// staleClone has not fetched, so its tracking refs are behind
+	found, stale, err := checkRemoteSageoxExists(staleClone)
+	require.NoError(t, err)
+
+	// either found=true (if the commit object happened to be available) or stale=true
+	// the important thing is we don't return found=false, stale=false
+	if !found {
+		assert.True(t, stale, "expected stale=true when local tracking refs are behind remote")
+	}
+}

--- a/internal/api/repo_test.go
+++ b/internal/api/repo_test.go
@@ -470,3 +470,4 @@ func TestNotifyUninstall_ServerError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server error")
 }
+


### PR DESCRIPTION
## Summary

Follow-up to #75. Removes the `MergeRepo()` client method and related types/tests that called `POST /api/v1/repo/{repo_id}/merge`. The server endpoint exists but picks canonical repo by earliest UUIDv7 — which can conflict with the user's selection in `ox doctor --fix`. Local-only cleanup is the correct approach: the user chooses which registration to keep, and doctor updates `config.json` + removes orphaned markers without a server round-trip.

## Changes

- Remove `MergeRepo()`, `MergeRepoRequest`, `MergeRepoResponse`, `repoMergePath` from `internal/api/repo.go`
- Remove 4 merge API tests from `internal/api/repo_test.go`
- Simplify doctor fix flow in `cmd/ox/doctor_sageox.go` to call `cleanupDuplicateMarkers()` directly

## Test plan

- [ ] `make lint` — 0 issues
- [ ] All duplicate marker tests still pass (detection + both cleanup scenarios)

Co-Authored-By: SageOx <ox@sageox.ai>