### PR TITLE
feat(session): add ox session lint command and recover skill

### DIFF
--- a/.claude/commands/ox-session-recover.md
+++ b/.claude/commands/ox-session-recover.md
@@ -1,0 +1,109 @@
+<!-- ox-hash: placeholder ver: 0.17.0 -->
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.).
+     Exception: Post-Command sections that require agent-side actions (e.g.,
+     displaying a notice, generating a summary) are legitimate here. -->
+Recover an ox session from a Claude Code transcript when session recording failed or captured no data.
+
+Use when:
+- `ox session stop` shows `entry_count: 0`
+- Session viewer shows empty or "Session not found"
+- You need to rebuild a session from a Claude Code transcript file
+
+## Recovery Flow
+
+### Step 1: Find the Claude Code transcript
+
+Claude Code stores transcripts at:
+```
+~/.claude/projects/<PROJECT_HASH>/*.jsonl
+```
+
+Where `PROJECT_HASH` is the CWD with `/` replaced by `-` (e.g., `-Users-ryan-Code-my-project`).
+
+Find the right transcript by checking modification times against the session's time window:
+```bash
+ls -lt ~/.claude/projects/<PROJECT_HASH>/*.jsonl | head -5
+```
+
+### Step 2: Try the built-in recover command first
+
+```bash
+ox agent <agent_id> session recover
+```
+
+If the adapter file still exists, this handles everything automatically. If it fails, continue to Step 3.
+
+### Step 3: Convert transcript to web viewer format
+
+The Claude Code transcript uses internal types (`queue-operation`, `progress`) that the web viewer cannot display. Convert to the expected format (`user`, `assistant`, `tool`, `system`).
+
+**Claude Code transcript entry types and their mapping:**
+
+| Transcript `type` | `message.role` | Web viewer `type` | Content location |
+|---|---|---|---|
+| `user` | `user` | `user` | `message.content` (string or content blocks) |
+| `assistant` | `assistant` | `assistant` | `message.content` text blocks |
+| `assistant` | (tool_use blocks) | `tool` | `message.content` tool_use blocks |
+| `progress` | (tool_result) | `tool` | `data.content` tool_result blocks |
+| `system` | | `system` | `message.content` |
+| `queue-operation` | | skip | internal queue ops |
+
+**Required output JSONL format (one JSON object per line):**
+```json
+{"type": "user", "content": "the user message", "ts": "ISO8601", "seq": 1}
+{"type": "assistant", "content": "assistant text response", "ts": "ISO8601", "seq": 2}
+{"type": "tool", "content": "", "tool_name": "Bash", "tool_input": "{...}", "ts": "ISO8601", "seq": 3}
+{"type": "tool", "content": "", "tool_output": "command output", "ts": "ISO8601", "seq": 4}
+```
+
+**Validation rules (lint before upload):**
+- Every entry MUST have `type` in: `user`, `assistant`, `system`, `tool`
+- Every entry MUST have `ts` (ISO8601 timestamp) and `seq` (integer)
+- `user`/`assistant`/`system` entries MUST have non-empty `content`
+- `tool` entries MUST have `tool_name` + `tool_input`, OR `tool_output`
+- Skip entries with `type: queue-operation` (internal Claude Code ops)
+- Skip user entries starting with `<system_instruction>` (framework context)
+- Extract text from assistant content blocks: use `text` field from `{"type": "text", "text": "..."}` blocks
+- Skip `thinking` blocks from assistant content
+
+### Step 4: Lint the converted JSONL
+
+Before uploading, validate the output:
+```bash
+ox session lint --file /tmp/converted-raw.jsonl
+```
+
+This checks all entries have valid types, required fields, and web viewer compatibility. Fix any errors before uploading.
+
+### Step 5: Upload to ledger
+
+Write the converted JSONL to the session cache, then use `ox session upload`:
+
+```bash
+# Copy converted raw.jsonl to the session's ledger directory
+LEDGER=$(ox status --json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('ledger',{}).get('path',''))")
+SESSION_DIR="$LEDGER/sessions/<session-name>"
+
+cp /tmp/converted-raw.jsonl "$SESSION_DIR/raw.jsonl"
+
+# Upload (handles LFS upload, meta.json, commit, push)
+ox session upload <session-name>
+```
+
+### Step 6: Verify
+
+Check the session is viewable at:
+```
+https://sageox.ai/repo/<repo_id>/sessions/<session-name>/viewer
+```
+
+The web viewer fetches `raw.jsonl` content via the LFS OID in `meta.json`. If the viewer shows empty, check that `meta.json` has the correct OID for `raw.jsonl`.
+
+## Future
+
+Once `ox session import-transcript` is implemented (see GitHub issue #192), this manual flow will be replaced by:
+```bash
+ox session import-transcript ~/.claude/projects/<hash>/<session-id>.jsonl
+```

--- a/cmd/ox/session_lint.go
+++ b/cmd/ox/session_lint.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// lintResult holds the outcome of linting a session's raw.jsonl.
+type lintResult struct {
+	SessionName string   `json:"session_name"`
+	Valid       bool     `json:"valid"`
+	Errors      []string `json:"errors,omitempty"`
+	Warnings    []string `json:"warnings,omitempty"`
+	EntryCount  int      `json:"entry_count"`
+	TypeCounts  map[string]int `json:"type_counts"`
+	HasHeader   bool     `json:"has_header"`
+	HasFooter   bool     `json:"has_footer"`
+}
+
+// validRawEntryTypes are the types the web viewer can display.
+var validRawEntryTypes = map[string]bool{
+	"user":      true,
+	"assistant": true,
+	"system":    true,
+	"tool":      true,
+}
+
+var sessionLintCmd = &cobra.Command{
+	Use:   "lint [session-name]",
+	Short: "Validate session raw.jsonl for web viewer compatibility",
+	Long: `Validate that a session's raw.jsonl is correctly formatted for the web viewer.
+
+Checks that every entry has a valid type (user, assistant, system, tool),
+required fields are present, and the format matches what the web viewer
+parser expects.
+
+Use --file to lint a standalone JSONL file instead of a ledger session.
+Use --all to lint all sessions in the ledger.
+
+Examples:
+  ox session lint OxRvKb
+  ox session lint 2026-03-11T22-13-rsnodgrass-OxRvKb
+  ox session lint --file /tmp/raw.jsonl
+  ox session lint --all`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		filePath, _ := cmd.Flags().GetString("file")
+		all, _ := cmd.Flags().GetBool("all")
+
+		if filePath != "" {
+			result := lintRawJSONLFile(filePath, filepath.Base(filePath))
+			return printLintResults([]lintResult{result}, jsonOutput)
+		}
+
+		ledgerPath, err := resolveLedgerPath()
+		if err != nil {
+			return err
+		}
+
+		sessionsDir := filepath.Join(ledgerPath, "sessions")
+
+		if all {
+			return lintAllSessions(sessionsDir, jsonOutput)
+		}
+
+		if len(args) == 0 {
+			return fmt.Errorf("provide a session name, --file path, or --all")
+		}
+
+		sessionName, err := resolveSessionInDir(sessionsDir, args[0])
+		if err != nil {
+			return err
+		}
+
+		rawPath := filepath.Join(sessionsDir, sessionName, "raw.jsonl")
+
+		// if file is an LFS pointer, report it
+		if lfs.IsPointerFile(rawPath) {
+			result := lintResult{
+				SessionName: sessionName,
+				Valid:       false,
+				Errors:      []string{"raw.jsonl is an LFS pointer (not hydrated). Run 'ox session download' first."},
+			}
+			return printLintResults([]lintResult{result}, jsonOutput)
+		}
+
+		result := lintRawJSONLFile(rawPath, sessionName)
+		return printLintResults([]lintResult{result}, jsonOutput)
+	},
+}
+
+func init() {
+	sessionCmd.AddCommand(sessionLintCmd)
+	sessionLintCmd.Flags().String("file", "", "lint a standalone JSONL file instead of a ledger session")
+	sessionLintCmd.Flags().Bool("all", false, "lint all sessions in the ledger")
+}
+
+// lintRawJSONLFile validates a raw.jsonl file for web viewer compatibility.
+func lintRawJSONLFile(path, name string) lintResult {
+	result := lintResult{
+		SessionName: name,
+		Valid:       true,
+		Errors:      make([]string, 0),
+		Warnings:    make([]string, 0),
+		TypeCounts:  make(map[string]int),
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, fmt.Sprintf("cannot open file: %s", err))
+		return result
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+
+	lineNum := 0
+	lastSeq := 0
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		lineNum++
+
+		if len(line) == 0 {
+			continue
+		}
+
+		var entry map[string]any
+		if err := json.Unmarshal(line, &entry); err != nil {
+			result.Valid = false
+			result.Errors = append(result.Errors, fmt.Sprintf("line %d: invalid JSON: %s", lineNum, err))
+			continue
+		}
+
+		entryType, _ := entry["type"].(string)
+
+		// skip header/footer (valid structural entries)
+		if entryType == "header" {
+			result.HasHeader = true
+			continue
+		}
+		if entryType == "footer" {
+			result.HasFooter = true
+			continue
+		}
+
+		// skip _meta entries (capture-prior format)
+		if _, hasMeta := entry["_meta"]; hasMeta {
+			continue
+		}
+
+		result.EntryCount++
+		result.TypeCounts[entryType]++
+
+		// validate type
+		if !validRawEntryTypes[entryType] {
+			result.Valid = false
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("line %d: invalid type=%q (expected user, assistant, system, or tool)", lineNum, entryType))
+			if len(result.Errors) > 20 {
+				result.Errors = append(result.Errors, "... (truncated, too many errors)")
+				break
+			}
+			continue
+		}
+
+		// validate timestamp
+		if _, hasTS := entry["ts"]; !hasTS {
+			if _, hasTimestamp := entry["timestamp"]; !hasTimestamp {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("line %d: missing ts/timestamp field", lineNum))
+			}
+		}
+
+		// validate seq
+		if seqVal, hasSeq := entry["seq"]; hasSeq {
+			var seq int
+			switch v := seqVal.(type) {
+			case float64:
+				seq = int(v)
+			}
+			if seq > 0 && seq <= lastSeq {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("line %d: seq=%d not monotonically increasing (last=%d)", lineNum, seq, lastSeq))
+			}
+			if seq > 0 {
+				lastSeq = seq
+			}
+		}
+
+		// validate content for non-tool entries
+		if entryType == "user" || entryType == "assistant" || entryType == "system" {
+			content, _ := entry["content"].(string)
+			if content == "" {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("line %d: %s entry has empty content", lineNum, entryType))
+			}
+		}
+
+		// validate tool entries
+		if entryType == "tool" {
+			toolName, _ := entry["tool_name"].(string)
+			toolOutput, _ := entry["tool_output"].(string)
+			if toolName == "" && toolOutput == "" {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("line %d: tool entry missing both tool_name and tool_output", lineNum))
+			}
+		}
+
+		// cap warnings
+		if len(result.Warnings) > 50 {
+			result.Warnings = append(result.Warnings, "... (truncated)")
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, fmt.Sprintf("read error: %s", err))
+	}
+
+	if result.EntryCount == 0 && result.Valid {
+		result.Valid = false
+		result.Errors = append(result.Errors, "no entries found in file")
+	}
+
+	return result
+}
+
+// lintAllSessions validates all sessions in the ledger.
+func lintAllSessions(sessionsDir string, jsonOutput bool) error {
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return fmt.Errorf("read sessions dir: %w", err)
+	}
+
+	var results []lintResult
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		rawPath := filepath.Join(sessionsDir, entry.Name(), "raw.jsonl")
+		if _, err := os.Stat(rawPath); os.IsNotExist(err) {
+			continue
+		}
+
+		if lfs.IsPointerFile(rawPath) {
+			results = append(results, lintResult{
+				SessionName: entry.Name(),
+				Valid:       false,
+				Errors:      []string{"raw.jsonl is an LFS pointer (not hydrated)"},
+			})
+			continue
+		}
+
+		results = append(results, lintRawJSONLFile(rawPath, entry.Name()))
+	}
+
+	return printLintResults(results, jsonOutput)
+}
+
+// printLintResults outputs lint results as JSON or human-readable text.
+func printLintResults(results []lintResult, jsonOutput bool) error {
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+
+	allValid := true
+	for _, r := range results {
+		if !r.Valid {
+			allValid = false
+		}
+		printLintResult(r)
+	}
+
+	if len(results) > 1 {
+		valid := 0
+		for _, r := range results {
+			if r.Valid {
+				valid++
+			}
+		}
+		fmt.Printf("\n%d/%d sessions valid\n", valid, len(results))
+	}
+
+	if !allValid {
+		return fmt.Errorf("lint failed")
+	}
+	return nil
+}
+
+func printLintResult(r lintResult) {
+	if r.Valid {
+		fmt.Printf("%s %s  %d entries", ui.RenderPassIcon(), r.SessionName, r.EntryCount)
+		if len(r.TypeCounts) > 0 {
+			var parts []string
+			for _, t := range []string{"user", "assistant", "tool", "system"} {
+				if c, ok := r.TypeCounts[t]; ok {
+					parts = append(parts, fmt.Sprintf("%s:%d", t, c))
+				}
+			}
+			fmt.Printf("  (%s)", strings.Join(parts, " "))
+		}
+		fmt.Println()
+	} else {
+		fmt.Printf("%s %s\n", ui.RenderFailIcon(), r.SessionName)
+		for _, e := range r.Errors {
+			fmt.Printf("    %s\n", e)
+		}
+	}
+
+	if len(r.Warnings) > 0 {
+		for _, w := range r.Warnings {
+			fmt.Printf("    %s %s\n", ui.RenderWarnIcon(), w)
+		}
+	}
+}

