### PR TITLE
Fix session start after clear + abort UX

### DIFF
--- a/.claude/commands/ox-session-abort.md
+++ b/.claude/commands/ox-session-abort.md
@@ -1,3 +1,6 @@
+<!-- Keep this file thin. Behavioral guidance (use-when, post-command, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 Abort the current session, discarding all local data without uploading to the ledger.
 This is destructive and cannot be undone. Use `/ox-session-stop` to save instead.
 

--- a/.claude/commands/ox-session-list.md
+++ b/.claude/commands/ox-session-list.md
@@ -1,3 +1,6 @@
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 List recent sessions from the project ledger and offer to view one.
 
 ## When to Use

--- a/.claude/commands/ox-session-start.md
+++ b/.claude/commands/ox-session-start.md
@@ -1,4 +1,9 @@
 <!-- ox-hash: b1e68f3b2727 ver: 0.17.0 -->
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.).
+     Exception: Post-Command sections that require agent-side actions (e.g.,
+     displaying a notice, generating a summary) are legitimate here. -->
 Start recording this agent session to the project ledger.
 
 Use when:

--- a/.claude/commands/ox-session-status.md
+++ b/.claude/commands/ox-session-status.md
@@ -1,4 +1,7 @@
 <!-- ox-hash: placeholder ver: 0.17.0 -->
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 Check the status of all active session recordings in this project.
 
 Use when:

--- a/.claude/commands/ox-session-stop.md
+++ b/.claude/commands/ox-session-stop.md
@@ -1,4 +1,9 @@
 <!-- ox-hash: 9b5ef157c16c ver: v0.13.0-1-gf9fefd1 -->
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.).
+     Exception: Post-Command sections that require agent-side actions (e.g.,
+     displaying a notice, generating a summary) are legitimate here. -->
 Stop recording and save this agent session to the project ledger.
 
 Use when:

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -947,6 +947,11 @@ func startSessionRecording(projectRoot, agentID, agentType string) *sessionStatu
 		}
 	}
 
+	// respect explicit session stop — user ran /ox-session-stop, don't auto-restart
+	if session.ConsumeExplicitStop(projectRoot) {
+		return nil
+	}
+
 	// check if already recording
 	if session.IsRecording(projectRoot) {
 		state, err := session.LoadRecordingState(projectRoot)

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -94,6 +94,9 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 		// non-ErrReadOnly errors fall through (fail-open)
 	}
 
+	// explicit start re-enables recording — clear any stop breadcrumb
+	session.ConsumeExplicitStop(projectRoot)
+
 	// one-time session recording notice (returned to caller via JSON)
 	notice := getSessionTermsNotice()
 
@@ -280,6 +283,9 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 		_ = doctor.SetNeedsDoctorAgent(projectRoot) // session data may be lost
 		return fmt.Errorf("failed to stop recording: %w", err)
 	}
+
+	// mark explicit stop so /clear hook doesn't silently auto-restart the session
+	_ = session.MarkExplicitStop(projectRoot)
 
 	duration := formatDurationHuman(state.Duration())
 

--- a/cmd/ox/agent_session_abort.go
+++ b/cmd/ox/agent_session_abort.go
@@ -18,6 +18,7 @@ type sessionAbortOutput struct {
 	AgentID     string `json:"agent_id"`
 	SessionName string `json:"session_name,omitempty"`
 	Message     string `json:"message"`
+	Guidance    string `json:"guidance,omitempty"`
 }
 
 // runAgentSessionAbort discards the active session without uploading to ledger.
@@ -78,6 +79,7 @@ func runAgentSessionAbort(inst *agentinstance.Instance, cmd *cobra.Command) erro
 		AgentID:     inst.AgentID,
 		SessionName: sessionName,
 		Message:     "session aborted and discarded",
