### PR TITLE
feat(distill): sandbox mode for isolated guidance experimentation

### DIFF
--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -611,6 +611,7 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return fmt.Errorf("create sandbox: %w", err)
 		}
+		// print results before cleanup removes the temp dir (LIFO order)
 		defer cleanup()
 		defer printSandboxResults(sb.TC.Path)
 

--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -45,6 +45,9 @@ var weeklyRe = regexp.MustCompile(`^(\d{4})-W(\d{2})`)
 // monthlyRe matches YYYY-MM monthly filenames.
 var monthlyRe = regexp.MustCompile(`^(\d{4}-\d{2})\.md$`)
 
+// sandboxReposKey is a context key for passing pre-resolved repos from sandbox setup.
+type sandboxReposKey struct{}
+
 // distillPlan describes what layers and periods to distill.
 type distillPlan struct {
 	Daily  bool
@@ -349,6 +352,11 @@ var (
 	distillNoPush      bool
 	distillConcurrency int
 	distillAll         bool
+
+	// sandbox mode: run distill in an isolated clone with a local bare remote
+	distillSandboxFlag    bool
+	distillSandboxExtract string
+	distillSandboxDistill string
 )
 
 var distillCmd = &cobra.Command{
@@ -376,6 +384,9 @@ func init() {
 	distillCmd.Flags().BoolVar(&distillNoPush, "no-push", false, "skip pushing team context commits to remote (useful for testing)")
 	distillCmd.Flags().IntVar(&distillConcurrency, "concurrency", 1, "max parallel LLM calls for fact extraction (1-8)")
 	distillCmd.Flags().BoolVar(&distillAll, "all", false, "process all history (default: last 7 days)")
+	distillCmd.Flags().BoolVar(&distillSandboxFlag, "sandbox", false, "run in an isolated clone — commits and pushes go to a local bare repo, not the real remote")
+	distillCmd.Flags().StringVar(&distillSandboxExtract, "sandbox-extract", "", "path to an EXTRACT.md override (implies --sandbox)")
+	distillCmd.Flags().StringVar(&distillSandboxDistill, "sandbox-distill", "", "path to a DISTILL.md override (implies --sandbox)")
 
 	rootCmd.AddCommand(distillCmd)
 }
@@ -584,6 +595,33 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// guidance override flags imply --sandbox
+	if distillSandboxExtract != "" || distillSandboxDistill != "" {
+		distillSandboxFlag = true
+	}
+
+	// sandbox mode: clone repos locally, swap remotes to bare repos
+	if distillSandboxFlag {
+		repos, err := resolveDistillRepos(projectRoot)
+		if err != nil {
+			return fmt.Errorf("resolve distill repos: %w", err)
+		}
+
+		sb, cleanup, err := createDistillSandbox(tc, repos, distillSandboxExtract, distillSandboxDistill)
+		if err != nil {
+			return fmt.Errorf("create sandbox: %w", err)
+		}
+		defer cleanup()
+		defer printSandboxResults(sb.TC.Path)
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Sandbox: %s\n", sb.Root)
+		tc = sb.TC
+		distillNoPush = true // sandbox has no meaningful remote
+		// stash sandbox repos for use below (skip resolveDistillRepos later)
+		cmd.SetContext(context.WithValue(ctx, sandboxReposKey{}, sb.Repos))
+		ctx = cmd.Context()
+	}
+
 	// push team context commits to remote when we're done — even if the
 	// pipeline partially fails, earlier stages may have committed facts or
 	// distilled summaries that should be synced.
@@ -671,10 +709,15 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	// resolve repos for multi-ledger extraction
-	repos, err := resolveDistillRepos(projectRoot)
-	if err != nil {
-		return fmt.Errorf("resolve distill repos: %w", err)
+	// resolve repos for multi-ledger extraction (sandbox may have pre-resolved)
+	var repos []distillRepo
+	if sbRepos, ok := ctx.Value(sandboxReposKey{}).([]distillRepo); ok {
+		repos = sbRepos
+	} else {
+		repos, err = resolveDistillRepos(projectRoot)
+		if err != nil {
+			return fmt.Errorf("resolve distill repos: %w", err)
+		}
 	}
 
 	// (per-repo state migration removed — extraction is now stateless via file metadata)

--- a/cmd/ox/distill_sandbox.go
+++ b/cmd/ox/distill_sandbox.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+)
+
+// distillSandbox holds the isolated environment for a sandbox distill run.
+// All git operations (commit, push) target the sandbox clones, leaving the
+// real team context and ledger repos untouched.
+type distillSandbox struct {
+	// Root is the temp directory containing all sandbox state.
+	Root string
+
+	// TC is the sandboxed team context (clone + local bare remote).
+	TC *config.TeamContext
+
+	// Repos overrides resolveDistillRepos — each ledger is cloned with
+	// its own bare remote so push succeeds without hitting the real remote.
+	Repos []distillRepo
+}
+
+// createDistillSandbox builds an isolated distill environment:
+//
+//  1. git clone --local the real team context to a temp dir
+//  2. git clone --local each ledger to temp dirs
+//  3. Create local bare repos as push targets for each clone
+//  4. Swap remotes so push goes to the bare repos, not the real remotes
+//  5. Optionally override guidance files (EXTRACT.md, DISTILL.md)
+//
+// The caller must call cleanup() when done.
+func createDistillSandbox(
+	realTC *config.TeamContext,
+	realRepos []distillRepo,
+	extractOverride, distillOverride string,
+) (*distillSandbox, func(), error) {
+
+	root, err := os.MkdirTemp("", "ox-distill-sandbox-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create sandbox dir: %w", err)
+	}
+	cleanup := func() { os.RemoveAll(root) }
+
+	// --- sandbox team context ---
+	sandboxTCPath := filepath.Join(root, "team-context")
+	if err := localCloneWithBareRemote(realTC.Path, sandboxTCPath, filepath.Join(root, "remote-tc.git")); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("sandbox team context: %w", err)
+	}
+
+	sandboxTC := &config.TeamContext{
+		TeamID:   realTC.TeamID,
+		TeamName: realTC.TeamName,
+		Path:     sandboxTCPath,
+	}
+
+	// --- apply guidance overrides ---
+	if extractOverride != "" {
+		if err := overrideGuidance(sandboxTCPath, "EXTRACT.md", extractOverride); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("override EXTRACT.md: %w", err)
+		}
+	}
+	if distillOverride != "" {
+		if err := overrideGuidance(sandboxTCPath, "DISTILL.md", distillOverride); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("override DISTILL.md: %w", err)
+		}
+	}
+
+	// --- sandbox ledgers ---
+	sandboxRepos := make([]distillRepo, 0, len(realRepos))
+	for i, repo := range realRepos {
+		if repo.LedgerPath == "" {
+			// no ledger for this repo — keep entry with empty path
+			sandboxRepos = append(sandboxRepos, repo)
+			continue
+		}
+
+		sandboxLedger := filepath.Join(root, fmt.Sprintf("ledger-%d", i))
+		bareRemote := filepath.Join(root, fmt.Sprintf("remote-ledger-%d.git", i))
+		if err := localCloneWithBareRemote(repo.LedgerPath, sandboxLedger, bareRemote); err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("sandbox ledger %s: %w", repo.RepoID, err)
+		}
+
+		sandboxRepos = append(sandboxRepos, distillRepo{
+			ProjectRoot: repo.ProjectRoot,
+			RepoID:      repo.RepoID,
+			LedgerPath:  sandboxLedger,
+			CodeDBDir:   repo.CodeDBDir, // read-only, shared with real repo
+		})
+	}
+
+	sb := &distillSandbox{
+		Root:  root,
+		TC:    sandboxTC,
+		Repos: sandboxRepos,
+	}
+	return sb, cleanup, nil
+}
+
+// localCloneWithBareRemote creates a hard-linked clone of srcRepo and points
+// its origin at a new local bare repo so push works without network access.
+//
+// The source repo may be a partial clone (--filter=blob:none) with sparse
+// checkout. In that case, the git index contains entries for files outside
+// the sparse cone whose blob objects may only exist on the remote (promisor
+// objects). Since the sandbox remote is a local bare repo with no promisor
+// relationship, `git commit` would fail with "invalid object" when building
+// trees that reference these missing blobs.
+//
+// Fix: after checkout, remove index entries for files not in the working
+// tree (i.e., outside the sparse cone). This only affects the sandbox clone.
+func localCloneWithBareRemote(srcRepo, cloneDir, bareDir string) error {
+	// step 1: local clone without checkout (hardlinks pack files, near-instant)
+	cmd := exec.Command("git", "clone", "--local", "--no-checkout", srcRepo, cloneDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone --local: %s: %w", string(out), err)
+	}
+
+	// step 2: immediately sever the link to the source repo so no
+	// subsequent git operation can accidentally reach it.
+	cmd = exec.Command("git", "-C", cloneDir, "remote", "remove", "origin")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("remove origin: %s: %w", string(out), err)
+	}
+
+	// step 3: copy sparse-checkout config if the source uses it
+	srcSparse := filepath.Join(srcRepo, ".git", "info", "sparse-checkout")
+	if data, err := os.ReadFile(srcSparse); err == nil {
+		destInfo := filepath.Join(cloneDir, ".git", "info")
+		if err := os.MkdirAll(destInfo, 0o755); err != nil {
+			return fmt.Errorf("create .git/info: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(destInfo, "sparse-checkout"), data, 0o644); err != nil {
+			return fmt.Errorf("write sparse-checkout: %w", err)
+		}
+		cfgCmd := exec.Command("git", "-C", cloneDir, "config", "core.sparseCheckout", "true")
+		if out, err := cfgCmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("enable sparse checkout: %s: %w", string(out), err)
+		}
+	}
+
+	// step 3: checkout (respects sparse-checkout rules)
+	cmd = exec.Command("git", "-C", cloneDir, "checkout")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// checkout may warn about missing promisor objects but still succeed
+		slog.Debug("checkout warnings", "output", string(out))
+	}
+
+	// step 4: remove index entries for files not in the working tree.
+	//
+	// In a partial clone with sparse checkout, the index has entries for ALL
+	// tracked files, but blobs outside the sparse cone may only exist on the
+	// remote (promisor packs). The sandbox bare remote has no promisor
+	// relationship, so git commit fails with "invalid object" for these
+	// entries. Removing them from the index is safe because the files aren't
+	// in the working tree anyway.
+	rmCmd := exec.Command("git", "-C", cloneDir, "ls-files", "--sparse", "--full-name", "-z")
+	lsOut, err := rmCmd.Output()
+	if err == nil {
+		var toRemove []string
+		for _, entry := range strings.Split(string(lsOut), "\x00") {
+			if entry == "" {
+				continue
+			}
+			if _, statErr := os.Lstat(filepath.Join(cloneDir, entry)); os.IsNotExist(statErr) {
+				toRemove = append(toRemove, entry)
+			}
+		}
+		if len(toRemove) > 0 {
+			args := append([]string{"-C", cloneDir, "rm", "--cached", "--sparse", "--quiet", "--"}, toRemove...)
+			rmCached := exec.Command("git", args...)
+			if out, err := rmCached.CombinedOutput(); err != nil {
+				slog.Debug("failed to remove non-sparse index entries", "error", string(out))
+			}
+		}
+	}
+
+	// step 5: create bare repo as the sandbox push target.
+	initCmd := exec.Command("git", "init", "--bare", bareDir)
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git init --bare: %s: %w", string(out), err)
+	}
+
+	// step 6: add the bare repo as the new origin
+	cmd = exec.Command("git", "-C", cloneDir, "remote", "add", "origin", bareDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git remote add origin: %s: %w", string(out), err)
+	}
+
+	// step 7: commit the index cleanup and tag the pre-distill state.
+	// The commit records the clean index so subsequent distill commits
+	// don't reference missing promisor objects. The tag marks the baseline
+	// for printSandboxResults to diff against.
+	commitCmd := exec.Command("git", "-C", cloneDir, "commit", "--allow-empty", "-m", "sandbox: clean index for distill")
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		slog.Debug("sandbox index commit", "output", string(out))
+	}
+	tagCmd := exec.Command("git", "-C", cloneDir, "tag", "sandbox-baseline")
+	if out, err := tagCmd.CombinedOutput(); err != nil {
+		slog.Debug("sandbox baseline tag", "output", string(out))
+	}
+
+	// set git identity and push defaults for commits
+	for _, kv := range [][2]string{
+		{"user.name", "ox-sandbox"},
+		{"user.email", "sandbox@ox.local"},
+		{"push.autoSetupRemote", "true"},
+	} {
+		cmd = exec.Command("git", "-C", cloneDir, "config", kv[0], kv[1])
+		if out, err := cmd.CombinedOutput(); err != nil {
+			slog.Debug("git config in sandbox", "key", kv[0], "error", string(out), "err", err)
+		}
+	}
+
+	return nil
+}
+
+// overrideGuidance replaces a guidance file in the sandbox team context.
+// sourcePath is the path to the override file on disk.
+func overrideGuidance(tcPath, filename, sourcePath string) error {
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return fmt.Errorf("read override file %s: %w", sourcePath, err)
+	}
+
+	guidanceDir := filepath.Join(tcPath, "memory", "guidance")
+	if err := os.MkdirAll(guidanceDir, 0o755); err != nil {
+		return fmt.Errorf("create guidance dir: %w", err)
+	}
+
+	dest := filepath.Join(guidanceDir, filename)
+	if err := os.WriteFile(dest, content, 0o644); err != nil {
+		return fmt.Errorf("write guidance file: %w", err)
+	}
+
+	return nil
+}
+
+// printSandboxResults shows a colored diff of everything the sandbox
+// distill run produced. Compares HEAD against the sandbox-baseline tag
+// (created before distill ran).
+func printSandboxResults(sandboxTCPath string) {
+	base := "sandbox-baseline"
+
+	// stat summary first
+	statCmd := exec.Command("git", "-C", sandboxTCPath, "diff", "--stat", base+"..HEAD")
+	statOut, err := statCmd.CombinedOutput()
+	if err != nil || strings.TrimSpace(string(statOut)) == "" {
+		fmt.Println("\nSandbox: no new files generated.")
+		return
+	}
+
+	fmt.Println("\n── Sandbox results ──")
+	fmt.Println(strings.TrimSpace(string(statOut)))
+
+	// full colored diff — git produces ANSI colors with --color=always
+	diffCmd := exec.Command("git", "-C", sandboxTCPath,
+		"diff", "--color=always", base+"..HEAD",
+		"--", "memory/daily", "memory/weekly", "memory/monthly",
+		"memory/.discussion-facts", "memory/.github-facts", "memory/.session-facts",
+	)
+	diffOut, err := diffCmd.CombinedOutput()
+	if err == nil && len(diffOut) > 0 {
+		fmt.Println()
+		fmt.Print(string(diffOut))
+	}
+
+	fmt.Printf("\nSandbox directory: %s\n", sandboxTCPath)
+}

