### PR TITLE
feat: whisper/murmur P1 — SessionMeta builder, push credential refresh, team store wiring

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1112,13 +1112,11 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	// write meta.json first (before LFS upload) to preserve session metadata even if LFS fails
 	projectEndpoint := endpoint.GetForProject(projectRoot)
 	username := getAuthenticatedUsername(projectEndpoint)
-	meta := lfs.NewSessionMeta(sessionName, username, state.AgentID, state.AdapterName, state.StartedAt).
+	meta := sessionMetaBase(sessionName, username, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
 		Model(result.Model).
 		Title(state.Title).
 		EntryCount(result.EntryCount).
 		Summary(result.Summary).
-		UserID(auth.GetUserID(projectEndpoint)).
-		RepoID(getRepoIDOrDefault(projectRoot)).
 		StopReason(session.StopReasonStopped).
 		Build()
 	if err := lfs.WriteSessionMeta(sessionDir, meta); err != nil {

--- a/cmd/ox/agent_session_recover.go
+++ b/cmd/ox/agent_session_recover.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/sageox/ox/internal/agentinstance"
-	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/doctor"
 	"github.com/sageox/ox/internal/endpoint"
@@ -204,12 +203,9 @@ func recoverFromCache(inst *agentinstance.Instance, projectRoot string, state *s
 				slog.Warn("LFS upload failed during recovery", "error", uploadErr)
 				_ = doctor.SetNeedsDoctorAgent(projectRoot)
 			} else {
-				recoverEndpoint := endpoint.GetForProject(projectRoot)
-				username := getAuthenticatedUsername(recoverEndpoint)
-				meta := lfs.NewSessionMeta(sessionName, username, state.AgentID, state.AdapterName, state.StartedAt).
+				username := getAuthenticatedUsername(endpoint.GetForProject(projectRoot))
+				meta := sessionMetaBase(sessionName, username, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
 					EntryCount(entryCount).
-					UserID(auth.GetUserID(recoverEndpoint)).
-					RepoID(getRepoIDOrDefault(projectRoot)).
 					StopReason(session.StopReasonRecovered).
 					WithFiles(fileRefs).
 					Build()

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -10,9 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
-	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 )
@@ -305,12 +303,9 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 	}
 
 	// build and write meta.json
-	retryEndpoint := endpoint.GetForProject(projectRoot)
-	meta := lfs.NewSessionMeta(orphan.SessionName, orphan.Meta.Username, orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt).
+	meta := sessionMetaBase(orphan.SessionName, orphan.Meta.Username, orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt, projectRoot).
 		Model(orphan.Meta.Model).
 		EntryCount(orphan.EntryCount).
-		UserID(auth.GetUserID(retryEndpoint)).
-		RepoID(orphan.Meta.RepoID).
 		StopReason(session.StopReasonRecovered).
 		WithFiles(fileRefs).
 		Build()

--- a/cmd/ox/session_meta_helper.go
+++ b/cmd/ox/session_meta_helper.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"time"
+
+	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// sessionMetaBase creates a SessionMetaBuilder pre-populated with identity
+// fields (UserID, RepoID) resolved from the project root. Callers chain
+// additional optional setters before calling Build().
+func sessionMetaBase(sessionName, username, agentID, agentType string, createdAt time.Time, projectRoot string) *lfs.SessionMetaBuilder {
+	ep := endpoint.GetForProject(projectRoot)
+	return lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
+		UserID(auth.GetUserID(ep)).
+		RepoID(getRepoIDOrDefault(projectRoot))
+}

--- a/cmd/ox/session_upload_cmd.go
+++ b/cmd/ox/session_upload_cmd.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
-	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
@@ -75,8 +74,7 @@ Example:
 		}
 
 		// build or create meta.json first (before LFS upload) to preserve metadata even if LFS fails
-		uploadEndpoint := endpoint.GetForProject(projectRoot)
-		meta, err := buildSessionMeta(sessionPath, sessionName, nil, uploadEndpoint)
+		meta, err := buildSessionMeta(sessionPath, sessionName, projectRoot, nil)
 		if err != nil {
 			return fmt.Errorf("build meta.json: %w", err)
 		}
@@ -142,8 +140,7 @@ func hasContentFiles(sessionPath string) bool {
 // buildSessionMeta reads existing meta.json or constructs one from the directory name.
 // If fileRefs is nil, Files field is initialized as empty map.
 // If fileRefs is non-nil, Files field is updated with the provided references.
-// ep is the normalized endpoint used for auth token lookup.
-func buildSessionMeta(sessionPath, sessionName string, fileRefs map[string]lfs.FileRef, ep string) (*lfs.SessionMeta, error) {
+func buildSessionMeta(sessionPath, sessionName, projectRoot string, fileRefs map[string]lfs.FileRef) (*lfs.SessionMeta, error) {
 	// try reading existing meta.json first
 	meta, err := lfs.ReadSessionMeta(sessionPath)
 	if err == nil {
@@ -170,10 +167,10 @@ func buildSessionMeta(sessionPath, sessionName string, fileRefs map[string]lfs.F
 		fileRefs = make(map[string]lfs.FileRef)
 	}
 
-	return lfs.NewSessionMeta(sessionName, firstNonEmpty(username, getAuthenticatedUsername(ep), "unknown"), agentID, "unknown", ts).
+	ep := endpoint.GetForProject(projectRoot)
+	return sessionMetaBase(sessionName, firstNonEmpty(username, getAuthenticatedUsername(ep), "unknown"), agentID, "unknown", ts, projectRoot).
 		EntryCount(entryCount).
 		Summary(summary).
-		UserID(auth.GetUserID(ep)).
 		WithFiles(fileRefs).
 		Build(), nil
 }

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1275,9 +1275,16 @@ func (s *SyncScheduler) pushMurmurCommits(ctx context.Context, ledgerPath string
 	s.ledgerMu.Lock()
 	defer s.ledgerMu.Unlock()
 
+	ep := s.workspaceRegistry.GetEndpoint()
 	if err := gitutil.PushWithRetry(ctx, ledgerPath, gitutil.PushOpts{
 		AutoResolvePrefixes: []string{"data/murmurs/"},
 		Logger:              s.logger,
+		PrePush: func(repoPath string) error {
+			if ep != "" {
+				return gitserver.RefreshRemoteCredentials(repoPath, ep)
+			}
+			return nil
+		},
 	}); err != nil {
 		s.logger.Warn("murmur push failed (non-fatal)", "error", err)
 	}
@@ -2199,20 +2206,25 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 		}
 		s.recordSyncState(ctx, r.ws.Path)
 
-		// open team whisper store and relay murmurs after successful sync
+		// open team whisper store (once per team) and relay murmurs after successful sync
 		if s.whisperRegistry != nil && s.murmurRelay != nil {
-			ep := s.workspaceRegistry.GetEndpoint()
-			teamWhisperDir := paths.TeamWhisperDBDir(r.ws.TeamID, ep)
-			if teamWhisperDir != "" {
-				dbPath := filepath.Join(teamWhisperDir, "whisper.db")
-				teamStore, err := whisperstore.Open(dbPath)
-				if err != nil {
-					s.logger.Warn("failed to open team whisper store", "team", r.ws.TeamName, "error", err)
-				} else {
-					s.whisperRegistry.AddTeamStore(r.ws.TeamID, teamStore)
-					s.murmurRelay.RelayFromPath(r.ws.Path, "team")
+			if !s.whisperRegistry.HasTeamStore(r.ws.TeamID) {
+				ep := s.workspaceRegistry.GetEndpoint()
+				teamWhisperDir := paths.TeamWhisperDBDir(r.ws.TeamID, ep)
+				if teamWhisperDir != "" {
+					dbPath := filepath.Join(teamWhisperDir, "whisper.db")
+					if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err == nil {
+						teamStore, err := whisperstore.Open(dbPath)
+						if err != nil {
+							s.logger.Warn("failed to open team whisper store", "team", r.ws.TeamName, "error", err)
+						} else {
+							s.whisperRegistry.AddTeamStore(r.ws.TeamID, teamStore)
+						}
+					}
 				}
 			}
+			// always relay murmurs (even if store was already registered)
+			s.murmurRelay.RelayFromPath(r.ws.Path, "team")
 		}
 
 		syncedCount++

--- a/internal/daemon/whisper_registry.go
+++ b/internal/daemon/whisper_registry.go
@@ -42,6 +42,14 @@ func (r *WhisperRegistry) AddTeamStore(teamID string, store *whisperstore.Store)
 	r.teamStores[teamID] = store
 }
 
+// HasTeamStore returns true if a team whisper store is already registered.
+func (r *WhisperRegistry) HasTeamStore(teamID string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.teamStores[teamID]
+	return ok
+}
+
 // Add routes entries to the correct store based on scope.
 func (r *WhisperRegistry) Add(scope string, entries ...whisperstore.WhisperEntry) error {
 	if len(entries) == 0 {

--- a/internal/daemon/whisper_registry_test.go
+++ b/internal/daemon/whisper_registry_test.go
@@ -104,6 +104,25 @@ func TestWhisperRegistryRemoveCursor(t *testing.T) {
 	}
 }
 
+func TestWhisperRegistryHasTeamStore(t *testing.T) {
+	registry := NewWhisperRegistry(nil, nil)
+
+	if registry.HasTeamStore("team-1") {
+		t.Error("expected HasTeamStore to return false for unregistered team")
+	}
+
+	// nil store is accepted by AddTeamStore — sufficient for map lookup testing
+	registry.AddTeamStore("team-1", nil)
+
+	if !registry.HasTeamStore("team-1") {
+		t.Error("expected HasTeamStore to return true after AddTeamStore")
+	}
+
+	if registry.HasTeamStore("team-2") {
+		t.Error("expected HasTeamStore to return false for different team")
+	}
+}
+
 func TestWhisperRegistryUnknownScope(t *testing.T) {
 	ledger := openTestStore(t)
 	r := NewWhisperRegistry(ledger, nil)


### PR DESCRIPTION
## Summary

- **Consolidate SessionMeta construction** (ox-5zl): Extract shared `sessionMetaBase()` helper that auto-resolves UserID/RepoID from project root. All 4 construction sites now use it, eliminating field drift when adding new metadata fields. Fixes missing RepoID in manual upload path.
- **Add PrePush credential refresh to murmur push** (ox-8wq): The daemon's `pushMurmurCommits()` now calls `RefreshRemoteCredentials` before each push attempt, preventing auth failures from expired PATs during long-running daemon sessions.
- **Wire team whisper store with dedup** (ox-z22): Add `HasTeamStore()` to `WhisperRegistry` so `doTeamSync` only opens a team whisper DB once per team per daemon lifetime, fixing a SQLite connection leak where every sync cycle opened a new store without closing the old one.

```mermaid
flowchart LR
    subgraph "SessionMeta Construction (before)"
        S1[agent_session.go] -->|inline| M[UserID + RepoID]
        S2[recover.go] -->|inline| M
        S3[upload_cmd.go] -->|inline, missing RepoID| M
        S4[doctor_retry.go] -->|inline| M
    end

    subgraph "SessionMeta Construction (after)"
        S1b[agent_session.go] --> H[sessionMetaBase]
        S2b[recover.go] --> H
        S3b[upload_cmd.go] --> H
        S4b[doctor_retry.go] --> H
        H -->|resolves| M2[UserID + RepoID]
    end
```

## Test plan

- [x] `go build ./cmd/ox/` compiles cleanly
- [x] `make lint` — 0 issues
- [x] `make test` — `internal/lfs`, `internal/daemon` all pass
- [x] `HasTeamStore` unit test added to `whisper_registry_test.go`
- [ ] Manual: verify `FEATURE_WHISPER=true` daemon syncs team whisper stores without leaking connections

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced credential refresh mechanism for reliable ledger synchronization.
  * Optimized team workspace store initialization for improved performance and stability.

* **Refactor**
  * Consolidated session metadata construction logic across multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->