### PR TITLE
fix(lint): resolve 19 golangci-lint issues across 10 files

### DIFF
--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -78,13 +78,13 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 	if output.Guidance != nil && len(output.Guidance.Commands) > 0 {
 		sb.WriteString("\n<commands")
 		if output.Guidance.Hint != "" {
-			sb.WriteString(fmt.Sprintf(" hint=%q", output.Guidance.Hint))
+			fmt.Fprintf(&sb, " hint=%q", output.Guidance.Hint)
 		}
 		sb.WriteString(">\n")
 		sb.WriteString("| Intent | Command |\n")
 		sb.WriteString("|--------|---------|\n")
 		for _, ic := range output.Guidance.Commands {
-			sb.WriteString(fmt.Sprintf("| %s | `%s` |\n", ic.Intent, ic.Command))
+			fmt.Fprintf(&sb, "| %s | `%s` |\n", ic.Intent, ic.Command)
 		}
 		sb.WriteString("</commands>\n")
 	}
@@ -97,16 +97,16 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 	sb.WriteString("\nPlan footer (required for team-guided plans):\n")
 	sb.WriteString("> Guided by SageOx\n")
 	if output.Attribution.Commit != "" {
-		sb.WriteString(fmt.Sprintf("\nCommit: `%s`\n", output.Attribution.Commit))
+		fmt.Fprintf(&sb, "\nCommit: `%s`\n", output.Attribution.Commit)
 	}
 	if output.Attribution.PR != "" {
-		sb.WriteString(fmt.Sprintf("PR body (last line): `%s`\n", output.Attribution.PR))
+		fmt.Fprintf(&sb, "PR body (last line): `%s`\n", output.Attribution.PR)
 	}
 	sb.WriteString("</attribution>\n")
 
 	// project guidance: AGENTS.md from the project root
 	if output.ProjectGuidance != nil && !output.ProjectGuidance.Skipped && output.ProjectGuidance.Content != "" {
-		sb.WriteString(fmt.Sprintf("\n<project-guidance source=%q>\n", output.ProjectGuidance.Source))
+		fmt.Fprintf(&sb, "\n<project-guidance source=%q>\n", output.ProjectGuidance.Source)
 		sb.WriteString(output.ProjectGuidance.Content)
 		if !strings.HasSuffix(output.ProjectGuidance.Content, "\n") {
 			sb.WriteString("\n")
@@ -158,7 +158,7 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 				if model == "" {
 					model = "inherit"
 				}
-				sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n", cw.Name, desc, model))
+				fmt.Fprintf(&sb, "| %s | %s | %s |\n", cw.Name, desc, model)
 			}
 			sb.WriteString("\nLoad: `ox coworker load <name>`\n")
 			sb.WriteString("</coworkers>\n")
@@ -174,7 +174,7 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 				if desc == "" {
 					desc = "(no description)"
 				}
-				sb.WriteString(fmt.Sprintf("| %s | %s | %s |\n", tcmd.Name, tcmd.Trigger, desc))
+				fmt.Fprintf(&sb, "| %s | %s | %s |\n", tcmd.Name, tcmd.Trigger, desc)
 			}
 			sb.WriteString("</team-commands>\n")
 		}
@@ -193,10 +193,10 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 				if when == "" {
 					when = title
 				}
-				sb.WriteString(fmt.Sprintf("| %s | %s |\n", doc.Name, when))
+				fmt.Fprintf(&sb, "| %s | %s |\n", doc.Name, when)
 			}
 			if output.TeamContext.ReadCommand != "" {
-				sb.WriteString(fmt.Sprintf("\nRead: `%s`\n", output.TeamContext.ReadCommand))
+				fmt.Fprintf(&sb, "\nRead: `%s`\n", output.TeamContext.ReadCommand)
 			}
 			sb.WriteString("</docs>\n")
 		}
@@ -233,7 +233,7 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 			if age == "" {
 				age = "unknown"
 			}
-			sb.WriteString(fmt.Sprintf("| %s | %s |\n", t.Slug, age))
+			fmt.Fprintf(&sb, "| %s | %s |\n", t.Slug, age)
 		}
 		sb.WriteString("\nList all: `ox teams`\n")
 		sb.WriteString("Read: `ox agent team-ctx <slug>`\n")
