### PR TITLE
fix(agent): accept session subcommand flags and pick adapter deterministically

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -138,6 +138,28 @@ func init() {
 		"skip confirmation for destructive operations")
 	_ = agentCmd.PersistentFlags().MarkHidden("force")
 
+	// Flags consumed by agent session subcommands via manual arg parsing
+	// (parseTitle, parseCapturePriorFile, parseSessionID, parseAdapter).
+	// They are registered here so cobra doesn't reject them as unknown
+	// flags on agentCmd — the dispatcher reinjects their values into
+	// sessionArgs before handing off to the subcommand handler, preserving
+	// the manual-parser call pattern used across session commands.
+	//
+	// Marked hidden: they only apply to specific subcommands and should
+	// not clutter agent-level help.
+	agentCmd.PersistentFlags().String("title", "",
+		"session title (session start, session import, session capture-prior)")
+	_ = agentCmd.PersistentFlags().MarkHidden("title")
+	agentCmd.PersistentFlags().String("file", "",
+		"input file path (session import, session capture-prior, session summarize)")
+	_ = agentCmd.PersistentFlags().MarkHidden("file")
+	agentCmd.PersistentFlags().String("session-id", "",
+		"native coding agent session id (session capture-prior)")
+	_ = agentCmd.PersistentFlags().MarkHidden("session-id")
+	agentCmd.PersistentFlags().String("adapter", "",
+		"explicit adapter name, overrides auto-detection (session capture-prior)")
+	_ = agentCmd.PersistentFlags().MarkHidden("adapter")
+
 	// initialize prime command flags
 	initAgentPrimeCmd()
 
@@ -209,6 +231,35 @@ func isAgentSubcommand(name string) bool {
 	return agentSubcommands[name]
 }
 
+// reinjectSessionFlags appends cobra-parsed values for --title, --file,
+// --session-id, and --adapter back into the session subcommand's args slice.
+//
+// Why: session subcommands (capture-prior, start, import, summarize) consume
+// these flags via manual parseTitle/parseCapturePriorFile/parseSessionID/
+// parseAdapter helpers that scan a []string. But the flags must also be
+// registered on agentCmd itself, otherwise cobra rejects them as unknown
+// during its flag-parse pass before the dispatcher ever runs. Cobra strips
+// registered flags from args when parsing, so by the time the dispatcher
+// sees args, the flags are gone — the manual parsers would see nothing.
+//
+// This helper bridges the gap: it reads the cobra-parsed values and appends
+// them back as positional tokens so the existing parsers work unchanged.
+// Flags left empty are not injected.
+func reinjectSessionFlags(cmd *cobra.Command, sessionArgs []string) []string {
+	if cmd == nil {
+		return sessionArgs
+	}
+	flags := cmd.Flags()
+	for _, name := range []string{"title", "file", "session-id", "adapter"} {
+		val, err := flags.GetString(name)
+		if err != nil || val == "" {
+			continue
+		}
+		sessionArgs = append(sessionArgs, "--"+name, val)
+	}
+	return sessionArgs
+}
+
 // runWithAgentID executes a command using the specified agent instance
 func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 	if len(args) == 0 {
@@ -261,6 +312,13 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 		}
 		sessionCmd := subargs[0]
 		sessionArgs := subargs[1:]
