### PR TITLE
fix(session): require explicit repoRoot to prevent silent recording failures

### DIFF
--- a/cmd/ox-adapter-aider/hooks.go
+++ b/cmd/ox-adapter-aider/hooks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,9 +151,9 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 }
 
 func resolveConventionsPath(repoRoot string) string {
-	if repoRoot != "" {
-		return filepath.Join(repoRoot, "CONVENTIONS.md")
+	if repoRoot == "" {
+		log.Println("WARN: resolveConventionsPath called with empty repoRoot, falling back to cwd")
+		repoRoot, _ = os.Getwd()
 	}
-	cwd, _ := os.Getwd()
-	return filepath.Join(cwd, "CONVENTIONS.md")
+	return filepath.Join(repoRoot, "CONVENTIONS.md")
 }

--- a/cmd/ox-adapter-aider/main.go
+++ b/cmd/ox-adapter-aider/main.go
@@ -74,7 +74,7 @@ func handleImportSession(p adapterprotocol.ImportSessionParams) (*adapterprotoco
 
 	repoRoot := p.RepoRoot
 	if repoRoot == "" {
-		repoRoot, _ = os.Getwd()
+		return nil, fmt.Errorf("repo-root is required for aider import (was empty)")
 	}
 
 	historyFile := filepath.Join(repoRoot, aiderHistoryFile)

--- a/cmd/ox-adapter-aider/session.go
+++ b/cmd/ox-adapter-aider/session.go
@@ -255,11 +255,7 @@ func parseAiderSessionByTimestamp(path, sessionTS string) ([]adapterprotocol.Raw
 func findAiderSession(repoRoot, _, since, _ string) (string, error) {
 	// aider always writes to .aider.chat.history.md in the project root
 	if repoRoot == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("cannot determine working directory: %w", err)
-		}
-		repoRoot = cwd
+		return "", fmt.Errorf("repo-root is required for aider session discovery (was empty)")
 	}
 
 	historyPath := filepath.Join(repoRoot, aiderHistoryFile)

--- a/cmd/ox-adapter-aider/session_test.go
+++ b/cmd/ox-adapter-aider/session_test.go
@@ -549,24 +549,24 @@ func TestFindAiderSession_InvalidSinceFormat(t *testing.T) {
 	}
 }
 
-// TestFindAiderSession_DefaultRepoRoot verifies current directory is used when repoRoot is empty.
-// Failure prevented: session lookup failing when no explicit repo root provided.
-func TestFindAiderSession_DefaultRepoRoot(t *testing.T) {
-	dir := t.TempDir()
+// TestFindAiderSession_EmptyRepoRoot_RejectsEmpty verifies that an empty repoRoot
+// is rejected instead of silently falling back to cwd.
+// Failure prevented: silent cwd derivation causing session discovery in wrong directory.
+func TestFindAiderSession_EmptyRepoRoot_RejectsEmpty(t *testing.T) {
+	_, err := findAiderSession("", "", "", "")
+	if err == nil {
+		t.Fatal("expected error for empty repoRoot, got nil")
+	}
+	if !strings.Contains(err.Error(), "repo-root is required") {
+		t.Errorf("expected 'repo-root is required' error, got: %v", err)
+	}
+}
 
-	// Change to temp directory
-	origWd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.Chdir(origWd); err != nil {
-			t.Fatal(err)
-		}
-	}()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
+// TestFindAiderSession_ExplicitRepoRoot verifies session discovery works
+// with an explicitly provided repoRoot.
+// Failure prevented: regression in explicit repoRoot path after removing cwd fallback.
+func TestFindAiderSession_ExplicitRepoRoot(t *testing.T) {
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, aiderHistoryFile)
 	content := "# aider chat started at 2024-01-15 14:30:45\n"
@@ -574,20 +574,18 @@ func TestFindAiderSession_DefaultRepoRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Call with empty repoRoot - should use current directory
-	got, err := findAiderSession("", "", "", "")
+	got, err := findAiderSession(dir, "", "", "")
 	if err != nil {
-		t.Fatalf("findAiderSession with empty repoRoot: %v", err)
+		t.Fatalf("findAiderSession with explicit repoRoot: %v", err)
 	}
 
-	// Resolve symlinks to compare paths properly (macOS /var -> /private/var)
 	gotResolved, err := filepath.EvalSymlinks(got)
 	if err != nil {
-		gotResolved = got // fallback if symlink resolution fails
+		gotResolved = got
 	}
 	pathResolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		pathResolved = path // fallback if symlink resolution fails
+		pathResolved = path
 	}
 
 	if gotResolved != pathResolved {

--- a/cmd/ox-adapter-amp/hooks.go
+++ b/cmd/ox-adapter-amp/hooks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,9 +151,9 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 }
 
 func resolveAgentsMDPath(repoRoot string) string {
-	if repoRoot != "" {
-		return filepath.Join(repoRoot, "AGENTS.md")
+	if repoRoot == "" {
+		log.Println("WARN: resolveAgentsMDPath called with empty repoRoot, falling back to cwd")
+		repoRoot, _ = os.Getwd()
 	}
-	cwd, _ := os.Getwd()
-	return filepath.Join(cwd, "AGENTS.md")
+	return filepath.Join(repoRoot, "AGENTS.md")
 }

--- a/cmd/ox-adapter-codex/hooks.go
+++ b/cmd/ox-adapter-codex/hooks.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,11 +181,11 @@ func resolveHooksPath(repoRoot, scope string) string {
 		home, _ := os.UserHomeDir()
 		return filepath.Join(home, codexUserPath, codexHooksFileName)
 	}
-	if repoRoot != "" {
-		return filepath.Join(repoRoot, codexProjectPath, codexHooksFileName)
+	if repoRoot == "" {
+		log.Println("WARN: resolveHooksPath called with empty repoRoot, falling back to cwd")
+		repoRoot, _ = os.Getwd()
 	}
-	cwd, _ := os.Getwd()
-	return filepath.Join(cwd, codexProjectPath, codexHooksFileName)
+	return filepath.Join(repoRoot, codexProjectPath, codexHooksFileName)
 }
 
 func resolveConfigPath(repoRoot, scope string) string {
@@ -192,11 +193,11 @@ func resolveConfigPath(repoRoot, scope string) string {
 		home, _ := os.UserHomeDir()
 		return filepath.Join(home, codexUserPath, codexConfigFile)
 	}
-	if repoRoot != "" {
-		return filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+	if repoRoot == "" {
+		log.Println("WARN: resolveConfigPath called with empty repoRoot, falling back to cwd")
+		repoRoot, _ = os.Getwd()
 	}
-	cwd, _ := os.Getwd()
-	return filepath.Join(cwd, codexProjectPath, codexConfigFile)
+	return filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
 }
 
 func readHooksFile(path string) (map[string][]codexHookEntry, map[string]json.RawMessage, error) {

--- a/cmd/ox-adapter-opencode/hooks.go
+++ b/cmd/ox-adapter-opencode/hooks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -92,9 +93,9 @@ func resolvePluginPath(repoRoot, scope string) string {
 		home, _ := os.UserHomeDir()
 		return filepath.Join(home, openCodeUserPath, openCodePluginFileName)
 	}
-	if repoRoot != "" {
-		return filepath.Join(repoRoot, openCodeProjectPath, openCodePluginFileName)
+	if repoRoot == "" {
+		log.Println("WARN: resolvePluginPath called with empty repoRoot, falling back to cwd")
+		repoRoot, _ = os.Getwd()
 	}
-	cwd, _ := os.Getwd()
-	return filepath.Join(cwd, openCodeProjectPath, openCodePluginFileName)
+	return filepath.Join(repoRoot, openCodeProjectPath, openCodePluginFileName)
 }

--- a/cmd/ox-adapter-pi/hooks.go
+++ b/cmd/ox-adapter-pi/hooks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,9 +151,9 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 }
 
 func resolveAgentsMDPath(repoRoot string) string {
-	if repoRoot != "" {
-		return filepath.Join(repoRoot, "AGENTS.md")
+	if repoRoot == "" {
+		log.Println("WARN: resolveAgentsMDPath called with empty repoRoot, falling back to cwd")
+		repoRoot, _ = os.Getwd()
 	}
-	cwd, _ := os.Getwd()
-	return filepath.Join(cwd, "AGENTS.md")
+	return filepath.Join(repoRoot, "AGENTS.md")
 }

--- a/cmd/ox/adapter_test_helpers_test.go
+++ b/cmd/ox/adapter_test_helpers_test.go
@@ -17,7 +17,7 @@ type testClaudeCodeAdapter struct{}
 
 func (a *testClaudeCodeAdapter) Name() string  { return "claude-code" }
 func (a *testClaudeCodeAdapter) Detect() bool  { return false }
-func (a *testClaudeCodeAdapter) FindSessionFile(_ string, _ time.Time) (string, error) {
+func (a *testClaudeCodeAdapter) FindSessionFile(_ adapters.SessionLookup) (string, error) {
 	return "", adapters.ErrSessionNotFound
 }
 func (a *testClaudeCodeAdapter) ReadMetadata(_ string) (*adapters.SessionMetadata, error) {
@@ -150,7 +150,7 @@ type testCodexAdapter struct{}
 
 func (a *testCodexAdapter) Name() string  { return "codex" }
 func (a *testCodexAdapter) Detect() bool  { return false }
-func (a *testCodexAdapter) FindSessionFile(_ string, since time.Time) (string, error) {
+func (a *testCodexAdapter) FindSessionFile(lookup adapters.SessionLookup) (string, error) {
 	// scan ~/.codex/sessions/ for recent session files (mirrors real CodexAdapter behavior)
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -374,7 +375,9 @@ func findProjectRoot() (string, error) {
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			// reached filesystem root, use cwd
+			// no .sageox/ found — fall back to cwd but warn so silent failures
+			// are visible in logs (this is a common source of path divergence)
+			slog.Warn("findProjectRoot: no .sageox/ found, falling back to cwd", "cwd", cwd)
 			if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
 				return resolved, nil
 			}

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -411,7 +411,15 @@ func handleAfterTool(ctx *HookContext) error {
 
 	if state.SessionFile == "" {
 		// discover session file on first hook call (Claude Code JSONL may not exist at prime time)
-		sf, findErr := adapter.FindSessionFile(agentID, state.StartedAt)
+		repoRoot := state.WorkspacePath
+		if repoRoot == "" {
+			repoRoot = ctx.ProjectRoot
+		}
+		sf, findErr := adapter.FindSessionFile(adapters.SessionLookup{
+			RepoRoot: repoRoot,
+			AgentID:  agentID,
+			Since:    state.StartedAt,
+		})
 		if findErr != nil || sf == "" {
 			slog.Debug("hook: session file not found", "agentID", agentID, "err", findErr)
 			return nil // session file not available yet
@@ -431,7 +439,15 @@ func handleAfterTool(ctx *HookContext) error {
 		} else {
 			slog.Info("hook: session file shrank, attempting rediscovery", "file", state.SessionFile, "size", fi.Size(), "offset", state.SourceOffset)
 		}
-		sf, findErr := adapter.FindSessionFile(agentID, state.StartedAt)
+		repoRoot := state.WorkspacePath
+		if repoRoot == "" {
+			repoRoot = ctx.ProjectRoot
+		}
+		sf, findErr := adapter.FindSessionFile(adapters.SessionLookup{
+			RepoRoot: repoRoot,
+			AgentID:  agentID,
+			Since:    state.StartedAt,
+		})
 		if findErr == nil && sf != "" && sf != state.SessionFile {
 			slog.Info("hook: rediscovered session file", "old", state.SessionFile, "new", sf)
 			state.SessionFile = sf

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -1019,7 +1019,15 @@ func sendSessionWatchStart(state *session.RecordingState, projectRoot string) {
 		if err != nil {
 			return
 		}
-		sf, err := adapter.FindSessionFile(state.AgentID, state.StartedAt)
+		repoRoot := state.WorkspacePath
+		if repoRoot == "" {
+			repoRoot = projectRoot
+		}
+		sf, err := adapter.FindSessionFile(adapters.SessionLookup{
+			RepoRoot: repoRoot,
+			AgentID:  state.AgentID,
+			Since:    state.StartedAt,
+		})
 		if err != nil {
 			slog.Debug("tail-mode: session file not found yet, daemon will discover later",
 				"agent_id", state.AgentID, "adapter", state.AdapterName)

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -469,8 +470,42 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 				state.SessionFile = sf
 			} else {
 				slog.Warn("session file not found at stop time", "agent_id", state.AgentID, "adapter", state.AdapterName, "started_at", state.StartedAt.Format(time.RFC3339), "error", findErr, "repo_root", repoRoot)
-				// recovery guidance: print exact import command so user can recover manually
+
+				// path variant retries: try alternate path forms that produce different project hashes
+				pathVariants := sessionPathVariants(repoRoot)
+				for _, variant := range pathVariants {
+					retryLookup := adapters.SessionLookup{
+						RepoRoot: variant,
+						AgentID:  state.AgentID,
+						Since:    state.StartedAt,
+					}
+					if sf, retryErr := adapter.FindSessionFile(retryLookup); retryErr == nil {
+						slog.Info("session file discovered via path variant", "file", sf, "original_root", repoRoot, "variant", variant)
+						state.SessionFile = sf
+						break
+					}
+				}
+
+				// last resort: time-window scan across all Claude project directories
+				if state.SessionFile == "" && state.AdapterName == "claude-code" {
+					if sf := scanClaudeProjectsForSession(state.AgentID, state.StartedAt); sf != "" {
+						slog.Info("session file discovered via time-window scan", "file", sf)
+						state.SessionFile = sf
+					}
+				}
+			}
+
+			// if still not found after all retries, set rich recovery marker
+			if state.SessionFile == "" {
 				fmt.Fprintf(os.Stderr, "\nSession data may still be recoverable. Try:\n  ox agent %s session import --file <path-to-session-jsonl>\n\n", state.AgentID)
+				_ = doctor.SetSessionRecoveryInfo(projectRoot, doctor.SessionRecoveryInfo{
+					AgentID:       state.AgentID,
+					AdapterName:   state.AdapterName,
+					StartedAt:     state.StartedAt,
+					WorkspacePath: repoRoot,
+					FailedAt:      time.Now(),
+					Error:         "session file not found at stop time",
+				})
 				_ = doctor.SetNeedsDoctorAgent(projectRoot)
 			}
 		}
@@ -505,10 +540,17 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 	// best-effort: record session-end observation to team memory
 	recordSessionObservation(projectRoot, processResult, duration)
 
-	// processing succeeded (or no source file to process) - clear active state.
-	if err := session.ClearRecordingStateForAgent(projectRoot, inst.AgentID); err != nil {
-		_ = doctor.SetNeedsDoctorAgent(projectRoot)
-		return fmt.Errorf("failed to finalize recording stop: %w", err)
+	// only clear recording state when processing succeeded or session was explicitly stopped
+	// with no data. Preserve state when session file discovery failed — it contains
+	// breadcrumbs (WorkspacePath, AdapterName, StartedAt) needed for recovery.
+	if processResult != nil || state.SessionFile == "" && state.AdapterName == "" {
+		if err := session.ClearRecordingStateForAgent(projectRoot, inst.AgentID); err != nil {
+			_ = doctor.SetNeedsDoctorAgent(projectRoot)
+			return fmt.Errorf("failed to finalize recording stop: %w", err)
+		}
+	} else if state.SessionFile == "" {
+		// session file not found — recording state preserved for recovery
+		slog.Info("recording state preserved for recovery", "agent_id", inst.AgentID, "adapter", state.AdapterName)
 	}
 	// finalize timing
 	timing["total_ms"] = time.Since(stopStart).Milliseconds()
@@ -550,6 +592,119 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 
 	// default: JSON output
 	return outputSessionStopJSON(inst, state, duration, processResult, timing)
+}
+
+// sessionPathVariants returns alternate path forms that may produce different
+// project hashes in Claude Code. Each variant is only included if it differs
+// from the original path. Covers: symlink resolution, trailing slash.
+func sessionPathVariants(repoRoot string) []string {
+	seen := map[string]bool{repoRoot: true}
+	var variants []string
+	add := func(p string) {
+		if p != "" && !seen[p] {
+			seen[p] = true
+			variants = append(variants, p)
+		}
+	}
+
+	// symlink-resolved path (e.g., /var → /private/var on macOS)
+	if resolved, err := filepath.EvalSymlinks(repoRoot); err == nil {
+		add(resolved)
+	}
+
+	// trailing slash variant: Claude Code may have stored the path with or without
+	add(strings.TrimSuffix(repoRoot, "/"))
+	if !strings.HasSuffix(repoRoot, "/") {
+		add(repoRoot + "/")
+	}
+
+	return variants
+}
+
+// scanClaudeProjectsForSession is a last-resort recovery that scans all
+// ~/.claude/projects/ directories for JSONL files modified within the session's
+// time window. This catches cases where the project hash doesn't match due to
+// path normalization differences (trailing slash, case, mount points).
+func scanClaudeProjectsForSession(agentID string, startedAt time.Time) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	projectsDir := filepath.Join(home, ".claude", "projects")
+	projectDirs, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return ""
+	}
+
+	// allow 30s buffer before session start for timing drift
+	searchStart := startedAt.Add(-30 * time.Second)
+
+	type candidate struct {
+		path    string
+		modTime time.Time
+	}
+	var candidates []candidate
+
+	for _, dir := range projectDirs {
+		if !dir.IsDir() {
+			continue
+		}
+		dirPath := filepath.Join(projectsDir, dir.Name())
+		files, err := os.ReadDir(dirPath)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".jsonl") {
+				continue
+			}
+			info, err := f.Info()
+			if err != nil {
+				continue
+			}
+			if info.ModTime().Before(searchStart) {
+				continue
+			}
+			candidates = append(candidates, candidate{
+				path:    filepath.Join(dirPath, f.Name()),
+				modTime: info.ModTime(),
+			})
+		}
+	}
+
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	// sort most recently modified first
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].modTime.After(candidates[j].modTime)
+	})
+
+	// check up to 10 candidates for the agent ID (avoid scanning thousands of files)
+	limit := 10
+	if len(candidates) < limit {
+		limit = len(candidates)
+	}
+	for _, c := range candidates[:limit] {
+		if fileContainsString(c.path, agentID) {
+			return c.path
+		}
+	}
+	return ""
+}
+
+// fileContainsString checks if a file contains the given string, reading at most 64KB.
+func fileContainsString(path, needle string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	buf := make([]byte, 64*1024)
+	n, _ := f.Read(buf)
+	return strings.Contains(string(buf[:n]), needle)
 }
 
 // recordSessionObservation writes a session summary observation to team memory.

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -132,7 +132,11 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 			return fmt.Errorf("codex adapter unavailable: %w", adapterErr)
 		}
 		since := time.Now().Add(-5 * time.Minute)
-		sf, findErr := codexAdapter.FindSessionFile(inst.AgentID, since)
+		sf, findErr := codexAdapter.FindSessionFile(adapters.SessionLookup{
+			RepoRoot: projectRoot,
+			AgentID:  inst.AgentID,
+			Since:    since,
+		})
 		if findErr != nil {
 			if errors.Is(findErr, adapters.ErrSessionNotFound) {
 				return fmt.Errorf("no active codex session found\nStart a Codex conversation in this repo, then run 'ox agent %s session start'", inst.AgentID)
@@ -149,8 +153,12 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 			if adapter, detectErr := adapters.DetectAdapter(); detectErr == nil {
 				adapterName = adapter.Name()
 				since := time.Now().Add(-5 * time.Minute)
-				sf, findErr := adapter.FindSessionFile(inst.AgentID, since)
-				if findErr != nil {
+				sf, findErr := adapter.FindSessionFile(adapters.SessionLookup{
+				RepoRoot: projectRoot,
+				AgentID:  inst.AgentID,
+				Since:    since,
+			})
+			if findErr != nil {
 					slog.Info("session file not found at start (will retry at stop)", "adapter", adapterName, "error", findErr)
 				} else {
 					sessionFile = sf
@@ -445,11 +453,25 @@ func runAgentSessionStop(inst *agentinstance.Instance) error {
 	// (Claude Code session JSONL may not have existed yet when recording started)
 	if state.SessionFile == "" && state.AdapterName != "" && state.AdapterName != "generic" {
 		if adapter, adapterErr := adapters.GetAdapter(state.AdapterName); adapterErr == nil {
-			if sf, findErr := adapter.FindSessionFile(state.AgentID, state.StartedAt); findErr == nil {
+			// use state.WorkspacePath (persisted at start) as the single source of truth
+			// for repoRoot -- never derive from ambient cwd/env at stop time
+			repoRoot := state.WorkspacePath
+			if repoRoot == "" {
+				repoRoot = projectRoot // fallback for legacy states without WorkspacePath
+			}
+			lookup := adapters.SessionLookup{
+				RepoRoot: repoRoot,
+				AgentID:  state.AgentID,
+				Since:    state.StartedAt,
+			}
+			if sf, findErr := adapter.FindSessionFile(lookup); findErr == nil {
 				slog.Info("session file discovered at stop time", "file", sf, "adapter", state.AdapterName)
 				state.SessionFile = sf
 			} else {
-				slog.Warn("session file not found at stop time", "agent_id", state.AgentID, "adapter", state.AdapterName, "started_at", state.StartedAt.Format(time.RFC3339), "error", findErr)
+				slog.Warn("session file not found at stop time", "agent_id", state.AgentID, "adapter", state.AdapterName, "started_at", state.StartedAt.Format(time.RFC3339), "error", findErr, "repo_root", repoRoot)
+				// recovery guidance: print exact import command so user can recover manually
+				fmt.Fprintf(os.Stderr, "\nSession data may still be recoverable. Try:\n  ox agent %s session import --file <path-to-session-jsonl>\n\n", state.AgentID)
+				_ = doctor.SetNeedsDoctorAgent(projectRoot)
 			}
 		}
 	}
@@ -801,9 +823,10 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 	}
 
 	// use AgentType from recording state if set, fall back to AdapterName
-	agentTypeForMeta := state.AgentType
+	// canonicalize to prevent drift ("claude" vs "claude-code")
+	agentTypeForMeta := adapters.CanonicalAdapterName(state.AgentType)
 	if agentTypeForMeta == "" {
-		agentTypeForMeta = state.AdapterName
+		agentTypeForMeta = adapters.CanonicalAdapterName(state.AdapterName)
 	}
 
 	// fall back to recording state model for generic adapters

--- a/cmd/ox/agent_session_incremental.go
+++ b/cmd/ox/agent_session_incremental.go
@@ -31,9 +31,9 @@ func writeRawHeader(projectRoot string, state *session.RecordingState) error {
 	projectEndpoint := endpoint.GetForProject(projectRoot)
 	repoID := getRepoIDOrDefault(projectRoot)
 
-	agentTypeForMeta := state.AgentType
+	agentTypeForMeta := adapters.CanonicalAdapterName(state.AgentType)
 	if agentTypeForMeta == "" {
-		agentTypeForMeta = state.AdapterName
+		agentTypeForMeta = adapters.CanonicalAdapterName(state.AdapterName)
 	}
 
 	meta := &session.StoreMeta{

--- a/cmd/ox/agent_session_plan_history.go
+++ b/cmd/ox/agent_session_plan_history.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/identity"
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/internal/version"
 )
 
@@ -413,7 +414,7 @@ func writePlanHistoryRaw(path string, entries []planHistoryEntry, meta *planHist
 	}
 	if meta != nil {
 		if meta.AgentType != "" {
-			header["metadata"].(map[string]any)["agent_type"] = meta.AgentType
+			header["metadata"].(map[string]any)["agent_type"] = adapters.CanonicalAdapterName(meta.AgentType)
 		}
 		if meta.StartedAt != "" {
 			header["metadata"].(map[string]any)["started_at"] = meta.StartedAt

--- a/internal/adapterprotocol/compliance/suite.go
+++ b/internal/adapterprotocol/compliance/suite.go
@@ -61,6 +61,8 @@ func (s *Suite) RunAll(t *testing.T) {
 	t.Run("serve/shutdown", s.TestServeShutdown)
 	t.Run("serve/unknown-method", s.TestServeUnknownMethod)
 
+	t.Run("find-session/bad-repo-root", s.TestFindSessionBadRepoRoot)
+
 	// subagent tests only run if the adapter declares the capability
 	if s.hasCapability(t, adapterprotocol.CapSubagentController) {
 		t.Run("serve/spawn-subagent", s.TestSpawnSubagent)
@@ -115,6 +117,48 @@ func (s *Suite) TestDetect(t *testing.T) {
 	if resp.Reason == "" {
 		t.Error("detect.reason should explain why detected/not detected")
 	}
+}
+
+// TestFindSessionBadRepoRoot verifies that find-session with a nonexistent
+// repo root returns a structured error, not empty output or a panic.
+// Failure prevented: adapter silently returns empty result for bad repoRoot,
+// causing session recording to fail without any error message.
+func (s *Suite) TestFindSessionBadRepoRoot(t *testing.T) {
+	stdout, stderr, err := s.execOnceAllowError(t, "find-session",
+		"--repo-root", "/nonexistent/path/compliance-test",
+		"--agent-id", s.AgentID,
+		"--since", time.Now().Add(-1*time.Hour).UTC().Format(time.RFC3339),
+	)
+
+	// adapter MUST signal failure: either non-zero exit or a JSON error field
+	if err == nil {
+		// exited 0 — stdout must contain an error field
+		var resp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(stdout, &resp) != nil || resp.Error == "" {
+			t.Fatalf("find-session with bad repo-root exited 0 without error field\nstdout: %s", stdout)
+		}
+		return
+	}
+
+	// non-zero exit — check for structured JSON error in stdout
+	if len(stdout) > 0 {
+		var resp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(stdout, &resp) == nil && resp.Error != "" {
+			return // structured error, good
+		}
+	}
+
+	// non-zero exit with stderr is also acceptable
+	if len(stderr) > 0 {
+		return
+	}
+
+	// non-zero exit with no output at all is still acceptable (it's an error)
+	_ = err
 }
 
 // --- Serve mode tests ---
@@ -612,6 +656,27 @@ func (s *Suite) execOnce(t *testing.T, subcommand string, args ...string) []byte
 	}
 
 	return bytes.TrimSpace(stdout.Bytes())
+}
+
+// execOnceAllowError runs a one-shot subcommand, returning stdout, stderr,
+// and any execution error. Unlike execOnce, it does not fatal on non-zero exit.
+func (s *Suite) execOnceAllowError(t *testing.T, subcommand string, args ...string) (stdout, stderr []byte, err error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmdArgs := append([]string{subcommand}, args...)
+	cmd := exec.CommandContext(ctx, s.Binary, cmdArgs...)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("OX_PROTOCOL_VERSION=%d", adapterprotocol.ProtocolVersion),
+	)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err = cmd.Run()
+	return bytes.TrimSpace(stdoutBuf.Bytes()), bytes.TrimSpace(stderrBuf.Bytes()), err
 }
 
 // hasCapability checks if the adapter under test declares a given capability.

--- a/internal/daemon/adapter_supervisor_subagent_test.go
+++ b/internal/daemon/adapter_supervisor_subagent_test.go
@@ -31,7 +31,7 @@ func TestSupervisor_SpawnSubagent(t *testing.T) {
 
 	// prime the adapter with a session first so the process is alive
 	ctx := context.Background()
-	_, err := sup.SendRequest(ctx, "test", "agent-parent", adapterprotocol.MethodFindSession, supFindSessionParams("agent-parent"))
+	_, err := sup.SendRequest(ctx, "test", "agent-parent", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-parent"))
 	if err != nil {
 		t.Fatalf("prime request failed: %v", err)
 	}

--- a/internal/daemon/adapter_supervisor_test.go
+++ b/internal/daemon/adapter_supervisor_test.go
@@ -59,10 +59,15 @@ func supFindRepoRoot(t *testing.T) string {
 	}
 }
 
-func supFindSessionParams(agentID string) adapterprotocol.FindSessionParams {
+func supFindSessionParams(t *testing.T, agentID string) adapterprotocol.FindSessionParams {
+	t.Helper()
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	return adapterprotocol.FindSessionParams{
 		AgentID:  agentID,
-		RepoRoot: "/tmp/test-repo",
+		RepoRoot: tmpDir,
 		RepoID:   "repo-1",
 		Since:    time.Now().UTC().Format(time.RFC3339),
 	}
@@ -90,7 +95,7 @@ func TestSupervisor_LazySpawnOnFirstRequest(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	resp, err := sup.SendRequest(ctx, "test", "agent-1", adapterprotocol.MethodFindSession, supFindSessionParams("agent-1"))
+	resp, err := sup.SendRequest(ctx, "test", "agent-1", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-1"))
 	if err != nil {
 		t.Fatalf("first request failed: %v", err)
 	}
@@ -115,7 +120,7 @@ func TestSupervisor_SessionTracking(t *testing.T) {
 	ctx := context.Background()
 
 	for _, agentID := range []string{"agent-a", "agent-b"} {
-		_, err := sup.SendRequest(ctx, "test", agentID, adapterprotocol.MethodFindSession, supFindSessionParams(agentID))
+		_, err := sup.SendRequest(ctx, "test", agentID, adapterprotocol.MethodFindSession, supFindSessionParams(t, agentID))
 		if err != nil {
 			t.Fatalf("request for %s failed: %v", agentID, err)
 		}
@@ -145,7 +150,7 @@ func TestSupervisor_EndSessionRemovesState(t *testing.T) {
 	defer sup.Shutdown(context.Background())
 
 	ctx := context.Background()
-	_, err := sup.SendRequest(ctx, "test", "agent-x", adapterprotocol.MethodFindSession, supFindSessionParams("agent-x"))
+	_, err := sup.SendRequest(ctx, "test", "agent-x", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-x"))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -170,7 +175,7 @@ func TestSupervisor_IdleShutdown(t *testing.T) {
 	defer sup.Shutdown(context.Background())
 
 	ctx := context.Background()
-	_, err := sup.SendRequest(ctx, "test", "agent-idle", adapterprotocol.MethodFindSession, supFindSessionParams("agent-idle"))
+	_, err := sup.SendRequest(ctx, "test", "agent-idle", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-idle"))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -203,7 +208,7 @@ func TestSupervisor_IdleTimerCancelledByNewSession(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := sup.SendRequest(ctx, "test", "agent-1", adapterprotocol.MethodFindSession, supFindSessionParams("agent-1"))
+	_, err := sup.SendRequest(ctx, "test", "agent-1", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-1"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +219,7 @@ func TestSupervisor_IdleTimerCancelledByNewSession(t *testing.T) {
 
 	// before idle fires, send a new request
 	time.Sleep(50 * time.Millisecond)
-	_, err = sup.SendRequest(ctx, "test", "agent-2", adapterprotocol.MethodFindSession, supFindSessionParams("agent-2"))
+	_, err = sup.SendRequest(ctx, "test", "agent-2", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-2"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +242,7 @@ func TestSupervisor_ShutdownAll(t *testing.T) {
 	sup := NewAdapterSupervisor(testLogger(), []string{adapterDir})
 
 	ctx := context.Background()
-	_, err := sup.SendRequest(ctx, "test", "agent-s", adapterprotocol.MethodFindSession, supFindSessionParams("agent-s"))
+	_, err := sup.SendRequest(ctx, "test", "agent-s", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-s"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +316,7 @@ func TestSupervisor_MultipleAdapterTypes(t *testing.T) {
 
 	ctx := context.Background()
 	for _, adapterType := range []string{"test", "test2"} {
-		_, err := sup.SendRequest(ctx, adapterType, "agent-1", adapterprotocol.MethodFindSession, supFindSessionParams("agent-1"))
+		_, err := sup.SendRequest(ctx, adapterType, "agent-1", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-1"))
 		if err != nil {
 			t.Fatalf("request to %s failed: %v", adapterType, err)
 		}
@@ -337,7 +342,7 @@ func TestSupervisor_CrashAndRespawn(t *testing.T) {
 	t.Setenv("OX_TEST_CRASH_AFTER", "1")
 
 	// find-session succeeds before crash
-	_, err := sup.SendRequest(ctx, "test", "agent-crash", adapterprotocol.MethodFindSession, supFindSessionParams("agent-crash"))
+	_, err := sup.SendRequest(ctx, "test", "agent-crash", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-crash"))
 	if err != nil {
 		t.Fatalf("find-session failed: %v", err)
 	}
@@ -356,7 +361,7 @@ func TestSupervisor_CrashAndRespawn(t *testing.T) {
 	t.Setenv("OX_TEST_CRASH_AFTER", "")
 
 	// next request triggers respawn
-	resp, err := sup.SendRequest(ctx, "test", "agent-crash", adapterprotocol.MethodFindSession, supFindSessionParams("agent-crash"))
+	resp, err := sup.SendRequest(ctx, "test", "agent-crash", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-crash"))
 	if err != nil {
 		t.Fatalf("request after respawn failed: %v", err)
 	}
@@ -410,7 +415,7 @@ func TestSupervisor_ConcurrentRequests(t *testing.T) {
 		go func(n int) {
 			defer wg.Done()
 			agentID := fmt.Sprintf("agent-%d", n)
-			_, err := sup.SendRequest(ctx, "test", agentID, adapterprotocol.MethodFindSession, supFindSessionParams(agentID))
+			_, err := sup.SendRequest(ctx, "test", agentID, adapterprotocol.MethodFindSession, supFindSessionParams(t, agentID))
 			if err != nil {
 				errs <- fmt.Errorf("agent-%d: %w", n, err)
 			}
@@ -455,7 +460,7 @@ func TestSupervisor_LifecycleEventsSessionStartEnd(t *testing.T) {
 	ctx := context.Background()
 
 	// session start triggers lifecycle log
-	_, err := sup.SendRequest(ctx, "test", "agent-lifecycle", adapterprotocol.MethodFindSession, supFindSessionParams("agent-lifecycle"))
+	_, err := sup.SendRequest(ctx, "test", "agent-lifecycle", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-lifecycle"))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -470,7 +475,7 @@ func TestSupervisor_LifecycleEventsSessionStartEnd(t *testing.T) {
 
 	// duplicate request for same agent should NOT emit a second "session started"
 	beforeLen := buf.Len()
-	_, err = sup.SendRequest(ctx, "test", "agent-lifecycle", adapterprotocol.MethodFindSession, supFindSessionParams("agent-lifecycle"))
+	_, err = sup.SendRequest(ctx, "test", "agent-lifecycle", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-lifecycle"))
 	if err != nil {
 		t.Fatalf("second request failed: %v", err)
 	}
@@ -500,7 +505,7 @@ func TestSupervisor_LifecycleEventsSpawnAndShutdown(t *testing.T) {
 	sup := NewAdapterSupervisor(logger, []string{adapterDir})
 
 	ctx := context.Background()
-	_, err := sup.SendRequest(ctx, "test", "agent-spawn", adapterprotocol.MethodFindSession, supFindSessionParams("agent-spawn"))
+	_, err := sup.SendRequest(ctx, "test", "agent-spawn", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-spawn"))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -650,7 +655,7 @@ func TestSupervisor_StatusRunning(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err := sup.SendRequest(ctx, "test", "agent-status", adapterprotocol.MethodFindSession, supFindSessionParams("agent-status"))
+	_, err := sup.SendRequest(ctx, "test", "agent-status", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-status"))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -806,7 +811,7 @@ func TestSupervisor_LifecycleEventsRespawn(t *testing.T) {
 	// make the adapter crash after first read-from-offset
 	t.Setenv("OX_TEST_CRASH_AFTER", "1")
 
-	_, err := sup.SendRequest(ctx, "test", "agent-respawn", adapterprotocol.MethodFindSession, supFindSessionParams("agent-respawn"))
+	_, err := sup.SendRequest(ctx, "test", "agent-respawn", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-respawn"))
 	if err != nil {
 		t.Fatalf("find-session failed: %v", err)
 	}
@@ -822,7 +827,7 @@ func TestSupervisor_LifecycleEventsRespawn(t *testing.T) {
 	t.Setenv("OX_TEST_CRASH_AFTER", "")
 
 	// trigger respawn
-	_, _ = sup.SendRequest(ctx, "test", "agent-respawn", adapterprotocol.MethodFindSession, supFindSessionParams("agent-respawn"))
+	_, _ = sup.SendRequest(ctx, "test", "agent-respawn", adapterprotocol.MethodFindSession, supFindSessionParams(t, "agent-respawn"))
 
 	logOutput := buf.String()
 	if !strings.Contains(logOutput, "adapter respawning") {

--- a/internal/daemon/agentwork/session_finalize_misc_test.go
+++ b/internal/daemon/agentwork/session_finalize_misc_test.go
@@ -42,7 +42,7 @@ type mockReadAdapter struct{}
 
 func (m *mockReadAdapter) Name() string  { return "test-mock" }
 func (m *mockReadAdapter) Detect() bool  { return false }
-func (m *mockReadAdapter) FindSessionFile(_ string, _ time.Time) (string, error) {
+func (m *mockReadAdapter) FindSessionFile(_ adapters.SessionLookup) (string, error) {
 	return "", adapters.ErrSessionNotFound
 }
 func (m *mockReadAdapter) ReadMetadata(_ string) (*adapters.SessionMetadata, error) {

--- a/internal/daemon/agentwork/session_watcher_test.go
+++ b/internal/daemon/agentwork/session_watcher_test.go
@@ -27,7 +27,7 @@ type testAdapter struct {
 
 func (a *testAdapter) Name() string  { return a.name }
 func (a *testAdapter) Detect() bool  { return false }
-func (a *testAdapter) FindSessionFile(_ string, _ time.Time) (string, error) {
+func (a *testAdapter) FindSessionFile(_ adapters.SessionLookup) (string, error) {
 	return "", adapters.ErrSessionNotFound
 }
 func (a *testAdapter) Read(_ string) ([]adapters.RawEntry, error) { return nil, nil }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -181,6 +181,10 @@ type Daemon struct {
 	lastActivity     time.Time // tracks last activity for inactivity timeout
 	pendingWorkSince time.Time // when pending work was first detected during inactivity (zero = no pending work)
 
+	// cachedWorkspacePath is set BEFORE StabilizeCWD() so that later code
+	// never falls back to os.Getwd() (which returns $HOME post-stabilize)
+	cachedWorkspacePath string
+
 	// startup timing (written once in Start(), read by IPC status handler)
 	startupDurationMs  atomic.Int64
 	throttleDurationMs atomic.Int64
@@ -320,10 +324,14 @@ func (d *Daemon) Start() error {
 
 	// register in daemon registry for multi-daemon support
 	// use ProjectRoot (the actual workspace), not LedgerPath
+	// NOTE: must happen BEFORE StabilizeCWD() which changes cwd to $HOME
 	workspacePath := d.config.ProjectRoot
 	if workspacePath == "" {
+		d.logger.Warn("daemon config missing ProjectRoot, falling back to cwd")
 		workspacePath, _ = os.Getwd()
 	}
+	// cache for later use (after StabilizeCWD, os.Getwd returns $HOME)
+	d.cachedWorkspacePath = workspacePath
 	if err := RegisterDaemon(workspacePath, Version()); err != nil {
 		d.logger.Warn("failed to register daemon", "error", err)
 	}
@@ -465,10 +473,10 @@ func (d *Daemon) getAgentSessions() []AgentSession {
 		return nil
 	}
 
-	// get workspace path for this daemon
-	workspacePath := d.config.ProjectRoot
+	// use cached workspace path (set before StabilizeCWD changed cwd to $HOME)
+	workspacePath := d.cachedWorkspacePath
 	if workspacePath == "" {
-		workspacePath, _ = os.Getwd()
+		workspacePath = d.config.ProjectRoot
 	}
 
 	tracker := d.heartbeat.GetAgentActivity()
@@ -541,10 +549,10 @@ func (d *Daemon) getAgentInstances() []InstanceInfo {
 		return nil
 	}
 
-	// get workspace path for this daemon
-	workspacePath := d.config.ProjectRoot
+	// use cached workspace path (set before StabilizeCWD changed cwd to $HOME)
+	workspacePath := d.cachedWorkspacePath
 	if workspacePath == "" {
-		workspacePath, _ = os.Getwd()
+		workspacePath = d.config.ProjectRoot
 	}
 
 	tracker := d.heartbeat.GetAgentActivity()

--- a/internal/daemon/fallback.go
+++ b/internal/daemon/fallback.go
@@ -328,6 +328,7 @@ func resolveRepoName() string {
 
 // findProjectRootForDaemon returns the project root for setting daemon CWD.
 // Uses canonical config.FindProjectRoot; falls back to os.Getwd if no .sageox/ found.
+// NOTE: must be called BEFORE StabilizeCWD() which changes cwd to $HOME.
 func findProjectRootForDaemon() string {
 	if root := config.FindProjectRoot(); root != "" {
 		return root
@@ -336,6 +337,7 @@ func findProjectRootForDaemon() string {
 	if err != nil {
 		return ""
 	}
+	slog.Warn("findProjectRootForDaemon: no .sageox/ found, falling back to cwd", "cwd", cwd)
 	return cwd
 }
 

--- a/internal/doctor/markers.go
+++ b/internal/doctor/markers.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -92,6 +93,57 @@ func touchMarker(gitRoot, markerName string) error {
 func clearMarker(gitRoot, markerName string) error {
 	markerPath := filepath.Join(gitRoot, sageoxDir, markerName)
 	err := os.Remove(markerPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// SessionRecoveryInfo contains metadata needed for automated session recovery.
+// Written to .sageox/.session-recovery.json when session file discovery fails at stop time.
+type SessionRecoveryInfo struct {
+	AgentID       string    `json:"agent_id"`
+	AdapterName   string    `json:"adapter_name"`
+	StartedAt     time.Time `json:"started_at"`
+	WorkspacePath string    `json:"workspace_path"`
+	FailedAt      time.Time `json:"failed_at"`
+	Error         string    `json:"error,omitempty"`
+}
+
+const sessionRecoveryFile = ".session-recovery.json"
+
+// SetSessionRecoveryInfo writes recovery metadata so ox doctor can drive automated recovery.
+func SetSessionRecoveryInfo(gitRoot string, info SessionRecoveryInfo) error {
+	sageoxPath := filepath.Join(gitRoot, sageoxDir)
+	if _, err := os.Stat(sageoxPath); os.IsNotExist(err) {
+		return errors.New(".sageox directory does not exist")
+	}
+
+	data, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(sageoxPath, sessionRecoveryFile), data, 0o644)
+}
+
+// GetSessionRecoveryInfo reads recovery metadata if it exists.
+// Returns nil if no recovery is pending.
+func GetSessionRecoveryInfo(gitRoot string) *SessionRecoveryInfo {
+	data, err := os.ReadFile(filepath.Join(gitRoot, sageoxDir, sessionRecoveryFile))
+	if err != nil {
+		return nil
+	}
+	var info SessionRecoveryInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil
+	}
+	return &info
+}
+
+// ClearSessionRecoveryInfo removes the recovery metadata file.
+func ClearSessionRecoveryInfo(gitRoot string) error {
+	path := filepath.Join(gitRoot, sageoxDir, sessionRecoveryFile)
+	err := os.Remove(path)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/session/adapters/adapter.go
+++ b/internal/session/adapters/adapter.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +26,44 @@ var (
 	// ErrWatchNotSupported is returned when an adapter does not support real-time watching
 	ErrWatchNotSupported = errors.New("watch not supported for this adapter")
 )
+
+// SessionLookup contains all parameters needed to locate an agent's session file.
+// Constructed from RecordingState at stop/hook time, or from command context at start time.
+// Replaces the old (agentID, since) signature that forced ambient repoRoot lookup.
+type SessionLookup struct {
+	RepoRoot       string    // absolute path to the project root (required, validated)
+	AgentID        string    // agent identifier (required)
+	Since          time.Time // filter to sessions created after this time (required)
+	AgentSessionID string    // adapter-native session UUID if known (optional)
+}
+
+// Validate checks that SessionLookup fields are well-formed.
+// RepoRoot must be absolute and contain a .sageox/ directory.
+func (sl SessionLookup) Validate() error {
+	if sl.RepoRoot == "" || sl.RepoRoot == "." {
+		return fmt.Errorf("repoRoot must be absolute, got %q", sl.RepoRoot)
+	}
+	if !filepath.IsAbs(sl.RepoRoot) {
+		return fmt.Errorf("repoRoot %q is not absolute", sl.RepoRoot)
+	}
+	if info, err := os.Stat(filepath.Join(sl.RepoRoot, ".sageox")); err != nil || !info.IsDir() {
+		return fmt.Errorf("repoRoot %q has no .sageox/ directory", sl.RepoRoot)
+	}
+	if sl.AgentID == "" {
+		return fmt.Errorf("agentID is required")
+	}
+	return nil
+}
+
+// CanonicalAdapterName returns the canonical adapter name for a given name or alias.
+// If the name is already canonical or unknown, it is returned as-is.
+func CanonicalAdapterName(name string) string {
+	lower := strings.ToLower(name)
+	if canonical, ok := adapterAliases[lower]; ok {
+		return canonical
+	}
+	return name
+}
 
 // RawEntry represents a conversation turn from any agent
 type RawEntry struct {
@@ -75,11 +115,11 @@ type Adapter interface {
 	// Returns true if the agent's session files are present and readable
 	Detect() bool
 
-	// FindSessionFile locates the session file for correlation
-	// Called after ox agent prime to find the matching agent session
-	// agentID is the unique identifier written during prime
-	// since filters to sessions created after this time
-	FindSessionFile(agentID string, since time.Time) (string, error)
+	// FindSessionFile locates the session file for correlation.
+	// Called after ox agent prime to find the matching agent session.
+	// The lookup struct carries all needed context (repoRoot, agentID, since)
+	// so the adapter never needs to derive repoRoot from ambient state.
+	FindSessionFile(lookup SessionLookup) (string, error)
 
 	// Read reads all entries from a session file
 	// Returns entries in chronological order

--- a/internal/session/adapters/adapter.go
+++ b/internal/session/adapters/adapter.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sageox/ox/pkg/adapterruntime"
 )
 
 var (
@@ -39,15 +39,11 @@ type SessionLookup struct {
 
 // Validate checks that SessionLookup fields are well-formed.
 // RepoRoot must be absolute and contain a .sageox/ directory.
+// Delegates path validation to adapterruntime.ValidateRepoRoot (single implementation,
+// includes 500ms stat timeout for NFS resilience).
 func (sl SessionLookup) Validate() error {
-	if sl.RepoRoot == "" || sl.RepoRoot == "." {
-		return fmt.Errorf("repoRoot must be absolute, got %q", sl.RepoRoot)
-	}
-	if !filepath.IsAbs(sl.RepoRoot) {
-		return fmt.Errorf("repoRoot %q is not absolute", sl.RepoRoot)
-	}
-	if info, err := os.Stat(filepath.Join(sl.RepoRoot, ".sageox")); err != nil || !info.IsDir() {
-		return fmt.Errorf("repoRoot %q has no .sageox/ directory", sl.RepoRoot)
+	if err := adapterruntime.ValidateRepoRoot(sl.RepoRoot); err != nil {
+		return err
 	}
 	if sl.AgentID == "" {
 		return fmt.Errorf("agentID is required")

--- a/internal/session/adapters/adapter_test.go
+++ b/internal/session/adapters/adapter_test.go
@@ -29,7 +29,7 @@ func (m *mockAdapter) Detect() bool {
 	return m.detect
 }
 
-func (m *mockAdapter) FindSessionFile(agentID string, since time.Time) (string, error) {
+func (m *mockAdapter) FindSessionFile(lookup SessionLookup) (string, error) {
 	if m.findErr != nil {
 		return "", m.findErr
 	}
@@ -226,7 +226,7 @@ func TestMockAdapter_FindSessionFile(t *testing.T) {
 		sessionID: "session-123",
 	}
 
-	path, err := adapter.FindSessionFile("agent-id", time.Now())
+	path, err := adapter.FindSessionFile(SessionLookup{RepoRoot: "/tmp", AgentID: "agent-id", Since: time.Now()})
 	require.NoError(t, err)
 	assert.Equal(t, "/path/to/session/session-123", path)
 }
@@ -238,7 +238,7 @@ func TestMockAdapter_FindSessionFile_Error(t *testing.T) {
 		findErr: expectedErr,
 	}
 
-	_, err := adapter.FindSessionFile("agent-id", time.Now())
+	_, err := adapter.FindSessionFile(SessionLookup{RepoRoot: "/tmp", AgentID: "agent-id", Since: time.Now()})
 	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
 }

--- a/internal/session/adapters/discovery_test.go
+++ b/internal/session/adapters/discovery_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func TestDiscoverExternalAdapters_FindsBinaries(t *testing.T) {
@@ -268,7 +267,7 @@ type discoveryMockAdapter struct {
 
 func (m *discoveryMockAdapter) Name() string                                              { return m.name }
 func (m *discoveryMockAdapter) Detect() bool                                              { return false }
-func (m *discoveryMockAdapter) FindSessionFile(_ string, _ time.Time) (string, error)     { return "", nil }
+func (m *discoveryMockAdapter) FindSessionFile(_ SessionLookup) (string, error)            { return "", nil }
 func (m *discoveryMockAdapter) Read(_ string) ([]RawEntry, error)                         { return nil, nil }
 func (m *discoveryMockAdapter) ReadMetadata(_ string) (*SessionMetadata, error)            { return nil, nil }
 func (m *discoveryMockAdapter) Watch(_ context.Context, _ string) (<-chan RawEntry, error) { return nil, nil }

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -9,13 +9,13 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/sageox/ox/pkg/adapterruntime"
 	"github.com/sageox/ox/pkg/ndjson"
 )
 
@@ -473,7 +473,7 @@ func (ea *ExternalAdapter) callInfo() (*adapterprotocol.InfoResponse, error) {
 // with a clear error instead of letting the adapter silently produce garbage.
 func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byte, error) {
 	if subcommand == "find-session" {
-		if err := validateRepoRootArg(args); err != nil {
+		if err := validateRepoRootArg(args, true); err != nil {
 			return nil, fmt.Errorf("pre-flight check for %s %s: %w", ea.binaryPath, subcommand, err)
 		}
 	}
@@ -511,26 +511,26 @@ func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byt
 }
 
 // validateRepoRootArg scans CLI args for --repo-root and validates the value
-// before spawning the subprocess. Catches bad paths at the CLI boundary
-// instead of letting adapters silently produce wrong results.
-func validateRepoRootArg(args []string) error {
+// before spawning the subprocess. Delegates path validation to
+// adapterruntime.ValidateRepoRoot (single implementation, includes 500ms stat
+// timeout for NFS resilience).
+// When requireRepoRoot is true (find-session), the absence of --repo-root is an error —
+// the adapter must not fall back to cwd for session discovery.
+func validateRepoRootArg(args []string, requireRepoRoot bool) error {
 	for i := 0; i < len(args)-1; i++ {
 		if args[i] != "--repo-root" {
 			continue
 		}
 		root := args[i+1]
-		if root == "" || root == "." {
-			return fmt.Errorf("--repo-root must be absolute, got %q", root)
-		}
-		if !filepath.IsAbs(root) {
-			return fmt.Errorf("--repo-root %q is not absolute", root)
-		}
-		if info, err := os.Stat(filepath.Join(root, ".sageox")); err != nil || !info.IsDir() {
-			return fmt.Errorf("--repo-root %q has no .sageox/ directory", root)
+		if err := adapterruntime.ValidateRepoRoot(root); err != nil {
+			return fmt.Errorf("--repo-root: %w", err)
 		}
 		return nil
 	}
-	return nil // no --repo-root arg present, nothing to validate
+	if requireRepoRoot {
+		return fmt.Errorf("--repo-root is required for find-session but was not provided")
+	}
+	return nil
 }
 
 // buildEnv constructs a sanitized environment for the adapter subprocess.

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -126,50 +126,22 @@ func (ea *ExternalAdapter) Detect() bool {
 	return resp.Detected
 }
 
-// resolveRepoRoot returns the symlink-resolved OX_REPO_ROOT, falling back to
-// cwd-based detection (walk up to find .sageox/) when the env var is unset.
-func resolveRepoRoot() string {
-	root := os.Getenv("OX_REPO_ROOT")
-	if root == "" {
-		root = detectRepoRootFromCwd()
-	}
-	if root == "" {
-		return ""
-	}
-	if resolved, err := filepath.EvalSymlinks(root); err == nil {
-		return resolved
-	}
-	return root
-}
-
-// detectRepoRootFromCwd walks up from cwd looking for a .sageox/ directory,
-// providing a fallback when OX_REPO_ROOT is not set in the environment.
-func detectRepoRootFromCwd() string {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-	dir := cwd
-	for {
-		if info, statErr := os.Stat(filepath.Join(dir, ".sageox")); statErr == nil && info.IsDir() {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return cwd
-		}
-		dir = parent
-	}
-}
-
 // FindSessionFile calls find-session via one-shot mode.
-// In production, serve mode is preferred, but one-shot provides a fallback.
-func (ea *ExternalAdapter) FindSessionFile(agentID string, since time.Time) (string, error) {
-	out, err := ea.execOneShot("find-session",
-		"--agent-id", agentID,
-		"--repo-root", resolveRepoRoot(),
-		"--since", since.UTC().Format(time.RFC3339),
-	)
+// The lookup.RepoRoot is passed directly to the adapter subprocess;
+// no ambient state (env/cwd) is consulted.
+func (ea *ExternalAdapter) FindSessionFile(lookup SessionLookup) (string, error) {
+	if err := lookup.Validate(); err != nil {
+		return "", fmt.Errorf("invalid session lookup: %w", err)
+	}
+	args := []string{
+		"--agent-id", lookup.AgentID,
+		"--repo-root", lookup.RepoRoot,
+		"--since", lookup.Since.UTC().Format(time.RFC3339),
+	}
+	if lookup.AgentSessionID != "" {
+		args = append(args, "--agent-session-id", lookup.AgentSessionID)
+	}
+	out, err := ea.execOneShot("find-session", args...)
 	if err != nil {
 		return "", err
 	}
@@ -497,7 +469,15 @@ func (ea *ExternalAdapter) callInfo() (*adapterprotocol.InfoResponse, error) {
 }
 
 // execOneShot runs a one-shot subcommand and returns stdout bytes.
+// Pre-validates --repo-root before spawning the subprocess to fail fast
+// with a clear error instead of letting the adapter silently produce garbage.
 func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byte, error) {
+	if subcommand == "find-session" {
+		if err := validateRepoRootArg(args); err != nil {
+			return nil, fmt.Errorf("pre-flight check for %s %s: %w", ea.binaryPath, subcommand, err)
+		}
+	}
+
 	cmdArgs := append([]string{subcommand}, args...)
 	ctx, cancel := context.WithTimeout(context.Background(), ea.oneShotTimeout)
 	defer cancel()
@@ -528,6 +508,29 @@ func (ea *ExternalAdapter) execOneShot(subcommand string, args ...string) ([]byt
 	}
 
 	return bytes.TrimSpace(stdout.Bytes()), nil
+}
+
+// validateRepoRootArg scans CLI args for --repo-root and validates the value
+// before spawning the subprocess. Catches bad paths at the CLI boundary
+// instead of letting adapters silently produce wrong results.
+func validateRepoRootArg(args []string) error {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] != "--repo-root" {
+			continue
+		}
+		root := args[i+1]
+		if root == "" || root == "." {
+			return fmt.Errorf("--repo-root must be absolute, got %q", root)
+		}
+		if !filepath.IsAbs(root) {
+			return fmt.Errorf("--repo-root %q is not absolute", root)
+		}
+		if info, err := os.Stat(filepath.Join(root, ".sageox")); err != nil || !info.IsDir() {
+			return fmt.Errorf("--repo-root %q has no .sageox/ directory", root)
+		}
+		return nil
+	}
+	return nil // no --repo-root arg present, nothing to validate
 }
 
 // buildEnv constructs a sanitized environment for the adapter subprocess.

--- a/internal/session/adapters/external_symlink_test.go
+++ b/internal/session/adapters/external_symlink_test.go
@@ -93,14 +93,14 @@ func TestSessionLookup_Validate_AcceptsValid(t *testing.T) {
 // TestValidateRepoRootArg_RejectsDot verifies "." is caught before subprocess spawn.
 // Failure prevented: adapter subprocess receives "." as --repo-root, silently fails.
 func TestValidateRepoRootArg_RejectsDot(t *testing.T) {
-	err := validateRepoRootArg([]string{"--repo-root", "."})
+	err := validateRepoRootArg([]string{"--repo-root", "."}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "absolute")
 }
 
 // TestValidateRepoRootArg_RejectsEmpty verifies empty value is caught.
 func TestValidateRepoRootArg_RejectsEmpty(t *testing.T) {
-	err := validateRepoRootArg([]string{"--repo-root", ""})
+	err := validateRepoRootArg([]string{"--repo-root", ""}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "absolute")
 }
@@ -110,7 +110,7 @@ func TestValidateRepoRootArg_RejectsNoSageox(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
 
-	err := validateRepoRootArg([]string{"--repo-root", tmpDir})
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir}, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), ".sageox/")
 }
@@ -121,13 +121,13 @@ func TestValidateRepoRootArg_AcceptsValid(t *testing.T) {
 	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
 
-	err := validateRepoRootArg([]string{"--repo-root", tmpDir})
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir}, false)
 	require.NoError(t, err)
 }
 
-// TestValidateRepoRootArg_NoRepoRootArg verifies no --repo-root arg passes (noop).
+// TestValidateRepoRootArg_NoRepoRootArg verifies no --repo-root arg passes when not required.
 func TestValidateRepoRootArg_NoRepoRootArg(t *testing.T) {
-	err := validateRepoRootArg([]string{"--agent-id", "test"})
+	err := validateRepoRootArg([]string{"--agent-id", "test"}, false)
 	require.NoError(t, err)
 }
 
@@ -283,7 +283,7 @@ func TestCanonicalAdapterName(t *testing.T) {
 // passes through. The loop condition `i < len(args)-1` skips it intentionally —
 // the adapter subprocess will reject the missing value.
 func TestValidateRepoRootArg_LastArgNoValue(t *testing.T) {
-	err := validateRepoRootArg([]string{"--repo-root"})
+	err := validateRepoRootArg([]string{"--repo-root"}, false)
 	require.NoError(t, err, "trailing --repo-root without value should pass through to subprocess")
 }
 
@@ -295,11 +295,11 @@ func TestValidateRepoRootArg_FirstOfDuplicates(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
 
 	// first is valid, second is bad — should pass because first is checked and returned
-	err := validateRepoRootArg([]string{"--repo-root", tmpDir, "--repo-root", "."})
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir, "--repo-root", "."}, false)
 	require.NoError(t, err)
 
 	// first is bad — should fail even though second is valid
-	err = validateRepoRootArg([]string{"--repo-root", ".", "--repo-root", tmpDir})
+	err = validateRepoRootArg([]string{"--repo-root", ".", "--repo-root", tmpDir}, false)
 	require.Error(t, err)
 }
 
@@ -307,7 +307,7 @@ func TestValidateRepoRootArg_FirstOfDuplicates(t *testing.T) {
 // This documents a known gap — the function only matches `--repo-root <value>` (space-separated).
 // The adapter subprocess handles --repo-root=value parsing itself.
 func TestValidateRepoRootArg_EqualsSyntaxPassthrough(t *testing.T) {
-	err := validateRepoRootArg([]string{"--repo-root=."})
+	err := validateRepoRootArg([]string{"--repo-root=."}, false)
 	require.NoError(t, err, "--repo-root=value syntax is not matched by pre-flight check")
 }
 
@@ -321,7 +321,7 @@ func TestValidateRepoRootArg_MixedArgs(t *testing.T) {
 		"--agent-id", "OxTest",
 		"--repo-root", tmpDir,
 		"--since", "2026-01-01T00:00:00Z",
-	})
+	}, false)
 	require.NoError(t, err)
 }
 
@@ -332,16 +332,45 @@ func TestValidateRepoRootArg_PathWithSpaces(t *testing.T) {
 	tmpDir = filepath.Join(tmpDir, "my project")
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
 
-	err := validateRepoRootArg([]string{"--repo-root", tmpDir})
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir}, false)
 	require.NoError(t, err)
 }
 
 // TestValidateRepoRootArg_NilArgs verifies nil slice is safe.
 func TestValidateRepoRootArg_NilArgs(t *testing.T) {
-	require.NoError(t, validateRepoRootArg(nil))
+	require.NoError(t, validateRepoRootArg(nil, false))
 }
 
 // TestValidateRepoRootArg_EmptySlice verifies empty slice is safe.
 func TestValidateRepoRootArg_EmptySlice(t *testing.T) {
-	require.NoError(t, validateRepoRootArg([]string{}))
+	require.NoError(t, validateRepoRootArg([]string{}, false))
+}
+
+// --- F. validateRepoRootArg fail-closed for find-session ---
+
+// TestValidateRepoRootArg_RequireRepoRoot_MissingFails verifies that when
+// requireRepoRoot is true, missing --repo-root is an error (fail closed).
+// Failure prevented: find-session silently falls back to cwd when --repo-root omitted.
+func TestValidateRepoRootArg_RequireRepoRoot_MissingFails(t *testing.T) {
+	err := validateRepoRootArg([]string{"--agent-id", "test"}, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required for find-session")
+}
+
+// TestValidateRepoRootArg_RequireRepoRoot_EmptyArgsFails verifies empty args
+// with requireRepoRoot is an error.
+func TestValidateRepoRootArg_RequireRepoRoot_EmptyArgsFails(t *testing.T) {
+	require.Error(t, validateRepoRootArg(nil, true))
+	require.Error(t, validateRepoRootArg([]string{}, true))
+}
+
+// TestValidateRepoRootArg_RequireRepoRoot_ValidPasses verifies that when
+// requireRepoRoot is true and --repo-root is valid, no error.
+func TestValidateRepoRootArg_RequireRepoRoot_ValidPasses(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir}, true)
+	require.NoError(t, err)
 }

--- a/internal/session/adapters/external_symlink_test.go
+++ b/internal/session/adapters/external_symlink_test.go
@@ -4,141 +4,344 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestResolveRepoRoot_Symlink(t *testing.T) {
-	realDir := t.TempDir()
-	// resolve any intermediate symlinks (e.g., /tmp -> /private/tmp on macOS)
-	realDir, err := filepath.EvalSymlinks(realDir)
-	if err != nil {
-		t.Fatalf("EvalSymlinks: %v", err)
-	}
+// --- A. SessionLookup validation ---
 
-	symlinkDir := filepath.Join(t.TempDir(), "symlink-repo")
-	if err := os.Symlink(realDir, symlinkDir); err != nil {
-		t.Fatalf("create symlink: %v", err)
+// TestSessionLookup_Validate_RejectsRelativePath verifies that "." and other
+// relative paths are rejected with a clear error.
+// Failure prevented: adapter receives "." as --repo-root, hashes it to "-",
+// looks in nonexistent ~/.claude/projects/-, silently fails.
+func TestSessionLookup_Validate_RejectsRelativePath(t *testing.T) {
+	lookup := SessionLookup{
+		RepoRoot: ".",
+		AgentID:  "OxTest",
+		Since:    time.Now(),
 	}
-
-	t.Setenv("OX_REPO_ROOT", symlinkDir)
-
-	got := resolveRepoRoot()
-	if got != realDir {
-		t.Errorf("resolveRepoRoot() = %q, want %q", got, realDir)
-	}
+	err := lookup.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
 }
 
-func TestResolveRepoRoot_NonexistentPath(t *testing.T) {
-	t.Setenv("OX_REPO_ROOT", "/nonexistent/path")
-
-	got := resolveRepoRoot()
-	if got != "/nonexistent/path" {
-		t.Errorf("resolveRepoRoot() = %q, want %q", got, "/nonexistent/path")
+// TestSessionLookup_Validate_RejectsEmpty verifies empty repoRoot is rejected.
+// Failure prevented: empty string passed as --repo-root to adapter subprocess.
+func TestSessionLookup_Validate_RejectsEmpty(t *testing.T) {
+	lookup := SessionLookup{
+		RepoRoot: "",
+		AgentID:  "OxTest",
+		Since:    time.Now(),
 	}
+	err := lookup.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
 }
 
-// --- B. Cwd-based fallback when OX_REPO_ROOT is unset ---
-
-// TestResolveRepoRoot_CwdFallback_FindsSageoxDir verifies that when OX_REPO_ROOT
-// is empty, resolveRepoRoot walks up from cwd to find .sageox/.
-// Failure prevented: adapter receives empty --repo-root, searches wrong Claude project dir.
-func TestResolveRepoRoot_CwdFallback_FindsSageoxDir(t *testing.T) {
-	tmpDir := t.TempDir()
-	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Chdir(origDir) })
-	t.Setenv("OX_REPO_ROOT", "")
-
-	got := resolveRepoRoot()
-	if got != tmpDir {
-		t.Errorf("resolveRepoRoot() = %q, want %q", got, tmpDir)
-	}
-}
-
-// TestResolveRepoRoot_CwdFallback_WalksUpToParent verifies cwd fallback finds
-// .sageox/ when cwd is a subdirectory of the project root.
-// Failure prevented: adapter fails when ox commands run from a subdirectory.
-func TestResolveRepoRoot_CwdFallback_WalksUpToParent(t *testing.T) {
-	tmpDir := t.TempDir()
-	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	subDir := filepath.Join(tmpDir, "src", "pkg", "deep")
-	if err := os.MkdirAll(subDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(subDir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Chdir(origDir) })
-	t.Setenv("OX_REPO_ROOT", "")
-
-	got := resolveRepoRoot()
-	if got != tmpDir {
-		t.Errorf("resolveRepoRoot() = %q, want %q (should walk up from subdirectory)", got, tmpDir)
-	}
-}
-
-// TestResolveRepoRoot_CwdFallback_ResolvesSymlinks verifies that the cwd fallback
-// resolves symlinks in the detected path. This is the actual production scenario:
-// /Users/ryan/Code → /Users/ryan/Documents/Code (symlink), and Claude Code stores
-// sessions under the resolved path.
-// Failure prevented: adapter computes hash from unresolved symlink path, wrong project dir.
-func TestResolveRepoRoot_CwdFallback_ResolvesSymlinks(t *testing.T) {
-	// create real dir with .sageox/
-	realDir := t.TempDir()
-	realDir, _ = filepath.EvalSymlinks(realDir)
-	if err := os.MkdirAll(filepath.Join(realDir, ".sageox"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// create symlink pointing to the real dir
-	symlinkParent := t.TempDir()
-	symlinkDir := filepath.Join(symlinkParent, "symlink-project")
-	if err := os.Symlink(realDir, symlinkDir); err != nil {
-		t.Fatalf("create symlink: %v", err)
-	}
-
-	// cd into symlink path
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(symlinkDir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Chdir(origDir) })
-	t.Setenv("OX_REPO_ROOT", "")
-
-	got := resolveRepoRoot()
-	if got != realDir {
-		t.Errorf("resolveRepoRoot() = %q, want %q (should resolve symlink)", got, realDir)
-	}
-}
-
-// TestResolveRepoRoot_CwdFallback_NoSageoxDir verifies that when no .sageox/
-// exists anywhere, the fallback returns cwd rather than empty string.
-// Failure prevented: nil/empty path causing panic or cryptic errors downstream.
-func TestResolveRepoRoot_CwdFallback_NoSageoxDir(t *testing.T) {
+// TestSessionLookup_Validate_RejectsNoSageox verifies that a valid absolute
+// path without .sageox/ is rejected.
+// Failure prevented: adapter runs against a directory that isn't an ox project.
+func TestSessionLookup_Validate_RejectsNoSageox(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
 
-	origDir, _ := os.Getwd()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
+	lookup := SessionLookup{
+		RepoRoot: tmpDir,
+		AgentID:  "OxTest",
+		Since:    time.Now(),
 	}
-	t.Cleanup(func() { os.Chdir(origDir) })
-	t.Setenv("OX_REPO_ROOT", "")
+	err := lookup.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".sageox/")
+}
 
-	got := resolveRepoRoot()
-	// should return cwd (resolved), not empty string
-	if got == "" {
-		t.Error("resolveRepoRoot() returned empty, want cwd fallback")
+// TestSessionLookup_Validate_RejectsEmptyAgentID verifies agentID is required.
+func TestSessionLookup_Validate_RejectsEmptyAgentID(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	lookup := SessionLookup{
+		RepoRoot: tmpDir,
+		AgentID:  "",
+		Since:    time.Now(),
 	}
+	err := lookup.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agentID")
+}
+
+// TestSessionLookup_Validate_AcceptsValid verifies a well-formed lookup passes.
+func TestSessionLookup_Validate_AcceptsValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	lookup := SessionLookup{
+		RepoRoot: tmpDir,
+		AgentID:  "OxTest",
+		Since:    time.Now(),
+	}
+	err := lookup.Validate()
+	require.NoError(t, err)
+}
+
+// --- B. execOneShot pre-flight validation (validateRepoRootArg) ---
+
+// TestValidateRepoRootArg_RejectsDot verifies "." is caught before subprocess spawn.
+// Failure prevented: adapter subprocess receives "." as --repo-root, silently fails.
+func TestValidateRepoRootArg_RejectsDot(t *testing.T) {
+	err := validateRepoRootArg([]string{"--repo-root", "."})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
+}
+
+// TestValidateRepoRootArg_RejectsEmpty verifies empty value is caught.
+func TestValidateRepoRootArg_RejectsEmpty(t *testing.T) {
+	err := validateRepoRootArg([]string{"--repo-root", ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
+}
+
+// TestValidateRepoRootArg_RejectsNoSageox verifies absolute path without .sageox/ is caught.
+func TestValidateRepoRootArg_RejectsNoSageox(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".sageox/")
+}
+
+// TestValidateRepoRootArg_AcceptsValid verifies a proper ox project root passes.
+func TestValidateRepoRootArg_AcceptsValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir})
+	require.NoError(t, err)
+}
+
+// TestValidateRepoRootArg_NoRepoRootArg verifies no --repo-root arg passes (noop).
+func TestValidateRepoRootArg_NoRepoRootArg(t *testing.T) {
+	err := validateRepoRootArg([]string{"--agent-id", "test"})
+	require.NoError(t, err)
+}
+
+// --- C. SessionLookup edge cases ---
+
+// TestSessionLookup_Validate_PathWithSpaces verifies paths containing spaces are accepted.
+// Failure prevented: paths with spaces silently break session file hashing.
+func TestSessionLookup_Validate_PathWithSpaces(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), "my project repo")
+	tmpDir, _ = filepath.EvalSymlinks(filepath.Dir(tmpDir))
+	tmpDir = filepath.Join(tmpDir, "my project repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	lookup := SessionLookup{RepoRoot: tmpDir, AgentID: "OxTest", Since: time.Now()}
+	require.NoError(t, lookup.Validate())
+}
+
+// TestSessionLookup_Validate_TrailingSlash verifies trailing slash is accepted.
+func TestSessionLookup_Validate_TrailingSlash(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	lookup := SessionLookup{RepoRoot: tmpDir + "/", AgentID: "OxTest", Since: time.Now()}
+	require.NoError(t, lookup.Validate())
+}
+
+// TestSessionLookup_Validate_SymlinkedSageox verifies .sageox as a symlink to a real dir.
+// Failure prevented: projects using symlinked .sageox/ (e.g., shared config) rejected.
+func TestSessionLookup_Validate_SymlinkedSageox(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	realDir := filepath.Join(tmpDir, "real-sageox")
+	require.NoError(t, os.MkdirAll(realDir, 0o755))
+	require.NoError(t, os.Symlink(realDir, filepath.Join(tmpDir, ".sageox")))
+
+	lookup := SessionLookup{RepoRoot: tmpDir, AgentID: "OxTest", Since: time.Now()}
+	require.NoError(t, lookup.Validate())
+}
+
+// TestSessionLookup_Validate_SageoxIsFile verifies .sageox as a file (not dir) is rejected.
+// Failure prevented: stale .sageox file from interrupted init passes validation.
+func TestSessionLookup_Validate_SageoxIsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".sageox"), []byte("not a dir"), 0o644))
+
+	lookup := SessionLookup{RepoRoot: tmpDir, AgentID: "OxTest", Since: time.Now()}
+	err := lookup.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".sageox/")
+}
+
+// TestSessionLookup_Validate_ZeroSinceAllowed verifies zero Since time passes.
+// Since is not validated by Validate() — it's the caller's responsibility.
+func TestSessionLookup_Validate_ZeroSinceAllowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	lookup := SessionLookup{RepoRoot: tmpDir, AgentID: "OxTest", Since: time.Time{}}
+	require.NoError(t, lookup.Validate())
+}
+
+// TestSessionLookup_Validate_AgentSessionIDOptional verifies empty AgentSessionID passes.
+func TestSessionLookup_Validate_AgentSessionIDOptional(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	lookup := SessionLookup{RepoRoot: tmpDir, AgentID: "OxTest", Since: time.Now(), AgentSessionID: ""}
+	require.NoError(t, lookup.Validate())
+}
+
+// TestSessionLookup_Validate_NonexistentPath verifies nonexistent path is rejected.
+func TestSessionLookup_Validate_NonexistentPath(t *testing.T) {
+	lookup := SessionLookup{RepoRoot: "/nonexistent/path/that/does/not/exist", AgentID: "OxTest", Since: time.Now()}
+	err := lookup.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".sageox/")
+}
+
+// TestSessionLookup_Validate_TildePath verifies ~ is rejected (not absolute after expansion).
+func TestSessionLookup_Validate_TildePath(t *testing.T) {
+	lookup := SessionLookup{RepoRoot: "~/repo", AgentID: "OxTest", Since: time.Now()}
+	err := lookup.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
+}
+
+// --- D. CanonicalAdapterName ---
+
+// TestCanonicalAdapterName verifies alias resolution for all known adapters.
+// Failure prevented: agent_type drift causes "claude" vs "claude-code" in metadata,
+// breaking session lookup and downstream analytics.
+func TestCanonicalAdapterName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// claude-code aliases
+		{"claude code", "claude-code"},
+		{"Claude Code", "claude-code"},
+		{"claude", "claude-code"},
+		{"CLAUDE", "claude-code"},
+
+		// gemini aliases
+		{"gemini", "gemini"},
+		{"gemini-cli", "gemini"},
+		{"Gemini CLI", "gemini"},
+		{"Gemini", "gemini"},
+
+		// generic fallbacks
+		{"codex", "codex"},
+		{"Codex", "codex"},
+		{"amp", "amp"},
+		{"cursor", "generic"},
+		{"windsurf", "generic"},
+		{"copilot", "generic"},
+		{"aider", "aider"},
+		{"cody", "generic"},
+		{"continue", "generic"},
+		{"cline", "generic"},
+		{"goose", "generic"},
+		{"kiro", "generic"},
+		{"opencode", "opencode"},
+		{"pi", "pi"},
+		{"pi-coding-agent", "pi"},
+		{"droid", "droid"},
+
+		// already canonical — passthrough
+		{"claude-code", "claude-code"},
+		{"generic", "generic"},
+
+		// unknown — passthrough unchanged
+		{"MyCustomAdapter", "MyCustomAdapter"},
+		{"unknown-agent", "unknown-agent"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := CanonicalAdapterName(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// --- E. validateRepoRootArg edge cases ---
+
+// TestValidateRepoRootArg_LastArgNoValue verifies --repo-root as the last arg (no value)
+// passes through. The loop condition `i < len(args)-1` skips it intentionally —
+// the adapter subprocess will reject the missing value.
+func TestValidateRepoRootArg_LastArgNoValue(t *testing.T) {
+	err := validateRepoRootArg([]string{"--repo-root"})
+	require.NoError(t, err, "trailing --repo-root without value should pass through to subprocess")
+}
+
+// TestValidateRepoRootArg_FirstOfDuplicates verifies only the first --repo-root is validated.
+// Failure prevented: second occurrence could bypass validation of the first.
+func TestValidateRepoRootArg_FirstOfDuplicates(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	// first is valid, second is bad — should pass because first is checked and returned
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir, "--repo-root", "."})
+	require.NoError(t, err)
+
+	// first is bad — should fail even though second is valid
+	err = validateRepoRootArg([]string{"--repo-root", ".", "--repo-root", tmpDir})
+	require.Error(t, err)
+}
+
+// TestValidateRepoRootArg_EqualsSyntaxPassthrough verifies --repo-root=/path is not matched.
+// This documents a known gap — the function only matches `--repo-root <value>` (space-separated).
+// The adapter subprocess handles --repo-root=value parsing itself.
+func TestValidateRepoRootArg_EqualsSyntaxPassthrough(t *testing.T) {
+	err := validateRepoRootArg([]string{"--repo-root=."})
+	require.NoError(t, err, "--repo-root=value syntax is not matched by pre-flight check")
+}
+
+// TestValidateRepoRootArg_MixedArgs verifies --repo-root is found among other args.
+func TestValidateRepoRootArg_MixedArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	err := validateRepoRootArg([]string{
+		"--agent-id", "OxTest",
+		"--repo-root", tmpDir,
+		"--since", "2026-01-01T00:00:00Z",
+	})
+	require.NoError(t, err)
+}
+
+// TestValidateRepoRootArg_PathWithSpaces verifies paths with spaces work.
+func TestValidateRepoRootArg_PathWithSpaces(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), "my project")
+	tmpDir, _ = filepath.EvalSymlinks(filepath.Dir(tmpDir))
+	tmpDir = filepath.Join(tmpDir, "my project")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+
+	err := validateRepoRootArg([]string{"--repo-root", tmpDir})
+	require.NoError(t, err)
+}
+
+// TestValidateRepoRootArg_NilArgs verifies nil slice is safe.
+func TestValidateRepoRootArg_NilArgs(t *testing.T) {
+	require.NoError(t, validateRepoRootArg(nil))
+}
+
+// TestValidateRepoRootArg_EmptySlice verifies empty slice is safe.
+func TestValidateRepoRootArg_EmptySlice(t *testing.T) {
+	require.NoError(t, validateRepoRootArg([]string{}))
 }

--- a/internal/session/adapters/generic_jsonl.go
+++ b/internal/session/adapters/generic_jsonl.go
@@ -31,7 +31,7 @@ func (a *GenericJSONLAdapter) Detect() bool {
 
 // FindSessionFile is not supported by the generic adapter. The session file
 // path is created by session start and passed through recording state.
-func (a *GenericJSONLAdapter) FindSessionFile(_ string, _ time.Time) (string, error) {
+func (a *GenericJSONLAdapter) FindSessionFile(_ SessionLookup) (string, error) {
 	return "", ErrSessionNotFound
 }
 

--- a/internal/session/adapters/generic_jsonl_test.go
+++ b/internal/session/adapters/generic_jsonl_test.go
@@ -23,7 +23,7 @@ func TestGenericJSONLAdapter_Detect(t *testing.T) {
 
 func TestGenericJSONLAdapter_FindSessionFile(t *testing.T) {
 	adapter := &GenericJSONLAdapter{}
-	_, err := adapter.FindSessionFile("agent-123", time.Now())
+	_, err := adapter.FindSessionFile(SessionLookup{RepoRoot: "/tmp", AgentID: "agent-123", Since: time.Now()})
 	assert.ErrorIs(t, err, ErrSessionNotFound)
 }
 

--- a/internal/session/history_store.go
+++ b/internal/session/history_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -85,6 +86,7 @@ func GetHistoryStoragePath(agentID string, activeRecording bool) string {
 	// try to find active recording state
 	cwd, err := os.Getwd()
 	if err != nil {
+		slog.Warn("GetHistoryStoragePath: os.Getwd failed, using '.'", "error", err)
 		cwd = "."
 	}
 

--- a/internal/session/recording_state_test.go
+++ b/internal/session/recording_state_test.go
@@ -516,6 +516,97 @@ func TestLoadAllRecordingStates_MixedValidAndCorrupt(t *testing.T) {
 	assert.Equal(t, "OxGood", states[0].AgentID)
 }
 
+// --- P0: WorkspacePath persistence (session-stop hardening) ---
+
+// TestRecordingState_WorkspacePath_RoundTrip verifies WorkspacePath survives JSON serialization.
+// Failure prevented: WorkspacePath lost during save/load cycle causes ambient cwd derivation
+// at stop time, which was the root cause of the 2h33m session loss.
+func TestRecordingState_WorkspacePath_RoundTrip(t *testing.T) {
+	cacheDir := t.TempDir()
+	projectRoot, sessionsBase := setupRecordingTestWithSessionsBase(t, cacheDir)
+	sessionPath := filepath.Join(sessionsBase, "2026-04-09T10-00-user-OxWksp")
+
+	originalState := &RecordingState{
+		AgentID:       "OxWksp",
+		StartedAt:     time.Now().Truncate(time.Second),
+		AdapterName:   "claude-code",
+		SessionPath:   sessionPath,
+		WorkspacePath: "/home/user/my-project",
+	}
+
+	err := SaveRecordingState(projectRoot, originalState)
+	require.NoError(t, err)
+
+	loaded, err := LoadRecordingState(projectRoot)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "/home/user/my-project", loaded.WorkspacePath,
+		"WorkspacePath must survive save/load round-trip")
+}
+
+// TestRecordingState_WorkspacePath_EmptyForLegacy verifies legacy states without
+// WorkspacePath deserialize correctly with empty string (backward compatibility).
+// Failure prevented: legacy .recording.json without workspace_path causes nil panic.
+func TestRecordingState_WorkspacePath_EmptyForLegacy(t *testing.T) {
+	cacheDir := t.TempDir()
+	projectRoot, sessionsBase := setupRecordingTestWithSessionsBase(t, cacheDir)
+	sessionPath := filepath.Join(sessionsBase, "2026-01-01T10-00-user-OxLgcy")
+	require.NoError(t, os.MkdirAll(sessionPath, 0o755))
+
+	// simulate old recording state JSON without workspace_path field
+	legacyJSON := `{"agent_id":"OxLgcy","started_at":"2026-01-01T10:00:00Z","adapter_name":"claude-code","session_path":"` + sessionPath + `"}`
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, recordingFile), []byte(legacyJSON), 0o600))
+
+	loaded, err := LoadRecordingState(projectRoot)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "", loaded.WorkspacePath,
+		"legacy state without workspace_path should deserialize as empty string")
+	assert.Equal(t, "OxLgcy", loaded.AgentID)
+}
+
+// TestRecordingState_WorkspacePath_WithSpaces verifies paths with spaces survive round-trip.
+// Failure prevented: paths with spaces get truncated or corrupted in JSON serialization.
+func TestRecordingState_WorkspacePath_WithSpaces(t *testing.T) {
+	cacheDir := t.TempDir()
+	projectRoot, sessionsBase := setupRecordingTestWithSessionsBase(t, cacheDir)
+	sessionPath := filepath.Join(sessionsBase, "2026-04-09T10-00-user-OxSpc")
+
+	pathWithSpaces := "/home/alice smith/my cool project"
+	state := &RecordingState{
+		AgentID:       "OxSpc",
+		StartedAt:     time.Now().Truncate(time.Second),
+		AdapterName:   "claude-code",
+		SessionPath:   sessionPath,
+		WorkspacePath: pathWithSpaces,
+	}
+
+	require.NoError(t, SaveRecordingState(projectRoot, state))
+
+	loaded, err := LoadRecordingState(projectRoot)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, pathWithSpaces, loaded.WorkspacePath,
+		"WorkspacePath with spaces must survive round-trip")
+}
+
+// TestStartRecording_SetsWorkspacePath verifies StartRecording populates WorkspacePath.
+// Failure prevented: WorkspacePath not set at start means stop time has no repoRoot source.
+func TestStartRecording_SetsWorkspacePath(t *testing.T) {
+	cacheDir := t.TempDir()
+	projectRoot := setupRecordingTest(t, cacheDir)
+
+	state, err := StartRecording(projectRoot, StartRecordingOptions{
+		AgentID:       "OxWsSet",
+		AdapterName:   "claude-code",
+		Username:      "testuser",
+		WorkspacePath: "/home/user/my-project",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/my-project", state.WorkspacePath,
+		"WorkspacePath should be set from StartRecordingOptions")
+}
+
 // --- P0: Recording state corruption resilience ---
 
 func TestLoadRecordingState_TruncatedJSON(t *testing.T) {

--- a/pkg/adapterruntime/runtime.go
+++ b/pkg/adapterruntime/runtime.go
@@ -19,14 +19,21 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/sageox/ox/pkg/ndjson"
 )
 
+// statTimeout is the maximum time to wait for os.Stat on .sageox/ directories.
+// NFS-mounted repos can hang indefinitely on stat calls; 500ms is generous for
+// local and most network filesystems while preventing hook-path hangs.
+const statTimeout = 500 * time.Millisecond
+
 // ValidateRepoRoot checks that a repo root path is non-empty, absolute, and
 // contains a .sageox/ directory. All adapters using this SDK get this
 // validation for free when called via the find-session dispatch path.
+// The .sageox stat uses a 500ms timeout to prevent NFS hangs in hook paths.
 func ValidateRepoRoot(root string) error {
 	if root == "" || root == "." {
 		return fmt.Errorf("repo-root must be absolute, got %q", root)
@@ -34,11 +41,34 @@ func ValidateRepoRoot(root string) error {
 	if !filepath.IsAbs(root) {
 		return fmt.Errorf("repo-root %q is not absolute", root)
 	}
-	info, err := os.Stat(filepath.Join(root, ".sageox"))
-	if err != nil || !info.IsDir() {
+	info, err := statWithTimeout(filepath.Join(root, ".sageox"), statTimeout)
+	if err != nil {
+		return fmt.Errorf("repo-root %q has no .sageox/ directory: %w", root, err)
+	}
+	if !info.IsDir() {
 		return fmt.Errorf("repo-root %q has no .sageox/ directory", root)
 	}
 	return nil
+}
+
+// statWithTimeout runs os.Stat in a goroutine with a deadline.
+// Returns the FileInfo on success, or an error on timeout / stat failure.
+func statWithTimeout(path string, timeout time.Duration) (os.FileInfo, error) {
+	type result struct {
+		info os.FileInfo
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		info, err := os.Stat(path)
+		ch <- result{info, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.info, r.err
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("stat %q timed out after %v (possible NFS hang)", path, timeout)
+	}
 }
 
 // Config holds the handler functions for each adapter subcommand.

--- a/pkg/adapterruntime/runtime.go
+++ b/pkg/adapterruntime/runtime.go
@@ -16,12 +16,30 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 
 	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/sageox/ox/pkg/ndjson"
 )
+
+// ValidateRepoRoot checks that a repo root path is non-empty, absolute, and
+// contains a .sageox/ directory. All adapters using this SDK get this
+// validation for free when called via the find-session dispatch path.
+func ValidateRepoRoot(root string) error {
+	if root == "" || root == "." {
+		return fmt.Errorf("repo-root must be absolute, got %q", root)
+	}
+	if !filepath.IsAbs(root) {
+		return fmt.Errorf("repo-root %q is not absolute", root)
+	}
+	info, err := os.Stat(filepath.Join(root, ".sageox"))
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("repo-root %q has no .sageox/ directory", root)
+	}
+	return nil
+}
 
 // Config holds the handler functions for each adapter subcommand.
 // Nil handlers cause the subcommand to return an error.
@@ -140,6 +158,11 @@ func RunWithArgs(cfg Config, args []string, stdin io.Reader, stdout io.Writer) e
 
 	case "find-session":
 		p := parseFindSessionParams(args[1:])
+		if err := ValidateRepoRoot(p.RepoRoot); err != nil {
+			return runOneShot(enc, func() (any, error) {
+				return nil, fmt.Errorf("invalid repo-root: %w", err)
+			})
+		}
 		return runOneShot(enc, func() (any, error) {
 			if cfg.FindSession == nil {
 				return nil, fmt.Errorf("find-session not implemented")
@@ -518,6 +541,17 @@ func (s *Server) Serve() {
 func (s *Server) dispatch(req adapterprotocol.Request) {
 	switch req.Method {
 	case adapterprotocol.MethodFindSession:
+		// pre-validate repoRoot before dispatching to handler
+		var fp adapterprotocol.FindSessionParams
+		if err := json.Unmarshal(req.Params, &fp); err == nil {
+			if err := ValidateRepoRoot(fp.RepoRoot); err != nil {
+				s.writer.WriteResponse(adapterprotocol.Response{
+					ID:    req.ID,
+					Error: &adapterprotocol.RPCError{Code: adapterprotocol.ErrCodeInvalidParams, Message: fmt.Sprintf("invalid repo-root: %v", err)},
+				})
+				return
+			}
+		}
 		dispatchMethod(s, req, s.findSession)
 	case adapterprotocol.MethodReadFromOffset:
 		dispatchMethod(s, req, s.readFromOffset)

--- a/pkg/adapterruntime/runtime_test.go
+++ b/pkg/adapterruntime/runtime_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -82,10 +84,16 @@ func TestServer_UnknownMethod(t *testing.T) {
 }
 
 func TestServer_FindSession(t *testing.T) {
+	// create real temp dir with .sageox/ so ValidateRepoRoot passes
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	params, _ := json.Marshal(adapterprotocol.FindSessionParams{
 		AgentID:  "OxA1b2",
 		RepoID:   "abc123",
-		RepoRoot: "/tmp/repo",
+		RepoRoot: tmpDir,
 		Since:    "2026-04-02T10:00:00Z",
 	})
 	req := adapterprotocol.Request{ID: 1, Method: "find-session", Params: params}
@@ -666,6 +674,127 @@ func TestRunWithArgs_InstallRules_NotImplemented(t *testing.T) {
 	}
 	if errResp["error"] == "" {
 		t.Error("expected non-empty error message in JSON response")
+	}
+}
+
+// --- FindSession RepoRoot validation (one-shot dispatch) ---
+// Failure prevented: adapter binary accepts bad repo-root and silently returns
+// garbage, causing session recording loss.
+
+func TestRunWithArgs_FindSession_RejectsDot(t *testing.T) {
+	var stdout bytes.Buffer
+	cfg := adapterruntime.Config{
+		FindSession: func(p adapterprotocol.FindSessionParams) (*adapterprotocol.FindSessionResult, error) {
+			t.Fatal("handler must not be called with bad repo-root")
+			return nil, nil
+		},
+	}
+	err := adapterruntime.RunWithArgs(cfg, []string{
+		"find-session", "--repo-root", ".", "--agent-id", "test", "--since", "2026-01-01T00:00:00Z",
+	}, nil, &stdout)
+	if err == nil {
+		t.Fatal("expected error for repo-root '.'")
+	}
+}
+
+func TestRunWithArgs_FindSession_RejectsEmpty(t *testing.T) {
+	var stdout bytes.Buffer
+	cfg := adapterruntime.Config{
+		FindSession: func(p adapterprotocol.FindSessionParams) (*adapterprotocol.FindSessionResult, error) {
+			t.Fatal("handler must not be called with empty repo-root")
+			return nil, nil
+		},
+	}
+	err := adapterruntime.RunWithArgs(cfg, []string{
+		"find-session", "--repo-root", "", "--agent-id", "test", "--since", "2026-01-01T00:00:00Z",
+	}, nil, &stdout)
+	if err == nil {
+		t.Fatal("expected error for empty repo-root")
+	}
+}
+
+func TestRunWithArgs_FindSession_RejectsRelative(t *testing.T) {
+	var stdout bytes.Buffer
+	cfg := adapterruntime.Config{
+		FindSession: func(p adapterprotocol.FindSessionParams) (*adapterprotocol.FindSessionResult, error) {
+			t.Fatal("handler must not be called with relative repo-root")
+			return nil, nil
+		},
+	}
+	err := adapterruntime.RunWithArgs(cfg, []string{
+		"find-session", "--repo-root", "some/relative/path", "--agent-id", "test", "--since", "2026-01-01T00:00:00Z",
+	}, nil, &stdout)
+	if err == nil {
+		t.Fatal("expected error for relative repo-root")
+	}
+}
+
+func TestRunWithArgs_FindSession_RejectsNonexistent(t *testing.T) {
+	var stdout bytes.Buffer
+	cfg := adapterruntime.Config{
+		FindSession: func(p adapterprotocol.FindSessionParams) (*adapterprotocol.FindSessionResult, error) {
+			t.Fatal("handler must not be called with nonexistent repo-root")
+			return nil, nil
+		},
+	}
+	err := adapterruntime.RunWithArgs(cfg, []string{
+		"find-session", "--repo-root", "/nonexistent/path/compliance", "--agent-id", "test", "--since", "2026-01-01T00:00:00Z",
+	}, nil, &stdout)
+	if err == nil {
+		t.Fatal("expected error for nonexistent repo-root")
+	}
+}
+
+func TestRunWithArgs_FindSession_AcceptsValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	handlerCalled := false
+	var stdout bytes.Buffer
+	cfg := adapterruntime.Config{
+		FindSession: func(p adapterprotocol.FindSessionParams) (*adapterprotocol.FindSessionResult, error) {
+			handlerCalled = true
+			if p.RepoRoot != tmpDir {
+				t.Errorf("RepoRoot = %q, want %q", p.RepoRoot, tmpDir)
+			}
+			return &adapterprotocol.FindSessionResult{SessionFile: "/tmp/session.jsonl"}, nil
+		},
+	}
+	err := adapterruntime.RunWithArgs(cfg, []string{
+		"find-session", "--repo-root", tmpDir, "--agent-id", "test", "--since", "2026-01-01T00:00:00Z",
+	}, nil, &stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handlerCalled {
+		t.Fatal("handler should have been called with valid repo-root")
+	}
+}
+
+// TestServer_FindSession_BadRepoRoot verifies serve-mode rejects bad repoRoot.
+// Failure prevented: daemon sends find-session via serve mode with bad repoRoot.
+func TestServer_FindSession_BadRepoRoot(t *testing.T) {
+	params, _ := json.Marshal(adapterprotocol.FindSessionParams{
+		AgentID:  "OxTest",
+		RepoRoot: ".",
+		Since:    "2026-01-01T00:00:00Z",
+	})
+	req := adapterprotocol.Request{ID: 50, Method: "find-session", Params: params}
+
+	resp := sendRequestViaBuffer(t, req, func(srv *adapterruntime.Server) {
+		srv.OnFindSession(func(ctx context.Context, p adapterprotocol.FindSessionParams) (*adapterprotocol.FindSessionResult, error) {
+			t.Fatal("handler must not be called with bad repo-root")
+			return nil, nil
+		})
+	})
+
+	if resp.ID != 50 {
+		t.Errorf("ID = %d, want 50", resp.ID)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error for find-session with bad repo-root in serve mode")
 	}
 }
 

--- a/pkg/adapterruntime/validate_test.go
+++ b/pkg/adapterruntime/validate_test.go
@@ -1,6 +1,142 @@
 package adapterruntime
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- A. ValidateRepoRoot ---
+
+// TestValidateRepoRoot_RejectsEmpty verifies empty string is rejected.
+// Failure prevented: adapter receives "" as repo-root, hashes to garbage path.
+func TestValidateRepoRoot_RejectsEmpty(t *testing.T) {
+	err := ValidateRepoRoot("")
+	if err == nil {
+		t.Fatal("expected error for empty root")
+	}
+}
+
+// TestValidateRepoRoot_RejectsDot verifies "." is rejected.
+// Failure prevented: adapter receives "." as repo-root, resolves to wrong directory.
+func TestValidateRepoRoot_RejectsDot(t *testing.T) {
+	err := ValidateRepoRoot(".")
+	if err == nil {
+		t.Fatal("expected error for dot root")
+	}
+}
+
+// TestValidateRepoRoot_RejectsRelative verifies relative paths are rejected.
+// Failure prevented: adapter receives "some/relative/path" which depends on cwd.
+func TestValidateRepoRoot_RejectsRelative(t *testing.T) {
+	err := ValidateRepoRoot("some/relative/path")
+	if err == nil {
+		t.Fatal("expected error for relative path")
+	}
+}
+
+// TestValidateRepoRoot_RejectsNoSageox verifies absolute path without .sageox/ is rejected.
+// Failure prevented: adapter runs against a directory that isn't an ox project.
+func TestValidateRepoRoot_RejectsNoSageox(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	err := ValidateRepoRoot(tmpDir)
+	if err == nil {
+		t.Fatal("expected error for directory without .sageox/")
+	}
+}
+
+// TestValidateRepoRoot_AcceptsValid verifies a proper ox project root passes.
+func TestValidateRepoRoot_AcceptsValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ValidateRepoRoot(tmpDir)
+	if err != nil {
+		t.Fatalf("expected no error for valid root, got: %v", err)
+	}
+}
+
+// --- A2. ValidateRepoRoot edge cases ---
+
+// TestValidateRepoRoot_PathWithSpaces verifies paths containing spaces pass.
+// Failure prevented: projects in directories with spaces silently fail session lookup.
+func TestValidateRepoRoot_PathWithSpaces(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), "my project")
+	tmpDir, _ = filepath.EvalSymlinks(filepath.Dir(tmpDir))
+	tmpDir = filepath.Join(tmpDir, "my project")
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateRepoRoot(tmpDir); err != nil {
+		t.Fatalf("path with spaces should pass: %v", err)
+	}
+}
+
+// TestValidateRepoRoot_TrailingSlash verifies trailing slash is accepted.
+func TestValidateRepoRoot_TrailingSlash(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateRepoRoot(tmpDir + "/"); err != nil {
+		t.Fatalf("trailing slash should pass: %v", err)
+	}
+}
+
+// TestValidateRepoRoot_SageoxIsFile verifies .sageox as a regular file is rejected.
+// Failure prevented: interrupted `ox init` leaves a .sageox file; adapter treats it as valid.
+func TestValidateRepoRoot_SageoxIsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	if err := os.WriteFile(filepath.Join(tmpDir, ".sageox"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := ValidateRepoRoot(tmpDir)
+	if err == nil {
+		t.Fatal("expected error when .sageox is a file, not directory")
+	}
+}
+
+// TestValidateRepoRoot_SymlinkedSageox verifies .sageox as a symlink to a real dir passes.
+func TestValidateRepoRoot_SymlinkedSageox(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	realDir := filepath.Join(tmpDir, "real-sageox")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDir, filepath.Join(tmpDir, ".sageox")); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateRepoRoot(tmpDir); err != nil {
+		t.Fatalf("symlinked .sageox should pass: %v", err)
+	}
+}
+
+// TestValidateRepoRoot_NonexistentPath verifies totally nonexistent path is rejected.
+func TestValidateRepoRoot_NonexistentPath(t *testing.T) {
+	err := ValidateRepoRoot("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+}
+
+// TestValidateRepoRoot_TildePath verifies ~ is not treated as absolute.
+func TestValidateRepoRoot_TildePath(t *testing.T) {
+	err := ValidateRepoRoot("~/repo")
+	if err == nil {
+		t.Fatal("expected error for tilde path")
+	}
+}
+
+// --- B. ValidateSessionID ---
 
 func TestValidateSessionID(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Eliminates silent session recording failures caused by `FindSessionFile` deriving `repoRoot` from ambient state (env vars, cwd) which could resolve to `"."` or `""`, silently hashing to a garbage path and losing entire sessions.

- **Interface change**: `FindSessionFile(agentID, since)` → `FindSessionFile(SessionLookup)` where `SessionLookup` carries an explicit, validated `RepoRoot`
- **Defense-in-depth validation** at four layers: `SessionLookup.Validate()`, `validateRepoRootArg()` (CLI pre-flight), `ValidateRepoRoot()` (adapter SDK), and compliance suite (binary-level black-box test)
- **Stop-time hardening**: Uses `RecordingState.WorkspacePath` (persisted at start) as single source of truth — never derives repoRoot from ambient cwd/env at stop time
- **Agent type canonicalization**: `CanonicalAdapterName()` prevents drift ("claude" vs "claude-code") in metadata across all write paths
- **Recovery guidance**: When session file discovery fails at stop time, prints exact `ox agent <id> session import` command and sets doctor marker

```mermaid
flowchart TD
    A[Session Start] -->|persists WorkspacePath| B[RecordingState]
    B -->|hook fires| C{SessionFile found?}
    C -->|no| D[FindSessionFile with explicit repoRoot]
    D --> E{SessionLookup.Validate}
    E -->|repoRoot invalid| F[Error: requires absolute path + .sageox/]
    E -->|valid| G[Adapter binary]
    G --> H{validateRepoRootArg pre-flight}
    H -->|invalid| F
    H -->|valid| I{ValidateRepoRoot SDK}
    I -->|invalid| F
    I -->|valid| J[Search for session JSONL]
    C -->|yes| K[Read entries incrementally]
    
    L[Session Stop] -->|reads WorkspacePath| D
    L -->|file not found| M[Recovery: print import command + doctor marker]
```

## Test plan

- [x] 11 `ValidateRepoRoot` tests (empty, dot, relative, no .sageox, spaces, trailing slash, symlink, file-not-dir, nonexistent, tilde, valid)
- [x] 7 `validateRepoRootArg` edge case tests (last-arg-no-value, duplicate args, equals syntax, mixed args, spaces, nil/empty slice)
- [x] 8 `SessionLookup.Validate` edge case tests (spaces, trailing slash, symlink, file-not-dir, zero-since, optional session ID, nonexistent, tilde)
- [x] 29 `CanonicalAdapterName` subtests covering all known aliases
- [x] 5 one-shot dispatch rejection tests + 1 serve-mode rejection test in `adapterruntime`
- [x] 4 `RecordingState.WorkspacePath` persistence tests (round-trip, legacy compat, spaces, start-sets-path)
- [x] Compliance suite `TestFindSessionBadRepoRoot` for binary-level validation
- [x] `make lint` clean, `make test` passes (1 pre-existing flaky timeout unrelated to changes)

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds session recovery metadata and explicit recovery guidance when session discovery fails.

* **Bug Fixes**
  * Repo-root is now validated and required for session discovery; implicit cwd fallbacks are logged or rejected.
  * Session lookup errors surface earlier with clearer messages; adapter names are normalized for consistent metadata.

* **Tests**
  * Expanded tests for repo-root validation, session discovery, adapter behavior, and canonicalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->