### PR TITLE
feat(session): add workspace path and branch to session status (#112)

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sageox/ox/internal/doctor"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/repotools"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	sessionhtml "github.com/sageox/ox/internal/session/html"
@@ -157,11 +158,13 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 
 	// start recording with agent ID from session
 	opts := session.StartRecordingOptions{
-		AgentID:     inst.AgentID,
-		AdapterName: adapterName,
-		SessionFile: sessionFile,
-		Title:       title,
-		Username:    getSessionUsername(),
+		AgentID:       inst.AgentID,
+		AdapterName:   adapterName,
+		SessionFile:   sessionFile,
+		Title:         title,
+		Username:      getSessionUsername(),
+		WorkspacePath: projectRoot,
+		Branch:        repotools.GetCurrentBranch(projectRoot),
 	}
 
 	state, err := session.StartRecording(projectRoot, opts)

--- a/cmd/ox/session_status.go
+++ b/cmd/ox/session_status.go
@@ -30,28 +30,32 @@ Examples:
 
 // sessionStatusOutput is the JSON output format for session status.
 type sessionStatusOutput struct {
-	Recording    bool                    `json:"recording"`
-	Guidance     string                  `json:"guidance,omitempty"`
-	Count        int                     `json:"count,omitempty"`
-	Sessions     []sessionRecordingEntry `json:"sessions,omitempty"`
-	Title        string                  `json:"title,omitempty"`
-	DurationSecs int                     `json:"duration_seconds,omitempty"`
-	Duration     string                  `json:"duration,omitempty"`
-	Agent        string                  `json:"agent,omitempty"`
-	AgentID      string                  `json:"agent_id,omitempty"`
-	SessionFile  string                  `json:"session_file,omitempty"`
-	StartedAt    string                  `json:"started_at,omitempty"`
+	Recording     bool                    `json:"recording"`
+	Guidance      string                  `json:"guidance,omitempty"`
+	Count         int                     `json:"count,omitempty"`
+	Sessions      []sessionRecordingEntry `json:"sessions,omitempty"`
+	Title         string                  `json:"title,omitempty"`
+	DurationSecs  int                     `json:"duration_seconds,omitempty"`
+	Duration      string                  `json:"duration,omitempty"`
+	Agent         string                  `json:"agent,omitempty"`
+	AgentID       string                  `json:"agent_id,omitempty"`
+	SessionFile   string                  `json:"session_file,omitempty"`
+	StartedAt     string                  `json:"started_at,omitempty"`
+	WorkspacePath string                  `json:"workspace_path,omitempty"`
+	Branch        string                  `json:"branch,omitempty"`
 }
 
 // sessionRecordingEntry represents one active recording in the multi-session output.
 type sessionRecordingEntry struct {
-	AgentID      string `json:"agent_id"`
-	Title        string `json:"title,omitempty"`
-	Agent        string `json:"agent,omitempty"`
-	DurationSecs int    `json:"duration_seconds"`
-	Duration     string `json:"duration"`
-	StartedAt    string `json:"started_at"`
-	SessionFile  string `json:"session_file,omitempty"`
+	AgentID       string `json:"agent_id"`
+	Title         string `json:"title,omitempty"`
+	Agent         string `json:"agent,omitempty"`
+	DurationSecs  int    `json:"duration_seconds"`
+	Duration      string `json:"duration"`
+	StartedAt     string `json:"started_at"`
+	SessionFile   string `json:"session_file,omitempty"`
+	WorkspacePath string `json:"workspace_path,omitempty"`
+	Branch        string `json:"branch,omitempty"`
 }
 
 func init() {
@@ -120,16 +124,18 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 
 		if jsonOutput {
 			output := sessionStatusOutput{
-				Recording:    true,
-				Guidance:     "Run 'ox agent <id> session stop' to save the recording",
-				Count:        1,
-				Title:        state.Title,
-				DurationSecs: int(duration.Seconds()),
-				Duration:     durationStr,
-				Agent:        state.AdapterName,
-				AgentID:      state.AgentID,
-				SessionFile:  state.SessionFile,
-				StartedAt:    state.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+				Recording:     true,
+				Guidance:      "Run 'ox agent <id> session stop' to save the recording",
+				Count:         1,
+				Title:         state.Title,
+				DurationSecs:  int(duration.Seconds()),
+				Duration:      durationStr,
+				Agent:         state.AdapterName,
+				AgentID:       state.AgentID,
+				SessionFile:   state.SessionFile,
+				StartedAt:     state.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+				WorkspacePath: state.WorkspacePath,
+				Branch:        state.Branch,
 			}
 			return outputJSON(output)
 		}
@@ -145,6 +151,12 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 		if state.AgentID != "" {
 			fmt.Printf("  Agent ID: %s\n", state.AgentID)
 		}
+		if state.WorkspacePath != "" {
+			fmt.Printf("  Workspace: %s\n", state.WorkspacePath)
+		}
+		if state.Branch != "" {
+			fmt.Printf("  Branch:   %s\n", state.Branch)
+		}
 		fmt.Println()
 		fmt.Println(cli.StyleDim.Render("Run 'ox agent <id> session stop' to save the recording"))
 		return nil
@@ -156,13 +168,15 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 		for _, s := range states {
 			d := s.Duration()
 			entries = append(entries, sessionRecordingEntry{
-				AgentID:      s.AgentID,
-				Title:        s.Title,
-				Agent:        s.AdapterName,
-				DurationSecs: int(d.Seconds()),
-				Duration:     formatDurationHuman(d),
-				StartedAt:    s.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
-				SessionFile:  s.SessionFile,
+				AgentID:       s.AgentID,
+				Title:         s.Title,
+				Agent:         s.AdapterName,
+				DurationSecs:  int(d.Seconds()),
+				Duration:      formatDurationHuman(d),
+				StartedAt:     s.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+				SessionFile:   s.SessionFile,
+				WorkspacePath: s.WorkspacePath,
+				Branch:        s.Branch,
 			})
 		}
 		return outputJSON(sessionStatusOutput{
@@ -194,6 +208,12 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("    Agent:   %s\n", state.AdapterName)
 		fmt.Printf("    Started: %s\n", state.StartedAt.Format("15:04:05"))
+		if state.WorkspacePath != "" {
+			fmt.Printf("    Workspace: %s\n", state.WorkspacePath)
+		}
+		if state.Branch != "" {
+			fmt.Printf("    Branch:  %s\n", state.Branch)
+		}
 	}
 
 	fmt.Println()

--- a/internal/repotools/service.go
+++ b/internal/repotools/service.go
@@ -172,3 +172,14 @@ func IsPublicRepo() (bool, error) {
 
 	return false, nil
 }
+
+// GetCurrentBranch returns the current git branch for the given directory.
+// Returns empty string on any error (best-effort).
+func GetCurrentBranch(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -37,6 +37,8 @@ type RecordingState struct {
 	LastReminderSeq  int       `json:"last_reminder_seq"`
 	ReminderInterval int       `json:"reminder_interval"`
 	FilterMode       string    `json:"filter_mode,omitempty"` // "infra" or "all" - controls event filtering
+	WorkspacePath    string    `json:"workspace_path,omitempty"` // git root / project directory
+	Branch           string    `json:"branch,omitempty"`         // git branch at recording start
 
 	// Parent-child session tracking for subagent workflows
 	// When a parent spawns subagents, each subagent can report its session
@@ -261,6 +263,8 @@ type StartRecordingOptions struct {
 	RepoContextPath  string // path to repo context directory (for storing sessions)
 	ReminderInterval int    // defaults to DefaultReminderInterval if 0
 	FilterMode       string // "infra" or "all" - controls event filtering on stop
+	WorkspacePath    string // git root / project directory
+	Branch           string // git branch at recording start
 
 	// Parent session tracking for subagent workflows
 	ParentSessionPath string // path to parent's session folder (optional)
@@ -352,6 +356,8 @@ func StartRecording(projectRoot string, opts StartRecordingOptions) (*RecordingS
 		LastReminderSeq:   0,
 		ReminderInterval:  reminderInterval,
 		FilterMode:        opts.FilterMode,
+		WorkspacePath:     opts.WorkspacePath,
+		Branch:            opts.Branch,
 		ParentSessionPath: opts.ParentSessionPath,
 		ParentAgentID:     opts.ParentAgentID,
 	}


### PR DESCRIPTION
## Summary

Added `workspace_path` and `branch` to session recording state and `ox session status` output, making it easy to identify which workspace and git branch each active recording belongs to — especially useful when running multiple agents in parallel via Conductor.

## Changes

- **`internal/session/recording.go`**: Added `WorkspacePath` and `Branch` fields to `RecordingState` and `StartRecordingOptions` structs
- **`internal/repotools/service.go`**: Added `GetCurrentBranch(dir)` helper (consolidates existing `git rev-parse --abbrev-ref HEAD` pattern)
- **`cmd/ox/agent_session.go`**: Populates workspace path and branch when starting a recording
- **`cmd/ox/session_status.go`**: Displays workspace and branch in both human-readable and JSON output (single and multi-recording cases)

## Test Plan

- `make test` passes (all existing tests + new fields)
- `make build` succeeds
- `ox agent session start` saves `workspace_path` and `branch` to `.recording.json`
- `ox session status` displays workspace and branch in output
- `ox session status --json` includes both fields

## Session Recording

[View session recording](https://sageox.ai/repo/repo_019c5812-01e9-7b7d-b5b1-321c471c9777/sessions/2026-03-03T15-20-ryan-OxdbAD/view)

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session status output now displays workspace path and git branch information for recordings in both JSON and text formats.
  * Automatic capture of workspace and branch metadata when starting recording sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->