### PR TITLE
feat: compact code search, worktree support, inline code index

### DIFF
--- a/cmd/ox/agent_query.go
+++ b/cmd/ox/agent_query.go
@@ -131,7 +131,14 @@ Also available as: ox agent <id> query "search text"`
 // combinedQueryResponse holds results from both team context and local code search.
 type combinedQueryResponse struct {
 	TeamContext *api.QueryResponse `json:"team_context,omitempty"`
-	CodeResults []search.Result    `json:"code_results,omitempty"`
+	CodeResults []search.Result    `json:"code_results,omitempty"` // used by --full-json only
+}
+
+// compactQueryResponse is the default agent query output — minimal context footprint.
+type compactQueryResponse struct {
+	TeamContext *api.QueryResponse    `json:"team_context,omitempty"`
+	CodeResults []compactSearchResult `json:"code_results,omitempty"`
+	Guidance    string                `json:"guidance,omitempty"`
 }
 
 // runAgentQuery handles `ox agent <id> query "search text"`.
@@ -183,6 +190,7 @@ func executeQuery(qa *queryArgs, agentID string, agentType string) (int, error) 
 	}
 
 	// query local code index if source is "all" or "code"
+	var codeResults []search.Result
 	if qa.source == "all" || qa.source == "code" {
 		results, err := queryCodeDB(qa, projectRoot)
 		if err != nil {
@@ -191,14 +199,24 @@ func executeQuery(qa *queryArgs, agentID string, agentType string) (int, error) 
 			}
 			slog.Warn("code search failed, continuing with team context", "error", err)
 		} else {
-			combined.CodeResults = results
+			codeResults = results
 		}
+	}
+
+	// compact output — minimal context footprint for agents
+	resp := compactQueryResponse{
+		TeamContext: combined.TeamContext,
+	}
+	if len(codeResults) > 0 {
+		compact := compactSearchResults(codeResults, qa.limit)
+		resp.CodeResults = compact.Results
+		resp.Guidance = compact.Guidance
 	}
 
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(combined); err != nil {
+	if err := enc.Encode(resp); err != nil {
 		return 0, fmt.Errorf("failed to encode response: %w", err)
 	}
 

--- a/cmd/ox/code.go
+++ b/cmd/ox/code.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/codedb"
+	"github.com/sageox/ox/internal/codedb/search"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/repotools"
@@ -81,19 +82,21 @@ var codeSearchCmd = &cobra.Command{
 			return fmt.Errorf("search: %w", err)
 		}
 
-		raw, _ := cmd.Flags().GetBool("raw")
+		fullJSON, _ := cmd.Flags().GetBool("full-json")
+		limit, _ := cmd.Flags().GetInt("limit")
 
 		var buf bytes.Buffer
 		enc := json.NewEncoder(&buf)
 		enc.SetIndent("", "  ")
 
-		if raw {
-			if err := enc.Encode(results); err != nil {
+		if fullJSON {
+			resp := &combinedQueryResponse{CodeResults: results}
+			if err := enc.Encode(resp); err != nil {
 				return fmt.Errorf("encode: %w", err)
 			}
 		} else {
-			resp := &combinedQueryResponse{CodeResults: results}
-			if err := enc.Encode(resp); err != nil {
+			compact := compactSearchResults(results, limit)
+			if err := enc.Encode(compact); err != nil {
 				return fmt.Errorf("encode: %w", err)
 			}
 		}
@@ -110,6 +113,101 @@ var codeSearchCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// compactSearchResult is a minimal search result optimized for agent context.
+type compactSearchResult struct {
+	File    string `json:"file"`
+	Line    int    `json:"line,omitempty"`
+	Lang    string `json:"lang,omitempty"`
+	Snippet string `json:"snippet"`
+	Symbol  string `json:"symbol,omitempty"`
+}
+
+// compactSearchResponse is the default search output — minimal context footprint.
+type compactSearchResponse struct {
+	Results  []compactSearchResult `json:"results"`
+	Total    int                   `json:"total"`
+	Guidance string                `json:"guidance,omitempty"`
+}
+
+// compactSearchResults converts full results into a compact format for agents.
+func compactSearchResults(results []search.Result, limit int) compactSearchResponse {
+	total := len(results)
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	compact := make([]compactSearchResult, 0, len(results))
+	for _, r := range results {
+		snippet := stripANSIEscapes(r.Content)
+		snippet = compactSnippet(snippet, 120)
+		cr := compactSearchResult{
+			File:    r.FilePath,
+			Line:    r.Line,
+			Lang:    r.Language,
+			Snippet: snippet,
+			Symbol:  r.SymbolName,
+		}
+		compact = append(compact, cr)
+	}
+
+	resp := compactSearchResponse{
+		Results: compact,
+		Total:   total,
+	}
+
+	if total > len(compact) {
+		resp.Guidance = fmt.Sprintf("Showing %d of %d results. Use --limit N for more, or --full-json for complete output.", len(compact), total)
+	}
+
+	return resp
+}
+
+// compactSnippet collapses whitespace and truncates to maxLen chars.
+func compactSnippet(s string, maxLen int) string {
+	// collapse newlines and tabs into single spaces
+	var b strings.Builder
+	prevSpace := false
+	for _, r := range strings.TrimSpace(s) {
+		if r == '\n' || r == '\r' || r == '\t' {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		prevSpace = r == ' '
+		b.WriteRune(r)
+	}
+	result := b.String()
+	// strip leading ellipsis from bleve fragments
+	result = strings.TrimPrefix(result, "…")
+	result = strings.TrimSpace(result)
+	if len(result) > maxLen {
+		result = result[:maxLen] + "…"
+	}
+	return result
+}
+
+// stripANSIEscapes removes ANSI escape sequences from a string.
+func stripANSIEscapes(s string) string {
+	var b strings.Builder
+	inEscape := false
+	for _, r := range s {
+		if r == '\033' {
+			inEscape = true
+			continue
+		}
+		if inEscape {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscape = false
+			}
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // codeQueryCmd is a hidden alias for codeSearchCmd — agents try "query" as a search verb
@@ -164,23 +262,24 @@ var codeStatsCmd = &cobra.Command{
 		}
 
 		dataDir := paths.CodeDBDataDir(root)
-		if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-			fmt.Println("No code index found. Run 'ox code index' to create one.")
-			return nil
+		indexExists := false
+		if _, err := os.Stat(dataDir); err == nil {
+			indexExists = true
 		}
 
-		db, err := codedb.Open(dataDir)
-		if err != nil {
-			return fmt.Errorf("open codedb: %w", err)
+		// get daemon stats for freshness and next-check info
+		var codeStats *daemon.CodeDBStats
+		var syncInterval time.Duration
+		client := daemon.NewClientWithTimeout(500 * time.Millisecond)
+		if cs, err := client.CodeStatus(); err == nil {
+			codeStats = cs
 		}
-		defer db.Close()
+		if ds, err := client.Status(); err == nil {
+			syncInterval = ds.SyncIntervalRead
+		}
 
+		// query DB directly for counts (daemon stats may lag)
 		var totalCommits, totalBlobs, totalSymbols int
-		_ = db.Store().QueryRow("SELECT COUNT(*) FROM commits").Scan(&totalCommits)
-		_ = db.Store().QueryRow("SELECT COUNT(*) FROM blobs").Scan(&totalBlobs)
-		_ = db.Store().QueryRow("SELECT COUNT(*) FROM symbols").Scan(&totalSymbols)
-
-		// per-repo breakdown
 		type repoRow struct {
 			name    string
 			path    string
@@ -188,86 +287,216 @@ var codeStatsCmd = &cobra.Command{
 			blobs   int
 		}
 		var repos []repoRow
-		rows, err := db.Store().Query(`
-			SELECT r.name, r.path, COUNT(DISTINCT c.id), COUNT(DISTINCT fr.blob_id)
-			FROM repos r
-			LEFT JOIN commits c ON c.repo_id = r.id
-			LEFT JOIN file_revs fr ON fr.commit_id = c.id
-			GROUP BY r.id ORDER BY r.name`)
-		if err == nil {
-			defer rows.Close()
-			for rows.Next() {
-				var r repoRow
-				if rows.Scan(&r.name, &r.path, &r.commits, &r.blobs) == nil {
-					repos = append(repos, r)
+
+		if indexExists {
+			db, err := codedb.Open(dataDir)
+			if err == nil {
+				_ = db.Store().QueryRow("SELECT COUNT(*) FROM commits").Scan(&totalCommits)
+				_ = db.Store().QueryRow("SELECT COUNT(*) FROM blobs").Scan(&totalBlobs)
+				_ = db.Store().QueryRow("SELECT COUNT(*) FROM symbols").Scan(&totalSymbols)
+
+				rows, qErr := db.Store().Query(`
+					SELECT r.name, r.path, COUNT(DISTINCT c.id), COUNT(DISTINCT fr.blob_id)
+					FROM repos r
+					LEFT JOIN commits c ON c.repo_id = r.id
+					LEFT JOIN file_revs fr ON fr.commit_id = c.id
+					GROUP BY r.id ORDER BY r.name`)
+				if qErr == nil {
+					for rows.Next() {
+						var r repoRow
+						if rows.Scan(&r.name, &r.path, &r.commits, &r.blobs) == nil {
+							repos = append(repos, r)
+						}
+					}
+					rows.Close()
 				}
+				db.Close()
 			}
 		}
 
 		raw, _ := cmd.Flags().GetBool("json")
 		if raw {
+			type jsonRepoStats struct {
+				Name    string `json:"name"`
+				Path    string `json:"path"`
+				Commits int    `json:"commits"`
+				Blobs   int    `json:"blobs"`
+			}
 			type jsonStats struct {
-				Commits int `json:"commits"`
-				Blobs   int `json:"blobs"`
-				Symbols int `json:"symbols"`
-				Repos   []struct {
-					Name    string `json:"name"`
-					Path    string `json:"path"`
-					Commits int    `json:"commits"`
-					Blobs   int    `json:"blobs"`
-				} `json:"repos"`
-				DataDir string `json:"data_dir"`
+				Commits     int              `json:"commits"`
+				Blobs       int              `json:"blobs"`
+				Symbols     int              `json:"symbols"`
+				Repos       []jsonRepoStats  `json:"repos"`
+				DataDir     string           `json:"data_dir"`
+				IndexExists bool             `json:"index_exists"`
+				IndexingNow bool             `json:"indexing_now"`
+				LastIndexed *time.Time       `json:"last_indexed,omitempty"`
+				LastError   string           `json:"last_error,omitempty"`
 			}
 			out := jsonStats{
-				Commits: totalCommits,
-				Blobs:   totalBlobs,
-				Symbols: totalSymbols,
-				DataDir: dataDir,
+				Commits:     totalCommits,
+				Blobs:       totalBlobs,
+				Symbols:     totalSymbols,
+				DataDir:     dataDir,
+				IndexExists: indexExists,
+			}
+			if codeStats != nil {
+				out.IndexingNow = codeStats.IndexingNow
+				if !codeStats.LastIndexed.IsZero() {
+					t := codeStats.LastIndexed
+					out.LastIndexed = &t
+				}
+				out.LastError = codeStats.LastError
 			}
 			for _, r := range repos {
-				out.Repos = append(out.Repos, struct {
-					Name    string `json:"name"`
-					Path    string `json:"path"`
-					Commits int    `json:"commits"`
-					Blobs   int    `json:"blobs"`
-				}{Name: r.name, Path: r.path, Commits: r.commits, Blobs: r.blobs})
+				out.Repos = append(out.Repos, jsonRepoStats{
+					Name: r.name, Path: r.path,
+					Commits: r.commits, Blobs: r.blobs,
+				})
 			}
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			return enc.Encode(out)
 		}
 
-		// human-readable output
-		fmt.Printf("Code Index: %s\n\n", dataDir)
+		// human-readable output — Tufte-inspired, matching ox status
+		var b strings.Builder
 
-		if len(repos) > 1 {
-			for _, r := range repos {
-				fmt.Printf("  %s\n", r.name)
-				fmt.Printf("    Path:    %s\n", r.path)
-				fmt.Printf("    Commits: %d\n", r.commits)
-				fmt.Printf("    Blobs:   %d\n", r.blobs)
-				fmt.Println()
+		b.WriteString(statusHeaderStyle.Render("Code Index"))
+		b.WriteString("\n")
+		b.WriteString(statusMutedStyle.Render("──────────"))
+		b.WriteString("\n")
+
+		// status line — health signal first
+		b.WriteString(statusLabelStyle.Render("Status"))
+		switch {
+		case !indexExists && (codeStats == nil || !codeStats.IndexingNow):
+			b.WriteString(statusWarningStyle.Render("⚠ not indexed"))
+			b.WriteString("\n")
+			b.WriteString(statusLabelStyle.Render(""))
+			b.WriteString(statusMutedStyle.Render("Run 'ox code index' to create one"))
+			b.WriteString("\n")
+			fmt.Print(b.String())
+			return nil
+		case codeStats != nil && codeStats.IndexingNow:
+			b.WriteString(statusWarningStyle.Render("◐ indexing…"))
+		case codeStats != nil && codeStats.LastError != "" && totalCommits == 0:
+			b.WriteString(statusWarningStyle.Render("⚠ pending"))
+		case codeStats != nil && codeStats.LastError != "":
+			b.WriteString(statusErrorStyle.Render("✗ error"))
+			b.WriteString("\n")
+			b.WriteString(statusLabelStyle.Render(""))
+			b.WriteString(statusMutedStyle.Render(codeStats.LastError))
+		case codeStats != nil && !codeStats.LastIndexed.IsZero():
+			b.WriteString(statusSuccessStyle.Render("✓ indexed (" + formatTimeAgo(codeStats.LastIndexed) + ")"))
+		default:
+			b.WriteString(statusSuccessStyle.Render("✓ indexed"))
+		}
+		b.WriteString("\n")
+
+		// repo identity
+		if len(repos) == 1 {
+			b.WriteString(statusLabelStyle.Render("Repository"))
+			b.WriteString(statusHighlightStyle.Render(repos[0].name))
+			b.WriteString("\n")
+		} else if len(repos) > 1 {
+			b.WriteString(statusLabelStyle.Render("Repositories"))
+			b.WriteString(statusValueStyle.Render(fmt.Sprintf("%d", len(repos))))
+			b.WriteString("\n")
+			for i, r := range repos {
+				connector := "├── "
+				if i == len(repos)-1 {
+					connector = "└── "
+				}
+				b.WriteString(statusLabelStyle.Render(""))
+				b.WriteString(statusMutedStyle.Render(connector))
+				b.WriteString(statusHighlightStyle.Render(r.name))
+				b.WriteString(statusMutedStyle.Render(fmt.Sprintf("  %s commits, %s blobs", formatComma(r.commits), formatComma(r.blobs))))
+				b.WriteString("\n")
 			}
-			fmt.Println("  Totals")
-		} else if len(repos) == 1 {
-			fmt.Printf("  Repo: %s\n", repos[0].name)
-			fmt.Printf("  Path: %s\n\n", repos[0].path)
 		}
 
-		fmt.Printf("  Commits: %d\n", totalCommits)
-		fmt.Printf("  Blobs:   %d\n", totalBlobs)
-		fmt.Printf("  Symbols: %d\n", totalSymbols)
+		// counts — only show when there's data
+		if totalCommits > 0 || totalBlobs > 0 || totalSymbols > 0 {
+			b.WriteString(statusLabelStyle.Render("Symbols"))
+			b.WriteString(statusHighlightStyle.Render(formatComma(totalSymbols)))
+			b.WriteString("\n")
+			b.WriteString(statusLabelStyle.Render("Commits"))
+			b.WriteString(statusValueStyle.Render(formatComma(totalCommits)))
+			b.WriteString("\n")
+			b.WriteString(statusLabelStyle.Render("Blobs"))
+			b.WriteString(statusValueStyle.Render(formatComma(totalBlobs)))
+			b.WriteString("\n")
+		}
 
+		// next check — only when daemon is running and index exists
+		if codeStats != nil && !codeStats.IndexingNow && indexExists && syncInterval > 0 && !codeStats.LastIndexed.IsZero() {
+			nextCheck := codeStats.LastIndexed.Add(syncInterval)
+			remaining := time.Until(nextCheck)
+			b.WriteString(statusLabelStyle.Render("Next check"))
+			if remaining <= 0 {
+				b.WriteString(statusMutedStyle.Render("due now"))
+			} else {
+				b.WriteString(statusMutedStyle.Render("in " + formatDurationBrief(remaining)))
+			}
+			b.WriteString("\n")
+		}
+
+		fmt.Print(b.String())
 		return nil
 	},
 }
 
-func init() {
-	codeSearchCmd.Flags().Bool("raw", false, "output raw results array instead of combined response")
-	_ = codeSearchCmd.Flags().MarkHidden("raw")
+// formatDurationBrief formats a duration as a compact human string (e.g., "4m 30s").
+func formatDurationBrief(d time.Duration) string {
+	d = d.Round(time.Second)
+	if d < time.Second {
+		return "<1s"
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) % 60
+		if s == 0 {
+			return fmt.Sprintf("%dm", m)
+		}
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	if m == 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh %dm", h, m)
+}
 
-	codeQueryCmd.Flags().Bool("raw", false, "output raw results array instead of combined response")
-	_ = codeQueryCmd.Flags().MarkHidden("raw")
+// formatComma formats an integer with comma separators (e.g., 12847 → "12,847").
+func formatComma(n int) string {
+	if n < 0 {
+		return "-" + formatComma(-n)
+	}
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var result strings.Builder
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			result.WriteByte(',')
+		}
+		result.WriteRune(c)
+	}
+	return result.String()
+}
+
+func init() {
+	codeSearchCmd.Flags().Bool("full-json", false, "full uncompacted JSON output (~6x more context tokens)")
+	codeSearchCmd.Flags().Int("limit", 10, "max results to return")
+
+	codeQueryCmd.Flags().Bool("full-json", false, "full uncompacted JSON output (~6x more context tokens)")
+	codeQueryCmd.Flags().Int("limit", 10, "max results to return")
 
 	codeStatsCmd.Flags().Bool("json", false, "output as JSON")
 

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -67,9 +67,20 @@ type statusConfigJSON struct {
 }
 
 type statusProjectJSON struct {
-	Initialized bool   `json:"initialized"`
-	Directory   string `json:"directory"`
-	ConfigPath  string `json:"config_path,omitempty"`
+	Initialized bool                  `json:"initialized"`
+	Directory   string                `json:"directory"`
+	ConfigPath  string                `json:"config_path,omitempty"`
+	CodeIndex   *statusCodeIndexJSON  `json:"code_index,omitempty"`
+}
+
+type statusCodeIndexJSON struct {
+	Indexed     bool       `json:"indexed"`
+	LastIndexed *time.Time `json:"last_indexed,omitempty"`
+	IndexingNow bool       `json:"indexing_now"`
+	Commits     int        `json:"commits,omitempty"`
+	Blobs       int        `json:"blobs,omitempty"`
+	Symbols     int        `json:"symbols,omitempty"`
+	Error       string     `json:"error,omitempty"`
 }
 
 type statusLedgerJSON struct {
@@ -1537,10 +1548,28 @@ daemon health, and a tree view of all SageOx directory locations.`,
 			}
 		}
 
