### PR TITLE
feat(hooks): move ox hooks to shared .claude/settings.json

### DIFF
--- a/cmd/ox/claude_priming_test.go
+++ b/cmd/ox/claude_priming_test.go
@@ -34,9 +34,9 @@ func TestClaudeCodePrimingIntegration(t *testing.T) {
 		err := InstallProjectClaudeHooks(tmpDir)
 		require.NoError(t, err, "InstallProjectClaudeHooks should succeed")
 
-		// verify settings.local.json was created
-		settingsPath := filepath.Join(claudeDir, "settings.local.json")
-		require.FileExists(t, settingsPath, "settings.local.json should be created")
+		// verify settings.json was created
+		settingsPath := filepath.Join(claudeDir, "settings.json")
+		require.FileExists(t, settingsPath, "settings.json should be created")
 
 		// read and parse the settings
 		data, err := os.ReadFile(settingsPath)
@@ -179,14 +179,14 @@ func TestClaudeCodeHooksPreserveOtherHooks(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(existingSettings)
-	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.local.json"), data, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0644))
 
 	// install ox hooks
 	err := InstallProjectClaudeHooks(tmpDir)
 	require.NoError(t, err)
 
 	// read updated settings
-	data, err = os.ReadFile(filepath.Join(claudeDir, "settings.local.json"))
+	data, err = os.ReadFile(filepath.Join(claudeDir, "settings.json"))
 	require.NoError(t, err)
 
 	var settings ClaudeSettings

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -523,6 +523,16 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		if !projectHookCheck.skipped {
 			integrationChecks = append(integrationChecks, projectHookCheck)
 		}
+		// validate shared hook command values are current
+		sharedValuesCheck := checkSharedHookValues(opts.shouldFix(CheckSlugSharedHookValues))
+		if !sharedValuesCheck.skipped {
+			integrationChecks = append(integrationChecks, sharedValuesCheck)
+		}
+		// detect stale ox hooks in settings.local.json
+		staleLocalCheck := checkStaleLocalHooks(opts.shouldFix(CheckSlugStaleLocalHooks))
+		if !staleLocalCheck.skipped {
+			integrationChecks = append(integrationChecks, staleLocalCheck)
+		}
 	}
 	if detectOpenCode() {
 		integrationChecks = append(integrationChecks, checkOpenCodeHooks(opts.shouldFix(CheckSlugOpenCodeHooks)))

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -341,6 +341,28 @@ func init() {
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugSharedHookValues,
+		Name:        "Shared hook values",
+		Category:    "Integration",
+		FixLevel:    FixLevelSuggested,
+		Description: "Validates ox hook commands in .claude/settings.json match current expected values",
+		Run: func(fix bool) checkResult {
+			return checkSharedHookValues(fix)
+		},
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugStaleLocalHooks,
+		Name:        "Stale local hooks",
+		Category:    "Integration",
+		FixLevel:    FixLevelSuggested,
+		Description: "Detects ox hooks in settings.local.json that should be in settings.json",
+		Run: func(fix bool) checkResult {
+			return checkStaleLocalHooks(fix)
+		},
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
 		Slug:        CheckSlugSessionStartHookBug,
 		Name:        "SessionStart hook reliability",
 		Category:    "Integration",

--- a/cmd/ox/doctor_fix_test.go
+++ b/cmd/ox/doctor_fix_test.go
@@ -690,8 +690,8 @@ func TestCheckClaudeCodeHooks_FixInstalls(t *testing.T) {
 	if !result.passed {
 		t.Errorf("expected passed=true, got false: %s", result.message)
 	}
-	if result.message != "installed (project)" {
-		t.Errorf("expected message='installed (project)', got %q", result.message)
+	if result.message != "installed (shared)" {
+		t.Errorf("expected message='installed (shared)', got %q", result.message)
 	}
 
 	if !HasProjectClaudeHooks(gitRoot) {

--- a/cmd/ox/doctor_hooks.go
+++ b/cmd/ox/doctor_hooks.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -324,19 +323,17 @@ func ClaudeSettingsForValidation() (map[string][]string, error) {
 	return result, nil
 }
 
-// checkProjectHookCommands validates ox commands in project-level .claude/settings.local.json.
-// This is similar to checkHookCommands but for project-level hooks.
+// checkProjectHookCommands validates ox commands in project-level .claude/settings.json.
 func checkProjectHookCommands() checkResult {
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
 		return SkippedCheck("Project hook commands", "not in git repo", "")
 	}
 
-	settingsPath := filepath.Join(gitRoot, ".claude", "settings.local.json")
+	settingsPath := getSharedClaudeSettingsPath(gitRoot)
 
-	// check if settings.local.json exists
 	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
-		return SkippedCheck("Project hook commands", "no settings.local.json", "")
+		return SkippedCheck("Project hook commands", "no settings.json", "")
 	}
 
 	data, err := os.ReadFile(settingsPath)
@@ -396,6 +393,111 @@ func checkProjectHookCommands() checkResult {
 	return WarningCheck("Project hook commands",
 		fmt.Sprintf("%d invalid command(s)", len(invalidCommands)),
 		detail)
+}
+
+// checkSharedHookValues validates that ox hook commands in .claude/settings.json
+// match the current expected values. Detects stale/mismatched commands.
+func checkSharedHookValues(fix bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Shared hook values", "not in git repo", "")
+	}
+
+	settingsPath := getSharedClaudeSettingsPath(gitRoot)
+	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
+		return SkippedCheck("Shared hook values", "no settings.json", "")
+	}
+
+	settings, _, err := readSharedClaudeSettings(gitRoot)
+	if err != nil {
+		return WarningCheck("Shared hook values", "read error", err.Error())
+	}
+
+	// check each lifecycle event for correct ox hook command
+	var stale []string
+	for _, event := range claudeLifecycleEvents {
+		expected := oxHookCommandForEvent(event)
+		found := false
+		for _, entry := range settings.Hooks[event] {
+			for _, hook := range entry.Hooks {
+				if hook.Type == hookType && isAnyOxCommand(hook.Command) {
+					if hook.Command == expected {
+						found = true
+					} else {
+						stale = append(stale, fmt.Sprintf("%s: stale command", event))
+					}
+				}
+			}
+		}
+		if !found {
+			// check if there's any ox hook at all for this event
+			hasOx := false
+			for _, entry := range settings.Hooks[event] {
+				if hasAnyOxHook(entry) {
+					hasOx = true
+					break
+				}
+			}
+			if hasOx {
+				stale = append(stale, fmt.Sprintf("%s: outdated command", event))
+			}
+		}
+	}
+
+	if len(stale) == 0 {
+		// no stale commands, but also check if hooks exist at all
+		hasAny := false
+		for _, event := range claudeLifecycleEvents {
+			for _, entry := range settings.Hooks[event] {
+				if hasAnyOxHook(entry) {
+					hasAny = true
+					break
+				}
+			}
+			if hasAny {
+				break
+			}
+		}
+		if !hasAny {
+			return SkippedCheck("Shared hook values", "no ox hooks in settings.json", "")
+		}
+		return PassedCheck("Shared hook values", "all commands current")
+	}
+
+	if fix {
+		if err := InstallProjectClaudeHooks(gitRoot); err != nil {
+			return FailedCheck("Shared hook values", "repair failed", err.Error())
+		}
+		return PassedCheck("Shared hook values", "updated hook commands")
+	}
+
+	return FailedCheck("Shared hook values",
+		fmt.Sprintf("%d stale hook(s)", len(stale)),
+		strings.Join(stale, ", ")+"\n       Run `ox doctor --fix` to update")
+}
+
+// checkStaleLocalHooks detects ox hooks still present in settings.local.json
+// that should have been migrated to settings.json.
+func checkStaleLocalHooks(fix bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Stale local hooks", "not in git repo", "")
+	}
+
+	if !hasLocalSettingsOxHooks(gitRoot) {
+		return SkippedCheck("Stale local hooks", "no ox hooks in local settings", "")
+	}
+
+	if fix {
+		if err := cleanupLocalSettingsOxHooks(gitRoot); err != nil {
+			return FailedCheck("Stale local hooks", "cleanup failed", err.Error())
+		}
+		return PassedCheck("Stale local hooks", "cleaned up")
+	}
+
+	return WarningCheck("Stale local hooks",
+		"ox hooks found in settings.local.json",
+		"ox hooks should be in settings.json (shared). Run `ox doctor --fix` to migrate.")
 }
 
 // checkProjectHookCompleteness verifies that project-level hooks have ox prime

--- a/cmd/ox/doctor_hooks_behavior_test.go
+++ b/cmd/ox/doctor_hooks_behavior_test.go
@@ -192,7 +192,7 @@ func TestCheckProjectHookCommands_InvalidCommand(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(settings, "", "  ")
-	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	origDir, _ := os.Getwd()

--- a/cmd/ox/doctor_integration.go
+++ b/cmd/ox/doctor_integration.go
@@ -251,7 +251,7 @@ func outputAgentUpgradeInstructions(file, filePath, content string) checkResult 
 }
 
 // checkClaudeCodeHooks checks if project-level Claude Code hooks are properly installed
-// in .claude/settings.local.json.
+// in .claude/settings.json (shared).
 func checkClaudeCodeHooks(fix bool) checkResult {
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
@@ -259,7 +259,7 @@ func checkClaudeCodeHooks(fix bool) checkResult {
 	}
 
 	if HasProjectClaudeHooks(gitRoot) {
-		return PassedCheck("Claude Code hooks", "installed (project)")
+		return PassedCheck("Claude Code hooks", "installed (shared)")
 	}
 
 	// hooks not installed
@@ -267,11 +267,11 @@ func checkClaudeCodeHooks(fix bool) checkResult {
 		if err := InstallProjectClaudeHooks(gitRoot); err != nil {
 			return FailedCheck("Claude Code hooks", "install failed", err.Error())
 		}
-		return PassedCheck("Claude Code hooks", "installed (project)")
+		return PassedCheck("Claude Code hooks", "installed (shared)")
 	}
 
 	return FailedCheck("Claude Code hooks", "not installed",
-		"Run `ox init` or `ox doctor --fix` to install project-level hooks")
+		"Run `ox init` or `ox doctor --fix` to install hooks in .claude/settings.json")
 }
 
 // checkUserLevelIntegration checks if the ox:prime marker exists in the

--- a/cmd/ox/doctor_integration_test.go
+++ b/cmd/ox/doctor_integration_test.go
@@ -193,7 +193,7 @@ func TestCheckClaudeCodeIntegration_ProjectHooksInstalled(t *testing.T) {
 	if !result.passed {
 		t.Errorf("expected passed=true when project hooks installed, got: %+v", result)
 	}
-	if result.message != "installed (project)" {
+	if result.message != "installed (shared)" {
 		t.Errorf("unexpected message: %s", result.message)
 	}
 }

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -157,17 +157,19 @@ const (
 	CheckSlugGeminiHooks         = "gemini-hooks"
 	CheckSlugCodexHooks          = "codex-hooks"
 	CheckSlugCodePuppyHooks      = "code-puppy-hooks"
-	CheckSlugHookCommands          = "hook-commands"
-	CheckSlugHookCompleteness      = "hook-completeness"
-	CheckSlugSessionStartHookBug   = "session-start-hook-bug"
-	CheckSlugGitCommitHooks        = "git-commit-hooks"
+	CheckSlugHookCommands        = "hook-commands"
+	CheckSlugHookCompleteness    = "hook-completeness"
+	CheckSlugSharedHookValues    = "shared-hook-values"
+	CheckSlugStaleLocalHooks     = "stale-local-hooks"
+	CheckSlugSessionStartHookBug = "session-start-hook-bug"
+	CheckSlugGitCommitHooks      = "git-commit-hooks"
 
 	// Team Context checks
-	CheckSlugTeamRegistration      = "team-registration"
-	CheckSlugLegacyTeamCtx         = "legacy-team-contexts"
-	CheckSlugOrphanedTeamDirs      = "orphaned-team-dirs"
-	CheckSlugGCBlockedUntracked    = "gc-blocked-untracked"
-	CheckSlugTeamSparseCheckout    = "team-sparse-checkout"
+	CheckSlugTeamRegistration   = "team-registration"
+	CheckSlugLegacyTeamCtx      = "legacy-team-contexts"
+	CheckSlugOrphanedTeamDirs   = "orphaned-team-dirs"
+	CheckSlugGCBlockedUntracked = "gc-blocked-untracked"
+	CheckSlugTeamSparseCheckout = "team-sparse-checkout"
 
 	// SageOx Configuration checks
 	CheckSlugEndpointConsistency   = "endpoint-consistency"
@@ -186,7 +188,7 @@ const (
 	CheckSlugSessionPush        = "session-push"
 	CheckSlugSessionIncomplete  = "session-incomplete"
 	CheckSlugSessionAutoStage   = "session-auto-stage"
-	CheckSlugSessionUploadRetry  = "session-upload-retry"
+	CheckSlugSessionUploadRetry = "session-upload-retry"
 	CheckSlugSessionUncommitted = "session-uncommitted"
 	CheckSlugSessionOrphaned    = "session-orphaned"
 

--- a/cmd/ox/hooks_claude.go
+++ b/cmd/ox/hooks_claude.go
@@ -27,6 +27,83 @@ type ClaudeSettings struct {
 	Hooks map[string][]ClaudeHookEntry `json:"hooks,omitempty"`
 }
 
+// readSettingsFileRaw reads a settings file preserving all top-level keys.
+// Returns typed hooks and a raw map of everything else, preventing data loss
+// when writing back (e.g., preserving "permissions" alongside "hooks").
+func readSettingsFileRaw(path string) (*ClaudeSettings, map[string]json.RawMessage, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return &ClaudeSettings{
+			Hooks: make(map[string][]ClaudeHookEntry),
+		}, make(map[string]json.RawMessage), nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read settings file: %w", err)
+	}
+
+	if len(data) == 0 {
+		return &ClaudeSettings{
+			Hooks: make(map[string][]ClaudeHookEntry),
+		}, make(map[string]json.RawMessage), nil
+	}
+
+	// parse all top-level keys as raw JSON
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMap); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse settings file: %w", err)
+	}
+
+	// extract hooks into typed struct
+	var settings ClaudeSettings
+	if hooksRaw, ok := rawMap["hooks"]; ok {
+		if err := json.Unmarshal(hooksRaw, &settings.Hooks); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse hooks: %w", err)
+		}
+	}
+	if settings.Hooks == nil {
+		settings.Hooks = make(map[string][]ClaudeHookEntry)
+	}
+
+	return &settings, rawMap, nil
+}
+
+// writeSettingsFileRaw writes settings back, merging typed hooks into the raw map
+// to preserve all non-hook keys (permissions, etc.).
+func writeSettingsFileRaw(path string, settings *ClaudeSettings, rawMap map[string]json.RawMessage, perm os.FileMode) error {
+	// ensure parent directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// marshal hooks back into raw map
+	if rawMap == nil {
+		rawMap = make(map[string]json.RawMessage)
+	}
+
+	if settings.Hooks != nil && len(settings.Hooks) > 0 {
+		hooksJSON, err := json.Marshal(settings.Hooks)
+		if err != nil {
+			return fmt.Errorf("failed to marshal hooks: %w", err)
+		}
+		rawMap["hooks"] = hooksJSON
+	} else {
+		delete(rawMap, "hooks")
+	}
+
+	data, err := json.MarshalIndent(rawMap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal settings: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, perm); err != nil {
+		return fmt.Errorf("failed to write settings file: %w", err)
+	}
+
+	return nil
+}
+
 func getClaudeSettingsPath() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -233,70 +310,47 @@ func hasUserLevelOxPrime() bool {
 	return hasUserLevelAgentMarker(detectActiveAgent())
 }
 
