### PR TITLE
fix(auth): prevent credential wipe on null tokens JSON; document Better Auth session token pattern

### DIFF
--- a/cmd/ox/doctor_credential_integrity.go
+++ b/cmd/ox/doctor_credential_integrity.go
@@ -25,7 +25,15 @@ func init() {
 }
 
 // checkCredentialIntegrity validates that credential files contain valid JSON.
-// Corrupt files are auto-fixed by removal — the user will re-auth on next use.
+//
+// Scope: STRUCTURAL ONLY. This check tests json.Valid() and nothing else.
+// It intentionally does NOT inspect token expiry, empty access_token, missing
+// fields, or access_token == refresh_token (which is a valid Better Auth state —
+// see StoredToken.EffectiveRefreshToken). Semantic credential issues are handled
+// by the auth refresh flow, not here.
+//
+// Corrupt files (unparseable JSON) are auto-fixed by removal when --fix is passed.
+// The user must re-login after removal.
 func checkCredentialIntegrity(fix bool) checkResult {
 	return checkCredentialIntegrityInDir(paths.ConfigDir(), fix)
 }

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -194,11 +194,15 @@ func Login(ctx context.Context, deviceCode *DeviceCodeResponse, statusCallback f
 				return fmt.Errorf("failed to exchange token for JWT: %w", err)
 			}
 
