### PR TITLE
fix(endpoint): prepend https:// to bare hostnames in NormalizeEndpoint

### DIFF
--- a/cmd/ox/init_pure_test.go
+++ b/cmd/ox/init_pure_test.go
@@ -86,17 +86,17 @@ func TestGenerateSageoxLinksSection(t *testing.T) {
 		},
 		{
 			name: "repo id only",
-			cfg:  &config.ProjectConfig{RepoID: "repo_abc123"},
+			cfg:  &config.ProjectConfig{RepoID: "repo_abc123", Endpoint: "https://sageox.ai"},
 			want: "## SageOx Links\n\n- **Repository Dashboard:** https://sageox.ai/repo/repo_abc123\n",
 		},
 		{
 			name: "team id only",
-			cfg:  &config.ProjectConfig{TeamID: "team_xyz789"},
+			cfg:  &config.ProjectConfig{TeamID: "team_xyz789", Endpoint: "https://sageox.ai"},
 			want: "## SageOx Links\n\n- **Team Dashboard:** https://sageox.ai/team/team_xyz789\n",
 		},
 		{
 			name: "both ids",
-			cfg:  &config.ProjectConfig{RepoID: "repo_abc123", TeamID: "team_xyz789"},
+			cfg:  &config.ProjectConfig{RepoID: "repo_abc123", TeamID: "team_xyz789", Endpoint: "https://sageox.ai"},
 			want: "## SageOx Links\n\n- **Repository Dashboard:** https://sageox.ai/repo/repo_abc123\n- **Team Dashboard:** https://sageox.ai/team/team_xyz789\n",
 		},
 	}

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -184,7 +184,8 @@ func extractHost(endpoint string) string {
 //	https://api.sageox.ai/v1  → https://sageox.ai/v1
 //	https://app.sageox.ai     → https://sageox.ai
 //	https://git.test.sageox.ai → https://test.sageox.ai
-//	www.test.sageox.ai        → test.sageox.ai
+//	www.test.sageox.ai        → https://test.sageox.ai
+//	test.sageox.ai            → https://test.sageox.ai
 //	http://localhost:8080      → http://localhost:8080  (no prefix to strip)
 func NormalizeEndpoint(ep string) string {
 	if ep == "" {
@@ -211,7 +212,7 @@ func NormalizeEndpoint(ep string) string {
 		return ep
 	}
 
-	// bare host or host:port — strip prefix from the host portion
+	// bare host or host:port — strip prefix, then add https:// scheme
 	host := ep
 	port := ""
 	if idx := strings.LastIndex(host, ":"); idx != -1 {
@@ -230,10 +231,13 @@ func NormalizeEndpoint(ep string) string {
 	}
 
 	normalized := stripSubdomainPrefix(host)
-	if port != "" {
-		return normalized + ":" + port
+	if normalized == "" {
+		return ""
 	}
-	return normalized
+	if port != "" {
+		return "https://" + normalized + ":" + port
+	}
+	return "https://" + normalized
 }
 
 // stripSubdomainPrefix removes a single common subdomain prefix from a hostname.

--- a/internal/endpoint/endpoint_test.go
+++ b/internal/endpoint/endpoint_test.go
@@ -76,14 +76,14 @@ func TestNormalizeEndpoint(t *testing.T) {
 		{"www full URL", "https://www.sageox.ai", "https://sageox.ai"},
 		{"www with path", "https://www.sageox.ai/v1", "https://sageox.ai/v1"},
 		{"www staging", "https://www.test.sageox.ai", "https://test.sageox.ai"},
-		{"www bare host", "www.sageox.ai", "sageox.ai"},
+		{"www bare host", "www.sageox.ai", "https://sageox.ai"},
 		{"www enterprise", "https://www.sageox.walmart.com", "https://sageox.walmart.com"},
 
 		// api. stripping
 		{"api full URL", "https://api.sageox.ai", "https://sageox.ai"},
 		{"api with path", "https://api.sageox.ai/v1/repos", "https://sageox.ai/v1/repos"},
 		{"api staging", "https://api.test.sageox.ai", "https://test.sageox.ai"},
-		{"api bare host", "api.sageox.ai", "sageox.ai"},
+		{"api bare host", "api.sageox.ai", "https://sageox.ai"},
 
 		// app. stripping
 		{"app full URL", "https://app.sageox.ai", "https://sageox.ai"},
@@ -104,8 +104,8 @@ func TestNormalizeEndpoint(t *testing.T) {
 		{"www trailing slash", "https://www.sageox.ai/", "https://sageox.ai"},
 
 		// bare host with port
-		{"bare host with port", "www.sageox.ai:443", "sageox.ai:443"},
-		{"api bare with port", "api.sageox.ai:443", "sageox.ai:443"},
+		{"bare host with port", "www.sageox.ai:443", "https://sageox.ai:443"},
+		{"api bare with port", "api.sageox.ai:443", "https://sageox.ai:443"},
 
 		// edge cases
 		{"empty", "", ""},
@@ -118,10 +118,13 @@ func TestNormalizeEndpoint(t *testing.T) {
 		{"prefix only api.", "api.", ""},
 
 		// git. bare host
-		{"git bare host", "git.sageox.ai", "sageox.ai"},
+		{"git bare host", "git.sageox.ai", "https://sageox.ai"},
 
 		// URL with prefix + port
 		{"api full URL with port and path", "https://api.sageox.ai:443/v1", "https://sageox.ai:443/v1"},
+
+		// bare host no prefix (the --endpoint flag bug)
+		{"bare host no prefix", "test.sageox.ai", "https://test.sageox.ai"},
 
 		// mixed case
 		{"mixed case prefix", "https://API.SageOx.AI", "https://SageOx.AI"},


### PR DESCRIPTION
## Summary

- `NormalizeEndpoint()` now prepends `https://` when given a bare hostname (e.g., `test.sageox.ai` → `https://test.sageox.ai`), fixing opaque "unsupported protocol scheme" errors when using `--endpoint` without a protocol
- Fixed pre-existing test isolation issue in `TestGenerateSageoxLinksSection` where test configs didn't set `Endpoint` explicitly, causing them to pick up the logged-in endpoint from the environment

## Before / After

```
# Before
$ ox login --endpoint test.sageox.ai
Error: failed to request device code: Post "test.sageox.ai/api/auth/device/code": unsupported protocol scheme ""

# After
$ ox login --endpoint test.sageox.ai
Initiating device authentication flow...
```

## Test plan

- [x] New test case: `{"bare host no prefix", "test.sageox.ai", "https://test.sageox.ai"}`
- [x] Updated 6 existing bare-host test expectations to expect `https://` prefix
- [x] Idempotency test still passes (double-normalizing produces same result)
- [x] `NormalizeSlug` unaffected (`extractHost` strips scheme)
- [x] `make test` — 9447 tests pass, 0 failures
- [x] `make lint` — 0 issues

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Endpoint URLs are now consistently normalized to include the `https://` scheme when provided as bare hosts or host:port combinations, with common subdomain prefixes properly stripped during normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->