### PR TITLE
fix(distill): render missing summary.json fields in fast path

### DIFF
--- a/cmd/ox/distill_discussions.go
+++ b/cmd/ox/distill_discussions.go
@@ -286,8 +286,18 @@ func extractFactsFromSummaryJSON(d discussionInput) (string, error) {
 		}
 	}
 
+	if len(summary.Requirements) > 0 {
+		sb.WriteString("\n## Requirements\n")
+		for _, item := range summary.Requirements {
+			fmt.Fprintf(&sb, "- %s\n", item.Text())
+		}
+	}
+
 	// key context from TechnicalContext, Constraints, NonGoals, high-importance chapters
 	var keyContext []string
+	keyContext = append(keyContext, summary.TechnicalContext.Technologies...)
+	keyContext = append(keyContext, summary.TechnicalContext.Architecture...)
+	keyContext = append(keyContext, summary.TechnicalContext.Integrations...)
 	keyContext = append(keyContext, summary.TechnicalContext.Notes...)
 	keyContext = append(keyContext, summary.Constraints...)
 	keyContext = append(keyContext, summary.NonGoals...)

--- a/cmd/ox/distill_discussions_test.go
+++ b/cmd/ox/distill_discussions_test.go
@@ -538,7 +538,14 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 		s["learnings"] = []map[string]any{{"description": "redis handles TTL well"}}
 		s["action_items"] = []map[string]any{{"description": "migrate by friday"}}
 		s["open_questions"] = []map[string]any{{"question": "failover strategy?"}}
+		s["requirements"] = []map[string]any{{"description": "must support SAML SSO"}}
 		s["constraints"] = []string{"compliance requirement"}
+		s["technical_context"] = map[string]any{
+			"technologies": []string{"Redis 7.x"},
+			"architecture": []string{"token service is stateless"},
+			"integrations": []string{"Okta SAML provider"},
+			"notes":        []string{"latency budget is 50ms"},
+		}
 		writeSummaryJSON(t, dir, s)
 
 		d := discussionInput{
@@ -557,7 +564,12 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 		assertContains(t, output, "redis handles TTL well")
 		assertContains(t, output, "migrate by friday")
 		assertContains(t, output, "failover strategy?")
+		assertContains(t, output, "must support SAML SSO")
 		assertContains(t, output, "compliance requirement")
+		assertContains(t, output, "Redis 7.x")
+		assertContains(t, output, "token service is stateless")
+		assertContains(t, output, "Okta SAML provider")
+		assertContains(t, output, "latency budget is 50ms")
 	})
 
 	t.Run("wrong schema version — returns error for LLM fallback", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes unresolved CodeRabbit feedback from PR #293 — `extractFactsFromSummaryJSON()` was silently dropping `Requirements`, `TechnicalContext.Technologies`, `.Architecture`, and `.Integrations` fields from server-generated `summary.json`. These structured facts now render in the markdown output alongside existing categories.

- **Requirements**: New `## Requirements` section using `.Text()` (same pattern as Decisions, Learnings, etc.)
- **TechnicalContext sub-fields**: Technologies, Architecture, and Integrations appended to Key Context (alongside existing Notes, Constraints, NonGoals)
- **Tests**: Extended the "categorized facts present" fixture with all new fields and assertions

## Test plan

- [x] `go test ./cmd/ox/ -run TestExtractFactsFromSummaryJSON -v` — all 6 subtests pass
- [x] `make lint` — 0 issues
- [x] `make test` — 6847 tests pass

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated requirements section extraction in discussion summaries
  * Enhanced technical context aggregation to include technologies, architecture, and integrations

* **Tests**
  * Added test coverage for new requirements and technical context extraction functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->