### PR TITLE
fix(resilience): harden file I/O, clone recovery, and credential safety

### DIFF
--- a/cmd/ox/doctor_backup_cleanup.go
+++ b/cmd/ox/doctor_backup_cleanup.go
@@ -18,13 +18,18 @@ import (
 // CheckSlugBackupCleanup is the slug for the backup directory cleanup check.
 const CheckSlugBackupCleanup = "backup-cleanup"
 
+// staleBackupThreshold is the minimum age a .bak directory must have before
+// it is flagged for cleanup. Recent backups may still be needed if a clone
+// retry is in progress.
+const staleBackupThreshold = 7 * 24 * time.Hour
+
 func init() {
 	RegisterDoctorCheck(&DoctorCheck{
 		Slug:        CheckSlugBackupCleanup,
 		Name:        "Backup directories",
 		Category:    "Git Repository Health",
 		FixLevel:    FixLevelSuggested,
-		Description: "Detects and cleans up .bak.* directories left by failed clone operations",
+		Description: "Detects and cleans up stale .bak.* directories (older than 7 days) left by failed clone operations",
 		Run: func(fix bool) checkResult {
 			return checkBackupDirectories(fix)
 		},
@@ -52,7 +57,17 @@ func checkBackupDirectories(fix bool) checkResult {
 		return SkippedCheck("Backup directories", "not in git repo", "")
 	}
 
-	backups := discoverBackupDirs(gitRoot)
+	allBackups := discoverBackupDirs(gitRoot)
+
+	// filter to only stale backups (older than threshold)
+	now := time.Now()
+	var backups []backupDirInfo
+	for _, b := range allBackups {
+		if now.Sub(b.timestamp) >= staleBackupThreshold {
+			backups = append(backups, b)
+		}
+	}
+
 	if len(backups) == 0 {
 		return PassedCheck("Backup directories", "none found")
 	}
@@ -75,7 +90,7 @@ func checkBackupDirectories(fix bool) checkResult {
 
 	// report mode: show what was found
 	sizeStr := humanSize(totalSize)
-	msg := fmt.Sprintf("%d backup(s), %s", len(backups), sizeStr)
+	msg := fmt.Sprintf("%d stale backup(s) older than 7 days, %s", len(backups), sizeStr)
 
 	var detailLines []string
 	for _, b := range backups {

--- a/cmd/ox/doctor_credential_integrity.go
+++ b/cmd/ox/doctor_credential_integrity.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/paths"
+)
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugCredentialIntegrity,
+		Name:        "credential file integrity",
+		Category:    "Authentication",
+		FixLevel:    FixLevelAuto,
+		Description: "Validates credential files are valid JSON",
+		Run: func(fix bool) checkResult {
+			return checkCredentialIntegrity(fix)
+		},
+	})
+}
+
+// checkCredentialIntegrity validates that credential files contain valid JSON.
+// Corrupt files are auto-fixed by removal — the user will re-auth on next use.
+func checkCredentialIntegrity(fix bool) checkResult {
+	return checkCredentialIntegrityInDir(paths.ConfigDir(), fix)
+}
+
+// checkCredentialIntegrityInDir is the testable core of the integrity check.
+func checkCredentialIntegrityInDir(configDir string, fix bool) checkResult {
+	const name = "credential file integrity"
+
+	if configDir == "" {
+		return SkippedCheck(name, "config dir unknown", "")
+	}
+
+	filesToCheck := []string{
+		filepath.Join(configDir, "auth.json"),
+		filepath.Join(configDir, "git-credentials.json"),
+	}
+
+	// per-endpoint git credential files
+	matches, _ := filepath.Glob(filepath.Join(configDir, "git-credentials-*.json"))
+	filesToCheck = append(filesToCheck, matches...)
+
+	var corrupt []string
+	var checked int
+
+	for _, path := range filesToCheck {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			slog.Debug("credential integrity: read error", "path", path, "error", err)
+			continue
+		}
+
+		checked++
+		if !json.Valid(data) {
+			corrupt = append(corrupt, path)
+		}
+	}
+
+	if checked == 0 {
+		return SkippedCheck(name, "no credential files found", "")
+	}
+
+	if len(corrupt) == 0 {
+		return PassedCheck(name, fmt.Sprintf("%d file(s) valid", checked))
+	}
+
+	if fix {
+		return fixCorruptCredentialFiles(corrupt)
+	}
+
+	names := make([]string, len(corrupt))
+	for i, p := range corrupt {
+		names[i] = filepath.Base(p)
+	}
+	return WarningCheck(name,
+		fmt.Sprintf("%d corrupt file(s)", len(corrupt)),
+		fmt.Sprintf("invalid JSON in: %s\nrun `ox doctor --fix` to remove (you will need to re-login)",
+			strings.Join(names, ", ")))
+}
+
+// fixCorruptCredentialFiles removes corrupt credential files so the user can re-auth cleanly.
+func fixCorruptCredentialFiles(corrupt []string) checkResult {
+	const name = "credential file integrity"
+
+	var removed, failed int
+	for _, path := range corrupt {
+		if err := os.Remove(path); err != nil {
+			slog.Error("credential integrity: remove failed", "path", path, "error", err)
+			failed++
+			continue
+		}
+		slog.Info("credential integrity: removed corrupt file", "path", path)
+		removed++
+	}
+
+	if failed > 0 {
+		return WarningCheck(name,
+			fmt.Sprintf("removed %d, failed %d", removed, failed),
+			"some corrupt files could not be removed")
+	}
+
+	return PassedCheck(name,
+		fmt.Sprintf("removed %d corrupt file(s), run `ox login` to re-authenticate", removed))
+}

--- a/cmd/ox/doctor_credential_integrity_test.go
+++ b/cmd/ox/doctor_credential_integrity_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckCredentialIntegrity_ValidFiles(t *testing.T) {
+	configDir := t.TempDir()
+	os.WriteFile(filepath.Join(configDir, "auth.json"), []byte(`{"tokens":{}}`), 0600)
+	os.WriteFile(filepath.Join(configDir, "git-credentials.json"), []byte(`{"token":"ok"}`), 0600)
+
+	result := checkCredentialIntegrityInDir(configDir, false)
+	if !result.passed {
+		t.Errorf("expected passed for valid files, got: %+v", result)
+	}
+}
+
+func TestCheckCredentialIntegrity_CorruptFile(t *testing.T) {
+	configDir := t.TempDir()
+	os.WriteFile(filepath.Join(configDir, "auth.json"), []byte("{corrupt!!!"), 0600)
+	os.WriteFile(filepath.Join(configDir, "git-credentials.json"), []byte(`{"token":"ok"}`), 0600)
+
+	result := checkCredentialIntegrityInDir(configDir, false)
+	if !result.warning {
+		t.Errorf("expected warning for corrupt file, got: %+v", result)
+	}
+	if !strings.Contains(result.message, "1 corrupt") {
+		t.Errorf("expected '1 corrupt' in message, got: %s", result.message)
+	}
+}
+
+func TestCheckCredentialIntegrity_FixRemovesCorrupt(t *testing.T) {
+	configDir := t.TempDir()
+	corruptPath := filepath.Join(configDir, "auth.json")
+	os.WriteFile(corruptPath, []byte("not json"), 0600)
+
+	result := checkCredentialIntegrityInDir(configDir, true)
+	if !result.passed {
+		t.Errorf("expected passed after fix, got: %+v", result)
+	}
+
+	if _, err := os.Stat(corruptPath); !os.IsNotExist(err) {
+		t.Error("corrupt file should have been removed")
+	}
+}
+
+func TestCheckCredentialIntegrity_NoFiles(t *testing.T) {
+	configDir := t.TempDir()
+	result := checkCredentialIntegrityInDir(configDir, false)
+	if !result.skipped {
+		t.Errorf("expected skipped when no files exist, got: %+v", result)
+	}
+}
+
+func TestCheckCredentialIntegrity_CorruptEndpointFile(t *testing.T) {
+	configDir := t.TempDir()
+	os.WriteFile(filepath.Join(configDir, "auth.json"), []byte(`{"tokens":{}}`), 0600)
+	os.WriteFile(filepath.Join(configDir, "git-credentials-test.sageox.ai.json"), []byte("{{bad"), 0600)
+
+	result := checkCredentialIntegrityInDir(configDir, false)
+	if !result.warning {
+		t.Errorf("expected warning for corrupt endpoint-specific file, got: %+v", result)
+	}
+}

--- a/cmd/ox/doctor_git_credentials.go
+++ b/cmd/ox/doctor_git_credentials.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/gitserver"
+)
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugGitCredsFreshness,
+		Name:        "git credentials freshness",
+		Category:    "Authentication",
+		FixLevel:    FixLevelSuggested,
+		Description: "Checks if git credentials are expired or expiring soon",
+		Run: func(fix bool) checkResult {
+			return checkGitCredentialsFreshness(fix)
+		},
+	})
+}
+
+// checkGitCredentialsFreshness verifies git credentials are not expired or near expiry.
+func checkGitCredentialsFreshness(fix bool) checkResult {
+	const name = "git credentials freshness"
+
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(name, "not in git repo", "")
+	}
+
+	if !config.IsInitialized(gitRoot) {
+		return SkippedCheck(name, "not initialized", "")
+	}
+
+	projectEndpoint := endpoint.GetForProject(gitRoot)
+	if projectEndpoint == "" {
+		projectEndpoint = endpoint.Get()
+	}
+
+	creds, err := gitserver.LoadCredentialsForEndpoint(projectEndpoint)
+	if err != nil || creds == nil {
+		return SkippedCheck(name, "no credentials found", "")
+	}
+
+	now := time.Now()
+
+	if now.After(creds.ExpiresAt) {
+		msg := fmt.Sprintf("expired %s ago", formatDurationRough(now.Sub(creds.ExpiresAt)))
+		return WarningCheck(name, msg, "run `ox login` to refresh expired credentials")
+	}
+
+	remaining := time.Until(creds.ExpiresAt)
+	if remaining < time.Hour {
+		msg := fmt.Sprintf("expiring in %s", formatDurationRough(remaining))
+		return WarningCheck(name, msg, "run `ox login` to refresh credentials before they expire")
+	}
+
+	return PassedCheck(name, fmt.Sprintf("valid, expires in %s", formatCredentialExpiry(creds.ExpiresAt)))
+}
+
+// formatDurationRough returns a rough human-readable duration string.
+func formatDurationRough(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/cmd/ox/doctor_git_credentials_test.go
+++ b/cmd/ox/doctor_git_credentials_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatDurationRough(t *testing.T) {
+	tests := []struct {
+		d        time.Duration
+		expected string
+	}{
+		{30 * time.Second, "30s"},
+		{5 * time.Minute, "5m"},
+		{3 * time.Hour, "3h"},
+		{48 * time.Hour, "2d"},
+		{-5 * time.Minute, "5m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := formatDurationRough(tt.d)
+			if result != tt.expected {
+				t.Errorf("formatDurationRough(%v) = %q, want %q", tt.d, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatDurationRough_BoundaryValues(t *testing.T) {
+	// exactly 1 minute
+	if got := formatDurationRough(time.Minute); got != "1m" {
+		t.Errorf("1m: got %q", got)
+	}
+	// exactly 1 hour
+	if got := formatDurationRough(time.Hour); got != "1h" {
+		t.Errorf("1h: got %q", got)
+	}
+	// exactly 24 hours
+	if got := formatDurationRough(24 * time.Hour); got != "1d" {
+		t.Errorf("24h: got %q", got)
+	}
+	// zero
+	if got := formatDurationRough(0); got != "0s" {
+		t.Errorf("0: got %q, want 0s", got)
+	}
+}

--- a/cmd/ox/doctor_session_uncommitted.go
+++ b/cmd/ox/doctor_session_uncommitted.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+)
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugSessionUncommitted,
+		Name:        "uncommitted session files",
+		Category:    "Sessions",
+		FixLevel:    FixLevelSuggested,
+		Description: "Detects session files in ledger that were never committed",
+		Run:         checkSessionUncommitted,
+	})
+}
+
+// checkSessionUncommitted looks for session files in the ledger working
+// directory that were written but never git-committed. This can happen when
+// session stop partially fails after writing files but before committing.
+func checkSessionUncommitted(fix bool) checkResult {
+	const name = "uncommitted session files"
+
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(name, "no git root", "")
+	}
+
+	if !config.IsInitialized(gitRoot) {
+		return SkippedCheck(name, "not initialized", "")
+	}
+
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger", "")
+	}
+
+	if !isGitRepo(ledgerPath) {
+		return SkippedCheck(name, "ledger not a git repo", "")
+	}
+
+	output, err := exec.Command("git", "-C", ledgerPath, "status", "--porcelain", "sessions/").Output()
+	if err != nil {
+		return SkippedCheck(name, "git status failed", err.Error())
+	}
+
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return PassedCheck(name, "no uncommitted session files")
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	count := len(lines)
+
+	if !fix {
+		return WarningCheck(name,
+			fmt.Sprintf("%d uncommitted session file(s)", count),
+			"run `ox doctor --fix` to commit and push")
+	}
+
+	return fixSessionUncommitted(ledgerPath, count)
+}
+
+// fixSessionUncommitted stages, commits, and pushes uncommitted session files.
+func fixSessionUncommitted(ledgerPath string, count int) checkResult {
+	const name = "uncommitted session files"
+
+	if out, err := exec.Command("git", "-C", ledgerPath, "add", "sessions/").CombinedOutput(); err != nil {
+		return FailedCheck(name, "staging failed",
+			fmt.Sprintf("git add error: %s", strings.TrimSpace(string(out))))
+	}
+
+	if out, err := exec.Command("git", "-C", ledgerPath, "commit", "-m", "recover uncommitted sessions").CombinedOutput(); err != nil {
+		errStr := strings.TrimSpace(string(out))
+		if strings.Contains(errStr, "nothing to commit") {
+			return PassedCheck(name, "nothing to commit after staging")
+		}
+		return FailedCheck(name, "commit failed",
+			fmt.Sprintf("git commit error: %s", errStr))
+	}
+
+	if out, err := exec.Command("git", "-C", ledgerPath, "push").CombinedOutput(); err != nil {
+		return WarningCheck(name,
+			fmt.Sprintf("committed %d file(s) but push failed", count),
+			fmt.Sprintf("git push error: %s", strings.TrimSpace(string(out))))
+	}
+
+	return PassedCheck(name, fmt.Sprintf("committed and pushed %d session file(s)", count))
+}

