### PR TITLE
fix: 15-min cooldown between friction events (e2e testing issue)

### DIFF
--- a/internal/daemon/flush_throttle.go
+++ b/internal/daemon/flush_throttle.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"sync"
+	"time"
+)
+
+// FlushThrottle prevents thundering herd flushes by enforcing a minimum cooldown
+// between flush operations. Without throttling, every Record() call above a batch
+// threshold can spawn a new flush goroutine, creating unbounded HTTP POSTs.
+//
+// Usage: call TryFlush() before spawning a flush goroutine. It atomically claims
+// a flush slot if the cooldown has elapsed. Call RecordFlush() from the flush
+// function itself (e.g., ticker-triggered flushes that bypass TryFlush).
+type FlushThrottle struct {
+	mu        sync.Mutex
+	lastFlush time.Time
+	cooldown  time.Duration
+}
+
+// NewFlushThrottle creates a throttle with the given minimum interval between flushes.
+func NewFlushThrottle(cooldown time.Duration) *FlushThrottle {
+	return &FlushThrottle{cooldown: cooldown}
+}
+
+// TryFlush atomically checks if the cooldown has elapsed and claims the flush slot.
+// Returns true if the caller should proceed with flushing.
+func (ft *FlushThrottle) TryFlush() bool {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+
+	if time.Since(ft.lastFlush) < ft.cooldown {
+		return false
+	}
+	ft.lastFlush = time.Now()
+	return true
+}
+
+// RecordFlush updates the last flush timestamp. Use this for flushes triggered
+// by the background ticker (which bypass TryFlush).
+func (ft *FlushThrottle) RecordFlush() {
+	ft.mu.Lock()
+	ft.lastFlush = time.Now()
+	ft.mu.Unlock()
+}

--- a/internal/daemon/flush_throttle_test.go
+++ b/internal/daemon/flush_throttle_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlushThrottle_TryFlush_FirstCallSucceeds(t *testing.T) {
+	ft := NewFlushThrottle(15 * time.Minute)
+	assert.True(t, ft.TryFlush(), "first TryFlush should succeed")
+}
+
+func TestFlushThrottle_TryFlush_SecondCallWithinCooldownFails(t *testing.T) {
+	ft := NewFlushThrottle(15 * time.Minute)
+	assert.True(t, ft.TryFlush())
+	assert.False(t, ft.TryFlush(), "second TryFlush within cooldown should fail")
+}
+
+func TestFlushThrottle_TryFlush_SucceedsAfterCooldown(t *testing.T) {
+	ft := NewFlushThrottle(1 * time.Millisecond)
+	assert.True(t, ft.TryFlush())
+
+	time.Sleep(5 * time.Millisecond)
+	assert.True(t, ft.TryFlush(), "TryFlush should succeed after cooldown elapses")
+}
+
+func TestFlushThrottle_RecordFlush_ResetsCooldown(t *testing.T) {
+	ft := NewFlushThrottle(15 * time.Minute)
+	ft.RecordFlush()
+	assert.False(t, ft.TryFlush(), "TryFlush should fail after RecordFlush resets cooldown")
+}
+
+func TestFlushThrottle_ConcurrentTryFlush_OnlyOneWins(t *testing.T) {
+	ft := NewFlushThrottle(15 * time.Minute)
+
+	var wins atomic.Int32
+	var wg sync.WaitGroup
+
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if ft.TryFlush() {
+				wins.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(1), wins.Load(), "exactly one goroutine should win the flush slot")
+}

