### PR TITLE
fix(daemon): close leaked file descriptors in workspace scanning

### DIFF
--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -323,6 +323,7 @@ func IndexLocalRepo(ctx context.Context, s *store.Store, localPath string, opts 
 	if err != nil {
 		return fmt.Errorf("open local repo %s: %w", localPath, err)
 	}
+	defer repo.Close()
 
 	// 2. Upsert repo record — use the local path as both name and path
 	repoName := filepath.Base(localPath)

--- a/internal/codedb/index/indexer_coverage_localrepo_test.go
+++ b/internal/codedb/index/indexer_coverage_localrepo_test.go
@@ -2,7 +2,12 @@ package index
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+
+	"github.com/sageox/ox/internal/testguard"
 )
 
 // --- IndexLocalRepo ---
@@ -12,6 +17,7 @@ func TestIndexLocalRepo_Idempotent(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short: git indexing")
 	}
+	testguard.RequireNoFDLeak(t)
 	dir, _ := initGitRepo(t, 3)
 	s := openTestStore(t)
 
@@ -168,6 +174,56 @@ func TestIndexLocalRepo_RefsRecorded(t *testing.T) {
 	}
 	if refName != "refs/heads/main" {
 		t.Errorf("expected ref refs/heads/main, got %q", refName)
+	}
+}
+
+// --- FD leak regression ---
+
+// TestIndexLocalRepo_NoFDLeak verifies that repeated IndexLocalRepo calls
+// don't leak file descriptors. go-git opens packfiles with KeepDescriptors
+// for performance — without repo.Close(), each call leaks those FDs.
+// Failure prevented: daemon exhausts FD limit after many indexing cycles.
+func TestIndexLocalRepo_NoFDLeak(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git indexing")
+	}
+	testguard.RequireNoFDLeak(t)
+
+	dir, _ := initGitRepo(t, 20)
+
+	// force packfile creation — KeepDescriptors only leaks when packfiles exist
+	gitGC := exec.Command("git", "gc", "--aggressive")
+	gitGC.Dir = dir
+	gitGC.Env = append(os.Environ(), // safe: git CLI in temp dir
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@sageox.ai",
+	)
+	if out, err := gitGC.CombinedOutput(); err != nil {
+		t.Fatalf("git gc: %s: %v", out, err)
+	}
+
+	// verify packfile was created
+	packDir := filepath.Join(dir, ".git", "objects", "pack")
+	entries, _ := os.ReadDir(packDir)
+	hasPack := false
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".pack" {
+			hasPack = true
+			break
+		}
+	}
+	if !hasPack {
+		t.Skip("git gc did not create a packfile")
+	}
+
+	s := openTestStore(t)
+
+	// index 10 times — without Close(), this leaked ~2 FDs per call
+	for i := 0; i < 10; i++ {
+		if err := IndexLocalRepo(context.Background(), s, dir, IndexOptions{}); err != nil {
+			t.Fatalf("IndexLocalRepo pass %d: %v", i+1, err)
+		}
 	}
 }
 

--- a/internal/daemon/project_watcher.go
+++ b/internal/daemon/project_watcher.go
@@ -406,6 +406,7 @@ func (pw *ProjectWatcher) Start(ctx context.Context) {
 
 		case <-refreshTicker.C:
 			pw.tracker.Refresh()
+			pw.pruneStaleWatches(watcher)
 		}
 	}
 }
@@ -482,11 +483,15 @@ func (pw *ProjectWatcher) handleEvent(watcher FileSystemWatcher, event fsnotify.
 		}
 	}
 
-	// directory removed — remove from tracked set
+	// directory removed — remove from tracked set and release kqueue/inotify FD
 	if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
 		pw.mu.Lock()
+		_, wasWatched := pw.watchedDirs[event.Name]
 		delete(pw.watchedDirs, event.Name)
 		pw.mu.Unlock()
+		if wasWatched {
+			_ = watcher.Remove(event.Name)
+		}
 	}
 
 	// only pass through tracked files (or newly created files that may become tracked)
@@ -495,6 +500,39 @@ func (pw *ProjectWatcher) handleEvent(watcher FileSystemWatcher, event fsnotify.
 	}
 
 	pw.accumulator.AddEvent(relPath, event.Op, isDir)