+		Guidance:    "Session aborted and discarded. No further action needed. Continue with your current task.",
 	}
 
 	if cfg.Text || cfg.Review {

--- a/cmd/ox/agent_session_abort_test.go
+++ b/cmd/ox/agent_session_abort_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -193,4 +195,29 @@ func TestAbort_SessionFolderWithReadOnlyFiles(t *testing.T) {
 	_, err = os.Stat(state.SessionPath)
 	assert.True(t, os.IsNotExist(err),
 		"session folder with read-only files should be fully removed after abort")
+}
+
+func TestAbortOutputIncludesGuidance(t *testing.T) {
+	setupAbortTest(t)
+	setForceFlag(t, true)
+
+	// capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	inst := &agentinstance.Instance{AgentID: "OxAbrt"}
+	err := runAgentSessionAbort(inst, agentCmd)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	require.NoError(t, err)
+
+	out, _ := io.ReadAll(r)
+	var output sessionAbortOutput
+	require.NoError(t, json.Unmarshal(out, &output), "output should be valid JSON")
+	assert.True(t, output.Success)
+	assert.NotEmpty(t, output.Guidance, "abort JSON output must include guidance field")
+	assert.Contains(t, output.Guidance, "No further action needed")
 }

--- a/extensions/claude/commands/ox-session-abort.md
+++ b/extensions/claude/commands/ox-session-abort.md
@@ -1,3 +1,6 @@
+<!-- Keep this file thin. Behavioral guidance (use-when, post-command, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 Abort the current session, discarding all local data without uploading to the ledger.
 This is destructive and cannot be undone. Use `/ox-session-stop` to save instead.
 

--- a/extensions/claude/commands/ox-session-list.md
+++ b/extensions/claude/commands/ox-session-list.md
@@ -1,3 +1,6 @@
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 List recent sessions from the project ledger and offer to view one.
 
 ## When to Use

--- a/extensions/claude/commands/ox-session-start.md
+++ b/extensions/claude/commands/ox-session-start.md
@@ -1,3 +1,8 @@
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.).
+     Exception: Post-Command sections that require agent-side actions (e.g.,
+     displaying a notice, generating a summary) are legitimate here. -->
 Start recording this agent session to the project ledger.
 
 Use when:

--- a/extensions/claude/commands/ox-session-status.md
+++ b/extensions/claude/commands/ox-session-status.md
@@ -1,4 +1,7 @@
 <!-- ox-hash: placeholder ver: 0.17.0 -->
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 Check the status of all active session recordings in this project.
 
 Use when:

--- a/extensions/claude/commands/ox-session-stop.md
+++ b/extensions/claude/commands/ox-session-stop.md
@@ -1,3 +1,8 @@
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.).
+     Exception: Post-Command sections that require agent-side actions (e.g.,
+     displaying a notice, generating a summary) are legitimate here. -->
 Stop recording and save this agent session to the project ledger.
 
 Use when:

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -104,22 +104,7 @@ func LoadRecordingState(projectRoot string) (*RecordingState, error) {
 		return nil, fmt.Errorf("%w: project root", ErrEmptyPath)
 	}
 