--- a/cmd/ox/doctor_session_uncommitted_test.go
+++ b/cmd/ox/doctor_session_uncommitted_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// uses initTestGitRepo from memory_put_write_test.go
+
+func TestSessionUncommitted_CleanLedger(t *testing.T) {
+	ledger := t.TempDir()
+	initTestGitRepo(t, ledger)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(ledger, "sessions"), 0755))
+
+	output, err := exec.Command("git", "-C", ledger, "status", "--porcelain", "sessions/").Output()
+	require.NoError(t, err)
+	assert.Empty(t, string(output))
+}
+
+func TestSessionUncommitted_DetectsUncommittedFiles(t *testing.T) {
+	ledger := t.TempDir()
+	initTestGitRepo(t, ledger)
+
+	sessionDir := filepath.Join(ledger, "sessions", "test-session-001")
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "meta.json"), []byte(`{"session":"test"}`), 0644))
+
+	output, err := exec.Command("git", "-C", ledger, "status", "--porcelain", "sessions/").Output()
+	require.NoError(t, err)
+	assert.NotEmpty(t, string(output))
+	assert.Contains(t, string(output), "meta.json")
+}

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -168,6 +168,14 @@ func readCacheSessionMeta(rawPath string) (*session.StoreMeta, int, error) {
 	}
 	defer f.Close()
 