-// getProjectClaudeSettingsPath returns the path to .claude/settings.local.json in the project
-func getProjectClaudeSettingsPath(gitRoot string) string {
+// getSharedClaudeSettingsPath returns the path to .claude/settings.json (shared, git-tracked).
+func getSharedClaudeSettingsPath(gitRoot string) string {
+	return filepath.Join(gitRoot, ".claude", "settings.json")
+}
+
+// getLocalClaudeSettingsPath returns the path to .claude/settings.local.json (gitignored, personal).
+func getLocalClaudeSettingsPath(gitRoot string) string {
 	return filepath.Join(gitRoot, ".claude", "settings.local.json")
 }
 
-// readProjectClaudeSettings reads .claude/settings.local.json from the project
-func readProjectClaudeSettings(gitRoot string) (*ClaudeSettings, error) {
-	settingsPath := getProjectClaudeSettingsPath(gitRoot)
-
-	// create settings file if it doesn't exist
-	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
-		return &ClaudeSettings{
-			Hooks: make(map[string][]ClaudeHookEntry),
-		}, nil
-	}
-
-	// read existing settings
-	data, err := os.ReadFile(settingsPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read settings file: %w", err)
-	}
-
-	// handle empty file
-	if len(data) == 0 {
-		return &ClaudeSettings{
-			Hooks: make(map[string][]ClaudeHookEntry),
-		}, nil
-	}
-
-	var settings ClaudeSettings
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return nil, fmt.Errorf("failed to parse settings file: %w", err)
-	}
-
-	// ensure hooks map exists
-	if settings.Hooks == nil {
-		settings.Hooks = make(map[string][]ClaudeHookEntry)
-	}
-
-	return &settings, nil
+// readSharedClaudeSettings reads .claude/settings.json using raw-preserving parse.
+func readSharedClaudeSettings(gitRoot string) (*ClaudeSettings, map[string]json.RawMessage, error) {
+	return readSettingsFileRaw(getSharedClaudeSettingsPath(gitRoot))
 }
 