-	// search for .recording.json in sessions directory structure
-	// check both project-local and XDG cache locations
-	sessionsPaths := []string{
-		filepath.Join(projectRoot, "sessions"),
-	}
-
-	// also check XDG cache location if we can determine repo ID
-	repoID := getRepoIDFromProject(projectRoot)
-	if repoID != "" {
-		contextPath := GetContextPath(repoID)
-		if contextPath != "" {
-			sessionsPaths = append(sessionsPaths, filepath.Join(contextPath, "sessions"))
-		}
-	}
-
-	for _, sessionsDir := range sessionsPaths {
+	for _, sessionsDir := range sessionsSearchPaths(projectRoot) {
 		entries, err := os.ReadDir(sessionsDir)
 		if err != nil {
 			continue // directory doesn't exist, try next
@@ -157,22 +142,10 @@ func LoadAllRecordingStates(projectRoot string) ([]*RecordingState, error) {
 		return nil, fmt.Errorf("%w: project root", ErrEmptyPath)
 	}
 
-	sessionsPaths := []string{
-		filepath.Join(projectRoot, "sessions"),
-	}
-
-	repoID := getRepoIDFromProject(projectRoot)
-	if repoID != "" {
-		contextPath := GetContextPath(repoID)
-		if contextPath != "" {
-			sessionsPaths = append(sessionsPaths, filepath.Join(contextPath, "sessions"))
-		}
-	}
-
 	seen := make(map[string]struct{}) // deduplicate by canonical recording file path
 	var states []*RecordingState
 
-	for _, sessionsDir := range sessionsPaths {
+	for _, sessionsDir := range sessionsSearchPaths(projectRoot) {
 		entries, err := os.ReadDir(sessionsDir)
 		if err != nil {
 			continue
@@ -240,6 +213,59 @@ func ClearRecordingState(projectRoot string) error {
 func IsRecording(projectRoot string) bool {
 	state, err := LoadRecordingState(projectRoot)
 	return err == nil && state != nil
+}
+
+const explicitStopMarker = ".session_stopped"
+
+// MarkExplicitStop writes a breadcrumb indicating the user explicitly stopped
+// recording. This prevents the next auto-start cycle (e.g. from /clear hook
+// re-prime) from silently restarting the session.
+func MarkExplicitStop(projectRoot string) error {
+	if projectRoot == "" {
+		return fmt.Errorf("%w: project root", ErrEmptyPath)
+	}
+	for _, dir := range sessionsSearchPaths(projectRoot) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			continue
+		}
+		markerPath := filepath.Join(dir, explicitStopMarker)
+		if err := os.WriteFile(markerPath, []byte(time.Now().Format(time.RFC3339)), 0600); err != nil {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("could not write explicit stop marker for project=%s", projectRoot)
+}
+
+// ConsumeExplicitStop checks for and removes the explicit-stop marker.
+// Returns true if the marker existed (meaning an auto-start should be skipped).
+func ConsumeExplicitStop(projectRoot string) bool {
+	if projectRoot == "" {
+		return false
+	}
+	for _, dir := range sessionsSearchPaths(projectRoot) {
+		markerPath := filepath.Join(dir, explicitStopMarker)
+		if err := os.Remove(markerPath); err == nil {
+			return true // marker existed and was removed
+		}
+	}
+	return false
+}
+
+// sessionsSearchPaths returns the sessions directory paths to search
+// (both project-local and XDG cache).
+func sessionsSearchPaths(projectRoot string) []string {
+	paths := []string{
+		filepath.Join(projectRoot, "sessions"),
+	}
+	repoID := getRepoIDFromProject(projectRoot)
+	if repoID != "" {
+		contextPath := GetContextPath(repoID)
+		if contextPath != "" {
+			paths = append(paths, filepath.Join(contextPath, "sessions"))
+		}
+	}
+	return paths
 }
 
 // GetRecordingDuration returns how long the current recording has been running.

--- a/internal/session/recording_test.go
+++ b/internal/session/recording_test.go
@@ -945,3 +945,64 @@ func TestLoadAllRecordingStates_Deduplicates(t *testing.T) {
 	// cleanup
 	_, _ = StopRecording(projectRoot)
 }
+
+func TestStopThenStartSameAgent(t *testing.T) {
+	cacheDir := t.TempDir()
+	projectRoot := setupRecordingTest(t, cacheDir)
+
+	// start recording
+	_, err := StartRecording(projectRoot, StartRecordingOptions{
+		AgentID: "OxSame1", AdapterName: "claude-code", Username: "testuser",
+	})
+	require.NoError(t, err)
+	require.True(t, IsRecording(projectRoot))
+
+	// stop recording
+	_, err = StopRecording(projectRoot)
+	require.NoError(t, err)
+	require.False(t, IsRecording(projectRoot))
+
+	// start again with same agent — must succeed
+	state2, err := StartRecording(projectRoot, StartRecordingOptions{
+		AgentID: "OxSame1", AdapterName: "claude-code", Username: "testuser",
+	})
+	require.NoError(t, err, "start after stop with same agent must succeed")
+	require.NotNil(t, state2)
+	assert.Equal(t, "OxSame1", state2.AgentID)
+
+	// cleanup
+	_, _ = StopRecording(projectRoot)
+}
+
+func TestExplicitStopMarker(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionsDir := filepath.Join(tmpDir, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0755))
+
+	// no marker initially
+	assert.False(t, ConsumeExplicitStop(tmpDir), "no marker should exist initially")
+
+	// write marker
+	require.NoError(t, MarkExplicitStop(tmpDir))
+
+	// marker file should exist
+	markerPath := filepath.Join(sessionsDir, explicitStopMarker)
+	_, err := os.Stat(markerPath)
+	assert.NoError(t, err, "marker file should exist after MarkExplicitStop")
+
+	// consume removes it and returns true
+	assert.True(t, ConsumeExplicitStop(tmpDir), "ConsumeExplicitStop should return true when marker exists")
+
+	// second consume returns false (already consumed)
+	assert.False(t, ConsumeExplicitStop(tmpDir), "ConsumeExplicitStop should return false after already consumed")
+
+	// marker file should be gone
+	_, err = os.Stat(markerPath)
+	assert.True(t, os.IsNotExist(err), "marker file should be removed after consume")
+}
+
+func TestExplicitStopMarker_EmptyProjectRoot(t *testing.T) {
+	err := MarkExplicitStop("")
+	assert.Error(t, err, "MarkExplicitStop with empty root should error")
+	assert.False(t, ConsumeExplicitStop(""), "ConsumeExplicitStop with empty root should return false")
+}


### PR DESCRIPTION
## Summary

Fixes Vikas's bug where `/ox-session-start` fails after `/ox-session-stop` + `/clear`. Root cause: `/clear` hook auto-restarts a session the user explicitly stopped. Also adds guidance field to abort JSON so agents know no action is needed after abort.

## Problem

**User flow that breaks:**
1. `/ox-session-start` — recording starts
2. `/ox-session-stop` — recording stops, `.recording.json` cleared
3. `/clear` — SessionStart hook fires, forces re-prime
4. Prime auto-starts recording (because IsRecording=false) — `.recording.json` created
5. `/ox-session-start` — sees `.recording.json`, same agent ID → `ErrAlreadyRecording`

User doesn't know a session was silently restarted in step 4.

## Solution

After explicit `session stop`, write a breadcrumb marker (`.session_stopped`). When auto-start tries to run, it checks for the marker — if present, skip auto-start and consume it. When the user runs explicit `session start`, it also consumes any pending marker.

**Key insight:** One explicit stop suppresses one auto-start cycle. The marker pattern respects user intent without changing adapter semantics.

## Changes

### Session recording state machine
- `MarkExplicitStop()` — write breadcrumb after `session stop`
- `ConsumeExplicitStop()` — check + remove marker, return true if it existed
- Extracted `sessionsSearchPaths()` helper (both project-local and XDG cache locations)

### Integration points
- `session stop`: calls `MarkExplicitStop()`
- `session start`: calls `ConsumeExplicitStop()` to clear pending marker
- `startSessionRecording()` in prime: checks `ConsumeExplicitStop()` before auto-starting

### Abort output
- Added `guidance` field to JSON output: "No further action needed"
- All session skill templates include inline documentation explaining thin-wrapper principle
- Behavioral guidance belongs in CLI JSON output (available to all agents), not skill files

## Testing

✅ All 5761 tests pass (0 failures)  
✅ New tests: `TestStopThenStartSameAgent`, `TestExplicitStopMarker*`, `TestAbortOutputIncludesGuidance`

## Issues Addressed

Fixes [#132](https://github.com/sageox/ox/issues/132) — Session start fails after stop+clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session restart behavior—sessions now properly respect explicit stop commands and will not auto-restart unexpectedly.

* **New Features**
  * Session operations now include clearer guidance messages in command output.

* **Documentation**
  * Updated command documentation with improved clarity on session management guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->