### PR TITLE
fix(session): daemon anti-entropy uploads fully-finalized and raw-only cache sessions

### DIFF
--- a/internal/daemon/agentwork/manager.go
+++ b/internal/daemon/agentwork/manager.go
@@ -501,42 +501,55 @@ func (m *Manager) executeItem(ctx context.Context, item *WorkItem) {
 	m.active[item.ID] = proc
 	m.mu.Unlock()
 
-	// run the agent
-	result, runErr := m.runner.Run(ctx, req)
-	duration := time.Since(start)
+	var result *RunResult
+	var runErr error
+	var duration time.Duration
 
-	// remove from active map
-	m.mu.Lock()
-	delete(m.active, item.ID)
-	m.mu.Unlock()
+	if req.SkipLLM {
+		// no LLM invocation needed — call ProcessResult directly with empty output
+		result = &RunResult{}
+		duration = time.Since(start)
+		m.mu.Lock()
+		delete(m.active, item.ID)
+		m.mu.Unlock()
+	} else {
+		// run the agent
+		result, runErr = m.runner.Run(ctx, req)
+		duration = time.Since(start)
 
-	if runErr != nil {
-		item.Attempts++
-		item.LastErr = runErr.Error()
+		// remove from active map
+		m.mu.Lock()
+		delete(m.active, item.ID)
+		m.mu.Unlock()
 
-		exitCode := 0
-		if result != nil {
-			exitCode = result.ExitCode
+		if runErr != nil {
+			item.Attempts++
+			item.LastErr = runErr.Error()
+
+			exitCode := 0
+			if result != nil {
+				exitCode = result.ExitCode
+			}
+
+			if item.Attempts < maxRetries {
+				m.logger.Warn("agent run failed, will retry",
+					"type", item.Type,
+					"attempt", item.Attempts,
+					"max_attempts", maxRetries,
+					"error", runErr,
+				)
+				m.queue.Requeue(item)
+			} else {
+				m.logger.Error("agent run failed after max retries",
+					"type", item.Type,
+					"attempts", item.Attempts,
+					"error", runErr,
+				)
+				m.queue.Complete(item.DedupKey)
+				m.recordFailure(item, start, exitCode, runErr.Error())
+			}
+			return
 		}
-
-		if item.Attempts < maxRetries {
-			m.logger.Warn("agent run failed, will retry",
-				"type", item.Type,
-				"attempt", item.Attempts,
-				"max_attempts", maxRetries,
-				"error", runErr,
-			)
-			m.queue.Requeue(item)
-		} else {
-			m.logger.Error("agent run failed after max retries",
-				"type", item.Type,
-				"attempts", item.Attempts,
-				"error", runErr,
-			)
-			m.queue.Complete(item.DedupKey)
-			m.recordFailure(item, start, exitCode, runErr.Error())
-		}
-		return
 	}
 
 	// process result through handler

--- a/internal/daemon/agentwork/runner.go
+++ b/internal/daemon/agentwork/runner.go
@@ -18,6 +18,11 @@ type RunRequest struct {
 	Prompt          string
 	WorkDir         string
 	TimeoutOverride time.Duration
+	// SkipLLM bypasses the LLM runner entirely. The manager calls
+	// ProcessResult directly with an empty RunResult. Use this when
+	// the work item has all the information it needs to proceed without
+	// generating a prompt (e.g., upload-only session recovery).
+	SkipLLM bool
 }
 
 // RunResult captures the outcome of an agent invocation.

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -55,6 +56,9 @@ type SessionFinalizePayload struct {
 	RawPath    string   `json:"raw_path"`    // path to raw.jsonl
 	Missing    []string `json:"missing"`     // which artifacts need generation
 	LedgerPath string   `json:"ledger_path"` // ledger repo root (for git operations)
+	// UploadOnly skips LLM summarization. All artifacts already exist locally;
+	// the session just needs to be staged in ledger/sessions/ and pushed.
+	UploadOnly bool `json:"upload_only,omitempty"`
 
 	// storedSession is populated by BuildPrompt and reused by ProcessResult
 	// to avoid reading raw.jsonl twice.
@@ -317,6 +321,27 @@ func (h *SessionFinalizeHandler) detectInDir(sessionsDir, ledgerPath string) ([]
 
 		missing := missingArtifacts(sessionDir)
 		if len(missing) == 0 {
+			// All LLM artifacts present. If this session is in the ledger cache
+			// but not yet in the git-tracked sessions/ dir, it needs to be pushed.
+			if isInLedgerCacheDir(sessionDir, ledgerPath) {
+				ledgerMeta := filepath.Join(ledgerPath, "sessions", name, "meta.json")
+				if _, statErr := os.Stat(ledgerMeta); os.IsNotExist(statErr) {
+					h.logger.Info("session needs upload (fully finalized, not pushed)",
+						"session", name,
+					)
+					items = append(items, &WorkItem{
+						Type:     sessionFinalizeType,
+						Priority: sessionFinalizePriority,
+						DedupKey: sessionFinalizeType + ":" + name,
+						Payload: &SessionFinalizePayload{
+							SessionDir: sessionDir,
+							RawPath:    rawPath,
+							LedgerPath: ledgerPath,
+							UploadOnly: true,
+						},
+					})
+				}
+			}
 			continue
 		}
 
@@ -505,10 +530,15 @@ func (h *SessionFinalizeHandler) DetectOrphanedForAgent(ledgerPath, agentID stri
 }
 
 // BuildPrompt reads the raw session and constructs a summarization prompt.
+// For UploadOnly items, returns a SkipLLM request — no prompt needed.
 func (h *SessionFinalizeHandler) BuildPrompt(item *WorkItem) (RunRequest, error) {
 	payload, err := extractPayload(item)
 	if err != nil {
 		return RunRequest{}, err
+	}
+
+	if payload.UploadOnly {
+		return RunRequest{SkipLLM: true}, nil
 	}
 
 	stored, err := session.ReadSessionFromPath(payload.RawPath)
@@ -552,6 +582,10 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 	payload, err := extractPayload(item)
 	if err != nil {
 		return err
+	}
+
+	if payload.UploadOnly {
+		return h.processUploadOnly(payload)
 	}
 
 	llmOutput := result.Output
@@ -632,6 +666,16 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 	// so we can write pointer files only after a successful push
 	fileRefs := h.writeMetaAndUploadLFS(payload, stored, summaryResp)
 
+	// save original cache path before stageSessionInLedger may update payload.SessionDir
+	origCacheDir := payload.SessionDir
+
+	// stage in ledger/sessions/ if the session is still in the cache dir
+	// (.sageox/cache/ is gitignored in the ledger, so we must copy first)
+	if err := h.stageSessionInLedger(payload); err != nil {
+		h.logger.Warn("failed to stage session in ledger, skipping commit", "session", sessionName, "err", err)
+		return nil
+	}
+
 	// ensure sessions/.gitignore before commit
 	sessionsDir := filepath.Dir(payload.SessionDir)
 	if err := lfs.EnsureSessionsGitignore(sessionsDir); err != nil {
@@ -643,9 +687,17 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 	// push succeeded — now safe to replace content files with LFS pointer stubs
 	if len(fileRefs) > 0 {
 		if _, err := lfs.WritePointerFiles(payload.SessionDir, fileRefs); err != nil {
-			h.logger.Warn("LFS pointer file write failed after push", "session", filepath.Base(payload.SessionDir), "err", err)
+			h.logger.Warn("LFS pointer file write failed after push", "session", sessionName, "err", err)
 		}
 	}
+
+	// prune cache dir now that session is committed to the ledger
+	if origCacheDir != payload.SessionDir {
+		if err := os.RemoveAll(origCacheDir); err != nil {
+			h.logger.Debug("prune cache after finalize", "dir", origCacheDir, "err", err)
+		}
+	}
+
 	h.logger.Info("session recovered via anti-entropy",
 		"session", sessionName,
 		"quality_score", summaryResp.QualityScore,
@@ -719,6 +771,116 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	return fileRefs
 }
 
+// isInLedgerCacheDir reports whether sessionDir is inside the ledger's
+// .sageox/cache/sessions/ directory. The cache is gitignored, so sessions
+// there must be copied to ledger/sessions/ before they can be committed.
+func isInLedgerCacheDir(sessionDir, ledgerPath string) bool {
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions")
+	return strings.HasPrefix(filepath.Clean(sessionDir)+string(filepath.Separator), filepath.Clean(cacheDir)+string(filepath.Separator))
+}
+
+// stageSessionInLedger copies session files from the ledger cache dir to the
+// git-tracked ledger/sessions/<name>/ directory and updates payload.SessionDir.
+// If the session is already in ledger/sessions/, this is a no-op.
+func (h *SessionFinalizeHandler) stageSessionInLedger(payload *SessionFinalizePayload) error {
+	if !isInLedgerCacheDir(payload.SessionDir, payload.LedgerPath) {
+		return nil // already in ledger/sessions/ or another tracked path
+	}
+
+	sessionName := filepath.Base(payload.SessionDir)
+	destDir := filepath.Join(payload.LedgerPath, "sessions", sessionName)
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("create ledger session dir: %w", err)
+	}
+
+	entries, err := os.ReadDir(payload.SessionDir)
+	if err != nil {
+		return fmt.Errorf("read cache session dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		src := filepath.Join(payload.SessionDir, entry.Name())
+		dst := filepath.Join(destDir, entry.Name())
+		if err := copySessionFile(src, dst); err != nil {
+			return fmt.Errorf("copy %s: %w", entry.Name(), err)
+		}
+	}
+
+	// update payload to point at the staged location
+	payload.SessionDir = destDir
+	return nil
+}
+
+// processUploadOnly handles sessions that are fully finalized in the cache
+// but were never committed/pushed to the ledger. Skips LLM summarization.
+func (h *SessionFinalizeHandler) processUploadOnly(payload *SessionFinalizePayload) error {
+	sessionName := filepath.Base(payload.SessionDir)
+	origCacheDir := payload.SessionDir
+
+	// copy all artifacts from cache to ledger/sessions/<name>/
+	if err := h.stageSessionInLedger(payload); err != nil {
+		h.logger.Warn("upload-only: failed to stage session", "session", sessionName, "err", err)
+		return nil
+	}
+
+	// LFS upload and meta.json update (best-effort — fallback to regular git blob)
+	var fileRefs map[string]lfs.FileRef
+	if !h.skipLFS && h.projectRoot != "" {
+		ep := endpoint.GetForProject(h.projectRoot)
+		client, err := lfs.NewClientFromLedger(payload.LedgerPath, ep)
+		if err != nil {
+			h.logger.Warn("upload-only: LFS client creation failed, committing raw content", "session", sessionName, "err", err)
+		} else {
+			refs, err := lfs.UploadSessionFiles(client, payload.SessionDir, h.logger)
+			if err != nil {
+				h.logger.Warn("upload-only: LFS upload failed, committing raw content", "session", sessionName, "err", err)
+			} else {
+				fileRefs = refs
+				// update meta.json with LFS refs
+				if len(fileRefs) > 0 {
+					metaPath := filepath.Join(payload.SessionDir, "meta.json")
+					if metaData, readErr := os.ReadFile(metaPath); readErr == nil {
+						var meta lfs.SessionMeta
+						if jsonErr := json.Unmarshal(metaData, &meta); jsonErr == nil {
+							meta.Files = fileRefs
+							if writeErr := lfs.WriteSessionMetaOnly(payload.SessionDir, &meta); writeErr != nil {
+								h.logger.Warn("upload-only: meta.json LFS update failed", "session", sessionName, "err", writeErr)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	sessionsDir := filepath.Dir(payload.SessionDir)
+	if err := lfs.EnsureSessionsGitignore(sessionsDir); err != nil {
+		h.logger.Warn("upload-only: gitignore setup failed", "err", err)
+	}
+
+	h.gitCommitAndPush(payload)
+
+	if len(fileRefs) > 0 {
+		if _, err := lfs.WritePointerFiles(payload.SessionDir, fileRefs); err != nil {
+			h.logger.Warn("upload-only: LFS pointer write failed after push", "session", sessionName, "err", err)
+		}
+	}
+
+	// prune original cache entry now that session is in the ledger
+	if err := os.RemoveAll(origCacheDir); err != nil {
+		h.logger.Debug("upload-only: prune cache", "dir", origCacheDir, "err", err)
+	}
+
+	h.logger.Info("session uploaded via anti-entropy (upload-only)",
+		"session", sessionName,
+	)
+	return nil
+}
+
 // gitCommitAndPush stages, commits, and pushes the finalized session.
 // Push failures are non-fatal.
 func (h *SessionFinalizeHandler) gitCommitAndPush(payload *SessionFinalizePayload) {
@@ -779,6 +941,26 @@ func (h *SessionFinalizeHandler) runGit(repoPath string, args ...string) error {
 }
 
 // --- helpers ---
+
+// copySessionFile copies src to dst, creating dst if it doesn't exist.
+func copySessionFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
 
 // extractPayload type-asserts the work item payload.
 func extractPayload(item *WorkItem) (*SessionFinalizePayload, error) {

--- a/internal/daemon/agentwork/session_finalize_upload_test.go
+++ b/internal/daemon/agentwork/session_finalize_upload_test.go
@@ -1,0 +1,352 @@
+package agentwork
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// rawContent is a minimal valid session with substantive entries.
+const testRawContent = `{"metadata":{"schema_version":"1","agent_type":"claude-code","username":"testuser","agent_id":"OxTEST"}}
+{"type":"user","content":"hello","seq":1}
+{"type":"assistant","content":"world","seq":2}
+{"entry_count":2}
+`
+
+// --- A. Detect: fully-finalized-but-not-pushed sessions ---
+// TestDetect_FullyFinalizedInCache_NotPushed verifies that Detect() queues sessions
+// that have all artifacts in the ledger cache but are absent from ledger/sessions/.
+// Failure prevented: such sessions were silently skipped because missingArtifacts()
+// returned [] — they accumulated indefinitely without being committed/pushed.
+func TestDetect_FullyFinalizedInCache_NotPushed(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	ledgerPath := t.TempDir()
+
+	// create a session in ledger cache with ALL artifacts present
+	sessionName := "2026-01-10T12-00-testuser-OxCACHE"
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"), []byte(testRawContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range requiredArtifacts {
+		if err := os.WriteFile(filepath.Join(cacheDir, name), []byte("artifact"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "meta.json"), []byte(`{"session":"test"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	items, err := handler.Detect(ledgerPath)
+	if err != nil {
+		t.Fatalf("Detect failed: %v", err)
+	}
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 upload-only item, got %d", len(items))
+	}
+	payload, ok := items[0].Payload.(*SessionFinalizePayload)
+	if !ok {
+		t.Fatalf("unexpected payload type %T", items[0].Payload)
+	}
+	if !payload.UploadOnly {
+		t.Error("expected UploadOnly=true for fully-finalized cache session")
+	}
+}
+
+// TestDetect_FullyFinalizedInCache_AlreadyPushed verifies that Detect() skips sessions
+// that are in the cache AND already present in ledger/sessions/ (already uploaded).
+// Failure prevented: re-uploading a session that was already pushed would create duplicates.
+func TestDetect_FullyFinalizedInCache_AlreadyPushed(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	ledgerPath := t.TempDir()
+
+	sessionName := "2026-01-10T13-00-testuser-OxDONE"
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"), []byte(testRawContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range requiredArtifacts {
+		if err := os.WriteFile(filepath.Join(cacheDir, name), []byte("done"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// also present in ledger/sessions/ (already uploaded)
+	ledgerSessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	if err := os.MkdirAll(ledgerSessionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ledgerSessionDir, "meta.json"), []byte(`{"session":"done"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	items, err := handler.Detect(ledgerPath)
+	if err != nil {
+		t.Fatalf("Detect failed: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items (already uploaded), got %d", len(items))
+	}
+}
+
+// --- B. BuildPrompt: UploadOnly skips LLM ---
+// TestBuildPrompt_UploadOnly_SkipsLLM verifies that UploadOnly payloads return
+// SkipLLM=true, preventing an unnecessary and costly LLM invocation.
+// Failure prevented: UploadOnly sessions triggering a full LLM summarization run.
+func TestBuildPrompt_UploadOnly_SkipsLLM(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	item := &WorkItem{
+		ID:   "test-upload-only",
+		Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			UploadOnly: true,
+			SessionDir: "/tmp/fake",
+			RawPath:    "/tmp/fake/raw.jsonl",
+			LedgerPath: "/tmp/fake-ledger",
+		},
+	}
+
+	req, err := handler.BuildPrompt(item)
+	if err != nil {
+		t.Fatalf("BuildPrompt failed: %v", err)
+	}
+	if !req.SkipLLM {
+		t.Error("expected SkipLLM=true for UploadOnly payload")
+	}
+	if req.Prompt != "" {
+		t.Errorf("expected empty prompt for UploadOnly, got %q", req.Prompt)
+	}
+}
+
+// --- C. stageSessionInLedger: moves from cache to sessions/ ---
+// TestStageSessionInLedger_CopiesFiles verifies that stageSessionInLedger copies
+// all files from .sageox/cache/sessions/<name>/ to ledger/sessions/<name>/ and
+// updates payload.SessionDir.
+// Failure prevented: gitCommitAndPush silently staging nothing because .sageox/cache/
+// is gitignored in the ledger.
+func TestStageSessionInLedger_CopiesFiles(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	ledgerPath := t.TempDir()
+
+	sessionName := "2026-01-10T14-00-testuser-OxSTAGE"
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	testFiles := []string{"raw.jsonl", "summary.md", "meta.json"}
+	for _, f := range testFiles {
+		if err := os.WriteFile(filepath.Join(cacheDir, f), []byte("content of "+f), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	payload := &SessionFinalizePayload{
+		SessionDir: cacheDir,
+		LedgerPath: ledgerPath,
+	}
+
+	if err := handler.stageSessionInLedger(payload); err != nil {
+		t.Fatalf("stageSessionInLedger failed: %v", err)
+	}
+
+	expectedDest := filepath.Join(ledgerPath, "sessions", sessionName)
+	if payload.SessionDir != expectedDest {
+		t.Errorf("payload.SessionDir not updated: got %q, want %q", payload.SessionDir, expectedDest)
+	}
+
+	for _, f := range testFiles {
+		dst := filepath.Join(expectedDest, f)
+		data, err := os.ReadFile(dst)
+		if err != nil {
+			t.Errorf("file %s not copied: %v", f, err)
+			continue
+		}
+		if string(data) != "content of "+f {
+			t.Errorf("file %s has wrong content: %q", f, data)
+		}
+	}
+}
+
+// TestStageSessionInLedger_NoopIfAlreadyInLedger verifies that stageSessionInLedger
+// is a no-op when the session is already in ledger/sessions/.
+func TestStageSessionInLedger_NoopIfAlreadyInLedger(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	ledgerPath := t.TempDir()
+
+	sessionName := "2026-01-10T14-30-testuser-OxNOOP"
+	sessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := &SessionFinalizePayload{
+		SessionDir: sessionDir,
+		LedgerPath: ledgerPath,
+	}
+
+	if err := handler.stageSessionInLedger(payload); err != nil {
+		t.Fatalf("stageSessionInLedger failed: %v", err)
+	}
+	if payload.SessionDir != sessionDir {
+		t.Errorf("payload.SessionDir should not change: got %q", payload.SessionDir)
+	}
+}
+
+// --- D. isInLedgerCacheDir ---
+func TestIsInLedgerCacheDir(t *testing.T) {
+	ledger := "/home/user/.local/share/sageox/sageox.ai/ledgers/repo_abc"
+	cases := []struct {
+		sessionDir string
+		want       bool
+	}{
+		{ledger + "/.sageox/cache/sessions/2026-01-01T00-00-user-OxABC", true},
+		{ledger + "/sessions/2026-01-01T00-00-user-OxABC", false},
+		{"/other/path/sessions/something", false},
+		// a sibling dir that shares a prefix with the cache path but isn't under it
+		{ledger + "/.sageox/cache/sessions-extra/OxABC", false},
+	}
+	for _, tc := range cases {
+		got := isInLedgerCacheDir(tc.sessionDir, ledger)
+		if got != tc.want {
+			t.Errorf("isInLedgerCacheDir(%q) = %v, want %v", tc.sessionDir, got, tc.want)
+		}
+	}
+}
+
+// --- E. End-to-end: UploadOnly session commits to git ---
+// TestProcessResult_UploadOnly_CommitsToGit verifies the full pipeline for an
+// UploadOnly session: cache → stage → git commit → push, without LLM involvement.
+// Failure prevented: UploadOnly sessions silently never landing in the ledger.
+func TestProcessResult_UploadOnly_CommitsToGit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, clonePath := setupBareAndCloneLedger(t)
+	sessionName := "2026-01-15T10-00-testuser-OxUPLOAD"
+
+	// put session in cache (fully finalized, all artifacts present)
+	cacheDir := filepath.Join(clonePath, ".sageox", "cache", "sessions", sessionName)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"), []byte(testRawContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range requiredArtifacts {
+		if err := os.WriteFile(filepath.Join(cacheDir, name), []byte("artifact content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "meta.json"), []byte(`{"session_name":"`+sessionName+`"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipLFS = true
+	handler.skipGit = false
+	handler.ledgerMu = &sync.Mutex{}
+
+	item := &WorkItem{
+		ID:   "test-upload-only-git",
+		Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: cacheDir,
+			RawPath:    filepath.Join(cacheDir, "raw.jsonl"),
+			LedgerPath: clonePath,
+			UploadOnly: true,
+		},
+	}
+
+	if err := handler.ProcessResult(item, &RunResult{}); err != nil {
+		t.Fatalf("ProcessResult failed: %v", err)
+	}
+
+	// session must be in ledger/sessions/ after commit
+	ledgerSessionDir := filepath.Join(clonePath, "sessions", sessionName)
+	if _, err := os.Stat(filepath.Join(ledgerSessionDir, "raw.jsonl")); err != nil {
+		t.Errorf("raw.jsonl not found in ledger/sessions/: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(ledgerSessionDir, "meta.json")); err != nil {
+		t.Errorf("meta.json not found in ledger/sessions/: %v", err)
+	}
+
+	// cache dir must be pruned after successful commit
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Error("cache dir should be removed after successful upload")
+	}
+}
+
+// TestProcessResult_RegularFinalize_StagesToLedger verifies that the regular
+// finalization path (with LLM output) also stages from cache to ledger/sessions/.
+// Failure prevented: regular ProcessResult silently committing to the gitignored
+// cache path, leaving sessions stuck in "local only" state forever.
+func TestProcessResult_RegularFinalize_StagesToLedger(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, clonePath := setupBareAndCloneLedger(t)
+	sessionName := "2026-01-15T11-00-testuser-OxREGULAR"
+
+	// put raw-only session in cache (typical: session stop failed before summarization)
+	cacheDir := filepath.Join(clonePath, ".sageox", "cache", "sessions", sessionName)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"), []byte(testRawContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipLFS = true
+	handler.skipGit = false
+	handler.ledgerMu = &sync.Mutex{}
+
+	llmOutput := `{"title":"Test Session","summary":"A test session.","quality_score":0.8,"score_reason":"fine","outcome":"success","key_actions":["did something"]}`
+
+	item := &WorkItem{
+		ID:   "test-regular-stage",
+		Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: cacheDir,
+			RawPath:    filepath.Join(cacheDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: clonePath,
+		},
+	}
+
+	if err := handler.ProcessResult(item, &RunResult{Output: llmOutput}); err != nil {
+		t.Fatalf("ProcessResult failed: %v", err)
+	}
+
+	// session must be in ledger/sessions/, not just in cache
+	ledgerSessionDir := filepath.Join(clonePath, "sessions", sessionName)
+	if _, err := os.Stat(filepath.Join(ledgerSessionDir, "raw.jsonl")); err != nil {
+		t.Errorf("raw.jsonl not in ledger/sessions/: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(ledgerSessionDir, "summary.json")); err != nil {
+		t.Errorf("summary.json not in ledger/sessions/: %v", err)
+	}
+
+	// cache dir must be pruned
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Error("cache dir should be pruned after finalize+commit")
+	}
+}


### PR DESCRIPTION
## Problem

Two bugs caused sessions to accumulate in `.sageox/cache/sessions/` indefinitely without ever being committed/pushed to the ledger:

**Bug 1 — fully-finalized sessions silently skipped:** `detectInDir()` called `missingArtifacts()` (which checks for `summary.md`, `summary.json`, `session.md`). If all three existed, the session was skipped — even if it was never git-committed. 118 sessions were stranded this way (all artifacts present in cache, absent from `ledger/sessions/`).

**Bug 2 — regular finalize path committed to gitignored path:** After generating artifacts, `ProcessResult` called `gitCommitAndPush` with `payload.SessionDir` still pointing to `.sageox/cache/sessions/<name>/`. That directory is gitignored in the ledger (`.sageox/.gitignore`), so `git add --sparse` staged nothing, the commit was a no-op, and the session stayed in cache forever. 322 raw-only sessions were stuck this way.

Both bugs were masked when auth was valid because `ox session stop` handled the push synchronously. Once the token expired (March 27), anti-entropy accumulated a 7-day backlog of 440 sessions with no recovery path.

## Solution

```
runner.go        — add SkipLLM bool to RunRequest
manager.go       — handle SkipLLM: call ProcessResult directly, skip runner.Run
session_finalize.go:
  detectInDir    — detect fully-finalized-but-not-pushed cache sessions, queue with UploadOnly=true
  BuildPrompt    — return SkipLLM=true for UploadOnly items
  ProcessResult  — UploadOnly path: stage → LFS upload → commit → push → prune cache
  ProcessResult  — regular path: call stageSessionInLedger before gitCommitAndPush
  stageSessionInLedger — copy files from .sageox/cache/sessions/<n>/ to sessions/<n>/
  isInLedgerCacheDir   — helper to detect cache-dir sessions
  processUploadOnly    — full upload pipeline without LLM
```

### Flow after fix

```
Detect() finds session in .sageox/cache/sessions/<name>/
  ├── has missing artifacts → queue session-finalize (existing path)
  │     ProcessResult: write artifacts → stageSessionInLedger → gitCommitAndPush → prune cache
  └── all artifacts present, not in ledger/sessions/<name>/meta.json → queue UploadOnly
        BuildPrompt: SkipLLM=true (no LLM call)
        ProcessResult: stageSessionInLedger → LFS upload → gitCommitAndPush → prune cache
```

## Tests

8 new tests in `session_finalize_upload_test.go`, each named after the failure it prevents:

- `TestDetect_FullyFinalizedInCache_NotPushed` — Detect queues stranded sessions
- `TestDetect_FullyFinalizedInCache_AlreadyPushed` — no duplicate upload
- `TestBuildPrompt_UploadOnly_SkipsLLM` — SkipLLM flag set correctly
- `TestStageSessionInLedger_CopiesFiles` — files copied from cache to sessions/
- `TestStageSessionInLedger_NoopIfAlreadyInLedger` — no-op for non-cache sessions
- `TestIsInLedgerCacheDir` — boundary conditions
- `TestProcessResult_UploadOnly_CommitsToGit` — end-to-end upload-only pipeline
- `TestProcessResult_RegularFinalize_StagesToLedger` — regular path stages to sessions/

## Notes

- Bug 3 (ghost sessions with no turns) was confirmed already handled correctly by `hasSubstantiveEntries` and ghost cleanup — no code change needed.
- `ox doctor --check=session-upload-retry` remains functional as a manual recovery tool; it is now redundant for new failures but still useful for diagnosing state.

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced upload-only session workflow to handle locally-finalized sessions requiring staging and synchronization without LLM reprocessing.
  * Automated session migration from cache to permanent ledger storage with cleanup after successful upload.

* **Tests**
  * Comprehensive test suite for session finalization and upload workflows, including cache-to-ledger migration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->