### PR TITLE
fix(auth): add proactive JWT refresh for token-dependent commands

### DIFF
--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -396,7 +396,7 @@ func runInit() error {
 	} else {
 		// fetch teams from API to determine if selection is needed
 		teamClient := api.NewRepoClient()
-		if token, err := auth.GetToken(); err == nil && token != nil && token.AccessToken != "" {
+		if token, err := auth.EnsureValidToken(300); err == nil && token != nil && token.AccessToken != "" {
 			teamClient.WithAuthToken(token.AccessToken)
 		}
 
@@ -721,7 +721,7 @@ func runInit() error {
 
 	// create client and add auth token (already verified authenticated above)
 	regClient := api.NewRepoClient()
-	if token, err := auth.GetToken(); err == nil && token != nil && token.AccessToken != "" {
+	if token, err := auth.EnsureValidToken(300); err == nil && token != nil && token.AccessToken != "" {
 		regClient.WithAuthToken(token.AccessToken)
 	}
 

--- a/cmd/ox/uninstall.go
+++ b/cmd/ox/uninstall.go
@@ -250,8 +250,8 @@ func notifyCloudUninstall(marker *api.RepoMarkerData) {
 		return
 	}
 
-	// get auth token for this endpoint
-	token, err := auth.GetTokenForEndpoint(ep)
+	// get auth token for this endpoint (proactive refresh if expiring soon)
+	token, err := auth.EnsureValidTokenForEndpoint(ep, 300)
 	if err != nil {
 		slog.Warn("uninstall cloud notification", "skipped", "failed to get auth token", "error", err)
 		fmt.Println(cli.StyleWarning.Render("⚠ Could not notify cloud (auth error). Cloud resources may need manual cleanup."))

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -81,6 +81,26 @@ func EnsureValidToken(bufferSeconds int) (*StoredToken, error) {
 	return token, nil
 }
 
+// EnsureValidTokenForEndpoint ensures we have a valid token for a specific endpoint,
+// refreshing proactively if the token expires within bufferSeconds.
+// Use this instead of GetTokenForEndpoint when the token will be used for API requests.
+func EnsureValidTokenForEndpoint(ep string, bufferSeconds int) (*StoredToken, error) {
+	token, err := GetTokenForEndpoint(ep)
+	if err != nil {
+		return nil, err
+	}
+
+	if token == nil {
+		return nil, nil
+	}
+
+	if token.IsExpired(bufferSeconds) {
+		return refreshTokenForEndpoint(token, ep)
+	}
+
+	return token, nil
+}
+
 // Handle401Error handles 401 Unauthorized by attempting token refresh.
 //
 // Reactive refresh: Called when a request returns 401, attempt refresh
@@ -117,7 +137,12 @@ func Handle401Error(token *StoredToken) (*StoredToken, error) {
 // Raises:
 //   - TokenRefreshError if refresh fails due to network, invalid token, or server error
 func refreshToken(token *StoredToken) (*StoredToken, error) {
-	baseURL := endpoint.Get()
+	return refreshTokenForEndpoint(token, endpoint.Get())
+}
+
+// refreshTokenForEndpoint performs token refresh against a specific endpoint.
+func refreshTokenForEndpoint(token *StoredToken, ep string) (*StoredToken, error) {
+	baseURL := ep
 	tokenURL := baseURL + TokenEndpoint
 
 	// prepare form data for token refresh
@@ -263,8 +288,8 @@ func refreshToken(token *StoredToken) (*StoredToken, error) {
 		UserInfo:     token.UserInfo, // preserve user info from original token
 	}
 
-	// save new token
-	if err := SaveToken(newToken); err != nil {
+	// save new token for the endpoint we refreshed against
+	if err := SaveTokenForEndpoint(baseURL, newToken); err != nil {
 		return nil, &TokenRefreshError{
 			Message: "failed to save refreshed token",
 			Err:     err,
@@ -290,6 +315,27 @@ func (c *AuthClient) EnsureValidToken(bufferSeconds int) (*StoredToken, error) {
 	// check if token needs refresh (expired or will expire within buffer)
 	if token.IsExpired(bufferSeconds) {
 		return c.refreshToken(token)
+	}
+
+	return token, nil
+}
+
+// EnsureValidTokenForEndpoint ensures we have a valid token for a specific endpoint,
+// refreshing proactively if the token expires within bufferSeconds.
+func (c *AuthClient) EnsureValidTokenForEndpoint(ep string, bufferSeconds int) (*StoredToken, error) {
+	token, err := c.GetTokenForEndpoint(ep)
+	if err != nil {
+		return nil, err
+	}
+
+	if token == nil {
+		return nil, nil
+	}
+
+	if token.IsExpired(bufferSeconds) {
+		// use endpoint-specific refresh by creating a temporary client
+		epClient := c.WithEndpoint(ep)
+		return epClient.refreshToken(token)
 	}
 
 	return token, nil

--- a/internal/auth/refresh_test.go
+++ b/internal/auth/refresh_test.go
@@ -619,3 +619,77 @@ func TestEnsureValidToken_NegativeBuffer(t *testing.T) {
 	// should return original token
 	assert.Equal(t, token.AccessToken, result.AccessToken, "expected no refresh with negative buffer")
 }
+
+func TestEnsureValidTokenForEndpoint_NoToken(t *testing.T) {
+	t.Parallel()
+
+	client := NewAuthClientWithDir(t.TempDir())
+
+	token, err := client.EnsureValidTokenForEndpoint("https://other.example.com", 300)
+	require.NoError(t, err)
+	assert.Nil(t, token, "want nil when no token exists for endpoint")
+}
+
+func TestEnsureValidTokenForEndpoint_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	client := NewAuthClientWithDir(t.TempDir())
+	ep := "https://other.example.com"
+
+	// save token for a specific endpoint
+	original := createTestToken(1 * time.Hour)
+	require.NoError(t, client.SaveTokenForEndpoint(ep, original))
+
+	// should return token as-is without refresh
+	token, err := client.EnsureValidTokenForEndpoint(ep, 300)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, original.AccessToken, token.AccessToken)
+}
+
+func TestEnsureValidTokenForEndpoint_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	// mock server that handles refresh + JWT exchange
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case TokenEndpoint:
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+			assert.Equal(t, "test-refresh-token", r.Form.Get("refresh_token"))
+
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "refreshed-opaque",
+				"refresh_token": "refreshed-refresh",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		case "/api/v1/cli/auth/token":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "refreshed-jwt",
+				"token_type":   "Bearer",
+				"expires_in":   900,
+			})
+		default:
+			t.Errorf("unexpected endpoint: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	client := NewAuthClientWithDir(t.TempDir())
+
+	// save expired token for the mock server endpoint
+	expired := createTestToken(-1 * time.Hour)
+	require.NoError(t, client.SaveTokenForEndpoint(mockServer.URL, expired))
+
+	// should refresh using the correct endpoint
+	token, err := client.EnsureValidTokenForEndpoint(mockServer.URL, 300)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "refreshed-jwt", token.AccessToken)
+	assert.Equal(t, "refreshed-refresh", token.RefreshToken)
+	assert.Equal(t, expired.UserInfo.UserID, token.UserInfo.UserID)
+}

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -149,12 +149,18 @@ func saveAuthStore(store *AuthStore) error {
 	return nil
 }
 
-// GetToken loads the authentication token for the current API endpoint
+// GetToken loads the raw stored token for the current endpoint.
+// Internal use only (refresh logic, display/identity checks).
+// Callers making API requests MUST use EnsureValidToken(300) or
+// EnsureValidTokenForEndpoint(ep, 300) instead — raw tokens may be expired.
 func GetToken() (*StoredToken, error) {
 	return GetTokenForEndpoint(endpoint.Get())
 }
 
-// GetTokenForEndpoint loads the authentication token for a specific API endpoint
+// GetTokenForEndpoint loads the raw stored token for a specific endpoint.
+// Internal use only (refresh logic, display/identity checks).
+// Callers making API requests MUST use EnsureValidTokenForEndpoint(ep, 300)
+// instead — raw tokens may be expired.
 func GetTokenForEndpoint(ep string) (*StoredToken, error) {
 	ep = endpoint.NormalizeEndpoint(ep)
 

--- a/internal/session/summarize.go
+++ b/internal/session/summarize.go
@@ -213,9 +213,9 @@ func Summarize(entries []Entry, agentID, agentType, model, endpointURL string) (
 	var token *auth.StoredToken
 	var err error
 	if endpointURL != "" {
-		token, err = auth.GetTokenForEndpoint(endpointURL)
+		token, err = auth.EnsureValidTokenForEndpoint(endpointURL, 300)
 	} else {
-		token, err = auth.GetToken()
+		token, err = auth.EnsureValidToken(300)
 	}
 	if err != nil || token == nil {
 		return nil, fmt.Errorf("authentication required for summarization")


### PR DESCRIPTION
## Problem
CLI commands like `ox init`, `ox uninstall`, and session summarization failed when run >15 minutes after login (JWT TTL = 15 min). These commands used `auth.GetToken()` which returned raw stored tokens without proactive refresh.

## Solution
- Add `EnsureValidTokenForEndpoint(ep, bufferSeconds)` for endpoint-specific token refresh
- Refactor `refreshToken()` to parameterized `refreshTokenForEndpoint(token, ep)` for endpoint awareness
- Update call sites (`init.go`, `uninstall.go`, `summarize.go`) to use safe refresh path
- Add guard comments on `GetToken()` / `GetTokenForEndpoint()` to steer callers toward refresh variants

## Testing
- 3 new tests for `EnsureValidTokenForEndpoint` (no token, valid, expired + refresh)
- All 6156 tests pass, 0 lint issues
- Tested init and summarize paths with proactive refresh

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication flow to proactively refresh tokens before expiration, reducing the likelihood of authentication failures during API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->