### PR TITLE
feat(session): add --summary flag to ox session regenerate

### DIFF
--- a/cmd/ox/session_regenerate.go
+++ b/cmd/ox/session_regenerate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 	sessionhtml "github.com/sageox/ox/internal/session/html"
+	"github.com/sageox/ox/pkg/sessionsummary"
 	"github.com/spf13/cobra"
 )
 
@@ -35,18 +36,24 @@ will be handled by the /api/v1/git/lfs/purge cloud API endpoint.
 
 The session name supports partial matching (e.g. agent ID suffix).
 
+With --summary, re-generates summary.json using the current prompt template
+by invoking Claude. Requires the claude CLI to be installed. Single-session
+only (ledgers can contain 10,000+ sessions; each requires an LLM invocation).
+
 Examples:
   ox session regenerate OxK3ZN                          # regenerate HTML
   ox session regenerate --all                           # regenerate all HTML
   ox session regenerate OxK3ZN --redact                 # re-redact session
   ox session regenerate --redact --all                  # re-redact all sessions
-  ox session regenerate OxK3ZN --redact --dry-run       # preview redaction`,
+  ox session regenerate OxK3ZN --redact --dry-run       # preview redaction
+  ox session regenerate OxK3ZN --summary                # re-summarize with current prompt`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runSessionRegenerate,
 }
 
 func init() {
 	sessionRegenerateCmd.Flags().Bool("redact", false, "re-apply current REDACT.md rules to session data")
+	sessionRegenerateCmd.Flags().Bool("summary", false, "re-generate summary.json using current prompt template (requires claude CLI)")
 	sessionRegenerateCmd.Flags().Bool("all", false, "regenerate all sessions")
 	sessionRegenerateCmd.Flags().Bool("dry-run", false, "preview what would change without modifying anything (--redact only)")
 	sessionRegenerateCmd.Flags().Bool("force", false, "skip confirmation prompts")
@@ -54,11 +61,26 @@ func init() {
 
 func runSessionRegenerate(cmd *cobra.Command, args []string) error {
 	redact, _ := cmd.Flags().GetBool("redact")
+	summary, _ := cmd.Flags().GetBool("summary")
 	regenAll, _ := cmd.Flags().GetBool("all")
 	force, _ := cmd.Flags().GetBool("force")
 
+	if summary && redact {
+		return fmt.Errorf("--summary and --redact cannot be used together")
+	}
+
 	if redact {
 		return runSessionRegenerateRedact(cmd, args)
+	}
+
+	if summary {
+		// Single-session only: ledgers can contain 10,000+ sessions (more for
+		// large monorepos). Each summary requires an LLM invocation (~60s + API
+		// cost), making batch regeneration prohibitively expensive.
+		if len(args) == 0 {
+			return fmt.Errorf("specify a session name\nRun 'ox session list' to see available sessions")
+		}
+		return regenerateSingleSessionSummary(args[0])
 	}
 
 	// default mode: HTML-only regeneration
@@ -209,6 +231,109 @@ func syncRegeneratedSession(projectRoot, sessionPath, sessionName string) error 
 		return fmt.Errorf("commit and push: %w", err)
 	}
 
+	return nil
+}
+
+// --- Summary regeneration (--summary) ---
+
+// regenerateSingleSessionSummary re-generates summary.json for a session by
+// invoking Claude with the current summary prompt template. The raw.jsonl is
+// read (downloaded from LFS if needed), a prompt is built using the shared
+// template, and Claude produces a new summary. Downstream artifacts
+// (summary.md, session.html, session.md) are regenerated from the result.
+func regenerateSingleSessionSummary(nameArg string) error {
+	projectRoot, err := requireProjectRoot()
+	if err != nil {
+		return err
+	}
+
+	ledgerPath, err := resolveLedgerPath()
+	if err != nil {
+		return err
+	}
+
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	sessionName, err := resolveSessionInDir(sessionsDir, nameArg)
+	if err != nil {
+		return err
+	}
+
+	sessionPath := filepath.Join(sessionsDir, sessionName)
+	rawPath := filepath.Join(sessionPath, ledgerFileRaw)
+
+	// ensure raw.jsonl is available locally (download from LFS if stub)
+	if _, statErr := os.Stat(rawPath); statErr != nil {
+		meta, metaErr := lfs.ReadSessionMeta(sessionPath)
+		if metaErr != nil {
+			return fmt.Errorf("read meta.json for %s: %w", sessionName, metaErr)
+		}
+		if dlErr := downloadFileFromLFS(projectRoot, sessionPath, meta, ledgerFileRaw); dlErr != nil {
+			return fmt.Errorf("download %s for %s: %w", ledgerFileRaw, sessionName, dlErr)
+		}
+	}
+
+	rawSession, err := session.ReadSessionFromPath(rawPath)
+	if err != nil {
+		return fmt.Errorf("read raw.jsonl: %w", err)
+	}
+
+	if len(rawSession.Entries) == 0 {
+		return fmt.Errorf("session %s has no entries", sessionName)
+	}
+
+	// build summary prompt using shared template
+	entries := sessionsummary.EntriesFromRaw(rawSession.Entries)
+	prompt := sessionsummary.BuildSummaryPrompt(entries, rawPath, "")
+
+	cli.PrintInfo(fmt.Sprintf("Generating summary for %s...", sessionName))
+
+	resultText, err := sessionsummary.InvokeClaude(context.Background(), prompt, sessionPath)
+	if err != nil {
+		return fmt.Errorf("claude invocation: %w", err)
+	}
+
+	summaryResp, err := sessionsummary.ParseSummaryJSON(resultText)
+	if err != nil {
+		return fmt.Errorf("parse summary from claude output: %w", err)
+	}
+
+	// write summary.json atomically
+	summaryData, err := json.MarshalIndent(summaryResp, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal summary: %w", err)
+	}
+
+	summaryPath := filepath.Join(sessionPath, "summary.json")
+	tmpPath := summaryPath + ".tmp"
+	if err := os.WriteFile(tmpPath, summaryData, 0644); err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+	if err := os.Rename(tmpPath, summaryPath); err != nil {
+		return fmt.Errorf("rename summary: %w", err)
+	}
+
+	// update meta.json title from new summary
+	if summaryResp.Title != "" {
+		if err := lfs.UpdateMetaSummary(sessionPath, summaryResp.Title); err != nil {
+			slog.Debug("update meta.json summary", "error", err)
+		}
+	}
+
+	// regenerate downstream artifacts (summary.md, session.html, session.md)
+	if err := regenerateArtifacts(sessionPath, rawSession); err != nil {
+		slog.Warn("artifact regeneration partially failed", "session", sessionName, "error", err)
+	}
+
+	// upload to LFS and push to ledger
+	if _, lfsErr := uploadSessionLFS(projectRoot, sessionPath); lfsErr != nil {
+		slog.Warn("LFS upload skipped", "session", sessionName, "error", lfsErr)
+	}
+
+	if err := commitAndPushLedger(ledgerPath, sessionName); err != nil {
+		slog.Warn("ledger push skipped", "error", err)
+	}
+
+	cli.PrintSuccess(fmt.Sprintf("Regenerated summary for %s (quality: %.2f)", sessionName, summaryResp.QualityScore))
 	return nil
 }
 

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/internal/session/html"
+	"github.com/sageox/ox/pkg/sessionsummary"
 )
 
 const (
@@ -355,8 +356,8 @@ func (h *SessionFinalizeHandler) BuildPrompt(item *WorkItem) (RunRequest, error)
 	// cache for ProcessResult to avoid re-reading
 	payload.storedSession = stored
 
-	entries := convertStoredEntries(stored.Entries)
-	prompt := session.BuildSummaryPrompt(entries, payload.RawPath, payload.SessionDir)
+	entries := sessionsummary.EntriesFromRaw(stored.Entries)
+	prompt := sessionsummary.BuildSummaryPrompt(entries, payload.RawPath, payload.SessionDir)
 
 	return RunRequest{
 		Prompt:  prompt,
@@ -387,7 +388,7 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 
 	// parse LLM output into SummarizeResponse
 	var summaryResp *session.SummarizeResponse
-	parsed, parseErr := parseSummaryJSON(llmOutput)
+	parsed, parseErr := sessionsummary.ParseSummaryJSON(llmOutput)
 	if parseErr != nil {
 		h.logger.Warn("could not parse summary JSON from LLM output, using raw text", "err", parseErr)
 		// fall back to raw LLM output as summary text; default to upload (benefit of the doubt)
@@ -631,69 +632,20 @@ func missingArtifacts(sessionDir string) []string {
 
 // convertStoredEntries converts []map[string]any from StoredSession to []session.Entry.
 func convertStoredEntries(stored []map[string]any) []session.Entry {
-	entries := make([]session.Entry, 0, len(stored))
-	for _, m := range stored {
-		e := session.Entry{}
-		if t, ok := m["type"].(string); ok {
-			e.Type = session.EntryType(t)
+	// delegate to shared conversion, then map sessionsummary.Entry → session.Entry
+	ssEntries := sessionsummary.EntriesFromRaw(stored)
+	entries := make([]session.Entry, len(ssEntries))
+	for i, e := range ssEntries {
+		entries[i] = session.Entry{
+			Timestamp:  e.Timestamp,
+			Type:       session.EntryType(e.Type),
+			Content:    e.Content,
+			ToolName:   e.ToolName,
+			ToolInput:  e.ToolInput,
+			ToolOutput: e.ToolOutput,
 		}
-		if c, ok := m["content"].(string); ok {
-			e.Content = c
-		}
-		if tn, ok := m["tool_name"].(string); ok {
-			e.ToolName = tn
-		}
-		if ti, ok := m["tool_input"].(string); ok {
-			e.ToolInput = ti
-		}
-		if ts, ok := m["timestamp"].(string); ok {
-			if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
-				e.Timestamp = t
-			} else if t, err := time.Parse(time.RFC3339, ts); err == nil {
-				e.Timestamp = t
-			}
-		}
-		entries = append(entries, e)
 	}
 	return entries
-}
-
-// parseSummaryJSON attempts to extract a SummarizeResponse from the LLM output.
-// The output may contain the JSON embedded in markdown code fences or as raw JSON.
-func parseSummaryJSON(output string) (*session.SummarizeResponse, error) {
-	// try raw JSON first
-	var resp session.SummarizeResponse
-	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &resp); err == nil && resp.Title != "" {
-		return &resp, nil
-	}
-
-	// try extracting from ```json ... ``` fences
-	if idx := strings.Index(output, "```json"); idx >= 0 {
-		start := idx + len("```json")
-		if end := strings.Index(output[start:], "```"); end >= 0 {
-			jsonStr := strings.TrimSpace(output[start : start+end])
-			if err := json.Unmarshal([]byte(jsonStr), &resp); err == nil && resp.Title != "" {
-				return &resp, nil
-			}
-		}
-	}
-
-	// try extracting from generic ``` ... ``` fences
-	if idx := strings.Index(output, "```"); idx >= 0 {
-		start := idx + len("```")
-		// skip to newline if present (e.g., ```\n{...}\n```)
-		if nlIdx := strings.Index(output[start:], "\n"); nlIdx >= 0 {
-			start += nlIdx + 1
-		}
-		if end := strings.Index(output[start:], "```"); end >= 0 {
-			jsonStr := strings.TrimSpace(output[start : start+end])
-			if err := json.Unmarshal([]byte(jsonStr), &resp); err == nil && resp.Title != "" {
-				return &resp, nil
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("no valid summary JSON found in LLM output")
 }
 
 // invalidLeakedTypes are internal Claude Code types that should never appear

--- a/internal/daemon/agentwork/session_finalize_test.go
+++ b/internal/daemon/agentwork/session_finalize_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/pkg/sessionsummary"
 )
 
 // createTestSession creates a session directory with raw.jsonl and optional artifacts.
@@ -382,7 +383,7 @@ func TestParseSummaryJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := parseSummaryJSON(tt.input)
+			resp, err := sessionsummary.ParseSummaryJSON(tt.input)
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error, got nil")

--- a/pkg/sessionsummary/claude.go
+++ b/pkg/sessionsummary/claude.go
@@ -1,0 +1,76 @@
+package sessionsummary
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+)
+
+const invokeTimeout = 10 * time.Minute
+
+// claudeResultMessage is the minimal structure for parsing Claude's stream-json output.
+type claudeResultMessage struct {
+	Type   string `json:"type"`
+	Result string `json:"result,omitempty"`
+}
+
+// InvokeClaude runs `claude --output-format stream-json -p <prompt>` and returns
+// the result text. Uses a 10-minute timeout. Returns an error if the claude binary
+// is not found, the invocation times out, or no result message appears in output.
+func InvokeClaude(ctx context.Context, prompt, workDir string) (string, error) {
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return "", fmt.Errorf("claude binary not found in PATH — ensure Claude Code CLI is installed")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, invokeTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, claudePath, "--output-format", "stream-json", "--verbose", "-p", prompt)
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	// discard stderr to avoid blocking
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("start claude: %w", err)
+	}
+
+	// scan JSONL stdout for the result message
+	var resultText string
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var msg claudeResultMessage
+		if json.Unmarshal(scanner.Bytes(), &msg) == nil && msg.Type == "result" {
+			resultText = msg.Result
+		}
+	}
+
+	if waitErr := cmd.Wait(); waitErr != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("claude timed out after %s", invokeTimeout)
+		}
+		// non-zero exit is acceptable if we got a result
+		if resultText == "" {
+			return "", fmt.Errorf("claude exited with error: %w", waitErr)
+		}
+	}
+
+	if resultText == "" {
+		return "", fmt.Errorf("no result message in claude output")
+	}
+
+	return resultText, nil
+}

