### PR TITLE
test(codedb): concurrency/race tests

### DIFF
--- a/internal/codedb/dirty_integration_test.go
+++ b/internal/codedb/dirty_integration_test.go
@@ -24,9 +24,9 @@ func initTestRepo(t *testing.T) string {
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
 			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_AUTHOR_EMAIL=test@sageox.ai",
 			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/internal/codedb/index/concurrency_test.go
+++ b/internal/codedb/index/concurrency_test.go
@@ -1,0 +1,212 @@
+package index
+
+// Concurrency and race condition tests for the codedb indexer.
+//
+// These tests verify that:
+//   - Concurrent IndexLocalRepo calls on the same Store do not corrupt data
+//   - Search queries can run safely while indexing is in progress
+//   - BuildDirtyIndex and GCDirtyIndexes are safe when called concurrently
+//
+// Run with the race detector to surface data races:
+//
+//	go test -race ./internal/codedb/index/ -run TestConcurrent -v
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/sageox/ox/internal/codedb/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitExec runs a git command in dir and fails the test on error.
+func gitExec(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@sageox.ai",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %s", args, out)
+	}
+}
+
+// TestConcurrentIndexLocalRepo verifies that two goroutines calling IndexLocalRepo
+// on the same Store simultaneously do not panic or corrupt state. SQLite is in
+// WAL mode so reads and the serialized write path are safe; this test validates
+// the Bleve layer and SQL transaction serialization under contention.
+func TestConcurrentIndexLocalRepo(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 3
+	dir, _ := initGitRepo(t, 5)
+	s := openTestStore(t)
+
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+
+	// Release all goroutines at the same moment to maximize contention.
+	start := make(chan struct{})
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			errs[idx] = IndexLocalRepo(context.Background(), s, dir, IndexOptions{})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		assert.NoError(t, err, "goroutine %d: IndexLocalRepo failed", i)
+	}
+
+	// Store must be intact: all commits must be queryable after concurrent indexing.
+	rows, err := s.Query("SELECT COUNT(*) FROM commits")
+	require.NoError(t, err)
+	defer rows.Close()
+	var count int
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&count))
+	assert.Equal(t, 5, count, "all commits must be present after concurrent indexing")
+}
+
+// TestSearchDuringIndexing verifies that search queries return without error
+// while a long IndexLocalRepo is running on the same Store. SQLite WAL mode
+// allows concurrent readers, and this test confirms no deadlock or crash.
+func TestSearchDuringIndexing(t *testing.T) {
+	t.Parallel()
+
+	dir, _ := initGitRepo(t, 20) // larger repo → longer index time → more read overlap
+	s := openTestStore(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// search worker: fires queries until indexing is done
+	var searchErr error
+	var searchWg sync.WaitGroup
+	searchWg.Add(1)
+	go func() {
+		defer searchWg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				q, parseErr := search.ParseQuery("type:commit refactor")
+				if parseErr != nil {
+					searchErr = fmt.Errorf("ParseQuery: %w", parseErr)
+					return
+				}
+				if _, execErr := search.Execute(ctx, s, q); execErr != nil && ctx.Err() == nil {
+					searchErr = fmt.Errorf("search.Execute: %w", execErr)
+					return
+				}
+			}
+		}
+	}()
+
+	indexErr := IndexLocalRepo(context.Background(), s, dir, IndexOptions{})
+	cancel() // stop search worker
+	searchWg.Wait()
+
+	require.NoError(t, indexErr)
+	assert.NoError(t, searchErr)
+}
+
+// TestGCDirtyIndexesDuringBuild verifies that GCDirtyIndexes running concurrently
+// with a single BuildDirtyIndex call does not cause panics or manifest corruption.
+// The realistic race: GC scans the dirty dir while BuildDirtyIndex is mid-swap
+// (tmp dir exists, manifest not yet written). GC must not remove a partially-built
+// overlay, and the final manifest must be intact after both complete.
+func TestGCDirtyIndexesDuringBuild(t *testing.T) {
+	t.Parallel()
+
+	dir, _ := initGitRepo(t, 3)
+	s := openTestStore(t)
+
+	require.NoError(t, IndexLocalRepo(context.Background(), s, dir, IndexOptions{}))
+
+	// Create a dirty file to index.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "dirty.go"),
+		[]byte("package main\nvar DirtyConcurrent = true\n"),
+		0o644,
+	))
+
+	dirtyPath := DirtyIndexPath(s.Root, dir)
+	codedbDir := filepath.Dir(filepath.Dir(dirtyPath)) // store root
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var gcErr error
+	var gcWg sync.WaitGroup
+	gcWg.Add(1)
+	go func() {
+		defer gcWg.Done()
+		// Run GC in a tight loop while the build is in progress.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				if _, err := GCDirtyIndexes(codedbDir); err != nil && ctx.Err() == nil {
+					gcErr = err
+					return
+				}
+			}
+		}
+	}()
+
+	_, buildErr := BuildDirtyIndex(context.Background(), dir, dirtyPath, IndexOptions{})
+	cancel()
+	gcWg.Wait()
+
+	assert.NoError(t, buildErr)
+	assert.NoError(t, gcErr)
+
+	// Manifest must exist and point to the correct absolute path.
+	manifestData, err := os.ReadFile(dirtyPath + ".manifest")
+	require.NoError(t, err, "manifest must exist after build")
+	assert.Equal(t, dir, string(manifestData), "manifest must contain abs worktree path")
+}
+
+// TestIncrementalIndexDoesNotDuplicateCommits verifies that calling IndexLocalRepo
+// a second time after new commits are added produces no duplicate rows — this is
+// the sequential precondition for safe incremental updates.
+func TestIncrementalIndexDoesNotDuplicateCommits(t *testing.T) {
+	t.Parallel()
+
+	dir, _ := initGitRepo(t, 3)
+	s := openTestStore(t)
+
+	require.NoError(t, IndexLocalRepo(context.Background(), s, dir, IndexOptions{}))
+
+	// Add a new commit.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "new.go"), []byte("package main\n"), 0o644))
+	gitExec(t, dir, "add", "new.go")
+	gitExec(t, dir, "commit", "-m", "commit 4")
+
+	require.NoError(t, IndexLocalRepo(context.Background(), s, dir, IndexOptions{}))
+
+	rows, err := s.Query("SELECT COUNT(*) FROM commits")
+	require.NoError(t, err)
+	defer rows.Close()
+	var count int
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&count))
+	assert.Equal(t, 4, count, "incremental index must not duplicate commits")
+}

