### PR TITLE
fix(friction): re-queue events on flush failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.2
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/sageox/agentx v0.1.2
-	github.com/sageox/frictionax v0.1.1
+	github.com/sageox/frictionax v0.1.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sageox/agentx v0.1.2 h1:XW+n6YGyAitVNgvpRIiwr91RYSutrI2dm3clOXwnTJk=
 github.com/sageox/agentx v0.1.2/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
-github.com/sageox/frictionax v0.1.1 h1:8FzL8MTdLJx86XmQava6SGzxmsN3AE5dQ5zFWE4V1f0=
-github.com/sageox/frictionax v0.1.1/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
+github.com/sageox/frictionax v0.1.2 h1:iQfssC1g/vVdGXi55smMfY5/4JKcQbJXRzcwrQWiNLo=
+github.com/sageox/frictionax v0.1.2/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
## Summary

- **Bumps `frictionax` from v0.1.1 to v0.1.2** to fix silent event loss when the user is not authenticated (or on any transient failure)
- Previously, `flush()` destructively drained the ring buffer before `Submit()` — if the submit failed (401, network error, 5xx), events were permanently lost
- Now failed events are re-queued via `Refill()` and retried on the next flush cycle

```mermaid
flowchart LR
    A[flush] --> B[Drain buffer]
    B --> C[Submit to API]
    C -->|2xx| D[Done - events delivered]
    C -->|fail| E["Refill(events) - re-queue"]
    E -->|next flush| B
```

## Why this matters

Friction telemetry is MVP-critical. A real session showed an AI coworker trying `ox context search`, `ox search`, `ox team discussions`, `ox query` — all failed because the user wasn't logged in. These are exactly the friction events we need, but they were silently dropped because the daemon couldn't authenticate with the API.

## What changed (in frictionax v0.1.2)

- **`ringbuffer.Refill()`** — new method to re-insert a batch of events after failed flush, respecting capacity limits and dedup
- **`collector.flush()`** — calls `Refill(events)` on submit error or non-2xx response instead of silently discarding

## Test plan

- [ ] `go mod tidy` clean
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] frictionax v0.1.2 tests pass (ring buffer refill, collector re-queue on error/non-2xx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->