### PR TITLE
fix: detect LFS pointer files and use agent-specific recording state

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -319,7 +319,7 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 	// For generic adapters: check if the drop file has content BEFORE clearing state.
 	// If empty, mark as incomplete and return retry guidance instead of processing.
 	// This must happen before clearing recording state.
-	state, err := session.LoadRecordingState(projectRoot)
+	state, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
 	if err != nil {
 		return fmt.Errorf("failed to load recording state: %w", err)
 	}
@@ -330,7 +330,7 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 		info, statErr := os.Stat(state.SessionFile)
 		if statErr != nil || info.Size() == 0 {
 			// mark recording as incomplete (allows restart without "already recording" error)
-			_ = session.UpdateRecordingState(projectRoot, func(s *session.RecordingState) {
+			_ = session.UpdateRecordingStateForAgent(projectRoot, inst.AgentID, func(s *session.RecordingState) {
 				s.StopIncomplete = true
 			})
 
@@ -386,7 +386,7 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 	recordSessionObservation(projectRoot, processResult, duration)
 
 	// processing succeeded (or no source file to process) - clear active state.
-	if err := session.ClearRecordingState(projectRoot); err != nil {
+	if err := session.ClearRecordingStateForAgent(projectRoot, inst.AgentID); err != nil {
 		_ = doctor.SetNeedsDoctorAgent(projectRoot)
 		return fmt.Errorf("failed to finalize recording stop: %w", err)
 	}

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -87,6 +87,18 @@ func uploadSessionLFS(projectRoot, sessionPath string) (map[string]lfs.FileRef, 
 
 	for _, name := range contentFiles {
 		filePath := filepath.Join(sessionPath, name)
+
+		// if file is already an LFS pointer, extract its ref directly —
+		// don't re-upload the pointer text as content
+		if lfs.IsPointerFile(filePath) {
+			ref, err := lfs.ReadPointerFile(filePath)
+			if err != nil {
+				return nil, fmt.Errorf("read pointer %s: %w", name, err)
+			}
+			fileRefs[name] = ref
+			continue
+		}
+
 		content, err := os.ReadFile(filePath)
 		if err != nil {
 			if os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

Fixes two critical bugs in session upload and multi-agent recording:

1. **LFS pointer detection** – `uploadSessionLFS()` now checks if session content files are already LFS pointers before reading them. Previously, it would read pointer text (~130 bytes) and upload it as content, creating broken pointer-to-pointer chains.

2. **GitHub #168 – Multi-agent state isolation** – `runAgentSessionStop()` now uses agent-specific recording state functions instead of first-match variants. In concurrent scenarios (Conductor workspaces, worktrees), this prevents loading/clearing the wrong agent's session data.

## Changes

- **session_upload.go**: Add `lfs.IsPointerFile()` check before `os.ReadFile()` in upload loop; extract existing OID/size from pointer files instead of re-uploading.
- **agent_session.go**: Replace `LoadRecordingState()` → `LoadRecordingStateForAgent()`, `UpdateRecordingState()` → `UpdateRecordingStateForAgent()`, and `ClearRecordingState()` → `ClearRecordingStateForAgent()` in `runAgentSessionStop()`.

Agent-specific functions already existed and are already used elsewhere. Tests pass.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized session uploads with improved LFS pointer file detection and handling to reduce redundant uploads.

* **Improvements**
  * Enhanced agent session state management with per-agent isolation for more robust session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->