### PR TITLE
fix(agent): make hook command reachable from dispatcher

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -151,6 +151,12 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// "hook" dispatched directly — no agent_id required.
+	// hooks fire before prime, so no agent ID exists yet.
+	if firstArg == "hook" {
+		return runAgentHook(args[1:])
+	}
+
 	// check if first arg looks like an agent_id (Ox<4-char>)
 	if agentinstance.IsValidAgentID(firstArg) {
 		return runWithAgentID(cmd, firstArg, args[1:])


### PR DESCRIPTION
## Summary

Lifecycle hook commands (`ox agent hook <event>`) were failing with "unknown command or invalid agent_id: hook" because the agent dispatcher didn't recognize "hook" at the top level.

Hooks fire before `ox agent prime`, so no agent ID exists when they run. The hook command template calls `ox agent hook <event>` (without an ID), but only the `runWithAgentID` path handled "hook" — requiring a valid agent ID to reach.

## Changes

Add a direct dispatch for "hook" in `runAgentDispatcher` before the agent ID check. The hook handler finds the project root and reads `AGENT_ENV` independently, so it doesn't need an agent instance.

## Test Plan

- ✅ All 6169 tests pass  
- ✅ Builds cleanly
- Hook commands now route correctly: `echo '{}' | AGENT_ENV=claude-code ox agent hook SessionStart`

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hooks can now be invoked directly without requiring an agent identifier, providing more flexible invocation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->