### PR TITLE
feat(import): add audio and video MIME type detection

### DIFF
--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -452,6 +452,34 @@ func detectContentType(filename string, content []byte) string {
 		return "image/png"
 	case ".jpg", ".jpeg":
 		return "image/jpeg"
+	// audio formats
+	case ".m4a":
+		return "audio/mp4"
+	case ".mp3":
+		return "audio/mpeg"
+	case ".wav":
+		return "audio/wav"
+	case ".ogg":
+		return "audio/ogg"
+	case ".opus":
+		return "audio/opus"
+	case ".flac":
+		return "audio/flac"
+	case ".aac":
+		return "audio/aac"
+	case ".wma":
+		return "audio/x-ms-wma"
+	case ".webm":
+		return "audio/webm"
+	// video formats
+	case ".mp4":
+		return "video/mp4"
+	case ".mov":
+		return "video/quicktime"
+	case ".mkv":
+		return "video/x-matroska"
+	case ".avi":
+		return "video/x-msvideo"
 	}
 	sniffLen := len(content)
 	if sniffLen > 512 {

--- a/cmd/ox/import_test.go
+++ b/cmd/ox/import_test.go
@@ -31,6 +31,21 @@ func TestDetectContentType(t *testing.T) {
 		{"photo.png", "image/png"},
 		{"photo.jpg", "image/jpeg"},
 		{"photo.jpeg", "image/jpeg"},
+		// audio formats
+		{"recording.m4a", "audio/mp4"},
+		{"recording.mp3", "audio/mpeg"},
+		{"recording.wav", "audio/wav"},
+		{"recording.ogg", "audio/ogg"},
+		{"recording.opus", "audio/opus"},
+		{"recording.flac", "audio/flac"},
+		{"recording.aac", "audio/aac"},
+		{"recording.wma", "audio/x-ms-wma"},
+		{"recording.webm", "audio/webm"},
+		// video formats
+		{"recording.mp4", "video/mp4"},
+		{"recording.mov", "video/quicktime"},
+		{"recording.mkv", "video/x-matroska"},
+		{"recording.avi", "video/x-msvideo"},
 		{"doc.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
 	}
 

--- a/cmd/ox/import_video_test.go
+++ b/cmd/ox/import_video_test.go
@@ -40,10 +40,10 @@ func TestDetectContentType_VideoFormats(t *testing.T) {
 	})
 
 	t.Run("mp4 without valid header", func(t *testing.T) {
-		// without a proper ftyp header, http.DetectContentType sniffs the content;
-		// ASCII text is detected as text/plain, not video/mp4
+		// .mp4 extension now has explicit mapping, so it returns video/mp4
+		// regardless of content bytes
 		got := detectContentType("video.mp4", []byte("not a real video"))
-		assert.NotEqual(t, "video/mp4", got, "plain text should not be detected as video/mp4")
+		assert.Equal(t, "video/mp4", got)
 	})
 
 	t.Run("mov with ftyp header", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add explicit extension-to-MIME mappings for 9 audio formats (`.m4a`, `.mp3`, `.wav`, `.ogg`, `.opus`, `.flac`, `.aac`, `.wma`, `.webm`) and 4 video formats (`.mp4`, `.mov`, `.mkv`, `.avi`) in `detectContentType()`
- Extension mapping now takes priority over content sniffing for these formats, making detection deterministic regardless of file content
- Update video test to reflect that `.mp4` no longer falls through to `http.DetectContentType`

## Test plan

- [x] `go test ./cmd/ox/ -run "TestDetectContentType"` — all pass
- [ ] Verify `ox import` with an audio/video file works end-to-end

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of audio and video format detection, now properly identifying a wider range of audio formats (M4A, MP3, WAV, OGG, Opus, FLAC, AAC, WMA, WebM) and video formats (MP4, MOV, MKV, AVI).

* **Tests**
  * Expanded test coverage for audio and video format detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->