### PR TITLE
perf(codedb): indexing pipeline optimization pass + dirty overlay GC

### DIFF
--- a/internal/codedb/index/dirty_test.go
+++ b/internal/codedb/index/dirty_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -154,120 +155,120 @@ func TestBuildDirtyIndex_WritesManifest(t *testing.T) {
 	assert.Equal(t, dir, string(raw), "manifest must contain the worktree path verbatim")
 }
 
-// TestGCDirtyIndexes_EmptyDir verifies GC returns 0 when the dirty dir is absent.
-func TestGCDirtyIndexes_EmptyDir(t *testing.T) {
+func TestGCDirtyIndexes(t *testing.T) {
 	t.Parallel()
-	codedbDir := t.TempDir()
-	removed, err := GCDirtyIndexes(codedbDir)
-	require.NoError(t, err)
-	assert.Equal(t, 0, removed)
-}
 
-// TestGCDirtyIndexes_KeepsLiveOverlay verifies GC does NOT remove an overlay
-// whose worktree still exists on disk.
-func TestGCDirtyIndexes_KeepsLiveOverlay(t *testing.T) {
-	t.Parallel()
-	dir, _ := initGitRepo(t, 1)
-	dataDir := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "live.go"), []byte("package main\nfunc Live() {}\n"), 0o644))
-
-	dirtyPath := DirtyIndexPath(dataDir, dir)
-	_, err := BuildDirtyIndex(context.Background(), dir, dirtyPath, IndexOptions{})
-	require.NoError(t, err)
-
-	removed, err := GCDirtyIndexes(dataDir)
-	require.NoError(t, err)
-	assert.Equal(t, 0, removed, "live worktree overlay must not be removed")
-
-	_, err = os.Stat(dirtyPath)
-	require.NoError(t, err, "dirty index dir must still exist")
-}
-
-// TestGCDirtyIndexes_RemovesStaleOverlay verifies GC removes an overlay once
-// its worktree directory is deleted.
-func TestGCDirtyIndexes_RemovesStaleOverlay(t *testing.T) {
-	t.Parallel()
-	dir, _ := initGitRepo(t, 1)
-	dataDir := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "stale.go"), []byte("package main\nfunc Stale() {}\n"), 0o644))
-
-	dirtyPath := DirtyIndexPath(dataDir, dir)
-	_, err := BuildDirtyIndex(context.Background(), dir, dirtyPath, IndexOptions{})
-	require.NoError(t, err)
-
-	// overlay + manifest should exist now
-	require.DirExists(t, dirtyPath)
-	require.FileExists(t, dirtyPath+".manifest")
-
-	// delete the worktree
-	require.NoError(t, os.RemoveAll(dir))
-
-	removed, err := GCDirtyIndexes(dataDir)
-	require.NoError(t, err)
-	assert.Equal(t, 1, removed, "stale overlay must be counted as removed")
-
-	_, err = os.Stat(dirtyPath)
-	assert.True(t, os.IsNotExist(err), "dirty index dir must be deleted")
-	_, err = os.Stat(dirtyPath + ".manifest")
-	assert.True(t, os.IsNotExist(err), "manifest must be deleted along with the overlay")
-}
-
-// TestGCDirtyIndexes_IgnoresNoManifest verifies GC leaves overlays alone when
-// no manifest is present (written by an older binary that predates this feature).
-func TestGCDirtyIndexes_IgnoresNoManifest(t *testing.T) {
-	t.Parallel()
-	codedbDir := t.TempDir()
-	dirtyDir := filepath.Join(codedbDir, "bleve", "dirty")
-	require.NoError(t, os.MkdirAll(dirtyDir, 0o755))
-
-	// create a dir that looks like a dirty overlay but has no manifest
-	orphanDir := filepath.Join(dirtyDir, "aabbccdd11223344")
-	require.NoError(t, os.MkdirAll(orphanDir, 0o755))
-
-	removed, err := GCDirtyIndexes(codedbDir)
-	require.NoError(t, err)
-	assert.Equal(t, 0, removed, "overlay without manifest must not be touched")
-	require.DirExists(t, orphanDir, "orphan dir must survive")
-}
-
-// TestGCDirtyIndexes_MixedStaleAndLive verifies GC removes only stale overlays
-// when live and stale overlays coexist in the same codedb.
-func TestGCDirtyIndexes_MixedStaleAndLive(t *testing.T) {
-	t.Parallel()
-	dataDir := t.TempDir()
-
-	// build two live overlays
-	liveDir1, _ := initGitRepo(t, 1)
-	liveDir2, _ := initGitRepo(t, 1)
-	// build two overlays for worktrees we will delete
-	staleDir1, _ := initGitRepo(t, 1)
-	staleDir2, _ := initGitRepo(t, 1)
-
-	for _, dir := range []string{liveDir1, liveDir2, staleDir1, staleDir2} {
-		d := dir // capture loop var
-		require.NoError(t, os.WriteFile(filepath.Join(d, "f.go"), []byte("package p\nfunc F() {}\n"), 0o644))
-		dp := DirtyIndexPath(dataDir, d)
-		_, err := BuildDirtyIndex(context.Background(), d, dp, IndexOptions{})
-		require.NoError(t, err)
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, codedbDir string)
+		wantRemoved int
+		wantErr     bool
+		verify      func(t *testing.T, codedbDir string)
+	}{
+		{
+			name:        "empty_dir",
+			setup:       func(t *testing.T, codedbDir string) {},
+			wantRemoved: 0,
+		},
+		{
+			name: "keeps_live_overlay",
+			setup: func(t *testing.T, codedbDir string) {
+				dir, _ := initGitRepo(t, 1)
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "live.go"), []byte("package main\nfunc Live() {}\n"), 0o644))
+				dp := DirtyIndexPath(codedbDir, dir)
+				_, err := BuildDirtyIndex(context.Background(), dir, dp, IndexOptions{})
+				require.NoError(t, err)
+			},
+			wantRemoved: 0,
+		},
+		{
+			name: "removes_stale_overlay",
+			setup: func(t *testing.T, codedbDir string) {
+				dir, _ := initGitRepo(t, 1)
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "stale.go"), []byte("package main\nfunc Stale() {}\n"), 0o644))
+				dp := DirtyIndexPath(codedbDir, dir)
+				_, err := BuildDirtyIndex(context.Background(), dir, dp, IndexOptions{})
+				require.NoError(t, err)
+				require.DirExists(t, dp)
+				require.FileExists(t, dp+".manifest")
+				require.NoError(t, os.RemoveAll(dir))
+			},
+			wantRemoved: 1,
+			verify: func(t *testing.T, codedbDir string) {
+				// all overlay dirs and manifests under dirty/ should be gone
+				dirtyDir := filepath.Join(codedbDir, "bleve", "dirty")
+				entries, err := os.ReadDir(dirtyDir)
+				require.NoError(t, err)
+				for _, e := range entries {
+					if e.IsDir() {
+						t.Errorf("stale overlay dir still exists: %s", e.Name())
+					}
+				}
+			},
+		},
+		{
+			name: "ignores_no_manifest",
+			setup: func(t *testing.T, codedbDir string) {
+				dirtyDir := filepath.Join(codedbDir, "bleve", "dirty")
+				require.NoError(t, os.MkdirAll(dirtyDir, 0o755))
+				orphanDir := filepath.Join(dirtyDir, "aabbccdd11223344")
+				require.NoError(t, os.MkdirAll(orphanDir, 0o755))
+			},
+			wantRemoved: 0,
+			verify: func(t *testing.T, codedbDir string) {
+				orphanDir := filepath.Join(codedbDir, "bleve", "dirty", "aabbccdd11223344")
+				require.DirExists(t, orphanDir, "orphan dir must survive")
+			},
+		},
+		{
+			name: "mixed_stale_and_live",
+			setup: func(t *testing.T, codedbDir string) {
+				liveDir, _ := initGitRepo(t, 1)
+				staleDir1, _ := initGitRepo(t, 1)
+				staleDir2, _ := initGitRepo(t, 1)
+				for _, dir := range []string{liveDir, staleDir1, staleDir2} {
+					require.NoError(t, os.WriteFile(filepath.Join(dir, "f.go"), []byte("package p\nfunc F() {}\n"), 0o644))
+					dp := DirtyIndexPath(codedbDir, dir)
+					_, err := BuildDirtyIndex(context.Background(), dir, dp, IndexOptions{})
+					require.NoError(t, err)
+				}
+				require.NoError(t, os.RemoveAll(staleDir1))
+				require.NoError(t, os.RemoveAll(staleDir2))
+			},
+			wantRemoved: 2,
+		},
+		{
+			name: "unreadable_dirty_dir",
+			setup: func(t *testing.T, codedbDir string) {
+				if runtime.GOOS == "windows" {
+					t.Skip("chmod not effective on Windows")
+				}
+				dirtyDir := filepath.Join(codedbDir, "bleve", "dirty")
+				require.NoError(t, os.MkdirAll(dirtyDir, 0o755))
+				require.NoError(t, os.Chmod(dirtyDir, 0o000))
+				t.Cleanup(func() { _ = os.Chmod(dirtyDir, 0o755) })
+			},
+			wantRemoved: 0,
+			wantErr:     true,
+		},
 	}
 
