### PR TITLE
feat: refine ox import

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/sageox/ox/internal/agentinstance"
+	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/repotools"
@@ -155,12 +156,14 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 // Used to distinguish `ox agent session start` (missing agent ID)
 // from `ox agent typo` (genuinely unknown command).
 var agentSubcommands = map[string]bool{
-	"distill": true,
 	"doctor":  true,
 	"session": true,
 }
 
 func isAgentSubcommand(name string) bool {
+	if name == "distill" {
+		return auth.IsMemoryEnabled()
+	}
 	return agentSubcommands[name]
 }
 
@@ -229,11 +232,18 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 			return fmt.Errorf("unknown session command: %s\nAvailable: start, stop, abort, delete, remind, summarize, html, record, plan, import, capture-prior, subagent-complete, subagent-list, recover", sessionCmd)
 		}
 	case "distill":
+		if !auth.IsMemoryEnabled() {
+			return fmt.Errorf("memory features are not enabled\nSet FEATURE_MEMORY=true to enable")
+		}
 		return runAgentDistill(inst, cmd)
 	case "hook":
 		return runAgentHook(subargs)
 	default:
-		return fmt.Errorf("unknown command: %s\nAvailable: distill, doctor, hook, session", subcommand)
+		available := "doctor, hook, session"
+		if auth.IsMemoryEnabled() {
+			available = "distill, " + available
+		}
+		return fmt.Errorf("unknown command: %s\nAvailable: %s", subcommand, available)
 	}
 }
 

