### PR TITLE
feat(distill): per-stage guidance files with progressive disclosure

### DIFF
--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -318,9 +318,10 @@ func readWeeklyFilesForMonth(weeklyDir string, year, month int) ([]string, []str
 }
 
 var (
-	distillLayer  string
-	distillDryRun bool
-	distillSync   bool
+	distillLayer   string
+	distillDryRun  bool
+	distillSync    bool
+	distillVerbose bool
 )
 
 var distillCmd = &cobra.Command{
@@ -343,6 +344,7 @@ func init() {
 	distillCmd.Flags().StringVar(&distillLayer, "layer", "", "distill only a specific layer (daily, weekly, monthly)")
 	distillCmd.Flags().BoolVar(&distillDryRun, "dry-run", false, "show what would be distilled without invoking the AI coworker")
 	distillCmd.Flags().BoolVar(&distillSync, "sync", false, "sync ledger, team context, and code index before distilling")
+	distillCmd.Flags().BoolVar(&distillVerbose, "verbose", false, "log full prompts to stderr")
 
 	rootCmd.AddCommand(distillCmd)
 }
@@ -410,8 +412,7 @@ func (s *distillStateV2) lastMonthlyTime() time.Time {
 
 // logPrompt logs the full prompt to stderr when --verbose is set.
 func logPrompt(cmd *cobra.Command, label, prompt string) {
-	verbose, _ := cmd.Flags().GetBool("verbose")
-	if !verbose {
+	if !distillVerbose {
 		return
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "--- prompt (%s) ---\n%s--- end prompt ---\n", label, prompt)
@@ -520,8 +521,21 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 		slog.Warn("failed to seed MEMORY.md", "error", err)
 	}
 
-	// load team distillation guidelines (DISTILL.md) — optional
-	guidelines := loadDistillGuidelines(tc.Path)
+	// migrate old DISTILL.md to memory/guidance/ if needed
+	if migrated, err := migrateDistillGuidelines(tc.Path); err != nil {
+		slog.Warn("failed to migrate DISTILL.md", "error", err)
+	} else if migrated {
+		slog.Info("migrated DISTILL.md to memory/guidance/")
+	}
+
+	// seed default guidance files if they don't exist
+	if err := seedGuidanceFiles(tc.Path); err != nil {
+		slog.Warn("failed to seed guidance files", "error", err)
+	}
+
+	// load guidance once — snapshot at run start, not re-read per stage
+	extractGuidelines := loadGuidance(tc.Path, "EXTRACT.md")
+	distillGuidelines := loadGuidance(tc.Path, "DISTILL.md")
 
 	now := time.Now().UTC()
 
@@ -535,7 +549,7 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 
 	// extract facts from unprocessed discussions before daily distill
 	if plan.Daily {
-		if err := extractDiscussionFacts(ctx, cmd, backend, tc, state, guidelines); err != nil {
+		if err := extractDiscussionFacts(ctx, cmd, backend, tc, state, extractGuidelines); err != nil {
 			slog.Warn("discussion fact extraction failed", "error", err)
 		} else if !distillDryRun {
 			if err := saveDistillStateV2(projectRoot, state); err != nil {
@@ -546,7 +560,7 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 
 	// extract facts from GitHub activity before daily distill
 	if plan.Daily {
-		if err := extractGitHubFacts(ctx, cmd, backend, tc, state, projectRoot); err != nil {
+		if err := extractGitHubFacts(ctx, cmd, backend, tc, state, projectRoot, extractGuidelines); err != nil {
 			slog.Warn("github fact extraction failed", "error", err)
 		} else if !distillDryRun {
 			if err := saveDistillStateV2(projectRoot, state); err != nil {
@@ -567,19 +581,19 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 	}
 
 	if plan.Daily {
-		if err := distillDaily(ctx, cmd, backend, tc, state, projectRoot, now, guidelines); err != nil {
+		if err := distillDaily(ctx, cmd, backend, tc, state, projectRoot, now, distillGuidelines); err != nil {
 			return fmt.Errorf("daily distill: %w", err)
 		}
 	}
 
 	for _, week := range plan.Weeks {
-		if err := distillWeekly(ctx, cmd, backend, tc, state, week, guidelines); err != nil {
+		if err := distillWeekly(ctx, cmd, backend, tc, state, week, distillGuidelines); err != nil {
 			return fmt.Errorf("weekly distill (%d-W%02d): %w", week.Year, week.Week, err)
 		}
 	}
 
 	for _, month := range plan.Months {
-		if err := distillMonthly(ctx, cmd, backend, tc, state, month, guidelines); err != nil {
+		if err := distillMonthly(ctx, cmd, backend, tc, state, month, distillGuidelines); err != nil {
 			return fmt.Errorf("monthly distill (%s): %w", month, err)
 		}
 	}

--- a/cmd/ox/distill_github.go
+++ b/cmd/ox/distill_github.go
@@ -94,7 +94,7 @@ If you are uncertain whether something is meaningful, include it with a note in 
 
 // extractGitHubFacts queries CodeDB for GitHub activity, partitions by day,
 // calls the LLM extractor per day, and writes facts to memory/.github-facts/{date}-{uuid7}.jsonl.
-func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, state *distillStateV2, projectRoot string) error {
+func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, state *distillStateV2, projectRoot, guidelines string) error {
 	// resolve CodeDB
 	dataDir := resolveCodeDBDir(projectRoot)
 	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
@@ -163,7 +163,7 @@ func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcl
 		}
 
 		interval := "1 day"
-		prompt := buildGitHubExtractorPrompt(string(data), interval)
+		prompt := buildGitHubExtractorPrompt(string(data), interval, guidelines)
 		logPrompt(cmd, "github-facts:"+day, prompt)
 
 		fmt.Fprintf(cmd.OutOrStdout(), "Extracting facts from %d PRs, %d issues, %d commits for %s...\n",
@@ -275,10 +275,12 @@ func inferGitHubFactsHighWater(tcPath string) time.Time {
 }
 
 // buildGitHubExtractorPrompt constructs the full prompt for the GitHub fact extractor.
-func buildGitHubExtractorPrompt(clustersJSON, interval string) string {
+func buildGitHubExtractorPrompt(clustersJSON, interval, guidelines string) string {
 	var sb strings.Builder
 	sb.WriteString(githubExtractorSystemPrompt)
-	sb.WriteString("\n\n---\n\n")
+	sb.WriteString("\n\n")
+	agentcli.WriteGuidelines(&sb, guidelines, "extract-github")
+	sb.WriteString("---\n\n")
 	fmt.Fprintf(&sb, "Here is a batch of GitHub event clusters from the last %s. ", interval)
 	sb.WriteString("Each cluster contains pre-assembled related objects with their full comment histories.\n\n")
 	sb.WriteString("Analyze each cluster and extract raw facts for any meaningful events. Remember:\n")

--- a/cmd/ox/distill_github_test.go
+++ b/cmd/ox/distill_github_test.go
@@ -48,7 +48,7 @@ func TestBuildGitHubExtractorPrompt(t *testing.T) {
 	t.Parallel()
 
 	clustersJSON := `[{"type":"pull_request","number":42}]`
-	prompt := buildGitHubExtractorPrompt(clustersJSON, "7 days")
+	prompt := buildGitHubExtractorPrompt(clustersJSON, "7 days", "")
 
 	// System prompt present
 	assert.Contains(t, prompt, "You are a signal extractor for an alignment feed system")
@@ -71,8 +71,22 @@ func TestBuildGitHubExtractorPrompt(t *testing.T) {
 func TestBuildGitHubExtractorPrompt_ContainsBatchTags(t *testing.T) {
 	t.Parallel()
 
-	prompt := buildGitHubExtractorPrompt("[]", "24 hours")
+	prompt := buildGitHubExtractorPrompt("[]", "24 hours", "")
 	assert.Contains(t, prompt, "<batch>\n[]\n</batch>")
+}
+
+func TestBuildGitHubExtractorPrompt_WithGuidelines(t *testing.T) {
+	t.Parallel()
+
+	prompt := buildGitHubExtractorPrompt("[]", "1 day", "Focus on security-related changes.")
+
+	// Guidelines should be injected
+	assert.Contains(t, prompt, "<team-guidelines>")
+	assert.Contains(t, prompt, "Focus on security-related changes.")
+	assert.Contains(t, prompt, "</team-guidelines>")
+
+	// System prompt still present
+	assert.Contains(t, prompt, "You are a signal extractor for an alignment feed system")
 }
 
 func TestGitHubFactsSince_Default(t *testing.T) {
@@ -203,11 +217,10 @@ func TestExtractGitHubFacts_Integration(t *testing.T) {
 	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
-	cmd.Flags().Bool("verbose", false, "")
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot)
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot, "")
 	require.NoError(t, err)
 
 	// Verify prompt was sent to backend
@@ -261,7 +274,6 @@ func TestExtractGitHubFacts_DryRun(t *testing.T) {
 	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
-	cmd.Flags().Bool("verbose", false, "")
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 
@@ -269,7 +281,7 @@ func TestExtractGitHubFacts_DryRun(t *testing.T) {
 	distillDryRun = true
 	defer func() { distillDryRun = oldDryRun }()
 
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot)
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot, "")
 	require.NoError(t, err)
 
 	// Backend should NOT have been called
@@ -292,11 +304,10 @@ func TestExtractGitHubFacts_EmptySkip(t *testing.T) {
 	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
-	cmd.Flags().Bool("verbose", false, "")
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot)
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot, "")
 	require.NoError(t, err)
 
 	// Backend should NOT have been called (no activity)
@@ -338,11 +349,10 @@ func TestExtractGitHubFacts_TwoRunStateTracking(t *testing.T) {
 	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
-	cmd.Flags().Bool("verbose", false, "")
 	cmd.SetOut(&bytes.Buffer{})
 
 	// First run: processes PRs #1-3
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot)
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot, "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, state.LastGitHubFacts)
 	assert.Contains(t, backend.promptReceived, "<batch>")
@@ -370,7 +380,7 @@ func TestExtractGitHubFacts_TwoRunStateTracking(t *testing.T) {
 	backend.output = `{"headline":"second run","source_type":"github","timestamp":"2026-03-23T00:00:00Z"}`
 	cmd.SetOut(&bytes.Buffer{})
 
-	err = extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot)
+	err = extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot, "")
 	require.NoError(t, err)
 
 	// The second run should have processed PR #4 (high-water mark works)
@@ -400,11 +410,10 @@ func TestExtractGitHubFacts_IntraDayRerun(t *testing.T) {
 	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
-	cmd.Flags().Bool("verbose", false, "")
 	cmd.SetOut(&bytes.Buffer{})
 
 	// First run
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot)
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot, "")
 	require.NoError(t, err)
 
 	factsDir := filepath.Join(tcPath, "memory", ".github-facts")
@@ -422,7 +431,7 @@ func TestExtractGitHubFacts_IntraDayRerun(t *testing.T) {
 	cmd.SetOut(&bytes.Buffer{})
 
 	// Second run same day
-	err = extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot)
+	err = extractGitHubFacts(context.Background(), cmd, backend, tc, state, projectRoot, "")
 	require.NoError(t, err)
 
 	entries2, err := os.ReadDir(factsDir)
@@ -470,10 +479,9 @@ func TestExtractGitHubFacts_MultiDayCatchup(t *testing.T) {
 	state.LastGitHubFacts = time.Now().UTC().AddDate(0, 0, -4).Format(time.RFC3339)
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
-	cmd.Flags().Bool("verbose", false, "")
 	cmd.SetOut(&bytes.Buffer{})
 
-	err := extractGitHubFacts(context.Background(), cmd, tracker, tc, state, projectRoot)
+	err := extractGitHubFacts(context.Background(), cmd, tracker, tc, state, projectRoot, "")
 	require.NoError(t, err)
 
 	// Verify fact files were created for each day

--- a/cmd/ox/distill_test.go
+++ b/cmd/ox/distill_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetermineLayers(t *testing.T) {
@@ -113,7 +115,7 @@ func TestEnsureMemoryDirs(t *testing.T) {
 		t.Fatalf("ensureMemoryDirs: %v", err)
 	}
 
-	for _, sub := range []string{"memory/daily", "memory/weekly", "memory/monthly"} {
+	for _, sub := range []string{"memory/daily", "memory/weekly", "memory/monthly", "memory/guidance"} {
 		path := filepath.Join(tmp, sub)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			t.Errorf("expected directory %s to exist", sub)
@@ -333,24 +335,179 @@ func TestDistillStateV2LastTimes(t *testing.T) {
 	})
 }
 
-func TestLoadDistillGuidelines(t *testing.T) {
+func TestLoadGuidance(t *testing.T) {
 	tmp := t.TempDir()
-
-	// no file — returns empty
-	got := loadDistillGuidelines(tmp)
-	if got != "" {
-		t.Errorf("expected empty string for missing DISTILL.md, got %q", got)
-	}
-
-	// with file — returns content
-	content := "Always track security decisions.\nIgnore dependency bumps."
-	if err := os.WriteFile(filepath.Join(tmp, "DISTILL.md"), []byte(content), 0o644); err != nil {
+	guidanceDir := filepath.Join(tmp, "memory", "guidance")
+	if err := os.MkdirAll(guidanceDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	got = loadDistillGuidelines(tmp)
-	if got != content {
-		t.Errorf("expected %q, got %q", content, got)
+
+	t.Run("missing file returns empty", func(t *testing.T) {
+		got := loadGuidance(tmp, "EXTRACT.md")
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("reads EXTRACT.md", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "EXTRACT.md"), []byte("extract guidance"), 0o644))
+		got := loadGuidance(tmp, "EXTRACT.md")
+		if got != "extract guidance" {
+			t.Errorf("expected 'extract guidance', got %q", got)
+		}
+	})
+
+	t.Run("reads DISTILL.md", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "DISTILL.md"), []byte("distill guidance"), 0o644))
+		got := loadGuidance(tmp, "DISTILL.md")
+		if got != "distill guidance" {
+			t.Errorf("expected 'distill guidance', got %q", got)
+		}
+	})
+
+	t.Run("trims whitespace", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "EXTRACT.md"), []byte("  padded  \n"), 0o644))
+		got := loadGuidance(tmp, "EXTRACT.md")
+		if got != "padded" {
+			t.Errorf("expected 'padded', got %q", got)
+		}
+	})
+}
+
+func TestSeedGuidanceFiles(t *testing.T) {
+	tmp := t.TempDir()
+	initGitRepo(t, tmp)
+
+	if err := seedGuidanceFiles(tmp); err != nil {
+		t.Fatalf("seedGuidanceFiles: %v", err)
 	}
+
+	guidanceDir := filepath.Join(tmp, "memory", "guidance")
+
+	// EXTRACT.md should exist
+	data, err := os.ReadFile(filepath.Join(guidanceDir, "EXTRACT.md"))
+	if err != nil {
+		t.Fatalf("EXTRACT.md not created: %v", err)
+	}
+	if !strings.Contains(string(data), "Extraction Guidance") {
+		t.Error("EXTRACT.md should contain default content")
+	}
+
+	// DISTILL.md should exist
+	data, err = os.ReadFile(filepath.Join(guidanceDir, "DISTILL.md"))
+	if err != nil {
+		t.Fatalf("DISTILL.md not created: %v", err)
+	}
+	if !strings.Contains(string(data), "Distillation Guidance") {
+		t.Error("DISTILL.md should contain default content")
+	}
+
+	// second call should not overwrite
+	require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "EXTRACT.md"), []byte("custom"), 0o644))
+	if err := seedGuidanceFiles(tmp); err != nil {
+		t.Fatalf("seedGuidanceFiles (second call): %v", err)
+	}
+	data, _ = os.ReadFile(filepath.Join(guidanceDir, "EXTRACT.md"))
+	if string(data) != "custom" {
+		t.Error("seedGuidanceFiles should not overwrite existing files")
+	}
+}
+
+func TestMigrateDistillGuidelines(t *testing.T) {
+	t.Run("migrates old file", func(t *testing.T) {
+		tmp := t.TempDir()
+		initGitRepo(t, tmp)
+
+		oldContent := "# Custom Guidelines\nTrack security."
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "DISTILL.md"), []byte(oldContent), 0o644))
+
+		// commit the old file so git tracks it (mirrors real-world state)
+		if err := commitMemoryFile(tmp, "DISTILL.md", "seed DISTILL.md"); err != nil {
+			t.Fatalf("commit old DISTILL.md: %v", err)
+		}
+
+		migrated, err := migrateDistillGuidelines(tmp)
+		if err != nil {
+			t.Fatalf("migrateDistillGuidelines: %v", err)
+		}
+		if !migrated {
+			t.Error("expected migration to occur")
+		}
+
+		// old file should be gone
+		if _, err := os.Stat(filepath.Join(tmp, "DISTILL.md")); err == nil {
+			t.Error("old DISTILL.md should be removed")
+		}
+
+		// new file should exist with same content
+		data, err := os.ReadFile(filepath.Join(tmp, "memory", "guidance", "DISTILL.md"))
+		if err != nil {
+			t.Fatalf("new DISTILL.md not found: %v", err)
+		}
+		if string(data) != oldContent {
+			t.Errorf("expected %q, got %q", oldContent, string(data))
+		}
+	})
+
+	t.Run("skips if old file missing", func(t *testing.T) {
+		tmp := t.TempDir()
+		migrated, err := migrateDistillGuidelines(tmp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if migrated {
+			t.Error("should not migrate when no old file")
+		}
+	})
+
+	t.Run("skips if new file exists", func(t *testing.T) {
+		tmp := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "DISTILL.md"), []byte("old"), 0o644))
+		guidanceDir := filepath.Join(tmp, "memory", "guidance")
+		require.NoError(t, os.MkdirAll(guidanceDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "DISTILL.md"), []byte("new"), 0o644))
+
+		migrated, err := migrateDistillGuidelines(tmp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if migrated {
+			t.Error("should not migrate when new file already exists")
+		}
+
+		// new file should still have original content
+		data, _ := os.ReadFile(filepath.Join(guidanceDir, "DISTILL.md"))
+		if string(data) != "new" {
+			t.Error("new file should not be overwritten")
+		}
+	})
+
+	t.Run("migrates untracked file via fallback", func(t *testing.T) {
+		tmp := t.TempDir()
+		initGitRepo(t, tmp)
+
+		// write DISTILL.md but do NOT commit it — it's untracked, so git mv will fail
+		oldContent := "untracked custom guidelines"
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "DISTILL.md"), []byte(oldContent), 0o644))
+
+		migrated, err := migrateDistillGuidelines(tmp)
+		require.NoError(t, err)
+		if !migrated {
+			t.Error("expected migration to occur for untracked file")
+		}
+
+		// old file should be gone
+		if _, err := os.Stat(filepath.Join(tmp, "DISTILL.md")); err == nil {
+			t.Error("old DISTILL.md should be removed")
+		}
+
+		// new file should exist with same content
+		data, err := os.ReadFile(filepath.Join(tmp, "memory", "guidance", "DISTILL.md"))
+		require.NoError(t, err)
+		if string(data) != oldContent {
+			t.Errorf("expected %q, got %q", oldContent, string(data))
+		}
+	})
 }
 
 func TestContentHash(t *testing.T) {

--- a/cmd/ox/distill_write.go
+++ b/cmd/ox/distill_write.go
@@ -9,17 +9,129 @@ import (
 	"strings"
 )
 
-// loadDistillGuidelines reads DISTILL.md from the team context root.
-// Returns empty string if the file doesn't exist — the baseline prompt is used instead.
-// DISTILL.md lets teams customize what gets emphasized, omitted, or structured
-// differently during distillation (e.g., "always track security decisions",
-// "ignore dependency update noise", "use our RFC numbering scheme").
-func loadDistillGuidelines(tcPath string) string {
-	data, err := os.ReadFile(filepath.Join(tcPath, "DISTILL.md"))
+// loadGuidance reads a single guidance file from memory/guidance/.
+// Returns empty string if the file doesn't exist.
+func loadGuidance(tcPath, filename string) string {
+	data, err := os.ReadFile(filepath.Join(tcPath, "memory", "guidance", filename))
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(data))
+}
+
+// seedGuidanceFiles creates default EXTRACT.md and DISTILL.md in memory/guidance/
+// if they don't already exist. Does NOT create the optional per-stage files (those
+// are opt-in customization). Commits each created file to git.
+func seedGuidanceFiles(tcPath string) error {
+	guidanceDir := filepath.Join(tcPath, "memory", "guidance")
+	if err := os.MkdirAll(guidanceDir, 0o755); err != nil {
+		return fmt.Errorf("create guidance dir: %w", err)
+	}
+
+	type guidanceDefault struct {
+		name    string
+		content string
+	}
+	defaults := []guidanceDefault{
+		{"EXTRACT.md", `# Extraction Guidance
+
+These guidelines apply to all fact extraction stages.
+Customize to control what gets extracted and how facts are structured.
+
+For source-specific guidance, create an optional file named EXTRACT-{source}.md
+in this directory (e.g., EXTRACT-discussions.md, EXTRACT-github.md).
+If the file exists, read it for additional guidance specific to that source.
+`},
+		{"DISTILL.md", `# Distillation Guidance
+
+These guidelines apply to all synthesis stages.
+Customize to control what gets emphasized, omitted, or structured differently.
+
+For cadence-specific guidance, create an optional file named DISTILL-{cadence}.md
+in this directory (e.g., DISTILL-daily.md, DISTILL-weekly.md, DISTILL-monthly.md).
+If the file exists, read it for additional guidance specific to that cadence.
+`},
+	}
+
+	for _, d := range defaults {
+		path := filepath.Join(guidanceDir, d.name)
+		if _, err := os.Stat(path); err == nil {
+			continue // already exists
+		}
+		if err := os.WriteFile(path, []byte(d.content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", d.name, err)
+		}
+		relPath := filepath.Join("memory", "guidance", d.name)
+		if err := commitMemoryFile(tcPath, relPath, fmt.Sprintf("memory: seed %s guidance", strings.TrimSuffix(d.name, ".md"))); err != nil {
+			return fmt.Errorf("commit %s: %w", d.name, err)
+		}
+	}
+
+	return nil
+}
+
+// migrateDistillGuidelines moves tc.Path/DISTILL.md to memory/guidance/DISTILL.md
+// if the old file exists and the new one doesn't. Uses git mv for atomic
+// move+stage so partial failures don't leave an inconsistent state.
+// Returns true if migration occurred.
+func migrateDistillGuidelines(tcPath string) (bool, error) {
+	oldPath := filepath.Join(tcPath, "DISTILL.md")
+	newDir := filepath.Join(tcPath, "memory", "guidance")
+	newPath := filepath.Join(newDir, "DISTILL.md")
+
+	// skip if old file doesn't exist
+	if _, err := os.Stat(oldPath); err != nil {
+		return false, nil
+	}
+
+	// skip if new file already exists
+	if _, err := os.Stat(newPath); err == nil {
+		return false, nil
+	}
+
+	// ensure target directory exists
+	if err := os.MkdirAll(newDir, 0o755); err != nil {
+		return false, fmt.Errorf("create guidance dir: %w", err)
+	}
+
+	// git mv atomically moves the file and stages both the deletion and addition
+	mvCmd := exec.Command("git", "mv", "DISTILL.md", filepath.Join("memory", "guidance", "DISTILL.md"))
+	mvCmd.Dir = tcPath
+	if out, err := mvCmd.CombinedOutput(); err != nil {
+		// git mv fails if file is untracked — fall back to manual move+stage
+		data, readErr := os.ReadFile(oldPath)
+		if readErr != nil {
+			return false, fmt.Errorf("read old DISTILL.md: %w", readErr)
+		}
+		if writeErr := os.WriteFile(newPath, data, 0o644); writeErr != nil {
+			return false, fmt.Errorf("write new DISTILL.md: %w", writeErr)
+		}
+		if removeErr := os.Remove(oldPath); removeErr != nil {
+			return false, fmt.Errorf("remove old DISTILL.md: %w", removeErr)
+		}
+		addCmd := exec.Command("git", "add", "--sparse", filepath.Join("memory", "guidance", "DISTILL.md"))
+		addCmd.Dir = tcPath
+		if addOut, addErr := addCmd.CombinedOutput(); addErr != nil {
+			// rollback: restore old file so next run can retry cleanly
+			_ = os.WriteFile(oldPath, data, 0o644)
+			_ = os.Remove(newPath)
+			return false, fmt.Errorf("git add: %s: %w", string(addOut), addErr)
+		}
+		_ = out // suppress unused warning
+	}
+
+	commitCmd := exec.Command("git", "commit", "-m", "memory: migrate DISTILL.md to guidance/")
+	commitCmd.Dir = tcPath
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 &&
+			strings.Contains(string(out), "nothing to commit") {
+			return true, nil
+		}
+		return false, fmt.Errorf("git commit: %s: %w", string(out), err)
+	}
+
+	return true, nil
 }
 
 // ensureMemoryDirs creates the memory directory structure if it doesn't exist.
@@ -28,6 +140,7 @@ func ensureMemoryDirs(tcPath string) error {
 		filepath.Join(tcPath, "memory", "daily"),
 		filepath.Join(tcPath, "memory", "weekly"),
 		filepath.Join(tcPath, "memory", "monthly"),
+		filepath.Join(tcPath, "memory", "guidance"),
 		filepath.Join(tcPath, "memory", ".discussion-facts"),
 		filepath.Join(tcPath, "memory", ".github-facts"),
 		filepath.Join(tcPath, "memory", ".session-facts"),

--- a/cmd/ox/doctor_guidance.go
+++ b/cmd/ox/doctor_guidance.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
+)
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugGuidanceFiles,
+		Name:        "Guidance files",
+		Category:    "Team Context",
+		FixLevel:    FixLevelAuto,
+		Description: "Ensures distill guidance files are in memory/guidance/ and migrates legacy DISTILL.md",
+		Run:         checkGuidanceFiles,
+	})
+}
+
+// checkGuidanceFiles detects whether the old root-level DISTILL.md needs migration
+// and whether the base guidance files exist. On fix, migrates and seeds as needed.
+func checkGuidanceFiles(fix bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Guidance files", "not in git repo", "")
+	}
+
+	tc := config.FindRepoTeamContext(gitRoot)
+	if tc == nil {
+		return SkippedCheck("Guidance files", "no team context", "")
+	}
+
+	result := checkGuidanceFilesForPath(tc.Path, fix)
+
+	// push team context after seeding/migrating guidance files
+	if fix && result.passed {
+		ep := endpoint.GetForProject(gitRoot)
+		if err := pushTeamContext(context.Background(), tc.Path, ep); err != nil {
+			slog.Warn("failed to push team context after guidance fix", "error", err)
+			result = WarningCheck("Guidance files", "seeded but push failed", err.Error())
+		}
+	}
+
+	return result
+}
+
+// checkGuidanceFilesForPath is the testable core of the guidance check.
+// It checks a specific team context path for guidance file presence and migration needs.
+func checkGuidanceFilesForPath(tcPath string, fix bool) checkResult {
+	oldDistill := filepath.Join(tcPath, "DISTILL.md")
+	newDistill := filepath.Join(tcPath, "memory", "guidance", "DISTILL.md")
+	newExtract := filepath.Join(tcPath, "memory", "guidance", "EXTRACT.md")
+
+	// check for legacy DISTILL.md needing migration
+	_, oldErr := os.Stat(oldDistill)
+	_, newDistillErr := os.Stat(newDistill)
+	needsMigration := oldErr == nil && newDistillErr != nil
+
+	// check for missing base guidance files (exclude migration case — that's a separate issue)
+	missingDistill := newDistillErr != nil && !needsMigration
+	_, extractErr := os.Stat(newExtract)
+	missingExtract := extractErr != nil
+
+	if !needsMigration && !missingDistill && !missingExtract {
+		return PassedCheck("Guidance files", "memory/guidance/ configured")
+	}
+
+	if !fix {
+		var issues []string
+		if needsMigration {
+			issues = append(issues, "DISTILL.md at root needs migration to memory/guidance/")
+		}
+		if missingDistill {
+			issues = append(issues, "memory/guidance/DISTILL.md missing")
+		}
+		if missingExtract {
+			issues = append(issues, "memory/guidance/EXTRACT.md missing")
+		}
+		detail := "  " + strings.Join(issues, "\n  ") + "\n  Run `ox doctor --fix` to resolve"
+		return WarningCheck("Guidance files",
+			fmt.Sprintf("%d issue(s)", len(issues)),
+			detail)
+	}
+
+	// fix: migrate and seed
+	if needsMigration {
+		if _, err := migrateDistillGuidelines(tcPath); err != nil {
+			// Don't fall through to seeding — that would replace custom content with defaults
+			return WarningCheck("Guidance files", "migration failed",
+				fmt.Sprintf("Failed to migrate DISTILL.md: %s\n  Move it manually to memory/guidance/DISTILL.md", err))
+		}
+		slog.Info("migrated DISTILL.md to memory/guidance/")
+	}
+
+	if err := seedGuidanceFiles(tcPath); err != nil {
+		slog.Warn("failed to seed guidance files", "error", err)
+		return WarningCheck("Guidance files", "seed failed", err.Error())
+	}
+
+	return PassedCheck("Guidance files", "memory/guidance/ configured")
+}