-	// delete the two stale worktrees
-	require.NoError(t, os.RemoveAll(staleDir1))
-	require.NoError(t, os.RemoveAll(staleDir2))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			codedbDir := t.TempDir()
+			tc.setup(t, codedbDir)
 
-	removed, err := GCDirtyIndexes(dataDir)
-	require.NoError(t, err)
-	assert.Equal(t, 2, removed, "exactly the two stale overlays must be removed")
-
-	// live overlays must survive
-	assert.DirExists(t, DirtyIndexPath(dataDir, liveDir1))
-	assert.DirExists(t, DirtyIndexPath(dataDir, liveDir2))
-
-	// stale overlays must be gone
-	_, err1 := os.Stat(DirtyIndexPath(dataDir, staleDir1))
-	assert.True(t, os.IsNotExist(err1))
-	_, err2 := os.Stat(DirtyIndexPath(dataDir, staleDir2))
-	assert.True(t, os.IsNotExist(err2))
+			got, err := GCDirtyIndexes(codedbDir)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantRemoved, got)
+			if tc.verify != nil {
+				tc.verify(t, codedbDir)
+			}
+		})
+	}
 }

--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
-	"errors"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -534,8 +534,12 @@ func GCDirtyIndexes(codedbDir string) (int, error) {
 		worktreePath := string(raw)
 		if _, statErr := os.Stat(worktreePath); os.IsNotExist(statErr) {
 			// worktree is gone — remove overlay + manifest
-			_ = os.RemoveAll(dirPath)
-			_ = os.Remove(manifestPath)
+			if err := os.RemoveAll(dirPath); err != nil {
+				return removed, fmt.Errorf("remove dirty overlay %s: %w", dirPath, err)
+			}
+			if err := os.Remove(manifestPath); err != nil && !os.IsNotExist(err) {
+				return removed, fmt.Errorf("remove dirty manifest %s: %w", manifestPath, err)
+			}
 			removed++
 		}
 	}

