### PR TITLE
fix(doctor): make warnings actionable for non-technical users

### DIFF
--- a/cmd/ox/doctor_sageox.go
+++ b/cmd/ox/doctor_sageox.go
@@ -708,8 +708,9 @@ func checkCloudDoctor() []checkResult {
 	if err != nil || resp == nil {
 		// show warning that extended checks are unavailable
 		return []checkResult{
-			WarningCheck("Cloud doctor", "unavailable",
-				"Extended cloud-side health checks could not be performed"),
+			WarningCheck("Cloud doctor", "skipped",
+				"Could not reach SageOx cloud for extended health checks. This is normal\n"+
+					"        if you're offline or the service is temporarily unavailable. No action needed."),
 		}
 	}
 

--- a/cmd/ox/doctor_sageox_test.go
+++ b/cmd/ox/doctor_sageox_test.go
@@ -1449,8 +1449,8 @@ func TestCheckCloudDoctor_HTTP500_ReturnsWarning(t *testing.T) {
 	if !result.warning {
 		t.Error("expected warning=true for unavailable cloud doctor")
 	}
-	if !strings.Contains(result.message, "unavailable") {
-		t.Errorf("expected message to mention 'unavailable', got %q", result.message)
+	if !strings.Contains(result.message, "skipped") {
+		t.Errorf("expected message to mention 'skipped', got %q", result.message)
 	}
 }
 

--- a/cmd/ox/doctor_team.go
+++ b/cmd/ox/doctor_team.go
@@ -251,9 +251,10 @@ func checkTeamAgentsMD(tc config.TeamContext) checkResult {
 	if os.IsNotExist(err) {
 		// AGENTS.md is critical - this is a warning, not a failure
 		return WarningCheck(name, "missing",
-			"Team context has no AGENTS.md file. This file is critical for establishing\n"+
-				"        team norms and conventions that guide AI agent planning.\n"+
-				"        Create: "+agentsMDPath)
+			"AGENTS.md tells AI coworkers your team's conventions (coding style, review\n"+
+				"        process, preferred tools). Without it, AI coworkers start each session\n"+
+				"        with no team context. Visit https://sageox.ai to add team norms, or\n"+
+				"        create the file manually at: "+agentsMDPath)
 	} else if err != nil {
 		return WarningCheck(name, "unreadable", fmt.Sprintf("Cannot read: %v", err))
 	}


### PR DESCRIPTION
## Summary

- `Team AGENTS.md (missing)`: rewritten to explain what the file does ("tells AI coworkers your team's conventions"), the consequence of missing it, and actionable next steps (visit sageox.ai or create the file manually)
- `Cloud doctor (unavailable)`: renamed to "skipped", clarifies this is normal when offline and explicitly says no action is needed

Addresses user feedback that doctor warnings showed raw file paths with no explanation of what to do next.

Co-authored-by: SageOx <ox@sageox.ai>

---

**Session Recording:** [View session](https://sageox.ai/repo/repo_019c5812-01e9-7b7d-b5b1-321c471c9777/sessions/2026-03-01T16-23-ryan-OxSTUT/view)