### PR TITLE
fix: restore changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,20 @@ These are separate APIs by design. Do not conflate them.
 
 **IPC Architecture:** When implementing or fixing IPC issues between CLI and daemon, read [docs/ai/specs/ipc-architecture.md](docs/ai/specs/ipc-architecture.md). Key principles: IPC is never required (daemon works independently), fire-and-forget for non-critical ops, clone has a fallback (critical path exception).
 
+**Team Context and Ledger Repos Are NOT Read-Only Mirrors (Critical):**
+
+Team context repos and ledger repos are **collaborative workspaces** with both remote and local writes:
+- **Remote** pushes team knowledge (SOUL.md, docs/, memory/) and session data
+- **Local** writes happen via `ox import` (data/), daemon (`EnsureCheckoutGitignore`), `ox remember` (memory/), and direct user edits (docs/, memory/)
+- Uncommitted local changes represent **valuable in-progress work**, not garbage
+
+**NEVER discard uncommitted changes** in team context or ledger repos. Use `--autostash` on pulls to preserve local state while syncing. During blue-green GC reclone, carry dirty files from the old clone into the new one.
+
+**Git operations in sparse-checkout repos:**
+- All `git add` calls MUST use `--sparse` — without it, git (2.37+) refuses to stage files outside the sparse definition
+- All `git pull --rebase` calls MUST use `--autostash` — without it, uncommitted local changes block the pull entirely
+- Use `git add -f` when adding files inside paths excluded by `.gitignore` (e.g., `.sageox/.gitignore` when root `.gitignore` excludes `.sageox/`)
+
 **Daemon-CLI Git Operations Split:**
 
 The daemon only performs git pull (read) operations on ledgers and team contexts.
@@ -208,8 +222,9 @@ The CLI performs add/commit/push (write) operations directly on the ledger. This
 |-----------|-------|-------|
 | `git clone` | daemon | Initial setup / anti-entropy |
 | `git fetch` | daemon | Background sync timer |
