### PR TITLE
feat(codedb): add ox codedb commands wrapping codedb binary

### DIFF
--- a/cmd/ox/codedb.go
+++ b/cmd/ox/codedb.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var codedbCmd = &cobra.Command{
+	Use:   "codedb",
+	Short: "Code search and indexing (powered by CodeDB)",
+	Long: `Sourcegraph-style code search across git repositories.
+
+CodeDB indexes git repos (including full commit history) and supports
+full-text search, symbol extraction, and commit/diff search.
+
+Data is stored at ~/.local/share/sageox/codedb/ (managed by codedb).
+
+Requires the codedb binary in PATH.`,
+}
+
+func init() {
+	codedbCmd.GroupID = "dev"
+	codedbCmd.AddCommand(codedbIndexCmd)
+	codedbCmd.AddCommand(codedbSearchCmd)
+	codedbCmd.AddCommand(codedbSQLCmd)
+	rootCmd.AddCommand(codedbCmd)
+}
+
+// findCodeDB locates the codedb binary in PATH.
+func findCodeDB() (string, error) {
+	path, err := exec.LookPath("codedb")
+	if err != nil {
+		return "", fmt.Errorf(
+			"codedb not found in PATH.\n\n" +
+				"Install CodeDB:\n" +
+				"  go install github.com/sageox/CodeDBGo/cmd/codedb@latest\n\n" +
+				"Or build from source:\n" +
+				"  cd CodeDBGo && make build && make install")
+	}
+	return path, nil
+}
+
+// runCodeDB executes the codedb binary with the given arguments,
+// streaming stdout/stderr to the terminal.
+func runCodeDB(bin string, args []string) error {
+	c := exec.Command(bin, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+	if err := c.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
+		return fmt.Errorf("failed to run codedb: %w", err)
+	}
+	return nil
+}

--- a/cmd/ox/codedb_index.go
+++ b/cmd/ox/codedb_index.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var codedbIndexCmd = &cobra.Command{
+	Use:                "index [url] [flags...]",
+	Short:              "Index a git repository",
+	Long:               "Clone and index a git repository for code search.\n\nRun `codedb index --help` for full options.",
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bin, err := findCodeDB()
+		if err != nil {
+			return err
+		}
+		return runCodeDB(bin, append([]string{"index"}, args...))
+	},
+}

--- a/cmd/ox/codedb_search.go
+++ b/cmd/ox/codedb_search.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var codedbSearchCmd = &cobra.Command{
+	Use:                "search [query] [flags...]",
+	Short:              "Search indexed code (Sourcegraph-style queries)",
+	Long:               "Search across indexed repositories using Sourcegraph-style query syntax.\n\nRun `codedb search --help` for full options and query syntax.",
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bin, err := findCodeDB()
+		if err != nil {
+			return err
+		}
+		return runCodeDB(bin, append([]string{"search"}, args...))
+	},
+}

--- a/cmd/ox/codedb_sql.go
+++ b/cmd/ox/codedb_sql.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var codedbSQLCmd = &cobra.Command{
+	Use:                "sql [query]",
+	Short:              "Run raw SQL against the metadata database",
+	Long:               "Execute SQL queries directly against the CodeDB metadata database.\n\nRun `codedb sql --help` for full options.",
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bin, err := findCodeDB()
+		if err != nil {
+			return err
+		}
+		return runCodeDB(bin, append([]string{"sql"}, args...))
+	},
+}