--- a/cmd/ox/doctor_guidance_test.go
+++ b/cmd/ox/doctor_guidance_test.go
@@ -1,0 +1,154 @@
+//go:build !short
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initTeamContextGitDir creates a temp directory with git init and user config.
+func initTeamContextGitDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "team-ctx")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run())
+	for _, kv := range [][2]string{{"user.name", "test"}, {"user.email", "test@test.com"}} {
+		c := exec.Command("git", "config", kv[0], kv[1])
+		c.Dir = dir
+		require.NoError(t, c.Run())
+	}
+	return dir
+}
+
+func TestCheckGuidanceFilesForPath_MissingFiles(t *testing.T) {
+	tcPath := initTeamContextGitDir(t)
+
+	result := checkGuidanceFilesForPath(tcPath, false)
+
+	assert.True(t, result.warning, "should warn when guidance files are missing")
+	assert.Contains(t, result.message, "2 issue(s)")
+}
+
+func TestCheckGuidanceFilesForPath_FixCreatesFiles(t *testing.T) {
+	tcPath := initTeamContextGitDir(t)
+
+	result := checkGuidanceFilesForPath(tcPath, true)
+
+	assert.True(t, result.passed, "should pass after fix")
+	assert.False(t, result.warning)
+
+	// verify files were created
+	guidanceDir := filepath.Join(tcPath, "memory", "guidance")
+	extractPath := filepath.Join(guidanceDir, "EXTRACT.md")
+	distillPath := filepath.Join(guidanceDir, "DISTILL.md")
+	assert.FileExists(t, extractPath)
+	assert.FileExists(t, distillPath)
+
+	// verify content
+	extractData, err := os.ReadFile(extractPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(extractData), "Extraction Guidance")
+
+	distillData, err := os.ReadFile(distillPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(distillData), "Distillation Guidance")
+}
+
+func TestCheckGuidanceFilesForPath_PassesWhenPresent(t *testing.T) {
+	tcPath := initTeamContextGitDir(t)
+
+	// create guidance files
+	guidanceDir := filepath.Join(tcPath, "memory", "guidance")
+	require.NoError(t, os.MkdirAll(guidanceDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "EXTRACT.md"), []byte("custom extract"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "DISTILL.md"), []byte("custom distill"), 0o644))
+
+	result := checkGuidanceFilesForPath(tcPath, false)
+
+	assert.True(t, result.passed, "should pass when both files exist")
+	assert.False(t, result.warning)
+}
+
+func TestCheckGuidanceFilesForPath_DetectsLegacyMigration(t *testing.T) {
+	tcPath := initTeamContextGitDir(t)
+
+	// create old-style DISTILL.md at root
+	require.NoError(t, os.WriteFile(filepath.Join(tcPath, "DISTILL.md"), []byte("legacy guidelines"), 0o644))
+
+	result := checkGuidanceFilesForPath(tcPath, false)
+
+	assert.True(t, result.warning, "should warn about migration needed")
+	assert.Contains(t, result.detail, "migration")
+}
+
+func TestCheckGuidanceFilesForPath_FixMigratesLegacy(t *testing.T) {
+	tcPath := initTeamContextGitDir(t)
+
+	// commit old DISTILL.md so git operations work
+	oldContent := "legacy team guidelines\ntrack security decisions"
+	require.NoError(t, os.WriteFile(filepath.Join(tcPath, "DISTILL.md"), []byte(oldContent), 0o644))
+	addCmd := exec.Command("git", "add", "DISTILL.md")
+	addCmd.Dir = tcPath
+	require.NoError(t, addCmd.Run())
+	commitCmd := exec.Command("git", "commit", "-m", "add DISTILL.md")
+	commitCmd.Dir = tcPath
+	require.NoError(t, commitCmd.Run())
+
+	result := checkGuidanceFilesForPath(tcPath, true)
+
+	assert.True(t, result.passed, "should pass after migration fix")
+
+	// verify legacy content was migrated
+	guidanceDir := filepath.Join(tcPath, "memory", "guidance")
+	newDistillPath := filepath.Join(guidanceDir, "DISTILL.md")
+	assert.FileExists(t, newDistillPath)
+	data, err := os.ReadFile(newDistillPath)
+	require.NoError(t, err)
+	assert.Equal(t, oldContent, string(data), "migrated file should preserve original content")
+
+	// verify old file was removed
+	assert.NoFileExists(t, filepath.Join(tcPath, "DISTILL.md"))
+
+	// verify EXTRACT.md was also seeded
+	assert.FileExists(t, filepath.Join(guidanceDir, "EXTRACT.md"))
+}
+
+func TestCheckGuidanceFilesForPath_FixDoesNotOverwrite(t *testing.T) {
+	tcPath := initTeamContextGitDir(t)
+
+	// create custom guidance files
+	guidanceDir := filepath.Join(tcPath, "memory", "guidance")
+	require.NoError(t, os.MkdirAll(guidanceDir, 0o755))
+	customContent := "my custom guidelines"
+	require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "EXTRACT.md"), []byte(customContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "DISTILL.md"), []byte(customContent), 0o644))
+
+	result := checkGuidanceFilesForPath(tcPath, true)
+
+	assert.True(t, result.passed)
+
+	// verify custom content was NOT overwritten
+	data, err := os.ReadFile(filepath.Join(guidanceDir, "EXTRACT.md"))
+	require.NoError(t, err)
+	assert.Equal(t, customContent, string(data), "existing content should not be overwritten")
+}
+
+func TestCheckGuidanceFiles_NoTeamContext(t *testing.T) {
+	gitRoot, cleanup := setupTempGitRepo(t)
+	defer cleanup()
+
+	restoreCwd := changeToDir(t, gitRoot)
+	defer restoreCwd()
+
+	result := checkGuidanceFiles(false)
+
+	assert.True(t, result.skipped, "should skip when no team context")
+}

