### PR TITLE
feat(agent-worker): auto-detect agent CLI with selector config

### DIFF
--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -158,21 +158,22 @@ Override per-invocation with --html, --text, or --json flags.`,
 	},
 	{
 		Key:         "agent_worker",
-		Description: "Daemon AI coworker spawning",
-		LongDescription: `Controls whether the daemon can spawn AI coworker processes for
-background tasks like session anti-entropy (generating missing
-summaries for orphaned sessions).
+		Description: "Daemon AI coworker for background tasks",
+		LongDescription: `Selects which agent CLI the daemon uses for background tasks like
+session anti-entropy (generating missing summaries for orphaned sessions).
 
-When enabled, the daemon automatically detects incomplete sessions
-and spawns a Claude process to generate summaries, then uploads
-them to the ledger. Rate-limited to 60 invocations/hour, 4 concurrent.
+  auto   — auto-detect from PATH (default). Prefers claude > codex.
+  none   — explicitly disabled. Only lightweight cleanup runs.
+  claude — use Claude Code CLI for background agent work.
+  codex  — use OpenAI Codex CLI for background agent work.
 
-When disabled (default), only lightweight cleanup runs (removing
-ghost sessions with no data). Sessions with recoverable data are
-preserved until this is enabled.`,
+When an agent is available (configured or auto-detected), the daemon
+automatically detects incomplete sessions and spawns the agent to
+generate summaries, then uploads them to the ledger.
+Rate-limited to 60 invocations/hour, 4 concurrent.`,
 		Category:    "Sessions",
-		ValidValues: []string{"on", "off"},
-		Default:     "off",
+		ValidValues: []string{"auto", "none", "claude", "codex"},
+		Default:     "auto",
 		Levels:      []ConfigLevel{ConfigLevelUser},
 	},
 }
@@ -280,11 +281,15 @@ func ResolveConfigValue(key string, projectRoot string) (*ConfigValue, error) {
 		}
 
 	case "agent_worker":
-		if userCfg != nil && userCfg.AgentWorker != nil && userCfg.AgentWorker.Enabled != nil {
-			if *userCfg.AgentWorker.Enabled {
-				cv.UserVal = "on"
-			} else {
-				cv.UserVal = "off"
+		if userCfg != nil && userCfg.AgentWorker != nil {
+			agent := userCfg.AgentWorker.GetAgent()
+			switch agent {
+			case "":
+				// not configured — auto-detect (don't set UserVal, use default)
+			case "none":
+				cv.UserVal = "none"
+			default:
+				cv.UserVal = agent
 			}
 		}
 	}
@@ -391,8 +396,11 @@ func setUserConfig(key, value string) error {
 		cfg.ViewFormat = value
 
 	case "agent_worker":
-		enabled := value == "on"
-		cfg.SetAgentWorkerEnabled(enabled)
+		if value == "auto" {
+			cfg.SetAgentWorkerAgent("") // empty = auto-detect
+		} else {
+			cfg.SetAgentWorkerAgent(value)
+		}
 
 	default:
 		return fmt.Errorf("unknown user setting: %s", key)

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -832,14 +832,21 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		})
 	}
 
-	// Category 11: Updates
+	// Category 11: Agent Worker
+	progress.show("Agent Worker")
+	categories = append(categories, checkCategory{
+		name:   "Agent Worker",
+		checks: []checkResult{checkAgentWorkerBinary()},
+	})
+
+	// Category 12: Updates
 	progress.show("Updates")
 	categories = append(categories, checkCategory{
 		name:   "Updates",
 		checks: []checkResult{checkForUpdates()},
 	})
 
-	// Category 12: SageOx Configuration
+	// Category 13: SageOx Configuration
 	// Endpoint consistency check - always run (doesn't require authentication)
 	progress.show("SageOx Configuration")
 	sageoxConfigChecks := []checkResult{
@@ -850,7 +857,7 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		checks: sageoxConfigChecks,
 	})
 
-	// Category 13: SageOx Service
+	// Category 14: SageOx Service
 	// suppress login-dependent SageOx service checks when not logged in
 	progress.show("SageOx Service")
 	if state.isAuthenticated {
@@ -863,7 +870,7 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 			},
 		})
 
-		// Category 14: Cloud Diagnostics (optional - only shows if cloud returns issues)
+		// Category 15: Cloud Diagnostics (optional - only shows if cloud returns issues)
 		// Cloud doctor detects things the local CLI cannot:
 		// - Pending merge conflicts (same repo registered twice)
 		// - Team invites pending acceptance

--- a/cmd/ox/doctor_agent_worker.go
+++ b/cmd/ox/doctor_agent_worker.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon/agentwork"
+)
+
+// checkAgentWorkerBinary validates that the effective agent CLI is installed and authenticated.
+// Resolves auto-detection: if unconfigured, reports what would be auto-detected.
+func checkAgentWorkerBinary() checkResult {
+	userCfg, err := config.LoadUserConfig()
+	if err != nil {
+		return SkippedCheck("agent worker binary", "config unavailable", "")
+	}
+
+	raw := userCfg.GetAgentWorkerAgent()
+
+	// explicitly disabled
+	if raw == "none" {
+		return SkippedCheck("agent worker binary", "disabled",
+			"Enable with: ox config set agent_worker claude")
+	}
+
+	resolved := agentwork.ResolveAgent(raw)
+
+	// unconfigured and nothing usable auto-detected
+	if resolved == "none" {
+		// check if anything is installed but not authenticated
+		for _, agent := range []string{"claude", "codex"} {
+			u := agentwork.CheckAgentUsability(agent)
+			if u.Installed && !u.Authenticated {
+				return WarningCheck("agent worker binary",
+					fmt.Sprintf("%s installed but not authenticated", agent),
+					fmt.Sprintf("Run '%s login' to enable automatic session finalization", agent))
+			}
+		}
+		return InfoCheck("agent worker binary", "no agent CLI found",
+			"Install claude or codex to enable automatic session finalization")
+	}
+
+	// verify usability of the resolved agent
+	u := agentwork.CheckAgentUsability(resolved)
+	if !u.Installed {
+		return WarningCheck("agent worker binary",
+			fmt.Sprintf("%s not found", resolved),
+			fmt.Sprintf("agent_worker is set to %q but the %s CLI is not in PATH", resolved, resolved))
+	}
+
+	if !u.Authenticated {
+		return WarningCheck("agent worker binary",
+			fmt.Sprintf("%s not authenticated", resolved),
+			fmt.Sprintf("Run '%s login' — the daemon can't use %s without authentication", resolved, resolved))
+	}
+
+	source := "configured"
+	if raw == "" {
+		source = "auto-detected"
+	}
+	return PassedCheck("agent worker binary",
+		fmt.Sprintf("%s (%s, %s)", resolved, source, u.AuthDetail))
+}

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -497,4 +497,17 @@ func init() {
 			return convertDoctorResult(result)
 		},
 	})
+
+	// ============================================================
+	// Agent Worker checks
+	// ============================================================
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugAgentWorkerBinary,
+		Name:        "agent worker binary",
+		Category:    "Agent Worker",
+		FixLevel:    FixLevelCheckOnly,
+		Description: "Verifies configured agent CLI binary is available in PATH",
+		Run:         func(_ bool) checkResult { return checkAgentWorkerBinary() },
+	})
 }

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -168,6 +168,9 @@ const (
 	// Distillation checks
 	CheckSlugGuidanceFiles = "guidance-files"
 
+	// Agent Worker checks
+	CheckSlugAgentWorkerBinary = "agent-worker-binary"
+
 	// Code Search checks
 	CheckSlugCodeIndex = "code-index"
 )

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/daemon/agentwork"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/gitutil"
@@ -970,6 +971,9 @@ func renderDaemonSyncSection(ds *daemon.StatusData, syncHistory []daemon.SyncEve
 		return b.String()
 	}
 
+	// agent worker status
+	b.WriteString(renderAgentWorkerLine())
+
 	// sync stats - show warning indicator when zero syncs but repos are configured
 	b.WriteString(statusLabelStyle.Render("Total syncs"))
 	if bootstrapping {
@@ -1136,6 +1140,79 @@ func renderDaemonSyncSection(ds *daemon.StatusData, syncHistory []daemon.SyncEve
 	}
 
 	return b.String()
+}
+
+// renderAgentWorkerLine renders the agent worker status as a single labeled line.
+func renderAgentWorkerLine() string {
+	var b strings.Builder
+
+	userCfg, _ := config.LoadUserConfig()
+	raw := ""
+	if userCfg != nil {
+		raw = userCfg.GetAgentWorkerAgent()
+	}
+
+	if raw == "none" {
+		b.WriteString(statusLabelStyle.Render("Summarizer"))
+		b.WriteString(statusMutedStyle.Render("disabled"))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	resolved := agentwork.ResolveAgent(raw)
+	if resolved == "none" {
+		b.WriteString(statusLabelStyle.Render("Summarizer"))
+		b.WriteString(statusMutedStyle.Render("none (no agent CLI found)"))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	u := agentwork.CheckAgentUsability(resolved)
+
+	b.WriteString(statusLabelStyle.Render("Summarizer"))
+	if !u.Authenticated {
+		b.WriteString(formatValue(fmt.Sprintf("%s (not authenticated)", resolved), "warning"))
+	} else {
+		source := "auto"
+		if raw != "" {
+			source = "configured"
+		}
+		b.WriteString(statusValueStyle.Render(resolved))
+		b.WriteString(statusMutedStyle.Render(fmt.Sprintf(" (%s)", source)))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// buildAgentWorkerJSON creates the agent worker JSON for ox status --json.
+func buildAgentWorkerJSON() *status.AgentWorkerJSON {
+	userCfg, _ := config.LoadUserConfig()
+	raw := ""
+	if userCfg != nil {
+		raw = userCfg.GetAgentWorkerAgent()
+	}
+
+	if raw == "none" {
+		return &status.AgentWorkerJSON{Agent: "none", Source: "disabled"}
+	}
+
+	resolved := agentwork.ResolveAgent(raw)
+	source := "auto"
+	if raw != "" {
+		source = "configured"
+	}
+
+	if resolved == "none" {
+		return &status.AgentWorkerJSON{Agent: "none", Source: source}
+	}
+
+	u := agentwork.CheckAgentUsability(resolved)
+	return &status.AgentWorkerJSON{
+		Agent:         resolved,
+		Source:        source,
+		Authenticated: u.Authenticated,
+		AuthDetail:    u.AuthDetail,
+	}
 }
 
 // renderAICoworkersSection renders a one-line summary of active AI coworkers.
@@ -1521,6 +1598,9 @@ func buildStatusJSON(authenticated bool, authErr error, token *auth.StoredToken,
 			output.Daemon.SyncsLastHour = daemonStatus.SyncsLastHour
 			output.Daemon.LastError = daemonStatus.LastError
 		}
+		// agent worker status
+		output.Daemon.AgentWorker = buildAgentWorkerJSON()
+
 		if daemonClient != nil {
 			// AI coworkers with context stats
 			if instances, err := daemonClient.Instances(); err == nil && len(instances) > 0 {

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -109,17 +109,20 @@ func (c *SessionsConfig) GetMode() string {
 	return "none"
 }
 
-// AllowedAgentTypes is the set of valid AgentWorkerConfig.AgentType values.
-var AllowedAgentTypes = []string{"claude"}
+// AllowedAgentTypes is the set of valid AgentWorkerConfig.Agent values.
+var AllowedAgentTypes = []string{"none", "claude", "codex"}
 
 // AgentWorkerConfig controls daemon-spawned AI coworker invocations.
 type AgentWorkerConfig struct {
-	// Enabled controls whether the daemon can spawn AI coworker processes.
-	// Default: false
+	// Agent selects which agent CLI the daemon uses for background work.
+	// "none" disables agent spawning, "claude" or "codex" selects that CLI.
+	// Default: "none"
+	Agent string `yaml:"agent,omitempty"`
+
+	// Deprecated: Use Agent instead. Kept for backward compatibility.
 	Enabled *bool `yaml:"enabled,omitempty"`
 
-	// AgentType is the agent CLI to use. Validated against AllowedAgentTypes.
-	// Default: "claude"
+	// Deprecated: Use Agent instead. Kept for backward compatibility.
 	AgentType string `yaml:"agent_type,omitempty"`
 
 	// MaxInvocationsPerHour rate-limits agent spawning per daemon.
@@ -146,20 +149,49 @@ type AgentWorkerConfig struct {
 	QualityDiscardThreshold *float64 `yaml:"quality_discard_threshold,omitempty"`
 }
 
-// IsEnabled returns true if agent worker spawning is enabled (default: false)
-func (c *AgentWorkerConfig) IsEnabled() bool {
-	if c == nil || c.Enabled == nil {
-		return false
+// GetAgent returns the raw configured agent selector.
+// Returns "" when nothing is configured (caller should auto-detect),
+// "none" (explicitly disabled), "claude", or "codex".
+// Handles backward compat: Enabled=true with no Agent field maps to "claude".
+// For a fully resolved value (with auto-detection), use agentwork.ResolveAgent().
+func (c *AgentWorkerConfig) GetAgent() string {
+	if c == nil {
+		return ""
 	}
-	return *c.Enabled
+	// new field takes precedence
+	if c.Agent != "" {
+		return c.Agent
+	}
+	// backward compat: Enabled bool + AgentType string
+	if c.Enabled != nil {
+		if *c.Enabled {
+			if c.AgentType != "" {
+				return c.AgentType
+			}
+			return "claude"
+		}
+		return "none" // explicitly disabled via legacy field
+	}
+	return "" // not configured — auto-detect
 }
 
-// GetAgentType returns the configured agent type (default: "claude")
+// IsEnabled returns true if agent worker spawning is enabled.
+// Returns false for "none" and "" (unconfigured). Callers that want
+// auto-detection should use agentwork.ResolveAgent() instead.
+func (c *AgentWorkerConfig) IsEnabled() bool {
+	agent := c.GetAgent()
+	return agent != "none" && agent != ""
+}
+
+// GetAgentType returns the configured agent type (default: "claude").
+// Returns "claude" for unset or disabled states. For callers that need
+// auto-detection, use agentwork.ResolveAgent() instead.
 func (c *AgentWorkerConfig) GetAgentType() string {
-	if c == nil || c.AgentType == "" {
+	agent := c.GetAgent()
+	if agent == "" || agent == "none" {
 		return "claude"
 	}
-	return c.AgentType
+	return agent
 }
 
 // GetMaxInvocationsPerHour returns the rate limit (default: 60)
@@ -207,14 +239,23 @@ func (c *AgentWorkerConfig) GetQualityDiscardThreshold() float64 {
 }
 
 // Validate checks the config for invalid values.
-// Returns an error if agent_type is not in AllowedAgentTypes or limits are non-positive.
+// Returns an error if agent is not in AllowedAgentTypes or limits are non-positive.
 func (c *AgentWorkerConfig) Validate() error {
 	if c == nil {
 		return nil
 	}
 
-	if c.AgentType != "" && !slices.Contains(AllowedAgentTypes, c.AgentType) {
-		return fmt.Errorf("unknown agent_type %q, allowed: %v", c.AgentType, AllowedAgentTypes)
+	if c.Agent != "" && !slices.Contains(AllowedAgentTypes, c.Agent) {
+		return fmt.Errorf("unknown agent %q, allowed: %v", c.Agent, AllowedAgentTypes)
+	}
+
+	// backward compat: validate legacy AgentType field too
+	if c.Agent == "" && c.AgentType != "" {
+		// legacy field only allowed non-"none" agent types
+		validLegacy := []string{"claude", "codex"}
+		if !slices.Contains(validLegacy, c.AgentType) {
+			return fmt.Errorf("unknown agent_type %q, allowed: %v", c.AgentType, validLegacy)
+		}
 	}
 
 	if c.MaxInvocationsPerHour != nil && *c.MaxInvocationsPerHour < 1 {
@@ -236,13 +277,19 @@ func (c *AgentWorkerConfig) WithDefaults() *AgentWorkerConfig {
 		*out = *c
 	}
 
-	if out.Enabled == nil {
-		f := false
-		out.Enabled = &f
+	// migrate legacy fields to new Agent field (only if legacy fields are set)
+	if out.Agent == "" && out.Enabled != nil {
+		if *out.Enabled {
+			if out.AgentType != "" {
+				out.Agent = out.AgentType
+			} else {
+				out.Agent = "claude"
+			}
+		} else {
+			out.Agent = "none"
+		}
 	}
-	if out.AgentType == "" {
-		out.AgentType = "claude"
-	}
+	// Agent="" with no legacy fields means "auto-detect" — don't override
 	if out.MaxInvocationsPerHour == nil {
 		v := 60
 		out.MaxInvocationsPerHour = &v
@@ -400,12 +447,32 @@ func (c *UserConfig) IsAgentWorkerEnabled() bool {
 	return c.AgentWorker.IsEnabled()
 }
 
-// SetAgentWorkerEnabled sets the agent worker enabled preference.
-func (c *UserConfig) SetAgentWorkerEnabled(enabled bool) {
+// GetAgentWorkerAgent returns the raw configured agent selector.
+// Returns "" (unconfigured/auto-detect), "none", "claude", or "codex".
+func (c *UserConfig) GetAgentWorkerAgent() string {
+	if c.AgentWorker == nil {
+		return ""
+	}
+	return c.AgentWorker.GetAgent()
+}
+
+// SetAgentWorkerAgent sets the agent worker agent selector and clears deprecated fields.
+func (c *UserConfig) SetAgentWorkerAgent(agent string) {
 	if c.AgentWorker == nil {
 		c.AgentWorker = &AgentWorkerConfig{}
 	}
-	c.AgentWorker.Enabled = &enabled
+	c.AgentWorker.Agent = agent
+	c.AgentWorker.Enabled = nil
+	c.AgentWorker.AgentType = ""
+}
+
+// Deprecated: Use SetAgentWorkerAgent instead.
+func (c *UserConfig) SetAgentWorkerEnabled(enabled bool) {
+	if enabled {
+		c.SetAgentWorkerAgent("claude")
+	} else {
+		c.SetAgentWorkerAgent("none")
+	}
 }
 
 // GetViewFormat returns the preferred session view format.

--- a/internal/daemon/agentwork/agent_auth.go
+++ b/internal/daemon/agentwork/agent_auth.go
@@ -1,0 +1,118 @@
+package agentwork
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// AgentUsability describes whether an agent CLI is installed and authenticated.
+type AgentUsability struct {
+	Installed     bool
+	Authenticated bool
+	AuthDetail    string // human-readable auth status (e.g. "OAuth", "API key", "not logged in")
+}
+
+// CheckAgentUsability probes whether the given agent CLI is installed and authenticated.
+// Designed to be fast (< 2s) for use in doctor checks and auto-detection.
+func CheckAgentUsability(agent string) AgentUsability {
+	switch agent {
+	case "claude":
+		return checkClaudeUsability()
+	case "codex":
+		return checkCodexUsability()
+	default:
+		return AgentUsability{}
+	}
+}
+
+// checkClaudeUsability checks if claude CLI is installed and has valid auth.
+// Checks: ANTHROPIC_API_KEY env var, then ~/.claude.json for oauthAccount.
+func checkClaudeUsability() AgentUsability {
+	result := AgentUsability{}
+
+	if _, err := exec.LookPath("claude"); err != nil {
+		return result
+	}
+	result.Installed = true
+
+	// check API key env var first (fastest)
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		result.Authenticated = true
+		result.AuthDetail = "API key"
+		return result
+	}
+
+	// check OAuth in ~/.claude.json
+	home, err := os.UserHomeDir()
+	if err != nil {
+		result.AuthDetail = "unable to check"
+		return result
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	if err != nil {
+		result.AuthDetail = "not logged in"
+		return result
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		result.AuthDetail = "config unreadable"
+		return result
+	}
+
+	if _, ok := cfg["oauthAccount"]; ok {
+		result.Authenticated = true
+		result.AuthDetail = "OAuth"
+		return result
+	}
+
+	result.AuthDetail = "not logged in"
+	return result
+}
+
+// checkCodexUsability checks if codex CLI is installed and has valid auth.
+// Runs `codex login status` which is designed to be fast.
+func checkCodexUsability() AgentUsability {
+	result := AgentUsability{}
+
+	codexPath, err := exec.LookPath("codex")
+	if err != nil {
+		return result
+	}
+	result.Installed = true
+
+	// check API key env var first
+	if os.Getenv("OPENAI_API_KEY") != "" {
+		result.Authenticated = true
+		result.AuthDetail = "API key"
+		return result
+	}
+
+	// run `codex login status` with a short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, codexPath, "login", "status")
+	out, err := cmd.Output()
+	if err != nil {
+		result.AuthDetail = "not logged in"
+		return result
+	}
+
+	output := strings.TrimSpace(string(out))
+	if strings.Contains(strings.ToLower(output), "logged in") {
+		result.Authenticated = true
+		// extract auth method from output (e.g. "Logged in using ChatGPT")
+		result.AuthDetail = output
+		return result
+	}
+
+	result.AuthDetail = "not logged in"
+	return result
+}

--- a/internal/daemon/agentwork/codex_runner.go
+++ b/internal/daemon/agentwork/codex_runner.go
@@ -1,0 +1,138 @@
+package agentwork
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// CodexRunner implements Runner using the OpenAI Codex CLI.
+// It spawns Codex in non-interactive mode with --full-auto.
+// CodexRunner is safe for concurrent use — each Run() call is independent.
+type CodexRunner struct {
+	binaryPath string
+	logger     *slog.Logger
+}
+
+// NewCodexRunner creates a CodexRunner by resolving the `codex` binary.
+// If the binary is not found, the runner is still created but Available() returns false.
+func NewCodexRunner(logger *slog.Logger) *CodexRunner {
+	path, err := exec.LookPath("codex")
+	if err != nil {
+		logger.Debug("codex binary not found in PATH", "error", err)
+		path = ""
+	}
+	return &CodexRunner{
+		binaryPath: path,
+		logger:     logger,
+	}
+}
+
+// Available reports whether the codex binary exists on disk.
+func (r *CodexRunner) Available() bool {
+	if r.binaryPath == "" {
+		return false
+	}
+	_, err := os.Stat(r.binaryPath)
+	return err == nil
+}
+
+// Run executes a codex invocation with the given request.
+func (r *CodexRunner) Run(ctx context.Context, req RunRequest) (*RunResult, error) {
+	if !r.Available() {
+		return nil, fmt.Errorf("codex binary not available")
+	}
+
+	timeout := defaultTimeout
+	if req.TimeoutOverride > 0 {
+		timeout = req.TimeoutOverride
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := []string{"--full-auto", "--quiet", "-p", req.Prompt}
+
+	cmd := exec.CommandContext(ctx, r.binaryPath, args...)
+	if req.WorkDir != "" {
+		cmd.Dir = req.WorkDir
+	}
+	setProcAttr(cmd)
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	start := time.Now()
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start codex: %w", err)
+	}
+
+	r.logger.Debug("codex process started", "pid", cmd.Process.Pid)
+
+	// read stderr in background
+	var stderrBuf []byte
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		stderrBuf, _ = io.ReadAll(io.LimitReader(stderrPipe, 64*1024))
+	}()
+
+	// read stdout in background
+	outputCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdoutPipe)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		var lines []byte
+		for scanner.Scan() {
+			if len(lines) > 0 {
+				lines = append(lines, '\n')
+			}
+			lines = append(lines, scanner.Bytes()...)
+		}
+		outputCh <- string(lines)
+	}()
+
+	waitErr := cmd.Wait()
+	elapsed := time.Since(start)
+
+	<-stderrDone
+	output := <-outputCh
+
+	if len(stderrBuf) > 0 {
+		r.logger.Debug("codex stderr", "output", string(stderrBuf))
+	}
+
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("codex timed out after %s: %w", timeout, ctx.Err())
+	}
+
+	exitCode := 0
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+			r.logger.Warn("codex exited with non-zero status", "exit_code", exitCode, "stderr", string(stderrBuf))
+		} else {
+			return nil, fmt.Errorf("wait codex: %w", waitErr)
+		}
+	}
+
+	return &RunResult{
+		Output:   output,
+		Duration: elapsed,
+		ExitCode: exitCode,
+	}, nil
+}

--- a/internal/daemon/agentwork/manager.go
+++ b/internal/daemon/agentwork/manager.go
@@ -214,14 +214,31 @@ func (m *Manager) Start(ctx context.Context) {
 	}
 }
 
+// isEffectivelyEnabled returns true if the agent worker should run.
+// Resolves auto-detection: unconfigured ("") checks PATH for available agents.
+func isEffectivelyEnabled(cfg *config.AgentWorkerConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	return ResolveAgent(cfg.GetAgent()) != "none"
+}
+
 // isHandlerEnabled checks whether a handler's work type is enabled in config.
+// Uses resolved agent state (auto-detection) rather than raw config.
 func isHandlerEnabled(cfg *config.AgentWorkerConfig, handlerType string) bool {
+	if !isEffectivelyEnabled(cfg) {
+		return false
+	}
 	switch handlerType {
 	case "session-finalize":
-		return cfg.IsSessionFinalizeEnabled()
+		// SessionFinalize defaults to true when agent worker is enabled.
+		// Only disabled if explicitly set to false.
+		if cfg != nil && cfg.SessionFinalize != nil {
+			return *cfg.SessionFinalize
+		}
+		return true
 	default:
-		// unknown handler types default to enabled (gated by master switch)
-		return cfg.IsEnabled()
+		return true
 	}
 }
 
@@ -235,7 +252,7 @@ func (m *Manager) detectAndEnqueue() {
 	m.runSessionCleanup()
 
 	cfg := m.configLoader()
-	if cfg == nil || !cfg.IsEnabled() {
+	if cfg == nil || !isEffectivelyEnabled(cfg) {
 		return
 	}
 
@@ -308,7 +325,7 @@ func (m *Manager) ForceDetect() int {
 	m.runSessionCleanup()
 
 	cfg := m.configLoader()
-	if cfg == nil || !cfg.IsEnabled() {
+	if cfg == nil || !isEffectivelyEnabled(cfg) {
 		return 0
 	}
 
@@ -359,7 +376,7 @@ func (m *Manager) ForceDetect() int {
 // processQueue drains the queue, respecting config, rate limits, and concurrency.
 func (m *Manager) processQueue(ctx context.Context) {
 	cfg := m.configLoader()
-	if cfg == nil || !cfg.IsEnabled() {
+	if cfg == nil || !isEffectivelyEnabled(cfg) {
 		return
 	}
 
@@ -586,10 +603,10 @@ func (m *Manager) recordFailure(item *WorkItem, startedAt time.Time, exitCode in
 // Status returns a point-in-time snapshot of the manager for IPC status responses.
 func (m *Manager) Status() AgentWorkStatus {
 	cfg := m.configLoader()
-	enabled := cfg != nil && cfg.IsEnabled()
-	agentType := "claude"
+	enabled := cfg != nil && isEffectivelyEnabled(cfg)
+	agentType := "none"
 	if cfg != nil {
-		agentType = cfg.GetAgentType()
+		agentType = ResolveAgent(cfg.GetAgent())
 	}
 
 	// read these outside the lock to avoid holding mu during syscalls

--- a/internal/daemon/agentwork/runner_factory.go
+++ b/internal/daemon/agentwork/runner_factory.go
@@ -1,0 +1,36 @@
+package agentwork
+
+import "log/slog"
+
+// agentPriority defines auto-detection order: claude preferred over codex.
+var agentPriority = []string{"claude", "codex"}
+
+// ResolveAgent resolves the effective agent from a config value.
+// If configured is "" (unconfigured), auto-detects by checking which agent CLIs
+// are installed AND authenticated, in priority order: claude > codex.
+// Returns "none" if no usable agent found.
+// If configured is a specific value ("none", "claude", "codex"), returns it as-is.
+func ResolveAgent(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	for _, agent := range agentPriority {
+		u := CheckAgentUsability(agent)
+		if u.Installed && u.Authenticated {
+			return agent
+		}
+	}
+	return "none"
+}
+
+// NewRunner creates a Runner for the given agent type.
+// Returns a ClaudeRunner for "claude" (or unknown/fallback), CodexRunner for "codex".
+// The caller should check Available() before invoking Run().
+func NewRunner(agentType string, logger *slog.Logger) Runner {
+	switch agentType {
+	case "codex":
+		return NewCodexRunner(logger)
+	default:
+		return NewClaudeRunner(logger)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -690,7 +690,6 @@ func (d *Daemon) initComponents() time.Duration {
 	// agent work manager
 	if d.config.LedgerPath != "" {
 		agentWorkSignal := make(chan struct{}, 1)
-		runner := agentwork.NewClaudeRunner(d.logger)
 		configLoader := func() *config.AgentWorkerConfig {
 			cfg, err := config.LoadUserConfig()
 			if err != nil {
@@ -703,6 +702,9 @@ func (d *Daemon) initComponents() time.Duration {
 			}
 			return awCfg
 		}
+		initialCfg := configLoader()
+		resolved := agentwork.ResolveAgent(initialCfg.GetAgent())
+		runner := agentwork.NewRunner(resolved, d.logger)
 		d.agentWorker = agentwork.NewManager(runner, d.logger, configLoader, agentWorkSignal, d.config.LedgerPath)
 		sfh := agentwork.NewSessionFinalizeHandler(d.logger)
 		sfh.SetPIDLookup(d.heartbeat.GetAgentPID)

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -95,12 +95,21 @@ type TeamContextJSON struct {
 
 // DaemonJSON represents daemon info in JSON output.
 type DaemonJSON struct {
-	Running       bool   `json:"running"`
-	Pid           int    `json:"pid,omitempty"`
-	UptimeSeconds int64  `json:"uptime_seconds,omitempty"`
-	TotalSyncs    int    `json:"total_syncs,omitempty"`
-	SyncsLastHour int    `json:"syncs_last_hour,omitempty"`
-	LastError     string `json:"last_error,omitempty"`
+	Running       bool             `json:"running"`
+	Pid           int              `json:"pid,omitempty"`
+	UptimeSeconds int64            `json:"uptime_seconds,omitempty"`
+	TotalSyncs    int              `json:"total_syncs,omitempty"`
+	SyncsLastHour int              `json:"syncs_last_hour,omitempty"`
+	LastError     string           `json:"last_error,omitempty"`
+	AgentWorker   *AgentWorkerJSON `json:"agent_worker,omitempty"`
+}
+
+// AgentWorkerJSON represents the agent worker status in JSON output.
+type AgentWorkerJSON struct {
+	Agent         string `json:"agent"`         // resolved agent: "claude", "codex", or "none"
+	Source        string `json:"source"`        // "auto", "configured", or "disabled"
+	Authenticated bool   `json:"authenticated"`
+	AuthDetail    string `json:"auth_detail,omitempty"`
 }
 
 // GitRepoStatus holds information about a git repository's status.


### PR DESCRIPTION
## Summary

Replaces the `agent_worker.enabled` boolean + `agent_type` string config with a single `agent` selector field (`auto`/`none`/`claude`/`codex`). Auto-detection probes PATH in priority order (claude > codex), checking both installation and authentication status. Adds a codex runner, runner factory, `ox doctor` check for agent CLI usability, and a "Summarizer" line in `ox status`.

- **Config**: `ox config set agent_worker auto|none|claude|codex` — backward compatible with old `enabled: true` YAML
- **Auto-detect**: When unconfigured, finds the first installed+authenticated agent CLI (claude preferred)
- **Auth checks**: Validates claude OAuth/API key and codex login status before auto-selecting
- **Doctor**: New `agent-worker-binary` check warns when configured agent is missing or unauthenticated
- **Status**: New "Summarizer" line shows resolved agent with source (auto/configured) and auth detail

```mermaid
graph LR
    A[agent_worker config] -->|"auto (default)"| B{Probe PATH}
    A -->|none| C[Disabled]
    A -->|claude/codex| D[Use specified]
    B -->|claude installed+auth| E[Use claude]
    B -->|codex installed+auth| F[Use codex]
    B -->|nothing found| C
```

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — 10970 tests pass
- [ ] Verify `ox config set agent_worker codex` writes correct YAML
- [ ] Verify `ox doctor` warns when agent binary missing/unauthenticated
- [ ] Verify `ox status` shows Summarizer line

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent worker now supports multiple agent types (Claude, Codex) with auto-detection capabilities.
  * Added diagnostic check to validate agent worker installation and authentication status.
  * Status output now displays agent worker configuration and availability information.

* **Configuration Changes**
  * Agent worker setting changed from on/off toggle to agent selection: auto, none, claude, or codex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->