### PR TITLE
fix(murmur): reduce token noise in file-change output

### DIFF
--- a/internal/daemon/file_change_source.go
+++ b/internal/daemon/file_change_source.go
@@ -209,7 +209,7 @@ func (p *FileChangeMurmurPublisher) publish() {
 
 	now := time.Now()
 	branch := repotools.GetCurrentBranch(p.projectRoot)
-	content := formatFileChangeMurmur(changes, branch, p.projectRoot)
+	content := formatFileChangeMurmur(changes, branch)
 	importance := "ambient"
 	if len(changes) > 10 {
 		importance = "normal"
@@ -341,19 +341,13 @@ func buildFileChangeMetadata(changes []FileChange, branch, projectRoot string) m
 }
 
 // formatFileChangeMurmur produces compact, human-scannable change summaries.
-// Files come first (visible in ox murmur list), branch/worktree as compact tag.
+// Files come first (visible in ox murmur list), branch as compact tag.
 // Agents use the JSON metadata for structured data.
-func formatFileChangeMurmur(changes []FileChange, branch, projectRoot string) string {
-	// context tag: [main@myproject]
+func formatFileChangeMurmur(changes []FileChange, branch string) string {
+	// context tag: [main] — worktree name omitted (local-only, noise for teammates)
 	var ctx string
-	worktree := filepath.Base(projectRoot)
-	switch {
-	case branch != "" && worktree != "" && worktree != ".":
-		ctx = fmt.Sprintf("[%s@%s] ", branch, worktree)
-	case branch != "":
+	if branch != "" {
 		ctx = fmt.Sprintf("[%s] ", branch)
-	case worktree != "" && worktree != ".":
-		ctx = fmt.Sprintf("[@%s] ", worktree)
 	}
 
 	count := len(changes)
@@ -368,13 +362,24 @@ func formatFileChangeMurmur(changes []FileChange, branch, projectRoot string) st
 }
 
 // formatSmallChanges lists each file inline (1-5 files).
+// Groups consecutive files with the same change type: "mod a.go, b.go, new c.go"
 func formatSmallChanges(changes []FileChange) string {
+	// sort by type then path so same-type files cluster
 	sort.Slice(changes, func(i, j int) bool {
+		if changes[i].ChangeType != changes[j].ChangeType {
+			return changes[i].ChangeType < changes[j].ChangeType
+		}
 		return changes[i].Path < changes[j].Path
 	})
-	parts := make([]string, len(changes))
-	for i, c := range changes {
-		parts[i] = fmt.Sprintf("%s %s", c.ChangeType, c.Path)
+	var parts []string
+	var curType ChangeType
+	for _, c := range changes {
+		if c.ChangeType != curType {
+			curType = c.ChangeType
+			parts = append(parts, c.ChangeType.Short()+" "+c.Path)
+		} else {
+			parts = append(parts, c.Path)
+		}
 	}
 	return strings.Join(parts, ", ")
 }

--- a/internal/daemon/file_change_source_test.go
+++ b/internal/daemon/file_change_source_test.go
@@ -180,7 +180,31 @@ func TestFormatSmallChanges(t *testing.T) {
 		{Path: "src/config.go", ChangeType: ChangeCreated},
 	}
 	content := formatSmallChanges(changes)
-	assert.Equal(t, "created src/config.go, modified src/main.go", content)
+	assert.Equal(t, "new src/config.go, mod src/main.go", content)
+}
+
+// TestFormatSmallChanges_GroupsSameType verifies consecutive same-type files
+// share one prefix: "mod a.go, b.go" not "mod a.go, mod b.go".
+// Failure prevented: redundant type prefixes waste tokens in murmur output.
+func TestFormatSmallChanges_GroupsSameType(t *testing.T) {
+	changes := []FileChange{
+		{Path: "lib/audio/recorder.cpp", ChangeType: ChangeModified},
+		{Path: "lib/sys/app_flow.cpp", ChangeType: ChangeModified},
+	}
+	content := formatSmallChanges(changes)
+	assert.Equal(t, "mod lib/audio/recorder.cpp, lib/sys/app_flow.cpp", content)
+}
+
+// TestFormatSmallChanges_MixedTypes verifies type prefix reappears when type changes.
+func TestFormatSmallChanges_MixedTypes(t *testing.T) {
+	changes := []FileChange{
+		{Path: "a.go", ChangeType: ChangeCreated},
+		{Path: "b.go", ChangeType: ChangeModified},
+		{Path: "c.go", ChangeType: ChangeModified},
+		{Path: "d.go", ChangeType: ChangeDeleted},
+	}
+	content := formatSmallChanges(changes)
+	assert.Equal(t, "new a.go, del d.go, mod b.go, c.go", content)
 }
 
 func TestFormatMediumChanges(t *testing.T) {
@@ -252,18 +276,17 @@ func TestFormatFileChangeMurmur_IncludesBranchAndWorktree(t *testing.T) {
 	changes := []FileChange{
 		{Path: "src/main.go", ChangeType: ChangeModified},
 	}
-	content := formatFileChangeMurmur(changes, "ajit/feature-branch", "/Users/ajit/src/myproject")
-	assert.Contains(t, content, "[ajit/feature-branch@myproject]")
-	assert.Contains(t, content, "modified src/main.go")
+	content := formatFileChangeMurmur(changes, "ajit/feature-branch")
+	assert.Contains(t, content, "[ajit/feature-branch]")
+	assert.Contains(t, content, "mod src/main.go")
 }
 
 func TestFormatFileChangeMurmur_NoBranch(t *testing.T) {
 	changes := []FileChange{
 		{Path: "README.md", ChangeType: ChangeModified},
 	}
-	content := formatFileChangeMurmur(changes, "", "/Users/ajit/src/myproject")
-	assert.Contains(t, content, "[@myproject]")
-	assert.Contains(t, content, "modified README.md")
+	content := formatFileChangeMurmur(changes, "")
+	assert.Equal(t, "mod README.md", content)
 }
 
 func TestShortenRemoteURL(t *testing.T) {

--- a/internal/daemon/project_watcher.go
+++ b/internal/daemon/project_watcher.go
@@ -24,6 +24,22 @@ const (
 	ChangeRenamed  ChangeType = "renamed"
 )
 
+// Short returns a compact label for human-readable murmur content.
+func (ct ChangeType) Short() string {
+	switch ct {
+	case ChangeCreated:
+		return "new"
+	case ChangeModified:
+		return "mod"
+	case ChangeDeleted:
+		return "del"
+	case ChangeRenamed:
+		return "mv"
+	default:
+		return string(ct)
+	}
+}
+
 // FileChange represents a single observed filesystem change.
 type FileChange struct {
 	Path       string // relative to project root

--- a/tests/ledger_twin/scenarios.go
+++ b/tests/ledger_twin/scenarios.go
@@ -245,13 +245,40 @@ func fileChangeMurmur(t time.Time, id, agentID, principal, branch string, change
 }
 
 // formatFCContent mimics the daemon's formatFileChangeMurmur output.
+// shortChangeType returns compact labels matching daemon's ChangeType.Short().
+func shortChangeType(ct string) string {
+	switch ct {
+	case "created":
+		return "new"
+	case "modified":
+		return "mod"
+	case "deleted":
+		return "del"
+	case "renamed":
+		return "mv"
+	default:
+		return ct
+	}
+}
+
 func formatFCContent(changes []fcEntry, branch string) string {
-	ctx := fmt.Sprintf("[%s@ox] ", branch)
+	ctx := fmt.Sprintf("[%s] ", branch)
 	if len(changes) <= 5 {
-		sort.Slice(changes, func(i, j int) bool { return changes[i].path < changes[j].path })
-		parts := make([]string, len(changes))
-		for i, c := range changes {
-			parts[i] = fmt.Sprintf("%s %s", c.changeType, c.path)
+		sort.Slice(changes, func(i, j int) bool {
+			if changes[i].changeType != changes[j].changeType {
+				return changes[i].changeType < changes[j].changeType
+			}
+			return changes[i].path < changes[j].path
+		})
+		var parts []string
+		var curType string
+		for _, c := range changes {
+			if c.changeType != curType {
+				curType = c.changeType
+				parts = append(parts, shortChangeType(c.changeType)+" "+c.path)
+			} else {
+				parts = append(parts, c.path)
+			}
 		}
 		return ctx + strings.Join(parts, ", ")
 	}


### PR DESCRIPTION
## Summary

- **Drop worktree suffix** from branch context tag (`[branch@dir]` → `[branch]`) — the worktree directory name is local-only and meaningless to teammates
- **Shorten change type labels** in small-format output: `modified` → `mod`, `created` → `new`, `deleted` → `del`, `renamed` → `mv`
- **Group consecutive same-type files** under one prefix: `mod a.go, b.go` instead of `mod a.go, mod b.go`

### Before
```
[ryan/perf-optimizations@speaker] modified firmware/sageox-scribe/lib/audio/recorder.cpp, modified firmware/sageox-scribe/lib/sys/app_flow.cpp
```

### After
```
[ryan/perf-optimizations] mod firmware/sageox-scribe/lib/audio/recorder.cpp, lib/sys/app_flow.cpp
```

## Test plan

- [x] All format tests pass (`TestFormatSmallChanges`, `TestFormatSmallChanges_GroupsSameType`, `TestFormatSmallChanges_MixedTypes`)
- [x] Worktree removal tests pass (`TestFormatFileChangeMurmur_IncludesBranchAndWorktree`, `TestFormatFileChangeMurmur_NoBranch`)
- [x] Medium/large format tests unaffected
- [x] Ledger twin test helper updated to match
- [x] `go build ./...` and `go vet` clean

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File change displays are now more compact, grouping consecutive changes of the same type (e.g., "mod a.go, b.go") instead of repeating type labels for each file
  * Change type labels are now abbreviated for cleaner output
  * Removed unnecessary context from file change messages for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->