### PR TITLE
fix: prevent wrong team context selection in multi-team repos

### DIFF
--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -187,12 +187,11 @@ func ResolveConfigValue(key string, projectRoot string) (*ConfigValue, error) {
 		repoCfg, _ = config.LoadProjectConfig(projectRoot)
 	}
 
-	// load team config
+	// load team config (repo's own team, not cross-team)
 	var teamCfg *config.TeamConfig
 	if projectRoot != "" {
-		localCfg, _ := config.LoadLocalConfig(projectRoot)
-		if localCfg != nil && len(localCfg.TeamContexts) > 0 {
-			teamCfg, _ = config.LoadTeamConfig(localCfg.TeamContexts[0].Path)
+		if tc := config.FindRepoTeamContext(projectRoot); tc != nil {
+			teamCfg, _ = config.LoadTeamConfig(tc.Path)
 		}
 	}
 
@@ -404,12 +403,12 @@ func setTeamConfig(key, value, projectRoot string) error {
 		return fmt.Errorf("not in a SageOx project")
 	}
 
-	localCfg, err := config.LoadLocalConfig(projectRoot)
-	if err != nil || len(localCfg.TeamContexts) == 0 {
+	tc := config.FindRepoTeamContext(projectRoot)
+	if tc == nil {
 		return fmt.Errorf("no team context configured")
 	}
 
-	teamPath := localCfg.TeamContexts[0].Path
+	teamPath := tc.Path
 	cfg, err := config.LoadTeamConfig(teamPath)
 	if err != nil {
 		cfg = &config.TeamConfig{}

--- a/internal/config/local_config.go
+++ b/internal/config/local_config.go
@@ -41,6 +41,7 @@ const (
 // global daemon, which would eliminate the multi-writer locking problem.
 type LocalConfig struct {
 	Ledger       *LedgerConfig `toml:"ledger,omitempty"`
+	// TeamContexts lists all teams for this user — use FindRepoTeamContext() to get the repo's own team.
 	TeamContexts []TeamContext `toml:"team_contexts,omitempty"`
 }
 
@@ -372,7 +373,7 @@ func (c *LocalConfig) RemoveTeamContext(teamID string) {
 
 // FindRepoTeamContext returns the team context that belongs to this repo's team.
 // Loads ProjectConfig.TeamID and matches it against LocalConfig.TeamContexts.
-// Falls back to the first configured team context if no match is found.
+// Returns nil if no match is found (never guesses a cross-team context).
 //
 // If no team contexts are configured in config.local.toml (daemon hasn't synced yet),
 // falls back to computing the expected path from config.json's team_id + endpoint.
@@ -386,10 +387,6 @@ func FindRepoTeamContext(projectRoot string) *TeamContext {
 
 	projectCfg, err := LoadProjectConfig(projectRoot)
 	if err != nil || projectCfg == nil {
-		// no project config — can only use local config entries
-		if len(localCfg.TeamContexts) > 0 {
-			return &localCfg.TeamContexts[0]
-		}
 		return nil
 	}
 
@@ -398,11 +395,6 @@ func FindRepoTeamContext(projectRoot string) *TeamContext {
 		if tc := localCfg.GetTeamContext(projectCfg.TeamID); tc != nil {
 			return tc
 		}
-	}
-
-	// fallback: any configured team context
-	if len(localCfg.TeamContexts) > 0 {
-		return &localCfg.TeamContexts[0]
 	}
 
 	// fallback: compute path from config.json team_id + endpoint (no daemon needed)

--- a/internal/config/local_config_test.go
+++ b/internal/config/local_config_test.go
@@ -674,6 +674,65 @@ func TestFindRepoTeamContext_NoProjectConfig(t *testing.T) {
 	assert.Nil(t, tc, "expected nil with no project config and no local config")
 }
 
+func TestFindRepoTeamContext_MultiTeam_MatchesCorrect(t *testing.T) {
+	// regression: with multiple teams in config.local.toml, must return the
+	// repo's own team (by ProjectConfig.TeamID), not TeamContexts[0]
+	tmpDir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+		TeamID:   "team_abc",
+		TeamName: "Team ABC",
+		Endpoint: "https://sageox.ai",
+	})
+	localCfg := &LocalConfig{
+		TeamContexts: []TeamContext{
+			{TeamID: "team_xyz", TeamName: "Team XYZ", Path: "/path/xyz"},
+			{TeamID: "team_abc", TeamName: "Team ABC", Path: "/path/abc"},
+			{TeamID: "team_def", TeamName: "Team DEF", Path: "/path/def"},
+		},
+	}
+	require.NoError(t, SaveLocalConfig(tmpDir, localCfg))
+
+	tc := FindRepoTeamContext(tmpDir)
+	require.NotNil(t, tc, "expected team context for repo's team")
+	assert.Equal(t, "team_abc", tc.TeamID, "must return repo's own team, not TeamContexts[0]")
+	assert.Equal(t, "/path/abc", tc.Path)
+}
+
+func TestFindRepoTeamContext_MultiTeam_NoMatchReturnsNil(t *testing.T) {
+	// regression: when repo's TeamID doesn't match any local config entry and
+	// no computed-path dir exists, must return nil — never return TeamContexts[0]
+	tmpDir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+		TeamID:   "team_missing",
+		TeamName: "Missing Team",
+		Endpoint: "https://sageox.ai",
+	})
+	localCfg := &LocalConfig{
+		TeamContexts: []TeamContext{
+			{TeamID: "team_xyz", TeamName: "Team XYZ", Path: "/path/xyz"},
+			{TeamID: "team_def", TeamName: "Team DEF", Path: "/path/def"},
+		},
+	}
+	require.NoError(t, SaveLocalConfig(tmpDir, localCfg))
+
+	tc := FindRepoTeamContext(tmpDir)
+	assert.Nil(t, tc, "must return nil when repo's team not found, not a random team")
+}
+
+func TestFindRepoTeamContext_NoProjectConfig_WithTeams_ReturnsNil(t *testing.T) {
+	// regression: with no config.json but teams in config.local.toml,
+	// must return nil — never guess from TeamContexts[0]
+	tmpDir := CreateInitializedProject(t)
+	localCfg := &LocalConfig{
+		TeamContexts: []TeamContext{
+			{TeamID: "team_xyz", TeamName: "Team XYZ", Path: "/path/xyz"},
+			{TeamID: "team_abc", TeamName: "Team ABC", Path: "/path/abc"},
+		},
+	}
+	require.NoError(t, SaveLocalConfig(tmpDir, localCfg))
+
+	tc := FindRepoTeamContext(tmpDir)
+	assert.Nil(t, tc, "must return nil without project config, not TeamContexts[0]")
+}
+
 // -----------------------------------------------------------------------------
 // Team Symlink Tests
 // -----------------------------------------------------------------------------

--- a/internal/config/session_recording.go
+++ b/internal/config/session_recording.go
@@ -159,14 +159,8 @@ func ResolveSessionRecording(projectRoot string) *ResolvedSessionRecording {
 // Checks for config.toml in the team context directory.
 // Returns empty string if no team context or no setting configured.
 func loadTeamSessionRecording(projectRoot string) string {
-	localCfg, err := LoadLocalConfig(projectRoot)
-	if err != nil || len(localCfg.TeamContexts) == 0 {
-		return ""
-	}
-
-	// use the first configured team context
-	tc := localCfg.TeamContexts[0]
-	if tc.Path == "" {
+	tc := FindRepoTeamContext(projectRoot)
+	if tc == nil || tc.Path == "" {
 		return ""
 	}
 


### PR DESCRIPTION
## Problem

Five locations used `TeamContexts[0]` (arbitrary first team) instead of matching against `ProjectConfig.TeamID`. For repos with multiple associated teams, this caused session observations, memories, config reads/writes, and session recording settings to silently target the wrong team.

## Changes

- **`FindRepoTeamContext()`**: Removed two `TeamContexts[0]` fallbacks; now returns `nil` instead of guessing
- **`loadTeamSessionRecording()`**: Use `FindRepoTeamContext()` instead of direct `[0]` access
- **`ResolveConfigValue()`**: Use `FindRepoTeamContext()` for team config reads
- **`setTeamConfig()`**: Use `FindRepoTeamContext()` for team config writes
- **Type comment**: Added inline comment on `TeamContexts` field to prevent future misuse

All 13 callers already handle `nil` correctly. Regression tests cover multi-team scenarios.

## Testing

- All 6,552 tests pass (1 pre-existing flaky test)
- 0 lint issues
- 7 `FindRepoTeamContext` tests including 3 new regression tests

Co-Authored-By: SageOx <ox@sageox.ai>