### PR TITLE
fix: use $AGENT_ID instead of <id> in session command references

### DIFF
--- a/.claude/commands/ox-session-start.md
+++ b/.claude/commands/ox-session-start.md
@@ -12,4 +12,4 @@ After the command completes, check the JSON output:
 - **`notice`**: If present, display the notice text to the user verbatim. This is a one-time transparency notice about session recording.
 - **`guidance`**: Follow this guidance throughout the session. It contains instructions about plan capture, session boundaries, and troubleshooting.
 
-$ox agent session start
+$ox agent $AGENT_ID session start

--- a/.claude/commands/ox-session-stop.md
+++ b/.claude/commands/ox-session-stop.md
@@ -21,7 +21,7 @@ Follow the `guidance` field for next steps. The summary step is critical for ses
 7. Clean up the temporary summary file
 
 **If summary generation fails:**
-- Run `ox agent <id> doctor` — it can detect and help recover missing summaries
+- Run `ox agent $AGENT_ID doctor` — it can detect and help recover missing summaries
 - The session data is safe regardless; only the rich summary is missing
 
-$ox agent session stop
+$ox agent $AGENT_ID session stop

--- a/.claude/commands/ox.md
+++ b/.claude/commands/ox.md
@@ -35,8 +35,8 @@ Check authentication, project initialization, sync, and daemon health.
 
 ## Session Recording
 ```bash
-ox agent <id> session start   # begin recording
-ox agent <id> session stop    # stop and save to ledger
+ox agent $AGENT_ID session start   # begin recording
+ox agent $AGENT_ID session stop    # stop and save to ledger
 ```
 Record agent sessions to the project ledger for team visibility.
 

--- a/claude-plugin/commands/session-start.md
+++ b/claude-plugin/commands/session-start.md
@@ -12,7 +12,7 @@ Keywords: session start, record, capture, begin, log, track, ledger, start recor
 
 ### Already recording
 **Symptom:** `session already active` or similar error
-**Solution:** A session is already in progress. Run `ox agent <id> session stop` first if you need to restart
+**Solution:** A session is already in progress. Run `ox agent $AGENT_ID session stop` first if you need to restart
 
 ### No agent detected
 **Symptom:** Agent ID is missing or unrecognized
@@ -28,4 +28,4 @@ After the command completes, check the JSON output for a `notice` field.
 If present, you MUST display the notice text to the user verbatim. This is a one-time
 transparency notice about session recording that the user needs to see.
 
-$ox agent session start
+$ox agent $AGENT_ID session start

--- a/claude-plugin/commands/session-stop.md
+++ b/claude-plugin/commands/session-stop.md
@@ -12,7 +12,7 @@ Keywords: session stop, save, finish, end, done, wrap up, stop recording, upload
 
 ### Not recording
 **Symptom:** `no active session` or similar error
-**Solution:** No session is currently active. Run `ox agent <id> session start` first
+**Solution:** No session is currently active. Run `ox agent $AGENT_ID session start` first
 
 ### LFS upload failed
 **Symptom:** Session saved locally but upload to ledger failed
@@ -36,7 +36,7 @@ This step is critical for session completeness - without it, the session has no 
 6. Verify the push succeeded by checking the JSON output for `"success": true`
 
 **If summary generation fails:**
-- Run `ox agent <id> doctor` - it can detect and help recover missing summaries
+- Run `ox agent $AGENT_ID doctor` - it can detect and help recover missing summaries
 - The session data is safe regardless; only the rich summary is missing
 
-$ox agent session stop
+$ox agent $AGENT_ID session stop

--- a/claude-plugin/skills/ox/SKILL.md
+++ b/claude-plugin/skills/ox/SKILL.md
@@ -10,7 +10,7 @@ ox is a CLI that gives AI coworkers shared team context: conventions, architectu
 ## When to Use
 
 - **Starting work**: Run `ox agent prime` to load team context (conventions, norms, decisions)
-- **Recording sessions**: `ox agent session start` / `ox agent session stop` to capture work to the project ledger
+- **Recording sessions**: `ox agent $AGENT_ID session start` / `ox agent $AGENT_ID session stop` to capture work to the project ledger
 - **Checking health**: `ox status` for auth/sync/daemon state, `ox doctor` for diagnostics
 - **Initializing**: `ox init` to set up SageOx in a new repository
 
@@ -26,8 +26,8 @@ ox is a CLI that gives AI coworkers shared team context: conventions, architectu
 | Command | Purpose |
 |---------|---------|
 | `ox agent prime` | Load team context for this session |
-| `ox agent session start` | Begin recording a session |
-| `ox agent session stop` | Stop recording and push to ledger |
+| `ox agent $AGENT_ID session start` | Begin recording a session |
+| `ox agent $AGENT_ID session stop` | Stop recording and push to ledger |
 | `ox status` | Check auth, sync, daemon health |
 | `ox doctor` | Run diagnostic checks |
 | `ox init` | Initialize SageOx in a repository |


### PR DESCRIPTION
## Summary

- Replaces all `<id>` placeholders with `$AGENT_ID` in session command docs (both `.claude/commands/` and `claude-plugin/`)
- Ensures agents use the environment variable for their agent ID rather than a generic placeholder

## Files changed

- `.claude/commands/ox-session-start.md`
- `.claude/commands/ox-session-stop.md`
- `.claude/commands/ox.md`
- `claude-plugin/commands/session-start.md`
- `claude-plugin/commands/session-stop.md`
- `claude-plugin/skills/ox/SKILL.md`

## Test plan

- [ ] Verify `/ox-session-start` and `/ox-session-stop` commands resolve `$AGENT_ID` correctly at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples to use environment variable notation for agent ID parameters.
  * Clarified session start and stop command syntax with agent-scoped variants.
  * Added documentation for new commands: `ox conventions` and `ox session list`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->