### PR TITLE
fix(hooks): handle legacy string-format hooks and make prime idempotent

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -242,6 +242,24 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		// reuse agent_id from marker (preserves identity across re-primes)
 		agentID = existingMarker.AgentID
 	} else {
+		// fallback: if a hook already started recording for the same agent process,
+		// reuse that recording's agent ID so prime stays idempotent.
+		// This handles the case where CLAUDE.md's BLOCKING instruction triggers
+		// a second prime call after the SessionStart hook already created a session.
+		if currentPID := proc.FindAgentAncestorPID(); currentPID > 0 {
+			if states, loadErr := session.LoadAllRecordingStates(projectRoot); loadErr == nil {
+				for _, s := range states {
+					if s.IsAgentAlive() && s.ParentPID > 0 && s.ParentPID == currentPID {
+						agentID = s.AgentID
+						slog.Debug("prime: reusing agent ID from active recording", "agent_id", agentID, "parent_pid", currentPID)
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if agentID == "" {
 		// collect existing IDs to avoid collision during generation
 		existingInstances, err := store.List()
 		if err != nil {

--- a/cmd/ox/doctor_hooks.go
+++ b/cmd/ox/doctor_hooks.go
@@ -336,17 +336,8 @@ func checkProjectHookCommands() checkResult {
 		return SkippedCheck("Project hook commands", "no settings.json", "")
 	}
 
-	data, err := os.ReadFile(settingsPath)
+	settings, _, err := readSharedClaudeSettings(gitRoot)
 	if err != nil {
-		return WarningCheck("Project hook commands", "read error", err.Error())
-	}
-
-	if len(data) == 0 {
-		return SkippedCheck("Project hook commands", "empty file", "")
-	}
-
-	var settings ClaudeSettings
-	if err := json.Unmarshal(data, &settings); err != nil {
 		return WarningCheck("Project hook commands", "parse error", err.Error())
 	}
 

--- a/internal/hooks/claude/parse.go
+++ b/internal/hooks/claude/parse.go
@@ -23,7 +23,14 @@ func ParseSettingsRaw(data []byte) (*Settings, map[string]json.RawMessage, error
 	var settings Settings
 	if hooksRaw, ok := rawMap["hooks"]; ok {
 		if err := json.Unmarshal(hooksRaw, &settings.Hooks); err != nil {
-			return nil, nil, fmt.Errorf("failed to parse hooks: %w", err)
+			// fallback: some settings files use old string-format hooks (e.g. "PostToolUse": "cmd")
+			// instead of the array format ("PostToolUse": [{hooks: [{command, type}]}]).
+			// Try parsing each event value individually to handle mixed formats.
+			mixed, mixedErr := parseHooksMixed(hooksRaw)
+			if mixedErr != nil {
+				return nil, nil, fmt.Errorf("failed to parse hooks: %w", err)
+			}
+			settings.Hooks = mixed
 		}
 	}
 	if settings.Hooks == nil {
@@ -31,6 +38,34 @@ func ParseSettingsRaw(data []byte) (*Settings, map[string]json.RawMessage, error
 	}
 
 	return &settings, rawMap, nil
+}
+
+// parseHooksMixed handles settings files where hook event values are either
+// the current array format ([]HookEntry) or the legacy string format ("command").
+// Legacy entries are promoted to a single-element HookEntry with no matcher.
+func parseHooksMixed(hooksRaw json.RawMessage) (map[string][]HookEntry, error) {
+	var rawEvents map[string]json.RawMessage
+	if err := json.Unmarshal(hooksRaw, &rawEvents); err != nil {
+		return nil, err
+	}
+	result := make(map[string][]HookEntry, len(rawEvents))
+	for event, val := range rawEvents {
+		// try array format first
+		var entries []HookEntry
+		if err := json.Unmarshal(val, &entries); err == nil {
+			result[event] = entries
+			continue
+		}
+		// fall back to legacy string format: "command string"
+		var cmd string
+		if err := json.Unmarshal(val, &cmd); err != nil {
+			return nil, fmt.Errorf("hook event %q: unsupported format", event)
+		}
+		result[event] = []HookEntry{{
+			Hooks: []Hook{{Command: cmd, Type: HookType}},
+		}}
+	}
+	return result, nil
 }
 
 // MarshalSettings serializes Settings back into JSON, merging typed hooks into

--- a/internal/hooks/claude/parse_test.go
+++ b/internal/hooks/claude/parse_test.go
@@ -63,6 +63,49 @@ func TestParseSettingsRaw_InvalidHooksJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "parse hooks")
 }
 
+// TestParseSettingsRaw_LegacyStringHooks verifies that hooks files using the
+// old string-value format ("PostToolUse": "command") are parsed without error.
+// Failure prevented: ox doctor reports parse errors for repos that installed
+// hooks before the array format was adopted.
+func TestParseSettingsRaw_LegacyStringHooks(t *testing.T) {
+	data := []byte(`{
+		"hooks": {
+			"PostToolUse": "ox agent hook PostToolUse",
+			"Stop": "ox agent hook Stop"
+		}
+	}`)
+	settings, _, err := ParseSettingsRaw(data)
+	require.NoError(t, err)
+	require.Len(t, settings.Hooks["PostToolUse"], 1)
+	assert.Equal(t, "ox agent hook PostToolUse", settings.Hooks["PostToolUse"][0].Hooks[0].Command)
+	require.Len(t, settings.Hooks["Stop"], 1)
+	assert.Equal(t, "ox agent hook Stop", settings.Hooks["Stop"][0].Hooks[0].Command)
+}
+
+// TestParseSettingsRaw_MixedHookFormats verifies that files with a mix of old
+// string-format and new array-format hook events parse correctly.
+// Failure prevented: mixed-format settings.json (created by upgrading hook install
+// while retaining manually-added string hooks) silently breaks session recording.
+func TestParseSettingsRaw_MixedHookFormats(t *testing.T) {
+	data := []byte(`{
+		"hooks": {
+			"PostToolUse": "ox agent hook PostToolUse",
+			"SessionStart": [{"matcher": "", "hooks": [{"command": "ox agent hook SessionStart", "type": "command"}]}]
+		}
+	}`)
+	settings, _, err := ParseSettingsRaw(data)
+	require.NoError(t, err)
+
+	// legacy string entry promoted to array
+	require.Len(t, settings.Hooks["PostToolUse"], 1)
+	assert.Equal(t, "ox agent hook PostToolUse", settings.Hooks["PostToolUse"][0].Hooks[0].Command)
+	assert.Equal(t, HookType, settings.Hooks["PostToolUse"][0].Hooks[0].Type)
+
+	// array entry unchanged
+	require.Len(t, settings.Hooks["SessionStart"], 1)
+	assert.Equal(t, "ox agent hook SessionStart", settings.Hooks["SessionStart"][0].Hooks[0].Command)
+}
+
 func TestMarshalSettings_EmptyHooksRemovesKey(t *testing.T) {
 	settings := &Settings{Hooks: map[string][]HookEntry{}}
 	rawMap := map[string]json.RawMessage{


### PR DESCRIPTION
## Summary

- **Hook parse fallback**: `ParseSettingsRaw` now handles settings files that use the old string-value format for hook events (`"PostToolUse": "command"`) instead of the array format. Falls back to `parseHooksMixed` which handles both formats, promoting string entries to a single-element `[]HookEntry`. Fixes `cannot unmarshal string into Go value of type []claude.HookEntry` errors that blocked `ox doctor` and `ox doctor --fix` in repos with mixed-format hooks.
- **Doctor hook check fix**: `checkProjectHookCommands` now uses `readSharedClaudeSettings` (which goes through `ParseSettingsRaw`) instead of a raw `json.Unmarshal`, so it benefits from the same mixed-format fallback.
- **Prime idempotency**: `ox agent prime` now scans active recording states for one with a matching `ParentPID` before generating a new agent ID. If a SessionStart hook already started recording for the same agent process, prime reuses that agent ID — preventing duplicate sessions when CLAUDE.md's BLOCKING instruction triggers a second prime call after the hook already created one.

## Why

When a project's `.claude/settings.json` has hooks in the old string format (installed by an older version), `ParseSettingsRaw` would fail entirely. This caused `ox doctor` to show parse errors and blocked `ox doctor --fix` from rewriting the file to normalize the format. Auto-repair now works as expected.

The prime idempotency issue caused `ox session stop` to report "not currently recording" — the hook created session `OxA1B2`, then CLAUDE.md's blocking `ox agent prime` created a new `OxfFdv`, so stop targeted the wrong one.

## Test plan

- [ ] `go test ./internal/hooks/claude/...` — new `TestParseSettingsRaw_LegacyStringHooks` and `TestParseSettingsRaw_MixedHookFormats` tests verify the fallback
- [ ] `go test ./... -short` — all packages pass
- [ ] Manual: open Claude Code in a repo with mixed-format hooks, verify `ox doctor` shows no parse errors and `ox doctor --fix` succeeds

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for legacy hook configuration formats, enabling backward compatibility with older project settings.

* **Bug Fixes**
  * Improved agent ID assignment to reuse active recording identifiers when available.

* **Tests**
  * Added test coverage for legacy and mixed hook format parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->