### PR TITLE
feat(murmur): IPC delegation, status command, hook heartbeats

### DIFF
--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -147,9 +147,23 @@ func resolvePhase(agentType, eventName string) string {
 	return string(phase)
 }
 
+// hookAgentID extracts the agent ID from a HookContext, or "" if unavailable.
+func hookAgentID(ctx *HookContext) string {
+	if ctx.Marker != nil {
+		return ctx.Marker.AgentID
+	}
+	return ""
+}
+
 // dispatchPhase routes to the appropriate handler based on the resolved phase.
 // Only phases listed in activePhaseBehavior reach here (others are fast-path nooped).
 func dispatchPhase(ctx *HookContext) error {
+	// emit heartbeat on every hook so the daemon tracks this agent as active —
+	// required for murmur nudge delivery during long sessions with no explicit ox commands.
+	if agentID := hookAgentID(ctx); agentID != "" {
+		Heartbeat(ctx.ProjectRoot, nil, agentID)
+	}
+
 	switch ctx.Phase {
 	case phaseStart:
 		return handleStart(ctx)

--- a/cmd/ox/murmur.go
+++ b/cmd/ox/murmur.go
@@ -17,7 +17,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const maxMurmurContentBytes = 500 // ~125 tokens — murmurs must be concise coordination signals
+const maxMurmurContentBytes = 500            // ~125 tokens — murmurs must be concise coordination signals
+const murmurRateInterval  = 5 * time.Second // max 1 murmur per agent per this window
 
 var murmurCmd = &cobra.Command{
 	Use:   "murmur [content]",
@@ -115,13 +116,12 @@ func runMurmur(cmd *cobra.Command, args []string) error {
 		agentID = os.Getenv("SAGEOX_AGENT_ID")
 	}
 
-	// rate limit: max 1 murmur per 5 seconds per agent
-	const minMurmurInterval = 5 * time.Second
+	// rate limit: max 1 murmur per agent per murmurRateInterval
 	if agentID != "" {
 		lastMurmur := ledger.MostRecentMurmurTime(targetDir, agentID)
-		if !lastMurmur.IsZero() && time.Since(lastMurmur) < minMurmurInterval {
+		if !lastMurmur.IsZero() && time.Since(lastMurmur) < murmurRateInterval {
 			return fmt.Errorf("rate limited: max 1 murmur per %s per agent (last: %s ago)",
-				minMurmurInterval, time.Since(lastMurmur).Truncate(time.Millisecond))
+				murmurRateInterval, time.Since(lastMurmur).Truncate(time.Millisecond))
 		}
 	}
 
@@ -156,9 +156,11 @@ func runMurmur(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("marshal murmur: %w", err)
 	}
 
-	// murmurs are best-effort — if the daemon isn't running, log and continue
+	// murmurs are best-effort — if the daemon isn't running, warn and continue
 	if err := publishMurmurViaIPC(targetDir, relPath, rawContent, murmurJSON); err != nil {
 		slog.Debug("murmur not delivered", "error", err)
+		fmt.Fprintf(cmd.OutOrStdout(), "Murmur not delivered (daemon unavailable): %s\n", id.String())
+		return nil
 	}
 
 	slog.Info("murmur published", "id", id.String(), "topic", topic, "importance", importance, "scope", scope)

--- a/cmd/ox/murmur_status.go
+++ b/cmd/ox/murmur_status.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ledger"
+	"github.com/spf13/cobra"
+)
+
+var murmurStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show murmur delivery status and per-coworker rate limit state",
+	Long: `Show the last murmur from each active coworker and whether they are
+currently rate-limited or ready to publish.
+
+Reads the current and previous hour from the ledger — no murmurs are sent.
+
+Examples:
+  ox murmur status            # table view
+  ox murmur status --json     # JSON for scripting`,
+	RunE: runMurmurStatus,
+}
+
+func init() {
+	murmurCmd.AddCommand(murmurStatusCmd)
+}
+
+// murmurAgentStatus holds the per-agent state for JSON output.
+type murmurAgentStatus struct {
+	AgentID      string `json:"agent_id"`
+	PrincipalID  string `json:"principal_id,omitempty"`
+	LastMurmur   string `json:"last_murmur"`          // RFC3339, or "" if none
+	NextEligible string `json:"next_eligible"`         // RFC3339, or "ready"
+	Ready        bool   `json:"ready"`
+	LastTopic    string `json:"last_topic,omitempty"`
+	LastContent  string `json:"last_content,omitempty"`
+}
+
+type murmurStatusOutput struct {
+	YourAgentID string              `json:"your_agent_id,omitempty"`
+	Agents      []murmurAgentStatus `json:"agents"`
+	Source      string              `json:"source"`
+}
+
+func runMurmurStatus(cmd *cobra.Command, _ []string) error {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return fmt.Errorf("not in a SageOx project: %w", err)
+	}
+
+	yourAgentID := os.Getenv("SAGEOX_AGENT_ID")
+
+	// collect murmurs from ledger (2h window covers current + previous hour boundary)
+	var allMurmurs []ledger.MurmurFile
+	source := "ledger"
+
+	ledgerPath := getLedgerPath()
+	if ledgerPath != "" {
+		murmurs, _ := ledger.ReadMurmursInWindow(ledgerPath, 2)
+		allMurmurs = append(allMurmurs, murmurs...)
+	}
+
+	// also check team context
+	tc := config.FindRepoTeamContext(projectRoot)
+	if tc != nil {
+		murmurs, _ := ledger.ReadMurmursInWindow(tc.Path, 2)
+		allMurmurs = append(allMurmurs, murmurs...)
+		source = "ledger+team"
+	}
+
+	// group by agent_id: keep only the most recent murmur per agent
+	type agentEntry struct {
+		latest      ledger.MurmurFile
+		principalID string
+	}
+	byAgent := make(map[string]*agentEntry)
+	for _, m := range allMurmurs {
+		id := m.AgentID
+		if id == "" {
+			id = "(unknown)"
+		}
+		e, ok := byAgent[id]
+		if !ok || m.Timestamp.After(e.latest.Timestamp) {
+			byAgent[id] = &agentEntry{latest: m, principalID: m.PrincipalID}
+		}
+	}
+
+	// build sorted list: your agent first, then alphabetical
+	type row struct {
+		agentID     string
+		principalID string
+		last        time.Time
+		lastTopic   string
+		lastContent string
+	}
+	var rows []row
+	for id, e := range byAgent {
+		rows = append(rows, row{
+			agentID:     id,
+			principalID: e.principalID,
+			last:        e.latest.Timestamp,
+			lastTopic:   e.latest.Topic,
+			lastContent: e.latest.Content,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].agentID == yourAgentID {
+			return true
+		}
+		if rows[j].agentID == yourAgentID {
+			return false
+		}
+		return rows[i].agentID < rows[j].agentID
+	})
+
+	now := time.Now()
+
+	jsonOutput, _ := cmd.Root().PersistentFlags().GetBool("json")
+	if jsonOutput {
+		agents := make([]murmurAgentStatus, 0, len(rows))
+		for _, r := range rows {
+			nextEligible := r.last.Add(murmurRateInterval)
+			ready := now.After(nextEligible)
+			s := murmurAgentStatus{
+				AgentID:     r.agentID,
+				PrincipalID: r.principalID,
+				Ready:       ready,
+				LastTopic:   r.lastTopic,
+				LastContent: r.lastContent,
+			}
+			if !r.last.IsZero() {
+				s.LastMurmur = r.last.UTC().Format(time.RFC3339)
+			}
+			if ready {
+				s.NextEligible = "ready"
+			} else {
+				s.NextEligible = nextEligible.UTC().Format(time.RFC3339)
+			}
+			agents = append(agents, s)
+		}
+		return outputJSON(murmurStatusOutput{
+			YourAgentID: yourAgentID,
+			Agents:      agents,
+			Source:      source,
+		})
+	}
+
+	// --- table output ---
+	fmt.Println()
+
+	if len(rows) == 0 {
+		fmt.Println(murmurDimStyle.Render("  No murmur activity in the last 2 hours."))
+		fmt.Println()
+		cli.PrintHint("Publish with: ox murmur --topic=wip \"what you're working on\"")
+		return nil
+	}
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(cli.ColorPrimary)
+	agentCol  := fmt.Sprintf("%-12s", "COWORKER")
+	userCol   := fmt.Sprintf("%-12s", "USER")
+	lastCol   := fmt.Sprintf("%-14s", "LAST MURMUR")
+	statusCol := fmt.Sprintf("%-16s", "STATUS")
+	topicCol  := "LAST TOPIC"
+	fmt.Println("  " + headerStyle.Render(agentCol+userCol+lastCol+statusCol+topicCol))
+	fmt.Println("  " + cli.StyleDim.Render(strings.Repeat("-", 90)))
+
+	for _, r := range rows {
+		nextEligible := r.last.Add(murmurRateInterval)
+		ready := now.After(nextEligible)
+
+		// time ago
+		age := now.Sub(r.last)
+		var lastStr string
+		switch {
+		case r.last.IsZero():
+			lastStr = "never"
+		case age < time.Minute:
+			lastStr = "just now"
+		case age < time.Hour:
+			lastStr = fmt.Sprintf("%dm ago", int(age.Minutes()))
+		default:
+			lastStr = fmt.Sprintf("%dh%dm ago", int(age.Hours()), int(age.Minutes())%60)
+		}
+
+		// status
+		var statusStr string
+		var statusStyle lipgloss.Style
+		if ready {
+			statusStr = "ready"
+			statusStyle = lipgloss.NewStyle().Foreground(cli.ColorSuccess)
+		} else {
+			remaining := time.Until(nextEligible).Truncate(time.Millisecond)
+			statusStr = fmt.Sprintf("ready in %s", remaining)
+			statusStyle = lipgloss.NewStyle().Foreground(cli.ColorWarning)
+		}
+
+		// user: email → local part
+		userStr := r.principalID
+		if userStr == "" {
+			userStr = "-"
+		}
+		if idx := strings.IndexByte(userStr, '@'); idx > 0 {
+			userStr = userStr[:idx]
+		}
+		if len(userStr) > 10 {
+			userStr = userStr[:10]
+		}
+
+		// topic
+		topicStr := r.lastTopic
+		if len(topicStr) > 16 {
+			topicStr = topicStr[:13] + "..."
+		}
+
+		isYours := r.agentID == yourAgentID
+		agentStr := r.agentID
+		if len(agentStr) > 10 {
+			agentStr = agentStr[:10]
+		}
+
+		agentStyle := murmurAgentStyle
+		if isYours {
+			agentStyle = lipgloss.NewStyle().Foreground(cli.ColorAccent).Bold(true)
+			agentStr += " ★"
+		}
+
+		row := agentStyle.Render(fmt.Sprintf("%-12s", agentStr)) +
+			murmurDimStyle.Render(fmt.Sprintf("%-12s", userStr)) +
+			murmurTimeStyle.Render(fmt.Sprintf("%-14s", lastStr)) +
+			statusStyle.Render(fmt.Sprintf("%-16s", statusStr)) +
+			murmurTopicStyle.Render(topicStr)
+
+		fmt.Println("  " + row)
+	}
+
+	fmt.Println()
+	hint := fmt.Sprintf("Rate limit: 1 murmur per %s per coworker  ·  Source: %s", murmurRateInterval, source)
+	fmt.Println("  " + cli.StyleDim.Render(hint))
+	if yourAgentID == "" {
+		fmt.Println()
+		cli.PrintHint("Set SAGEOX_AGENT_ID to highlight your agent with ★")
+	}
+	fmt.Println()
+	return nil
+}