--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -26,7 +26,6 @@ import (
 )
 
 var importFlags struct {
-	title string
 	text  string
 	date  string
 	force bool
@@ -41,7 +40,7 @@ var importCmd = &cobra.Command{
 Documents are stored with LFS-backed content and git-tracked metadata.
 AI coworkers extract text before importing for indexing:
 
-  ox import report.pdf --text extracted.md --title "Q1 Report"
+  ox import report.pdf --text extracted.md
   ox import notes.md --date 2026-01-15
   ox import report.pdf --team my-team
 
@@ -52,30 +51,45 @@ or when working outside an initialized repo.`,
 }
 
 func init() {
-	importCmd.Flags().StringVar(&importFlags.title, "title", "", "document title (default: filename stem)")
-	importCmd.Flags().StringVar(&importFlags.text, "text", "", "path to pre-extracted text/markdown for indexing")
-	importCmd.Flags().StringVar(&importFlags.date, "date", "", "document date for filing (YYYY-MM-DD, default: file mtime)")
+	importCmd.Flags().StringVar(&importFlags.text, "text", "", "path to pre-extracted text/markdown for indexing (optional)")
+	importCmd.Flags().SetAnnotation("text", "cobra_annotation_flag_value_name", []string{"file"})
+	importCmd.Flags().StringVar(&importFlags.date, "date", "", "document date for filing (YYYY-MM-DD, default: attempts to auto-detect from file metadata)")
 	importCmd.Flags().BoolVar(&importFlags.force, "force", false, "re-import even if content hash already exists")
 	importCmd.Flags().StringVar(&importFlags.team, "team", "", "team ID (or slug/name when inside a repo)")
 }
 
 // docMeta is the metadata.json schema for imported documents.
+//
+// This manifest is a living document — the CLI creates it at import time with
+// the source file and any client-provided sidecars (e.g., "text-extract").
+// The SageOx server may later add or update server-generated sidecars such as
+// "what-matters" (a cached summary of what's relevant to the team from this
+// document). Server-side sidecars are versioned through normal git commits, so
+// the history of how a document's relevance evolves over time is preserved.
 type docMeta struct {
-	Version        string              `json:"version"`
-	Title          string              `json:"title"`
-	SourceFilename string              `json:"source_filename"`
-	ContentType    string              `json:"content_type"`
-	SourceSize     int64               `json:"source_size"`
-	SourceOID      string              `json:"source_oid"`
-	CreatedAt      string              `json:"created_at"`
-	ImportedAt     string              `json:"imported_at"`
-	HasTextExtract bool                `json:"has_text_extract"`
-	Path           string              `json:"path"`
-	Sidecars       map[string]sidecar  `json:"sidecars"`
+	Version        string             `json:"version"`
+	Title          string             `json:"title"`
+	SourceFilename string             `json:"source_filename"`
+	ContentType    string             `json:"content_type"`
+	SourceSize     int64              `json:"source_size"`
+	SourceOID      string             `json:"source_oid"`
+	CreatedAt      string             `json:"created_at"`
+	ImportedAt     string             `json:"imported_at"`
+	Path           string             `json:"path"`
+	Sidecars       map[string]sidecar `json:"sidecars"`
 }
 
 // sidecar describes an additional derived file associated with an imported document.
-// The map key in docMeta.Sidecars is the sidecar type (e.g., "text-extract").
+// The map key in docMeta.Sidecars is the sidecar type.
+//
+// Client-created sidecars (at import time):
+//   - "text-extract" — pre-extracted text/markdown for indexing
+//
+// Server-generated sidecars (added/updated post-import):
+//   - "what-matters" — a short summary of what's relevant to the team from this
+//     document. Periodically re-summarized as team context evolves, so it may be
+//     recommitted over time. Git history preserves how the document's relevance
+//     changes until it no longer matters at all.
 type sidecar struct {
 	Filename  string `json:"filename"`
 	OID       string `json:"oid"`
@@ -172,11 +186,8 @@ func runImport(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// derive directory name from --title or filename stem
-	dirName := importFlags.title
-	if dirName == "" {
-		dirName = inferTitle(srcPath)
-	}
+	// derive directory name from filename stem
+	dirName := inferTitle(srcPath)
 	dirSlug := slugify(dirName)
 
 	docDir := filepath.Join(docsBaseDir,
@@ -186,7 +197,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 		dirSlug,
 	)
 	if _, statErr := os.Stat(docDir); statErr == nil && !importFlags.force {
-		return fmt.Errorf("document directory already exists for this date — use --title to differentiate or --force to reimport: %s", docDir)
+		return fmt.Errorf("document directory already exists for this date — use --force to reimport: %s", docDir)
 	}
 	if err := os.MkdirAll(docDir, 0o755); err != nil {
 		return fmt.Errorf("create doc directory: %w", err)
@@ -257,10 +268,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	title := importFlags.title
-	if title == "" {
-		title = inferTitle(srcPath)
-	}
+	title := inferTitle(srcPath)
 
 	// build and write metadata.json (plain git, not LFS — stays readable without
 	// hydration). like pointer files, the local copy is ephemeral and cleaned up
@@ -288,7 +296,6 @@ func runImport(cmd *cobra.Command, args []string) error {
 		SourceOID:      srcRef.OID,
 		CreatedAt:      importDate.Format(time.RFC3339),
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
-		HasTextExtract: hasText,
 		Path:           relDocDir,
 		Sidecars:       sidecars,
 	}

--- a/cmd/ox/import_integration_test.go
+++ b/cmd/ox/import_integration_test.go
@@ -37,7 +37,6 @@ func TestCommitAndPushDocImport_Success(t *testing.T) {
 		SourceOID:      srcRef.OID,
 		CreatedAt:      "2026-01-15",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
-		HasTextExtract: false,
 	}
 	metaData, err := json.MarshalIndent(meta, "", "  ")
 	require.NoError(t, err)
@@ -90,7 +89,6 @@ func TestCommitAndPushDocImport_WithTextExtract(t *testing.T) {
 		SourceOID:      srcRef.OID,
 		CreatedAt:      "2026-02-14",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
-		HasTextExtract: true,
 		Sidecars: map[string]sidecar{
 			"text-extract": {
 				Filename:  "extracted.md",
@@ -145,7 +143,6 @@ func TestCommitAndPushDocImport_GitattributesIncluded(t *testing.T) {
 		SourceOID:      srcRef.OID,
 		CreatedAt:      "2026-03-01",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
-		HasTextExtract: false,
 	}
 	metaData, err := json.MarshalIndent(meta, "", "  ")
 	require.NoError(t, err)
@@ -186,7 +183,6 @@ func TestCommitAndPushDocImport_NothingToCommit(t *testing.T) {
 		SourceOID:      srcRef.OID,
 		CreatedAt:      "2026-01-01",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
-		HasTextExtract: false,
 	}
 	metaData, err := json.MarshalIndent(meta, "", "  ")
 	require.NoError(t, err)
@@ -332,7 +328,6 @@ func TestImportEmptyFile(t *testing.T) {
 		SourceOID:      ref.OID,
 		CreatedAt:      "2026-01-01",
 		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
-		HasTextExtract: false,
 	}
 	data, err := json.Marshal(meta)
 	require.NoError(t, err)

--- a/cmd/ox/import_test.go
+++ b/cmd/ox/import_test.go
@@ -195,8 +195,7 @@ func TestDocMetaSerialization(t *testing.T) {
 		SourceOID:      srcRef.OID,
 		CreatedAt:      time.Date(2026, 2, 14, 10, 30, 0, 0, time.UTC).Format(time.RFC3339),
 		ImportedAt:     now,
-		HasTextExtract: true,
-		Path:           "data/docs/2026/02/14/test-doc",
+		Path: "data/docs/2026/02/14/test-doc",
 		Sidecars: map[string]sidecar{
 			"text-extract": {
 				Filename:  "extracted.md",
@@ -221,7 +220,6 @@ func TestDocMetaSerialization(t *testing.T) {
 	assert.Equal(t, float64(srcRef.Size), parsed["source_size"])
 	assert.True(t, strings.HasPrefix(parsed["source_oid"].(string), "sha256:"))
 	assert.Equal(t, "2026-02-14T10:30:00Z", parsed["created_at"])
-	assert.Equal(t, true, parsed["has_text_extract"])
 	assert.Equal(t, "data/docs/2026/02/14/test-doc", parsed["path"])
 
 	// verify sidecars keyed by type with filename inside

--- a/cmd/ox/memory.go
+++ b/cmd/ox/memory.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/sageox/ox/internal/auth"
+	"github.com/spf13/cobra"
+)
 
 var memoryCmd = &cobra.Command{
 	Use:   "memory",
@@ -11,5 +14,7 @@ var memoryCmd = &cobra.Command{
 func init() {
 	memoryCmd.AddCommand(memoryPutCmd)
 	memoryCmd.AddCommand(memoryDistillCmd)
-	rootCmd.AddCommand(memoryCmd)
+	if auth.IsMemoryEnabled() {
+		rootCmd.AddCommand(memoryCmd)
+	}
 }

--- a/cmd/ox/root.go
+++ b/cmd/ox/root.go
@@ -275,7 +275,7 @@ func brandedHelp(cmd *cobra.Command, args []string) {
 				flagStr = fmt.Sprintf("      --%s", flag.Name)
 			}
 			if flag.Value.Type() != "bool" {
-				flagStr += " " + flag.Value.Type()
+				flagStr += " " + flagValueLabel(flag)
 			}
 			padded := fmt.Sprintf("%-26s", flagStr)
 			fmt.Printf("%s %s\n", cli.StyleFlag.Render(padded), formatUsage(flag.Usage))
@@ -297,7 +297,7 @@ func brandedHelp(cmd *cobra.Command, args []string) {
 				flagStr = fmt.Sprintf("      --%s", flag.Name)
 			}
 			if flag.Value.Type() != "bool" {
-				flagStr += " " + flag.Value.Type()
+				flagStr += " " + flagValueLabel(flag)
 			}
 			padded := fmt.Sprintf("%-26s", flagStr)
 			fmt.Printf("%s %s\n", cli.StyleFlag.Render(padded), formatUsage(flag.Usage))
@@ -343,6 +343,16 @@ func formatDescription(desc string) string {
 }
 
 // formatUsage styles flag usage text with highlighted file paths
+// flagValueLabel returns the display label for a flag's value placeholder.
+// Uses the "cobra_annotation_flag_value_name" annotation if set (e.g., "file"),
+// otherwise falls back to pflag's Type() (e.g., "string").
+func flagValueLabel(flag *pflag.Flag) string {
+	if ann, ok := flag.Annotations["cobra_annotation_flag_value_name"]; ok && len(ann) > 0 {
+		return ann[0]
+	}
+	return flag.Value.Type()
+}
+
 func formatUsage(usage string) string {
 	// find all file path matches
 	matches := filePathPattern.FindAllStringIndex(usage, -1)

--- a/internal/auth/feature.go
+++ b/internal/auth/feature.go
@@ -56,3 +56,11 @@ func IsPostMVPEnabled() bool {
 	value := strings.ToLower(os.Getenv("FEATURE_POST_MVP"))
 	return value == "true" || value == "1" || value == "yes"
 }
+
+// IsMemoryEnabled checks if memory features (ox memory, ox agent <id> distill) are enabled.
+// Memory is experimental and not included in the default experience.
+// Set FEATURE_MEMORY=true to enable.
+func IsMemoryEnabled() bool {
+	value := strings.ToLower(os.Getenv("FEATURE_MEMORY"))
+	return value == "true" || value == "1" || value == "yes"
+}

--- a/internal/auth/feature_test.go
+++ b/internal/auth/feature_test.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestIsMemoryEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"true", "true", true},
+		{"TRUE", "TRUE", true},
+		{"1", "1", true},
+		{"yes", "yes", true},
+		{"false", "false", false},
+		{"0", "0", false},
+		{"no", "no", false},
+		{"random", "random", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FEATURE_MEMORY", tt.value)
+			if got := IsMemoryEnabled(); got != tt.want {
+				t.Errorf("IsMemoryEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Refined `ox import`: removed `--title` flag (title now derived from filename only), marked `--text` as optional, improved help text to show `--text <file>`.
- Cleaned up metadata.json schema: removed redundant `has_text_extract` field, added comprehensive comments explaining manifest as living document with server-generated sidecars (e.g., `what-matters` for relevance summaries).

## Test Plan

- Build: `make build` ✓
- Import tests: `go test ./cmd/ox/ -run Import` ✓
- Feature flag tests: `go test ./internal/auth/ -run Memory` ✓
- Full test suite: `make test` (5737 tests pass)
- Verify memory hidden: `ox memory --help` (fails with command not found)
- Verify memory visible: `FEATURE_MEMORY=true ox memory --help` (shows commands)

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory features can now be controlled via environment variable.

* **Refactor**
  * Simplified import process—the --title flag has been removed; directory naming now defaults to source filename stem.
  * Memory subcommand availability is now controlled by feature flag with dynamic error messaging.
  * Improved help text formatting for command-line flag value labels.

* **Tests**
  * Added tests for feature flag behavior.
  * Updated tests to reflect metadata simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->