--- a/cmd/ox/doctor_team.go
+++ b/cmd/ox/doctor_team.go
@@ -27,11 +27,17 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 	localCfg, err := config.LoadLocalConfig(gitRoot)
 	if err != nil || len(localCfg.TeamContexts) == 0 {
 		// no team contexts configured, check for legacy directories
+		var checks []checkResult
 		legacyCheck := checkLegacyTeamContexts(gitRoot)
 		if legacyCheck.warning || !legacyCheck.passed {
-			return []checkResult{legacyCheck}
+			checks = append(checks, legacyCheck)
 		}
-		return nil
+		// guidance check uses FindRepoTeamContext (daemon-discovered)
+		guidanceCheck := checkGuidanceFiles(opts.shouldFix(CheckSlugGuidanceFiles))
+		if guidanceCheck.warning || !guidanceCheck.passed {
+			checks = append(checks, guidanceCheck)
+		}
+		return checks
 	}
 
 	var checks []checkResult
@@ -58,6 +64,12 @@ func checkTeamContextHealth(opts doctorOptions) []checkResult {
 	orphanCheck := checkOrphanedTeamDirs(opts)
 	if orphanCheck.warning || !orphanCheck.passed {
 		checks = append(checks, orphanCheck)
+	}
+
+	// check for distill guidance files
+	guidanceCheck := checkGuidanceFiles(opts.shouldFix(CheckSlugGuidanceFiles))
+	if guidanceCheck.warning || !guidanceCheck.passed {
+		checks = append(checks, guidanceCheck)
 	}
 
 	return checks

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -165,6 +165,9 @@ const (
 	CheckSlugCredentialIntegrity = "credential-integrity"
 	CheckSlugGitPATLiveness      = "git-pat-liveness"
 
+	// Distillation checks
+	CheckSlugGuidanceFiles = "guidance-files"
+
 	// Code Search checks
 	CheckSlugCodeIndex = "code-index"
 )

--- a/internal/agentcli/agentcli_test.go
+++ b/internal/agentcli/agentcli_test.go
@@ -247,3 +247,56 @@ func TestClaudeRunRequiresCLI(t *testing.T) {
 		t.Error("expected error when claude CLI not in PATH")
 	}
 }