+	info, err := f.Stat()
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to stat file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, 0, fmt.Errorf("not a regular file: %s", rawPath)
+	}
+
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 256*1024), 256*1024) // 256KB line buffer
 
@@ -301,6 +309,14 @@ func validateRawJSONLHeader(rawPath string) error {
 	}
 	defer f.Close()
 
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file: %s", rawPath)
+	}
+
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 64*1024), 64*1024)
 
@@ -327,6 +343,14 @@ func copyFile(src, dst string) error {
 		return err
 	}
 	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file: %s", src)
+	}
 
 	out, err := os.Create(dst)
 	if err != nil {

--- a/cmd/ox/doctor_session_upload_retry_test.go
+++ b/cmd/ox/doctor_session_upload_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -288,6 +289,40 @@ func TestFindOrphanedSessions_CorruptRawJSONL(t *testing.T) {
 
 	orphans := scanCacheDirForOrphans(cacheDir, ledgerDir)
 	assert.Empty(t, orphans, "corrupt raw.jsonl should be excluded from orphan list")
+}
+
+func TestReadCacheSessionMeta_DirectoryPath(t *testing.T) {
+	dirPath := t.TempDir()
+	_, _, err := readCacheSessionMeta(dirPath)
+	if err == nil {
+		t.Fatal("expected error for directory path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("expected 'not a regular file' error, got: %v", err)
+	}
+}
+
+func TestValidateRawJSONLHeader_DirectoryPath(t *testing.T) {
+	dirPath := t.TempDir()
+	err := validateRawJSONLHeader(dirPath)
+	if err == nil {
+		t.Fatal("expected error for directory path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("expected 'not a regular file' error, got: %v", err)
+	}
+}
+
+func TestCopyFile_DirectoryPath(t *testing.T) {
+	dirPath := t.TempDir()
+	dstPath := filepath.Join(t.TempDir(), "out.txt")
+	err := copyFile(dirPath, dstPath)
+	if err == nil {
+		t.Fatal("expected error for directory path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("expected 'not a regular file' error, got: %v", err)
+	}
 }
 
 func TestFindOrphanedSessions_ActiveRecordingWithRawJSONL(t *testing.T) {

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -184,5 +184,10 @@ const (
 	CheckSlugSessionPush        = "session-push"
 	CheckSlugSessionIncomplete  = "session-incomplete"
 	CheckSlugSessionAutoStage   = "session-auto-stage"
-	CheckSlugSessionUploadRetry = "session-upload-retry"
+	CheckSlugSessionUploadRetry  = "session-upload-retry"
+	CheckSlugSessionUncommitted = "session-uncommitted"
+
+	// Authentication checks (credential health)
+	CheckSlugGitCredsFreshness   = "git-creds-freshness"
+	CheckSlugCredentialIntegrity = "credential-integrity"
 )

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/paths"
 )
 
@@ -140,25 +141,9 @@ func saveAuthStore(store *AuthStore) error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	// marshal store to JSON
-	data, err := json.MarshalIndent(store, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal auth store: %w", err)
-	}
-
-	// SECURITY: atomic write pattern prevents partial/corrupt token files.
-	// Write to temp file, then atomic rename. This prevents:
-	//   1. Partial writes on crash leaving corrupt auth state
-	//   2. Race conditions where another process reads mid-write
-	//   3. Token leakage via temp files (0600 = owner-only read/write)
-	tempPath := authPath + ".tmp"
-	if err := os.WriteFile(tempPath, data, 0600); err != nil {
-		return fmt.Errorf("failed to write temp auth file: %w", err)
-	}
-
-	if err := os.Rename(tempPath, authPath); err != nil {
-		os.Remove(tempPath) // cleanup temp file on error
-		return fmt.Errorf("failed to rename temp auth file: %w", err)
+	// SECURITY: atomic write with fsync prevents partial/corrupt token files.
+	if err := fileutil.AtomicWriteJSON(authPath, store, 0600); err != nil {
+		return fmt.Errorf("failed to save auth store: %w", err)
 	}
 
 	return nil
@@ -384,21 +369,9 @@ func (c *AuthClient) saveAuthStore(store *AuthStore) error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	// marshal store to JSON
-	data, err := json.MarshalIndent(store, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal auth store: %w", err)
-	}
-
-	// SECURITY: atomic write pattern prevents partial/corrupt token files.
-	tempPath := authPath + ".tmp"
-	if err := os.WriteFile(tempPath, data, 0600); err != nil {
-		return fmt.Errorf("failed to write temp auth file: %w", err)
-	}
-
-	if err := os.Rename(tempPath, authPath); err != nil {
-		os.Remove(tempPath) // cleanup temp file on error
-		return fmt.Errorf("failed to rename temp auth file: %w", err)
+	// SECURITY: atomic write with fsync prevents partial/corrupt token files.
+	if err := fileutil.AtomicWriteJSON(authPath, store, 0600); err != nil {
+		return fmt.Errorf("failed to save auth store: %w", err)
 	}
 
 	return nil

--- a/internal/daemon/heartbeat_file.go
+++ b/internal/daemon/heartbeat_file.go
@@ -163,6 +163,14 @@ func readHeartbeatsFromPath(heartbeatPath string) ([]HeartbeatEntry, error) {
 	}
 	defer f.Close()
 
+	info, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat heartbeat file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file: %s", heartbeatPath)
+	}
+
 	var entries []HeartbeatEntry
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/internal/daemon/heartbeat_test.go
+++ b/internal/daemon/heartbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -669,5 +670,16 @@ func TestHeartbeatHandler_RejectsExpiredHeartbeatCredentials(t *testing.T) {
 	creds, _ := handler.GetCredentials()
 	if creds.Token != "valid-token" {
 		t.Error("expired heartbeat credentials should be rejected, keeping old valid ones")
+	}
+}
+
+func TestReadHeartbeatsFromPath_DirectoryPath(t *testing.T) {
+	dirPath := t.TempDir()
+	_, err := readHeartbeatsFromPath(dirPath)
+	if err == nil {
+		t.Fatal("expected error for directory path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("expected 'not a regular file' error, got: %v", err)
 	}
 }

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -56,6 +56,10 @@ const (
 	// maxConcurrentClones limits background clone operations to prevent resource exhaustion.
 	// 100 team contexts shouldn't spawn 100 concurrent git clones.
 	maxConcurrentClones = 3
+
+	// cloneSemTimeout is the maximum time to wait for a clone semaphore slot.
+	// Prevents indefinite blocking when all clone slots are hung.
+	cloneSemTimeout = 2 * time.Minute
 )
 
 // ErrInvalidRepoPath indicates the repo path failed security validation.
@@ -268,7 +272,8 @@ type SyncScheduler struct {
 	syncStateLocks sync.Map // map[string]*sync.Mutex
 
 	// test hooks (nil in production)
-	onBeforeCloneSem func() // called just before acquiring cloneSem; tests use this to observe blocking
+	onBeforeCloneSem         func()        // called just before acquiring cloneSem; tests use this to observe blocking
+	cloneSemTimeoutOverride  time.Duration // override cloneSemTimeout for tests (0 = use default)
 
 	// callbacks
 	onActivity   func()                                                           // called on any sync activity
@@ -693,6 +698,15 @@ func (s *SyncScheduler) shouldSyncOrBypass(id string, forceSync bool) bool {
 	return false
 }
 
+// isValidGitRepo runs git rev-parse --git-dir to verify the repo is functional,
+// not just that .git directory exists. Catches partial/corrupt clones from interrupted operations.
+func isValidGitRepo(path string) bool {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--git-dir")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
+}
+
 // doPull fetches and pulls from remote with optional progress updates.
 // If ledger doesn't exist locally but has a clone URL, spawns background clone.
 // Returns an error if fetch or pull fails (for on-demand sync error reporting).
@@ -735,6 +749,20 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 			}
 		}
 		return nil // can't pull from repo that isn't cloned yet
+	}
+
+	// validate the repo is functional (not just .git dir exists)
+	// catches partial/corrupt clones from interrupted git clone operations
+	if !isValidGitRepo(s.config.LedgerPath) {
+		backupPath := fmt.Sprintf("%s.bak.%d", s.config.LedgerPath, time.Now().Unix())
+		s.logger.Warn("ledger repo corrupt, moving aside for re-clone",
+			"path", s.config.LedgerPath, "backup", backupPath)
+		if err := os.Rename(s.config.LedgerPath, backupPath); err != nil {
+			s.logger.Error("failed to move corrupt ledger aside", "error", err)
+			return fmt.Errorf("corrupt ledger at %s but rename failed: %w", s.config.LedgerPath, err)
+		}
+		// trigger re-clone on next cycle
+		return nil
 	}
 
 	// skip if repo stuck in broken rebase state
@@ -1523,7 +1551,17 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 	if s.onBeforeCloneSem != nil {
 		s.onBeforeCloneSem()
 	}
-	s.cloneSem <- struct{}{}
+	// acquire clone slot with timeout to prevent indefinite blocking
+	semTimeout := s.cloneSemTimeoutOverride
+	if semTimeout == 0 {
+		semTimeout = cloneSemTimeout
+	}
+	select {
+	case s.cloneSem <- struct{}{}:
+		// acquired
+	case <-time.After(semTimeout):
+		return nil, fmt.Errorf("clone semaphore timeout after %v: all %d slots busy", semTimeout, maxConcurrentClones)
+	}
 	defer func() { <-s.cloneSem }()
 
 	// validate clone URL to prevent SSRF attacks

--- a/internal/daemon/sync_network_test.go
+++ b/internal/daemon/sync_network_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -178,31 +179,34 @@ func TestCheckout_CorruptRepoSelfHealing(t *testing.T) {
 }
 
 // TestDoPull_CorruptGitHeadDetection verifies that doPull detects when .git/HEAD
-// is corrupted (making the directory fail pathIsGitRepo) and enters the clone
-// path instead of attempting git operations on a broken repo.
+// is corrupted (making the repo fail isValidGitRepo) and self-heals by moving
+// the corrupt directory aside so a re-clone can happen on the next cycle.
 func TestDoPull_CorruptGitHeadDetection(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+
 	tmpDir := t.TempDir()
 	ledgerDir := filepath.Join(tmpDir, "ledger")
 	require.NoError(t, os.MkdirAll(ledgerDir, 0755))
 
 	// create a .git directory but no valid git structure
 	// pathIsGitRepo checks for .git directory existence, so this should pass
-	// but git commands would fail
+	// but isValidGitRepo (git rev-parse --git-dir) will fail
 	gitDir := filepath.Join(ledgerDir, ".git")
 	require.NoError(t, os.MkdirAll(gitDir, 0755))
 
-	// pathIsGitRepo only checks if .git exists, so this IS detected as a git repo.
-	// the daemon will attempt fetch/pull and get git errors.
-	// verify pathIsGitRepo reports true for a directory with .git
+	// verify pathIsGitRepo reports true (shallow check passes)
 	assert.True(t, pathIsGitRepo(ledgerDir), "pathIsGitRepo should return true when .git exists")
+
+	// verify isValidGitRepo reports false (deep check fails)
+	assert.False(t, isValidGitRepo(ledgerDir), "isValidGitRepo should return false for empty .git dir")
 
 	// without a .git directory, pathIsGitRepo should return false
 	emptyDir := filepath.Join(tmpDir, "empty")
 	require.NoError(t, os.MkdirAll(emptyDir, 0755))
 	assert.False(t, pathIsGitRepo(emptyDir), "pathIsGitRepo should return false without .git")
 
-	// doPull with a directory that has .git but is not a real git repo
-	// should fail on git fetch (not panic or hang)
 	cfg := DefaultConfig()
 	cfg.LedgerPath = ledgerDir
 	cfg.SyncIntervalRead = 1 * time.Second
@@ -211,12 +215,17 @@ func TestDoPull_CorruptGitHeadDetection(t *testing.T) {
 	scheduler := NewSyncScheduler(cfg, logger)
 	ctx := context.Background()
 
-	// this will pass the pathIsGitRepo check but fail on git operations
+	// doPull should detect the corrupt repo via isValidGitRepo and move it aside
 	err := scheduler.doPull(ctx, nil, true)
-	// should error (fetch fails on non-git dir) rather than panic
-	// the error might be nil if ls-remote skips or other early returns,
-	// but it should NOT panic
-	_ = err // we just verify no panic; the exact error depends on git version
+	assert.NoError(t, err, "doPull should return nil after moving corrupt repo aside")
+
+	// verify the original directory was moved to .bak
+	_, statErr := os.Stat(ledgerDir)
+	assert.True(t, os.IsNotExist(statErr), "original ledger dir should be moved aside")
+
+	// verify backup exists
+	backups, _ := filepath.Glob(filepath.Join(tmpDir, "ledger.bak.*"))
+	require.Len(t, backups, 1, "exactly one backup should be created")
 }
 
 // TestDoPull_FetchFailureRecordsBackoff verifies that when git fetch fails
@@ -615,4 +624,90 @@ func TestDoPull_RebaseStateSkips(t *testing.T) {
 
 	err := scheduler.doPull(context.Background(), nil, false)
 	assert.NoError(t, err, "doPull should skip gracefully when in rebase state")
+}
+
+// TestDoPull_PartialGitDirTriggersReclone verifies that doPull detects a partial
+// .git directory (from an interrupted clone) and self-heals by moving it aside.
+// The directory passes pathIsGitRepo (.git exists) but fails isValidGitRepo
+// (git rev-parse --git-dir fails), triggering the self-healing path.
+func TestDoPull_PartialGitDirTriggersReclone(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+
+	tmpDir := t.TempDir()
+	ledgerDir := filepath.Join(tmpDir, "ledger")
+	require.NoError(t, os.MkdirAll(ledgerDir, 0755))
+
+	// simulate an interrupted clone: .git exists but is empty/incomplete
+	gitDir := filepath.Join(ledgerDir, ".git")
+	require.NoError(t, os.MkdirAll(gitDir, 0755))
+
+	// create a marker file to verify backup preserves content
+	require.NoError(t, os.WriteFile(filepath.Join(ledgerDir, "partial.txt"), []byte("interrupted"), 0644))
+
+	// precondition: pathIsGitRepo passes, isValidGitRepo fails
+	require.True(t, pathIsGitRepo(ledgerDir), "precondition: .git dir must exist")
+	require.False(t, isValidGitRepo(ledgerDir), "precondition: repo must be invalid")
+
+	cfg := DefaultConfig()
+	cfg.LedgerPath = ledgerDir
+	cfg.SyncIntervalRead = 1 * time.Second
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	scheduler := NewSyncScheduler(cfg, logger)
+	ctx := context.Background()
+
+	err := scheduler.doPull(ctx, nil, false)
+	assert.NoError(t, err, "doPull should return nil after self-healing corrupt repo")
+
+	// original directory should be gone (renamed to .bak)
+	_, statErr := os.Stat(ledgerDir)
+	assert.True(t, os.IsNotExist(statErr), "original ledger dir should be moved aside")
+
+	// backup should exist with .bak.* suffix
+	backups, _ := filepath.Glob(filepath.Join(tmpDir, "ledger.bak.*"))
+	require.Len(t, backups, 1, "exactly one backup should be created")
+
+	// verify backup preserved original content
+	backupContent, err := os.ReadFile(filepath.Join(backups[0], "partial.txt"))
+	require.NoError(t, err, "backup should contain original files")
+	assert.Equal(t, "interrupted", string(backupContent))
+}
+
+// TestCheckout_SemaphoreTimeout verifies that Checkout returns an error when
+// all clone semaphore slots are occupied and the timeout expires, rather than
+// blocking indefinitely.
+func TestCheckout_SemaphoreTimeout(t *testing.T) {
+	cfg := DefaultConfig()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	scheduler := NewSyncScheduler(cfg, logger)
+
+	// use a very short timeout for the test
+	scheduler.cloneSemTimeoutOverride = 100 * time.Millisecond
+
+	// fill all clone semaphore slots
+	for i := 0; i < maxConcurrentClones; i++ {
+		scheduler.cloneSem <- struct{}{}
+	}
+
+	// Checkout should timeout trying to acquire a slot
+	parentDir := t.TempDir()
+	repoDir := filepath.Join(parentDir, "test-repo")
+
+	result, err := scheduler.Checkout(CheckoutPayload{
+		RepoPath: repoDir,
+		CloneURL: "https://example.com/repo.git",
+		RepoType: "ledger",
+	}, nil)
+
+	require.Error(t, err, "Checkout should fail when semaphore is full")
+	assert.Nil(t, result)
+	assert.True(t, strings.Contains(err.Error(), "clone semaphore timeout"),
+		"error should mention semaphore timeout, got: %s", err.Error())
+
+	// drain semaphore slots to clean up
+	for i := 0; i < maxConcurrentClones; i++ {
+		<-scheduler.cloneSem
+	}
 }

--- a/internal/docs/postprocess.go
+++ b/internal/docs/postprocess.go
@@ -177,6 +177,14 @@ func transformFile(srcPath, destPath string, sidebarPosition int) error {
 	}
 	defer srcFile.Close()
 
+	info, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat source file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file: %s", srcPath)
+	}
+
 	// Create destination file
 	destFile, err := os.Create(destPath)
 	if err != nil {

--- a/internal/docs/postprocess_test.go
+++ b/internal/docs/postprocess_test.go
@@ -1,0 +1,19 @@
+package docs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTransformFile_DirectoryPath(t *testing.T) {
+	srcDir := t.TempDir()
+	destPath := t.TempDir() + "/out.md"
+
+	err := transformFile(srcDir, destPath, 1)
+	if err == nil {
+		t.Fatal("expected error for directory path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("expected 'not a regular file' error, got: %v", err)
+	}
+}

--- a/internal/fileutil/atomic.go
+++ b/internal/fileutil/atomic.go
@@ -1,0 +1,55 @@
+package fileutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteJSON writes data as JSON to filePath atomically using temp+rename.
+// This prevents partial/corrupt files from concurrent reads during write.
+// The file is fsync'd before rename to ensure durability.
+func AtomicWriteJSON(filePath string, data any, perm os.FileMode) error {
+	dir := filepath.Dir(filePath)
+
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	success := false
+	defer func() {
+		if !success {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	enc := json.NewEncoder(tmp)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("encode JSON: %w", err)
+	}
+
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("fsync: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return fmt.Errorf("chmod: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+
+	success = true
+	return nil
+}

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -1,0 +1,69 @@
+package fileutil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAtomicWriteJSON_Success(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.json")
+
+	data := map[string]string{"key": "value"}
+	if err := AtomicWriteJSON(path, data, 0600); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["key"] != "value" {
+		t.Errorf("expected value, got %q", got["key"])
+	}
+}
+
+func TestAtomicWriteJSON_NoPartialOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fail.json")
+
+	// channels cannot be marshaled to JSON
+	err := AtomicWriteJSON(path, make(chan int), 0600)
+	if err == nil {
+		t.Fatal("expected error for unencodable value")
+	}
+
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Error("file should not exist after failed write")
+	}
+
+	// also verify no temp files left behind
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		t.Errorf("leftover file: %s", e.Name())
+	}
+}
+
+func TestAtomicWriteJSON_Permissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perms.json")
+
+	if err := AtomicWriteJSON(path, "test", 0600); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected 0600, got %o", info.Mode().Perm())
+	}
+}

--- a/internal/gitserver/credentials.go
+++ b/internal/gitserver/credentials.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/zalando/go-keyring"
 )
@@ -433,21 +434,9 @@ func saveCredentialsToFileForEndpoint(endpointURL string, creds GitCredentials) 
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	// marshal credentials to JSON with indentation for readability
-	data, err := json.MarshalIndent(creds, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal git credentials: %w", err)
-	}
-
-	// atomic write pattern
-	tempPath := credsPath + ".tmp"
-	if err := os.WriteFile(tempPath, data, 0600); err != nil {
-		return fmt.Errorf("failed to write temp git credentials file: %w", err)
-	}
-
-	if err := os.Rename(tempPath, credsPath); err != nil {
-		os.Remove(tempPath)
-		return fmt.Errorf("failed to rename temp git credentials file: %w", err)
+	// atomic write with fsync prevents partial/corrupt credential files
+	if err := fileutil.AtomicWriteJSON(credsPath, creds, 0600); err != nil {
+		return fmt.Errorf("failed to save git credentials: %w", err)
 	}
 
 	return nil

--- a/internal/teamdocs/discover.go
+++ b/internal/teamdocs/discover.go
@@ -124,6 +124,11 @@ func extractTitleFromContent(path string) string {
 	}
 	defer file.Close()
 
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return ""
+	}
+
 	scanner := bufio.NewScanner(file)
 	inFrontmatter := false
 	lineCount := 0
@@ -166,6 +171,11 @@ func extractDescriptionFromContent(path string) string {
 		return ""
 	}
 	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return ""
+	}
 
 	scanner := bufio.NewScanner(file)
 	inFrontmatter := false

--- a/internal/teamdocs/discover_test.go
+++ b/internal/teamdocs/discover_test.go
@@ -281,6 +281,20 @@ func TestExtractDescriptionFromContent(t *testing.T) {
 	}
 }
 