--- a/cmd/ox/session_lint_test.go
+++ b/cmd/ox/session_lint_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLintRawJSONLFile_Valid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raw.jsonl")
+	content := `{"type":"user","content":"hello","ts":"2026-03-11T00:00:00Z","seq":1}
+{"type":"assistant","content":"hi there","ts":"2026-03-11T00:00:01Z","seq":2}
+{"type":"tool","content":"","tool_name":"Bash","tool_input":"ls","ts":"2026-03-11T00:00:02Z","seq":3}
+{"type":"tool","content":"","tool_output":"file.txt","ts":"2026-03-11T00:00:03Z","seq":4}
+{"type":"system","content":"context loaded","ts":"2026-03-11T00:00:04Z","seq":5}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	result := lintRawJSONLFile(path, "test-session")
+
+	assert.True(t, result.Valid)
+	assert.Empty(t, result.Errors)
+	assert.Equal(t, 5, result.EntryCount)
+	assert.Equal(t, 1, result.TypeCounts["user"])
+	assert.Equal(t, 1, result.TypeCounts["assistant"])
+	assert.Equal(t, 2, result.TypeCounts["tool"])
+	assert.Equal(t, 1, result.TypeCounts["system"])
+}
+
+func TestLintRawJSONLFile_InvalidTypes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raw.jsonl")
+	content := `{"type":"queue-operation","content":"test","ts":"2026-03-11T00:00:00Z","seq":1}
+{"type":"progress","content":"stuff","ts":"2026-03-11T00:00:01Z","seq":2}
+{"type":"user","content":"valid","ts":"2026-03-11T00:00:02Z","seq":3}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	result := lintRawJSONLFile(path, "test-session")
+
+	assert.False(t, result.Valid)
+	assert.Len(t, result.Errors, 2)
+	assert.Contains(t, result.Errors[0], "queue-operation")
+	assert.Contains(t, result.Errors[1], "progress")
+}
+
+func TestLintRawJSONLFile_HeaderFooterSkipped(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raw.jsonl")
+	content := `{"type":"header","started_at":"2026-03-11T00:00:00Z"}
+{"type":"user","content":"hello","ts":"2026-03-11T00:00:00Z","seq":1}
+{"type":"assistant","content":"hi","ts":"2026-03-11T00:00:01Z","seq":2}
+{"type":"footer","closed_at":"2026-03-11T00:00:02Z","entry_count":2}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	result := lintRawJSONLFile(path, "test-session")
+
+	assert.True(t, result.Valid)
+	assert.True(t, result.HasHeader)
+	assert.True(t, result.HasFooter)
+	assert.Equal(t, 2, result.EntryCount)
+}
+
+func TestLintRawJSONLFile_MetaLineSkipped(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raw.jsonl")
+	content := `{"_meta":{"schema_version":"1","source":"test","agent_id":"Ox1234"}}
+{"type":"user","content":"hello","ts":"2026-03-11T00:00:00Z","seq":1}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	result := lintRawJSONLFile(path, "test-session")
+
+	assert.True(t, result.Valid)
+	assert.Equal(t, 1, result.EntryCount)
+}
+
+func TestLintRawJSONLFile_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raw.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(""), 0644))
+
+	result := lintRawJSONLFile(path, "test-session")
+
+	assert.False(t, result.Valid)
+	assert.Contains(t, result.Errors[0], "no entries found")
+}
+
+func TestLintRawJSONLFile_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raw.jsonl")
+	content := `{"type":"user","content":"hello","ts":"2026-03-11T00:00:00Z","seq":1}
+not valid json
+{"type":"assistant","content":"hi","ts":"2026-03-11T00:00:01Z","seq":2}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	result := lintRawJSONLFile(path, "test-session")
+
+	assert.False(t, result.Valid)
+	assert.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0], "invalid JSON")
+}
+
+func TestLintRawJSONLFile_WarningsForMissingFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raw.jsonl")
+	content := `{"type":"user","content":"hello","seq":1}
+{"type":"assistant","content":"","ts":"2026-03-11T00:00:01Z","seq":2}
+{"type":"tool","content":"","ts":"2026-03-11T00:00:02Z","seq":3}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	result := lintRawJSONLFile(path, "test-session")
+
+	// valid but with warnings
+	assert.True(t, result.Valid)
+	assert.NotEmpty(t, result.Warnings)
+
+	// check specific warnings
+	hasTimestampWarning := false
+	hasEmptyContentWarning := false
+	hasToolWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "missing ts/timestamp") {
+			hasTimestampWarning = true
+		}
+		if strings.Contains(w, "empty content") {
+			hasEmptyContentWarning = true
+		}
+		if strings.Contains(w, "tool entry missing") {
+			hasToolWarning = true
+		}
+	}
+	assert.True(t, hasTimestampWarning, "should warn about missing timestamp")
+	assert.True(t, hasEmptyContentWarning, "should warn about empty content")
+	assert.True(t, hasToolWarning, "should warn about tool missing tool_name/tool_output")
+}
+
+func TestLintRawJSONLFile_NonMonotonicSeq(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "raw.jsonl")
+	content := `{"type":"user","content":"hello","ts":"2026-03-11T00:00:00Z","seq":5}
+{"type":"assistant","content":"hi","ts":"2026-03-11T00:00:01Z","seq":3}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	result := lintRawJSONLFile(path, "test-session")
+
+	assert.True(t, result.Valid) // non-monotonic seq is a warning, not error
+	hasSeqWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "not monotonically increasing") {
+			hasSeqWarning = true
+		}
+	}
+	assert.True(t, hasSeqWarning)
+}


### PR DESCRIPTION
## Summary

- **`ox session lint`** — validates `raw.jsonl` files for web viewer compatibility before upload
  - Supports `--file` for standalone files, `--all` for bulk ledger validation, `--json` for machine output
  - Errors: invalid types, malformed JSON, empty files
  - Warnings: missing timestamps, empty content, non-monotonic seq numbers
  - Skips structural entries (header/footer, `_meta`) correctly
- **`ox-session-recover` skill** — documents full session recovery flow from Claude Code transcripts
  - Type mapping table (Claude Code internal → web viewer format)
  - JSONL validation rules
  - Step-by-step: find transcript → try built-in recover → convert → lint → upload → verify

## Test plan

- [x] 8 unit tests covering valid, invalid types, header/footer, meta lines, empty files, invalid JSON, warnings, non-monotonic seq
- [ ] Manual: `ox session lint --file /tmp/test.jsonl` with valid/invalid files
- [ ] Manual: `ox session lint --all` against ledger with mixed sessions

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session linting capability to validate session data integrity.

* **Documentation**
  * Added comprehensive guide for recovering sessions from transcripts.

* **Tests**
  * Added unit tests for session linting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->