### PR TITLE
fix: increase IPC timeouts for daemon detection

### DIFF
--- a/cmd/ox/doctor_daemon.go
+++ b/cmd/ox/doctor_daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
@@ -64,9 +65,9 @@ func checkDaemonHealth(opts doctorOptions) []checkResult {
 			goto skipHeartbeats
 		}
 
-		// Get both repo_id (for debugging) and workspace_id (for uniqueness)
+		// Get repo_id and repo-based workspace_id (consistent across worktrees)
 		repoID := config.GetRepoID(gitRoot)
-		workspaceID := daemon.WorkspaceID(gitRoot)
+		workspaceID := daemon.RepoBasedWorkspaceID(gitRoot)
 		if repoID == "" || workspaceID == "" {
 			goto skipHeartbeats
 		}
@@ -190,7 +191,7 @@ func checkDaemonVersion(fix bool) checkResult {
 		}
 	}
 
-	client := daemon.NewClient()
+	client := daemon.NewClientWithTimeout(500 * time.Millisecond)
 	status, err := client.Status()
 	if err != nil {
 		return checkResult{

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -1551,8 +1551,10 @@ daemon health, and a tree view of all SageOx directory locations.`,
 		var codeStats *daemon.CodeDBStats
 		var client *daemon.Client
 		if gitRoot != "" {
-			client = daemon.TryConnectOrDirect()
-			if client != nil {
+			// use longer timeout for status queries — the status handler collects data
+			// from multiple subsystems and can exceed 50ms under sync load
+			client = daemon.NewClientWithTimeout(500 * time.Millisecond)
+			if client.Ping() == nil {
 				if ds, err := client.Status(); err == nil {
 					daemonStatus = ds
 					syncHistory, _ = client.SyncHistory()
@@ -1560,6 +1562,8 @@ daemon health, and a tree view of all SageOx directory locations.`,
 				if cs, err := client.CodeStatus(); err == nil {
 					codeStats = cs
 				}
+			} else {
+				client = nil
 			}
 		}
 
@@ -1738,8 +1742,8 @@ func buildStatusJSON(authenticated bool, token *auth.StoredToken, endpointSlug, 
 	// daemon section + AI coworkers
 	if gitRoot != "" {
 		output.Daemon = &statusDaemonJSON{}
-		client := daemon.TryConnectOrDirect()
-		if client != nil {
+		client := daemon.NewClientWithTimeout(500 * time.Millisecond)
+		if client.Ping() == nil {
 			if daemonStatus, err := client.Status(); err == nil {
 				output.Daemon.Running = daemonStatus.Running
 				output.Daemon.Pid = daemonStatus.Pid

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -3046,17 +3046,16 @@ func (s *SyncScheduler) writeHeartbeats() {
 		return
 	}
 
-	// CRITICAL: Use BOTH repo_id AND workspace_id for heartbeat filenames.
-	// - workspace_id (hash of path) prevents collisions between worktrees
-	// - repo_id makes debugging easier - you can see which repo it belongs to
-	// See UserHeartbeatPath() docs for full explanation.
+	// Use repo_id + repo-based workspace_id for heartbeat filenames.
+	// With 1 daemon per repo, all worktrees share a daemon and should
+	// see the same heartbeat files. Repo-based ID is consistent across clones.
 	repoID := s.workspaceRegistry.GetRepoID()
 	if repoID == "" {
 		s.logger.Debug("no repo_id available for heartbeat")
 		return
 	}
 
-	workspaceID := WorkspaceID(s.config.ProjectRoot)
+	workspaceID := CurrentWorkspaceID()
 	if workspaceID == "" {
 		s.logger.Debug("no workspace_id available for heartbeat")
 		return

--- a/internal/doctor/daemon.go
+++ b/internal/doctor/daemon.go
@@ -105,7 +105,7 @@ func (c *DaemonSyncStatusCheck) Run(ctx context.Context) CheckResult {
 		}
 	}
 
-	client := daemon.NewClient()
+	client := daemon.NewClientWithTimeout(500 * time.Millisecond)
 	status, err := client.Status()
 	if err != nil {
 		return CheckResult{
@@ -176,7 +176,7 @@ func (c *DaemonUptimeCheck) Run(ctx context.Context) CheckResult {
 		}
 	}
 
-	client := daemon.NewClient()
+	client := daemon.NewClientWithTimeout(500 * time.Millisecond)
 	status, err := client.Status()
 	if err != nil {
 		return CheckResult{
@@ -214,7 +214,7 @@ func (c *DaemonSyncErrorsCheck) Run(ctx context.Context) CheckResult {
 		}
 	}
 
-	client := daemon.NewClient()
+	client := daemon.NewClientWithTimeout(500 * time.Millisecond)
 	status, err := client.Status()
 	if err != nil {
 		return CheckResult{
@@ -267,7 +267,7 @@ func (c *DaemonDirtyTeamContextCheck) Run(ctx context.Context) CheckResult {
 		}
 	}
 
-	client := daemon.NewClient()
+	client := daemon.NewClientWithTimeout(500 * time.Millisecond)
 	status, err := client.Status()
 	if err != nil {
 		return CheckResult{
@@ -384,7 +384,7 @@ func (c *DaemonHeartbeatCheck) Run(ctx context.Context) CheckResult {
 	if err != nil || entry == nil {
 		if daemon.IsRunning() {
 			// grace period: daemon just started
-			client := daemon.NewClient()
+			client := daemon.NewClientWithTimeout(500 * time.Millisecond)
 			if dStatus, dErr := client.Status(); dErr == nil && dStatus.Uptime < DaemonBootstrapGrace {
 				return CheckResult{
 					Name:    c.Name(),


### PR DESCRIPTION
## Summary
Fixes `ox status` showing "daemon not started" and `ox doctor` reporting false negatives when the daemon is actually running and healthy. The root cause: daemon status handler collects data from multiple subsystems under load, exceeding the 50ms IPC timeout used by status queries.

**Changes:**
- Increase IPC timeout from 50ms → 500ms for all daemon status queries in `ox status` and `ox doctor` commands
- Fix heartbeat detection to use repo-based workspace ID instead of path-based, so heartbeats are found consistently across worktrees under the 1-daemon-per-repo model
- Daemon now writes heartbeats with repo-based ID for cross-worktree visibility

## Verification
- [x] `ox status` correctly detects running daemon (human and JSON output)
- [x] `ox daemon status` still works (no regression)
- [x] `ox doctor` daemon checks pass (no more "status check failed" or "not syncing")
- [x] All 6544 tests pass
- [x] No lint issues

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon responsiveness with enhanced timeout handling.
  * Added connectivity checks to prevent system hangs when the daemon is unavailable.
  * Enhanced consistency in workspace identification across multiple worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->