+
+func TestWriteGuidelines(t *testing.T) {
+	t.Run("empty guidelines is no-op", func(t *testing.T) {
+		var sb strings.Builder
+		WriteGuidelines(&sb, "", "distill-daily")
+		if sb.Len() != 0 {
+			t.Errorf("expected empty output, got %q", sb.String())
+		}
+	})
+
+	t.Run("with stage", func(t *testing.T) {
+		var sb strings.Builder
+		WriteGuidelines(&sb, "focus on security", "extract-discussions")
+		out := sb.String()
+		if !strings.Contains(out, "<team-guidelines>") {
+			t.Error("should contain opening tag")
+		}
+		if !strings.Contains(out, "Current pipeline stage: extract-discussions") {
+			t.Error("should contain stage identifier")
+		}
+		if !strings.Contains(out, "focus on security") {
+			t.Error("should contain guidelines content")
+		}
+		if !strings.Contains(out, "You MAY use the Read tool") {
+			t.Error("should contain Read tool permission")
+		}
+		if !strings.Contains(out, "</team-guidelines>") {
+			t.Error("should contain closing tag")
+		}
+	})
+
+	t.Run("empty stage omits stage line", func(t *testing.T) {
+		var sb strings.Builder
+		WriteGuidelines(&sb, "some guidance", "")
+		out := sb.String()
+		if strings.Contains(out, "Current pipeline stage") {
+			t.Error("should not contain stage line when stage is empty")
+		}
+		if !strings.Contains(out, "some guidance") {
+			t.Error("should still contain guidelines content")
+		}
+	})
+
+	t.Run("adds trailing newline if missing", func(t *testing.T) {
+		var sb strings.Builder
+		WriteGuidelines(&sb, "no trailing newline", "test")
+		out := sb.String()
+		// guidelines content should end with \n before the Read tool line
+		if !strings.Contains(out, "no trailing newline\n") {
+			t.Error("should add trailing newline to guidelines content")
+		}
+	})
+}

