### PR TITLE
feat(resummary): use local daemon instead of server-side API

### DIFF
--- a/cmd/ox/session_resummary_batch.go
+++ b/cmd/ox/session_resummary_batch.go
@@ -1,22 +1,19 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 
-	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/lfs"
-	"github.com/sageox/ox/internal/session"
 	"github.com/spf13/cobra"
 )
 
 var sessionResummaryBatchCmd = &cobra.Command{
 	Use:    "resummary-batch [session-name...]",
-	Short:  "Re-summarize sessions via the SageOx API",
-	Long:   "Download raw.jsonl from LFS, call the summarize API, and push new summary.json to ledger.",
+	Short:  "Re-summarize sessions locally via daemon",
+	Long:   "Hydrate raw.jsonl from LFS if needed, then signal the daemon to re-summarize and push artifacts.",
 	Hidden: true,
 	Args:   cobra.MinimumNArgs(1),
 	RunE:   runSessionResummaryBatch,
@@ -104,7 +101,7 @@ func runSessionResummaryBatch(cmd *cobra.Command, args []string) error {
 	}
 
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
-	ep := endpoint.GetForProject(projectRoot)
+	var queued int
 
 	for _, sessionName := range args {
 		sessionPath := filepath.Join(sessionsDir, sessionName)
@@ -113,81 +110,43 @@ func runSessionResummaryBatch(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		if err := resummarySession(projectRoot, ledgerPath, sessionPath, sessionName, ep); err != nil {
+		if err := resummarySession(projectRoot, ledgerPath, sessionPath, sessionName); err != nil {
 			fmt.Fprintf(os.Stderr, "failed %s: %v\n", sessionName, err)
 			continue
 		}
 
-		fmt.Printf("re-summarized %s\n", sessionName)
+		fmt.Printf("queued %s for re-summarization\n", sessionName)
+		queued++
+	}
+
+	if queued > 0 {
+		fmt.Printf("\n%d session(s) queued. The daemon will process them in the background.\n", queued)
 	}
 
 	return nil
 }
 
-func resummarySession(projectRoot, ledgerPath, sessionPath, sessionName, ep string) error {
-	// read meta.json for agent info and file OIDs
-	meta, err := lfs.ReadSessionMeta(sessionPath)
-	if err != nil {
-		return fmt.Errorf("read meta.json: %w", err)
+func resummarySession(projectRoot, ledgerPath, sessionPath, sessionName string) error {
+	rawPath := filepath.Join(sessionPath, ledgerFileRaw)
+	if _, err := os.Stat(rawPath); os.IsNotExist(err) {
+		return fmt.Errorf("missing %s", ledgerFileRaw)
 	}
 
-	// ensure raw.jsonl is local (not just a pointer)
-	rawPath := filepath.Join(sessionPath, ledgerFileRaw)
+	// hydrate raw.jsonl from LFS if needed so daemon can read it
 	if lfs.IsPointerFile(rawPath) {
+		meta, err := lfs.ReadSessionMeta(sessionPath)
+		if err != nil {
+			return fmt.Errorf("read meta.json: %w", err)
+		}
 		slog.Info("downloading raw.jsonl from LFS", "session", sessionName)
 		if err := downloadFileFromLFS(projectRoot, sessionPath, meta, ledgerFileRaw); err != nil {
 			return fmt.Errorf("download raw.jsonl: %w", err)
 		}
-		// restore pointer on any exit path to avoid leaving large content in ledger
-		if ref, ok := meta.Files[ledgerFileRaw]; ok {
-			defer func() {
-				_ = lfs.WritePointerFile(rawPath, ref)
-			}()
-		}
 	}
 
-	// read raw.jsonl
-	stored, err := session.ReadSessionFromPath(rawPath)
-	if err != nil {
-		return fmt.Errorf("read raw.jsonl: %w", err)
-	}
-
-	if len(stored.Entries) == 0 {
-		return fmt.Errorf("empty session")
-	}
-
-	// convert map entries to session.Entry for the summarize API
-	entries := convertStoredMapEntries(stored.Entries)
-
-	// call the server-side summarize API
-	slog.Info("calling summarize API", "session", sessionName, "entries", len(entries))
-	result, err := session.Summarize(entries, meta.AgentID, meta.AgentType, meta.Model, ep)
-	if err != nil {
-		return fmt.Errorf("summarize API: %w", err)
-	}
-
-	// write summary.json
-	summaryData, err := json.MarshalIndent(result, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal summary: %w", err)
-	}
-
-	summaryPath := filepath.Join(sessionPath, "summary.json")
-	if err := os.WriteFile(summaryPath, summaryData, 0644); err != nil {
-		return fmt.Errorf("write summary.json: %w", err)
-	}
-
-	// update meta.json title
-	if result.Title != "" {
-		if err := lfs.UpdateMetaSummary(sessionPath, result.Title); err != nil {
-			slog.Warn("failed to update meta.json title", "session", sessionName, "err", err)
-		}
-	}
-
-	// commit and push summary.json (git-tracked, not LFS)
-	pushResult := pushSummaryToLedger(summaryPath, sessionPath)
-	if !pushResult.Success {
-		return fmt.Errorf("push summary: %s", pushResult.Error)
+	// signal daemon to finalize (reuses existing anti-entropy pipeline)
+	if err := signalDaemonSessionFinalize(sessionName, ledgerPath, "", projectRoot); err != nil {
+		return fmt.Errorf("daemon not reachable (is it running?): %w", err)
 	}
 
 	return nil

--- a/internal/session/summarize.go
+++ b/internal/session/summarize.go
@@ -1,24 +1,7 @@
 package session
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
-
-	"github.com/sageox/ox/internal/auth"
-	"github.com/sageox/ox/internal/endpoint"
-	"github.com/sageox/ox/internal/useragent"
 	ss "github.com/sageox/ox/pkg/sessionsummary"
-)
-
-const (
-	summarizePath    = "/api/v1/session/summarize"
-	summarizeTimeout = 30 * time.Second
 )
 
 // SummaryPromptGuidelines contains the shared guidelines for session summarization.
@@ -40,72 +23,6 @@ type (
 	OpenQuestion      = ss.OpenQuestion
 	TechnicalContext  = ss.TechnicalContext
 )
-
-// Summarize calls the SageOx API to generate an LLM summary of a session.
-// If endpointURL is non-empty, uses that endpoint for auth and API calls;
-// otherwise falls back to the default endpoint.
-// Returns nil if summarization fails (non-critical feature).
-func Summarize(entries []Entry, agentID, agentType, model, endpointURL string) (*SummarizeResponse, error) {
-	var token *auth.StoredToken
-	var err error
-	if endpointURL != "" {
-		token, err = auth.EnsureValidTokenForEndpoint(endpointURL, 300)
-	} else {
-		token, err = auth.EnsureValidToken(300)
-	}
-	if err != nil || token == nil {
-		return nil, fmt.Errorf("authentication required for summarization")
-	}
-
-	// prepare request with limited entries
-	req := buildSummarizeRequest(entries, agentID, agentType, model)
-
-	// make API call
-	client := &http.Client{Timeout: summarizeTimeout}
-	var reqURL string
-	if endpointURL != "" {
-		reqURL = endpointURL + summarizePath
-	} else {
-		reqURL = endpoint.Get() + summarizePath
-	}
-
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("marshal request: %w", err)
-	}
-
-	httpReq, err := useragent.NewRequest(context.Background(), "POST", reqURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
-
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("API request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API error: %d %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
-	}
-
-	var result SummarizeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
-	}
-
-	return &result, nil
-}
-
-// buildSummarizeRequest converts entries to the API request format.
-// Delegates filtering and construction to pkg/sessionsummary.
-func buildSummarizeRequest(entries []Entry, agentID, agentType, model string) *SummarizeRequest {
-	return ss.BuildSummarizeRequest(entriesToPkg(entries), agentID, agentType, model)
-}
 
 // FilterForSummarization removes low-value tool entries from session data.
 // Delegates to pkg/sessionsummary.


### PR DESCRIPTION
## Summary

- **Removes the server-side `/api/v1/session/summarize` call** from `resummary-batch`. Sessions are now re-summarized locally via the daemon's existing anti-entropy finalization pipeline.
- **Simplifies `internal/session/summarize.go`** by removing the `Summarize()` HTTP client and `buildSummarizeRequest()` — the CLI no longer needs to call a cloud endpoint for summarization.
- **Hydrates LFS stubs only when needed** — raw.jsonl is downloaded from LFS so the daemon can read it, but no longer restored to a pointer afterward (daemon handles the full lifecycle).

```mermaid
flowchart LR
    CLI["ox resummary-batch"] -->|hydrate LFS| RAW[raw.jsonl]
    CLI -->|signal finalize| DAEMON[daemon]
    DAEMON -->|summarize locally| ARTIFACTS[summary.json + meta]
    DAEMON -->|commit & push| LEDGER[ledger repo]
```

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [ ] Manual: run `ox session resummary-batch <session>` with daemon running, verify summary artifacts are generated and pushed

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Transitioned session re-summarization from server-based API calls to local daemon processing.

* **New Features**
  * Added feedback message displaying the number of sessions successfully queued for background re-summarization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->