### PR TITLE
fix(doctor): use version.Full() for daemon version comparison

### DIFF
--- a/cmd/ox/doctor_daemon.go
+++ b/cmd/ox/doctor_daemon.go
@@ -202,7 +202,7 @@ func checkDaemonVersion(fix bool) checkResult {
 		}
 	}
 
-	cliVersion := version.Version
+	cliVersion := version.Full()
 	daemonVersion := status.Version
 
 	if daemonVersion == cliVersion {


### PR DESCRIPTION
## Summary

The `checkDaemonVersion` doctor check compared `version.Version` (bare `0.5.1`) against the daemon's status which uses `version.Full()` (`0.5.1+<build-timestamp>`). Since every build produces a unique timestamp, the comparison always reported a mismatch even when the version was identical. Fixed by using `version.Full()` on the CLI side too, matching what `heartbeat.go` already does.

## Test plan

- [x] `go build` compiles cleanly
- [x] `ox doctor` no longer reports false version mismatch
- [x] Verified on two repos (`test-code`, `test-code2`)

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved daemon version checking accuracy to properly determine if the daemon is up-to-date with the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->