### PR TITLE
feat(insights): auto-detect agent context for JSON output and add prime hint

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -962,6 +962,10 @@ func buildGuidance(agentID, projectRoot string, teamCtx *teamContextInfo, ledger
 			Intent:  fmt.Sprintf("find/search/grep code in %s: symbols, functions, git history, file contents, diffs — PREFER over grep/ripgrep", repoSlug),
 			Command: `ox code search "<pattern>"`,
 		})
+		cmds = append(cmds, intentCommand{
+			Intent:  "recent code changes, hotspots, contention risk, open PRs/issues — use before planning multi-file changes",
+			Command: "ox code insights",
+		})
 	} else {
 		cmds = append(cmds, intentCommand{
 			Intent:  fmt.Sprintf("code search %s (not indexed yet): index first, then search code, symbols, and diffs", repoSlug),

--- a/cmd/ox/code_insights.go
+++ b/cmd/ox/code_insights.go
@@ -85,6 +85,12 @@ var codeInsightsCmd = &cobra.Command{
 		limit, _ := cmd.Flags().GetInt("limit")
 		jsonOut, _ := cmd.Flags().GetBool("json")
 
+		// auto-detect: default to JSON when called by an agent
+		agentID, _ := detectAgentContext()
+		if agentID != "" && !cmd.Flags().Changed("json") {
+			jsonOut = true
+		}
+
 		s := db.Store()
 		out := insightsOutput{}
 
@@ -113,7 +119,6 @@ var codeInsightsCmd = &cobra.Command{
 			fmt.Print(rendered)
 		}
 
-		agentID, _ := detectAgentContext()
 		if agentID != "" {
 			slog.Debug("code insights context cost", "agent_id", agentID, "bytes", outputBytes)
 			trackContextBytes(int64(outputBytes))


### PR DESCRIPTION
## Summary

Two small improvements to `ox code insights`:

1. **Auto-JSON for agents**: When an AI coworker calls `ox code insights`, automatically default to JSON output (preserving tokens) without requiring `--json` flag. Human CLI users still get styled output.
2. **Prime command hint**: Added `ox code insights` to the `ox agent prime` intent table so agents discover it when planning multi-file changes.

## Changes

- **cmd/ox/code_insights.go**: Detect agent context via `detectAgentContext()` early in `RunE`; if agent detected and `--json` not explicitly set, default to JSON output. Reuse `agentID` for context tracking.
- **cmd/ox/agent_prime.go**: Add insights command to `intentCommands` table with description: "recent code changes, hotspots, contention risk, open PRs/issues — use before planning multi-file changes"

## Test plan

- [ ] `ox code insights` from CLI shows styled human output
- [ ] `ox code insights` from agent context returns JSON
- [ ] `ox code insights --json` always returns JSON regardless of context
- [ ] `ox agent prime` includes insights command hint when codeDB index exists

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced code insights guidance that now includes detailed information on recent code changes, performance hotspots, contention risks, and the status of open pull requests and issues. Available when code indexing is enabled.

* **Improvements**
  * Automatic JSON output formatting when invoked programmatically by agents, streamlining integration scenarios and improving developer experience without requiring explicit configuration flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->