--- a/cmd/ox/distill_sandbox.go
+++ b/cmd/ox/distill_sandbox.go
@@ -201,29 +201,33 @@ func localCloneWithBareRemote(ctx context.Context, srcRepo, cloneDir, bareDir st
 		return fmt.Errorf("git remote add origin: %s: %w", string(out), err)
 	}
 
-	// step 8: commit the index cleanup and tag the pre-distill state.
-	// The commit records the clean index so subsequent distill commits
-	// don't reference missing promisor objects. The tag marks the baseline
-	// for printSandboxResults to diff against.
-	commitCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "commit", "--allow-empty", "-m", "sandbox: clean index for distill")
-	if out, err := commitCmd.CombinedOutput(); err != nil {
-		slog.Debug("sandbox index commit", "output", string(out))
-	}
-	tagCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "tag", "sandbox-baseline")
-	if out, err := tagCmd.CombinedOutput(); err != nil {
-		slog.Debug("sandbox baseline tag", "output", string(out))
-	}
-
-	// set git identity and push defaults for commits
+	// set git identity before committing
 	for _, kv := range [][2]string{
 		{"user.name", "ox-sandbox"},
 		{"user.email", "sandbox@ox.local"},
-		{"push.autoSetupRemote", "true"},
 	} {
 		cmd = exec.CommandContext(ctx, "git", "-C", cloneDir, "config", kv[0], kv[1])
 		if out, err := cmd.CombinedOutput(); err != nil {
 			slog.Debug("git config in sandbox", "key", kv[0], "error", string(out), "err", err)
 		}
+	}
+
+	// step 8: commit the index cleanup, push to bare, and tag the baseline.
+	// The commit records the clean index so subsequent distill commits
+	// don't reference missing promisor objects. The push establishes
+	// tracking so subsequent pushes (from distill) work with plain `git push`.
+	// The tag marks the baseline for printSandboxResults to diff against.
+	commitCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "commit", "--allow-empty", "-m", "sandbox: clean index for distill")
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		slog.Debug("sandbox index commit", "output", string(out))
+	}
+	pushCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "push", "--set-upstream", "origin", "HEAD")
+	if out, err := pushCmd.CombinedOutput(); err != nil {
+		slog.Debug("sandbox initial push", "output", string(out))
+	}
+	tagCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "tag", "sandbox-baseline")
+	if out, err := tagCmd.CombinedOutput(); err != nil {
+		slog.Debug("sandbox baseline tag", "output", string(out))
 	}
 
 	return nil

