### PR TITLE
fix: move codedb from ledger root to .sageox/cache

### DIFF
--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -100,6 +101,15 @@ func (m *CodeDBManager) resolveSharedDataDir() string {
 	ctx, err := config.LoadProjectContext(m.projectRoot)
 	if err == nil {
 		if dir := paths.CodeDBSharedDir(ctx.RepoID(), ctx.Endpoint()); dir != "" {
+			// clean up legacy root-level codedb/ if it exists
+			legacyDir := paths.LedgersDataDir(ctx.RepoID(), ctx.Endpoint())
+			if legacyDir != "" {
+				legacyCodedb := filepath.Join(legacyDir, "codedb")
+				if _, statErr := os.Stat(legacyCodedb); statErr == nil {
+					m.logger.Info("removing legacy codedb at ledger root", "old", legacyCodedb, "new", dir)
+					_ = os.RemoveAll(legacyCodedb)
+				}
+			}
 			return dir
 		}
 	}

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -162,6 +162,22 @@ func EnsureGitignoreBeforeCommitCtx(ctx context.Context, repoPath string) {
 	if out, err := rmCmd.CombinedOutput(); err != nil {
 		slog.Debug("pre-commit cache untrack failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
 	}
+
+	// untrack root-level codedb/ that was committed before the path was fixed
+	// (codedb now lives at .sageox/cache/codedb/ inside the ledger).
+	rmCodedbCmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"rm", "--cached", "-r", "--ignore-unmatch", "codedb/")
+	if out, err := rmCodedbCmd.CombinedOutput(); err != nil {
+		slog.Debug("pre-commit codedb untrack failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
+	}
+
+	// delete root-level codedb/ from disk — it's a rebuildable index and without
+	// deletion, git add -A would re-stage it (no root .gitignore entry covers it).
+	codedbDir := filepath.Join(repoPath, "codedb")
+	if _, err := os.Stat(codedbDir); err == nil {
+		slog.Info("removing legacy codedb at repo root", "path", codedbDir)
+		_ = os.RemoveAll(codedbDir)
+	}
 }
 
 // CacheFilesTracked returns true if any .sageox/cache/ files are tracked by git.

--- a/internal/gitserver/gitignore_test.go
+++ b/internal/gitserver/gitignore_test.go
@@ -262,6 +262,41 @@ func TestCheckoutGitignoreNeedsFix_Complete(t *testing.T) {
 	assert.False(t, CheckoutGitignoreNeedsFix(dir), "should not need fix when all entries present")
 }
 
+// TestEnsureGitignoreBeforeCommit_UntracksRootCodeDB is a regression test for the
+// bug where codedb/ was committed to the ledger root because CodeDBSharedDir
+// pointed to the ledger root instead of .sageox/cache/codedb/.
+func TestEnsureGitignoreBeforeCommit_UntracksRootCodeDB(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := setupGitRepoWithSageox(t)
+
+	// simulate: codedb/ was committed at the ledger root (the old bug)
+	codedbDir := filepath.Join(dir, "codedb")
+	require.NoError(t, os.MkdirAll(codedbDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(codedbDir, "index.db"), []byte("fake-db"), 0644))
+	runGit(t, dir, "add", "codedb/")
+	runGit(t, dir, "commit", "-m", "accidentally commit codedb")
+
+	// verify codedb/ is tracked before the fix
+	lsOut, err := exec.Command("git", "-C", dir, "ls-files", "codedb/").Output()
+	require.NoError(t, err)
+	assert.NotEmpty(t, strings.TrimSpace(string(lsOut)), "codedb/ should be tracked before fix")
+
+	// run the pre-commit guard
+	EnsureGitignoreBeforeCommit(dir)
+
+	// verify codedb/ is no longer tracked
+	lsOut, err = exec.Command("git", "-C", dir, "ls-files", "codedb/").Output()
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(string(lsOut)), "codedb/ should be untracked after fix")
+
+	// verify codedb/ directory was deleted from disk (prevents git add -A re-staging)
+	_, err = os.Stat(codedbDir)
+	assert.True(t, os.IsNotExist(err), "codedb/ should be deleted from disk after fix")
+}
+
 // TestEnsureCheckoutGitignore_WithSparseCheckout is a regression test for the
 // bug where git add .sageox/.gitignore fails during TwoPhaseClone because
 // sparse-checkout blocks staging files outside the sparse definition.

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -135,12 +135,12 @@ func StateDir() string {
 
 // CodeDBSharedDir returns the directory for the shared CodeDB index (committed content).
 // Stored inside the ledger's local cache, shared across all worktrees for the same repo.
-// Format: ~/.local/share/sageox/<endpoint>/ledgers/<repoID>/codedb/
+// Format: ~/.local/share/sageox/<endpoint>/ledgers/<repoID>/.sageox/cache/codedb/
 func CodeDBSharedDir(repoID, endpointURL string) string {
 	if repoID == "" || endpointURL == "" {
 		return ""
 	}
-	return filepath.Join(LedgersDataDir(repoID, endpointURL), "codedb")
+	return filepath.Join(LedgersDataDir(repoID, endpointURL), ".sageox", "cache", "codedb")
 }
 
 // CodeDBDataDir returns the legacy per-worktree CodeDB directory.

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -577,6 +577,39 @@ func TestLedgersDataDir(t *testing.T) {
 	})
 }
 