-			// use JWT as access token, keep original refresh token
+			// Prefer JWT as access token; fall back to the opaque session token when the
+			// JWT exchange endpoint returns an empty access_token. This is a valid Better
+			// Auth configuration where the server does not issue JWTs — the opaque token
+			// is the credential. In this mode access_token == refresh_token is expected
+			// and intentional (see StoredToken.EffectiveRefreshToken). Do NOT treat this
+			// fallback as an error or broken state.
 			accessToken := jwtToken.AccessToken
 			if accessToken == "" {
-				// fallback to original if exchange didn't return a new token
-				slog.Warn("JWT exchange returned empty access_token, falling back to opaque token",
+				slog.Debug("JWT exchange returned empty access_token, using opaque session token (Better Auth mode)",
 					"endpoint", apiURL+"/api/v1/cli/auth/token")
 				accessToken = token.AccessToken
 			}
@@ -543,11 +547,15 @@ func (c *AuthClient) Login(ctx context.Context, deviceCode *DeviceCodeResponse, 
 				return fmt.Errorf("failed to exchange token for JWT: %w", err)
 			}
 
-			// use JWT as access token, keep original refresh token
+			// Prefer JWT as access token; fall back to the opaque session token when the
+			// JWT exchange endpoint returns an empty access_token. This is a valid Better
+			// Auth configuration where the server does not issue JWTs — the opaque token
+			// is the credential. In this mode access_token == refresh_token is expected
+			// and intentional (see StoredToken.EffectiveRefreshToken). Do NOT treat this
+			// fallback as an error or broken state.
 			accessToken := jwtToken.AccessToken
 			if accessToken == "" {
-				// fallback to original if exchange didn't return a new token
-				slog.Warn("JWT exchange returned empty access_token, falling back to opaque token",
+				slog.Debug("JWT exchange returned empty access_token, using opaque session token (Better Auth mode)",
 					"endpoint", apiURL+"/api/v1/cli/auth/token")
 				accessToken = token.AccessToken
 			}

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -38,13 +38,19 @@ type tokenResponse struct {
 	Scope        string `json:"scope"`
 }
 
-// effectiveRefreshToken returns the refresh token, falling back to session_token.
+// effectiveRefreshToken returns the token to use for subsequent refresh grant requests.
+//
+// Better Auth compatibility: some server configurations return session_token instead
+// of (or in addition to) a standard OAuth2 refresh_token. The session token is a
+// long-lived credential that the server accepts as a refresh_token — i.e. sending it
+// as grant_type=refresh_token is correct behavior, not a workaround.
+// See StoredToken.EffectiveRefreshToken for the stored-credential counterpart.
 func (t *tokenResponse) effectiveRefreshToken() string {
 	if t.RefreshToken != "" {
 		return t.RefreshToken
 	}
 	if t.SessionToken != "" {
-		slog.Warn("server returned session_token instead of refresh_token, using as fallback")
+		slog.Debug("server returned session_token instead of refresh_token (Better Auth mode), using as refresh credential")
 		return t.SessionToken
 	}
 	return ""

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -23,15 +23,30 @@ type UserInfo struct {
 type StoredToken struct {
 	AccessToken  string    `json:"access_token"`
 	RefreshToken string    `json:"refresh_token"`
-	SessionToken string    `json:"session_token,omitempty"` // Better Auth fallback for refresh_token
+	// SessionToken is a Better Auth compatibility field. Better Auth servers may issue
+	// a single long-lived session token that serves as BOTH the access token AND the
+	// refresh token — i.e. access_token == refresh_token == session_token is a valid
+	// and intentional state. When the server omits refresh_token but provides
+	// session_token, EffectiveRefreshToken uses session_token so the refresh flow
+	// works correctly. Do NOT treat access_token == refresh_token as a bug.
+	// See PR #299 for the original fix, and refresh.go:effectiveRefreshToken.
+	SessionToken string    `json:"session_token,omitempty"`
 	ExpiresAt    time.Time `json:"expires_at"`
 	TokenType    string    `json:"token_type"`
 	Scope        string    `json:"scope"`
 	UserInfo     UserInfo  `json:"user_info"`
 }
 
-// EffectiveRefreshToken returns the refresh token, falling back to session_token
-// if refresh_token is empty (Better Auth compatibility).
+// EffectiveRefreshToken returns the token to use for refresh grant requests.
+//
+// Better Auth compatibility: some server configurations issue a session_token that
+// acts as a long-lived refresh credential instead of (or in addition to) a standard
+// OAuth2 refresh_token. In these configurations access_token == refresh_token is
+// normal and expected — the opaque session token can legitimately be sent as the
+// refresh_token in a grant_type=refresh_token request.
+//
+// When the session expires server-side the refresh will return 401/authentication_required,
+// which is correct — the user must re-login. This is not a client bug.
 func (t *StoredToken) EffectiveRefreshToken() string {
 	if t.RefreshToken != "" {
 		return t.RefreshToken
@@ -110,21 +125,37 @@ func loadAuthStore() (*AuthStore, error) {
 		return nil, fmt.Errorf("failed to read auth file: %w", err)
 	}
 
-	// try new multi-endpoint format first
-	var store AuthStore
-	if err := json.Unmarshal(data, &store); err == nil && store.Tokens != nil {
+	// Distinguish new multi-endpoint format from legacy single-token format by probing
+	// for the "tokens" key. This is necessary because both formats produce
+	// store.Tokens == nil after a bare json.Unmarshal (legacy has no "tokens" key;
+	// new format may have "tokens": null). We must not fall through to legacy
+	// migration for new-format files — doing so would overwrite the file with an
+	// empty zero-value StoredToken, silently wiping all credentials.
+	var probe struct {
+		Tokens json.RawMessage `json:"tokens"`
+	}
+	if json.Unmarshal(data, &probe) == nil && probe.Tokens != nil {
+		// "tokens" key is present — this is the new multi-endpoint format.
+		// Parse and normalize; treat null/empty tokens map as an empty store.
+		var store AuthStore
+		if err := json.Unmarshal(data, &store); err != nil {
+			return nil, fmt.Errorf("failed to parse auth file: %w", err)
+		}
+		if store.Tokens == nil {
+			store.Tokens = make(map[string]*StoredToken)
+		}
 		normalizeTokenKeys(&store)
 		return &store, nil
 	}
 
-	// migrate from legacy single-token format
+	// No "tokens" key — migrate from legacy single-token format.
 	var legacyToken StoredToken
 	if err := json.Unmarshal(data, &legacyToken); err != nil {
 		return nil, fmt.Errorf("failed to parse auth file: %w", err)
 	}
 
 	// migrate legacy token to new format using default endpoint
-	store = AuthStore{
+	store := AuthStore{
 		Tokens: map[string]*StoredToken{
 			endpoint.Get(): &legacyToken,
 		},
@@ -364,14 +395,24 @@ func (c *AuthClient) loadAuthStore() (*AuthStore, error) {
 		return nil, fmt.Errorf("failed to read auth file: %w", err)
 	}
 
-	// try new multi-endpoint format first
-	var store AuthStore
-	if err := json.Unmarshal(data, &store); err == nil && store.Tokens != nil {
+	// Distinguish new multi-endpoint format from legacy single-token format by probing
+	// for the "tokens" key. See the package-level loadAuthStore for the full rationale.
+	var probe struct {
+		Tokens json.RawMessage `json:"tokens"`
+	}
+	if json.Unmarshal(data, &probe) == nil && probe.Tokens != nil {
+		var store AuthStore
+		if err := json.Unmarshal(data, &store); err != nil {
+			return nil, fmt.Errorf("failed to parse auth file: %w", err)
+		}
+		if store.Tokens == nil {
+			store.Tokens = make(map[string]*StoredToken)
+		}
 		normalizeTokenKeys(&store)
 		return &store, nil
 	}
 
-	// migrate from legacy single-token format
+	// No "tokens" key — migrate from legacy single-token format.
 	var legacyToken StoredToken
 	if err := json.Unmarshal(data, &legacyToken); err != nil {
 		return nil, fmt.Errorf("failed to parse auth file: %w", err)
@@ -382,7 +423,7 @@ func (c *AuthClient) loadAuthStore() (*AuthStore, error) {
 	if ep == "" {
 		ep = endpoint.Get()
 	}
-	store = AuthStore{
+	store := AuthStore{
 		Tokens: map[string]*StoredToken{
 			ep: &legacyToken,
 		},

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -798,6 +798,145 @@ func TestLoadAuthStore_LegacyMigration(t *testing.T) {
 	}
 }
 
+// TestLoadAuthStore_NullTokensField verifies that {"tokens": null} is treated as an
+// empty store and does NOT fall through to legacy migration, which would overwrite
+// auth.json with a zero-value StoredToken and silently wipe all credentials.
+func TestLoadAuthStore_NullTokensField(t *testing.T) {
+	t.Parallel()
+
+	client := NewTestClient(t)
+
+	authPath, err := client.GetAuthFilePath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(authPath), 0700))
+	require.NoError(t, os.WriteFile(authPath, []byte(`{"tokens": null}`), 0600))
+
+	store, err := client.loadAuthStore()
+	require.NoError(t, err, `{"tokens": null} is valid JSON and should not error`)
+	require.NotNil(t, store)
+	assert.Empty(t, store.Tokens, "null tokens should yield an empty store, not a migrated zero-value token")
+
+	// the file must not have been overwritten with a zero-value token
+	raw, err := os.ReadFile(authPath)
+	require.NoError(t, err)
+	var onDisk AuthStore
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	for ep, tok := range onDisk.Tokens {
+		assert.NotEmpty(t, tok.AccessToken,
+			"disk must not contain a zero-value token for endpoint %s after null-tokens load", ep)
+	}
+}
+
+// TestSaveGetToken_SurvivesNullTokensOnDisk verifies the full observable contract:
+// after auth.json is overwritten externally with {"tokens": null}, GetToken must
+// return nil (no token) and must NOT persist a zero-value token to disk.
+func TestSaveGetToken_SurvivesNullTokensOnDisk(t *testing.T) {
+	t.Parallel()
+
+	client := NewTestClient(t)
+	_ = CreateTestTokenForClient(t, client, time.Hour)
+
+	// simulate external corruption
+	authPath, err := client.GetAuthFilePath()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(authPath, []byte(`{"tokens": null}`), 0600))
+
+	tok, err := client.GetToken()
+	require.NoError(t, err)
+
+	// correct behavior: nil token (no credentials), never a zero-value token
+	if tok != nil {
+		assert.NotEmpty(t, tok.AccessToken,
+			"GetToken must never return a zero-value token from a null-tokens file")
+	}
+
+	// disk must not have been silently rewritten with a zero-value token
+	raw, readErr := os.ReadFile(authPath)
+	require.NoError(t, readErr)
+	var onDisk AuthStore
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	for ep, stored := range onDisk.Tokens {
+		assert.NotEmpty(t, stored.AccessToken,
+			"disk must not contain a zero-value token for endpoint %s", ep)
+	}
+}
+
+// TestLegacyMigration_TokenStoredUnderClientEndpoint verifies that a legacy
+// single-token file is migrated under the client's configured endpoint, not the
+// global default. A client configured for a custom endpoint must be able to read
+// back a migrated legacy token without needing to know the default endpoint.
+func TestLegacyMigration_TokenStoredUnderClientEndpoint(t *testing.T) {
+	t.Parallel()
+
+	customEndpoint := "https://custom.example.com"
+	client := NewTestClient(t).WithEndpoint(customEndpoint)
+
+	// write legacy single-token format (no "tokens" key)
+	legacyToken := StoredToken{
+		AccessToken:  "legacy-access",
+		RefreshToken: "legacy-refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		TokenType:    "Bearer",
+		UserInfo:     UserInfo{UserID: "user-legacy", Email: "legacy@example.com"},
+	}
+	data, err := json.Marshal(legacyToken)
+	require.NoError(t, err)
+
+	authPath, err := client.GetAuthFilePath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(authPath), 0700))
+	require.NoError(t, os.WriteFile(authPath, data, 0600))
+
+	// the client must be able to retrieve the token via its configured endpoint
+	tok, err := client.GetToken()
+	require.NoError(t, err)
+	require.NotNil(t, tok, "migrated legacy token must be retrievable via client's endpoint")
+	assert.Equal(t, "legacy-access", tok.AccessToken)
+
+	// the on-disk key must match the client's endpoint, not a global default
+	raw, err := os.ReadFile(authPath)
+	require.NoError(t, err)
+	var onDisk struct {
+		Tokens map[string]json.RawMessage `json:"tokens"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	_, found := onDisk.Tokens[customEndpoint]
+	assert.True(t, found,
+		"migrated token should be keyed under %q, got keys: %v",
+		customEndpoint, tokenKeys(onDisk.Tokens))
+}
+
+// TestNormalizeTokenKeys_CollisionSameExpiryIsStable verifies that when two
+// keys normalize to the same endpoint and have identical ExpiresAt, exactly one
+// token survives with a non-empty AccessToken (no panic, no empty slot).
+func TestNormalizeTokenKeys_CollisionSameExpiryIsStable(t *testing.T) {
+	t.Parallel()
+
+	expiry := time.Now().Add(time.Hour)
+	store := &AuthStore{
+		Tokens: map[string]*StoredToken{
+			"https://api.sageox.ai": {AccessToken: "token-a", ExpiresAt: expiry},
+			"https://www.sageox.ai": {AccessToken: "token-b", ExpiresAt: expiry},
+		},
+	}
+
+	normalizeTokenKeys(store)
+
+	assert.Len(t, store.Tokens, 1, "exactly one token should survive a same-expiry collision")
+	surviving := store.Tokens["https://sageox.ai"]
+	require.NotNil(t, surviving, "normalized key must exist after collision")
+	assert.NotEmpty(t, surviving.AccessToken, "surviving token must not be zero-value")
+}
+
+// tokenKeys extracts the keys of a map for use in test failure messages.
+func tokenKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 func TestLoadAuthStore_TruncatedJSON(t *testing.T) {
 	t.Parallel()
 	client := NewTestClient(t)


### PR DESCRIPTION
## Summary

- **Bug fix**: `{"tokens": null}` in `auth.json` previously fell through to legacy single-token migration, silently overwriting all credentials with a zero-value `StoredToken`. Fixed by probing for the `"tokens"` key via `json.RawMessage` before deciding which parse path to take.
- **Documentation**: Clarified throughout that `access_token == refresh_token` is a valid and intentional Better Auth configuration (opaque session token serves as both). Downgraded misleading `Warn` logs to `Debug` in `device_flow.go` and `refresh.go`.
- **Test coverage**: 4 new tests covering the confirmed bugs and edge cases the test engineer identified as uncovered.

## What was broken

`loadAuthStore` used `store.Tokens != nil` to detect the new multi-endpoint format. Both `{"tokens": null}` (valid JSON with an explicit null) and the legacy single-token format produce `store.Tokens == nil` after `json.Unmarshal`. This meant a file containing `{"tokens": null}` — writable by any partial serializer, script, or bug — would:

1. Pass `json.Valid()` (the integrity check) without being caught
2. Fall through to legacy migration
3. Get `saveAuthStore` called with an empty `StoredToken` under `endpoint.Get()`
4. Silently wipe all real credentials with no error returned

## Fix

```go
// probe for the "tokens" key to distinguish formats
var probe struct {
    Tokens json.RawMessage `json:"tokens"`
}
if json.Unmarshal(data, &probe) == nil && probe.Tokens != nil {
    // "tokens" key present → new format; null map → empty store, not migration
    ...
}
// no "tokens" key → legacy format
```

`probe.Tokens` is `nil` only when the key is absent. `{"tokens": null}` sets it to `[]byte("null")`, which is not nil — it enters the new-format branch and returns an empty store.

## Tests added

| Test | Intent |
|---|---|
| `TestLoadAuthStore_NullTokensField` | `{"tokens": null}` returns empty store, does not rewrite disk |
| `TestSaveGetToken_SurvivesNullTokensOnDisk` | `GetToken` after external null-tokens corruption returns nil, never a zero-value token |
| `TestLegacyMigration_TokenStoredUnderClientEndpoint` | Legacy migration key matches the client's configured endpoint, not the hardcoded default |
| `TestNormalizeTokenKeys_CollisionSameExpiryIsStable` | Equal-expiry collision leaves exactly one non-empty token |

## Test plan

- [ ] `go test ./internal/auth/...` passes
- [ ] `go test ./cmd/ox/...` passes
- [ ] `ox login` still works after this change
- [ ] Manual: write `{"tokens": null}` to `~/.config/sageox/auth.json`, run `ox status` — should report "not authenticated", not crash or corrupt the file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified credential integrity validation scope: validates JSON structure only, not semantic correctness (expiry, fields, token values)

* **New Features**
  * Added support for new token storage format with multiple endpoint support
  * Improved automatic legacy token format migration

* **Improvements**
  * Enhanced Better Auth mode fallback handling with refined logging
  * Better edge case handling for null tokens and credential migration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->