--- a/cmd/ox/distill_sandbox.go
+++ b/cmd/ox/distill_sandbox.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/sageox/ox/internal/config"
 )
+
 
 // distillSandbox holds the isolated environment for a sandbox distill run.
 // All git operations (commit, push) target the sandbox clones, leaving the
@@ -40,6 +43,8 @@ func createDistillSandbox(
 	realRepos []distillRepo,
 	extractOverride, distillOverride string,
 ) (*distillSandbox, func(), error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	root, err := os.MkdirTemp("", "ox-distill-sandbox-*")
 	if err != nil {
@@ -49,7 +54,7 @@ func createDistillSandbox(
 
 	// --- sandbox team context ---
 	sandboxTCPath := filepath.Join(root, "team-context")
-	if err := localCloneWithBareRemote(realTC.Path, sandboxTCPath, filepath.Join(root, "remote-tc.git")); err != nil {
+	if err := localCloneWithBareRemote(ctx, realTC.Path, sandboxTCPath, filepath.Join(root, "remote-tc.git")); err != nil {
 		cleanup()
 		return nil, nil, fmt.Errorf("sandbox team context: %w", err)
 	}
@@ -85,7 +90,7 @@ func createDistillSandbox(
 
 		sandboxLedger := filepath.Join(root, fmt.Sprintf("ledger-%d", i))
 		bareRemote := filepath.Join(root, fmt.Sprintf("remote-ledger-%d.git", i))
-		if err := localCloneWithBareRemote(repo.LedgerPath, sandboxLedger, bareRemote); err != nil {
+		if err := localCloneWithBareRemote(ctx, repo.LedgerPath, sandboxLedger, bareRemote); err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("sandbox ledger %s: %w", repo.RepoID, err)
 		}
@@ -118,21 +123,21 @@ func createDistillSandbox(
 //
 // Fix: after checkout, remove index entries for files not in the working
 // tree (i.e., outside the sparse cone). This only affects the sandbox clone.
-func localCloneWithBareRemote(srcRepo, cloneDir, bareDir string) error {
+func localCloneWithBareRemote(ctx context.Context, srcRepo, cloneDir, bareDir string) error {
 	// step 1: local clone without checkout (hardlinks pack files, near-instant)
-	cmd := exec.Command("git", "clone", "--local", "--no-checkout", srcRepo, cloneDir)
+	cmd := exec.CommandContext(ctx, "git", "clone", "--local", "--no-checkout", srcRepo, cloneDir)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git clone --local: %s: %w", string(out), err)
 	}
 
 	// step 2: immediately sever the link to the source repo so no
 	// subsequent git operation can accidentally reach it.
-	cmd = exec.Command("git", "-C", cloneDir, "remote", "remove", "origin")
+	cmd = exec.CommandContext(ctx, "git", "-C", cloneDir, "remote", "remove", "origin")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("remove origin: %s: %w", string(out), err)
 	}
 
-	// step 3: copy sparse-checkout config if the source uses it
+	// step 3: copy sparse-checkout config from source if present
 	srcSparse := filepath.Join(srcRepo, ".git", "info", "sparse-checkout")
 	if data, err := os.ReadFile(srcSparse); err == nil {
 		destInfo := filepath.Join(cloneDir, ".git", "info")
@@ -142,20 +147,20 @@ func localCloneWithBareRemote(srcRepo, cloneDir, bareDir string) error {
 		if err := os.WriteFile(filepath.Join(destInfo, "sparse-checkout"), data, 0o644); err != nil {
 			return fmt.Errorf("write sparse-checkout: %w", err)
 		}
-		cfgCmd := exec.Command("git", "-C", cloneDir, "config", "core.sparseCheckout", "true")
+		cfgCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "config", "core.sparseCheckout", "true")
 		if out, err := cfgCmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("enable sparse checkout: %s: %w", string(out), err)
 		}
 	}
 
-	// step 3: checkout (respects sparse-checkout rules)
-	cmd = exec.Command("git", "-C", cloneDir, "checkout")
+	// step 4: checkout (respects sparse-checkout rules)
+	cmd = exec.CommandContext(ctx, "git", "-C", cloneDir, "checkout")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// checkout may warn about missing promisor objects but still succeed
 		slog.Debug("checkout warnings", "output", string(out))
 	}
 
-	// step 4: remove index entries for files not in the working tree.
+	// step 5: remove index entries for files not in the working tree.
 	//
 	// In a partial clone with sparse checkout, the index has entries for ALL
 	// tracked files, but blobs outside the sparse cone may only exist on the
@@ -163,7 +168,7 @@ func localCloneWithBareRemote(srcRepo, cloneDir, bareDir string) error {
 	// relationship, so git commit fails with "invalid object" for these
 	// entries. Removing them from the index is safe because the files aren't
 	// in the working tree anyway.
-	rmCmd := exec.Command("git", "-C", cloneDir, "ls-files", "--sparse", "--full-name", "-z")
+	rmCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "ls-files", "--sparse", "--full-name", "-z")
 	lsOut, err := rmCmd.Output()
 	if err == nil {
 		var toRemove []string
@@ -177,34 +182,34 @@ func localCloneWithBareRemote(srcRepo, cloneDir, bareDir string) error {
 		}
 		if len(toRemove) > 0 {
 			args := append([]string{"-C", cloneDir, "rm", "--cached", "--sparse", "--quiet", "--"}, toRemove...)
-			rmCached := exec.Command("git", args...)
+			rmCached := exec.CommandContext(ctx, "git", args...)
 			if out, err := rmCached.CombinedOutput(); err != nil {
-				slog.Debug("failed to remove non-sparse index entries", "error", string(out))
+				slog.Warn("failed to remove non-sparse index entries — git commit may fail with 'invalid object'", "error", string(out))
 			}
 		}
 	}
 
-	// step 5: create bare repo as the sandbox push target.
-	initCmd := exec.Command("git", "init", "--bare", bareDir)
+	// step 6: create bare repo as the sandbox push target.
+	initCmd := exec.CommandContext(ctx, "git", "init", "--bare", bareDir)
 	if out, err := initCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git init --bare: %s: %w", string(out), err)
 	}
 
-	// step 6: add the bare repo as the new origin
-	cmd = exec.Command("git", "-C", cloneDir, "remote", "add", "origin", bareDir)
+	// step 7: add the bare repo as the new origin
+	cmd = exec.CommandContext(ctx, "git", "-C", cloneDir, "remote", "add", "origin", bareDir)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git remote add origin: %s: %w", string(out), err)
 	}
 
-	// step 7: commit the index cleanup and tag the pre-distill state.
+	// step 8: commit the index cleanup and tag the pre-distill state.
 	// The commit records the clean index so subsequent distill commits
 	// don't reference missing promisor objects. The tag marks the baseline
 	// for printSandboxResults to diff against.
-	commitCmd := exec.Command("git", "-C", cloneDir, "commit", "--allow-empty", "-m", "sandbox: clean index for distill")
+	commitCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "commit", "--allow-empty", "-m", "sandbox: clean index for distill")
 	if out, err := commitCmd.CombinedOutput(); err != nil {
 		slog.Debug("sandbox index commit", "output", string(out))
 	}
-	tagCmd := exec.Command("git", "-C", cloneDir, "tag", "sandbox-baseline")
+	tagCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "tag", "sandbox-baseline")
 	if out, err := tagCmd.CombinedOutput(); err != nil {
 		slog.Debug("sandbox baseline tag", "output", string(out))
 	}