+}
+
+// pruneStaleWatches removes watches for directories that are no longer
+// git-tracked. Called after each tracker.Refresh() to release kqueue/inotify
+// FDs for directories that were transiently watched (build outputs, temp dirs).
+func (pw *ProjectWatcher) pruneStaleWatches(watcher FileSystemWatcher) {
+	pw.mu.Lock()
+	snapshot := make(map[string]struct{}, len(pw.watchedDirs))
+	for d := range pw.watchedDirs {
+		snapshot[d] = struct{}{}
+	}
+	pw.mu.Unlock()
+
+	var pruned int
+	for absDir := range snapshot {
+		if absDir == pw.projectRoot {
+			continue
+		}
+		relDir, err := filepath.Rel(pw.projectRoot, absDir)
+		if err != nil {
+			continue
+		}
+		if !pw.tracker.IsTrackedDir(relDir) {
+			_ = watcher.Remove(absDir)
+			pw.mu.Lock()
+			delete(pw.watchedDirs, absDir)
+			pw.mu.Unlock()
+			pruned++
+		}
+	}
+	if pruned > 0 {
+		pw.logger.Info("project watcher: pruned stale watches", "count", pruned)
+	}
 }
 
 // WatchedDirCount returns the number of directories being watched.

--- a/internal/daemon/project_watcher_test.go
+++ b/internal/daemon/project_watcher_test.go
@@ -583,3 +583,185 @@ func TestChangeAccumulator_OnSettledNotCalledWhenEmpty(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	assert.Equal(t, int64(1), atomic.LoadInt64(&count), "callback should not fire with no pending changes")
 }