+		// connect to daemon early — needed for project status (code index) and later sections
+		var daemonStatus *daemon.StatusData
+		var syncHistory []daemon.SyncEvent
+		var codeStats *daemon.CodeDBStats
+		var client *daemon.Client
+		if gitRoot != "" {
+			client = daemon.TryConnectOrDirect()
+			if client != nil {
+				if ds, err := client.Status(); err == nil {
+					daemonStatus = ds
+					syncHistory, _ = client.SyncHistory()
+				}
+				if cs, err := client.CodeStatus(); err == nil {
+					codeStats = cs
+				}
+			}
+		}
+
 		// JSON output mode
 		if statusJSONFlag {
 			output := buildStatusJSON(authenticated, token, endpointSlug, authFile, authFileExists,
-				userConfigDir, cwd, sageoxDir, projectInitialized, localCfg, gitRoot, repoDetail)
+				userConfigDir, cwd, sageoxDir, projectInitialized, localCfg, gitRoot, repoDetail, codeStats)
 			jsonBytes, err := json.MarshalIndent(output, "", "  ")
 			if err != nil {
 				return fmt.Errorf("failed to marshal JSON: %w", err)
@@ -1567,23 +1596,17 @@ daemon health, and a tree view of all SageOx directory locations.`,
 		}
 		fmt.Print(renderTable("Configuration", configRows))
 
-		fmt.Print(renderProjectStatus(cwd, gitRoot, projectInitialized))
+		fmt.Print(renderProjectStatus(cwd, gitRoot, projectInitialized, codeStats))
 		if gitRoot != "" && !projectInitialized {
 			cli.PrintActionHint("ox init", "Initialize project for AI agent context", 2)
+		}
+		if gitRoot != "" && projectInitialized && codeStats == nil {
+			// no daemon connected — suggest manual indexing
+			cli.PrintActionHint("ox code index", "Index repo for local code search", 0)
 		}
 
 		// skip ledger/daemon sections when not in a git repo — nothing to show
 		if gitRoot != "" {
-			// fetch daemon status once, pass to both git repos and daemon sync sections
-			var daemonStatus *daemon.StatusData
-			var syncHistory []daemon.SyncEvent
-			client := daemon.TryConnectOrDirect()
-			if client != nil {
-				if ds, err := client.Status(); err == nil {
-					daemonStatus = ds
-					syncHistory, _ = client.SyncHistory()
-				}
-			}
 
 			// Ledger and Team Context sections - shows repos from cloud API
 			// Only displays repos that are actually provisioned
@@ -1615,7 +1638,7 @@ daemon health, and a tree view of all SageOx directory locations.`,
 // buildStatusJSON constructs the JSON output structure for ox status --json
 func buildStatusJSON(authenticated bool, token *auth.StoredToken, endpointSlug, authFile string, authFileExists bool,
 	userConfigDir, cwd, sageoxDir string, projectInitialized bool, localCfg *config.LocalConfig, gitRoot string,
-	repoDetail *api.RepoDetailResponse) statusJSONOutput {
+	repoDetail *api.RepoDetailResponse, codeStats *daemon.CodeDBStats) statusJSONOutput {
 
 	output := statusJSONOutput{}
 
@@ -1644,6 +1667,20 @@ func buildStatusJSON(authenticated bool, token *auth.StoredToken, endpointSlug, 
 	}
 	if projectInitialized {
 		output.Project.ConfigPath = sageoxDir
+		if codeStats != nil {
+			ci := &statusCodeIndexJSON{
+				Indexed:     codeStats.IndexExists,
+				IndexingNow: codeStats.IndexingNow,
+				Commits:     codeStats.Commits,
+				Blobs:       codeStats.Blobs,
+				Symbols:     codeStats.Symbols,
+				Error:       codeStats.LastError,
+			}
+			if !codeStats.LastIndexed.IsZero() {
+				ci.LastIndexed = &codeStats.LastIndexed
+			}
+			output.Project.CodeIndex = ci
+		}
 	}
 
 	// ledger section
@@ -1796,7 +1833,7 @@ func renderAuthStatus(authFile string) string {
 
 // renderProjectStatus renders the project status section with tree-like structure.
 // gitRoot is empty when not inside a git repository.
-func renderProjectStatus(cwd, gitRoot string, initialized bool) string {
+func renderProjectStatus(cwd, gitRoot string, initialized bool, codeStats *daemon.CodeDBStats) string {
 	var b strings.Builder
 
 	b.WriteString("\n")
@@ -1821,13 +1858,44 @@ func renderProjectStatus(cwd, gitRoot string, initialized bool) string {
 
 	b.WriteString(statusLabelStyle.Render("  " + cli.Wordmark() + " state"))
 	if initialized {
-		b.WriteString(statusMutedStyle.Render("└── .sageox/ dir "))
+		b.WriteString(statusMutedStyle.Render("├── .sageox/ dir "))
 		b.WriteString(statusSuccessStyle.Render("✓"))
 	} else {
 		b.WriteString(statusMutedStyle.Render("└── .sageox/ dir "))
 		b.WriteString(statusWarningStyle.Render("(not initialized)"))
 	}
 	b.WriteString("\n")
+
+	// code index status — only show when project is initialized
+	if initialized {
+		b.WriteString(statusLabelStyle.Render("  Code indexed"))
+		switch {
+		case codeStats == nil:
+			b.WriteString(statusMutedStyle.Render("└── unknown (no daemon)"))
+		case codeStats.IndexingNow:
+			b.WriteString(statusMutedStyle.Render("└── "))
+			b.WriteString(statusWarningStyle.Render("indexing…"))
+		case !codeStats.IndexExists:
+			// no index yet — daemon auto-indexes on start
+			b.WriteString(statusMutedStyle.Render("└── "))
+			b.WriteString(statusWarningStyle.Render("pending"))
+		case codeStats.LastError != "" && codeStats.Commits == 0:
+			// index dir exists but empty — initial index failed, will retry
+			b.WriteString(statusMutedStyle.Render("└── "))
+			b.WriteString(statusWarningStyle.Render("pending"))
+		case codeStats.LastError != "":
+			b.WriteString(statusMutedStyle.Render("└── "))
+			b.WriteString(statusErrorStyle.Render("error: " + codeStats.LastError))
+		default:
+			b.WriteString(statusMutedStyle.Render("└── "))
+			if !codeStats.LastIndexed.IsZero() {
+				b.WriteString(statusSuccessStyle.Render(formatTimeAgo(codeStats.LastIndexed)))
+			} else {
+				b.WriteString(statusSuccessStyle.Render("✓"))
+			}
+		}
+		b.WriteString("\n")
+	}
 
 	return b.String()
 }

--- a/cmd/ox/status_test.go
+++ b/cmd/ox/status_test.go
@@ -31,7 +31,7 @@ func TestBuildStatusJSON_WithRepoDetail(t *testing.T) {
 	output := buildStatusJSON(
 		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
-		localCfg, "", repoDetail,
+		localCfg, "", repoDetail, nil,
 	)
 
 	require.NotNil(t, output.Ledger, "ledger section should be populated when localCfg.Ledger has a path")
@@ -53,7 +53,7 @@ func TestBuildStatusJSON_WithoutRepoDetail(t *testing.T) {
 	output := buildStatusJSON(
 		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
-		localCfg, "", nil,
+		localCfg, "", nil, nil,
 	)
 
 	require.NotNil(t, output.Ledger, "ledger section should be populated even without repoDetail")
@@ -79,7 +79,7 @@ func TestBuildStatusJSON_ViewerAccess(t *testing.T) {
 	output := buildStatusJSON(
 		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
-		localCfg, "", repoDetail,
+		localCfg, "", repoDetail, nil,
 	)
 
 	require.NotNil(t, output.Ledger)
@@ -101,7 +101,7 @@ func TestBuildStatusJSON_NoLedgerConfig(t *testing.T) {
 	output := buildStatusJSON(
 		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
-		localCfg, "", repoDetail,
+		localCfg, "", repoDetail, nil,
 	)
 
 	assert.Nil(t, output.Ledger, "ledger section should be nil when no ledger config exists")
@@ -113,7 +113,7 @@ func TestBuildStatusJSON_NilLocalConfig(t *testing.T) {
 	output := buildStatusJSON(
 		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
-		nil, "", nil,
+		nil, "", nil, nil,
 	)
 
 	assert.Nil(t, output.Ledger, "ledger section should be nil when localCfg is nil")
@@ -136,7 +136,7 @@ func TestBuildStatusJSON_LedgerPathNotExists(t *testing.T) {
 	output := buildStatusJSON(
 		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
-		localCfg, "", repoDetail,
+		localCfg, "", repoDetail, nil,
 	)
 
 	require.NotNil(t, output.Ledger)
@@ -164,7 +164,7 @@ func TestBuildStatusJSON_AuthenticatedWithToken(t *testing.T) {
 	output := buildStatusJSON(
 		true, token, "test.sageox.ai", "/tmp/auth.json", true,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", true,
-		nil, "", nil,
+		nil, "", nil, nil,
 	)
 
 	require.NotNil(t, output.Auth)
@@ -180,7 +180,7 @@ func TestBuildStatusJSON_ProjectInitialized(t *testing.T) {
 	output := buildStatusJSON(
 		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", true,
-		nil, "", nil,
+		nil, "", nil, nil,
 	)
 
 	require.NotNil(t, output.Project)
@@ -194,7 +194,7 @@ func TestBuildStatusJSON_ProjectNotInitialized(t *testing.T) {
 	output := buildStatusJSON(
 		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
-		nil, "", nil,
+		nil, "", nil, nil,
 	)
 
 	require.NotNil(t, output.Project)
@@ -248,7 +248,7 @@ func TestBuildStatusJSON_VisibilityAccessLevelCombinations(t *testing.T) {
 			output := buildStatusJSON(
 				false, nil, "test.sageox.ai", "/tmp/auth.json", false,
 				"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
-				localCfg, "", repoDetail,
+				localCfg, "", repoDetail, nil,
 			)
 
 			require.NotNil(t, output.Ledger)

--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -245,9 +246,11 @@ func IndexLocalRepo(ctx context.Context, s *store.Store, localPath string, opts 
 
 	t0 := time.Now()
 
-	// 1. Open the repo in-place
+	// 1. Open the repo — for linked worktrees, open the main repo so
+	// go-git can access the shared object store (packfiles, loose objects).
 	report("Opening local repository...")
-	repo, err := git.PlainOpen(localPath)
+	repoOpenPath, isWorktree := resolveGitDir(localPath)
+	repo, err := git.PlainOpen(repoOpenPath)
 	if err != nil {
 		return fmt.Errorf("open local repo %s: %w", localPath, err)
 	}
@@ -265,8 +268,14 @@ func IndexLocalRepo(ctx context.Context, s *store.Store, localPath string, opts 
 		return fmt.Errorf("load known commits: %w", err)
 	}
 
-	// 4. Resolve default branch
-	defaultRef, err := resolveDefaultBranch(repo)
+	// 4. Resolve default branch — for linked worktrees, always use git CLI
+	// since go-git opened the main repo (which has a different HEAD)
+	var defaultRef refInfo
+	if isWorktree {
+		defaultRef, err = resolveDefaultBranchGit(localPath)
+	} else {
+		defaultRef, err = resolveDefaultBranchWithPath(repo, localPath)
+	}
 	if err != nil {
 		return fmt.Errorf("resolve default branch: %w", err)
 	}
@@ -555,6 +564,8 @@ func loadExistingRefs(s *store.Store, repoID int64) (map[string]string, error) {
 
 // resolveDefaultBranch returns the single default branch ref (main/master).
 // It checks HEAD first, then falls back to common default branch names.
+// For linked worktrees (where .git is a file), go-git may fail to resolve HEAD,
+// so we fall back to the git CLI.
 func resolveDefaultBranch(repo *git.Repository) (refInfo, error) {
 	// Try HEAD — in bare repos this points to the default branch
 	headRef, err := repo.Head()
@@ -577,6 +588,86 @@ func resolveDefaultBranch(repo *git.Repository) (refInfo, error) {
 	}
 
 	return refInfo{}, fmt.Errorf("no default branch found (tried HEAD, main, master)")
+}
+
+// resolveDefaultBranchWithPath resolves the default branch, falling back to
+// the git CLI for linked worktrees where go-git can't resolve HEAD.
+func resolveDefaultBranchWithPath(repo *git.Repository, localPath string) (refInfo, error) {
+	ref, err := resolveDefaultBranch(repo)
+	if err == nil {
+		return ref, nil
+	}
+
+	// go-git fails on linked worktrees — fall back to git CLI
+	return resolveDefaultBranchGit(localPath)
+}
+
+// resolveDefaultBranchGit uses the git CLI to resolve HEAD when go-git can't
+// (e.g., linked worktrees where .git is a file).
+func resolveDefaultBranchGit(repoPath string) (refInfo, error) {
+	// get the symbolic ref name (e.g., refs/heads/main)
+	nameCmd := exec.Command("git", "symbolic-ref", "HEAD")
+	nameCmd.Dir = repoPath
+	nameOut, err := nameCmd.Output()
+	if err != nil {
+		return refInfo{}, fmt.Errorf("git symbolic-ref HEAD: %w", err)
+	}
+	refName := strings.TrimSpace(string(nameOut))
+
+	// get the commit hash
+	hashCmd := exec.Command("git", "rev-parse", "HEAD")
+	hashCmd.Dir = repoPath
+	hashOut, err := hashCmd.Output()
+	if err != nil {
+		return refInfo{}, fmt.Errorf("git rev-parse HEAD: %w", err)
+	}
+	hashStr := strings.TrimSpace(string(hashOut))
+
+	return refInfo{
+		name:   refName,
+		tipOID: plumbing.NewHash(hashStr),
+	}, nil
+}
+
+// resolveGitDir returns the path to open with go-git and whether it's a linked
+// worktree. For linked worktrees (where .git is a file containing "gitdir: ..."),
+// it follows the pointer to the main repo's .git directory so go-git can access
+// the shared object store. For normal repos, returns the path unchanged.
+func resolveGitDir(repoPath string) (string, bool) {
+	dotGit := filepath.Join(repoPath, ".git")
+	info, err := os.Lstat(dotGit)
+	if err != nil || info.IsDir() {
+		return repoPath, false // normal repo or no .git
+	}
+
+	// .git is a file → linked worktree, read "gitdir: <path>"
+	content, err := os.ReadFile(dotGit)
+	if err != nil {
+		return repoPath, false
+	}
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return repoPath, false
+	}
+	worktreeGitDir := strings.TrimPrefix(line, "gitdir: ")
+	if !filepath.IsAbs(worktreeGitDir) {
+		worktreeGitDir = filepath.Join(repoPath, worktreeGitDir)
+	}
+
+	// read commondir to find the shared .git (e.g., "../.." → main .git)
+	commondirFile := filepath.Join(worktreeGitDir, "commondir")
+	commondirBytes, err := os.ReadFile(commondirFile)
+	if err != nil {
+		return repoPath, false
+	}
+	commondir := strings.TrimSpace(string(commondirBytes))
+	if !filepath.IsAbs(commondir) {
+		commondir = filepath.Join(worktreeGitDir, commondir)
+	}
+
+	// commondir points to the main .git dir; the repo root is its parent
+	mainRepoRoot := filepath.Dir(commondir)
+	return mainRepoRoot, true
 }
 
 // walkNewCommits discovers commits reachable from tip that aren't in knownCommits.

--- a/internal/codedb/index/worktree_test.go
+++ b/internal/codedb/index/worktree_test.go
@@ -1,0 +1,256 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/codedb/store"
+)
+
+// initGitRepo creates a git repo with N commits and returns the repo path and tip hash.
+// Uses git CLI to avoid go-git quirks with config.
+func initGitRepo(t *testing.T, numCommits int) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+		return string(out)
+	}
+
+	run("init", "-b", "main")
+
+	for i := 1; i <= numCommits; i++ {
+		fname := fmt.Sprintf("file%d.go", i)
+		content := fmt.Sprintf("package main\nfunc F%d() {}\n", i)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fname), []byte(content), 0o644))
+		run("add", fname)
+		run("commit", "-m", fmt.Sprintf("commit %d", i))
+	}
+
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	return dir, string(out[:len(out)-1]) // trim newline
+}
+
+// createLinkedWorktree creates a linked worktree from mainRepoDir on a new branch.
+func createLinkedWorktree(t *testing.T, mainRepoDir, branchName string) string {
+	t.Helper()
+	worktreeDir := filepath.Join(t.TempDir(), "worktree")
+
+	cmd := exec.Command("git", "worktree", "add", "-b", branchName, worktreeDir)
+	cmd.Dir = mainRepoDir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git worktree add: %s", out)
+
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	})
+
+	return worktreeDir
+}
+
+func TestResolveGitDir_NormalRepo(t *testing.T) {
+	t.Parallel()
+	dir, _ := initGitRepo(t, 1)
+
+	path, isWorktree := resolveGitDir(dir)
+	assert.Equal(t, dir, path)
+	assert.False(t, isWorktree)
+}
+
+func TestResolveGitDir_LinkedWorktree(t *testing.T) {
+	t.Parallel()
+	mainDir, _ := initGitRepo(t, 1)
+
+	worktreeDir := createLinkedWorktree(t, mainDir, "feature-branch")
+
+	path, isWorktree := resolveGitDir(worktreeDir)
+	assert.True(t, isWorktree, "should detect linked worktree")
+
+	// resolve symlinks for macOS /var → /private/var
+	expectedDir, _ := filepath.EvalSymlinks(mainDir)
+	actualDir, _ := filepath.EvalSymlinks(path)
+	assert.Equal(t, expectedDir, actualDir, "should resolve to main repo root")
+}
+
+func TestResolveGitDir_NoGit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	path, isWorktree := resolveGitDir(dir)
+	assert.Equal(t, dir, path)
+	assert.False(t, isWorktree)
+}
+
+func TestResolveDefaultBranchGit(t *testing.T) {
+	t.Parallel()
+	dir, tipHash := initGitRepo(t, 3)
+
+	ref, err := resolveDefaultBranchGit(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "refs/heads/main", ref.name)
+	assert.Equal(t, plumbing.NewHash(tipHash), ref.tipOID)
+}
+
+func TestResolveDefaultBranchGit_Worktree(t *testing.T) {
+	t.Parallel()
+	mainDir, _ := initGitRepo(t, 3)
+	worktreeDir := createLinkedWorktree(t, mainDir, "wt-branch")
+
+	// add a commit on the worktree branch
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, "wt.txt"), []byte("worktree"), 0o644))
+	run(worktreeDir, "add", "wt.txt")
+	run(worktreeDir, "commit", "-m", "worktree commit")
+
+	ref, err := resolveDefaultBranchGit(worktreeDir)
+	require.NoError(t, err)
+	assert.Equal(t, "refs/heads/wt-branch", ref.name)
+	assert.False(t, ref.tipOID.IsZero(), "tip hash should be non-zero")
+}
+
+func TestResolveDefaultBranchWithPath_NormalRepo(t *testing.T) {
+	t.Parallel()
+	dir, tipHash := initGitRepo(t, 2)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	ref, err := resolveDefaultBranchWithPath(repo, dir)
+	require.NoError(t, err)
+	assert.Equal(t, "refs/heads/main", ref.name)
+	assert.Equal(t, plumbing.NewHash(tipHash), ref.tipOID)
+}
+
+func TestResolveDefaultBranchWithPath_WorktreeFallback(t *testing.T) {
+	t.Parallel()
+	mainDir, _ := initGitRepo(t, 2)
+	worktreeDir := createLinkedWorktree(t, mainDir, "fallback-branch")
+
+	// open the main repo (as IndexLocalRepo does for worktrees)
+	repo, err := git.PlainOpen(mainDir)
+	require.NoError(t, err)
+
+	// go-git on main repo resolves main repo's HEAD (main), not the worktree's
+	// so the git CLI fallback should be used for worktree path
+	ref, err := resolveDefaultBranchGit(worktreeDir)
+	require.NoError(t, err)
+	assert.Equal(t, "refs/heads/fallback-branch", ref.name)
+
+	// resolveDefaultBranchWithPath on the main repo should resolve go-git's HEAD
+	ref2, err := resolveDefaultBranchWithPath(repo, mainDir)
+	require.NoError(t, err)
+	assert.Equal(t, "refs/heads/main", ref2.name)
+}
+
+func TestIndexLocalRepo_LinkedWorktree(t *testing.T) {
+	t.Parallel()
+	mainDir, _ := initGitRepo(t, 5)
+	worktreeDir := createLinkedWorktree(t, mainDir, "index-branch")
+
+	// add commits on the worktree branch
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	for i := 1; i <= 3; i++ {
+		fname := fmt.Sprintf("wt_file%d.go", i)
+		content := fmt.Sprintf("package wt\nfunc WT%d() {}\n", i)
+		require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, fname), []byte(content), 0o644))
+		run(worktreeDir, "add", fname)
+		run(worktreeDir, "commit", "-m", fmt.Sprintf("worktree commit %d", i))
+	}
+
+	// index the worktree
+	dataDir := filepath.Join(t.TempDir(), "codedb")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	s, err := store.Open(dataDir)
+	require.NoError(t, err)
+	defer s.Close()
+
+	err = IndexLocalRepo(context.Background(), s, worktreeDir, IndexOptions{})
+	require.NoError(t, err)
+
+	// verify commits: 5 from main + 3 from worktree branch + 1 synthetic worktree commit = 9
+	var commitCount int
+	require.NoError(t, s.QueryRow("SELECT COUNT(*) FROM commits").Scan(&commitCount))
+	assert.Equal(t, 9, commitCount, "should index all commits reachable from worktree HEAD plus synthetic worktree commit")
+
+	// verify blobs exist (from both committed files and working tree)
+	var blobCount int
+	require.NoError(t, s.QueryRow("SELECT COUNT(*) FROM blobs").Scan(&blobCount))
+	assert.Greater(t, blobCount, 0, "should have indexed blobs")
+
+	// verify repo record uses worktree path, not main repo path
+	var repoPath string
+	require.NoError(t, s.QueryRow("SELECT path FROM repos LIMIT 1").Scan(&repoPath))
+	assert.Equal(t, worktreeDir, repoPath, "repo path should be the worktree, not the main repo")
+}
+
+func TestIndexLocalRepo_NormalRepo(t *testing.T) {
+	t.Parallel()
+	dir, _ := initGitRepo(t, 3)
+
+	dataDir := filepath.Join(t.TempDir(), "codedb")
+	require.NoError(t, os.MkdirAll(dataDir, 0o755))
+
+	s, err := store.Open(dataDir)
+	require.NoError(t, err)
+	defer s.Close()
+
+	err = IndexLocalRepo(context.Background(), s, dir, IndexOptions{})
+	require.NoError(t, err)
+
+	var commitCount int
+	require.NoError(t, s.QueryRow("SELECT COUNT(*) FROM commits").Scan(&commitCount))
+	assert.Equal(t, 3, commitCount, "should index all 3 commits")
+}

--- a/internal/codedb/search/executor.go
+++ b/internal/codedb/search/executor.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 
 	"github.com/blevesearch/bleve/v2"
-	"github.com/blevesearch/bleve/v2/search/query"
 	blevesearch "github.com/blevesearch/bleve/v2/search"
+	_ "github.com/blevesearch/bleve/v2/search/highlight/highlighter/ansi"
+	"github.com/blevesearch/bleve/v2/search/query"
 
 	"github.com/sageox/ox/internal/codedb/store"
 )

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -169,13 +169,9 @@ func (m *CodeDBManager) Index(ctx context.Context, payload CodeIndexPayload, pw 
 }
 
 // CheckFreshness checks if the index needs refreshing and triggers a background
