### PR TITLE
fix(build): add freebsd to proc_unix.go build constraint

### DIFF
--- a/internal/proc/proc_unix.go
+++ b/internal/proc/proc_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || linux
+//go:build darwin || linux || freebsd
 
 package proc
 


### PR DESCRIPTION
## Summary

- Adds `freebsd` to the `//go:build` constraint in `internal/proc/proc_unix.go`
- Fixes GoReleaser v0.6.0 release failure — freebsd target couldn't compile because `processName`, `parentPID`, and `isAliveProc` were undefined

## Context

GoReleaser builds for `freebsd/amd64` (added in PR #7), but PR #372 introduced `internal/proc` with a build constraint limited to `darwin || linux`. The syscalls used (`sysctl` for process name, parent PID) are compatible with FreeBSD.

## Test plan

- [x] `GOOS=freebsd GOARCH=amd64 go build ./cmd/ox/` compiles cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended platform support to FreeBSD, enabling the application to run on FreeBSD operating systems in addition to existing macOS and Linux support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->