### PR TITLE
fix: register ox agent hook as cobra subcommand

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -85,6 +85,7 @@ var agentListCmd = &cobra.Command{
 func init() {
 	// register subcommands under agent
 	agentCmd.AddCommand(agentPrimeCmd)
+	agentCmd.AddCommand(agentHookCmd)
 	agentCmd.AddCommand(agentListCmd)
 	agentCmd.AddCommand(agentTeamCtxCmd)
 	agentCmd.AddCommand(agentRedactCmd)

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -7,9 +7,24 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/pkg/agentx"
 )
+
+// agentHookCmd handles lifecycle hooks from AI coworkers.
+// Registered as a direct cobra subcommand (no agent ID required) because
+// hooks fire before ox agent prime — no agent ID exists yet.
+var agentHookCmd = &cobra.Command{
+	Use:    "hook <event>",
+	Short:  "Handle lifecycle hooks from AI coworkers",
+	Hidden: true,
+	Args:   cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runAgentHook(args)
+	},
+}
 
 // ReadHookInput reads hook input from stdin.
 // Delegates to agentx.ReadHookInputFromStdin for the actual implementation.

--- a/cmd/ox/agent_test.go
+++ b/cmd/ox/agent_test.go
@@ -325,6 +325,31 @@ func TestAgentPrimeOutputStatuses(t *testing.T) {
 	}
 }
 
+// TestAgentIDFreeSubcommands ensures all commands that don't require an agent ID
+// are registered as cobra subcommands on agentCmd. These commands are matched
+// first in runAgentDispatcher (before the agent ID check), so removing one
+// would break `ox agent <cmd>` invocations without an ID.
+//
+// Regression guard: hooks fire before ox agent prime (no ID exists yet),
+// and prime itself obviously can't require an ID.
+func TestAgentIDFreeSubcommands(t *testing.T) {
+	// commands that MUST work without an agent ID
+	requiredIDFree := []string{"prime", "hook", "list", "team-ctx", "redact"}
+
+	registered := make(map[string]bool)
+	for _, sub := range agentCmd.Commands() {
+		registered[sub.Name()] = true
+	}
+
+	for _, name := range requiredIDFree {
+		t.Run(name+" is registered", func(t *testing.T) {
+			if !registered[name] {
+				t.Errorf("%q must be registered as a cobra subcommand on agentCmd (no agent ID required), but it is missing", name)
+			}
+		})
+	}
+}
+
 func TestIsAgentSubcommand(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/ox/import_integration_test.go
+++ b/cmd/ox/import_integration_test.go
@@ -37,7 +37,6 @@ func TestCommitAndPushDocImport_Success(t *testing.T) {
 		CreatedAt:      "2026-01-15",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
 		HasTextExtract: false,
-		Files:          map[string]lfs.FileRef{"source.bin": srcRef},
 	}
 	metaData, err := json.MarshalIndent(meta, "", "  ")
 	require.NoError(t, err)
@@ -90,10 +89,6 @@ func TestCommitAndPushDocImport_WithTextExtract(t *testing.T) {
 		CreatedAt:      "2026-02-14",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
 		HasTextExtract: true,
-		Files: map[string]lfs.FileRef{
-			"source.bin":   srcRef,
-			"extracted.md": textRef,
-		},
 	}
 	metaData, err := json.MarshalIndent(meta, "", "  ")
 	require.NoError(t, err)
@@ -140,7 +135,6 @@ func TestCommitAndPushDocImport_GitattributesIncluded(t *testing.T) {
 		CreatedAt:      "2026-03-01",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
 		HasTextExtract: false,
-		Files:          map[string]lfs.FileRef{"source.bin": srcRef},
 	}
 	metaData, err := json.MarshalIndent(meta, "", "  ")
 	require.NoError(t, err)
@@ -181,7 +175,6 @@ func TestCommitAndPushDocImport_NothingToCommit(t *testing.T) {
 		CreatedAt:      "2026-01-01",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
 		HasTextExtract: false,
-		Files:          map[string]lfs.FileRef{"source.bin": srcRef},
 	}
 	metaData, err := json.MarshalIndent(meta, "", "  ")
 	require.NoError(t, err)
@@ -333,7 +326,6 @@ func TestImportEmptyFile(t *testing.T) {
 		CreatedAt:      "2026-01-01",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
 		HasTextExtract: false,
-		Files:          map[string]lfs.FileRef{"source.bin": ref},
 	}
 	data, err := json.Marshal(meta)
 	require.NoError(t, err)
@@ -341,7 +333,6 @@ func TestImportEmptyFile(t *testing.T) {
 	var parsed docMeta
 	require.NoError(t, json.Unmarshal(data, &parsed))
 	assert.Equal(t, int64(0), parsed.SourceSize)
-	assert.Equal(t, ref.OID, parsed.Files["source.bin"].OID)
 }
 
 // --- date validation tests ---


### PR DESCRIPTION
## Summary

Claude Code hooks were failing with 'unknown command or invalid agent_id: hook' because `ox agent hook` was only reachable via `runWithAgentID`, which requires an agent ID. However, hooks fire before `ox agent prime` runs — no agent ID exists yet.

**Fix:** Register `hook` as a cobra subcommand (like `prime`, `list`, `team-ctx`, `redact`) so it can be dispatched directly without requiring an agent ID.

## Changes

- Register `agentHookCmd` as a direct cobra subcommand in `cmd/ox/agent_hook.go`
- Add it to `agentCmd.AddCommand()` in init()
- Add `TestAgentIDFreeSubcommands` regression test to catch future removals of any ID-free command
- Fix pre-existing compilation errors in `import_integration_test.go` (removed references to deleted `Files` field on `docMeta`)

## Test Plan

- New test `TestAgentIDFreeSubcommands` verifies all 5 ID-free commands are registered: `prime`, `hook`, `list`, `team-ctx`, `redact`
- Verify: `./ox agent hook SessionStart` succeeds (no agent ID needed)
- Verify: `./ox agent hook SessionEnd` succeeds
- All existing agent tests pass

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `hook` subcommand to the agent command for triggering lifecycle hooks via CLI without requiring an agent ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->