### PR TITLE
fix(daemon): kill stale daemons to prevent orphan accumulation

### DIFF
--- a/cmd/ox/daemon.go
+++ b/cmd/ox/daemon.go
@@ -47,6 +47,11 @@ var daemonStartCmd = &cobra.Command{
 			return nil
 		}
 
+		// kill any stale daemon for this workspace before starting a new one
+		if err := daemon.KillStaleDaemonForCurrentWorkspace(); err != nil {
+			return fmt.Errorf("failed to stop stale daemon: %w", err)
+		}
+
 		// resolve ledger path (only if it's actually a git repo)
 		ledgerPath, err := ledger.DefaultPath()
 		if err != nil {

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -67,6 +67,12 @@ type Config struct {
 	// Zero disables nudging (used when murmuring config is "manual").
 	MurmurNudgeInterval time.Duration
 
+	// SocketCheckInterval is how often the daemon checks the registry to see if
+	// its PID is still registered. If a different PID is registered, the daemon
+	// assumes it has been superseded and exits gracefully.
+	// Zero disables the check.
+	SocketCheckInterval time.Duration
+
 	// AutoStart starts daemon on first ox command if true.
 	AutoStart bool
 
@@ -89,6 +95,7 @@ func DefaultConfig() *Config {
 		GitHubSyncInterval:      15 * time.Minute, // sync PRs/issues every 15 minutes
 		MurmurNudgeInterval:     15 * time.Minute, // nudge agents to self-report every 15 minutes
 		InactivityTimeout:       1 * time.Hour,    // exit after 1 hour of inactivity
+		SocketCheckInterval:     30 * time.Second, // detect socket takeover by new daemon
 		AutoStart:               true,
 		LedgerPath:              "", // resolved at runtime
 		ProjectRoot:             "", // resolved at runtime

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -164,7 +164,8 @@ type Daemon struct {
 	// state
 	mu               sync.Mutex
 	running          bool
-	restartRequested bool      // set when version mismatch triggers restart
+	restartRequested bool // set when version mismatch triggers restart
+	wasSuperseded    bool // set when exiting because another daemon took over
 	startTime        time.Time // daemon start time for uptime tracking
 	lastActivity     time.Time // tracks last activity for inactivity timeout
 
@@ -307,6 +308,16 @@ func (d *Daemon) Start() error {
 		d.logger.Info("inactivity timeout enabled", "timeout", d.config.InactivityTimeout, "check_interval", checkInterval)
 	}
 
+	// socket self-check ticker: detect when another daemon has taken over our socket
+	var socketCheckTicker *time.Ticker
+	var socketCheckChan <-chan time.Time
+	if d.config.SocketCheckInterval > 0 {
+		socketCheckTicker = time.NewTicker(d.config.SocketCheckInterval)
+		socketCheckChan = socketCheckTicker.C
+		defer socketCheckTicker.Stop()
+		d.logger.Info("socket self-check enabled", "interval", d.config.SocketCheckInterval)
+	}
+
 	for {
 		select {
 		case sig := <-sigChan:
@@ -315,6 +326,12 @@ func (d *Daemon) Start() error {
 		case <-d.ctx.Done():
 			d.logger.Info("context canceled")
 			return d.shutdown()
+		case <-socketCheckChan:
+			if superseded() {
+				d.logger.Info("registry PID changed, shutting down (superseded by new daemon)")
+				d.wasSuperseded = true
+				return d.shutdown()
+			}
 		case <-inactivityChan:
 			// check if ledger path still exists (handles directory renames/moves)
 			if d.config.LedgerPath != "" {
@@ -537,14 +554,33 @@ func (d *Daemon) writePidFile() error {
 }
 
 // cleanup removes PID and socket files.
+// When the daemon was superseded by a new instance, skip removing the socket
+// and registry entry — those now belong to the replacement daemon.
 func (d *Daemon) cleanup() {
-	// unregister from daemon registry
-	if err := UnregisterDaemon(); err != nil {
-		d.logger.Warn("failed to unregister daemon", "error", err)
+	if !d.wasSuperseded {
+		if err := UnregisterDaemon(); err != nil {
+			d.logger.Warn("failed to unregister daemon", "error", err)
+		}
+		os.Remove(SocketPath())
+		os.Remove(PidPath())
 	}
+}
 
-	os.Remove(PidPath())
-	os.Remove(SocketPath())
+// superseded returns true if another daemon has taken over this workspace.
+// Checks the registry to see if a different PID is now registered for our workspace ID.
+// This handles the case where a new daemon replaces the socket file (same path, different process).
+func superseded() bool {
+	reg, err := LoadRegistry()
+	if err != nil {
+		return false // can't tell, assume not superseded
+	}
+	info := reg.FindByWorkspaceID(CurrentWorkspaceID())
+	if info == nil {
+		// Entry missing — could be a race in registry writes or a cleared file.
+		// Only evict when the registry positively names a different PID.
+		return false
+	}
+	return info.PID != os.Getpid()
 }
 
 // IsRunning checks if a daemon is currently running and responsive.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -136,6 +136,10 @@ func TestDefaultConfig_NewFields(t *testing.T) {
 	t.Run("team context sync interval is set", func(t *testing.T) {
 		assert.Equal(t, 15*time.Second, cfg.TeamContextSyncInterval)
 	})
+
+	t.Run("socket check interval is set", func(t *testing.T) {
+		assert.Equal(t, 30*time.Second, cfg.SocketCheckInterval)
+	})
 }
 
 // TestDaemon_Stop_SetsRunningFalseBeforeCancel verifies that Stop() sets

--- a/internal/daemon/eviction_test.go
+++ b/internal/daemon/eviction_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestRegistry writes a registry file with the given entries into the XDG runtime dir.
+func writeTestRegistry(t *testing.T, tmpDir string, entries map[string]DaemonInfo) {
+	t.Helper()
+	reg := &Registry{Daemons: entries}
+	data, err := json.MarshalIndent(reg, "", "  ")
+	require.NoError(t, err)
+	regDir := filepath.Join(tmpDir, "sageox", "daemon")
+	require.NoError(t, os.MkdirAll(regDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(regDir, "registry.json"), data, 0600))
+}
+
+func TestSuperseded_NotSuperseded_WhenOurPIDRegistered(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	wsID := CurrentWorkspaceID()
+	writeTestRegistry(t, tmpDir, map[string]DaemonInfo{
+		wsID: {WorkspaceID: wsID, PID: os.Getpid()},
+	})
+
+	assert.False(t, superseded(), "should not be superseded when our PID is registered")
+}
+
+func TestSuperseded_Superseded_WhenDifferentPIDRegistered(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	wsID := CurrentWorkspaceID()
+	writeTestRegistry(t, tmpDir, map[string]DaemonInfo{
+		wsID: {WorkspaceID: wsID, PID: os.Getpid() + 99999},
+	})
+
+	assert.True(t, superseded(), "should be superseded when different PID is registered")
+}
+
+func TestSuperseded_NotSuperseded_WhenEntryMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	// empty registry — entry missing could be a race, don't evict
+	writeTestRegistry(t, tmpDir, map[string]DaemonInfo{})
+
+	assert.False(t, superseded(), "should not evict on missing entry (could be registry race)")
+}
+
+func TestSuperseded_NotSuperseded_WhenRegistryMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	// no registry file at all — can't determine, assume not superseded
+	assert.False(t, superseded(), "should not evict when registry is missing")
+}

--- a/internal/daemon/fallback.go
+++ b/internal/daemon/fallback.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/sageox/ox/internal/repotools"
 )
 
 // TryConnectOrDirect attempts to connect to the daemon.
@@ -139,6 +141,27 @@ func ensureDaemonInternal() error {
 		return nil // already running on new (repo-based) socket
 	}
 
+	// A daemon may be alive but not yet listening on its socket (startup/throttle).
+	// Wait for it rather than killing it.
+	if IsStarting() {
+		for i := 0; i < 20; i++ {
+			time.Sleep(100 * time.Millisecond)
+			if IsRunning() {
+				return nil
+			}
+			if !IsStarting() {
+				break
+			}
+		}
+	}
+
+	// Kill any stale daemon for this workspace before starting a new one.
+	// Since IsRunning() returned false and IsStarting() is also false, the old
+	// daemon is unresponsive. IPC stop will likely fail; SIGTERM is the fallback.
+	if err := killStaleDaemon(CurrentWorkspaceID()); err != nil {
+		return fmt.Errorf("failed to stop stale daemon: %w", err)
+	}
+
 	// migration: stop old path-based daemon if one exists on a legacy socket
 	stopLegacyDaemon()
 
@@ -163,7 +186,7 @@ func ensureDaemonInternal() error {
 	// start daemon process
 	// NOTE: No setsid/detach — Claude manages the daemon process lifecycle.
 	// The daemon relies on inactivity timeout to self-exit when claude dies.
-	cmd := exec.Command(exe, "daemon", "start", "--foreground")
+	cmd := exec.Command(exe, buildDaemonArgs(resolveRepoName())...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 
@@ -184,6 +207,110 @@ func ensureDaemonInternal() error {
 	}
 
 	return fmt.Errorf("daemon started but not responding")
+}
+
+// killStaleDaemon kills any existing daemon for the given workspace before starting a new one.
+// Escalation: IPC stop (graceful) → SIGTERM (forceful) → error.
+// Returns nil if the stale daemon was successfully stopped or none existed.
+// Returns an error if the stale daemon could not be stopped (caller should not start a new one).
+func killStaleDaemon(workspaceID string) error {
+	reg, err := LoadRegistry()
+	if err != nil {
+		slog.Debug("failed to load registry for stale daemon check", "error", err)
+		return nil
+	}
+
+	info := reg.FindByWorkspaceID(workspaceID)
+	if info == nil {
+		return nil // no existing entry
+	}
+
+	// check if process is alive (signal 0)
+	if err := signalProcess(info.PID, 0); err != nil {
+		// process is dead — clean up stale registry entry and files
+		slog.Debug("stale daemon entry (process dead), cleaning up", "workspace_id", workspaceID, "pid", info.PID)
+		_ = reg.Unregister(workspaceID)
+		_ = os.Remove(PidPathForWorkspace(workspaceID))
+		_ = os.Remove(info.SocketPath)
+		return nil
+	}
+
+	// process is alive — try graceful IPC stop first (2s timeout for busy daemons)
+	client := &Client{socketPath: info.SocketPath, timeout: 2 * time.Second}
+	if err := client.Ping(); err == nil {
+		slog.Info("stopping existing daemon via IPC", "workspace_id", workspaceID, "pid", info.PID)
+		if err := client.Stop(); err != nil {
+			slog.Warn("IPC stop failed, falling back to SIGTERM", "workspace_id", workspaceID, "pid", info.PID, "error", err)
+		}
+		if waitForProcessExit(info.PID, 5*time.Second) {
+			_ = reg.Unregister(workspaceID)
+			_ = os.Remove(PidPathForWorkspace(workspaceID))
+			_ = os.Remove(info.SocketPath)
+			return nil
+		}
+		slog.Warn("daemon did not exit after IPC stop, escalating to SIGTERM", "workspace_id", workspaceID, "pid", info.PID)
+	}
+
+	// IPC unreachable or stop didn't work — verify this is actually an ox daemon
+	// before sending SIGTERM (guards against PID reuse by an unrelated process)
+	if !isOxDaemonProcess(info.PID) {
+		slog.Info("PID is not an ox daemon, cleaning up stale entry", "workspace_id", workspaceID, "pid", info.PID)
+		_ = reg.Unregister(workspaceID)
+		_ = os.Remove(PidPathForWorkspace(workspaceID))
+		_ = os.Remove(info.SocketPath)
+		return nil
+	}
+
+	slog.Info("sending SIGTERM to stale daemon", "workspace_id", workspaceID, "pid", info.PID)
+	if err := signalProcess(info.PID, sigTERM); err != nil {
+		slog.Warn("failed to SIGTERM stale daemon", "workspace_id", workspaceID, "pid", info.PID, "error", err)
+	}
+
+	if waitForProcessExit(info.PID, 2*time.Second) {
+		_ = reg.Unregister(workspaceID)
+		_ = os.Remove(PidPathForWorkspace(workspaceID))
+		_ = os.Remove(info.SocketPath)
+		return nil
+	}
+	return fmt.Errorf("stale daemon %d did not exit after SIGTERM", info.PID)
+}
+
+// waitForProcessExit polls signal 0 until the process exits or timeout is reached.
+// Returns true if the process exited, false if it's still alive at timeout.
+func waitForProcessExit(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := signalProcess(pid, 0); err != nil {
+			return true // process exited
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+// KillStaleDaemonForCurrentWorkspace is the public entry point for pre-start kill.
+// Called by `ox daemon start` CLI command.
+func KillStaleDaemonForCurrentWorkspace() error {
+	return killStaleDaemon(CurrentWorkspaceID())
+}
+
+// buildDaemonArgs constructs command-line arguments for starting a daemon subprocess.
+// Includes --repo flag for ps identification when repoName is non-empty.
+func buildDaemonArgs(repoName string) []string {
+	args := []string{"daemon", "start", "--foreground"}
+	if repoName != "" {
+		args = append(args, "--repo="+repoName)
+	}
+	return args
+}
+
+// resolveRepoName returns the human-readable repo name (e.g., "owner/repo") for the CWD.
+func resolveRepoName() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return repotools.GetRepoName(cwd)
 }
 
 // stopLegacyDaemon stops a daemon running under the old path-based workspace ID.

--- a/internal/daemon/fallback_unix.go
+++ b/internal/daemon/fallback_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// sigTERM is the signal to send for graceful termination.
+const sigTERM = syscall.SIGTERM
+
+// signalProcess sends a signal to the given PID.
+// Used by killStaleDaemon to check liveness (signal 0) and terminate (SIGTERM).
+func signalProcess(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
+}
+
+// isOxDaemonProcess checks if the given PID is an ox daemon process by reading
+// /proc/<pid>/cmdline. Returns false if the process cannot be identified as an
+// ox daemon (e.g., PID was reused by an unrelated process).
+func isOxDaemonProcess(pid int) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return false // can't read cmdline (process gone, or not Linux)
+	}
+	// cmdline is NUL-separated; join for simple substring match
+	cmdline := strings.ReplaceAll(string(data), "\x00", " ")
+	return strings.Contains(cmdline, "ox") && strings.Contains(cmdline, "daemon")
+}

--- a/internal/daemon/fallback_unix_test.go
+++ b/internal/daemon/fallback_unix_test.go
@@ -1,0 +1,300 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- killStaleDaemon tests ---
+
+// setupIsolatedRegistry creates an isolated XDG environment and writes a registry
+// with the given entries. Returns the tmp dir.
+func setupIsolatedRegistry(t *testing.T, entries map[string]DaemonInfo) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	reg := &Registry{Daemons: entries}
+	data, err := json.MarshalIndent(reg, "", "  ")
+	require.NoError(t, err)
+
+	regDir := filepath.Join(tmpDir, "sageox", "daemon")
+	require.NoError(t, os.MkdirAll(regDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(regDir, "registry.json"), data, 0600))
+
+	return tmpDir
+}
+
+func TestKillStaleDaemon_NoRegistryEntry(t *testing.T) {
+	setupIsolatedRegistry(t, map[string]DaemonInfo{})
+
+	// should be a no-op, no panics
+	killStaleDaemon("nonexistent")
+}
+
+func TestKillStaleDaemon_DeadProcess(t *testing.T) {
+	wsID := "deadbeef"
+	tmpDir := setupIsolatedRegistry(t, map[string]DaemonInfo{
+		wsID: {
+			WorkspaceID: wsID,
+			PID:         999999999, // very unlikely to be alive
+			SocketPath:  "/tmp/nonexistent.sock",
+		},
+	})
+
+	// create stale PID file so cleanup behavior is actually exercised
+	pidPath := filepath.Join(tmpDir, "sageox", "daemon", "daemon-"+wsID+".pid")
+	require.NoError(t, os.WriteFile(pidPath, []byte("999999999\n"), 0600))
+
+	killStaleDaemon(wsID)
+
+	// registry entry should be cleaned up
+	reg, err := LoadRegistry()
+	require.NoError(t, err)
+	assert.Nil(t, reg.FindByWorkspaceID(wsID), "dead entry should be removed from registry")
+
+	// stale PID file should be cleaned up
+	_, err = os.Stat(pidPath)
+	assert.True(t, os.IsNotExist(err), "stale PID file should be removed")
+}
+
+func TestKillStaleDaemon_AliveButReachable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping daemon IPC test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	// start a child process to act as the "stale daemon"
+	child := exec.Command("sleep", "300")
+	require.NoError(t, child.Start())
+	childPID := child.Process.Pid
+	childDone := make(chan struct{})
+	go func() {
+		_ = child.Wait()
+		close(childDone)
+	}()
+
+	wsID := "reachable"
+	socketPath := filepath.Join(tmpDir, "sageox", "daemon", "daemon-"+wsID+".sock")
+	require.NoError(t, os.MkdirAll(filepath.Dir(socketPath), 0700))
+
+	// create a mock socket that responds to ping and stop, then kills the child
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	stopCalled := make(chan struct{}, 1)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 4096)
+			n, _ := conn.Read(buf)
+			var msg Message
+			if json.Unmarshal(buf[:n], &msg) == nil {
+				switch msg.Type {
+				case MsgTypePing:
+					resp := Response{Success: true, Data: json.RawMessage(`"pong"`)}
+					data, _ := json.Marshal(resp)
+					conn.Write(append(data, '\n'))
+				case MsgTypeStop:
+					resp := Response{Success: true}
+					data, _ := json.Marshal(resp)
+					conn.Write(append(data, '\n'))
+					// simulate graceful shutdown: kill the child process
+					_ = child.Process.Kill()
+					stopCalled <- struct{}{}
+				}
+			}
+			conn.Close()
+		}
+	}()
+	defer listener.Close()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		<-childDone
+	})
+
+	// write registry entry with the child's PID
+	reg := &Registry{Daemons: map[string]DaemonInfo{
+		wsID: {
+			WorkspaceID: wsID,
+			PID:         childPID,
+			SocketPath:  socketPath,
+		},
+	}}
+	data, _ := json.MarshalIndent(reg, "", "  ")
+	regPath := filepath.Join(tmpDir, "sageox", "daemon", "registry.json")
+	require.NoError(t, os.WriteFile(regPath, data, 0600))
+
+	killStaleDaemon(wsID)
+
+	// IPC stop should have been called (graceful path)
+	select {
+	case <-stopCalled:
+		// good — graceful stop was used
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected IPC stop to be called")
+	}
+}
+
+func TestKillStaleDaemon_StopAckedPidAlive(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux /proc cmdline check")
+	}
+	if testing.Short() {
+		t.Skip("skipping daemon IPC escalation test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	// start a child process whose cmdline contains "ox" and "daemon"
+	child := exec.Command("bash", "-c", "exec -a 'ox daemon start --foreground' sleep 300")
+	require.NoError(t, child.Start())
+	childPID := child.Process.Pid
+	childDone := make(chan struct{})
+	go func() {
+		_ = child.Wait()
+		close(childDone)
+	}()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		<-childDone
+	})
+
+	wsID := "stop-acked"
+	socketPath := filepath.Join(tmpDir, "sageox", "daemon", "daemon-"+wsID+".sock")
+	require.NoError(t, os.MkdirAll(filepath.Dir(socketPath), 0700))
+
+	// mock daemon ACKs Stop but does NOT kill the child — simulates a hung daemon
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 4096)
+			n, _ := conn.Read(buf)
+			var msg Message
+			if json.Unmarshal(buf[:n], &msg) == nil {
+				switch msg.Type {
+				case MsgTypePing:
+					resp := Response{Success: true, Data: json.RawMessage(`"pong"`)}
+					data, _ := json.Marshal(resp)
+					conn.Write(append(data, '\n'))
+				case MsgTypeStop:
+					// ACK stop but DON'T kill the process
+					resp := Response{Success: true}
+					data, _ := json.Marshal(resp)
+					conn.Write(append(data, '\n'))
+				}
+			}
+			conn.Close()
+		}
+	}()
+	defer listener.Close()
+
+	reg := &Registry{Daemons: map[string]DaemonInfo{
+		wsID: {WorkspaceID: wsID, PID: childPID, SocketPath: socketPath},
+	}}
+	data, _ := json.MarshalIndent(reg, "", "  ")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, "sageox", "daemon", "registry.json"), data, 0600))
+
+	err = killStaleDaemon(wsID)
+	require.NoError(t, err, "should succeed via SIGTERM escalation")
+
+	// child should be dead — SIGTERM escalation should have killed it
+	select {
+	case <-childDone:
+		// child was reaped — escalation to SIGTERM worked
+	case <-time.After(3 * time.Second):
+		t.Fatal("child process did not exit after IPC→SIGTERM escalation")
+	}
+}
+
+func TestKillStaleDaemon_AliveButUnreachable(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("requires Linux /proc cmdline check")
+	}
+	if testing.Short() {
+		t.Skip("skipping process kill test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	// start a child process whose cmdline contains "ox" and "daemon"
+	// so isOxDaemonProcess returns true
+	child := exec.Command("bash", "-c", "exec -a 'ox daemon start --foreground' sleep 300")
+	require.NoError(t, child.Start())
+	childPID := child.Process.Pid
+	// reap child in background so it doesn't become zombie after SIGTERM
+	childDone := make(chan struct{})
+	go func() {
+		_ = child.Wait()
+		close(childDone)
+	}()
+	t.Cleanup(func() {
+		_ = child.Process.Kill()
+		<-childDone
+	})
+
+	// verify child is alive
+	require.NoError(t, signalProcess(childPID, 0), "child should be alive")
+
+	wsID := "unreachable"
+	// no socket file — daemon is unreachable via IPC
+	regDir := filepath.Join(tmpDir, "sageox", "daemon")
+	require.NoError(t, os.MkdirAll(regDir, 0700))
+	reg := &Registry{Daemons: map[string]DaemonInfo{
+		wsID: {
+			WorkspaceID: wsID,
+			PID:         childPID,
+			SocketPath:  filepath.Join(regDir, "daemon-"+wsID+".sock"), // doesn't exist
+		},
+	}}
+	data, _ := json.MarshalIndent(reg, "", "  ")
+	require.NoError(t, os.WriteFile(filepath.Join(regDir, "registry.json"), data, 0600))
+
+	killStaleDaemon(wsID)
+
+	// child should exit after SIGTERM — wait for reaper goroutine
+	select {
+	case <-childDone:
+		// child was reaped — SIGTERM worked
+	case <-time.After(3 * time.Second):
+		t.Fatal("child process did not exit after SIGTERM")
+	}
+}
+
+// --- buildDaemonArgs tests ---
+
+func TestBuildDaemonArgs_WithRepo(t *testing.T) {
+	args := buildDaemonArgs("sageox/ox")
+	assert.Equal(t, []string{"daemon", "start", "--foreground", "--repo=sageox/ox"}, args)
+}
+
+func TestBuildDaemonArgs_WithoutRepo(t *testing.T) {
+	args := buildDaemonArgs("")
+	assert.Equal(t, []string{"daemon", "start", "--foreground"}, args)
+	for _, arg := range args {
+		assert.NotContains(t, arg, "--repo")
+	}
+}

--- a/internal/daemon/fallback_windows.go
+++ b/internal/daemon/fallback_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// sigTERM is the signal to send for graceful termination.
+// Windows doesn't have SIGTERM; we use 0xF (15) as a placeholder since
+// signalProcess on Windows ignores the signal value and calls proc.Kill().
+const sigTERM = syscall.Signal(0xF)
+
+// isOxDaemonProcess checks if the given PID is an ox daemon process.
+// On Windows, /proc is not available; we optimistically assume it is.
+// TODO: use Windows API (CreateToolhelp32Snapshot) for process identity checks.
+func isOxDaemonProcess(pid int) bool {
+	return true
+}
+
+// signalProcess sends a signal to the given PID.
+// On Windows, only signal 0 (liveness check) and termination are supported.
+//
+// TODO: os.FindProcess always succeeds on Windows even for non-existent PIDs,
+// and proc.Signal(0) is unreliable for liveness checks. Consider using the
+// Windows OpenProcess API for accurate liveness detection.
+func signalProcess(pid int, sig syscall.Signal) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	if sig == 0 {
+		// os.FindProcess succeeds if process exists; Signal(0) is unsupported
+		// on Windows (returns EWINDOWS). FindProcess success = alive.
+		return nil
+	}
+	// Windows doesn't support SIGTERM; kill the process directly.
+	if err := proc.Kill(); err != nil {
+		return fmt.Errorf("kill process %d: %w", pid, err)
+	}
+	return nil
+}