+
+// --- FD leak regression tests ---
+
+// TestProjectWatcher_RemoveOnDirectoryDelete verifies that deleting a watched
+// directory calls watcher.Remove() to release the kqueue/inotify FD.
+// Without this fix, deleted directory watches leak FDs indefinitely.
+func TestProjectWatcher_RemoveOnDirectoryDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: watcher polling")
+	}
+	mockWatcher := NewMockFileSystemWatcher()
+	mockFS := NewMockFileSystem()
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0755))
+	mockFS.AddDir(srcDir, nil)
+
+	acc := NewChangeAccumulator(50 * time.Millisecond)
+	defer acc.Stop()
+
+	tracker := &GitTrackedMatcher{
+		projectRoot:  dir,
+		trackedDirs:  map[string]struct{}{"src": {}},
+		trackedFiles: map[string]struct{}{},
+		logger:       slogDiscard(),
+	}
+
+	pw := NewProjectWatcher(
+		dir, slogDiscard(),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS, acc, tracker,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		pw.Start(ctx)
+		close(done)
+	}()
+
+	// wait for initial watches
+	require.Eventually(t, func() bool {
+		return len(mockWatcher.AddedPaths()) >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// simulate directory deletion
+	mockFS.SetStatError(srcDir, os.ErrNotExist)
+	mockWatcher.SendEvent(fsnotify.Event{
+		Name: srcDir,
+		Op:   fsnotify.Remove,
+	})
+
+	// verify Remove() was called
+	require.Eventually(t, func() bool {
+		return len(mockWatcher.RemovedPaths()) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	removed := mockWatcher.RemovedPaths()
+	assert.Contains(t, removed, srcDir, "watcher.Remove must be called for deleted directory")
+	assert.Equal(t, 1, pw.WatchedDirCount(), "only root should remain watched")
+
+	cancel()
+	<-done
+}
+
+// TestProjectWatcher_PruneStaleWatches verifies that directories which are no
+// longer git-tracked are pruned on the next refresh cycle.
+// Without this, non-tracked directories (build/, tmp/) accumulate watches.
+func TestProjectWatcher_PruneStaleWatches(t *testing.T) {
+	mockWatcher := NewMockFileSystemWatcher()
+	mockFS := NewMockFileSystem()
+
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	buildDir := filepath.Join(dir, "build")
+	require.NoError(t, os.MkdirAll(srcDir, 0755))
+	require.NoError(t, os.MkdirAll(buildDir, 0755))
+	mockFS.AddDir(srcDir, nil)
+	mockFS.AddDir(buildDir, nil)
+
+	acc := NewChangeAccumulator(50 * time.Millisecond)
+	defer acc.Stop()
+
+	tracker := &GitTrackedMatcher{
+		projectRoot:  dir,
+		trackedDirs:  map[string]struct{}{"src": {}, "build": {}},
+		trackedFiles: map[string]struct{}{},
+		logger:       slogDiscard(),
+	}
+
+	pw := NewProjectWatcher(
+		dir, slogDiscard(),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS, acc, tracker,
+	)
+
+	// simulate walkAndWatch to populate watchedDirs
+	pw.walkAndWatch(mockWatcher)
+	require.Equal(t, 3, pw.WatchedDirCount(), "root + src + build")
+
+	// now remove "build" from tracked dirs (simulating git branch switch)
+	tracker.mu.Lock()
+	delete(tracker.trackedDirs, "build")
+	tracker.mu.Unlock()
+
+	// prune
+	pw.pruneStaleWatches(mockWatcher)
+
+	assert.Equal(t, 2, pw.WatchedDirCount(), "root + src should remain")
+	removed := mockWatcher.RemovedPaths()
+	assert.Contains(t, removed, buildDir, "build dir should be pruned")
+}
+
+// TestProjectWatcher_FDStability verifies that Add and Remove counts stay
+// balanced across create+delete cycles — the core FD leak invariant.
+func TestProjectWatcher_FDStability(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: watcher polling")
+	}
+	mockWatcher := NewMockFileSystemWatcher()
+	mockFS := NewMockFileSystem()
+
+	dir := t.TempDir()
+	acc := NewChangeAccumulator(50 * time.Millisecond)
+	defer acc.Stop()
+
+	tracker := &GitTrackedMatcher{
+		projectRoot:  dir,
+		trackedDirs:  map[string]struct{}{},
+		trackedFiles: map[string]struct{}{},
+		logger:       slogDiscard(),
+	}
+
+	pw := NewProjectWatcher(
+		dir, slogDiscard(),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS, acc, tracker,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		pw.Start(ctx)
+		close(done)
+	}()
+
+	// wait for root watch
+	require.Eventually(t, func() bool {
+		return len(mockWatcher.AddedPaths()) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	initialAdds := len(mockWatcher.AddedPaths())
+
+	// simulate 10 create+delete directory cycles
+	for i := 0; i < 10; i++ {
+		tmpDir := filepath.Join(dir, "tmp", time.Now().Format("150405.000"))
+		mockFS.AddDir(tmpDir, nil)
+		mockWatcher.SendEvent(fsnotify.Event{Name: tmpDir, Op: fsnotify.Create})
+
+		// wait for add
+		time.Sleep(20 * time.Millisecond)
+
+		// delete
+		mockFS.SetStatError(tmpDir, os.ErrNotExist)
+		mockWatcher.SendEvent(fsnotify.Event{Name: tmpDir, Op: fsnotify.Remove})
+
+		// wait for remove
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// allow events to settle
+	time.Sleep(100 * time.Millisecond)
+
+	adds := len(mockWatcher.AddedPaths()) - initialAdds
+	removes := len(mockWatcher.RemovedPaths())
+	assert.Equal(t, adds, removes,
+		"every Add from a create event must have a matching Remove on delete (adds=%d, removes=%d)", adds, removes)
+
+	cancel()
+	<-done
+}

--- a/internal/daemon/watcher.go
+++ b/internal/daemon/watcher.go
@@ -20,6 +20,9 @@ type FileSystemWatcher interface {
 	// Add adds a path to the watch list.
 	Add(path string) error
 
+	// Remove removes a path from the watch list, releasing its file descriptor.
+	Remove(path string) error
+
 	// Events returns the channel for receiving file system events.
 	Events() <-chan fsnotify.Event
 
@@ -56,6 +59,11 @@ func NewRealFileSystemWatcher() (*RealFileSystemWatcher, error) {
 // Add adds a path to the watch list.
 func (r *RealFileSystemWatcher) Add(path string) error {
 	return r.watcher.Add(path)
+}
+
+// Remove removes a path from the watch list, releasing its file descriptor.
+func (r *RealFileSystemWatcher) Remove(path string) error {
+	return r.watcher.Remove(path)
 }
 
 // Events returns the channel for receiving file system events.
@@ -255,20 +263,23 @@ func (w *Watcher) debounce() {
 // MockFileSystemWatcher implements FileSystemWatcher for testing.
 // It allows tests to inject events and errors without real filesystem operations.
 type MockFileSystemWatcher struct {
-	events     chan fsnotify.Event
-	errors     chan error
-	addedPaths []string
-	addErr     error
-	closeErr   error
-	mu         sync.Mutex
+	events       chan fsnotify.Event
+	errors       chan error
+	addedPaths   []string
+	removedPaths []string
+	addErr       error
+	removeErr    error
+	closeErr     error
+	mu           sync.Mutex
 }
 
 // NewMockFileSystemWatcher creates a new mock watcher for testing.
 func NewMockFileSystemWatcher() *MockFileSystemWatcher {
 	return &MockFileSystemWatcher{
-		events:     make(chan fsnotify.Event, 100),
-		errors:     make(chan error, 10),
-		addedPaths: make([]string, 0),
+		events:       make(chan fsnotify.Event, 100),
+		errors:       make(chan error, 10),
+		addedPaths:   make([]string, 0),
+		removedPaths: make([]string, 0),
 	}
 }
 
@@ -278,6 +289,14 @@ func (m *MockFileSystemWatcher) Add(path string) error {
 	defer m.mu.Unlock()
 	m.addedPaths = append(m.addedPaths, path)
 	return m.addErr
+}
+
+// Remove records the path removal and returns the configured error (if any).
+func (m *MockFileSystemWatcher) Remove(path string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removedPaths = append(m.removedPaths, path)
+	return m.removeErr
 }
 
 // Events returns the events channel.
@@ -329,6 +348,22 @@ func (m *MockFileSystemWatcher) SetAddError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.addErr = err
+}
+
+// RemovedPaths returns the paths that were removed from the watcher.
+func (m *MockFileSystemWatcher) RemovedPaths() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	paths := make([]string, len(m.removedPaths))
+	copy(paths, m.removedPaths)
+	return paths
+}
+
+// SetRemoveError configures the error to return from Remove().
+func (m *MockFileSystemWatcher) SetRemoveError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removeErr = err
 }
 
 // SetCloseError configures the error to return from Close().

--- a/internal/daemon/watcher_test.go
+++ b/internal/daemon/watcher_test.go
@@ -888,3 +888,18 @@ func TestWatcher_ContextCancelCallsStop(t *testing.T) {
 	assert.True(t, w.stopped)
 	w.mu.Unlock()
 }
+
+// --- MockFileSystemWatcher.Remove tests ---
+
+func TestMockFileSystemWatcher_Remove(t *testing.T) {
+	mock := NewMockFileSystemWatcher()
+
+	require.NoError(t, mock.Remove("/path/a"))
+	require.NoError(t, mock.Remove("/path/b"))
+	assert.Equal(t, []string{"/path/a", "/path/b"}, mock.RemovedPaths())
+
+	mock.SetRemoveError(errors.New("not watched"))
+	err := mock.Remove("/path/c")
+	assert.Error(t, err)
+	assert.Equal(t, 3, len(mock.RemovedPaths()), "path still recorded even on error")
+}

--- a/internal/testguard/fdleak.go
+++ b/internal/testguard/fdleak.go
@@ -1,0 +1,71 @@
+package testguard
+
+import (
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// RequireNoFDLeak snapshots the open file descriptor count at call time and
+// registers a t.Cleanup that fails the test if FDs grew beyond a small delta.
+// Use it in any test that exercises resource-acquiring code (fsnotify watchers,
+// go-git repos, database connections) to catch leaked handles.
+//
+// The allowed delta accounts for runtime noise (GC finalizers, runtime file
+// table resizing). Set it higher only if the test legitimately opens
+// long-lived descriptors that outlive the cleanup.
+//
+// Platforms: works on macOS and Linux via dup2 probing.
+// Silently skips on unsupported platforms (Windows).
+func RequireNoFDLeak(t *testing.T) {
+	t.Helper()
+	RequireNoFDLeakWithDelta(t, 5)
+}
+
+// RequireNoFDLeakWithDelta is like RequireNoFDLeak but accepts a custom delta.
+func RequireNoFDLeakWithDelta(t *testing.T, allowedDelta int) {
+	t.Helper()
+
+	before := countOpenFDs()
+	if before < 0 {
+		return // unsupported platform
+	}
+
+	t.Cleanup(func() {
+		// let finalizers and deferred closes run
+		runtime.GC()
+		time.Sleep(50 * time.Millisecond)
+		runtime.GC()
+
+		after := countOpenFDs()
+		if after < 0 {
+			return
+		}
+		leaked := after - before
+		if leaked > allowedDelta {
+			t.Errorf("FD leak detected: %d open before test, %d after (+%d, allowed +%d)",
+				before, after, leaked, allowedDelta)
+		}
+	})
+}
+
+// maxFDProbe is the upper bound for FD probing. 8192 covers typical ulimit -n
+// defaults and is fast enough (single syscall per FD, ~1ms total).
+const maxFDProbe = 8192
+
+// countOpenFDs counts open file descriptors by probing with fcntl(F_GETFD).
+// Returns -1 on unsupported platforms.
+func countOpenFDs() int {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		return -1
+	}
+	count := 0
+	for fd := 0; fd < maxFDProbe; fd++ {
+		_, _, err := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_GETFD, 0)
+		if err == 0 {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/testguard/fdleak_test.go
+++ b/internal/testguard/fdleak_test.go
@@ -1,0 +1,50 @@
+package testguard
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountOpenFDs(t *testing.T) {
+	count := countOpenFDs()
+	if count < 0 {
+		t.Skip("FD counting not supported on this platform")
+	}
+	// any running process has at least stdin/stdout/stderr
+	assert.GreaterOrEqual(t, count, 3, "should have at least 3 FDs (stdin/stdout/stderr)")
+}
+
+func TestCountOpenFDs_DetectsDelta(t *testing.T) {
+	before := countOpenFDs()
+	if before < 0 {
+		t.Skip("FD counting not supported on this platform")
+	}
+
+	// open 5 FDs
+	files := make([]*os.File, 5)
+	for i := range files {
+		f, err := os.Open("/dev/null")
+		if err != nil {
+			t.Fatalf("open /dev/null: %v", err)
+		}
+		files[i] = f
+	}
+
+	after := countOpenFDs()
+	assert.GreaterOrEqual(t, after-before, 4, "opening 5 files should increase FD count by at least 4")
+
+	// close them
+	for _, f := range files {
+		f.Close()
+	}
+
+	final := countOpenFDs()
+	assert.InDelta(t, before, final, 2, "FD count should return to baseline after closing")
+}
+
+func TestRequireNoFDLeak_PassesWhenClean(t *testing.T) {
+	// verifies the helper doesn't false-positive on a clean test
+	RequireNoFDLeak(t)
+}


### PR DESCRIPTION
## Summary

Fixes #443 — the ox daemon accumulated ~4977 open file descriptors over time, exhausting system resources and causing ENOSPC errors on macOS.

**Two root causes identified and fixed:**

- **kqueue FD leak in ProjectWatcher**: The `FileSystemWatcher` interface had no `Remove()` method, so when watched directories were deleted or renamed, the kqueue file descriptor was never released. Added `Remove()` to the interface and wired it into `handleEvent()` on directory deletion. Also added `pruneStaleWatches()` to clean up watches for directories that are no longer git-tracked (build outputs, temp dirs) on each refresh cycle.

- **go-git packfile FD leak in IndexLocalRepo**: `plainOpenTolerant()` opens repos with `KeepDescriptors: true` for performance (caches packfile FDs across reads), but `IndexLocalRepo` never called `repo.Close()`. Added `defer repo.Close()`.

**Prevention infrastructure:**

- **`testguard.RequireNoFDLeak(t)`** — new test helper (analogous to Uber's `goleak` for goroutines) that snapshots open FD count before a test and fails in `t.Cleanup` if FDs grew. Uses `fcntl(F_GETFD)` probing — works on macOS and Linux, silently skips on unsupported platforms. Drop one line into any test to guard against future FD leaks.

```mermaid
flowchart TD
    A[Directory deleted] -->|fsnotify Remove event| B[handleEvent]
    B -->|"NEW: watcher.Remove(path)"| C[kqueue FD released]
    B -->|"OLD: no Remove call"| D[kqueue FD leaked forever]
    
    E[Refresh ticker fires] --> F[tracker.Refresh]
    F --> G["NEW: pruneStaleWatches()"]
    G -->|"non-tracked dirs"| H[watcher.Remove + delete from map]
    
    I[IndexLocalRepo called] --> J[plainOpenTolerant]
    J -->|"KeepDescriptors: true"| K[packfile FDs cached]
    K -->|"NEW: defer repo.Close()"| L[FDs released on return]
    K -->|"OLD: no Close()"| M[FDs leaked per call]
```

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — 12267 tests pass, 854 skipped
- [x] New tests:
  - `TestProjectWatcher_RemoveOnDirectoryDelete` — verifies `Remove()` called on dir deletion
  - `TestProjectWatcher_PruneStaleWatches` — verifies stale watches cleaned on refresh
  - `TestProjectWatcher_FDStability` — Add/Remove counts balanced across create+delete cycles
  - `TestMockFileSystemWatcher_Remove` — mock Remove with error injection
  - `TestIndexLocalRepo_NoFDLeak` — 10x repeated indexing with packfiles + `RequireNoFDLeak` guard
  - `TestIndexLocalRepo_Idempotent` — now guarded with `RequireNoFDLeak`
  - `TestCountOpenFDs` / `TestCountOpenFDs_DetectsDelta` / `TestRequireNoFDLeak_PassesWhenClean` — FD helper self-tests

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed file descriptor leaks in repository indexing and directory watch lifecycle management that could lead to resource exhaustion over time.

* **Tests**
  * Added file descriptor leak detection utilities and comprehensive tests to ensure proper resource cleanup and prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->