### PR TITLE
fix(session): prevent empty sessions from being committed to ledger

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -942,7 +942,11 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 		result.UploadWarning = "Session saved locally but ledger upload skipped (no ledger). Run 'ox doctor' to retry."
 	} else if asyncUpload {
 		// async mode: copy files to ledger dir locally, signal daemon to upload+finalize
-		if copyErr := copySessionCacheToLedger(result, ledgerPath, sessionName); copyErr != nil {
+		if result.EntryCount == 0 {
+			// nothing to upload — skip copy and daemon signal entirely.
+			// the 1-line header-only raw.jsonl written at session start is not worth committing.
+			slog.Info("async upload skipped: session has no entries", "session", sessionName)
+		} else if copyErr := copySessionCacheToLedger(result, ledgerPath, sessionName); copyErr != nil {
 			slog.Warn("async copy to ledger failed", "error", copyErr)
 			_ = doctor.SetNeedsDoctorAgent(projectRoot)
 			result.UploadWarning = "Session saved locally but async copy failed. Run 'ox doctor' to retry."

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/version"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
@@ -1423,6 +1424,17 @@ func (s *daemonServiceImpl) SessionFinalize(payload SessionFinalizeIPCPayload) {
 				"cache_path", payload.CachePath, "ledger", payload.LedgerPath)
 		}
 	}
+
+	// defense in depth: reject header-only sessions before enqueueing.
+	// the primary guard is in processAgentSession (CLI), but this prevents any
+	// empty session from reaching the LLM and being committed to the ledger.
+	rawPath := filepath.Join(sessionDir, "raw.jsonl")
+	if !session.HasSubstantiveEntries(rawPath) {
+		s.d.logger.Info("session_finalize skipped: header-only raw.jsonl, nothing to upload",
+			"session", payload.SessionName)
+		return
+	}
+
 	s.d.agentWorker.Enqueue(&agentwork.WorkItem{
 		Type:     "session-finalize",
 		Priority: 1, // high priority (vs 10 for doctor-detected)


### PR DESCRIPTION
## Problem

Sessions with no content (header-only `raw.jsonl`) were being committed to the ledger via the async upload path, producing ghost records like _"Empty Session No Work Performed"_. ~24 such sessions accumulated in the ledger on Apr 4–5.

## Root Cause

The async upload path in `processAgentSession` called `signalDaemonSessionFinalize` unconditionally — even when `result.EntryCount == 0`.

```
ox session start  →  writes 1-line header to raw.jsonl (always)
ox session stop   →  empty session, EntryCount=0
async path        →  copySessionCacheToLedger correctly skips ✓
                  →  signalDaemonSessionFinalize called anyway ✗
daemon IPC        →  no HasSubstantiveEntries guard, enqueues work item
LLM              →  "Empty Session No Work Performed"
git push         →  committed to ledger
```

The `HasSubstantiveEntries` guard existed only in the anti-entropy `detectInDir` path, not the IPC-triggered path.

## Fix

**`cmd/ox/agent_session.go`** — Primary guard in the async upload block:

```go
if result.EntryCount == 0 {
    // nothing to upload — skip copy and daemon signal entirely
    slog.Info("async upload skipped: session has no entries", ...)
} else if copyErr := copySessionCacheToLedger(...); ...
```

**`internal/daemon/daemon.go`** — Defense in depth in the IPC handler before enqueueing:

```go
rawPath := filepath.Join(sessionDir, "raw.jsonl")
if !session.HasSubstantiveEntries(rawPath) {
    s.d.logger.Info("session_finalize skipped: header-only raw.jsonl", ...)
    return
}
```

## Flow After Fix

```mermaid
flowchart TD
    A[ox session stop] --> B{EntryCount == 0?}
    B -->|yes| C[skip entirely — log and return]
    B -->|no| D[copySessionCacheToLedger]
    D --> E[signalDaemonSessionFinalize]
    E --> F{daemon: HasSubstantiveEntries?}
    F -->|no| G[skip — log and return]
    F -->|yes| H[enqueue → LLM → commit]
```

## Test Plan

- [x] `go test ./cmd/ox/... -short` passes
- [x] `go test ./internal/daemon/... -short` passes
- [x] `make lint` passes — 0 issues
- [x] Existing `TestDetect_SkipsHeaderOnlySessions` validates the anti-entropy path guard

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or header-only sessions are now skipped during processing and will not be committed to the ledger.
  * Async upload operations no longer attempt to process sessions with no substantive entries, improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->