### PR TITLE
fix(lint): use tagged switch in config TUI

### DIFF
--- a/cmd/ox/config_tui.go
+++ b/cmd/ox/config_tui.go
@@ -708,11 +708,12 @@ func (m configModel) editView(width int) string {
 
 	b.WriteString("\n")
 	levelLabel := string(m.editLevel) + "-level"
-	if m.editLevel == ConfigLevelUser {
+	switch m.editLevel {
+	case ConfigLevelUser:
 		levelLabel += " override (highest priority)"
-	} else if m.editLevel == ConfigLevelRepo {
+	case ConfigLevelRepo:
 		levelLabel += " setting"
-	} else if m.editLevel == ConfigLevelTeam {
+	case ConfigLevelTeam:
 		levelLabel += " default"
 	}
 	b.WriteString(detailMutedStyle.Render("Sets " + levelLabel))


### PR DESCRIPTION
Fixes a staticcheck QF1003 lint warning in `cmd/ox/config_tui.go` by converting an `if/else if` chain on `m.editLevel` to a tagged `switch` statement.

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvement with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->