### PR TITLE
fix(codedb): bypass go-git extension rejection in repo indexing

### DIFF
--- a/internal/codedb/index/gitops.go
+++ b/internal/codedb/index/gitops.go
@@ -49,7 +49,7 @@ func RepoNameFromURL(url string) (string, error) {
 // Returns the opened go-git Repository.
 func CloneOrFetch(url, repoPath string) (*git.Repository, error) {
 	if _, err := os.Stat(repoPath); err == nil {
-		repo, err := git.PlainOpen(repoPath)
+		repo, err := plainOpenTolerant(repoPath)
 		if err != nil {
 			return nil, fmt.Errorf("open existing repo: %w", err)
 		}

--- a/internal/codedb/index/gogit.go
+++ b/internal/codedb/index/gogit.go
@@ -1,0 +1,142 @@
+package index
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	billy "github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/storage"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+)
+
+// extensionSafeStorer wraps a storage.Storer and strips [extensions] from the
+// in-memory config so go-git's verifyExtensions doesn't reject the repo.
+// The on-disk .git/config is never modified.
+type extensionSafeStorer struct {
+	storage.Storer
+	stripped []string
+	once     sync.Once
+}
+
+func (e *extensionSafeStorer) Config() (*config.Config, error) {
+	cfg, err := e.Storer.Config()
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Raw != nil && cfg.Raw.HasSection("extensions") {
+		e.once.Do(func() {
+			for _, opt := range cfg.Raw.Section("extensions").Options {
+				e.stripped = append(e.stripped, opt.Key+"="+opt.Value)
+			}
+		})
+		cfg.Raw = cfg.Raw.RemoveSection("extensions")
+		cfg.Extensions.ObjectFormat = ""
+	}
+	return cfg, nil
+}
+
+// plainOpenTolerant opens a git repo like git.PlainOpen but falls back to
+// stripping unsupported extensions from the in-memory config when go-git
+// rejects them. The on-disk .git/config is never modified.
+func plainOpenTolerant(path string) (*git.Repository, error) {
+	repo, err := git.PlainOpen(path)
+	if err == nil {
+		return repo, nil
+	}
+	if !errors.Is(err, git.ErrUnsupportedExtensionRepositoryFormatVersion) &&
+		!errors.Is(err, git.ErrUnknownExtension) {
+		return nil, err
+	}
+
+	// Replicate PlainOpenWithOptions logic with extension-safe storer.
+	// dotGitToOSFilesystems is unexported, so we resolve .git ourselves.
+	dot, wt, resolveErr := resolveGitDirFS(path)
+	if resolveErr != nil {
+		return nil, fmt.Errorf("open repo %s (extension-tolerant): %w", path, resolveErr)
+	}
+
+	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	safe := &extensionSafeStorer{Storer: s}
+
+	repo, err = git.Open(safe, wt)
+	if err != nil {
+		return nil, fmt.Errorf("open repo %s (extension-tolerant): %w", path, err)
+	}
+	slog.Warn("opened git repo bypassing unsupported extensions",
+		"path", path, "stripped", safe.stripped)
+	return repo, nil
+}
+
+// resolveGitDirFS replicates the essential logic of go-git's unexported
+// dotGitToOSFilesystems: given a repo path, return the .git filesystem and
+// the worktree filesystem. Handles normal repos (.git is a dir), bare repos
+// (path itself is the git dir), and worktrees (.git is a file with gitdir pointer).
+func resolveGitDirFS(path string) (dot, wt billy.Filesystem, err error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gitPath := filepath.Join(absPath, ".git")
+	fi, err := os.Stat(gitPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Might be a bare repo — .git dir doesn't exist but path itself is git dir
+			if _, headErr := os.Stat(filepath.Join(absPath, "HEAD")); headErr == nil {
+				return osfs.New(absPath), nil, nil
+			}
+			return nil, nil, fmt.Errorf("not a git repository: %s", absPath)
+		}
+		return nil, nil, err
+	}
+
+	wtFs := osfs.New(absPath)
+
+	if fi.IsDir() {
+		return osfs.New(gitPath), wtFs, nil
+	}
+
+	// .git is a file (worktree) — read gitdir pointer
+	gitdir, err := readGitDirFile(gitPath, absPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return osfs.New(gitdir), wtFs, nil
+}
+
+// readGitDirFile reads a .git file that contains a gitdir pointer.
+func readGitDirFile(gitFilePath, repoPath string) (string, error) {
+	f, err := os.Open(gitFilePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	line := string(b)
+	const prefix = "gitdir: "
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf(".git file has no %s prefix", prefix)
+	}
+
+	gitdir := strings.Split(line[len(prefix):], "\n")[0]
+	gitdir = strings.TrimSpace(gitdir)
+	if filepath.IsAbs(gitdir) {
+		return gitdir, nil
+	}
+	return filepath.Join(repoPath, gitdir), nil
+}

--- a/internal/codedb/index/gogit_test.go
+++ b/internal/codedb/index/gogit_test.go
@@ -1,0 +1,99 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func replaceFormatVersion(content, version string) string {
+	return strings.Replace(content,
+		"repositoryformatversion = 0",
+		"repositoryformatversion = "+version, 1)
+}
+
+func TestPlainOpenTolerant_NormalRepo(t *testing.T) {
+	t.Parallel()
+	dir, _ := initGitRepo(t, 1)
+
+	repo, err := plainOpenTolerant(dir)
+	require.NoError(t, err)
+	assert.NotNil(t, repo)
+}
+
+func TestPlainOpenTolerant_RepoWithExtensions(t *testing.T) {
+	t.Parallel()
+	dir, _ := initGitRepo(t, 1)
+
+	// Append an extension that go-git doesn't recognize
+	gitConfig := filepath.Join(dir, ".git", "config")
+	f, err := os.OpenFile(gitConfig, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("\n[extensions]\n\tobjectformat = sha1\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	repo, err := plainOpenTolerant(dir)
+	require.NoError(t, err)
+	assert.NotNil(t, repo)
+}
+
+func TestPlainOpenTolerant_FormatV1WithUnknownExtension(t *testing.T) {
+	t.Parallel()
+	dir, _ := initGitRepo(t, 1)
+
+	// Directly edit .git/config to set repositoryformatversion = 1 with extension.
+	// We write the file directly because `git config` may reject format version changes.
+	gitConfig := filepath.Join(dir, ".git", "config")
+	content, err := os.ReadFile(gitConfig)
+	require.NoError(t, err)
+
+	// Replace repositoryformatversion = 0 with 1 and add extensions
+	newContent := string(content)
+	newContent = newContent + "\n[extensions]\n\tobjectformat = sha256\n"
+	// Also bump format version in [core] section
+	newContent = replaceFormatVersion(newContent, "1")
+	require.NoError(t, os.WriteFile(gitConfig, []byte(newContent), 0o644))
+
+	repo, err := plainOpenTolerant(dir)
+	require.NoError(t, err)
+	assert.NotNil(t, repo)
+}
+
+func TestPlainOpenTolerant_NonRepoPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	repo, err := plainOpenTolerant(dir)
+	assert.Error(t, err)
+	assert.Nil(t, repo)
+}
+
+func TestPlainOpenTolerant_WorktreeWithExtensions(t *testing.T) {
+	t.Parallel()
+	mainDir, _ := initGitRepo(t, 1)
+
+	worktreeDir := createLinkedWorktree(t, mainDir, "ext-test")
+
+	// Add extensions to the main repo's .git/config
+	gitConfig := filepath.Join(mainDir, ".git", "config")
+	f, err := os.OpenFile(gitConfig, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("\n[extensions]\n\tobjectformat = sha1\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// The worktree's .git is a file pointing to the main repo.
+	// plainOpenTolerant resolves this via resolveGitDir (existing function
+	// in indexer.go) which follows commondir to the main repo. Since the
+	// plan calls plainOpenTolerant on the resolved main repo path, test
+	// that opening the main repo path works with extensions.
+	repoOpenPath, _ := resolveGitDir(worktreeDir)
+	repo, err := plainOpenTolerant(repoOpenPath)
+	require.NoError(t, err)
+	assert.NotNil(t, repo)
+}

--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -251,7 +251,7 @@ func IndexLocalRepo(ctx context.Context, s *store.Store, localPath string, opts 
 	// go-git can access the shared object store (packfiles, loose objects).
 	report("Opening local repository...")
 	repoOpenPath, isWorktree := resolveGitDir(localPath)
-	repo, err := git.PlainOpen(repoOpenPath)
+	repo, err := plainOpenTolerant(repoOpenPath)
 	if err != nil {
 		return fmt.Errorf("open local repo %s: %w", localPath, err)
 	}
@@ -1151,7 +1151,7 @@ func ParseSymbols(ctx context.Context, s *store.Store, progress ProgressFunc) (P
 
 	var repos []*git.Repository
 	for _, rp := range repoPaths {
-		r, err := git.PlainOpen(rp)
+		r, err := plainOpenTolerant(rp)
 		if err != nil {
 			continue
 		}
@@ -1347,7 +1347,7 @@ func ParseComments(ctx context.Context, s *store.Store, progress ProgressFunc) (
 
 	var repos []*git.Repository
 	for _, rp := range repoPaths {
-		r, err := git.PlainOpen(rp)
+		r, err := plainOpenTolerant(rp)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Summary

- **go-git v5.17.0 rejects repos** with unsupported extensions (e.g., `extensions.objectformat = sha256`) in `.git/config`, causing codedb to silently skip indexing those repos entirely
- Adds `plainOpenTolerant()` which tries normal `git.PlainOpen` first, then on extension errors only, re-opens with an in-memory config wrapper that strips `[extensions]` — **never modifies `.git/config` on disk**
- Replaces all 4 `git.PlainOpen` call sites in codedb (indexer + gitops) with the tolerant variant

## How it works

```
plainOpenTolerant(path)
  ├─ git.PlainOpen(path)  →  success? return repo (zero overhead)
  └─ extension error?
       ├─ resolveGitDirFS(path)  →  billy filesystems for .git + worktree
       ├─ extensionSafeStorer    →  wraps storer, strips [extensions] in-memory
       └─ git.Open(safe, wt)    →  open with clean config
```

Does **NOT** bypass `ErrUnsupportedRepositoryFormatVersion` — if the format version itself is unknown (not 0 or 1), go-git truly can't read the objects.

## Test plan

- [x] `TestPlainOpenTolerant_NormalRepo` — standard repo opens via fast path
- [x] `TestPlainOpenTolerant_RepoWithExtensions` — repo with `extensions.objectformat = sha1` on format v0
- [x] `TestPlainOpenTolerant_FormatV1WithUnknownExtension` — format v1 + `objectformat = sha256`
- [x] `TestPlainOpenTolerant_NonRepoPath` — error propagates correctly
- [x] `TestPlainOpenTolerant_WorktreeWithExtensions` — worktree resolution + extension bypass
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository opening to successfully handle Git repositories with non-standard or extended configurations when indexing code.

* **Tests**
  * Added tests for repository opening behavior, including scenarios with extended configurations, worktrees, and non-standard repository layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->