### PR TITLE
test: E2E coworker discovery via real Claude instance

### DIFF
--- a/tests/integration/agents/claude/coworker_discovery_test.go
+++ b/tests/integration/agents/claude/coworker_discovery_test.go
@@ -181,7 +181,9 @@ func setupRealTeamContext(t *testing.T, env *common.TestEnvironment) {
 			"GIT_COMMITTER_NAME=Test",
 			"GIT_COMMITTER_EMAIL=test@test.com",
 		)
-		cmd.CombinedOutput()
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("failed to stage team context files: %v\n%s", err, output)
+		}
 		cmd = exec.Command("git", "commit", "--allow-empty", "-m", "init")
 		cmd.Dir = destTeamPath
 		cmd.Env = append(os.Environ(),
@@ -190,7 +192,9 @@ func setupRealTeamContext(t *testing.T, env *common.TestEnvironment) {
 			"GIT_COMMITTER_NAME=Test",
 			"GIT_COMMITTER_EMAIL=test@test.com",
 		)
-		cmd.CombinedOutput()
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("failed to create initial commit in team context: %v\n%s", err, output)
+		}
 	}
 
 	// Patch project config.json to include the real team_id
@@ -224,13 +228,17 @@ func setupRealTeamContext(t *testing.T, env *common.TestEnvironment) {
 func findRealTeamContextPath(t *testing.T) string {
 	t.Helper()
 
-	// Standard XDG path for the real team context
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skipf("cannot determine home dir: %v", err)
+	// Resolve via XDG_DATA_HOME (respects custom XDG config), fallback to ~/.local/share
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skipf("cannot determine home dir: %v", err)
+		}
+		dataHome = filepath.Join(home, ".local", "share")
 	}
 
-	teamPath := filepath.Join(home, ".local", "share", "sageox", "sageox.ai", "teams", "team_jihjpfkt8b")
+	teamPath := filepath.Join(dataHome, "sageox", "sageox.ai", "teams", "team_jihjpfkt8b")
 
 	if _, err := os.Stat(teamPath); os.IsNotExist(err) {
 		t.Skipf("real team context not found at %s — requires ox to be synced on this machine", teamPath)


### PR DESCRIPTION
## Summary

Add integration test `TestCoworkerDiscovery_OSSReleaseEngineer` that verifies a real Claude Code process discovers and loads the `oss-release-engineer` coworker from the SageOx team context. The test uses the actual team context synced to disk (team_jihjpfkt8b) instead of mocks, validating the full coworker discovery pipeline: ox prime → coworker list → Claude recognition → coworker load.

## Test Plan

Run the test with:
```bash
go test -tags=integration -timeout=5m -run TestCoworkerDiscovery ./tests/integration/agents/claude/ -v
```

Expects: Claude discovers the oss-release-engineer agent and loads it via `ox coworker load`, evidenced by tool use, name mentions, or release-engineer-specific content (GoReleaser, Homebrew tap, Cosign, SBOM) in the response.

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for Claude's coworker discovery capability, verifying successful identification and loading of designated team members and proper contextual understanding through tool usage and content analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->