--- a/internal/daemon/murmur_nudge_tracker.go
+++ b/internal/daemon/murmur_nudge_tracker.go
@@ -97,6 +97,27 @@ func (t *MurmurNudgeTracker) ShouldNudge(agentID string, interval time.Duration)
 	return now.Sub(lastMurmur) >= interval
 }
 
+// KnownAgentIDs returns all agent IDs the tracker has seen — either via
+// heartbeat (firstSeen) or via a relayed murmur (lastMurmur). Used by
+// MurmurNudgeSource to generate nudges for ledger-known agents even when
+// the daemon has restarted and lost in-memory heartbeat state.
+func (t *MurmurNudgeTracker) KnownAgentIDs() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	seen := make(map[string]struct{}, len(t.firstSeen)+len(t.lastMurmur))
+	for id := range t.firstSeen {
+		seen[id] = struct{}{}
+	}
+	for id := range t.lastMurmur {
+		seen[id] = struct{}{}
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 // RecordNudge records that a nudge was sent to the agent.
 func (t *MurmurNudgeTracker) RecordNudge(agentID string) {
 	t.mu.Lock()


### PR DESCRIPTION
## Summary

Full murmur pipeline hardening across three areas: fast IPC delegation, debuggability, and reliable nudge delivery.

```mermaid
sequenceDiagram
    participant Hook as Claude Code Hook
    participant CLI as ox murmur
    participant IPC as Unix Socket
    participant Daemon as ox daemon
    participant Ledger as Ledger repo

    Hook->>Daemon: Heartbeat (every hook invocation)
    Note over Daemon: tracks agent as active
    Daemon-->>Hook: (nudge whisper queued if overdue)

    CLI->>CLI: validate input (pure, no I/O)
    CLI->>CLI: resolve targetDir, generate UUID
    CLI->>IPC: SendOneWay("murmur", MurmurPayload)
    alt IPC succeeds
        CLI-->>User: "Murmur published: <id>"
        IPC->>Daemon: handleMurmur()
        Daemon->>Ledger: WriteMurmurRaw + git add + git commit
    else daemon unavailable
        CLI-->>User: "Murmur not delivered (daemon unavailable): <id>"
    end
```

## Changes

### IPC delegation (`cmd/ox/murmur.go`, `internal/daemon/`)
- `ox murmur` is now fire-and-forget: CLI passes full murmur JSON over IPC, daemon owns all disk I/O (write + `git add --sparse` + `git commit`) in a background goroutine
- **Honest delivery message**: prints `"Murmur not delivered (daemon unavailable)"` on IPC failure instead of claiming success regardless
- Pure input validation (content, JSON, importance, size) runs before `findProjectRoot()` — test isolation via `t.Chdir(t.TempDir())` works correctly

### `ox murmur status` (`cmd/ox/murmur_status.go`)
- New subcommand: shows per-agent last murmur time and rate-limit state (`ready` / `ready in Xs`)
- Your agent (`SAGEOX_AGENT_ID`) sorted to top and marked ★
- `--json` for scripting
- Reads last 2 hours from ledger — no murmurs published

### Hook heartbeats (`cmd/ox/agent_hook.go`)
- `dispatchPhase` now emits a heartbeat on every hook invocation (`UserPromptSubmit`, `PostToolUse`, `Stop`, etc.)
- Without this, the daemon never sees an agent as active during long sessions that don't call explicit `ox agent` commands — breaking the murmur nudge pipeline entirely
- `KnownAgentIDs()` added to `MurmurNudgeTracker` for future SQLite migration (sageox-wm8)

## Test plan

- [ ] `go test ./cmd/ox -run TestMurmur` — all 19 CLI tests pass
- [ ] `go test ./internal/daemon -run "Murmur|murmur"` — all daemon tests pass
- [ ] `go build ./...` — clean build
- [ ] Manual: `ox murmur status` shows per-agent state after murmurs exist
- [ ] Manual: `ox murmur "test"` with daemon down prints "not delivered" not "published"

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `ox murmur status` command to monitor murmur activity across agents with rate-limit readiness information
  * Supports both JSON and human-readable table output formats
  * Enhanced agent heartbeat tracking for improved activity monitoring
  * Improved error messaging when daemon delivery encounters issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->