-// re-index if stale. This is non-blocking and safe to call from the scheduler.
+// re-index if needed. If no index exists yet, creates the initial index.
+// This is non-blocking and safe to call from the scheduler or daemon startup.
 func (m *CodeDBManager) CheckFreshness(ctx context.Context) {
-	dataDir := paths.CodeDBDataDir(m.projectRoot)
-	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
-		return // no index yet, nothing to refresh
-	}
-
 	m.mu.Lock()
 	if m.indexing {
 		m.mu.Unlock()
@@ -183,12 +179,26 @@ func (m *CodeDBManager) CheckFreshness(ctx context.Context) {
 	}
 	m.mu.Unlock()
 
-	// run a quick background re-index (incremental — skips if tip unchanged)
+	dataDir := paths.CodeDBDataDir(m.projectRoot)
+	isInitial := false
+	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
+		isInitial = true
+	}
+
+	// run background index (initial build or incremental refresh)
 	go func() {
-		m.logger.Debug("codedb freshness check starting")
+		if isInitial {
+			m.logger.Info("codedb auto-indexing repo for first time")
+		} else {
+			m.logger.Debug("codedb freshness check starting")
+		}
 		_, err := m.Index(ctx, CodeIndexPayload{}, nil)
 		if err != nil {
-			m.logger.Debug("codedb freshness check failed", "error", err)
+			if isInitial {
+				m.logger.Warn("codedb initial index failed", "error", err)
+			} else {
+				m.logger.Debug("codedb freshness check failed", "error", err)
+			}
 		}
 	}()
 }

