### PR TITLE
feat(agents): bump agentx v0.1.5 for gemini + flexible version detection

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -185,11 +185,18 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	if agentVer != "" {
 		useragent.SetAgentVersion(agentVer)
 	} else if agentType != "" {
-		// auto-detect agent version as fallback when --agent-ver not provided
+		// auto-detect agent version: try agentx first, then flexible fallback
 		if agent := agentx.CurrentAgent(); agent != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 			if ver := agent.DetectVersion(ctx, agentx.NewSystemEnvironment()); ver != "" {
+				agentVer = ver
+				useragent.SetAgentVersion(ver)
+			}
+		}
+		// fallback: flexible regex for CLIs with non-standard version output
+		if agentVer == "" {
+			if ver := detectAgentVersionFallback(agentType); ver != "" {
 				agentVer = ver
 				useragent.SetAgentVersion(ver)
 			}

--- a/cmd/ox/agent_version.go
+++ b/cmd/ox/agent_version.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// flexVersionRe matches version patterns more broadly than agentx's strict X.Y.Z:
+// handles X.Y, X.Y.Z, vX.Y.Z, and prefixed output like "tool v1.2".
+var flexVersionRe = regexp.MustCompile(`v?(\d+\.\d+(?:\.\d+)?)`)
+
+// detectAgentVersionFallback attempts version detection with a flexible regex
+// when agentx's strict X.Y.Z pattern fails. Some CLIs output "X.Y" or
+// prefixed versions that agentx doesn't match.
+func detectAgentVersionFallback(agentType string) string {
+	binary := agentTypeToBinary(agentType)
+	if binary == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, binary, "--version").Output()
+	if err != nil {
+		return ""
+	}
+	return extractFlexibleVersion(string(out))
+}
+
+// extractFlexibleVersion finds the first version-like pattern in text.
+func extractFlexibleVersion(text string) string {
+	m := flexVersionRe.FindStringSubmatch(strings.TrimSpace(text))
+	if len(m) >= 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// agentTypeToBinary maps canonical agent type slugs to CLI binary names.
+func agentTypeToBinary(agentType string) string {
+	switch agentType {
+	case "claude":
+		return "claude"
+	case "":
+		return ""
+	default:
+		// most agents use their type as the binary name
+		return agentType
+	}
+}

--- a/cmd/ox/agent_version_test.go
+++ b/cmd/ox/agent_version_test.go
@@ -1,0 +1,65 @@
+package main
+
+import "testing"
+
+// --- A. Flexible version extraction ---
+
+// TestExtractFlexibleVersion_Formats validates that the flexible regex matches
+// version patterns that agentx's strict X.Y.Z regex misses.
+// Failure prevented: agents reporting "unknown" when their CLI outputs non-standard versions.
+func TestExtractFlexibleVersion_Formats(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"three-part semver", "1.2.3", "1.2.3"},
+		{"two-part version", "0.14", "0.14"},
+		{"v-prefixed", "v1.2.3", "1.2.3"},
+		{"v-prefixed two-part", "v0.14", "0.14"},
+		{"with tool name", "pi-coding-agent 1.2.3", "1.2.3"},
+		{"with tool name two-part", "amp 0.5", "0.5"},
+		{"with newline", "gemini 2.1.0\n", "2.1.0"},
+		{"embedded in text", "Version: v3.14.1 (stable)", "3.14.1"},
+		{"empty", "", ""},
+		{"no version", "hello world", ""},
+		{"whitespace only", "   ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractFlexibleVersion(tt.input)
+			if got != tt.want {
+				t.Errorf("extractFlexibleVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- B. Agent type to binary mapping ---
+
+// TestAgentTypeToBinary_Mapping validates that canonical agent types map to correct CLI binaries.
+// Failure prevented: version fallback running wrong binary for an agent type.
+func TestAgentTypeToBinary_Mapping(t *testing.T) {
+	tests := []struct {
+		agentType string
+		want      string
+	}{
+		{"claude", "claude"},
+		{"pi", "pi"},
+		{"amp", "amp"},
+		{"gemini", "gemini"},
+		{"droid", "droid"},
+		{"codex", "codex"},
+		{"aider", "aider"},
+		{"opencode", "opencode"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.agentType, func(t *testing.T) {
+			got := agentTypeToBinary(tt.agentType)
+			if got != tt.want {
+				t.Errorf("agentTypeToBinary(%q) = %q, want %q", tt.agentType, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ox/hooks_user_marker.go
+++ b/cmd/ox/hooks_user_marker.go
@@ -143,6 +143,8 @@ func detectActiveAgent() agentx.AgentType {
 		return agentx.AgentTypeCline
 	case "copilot":
 		return agentx.AgentTypeCopilot
+	case "gemini", "gemini-cli":
+		return agentx.AgentTypeGemini
 	}
 
 	// default to Claude Code (most common)
@@ -166,17 +168,9 @@ func userContextFilePath(agentType agentx.AgentType, contextFile string) (string
 }
 
 // agentDisplayName returns a human-friendly name for an agent type.
-// localDisplayNames supplements agentx registry for agents not yet in agentx.
-var localDisplayNames = map[agentx.AgentType]string{
-	"gemini": "Gemini CLI",
-}
-
 func agentDisplayName(agentType agentx.AgentType) string {
 	if agent, ok := agentx.DefaultRegistry.Get(agentType); ok {
 		return agent.Name()
-	}
-	if name, ok := localDisplayNames[agentType]; ok {
-		return name
 	}
 	return string(agentType)
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/sageox/agentx v0.1.4
+	github.com/sageox/agentx v0.1.5
 	github.com/sageox/frictionax v0.1.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sageox/agentx v0.1.4 h1:RQql9h1szdE5xFjQNkmPFGt07tdyIW29IhIpIviNJRw=
-github.com/sageox/agentx v0.1.4/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
+github.com/sageox/agentx v0.1.5 h1:tfe2yHCIhyh5ArxcxuOIW4eYqpHWRZ7Yrrqaais4+NU=
+github.com/sageox/agentx v0.1.5/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
 github.com/sageox/frictionax v0.1.2 h1:iQfssC1g/vVdGXi55smMfY5/4JKcQbJXRzcwrQWiNLo=
 github.com/sageox/frictionax v0.1.2/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/internal/prime/agent_type.go
+++ b/internal/prime/agent_type.go
@@ -12,7 +12,7 @@ import (
 var SupportedAgents = map[string]bool{
 	string(agentx.AgentTypeClaudeCode): true,
 	string(agentx.AgentTypeCodex):      true,
-	"gemini":                           true, // agentx.AgentTypeGemini pending
+	string(agentx.AgentTypeGemini):     true,
 	string(agentx.AgentTypeAmp):        true,
 	string(agentx.AgentTypePi):         true,
 }
@@ -28,7 +28,7 @@ func CanonicalAgentType(agentType string) string {
 	case "codex":
 		return string(agentx.AgentTypeCodex)
 	case "gemini", "gemini-cli", "gemini cli":
-		return "gemini"
+		return string(agentx.AgentTypeGemini)
 	case "amp", "amp-cli", "amp cli", "sourcegraph":
 		return string(agentx.AgentTypeAmp)
 	case "pi", "pi-coding-agent", "pi agent":


### PR DESCRIPTION
## Summary

- Bumps `agentx` from v0.1.4 to v0.1.5, which adds `AgentTypeGemini` to the registry and `SupportedAgents` — fixes "ox doesn't recognize gemini" test failure
- Replaces hardcoded `"gemini"` string literals with `agentx.AgentTypeGemini` constant
- Fixes `detectActiveAgent()` bug where `AGENT_ENV=gemini` silently fell through to Claude Code default
- Adds `detectAgentVersionFallback()` with flexible regex (`X.Y`, `X.Y.Z`, `vX.Y.Z`) for agents whose `--version` output doesn't match agentx's strict `X.Y.Z` pattern (pi, amp, droid)
- Removes dead `localDisplayNames` map now that gemini is in the agentx registry

```mermaid
flowchart TD
    A[ox agent prime] --> B{--agent-ver provided?}
    B -->|yes| C[use provided version]
    B -->|no| D[agentx DetectVersion]
    D -->|X.Y.Z found| C
    D -->|empty| E[detectAgentVersionFallback]
    E -->|X.Y or X.Y.Z found| C
    E -->|empty| F[version unknown]
```

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — 12169 tests pass
- [x] New `TestExtractFlexibleVersion_Formats` and `TestAgentTypeToBinary_Mapping` pass
- [ ] Verify gemini detection in real agent session

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced agent version detection with automatic fallback when explicit version not provided, extracting versions from agent CLI output.
  * Improved Gemini agent type recognition and normalization.

* **Dependencies**
  * Updated agentx library to v0.1.5.

* **Tests**
  * Added comprehensive test coverage for version detection and agent type mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->