### PR TITLE
fix(manifest): include discussions and agent-context in fallback sparse-checkout

### DIFF
--- a/internal/manifest/fallback.go
+++ b/internal/manifest/fallback.go
@@ -11,6 +11,8 @@ var fallbackIncludes = []string{
 	"memory/",
 	"docs/",
 	"coworkers/",
+	"discussions/",
+	"agent-context/",
 }
 
 // FallbackConfig returns a ManifestConfig with hardcoded control-plane

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -309,7 +309,7 @@ func TestFallbackConfig(t *testing.T) {
 		t.Errorf("gc_interval = %d, want %d", cfg.GCIntervalDays, DefaultGCIntervalDays)
 	}
 
-	expectedPaths := []string{".sageox/", "SOUL.md", "TEAM.md", "MEMORY.md", "AGENTS.md", "memory/", "docs/", "coworkers/"}
+	expectedPaths := []string{".sageox/", "SOUL.md", "TEAM.md", "MEMORY.md", "AGENTS.md", "memory/", "docs/", "coworkers/", "discussions/", "agent-context/"}
 	for _, p := range expectedPaths {
 		assertContains(t, "fallback includes", cfg.Includes, p)
 	}


### PR DESCRIPTION
## Summary
Add `discussions/` and `agent-context/` to the fallback sparse-checkout includes in `internal/manifest/fallback.go`.

## Why
These directories are consumed by `ox agent team-ctx` and notification tracking, but were missing from the hardcoded fallback used when `.sageox/sync.manifest` is missing or unparseable. This ensures they're always materialized even in degraded scenarios where the manifest file isn't available.

## Changes
- Added `discussions/` and `agent-context/` to `fallbackIncludes`
- Updated test expectations in `TestFallbackConfig`

## Testing
All manifest tests pass, including fallback-specific tests.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced fallback manifest handling to support two additional content path types, improving system resilience when manifest data is unavailable or cannot be parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->