### PR TITLE
fix(status): show platform-appropriate upgrade hint

### DIFF
--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -1625,9 +1626,13 @@ daemon health, and a tree view of all SageOx directory locations.`,
 
 		// show version update notice if available
 		if vResult := checkVersionFromCache(); vResult != nil {
+			upgradeHint := "brew upgrade sageox"
+			if runtime.GOOS != "darwin" {
+				upgradeHint = "https://github.com/sageox/ox/releases"
+			}
 			fmt.Printf("\n%s  %s\n",
 				statusWarningStyle.Render("Update available"),
-				fmt.Sprintf("v%s → v%s — brew upgrade sageox", vResult.CurrentVersion, vResult.LatestVersion),
+				fmt.Sprintf("v%s → v%s — %s", vResult.CurrentVersion, vResult.LatestVersion, upgradeHint),
 			)
 		}
 


### PR DESCRIPTION
## Summary
- Show `brew upgrade sageox` on macOS and a GitHub releases link on Linux when an update is available in `ox status`
- Previously the upgrade hint always showed `brew upgrade sageox` regardless of platform

## Test plan
- [ ] Run `ox status` on macOS — verify hint shows `brew upgrade sageox`
- [ ] Run `ox status` on Linux — verify hint shows GitHub releases URL
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version update notifications now provide platform-optimized upgrade guidance, with tailored instructions for macOS and other operating systems to streamline the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->