+func TestExtractTitleFromContent_DirectoryPath(t *testing.T) {
+	got := extractTitleFromContent(t.TempDir())
+	if got != "" {
+		t.Errorf("expected empty string for directory path, got %q", got)
+	}
+}
+
+func TestExtractDescriptionFromContent_DirectoryPath(t *testing.T) {
+	got := extractDescriptionFromContent(t.TempDir())
+	if got != "" {
+		t.Errorf("expected empty string for directory path, got %q", got)
+	}
+}
+
 func TestTitleFromFilename(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Summary

Comprehensive resilience hardening across file I/O, daemon clone recovery, and credential management:

- **IsRegular guards** on all `os.Open` + `bufio.Scanner` paths to prevent reading directories as files (silent corruption)
- **Partial .git detection** in `doPull()` — catches interrupted clones and self-heals by moving corrupt repos aside for re-clone
- **Clone semaphore timeout** — prevents indefinite blocking when all clone slots are hung (2min default)
- **Atomic credential writes** — new `fileutil.AtomicWriteJSON` with fsync+rename, replacing 3 duplicate write-temp-rename patterns
- **3 new `ox doctor` checks**: git credentials freshness, credential file integrity (auto-fix), uncommitted session files
- **Stale backup age filter** — `.bak` cleanup now only flags directories older than 7 days

## Changes by Area

### File I/O Safety (IsRegular)
| File | Function | Guard |
|------|----------|-------|
| `internal/teamdocs/discover.go` | `extractTitleFromContent`, `extractDescriptionFromContent` | Return `""` |
| `internal/daemon/heartbeat_file.go` | `readHeartbeatsFromPath` | Return error |
| `internal/docs/postprocess.go` | `transformFile` | Return error |
| `cmd/ox/doctor_session_upload_retry.go` | `readCacheSessionMeta`, `validateRawJSONLHeader`, `copyFile` | Return error |

### Daemon Clone Self-Healing

```mermaid
flowchart TD
    A[doPull] --> B{pathIsGitRepo?}
    B -->|No| C[Skip - not cloned yet]
    B -->|Yes| D{isValidGitRepo?}
    D -->|Yes| E[Proceed with fetch/pull]
    D -->|No| F[Move to .bak]
    F --> G[Return nil - triggers re-clone next cycle]
```

### Atomic Credential Writes
Consolidated 3 identical write-temp-rename patterns into `fileutil.AtomicWriteJSON`:
- `internal/auth/storage.go` — both `saveAuthStore` functions
- `internal/gitserver/credentials.go` — `saveCredentialsToFileForEndpoint`

Added `fsync` before rename (previously missing) for crash safety.

### New Doctor Checks
| Slug | Category | FixLevel | Purpose |
|------|----------|----------|---------|
| `git-creds-freshness` | Authentication | Suggested | Warns on expired/expiring credentials |
| `credential-integrity` | Authentication | Auto | Detects & removes corrupt JSON credential files |
| `session-uncommitted` | Sessions | Suggested | Finds session files written but never committed |

### Backup Cleanup Age Filter
`.bak` directories younger than 7 days are no longer flagged — they may still be needed if a clone retry is in progress.

## Test Plan

- [x] All `internal/fileutil/` tests pass (AtomicWriteJSON success, failure cleanup, permissions)
- [x] All `internal/daemon/` tests pass (partial .git detection, semaphore timeout, corrupt HEAD)
- [x] All `internal/teamdocs/`, `internal/docs/` DirectoryPath tests pass
- [x] All `internal/auth/`, `internal/gitserver/` tests pass
- [x] Credential integrity tests pass (valid, corrupt, fix, no-files, endpoint-specific)
- [x] `go build ./cmd/ox/` succeeds
- [x] Pre-existing `import_integration_test.go` build error confirmed on main (not caused by this PR)


Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added credential integrity check to detect and repair corrupt credential files.
  * Added git credentials freshness check to warn of expiring or expired credentials.
  * Added session uncommitted files check to identify and auto-commit unsaved session data.

* **Bug Fixes**
  * Backup cleanup now targets only stale backups older than 7 days.
  * Improved file validation across system checks for better error handling and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->