### PR TITLE
feat: colorize ox daemon logs with semantic colors

### DIFF
--- a/cmd/ox/daemon.go
+++ b/cmd/ox/daemon.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
@@ -187,9 +188,26 @@ var daemonLogsCmd = &cobra.Command{
 		tailArgs = append(tailArgs, logPath)
 
 		tailCmd := exec.Command("tail", tailArgs...)
-		tailCmd.Stdout = os.Stdout
 		tailCmd.Stderr = os.Stderr
-		return tailCmd.Run()
+
+		// colorize when output is a terminal
+		colorize := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+		if !colorize {
+			tailCmd.Stdout = os.Stdout
+			return tailCmd.Run()
+		}
+
+		stdout, err := tailCmd.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("failed to create pipe: %w", err)
+		}
+
+		if err := tailCmd.Start(); err != nil {
+			return fmt.Errorf("failed to start tail: %w", err)
+		}
+
+		cli.StreamFormattedLogs(stdout, os.Stdout)
+		return tailCmd.Wait()
 	},
 }
 

--- a/internal/cli/logfmt.go
+++ b/internal/cli/logfmt.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// SlogLine holds parsed fields from a slog TextHandler line.
+type SlogLine struct {
+	Time    string // raw timestamp value
+	Level   string // DEBUG, INFO, WARN, ERROR
+	Message string // msg value (unquoted)
+	Attrs   string // remaining key=value pairs
+}
+
+// ParseSlogLine parses a slog TextHandler line into its components.
+// Returns false if the line doesn't match the expected format.
+func ParseSlogLine(line string) (SlogLine, bool) {
+	// slog TextHandler format: time=<ts> level=<level> msg=<msg> [key=value ...]
+	rest, ok := strings.CutPrefix(line, "time=")
+	if !ok {
+		return SlogLine{}, false
+	}
+
+	// extract timestamp (everything before " level=")
+	idx := strings.Index(rest, " level=")
+	if idx < 0 {
+		return SlogLine{}, false
+	}
+	ts := rest[:idx]
+	rest = rest[idx+len(" level="):]
+
+	// extract level (everything before " msg=")
+	idx = strings.Index(rest, " msg=")
+	if idx < 0 {
+		return SlogLine{}, false
+	}
+	level := rest[:idx]
+	rest = rest[idx+len(" msg="):]
+
+	// extract message — may be quoted
+	var msg, attrs string
+	if strings.HasPrefix(rest, "\"") {
+		// find closing quote (handle escaped quotes)
+		i := 1
+		for i < len(rest) {
+			if rest[i] == '\\' {
+				i += 2 // skip escaped char
+				continue
+			}
+			if rest[i] == '"' {
+				msg = rest[1:i]
+				if i+1 < len(rest) {
+					attrs = strings.TrimLeft(rest[i+1:], " ")
+				}
+				break
+			}
+			i++
+		}
+		if i >= len(rest) {
+			// unterminated quote — use everything as msg
+			msg = rest[1:]
+		}
+	} else {
+		// unquoted msg — take until next space
+		if idx := strings.IndexByte(rest, ' '); idx >= 0 {
+			msg = rest[:idx]
+			attrs = strings.TrimLeft(rest[idx+1:], " ")
+		} else {
+			msg = rest
+		}
+	}
+
+	return SlogLine{
+		Time:    ts,
+		Level:   level,
+		Message: msg,
+		Attrs:   attrs,
+	}, true
+}
+
+// FormatSlogLine parses a raw slog log line and returns a colorized version.
+// Malformed lines are returned as-is.
+func FormatSlogLine(line string) string {
+	parsed, ok := ParseSlogLine(line)
+	if !ok {
+		return line
+	}
+
+	// compact timestamp to time-only with milliseconds
+	ts := compactTimestamp(parsed.Time)
+
+	// color the level
+	levelStr := fmt.Sprintf("%-5s", parsed.Level)
+	var coloredLevel string
+	switch parsed.Level {
+	case "DEBUG":
+		coloredLevel = StyleDim.Render(levelStr)
+	case "INFO":
+		coloredLevel = StyleInfo.Render(levelStr)
+	case "WARN":
+		coloredLevel = StyleWarning.Render(levelStr)
+	case "ERROR":
+		coloredLevel = StyleError.Render(levelStr)
+	default:
+		coloredLevel = levelStr
+	}
+
+	// build output: timestamp  level  message  [attrs]
+	var b strings.Builder
+	b.WriteString(StyleDim.Render(ts))
+	b.WriteString("  ")
+	b.WriteString(coloredLevel)
+	b.WriteString("  ")
+	b.WriteString(parsed.Message)
+	if parsed.Attrs != "" {
+		b.WriteString("  ")
+		b.WriteString(StyleDim.Render(parsed.Attrs))
+	}
+
+	return b.String()
+}
+
+// compactTimestamp converts an ISO8601 timestamp to time-only with milliseconds.
+// Falls back to the raw value if parsing fails.
+func compactTimestamp(raw string) string {
+	// slog uses time.RFC3339Nano-like format
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999-07:00",
+		"2006-01-02T15:04:05.999999999Z07:00",
+		"2006-01-02T15:04:05.999999999Z",
+		time.RFC3339Nano,
+		time.RFC3339,
+	} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t.Format("15:04:05.000")
+		}
+	}
+	return raw
+}
+
+// StreamFormattedLogs reads log lines from r, colorizes each, and writes to w.
+// Blocks until r is closed or an error occurs.
+func StreamFormattedLogs(r io.Reader, w io.Writer) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		fmt.Fprintln(w, FormatSlogLine(scanner.Text()))
+	}
+}

