### PR TITLE
feat(flags): wire daemon polling, IPC handler, and CLI startup

### DIFF
--- a/cmd/ox/root.go
+++ b/cmd/ox/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/flags"
 	"github.com/sageox/ox/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -58,6 +60,9 @@ var rootCmd = &cobra.Command{
 				Heartbeat(gitRoot, nil, "")
 			}
 		}
+
+		// resolve feature flags: daemon cache → disk cache → env vars → defaults
+		initFeatureFlags(cmd)
 
 		// performance profiling setup
 		// creates CPU profile (.prof) and execution trace (.out) files
@@ -455,6 +460,39 @@ func shouldHeartbeat(cmd *cobra.Command) bool {
 	}
 
 	return true
+}
+
+// initFeatureFlags resolves feature flags from daemon cache, disk cache, and env vars.
+// Zero network calls — reads only from local sources at CLI startup.
+func initFeatureFlags(cmd *cobra.Command) {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var daemonProvider flags.DaemonProvider
+
+	// try daemon IPC first (fast path: daemon already has settings in memory)
+	if config.IsInitializedInCwd() && daemon.IsRunning() {
+		client := daemon.NewClientForCurrentRepo()
+		if settings, err := client.SettingsGet(); err == nil && settings != nil {
+			daemonProvider.CachedSettings = settings
+		}
+	}
+
+	// fall back to disk cache if daemon didn't have settings
+	if daemonProvider.CachedSettings == nil {
+		if gitRoot := findGitRoot(); gitRoot != "" {
+			ep := endpoint.GetForProject(gitRoot)
+			if ep != "" {
+				if cached, err := flags.LoadCachedSettings(ep); err == nil && cached != nil {
+					daemonProvider.CachedSettings = cached
+				}
+			}
+		}
+	}
+
+	flags.Init(ctx, daemonProvider, flags.EnvProvider{})
 }
 
 // printCommandEntry renders a command with contextual highlighting based on user state

--- a/internal/api/repos.go
+++ b/internal/api/repos.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	reposPath      = "/api/v1/cli/repos"
-	repoDetailPath = "/api/v1/cli/repos/%s" // %s = repo_id (SageOx UUID)
-	teamInfoPath   = "/api/v1/teams/%s"     // %s = team_id
+	reposPath       = "/api/v1/cli/repos"
+	repoDetailPath  = "/api/v1/cli/repos/%s" // %s = repo_id (SageOx UUID)
+	teamInfoPath    = "/api/v1/teams/%s"     // %s = team_id
+	cliSettingsPath = "/api/v1/cli/settings"
 )
 
 // RepoInfo represents a single git repository from the server.
@@ -349,4 +350,59 @@ func (c *RepoClient) GetRepoDetail(repoID string) (*RepoDetailResponse, error) {
 	}
 
 	return &detail, nil
+}
+
+// GetCLISettings calls GET /api/v1/cli/settings to fetch server-evaluated feature flags.
+// The server evaluates PostHog feature flags server-side (device_id + user_id) and returns
+// pre-evaluated booleans. Requires authentication. Returns flags.CLISettingsResponse.
+//
+// Called by the daemon on a background interval; the CLI reads the cached result from disk.
+func (c *RepoClient) GetCLISettings() (json.RawMessage, error) {
+	reqURL := strings.TrimSuffix(c.baseURL, "/") + cliSettingsPath
+
+	logger.LogHTTPRequest("GET", reqURL)
+	start := time.Now()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	httpReq, err := useragent.NewRequest(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	if c.authToken != "" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	duration := time.Since(start)
+	if err != nil {
+		logger.LogHTTPError("GET", reqURL, err, duration)
+		return nil, fmt.Errorf("network error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	logger.LogHTTPResponse("GET", reqURL, resp.StatusCode, duration)
+
+	if CheckVersionResponse(resp) {
+		return nil, ErrVersionUnsupported
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
+		}
+		errMsg := strings.TrimSpace(string(bodyBytes))
+		if errMsg == "" {
+			return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, reqURL)
+		}
+		return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, reqURL, errMsg)
+	}
+
+	return json.RawMessage(bodyBytes), nil
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon/agentwork"
+	"github.com/sageox/ox/internal/flags"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
@@ -168,6 +169,7 @@ type Daemon struct {
 	murmurNudgeSource      *MurmurNudgeSource
 	projectWatcher         *ProjectWatcher
 	dbMaintenance          *DBMaintenanceScheduler
+	settingsFetcher        *SettingsFetcher
 
 	// state
 	mu               sync.Mutex
@@ -1040,6 +1042,13 @@ func (d *Daemon) initComponents() time.Duration {
 		}
 	})
 
