### PR TITLE
fix(daemon): use errors.Is() for GC lock error checking

### DIFF
--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -2620,6 +2620,9 @@ const (
 func acquireGCLock(lockPath string) (*os.File, error) {
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
 	if err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("gc lock create failed: %w", err)
+		}
 		// lock file exists — check if stale (>5 min old = likely crashed process)
 		if info, statErr := os.Stat(lockPath); statErr == nil {
 			if time.Since(info.ModTime()) > 5*time.Minute {


### PR DESCRIPTION
## Summary

Fixes incorrect error handling in `acquireGCLock` that assumed all `O_CREATE|O_EXCL` failures meant the file already exists. Now properly distinguishes file-exists errors from permission denied, disk full, and other filesystem errors.

## Details

The `acquireGCLock` function was entering the stale-lock recovery path for all errors, potentially removing lock files it doesn't own and returning misleading error messages. Now uses `errors.Is(err, os.ErrExist)` to check specifically for file-exists, returning immediately for other filesystem errors.

Addresses code review feedback on PR #220 and adheres to project Go conventions.

Fixes #217, Fixes #218, Fixes #219

Co-Authored-By: SageOx <ox@sageox.ai>