### PR TITLE
feat: add agent whisper and murmur infrastructure

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/repotools"
 	"github.com/sageox/ox/internal/session"
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
 	"github.com/spf13/cobra"
 )
 
@@ -221,6 +222,9 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 	if userCfg, _ := config.LoadUserConfig(); userCfg != nil && userCfg.Notifications.AreNotificationsEnabled() {
 		emitTeamContextNotifications(agentID)
 	}
+
+	// check for pending whispers (non-blocking, ~50ms max)
+	emitWhispers(agentID)
 
 	subcommand := args[0]
 
@@ -592,6 +596,52 @@ func emitTeamContextNotifications(agentID string) {
 	fmt.Fprintln(os.Stderr, "NOTICE: Team context updated. Re-read only if relevant to current work:")
 	for _, f := range notifs.Files {
 		fmt.Fprintf(os.Stderr, "  %s\n", f.Path)
+	}
+}
+
+// emitWhispers checks daemon for pending whisper entries.
+// Non-blocking: if daemon is unavailable, silently returns.
+func emitWhispers(agentID string) {
+	client := daemon.NewClient() // 50ms timeout
+	resp, err := client.Whispers(agentID, "normal", nil)
+	if err != nil || resp == nil {
+		return
+	}
+	if len(resp.Entries) == 0 {
+		return
+	}
+
+	// group whispers by importance
+	var critical, normal, ambient []string
+	for _, e := range resp.Entries {
+		line := fmt.Sprintf("[%s] %s", e.Topic, e.Content)
+		switch e.Importance {
+		case whisperstore.ImportanceCritical:
+			critical = append(critical, line)
+		case whisperstore.ImportanceNormal:
+			normal = append(normal, line)
+		default:
+			ambient = append(ambient, line)
+		}
+	}
+
+	if len(critical) > 0 {
+		fmt.Fprintln(os.Stderr, "CRITICAL WHISPERS:")
+		for _, line := range critical {
+			fmt.Fprintf(os.Stderr, "  %s\n", line)
+		}
+	}
+	if len(normal) > 0 {
+		fmt.Fprintln(os.Stderr, "WHISPERS:")
+		for _, line := range normal {
+			fmt.Fprintf(os.Stderr, "  %s\n", line)
+		}
+	}
+	if len(ambient) > 0 {
+		fmt.Fprintln(os.Stderr, "AMBIENT:")
+		for _, line := range ambient {
+			fmt.Fprintf(os.Stderr, "  %s\n", line)
+		}
 	}
 }
 

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -713,6 +713,16 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		}
 	}
 
+	// Category 5c: Local State (ephemeral caches)
+	progress.show("Local State")
+	localStateChecks := []checkResult{
+		checkWhisperDBIntegrity(opts.shouldFix(CheckSlugWhisperDB)),
+	}
+	categories = append(categories, checkCategory{
+		name:   "Local State",
+		checks: localStateChecks,
+	})
+
 	// Category 6: Auth Security
 	authSecurityChecks := []checkResult{checkAuthFilePermissions(opts.shouldFix(CheckSlugAuthPermissions))}
 	categories = append(categories, checkCategory{

--- a/cmd/ox/doctor_whisper.go
+++ b/cmd/ox/doctor_whisper.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/paths"
+
+	_ "modernc.org/sqlite"
+)
+
+// CheckSlugWhisperDB is the slug for the whisper DB integrity check.
+const CheckSlugWhisperDB = "whisper-db"
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugWhisperDB,
+		Name:        "whisper DB integrity",
+		Category:    "Local State",
+		FixLevel:    FixLevelAuto,
+		Description: "Validates whisper SQLite databases are not corrupt",
+		Run: func(fix bool) checkResult {
+			return checkWhisperDBIntegrity(fix)
+		},
+	})
+}
+
+// checkWhisperDBIntegrity validates whisper DB files for corruption.
+// Corrupt DBs are auto-fixed by deletion — the daemon recreates on next start.
+func checkWhisperDBIntegrity(fix bool) checkResult {
+	const name = "whisper DB integrity"
+
+	gitRoot := findGitRoot()
+	if gitRoot == "" || !config.IsInitialized(gitRoot) {
+		return SkippedCheck(name, "project not initialized", "")
+	}
+
+	projectCfg, err := config.LoadProjectConfig(gitRoot)
+	if err != nil || projectCfg == nil || projectCfg.RepoID == "" {
+		return SkippedCheck(name, "no project config", "")
+	}
+
+	ep := endpoint.GetForProject(gitRoot)
+	if ep == "" {
+		return SkippedCheck(name, "no endpoint configured", "")
+	}
+
+	type dbTarget struct {
+		label string
+		dir   string
+	}
+
+	var targets []dbTarget
+
+	// ledger whisper DB
+	ledgerDir := paths.WhisperDBDir(projectCfg.RepoID, ep)
+	if ledgerDir != "" {
+		targets = append(targets, dbTarget{label: "ledger", dir: ledgerDir})
+	}
+
+	// team whisper DB(s)
+	localCfg, _ := config.LoadLocalConfig(gitRoot)
+	if localCfg != nil {
+		for _, tc := range localCfg.TeamContexts {
+			if tc.TeamID == "" {
+				continue
+			}
+			teamDir := paths.TeamWhisperDBDir(tc.TeamID, ep)
+			if teamDir != "" {
+				targets = append(targets, dbTarget{label: fmt.Sprintf("team/%s", tc.TeamID), dir: teamDir})
+			}
+		}
+	}
+
+	// also check the project-level team if not already covered by local config
+	if projectCfg.TeamID != "" {
+		teamDir := paths.TeamWhisperDBDir(projectCfg.TeamID, ep)
+		if teamDir != "" {
+			alreadyCovered := false
+			for _, t := range targets {
+				if t.dir == teamDir {
+					alreadyCovered = true
+					break
+				}
+			}
+			if !alreadyCovered {
+				targets = append(targets, dbTarget{label: fmt.Sprintf("team/%s", projectCfg.TeamID), dir: teamDir})
+			}
+		}
+	}
+
+	if len(targets) == 0 {
+		return SkippedCheck(name, "no whisper DB paths resolved", "")
+	}
+
+	var checked, healthy, missing int
+	var corruptLabels []string
+	var fixedLabels []string
+	var fixErrors []string
+
+	for _, t := range targets {
+		dbPath := filepath.Join(t.dir, "whisper.db")
+
+		if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
+			missing++
+			continue
+		}
+
+		checked++
+
+		corrupted := isWhisperDBCorrupt(dbPath)
+		if !corrupted {
+			healthy++
+			continue
+		}
+
+		if fix {
+			removeWhisperSQLiteFiles(dbPath)
+			// verify removal
+			if _, statErr := os.Stat(dbPath); errors.Is(statErr, os.ErrNotExist) {
+				fixedLabels = append(fixedLabels, t.label)
+				slog.Info("whisper DB auto-fixed: removed corrupt DB", "label", t.label, "path", dbPath)
+			} else {
+				fixErrors = append(fixErrors, t.label)
+				slog.Error("whisper DB auto-fix failed: could not remove", "label", t.label, "path", dbPath)
+			}
+		} else {
+			corruptLabels = append(corruptLabels, t.label)
+		}
+	}
+
+	// all DBs missing — healthy state, daemon creates on next start
+	if checked == 0 {
+		return PassedCheck(name, "no whisper DBs present (created on demand)")
+	}
+
+	// report fix results
+	if len(fixedLabels) > 0 && len(fixErrors) == 0 {
+		return PassedCheck(name,
+			fmt.Sprintf("auto-fixed: removed %d corrupt DB(s) (%s), daemon will recreate",
+				len(fixedLabels), strings.Join(fixedLabels, ", ")))
+	}
+	if len(fixErrors) > 0 {
+		return WarningCheck(name,
+			fmt.Sprintf("fixed %d, failed %d", len(fixedLabels), len(fixErrors)),
+			fmt.Sprintf("could not remove: %s", strings.Join(fixErrors, ", ")))
+	}
+
+	// report corruption without fix
+	if len(corruptLabels) > 0 {
+		return FailedCheck(name,
+			fmt.Sprintf("%d corrupt DB(s): %s", len(corruptLabels), strings.Join(corruptLabels, ", ")),
+			"corrupt whisper DBs will be auto-fixed on next run").
+			WithFixInfo(CheckSlugWhisperDB, FixLevelAuto)
+	}
+
+	return PassedCheck(name, fmt.Sprintf("%d DB(s) healthy", healthy))
+}
+
+// isWhisperDBCorrupt opens a raw sqlite connection and runs PRAGMA integrity_check.
+func isWhisperDBCorrupt(dbPath string) bool {
+	dsn := dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(3000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		slog.Debug("whisper DB open failed during integrity check", "path", dbPath, "error", err)
+		return true
+	}
+	defer db.Close()
+
+	var result string
+	if err := db.QueryRow("PRAGMA integrity_check").Scan(&result); err != nil {
+		slog.Debug("whisper DB integrity_check query failed", "path", dbPath, "error", err)
+		return true
+	}
+
+	return result != "ok"
+}
+
+// removeWhisperSQLiteFiles removes the .db, .db-wal, and .db-shm files.
+// Mirrors the pattern from internal/whisper/store/store.go:removeSQLiteFiles.
+func removeWhisperSQLiteFiles(dbPath string) {
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		p := dbPath + suffix
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("failed to remove whisper db file", "path", p, "error", err)
+		}
+	}
+}

--- a/cmd/ox/doctor_whisper_test.go
+++ b/cmd/ox/doctor_whisper_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestIsWhisperDBCorrupt_HealthyDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "whisper.db")
+
+	// create a valid SQLite DB
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	_, err = db.Exec("CREATE TABLE test (id INTEGER PRIMARY KEY)")
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	db.Close()
+
+	if isWhisperDBCorrupt(dbPath) {
+		t.Error("expected healthy DB to not be reported as corrupt")
+	}
+}
+
+func TestIsWhisperDBCorrupt_CorruptDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "whisper.db")
+
+	// write garbage to simulate corruption
+	if err := os.WriteFile(dbPath, []byte("this is not a valid sqlite database"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if !isWhisperDBCorrupt(dbPath) {
+		t.Error("expected corrupt DB to be detected")
+	}
+}
+
+func TestIsWhisperDBCorrupt_MissingDB(t *testing.T) {
+	// SQLite lazily creates missing files, so isWhisperDBCorrupt returns false
+	// for non-existent paths. The caller (checkWhisperDBIntegrity) handles
+	// missing files via os.Stat before calling this function.
+	dbPath := filepath.Join(t.TempDir(), "nonexistent.db")
+
+	// not corrupt — SQLite creates a fresh empty DB on open
+	if isWhisperDBCorrupt(dbPath) {
+		t.Error("expected missing DB to not be reported as corrupt (SQLite creates on open)")
+	}
+
+	// clean up the auto-created file
+	os.Remove(dbPath)
+}
+
+func TestRemoveWhisperSQLiteFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "whisper.db")
+
+	// create all three files
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if err := os.WriteFile(dbPath+suffix, []byte("data"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", suffix, err)
+		}
+	}
+
+	removeWhisperSQLiteFiles(dbPath)
+
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if _, err := os.Stat(dbPath + suffix); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed", dbPath+suffix)
+		}
+	}
+}
+
+func TestRemoveWhisperSQLiteFiles_PartialFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "whisper.db")
+
+	// only create the main file (no WAL or SHM)
+	if err := os.WriteFile(dbPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// should not panic or error on missing WAL/SHM
+	removeWhisperSQLiteFiles(dbPath)
+
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Error("expected main db file to be removed")
+	}
+}
+
+func TestCheckSlugWhisperDB_Registered(t *testing.T) {
+	check := GetDoctorCheck(CheckSlugWhisperDB)
+	if check == nil {
+		t.Fatal("whisper-db check not registered in DoctorCheckRegistry")
+	}
+	if check.FixLevel != FixLevelAuto {
+		t.Errorf("expected FixLevelAuto, got %s", check.FixLevel)
+	}
+	if !check.IsAutoFixable() {
+		t.Error("whisper-db check should be auto-fixable")
+	}
+}

--- a/cmd/ox/murmur.go
+++ b/cmd/ox/murmur.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/ledger"
+	"github.com/spf13/cobra"
+)
+
+const maxMurmurContentBytes = 4096 // ~1000 tokens — murmurs are short coordination signals
+
+var murmurCmd = &cobra.Command{
+	Use:   "murmur [content]",
+	Short: "Publish a coordination signal to other AI coworkers",
+	Long: `Murmur publishes a short-lived coordination signal that other AI coworkers
+on the same repo (or team) will hear as a whisper.
+
+Examples:
+  ox murmur --topic=lint "ESLint rule failing in src/auth/"
+  ox murmur --scope=team --topic=architecture "API contract v3 rolling out"
+  ox murmur --importance=critical --topic=conflict "Modifying shared auth middleware"
+  ox murmur '{"content": "Fixing lint rule X", "topic": "lint"}'`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runMurmur,
+}
+
+var validImportanceLevels = map[string]bool{
+	"critical": true,
+	"normal":   true,
+	"ambient":  true,
+}
+
+func init() {
+	murmurCmd.Flags().String("topic", "general", "topic slug for filtering (e.g., lint, architecture, conflict)")
+	murmurCmd.Flags().String("importance", "normal", "importance level: critical, normal, ambient")
+	murmurCmd.Flags().String("scope", "ledger", "scope: ledger (this repo) or team (all repos)")
+	murmurCmd.Flags().String("agent-id", "", "agent ID (falls back to SAGEOX_AGENT_ID env)")
+
+	murmurCmd.GroupID = "agent-interface"
+	rootCmd.AddCommand(murmurCmd)
+}
+
+// murmurInput holds parsed input from either flags+positional or JSON.
+type murmurInput struct {
+	Content    string `json:"content"`
+	Topic      string `json:"topic,omitempty"`
+	Importance string `json:"importance,omitempty"`
+}
+
+func runMurmur(cmd *cobra.Command, args []string) error {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return fmt.Errorf("not in a SageOx project: %w", err)
+	}
+
+	// parse input: positional arg or stdin
+	var rawContent string
+	if len(args) > 0 {
+		rawContent = strings.TrimSpace(args[0])
+	}
+	if rawContent == "" {
+		return fmt.Errorf("no content provided\nUsage: ox murmur [--topic=...] \"message\"")
+	}
+
+	// detect JSON input vs plain text
+	topic, _ := cmd.Flags().GetString("topic")
+	importance, _ := cmd.Flags().GetString("importance")
+
+	if strings.HasPrefix(rawContent, "{") {
+		var input murmurInput
+		if err := json.Unmarshal([]byte(rawContent), &input); err != nil {
+			return fmt.Errorf("invalid JSON input: %w", err)
+		}
+		if input.Content == "" {
+			return fmt.Errorf("JSON input must have a 'content' field")
+		}
+		rawContent = input.Content
+		// JSON fields override defaults but flags override JSON
+		if input.Topic != "" && !cmd.Flags().Changed("topic") {
+			topic = input.Topic
+		}
+		if input.Importance != "" && !cmd.Flags().Changed("importance") {
+			importance = input.Importance
+		}
+	}
+
+	// validate importance
+	if !validImportanceLevels[importance] {
+		return fmt.Errorf("invalid importance %q: must be critical, normal, or ambient", importance)
+	}
+
+	// validate content size
+	if len(rawContent) > maxMurmurContentBytes {
+		return fmt.Errorf("content too large (%d bytes, max %d)", len(rawContent), maxMurmurContentBytes)
+	}
+
+	// resolve scope and target directory
+	scope, _ := cmd.Flags().GetString("scope")
+	targetDir, err := resolveMurmurTarget(projectRoot, scope)
+	if err != nil {
+		return err
+	}
+
+	// resolve agent ID: flag > env > empty
+	agentID, _ := cmd.Flags().GetString("agent-id")
+	if agentID == "" {
+		agentID = os.Getenv("SAGEOX_AGENT_ID")
+	}
+
+	// generate UUIDv7
+	id, err := uuid.NewV7()
+	if err != nil {
+		return fmt.Errorf("generate murmur ID: %w", err)
+	}
+
+	now := time.Now().UTC()
+
+	murmur := ledger.MurmurFile{
+		SchemaVersion: "1",
+		ID:            id.String(),
+		Timestamp:     now,
+		AgentID:       agentID,
+		Topic:         topic,
+		Importance:    importance,
+		Content:       rawContent,
+		Scope:         scope,
+	}
+
+	// write murmur file
+	relPath, err := ledger.WriteMurmur(targetDir, murmur)
+	if err != nil {
+		return fmt.Errorf("write murmur: %w", err)
+	}
+
+	// git add --sparse + commit (no push — daemon syncs)
+	if err := commitMurmur(targetDir, relPath, rawContent); err != nil {
+		return fmt.Errorf("commit murmur: %w", err)
+	}
+
+	slog.Info("murmur published", "id", id.String(), "topic", topic, "importance", importance, "scope", scope)
+	fmt.Fprintf(cmd.OutOrStdout(), "Murmur published: %s\n", id.String())
+	return nil
+}
+
+// resolveMurmurTarget returns the git repo path where the murmur file should be written.
+func resolveMurmurTarget(projectRoot, scope string) (string, error) {
+	switch scope {
+	case "ledger":
+		path := getLedgerPath()
+		if path == "" {
+			return "", fmt.Errorf("no ledger found — run 'ox doctor --fix' or wait for daemon to clone")
+		}
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return "", fmt.Errorf("ledger not found at %s — run 'ox doctor --fix'", path)
+		}
+		return path, nil
+
+	case "team":
+		tc := config.FindRepoTeamContext(projectRoot)
+		if tc == nil {
+			return "", fmt.Errorf("no team context configured — run 'ox init' first")
+		}
+		return tc.Path, nil
+
+	default:
+		return "", fmt.Errorf("invalid scope %q: must be ledger or team", scope)
+	}
+}
+
+// commitMurmur stages and commits a murmur file. Does not push.
+func commitMurmur(repoDir, relPath, content string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// --sparse: repos use sparse-checkout; without this flag
+	// git refuses to stage files outside the sparse definition
+	if _, err := gitutil.RunGit(ctx, repoDir, "add", "--sparse", relPath); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+
+	summary := content
+	if len(summary) > 50 {
+		summary = summary[:50] + "..."
+	}
+	commitMsg := fmt.Sprintf("murmur: %s", summary)
+
+	if _, err := gitutil.RunGit(ctx, repoDir, "commit", "-m", commitMsg); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/ox/murmur_test.go
+++ b/cmd/ox/murmur_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestMurmurFlagDefaults(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("topic", "general", "")
+	cmd.Flags().String("importance", "normal", "")
+	cmd.Flags().String("scope", "ledger", "")
+	cmd.Flags().String("agent-id", "", "")
+
+	topic, _ := cmd.Flags().GetString("topic")
+	if topic != "general" {
+		t.Errorf("default topic: got %q, want %q", topic, "general")
+	}
+
+	importance, _ := cmd.Flags().GetString("importance")
+	if importance != "normal" {
+		t.Errorf("default importance: got %q, want %q", importance, "normal")
+	}
+
+	scope, _ := cmd.Flags().GetString("scope")
+	if scope != "ledger" {
+		t.Errorf("default scope: got %q, want %q", scope, "ledger")
+	}
+
+	agentID, _ := cmd.Flags().GetString("agent-id")
+	if agentID != "" {
+		t.Errorf("default agent-id: got %q, want empty", agentID)
+	}
+}
+
+func TestMurmurValidImportanceLevels(t *testing.T) {
+	tests := []struct {
+		level string
+		valid bool
+	}{
+		{"critical", true},
+		{"normal", true},
+		{"ambient", true},
+		{"high", false},
+		{"low", false},
+		{"", false},
+		{"CRITICAL", false}, // case-sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			got := validImportanceLevels[tt.level]
+			if got != tt.valid {
+				t.Errorf("validImportanceLevels[%q] = %v, want %v", tt.level, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestMurmurMissingContent(t *testing.T) {
+	cmd := *murmurCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err := cmd.RunE(&cmd, []string{})
+	if err == nil {
+		t.Fatal("expected error for missing content")
+	}
+	if !strings.Contains(err.Error(), "no content provided") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "no content provided")
+	}
+}
+
+func TestMurmurEmptyContent(t *testing.T) {
+	cmd := *murmurCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err := cmd.RunE(&cmd, []string{"   "})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only content")
+	}
+	if !strings.Contains(err.Error(), "no content provided") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "no content provided")
+	}
+}
+
+func TestMurmurJSONInputParsing(t *testing.T) {
+	t.Run("valid JSON with content passes parsing", func(t *testing.T) {
+		cmd := *murmurCmd
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+
+		input := `{"content": "test message", "topic": "lint"}`
+		err := cmd.RunE(&cmd, []string{input})
+		// will fail downstream (no ledger), but must NOT fail at JSON parsing
+		if err == nil {
+			t.Fatal("expected error (no ledger in test env)")
+		}
+		if strings.Contains(err.Error(), "invalid JSON") {
+			t.Errorf("should have parsed JSON successfully, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "must have a 'content' field") {
+			t.Errorf("should have found content field, got: %v", err)
+		}
+	})
+
+	t.Run("JSON missing content field", func(t *testing.T) {
+		cmd := *murmurCmd
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+
+		err := cmd.RunE(&cmd, []string{`{"topic": "lint"}`})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "must have a 'content' field") {
+			t.Errorf("error = %q, want substring about missing content field", err.Error())
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		cmd := *murmurCmd
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+
+		err := cmd.RunE(&cmd, []string{`{"content": broken}`})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "invalid JSON input") {
+			t.Errorf("error = %q, want substring %q", err.Error(), "invalid JSON input")
+		}
+	})
+}
+
+func TestMurmurInvalidImportanceReturnsError(t *testing.T) {
+	cmd := *murmurCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	_ = cmd.Flags().Set("importance", "high")
+
+	err := cmd.RunE(&cmd, []string{"test message"})
+	if err == nil {
+		t.Fatal("expected error for invalid importance")
+	}
+	if !strings.Contains(err.Error(), "invalid importance") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "invalid importance")
+	}
+}
+
+func TestMurmurInvalidScopeReturnsError(t *testing.T) {
+	cmd := *murmurCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	_ = cmd.Flags().Set("scope", "global")
+	_ = cmd.Flags().Set("importance", "normal")
+
+	err := cmd.RunE(&cmd, []string{"test message"})
+	if err == nil {
+		t.Fatal("expected error for invalid scope")
+	}
+	// error will reference the invalid scope
+	if !strings.Contains(err.Error(), "invalid scope") {
+		t.Errorf("error = %q, want substring about invalid scope", err.Error())
+	}
+}
+
+func TestMurmurContentTooLarge(t *testing.T) {
+	cmd := *murmurCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	content := make([]byte, maxMurmurContentBytes+1)
+	for i := range content {
+		content[i] = 'a'
+	}
+
+	err := cmd.RunE(&cmd, []string{string(content)})
+	if err == nil {
+		t.Fatal("expected error for oversized content")
+	}
+	if !strings.Contains(err.Error(), "content too large") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "content too large")
+	}
+}
+
+func TestMurmurJSONOverridesDefaults(t *testing.T) {
+	cmd := *murmurCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	// JSON with topic and importance — should be used since flags weren't explicitly set
+	input := `{"content": "test", "topic": "lint", "importance": "critical"}`
+	err := cmd.RunE(&cmd, []string{input})
+	// will fail downstream, but the parsing path is exercised
+	if err == nil {
+		t.Fatal("expected error (no ledger in test env)")
+	}
+	// verify it got past JSON parsing
+	if strings.Contains(err.Error(), "invalid JSON") || strings.Contains(err.Error(), "must have a 'content' field") {
+		t.Errorf("unexpected parsing error: %v", err)
+	}
+}

