### PR TITLE
chore: migrate session skill guidance to CLI JSON

### DIFF
--- a/.claude/commands/ox-session-list.md
+++ b/.claude/commands/ox-session-list.md
@@ -3,11 +3,6 @@
      Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 List recent sessions from the project ledger and offer to view one.
 
-## When to Use
-- Reviewing what happened in recent sessions
-- Viewing a teammate's session
-- Checking session history for context
-
 ## Steps
 
 1. Run the command below to show recent sessions:

--- a/.claude/commands/ox-session-start.md
+++ b/.claude/commands/ox-session-start.md
@@ -6,32 +6,10 @@
      displaying a notice, generating a summary) are legitimate here. -->
 Start recording this agent session to the project ledger.
 
-Use when:
-- Beginning a new coding session you want captured
-- Starting work on a feature, bug fix, or investigation worth recording
-- You want decisions and context preserved for teammates
-- Resuming work after a break and want to record the new session
-
-Keywords: session start, record, capture, begin, log, track, ledger, start recording
-
-## Common Issues
-
-### Already recording
-**Symptom:** `session already active` or similar error
-**Solution:** A session is already in progress. Run `ox agent <id> session stop` first if you need to restart
-
-### No agent detected
-**Symptom:** Agent ID is missing or unrecognized
-**Solution:** Run `ox agent prime` first to register this agent instance
-
-### Not initialized
-**Symptom:** No SageOx configuration found
-**Solution:** Run `ox init` to initialize SageOx in this repository
-
 ## Post-Command (REQUIRED)
 
 After the command completes, check the JSON output:
 - **`notice`**: If present, display the notice text to the user verbatim. This is a one-time transparency notice about session recording.
-- **`guidance`**: Follow this guidance throughout the session. It contains instructions about plan capture and session boundaries.
+- **`guidance`**: Follow this guidance throughout the session. It contains instructions about plan capture, session boundaries, and troubleshooting.
 
 $ox agent session start

--- a/.claude/commands/ox-session-status.md
+++ b/.claude/commands/ox-session-status.md
@@ -4,33 +4,12 @@
      Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 Check the status of all active session recordings in this project.
 
-Use when:
-- Checking if a recording is currently in progress
-- Verifying which agents have active recordings
-- Debugging session state before starting or stopping a recording
-- Confirming your agent's recording is active after context compaction
-
-Keywords: session status, check, recording, active, inflight, am I recording, is recording
-
-## Common Issues
-
-### Not recording
-**Symptom:** `Not recording` message
-**Solution:** No sessions are active. Run `/ox-session-start` to begin recording
-
-### Multiple recordings shown
-**Symptom:** Multiple recordings displayed
-**Explanation:** This is normal when multiple worktrees or agents are recording simultaneously. Use `--current` to see only your agent's recording.
-
-### --current shows nothing
-**Symptom:** `--current` returns "Not recording" even though recordings exist
-**Solution:** SAGEOX_AGENT_ID environment variable may not be set. Run `ox agent prime` first.
-
 ## Post-Command
 
 After the command completes, check the JSON output:
 - **`recording: true`** — A session is active. Continue working normally.
 - **`recording: false`** — No active session. Consider running `/ox-session-start` if you want to record.
+- **`guidance`** — Follow any guidance returned by the CLI.
 - **`count > 1`** — Multiple concurrent recordings. The `sessions` array shows each one.
 - **`agent_id`** — The agent ID of the recording. Compare with your own to identify your session.
 

--- a/.claude/commands/ox-session-stop.md
+++ b/.claude/commands/ox-session-stop.md
@@ -6,32 +6,10 @@
      displaying a notice, generating a summary) are legitimate here. -->
 Stop recording and save this agent session to the project ledger.
 
-Use when:
-- Finishing a coding session and want to save the recording
-- Wrapping up a feature, investigation, or bug fix
-- Ending work for the day and want context preserved
-- Before switching to a different task or repository
-
-Keywords: session stop, save, finish, end, done, wrap up, stop recording, upload, ledger
-
-## Common Issues
-
-### Not recording
-**Symptom:** `no active session` or similar error
-**Solution:** No session is currently active. Run `ox agent <id> session start` first
-
-### LFS upload failed
-**Symptom:** Session saved locally but upload to ledger failed
-**Solution:** Check network connectivity and retry. The session data is saved locally and can be pushed later
-
-### Summary generation slow
-**Symptom:** Command hangs during "Generating summary..."
-**Solution:** Summarization runs client-side. Wait for completion or check network if it stalls
-
 ## Post-Command: Generate and Push Summary (REQUIRED)
 
