### PR TITLE
fix(pat-liveness): suppress system credential helpers during probe

### DIFF
--- a/cmd/ox/doctor_pat_liveness.go
+++ b/cmd/ox/doctor_pat_liveness.go
@@ -110,6 +110,12 @@ func attemptPATAutoRepair(ep string) bool {
 		return false
 	}
 
+	// clear any stale credential helper entry (osxkeychain, libsecret, wincred)
+	// that could preempt the fresh token in future git operations
+	if creds, err := gitserver.LoadCredentialsForEndpoint(ep); err == nil && creds != nil && creds.ServerURL != "" {
+		gitserver.ClearCredentialHelperEntry(creds.ServerURL)
+	}
+
 	// update PAT in existing remote URLs
 	refreshExistingRemotes(ep)
 

--- a/cmd/ox/login.go
+++ b/cmd/ox/login.go
@@ -482,9 +482,16 @@ func fetchGitCredentialsWithRetry(client *api.RepoClient) error {
 	return lastErr
 }
 
-// refreshExistingRemotes updates PATs in all known ledger/team-context remote URLs.
+// refreshExistingRemotes updates PATs in all known ledger/team-context remote URLs
+// and evicts any stale credential helper entry for the git server.
 // Called after login to ensure existing repos use the new credentials.
 func refreshExistingRemotes(ep string) {
+	// evict stale osxkeychain/libsecret/wincred entries for the git server so
+	// they don't silently override the fresh token in future git operations
+	if creds, err := gitserver.LoadCredentialsForEndpoint(ep); err == nil && creds != nil && creds.ServerURL != "" {
+		gitserver.ClearCredentialHelperEntry(creds.ServerURL)
+	}
+
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
 		return

--- a/internal/gitserver/pat_liveness.go
+++ b/internal/gitserver/pat_liveness.go
@@ -136,6 +136,44 @@ func buildProbeURL(repoURL string) (string, error) {
 	return u.String(), nil
 }
 
+// ClearCredentialHelperEntry evicts any stored credential for the given git
+// server from all configured credential helpers (osxkeychain, libsecret,
+// wincred, etc.) using `git credential reject`. This prevents stale entries
+// from a previous install from silently overriding GIT_ASKPASS in future
+// git operations.
+//
+// Failures are logged but not returned — this is best-effort cleanup.
+// serverURL should be the git server base URL (e.g. "https://git.sageox.ai").
+func ClearCredentialHelperEntry(serverURL string) {
+	u, err := url.Parse(serverURL)
+	if err != nil || u.Host == "" {
+		slog.Debug("credential helper clear: skipped", "reason", "invalid server URL", "url", serverURL)
+		return
+	}
+
+	protocol := u.Scheme
+	if protocol == "" {
+		protocol = "https"
+	}
+	host := u.Hostname()
+
+	// `git credential reject` reads protocol/host/username from stdin and
+	// instructs each configured helper to delete the matching entry.
+	input := fmt.Sprintf("protocol=%s\nhost=%s\nusername=oauth2\n\n", protocol, host)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "credential", "reject")
+	cmd.Stdin = strings.NewReader(input)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		slog.Debug("credential helper clear: git credential reject failed",
+			"host", host, "error", err, "output", strings.TrimSpace(string(out)))
+	} else {
+		slog.Debug("credential helper clear: evicted stale entry", "host", host)
+	}
+}
+
 // writeAskpassScript creates a temporary script that echoes the token.
 // Git calls this script with a prompt like "Password for ..." and expects
 // the credential on stdout. Returns the path to the script.

--- a/internal/gitserver/pat_liveness_test.go
+++ b/internal/gitserver/pat_liveness_test.go
@@ -208,6 +208,45 @@ exit 0
 	assert.True(t, result.Valid, "should succeed when credential helper is suppressed; got reason: %s", result.Reason)
 }
 