--- a/docs/ai/adr/adr-whisper-murmur-architecture.md
+++ b/docs/ai/adr/adr-whisper-murmur-architecture.md
@@ -1,0 +1,411 @@
+<!-- doc-audience: ai -->
+# ADR: Agent Whisper & Murmur Architecture
+
+- **Status:** Accepted
+- **Date:** 2026-03-22
+- **Deciders:** Ryan Snodgrass, SageOx Team
+- **Relates to:** [Daemon State Design Principles](../specs/daemon-state-principles.md), [Ledger Architecture](adr-ledger-architecture.md)
+
+## Context
+
+AI coworkers operating on the same repo (or across repos in a team) need real-time coordination — knowing what others are working on, hearing about breaking changes, and avoiding stepping on each other's toes. Before this ADR, the ox daemon had three ad-hoc systems that partially addressed this:
+
+1. **`NotificationStore`** — in-memory bounded buffer tracking team context file changes, with per-agent cursors. Lost on daemon restart. No filtering by importance or topic.
+2. **`ox agent prime`** — one-shot context injection at session start. No ongoing updates.
+3. **Hook system** — lifecycle callbacks (start, compact, afterTool, stop). No mechanism for inter-agent or event-driven signals.
+
+These systems work but are disconnected, have no common abstraction, and don't support cross-agent communication. The number of "things the daemon wants to tell agents about" is growing (file changes, murmurs, scheduled reminders, errors), and each one was being bolted on separately.
+
+### Problem Statement
+
+We need a **generalized agent communication infrastructure** that:
+
+- Unifies all daemon→agent signals under a single delivery pipeline
+- Supports agent→agent coordination via a pub/sub model
+- Filters by topic and importance to manage agent context token budgets
+- Persists across daemon restarts (cursors, dedup state)
+- Works cross-repo for teams
+- Avoids the catastrophic state management failures seen in the [Beads/Dolt migration](../specs/daemon-state-principles.md)
+
+## Decision
+
+### Voice Metaphor
+
+The entire system uses a consistent voice/hearing metaphor:
+
+```mermaid
+graph LR
+    A[AI Coworker A] -->|murmur| L[Ledger / Team Context]
+    L -->|daemon git pull| D[Daemon]
+    D -->|whisper| B[AI Coworker B]
+    D -->|whisper| C[AI Coworker C]
+
+    style L fill:#fff3e0
+    style D fill:#e1f5fe
+```
+
+| Concept | Name | Direction | Description |
+|---------|------|-----------|-------------|
+| Outbound signal | **Murmur** | agent → ledger | Agent publishes a topic-tagged coordination signal |
+| Inbound delivery | **Whisper** | daemon → agent | System delivers relevant content to agent's context |
+| Subject filter | **Topic** | both | Freeform slug (e.g., `lint`, `build`, `architecture`) |
+| Sender weight | **Importance** | outbound | How important the sender considers the murmur |
+| Receiver sensitivity | **Attention** | inbound | How much the receiver wants to hear |
+
+### Importance × Attention Delivery Matrix
+
+Senders tag murmurs with importance. Receivers configure attention. The delivery rule is a simple threshold:
+
+| | `focused` | `normal` (default) | `all` |
+|---|:-:|:-:|:-:|
+| **`critical`** | ✓ | ✓ | ✓ |
+| **`normal`** | | ✓ | ✓ |
+| **`ambient`** | | | ✓ |
+
+- **`critical`**: Breaking changes, merge conflicts, shared resource contention
+- **`normal`**: Standard coordination — "I'm working on X", test failures
+- **`ambient`**: Nice-to-know — minor observations, style preferences
+
+### Topics
+
+Topics are **freeform slugs** (not an enum). A default set ships with ox, expandable via repo or team config. Agents subscribe to `*` (all topics) by default, or specific topics for filtering.
+
+Default topics: `build`, `lint`, `test`, `architecture`, `discovery`, `conflict`
+
+### Two Scopes: Ledger and Team
+
+| Scope | Storage Location | Propagation | Use Case |
+|-------|-----------------|-------------|----------|
+| `ledger` | `<ledger>/data/murmurs/` | Same repo only | "Fixing lint in src/auth/" |
+| `team` | `<team-ctx>/data/murmurs/` | All repos in team | "API contract v3 rolling out" |
+
+Cross-repo coordination works because all daemons on the same team pull the same team context repo. An agent on repo-X murmurs with `--scope=team` → team context → daemon on repo-Y pulls it → whispers to agents on repo-Y.
+
+### Whisper Types
+
+Three categories of whisper, unified under the same delivery pipeline:
+
+```mermaid
+graph TB
+    subgraph "Whisper Sources"
+        S1[Structural<br/>prime, hooks, errors]
+        S2[Time-Based<br/>periodic scheduler]
+        S3[Trigger-Based<br/>file changes, murmurs]
+    end
+
+    subgraph "Daemon"
+        WR[WhisperRegistry]
+        WS[WhisperStore<br/>SQLite + cursors]
+        MR[Murmur Relay]
+        SCH[WhisperScheduler]
+    end
+
+    subgraph "Ledger / Team Context"
+        MF["data/murmurs/<br/>YYYY-MM-DD/HH/uuid.json"]
+    end
+
+    subgraph "CLI"
+        MC["ox murmur"]
+        ED["emitWhispers()"]
+    end
+
+    S1 --> WR
+    S2 --> SCH --> WR
+    S3 --> WR
+    WR --> WS
+    MR -->|relay after pull| WR
+    MF -->|daemon git pull| MR
+    MC -->|git add/commit/push| MF
+    WS -->|IPC: MsgTypeWhispers| ED
+    ED -->|stderr| Agent
+
+    style WS fill:#e1f5fe
+    style MF fill:#fff3e0
+```
+
+| Type | Source | Examples |
+|------|--------|----------|
+| **Structural** | Lifecycle events | Prime data, hook callbacks, daemon errors |
+| **Time-based** | Periodic scheduler | "N coworkers active", "last sync Xm ago" |
+| **Trigger-based** | External events | File changes, murmur relay, CI results |
+
+### Observations vs Murmurs
+
+These serve fundamentally different purposes and must not be conflated:
+
+| Aspect | Observations (`ox memory put`) | Murmurs (`ox murmur`) |
+|--------|------|---------|
+| **Storage** | Team context `memory/.observations/` | Ledger/team `data/murmurs/` |
+| **Purpose** | Long-term team memory (distilled) | Real-time coordination (ephemeral) |
+| **Audience** | Future sessions, any coworker, any time | Currently-active agents, same repo, right now |
+| **Delivery** | Pull-based (read at prime) | Push-based (daemon whispers to agents) |
+| **Lifecycle** | Permanent (distilled, never deleted) | Ephemeral (12h sparse checkout window) |
+| **Filtering** | None (all feed distillation) | Topic + importance/attention filtering |
+
+### Principal Identity
+
+Every murmur optionally records who created it:
+
+- **`agent_id`**: Which AI coworker instance (e.g., "Oxa7b3")
+- **`principal_id`**: Who the agent works for (e.g., user email). Optional.
+- **`principal_type`**: Always `"human"` for now. Optional, extensible later.
+
+All three fields are optional. This enables self-filtering (agents don't hear their own murmurs) and attribution when present.
+
+### Content vs Metadata
+
+Every whisper has **content** (required) and optional **metadata**:
+
+- **Content**: What you'd say out loud in an office — a terse, one-line message that competes for agent context tokens. Required.
+- **Metadata**: A `map[string]string` of structured context (files, branches, PRs, rule names) for programmatic consumers. Optional.
+
+```json
+{
+  "content": "Modifying shared auth middleware — heads up",
+  "metadata": {"files": "internal/middleware/auth.go", "branch": "ryan/auth-refactor", "pr": "287"}
+}
+```
+
+Agents not working on auth see the content and move on. Agents working on auth use metadata to check exact files.
+
+## Storage Design
+
+### Murmur Files (Source of Truth)
+
+Murmurs are JSON files stored in hourly-partitioned directories:
+
+```
+data/murmurs/YYYY-MM-DD/HH/<uuidv7>.json
+```
+
+The daemon maintains a **rolling 12-hour sparse checkout window**. At 3pm, hours `04/` through `15/` are checked out. GC reclone naturally prunes older directories — no explicit cleanup needed.
+
+### WhisperStore (Derived Cache)
+
+A SQLite database stored in the ledger's local cache:
+
+```
+~/.local/share/sageox/<endpoint>/ledgers/<repo_id>/.sageox/cache/whisper/whisper.db
+```
+
+Team whisper DBs are stored per-team:
+
+```
+~/.local/share/sageox/<endpoint>/teams/<team_id>/.sageox/cache/whisper/whisper.db
+```
+
+#### Schema
+
+```sql
+CREATE TABLE whispers (
+    id              TEXT PRIMARY KEY,   -- UUIDv7
+    scope           TEXT NOT NULL,      -- "ledger" or "team"
+    type            TEXT NOT NULL,      -- "structural", "time-based", "trigger"
+    source          TEXT NOT NULL,      -- "team-context", "murmur", "scheduler"
+    topic           TEXT NOT NULL,      -- freeform slug
+    content         TEXT NOT NULL,      -- terse one-liner
+    importance      TEXT NOT NULL,      -- "critical", "normal", "ambient"
+    created_at      TEXT NOT NULL,      -- RFC3339
+    agent_id        TEXT,               -- originating agent
+    principal_id    TEXT,               -- who the agent works for (optional)
+    principal_type  TEXT,               -- "human" for now (optional, extensible)
+    team_id         TEXT,
+    metadata        TEXT                -- JSON map
+);
+
+CREATE TABLE cursors (
+    agent_id    TEXT PRIMARY KEY,
+    last_seen   TEXT NOT NULL,          -- RFC3339
+    updated_at  TEXT NOT NULL           -- RFC3339
+);
+
+CREATE TABLE relayed_murmurs (
+    murmur_id   TEXT NOT NULL,
+    scope       TEXT NOT NULL,
+    relayed_at  TEXT NOT NULL,          -- RFC3339
+    PRIMARY KEY (murmur_id, scope)
+);
+```
+
+#### Why SQLite, Not Dolt
+
+The Beads project migrated from SQLite to Dolt and experienced 7 families of catastrophic failures (see [Daemon State Design Principles](../specs/daemon-state-principles.md)). The whisper store needs none of Dolt's superpowers (branching, merging, diffing tables). It is **ephemeral local cache** with 24-hour retention. SQLite with WAL mode is battle-tested, already in the dep tree via CodeDB (`modernc.org/sqlite`), and adds zero operational complexity.
+
+#### Why Two Physical DBs
+
+The ledger whisper DB has a single writer (the daemon that owns that ledger). The team whisper DB is shared across multiple daemons (one per repo in the team). Putting both in the same file would create multi-writer contention — the exact failure pattern from Beads Principle 4. WAL mode + `busy_timeout(5000)` handles the team DB's multi-daemon writes safely.
+
+#### Auto-Recovery
+
+If the DB is corrupt or missing, `Open()` transparently deletes it, recreates the schema, and continues. Callers never see corruption errors. The murmur relay re-scans ledger files on the next sync tick, repopulating the store. Zero data loss, zero user impact.
+
+```
+Open() → integrity_check fails → delete DB + WAL + SHM → recreate → continue
+```
+
+`ox doctor` auto-fixes whisper DB corruption at `FixLevelAuto` (no `--fix` flag needed). The DB is ephemeral cache — losing it costs nothing.
+
+### Size Management
+
+Three-layer cleanup:
+
+| Layer | Trigger | Action |
+|-------|---------|--------|
+| Time-based prune | Startup + hourly | `DELETE WHERE created_at < now - 24h` |
+| Hard size cap | Startup | If > 10MB: aggressive prune (keep 6h), VACUUM |
+| Nuclear option | After aggressive prune | If still over: delete all, VACUUM |
+
+Steady state: ~200-500 bytes/entry, ~1000 entries/day = ~500KB.
+
+## Component Architecture
+
+### WhisperRegistry (`internal/daemon/whisper_registry.go`)
+
+Aggregates one ledger store + N team stores under a unified API. Routes writes by scope, merges reads across all stores.
+
+```go
+type WhisperRegistry struct {
+    ledgerStore *Store
+    teamStores  map[string]*Store  // teamID -> store
+}
+```
+
+### WhisperStore (`internal/whisper/store/store.go`)
+
+SQLite-backed store with these operations:
+
+- `Add(entries...)` — insert with ID-based dedup
+- `GetWhispers(agentID, attention, topics)` — filtered query + cursor update
+- `IsRelayed/MarkRelayed(murmurID, scope)` — murmur dedup across restarts
+- `Prune(retention)` — time-based cleanup
+- `EnforceMaxSize(maxBytes)` — safety net
+
+### IPC (`internal/daemon/ipc.go`)
+
+New message type `MsgTypeWhispers` with payload:
+
+```json
+{"type": "whispers", "payload": {"agent_id": "OxKpCG", "attention": "normal", "topics": ["lint", "build"]}}
+```
+
+### Murmur Relay (`internal/daemon/murmur_relay.go` — Phase 2)
+
+Scans `data/murmurs/` directories in ledger and team context repos after git pull, converts murmur files to whisper entries, dedup via `relayed_murmurs` table.
+
+### CLI Delivery (`cmd/ox/agent.go` — Phase 1c)
+
+`emitWhispers(agentID)` called from `runWithAgentID()`, queries daemon via IPC, formats to stderr grouped by importance.
+
+### Path Helpers (`internal/paths/paths.go`)
+
+- `WhisperDBDir(repoID, endpointURL)` — ledger whisper DB location
+- `TeamWhisperDBDir(teamID, endpointURL)` — team whisper DB location
+
+## Phased Implementation
+
+```mermaid
+gantt
+    title Whisper & Murmur Implementation Phases
+    dateFormat X
+    axisFormat %s
+
+    section Phase 1
+    WhisperStore + Registry + IPC     :done, p1a, 0, 1
+    Time-based scheduler              :p1b, 1, 2
+    Trigger whisper + CLI delivery    :p1c, 2, 3
+    Doctor auto-fix                   :p1d, 2, 3
+
+    section Phase 2
+    Murmur schema + storage           :p2a, 3, 4
+    ox murmur CLI                     :p2b, 3, 4
+    Murmur Relay                      :p2c, 4, 5
+    Sparse checkout integration       :p2d, 4, 5
+
+    section Phase 3
+    Migrate NotificationStore         :p3a, 5, 6
+    Structural whispers               :p3b, 5, 6
+    Prime reminders                   :p3c, 6, 7
+```
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| **1a** | WhisperStore (SQLite) + WhisperRegistry + IPC | Implemented |
+| **1b** | Time-based whisper scheduler | Planned |
+| **1c** | Trigger-based whisper + CLI delivery | Planned |
+| **1d** | `ox doctor` auto-fix for whisper DB | Planned |
+| **2** | Murmuring infrastructure (murmur schema, CLI, relay, sparse checkout) | Planned |
+| **3** | Migrate NotificationStore → WhisperStore, structural whispers | Future |
+
+Phase 1 runs **in parallel** alongside existing `NotificationStore` — no migration, no breakage.
+
+## Alternatives Considered
+
+### 1. Extend NotificationStore In-Memory
+
+Add importance/topic filtering to the existing in-memory buffer. Rejected because:
+- Cursors lost on daemon restart (agents miss whispers)
+- No murmur dedup across restarts
+- No audit trail for debugging
+- Would need to grow the same in-memory buffer indefinitely
+
+### 2. Dolt for Daemon State
+
+Use Dolt's SQL interface with versioned tables. Rejected because:
+- Dolt requires managing a sidecar SQL server process (lifecycle complexity)
+- Known corruption issues under concurrency (Beads #2430, #2672)
+- Whisper data doesn't need branching/merging/diffing
+- Overkill for 24-hour ephemeral cache
+
+### 3. Redis / External Cache
+
+Use Redis for whisper state. Rejected because:
+- Adds an external dependency users must install
+- ox targets developer machines, not server infrastructure
+- SQLite is zero-config and already in the dep tree
+
+### 4. File-Based State (JSON files)
+
+Store whispers as JSON files, scan on query. Rejected because:
+- No cursor persistence without additional files
+- File scanning gets slow with thousands of entries
+- No transactional guarantees for concurrent access
+- Filtering requires reading every file
+
+### 5. Numeric Priority Instead of Named Slugs
+
+Use 0-3 for importance levels. Rejected because:
+- Named slugs (`critical`, `normal`, `ambient`) are self-documenting
+- Numeric values require looking up the mapping
+- Slugs work naturally in config files and CLI flags
+
+## Consequences
+
+### Positive
+
+- **Unified delivery pipeline**: All daemon→agent signals go through one system with consistent filtering
+- **Cross-agent coordination**: Agents can coordinate in real-time without human intervention
+- **Restart-safe**: SQLite persists cursors and dedup state across daemon restarts
+- **Cross-repo awareness**: Team-scoped murmurs propagate via team context repos
+- **Token-conscious**: Importance/attention filtering prevents context token waste
+- **Self-healing**: Corrupt state auto-recovers without user intervention
+
+### Negative
+
+- **Adds SQLite dependency to daemon** — already in dep tree via CodeDB, but increases daemon state surface
+- **Complexity**: Three whisper types, two scopes, importance × attention matrix adds conceptual complexity
+- **Eventual consistency**: Murmurs propagate via git pull, so there's a delay (seconds, not milliseconds)
+
+### Risks
+
+- **Token budget**: Whispers compete with work context. Mitigated by importance ordering, attention filtering, and configurable max budget (~500 tokens per delivery)
+- **Noisy agents**: An agent flooding murmurs could overwhelm others. Mitigated by rate limiting in `ox murmur` CLI and per-source caps in the scheduler
+- **DB growth**: Mitigated by three-layer cleanup (time prune, size cap, nuclear option)
+
+## References
+
+- [Daemon State Design Principles](../specs/daemon-state-principles.md) — 7 principles from Beads/Dolt failures
+- [Implementation Plan](/Users/ryan/.claude/plans/jiggly-bubbling-wozniak.md) — detailed file lists, schemas, test strategy
+- SageOx Memos discussion (2026-03-22) — Ryan's original design discussion on whispering patterns
+- `internal/whisper/store/store.go` — WhisperStore implementation
+- `internal/daemon/whisper_registry.go` — WhisperRegistry implementation
+- `internal/daemon/notifications.go` — existing NotificationStore (Phase 3 migration target)

--- a/docs/ai/specs/daemon-state-principles.md
+++ b/docs/ai/specs/daemon-state-principles.md
@@ -1,0 +1,70 @@
+<!-- doc-audience: ai -->
+# Daemon State Design Principles
+
+Distilled from the [Beads/Dolt failure analysis](/tmp/attachments/pasted_text_2026-03-22_08-18-43.txt) — 7 families of catastrophic failures that occurred when the beads project migrated from SQLite to Dolt for its local state management.
+
+These principles apply to **all persistent state in the ox daemon** — whisper store, future caches, any new SQLite databases, or any other local state mechanism.
+
+## Principle 1: Embedded-only, no sidecar processes
+
+**Beads failure**: Server Lifecycle Hell (#2685) — zombie dolt processes consuming 600MB each, 5.5s cold-start penalties, infinite restart loops, stale cleanup killing healthy servers from other repos. "What looked like separate bugs was really one subsystem failing through different entry points."
+
+**Rule**: The daemon's state store is an **embedded library** (SQLite via `modernc.org/sqlite`), not a separate server process. No ports, no PIDs, no ownership tracking, no lifecycle management. The store opens when the daemon starts and closes when it stops.
+
+## Principle 2: Single authoritative state model
+
+**Beads failure**: Runtime state (ports, PIDs, ownership, data dirs) was reconstructed independently by CLI code, reopen helpers, doctor checks, repair flows, and storage code — and they didn't reconstruct the same thing (#2685).
+
+**Rule**: One `Store` struct owns all state access. No parallel paths to the same data. `ox doctor` reads the same `Store` the daemon uses — never reconstructs state independently. All callers go through the same API surface.
+
+## Principle 3: Never version machine-local state
+
+**Beads failure**: Machine-local metadata (timestamps, auto-push commits) was committed to Dolt's versioned history, causing merge conflicts on every multi-machine sync (#2466). `bd init` on a second clone created unrelated history (#2580).
+
+**Rule**: The whisper DB is **local-only cache** in `.sageox/cache/`. Never committed to git. Never synced between machines. Never versioned. The source of truth is the murmur files in the ledger (git-tracked). The SQLite DB is a derived index.
+
+## Principle 4: Concurrent access must be safe by design, not by bolt-on locking
+
+**Beads failure**: Journal corruption with 3 concurrent agents (#2430). Concurrent `initSchema` DDL races corrupted the journal (#2672). Fix was bolting on `GET_LOCK/RELEASE_LOCK` — a workaround, not a cure. Even read-only commands panicked under concurrency (#2571).
+
+**Rule**: SQLite WAL mode provides safe concurrent reads with a single writer (the daemon). Multiple CLI processes access state via the daemon's IPC layer, not direct file access. No bolt-on locking. No multi-process direct DB access.
+
+## Principle 5: Transparent auto-recovery, never require user intervention
+
+**Beads failure**: `bd doctor` reported false errors, started servers when it shouldn't, didn't connect to configured servers (#2694/#2722). Fresh `bd init` succeeded but immediately reported failures (#2656). "For a tool called doctor, it was sick more often than the patients."
+
+**Rule**: If the state DB is corrupt → delete it → recreate it → continue. Callers never see the error. No manual recovery steps. The DB is ephemeral cache — losing it costs nothing. Log a warning for debugging, but the user experience is: nothing happened.
+
+**`ox doctor` integration**: Doctor auto-fixes state DB corruption at `FixLevelAuto` (no `--fix` flag needed). The `--fix` flag is reserved for destructive/ambiguous repairs that require human oversight.
+
+## Principle 6: SQL engine must be battle-tested, not "mostly compatible"
+
+**Beads failure**: Dolt's SQL engine cast UUIDs to float64 producing +Inf (#2760). `DOLT_CHECKOUT` didn't persist across calls. `INFORMATION_SCHEMA` worked differently between modes.
+
+**Rule**: Use `modernc.org/sqlite` — a pure-Go port of the canonical SQLite C codebase. Not "mostly SQLite-compatible," but actual SQLite. Same behavior everywhere. Already proven in this codebase via CodeDB.
+
+## Principle 7: State must be rebuildable from the source of truth
+
+**Beads failure**: Moving to Dolt broke the atomic git model — issue data became decoupled from code in a gitignored directory (#2489). If Dolt state was lost, the data was gone.
+
+**Rule**: The state DB is a **derived cache**, not a primary store. Source of truth:
+- **Murmur files**: `data/murmurs/` in the ledger (git-tracked)
+- **Whisper entries**: re-scannable from murmur files on demand
+- **Cursors**: reset gracefully (agents get one noisy cycle, then normal)
+- **Relayed tracking**: lost = some murmurs re-deliver once (harmless)
+
+If the entire DB disappears, the relay re-scans the ledger on the next sync tick and repopulates everything. Zero data loss. Zero user impact.
+
+---
+
+## Anti-Pattern Checklist
+
+Before adding any persistent state to the daemon, verify:
+
+- [ ] **No sidecar process** — is it embedded in the daemon, or does it require managing a separate server?
+- [ ] **Single state owner** — is there exactly one code path that reads/writes this state, or do multiple paths reconstruct it independently?
+- [ ] **No versioned local state** — is machine-local state kept out of git/sync, or could it cause merge conflicts?
+- [ ] **Safe concurrency** — does the concurrency model work by design (e.g., WAL + single writer), or does it require bolt-on locking?
+- [ ] **Invisible recovery** — if the state is corrupt, can it auto-recover without user intervention?
+- [ ] **Battle-tested engine** — is the storage engine proven at scale, or "mostly compatible" with something proven?
+- [ ] **Rebuildable from source of truth** — if the state disappears, can it be fully reconstructed from authoritative data?

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -18,7 +18,9 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon/agentwork"
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/version"
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
 
 // Version returns the daemon version including build timestamp.
@@ -147,16 +149,17 @@ type Daemon struct {
 	wg     sync.WaitGroup
 
 	// components
-	server        *Server
-	scheduler     *SyncScheduler
-	watcher       *Watcher
-	heartbeat     *HeartbeatHandler
-	telemetry     *TelemetryCollector
-	friction      *FrictionCollector
-	issues        *IssueTracker
-	codedb        *CodeDBManager
-	agentWorker   *agentwork.Manager
-	notifications *NotificationStore
+	server          *Server
+	scheduler       *SyncScheduler
+	watcher         *Watcher
+	heartbeat       *HeartbeatHandler
+	telemetry       *TelemetryCollector
+	friction        *FrictionCollector
+	issues          *IssueTracker
+	codedb          *CodeDBManager
+	agentWorker     *agentwork.Manager
+	notifications   *NotificationStore
+	whisperRegistry *WhisperRegistry
 
 	// state
 	mu               sync.Mutex
@@ -284,6 +287,21 @@ func (d *Daemon) Start() error {
 	// initialize notification store for team context change tracking
 	d.notifications = NewNotificationStore(200)
 
+	// initialize whisper store for persistent agent signal delivery
+	repoID := config.GetRepoID(d.config.ProjectRoot)
+	if repoID != "" && projectEndpoint != "" {
+		whisperDBPath := filepath.Join(paths.WhisperDBDir(repoID, projectEndpoint), "whisper.db")
+		ledgerWhisperStore, err := whisperstore.Open(whisperDBPath)
+		if err != nil {
+			d.logger.Warn("failed to open whisper store", "error", err)
+		} else {
+			d.whisperRegistry = NewWhisperRegistry(ledgerWhisperStore, d.logger)
+			// startup maintenance: prune old entries and enforce size limit
+			d.whisperRegistry.Prune(24 * time.Hour)
+			d.whisperRegistry.EnforceMaxSize(10 * 1024 * 1024) // 10MB
+		}
+	}
+
 	// start heartbeat handler
 	d.heartbeat = NewHeartbeatHandler(d.logger)
 	d.heartbeat.SetActivityCallback(d.recordActivity)
@@ -379,6 +397,11 @@ func (d *Daemon) Start() error {
 
 	// wire notification store so scheduler can record team context changes
 	d.scheduler.SetNotificationStore(d.notifications)
+
+	// wire whisper registry so scheduler can emit trigger whispers
+	if d.whisperRegistry != nil {
+		d.scheduler.SetWhisperRegistry(d.whisperRegistry)
+	}
 
 	// wire code index manager into scheduler for periodic freshness checks
 	if d.codedb != nil {
@@ -637,6 +660,13 @@ func (d *Daemon) Start() error {
 		return d.notifications.GetNotifications(agentID)
 	})
 
+	// set whisper handler for agent whisper queries
+	if d.whisperRegistry != nil {
+		d.server.SetWhispersHandler(func(agentID string, attention whisperstore.Attention, topics []string) ([]whisperstore.WhisperEntry, error) {
+			return d.whisperRegistry.GetWhispers(agentID, attention, topics)
+		})
+	}
+
 	setupDuration := time.Since(startSetup)
 
 	// start telemetry background sender
@@ -658,6 +688,14 @@ func (d *Daemon) Start() error {
 		defer d.wg.Done()
 		d.scheduler.Start(d.ctx)
 	}()
+
+	// start whisper scheduler (periodic sources + prune tick)
+	if d.whisperRegistry != nil {
+		ws := NewWhisperScheduler(d.whisperRegistry, d.logger)
+		ws.RegisterSource(NewActivitySummarySource(d.heartbeat, d.scheduler))
+		ws.Start(d.ctx, &d.wg)
+		ws.RunPrune(d.ctx, &d.wg, 1*time.Hour)
+	}
 
 	// start file watcher if ledger path is set
 	if d.config.LedgerPath != "" {
@@ -889,6 +927,13 @@ func (d *Daemon) shutdown() error {
 	// stop friction collector and flush pending events
 	if d.friction != nil {
 		d.friction.Stop()
+	}
+
+	// close whisper registry (flush SQLite WAL before exit)
+	if d.whisperRegistry != nil {
+		if err := d.whisperRegistry.Close(); err != nil {
+			d.logger.Warn("failed to close whisper registry", "error", err)
+		}
 	}
 
 	// cancel context to stop all goroutines

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/daemon/agentwork"
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
 
 // maxIPCMessageSize limits the maximum size of an IPC message to prevent DoS.
@@ -47,6 +48,7 @@ const (
 	MsgTypeCodeIndex       = "code_index"       // index local code with progress
 	MsgTypeCodeStatus      = "code_status"      // get code index status/stats
 	MsgTypeNotifications   = "notifications"    // query pending team context change notifications
+	MsgTypeWhispers        = "whispers"         // query whisper entries for an agent
 	MsgTypeSessionFinalize = "session_finalize" // one-way, trigger async session upload+finalization
 )
 
@@ -363,6 +365,18 @@ type NotificationsResponse struct {
 	Stale bool          `json:"stale"`
 }
 
+// WhispersPayload is the payload for whisper queries.
+type WhispersPayload struct {
+	AgentID   string   `json:"agent_id"`
+	Attention string   `json:"attention,omitempty"` // "all", "normal", "focused" (default: "normal")
+	Topics    []string `json:"topics,omitempty"`    // nil = all topics
+}
+
+// WhispersResponse is the response for whisper queries.
+type WhispersResponse struct {
+	Entries []whisperstore.WhisperEntry `json:"entries"`
+}
+
 // DoctorResponse is the response for the doctor IPC message.
 type DoctorResponse struct {
 	AntiEntropyTriggered     bool     `json:"anti_entropy_triggered"`
@@ -508,6 +522,7 @@ type Server struct {
 	onCodeIndex        func(payload CodeIndexPayload, progress *ProgressWriter) (*CodeIndexResult, error) // index local code
 	onCodeStatus       func() *CodeDBStats                                                                // get code index stats
 	onNotifications    func(agentID string) ([]ChangeEntry, bool)                                         // get pending notifications
+	onWhispers         func(agentID string, attention whisperstore.Attention, topics []string) ([]whisperstore.WhisperEntry, error)
 
 	startTime time.Time
 }
@@ -548,6 +563,7 @@ func (s *Server) buildRouter() *MessageRouter {
 	router.Register(MsgTypeCodeIndex, handleCodeIndex)
 	router.Register(MsgTypeCodeStatus, handleCodeStatus)
 	router.Register(MsgTypeNotifications, handleNotifications)
+	router.Register(MsgTypeWhispers, handleWhispers)
 
 	return router
 }
@@ -943,6 +959,47 @@ func handleNotifications(s *Server, msg Message, _ net.Conn) HandlerResult {
 	return HandlerResult{Response: marshalResponse(resp)}
 }
 
+func handleWhispers(s *Server, msg Message, _ net.Conn) HandlerResult {
+	s.mu.Lock()
+	handler := s.onWhispers
+	s.mu.Unlock()
+
+	if handler == nil {
+		resp := WhispersResponse{Entries: []whisperstore.WhisperEntry{}}
+		return HandlerResult{Response: marshalResponse(resp)}
+	}
+
+	var payload WhispersPayload
+	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+		return HandlerResult{
+			Response: &Response{Success: false, Error: fmt.Sprintf("invalid payload: %v", err)},
+		}
+	}
+
+	if payload.AgentID == "" {
+		return HandlerResult{
+			Response: &Response{Success: false, Error: "agent_id required"},
+		}
+	}
+
+	attention := whisperstore.Attention(payload.Attention)
+	if attention == "" {
+		attention = whisperstore.AttentionNormal
+	}
+
+	entries, err := handler(payload.AgentID, attention, payload.Topics)
+	if err != nil {
+		return HandlerResult{
+			Response: &Response{Success: false, Error: fmt.Sprintf("get whispers: %v", err)},
+		}
+	}
+	if entries == nil {
+		entries = []whisperstore.WhisperEntry{}
+	}
+	resp := WhispersResponse{Entries: entries}
+	return HandlerResult{Response: marshalResponse(resp)}
+}
+
 // SetHandlers sets the message handlers.
 func (s *Server) SetHandlers(onSync func() error, onStop func(), onStatus func() *StatusData) {
 	s.mu.Lock()
@@ -1078,6 +1135,13 @@ func (s *Server) SetNotificationsHandler(cb func(agentID string) ([]ChangeEntry,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onNotifications = cb
+}
+
+// SetWhispersHandler sets the handler for whisper queries.
+func (s *Server) SetWhispersHandler(cb func(agentID string, attention whisperstore.Attention, topics []string) ([]whisperstore.WhisperEntry, error)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onWhispers = cb
 }
 
 // Start starts the IPC server.
@@ -1495,6 +1559,31 @@ func (c *Client) Notifications(agentID string) (*NotificationsResponse, error) {
 	var result NotificationsResponse
 	if err := json.Unmarshal(resp.Data, &result); err != nil {
 		return nil, fmt.Errorf("unmarshal notifications: %w", err)
+	}
+	return &result, nil
+}
+
+// Whispers queries whisper entries for an agent from the daemon.
+// Returns entries since the agent last checked, filtered by attention and topics.
+func (c *Client) Whispers(agentID string, attention string, topics []string) (*WhispersResponse, error) {
+	payload, _ := json.Marshal(WhispersPayload{
+		AgentID:   agentID,
+		Attention: attention,
+		Topics:    topics,
+	})
+	resp, err := c.sendMessage(Message{
+		Type:    MsgTypeWhispers,
+		Payload: payload,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Success {
+		return nil, errors.New(resp.Error)
+	}
+	var result WhispersResponse
+	if err := json.Unmarshal(resp.Data, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal whispers: %w", err)
 	}
 	return &result, nil
 }

--- a/internal/daemon/murmur_relay.go
+++ b/internal/daemon/murmur_relay.go
@@ -1,0 +1,101 @@
+package daemon
+
+import (
+	"log/slog"
+
+	"github.com/sageox/ox/internal/ledger"
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
+)
+
+// MurmurRelay detects new murmur files in ledger and team context repos
+// after git pull, converts them to whisper entries, and feeds them to the
+// WhisperRegistry. Uses the relayed_murmurs table for dedup across restarts.
+type MurmurRelay struct {
+	registry      *WhisperRegistry
+	localAgentIDs map[string]bool // agent IDs on this machine (skip self-authored murmurs)
+	logger        *slog.Logger
+}
+
+// NewMurmurRelay creates a relay that scans murmur files and converts them
+// to whisper entries in the registry.
+func NewMurmurRelay(registry *WhisperRegistry, logger *slog.Logger) *MurmurRelay {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MurmurRelay{
+		registry:      registry,
+		localAgentIDs: make(map[string]bool),
+		logger:        logger,
+	}
+}
+
+// SetLocalAgentIDs sets the agent IDs running on this machine.
+// Murmurs authored by these agents are filtered out to avoid echo.
+func (r *MurmurRelay) SetLocalAgentIDs(ids []string) {
+	r.localAgentIDs = make(map[string]bool, len(ids))
+	for _, id := range ids {
+		r.localAgentIDs[id] = true
+	}
+}
+
+// RelayFromPath scans a directory for murmur files within the default window
+// and relays any new ones into the whisper registry.
+// Called after git pull on a ledger or team context repo.
+// scope must be "ledger" or "team".
+// Returns the number of murmurs successfully relayed.
+func (r *MurmurRelay) RelayFromPath(baseDir, scope string) int {
+	murmurs, err := ledger.ReadMurmursInWindow(baseDir, ledger.DefaultMurmurWindowHours)
+	if err != nil {
+		r.logger.Warn("failed to read murmurs", "dir", baseDir, "scope", scope, "err", err)
+		return 0
+	}
+
+	var relayed int
+	for _, m := range murmurs {
+		// skip self-authored murmurs
+		if m.AgentID != "" && r.localAgentIDs[m.AgentID] {
+			continue
+		}
+
+		// dedup: skip if already relayed (persisted in SQLite)
+		already, err := r.registry.IsRelayed(m.ID, scope)
+		if err != nil {
+			r.logger.Warn("failed to check relay status", "murmur_id", m.ID, "err", err)
+			continue
+		}
+		if already {
+			continue
+		}
+
+		entry := whisperstore.WhisperEntry{
+			ID:            m.ID,
+			Scope:         scope,
+			Type:          whisperstore.WhisperTrigger,
+			Source:        "murmur",
+			Topic:         m.Topic,
+			Content:       m.Content,
+			Importance:    whisperstore.Importance(m.Importance),
+			CreatedAt:     m.Timestamp,
+			AgentID:       m.AgentID,
+			PrincipalID:   m.PrincipalID,
+			PrincipalType: m.PrincipalType,
+			Metadata:      m.Metadata,
+		}
+
+		if err := r.registry.Add(scope, entry); err != nil {
+			r.logger.Warn("failed to add murmur as whisper", "murmur_id", m.ID, "err", err)
+			continue
+		}
+
+		if err := r.registry.MarkRelayed(m.ID, scope); err != nil {
+			r.logger.Warn("failed to mark murmur relayed", "murmur_id", m.ID, "err", err)
+		}
+
+		relayed++
+	}
+
+	if relayed > 0 {
+		r.logger.Debug("murmurs relayed", "scope", scope, "count", relayed, "dir", baseDir)
+	}
+	return relayed
+}

--- a/internal/daemon/murmur_relay_test.go
+++ b/internal/daemon/murmur_relay_test.go
@@ -1,0 +1,357 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/ledger"
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
+)
+
+// writeMurmurAt writes a murmur file into the correct hourly partition directory.
+func writeMurmurAt(t *testing.T, baseDir string, m ledger.MurmurFile) {
+	t.Helper()
+	_, err := ledger.WriteMurmur(baseDir, m)
+	if err != nil {
+		t.Fatalf("write murmur: %v", err)
+	}
+}
+
+func newTestRelay(t *testing.T) (*MurmurRelay, *WhisperRegistry, *whisperstore.Store) {
+	t.Helper()
+	store := openTestStore(t)
+	registry := NewWhisperRegistry(store, nil)
+	relay := NewMurmurRelay(registry, nil)
+	t.Cleanup(func() { registry.Close() })
+	return relay, registry, store
+}
+
+func TestMurmurRelayNewMurmurDetected(t *testing.T) {
+	relay, registry, _ := newTestRelay(t)
+	baseDir := t.TempDir()
+
+	now := time.Now().UTC()
+	writeMurmurAt(t, baseDir, ledger.MurmurFile{
+		ID:         "murmur-001",
+		Timestamp:  now,
+		AgentID:    "remote-agent",
+		Topic:      "lint",
+		Importance: "normal",
+		Content:    "fix the linter warnings",
+	})
+
+	count := relay.RelayFromPath(baseDir, "ledger")
+	if count != 1 {
+		t.Fatalf("expected 1 relayed, got %d", count)
+	}
+
+	entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get whispers: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 whisper entry, got %d", len(entries))
+	}
+	if entries[0].ID != "murmur-001" {
+		t.Errorf("expected ID murmur-001, got %s", entries[0].ID)
+	}
+	if entries[0].Source != "murmur" {
+		t.Errorf("expected source murmur, got %s", entries[0].Source)
+	}
+}
+
+func TestMurmurRelaySelfAuthoredFiltered(t *testing.T) {
+	relay, registry, _ := newTestRelay(t)
+	baseDir := t.TempDir()
+
+	now := time.Now().UTC()
+	writeMurmurAt(t, baseDir, ledger.MurmurFile{
+		ID:         "murmur-self",
+		Timestamp:  now,
+		AgentID:    "local-agent-1",
+		Topic:      "status",
+		Importance: "normal",
+		Content:    "I finished the task",
+	})
+
+	relay.SetLocalAgentIDs([]string{"local-agent-1"})
+
+	count := relay.RelayFromPath(baseDir, "ledger")
+	if count != 0 {
+		t.Fatalf("expected 0 relayed (self-authored), got %d", count)
+	}
+
+	entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get whispers: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 whisper entries, got %d", len(entries))
+	}
+}
+
+func TestMurmurRelayDedupAcrossCalls(t *testing.T) {
+	relay, _, _ := newTestRelay(t)
+	baseDir := t.TempDir()
+
+	now := time.Now().UTC()
+	writeMurmurAt(t, baseDir, ledger.MurmurFile{
+		ID:         "murmur-dup",
+		Timestamp:  now,
+		AgentID:    "remote-agent",
+		Topic:      "build",
+		Importance: "critical",
+		Content:    "build failed",
+	})
+
+	count1 := relay.RelayFromPath(baseDir, "ledger")
+	count2 := relay.RelayFromPath(baseDir, "ledger")
+
+	if count1 != 1 {
+		t.Fatalf("first relay: expected 1, got %d", count1)
+	}
+	if count2 != 0 {
+		t.Fatalf("second relay: expected 0 (dedup), got %d", count2)
+	}
+}
+
+func TestMurmurRelayRestartResilience(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "whisper.db")
+	baseDir := t.TempDir()
+
+	now := time.Now().UTC()
+	writeMurmurAt(t, baseDir, ledger.MurmurFile{
+		ID:         "murmur-persist",
+		Timestamp:  now,
+		AgentID:    "remote-agent",
+		Topic:      "deploy",
+		Importance: "normal",
+		Content:    "deployment started",
+	})
+
+	// first "session": relay the murmur, then close store
+	{
+		store, err := whisperstore.Open(dbPath)
+		if err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		registry := NewWhisperRegistry(store, nil)
+		relay := NewMurmurRelay(registry, nil)
+
+		count := relay.RelayFromPath(baseDir, "ledger")
+		if count != 1 {
+			t.Fatalf("first session: expected 1, got %d", count)
+		}
+
+		registry.Close()
+	}
+
+	// second "session": reopen and verify dedup state survived
+	{
+		store, err := whisperstore.Open(dbPath)
+		if err != nil {
+			t.Fatalf("reopen store: %v", err)
+		}
+		registry := NewWhisperRegistry(store, nil)
+		relay := NewMurmurRelay(registry, nil)
+
+		count := relay.RelayFromPath(baseDir, "ledger")
+		if count != 0 {
+			t.Fatalf("second session: expected 0 (persisted dedup), got %d", count)
+		}
+
+		registry.Close()
+	}
+}
+
+func TestMurmurRelayInvalidJSONSkipped(t *testing.T) {
+	relay, _, _ := newTestRelay(t)
+	baseDir := t.TempDir()
+
+	now := time.Now().UTC()
+	writeMurmurAt(t, baseDir, ledger.MurmurFile{
+		ID:         "murmur-valid",
+		Timestamp:  now,
+		AgentID:    "remote-agent",
+		Topic:      "test",
+		Importance: "normal",
+		Content:    "valid murmur",
+	})
+
+	// write invalid JSON into the same hourly directory
+	hourDir := filepath.Join(baseDir, ledger.MurmurDateHourDir(now))
+	invalidPath := filepath.Join(hourDir, "not-json.json")
+	if err := os.WriteFile(invalidPath, []byte("this is not json {{{"), 0o644); err != nil {
+		t.Fatalf("write invalid file: %v", err)
+	}
+
+	// should relay the valid one and skip the invalid one without error
+	count := relay.RelayFromPath(baseDir, "ledger")
+	if count != 1 {
+		t.Fatalf("expected 1 relayed (invalid skipped), got %d", count)
+	}
+}
+
+func TestMurmurRelayEmptyDirectory(t *testing.T) {
+	relay, _, _ := newTestRelay(t)
+	baseDir := t.TempDir()
+
+	count := relay.RelayFromPath(baseDir, "ledger")
+	if count != 0 {
+		t.Fatalf("expected 0 for empty dir, got %d", count)
+	}
+}
+
+func TestMurmurRelayScopeCorrectlyTagged(t *testing.T) {
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+
+	writeMurmurAt(t, baseDir, ledger.MurmurFile{
+		ID:         "murmur-scope",
+		Timestamp:  now,
+		AgentID:    "remote-agent",
+		Topic:      "architecture",
+		Importance: "normal",
+		Content:    "use event sourcing",
+	})
+
+	tests := []struct {
+		name  string
+		scope string
+	}{
+		{"ledger scope", "ledger"},
+		{"team scope", "team"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relay, registry, _ := newTestRelay(t)
+
+			// team scope requires a registered team store for writes to land
+			if tt.scope == "team" {
+				teamStore := openTestStore(t)
+				registry.AddTeamStore("team-1", teamStore)
+			}
+
+			count := relay.RelayFromPath(baseDir, tt.scope)
+			if count != 1 {
+				t.Fatalf("expected 1 relayed, got %d", count)
+			}
+
+			entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+			if err != nil {
+				t.Fatalf("get whispers: %v", err)
+			}
+			if len(entries) != 1 {
+				t.Fatalf("expected 1 entry, got %d", len(entries))
+			}
+			if entries[0].Scope != tt.scope {
+				t.Errorf("expected scope %s, got %s", tt.scope, entries[0].Scope)
+			}
+		})
+	}
+}
+
+func TestMurmurRelayMultipleMurmursInWindow(t *testing.T) {
+	relay, registry, _ := newTestRelay(t)
+	baseDir := t.TempDir()
+
+	now := time.Now().UTC()
+
+	// write murmurs across different hours within the window
+	for i, id := range []string{"m1", "m2", "m3"} {
+		writeMurmurAt(t, baseDir, ledger.MurmurFile{
+			ID:         id,
+			Timestamp:  now.Add(-time.Duration(i) * time.Hour),
+			AgentID:    "remote-agent",
+			Topic:      "test",
+			Importance: "normal",
+			Content:    "murmur " + id,
+		})
+	}
+
+	count := relay.RelayFromPath(baseDir, "ledger")
+	if count != 3 {
+		t.Fatalf("expected 3 relayed, got %d", count)
+	}
+
+	entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get whispers: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 whisper entries, got %d", len(entries))
+	}
+}
+
+func TestMurmurRelayContentAndMetadataPreserved(t *testing.T) {
+	relay, registry, _ := newTestRelay(t)
+	baseDir := t.TempDir()
+
+	now := time.Now().UTC()
+	writeMurmurAt(t, baseDir, ledger.MurmurFile{
+		ID:            "murmur-meta",
+		Timestamp:     now,
+		AgentID:       "agent-42",
+		AgentType:     "claude-code",
+		PrincipalID:   "user-99",
+		PrincipalType: "human",
+		Topic:         "security",
+		Importance:    "critical",
+		Content:       "rotate the API keys immediately",
+		Metadata: map[string]string{
+			"source_file": "config.yaml",
+			"severity":    "high",
+		},
+	})
+
+	count := relay.RelayFromPath(baseDir, "ledger")
+	if count != 1 {
+		t.Fatalf("expected 1 relayed, got %d", count)
+	}
+
+	entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get whispers: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+	if e.Content != "rotate the API keys immediately" {
+		t.Errorf("content mismatch: %s", e.Content)
+	}
+	if e.Topic != "security" {
+		t.Errorf("topic mismatch: %s", e.Topic)
+	}
+	if e.Importance != whisperstore.ImportanceCritical {
+		t.Errorf("importance mismatch: %s", e.Importance)
+	}
+	if e.AgentID != "agent-42" {
+		t.Errorf("agent_id mismatch: %s", e.AgentID)
+	}
+	if e.PrincipalID != "user-99" {
+		t.Errorf("principal_id mismatch: %s", e.PrincipalID)
+	}
+	if e.PrincipalType != "human" {
+		t.Errorf("principal_type mismatch: %s", e.PrincipalType)
+	}
+	if e.Source != "murmur" {
+		t.Errorf("source mismatch: %s", e.Source)
+	}
+	if e.Type != whisperstore.WhisperTrigger {
+		t.Errorf("type mismatch: %s", e.Type)
+	}
+	if len(e.Metadata) != 2 {
+		t.Fatalf("expected 2 metadata entries, got %d", len(e.Metadata))
+	}
+	if e.Metadata["source_file"] != "config.yaml" {
+		t.Errorf("metadata source_file mismatch: %s", e.Metadata["source_file"])
+	}
+	if e.Metadata["severity"] != "high" {
+		t.Errorf("metadata severity mismatch: %s", e.Metadata["severity"])
+	}
+}

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -37,6 +37,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/endpoint"
@@ -45,6 +46,7 @@ import (
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/manifest"
 	"github.com/sageox/ox/internal/version"
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
 
 // Sync timing constants - extracted for clarity and testability.
@@ -317,6 +319,9 @@ type SyncScheduler struct {
 
 	// notification store for team context change tracking
 	notifications *NotificationStore
+
+	// whisper registry for trigger whispers on sync events
+	whisperRegistry *WhisperRegistry
 }
 
 // syncError tracks a sync error with timestamp.
@@ -428,6 +433,13 @@ func (s *SyncScheduler) SetNotificationStore(store *NotificationStore) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.notifications = store
+}
+
+// SetWhisperRegistry sets the whisper registry for trigger whispers on sync events.
+func (s *SyncScheduler) SetWhisperRegistry(r *WhisperRegistry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.whisperRegistry = r
 }
 
 // captureHEAD returns the current HEAD SHA for a git repo.
@@ -2148,6 +2160,23 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 				s.notifications.RecordChanges(changedFiles, r.ws.TeamID, r.ws.TeamName)
 				s.logger.Debug("team context changes detected",
 					"team", r.ws.TeamName, "count", len(changedFiles))
+
+				// also emit trigger whispers for each changed file
+				if s.whisperRegistry != nil {
+					for _, cf := range changedFiles {
+						id, _ := uuid.NewV7()
+						s.whisperRegistry.Add("ledger", whisperstore.WhisperEntry{
+							ID:         id.String(),
+							Scope:      "ledger",
+							Type:       whisperstore.WhisperTrigger,
+							Source:     "team-context",
+							Topic:      "team-context",
+							Content:    fmt.Sprintf("Team context updated: %s", cf),
+							Importance: whisperstore.ImportanceNormal,
+							CreatedAt:  time.Now(),
+						})
+					}
+				}
 			}
 		}
 		s.logger.Debug("team context synced", "team", r.ws.TeamName, "duration", r.duration)

--- a/internal/daemon/whisper_registry.go
+++ b/internal/daemon/whisper_registry.go
@@ -1,0 +1,208 @@
+package daemon
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
+)
+
+// WhisperRegistry aggregates whisper stores across scopes (ledger + team)
+// and provides a unified API for adding and querying whispers.
+//
+// The daemon creates one WhisperRegistry at startup. It wraps:
+//   - One ledger whisper store (single-writer, owned by this daemon)
+//   - Zero or more team whisper stores (shared across daemons via WAL)
+type WhisperRegistry struct {
+	ledgerStore *whisperstore.Store
+	teamStores  map[string]*whisperstore.Store // teamID -> store
+	mu          sync.RWMutex
+	logger      *slog.Logger
+}
+
+// NewWhisperRegistry creates a new registry with the given ledger store.
+// Team stores can be added later via AddTeamStore.
+func NewWhisperRegistry(ledgerStore *whisperstore.Store, logger *slog.Logger) *WhisperRegistry {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &WhisperRegistry{
+		ledgerStore: ledgerStore,
+		teamStores:  make(map[string]*whisperstore.Store),
+		logger:      logger,
+	}
+}
+
+// AddTeamStore registers a team whisper store.
+func (r *WhisperRegistry) AddTeamStore(teamID string, store *whisperstore.Store) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.teamStores[teamID] = store
+}
+
+// Add routes entries to the correct store based on scope.
+func (r *WhisperRegistry) Add(scope string, entries ...whisperstore.WhisperEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	switch scope {
+	case "ledger":
+		if r.ledgerStore == nil {
+			return fmt.Errorf("no ledger store configured")
+		}
+		return r.ledgerStore.Add(entries...)
+	case "team":
+		// team entries go to all team stores (each daemon manages its own view)
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		for teamID, store := range r.teamStores {
+			if err := store.Add(entries...); err != nil {
+				r.logger.Warn("failed to add to team store", "team_id", teamID, "err", err)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown scope: %s", scope)
+	}
+}
+
+// GetWhispers queries ALL stores and merges results, sorted by importance then time.
+func (r *WhisperRegistry) GetWhispers(agentID string, attention whisperstore.Attention, topics []string) ([]whisperstore.WhisperEntry, error) {
+	var all []whisperstore.WhisperEntry
+
+	// query ledger store
+	if r.ledgerStore != nil {
+		entries, err := r.ledgerStore.GetWhispers(agentID, attention, topics)
+		if err != nil {
+			r.logger.Warn("ledger whisper query failed", "err", err)
+		} else {
+			all = append(all, entries...)
+		}
+	}
+
+	// query all team stores
+	r.mu.RLock()
+	stores := make(map[string]*whisperstore.Store, len(r.teamStores))
+	for k, v := range r.teamStores {
+		stores[k] = v
+	}
+	r.mu.RUnlock()
+
+	for teamID, store := range stores {
+		entries, err := store.GetWhispers(agentID, attention, topics)
+		if err != nil {
+			r.logger.Warn("team whisper query failed", "team_id", teamID, "err", err)
+			continue
+		}
+		all = append(all, entries...)
+	}
+
+	if all == nil {
+		all = []whisperstore.WhisperEntry{}
+	}
+	return all, nil
+}
+
+// IsRelayed checks if a murmur has been relayed in the appropriate store.
+func (r *WhisperRegistry) IsRelayed(murmurID, scope string) (bool, error) {
+	store := r.storeForScope(scope)
+	if store == nil {
+		return false, nil
+	}
+	return store.IsRelayed(murmurID, scope)
+}
+
+// MarkRelayed records that a murmur has been relayed.
+func (r *WhisperRegistry) MarkRelayed(murmurID, scope string) error {
+	store := r.storeForScope(scope)
+	if store == nil {
+		return nil
+	}
+	return store.MarkRelayed(murmurID, scope)
+}
+
+// RemoveCursor removes an agent's cursor from all stores.
+func (r *WhisperRegistry) RemoveCursor(agentID string) {
+	if r.ledgerStore != nil {
+		r.ledgerStore.RemoveCursor(agentID)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, store := range r.teamStores {
+		store.RemoveCursor(agentID)
+	}
+}
+
+// Prune runs cleanup on all stores.
+func (r *WhisperRegistry) Prune(retention time.Duration) {
+	if r.ledgerStore != nil {
+		result, err := r.ledgerStore.Prune(retention)
+		if err != nil {
+			r.logger.Warn("ledger whisper prune failed", "err", err)
+		} else if result.WhispersDeleted > 0 {
+			r.logger.Debug("ledger whisper prune", "deleted", result.WhispersDeleted, "vacuumed", result.Vacuumed)
+		}
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for teamID, store := range r.teamStores {
+		result, err := store.Prune(retention)
+		if err != nil {
+			r.logger.Warn("team whisper prune failed", "team_id", teamID, "err", err)
+		} else if result.WhispersDeleted > 0 {
+			r.logger.Debug("team whisper prune", "team_id", teamID, "deleted", result.WhispersDeleted)
+		}
+	}
+}
+
+// EnforceMaxSize runs size enforcement on all stores.
+func (r *WhisperRegistry) EnforceMaxSize(maxBytes int64) {
+	if r.ledgerStore != nil {
+		if err := r.ledgerStore.EnforceMaxSize(maxBytes); err != nil {
+			r.logger.Warn("ledger whisper size enforcement failed", "err", err)
+		}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for teamID, store := range r.teamStores {
+		if err := store.EnforceMaxSize(maxBytes); err != nil {
+			r.logger.Warn("team whisper size enforcement failed", "team_id", teamID, "err", err)
+		}
+	}
+}
+
+// Close closes all stores.
+func (r *WhisperRegistry) Close() error {
+	var firstErr error
+	if r.ledgerStore != nil {
+		if err := r.ledgerStore.Close(); err != nil {
+			firstErr = err
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, store := range r.teamStores {
+		if err := store.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// storeForScope returns the store that handles the given scope.
+// For "team", returns the ledger store as fallback (relayed records are co-located).
+func (r *WhisperRegistry) storeForScope(scope string) *whisperstore.Store {
+	switch scope {
+	case "ledger":
+		return r.ledgerStore
+	case "team":
+		// team relay tracking goes to ledger store (single writer)
+		return r.ledgerStore
+	default:
+		return r.ledgerStore
+	}
+}

--- a/internal/daemon/whisper_registry_test.go
+++ b/internal/daemon/whisper_registry_test.go
@@ -1,0 +1,120 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
+)
+
+func openTestStore(t *testing.T) *whisperstore.Store {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "whisper.db")
+	s, err := whisperstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestWhisperRegistryAddAndGet(t *testing.T) {
+	ledger := openTestStore(t)
+	team := openTestStore(t)
+
+	r := NewWhisperRegistry(ledger, nil)
+	r.AddTeamStore("team-1", team)
+	defer r.Close()
+
+	now := time.Now()
+
+	// add to ledger scope
+	err := r.Add("ledger", whisperstore.WhisperEntry{
+		ID: "l1", Scope: "ledger", Type: whisperstore.WhisperTrigger,
+		Source: "test", Topic: "lint", Content: "ledger lint",
+		Importance: whisperstore.ImportanceNormal, CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("add ledger: %v", err)
+	}
+
+	// add to team scope
+	err = r.Add("team", whisperstore.WhisperEntry{
+		ID: "t1", Scope: "team", Type: whisperstore.WhisperTrigger,
+		Source: "test", Topic: "architecture", Content: "team arch",
+		Importance: whisperstore.ImportanceCritical, CreatedAt: now.Add(time.Millisecond),
+	})
+	if err != nil {
+		t.Fatalf("add team: %v", err)
+	}
+
+	// get all whispers — should merge from both stores
+	got, err := r.GetWhispers("agent-1", whisperstore.AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+}
+
+func TestWhisperRegistryPrune(t *testing.T) {
+	ledger := openTestStore(t)
+	r := NewWhisperRegistry(ledger, nil)
+	defer r.Close()
+
+	old := time.Now().Add(-48 * time.Hour)
+	r.Add("ledger", whisperstore.WhisperEntry{
+		ID: "old", Scope: "ledger", Type: whisperstore.WhisperTrigger,
+		Source: "test", Topic: "lint", Content: "old",
+		Importance: whisperstore.ImportanceNormal, CreatedAt: old,
+	})
+
+	r.Prune(24 * time.Hour)
+
+	got, _ := r.GetWhispers("agent-1", whisperstore.AttentionAll, nil)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 after prune, got %d", len(got))
+	}
+}
+
+func TestWhisperRegistryRemoveCursor(t *testing.T) {
+	ledger := openTestStore(t)
+	r := NewWhisperRegistry(ledger, nil)
+	defer r.Close()
+
+	now := time.Now()
+	r.Add("ledger", whisperstore.WhisperEntry{
+		ID: "w1", Scope: "ledger", Type: whisperstore.WhisperTrigger,
+		Source: "test", Topic: "lint", Content: "test",
+		Importance: whisperstore.ImportanceNormal, CreatedAt: now,
+	})
+
+	// set cursor
+	r.GetWhispers("agent-1", whisperstore.AttentionAll, nil)
+
+	// remove cursor
+	r.RemoveCursor("agent-1")
+
+	// should get entries again
+	got, _ := r.GetWhispers("agent-1", whisperstore.AttentionAll, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 after cursor reset, got %d", len(got))
+	}
+}
+
+func TestWhisperRegistryUnknownScope(t *testing.T) {
+	ledger := openTestStore(t)
+	r := NewWhisperRegistry(ledger, nil)
+	defer r.Close()
+
+	err := r.Add("unknown", whisperstore.WhisperEntry{
+		ID: "x", Scope: "unknown", Type: whisperstore.WhisperTrigger,
+		Source: "test", Topic: "lint", Content: "test",
+		Importance: whisperstore.ImportanceNormal, CreatedAt: time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown scope")
+	}
+}

--- a/internal/daemon/whisper_scheduler.go
+++ b/internal/daemon/whisper_scheduler.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
+)
+
+// TimeBasedSource produces whisper entries on a periodic interval.
+type TimeBasedSource interface {
+	Name() string
+	Interval() time.Duration
+	Produce(ctx context.Context) []whisperstore.WhisperEntry
+}
+
+// WhisperScheduler runs periodic whisper sources and feeds entries to the registry.
+type WhisperScheduler struct {
+	registry *WhisperRegistry
+	sources  []TimeBasedSource
+	logger   *slog.Logger
+	mu       sync.Mutex
+}
+
+// NewWhisperScheduler creates a scheduler that feeds periodic whisper entries to the registry.
+func NewWhisperScheduler(registry *WhisperRegistry, logger *slog.Logger) *WhisperScheduler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &WhisperScheduler{
+		registry: registry,
+		logger:   logger,
+	}
+}
+
+// RegisterSource adds a time-based source. Must be called before Start.
+func (s *WhisperScheduler) RegisterSource(source TimeBasedSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sources = append(s.sources, source)
+}
+
+// Start runs each source on its own ticker goroutine. Blocks until ctx is canceled.
+func (s *WhisperScheduler) Start(ctx context.Context, wg *sync.WaitGroup) {
+	s.mu.Lock()
+	sources := make([]TimeBasedSource, len(s.sources))
+	copy(sources, s.sources)
+	s.mu.Unlock()
+
+	for _, src := range sources {
+		wg.Add(1)
+		go func(source TimeBasedSource) {
+			defer wg.Done()
+			s.runSource(ctx, source)
+		}(src)
+	}
+}
+
+func (s *WhisperScheduler) runSource(ctx context.Context, source TimeBasedSource) {
+	ticker := time.NewTicker(source.Interval())
+	defer ticker.Stop()
+
+	s.logger.Debug("whisper source started", "name", source.Name(), "interval", source.Interval())
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			entries := source.Produce(ctx)
+			if len(entries) == 0 {
+				continue
+			}
+			if err := s.registry.Add("ledger", entries...); err != nil {
+				s.logger.Warn("failed to add whisper entries", "source", source.Name(), "err", err)
+			}
+		}
+	}
+}
+
+// RunPrune runs periodic cleanup on the whisper registry.
+// Called as a daemon goroutine.
+func (s *WhisperScheduler) RunPrune(ctx context.Context, wg *sync.WaitGroup, interval time.Duration) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.registry.Prune(24 * time.Hour)
+				s.registry.EnforceMaxSize(10 * 1024 * 1024) // 10MB
+			}
+		}
+	}()
+}

--- a/internal/daemon/whisper_scheduler_test.go
+++ b/internal/daemon/whisper_scheduler_test.go
@@ -1,0 +1,314 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
+)
+
+// stubSource is a test source with configurable behavior.
+type stubSource struct {
+	name     string
+	interval time.Duration
+	entries  []whisperstore.WhisperEntry
+	mu       sync.Mutex
+	calls    int
+}
+
+func (s *stubSource) Name() string            { return s.name }
+func (s *stubSource) Interval() time.Duration { return s.interval }
+
+func (s *stubSource) Produce(_ context.Context) []whisperstore.WhisperEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.entries
+}
+
+func (s *stubSource) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// newTestRegistry creates a WhisperRegistry backed by a real SQLite store in a temp dir.
+func newTestRegistry(t *testing.T) *WhisperRegistry {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "whisper.db")
+	store, err := whisperstore.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+	return NewWhisperRegistry(store, testLogger())
+}
+
+func TestWhisperScheduler_ProduceAtInterval(t *testing.T) {
+	registry := newTestRegistry(t)
+	scheduler := NewWhisperScheduler(registry, testLogger())
+
+	source := &stubSource{
+		name:     "test-source",
+		interval: 10 * time.Millisecond,
+		entries: []whisperstore.WhisperEntry{{
+			ID:         "entry-1",
+			Scope:      "ledger",
+			Type:       whisperstore.WhisperTimeBased,
+			Source:     "test-source",
+			Topic:      "test",
+			Content:    "hello",
+			Importance: whisperstore.ImportanceAmbient,
+			CreatedAt:  time.Now(),
+		}},
+	}
+	scheduler.RegisterSource(source)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	scheduler.Start(ctx, &wg)
+
+	// wait for at least 2 ticks
+	require.Eventually(t, func() bool {
+		return source.callCount() >= 2
+	}, 500*time.Millisecond, 5*time.Millisecond, "source should be called at least twice")
+
+	cancel()
+	wg.Wait()
+
+	// verify entries were added to the store
+	entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries, "entries should be present in the store")
+}
+
+func TestWhisperScheduler_ContextCancellation(t *testing.T) {
+	registry := newTestRegistry(t)
+	scheduler := NewWhisperScheduler(registry, testLogger())
+
+	source := &stubSource{
+		name:     "cancel-test",
+		interval: 10 * time.Millisecond,
+	}
+	scheduler.RegisterSource(source)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	scheduler.Start(ctx, &wg)
+
+	// cancel immediately
+	cancel()
+
+	// goroutines should exit promptly
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler goroutines did not exit after context cancellation")
+	}
+}
+
+func TestWhisperScheduler_EmptyEntriesNoOp(t *testing.T) {
+	registry := newTestRegistry(t)
+	scheduler := NewWhisperScheduler(registry, testLogger())
+
+	source := &stubSource{
+		name:     "empty-source",
+		interval: 10 * time.Millisecond,
+		entries:  nil, // returns no entries
+	}
+	scheduler.RegisterSource(source)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	scheduler.Start(ctx, &wg)
+
+	// wait for a few ticks
+	require.Eventually(t, func() bool {
+		return source.callCount() >= 3
+	}, 500*time.Millisecond, 5*time.Millisecond)
+
+	cancel()
+	wg.Wait()
+
+	// no entries should be in the store
+	entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "empty source should not add entries")
+}
+
+func TestWhisperScheduler_MultipleSources(t *testing.T) {
+	registry := newTestRegistry(t)
+	scheduler := NewWhisperScheduler(registry, testLogger())
+
+	fastSource := &stubSource{
+		name:     "fast",
+		interval: 10 * time.Millisecond,
+		entries: []whisperstore.WhisperEntry{{
+			ID:         "fast-entry",
+			Scope:      "ledger",
+			Type:       whisperstore.WhisperTimeBased,
+			Source:     "fast",
+			Topic:      "speed",
+			Content:    "fast data",
+			Importance: whisperstore.ImportanceNormal,
+			CreatedAt:  time.Now(),
+		}},
+	}
+
+	slowSource := &stubSource{
+		name:     "slow",
+		interval: 50 * time.Millisecond,
+		entries: []whisperstore.WhisperEntry{{
+			ID:         "slow-entry",
+			Scope:      "ledger",
+			Type:       whisperstore.WhisperTimeBased,
+			Source:     "slow",
+			Topic:      "patience",
+			Content:    "slow data",
+			Importance: whisperstore.ImportanceAmbient,
+			CreatedAt:  time.Now(),
+		}},
+	}
+
+	scheduler.RegisterSource(fastSource)
+	scheduler.RegisterSource(slowSource)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	scheduler.Start(ctx, &wg)
+
+	// wait for fast source to tick several times and slow at least once
+	require.Eventually(t, func() bool {
+		return fastSource.callCount() >= 3 && slowSource.callCount() >= 1
+	}, 500*time.Millisecond, 5*time.Millisecond)
+
+	// fast should have more calls than slow
+	assert.Greater(t, fastSource.callCount(), slowSource.callCount(),
+		"fast source should tick more frequently than slow source")
+
+	cancel()
+	wg.Wait()
+
+	// both sources should have contributed entries
+	entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(entries), 2, "both sources should contribute entries")
+}
+
+func TestWhisperScheduler_RunPrune(t *testing.T) {
+	registry := newTestRegistry(t)
+	scheduler := NewWhisperScheduler(registry, testLogger())
+
+	// add an old entry directly
+	err := registry.Add("ledger", whisperstore.WhisperEntry{
+		ID:         "old-entry",
+		Scope:      "ledger",
+		Type:       whisperstore.WhisperTimeBased,
+		Source:     "test",
+		Topic:      "test",
+		Content:    "old data",
+		Importance: whisperstore.ImportanceAmbient,
+		CreatedAt:  time.Now().Add(-48 * time.Hour), // 2 days old
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	scheduler.RunPrune(ctx, &wg, 10*time.Millisecond)
+
+	// wait for at least one prune cycle
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	wg.Wait()
+
+	// the 2-day-old entry should have been pruned (retention is 24h)
+	entries, err := registry.GetWhispers("test-agent", whisperstore.AttentionAll, nil)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "old entry should be pruned")
+}
+
+func TestActivitySummarySource_Content(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupHB     func(hb *HeartbeatHandler)
+		wantNil     bool
+		wantContent string
+	}{
+		{
+			name:    "no heartbeat activity produces nil",
+			wantNil: true,
+		},
+		{
+			name: "active agents reported",
+			setupHB: func(hb *HeartbeatHandler) {
+				hb.agentActivity.Record("agent-1")
+			},
+			wantContent: "1 coworker(s) active on this repo",
+		},
+		{
+			name: "multiple agents reported",
+			setupHB: func(hb *HeartbeatHandler) {
+				hb.agentActivity.Record("agent-1")
+				hb.agentActivity.Record("agent-2")
+				hb.agentActivity.Record("agent-3")
+			},
+			wantContent: "3 coworker(s) active on this repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hb := NewHeartbeatHandler(testLogger())
+			if tt.setupHB != nil {
+				tt.setupHB(hb)
+			}
+
+			source := NewActivitySummarySource(hb, nil)
+			assert.Equal(t, "activity-summary", source.Name())
+			assert.Equal(t, 30*time.Minute, source.Interval())
+
+			entries := source.Produce(context.Background())
+			if tt.wantNil {
+				assert.Nil(t, entries)
+				return
+			}
+
+			require.Len(t, entries, 1)
+			entry := entries[0]
+			assert.Contains(t, entry.Content, tt.wantContent)
+			assert.Equal(t, "ledger", entry.Scope)
+			assert.Equal(t, whisperstore.WhisperTimeBased, entry.Type)
+			assert.Equal(t, "activity-summary", entry.Source)
+			assert.Equal(t, "activity", entry.Topic)
+			assert.Equal(t, whisperstore.ImportanceAmbient, entry.Importance)
+			assert.NotEmpty(t, entry.ID)
+		})
+	}
+}
+
+func TestActivitySummarySource_NilDeps(t *testing.T) {
+	// both nil heartbeat and nil scheduler should not panic
+	source := NewActivitySummarySource(nil, nil)
+	entries := source.Produce(context.Background())
+	assert.Nil(t, entries)
+}