--- a/internal/daemon/ipc_test.go
+++ b/internal/daemon/ipc_test.go
@@ -991,9 +991,12 @@ func TestServerClient_TeamSyncWithProgress_Integration(t *testing.T) {
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
-	go server.Start(ctx)
+	serverDone := make(chan struct{})
+	go func() {
+		server.Start(ctx)
+		close(serverDone)
+	}()
 	time.Sleep(100 * time.Millisecond)
 
 	client := &Client{
@@ -1018,6 +1021,7 @@ func TestServerClient_TeamSyncWithProgress_Integration(t *testing.T) {
 	assert.Equal(t, "complete", progressUpdates[5])
 
 	cancel()
+	<-serverDone // wait for server to fully shut down and clean up socket
 }
 
 // TestServer_GracefulShutdown_WaitsForInflightConnections tests that the server
@@ -1152,9 +1156,12 @@ func TestServerClient_TeamSyncWithProgress_NoHandler(t *testing.T) {
 	// deliberately not setting team sync handler
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
-	go server.Start(ctx)
+	serverDone := make(chan struct{})
+	go func() {
+		server.Start(ctx)
+		close(serverDone)
+	}()
 	time.Sleep(100 * time.Millisecond)
 
 	client := &Client{
@@ -1167,6 +1174,7 @@ func TestServerClient_TeamSyncWithProgress_NoHandler(t *testing.T) {
 	assert.Contains(t, err.Error(), "team sync handler not set")
 
 	cancel()
+	<-serverDone // wait for server to fully shut down and clean up socket
 }
 
 // --- Regression tests: IPC status must remain responsive during long-running operations ---

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -201,6 +201,22 @@ func FindDaemonForRepo(repoID string) *DaemonInfo {
 	return reg.FindByRepoID(repoID)
 }
 
+// FindByWorkspaceID returns the daemon entry for the given workspace ID,
+// or nil if no match is found. Empty workspaceID always returns nil.
+func (r *Registry) FindByWorkspaceID(workspaceID string) *DaemonInfo {
+	if workspaceID == "" {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if info, ok := r.Daemons[workspaceID]; ok {
+		return &info
+	}
+	return nil
+}
+
 // FindByRepoID returns the first daemon entry matching the given repo_id,
 // or nil if no match is found. Empty repoID always returns nil.
 func (r *Registry) FindByRepoID(repoID string) *DaemonInfo {

--- a/internal/daemon/registry_test.go
+++ b/internal/daemon/registry_test.go
@@ -175,6 +175,35 @@ func TestRegistry_Register_WithRepoID(t *testing.T) {
 	assert.Equal(t, "repo_test", stored.RepoID)
 }
 
+func TestRegistry_FindByWorkspaceID(t *testing.T) {
+	reg := &Registry{Daemons: map[string]DaemonInfo{
+		"aaaa1111": {WorkspaceID: "aaaa1111", PID: 100},
+		"bbbb2222": {WorkspaceID: "bbbb2222", PID: 200},
+	}}
+
+	t.Run("found", func(t *testing.T) {
+		info := reg.FindByWorkspaceID("aaaa1111")
+		require.NotNil(t, info)
+		assert.Equal(t, 100, info.PID)
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		info := reg.FindByWorkspaceID("cccc3333")
+		assert.Nil(t, info)
+	})
+
+	t.Run("empty_id", func(t *testing.T) {
+		info := reg.FindByWorkspaceID("")
+		assert.Nil(t, info)
+	})
+}
+
+func TestRegistry_FindByWorkspaceID_EmptyRegistry(t *testing.T) {
+	reg := &Registry{Daemons: make(map[string]DaemonInfo)}
+	info := reg.FindByWorkspaceID("aaaa1111")
+	assert.Nil(t, info)
+}
+
 func TestDaemonInfo_RepoID_OmittedWhenEmpty(t *testing.T) {
 	// when RepoID is empty, it should be omitted from JSON (if tagged with omitempty)
 	// or present as empty string. Either is acceptable for backwards compat.

--- a/internal/daemon/testutil/dualmode.go
+++ b/internal/daemon/testutil/dualmode.go
@@ -119,6 +119,7 @@ func StartTestDaemon(t *testing.T, tmpDir string) (cleanup func()) {
 	cfg.ProjectRoot = tmpDir
 	cfg.SyncIntervalRead = 1 * time.Hour // don't auto-sync during tests
 	cfg.InactivityTimeout = 0            // disable inactivity timeout for tests
+	cfg.SocketCheckInterval = 0          // disable socket self-check for tests
 
 	// create ledger directory
 	if err := os.MkdirAll(cfg.LedgerPath, 0755); err != nil {
@@ -196,6 +197,7 @@ func TestDaemonConfig(tmpDir string) *daemon.Config {
 	cfg.ProjectRoot = tmpDir
 	cfg.SyncIntervalRead = 1 * time.Hour
 	cfg.InactivityTimeout = 0
+	cfg.SocketCheckInterval = 0
 	return cfg
 }
 


### PR DESCRIPTION
## Summary

- **Pre-start kill**: Before spawning a new daemon, look up the registry for the workspace's existing PID and kill it via IPC stop → SIGTERM escalation. This is the primary fix that prevents orphans from accumulating.
- **Self-eviction**: The daemon periodically checks the registry to verify its PID is still registered. If another daemon has taken over (different PID registered), it shuts down gracefully. Defense in depth for crashes, SIGKILL, etc.
- **`--repo` flag for `ensureDaemonInternal`**: Daemons started via the hot path (`ox agent prime`, `ox doctor`, `ox index`) now include `--repo=owner/repo` in their process args, making them identifiable in `ps`.

## Root Cause

When `ensureDaemonInternal()` found the socket unresponsive (daemon busy, socket deleted), it started a new daemon without killing the old process. The new daemon's `listen()` deleted the old socket and created a new one, orphaning the old process. Orphaned daemons with file watchers on active ledger directories kept getting activity resets, preventing the 1-hour inactivity timeout from ever firing — allowing orphans to survive indefinitely.

```mermaid
sequenceDiagram
    participant CLI as CLI (ensureDaemonInternal)
    participant Old as Old Daemon
    participant New as New Daemon
    participant Reg as Registry

    CLI->>Old: Ping socket (500ms timeout)
    Old--xCLI: No response (busy/gone)
    
    Note over CLI: Before (bug): starts new daemon without killing old
    Note over CLI: After (fix): killStaleDaemon() first
    
    CLI->>Reg: Lookup workspace PID
    Reg-->>CLI: PID exists, alive
    CLI->>Old: IPC Stop (2s timeout)
    alt IPC succeeds
        Old->>Old: Graceful shutdown
    else IPC fails
        CLI->>Old: SIGTERM
    end
    CLI->>New: Start new daemon
    New->>Reg: Register with new PID
```

## Test Plan

- [x] `TestKillStaleDaemon_NoRegistryEntry` — no-op when no entry exists
- [x] `TestKillStaleDaemon_DeadProcess` — cleans up registry when PID is dead
- [x] `TestKillStaleDaemon_AliveButReachable` — graceful IPC stop path
- [x] `TestKillStaleDaemon_AliveButUnreachable` — SIGTERM fallback (real child process)
- [x] `TestSuperseded_*` — 4 cases covering PID match, mismatch, entry removed, registry missing
- [x] `TestBuildDaemonArgs_*` — `--repo` flag included/omitted correctly
- [x] `TestRegistry_FindByWorkspaceID` — found, not found, empty registry
- [x] `TestDefaultConfig_NewFields` — `SocketCheckInterval` default is 30s
- [x] All tests pass with `-race` flag
- [x] `make test` — 11,143 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable daemon socket self-check interval (default 30s).
  * Daemon will exit if its registry entry is taken over by another instance.
  * Startup now detects and cleans up stale workspace daemon processes before launching; start command pre-checks for stale daemons.

* **Tests**
  * Added extensive tests covering stale-instance detection/eviction, IPC stop flows, argument construction, registry lookup, and clean server shutdown.
  * Tests disable socket self-checks in test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->