--- a/internal/daemon/codedb_race_test.go
+++ b/internal/daemon/codedb_race_test.go
@@ -231,12 +231,17 @@ func TestConcurrentSearchWhileIndexing(t *testing.T) {
 
 // TestMultipleManagersCheckFreshness simulates multiple daemons (worktrees)
 // calling CheckFreshness simultaneously. CheckFreshness is non-blocking and
-// should not panic or deadlock.
+// should not panic or deadlock. When no index exists, it fires a background
+// goroutine to create the initial index.
 func TestMultipleManagersCheckFreshness(t *testing.T) {
 	t.Parallel()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	tmpDir := t.TempDir()
+
+	// use a cancellable context so background indexing goroutines stop before cleanup
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	const managers = 10
 	var wg sync.WaitGroup
@@ -246,8 +251,7 @@ func TestMultipleManagersCheckFreshness(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			mgr := NewCodeDBManager(tmpDir, logger)
-			// CheckFreshness should return immediately when no index exists
-			mgr.CheckFreshness(context.Background())
+			mgr.CheckFreshness(ctx)
 		}()
 	}
 
@@ -262,6 +266,11 @@ func TestMultipleManagersCheckFreshness(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("CheckFreshness deadlocked under concurrent calls")
 	}
+
+	// cancel to stop any background indexing before temp dir cleanup
+	cancel()
+	// brief pause for goroutines to notice cancellation
+	time.Sleep(50 * time.Millisecond)
 }
 
 // TestConcurrentStatsWithPerRepoData verifies Stats() returns correct per-repo

