### PR TITLE
feat(init): add --endpoint flag

### DIFF
--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -356,10 +356,14 @@ func runInit() error {
 	// === ENDPOINT SELECTION ===
 	// Priority: --endpoint flag > SAGEOX_ENDPOINT env var > interactive picker
 	if initEndpointFlag != "" {
-		os.Setenv(endpoint.EnvVar, endpoint.NormalizeEndpoint(initEndpointFlag))
+		resolvedEndpoint := endpoint.NormalizeEndpoint(initEndpointFlag)
+		if resolvedEndpoint == "" {
+			return fmt.Errorf("invalid --endpoint value: %q", initEndpointFlag)
+		}
+		os.Setenv(endpoint.EnvVar, resolvedEndpoint)
 		if !initQuiet {
 			fmt.Println()
-			fmt.Printf("Using endpoint: %s\n", cli.StyleBold.Render(endpoint.NormalizeSlug(initEndpointFlag)))
+			fmt.Printf("Using endpoint: %s\n", cli.StyleBold.Render(endpoint.NormalizeSlug(resolvedEndpoint)))
 		}
 	} else if os.Getenv(endpoint.EnvVar) == "" {
 		selectedEndpoint, needsLogin := selectInitEndpoint()


### PR DESCRIPTION
## Summary
- Adds `--endpoint` flag to `ox init`, matching the existing `ox login --endpoint` behavior
- Priority: `--endpoint` flag > `SAGEOX_ENDPOINT` env var > interactive picker
- Enables fully non-interactive init: `ox init --endpoint https://test.sageox.ai --team <id> -q`

## Test plan
- [ ] `ox init --endpoint https://test.sageox.ai --team <team> -q` uses the specified endpoint without prompting
- [ ] `ox init` without `--endpoint` still shows interactive picker
- [ ] `SAGEOX_ENDPOINT` env var still works when no `--endpoint` flag provided

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --endpoint command-line option to configure the endpoint during initialization.
  * Improved endpoint selection: the explicit option now takes priority, triggers clearer user feedback when used, and preserves the previous interactive or fallback behavior when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->