### PR TITLE
feat(prime): surface memory/GUIDE.md as observation guidance

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -186,7 +186,8 @@ type teamContextInfo struct {
 	TeamHint      string   `json:"team_hint,omitempty"`      // path to TEAM.md (reference, not inlined)
 	MemoryDaily   []string `json:"memory_daily,omitempty"`   // available daily summary files
 	MemoryWeekly  []string `json:"memory_weekly,omitempty"`  // available weekly summary files
-	MemoryMonthly []string `json:"memory_monthly,omitempty"` // available monthly summary files
+	MemoryMonthly        []string `json:"memory_monthly,omitempty"`         // available monthly summary files
+	ObservationGuideHint string   `json:"observation_guide_hint,omitempty"` // path to memory/GUIDE.md (read when needed)
 
 	// sync health
 	Stale      bool   `json:"stale,omitempty"`       // true if last sync exceeds staleness threshold
@@ -286,6 +287,8 @@ type agentPrimeOutput struct {
 	// Doctor agent marker
 	NeedsDoctorAgent bool   `json:"needs_doctor_agent,omitempty"` // true if .needs-doctor-agent marker exists
 	DoctorHint       string `json:"doctor_hint,omitempty"`        // hint for agent to run ox agent doctor
+	// Observation recording directive (behavioral, not just a tool reference)
+	ObservationDirective string `json:"observation_directive,omitempty"` // proactive instruction to record observations via ox memory put
 	// Code search availability
 	CodeSearchTip string `json:"code_search_tip,omitempty"` // guidance on code search availability for this repo
 	// Hook auto-install
@@ -724,6 +727,14 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// observation directive — behavioral instruction for agents to proactively record
+	if teamCtx != nil && auth.IsMemoryEnabled() && teamCtx.ObservationGuideHint != "" {
+		output.ObservationDirective = fmt.Sprintf(
+			"Proactively record observations throughout this session using `ox memory put`. "+
+				"Record decisions, discoveries, questions, and notable events as they happen — don't wait to be asked. "+
+				"Read GUIDE.md first for what to capture: %s", teamCtx.ObservationGuideHint)
+	}
+
 	// build pre-assembled notification for JSON-consuming agents.
 	// this duplicates the logic in outputAgentPrimeText so JSON consumers
 	// don't have to assemble the notification from individual fields.
@@ -1010,6 +1021,14 @@ func buildGuidance(agentID, projectRoot string, teamCtx *teamContextInfo, ledger
 		cmds = append(cmds, intentCommand{
 			Intent:  fmt.Sprintf("code search %s (not indexed yet): index first, then search code, symbols, and diffs", repoSlug),
 			Command: "ox code index",
+		})
+	}
+
+	// record observations — only when GUIDE.md exists and memory feature is enabled
+	if teamCtx != nil && auth.IsMemoryEnabled() && teamCtx.ObservationGuideHint != "" {
+		cmds = append(cmds, intentCommand{
+			Intent:  "record observation, note decision, capture learning, remember for team — read GUIDE.md first",
+			Command: `ox memory put '{"content": "<observation>"}'`,
 		})
 	}
 
@@ -1875,6 +1894,12 @@ func loadTeamMemory(info *teamContextInfo, teamDir string) {
 		info.TeamHint = teamPath
 	}
 
+	// memory/GUIDE.md — observation guidance reference pointer
+	guidePath := filepath.Join(teamDir, "memory", "GUIDE.md")
+	if _, err := os.Stat(guidePath); err == nil {
+		info.ObservationGuideHint = guidePath
+	}
+
 	// discover memory timeline files for progressive disclosure
 	info.MemoryDaily = discoverMemoryFiles(filepath.Join(teamDir, "memory", "daily"))
 	info.MemoryWeekly = discoverMemoryFiles(filepath.Join(teamDir, "memory", "weekly"))
@@ -1903,7 +1928,8 @@ func emitTeamMemorySection(cmd *cobra.Command, tc *teamContextInfo) {
 		return
 	}
 
-	hasMemory := tc.MemoryContent != "" || tc.SoulHint != "" || tc.TeamHint != "" ||
+	guideEnabled := tc.ObservationGuideHint != "" && auth.IsMemoryEnabled()
+	hasMemory := tc.MemoryContent != "" || tc.SoulHint != "" || tc.TeamHint != "" || guideEnabled ||
 		len(tc.MemoryDaily) > 0 || len(tc.MemoryWeekly) > 0 || len(tc.MemoryMonthly) > 0
 
 	if !hasMemory {
@@ -1926,8 +1952,8 @@ func emitTeamMemorySection(cmd *cobra.Command, tc *teamContextInfo) {
 		fmt.Fprintln(out)
 	}
 
-	// SOUL.md and TEAM.md — reference pointers
-	if tc.SoulHint != "" || tc.TeamHint != "" {
+	// SOUL.md, TEAM.md, GUIDE.md — reference pointers
+	if tc.SoulHint != "" || tc.TeamHint != "" || guideEnabled {
 		fmt.Fprintln(out, "### Available Context")
 		if tc.SoulHint != "" {
 			fmt.Fprintf(out, "- SOUL.md: %s (team identity and values — read when needed)\n", tc.SoulHint)
@@ -1935,6 +1961,18 @@ func emitTeamMemorySection(cmd *cobra.Command, tc *teamContextInfo) {
 		if tc.TeamHint != "" {
 			fmt.Fprintf(out, "- TEAM.md: %s (team members and patterns — read when needed)\n", tc.TeamHint)
 		}
+		if guideEnabled {
+			fmt.Fprintf(out, "- GUIDE.md: %s (observation guidance — read before using 'ox memory put')\n", tc.ObservationGuideHint)
+		}
+		fmt.Fprintln(out)
+	}
+
+	// observation recording — behavioral directive (not just a tool reference)
+	if guideEnabled {
+		fmt.Fprintln(out, "### Observation Recording (Active)")
+		fmt.Fprintln(out, "Proactively record observations throughout this session using `ox memory put`.")
+		fmt.Fprintln(out, "Record decisions, discoveries, questions, and notable events as they happen — don't wait to be asked.")
+		fmt.Fprintf(out, "Read GUIDE.md first for what to capture: %s\n", tc.ObservationGuideHint)
 		fmt.Fprintln(out)
 	}
 

--- a/cmd/ox/agent_prime_test.go
+++ b/cmd/ox/agent_prime_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestIsAgentSupported(t *testing.T) {
@@ -341,6 +344,188 @@ func TestCodexLifecycleNotification(t *testing.T) {
 				}
 				if !strings.Contains(got, "ox agent <id> session start") {
 					t.Errorf("expected Codex lifecycle note to mention manual session start, got: %q", got)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadTeamMemory_ObservationGuide(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(dir string) // create files under dir
+		wantGuide bool
+	}{
+		{
+			name: "GUIDE.md exists",
+			setup: func(dir string) {
+				memDir := filepath.Join(dir, "memory")
+				os.MkdirAll(memDir, 0755)
+				os.WriteFile(filepath.Join(memDir, "GUIDE.md"), []byte("# Observation Guide\n"), 0644)
+			},
+			wantGuide: true,
+		},
+		{
+			name:      "GUIDE.md absent",
+			setup:     func(dir string) {},
+			wantGuide: false,
+		},
+		{
+			name: "memory dir exists but no GUIDE.md",
+			setup: func(dir string) {
+				os.MkdirAll(filepath.Join(dir, "memory"), 0755)
+			},
+			wantGuide: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.setup(dir)
+
+			info := &teamContextInfo{}
+			loadTeamMemory(info, dir)
+
+			if tt.wantGuide {
+				want := filepath.Join(dir, "memory", "GUIDE.md")
+				if info.ObservationGuideHint != want {
+					t.Errorf("ObservationGuideHint = %q, want %q", info.ObservationGuideHint, want)
+				}
+			} else {
+				if info.ObservationGuideHint != "" {
+					t.Errorf("ObservationGuideHint = %q, want empty", info.ObservationGuideHint)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildGuidance_MemoryPut(t *testing.T) {
+	tests := []struct {
+		name       string
+		teamCtx    *teamContextInfo
+		featureEnv string // FEATURE_MEMORY value
+		wantPut    bool
+	}{
+		{
+			name:       "all conditions met",
+			teamCtx:    &teamContextInfo{TeamID: "t", ObservationGuideHint: "/path/GUIDE.md"},
+			featureEnv: "true",
+			wantPut:    true,
+		},
+		{
+			name:       "no GUIDE.md",
+			teamCtx:    &teamContextInfo{TeamID: "t"},
+			featureEnv: "true",
+			wantPut:    false,
+		},
+		{
+			name:       "flag off",
+			teamCtx:    &teamContextInfo{TeamID: "t", ObservationGuideHint: "/path/GUIDE.md"},
+			featureEnv: "",
+			wantPut:    false,
+		},
+		{
+			name:       "nil team ctx",
+			teamCtx:    nil,
+			featureEnv: "true",
+			wantPut:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FEATURE_MEMORY", tt.featureEnv)
+
+			projectRoot := t.TempDir()
+			g := buildGuidance("test-agent", projectRoot, tt.teamCtx, nil)
+
+			found := false
+			for _, cmd := range g.Commands {
+				if strings.Contains(cmd.Command, "ox memory put") {
+					found = true
+					break
+				}
+			}
+			if found != tt.wantPut {
+				t.Errorf("ox memory put in guidance = %v, want %v", found, tt.wantPut)
+			}
+		})
+	}
+}
+
+func TestEmitTeamMemorySection_ObservationGuide(t *testing.T) {
+	tests := []struct {
+		name          string
+		tc            *teamContextInfo
+		featureEnv    string
+		wantGuide     bool // expect "GUIDE.md:" in output
+		wantDirective bool // expect "Observation Recording (Active)" behavioral directive
+		wantMemory    bool // expect "## Team Memory" header
+		wantSoul      bool // expect "SOUL.md:" in output
+	}{
+		{
+			name:          "GUIDE.md with flag on",
+			tc:            &teamContextInfo{ObservationGuideHint: "/team/memory/GUIDE.md"},
+			featureEnv:    "true",
+			wantGuide:     true,
+			wantDirective: true,
+			wantMemory:    true,
+		},
+		{
+			name:       "GUIDE.md with flag off",
+			tc:         &teamContextInfo{ObservationGuideHint: "/team/memory/GUIDE.md"},
+			featureEnv: "",
+			wantGuide:  false,
+			wantMemory: false,
+		},
+		{
+			name:          "GUIDE.md and SOUL.md with flag on",
+			tc:            &teamContextInfo{SoulHint: "/team/SOUL.md", ObservationGuideHint: "/team/memory/GUIDE.md"},
+			featureEnv:    "true",
+			wantGuide:     true,
+			wantDirective: true,
+			wantMemory:    true,
+			wantSoul:      true,
+		},
+		{
+			name:       "no hints at all",
+			tc:         &teamContextInfo{},
+			featureEnv: "true",
+			wantGuide:  false,
+			wantMemory: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FEATURE_MEMORY", tt.featureEnv)
+
+			var buf bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&buf)
+
+			emitTeamMemorySection(cmd, tt.tc)
+			out := buf.String()
+
+			if got := strings.Contains(out, "## Team Memory"); got != tt.wantMemory {
+				t.Errorf("'## Team Memory' present = %v, want %v\noutput: %s", got, tt.wantMemory, out)
+			}
+			if got := strings.Contains(out, "GUIDE.md:"); got != tt.wantGuide {
+				t.Errorf("'GUIDE.md:' present = %v, want %v\noutput: %s", got, tt.wantGuide, out)
+			}
+			if got := strings.Contains(out, "Observation Recording (Active)"); got != tt.wantDirective {
+				t.Errorf("'Observation Recording (Active)' present = %v, want %v\noutput: %s", got, tt.wantDirective, out)
+			}
+			if tt.wantDirective {
+				if !strings.Contains(out, "Proactively record observations") {
+					t.Errorf("expected proactive instruction in output, got: %s", out)
+				}
+			}
+			if tt.wantSoul {
+				if !strings.Contains(out, "SOUL.md:") {
+					t.Errorf("expected 'SOUL.md:' in output, got: %s", out)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

- Discover `memory/GUIDE.md` in team context during prime and surface it as a reference pointer (same pattern as SOUL.md / TEAM.md)
- Add `observation_directive` field to JSON prime output with a **behavioral instruction** telling agents to proactively record observations — not just listing `ox memory put` as an available command
- Add `ox memory put` to `buildGuidance()` command list, triple-gated on team context + `FEATURE_MEMORY` flag + GUIDE.md existence
- Teams opt in by creating `memory/GUIDE.md` — without it, agents get no observation guidance at all

## Why behavioral directive matters

Early testing showed that listing `ox memory put` in the command list alone wasn't enough — agents treated it as an on-demand tool rather than an ongoing responsibility. The `observation_directive` field frames it as a proactive behavior: "record as you go, don't wait to be asked."

## Test plan

- [x] `TestLoadTeamMemory_ObservationGuide` — verifies discovery (3 cases: exists, absent, dir-only)
- [x] `TestBuildGuidance_MemoryPut` — verifies triple-gating (4 cases: all met, no guide, flag off, nil ctx)
- [x] `TestEmitTeamMemorySection_ObservationGuide` — verifies text output + behavioral directive (4 cases)
- [x] Full `cmd/ox/` test suite passes
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled memory-guided observation recording mechanism within agent outputs for proactive guidance
  * Integrated observation directives into prime outputs to enhance agent recommendations
  * Enhanced agent guidance with observation-recording commands when memory tracking is enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->