### PR TITLE
feat(telemetry): add session stop and upload latency metrics

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	sessionhtml "github.com/sageox/ox/internal/session/html"
+	"github.com/sageox/ox/internal/telemetry"
 	"github.com/sageox/ox/internal/useragent"
 	"github.com/sageox/ox/internal/version"
 )
@@ -486,6 +488,26 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 	}
 	// finalize timing
 	timing["total_ms"] = time.Since(stopStart).Milliseconds()
+
+	// emit session stop latency telemetry
+	if cliCtx != nil && cliCtx.TelemetryClient != nil {
+		uploadSuccess := processResult != nil && processResult.UploadWarning == ""
+		meta := map[string]string{
+			"process_ms": strconv.FormatInt(timing["process_ms"], 10),
+			"upload_ms":  strconv.FormatInt(timing["upload_ms"], 10),
+			"total_ms":   strconv.FormatInt(timing["total_ms"], 10),
+		}
+		if processResult != nil {
+			meta["entry_count"] = strconv.Itoa(processResult.EntryCount)
+		}
+		cliCtx.TelemetryClient.TrackAsync(telemetry.Event{
+			Type:     telemetry.EventSessionEnd,
+			AgentID:  inst.AgentID,
+			Duration: timing["total_ms"],
+			Success:  uploadSuccess,
+			Metadata: meta,
+		})
+	}
 
 	// output format selection (priority: review > text > json default)
 	if cfg.Review {

--- a/cmd/ox/session_push_summary.go
+++ b/cmd/ox/session_push_summary.go
@@ -9,12 +9,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -70,6 +73,15 @@ func runSessionPushSummary(cmd *cobra.Command, args []string) error {
 
 // pushSummaryToLedger validates inputs, copies the summary file, and commits+pushes.
 func pushSummaryToLedger(filePath, sessionDir string) *pushSummaryOutput {
+	pushStart := time.Now()
+
+	// capture meta.json mtime before we modify it — represents when session stop
+	// finished uploading initial artifacts. Used to compute stop-to-visible latency.
+	var stopUploadedAt time.Time
+	if info, err := os.Stat(filepath.Join(sessionDir, "meta.json")); err == nil {
+		stopUploadedAt = info.ModTime()
+	}
+
 	// read summary data from file or stdin
 	var data []byte
 	var err error
@@ -246,6 +258,22 @@ func pushSummaryToLedger(filePath, sessionDir string) *pushSummaryOutput {
 
 	// clear .needs-summary marker in cache if we can find it
 	clearNeedsSummaryMarkerForSession(sessionName)
+
+	// emit stop-to-visible telemetry: total time from session stop upload to summary push
+	if cliCtx != nil && cliCtx.TelemetryClient != nil {
+		meta := map[string]string{
+			"push_ms":       strconv.FormatInt(time.Since(pushStart).Milliseconds(), 10),
+			"quality_score": strconv.FormatFloat(summaryParsed.QualityScore, 'f', 2, 64),
+		}
+		if !stopUploadedAt.IsZero() {
+			meta["stop_to_visible_ms"] = strconv.FormatInt(time.Since(stopUploadedAt).Milliseconds(), 10)
+		}
+		cliCtx.TelemetryClient.TrackAsync(telemetry.Event{
+			Type:     telemetry.EventSessionPushSummary,
+			Success:  true,
+			Metadata: meta,
+		})
+	}
 
 	return &pushSummaryOutput{
 		Success:      true,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -682,6 +682,12 @@ func (d *Daemon) initComponents() time.Duration {
 				"status", status,
 				"duration", result.Duration,
 			)
+			if d.telemetry != nil && result.Item.Type == "session-finalize" {
+				d.telemetry.Record("session:finalize", map[string]any{
+					"status":      status,
+					"duration_ms": result.Duration.Milliseconds(),
+				})
+			}
 		})
 		d.scheduler.SetAgentWorkSignal(agentWorkSignal)
 	}

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -51,6 +51,9 @@ const (
 	// daemon events (sent directly from CLI when daemon unavailable)
 	EventDaemonStartFailure = "daemon:start_failure" // daemon failed to start
 
+	// session latency events
+	EventSessionPushSummary = "session_push_summary" // summary pushed to ledger (stop-to-visible latency)
+
 	// coworker events
 	EventCoworkerLoad = "coworker_load" // coworker/subagent loaded into context
 )


### PR DESCRIPTION
## Summary

Adds three telemetry events to measure session recording latency across the full stop-to-visible pipeline:

- **`session_end`** (CLI) — emitted after `ox session stop` completes, with `process_ms`, `upload_ms`, and `total_ms` breakdown
- **`session_push_summary`** (CLI) — emitted after `ox session push-summary` pushes the final summary, with `push_ms` and `stop_to_visible_ms` (meta.json mtime → push complete, the key metric for how long until an observer on another machine can see the full session)
- **`session:finalize`** (daemon) — emitted when the daemon's anti-entropy finalizes a session, with `duration_ms`

All events flow through existing telemetry infrastructure (CLI file-queue + IPC, daemon ring buffer) to `telemetry.sageox.ai/tevents`. No new dependencies or schema changes beyond one new event type constant.

```mermaid
sequenceDiagram
    participant User
    participant CLI as ox session stop
    participant Agent as AI Coworker
    participant Push as ox session push-summary
    participant Daemon

    User->>CLI: stop
    CLI->>CLI: process + LFS upload + git push
    Note over CLI: 📊 session_end (process_ms, upload_ms, total_ms)
    CLI->>Agent: summary_prompt
    Agent->>Agent: generate summary (LLM)
    Agent->>Push: push-summary --file summary.json
    Push->>Push: git commit + push
    Note over Push: 📊 session_push_summary (stop_to_visible_ms)
    
    Note over Daemon: Anti-entropy (Ctrl-C recovery)
    Daemon->>Daemon: detect + summarize + push
    Note over Daemon: 📊 session:finalize (duration_ms)
```

## Test plan

- [x] `go build ./cmd/ox/` compiles clean
- [x] `go test ./cmd/ox/ -run Session` passes
- [x] `go test ./internal/telemetry/` passes
- [ ] Manual: run `ox session stop` and verify `session_end` event in daemon telemetry logs
- [ ] Manual: verify `session_push_summary` fires after agent pushes summary

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced telemetry infrastructure to track session lifecycle events including completion status, timing metrics, and success indicators
  * Added comprehensive event tracking for summary publication with quality assessment and end-to-end latency measurement
  * Improved daemon work completion monitoring to capture detailed performance data for enhanced system observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->