### PR TITLE
feat(session): capture tool errors from hook stdin in recordings

### DIFF
--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -384,6 +384,21 @@ func handleAfterTool(ctx *HookContext) error {
 	redactor, _ := session.NewRedactorWithCustomRules(ctx.ProjectRoot)
 
 	sessionEntries := session.ConvertRawEntries(entries)
+
+	// enrich the last tool entry with error data from hook stdin.
+	// hook stdin provides real-time error info that isn't in the JSONL file.
+	if ctx.Input != nil && ctx.Input.ToolError != "" {
+		for i := len(sessionEntries) - 1; i >= 0; i-- {
+			if sessionEntries[i].Type == session.EntryTypeTool {
+				sessionEntries[i].IsError = true
+				if sessionEntries[i].ToolOutput == "" {
+					sessionEntries[i].ToolOutput = ctx.Input.ToolError
+				}
+				break
+			}
+		}
+	}
+
 	redactor.RedactEntries(sessionEntries)
 
 	rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
@@ -441,6 +456,9 @@ func appendRedactedEntries(rawPath string, entries []session.Entry) error {
 		}
 		if entry.ToolOutput != "" {
 			data["tool_output"] = entry.ToolOutput
+		}
+		if entry.IsError {
+			data["is_error"] = true
 		}
 		if err := encoder.Encode(data); err != nil {
 			return fmt.Errorf("encode entry: %w", err)

--- a/cmd/ox/hooks_claude_test.go
+++ b/cmd/ox/hooks_claude_test.go
@@ -529,6 +529,56 @@ func TestAppendRedactedEntries_OmitsEmptyToolFields(t *testing.T) {
 	assert.NotContains(t, string(data), "tool_name")
 	assert.NotContains(t, string(data), "tool_input")
 	assert.NotContains(t, string(data), "tool_output")
+	assert.NotContains(t, string(data), "is_error")
+}
+
+func TestAppendRedactedEntries_WritesIsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	rawPath := filepath.Join(tmpDir, "raw.jsonl")
+
+	entries := []session.Entry{
+		{
+			Type:       session.EntryTypeTool,
+			ToolName:   "Bash",
+			ToolInput:  `{"command":"make build"}`,
+			ToolOutput: "exit code 1: compilation failed",
+			IsError:    true,
+			Timestamp:  time.Now(),
+		},
+	}
+
+	require.NoError(t, appendRedactedEntries(rawPath, entries))
+
+	data, err := os.ReadFile(rawPath)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	assert.Equal(t, "Bash", parsed["tool_name"])
+	assert.Equal(t, "exit code 1: compilation failed", parsed["tool_output"])
+	assert.Equal(t, true, parsed["is_error"])
+}
+
+func TestAppendRedactedEntries_OmitsIsErrorWhenFalse(t *testing.T) {
+	tmpDir := t.TempDir()
+	rawPath := filepath.Join(tmpDir, "raw.jsonl")
+
+	entries := []session.Entry{
+		{
+			Type:      session.EntryTypeTool,
+			ToolName:  "Read",
+			ToolInput: "/path/to/file",
+			Timestamp: time.Now(),
+		},
+	}
+
+	require.NoError(t, appendRedactedEntries(rawPath, entries))
+
+	data, err := os.ReadFile(rawPath)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), "is_error")
 }
 
 func TestAppendRedactedEntries_MultipleEntriesAppend(t *testing.T) {

--- a/internal/session/adapters/adapter.go
+++ b/internal/session/adapters/adapter.go
@@ -41,6 +41,13 @@ type RawEntry struct {
 	// ToolInput is the input provided to the tool (only for role="tool")
 	ToolInput string
 
+	// ToolOutput is the output from the tool (only for role="tool").
+	// Only populated for error results to keep recordings lean.
+	ToolOutput string
+
+	// IsError indicates the tool call failed (only for role="tool")
+	IsError bool
+
 	// Raw contains the original data for debugging and auditing
 	Raw json.RawMessage
 }

--- a/internal/session/convert.go
+++ b/internal/session/convert.go
@@ -23,10 +23,12 @@ func ConvertRawEntries(rawEntries []adapters.RawEntry) []Entry {
 	entries := make([]Entry, 0, len(rawEntries))
 	for _, raw := range rawEntries {
 		entry := Entry{
-			Timestamp: raw.Timestamp,
-			Content:   raw.Content,
-			ToolName:  raw.ToolName,
-			ToolInput: raw.ToolInput,
+			Timestamp:  raw.Timestamp,
+			Content:    raw.Content,
+			ToolName:   raw.ToolName,
+			ToolInput:  raw.ToolInput,
+			ToolOutput: raw.ToolOutput,
+			IsError:    raw.IsError,
 		}
 		entry.Type = MapRoleToEntryType(raw.Role)
 		entries = append(entries, entry)

--- a/internal/session/convert_test.go
+++ b/internal/session/convert_test.go
@@ -76,4 +76,37 @@ func TestConvertRawEntries(t *testing.T) {
 		assert.Equal(t, "Bash", result[2].ToolName)
 		assert.Equal(t, "ls -la", result[2].ToolInput)
 	})
+
+	t.Run("preserves tool error fields", func(t *testing.T) {
+		now := time.Now().Truncate(time.Second)
+		rawEntries := []adapters.RawEntry{
+			{
+				Timestamp:  now,
+				Role:       "tool",
+				ToolName:   "Bash",
+				ToolInput:  `{"command":"make build"}`,
+				ToolOutput: "exit code 1: compilation failed",
+				IsError:    true,
+			},
+			{
+				Timestamp: now.Add(time.Second),
+				Role:      "tool",
+				ToolName:  "Read",
+				ToolInput: "/path/to/file.go",
+			},
+		}
+
+		result := ConvertRawEntries(rawEntries)
+		require.Len(t, result, 2)
+
+		// error tool entry preserves output and error flag
+		assert.Equal(t, "Bash", result[0].ToolName)
+		assert.Equal(t, "exit code 1: compilation failed", result[0].ToolOutput)
+		assert.True(t, result[0].IsError)
+
+		// non-error tool entry has no output or error
+		assert.Equal(t, "Read", result[1].ToolName)
+		assert.Empty(t, result[1].ToolOutput)
+		assert.False(t, result[1].IsError)
+	})
 }

--- a/internal/session/enrich.go
+++ b/internal/session/enrich.go
@@ -22,9 +22,10 @@ type EnrichMessage struct {
 
 // EnrichToolCall holds tool invocation details for enrichment.
 type EnrichToolCall struct {
-	Name   string
-	Input  string
-	Output string
+	Name    string
+	Input   string
+	Output  string
+	IsError bool
 }
 
 // EnrichChapterView groups conversation turns into a narrative section.
@@ -43,11 +44,12 @@ type EnrichChapterItem struct {
 
 // EnrichWorkBlock groups consecutive tool/system calls.
 type EnrichWorkBlock struct {
-	Messages   []EnrichMessage
-	ToolCounts map[string]int
-	Summary    string
-	TotalTools int
-	HasEdits   bool
+	Messages    []EnrichMessage
+	ToolCounts  map[string]int
+	Summary     string
+	TotalTools  int
+	TotalErrors int
+	HasEdits    bool
 }
 
 // EnrichFileChange represents a file modified during the session.
@@ -99,6 +101,7 @@ func EnrichSummary(stored *StoredSession, summary *SummarizeResponse) {
 			}
 			if item.WorkBlock != nil {
 				cs.TotalTools += item.WorkBlock.TotalTools
+				cs.TotalErrors += item.WorkBlock.TotalErrors
 				cs.HasEdits = cs.HasEdits || item.WorkBlock.HasEdits
 				for name, count := range item.WorkBlock.ToolCounts {
 					toolCounts[name] += count
@@ -187,11 +190,13 @@ func buildEnrichMessage(id int, entry map[string]any, userLabel, agentLabel stri
 		toolName, _ := entry["tool_name"].(string)
 		toolInput, _ := entry["tool_input"].(string)
 		toolOutput, _ := entry["tool_output"].(string)
+		isError, _ := entry["is_error"].(bool)
 		if toolName != "" {
 			msg.ToolCall = &EnrichToolCall{
-				Name:   toolName,
-				Input:  stripANSI(toolInput),
-				Output: stripANSI(toolOutput),
+				Name:    toolName,
+				Input:   stripANSI(toolInput),
+				Output:  stripANSI(toolOutput),
+				IsError: isError,
 			}
 		}
 	}
@@ -344,6 +349,9 @@ func enrichBuildWorkBlock(messages []EnrichMessage) EnrichWorkBlock {
 		if msg.ToolCall != nil && msg.ToolCall.Name != "" {
 			wb.ToolCounts[msg.ToolCall.Name]++
 			wb.TotalTools++
+			if msg.ToolCall.IsError {
+				wb.TotalErrors++
+			}
 
 			nameLower := strings.ToLower(msg.ToolCall.Name)
 			if nameLower == "edit" || nameLower == "write" || nameLower == "multiedit" {
@@ -425,6 +433,7 @@ func enrichMergeShortAssistantBlocks(items []EnrichChapterItem) []EnrichChapterI
 						prevWB.ToolCounts[name] += count
 					}
 					prevWB.TotalTools += nextWB.TotalTools
+					prevWB.TotalErrors += nextWB.TotalErrors
 					prevWB.HasEdits = prevWB.HasEdits || nextWB.HasEdits
 					prevWB.Summary = enrichFormatWorkBlockSummary(prevWB)
 					i++

--- a/internal/session/history_schema.go
+++ b/internal/session/history_schema.go
@@ -110,6 +110,9 @@ type HistoryEntry struct {
 	// ToolOutput is the output from the tool (for tool entries)
 	ToolOutput string `json:"tool_output,omitempty"`
 
+	// IsError indicates the tool call failed (for tool entries)
+	IsError bool `json:"is_error,omitempty"`
+
 	// Summary is a brief summary of this entry (optional)
 	Summary string `json:"summary,omitempty"`
 
@@ -331,6 +334,7 @@ func (e *HistoryEntry) ToSessionEntry() SessionEntry {
 		ToolName:   e.ToolName,
 		ToolInput:  e.ToolInput,
 		ToolOutput: e.ToolOutput,
+		IsError:    e.IsError,
 	}
 }
 
@@ -345,6 +349,7 @@ func HistoryEntryFromSessionEntry(e SessionEntry, seq int, source string) Histor
 		ToolName:   e.ToolName,
 		ToolInput:  e.ToolInput,
 		ToolOutput: e.ToolOutput,
+		IsError:    e.IsError,
 	}
 }
 

--- a/internal/session/history_store.go
+++ b/internal/session/history_store.go
@@ -174,6 +174,9 @@ func MergeHistoryWithRecording(sessionPath string, history *CapturedHistory) err
 		if he.ToolOutput != "" {
 			entry["tool_output"] = he.ToolOutput
 		}
+		if he.IsError {
+			entry["is_error"] = true
+		}
 		mergedEntries = append(mergedEntries, entry)
 	}
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -39,6 +39,9 @@ type SessionEntry struct {
 	// ToolOutput is the output from the tool (for tool entries)
 	ToolOutput string `json:"tool_output,omitempty"`
 
+	// IsError indicates the tool call failed (for tool entries)
+	IsError bool `json:"is_error,omitempty"`
+
 	// CoworkerName identifies the coworker or subagent that contributed to this entry.
 	// This includes both team coworkers (loaded via ox coworker load) and built-in
 	// Claude Code subagents (invoked via Task tool, e.g., code-reviewer, debugger).

--- a/internal/session/summarize.go
+++ b/internal/session/summarize.go
@@ -53,6 +53,7 @@ func entriesToPkg(entries []Entry) []ss.Entry {
 			ToolName:   e.ToolName,
 			ToolInput:  e.ToolInput,
 			ToolOutput: e.ToolOutput,
+			IsError:    e.IsError,
 		}
 	}
 	return out
@@ -69,6 +70,7 @@ func pkgToEntries(entries []ss.Entry) []Entry {
 			ToolName:   e.ToolName,
 			ToolInput:  e.ToolInput,
 			ToolOutput: e.ToolOutput,
+			IsError:    e.IsError,
 		}
 	}
 	return out

--- a/pkg/sessionsummary/types.go
+++ b/pkg/sessionsummary/types.go
@@ -20,6 +20,7 @@ type Entry struct {
 	ToolName   string    `json:"tool_name,omitempty"`
 	ToolInput  string    `json:"tool_input,omitempty"`
 	ToolOutput string    `json:"tool_output,omitempty"`
+	IsError    bool      `json:"is_error,omitempty"`
 }
 
 // SummarizeResponse contains the LLM-generated summary plus computed metadata.
@@ -127,8 +128,9 @@ type ChapterSummary struct {
 	StartSeq   int            `json:"start_seq"`             // first message seq in this chapter
 	EndSeq     int            `json:"end_seq"`               // last message seq in this chapter
 	ToolCounts map[string]int `json:"tool_counts,omitempty"` // aggregated tool usage {"Read": 5, "Edit": 3}
-	TotalTools int            `json:"total_tools"`           // total tool calls in chapter
-	HasEdits   bool           `json:"has_edits"`             // true if chapter contains file modifications
+	TotalTools  int            `json:"total_tools"`            // total tool calls in chapter
+	TotalErrors int            `json:"total_errors,omitempty"` // tool calls that failed
+	HasEdits    bool           `json:"has_edits"`              // true if chapter contains file modifications
 }
 
 // FileSummary records a file modified during the session.


### PR DESCRIPTION
## Summary

Claude Code pipes structured JSON to hooks via stdin on every `PostToolUse` event, including `tool_name`, `tool_response`, and `error` fields. Previously, all tool-level data was ignored — tool errors were captured **nowhere** in session recordings despite the entire downstream pipeline (enrichment, redaction, markdown rendering, summaries) already handling `tool_output`.

This PR closes the gap by:

- Adding `ToolOutput` and `IsError` fields to `RawEntry` (adapter layer) and wiring them through `ConvertRawEntries`
- Adding `IsError` to `SessionEntry`, `HistoryEntry`, and the pkg `Entry` type
- Enriching the last tool entry in `handleAfterTool` with error data from hook stdin (`ctx.Input.ToolError`)
- Writing `is_error` to `raw.jsonl` via `appendRedactedEntries`
- Counting tool errors in the enrichment pipeline (`EnrichWorkBlock.TotalErrors`, `ChapterSummary.TotalErrors`)

```mermaid
flowchart LR
    A[Hook stdin<br/>tool_name, error] -->|handleAfterTool| B[SessionEntry<br/>IsError, ToolOutput]
    B -->|appendRedactedEntries| C[raw.jsonl<br/>is_error: true]
    C -->|enrich pipeline| D[ChapterSummary<br/>TotalErrors]
    C -->|redaction| E[secrets scanner]
    C -->|markdown| F[session.md]
```

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all pass (11,763 tests, 1 pre-existing flaky test unrelated to changes)
- [x] New tests: `TestConvertRawEntries/preserves_tool_error_fields`, `TestAppendRedactedEntries_WritesIsError`, `TestAppendRedactedEntries_OmitsIsErrorWhenFalse`
- [ ] Manual: Run a Claude Code session with intentional tool failures, verify `raw.jsonl` entries contain `is_error: true` and `tool_output` with error message

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tool call tracking with error status indicators and error counting throughout conversation history and summaries, enabling better monitoring of tool execution failures and outcomes.

* **Tests**
  * Added tests validating error status propagation, error counting in work blocks, and error information persistence across session entries and summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->