### PR TITLE
fix(login): don't block login when token refresh fails

### DIFF
--- a/cmd/ox/login.go
+++ b/cmd/ox/login.go
@@ -255,8 +255,6 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 	// check if already authenticated for this endpoint
 	// If token refresh fails, treat as unauthenticated and proceed with login
 	// (the user is explicitly trying to log in, so a refresh failure shouldn't block them)
-	// If token refresh fails, treat as unauthenticated and proceed with login
-	// (the user is explicitly trying to log in, so a refresh failure shouldn't block them)
 	authenticated, err := auth.IsAuthenticatedForEndpoint(currentEndpoint)
 	if err != nil {
 		slog.Debug("auth check failed, proceeding with login", "error", err)

--- a/cmd/ox/login_test.go
+++ b/cmd/ox/login_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,14 +28,14 @@ func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
 	// Mock server: return 404 on /oauth2/token (refresh) and 200 on
 	// /api/auth/device/code (device flow) so we can detect that login
 	// proceeded past the refresh failure.
-	var deviceCodeRequested bool
+	var deviceCodeRequested atomic.Bool
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/oauth2/token":
 			// Simulate the 404 that triggered the original bug
 			w.WriteHeader(http.StatusNotFound)
 		case "/api/auth/device/code":
-			deviceCodeRequested = true
+			deviceCodeRequested.Store(true)
 			// Return a valid device code response so the flow proceeds
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -124,6 +125,6 @@ func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
 
 	// The device code endpoint should have been hit, proving login
 	// proceeded past the failed refresh
-	assert.True(t, deviceCodeRequested,
+	assert.True(t, deviceCodeRequested.Load(),
 		"login should have proceeded to device code request after refresh failure")
 }


### PR DESCRIPTION
## Summary

- `ox login` no longer fails when a stored token can't be refreshed
- Token refresh errors are debug-logged and login proceeds normally

## Bug

Running `ox login` with an expired token fails with:
```
Error: failed to check authentication status: token refresh failed:
token refresh failed with HTTP 404: HTTP 404: 404 Not Found
```

The user is completely locked out — the very command they need to fix their auth is blocked by the broken auth.

## Root Cause

Before starting the device code flow, `runLoginFlow()` calls `auth.IsAuthenticatedForEndpoint()` to check if the user is already logged in. This function calls `EnsureValidTokenForEndpoint()`, which attempts to refresh an expired token by hitting `/oauth2/token`. If the refresh endpoint returns a non-200 status (e.g., 404 because the endpoint changed or the server-side OAuth config was updated), the error propagates back to `runLoginFlow()` which treats it as fatal:

```go
authenticated, err := auth.IsAuthenticatedForEndpoint(currentEndpoint)
if err != nil {
    return fmt.Errorf("failed to check authentication status: %w", err)
}
```

## Fix

Token refresh failures during `ox login` are now treated as "not authenticated" — the error is debug-logged and the login flow proceeds. The user is explicitly trying to log in, so a refresh failure should never prevent them from doing so.

```go
authenticated, err := auth.IsAuthenticatedForEndpoint(currentEndpoint)
if err != nil {
    slog.Debug("auth check failed, proceeding with login", "error", err)
    authenticated = false
}
```

## Test plan

- [x] `ox login` succeeds with expired token that can't be refreshed (verified manually)
- [x] `ox login` still shows "Already authenticated" prompt when token is valid
- [x] Build passes (`make build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login now treats authentication-status check failures as unauthenticated and continues with the device-code login flow instead of aborting.

* **Tests**
  * Added a test confirming that login proceeds to the device-code flow when token refresh or auth-status checks fail, and that error messages do not expose the original internal failure details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->