### PR TITLE
fix(distill): push team context to remote after pipeline

### DIFF
--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sageox/ox/internal/agentcli"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/facts"
 	"github.com/spf13/cobra"
 )
@@ -422,6 +423,18 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 	tc := config.FindRepoTeamContext(projectRoot)
 	if tc == nil {
 		return fmt.Errorf("no team context configured — run 'ox init' first")
+	}
+
+	// push team context commits to remote when we're done — even if the
+	// pipeline partially fails, earlier stages may have committed facts or
+	// distilled summaries that should be synced.
+	if !distillDryRun {
+		ep := endpoint.GetForProject(projectRoot)
+		defer func() {
+			if err := pushTeamContext(context.Background(), tc.Path, ep); err != nil {
+				slog.Warn("failed to push team context after distill", "error", err)
+			}
+		}()
 	}
 
 	// detect AI coworker CLI


### PR DESCRIPTION
## Summary

- **Push team context commits after distill completes.** The distill pipeline makes multiple commits during execution (discussion fact extraction, GitHub fact extraction, daily/weekly/monthly distills), but never pushed them to the remote. Only `ox import` had a push path.
- Uses a `defer` so the push fires even if a mid-pipeline stage fails — earlier committed work (e.g., extracted facts) still gets synced.
- Non-fatal: logs a warning on push failure, doesn't mask the pipeline's own error.
- Skipped in dry-run mode.

## Test plan

- [x] Run `ox distill` on a repo with pending discussions — verify team context is pushed after completion
- [ ] Run `ox distill` where a later stage fails — verify earlier commits are still pushed
- [ ] Run `ox distill --dry-run` — verify no push attempt
- [ ] Run `ox distill` with no network — verify warning is logged but command still returns the pipeline result

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* The distill command now automatically syncs team context commits after completion for non-dry runs. Any synchronization errors are logged as warnings without blocking the command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->