--- a/internal/daemon/whisper_sources.go
+++ b/internal/daemon/whisper_sources.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
+)
+
+// ActivitySummarySource produces periodic activity whispers.
+// Reports active coworker count and last sync time.
+type ActivitySummarySource struct {
+	heartbeat *HeartbeatHandler
+	scheduler *SyncScheduler
+}
+
+// NewActivitySummarySource creates a source that periodically summarizes
+// coworker activity and sync status as ambient whispers.
+func NewActivitySummarySource(heartbeat *HeartbeatHandler, scheduler *SyncScheduler) *ActivitySummarySource {
+	return &ActivitySummarySource{
+		heartbeat: heartbeat,
+		scheduler: scheduler,
+	}
+}
+
+func (s *ActivitySummarySource) Name() string { return "activity-summary" }
+
+func (s *ActivitySummarySource) Interval() time.Duration { return 30 * time.Minute }
+
+func (s *ActivitySummarySource) Produce(_ context.Context) []whisperstore.WhisperEntry {
+	var activeCount int
+	if s.heartbeat != nil {
+		summary := s.heartbeat.GetActivitySummary()
+		activeCount = len(summary.Agents)
+	}
+
+	var lastSyncStr string
+	if s.scheduler != nil {
+		lastSync := s.scheduler.LastSync()
+		if !lastSync.IsZero() {
+			ago := time.Since(lastSync).Round(time.Minute)
+			lastSyncStr = fmt.Sprintf(", last sync %s ago", ago)
+		}
+	}
+
+	if activeCount == 0 && lastSyncStr == "" {
+		return nil
+	}
+
+	content := fmt.Sprintf("%d coworker(s) active on this repo%s", activeCount, lastSyncStr)
+
+	id, err := uuid.NewV7()
+	if err != nil {
+		id = uuid.New()
+	}
+
+	return []whisperstore.WhisperEntry{{
+		ID:         id.String(),
+		Scope:      "ledger",
+		Type:       whisperstore.WhisperTimeBased,
+		Source:     "activity-summary",
+		Topic:      "activity",
+		Content:    content,
+		Importance: whisperstore.ImportanceAmbient,
+		CreatedAt:  time.Now(),
+	}}
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -369,9 +369,10 @@ func InitForEndpoint(endpointURL string, remoteURL string) (*Ledger, error) {
 }
 
 // CloneWithSparseCheckout clones a remote repo with sparse checkout enabled.
-// Only .sync/, sessions/, audit/, and recent data/github/ directories are checked out.
-// The assets/ directory and older GitHub data are excluded to save space.
-// Exported for use by the daemon's GC reclone (fresh clone with sparse checkout).
+// Only .sync/, sessions/, audit/, recent data/github/, and recent data/murmurs/
+// directories are checked out. The assets/ directory and older data are excluded
+// to save space. Exported for use by the daemon's GC reclone (fresh clone with
+// sparse checkout).
 func CloneWithSparseCheckout(path, remoteURL string) error {
 	// remove existing directory if empty
 	entries, _ := os.ReadDir(path)
@@ -399,8 +400,9 @@ func CloneWithSparseCheckout(path, remoteURL string) error {
 }
 
 // ConfigureSparseCheckout sets up sparse checkout for the ledger.
-// Includes: .sync/, sessions/, audit/, and a sliding window of recent GitHub data
-// Excludes: assets/ (large files), older GitHub data outside the window
+// Includes: .sync/, sessions/, audit/, a sliding window of recent GitHub data,
+// and a rolling window of recent murmur data (hourly granularity).
+// Excludes: assets/ (large files), older data outside the windows.
 //
 // Called during initial clone (CloneWithSparseCheckout) and by EnableSparseCheckout.
 // Future: daemon GC reclone will also call this to reconfigure the sliding window
@@ -426,6 +428,11 @@ func ConfigureSparseCheckout(path string) error {
 	// add sliding window of recent GitHub data (last N days, default 30)
 	// keeps local disk usage small; older data lives in git history
 	dirs = append(dirs, ComputeGitHubDataPaths(DefaultGitHubDataWindowDays)...)
+
+	// add rolling window of recent murmur data (last N hours, default 12)
+	// hourly granularity keeps the checkout tight while ensuring the daemon
+	// can read murmur files after git pull
+	dirs = append(dirs, ComputeMurmurDataPaths(DefaultMurmurWindowHours)...)
 
 	// set directories to include (excludes everything else like assets/)
 	args := append([]string{"-C", path, "sparse-checkout", "set"}, dirs...)

--- a/internal/ledger/murmur.go
+++ b/internal/ledger/murmur.go
@@ -1,0 +1,127 @@
+package ledger
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DefaultMurmurWindowHours is the default rolling sparse checkout window.
+const DefaultMurmurWindowHours = 12
+
+// MurmurFile is the JSON schema for a murmur file stored in the ledger.
+type MurmurFile struct {
+	SchemaVersion string            `json:"schema_version"`           // "1"
+	ID            string            `json:"id"`                       // UUIDv7
+	Timestamp     time.Time         `json:"timestamp"`                // when the murmur was created
+	AgentID       string            `json:"agent_id,omitempty"`       // which agent instance
+	AgentType     string            `json:"agent_type,omitempty"`     // "claude-code", etc.
+	PrincipalID   string            `json:"principal_id,omitempty"`   // who the agent works for
+	PrincipalType string            `json:"principal_type,omitempty"` // "human" for now
+	Topic         string            `json:"topic"`                    // freeform slug
+	Importance    string            `json:"importance"`               // "critical", "normal", "ambient"
+	Content       string            `json:"content"`                  // the spoken message
+	Metadata      map[string]string `json:"metadata,omitempty"`       // optional structured context
+	Tags          []string          `json:"tags,omitempty"`
+	Scope         string            `json:"scope,omitempty"` // "ledger" or "team" (informational)
+}
+
+// MurmurDateHourDir returns the relative directory path for murmurs at a given time.
+// Format: data/murmurs/YYYY-MM-DD/HH/
+func MurmurDateHourDir(t time.Time) string {
+	return filepath.Join("data", "murmurs", t.Format("2006-01-02"), fmt.Sprintf("%02d", t.Hour()))
+}
+
+// MurmurFilePath returns the relative path for a murmur file.
+// Format: data/murmurs/YYYY-MM-DD/HH/<id>.json
+func MurmurFilePath(t time.Time, id string) string {
+	return filepath.Join(MurmurDateHourDir(t), id+".json")
+}
+
+// ComputeMurmurDataPaths generates sparse checkout paths for the last N hours.
+// Returns paths like "data/murmurs/2026-03-22/14/" for each hour in the window.
+// Correctly handles date boundary crossing (e.g., window spanning midnight).
+func ComputeMurmurDataPaths(hours int) []string {
+	now := time.Now().UTC()
+	seen := make(map[string]bool)
+	var paths []string
+
+	for i := 0; i < hours; i++ {
+		t := now.Add(-time.Duration(i) * time.Hour)
+		p := MurmurDateHourDir(t) + "/"
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+
+	return paths
+}
+
+// WriteMurmur writes a murmur file to the given base directory.
+// Creates the hourly partition directory if needed. Returns the relative path
+// of the written file within baseDir.
+func WriteMurmur(baseDir string, m MurmurFile) (string, error) {
+	if m.SchemaVersion == "" {
+		m.SchemaVersion = "1"
+	}
+
+	relPath := MurmurFilePath(m.Timestamp, m.ID)
+	fullPath := filepath.Join(baseDir, relPath)
+
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		return "", fmt.Errorf("create murmur dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal murmur: %w", err)
+	}
+
+	if err := os.WriteFile(fullPath, data, 0o644); err != nil {
+		return "", fmt.Errorf("write murmur: %w", err)
+	}
+
+	return relPath, nil
+}
+
+// ReadMurmursInWindow reads all murmur files within the given time window.
+// Skips invalid JSON files without error (best-effort).
+// baseDir is the root of the ledger or team context checkout.
+func ReadMurmursInWindow(baseDir string, windowHours int) ([]MurmurFile, error) {
+	now := time.Now().UTC()
+	var murmurs []MurmurFile
+
+	for i := 0; i < windowHours; i++ {
+		t := now.Add(-time.Duration(i) * time.Hour)
+		dir := filepath.Join(baseDir, MurmurDateHourDir(t))
+
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			// missing or unreadable directories are not fatal
+			continue
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+				continue
+			}
+
+			data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				continue
+			}
+
+			var m MurmurFile
+			if err := json.Unmarshal(data, &m); err != nil {
+				continue // skip invalid JSON
+			}
+
+			murmurs = append(murmurs, m)
+		}
+	}
+
+	return murmurs, nil
+}

