### PR TITLE
feat(sync): reduce default sync intervals to 60s ledger and 15s team context

### DIFF
--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -75,8 +75,8 @@ type Config struct {
 // DefaultConfig returns the default daemon configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		SyncIntervalRead:        5 * time.Minute, // includes anti-entropy checks
-		TeamContextSyncInterval: 1 * time.Minute,
+		SyncIntervalRead:        60 * time.Second, // includes anti-entropy checks
+		TeamContextSyncInterval: 15 * time.Second,
 		DebounceWindow:          500 * time.Millisecond,
 		VersionCheckInterval:    30 * time.Minute, // ETag conditional requests make this cheap
 		GCCheckInterval:         1 * time.Hour,    // check hourly, actual GC cadence is per-workspace

--- a/internal/daemon/config_test.go
+++ b/internal/daemon/config_test.go
@@ -16,7 +16,7 @@ import (
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
 
-	assert.Equal(t, 5*time.Minute, cfg.SyncIntervalRead)
+	assert.Equal(t, 60*time.Second, cfg.SyncIntervalRead)
 	assert.Equal(t, 500*time.Millisecond, cfg.DebounceWindow)
 	assert.True(t, cfg.AutoStart)
 	assert.Empty(t, cfg.LedgerPath)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -16,7 +16,7 @@ func TestNew(t *testing.T) {
 		d := New(nil, nil)
 		assert.NotNil(t, d)
 		assert.NotNil(t, d.config)
-		assert.Equal(t, 5*time.Minute, d.config.SyncIntervalRead)
+		assert.Equal(t, 60*time.Second, d.config.SyncIntervalRead)
 	})
 
 	t.Run("with custom config", func(t *testing.T) {
@@ -134,7 +134,7 @@ func TestDefaultConfig_NewFields(t *testing.T) {
 	})
 
 	t.Run("team context sync interval is set", func(t *testing.T) {
-		assert.Equal(t, 1*time.Minute, cfg.TeamContextSyncInterval)
+		assert.Equal(t, 15*time.Second, cfg.TeamContextSyncInterval)
 	})
 }
 

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -50,8 +50,8 @@ import (
 // Sync timing constants - extracted for clarity and testability.
 const (
 	// minTeamContextFetchAge is the minimum age before re-fetching a team context.
-	// Team contexts are shared across repos, so we use a longer interval to reduce redundant fetches.
-	minTeamContextFetchAge = 5 * time.Minute
+	// Team contexts are shared across repos, so we use a shorter interval for fast sync.
+	minTeamContextFetchAge = 15 * time.Second
 
 	// teamDiscoveryInterval is how often we re-fetch the team list from the API,
 	// independent of credential token expiry. This ensures new teams are discovered

--- a/internal/gitutil/safety.go
+++ b/internal/gitutil/safety.go
@@ -12,7 +12,7 @@ import (
 
 // MinFetchHeadAge is the minimum age of FETCH_HEAD before we'll fetch again.
 // Prevents redundant fetches if another process fetched recently.
-const MinFetchHeadAge = 2 * time.Minute
+const MinFetchHeadAge = 30 * time.Second
 
 // knownLockFiles are git lock files that indicate a crashed or in-progress git process.
 var knownLockFiles = []string{


### PR DESCRIPTION
## Summary

Faster sync defaults improve responsiveness:
- **Ledger sync**: 5min → 60s (SyncIntervalRead)
- **Team context sync**: 1min → 15s (TeamContextSyncInterval)

Also lowered fetch-age thresholds to prevent the new intervals from being silently clamped:
- MinFetchHeadAge: 2min → 30s
- minTeamContextFetchAge: 5min → 15s

Tests updated to assert new defaults.

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced default synchronization intervals for daemon operations managing repository data and team context updates. Repository information and team context changes now synchronize at increased frequency throughout your workspace. Git fetch-head verification thresholds have been adjusted accordingly to align with updated repository refresh timing during collaborative work across team contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->