--- a/internal/cli/logfmt_test.go
+++ b/internal/cli/logfmt_test.go
@@ -1,0 +1,265 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseSlogLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    SlogLine
+		wantOK  bool
+	}{
+		{
+			name: "info with quoted msg",
+			line: `time=2026-03-09T18:27:44.282-07:00 level=INFO msg="daemon starting" version=0.8.0`,
+			want: SlogLine{
+				Time:    "2026-03-09T18:27:44.282-07:00",
+				Level:   "INFO",
+				Message: "daemon starting",
+				Attrs:   "version=0.8.0",
+			},
+			wantOK: true,
+		},
+		{
+			name: "warn with long msg and path attr",
+			line: `time=2026-03-09T18:27:44.282-07:00 level=WARN msg="manifest: file not found, using fallback" path=/Users/ryan/.local/share/sageox/sync.manifest`,
+			want: SlogLine{
+				Time:    "2026-03-09T18:27:44.282-07:00",
+				Level:   "WARN",
+				Message: "manifest: file not found, using fallback",
+				Attrs:   "path=/Users/ryan/.local/share/sageox/sync.manifest",
+			},
+			wantOK: true,
+		},
+		{
+			name: "error with quoted error attr",
+			line: `time=2026-03-09T18:27:46.503-07:00 level=ERROR msg="failed to sync" error="connection refused"`,
+			want: SlogLine{
+				Time:    "2026-03-09T18:27:46.503-07:00",
+				Level:   "ERROR",
+				Message: "failed to sync",
+				Attrs:   `error="connection refused"`,
+			},
+			wantOK: true,
+		},
+		{
+			name: "debug no attrs",
+			line: `time=2026-03-09T18:27:44.282-07:00 level=DEBUG msg="tick"`,
+			want: SlogLine{
+				Time:    "2026-03-09T18:27:44.282-07:00",
+				Level:   "DEBUG",
+				Message: "tick",
+				Attrs:   "",
+			},
+			wantOK: true,
+		},
+		{
+			name: "unquoted msg",
+			line: `time=2026-03-09T18:27:44.282-07:00 level=INFO msg=starting version=1.0`,
+			want: SlogLine{
+				Time:    "2026-03-09T18:27:44.282-07:00",
+				Level:   "INFO",
+				Message: "starting",
+				Attrs:   "version=1.0",
+			},
+			wantOK: true,
+		},
+		{
+			name: "unquoted msg no attrs",
+			line: `time=2026-03-09T18:27:44.282-07:00 level=INFO msg=done`,
+			want: SlogLine{
+				Time:    "2026-03-09T18:27:44.282-07:00",
+				Level:   "INFO",
+				Message: "done",
+				Attrs:   "",
+			},
+			wantOK: true,
+		},
+		{
+			name:   "empty line",
+			line:   "",
+			wantOK: false,
+		},
+		{
+			name:   "non-slog line",
+			line:   "some random log output",
+			wantOK: false,
+		},
+		{
+			name:   "missing level",
+			line:   "time=2026-03-09T18:27:44.282-07:00 msg=hello",
+			wantOK: false,
+		},
+		{
+			name:   "missing msg",
+			line:   "time=2026-03-09T18:27:44.282-07:00 level=INFO",
+			wantOK: false,
+		},
+		{
+			name: "msg with escaped quotes",
+			line: `time=2026-03-09T18:27:44.282-07:00 level=INFO msg="said \"hello\"" key=val`,
+			want: SlogLine{
+				Time:    "2026-03-09T18:27:44.282-07:00",
+				Level:   "INFO",
+				Message: `said \"hello\"`,
+				Attrs:   "key=val",
+			},
+			wantOK: true,
+		},
+		{
+			name: "multiple attrs",
+			line: `time=2026-03-09T18:27:44.282-07:00 level=INFO msg="sync complete" repos=3 duration=1.23s`,
+			want: SlogLine{
+				Time:    "2026-03-09T18:27:44.282-07:00",
+				Level:   "INFO",
+				Message: "sync complete",
+				Attrs:   "repos=3 duration=1.23s",
+			},
+			wantOK: true,
+		},
+		{
+			name: "utc timestamp",
+			line: `time=2026-03-09T01:27:44.282Z level=INFO msg="utc log"`,
+			want: SlogLine{
+				Time:    "2026-03-09T01:27:44.282Z",
+				Level:   "INFO",
+				Message: "utc log",
+				Attrs:   "",
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseSlogLine(tt.line)
+			if ok != tt.wantOK {
+				t.Fatalf("ParseSlogLine() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.Time != tt.want.Time {
+				t.Errorf("Time = %q, want %q", got.Time, tt.want.Time)
+			}
+			if got.Level != tt.want.Level {
+				t.Errorf("Level = %q, want %q", got.Level, tt.want.Level)
+			}
+			if got.Message != tt.want.Message {
+				t.Errorf("Message = %q, want %q", got.Message, tt.want.Message)
+			}
+			if got.Attrs != tt.want.Attrs {
+				t.Errorf("Attrs = %q, want %q", got.Attrs, tt.want.Attrs)
+			}
+		})
+	}
+}
+
+func TestCompactTimestamp(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "iso8601 with offset",
+			raw:  "2026-03-09T18:27:44.282-07:00",
+			want: "18:27:44.282",
+		},
+		{
+			name: "utc z suffix",
+			raw:  "2026-03-09T01:27:44.282Z",
+			want: "01:27:44.282",
+		},
+		{
+			name: "no fractional seconds",
+			raw:  "2026-03-09T18:27:44-07:00",
+			want: "18:27:44.000",
+		},
+		{
+			name: "nanoseconds truncated to ms",
+			raw:  "2026-03-09T18:27:44.282456789-07:00",
+			want: "18:27:44.282",
+		},
+		{
+			name: "unparseable falls back to raw",
+			raw:  "not-a-timestamp",
+			want: "not-a-timestamp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compactTimestamp(tt.raw)
+			if got != tt.want {
+				t.Errorf("compactTimestamp(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSlogLine_Passthrough(t *testing.T) {
+	// non-slog lines should pass through unchanged
+	lines := []string{
+		"",
+		"some random text",
+		"not a slog line at all",
+	}
+	for _, line := range lines {
+		got := FormatSlogLine(line)
+		if got != line {
+			t.Errorf("FormatSlogLine(%q) = %q, want passthrough", line, got)
+		}
+	}
+}
+
+func TestFormatSlogLine_ContainsLevel(t *testing.T) {
+	// verify that formatted output contains the level text
+	line := `time=2026-03-09T18:27:44.282-07:00 level=WARN msg="test warning" key=val`
+	got := FormatSlogLine(line)
+	if !strings.Contains(got, "WARN") {
+		t.Errorf("formatted output should contain WARN, got: %q", got)
+	}
+	if !strings.Contains(got, "test warning") {
+		t.Errorf("formatted output should contain message, got: %q", got)
+	}
+	if !strings.Contains(got, "18:27:44.282") {
+		t.Errorf("formatted output should contain compact timestamp, got: %q", got)
+	}
+}
+
+func TestStreamFormattedLogs(t *testing.T) {
+	input := strings.Join([]string{
+		`time=2026-03-09T18:27:44.282-07:00 level=INFO msg="first line"`,
+		`time=2026-03-09T18:27:45.019-07:00 level=WARN msg="second line"`,
+		`not a slog line`,
+		`time=2026-03-09T18:27:46.503-07:00 level=ERROR msg="third line"`,
+	}, "\n")
+
+	var buf bytes.Buffer
+	StreamFormattedLogs(strings.NewReader(input), &buf)
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 output lines, got %d: %v", len(lines), lines)
+	}
+
+	// slog lines should be formatted (contain compact timestamp)
+	if !strings.Contains(lines[0], "18:27:44.282") {
+		t.Errorf("line 0 should contain compact timestamp: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "18:27:45.019") {
+		t.Errorf("line 1 should contain compact timestamp: %q", lines[1])
+	}
+
+	// non-slog line should pass through
+	if !strings.Contains(lines[2], "not a slog line") {
+		t.Errorf("line 2 should be passthrough: %q", lines[2])
+	}
+}


### PR DESCRIPTION
## Summary
Adds semantic coloring and compact formatting to `ox daemon logs` output when displayed in a terminal.

Closes #172

## Changes
- **New: `internal/cli/logfmt.go`** — Slog TextHandler line parser and colorizer
  - `ParseSlogLine()` extracts time, level, message, and attributes from slog format
  - `FormatSlogLine()` colorizes parsed lines with semantic colors
  - `StreamFormattedLogs()` pipes tail output through the formatter
- **New: `internal/cli/logfmt_test.go`** — 13 test cases covering parsing, formatting, and streaming
- **Modified: `cmd/ox/daemon.go`** — Pipes `tail` output through the colorizer when stdout is a TTY; non-TTY output passes through unchanged

## Output
Before: `time=2026-03-09T18:27:44.282-07:00 level=WARN msg="manifest: file not found"`
After: `18:27:44.282  WARN  manifest: file not found` (with colors: timestamps dimmed, levels colored)

## Design
- On-disk format unchanged (slog TextHandler, machine-parseable)
- Display-layer formatter applies colors only to terminal output
- Levels: DEBUG/INFO=dimmed/blue, WARN=amber, ERROR=red
- TTY detection via `mattn/go-isatty`; respects NO_COLOR env var

## Verification
All tests pass (`make test`), linter passes (`make lint`).

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon logs now display with enhanced formatting and colors when viewed in a terminal, improving readability and making logs easier to scan. The system automatically detects terminal output and applies formatting accordingly, while falling back to plain output in non-terminal environments for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->