--- a/internal/ledger/murmur_test.go
+++ b/internal/ledger/murmur_test.go
@@ -1,0 +1,615 @@
+package ledger
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMurmurDateHourDir(t *testing.T) {
+	tests := []struct {
+		name string
+		time time.Time
+		want string
+	}{
+		{
+			name: "afternoon",
+			time: time.Date(2026, 3, 22, 14, 30, 0, 0, time.UTC),
+			want: filepath.Join("data", "murmurs", "2026-03-22", "14"),
+		},
+		{
+			name: "midnight",
+			time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			want: filepath.Join("data", "murmurs", "2026-01-01", "00"),
+		},
+		{
+			name: "end of day",
+			time: time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC),
+			want: filepath.Join("data", "murmurs", "2026-12-31", "23"),
+		},
+		{
+			name: "single digit month and day",
+			time: time.Date(2026, 3, 5, 9, 0, 0, 0, time.UTC),
+			want: filepath.Join("data", "murmurs", "2026-03-05", "09"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MurmurDateHourDir(tt.time)
+			if got != tt.want {
+				t.Errorf("MurmurDateHourDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMurmurFilePath(t *testing.T) {
+	tests := []struct {
+		name string
+		time time.Time
+		id   string
+		want string
+	}{
+		{
+			name: "standard path",
+			time: time.Date(2026, 3, 22, 14, 0, 0, 0, time.UTC),
+			id:   "01961234-5678-7abc-def0-123456789abc",
+			want: filepath.Join("data", "murmurs", "2026-03-22", "14", "01961234-5678-7abc-def0-123456789abc.json"),
+		},
+		{
+			name: "midnight boundary",
+			time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			id:   "test-id",
+			want: filepath.Join("data", "murmurs", "2026-01-01", "00", "test-id.json"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MurmurFilePath(tt.time, tt.id)
+			if got != tt.want {
+				t.Errorf("MurmurFilePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeMurmurDataPaths(t *testing.T) {
+	t.Run("generates correct count", func(t *testing.T) {
+		paths := ComputeMurmurDataPaths(12)
+		if len(paths) != 12 {
+			t.Errorf("expected 12 paths, got %d", len(paths))
+		}
+	})
+
+	t.Run("no duplicates", func(t *testing.T) {
+		paths := ComputeMurmurDataPaths(24)
+		seen := make(map[string]bool)
+		for _, p := range paths {
+			if seen[p] {
+				t.Errorf("duplicate path: %s", p)
+			}
+			seen[p] = true
+		}
+	})
+
+	t.Run("all paths have trailing slash", func(t *testing.T) {
+		paths := ComputeMurmurDataPaths(6)
+		for _, p := range paths {
+			if !strings.HasSuffix(p, "/") {
+				t.Errorf("path missing trailing slash: %s", p)
+			}
+		}
+	})
+
+	t.Run("all paths start with data/murmurs/", func(t *testing.T) {
+		paths := ComputeMurmurDataPaths(6)
+		prefix := filepath.Join("data", "murmurs") + "/"
+		for _, p := range paths {
+			if !strings.HasPrefix(p, prefix) {
+				t.Errorf("path %q does not start with %q", p, prefix)
+			}
+		}
+	})
+
+	t.Run("zero hours returns empty", func(t *testing.T) {
+		paths := ComputeMurmurDataPaths(0)
+		if len(paths) != 0 {
+			t.Errorf("expected 0 paths, got %d", len(paths))
+		}
+	})
+}
+
+func TestComputeMurmurDataPaths_DateBoundaryCrossing(t *testing.T) {
+	// We can't control time.Now() directly, but we can verify that a 24-hour
+	// window always produces paths spanning at least 2 calendar dates (unless
+	// it's exactly midnight, in which case exactly at the boundary).
+	paths := ComputeMurmurDataPaths(24)
+
+	dates := make(map[string]bool)
+	for _, p := range paths {
+		// extract YYYY-MM-DD from "data/murmurs/YYYY-MM-DD/HH/"
+		parts := strings.Split(p, "/")
+		if len(parts) >= 4 {
+			dates[parts[2]] = true
+		}
+	}
+
+	// a 24-hour window must span at least 2 calendar dates
+	// (unless we're exactly at 23:00 UTC, we get today + yesterday)
+	if len(dates) < 2 {
+		t.Errorf("24-hour window should span at least 2 dates, got %d: %v", len(dates), dates)
+	}
+}
+
+func TestWriteMurmur(t *testing.T) {
+	t.Run("creates directory and file", func(t *testing.T) {
+		baseDir := t.TempDir()
+		ts := time.Date(2026, 3, 22, 14, 30, 0, 0, time.UTC)
+
+		m := MurmurFile{
+			SchemaVersion: "1",
+			ID:            "test-murmur-001",
+			Timestamp:     ts,
+			AgentID:       "agent-123",
+			AgentType:     "claude-code",
+			Topic:         "architecture",
+			Importance:    "normal",
+			Content:       "This service should use connection pooling.",
+		}
+
+		relPath, err := WriteMurmur(baseDir, m)
+		if err != nil {
+			t.Fatalf("WriteMurmur: %v", err)
+		}
+
+		expectedRel := MurmurFilePath(ts, m.ID)
+		if relPath != expectedRel {
+			t.Errorf("relPath = %q, want %q", relPath, expectedRel)
+		}
+
+		// verify file exists and is valid JSON
+		fullPath := filepath.Join(baseDir, relPath)
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Fatalf("read written file: %v", err)
+		}
+
+		var read MurmurFile
+		if err := json.Unmarshal(data, &read); err != nil {
+			t.Fatalf("unmarshal written file: %v", err)
+		}
+
+		if read.ID != m.ID {
+			t.Errorf("ID = %q, want %q", read.ID, m.ID)
+		}
+		if read.Content != m.Content {
+			t.Errorf("Content = %q, want %q", read.Content, m.Content)
+		}
+		if read.Topic != "architecture" {
+			t.Errorf("Topic = %q, want %q", read.Topic, "architecture")
+		}
+	})
+
+	t.Run("defaults schema version to 1", func(t *testing.T) {
+		baseDir := t.TempDir()
+		ts := time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC)
+
+		m := MurmurFile{
+			ID:         "test-default-schema",
+			Timestamp:  ts,
+			Topic:      "test",
+			Importance: "ambient",
+			Content:    "hello",
+			// SchemaVersion intentionally empty
+		}
+
+		relPath, err := WriteMurmur(baseDir, m)
+		if err != nil {
+			t.Fatalf("WriteMurmur: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(baseDir, relPath))
+		if err != nil {
+			t.Fatalf("read file: %v", err)
+		}
+
+		var read MurmurFile
+		json.Unmarshal(data, &read)
+		if read.SchemaVersion != "1" {
+			t.Errorf("SchemaVersion = %q, want %q", read.SchemaVersion, "1")
+		}
+	})
+}
+
+func TestReadMurmursInWindow(t *testing.T) {
+	t.Run("reads murmurs within window", func(t *testing.T) {
+		baseDir := t.TempDir()
+		now := time.Now().UTC()
+
+		// write a murmur in the current hour
+		m := MurmurFile{
+			SchemaVersion: "1",
+			ID:            "recent-murmur",
+			Timestamp:     now,
+			Topic:         "test",
+			Importance:    "normal",
+			Content:       "recent message",
+		}
+		if _, err := WriteMurmur(baseDir, m); err != nil {
+			t.Fatalf("WriteMurmur: %v", err)
+		}
+
+		murmurs, err := ReadMurmursInWindow(baseDir, 1)
+		if err != nil {
+			t.Fatalf("ReadMurmursInWindow: %v", err)
+		}
+
+		if len(murmurs) != 1 {
+			t.Fatalf("expected 1 murmur, got %d", len(murmurs))
+		}
+		if murmurs[0].ID != "recent-murmur" {
+			t.Errorf("ID = %q, want %q", murmurs[0].ID, "recent-murmur")
+		}
+	})
+
+	t.Run("excludes murmurs outside window", func(t *testing.T) {
+		baseDir := t.TempDir()
+		now := time.Now().UTC()
+
+		// write a murmur 24 hours ago
+		old := now.Add(-24 * time.Hour)
+		m := MurmurFile{
+			SchemaVersion: "1",
+			ID:            "old-murmur",
+			Timestamp:     old,
+			Topic:         "test",
+			Importance:    "normal",
+			Content:       "old message",
+		}
+		if _, err := WriteMurmur(baseDir, m); err != nil {
+			t.Fatalf("WriteMurmur: %v", err)
+		}
+
+		// read with 1 hour window — should not include the old murmur
+		murmurs, err := ReadMurmursInWindow(baseDir, 1)
+		if err != nil {
+			t.Fatalf("ReadMurmursInWindow: %v", err)
+		}
+
+		if len(murmurs) != 0 {
+			t.Errorf("expected 0 murmurs in 1-hour window, got %d", len(murmurs))
+		}
+	})
+
+	t.Run("empty directories handled gracefully", func(t *testing.T) {
+		baseDir := t.TempDir()
+
+		murmurs, err := ReadMurmursInWindow(baseDir, 12)
+		if err != nil {
+			t.Fatalf("ReadMurmursInWindow: %v", err)
+		}
+
+		if len(murmurs) != 0 {
+			t.Errorf("expected 0 murmurs, got %d", len(murmurs))
+		}
+	})
+
+	t.Run("invalid JSON files are skipped", func(t *testing.T) {
+		baseDir := t.TempDir()
+		now := time.Now().UTC()
+
+		// write a valid murmur
+		valid := MurmurFile{
+			SchemaVersion: "1",
+			ID:            "valid-murmur",
+			Timestamp:     now,
+			Topic:         "test",
+			Importance:    "normal",
+			Content:       "valid",
+		}
+		if _, err := WriteMurmur(baseDir, valid); err != nil {
+			t.Fatalf("WriteMurmur: %v", err)
+		}
+
+		// write an invalid JSON file in the same directory
+		dir := filepath.Join(baseDir, MurmurDateHourDir(now))
+		invalidPath := filepath.Join(dir, "bad-file.json")
+		os.WriteFile(invalidPath, []byte("not valid json{{{"), 0o644)
+
+		// write a non-JSON file (should also be skipped)
+		txtPath := filepath.Join(dir, "notes.txt")
+		os.WriteFile(txtPath, []byte("just a text file"), 0o644)
+
+		murmurs, err := ReadMurmursInWindow(baseDir, 1)
+		if err != nil {
+			t.Fatalf("ReadMurmursInWindow: %v", err)
+		}
+
+		if len(murmurs) != 1 {
+			t.Errorf("expected 1 valid murmur (skipping invalid), got %d", len(murmurs))
+		}
+		if len(murmurs) > 0 && murmurs[0].ID != "valid-murmur" {
+			t.Errorf("ID = %q, want %q", murmurs[0].ID, "valid-murmur")
+		}
+	})
+}
+
+func TestMurmurRoundTrip(t *testing.T) {
+	baseDir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	original := MurmurFile{
+		SchemaVersion: "1",
+		ID:            "round-trip-test",
+		Timestamp:     now,
+		AgentID:       "agent-abc",
+		AgentType:     "claude-code",
+		PrincipalID:   "user-xyz",
+		PrincipalType: "human",
+		Topic:         "database-migration",
+		Importance:    "critical",
+		Content:       "Remember to add an index on the users table.",
+		Metadata:      map[string]string{"table": "users", "column": "email"},
+		Tags:          []string{"database", "performance"},
+		Scope:         "ledger",
+	}
+
+	_, err := WriteMurmur(baseDir, original)
+	if err != nil {
+		t.Fatalf("WriteMurmur: %v", err)
+	}
+
+	murmurs, err := ReadMurmursInWindow(baseDir, 1)
+	if err != nil {
+		t.Fatalf("ReadMurmursInWindow: %v", err)
+	}
+
+	if len(murmurs) != 1 {
+		t.Fatalf("expected 1 murmur, got %d", len(murmurs))
+	}
+
+	got := murmurs[0]
+	if got.ID != original.ID {
+		t.Errorf("ID = %q, want %q", got.ID, original.ID)
+	}
+	if got.SchemaVersion != "1" {
+		t.Errorf("SchemaVersion = %q, want %q", got.SchemaVersion, "1")
+	}
+	if !got.Timestamp.Equal(original.Timestamp) {
+		t.Errorf("Timestamp = %v, want %v", got.Timestamp, original.Timestamp)
+	}
+	if got.AgentID != original.AgentID {
+		t.Errorf("AgentID = %q, want %q", got.AgentID, original.AgentID)
+	}
+	if got.AgentType != original.AgentType {
+		t.Errorf("AgentType = %q, want %q", got.AgentType, original.AgentType)
+	}
+	if got.PrincipalID != original.PrincipalID {
+		t.Errorf("PrincipalID = %q, want %q", got.PrincipalID, original.PrincipalID)
+	}
+	if got.PrincipalType != original.PrincipalType {
+		t.Errorf("PrincipalType = %q, want %q", got.PrincipalType, original.PrincipalType)
+	}
+	if got.Topic != original.Topic {
+		t.Errorf("Topic = %q, want %q", got.Topic, original.Topic)
+	}
+	if got.Importance != original.Importance {
+		t.Errorf("Importance = %q, want %q", got.Importance, original.Importance)
+	}
+	if got.Content != original.Content {
+		t.Errorf("Content = %q, want %q", got.Content, original.Content)
+	}
+	if got.Scope != original.Scope {
+		t.Errorf("Scope = %q, want %q", got.Scope, original.Scope)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "database" || got.Tags[1] != "performance" {
+		t.Errorf("Tags = %v, want %v", got.Tags, original.Tags)
+	}
+	if got.Metadata["table"] != "users" || got.Metadata["column"] != "email" {
+		t.Errorf("Metadata = %v, want %v", got.Metadata, original.Metadata)
+	}
+}
+
+func TestMurmurOptionalFields(t *testing.T) {
+	// verify optional fields are omitted from JSON when empty
+	baseDir := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	minimal := MurmurFile{
+		SchemaVersion: "1",
+		ID:            "minimal-murmur",
+		Timestamp:     now,
+		Topic:         "test",
+		Importance:    "ambient",
+		Content:       "minimal message",
+		// all optional fields left empty
+	}
+
+	relPath, err := WriteMurmur(baseDir, minimal)
+	if err != nil {
+		t.Fatalf("WriteMurmur: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(baseDir, relPath))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	// verify omitempty fields are absent from JSON
+	jsonStr := string(data)
+	for _, field := range []string{"agent_id", "agent_type", "principal_id", "principal_type", "metadata", "tags", "scope"} {
+		if strings.Contains(jsonStr, fmt.Sprintf("%q", field)) {
+			t.Errorf("expected field %q to be omitted from JSON when empty", field)
+		}
+	}
+
+	// verify it still deserializes correctly
+	var read MurmurFile
+	if err := json.Unmarshal(data, &read); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if read.AgentID != "" {
+		t.Errorf("AgentID should be empty, got %q", read.AgentID)
+	}
+	if read.Metadata != nil {
+		t.Errorf("Metadata should be nil, got %v", read.Metadata)
+	}
+	if read.Tags != nil {
+		t.Errorf("Tags should be nil, got %v", read.Tags)
+	}
+}
+
+func TestWriteMurmur_MultipleInSameHour(t *testing.T) {
+	baseDir := t.TempDir()
+	now := time.Now().UTC()
+
+	for i := 0; i < 3; i++ {
+		m := MurmurFile{
+			ID:         fmt.Sprintf("murmur-%d", i),
+			Timestamp:  now,
+			Topic:      "batch",
+			Importance: "normal",
+			Content:    fmt.Sprintf("message %d", i),
+		}
+		if _, err := WriteMurmur(baseDir, m); err != nil {
+			t.Fatalf("WriteMurmur %d: %v", i, err)
+		}
+	}
+
+	murmurs, err := ReadMurmursInWindow(baseDir, 1)
+	if err != nil {
+		t.Fatalf("ReadMurmursInWindow: %v", err)
+	}
+
+	if len(murmurs) != 3 {
+		t.Errorf("expected 3 murmurs, got %d", len(murmurs))
+	}
+}
+
+// --- Sparse checkout integration tests ---
+
+func TestConfigureSparseCheckout_IncludesMurmurPaths(t *testing.T) {
+	tempDir := t.TempDir()
+
+	initCmd := exec.Command("git", "init", tempDir)
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	if err := ConfigureSparseCheckout(tempDir); err != nil {
+		t.Fatalf("ConfigureSparseCheckout: %v", err)
+	}
+
+	cmd := exec.Command("git", "-C", tempDir, "sparse-checkout", "list")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("sparse-checkout list: %v", err)
+	}
+
+	outputStr := string(output)
+
+	// base dirs must still be present
+	for _, dir := range []string{".sync", "sessions", "audit"} {
+		if !strings.Contains(outputStr, dir) {
+			t.Errorf("sparse checkout missing base dir %q", dir)
+		}
+	}
+
+	// current hour murmur path must be present
+	now := time.Now().UTC()
+	currentMurmurDir := MurmurDateHourDir(now)
+	if !strings.Contains(outputStr, currentMurmurDir) {
+		t.Errorf("sparse checkout missing current murmur hour path %q in output:\n%s", currentMurmurDir, outputStr)
+	}
+
+	// today's GitHub data path must still be present
+	todayGitHub := fmt.Sprintf("data/github/%d/%02d/%02d", now.Year(), now.Month(), now.Day())
+	if !strings.Contains(outputStr, todayGitHub) {
+		t.Errorf("sparse checkout missing today's GitHub data path %q", todayGitHub)
+	}
+}
+
+func TestConfigureSparseCheckout_MurmurPathCount(t *testing.T) {
+	tempDir := t.TempDir()
+
+	initCmd := exec.Command("git", "init", tempDir)
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	if err := ConfigureSparseCheckout(tempDir); err != nil {
+		t.Fatalf("ConfigureSparseCheckout: %v", err)
+	}
+
+	cmd := exec.Command("git", "-C", tempDir, "sparse-checkout", "list")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("sparse-checkout list: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	murmurCount := 0
+	for _, line := range lines {
+		if strings.Contains(line, "data/murmurs/") {
+			murmurCount++
+		}
+	}
+
+	if murmurCount != DefaultMurmurWindowHours {
+		t.Errorf("expected %d murmur paths in sparse checkout, got %d", DefaultMurmurWindowHours, murmurCount)
+	}
+}
+
+func TestConfigureSparseCheckout_MurmurDoesNotBreakExisting(t *testing.T) {
+	// verify that adding murmur paths doesn't remove or corrupt existing
+	// sparse checkout entries (GitHub data, base dirs)
+	tempDir := t.TempDir()
+
+	initCmd := exec.Command("git", "init", tempDir)
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	if err := ConfigureSparseCheckout(tempDir); err != nil {
+		t.Fatalf("ConfigureSparseCheckout: %v", err)
+	}
+
+	cmd := exec.Command("git", "-C", tempDir, "sparse-checkout", "list")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("sparse-checkout list: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+
+	githubCount := 0
+	for _, line := range lines {
+		if strings.Contains(line, "data/github/") {
+			githubCount++
+		}
+	}
+
+	if githubCount != DefaultGitHubDataWindowDays {
+		t.Errorf("expected %d GitHub data paths, got %d (murmur integration may have broken GitHub paths)", DefaultGitHubDataWindowDays, githubCount)
+	}
+
+	// total should be base dirs + GitHub + murmur
+	expectedTotal := 3 + DefaultGitHubDataWindowDays + DefaultMurmurWindowHours
+	if len(lines) != expectedTotal {
+		t.Errorf("expected %d total sparse checkout entries (3 base + %d GitHub + %d murmur), got %d",
+			expectedTotal, DefaultGitHubDataWindowDays, DefaultMurmurWindowHours, len(lines))
+	}
+}
+
+func TestDefaultMurmurWindowHours(t *testing.T) {
+	if DefaultMurmurWindowHours != 12 {
+		t.Errorf("DefaultMurmurWindowHours = %d, want 12", DefaultMurmurWindowHours)
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -143,6 +143,26 @@ func CodeDBSharedDir(repoID, endpointURL string) string {
 	return filepath.Join(LedgersDataDir(repoID, endpointURL), ".sageox", "cache", "codedb")
 }
 
+// WhisperDBDir returns the directory for the whisper SQLite database.
+// Stored inside the ledger's local cache, shared across all worktrees for the same repo.
+// Format: ~/.local/share/sageox/<endpoint>/ledgers/<repoID>/.sageox/cache/whisper/
+func WhisperDBDir(repoID, endpointURL string) string {
+	if repoID == "" || endpointURL == "" {
+		return ""
+	}
+	return filepath.Join(LedgersDataDir(repoID, endpointURL), ".sageox", "cache", "whisper")
+}
+
+// TeamWhisperDBDir returns the directory for a team's whisper SQLite database.
+// Shared across daemons on the same machine that pull the same team context.
+// Format: ~/.local/share/sageox/<endpoint>/teams/<teamID>/.sageox/cache/whisper/
+func TeamWhisperDBDir(teamID, endpointURL string) string {
+	if teamID == "" || endpointURL == "" {
+		return ""
+	}
+	return filepath.Join(TeamContextDir(teamID, endpointURL), ".sageox", "cache", "whisper")
+}
+
 // LedgerSessionCacheBase returns the base cache directory inside a repo's ledger.
 // Session recording states are stored under <base>/sessions/<session-name>/.
 // This is the canonical, environment-independent cache location — unlike XDG cache dirs

--- a/internal/whisper/store/schema.go
+++ b/internal/whisper/store/schema.go
@@ -1,0 +1,46 @@
+package store
+
+import "database/sql"
+
+const schemaDDL = `
+CREATE TABLE IF NOT EXISTS whispers (
+    id              TEXT PRIMARY KEY,
+    scope           TEXT NOT NULL,
+    type            TEXT NOT NULL,
+    source          TEXT NOT NULL,
+    topic           TEXT NOT NULL,
+    content         TEXT NOT NULL,
+    importance      TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    agent_id        TEXT,
+    principal_id    TEXT,               -- who the agent works for (optional)
+    principal_type  TEXT,               -- "human" for now (optional, extensible)
+    team_id         TEXT,
+    metadata        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_whispers_created ON whispers(created_at);
+CREATE INDEX IF NOT EXISTS idx_whispers_scope ON whispers(scope, created_at);
+CREATE INDEX IF NOT EXISTS idx_whispers_importance ON whispers(importance, created_at);
+CREATE INDEX IF NOT EXISTS idx_whispers_topic ON whispers(topic, created_at);
+
+CREATE TABLE IF NOT EXISTS cursors (
+    agent_id    TEXT PRIMARY KEY,
+    last_seen   TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS relayed_murmurs (
+    murmur_id   TEXT NOT NULL,
+    scope       TEXT NOT NULL,
+    relayed_at  TEXT NOT NULL,
+    PRIMARY KEY (murmur_id, scope)
+);
+CREATE INDEX IF NOT EXISTS idx_relayed_scope ON relayed_murmurs(scope, relayed_at);
+`
+
+// CreateSchema initializes the whisper store tables and indexes.
+func CreateSchema(db *sql.DB) error {
+	_, err := db.Exec(schemaDDL)
+	return err
+}

--- a/internal/whisper/store/store.go
+++ b/internal/whisper/store/store.go
@@ -1,0 +1,485 @@
+// Package store provides a SQLite-backed whisper store for the daemon.
+//
+// The store tracks whisper entries (inbound signals to agents), per-agent
+// delivery cursors, and relayed murmur dedup state. It is designed as an
+// ephemeral local cache — all data is rebuildable from the ledger's murmur
+// files. If corrupt, the store auto-recovers by deleting and recreating.
+//
+// See docs/ai/specs/daemon-state-principles.md for design principles.
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Importance levels (sender sets this).
+type Importance string
+
+const (
+	ImportanceCritical Importance = "critical"
+	ImportanceNormal   Importance = "normal"
+	ImportanceAmbient  Importance = "ambient"
+)
+
+// Attention levels (receiver configures this).
+type Attention string
+
+const (
+	AttentionAll     Attention = "all"     // hear everything
+	AttentionNormal  Attention = "normal"  // critical + normal (default)
+	AttentionFocused Attention = "focused" // critical only
+)
+
+// WhisperType categorizes the origin of a whisper.
+type WhisperType string
+
+const (
+	WhisperStructural WhisperType = "structural"
+	WhisperTimeBased  WhisperType = "time-based"
+	WhisperTrigger    WhisperType = "trigger"
+)
+
+// WhisperEntry is a single whisper destined for agent delivery.
+type WhisperEntry struct {
+	ID            string            `json:"id"`
+	Scope         string            `json:"scope"`                    // "ledger" or "team"
+	Type          WhisperType       `json:"type"`
+	Source        string            `json:"source"`
+	Topic         string            `json:"topic"`
+	Content       string            `json:"content"`
+	Importance    Importance        `json:"importance"`
+	CreatedAt     time.Time         `json:"created_at"`
+	AgentID       string            `json:"agent_id,omitempty"`
+	PrincipalID   string            `json:"principal_id,omitempty"`   // who the agent works for (optional)
+	PrincipalType string            `json:"principal_type,omitempty"` // "human" for now (optional, extensible)
+	TeamID        string            `json:"team_id,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}
+
+// Store wraps a SQLite database for whisper state.
+// All write access goes through the daemon (single writer).
+// Multiple readers (CLI via IPC) are safe via WAL mode.
+type Store struct {
+	db        *sql.DB
+	dbPath    string
+	closeOnce sync.Once
+}
+
+// Open opens (or creates) a whisper store at the given path.
+// Auto-recovers from corruption by deleting and recreating the DB.
+// Callers never see corruption errors — the store silently rebuilds.
+func Open(dbPath string) (*Store, error) {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create whisper db dir: %w", err)
+	}
+
+	db, err := openSQLite(dbPath)
+	if err != nil {
+		slog.Warn("whisper db open failed, recreating", "path", dbPath, "err", err)
+		removeSQLiteFiles(dbPath)
+		db, err = openSQLite(dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("open whisper db after recovery: %w", err)
+		}
+	}
+
+	if err := checkIntegrity(db); err != nil {
+		db.Close()
+		slog.Warn("whisper db corrupt, recreating", "path", dbPath, "err", err)
+		removeSQLiteFiles(dbPath)
+		db, err = openSQLite(dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("open whisper db after corruption recovery: %w", err)
+		}
+	}
+
+	if err := CreateSchema(db); err != nil {
+		db.Close()
+		slog.Warn("whisper db schema failed, recreating", "path", dbPath, "err", err)
+		removeSQLiteFiles(dbPath)
+		db, err = openSQLite(dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("open whisper db after schema recovery: %w", err)
+		}
+		if err := CreateSchema(db); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("create whisper schema: %w", err)
+		}
+	}
+
+	return &Store{db: db, dbPath: dbPath}, nil
+}
+
+func openSQLite(dbPath string) (*sql.DB, error) {
+	dsn := dbPath + "?" + strings.Join([]string{
+		"_pragma=journal_mode(WAL)",
+		"_pragma=foreign_keys(1)",
+		"_pragma=busy_timeout(5000)",
+		"_pragma=synchronous(NORMAL)",
+		"_pragma=cache_size(-8192)", // 8 MB — whisper DB is small
+		"_pragma=temp_store(MEMORY)",
+	}, "&")
+	return sql.Open("sqlite", dsn)
+}
+
+func checkIntegrity(db *sql.DB) error {
+	var result string
+	if err := db.QueryRow("PRAGMA integrity_check").Scan(&result); err != nil {
+		return fmt.Errorf("integrity_check query: %w", err)
+	}
+	if result != "ok" {
+		return fmt.Errorf("integrity_check: %s", result)
+	}
+	return nil
+}
+
+func removeSQLiteFiles(dbPath string) {
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		p := dbPath + suffix
+		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("failed to remove whisper db file", "path", p, "err", err)
+		}
+	}
+}
+
+// Close closes the store. Safe to call multiple times.
+func (s *Store) Close() error {
+	var firstErr error
+	s.closeOnce.Do(func() {
+		if s.db != nil {
+			firstErr = s.db.Close()
+		}
+	})
+	return firstErr
+}
+
+// Add inserts whisper entries. Duplicate IDs are silently ignored (upsert).
+func (s *Store) Add(entries ...WhisperEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`INSERT OR IGNORE INTO whispers
+		(id, scope, type, source, topic, content, importance, created_at,
+		 agent_id, principal_id, principal_type, team_id, metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, e := range entries {
+		var metadataJSON *string
+		if len(e.Metadata) > 0 {
+			b, _ := json.Marshal(e.Metadata)
+			s := string(b)
+			metadataJSON = &s
+		}
+		_, err := stmt.Exec(
+			e.ID, e.Scope, string(e.Type), e.Source, e.Topic,
+			e.Content, string(e.Importance),
+			e.CreatedAt.Format(time.RFC3339Nano),
+			nilIfEmpty(e.AgentID), nilIfEmpty(e.PrincipalID),
+			nilIfEmpty(e.PrincipalType), nilIfEmpty(e.TeamID),
+			metadataJSON,
+		)
+		if err != nil {
+			return fmt.Errorf("insert whisper %s: %w", e.ID, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetWhispers returns whisper entries for an agent, filtered by attention and topics.
+// Updates the agent's cursor so subsequent calls only return new entries.
+// On first call for an unknown agent, returns all current entries.
+func (s *Store) GetWhispers(agentID string, attention Attention, topics []string) ([]WhisperEntry, error) {
+	now := time.Now()
+
+	// read current cursor
+	var cursor time.Time
+	var cursorStr sql.NullString
+	err := s.db.QueryRow("SELECT last_seen FROM cursors WHERE agent_id = ?", agentID).Scan(&cursorStr)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("read cursor: %w", err)
+	}
+	if cursorStr.Valid {
+		cursor, _ = time.Parse(time.RFC3339Nano, cursorStr.String)
+	}
+
+	// build query with filters
+	query := `SELECT id, scope, type, source, topic, content, importance, created_at,
+		agent_id, principal_id, principal_type, team_id, metadata
+		FROM whispers WHERE created_at > ?`
+	args := []any{cursor.Format(time.RFC3339Nano)}
+
+	// attention filter
+	allowedImportance := importanceForAttention(attention)
+	if len(allowedImportance) > 0 && len(allowedImportance) < 3 {
+		placeholders := make([]string, len(allowedImportance))
+		for i, imp := range allowedImportance {
+			placeholders[i] = "?"
+			args = append(args, string(imp))
+		}
+		query += " AND importance IN (" + strings.Join(placeholders, ",") + ")"
+	}
+
+	// topic filter
+	if len(topics) > 0 {
+		placeholders := make([]string, len(topics))
+		for i, t := range topics {
+			placeholders[i] = "?"
+			args = append(args, t)
+		}
+		query += " AND topic IN (" + strings.Join(placeholders, ",") + ")"
+	}
+
+	// order: critical first, then normal, then ambient; within each, by time
+	query += ` ORDER BY CASE importance
+		WHEN 'critical' THEN 0
+		WHEN 'normal' THEN 1
+		WHEN 'ambient' THEN 2
+		ELSE 3 END, created_at`
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query whispers: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []WhisperEntry
+	for rows.Next() {
+		var e WhisperEntry
+		var createdStr string
+		var agentID, principalID, principalType, teamID, metadataJSON sql.NullString
+		var typ, imp string
+
+		if err := rows.Scan(
+			&e.ID, &e.Scope, &typ, &e.Source, &e.Topic, &e.Content, &imp, &createdStr,
+			&agentID, &principalID, &principalType, &teamID, &metadataJSON,
+		); err != nil {
+			return nil, fmt.Errorf("scan whisper: %w", err)
+		}
+
+		e.Type = WhisperType(typ)
+		e.Importance = Importance(imp)
+		e.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdStr)
+		e.AgentID = agentID.String
+		e.PrincipalID = principalID.String
+		e.PrincipalType = principalType.String
+		e.TeamID = teamID.String
+
+		if metadataJSON.Valid && metadataJSON.String != "" {
+			var m map[string]string
+			if json.Unmarshal([]byte(metadataJSON.String), &m) == nil {
+				e.Metadata = m
+			}
+		}
+
+		entries = append(entries, e)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate whispers: %w", err)
+	}
+
+	// update cursor
+	nowStr := now.Format(time.RFC3339Nano)
+	_, err = s.db.Exec(
+		`INSERT INTO cursors (agent_id, last_seen, updated_at) VALUES (?, ?, ?)
+		 ON CONFLICT(agent_id) DO UPDATE SET last_seen = excluded.last_seen, updated_at = excluded.updated_at`,
+		agentID, nowStr, nowStr,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update cursor: %w", err)
+	}
+
+	if entries == nil {
+		entries = []WhisperEntry{} // ensure JSON array, not null
+	}
+	return entries, nil
+}
+
+// IsRelayed checks if a murmur has already been relayed into the store.
+func (s *Store) IsRelayed(murmurID, scope string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM relayed_murmurs WHERE murmur_id = ? AND scope = ?",
+		murmurID, scope,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check relayed: %w", err)
+	}
+	return count > 0, nil
+}
+
+// MarkRelayed records that a murmur has been relayed into the store.
+func (s *Store) MarkRelayed(murmurID, scope string) error {
+	_, err := s.db.Exec(
+		"INSERT OR IGNORE INTO relayed_murmurs (murmur_id, scope, relayed_at) VALUES (?, ?, ?)",
+		murmurID, scope, time.Now().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("mark relayed: %w", err)
+	}
+	return nil
+}
+
+// RemoveCursor removes a specific agent's cursor.
+// Called when an agent is cleaned up as stale.
+func (s *Store) RemoveCursor(agentID string) error {
+	_, err := s.db.Exec("DELETE FROM cursors WHERE agent_id = ?", agentID)
+	if err != nil {
+		return fmt.Errorf("remove cursor: %w", err)
+	}
+	return nil
+}
+
+// PruneResult holds counts from a prune operation.
+type PruneResult struct {
+	WhispersDeleted int64
+	RelayedDeleted  int64
+	CursorsDeleted  int64
+	Vacuumed        bool
+}
+
+// Prune removes entries older than the given retention duration.
+// Also prunes stale cursors (not updated in 7 days) and old relayed records.
+func (s *Store) Prune(retention time.Duration) (PruneResult, error) {
+	var result PruneResult
+	cutoff := time.Now().Add(-retention).Format(time.RFC3339Nano)
+	cursorCutoff := time.Now().Add(-7 * 24 * time.Hour).Format(time.RFC3339Nano)
+
+	// delete old whispers
+	res, err := s.db.Exec("DELETE FROM whispers WHERE created_at < ?", cutoff)
+	if err != nil {
+		return result, fmt.Errorf("prune whispers: %w", err)
+	}
+	result.WhispersDeleted, _ = res.RowsAffected()
+
+	// delete old relayed records
+	res, err = s.db.Exec("DELETE FROM relayed_murmurs WHERE relayed_at < ?", cutoff)
+	if err != nil {
+		return result, fmt.Errorf("prune relayed: %w", err)
+	}
+	result.RelayedDeleted, _ = res.RowsAffected()
+
+	// delete stale cursors
+	res, err = s.db.Exec("DELETE FROM cursors WHERE updated_at < ?", cursorCutoff)
+	if err != nil {
+		return result, fmt.Errorf("prune cursors: %w", err)
+	}
+	result.CursorsDeleted, _ = res.RowsAffected()
+
+	// vacuum if enough was deleted
+	totalDeleted := result.WhispersDeleted + result.RelayedDeleted + result.CursorsDeleted
+	if totalDeleted > 100 {
+		if _, err := s.db.Exec("VACUUM"); err != nil {
+			slog.Warn("whisper db vacuum failed", "err", err)
+		} else {
+			result.Vacuumed = true
+		}
+	}
+
+	return result, nil
+}
+
+// EnforceMaxSize checks the DB file size and aggressively prunes if over maxBytes.
+func (s *Store) EnforceMaxSize(maxBytes int64) error {
+	info, err := os.Stat(s.dbPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat whisper db: %w", err)
+	}
+
+	if info.Size() <= maxBytes {
+		return nil
+	}
+
+	slog.Warn("whisper db over size limit, aggressive prune", "size", info.Size(), "limit", maxBytes)
+
+	// keep only last 6 hours
+	cutoff := time.Now().Add(-6 * time.Hour).Format(time.RFC3339Nano)
+	if _, err := s.db.Exec("DELETE FROM whispers WHERE created_at < ?", cutoff); err != nil {
+		return fmt.Errorf("aggressive prune whispers: %w", err)
+	}
+	if _, err := s.db.Exec("DELETE FROM relayed_murmurs WHERE relayed_at < ?", cutoff); err != nil {
+		return fmt.Errorf("aggressive prune relayed: %w", err)
+	}
+	if _, err := s.db.Exec("VACUUM"); err != nil {
+		return fmt.Errorf("vacuum after aggressive prune: %w", err)
+	}
+
+	// check if still over after prune
+	info, err = os.Stat(s.dbPath)
+	if err != nil {
+		return nil
+	}
+	if info.Size() > maxBytes {
+		slog.Warn("whisper db still over limit after prune, nuclear cleanup", "size", info.Size())
+		if _, err := s.db.Exec("DELETE FROM whispers"); err != nil {
+			return fmt.Errorf("nuclear prune whispers: %w", err)
+		}
+		if _, err := s.db.Exec("DELETE FROM relayed_murmurs"); err != nil {
+			return fmt.Errorf("nuclear prune relayed: %w", err)
+		}
+		if _, err := s.db.Exec("VACUUM"); err != nil {
+			return fmt.Errorf("vacuum after nuclear prune: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// CheckIntegrity validates that the whisper DB is healthy.
+// Returns nil if OK, an error describing the problem otherwise.
+func (s *Store) CheckIntegrity() error {
+	return checkIntegrity(s.db)
+}
+
+// DBPath returns the path to the SQLite database file.
+func (s *Store) DBPath() string {
+	return s.dbPath
+}
+
+// importanceForAttention returns which importance levels pass the attention filter.
+func importanceForAttention(attention Attention) []Importance {
+	switch attention {
+	case AttentionFocused:
+		return []Importance{ImportanceCritical}
+	case AttentionNormal:
+		return []Importance{ImportanceCritical, ImportanceNormal}
+	case AttentionAll:
+		return []Importance{ImportanceCritical, ImportanceNormal, ImportanceAmbient}
+	default:
+		// default to normal
+		return []Importance{ImportanceCritical, ImportanceNormal}
+	}
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/internal/whisper/store/store_test.go
+++ b/internal/whisper/store/store_test.go
@@ -1,0 +1,630 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func tempDB(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "whisper.db")
+}
+
+func mustOpen(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(tempDB(t))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func makeEntry(id, topic string, importance Importance, createdAt time.Time) WhisperEntry {
+	return WhisperEntry{
+		ID:         id,
+		Scope:      "ledger",
+		Type:       WhisperTrigger,
+		Source:     "test",
+		Topic:      topic,
+		Content:    "test content for " + id,
+		Importance: importance,
+		CreatedAt:  createdAt,
+	}
+}
+
+func TestOpenClose(t *testing.T) {
+	s := mustOpen(t)
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	// double close is safe
+	if err := s.Close(); err != nil {
+		t.Fatalf("double close: %v", err)
+	}
+}
+
+func TestAddAndGetWhispers(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	entries := []WhisperEntry{
+		makeEntry("w1", "lint", ImportanceNormal, now.Add(-2*time.Minute)),
+		makeEntry("w2", "build", ImportanceCritical, now.Add(-1*time.Minute)),
+		makeEntry("w3", "discovery", ImportanceAmbient, now),
+	}
+
+	if err := s.Add(entries...); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// first query: all entries (no prior cursor)
+	got, err := s.GetWhispers("agent-1", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3, got %d", len(got))
+	}
+
+	// critical should come first (importance ordering)
+	if got[0].ID != "w2" {
+		t.Errorf("expected critical first, got %s (importance=%s)", got[0].ID, got[0].Importance)
+	}
+}
+
+func TestCursorPersistence(t *testing.T) {
+	dbPath := tempDB(t)
+
+	// open, add, query to set cursor
+	s1, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	now := time.Now()
+	s1.Add(makeEntry("w1", "lint", ImportanceNormal, now.Add(-1*time.Minute)))
+	s1.GetWhispers("agent-1", AttentionAll, nil)
+	s1.Close()
+
+	// reopen, add new entry, query — should only get new entry
+	s2, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+
+	s2.Add(makeEntry("w2", "build", ImportanceNormal, time.Now()))
+	got, err := s2.GetWhispers("agent-1", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 new entry, got %d", len(got))
+	}
+	if got[0].ID != "w2" {
+		t.Errorf("expected w2, got %s", got[0].ID)
+	}
+}
+
+func TestAttentionFiltering(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	s.Add(
+		makeEntry("crit", "lint", ImportanceCritical, now.Add(-2*time.Second)),
+		makeEntry("norm", "lint", ImportanceNormal, now.Add(-1*time.Second)),
+		makeEntry("ambi", "lint", ImportanceAmbient, now),
+	)
+
+	tests := []struct {
+		name      string
+		attention Attention
+		wantIDs   []string
+	}{
+		{"focused", AttentionFocused, []string{"crit"}},
+		{"normal", AttentionNormal, []string{"crit", "norm"}},
+		{"all", AttentionAll, []string{"crit", "norm", "ambi"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.GetWhispers("agent-"+tt.name, tt.attention, nil)
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("expected %d entries, got %d", len(tt.wantIDs), len(got))
+			}
+			for i, id := range tt.wantIDs {
+				if got[i].ID != id {
+					t.Errorf("entry %d: expected %s, got %s", i, id, got[i].ID)
+				}
+			}
+		})
+	}
+}
+
+func TestTopicFiltering(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	s.Add(
+		makeEntry("w1", "lint", ImportanceNormal, now.Add(-2*time.Second)),
+		makeEntry("w2", "build", ImportanceNormal, now.Add(-1*time.Second)),
+		makeEntry("w3", "test", ImportanceNormal, now),
+	)
+
+	got, err := s.GetWhispers("agent-1", AttentionAll, []string{"lint", "build"})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+
+	// nil topics = all topics
+	got2, err := s.GetWhispers("agent-2", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got2) != 3 {
+		t.Fatalf("expected 3, got %d", len(got2))
+	}
+}
+
+func TestDedupByID(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	e := makeEntry("dup-1", "lint", ImportanceNormal, now)
+	s.Add(e)
+	s.Add(e) // duplicate
+
+	got, err := s.GetWhispers("agent-1", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 (deduped), got %d", len(got))
+	}
+}
+
+func TestRelayedTracking(t *testing.T) {
+	s := mustOpen(t)
+
+	ok, err := s.IsRelayed("murmur-1", "ledger")
+	if err != nil {
+		t.Fatalf("is relayed: %v", err)
+	}
+	if ok {
+		t.Fatal("expected not relayed")
+	}
+
+	if err := s.MarkRelayed("murmur-1", "ledger"); err != nil {
+		t.Fatalf("mark relayed: %v", err)
+	}
+
+	ok, err = s.IsRelayed("murmur-1", "ledger")
+	if err != nil {
+		t.Fatalf("is relayed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected relayed")
+	}
+
+	// same murmur ID, different scope — not relayed
+	ok, err = s.IsRelayed("murmur-1", "team")
+	if err != nil {
+		t.Fatalf("is relayed team: %v", err)
+	}
+	if ok {
+		t.Fatal("expected not relayed in team scope")
+	}
+}
+
+func TestRelayedPersistsAcrossReopen(t *testing.T) {
+	dbPath := tempDB(t)
+
+	s1, _ := Open(dbPath)
+	s1.MarkRelayed("murmur-1", "ledger")
+	s1.Close()
+
+	s2, _ := Open(dbPath)
+	defer s2.Close()
+
+	ok, _ := s2.IsRelayed("murmur-1", "ledger")
+	if !ok {
+		t.Fatal("expected relayed after reopen")
+	}
+}
+
+func TestPrune(t *testing.T) {
+	s := mustOpen(t)
+
+	old := time.Now().Add(-48 * time.Hour)
+	recent := time.Now().Add(-1 * time.Hour)
+
+	s.Add(
+		makeEntry("old-1", "lint", ImportanceNormal, old),
+		makeEntry("old-2", "build", ImportanceNormal, old),
+		makeEntry("new-1", "lint", ImportanceNormal, recent),
+	)
+	s.MarkRelayed("relay-old", "ledger")
+	// manually backdate the relayed entry
+	s.db.Exec("UPDATE relayed_murmurs SET relayed_at = ? WHERE murmur_id = ?",
+		old.Format(time.RFC3339Nano), "relay-old")
+
+	result, err := s.Prune(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	if result.WhispersDeleted != 2 {
+		t.Errorf("expected 2 whispers deleted, got %d", result.WhispersDeleted)
+	}
+	if result.RelayedDeleted != 1 {
+		t.Errorf("expected 1 relayed deleted, got %d", result.RelayedDeleted)
+	}
+
+	// new entry should survive
+	got, _ := s.GetWhispers("agent-1", AttentionAll, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 surviving entry, got %d", len(got))
+	}
+}
+
+func TestScopeCoexistence(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	s.Add(
+		WhisperEntry{
+			ID: "ledger-1", Scope: "ledger", Type: WhisperTrigger,
+			Source: "test", Topic: "lint", Content: "repo lint",
+			Importance: ImportanceNormal, CreatedAt: now.Add(-1 * time.Second),
+		},
+		WhisperEntry{
+			ID: "team-1", Scope: "team", Type: WhisperTrigger,
+			Source: "test", Topic: "architecture", Content: "team arch",
+			Importance: ImportanceNormal, CreatedAt: now,
+		},
+	)
+
+	// both scopes queryable
+	got, _ := s.GetWhispers("agent-1", AttentionAll, nil)
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+}
+
+func TestMetadataRoundTrip(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	e := makeEntry("meta-1", "lint", ImportanceNormal, now)
+	e.Metadata = map[string]string{
+		"files":  "internal/auth.go",
+		"branch": "ryan/auth-refactor",
+		"pr":     "287",
+	}
+
+	s.Add(e)
+
+	got, _ := s.GetWhispers("agent-1", AttentionAll, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d", len(got))
+	}
+	if got[0].Metadata["files"] != "internal/auth.go" {
+		t.Errorf("metadata files: %v", got[0].Metadata)
+	}
+	if got[0].Metadata["pr"] != "287" {
+		t.Errorf("metadata pr: %v", got[0].Metadata)
+	}
+}
+
+func TestPrincipalFields(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	e := makeEntry("principal-1", "lint", ImportanceNormal, now)
+	e.AgentID = "Oxa7b3"
+	e.PrincipalID = "user@example.com"
+	e.PrincipalType = "human"
+	e.TeamID = "team-123"
+
+	s.Add(e)
+
+	got, _ := s.GetWhispers("agent-1", AttentionAll, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d", len(got))
+	}
+	if got[0].AgentID != "Oxa7b3" {
+		t.Errorf("agent_id: %s", got[0].AgentID)
+	}
+	if got[0].PrincipalID != "user@example.com" {
+		t.Errorf("principal_id: %s", got[0].PrincipalID)
+	}
+	if got[0].PrincipalType != "human" {
+		t.Errorf("principal_type: %s", got[0].PrincipalType)
+	}
+	if got[0].TeamID != "team-123" {
+		t.Errorf("team_id: %s", got[0].TeamID)
+	}
+}
+
+func TestEmptyStore(t *testing.T) {
+	s := mustOpen(t)
+
+	got, err := s.GetWhispers("agent-1", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %d", len(got))
+	}
+}
+
+func TestRemoveCursor(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	s.Add(makeEntry("w1", "lint", ImportanceNormal, now))
+	s.GetWhispers("agent-1", AttentionAll, nil) // sets cursor
+
+	if err := s.RemoveCursor("agent-1"); err != nil {
+		t.Fatalf("remove cursor: %v", err)
+	}
+
+	// after cursor removal, should get all entries again
+	got, _ := s.GetWhispers("agent-1", AttentionAll, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 after cursor reset, got %d", len(got))
+	}
+}
+
+func TestCorruptionRecovery(t *testing.T) {
+	dbPath := tempDB(t)
+
+	// create valid DB
+	s1, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("initial open: %v", err)
+	}
+	s1.Add(makeEntry("w1", "lint", ImportanceNormal, time.Now()))
+	s1.Close()
+
+	// corrupt it
+	if err := os.WriteFile(dbPath, []byte("corrupted data"), 0o644); err != nil {
+		t.Fatalf("corrupt: %v", err)
+	}
+
+	// open should auto-recover
+	s2, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("recovery open: %v", err)
+	}
+	defer s2.Close()
+
+	// should work (empty but functional)
+	got, err := s2.GetWhispers("agent-1", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get after recovery: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty after recovery, got %d", len(got))
+	}
+
+	// can add new entries
+	if err := s2.Add(makeEntry("w2", "build", ImportanceNormal, time.Now())); err != nil {
+		t.Fatalf("add after recovery: %v", err)
+	}
+}
+
+func TestDeleteRecovery(t *testing.T) {
+	dbPath := tempDB(t)
+
+	// create valid DB then delete it
+	s1, _ := Open(dbPath)
+	s1.Close()
+	os.Remove(dbPath)
+
+	// open should create fresh
+	s2, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open after delete: %v", err)
+	}
+	defer s2.Close()
+
+	if err := s2.Add(makeEntry("w1", "lint", ImportanceNormal, time.Now())); err != nil {
+		t.Fatalf("add after delete recovery: %v", err)
+	}
+}
+
+func TestWALSHMCleanup(t *testing.T) {
+	dbPath := tempDB(t)
+
+	// create stale WAL/SHM files alongside corrupt DB
+	os.WriteFile(dbPath, []byte("corrupt"), 0o644)
+	os.WriteFile(dbPath+"-wal", []byte("stale wal"), 0o644)
+	os.WriteFile(dbPath+"-shm", []byte("stale shm"), 0o644)
+
+	s, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer s.Close()
+
+	// should have recovered — old WAL/SHM cleaned up
+	if err := s.Add(makeEntry("w1", "lint", ImportanceNormal, time.Now())); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	// add some entries
+	for i := range 50 {
+		s.Add(makeEntry(
+			fmt.Sprintf("w%d", i), "lint", ImportanceNormal,
+			now.Add(time.Duration(i)*time.Millisecond),
+		))
+	}
+
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		go func(agentNum int) {
+			defer wg.Done()
+			agentID := fmt.Sprintf("agent-%d", agentNum)
+			for range 5 {
+				s.GetWhispers(agentID, AttentionAll, nil)
+			}
+		}(i)
+	}
+
+	// concurrent writes
+	for i := range 10 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			s.Add(makeEntry(
+				fmt.Sprintf("w%d", n+50), "build", ImportanceCritical,
+				time.Now(),
+			))
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestEnforceMaxSize(t *testing.T) {
+	s := mustOpen(t)
+
+	// add enough entries to make a non-trivial DB
+	for i := range 200 {
+		s.Add(makeEntry(
+			fmt.Sprintf("w%d", i), "lint", ImportanceNormal,
+			time.Now().Add(-time.Duration(i)*time.Minute),
+		))
+	}
+
+	// enforce a very low max size (1 byte) to force cleanup
+	if err := s.EnforceMaxSize(1); err != nil {
+		t.Fatalf("enforce: %v", err)
+	}
+
+	// should still be functional
+	got, err := s.GetWhispers("agent-1", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("get after enforce: %v", err)
+	}
+	// all or some entries pruned
+	_ = got
+}
+
+func TestImportanceOrdering(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	// add in wrong order (ambient first, critical last)
+	s.Add(
+		makeEntry("ambi", "lint", ImportanceAmbient, now.Add(-3*time.Second)),
+		makeEntry("norm", "lint", ImportanceNormal, now.Add(-2*time.Second)),
+		makeEntry("crit", "lint", ImportanceCritical, now.Add(-1*time.Second)),
+	)
+
+	got, _ := s.GetWhispers("agent-1", AttentionAll, nil)
+	if len(got) != 3 {
+		t.Fatalf("expected 3, got %d", len(got))
+	}
+	// critical first regardless of creation time
+	if got[0].Importance != ImportanceCritical {
+		t.Errorf("expected critical first, got %s", got[0].Importance)
+	}
+	if got[1].Importance != ImportanceNormal {
+		t.Errorf("expected normal second, got %s", got[1].Importance)
+	}
+	if got[2].Importance != ImportanceAmbient {
+		t.Errorf("expected ambient third, got %s", got[2].Importance)
+	}
+}
+
+func TestAddEmpty(t *testing.T) {
+	s := mustOpen(t)
+	// should be a no-op, not an error
+	if err := s.Add(); err != nil {
+		t.Fatalf("add empty: %v", err)
+	}
+}
+
+func TestCheckIntegrity(t *testing.T) {
+	s := mustOpen(t)
+	if err := s.CheckIntegrity(); err != nil {
+		t.Fatalf("integrity: %v", err)
+	}
+}
+
+func TestMetadataJSON(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	// entry without metadata
+	e1 := makeEntry("no-meta", "lint", ImportanceNormal, now)
+	s.Add(e1)
+
+	got, _ := s.GetWhispers("agent-1", AttentionAll, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1, got %d", len(got))
+	}
+	if got[0].Metadata != nil {
+		t.Errorf("expected nil metadata, got %v", got[0].Metadata)
+	}
+}
+
+func TestMultiDaemonTeamDB(t *testing.T) {
+	// simulate two daemons accessing the same team whisper DB
+	dbPath := tempDB(t)
+
+	s1, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open s1: %v", err)
+	}
+	defer s1.Close()
+
+	s2, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open s2: %v", err)
+	}
+	defer s2.Close()
+
+	now := time.Now()
+
+	// both write
+	if err := s1.Add(makeEntry("from-daemon-1", "lint", ImportanceNormal, now)); err != nil {
+		t.Fatalf("s1 add: %v", err)
+	}
+	if err := s2.Add(makeEntry("from-daemon-2", "build", ImportanceNormal, now.Add(time.Millisecond))); err != nil {
+		t.Fatalf("s2 add: %v", err)
+	}
+
+	// both read
+	got1, _ := s1.GetWhispers("agent-a", AttentionAll, nil)
+	got2, _ := s2.GetWhispers("agent-b", AttentionAll, nil)
+
+	if len(got1) != 2 {
+		t.Errorf("s1 expected 2, got %d", len(got1))
+	}
+	if len(got2) != 2 {
+		t.Errorf("s2 expected 2, got %d", len(got2))
+	}
+}
+


### PR DESCRIPTION
## Summary

Adds generalized infrastructure for agent whispering (system → agent communication) and murmuring (agent → system → other agents communication). This is Phase 1 + Phase 2 of the whisper/murmur architecture, running parallel to the existing NotificationStore (Phase 3 migration is future work).

- **WhisperStore** — SQLite-backed persistent store (`internal/whisper/store/`) with WAL mode, auto-recovery from corruption, TTL-based cleanup, and importance/attention filtering
- **WhisperRegistry + Scheduler** — Daemon components (`internal/daemon/`) that manage whisper sources, periodic scheduling, and CLI delivery via IPC
- **MurmurRelay** — Daemon component that watches ledger/team context murmur directories and relays into the whisper pipeline
- **`ox murmur` CLI** — Publish murmurs with topic, importance level, and content/metadata separation
- **Murmur temporal storage** — Hourly-partitioned paths (`data/murmurs/YYYY-MM-DD/HH/`) with rolling 12-hour sparse checkout window
- **Doctor auto-fix** — `FixLevelAuto` for whisper DB corruption (no `--fix` flag needed)
- **ADR** — Full architecture decision record documenting the voice metaphor, design principles, and trade-offs
- **Daemon state principles** — 7 design principles extracted from Beads/Dolt failure analysis

### Architecture

```mermaid
graph TB
    subgraph "Inbound (Whispering)"
        S1[Structural - lifecycle hooks, prime]
        S2[Time-based - periodic scheduler]
        S3[Trigger-based - file changes, murmurs]
    end

    subgraph "Daemon"
        WR[WhisperRegistry]
        WS[WhisperScheduler]
        MR[MurmurRelay]
        DB[(WhisperStore SQLite)]
    end

    subgraph "Outbound (Murmuring)"
        CLI[ox murmur CLI]
        LED[Ledger data/murmurs/]
        TC[Team Context data/murmurs/]
    end

    S1 --> WR
    S2 --> WS --> WR
    S3 --> MR --> WR
    WR --> DB
    DB -->|IPC| Agent[AI Coworker]
    CLI --> LED
    CLI --> TC
    LED --> MR
    TC --> MR
```

### Key Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| State backend | SQLite (modernc.org/sqlite) | Already in dep tree via CodeDB, WAL mode handles concurrency, auto-recovery on corruption |
| Two physical DBs | Ledger DB + Team DB | Ledger is single-daemon-writer; team DB is shared across daemons |
| Importance levels | `critical`, `normal`, `ambient` (slugs, not ints) | Human-readable, extensible without schema changes |
| Attention levels | `all`, `normal`, `focused` (receiver config) | Receiver controls signal-to-noise ratio |
| Murmur storage | Hourly partitions in ledger/team context | Enables sparse checkout, GC reclone naturally cleans old data |
| Principal identity | Optional `principal_id` + `principal_type` ("human" only for now) | Tracks who the agent works for; extensible later |

### New Files

| Path | Purpose |
|------|---------|
| `internal/whisper/store/` | SQLite WhisperStore with schema, CRUD, TTL cleanup |
| `internal/daemon/whisper_registry.go` | Registry for whisper sources |
| `internal/daemon/whisper_scheduler.go` | Time-based whisper scheduling |
| `internal/daemon/whisper_sources.go` | Whisper source interface |
| `internal/daemon/murmur_relay.go` | Daemon component relaying murmurs to whispers |
| `internal/ledger/murmur.go` | Murmur path computation + sparse checkout integration |
| `cmd/ox/murmur.go` | `ox murmur` CLI command |
| `cmd/ox/doctor_whisper.go` | Doctor auto-fix for whisper DB |
| `docs/ai/adr/adr-whisper-murmur-architecture.md` | Full ADR |
| `docs/ai/specs/daemon-state-principles.md` | 7 principles from Beads failures |

## Test plan

- [ ] `go test ./internal/whisper/store/...` — WhisperStore CRUD, TTL, corruption recovery, concurrent access
- [ ] `go test ./internal/daemon/...` — WhisperRegistry, WhisperScheduler, MurmurRelay
- [ ] `go test ./internal/ledger/...` — Murmur path computation, sparse checkout, rolling window
- [ ] `go test ./cmd/ox/...` — Doctor whisper auto-fix, murmur CLI
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Verify no regressions in existing notification/priming flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ox murmur` command for agents to publish coordination messages with configurable importance levels
  * Agents now receive whisper notifications from the daemon during command execution (displayed on stderr with categorized importance levels)
  * Added whisper database integrity check to `ox doctor` with automatic recovery

* **Documentation**
  * Added Agent Whisper & Murmur architecture specification
  * Added daemon persistent state design principles guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->