### PR TITLE
fix(session): reduce anti-entropy interval to 5m and fix ghost classification

### DIFF
--- a/internal/daemon/agentwork/manager.go
+++ b/internal/daemon/agentwork/manager.go
@@ -18,13 +18,14 @@ const (
 	// maxRecentEntries is the number of completed processes to keep for observability.
 	maxRecentEntries = 10
 	// doctorInterval is the periodic timer for running detection scans
-	// independent of sync signals. Catches time-based conditions (e.g.,
-	// stale recordings hitting the 24h threshold) that won't trigger from
-	// a sync signal alone.
-	doctorInterval = 1 * time.Hour
+	// independent of sync signals. Catches orphaned sessions, stale
+	// recordings, and other time-based conditions. Kept short (5m) because
+	// detection is cheap (directory listing + PID checks) and the daemon
+	// auto-exits after 1h idle — a long interval risks never running.
+	doctorInterval = 5 * time.Minute
 	// detectCooldown is the minimum interval between detection scans for a handler.
 	// Prevents expensive ledger scans from running on every sync signal.
-	detectCooldown = 1 * time.Hour
+	detectCooldown = 5 * time.Minute
 
 	// status constants for AgentProcess
 	statusRunning   = "running"

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -444,7 +444,7 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 			// raw.jsonl exists (hydrated or recording in progress)
 			filePath = rawPath
 			fileSize = info.Size()
-			hasRawData = info.Size() > 0
+			hasRawData = HasSubstantiveEntries(rawPath)
 			modTime = info.ModTime()
 			if createdAt.IsZero() {
 				createdAt = info.ModTime()


### PR DESCRIPTION
## Summary

Reduce anti-entropy detection interval from 1h to 5m and fix ghost session misclassification.

**Problem:** Orphaned sessions accumulate because anti-entropy runs infrequently (every 1h with 1h cooldown), and the daemon often auto-exits before the first detect cycle. Sessions with no data incorrectly show as "orphan" instead of "ghost" because the classification checks file existence rather than substantive entries.

**Changes:**
- `manager.go`: Reduce `doctorInterval` and `detectCooldown` to 5m (cheap scan: dir listing + PID checks)
- `store.go`: Use `HasSubstantiveEntries()` instead of `info.Size() > 0` so header-only files are correctly classified as ghost (no data)

**Related:** See #235 for longer-term auto-finalization options (Option C: fork detached process).

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased detection scan frequency from hourly to every 5 minutes for faster system monitoring
  * Reduced detection cooldown to every 5 minutes for more responsive detection cycles
  * Improved raw data handling to more accurately identify substantive content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->