### PR TITLE
Handle duplicate repo detection in ox init

### DIFF
--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -745,9 +745,18 @@ func runInit() error {
 			cli.PrintWarning(fmt.Sprintf("Could not save config: %v", err))
 		}
 	} else {
+		// handle duplicate detection: server found an existing repo with matching remote hashes
+		if resp.ExistingRepoID != "" && !initQuiet {
+			cli.PrintWarning(resp.DuplicateWarning)
+		}
+
 		// success - update config with all server-returned info
-		// repo_id may differ if server assigned canonical ID
+		// repo_id may differ if server assigned canonical ID or dedup matched existing repo
 		if resp.RepoID != "" && resp.RepoID != cfg.RepoID {
+			// rename local marker to match the canonical repo_id
+			if err := api.RenameRepoMarker(gitRoot, cfg.RepoID, resp.RepoID); err != nil {
+				slog.Debug("failed to rename repo marker after dedup", "error", err)
+			}
 			cfg.RepoID = resp.RepoID
 		}
 		if resp.TeamID != "" {

--- a/internal/api/redirect.go
+++ b/internal/api/redirect.go
@@ -78,7 +78,7 @@ func HandleRedirect(projectRoot string, info *RedirectInfo) error {
 
 	// rename marker file if repo changed
 	if info.Repo != nil {
-		if err := renameRepoMarker(projectRoot, info.Repo.From, info.Repo.To); err != nil {
+		if err := RenameRepoMarker(projectRoot, info.Repo.From, info.Repo.To); err != nil {
 			// log but don't fail - marker rename is best-effort
 			logger.Debug("failed to rename repo marker", "error", err)
 		}
@@ -110,9 +110,9 @@ func updateProjectConfig(projectRoot string, cfg *RedirectConfig) error {
 	return nil
 }
 
-// renameRepoMarker renames the .repo_* marker file from old ID to new ID using VCS
+// RenameRepoMarker renames the .repo_* marker file from old ID to new ID using VCS
 // and updates the repo_id value inside the marker file
-func renameRepoMarker(projectRoot, oldID, newID string) error {
+func RenameRepoMarker(projectRoot, oldID, newID string) error {
 	sageoxDir := filepath.Join(projectRoot, ".sageox")
 
 	// extract UUID suffix from IDs (repo_xxx -> xxx)

--- a/internal/api/redirect_test.go
+++ b/internal/api/redirect_test.go
@@ -90,7 +90,7 @@ func TestRenameRepoMarker_NoMarkerExists(t *testing.T) {
 	require.NoError(t, os.MkdirAll(sageoxDir, 0755))
 
 	// should not error when old marker doesn't exist
-	err := renameRepoMarker(tmpDir, "repo_oldid", "repo_newid")
+	err := RenameRepoMarker(tmpDir, "repo_oldid", "repo_newid")
 	assert.NoError(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestRenameRepoMarker_Success(t *testing.T) {
 	oldMarker := filepath.Join(sageoxDir, ".repo_oldid")
 	require.NoError(t, os.WriteFile(oldMarker, []byte(`{"id":"repo_oldid"}`), 0600))
 
-	err := renameRepoMarker(tmpDir, "repo_oldid", "repo_newid")
+	err := RenameRepoMarker(tmpDir, "repo_oldid", "repo_newid")
 	assert.NoError(t, err)
 
 	// old marker should be gone
@@ -129,7 +129,7 @@ func TestRenameRepoMarker_NewAlreadyExists(t *testing.T) {
 	require.NoError(t, os.WriteFile(oldMarker, []byte(`{"id":"repo_oldid"}`), 0600))
 	require.NoError(t, os.WriteFile(newMarker, []byte(`{"id":"repo_newid"}`), 0600))
 
-	err := renameRepoMarker(tmpDir, "repo_oldid", "repo_newid")
+	err := RenameRepoMarker(tmpDir, "repo_oldid", "repo_newid")
 	assert.NoError(t, err)
 
 	// old marker should be removed

--- a/internal/api/repo.go
+++ b/internal/api/repo.go
@@ -61,9 +61,11 @@ type RepoFingerprint struct {
 
 // RepoInitResponse represents the POST /api/v1/repo/init response
 type RepoInitResponse struct {
-	RepoID     string `json:"repo_id"`
-	TeamID     string `json:"team_id"`
-	WebBaseURL string `json:"web_base_url,omitempty"` // web dashboard base URL (for enterprise endpoints)
+	RepoID           string `json:"repo_id"`
+	TeamID           string `json:"team_id"`
+	WebBaseURL       string `json:"web_base_url,omitempty"`       // web dashboard base URL (for enterprise endpoints)
+	ExistingRepoID   string `json:"existing_repo_id,omitempty"`   // set when dedup matched a different repo_id
+	DuplicateWarning string `json:"duplicate_warning,omitempty"`  // human-readable warning for CLI display
 }
 
 // RepoUninstallRequest represents the POST /api/v1/repo/{repo_id}/uninstall request

--- a/internal/api/repo_test.go
+++ b/internal/api/repo_test.go
@@ -166,6 +166,70 @@ func TestRegisterRepo_Success_ReturnsResponse(t *testing.T) {
 	assert.Equal(t, "team_xyz", resp.TeamID)
 }
 
+func TestRegisterRepo_DuplicateDetection_ParsesExistingRepoFields(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"repo_id":"repo_existing",
+			"team_id":"team_xyz",
+			"existing_repo_id":"repo_existing",
+			"duplicate_warning":"This repository is already registered in this team as repo_existing. Using existing registration."
+		}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+	}
+
+	req := &RepoInitRequest{
+		RepoID: "repo_new_attempt",
+		Type:   "git",
+		InitAt: "2025-01-01T00:00:00Z",
+	}
+
+	resp, err := client.RegisterRepo(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "repo_existing", resp.RepoID)
+	assert.Equal(t, "team_xyz", resp.TeamID)
+	assert.Equal(t, "repo_existing", resp.ExistingRepoID)
+	assert.Contains(t, resp.DuplicateWarning, "already registered")
+}
+
+func TestRegisterRepo_NoDuplicate_ExistingRepoFieldsEmpty(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"repo_id":"repo_new","team_id":"team_xyz"}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+	}
+
+	req := &RepoInitRequest{
+		RepoID: "repo_new",
+		Type:   "git",
+		InitAt: "2025-01-01T00:00:00Z",
+	}
+
+	resp, err := client.RegisterRepo(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "repo_new", resp.RepoID)
+	assert.Empty(t, resp.ExistingRepoID)
+	assert.Empty(t, resp.DuplicateWarning)
+}
+
 // ============================================================================
 // GetDoctorIssues Tests
 // ======


### PR DESCRIPTION
## Summary

When `ox init` is called on a repo that's already registered in the same team, the server detects the duplicate via `repo_remote_hashes` and returns `existing_repo_id` and `duplicate_warning` fields. This PR teaches the CLI to handle these fields: it shows the warning to the user, renames the local marker file to match the canonical repo_id, and updates config to use the existing registration. This prevents orphaned marker files and provides clear feedback when a repo is already registered.

## Changes

- Add `ExistingRepoID` and `DuplicateWarning` fields to `RepoInitResponse`
- Export `RenameRepoMarker` for use during duplicate detection
- In `ox init`, when duplicate detected: show warning, rename marker, update config
- Add tests for both duplicate and non-duplicate cases

## Test Plan

- All 5178 existing tests pass
- New tests verify duplicate detection response parsing
- Marker rename tests pass

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added duplicate repository detection during initialization. When a duplicate is detected, users receive a warning message and the system automatically synchronizes local repository identifiers with the server's canonical ID.

* **Tests**
  * Added tests for duplicate repository detection and field parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->