### PR TITLE
fix(codedb): skip indexing when ledger not yet cloned

### DIFF
--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -142,6 +143,19 @@ func (m *CodeDBManager) resolveSharedDataDir() string {
 	return dir
 }
 
+// ledgerRootForDataDir returns the ledger root directory if dataDir is inside a
+// ledger's .sageox/cache/ tree. Returns "" if dataDir is not a ledger-based path.
+// The shared CodeDB path is <ledger_root>/.sageox/cache/codedb/, so we look for
+// the /.sageox/cache/ suffix to extract the ledger root.
+func (m *CodeDBManager) ledgerRootForDataDir(dataDir string) string {
+	// CodeDBSharedDir produces: <ledger_root>/.sageox/cache/codedb
+	const marker = string(filepath.Separator) + ".sageox" + string(filepath.Separator) + "cache" + string(filepath.Separator)
+	if idx := strings.Index(dataDir, marker); idx > 0 {
+		return dataDir[:idx]
+	}
+	return ""
+}
+
 // SetLedgerPath sets the ledger checkout path for GitHub data indexing.
 // Called by the daemon when the ledger workspace is discovered.
 func (m *CodeDBManager) SetLedgerPath(path string) {
@@ -211,6 +225,17 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 	}
 
 	dataDir := m.resolveSharedDataDir()
+
+	// Guard: if dataDir lives inside a ledger that hasn't been cloned yet,
+	// skip indexing. Without this check, os.MkdirAll(dataDir) creates the
+	// ledger root directory as a side effect, which causes the subsequent
+	// git clone to fail with "already exists and is not an empty directory".
+	if ledgerRoot := m.ledgerRootForDataDir(dataDir); ledgerRoot != "" {
+		gitDir := filepath.Join(ledgerRoot, ".git")
+		if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+			return nil, fmt.Errorf("ledger not yet cloned at %s, skipping index", ledgerRoot)
+		}
+	}
 
 	target := projectRoot
 	if payload.URL != "" {


### PR DESCRIPTION
## Summary

- **Fix race condition** between codedb indexing and ledger cloning during `ox init`
- codedb's `doIndex()` calls `os.MkdirAll()` on the shared data dir (inside the ledger path), which creates the ledger root directory as a side effect — before the ledger has been cloned
- The subsequent `git clone` fails with "already exists and is not an empty directory"
- Added a guard in `doIndex()` that checks whether the ledger root is a valid git repo before proceeding. If the ledger hasn't been cloned yet, indexing is skipped and will succeed on the next freshness check

## Test plan

- [ ] Run `ox init` on a fresh repo and verify `ox status` shows successful ledger clone
- [ ] Verify codedb indexes successfully after ledger clone completes
- [ ] Existing daemon tests pass (`go test ./internal/daemon/ -short`)

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexing logic to detect and gracefully skip index operations when a ledger repository has not yet been cloned. The system now validates repository prerequisites before processing and provides clear error messaging to guide users through incomplete setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->