### PR TITLE
fix(query): team context search never executed due to stale source check

### DIFF
--- a/cmd/ox/agent_query.go
+++ b/cmd/ox/agent_query.go
@@ -175,11 +175,11 @@ func executeQuery(qa *queryArgs, agentID string, agentType string) (int, error) 
 
 	combined := &combinedQueryResponse{}
 
-	// query team context if source is "all" or "teamctx"
-	if qa.source == "all" || qa.source == "teamctx" {
+	// query team context if source is "all" or "team"
+	if qa.source == "all" || qa.source == "team" {
 		resp, err := queryTeamContext(qa, projectRoot, agentID, agentType)
 		if err != nil {
-			if qa.source == "teamctx" {
+			if qa.source == "team" {
 				return 0, fmt.Errorf("team context query failed: %w", err)
 			}
 			slog.Warn("team context query failed, continuing with code search", "error", err)


### PR DESCRIPTION
## Summary

- **`ox agent <id> query` and `ox query` silently skipped team context search**, returning empty `{}` for every query
- Root cause: PR #170 (`330a169`) renamed source values from `"teamctx"` → `"team"` in `parseQueryArgs()` normalization and validation, but didn't update the routing condition in `executeQuery()` — so the default source `"team"` never matched the stale `"teamctx"` check

## Fix

Two-line change in `executeQuery()`: replace `"teamctx"` with `"team"` in the source routing condition (line 179) and error handling (line 182).

## Test plan

- [x] `go test ./cmd/ox/ -run Query` passes
- [x] Manual: `ox agent <id> query slack --verbose` now shows `POST /api/v1/query` call and returns results

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for team context queries to provide more consistent behavior when queries fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->