@@ -250,16 +250,16 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 
 	// session context: binds all per-session dynamic values
 	sb.WriteString("\n<session-context")
-	sb.WriteString(fmt.Sprintf(" agent_id=%q", output.AgentID))
-	sb.WriteString(fmt.Sprintf(" status=%q", output.Status))
+	fmt.Fprintf(&sb, " agent_id=%q", output.AgentID)
+	fmt.Fprintf(&sb, " status=%q", output.Status)
 	if output.TeamContext != nil {
 		teamName := output.TeamContext.TeamName
 		if teamName == "" {
 			teamName = output.TeamContext.TeamID
 		}
-		sb.WriteString(fmt.Sprintf(" team=%q", teamName))
+		fmt.Fprintf(&sb, " team=%q", teamName)
 		if output.TeamContext.Stale {
-			sb.WriteString(fmt.Sprintf(" team_stale=%q", output.TeamContext.StaleSince))
+			fmt.Fprintf(&sb, " team_stale=%q", output.TeamContext.StaleSince)
 		} else {
 			sb.WriteString(" team_synced=\"true\"")
 		}
@@ -268,10 +268,10 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 		if output.Session.Recording {
 			sb.WriteString(" recording=\"true\"")
 			if output.Session.Mode != "" {
-				sb.WriteString(fmt.Sprintf(" mode=%q", output.Session.Mode))
+				fmt.Fprintf(&sb, " mode=%q", output.Session.Mode)
 			}
 			if output.Session.SessionURL != "" {
-				sb.WriteString(fmt.Sprintf(" url=%q", output.Session.SessionURL))
+				fmt.Fprintf(&sb, " url=%q", output.Session.SessionURL)
 			}
 		}
 	}
@@ -296,11 +296,11 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 	if len(output.UserNotices) > 0 {
 		sb.WriteString("\n<user-notices hint=\"Show each notice to the user\">\n")
 		for _, n := range output.UserNotices {
-			sb.WriteString(fmt.Sprintf(
+			fmt.Fprintf(&sb,
 				"<notice type=\"%s\">%s</notice>\n",
 				escapeXML(n.Type),
 				escapeXML(n.Message),
-			))
+			)
 		}
 		sb.WriteString("</user-notices>\n")
 	}
@@ -331,14 +331,14 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) error {
 
 	// capture-prior: instructions for capturing planning history (session-specific)
 	if output.CapturePrior != nil {
-		sb.WriteString(fmt.Sprintf("\n<capture-prior agent_id=%q>\n", output.AgentID))
+		fmt.Fprintf(&sb, "\n<capture-prior agent_id=%q>\n", output.AgentID)
 		sb.WriteString(output.CapturePrior.Description)
 		sb.WriteString("\n")
 		for _, instr := range output.CapturePrior.Instructions {
-			sb.WriteString(fmt.Sprintf("- %s\n", instr))
+			fmt.Fprintf(&sb, "- %s\n", instr)
 		}
 		if output.CapturePrior.Example != "" {
-			sb.WriteString(fmt.Sprintf("\nExample:\n%s\n", output.CapturePrior.Example))
+			fmt.Fprintf(&sb, "\nExample:\n%s\n", output.CapturePrior.Example)
 		}
 		sb.WriteString("</capture-prior>\n")
 	}

--- a/cmd/ox/code_insights.go
+++ b/cmd/ox/code_insights.go
@@ -407,9 +407,9 @@ func renderInsightsHuman(out insightsOutput, days int) string {
 		b.WriteString(statusHeaderStyle.Render("Hotspots"))
 		b.WriteString("\n")
 		for _, h := range out.Hotspots {
-			b.WriteString(fmt.Sprintf("  %s  %s\n",
+			fmt.Fprintf(&b, "  %s  %s\n",
 				statusWarningStyle.Render(fmt.Sprintf("%d changes", h.Changes)),
-				statusValueStyle.Render(h.Path)))
+				statusValueStyle.Render(h.Path))
 			if len(h.RecentCommits) > 0 {
 				msgs := h.RecentCommits
 				if len(msgs) > 3 {
@@ -423,8 +423,8 @@ func renderInsightsHuman(out insightsOutput, days int) string {
 					}
 					short = append(short, m)
 				}
-				b.WriteString(fmt.Sprintf("              %s\n",
-					statusMutedStyle.Render(strings.Join(short, ", "))))
+				fmt.Fprintf(&b, "              %s\n",
+					statusMutedStyle.Render(strings.Join(short, ", ")))
 			}
 		}
 	}
@@ -440,10 +440,10 @@ func renderInsightsHuman(out insightsOutput, days int) string {
 			if c.WorkspaceCount >= 3 {
 				style = statusWarningStyle
 			}
-			b.WriteString(fmt.Sprintf("  %s  %s  %s\n",
+			fmt.Fprintf(&b, "  %s  %s  %s\n",
 				style.Render(wsLabel),
 				statusValueStyle.Render(c.Path),
-				statusMutedStyle.Render("("+strings.Join(c.Workspaces, ", ")+")")))
+				statusMutedStyle.Render("("+strings.Join(c.Workspaces, ", ")+")"))
 		}
 	}
 