-After the command completes, check the JSON output for a `summary_prompt` field.
-This step is critical for session completeness — without it, the session has no rich summary.
+After the command completes, check the JSON output for `guidance` and `summary_prompt` fields.
+Follow the `guidance` field for next steps. The summary step is critical for session completeness.
 
 **If `summary_prompt` is present:**
 1. Read the prompt carefully — it references the raw session file on disk

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -50,7 +50,11 @@ import (
 const sessionStartGuidance = `During this recorded session:
 1. Plan capture: After creating or revising a plan, immediately save it with: cat <plan-file> | ox agent <id> session plan
 2. After stopping: Check the session stop output for plan_path. If empty and you created a plan, save it now with: cat <plan-file> | ox agent <id> session plan
-3. Session boundaries: One plan per session. If work shifts to an unrelated feature, suggest stopping this session and starting a new one.`
+3. Session boundaries: One plan per session. If work shifts to an unrelated feature, suggest stopping this session and starting a new one.
+Troubleshooting: If 'session already active' error, run session stop first. If agent ID missing, run 'ox agent prime'. If not initialized, run 'ox init'.`
+
+// sessionStopGuidance is behavioral guidance returned in the session stop JSON output.
+const sessionStopGuidance = `Session stopped and saved. Check the summary_prompt field — if present, follow its instructions to generate and push a rich summary. If summary generation fails, the session data is safe; run 'ox agent <id> doctor' to recover.`
 
 // sessionStartOutput is the JSON output format for session start.
 type sessionStartOutput struct {
@@ -419,6 +423,7 @@ func outputSessionStopJSON(inst *agentinstance.Instance, state *session.Recordin
 		Type:     "session_stop",
 		AgentID:  inst.AgentID,
 		Duration: duration,
+		Guidance: sessionStopGuidance,
 	}
 	if state.Title != "" {
 		output.Title = state.Title
@@ -474,6 +479,7 @@ type sessionStopOutput struct {
 	EventsAfterFilter  int    `json:"events_after_filter,omitempty"`  // events after filtering
 	LedgerSessionDir   string `json:"ledger_session_dir,omitempty"`   // path to session dir in ledger
 	UploadWarning      string `json:"upload_warning,omitempty"`       // set when ledger upload failed
+	Guidance           string `json:"guidance,omitempty"`             // behavioral guidance for the agent
 }
 
 // parseTitle extracts --title value from args

--- a/extensions/claude/commands/ox-session-list.md
+++ b/extensions/claude/commands/ox-session-list.md
@@ -3,11 +3,6 @@
      Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 List recent sessions from the project ledger and offer to view one.
 
-## When to Use
-- Reviewing what happened in recent sessions
-- Viewing a teammate's session
-- Checking session history for context
-
 ## Steps
 
 1. Run the command below to show recent sessions:

--- a/extensions/claude/commands/ox-session-start.md
+++ b/extensions/claude/commands/ox-session-start.md
@@ -5,32 +5,10 @@
      displaying a notice, generating a summary) are legitimate here. -->
 Start recording this agent session to the project ledger.
 
-Use when:
-- Beginning a new coding session you want captured
-- Starting work on a feature, bug fix, or investigation worth recording
-- You want decisions and context preserved for teammates
-- Resuming work after a break and want to record the new session
+## Post-Command (REQUIRED)
 
-Keywords: session start, record, capture, begin, log, track, ledger, start recording
-
-## Common Issues
-
-### Already recording
-**Symptom:** `session already active` or similar error
-**Solution:** A session is already in progress. Run `ox agent <id> session stop` first if you need to restart
-
-### No agent detected
-**Symptom:** Agent ID is missing or unrecognized
-**Solution:** Run `ox agent prime` first to register this agent instance
-
-### Not initialized
-**Symptom:** No SageOx configuration found
-**Solution:** Run `ox init` to initialize SageOx in this repository
-
-## Post-Command: Show Notice (REQUIRED)
-
-After the command completes, check the JSON output for a `notice` field.
-If present, you MUST display the notice text to the user verbatim. This is a one-time
-transparency notice about session recording that the user needs to see.
+After the command completes, check the JSON output:
+- **`notice`**: If present, display the notice text to the user verbatim. This is a one-time transparency notice about session recording.
+- **`guidance`**: Follow this guidance throughout the session. It contains instructions about plan capture, session boundaries, and troubleshooting.
 
 $ox agent session start

--- a/extensions/claude/commands/ox-session-status.md
+++ b/extensions/claude/commands/ox-session-status.md
@@ -1,36 +1,14 @@
-<!-- ox-hash: placeholder ver: 0.17.0 -->
 <!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
      belongs in the ox CLI JSON output (guidance field), not here.
      Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
 Check the status of all active session recordings in this project.
-
-Use when:
-- Checking if a recording is currently in progress
-- Verifying which agents have active recordings
-- Debugging session state before starting or stopping a recording
-- Confirming your agent's recording is active after context compaction
-
-Keywords: session status, check, recording, active, inflight, am I recording, is recording
-
-## Common Issues
-
-### Not recording
-**Symptom:** `Not recording` message
-**Solution:** No sessions are active. Run `/ox-session-start` to begin recording
-
-### Multiple recordings shown
-**Symptom:** Multiple recordings displayed
-**Explanation:** This is normal when multiple worktrees or agents are recording simultaneously. Use `--current` to see only your agent's recording.
-
-### --current shows nothing
-**Symptom:** `--current` returns "Not recording" even though recordings exist
-**Solution:** SAGEOX_AGENT_ID environment variable may not be set. Run `ox agent prime` first.
 
 ## Post-Command
 
 After the command completes, check the JSON output:
 - **`recording: true`** — A session is active. Continue working normally.
 - **`recording: false`** — No active session. Consider running `/ox-session-start` if you want to record.
+- **`guidance`** — Follow any guidance returned by the CLI.
 - **`count > 1`** — Multiple concurrent recordings. The `sessions` array shows each one.
 - **`agent_id`** — The agent ID of the recording. Compare with your own to identify your session.
 

--- a/extensions/claude/commands/ox-session-stop.md
+++ b/extensions/claude/commands/ox-session-stop.md
@@ -5,26 +5,22 @@
      displaying a notice, generating a summary) are legitimate here. -->
 Stop recording and save this agent session to the project ledger.
 
-Use when:
-- Finishing a coding session and want to save the recording
-- Wrapping up a feature, investigation, or bug fix
-- Ending work for the day and want context preserved
-- Before switching to a different task or repository
+## Post-Command: Generate and Push Summary (REQUIRED)
 
-Keywords: session stop, save, finish, end, done, wrap up, stop recording, upload, ledger
+After the command completes, check the JSON output for `guidance` and `summary_prompt` fields.
+Follow the `guidance` field for next steps. The summary step is critical for session completeness.
 
-## Common Issues
+**If `summary_prompt` is present:**
+1. Read the prompt carefully — it references the raw session file on disk
+2. Read the raw session file at the path specified in the prompt
+3. Generate the summary JSON following the Output Format in the prompt
+4. Save it to a temporary file (e.g., `.ox-summary.json` in the workspace root, or `/tmp/ox-summary.json`) — do NOT write to the session cache dir as it may be outside the workspace sandbox
+5. If the prompt includes a `push-summary` step, run that command with `--file` pointing to your temp file
+6. Verify the push succeeded by checking the JSON output for `"success": true`
+7. Clean up the temporary summary file
 
-### Not recording
-**Symptom:** `no active session` or similar error
-**Solution:** No session is currently active. Run `ox agent <id> session start` first
-
-### LFS upload failed
-**Symptom:** Session saved locally but upload to ledger failed
-**Solution:** Check network connectivity and retry. The session data is saved locally and can be pushed later
-
-### Summary generation slow
-**Symptom:** Command hangs during "Generating summary..."
-**Solution:** Summarization runs client-side. Wait for completion or check network if it stalls
+**If summary generation fails:**
+- Run `ox agent <id> doctor` — it can detect and help recover missing summaries
+- The session data is safe regardless; only the rich summary is missing
 
 $ox agent session stop


### PR DESCRIPTION
## Summary

Moves behavioral guidance from Claude Code skill files (`.claude/commands/ox-session-*.md`) into the ox CLI's JSON output where all coding agents can access it. Session abort and status already had guidance; this adds it to session stop and expands session start. Skills are now thin wrappers relaying CLI output.

## Changes

- Added `sessionStopGuidance` constant and `Guidance` field to `sessionStopOutput`
- Expanded `sessionStartGuidance` to include troubleshooting (session already active, agent ID missing, not initialized)
- Removed Use-when, Keywords, and Common Issues sections from all 4 session skill files (8 files total, including extensions copies)
- Updated Post-Command sections to reference guidance fields

## Testing

- `make build` succeeds
- `make test` passes (5761 tests)
- All 9 files validated

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized session command documentation, removing redundant guidance sections for improved clarity.
  * Enhanced post-command guidance across session commands with comprehensive troubleshooting and error recovery information.
  * Updated session stop workflow with detailed recovery steps for handling failures and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->