+func TestCodeDBSharedDir(t *testing.T) {
+	saved := saveEnv("OX_XDG_ENABLE", "SAGEOX_ENDPOINT")
+	defer restoreEnv(saved)
+
+	clearXDGEnv()
+	os.Unsetenv("SAGEOX_ENDPOINT")
+
+	t.Run("returns path under .sageox/cache", func(t *testing.T) {
+		dir := CodeDBSharedDir("repo123", "https://sageox.ai")
+		if !strings.Contains(dir, filepath.Join(".sageox", "cache", "codedb")) {
+			t.Errorf("CodeDBSharedDir() = %q, want path containing .sageox/cache/codedb", dir)
+		}
+	})
+
+	t.Run("not at ledger root", func(t *testing.T) {
+		dir := CodeDBSharedDir("repo123", "https://sageox.ai")
+		ledgerRoot := LedgersDataDir("repo123", "https://sageox.ai")
+		badPath := filepath.Join(ledgerRoot, "codedb")
+		if dir == badPath {
+			t.Errorf("CodeDBSharedDir() = %q, must not be at ledger root", dir)
+		}
+	})
+
+	t.Run("empty inputs return empty", func(t *testing.T) {
+		if dir := CodeDBSharedDir("", "https://sageox.ai"); dir != "" {
+			t.Errorf("CodeDBSharedDir('', endpoint) = %q, want empty", dir)
+		}
+		if dir := CodeDBSharedDir("repo123", ""); dir != "" {
+			t.Errorf("CodeDBSharedDir(repo, '') = %q, want empty", dir)
+		}
+	})
+}
+
 func TestDaemonPaths(t *testing.T) {
 	saved := saveEnv("OX_XDG_ENABLE")
 	defer restoreEnv(saved)


### PR DESCRIPTION
## Problem

codedb (SQLite + Bleve indexes) was incorrectly stored at the ledger git repo root, causing it to be committed when `ox doctor` ran `git add -A`. Per project conventions, local-only derived data should live in `ledger/.sageox/cache/<feature>/`.

## Solution

- **CodeDBSharedDir**: Now returns `ledger/.sageox/cache/codedb` instead of `ledger/codedb` (protected by existing `.sageox/.gitignore`)
- **Pre-commit guard**: Untracks and deletes legacy root-level `codedb/` to prevent `git add -A` from re-staging it (safe because codedb is a rebuildable index)
- **Daemon startup**: Cleans up legacy `codedb/` directory before using new path
- **Tests**: Added regression tests for both the path and cleanup behavior

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically removes legacy cache files and prevents code database directories from being tracked in Git repositories, ensuring cleaner repository state and proper file organization.

* **Tests**
  * Added regression test to verify proper cleanup of legacy cache artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->