@@ -457,11 +457,11 @@ func renderInsightsHuman(out insightsOutput, days int) string {
 			if len(msg) > 60 {
 				msg = msg[:57] + "..."
 			}
-			b.WriteString(fmt.Sprintf("  %s  %s  %s  %s\n",
+			fmt.Fprintf(&b, "  %s  %s  %s  %s\n",
 				statusMutedStyle.Render(c.Hash),
 				statusHighlightStyle.Render(c.Author),
 				statusValueStyle.Render(msg),
-				statusMutedStyle.Render("("+c.Age+")")))
+				statusMutedStyle.Render("("+c.Age+")"))
 		}
 	}
 
@@ -475,10 +475,10 @@ func renderInsightsHuman(out insightsOutput, days int) string {
 			if len(title) > 60 {
 				title = title[:57] + "..."
 			}
-			b.WriteString(fmt.Sprintf("  %s  %s  %s\n",
+			fmt.Fprintf(&b, "  %s  %s  %s\n",
 				statusHighlightStyle.Render(fmt.Sprintf("#%d", p.Number)),
 				statusValueStyle.Render(title),
-				statusMutedStyle.Render("("+p.Author+")")))
+				statusMutedStyle.Render("("+p.Author+")"))
 		}
 	}
 
@@ -496,11 +496,11 @@ func renderInsightsHuman(out insightsOutput, days int) string {
 			if len(i.Labels) > 0 {
 				labelStr = "  " + statusMutedStyle.Render("["+strings.Join(i.Labels, ", ")+"]")
 			}
-			b.WriteString(fmt.Sprintf("  %s  %s  %s%s\n",
+			fmt.Fprintf(&b, "  %s  %s  %s%s\n",
 				statusHighlightStyle.Render(fmt.Sprintf("#%d", i.Number)),
 				statusValueStyle.Render(title),
 				statusMutedStyle.Render("("+i.Author+")"),
-				labelStr))
+				labelStr)
 		}
 	}
 

