### PR TITLE
fix(daemon): add PID to log entries and project path to sync warnings

### DIFF
--- a/cmd/ox/daemon.go
+++ b/cmd/ox/daemon.go
@@ -353,9 +353,10 @@ func runDaemonForeground(ledgerPath string) error {
 	cfg.ProjectRoot = findGitRoot() // required for team context syncing
 
 	// use INFO level logging to stderr (which gets redirected to log file)
+	// include PID so multi-daemon scenarios and auto-restarts can be distinguished
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
-	}))
+	})).With("pid", os.Getpid())
 
 	d := daemon.New(cfg, logger)
 	if err := d.Start(); err != nil {

--- a/internal/daemon/sync_clone.go
+++ b/internal/daemon/sync_clone.go
@@ -160,7 +160,7 @@ func (s *SyncScheduler) cloneInBackground(cloneURL, repoPath, repoType, workspac
 		// ensure sync timestamp is set (may be zero if cloned before this fix)
 		if ws := s.workspaceRegistry.GetWorkspace(workspaceID); ws != nil && ws.ConfigLastSync.IsZero() {
 			if err := s.workspaceRegistry.UpdateConfigLastSync(workspaceID); err != nil {
-				s.logger.Warn("failed to backfill config last sync", "type", repoType, "error", err)
+				s.logger.Warn("failed to backfill config last sync", "type", repoType, "path", repoPath, "error", err)
 			}
 			s.recordSyncState(context.Background(), repoPath)
 		}
@@ -174,7 +174,7 @@ func (s *SyncScheduler) cloneInBackground(cloneURL, repoPath, repoType, workspac
 		}
 		// persist sync timestamp so status shows "synced" after clone
 		if err := s.workspaceRegistry.UpdateConfigLastSync(workspaceID); err != nil {
-			s.logger.Warn("failed to update config last sync after clone", "type", repoType, "error", err)
+			s.logger.Warn("failed to update config last sync after clone", "type", repoType, "path", repoPath, "error", err)
 		}
 		s.recordSyncState(context.Background(), repoPath)
 	}

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -204,7 +204,7 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 		}
 
 		if err := s.workspaceRegistry.UpdateConfigLastSync(r.ws.ID); err != nil {
-			s.logger.Warn("failed to update config last sync", "team", r.ws.TeamName, "error", err)
+			s.logger.Warn("failed to update config last sync", "team", r.ws.TeamName, "path", r.ws.Path, "error", err)
 		}
 		s.recordSyncState(ctx, r.ws.Path)
 


### PR DESCRIPTION
## Summary

- **PID in every log line**: The daemon logger now includes `pid=<N>` on every entry, making it easy to distinguish entries from different daemon instances after auto-restarts or when multiple daemons accidentally run against the same ledger.
- **Project path in sync warnings**: The "failed to update config last sync" warnings now include `path=<repo_path>`, so it's immediately clear which project triggered the error (previously just showed team name).

## Changes

- `cmd/ox/daemon.go`: Add `.With("pid", os.Getpid())` to the daemon slog logger
- `internal/daemon/sync_team.go`: Add `"path", r.ws.Path` to config sync warning
- `internal/daemon/sync_clone.go`: Add `"path", repoPath` to clone sync warnings (2 sites)

## Test plan

- [x] `go build ./cmd/ox/` — compiles cleanly
- [x] `go test ./internal/daemon/ -short` — all tests pass
- [x] Verified log output includes `pid=` attribute on all daemon lines
- [x] Verified sync warning messages include `path=` for project identification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced daemon logging to include process ID for better identification across multi-daemon scenarios
  * Improved synchronization operation logs with additional repository path context in warning messages for easier troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->