### PR TITLE
feat(teams): enrich team names from credentials, global discovery

### DIFF
--- a/cmd/ox/team_discovery.go
+++ b/cmd/ox/team_discovery.go
@@ -5,8 +5,12 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/paths"
 )
 
 // enrichedTeam is a fully-resolved team with all fields populated.
@@ -44,6 +48,15 @@ func discoverAllTeams(projectRoot string) []enrichedTeam {
 		return nil
 	}
 
+	// load credentials for name/slug enrichment
+	var creds *gitserver.GitCredentials
+	if projectCfg != nil {
+		ep := endpoint.GetForProject(projectRoot)
+		if ep != "" {
+			creds, _ = gitserver.LoadCredentialsForEndpoint(ep)
+		}
+	}
+
 	// enrich: fill missing names/slugs, mark primary
 	for i := range teams {
 		t := &teams[i]
@@ -52,6 +65,28 @@ func discoverAllTeams(projectRoot string) []enrichedTeam {
 		// enrich primary team name from project config
 		if t.Name == "" && t.Primary && projectCfg != nil {
 			t.Name = projectCfg.TeamName
+		}
+		// enrich from credentials (has server-provided names/slugs)
+		if (t.Name == "" || t.Slug == "") && creds != nil {
+			repo, ok := creds.Repos[t.TeamID]
+			if !ok {
+				// fallback: scan values for legacy name-keyed credentials
+				for _, r := range creds.Repos {
+					if r.TeamID == t.TeamID {
+						repo = r
+						ok = true
+						break
+					}
+				}
+			}
+			if ok {
+				if t.Name == "" {
+					t.Name = repo.Name
+				}
+				if t.Slug == "" && repo.Slug != "" {
+					t.Slug = repo.Slug
+				}
+			}
 		}
 		if t.Name == "" {
 			t.Name = t.TeamID
@@ -74,6 +109,65 @@ func discoverAllTeams(projectRoot string) []enrichedTeam {
 		}
 	}
 	return append(primary, others...)
+}
+
+// discoverTeamsGlobal returns teams from all authenticated endpoints.
+// Used when not inside a SageOx project (no project root available).
+// Discovers teams from git credentials across all endpoints.
+func discoverTeamsGlobal() []enrichedTeam {
+	endpoints, err := auth.ListEndpoints()
+	if err != nil || len(endpoints) == 0 {
+		return nil
+	}
+
+	var teams []enrichedTeam
+	seen := make(map[string]bool)
+
+	for _, ep := range endpoints {
+		creds, err := gitserver.LoadCredentialsForEndpoint(ep)
+		if err != nil || creds == nil {
+			continue
+		}
+		for key, repo := range creds.Repos {
+			if repo.Type != "team-context" {
+				continue
+			}
+			teamID := repo.StableID()
+			if teamID == "" {
+				// legacy name-keyed credentials may have TeamID in the key
+				if strings.HasPrefix(key, "team_") {
+					teamID = key
+				} else {
+					continue
+				}
+			}
+			if seen[teamID] {
+				continue
+			}
+			seen[teamID] = true
+
+			name := repo.Name
+			if name == "" {
+				name = teamID
+			}
+			slug := repo.Slug
+			if slug == "" {
+				slug = api.DeriveSlug(name)
+			}
+			if slug == "" {
+				slug = teamID
+			}
+
+			teamPath := paths.TeamContextDir(teamID, ep)
+			teams = append(teams, enrichedTeam{
+				TeamID: teamID,
+				Name:   name,
+				Slug:   slug,
+				Path:   teamPath,
+			})
+		}
+	}
+	return teams
 }
 
 // resolveTeamByQuery finds a team by slug, team ID, or name.

--- a/cmd/ox/teams.go
+++ b/cmd/ox/teams.go
@@ -74,20 +74,16 @@ func runTeams(cmd *cobra.Command, args []string) error {
 	jsonMode, _ := cmd.Flags().GetBool("json")
 	out := cmd.OutOrStdout()
 
-	projectRoot, err := findProjectRoot()
-	if err != nil {
-		if jsonMode {
-			return json.NewEncoder(out).Encode(teamsOutput{
-				Teams:    []teamEntry{},
-				Guidance: "Run 'ox init' to set up a project.",
-			})
-		}
-		fmt.Fprintln(out, "Not in a SageOx project.")
-		fmt.Fprintln(out, "Run 'ox init' to set up.")
-		return nil
+	projectRoot, _ := findProjectRoot()
+
+	var teams []enrichedTeam
+	if projectRoot != "" {
+		teams = discoverAllTeams(projectRoot)
+	} else {
+		// not in a project — discover from credentials across all endpoints
+		teams = discoverTeamsGlobal()
 	}
 
-	teams := discoverAllTeams(projectRoot)
 	var primaryTeamID string
 	for _, t := range teams {
 		if t.Primary {
@@ -122,7 +118,10 @@ func runTeams(cmd *cobra.Command, args []string) error {
 	}
 
 	// compute root dir — path is always root/team_id so no need to show per-team
-	ep := endpoint.GetForProject(projectRoot)
+	var ep string
+	if projectRoot != "" {
+		ep = endpoint.GetForProject(projectRoot)
+	}
 	var rootDir string
 	if ep != "" {
 		rootDir = paths.TeamsDataDir(ep)
@@ -216,7 +215,7 @@ func runTeams(cmd *cobra.Command, args []string) error {
 func enrichedTeamsToEntries(teams []enrichedTeam) []teamEntry {
 	entries := make([]teamEntry, 0, len(teams))
 	for _, t := range teams {
-		sync := "unknown"
+		sync := "never"
 		if !t.LastSync.IsZero() {
 			sync = formatAge(time.Since(t.LastSync))
 		}

--- a/cmd/ox/teams_coverage_test.go
+++ b/cmd/ox/teams_coverage_test.go
@@ -44,7 +44,7 @@ func TestEnrichedTeamsToEntries(t *testing.T) {
 			},
 		},
 		{
-			name: "team with zero sync time shows unknown",
+			name: "team with zero sync time shows never",
 			teams: []enrichedTeam{
 				{
 					TeamID: "team_xyz",
@@ -57,7 +57,7 @@ func TestEnrichedTeamsToEntries(t *testing.T) {
 					TeamID:   "team_xyz",
 					Name:     "Unsynced",
 					Slug:     "unsynced",
-					LastSync: "unknown",
+					LastSync: "never",
 				},
 			},
 		},
@@ -69,9 +69,9 @@ func TestEnrichedTeamsToEntries(t *testing.T) {
 				{TeamID: "team_3", Name: "Third", Slug: "third"},
 			},
 			want: []teamEntry{
-				{TeamID: "team_1", Name: "First", Slug: "first", LastSync: "unknown"},
-				{TeamID: "team_2", Name: "Second", Slug: "second", Primary: true, LastSync: "unknown"},
-				{TeamID: "team_3", Name: "Third", Slug: "third", LastSync: "unknown"},
+				{TeamID: "team_1", Name: "First", Slug: "first", LastSync: "never"},
+				{TeamID: "team_2", Name: "Second", Slug: "second", Primary: true, LastSync: "never"},
+				{TeamID: "team_3", Name: "Third", Slug: "third", LastSync: "never"},
 			},
 		},
 	}
@@ -89,11 +89,11 @@ func TestEnrichedTeamsToEntries(t *testing.T) {
 				assert.Equal(t, want.Primary, got[i].Primary)
 				assert.Equal(t, want.Path, got[i].Path)
 
-				if want.LastSync == "unknown" {
-					assert.Equal(t, "unknown", got[i].LastSync)
+				if want.LastSync == "never" {
+					assert.Equal(t, "never", got[i].LastSync)
 				} else if want.LastSync != "" {
-					// for non-zero sync times, just verify it's not "unknown"
-					assert.NotEqual(t, "unknown", got[i].LastSync)
+					// for non-zero sync times, just verify it's not "never"
+					assert.NotEqual(t, "never", got[i].LastSync)
 				}
 			}
 		})
@@ -115,7 +115,7 @@ func TestEnrichedTeamsToEntries_RecentSync(t *testing.T) {
 
 	entries := enrichedTeamsToEntries(teams)
 	assert.Len(t, entries, 1)
-	assert.NotEqual(t, "unknown", entries[0].LastSync)
+	assert.NotEqual(t, "never", entries[0].LastSync)
 	// should be a short duration string
 	assert.NotEmpty(t, entries[0].LastSync)
 }
@@ -134,5 +134,5 @@ func TestEnrichedTeamsToEntries_OldSync(t *testing.T) {
 
 	entries := enrichedTeamsToEntries(teams)
 	assert.Len(t, entries, 1)
-	assert.NotEqual(t, "unknown", entries[0].LastSync)
+	assert.NotEqual(t, "never", entries[0].LastSync)
 }

--- a/internal/daemon/sync_discovery.go
+++ b/internal/daemon/sync_discovery.go
@@ -154,7 +154,7 @@ func (s *SyncScheduler) discoverTeams() {
 			TeamID: repo.StableID(),
 			Slug:   repo.Slug,
 		}
-		newRepos[entry.Name] = entry
+		newRepos[entry.StableID()] = entry
 	}
 
 	// check if repos changed before writing


### PR DESCRIPTION
## Summary

- **Credential-based name/slug enrichment**: `discoverAllTeams()` now loads git credentials to fill missing team names and slugs from server-provided data, with a legacy fallback for name-keyed credentials
- **Global team discovery**: `ox teams` works outside a SageOx project by discovering teams from credentials across all authenticated endpoints via new `discoverTeamsGlobal()`
- **Sync label fix**: Changed unsynced team display from "unknown" to "never" for accuracy
- **Daemon bug fix**: Fixed `discoverTeams()` keying repos map by `entry.Name` instead of `entry.StableID()`, which could cause incorrect dedup and lookup failures

## Test plan

- [x] Updated `teams_coverage_test.go` to match "never" string change
- [ ] Verify `ox teams` outside a project shows teams from all endpoints
- [ ] Verify `ox teams` inside a project enriches names/slugs from credentials
- [ ] Verify daemon discovers teams correctly with StableID keying

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teams can now be discovered globally when outside a project directory.

* **Bug Fixes**
  * Corrected team sync status display to show "never" instead of "unknown" for teams not yet synced.

* **Tests**
  * Updated test expectations for team sync status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->