### PR TITLE
Clone team contexts with --single-branch --branch main

### DIFF
--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -1554,7 +1554,12 @@ func cloneViaDaemon(cloneURL, targetPath, repoType, endpointURL string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	if err := gitserver.CloneFromURLWithEndpoint(ctx, cloneURL, targetPath, endpointURL, nil); err != nil {
+	// team contexts only need main branch
+	var cloneOpts *gitserver.CheckoutOptions
+	if repoType == "team_context" {
+		cloneOpts = &gitserver.CheckoutOptions{Branch: "main", SingleBranch: true}
+	}
+	if err := gitserver.CloneFromURLWithEndpoint(ctx, cloneURL, targetPath, endpointURL, cloneOpts); err != nil {
 		return fmt.Errorf("direct clone failed: %w", err)
 	}
 

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1520,7 +1520,13 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 
 	// git clone with progress
 	// note: git clone --progress sends progress to stderr, could parse it for more detailed updates
-	cloneCmd := exec.CommandContext(ctx, "git", "clone", "--quiet", cloneURL, payload.RepoPath)
+	// team contexts only need main branch — skip fetching other branches
+	cloneArgs := []string{"clone", "--quiet"}
+	if payload.RepoType != "ledger" {
+		cloneArgs = append(cloneArgs, "--single-branch", "--branch", "main")
+	}
+	cloneArgs = append(cloneArgs, cloneURL, payload.RepoPath)
+	cloneCmd := exec.CommandContext(ctx, "git", cloneArgs...)
 	if output, err := cloneCmd.CombinedOutput(); err != nil {
 		// sanitize output to prevent credential leaks (clone URL may contain PAT token)
 		sanitizedOutput := gitutil.SanitizeOutput(string(output))

--- a/internal/gitserver/checkout.go
+++ b/internal/gitserver/checkout.go
@@ -34,6 +34,9 @@ type CheckoutOptions struct {
 
 	// Branch specifies the branch to checkout (empty = default branch)
 	Branch string
+
+	// SingleBranch clones only the specified branch (or default branch if Branch is empty)
+	SingleBranch bool
 }
 
 // DefaultCheckoutPath returns the default checkout path for a repo.
@@ -121,6 +124,9 @@ func cloneRepo(ctx context.Context, repoURL, path string, creds *GitCredentials,
 	if opts != nil {
 		if opts.Depth > 0 {
 			args = append(args, "--depth", fmt.Sprintf("%d", opts.Depth))
+		}
+		if opts.SingleBranch {
+			args = append(args, "--single-branch")
 		}
 		if opts.Branch != "" {
 			args = append(args, "--branch", opts.Branch)


### PR DESCRIPTION
## Summary
Team contexts only use the `main` branch, so cloning all branches wastes bandwidth and time. This change adds `--single-branch --branch main` to team context clones across three paths: the daemon's primary checkout handler, the gitserver fallback, and the doctor CLI fallback.

## Changes
- **daemon/sync.go**: Dynamically build clone args, adding `--single-branch --branch main` when `RepoType != "ledger"`
- **gitserver/checkout.go**: Add `SingleBranch` field to `CheckoutOptions` and wire it into git command builder
- **doctor_git_repos.go**: Pass `{Branch: "main", SingleBranch: true}` for team_context repos in fallback clone path

Ledger clones remain unchanged and continue fetching all branches.

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Repository cloning behavior has been optimized for improved efficiency and performance. Team context repositories and non-ledger repositories now fetch only the main branch during clone operations instead of retrieving all available branches. This reduces data transfer overhead, decreases clone times, and improves overall system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->