-| `git pull --rebase` | daemon | Background sync timer |
-| `git add/commit` | CLI | Session upload pipeline |
+| `git pull --rebase --autostash` | daemon | Background sync timer |
+| `git add --sparse` | CLI | Session upload, import, doctor |
+| `git commit` | CLI | Session upload pipeline |
 | `git push` | CLI | Session upload pipeline |
 
 ```go

--- a/cmd/ox/agent_session_delete.go
+++ b/cmd/ox/agent_session_delete.go
@@ -151,7 +151,7 @@ func runAgentSessionDelete(inst *agentinstance.Instance, cmd *cobra.Command, arg
 }
 
 // deleteSessionFromLedger removes the session folder from the ledger git repo,
-// commits the removal, and pushes.
+// commits the removal, and pushes. NEVER uses --force push.
 func deleteSessionFromLedger(ledgerPath, sessionName, sessionDir string) error {
 	// git rm -r the session folder
 	gitRm := exec.Command("git", "rm", "-r", "--force", filepath.Join("sessions", sessionName))
@@ -168,7 +168,7 @@ func deleteSessionFromLedger(ledgerPath, sessionName, sessionDir string) error {
 		return fmt.Errorf("git commit: %s: %w", string(out), err)
 	}
 
-	// push
+	// push — no --force: ledger history must never be rewritten
 	gitPush := exec.Command("git", "push")
 	gitPush.Dir = ledgerPath
 	if out, err := gitPush.CombinedOutput(); err != nil {

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -641,19 +641,29 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 	})
 
 	// Category 5b: Ledger Git Health (SageOx is multiplayer - always check)
+	// Skip during bootstrap — ledger is still being cloned/initialized
 	progress.show("Ledger Git Health")
-	ledgerGitChecks := checkLedgerGitHealth(
-		opts.fix,
-		opts.shouldFix(CheckSlugLedgerRemote),
-		opts.shouldFix(CheckSlugGitignoreMissing),
-		opts.shouldFix(CheckSlugLedgerBranchStatus),
-		opts.shouldFix(CheckSlugLedgerCleanWorkdir),
-	)
-	if len(ledgerGitChecks) > 0 {
+	if state.isBootstrapping {
 		categories = append(categories, checkCategory{
-			name:   "Ledger Git Health",
-			checks: ledgerGitChecks,
+			name: "Ledger Git Health",
+			checks: []checkResult{
+				InfoCheck("Ledger git", "initial sync in progress", "Run `ox doctor` again in a minute"),
+			},
 		})
+	} else {
+		ledgerGitChecks := checkLedgerGitHealth(
+			opts.fix,
+			opts.shouldFix(CheckSlugLedgerRemote),
+			opts.shouldFix(CheckSlugGitignoreMissing),
+			opts.shouldFix(CheckSlugLedgerBranchStatus),
+			opts.shouldFix(CheckSlugLedgerCleanWorkdir),
+		)
+		if len(ledgerGitChecks) > 0 {
+			categories = append(categories, checkCategory{
+				name:   "Ledger Git Health",
+				checks: ledgerGitChecks,
+			})
+		}
 	}
 
 	// Category 6: Auth Security
@@ -691,13 +701,23 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 	})
 
 	// Category 9: Sessions
+	// Skip during bootstrap — session infrastructure depends on ledger being ready
 	progress.show("Sessions")
-	sessionChecks := checkSessionHealth(opts)
-	if len(sessionChecks) > 0 {
+	if state.isBootstrapping {
 		categories = append(categories, checkCategory{
-			name:   "Sessions",
-			checks: sessionChecks,
+			name: "Sessions",
+			checks: []checkResult{
+				InfoCheck("Sessions", "waiting for initial sync", ""),
+			},
 		})
+	} else {
+		sessionChecks := checkSessionHealth(opts)
+		if len(sessionChecks) > 0 {
+			categories = append(categories, checkCategory{
+				name:   "Sessions",
+				checks: sessionChecks,
+			})
+		}
 	}
 
 	// Category 10: Daemon

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -431,6 +431,15 @@ func init() {
 		Run:         checkGCBlockedByUntracked,
 	})
 
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugTeamSparseCheckout,
+		Name:        "Team sparse checkout",
+		Category:    "Team Context",
+		FixLevel:    FixLevelAuto,
+		Description: "Ensures team context sparse-checkout includes root-level file patterns (/* and !/*/)",
+		Run:         checkTeamSparseCheckout,
+	})
+
 	// ============================================================
 	// Daemon checks
 	// ============================================================

--- a/cmd/ox/doctor_e2e_test.go
+++ b/cmd/ox/doctor_e2e_test.go
@@ -240,10 +240,17 @@ func filterExpectedE2EIssues(checks []ReportCheck) []ReportCheck {
 
 // isExpectedE2EIssue returns true if the check is expected to fail/warn
 // in the E2E test environment.
+// IMPORTANT: Keep this tight — only exclude issues inherent to mock/test environments.
+// Do NOT exclude issues that indicate real bugs (unstaged files, uncommitted changes, etc.).
 func isExpectedE2EIssue(check ReportCheck) bool {
 	cat := check.Category
 	msg := check.Message
 	name := check.Name
+
+	// info-priority checks are informational, not actionable — always expected
+	if check.Priority == "info" {
+		return true
+	}
 
 	// daemon not running -- expected in E2E test (we don't start one)
 	if cat == "Daemon" {
@@ -261,30 +268,12 @@ func isExpectedE2EIssue(check ReportCheck) bool {
 		return true
 	}
 
-	// no real ledger/team context cloned
-	if cat == "Ledger Git Health" {
-		return true
-	}
+	// team context not cloned in test
 	if cat == "Team Context" {
 		return true
 	}
 
-	// git repo paths: repos syncing (info-level, expected right after init)
-	if containsAny(msg, "syncing", "no repos configured") {
-		return true
-	}
-
-	// uncommitted .sageox/ changes are expected right after init
-	if containsAny(msg, "unstaged") && containsAny(name, ".sageox/") {
-		return true
-	}
-
-	// uncommitted changes from init-created files
-	if containsAny(msg, "uncommitted change") {
-		return true
-	}
-
-	// sessions/ledger not provisioned locally
+	// sessions/ledger not provisioned locally (no daemon to clone)
 	if containsAny(name, "ledger for sessions") && containsAny(msg, "not provisioned") {
 		return true
 	}

--- a/cmd/ox/doctor_fresh_install_test.go
+++ b/cmd/ox/doctor_fresh_install_test.go
@@ -229,11 +229,12 @@ func createFreshSageoxStructure(t *testing.T, gitRoot string) {
 	require.NoError(t, cmd.Run(), "failed to git commit")
 }
 
-// collectIssues recursively collects warnings and failures from check results
+// collectIssues recursively collects warnings and failures from check results.
+// Info-priority checks (priority="info") are excluded — they are informational, not actionable.
 func collectIssues(check checkResult, category string, warnings, failures *[]string) {
 	prefix := category + ": " + check.name + ": "
 
-	if check.warning {
+	if check.warning && check.priority != "info" {
 		*warnings = append(*warnings, prefix+check.message)
 	}
 	if !check.passed && !check.skipped && !check.warning {
@@ -370,10 +371,8 @@ func filterTestEnvironmentIssues(issues []string) []string {
 		if strings.Contains(issue, "AGENT_ENV") {
 			continue
 		}
-		// skip uncommitted changes in test repos (test setup artifacts)
-		if strings.Contains(issue, "uncommitted change") {
-			continue
-		}
+		// NOTE: "uncommitted change" filter was intentionally removed —
+		// it was hiding a real bug where init didn't properly re-stage files.
 		// skip git hooks — fresh installs don't have hooks until `ox integrate install`
 		if strings.Contains(issue, "hook not installed") {
 			continue

--- a/cmd/ox/doctor_git.go
+++ b/cmd/ox/doctor_git.go
@@ -73,8 +73,9 @@ func GetSageoxFilesToCommit() []string {
 	return files
 }
 
-// ForceAddSageoxFiles adds all .sageox/ files to the VCS (git or svn).
-// For git, uses -f flag in case files were previously ignored.
+// ForceAddSageoxFiles stages .sageox/ config files with git add -f (force stage, NOT force push).
+// Only matches top-level .sageox/ files via non-recursive glob — cache/ subdirectory is never touched.
+// The -f flag overrides .gitignore, used because files may have been previously ignored.
 func ForceAddSageoxFiles() error {
 	repoRoot := findRepoRoot()
 	if repoRoot == "" {
@@ -181,12 +182,11 @@ func checkGitStatus() checkResult {
 			}
 		}
 
-		// all changes are staged - informational, ready to commit
+		// all changes are staged — informational, ready to commit
 		return checkResult{
 			name:    ".sageox/ changes",
 			passed:  true,
-			message: "staged",
-			detail:  "Commit to track convention updates",
+			message: "staged, ready to commit",
 		}
 	}
 

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -34,18 +34,29 @@ func checkGitAuth() checkResult {
 
 	// check if credential helper is configured
 	credHelper := getGitConfigValue("credential.helper")
-	if credHelper == "" {
-		// no credential helper - check if SSH key exists as fallback
-		sshConfigured := checkSSHAuth()
-		if sshConfigured {
-			return PassedCheck("Git auth", "SSH configured")
-		}
-		return WarningCheck("Git auth", "no credential helper",
-			"Configure git credentials for remote operations")
+	if credHelper != "" {
+		return PassedCheck("Git auth", credHelper)
 	}
 
-	// credential helper is configured
-	return PassedCheck("Git auth", credHelper)
+	// no credential helper - check if SSH key exists as fallback
+	if checkSSHAuth() {
+		return PassedCheck("Git auth", "SSH configured")
+	}
+
+	// check if ox has its own PAT-based credentials for this project
+	if config.IsInitialized(gitRoot) {
+		projectEndpoint := endpoint.GetForProject(gitRoot)
+		if projectEndpoint == "" {
+			projectEndpoint = endpoint.Get()
+		}
+		creds, err := gitserver.LoadCredentialsForEndpoint(projectEndpoint)
+		if err == nil && creds != nil && !creds.IsExpired() {
+			return PassedCheck("Git auth", "SageOx credentials")
+		}
+	}
+
+	return WarningCheck("Git auth", "no credential helper",
+		"Configure git credentials for remote operations")
 }
 
 // checkSSHAuth checks if SSH authentication is likely configured for git.
@@ -158,10 +169,11 @@ func checkGitConfig(fix bool) checkResult {
 
 // checkGitRepoState checks for uncommitted SageOx config under .sageox/.
 // Only reports issues with SageOx-managed files — the user's repo state is their own business.
+// Distinguishes staged (ready to commit, informational) from unstaged (needs action, warning).
 func checkGitRepoState() checkResult {
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
-		return SkippedCheck("SageOx config", "not in git repo", "")
+		return SkippedCheck("Repo state", "not in git repo", "")
 	}
 
 	// only check for uncommitted changes under .sageox/
@@ -170,22 +182,33 @@ func checkGitRepoState() checkResult {
 	output, err := statusCmd.Output()
 	if err == nil && len(output) > 0 {
 		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+		hasUnstaged := false
 		count := 0
 		for _, line := range lines {
-			if line != "" {
-				count++
+			if line == "" {
+				continue
+			}
+			count++
+			// porcelain format: XY filename (X=index, Y=worktree)
+			if len(line) >= 2 && line[1] != ' ' {
+				hasUnstaged = true
 			}
 		}
 		if count > 0 {
-			return WarningCheck("SageOx config",
-				fmt.Sprintf("%d uncommitted change(s) in .sageox/", count),
-				"Run 'git add .sageox/ && git commit' to persist config")
+			if hasUnstaged {
+				return WarningCheck("Repo state",
+					fmt.Sprintf("%d uncommitted change(s) in .sageox/", count),
+					"Run 'git add .sageox/ && git commit' to persist config")
+			}
+			// all changes are staged — informational, expected after init
+			return InfoCheck("Repo state",
+				fmt.Sprintf("%d staged change(s) in .sageox/", count),
+				"Run 'git commit' to persist config")
 		}
 	}
 
-	return PassedCheck("SageOx config", "committed and up to date")
+	return PassedCheck("Repo state", "committed and up to date")
 }
-
 
 // checkGitRemotes validates configured git remotes.
 // Checks that origin is configured and URL format is valid.
@@ -2390,7 +2413,6 @@ func checkLedgerPathMismatch(fix bool) checkResult {
 
 	return WarningCheck("Ledger path config", "path mismatch", detail)
 }
-
 
 // getTeamURLFromCredentials reads a team context URL from locally saved git credentials.
 // Matches by repo name (team slug). This avoids a duplicate API call.

--- a/cmd/ox/doctor_git_test.go
+++ b/cmd/ox/doctor_git_test.go
@@ -849,7 +849,7 @@ func TestCheckGitStatus_StagedButUncommitted(t *testing.T) {
 	if result.name != ".sageox/ changes" {
 		t.Errorf("unexpected name: %s", result.name)
 	}
-	if result.message != "staged" {
+	if result.message != "staged, ready to commit" {
 		t.Errorf("unexpected message: %s", result.message)
 	}
 }

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -24,6 +24,7 @@ const (
 	CheckSlugLedgerCleanWorkdir    = "ledger-clean-workdir"
 	CheckSlugLedgerRemoteURLMatch  = "ledger-remote-url-match"
 	CheckSlugLedgerURLAPIMatch     = "ledger-url-api-match"
+	CheckSlugLedgerCacheTracked    = "ledger-cache-tracked"
 )
 
 func init() {
@@ -56,6 +57,15 @@ func init() {
 		FixLevel:    FixLevelAuto,
 		Description: "Checks for uncommitted changes in ledger repository",
 		Run:         func(fix bool) checkResult { return checkLedgerCleanWorkdir(fix) },
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugLedgerCacheTracked,
+		Name:        "Ledger cache files untracked",
+		Category:    "Ledger Git Health",
+		FixLevel:    FixLevelAuto,
+		Description: "Detects local-only cache files that were accidentally committed to the ledger",
+		Run:         func(fix bool) checkResult { return checkLedgerCacheTracked(fix) },
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
@@ -255,11 +265,16 @@ func checkLedgerBranchStatus(fix bool) checkResult {
 }
 
 // fixLedgerBranchAhead pushes local ledger commits to remote.
+// Falls back to pull --rebase + push if the remote has diverged (stale tracking info).
 func fixLedgerBranchAhead(ledgerPath string, aheadCount int) checkResult {
 	pushCmd := exec.Command("git", "-C", ledgerPath, "push")
 	output, err := pushCmd.CombinedOutput()
 	if err != nil {
 		errStr := strings.TrimSpace(string(output))
+		// if push rejected because remote has new commits, try pull --rebase then push
+		if strings.Contains(errStr, "rejected") || strings.Contains(errStr, "fetch first") || strings.Contains(errStr, "non-fast-forward") {
+			return fixLedgerBranchDiverged(ledgerPath, aheadCount, 0)
+		}
 		return FailedCheck("Ledger branch status",
 			"push failed",
 			fmt.Sprintf("git push error: %s", errStr))
@@ -270,7 +285,8 @@ func fixLedgerBranchAhead(ledgerPath string, aheadCount int) checkResult {
 
 // fixLedgerBranchBehind pulls remote changes into local ledger.
 func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
-	pullCmd := exec.Command("git", "-C", ledgerPath, "pull", "--rebase")
+	// --autostash: uncommitted local changes must not block the pull
+	pullCmd := exec.Command("git", "-C", ledgerPath, "pull", "--rebase", "--autostash")
 	output, err := pullCmd.CombinedOutput()
 	if err != nil {
 		errStr := strings.TrimSpace(string(output))
@@ -287,7 +303,8 @@ func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
 // fixLedgerBranchDiverged reconciles a diverged ledger by rebasing then pushing.
 func fixLedgerBranchDiverged(ledgerPath string, aheadCount, behindCount int) checkResult {
 	// pull --rebase first to linearize history
-	pullCmd := exec.Command("git", "-C", ledgerPath, "pull", "--rebase")
+	// --autostash: uncommitted local changes must not block the pull
+	pullCmd := exec.Command("git", "-C", ledgerPath, "pull", "--rebase", "--autostash")
 	pullOutput, err := pullCmd.CombinedOutput()
 	if err != nil {
 		errStr := strings.TrimSpace(string(pullOutput))
@@ -392,8 +409,13 @@ func checkLedgerCleanWorkdir(fix bool) checkResult {
 
 // fixLedgerDirtyWorkdir stages and commits all changes in the ledger.
 func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
+	// ensure .gitignore exists and untrack any cache files BEFORE staging.
+	// without this, git add -A will commit local-only files like sync-state.json.
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
 	// stage all changes
-	addCmd := exec.Command("git", "-C", ledgerPath, "add", "-A")
+	// --sparse: ledger repos use sparse-checkout
+	addCmd := exec.Command("git", "-C", ledgerPath, "add", "--sparse", "-A")
 	if output, err := addCmd.CombinedOutput(); err != nil {
 		return FailedCheck("Ledger clean workdir",
 			"staging failed",
@@ -415,6 +437,51 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 
 	return PassedCheck("Ledger clean workdir",
 		fmt.Sprintf("committed %d file(s)", fileCount))
+}
+
+// checkLedgerCacheTracked detects .sageox/cache/ files that are tracked by git in the ledger.
+// Cache files are local-only machine state (e.g., sync-state.json) and must never be committed.
+// This can happen when commits occurred before .sageox/.gitignore was in place.
+// With fix=true, untracks them via `git rm --cached` (preserves local files).
+func checkLedgerCacheTracked(fix bool) checkResult {
+	const name = "Ledger cache files untracked"
+
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger found", "")
+	}
+
+	if !isGitRepo(ledgerPath) {
+		return SkippedCheck(name, "ledger not a git repo", "")
+	}
+
+	if !gitserver.CacheFilesTracked(ledgerPath) {
+		return PassedCheck(name, "no cache files tracked")
+	}
+
+	if !fix {
+		return WarningCheck(name,
+			"local-only cache files are tracked in ledger git history",
+			"run `ox doctor --fix` to untrack (local files preserved)")
+	}
+
+	// untrack cache files and ensure gitignore is in place
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
+	// check if untracking created staged changes that need committing
+	statusCmd := exec.Command("git", "-C", ledgerPath, "diff", "--cached", "--name-only")
+	if out, err := statusCmd.Output(); err == nil && len(strings.TrimSpace(string(out))) > 0 {
+		commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "-m", "chore: untrack local-only cache files")
+		if commitOut, err := commitCmd.CombinedOutput(); err != nil {
+			errStr := strings.TrimSpace(string(commitOut))
+			if !strings.Contains(errStr, "nothing to commit") {
+				return FailedCheck(name, "commit failed after untracking",
+					fmt.Sprintf("git commit error: %s", errStr))
+			}
+		}
+	}
+
+	return PassedCheck(name, "untracked cache files from ledger")
 }
 
 // checkLedgerRemoteURLMatch detects stale PATs in the ledger's git remote URL.

--- a/cmd/ox/doctor_session_uncommitted.go
+++ b/cmd/ox/doctor_session_uncommitted.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/gitserver"
 )
 
 func init() {
@@ -69,7 +70,11 @@ func checkSessionUncommitted(fix bool) checkResult {
 func fixSessionUncommitted(ledgerPath string, count int) checkResult {
 	const name = "uncommitted session files"
 
-	if out, err := exec.Command("git", "-C", ledgerPath, "add", "sessions/").CombinedOutput(); err != nil {
+	// ensure .gitignore is in place before any commit to prevent cache file leakage
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
+	// --sparse: ledger repos use sparse-checkout
+	if out, err := exec.Command("git", "-C", ledgerPath, "add", "--sparse", "sessions/").CombinedOutput(); err != nil {
 		return FailedCheck(name, "staging failed",
 			fmt.Sprintf("git add error: %s", strings.TrimSpace(string(out))))
 	}
@@ -83,6 +88,7 @@ func fixSessionUncommitted(ledgerPath string, count int) checkResult {
 			fmt.Sprintf("git commit error: %s", errStr))
 	}
 
+	// no --force: ledger history must never be rewritten
 	if out, err := exec.Command("git", "-C", ledgerPath, "push").CombinedOutput(); err != nil {
 		return WarningCheck(name,
 			fmt.Sprintf("committed %d file(s) but push failed", count),

--- a/cmd/ox/doctor_team.go
+++ b/cmd/ox/doctor_team.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/manifest"
 	"github.com/sageox/ox/internal/tokens"
 )
 
@@ -380,6 +382,125 @@ func checkGCBlockedByUntracked(fix bool) checkResult {
 	return WarningCheck("GC blocked",
 		fmt.Sprintf("%d team(s) with uncommitted changes blocking GC", len(dirtyTeams)),
 		detail.String())
+}
+
+// checkTeamSparseCheckout verifies that every team context repo with
+// sparse-checkout enabled includes the root-level file patterns (/* and !/*/).
+// Without these, git blocks staging root-level files like .gitattributes.
+func checkTeamSparseCheckout(fix bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Team sparse checkout", "not in git repo", "")
+	}
+
+	localCfg, err := config.LoadLocalConfig(gitRoot)
+	if err != nil || len(localCfg.TeamContexts) == 0 {
+		return SkippedCheck("Team sparse checkout", "no team contexts", "")
+	}
+
+	var needsFix, fixed, checked int
+
+	for _, tc := range localCfg.TeamContexts {
+		if tc.Path == "" || !isGitRepo(tc.Path) {
+			continue
+		}
+
+		// check if sparse-checkout is enabled
+		sparseFile := filepath.Join(tc.Path, ".git", "info", "sparse-checkout")
+		content, err := os.ReadFile(sparseFile)
+		if err != nil {
+			// no sparse-checkout file = not using sparse checkout, skip
+			continue
+		}
+
+		checked++
+
+		// check for root-level file patterns: /* and !/*/
+		// git may write the negation as \!/*/ (escaped) in the file
+		lines := strings.Split(string(content), "\n")
+		hasRootGlob := false
+		hasNegateRootDirs := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "/*" {
+				hasRootGlob = true
+			}
+			if trimmed == "!/*/" || trimmed == "\\!/*/" {
+				hasNegateRootDirs = true
+			}
+		}
+
+		if hasRootGlob && hasNegateRootDirs {
+			continue
+		}
+
+		needsFix++
+
+		if fix {
+			if repairErr := repairTeamSparseCheckout(tc.Path); repairErr != nil {
+				slog.Warn("failed to repair sparse-checkout",
+					"path", tc.Path, "error", repairErr)
+				continue
+			}
+			fixed++
+		}
+	}
+
+	if checked == 0 {
+		return SkippedCheck("Team sparse checkout", "no sparse-checkout repos", "")
+	}
+
+	if needsFix == 0 {
+		return PassedCheck("Team sparse checkout",
+			fmt.Sprintf("%d repo(s) have root-level patterns", checked))
+	}
+
+	if fix && fixed == needsFix {
+		return PassedCheck("Team sparse checkout",
+			fmt.Sprintf("repaired %d repo(s)", fixed))
+	}
+
+	unfixed := needsFix - fixed
+	return FailedCheck("Team sparse checkout",
+		fmt.Sprintf("%d repo(s) missing root-level patterns (/* and !/*/)", unfixed),
+		"Root-level files like .gitattributes cannot be staged without these patterns.\n"+
+			"        Run `ox doctor` to auto-fix (FixLevelAuto)")
+}
+
+// repairTeamSparseCheckout re-applies sparse-checkout from the manifest
+// with root-level file patterns included.
+func repairTeamSparseCheckout(tcPath string) error {
+	manifestPath := filepath.Join(tcPath, ".sageox", "sync.manifest")
+	cfg := manifest.ParseFile(manifestPath)
+
+	sparsePaths := manifest.ComputeSparseSet(cfg)
+	if len(sparsePaths) == 0 {
+		return fmt.Errorf("no sparse paths computed from manifest")
+	}
+
+	// ensure .sageox/ is always in the sparse set
+	hasSageox := false
+	for _, p := range sparsePaths {
+		if p == ".sageox/" || p == ".sageox" {
+			hasSageox = true
+			break
+		}
+	}
+	if !hasSageox {
+		sparsePaths = append([]string{".sageox/"}, sparsePaths...)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	args := append([]string{"-C", tcPath, "sparse-checkout", "set", "--no-cone"}, sparsePaths...)
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git sparse-checkout set: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	return nil
 }
 
 // runGitStatus runs git status --porcelain on a directory and returns the output.

--- a/cmd/ox/doctor_team_test.go
+++ b/cmd/ox/doctor_team_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -482,4 +483,153 @@ func TestCheckTeamContextHealth_MultipleTeamsOneFailing(t *testing.T) {
 
 	assert.True(t, okCheck.passed, "OK team should pass")
 	assert.False(t, missingCheck.passed, "missing team should fail")
+}
+
+// --- sparse-checkout doctor check tests ---
+
+// setupTeamContextWithSparseCheckout creates a git repo with sparse-checkout
+// configured using the given patterns, plus a local config pointing to it.
+func setupTeamContextWithSparseCheckout(t *testing.T, gitRoot string, patterns []string) string {
+	t.Helper()
+
+	teamDir := filepath.Join(t.TempDir(), "team-sparse")
+	require.NoError(t, os.MkdirAll(teamDir, 0755))
+
+	// init git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = teamDir
+	require.NoError(t, cmd.Run())
+
+	// create .sageox/ with a manifest
+	sageoxDir := filepath.Join(teamDir, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0755))
+	manifestContent := "version 1\ninclude .sageox/\ninclude SOUL.md\ninclude docs/\ninclude memory/\n"
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "sync.manifest"), []byte(manifestContent), 0644))
+
+	// initial commit so sparse-checkout has something to work with
+	cmd = exec.Command("git", "-C", teamDir, "add", "-A")
+	require.NoError(t, cmd.Run())
+	cmd = exec.Command("git", "-C", teamDir, "commit", "-m", "init", "--allow-empty")
+	cmd.Env = append(os.Environ(), // safe: git commit in temp dir needs author identity
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com")
+	require.NoError(t, cmd.Run())
+
+	// set up sparse-checkout with given patterns
+	args := append([]string{"-C", teamDir, "sparse-checkout", "set", "--no-cone"}, patterns...)
+	cmd = exec.Command("git", args...)
+	require.NoError(t, cmd.Run())
+
+	// register in local config
+	localCfg := &config.LocalConfig{}
+	localCfg.SetTeamContext("sparse-team", "Sparse Team", teamDir)
+	require.NoError(t, config.SaveLocalConfig(gitRoot, localCfg))
+
+	return teamDir
+}
+
+func TestCheckTeamSparseCheckout_MissingRootPatterns(t *testing.T) {
+	skipIntegration(t)
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+	requireSageoxDir(t, gitRoot)
+
+	// set up sparse-checkout WITHOUT root patterns (old format)
+	setupTeamContextWithSparseCheckout(t, gitRoot, []string{".sageox/", "SOUL.md", "docs/", "memory/"})
+
+	result := checkTeamSparseCheckout(false)
+	assert.False(t, result.passed, "should fail when root patterns are missing")
+	assert.Contains(t, result.message, "missing root-level patterns")
+}
+
+func TestCheckTeamSparseCheckout_HasRootPatterns(t *testing.T) {
+	skipIntegration(t)
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+	requireSageoxDir(t, gitRoot)
+
+	// set up sparse-checkout WITH root patterns (new format)
+	setupTeamContextWithSparseCheckout(t, gitRoot, []string{"/*", "!/*/", ".sageox/", "SOUL.md", "docs/", "memory/"})
+
+	result := checkTeamSparseCheckout(false)
+	assert.True(t, result.passed || result.skipped, "should pass when root patterns are present")
+}
+
+func TestCheckTeamSparseCheckout_AutoFix(t *testing.T) {
+	skipIntegration(t)
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+	requireSageoxDir(t, gitRoot)
+
+	// set up sparse-checkout WITHOUT root patterns
+	teamDir := setupTeamContextWithSparseCheckout(t, gitRoot, []string{".sageox/", "SOUL.md", "docs/", "memory/"})
+
+	// auto-fix (FixLevelAuto — fix=true always for auto checks)
+	result := checkTeamSparseCheckout(true)
+	assert.True(t, result.passed, "should pass after auto-fix: %s", result.message)
+
+	// verify sparse-checkout file now has root patterns
+	sparseFile := filepath.Join(teamDir, ".git", "info", "sparse-checkout")
+	content, err := os.ReadFile(sparseFile)
+	require.NoError(t, err)
+
+	lines := strings.Split(string(content), "\n")
+	hasRootGlob := false
+	hasNegateRootDirs := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "/*" {
+			hasRootGlob = true
+		}
+		if trimmed == "!/*/" || trimmed == "\\!/*/" {
+			hasNegateRootDirs = true
+		}
+	}
+	assert.True(t, hasRootGlob, "sparse-checkout should contain /*")
+	assert.True(t, hasNegateRootDirs, "sparse-checkout should contain !/*/ or \\!/*/")
+}
+
+func TestCheckTeamSparseCheckout_NoSparseCheckout(t *testing.T) {
+	skipIntegration(t)
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+	requireSageoxDir(t, gitRoot)
+
+	// create team context WITHOUT sparse-checkout
+	teamDir := filepath.Join(t.TempDir(), "team-no-sparse")
+	require.NoError(t, os.MkdirAll(teamDir, 0755))
+	cmd := exec.Command("git", "init")
+	cmd.Dir = teamDir
+	require.NoError(t, cmd.Run())
+
+	localCfg := &config.LocalConfig{}
+	localCfg.SetTeamContext("no-sparse-team", "No Sparse Team", teamDir)
+	require.NoError(t, config.SaveLocalConfig(gitRoot, localCfg))
+
+	result := checkTeamSparseCheckout(false)
+	assert.True(t, result.skipped, "should skip when no sparse-checkout repos found")
 }

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -163,10 +163,11 @@ const (
 	CheckSlugGitCommitHooks        = "git-commit-hooks"
 
 	// Team Context checks
-	CheckSlugTeamRegistration   = "team-registration"
-	CheckSlugLegacyTeamCtx      = "legacy-team-contexts"
-	CheckSlugOrphanedTeamDirs   = "orphaned-team-dirs"
-	CheckSlugGCBlockedUntracked = "gc-blocked-untracked"
+	CheckSlugTeamRegistration      = "team-registration"
+	CheckSlugLegacyTeamCtx         = "legacy-team-contexts"
+	CheckSlugOrphanedTeamDirs      = "orphaned-team-dirs"
+	CheckSlugGCBlockedUntracked    = "gc-blocked-untracked"
+	CheckSlugTeamSparseCheckout    = "team-sparse-checkout"
 
 	// SageOx Configuration checks
 	CheckSlugEndpointConsistency   = "endpoint-consistency"

--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -528,7 +528,9 @@ func commitAndPushDocImport(tcPath, ep, docID, metaPath, srcPointerPath, textPoi
 		filesToAdd = append(filesToAdd, gitattrsPath)
 	}
 
-	addArgs := append([]string{"-C", tcPath, "add"}, filesToAdd...)
+	// --sparse: team context repos use sparse-checkout; without this flag
+	// git refuses to stage files outside the sparse definition (e.g. .gitattributes at root)
+	addArgs := append([]string{"-C", tcPath, "add", "--sparse"}, filesToAdd...)
 	addCmd := exec.CommandContext(ctx, "git", addArgs...)
 	if out, err := addCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git add failed: %s: %w", string(out), err)
@@ -601,7 +603,7 @@ func pushTeamContext(ctx context.Context, tcPath, ep string) error {
 			}
 
 			pullCtx, pullCancel := context.WithTimeout(ctx, opTimeout)
-			pullOut, pullErr := gitutil.RunGit(pullCtx, tcPath, "pull", "--rebase", "--quiet")
+			pullOut, pullErr := gitutil.RunGit(pullCtx, tcPath, "pull", "--rebase", "--autostash", "--quiet")
 			pullCancel()
 			if pullErr != nil {
 				abortCtx, abortCancel := context.WithTimeout(ctx, opTimeout)

--- a/cmd/ox/import_integration_test.go
+++ b/cmd/ox/import_integration_test.go
@@ -161,6 +161,61 @@ func TestCommitAndPushDocImport_GitattributesIncluded(t *testing.T) {
 	assert.Contains(t, string(data), "data/**/metadata.json !filter !diff !merge text")
 }
 
+// TestCommitAndPushDocImport_WithSparseCheckout is a regression test for the
+// bug where git add .gitattributes fails because sparse-checkout blocks staging
+// files outside the sparse definition. Team context repos use --no-cone sparse
+// checkout, and .gitattributes at the repo root is outside the sparse set.
+// Without --sparse on git add, this test fails with:
+//
+//	"The following paths and/or pathspecs matched paths that exist
+//	 outside of your sparse-checkout definition"
+func TestCommitAndPushDocImport_WithSparseCheckout(t *testing.T) {
+	barePath, clonePath := createBareAndClone(t)
+	isolatePushEnv(t, clonePath)
+
+	// enable sparse-checkout in --no-cone mode (simulates team context two-phase clone)
+	// include data/ and .sageox/ but NOT root — .gitattributes is outside sparse set
+	runGit(t, clonePath, "sparse-checkout", "set", "--no-cone", "data/", ".sageox/")
+
+	// write .gitattributes at repo root (outside sparse set)
+	gitattrsContent := "data/**/metadata.json !filter !diff !merge text\n"
+	require.NoError(t, os.WriteFile(filepath.Join(clonePath, ".gitattributes"), []byte(gitattrsContent), 0o644))
+
+	// create doc files inside sparse set
+	docID := "sparse-test-doc"
+	docDir := filepath.Join(clonePath, "data", "docs", "2026", "03", "06", docID)
+	require.NoError(t, os.MkdirAll(docDir, 0o755))
+
+	srcContent := []byte("sparse checkout test content")
+	srcRef := lfs.NewFileRef(srcContent)
+	srcPointerPath := filepath.Join(docDir, "source.bin")
+	require.NoError(t, os.WriteFile(srcPointerPath, []byte(lfs.FormatPointer(srcRef.OID, srcRef.Size)), 0o644))
+
+	meta := docMeta{
+		Version:        "1",
+		Title:          "Sparse Checkout Test",
+		SourceFilename: "test.bin",
+		ContentType:    "application/octet-stream",
+		SourceSize:     srcRef.Size,
+		SourceOID:      srcRef.OID,
+		CreatedAt:      "2026-03-06",
+		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
+	}
+	metaData, err := json.MarshalIndent(meta, "", "  ")
+	require.NoError(t, err)
+	metaPath := filepath.Join(docDir, "metadata.json")
+	require.NoError(t, os.WriteFile(metaPath, metaData, 0o644))
+
+	err = commitAndPushDocImport(clonePath, "https://test.invalid", docID, metaPath, srcPointerPath, "", false)
+	require.NoError(t, err, "git add should succeed with --sparse even when .gitattributes is outside sparse set")
+
+	// verify .gitattributes on remote
+	verifyClone := cloneBare(t, barePath)
+	data, readErr := os.ReadFile(filepath.Join(verifyClone, ".gitattributes"))
+	require.NoError(t, readErr, ".gitattributes should exist on remote")
+	assert.Contains(t, string(data), "data/**/metadata.json !filter !diff !merge text")
+}
+
 func TestCommitAndPushDocImport_NothingToCommit(t *testing.T) {
 	_, clonePath := createBareAndClone(t)
 	isolatePushEnv(t, clonePath)

--- a/cmd/ox/memory_put.go
+++ b/cmd/ox/memory_put.go
@@ -176,7 +176,9 @@ func writeObservation(teamContextPath string, observations []observation) error 
 
 	relPath := filepath.Join("memory", observationDirName, dateDir, filename)
 
-	if _, err := gitutil.RunGit(ctx, teamContextPath, "add", relPath); err != nil {
+	// --sparse: team context repos use sparse-checkout; without this flag
+	// git refuses to stage files outside the sparse definition
+	if _, err := gitutil.RunGit(ctx, teamContextPath, "add", "--sparse", relPath); err != nil {
 		return fmt.Errorf("git add: %w", err)
 	}
 

--- a/cmd/ox/session_push_summary.go
+++ b/cmd/ox/session_push_summary.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 	"github.com/spf13/cobra"
@@ -133,11 +134,15 @@ func pushSummaryToLedger(filePath, sessionDir string) *pushSummaryOutput {
 		}
 	}
 
+	// ensure .gitignore is in place before any commit to prevent cache file leakage
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
 	// extract session name from session dir path for commit message
 	sessionName := filepath.Base(sessionDir)
 
 	// git add the summary file (and meta.json if updated)
-	addArgs := []string{"-C", ledgerPath, "add", summaryDst}
+	// --sparse: ledger repos use sparse-checkout
+	addArgs := []string{"-C", ledgerPath, "add", "--sparse", summaryDst}
 	if metaUpdated {
 		addArgs = append(addArgs, filepath.Join(sessionDir, "meta.json"))
 	}

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -208,7 +208,11 @@ func ensureSessionsGitignore(sessionsDir string) error {
 
 // commitAndPushLedger commits meta.json and .gitignore, then pushes to remote.
 // Uses pull --rebase with retry to handle concurrent pushes from other team members.
+// NEVER uses --force push. Conflicts are resolved via pull --rebase.
 func commitAndPushLedger(ledgerPath, sessionName string) error {
+	// ensure .gitignore is in place before any commit to prevent cache file leakage
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
 	// stage meta.json and .gitignore
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	sessionDir := filepath.Join(sessionsDir, sessionName)
@@ -223,7 +227,9 @@ func commitAndPushLedger(ledgerPath, sessionName string) error {
 		filesToAdd = append(filesToAdd, matches...)
 	}
 
-	addArgs := append([]string{"-C", ledgerPath, "add"}, filesToAdd...)
+	// --sparse: ledger repos use sparse-checkout (cone mode); this flag
+	// prevents git from blocking adds if sparse rules change or edge cases arise
+	addArgs := append([]string{"-C", ledgerPath, "add", "--sparse"}, filesToAdd...)
 	addCmd := exec.Command("git", addArgs...)
 	if output, err := addCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git add failed: %s: %w", string(output), err)
@@ -247,7 +253,10 @@ func commitAndPushLedger(ledgerPath, sessionName string) error {
 // commitAndPushLedgerWithExtras commits meta.json, .gitignore, and optionally summary.json,
 // then pushes to remote. Used by doctor retry path where summary.json may have been
 // copied from cache alongside the LFS upload retry.
+// NEVER uses --force push. Conflicts are resolved via pull --rebase.
 func commitAndPushLedgerWithExtras(ledgerPath, sessionName string, includeSummary bool) error {
+	// ensure .gitignore is in place before any commit to prevent cache file leakage
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	sessionDir := filepath.Join(sessionsDir, sessionName)
 
@@ -264,7 +273,8 @@ func commitAndPushLedgerWithExtras(ledgerPath, sessionName string, includeSummar
 		filesToAdd = append(filesToAdd, matches...)
 	}
 
-	args := append([]string{"-C", ledgerPath, "add"}, filesToAdd...)
+	// --sparse: see commitAndPushLedger for rationale
+	args := append([]string{"-C", ledgerPath, "add", "--sparse"}, filesToAdd...)
 	addCmd := exec.Command("git", args...)
 	if output, err := addCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git add failed: %s: %w", string(output), err)
@@ -299,6 +309,8 @@ func resolveLedgerPath() (string, error) {
 }
 
 // pushLedger pushes ledger changes to remote with conflict retry.
+// NEVER uses --force. Ledger and team context history must not be rewritten.
+// Conflicts are resolved via pull --rebase, never by overwriting remote history.
 // Retries on transient failures (network, rejection). Fails fast on permanent errors
 // (auth, config) to avoid wasting time on retries that will never succeed.
 // Uses context for timeout control (60s per git operation).
@@ -334,6 +346,7 @@ func pushLedger(ctx context.Context, ledgerPath string) error {
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		attemptCtx, cancel := context.WithTimeout(ctx, opTimeout)
+		// no --force: conflicts resolved via pull --rebase, never by overwriting remote history
 		outStr, err := gitutil.RunGit(attemptCtx, ledgerPath, "push", "--quiet")
 		cancel()
 		if err == nil {
@@ -363,7 +376,7 @@ func pushLedger(ctx context.Context, ledgerPath string) error {
 			}
 
 			pullCtx, pullCancel := context.WithTimeout(ctx, opTimeout)
-			pullOut, pullErr := gitutil.RunGit(pullCtx, ledgerPath, "pull", "--rebase", "--quiet")
+			pullOut, pullErr := gitutil.RunGit(pullCtx, ledgerPath, "pull", "--rebase", "--autostash", "--quiet")
 			pullCancel()
 			if pullErr != nil {
 				// abort rebase to avoid leaving repo in broken state

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -7,10 +7,19 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/paths"
+)
+
+// cachedWorkspaceID stores the workspace ID computed from CWD on first call.
+// This ensures a stable ID even if the daemon's CWD becomes invalid later
+// (e.g. tmpdir cleanup on macOS while the daemon is running).
+var (
+	cachedWorkspaceID     string
+	cachedWorkspaceIDOnce sync.Once
 )
 
 // IsDaemonDisabled returns true if the daemon has been explicitly disabled
@@ -83,12 +92,19 @@ func WorkspaceID(workspacePath string) string {
 }
 
 // CurrentWorkspaceID returns the ID for the current working directory.
+// The result is cached on first call so the daemon continues to use the
+// correct workspace ID even if its CWD is later deleted (e.g. macOS
+// tmpdir cleanup while the daemon is running long-term).
 func CurrentWorkspaceID() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "default"
-	}
-	return WorkspaceID(cwd)
+	cachedWorkspaceIDOnce.Do(func() {
+		cwd, err := os.Getwd()
+		if err != nil {
+			cachedWorkspaceID = "default"
+			return
+		}
+		cachedWorkspaceID = WorkspaceID(cwd)
+	})
+	return cachedWorkspaceID
 }
 
 // SocketPath returns the path to the daemon Unix socket for the current workspace.
@@ -99,6 +115,18 @@ func SocketPath() string {
 // SocketPathForWorkspace returns the socket path for a specific workspace.
 func SocketPathForWorkspace(workspaceID string) string {
 	return paths.DaemonSocketFile(workspaceID)
+}
+
+// StabilizeCWD moves the daemon's working directory to $HOME so that git
+// commands don't fail if the original CWD is deleted (e.g. tmpdir cleanup).
+// Must be called AFTER CurrentWorkspaceID() has cached the workspace ID.
+func StabilizeCWD() {
+	// ensure workspace ID is cached before changing CWD
+	_ = CurrentWorkspaceID()
+
+	if home, err := os.UserHomeDir(); err == nil {
+		_ = os.Chdir(home)
+	}
 }
 
 // LogPath returns the path to the daemon log file for the current workspace.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -243,6 +243,11 @@ func (d *Daemon) Start() error {
 		d.logger.Warn("failed to register daemon", "error", err)
 	}
 
+	// move CWD to $HOME so git commands don't fail if the original CWD
+	// is deleted (e.g. tmpdir cleanup on macOS). Must happen after
+	// workspace ID is cached and PID file is written.
+	StabilizeCWD()
+
 	// start IPC server
 	d.server = NewServer(d.logger)
 
@@ -324,8 +329,8 @@ func (d *Daemon) Start() error {
 				lastErrTimeStr = lastErrTime.Format(time.RFC3339)
 			}
 			stats := d.scheduler.SyncStats()
-			// get workspace path
-			workspacePath, _ := os.Getwd()
+			// get workspace path (use config, not CWD — CWD may have been stabilized to $HOME)
+			workspacePath := d.config.ProjectRoot
 
 			// get activity summary from heartbeat handler
 			var activitySummary *ActivitySummary

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -163,13 +163,9 @@ func RegisterDaemon(workspacePath, version string) error {
 }
 
 // UnregisterDaemon removes the current daemon from the registry.
+// Uses cached workspace ID since CWD may have been stabilized to $HOME.
 func UnregisterDaemon() error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	workspaceID := WorkspaceID(cwd)
+	workspaceID := CurrentWorkspaceID()
 	reg, err := LoadRegistry()
 	if err != nil {
 		return err

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -920,8 +920,10 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 		_ = progress.WriteStage("pulling", "Pulling changes...")
 	}
 
-	// git pull --rebase (capture stderr for diagnosable error messages)
-	pullCmd := exec.CommandContext(ctx, "git", "-C", s.config.LedgerPath, "pull", "--rebase", "--quiet")
+	// git pull --rebase --autostash (capture stderr for diagnosable error messages)
+	// --autostash: local uncommitted changes (from CLI writes, user edits) must not
+	// block background sync — stash before rebase, pop after
+	pullCmd := exec.CommandContext(ctx, "git", "-C", s.config.LedgerPath, "pull", "--rebase", "--autostash", "--quiet")
 	if output, err := pullCmd.CombinedOutput(); err != nil {
 		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
 		s.logger.Warn("pull failed", "error", err, "output", detail)
@@ -1630,6 +1632,11 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 		}
 		cloneArgs := []string{"clone", "--quiet", cloneURL, payload.RepoPath}
 		cloneCmd := exec.CommandContext(ctx, "git", cloneArgs...)
+		// set cmd.Dir so git doesn't fail when daemon CWD has been deleted
+		if parentDir := filepath.Dir(payload.RepoPath); parentDir != "" {
+			_ = os.MkdirAll(parentDir, 0755)
+			cloneCmd.Dir = parentDir
+		}
 		if output, err := cloneCmd.CombinedOutput(); err != nil {
 			sanitizedOutput := gitutil.SanitizeOutput(string(output))
 			s.logger.Error("checkout: clone failed", "error", err, "output", sanitizedOutput)
@@ -2146,8 +2153,10 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 		s.recordRemoteChange(path, info.ModTime())
 	}
 
-	// git pull --rebase (capture stderr for diagnosable error messages)
-	pullCmd := exec.CommandContext(ctx, "git", "-C", path, "pull", "--rebase", "--quiet")
+	// git pull --rebase --autostash (capture stderr for diagnosable error messages)
+	// --autostash: team context repos are collaborative workspaces — users may have
+	// uncommitted local edits (docs/, data/) that must not block background sync
+	pullCmd := exec.CommandContext(ctx, "git", "-C", path, "pull", "--rebase", "--autostash", "--quiet")
 	if output, err := pullCmd.CombinedOutput(); err != nil {
 		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
 

--- a/internal/daemon/sync_state.go
+++ b/internal/daemon/sync_state.go
@@ -18,6 +18,9 @@ const (
 
 // SyncState tracks the sync health of a workspace (team context or ledger).
 // Stored in .sageox/cache/sync-state.json within the workspace directory.
+//
+// This is local-only machine state — never committed or pushed to the remote.
+// Protected by .sageox/.gitignore (cache/ is gitignored).
 type SyncState struct {
 	LastSync            time.Time `json:"last_sync"`
 	LastSyncCommit      string    `json:"last_sync_commit"`
@@ -76,6 +79,7 @@ func LoadSyncState(workspacePath string) *SyncState {
 }
 
 // SaveSyncState writes sync state to .sageox/cache/sync-state.json within workspacePath.
+// Writes to .sageox/cache/ which is gitignored — local-only, never committed to the ledger.
 func SaveSyncState(workspacePath string, state *SyncState) error {
 	if workspacePath == "" || state == nil {
 		return nil

--- a/internal/doctor/session.go
+++ b/internal/doctor/session.go
@@ -1083,7 +1083,8 @@ func (c *SessionAutoStageCheck) stageSessionFiles(ledgerPath string, files []str
 
 	// stage files using git add
 	// use sessions/ directory to catch all session files in one command
-	cmd := exec.Command("git", "-C", ledgerPath, "add", "sessions/")
+	// --sparse: ledger repos use sparse-checkout
+	cmd := exec.Command("git", "-C", ledgerPath, "add", "--sparse", "sessions/")
 	if err := cmd.Run(); err != nil {
 		return 0, fmt.Errorf("git add sessions/: %w", err)
 	}

--- a/internal/gitserver/agents_md.go
+++ b/internal/gitserver/agents_md.go
@@ -144,7 +144,7 @@ func commitAndPushAgentsMD(ctx context.Context, repoPath string) error {
 		return err
 	}
 
-	// push
+	// push — no --force: team context history must never be rewritten
 	pushCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "push", "--quiet")
 	if err := pushCmd.Run(); err != nil {
 		return fmt.Errorf("push: %w", err)
@@ -157,7 +157,9 @@ func commitAndPushAgentsMD(ctx context.Context, repoPath string) error {
 // commitAgentsMD commits the AGENTS.md file.
 func commitAgentsMD(ctx context.Context, repoPath string) error {
 	// add file
-	addCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "add", "AGENTS.md")
+	// --sparse: defensive; user repos don't typically use sparse-checkout but
+	// this ensures compatibility if they do
+	addCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "add", "--sparse", "AGENTS.md")
 	if err := addCmd.Run(); err != nil {
 		return fmt.Errorf("git add: %w", err)
 	}

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -129,13 +130,63 @@ func CheckoutGitignoreNeedsFix(repoPath string) bool {
 	return false
 }
 
+// EnsureGitignoreBeforeCommit is a guard that MUST be called before any git commit
+// to a ledger or team context. It ensures .sageox/.gitignore is in place so that
+// local-only cache files (e.g., sync-state.json) are never committed.
+//
+// Without this guard, broad operations like `git add -A` will stage cache files.
+// Even with explicit file lists, this guard prevents future regressions.
+//
+// Also untracks any cache files that were committed before .gitignore existed
+// (git rm --cached does not delete the local file).
+func EnsureGitignoreBeforeCommit(repoPath string) {
+	EnsureGitignoreBeforeCommitCtx(context.Background(), repoPath)
+}
+
+// EnsureGitignoreBeforeCommitCtx is like EnsureGitignoreBeforeCommit but accepts a context.
+func EnsureGitignoreBeforeCommitCtx(ctx context.Context, repoPath string) {
+	if repoPath == "" {
+		return
+	}
+
+	// ensure .gitignore exists with required entries
+	if err := EnsureCheckoutGitignoreCtx(ctx, repoPath); err != nil {
+		slog.Debug("pre-commit gitignore guard failed", "path", repoPath, "error", err)
+	}
+
+	// untrack cache files that were committed before .gitignore existed.
+	// --cached removes from git index only, local files are preserved.
+	// --ignore-unmatch avoids errors when nothing is tracked.
+	rmCmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"rm", "--cached", "-r", "--ignore-unmatch", ".sageox/cache/")
+	if out, err := rmCmd.CombinedOutput(); err != nil {
+		slog.Debug("pre-commit cache untrack failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
+	}
+}
+
+// CacheFilesTracked returns true if any .sageox/cache/ files are tracked by git.
+// Used by doctor checks to detect cache files that were committed before
+// .gitignore was in place.
+func CacheFilesTracked(repoPath string) bool {
+	cmd := exec.Command("git", "-C", repoPath, "ls-files", ".sageox/cache/")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return len(strings.TrimSpace(string(out))) > 0
+}
+
 // commitCheckoutGitignore stages and commits .sageox/.gitignore.
 // Non-fatal: if the commit fails (e.g., nothing to commit), we still have
 // the file on disk which protects against the GC blocking bug.
 func commitCheckoutGitignore(ctx context.Context, repoPath string) error {
-	addCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "add", ".sageox/.gitignore")
-	if err := addCmd.Run(); err != nil {
-		return fmt.Errorf("git add .sageox/.gitignore: %w", err)
+	// --sparse: repos may have sparse-checkout enabled (team contexts use --no-cone);
+	// without this flag git blocks staging new files even inside included paths.
+	// -f: the root .gitignore may exclude .sageox/ to hide daemon-created local state;
+	// force-add overrides this so the committed .gitignore inside .sageox/ is tracked.
+	addCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "add", "--sparse", "-f", ".sageox/.gitignore")
+	if output, err := addCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add .sageox/.gitignore: %s: %w", strings.TrimSpace(string(output)), err)
 	}
 
 	commitCmd := exec.CommandContext(ctx, "git", "-C", repoPath,

--- a/internal/gitserver/gitignore_test.go
+++ b/internal/gitserver/gitignore_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// runGit runs a git command in the given directory and fails the test on error.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+}
+
 // setupGitRepoWithSageox creates a git repo with a committed .sageox/sync.manifest.
 func setupGitRepoWithSageox(t *testing.T) string {
 	t.Helper()
@@ -251,4 +260,38 @@ func TestCheckoutGitignoreNeedsFix_Complete(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, ".gitignore"),
 		[]byte("*\n!.gitignore\n!sync.manifest\n"), 0644))
 	assert.False(t, CheckoutGitignoreNeedsFix(dir), "should not need fix when all entries present")
+}
+
+// TestEnsureCheckoutGitignore_WithSparseCheckout is a regression test for the
+// bug where git add .sageox/.gitignore fails during TwoPhaseClone because
+// sparse-checkout blocks staging files outside the sparse definition.
+// Without --sparse on git add, this test fails with:
+//
+//	"The following paths and/or pathspecs matched paths that exist
+//	 outside of your sparse-checkout definition"
+func TestEnsureCheckoutGitignore_WithSparseCheckout(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := setupGitRepoWithSageox(t)
+
+	// enable sparse-checkout in --no-cone mode (same as TwoPhaseClone)
+	runGit(t, dir, "sparse-checkout", "set", "--no-cone", ".sageox/")
+
+	// this is the exact call that fails during TwoPhaseClone (line 106)
+	require.NoError(t, EnsureCheckoutGitignore(dir))
+
+	// verify file exists with required entries
+	content, err := os.ReadFile(filepath.Join(dir, ".sageox", ".gitignore"))
+	require.NoError(t, err)
+	for _, entry := range checkoutRequiredEntries {
+		assert.Contains(t, string(content), entry)
+	}
+
+	// verify committed (not untracked)
+	output, err := exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(string(output)),
+		"gitignore should be committed, not untracked")
 }

--- a/internal/gitserver/two_phase_clone.go
+++ b/internal/gitserver/two_phase_clone.go
@@ -30,7 +30,14 @@ type TwoPhaseCloneResult struct {
 // This function is used by both the daemon (normal path) and the CLI
 // (doctor fallback when daemon unavailable).
 func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string) (*TwoPhaseCloneResult, error) {
-	// phase 1: minimal clone — trees only, no blobs
+	// phase 1: minimal clone — trees only, no blobs.
+	// Set cmd.Dir to the parent of repoPath so git doesn't fail with
+	// "Unable to read current working directory" when the daemon's CWD
+	// has been deleted (e.g. tmpdir cleanup on macOS).
+	parentDir := filepath.Dir(repoPath)
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
+		return nil, fmt.Errorf("create parent dir %s: %w", parentDir, err)
+	}
 	cloneCmd := exec.CommandContext(ctx, "git", "clone",
 		"--filter=blob:none",
 		"--depth=1",
@@ -41,6 +48,7 @@ func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string) (*TwoPhaseClo
 		"--quiet",
 		cloneURL, repoPath,
 	)
+	cloneCmd.Dir = parentDir
 	if output, err := cloneCmd.CombinedOutput(); err != nil {
 		sanitized := gitutil.SanitizeOutput(string(output))
 		if sanitized != "" {

--- a/internal/gitutil/run.go
+++ b/internal/gitutil/run.go
@@ -18,6 +18,11 @@ func RunGit(ctx context.Context, repoPath string, args ...string) (string, error
 	cmdArgs = append(cmdArgs, args...)
 
 	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+	// set cmd.Dir so git doesn't fail on getcwd() when the process CWD
+	// has been deleted (e.g. daemon started from a tmpdir that was cleaned)
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
 	output, err := cmd.CombinedOutput()
 	sanitized := SanitizeOutput(strings.TrimSpace(string(output)))
 

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -154,6 +154,11 @@ func ParseFile(path string) *ManifestConfig {
 
 // ComputeSparseSet returns the effective sparse checkout paths:
 // includes minus any paths that match a deny prefix. Deny always wins.
+//
+// The result always starts with "/*" and "!/*/" to include root-level files
+// (like .gitattributes) without pulling in root-level directories. Specific
+// directories from includes are then re-added. This ensures root-level
+// control files are materialized in sparse-checkout --no-cone mode.
 func ComputeSparseSet(cfg *ManifestConfig) []string {
 	if cfg == nil {
 		return nil
@@ -164,7 +169,12 @@ func ComputeSparseSet(cfg *ManifestConfig) []string {
 		denySet[d] = true
 	}
 
-	var result []string
+	// start with root-level files: /* includes everything at root,
+	// !/*/ excludes root-level directories only (re-included explicitly below).
+	// The leading / anchors to the repo root so subdirectories inside
+	// included paths (e.g., memory/daily/) are not accidentally excluded.
+	result := []string{"/*", "!/*/"}
+
 	for _, inc := range cfg.Includes {
 		if denySet[inc] {
 			continue

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -236,7 +236,7 @@ func TestComputeSparseSet(t *testing.T) {
 				Includes: []string{".sageox/", "memory/", "data/"},
 				Denies:   []string{"data/"},
 			},
-			want:     []string{".sageox/", "memory/"},
+			want:     []string{"/*", "!/*/", ".sageox/", "memory/"},
 			wantNone: []string{"data/"},
 		},
 		{
@@ -245,7 +245,7 @@ func TestComputeSparseSet(t *testing.T) {
 				Includes: []string{"data/slack/"},
 				Denies:   []string{"data/"},
 			},
-			want:     nil,
+			want:     []string{"/*", "!/*/"},
 			wantNone: []string{"data/slack/"},
 		},
 		{
@@ -253,7 +253,7 @@ func TestComputeSparseSet(t *testing.T) {
 			cfg: &ManifestConfig{
 				Includes: []string{".sageox/", "SOUL.md", "memory/"},
 			},
-			want: []string{".sageox/", "SOUL.md", "memory/"},
+			want: []string{"/*", "!/*/", ".sageox/", "SOUL.md", "memory/"},
 		},
 		{
 			name: "nil config",
@@ -266,7 +266,7 @@ func TestComputeSparseSet(t *testing.T) {
 				Includes: []string{"data/"},
 				Denies:   []string{"data/secrets/"},
 			},
-			want:     nil,
+			want:     []string{"/*", "!/*/"},
 			wantNone: []string{"data/"},
 		},
 		{
@@ -275,7 +275,7 @@ func TestComputeSparseSet(t *testing.T) {
 				Includes: []string{"README.md", ".sageox/"},
 				Denies:   []string{"README.md"},
 			},
-			want:     []string{".sageox/"},
+			want:     []string{"/*", "!/*/", ".sageox/"},
 			wantNone: []string{"README.md"},
 		},
 	}

--- a/internal/manifest/sparse_checkout_test.go
+++ b/internal/manifest/sparse_checkout_test.go
@@ -23,6 +23,21 @@ func TestComputeSparseSet_DenyDataExcludesData(t *testing.T) {
 	assert.NotContains(t, result, "data/")
 }
 
+func TestComputeSparseSet_IncludesRootFiles(t *testing.T) {
+	cfg := &ManifestConfig{
+		Includes: []string{"memory/", ".sageox/"},
+		Denies:   []string{"data/"},
+	}
+
+	result := ComputeSparseSet(cfg)
+
+	// /* and !/*/ must be the first two entries: include root-level files,
+	// exclude root-level directories (re-included explicitly by includes)
+	require.Len(t, result, 4, "expected /* + !/*/ + 2 includes")
+	assert.Equal(t, "/*", result[0], "first entry should be /* to include root files")
+	assert.Equal(t, "!/*/", result[1], "second entry should be !/*/ to exclude root dirs")
+}
+
 func TestComputeSparseSet_DenyDataBlocksDataSubdirs(t *testing.T) {
 	cfg := &ManifestConfig{
 		Includes: []string{"data/slack/"},
@@ -31,7 +46,8 @@ func TestComputeSparseSet_DenyDataBlocksDataSubdirs(t *testing.T) {
 
 	result := ComputeSparseSet(cfg)
 
-	assert.Empty(t, result, "deny on parent data/ should block child data/slack/")
+	// only root-file patterns remain — no include dirs survived the deny
+	assert.Equal(t, []string{"/*", "!/*/"}, result, "deny on parent data/ should block child data/slack/")
 }
 
 func TestComputeSparseSet_FallbackConfigExcludesData(t *testing.T) {
@@ -98,11 +114,12 @@ func TestSparseCheckout_DataExcludedFromWorkingTree(t *testing.T) {
 
 	dir := t.TempDir()
 
-	// create repo with files in data/, memory/, and .sageox/
+	// create repo with files in data/, memory/, .sageox/, and root-level files
 	initGitRepo(t, dir, map[string]string{
-		"data/raw.txt":                  "raw data content",
-		"memory/daily/2026-01-01.md":    "daily memory",
-		".sageox/config.json":           `{"version": 1}`,
+		"data/raw.txt":               "raw data content",
+		"memory/daily/2026-01-01.md": "daily memory",
+		".sageox/config.json":        `{"version": 1}`,
+		".gitattributes":             "data/** filter=lfs\n",
 	})
 
 	// compute sparse set from a manifest that denies data/
@@ -113,9 +130,8 @@ func TestSparseCheckout_DataExcludedFromWorkingTree(t *testing.T) {
 	sparseSet := ComputeSparseSet(cfg)
 	require.NotEmpty(t, sparseSet)
 
-	// enable sparse checkout
-	runGit(t, dir, "sparse-checkout", "init", "--cone")
-	runGit(t, dir, append([]string{"sparse-checkout", "set"}, sparseSet...)...)
+	// enable sparse checkout in --no-cone mode (matches TwoPhaseClone)
+	runGit(t, dir, append([]string{"sparse-checkout", "set", "--no-cone"}, sparseSet...)...)
 
 	// data/raw.txt should NOT exist in the working tree
 	_, err := os.Stat(filepath.Join(dir, "data", "raw.txt"))
@@ -128,6 +144,10 @@ func TestSparseCheckout_DataExcludedFromWorkingTree(t *testing.T) {
 	// .sageox/ files should exist
 	_, err = os.Stat(filepath.Join(dir, ".sageox", "config.json"))
 	assert.NoError(t, err, ".sageox/config.json should exist in sparse working tree")
+
+	// root-level files (like .gitattributes) should exist via /* pattern
+	_, err = os.Stat(filepath.Join(dir, ".gitattributes"))
+	assert.NoError(t, err, ".gitattributes should exist in sparse working tree (root-level files included)")
 }
 
 func TestSparseCheckout_FreshCloneExcludesData(t *testing.T) {
@@ -142,9 +162,10 @@ func TestSparseCheckout_FreshCloneExcludesData(t *testing.T) {
 	// create a working repo, add files, push to bare
 	srcDir := t.TempDir()
 	initGitRepo(t, srcDir, map[string]string{
-		"data/file.txt":     "should be excluded",
-		"memory/obs.jsonl":  `{"observation": "test"}`,
-		".sageox/soul.md":   "team soul",
+		"data/file.txt":    "should be excluded",
+		"memory/obs.jsonl": `{"observation": "test"}`,
+		".sageox/soul.md":  "team soul",
+		".gitattributes":   "data/** filter=lfs\n",
 	})
 	runGit(t, srcDir, "remote", "add", "origin", bareDir)
 	runGit(t, srcDir, "push", "origin", "HEAD:main")
@@ -164,7 +185,7 @@ func TestSparseCheckout_FreshCloneExcludesData(t *testing.T) {
 	sparseSet := ComputeSparseSet(cfg)
 	require.NotEmpty(t, sparseSet)
 
-	runGit(t, cloneDir, append([]string{"sparse-checkout", "set"}, sparseSet...)...)
+	runGit(t, cloneDir, append([]string{"sparse-checkout", "set", "--no-cone"}, sparseSet...)...)
 
 	// data/ should not be in the working tree
 	_, err = os.Stat(filepath.Join(cloneDir, "data"))
@@ -173,4 +194,8 @@ func TestSparseCheckout_FreshCloneExcludesData(t *testing.T) {
 	// memory/ should be present
 	_, err = os.Stat(filepath.Join(cloneDir, "memory", "obs.jsonl"))
 	assert.NoError(t, err, "memory/obs.jsonl should exist in sparse clone")
+
+	// root-level files should be present via /* pattern
+	_, err = os.Stat(filepath.Join(cloneDir, ".gitattributes"))
+	assert.NoError(t, err, ".gitattributes should exist in sparse clone (root-level files included)")
 }


### PR DESCRIPTION
## Restored

- `--sparse` flag on 14 git add calls, `--autostash` on 6 pulls, `-f` on gitignore
- Cache leakage guards: `EnsureGitignoreBeforeCommit()` function and all call sites
- Doctor: sparse-checkout check, cache-tracked check, warning filters, bootstrap guard
- Daemon: `cachedWorkspaceID`, `StabilizeCWD()`, per-agent recording state isolation
- LFS: pointer file patterns in sparse-checkout root-file handling

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Team sparse-checkout validation and automatic repair
  * Ledger cache file tracking detection and cleanup
  * Git credential helper support for authentication

* **Improvements**
  * Git pull operations now use autostash to preserve uncommitted changes
  * Force-push protection enforced on collaborative repositories
  * Health checks display informational messages during initial sync instead of warnings
  * Enhanced git credential detection (SSH, SageOx credentials, credential helpers)
  * Improved workspace stability for daemon operations

* **Documentation**
  * Updated guidance on collaborative repositories and safe git workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->