--- a/internal/daemon/friction.go
+++ b/internal/daemon/friction.go
@@ -27,6 +27,12 @@ const (
 	// frictionBatchThreshold triggers early flush when buffer reaches this count.
 	frictionBatchThreshold = 20
 
+	// frictionFlushCooldown is the minimum interval between any two flush operations.
+	// Prevents thundering herd: without this, every Record() call above the batch
+	// threshold spawns a new flush goroutine, creating unbounded HTTP POSTs under
+	// rapid input (e.g., a runaway client generating unique args in a loop).
+	frictionFlushCooldown = 15 * time.Minute
+
 	// frictionDefaultEndpoint is the fallback friction API endpoint when no project
 	// endpoint is configured. Matches endpoint.Default.
 	frictionDefaultEndpoint = "https://sageox.ai"
@@ -41,6 +47,7 @@ type FrictionCollector struct {
 	buffer       *uxfriction.RingBuffer
 	client       *uxfriction.Client
 	catalogCache *CatalogCache
+	throttle     *FlushThrottle
 
 	enabled      bool
 	shutdown     chan struct{}
@@ -71,6 +78,7 @@ func NewFrictionCollector(logger *slog.Logger, projectEndpoint string) *Friction
 	fc := &FrictionCollector{
 		buffer:       uxfriction.NewRingBuffer(frictionBufferSize),
 		catalogCache: NewCatalogCache(),
+		throttle:     NewFlushThrottle(frictionFlushCooldown),
 		enabled:      enabled,
 		shutdown:     make(chan struct{}),
 		logger:       logger,
@@ -183,13 +191,12 @@ func (f *FrictionCollector) Record(event uxfriction.FrictionEvent) {
 
 	f.buffer.Add(event)
 
-	// trigger early flush if threshold reached
-	if f.buffer.Count() >= frictionBatchThreshold {
+	// trigger early flush if threshold reached AND cooldown has elapsed
+	if f.buffer.Count() >= frictionBatchThreshold && f.throttle.TryFlush() {
 		select {
 		case <-f.shutdown:
 			// don't trigger if shutting down
 		default:
-			// non-blocking signal to flush
 			go f.flush()
 		}
 	}
@@ -228,6 +235,10 @@ func (f *FrictionCollector) flush() {
 	if len(events) == 0 {
 		return
 	}
+
+	// record flush time to enforce cooldown in Record()
+	// only reset when actually sending to avoid empty ticker flushes consuming the window
+	f.throttle.RecordFlush()
 
 	// submit events
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/daemon/friction_test.go
+++ b/internal/daemon/friction_test.go
@@ -692,6 +692,7 @@ func TestFrictionCollector_CatalogVersionHeader(t *testing.T) {
 		buffer:       uxfriction.NewRingBuffer(frictionBufferSize),
 		client:       uxfriction.NewClient(uxfriction.ClientConfig{Endpoint: server.URL, Version: "test"}),
 		catalogCache: &CatalogCache{filePath: catalogPath},
+		throttle:     NewFlushThrottle(frictionFlushCooldown),
 		enabled:      true,
 		shutdown:     make(chan struct{}),
 		logger:       logger,
@@ -736,6 +737,7 @@ func TestFrictionCollector_CatalogUpdateFromResponse(t *testing.T) {
 		buffer:       uxfriction.NewRingBuffer(frictionBufferSize),
 		client:       uxfriction.NewClient(uxfriction.ClientConfig{Endpoint: server.URL, Version: "test"}),
 		catalogCache: &CatalogCache{filePath: catalogPath},
+		throttle:     NewFlushThrottle(frictionFlushCooldown),
 		enabled:      true,
 		shutdown:     make(chan struct{}),
 		logger:       logger,
@@ -801,6 +803,7 @@ func TestFrictionCollector_CatalogNotUpdatedWhenSameVersion(t *testing.T) {
 		buffer:       uxfriction.NewRingBuffer(frictionBufferSize),
 		client:       uxfriction.NewClient(uxfriction.ClientConfig{Endpoint: server.URL, Version: "test"}),
 		catalogCache: &CatalogCache{filePath: catalogPath},
+		throttle:     NewFlushThrottle(frictionFlushCooldown),
 		enabled:      true,
 		shutdown:     make(chan struct{}),
 		logger:       logger,
@@ -832,6 +835,7 @@ func TestFrictionCollector_UpdateCatalog(t *testing.T) {
 		buffer:       uxfriction.NewRingBuffer(frictionBufferSize),
 		client:       uxfriction.NewClient(uxfriction.ClientConfig{Endpoint: "http://test", Version: "test"}),
 		catalogCache: &CatalogCache{filePath: catalogPath},
+		throttle:     NewFlushThrottle(frictionFlushCooldown),
 		enabled:      true,
 		shutdown:     make(chan struct{}),
 		logger:       logger,
@@ -878,6 +882,7 @@ func TestFrictionCollector_StatsIncludesCatalogVersion(t *testing.T) {
 		buffer:       uxfriction.NewRingBuffer(frictionBufferSize),
 		client:       uxfriction.NewClient(uxfriction.ClientConfig{Endpoint: "http://test", Version: "test"}),
 		catalogCache: &CatalogCache{filePath: catalogPath},
+		throttle:     NewFlushThrottle(frictionFlushCooldown),
 		enabled:      true,
 		shutdown:     make(chan struct{}),
 		logger:       logger,
@@ -886,6 +891,45 @@ func TestFrictionCollector_StatsIncludesCatalogVersion(t *testing.T) {
 
 	stats := fc.Stats()
 	assert.Equal(t, "v2026-01-17-005", stats.CatalogVersion)
+}
+
+// TestFrictionCollector_FlushCooldown_PreventsThunderingHerd verifies that rapid
+// event recording does not trigger unbounded HTTP requests. Before this fix,
+// every Record() call above the batch threshold spawned a new flush goroutine,
+// creating ~1 HTTP POST per 20 events with no cooldown. This caused 1,443 POSTs
+// to hit production in 15 seconds during a test run on 2026-03-04.
+func TestFrictionCollector_FlushCooldown_PreventsThunderingHerd(t *testing.T) {
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv("SAGEOX_FRICTION_ENDPOINT", server.URL)
+
+	logger := testLogger()
+	fc := NewFrictionCollector(logger, "")
+
+	// rapidly record 200 events with unique inputs (bypasses dedup)
+	for i := range 200 {
+		fc.Record(uxfriction.FrictionEvent{
+			Kind:  "unknown-command",
+			Input: fmt.Sprintf("rapid-test-%d", i),
+		})
+	}
+
+	// allow goroutines to settle
+	time.Sleep(100 * time.Millisecond)
+
+	// with cooldown, at most 1 early flush should have fired (the first one
+	// that crosses the batch threshold). Subsequent Record() calls see that
+	// lastFlush is recent and skip the flush goroutine.
+	count := requestCount.Load()
+	if count > 1 {
+		t.Errorf("requestCount = %d, want <= 1 (cooldown should prevent thundering herd)", count)
+	}
 }
 
 // TestFrictionEvent_SynchronousDelivery_ExitSafe verifies that friction event

--- a/internal/daemon/telemetry.go
+++ b/internal/daemon/telemetry.go
@@ -32,6 +32,11 @@ const (
 	// telemetrySendTimeout for HTTP requests
 	telemetrySendTimeout = 5 * time.Second
 
+	// telemetryFlushCooldown is the minimum interval between any two flush operations.
+	// Prevents thundering herd: without this, every Record() call above the batch
+	// threshold spawns a new flush goroutine, creating unbounded HTTP POSTs.
+	telemetryFlushCooldown = 15 * time.Minute
+
 	// telemetryEndpoint is the default telemetry API endpoint
 	telemetryEndpoint = "https://telemetry.sageox.ai/tevents"
 )
@@ -54,6 +59,7 @@ type TelemetryCollector struct {
 	head       int              // next write position
 	count      int              // current number of events (0 to bufferSize)
 	bufferSize int              // max capacity
+	throttle   *FlushThrottle
 
 	sendInterval time.Duration // from server header (default 60s)
 	lastSend     time.Time
@@ -85,6 +91,7 @@ func NewTelemetryCollector(logger *slog.Logger) *TelemetryCollector {
 	return &TelemetryCollector{
 		buffer:       make([]TelemetryEvent, telemetryBufferSize),
 		bufferSize:   telemetryBufferSize,
+		throttle:     NewFlushThrottle(telemetryFlushCooldown),
 		sendInterval: telemetryDefaultInterval,
 		clientID:     getOrCreateClientID(),
 		appType:      "ox-daemon",
@@ -206,13 +213,12 @@ func (c *TelemetryCollector) Record(event string, props map[string]any) {
 	shouldFlush := c.count >= telemetryBatchThreshold
 	c.mu.Unlock()
 
-	// trigger early flush if threshold reached
-	if shouldFlush {
+	// trigger early flush if threshold reached AND cooldown has elapsed
+	if shouldFlush && c.throttle.TryFlush() {
 		select {
 		case <-c.shutdown:
 			// don't trigger if shutting down
 		default:
-			// non-blocking signal to flush
 			go c.flush()
 		}
 	}
@@ -274,6 +280,8 @@ func (c *TelemetryCollector) flush() {
 		return
 	}
 
+	// only reset cooldown when actually sending data
+	c.throttle.RecordFlush()
 	c.sendEvents(events)
 }
 

--- a/internal/daemon/telemetry_test.go
+++ b/internal/daemon/telemetry_test.go
@@ -502,6 +502,42 @@ func TestTelemetryCollector_Stop_Concurrent(t *testing.T) {
 	}, "concurrent Stop() calls should not panic")
 }
 
+// TestTelemetryCollector_FlushCooldown_PreventsThunderingHerd verifies that rapid
+// event recording does not trigger unbounded HTTP requests. Before this fix,
+// every Record() call above the batch threshold (50) spawned a new flush goroutine
+// with no cooldown, creating unbounded HTTP POSTs under rapid input.
+func TestTelemetryCollector_FlushCooldown_PreventsThunderingHerd(t *testing.T) {
+	var requestCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("SAGEOX_TELEMETRY", "")
+	t.Setenv("SAGEOX_TELEMETRY_ENDPOINT", server.URL)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	collector := NewTelemetryCollector(logger)
+
+	// rapidly record 200 events (well above batch threshold of 50)
+	for i := range 200 {
+		collector.Record("test:rapid", map[string]any{"index": i})
+	}
+
+	// allow goroutines to settle
+	time.Sleep(100 * time.Millisecond)
+
+	// with cooldown, at most 1 early flush should have fired
+	count := requestCount.Load()
+	if count > 1 {
+		t.Errorf("requestCount = %d, want <= 1 (cooldown should prevent thundering herd)", count)
+	}
+}
+
 func TestTelemetryCollector_RecordDuringShutdown(t *testing.T) {
 	t.Setenv("DO_NOT_TRACK", "")
 	t.Setenv("SAGEOX_TELEMETRY", "")

--- a/internal/testguard/testguard.go
+++ b/internal/testguard/testguard.go
@@ -103,6 +103,7 @@ func MinimalEnv(testVars []string) []string {
 		}
 	}
 	env = append(env, "OX_NO_DAEMON=1")
+	env = append(env, "DO_NOT_TRACK=1") // prevent friction telemetry hitting production
 	env = append(env, testVars...)
 	return env
 }

--- a/internal/testguard/testguard_test.go
+++ b/internal/testguard/testguard_test.go
@@ -23,6 +23,19 @@ func TestMinimalEnv_InjectsNoDaemon(t *testing.T) {
 	assert.True(t, found, "MinimalEnv should always inject OX_NO_DAEMON=1")
 }
 
+func TestMinimalEnv_InjectsDoNotTrack(t *testing.T) {
+	env := MinimalEnv(nil)
+
+	found := false
+	for _, kv := range env {
+		if kv == "DO_NOT_TRACK=1" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "MinimalEnv should always inject DO_NOT_TRACK=1")
+}
+
 func TestMinimalEnv_ExcludesSageoxEndpoint(t *testing.T) {
 	// even if SAGEOX_ENDPOINT is in the real env, MinimalEnv should NOT inherit it
 	t.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")


### PR DESCRIPTION
## Summary

Fixes a thundering herd bug where rapid event recording triggered unbounded HTTP POST requests to production. The issue: without cooldown throttling, every `Record()` call above the batch threshold spawned a new flush goroutine unconditionally, creating hundreds of POSTs per second. Production incident on 2026-03-04: 1,443 POSTs to friction API in 15 seconds from a single runaway client.

## Changes

- **New `FlushThrottle` struct** — Enforces 15-minute minimum cooldown between flush operations using atomic timestamp tracking
- **Friction + Telemetry** — Both collectors now gate early flushes behind `TryFlush()`, and only ticker flushes with actual data call `RecordFlush()` (preventing empty-buffer ticker runs from resetting the cooldown window)
- **Test coverage** — Regression tests verify cooldown suppresses thundering herd; test helper injects `DO_NOT_TRACK=1` to prevent telemetry pollution during test runs

## Impact

Buffer filling now triggers early flush only once per 15 minutes. Ticker-triggered flushes on empty buffers no longer consume the cooldown, ensuring the batch-threshold path remains functional. Telemetry and friction events now send with predictable request rate.

Co-Authored-By: SageOx <ox@sageox.ai>