### PR TITLE
feat: surface all team contexts to agents with slug lookup

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -7,11 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/sageox/ox/internal/agentinstance"
+	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/claude"
 	"github.com/sageox/ox/internal/cli"
@@ -21,6 +24,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/notification"
+	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/teamdocs"
 	"github.com/sageox/ox/internal/telemetry"
@@ -165,6 +169,23 @@ type teamContextInfo struct {
 	TeamDocs []teamdocs.TeamDoc `json:"team_docs,omitempty"`
 }
 
+// otherTeams lists non-primary team contexts available to the agent.
+// Included in prime output so agents know what other teams exist.
+// Agents MUST NOT read these unless the user explicitly asks by team name.
+type otherTeams struct {
+	Root  string           `json:"root"`  // base directory for all team contexts
+	Hint  string           `json:"hint"`  // instruction for agent: only read when asked
+	Teams []otherTeamEntry `json:"teams"` // sorted by content freshness
+}
+
+// otherTeamEntry is a compact reference to a non-primary team context.
+type otherTeamEntry struct {
+	Slug string `json:"slug"`          // kebab-case identifier for CLI arg
+	Name string `json:"name"`          // display name
+	Dir  string `json:"dir"`           // subdirectory under root
+	Age  string `json:"age,omitempty"` // content freshness from git log
+}
+
 // teamClaudeInstructions holds paths to team instruction files.
 // These files should be read immediately by Claude for team-specific configuration.
 type teamClaudeInstructions struct {
@@ -229,6 +250,7 @@ type agentPrimeOutput struct {
 	Important       string                     `json:"important"`                // always-present disambiguation of knowledge sources
 	TeamContext       *teamContextInfo `json:"team_context,omitempty"`        // team context if configured
 	TeamContextStatus string           `json:"team_context_status,omitempty"` // "synced", "syncing", or empty; set when team_context is null but sync is expected
+	OtherTeams        *otherTeams      `json:"other_teams,omitempty"`         // non-primary teams (nil when only 1 team)
 	UserNotification  string           `json:"user_notification,omitempty"`   // pre-built status summary for agent to relay to user
 	AgentTip          string           `json:"agent_tip,omitempty"`           // contextual tip for the agent itself (not for the user)
 	// Prime call tracking
@@ -551,6 +573,29 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		"(2) SESSIONS/LEDGER: repo-specific archive of prior AI coworker coding sessions for THIS repo only. Browse with: ox session list. " +
 		"These are unrelated — sessions are NOT discussions, and the ledger is NOT team context."
 
+	// discover other team contexts (non-primary)
+	primaryTeamID := ""
+	if teamCtx != nil {
+		primaryTeamID = teamCtx.TeamID
+	} else if projCfg, _ := config.LoadProjectConfig(projectRoot); projCfg != nil {
+		primaryTeamID = projCfg.TeamID
+	}
+	output.OtherTeams = discoverOtherTeamContexts(projectRoot, primaryTeamID)
+
+	// update Important text when multiple teams are available
+	totalTeams := 1 // primary
+	if output.OtherTeams != nil {
+		totalTeams += len(output.OtherTeams.Teams)
+	}
+	if totalTeams > 1 {
+		output.Important = fmt.Sprintf("SageOx has two SEPARATE knowledge sources. "+
+			"(1) TEAM CONTEXT: team-wide meetings, architecture decisions, and conventions shared across ALL repos. "+
+			"You have access to %d team contexts. Read with: ox agent team-ctx [slug]. "+
+			"(2) SESSIONS/LEDGER: repo-specific archive of prior AI coworker coding sessions for THIS repo only. "+
+			"Browse with: ox session list. "+
+			"These are unrelated — sessions are NOT discussions, and the ledger is NOT team context.", totalTeams)
+	}
+
 	// set team context status hint for agents when team context hasn't synced yet
 	if output.TeamContext == nil {
 		// check if we have a team ID configured (team context expected but not yet synced)
@@ -676,12 +721,12 @@ func loadProjectGuidance(projectRoot string) *ProjectGuidance {
 	}
 
 	// search paths in priority order
-	paths := []string{
+	searchPaths := []string{
 		filepath.Join(projectRoot, "AGENTS.md"),
 		filepath.Join(projectRoot, ".sageox", "AGENTS.md"),
 	}
 
-	for _, p := range paths {
+	for _, p := range searchPaths {
 		data, err := os.ReadFile(p)
 		if err != nil {
 			continue // file not found or not readable
@@ -779,7 +824,7 @@ func buildGuidance(teamCtx *teamContextInfo, ledger *ledgerInfo) *agentGuidance 
 	if teamCtx != nil {
 		cmds = append(cmds, intentCommand{
 			Intent:  "team context (team-wide, all repos): recorded meetings, architecture decisions, conventions",
-			Command: "ox agent team-ctx",
+			Command: "ox agent team-ctx [slug]",
 		})
 	}
 
@@ -1043,6 +1088,10 @@ func buildHumanSummary(output agentPrimeOutput) string {
 		}
 	}
 
+	if output.OtherTeams != nil {
+		fmt.Fprintf(&sb, "- **Other Teams:** %d additional team contexts available\n", len(output.OtherTeams.Teams))
+	}
+
 	if output.PrimeCallCount > 0 {
 		fmt.Fprintf(&sb, "- **Prime Call Count:** %d\n", output.PrimeCallCount)
 	}
@@ -1204,9 +1253,23 @@ func outputAgentPrimeText(cmd *cobra.Command, output agentPrimeOutput) error {
 	fmt.Fprintln(cmd.OutOrStdout(), "## Knowledge Sources")
 	fmt.Fprintln(cmd.OutOrStdout())
 	fmt.Fprintln(cmd.OutOrStdout(), "SageOx has two SEPARATE knowledge sources:")
-	fmt.Fprintln(cmd.OutOrStdout(), "  1. TEAM CONTEXT — team-wide meetings, decisions, conventions (all repos). Command: ox agent team-ctx")
+	fmt.Fprintln(cmd.OutOrStdout(), "  1. TEAM CONTEXT — team-wide meetings, decisions, conventions (all repos). Command: ox agent team-ctx [slug]")
 	fmt.Fprintln(cmd.OutOrStdout(), "  2. SESSIONS/LEDGER — repo-specific coding session archive (this repo only). Command: ox session list")
 	fmt.Fprintln(cmd.OutOrStdout(), "These are unrelated. Sessions are NOT discussions. The ledger is NOT team context.")
+
+	// other team contexts section
+	if output.OtherTeams != nil && len(output.OtherTeams.Teams) > 0 {
+		fmt.Fprintln(cmd.OutOrStdout())
+		fmt.Fprintf(cmd.OutOrStdout(), "## Other Team Contexts (%d)\n", len(output.OtherTeams.Teams))
+		fmt.Fprintln(cmd.OutOrStdout())
+		// column-aligned table
+		fmt.Fprintf(cmd.OutOrStdout(), "  %-20s %-30s %s\n", "slug", "name", "age")
+		for _, t := range output.OtherTeams.Teams {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %-20s %-30s %s\n", t.Slug, t.Name, t.Age)
+		}
+		fmt.Fprintln(cmd.OutOrStdout())
+		fmt.Fprintln(cmd.OutOrStdout(), "Read with: ox agent team-ctx <slug>")
+	}
 
 	// ledger / repo session history section
 	if output.Ledger != nil {
@@ -1531,6 +1594,160 @@ func discoverTeamContext(projectRoot string) *teamContextInfo {
 	}
 
 	return info
+}
+
+// discoverOtherTeamContexts returns lightweight entries for non-primary team contexts.
+// Returns nil when the user only belongs to one team.
+func discoverOtherTeamContexts(projectRoot string, primaryTeamID string) *otherTeams {
+	allTeams := config.FindAllTeamContexts(projectRoot)
+	if len(allTeams) == 0 {
+		return nil
+	}
+
+	// filter out primary team
+	var others []config.TeamContext
+	for _, tc := range allTeams {
+		if tc.TeamID == primaryTeamID {
+			continue
+		}
+		others = append(others, tc)
+	}
+	if len(others) == 0 {
+		return nil
+	}
+
+	// get endpoint for root path
+	ep := endpoint.GetForProject(projectRoot)
+	if ep == "" {
+		return nil
+	}
+	root := paths.TeamsDataDir(ep)
+
+	var entries []otherTeamEntry
+	for _, tc := range others {
+		slug := tc.Slug
+		if slug == "" {
+			slug = api.DeriveSlug(tc.TeamName)
+		}
+		if slug == "" {
+			slug = tc.TeamID
+		}
+
+		// compute content age from git log
+		age := teamContextAge(tc.Path)
+
+		// extract dir relative to root
+		dir := tc.TeamID
+		if rel, err := filepath.Rel(root, tc.Path); err == nil {
+			dir = rel
+		}
+
+		name := tc.TeamName
+		if name == "" {
+			name = tc.TeamID
+		}
+
+		entries = append(entries, otherTeamEntry{
+			Slug: slug,
+			Name: name,
+			Dir:  dir,
+			Age:  age,
+		})
+	}
+
+	// sort by content freshness (entries with age come first, newest first)
+	sortOtherTeamsByAge(entries)
+
+	return &otherTeams{
+		Root:  root,
+		Hint:  "Only read when user asks about a specific team by name: ox agent team-ctx <slug>",
+		Teams: entries,
+	}
+}
+
+// teamContextAge returns a human-readable age of the most recent content change
+// in a team context directory, based on git log.
+func teamContextAge(teamCtxPath string) string {
+	if teamCtxPath == "" {
+		return ""
+	}
+	if _, err := os.Stat(teamCtxPath); os.IsNotExist(err) {
+		return ""
+	}
+	cmd := exec.Command("git", "-C", teamCtxPath, "log", "-1", "--format=%ci")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	dateStr := strings.TrimSpace(string(output))
+	if dateStr == "" {
+		return ""
+	}
+	t, err := time.Parse("2006-01-02 15:04:05 -0700", dateStr)
+	if err != nil {
+		return ""
+	}
+	return formatAge(time.Since(t))
+}
+
+// formatAge returns a human-readable relative time string.
+func formatAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		m := int(d.Minutes())
+		if m == 1 {
+			return "1m ago"
+		}
+		return fmt.Sprintf("%dm ago", m)
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		if h == 1 {
+			return "1h ago"
+		}
+		return fmt.Sprintf("%dh ago", h)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "1d ago"
+		}
+		return fmt.Sprintf("%dd ago", days)
+	}
+}
+
+// sortOtherTeamsByAge sorts otherTeamEntry slices by content age.
+// Entries with a known age are sorted newest-first; entries without age go last.
+func sortOtherTeamsByAge(entries []otherTeamEntry) {
+	// parse age strings back to approximate durations for sorting
+	parseDuration := func(age string) time.Duration {
+		if age == "" {
+			return time.Duration(1<<63 - 1) // max duration, sort last
+		}
+		if age == "just now" {
+			return 0
+		}
+		// parse "Nm ago", "Nh ago", "Nd ago"
+		var n int
+		var unit string
+		if _, err := fmt.Sscanf(age, "%d%s", &n, &unit); err != nil {
+			return time.Duration(1<<63 - 1)
+		}
+		switch {
+		case strings.HasPrefix(unit, "m"):
+			return time.Duration(n) * time.Minute
+		case strings.HasPrefix(unit, "h"):
+			return time.Duration(n) * time.Hour
+		case strings.HasPrefix(unit, "d"):
+			return time.Duration(n) * 24 * time.Hour
+		default:
+			return time.Duration(1<<63 - 1)
+		}
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		return parseDuration(entries[i].Age) < parseDuration(entries[j].Age)
+	})
 }
 
 // discoverLedger checks whether the ledger exists and returns actionable guidance

--- a/cmd/ox/agent_team_ctx.go
+++ b/cmd/ox/agent_team_ctx.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
+	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -15,15 +17,19 @@ import (
 const recentDiscussionLimit = 15
 
 var agentTeamCtxCmd = &cobra.Command{
-	Use:   "team-ctx",
+	Use:   "team-ctx [slug]",
 	Short: "Output team context for AI agent planning",
 	Long: `Output team discussions and distilled context for AI agent planning.
+
+Without arguments: outputs the primary team's context (this repo's team).
+With a team slug: outputs that specific team's context.
 
 Lists the 15 most recent discussion files (read them for full detail),
 then outputs the distilled summary from agent-context/distilled-discussions.md.
 
 Output includes a content hash (team-ctx:<hash>) - if this marker is already
 in your context, you don't need to re-run this command.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentTeamCtx,
 }
 
@@ -33,9 +39,18 @@ func runAgentTeamCtx(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a SageOx project: %w", err)
 	}
 
-	tc := config.FindRepoTeamContext(projectRoot)
-	if tc == nil {
-		return fmt.Errorf("no team context configured for this project")
+	var tc *config.TeamContext
+
+	if len(args) > 0 {
+		tc = resolveTeamContext(projectRoot, args[0])
+		if tc == nil {
+			return fmt.Errorf("team context not found: %q (use ox agent prime to see available teams)", args[0])
+		}
+	} else {
+		tc = config.FindRepoTeamContext(projectRoot)
+		if tc == nil {
+			return fmt.Errorf("no team context configured for this project")
+		}
 	}
 
 	out := cmd.OutOrStdout()
@@ -50,6 +65,44 @@ func runAgentTeamCtx(cmd *cobra.Command, args []string) error {
 
 	if !hasDiscussions && !hasDistilled {
 		return fmt.Errorf("no team context available: no discussions or distilled context found in %s", tc.Path)
+	}
+
+	return nil
+}
+
+// resolveTeamContext finds a team context by slug, team ID, or name.
+// Resolution order: exact slug match -> exact team ID match -> case-insensitive name match.
+func resolveTeamContext(projectRoot, query string) *config.TeamContext {
+	allTeams := config.FindAllTeamContexts(projectRoot)
+	if len(allTeams) == 0 {
+		return nil
+	}
+
+	queryLower := strings.ToLower(strings.TrimSpace(query))
+
+	// pass 1: exact slug match
+	for i, tc := range allTeams {
+		slug := tc.Slug
+		if slug == "" {
+			slug = api.DeriveSlug(tc.TeamName)
+		}
+		if slug == queryLower {
+			return &allTeams[i]
+		}
+	}
+
+	// pass 2: exact team ID match
+	for i, tc := range allTeams {
+		if tc.TeamID == query {
+			return &allTeams[i]
+		}
+	}
+
+	// pass 3: case-insensitive name match
+	for i, tc := range allTeams {
+		if strings.EqualFold(tc.TeamName, query) {
+			return &allTeams[i]
+		}
 	}
 
 	return nil

--- a/internal/api/repos.go
+++ b/internal/api/repos.go
@@ -27,6 +27,7 @@ type RepoInfo struct {
 	URL    string `json:"url"`               // git clone URL
 	Type   string `json:"type"`              // "team-context" (ledgers use separate API)
 	TeamID string `json:"team_id,omitempty"` // team_xxx (present for team-context repos)
+	Slug   string `json:"slug,omitempty"`    // kebab-case team slug (server-provided)
 }
 
 // StableID returns the stable team identifier (team_xxx) for path construction and lookups.
@@ -36,9 +37,10 @@ func (r RepoInfo) StableID() string {
 
 // TeamMembership represents a team the user belongs to
 type TeamMembership struct {
-	ID   string `json:"id"`   // team_xxx
-	Name string `json:"name"` // display name
-	Role string `json:"role"` // "owner", "admin", "member"
+	ID   string `json:"id"`             // team_xxx
+	Name string `json:"name"`           // display name
+	Slug string `json:"slug,omitempty"` // kebab-case team slug
+	Role string `json:"role"`           // "owner", "admin", "member"
 }
 
 // ReposResponse represents the GET /api/v1/cli/repos response.
@@ -68,6 +70,7 @@ func (r *ReposResponse) TeamMembershipsFromRepos() []TeamMembership {
 		teams = append(teams, TeamMembership{
 			ID:   repo.StableID(),
 			Name: repo.Name,
+			Slug: repo.Slug,
 		})
 	}
 	return teams
@@ -101,11 +104,12 @@ type RepoDetailLedger struct {
 
 // RepoDetailTeamContext is a team context in the repo detail response.
 type RepoDetailTeamContext struct {
-	TeamID      string `json:"team_id"`      // team_xxx
-	Name        string `json:"name"`         // display name
-	Visibility  string `json:"visibility"`   // "public" or "private"
-	AccessLevel string `json:"access_level"` // "member" or "viewer"
-	RepoURL     string `json:"repo_url"`     // git clone URL
+	TeamID      string `json:"team_id"`               // team_xxx
+	Name        string `json:"name"`                  // display name
+	Slug        string `json:"slug,omitempty"`         // kebab-case team slug
+	Visibility  string `json:"visibility"`            // "public" or "private"
+	AccessLevel string `json:"access_level"`          // "member" or "viewer"
+	RepoURL     string `json:"repo_url"`              // git clone URL
 }
 
 // StableID returns the stable team identifier (team_xxx) for path construction and lookups.
@@ -116,6 +120,20 @@ func (r RepoDetailTeamContext) StableID() string {
 // IsReadOnly returns true if the user has viewer (read-only) access.
 func (r *RepoDetailResponse) IsReadOnly() bool {
 	return r.AccessLevel == "viewer"
+}
+
+// DeriveSlug generates a kebab-case slug from a display name.
+// Used as fallback when the server doesn't provide a slug.
+func DeriveSlug(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = strings.ReplaceAll(s, " ", "-")
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 // GetRepos calls GET /api/v1/cli/repos to fetch user's team context repos.

--- a/internal/config/local_config.go
+++ b/internal/config/local_config.go
@@ -63,6 +63,7 @@ func (c *LedgerConfig) HasLastSync() bool {
 type TeamContext struct {
 	TeamID   string    `toml:"team_id"`
 	TeamName string    `toml:"team_name"`
+	Slug     string    `toml:"slug,omitempty"`
 	Path     string    `toml:"path"`
 	LastSync time.Time `toml:"last_sync"`
 }
@@ -438,6 +439,62 @@ func IsRepoTeamContext(projectRoot, teamID string) bool {
 		return false
 	}
 	return projectCfg.TeamID == teamID
+}
+
+// FindAllTeamContexts returns all team contexts available to the user.
+// Primary source is LocalConfig.TeamContexts (populated by daemon).
+// Falls back to scanning paths.TeamsDataDir(endpoint) subdirectories.
+// Returns empty slice (not nil) if none found.
+func FindAllTeamContexts(projectRoot string) []TeamContext {
+	// try LocalConfig first (daemon-populated, authoritative)
+	localCfg, err := LoadLocalConfig(projectRoot)
+	if err == nil && localCfg != nil && len(localCfg.TeamContexts) > 0 {
+		var result []TeamContext
+		for _, tc := range localCfg.TeamContexts {
+			if tc.Path == "" {
+				continue
+			}
+			if _, err := os.Stat(tc.Path); err == nil {
+				result = append(result, tc)
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+	}
+
+	// fallback: scan TeamsDataDir for subdirectories
+	projectCfg, err := LoadProjectConfig(projectRoot)
+	if err != nil || projectCfg == nil {
+		return []TeamContext{}
+	}
+
+	ep := projectCfg.Endpoint
+	if ep == "" {
+		ep = endpoint.GetForProject(projectRoot)
+	}
+	if ep == "" {
+		return []TeamContext{}
+	}
+
+	teamsDir := paths.TeamsDataDir(ep)
+	entries, err := os.ReadDir(teamsDir)
+	if err != nil {
+		return []TeamContext{}
+	}
+
+	var result []TeamContext
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		teamPath := filepath.Join(teamsDir, entry.Name())
+		result = append(result, TeamContext{
+			TeamID: entry.Name(),
+			Path:   teamPath,
+		})
+	}
+	return result
 }
 
 // GetConfiguredEndpoints returns all unique endpoints configured for a project.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -353,6 +353,7 @@ func (d *Daemon) Start() error {
 						Exists:   ws.Exists,
 						TeamID:   ws.TeamID,
 						TeamName: ws.TeamName,
+						TeamSlug: ws.TeamSlug,
 						LastSync: ws.ConfigLastSync,
 						LastErr:  ws.LastErr,
 						Syncing:  ws.SyncInProgress,

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -156,6 +156,7 @@ type WorkspaceSyncStatus struct {
 	Exists   bool      `json:"exists"`               // whether path exists locally
 	TeamID   string    `json:"team_id,omitempty"`    // team ID (for team contexts)
 	TeamName string    `json:"team_name,omitempty"`  // team name (for team contexts)
+	TeamSlug string    `json:"team_slug,omitempty"` // kebab-case team slug
 	LastSync time.Time `json:"last_sync,omitempty"`  // last successful sync
 	LastErr  string    `json:"last_error,omitempty"` // last error message
 	Syncing  bool      `json:"syncing,omitempty"`    // currently syncing

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1028,6 +1028,7 @@ func (s *SyncScheduler) refreshCredentialsIfNeeded() {
 			Type:   repo.Type,
 			URL:    repo.URL,
 			TeamID: repo.StableID(),
+			Slug:   repo.Slug,
 		})
 	}
 
@@ -1093,6 +1094,7 @@ func (s *SyncScheduler) discoverTeams() {
 			Type:   repo.Type,
 			URL:    repo.URL,
 			TeamID: repo.StableID(),
+			Slug:   repo.Slug,
 		}
 		newRepos[entry.Name] = entry
 	}
@@ -1122,7 +1124,7 @@ func reposEqual(a, b map[string]gitserver.RepoEntry) bool {
 		if !ok {
 			return false
 		}
-		if va.Name != vb.Name || va.Type != vb.Type || va.URL != vb.URL || va.TeamID != vb.TeamID {
+		if va.Name != vb.Name || va.Type != vb.Type || va.URL != vb.URL || va.TeamID != vb.TeamID || va.Slug != vb.Slug {
 			return false
 		}
 	}

--- a/internal/daemon/workspace_registry.go
+++ b/internal/daemon/workspace_registry.go
@@ -34,6 +34,7 @@ type WorkspaceState struct {
 	// team-specific (only for team_context type)
 	TeamID   string `json:"team_id,omitempty"`
 	TeamName string `json:"team_name,omitempty"`
+	TeamSlug string `json:"team_slug,omitempty"` // kebab-case slug for CLI identifiers
 	CloneURL string `json:"clone_url,omitempty"` // git clone URL (from credentials)
 
 	// config (from config.local.toml)
@@ -264,6 +265,7 @@ func (r *WorkspaceRegistry) rebuildFromConfigLocked(cfg *config.LocalConfig) {
 
 		existing.TeamID = tc.TeamID
 		existing.TeamName = tc.TeamName
+		existing.TeamSlug = tc.Slug
 		existing.Path = tc.Path
 		existing.Endpoint = r.endpoint
 		existing.ConfigLastSync = tc.LastSync
@@ -274,6 +276,10 @@ func (r *WorkspaceRegistry) rebuildFromConfigLocked(cfg *config.LocalConfig) {
 			for _, repo := range creds.Repos {
 				if repo.Type == "team-context" && (repo.StableID() == tc.TeamID || repo.Name == tc.TeamName || repo.Name == tc.TeamID) {
 					existing.CloneURL = repo.URL
+					// backfill slug from credentials if not in config
+					if existing.TeamSlug == "" && repo.Slug != "" {
+						existing.TeamSlug = repo.Slug
+					}
 					break
 				}
 			}
@@ -317,6 +323,7 @@ func (r *WorkspaceRegistry) rebuildFromConfigLocked(cfg *config.LocalConfig) {
 
 			existing.TeamID = teamID
 			existing.TeamName = repo.Name
+			existing.TeamSlug = repo.Slug
 			existing.Endpoint = r.endpoint
 			// use centralized path: ~/.sageox/data/<endpoint>/teams/<team_id>/
 			existing.Path = paths.TeamContextDir(teamID, r.endpoint)
@@ -808,6 +815,7 @@ func (r *WorkspaceRegistry) RegisterTeamContextsFromAPI(teamContexts []api.RepoD
 			Type:     WorkspaceTypeTeamContext,
 			TeamID:   tc.TeamID,
 			TeamName: tc.Name,
+			TeamSlug: tc.Slug,
 			Endpoint: r.endpoint,
 			Path:     paths.TeamContextDir(tc.TeamID, r.endpoint),
 			CloneURL: tc.RepoURL,

--- a/internal/gitserver/credentials.go
+++ b/internal/gitserver/credentials.go
@@ -28,6 +28,7 @@ type RepoEntry struct {
 	Type   string `json:"type"`              // "team-context"
 	URL    string `json:"url"`               // git clone URL
 	TeamID string `json:"team_id,omitempty"` // stable team identifier (e.g., "team_jij1bg2btu")
+	Slug   string `json:"slug,omitempty"`    // kebab-case team slug (server-provided)
 }
 
 // StableID returns the stable team identifier (team_xxx) for path construction and lookups.


### PR DESCRIPTION
## Summary

Agents now discover all available team contexts during priming, with slug-based lookup for targeting specific teams. This solves the problem where agents couldn't find discussions from non-primary teams.

**Key changes:**
- Thread team `Slug` fields through entire stack (API structs → daemon → local config → IPC)
- `ox agent prime` emits compact `other_teams` list with slugs, display names, and content age (never inlines non-primary content)
- `ox agent team-ctx [slug]` now accepts optional positional arg to read any team's context
- Added `FindAllTeamContexts()` helper for discovering all available teams (daemon → config → filesystem fallback)
- Explicit agent guidance: "Only read when user asks by name"

**Agent UX:** Prime tells agent "you have access to 3 teams: primary, platform-team, data-eng" with paths. Agent does NOT proactively read others. User asks about platform-team, agent runs `ox agent team-ctx platform-team`. Done in one call.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added slug-based team identification for selecting and referencing specific team contexts in CLI commands
  - Agent Prime now discovers and displays all available team contexts within a project
  - Team slug metadata propagated throughout workspace sync status and API responses for consistent team identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->