### PR TITLE
feat(distill): stateless fact-tracking, per-item GitHub extraction, parallel LLM calls

### DIFF
--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -341,10 +341,14 @@ func readWeeklyFilesForMonth(weeklyDir string, year, month int, tz *time.Locatio
 }
 
 var (
-	distillLayer   string
-	distillDryRun  bool
-	distillSync    bool
-	distillVerbose bool
+	distillLayer       string
+	distillDryRun      bool
+	distillSync        bool
+	distillVerbose     bool
+	distillModel       string
+	distillNoPush      bool
+	distillConcurrency int
+	distillAll         bool
 )
 
 var distillCmd = &cobra.Command{
@@ -368,113 +372,23 @@ func init() {
 	distillCmd.Flags().BoolVar(&distillDryRun, "dry-run", false, "show what would be distilled without invoking the AI coworker")
 	distillCmd.Flags().BoolVar(&distillSync, "sync", false, "sync ledger, team context, and code index before distilling")
 	distillCmd.Flags().BoolVar(&distillVerbose, "verbose", false, "log full prompts to stderr")
+	distillCmd.Flags().StringVar(&distillModel, "model", "", "override the AI coworker model (e.g., sonnet, opus)")
+	distillCmd.Flags().BoolVar(&distillNoPush, "no-push", false, "skip pushing team context commits to remote (useful for testing)")
+	distillCmd.Flags().IntVar(&distillConcurrency, "concurrency", 1, "max parallel LLM calls for fact extraction (1-8)")
+	distillCmd.Flags().BoolVar(&distillAll, "all", false, "process all history (default: last 7 days)")
 
 	rootCmd.AddCommand(distillCmd)
 }
 
-// distillStateV2 tracks per-layer distillation timestamps.
+// distillStateV2 tracks weekly/monthly distillation timestamps.
+// Extraction tracking (sessions, discussions, github) is now stateless —
+// handled via source_hash and query_since/query_until in fact file metadata.
+// Daily distill tracking uses sources frontmatter in daily .md files.
 type distillStateV2 struct {
 	SchemaVersion string `json:"schema_version"`
 	TeamID        string `json:"team_id"`
-	LastDaily     string `json:"last_daily,omitempty"`
 	LastWeekly    string `json:"last_weekly,omitempty"`
 	LastMonthly   string `json:"last_monthly,omitempty"`
-	DailyCount    int    `json:"daily_count"`
-	// content hash of last distilled input — skip LLM call if unchanged
-	LastDailyHash   string `json:"last_daily_hash,omitempty"`
-	LastWeeklyHash  string `json:"last_weekly_hash,omitempty"`
-	LastMonthlyHash string `json:"last_monthly_hash,omitempty"`
-	// ProcessedDiscussions tracks which discussion dirs have been processed.
-	// Key: directory name, Value: content hash at time of processing.
-	// Map-based (not timestamp cursor) because discussions arrive out of order via daemon sync.
-	ProcessedDiscussions map[string]string `json:"processed_discussions,omitempty"`
-	// LastGitHubFacts is the RFC3339 timestamp of the last successful GitHub fact extraction.
-	// Used for single-repo mode (v2 compat). Multi-repo uses RepoGitHubFacts.
-	LastGitHubFacts string `json:"last_github_facts,omitempty"`
-	// ProcessedSessions tracks which session dirs have been processed.
-	// Used for single-repo mode (v2 compat). Multi-repo uses RepoSessions.
-	ProcessedSessions map[string]string `json:"processed_sessions,omitempty"`
-
-	// Per-repo fields (v3): keyed by RepoID for multi-ledger support.
-	// When DISTILL_REPOS is set, extraction state is tracked per-repo.
-	RepoSessions    map[string]map[string]string `json:"repo_sessions,omitempty"`
-	RepoGitHubFacts map[string]string            `json:"repo_github_facts,omitempty"`
-
-	// v1 compat fields (read for migration, not written)
-	LastDistilled    string `json:"last_distilled,omitempty"`
-	ObservationCount int    `json:"observation_count,omitempty"`
-}
-
-// sessionsForRepo returns the processed sessions map for a specific repo.
-// Handles migration from flat ProcessedSessions to per-repo RepoSessions.
-func (s *distillStateV2) sessionsForRepo(repoID string) map[string]string {
-	if s.RepoSessions == nil {
-		s.RepoSessions = make(map[string]map[string]string)
-	}
-	if m, ok := s.RepoSessions[repoID]; ok {
-		return m
-	}
-	s.RepoSessions[repoID] = make(map[string]string)
-	return s.RepoSessions[repoID]
-}
-
-// githubFactsTimeForRepo returns the last GitHub extraction timestamp for a repo.
-// Falls back to the flat LastGitHubFacts for single-repo compat.
-func (s *distillStateV2) githubFactsTimeForRepo(repoID, tcPath string) time.Time {
-	if s.RepoGitHubFacts != nil {
-		if ts, ok := s.RepoGitHubFacts[repoID]; ok {
-			if t, err := time.Parse(time.RFC3339, ts); err == nil {
-				return t
-			}
-		}
-	}
-	// fall back to flat field for single-repo compat
-	return githubFactsSince(&distillStateV2{LastGitHubFacts: s.LastGitHubFacts}, tcPath)
-}
-
-// setGitHubFactsTime records the last GitHub extraction timestamp for a repo.
-func (s *distillStateV2) setGitHubFactsTime(repoID string, t time.Time) {
-	if s.RepoGitHubFacts == nil {
-		s.RepoGitHubFacts = make(map[string]string)
-	}
-	s.RepoGitHubFacts[repoID] = t.Format(time.RFC3339)
-}
-
-// migrateToPerRepo migrates flat v2 state into per-repo maps for the given repoID.
-// Called once when transitioning from single-repo to multi-repo mode.
-func (s *distillStateV2) migrateToPerRepo(repoID string) {
-	if len(s.ProcessedSessions) > 0 && len(s.RepoSessions) == 0 {
-		if s.RepoSessions == nil {
-			s.RepoSessions = make(map[string]map[string]string)
-		}
-		copied := make(map[string]string, len(s.ProcessedSessions))
-		for k, v := range s.ProcessedSessions {
-			copied[k] = v
-		}
-		s.RepoSessions[repoID] = copied
-	}
-	if s.LastGitHubFacts != "" && len(s.RepoGitHubFacts) == 0 {
-		if s.RepoGitHubFacts == nil {
-			s.RepoGitHubFacts = make(map[string]string)
-		}
-		s.RepoGitHubFacts[repoID] = s.LastGitHubFacts
-	}
-}
-
-// lastDailyTime returns the effective last daily distill time,
-// falling back to v1's LastDistilled for backward compatibility.
-func (s *distillStateV2) lastDailyTime() time.Time {
-	if s.LastDaily != "" {
-		if t, err := time.Parse(time.RFC3339, s.LastDaily); err == nil {
-			return t
-		}
-	}
-	if s.LastDistilled != "" {
-		if t, err := time.Parse(time.RFC3339, s.LastDistilled); err == nil {
-			return t
-		}
-	}
-	return time.Time{}
 }
 
 func (s *distillStateV2) lastWeeklyTime() time.Time {
@@ -673,7 +587,7 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 	// push team context commits to remote when we're done — even if the
 	// pipeline partially fails, earlier stages may have committed facts or
 	// distilled summaries that should be synced.
-	if !distillDryRun {
+	if !distillDryRun && !distillNoPush {
 		ep := endpoint.GetForProject(projectRoot)
 		defer func() {
 			if err := pushTeamContext(context.Background(), tc.Path, ep); err != nil {
@@ -691,10 +605,32 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 	// set working directory so relative file paths in prompts resolve correctly
 	if claude, ok := backend.(*agentcli.Claude); ok {
 		claude.WorkDir = tc.Path
+		if distillModel != "" {
+			claude.Model = distillModel
+		}
 	}
 
 	// load distill state (v2 format, backward compat with v1)
 	state := loadDistillStateV2(projectRoot, tc.Path)
+
+	// load or rebuild the distill index (performance cache for file scanning)
+	idx, rebuilt := loadDistillIndex(projectRoot, tc.Path)
+	if rebuilt {
+		fmt.Fprintf(cmd.OutOrStdout(), "Rebuilt distill index from %d facts, %d dailies\n", len(idx.FactMeta), len(idx.DailySources))
+	} else {
+		// check for new files from other machines
+		if n := updateDistillIndex(idx, tc.Path); n > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated index: %d new files\n", n)
+		}
+	}
+	// always save index on exit — even partial runs should cache progress
+	if !distillDryRun {
+		defer func() {
+			if err := saveDistillIndex(projectRoot, idx); err != nil {
+				slog.Warn("failed to save distill index", "error", err)
+			}
+		}()
+	}
 
 	// ensure memory directories exist
 	if err := ensureMemoryDirs(tc.Path); err != nil {
@@ -741,29 +677,13 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("resolve distill repos: %w", err)
 	}
 
-	// migrate flat state to per-repo if transitioning to multi-repo.
-	// attribute existing flat state to the CWD project (whose state file we loaded),
-	// not repos[0] which may differ depending on DISTILL_REPOS order.
-	if len(repos) > 0 {
-		migrateRepoID := repos[0].RepoID
-		for _, r := range repos {
-			if r.ProjectRoot == projectRoot {
-				migrateRepoID = r.RepoID
-				break
-			}
-		}
-		state.migrateToPerRepo(migrateRepoID)
-	}
+	// (per-repo state migration removed — extraction is now stateless via file metadata)
 
 	// extract facts from unprocessed discussions before daily distill
 	// (discussions live in team context, not per-ledger — no multi-repo loop needed)
 	if plan.Daily {
-		if err := extractDiscussionFacts(ctx, cmd, backend, tc, state, extractGuidelines); err != nil {
+		if err := extractDiscussionFacts(ctx, cmd, backend, tc, extractGuidelines); err != nil {
 			slog.Warn("discussion fact extraction failed", "error", err)
-		} else if !distillDryRun {
-			if err := saveDistillStateV2(projectRoot, state); err != nil {
-				slog.Warn("failed to save distill state after discussion extraction", "error", err)
-			}
 		}
 	}
 
@@ -775,11 +695,11 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 				fmt.Fprintf(cmd.OutOrStdout(), "Processing repo %s (%s)...\n", repo.RepoID, repo.ProjectRoot)
 			}
 
-			if err := extractSessionFacts(cmd, tc, state, repo.RepoID, repo.LedgerPath); err != nil {
+			if err := extractSessionFacts(cmd, tc, repo.RepoID, repo.LedgerPath); err != nil {
 				slog.Warn("session fact extraction failed", "repo", repoLabel, "error", err)
 			}
 
-			if err := extractGitHubFacts(ctx, cmd, backend, tc, state, repo.RepoID, repo.CodeDBDir, extractGuidelines); err != nil {
+			if err := extractGitHubFacts(ctx, cmd, backend, tc, repo.RepoID, repo.CodeDBDir, extractGuidelines); err != nil {
 				slog.Warn("github fact extraction failed", "repo", repoLabel, "error", err)
 			}
 
@@ -793,7 +713,7 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 	}
 
 	if plan.Daily {
-		if err := distillDaily(ctx, cmd, backend, tc, state, projectRoot, now, distillGuidelines, tz); err != nil {
+		if err := distillDaily(ctx, cmd, backend, tc, state, idx, projectRoot, now, distillGuidelines, tz); err != nil {
 			return fmt.Errorf("daily distill: %w", err)
 		}
 	}
@@ -810,7 +730,7 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// save updated state (skip in dry-run to avoid side effects)
+	// save updated state (skip in dry-run; index is saved via defer)
 	if !distillDryRun {
 		if err := saveDistillStateV2(projectRoot, state); err != nil {
 			slog.Warn("failed to save distill state", "error", err)
@@ -928,12 +848,8 @@ func enumerateMonths(lastTime, now time.Time, tz *time.Location) []string {
 // extractDiscussionFacts scans for unprocessed discussions and writes fact files.
 // Each discussion gets a fact file in memory/.discussion-facts/{dirName}.md.
 // Uses LLM to extract structured facts, or writes stub if in dry-run mode.
-func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, state *distillStateV2, guidelines string) error {
-	if state.ProcessedDiscussions == nil {
-		state.ProcessedDiscussions = make(map[string]string)
-	}
-
-	pending, err := scanPendingDiscussions(tc.Path, state.ProcessedDiscussions)
+func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, guidelines string) error {
+	pending, err := scanPendingDiscussions(tc.Path)
 	if err != nil {
 		return fmt.Errorf("scan discussions: %w", err)
 	}
@@ -956,7 +872,10 @@ func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend age
 	}
 
 	for _, d := range pending {
-		factContent, err := extractSingleDiscussionFacts(ctx, cmd, backend, d, guidelines)
+		// compute source hash before extraction for embedding in the fact file
+		sourceHash := discussionContentHash(filepath.Join(tc.Path, "discussions", d.DirName))
+
+		factContent, err := extractSingleDiscussionFacts(ctx, cmd, backend, d, guidelines, sourceHash)
 		if err != nil {
 			// non-fatal per discussion — log and continue
 			slog.Warn("skip discussion fact extraction", "dir", d.DirName, "error", err)
@@ -973,9 +892,14 @@ func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend age
 			slog.Warn("failed to commit discussion facts", "dir", d.DirName, "error", err)
 		}
 
-		// track as processed with content hash
-		hash := discussionContentHash(filepath.Join(tc.Path, "discussions", d.DirName))
-		state.ProcessedDiscussions[d.DirName] = hash
+		// remove legacy .md fact file to prevent duplicate facts in daily distill
+		oldMdFile := filepath.Join("memory", ".discussion-facts", d.DirName+".md")
+		oldMdPath := filepath.Join(tc.Path, oldMdFile)
+		if _, err := os.Stat(oldMdPath); err == nil {
+			if err := removeMemoryFile(tc.Path, oldMdFile, fmt.Sprintf("memory: remove legacy %s (migrated to .jsonl)", d.DirName+".md")); err != nil {
+				slog.Warn("failed to remove legacy .md fact file", "path", oldMdFile, "error", err)
+			}
+		}
 
 		fmt.Fprintf(cmd.OutOrStdout(), "Extracted facts from discussion: %s\n", d.Title)
 	}
@@ -986,10 +910,11 @@ func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend age
 // extractSingleDiscussionFacts generates facts for one discussion.
 // When server-generated summary.json exists, extracts facts directly from
 // structured data without an LLM call. Falls back to LLM via JSONL output.
-func extractSingleDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, d discussionInput, guidelines string) (string, error) {
+// sourceHash is embedded in the fact file header for stateless change detection.
+func extractSingleDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, d discussionInput, guidelines, sourceHash string) (string, error) {
 	// if server-generated summary.json exists, extract facts directly without LLM
 	if d.SummaryJSONDir != "" {
-		result, err := extractFactsFromSummaryJSON(d)
+		result, err := extractFactsFromSummaryJSON(d, sourceHash)
 		if err == nil {
 			slog.Info("extracted facts from summary.json", "discussion", d.DirName)
 			return result, nil
@@ -1018,6 +943,7 @@ func extractSingleDiscussionFacts(ctx context.Context, cmd *cobra.Command, backe
 			SchemaVersion: facts.SchemaVersion,
 			SourceType:    facts.SourceDiscussion,
 			RecordedAt:    d.CreatedAt.Format(time.RFC3339),
+			SourceHash:    sourceHash,
 		},
 	}
 
@@ -1037,9 +963,15 @@ func extractSingleDiscussionFacts(ctx context.Context, cmd *cobra.Command, backe
 	return sb.String(), nil
 }
 
-func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, state *distillStateV2, projectRoot string, now time.Time, guidelines string, tz *time.Location) error {
+func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, state *distillStateV2, idx *distillIndex, projectRoot string, now time.Time, guidelines string, tz *time.Location) error {
 	obsDir := filepath.Join(tc.Path, "memory", ".observations")
-	since := state.lastDailyTime()
+	since := inferDailyHighWater(tc.Path)
+
+	// default to 7 days back unless --all is set
+	if since.IsZero() && !distillAll {
+		since = now.AddDate(0, 0, -7)
+		slog.Info("no prior daily distill found, defaulting to last 7 days (use --all for full history)")
+	}
 
 	observations, _, err := scanPendingObservations(obsDir, since)
 	if err != nil {
@@ -1077,6 +1009,28 @@ func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Back
 		factsByDay[day] = append(factsByDay[day], sessionFacts...)
 	}
 
+	// filter out facts already distilled (tracked via index, mirrors sources frontmatter)
+	alreadyDistilled := idx.distilledSources()
+	var skippedFacts int
+	for day, dayFacts := range factsByDay {
+		var newFacts []discussionFactEntry
+		for _, f := range dayFacts {
+			if alreadyDistilled[f.RelPath] {
+				skippedFacts++
+				continue
+			}
+			newFacts = append(newFacts, f)
+		}
+		if len(newFacts) == 0 {
+			delete(factsByDay, day)
+		} else {
+			factsByDay[day] = newFacts
+		}
+	}
+	if skippedFacts > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "Skipped %d already-distilled facts\n", skippedFacts)
+	}
+
 	if len(observations) == 0 && len(factsByDay) == 0 {
 		fmt.Fprintln(cmd.OutOrStdout(), "No pending observations or facts for daily distill")
 		return nil
@@ -1111,7 +1065,7 @@ func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Back
 		return nil
 	}
 
-	var latestDay string
+
 	for _, day := range days {
 		dayObs := obsByDay[day]
 		dayFacts := factsByDay[day]
@@ -1144,8 +1098,14 @@ func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Back
 			return fmt.Errorf("generate daily file ID: %w", err)
 		}
 
+		// collect source paths for frontmatter
+		var sources []string
+		for _, f := range dayFacts {
+			sources = append(sources, f.RelPath)
+		}
+
 		filePath := filepath.Join("memory", "daily", day+"-"+id.String()+".md")
-		content := formatDailyMemory(day, output, len(dayObs), len(dayFacts))
+		content := formatDailyMemory(day, output, len(dayObs), len(dayFacts), sources)
 
 		if err := writeMemoryFile(tc.Path, filePath, content); err != nil {
 			return fmt.Errorf("write daily memory: %w", err)
@@ -1155,16 +1115,13 @@ func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Back
 			slog.Warn("failed to commit daily memory", "error", err)
 		}
 
-		state.DailyCount += len(dayObs) + len(dayFacts)
-		latestDay = day
+		// update index with new daily summary
+		idx.addDailySummary(filePath, sources)
+
 		fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s\n", filePath)
 	}
 
-	if latestDay != "" {
-		// Use actual processing time so intra-day re-runs pick up new observations
-		state.LastDaily = now.Format(time.RFC3339)
-		state.LastDailyHash = "" // hash no longer used for per-day bucketing
-	}
+	// (LastDaily no longer tracked — daily high-water inferred from files)
 
 	return nil
 }
@@ -1216,7 +1173,6 @@ func distillWeekly(ctx context.Context, cmd *cobra.Command, backend agentcli.Bac
 	}
 
 	state.LastWeekly = end.Format(time.RFC3339)
-	state.LastWeeklyHash = "" // hash no longer used
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s\n", filePath)
 	return nil
@@ -1267,7 +1223,6 @@ func distillMonthly(ctx context.Context, cmd *cobra.Command, backend agentcli.Ba
 	}
 
 	state.LastMonthly = endOfMonth(t, tz).Format(time.RFC3339)
-	state.LastMonthlyHash = "" // hash no longer used
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s\n", filePath)
 	return nil
@@ -1313,7 +1268,16 @@ func readRecentMemoryFiles(dir string, maxFiles int) ([]string, []string, error)
 	return contents, names, nil
 }
 
-func formatDailyMemory(date, content string, obsCount, factCount int) string {
+func formatDailyMemory(date, content string, obsCount, factCount int, sources []string) string {
+	var sb strings.Builder
+	if len(sources) > 0 {
+		sb.WriteString("---\nsources:\n")
+		for _, s := range sources {
+			fmt.Fprintf(&sb, "  - %s\n", s)
+		}
+		sb.WriteString("---\n")
+	}
+
 	var source string
 	switch {
 	case obsCount > 0 && factCount > 0:
@@ -1323,13 +1287,49 @@ func formatDailyMemory(date, content string, obsCount, factCount int) string {
 	default:
 		source = fmt.Sprintf("%d observations", obsCount)
 	}
-	return fmt.Sprintf("# Daily Memory — %s\n\n%s\n\n---\n*Distilled from %s*\n", date, content, source)
+	fmt.Fprintf(&sb, "# Daily Memory — %s\n\n%s\n\n---\n*Distilled from %s*\n", date, content, source)
+	return sb.String()
 }
 
-// loadDistillStateV2 loads distill state, migrating from v1 if needed.
-// tcPath is used to infer high-water marks from existing files when no state exists.
+// parseDailySources extracts source paths from YAML frontmatter in a daily summary.
+// Expects format:
+//
+//	---
+//	sources:
+//	  - memory/.github-facts/2026-03-30-xxx.jsonl
+//	  - memory/.session-facts/2026-03-30/yyy.jsonl
+//	---
+func parseDailySources(content string) []string {
+	// find frontmatter block between --- delimiters
+	if !strings.HasPrefix(content, "---\n") {
+		return nil
+	}
+	end := strings.Index(content[4:], "\n---")
+	if end < 0 {
+		return nil
+	}
+	frontmatter := content[4 : 4+end]
+
+	var sources []string
+	inSources := false
+	for _, line := range strings.Split(frontmatter, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "sources:" {
+			inSources = true
+			continue
+		}
+		if inSources && strings.HasPrefix(line, "  - ") {
+			sources = append(sources, strings.TrimPrefix(trimmed, "- "))
+		} else if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			inSources = false
+		}
+	}
+	return sources
+}
+
+// loadDistillStateV2 loads distill state for weekly/monthly tracking.
+// Daily and extraction tracking is now stateless (via file metadata).
 func loadDistillStateV2(projectRoot, tcPath string) *distillStateV2 {
-	// try loading v2 state from cache directory
 	v2Path := filepath.Join(projectRoot, ".sageox", "cache", "distill-state-v2.json")
 	if data, err := os.ReadFile(v2Path); err == nil {
 		var loaded distillStateV2
@@ -1338,23 +1338,9 @@ func loadDistillStateV2(projectRoot, tcPath string) *distillStateV2 {
 		}
 	}
 
-	// fall back to v1 state for migration
-	v1State, _ := loadDistillState(projectRoot)
-
+	// no state — infer weekly/monthly from existing files
 	state := &distillStateV2{
 		SchemaVersion: "2",
-	}
-
-	if v1State != nil {
-		state.TeamID = v1State.TeamID
-		state.LastDistilled = v1State.LastDistilled
-		state.ObservationCount = v1State.ObservationCount
-		return state
-	}
-
-	// no state at all — infer from existing memory files to avoid reprocessing
-	if t := inferDailyHighWater(tcPath); !t.IsZero() {
-		state.LastDaily = t.Format(time.RFC3339)
 	}
 	if t := inferWeeklyHighWater(tcPath); !t.IsZero() {
 		state.LastWeekly = t.Format(time.RFC3339)
@@ -1362,7 +1348,6 @@ func loadDistillStateV2(projectRoot, tcPath string) *distillStateV2 {
 	if t := inferMonthlyHighWater(tcPath); !t.IsZero() {
 		state.LastMonthly = t.Format(time.RFC3339)
 	}
-
 	return state
 }
 

--- a/cmd/ox/distill_coverage_test.go
+++ b/cmd/ox/distill_coverage_test.go
@@ -8,43 +8,6 @@ import (
 	"time"
 )
 
-func TestDistillStateV2_LastDailyTime_InvalidFormat(t *testing.T) {
-	t.Parallel()
-
-	state := &distillStateV2{LastDaily: "not-a-timestamp"}
-	got := state.lastDailyTime()
-	if !got.IsZero() {
-		t.Errorf("lastDailyTime() with invalid format = %v, want zero", got)
-	}
-}
-
-func TestDistillStateV2_LastDailyTime_V1Fallback(t *testing.T) {
-	t.Parallel()
-
-	state := &distillStateV2{
-		LastDaily:     "",
-		LastDistilled: "2026-03-15T10:00:00Z",
-	}
-	got := state.lastDailyTime()
-	expected := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
-	if !got.Equal(expected) {
-		t.Errorf("lastDailyTime() with v1 fallback = %v, want %v", got, expected)
-	}
-}
-
-func TestDistillStateV2_LastDailyTime_V1FallbackInvalid(t *testing.T) {
-	t.Parallel()
-
-	state := &distillStateV2{
-		LastDaily:     "",
-		LastDistilled: "garbage",
-	}
-	got := state.lastDailyTime()
-	if !got.IsZero() {
-		t.Errorf("lastDailyTime() with invalid v1 fallback = %v, want zero", got)
-	}
-}
-
 func TestDistillStateV2_LastWeeklyTime_InvalidFormat(t *testing.T) {
 	t.Parallel()
 
@@ -376,7 +339,7 @@ func TestFormatDailyMemory_AllCombinations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatDailyMemory(tt.date, tt.content, tt.obsCount, tt.factCount)
+			got := formatDailyMemory(tt.date, tt.content, tt.obsCount, tt.factCount, nil)
 			if len(got) == 0 {
 				t.Fatal("formatDailyMemory returned empty string")
 			}

--- a/cmd/ox/distill_discussions.go
+++ b/cmd/ox/distill_discussions.go
@@ -44,9 +44,9 @@ type discussionMetadata struct {
 }
 
 // scanPendingDiscussions reads the discussions/ directory in the team context
-// and returns discussions not yet tracked in state.ProcessedDiscussions.
+// and returns discussions that need (re-)extraction based on source_hash in fact files.
 // Each discussion dir is expected to contain metadata.json, summary.md, and optionally transcript.vtt.
-func scanPendingDiscussions(tcPath string, processed map[string]string) ([]discussionInput, error) {
+func scanPendingDiscussions(tcPath string) ([]discussionInput, error) {
 	discussionsDir := filepath.Join(tcPath, "discussions")
 	entries, err := os.ReadDir(discussionsDir)
 	if err != nil {
@@ -74,26 +74,13 @@ func scanPendingDiscussions(tcPath string, processed map[string]string) ([]discu
 
 		// compute content hash for change detection
 		currentHash := discussionContentHash(dirPath)
-		factFileExists := fileExists(filepath.Join(tcPath, "memory", ".discussion-facts", dirName+".md")) ||
-			fileExists(filepath.Join(tcPath, "memory", ".discussion-facts", dirName+".jsonl"))
 
-		// skip if already processed with same hash and fact file exists
-		if prevHash, ok := processed[dirName]; ok && prevHash == currentHash && factFileExists {
-			continue
-		}
+		// check existing fact files for source_hash match
+		jsonlPath := filepath.Join(tcPath, "memory", ".discussion-facts", dirName+".jsonl")
 
-		// legacy hash migration: older CLI versions hashed only core files
-		// (metadata.json, summary.md, transcript.vtt). If the core hash matches
-		// the stored hash, the discussion content hasn't changed — only the hash
-		// function expanded. Update the stored hash and skip re-processing,
-		// but only if the fact file still exists on disk.
-		if prevHash, ok := processed[dirName]; ok && prevHash == discussionCoreHash(dirPath) && factFileExists {
-			processed[dirName] = currentHash
-			continue
-		}
-
-		// skip if fact file already exists (covers fresh clone / deleted state)
-		if _, ok := processed[dirName]; !ok && factFileExists {
+		// skip if JSONL fact file exists with matching source_hash;
+		// all other cases (missing, legacy .md, stale hash) need extraction
+		if readFactFileSourceHash(jsonlPath) == currentHash && currentHash != "" {
 			continue
 		}
 
@@ -127,6 +114,25 @@ func scanPendingDiscussions(tcPath string, processed map[string]string) ([]discu
 	})
 
 	return pending, nil
+}
+
+// readFactFileSourceHash reads the _meta.source_hash from the first line of a JSONL fact file.
+// Returns empty string if the file doesn't exist, can't be parsed, or has no source_hash.
+func readFactFileSourceHash(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	firstLine, _, _ := strings.Cut(string(data), "\n")
+	firstLine = strings.TrimSpace(firstLine)
+	if firstLine == "" {
+		return ""
+	}
+	var header facts.FileHeader
+	if err := json.Unmarshal([]byte(firstLine), &header); err != nil {
+		return ""
+	}
+	return header.Meta.SourceHash
 }
 
 // loadDiscussionMetadata reads and parses metadata.json from a discussion dir.
@@ -220,19 +226,6 @@ func discussionContentHash(dirPath string) string {
 	return contentHash(parts...)
 }
 
-// discussionCoreHash computes a hash from only the core discussion files
-// (metadata.json, summary.md, transcript.vtt). This matches the hash that
-// older CLI versions stored, enabling migration without spurious re-processing.
-func discussionCoreHash(dirPath string) string {
-	var parts []string
-	for _, name := range coreDiscussionFiles {
-		if data, err := os.ReadFile(filepath.Join(dirPath, name)); err == nil {
-			parts = append(parts, string(data))
-		}
-	}
-	return contentHash(parts...)
-}
-
 // categorizeAnnotations groups annotations into fact categories aligned with
 // DiscussionFactsPrompt output (decisions, learnings, open_questions, action_items).
 func categorizeAnnotations(af *discussion.AnnotationsFile) (decisions, learnings, actionItems, openQuestions []string) {
@@ -254,14 +247,14 @@ func categorizeAnnotations(af *discussion.AnnotationsFile) (decisions, learnings
 	return
 }
 
-// extractFactsFromSummaryJSON generates fact output directly from server-generated
+// extractFactsFromSummaryJSON generates JSONL fact output directly from server-generated
 // structured data (summary.json), skipping the LLM entirely.
 // Pure data transformation — no network calls.
 //
 // Works with both v1 and v2 server summary formats. The top-level fact categories
 // (decisions, learnings, etc.) are identical in both versions. Chapters are only
-// present in v2 and contribute to Key Context when available.
-func extractFactsFromSummaryJSON(d discussionInput) (string, error) {
+// present in v2 and contribute to context facts when available.
+func extractFactsFromSummaryJSON(d discussionInput, sourceHash string) (string, error) {
 	summary, err := discussion.LoadSummary(d.SummaryJSONDir)
 	if err != nil {
 		return "", fmt.Errorf("load summary.json: %w", err)
@@ -273,42 +266,55 @@ func extractFactsFromSummaryJSON(d discussionInput) (string, error) {
 		return "", fmt.Errorf("summary.json has no categorized facts")
 	}
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "# Facts: %s\n", d.Title)
+	ts := d.CreatedAt.Format(time.RFC3339)
+	sourceRef := fmt.Sprintf("discussions/%s", d.DirName)
 
-	if len(summary.Decisions) > 0 {
-		sb.WriteString("\n## Decisions\n")
-		for _, item := range summary.Decisions {
-			fmt.Fprintf(&sb, "- %s\n", item.Text())
-		}
+	var parsedFacts []facts.Fact
+
+	for _, item := range summary.Decisions {
+		parsedFacts = append(parsedFacts, facts.Fact{
+			Headline:   item.Text(),
+			SourceType: facts.SourceDiscussion,
+			SourceRef:  sourceRef,
+			Timestamp:  ts,
+			Category:   facts.CategoryDecision,
+		})
 	}
-
-	if len(summary.Learnings) > 0 {
-		sb.WriteString("\n## Learnings\n")
-		for _, item := range summary.Learnings {
-			fmt.Fprintf(&sb, "- %s\n", item.Text())
-		}
+	for _, item := range summary.Learnings {
+		parsedFacts = append(parsedFacts, facts.Fact{
+			Headline:   item.Text(),
+			SourceType: facts.SourceDiscussion,
+			SourceRef:  sourceRef,
+			Timestamp:  ts,
+			Category:   facts.CategoryLearning,
+		})
 	}
-
-	if len(summary.ActionItems) > 0 {
-		sb.WriteString("\n## Action Items\n")
-		for _, item := range summary.ActionItems {
-			fmt.Fprintf(&sb, "- %s\n", item.Text())
-		}
+	for _, item := range summary.ActionItems {
+		parsedFacts = append(parsedFacts, facts.Fact{
+			Headline:   item.Text(),
+			SourceType: facts.SourceDiscussion,
+			SourceRef:  sourceRef,
+			Timestamp:  ts,
+			Category:   facts.CategoryActionItem,
+		})
 	}
-
-	if len(summary.OpenQuestions) > 0 {
-		sb.WriteString("\n## Open Questions\n")
-		for _, item := range summary.OpenQuestions {
-			fmt.Fprintf(&sb, "- %s\n", item.Text())
-		}
+	for _, item := range summary.OpenQuestions {
+		parsedFacts = append(parsedFacts, facts.Fact{
+			Headline:   item.Text(),
+			SourceType: facts.SourceDiscussion,
+			SourceRef:  sourceRef,
+			Timestamp:  ts,
+			Category:   facts.CategoryOpenQuestion,
+		})
 	}
-
-	if len(summary.Requirements) > 0 {
-		sb.WriteString("\n## Requirements\n")
-		for _, item := range summary.Requirements {
-			fmt.Fprintf(&sb, "- %s\n", item.Text())
-		}
+	for _, item := range summary.Requirements {
+		parsedFacts = append(parsedFacts, facts.Fact{
+			Headline:   item.Text(),
+			SourceType: facts.SourceDiscussion,
+			SourceRef:  sourceRef,
+			Timestamp:  ts,
+			Category:   facts.CategoryContext,
+		})
 	}
 
 	// key context from TechnicalContext, Constraints, NonGoals, and (v2 only) high-importance chapters
@@ -326,14 +332,38 @@ func extractFactsFromSummaryJSON(d discussionInput) (string, error) {
 			}
 		}
 	}
-	if len(keyContext) > 0 {
-		sb.WriteString("\n## Key Context\n")
-		for _, item := range keyContext {
-			fmt.Fprintf(&sb, "- %s\n", item)
-		}
+	for _, item := range keyContext {
+		parsedFacts = append(parsedFacts, facts.Fact{
+			Headline:   item,
+			SourceType: facts.SourceDiscussion,
+			SourceRef:  sourceRef,
+			Timestamp:  ts,
+			Category:   facts.CategoryContext,
+		})
 	}
 
-	fmt.Fprintf(&sb, "\n---\n*Extracted from discussion: %s (created %s)*\n", d.DirName, d.CreatedAt.Format("2006-01-02"))
+	header := facts.FileHeader{
+		Meta: facts.FileMeta{
+			SchemaVersion: facts.SchemaVersion,
+			SourceType:    facts.SourceDiscussion,
+			RecordedAt:    ts,
+			SourceHash:    sourceHash,
+		},
+	}
+
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("marshal header: %w", err)
+	}
+
+	var sb strings.Builder
+	sb.Write(headerBytes)
+	sb.WriteByte('\n')
+	for _, f := range parsedFacts {
+		line, _ := json.Marshal(f)
+		sb.Write(line)
+		sb.WriteByte('\n')
+	}
 	return sb.String(), nil
 }
 

--- a/cmd/ox/distill_discussions_test.go
+++ b/cmd/ox/distill_discussions_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestScanPendingDiscussions(t *testing.T) {
-	// helper: set up a tcPath with two discussions and optional fact files
+	// helper: set up tcPath with two discussions and optional fact files with source_hash
 	setup := func(t *testing.T, withFactFiles bool) (string, string) {
 		t.Helper()
 		tcPath := t.TempDir()
@@ -22,15 +22,18 @@ func TestScanPendingDiscussions(t *testing.T) {
 		if withFactFiles {
 			factsDir := filepath.Join(tcPath, "memory", ".discussion-facts")
 			os.MkdirAll(factsDir, 0o755)
-			os.WriteFile(filepath.Join(factsDir, "2026-03-10-1423-ryan.jsonl"), []byte(`{"_meta":{"schema_version":"2"}}`), 0o644)
-			os.WriteFile(filepath.Join(factsDir, "2026-03-11-0900-alice.jsonl"), []byte(`{"_meta":{"schema_version":"2"}}`), 0o644)
+			// write JSONL fact files with source_hash matching current content
+			ryanHash := discussionContentHash(filepath.Join(discussionsDir, "2026-03-10-1423-ryan"))
+			aliceHash := discussionContentHash(filepath.Join(discussionsDir, "2026-03-11-0900-alice"))
+			writeFactFileWithHash(t, factsDir, "2026-03-10-1423-ryan.jsonl", ryanHash)
+			writeFactFileWithHash(t, factsDir, "2026-03-11-0900-alice.jsonl", aliceHash)
 		}
 		return tcPath, discussionsDir
 	}
 
-	t.Run("no processed — finds all", func(t *testing.T) {
+	t.Run("no fact files — finds all", func(t *testing.T) {
 		tcPath, _ := setup(t, false)
-		pending, err := scanPendingDiscussions(tcPath, nil)
+		pending, err := scanPendingDiscussions(tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -39,58 +42,79 @@ func TestScanPendingDiscussions(t *testing.T) {
 		}
 	})
 
-	t.Run("one processed with fact file — finds remaining", func(t *testing.T) {
-		tcPath, discussionsDir := setup(t, true)
-		processed := map[string]string{"2026-03-10-1423-ryan": discussionContentHash(filepath.Join(discussionsDir, "2026-03-10-1423-ryan"))}
-		pending, err := scanPendingDiscussions(tcPath, processed)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		// alice is not in processed map but her fact file exists → skipped
-		if len(pending) != 0 {
-			t.Errorf("got %d pending, want 0 (both have fact files)", len(pending))
-		}
-	})
-
-	t.Run("all processed with fact files — finds none", func(t *testing.T) {
-		tcPath, discussionsDir := setup(t, true)
-		processed := map[string]string{
-			"2026-03-10-1423-ryan":  discussionContentHash(filepath.Join(discussionsDir, "2026-03-10-1423-ryan")),
-			"2026-03-11-0900-alice": discussionContentHash(filepath.Join(discussionsDir, "2026-03-11-0900-alice")),
-		}
-		pending, err := scanPendingDiscussions(tcPath, processed)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(pending) != 0 {
-			t.Errorf("got %d pending, want 0", len(pending))
-		}
-	})
-
-	t.Run("stale hash + no fact file — re-processes", func(t *testing.T) {
-		tcPath, _ := setup(t, false)
-		processed := map[string]string{"2026-03-10-1423-ryan": "stale-hash"}
-		pending, err := scanPendingDiscussions(tcPath, processed)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(pending) != 2 {
-			t.Errorf("got %d pending, want 2", len(pending))
-		}
-	})
-
-	t.Run("stale hash + fact file exists — re-processes changed discussion", func(t *testing.T) {
+	t.Run("fact files with matching source_hash — finds none", func(t *testing.T) {
 		tcPath, _ := setup(t, true)
-		processed := map[string]string{"2026-03-10-1423-ryan": "stale-hash"}
-		pending, err := scanPendingDiscussions(tcPath, processed)
+		pending, err := scanPendingDiscussions(tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// ryan has stale hash → re-process; alice not in processed but fact file exists → skip
+		if len(pending) != 0 {
+			t.Errorf("got %d pending, want 0 (both have matching source_hash)", len(pending))
+		}
+	})
+
+	t.Run("stale source_hash — re-processes changed discussion", func(t *testing.T) {
+		tcPath, _ := setup(t, true)
+		// overwrite ryan's fact file with stale hash
+		factsDir := filepath.Join(tcPath, "memory", ".discussion-facts")
+		writeFactFileWithHash(t, factsDir, "2026-03-10-1423-ryan.jsonl", "stale-hash")
+		pending, err := scanPendingDiscussions(tcPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// ryan has stale hash → re-process; alice has matching hash → skip
 		if len(pending) != 1 {
 			t.Errorf("got %d pending, want 1", len(pending))
 		}
+		if len(pending) > 0 && pending[0].DirName != "2026-03-10-1423-ryan" {
+			t.Errorf("expected ryan to be pending, got %s", pending[0].DirName)
+		}
 	})
+
+	t.Run("legacy fact file without source_hash — re-processes", func(t *testing.T) {
+		tcPath, _ := setup(t, false)
+		factsDir := filepath.Join(tcPath, "memory", ".discussion-facts")
+		os.MkdirAll(factsDir, 0o755)
+		// write JSONL without source_hash
+		os.WriteFile(filepath.Join(factsDir, "2026-03-10-1423-ryan.jsonl"),
+			[]byte(`{"_meta":{"schema_version":"2","source_type":"discussion"}}`), 0o644)
+		pending, err := scanPendingDiscussions(tcPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// ryan has no source_hash → re-process; alice has no fact file → process
+		if len(pending) != 2 {
+			t.Errorf("got %d pending, want 2", len(pending))
+		}
+	})
+
+	t.Run("legacy .md fact file — re-processes for upgrade", func(t *testing.T) {
+		tcPath, _ := setup(t, false)
+		factsDir := filepath.Join(tcPath, "memory", ".discussion-facts")
+		os.MkdirAll(factsDir, 0o755)
+		os.WriteFile(filepath.Join(factsDir, "2026-03-10-1423-ryan.md"),
+			[]byte("# Facts\nold markdown"), 0o644)
+		pending, err := scanPendingDiscussions(tcPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// ryan has legacy .md → re-process; alice has no fact file → process
+		if len(pending) != 2 {
+			t.Errorf("got %d pending, want 2", len(pending))
+		}
+	})
+}
+
+// writeFactFileWithHash writes a minimal JSONL fact file with the given source_hash.
+func writeFactFileWithHash(t *testing.T, factsDir, filename, sourceHash string) {
+	t.Helper()
+	if err := os.MkdirAll(factsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	header := `{"_meta":{"schema_version":"2","source_type":"discussion","source_hash":"` + sourceHash + `"}}`
+	if err := os.WriteFile(filepath.Join(factsDir, filename), []byte(header+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestScanPendingDiscussionsSorted(t *testing.T) {
@@ -101,7 +125,7 @@ func TestScanPendingDiscussionsSorted(t *testing.T) {
 	createDiscussionDir(t, discussionsDir, "2026-03-11-0900-alice", "Later", "2026-03-11T09:00:00Z")
 	createDiscussionDir(t, discussionsDir, "2026-03-10-1423-ryan", "Earlier", "2026-03-10T14:23:00Z")
 
-	pending, err := scanPendingDiscussions(tcPath, nil)
+	pending, err := scanPendingDiscussions(tcPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -126,7 +150,7 @@ func TestScanPendingDiscussionsMissingMetadata(t *testing.T) {
 	// create a valid dir
 	createDiscussionDir(t, discussionsDir, "2026-03-10-1423-ryan", "Valid", "2026-03-10T14:23:00Z")
 
-	pending, err := scanPendingDiscussions(tcPath, nil)
+	pending, err := scanPendingDiscussions(tcPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +162,7 @@ func TestScanPendingDiscussionsMissingMetadata(t *testing.T) {
 func TestScanPendingDiscussionsNoDir(t *testing.T) {
 	tcPath := t.TempDir() // no discussions/ subdir
 
-	pending, err := scanPendingDiscussions(tcPath, nil)
+	pending, err := scanPendingDiscussions(tcPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -168,7 +192,7 @@ func TestScanPendingDiscussionsParsesContent(t *testing.T) {
 `
 	os.WriteFile(filepath.Join(discussionsDir, dirName, "transcript.vtt"), []byte(vttContent), 0o644)
 
-	pending, err := scanPendingDiscussions(tcPath, nil)
+	pending, err := scanPendingDiscussions(tcPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -188,63 +212,37 @@ func TestScanPendingDiscussionsParsesContent(t *testing.T) {
 	}
 }
 
-func TestScanPendingDiscussionsLegacyHashMigration(t *testing.T) {
-	t.Run("legacy hash + fact file exists — migrates and skips", func(t *testing.T) {
-		tcPath := t.TempDir()
-		discussionsDir := filepath.Join(tcPath, "discussions")
-
-		dirName := "2026-03-10-1423-ryan"
-		createDiscussionDir(t, discussionsDir, dirName, "Arch Review", "2026-03-10T14:23:00Z")
-
-		dirPath := filepath.Join(discussionsDir, dirName)
-		legacyHash := discussionCoreHash(dirPath)
-
-		// Add server-generated summary.json — changes the full hash but not the core hash.
-		os.WriteFile(filepath.Join(dirPath, "summary.json"), []byte(`{"schema_version":2}`), 0o644)
-
-		fullHash := discussionContentHash(dirPath)
-		if fullHash == legacyHash {
-			t.Fatal("expected full hash to differ from core hash after adding summary.json")
-		}
-
-		// Create the fact file that the old CLI would have written.
-		factsDir := filepath.Join(tcPath, "memory", ".discussion-facts")
-		os.MkdirAll(factsDir, 0o755)
-		os.WriteFile(filepath.Join(factsDir, dirName+".jsonl"), []byte(`{"_meta":{"schema_version":"2"}}`), 0o644)
-
-		processed := map[string]string{dirName: legacyHash}
-		pending, err := scanPendingDiscussions(tcPath, processed)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(pending) != 0 {
-			t.Errorf("expected 0 pending (legacy hash migration), got %d", len(pending))
-		}
-		if processed[dirName] != fullHash {
-			t.Errorf("stored hash not migrated: got %q, want %q", processed[dirName], fullHash)
+func TestReadFactFileSourceHash(t *testing.T) {
+	t.Run("reads source_hash from JSONL header", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.jsonl")
+		os.WriteFile(path, []byte(`{"_meta":{"schema_version":"2","source_hash":"abc123"}}`+"\n"), 0o644)
+		if got := readFactFileSourceHash(path); got != "abc123" {
+			t.Errorf("got %q, want abc123", got)
 		}
 	})
 
-	t.Run("legacy hash + missing fact file — re-processes", func(t *testing.T) {
-		tcPath := t.TempDir()
-		discussionsDir := filepath.Join(tcPath, "discussions")
-
-		dirName := "2026-03-10-1423-ryan"
-		createDiscussionDir(t, discussionsDir, dirName, "Arch Review", "2026-03-10T14:23:00Z")
-
-		dirPath := filepath.Join(discussionsDir, dirName)
-		legacyHash := discussionCoreHash(dirPath)
-
-		// Add server artifact but do NOT create the fact file.
-		os.WriteFile(filepath.Join(dirPath, "summary.json"), []byte(`{"schema_version":2}`), 0o644)
-
-		processed := map[string]string{dirName: legacyHash}
-		pending, err := scanPendingDiscussions(tcPath, processed)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+	t.Run("returns empty for missing file", func(t *testing.T) {
+		if got := readFactFileSourceHash("/nonexistent/path.jsonl"); got != "" {
+			t.Errorf("got %q, want empty", got)
 		}
-		if len(pending) != 1 {
-			t.Errorf("expected 1 pending (missing fact file), got %d", len(pending))
+	})
+
+	t.Run("returns empty for JSONL without source_hash", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.jsonl")
+		os.WriteFile(path, []byte(`{"_meta":{"schema_version":"2"}}`+"\n"), 0o644)
+		if got := readFactFileSourceHash(path); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("returns empty for non-JSON content", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.jsonl")
+		os.WriteFile(path, []byte("# Markdown header\nnot json"), 0o644)
+		if got := readFactFileSourceHash(path); got != "" {
+			t.Errorf("got %q, want empty", got)
 		}
 	})
 }
@@ -469,7 +467,7 @@ func TestDiscussionContentHash(t *testing.T) {
 	}
 }
 
-func TestDistillStateProcessedDiscussionsRoundtrip(t *testing.T) {
+func TestDistillStateRoundtrip(t *testing.T) {
 	tmp := t.TempDir()
 	sageoxDir := filepath.Join(tmp, ".sageox")
 	if err := os.MkdirAll(sageoxDir, 0o755); err != nil {
@@ -479,10 +477,8 @@ func TestDistillStateProcessedDiscussionsRoundtrip(t *testing.T) {
 	state := &distillStateV2{
 		SchemaVersion: "2",
 		TeamID:        "team-xyz",
-		ProcessedDiscussions: map[string]string{
-			"2026-03-10-1423-ryan":  "abc123",
-			"2026-03-11-0900-alice": "def456",
-		},
+		LastWeekly:    "2026-03-29T23:59:59Z",
+		LastMonthly:   "2026-03-31T23:59:59Z",
 	}
 
 	if err := saveDistillStateV2(tmp, state); err != nil {
@@ -490,14 +486,11 @@ func TestDistillStateProcessedDiscussionsRoundtrip(t *testing.T) {
 	}
 
 	loaded := loadDistillStateV2(tmp, tmp)
-	if len(loaded.ProcessedDiscussions) != 2 {
-		t.Fatalf("expected 2 processed discussions, got %d", len(loaded.ProcessedDiscussions))
+	if loaded.LastWeekly != "2026-03-29T23:59:59Z" {
+		t.Errorf("expected LastWeekly preserved, got %q", loaded.LastWeekly)
 	}
-	if loaded.ProcessedDiscussions["2026-03-10-1423-ryan"] != "abc123" {
-		t.Error("expected hash abc123 for ryan discussion")
-	}
-	if loaded.ProcessedDiscussions["2026-03-11-0900-alice"] != "def456" {
-		t.Error("expected hash def456 for alice discussion")
+	if loaded.LastMonthly != "2026-03-31T23:59:59Z" {
+		t.Errorf("expected LastMonthly preserved, got %q", loaded.LastMonthly)
 	}
 }
 
@@ -528,7 +521,7 @@ func TestFormatDailyMemoryWithDiscussions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content := formatDailyMemory("2026-03-11", "content", tt.obsCount, tt.discCount)
+			content := formatDailyMemory("2026-03-11", "content", tt.obsCount, tt.discCount, nil)
 			if !strings.Contains(content, tt.wantSource) {
 				t.Errorf("expected %q in output, got:\n%s", tt.wantSource, content)
 			}
@@ -620,7 +613,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 		}
 	}
 
-	t.Run("categorized facts present — uses .Text() directly", func(t *testing.T) {
+	t.Run("categorized facts present — outputs JSONL with source_hash", func(t *testing.T) {
 		dir := t.TempDir()
 		s := v2Base()
 		s["chapters"] = []map[string]any{
@@ -647,11 +640,17 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d)
+		output, err := extractFactsFromSummaryJSON(d, "test-hash-123")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
+		// verify JSONL header contains source_hash
+		firstLine, _, _ := strings.Cut(output, "\n")
+		assertContains(t, firstLine, `"source_hash":"test-hash-123"`)
+		assertContains(t, firstLine, `"schema_version":"2"`)
+
+		// verify fact content
 		assertContains(t, output, "use rotating tokens")
 		assertContains(t, output, "redis handles TTL well")
 		assertContains(t, output, "migrate by friday")
@@ -682,7 +681,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d)
+		output, err := extractFactsFromSummaryJSON(d, "v1-hash")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -707,7 +706,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		_, err := extractFactsFromSummaryJSON(d)
+		_, err := extractFactsFromSummaryJSON(d, "test-hash")
 		if err == nil {
 			t.Fatal("expected error for empty facts")
 		}
@@ -724,7 +723,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		_, err := extractFactsFromSummaryJSON(d)
+		_, err := extractFactsFromSummaryJSON(d, "test-hash")
 		if err == nil {
 			t.Fatal("expected error for missing summary.json")
 		}
@@ -753,7 +752,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d)
+		output, err := extractFactsFromSummaryJSON(d, "test-hash")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -785,7 +784,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d)
+		output, err := extractFactsFromSummaryJSON(d, "test-hash")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -820,7 +819,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d)
+		output, err := extractFactsFromSummaryJSON(d, "test-hash")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -848,7 +847,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d)
+		output, err := extractFactsFromSummaryJSON(d, "test-hash")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/ox/distill_github.go
+++ b/cmd/ox/distill_github.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/sageox/ox/internal/agentcli"
 	"github.com/sageox/ox/internal/codedb"
 	"github.com/sageox/ox/internal/codedb/query"
@@ -97,7 +100,7 @@ If you are uncertain whether something is meaningful, include it with a note in 
 //
 // repoID identifies the repo for per-repo state tracking.
 // dataDir is the path to the CodeDB data directory.
-func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, state *distillStateV2, repoID, dataDir, guidelines string) error {
+func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, repoID, dataDir, guidelines string) error {
 	if dataDir == "" {
 		slog.Debug("no CodeDB dir, skipping github fact extraction", "repo", repoID)
 		return nil
@@ -113,9 +116,9 @@ func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcl
 	}
 	defer db.Close()
 
-	// compute time window from distill state (per-repo)
+	// compute time window from fact file metadata (stateless)
 	now := time.Now().UTC()
-	since := state.githubFactsTimeForRepo(repoID, tc.Path)
+	since := inferGitHubQueryHighWater(tc.Path)
 
 	result, err := query.AssembleActivity(ctx, db.Store(), since, now)
 	if err != nil {
@@ -126,9 +129,6 @@ func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcl
 	if result.Metadata.PRCount == 0 && result.Metadata.IssueCount == 0 && result.Metadata.CommitCount == 0 {
 		slog.Debug("no github activity in window, skipping extraction",
 			"since", since.Format(time.RFC3339), "until", now.Format(time.RFC3339))
-		if !distillDryRun {
-			state.setGitHubFactsTime(repoID, now)
-		}
 		return nil
 	}
 
@@ -139,8 +139,43 @@ func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcl
 	if distillDryRun {
 		for _, day := range days {
 			bucket := byDay[day]
-			fmt.Fprintf(cmd.OutOrStdout(), "GitHub activity: %d PRs, %d issues, %d commits for extraction (%s)\n",
-				bucket.Metadata.PRCount, bucket.Metadata.IssueCount, bucket.Metadata.CommitCount, day)
+			// count items that already have fact files (skippable)
+			var skippedPRs, skippedIssues, skippedCommits int
+			for _, pr := range bucket.PRClusters {
+				data, _ := json.Marshal(pr)
+				hash := contentHash(string(data))
+				factPath := filepath.Join(tc.Path, "memory", ".github-facts", fmt.Sprintf("%s-pr-%d.jsonl", day, pr.Number))
+				if readFactFileSourceHash(factPath) == hash {
+					skippedPRs++
+				}
+			}
+			for _, issue := range bucket.StandaloneIssues {
+				data, _ := json.Marshal(issue)
+				hash := contentHash(string(data))
+				factPath := filepath.Join(tc.Path, "memory", ".github-facts", fmt.Sprintf("%s-issue-%d.jsonl", day, issue.Number))
+				if readFactFileSourceHash(factPath) == hash {
+					skippedIssues++
+				}
+			}
+			if len(bucket.StandaloneCommits) > 0 {
+				data, _ := json.Marshal(bucket.StandaloneCommits)
+				hash := contentHash(string(data))
+				commitsPath := filepath.Join(tc.Path, "memory", ".github-facts", day+"-commits.jsonl")
+				if readFactFileSourceHash(commitsPath) == hash {
+					skippedCommits = len(bucket.StandaloneCommits)
+				}
+			}
+			newPRs := bucket.Metadata.PRCount - skippedPRs
+			newIssues := bucket.Metadata.IssueCount - skippedIssues
+			newCommits := bucket.Metadata.CommitCount - skippedCommits
+			if newPRs > 0 || newIssues > 0 || newCommits > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "GitHub activity: %d PRs, %d issues, %d commits for extraction (%s)\n",
+					newPRs, newIssues, newCommits, day)
+			}
+			if skippedPRs > 0 || skippedIssues > 0 || skippedCommits > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "  (skipping %d PRs, %d issues, %d commits already extracted)\n",
+					skippedPRs, skippedIssues, skippedCommits)
+			}
 		}
 		return nil
 	}
@@ -150,97 +185,257 @@ func extractGitHubFacts(ctx context.Context, cmd *cobra.Command, backend agentcl
 		return fmt.Errorf("create github-facts dir: %w", err)
 	}
 
+	// collect work items, then fan out with bounded concurrency.
+	// each item writes to its own deterministic file — no shared state.
+	type workItem struct {
+		day      string
+		itemType string // "pr", "issue", "commits"
+		number   int    // PR/issue number, 0 for commits
+		item     any    // PRCluster, StandaloneIssue, or []StandaloneCommit
+	}
+
+	var items []workItem
 	for _, day := range days {
 		bucket := byDay[day]
-
-		// skip days with no meaningful clusters
-		if bucket.Metadata.PRCount == 0 && bucket.Metadata.IssueCount == 0 && bucket.Metadata.CommitCount == 0 {
-			continue
+		for _, pr := range bucket.PRClusters {
+			data, _ := json.Marshal(pr)
+			hash := contentHash(string(data))
+			factPath := filepath.Join(tc.Path, "memory", ".github-facts", fmt.Sprintf("%s-pr-%d.jsonl", day, pr.Number))
+			if readFactFileSourceHash(factPath) == hash {
+				continue
+			}
+			items = append(items, workItem{day, "pr", pr.Number, pr})
 		}
-
-		data, err := bucket.MarshalEventClusters()
-		if err != nil {
-			return fmt.Errorf("marshal event clusters (%s): %w", day, err)
+		for _, issue := range bucket.StandaloneIssues {
+			data, _ := json.Marshal(issue)
+			hash := contentHash(string(data))
+			factPath := filepath.Join(tc.Path, "memory", ".github-facts", fmt.Sprintf("%s-issue-%d.jsonl", day, issue.Number))
+			if readFactFileSourceHash(factPath) == hash {
+				continue
+			}
+			items = append(items, workItem{day, "issue", issue.Number, issue})
 		}
-
-		if len(data) > 100_000 {
-			slog.Warn("github activity batch is large, may exceed LLM context", "day", day, "bytes", len(data))
+		if len(bucket.StandaloneCommits) > 0 {
+			data, _ := json.Marshal(bucket.StandaloneCommits)
+			hash := contentHash(string(data))
+			commitsPath := filepath.Join(tc.Path, "memory", ".github-facts", day+"-commits.jsonl")
+			if readFactFileSourceHash(commitsPath) == hash {
+				continue
+			}
+			items = append(items, workItem{day, "commits", 0, bucket.StandaloneCommits})
 		}
+	}
 
-		interval := "1 day"
-		prompt := buildGitHubExtractorPrompt(string(data), interval, guidelines)
-		logPrompt(cmd, "github-facts:"+day, prompt)
+	if len(items) == 0 {
+		slog.Debug("all github items already extracted")
+		return nil
+	}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Extracting facts from %d PRs, %d issues, %d commits for %s...\n",
-			bucket.Metadata.PRCount, bucket.Metadata.IssueCount, bucket.Metadata.CommitCount, day)
+	concurrency := distillConcurrency
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	if concurrency > 8 {
+		concurrency = 8
+	}
 
-		output, err := backend.Run(ctx, prompt)
-		if err != nil {
-			return fmt.Errorf("AI coworker (%s): %w", day, err)
-		}
+	if concurrency > 1 {
+		fmt.Fprintf(cmd.OutOrStdout(), "Extracting %d GitHub items with concurrency %d...\n", len(items), concurrency)
+	}
 
-		output = strings.TrimSpace(output)
-		if output == "" || output == "[]" {
-			slog.Debug("github extractor returned no facts", "day", day)
-			continue
-		}
+	var mu sync.Mutex // protects stdout and git operations
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
 
-		// generate UUID7 filename for collision avoidance
-		id, err := uuid.NewV7()
-		if err != nil {
-			return fmt.Errorf("generate fact file ID: %w", err)
-		}
+	for _, wi := range items {
+		wi := wi // capture loop var
+		g.Go(func() error {
+			var err error
+			switch wi.itemType {
+			case "pr", "issue":
+				err = extractSingleGitHubItem(gctx, cmd, &mu, backend, tc.Path, wi.day, wi.itemType, wi.number, wi.item, since, guidelines)
+			case "commits":
+				commits := wi.item.([]query.StandaloneCommit)
+				err = extractGitHubCommitBatch(gctx, cmd, &mu, backend, tc.Path, wi.day, commits, since, guidelines)
+			}
+			if err != nil {
+				slog.Warn("github extraction failed", "day", wi.day, "type", wi.itemType, "number", wi.number, "error", err)
+			}
+			return nil // don't abort other items on failure
+		})
+	}
 
-		factFile := filepath.Join("memory", ".github-facts", day+"-"+id.String()+".jsonl")
+	_ = g.Wait()
+	return nil
+}
 
-		// Parse and validate LLM output as JSONL facts
-		_, parsedFacts, err := facts.ParseFacts([]byte(output))
-		if err != nil {
-			slog.Warn("github extractor returned unparseable output, skipping", "day", day, "error", err)
-			continue
-		}
-		if len(parsedFacts) == 0 {
-			slog.Debug("github extractor returned no valid facts after parsing", "day", day)
-			continue
-		}
+// extractSingleGitHubItem extracts facts from a single PR or issue.
+// Uses a deterministic filename based on day + item type + number for dedup.
+func extractSingleGitHubItem(ctx context.Context, cmd *cobra.Command, mu *sync.Mutex, backend agentcli.Backend, tcPath, day, itemType string, number int, item any, since time.Time, guidelines string) error {
+	// deterministic filename: 2026-03-28-pr-152.jsonl
+	factFile := filepath.Join("memory", ".github-facts", fmt.Sprintf("%s-%s-%d.jsonl", day, itemType, number))
+	fullPath := filepath.Join(tcPath, factFile)
 
+	data, err := json.Marshal(item)
+	if err != nil {
+		return fmt.Errorf("marshal %s #%d: %w", itemType, number, err)
+	}
+
+	prompt := buildGitHubExtractorPrompt(string(data), "1 day", guidelines)
+	logPrompt(cmd, fmt.Sprintf("github-%s:%d", itemType, number), prompt)
+
+	mu.Lock()
+	fmt.Fprintf(cmd.OutOrStdout(), "Extracting facts from %s #%d for %s (%d bytes)...\n",
+		itemType, number, day, len(data))
+	mu.Unlock()
+
+	llmStart := time.Now()
+	output, err := backend.Run(ctx, prompt)
+	elapsed := time.Since(llmStart).Round(time.Millisecond)
+	mu.Lock()
+	fmt.Fprintf(cmd.OutOrStdout(), "  %s #%d took %s\n", itemType, number, elapsed)
+	mu.Unlock()
+	if err != nil {
+		return fmt.Errorf("AI coworker (%s #%d): %w", itemType, number, err)
+	}
+
+	output = strings.TrimSpace(output)
+	sourceHash := contentHash(string(data))
+
+	if output == "" || output == "[]" {
+		// write empty marker (serialize git ops)
+		mu.Lock()
 		header := facts.FileHeader{
 			Meta: facts.FileMeta{
 				SchemaVersion: facts.SchemaVersion,
 				SourceType:    facts.SourceGitHub,
 				RecordedAt:    day + "T00:00:00Z",
+				SourceHash:    sourceHash,
+				QuerySince:    since.Format(time.RFC3339),
 			},
 		}
-
-		if err := facts.WriteFacts(filepath.Join(tc.Path, factFile), header, parsedFacts); err != nil {
-			return fmt.Errorf("write github facts: %w", err)
+		if err := facts.WriteFacts(fullPath, header, nil); err != nil {
+			mu.Unlock()
+			return fmt.Errorf("write empty marker: %w", err)
 		}
-
-		if err := commitMemoryFile(tc.Path, factFile, fmt.Sprintf("memory: extract github facts for %s", day)); err != nil {
-			slog.Warn("failed to commit github facts", "error", err)
+		if err := commitMemoryFile(tcPath, factFile, fmt.Sprintf("memory: no facts from %s #%d on %s", itemType, number, day)); err != nil {
+			slog.Warn("failed to commit empty marker, rolling back", "error", err)
+			os.Remove(fullPath)
 		}
-
-		fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s\n", factFile)
+		mu.Unlock()
+		return nil
 	}
 
-	state.setGitHubFactsTime(repoID, now)
+	_, parsedFacts, err := facts.ParseFacts([]byte(output))
+	if err != nil {
+		slog.Warn("github extractor returned unparseable output", "item", fmt.Sprintf("%s-%d", itemType, number), "error", err)
+		return nil
+	}
+	if len(parsedFacts) == 0 {
+		return nil
+	}
+
+	header := facts.FileHeader{
+		Meta: facts.FileMeta{
+			SchemaVersion: facts.SchemaVersion,
+			SourceType:    facts.SourceGitHub,
+			RecordedAt:    day + "T00:00:00Z",
+			SourceHash:    sourceHash,
+			QuerySince:    since.Format(time.RFC3339),
+		},
+	}
+
+	// serialize file writes and git commits (git isn't concurrent-safe)
+	mu.Lock()
+	defer mu.Unlock()
+
+	if err := facts.WriteFacts(fullPath, header, parsedFacts); err != nil {
+		return fmt.Errorf("write github facts: %w", err)
+	}
+
+	if err := commitMemoryFile(tcPath, factFile, fmt.Sprintf("memory: extract facts from %s #%d on %s", itemType, number, day)); err != nil {
+		slog.Warn("failed to commit github facts, rolling back", "error", err)
+		os.Remove(fullPath)
+		return fmt.Errorf("commit github facts: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s (%d facts)\n", factFile, len(parsedFacts))
 	return nil
 }
 
-// githubFactsSince returns the start of the time window for GitHub fact extraction.
-// If no state is available, it infers the high-water mark from existing files.
-func githubFactsSince(state *distillStateV2, tcPath string) time.Time {
-	if state.LastGitHubFacts != "" {
-		if t, err := time.Parse(time.RFC3339, state.LastGitHubFacts); err == nil {
-			return t
+// extractGitHubCommitBatch extracts facts from a batch of standalone commits for a day.
+func extractGitHubCommitBatch(ctx context.Context, cmd *cobra.Command, mu *sync.Mutex, backend agentcli.Backend, tcPath, day string, commits []query.StandaloneCommit, since time.Time, guidelines string) error {
+	factFile := filepath.Join("memory", ".github-facts", day+"-commits.jsonl")
+	fullPath := filepath.Join(tcPath, factFile)
+
+	data, err := json.Marshal(commits)
+	if err != nil {
+		return fmt.Errorf("marshal commits: %w", err)
+	}
+
+	sourceHash := contentHash(string(data))
+
+	prompt := buildGitHubExtractorPrompt(string(data), "1 day", guidelines)
+	logPrompt(cmd, "github-commits:"+day, prompt)
+
+	mu.Lock()
+	fmt.Fprintf(cmd.OutOrStdout(), "Extracting facts from %d standalone commits for %s (%d bytes)...\n", len(commits), day, len(data))
+	mu.Unlock()
+
+	llmStart := time.Now()
+	output, err := backend.Run(ctx, prompt)
+	elapsed := time.Since(llmStart).Round(time.Millisecond)
+	mu.Lock()
+	fmt.Fprintf(cmd.OutOrStdout(), "  commits batch took %s\n", elapsed)
+	mu.Unlock()
+	if err != nil {
+		return fmt.Errorf("AI coworker (commits %s): %w", day, err)
+	}
+
+	output = strings.TrimSpace(output)
+	header := facts.FileHeader{
+		Meta: facts.FileMeta{
+			SchemaVersion: facts.SchemaVersion,
+			SourceType:    facts.SourceGitHub,
+			RecordedAt:    day + "T00:00:00Z",
+			SourceHash:    sourceHash,
+			QuerySince:    since.Format(time.RFC3339),
+		},
+	}
+
+	// serialize file writes and git commits
+	mu.Lock()
+	defer mu.Unlock()
+
+	if output == "" || output == "[]" {
+		if err := facts.WriteFacts(fullPath, header, nil); err != nil {
+			return fmt.Errorf("write empty marker: %w", err)
 		}
+		if err := commitMemoryFile(tcPath, factFile, fmt.Sprintf("memory: no facts from commits on %s", day)); err != nil {
+			slog.Warn("failed to commit empty marker, rolling back", "error", err)
+			os.Remove(fullPath)
+		}
+		return nil
 	}
-	// infer high-water from existing fact files (fresh clone recovery)
-	if hw := inferGitHubFactsHighWater(tcPath); !hw.IsZero() {
-		return hw
+
+	_, parsedFacts, err := facts.ParseFacts([]byte(output))
+	if err != nil {
+		slog.Warn("github extractor returned unparseable output", "day", day, "error", err)
+		return nil
 	}
-	// default: 7 days ago
-	return time.Now().UTC().AddDate(0, 0, -7)
+
+	if err := facts.WriteFacts(fullPath, header, parsedFacts); err != nil {
+		return fmt.Errorf("write github facts: %w", err)
+	}
+
+	if err := commitMemoryFile(tcPath, factFile, fmt.Sprintf("memory: extract facts from %d commits on %s", len(commits), day)); err != nil {
+		slog.Warn("failed to commit github facts, rolling back", "error", err)
+		os.Remove(fullPath)
+		return fmt.Errorf("commit github facts: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s (%d facts)\n", factFile, len(parsedFacts))
+	return nil
 }
 
 // inferGitHubFactsHighWater scans memory/.github-facts/ for the latest YYYY-MM-DD
@@ -277,6 +472,17 @@ func inferGitHubFactsHighWater(tcPath string) time.Time {
 		return time.Time{}
 	}
 	return t
+}
+
+// inferGitHubQueryHighWater returns the start of the query window for GitHub extraction.
+// Uses the latest date prefix from existing fact filenames. Falls back to 7 days ago.
+// source_hash in each file handles dedup for items that changed within the same day.
+func inferGitHubQueryHighWater(tcPath string) time.Time {
+	// use filename-based inference (YYYY-MM-DD prefix)
+	if hw := inferGitHubFactsHighWater(tcPath); !hw.IsZero() {
+		return hw
+	}
+	return time.Now().UTC().AddDate(0, 0, -7)
 }
 
 // buildGitHubExtractorPrompt constructs the full prompt for the GitHub fact extractor.

--- a/cmd/ox/distill_github_test.go
+++ b/cmd/ox/distill_github_test.go
@@ -89,29 +89,6 @@ func TestBuildGitHubExtractorPrompt_WithGuidelines(t *testing.T) {
 	assert.Contains(t, prompt, "You are a signal extractor for an alignment feed system")
 }
 
-func TestGitHubFactsSince_Default(t *testing.T) {
-	t.Parallel()
-
-	state := &distillStateV2{}
-	since := githubFactsSince(state, t.TempDir())
-
-	// Should default to ~7 days ago
-	expected := time.Now().UTC().AddDate(0, 0, -7)
-	assert.InDelta(t, expected.Unix(), since.Unix(), 2)
-}
-
-func TestGitHubFactsSince_FromState(t *testing.T) {
-	t.Parallel()
-
-	ts := "2026-03-15T10:00:00Z"
-	state := &distillStateV2{LastGitHubFacts: ts}
-	since := githubFactsSince(state, t.TempDir())
-
-	assert.Equal(t, 2026, since.Year())
-	assert.Equal(t, time.March, since.Month())
-	assert.Equal(t, 15, since.Day())
-}
-
 func TestReadPendingGitHubFacts_EmptyDir(t *testing.T) {
 	t.Parallel()
 
@@ -214,13 +191,12 @@ func TestExtractGitHubFacts_Integration(t *testing.T) {
 		output: `{"headline":"Adopted token bucket rate limiting","summary":"Token bucket at 100 req/min","rationale":"Traffic growth","who":"alice","source_type":"github","source_ref":"https://github.com/org/repo/pull/42","timestamp":"2026-03-20T00:00:00Z"}`,
 	}
 
-	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, "test-repo", codeDBDir, "")
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, "test-repo", codeDBDir, "")
 	require.NoError(t, err)
 
 	// Verify prompt was sent to backend
@@ -246,15 +222,15 @@ func TestExtractGitHubFacts_Integration(t *testing.T) {
 			assert.Contains(t, contentStr, `"_meta"`)
 			assert.Contains(t, contentStr, `"schema_version":"2"`)
 			assert.Contains(t, contentStr, `"source_type":"github"`)
+			// query_since and source_hash should be present
+			assert.Contains(t, contentStr, `"query_since"`)
+			assert.Contains(t, contentStr, `"source_hash"`)
 			// UUID7 filename should be longer than just "YYYY-MM-DD.jsonl"
 			assert.Greater(t, len(e.Name()), len(expectedDay+".jsonl"))
 			found = true
 		}
 	}
 	assert.True(t, found, "expected UUID7 fact file for %s", expectedDay)
-
-	// Verify state was updated
-	assert.NotEmpty(t, state.RepoGitHubFacts["test-repo"])
 }
 
 func TestExtractGitHubFacts_DryRun(t *testing.T) {
@@ -271,7 +247,6 @@ func TestExtractGitHubFacts_DryRun(t *testing.T) {
 	})
 
 	backend := &mockBackend{}
-	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
 	var buf bytes.Buffer
@@ -281,13 +256,11 @@ func TestExtractGitHubFacts_DryRun(t *testing.T) {
 	distillDryRun = true
 	defer func() { distillDryRun = oldDryRun }()
 
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, "test-repo", codeDBDir, "")
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, "test-repo", codeDBDir, "")
 	require.NoError(t, err)
 
 	// Backend should NOT have been called
 	assert.Empty(t, backend.promptReceived)
-	// State should NOT have been updated
-	assert.Empty(t, state.RepoGitHubFacts["test-repo"])
 	// Output should show what would be processed, with per-day date
 	output := buf.String()
 	assert.Contains(t, output, "GitHub activity")
@@ -301,19 +274,16 @@ func TestExtractGitHubFacts_EmptySkip(t *testing.T) {
 	_, tcPath, codeDBDir := setupExtractGitHubFacts(t, nil)
 
 	backend := &mockBackend{}
-	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, "test-repo", codeDBDir, "")
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, "test-repo", codeDBDir, "")
 	require.NoError(t, err)
 
 	// Backend should NOT have been called (no activity)
 	assert.Empty(t, backend.promptReceived)
-	// State should be updated even on empty skip
-	assert.NotEmpty(t, state.RepoGitHubFacts["test-repo"])
 }
 
 // insertPRInCodeDB opens the CodeDB store, inserts a PR, and closes it.
@@ -346,47 +316,36 @@ func TestExtractGitHubFacts_TwoRunStateTracking(t *testing.T) {
 	})
 
 	backend := &mockBackend{output: `{"headline":"first run","source_type":"github","timestamp":"2026-03-23T00:00:00Z"}`}
-	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
 	cmd.SetOut(&bytes.Buffer{})
 
 	// First run: processes PRs #1-3
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, "test-repo", codeDBDir, "")
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, "test-repo", codeDBDir, "")
 	require.NoError(t, err)
-	assert.NotEmpty(t, state.RepoGitHubFacts["test-repo"])
 	assert.Contains(t, backend.promptReceived, "<batch>")
 
-	// Verify first run wrote UUID7 fact file(s)
+	// Verify first run wrote UUID7 fact file(s) with source_hash/date prefix in _meta
 	factsDir := filepath.Join(tcPath, "memory", ".github-facts")
 	entries1, err := os.ReadDir(factsDir)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(entries1), 1, "first run should produce at least 1 fact file")
 
-	// Record state after first run
-	firstRunState := state.RepoGitHubFacts["test-repo"]
-
-	// Artificially set the state back a bit so the second run has a wider window
-	// This simulates "time passing" between extraction runs
-	adjustedState, _ := time.Parse(time.RFC3339, firstRunState)
-	state.setGitHubFactsTime("test-repo", adjustedState.Add(-5*time.Minute))
-
-	// Insert PR #4 with current timestamp (within the adjusted window)
+	// Insert PR #4 with current timestamp — second run should pick it up
+	// because inferGitHubQueryHighWater reads source_hash/date prefix from first run's files
 	ts4 := time.Now().UTC().Unix()
 	insertPRInCodeDB(t, projectRoot, 4, "New PR", "bob", "open", ts4)
 
-	// Second run: should use adjusted state as window start, capturing PR #4
+	// Second run: should use source_hash/date prefix from first run's fact files as window start
 	backend.promptReceived = ""
 	backend.output = `{"headline":"second run","source_type":"github","timestamp":"2026-03-23T00:00:00Z"}`
 	cmd.SetOut(&bytes.Buffer{})
 
-	err = extractGitHubFacts(context.Background(), cmd, backend, tc, state, "test-repo", codeDBDir, "")
+	err = extractGitHubFacts(context.Background(), cmd, backend, tc, "test-repo", codeDBDir, "")
 	require.NoError(t, err)
 
-	// The second run should have processed PR #4 (high-water mark works)
+	// The second run should have processed PR #4 (high-water from fact files works)
 	assert.Contains(t, backend.promptReceived, "New PR")
-	// State should still be updated
-	assert.NotEmpty(t, state.RepoGitHubFacts["test-repo"])
 
 	// Both runs should have created separate UUID7 files (no overwrite)
 	entries2, err := os.ReadDir(factsDir)
@@ -407,13 +366,12 @@ func TestExtractGitHubFacts_IntraDayRerun(t *testing.T) {
 	})
 
 	backend := &mockBackend{output: `{"headline":"run 1","source_type":"github","timestamp":"2026-03-23T00:00:00Z"}`}
-	state := &distillStateV2{}
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
 	cmd.SetOut(&bytes.Buffer{})
 
 	// First run
-	err := extractGitHubFacts(context.Background(), cmd, backend, tc, state, "test-repo", codeDBDir, "")
+	err := extractGitHubFacts(context.Background(), cmd, backend, tc, "test-repo", codeDBDir, "")
 	require.NoError(t, err)
 
 	factsDir := filepath.Join(tcPath, "memory", ".github-facts")
@@ -422,16 +380,15 @@ func TestExtractGitHubFacts_IntraDayRerun(t *testing.T) {
 	firstRunCount := len(entries1)
 	assert.GreaterOrEqual(t, firstRunCount, 1, "first run should produce fact files")
 
-	// Reset state to simulate same-day re-run with new activity
-	state.setGitHubFactsTime("test-repo", time.Now().UTC().Add(-30*time.Minute))
+	// Insert new activity — second run picks up from source_hash/date prefix in first run's files
 	insertPRInCodeDB(t, projectRoot, 43, "Second PR", "bob", "open", time.Now().UTC().Unix())
 
 	backend.promptReceived = ""
 	backend.output = `{"headline":"run 2","source_type":"github","timestamp":"2026-03-23T00:00:00Z"}`
 	cmd.SetOut(&bytes.Buffer{})
 
-	// Second run same day
-	err = extractGitHubFacts(context.Background(), cmd, backend, tc, state, "test-repo", codeDBDir, "")
+	// Second run same day — uses source_hash/date prefix from first run's fact files
+	err = extractGitHubFacts(context.Background(), cmd, backend, tc, "test-repo", codeDBDir, "")
 	require.NoError(t, err)
 
 	entries2, err := os.ReadDir(factsDir)
@@ -474,14 +431,13 @@ func TestExtractGitHubFacts_MultiDayCatchup(t *testing.T) {
 
 	tracker := &trackingBackend{output: `{"headline":"facts","source_type":"github","timestamp":"2026-03-23T00:00:00Z"}`}
 
-	state := &distillStateV2{}
-	// Set state to before all 3 days
-	state.setGitHubFactsTime("test-repo", time.Now().UTC().AddDate(0, 0, -4))
 	tc := &config.TeamContext{Path: tcPath}
 	cmd := &cobra.Command{}
 	cmd.SetOut(&bytes.Buffer{})
 
-	err := extractGitHubFacts(context.Background(), cmd, tracker, tc, state, "test-repo", codeDBDir, "")
+	// No existing fact files — inferGitHubQueryHighWater falls back to 7 days ago,
+	// which covers all 3 days of inserted data
+	err := extractGitHubFacts(context.Background(), cmd, tracker, tc, "test-repo", codeDBDir, "")
 	require.NoError(t, err)
 
 	// Verify fact files were created for each day
@@ -536,9 +492,9 @@ func TestExtractGitHubFacts_HighWaterInference(t *testing.T) {
 		filepath.Join(factsDir, threeDaysAgo+"-019526a0-aaaa-7abc-8def-0123456789ab.md"),
 		[]byte(content), 0o644))
 
-	// No LastGitHubFacts in state — should infer from existing files
-	state := &distillStateV2{}
-	since := githubFactsSince(state, tcPath)
+	// inferGitHubQueryHighWater should fall back to filename-based inference
+	// (no .jsonl files with source_hash/date prefix, but .md files have date prefix)
+	since := inferGitHubQueryHighWater(tcPath)
 
 	// High-water should be inferred from the most recent fact file date
 	expectedDate := threeDaysAgo
@@ -787,4 +743,65 @@ func TestReadPendingGitHubFacts_MultiDayCatchup(t *testing.T) {
 		require.Len(t, result[day], 1, "day %s should have exactly 1 fact", day)
 		assert.Contains(t, result[day][0].Content, "Facts for "+day)
 	}
+}
+
+// --- inferGitHubQueryHighWater tests ---
+
+func TestInferGitHubQueryHighWater_WithFiles(t *testing.T) {
+	t.Parallel()
+
+	tcPath := t.TempDir()
+	factsDir := filepath.Join(tcPath, "memory", ".github-facts")
+	require.NoError(t, os.MkdirAll(factsDir, 0o755))
+
+	// Two JSONL files with different date prefixes
+	file1 := `{"_meta":{"schema_version":"2","source_type":"github","recorded_at":"2026-03-18T00:00:00Z"}}
+{"headline":"fact1","source_type":"github","timestamp":"2026-03-18T10:00:00Z"}
+`
+	file2 := `{"_meta":{"schema_version":"2","source_type":"github","recorded_at":"2026-03-20T00:00:00Z"}}
+{"headline":"fact2","source_type":"github","timestamp":"2026-03-20T10:00:00Z"}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(factsDir, "2026-03-18-pr-100.jsonl"),
+		[]byte(file1), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(factsDir, "2026-03-20-pr-200.jsonl"),
+		[]byte(file2), 0o644))
+
+	hw := inferGitHubQueryHighWater(tcPath)
+
+	// Should return start-of-day for the latest date prefix in filenames
+	expected, _ := time.Parse("2006-01-02", "2026-03-20")
+	assert.Equal(t, expected, hw, "should return latest date from filenames")
+}
+
+func TestInferGitHubQueryHighWater_NoQueryUntil_FallsBackToFilename(t *testing.T) {
+	t.Parallel()
+
+	tcPath := t.TempDir()
+	factsDir := filepath.Join(tcPath, "memory", ".github-facts")
+	require.NoError(t, os.MkdirAll(factsDir, 0o755))
+
+	// Old-style .md file without source_hash/date prefix — should fall back to filename-based
+	content := "# GitHub Facts: 2026-03-15\n\nOld facts\n"
+	require.NoError(t, os.WriteFile(
+		filepath.Join(factsDir, "2026-03-15-019526a0-aaaa-7abc-8def-0123456789ab.md"),
+		[]byte(content), 0o644))
+
+	hw := inferGitHubQueryHighWater(tcPath)
+
+	// Should fall back to inferGitHubFactsHighWater (filename-based)
+	assert.Equal(t, "2026-03-15", hw.Format("2006-01-02"),
+		"should fall back to filename-based high water when no source_hash/date prefix present")
+}
+
+func TestInferGitHubQueryHighWater_NoFiles_DefaultsTo7DaysAgo(t *testing.T) {
+	t.Parallel()
+
+	tcPath := t.TempDir()
+	hw := inferGitHubQueryHighWater(tcPath)
+
+	expected := time.Now().UTC().AddDate(0, 0, -7)
+	assert.InDelta(t, expected.Unix(), hw.Unix(), 2,
+		"should default to ~7 days ago when no fact files exist")
 }

--- a/cmd/ox/distill_index.go
+++ b/cmd/ox/distill_index.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/facts"
+)
+
+// distillIndex is a performance cache that mirrors metadata already stored
+// in memory files. It is NOT the source of truth — the files are.
+// If missing or corrupt, it is rebuilt by reading file headers.
+//
+// Every field here corresponds 1:1 to metadata in the files:
+//   - FactMeta: _meta header from .jsonl fact files (source_hash, query_since, query_until)
+//   - DailySources: sources frontmatter from daily .md files
+type distillIndex struct {
+	// FactMeta caches the _meta header of each fact file.
+	// Key: relative path (e.g., "memory/.github-facts/2026-03-30-xxx.jsonl").
+	// Value: the FileMeta from the file's first line — same fields, same values.
+	FactMeta map[string]facts.FileMeta `json:"fact_meta"`
+
+	// DailySources caches the sources frontmatter from each daily summary.
+	// Key: relative path (e.g., "memory/daily/2026-03-30-xxx.md").
+	// Value: list of fact file paths from the file's YAML frontmatter.
+	DailySources map[string][]string `json:"daily_sources"`
+}
+
+const distillIndexFile = "distill-index.json"
+
+// loadDistillIndex loads the cache index, or rebuilds it from memory files.
+// Returns the index and whether it was rebuilt (vs loaded from cache).
+func loadDistillIndex(projectRoot, tcPath string) (*distillIndex, bool) {
+	indexPath := filepath.Join(projectRoot, ".sageox", "cache", distillIndexFile)
+
+	if data, err := os.ReadFile(indexPath); err == nil {
+		var idx distillIndex
+		if err := json.Unmarshal(data, &idx); err != nil {
+			slog.Warn("corrupt distill index, rebuilding", "error", err)
+		} else if idx.FactMeta != nil {
+			return &idx, false
+		} else {
+			slog.Warn("distill index missing FactMeta, rebuilding")
+		}
+	}
+
+	idx := rebuildDistillIndex(tcPath)
+	return idx, true
+}
+
+// saveDistillIndex persists the index to disk.
+func saveDistillIndex(projectRoot string, idx *distillIndex) error {
+	cacheDir := filepath.Join(projectRoot, ".sageox", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return fmt.Errorf("create cache dir: %w", err)
+	}
+	data, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(cacheDir, distillIndexFile), append(data, '\n'), 0o644)
+}
+
+// rebuildDistillIndex scans all memory files and builds the index from scratch.
+func rebuildDistillIndex(tcPath string) *distillIndex {
+	idx := &distillIndex{
+		FactMeta:     make(map[string]facts.FileMeta),
+		DailySources: make(map[string][]string),
+	}
+
+	// scan fact files (.github-facts, .session-facts, .discussion-facts)
+	scanFactDir(idx, tcPath, filepath.Join("memory", ".github-facts"))
+	scanFactDir(idx, tcPath, filepath.Join("memory", ".discussion-facts"))
+	scanSessionFactDirs(idx, tcPath)
+
+	// scan daily summaries for sources frontmatter
+	scanDailySummaries(idx, tcPath)
+
+	slog.Info("rebuilt distill index", "facts", len(idx.FactMeta), "dailies", len(idx.DailySources))
+	return idx
+}
+
+// updateDistillIndex scans for new files not in the index and merges them in.
+// Returns the number of new files discovered.
+func updateDistillIndex(idx *distillIndex, tcPath string) int {
+	var newFiles int
+	newFiles += scanFactDirUpdate(idx, tcPath, filepath.Join("memory", ".github-facts"))
+	newFiles += scanFactDirUpdate(idx, tcPath, filepath.Join("memory", ".discussion-facts"))
+	newFiles += scanSessionFactDirsUpdate(idx, tcPath)
+	newFiles += scanDailySummariesUpdate(idx, tcPath)
+
+	if newFiles > 0 {
+		slog.Info("updated distill index", "new_files", newFiles)
+	}
+	return newFiles
+}
+
+// --- scan helpers ---
+
+// scanFactDir reads all .jsonl files in a flat directory and caches their _meta.
+func scanFactDir(idx *distillIndex, tcPath, relDir string) {
+	absDir := filepath.Join(tcPath, relDir)
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		relPath := filepath.Join(relDir, entry.Name())
+		meta, err := readFactFileMeta(filepath.Join(absDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		idx.FactMeta[relPath] = meta
+	}
+}
+
+// scanFactDirUpdate is like scanFactDir but only processes files not already in the index.
+func scanFactDirUpdate(idx *distillIndex, tcPath, relDir string) int {
+	absDir := filepath.Join(tcPath, relDir)
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return 0
+	}
+	var newFiles int
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		relPath := filepath.Join(relDir, entry.Name())
+		if _, known := idx.FactMeta[relPath]; known {
+			continue
+		}
+		meta, err := readFactFileMeta(filepath.Join(absDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		idx.FactMeta[relPath] = meta
+		newFiles++
+	}
+	return newFiles
+}
+
+// scanSessionFactDirs reads .session-facts/<date>/<file>.jsonl (nested structure).
+func scanSessionFactDirs(idx *distillIndex, tcPath string) {
+	sessDir := filepath.Join(tcPath, "memory", ".session-facts")
+	dateDirs, err := os.ReadDir(sessDir)
+	if err != nil {
+		return
+	}
+	for _, dateDir := range dateDirs {
+		if !dateDir.IsDir() {
+			continue
+		}
+		scanFactDir(idx, tcPath, filepath.Join("memory", ".session-facts", dateDir.Name()))
+	}
+}
+
+// scanSessionFactDirsUpdate is like scanSessionFactDirs but only processes new files.
+func scanSessionFactDirsUpdate(idx *distillIndex, tcPath string) int {
+	sessDir := filepath.Join(tcPath, "memory", ".session-facts")
+	dateDirs, err := os.ReadDir(sessDir)
+	if err != nil {
+		return 0
+	}
+	var newFiles int
+	for _, dateDir := range dateDirs {
+		if !dateDir.IsDir() {
+			continue
+		}
+		newFiles += scanFactDirUpdate(idx, tcPath, filepath.Join("memory", ".session-facts", dateDir.Name()))
+	}
+	return newFiles
+}
+
+// scanDailySummaries reads daily .md files and caches their sources frontmatter.
+func scanDailySummaries(idx *distillIndex, tcPath string) {
+	dailyDir := filepath.Join(tcPath, "memory", "daily")
+	entries, err := os.ReadDir(dailyDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		relPath := filepath.Join("memory", "daily", entry.Name())
+		data, err := os.ReadFile(filepath.Join(dailyDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		if sources := parseDailySources(string(data)); len(sources) > 0 {
+			idx.DailySources[relPath] = sources
+		}
+	}
+}
+
+// scanDailySummariesUpdate is like scanDailySummaries but only processes new files.
+func scanDailySummariesUpdate(idx *distillIndex, tcPath string) int {
+	dailyDir := filepath.Join(tcPath, "memory", "daily")
+	entries, err := os.ReadDir(dailyDir)
+	if err != nil {
+		return 0
+	}
+	var newFiles int
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		relPath := filepath.Join("memory", "daily", entry.Name())
+		if _, known := idx.DailySources[relPath]; known {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dailyDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		if sources := parseDailySources(string(data)); len(sources) > 0 {
+			idx.DailySources[relPath] = sources
+			newFiles++
+		}
+	}
+	return newFiles
+}
+
+// --- index query helpers ---
+
+// readFactFileMeta reads the _meta header from the first line of a JSONL fact file.
+func readFactFileMeta(path string) (facts.FileMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return facts.FileMeta{}, err
+	}
+	firstLine, _, _ := strings.Cut(string(data), "\n")
+	firstLine = strings.TrimSpace(firstLine)
+	if firstLine == "" {
+		return facts.FileMeta{}, fmt.Errorf("empty file")
+	}
+	var header facts.FileHeader
+	if err := json.Unmarshal([]byte(firstLine), &header); err != nil {
+		return facts.FileMeta{}, err
+	}
+	return header.Meta, nil
+}
+
+// distilledSources returns the set of fact file paths already included in daily summaries.
+func (idx *distillIndex) distilledSources() map[string]bool {
+	result := make(map[string]bool)
+	for _, sources := range idx.DailySources {
+		for _, src := range sources {
+			result[src] = true
+		}
+	}
+	return result
+}
+
+// sourceHash returns the cached source_hash for a fact file, or empty string.
+func (idx *distillIndex) sourceHash(relPath string) string {
+	if meta, ok := idx.FactMeta[relPath]; ok {
+		return meta.SourceHash
+	}
+	return ""
+}
+
+// addFactFile records a newly created fact file in the index.
+func (idx *distillIndex) addFactFile(relPath string, meta facts.FileMeta) {
+	idx.FactMeta[relPath] = meta
+}
+
+// addDailySummary records a newly created daily summary and its sources.
+func (idx *distillIndex) addDailySummary(relPath string, sources []string) {
+	idx.DailySources[relPath] = sources
+}

--- a/cmd/ox/distill_pure_test.go
+++ b/cmd/ox/distill_pure_test.go
@@ -230,7 +230,7 @@ func TestFormatDailyMemory_SourceVariants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := formatDailyMemory("2026-03-25", "Distilled content here.", tt.obsCount, tt.factCount)
+			result := formatDailyMemory("2026-03-25", "Distilled content here.", tt.obsCount, tt.factCount, nil)
 			assert.Contains(t, result, "# Daily Memory")
 			assert.Contains(t, result, "2026-03-25")
 			assert.Contains(t, result, "Distilled content here.")
@@ -309,7 +309,7 @@ func TestGroupObservationsByDay_EdgeCases(t *testing.T) {
 
 func TestScanPendingDiscussions_Pure(t *testing.T) {
 	t.Run("missing directory returns nil", func(t *testing.T) {
-		result, err := scanPendingDiscussions("/nonexistent/path", nil)
+		result, err := scanPendingDiscussions("/nonexistent/path")
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
@@ -319,7 +319,7 @@ func TestScanPendingDiscussions_Pure(t *testing.T) {
 		discussionsDir := filepath.Join(tmp, "discussions")
 		require.NoError(t, os.MkdirAll(discussionsDir, 0755))
 
-		result, err := scanPendingDiscussions(tmp, nil)
+		result, err := scanPendingDiscussions(tmp)
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
@@ -331,7 +331,7 @@ func TestScanPendingDiscussions_Pure(t *testing.T) {
 		// create a file (not dir) in discussions
 		require.NoError(t, os.WriteFile(filepath.Join(discussionsDir, "notes.txt"), []byte("hi"), 0644))
 
-		result, err := scanPendingDiscussions(tmp, nil)
+		result, err := scanPendingDiscussions(tmp)
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
@@ -362,14 +362,10 @@ func TestSaveAndLoadDistillStateV2(t *testing.T) {
 	requireSageoxDir(t, tmp)
 
 	original := &distillStateV2{
-		SchemaVersion:        "2",
-		TeamID:               "team-round-trip",
-		LastDaily:            "2026-03-20T10:00:00Z",
-		LastWeekly:           "2026-03-15T10:00:00Z",
-		LastMonthly:          "2026-02-28T23:59:59Z",
-		DailyCount:           42,
-		LastDailyHash:        "abc123",
-		ProcessedDiscussions: map[string]string{"disc-1": "hash1"},
+		SchemaVersion: "2",
+		TeamID:        "team-round-trip",
+		LastWeekly:    "2026-03-15T10:00:00Z",
+		LastMonthly:   "2026-02-28T23:59:59Z",
 	}
 
 	require.NoError(t, saveDistillStateV2(tmp, original))
@@ -377,12 +373,8 @@ func TestSaveAndLoadDistillStateV2(t *testing.T) {
 	loaded := loadDistillStateV2(tmp, tmp)
 	assert.Equal(t, "2", loaded.SchemaVersion)
 	assert.Equal(t, "team-round-trip", loaded.TeamID)
-	assert.Equal(t, "2026-03-20T10:00:00Z", loaded.LastDaily)
 	assert.Equal(t, "2026-03-15T10:00:00Z", loaded.LastWeekly)
 	assert.Equal(t, "2026-02-28T23:59:59Z", loaded.LastMonthly)
-	assert.Equal(t, 42, loaded.DailyCount)
-	assert.Equal(t, "abc123", loaded.LastDailyHash)
-	assert.Equal(t, map[string]string{"disc-1": "hash1"}, loaded.ProcessedDiscussions)
 }
 
 func TestDetermineLayers_ExplicitMonthly(t *testing.T) {

--- a/cmd/ox/distill_sessions.go
+++ b/cmd/ox/distill_sessions.go
@@ -46,7 +46,7 @@ type sessionInput struct {
 // ledgerPath is the path to the ledger directory containing sessions/.
 //
 // No LLM calls — pure data transformation from structured summary.json.
-func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, state *distillStateV2, repoID, ledgerPath string) error {
+func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, repoID, ledgerPath string) error {
 	if ledgerPath == "" {
 		slog.Debug("no ledger path, skipping session fact extraction", "repo", repoID)
 		return nil
@@ -56,9 +56,7 @@ func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, state *dist
 		return nil
 	}
 
-	processed := state.sessionsForRepo(repoID)
-
-	pending, err := scanPendingSessions(ledgerPath, tc.Path, processed)
+	pending, err := scanPendingSessions(ledgerPath, tc.Path)
 	if err != nil {
 		return fmt.Errorf("scan sessions: %w", err)
 	}
@@ -93,12 +91,11 @@ func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, state *dist
 					SchemaVersion: facts.SchemaVersion,
 					SourceType:    facts.SourceSession,
 					RecordedAt:    recordedAt,
+					SourceHash:    s.Hash,
 				},
 			}
 			if err := facts.WriteFacts(filepath.Join(tc.Path, markerFile), markerHeader, nil); err != nil {
 				slog.Warn("failed to write empty session fact marker", "session", s.DirName, "error", err)
-			} else {
-				processed[s.DirName] = s.Hash
 			}
 			continue
 		}
@@ -108,6 +105,7 @@ func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, state *dist
 				SchemaVersion: facts.SchemaVersion,
 				SourceType:    facts.SourceSession,
 				RecordedAt:    recordedAt,
+				SourceHash:    s.Hash,
 			},
 		}
 
@@ -126,8 +124,6 @@ func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, state *dist
 			}
 			continue
 		}
-
-		processed[s.DirName] = s.Hash
 
 		fmt.Fprintf(cmd.OutOrStdout(), "Extracted %d facts from session: %s\n", len(extractedFacts), s.Summary.Title)
 	}
@@ -167,8 +163,10 @@ func readSessionStartedAt(sessionDir string) time.Time {
 }
 
 // scanPendingSessions reads the sessions/ directory in the ledger and returns
-// sessions not yet tracked in state.ProcessedSessions that have a summary.json.
-func scanPendingSessions(ledgerPath, tcPath string, processed map[string]string) ([]sessionInput, error) {
+// sessions that need fact extraction. A session is skipped if its fact file
+// already exists and the embedded source_hash matches the current summary hash.
+// Legacy fact files without source_hash are re-extracted.
+func scanPendingSessions(ledgerPath, tcPath string) ([]sessionInput, error) {
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	entries, err := os.ReadDir(sessionsDir)
 	if err != nil {
@@ -200,21 +198,20 @@ func scanPendingSessions(ledgerPath, tcPath string, processed map[string]string)
 			continue // no summary.json, skip
 		}
 
+		// derive the final date before dedup check — started_at may differ from dir name
+		startedAt := readSessionStartedAt(filepath.Join(sessionsDir, dirName))
+		sessionDate := date
+		if !startedAt.IsZero() {
+			sessionDate = startedAt.UTC().Format("2006-01-02")
+		}
+
 		// compute content hash for change detection
 		currentHash := contentHash(string(summaryData))
 
-		// check if fact file already exists in team context
-		factFilePath := filepath.Join(tcPath, "memory", ".session-facts", date, dirName+".jsonl")
-		factFileExists := fileExists(factFilePath)
-
-		// skip if already processed with same hash and fact file exists
-		if prevHash, ok := processed[dirName]; ok && prevHash == currentHash && factFileExists {
-			continue
-		}
-
-		// skip if fact file already exists (covers fresh clone / deleted state)
-		if _, ok := processed[dirName]; !ok && factFileExists {
-			continue
+		// check if fact file already exists with matching source_hash
+		factFilePath := filepath.Join(tcPath, "memory", ".session-facts", sessionDate, dirName+".jsonl")
+		if existingHash := readFactFileSourceHash(factFilePath); existingHash == currentHash {
+			continue // fact file is up to date
 		}
 
 		// parse summary.json
@@ -228,13 +225,6 @@ func scanPendingSessions(ledgerPath, tcPath string, processed map[string]string)
 		if summary.QualityScore > 0 && summary.QualityScore < minSessionQuality {
 			slog.Debug("skip low-quality session", "session", dirName, "score", summary.QualityScore)
 			continue
-		}
-
-		// try to get accurate started_at from raw.jsonl _meta
-		startedAt := readSessionStartedAt(filepath.Join(sessionsDir, dirName))
-		sessionDate := date
-		if !startedAt.IsZero() {
-			sessionDate = startedAt.UTC().Format("2006-01-02")
 		}
 
 		pending = append(pending, sessionInput{

--- a/cmd/ox/distill_sessions_test.go
+++ b/cmd/ox/distill_sessions_test.go
@@ -28,6 +28,13 @@ func createSessionDir(t *testing.T, sessionsDir, dirName string, summary *sessio
 	}
 }
 
+// writeSessionFactFileWithHash writes a session fact file with the given source_hash in _meta.
+func writeSessionFactFileWithHash(t *testing.T, tcPath, date, dirName, hash string) {
+	t.Helper()
+	factsDir := filepath.Join(tcPath, "memory", ".session-facts", date)
+	writeFactFileWithHash(t, factsDir, dirName+".jsonl", hash)
+}
+
 func testSummary(title string, score float64) *sessionsummary.SummarizeResponse {
 	return &sessionsummary.SummarizeResponse{
 		Title:        title,
@@ -106,9 +113,9 @@ func TestScanPendingSessions(t *testing.T) {
 		return ledgerPath, tcPath
 	}
 
-	t.Run("no processed — finds all", func(t *testing.T) {
+	t.Run("no fact files — finds all", func(t *testing.T) {
 		ledgerPath, tcPath := setup(t, false)
-		pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -117,67 +124,56 @@ func TestScanPendingSessions(t *testing.T) {
 		}
 	})
 
-	t.Run("one processed with fact file — finds remaining", func(t *testing.T) {
-		ledgerPath, tcPath := setup(t, true)
-		processed := map[string]string{
-			"2026-03-10T14-23-ryan-Ox7f3a": sessionContentHash(ledgerPath, "2026-03-10T14-23-ryan-Ox7f3a"),
-		}
-		pending, err := scanPendingSessions(ledgerPath, tcPath, processed)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		// alice is not in processed map but her fact file exists → skipped
-		if len(pending) != 0 {
-			t.Errorf("got %d pending, want 0 (both have fact files)", len(pending))
-		}
-	})
-
-	t.Run("all processed with fact files — finds none", func(t *testing.T) {
-		ledgerPath, tcPath := setup(t, true)
-		processed := map[string]string{
-			"2026-03-10T14-23-ryan-Ox7f3a": sessionContentHash(ledgerPath, "2026-03-10T14-23-ryan-Ox7f3a"),
-			"2026-03-11T09-00-alice-OxABCD": sessionContentHash(ledgerPath, "2026-03-11T09-00-alice-OxABCD"),
-		}
-		pending, err := scanPendingSessions(ledgerPath, tcPath, processed)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(pending) != 0 {
-			t.Errorf("got %d pending, want 0", len(pending))
-		}
-	})
-
-	t.Run("stale hash + no fact file — re-processes", func(t *testing.T) {
+	t.Run("fact files with matching source_hash — skips all", func(t *testing.T) {
 		ledgerPath, tcPath := setup(t, false)
-		processed := map[string]string{
-			"2026-03-10T14-23-ryan-Ox7f3a": "stale-hash",
+		// Write fact files with matching source_hash for both sessions
+		for _, item := range []struct {
+			date, dirName string
+		}{
+			{"2026-03-10", "2026-03-10T14-23-ryan-Ox7f3a"},
+			{"2026-03-11", "2026-03-11T09-00-alice-OxABCD"},
+		} {
+			hash := sessionContentHash(ledgerPath, item.dirName)
+			writeSessionFactFileWithHash(t, tcPath, item.date, item.dirName, hash)
 		}
-		pending, err := scanPendingSessions(ledgerPath, tcPath, processed)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(pending) != 2 {
-			t.Errorf("got %d pending, want 2", len(pending))
+		if len(pending) != 0 {
+			t.Errorf("got %d pending, want 0 (all have matching source_hash)", len(pending))
 		}
 	})
 
-	t.Run("stale hash + fact file exists — re-processes changed session", func(t *testing.T) {
-		ledgerPath, tcPath := setup(t, true)
-		processed := map[string]string{
-			"2026-03-10T14-23-ryan-Ox7f3a": "stale-hash",
-			"2026-03-11T09-00-alice-OxABCD": sessionContentHash(ledgerPath, "2026-03-11T09-00-alice-OxABCD"),
-		}
-		pending, err := scanPendingSessions(ledgerPath, tcPath, processed)
+	t.Run("fact file with stale source_hash — re-extracts", func(t *testing.T) {
+		ledgerPath, tcPath := setup(t, false)
+		// ryan: stale hash → should re-extract
+		writeSessionFactFileWithHash(t, tcPath, "2026-03-10", "2026-03-10T14-23-ryan-Ox7f3a", "stale-hash")
+		// alice: matching hash → skip
+		aliceHash := sessionContentHash(ledgerPath, "2026-03-11T09-00-alice-OxABCD")
+		writeSessionFactFileWithHash(t, tcPath, "2026-03-11", "2026-03-11T09-00-alice-OxABCD", aliceHash)
+
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// ryan: stale hash → re-process despite fact file existing
-		// alice: matching hash + fact file → skip
 		if len(pending) != 1 {
 			t.Fatalf("got %d pending, want 1", len(pending))
 		}
 		if pending[0].DirName != "2026-03-10T14-23-ryan-Ox7f3a" {
-			t.Errorf("expected ryan's session to be re-processed, got %s", pending[0].DirName)
+			t.Errorf("expected ryan's session to be re-extracted, got %s", pending[0].DirName)
+		}
+	})
+
+	t.Run("legacy fact file without source_hash — re-extracts", func(t *testing.T) {
+		ledgerPath, tcPath := setup(t, true) // writes fact files without source_hash
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Both legacy fact files have no source_hash → both re-extracted
+		if len(pending) != 2 {
+			t.Errorf("got %d pending, want 2 (legacy files without source_hash)", len(pending))
 		}
 	})
 
@@ -192,7 +188,7 @@ func TestScanPendingSessions(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -207,7 +203,7 @@ func TestScanPendingSessions(t *testing.T) {
 		sessionsDir := filepath.Join(ledgerPath, "sessions")
 		createSessionDir(t, sessionsDir, "2026-03-10T14-23-ryan-Ox7f3a", testSummary("Low quality", 0.1))
 
-		pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -222,7 +218,7 @@ func TestScanPendingSessions(t *testing.T) {
 		sessionsDir := filepath.Join(ledgerPath, "sessions")
 		createSessionDir(t, sessionsDir, "2026-03-10T14-23-ryan-Ox7f3a", testSummary("No score", 0))
 
-		pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -237,7 +233,7 @@ func TestScanPendingSessions(t *testing.T) {
 		// create session dir without summary.json
 		os.MkdirAll(filepath.Join(ledgerPath, "sessions", "2026-03-10T14-23-ryan-Ox7f3a"), 0o755)
 
-		pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -249,7 +245,7 @@ func TestScanPendingSessions(t *testing.T) {
 	t.Run("nonexistent sessions dir — returns nil", func(t *testing.T) {
 		ledgerPath := t.TempDir()
 		tcPath := t.TempDir()
-		pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -715,7 +711,7 @@ func TestScanPendingSessionsStartedAt(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -739,7 +735,7 @@ func TestScanPendingSessionsStartedAt(t *testing.T) {
 		dirName := "2026-03-10T14-23-ryan-Ox7f3a"
 		createSessionDir(t, sessionsDir, dirName, testSummary("No raw", 0.8))
 
-		pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+		pending, err := scanPendingSessions(ledgerPath, tcPath)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -843,7 +839,7 @@ func TestScanPendingSessionsPopulatesHash(t *testing.T) {
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	createSessionDir(t, sessionsDir, "2026-03-10T14-23-ryan-Ox7f3a", testSummary("Test", 0.8))
 
-	pending, err := scanPendingSessions(ledgerPath, tcPath, nil)
+	pending, err := scanPendingSessions(ledgerPath, tcPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/ox/distill_test.go
+++ b/cmd/ox/distill_test.go
@@ -184,7 +184,7 @@ func TestWriteMemoryFile(t *testing.T) {
 }
 
 func TestFormatDailyMemory(t *testing.T) {
-	content := formatDailyMemory("2026-03-11", "Some distilled content", 5, 0)
+	content := formatDailyMemory("2026-03-11", "Some distilled content", 5, 0, nil)
 	if content == "" {
 		t.Error("expected non-empty content")
 	}
@@ -260,16 +260,10 @@ func TestDistillStateV2Migration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// load as v2 (with empty tcPath — no memory files to infer from)
+	// v1 state is no longer migrated — just verify we get a fresh v2 state
 	state := loadDistillStateV2(tmp, tmp)
-	if state.TeamID != "team-abc" {
-		t.Errorf("expected team-abc, got %s", state.TeamID)
-	}
-
-	// v1's LastDistilled should be used as fallback for lastDailyTime
-	daily := state.lastDailyTime()
-	if daily.IsZero() {
-		t.Error("lastDailyTime should fall back to v1 LastDistilled")
+	if state.SchemaVersion != "2" {
+		t.Errorf("expected schema version 2, got %s", state.SchemaVersion)
 	}
 }
 
@@ -283,9 +277,8 @@ func TestDistillStateV2SaveLoad(t *testing.T) {
 	state := &distillStateV2{
 		SchemaVersion: "2",
 		TeamID:        "team-xyz",
-		LastDaily:     "2026-03-11T10:00:00Z",
 		LastWeekly:    "2026-03-10T10:00:00Z",
-		DailyCount:    15,
+		LastMonthly:   "2026-02-28T23:59:59Z",
 	}
 
 	if err := saveDistillStateV2(tmp, state); err != nil {
@@ -296,47 +289,19 @@ func TestDistillStateV2SaveLoad(t *testing.T) {
 	if loaded.TeamID != "team-xyz" {
 		t.Errorf("expected team-xyz, got %s", loaded.TeamID)
 	}
-	if loaded.LastDaily != "2026-03-11T10:00:00Z" {
-		t.Errorf("expected LastDaily 2026-03-11T10:00:00Z, got %s", loaded.LastDaily)
-	}
-	if loaded.DailyCount != 15 {
-		t.Errorf("expected DailyCount 15, got %d", loaded.DailyCount)
+	if loaded.LastWeekly != "2026-03-10T10:00:00Z" {
+		t.Errorf("expected LastWeekly 2026-03-10T10:00:00Z, got %s", loaded.LastWeekly)
 	}
 }
 
 func TestDistillStateV2LastTimes(t *testing.T) {
 	t.Run("zero state returns zero times", func(t *testing.T) {
 		state := &distillStateV2{}
-		if !state.lastDailyTime().IsZero() {
-			t.Error("expected zero lastDailyTime for empty state")
-		}
 		if !state.lastWeeklyTime().IsZero() {
 			t.Error("expected zero lastWeeklyTime for empty state")
 		}
 		if !state.lastMonthlyTime().IsZero() {
 			t.Error("expected zero lastMonthlyTime for empty state")
-		}
-	})
-
-	t.Run("lastDaily prefers LastDaily over LastDistilled", func(t *testing.T) {
-		state := &distillStateV2{
-			LastDaily:     "2026-03-11T10:00:00Z",
-			LastDistilled: "2026-03-01T10:00:00Z",
-		}
-		daily := state.lastDailyTime()
-		expected, _ := time.Parse(time.RFC3339, "2026-03-11T10:00:00Z")
-		if !daily.Equal(expected) {
-			t.Errorf("expected %v, got %v", expected, daily)
-		}
-	})
-
-	t.Run("lastDaily falls back to LastDistilled", func(t *testing.T) {
-		state := &distillStateV2{
-			LastDistilled: "2026-03-01T10:00:00Z",
-		}
-		daily := state.lastDailyTime()
-		if daily.IsZero() {
-			t.Error("expected non-zero lastDailyTime from LastDistilled fallback")
 		}
 	})
 }
@@ -814,17 +779,8 @@ func TestLoadState_FallbackToHighWater(t *testing.T) {
 	os.MkdirAll(monthlyDir, 0o755)
 	os.WriteFile(filepath.Join(monthlyDir, "2026-02.md"), []byte("feb"), 0o644)
 
-	// no state file — should infer from existing files
+	// no state file — should infer weekly/monthly from existing files
 	state := loadDistillStateV2(tmp, tcPath)
-
-	daily := state.lastDailyTime()
-	if daily.IsZero() {
-		t.Error("expected non-zero lastDailyTime from high-water inference")
-	}
-	wantDaily := time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC)
-	if !daily.Equal(wantDaily) {
-		t.Errorf("lastDailyTime = %v, want %v", daily, wantDaily)
-	}
 
 	weekly := state.lastWeeklyTime()
 	if weekly.IsZero() {
@@ -834,30 +790,6 @@ func TestLoadState_FallbackToHighWater(t *testing.T) {
 	monthly := state.lastMonthlyTime()
 	if monthly.IsZero() {
 		t.Error("expected non-zero lastMonthlyTime from high-water inference")
-	}
-}
-
-func TestLoadState_MigratesV1(t *testing.T) {
-	tmp := t.TempDir()
-	sageoxDir := filepath.Join(tmp, ".sageox")
-	os.MkdirAll(sageoxDir, 0o755)
-
-	v1State := &distillState{
-		SchemaVersion:    "1",
-		LastDistilled:    "2026-03-10T12:00:00Z",
-		ObservationCount: 10,
-		TeamID:           "team-abc",
-	}
-	saveDistillState(tmp, v1State)
-
-	// v1 migration should NOT also infer from files (v1 data takes precedence)
-	state := loadDistillStateV2(tmp, tmp)
-	if state.TeamID != "team-abc" {
-		t.Errorf("expected team-abc, got %s", state.TeamID)
-	}
-	daily := state.lastDailyTime()
-	if daily.IsZero() {
-		t.Error("v1 LastDistilled should be used as daily fallback")
 	}
 }
 
@@ -902,95 +834,6 @@ func TestParseFactDate(t *testing.T) {
 			}
 		})
 	}
-}
-
-// --- Multi-ledger (per-repo state) tests ---
-
-func TestDistillStateV2_SessionsForRepo(t *testing.T) {
-	t.Parallel()
-	state := &distillStateV2{}
-
-	// first access creates the map
-	m := state.sessionsForRepo("repo-a")
-	require.NotNil(t, m)
-	m["session-1"] = "hash1"
-
-	// same repo returns same map
-	m2 := state.sessionsForRepo("repo-a")
-	assert.Equal(t, "hash1", m2["session-1"])
-
-	// different repo gets independent map
-	m3 := state.sessionsForRepo("repo-b")
-	assert.Empty(t, m3)
-}
-
-func TestDistillStateV2_GitHubFactsTimeForRepo(t *testing.T) {
-	t.Parallel()
-	now := time.Now().UTC()
-	state := &distillStateV2{}
-
-	// no per-repo state, no flat state, no fact files on disk →
-	// falls through to the 7-day default in githubFactsSince
-	tcDir := t.TempDir()
-	since := state.githubFactsTimeForRepo("repo-a", tcDir)
-	expectedDefault := now.AddDate(0, 0, -7)
-	assert.InDelta(t, expectedDefault.Unix(), since.Unix(), 5,
-		"empty state should fall back to ~7 days ago, got %s", since)
-
-	// set per-repo time — should return exactly that
-	state.setGitHubFactsTime("repo-a", now)
-	since = state.githubFactsTimeForRepo("repo-a", tcDir)
-	assert.Equal(t, now.Format(time.RFC3339), since.Format(time.RFC3339))
-
-	// different repo has no per-repo entry → falls back to 7-day default,
-	// NOT to repo-a's timestamp
-	since2 := state.githubFactsTimeForRepo("repo-b", tcDir)
-	assert.InDelta(t, expectedDefault.Unix(), since2.Unix(), 5,
-		"repo-b should get the 7-day default, not repo-a's time; got %s", since2)
-}
-
-func TestDistillStateV2_MigrateToPerRepo(t *testing.T) {
-	t.Parallel()
-
-	state := &distillStateV2{
-		ProcessedSessions: map[string]string{
-			"session-1": "hash-a",
-			"session-2": "hash-b",
-		},
-		LastGitHubFacts: "2026-03-20T10:00:00Z",
-	}
-
-	state.migrateToPerRepo("repo-primary")
-
-	// sessions migrated
-	require.Contains(t, state.RepoSessions, "repo-primary")
-	assert.Equal(t, "hash-a", state.RepoSessions["repo-primary"]["session-1"])
-	assert.Equal(t, "hash-b", state.RepoSessions["repo-primary"]["session-2"])
-
-	// github facts migrated
-	require.Contains(t, state.RepoGitHubFacts, "repo-primary")
-	assert.Equal(t, "2026-03-20T10:00:00Z", state.RepoGitHubFacts["repo-primary"])
-}
-
-func TestDistillStateV2_MigrateToPerRepo_NoOp(t *testing.T) {
-	t.Parallel()
-
-	// already has per-repo state — migration should not overwrite
-	state := &distillStateV2{
-		ProcessedSessions: map[string]string{"old": "data"},
-		RepoSessions: map[string]map[string]string{
-			"repo-a": {"session-x": "hash-x"},
-		},
-		RepoGitHubFacts: map[string]string{
-			"repo-a": "2026-03-25T00:00:00Z",
-		},
-	}
-
-	state.migrateToPerRepo("repo-a")
-
-	// per-repo state should be unchanged
-	assert.Equal(t, "hash-x", state.RepoSessions["repo-a"]["session-x"])
-	assert.Equal(t, "2026-03-25T00:00:00Z", state.RepoGitHubFacts["repo-a"])
 }
 
 func TestResolveDistillRepos_NoEnv(t *testing.T) {

--- a/cmd/ox/distill_write.go
+++ b/cmd/ox/distill_write.go
@@ -179,6 +179,33 @@ func writeMemoryFile(tcPath, relPath, content string) error {
 	return os.WriteFile(fullPath, []byte(content), 0o644)
 }
 
+// removeMemoryFile deletes a file from the team context and commits the removal.
+func removeMemoryFile(tcPath, relPath, commitMsg string) error {
+	fullPath := filepath.Join(tcPath, relPath)
+	if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove file: %w", err)
+	}
+
+	// git add --sparse stages the deletion
+	addCmd := exec.Command("git", "add", "--sparse", relPath)
+	addCmd.Dir = tcPath
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add (removal): %s: %w", string(out), err)
+	}
+
+	commitCmd := exec.Command("git", "commit", "-m", commitMsg, "--allow-empty-message")
+	commitCmd.Dir = tcPath
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 &&
+			strings.Contains(string(out), "nothing to commit") {
+			return nil
+		}
+		return fmt.Errorf("git commit: %s: %w", string(out), err)
+	}
+	return nil
+}
+
 // commitMemoryFile stages and commits a memory file in the team context git repo.
 func commitMemoryFile(tcPath, relPath, commitMsg string) error {
 	// git add --sparse (required for sparse checkout repos)

--- a/internal/agentcli/agentcli.go
+++ b/internal/agentcli/agentcli.go
@@ -27,6 +27,9 @@ type Claude struct {
 	// WorkDir sets the working directory for the claude process.
 	// When set, relative file paths in prompts resolve from this directory.
 	WorkDir string
+	// Model overrides the default model (e.g., "sonnet" or "claude-sonnet-4-6").
+	// Empty string uses the claude CLI default.
+	Model string
 }
 
 func (c *Claude) Name() string { return "claude" }
@@ -43,7 +46,11 @@ func (c *Claude) Run(ctx context.Context, prompt string) (string, error) {
 		defer cancel()
 	}
 
-	cmd := exec.CommandContext(ctx, "claude", "-p", "--output-format", "text", "--tools", "Read")
+	args := []string{"-p", "--output-format", "text", "--tools", "Read"}
+	if c.Model != "" {
+		args = append(args, "--model", c.Model)
+	}
+	cmd := exec.CommandContext(ctx, "claude", args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	if c.WorkDir != "" {
 		cmd.Dir = c.WorkDir

--- a/internal/facts/types.go
+++ b/internal/facts/types.go
@@ -23,6 +23,9 @@ type FileMeta struct {
 	SchemaVersion string `json:"schema_version"`
 	SourceType    string `json:"source_type"`
 	RecordedAt    string `json:"recorded_at"`
+	SourceHash    string `json:"source_hash,omitempty"`
+	QuerySince    string `json:"query_since,omitempty"`
+	QueryUntil    string `json:"query_until,omitempty"`
 }
 
 // Source type constants.


### PR DESCRIPTION
## Summary

- **Stateless extraction**: Sessions and discussions use `source_hash` in fact file `_meta` headers for change detection. GitHub uses `query_since`/`query_until`. No cache file needed for extraction dedup — the output files are self-describing.
- **Stateless daily distill**: Daily summary `.md` files list consumed fact paths in `sources:` YAML frontmatter. Re-runs skip already-distilled facts without needing a state file.
- **Per-item GitHub extraction**: Each PR and issue gets its own LLM call and deterministic fact file (`day-pr-N.jsonl`). Standalone commits batched per day. Eliminates 400-720KB batch prompts that caused 5-minute timeouts.
- **Parallel LLM calls**: `--concurrency N` flag (1-8) via `errgroup.SetLimit`. Git ops serialized via mutex. ~3x wall-clock improvement at concurrency 3.
- **Cache index**: `distill-index.json` mirrors file metadata for fast startup. Rebuilt from files if missing/corrupt. Updated incrementally when new files appear from other machines.
- **State cleanup**: `distillStateV2` reduced from 15 fields to 4 (schema_version, team_id, last_weekly, last_monthly). All extraction and daily tracking removed — handled by file metadata.
- **New flags**: `--model` (override LLM model), `--no-push` (skip remote push for testing), `--concurrency` (parallel LLM calls)

## Motivation

`distill-state-v2.json` was a fragile cache file that caused:
- **Cache loss → full reprocessing**: Fresh clone or cache clear re-extracted everything, creating duplicate summaries
- **Same-day re-runs**: Coarse timestamp cursors couldn't distinguish "already processed today" from "new facts arrived today"
- **Timezone changes**: Re-bucketed facts into different dates, breaking the cursor
- **Batch timeouts**: Per-day GitHub batches grew to 580KB+, exceeding the 5-minute LLM timeout

## Architecture

```
Before: distill-state-v2.json (15 fields)
  ProcessedSessions ──→ session extraction skip
  ProcessedDiscussions ──→ discussion extraction skip
  RepoGitHubFacts ──→ github extraction window
  LastDaily + DistilledFacts ──→ daily distill skip

After: self-describing files
  .session-facts/*.jsonl    _meta.source_hash ──→ skip if hash matches
  .discussion-facts/*.jsonl _meta.source_hash ──→ skip if hash matches
  .github-facts/*.jsonl     _meta.query_until ──→ max = next since
  memory/daily/*.md         sources: frontmatter ──→ skip listed facts
  distill-index.json        performance cache (mirrors file metadata)
```

## Test plan

- [x] Unit tests pass (`go test ./cmd/ox/ -short` — 85s)
- [x] `go vet` clean
- [x] Delete state file + index → rebuild from files → no re-extraction, no duplicate summaries
- [x] Per-item extraction: no single prompt > 200KB, no timeouts on busy days
- [x] `--concurrency 3`: 3 parallel claude processes, ~3x speedup
- [x] Backward compat: old state files with removed fields load without error
- [x] Code reviewed: 2 HIGH issues found and fixed (prompt interval, frontmatter parser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI flags: --model, --no-push, --concurrency, and --all.

* **Improvements**
  * Extraction is now stateless and driven by content hashes to avoid duplicate work.
  * Daily summaries include source attribution and skip already-distilled facts.
  * Added a persistent, rebuildable disk-backed distill index for faster incremental runs and high-water inference.
  * GitHub and session extraction produce deterministic outputs, use bounded concurrency, and write explicit empty-result markers.

* **Tests**
  * Tests updated for new call signatures and JSONL metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->