### PR TITLE
test: add video import smoke test and component tests

### DIFF
--- a/cmd/ox/import_video_test.go
+++ b/cmd/ox/import_video_test.go
@@ -1,0 +1,439 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/testguard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mp4Header is a minimal valid ftyp box header for mp4 content type detection.
+// http.DetectContentType recognizes this as video/mp4.
+var mp4Header = []byte{
+	0x00, 0x00, 0x00, 0x20, // box size (32 bytes)
+	0x66, 0x74, 0x79, 0x70, // "ftyp"
+	0x69, 0x73, 0x6F, 0x6D, // "isom" (major brand)
+	0x00, 0x00, 0x02, 0x00, // minor version
+	0x69, 0x73, 0x6F, 0x6D, // "isom" (compatible brand)
+	0x69, 0x73, 0x6F, 0x32, // "iso2"
+	0x61, 0x76, 0x63, 0x31, // "avc1"
+	0x6D, 0x70, 0x34, 0x31, // "mp41"
+}
+
+func TestDetectContentType_VideoFormats(t *testing.T) {
+	// video extensions are not in the explicit extension map, so they fall
+	// through to http.DetectContentType which sniffs the content bytes.
+
+	t.Run("mp4 with ftyp header", func(t *testing.T) {
+		got := detectContentType("meeting.mp4", mp4Header)
+		assert.Equal(t, "video/mp4", got)
+	})
+
+	t.Run("mp4 without valid header", func(t *testing.T) {
+		// without a proper ftyp header, http.DetectContentType sniffs the content;
+		// ASCII text is detected as text/plain, not video/mp4
+		got := detectContentType("video.mp4", []byte("not a real video"))
+		assert.NotEqual(t, "video/mp4", got, "plain text should not be detected as video/mp4")
+	})
+
+	t.Run("mov with ftyp header", func(t *testing.T) {
+		// mov files also use ftyp boxes
+		movHeader := make([]byte, len(mp4Header))
+		copy(movHeader, mp4Header)
+		// change major brand to "qt  " (QuickTime)
+		movHeader[8] = 0x71  // 'q'
+		movHeader[9] = 0x74  // 't'
+		movHeader[10] = 0x20 // ' '
+		movHeader[11] = 0x20 // ' '
+		got := detectContentType("recording.mov", movHeader)
+		// http.DetectContentType recognizes ftyp as video/mp4 regardless of brand
+		assert.Contains(t, got, "video/")
+	})
+}
+
+func TestCommitAndPushDocImport_VideoFile(t *testing.T) {
+	barePath, clonePath := createBareAndClone(t)
+	isolatePushEnv(t, clonePath)
+
+	docID := "team-standup-recording"
+	docDir := filepath.Join(clonePath, "data", "docs", "2026", "03", "24", docID)
+	require.NoError(t, os.MkdirAll(docDir, 0o755))
+
+	// simulate a video file with a valid ftyp header
+	srcContent := make([]byte, 512)
+	copy(srcContent, mp4Header)
+	srcRef := lfs.NewFileRef(srcContent)
+
+	srcPointerPath := filepath.Join(docDir, "standup.mp4")
+	require.NoError(t, os.WriteFile(srcPointerPath, []byte(lfs.FormatPointer(srcRef.OID, srcRef.Size)), 0o644))
+
+	meta := docMeta{
+		Version:        "1",
+		Title:          "team standup recording",
+		SourceFilename: "standup.mp4",
+		ContentType:    detectContentType("standup.mp4", srcContent),
+		SourceSize:     srcRef.Size,
+		SourceOID:      srcRef.OID,
+		CreatedAt:      "2026-03-24",
+		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
+		Path:           "data/docs/2026/03/24/" + docID,
+		Sidecars:       map[string]sidecar{},
+	}
+	metaData, err := json.MarshalIndent(meta, "", "  ")
+	require.NoError(t, err)
+	metaPath := filepath.Join(docDir, "metadata.json")
+	require.NoError(t, os.WriteFile(metaPath, metaData, 0o644))
+
+	textPointerPath := filepath.Join(docDir, "extracted.md")
+	err = commitAndPushDocImport(clonePath, "https://test.invalid", docID, metaPath, srcPointerPath, textPointerPath, false)
+	require.NoError(t, err)
+
+	// verify artifacts on remote
+	verifyClone := cloneBare(t, barePath)
+
+	// metadata.json
+	verifyMeta := filepath.Join(verifyClone, "data", "docs", "2026", "03", "24", docID, "metadata.json")
+	verifyMetaBytes, err := os.ReadFile(verifyMeta)
+	require.NoError(t, err, "metadata.json should exist on remote")
+
+	var parsedMeta docMeta
+	require.NoError(t, json.Unmarshal(verifyMetaBytes, &parsedMeta))
+	assert.Equal(t, "video/mp4", parsedMeta.ContentType)
+	assert.Equal(t, "standup.mp4", parsedMeta.SourceFilename)
+	assert.Equal(t, srcRef.OID, parsedMeta.SourceOID)
+	assert.Equal(t, srcRef.Size, parsedMeta.SourceSize)
+	assert.Equal(t, "team standup recording", parsedMeta.Title)
+
+	// LFS pointer file
+	verifySrc := filepath.Join(verifyClone, "data", "docs", "2026", "03", "24", docID, "standup.mp4")
+	pointerContent, err := os.ReadFile(verifySrc)
+	require.NoError(t, err, "LFS pointer should exist on remote")
+	parsedOID, parsedSize, err := lfs.ParsePointer(string(pointerContent))
+	require.NoError(t, err, "should be a valid LFS pointer")
+	assert.Equal(t, srcRef.OID, parsedOID)
+	assert.Equal(t, srcRef.Size, parsedSize)
+
+	// commit message
+	msg := runGit(t, verifyClone, "log", "-1", "--format=%s")
+	assert.Equal(t, "import: doc "+docID, msg)
+}
+
+func TestVideoMetadataSerialization(t *testing.T) {
+	srcContent := make([]byte, 1024)
+	copy(srcContent, mp4Header)
+	srcRef := lfs.NewFileRef(srcContent)
+
+	meta := docMeta{
+		Version:        "1",
+		Title:          "architecture review",
+		SourceFilename: "architecture-review.mp4",
+		ContentType:    "video/mp4",
+		SourceSize:     srcRef.Size,
+		SourceOID:      srcRef.OID,
+		CreatedAt:      time.Date(2026, 3, 24, 14, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
+		Path:           "data/docs/2026/03/24/architecture-review",
+		Sidecars:       map[string]sidecar{},
+	}
+
+	data, err := json.MarshalIndent(meta, "", "  ")
+	require.NoError(t, err)
+
+	// round-trip
+	var parsed docMeta
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	assert.Equal(t, "video/mp4", parsed.ContentType)
+	assert.Equal(t, "architecture-review.mp4", parsed.SourceFilename)
+	assert.Equal(t, int64(1024), parsed.SourceSize)
+	assert.NotEmpty(t, parsed.SourceOID)
+	assert.Empty(t, parsed.Sidecars, "video import should have no sidecars")
+}
+
+// --- URL import mock server tests ---
+
+func TestImportVideoURL_MockServer(t *testing.T) {
+	var importCalled atomic.Int32
+	var statusCalled atomic.Int32
+
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/api/v1/teams/team_test123/recordings/import/url":
+			importCalled.Add(1)
+
+			var req api.ImportVideoURLRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+
+			assert.NotEmpty(t, req.URL, "source_url should be set")
+
+			resp := api.ImportVideoURLResponse{
+				ImportID:    "rec_test_001",
+				RecordingID: "rec_test_001",
+				Status:      "pending",
+				Title:       req.Title,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+
+		case r.Method == "GET" && r.URL.Path == "/api/v1/teams/team_test123/recordings/rec_test_001":
+			statusCalled.Add(1)
+
+			dur := 5.0
+			resp := api.VideoStatusResponse{
+				ID:       "rec_test_001",
+				Title:    "Test Video",
+				Status:   "ready",
+				MimeType: "video/mp4",
+				Duration: &dur,
+				ProcessingSteps: map[string]map[string]any{
+					"upload":     {"status": "completed"},
+					"transcribe": {"status": "completed"},
+					"summarize":  {"status": "completed"},
+					"commit":     {"status": "completed"},
+				},
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+
+		default:
+			http.Error(w, fmt.Sprintf("unexpected request: %s %s", r.Method, r.URL.Path), http.StatusNotFound)
+		}
+	}))
+
+	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
+
+	// test ImportVideoURL
+	resp, err := client.ImportVideoURL("team_test123", &api.ImportVideoURLRequest{
+		URL:   "https://localhost/test-video.mp4",
+		Title: "Test Video",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "rec_test_001", resp.RecordingID)
+	assert.Equal(t, "pending", resp.Status)
+	assert.Equal(t, int32(1), importCalled.Load())
+
+	// test GetVideoStatus
+	status, err := client.GetVideoStatus("team_test123", "rec_test_001")
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Equal(t, "ready", status.Status)
+	assert.Equal(t, "video/mp4", status.MimeType)
+	assert.NotNil(t, status.Duration)
+	assert.Equal(t, 5.0, *status.Duration)
+	assert.Len(t, status.ProcessingSteps, 4)
+	assert.Equal(t, int32(1), statusCalled.Load())
+
+	// verify all processing steps are completed
+	for _, step := range []string{"upload", "transcribe", "summarize", "commit"} {
+		stepData, ok := status.ProcessingSteps[step]
+		require.True(t, ok, "processing step %q should exist", step)
+		assert.Equal(t, "completed", stepData["status"], "step %q should be completed", step)
+	}
+}
+
+func TestImportVideoURL_404GracefulDegradation(t *testing.T) {
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
+
+	// ImportVideoURL returns nil, nil on 404
+	resp, err := client.ImportVideoURL("team_test123", &api.ImportVideoURLRequest{
+		URL: "https://localhost/video.mp4",
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, resp, "should return nil on 404 (endpoint not deployed)")
+
+	// GetVideoStatus returns nil, nil on 404
+	status, err := client.GetVideoStatus("team_test123", "rec_nonexistent")
+	assert.NoError(t, err)
+	assert.Nil(t, status, "should return nil on 404 (recording not found)")
+}
+
+func TestImportVideoURL_StatusProgression(t *testing.T) {
+	// simulates a recording progressing through states: pending -> processing -> ready
+	var callCount atomic.Int32
+
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		var status string
+		var steps map[string]map[string]any
+
+		switch {
+		case count <= 1:
+			status = "pending"
+			steps = map[string]map[string]any{
+				"upload": {"status": "in_progress"},
+			}
+		case count <= 2:
+			status = "processing"
+			steps = map[string]map[string]any{
+				"upload":     {"status": "completed"},
+				"transcribe": {"status": "in_progress"},
+			}
+		default:
+			status = "ready"
+			steps = map[string]map[string]any{
+				"upload":     {"status": "completed"},
+				"transcribe": {"status": "completed"},
+				"summarize":  {"status": "completed"},
+				"commit":     {"status": "completed"},
+			}
+		}
+
+		dur := 60.0
+		resp := api.VideoStatusResponse{
+			ID:              "rec_progress_001",
+			Title:           "Progressing Video",
+			Status:          status,
+			Duration:        &dur,
+			ProcessingSteps: steps,
+			CreatedAt:       time.Now(),
+			UpdatedAt:       time.Now(),
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+
+	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
+
+	// first call: pending
+	s1, err := client.GetVideoStatus("team_test123", "rec_progress_001")
+	require.NoError(t, err)
+	assert.Equal(t, "pending", s1.Status)
+
+	// second call: processing
+	s2, err := client.GetVideoStatus("team_test123", "rec_progress_001")
+	require.NoError(t, err)
+	assert.Equal(t, "processing", s2.Status)
+
+	// third call: ready
+	s3, err := client.GetVideoStatus("team_test123", "rec_progress_001")
+	require.NoError(t, err)
+	assert.Equal(t, "ready", s3.Status)
+	assert.Len(t, s3.ProcessingSteps, 4)
+}
+
+func TestListVideos_MockServer(t *testing.T) {
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := api.ListVideosResponse{
+			Recordings: []api.RecordingListItem{
+				{
+					ID:        "rec_001",
+					Title:     "Architecture Review",
+					Status:    "ready",
+					MimeType:  "video/mp4",
+					CreatedAt: time.Date(2026, 3, 24, 10, 0, 0, 0, time.UTC),
+				},
+				{
+					ID:        "rec_002",
+					Title:     "Sprint Retro",
+					Status:    "processing",
+					MimeType:  "video/mp4",
+					CreatedAt: time.Date(2026, 3, 23, 15, 0, 0, 0, time.UTC),
+				},
+			},
+			Pagination: api.PaginationResponse{
+				Total:   2,
+				Limit:   50,
+				Offset:  0,
+				HasMore: false,
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+
+	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
+	resp, err := client.ListVideos("team_test123", 50, 0)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Len(t, resp.Recordings, 2)
+	assert.Equal(t, "rec_001", resp.Recordings[0].ID)
+	assert.Equal(t, "ready", resp.Recordings[0].Status)
+	assert.Equal(t, "video/mp4", resp.Recordings[0].MimeType)
+	assert.Equal(t, "rec_002", resp.Recordings[1].ID)
+	assert.Equal(t, "processing", resp.Recordings[1].Status)
+	assert.False(t, resp.Pagination.HasMore)
+}
+
+func TestListVideos_404GracefulDegradation(t *testing.T) {
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
+	resp, err := client.ListVideos("team_test123", 50, 0)
+	assert.NoError(t, err)
+	assert.Nil(t, resp, "should return nil on 404")
+}
+
+// --- notifyImport tests ---
+
+func TestNotifyImport_VideoContentType(t *testing.T) {
+	var notifyCalled atomic.Int32
+	var receivedMeta docMeta
+
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/teams/team_vid_001/context/import" && r.Method == "POST" {
+			notifyCalled.Add(1)
+
+			var body struct {
+				Metadata json.RawMessage `json:"metadata"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, "bad", http.StatusBadRequest)
+				return
+			}
+			json.Unmarshal(body.Metadata, &receivedMeta)
+
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	// set up auth so notifyImport finds a token
+	t.Setenv("SAGEOX_ENDPOINT", server.URL)
+
+	// notifyImport reads from auth store which requires disk — test the API client directly
+	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
+
+	meta := docMeta{
+		Version:        "1",
+		Title:          "sprint planning recording",
+		SourceFilename: "sprint-planning.mp4",
+		ContentType:    "video/mp4",
+		SourceSize:     1048576,
+		SourceOID:      "sha256:abcdef1234567890",
+		CreatedAt:      "2026-03-24",
+		ImportedAt:     time.Now().UTC().Format(time.RFC3339),
+		Path:           "data/docs/2026/03/24/sprint-planning",
+		Sidecars:       map[string]sidecar{},
+	}
+
+	err := client.NotifyImport("team_vid_001", &meta)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), notifyCalled.Load())
+	assert.Equal(t, "video/mp4", receivedMeta.ContentType)
+	assert.Equal(t, "sha256:abcdef1234567890", receivedMeta.SourceOID)
+	assert.Equal(t, int64(1048576), receivedMeta.SourceSize)
+}

--- a/scripts/smoketest/smoke-test-import.sh
+++ b/scripts/smoketest/smoke-test-import.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# smoke-test-import.sh - Test ox import with a video file
+#
+# Tests the full import pipeline: LFS upload, metadata creation, cloud notification,
+# and (when backend supports it) video processing with keyframes/transcript/summary.
+#
+# Required environment variables (set by smoke-test.sh):
+#   SAGEOX_ENDPOINT - API endpoint
+#   SMOKE_TEST_WORKDIR - Temp directory for test
+#   OX - Path to ox binary
+#
+# Optional environment variables:
+#   SAGEOX_CI_TEAM_ID - Team ID to import into (skip if not set)
+
+set -euo pipefail
+
+: "${SAGEOX_ENDPOINT:?SAGEOX_ENDPOINT is required}"
+: "${SMOKE_TEST_WORKDIR:?SMOKE_TEST_WORKDIR is required}"
+: "${OX:?OX is required}"
+
+if [[ -z "${SAGEOX_CI_TEAM_ID:-}" ]]; then
+    echo "Skipping: SAGEOX_CI_TEAM_ID not set"
+    echo "Set SAGEOX_CI_TEAM_ID to enable import test"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: Generate a synthetic test video with ffmpeg
+# ---------------------------------------------------------------------------
+
+TEST_VIDEO="$SMOKE_TEST_WORKDIR/smoke-test-video.mp4"
+
+if command -v ffmpeg &>/dev/null; then
+    echo "Generating 5-second synthetic test video..."
+    ffmpeg -y -f lavfi -i "testsrc=duration=5:size=320x240:rate=10" \
+           -f lavfi -i "sine=frequency=440:duration=5" \
+           -c:v libx264 -preset ultrafast -pix_fmt yuv420p \
+           -c:a aac -b:a 64k \
+           "$TEST_VIDEO" 2>/dev/null
+else
+    echo "error: ffmpeg not found, cannot generate test video"
+    exit 1
+fi
+
+if [[ ! -f "$TEST_VIDEO" ]]; then
+    echo "error: failed to generate test video"
+    exit 1
+fi
+
+VIDEO_SIZE=$(wc -c < "$TEST_VIDEO" | tr -d ' ')
+echo "Test video generated: $TEST_VIDEO ($VIDEO_SIZE bytes)"
+
+# ---------------------------------------------------------------------------
+# Step 2: Import the video file
+# ---------------------------------------------------------------------------
+
+echo "Importing video to team $SAGEOX_CI_TEAM_ID..."
+
+set +e
+import_output=$($OX import "$TEST_VIDEO" --team "$SAGEOX_CI_TEAM_ID" --force 2>&1)
+import_exit=$?
+set -e
+
+if [[ $import_exit -ne 0 ]]; then
+    echo "error: ox import failed with exit code $import_exit"
+    echo "$import_output"
+    exit 1
+fi
+
+# check for panics
+if echo "$import_output" | grep -qi "panic\|goroutine\|stack trace"; then
+    echo "error: ox import produced a panic"
+    echo "$import_output"
+    exit 1
+fi
+
+echo "Import output: $import_output"
+
+# extract the import path from output (e.g., "Path: data/docs/2026/03/24/smoke-test-video")
+import_path=$(echo "$import_output" | sed -n 's/.*Path: //p' || true)
+if [[ -z "$import_path" ]]; then
+    echo "error: could not extract import path from output"
+    echo "$import_output"
+    exit 1
+fi
+
+echo "Import path: $import_path"
+
+# ---------------------------------------------------------------------------
+# Step 3: Verify local artifacts in the team context repo
+# ---------------------------------------------------------------------------
+
+# find the team context directory
+TC_BASE="$HOME/.local/share/sageox"
+
+# normalize endpoint to a directory slug (strip https://, trailing slashes)
+ep_slug=$(echo "$SAGEOX_ENDPOINT" | sed 's|https://||;s|http://||;s|/$||')
+
+TC_DIR="$TC_BASE/$ep_slug/teams/$SAGEOX_CI_TEAM_ID"
+
+if [[ ! -d "$TC_DIR" ]]; then
+    echo "warn: team context directory not found at $TC_DIR"
+    echo "Skipping local artifact verification (daemon may not have synced)"
+else
+    DOC_DIR="$TC_DIR/$import_path"
+
+    echo "Checking local artifacts in $DOC_DIR..."
+
+    # metadata.json must exist
+    if [[ ! -f "$DOC_DIR/metadata.json" ]]; then
+        echo "error: metadata.json not found in $DOC_DIR"
+        exit 1
+    fi
+
+    # validate metadata.json fields
+    meta_content_type=$(jq -r '.content_type' "$DOC_DIR/metadata.json")
+    if [[ "$meta_content_type" != "video/mp4" ]]; then
+        echo "error: metadata.json content_type is '$meta_content_type', expected 'video/mp4'"
+        exit 1
+    fi
+
+    meta_source_oid=$(jq -r '.source_oid' "$DOC_DIR/metadata.json")
+    if [[ -z "$meta_source_oid" || "$meta_source_oid" == "null" ]]; then
+        echo "error: metadata.json source_oid is missing"
+        exit 1
+    fi
+
+    meta_source_size=$(jq -r '.source_size' "$DOC_DIR/metadata.json")
+    if [[ "$meta_source_size" -le 0 ]]; then
+        echo "error: metadata.json source_size is $meta_source_size, expected > 0"
+        exit 1
+    fi
+
+    echo "  metadata.json: content_type=$meta_content_type, source_size=$meta_source_size ✓"
+
+    # LFS pointer file must exist
+    LFS_FILE="$DOC_DIR/smoke-test-video.mp4"
+    if [[ ! -f "$LFS_FILE" ]]; then
+        echo "error: LFS pointer file not found at $LFS_FILE"
+        exit 1
+    fi
+
+    # validate it's an LFS pointer (starts with "version https://git-lfs.github.com/spec/v1")
+    if ! head -1 "$LFS_FILE" | grep -q "version https://git-lfs.github.com/spec/v1"; then
+        echo "error: $LFS_FILE is not a valid LFS pointer"
+        exit 1
+    fi
+
+    echo "  LFS pointer: valid ✓"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Verify backend video processing (when supported)
+# ---------------------------------------------------------------------------
+
+# Check if the recording appeared in --list (indicates backend processed it)
+echo "Checking recordings list for processed video..."
+
+set +e
+list_output=$($OX import --list --team "$SAGEOX_CI_TEAM_ID" --json 2>&1)
+list_exit=$?
+set -e
+
+if [[ $list_exit -ne 0 ]]; then
+    echo "warn: ox import --list failed (exit $list_exit), skipping processing verification"
+    echo "$list_output"
+else
+    # look for a recording with title matching our video
+    rec_id=$(echo "$list_output" | jq -r '.recordings[] | select(.title | test("smoke.test.video"; "i")) | .id' 2>/dev/null || true)
+
+    if [[ -z "$rec_id" ]]; then
+        echo "info: no recording found for imported video (backend may not process file imports yet)"
+        echo "  This is expected until the video/* dispatcher route is deployed (see ox-ulyi)"
+    else
+        echo "Recording found: $rec_id"
+
+        # poll status until ready or timeout (5 minutes)
+        echo "Waiting for processing to complete..."
+        TIMEOUT=300
+        ELAPSED=0
+        INTERVAL=5
+        FINAL_STATUS=""
+
+        while [[ $ELAPSED -lt $TIMEOUT ]]; do
+            set +e
+            status_output=$($OX import --status "$rec_id" --team "$SAGEOX_CI_TEAM_ID" --json 2>&1)
+            status_exit=$?
+            set -e
+
+            if [[ $status_exit -ne 0 ]]; then
+                echo "warn: status check failed, retrying..."
+                sleep "$INTERVAL"
+                ELAPSED=$((ELAPSED + INTERVAL))
+                continue
+            fi
+
+            current_status=$(echo "$status_output" | jq -r '.status' 2>/dev/null || echo "unknown")
+
+            if [[ "$current_status" == "ready" ]]; then
+                FINAL_STATUS="$status_output"
+                echo "Processing complete ✓"
+                break
+            elif [[ "$current_status" == "failed" ]]; then
+                echo "error: video processing failed"
+                echo "$status_output" | jq '.' 2>/dev/null || echo "$status_output"
+                exit 1
+            fi
+
+            echo "  status: $current_status (${ELAPSED}s / ${TIMEOUT}s)"
+            sleep "$INTERVAL"
+            ELAPSED=$((ELAPSED + INTERVAL))
+        done
+
+        if [[ -z "$FINAL_STATUS" ]]; then
+            echo "error: video processing did not complete within ${TIMEOUT}s"
+            exit 1
+        fi
+
+        # ---------------------------------------------------------------
+        # Assert processing_steps all completed
+        # ---------------------------------------------------------------
+        for step in upload transcribe summarize commit; do
+            step_status=$(echo "$FINAL_STATUS" | jq -r ".processing_steps.${step}.status // \"missing\"")
+            if [[ "$step_status" != "completed" && "$step_status" != "complete" ]]; then
+                echo "error: processing_steps.$step status is '$step_status', expected 'completed'"
+                exit 1
+            fi
+        done
+        echo "  processing_steps: all completed ✓"
+
+        # ---------------------------------------------------------------
+        # Assert duration > 0
+        # ---------------------------------------------------------------
+        duration=$(echo "$FINAL_STATUS" | jq -r '.duration // 0')
+        duration_ok=$(echo "$FINAL_STATUS" | jq '.duration != null and .duration > 0')
+        if [[ "$duration_ok" != "true" ]]; then
+            echo "error: duration is $duration, expected > 0"
+            exit 1
+        fi
+        echo "  duration: ${duration}s ✓"
+
+        # ---------------------------------------------------------------
+        # Verify git discussion artifacts (if team context is local)
+        # ---------------------------------------------------------------
+        if [[ -d "$TC_DIR" ]]; then
+            # pull latest to get discussion folder
+            (cd "$TC_DIR" && git pull --rebase --autostash 2>/dev/null || true)
+
+            # find the discussion folder by listing discussions/ sorted by date
+            DISC_DIR=$(find "$TC_DIR/discussions" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort -r | head -1)
+
+            if [[ -n "$DISC_DIR" && -d "$DISC_DIR" ]]; then
+                echo "Checking discussion artifacts in $DISC_DIR..."
+
+                # transcript.vtt
+                if [[ -f "$DISC_DIR/transcript.vtt" ]]; then
+                    vtt_size=$(wc -c < "$DISC_DIR/transcript.vtt" | tr -d ' ')
+                    if [[ $vtt_size -gt 0 ]]; then
+                        echo "  transcript.vtt: ${vtt_size} bytes ✓"
+                    else
+                        echo "error: transcript.vtt is empty"
+                        exit 1
+                    fi
+                else
+                    echo "error: transcript.vtt not found in discussion folder"
+                    exit 1
+                fi
+
+                # metadata.json (discussion metadata, not import metadata)
+                if [[ -f "$DISC_DIR/metadata.json" ]]; then
+                    disc_rec_id=$(jq -r '.recording_id // empty' "$DISC_DIR/metadata.json")
+                    if [[ -n "$disc_rec_id" ]]; then
+                        echo "  metadata.json: recording_id=$disc_rec_id ✓"
+                    else
+                        echo "warn: metadata.json missing recording_id"
+                    fi
+                else
+                    echo "error: metadata.json not found in discussion folder"
+                    exit 1
+                fi
+
+                # keyframes.json
+                if [[ -f "$DISC_DIR/keyframes.json" ]]; then
+                    kf_count=$(jq -r '.keyframe_count // 0' "$DISC_DIR/keyframes.json")
+                    kf_array_len=$(jq -r '.keyframes | length' "$DISC_DIR/keyframes.json")
+                    if [[ $kf_count -gt 0 && $kf_array_len -gt 0 ]]; then
+                        echo "  keyframes.json: keyframe_count=$kf_count, array_len=$kf_array_len ✓"
+
+                        # verify each keyframe has s3_key and timestamp_seconds
+                        bad_kf=$(jq '[.keyframes[] | select(.s3_key == null or .s3_key == "" or .timestamp_seconds == null)] | length' "$DISC_DIR/keyframes.json")
+                        if [[ $bad_kf -gt 0 ]]; then
+                            echo "error: $bad_kf keyframes missing s3_key or timestamp_seconds"
+                            exit 1
+                        fi
+                        echo "  keyframes: all have s3_key + timestamp_seconds ✓"
+                    else
+                        echo "error: keyframes.json has keyframe_count=$kf_count, array_len=$kf_array_len"
+                        exit 1
+                    fi
+                else
+                    echo "error: keyframes.json not found in discussion folder"
+                    exit 1
+                fi
+
+                # summary.md
+                if [[ -f "$DISC_DIR/summary.md" ]]; then
+                    sm_size=$(wc -c < "$DISC_DIR/summary.md" | tr -d ' ')
+                    if [[ $sm_size -gt 0 ]]; then
+                        echo "  summary.md: ${sm_size} bytes ✓"
+                    else
+                        echo "error: summary.md is empty"
+                        exit 1
+                    fi
+                else
+                    echo "error: summary.md not found in discussion folder"
+                    exit 1
+                fi
+
+                # summary.json
+                if [[ -f "$DISC_DIR/summary.json" ]]; then
+                    sj_version=$(jq -r '.schema_version // 0' "$DISC_DIR/summary.json")
+                    sj_chapters=$(jq -r '.chapters | length' "$DISC_DIR/summary.json")
+                    if [[ $sj_version -ge 1 ]]; then
+                        echo "  summary.json: schema_version=$sj_version, chapters=$sj_chapters ✓"
+                    else
+                        echo "error: summary.json schema_version=$sj_version, expected >= 1"
+                        exit 1
+                    fi
+                else
+                    echo "error: summary.json not found in discussion folder"
+                    exit 1
+                fi
+
+                # annotations.json (optional — may not exist for short videos)
+                if [[ -f "$DISC_DIR/annotations.json" ]]; then
+                    ann_version=$(jq -r '.schema_version // 0' "$DISC_DIR/annotations.json")
+                    echo "  annotations.json: schema_version=$ann_version (optional, present) ✓"
+                else
+                    echo "  annotations.json: not present (optional, ok for short videos)"
+                fi
+            else
+                echo "warn: no discussion folder found in $TC_DIR/discussions/"
+                echo "  Backend may not have committed artifacts yet"
+            fi
+        fi
+    fi
+fi
+
+echo ""
+echo "ox import smoke test passed"
+exit 0

--- a/scripts/smoketest/smoke-test.sh
+++ b/scripts/smoketest/smoke-test.sh
@@ -134,6 +134,7 @@ main() {
     run_test "ox agent prime" "smoke-test-prime.sh" || true
     run_test "ox session list" "smoke-test-sessions.sh" || true
     run_test "Clone without ox" "smoke-test-clone-no-ox.sh" || true
+    run_test "ox import (video)" "smoke-test-import.sh" || true
     # skip checkout test for now - requires team setup
     # run_test "ox team context add" "smoke-test-checkout.sh" || true
 


### PR DESCRIPTION
## Summary

- Adds `smoke-test-import.sh` — E2E smoke test that imports a synthetic video via `ox import`, verifies LFS pointer + metadata locally, then polls the backend for full video processing artifacts (keyframes, transcript, summary) when the `video/*` dispatcher route is deployed
- Adds `import_video_test.go` — 10 component tests covering video content type detection, video file commit+push with metadata assertions, URL import/status/list against mock servers, 404 graceful degradation, and cloud notification payload verification
- Wires the import smoke test into the orchestrator (`smoke-test.sh`)

## Context

During manual testing, we discovered that the backend's `team-context-doc-import` dispatcher silently drops `video/*` content types (documented but never implemented — tracked as `ox-ulyi`). The smoke test is designed to pass today for the CLI-side assertions and will automatically verify backend processing once that fix deploys.

## Test plan

- [x] All 10 new component tests pass (`go test ./cmd/ox/ -run "TestDetectContentType_Video|TestCommitAndPushDocImport_Video|TestVideoMetadata|TestImportVideoURL|TestListVideos|TestNotifyImport_Video"`)
- [x] All existing import tests still pass
- [ ] Smoke test passes against `test.sageox.ai` with `SAGEOX_CI_TEAM_ID` set (requires backend deploy of `ox-ulyi` for full artifact verification)

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for video import functionality, including content-type detection, metadata serialization, API client behavior, and end-to-end import pipeline validation.

* **Chores**
  * Added smoke test script to validate the video import pipeline and backend processing steps in CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->