### PR TITLE
fix: lint violations and improve team context status display

### DIFF
--- a/cmd/ox/memory_observation_roundtrip_test.go
+++ b/cmd/ox/memory_observation_roundtrip_test.go
@@ -23,7 +23,7 @@ func initTestGitRepoForRoundtrip(t *testing.T, dir string) {
 	for _, args := range cmds {
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(os.Environ(), // safe: git subprocess in temp dir, not ox
 			"GIT_AUTHOR_NAME=Test User",
 			"GIT_AUTHOR_EMAIL=test@example.com",
 			"GIT_COMMITTER_NAME=Test User",
@@ -36,7 +36,7 @@ func initTestGitRepoForRoundtrip(t *testing.T, dir string) {
 	require.NoError(t, os.WriteFile(readme, []byte("repo"), 0644))
 	cmd := exec.Command("git", "add", "README.md")
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(os.Environ(), // safe: git subprocess in temp dir, not ox
 		"GIT_AUTHOR_NAME=Test User",
 		"GIT_AUTHOR_EMAIL=test@example.com",
 		"GIT_COMMITTER_NAME=Test User",
@@ -46,7 +46,7 @@ func initTestGitRepoForRoundtrip(t *testing.T, dir string) {
 	require.NoError(t, err, "git add: %s", string(out))
 	cmd = exec.Command("git", "commit", "-m", "initial")
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(os.Environ(), // safe: git subprocess in temp dir, not ox
 		"GIT_AUTHOR_NAME=Test User",
 		"GIT_AUTHOR_EMAIL=test@example.com",
 		"GIT_COMMITTER_NAME=Test User",

--- a/cmd/ox/memory_put_write_test.go
+++ b/cmd/ox/memory_put_write_test.go
@@ -16,7 +16,7 @@ import (
 // initTestGitRepo creates a minimal git repo at dir with an initial commit.
 func initTestGitRepo(t *testing.T, dir string) {
 	t.Helper()
-	gitEnv := append(os.Environ(),
+	gitEnv := append(os.Environ(), // safe: git subprocess in temp dir, not ox
 		"GIT_AUTHOR_NAME=Test User",
 		"GIT_AUTHOR_EMAIL=test@example.com",
 		"GIT_COMMITTER_NAME=Test User",

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -301,8 +301,8 @@ func getGitRepoStatus(repoPath string, lastSync time.Time, hasLastSync bool) git
 	}
 	status.Branch = strings.TrimSpace(string(branchOutput))
 
-	// get uncommitted changes count
-	statusCmd := exec.Command("git", "-C", repoPath, "status", "--porcelain")
+	// get uncommitted changes count (ignore untracked files like .sageox/, .observations/)
+	statusCmd := exec.Command("git", "-C", repoPath, "status", "--porcelain", "-uno")
 	statusOutput, err := statusCmd.Output()
 	if err == nil && len(statusOutput) > 0 {
 		lines := strings.Split(strings.TrimSpace(string(statusOutput)), "\n")

--- a/internal/daemon/workspace_registry.go
+++ b/internal/daemon/workspace_registry.go
@@ -970,7 +970,9 @@ func (r *WorkspaceRegistry) CleanupRevokedTeamContexts(currentTeamIDs map[string
 	}
 }
 
-// isCheckoutClean returns true if a git repo has no uncommitted changes.
+// isCheckoutClean returns true if a git repo has no uncommitted or untracked changes.
+// Includes untracked files — GC (blue/green reclone) destroys the old directory,
+// so untracked files like .sageox/cache/ and pending .observations/ would be lost.
 func isCheckoutClean(path string) bool {
 	cmd := exec.Command("git", "-C", path, "status", "--porcelain")
 	output, err := cmd.Output()

--- a/internal/manifest/sparse_checkout_test.go
+++ b/internal/manifest/sparse_checkout_test.go
@@ -54,7 +54,7 @@ func TestComputeSparseSet_FallbackConfigExcludesData(t *testing.T) {
 // gitEnv returns environment variables that provide git identity
 // so tests don't depend on global git config.
 func gitEnv() []string {
-	return append(os.Environ(),
+	return append(os.Environ(), // safe: git subprocess in temp dir, not ox
 		"GIT_AUTHOR_NAME=Test User",
 		"GIT_AUTHOR_EMAIL=test@example.com",
 		"GIT_COMMITTER_NAME=Test User",


### PR DESCRIPTION
## Summary

Fixed lint violations from `os.Environ()` calls in test files and improved status display for team contexts.

## Changes

- **Lint fixes**: Added `// safe:` annotations to 5 `os.Environ()` calls in test files (`memory_put_write_test.go`, `memory_observation_roundtrip_test.go`, `sparse_checkout_test.go`). These are legitimate uses for git subprocesses in temp directories and required explicit annotation to pass the linter.

- **Status display improvement**: Updated `status.go` to use `git status --porcelain -uno` instead of `--porcelain` alone. This prevents untracked `.sageox/` directories (created by the daemon) from incorrectly appearing as "uncommitted changes" in `ox status` output for team contexts, improving user experience.

- **Documentation**: Added clarifying comment to `isCheckoutClean()` explaining why it must detect untracked files — GC's blue/green reclone destroys the old directory, so untracked files like `.sageox/cache/` would be lost without blocking GC.

## Test Results

- All 5,727 tests pass
- Lint check: 0 issues

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated git status checking to exclude untracked files from change counts.
  * Refined workspace cleanliness detection to include untracked files in addition to uncommitted changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->