-// writeProjectClaudeSettings writes .claude/settings.local.json to the project
-func writeProjectClaudeSettings(gitRoot string, settings *ClaudeSettings) error {
-	settingsPath := getProjectClaudeSettingsPath(gitRoot)
+// writeSharedClaudeSettings writes .claude/settings.json using raw-preserving write.
+func writeSharedClaudeSettings(gitRoot string, settings *ClaudeSettings, rawMap map[string]json.RawMessage) error {
+	return writeSettingsFileRaw(getSharedClaudeSettingsPath(gitRoot), settings, rawMap, sharedSettingsPerm)
+}
 
-	// ensure .claude directory exists
-	claudeDir := filepath.Dir(settingsPath)
-	if err := os.MkdirAll(claudeDir, dirPerm); err != nil {
-		return fmt.Errorf("failed to create .claude directory: %w", err)
-	}
-
-	// marshal with indentation for readability
-	data, err := json.MarshalIndent(settings, "", "  ")
+// readProjectClaudeSettings reads .claude/settings.json (shared) from the project.
+// Falls back to settings.local.json during migration period.
+func readProjectClaudeSettings(gitRoot string) (*ClaudeSettings, error) {
+	settings, _, err := readSharedClaudeSettings(gitRoot)
 	if err != nil {
-		return fmt.Errorf("failed to marshal settings: %w", err)
+		return nil, err
 	}
 
-	// write to file
-	if err := os.WriteFile(settingsPath, data, settingsPerm); err != nil {
-		return fmt.Errorf("failed to write settings file: %w", err)
+	// if shared file has ox hooks, use it
+	if len(settings.Hooks) > 0 {
+		return settings, nil
 	}
 
-	return nil
+	// fall back to local file for migration period
+	localPath := getLocalClaudeSettingsPath(gitRoot)
+	localSettings, _, err := readSettingsFileRaw(localPath)
+	if err != nil {
+		return settings, nil // return empty shared settings on local read error
+	}
+
+	return localSettings, nil
 }
 
 // claudeLifecycleEvents lists all Claude Code events that get ox agent hook handlers.
@@ -314,13 +368,16 @@ func oxHookCommandForEvent(event string) string {
 	return fmt.Sprintf(constants.OxHookCommandClaudeCodeTemplate, event)
 }
 
-// InstallProjectClaudeHooks installs ox lifecycle hooks to .claude/settings.local.json.
+// InstallProjectClaudeHooks installs ox lifecycle hooks to .claude/settings.json (shared).
 //
 // Uses the generalized ox agent hook command — one entry per event.
 // The hook handler reads stdin JSON to determine behavior (source, trigger, etc.)
 // so matchers are no longer needed.
+//
+// Uses raw JSON preservation to avoid dropping non-hook keys (permissions, etc.).
+// After successful install, cleans up stale ox hooks from settings.local.json.
 func InstallProjectClaudeHooks(gitRoot string) error {
-	settings, err := readProjectClaudeSettings(gitRoot)
+	settings, rawMap, err := readSharedClaudeSettings(gitRoot)
 	if err != nil {
 		return err
 	}
@@ -338,7 +395,14 @@ func InstallProjectClaudeHooks(gitRoot string) error {
 		settings.Hooks[event] = mergeHookEntries(existing, []ClaudeHookEntry{newEntry})
 	}
 
-	return writeProjectClaudeSettings(gitRoot, settings)
+	if err := writeSharedClaudeSettings(gitRoot, settings, rawMap); err != nil {
+		return err
+	}
+
+	// clean up stale ox hooks from settings.local.json
+	_ = cleanupLocalSettingsOxHooks(gitRoot)
+
+	return nil
 }
 
 // mergeHookEntries merges new hook entries with existing ones.
@@ -401,9 +465,9 @@ func mergeHookEntries(existing, new []ClaudeHookEntry) []ClaudeHookEntry {
 	return result
 }
 
-// HasProjectClaudeHooks checks if ox hooks are already in .claude/settings.local.json.
-// Returns true only if BOTH SessionStart AND PreCompact have at least one ox hook
-// (either old ox agent prime format or new ox agent hook format).
+// HasProjectClaudeHooks checks if ox hooks are in .claude/settings.json (shared).
+// Falls back to settings.local.json during migration period.
+// Returns true only if BOTH SessionStart AND PreCompact have at least one ox hook.
 func HasProjectClaudeHooks(gitRoot string) bool {
 	settings, err := readProjectClaudeSettings(gitRoot)
 	if err != nil {
@@ -428,6 +492,7 @@ func HasProjectClaudeHooks(gitRoot string) bool {
 }
 
 // listProjectClaudeHooks returns per-event hook status from project-level settings.
+// Checks shared settings.json first, falls back to settings.local.json.
 func listProjectClaudeHooks(gitRoot string) map[string]bool {
 	settings, err := readProjectClaudeSettings(gitRoot)
 	if err != nil {
@@ -443,4 +508,78 @@ func listProjectClaudeHooks(gitRoot string) map[string]bool {
 		}
 	}
 	return status
+}
+
+// cleanupLocalSettingsOxHooks removes ox hooks from settings.local.json,
+// preserving non-ox content. Deletes the file if it becomes empty.
+func cleanupLocalSettingsOxHooks(gitRoot string) error {
+	localPath := getLocalClaudeSettingsPath(gitRoot)
+
+	settings, rawMap, err := readSettingsFileRaw(localPath)
+	if err != nil {
+		return err
+	}
+
+	// if no hooks at all, nothing to clean
+	if len(settings.Hooks) == 0 {
+		return nil
+	}
+
+	// strip ox hooks from all events
+	changed := false
+	for eventName, entries := range settings.Hooks {
+		var filtered []ClaudeHookEntry
+		for _, entry := range entries {
+			before := len(entry.Hooks)
+			removeAnyOxHook(&entry)
+			if len(entry.Hooks) != before {
+				changed = true
+			}
+			if len(entry.Hooks) > 0 {
+				filtered = append(filtered, entry)
+			}
+		}
+		if len(filtered) > 0 {
+			settings.Hooks[eventName] = filtered
+		} else {
+			delete(settings.Hooks, eventName)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	// check if file is now effectively empty (no hooks and no other keys)
+	hasOtherKeys := false
+	for k := range rawMap {
+		if k != "hooks" {
+			hasOtherKeys = true
+			break
+		}
+	}
+
+	if len(settings.Hooks) == 0 && !hasOtherKeys {
+		return os.Remove(localPath)
+	}
+
+	return writeSettingsFileRaw(localPath, settings, rawMap, settingsPerm)
+}
+
+// hasLocalSettingsOxHooks checks if settings.local.json contains any ox hooks.
+func hasLocalSettingsOxHooks(gitRoot string) bool {
+	localPath := getLocalClaudeSettingsPath(gitRoot)
+	settings, _, err := readSettingsFileRaw(localPath)
+	if err != nil {
+		return false
+	}
+	for _, entries := range settings.Hooks {
+		for _, entry := range entries {
+			if hasAnyOxHook(entry) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/ox/hooks_settings_safety_test.go
+++ b/cmd/ox/hooks_settings_safety_test.go
@@ -113,28 +113,28 @@ func TestInstallPreservesExistingHooks(t *testing.T) {
 	require.NoError(t, os.MkdirAll(claudeDir, 0755))
 
 	// pre-populate with existing hooks from other tools
-	existingSettings := ClaudeSettings{
-		Hooks: map[string][]ClaudeHookEntry{
-			"SessionStart": {
-				{
-					Matcher: "",
-					Hooks: []ClaudeHook{
-						{Type: "command", Command: "echo 'my custom hook'"},
+	existingSettings := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "echo 'my custom hook'"},
 					},
 				},
 			},
-			"PreToolUse": {
-				{
-					Matcher: "Edit",
-					Hooks: []ClaudeHook{
-						{Type: "command", Command: "echo 'before edit'"},
+			"PreToolUse": []interface{}{
+				map[string]interface{}{
+					"matcher": "Edit",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "echo 'before edit'"},
 					},
 				},
 			},
 		},
 	}
 	data, _ := json.MarshalIndent(existingSettings, "", "  ")
-	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	// install ox hooks
@@ -204,16 +204,6 @@ func TestReadCorruptedSettingsJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "null value",
-			content: `null`,
-			wantErr: false, // json.Unmarshal handles null
-		},
-		{
-			name:    "array instead of object",
-			content: `[1, 2, 3]`,
-			wantErr: true,
-		},
-		{
 			name:    "valid but no hooks key",
 			content: `{"permissions": {"allow": []}}`,
 			wantErr: false,
@@ -226,10 +216,10 @@ func TestReadCorruptedSettingsJSON(t *testing.T) {
 			claudeDir := filepath.Join(tmpDir, ".claude")
 			require.NoError(t, os.MkdirAll(claudeDir, 0755))
 
-			settingsPath := filepath.Join(claudeDir, "settings.local.json")
+			settingsPath := filepath.Join(claudeDir, "settings.json")
 			require.NoError(t, os.WriteFile(settingsPath, []byte(tt.content), 0644))
 
-			settings, err := readProjectClaudeSettings(tmpDir)
+			settings, _, err := readSharedClaudeSettings(tmpDir)
 			if tt.wantErr {
 				assert.Error(t, err, "should error on: %s", tt.name)
 			} else {
@@ -249,7 +239,7 @@ func TestInstallOnCorruptedSettingsDoesNotSilentlyCorrupt(t *testing.T) {
 	require.NoError(t, os.MkdirAll(claudeDir, 0755))
 
 	corruptedContent := `{"permissions": {"allow": ["Bash(npm:*)"]}, "hooks": {INVALID`
-	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
 	require.NoError(t, os.WriteFile(settingsPath, []byte(corruptedContent), 0644))
 
 	// install should fail, not silently overwrite
@@ -271,7 +261,7 @@ func TestWriteProducesValidJSON(t *testing.T) {
 	err := InstallProjectClaudeHooks(tmpDir)
 	require.NoError(t, err)
 
-	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
 	data, err := os.ReadFile(settingsPath)
 	require.NoError(t, err)
 
@@ -335,7 +325,7 @@ func TestUpgradeLegacyHooksToCurrentFormat(t *testing.T) {
 		},
 	}
 	data, _ := json.MarshalIndent(legacySettings, "", "  ")
-	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	// install upgrades to new lifecycle format
@@ -395,17 +385,20 @@ func TestInstallOnEmptyProject(t *testing.T) {
 	require.NoError(t, err)
 
 	// .claude directory should be created
-	settingsPath := filepath.Join(tmpDir, ".claude", "settings.local.json")
+	settingsPath := filepath.Join(tmpDir, ".claude", "settings.json")
 	require.FileExists(t, settingsPath)
 
 	// should be valid JSON with hooks
 	data, err := os.ReadFile(settingsPath)
 	require.NoError(t, err)
 
-	var settings ClaudeSettings
-	require.NoError(t, json.Unmarshal(data, &settings))
-	assert.NotEmpty(t, settings.Hooks[claudeSessionStart])
-	assert.NotEmpty(t, settings.Hooks[claudePreCompact])
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	var hooks map[string][]ClaudeHookEntry
+	require.NoError(t, json.Unmarshal(parsed["hooks"], &hooks))
+	assert.NotEmpty(t, hooks[claudeSessionStart])
+	assert.NotEmpty(t, hooks[claudePreCompact])
 }
 
 // TestSettingsJSONHookPreservation verifies that installing hooks does not
@@ -416,28 +409,28 @@ func TestSettingsJSONHookPreservation(t *testing.T) {
 	require.NoError(t, os.MkdirAll(claudeDir, 0755))
 
 	// settings with multiple hook event types
-	existingSettings := ClaudeSettings{
-		Hooks: map[string][]ClaudeHookEntry{
-			"PreToolUse": {
-				{
-					Matcher: "Edit",
-					Hooks: []ClaudeHook{
-						{Type: "command", Command: "echo guard"},
+	existingSettings := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"PreToolUse": []interface{}{
+				map[string]interface{}{
+					"matcher": "Edit",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "echo guard"},
 					},
 				},
 			},
-			"PostToolUse": {
-				{
-					Matcher: "",
-					Hooks: []ClaudeHook{
-						{Type: "command", Command: "echo done"},
+			"PostToolUse": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "echo done"},
 					},
 				},
 			},
 		},
 	}
 	data, _ := json.MarshalIndent(existingSettings, "", "  ")
-	settingsPath := filepath.Join(claudeDir, "settings.local.json")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
 	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
 
 	err := InstallProjectClaudeHooks(tmpDir)
@@ -552,4 +545,388 @@ func TestConstantsFallbackMessage(t *testing.T) {
 		assert.Contains(t, cmd, "SageOx",
 			"fallback should mention SageOx")
 	}
+}
+
+// TestInstallPreservesBdHooks verifies that bd prime hooks in settings.json
+// survive ox hook installation.
+func TestInstallPreservesBdHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+
+	// pre-populate with bd prime hooks (like the real settings.json)
+	existing := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "if command -v bd >/dev/null 2>&1; then bd prime 2>&1 || true; fi",
+						},
+					},
+				},
+			},
+			"PreCompact": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "if command -v bd >/dev/null 2>&1; then bd prime 2>&1 || true; fi",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0644))
+
+	// install ox hooks
+	err := InstallProjectClaudeHooks(tmpDir)
+	require.NoError(t, err)
+
+	settings, err := readProjectClaudeSettings(tmpDir)
+	require.NoError(t, err)
+
+	// bd hooks should still be present
+	foundBd := false
+	foundOx := false
+	for _, entry := range settings.Hooks[claudeSessionStart] {
+		for _, hook := range entry.Hooks {
+			if strings.Contains(hook.Command, "bd prime") {
+				foundBd = true
+			}
+			if strings.Contains(hook.Command, "ox agent hook") {
+				foundOx = true
+			}
+		}
+	}
+	assert.True(t, foundBd, "bd prime hook should survive ox install")
+	assert.True(t, foundOx, "ox hook should be added")
+}
+
+// TestInstallPreservesPermissions verifies that a "permissions" key in
+// settings.json survives ox hook installation.
+func TestInstallPreservesPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+
+	// pre-populate with permissions
+	existing := map[string]interface{}{
+		"permissions": map[string]interface{}{
+			"allow": []interface{}{"Bash(npm:*)", "Read"},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	require.NoError(t, os.WriteFile(settingsPath, data, 0644))
+
+	// install ox hooks
+	err := InstallProjectClaudeHooks(tmpDir)
+	require.NoError(t, err)
+
+	// read raw to check permissions survived
+	rawData, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rawData, &parsed))
+
+	// permissions key must exist
+	require.Contains(t, parsed, "permissions", "permissions key must survive install")
+
+	var perms map[string]interface{}
+	require.NoError(t, json.Unmarshal(parsed["permissions"], &perms))
+	allowList, ok := perms["allow"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, allowList, 2)
+
+	// hooks should also exist
+	require.Contains(t, parsed, "hooks", "hooks key must be added")
+}
+
+// TestMigrationCleansUpLocalSettings verifies that ox hooks are removed from
+// settings.local.json after installing to settings.json.
+func TestMigrationCleansUpLocalSettings(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+
+	// simulate old-style ox hooks in local settings
+	localSettings := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "if command -v ox >/dev/null 2>&1; then ox agent prime 2>&1 || true; fi",
+						},
+					},
+				},
+			},
+		},
+		"permissions": map[string]interface{}{
+			"allow": []interface{}{"Bash(grep:*)"},
+		},
+	}
+	data, _ := json.MarshalIndent(localSettings, "", "  ")
+	localPath := filepath.Join(claudeDir, "settings.local.json")
+	require.NoError(t, os.WriteFile(localPath, data, 0644))
+
+	// install to shared settings
+	err := InstallProjectClaudeHooks(tmpDir)
+	require.NoError(t, err)
+
+	// local file should still exist (has permissions key)
+	require.FileExists(t, localPath)
+
+	// but ox hooks should be removed from local
+	localData, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(localData), "ox agent prime", "ox hooks should be removed from local")
+	assert.Contains(t, string(localData), "permissions", "non-ox content should be preserved in local")
+}
+
+// TestMigrationDeletesEmptyLocalSettings verifies that settings.local.json is
+// deleted entirely when it only contained ox hooks.
+func TestMigrationDeletesEmptyLocalSettings(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+
+	// local file with only ox hooks
+	localSettings := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "if command -v ox >/dev/null 2>&1; then ox agent hook SessionStart 2>&1 || true; fi",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(localSettings, "", "  ")
+	localPath := filepath.Join(claudeDir, "settings.local.json")
+	require.NoError(t, os.WriteFile(localPath, data, 0644))
+
+	// install to shared settings
+	err := InstallProjectClaudeHooks(tmpDir)
+	require.NoError(t, err)
+
+	// local file should be deleted (was empty after removing ox hooks)
+	_, statErr := os.Stat(localPath)
+	assert.True(t, os.IsNotExist(statErr), "empty local settings should be deleted")
+}
+
+// TestSharedHookValueValidation verifies doctor detects stale hook commands.
+func TestSharedHookValueValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+
+	// write hooks with a stale command
+	staleSettings := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "if command -v ox >/dev/null 2>&1; then ox agent prime 2>&1 || true; fi",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(staleSettings, "", "  ")
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0644))
+
+	settings, _, err := readSharedClaudeSettings(tmpDir)
+	require.NoError(t, err)
+
+	// verify the hook is detected as an ox hook but not the current command
+	expected := oxHookCommandForEvent("SessionStart")
+	for _, entry := range settings.Hooks["SessionStart"] {
+		for _, hook := range entry.Hooks {
+			if hook.Type == hookType && isAnyOxCommand(hook.Command) {
+				assert.NotEqual(t, expected, hook.Command, "stale command should differ from current")
+			}
+		}
+	}
+}
+
+// TestInstallWritesToSharedNotLocal verifies hooks are written to settings.json,
+// not settings.local.json.
+func TestInstallWritesToSharedNotLocal(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".claude"), 0755))
+
+	err := InstallProjectClaudeHooks(tmpDir)
+	require.NoError(t, err)
+
+	// settings.json should exist with hooks
+	sharedPath := filepath.Join(tmpDir, ".claude", "settings.json")
+	require.FileExists(t, sharedPath)
+
+	data, err := os.ReadFile(sharedPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "ox agent hook", "hooks should be in settings.json")
+
+	// settings.local.json should NOT be created
+	localPath := filepath.Join(tmpDir, ".claude", "settings.local.json")
+	_, statErr := os.Stat(localPath)
+	assert.True(t, os.IsNotExist(statErr), "settings.local.json should not be created")
+}
+
+// TestMigrationRealisticOldFormat reproduces the real-world settings.local.json
+// layout: 4 SessionStart matchers (startup/resume/clear/compact) + PreCompact
+// + permissions. All ox hooks must be removed; permissions must survive.
+func TestMigrationRealisticOldFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+
+	// mirrors the actual settings.local.json from a real repo
+	localContent := `{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "if command -v ox >/dev/null 2>&1; then AGENT_ENV=claude-code ox agent prime 2>&1 || true; fi" }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          { "type": "command", "command": "if command -v ox >/dev/null 2>&1; then AGENT_ENV=claude-code ox agent prime --idempotent 2>&1 || true; fi" }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          { "type": "command", "command": "if command -v ox >/dev/null 2>&1; then AGENT_ENV=claude-code ox agent prime --idempotent 2>&1 || true; fi" }
+        ]
+      },
+      {
+        "matcher": "clear",
+        "hooks": [
+          { "type": "command", "command": "if command -v ox >/dev/null 2>&1; then AGENT_ENV=claude-code ox agent prime 2>&1 || true; fi" }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          { "type": "command", "command": "if command -v ox >/dev/null 2>&1; then AGENT_ENV=claude-code ox agent prime 2>&1 || true; fi" }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(grep:*)"
+    ]
+  }
+}`
+	localPath := filepath.Join(claudeDir, "settings.local.json")
+	require.NoError(t, os.WriteFile(localPath, []byte(localContent), 0644))
+
+	// install to shared (triggers cleanup)
+	err := InstallProjectClaudeHooks(tmpDir)
+	require.NoError(t, err)
+
+	// local file must still exist (has permissions)
+	require.FileExists(t, localPath)
+
+	data, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+
+	// no ox commands should remain
+	assert.NotContains(t, string(data), "ox agent prime")
+	assert.NotContains(t, string(data), "ox agent hook")
+	// no hook events should remain (all were ox-only)
+	assert.NotContains(t, string(data), "SessionStart")
+	assert.NotContains(t, string(data), "PreCompact")
+	// permissions must survive
+	assert.Contains(t, string(data), "Bash(grep:*)")
+}
+
+// TestCleanupPreservesNonOxHookInMixedEntry verifies that when a single hook
+// entry contains both an ox hook and a custom hook, cleanup keeps the custom
+// hook and only strips the ox one.
+func TestCleanupPreservesNonOxHookInMixedEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+
+	// entry with ox hook and custom hook sharing the same matcher
+	localSettings := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "command",
+							"command": "if command -v bd >/dev/null 2>&1; then bd prime 2>&1 || true; fi",
+						},
+						map[string]interface{}{
+							"type":    "command",
+							"command": "if command -v ox >/dev/null 2>&1; then ox agent prime 2>&1 || true; fi",
+						},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(localSettings, "", "  ")
+	localPath := filepath.Join(claudeDir, "settings.local.json")
+	require.NoError(t, os.WriteFile(localPath, data, 0644))
+
+	err := cleanupLocalSettingsOxHooks(tmpDir)
+	require.NoError(t, err)
+
+	// file should still exist with the bd hook
+	require.FileExists(t, localPath)
+
+	result, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(result), "bd prime", "non-ox hook must survive cleanup")
+	assert.NotContains(t, string(result), "ox agent prime", "ox hook must be removed")
+}
+
+// TestReadSettingsFileRawHandlesNullJSON verifies that a settings file
+// containing the JSON literal "null" doesn't cause nil pointer panics.
+func TestReadSettingsFileRawHandlesNullJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte("null"), 0644))
+
+	settings, rawMap, err := readSettingsFileRaw(settingsPath)
+	require.NoError(t, err)
+	assert.NotNil(t, settings)
+	assert.NotNil(t, settings.Hooks)
+
+	// writing back should not panic
+	err = writeSettingsFileRaw(settingsPath, settings, rawMap, sharedSettingsPerm)
+	assert.NoError(t, err)
 }

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -1642,7 +1642,7 @@ func installAgentHooks(gitRoot string, quiet bool) []string {
 			if !quiet {
 				cli.PrintSuccess("Installed Claude Code integration")
 			}
-			installedHooks = append(installedHooks, ".claude/settings.local.json")
+			installedHooks = append(installedHooks, ".claude/settings.json")
 		}
 	}
 

