### PR TITLE
chore(coverage): align codecov config with other repos

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: Coverage
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # daily at 6am UTC
+    - cron: '0 11 * * *'  # daily at 3am Pacific / 11am UTC
   workflow_dispatch: {}   # allow manual trigger
 
 permissions:
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
 
       - name: Configure git identity for tests
         run: |
@@ -31,5 +31,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.out
+          flags: ox-cli
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,19 +1,28 @@
 codecov:
-  require_ci_to_pass: true
+  require_ci_to_pass: false
 
 coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
+        target: 80%
+        threshold: 2%
+        informational: true
     patch:
       default:
         target: 80%
+        informational: true
 
 comment:
-  layout: "reach,diff,flags,files"
+  layout: "condensed_header, condensed_files, condensed_footer"
   behavior: default
+  require_changes: true
+
+flags:
+  ox-cli:
+    paths:
+      - ./
+    carryforward: true
 
 ignore:
   - "cmd/ox/docs.go"


### PR DESCRIPTION
## Summary

Align codecov configuration and daily coverage workflow with established SageOx patterns.

## Changes

**codecov.yml:**
- Set `require_ci_to_pass: false` — coverage gates are informational only (non-blocking)
- Update project target to 80% with 2% threshold
- Add patch-level informational status for better visibility
- Switch to condensed comment layout with `require_changes: true` to reduce noise
- Add `ox-cli` flag with `carryforward: true` for better multi-run tracking

**.github/workflows/coverage.yml:**
- Align daily schedule to 3am Pacific (11am UTC) for consistent team nightly runs
- Use `go-version-file: 'go.mod'` instead of hardcoded version
- Add `flags: ox-cli` to codecov upload for flag-based reporting

## Verification

Coverage already runs on schedule and via manual dispatch. Baseline established on 2026-03-19.

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow scheduling to run at 11:00 UTC.
  * Modified Go version configuration to derive from go.mod file.
  * Enhanced code coverage tracking with updated thresholds and settings.
  * Adjusted code quality check requirements and comment formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->