--- a/pkg/sessionsummary/parse.go
+++ b/pkg/sessionsummary/parse.go
@@ -1,0 +1,81 @@
+package sessionsummary
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ParseSummaryJSON extracts a SummarizeResponse from LLM output text.
+// The output may contain the JSON as raw text, inside ```json fences,
+// or inside generic ``` fences.
+func ParseSummaryJSON(output string) (*SummarizeResponse, error) {
+	// try raw JSON first
+	var resp SummarizeResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &resp); err == nil && resp.Title != "" {
+		return &resp, nil
+	}
+
+	// try extracting from ```json ... ``` fences
+	if idx := strings.Index(output, "```json"); idx >= 0 {
+		start := idx + len("```json")
+		if end := strings.Index(output[start:], "```"); end >= 0 {
+			jsonStr := strings.TrimSpace(output[start : start+end])
+			if err := json.Unmarshal([]byte(jsonStr), &resp); err == nil && resp.Title != "" {
+				return &resp, nil
+			}
+		}
+	}
+
+	// try extracting from generic ``` ... ``` fences
+	if idx := strings.Index(output, "```"); idx >= 0 {
+		start := idx + len("```")
+		// skip to newline if present (e.g., ```\n{...}\n```)
+		if nlIdx := strings.Index(output[start:], "\n"); nlIdx >= 0 {
+			start += nlIdx + 1
+		}
+		if end := strings.Index(output[start:], "```"); end >= 0 {
+			jsonStr := strings.TrimSpace(output[start : start+end])
+			if err := json.Unmarshal([]byte(jsonStr), &resp); err == nil && resp.Title != "" {
+				return &resp, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no valid summary JSON found in LLM output")
+}
+
+// EntriesFromRaw converts []map[string]any (from StoredSession.Entries) to
+// []Entry for use with BuildSummaryPrompt. Shared by the daemon's session
+// finalization and the CLI's --summary regeneration.
+func EntriesFromRaw(raw []map[string]any) []Entry {
+	entries := make([]Entry, 0, len(raw))
+	for _, m := range raw {
+		e := Entry{}
+		if t, ok := m["type"].(string); ok {
+			e.Type = t
+		}
+		if c, ok := m["content"].(string); ok {
+			e.Content = c
+		}
+		if tn, ok := m["tool_name"].(string); ok {
+			e.ToolName = tn
+		}
+		if ti, ok := m["tool_input"].(string); ok {
+			e.ToolInput = ti
+		}
+		if to, ok := m["tool_output"].(string); ok {
+			e.ToolOutput = to
+		}
+		if ts, ok := m["timestamp"].(string); ok {
+			if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+				e.Timestamp = t
+			} else if t, err := time.Parse(time.RFC3339, ts); err == nil {
+				e.Timestamp = t
+			}
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}

--- a/pkg/sessionsummary/parse_test.go
+++ b/pkg/sessionsummary/parse_test.go
@@ -1,0 +1,94 @@
+package sessionsummary
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSummaryJSON_RawJSON(t *testing.T) {
+	input := `{"title":"Fix auth bug","summary":"Fixed token refresh","key_actions":["patched refresh"],"outcome":"success","quality_score":0.8}`
+	resp, err := ParseSummaryJSON(input)
+	require.NoError(t, err)
+	assert.Equal(t, "Fix auth bug", resp.Title)
+	assert.Equal(t, 0.8, resp.QualityScore)
+}
+
+func TestParseSummaryJSON_JSONFence(t *testing.T) {
+	input := "Here is the summary:\n\n```json\n{\"title\":\"Add caching\",\"summary\":\"Added Redis cache\",\"key_actions\":[\"added cache layer\"],\"outcome\":\"success\",\"quality_score\":0.7}\n```\n\nDone."
+	resp, err := ParseSummaryJSON(input)
+	require.NoError(t, err)
+	assert.Equal(t, "Add caching", resp.Title)
+}
+
+func TestParseSummaryJSON_GenericFence(t *testing.T) {
+	input := "Summary:\n\n```\n{\"title\":\"Refactor DB\",\"summary\":\"Moved to connection pool\",\"key_actions\":[\"pooling\"],\"outcome\":\"success\",\"quality_score\":0.6}\n```"
+	resp, err := ParseSummaryJSON(input)
+	require.NoError(t, err)
+	assert.Equal(t, "Refactor DB", resp.Title)
+}
+
+func TestParseSummaryJSON_NoTitle(t *testing.T) {
+	input := `{"summary":"no title here","quality_score":0.5}`
+	_, err := ParseSummaryJSON(input)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid summary JSON")
+}
+
+func TestParseSummaryJSON_Empty(t *testing.T) {
+	_, err := ParseSummaryJSON("")
+	assert.Error(t, err)
+}
+
+func TestParseSummaryJSON_InvalidJSON(t *testing.T) {
+	_, err := ParseSummaryJSON("this is not json at all")
+	assert.Error(t, err)
+}
+
+func TestEntriesFromRaw(t *testing.T) {
+	ts := "2026-03-24T10:00:00.000Z"
+	raw := []map[string]any{
+		{"type": "user", "content": "Fix the bug", "timestamp": ts},
+		{"type": "assistant", "content": "Looking at it.", "timestamp": ts},
+		{"type": "tool", "tool_name": "Read", "tool_input": "main.go", "tool_output": "package main"},
+	}
+
+	entries := EntriesFromRaw(raw)
+	require.Len(t, entries, 3)
+
+	assert.Equal(t, "user", entries[0].Type)
+	assert.Equal(t, "Fix the bug", entries[0].Content)
+	assert.False(t, entries[0].Timestamp.IsZero())
+
+	assert.Equal(t, "assistant", entries[1].Type)
+	assert.Equal(t, "Looking at it.", entries[1].Content)
+
+	assert.Equal(t, "tool", entries[2].Type)
+	assert.Equal(t, "Read", entries[2].ToolName)
+	assert.Equal(t, "main.go", entries[2].ToolInput)
+	assert.Equal(t, "package main", entries[2].ToolOutput)
+}
+
+func TestEntriesFromRaw_Empty(t *testing.T) {
+	entries := EntriesFromRaw(nil)
+	assert.Empty(t, entries)
+}
+
+func TestEntriesFromRaw_TimestampFormats(t *testing.T) {
+	raw := []map[string]any{
+		{"type": "user", "content": "nano", "timestamp": "2026-03-24T10:00:00.123456789Z"},
+		{"type": "user", "content": "rfc3339", "timestamp": "2026-03-24T10:00:00Z"},
+		{"type": "user", "content": "invalid", "timestamp": "not-a-date"},
+		{"type": "user", "content": "missing"},
+	}
+
+	entries := EntriesFromRaw(raw)
+	require.Len(t, entries, 4)
+
+	assert.False(t, entries[0].Timestamp.IsZero(), "nano timestamp should parse")
+	assert.False(t, entries[1].Timestamp.IsZero(), "rfc3339 timestamp should parse")
+	assert.True(t, entries[2].Timestamp.Equal(time.Time{}), "invalid timestamp should be zero")
+	assert.True(t, entries[3].Timestamp.Equal(time.Time{}), "missing timestamp should be zero")
+}


### PR DESCRIPTION
## Summary

- Adds `--summary` flag to `ox session regenerate` that re-generates `summary.json` using the current prompt template by invoking Claude synchronously. Single-session only — ledgers can contain 10,000+ sessions (more for large monorepos), making batch prohibitively expensive.
- Extracts `ParseSummaryJSON` and `EntriesFromRaw` from daemon internals into shared `pkg/sessionsummary/` package, eliminating duplication between daemon finalization and CLI regeneration.
- Adds thin `InvokeClaude` helper in `pkg/sessionsummary/claude.go` for one-shot Claude CLI subprocess invocation with 10-minute timeout and JSONL stream parsing.
- `--summary` and `--redact` are mutually exclusive.

```mermaid
flowchart LR
    A[ox session regenerate NAME --summary] --> B[Read raw.jsonl\nhydrate from LFS if stub]
    B --> C[Build prompt\nvia shared template]
    C --> D[Invoke Claude CLI\nstream-json + parse result]
    D --> E[Write summary.json\natomic tmp+rename]
    E --> F[Regenerate artifacts\nsummary.md, session.html, session.md]
    F --> G[Upload LFS + push ledger]
```

## Test plan

- [x] `go build ./cmd/ox/` compiles
- [x] `go test ./pkg/sessionsummary/...` — 9 new tests pass (ParseSummaryJSON, EntriesFromRaw)
- [x] `go test ./internal/daemon/agentwork/...` — existing tests pass with refactored imports
- [x] `make test` — 6770 tests pass
- [ ] Manual: `ox session regenerate <session> --summary` on a real session

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--summary` flag to `ox session regenerate` command, enabling regeneration of session summaries for individual sessions independently.

* **Refactor**
  * Consolidated summary processing logic into shared utilities for consistent handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->