--- a/internal/codedb/index/gogit_v6_test.go
+++ b/internal/codedb/index/gogit_v6_test.go
@@ -105,8 +105,8 @@ func TestV6_TreeFilesReturnsFullPaths(t *testing.T) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git in temp dir, not ox subprocess
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t.com")
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
 	}
@@ -185,8 +185,8 @@ func TestV6_CloneOrFetchUpdatesOnRefetch(t *testing.T) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = srcDir
 		cmd.Env = append(os.Environ(), // safe: git in temp dir, not ox subprocess
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t.com")
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
 	}
@@ -222,8 +222,8 @@ func TestV6_GetTreeEntriesWithSubdirs(t *testing.T) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git in temp dir, not ox subprocess
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t.com")
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
 	}

--- a/internal/codedb/index/indexer_coverage_test.go
+++ b/internal/codedb/index/indexer_coverage_test.go
@@ -28,9 +28,9 @@ func TestGitStatusDirtyFiles(t *testing.T) {
 			cmd.Dir = dir
 			cmd.Env = append(os.Environ(), // safe: git subprocess needs parent env for PATH
 				"GIT_AUTHOR_NAME=test",
-				"GIT_AUTHOR_EMAIL=test@test.com",
+				"GIT_AUTHOR_EMAIL=test@sageox.ai",
 				"GIT_COMMITTER_NAME=test",
-				"GIT_COMMITTER_EMAIL=test@test.com",
+				"GIT_COMMITTER_EMAIL=test@sageox.ai",
 			)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
@@ -834,9 +834,9 @@ func TestBuildDirtyIndex_RemovesStaleOnClean(t *testing.T) {
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git subprocess needs parent env for PATH
 			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_AUTHOR_EMAIL=test@sageox.ai",
 			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -1013,9 +1013,9 @@ func TestResolveDefaultBranch_FallbackToBranchNames(t *testing.T) {
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git subprocess needs parent env for PATH
 			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_AUTHOR_EMAIL=test@sageox.ai",
 			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {

--- a/internal/codedb/index/perf_regression_test.go
+++ b/internal/codedb/index/perf_regression_test.go
@@ -76,8 +76,8 @@ func TestParentLinks_IncrementalRun(t *testing.T) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
@@ -226,7 +226,7 @@ func TestGenerateDiffText_PreReadMatchesFallback(t *testing.T) {
 
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
-	sig := &object.Signature{Name: "t", Email: "t@t.com", When: time.Now()}
+	sig := &object.Signature{Name: "t", Email: "test@sageox.ai", When: time.Now()}
 
 	content1 := strings.Repeat("line of code\n", 50)
 	content2 := strings.Repeat("modified line\n", 50)
@@ -287,7 +287,7 @@ func TestGenerateDiffText_PartialPreRead(t *testing.T) {
 
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
-	sig := &object.Signature{Name: "t", Email: "t@t.com", When: time.Now()}
+	sig := &object.Signature{Name: "t", Email: "test@sageox.ai", When: time.Now()}
 
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "g.go"), []byte("package g\n"), 0o644))
 	_, err = wt.Add("g.go")
@@ -330,8 +330,8 @@ func TestIndexLocalRepo_BlobDedup(t *testing.T) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
@@ -478,8 +478,8 @@ func TestDiffTree_InitialCommitAllFilesIndexed(t *testing.T) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
@@ -516,8 +516,8 @@ func TestDiffTree_ModifyAndDeleteTracked(t *testing.T) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
@@ -574,8 +574,8 @@ func TestDiffTree_UnchangedFilesNotDuplicated(t *testing.T) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/internal/codedb/index/walk_test.go
+++ b/internal/codedb/index/walk_test.go
@@ -28,7 +28,7 @@ func TestWalkNewCommitsBFSOrder(t *testing.T) {
 		t.Fatalf("worktree: %v", err)
 	}
 
-	sig := &object.Signature{Name: "test", Email: "t@t.com", When: time.Now()}
+	sig := &object.Signature{Name: "test", Email: "test@sageox.ai", When: time.Now()}
 
 	// commit 1 on default branch
 	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("a"), 0o644); err != nil {
@@ -121,7 +121,7 @@ func TestWalkNewCommitsSkipsKnown(t *testing.T) {
 		t.Fatalf("worktree: %v", err)
 	}
 
-	sig := &object.Signature{Name: "test", Email: "t@t.com", When: time.Now()}
+	sig := &object.Signature{Name: "test", Email: "test@sageox.ai", When: time.Now()}
 
 	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("a"), 0o644); err != nil {
 		t.Fatal(err)
@@ -171,7 +171,7 @@ func TestWalkNewCommitsMaxDepth(t *testing.T) {
 		t.Fatalf("worktree: %v", err)
 	}
 
-	sig := &object.Signature{Name: "test", Email: "t@t.com", When: time.Now()}
+	sig := &object.Signature{Name: "test", Email: "test@sageox.ai", When: time.Now()}
 
 	var lastHash plumbing.Hash
 	for i := 0; i < 5; i++ {

--- a/internal/codedb/index/worktree_test.go
+++ b/internal/codedb/index/worktree_test.go
@@ -28,9 +28,9 @@ func initGitRepo(t *testing.T, numCommits int) (string, string) {
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
 			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_AUTHOR_EMAIL=test@sageox.ai",
 			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
@@ -129,9 +129,9 @@ func TestResolveDefaultBranchGit_Worktree(t *testing.T) {
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
 			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_AUTHOR_EMAIL=test@sageox.ai",
 			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
@@ -193,9 +193,9 @@ func TestIndexLocalRepo_LinkedWorktree(t *testing.T) {
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
 			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_AUTHOR_EMAIL=test@sageox.ai",
 			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
+			"GIT_COMMITTER_EMAIL=test@sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)


### PR DESCRIPTION
## Summary

- Adds `concurrency_test.go` with 4 new tests covering concurrent access scenarios that were previously untested
- Standardizes test git author email to `test@sageox.ai` across all codedb test files (was `test@test.com` and `t@t.com`)

## New Tests

| Test | What It Validates |
|------|-------------------|
| `TestConcurrentIndexLocalRepo` | 3 goroutines calling `IndexLocalRepo` on the same Store simultaneously — no panic, no corruption, all 5 commits present after |
| `TestSearchDuringIndexing` | Search queries firing while `IndexLocalRepo` is in progress — no deadlock, no error |
| `TestGCDirtyIndexesDuringBuild` | `GCDirtyIndexes` running in a tight loop while `BuildDirtyIndex` completes — manifest intact after, no panic |
| `TestIncrementalIndexDoesNotDuplicateCommits` | Sequential incremental reindex after new commits — commit count exactly 4, no duplicates |

## Race Detector

All tests pass with `go test -race`. The existing `make test` already runs with `-race`, so these are covered by CI automatically.

## Existing Concurrency Mechanisms (confirmed safe)

- SQLite WAL mode + `busy_timeout(5000ms)`: concurrent readers non-blocking, writes serialize
- `repoPool` (`indexer.go:1342`): per-repo `sync.Mutex` protects go-git blob access within a single `IndexLocalRepo`  
- Atomic swap via `os.Rename` for dirty index build
- Manifest now uses `filepath.Abs` and propagates write errors (from PR #347)

## Resolves

Closes beads issue ox-qth

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive concurrency and race-safety tests for the code indexer, including concurrent indexing, search-during-indexing, garbage collection, and incremental indexing scenarios.
  * Updated test fixtures across multiple test suites to use standardized test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->