@@ -215,7 +220,7 @@ func localCloneWithBareRemote(srcRepo, cloneDir, bareDir string) error {
 		{"user.email", "sandbox@ox.local"},
 		{"push.autoSetupRemote", "true"},
 	} {
-		cmd = exec.Command("git", "-C", cloneDir, "config", kv[0], kv[1])
+		cmd = exec.CommandContext(ctx, "git", "-C", cloneDir, "config", kv[0], kv[1])
 		if out, err := cmd.CombinedOutput(); err != nil {
 			slog.Debug("git config in sandbox", "key", kv[0], "error", string(out), "err", err)
 		}

--- a/cmd/ox/distill_sandbox.go
+++ b/cmd/ox/distill_sandbox.go
@@ -190,7 +190,17 @@ func localCloneWithBareRemote(ctx context.Context, srcRepo, cloneDir, bareDir st
 	}
 
 	// step 6: create bare repo as the sandbox push target.
-	initCmd := exec.CommandContext(ctx, "git", "init", "--bare", bareDir)
+	// Detect the clone's current branch so we can set HEAD in the bare repo
+	// to match — otherwise git init --bare defaults HEAD to "master" which
+	// may not match the clone's branch (e.g., "main").
+	branchCmd := exec.CommandContext(ctx, "git", "-C", cloneDir, "rev-parse", "--abbrev-ref", "HEAD")
+	branchOut, _ := branchCmd.Output()
+	branch := strings.TrimSpace(string(branchOut))
+	if branch == "" || branch == "HEAD" {
+		branch = "main"
+	}
+
+	initCmd := exec.CommandContext(ctx, "git", "init", "--bare", "-b", branch, bareDir)
 	if out, err := initCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git init --bare: %s: %w", string(out), err)
 	}

