### PR TITLE
fix(ledger): handle rename/rename conflicts in rebase auto-resolve

### DIFF
--- a/cmd/ox/doctor_github_migrate.go
+++ b/cmd/ox/doctor_github_migrate.go
@@ -18,7 +18,7 @@ func init() {
 		Slug:        CheckSlugGitHubDataMigration,
 		Name:        "GitHub data migration",
 		Category:    "Ledger Git Health",
-		FixLevel:    FixLevelAuto,
+		FixLevel:    FixLevelSuggested,
 		Description: "Renames legacy GitHub data filenames to content-hash format and deletes corrupted files with conflict markers",
 		Run:         func(fix bool) checkResult { return checkGitHubDataMigration(fix) },
 	})

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -361,6 +361,13 @@ func checkLedgerCleanWorkdir(fix bool) checkResult {
 		return SkippedCheck("Ledger clean workdir", "ledger not a git repo", "")
 	}
 
+	// skip if a rebase is in progress — committing during a broken rebase
+	// sweeps conflict debris into a generic commit, making things worse
+	if gitutil.IsRebaseInProgress(ledgerPath) {
+		return SkippedCheck("Ledger clean workdir", "rebase in progress",
+			"Resolve or abort the rebase first: git -C <ledger> rebase --abort")
+	}
+
 	// check for any uncommitted changes
 	statusCmd := exec.Command("git", "-C", ledgerPath, "status", "--porcelain")
 	output, err := statusCmd.Output()