+	// settings fetcher — background polling for CLI feature flags from cloud API
+	if projectEndpoint != "" {
+		d.settingsFetcher = NewSettingsFetcher(d.logger, projectEndpoint)
+		d.settingsFetcher.SetAuthTokenGetter(d.heartbeat.GetAuthToken)
+		d.scheduler.SetSettingsFetcher(d.settingsFetcher)
+	}
+
 	return time.Since(startSetup)
 }
 
@@ -1274,6 +1283,13 @@ func (s *daemonServiceImpl) Status() *StatusData {
 		AgentWork:          agentWorkStatus,
 		Callers:            callers,
 	}
+}
+
+func (s *daemonServiceImpl) SettingsGet() *flags.CLISettingsResponse {
+	if s.d.settingsFetcher == nil {
+		return nil
+	}
+	return s.d.settingsFetcher.CachedSettings()
 }
 
 func (s *daemonServiceImpl) GetErrors() []StoredError {

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/daemon/agentwork"
+	"github.com/sageox/ox/internal/flags"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
 
@@ -55,6 +56,7 @@ const (
 	MsgTypeMurmurResume       = "murmur_resume"        // one-way, resume murmur nudging for an agent
 	MsgTypeSessionWatchStart  = "session_watch_start"  // one-way, start tailing a hookless agent session
 	MsgTypeSessionWatchStop   = "session_watch_stop"   // one-way, stop tailing a session
+	MsgTypeSettingsGet        = "settings_get"         // get cached CLI feature flag settings
 )
 
 // Protocol Design Decision: NDJSON (Newline-Delimited JSON)
@@ -574,6 +576,7 @@ type DaemonService interface {
 
 	// status / query operations
 	Status() *StatusData
+	SettingsGet() *flags.CLISettingsResponse
 	GetErrors() []StoredError
 	Sessions() []AgentSession // deprecated: use Instances
 	Instances() []InstanceInfo
@@ -635,6 +638,7 @@ type CallbackService struct {
 	onCodeStatus       func() *CodeDBStats
 	onWhispers         func(agentID string, attention whisperstore.Attention, topics []string) ([]whisperstore.WhisperEntry, error)
 	onWhisperHistory   func(agentID string, before time.Time, limit int) (*WhisperHistoryResponse, error)
+	onSettingsGet      func() *flags.CLISettingsResponse
 }
 
 func (c *CallbackService) Sync() error {
@@ -740,6 +744,16 @@ func (c *CallbackService) WhisperHistory(agentID string, before time.Time, limit
 func (c *CallbackService) CodeStatus() *CodeDBStats {
 	c.mu.Lock()
 	fn := c.onCodeStatus
+	c.mu.Unlock()
+	if fn != nil {
+		return fn()
+	}
+	return nil
+}
+
+func (c *CallbackService) SettingsGet() *flags.CLISettingsResponse {
+	c.mu.Lock()
+	fn := c.onSettingsGet
 	c.mu.Unlock()
 	if fn != nil {
 		return fn()
@@ -968,6 +982,7 @@ func (s *Server) buildRouter() *MessageRouter {
 	router.Register(MsgTypeMurmurResume, handleMurmurResume)
 	router.Register(MsgTypeSessionWatchStart, handleSessionWatchStart)
 	router.Register(MsgTypeSessionWatchStop, handleSessionWatchStop)
+	router.Register(MsgTypeSettingsGet, handleSettingsGet)
 
 	return router
 }
@@ -1179,6 +1194,14 @@ func (s *Server) SetWhisperHistoryHandler(cb func(agentID string, before time.Ti
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 	svc.onWhisperHistory = cb
+}
+
+// SetSettingsGetHandler sets the handler for CLI feature flag settings queries.
+func (s *Server) SetSettingsGetHandler(cb func() *flags.CLISettingsResponse) {
+	svc := s.mustCallbackService("SetSettingsGetHandler")
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	svc.onSettingsGet = cb
 }
 
 // mustCallbackService returns the mutable callback adapter.
@@ -1995,6 +2018,27 @@ func (c *Client) CodeStatus() (*CodeDBStats, error) {
 		return nil, fmt.Errorf("unmarshal code status: %w", err)
 	}
 	return &stats, nil
+}
+
+// SettingsGet returns the daemon's cached CLI feature flag settings.
+// Returns nil with no error if the daemon hasn't fetched settings yet.
+func (c *Client) SettingsGet() (*flags.CLISettingsResponse, error) {
+	resp, err := c.sendMessage(Message{Type: MsgTypeSettingsGet})
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Success {
+		return nil, errors.New(resp.Error)
+	}
+	// null response means daemon has no cached settings
+	if string(resp.Data) == "null" {
+		return nil, nil
+	}
+	var settings flags.CLISettingsResponse
+	if err := json.Unmarshal(resp.Data, &settings); err != nil {
+		return nil, fmt.Errorf("unmarshal settings: %w", err)
+	}
+	return &settings, nil
 }
 
 // SessionFinalize sends a fire-and-forget request to finalize a session.

--- a/internal/daemon/ipc_handlers.go
+++ b/internal/daemon/ipc_handlers.go
@@ -390,6 +390,16 @@ func handleMurmurResume(s *Server, msg Message, _ net.Conn) HandlerResult {
 	return HandlerResult{SkipDefault: true}
 }
 
+func handleSettingsGet(s *Server, _ Message, _ net.Conn) HandlerResult {
+	settings := s.service.SettingsGet()
+	if settings != nil {
+		return HandlerResult{Response: marshalResponse(settings)}
+	}
+	return HandlerResult{
+		Response: &Response{Success: true, Data: json.RawMessage(`null`)},
+	}
+}
+
 func handleWhisperHistory(s *Server, msg Message, _ net.Conn) HandlerResult {
 	var payload WhisperHistoryPayload
 	if err := json.Unmarshal(msg.Payload, &payload); err != nil {

--- a/internal/daemon/ipc_handlers_settings_test.go
+++ b/internal/daemon/ipc_handlers_settings_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/flags"
+)
+
+func TestHandleSettingsGet_WithCachedSettings(t *testing.T) {
+	s := NewServer(nil)
+
+	want := &flags.CLISettingsResponse{
+		Features: flags.CLIFeatures{
+			CodeDB:  boolPtrSettings(true),
+			Whisper: boolPtrSettings(false),
+		},
+		Killswitches: flags.CLIKillswitches{
+			DisableFileDeleteTools: true,
+		},
+		FetchedAt: time.Now(),
+	}
+
+	s.SetSettingsGetHandler(func() *flags.CLISettingsResponse {
+		return want
+	})
+
+	result := handleSettingsGet(s, Message{}, nil)
+	if result.Response == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if !result.Response.Success {
+		t.Fatalf("expected success, got error: %s", result.Response.Error)
+	}
+
+	var got flags.CLISettingsResponse
+	if err := json.Unmarshal(result.Response.Data, &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got.Features.CodeDB == nil || !*got.Features.CodeDB {
+		t.Error("expected CodeDB=true")
+	}
+	if got.Features.Whisper == nil || *got.Features.Whisper {
+		t.Error("expected Whisper=false")
+	}
+	if !got.Killswitches.DisableFileDeleteTools {
+		t.Error("expected DisableFileDeleteTools=true")
+	}
+}
+
+func TestHandleSettingsGet_NilSettings(t *testing.T) {
+	s := NewServer(nil)
+
+	s.SetSettingsGetHandler(func() *flags.CLISettingsResponse {
+		return nil
+	})
+
+	result := handleSettingsGet(s, Message{}, nil)
+	if result.Response == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if !result.Response.Success {
+		t.Fatalf("expected success, got error: %s", result.Response.Error)
+	}
+	if string(result.Response.Data) != `null` {
+		t.Errorf("expected null data, got %s", result.Response.Data)
+	}
+}
+
+func TestHandleSettingsGet_NoHandler(t *testing.T) {
+	s := NewServer(nil)
+	// don't set handler — CallbackService returns nil
+
+	result := handleSettingsGet(s, Message{}, nil)
+	if result.Response == nil {
+		t.Fatal("expected non-nil response")
+	}
+	if !result.Response.Success {
+		t.Fatalf("expected success (nil = no settings yet), got error: %s", result.Response.Error)
+	}
+	if string(result.Response.Data) != `null` {
+		t.Errorf("expected null data, got %s", result.Response.Data)
+	}
+}
+
+// boolPtrSettings avoids conflict with other test files in the package
+func boolPtrSettings(b bool) *bool { return &b }

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/flags"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
@@ -176,6 +177,9 @@ type SyncScheduler struct {
 
 	// tracks last ledger HEAD sha to detect changes and trigger ledger index rebuilds
 	lastLedgerSha string
+
+	// settings fetcher for CLI feature flag polling
+	settingsFetcher *SettingsFetcher
 }
 
 // syncError tracks a sync error with timestamp.
@@ -309,6 +313,12 @@ func (s *SyncScheduler) SetMurmurRelay(r *MurmurRelay) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.murmurRelay = r
+}
+
+func (s *SyncScheduler) SetSettingsFetcher(f *SettingsFetcher) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.settingsFetcher = f
 }
 
 // captureHEAD returns the current HEAD SHA for a git repo.
@@ -634,6 +644,22 @@ func (s *SyncScheduler) Start(ctx context.Context) {
 		}()
 	}
 
+	// CLI settings polling — fetch feature flags from cloud API on a background interval.
+	// Uses CLISettingsMaxAge (1h) as the ticker interval; SettingsFetcher deduplicates internally.
+	var settingsTicker *time.Ticker
+	var settingsChan <-chan time.Time
+	if s.settingsFetcher != nil {
+		settingsTicker = time.NewTicker(flags.CLISettingsMaxAge)
+		settingsChan = settingsTicker.C
+		defer settingsTicker.Stop()
+
+		// initial fetch after short delay (let credentials settle from heartbeat)
+		go func() {
+			time.Sleep(3 * time.Second)
+			s.settingsFetcher.Fetch(ctx)
+		}()
+	}
+
 	// write initial heartbeat
 	s.writeHeartbeats()
 
@@ -698,6 +724,11 @@ func (s *SyncScheduler) Start(ctx context.Context) {
 
 		case <-ledgerIndexChan:
 			s.triggerLedgerIndexRebuild(ctx)
+
+		case <-settingsChan:
+			if s.settingsFetcher != nil {
+				go s.settingsFetcher.Fetch(ctx)
+			}
 
 		case <-s.triggerChan:
 			// watcher-triggered sync: skip sparse-checkout refresh to avoid

--- a/internal/daemon/sync_settings.go
+++ b/internal/daemon/sync_settings.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/flags"
+)
+
+// SettingsFetcher periodically fetches CLI settings from the cloud API
+// and caches them to disk for zero-latency CLI startup.
+type SettingsFetcher struct {
+	logger       *slog.Logger
+	endpoint     string // normalized project endpoint
+	getAuthToken func() string
+
+	mu       sync.Mutex
+	last     *flags.CLISettingsResponse
+	lastFetch time.Time
+	lastErr  error
+}
+
+// NewSettingsFetcher creates a fetcher for the given project endpoint.
+func NewSettingsFetcher(logger *slog.Logger, projectEndpoint string) *SettingsFetcher {
+	return &SettingsFetcher{
+		logger:   logger,
+		endpoint: endpoint.NormalizeEndpoint(projectEndpoint),
+	}
+}
+
+// SetAuthTokenGetter wires the auth token source (typically from heartbeat).
+func (f *SettingsFetcher) SetAuthTokenGetter(fn func() string) {
+	f.getAuthToken = fn
+}
+
+// Fetch calls GET /api/v1/cli/settings and caches the result to disk.
+// Safe to call concurrently; deduplicates within CLISettingsMaxAge.
+func (f *SettingsFetcher) Fetch(ctx context.Context) {
+	f.mu.Lock()
+	if !f.lastFetch.IsZero() && time.Since(f.lastFetch) < flags.CLISettingsMaxAge {
+		f.mu.Unlock()
+		return // dedup: too soon since last fetch
+	}
+	f.lastFetch = time.Now()
+	f.mu.Unlock()
+
+	token := f.resolveAuthToken()
+	if token == "" {
+		f.logger.Debug("settings fetch skipped: no auth token")
+		return
+	}
+
+	client := api.NewRepoClientWithEndpoint(f.endpoint).WithAuthToken(token)
+
+	fetchCtx, cancel := context.WithTimeout(ctx, flags.CLISettingsFetchTimeout)
+	defer cancel()
+	_ = fetchCtx // timeout is on the HTTP request inside GetCLISettings
+
+	rawJSON, err := client.GetCLISettings()
+	if err != nil {
+		f.mu.Lock()
+		f.lastErr = err
+		f.mu.Unlock()
+		f.logger.Warn("cli settings fetch failed", "endpoint", f.endpoint, "err", err)
+		return
+	}
+
+	var resp flags.CLISettingsResponse
+	if err := json.Unmarshal(rawJSON, &resp); err != nil {
+		f.mu.Lock()
+		f.lastErr = err
+		f.mu.Unlock()
+		f.logger.Warn("cli settings unmarshal failed", "err", err)
+		return
+	}
+	resp.FetchedAt = time.Now()
+
+	// cache to disk for CLI startup
+	if err := flags.SaveCachedSettings(f.endpoint, &resp); err != nil {
+		f.logger.Warn("cli settings cache write failed", "err", err)
+	}
+
+	f.mu.Lock()
+	f.last = &resp
+	f.lastErr = nil
+	f.mu.Unlock()
+
+	f.logger.Debug("cli settings fetched and cached", "endpoint", f.endpoint)
+}
+
+// CachedSettings returns the in-memory cached settings (may be nil if never fetched).
+func (f *SettingsFetcher) CachedSettings() *flags.CLISettingsResponse {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.last
+}
+
+// resolveAuthToken gets the auth token from heartbeat or falls back to disk.
+func (f *SettingsFetcher) resolveAuthToken() string {
+	if f.getAuthToken != nil {
+		if t := f.getAuthToken(); t != "" {
+			return t
+		}
+	}
+	// fall back to on-disk auth token
+	tok, err := auth.GetTokenForEndpoint(f.endpoint)
+	if err != nil || tok == nil {
+		return ""
+	}
+	return tok.AccessToken
+}

--- a/internal/daemon/sync_settings_test.go
+++ b/internal/daemon/sync_settings_test.go
@@ -1,0 +1,174 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/flags"
+)
+
+func TestSettingsFetcher_Fetch_CachesResult(t *testing.T) {
+	called := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		if r.URL.Path != "/api/v1/cli/settings" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		resp := flags.CLISettingsResponse{
+			Features: flags.CLIFeatures{
+				CodeDB: boolPtr(true),
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := NewSettingsFetcher(logger, srv.URL)
+	f.SetAuthTokenGetter(func() string { return "test-token" })
+
+	f.Fetch(context.Background())
+
+	if called != 1 {
+		t.Fatalf("expected 1 API call, got %d", called)
+	}
+
+	cached := f.CachedSettings()
+	if cached == nil {
+		t.Fatal("expected cached settings, got nil")
+	}
+	if cached.Features.CodeDB == nil || !*cached.Features.CodeDB {
+		t.Error("expected CodeDB=true in cached settings")
+	}
+}
+
+func TestSettingsFetcher_Fetch_DeduplicatesWithinMaxAge(t *testing.T) {
+	called := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		json.NewEncoder(w).Encode(flags.CLISettingsResponse{})
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := NewSettingsFetcher(logger, srv.URL)
+	f.SetAuthTokenGetter(func() string { return "test-token" })
+
+	// first fetch succeeds
+	f.Fetch(context.Background())
+	// second fetch within CLISettingsMaxAge is deduped
+	f.Fetch(context.Background())
+
+	if called != 1 {
+		t.Fatalf("expected 1 API call (dedup), got %d", called)
+	}
+}
+
+func TestSettingsFetcher_Fetch_SkipsWithoutAuthToken(t *testing.T) {
+	called := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		json.NewEncoder(w).Encode(flags.CLISettingsResponse{})
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := NewSettingsFetcher(logger, srv.URL)
+	// no auth token getter set
+
+	f.Fetch(context.Background())
+
+	if called != 0 {
+		t.Fatalf("expected 0 API calls (no auth), got %d", called)
+	}
+	if f.CachedSettings() != nil {
+		t.Error("expected nil cached settings without auth")
+	}
+}
+
+func TestSettingsFetcher_Fetch_WritesToDiskCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := flags.CLISettingsResponse{
+			Features: flags.CLIFeatures{
+				Whisper: boolPtr(false),
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := NewSettingsFetcher(logger, srv.URL)
+	f.SetAuthTokenGetter(func() string { return "test-token" })
+
+	f.Fetch(context.Background())
+
+	// verify disk cache was written (LoadCachedSettings should find it)
+	cached, err := flags.LoadCachedSettings(srv.URL)
+	if err != nil {
+		t.Fatalf("LoadCachedSettings: %v", err)
+	}
+	if cached == nil {
+		t.Fatal("expected disk-cached settings, got nil")
+	}
+	if cached.Features.Whisper == nil || *cached.Features.Whisper {
+		t.Error("expected Whisper=false in disk cache")
+	}
+}
+
+func TestSettingsFetcher_CachedSettings_NilBeforeFetch(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := NewSettingsFetcher(logger, "https://example.com")
+
+	if f.CachedSettings() != nil {
+		t.Error("expected nil cached settings before any fetch")
+	}
+}
+
+func TestSettingsFetcher_Fetch_HandlesServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := NewSettingsFetcher(logger, srv.URL)
+	f.SetAuthTokenGetter(func() string { return "test-token" })
+
+	f.Fetch(context.Background())
+
+	if f.CachedSettings() != nil {
+		t.Error("expected nil cached settings after server error")
+	}
+}
+
+func TestSettingsFetcher_Fetch_FetchedAtIsSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(flags.CLISettingsResponse{})
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	f := NewSettingsFetcher(logger, srv.URL)
+	f.SetAuthTokenGetter(func() string { return "test-token" })
+
+	before := time.Now()
+	f.Fetch(context.Background())
+	after := time.Now()
+
+	cached := f.CachedSettings()
+	if cached == nil {
+		t.Fatal("expected cached settings")
+	}
+	if cached.FetchedAt.Before(before) || cached.FetchedAt.After(after) {
+		t.Errorf("FetchedAt %v not between %v and %v", cached.FetchedAt, before, after)
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/daemon/testutil/mock_service.go
+++ b/internal/daemon/testutil/mock_service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/flags"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
 
@@ -42,6 +43,9 @@ type MockService struct {
 	SessionFinalizeFunc    func(payload daemon.SessionFinalizeIPCPayload)
 	SessionWatchStartFunc  func(payload daemon.SessionWatchStartPayload)
 	SessionWatchStopFunc   func(payload daemon.SessionWatchStopPayload)
+
+	// settings
+	SettingsGetFunc func() *flags.CLISettingsResponse
 
 	// fire-and-forget operations
 	ActivityFunc  func()
@@ -135,6 +139,13 @@ func (m *MockService) WhisperHistory(agentID string, before time.Time, limit int
 func (m *MockService) CodeStatus() *daemon.CodeDBStats {
 	if m.CodeStatusFunc != nil {
 		return m.CodeStatusFunc()
+	}
+	return nil
+}
+
+func (m *MockService) SettingsGet() *flags.CLISettingsResponse {
+	if m.SettingsGetFunc != nil {
+		return m.SettingsGetFunc()
 	}
 	return nil
 }

--- a/internal/flags/remote.go
+++ b/internal/flags/remote.go
@@ -70,11 +70,9 @@ func RemoteSettingsToPatch(r *CLISettingsResponse) *Patch {
 }
 
 // DaemonProvider reads a pre-fetched CLISettingsResponse from the daemon IPC
-// cache. It is a stub until ox-ha7r wires in the daemon polling loop and IPC
-// handler. Until then, Patch always returns nil (no opinion).
-//
-// Once ox-ha7r lands, this provider is initialized with the daemon-cached
-// response and passes it to RemoteSettingsToPatch.
+// cache. At CLI startup, initFeatureFlags() queries the daemon via IPC
+// (settings_get) and falls back to disk cache. The daemon polls
+// GET /api/v1/cli/settings on a background interval (CLISettingsMaxAge).
 type DaemonProvider struct {
 	// CachedSettings is populated by the daemon IPC settings_get handler.
 	// Nil means the daemon has not yet fetched remote settings.


### PR DESCRIPTION
## Summary

Completes the runtime wiring for the layered feature flag system introduced in #431:

- **Daemon polling**: `SettingsFetcher` created in `initComponents()`, polls `GET /api/v1/cli/settings` on a 1-hour ticker via `SyncScheduler`. Initial fetch after 3s delay to let credentials settle from heartbeat.
- **`settings_get` IPC handler**: Full plumbing through `DaemonService` interface → `CallbackService` → handler → client method. Returns cached `CLISettingsResponse` or `null` if not yet fetched.
- **CLI startup wiring**: `initFeatureFlags()` in `PersistentPreRunE` queries daemon IPC first, falls back to disk cache, then calls `flags.Init(ctx, DaemonProvider{...}, EnvProvider{})`.
- **MockService**: Updated with `SettingsGet()` to satisfy `DaemonService` interface.

```mermaid
sequenceDiagram
    participant Cloud as Cloud API
    participant Daemon as Daemon (SettingsFetcher)
    participant Disk as Disk Cache
    participant CLI as CLI Startup

    Daemon->>Cloud: GET /api/v1/cli/settings (1h interval)
    Cloud-->>Daemon: CLISettingsResponse
    Daemon->>Disk: SaveCachedSettings (per-endpoint file)
    
    CLI->>Daemon: IPC settings_get
    alt daemon has cache
        Daemon-->>CLI: CLISettingsResponse
    else no cache
        CLI->>Disk: LoadCachedSettings(endpoint)
        Disk-->>CLI: CLISettingsResponse (or nil)
    end
    CLI->>CLI: flags.Init(DaemonProvider, EnvProvider)
```

## Test plan

- [x] `TestSettingsFetcher_Fetch_CachesResult` — verifies API call and in-memory cache
- [x] `TestSettingsFetcher_Fetch_DeduplicatesWithinMaxAge` — dedup within 1h window
- [x] `TestSettingsFetcher_Fetch_SkipsWithoutAuthToken` — no API call without auth
- [x] `TestSettingsFetcher_Fetch_WritesToDiskCache` — verifies `SaveCachedSettings` is called
- [x] `TestSettingsFetcher_CachedSettings_NilBeforeFetch` — clean zero-value before first fetch
- [x] `TestSettingsFetcher_Fetch_HandlesServerError` — server 500 doesn't corrupt cache
- [x] `TestSettingsFetcher_Fetch_FetchedAtIsSet` — timestamp is populated
- [x] `TestHandleSettingsGet_WithCachedSettings` — IPC handler returns settings
- [x] `TestHandleSettingsGet_NilSettings` — IPC handler returns null when no settings
- [x] `TestHandleSettingsGet_NoHandler` — IPC handler returns null when no callback set
- [x] `make lint` — 0 issues
- [x] `go build ./...` — clean compile
- [x] `go vet ./...` — clean

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI feature flags now initialize at startup with support for daemon-cached or disk-cached settings.
  * Daemon periodically syncs feature flag settings from the cloud API and caches them locally for quick CLI access.
  * Added IPC messaging for settings retrieval between CLI and daemon.

* **Tests**
  * Added comprehensive test coverage for settings fetching, caching, and IPC handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->