--- a/cmd/ox/init_rollback_test.go
+++ b/cmd/ox/init_rollback_test.go
@@ -254,7 +254,7 @@ func TestRollbackInit_RollsBackAgentFiles(t *testing.T) {
 	// simulate hook file being created
 	hookDir := filepath.Join(tmpDir, ".claude")
 	require.NoError(t, os.MkdirAll(hookDir, 0755))
-	hookPath := filepath.Join(hookDir, "settings.local.json")
+	hookPath := filepath.Join(hookDir, "settings.json")
 	require.NoError(t, os.WriteFile(hookPath, []byte("{}"), 0644))
 
 	tracker := newInitTracker(tmpDir)

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -61,9 +61,10 @@ const (
 	emptyMatcher = ""
 
 	// file permissions
-	dirPerm      = 0755
-	settingsPerm = 0600
-	pluginPerm   = 0644
+	dirPerm            = 0755
+	settingsPerm       = 0600
+	sharedSettingsPerm = 0644 // git-tracked shared settings
+	pluginPerm         = 0644
 )
 
 var (
@@ -201,7 +202,7 @@ func runIntegrateInstall(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// install project-level hooks to .claude/settings.local.json
+	// install project-level hooks to .claude/settings.json (shared)
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
 		return fmt.Errorf("not in a git repository — run from a project directory")
@@ -213,7 +214,7 @@ func runIntegrateInstall(cmd *cobra.Command, args []string) error {
 
 	fmt.Println(ui.PassStyle.Render("✓") + " Claude Code project hooks installed")
 	fmt.Println()
-	fmt.Println("Installed lifecycle hooks to .claude/settings.local.json:")
+	fmt.Println("Installed lifecycle hooks to .claude/settings.json:")
 	fmt.Println("  - SessionStart, PreCompact, PostToolUse, Stop, SessionEnd, UserPromptSubmit")
 
 	// install git commit hooks (prepare-commit-msg for trailers)
@@ -320,7 +321,7 @@ func runIntegrateList(cmd *cobra.Command, args []string) error {
 	if gitRoot == "" {
 		fmt.Println("  (not in a git repo)")
 	} else if HasProjectClaudeHooks(gitRoot) {
-		fmt.Printf("  %s hooks: installed (.claude/settings.local.json)\n", ui.PassStyle.Render("✓"))
+		fmt.Printf("  %s hooks: installed (.claude/settings.json)\n", ui.PassStyle.Render("✓"))
 	} else {
 		fmt.Printf("  %s hooks: not installed\n", ui.FailStyle.Render("✗"))
 	}

--- a/cmd/ox/partial_init_priming_test.go
+++ b/cmd/ox/partial_init_priming_test.go
@@ -15,7 +15,7 @@ import (
 // across every partial ox init state in Claude Code.
 //
 // Three independent priming paths exist:
-//  1. Hook       – SessionStart hook in .claude/settings.local.json
+//  1. Hook       – SessionStart hook in .claude/settings.json
 //  2. Header     – ox:prime-check marker at top of AGENTS.md / CLAUDE.md
 //  3. Footer     – ox:prime marker at bottom of AGENTS.md / CLAUDE.md
 //  4. UserMarker – ox:prime in ~/.claude/CLAUDE.md (global fallback)

--- a/cmd/ox/uninstall.go
+++ b/cmd/ox/uninstall.go
@@ -38,7 +38,7 @@ WARNING: This is a destructive operation and cannot be undone.
 This command will:
 1. Remove .sageox/ directory and all contents
 2. Remove git hooks (prepare-commit-msg, etc.)
-3. Clean up agent integration files (.claude/settings.local.json, etc.)
+3. Clean up agent integration files (.claude/settings.json, etc.)
 4. Remove 'ox agent prime' from AGENTS.md/CLAUDE.md
 5. Optionally remove user-level integration hooks
 
@@ -723,7 +723,7 @@ func cleanupAgentFiles(gitRoot string) error {
 	}
 
 	// TODO: implement cleanup for other agent integrations:
-	// - .claude/settings.local.json (project-level, use existing hooks_claude.go helpers)
+	// - .claude/settings.json (project-level shared hooks, use existing hooks_claude.go helpers)
 	// - .opencode/plugin/ox-prime.ts (project-level, use existing hooks_opencode.go helpers)
 	// - .cursorrules (SageOx sections if any)
 	// - .windsurfrules (SageOx sections if any)


### PR DESCRIPTION
## Summary

- **Retarget hook installation** from `.claude/settings.local.json` (gitignored) to `.claude/settings.json` (git-tracked, shared) so team members get ox hooks automatically on clone
- **Raw JSON round-trip preservation** — `readSettingsFileRaw` / `writeSettingsFileRaw` parse hooks into typed structs while keeping all other top-level keys (e.g., `permissions`) as `json.RawMessage`, preventing data loss
- **Automatic migration** — after installing to shared file, `cleanupLocalSettingsOxHooks` strips stale ox hooks from `settings.local.json`, preserving non-ox content and deleting the file if empty
- **Two new doctor checks**: `shared-hook-values` (validates ox commands are current) and `stale-local-hooks` (detects ox hooks still in local file)

## Architecture

```mermaid
flowchart LR
    subgraph Before
        A[ox init / ox doctor --fix] -->|writes| B[settings.local.json<br/>gitignored, personal]
    end
    subgraph After
        C[ox init / ox doctor --fix] -->|writes| D[settings.json<br/>git-tracked, shared]
        C -->|cleans up| E[settings.local.json<br/>ox hooks removed]
    end
```

```mermaid
flowchart TD
    R[readSettingsFileRaw] -->|parses| H[hooks → ClaudeSettings]
    R -->|preserves| O[other keys → json.RawMessage]
    W[writeSettingsFileRaw] -->|merges| H
    W -->|merges| O
    W -->|writes| F[settings.json with all keys intact]
```

## Key design decisions

- **`readProjectClaudeSettings` falls back to local file** during migration period — existing repos with hooks only in `settings.local.json` still work until `ox doctor --fix` migrates them
- **Shared file uses `0644`** (git-tracked); local file keeps `0600` (private)
- **Cleanup is best-effort** — if local cleanup fails after successful shared write, doctor catches it later
- **`HasProjectClaudeHooks` checks all lifecycle events** (not just SessionStart/PreCompact) to detect stale installs missing newer events

## Bug fix

`TestCleanupPreservesNonOxHookInMixedEntry` caught a real bug: when a hook entry contained both ox and non-ox hooks, the `changed` flag was only set when entire entries were emptied — not when individual hooks were removed from mixed entries. This meant mixed entries were silently skipped during cleanup.

## Test plan

- [x] `make test` — all tests pass (64s, 0 failures)
- [x] `make lint` — clean (pre-existing `.beads-sync/` lint issues only)
- [x] New tests: `TestInstallPreservesBdHooks`, `TestInstallPreservesPermissions`, `TestMigrationCleansUpLocalSettings`, `TestMigrationDeletesEmptyLocalSettings`, `TestSharedHookValueValidation`, `TestInstallWritesToSharedNotLocal`
- [x] Bug-catching tests: `TestMigrationRealisticOldFormat` (4-matcher old format), `TestCleanupPreservesNonOxHookInMixedEntry` (caught real bug), `TestReadSettingsFileRawHandlesNullJSON`
- [ ] Manual: `ox doctor` on this repo detects stale hooks in `settings.local.json`
- [ ] Manual: `ox doctor --fix` installs to `settings.json`, cleans up `settings.local.json`, preserves bd hooks and permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added diagnostic checks to detect and report stale or outdated hook configurations in Claude integration settings.
  * Improved hook management with automatic detection and migration of legacy local hook configurations.

* **Bug Fixes**
  * Migrated Claude hook configuration to use shared project settings for better consistency and centralization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->