--- a/internal/daemon/status_display.go
+++ b/internal/daemon/status_display.go
@@ -102,6 +102,8 @@ func formatStatusCore(status *StatusData, cliVersion string, verbose bool) strin
 	// workspace sync groups
 	out.WriteString(formatWorkspaceGroups(status, verbose))
 
+	// code index is now part of the "This Project" tree — see formatWorkspaceGroups
+
 	// issues (if any)
 	if issues := formatIssues(status.NeedsHelp, status.Issues); issues != "" {
 		out.WriteString("\n")
@@ -314,8 +316,12 @@ func formatWorkspaceGroups(status *StatusData, verbose bool) string {
 		}
 	}
 
-	// project section: ledger + primary team context shown as a tree
+	// project section: ledger + primary team context + code index shown as a tree
 	projectCount := len(ledgers) + len(projectTCs)
+	hasCodeIndex := status.CodeDB != nil
+	if hasCodeIndex {
+		projectCount++
+	}
 	if projectCount > 0 {
 		out.WriteString("\n")
 		out.WriteString(styleBold.Render("This Project"))
@@ -342,6 +348,14 @@ func formatWorkspaceGroups(status *StatusData, verbose bool) string {
 			items = append(items, treeItem{
 				label:  name + styleMuted.Render(" (team context)"),
 				status: formatWSStatus(tc) + formatGCStatus(tc, verbose),
+			})
+		}
+
+		// code index as tree item
+		if hasCodeIndex {
+			items = append(items, treeItem{
+				label:  "Code index",
+				status: formatCodeIndexInline(status, verbose),
 			})
 		}
 
@@ -402,6 +416,43 @@ func formatWorkspaceGroups(status *StatusData, verbose bool) string {
 	}
 
 	return out.String()
+}
+
+// formatCodeIndexInline renders a compact single-line code index status for tree display.
+func formatCodeIndexInline(status *StatusData, verbose bool) string {
+	cs := status.CodeDB
+	if cs == nil {
+		return styleMuted.Render("○ unknown")
+	}
+
+	var line string
+	switch {
+	case cs.IndexingNow:
+		line = styleWarning.Render("◐ indexing…")
+	case !cs.IndexExists:
+		line = styleWarning.Render("○ pending")
+	case cs.LastError != "" && cs.Commits == 0:
+		line = styleWarning.Render("○ pending")
+	case cs.LastError != "":
+		line = styleCritical.Render("○ " + cs.LastError)
+	case !cs.LastIndexed.IsZero():
+		age := formatRelativeTime(time.Since(cs.LastIndexed))
+		metrics := fmt.Sprintf("%d commits, %d blobs", cs.Commits, cs.Blobs)
+		line = styleHealthy.Render("● "+age) + "  " + styleMuted.Render(metrics)
+	default:
+		line = styleHealthy.Render("● ready")
+	}
+
+	if verbose && cs.IndexExists && cs.Commits > 0 {
+		if cs.DataDir != "" {
+			line += "\n" + styleMuted.Render("              "+shortenPath(cs.DataDir))
+		}
+		for _, r := range cs.Repos {
+			line += "\n" + styleMuted.Render(fmt.Sprintf("              %s  %d commits, %d blobs", r.Name, r.Commits, r.Blobs))
+		}
+	}
+
+	return line
 }
 
 // stripANSI removes ANSI escape sequences for measuring display width.


