### PR TITLE
fix(session): walk process tree to capture correct agent PID

### DIFF
--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sageox/agentx"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/proc"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 )
@@ -399,13 +400,16 @@ func handleAfterTool(ctx *HookContext) error {
 		return nil // non-fatal
 	}
 
-	currentPPID := os.Getppid()
 	_ = session.UpdateRecordingStateForAgent(ctx.ProjectRoot, agentID, func(s *session.RecordingState) {
 		s.SourceOffset = newOffset
 		s.EntryCount += len(sessionEntries)
-		// update PID if it changed (fixes Conductor where prime runs in a short-lived wrapper)
-		if currentPPID > 0 && s.ParentPID != currentPPID {
-			s.ParentPID = currentPPID
+		// Refresh parent_pid only if the stored PID is dead — each hook call runs in a
+		// new transient shell, so blindly overwriting with os.Getppid() would store a dead
+		// PID. FindAgentAncestorPID walks the tree to find the long-lived agent process.
+		if !proc.IsAlive(s.ParentPID) {
+			if agentPID := proc.FindAgentAncestorPID(); agentPID > 0 {
+				s.ParentPID = agentPID
+			}
 		}
 	})
 
@@ -461,10 +465,10 @@ func runPrimeForHook(agentID string, ctx *HookContext) error {
 
 	cmd := exec.Command(oxPath, args...)
 	cmd.Env = append(os.Environ(),
-		// Pass the agent's parent PID (Claude Code process) to prime so session
-		// recording captures the long-lived agent PID, not the transient hook PID.
-		// The hook's parent is the agent; prime's parent is the hook (transient).
-		fmt.Sprintf("OX_PARENT_PID=%d", os.Getppid()),
+		// Pass the long-lived agent PID (e.g., claude) to prime for session recording.
+		// Hooks run inside a transient bash shell, so os.Getppid() returns the shell PID
+		// which dies immediately. FindAgentAncestorPID walks the tree to find the agent.
+		fmt.Sprintf("OX_PARENT_PID=%d", proc.FindAgentAncestorPID()),
 	)
 	// pass original raw bytes to preserve unknown fields (not re-serialized)
 	if ctx.Input != nil && len(ctx.Input.RawBytes) > 0 {

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/prime"
+	"github.com/sageox/ox/internal/proc"
 	"github.com/sageox/ox/internal/repotools"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/teamdocs"
@@ -281,7 +282,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 					AgentID:        agentID,
 					AgentSessionID: agentSessionID,
 					PrimedAt:       time.Now(),
-					ParentPID:      os.Getppid(),
+					ParentPID:      proc.FindAgentAncestorPID(),
 				}
 				if writeErr := WriteSessionMarker(marker); writeErr != nil {
 					slog.Warn("failed to write session marker in degraded mode", "error", writeErr)
@@ -374,7 +375,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 			AgentType:       agentType,
 			AgentVer:        agentVer,
 			Model:           model,
-			ParentPID:       os.Getppid(),
+			ParentPID:       proc.FindAgentAncestorPID(),
 			ParentAgentID:   parentAgentID,
 			PrimeCallCount:  1,
 		}
@@ -582,7 +583,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 			SessionID:      inst.ServerSessionID,
 			AgentSessionID: agentSessionID,
 			PrimedAt:       time.Now(),
-			ParentPID:      os.Getppid(),
+			ParentPID:      proc.FindAgentAncestorPID(),
 		}
 		if err := WriteSessionMarker(marker); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to write session marker: %v\n", err)
@@ -808,10 +809,12 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string
 	timestamp := time.Now().Format("2006-01-02-150405")
 	outputFile := filepath.Join(projectRoot, ".sageox", "sessions", fmt.Sprintf("%s-%s.md", timestamp, agentID))
 
-	// start recording with filter mode
-	// prefer OX_PARENT_PID (set by hook) — it's the long-lived agent process.
-	// os.Getppid() here would be the transient hook process which exits immediately.
-	parentPID := os.Getppid()
+	// Determine the long-lived agent PID for liveness detection.
+	// Hooks run inside a transient bash shell, so os.Getppid() returns the shell
+	// PID which dies immediately after the hook. OX_PARENT_PID is set by the hook
+	// to proc.FindAgentAncestorPID(), which walks the tree to find the agent process.
+	// If OX_PARENT_PID is missing (direct invocation), walk the tree ourselves.
+	parentPID := proc.FindAgentAncestorPID()
 	if envPID := os.Getenv("OX_PARENT_PID"); envPID != "" {
 		if parsed, parseErr := strconv.Atoi(envPID); parseErr == nil && parsed > 0 {
 			parentPID = parsed

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sageox/ox/internal/doctor"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/proc"
 	"github.com/sageox/ox/internal/repotools"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
@@ -220,7 +221,7 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 		Username:      getSessionUsername(),
 		WorkspacePath: projectRoot,
 		Branch:        repotools.GetCurrentBranch(projectRoot),
-		ParentPID:     os.Getppid(), // use current parent, not stale prime-time PID (fixes Conductor orphan detection)
+		ParentPID:     proc.FindAgentAncestorPID(),
 		StartOffset:   startOffset,
 	}
 

--- a/cmd/ox/heartbeat.go
+++ b/cmd/ox/heartbeat.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/proc"
 	"github.com/sageox/ox/internal/status"
 	"github.com/sageox/ox/internal/version"
 )
@@ -76,7 +77,7 @@ func Heartbeat(repoPath string, teamIDs []string, agentID string) {
 			CLIVersion:    version.Full(),
 			ParentAgentID: parentAgentID,
 			AgentType:     agentType,
-			ParentPID:     os.Getppid(),
+			ParentPID:     proc.FindAgentAncestorPID(),
 		}
 
 		// include workspace ID if available
@@ -136,7 +137,7 @@ func sendContextHeartbeat(agentID string, bytes int64, commandName string) {
 			Timestamp:     time.Now().UTC(),
 			ParentAgentID: parentAgentID,
 			AgentType:     agentType,
-			ParentPID:     os.Getppid(),
+			ParentPID:     proc.FindAgentAncestorPID(),
 		}
 		data, err := json.Marshal(payload)
 		if err != nil {
@@ -168,7 +169,7 @@ func HeartbeatWithCreds(repoPath string, teamIDs []string, agentID string, creds
 			CLIVersion:    version.Full(),
 			ParentAgentID: parentAgentID,
 			AgentType:     agentType,
-			ParentPID:     os.Getppid(),
+			ParentPID:     proc.FindAgentAncestorPID(),
 		}
 
 		// include workspace ID if available

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -136,16 +136,24 @@ func (h *SessionFinalizeHandler) Type() string { return sessionFinalizeType }
 // of agent_worker.enabled. Does NOT clear .recording.json markers on sessions
 // that have recoverable data — that's Detect()'s job when LLM processing follows.
 //
-// Cleans both the ledger sessions dir and the session cache dir (where ox session
-// list reads from). The cache dir is derived from the repoID in the ledger path.
+// Scans three locations where sessions can live:
+//   - ledgerPath/.sageox/cache/sessions/ — primary ledger cache (StartRecording writes here)
+//   - ledgerPath/sessions/ — git-tracked sessions (after finalization/upload)
+//   - XDG cache paths — legacy and alternate cache locations
 func (h *SessionFinalizeHandler) Cleanup(ledgerPath string) {
-	// clean ledger sessions
+	// clean primary ledger cache (where StartRecording writes sessions)
+	ledgerCacheSessionsDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions")
+	if ghostResult := session.CleanupGhostSessionsInDir(ledgerCacheSessionsDir); ghostResult.Removed > 0 {
+		h.logger.Info("ghost cleanup (ledger cache): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
+	}
+
+	// clean git-tracked ledger sessions (uploaded/finalized sessions)
 	ledgerSessionsDir := filepath.Join(ledgerPath, "sessions")
 	if ghostResult := session.CleanupGhostSessionsInDir(ledgerSessionsDir); ghostResult.Removed > 0 {
 		h.logger.Info("ghost cleanup (ledger): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
 	}
 
-	// clean session cache (where ox session list reads from)
+	// clean XDG/legacy cache paths (different XDG_CACHE_HOME resolution or older ox versions)
 	repoID := filepath.Base(ledgerPath)
 	if repoID != "" && repoID != "." {
 		cacheSessionsDir := filepath.Join(paths.SessionCacheDir(repoID), "sessions")
@@ -153,7 +161,6 @@ func (h *SessionFinalizeHandler) Cleanup(ledgerPath string) {
 			h.logger.Info("ghost cleanup (cache): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
 		}
 
-		// also clean alternate cache paths (different XDG_CACHE_HOME resolution)
 		for _, altDir := range paths.AlternateSessionCacheDirs(repoID) {
 			altSessionsDir := filepath.Join(altDir, "sessions")
 			if ghostResult := session.CleanupGhostSessionsInDir(altSessionsDir); ghostResult.Removed > 0 {
@@ -163,70 +170,64 @@ func (h *SessionFinalizeHandler) Cleanup(ledgerPath string) {
 	}
 }
 
-// Detect scans both the ledger and session cache for sessions missing artifacts.
-// The cache dir is where sessions are initially recorded; the ledger is where they
-// are pushed after finalization. Both must be scanned to catch orphans.
+// Detect scans all locations where sessions can live for sessions missing artifacts.
+// Sessions are initially written to ledgerPath/.sageox/cache/sessions/ (primary),
+// and moved to ledgerPath/sessions/ after finalization/upload. XDG cache paths
+// are also scanned for sessions written by older ox versions or different environments.
 func (h *SessionFinalizeHandler) Detect(ledgerPath string) ([]*WorkItem, error) {
-	ledgerSessionsDir := filepath.Join(ledgerPath, "sessions")
+	// deduplicate across all scan dirs (prefer earlier-found copy)
+	seen := make(map[string]bool)
+	var items []*WorkItem
 
-	// ghost cleanup also runs via Cleanup() on every doctor cycle regardless of
-	// agent_worker.enabled. Run it here too for callers that invoke Detect() directly
-	// (e.g. ForceDetect, tests).
-	if ghostResult := session.CleanupGhostSessionsInDir(ledgerSessionsDir); ghostResult.Removed > 0 {
-		h.logger.Info("ghost cleanup: removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
-	}
-
-	// scan ledger sessions dir
-	items, err := h.detectInDir(ledgerSessionsDir, ledgerPath)
-	if err != nil {
-		return nil, err
-	}
-
-	// also scan session cache dir (where sessions are initially recorded)
-	repoID := filepath.Base(ledgerPath)
-	if repoID != "" && repoID != "." {
-		cacheSessionsDir := filepath.Join(paths.SessionCacheDir(repoID), "sessions")
-		if cacheSessionsDir != ledgerSessionsDir {
-			if ghostResult := session.CleanupGhostSessionsInDir(cacheSessionsDir); ghostResult.Removed > 0 {
-				h.logger.Info("ghost cleanup (cache): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
-			}
-
-			cacheItems, cacheErr := h.detectInDir(cacheSessionsDir, ledgerPath)
-			if cacheErr == nil {
-				// deduplicate by session name (prefer ledger copy)
-				seen := make(map[string]bool)
-				for _, item := range items {
-					seen[item.DedupKey] = true
-				}
-				for _, item := range cacheItems {
-					if !seen[item.DedupKey] {
-						items = append(items, item)
-					}
-				}
+	mergeItems := func(newItems []*WorkItem) {
+		for _, item := range newItems {
+			if !seen[item.DedupKey] {
+				seen[item.DedupKey] = true
+				items = append(items, item)
 			}
 		}
+	}
 
-		// also scan alternate cache paths (different XDG_CACHE_HOME resolution)
-		for _, altDir := range paths.AlternateSessionCacheDirs(repoID) {
-			altSessionsDir := filepath.Join(altDir, "sessions")
-			if altSessionsDir == ledgerSessionsDir {
+	// 1. primary ledger cache — where StartRecording writes sessions
+	ledgerCacheSessionsDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions")
+	if ghostResult := session.CleanupGhostSessionsInDir(ledgerCacheSessionsDir); ghostResult.Removed > 0 {
+		h.logger.Info("ghost cleanup (ledger cache): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
+	}
+	if cacheItems, err := h.detectInDir(ledgerCacheSessionsDir, ledgerPath); err == nil {
+		mergeItems(cacheItems)
+	}
+
+	// 2. git-tracked ledger sessions — uploaded/finalized sessions
+	ledgerSessionsDir := filepath.Join(ledgerPath, "sessions")
+	if ghostResult := session.CleanupGhostSessionsInDir(ledgerSessionsDir); ghostResult.Removed > 0 {
+		h.logger.Info("ghost cleanup (ledger): removed abandoned recordings", "count", ghostResult.Removed, "sessions", ghostResult.Names)
+	}
+	if ledgerItems, err := h.detectInDir(ledgerSessionsDir, ledgerPath); err == nil {
+		mergeItems(ledgerItems)
+	}
+
+	// 3. XDG/legacy cache paths — older ox versions or different XDG_CACHE_HOME environments
+	repoID := filepath.Base(ledgerPath)
+	if repoID != "" && repoID != "." {
+		xdgDirs := append(
+			[]string{filepath.Join(paths.SessionCacheDir(repoID), "sessions")},
+			func() []string {
+				var out []string
+				for _, d := range paths.AlternateSessionCacheDirs(repoID) {
+					out = append(out, filepath.Join(d, "sessions"))
+				}
+				return out
+			}()...,
+		)
+		for _, dir := range xdgDirs {
+			if dir == ledgerCacheSessionsDir || dir == ledgerSessionsDir {
 				continue
 			}
-			if ghostResult := session.CleanupGhostSessionsInDir(altSessionsDir); ghostResult.Removed > 0 {
-				h.logger.Info("ghost cleanup (alternate cache): removed abandoned recordings", "dir", altDir, "count", ghostResult.Removed, "sessions", ghostResult.Names)
+			if ghostResult := session.CleanupGhostSessionsInDir(dir); ghostResult.Removed > 0 {
+				h.logger.Info("ghost cleanup (xdg cache): removed abandoned recordings", "dir", dir, "count", ghostResult.Removed, "sessions", ghostResult.Names)
 			}
-
-			altItems, altErr := h.detectInDir(altSessionsDir, ledgerPath)
-			if altErr == nil {
-				seen := make(map[string]bool)
-				for _, item := range items {
-					seen[item.DedupKey] = true
-				}
-				for _, item := range altItems {
-					if !seen[item.DedupKey] {
-						items = append(items, item)
-					}
-				}
+			if xdgItems, err := h.detectInDir(dir, ledgerPath); err == nil {
+				mergeItems(xdgItems)
 			}
 		}
 	}

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -1,0 +1,102 @@
+// Package proc provides process tree utilities for identifying long-lived
+// ancestor processes (e.g., the agent binary that launched a hook subprocess chain).
+//
+// Problem: hooks run as: agent (e.g., claude) → bash → ox agent hook → ox agent prime.
+// os.Getppid() in any hook subprocess returns the transient bash PID, which dies
+// immediately. FindAgentAncestorPID walks the tree to find the actual agent process.
+package proc
+
+import (
+	"os"
+	"strings"
+
+	"github.com/sageox/agentx"
+)
+
+// knownAgentBinaries returns the list of known long-lived AI agent process names,
+// derived from agentx.SupportedAgents so we stay in sync as new agents are added.
+// Process names on macOS/Linux are often truncated by the kernel (e.g., 15 chars on macOS).
+func knownAgentBinaries() []string {
+	names := make([]string, 0, len(agentx.SupportedAgents))
+	for _, at := range agentx.SupportedAgents {
+		if at != agentx.AgentTypeUnknown {
+			names = append(names, string(at))
+		}
+	}
+	return names
+}
+
+// FindAgentAncestorPID walks the process tree from the current process's parent
+// upward, looking for the first ancestor whose name matches a known agent binary.
+//
+// This is necessary because hooks run inside a transient bash shell spawned by
+// the agent, so os.Getppid() returns the bash PID (which dies), not the agent PID.
+//
+// If AGENT_ENV is set in the environment, its resolved binary name is searched first
+// so we find the correct agent quickly without scanning all known names.
+//
+// Returns the matching ancestor PID, or os.Getppid() as fallback if no agent found.
+func FindAgentAncestorPID() int {
+	// If AGENT_ENV is set, resolve it to a binary name and use as a hint.
+	// This avoids scanning all known agent names on every hook call.
+	hint := ""
+	if agentEnv := os.Getenv("AGENT_ENV"); agentEnv != "" {
+		at := agentx.ResolveAgentENV(agentEnv)
+		if at != agentx.AgentTypeUnknown {
+			hint = string(at)
+		}
+	}
+	return findAgentAncestorFrom(os.Getppid(), hint)
+}
+
+// findAgentAncestorFrom walks from startPID upward (max 10 levels) looking for a
+// process whose name matches a known agent binary.
+// hint, if non-empty, is checked first before scanning all known agent names.
+func findAgentAncestorFrom(startPID int, hint string) int {
+	pid := startPID
+	fallback := startPID
+
+	known := knownAgentBinaries()
+	for range 10 {
+		if pid <= 1 {
+			break
+		}
+		name := processName(pid)
+		if name != "" && matchesAgent(name, hint, known) {
+			return pid
+		}
+		ppid, err := parentPID(pid)
+		if err != nil || ppid <= 1 || ppid == pid {
+			break
+		}
+		pid = ppid
+	}
+
+	return fallback
+}
+
+// matchesAgent returns true if name matches the hint (checked first) or any known agent.
+func matchesAgent(name, hint string, known []string) bool {
+	lower := strings.ToLower(name)
+	if hint != "" && strings.HasPrefix(lower, hint) {
+		return true
+	}
+	for _, agent := range known {
+		if strings.HasPrefix(lower, agent) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAlive returns true if the process with the given PID is still running.
+func IsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return isAliveProc(proc)
+}

--- a/internal/proc/proc_test.go
+++ b/internal/proc/proc_test.go
@@ -1,0 +1,69 @@
+package proc
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFindAgentAncestorPID_ReturnsLiveProcess(t *testing.T) {
+	pid := FindAgentAncestorPID()
+	if pid <= 0 {
+		t.Fatalf("FindAgentAncestorPID returned non-positive PID: %d", pid)
+	}
+	if !IsAlive(pid) {
+		t.Errorf("FindAgentAncestorPID returned dead PID %d", pid)
+	}
+}
+
+func TestFindAgentAncestorPID_NotSelf(t *testing.T) {
+	self := os.Getpid()
+	pid := FindAgentAncestorPID()
+	if pid == self {
+		t.Errorf("FindAgentAncestorPID returned current process PID %d", pid)
+	}
+}
+
+func TestParentPID_Self(t *testing.T) {
+	pid := os.Getpid()
+	ppid, err := parentPID(pid)
+	if err != nil {
+		t.Fatalf("parentPID(%d): %v", pid, err)
+	}
+	if ppid != os.Getppid() {
+		t.Errorf("parentPID(%d) = %d, want %d (os.Getppid)", pid, ppid, os.Getppid())
+	}
+}
+
+func TestProcessName_Self(t *testing.T) {
+	pid := os.Getpid()
+	name := processName(pid)
+	if name == "" {
+		t.Errorf("processName(%d) returned empty string", pid)
+	}
+}
+
+func TestMatchesAgent(t *testing.T) {
+	known := []string{"claude", "cursor", "windsurf", "aider"}
+	cases := []struct {
+		name string
+		hint string
+		want bool
+	}{
+		{"claude", "claude", true},
+		{"cursor", "", true},
+		{"windsurf", "", true},
+		{"aider", "aider", true},
+		{"bash", "", false},
+		{"sh", "", false},
+		{"ox", "", false},
+		{"", "", false},
+		// hint match without being in known list
+		{"myagent", "myagent", true},
+	}
+	for _, tc := range cases {
+		got := matchesAgent(tc.name, tc.hint, known)
+		if got != tc.want {
+			t.Errorf("matchesAgent(%q, %q, ...) = %v, want %v", tc.name, tc.hint, got, tc.want)
+		}
+	}
+}

--- a/internal/proc/proc_unix.go
+++ b/internal/proc/proc_unix.go
@@ -1,0 +1,45 @@
+//go:build darwin || linux
+
+package proc
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// parentPID returns the parent PID of the given PID using ps.
+func parentPID(pid int) (int, error) {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "ppid=").Output()
+	if err != nil {
+		return 0, fmt.Errorf("ps ppid for %d: %w", pid, err)
+	}
+	ppid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("parse ppid for %d: %w", pid, err)
+	}
+	return ppid, nil
+}
+
+// processName returns the process name for the given PID using ps.
+func processName(pid int) string {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	if err != nil {
+		return ""
+	}
+	// ps returns the full path on some systems; use the base name
+	name := strings.TrimSpace(string(out))
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}
+
+// isAliveProc checks if a process is alive using kill(pid, 0).
+func isAliveProc(proc *os.Process) bool {
+	err := proc.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package proc
+
+import "os"
+
+// parentPID is not implemented on Windows; returns unsupported.
+func parentPID(_ int) (int, error) {
+	return 0, nil
+}
+
+// processName is not implemented on Windows.
+func processName(_ int) string {
+	return ""
+}
+
+// isAliveProc checks if a process is alive by sending signal 0.
+// On Windows, os.FindProcess always succeeds; use process.Wait as a proxy.
+func isAliveProc(proc *os.Process) bool {
+	// On Windows, Signal(0) is not supported. Best-effort: assume alive if findProcess succeeded.
+	return proc != nil
+}

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -520,9 +520,13 @@ func cleanupGhosts(states []*RecordingState) GhostCleanupResult {
 			continue
 		}
 
-		// parent is dead — check if there's any real data
-		if RawJSONLHasData(state.SessionPath) {
-			// has raw.jsonl with content — this is an orphan, not a ghost.
+		// parent is dead — check if there's any real data beyond the header line.
+		// Use HasSubstantiveEntries (2+ lines) rather than RawJSONLHasData (size > 0)
+		// because writeRawHeader always writes a 1-line metadata header at session start.
+		// A header-only file has no recoverable session content and should be cleaned up.
+		rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+		if HasSubstantiveEntries(rawPath) {
+			// has session entries — this is an orphan, not a ghost.
 			// don't delete: it has recoverable data.
 			continue
 		}

--- a/internal/session/recording_test.go
+++ b/internal/session/recording_test.go
@@ -1580,6 +1580,34 @@ func TestCleanupGhostSessionsInDir_PreservesOrphanWithData(t *testing.T) {
 	assert.NoError(t, err, "orphan recording marker should be preserved")
 }
 
+func TestCleanupGhostSessionsInDir_RemovesHeaderOnlyRawJSONL(t *testing.T) {
+	// Regression test: writeRawHeader always writes a 1-line metadata header to raw.jsonl
+	// at session start. A header-only file (size > 0, but 1 line) has no real session
+	// content and should be treated as a ghost, not an orphan.
+	sessionsDir := filepath.Join(t.TempDir(), "sessions")
+	sessionPath := filepath.Join(sessionsDir, "2026-01-01T00-00-user-OxHead")
+	require.NoError(t, os.MkdirAll(sessionPath, 0755))
+
+	state := &RecordingState{
+		AgentID:     "OxHead",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+		SessionPath: sessionPath,
+		ParentPID:   99999999,
+	}
+	data, _ := json.Marshal(state)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, recordingFile), data, 0600))
+
+	// write ONLY the header line (what writeRawHeader produces)
+	headerOnly := `{"schema_version":"1","agent_id":"OxHead","started_at":"2026-01-01T00:00:00Z"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, "raw.jsonl"), []byte(headerOnly), 0600))
+
+	result := CleanupGhostSessionsInDir(sessionsDir)
+	assert.Equal(t, 1, result.Removed, "header-only raw.jsonl is a ghost, not an orphan — should be cleaned")
+
+	_, err := os.Stat(filepath.Join(sessionPath, recordingFile))
+	assert.True(t, os.IsNotExist(err), "ghost recording marker should be removed")
+}
+
 func TestCleanupGhostSessionsInDir_SkipsLiveProcess(t *testing.T) {
 	sessionsDir := filepath.Join(t.TempDir(), "sessions")
 	sessionPath := filepath.Join(sessionsDir, "2026-01-01T00-00-user-OxLive")

--- a/tests/integration/agents/claude/hook_session_recording_test.go
+++ b/tests/integration/agents/claude/hook_session_recording_test.go
@@ -26,13 +26,12 @@ import (
 // creates a .recording.json with a ParentPID that is actually alive.
 //
 // This is a regression test for a bug where:
-//   - The hook spawns `ox agent prime` as a subprocess
-//   - Prime captured os.Getppid() = the transient hook process PID
-//   - The hook process exits immediately after
+//   - The hook runs inside a transient bash shell spawned by the agent
+//   - os.Getppid() in any hook subprocess returns the bash PID, which dies immediately
 //   - The session appears as orphan/ghost because the tracked PID is dead
 //
-// The fix passes OX_PARENT_PID from the hook (its own parent = the agent) down
-// to prime, so the recorded ParentPID is the long-lived agent process.
+// The fix uses proc.FindAgentAncestorPID() to walk the process tree and find the
+// long-lived agent process (e.g., claude), rather than relying on os.Getppid().
 func TestHookSessionStart_RecordingState(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")


### PR DESCRIPTION
## Problem

Active sessions showed as `ghost` or `orphan` in `ox session list` because the wrong `parent_pid` was being recorded — a transient bash shell PID that died immediately, rather than the long-lived agent process (e.g., `claude`).

Hook commands run inside a transient bash shell spawned by the agent:

```
claude (81690) → bash (dies) → ox agent hook → ox agent prime
                                                    ↑
                                            os.Getppid() = bash PID (dead)
```

`os.Getppid()` at any point in the hook subprocess chain captures the bash PID. The `OX_PARENT_PID` env var mechanism meant to fix this also captured the bash PID.

## Fix

New `internal/proc` package with `FindAgentAncestorPID()` that walks the process tree upward from `os.Getppid()` to find the first ancestor matching a known agent binary.

```mermaid
sequenceDiagram
    participant C as claude (81690)
    participant B as bash (transient)
    participant H as ox agent hook
    participant P as ox agent prime

    C->>B: spawn hook command
    B->>H: exec ox agent hook
    H->>H: proc.FindAgentAncestorPID()
    Note over H: walks: ox→bash→claude ✓ PID=81690
    H->>P: OX_PARENT_PID=81690
    P->>P: startSessionRecording(parentPID=81690)
    B-->>C: exits (bash dies)
    Note over C: PID 81690 still alive → session stays "recording" ✓
```

**Agent discovery:** Uses `AGENT_ENV` → `agentx.ResolveAgentENV()` as a hint to prioritize the correct binary, with `agentx.SupportedAgents` as the fallback list — stays in sync automatically as new agents are added.

**Also fixed:** The hook update logic (called on every hook event) was unconditionally overwriting `parent_pid` with the latest transient shell PID. Now only updates if the stored PID is confirmed dead.

## Locations fixed

| File | Location | What was wrong |
|------|----------|----------------|
| `cmd/ox/agent_prime.go` | `startSessionRecording` | `os.Getppid()` for session `ParentPID` |
| `cmd/ox/agent_prime.go` | `SessionMarker` writes (×2) | `os.Getppid()` for marker `ParentPID` |
| `cmd/ox/agent_prime.go` | `agentinstance.Instance` create | `os.Getppid()` for instance `ParentPID` |
| `cmd/ox/agent_hook.go` | `OX_PARENT_PID` env var | Set to bash PID instead of agent PID |
| `cmd/ox/agent_hook.go` | hook update logic | Overwrote PID on every hook call |
| `cmd/ox/agent_session.go` | manual session start | `os.Getppid()` for session `ParentPID` |
| `cmd/ox/heartbeat.go` | heartbeat payload (×3) | `os.Getppid()` for heartbeat `ParentPID` |

Also: daemon `session_finalize.go` now scans `ledgerPath/.sageox/cache/sessions/` (the primary write location) in addition to the git-tracked sessions dir — previously it missed live recordings entirely.

## Test plan

- [x] `go test ./internal/proc/` — process tree walking unit tests
- [x] `go test ./cmd/ox/` — all hook and session tests
- [x] `go test ./internal/session/` — ghost/orphan classification tests
- [x] Manual: `ox session list` shows current session as `recording` not `ghost`
- [ ] `make test-integration` — real Claude session e2e

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parent process detection for session recording to reliably identify long-lived agent processes instead of transient shell parents
  * Enhanced ghost session cleanup to properly detect and remove abandoned recordings across all cache tiers
  * Fixed raw data file validation to correctly identify header-only recordings as eligible for cleanup

* **Tests**
  * Added process discovery and ghost session cleanup regression tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->