### PR TITLE
fix(test): address CodeRabbit review comments on PR #318

### DIFF
--- a/cmd/ox/config_settings_coverage_test.go
+++ b/cmd/ox/config_settings_coverage_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -102,20 +104,25 @@ func TestSetConfigValue_DefaultLevel(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot be set at default level")
 }
 
-func TestSetConfigValue_RepoLevelWithoutProject(t *testing.T) {
+func TestSetConfigValue_WithoutProject(t *testing.T) {
 	t.Parallel()
 
-	err := SetConfigValue("session_recording", "auto", ConfigLevelRepo, "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not in a SageOx project")
-}
+	tests := []struct {
+		name  string
+		level ConfigLevel
+	}{
+		{"repo level", ConfigLevelRepo},
+		{"team level", ConfigLevelTeam},
+	}
 
-func TestSetConfigValue_TeamLevelWithoutProject(t *testing.T) {
-	t.Parallel()
-
-	err := SetConfigValue("session_recording", "auto", ConfigLevelTeam, "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not in a SageOx project")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := SetConfigValue("session_recording", "auto", tt.level, "")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "not in a SageOx project")
+		})
+	}
 }
 
 func TestResolveConfigValue_UnknownSetting(t *testing.T) {
@@ -181,11 +188,14 @@ func TestConfigLevel_Constants(t *testing.T) {
 func TestSetRepoConfig_UnsupportedKey(t *testing.T) {
 	t.Parallel()
 
-	// create a temp dir with .sageox/config.json
 	dir := t.TempDir()
+	sageoxDir := filepath.Join(dir, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(`{}`), 0o644))
+
 	err := setRepoConfig("telemetry", "on", dir)
-	// should fail because telemetry is not supported at repo level
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported at repo level")
 }
 
 func TestSetTeamConfig_NoTeamContext(t *testing.T) {
@@ -200,7 +210,7 @@ func TestSetTeamConfig_NoTeamContext(t *testing.T) {
 func TestResolveConfigValue_KnownSettings(t *testing.T) {
 	t.Parallel()
 
-	// resolve with empty project root — should return defaults
+	// resolve with empty project root — resolves from user config or defaults
 	for _, setting := range AllSettings {
 		t.Run(setting.Key, func(t *testing.T) {
 			t.Parallel()
@@ -209,7 +219,8 @@ func TestResolveConfigValue_KnownSettings(t *testing.T) {
 			require.NotNil(t, cv)
 			assert.Equal(t, setting.Key, cv.Key)
 			assert.Equal(t, setting.Default, cv.Default)
-			// with no project root, only user config is loaded
+			assert.NotEmpty(t, cv.Value, "resolved value should not be empty")
+			assert.NotEmpty(t, cv.Source, "source should be set")
 			assert.Empty(t, cv.RepoVal)
 			assert.Empty(t, cv.TeamVal)
 		})
@@ -225,6 +236,8 @@ func TestResolveConfigValue_WithFakeProjectRoot(t *testing.T) {
 	require.NotNil(t, cv)
 	assert.Equal(t, "session_recording", cv.Key)
 	assert.Equal(t, "auto", cv.Default)
+	assert.NotEmpty(t, cv.Value, "resolved value should not be empty")
+	assert.NotEmpty(t, cv.Source, "source should be set")
 }
 
 func TestResolveConfigValue_AllKnownKeys(t *testing.T) {
@@ -238,6 +251,7 @@ func TestResolveConfigValue_AllKnownKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, cv)
 			assert.Equal(t, key, cv.Key)
+			assert.NotEmpty(t, cv.Value, "resolved value should not be empty")
 		})
 	}
 }

--- a/cmd/ox/config_tui_coverage_test.go
+++ b/cmd/ox/config_tui_coverage_test.go
@@ -438,13 +438,24 @@ func TestWrapText_IndentedMultilineWrapping(t *testing.T) {
 	result := m.wrapText(text, 20)
 
 	lines := strings.Split(result, "\n")
-	// indented lines should preserve the indent
-	for _, line := range lines {
-		if strings.HasPrefix(line, "  ") {
-			trimmed := strings.TrimLeft(line, " ")
-			assert.True(t, len(line)-len(trimmed) >= 2, "indent should be preserved")
+	assert.Greater(t, len(lines), 2, "wrapping should produce multiple lines")
+
+	// find the boundary between indented paragraph and normal line
+	normalIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "normal") {
+			normalIdx = i
+			break
 		}
 	}
-	// normal line should appear
-	assert.Contains(t, result, "normal")
+	assert.Greater(t, normalIdx, 0, "normal line should appear after indented lines")
+
+	// all lines before "normal" should preserve the two-space indent
+	for i := 0; i < normalIdx; i++ {
+		if lines[i] == "" {
+			continue
+		}
+		assert.True(t, strings.HasPrefix(lines[i], "  "),
+			"line %d should preserve indent: %q", i, lines[i])
+	}
 }

--- a/cmd/ox/session_helpers_coverage_test.go
+++ b/cmd/ox/session_helpers_coverage_test.go
@@ -66,10 +66,10 @@ func TestGetDisplayName_EmptyEndpoint(t *testing.T) {
 	assert.Equal(t, "", got)
 }
 
-// --- email username extraction logic (verified through getAuthenticatedUsername behavior) ---
-// The function extracts the local part before @ from the email.
-// Since we can't easily inject auth tokens, we verify the string logic is sound
-// by testing the pattern used in the function:
+// Tests the email-to-username extraction logic used by getAuthenticatedUsername.
+// The production function couples auth lookup with extraction, so we test the
+// extraction logic in isolation here. A refactor to extract this to a shared
+// helper would enable direct testing of the production code path.
 
 func TestEmailUsernameExtraction(t *testing.T) {
 	t.Parallel()

--- a/cmd/ox/session_show_coverage_test.go
+++ b/cmd/ox/session_show_coverage_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatSize_ShowCoverage(t *testing.T) {
@@ -176,12 +178,20 @@ func TestShowRawSession_NoLimit(t *testing.T) {
 	}
 }
 
-func TestPrintSessionEntry_MessageType(t *testing.T) {
-	// test doesn't crash and produces output for message entries
+// captureStdout runs fn while capturing stdout, returning the output.
+func captureStdout(fn func()) string {
 	old := os.Stdout
-	_, w, _ := os.Pipe()
+	r, w, _ := os.Pipe()
 	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
 
+func TestPrintSessionEntry_MessageType(t *testing.T) {
 	entry := map[string]any{
 		"type":      "message",
 		"timestamp": time.Now().Format(time.RFC3339Nano),
@@ -190,17 +200,11 @@ func TestPrintSessionEntry_MessageType(t *testing.T) {
 			"content": "hello world",
 		},
 	}
-	printSessionEntry(1, entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printSessionEntry(1, entry) })
+	assert.Contains(t, output, "user")
 }
 
 func TestPrintSessionEntry_ToolCallType(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	entry := map[string]any{
 		"type": "tool_call",
 		"data": map[string]any{
@@ -208,17 +212,11 @@ func TestPrintSessionEntry_ToolCallType(t *testing.T) {
 			"input":     "/path/to/file",
 		},
 	}
-	printSessionEntry(2, entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printSessionEntry(2, entry) })
+	assert.Contains(t, output, "read_file")
 }
 
 func TestPrintSessionEntry_ToolResultType(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	entry := map[string]any{
 		"type": "tool_result",
 		"data": map[string]any{
@@ -227,17 +225,11 @@ func TestPrintSessionEntry_ToolResultType(t *testing.T) {
 			"output":    "file written successfully",
 		},
 	}
-	printSessionEntry(3, entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printSessionEntry(3, entry) })
+	assert.Contains(t, output, "write_file")
 }
 
 func TestPrintSessionEntry_ToolResultFailed(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	entry := map[string]any{
 		"type": "tool_result",
 		"data": map[string]any{
@@ -246,27 +238,19 @@ func TestPrintSessionEntry_ToolResultFailed(t *testing.T) {
 			"output":    "permission denied",
 		},
 	}
-	printSessionEntry(4, entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printSessionEntry(4, entry) })
+	assert.Contains(t, output, "write_file")
 }
 
 func TestPrintSessionEntry_UnknownType(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	entry := map[string]any{
 		"type": "custom_event",
 		"data": map[string]any{
 			"key": "value",
 		},
 	}
-	printSessionEntry(5, entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printSessionEntry(5, entry) })
+	assert.NotEmpty(t, output)
 }
 
 func TestPrintSessionEntry_EmptyType(t *testing.T) {
@@ -284,42 +268,26 @@ func TestPrintSessionEntry_EmptyType(t *testing.T) {
 }
 
 func TestPrintMessageEntry_LongContent(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
-	// content > 200 chars triggers truncation
-	longContent := ""
-	for i := 0; i < 250; i++ {
-		longContent += "x"
-	}
+	longContent := strings.Repeat("x", 250)
 	entry := map[string]any{
 		"data": map[string]any{
 			"role":    "assistant",
 			"content": longContent,
 		},
 	}
-	printMessageEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printMessageEntry(entry) })
+	assert.Contains(t, output, "assistant")
 }
 
 func TestPrintMessageEntry_MultilineContent(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	entry := map[string]any{
 		"data": map[string]any{
 			"role":    "user",
 			"content": "line1\nline2\nline3\nline4\nline5\nline6\nline7",
 		},
 	}
-	printMessageEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printMessageEntry(entry) })
+	assert.Contains(t, output, "user")
 }
 
 func TestPrintMessageEntry_NoData(t *testing.T) {
@@ -364,24 +332,15 @@ func TestPrintToolCallEntry_NoData(t *testing.T) {
 }
 
 func TestPrintToolCallEntry_LongInput(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
-	longInput := ""
-	for i := 0; i < 150; i++ {
-		longInput += "y"
-	}
+	longInput := strings.Repeat("y", 150)
 	entry := map[string]any{
 		"data": map[string]any{
 			"tool_name": "bash",
 			"input":     longInput,
 		},
 	}
-	printToolCallEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printToolCallEntry(entry) })
+	assert.Contains(t, output, "bash")
 }
 
 func TestPrintToolResultEntry_NoData(t *testing.T) {
@@ -397,14 +356,7 @@ func TestPrintToolResultEntry_NoData(t *testing.T) {
 }
 
 func TestPrintToolResultEntry_LongOutput(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
-	longOutput := ""
-	for i := 0; i < 150; i++ {
-		longOutput += "z"
-	}
+	longOutput := strings.Repeat("z", 150)
 	entry := map[string]any{
 		"data": map[string]any{
 			"tool_name": "bash",
@@ -412,10 +364,8 @@ func TestPrintToolResultEntry_LongOutput(t *testing.T) {
 			"output":    longOutput,
 		},
 	}
-	printToolResultEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printToolResultEntry(entry) })
+	assert.NotEmpty(t, output)
 }
 
 func TestPrintGenericEntry_NoData(t *testing.T) {
@@ -431,30 +381,17 @@ func TestPrintGenericEntry_NoData(t *testing.T) {
 }
 
 func TestPrintGenericEntry_LongJSON(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
-	longVal := ""
-	for i := 0; i < 200; i++ {
-		longVal += "a"
-	}
+	longVal := strings.Repeat("a", 200)
 	entry := map[string]any{
 		"data": map[string]any{
 			"long_key": longVal,
 		},
 	}
-	printGenericEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printGenericEntry(entry) })
+	assert.NotEmpty(t, output)
 }
 
 func TestShowFormattedSession_MetadataOnly(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	now := time.Now()
 	data := &sessionShowData{
 		Info: session.SessionInfo{
@@ -481,21 +418,16 @@ func TestShowFormattedSession_MetadataOnly(t *testing.T) {
 		},
 	}
 
-	err := showFormattedSession(data, true, 0)
-
-	w.Close()
-	os.Stdout = old
+	var err error
+	output := captureStdout(func() { err = showFormattedSession(data, true, 0) })
 
 	if err != nil {
 		t.Fatalf("showFormattedSession returned error: %v", err)
 	}
+	assert.Contains(t, output, "OxABC")
 }
 
 func TestShowFormattedSession_NoEntries(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	now := time.Now()
 	data := &sessionShowData{
 		Info: session.SessionInfo{
@@ -508,21 +440,16 @@ func TestShowFormattedSession_NoEntries(t *testing.T) {
 		Entries: nil,
 	}
 
-	err := showFormattedSession(data, false, 0)
-
-	w.Close()
-	os.Stdout = old
+	var err error
+	output := captureStdout(func() { err = showFormattedSession(data, false, 0) })
 
 	if err != nil {
 		t.Fatalf("showFormattedSession returned error: %v", err)
 	}
+	assert.Contains(t, output, "test.jsonl")
 }
 
 func TestShowFormattedSession_WithLimit(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	now := time.Now()
 	data := &sessionShowData{
 		Info: session.SessionInfo{
@@ -539,14 +466,13 @@ func TestShowFormattedSession_WithLimit(t *testing.T) {
 		},
 	}
 
-	err := showFormattedSession(data, false, 1)
-
-	w.Close()
-	os.Stdout = old
+	var err error
+	output := captureStdout(func() { err = showFormattedSession(data, false, 1) })
 
 	if err != nil {
 		t.Fatalf("showFormattedSession returned error: %v", err)
 	}
+	assert.NotEmpty(t, output)
 }
 
 func TestViewAsJSON_MetadataOnly(t *testing.T) {
@@ -624,10 +550,6 @@ func TestViewAsJSON_WithEntries(t *testing.T) {
 }
 
 func TestPrintSessionEntry_InvalidTimestamp(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
 	entry := map[string]any{
 		"type":      "message",
 		"timestamp": "not-a-timestamp",
@@ -636,8 +558,6 @@ func TestPrintSessionEntry_InvalidTimestamp(t *testing.T) {
 			"content": "test",
 		},
 	}
-	printSessionEntry(1, entry)
-
-	w.Close()
-	os.Stdout = old
+	output := captureStdout(func() { printSessionEntry(1, entry) })
+	assert.Contains(t, output, "user")
 }

--- a/internal/config/github_sync_test.go
+++ b/internal/config/github_sync_test.go
@@ -46,7 +46,7 @@ func TestNormalizeGitHubSync(t *testing.T) {
 }
 
 func TestResolveGitHubSync_Default(t *testing.T) {
-	t.Parallel()
+	// no t.Parallel(): reads os.Getenv that sibling tests mutate via t.Setenv
 	// no env var, no project config → default enabled
 	got := ResolveGitHubSync("")
 	assert.Equal(t, GitHubSyncEnabled, got)
@@ -71,7 +71,6 @@ func TestResolveGitHubSyncPRs_MasterDisabled(t *testing.T) {
 }
 
 func TestResolveGitHubSyncPRs_Default(t *testing.T) {
-	t.Parallel()
 	got := ResolveGitHubSyncPRs("")
 	assert.Equal(t, GitHubSyncEnabled, got)
 }
@@ -89,7 +88,6 @@ func TestResolveGitHubSyncIssues_MasterDisabled(t *testing.T) {
 }
 
 func TestResolveGitHubSyncIssues_Default(t *testing.T) {
-	t.Parallel()
 	got := ResolveGitHubSyncIssues("")
 	assert.Equal(t, GitHubSyncEnabled, got)
 }
@@ -101,7 +99,6 @@ func TestResolveGitHubSyncIssues_EnvOverride(t *testing.T) {
 }
 
 func TestResolveGitHubSyncPRs_WithTempProject(t *testing.T) {
-	t.Parallel()
 	// temp dir with no config — defaults to enabled
 	dir := t.TempDir()
 	got := ResolveGitHubSyncPRs(dir)
@@ -109,7 +106,6 @@ func TestResolveGitHubSyncPRs_WithTempProject(t *testing.T) {
 }
 
 func TestResolveGitHubSyncIssues_WithTempProject(t *testing.T) {
-	t.Parallel()
 	dir := t.TempDir()
 	got := ResolveGitHubSyncIssues(dir)
 	assert.Equal(t, GitHubSyncEnabled, got)

--- a/internal/daemon/status_display_test.go
+++ b/internal/daemon/status_display_test.go
@@ -85,8 +85,11 @@ func TestShortenPath_StatusDisplay(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := shortenPath(tt.input)
-			// should not panic and should return something
-			_ = got
+			if tt.input == "" {
+				assert.Empty(t, got)
+			} else {
+				assert.NotEmpty(t, got, "non-empty input should produce non-empty output")
+			}
 		})
 	}
 }
@@ -141,21 +144,40 @@ func TestFormatVersionMatch(t *testing.T) {
 func TestDetermineHealth(t *testing.T) {
 	t.Parallel()
 
-	t.Run("healthy status", func(t *testing.T) {
-		got := determineHealth(&StatusData{
-			Running: true,
-		})
-		assert.Equal(t, HealthHealthy, got)
-	})
+	tests := []struct {
+		name   string
+		status *StatusData
+		want   HealthStatus
+	}{
+		{
+			"healthy - no errors",
+			&StatusData{Running: true},
+			HealthHealthy,
+		},
+		{
+			"warning - some errors",
+			&StatusData{Running: true, RecentErrorCount: 4},
+			HealthWarning,
+		},
+		{
+			"critical - error threshold",
+			&StatusData{Running: true, RecentErrorCount: 5},
+			HealthCritical,
+		},
+		{
+			"critical - above threshold",
+			&StatusData{Running: true, RecentErrorCount: 10},
+			HealthCritical,
+		},
+	}
 
-	t.Run("status with errors", func(t *testing.T) {
-		got := determineHealth(&StatusData{
-			Running:          true,
-			RecentErrorCount: 5,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := determineHealth(tt.status)
+			assert.Equal(t, tt.want, got)
 		})
-		// should be warning or critical depending on threshold
-		assert.NotEqual(t, HealthHealthy, got)
-	})
+	}
 }
 
 func TestCountWorkspaces(t *testing.T) {

--- a/internal/session/markdown_coverage_test.go
+++ b/internal/session/markdown_coverage_test.go
@@ -86,18 +86,14 @@ func TestMdFormatFieldValue(t *testing.T) {
 	}{
 		{"empty", "", ""},
 		{"short", "hello", "hello"},
-		{"multiline", "line1\nline2", "line1\\nline2"},
+		{"multiline", "line1\nline2", "line1\nline2"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := mdFormatFieldValue(tt.input)
-			if tt.input == "" {
-				assert.Empty(t, got)
-			} else {
-				assert.NotEmpty(t, got)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -152,7 +148,7 @@ func TestMdShortenPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := mdShortenPath(tt.input)
-			assert.NotEmpty(t, got)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/whisper/store/store_coverage_test.go
+++ b/internal/whisper/store/store_coverage_test.go
@@ -271,7 +271,7 @@ func TestEnforceMaxSize_MissingDB(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	os.Remove(dbPath)
+	require.NoError(t, os.Remove(dbPath))
 	err = s.EnforceMaxSize(1024)
 	assert.NoError(t, err, "should handle missing file gracefully")
 }
@@ -287,8 +287,7 @@ func TestCursorAdvancement_Coverage(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, got, 1)
 
-	time.Sleep(10 * time.Millisecond)
-	require.NoError(t, s.Add(makeEntry("ca-batch2", "topic", ImportanceNormal, time.Now())))
+	require.NoError(t, s.Add(makeEntry("ca-batch2", "topic", ImportanceNormal, now.Add(2*time.Second))))
 
 	got, err = s.GetWhispers("cursor-adv-cov", AttentionAll, nil)
 	require.NoError(t, err)
@@ -311,4 +310,49 @@ func TestNilIfEmpty_Coverage(t *testing.T) {
 	assert.Nil(t, nilIfEmpty(""))
 	assert.NotNil(t, nilIfEmpty("test"))
 	assert.Equal(t, "test", *nilIfEmpty("test"))
+}
+
+func TestOpen_InvalidPath(t *testing.T) {
+	t.Parallel()
+	_, err := Open("/dev/null/impossible/whisper.db")
+	assert.Error(t, err)
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	t.Parallel()
+	s := mustOpen(t)
+	assert.NoError(t, s.Close())
+	assert.NoError(t, s.Close())
+	assert.NoError(t, s.Close())
+}
+
+func TestIsRelayed_NotMarked(t *testing.T) {
+	t.Parallel()
+	s := mustOpen(t)
+
+	relayed, err := s.IsRelayed("nonexistent-murmur", "ledger")
+	require.NoError(t, err)
+	assert.False(t, relayed)
+}
+
+func TestCheckIntegrity_AfterOperations(t *testing.T) {
+	t.Parallel()
+	s := mustOpen(t)
+	now := time.Now()
+
+	require.NoError(t, s.Add(makeEntry("integrity-1", "topic", ImportanceNormal, now)))
+	require.NoError(t, s.MarkRelayed("integrity-1", "ledger"))
+	_, err := s.GetWhispers("integrity-agent", AttentionAll, nil)
+	require.NoError(t, err)
+
+	assert.NoError(t, s.CheckIntegrity())
+}
+
+func TestPrune_EmptyStore(t *testing.T) {
+	t.Parallel()
+	s := mustOpen(t)
+
+	result, err := s.Prune(24 * time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), result.WhispersDeleted)
 }


### PR DESCRIPTION
## Summary

Fixes all 15 CodeRabbit review comments from PR #318 across 8 test files:

- **2 Critical fixes**: Timing drift in `TestFormatTimeAgoShort` (already fixed in prior commit), exact threshold assertions in `TestDetermineHealth` and `TestSemverOnly`
- **13 Major fixes**: Proper output assertions in session show tests, env race removal in github_sync tests, actual `want` value comparisons in markdown tests, deterministic timestamps in whisper store, `t.TempDir()` fixture setup for config tests, indentation wrapping assertions, and new coverage tests

### Key changes

| File | Fix |
|------|-----|
| `status_display_test.go` | Assert exact `HealthStatus` values; validate `shortenPath` output |
| `config_settings_coverage_test.go` | Consolidate repo/team tests; create `.sageox/` fixture for unsupported key test; add value/source assertions |
| `session_show_coverage_test.go` | Extract `captureStdout` helper; assert rendered content in all print tests |
| `github_sync_test.go` | Remove `t.Parallel()` from env-dependent resolver tests |
| `markdown_coverage_test.go` | Use `assert.Equal` against `want` values instead of empty/not-empty checks |
| `store_coverage_test.go` | `require.NoError` on `os.Remove`; deterministic timestamps; 5 new coverage tests |
| `config_tui_coverage_test.go` | Assert all continuation lines preserve indent, not just matching ones |
| `session_helpers_coverage_test.go` | Document limitation of testing extracted logic vs production function |

## Test plan

- [x] `go build ./...` passes
- [x] All 8 changed test files pass individually
- [x] `make test` passes (10816 tests, 1 pre-existing flaky race in `TestRunDoctorChecks_WithFixFlag`)

Co-Authored-By: SageOx <ox@sageox.ai>