### PR TITLE
fix: use team_id instead of repo_id for import notification

### DIFF
--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -281,8 +281,9 @@ func runImport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("commit and push: %w", err)
 	}
 
-	// fire-and-forget cloud notification
-	notifyImport(projectRoot, ep, meta)
+	// fire-and-forget cloud notification — uses team_id since imports
+	// target team contexts, not project repos
+	notifyImport(tc.TeamID, ep, meta)
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Imported: %s\nPath: %s\n", title, relDocDir)
 	return nil
@@ -543,11 +544,11 @@ func slugify(s string) string {
 }
 
 // notifyImport sends a fire-and-forget notification to the cloud about a new import.
+// Uses team_id since imports target team contexts, not project repos.
 // Failures are logged but never block the import.
-func notifyImport(projectRoot, ep string, meta docMeta) {
-	projCfg, err := config.LoadProjectConfig(projectRoot)
-	if err != nil || projCfg.RepoID == "" {
-		slog.Debug("skipping import notification, no repo_id", "error", err)
+func notifyImport(teamID, ep string, meta docMeta) {
+	if teamID == "" {
+		slog.Debug("skipping import notification, no team_id")
 		return
 	}
 
@@ -557,8 +558,8 @@ func notifyImport(projectRoot, ep string, meta docMeta) {
 		return
 	}
 
-	client := api.NewRepoClientForProject(projectRoot).WithAuthToken(storedToken.AccessToken)
-	if err := client.NotifyImport(projCfg.RepoID, &meta); err != nil {
+	client := api.NewRepoClientWithEndpoint(ep).WithAuthToken(storedToken.AccessToken)
+	if err := client.NotifyImport(teamID, &meta); err != nil {
 		slog.Warn("import cloud notification failed", "error", err)
 	}
 }

--- a/internal/api/repo.go
+++ b/internal/api/repo.go
@@ -87,10 +87,11 @@ type MergeRepoResponse struct {
 }
 
 // ImportNotification is the POST /api/v1/git/import request body.
-// The Metadata field is passed as-is (json.RawMessage) to avoid coupling
-// the API package to the docMeta struct in cmd/ox.
+// Imports target a team context (not a project repo), so team_id is the
+// primary identifier. The Metadata field is passed as-is (json.RawMessage)
+// to avoid coupling the API package to the docMeta struct in cmd/ox.
 type ImportNotification struct {
-	RepoID   string          `json:"repo_id"`
+	TeamID   string          `json:"team_id"`
 	Metadata json.RawMessage `json:"metadata"`
 }
 
@@ -453,16 +454,17 @@ func (c *RepoClient) MergeRepo(repoID string, markers map[string]json.RawMessage
 }
 
 // NotifyImport sends a fire-and-forget notification about a new document import.
+// Imports target a team context, so teamID identifies where the document lives.
 // The metadata argument should be JSON-marshalable (typically the docMeta struct).
 // Returns nil on network error, 404, or any non-2xx — never fails the caller's operation.
-func (c *RepoClient) NotifyImport(repoID string, metadata any) error {
+func (c *RepoClient) NotifyImport(teamID string, metadata any) error {
 	metaBytes, err := json.Marshal(metadata)
 	if err != nil {
 		return fmt.Errorf("marshal metadata: %w", err)
 	}
 
 	reqBody := ImportNotification{
-		RepoID:   repoID,
+		TeamID:   teamID,
 		Metadata: metaBytes,
 	}
 


### PR DESCRIPTION
## Summary

The import cloud notification (`POST /api/v1/git/import`) was incorrectly sending `repo_id` (project repo) instead of `team_id` (team context). Imports target team contexts, not project repos — and an import could happen for a team without any project repo checked out.

- **`ImportNotification.RepoID`** → **`ImportNotification.TeamID`**
- **`NotifyImport(repoID, ...)`** → **`NotifyImport(teamID, ...)`**
- Caller passes `tc.TeamID` directly instead of loading `ProjectConfig` just to get `RepoID`
- Removed unnecessary `config.LoadProjectConfig` dependency from `notifyImport()`

## Updated API contract for server team

```
POST /api/v1/git/import
Authorization: Bearer <token>

{
  "team_id": "team_jihjpfkt8b",
  "metadata": { ... docMeta ... }
}
```

## Test plan
- [ ] `go build ./...` compiles
- [ ] Existing import integration tests pass
- [ ] Server team implements endpoint accepting `team_id`

Co-Authored-By: SageOx <ox@sageox.ai>