### PR DESCRIPTION
## Summary
- **Compact code search output (6x smaller)**: Default compact JSON with file/line/snippet/lang; `--full-json` for verbose uncompacted output. Metrics tracked to context usage.
- **Worktree support**: Fixed CodeDB indexer for linked git worktrees via go-git fallback; 9 comprehensive tests.
- **Code index in daemon status**: Moved from standalone section into "This Project" tree with inline rendering.
- **Auto-index on daemon start**: CheckFreshness now creates initial CodeDB index async.

## Implementation Details
Code search output optimization reduces typical query from ~5,800 tokens to ~900 tokens by stripping ANSI, omitting scores/repo fields, and truncating snippets to 120 chars. Flag help text warns agents about `--full-json` cost (~6x more tokens). Both CLI search paths (`ox code search` and `ox agent query`) use compact format by default.

Worktree support adds `resolveGitDir()` to follow `.git` file → `gitdir:` → `commondir` → main repo root, with git CLI fallback for branch resolution (go-git limitation). Tests verify both normal repos and linked worktrees index correctly, including synthetic commits for working tree state.

## Test Plan
- `make lint` passes
- `go test ./internal/codedb/index/ -run Worktree` (9 tests)
- `go test ./cmd/ox/ -run TestBuildStatusJSON`
- `ox code search "test"` shows compact output (~900 tokens)
- `ox code search "test" --full-json` shows verbose output (~5,800 tokens)
- `ox code search "test" --limit 3` respects limit

Co-Authored-By: SageOx <ox@sageox.ai>