--- a/internal/gitutil/rebase_resolve.go
+++ b/internal/gitutil/rebase_resolve.go
@@ -20,6 +20,10 @@ import (
 // ["data/"] with denyPrefixes ["data/proprietary/"] means data/github/prs.json
 // is safe but data/proprietary/keys.json is not.
 //
+// Handles rename/rename and rename/delete conflicts by using git ls-files
+// --unmerged to detect index stages, then resolving via git rm + git add
+// instead of git checkout --theirs (which fails for rename conflicts).
+//
 // Returns nil if the rebase was successfully continued after resolution.
 // Returns an error if any conflicted file fails the safety check (the
 // rebase is NOT aborted — caller should abort if needed).
@@ -29,32 +33,91 @@ func ResolveRebaseAcceptTheirs(ctx context.Context, repoPath string, safePrefixe
 		denies = denyPrefixes[0]
 	}
 
-	// list conflicted files (unmerged)
-	conflicted, err := listConflictedFiles(ctx, repoPath)
+	// list all unmerged files from the index (handles content, rename, and delete conflicts)
+	entries, err := listUnmergedEntries(ctx, repoPath)
 	if err != nil {
-		return fmt.Errorf("list conflicted files: %w", err)
+		return fmt.Errorf("list unmerged entries: %w", err)
 	}
-	if len(conflicted) == 0 {
+	if len(entries) == 0 {
 		return fmt.Errorf("no conflicted files found")
 	}
 
+	// collect all unique file paths across all stages
+	allPaths := make(map[string]bool)
+	for _, e := range entries {
+		allPaths[e.path] = true
+	}
+
 	// verify all conflicted files are under safe prefixes and not denied
-	for _, f := range conflicted {
-		if !matchesSafePrefix(f, safePrefixes, denies) {
-			return fmt.Errorf("conflicted file %q is not under safe auto-resolve prefixes %v", f, safePrefixes)
+	for path := range allPaths {
+		if !matchesSafePrefix(path, safePrefixes, denies) {
+			return fmt.Errorf("conflicted file %q is not under safe auto-resolve prefixes %v", path, safePrefixes)
 		}
 	}
 
-	// accept theirs for all conflicted files
-	checkoutArgs := append([]string{"checkout", "--theirs", "--"}, conflicted...)
-	if _, err := RunGit(ctx, repoPath, checkoutArgs...); err != nil {
-		return fmt.Errorf("checkout --theirs: %w", err)
+	// group entries by path to understand conflict type
+	fileStages := groupByPath(entries)
+
+	// resolve each conflicted file based on its conflict type
+	var toCheckoutTheirs []string // content conflicts: use checkout --theirs
+	var toAdd []string            // rename conflicts: stage the file as-is
+	var toRemove []string         // base-only: file deleted in both branches
+
+	for path, stages := range fileStages {
+		hasBase := stages[1]   // stage 1: common ancestor
+		hasTheirs := stages[2] // stage 2: version on branch we're rebasing onto
+		hasOurs := stages[3]   // stage 3: version from commit being replayed
+
+		switch {
+		case hasBase && hasTheirs && hasOurs:
+			// content conflict: all three stages exist for the same path.
+			// working tree has conflict markers — use checkout --theirs to
+			// pick a clean version (during rebase, "theirs" = commit being replayed)
+			toCheckoutTheirs = append(toCheckoutTheirs, path)
+		case hasOurs && !hasBase:
+			// rename conflict: ours exists but no base at this path.
+			// this is the new name from our rename — just stage it
+			toAdd = append(toAdd, path)
+		case hasOurs:
+			// rename/rename variant: ours exists with base — stage it
+			toAdd = append(toAdd, path)
+		case hasTheirs && !hasOurs:
+			// rename/delete: theirs exists but ours was deleted/renamed away.
+			// accept theirs (the version on the target branch)
+			toAdd = append(toAdd, path)
+		case hasBase && !hasTheirs && !hasOurs:
+			// base-only: file was deleted in both branches (common in rename scenarios
+			// where the original file no longer exists in either branch)
+			toRemove = append(toRemove, path)
+		}
 	}
 
-	// stage resolved files
-	addArgs := append([]string{"add", "--"}, conflicted...)
-	if _, err := RunGit(ctx, repoPath, addArgs...); err != nil {
-		return fmt.Errorf("git add resolved files: %w", err)
+	// resolve content conflicts by checking out the "theirs" version
+	if len(toCheckoutTheirs) > 0 {
+		checkoutArgs := append([]string{"checkout", "--theirs", "--"}, toCheckoutTheirs...)
+		if _, err := RunGit(ctx, repoPath, checkoutArgs...); err != nil {
+			return fmt.Errorf("checkout --theirs: %w", err)
+		}
+		addArgs := append([]string{"add", "--"}, toCheckoutTheirs...)
+		if _, err := RunGit(ctx, repoPath, addArgs...); err != nil {
+			return fmt.Errorf("git add after checkout --theirs: %w", err)
+		}
+	}
+
+	// remove files that exist only in base (deleted in both branches)
+	if len(toRemove) > 0 {
+		rmArgs := append([]string{"rm", "--cached", "--quiet", "--"}, toRemove...)
+		if _, err := RunGit(ctx, repoPath, rmArgs...); err != nil {
+			return fmt.Errorf("git rm --cached: %w", err)
+		}
+	}
+
+	// stage rename-conflict files that should be kept
+	if len(toAdd) > 0 {
+		addArgs := append([]string{"add", "--"}, toAdd...)
+		if _, err := RunGit(ctx, repoPath, addArgs...); err != nil {
+			return fmt.Errorf("git add resolved files: %w", err)
+		}
 	}
 
 	// continue the rebase
@@ -70,7 +133,73 @@ func ResolveRebaseAcceptTheirs(ctx context.Context, repoPath string, safePrefixe
 	return nil
 }
 
+// unmergedEntry represents one stage of an unmerged file in the git index.
+type unmergedEntry struct {
+	stage int    // 1=base, 2=theirs (target branch), 3=ours (commit being replayed)
+	path  string
+}
+
+// listUnmergedEntries returns all unmerged entries from the git index.
+// Uses git ls-files --unmerged which correctly reports rename/rename,
+// rename/delete, and content conflicts — unlike git diff --diff-filter=U
+// which can miss files in rename conflict scenarios.
+func listUnmergedEntries(ctx context.Context, repoPath string) ([]unmergedEntry, error) {
+	out, err := RunGit(ctx, repoPath, "ls-files", "--unmerged")
+	if err != nil {
+		return nil, err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil, nil
+	}
+
+	var entries []unmergedEntry
+	for _, line := range strings.Split(out, "\n") {
+		// format: <mode> <hash> <stage>\t<path>
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		path := parts[1]
+
+		// parse stage from the metadata portion: "<mode> <hash> <stage>"
+		meta := strings.Fields(parts[0])
+		if len(meta) < 3 {
+			continue
+		}
+		stage := 0
+		switch meta[2] {
+		case "1":
+			stage = 1
+		case "2":
+			stage = 2
+		case "3":
+			stage = 3
+		default:
+			continue
+		}
+
+		entries = append(entries, unmergedEntry{stage: stage, path: path})
+	}
+
+	return entries, nil
+}
+
+// groupByPath groups unmerged entries by file path, returning a map of
+// path -> stages present (indexed by stage number).
+func groupByPath(entries []unmergedEntry) map[string]map[int]bool {
+	result := make(map[string]map[int]bool)
+	for _, e := range entries {
+		if result[e.path] == nil {
+			result[e.path] = make(map[int]bool)
+		}
+		result[e.path][e.stage] = true
+	}
+	return result
+}
+
 // listConflictedFiles returns the list of files with unresolved merge conflicts.
+// Kept for backward compatibility but prefer listUnmergedEntries for rename-aware resolution.
 func listConflictedFiles(ctx context.Context, repoPath string) ([]string, error) {
 	out, err := RunGit(ctx, repoPath, "diff", "--name-only", "--diff-filter=U")
 	if err != nil {

--- a/internal/gitutil/rebase_resolve_rename_test.go
+++ b/internal/gitutil/rebase_resolve_rename_test.go
@@ -1,0 +1,247 @@
+package gitutil
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- A. Rename/rename conflicts ---
+
+// TestResolveRebase_RenameRenameConflict verifies that auto-resolve handles
+// the case where both branches rename the same file to different names.
+// Failure prevented: rename/rename conflicts wedge the ledger permanently,
+// requiring manual intervention to unstick.
+func TestResolveRebase_RenameRenameConflict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git rebase operations")
+	}
+
+	bareDir, oursClone, theirsClone := setupRenameRepos(t)
+
+	// both branches rename the same file to different names
+	// simulates two machines running migration with different content hashes
+	renameFile(t, oursClone, "data/github/2026/04/07/pr/458.json", "data/github/2026/04/07/pr/458-aaaa1111.json")
+	gitInRepo(t, oursClone, "add", "-A")
+	gitInRepo(t, oursClone, "commit", "-m", "local migration")
+
+	renameFile(t, theirsClone, "data/github/2026/04/07/pr/458.json", "data/github/2026/04/07/pr/458-bbbb2222.json")
+	gitInRepo(t, theirsClone, "add", "-A")
+	gitInRepo(t, theirsClone, "commit", "-m", "remote migration")
+	gitInRepo(t, theirsClone, "push", "origin", "HEAD")
+
+	// fetch and start rebase (will conflict with rename/rename)
+	gitInRepo(t, oursClone, "fetch", "origin")
+	startRebase(t, oursClone)
+	require.True(t, IsRebaseInProgress(oursClone), "rebase should be in progress")
+
+	err := ResolveRebaseAcceptTheirs(context.Background(), oursClone, []string{"data/github/"})
+	assert.NoError(t, err, "rename/rename conflict should be auto-resolved")
+	assert.False(t, IsRebaseInProgress(oursClone), "rebase should be complete")
+
+	// verify at least one of the renamed files exists (the conflict is resolved)
+	_, errA := os.Stat(filepath.Join(oursClone, "data/github/2026/04/07/pr/458-aaaa1111.json"))
+	_, errB := os.Stat(filepath.Join(oursClone, "data/github/2026/04/07/pr/458-bbbb2222.json"))
+	assert.True(t, errA == nil || errB == nil, "at least one renamed file should exist after resolution")
+
+	_ = bareDir
+}
+
+// --- B. Rename/delete conflicts ---
+
+// TestResolveRebase_RenameDeleteConflict verifies that auto-resolve handles
+// the case where one branch renames a file and the other deletes it.
+// Failure prevented: rename/delete conflicts leave rebase stuck with
+// "does not have their version" errors from git checkout --theirs.
+func TestResolveRebase_RenameDeleteConflict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git rebase operations")
+	}
+
+	_, oursClone, theirsClone := setupRenameRepos(t)
+
+	// ours: delete the file
+	os.Remove(filepath.Join(oursClone, "data/github/2026/04/07/pr/459.json"))
+	gitInRepo(t, oursClone, "add", "-A")
+	gitInRepo(t, oursClone, "commit", "-m", "delete pr 459")
+
+	// theirs: rename the file (migration)
+	renameFile(t, theirsClone, "data/github/2026/04/07/pr/459.json", "data/github/2026/04/07/pr/459-cccc3333.json")
+	gitInRepo(t, theirsClone, "add", "-A")
+	gitInRepo(t, theirsClone, "commit", "-m", "remote migration of 459")
+	gitInRepo(t, theirsClone, "push", "origin", "HEAD")
+
+	gitInRepo(t, oursClone, "fetch", "origin")
+	startRebase(t, oursClone)
+	require.True(t, IsRebaseInProgress(oursClone), "rebase should be in progress")
+
+	err := ResolveRebaseAcceptTheirs(context.Background(), oursClone, []string{"data/github/"})
+	assert.NoError(t, err, "rename/delete conflict should be auto-resolved")
+	assert.False(t, IsRebaseInProgress(oursClone), "rebase should be complete")
+}
+
+// --- C. Mixed rename + content conflicts ---
+
+// TestResolveRebase_RenameAndContentConflictMixed verifies handling when
+// some files have rename conflicts and others have content conflicts.
+// Failure prevented: partial resolution where content conflicts resolve
+// but rename conflicts wedge the rebase.
+func TestResolveRebase_RenameAndContentConflictMixed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git rebase operations")
+	}
+
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	oursClone := filepath.Join(t.TempDir(), "ours")
+	theirsClone := filepath.Join(t.TempDir(), "theirs")
+
+	gitInRepo(t, t.TempDir(), "init", "--bare", "--initial-branch=main", bareDir)
+
+	// initial commit
+	gitInRepo(t, t.TempDir(), "clone", bareDir, theirsClone)
+	gitInRepo(t, theirsClone, "config", "user.name", "test")
+	gitInRepo(t, theirsClone, "config", "user.email", "test@test.com")
+	require.NoError(t, os.MkdirAll(filepath.Join(theirsClone, "data/github/pr"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(theirsClone, "data/github/pr/100.json"), []byte(`{"number":100}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(theirsClone, "data/github/pr/101.json"), []byte(`{"number":101}`), 0o644))
+	gitInRepo(t, theirsClone, "add", ".")
+	gitInRepo(t, theirsClone, "commit", "-m", "initial")
+	gitInRepo(t, theirsClone, "push", "origin", "HEAD")
+
+	// clone ours
+	gitInRepo(t, t.TempDir(), "clone", bareDir, oursClone)
+	gitInRepo(t, oursClone, "config", "user.name", "test")
+	gitInRepo(t, oursClone, "config", "user.email", "test@test.com")
+
+	// ours: rename 100.json (migration) + modify 101.json (content change)
+	renameFile(t, oursClone, "data/github/pr/100.json", "data/github/pr/100-aaaa.json")
+	require.NoError(t, os.WriteFile(filepath.Join(oursClone, "data/github/pr/101.json"), []byte(`{"number":101,"local":true}`), 0o644))
+	gitInRepo(t, oursClone, "add", "-A")
+	gitInRepo(t, oursClone, "commit", "-m", "local changes")
+
+	// theirs: rename 100.json differently + modify 101.json differently
+	renameFile(t, theirsClone, "data/github/pr/100.json", "data/github/pr/100-bbbb.json")
+	require.NoError(t, os.WriteFile(filepath.Join(theirsClone, "data/github/pr/101.json"), []byte(`{"number":101,"remote":true}`), 0o644))
+	gitInRepo(t, theirsClone, "add", "-A")
+	gitInRepo(t, theirsClone, "commit", "-m", "remote changes")
+	gitInRepo(t, theirsClone, "push", "origin", "HEAD")
+
+	gitInRepo(t, oursClone, "fetch", "origin")
+	startRebase(t, oursClone)
+	require.True(t, IsRebaseInProgress(oursClone))
+
+	err := ResolveRebaseAcceptTheirs(context.Background(), oursClone, []string{"data/github/"})
+	assert.NoError(t, err, "mixed rename+content conflicts should be auto-resolved")
+	assert.False(t, IsRebaseInProgress(oursClone))
+}
+
+// --- D. Unsafe rename conflicts still rejected ---
+
+// TestResolveRebase_RenameOutsideSafePrefixRejected verifies that rename
+// conflicts outside safe prefixes are still rejected.
+// Failure prevented: rename-aware resolution accidentally bypasses safety checks.
+func TestResolveRebase_RenameOutsideSafePrefixRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git rebase operations")
+	}
+
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	oursClone := filepath.Join(t.TempDir(), "ours")
+	theirsClone := filepath.Join(t.TempDir(), "theirs")
+
+	gitInRepo(t, t.TempDir(), "init", "--bare", "--initial-branch=main", bareDir)
+
+	gitInRepo(t, t.TempDir(), "clone", bareDir, theirsClone)
+	gitInRepo(t, theirsClone, "config", "user.name", "test")
+	gitInRepo(t, theirsClone, "config", "user.email", "test@test.com")
+	require.NoError(t, os.MkdirAll(filepath.Join(theirsClone, "sessions"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(theirsClone, "sessions/important.jsonl"), []byte("base"), 0o644))
+	gitInRepo(t, theirsClone, "add", ".")
+	gitInRepo(t, theirsClone, "commit", "-m", "initial")
+	gitInRepo(t, theirsClone, "push", "origin", "HEAD")
+
+	gitInRepo(t, t.TempDir(), "clone", bareDir, oursClone)
+	gitInRepo(t, oursClone, "config", "user.name", "test")
+	gitInRepo(t, oursClone, "config", "user.email", "test@test.com")
+
+	// both sides rename sessions file
+	renameFile(t, oursClone, "sessions/important.jsonl", "sessions/important-local.jsonl")
+	gitInRepo(t, oursClone, "add", "-A")
+	gitInRepo(t, oursClone, "commit", "-m", "local rename")
+
+	renameFile(t, theirsClone, "sessions/important.jsonl", "sessions/important-remote.jsonl")
+	gitInRepo(t, theirsClone, "add", "-A")
+	gitInRepo(t, theirsClone, "commit", "-m", "remote rename")
+	gitInRepo(t, theirsClone, "push", "origin", "HEAD")
+
+	gitInRepo(t, oursClone, "fetch", "origin")
+	startRebase(t, oursClone)
+	require.True(t, IsRebaseInProgress(oursClone))
+
+	err := ResolveRebaseAcceptTheirs(context.Background(), oursClone, []string{"data/github/"})
+	assert.Error(t, err, "rename conflicts outside safe prefix should be rejected")
+	assert.Contains(t, err.Error(), "not under safe auto-resolve prefixes")
+	assert.True(t, IsRebaseInProgress(oursClone), "rebase should remain for caller to handle")
+}
+
+// --- Helpers ---
+
+// setupRenameRepos creates a bare repo with two clones, both having initial
+// files that can be renamed. Returns (bareDir, oursClone, theirsClone).
+func setupRenameRepos(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	oursClone := filepath.Join(t.TempDir(), "ours")
+	theirsClone := filepath.Join(t.TempDir(), "theirs")
+
+	gitInRepo(t, t.TempDir(), "init", "--bare", "--initial-branch=main", bareDir)
+
+	// initial commit via theirs clone
+	gitInRepo(t, t.TempDir(), "clone", bareDir, theirsClone)
+	gitInRepo(t, theirsClone, "config", "user.name", "test")
+	gitInRepo(t, theirsClone, "config", "user.email", "test@test.com")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(theirsClone, "data/github/2026/04/07/pr"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(theirsClone, "data/github/2026/04/07/pr/458.json"), []byte(`{"number":458,"state":"open"}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(theirsClone, "data/github/2026/04/07/pr/459.json"), []byte(`{"number":459,"state":"open"}`), 0o644))
+	gitInRepo(t, theirsClone, "add", ".")
+	gitInRepo(t, theirsClone, "commit", "-m", "initial")
+	gitInRepo(t, theirsClone, "push", "origin", "HEAD")
+
+	// clone ours
+	gitInRepo(t, t.TempDir(), "clone", bareDir, oursClone)
+	gitInRepo(t, oursClone, "config", "user.name", "test")
+	gitInRepo(t, oursClone, "config", "user.email", "test@test.com")
+
+	return bareDir, oursClone, theirsClone
+}
+
+// renameFile moves a file within a git repo (without staging).
+func renameFile(t *testing.T, repoDir, oldPath, newPath string) {
+	t.Helper()
+	abs := filepath.Join(repoDir, oldPath)
+	dest := filepath.Join(repoDir, newPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(dest), 0o755))
+	require.NoError(t, os.Rename(abs, dest))
+}
+
+// startRebase initiates a rebase that's expected to conflict.
+func startRebase(t *testing.T, repoDir string) {
+	t.Helper()
+	cmd := exec.Command("git", "rebase", "origin/main")
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), // safe: git subprocess in temp dir, not ox CLI
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=commit.gpgsign", "GIT_CONFIG_VALUE_0=false",
+	)
+	_ = cmd.Run() // expected to fail with conflict
+}


### PR DESCRIPTION
## Summary

Fixes a class of bugs where ledger sync gets permanently wedged by rename/rename and rename/delete git conflicts that the auto-resolve logic couldn't handle.

### Root Cause

Three interacting bugs created a self-reinforcing failure cycle:

```mermaid
graph TD
    A[Machine A: ox doctor runs migration] -->|renames 458.json → 458-abc.json| C[Both push to remote]
    B[Machine B: ox doctor runs migration] -->|renames 458.json → 458-def.json| C
    C --> D[git pull --rebase]
    D --> E[rename/rename conflict]
    E --> F[ResolveRebaseAcceptTheirs fails]
    F -->|checkout --theirs doesn't work for renames| G[rebase left in broken state]
    G --> H[next ox doctor: checkLedgerCleanWorkdir]
    H -->|auto-commits conflict debris| I[cycle repeats ♻️]
```

### Bug 1: `ResolveRebaseAcceptTheirs` doesn't handle rename conflicts

`git checkout --theirs` fails for rename/rename conflicts because the conflicted paths don't have a "theirs" version in the expected sense. The function used `git diff --diff-filter=U` which doesn't properly report rename conflict file states.

**Fix:** Replaced with `git ls-files --unmerged` to detect index stages (base/theirs/ours), then resolve by type:
- **Content conflicts** (all 3 stages same path): `git checkout --theirs` (existing behavior)
- **Rename conflicts** (stages at different paths): `git add` / `git rm --cached` based on stage presence
- **Rename/delete** (one side renames, other deletes): stage whichever version exists

### Bug 2: GitHub data migration runs on every `ox doctor` invocation

`FixLevelAuto` meant migration ran silently every time, not just with `--fix`. Two machines running `ox doctor` independently would both rename the same files with different content hashes (if fetched at different times), creating the rename/rename conflicts.

**Fix:** Changed to `FixLevelSuggested` — migration now requires explicit `--fix`.

### Bug 3: `checkLedgerCleanWorkdir` commits during broken rebase

The dirty workdir check (`FixLevelAuto`) would `git add -A && git commit` even when a rebase was in progress, sweeping conflict debris into a generic "ox doctor: auto-commit ledger changes" commit.

**Fix:** Skip the check when `IsRebaseInProgress()` returns true.

## Test plan

- [x] 4 new tests for rename conflict scenarios (rename/rename, rename/delete, mixed, unsafe rejection)
- [x] All 9 existing rebase resolve tests still pass
- [x] `make lint` clean
- [x] `go test ./internal/gitutil/... ./cmd/ox/... -short` passes
- [x] Build compiles

## Changed files

| File | Change |
|------|--------|
| `internal/gitutil/rebase_resolve.go` | Rewrite conflict detection to use `git ls-files --unmerged`; handle rename conflicts by stage analysis |
| `internal/gitutil/rebase_resolve_rename_test.go` | 4 new tests for rename/rename, rename/delete, mixed, and safety rejection |
| `cmd/ox/doctor_github_migrate.go` | `FixLevelAuto` → `FixLevelSuggested` |
| `cmd/ox/doctor_ledger_git.go` | Skip dirty workdir check when rebase is in progress |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * GitHub data migration check is now suggested rather than automatically applied during doctor operations.

* **Bug Fixes**
  * Improved detection of in-progress rebases in ledger operations, preventing incorrect status checks.
  * Enhanced conflict resolution during git rebases with better handling of complex rename and deletion scenarios.

* **Tests**
  * Added comprehensive integration tests for rebase conflict resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->