### PR TITLE
fix(session): validate session file is regular file before reading

### DIFF
--- a/internal/session/adapters/claude_code.go
+++ b/internal/session/adapters/claude_code.go
@@ -101,10 +101,11 @@ func (a *ClaudeCodeAdapter) Detect() bool {
 // It searches through all project directories for JSONL files modified after 'since',
 // then scans for content matching the agentID (from ox agent prime output).
 func (a *ClaudeCodeAdapter) FindSessionFile(agentID string, since time.Time) (string, error) {
-	projectsDir := filepath.Join(a.claudeDir(), "projects")
-	if projectsDir == "" {
+	claudeDir := a.claudeDir()
+	if claudeDir == "" {
 		return "", ErrSessionNotFound
 	}
+	projectsDir := filepath.Join(claudeDir, "projects")
 
 	// get current working directory to find project-specific sessions
 	cwd, err := os.Getwd()
@@ -211,6 +212,14 @@ func (a *ClaudeCodeAdapter) ReadMetadata(sessionPath string) (*SessionMetadata, 
 	}
 	defer f.Close()
 
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat session file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("session path is not a regular file: %s", sessionPath)
+	}
+
 	meta := &SessionMetadata{}
 	scanner := bufio.NewScanner(f)
 	buf := make([]byte, 0, 64*1024)
@@ -262,6 +271,14 @@ func (a *ClaudeCodeAdapter) Read(sessionPath string) ([]RawEntry, error) {
 		return nil, fmt.Errorf("failed to open session file: %w", err)
 	}
 	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat session file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("session path is not a regular file: %s", sessionPath)
+	}
 
 	var entries []RawEntry
 	scanner := bufio.NewScanner(f)

--- a/internal/session/adapters/claude_code_test.go
+++ b/internal/session/adapters/claude_code_test.go
@@ -1011,3 +1011,23 @@ func TestClaudeCodeAdapter_ReadMetadata_NoModel(t *testing.T) {
 	assert.Equal(t, "1.0.3", meta.AgentVersion)
 	assert.Empty(t, meta.Model)
 }
+
+func TestClaudeCodeAdapter_Read_DirectoryPath(t *testing.T) {
+	// regression: Read() must reject directory paths (ox-5eu5)
+	adapter := &ClaudeCodeAdapter{}
+	dir := t.TempDir()
+
+	_, err := adapter.Read(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+}
+
+func TestClaudeCodeAdapter_ReadMetadata_DirectoryPath(t *testing.T) {
+	// regression: ReadMetadata() must reject directory paths (ox-5eu5)
+	adapter := &ClaudeCodeAdapter{}
+	dir := t.TempDir()
+
+	_, err := adapter.ReadMetadata(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+}

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -344,6 +344,17 @@ func StartRecording(projectRoot string, opts StartRecordingOptions) (*RecordingS
 		sessionFile = filepath.Join(sessionPath, "raw.jsonl")
 	}
 
+	// validate session file is a regular file (not a directory)
+	if opts.SessionFile != "" {
+		info, err := os.Stat(opts.SessionFile)
+		if err != nil {
+			return nil, fmt.Errorf("session file not accessible: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("session file is not a regular file: %s", opts.SessionFile)
+		}
+	}
+
 	state := &RecordingState{
 		AgentID:           opts.AgentID,
 		AdapterName:       opts.AdapterName,

--- a/internal/session/recording_test.go
+++ b/internal/session/recording_test.go
@@ -325,10 +325,14 @@ func TestStartRecording(t *testing.T) {
 		cacheDir := t.TempDir()
 		projectRoot := setupRecordingTest(t, cacheDir)
 
+		// create a real session file for validation
+		sessionFile := filepath.Join(t.TempDir(), "session.jsonl")
+		require.NoError(t, os.WriteFile(sessionFile, []byte("{}\n"), 0644))
+
 		opts := StartRecordingOptions{
 			AgentID:     "OxA1b2",
 			AdapterName: "claude-code",
-			SessionFile: "/path/to/session.jsonl",
+			SessionFile: sessionFile,
 			Title:       "Test recording",
 			Username:    "testuser",
 			// no RepoContextPath - uses XDG cache via repo_id
@@ -426,6 +430,23 @@ func TestStartRecording(t *testing.T) {
 		recordingPath := filepath.Join(firstState.SessionPath, recordingFile)
 		_, err = os.Stat(recordingPath)
 		assert.False(t, os.IsNotExist(err), "original .recording.json must not be deleted")
+	})
+
+	t.Run("rejects directory as session file", func(t *testing.T) {
+		// regression: directory path stored as SessionFile caused read failures (ox-5eu5)
+		cacheDir := t.TempDir()
+		projectRoot := setupRecordingTest(t, cacheDir)
+
+		opts := StartRecordingOptions{
+			AgentID:     "OxA1b2",
+			AdapterName: "claude-code",
+			SessionFile: t.TempDir(), // a directory, not a file
+			Username:    "testuser",
+		}
+
+		_, err := StartRecording(projectRoot, opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a regular file")
 	})
 
 	t.Run("session name from state matches GetSessionName", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fixes ox-5eu5**: `ox session stop` failed with `read /Users/.../.claude/projects: is a directory` because `FindSessionFile()` returned a directory path, `StartRecording()` stored it without validation, and `Read()` opened it (Unix allows `os.Open` on dirs) but `bufio.Scanner` failed
- Adds `IsRegular()` file-type validation at 3 defense-in-depth layers
- Includes 3 regression tests that reproduce the exact failure

## Changes

### Fix 1: Dead check in `FindSessionFile()` (`claude_code.go:104`)
`filepath.Join()` never returns `""`, so the guard was dead code. Now checks `claudeDir()` return value directly.

### Fix 2: `Read()` and `ReadMetadata()` (`claude_code.go:272,212`)
Added `f.Stat()` + `IsRegular()` after `os.Open()` — directories are rejected with a clear error instead of a confusing `bufio.Scanner` failure.

### Fix 3: `StartRecording()` (`recording.go:349`)
Added `os.Stat()` + `IsRegular()` validation before persisting `SessionFile` to `.recording.json`, preventing bad paths from being stored in the first place.

```mermaid
flowchart LR
    A[FindSessionFile] -->|path| B[StartRecording]
    B -->|persists to .recording.json| C[Read / ReadMetadata]
    
    style A fill:#fdd,stroke:#c33
    style B fill:#fdd,stroke:#c33
    style C fill:#fdd,stroke:#c33
    
    A -.- A1["Fix 1: check claudeDir() != empty"]
    B -.- B1["Fix 2: validate IsRegular before storing"]
    C -.- C1["Fix 3: validate IsRegular before scanning"]
```

## Regression Tests

| Test | What it catches |
|------|----------------|
| `TestClaudeCodeAdapter_Read_DirectoryPath` | `Read()` given a directory path → error |
| `TestClaudeCodeAdapter_ReadMetadata_DirectoryPath` | `ReadMetadata()` given a directory path → error |
| `TestStartRecording/rejects_directory_as_session_file` | `StartRecording()` given a directory as SessionFile → error |

## Follow-up

Codebase audit found 3 more locations with the same `os.Open` → `bufio.Scanner` pattern lacking `IsRegular()` checks. Filed as **P1 epic ox-83zm** with child issues:
- **ox-o347**: `teamdocs/discover.go` — `extractTitleFromContent`, `extractDescriptionFromContent`
- **ox-a7gd**: `daemon/heartbeat_file.go` — `readHeartbeatsFromPath`
- **ox-0r7y**: `docs/postprocess.go` — `transformFile`

## Test plan

- [x] `go test ./internal/session/... -count=1` — all pass
- [x] `go test ./internal/session/adapters/... -count=1` — all pass
- [x] New regression tests fail without the fix, pass with it

## Session Recording
[View session recording](https://sageox.ai/repo/repo_019c5812-01e9-7b7d-b5b1-321c471c9777/sessions/2026-03-03T15-43-user-OxHCjL/view)

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened session file validation to ensure files are regular files, rejecting directories with clear error messages. Enhanced file accessibility checks before operations.

* **Tests**
  * Added tests validating rejection of directory paths and confirming proper session file validation across multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->