### PR TITLE
fix(session): replace dots in project hash to match Claude Code naming

### DIFF
--- a/internal/session/adapters/claude_code.go
+++ b/internal/session/adapters/claude_code.go
@@ -97,6 +97,17 @@ func (a *ClaudeCodeAdapter) Detect() bool {
 	return len(entries) > 0
 }
 
+// claudeProjectHash converts an absolute directory path to Claude Code's
+// project hash format used for ~/.claude/projects/ directory names.
+// All path separators, underscores, and dots are replaced with dashes.
+// e.g., /home/user/src/github.com/org/my_project -> -home-user-src-github-com-org-my-project
+func claudeProjectHash(path string) string {
+	h := strings.ReplaceAll(path, string(os.PathSeparator), "-")
+	h = strings.ReplaceAll(h, "_", "-")
+	h = strings.ReplaceAll(h, ".", "-")
+	return h
+}
+
 // FindSessionFile locates the most recent session file matching criteria.
 // It searches through all project directories for JSONL files modified after 'since',
 // then scans for content matching the agentID (from ox agent prime output).
@@ -113,10 +124,7 @@ func (a *ClaudeCodeAdapter) FindSessionFile(agentID string, since time.Time) (st
 		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	// convert cwd to Claude's project hash format: path separators and underscores become dashes
-	// e.g., /Users/ryan/Code/my_project -> -Users-ryan-Code-my-project
-	projectHash := strings.ReplaceAll(cwd, string(os.PathSeparator), "-")
-	projectHash = strings.ReplaceAll(projectHash, "_", "-")
+	projectHash := claudeProjectHash(cwd)
 	projectDir := filepath.Join(projectsDir, projectHash)
 
 	// check if project-specific directory exists

--- a/internal/session/adapters/claude_code_test.go
+++ b/internal/session/adapters/claude_code_test.go
@@ -1016,11 +1016,9 @@ func TestClaudeCodeAdapter_ReadMetadata_NoModel(t *testing.T) {
 func TestClaudeCodeAdapter_FindSessionFile(t *testing.T) {
 	adapter := &ClaudeCodeAdapter{}
 
-	// compute project hash from CWD (same logic as FindSessionFile)
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	projectHash := strings.ReplaceAll(cwd, string(os.PathSeparator), "-")
-	projectHash = strings.ReplaceAll(projectHash, "_", "-")
+	projectHash := claudeProjectHash(cwd)
 
 	t.Run("returns JSONL file path", func(t *testing.T) {
 		tmpHome := t.TempDir()
@@ -1105,6 +1103,50 @@ func TestClaudeCodeAdapter_FindSessionFile(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, info.IsDir(), "FindSessionFile must never return a directory: %s", result)
 	})
+}
+
+func TestClaudeProjectHash(t *testing.T) {
+	// Regression: dots in paths (e.g. github.com) must be replaced with dashes
+	// to match Claude Code's project directory naming.
+	// See: https://github.com/sageox/ox/issues/261
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "simple path",
+			path: "/Users/ryan/Code/project",
+			want: "-Users-ryan-Code-project",
+		},
+		{
+			name: "path with underscore",
+			path: "/Users/ryan/Code/my_project",
+			want: "-Users-ryan-Code-my-project",
+		},
+		{
+			name: "github.com path with dot",
+			path: "/home/user/src/github.com/org/repo",
+			want: "-home-user-src-github-com-org-repo",
+		},
+		{
+			name: "multiple dots",
+			path: "/home/user/src/git.internal.company.io/team/repo",
+			want: "-home-user-src-git-internal-company-io-team-repo",
+		},
+		{
+			name: "dots and underscores combined",
+			path: "/home/user/src/github.com/org/my_project",
+			want: "-home-user-src-github-com-org-my-project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := claudeProjectHash(tt.path)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestClaudeCodeAdapter_Read_DirectoryPath(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fix**: `FindSessionFile()` fails to locate Claude Code's transcript for any repo path containing a dot (e.g., `github.com`), silently producing zero-entry sessions
- **Cause**: The project hash computation replaced `/` and `_` with `-` but missed `.`, producing `-home-galex-src-github.com-...` instead of `-home-galex-src-github-com-...`
- **Extracted** the hash logic into a standalone `claudeProjectHash()` function for direct unit testing

## What changed

`internal/session/adapters/claude_code.go`:
- Extracted `claudeProjectHash()` — converts absolute path to Claude Code's `~/.claude/projects/` directory name format
- Added `.` → `-` replacement to match Claude Code's documented behavior

`internal/session/adapters/claude_code_test.go`:
- Added `TestClaudeProjectHash` — table-driven tests covering dots (`github.com`), underscores, multiple dots (`git.internal.company.io`), and combinations
- Updated existing `FindSessionFile` test to use the extracted function

## Test plan

- [x] `TestClaudeProjectHash` passes all cases including `github.com` paths
- [x] `TestClaudeCodeAdapter_FindSessionFile` still passes
- [x] Full adapter test suite passes
- [ ] Manual verification: start a session recording in a `github.com` repo, confirm entries are captured and uploaded at stop

Fixes #261

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for session file handling.

* **Tests**
  * Enhanced test coverage for session management with additional test scenarios.

---

**Note:** These changes are internal improvements with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->