### PR TITLE
feat(session): add migrate-lfs and resummary-batch maintenance commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,6 +431,12 @@ Always confirm with human before doing a git commit or a git push in this repo.
 - Write for humans who skim — lead with the most important change, use headings and bullets
 - **Squash merges use "PR title + description"** — the PR body becomes the squash commit message on main, so write it as the permanent record
 
+**Resolving CodeRabbit PR comments:**
+When addressing CodeRabbit review comments, after fixing the code:
+1. Reply "Fixed." to each review comment via `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies -f body="Fixed."`
+2. Resolve each thread via GraphQL: `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'`
+3. Get thread IDs from: `gh api graphql -f query='{ repository(owner: "{owner}", name: "{repo}") { pullRequest(number: {n}) { reviewThreads(first: 50) { nodes { id isResolved comments(first: 1) { nodes { databaseId path } } } } } } }'`
+
 ### Key Practices
 
 - **Simplicity**: Don't over-engineer; minimum complexity for current needs

--- a/cmd/ox/session_migrate_lfs.go
+++ b/cmd/ox/session_migrate_lfs.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/spf13/cobra"
@@ -32,28 +33,34 @@ var sessionMigrateLFSCmd = &cobra.Command{
 
 		sessionsDir := filepath.Join(ledgerPath, "sessions")
 
+		var failed []string
 		for _, sessionName := range args {
 			sessionPath := filepath.Join(sessionsDir, sessionName)
 			if _, err := os.Stat(sessionPath); os.IsNotExist(err) {
 				fmt.Fprintf(os.Stderr, "session not found: %s\n", sessionName)
+				failed = append(failed, sessionName)
 				continue
 			}
 
 			if err := migrateSessionToLFS(projectRoot, ledgerPath, sessionPath, sessionName); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to migrate %s: %v\n", sessionName, err)
+				failed = append(failed, sessionName)
 				continue
 			}
 
 			fmt.Printf("migrated %s to LFS\n", sessionName)
 		}
 
+		if len(failed) > 0 {
+			return fmt.Errorf("migrate-lfs failed for %d session(s): %s", len(failed), strings.Join(failed, ", "))
+		}
 		return nil
 	},
 }
 
 func migrateSessionToLFS(projectRoot, ledgerPath, sessionPath, sessionName string) error {
 	// check if already migrated (all content files are pointers)
-	contentFiles := []string{ledgerFileRaw, ledgerFileSummaryMD, ledgerFileSessionMD, ledgerFileHTML}
+	contentFiles := []string{ledgerFileRaw, ledgerFileSummaryMD, ledgerFileSessionMD, ledgerFileHTML, ledgerFilePlan}
 	allPointers := true
 	hasContent := false
 	for _, name := range contentFiles {

--- a/cmd/ox/session_resummary_batch.go
+++ b/cmd/ox/session_resummary_batch.go
@@ -53,6 +53,15 @@ func runSessionHydrateLFS(cmd *cobra.Command, args []string) error {
 		sessionPath := filepath.Join(sessionsDir, sessionName)
 		rawPath := filepath.Join(sessionPath, ledgerFileRaw)
 
+		if _, err := os.Stat(sessionPath); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "%s: session not found\n", sessionName)
+			continue
+		}
+		if _, err := os.Stat(rawPath); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "%s: missing %s\n", sessionName, ledgerFileRaw)
+			continue
+		}
+
 		if !lfs.IsPointerFile(rawPath) {
 			fmt.Printf("%s: already hydrated (%d bytes)\n", sessionName, fileSize(rawPath))
 			continue
@@ -122,12 +131,18 @@ func resummarySession(projectRoot, ledgerPath, sessionPath, sessionName, ep stri
 		return fmt.Errorf("read meta.json: %w", err)
 	}
 
-	// ensure raw.jsonl is hydrated (not just a pointer)
+	// ensure raw.jsonl is local (not just a pointer)
 	rawPath := filepath.Join(sessionPath, ledgerFileRaw)
 	if lfs.IsPointerFile(rawPath) {
 		slog.Info("downloading raw.jsonl from LFS", "session", sessionName)
 		if err := downloadFileFromLFS(projectRoot, sessionPath, meta, ledgerFileRaw); err != nil {
 			return fmt.Errorf("download raw.jsonl: %w", err)
+		}
+		// restore pointer on any exit path to avoid leaving large content in ledger
+		if ref, ok := meta.Files[ledgerFileRaw]; ok {
+			defer func() {
+				_ = lfs.WritePointerFile(rawPath, ref)
+			}()
 		}
 	}
 
@@ -164,12 +179,9 @@ func resummarySession(projectRoot, ledgerPath, sessionPath, sessionName, ep stri
 
 	// update meta.json title
 	if result.Title != "" {
-		_ = lfs.UpdateMetaSummary(sessionPath, result.Title)
-	}
-
-	// restore raw.jsonl to pointer (don't leave hydrated content in ledger)
-	if ref, ok := meta.Files[ledgerFileRaw]; ok {
-		_ = lfs.WritePointerFile(rawPath, ref)
+		if err := lfs.UpdateMetaSummary(sessionPath, result.Title); err != nil {
+			slog.Warn("failed to update meta.json title", "session", sessionName, "err", err)
+		}
 	}
 
 	// commit and push summary.json (git-tracked, not LFS)


### PR DESCRIPTION
## Summary

- **Add hidden `ox session migrate-lfs`** — migrates pre-LFS sessions (content committed directly to git) to LFS pointer files so the web UI can render them
- **Add hidden `ox session hydrate-lfs`** — downloads raw.jsonl from LFS blob storage to disk for local inspection
- **Add hidden `ox session resummary-batch`** — re-summarizes sessions via the SageOx API (hydrates raw.jsonl, calls summarize, pushes updated summary.json)

### Context

An audit of all 176 session recordings revealed:
- 32 pre-LFS sessions had content committed directly to git — invisible to the web UI (which reads exclusively from LFS)
- 12 sessions had missing or incomplete `summary.json` (no `key_actions` or `aha_moments`)
- 131 empty orphaned directories from failed session starts

All issues were resolved using these commands + manual summary generation. The commands are kept as hidden maintenance tools for future use.

```mermaid
flowchart LR
    A[Direct-git session] -->|migrate-lfs| B[LFS pointer files]
    B -->|web UI reads OIDs| C[Session renders]
    D[LFS pointer raw.jsonl] -->|hydrate-lfs| E[Local raw.jsonl]
    E -->|resummary-batch| F[New summary.json pushed]
```

## Test plan

- [ ] `go build ./cmd/ox/` compiles cleanly
- [ ] `make test` passes (6079 tests, 0 failures)
- [ ] Verify migrated sessions render on web UI
- [ ] Verify regenerated summaries show key_actions and aha_moments on web UI

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LFS migration workflow to convert session storage with automatic content uploads and pointer management.
  * Added batch session re-summarization capability via API integration with metadata updates.
  * Added LFS hydration feature to download and manage session data with per-session status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->