--- a/cmd/ox/distill_sandbox_test.go
+++ b/cmd/ox/distill_sandbox_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,7 +33,7 @@ func TestLocalCloneWithBareRemote(t *testing.T) {
 	cloneDir := filepath.Join(t.TempDir(), "clone")
 	bareDir := filepath.Join(t.TempDir(), "remote.git")
 
-	err := localCloneWithBareRemote(srcDir, cloneDir, bareDir)
+	err := localCloneWithBareRemote(context.Background(), srcDir, cloneDir, bareDir)
 	require.NoError(t, err)
 
 	// clone should have all files

--- a/cmd/ox/distill_sandbox_test.go
+++ b/cmd/ox/distill_sandbox_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- A. Local clone with bare remote ---
+
+// TestLocalCloneWithBareRemote verifies the core sandbox primitive:
+// clone a repo locally, create a bare remote, push to it.
+// Failure prevented: sandbox setup fails silently, leaving distill
+// writing to the real team context.
+func TestLocalCloneWithBareRemote(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+
+	// create a source repo with some content
+	srcDir := t.TempDir()
+	gitInit(t, srcDir)
+	writeAndCommit(t, srcDir, "memory/daily/2026-03-10.md", "observation one\n", "add daily")
+	writeAndCommit(t, srcDir, "memory/guidance/EXTRACT.md", "extract guidance\n", "add extract")
+	writeAndCommit(t, srcDir, "SOUL.md", "# Soul\n", "add soul")
+
+	cloneDir := filepath.Join(t.TempDir(), "clone")
+	bareDir := filepath.Join(t.TempDir(), "remote.git")
+
+	err := localCloneWithBareRemote(srcDir, cloneDir, bareDir)
+	require.NoError(t, err)
+
+	// clone should have all files
+	require.FileExists(t, filepath.Join(cloneDir, "memory", "daily", "2026-03-10.md"))
+	require.FileExists(t, filepath.Join(cloneDir, "memory", "guidance", "EXTRACT.md"))
+	require.FileExists(t, filepath.Join(cloneDir, "SOUL.md"))
+
+	// remote should point to bare repo, not source
+	cmd := exec.Command("git", "-C", cloneDir, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "remote.git")
+
+	// push should work (to bare)
+	writeAndCommit(t, cloneDir, "memory/daily/2026-03-11.md", "observation two\n", "add day 2")
+	cmd = exec.Command("git", "-C", cloneDir, "push")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "push to bare remote should succeed: %s", string(out))
+
+	// verify bare received the push (clone from bare and check)
+	verifyDir := filepath.Join(t.TempDir(), "verify")
+	cmd = exec.Command("git", "clone", bareDir, verifyDir)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "clone from bare: %s", string(out))
+	require.FileExists(t, filepath.Join(verifyDir, "memory", "daily", "2026-03-11.md"))
+}
+
+// --- B. Guidance override ---
+
+// TestOverrideGuidance verifies that sandbox guidance overrides replace
+// the original files in the sandbox clone.
+// Failure prevented: guidance override silently ignored, causing sandbox
+// to use the original guidance and produce identical output.
+func TestOverrideGuidance(t *testing.T) {
+	tcDir := t.TempDir()
+	guidanceDir := filepath.Join(tcDir, "memory", "guidance")
+	require.NoError(t, os.MkdirAll(guidanceDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(guidanceDir, "EXTRACT.md"), []byte("original"), 0o644))
+
+	// create override file
+	overrideFile := filepath.Join(t.TempDir(), "my-extract.md")
+	require.NoError(t, os.WriteFile(overrideFile, []byte("experimental v2"), 0o644))
+
+	err := overrideGuidance(tcDir, "EXTRACT.md", overrideFile)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(guidanceDir, "EXTRACT.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "experimental v2", string(content))
+}
+
+// --- C. Full sandbox creation ---
+
+// TestCreateDistillSandbox verifies the complete sandbox lifecycle:
+// team context clone, ledger clone, guidance overrides, push isolation.
+// Failure prevented: sandbox leaks writes to real repos.
+func TestCreateDistillSandbox(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+
+	// create fake "real" team context repo
+	realTCDir := t.TempDir()
+	gitInit(t, realTCDir)
+	writeAndCommit(t, realTCDir, "SOUL.md", "# Real Soul\n", "init")
+	writeAndCommit(t, realTCDir, "memory/guidance/EXTRACT.md", "real extract\n", "guidance")
+	writeAndCommit(t, realTCDir, "memory/guidance/DISTILL.md", "real distill\n", "guidance")
+	writeAndCommit(t, realTCDir, "memory/.discussion-facts/d1.jsonl", `{"fact":"one"}`+"\n", "fact")
+
+	// create fake "real" ledger repo
+	realLedgerDir := t.TempDir()
+	gitInit(t, realLedgerDir)
+	writeAndCommit(t, realLedgerDir, "sessions/s1/summary.json", `{"title":"test"}`, "session")
+
+	// create override files
+	extractOverride := filepath.Join(t.TempDir(), "extract-v2.md")
+	require.NoError(t, os.WriteFile(extractOverride, []byte("experimental extract v2"), 0o644))
+
+	realTC := &config.TeamContext{TeamID: "team_test", TeamName: "Test Team", Path: realTCDir}
+	realRepos := []distillRepo{{
+		ProjectRoot: "/fake/project",
+		RepoID:      "repo_123",
+		LedgerPath:  realLedgerDir,
+		CodeDBDir:   "/fake/codedb",
+	}}
+
+	sb, cleanup, err := createDistillSandbox(realTC, realRepos, extractOverride, "")
+	require.NoError(t, err)
+	defer cleanup()
+
+	// sandbox TC should exist with overridden guidance
+	require.FileExists(t, filepath.Join(sb.TC.Path, "SOUL.md"))
+
+	extractContent, err := os.ReadFile(filepath.Join(sb.TC.Path, "memory", "guidance", "EXTRACT.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "experimental extract v2", string(extractContent))
+
+	// original DISTILL.md should be preserved (no override)
+	distillContent, err := os.ReadFile(filepath.Join(sb.TC.Path, "memory", "guidance", "DISTILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "real distill\n", string(distillContent))
+
+	// sandbox TC remote should NOT point to the real repo
+	cmd := exec.Command("git", "-C", sb.TC.Path, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), realTCDir, "sandbox must not point to real TC")
+
+	// sandbox ledger should exist
+	require.Len(t, sb.Repos, 1)
+	require.FileExists(t, filepath.Join(sb.Repos[0].LedgerPath, "sessions", "s1", "summary.json"))
+
+	// CodeDB should be shared (read-only), not cloned
+	assert.Equal(t, "/fake/codedb", sb.Repos[0].CodeDBDir)
+
+	// push from sandbox TC should work (to bare remote, not real)
+	writeAndCommit(t, sb.TC.Path, "memory/daily/sandbox-test.md", "sandbox output\n", "sandbox distill")
+	cmd = exec.Command("git", "-C", sb.TC.Path, "push")
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "sandbox push should succeed: %s", string(out))
+
+	// real TC should NOT have the sandbox file
+	_, err = os.Stat(filepath.Join(realTCDir, "memory", "daily", "sandbox-test.md"))
+	assert.True(t, os.IsNotExist(err), "real TC must not have sandbox output")
+}
+
+// --- helpers ---
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.name", "test"},
+		{"config", "user.email", "test@test.local"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, string(out))
+	}
+}
+
+func writeAndCommit(t *testing.T, repoDir, relPath, content, msg string) {
+	t.Helper()
+	absPath := filepath.Join(repoDir, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(absPath), 0o755))
+	require.NoError(t, os.WriteFile(absPath, []byte(content), 0o644))
+
+	cmd := exec.Command("git", "-C", repoDir, "add", relPath)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git add: %s", string(out))
+
+	cmd = exec.Command("git", "-C", repoDir, "commit", "-m", msg)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "git commit: %s", string(out))
+}