--- a/cmd/ox/distill_github.go
+++ b/cmd/ox/distill_github.go
@@ -279,7 +279,7 @@ func buildGitHubExtractorPrompt(clustersJSON, interval string) string {
 	var sb strings.Builder
 	sb.WriteString(githubExtractorSystemPrompt)
 	sb.WriteString("\n\n---\n\n")
-	sb.WriteString(fmt.Sprintf("Here is a batch of GitHub event clusters from the last %s. ", interval))
+	fmt.Fprintf(&sb, "Here is a batch of GitHub event clusters from the last %s. ", interval)
 	sb.WriteString("Each cluster contains pre-assembled related objects with their full comment histories.\n\n")
 	sb.WriteString("Analyze each cluster and extract raw facts for any meaningful events. Remember:\n")
 	sb.WriteString("- One fact per meaningful event, not one fact per GitHub object\n")

--- a/cmd/ox/doctor_team.go
+++ b/cmd/ox/doctor_team.go
@@ -354,10 +354,10 @@ func checkGCBlockedByUntracked(fix bool) checkResult {
 
 	// build detail message showing the blocking files and what to do
 	var detail strings.Builder
-	detail.WriteString(fmt.Sprintf("Teams with dirty checkouts: %s\n", strings.Join(dirtyTeams, ", ")))
+	fmt.Fprintf(&detail, "Teams with dirty checkouts: %s\n", strings.Join(dirtyTeams, ", "))
 	detail.WriteString("        Blocking files:\n")
 	for _, f := range allFiles {
-		detail.WriteString(fmt.Sprintf("          %s\n", f))
+		fmt.Fprintf(&detail, "          %s\n", f)
 	}
 
 	if hasSageoxFiles && !hasOtherFiles && !hasObservationFiles {

--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -406,7 +406,7 @@ func findExistingDocByOID(docsBaseDir, oid string) (string, bool) {
 		if err != nil || d.IsDir() || d.Name() != "metadata.json" {
 			return nil
 		}
-		data, readErr := os.ReadFile(path)
+		data, readErr := os.ReadFile(path) //nolint:gosec // G122 - path comes from controlled walkDir within validated import directory
 		if readErr != nil {
 			return nil
 		}

--- a/internal/codedb/index/indexer_coverage_test.go
+++ b/internal/codedb/index/indexer_coverage_test.go
@@ -26,7 +26,7 @@ func TestGitStatusDirtyFiles(t *testing.T) {
 			t.Helper()
 			cmd := exec.Command("git", args...)
 			cmd.Dir = dir
-			cmd.Env = append(os.Environ(),
+			cmd.Env = append(os.Environ(), // safe: git subprocess needs parent env for PATH
 				"GIT_AUTHOR_NAME=test",
 				"GIT_AUTHOR_EMAIL=test@test.com",
 				"GIT_COMMITTER_NAME=test",
@@ -116,7 +116,7 @@ func TestGitStatusDirtyFiles(t *testing.T) {
 		cancel()
 		_, err := gitStatusDirtyFiles(ctx, dir)
 		if err == nil {
-			t.Error("expected error with cancelled context")
+			t.Error("expected error with canceled context")
 		}
 	})
 }
@@ -649,7 +649,7 @@ func TestIndexLocalRepo_ContextCancellation(t *testing.T) {
 	cancel()
 
 	err := IndexLocalRepo(ctx, s, dir, IndexOptions{})
-	// should error due to cancelled context (may fail at various stages)
+	// should error due to canceled context (may fail at various stages)
 	if err == nil {
 		// timing-dependent; not failing is also acceptable
 		return
@@ -832,7 +832,7 @@ func TestBuildDirtyIndex_RemovesStaleOnClean(t *testing.T) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(os.Environ(), // safe: git subprocess needs parent env for PATH
 			"GIT_AUTHOR_NAME=test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=test",
@@ -1011,7 +1011,7 @@ func TestResolveDefaultBranch_FallbackToBranchNames(t *testing.T) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
+		cmd.Env = append(os.Environ(), // safe: git subprocess needs parent env for PATH
 			"GIT_AUTHOR_NAME=test",
 			"GIT_AUTHOR_EMAIL=test@test.com",
 			"GIT_COMMITTER_NAME=test",

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -848,7 +848,7 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 					}
 					// clone in background goroutine - don't block sync loop
 					s.cloneWg.Add(1)
-					go s.cloneInBackground(ledger.CloneURL, ledger.Path, "ledger", ledger.ID)
+					go s.cloneInBackground(ledger.CloneURL, ledger.Path, "ledger", ledger.ID) //nolint:gosec // G118 - intentionally uses background context; goroutine outlives request scope
 				}
 			}
 		}

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -121,7 +121,7 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 					_ = progress.WriteStage("cloning", fmt.Sprintf("Cloning team %s in background...", ws.TeamName))
 				}
 				s.cloneWg.Add(1)
-				go s.cloneInBackground(ws.CloneURL, ws.Path, "team-context", ws.ID)
+				go s.cloneInBackground(ws.CloneURL, ws.Path, "team-context", ws.ID) //nolint:gosec // G118 - intentionally uses background context; goroutine outlives request scope
 				cloningCount++
 			} else {
 				s.workspaceRegistry.SetWorkspaceError(ws.ID, "path does not exist and no clone URL available")

--- a/internal/tui/sparkline_test.go
+++ b/internal/tui/sparkline_test.go
@@ -40,8 +40,7 @@ func TestRenderSparkline_EventOutsideWindow(t *testing.T) {
 	now := time.Now()
 	// event is 5 hours ago, window is 4 hours
 	result := RenderSparkline([]time.Time{now.Add(-5 * time.Hour)}, 4, 4*time.Hour)
-	runes := []rune(result)
-	for _, r := range runes {
+	for _, r := range result {
 		if r != SparklineChars[0] && r != '|' {
 			t.Errorf("event outside window should produce all-low sparkline, got char %c", r)
 		}
@@ -51,8 +50,7 @@ func TestRenderSparkline_EventOutsideWindow(t *testing.T) {
 func TestRenderSparkline_FutureEvent(t *testing.T) {
 	now := time.Now()
 	result := RenderSparkline([]time.Time{now.Add(time.Hour)}, 4, time.Hour)
-	runes := []rune(result)
-	for _, r := range runes {
+	for _, r := range result {
 		if r != SparklineChars[0] && r != '|' {
 			t.Errorf("future event (negative age) should be excluded, got char %c", r)
 		}
@@ -61,17 +59,14 @@ func TestRenderSparkline_FutureEvent(t *testing.T) {
 
 func TestRenderSparkline_HourSeparators(t *testing.T) {
 	// with 48 buckets and 4-hour window, separators at every 12 buckets
-	result := RenderSparkline(nil, SparklineBuckets, SparklineWindow)
-	if !strings.Contains(result, "|") {
-		// empty sparkline is all dashes, no separators
-		// but with timestamps, separators should appear
-	}
+	// empty sparkline has no separators (all dashes); verify with timestamps below
+	_ = RenderSparkline(nil, SparklineBuckets, SparklineWindow)
 	now := time.Now()
 	ts := make([]time.Time, 0, 48)
 	for i := range 48 {
 		ts = append(ts, now.Add(-time.Duration(i)*5*time.Minute))
 	}
-	result = RenderSparkline(ts, SparklineBuckets, SparklineWindow)
+	result := RenderSparkline(ts, SparklineBuckets, SparklineWindow)
 	separatorCount := strings.Count(result, "|")
 	if separatorCount != 3 {
 		t.Errorf("expected 3 hour separators in 4-hour sparkline, got %d", separatorCount)

--- a/internal/whisper/store/store.go
+++ b/internal/whisper/store/store.go
@@ -249,7 +249,7 @@ func (s *Store) GetWhispers(agentID string, attention Attention, topics []string
 			placeholders[i] = "?"
 			args = append(args, t)
 		}
-		query += " AND topic IN (" + strings.Join(placeholders, ",") + ")"
+		query += " AND topic IN (" + strings.Join(placeholders, ",") + ")" //nolint:gosec // G202 - placeholders are "?" literals, not user input
 	}
 
 	// order: critical first, then normal, then ambient; within each, by time


### PR DESCRIPTION
## Summary

- **staticcheck QF1012 (10 instances)**: Replace `sb.WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(&sb, ...)` across `agent_prime_xml.go`, `code_insights.go`, `distill_github.go`, `doctor_team.go`
- **gosec G122**: Add nolint for controlled `filepath.WalkDir` callback in `import.go`
- **gosec G118 (2 instances)**: Add nolint for goroutines that intentionally outlive request scope in `sync.go`, `sync_team.go`
- **gosec G202**: Add nolint for SQL placeholder concatenation using `?` literals in `store.go`
- **misspell (2 instances)**: Fix `cancelled` → `canceled` in `indexer_coverage_test.go`
- **staticcheck SA6003 (2 instances)**: Range directly over string instead of `[]rune(string)` in `sparkline_test.go`
- **staticcheck SA9003**: Remove empty if-branch in `sparkline_test.go`
- **lint-test-env (3 instances)**: Add `// safe:` annotations to `os.Environ()` calls in `indexer_coverage_test.go`

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — 9446 tests passed, 0 failures

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal formatted output writing mechanisms across multiple modules.

* **Chores**
  * Added linting directives to suppress static-analysis warnings on intentionally flagged code patterns.

* **Tests**
  * Updated test assertions and simplified test iteration logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->