### PR TITLE
fix: use agent-specific recording state in multi-agent scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,10 @@ demo/credentials.sops.yaml
 demo/playwright/node_modules/
 .team-contexts/
 
+# Conductor workspace artifacts (blue-green GC reclone)
+.gc-diff
+.gc-untracked/
+
 # Dolt database files (added by bd init)
 .dolt/
 *.db

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -319,7 +319,7 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 	// For generic adapters: check if the drop file has content BEFORE clearing state.
 	// If empty, mark as incomplete and return retry guidance instead of processing.
 	// This must happen before clearing recording state.
-	state, err := session.LoadRecordingState(projectRoot)
+	state, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
 	if err != nil {
 		return fmt.Errorf("failed to load recording state: %w", err)
 	}
@@ -330,7 +330,7 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 		info, statErr := os.Stat(state.SessionFile)
 		if statErr != nil || info.Size() == 0 {
 			// mark recording as incomplete (allows restart without "already recording" error)
-			_ = session.UpdateRecordingState(projectRoot, func(s *session.RecordingState) {
+			_ = session.UpdateRecordingStateForAgent(projectRoot, inst.AgentID, func(s *session.RecordingState) {
 				s.StopIncomplete = true
 			})
 
@@ -386,7 +386,7 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 	recordSessionObservation(projectRoot, processResult, duration)
 
 	// processing succeeded (or no source file to process) - clear active state.
-	if err := session.ClearRecordingState(projectRoot); err != nil {
+	if err := session.ClearRecordingStateForAgent(projectRoot, inst.AgentID); err != nil {
 		_ = doctor.SetNeedsDoctorAgent(projectRoot)
 		return fmt.Errorf("failed to finalize recording stop: %w", err)
 	}

--- a/cmd/ox/agent_session_log.go
+++ b/cmd/ox/agent_session_log.go
@@ -98,7 +98,7 @@ func runAgentSessionLog(inst *agentinstance.Instance, args []string) error {
 	}
 
 	// load recording state
-	state, err := session.LoadRecordingState(projectRoot)
+	state, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
 	if err != nil {
 		return fmt.Errorf("failed to load recording state: %w", err)
 	}

--- a/internal/session/recording_test.go
+++ b/internal/session/recording_test.go
@@ -1221,3 +1221,140 @@ func TestExplicitStopMarker_XDGPaths(t *testing.T) {
 	assert.False(t, ConsumeExplicitStop(projectRoot),
 		"consumed marker must not be consumable again")
 }
+
+// TestMultiAgentLoadForAgent_ReturnsCorrectAgent is a regression test for
+// https://github.com/sageox/ox/issues/168 — LoadRecordingState (first-found)
+// returned the wrong agent's state when multiple agents recorded concurrently,
+// causing session stop to process an empty subagent recording instead of the
+// real one.
+func TestMultiAgentLoadForAgent_ReturnsCorrectAgent(t *testing.T) {
+	projectRoot, _ := createTestSessionProject(t)
+
+	// simulate Conductor: main agent has a real session file, subagents have empty ones
+	mainAgent := "OxzJGM" // alphabetically AFTER subagents
+	subAgents := []string{"Ox0OE4", "Ox88vV", "OxHc7U", "Oxsv7q"}
+
+	// start subagents first (empty session_file, generic adapter)
+	for _, id := range subAgents {
+		state, err := StartRecording(projectRoot, StartRecordingOptions{
+			AgentID:     id,
+			AdapterName: "claude",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		assert.Empty(t, state.SessionFile, "subagent %s should have empty session_file", id)
+	}
+
+	// start main agent with a real session file (claude-code adapter finds JSONL)
+	mainState, err := StartRecording(projectRoot, StartRecordingOptions{
+		AgentID:     mainAgent,
+		AdapterName: "claude-code",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mainState)
+
+	// simulate claude-code adapter finding a real JSONL file
+	fakeJSONL := filepath.Join(t.TempDir(), "session.jsonl")
+	require.NoError(t, os.WriteFile(fakeJSONL, []byte(`{"type":"user","content":"hello"}`), 0600))
+	err = UpdateRecordingStateForAgent(projectRoot, mainAgent, func(s *RecordingState) {
+		s.SessionFile = fakeJSONL
+	})
+	require.NoError(t, err)
+
+	// BUG SCENARIO: LoadRecordingState (first-found) returns Ox0OE4 or Ox88vV
+	// (alphabetically first), which has empty SessionFile.
+	// LoadRecordingStateForAgent must return the correct agent.
+	firstFound, err := LoadRecordingState(projectRoot)
+	require.NoError(t, err)
+	require.NotNil(t, firstFound)
+
+	agentSpecific, err := LoadRecordingStateForAgent(projectRoot, mainAgent)
+	require.NoError(t, err)
+	require.NotNil(t, agentSpecific)
+
+	// the first-found state is NOT the main agent (it's a subagent sorted first)
+	assert.NotEqual(t, mainAgent, firstFound.AgentID,
+		"first-found should return a subagent (alphabetically first), demonstrating the bug")
+	assert.Empty(t, firstFound.SessionFile,
+		"first-found subagent has empty session_file — this is what the bug processed")
+
+	// agent-specific returns the correct state with the real session file
+	assert.Equal(t, mainAgent, agentSpecific.AgentID)
+	assert.Equal(t, fakeJSONL, agentSpecific.SessionFile,
+		"agent-specific must return the correct session file")
+}
+
+// TestMultiAgentClearForAgent_OnlyClearsTargetAgent is a regression test for
+// https://github.com/sageox/ox/issues/168 — ClearRecordingState (first-found)
+// cleared the wrong agent's recording, leaving the target agent orphaned.
+func TestMultiAgentClearForAgent_OnlyClearsTargetAgent(t *testing.T) {
+	projectRoot, _ := createTestSessionProject(t)
+
+	mainAgent := "OxzJGM"
+	subAgent := "Ox88vV" // alphabetically before main
+
+	_, err := StartRecording(projectRoot, StartRecordingOptions{
+		AgentID: subAgent, AdapterName: "claude",
+	})
+	require.NoError(t, err)
+
+	_, err = StartRecording(projectRoot, StartRecordingOptions{
+		AgentID: mainAgent, AdapterName: "claude-code",
+	})
+	require.NoError(t, err)
+
+	// clear the main agent specifically
+	err = ClearRecordingStateForAgent(projectRoot, mainAgent)
+	require.NoError(t, err)
+
+	// main agent cleared
+	assert.False(t, IsRecordingForAgent(projectRoot, mainAgent),
+		"main agent should no longer be recording")
+
+	// subagent must survive — the bug would have cleared this one instead
+	assert.True(t, IsRecordingForAgent(projectRoot, subAgent),
+		"subagent must still be recording after clearing a different agent")
+
+	// verify via load
+	subState, err := LoadRecordingStateForAgent(projectRoot, subAgent)
+	require.NoError(t, err)
+	require.NotNil(t, subState, "subagent state must still exist")
+	assert.Equal(t, subAgent, subState.AgentID)
+}
+
+// TestMultiAgentUpdateForAgent_Isolation verifies that UpdateRecordingStateForAgent
+// only modifies the target agent's state in a multi-agent scenario.
+// Regression test for https://github.com/sageox/ox/issues/168
+func TestMultiAgentUpdateForAgent_Isolation(t *testing.T) {
+	projectRoot, _ := createTestSessionProject(t)
+
+	mainAgent := "OxzJGM"
+	subAgent := "Ox88vV"
+
+	_, err := StartRecording(projectRoot, StartRecordingOptions{
+		AgentID: subAgent, AdapterName: "claude",
+	})
+	require.NoError(t, err)
+
+	_, err = StartRecording(projectRoot, StartRecordingOptions{
+		AgentID: mainAgent, AdapterName: "claude-code",
+	})
+	require.NoError(t, err)
+
+	// mark main agent as incomplete (the StopIncomplete path from the bug)
+	err = UpdateRecordingStateForAgent(projectRoot, mainAgent, func(s *RecordingState) {
+		s.StopIncomplete = true
+	})
+	require.NoError(t, err)
+
+	// main agent updated
+	mainState, err := LoadRecordingStateForAgent(projectRoot, mainAgent)
+	require.NoError(t, err)
+	assert.True(t, mainState.StopIncomplete)
+
+	// subagent untouched
+	subState, err := LoadRecordingStateForAgent(projectRoot, subAgent)
+	require.NoError(t, err)
+	assert.False(t, subState.StopIncomplete,
+		"subagent must not be affected by updating a different agent")
+}


### PR DESCRIPTION
## Problem

Session stop was processing the wrong agent's recording state when multiple agents recorded concurrently (Conductor/multi-worktree). Used `LoadRecordingState`/`ClearRecordingState` (first-found) instead of agent-specific variants, causing it to orphan correct recording data.

## Solution

Replace 4 call sites with agent-specific functions:
- `runAgentSessionStop`: `LoadRecordingState` → `LoadRecordingStateForAgent`
- `runAgentSessionStop`: `UpdateRecordingState` → `UpdateRecordingStateForAgent`
- `runAgentSessionStop`: `ClearRecordingState` → `ClearRecordingStateForAgent`
- `runAgentSessionLog`: `LoadRecordingState` → `LoadRecordingStateForAgent`

Add 3 regression tests verifying agent isolation in multi-agent scenarios.

Fixes #168

Co-Authored-By: SageOx <ox@sageox.ai>