--- a/cmd/ox/codedb_test.go
+++ b/cmd/ox/codedb_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFindCodeDB_NotInPath(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	_, err := findCodeDB()
+	if err == nil {
+		t.Fatal("expected error when codedb not in PATH")
+	}
+	if got := err.Error(); !strings.Contains(got, "not found") {
+		t.Errorf("error should mention 'not found', got: %s", got)
+	}
+}
+
+func TestFindCodeDB_InPath(t *testing.T) {
+	path, err := findCodeDB()
+	if err != nil {
+		t.Skip("codedb not installed, skipping")
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+}

--- a/docs/plans/2026-03-07-ox-codedb-design.md
+++ b/docs/plans/2026-03-07-ox-codedb-design.md
@@ -1,0 +1,218 @@
+<!-- doc-audience: ai -->
+# Design: `ox codedb` Integration
+
+## Overview
+
+Add `ox codedb` as a thin subprocess wrapper around the `codedb` binary ([CodeDBGo](https://github.com/sageox/CodeDBGo)). All three commands (`index`, `search`, `sql`) are exposed with full flag passthrough. No CGO dependency added to ox.
+
+CodeDBGo is a Sourcegraph-style code search engine built in Go that indexes git repositories (full history) and supports full-text search (Bleve), symbol extraction (tree-sitter), and commit/diff search — all backed by SQLite + Bleve, running entirely locally.
+
+## Architecture
+
+```
+User -> ox codedb search "lang:go Iterator" --json
+          |
+          +-- Find `codedb` in $PATH
+          +-- Build args: ["search", "lang:go Iterator", "--json"]
+          +-- exec.Command("codedb", args...)
+          +-- Stream stdout/stderr to terminal
+          +-- Return exit code
+```
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ox as ox CLI
+    participant codedb as codedb binary
+
+    User->>ox: ox codedb search "lang:go Iterator" --json
+    ox->>ox: LookPath("codedb")
+    alt not found
+        ox-->>User: Error: codedb not found in PATH
+    end
+    ox->>codedb: exec.Command("codedb", "search", "lang:go Iterator", "--json")
+    codedb-->>ox: stdout/stderr streamed
+    ox-->>User: output + exit code
+```
+
+## Commands
+
+| Command | Maps To | Description |
+|---------|---------|-------------|
+| `ox codedb index <url> [flags...]` | `codedb index <url> [flags...]` | Index a git repository |
+| `ox codedb search <query> [flags...]` | `codedb search <query> [flags...]` | Search indexed code |
+| `ox codedb sql <query>` | `codedb sql <query>` | Run raw SQL against metadata DB |
+
+### Usage Examples
+
+```bash
+# Index a repository
+ox codedb index https://github.com/sageox/ox
+
+# Search for Go iterators
+ox codedb search "lang:go type:symbol Iterator"
+
+# Search with JSON output
+ox codedb search --json "lang:rust file:*.rs serialize"
+
+# Search commit diffs by author
+ox codedb search "type:diff author:alice streaming"
+
+# Find callers of a function
+ox codedb search "calls:groupby"
+
+# Regex search
+ox codedb search "/fn\s+process_\w+/"
+
+# Raw SQL query against metadata
+ox codedb sql "SELECT name, path FROM repos"
+
+# Limit index depth
+ox codedb index --depth 100 https://github.com/sageox/ox
+```
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Binary discovery | `$PATH` lookup only | Simplest approach; `codedb` is actively developed and installed locally. Config override or auto-install can come later. |
+| Flag handling | Full passthrough (`DisableFlagParsing: true`) | Zero maintenance when codedb adds flags. Ox help points to `codedb <cmd> --help` for full reference. |
+| Data directory | CodeDBGo default (`~/.local/share/sageox/codedb/`) | CodeDBGo already uses the `sageox` XDG namespace. Ox does not pass `--root`. |
+| Help group | `dev` group | Code search is a core developer workflow tool, alongside `init`, `login`, `status`. |
+| Output handling | Stream stdout/stderr directly | No reformatting. Exit code propagated. |
+| CodeDBGo modifications | None | CodeDBGo is under active parallel development. This integration is a pure wrapper. |
+
+## File Structure
+
+```
+cmd/ox/
++-- codedb.go            # Parent command + binary lookup + shared exec helper
++-- codedb_index.go      # index subcommand
++-- codedb_search.go     # search subcommand
++-- codedb_sql.go        # sql subcommand
+```
+
+Follows existing ox convention: flat `cmd/ox/` directory, `<group>_<subcommand>.go` naming.
+
+## Implementation Details
+
+### Binary Lookup
+
+```go
+func findCodeDB() (string, error) {
+    path, err := exec.LookPath("codedb")
+    if err != nil {
+        return "", fmt.Errorf(
+            "codedb not found in PATH.\n\n" +
+            "Install CodeDB:\n" +
+            "  go install github.com/sageox/CodeDBGo/cmd/codedb@latest\n\n" +
+            "Or build from source:\n" +
+            "  cd CodeDBGo && make build && make install")
+    }
+    return path, nil
+}
+```
+
+### Subprocess Execution (shared helper in codedb.go)
+
+```go
+func runCodeDB(bin string, args []string) error {
+    c := exec.Command(bin, args...)
+    c.Stdout = os.Stdout
+    c.Stderr = os.Stderr
+    c.Stdin = os.Stdin
+    return c.Run()
+}
+```
+
+### Subcommand Pattern (each subcommand follows this)
+
+```go
+var codedbSearchCmd = &cobra.Command{
+    Use:                "search [query] [flags...]",
+    Short:              "Search indexed code (Sourcegraph-style queries)",
+    Long:               "Run codedb search --help for full options and query syntax.",
+    DisableFlagParsing: true,
+    RunE: func(cmd *cobra.Command, args []string) error {
+        bin, err := findCodeDB()
+        if err != nil {
+            return err
+        }
+        return runCodeDB(bin, append([]string{"search"}, args...))
+    },
+}
+```
+
+### Parent Command (codedb.go)
+
+```go
+var codedbCmd = &cobra.Command{
+    Use:   "codedb",
+    Short: "Code search and indexing (powered by CodeDB)",
+    Long:  "Sourcegraph-style code search across git repositories.\n\nRequires the codedb binary in PATH.",
+}
+
+func init() {
+    codedbCmd.GroupID = "dev"
+    codedbCmd.AddCommand(codedbIndexCmd)
+    codedbCmd.AddCommand(codedbSearchCmd)
+    codedbCmd.AddCommand(codedbSQLCmd)
+    rootCmd.AddCommand(codedbCmd)
+}
+```
+
+### Command Registration
+
+```go
+// codedb_index.go
+func init() {
+    // Registered via codedb.go parent init
+}
+
+// codedb_search.go
+func init() {
+    // Registered via codedb.go parent init
+}
+
+// codedb_sql.go
+func init() {
+    // Registered via codedb.go parent init
+}
+```
+
+## Data Directory Convention
+
+CodeDBGo stores all data at `~/.local/share/sageox/codedb/` by default, following XDG Base Directory Specification:
+
+```
+~/.local/share/sageox/codedb/
++-- metadata.db          # SQLite database (repos, commits, symbols, refs)
++-- bleve/
+|   +-- code/            # Full-text index for file contents
+|   +-- diff/            # Full-text index for commit diffs
++-- repos/
+    +-- github.com/
+    |   +-- user/repo.git/    # Bare git clone
+    +-- gitlab.com/
+        +-- org/project.git/  # Bare git clone
+```
+
+ox does NOT manage this directory. It is owned entirely by `codedb`. The `--root` flag is available to users via passthrough if they need a custom location.
+
+## What This Does NOT Do
+
+- No flag curation or validation in ox
+- No output reformatting or ox-styled output
+- No `--root` management by ox
+- No auto-install of `codedb` binary
+- No modifications to CodeDBGo repo
+- No CGO dependency added to ox
+- No daemon integration (codedb runs synchronously)
+
+## Future Considerations
+
+- **Auto-install**: `ox codedb` could offer to install codedb if not found
+- **Config override**: `ox config set codedb.path /custom/path` for non-PATH installs
+- **Go module import**: Once CGO deps are reduced/removed in CodeDBGo, direct import becomes viable
+- **Agent integration**: `ox agent prime` could surface codedb search as a tool for AI coworkers
+- **Daemon indexing**: Background re-indexing via ox daemon when repos change

--- a/docs/plans/2026-03-07-ox-codedb-impl.md
+++ b/docs/plans/2026-03-07-ox-codedb-impl.md
@@ -1,0 +1,344 @@
+<!-- doc-audience: ai -->
+# `ox codedb` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `ox codedb` commands that wrap the `codedb` binary as a subprocess, exposing `index`, `search`, and `sql` subcommands with full flag passthrough.
+
+**Architecture:** Thin subprocess wrapper — ox finds `codedb` in `$PATH`, forwards all arguments, streams stdout/stderr directly. No CGO, no import of CodeDBGo internals.
+
+**Tech Stack:** Go, cobra, os/exec
+
+**Design doc:** `docs/plans/2026-03-07-ox-codedb-design.md`
+
+---
+
+### Task 1: Create parent command and shared helpers (`codedb.go`)
+
+**Files:**
+- Create: `cmd/ox/codedb.go`
+
+**Step 1: Write the test**
+
+Create `cmd/ox/codedb_test.go` with a test that verifies `findCodeDB` returns an error when the binary is not in PATH:
+
+```go
+// cmd/ox/codedb_test.go
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFindCodeDB_NotInPath(t *testing.T) {
+	// Save original PATH and set to empty
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", "")
+	defer os.Setenv("PATH", origPath)
+
+	_, err := findCodeDB()
+	if err == nil {
+		t.Fatal("expected error when codedb not in PATH")
+	}
+	if got := err.Error(); !containsAll(got, "codedb", "not found") {
+		t.Errorf("error message should mention codedb not found, got: %s", got)
+	}
+}
+
+func TestFindCodeDB_InPath(t *testing.T) {
+	// Only run if codedb is actually installed
+	path, err := findCodeDB()
+	if err != nil {
+		t.Skip("codedb not installed, skipping")
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+}
+
+func containsAll(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if !contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/ox/ -run TestFindCodeDB -v -count=1`
+Expected: FAIL — `findCodeDB` not defined
+
+**Step 3: Write the implementation**
+
+```go
+// cmd/ox/codedb.go
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var codedbCmd = &cobra.Command{
+	Use:   "codedb",
+	Short: "Code search and indexing (powered by CodeDB)",
+	Long: `Sourcegraph-style code search across git repositories.
+
+CodeDB indexes git repos (including full commit history) and supports
+full-text search, symbol extraction, and commit/diff search.
+
+Data is stored at ~/.local/share/sageox/codedb/ (managed by codedb).
+
+Requires the codedb binary in PATH.`,
+}
+
+func init() {
+	codedbCmd.GroupID = "dev"
+	codedbCmd.AddCommand(codedbIndexCmd)
+	codedbCmd.AddCommand(codedbSearchCmd)
+	codedbCmd.AddCommand(codedbSQLCmd)
+	rootCmd.AddCommand(codedbCmd)
+}
+
+// findCodeDB locates the codedb binary in PATH.
+func findCodeDB() (string, error) {
+	path, err := exec.LookPath("codedb")
+	if err != nil {
+		return "", fmt.Errorf(
+			"codedb not found in PATH.\n\n" +
+				"Install CodeDB:\n" +
+				"  go install github.com/sageox/CodeDBGo/cmd/codedb@latest\n\n" +
+				"Or build from source:\n" +
+				"  cd CodeDBGo && make build && make install")
+	}
+	return path, nil
+}
+
+// runCodeDB executes the codedb binary with the given arguments,
+// streaming stdout/stderr to the terminal.
+func runCodeDB(bin string, args []string) error {
+	c := exec.Command(bin, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+	if err := c.Run(); err != nil {
+		// If codedb exited with a non-zero status, propagate it
+		// without wrapping (the error message was already printed to stderr)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		return fmt.Errorf("failed to run codedb: %w", err)
+	}
+	return nil
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/ox/ -run TestFindCodeDB -v -count=1`
+Expected: PASS (or skip if codedb not installed for the InPath test)
+
+**Step 5: Commit**
+
+```bash
+git add cmd/ox/codedb.go cmd/ox/codedb_test.go
+git commit -m "feat(codedb): add parent command and binary lookup helpers"
+```
+
+---
+
+### Task 2: Add `index` subcommand (`codedb_index.go`)
+
+**Files:**
+- Create: `cmd/ox/codedb_index.go`
+
+**Step 1: Write the implementation**
+
+```go
+// cmd/ox/codedb_index.go
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var codedbIndexCmd = &cobra.Command{
+	Use:                "index [url] [flags...]",
+	Short:              "Index a git repository",
+	Long:               "Clone and index a git repository for code search.\n\nRun `codedb index --help` for full options.",
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bin, err := findCodeDB()
+		if err != nil {
+			return err
+		}
+		return runCodeDB(bin, append([]string{"index"}, args...))
+	},
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `go build ./cmd/ox/`
+Expected: SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cmd/ox/codedb_index.go
+git commit -m "feat(codedb): add index subcommand"
+```
+
+---
+
+### Task 3: Add `search` subcommand (`codedb_search.go`)
+
+**Files:**
+- Create: `cmd/ox/codedb_search.go`
+
+**Step 1: Write the implementation**
+
+```go
+// cmd/ox/codedb_search.go
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var codedbSearchCmd = &cobra.Command{
+	Use:                "search [query] [flags...]",
+	Short:              "Search indexed code (Sourcegraph-style queries)",
+	Long:               "Search across indexed repositories using Sourcegraph-style query syntax.\n\nRun `codedb search --help` for full options and query syntax.",
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bin, err := findCodeDB()
+		if err != nil {
+			return err
+		}
+		return runCodeDB(bin, append([]string{"search"}, args...))
+	},
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `go build ./cmd/ox/`
+Expected: SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cmd/ox/codedb_search.go
+git commit -m "feat(codedb): add search subcommand"
+```
+
+---
+
+### Task 4: Add `sql` subcommand (`codedb_sql.go`)
+
+**Files:**
+- Create: `cmd/ox/codedb_sql.go`
+
+**Step 1: Write the implementation**
+
+```go
+// cmd/ox/codedb_sql.go
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var codedbSQLCmd = &cobra.Command{
+	Use:                "sql [query]",
+	Short:              "Run raw SQL against the metadata database",
+	Long:               "Execute SQL queries directly against the CodeDB metadata database.\n\nRun `codedb sql --help` for full options.",
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bin, err := findCodeDB()
+		if err != nil {
+			return err
+		}
+		return runCodeDB(bin, append([]string{"sql"}, args...))
+	},
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `go build ./cmd/ox/`
+Expected: SUCCESS
+
+**Step 3: Commit**
+
+```bash
+git add cmd/ox/codedb_sql.go
+git commit -m "feat(codedb): add sql subcommand"
+```
+
+---
+
+### Task 5: Run full test suite and lint
+
+**Step 1: Run tests**
+
+Run: `make test`
+Expected: All tests pass
+
+**Step 2: Run linter**
+
+Run: `make lint`
+Expected: No lint errors
+
+**Step 3: Build**
+
+Run: `make build`
+Expected: Binary builds successfully
+
+**Step 4: Manual smoke test (if codedb is installed)**
+
+Run:
+```bash
+./ox-tmp codedb --help
+./ox-tmp codedb index --help
+./ox-tmp codedb search --help
+./ox-tmp codedb sql --help
+```
+Expected: Help text displayed for each command
+
+---
+
+### Task 6: Regenerate reference docs
+
+**Step 1: Regenerate docs from cobra definitions**
+
+Run: `go build -o ox-tmp ./cmd/ox && ./ox-tmp docs --output docs/reference && rm ox-tmp`
+Expected: Reference docs updated with new `codedb` commands
+
+**Step 2: Commit**
+
+```bash
+git add docs/reference/
+git commit -m "docs: regenerate reference docs with codedb commands"
+```


### PR DESCRIPTION
## Summary

- Adds `ox codedb` command group with three subcommands: `index`, `search`, and `sql`
- Thin subprocess wrapper — finds `codedb` in `$PATH` and forwards all arguments with full flag passthrough
- No CGO dependency added to ox; no modifications to CodeDBGo
- Registered under the `dev` help group alongside `init`, `login`, `status`

## Architecture

```mermaid
sequenceDiagram
    participant User
    participant ox as ox CLI
    participant codedb as codedb binary

    User->>ox: ox codedb search "lang:go Iterator" --json
    ox->>ox: LookPath("codedb")
    alt not found
        ox-->>User: Error: codedb not found in PATH
    end
    ox->>codedb: exec.Command("codedb", "search", ...)
    codedb-->>ox: stdout/stderr streamed
    ox-->>User: output + exit code
```

## Key decisions

| Decision | Choice |
|----------|--------|
| Binary discovery | `$PATH` lookup only |
| Flag handling | Full passthrough (`DisableFlagParsing: true`) |
| Data directory | CodeDBGo default (`~/.local/share/sageox/codedb/`), not managed by ox |
| Output | Streamed directly, no reformatting |

## Files added

- `cmd/ox/codedb.go` — Parent command + `findCodeDB()` / `runCodeDB()` helpers
- `cmd/ox/codedb_index.go` — `ox codedb index`
- `cmd/ox/codedb_search.go` — `ox codedb search`
- `cmd/ox/codedb_sql.go` — `ox codedb sql`
- `cmd/ox/codedb_test.go` — Tests for binary lookup
- `docs/plans/2026-03-07-ox-codedb-design.md` — Design doc
- `docs/plans/2026-03-07-ox-codedb-impl.md` — Implementation plan

## Note on CodeDBGo repo

CodeDBGo currently lives at https://github.com/rupakm/CodeDBGo — we should fork it to the `sageox` org so install instructions and module paths point to `github.com/sageox/CodeDBGo`.

## Test plan

- [x] `go build ./cmd/ox/` passes
- [x] `TestFindCodeDB_NotInPath` passes (verifies error when binary not in PATH)
- [x] `TestFindCodeDB_InPath` skips gracefully when codedb not installed
- [x] No new lint issues
- [ ] Manual: `ox codedb --help` shows all three subcommands
- [ ] Manual: `ox codedb search "lang:go Iterator"` works with codedb installed

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ox codedb` command to integrate CodeDB functionality into the CLI. Includes three subcommands: `index` for indexing code repositories, `search` for querying code with code search queries, and `sql` for executing raw SQL queries against the code metadata database. All commands support full flag and argument passthrough.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->