--- a/cmd/ox/distill_sandbox_test.go
+++ b/cmd/ox/distill_sandbox_test.go
@@ -47,9 +47,9 @@ func TestLocalCloneWithBareRemote(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "remote.git")
 
-	// push should work (to bare)
+	// push should work (to bare) — use explicit refspec for portability
 	writeAndCommit(t, cloneDir, "memory/daily/2026-03-11.md", "observation two\n", "add day 2")
-	cmd = exec.Command("git", "-C", cloneDir, "push")
+	cmd = exec.Command("git", "-C", cloneDir, "push", "origin", "HEAD")
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, "push to bare remote should succeed: %s", string(out))
 

--- a/docs/ai/specs/digital-twin-testing.md
+++ b/docs/ai/specs/digital-twin-testing.md
@@ -1,0 +1,238 @@
+---
+audience: ai
+ai_editing: allowed
+refreshable: true
+---
+
+# Digital Twin Testing Architecture
+
+Two digital twin systems provide realistic test environments without touching production remotes.
+
+## Gitea Twin (Daemon Integration)
+
+**Location:** `internal/daemon/twin_*.go` (18 files, ~5,100 lines)
+**Build tag:** `slow` | **Requires:** Docker
+
+A disposable Gitea 1.22 container emulates the real git+LFS remote. Tests exercise actual git protocol — clone, push, pull, rebase, LFS batch API — against a real server, not mocks.
+
+### Architecture
+
+```
+┌─────────────────────────────────┐
+│  Gitea Container (Docker)       │
+│  localhost:13719 (fixed port)   │
+│  git HTTP + LFS batch API       │
+│  Admin: testadmin/testpass123   │
+└──────────┬──────────────────────┘
+           │ real git protocol
+┌──────────▼──────────────────────┐
+│  giteaFixture (twin_gitea_test) │
+│  createRepo() → isolated repo  │
+│  cloneRepo()  → git clone      │
+│  pushFromTempClone() → remote Δ │
+│  lfsClient()  → LFS batch API  │
+└──────────┬──────────────────────┘
+           │
+┌──────────▼──────────────────────┐
+│  Production Code Under Test     │
+│  TwoPhaseClone, PushWithRetry,  │
+│  runBlueGreenGC, pullManagedRepo│
+└─────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+- **Shared singleton** (`sync.Once`): One container per test run. Non-twin slow tests don't pay startup cost.
+- **Per-test repo isolation**: `createRepo(t, "unique-name")` — tests share the server, never data.
+- **Fixed port 13719**: Gitea LFS batch responses embed `ROOT_URL` in action hrefs. Random ports break LFS URLs.
+- **Ryuk cleanup**: testcontainers' sidecar auto-removes the container when the test process exits.
+
+### What It Tests
+
+| Domain | Files | Scenarios |
+|--------|-------|-----------|
+| Clone | `twin_clone_test.go` | Sparse checkout, manifest parsing, unshallow |
+| Sync | `twin_sync_test.go` | Pull after concurrent push, rebase, autostash |
+| Push | `twin_push_test.go` | Concurrent pushers, auto-resolve, conflicts |
+| Team context | `twin_teamctx_push_test.go` | Push conflicts, autostash, ref checks |
+| LFS | `twin_lfs_test.go`, `twin_lfs_git_test.go` | Batch API round-trip, pointer files |
+| GC | `twin_gc_test.go`, `twin_gc_teamctx_test.go` | Blue-green reclone, dirty state, unpushed commits |
+| Credentials | `twin_cred_test.go` | Auth, private repos, token handling |
+| Sessions | `twin_session_finalize_test.go` | Session finalization workflows |
+| Adversarial | `twin_adversarial_*.go` (4 files) | Symlink safety, races, state edge cases |
+
+### Helpers
+
+```go
+pushMultipleFiles(t, cloneURL, map[string]string{...})  // seed repo structure
+twinCommitFile(t, repoDir, relPath, content, msg)        // write + add + commit
+gitConfig(t, dir)                                         // set test user identity
+isolateCredentials(t)                                     // prevent leaking real creds
+setupProjectWithConfig(t, "")                             // create .sageox/ project
+newTestScheduler(projectDir)                              // daemon scheduler for GC tests
+```
+
+### Running
+
+```bash
+go test -tags=slow ./internal/daemon/ -run ^TestTwin    # all twin tests
+go test -tags=slow ./internal/daemon/ -run TestGC_Team  # specific domain
+OX_SKIP_DOCKER=1 go test -tags=slow ./internal/daemon/  # skip if no Docker
+```
+
+---
+
+## Ledger Twin (Glance / Activity Analysis)
+
+**Location:** `tests/ledger_twin/` (5 files, ~2,500 lines)
+**Build tag:** `ledger_twin`
+
+Generates a synthetic ledger with realistic sessions, murmurs, and carts for testing the glance (activity analysis) pipeline — conflict detection, pattern analysis, velocity tracking.
+
+### Architecture
+
+```
+TwinManifest (scenarios.go)
+  ├── 6 developers (alice, bob, carol, dave, eve, frank)
+  ├── 60+ SessionSpecs → sessions/{timestamp}-{user}-{id}/
+  ├── 100+ MurmurSpecs → data/murmurs/{date}/{hour}/{id}.json
+  ├── 50+ CartSpecs    → carts/{id}.json
+  └── 9 Windows (time ranges with statistical assertions)
+
+GenerateTwinLedger(tmpDir, manifest) → writes to disk
+
+Tests call:
+  glance.HarvestMurmurs() / HarvestSessions()
+  glance.DetectConflicts() / DetectPatterns()
+  → assert against Window expectations
+```
+
+### Key Design Decisions
+
+- **No Docker**: Pure filesystem — generates files to a tmpdir. Fast, no dependencies.
+- **Deterministic scenarios**: Each Window defines expected conflicts, authors, pairs. Tests are assertions, not explorations.
+- **Realistic paths**: Each developer has different worktree prefixes (macOS/Linux). Tests path normalization.
+- **`PRESERVE_TWIN=1`**: Env var keeps the generated ledger on disk for manual inspection.
+
+### What It Tests
+
+| Domain | Scenarios |
+|--------|-----------|
+| Hot zone detection | 3-way file overlap between alice/bob/dave |
+| Parallel streams | Zero collisions with isolated work (negative case) |
+| Pair convergence | Exactly N conflicts matching expected author pairs |
+| Escalation | Conflict density increasing over 3 consecutive days |
+| Cluster bridge | Carol bridging two otherwise-disjoint team clusters |
+| Hot file | Single file touched by 3+ authors |
+| Session harvest | Files extracted from raw.jsonl tool calls |
+| Cart analysis | Cart lifecycle across time windows |
+
+### Running
+
+```bash
+go test -tags=ledger_twin ./tests/ledger_twin/...                    # all
+go test -tags=ledger_twin -run TestPreCrime ./tests/ledger_twin/...  # specific
+PRESERVE_TWIN=1 go test -tags=ledger_twin -v ./tests/ledger_twin/   # inspect output
+```
+
+---
+
+## Relationship Between the Two
+
+| | Gitea Twin | Ledger Twin |
+|---|---|---|
+| **Tests** | Git transport (daemon) | Data analysis (glance) |
+| **Remote** | Real Gitea container | None (filesystem only) |
+| **Data** | Team context structure, LFS blobs | Sessions, murmurs, carts |
+| **Speed** | ~10s startup + tests | <1s |
+| **Requires** | Docker | Nothing |
+
+They are complementary: the Gitea twin proves the daemon can **move** data safely; the ledger twin proves the analysis pipeline can **interpret** data correctly.
+
+---
+
+## Extending for New Test Domains
+
+### Pattern: Seeding a Team Context via Gitea Twin
+
+The Gitea twin already supports team context structure. To test features that read/write team context content (e.g., distill pipeline, memory operations):
+
+```go
+func TestMyFeature(t *testing.T) {
+    g := getSharedGitea(t)
+    cloneURL := g.createRepo(t, "twin-my-feature")
+
+    // Seed with team context structure
+    pushMultipleFiles(t, cloneURL, map[string]string{
+        ".sageox/config.json":            `{"version":1}`,
+        "SOUL.md":                        "# Soul\n...",
+        "memory/guidance/EXTRACT.md":     extractGuidance,
+        "memory/guidance/DISTILL.md":     distillGuidance,
+        "memory/.discussion-facts/d1.jsonl": knownFacts,
+        "memory/daily/2026-03-10-abc.md": existingSummary,
+    })
+
+    // Clone locally — this path acts as tc.Path
+    tcDir := filepath.Join(t.TempDir(), "teamctx")
+    g.cloneRepo(t, cloneURL, tcDir)
+
+    // Exercise your feature against tcDir
+    // Push results back to verify they survive round-trip
+}
+```
+
+### Pattern: Combining Both Twins
+
+For features that span ledger + team context (e.g., session fact extraction feeds into distill):
+
+1. Use ledger twin to generate sessions with known summaries
+2. Use Gitea twin for the team context repo
+3. Run the pipeline that reads sessions → writes facts → synthesizes memory
+4. Assert on the output in the team context repo
+
+---
+
+## Distill Sandbox (`--sandbox`)
+
+**Location:** `cmd/ox/distill_sandbox.go`
+
+The distill sandbox extends the digital twin concept to the CLI itself. It creates an isolated copy of the real team context and ledger repos using `git clone --local` (hard-linked objects, near-instant), then swaps remotes to local bare repos so push succeeds without network access.
+
+### How It Works
+
+```
+Real team context             Bare repo (tmpdir, disposable)
+  ~/.local/share/sageox/        /tmp/ox-distill-sandbox-xxx/remote-tc.git
+  .../team-contexts/team_xyz      (bare, accepts push)
+         │                                ▲
+         │ git clone --local              │ remote set-url origin
+         ▼                                │
+  /tmp/ox-distill-sandbox-xxx/  ──────────┘
+    team-context/
+    ledger-0/          (same pattern: local clone + bare remote)
+    remote-ledger-0.git/
+```
+
+### Usage
+
+```bash
+# Sandbox with real data — full pipeline, push goes to local bare repo
+ox distill --sandbox
+
+# Override guidance files for experimentation
+ox distill --sandbox --sandbox-extract=./my-EXTRACT-v2.md
+
+# Override both guidance files
+ox distill --sandbox --sandbox-extract=./EXTRACT.md --sandbox-distill=./DISTILL.md
+
+# Guidance overrides imply --sandbox
+ox distill --sandbox-extract=./my-EXTRACT.md
+```
+
+### Design Decisions
+
+- **`git clone --local`** hard-links `.git/objects` — near-instant, minimal disk usage
+- **Local bare remote** instead of Gitea — no Docker dependency for user-facing feature
+- **CodeDB shared read-only** — no clone needed, distill only reads GitHub activity from it
+- **`printSandboxResults()`** shows git log of new commits at the end for easy inspection
+- **Guidance overrides imply `--sandbox`** — providing `--sandbox-extract` or `--sandbox-distill` automatically enables sandbox mode


### PR DESCRIPTION
## Summary

- **`ox distill --sandbox`** runs the distill pipeline in an isolated `git clone --local` of the team context and ledger repos, with remotes swapped to local bare repos so push succeeds without touching the real remote
- **`--sandbox-extract` / `--sandbox-distill`** override guidance files (EXTRACT.md, DISTILL.md) for experimentation — implies `--sandbox`
- **`docs/ai/specs/digital-twin-testing.md`** documents the Gitea twin, ledger twin, and sandbox architectures

### How it works

```
Real team context repo              Local bare repo (tmpdir)
  ~/.local/share/sageox/...           /tmp/ox-distill-sandbox-xxx/remote-tc.git
         │                                      ▲
         │ git clone --local                    │ git remote add origin
         │ git remote remove origin             │
         ▼                                      │
  /tmp/ox-distill-sandbox-xxx/  ────────────────┘
    team-context/   (sandbox clone)
    ledger-0/       (sandbox clone)
```

- `git clone --local` hardlinks `.git/objects` (near-instant, minimal disk)
- Origin remote is **immediately removed** after clone — no window where git can reach the source
- Bare repo added as new origin — push works naturally
- Partial clone promisor objects cleaned from index (source repos use `--filter=blob:none`)
- `sandbox-baseline` tag marks pre-distill state for colored diff output
- CodeDB shared read-only (no clone needed)

### Usage

```bash
ox distill --sandbox                              # full pipeline, isolated
ox distill --sandbox --layer=daily                # daily only
ox distill --sandbox-extract=./my-EXTRACT-v2.md   # override guidance (implies --sandbox)
ox distill --sandbox --dry-run                    # see what would be distilled
```

## Test plan

- [x] `TestLocalCloneWithBareRemote` — clone, bare remote, push round-trip
- [x] `TestOverrideGuidance` — guidance file replacement
- [x] `TestCreateDistillSandbox` — full lifecycle: TC clone, ledger clone, guidance override, push isolation, source repo unmodified
- [x] E2E: `ox distill --sandbox --layer=daily` on real ox repo — extracts facts, shows colored diff
- [x] Lint clean, build clean
- [ ] Verify on repo with no partial clone (plain git repo)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)