--- a/internal/agentcli/prompts.go
+++ b/internal/agentcli/prompts.go
@@ -10,8 +10,10 @@ const systemPrompt = `<system>
 You are an expert summarizer and distiller of information.
 
 This is a pure text-in/text-out task. All the input you need is provided below.
-Do NOT read files, check the filesystem, or use any tools. Do NOT consider any
-prior context or existing files — work ONLY from the input provided in this prompt.
+Do NOT read files, check the filesystem, or use any tools — EXCEPT when
+explicitly permitted (e.g., reading team guidance or fact files listed below).
+Do NOT consider any prior context or existing files beyond what is provided or
+permitted in this prompt.
 
 Your sole output is the summary or extraction described in the <task> section.
 
@@ -28,18 +30,24 @@ Rules:
 
 `
 
-// writeGuidelines wraps team distillation guidelines in a <team-guidelines> tag.
-// Guidelines come from DISTILL.md in the team context — they let teams
-// customize what gets emphasized, omitted, or structured differently.
-func writeGuidelines(sb *strings.Builder, guidelines string) {
+// WriteGuidelines wraps team guidelines in a <team-guidelines> tag and tells
+// the LLM which pipeline stage it's in. The stage identifier lets the guidelines
+// reference optional per-stage override files via progressive disclosure
+// (e.g., "if extracting discussions, read EXTRACT-discussions.md").
+// The LLM MAY use the Read tool to access files in memory/guidance/.
+func WriteGuidelines(sb *strings.Builder, guidelines, stage string) {
 	if guidelines == "" {
 		return
 	}
 	sb.WriteString("<team-guidelines>\n")
+	if stage != "" {
+		fmt.Fprintf(sb, "Current pipeline stage: %s\n\n", stage)
+	}
 	sb.WriteString(guidelines)
 	if !strings.HasSuffix(guidelines, "\n") {
 		sb.WriteByte('\n')
 	}
+	sb.WriteString("\nYou MAY use the Read tool to access any file referenced above in memory/guidance/.\n")
 	sb.WriteString("</team-guidelines>\n\n")
 }
 
@@ -51,7 +59,7 @@ func DailyPrompt(observations []string, date, guidelines string, factPaths ...st
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
-	writeGuidelines(&sb, guidelines)
+	WriteGuidelines(&sb, guidelines, "distill-daily")
 
 	sb.WriteString("<task>\n")
 	sb.WriteString("Distill these team observations into a daily memory summary.\n")
@@ -90,7 +98,7 @@ func DiscussionFactsPrompt(title, summary, transcript, guidelines, annotations s
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
-	writeGuidelines(&sb, guidelines)
+	WriteGuidelines(&sb, guidelines, "extract-discussions")
 
 	sb.WriteString("<task>\n")
 	sb.WriteString("Extract structured facts from this team discussion as JSONL.\n")
@@ -138,7 +146,7 @@ func WeeklyPrompt(dailySummaries []string, weekID, guidelines string) string {
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
-	writeGuidelines(&sb, guidelines)
+	WriteGuidelines(&sb, guidelines, "distill-weekly")
 
 	sb.WriteString("<task>\n")
 	sb.WriteString("Synthesize these daily summaries into a weekly memory.\n")
@@ -158,7 +166,7 @@ func MonthlyPrompt(weeklySummaries []string, month, guidelines string) string {
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
-	writeGuidelines(&sb, guidelines)
+	WriteGuidelines(&sb, guidelines, "distill-monthly")
 
 	sb.WriteString("<task>\n")
 	sb.WriteString("Synthesize these weekly summaries into a monthly memory.\n")


### PR DESCRIPTION
## Summary

- Replaces single root-level `DISTILL.md` with per-stage guidance files under `memory/guidance/` (`EXTRACT.md` for extraction, `DISTILL.md` for synthesis)
- Teams can create optional per-stage overrides (e.g., `EXTRACT-discussions.md`, `DISTILL-daily.md`) via progressive disclosure — the LLM reads them at runtime based on its pipeline stage
- GitHub fact extractor now receives team guidance (previously excluded)
- `ox doctor` auto-fixes missing guidance files and migrates legacy `DISTILL.md`

## Design

```mermaid
flowchart TD
    A[runDistill] --> B[loadGuidance EXTRACT.md]
    A --> C[loadGuidance DISTILL.md]
    B --> D[extractDiscussionFacts<br/>stage: extract-discussions]
    B --> E[extractGitHubFacts<br/>stage: extract-github]
    C --> F[distillDaily<br/>stage: distill-daily]
    C --> G[distillWeekly<br/>stage: distill-weekly]
    C --> H[distillMonthly<br/>stage: distill-monthly]
    
    subgraph "memory/guidance/"
        I[EXTRACT.md<br/>base extraction guidance]
        J[EXTRACT-discussions.md<br/>optional override]
        K[EXTRACT-github.md<br/>optional override]
        L[DISTILL.md<br/>base synthesis guidance]
        M[DISTILL-daily.md<br/>optional override]
    end
    
    D -.->|LLM reads if referenced| J
    E -.->|LLM reads if referenced| K
    F -.->|LLM reads if referenced| M
```

**Progressive disclosure**: Go code loads only the base file. The base file tells the LLM about optional per-stage overrides. `WriteGuidelines` injects the current pipeline stage (e.g., `extract-discussions`) so the LLM knows which override to read. The system prompt permits reading files in `memory/guidance/`.

## Changes

| File | Change |
|------|--------|
| `internal/agentcli/prompts.go` | Export `WriteGuidelines(sb, guidelines, stage)` — injects stage identifier and Read tool permission |
| `cmd/ox/distill_write.go` | `loadGuidance`, `seedGuidanceFiles`, `migrateDistillGuidelines` (git mv + fallback with rollback) |
| `cmd/ox/distill.go` | Load guidance once at run start, pass to all stages; wire `--verbose` flag; add migration + seeding |
| `cmd/ox/distill_github.go` | `extractGitHubFacts` and `buildGitHubExtractorPrompt` now accept and inject guidelines |
| `cmd/ox/doctor_guidance.go` | New `FixLevelAuto` check — detects missing guidance + legacy migration, pushes after fix |
| `cmd/ox/doctor_team.go` | Wire guidance check into both early-return and main paths |
| `cmd/ox/doctor_types.go` | Add `CheckSlugGuidanceFiles` |

## Test plan

- [ ] `go test ./internal/agentcli/ ./cmd/ox/ -run "TestWriteGuidelines|TestLoadGuidance|TestSeed|TestMigrate|TestCheckGuidanceFiles|TestBuildGitHub|TestExtractGitHub"` — all pass
- [ ] `ox doctor` on repo without guidance files shows warning
- [ ] `ox doctor --fix` seeds defaults and pushes to remote
- [ ] `ox distill --layer daily --verbose` shows `<team-guidelines>` with stage identifier in prompt
- [ ] Legacy `DISTILL.md` at team context root is migrated on first `ox distill` or `ox doctor --fix`

Co-Authored-By: [SageOx](https://github.com/SageOx)