### PR TITLE
feat(coverage): add Makefile targets and Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Configure git identity for tests
+        run: |
+          git config --global user.email "ci@sageox.ai"
+          git config --global user.name "CI"
+
       - name: Build
         run: go build -v ./...
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,10 +18,16 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Configure git identity for tests
+        run: |
+          git config --global user.email "ci@sageox.ai"
+          git config --global user.name "CI"
+
       - name: Test with coverage
         run: go test -short -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           files: coverage.out


### PR DESCRIPTION
## Summary

Add developer-friendly coverage workflows and CI integration:

- **8 new Makefile targets** using Go's built-in tools: `coverage-func` (terminal summary), `coverage-baseline`/`coverage-diff` (delta tracking), `coverage-check` (CI gate), `build-cover`/`coverage-integration` (binary + integration coverage)
- **Enable CI workflow** with Go 1.24, test with coverage, upload to Codecov
- **Codecov integration** with auto project target, 80% patch target, ignore patterns for generated code

Makefile targets leverage Go 1.20+ (`GOCOVERDIR`, `go tool covdata`) — zero external dependencies beyond Codecov for CI reporting.

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow reliability by establishing consistent Git configuration for test environments and ensuring coverage reports are generated consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->