### PR TITLE
feat(session): ledger support for session removal

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,19 +1,77 @@
 {
   "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=claude-code ox agent hook PostToolUse 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
     "PreCompact": [
       {
-        "matcher": "",
         "hooks": [
-          { "type": "command", "command": "if command -v bd >/dev/null 2>&1; then bd prime 2>&1 || true; else echo '{\"sageox\": {\"notice\": \"This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.\"}}'; fi" }
-        ]
+          {
+            "command": "if command -v bd \u003e/dev/null 2\u003e\u00261; then bd prime 2\u003e\u00261 || true; else echo '{\"sageox\": {\"notice\": \"This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.\"}}'; fi",
+            "type": "command"
+          },
+          {
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=claude-code ox agent hook PreCompact 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=claude-code ox agent hook SessionEnd 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "SessionStart": [
       {
-        "matcher": "",
         "hooks": [
-          { "type": "command", "command": "if command -v bd >/dev/null 2>&1; then bd prime 2>&1 || true; else echo '{\"sageox\": {\"notice\": \"This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.\"}}'; fi" }
-        ]
+          {
+            "command": "if command -v bd \u003e/dev/null 2\u003e\u00261; then bd prime 2\u003e\u00261 || true; else echo '{\"sageox\": {\"notice\": \"This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.\"}}'; fi",
+            "type": "command"
+          },
+          {
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=claude-code ox agent hook SessionStart 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=claude-code ox agent hook Stop 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=claude-code ox agent hook UserPromptSubmit 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ]
   }

--- a/cmd/ox/hooks_claude.go
+++ b/cmd/ox/hooks_claude.go
@@ -82,7 +82,7 @@ func writeSettingsFileRaw(path string, settings *ClaudeSettings, rawMap map[stri
 		rawMap = make(map[string]json.RawMessage)
 	}
 
-	if settings.Hooks != nil && len(settings.Hooks) > 0 {
+	if len(settings.Hooks) > 0 {
 		hooksJSON, err := json.Marshal(settings.Hooks)
 		if err != nil {
 			return fmt.Errorf("failed to marshal hooks: %w", err)

--- a/cmd/ox/session_remove.go
+++ b/cmd/ox/session_remove.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/sageox/ox/internal/cli"
@@ -12,19 +15,19 @@ import (
 var sessionRemoveCmd = &cobra.Command{
 	Use:   "remove <filename>",
 	Short: "Remove a session",
-	Long: `Remove a session from the local cache.
+	Long: `Remove a session from the local cache or ledger.
 
 The filename can be a full filename or a partial match.
 Use 'ox session list' to see available sessions.
 
-This removes the session from local storage. If the session
-has already been committed to the ledger, you may need to
-remove it there separately.
+Searches both local cache and ledger for matching sessions.
+Ledger removal requires --force or interactive confirmation
+since it affects all coworkers.
 
 Examples:
   ox session remove 2026-01-05T10-30-ryan-Oxa7b3.jsonl
   ox session remove Oxa7b3    # partial match by agent ID
-  ox session remove --all     # remove all sessions (with confirmation)`,
+  ox session remove --all     # remove all local sessions (with confirmation)`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runSessionRemove,
 }
@@ -38,8 +41,16 @@ Examples:
 
 func init() {
 	sessionCmd.AddCommand(sessionRemoveCmd)
-	sessionRemoveCmd.Flags().Bool("all", false, "Remove all sessions (requires confirmation)")
+	sessionRemoveCmd.Flags().Bool("all", false, "Remove all local sessions (requires confirmation)")
 	sessionRemoveCmd.Flags().Bool("force", false, "Skip confirmation prompts")
+}
+
+// sessionMatch tracks where a matching session was found.
+type sessionMatch struct {
+	info       session.SessionInfo
+	isLocal    bool
+	isLedger   bool
+	ledgerPath string
 }
 
 func runSessionRemove(cmd *cobra.Command, args []string) error {
@@ -62,7 +73,8 @@ func runSessionRemove(cmd *cobra.Command, args []string) error {
 	return removeSessionByPattern(store, args[0], force)
 }
 
-// removeAllSessions removes all sessions with confirmation
+// removeAllSessions removes all local sessions with confirmation.
+// Does not touch ledger sessions — use pattern matching for that.
 func removeAllSessions(store *session.Store, force bool) error {
 	sessions, err := store.ListSessions()
 	if err != nil {
@@ -76,7 +88,7 @@ func removeAllSessions(store *session.Store, force bool) error {
 
 	// confirm unless force flag is set
 	if !force {
-		if !cli.ConfirmYesNo(fmt.Sprintf("This will remove %d session(s). Continue?", len(sessions)), false) {
+		if !cli.ConfirmYesNo(fmt.Sprintf("This will remove %d local session(s). Continue?", len(sessions)), false) {
 			fmt.Println("Canceled.")
 			return nil
 		}
@@ -95,57 +107,254 @@ func removeAllSessions(store *session.Store, force bool) error {
 	return nil
 }
 
-// removeSessionByPattern removes sessions matching the pattern
+// removeSessionByPattern removes sessions matching the pattern from local cache and/or ledger.
 func removeSessionByPattern(store *session.Store, pattern string, force bool) error {
-	sessions, err := store.ListSessions()
+	// search local sessions
+	localSessions, err := store.ListAllSessions()
 	if err != nil {
 		return fmt.Errorf("failed to list sessions: %w", err)
 	}
 
-	// find matching sessions
-	var matches []session.SessionInfo
-	for _, t := range sessions {
-		if strings.Contains(t.Filename, pattern) {
-			matches = append(matches, t)
+	// build matches map keyed by session name
+	matchMap := make(map[string]*sessionMatch)
+	for _, t := range localSessions {
+		name := t.SessionName
+		if name == "" {
+			name = t.Filename
 		}
+		if strings.Contains(name, pattern) {
+			matchMap[name] = &sessionMatch{
+				info:    t,
+				isLocal: true,
+			}
+		}
+	}
+
+	// search ledger sessions
+	ledgerPath, ledgerErr := resolveLedgerPath()
+	if ledgerErr == nil {
+		ledgerStore, storeErr := session.NewStore(ledgerPath)
+		if storeErr == nil {
+			ledgerSessions, listErr := ledgerStore.ListAllSessions()
+			if listErr != nil {
+				slog.Debug("list_ledger_sessions", "err", listErr)
+			}
+			for _, ls := range ledgerSessions {
+				name := ls.SessionName
+				if name == "" {
+					name = ls.Filename
+				}
+				if !strings.Contains(name, pattern) {
+					continue
+				}
+				if existing, ok := matchMap[name]; ok {
+					existing.isLedger = true
+					existing.ledgerPath = ledgerPath
+				} else {
+					matchMap[name] = &sessionMatch{
+						info:       ls,
+						isLedger:   true,
+						ledgerPath: ledgerPath,
+					}
+				}
+			}
+		} else {
+			slog.Debug("skip_ledger_search", "err", storeErr)
+		}
+	} else {
+		slog.Debug("ledger_unavailable", "err", ledgerErr)
+	}
+
+	// convert to slice
+	var matches []*sessionMatch
+	for _, m := range matchMap {
+		matches = append(matches, m)
 	}
 
 	if len(matches) == 0 {
 		return fmt.Errorf("no sessions found matching %q\nRun 'ox session list' to see available sessions", pattern)
 	}
 
+	// separate local-only and ledger matches for different confirmation flows
+	hasLedger := false
+	for _, m := range matches {
+		if m.isLedger {
+			hasLedger = true
+			break
+		}
+	}
+
 	// if multiple matches, show them and ask user to be more specific
 	if len(matches) > 1 && !force {
 		fmt.Printf("Multiple sessions match %q:\n", pattern)
 		for _, m := range matches {
-			fmt.Printf("  %s (%s)\n", m.Filename, m.Type)
+			name := matchName(m)
+			location := locationLabel(m)
+			fmt.Printf("  %s  %s\n", name, cli.StyleDim.Render(location))
 		}
 		fmt.Println("\nPlease provide a more specific pattern or use --force to remove all matches.")
 		return nil
 	}
 
-	// confirm unless force flag is set
-	if !force && len(matches) == 1 {
-		if !cli.ConfirmYesNo(fmt.Sprintf("Remove %s?", matches[0].Filename), false) {
+	// always show what will be removed when using --force with multiple matches
+	if force && len(matches) > 1 {
+		fmt.Printf("Removing %d sessions matching %q:\n", len(matches), pattern)
+		for _, m := range matches {
+			fmt.Printf("  %s  %s\n", matchName(m), cli.StyleDim.Render(locationLabel(m)))
+		}
+	}
+
+	// ledger deletions always require explicit confirmation (--force or interactive)
+	if hasLedger && !force {
+		var ledgerNames []string
+		for _, m := range matches {
+			if m.isLedger {
+				ledgerNames = append(ledgerNames, matchName(m))
+			}
+		}
+		prompt := fmt.Sprintf("Remove %s from ledger? This affects all coworkers and cannot be undone", strings.Join(ledgerNames, ", "))
+		if !cli.ConfirmYesNo(prompt, false) {
+			fmt.Println("Canceled.")
+			return nil
+		}
+	} else if !force && !hasLedger {
+		// local-only single match confirmation
+		if !cli.ConfirmYesNo(fmt.Sprintf("Remove %s?", matchName(matches[0])), false) {
 			fmt.Println("Canceled.")
 			return nil
 		}
 	}
 
-	var removed int
+	// delete from local cache
+	var localRemoved int
 	for _, m := range matches {
-		if err := store.Delete(m.Filename); err != nil {
-			fmt.Printf("  Warning: failed to remove %s: %v\n", m.Filename, err)
+		if !m.isLocal {
+			continue
+		}
+		name := matchName(m)
+		if err := store.Delete(name); err != nil {
+			fmt.Printf("  Warning: failed to remove %s locally: %v\n", name, err)
 		} else {
-			removed++
+			localRemoved++
 		}
 	}
 
-	if removed == 1 {
-		cli.PrintSuccess(fmt.Sprintf("Removed %s", matches[0].Filename))
+	// batch-delete from ledger: collect all session names, single commit + push
+	var ledgerRemoved int
+	if hasLedger {
+		var ledgerSessionNames []string
+		var ledgerBase string
+		for _, m := range matches {
+			if m.isLedger {
+				ledgerSessionNames = append(ledgerSessionNames, matchName(m))
+				ledgerBase = m.ledgerPath
+			}
+		}
+		if len(ledgerSessionNames) > 0 {
+			removed, err := batchDeleteSessionsFromLedger(ledgerBase, ledgerSessionNames)
+			ledgerRemoved = removed
+			if err != nil {
+				fmt.Printf("  Warning: ledger removal error: %v\n", err)
+			}
+		}
+	}
+
+	// print summary
+	total := localRemoved + ledgerRemoved
+	if total == 0 {
+		return fmt.Errorf("failed to remove any sessions")
+	}
+
+	if len(matches) == 1 {
+		location := removedLocationLabel(localRemoved > 0, ledgerRemoved > 0)
+		cli.PrintSuccess(fmt.Sprintf("Removed %s %s", matchName(matches[0]), location))
 	} else {
-		cli.PrintSuccess(fmt.Sprintf("Removed %d session(s)", removed))
+		var parts []string
+		if localRemoved > 0 {
+			parts = append(parts, fmt.Sprintf("%d local", localRemoved))
+		}
+		if ledgerRemoved > 0 {
+			parts = append(parts, fmt.Sprintf("%d from ledger", ledgerRemoved))
+		}
+		cli.PrintSuccess(fmt.Sprintf("Removed %s", strings.Join(parts, ", ")))
 	}
 
 	return nil
+}
+
+// matchName returns the display name for a session match.
+func matchName(m *sessionMatch) string {
+	if m.info.SessionName != "" {
+		return m.info.SessionName
+	}
+	return m.info.Filename
+}
+
+// locationLabel returns a human-readable label for where a session exists.
+func locationLabel(m *sessionMatch) string {
+	if m.isLocal && m.isLedger {
+		return "(local + ledger)"
+	}
+	if m.isLedger {
+		return "(ledger)"
+	}
+	return "(local)"
+}
+
+// removedLocationLabel returns a label for the removal summary.
+func removedLocationLabel(local, ledger bool) string {
+	if local && ledger {
+		return "(local + ledger)"
+	}
+	if ledger {
+		return "(ledger)"
+	}
+	return "(local)"
+}
+
+// batchDeleteSessionsFromLedger removes multiple sessions from the ledger in a
+// single git commit + push. Returns the count of successfully staged removals.
+// On push failure, resets the local commit to prevent orphaned commits from
+// leaking into future git operations.
+func batchDeleteSessionsFromLedger(ledgerPath string, sessionNames []string) (int, error) {
+	var staged int
+	for _, name := range sessionNames {
+		gitRm := exec.Command("git", "rm", "-r", "--force", filepath.Join("sessions", name))
+		gitRm.Dir = ledgerPath
+		if out, err := gitRm.CombinedOutput(); err != nil {
+			slog.Warn("git_rm_session", "session", name, "err", fmt.Sprintf("%s: %v", string(out), err))
+			continue
+		}
+		staged++
+	}
+
+	if staged == 0 {
+		return 0, fmt.Errorf("no sessions could be staged for removal")
+	}
+
+	// single commit for all removals
+	commitMsg := fmt.Sprintf("session: delete %d session(s)", staged)
+	if staged == 1 {
+		commitMsg = fmt.Sprintf("session: delete %s", sessionNames[0])
+	}
+	gitCommit := exec.Command("git", "commit", "-m", commitMsg)
+	gitCommit.Dir = ledgerPath
+	if out, err := gitCommit.CombinedOutput(); err != nil {
+		return 0, fmt.Errorf("git commit: %s: %w", string(out), err)
+	}
+
+	// single push — on failure, reset to prevent orphaned commit
+	gitPush := exec.Command("git", "push")
+	gitPush.Dir = ledgerPath
+	if out, err := gitPush.CombinedOutput(); err != nil {
+		// reset the commit so it doesn't leak into future pushes
+		gitReset := exec.Command("git", "reset", "HEAD~1")
+		gitReset.Dir = ledgerPath
+		if resetOut, resetErr := gitReset.CombinedOutput(); resetErr != nil {
+			slog.Warn("git_reset_after_push_fail", "err", fmt.Sprintf("%s: %v", string(resetOut), resetErr))
+		}
+		return 0, fmt.Errorf("git push: %s: %w", string(out), err)
+	}
+
+	return staged, nil
 }

--- a/tests/integration/agents/claude/coworker_discovery_test.go
+++ b/tests/integration/agents/claude/coworker_discovery_test.go
@@ -175,7 +175,7 @@ func setupRealTeamContext(t *testing.T, env *common.TestEnvironment) {
 		}
 		cmd = exec.Command("git", "add", "-A")
 		cmd.Dir = destTeamPath
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(os.Environ(), // safe: raw git command, not ox subprocess
 			"GIT_AUTHOR_NAME=Test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=Test",
@@ -186,7 +186,7 @@ func setupRealTeamContext(t *testing.T, env *common.TestEnvironment) {
 		}
 		cmd = exec.Command("git", "commit", "--allow-empty", "-m", "init")
 		cmd.Dir = destTeamPath
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(os.Environ(), // safe: raw git command, not ox subprocess
 			"GIT_AUTHOR_NAME=Test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=Test",


### PR DESCRIPTION
## Summary

Extends `ox session remove` to search both local cache and ledger for matching sessions. Sessions found in the ledger can now be deleted directly, with explicit confirmation required since deletions affect all coworkers.

## Changes

- **session_remove.go**: Dual-source search (local + ledger) with separate confirmation flows. Ledger deletions are batch-processed in a single git commit + push. New `sessionMatch` type tracks session origin (local, ledger, or both).
- **.claude/settings.json**: Registers additional Claude Code hook events (`PostToolUse`, `SessionEnd`, `Stop`, `UserPromptSubmit`, `PreCompact`) alongside existing hooks.
- **hooks_claude.go**: Simplified nil-length check to idiomatic Go (`len(settings.Hooks) > 0` instead of `settings.Hooks != nil && len(settings.Hooks) > 0`).
- **Integration tests**: Added clarifying comments on git identity overrides in test setup.

## Test Plan

Manual testing:
- `ox session remove <pattern>` finds and removes local sessions as before
- `ox session remove <pattern>` also finds ledger sessions and requires confirmation or `--force`
- `--all` flag removes local sessions only (does not touch ledger)
- Multiple matches show location labels: `(local)`, `(ledger)`, `(local + ledger)`

Co-Authored-By: SageOx <ox@sageox.ai>