### PR TITLE
audit: annotate offline-safe fallbacks for local-only git repos

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -744,6 +744,7 @@ func buildGuidance(agentID, projectRoot string, teamCtx *teamContextInfo, ledger
 // repoSlugFromRemoteOrDir extracts "owner/repo" from git remote origin URL,
 // falling back to the directory name if the remote is unavailable.
 // Examples: "sageox/ox", "my-project"
+// offline-safe: falls back to directory name for local-only repos
 func repoSlugFromRemoteOrDir(projectRoot string) string {
 	cmd := exec.Command("git", "remote", "get-url", "origin")
 	cmd.Dir = projectRoot

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -30,6 +30,12 @@ func checkGitAuth() checkResult {
 		return SkippedCheck("Git auth", "not in git repo", "")
 	}
 
+	// offline-safe: auth checks are irrelevant for local-only repos with no remotes
+	urls, _ := repotools.GetRemoteURLs()
+	if len(urls) == 0 {
+		return SkippedCheck("Git auth", "no remotes configured (local-only repo)", "")
+	}
+
 	// check if credential helper is configured
 	credHelper := getGitConfigValue("credential.helper")
 	if credHelper != "" {
@@ -81,6 +87,7 @@ func checkSSHAuth() bool {
 
 // checkGitConnectivity verifies network connectivity to git remotes.
 // Pings the configured origin remote to check reachability.
+// offline-safe: skipped when no origin remote exists (local-only project repo)
 func checkGitConnectivity() checkResult {
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
@@ -216,8 +223,9 @@ func checkGitRemotes() checkResult {
 	}
 
 	if len(urls) == 0 {
+		// offline-safe: local-only repos have no remotes; this is a valid configuration
 		return InfoCheck("Git remotes", "no remotes configured",
-			"Add a remote with `git remote add origin <url>`")
+			"Local-only repo (no remote configured)")
 	}
 
 	// check for origin specifically

--- a/cmd/ox/doctor_git_repos_test.go
+++ b/cmd/ox/doctor_git_repos_test.go
@@ -413,8 +413,8 @@ func TestCheckGitRemotes_NoRemotes(t *testing.T) {
 	if !result.warning {
 		t.Error("expected warning when no remotes configured")
 	}
-	if !strings.Contains(result.detail, "git remote add origin") {
-		t.Error("expected detail to suggest adding remote")
+	if !strings.Contains(result.detail, "Local-only repo") {
+		t.Error("expected detail to indicate local-only repo")
 	}
 }
 

--- a/cmd/ox/doctor_sageox.go
+++ b/cmd/ox/doctor_sageox.go
@@ -589,7 +589,7 @@ func registerRepoWithSageOx(gitRoot string, cfg *config.ProjectConfig) (string, 
 	// get repo_salt from initial commit hash
 	repoSalt, _ := repotools.GetInitialCommitHash()
 
-	// get and hash remote URLs
+	// offline-safe: remote URL hashing is best-effort; registration works without remotes
 	remoteURLs, _ := repotools.GetRemoteURLs()
 	var repoRemoteHashes []string
 	if repoSalt != "" && len(remoteURLs) > 0 {

--- a/cmd/ox/index.go
+++ b/cmd/ox/index.go
@@ -214,6 +214,7 @@ func runIndexGitHub(cmd *cobra.Command, args []string) error {
 }
 
 // detectGitHubRemote finds the GitHub owner/repo from git remotes.
+// offline-safe: returns error for non-GitHub/local-only repos; caller handles gracefully
 func detectGitHubRemote() (owner, repo string, err error) {
 	urls, err := repotools.GetRemoteURLs()
 	if err != nil {

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -210,7 +210,7 @@ func checkRemoteSageoxExists(gitRoot string) (found bool, stale bool, err error)
 		}
 	}
 
-	// tier 2: use git ls-remote to check if local refs are stale
+	// offline-safe: ls-remote fails for local-only repos; caller treats error as "not found, continue"
 	cmd := exec.Command("git", "-C", gitRoot, "ls-remote", "--heads", "origin")
 	out, err := cmd.Output()
 	if err != nil {
@@ -305,7 +305,7 @@ func runInit() error {
 		return cli.ErrSilent
 	}
 
-	// add remote URL hashes to fingerprint
+	// offline-safe: remote hashes are optional; registration works for local-only repos
 	if hashErr := fingerprint.WithRemoteHashes(); hashErr != nil {
 		cli.PrintWarning(fmt.Sprintf("Could not add remote hashes: %v", hashErr))
 	}

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -224,6 +224,7 @@ func getGitRepoStatus(repoPath string, lastSync time.Time, hasLastSync bool) git
 
 // getGitRemoteURL returns the origin remote URL for a git repo.
 // Returns empty string on error or if remote doesn't exist.
+// offline-safe: returns "" for local-only repos
 func getGitRemoteURL(repoPath string) string {
 	if repoPath == "" {
 		return ""

--- a/internal/daemon/github_sync.go
+++ b/internal/daemon/github_sync.go
@@ -219,6 +219,7 @@ func (m *GitHubSyncManager) resolveRemote() (string, string, error) {
 	}
 	m.mu.Unlock()
 
+	// offline-safe: returns error for local-only repos; GitHub sync skips entirely
 	urls, err := repotools.GetRemoteURLsForDir(m.projectRoot)
 	if err != nil {
 		return "", "", fmt.Errorf("get git remotes: %w", err)

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1536,6 +1536,7 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 //
 // This is cheaper than git fetch because ls-remote only hits /info/refs (1 HTTP
 // round-trip) without git-upload-pack negotiation or packfile transfer.
+// offline-safe: returns false on any error, causing fallback to normal fetch+pull path
 func (s *SyncScheduler) remoteRefCheck(ctx context.Context, repoPath string) bool {
 	lsCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/internal/gitserver/pat_liveness.go
+++ b/internal/gitserver/pat_liveness.go
@@ -33,6 +33,7 @@ type PATLivenessResult struct {
 //
 // Requires at least one repo URL in credentials to probe against.
 // Timeout should be kept short (3s) so callers (doctor, status) stay responsive.
+// offline-safe: returns Skipped when no credentials or repo URLs available
 func ValidatePATLiveness(ctx context.Context, creds *GitCredentials) PATLivenessResult {
 	if creds == nil || creds.Token == "" {
 		return PATLivenessResult{Skipped: true, Reason: "no credentials"}

--- a/internal/gitserver/remote.go
+++ b/internal/gitserver/remote.go
@@ -17,6 +17,7 @@ import (
 // No-op for SSH URLs, local remotes, or non-oauth2 usernames (deploy tokens).
 // Returns nil on success or no-op. Returns an error if credentials are unavailable
 // or the git command fails — callers should log and continue, not abort.
+// offline-safe: returns error when no origin exists; callers handle gracefully
 //
 // endpointURL is used as a hint for credential lookup. If empty, the endpoint
 // is derived from the remote URL's host (e.g., git.sageox.ai → sageox.ai).
@@ -165,6 +166,7 @@ func extractPATFromRemote(repoPath string) (pat string, remoteURL string, err er
 // GetBareRemoteURL returns the origin remote URL with credentials stripped.
 // Useful when you need the repo URL for API derivation (e.g., LFS batch endpoint)
 // without embedding the PAT.
+// offline-safe: returns error for repos with no origin remote; callers must handle
 func GetBareRemoteURL(repoPath string) (string, error) {
 	_, remoteURL, err := extractPATFromRemote(repoPath)
 	if err != nil {

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -208,6 +208,7 @@ func ResolveWithConfig(cfg *Config) (*ResolvedIdentities, error) {
 //
 // Privacy: We explicitly do NOT probe providers that aren't in the remote list.
 // This means we never make unnecessary API calls or leak credential presence.
+// offline-safe: returns nil for local-only repos; identity resolution falls back to git config
 func detectProvidersFromRemotes() ([]ProviderType, []string) {
 	urls, err := repotools.GetRemoteURLs()
 	if err != nil {

--- a/internal/repotools/fingerprint.go
+++ b/internal/repotools/fingerprint.go
@@ -142,6 +142,7 @@ func ComputeFingerprint() (*RepoFingerprint, error) {
 // WithRemoteHashes adds salted remote URL hashes to the fingerprint.
 // Call this after ComputeFingerprint() to include remote URL identity.
 // The hashes are salted with FirstCommit to prevent enumeration.
+// offline-safe: remote hashes are optional; fingerprint is valid without them
 func (f *RepoFingerprint) WithRemoteHashes() error {
 	if f == nil || f.FirstCommit == "" {
 		return fmt.Errorf("fingerprint has no first commit for salting")

--- a/internal/repotools/service.go
+++ b/internal/repotools/service.go
@@ -86,6 +86,7 @@ func GetInitialCommitHash() (string, error) {
 }
 
 // GetRemoteURLs returns all configured git remote URLs for the current directory.
+// offline-safe: returns empty slice for local-only repos (no remotes configured)
 func GetRemoteURLs() ([]string, error) {
 	return GetRemoteURLsForDir("")
 }
@@ -129,6 +130,7 @@ func GetRemoteURLsForDir(dir string) ([]string, error) {
 
 // getOriginURL returns the normalized URL for the "origin" remote in the given directory.
 // Returns empty string if origin doesn't exist or git fails.
+// offline-safe: returns "" for local-only repos
 func getOriginURL(dir string) string {
 	var cmd *exec.Cmd
 	if dir != "" {
@@ -152,6 +154,7 @@ func getOriginURL(dir string) string {
 // (e.g. git@github.com:sageox/ox.git → "sageox/ox").
 // Falls back to the git root directory name if no remote is available.
 // Uses gitRoot to query remotes (via git -C), not the current working directory.
+// offline-safe: falls back to directory basename when no remotes available
 func GetRepoName(gitRoot string) string {
 	// prefer origin remote explicitly to avoid non-determinism with multiple remotes
 	if normalized := getOriginURL(gitRoot); normalized != "" {

--- a/internal/repotools/url.go
+++ b/internal/repotools/url.go
@@ -73,6 +73,7 @@ func isNumeric(s string) bool {
 // an attacker with server access cannot precompute hashes for known repo URLs
 // like "github.com/company/secret-project" to identify which repos are registered.
 // Each repo's salt is unique, so the same URL produces different hashes for different repos.
+// offline-safe: returns empty slice when urls is empty (local-only repos)
 func HashRemoteURLs(salt string, urls []string) []string {
 	var hashes []string
 	for _, url := range urls {


### PR DESCRIPTION
## Summary

- Audited all 15 code paths that access git remote info from the user's project repo
- Added `// offline-safe:` inline comments documenting how each function handles local-only repos (no remotes configured)
- Fixed `checkGitAuth()` in doctor to skip auth checks entirely for repos with no remotes (was giving misleading advice)
- Changed `checkGitRemotes()` detail message from "Add a remote with \`git remote add origin <url>\`" to "Local-only repo (no remote configured)" — local-only is a valid configuration, not a problem to fix
- Updated test assertions to match the new messaging

## Context

ox works on local-only git repos (no remote configured). Several code paths were silently handling this case correctly but without documentation. This audit adds explicit `// offline-safe:` annotations so future contributors know:
1. Which functions touch git remotes
2. What the fallback behavior is for local-only repos
3. That the fallback is intentional, not accidental

Ledger and team context repos always have remotes (created server-side) — this concern is specifically about the **user's project repo**.

```mermaid
graph TD
    A[User's Project Repo] -->|may be local-only| B{Has remotes?}
    B -->|Yes| C[Normal path: auth, connectivity, fingerprint]
    B -->|No| D[Offline-safe fallbacks]
    D --> D1[doctor: skip auth/connectivity checks]
    D --> D2[fingerprint: valid without remote hashes]
    D --> D3[identity: fall back to git config]
    D --> D4[status: show empty remote URL]
    D --> D5[init: registration works without remotes]
    
    E[Ledger Repo] -->|always has remote| C
    F[Team Context Repo] -->|always has remote| C
```

## Test plan

- [x] Existing `TestCheckGitRemotes_NoRemotes` updated to assert new "Local-only repo" message
- [x] `make lint` passes
- [x] `make test` passes

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated diagnostic messaging for local-only repositories to clarify they have no remote configured, rather than prompting to add one.

* **Documentation**
  * Added clarifications throughout the codebase documenting offline-safe behavior when git remotes are unavailable or not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->