+func TestClearCredentialHelperEntry(t *testing.T) {
+	t.Run("no-op on invalid URL", func(t *testing.T) {
+		// should not panic or error
+		ClearCredentialHelperEntry("")
+		ClearCredentialHelperEntry("://not-a-url")
+	})
+
+	t.Run("runs git credential reject for valid URL", func(t *testing.T) {
+		// inject a fake git that records whether it was called with "credential reject"
+		called := false
+		fakeGit, err := os.CreateTemp("", "fake-git-cred-*")
+		require.NoError(t, err)
+		defer os.Remove(fakeGit.Name())
+
+		recordFile := t.TempDir() + "/called"
+		_, err = fakeGit.WriteString("#!/bin/sh\n" +
+			"if [ \"$1\" = 'credential' ] && [ \"$2\" = 'reject' ]; then\n" +
+			"  touch " + recordFile + "\n" +
+			"fi\n" +
+			"exit 0\n")
+		require.NoError(t, err)
+		fakeGit.Close()
+		require.NoError(t, os.Chmod(fakeGit.Name(), 0700))
+
+		fakeDir := t.TempDir()
+		require.NoError(t, os.Symlink(fakeGit.Name(), fakeDir+"/git"))
+		t.Setenv("PATH", fakeDir+":"+os.Getenv("PATH"))
+
+		ClearCredentialHelperEntry("https://git.sageox.ai")
+
+		if _, err := os.Stat(recordFile); os.IsNotExist(err) {
+			called = false
+		} else {
+			called = true
+		}
+		assert.True(t, called, "expected git credential reject to be called")
+	})
+}
+
 func TestWriteAskpassScript(t *testing.T) {
 	path, err := writeAskpassScript("test-token-123")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- **Bug**: \`ox status\` showed \`✗ PAT rejected by server\` as a false positive even when credentials were valid and the daemon was syncing fine
- **Root cause**: OS credential helpers (osxkeychain on macOS, libsecret on Linux, wincred on Windows) preempt \`GIT_ASKPASS\` in git's credential resolution chain. Any user with a prior ox install has a stored entry for \`git.sageox.ai\` in their system keychain — git uses that stale entry before \`GIT_ASKPASS\` is ever consulted, returning 401.
- **Fix**: Three coordinated changes that fully self-heal for all existing users

## Credential Resolution Order (why this affects everyone)

\`\`\`
git ls-remote URL
  1. Credentials embedded in URL  →  bypass everything   ← daemon uses this (unaffected)
  2. Credential helpers           →  if found, ASKPASS is never called
       macOS:   osxkeychain  (Homebrew system git default)
       Linux:   libsecret / gnome-keyring
       Windows: credential manager
  3. GIT_ASKPASS                  →  what we want        ← was being skipped
  4. Terminal prompt              →  blocked by GIT_TERMINAL_PROMPT=0
\`\`\`

## Changes

### 1. Probe fix — `internal/gitserver/pat_liveness.go`
Set \`GIT_CONFIG_COUNT\` env vars on the \`git ls-remote\` subprocess to override \`credential.helper\` to empty, making \`GIT_ASKPASS\` the sole credential source. Fixes the false positive immediately on upgrade.

### 2. Self-healing cleanup — \`ClearCredentialHelperEntry(serverURL)\`
New function that runs \`git credential reject\` to evict any stale entry from whatever credential helper is configured. Cross-platform: works with osxkeychain, libsecret, wincred, and custom helpers.

### 3. Wired into both repair paths
- **\`ox doctor --fix\`** (`doctor_pat_liveness.go`): calls \`ClearCredentialHelperEntry\` after refreshing credentials
- **\`ox login\`** (`login.go`): calls \`ClearCredentialHelperEntry\` in \`refreshExistingRemotes\`, so the stale entry is evicted on every re-login

## Self-healing for existing users

| User action | Result |
|-------------|--------|
| Upgrade ox (no other action) | \`ox status\` no longer shows false positive |
| Run \`ox doctor --fix\` | Credentials refreshed + stale keychain entry evicted |
| Run \`ox login\` | Credentials refreshed + stale keychain entry evicted |

## Tests

- **Regression test** (`TestValidatePATLiveness_CredentialHelperSuppressed`): fake \`git\` binary exits 128 with "401 Unauthorized" unless \`GIT_CONFIG_COUNT\` is set — fails on old code, passes with fix
- **Unit test** (`TestClearCredentialHelperEntry`): fake \`git\` records whether \`credential reject\` was invoked

## Test Plan

- [x] \`go test ./internal/gitserver/ ./cmd/ox/\` — all pass
- [x] Regression test fails on old code, passes with fix
- [ ] Verify \`ox status\` shows \`✓ valid\` after upgrade on a machine with stale keychain entry

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PAT validation to prevent system credential helpers from replacing fresh tokens during verification.

* **New Features**
  * When refreshing or saving tokens, the tool now attempts to clear lingering Git credential-helper entries so updated tokens are used.

* **Tests**
  * Added tests simulating credential-helper interference and validating suppression and credential-clear behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->