### PR TITLE
fix(index): skip unnecessary push in ox index github when nothing synced

### DIFF
--- a/cmd/ox/index.go
+++ b/cmd/ox/index.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -173,6 +172,7 @@ func runIndexGitHub(cmd *cobra.Command, args []string) error {
 	combined := &ledger.SyncResult{}
 
 	if syncPRs {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Fetching PRs from GitHub (%s/%s)...\n", owner, repo)
 		prResult, prErr := ledger.SyncPRs(cmd.Context(), fetcher, ledgerPath, owner, repo, maxDays, logger)
 		if prErr != nil {
 			return fmt.Errorf("sync PRs: %w", prErr)
@@ -183,6 +183,7 @@ func runIndexGitHub(cmd *cobra.Command, args []string) error {
 	}
 
 	if syncIssues {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Fetching issues from GitHub (%s/%s)...\n", owner, repo)
 		issueResult, issueErr := ledger.SyncIssues(cmd.Context(), fetcher, ledgerPath, owner, repo, maxDays, logger)
 		if issueErr != nil {
 			return fmt.Errorf("sync issues: %w", issueErr)
@@ -205,7 +206,13 @@ func runIndexGitHub(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := ledger.CommitAndPushGitHubData(context.Background(), ledgerPath, owner, repo, combined, pushLedger); err != nil {
+	// skip push if nothing was synced (daemon handles catch-up pushes)
+	totalItems := combined.PRTotal + combined.IssueTotal
+	if totalItems == 0 {
+		return nil
+	}
+
+	if err := ledger.CommitAndPushGitHubData(cmd.Context(), ledgerPath, owner, repo, combined, pushLedger); err != nil {
 		return fmt.Errorf("push to ledger: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- **Skip push when nothing synced**: When `ox index github` finds 0 new PRs/issues (daemon already synced), skip the `CommitAndPushGitHubData` call entirely — avoids unnecessary `git add`, `git commit`, LFS repair, credential refresh, and network push
- **Add progress output**: Print "Fetching PRs/issues from GitHub..." before API calls so the command doesn't appear hung during long syncs
- **Use `cmd.Context()` instead of `context.Background()`**: Ctrl+C now properly cancels the push phase

## Root cause

The daemon's `GitHubSyncManager.doSync()` correctly skips the push when 0 items are synced (`github_sync.go:179`), but the CLI's `runIndexGitHub()` always called `CommitAndPushGitHubData` — even with nothing new. This triggered git operations, LFS repair, and network I/O on every invocation regardless of whether there was work to do.

## Test plan

- [x] `go build ./cmd/ox/` — compiles cleanly
- [x] `go vet ./cmd/ox/` — no issues
- [x] `go test ./cmd/ox/ -run Index` — all tests pass
- [x] `go test ./internal/ledger/` — all tests pass
- [x] Manual test: `ox index github` with daemon already synced completes in ~1.5s with progress output, no unnecessary push

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress messages during GitHub synchronization, displaying status when fetching pull requests and issues.

* **Improvements**
  * Optimized sync operations to skip unnecessary push actions when no new data is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->