--- a/internal/codedb/search/testdata/golden/translate/issue_empty_pattern_with_state.golden
+++ b/internal/codedb/search/testdata/golden/translate/issue_empty_pattern_with_state.golden
@@ -1,5 +1,5 @@
 {
-  "SQL": "SELECT i.number, i.title, i.author, i.state, i.url\nFROM issues i\nLEFT JOIN issue_comments ic ON ic.issue_id = i.id\nWHERE 1=1\n  AND i.state = ?1\nGROUP BY i.id\nORDER BY i.updated_at DESC\nLIMIT 20",
+  "SQL": "SELECT i.number, i.title, i.author, i.state, i.url\nFROM issues i\nWHERE 1=1\n  AND i.state = ?1\nORDER BY i.updated_at DESC\nLIMIT 20",
   "Params": [
     "open"
   ],

--- a/internal/codedb/search/testdata/golden/translate/issue_with_state.golden
+++ b/internal/codedb/search/testdata/golden/translate/issue_with_state.golden
@@ -1,5 +1,5 @@
 {
-  "SQL": "SELECT i.number, i.title, i.author, i.state, i.url\nFROM issues i\nLEFT JOIN issue_comments ic ON ic.issue_id = i.id\nWHERE 1=1\n  AND i.state = ?1\nGROUP BY i.id\nORDER BY i.updated_at DESC\nLIMIT 20",
+  "SQL": "SELECT i.number, i.title, i.author, i.state, i.url\nFROM issues i\nWHERE 1=1\n  AND i.state = ?1\nORDER BY i.updated_at DESC\nLIMIT 20",
   "Params": [
     "closed"
   ],

--- a/internal/codedb/search/testdata/golden/translate/pr_empty_pattern_with_state.golden
+++ b/internal/codedb/search/testdata/golden/translate/pr_empty_pattern_with_state.golden
@@ -1,5 +1,5 @@
 {
-  "SQL": "SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nLEFT JOIN pr_comments pc ON pc.pr_id = p.id\nWHERE 1=1\n  AND p.state = ?1\nGROUP BY p.id\nORDER BY p.updated_at DESC\nLIMIT 20",
+  "SQL": "SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nWHERE 1=1\n  AND p.state = ?1\nORDER BY p.updated_at DESC\nLIMIT 20",
   "Params": [
     "open"
   ],

--- a/internal/codedb/search/testdata/golden/translate/pr_with_count.golden
+++ b/internal/codedb/search/testdata/golden/translate/pr_with_count.golden
@@ -1,5 +1,5 @@
 {
-  "SQL": "SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nLEFT JOIN pr_comments pc ON pc.pr_id = p.id\nWHERE 1=1\n  AND p.state = ?1\nGROUP BY p.id\nORDER BY p.updated_at DESC\nLIMIT 5",
+  "SQL": "SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nWHERE 1=1\n  AND p.state = ?1\nORDER BY p.updated_at DESC\nLIMIT 5",
   "Params": [
     "open"
   ],

--- a/internal/codedb/search/testdata/golden/translate/pr_with_state_closed.golden
+++ b/internal/codedb/search/testdata/golden/translate/pr_with_state_closed.golden
@@ -1,5 +1,5 @@
 {
-  "SQL": "SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nLEFT JOIN pr_comments pc ON pc.pr_id = p.id\nWHERE 1=1\n  AND p.state = ?1\nGROUP BY p.id\nORDER BY p.updated_at DESC\nLIMIT 20",
+  "SQL": "SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nWHERE 1=1\n  AND p.state = ?1\nORDER BY p.updated_at DESC\nLIMIT 20",
   "Params": [
     "closed"
   ],

--- a/internal/codedb/search/testdata/golden/translate/pr_with_state_open.golden
+++ b/internal/codedb/search/testdata/golden/translate/pr_with_state_open.golden
@@ -1,5 +1,5 @@
 {
-  "SQL": "SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nLEFT JOIN pr_comments pc ON pc.pr_id = p.id\nWHERE 1=1\n  AND p.state = ?1\nGROUP BY p.id\nORDER BY p.updated_at DESC\nLIMIT 20",
+  "SQL": "SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nWHERE 1=1\n  AND p.state = ?1\nORDER BY p.updated_at DESC\nLIMIT 20",
   "Params": [
     "open"
   ],

--- a/internal/codedb/search/translate.go
+++ b/internal/codedb/search/translate.go
@@ -580,9 +580,15 @@ func translatePR(query *ParsedQuery) (*TranslatedQuery, error) {
 
 	limit := resolveLimit(f.Count)
 
+	var joinClause, groupClause string
+	if !query.HasEmptyPattern() {
+		joinClause = "\nLEFT JOIN pr_comments pc ON pc.pr_id = p.id"
+		groupClause = "\nGROUP BY p.id"
+	}
+
 	sql := fmt.Sprintf(
-		"SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p\nLEFT JOIN pr_comments pc ON pc.pr_id = p.id\nWHERE 1=1%s\nGROUP BY p.id\nORDER BY p.updated_at DESC\nLIMIT %d",
-		conditionsSQL(conditions), limit)
+		"SELECT p.number, p.title, p.author, p.state, p.url\nFROM pull_requests p%s\nWHERE 1=1%s%s\nORDER BY p.updated_at DESC\nLIMIT %d",
+		joinClause, conditionsSQL(conditions), groupClause, limit)
 
 	return &TranslatedQuery{
 		SQL:        sql,
@@ -636,9 +642,15 @@ func translateIssue(query *ParsedQuery) (*TranslatedQuery, error) {
 
 	limit := resolveLimit(f.Count)
 
+	var joinClause, groupClause string
+	if !query.HasEmptyPattern() {
+		joinClause = "\nLEFT JOIN issue_comments ic ON ic.issue_id = i.id"
+		groupClause = "\nGROUP BY i.id"
+	}
+
 	sql := fmt.Sprintf(
-		"SELECT i.number, i.title, i.author, i.state, i.url\nFROM issues i\nLEFT JOIN issue_comments ic ON ic.issue_id = i.id\nWHERE 1=1%s\nGROUP BY i.id\nORDER BY i.updated_at DESC\nLIMIT %d",
-		conditionsSQL(conditions), limit)
+		"SELECT i.number, i.title, i.author, i.state, i.url\nFROM issues i%s\nWHERE 1=1%s%s\nORDER BY i.updated_at DESC\nLIMIT %d",
+		joinClause, conditionsSQL(conditions), groupClause, limit)
 
 	return &TranslatedQuery{
 		SQL:        sql,

--- a/internal/codedb/testdata/golden/README.md
+++ b/internal/codedb/testdata/golden/README.md
@@ -42,7 +42,7 @@ change — it must be intentional.
 
 ## Location
 
-```
+```text
 internal/codedb/search/testdata/golden/
   tokenize/     14 files — tokenize() output
   parse/        48 files — ParseQuery() struct output


### PR DESCRIPTION
## Summary

Four targeted optimizations to the codedb indexing pipeline. Micro-benchmarks show 32% faster + 64% fewer allocations on the diff-text hot path. Real-world indexing of sageox-mono (a large monorepo) shows ~5% wall-clock improvement.

**Note:** Profiling of the real-world workload is in progress. The ~5% end-to-end gain (vs 32% in micro-benchmarks) indicates the dominant bottleneck is elsewhere — likely git object I/O or Bleve batch commits. See follow-up work below.

### Optimizations

- **Reduce `generateDiffText` allocations 64%** — replaced `strings.SplitN` + `fmt.Fprintf` with `strings.IndexByte` loop + direct `WriteByte`/`WriteString` calls, eliminating per-line `[]string` and format allocations
- **Eliminate double blob reads** — `ensureBlob` now returns blob text when it reads from git, so `generateDiffText` never re-reads the same git object
- **Eliminate SELECT after INSERT** — blobs, diffs, and commits tables now use `LastInsertId()` when `RowsAffected() > 0`, dropping one SQL round-trip per new row
- **Cache commit DB IDs** — `commitIDCache` map avoids `SELECT id FROM commits` per parent link during the same indexing run
- **FIFO tree cache eviction** — replaced wipe-all eviction with per-entry FIFO, preserving recently-needed parent trees across sequential commit walks

### Dirty Overlay GC

When a git worktree is deleted, its dirty overlay (`codedb/bleve/dirty/<hash>`) was left on disk indefinitely.

- `BuildDirtyIndex` now writes `<dirtyPath>.manifest` with the original worktree path
- New `GCDirtyIndexes(codedbDir)` scans `bleve/dirty/`, reads manifests, removes stale overlay+manifest when worktree path no longer exists
- Overlays without a manifest (older builds) are left alone
- Daemon calls GC after each `CheckFreshness` cycle

## Data Flow

```mermaid
graph LR
    subgraph Before
        B1[ensureBlob<br/>reads blob] --> B2[generateDiffText<br/>reads blob AGAIN]
        B3[INSERT blob] --> B4[SELECT id<br/>round-trip]
        B5[INSERT commit] --> B6[SELECT id<br/>round-trip]
    end

    subgraph After
        A1[ensureBlob<br/>reads blob, returns text] --> A2[generateDiffText<br/>uses returned text]
        A3[INSERT blob] --> A4[LastInsertId<br/>no SELECT]
        A5[INSERT commit] --> A6[LastInsertId + cache<br/>no SELECT]
    end
```

## Benchmark Results

### Micro-benchmarks (Apple M2 Pro, -count=3)

| Benchmark | Before | After | Δ time | Δ allocs |
|-----------|--------|-------|--------|----------|
| `BenchmarkGenerateDiffText` | 106–119 µs/op | 77–98 µs/op | **−18%** | 317 → 114 **−64%** |
| `BenchmarkIndexLocalRepo_50Commits` | 252–355 ms/op | 172–208 ms/op | **−32%** | 572K → 523K **−8.5%** |

### Real-world: sageox-mono full index (Apple M2 Pro, benchtime=1x)

| Binary | Time | 
|--------|------|
| v0.5.1 (fca6b9a, before) | 356.5s (5m 56s) |
| ryan/optimization (after) | 339.7s (5m 39s) |
| **Improvement** | **−16.8s (~4.7%)** |

The 32% micro-benchmark gain vs 4.7% real-world gain indicates the dominant bottleneck is not in the optimized functions. Profiling in progress to identify the actual hotspot (likely git object I/O, Bleve index batch writes, or WAL checkpointing).

## Tests

- 10 regression tests in `perf_regression_test.go`
- 6 GC tests in `dirty_test.go`
- 265 golden files — all pass
- `go test ./internal/codedb/... ./internal/daemon/` — all pass

## Isomorphism Proof

- `TestGenerateDiffText_PreReadMatchesFallback` — pre-read path == fallback path byte-for-byte
- 265 / 265 golden files pass
- No regressions

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting during cleanup operations to properly handle filesystem failures.

* **Performance**
  * Optimized search queries for issues and pull requests, reducing unnecessary data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->