### PR TITLE
fix(ci): add back goreleaser brews config to auto-update homebrew-tap

### DIFF
--- a/.config/goreleaser.yml
+++ b/.config/goreleaser.yml
@@ -140,5 +140,19 @@ release:
     **Manual Install:**
     Download the appropriate binary for your platform below, extract it, and place it in your PATH.
 
+brews:
+  - name: ox
+    repository:
+      owner: sageox
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://sageox.ai"
+    description: "The hivemind for agentic engineering"
+    license: "Apache-2.0"
+    test: |
+      system "#{bin}/ox", "version"
+    install: |
+      bin.install "ox"
+
 announce:
   skip: true


### PR DESCRIPTION
## Summary

- Adds `brews:` section to `.config/goreleaser.yml` so future releases automatically commit an updated formula to `sageox/homebrew-tap`
- Eliminates manual formula updates after each release

## Setup Required

Add a `HOMEBREW_TAP_GITHUB_TOKEN` secret to `sageox/ox` (repo Settings → Secrets and variables → Actions) with a token that has write access to `sageox/homebrew-tap`.

## How it works

```mermaid
sequenceDiagram
    participant Dev
    participant GH as GitHub Release
    participant GR as GoReleaser
    participant Tap as homebrew-tap

    Dev->>GH: Publish release tag
    GH->>GR: Trigger release workflow
    GR->>GH: Build & upload binaries
    GR->>Tap: Commit updated ox.rb formula
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Homebrew distribution support is now available, enabling users to install and manage the application through the Homebrew package manager.
  * Added automated package verification and testing steps to ensure reliable delivery.
  * Enhanced installation options for users who prefer package manager-based approaches for simplified dependency management and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->