+		// Reinject persistent string flags consumed by subcommand manual
+		// parsers. Cobra has already stripped these from args when it
+		// parsed agentCmd's flags; the parseTitle/parseCapturePriorFile/
+		// parseSessionID/parseAdapter helpers expect them as positional
+		// tokens. This preserves the manual-parser call pattern without a
+		// wider refactor of every session handler signature.
+		sessionArgs = reinjectSessionFlags(cmd, sessionArgs)
 		switch sessionCmd {
 		case "start":
 			return runAgentSessionStart(inst, sessionArgs)

--- a/cmd/ox/agent_capture_prior_coverage_test.go
+++ b/cmd/ox/agent_capture_prior_coverage_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/session/adapters"
 )
 
 func TestParseCapturePriorFile(t *testing.T) {
@@ -149,6 +152,142 @@ func TestParseSessionID(t *testing.T) {
 			got := parseSessionID(tt.args)
 			if got != tt.want {
 				t.Errorf("parseSessionID(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindCapturePriorAdapterByName_NotFound verifies that an explicit
+// --adapter <name> for an unknown adapter returns a clear "not found" error
+// rather than silently falling back to auto-detection.
+//
+// Failure prevented: a typo or stale adapter reference would otherwise be
+// masked by auto-detect picking up whatever adapter happens to detect first,
+// reintroducing the original "wrong adapter chosen" bug.
+func TestFindCapturePriorAdapterByName_NotFound(t *testing.T) {
+	// not parallel: mutates global adapter registry
+	saveAdapterRegistry(t)
+
+	_, err := findCapturePriorAdapterByName("nonexistent-adapter")
+	if err == nil {
+		t.Fatal("expected error for unknown adapter, got nil")
+	}
+	if !errors.Is(err, adapters.ErrAdapterNotFound) {
+		t.Errorf("expected ErrAdapterNotFound in chain, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "nonexistent-adapter") {
+		t.Errorf("error should name the adapter, got: %v", err)
+	}
+}
+
+// TestFindCapturePriorAdapterByName_NotExternal verifies that an explicit
+// adapter name pointing at a built-in (non-ExternalAdapter) returns a clear
+// "does not support capture-prior" error.
+//
+// Failure prevented: capture-prior is implemented exclusively by external
+// adapter binaries via the protocol; built-in adapters lack the
+// CapturePrior() method. Without this guard, the type assertion would panic
+// at runtime.
+func TestFindCapturePriorAdapterByName_NotExternal(t *testing.T) {
+	// not parallel: mutates global adapter registry
+	saveAdapterRegistry(t)
+
+	// GenericJSONLAdapter is a built-in (registered in init() of generic_jsonl.go),
+	// not an *ExternalAdapter — exercises the type-assertion failure branch.
+	_, err := findCapturePriorAdapterByName("generic")
+	if err == nil {
+		t.Fatal("expected error for built-in adapter, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not support capture-prior") {
+		t.Errorf("error should explain capability gap, got: %v", err)
+	}
+}
+
+// TestFindCapturePriorAdapter_NoneCapable verifies the auto-detect path
+// returns a clean error when no installed adapter advertises capture-prior.
+//
+// Failure prevented: the previous bug surfaced as a confusing "adapter X
+// does not support capture-prior" pointing at the wrong (random) adapter.
+// The capability filter must run BEFORE detect, and an empty capable set
+// must produce a stable diagnostic message.
+func TestFindCapturePriorAdapter_NoneCapable(t *testing.T) {
+	// not parallel: mutates global adapter registry
+	saveAdapterRegistry(t)
+	adapters.ResetRegistry() // strip GenericJSONLAdapter and any externals
+
+	_, err := findCapturePriorAdapter("")
+	if err == nil {
+		t.Fatal("expected error for empty registry, got nil")
+	}
+	if !strings.Contains(err.Error(), "no installed adapter supports capture-prior") {
+		t.Errorf("error should mention missing capability, got: %v", err)
+	}
+}
+
+// saveAdapterRegistry snapshots the global adapter registry and restores it
+// at test cleanup. Used by tests that need to mutate the registry.
+func saveAdapterRegistry(t *testing.T) {
+	t.Helper()
+	// snapshot current adapters by name; we restore by re-importing the
+	// generic builtin via package init on next test (if needed). Since
+	// ResetRegistry/Unregister mutate global state and Register would
+	// panic on duplicate, we restore by capturing names then unregistering
+	// any names not in the snapshot afterward.
+	originalNames := adapters.ListAdapters()
+	originalSet := make(map[string]bool, len(originalNames))
+	for _, n := range originalNames {
+		originalSet[n] = true
+	}
+	t.Cleanup(func() {
+		// remove any adapters added during the test
+		for _, n := range adapters.ListAdapters() {
+			if !originalSet[n] {
+				adapters.Unregister(n)
+			}
+		}
+		// re-register any builtin that the test removed (only "generic" is
+		// registered via package init; external adapters are discovered
+		// lazily, so they don't need restoring here).
+		stillThere := make(map[string]bool)
+		for _, n := range adapters.ListAdapters() {
+			stillThere[n] = true
+		}
+		if originalSet["generic"] && !stillThere["generic"] {
+			adapters.Register(&adapters.GenericJSONLAdapter{})
+		}
+	})
+}
+
+// TestParseAdapter exercises the manual --adapter parser used by
+// capture-prior to bypass auto-detection.
+//
+// Failure prevented: a regression that breaks --adapter parsing would
+// silently fall back to auto-detect, reintroducing the non-deterministic
+// adapter race that this flag exists to defeat.
+func TestParseAdapter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no flag", []string{"capture-prior"}, ""},
+		{"separate value", []string{"--adapter", "claude-code"}, "claude-code"},
+		{"equals value", []string{"--adapter=claude-code"}, "claude-code"},
+		{"alias separate", []string{"--adapter", "claude"}, "claude"},
+		{"alias equals", []string{"--adapter=claude"}, "claude"},
+		{"no value", []string{"--adapter"}, ""},
+		{"empty args", []string{}, ""},
+		{"between other args", []string{"--verbose", "--adapter", "codex", "--title", "test"}, "codex"},
+		{"after session-id", []string{"--session-id", "abc", "--adapter", "claude"}, "claude"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseAdapter(tt.args)
+			if got != tt.want {
+				t.Errorf("parseAdapter(%v) = %q, want %q", tt.args, got, tt.want)
 			}
 		})
 	}

--- a/cmd/ox/agent_session_capture_prior.go
+++ b/cmd/ox/agent_session_capture_prior.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/sageox/agentx"
 	"github.com/sageox/ox/internal/agentinstance"
@@ -16,10 +18,12 @@ import (
 
 // runAgentSessionCapturePrior captures prior history from the active coding agent.
 //
-// Usage: ox agent <id> session capture-prior [--title "..."] [--file <path>] [--session-id <id>]
+// Usage: ox agent <id> session capture-prior [--title "..."] [--file <path>] [--session-id <id>] [--adapter <name>]
 //
 // The command detects the active adapter and delegates to it. Each adapter
 // (Claude Code, Codex, etc.) implements its own session discovery and parsing.
+// An explicit --adapter <name> overrides auto-detection — useful when multiple
+// adapters detect as present (e.g. both aider and claude-code installed).
 //
 // If no adapter with capture-prior capability is detected, falls back to
 // reading validated JSONL from stdin or --file.
@@ -27,6 +31,7 @@ func runAgentSessionCapturePrior(inst *agentinstance.Instance, args []string) er
 	title := parseTitle(args)
 	filePath := parseCapturePriorFile(args)
 	sessionID := parseSessionID(args)
+	adapterName := parseAdapter(args)
 
 	projectRoot := mustFindProjectRoot()
 
@@ -41,7 +46,7 @@ func runAgentSessionCapturePrior(inst *agentinstance.Instance, args []string) er
 
 	// try adapter-based capture first (unless explicit --file was given)
 	if filePath == "" && !isStdinPiped() {
-		result, err = capturePriorViaAdapter(inst, projectRoot, opts, sessionID)
+		result, err = capturePriorViaAdapter(inst, projectRoot, opts, sessionID, adapterName)
 		if err != nil {
 			return fmt.Errorf("capture-prior failed: %w", err)
 		}
@@ -68,7 +73,9 @@ func runAgentSessionCapturePrior(inst *agentinstance.Instance, args []string) er
 }
 
 // capturePriorViaAdapter detects the active adapter and delegates capture-prior to it.
-func capturePriorViaAdapter(inst *agentinstance.Instance, projectRoot string, opts session.CaptureOptions, sessionID string) (*session.CaptureResult, error) {
+// When adapterName is non-empty, that adapter is used explicitly instead of
+// auto-detection, overriding the usual Detect() race.
+func capturePriorViaAdapter(inst *agentinstance.Instance, projectRoot string, opts session.CaptureOptions, sessionID, adapterName string) (*session.CaptureResult, error) {
 	// resolve native session ID from agent environment if not provided
 	if sessionID == "" {
 		if agent := agentx.CurrentAgent(); agent != nil && agent.SupportsSession() {
@@ -76,12 +83,7 @@ func capturePriorViaAdapter(inst *agentinstance.Instance, projectRoot string, op
 		}
 	}
 
-	// discover adapters and find one with capture-prior capability
-	if err := adapters.RegisterExternalAdapters(); err != nil {
-		return nil, fmt.Errorf("adapter discovery: %w", err)
-	}
-
-	ea, err := findCapturePriorAdapter()
+	ea, err := findCapturePriorAdapter(adapterName)
 	if err != nil {
 		return nil, err
 	}
@@ -112,22 +114,83 @@ func capturePriorViaAdapter(inst *agentinstance.Instance, projectRoot string, op
 }
 
 // findCapturePriorAdapter discovers an adapter that supports capture-prior.
-// DetectAdapter already handles full discovery (built-in + external binaries).
-func findCapturePriorAdapter() (*adapters.ExternalAdapter, error) {
-	adapter, err := adapters.DetectAdapter()
-	if err != nil {
-		return nil, fmt.Errorf("no adapter detected: %w", err)
+//
+// When adapterName is non-empty, that adapter is looked up by name (canonical
+// or alias) and its capability is verified. An explicit name is authoritative
+// and does not run Detect() — the caller has declared intent.
+//
+// When adapterName is empty, selection is deterministic:
+//   1. Ensure external adapters are discovered (one-time registry scan).
+//   2. Filter the registry to adapters that *have* the capture-prior
+//      capability (cheap: uses cached Info response).
+//   3. Run Detect() only on capable adapters, in alphabetical order, and
+//      return the first that detects.
+//
+// This avoids the previous bug where DetectAdapter() iterated the registry in
+// non-deterministic map order and returned any adapter that detected, even
+// when it lacked the capability (e.g. aider winning the race over claude-code
+// when both had Detect()=true). It also avoids shelling out to every
+// adapter's detect binary — only adapters that could possibly serve the
+// request are asked.
+func findCapturePriorAdapter(adapterName string) (*adapters.ExternalAdapter, error) {
+	if adapterName != "" {
+		return findCapturePriorAdapterByName(adapterName)
 	}
 
+	if err := adapters.RegisterExternalAdapters(); err != nil {
+		return nil, fmt.Errorf("adapter discovery: %w", err)
+	}
+
+	// filter by capability first (cheap: uses cached Info response)
+	names := adapters.ListAdapters()
+	sort.Strings(names)
+
+	var capable []*adapters.ExternalAdapter
+	for _, name := range names {
+		a, err := adapters.GetAdapter(name)
+		if err != nil {
+			continue
+		}
+		ea, ok := a.(*adapters.ExternalAdapter)
+		if !ok {
+			continue
+		}
+		if ea.HasCapability(adapterprotocol.CapCapturePrior) {
+			capable = append(capable, ea)
+		}
+	}
+
+	if len(capable) == 0 {
+		return nil, fmt.Errorf("no installed adapter supports capture-prior")
+	}
+
+	// detect only on capable adapters (expensive: shells out to detect subcommand)
+	var tried []string
+	for _, ea := range capable {
+		if ea.Detect() {
+			return ea, nil
+		}
+		tried = append(tried, ea.Name())
+	}
+
+	return nil, fmt.Errorf("no capture-prior adapter detected in current environment (tried: %s)",
+		strings.Join(tried, ", "))
+}
+
+// findCapturePriorAdapterByName looks up an adapter by canonical name or alias
+// and verifies it supports capture-prior.
+func findCapturePriorAdapterByName(name string) (*adapters.ExternalAdapter, error) {
+	adapter, err := adapters.GetAdapter(name)
+	if err != nil {
+		return nil, fmt.Errorf("adapter %q not found: %w", name, err)
+	}
 	ea, ok := adapter.(*adapters.ExternalAdapter)
 	if !ok {
-		return nil, fmt.Errorf("detected adapter does not support capture-prior")
+		return nil, fmt.Errorf("adapter %q does not support capture-prior", name)
 	}
-
 	if !ea.HasCapability(adapterprotocol.CapCapturePrior) {
-		return nil, fmt.Errorf("adapter %q does not support capture-prior", ea.Name())
+		return nil, fmt.Errorf("adapter %q does not support capture-prior", name)
 	}
-
 	return ea, nil
 }
 
@@ -210,6 +273,21 @@ func parseCapturePriorFile(args []string) string {
 		}
 		if len(arg) > 7 && arg[:7] == "--file=" {
 			return arg[7:]
+		}
+	}
+	return ""
+}
+
+// parseAdapter extracts --adapter value from args. Used to explicitly select
+// an adapter by canonical name (e.g. "claude-code") or alias (e.g. "claude"),
+// overriding the default capability-filtered detection.
+func parseAdapter(args []string) string {
+	for i, arg := range args {
+		if arg == "--adapter" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if len(arg) > 10 && arg[:10] == "--adapter=" {
+			return arg[10:]
 		}
 	}
 	return ""

--- a/cmd/ox/agent_session_capture_prior_slow_test.go
+++ b/cmd/ox/agent_session_capture_prior_slow_test.go
@@ -1,0 +1,89 @@
+//go:build slow
+
+// Slow tests for ox agent <id> session capture-prior that exercise the
+// REAL ox binary. They build ox from source and shell out to it, which is
+// the only way to verify cobra's flag parsing accepts the flags consumed
+// by the dispatcher's manual parsers (parseTitle, parseCapturePriorFile,
+// parseSessionID, parseAdapter).
+//
+// Why slow: previous unit tests only exercised the parse* helpers as pure
+// functions, never the cobra path. That left the original bug — cobra
+// rejecting --session-id, --title, --file, --adapter as "unknown flag" —
+// invisible to CI for as long as it shipped. These tests are the regression
+// gate for that class of failure.
+//
+// Run with: go test -tags=slow -run TestCobraFlagsAcceptedByCapturePrior ./cmd/ox/
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestCobraFlagsAcceptedByCapturePrior verifies that the real ox binary
+// does NOT reject --title, --file, --session-id, or --adapter as unknown
+// flags when invoked under `ox agent <id> session capture-prior`.
+//
+// Failure prevented: a regression that re-removes the agentCmd flag
+// registration (or the dispatcher reinjection) would silently break every
+// session subcommand that depends on these flags. The original bug only
+// surfaced when a user actually tried to use --session-id in production.
+//
+// We don't care about the command's success — only that cobra accepts the
+// flag tokens. We assert the binary fails for some OTHER reason (no agent,
+// no recording, etc.) but never with "unknown flag".
+func TestCobraFlagsAcceptedByCapturePrior(t *testing.T) {
+	oxBin := buildOxBinary(t)
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "session capture-prior --title",
+			args: []string{"agent", "Oxslow1", "session", "capture-prior", "--title", "regression test"},
+		},
+		{
+			name: "session capture-prior --file",
+			args: []string{"agent", "Oxslow1", "session", "capture-prior", "--file", "/tmp/nonexistent.jsonl"},
+		},
+		{
+			name: "session capture-prior --session-id",
+			args: []string{"agent", "Oxslow1", "session", "capture-prior", "--session-id", "00000000-0000-0000-0000-000000000000"},
+		},
+		{
+			name: "session capture-prior --adapter",
+			args: []string{"agent", "Oxslow1", "session", "capture-prior", "--adapter", "claude"},
+		},
+		{
+			name: "session capture-prior all flags combined",
+			args: []string{
+				"agent", "Oxslow1", "session", "capture-prior",
+				"--title", "combined",
+				"--adapter", "claude-code",
+				"--session-id", "00000000-0000-0000-0000-000000000000",
+			},
+		},
+		{
+			name: "session capture-prior equals form",
+			args: []string{"agent", "Oxslow1", "session", "capture-prior", "--adapter=claude", "--session-id=abc"},
+		},
+		{
+			name: "session start --title",
+			args: []string{"agent", "Oxslow1", "session", "start", "--title", "regression test"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(oxBin, tc.args...)
+			out, _ := cmd.CombinedOutput()
+			combined := string(out)
+			if strings.Contains(combined, "unknown flag") {
+				t.Errorf("cobra rejected a flag for args %v\noutput:\n%s", tc.args, combined)
+			}
+		})
+	}
+}

--- a/cmd/ox/agent_test.go
+++ b/cmd/ox/agent_test.go
@@ -4,12 +4,119 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/sageox/ox/internal/agentinstance"
+	"github.com/spf13/cobra"
 )
+
+// TestReinjectSessionFlags verifies the dispatcher reinjects cobra-parsed
+// values for --title, --file, --session-id, and --adapter back into
+// sessionArgs as positional tokens.
+//
+// Failure prevented: cobra strips flags it has registered when parsing
+// agentCmd. Without reinjection, the manual parsers (parseTitle,
+// parseCapturePriorFile, parseSessionID, parseAdapter) used by every
+// session subcommand handler would see empty args and silently behave as
+// if no flag was passed. The original bug was that --session-id, --title,
+// and --file were rejected entirely with "unknown flag"; the FParseErrWhitelist
+// fix appears to make them work but actually drops them — this test pins the
+// reinjection behavior so a future "simplification" can't quietly regress.
+func TestReinjectSessionFlags(t *testing.T) {
+	t.Parallel()
+
+	// Use local flags (not persistent) so Set() and GetString() target the
+	// same flagset without going through cobra's Execute()/merge step.
+	// In production, agentCmd registers these as persistent flags and
+	// cobra merges them into cmd.Flags() during Execute() — so the
+	// helper sees the values via Flags().GetString(). The behavior under
+	// test is the lookup-and-append, which is identical regardless of
+	// where the flag was originally declared.
+	makeCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "agent"}
+		cmd.Flags().String("title", "", "")
+		cmd.Flags().String("file", "", "")
+		cmd.Flags().String("session-id", "", "")
+		cmd.Flags().String("adapter", "", "")
+		return cmd
+	}
+
+	tests := []struct {
+		name     string
+		setFlags map[string]string
+		input    []string
+		want     []string
+	}{
+		{
+			name:     "no flags set leaves args unchanged",
+			setFlags: nil,
+			input:    []string{"existing", "positional"},
+			want:     []string{"existing", "positional"},
+		},
+		{
+			name:     "session-id only",
+			setFlags: map[string]string{"session-id": "abc-123"},
+			input:    []string{},
+			want:     []string{"--session-id", "abc-123"},
+		},
+		{
+			name: "all four flags reinjected in stable order",
+			setFlags: map[string]string{
+				"title":      "My Plan",
+				"file":       "/tmp/data.jsonl",
+				"session-id": "sess-xyz",
+				"adapter":    "claude",
+			},
+			input: []string{},
+			want: []string{
+				"--title", "My Plan",
+				"--file", "/tmp/data.jsonl",
+				"--session-id", "sess-xyz",
+				"--adapter", "claude",
+			},
+		},
+		{
+			name:     "appends after existing positional args",
+			setFlags: map[string]string{"adapter": "codex"},
+			input:    []string{"capture-prior-positional"},
+			want:     []string{"capture-prior-positional", "--adapter", "codex"},
+		},
+		{
+			name:     "empty string flag not injected",
+			setFlags: map[string]string{"title": "", "adapter": "claude"},
+			input:    []string{},
+			want:     []string{"--adapter", "claude"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := makeCmd()
+			for k, v := range tt.setFlags {
+				if err := cmd.Flags().Set(k, v); err != nil {
+					t.Fatalf("set %s: %v", k, err)
+				}
+			}
+			got := reinjectSessionFlags(cmd, tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("reinjectSessionFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("nil cmd is a no-op", func(t *testing.T) {
+		t.Parallel()
+		input := []string{"a", "b"}
+		got := reinjectSessionFlags(nil, input)
+		if !reflect.DeepEqual(got, input) {
+			t.Errorf("reinjectSessionFlags(nil) = %v, want %v", got, input)
+		}
+	})
+}
 
 func TestGenerateAgentID(t *testing.T) {
 	t.Run("generates valid agent ID with no existing IDs", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes three latent bugs in `ox agent <id> session capture-prior` (and the related session subcommands), surfaced by trying to recreate a Claude Code session via its session id.

1. **Cobra rejects `--title` / `--file` / `--session-id`** as unknown flags before the dispatcher ever runs. Every session subcommand that consumes these via the manual `parseTitle` / `parseCapturePriorFile` / `parseSessionID` helpers has been silently broken — `ox agent <id> session start --title 'foo'` fails with `Error: unknown flag: --title`. Unit tests only exercised the parsers as pure functions, so the cobra path was never covered.

2. **Adapter selection for `capture-prior` is non-deterministic.** `findCapturePriorAdapter` calls `DetectAdapter()`, which iterates the registry in randomized Go map order and returns the first adapter whose `Detect()` fires. With both `aider` (in `PATH`) and `claude-code` (`~/.claude/projects` present) detecting as installed, aider could win the race and then be rejected with `adapter "aider" does not support capture-prior` — even though claude-code was capable and present.

3. **No way to specify the adapter explicitly.** No `--adapter` flag, no env var, no override. The only workaround was hiding `aider` from `PATH`.

## Changes

### `cmd/ox/agent.go` — fix #1

- Register `--title`, `--file`, `--session-id`, `--adapter` as **hidden** persistent flags on `agentCmd` so cobra accepts them. Hidden because they only apply to specific subcommands and shouldn't clutter agent-level help.
- New `reinjectSessionFlags(cmd, sessionArgs)` helper. Cobra strips registered flags from args during parsing, so by the time the dispatcher runs the manual `parse*` helpers see nothing. The helper reads cobra's parsed values and re-appends them as positional tokens before the session subcommand handler runs. This preserves the existing `parse*` call pattern without refactoring every session handler signature.

### `cmd/ox/agent_session_capture_prior.go` — fixes #2 and #3

- New `parseAdapter(args)` helper (mirrors `parseSessionID`).
- `findCapturePriorAdapter` now takes an optional adapter name and is split into two paths:

```mermaid
flowchart TD
    A[capture-prior called] --> B{--adapter set?}
    B -- yes --> C[GetAdapter by name/alias]
    C --> D{type *ExternalAdapter<br/>and CapCapturePrior?}
    D -- no --> E[Error: does not support capture-prior]
    D -- yes --> F[Use this adapter]
    B -- no --> G[RegisterExternalAdapters]
    G --> H[List adapters, sort alphabetically]
    H --> I[Filter: keep only those with<br/>CapCapturePrior capability<br/>cheap: cached Info]
    I --> J{capable set empty?}
    J -- yes --> K[Error: no installed adapter<br/>supports capture-prior]
    J -- no --> L[Detect on capable adapters only<br/>expensive: shells out]
    L --> M{any detected?}
    M -- yes --> F
    M -- no --> N[Error: no capture-prior adapter<br/>detected, tried: ...]
```

Two important properties:

- **Capability filter runs before `Detect()`**, so we never shell out to adapters that couldn't possibly serve the request. This is both faster and avoids the race that picked aider.
- **Alphabetical sort makes the auto-detect path deterministic** when multiple capable adapters detect.

### Tests

- `TestParseAdapter` — pure parser unit test.
- `TestReinjectSessionFlags` — six cases pinning the dispatcher reinjection contract (single flag, all flags, append after positionals, empty values not injected, nil cmd).
- `TestFindCapturePriorAdapterByName_NotFound` — explicit unknown name returns `ErrAdapterNotFound`.
- `TestFindCapturePriorAdapterByName_NotExternal` — uses built-in `generic` adapter to exercise the type-assertion failure branch.
- `TestFindCapturePriorAdapter_NoneCapable` — empty registry produces stable diagnostic.
- `agent_session_capture_prior_slow_test.go` (`//go:build slow`): **`TestCobraFlagsAcceptedByCapturePrior`** runs the **real ox binary** with each flag form (`--flag value`, `--flag=value`, all combined) and asserts cobra never errors with \"unknown flag\". This is the regression test the original bug needed — unit tests of pure parsers couldn't catch a cobra-side rejection.

## Why no bd issues filed

`bd` is unavailable on this machine (`dolt` not installed). The bugs and their fix are documented here in the PR body and in inline comments on the new code.

## Test plan

- [x] `go test ./cmd/ox/... -count=1` — passes
- [x] `go test ./internal/session/adapters/... -count=1` — passes
- [x] `go test -tags=slow -run TestCobraFlagsAcceptedByCapturePrior ./cmd/ox/` — passes
- [x] `make lint` — 0 issues
- [x] Live verification on real binary:
  - `ox agent <id> session capture-prior --session-id <uuid>` — original failing command, now succeeds (deterministic auto-detect picks claude-code over aider via capability filter)
  - `ox agent <id> session capture-prior --adapter aider --session-id ...` — explicit name correctly routes to aider, errors cleanly with \"does not support capture-prior\"
  - `ox agent <id> session capture-prior --adapter claude --session-id ...` — alias `claude` resolves to `claude-code`, captures successfully
  - `ox agent <id> session capture-prior --adapter bogus ...` — clean \"adapter not found\" error
  - `ox agent <id> session start --title 'foo'` — no longer rejected with \"unknown flag\"
- [ ] Reviewer: confirm the hidden persistent flags on `agentCmd` are an acceptable trade-off vs a wider refactor that plumbs `*cobra.Command` into every session handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--adapter` flag to explicitly select a capture-prior adapter during session capture
  * Enabled passing of `--title`, `--file`, `--session-id`, and `--adapter` flags to session subcommands
  * Improved adapter discovery with deterministic selection when adapter is not explicitly specified

* **Tests**
  * Added integration tests validating flag acceptance across session subcommands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->