### PR TITLE
Add Codecov Test Analytics to scheduled coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,8 +23,11 @@ jobs:
           git config --global user.email "ci@sageox.ai"
           git config --global user.name "CI"
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Test with coverage
-        run: go test -short -race -coverprofile=coverage.out -covermode=atomic ./...
+        run: gotestsum --junitfile junit.xml --format pkgname-and-test-fails -- -short -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage
         if: always()
@@ -34,3 +37,10 @@ jobs:
           flags: ox-cli
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: junit.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Adds Codecov Test Analytics to the existing daily `coverage.yml` workflow. This enables tracking test run times, failure rates, and flaky test detection on Codecov's dashboard.

- Installs `gotestsum` and uses it to generate JUnit XML output alongside coverage data
- Uploads `junit.xml` via `codecov/test-results-action@v1` after the existing coverage upload
- Runs on the same daily schedule — not on every PR — to avoid burning CI minutes given our high PR volume

Co-Authored-By: SageOx <ox@sageox.ai>