### PR TITLE
fix(codedb): prevent projectRoot oscillation when multiple worktrees are active

### DIFF
--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -607,6 +607,15 @@ func (m *CodeDBManager) UpdateProjectRoot(path string) {
 	if path == "" || path == m.projectRoot {
 		return
 	}
+	// Only switch if the current project root no longer exists on disk.
+	// This handles the Conductor pattern (old workspace deleted, new one created)
+	// while preventing oscillation when multiple sessions share the same daemon
+	// (e.g., one session in the main worktree, one in a Conductor worktree,
+	// both alive simultaneously — without this guard, their heartbeats cause
+	// the root to flip every 60s, triggering repeated full re-indexes).
+	if _, err := os.Stat(m.projectRoot); err == nil {
+		return
+	}
 	old := m.projectRoot
 	m.projectRoot = path
 	m.logger.Info("codedb project root updated", "old", old, "new", path)

--- a/internal/daemon/codedb_test.go
+++ b/internal/daemon/codedb_test.go
@@ -45,6 +45,32 @@ func TestUpdateProjectRoot_IgnoresEmptyPath(t *testing.T) {
 	assert.Equal(t, "/original", got)
 }
 
+// TestUpdateProjectRoot_NoSwitchWhenCurrentExists is the regression test for the
+// "worktree oscillation" bug: two simultaneously active sessions (e.g., main
+// worktree + Conductor worktree) caused the daemon to flip projectRoot on every
+// heartbeat, triggering a full dirty-index rebuild (~79ms) and occasionally a
+// full git re-index (~10s) on every 60s scheduler tick.
+// The fix: only switch if the current path no longer exists on disk.
+func TestUpdateProjectRoot_NoSwitchWhenCurrentExists(t *testing.T) {
+	t.Parallel()
+
+	// both worktrees exist simultaneously
+	mainWorktree := t.TempDir()
+	conductorWorktree := t.TempDir()
+
+	mgr := NewCodeDBManager(mainWorktree, codedbTestLogger(), nil)
+
+	// simulate heartbeat from a simultaneously active Conductor workspace
+	mgr.UpdateProjectRoot(conductorWorktree)
+
+	mgr.mu.Lock()
+	got := mgr.projectRoot
+	mgr.mu.Unlock()
+
+	// must NOT switch — mainWorktree still exists
+	assert.Equal(t, mainWorktree, got, "should not switch while current path still exists")
+}
+
 func TestUpdateProjectRoot_IgnoresSamePath(t *testing.T) {
 	t.Parallel()
 	mgr := NewCodeDBManager("/same/path", codedbTestLogger(), nil)
@@ -496,6 +522,9 @@ func TestUpdateProjectRoot_Symlink(t *testing.T) {
 	require.NoError(t, os.Symlink(realDir, linkDir))
 
 	mgr := NewCodeDBManager(realDir, codedbTestLogger(), nil)
+
+	// simulate Conductor deleting the old workspace — only then should we switch
+	require.NoError(t, os.RemoveAll(realDir))
 
 	// update to symlink path — should accept it (let git resolve the real path)
 	mgr.UpdateProjectRoot(linkDir)


### PR DESCRIPTION
## Problem

When two sessions are simultaneously active (e.g., main worktree + Conductor worktree), `UpdateProjectRoot` flips the index target on every heartbeat — once per 60s scheduler tick. Each flip triggers a full dirty-index rebuild (~79ms) or, when the new root has unseen commits, a full git re-index (~10s). Observed in production: **46% continuous CPU burn** on the `ox daemon`.

Root cause: `UpdateProjectRoot` accepted any path change unconditionally. Both live sessions kept heartbeating their respective paths, causing perpetual oscillation.

## Fix

Guard `UpdateProjectRoot` with an `os.Stat` check: only switch `projectRoot` if the current path **no longer exists on disk**.

```go
if _, err := os.Stat(m.projectRoot); err == nil {
    return // current path still alive — don't switch
}
```

This preserves the Conductor delete+recreate pattern (old workspace gone → new one accepted) while eliminating oscillation between simultaneously live sessions.

## Tests

- Added `TestUpdateProjectRoot_NoSwitchWhenCurrentExists` — regression test for the oscillation bug
- Updated `TestUpdateProjectRoot_Symlink` — must delete the original dir before a switch is accepted

## Related

- Beads: ox-bjup
- Architecture issue (two-tier baseline index, P1 follow-up): https://github.com/sageox/ox/issues/368

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary re-indexing when using multiple concurrent worktrees with the same daemon, improving performance and stability in multi-worktree scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->