### PR TITLE
fix(ci): replace hardcoded Go versions with go-version-file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
 
       - name: Configure git identity for tests
         run: |
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
 
       - uses: golangci/golangci-lint-action@v7
         with:

--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
 
       - name: Build
         run: go build -v ./...
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/smoke-test.yml.disabled
+++ b/.github/workflows/smoke-test.yml.disabled
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
           cache: true
 
       - name: Build ox

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.5
+golang 1.24.2


### PR DESCRIPTION
## Summary

- Replace all hardcoded `go-version` values with `go-version-file: 'go.mod'` so CI always uses the same Go version declared in `go.mod`
- **ci.yml**: both `test` and `lint` jobs (was `1.24`)
- **docs.yml**: publish job (was `1.22` — 2 major versions behind)
- **ci.yml.disabled**: both jobs (was `1.22`)
- **smoke-test.yml.disabled**: (was `1.24`)
- **.tool-versions**: update Go from `1.22.5` to `1.24.2` to match `go.mod`

## Why

Go version was hardcoded in 6 places across workflows, with `docs.yml` stuck on 1.22 and `.tool-versions` on 1.22.5 while `go.mod` requires 1.24.2. Using `go-version-file` makes `go.mod` the single source of truth — future Go bumps only need one change.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.22 to 1.24.2
  * Standardized Go version management across CI/CD workflows: now dynamically references version from project configuration file instead of separate hardcoded values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->