### PR TITLE
fix(auth): handle refresh_token, resilient status, PAT probe

### DIFF
--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -63,6 +63,7 @@ type statusAuthJSON struct {
 	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
 	GitPATValid   *bool      `json:"git_pat_valid,omitempty"`
 	GitPATReason  string     `json:"git_pat_reason,omitempty"`
+	Error         string     `json:"error,omitempty"`
 }
 
 type statusConfigJSON struct {
@@ -1457,9 +1458,12 @@ daemon health, and a tree view of all SageOx directory locations.`,
 		currentEndpoint := endpoint.GetForProject(gitRoot)
 		endpointSlug := endpoint.NormalizeSlug(currentEndpoint)
 
+		var authErr error
 		authenticated, err := auth.IsAuthenticatedForEndpoint(currentEndpoint)
 		if err != nil {
-			return fmt.Errorf("failed to check authentication status: %w", err)
+			// don't bail — show what we can without auth
+			authErr = err
+			authenticated = false
 		}
 
 		// get auth token if authenticated
@@ -1467,7 +1471,8 @@ daemon health, and a tree view of all SageOx directory locations.`,
 		if authenticated {
 			token, err = auth.GetTokenForEndpoint(currentEndpoint)
 			if err != nil {
-				return fmt.Errorf("failed to get token: %w", err)
+				authErr = err
+				authenticated = false
 			}
 
 			// ensure git credentials are valid (auto-refresh if needed)
@@ -1568,7 +1573,7 @@ daemon health, and a tree view of all SageOx directory locations.`,
 
 		// JSON output mode
 		if statusJSONFlag {
-			output := buildStatusJSON(authenticated, token, endpointSlug, authFile, authFileExists,
+			output := buildStatusJSON(authenticated, authErr, token, endpointSlug, authFile, authFileExists,
 				userConfigDir, cwd, sageoxDir, projectInitialized, localCfg, gitRoot, repoDetail, codeStats,
 				daemonStatus, client)
 			jsonBytes, err := json.MarshalIndent(output, "", "  ")
@@ -1582,7 +1587,9 @@ daemon health, and a tree view of all SageOx directory locations.`,
 		// Human-readable output mode
 		// Authentication Status - always show, includes endpoint
 		fmt.Print(renderAuthStatus(authFile))
-		if len(auth.GetLoggedInEndpoints()) == 0 {
+		if authErr != nil {
+			fmt.Printf("  %s %s\n", statusWarningStyle.Render("⚠ token refresh failed:"), statusMutedStyle.Render("run `ox login` to re-authenticate"))
+		} else if len(auth.GetLoggedInEndpoints()) == 0 {
 			// use contextual action hint matching help's visual style
 			cli.PrintActionHint("ox login", "Authenticate with "+cli.Wordmark(), 1)
 		}
@@ -1643,7 +1650,7 @@ daemon health, and a tree view of all SageOx directory locations.`,
 // buildStatusJSON constructs the JSON output structure for ox status --json.
 // daemonStatus and daemonClient are pre-fetched from the daemon to avoid a second ping
 // that could race with the first (one succeeds, the other times out = contradictory output).
-func buildStatusJSON(authenticated bool, token *auth.StoredToken, endpointSlug, authFile string, authFileExists bool,
+func buildStatusJSON(authenticated bool, authErr error, token *auth.StoredToken, endpointSlug, authFile string, authFileExists bool,
 	userConfigDir, cwd, sageoxDir string, projectInitialized bool, localCfg *config.LocalConfig, gitRoot string,
 	repoDetail *api.RepoDetailResponse, codeStats *daemon.CodeDBStats,
 	daemonStatus *daemon.StatusData, daemonClient *daemon.Client) statusJSONOutput {
@@ -1654,6 +1661,9 @@ func buildStatusJSON(authenticated bool, token *auth.StoredToken, endpointSlug, 
 	output.Auth = &statusAuthJSON{
 		Authenticated: authenticated,
 		Endpoint:      endpointSlug,
+	}
+	if authErr != nil {
+		output.Auth.Error = authErr.Error()
 	}
 	if authenticated && token != nil {
 		output.Auth.User = token.UserInfo.Name

--- a/cmd/ox/status_test.go
+++ b/cmd/ox/status_test.go
@@ -29,7 +29,7 @@ func TestBuildStatusJSON_WithRepoDetail(t *testing.T) {
 	}
 
 	output := buildStatusJSON(
-		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+		false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
 		localCfg, "", repoDetail, nil,
 		nil, nil,
@@ -52,7 +52,7 @@ func TestBuildStatusJSON_WithoutRepoDetail(t *testing.T) {
 	}
 
 	output := buildStatusJSON(
-		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+		false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
 		localCfg, "", nil, nil,
 		nil, nil,
@@ -79,7 +79,7 @@ func TestBuildStatusJSON_ViewerAccess(t *testing.T) {
 	}
 
 	output := buildStatusJSON(
-		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+		false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
 		localCfg, "", repoDetail, nil,
 		nil, nil,
@@ -102,7 +102,7 @@ func TestBuildStatusJSON_NoLedgerConfig(t *testing.T) {
 	}
 
 	output := buildStatusJSON(
-		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+		false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
 		localCfg, "", repoDetail, nil,
 		nil, nil,
@@ -116,7 +116,7 @@ func TestBuildStatusJSON_NilLocalConfig(t *testing.T) {
 	t.Parallel()
 
 	output := buildStatusJSON(
-		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+		false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
 		nil, "", nil, nil,
 		nil, nil,
@@ -141,7 +141,7 @@ func TestBuildStatusJSON_LedgerPathNotExists(t *testing.T) {
 	}
 
 	output := buildStatusJSON(
-		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+		false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
 		localCfg, "", repoDetail, nil,
 		nil, nil,
@@ -170,7 +170,7 @@ func TestBuildStatusJSON_AuthenticatedWithToken(t *testing.T) {
 	}
 
 	output := buildStatusJSON(
-		true, token, "test.sageox.ai", "/tmp/auth.json", true,
+		true, nil, token, "test.sageox.ai", "/tmp/auth.json", true,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", true,
 		nil, "", nil, nil,
 		nil, nil,
@@ -187,7 +187,7 @@ func TestBuildStatusJSON_ProjectInitialized(t *testing.T) {
 	t.Parallel()
 
 	output := buildStatusJSON(
-		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+		false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", true,
 		nil, "", nil, nil,
 		nil, nil,
@@ -202,7 +202,7 @@ func TestBuildStatusJSON_ProjectNotInitialized(t *testing.T) {
 	t.Parallel()
 
 	output := buildStatusJSON(
-		false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+		false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 		"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
 		nil, "", nil, nil,
 		nil, nil,
@@ -257,7 +257,7 @@ func TestBuildStatusJSON_VisibilityAccessLevelCombinations(t *testing.T) {
 			}
 
 			output := buildStatusJSON(
-				false, nil, "test.sageox.ai", "/tmp/auth.json", false,
+				false, nil, nil, "test.sageox.ai", "/tmp/auth.json", false,
 				"/tmp/config", "/tmp/cwd", "/tmp/cwd/.sageox", false,
 				localCfg, "", repoDetail, nil,
 				nil, nil,

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -219,6 +219,7 @@ func Login(ctx context.Context, deviceCode *DeviceCodeResponse, statusCallback f
 			storedToken := &StoredToken{
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
+				SessionToken: token.SessionToken, // preserve for refresh fallback
 				ExpiresAt:    time.Now().Add(time.Duration(expiresIn) * time.Second),
 				TokenType:    token.TokenType,
 				Scope:        token.Scope,
@@ -561,6 +562,7 @@ func (c *AuthClient) Login(ctx context.Context, deviceCode *DeviceCodeResponse, 
 			storedToken := &StoredToken{
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
+				SessionToken: token.SessionToken, // preserve for refresh fallback
 				ExpiresAt:    time.Now().Add(time.Duration(expiresIn) * time.Second),
 				TokenType:    token.TokenType,
 				Scope:        token.Scope,

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -159,11 +159,19 @@ func refreshTokenForEndpoint(token *StoredToken, ep string) (*StoredToken, error
 	baseURL := ep
 	tokenURL := baseURL + TokenEndpoint
 
+	// use refresh_token with session_token fallback (Better Auth compatibility)
+	rt := token.EffectiveRefreshToken()
+	if rt == "" {
+		return nil, &TokenRefreshError{
+			Message: "no refresh token available, re-authentication required",
+		}
+	}
+
 	// prepare form data for token refresh
 	data := url.Values{}
 	data.Set("grant_type", "refresh_token")
 	data.Set("client_id", ClientID)
-	data.Set("refresh_token", token.RefreshToken)
+	data.Set("refresh_token", rt)
 
 	// create request
 	req, err := useragent.NewRequest(context.Background(), "POST", tokenURL, strings.NewReader(data.Encode()))
@@ -254,6 +262,12 @@ func refreshTokenForEndpoint(token *StoredToken, ep string) (*StoredToken, error
 		refreshToken = rt
 	}
 
+	// preserve session_token from response, falling back to stored value
+	sessionToken := token.SessionToken
+	if responseData.SessionToken != "" {
+		sessionToken = responseData.SessionToken
+	}
+
 	// extract optional fields with defaults
 	tokenType := "Bearer"
 	if responseData.TokenType != "" {
@@ -296,6 +310,7 @@ func refreshTokenForEndpoint(token *StoredToken, ep string) (*StoredToken, error
 	newToken := &StoredToken{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
+		SessionToken: sessionToken,
 		ExpiresAt:    expiresAt,
 		TokenType:    tokenType,
 		Scope:        scope,
@@ -365,11 +380,19 @@ func (c *AuthClient) refreshToken(token *StoredToken) (*StoredToken, error) {
 	baseURL := c.Endpoint()
 	tokenURL := baseURL + TokenEndpoint
 
+	// use refresh_token with session_token fallback (Better Auth compatibility)
+	rt := token.EffectiveRefreshToken()
+	if rt == "" {
+		return nil, &TokenRefreshError{
+			Message: "no refresh token available, re-authentication required",
+		}
+	}
+
 	// prepare form data for token refresh
 	data := url.Values{}
 	data.Set("grant_type", "refresh_token")
 	data.Set("client_id", ClientID)
-	data.Set("refresh_token", token.RefreshToken)
+	data.Set("refresh_token", rt)
 
 	// create request
 	req, err := useragent.NewRequest(context.Background(), "POST", tokenURL, strings.NewReader(data.Encode()))
@@ -460,6 +483,12 @@ func (c *AuthClient) refreshToken(token *StoredToken) (*StoredToken, error) {
 		refreshTokenStr = rt
 	}
 
+	// preserve session_token from response, falling back to stored value
+	sessionTokenStr := token.SessionToken
+	if responseData.SessionToken != "" {
+		sessionTokenStr = responseData.SessionToken
+	}
+
 	// extract optional fields with defaults
 	tokenType := "Bearer"
 	if responseData.TokenType != "" {
@@ -502,6 +531,7 @@ func (c *AuthClient) refreshToken(token *StoredToken) (*StoredToken, error) {
 	newToken := &StoredToken{
 		AccessToken:  accessToken,
 		RefreshToken: refreshTokenStr,
+		SessionToken: sessionTokenStr,
 		ExpiresAt:    expiresAt,
 		TokenType:    tokenType,
 		Scope:        scope,

--- a/internal/auth/refresh_test.go
+++ b/internal/auth/refresh_test.go
@@ -586,6 +586,71 @@ func TestTokenRefreshError_Unwrap(t *testing.T) {
 	assert.Nil(t, unwrapped2)
 }
 
+func TestRefreshToken_SessionTokenFallback(t *testing.T) {
+	t.Parallel()
+
+	// mock server that accepts session_token as refresh_token
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case TokenEndpoint:
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+			// should receive the session_token value as refresh_token
+			assert.Equal(t, "test-session-token", r.Form.Get("refresh_token"))
+
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "refreshed-opaque",
+				"session_token": "new-session-token",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		case "/api/v1/cli/auth/token":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "refreshed-jwt",
+				"token_type":   "Bearer",
+				"expires_in":   900,
+			})
+		default:
+			t.Errorf("unexpected endpoint: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	client := NewAuthClientWithDir(t.TempDir()).WithEndpoint(mockServer.URL)
+
+	// expired token with empty RefreshToken but valid SessionToken
+	expiredToken := createTestToken(-1 * time.Hour)
+	expiredToken.RefreshToken = ""
+	expiredToken.SessionToken = "test-session-token"
+	require.NoError(t, client.SaveToken(expiredToken))
+
+	token, err := client.EnsureValidToken(300)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "refreshed-jwt", token.AccessToken)
+	assert.Equal(t, "new-session-token", token.SessionToken)
+}
+
+func TestRefreshToken_NoRefreshOrSessionToken(t *testing.T) {
+	t.Parallel()
+
+	client := NewAuthClientWithDir(t.TempDir())
+
+	// expired token with neither RefreshToken nor SessionToken
+	expiredToken := createTestToken(-1 * time.Hour)
+	expiredToken.RefreshToken = ""
+	expiredToken.SessionToken = ""
+	require.NoError(t, client.SaveToken(expiredToken))
+
+	token, err := client.EnsureValidToken(300)
+	require.Error(t, err)
+	assert.Nil(t, token)
+	assert.Contains(t, err.Error(), "no refresh token available")
+}
+
 func TestEnsureValidToken_ZeroBuffer(t *testing.T) {
 	t.Parallel()
 

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -23,10 +23,20 @@ type UserInfo struct {
 type StoredToken struct {
 	AccessToken  string    `json:"access_token"`
 	RefreshToken string    `json:"refresh_token"`
+	SessionToken string    `json:"session_token,omitempty"` // Better Auth fallback for refresh_token
 	ExpiresAt    time.Time `json:"expires_at"`
 	TokenType    string    `json:"token_type"`
 	Scope        string    `json:"scope"`
 	UserInfo     UserInfo  `json:"user_info"`
+}
+
+// EffectiveRefreshToken returns the refresh token, falling back to session_token
+// if refresh_token is empty (Better Auth compatibility).
+func (t *StoredToken) EffectiveRefreshToken() string {
+	if t.RefreshToken != "" {
+		return t.RefreshToken
+	}
+	return t.SessionToken
 }
 
 // AuthStore holds tokens for multiple API endpoints

--- a/internal/gitserver/pat_liveness.go
+++ b/internal/gitserver/pat_liveness.go
@@ -23,9 +23,11 @@ type PATLivenessResult struct {
 // rather than git ls-remote, since we may not have a repo URL handy and we
 // want to avoid git subprocess overhead.
 //
-// NOTE: Currently GitLab-specific (PRIVATE-TOKEN header, /api/v4/user endpoint).
-// SageOx uses GitLab for all git hosting. If multi-provider support is needed,
-// this should detect the provider and adapt the probe strategy.
+// NOTE: Currently GitLab-specific (PRIVATE-TOKEN header,
+// /api/v4/personal_access_tokens/self endpoint). SageOx uses GitLab for all
+// git hosting. We use the token introspection endpoint because it works with
+// any valid PAT regardless of scopes — our PATs only have
+// [read_repository, write_repository], which is insufficient for /api/v4/user.
 //
 // Timeout should be kept short (2-3s) so callers (doctor, status) stay responsive.
 func ValidatePATLiveness(ctx context.Context, serverURL, token string) PATLivenessResult {
@@ -33,7 +35,7 @@ func ValidatePATLiveness(ctx context.Context, serverURL, token string) PATLivene
 		return PATLivenessResult{Skipped: true, Reason: "no credentials"}
 	}
 
-	// build a lightweight API probe URL — GitLab /api/v4/user returns 200 for valid tokens
+	// build a lightweight API probe URL — token introspection works with any scopes
 	probeURL, err := buildProbeURL(serverURL)
 	if err != nil {
 		return PATLivenessResult{Skipped: true, Reason: fmt.Sprintf("invalid server URL: %s", err)}
@@ -65,17 +67,17 @@ func ValidatePATLiveness(ctx context.Context, serverURL, token string) PATLivene
 }
 
 // buildProbeURL constructs a lightweight GitLab API endpoint to test PAT validity.
+// Uses /api/v4/personal_access_tokens/self which works with any valid PAT
+// regardless of scopes (unlike /api/v4/user which requires read_user or api scope).
 func buildProbeURL(serverURL string) (string, error) {
 	u, err := url.Parse(serverURL)
 	if err != nil {
 		return "", err
 	}
-	// ensure scheme
 	if u.Scheme == "" {
 		u.Scheme = "https"
 	}
-	// GitLab /api/v4/user is lightweight and returns 200 for valid PATs
-	u.Path = "/api/v4/user"
+	u.Path = "/api/v4/personal_access_tokens/self"
 	u.RawQuery = ""
 	u.Fragment = ""
 	return u.String(), nil

--- a/internal/gitserver/pat_liveness_test.go
+++ b/internal/gitserver/pat_liveness_test.go
@@ -123,17 +123,17 @@ func TestBuildProbeURL(t *testing.T) {
 		{
 			name:      "https URL",
 			serverURL: "https://git.sageox.ai",
-			want:      "https://git.sageox.ai/api/v4/user",
+			want:      "https://git.sageox.ai/api/v4/personal_access_tokens/self",
 		},
 		{
 			name:      "http URL with port",
 			serverURL: "http://localhost:3000",
-			want:      "http://localhost:3000/api/v4/user",
+			want:      "http://localhost:3000/api/v4/personal_access_tokens/self",
 		},
 		{
 			name:      "URL with existing path stripped",
 			serverURL: "https://git.sageox.ai/some/path",
-			want:      "https://git.sageox.ai/api/v4/user",
+			want:      "https://git.sageox.ai/api/v4/personal_access_tokens/self",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- **Token refresh fallback**: The CLI API doesn't always return `refresh_token` — add `session_token` as a fallback via `StoredToken.EffectiveRefreshToken()`. Stored during login, preserved across refresh cycles.
- **Resilient `ox status`**: Auth failures (expired/missing tokens) no longer crash the command. Status degrades gracefully — shows a warning and continues rendering all local information it can gather.
- **PAT liveness probe fix**: Switch from `/api/v4/user` (requires `read_user` scope) to `/api/v4/personal_access_tokens/self` (works with any valid PAT). Our PATs only have `[read_repository, write_repository]` so the old probe always 403'd.

```mermaid
flowchart LR
    A[Token Refresh] -->|refresh_token exists| B[Use refresh_token]
    A -->|refresh_token empty| C{session_token?}
    C -->|exists| D[Use session_token as fallback]
    C -->|empty| E[Error: re-auth required]
```

## Test plan

- [ ] `ox status` works when token is valid
- [ ] `ox status` shows warning (not crash) when token refresh fails
- [ ] `ox status --json` includes `auth.error` field on refresh failure
- [ ] Token refresh uses `session_token` when `refresh_token` is missing
- [ ] Token refresh fails cleanly when neither token is available
- [ ] PAT liveness check succeeds with `read_repository`-only scoped PATs
- [ ] `make test` passes (unit tests for all three fixes included)

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status command now surfaces authentication errors instead of terminating execution
  * Token refresh now supports session tokens as fallback when refresh tokens are unavailable
  * Improved authentication error messaging with re-authentication guidance
  * GitLab PAT validation now works with any valid token regardless of scopes

* **Tests**
  * Added tests for session token fallback and missing token scenarios
  * Updated validation endpoint tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->