### PR TITLE
feat(import): add --team flag for explicit team targeting

### DIFF
--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -56,7 +56,7 @@ func init() {
 	importCmd.Flags().StringVar(&importFlags.text, "text", "", "path to pre-extracted text/markdown for indexing")
 	importCmd.Flags().StringVar(&importFlags.date, "date", "", "document date for filing (YYYY-MM-DD, default: file mtime)")
 	importCmd.Flags().BoolVar(&importFlags.force, "force", false, "re-import even if content hash already exists")
-	importCmd.Flags().StringVar(&importFlags.team, "team", "", "team slug, ID, or name (default: auto-discover from repo)")
+	importCmd.Flags().StringVar(&importFlags.team, "team", "", "team ID (or slug/name when inside a repo)")
 }
 
 // docMeta is the metadata.json schema for imported documents.


### PR DESCRIPTION
## Summary

Add `--team` flag to `ox import` command, enabling explicit team targeting and working outside repos.

## Changes

- **`--team` flag**: Optional flag to specify team by slug, ID, or name
- **Auto-discovery chain**: Inside repo (project team) → explicit `--team` flag → single team (when outside repo) → error
- **Works outside repos**: Import documents from anywhere with `--team`, not just inside initialized repos
- **Endpoint fallback**: Resolves endpoint from project config, `SAGEOX_ENDPOINT` env var, or global default

## Usage

```bash
ox import report.pdf --team my-team         # explicit team
ox import report.pdf                        # auto-discovers (inside repo)
cd /tmp && ox import report.pdf --team foo  # works outside a repo
```

## Test plan

- [x] Compiles with `go build ./cmd/ox/`
- [x] Help text shows usage examples
- [x] Respects `--team` flag override
- [x] Falls back to single-team auto-discovery outside repo
- [x] Endpoint resolution works without project root

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --team flag to explicitly specify a team during import.
  * Endpoint-aware team resolution and automatic team discovery when --team is omitted.

* **Bug Fixes / Improvements**
  * Import flow no longer requires a project root when --team is used.
  * More reliable endpoint handling for import/push operations.
  * Improved error messages with clearer guidance when team resolution fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->