### PR TITLE
feat(claws): add openclaw sageox skills + clawhub-skill-lint

### DIFF
--- a/.claude/skills/clawhub-skill-lint/SKILL.md
+++ b/.claude/skills/clawhub-skill-lint/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: clawhub-skill-lint
+description: >
+  Use this skill before publishing any ClawHub skill from this repo, or after
+  editing a SKILL.md, to verify the skill won't be flagged or rejected by
+  ClawHub's server-side moderation pipeline. The skill re-implements every
+  static-scanner rule from openclaw/clawhub's `convex/lib/moderationEngine.ts`
+  plus the frontmatter spec from `docs/skill-format.md` and runs them locally.
+  Triggers: "lint the claws skills", "check the claws/openclaw skills",
+  "scan before publish", "is the skill clean", "any scanner findings",
+  /clawhub-skill-lint, before any `clawhub sync` or `clawhub skill publish`.
+---
+
+# clawhub-skill-lint
+
+A pre-publish validator for ClawHub skills. Catches publish-time failures
+locally — no network round-trip, no `clawhub` CLI required.
+
+## When to use
+
+- **Before** running `clawhub sync` or `clawhub skill publish`.
+- **After** editing any `SKILL.md`, `README.md`, or other text file in a
+  ClawHub skill folder, to confirm no new patterns trigger the scanner.
+- **In CI** as a pre-publish gate.
+- Whenever the user asks "is this skill clean", "will this pass review",
+  or "scan before I publish".
+
+## How to invoke
+
+The skill bundles a Python linter at
+`.claude/skills/clawhub-skill-lint/scripts/lint.py`. Call it with one or
+more paths:
+
+```bash
+# Lint a single skill folder
+python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw/sageox-distill
+
+# Lint every skill under a parent directory
+python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw
+
+# Multiple paths in one invocation
+python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw/sageox-distill claws/openclaw/sageox-summary
+
+# Machine-readable JSON output (for CI)
+python3 .claude/skills/clawhub-skill-lint/scripts/lint.py --json claws/openclaw
+
+# Treat warnings as errors
+python3 .claude/skills/clawhub-skill-lint/scripts/lint.py --strict claws/openclaw
+```
+
+The linter discovers skill folders by looking for `SKILL.md` (or `skill.md`).
+A path that contains `SKILL.md` directly is treated as a single skill;
+any other directory is scanned for child folders.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | Clean (or only `info` findings; or `--strict` not set and only `warn` findings) |
+| `1` | At least one `critical` finding, or `--strict` and at least one `warn` |
+| `2` | Usage / I/O error (bad path, missing `SKILL.md`, etc.) |
+
+## How to interpret results
+
+Each finding has:
+
+- **rule_id** — short stable identifier (e.g. `static.malicious_install_prompt`,
+  `frontmatter.missing_required_field`)
+- **severity** — `critical`, `warn`, or `info`
+- **file** — path inside the skill folder (or `SKILL.md` / `metadata` for
+  frontmatter findings)
+- **line** — 1-indexed line number where the rule first matched
+- **message** — human-readable explanation
+- **evidence** — truncated snippet of the matching text
+
+**Critical findings will hard-block publish.** Examples: malicious install
+prompt, frontmatter missing required field, slug regex fail, install kind
+not in {`brew`, `node`, `go`, `uv`}, bundle size > 50 MB.
+
+**Warnings are advisory** but worth fixing — they signal patterns the
+scanner may flag as `suspicious` (which doesn't block but adds a warning
+banner on the skill page). Examples: `always: true` in frontmatter,
+URL shortener references, prompt-injection bait phrases.
+
+**Info findings** are observations that don't affect publishability.
+
+## Workflow when findings are reported
+
+1. **Read each finding** out loud to the user, grouped by severity.
+2. **For each critical finding:**
+   - Show the file:line and the offending evidence.
+   - Propose a concrete fix (e.g., "rephrase 'for macOS:' to '**macOS:**'
+     to avoid triggering the terminal-instruction precondition" or
+     "add `version: 0.1.0` to the frontmatter").
+   - Apply the fix only after the user confirms.
+3. **Re-run the linter** after fixes to confirm clean.
+4. **Only proceed to publish** when the linter exits 0.
+
+## Source-of-truth references
+
+The linter is kept in sync with these upstream files. If ClawHub updates
+its rules, update `scripts/lint.py` to match:
+
+- [openclaw/clawhub `docs/skill-format.md`](https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md) — frontmatter schema, slug regex, bundle limits, install kinds
+- [openclaw/clawhub `convex/lib/moderationEngine.ts`](https://github.com/openclaw/clawhub/blob/main/convex/lib/moderationEngine.ts) — static scanner rules (the canonical source of truth for `hasMaliciousInstallPrompt` and friends)
+- [openclaw/clawhub `docs/security.md`](https://github.com/openclaw/clawhub/blob/main/docs/security.md) — moderation pipeline overview
+
+## What this linter does NOT cover
+
+- **VirusTotal hash lookup** — server-side, runs against a live SHA-256 DB.
+  Not reproducible locally.
+- **VT Code Insight (Gemini LLM scan)** — opaque, server-side. The only
+  way to get the LLM verdict is to publish under a throwaway slug and
+  query `/api/v1/skills/<slug>/scan`. See `claws/openclaw/PUBLISHING.md`
+  § "Throwaway-slug pre-flight" for the workflow.
+- **Behavioral correctness of the skill** — the linter only looks at
+  patterns. Whether the skill *actually does what it says* is a separate
+  test (load it into a real OpenClaw via `skills.load.extraDirs`).
+
+A clean lint result is necessary but not sufficient for a successful
+publish. Always also do at least one throwaway-slug publish before
+claiming the canonical slug.

--- a/.claude/skills/clawhub-skill-lint/scripts/.gitignore
+++ b/.claude/skills/clawhub-skill-lint/scripts/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.claude/skills/clawhub-skill-lint/scripts/lint.py
+++ b/.claude/skills/clawhub-skill-lint/scripts/lint.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+"""
+clawhub-skill-lint — pre-publish validator for ClawHub skills.
+
+Re-implements the rules from openclaw/clawhub's server-side static scanner
+(convex/lib/moderationEngine.ts) and the skill format spec (docs/skill-format.md)
+so you can catch publish-time failures locally without needing the clawhub CLI
+or a network round-trip.
+
+Usage:
+    lint.py [--json] [--strict] <path>...
+
+Where <path> is a single skill folder (containing SKILL.md) or a parent
+directory containing skill subfolders.
+
+Exit codes:
+  0   clean (no critical findings; warnings allowed unless --strict)
+  1   at least one critical finding (or warning + --strict)
+  2   usage / I/O error
+
+Source-of-truth references:
+  https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md
+  https://github.com/openclaw/clawhub/blob/main/convex/lib/moderationEngine.ts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Iterable
+
+# ============================================================================
+# Constants from docs/skill-format.md
+# ============================================================================
+
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$")
+ALLOWED_INSTALL_KINDS = {"brew", "node", "go", "uv"}
+ALLOWED_OS = {"macos", "linux", "windows"}
+BUNDLE_BYTE_LIMIT = 50 * 1024 * 1024  # 50 MB
+
+# Text-file extensions that ClawHub accepts. Subset; extend if needed.
+TEXT_FILE_EXTS = {
+    ".md", ".markdown", ".mdx", ".txt",
+    ".json", ".json5", ".yaml", ".yml", ".toml",
+    ".js", ".ts", ".mjs", ".cjs", ".mts", ".cts", ".jsx", ".tsx",
+    ".py", ".sh", ".bash", ".zsh", ".rb", ".go",
+    ".svg", ".html", ".css", ".clawhubignore", ".gitignore",
+}
+
+# ============================================================================
+# Static scanner rules from convex/lib/moderationEngine.ts
+# ============================================================================
+
+MARKDOWN_EXT_RE = re.compile(r"\.(md|markdown|mdx)$", re.I)
+CODE_EXT_RE = re.compile(r"\.(js|ts|mjs|cjs|mts|cts|jsx|tsx|py|sh|bash|zsh|rb|go)$", re.I)
+MANIFEST_EXT_RE = re.compile(r"\.(json|yaml|yml|toml)$", re.I)
+
+RAW_IP_URL_RE = re.compile(r"https?://\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?(?:/|[\"'])", re.I)
+INSTALL_PACKAGE_RE = re.compile(r"installer-package\s*:\s*https?://[^\s\"'`]+", re.I)
+URL_SHORTENER_RE = re.compile(
+    r"https?://(bit\.ly|tinyurl\.com|t\.co|goo\.gl|is\.gd)/", re.I
+)
+
+# hasMaliciousInstallPrompt preconditions
+TI_PATTERNS = [
+    re.compile(r"(?:copy|paste).{0,80}(?:command|snippet).{0,120}(?:terminal|shell)", re.I | re.S),
+    re.compile(r"run\s+it\s+in\s+terminal", re.I),
+    re.compile(r"open\s+terminal", re.I),
+    re.compile(r"for\s+macos\s*:", re.I),
+]
+CURL_PIPE_SH_RE = re.compile(r"(?:curl|wget)\b[^\n|]{0,240}\|\s*(?:/bin/)?(?:ba)?sh\b", re.I)
+BASE64_EXEC_RE = re.compile(
+    r"(?:echo|printf)\s+[\"'][A-Za-z0-9+/=\s]{40,}[\"']\s*\|\s*base64\s+-?[dD]\b"
+    r"[^\n|]{0,120}\|\s*(?:/bin/)?(?:ba)?sh\b",
+    re.I,
+)
+
+# Other markdown rules
+PROMPT_INJECTION_RE = re.compile(
+    r"ignore\s+(all\s+)?previous\s+instructions|system\s*prompt\s*[:=]", re.I
+)
+GEN_SOURCE_PLACEHOLDER_RE = re.compile(
+    r"^\s*[A-Za-z_][A-Za-z0-9_]*\s*=.*[\"']\$\{[A-Za-z_][A-Za-z0-9_-]*\}[\"']", re.M
+)
+GEN_SOURCE_CONTEXT_RE = re.compile(
+    r"```(?:python|py|javascript|js|typescript|ts|shell|bash|sh)\b"
+    r"|cat\s*(?:>|>>)?\s*[^`\n]*\.(?:py|js|ts|sh)\b"
+    r"|python3?\b|node\b",
+    re.I,
+)
+HARDCODED_CONNECTION_ID_RE = re.compile(
+    r"[\"']connection_id[\"']\s*:\s*[\"'][0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}"
+    r"-[89ab][0-9a-f]{3}-[0-9a-f]{12}[\"']",
+    re.I,
+)
+
+# Code file rules (only fire on .js/.ts/.py/.sh/.rb/.go etc.)
+CHILD_PROCESS_RE = re.compile(r"child_process")
+EXEC_RE = re.compile(r"\b(exec|execSync|spawn|spawnSync|execFile|execFileSync)\s*\(")
+EVAL_RE = re.compile(r"\beval\s*\(|new\s+Function\s*\(")
+CRYPTO_MINING_RE = re.compile(r"stratum\+tcp|stratum\+ssl|coinhive|cryptonight|xmrig", re.I)
+NETWORK_SEND_RE = re.compile(r"\bfetch\b|http\.request|\baxios\b")
+PROCESS_ENV_RE = re.compile(r"process\.env")
+FILE_READ_RE = re.compile(r"readFileSync|readFile")
+OBFUSCATED_HEX_RE = re.compile(r"(\\x[0-9a-fA-F]{2}){6,}")
+OBFUSCATED_B64_RE = re.compile(r"(?:atob|Buffer\.from)\s*\(\s*[\"'][A-Za-z0-9+/=]{200,}[\"']")
+
+# ============================================================================
+# Findings model
+# ============================================================================
+
+
+@dataclass
+class Finding:
+    rule_id: str
+    severity: str  # "critical" | "warn" | "info"
+    file: str
+    line: int
+    message: str
+    evidence: str = ""
+
+    def __post_init__(self):
+        if len(self.evidence) > 120:
+            self.evidence = self.evidence[:120] + "…"
+
+
+@dataclass
+class SkillReport:
+    slug: str
+    path: str
+    findings: list[Finding] = field(default_factory=list)
+    bundle_bytes: int = 0
+    file_count: int = 0
+
+    def add(self, f: Finding):
+        self.findings.append(f)
+
+    def by_severity(self, sev: str) -> list[Finding]:
+        return [f for f in self.findings if f.severity == sev]
+
+    def is_clean(self, strict: bool) -> bool:
+        if any(f.severity == "critical" for f in self.findings):
+            return False
+        if strict and any(f.severity == "warn" for f in self.findings):
+            return False
+        return True
+
+
+# ============================================================================
+# Frontmatter parser (regex-based, no PyYAML dep)
+# ============================================================================
+
+
+def parse_frontmatter(text: str) -> dict | None:
+    """Extract and parse the YAML frontmatter from a SKILL.md file."""
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    if not m:
+        return None
+    return _parse_yaml_subset(m.group(1))
+
+
+def _parse_yaml_subset(text: str) -> dict:
+    """Recursive-descent parser for the YAML subset SKILL.md frontmatter uses:
+    - scalar keys (quoted or bare)
+    - nested maps (block style, indented)
+    - lists of scalars and lists of maps (`- key: val` form)
+    - flow-style lists `[a, b, c]`
+    - folded scalars `key: >` followed by indented continuation lines
+    """
+    raw_lines = text.split("\n")
+    # Drop blank/comment lines but remember nothing — recursive descent handles indent.
+    lines = [ln for ln in raw_lines if ln.strip() and not ln.lstrip().startswith("#")]
+    pos = [0]
+
+    def peek_indent() -> int | None:
+        if pos[0] >= len(lines):
+            return None
+        ln = lines[pos[0]]
+        return len(ln) - len(ln.lstrip(" "))
+
+    def parse_scalar_value(val: str, parent_indent: int):
+        """Convert an inline value (everything after `key:`) to a Python value."""
+        val = val.strip()
+        if val == ">" or val == ">-":
+            return parse_folded(parent_indent)
+        if val.startswith("[") and val.endswith("]"):
+            inner = val[1:-1]
+            return [_strip_quotes(x.strip()) for x in inner.split(",") if x.strip()]
+        return _strip_quotes(val)
+
+    def parse_value_after_key(parent_indent: int):
+        """Parse the value that follows a `key:` with no inline content.
+        The value lives on subsequent lines at indent > parent_indent."""
+        ni = peek_indent()
+        if ni is None or ni <= parent_indent:
+            return None
+        stripped = lines[pos[0]].strip()
+        if stripped.startswith("- "):
+            return parse_list(ni)
+        return parse_map(ni)
+
+    def parse_map(min_indent: int) -> dict:
+        result: dict = {}
+        while pos[0] < len(lines):
+            ln = lines[pos[0]]
+            indent = len(ln) - len(ln.lstrip(" "))
+            stripped = ln.strip()
+            if indent < min_indent:
+                return result
+            if stripped.startswith("- "):
+                return result
+            if indent != min_indent:
+                pos[0] += 1
+                continue
+            if ":" not in stripped:
+                pos[0] += 1
+                continue
+            key, _, val = stripped.partition(":")
+            key = key.strip()
+            val = val.strip()
+            pos[0] += 1
+            if not val:
+                result[key] = parse_value_after_key(indent)
+            else:
+                result[key] = parse_scalar_value(val, indent)
+        return result
+
+    def parse_list(min_indent: int) -> list:
+        result: list = []
+        while pos[0] < len(lines):
+            ln = lines[pos[0]]
+            indent = len(ln) - len(ln.lstrip(" "))
+            stripped = ln.strip()
+            if indent < min_indent:
+                return result
+            if not stripped.startswith("- "):
+                return result
+            if indent != min_indent:
+                return result
+            item_content = stripped[2:].strip()
+            pos[0] += 1
+            if ":" in item_content and not item_content.startswith("["):
+                # List item is a map. Its inner keys live at min_indent + 2
+                # (the column where item content starts after `- `).
+                inner_indent = min_indent + 2
+                item: dict = {}
+                key, _, val = item_content.partition(":")
+                key = key.strip()
+                val = val.strip()
+                if not val:
+                    item[key] = parse_value_after_key(inner_indent)
+                else:
+                    item[key] = parse_scalar_value(val, inner_indent)
+                # Parse any additional keys for this same item at inner_indent.
+                additional = parse_map(inner_indent)
+                item.update(additional)
+                result.append(item)
+            else:
+                result.append(_strip_quotes(item_content))
+        return result
+
+    def parse_folded(parent_indent: int) -> str:
+        fold_lines: list[str] = []
+        while pos[0] < len(lines):
+            ln = lines[pos[0]]
+            indent = len(ln) - len(ln.lstrip(" "))
+            if indent <= parent_indent:
+                break
+            fold_lines.append(ln.strip())
+            pos[0] += 1
+        return " ".join(fold_lines).strip()
+
+    return parse_map(0)
+
+
+def _strip_quotes(s: str) -> str:
+    if len(s) >= 2 and (
+        (s[0] == '"' and s[-1] == '"') or (s[0] == "'" and s[-1] == "'")
+    ):
+        return s[1:-1]
+    return s
+
+
+# ============================================================================
+# Skill discovery
+# ============================================================================
+
+
+def find_skills(path: Path) -> list[Path]:
+    """Discover skill folders. A path containing SKILL.md is a single skill;
+    otherwise scan child directories for SKILL.md."""
+    if (path / "SKILL.md").is_file() or (path / "skill.md").is_file():
+        return [path]
+    if not path.is_dir():
+        return []
+    out: list[Path] = []
+    for child in sorted(path.iterdir()):
+        if child.is_dir() and not child.name.startswith("."):
+            if (child / "SKILL.md").is_file() or (child / "skill.md").is_file():
+                out.append(child)
+    return out
+
+
+def read_clawhubignore(skill_dir: Path) -> set[str]:
+    """Return the set of basename patterns to ignore from .clawhubignore."""
+    f = skill_dir / ".clawhubignore"
+    if not f.is_file():
+        return set()
+    return {ln.strip() for ln in f.read_text().splitlines() if ln.strip() and not ln.startswith("#")}
+
+
+def iter_skill_files(skill_dir: Path) -> Iterable[Path]:
+    """Yield every file in the skill folder that would be included in the bundle."""
+    ignore = read_clawhubignore(skill_dir)
+    for p in skill_dir.rglob("*"):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(skill_dir)
+        if any(part.startswith(".") and part not in (".clawhubignore", ".gitignore") for part in rel.parts):
+            continue
+        if rel.name in ignore:
+            continue
+        yield p
+
+
+# ============================================================================
+# Frontmatter checks
+# ============================================================================
+
+
+def check_frontmatter(report: SkillReport, skill_dir: Path) -> dict | None:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        skill_md = skill_dir / "skill.md"
+    if not skill_md.is_file():
+        report.add(Finding(
+            "frontmatter.missing_skill_md", "critical",
+            "SKILL.md", 1, "Skill folder has no SKILL.md (or skill.md) file.",
+        ))
+        return None
+
+    text = skill_md.read_text()
+    fm = parse_frontmatter(text)
+    if fm is None:
+        report.add(Finding(
+            "frontmatter.no_frontmatter", "critical",
+            "SKILL.md", 1, "SKILL.md has no YAML frontmatter (--- block at top of file).",
+        ))
+        return None
+
+    # Required fields
+    for field_name in ("name", "description"):
+        if field_name not in fm or not fm[field_name]:
+            report.add(Finding(
+                "frontmatter.missing_required_field", "critical",
+                "SKILL.md", 1,
+                f"Required frontmatter field `{field_name}` is missing or empty.",
+            ))
+
+    # Version (optional in spec but required for `clawhub skill publish --version`,
+    # and we want it for clarity)
+    if "version" in fm and fm["version"]:
+        if not SEMVER_RE.match(str(fm["version"])):
+            report.add(Finding(
+                "frontmatter.invalid_version", "critical",
+                "SKILL.md", 1,
+                f"`version` is not valid semver: {fm['version']!r}",
+                evidence=f"version: {fm['version']}",
+            ))
+    else:
+        report.add(Finding(
+            "frontmatter.missing_version", "warn",
+            "SKILL.md", 1,
+            "No `version` field in frontmatter. Required for explicit `clawhub skill publish`; "
+            "`clawhub sync --bump` can derive it from registry state.",
+        ))
+
+    # Slug == folder name
+    folder_slug = skill_dir.name
+    if not SLUG_RE.match(folder_slug):
+        report.add(Finding(
+            "frontmatter.invalid_slug", "critical",
+            "SKILL.md", 1,
+            f"Folder name `{folder_slug}` is not a valid ClawHub slug "
+            f"(must match {SLUG_RE.pattern}).",
+        ))
+    if "name" in fm and fm["name"] != folder_slug:
+        report.add(Finding(
+            "frontmatter.name_slug_mismatch", "warn",
+            "SKILL.md", 1,
+            f"Frontmatter `name: {fm['name']}` does not match folder name "
+            f"`{folder_slug}`. The folder name is used as the slug by default.",
+        ))
+
+    # metadata.openclaw checks
+    oc = (fm.get("metadata") or {}).get("openclaw") or {}
+
+    # os
+    os_field = oc.get("os")
+    if os_field is not None:
+        if not isinstance(os_field, list):
+            report.add(Finding(
+                "frontmatter.invalid_os", "critical",
+                "SKILL.md", 1, f"`metadata.openclaw.os` must be a list, got {type(os_field).__name__}.",
+            ))
+        else:
+            for entry in os_field:
+                if entry not in ALLOWED_OS:
+                    report.add(Finding(
+                        "frontmatter.unknown_os", "warn",
+                        "SKILL.md", 1,
+                        f"Unknown OS `{entry}` in `metadata.openclaw.os`. "
+                        f"Allowed: {sorted(ALLOWED_OS)}.",
+                    ))
+
+    # install kinds
+    install = oc.get("install") or []
+    if isinstance(install, list):
+        for entry in install:
+            if isinstance(entry, dict) and "kind" in entry:
+                if entry["kind"] not in ALLOWED_INSTALL_KINDS:
+                    report.add(Finding(
+                        "frontmatter.invalid_install_kind", "critical",
+                        "SKILL.md", 1,
+                        f"install kind `{entry['kind']}` is not in the allowed set "
+                        f"{sorted(ALLOWED_INSTALL_KINDS)}. The skill format spec only "
+                        f"supports these kinds; everything else is ignored.",
+                    ))
+
+    # primaryEnv must be in requires.env if both are set
+    primary = oc.get("primaryEnv")
+    requires_env = (oc.get("requires") or {}).get("env") or []
+    if primary and requires_env and primary not in requires_env:
+        report.add(Finding(
+            "frontmatter.primary_env_not_in_requires", "warn",
+            "SKILL.md", 1,
+            f"`primaryEnv: {primary}` is not listed in `requires.env`. "
+            f"Add it to keep the metadata internally consistent.",
+        ))
+
+    # always: true is privileged (scanner flags as warn)
+    if oc.get("always") is True or oc.get("always") == "true":
+        report.add(Finding(
+            "frontmatter.privileged_always", "warn",
+            "SKILL.md", 1,
+            "`metadata.openclaw.always: true` makes the skill persistently invoked. "
+            "ClawHub flags this as a privileged manifest.",
+            evidence="always: true",
+        ))
+
+    return fm
+
+
+# ============================================================================
+# Bundle checks
+# ============================================================================
+
+
+def check_bundle(report: SkillReport, skill_dir: Path) -> None:
+    total = 0
+    count = 0
+    for p in iter_skill_files(skill_dir):
+        try:
+            size = p.stat().st_size
+        except OSError:
+            continue
+        total += size
+        count += 1
+        ext = p.suffix.lower()
+        if ext and ext not in TEXT_FILE_EXTS and p.name not in TEXT_FILE_EXTS:
+            report.add(Finding(
+                "bundle.non_text_file", "warn",
+                str(p.relative_to(skill_dir)), 1,
+                f"File extension `{ext}` is not in the ClawHub text-file allowlist. "
+                f"Server may reject the bundle.",
+            ))
+    report.bundle_bytes = total
+    report.file_count = count
+    if total > BUNDLE_BYTE_LIMIT:
+        report.add(Finding(
+            "bundle.size_exceeded", "critical",
+            "<bundle>", 1,
+            f"Bundle size {total // 1024} KB exceeds 50 MB limit.",
+        ))
+
+
+# ============================================================================
+# Static scanner — markdown rules
+# ============================================================================
+
+
+def has_terminal_instruction(content: str) -> bool:
+    return any(p.search(content) for p in TI_PATTERNS)
+
+
+def find_first_line(content: str, pattern: re.Pattern) -> tuple[int, str]:
+    for i, line in enumerate(content.split("\n"), start=1):
+        if pattern.search(line):
+            return i, line
+    m = pattern.search(content)
+    if m:
+        line_no = content[: m.start()].count("\n") + 1
+        line_text = content.split("\n")[line_no - 1]
+        return line_no, line_text
+    return 1, content[:120]
+
+
+def scan_markdown(report: SkillReport, rel_path: str, content: str) -> None:
+    # hasMaliciousInstallPrompt
+    if has_terminal_instruction(content):
+        has_curl = bool(CURL_PIPE_SH_RE.search(content))
+        has_b64 = bool(BASE64_EXEC_RE.search(content))
+        has_rawip = bool(RAW_IP_URL_RE.search(content))
+        has_instpkg = bool(INSTALL_PACKAGE_RE.search(content))
+        if has_b64 or (has_curl and (has_rawip or has_instpkg)):
+            line, evidence = find_first_line(
+                content,
+                re.compile(
+                    r"installer-package\s*:|base64\s+-?[dD]|(?:curl|wget)\b|run\s+it\s+in\s+terminal",
+                    re.I,
+                ),
+            )
+            report.add(Finding(
+                "static.malicious_install_prompt", "critical",
+                rel_path, line,
+                "Install prompt contains an obfuscated terminal payload "
+                "(curl|sh + raw IP / installer-package, or base64-decoded pipe-to-sh).",
+                evidence=evidence,
+            ))
+
+    # Prompt injection bait
+    if PROMPT_INJECTION_RE.search(content):
+        line, evidence = find_first_line(content, PROMPT_INJECTION_RE)
+        report.add(Finding(
+            "static.injection_instructions", "warn",
+            rel_path, line,
+            "Prompt-injection style instruction pattern detected ('ignore previous instructions' or 'system prompt:').",
+            evidence=evidence,
+        ))
+
+    # Generated source placeholder + code context
+    if GEN_SOURCE_PLACEHOLDER_RE.search(content) and GEN_SOURCE_CONTEXT_RE.search(content):
+        line, evidence = find_first_line(content, GEN_SOURCE_PLACEHOLDER_RE)
+        report.add(Finding(
+            "static.generated_source_template", "critical",
+            rel_path, line,
+            "User-controlled placeholder is embedded directly into generated source code.",
+            evidence=evidence,
+        ))
+
+    # Hardcoded connection_id UUID
+    if HARDCODED_CONNECTION_ID_RE.search(content):
+        line, evidence = find_first_line(content, HARDCODED_CONNECTION_ID_RE)
+        report.add(Finding(
+            "static.hardcoded_connection_id", "critical",
+            rel_path, line,
+            "Example code exposes a concrete connection_id UUID instead of a placeholder.",
+            evidence=evidence,
+        ))
+
+
+# ============================================================================
+# Static scanner — code file rules
+# ============================================================================
+
+
+def scan_code(report: SkillReport, rel_path: str, content: str) -> None:
+    if CHILD_PROCESS_RE.search(content) and EXEC_RE.search(content):
+        line, evidence = find_first_line(content, EXEC_RE)
+        report.add(Finding(
+            "static.dangerous_exec", "critical",
+            rel_path, line,
+            "Shell command execution detected (child_process exec/spawn).",
+            evidence=evidence,
+        ))
+
+    if EVAL_RE.search(content):
+        line, evidence = find_first_line(content, EVAL_RE)
+        report.add(Finding(
+            "static.dynamic_code_execution", "critical",
+            rel_path, line,
+            "Dynamic code execution detected (eval / new Function).",
+            evidence=evidence,
+        ))
+
+    if CRYPTO_MINING_RE.search(content):
+        line, evidence = find_first_line(content, CRYPTO_MINING_RE)
+        report.add(Finding(
+            "static.crypto_mining", "critical",
+            rel_path, line,
+            "Possible crypto mining behavior detected.",
+            evidence=evidence,
+        ))
+
+    if FILE_READ_RE.search(content) and NETWORK_SEND_RE.search(content):
+        line, evidence = find_first_line(content, FILE_READ_RE)
+        report.add(Finding(
+            "static.exfiltration", "warn",
+            rel_path, line,
+            "File read combined with network send (possible exfiltration).",
+            evidence=evidence,
+        ))
+
+    if PROCESS_ENV_RE.search(content) and NETWORK_SEND_RE.search(content):
+        line, evidence = find_first_line(content, PROCESS_ENV_RE)
+        report.add(Finding(
+            "static.credential_harvest", "critical",
+            rel_path, line,
+            "Environment variable access combined with network send.",
+            evidence=evidence,
+        ))
+
+    if OBFUSCATED_HEX_RE.search(content) or OBFUSCATED_B64_RE.search(content):
+        pat = OBFUSCATED_HEX_RE if OBFUSCATED_HEX_RE.search(content) else OBFUSCATED_B64_RE
+        line, evidence = find_first_line(content, pat)
+        report.add(Finding(
+            "static.obfuscated_code", "warn",
+            rel_path, line,
+            "Potential obfuscated payload detected (hex or large base64).",
+            evidence=evidence,
+        ))
+
+
+# ============================================================================
+# Static scanner — manifest file rules
+# ============================================================================
+
+
+def scan_manifest(report: SkillReport, rel_path: str, content: str) -> None:
+    if URL_SHORTENER_RE.search(content) or RAW_IP_URL_RE.search(content):
+        pat = URL_SHORTENER_RE if URL_SHORTENER_RE.search(content) else RAW_IP_URL_RE
+        line, evidence = find_first_line(content, pat)
+        report.add(Finding(
+            "static.suspicious_install_source", "warn",
+            rel_path, line,
+            "Install source points to URL shortener or raw IP.",
+            evidence=evidence,
+        ))
+
+
+# ============================================================================
+# Per-skill linter
+# ============================================================================
+
+
+def lint_skill(skill_dir: Path) -> SkillReport:
+    report = SkillReport(slug=skill_dir.name, path=str(skill_dir))
+    fm = check_frontmatter(report, skill_dir)
+    check_bundle(report, skill_dir)
+
+    for p in iter_skill_files(skill_dir):
+        rel = str(p.relative_to(skill_dir))
+        try:
+            content = p.read_text(errors="replace")
+        except OSError:
+            continue
+        if MARKDOWN_EXT_RE.search(rel):
+            scan_markdown(report, rel, content)
+        if CODE_EXT_RE.search(rel):
+            scan_code(report, rel, content)
+        if MANIFEST_EXT_RE.search(rel):
+            scan_manifest(report, rel, content)
+
+    return report
+
+
+# ============================================================================
+# Output
+# ============================================================================
+
+ANSI_RED = "\033[31m"
+ANSI_YELLOW = "\033[33m"
+ANSI_GREEN = "\033[32m"
+ANSI_DIM = "\033[2m"
+ANSI_BOLD = "\033[1m"
+ANSI_RESET = "\033[0m"
+
+SEVERITY_COLOR = {
+    "critical": ANSI_RED,
+    "warn": ANSI_YELLOW,
+    "info": ANSI_DIM,
+}
+
+
+def color(s: str, c: str, use_color: bool) -> str:
+    if not use_color:
+        return s
+    return f"{c}{s}{ANSI_RESET}"
+
+
+def print_text_report(reports: list[SkillReport], strict: bool, use_color: bool) -> None:
+    total_critical = 0
+    total_warn = 0
+    for report in reports:
+        critical = report.by_severity("critical")
+        warns = report.by_severity("warn")
+        infos = report.by_severity("info")
+        total_critical += len(critical)
+        total_warn += len(warns)
+
+        clean = report.is_clean(strict)
+        banner_color = ANSI_GREEN if clean else (ANSI_RED if critical else ANSI_YELLOW)
+        status = "PASS" if clean else ("FAIL" if critical else "WARN")
+        print()
+        print(color(f"=== {status} {report.slug}", banner_color + ANSI_BOLD, use_color))
+        print(color(f"    {report.path}", ANSI_DIM, use_color))
+        print(color(
+            f"    {report.file_count} files, {report.bundle_bytes // 1024} KB / 50 MB limit",
+            ANSI_DIM, use_color,
+        ))
+        if not report.findings:
+            print(color("    no findings", ANSI_DIM, use_color))
+            continue
+        for sev in ("critical", "warn", "info"):
+            group = report.by_severity(sev)
+            if not group:
+                continue
+            print(color(f"    [{sev}] {len(group)} finding(s)", SEVERITY_COLOR[sev], use_color))
+            for f in group:
+                print(f"      {f.rule_id}  {f.file}:{f.line}")
+                print(f"        {f.message}")
+                if f.evidence:
+                    print(color(f"        evidence: {f.evidence}", ANSI_DIM, use_color))
+
+    print()
+    summary = (
+        f"{len(reports)} skill(s) scanned, "
+        f"{total_critical} critical, {total_warn} warning(s)"
+    )
+    if total_critical:
+        print(color(f"FAIL — {summary}", ANSI_RED + ANSI_BOLD, use_color))
+    elif total_warn and strict:
+        print(color(f"FAIL (strict) — {summary}", ANSI_YELLOW + ANSI_BOLD, use_color))
+    elif total_warn:
+        print(color(f"PASS with warnings — {summary}", ANSI_YELLOW, use_color))
+    else:
+        print(color(f"PASS — {summary}", ANSI_GREEN + ANSI_BOLD, use_color))
+
+
+def print_json_report(reports: list[SkillReport]) -> None:
+    out = []
+    for r in reports:
+        out.append({
+            "slug": r.slug,
+            "path": r.path,
+            "file_count": r.file_count,
+            "bundle_bytes": r.bundle_bytes,
+            "findings": [asdict(f) for f in r.findings],
+        })
+    json.dump(out, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pre-publish validator for ClawHub skills.",
+    )
+    parser.add_argument("paths", nargs="+", type=Path, help="Skill folders or parent directories")
+    parser.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    parser.add_argument("--strict", action="store_true", help="Treat warnings as errors")
+    parser.add_argument("--no-color", action="store_true", help="Disable ANSI colors")
+    args = parser.parse_args(argv)
+
+    skills: list[Path] = []
+    for p in args.paths:
+        if not p.exists():
+            print(f"ERROR: path does not exist: {p}", file=sys.stderr)
+            return 2
+        found = find_skills(p)
+        if not found:
+            print(f"ERROR: no skill folders found under {p} (looked for SKILL.md / skill.md)",
+                  file=sys.stderr)
+            return 2
+        skills.extend(found)
+
+    reports = [lint_skill(s) for s in skills]
+    use_color = sys.stdout.isatty() and not args.no_color and not args.json
+
+    if args.json:
+        print_json_report(reports)
+    else:
+        print_text_report(reports, args.strict, use_color)
+
+    has_critical = any(r.by_severity("critical") for r in reports)
+    has_warn = any(r.by_severity("warn") for r in reports)
+    if has_critical:
+        return 1
+    if args.strict and has_warn:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/clawhub-skill-lint/scripts/lint.py
+++ b/.claude/skills/clawhub-skill-lint/scripts/lint.py
@@ -62,7 +62,14 @@ CODE_EXT_RE = re.compile(r"\.(js|ts|mjs|cjs|mts|cts|jsx|tsx|py|sh|bash|zsh|rb|go
 MANIFEST_EXT_RE = re.compile(r"\.(json|yaml|yml|toml)$", re.I)
 
 RAW_IP_URL_RE = re.compile(r"https?://\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?(?:/|[\"'])", re.I)
-INSTALL_PACKAGE_RE = re.compile(r"installer-package\s*:\s*https?://[^\s\"'`]+", re.I)
+# Match both quoted and unquoted YAML/JSON forms:
+#   installer-package: https://example.com/x
+#   installer-package: "https://example.com/x"
+#   installer-package: 'https://example.com/x'
+INSTALL_PACKAGE_RE = re.compile(
+    r"installer-package\s*:\s*[\"']?https?://[^\s\"'`]+[\"']?",
+    re.I,
+)
 URL_SHORTENER_RE = re.compile(
     r"https?://(bit\.ly|tinyurl\.com|t\.co|goo\.gl|is\.gd)/", re.I
 )
@@ -315,8 +322,16 @@ def read_clawhubignore(skill_dir: Path) -> set[str]:
     return {ln.strip() for ln in f.read_text().splitlines() if ln.strip() and not ln.startswith("#")}
 
 
+SKILL_MD_NAMES = {"SKILL.md", "skill.md"}
+
+
 def iter_skill_files(skill_dir: Path) -> Iterable[Path]:
-    """Yield every file in the skill folder that would be included in the bundle."""
+    """Yield every file in the skill folder that would be included in the bundle.
+
+    SKILL.md is always yielded — even if a maintainer adds it to .clawhubignore
+    by mistake — because the publish would fail server-side without it. The
+    linter separately reports the bad ignore pattern via check_clawhubignore().
+    """
     ignore = read_clawhubignore(skill_dir)
     for p in skill_dir.rglob("*"):
         if not p.is_file():
@@ -324,9 +339,34 @@ def iter_skill_files(skill_dir: Path) -> Iterable[Path]:
         rel = p.relative_to(skill_dir)
         if any(part.startswith(".") and part not in (".clawhubignore", ".gitignore") for part in rel.parts):
             continue
+        # SKILL.md at the root is always included regardless of .clawhubignore.
+        if str(rel) in SKILL_MD_NAMES:
+            yield p
+            continue
         if rel.name in ignore:
             continue
         yield p
+
+
+def check_clawhubignore(report: SkillReport, skill_dir: Path) -> None:
+    """Report if .clawhubignore tries to exclude SKILL.md (which the publisher
+    would silently override but is still a maintenance bug worth flagging)."""
+    f = skill_dir / ".clawhubignore"
+    if not f.is_file():
+        return
+    for ln_no, raw in enumerate(f.read_text().splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line in SKILL_MD_NAMES:
+            report.add(Finding(
+                "bundle.skill_md_in_ignore", "critical",
+                ".clawhubignore", ln_no,
+                f"`.clawhubignore` lists `{line}`, which would exclude the required "
+                "SKILL.md from the published bundle. Remove this entry — SKILL.md "
+                "must always ship.",
+                evidence=raw,
+            ))
 
 
 # ============================================================================
@@ -398,8 +438,32 @@ def check_frontmatter(report: SkillReport, skill_dir: Path) -> dict | None:
             f"`{folder_slug}`. The folder name is used as the slug by default.",
         ))
 
-    # metadata.openclaw checks
-    oc = (fm.get("metadata") or {}).get("openclaw") or {}
+    # metadata.openclaw checks. Validate the shape of every nested level
+    # before calling .get() — a malformed manifest should produce a finding,
+    # not an AttributeError that aborts the linter.
+    metadata = fm.get("metadata")
+    if metadata is None:
+        oc: dict = {}
+    elif not isinstance(metadata, dict):
+        report.add(Finding(
+            "frontmatter.invalid_metadata", "critical",
+            "SKILL.md", 1,
+            f"`metadata` must be a mapping, got {type(metadata).__name__}.",
+        ))
+        oc = {}
+    else:
+        openclaw = metadata.get("openclaw")
+        if openclaw is None:
+            oc = {}
+        elif not isinstance(openclaw, dict):
+            report.add(Finding(
+                "frontmatter.invalid_openclaw", "critical",
+                "SKILL.md", 1,
+                f"`metadata.openclaw` must be a mapping, got {type(openclaw).__name__}.",
+            ))
+            oc = {}
+        else:
+            oc = openclaw
 
     # os
     os_field = oc.get("os")
@@ -420,22 +484,51 @@ def check_frontmatter(report: SkillReport, skill_dir: Path) -> dict | None:
                     ))
 
     # install kinds
-    install = oc.get("install") or []
-    if isinstance(install, list):
-        for entry in install:
-            if isinstance(entry, dict) and "kind" in entry:
-                if entry["kind"] not in ALLOWED_INSTALL_KINDS:
-                    report.add(Finding(
-                        "frontmatter.invalid_install_kind", "critical",
-                        "SKILL.md", 1,
-                        f"install kind `{entry['kind']}` is not in the allowed set "
-                        f"{sorted(ALLOWED_INSTALL_KINDS)}. The skill format spec only "
-                        f"supports these kinds; everything else is ignored.",
-                    ))
+    install = oc.get("install")
+    if install is not None:
+        if not isinstance(install, list):
+            report.add(Finding(
+                "frontmatter.invalid_install", "critical",
+                "SKILL.md", 1,
+                f"`metadata.openclaw.install` must be a list, got {type(install).__name__}.",
+            ))
+        else:
+            for entry in install:
+                if isinstance(entry, dict) and "kind" in entry:
+                    if entry["kind"] not in ALLOWED_INSTALL_KINDS:
+                        report.add(Finding(
+                            "frontmatter.invalid_install_kind", "critical",
+                            "SKILL.md", 1,
+                            f"install kind `{entry['kind']}` is not in the allowed set "
+                            f"{sorted(ALLOWED_INSTALL_KINDS)}. The skill format spec only "
+                            f"supports these kinds; everything else is ignored.",
+                        ))
 
     # primaryEnv must be in requires.env if both are set
     primary = oc.get("primaryEnv")
-    requires_env = (oc.get("requires") or {}).get("env") or []
+    requires = oc.get("requires")
+    if requires is not None and not isinstance(requires, dict):
+        report.add(Finding(
+            "frontmatter.invalid_requires", "critical",
+            "SKILL.md", 1,
+            f"`metadata.openclaw.requires` must be a mapping, got {type(requires).__name__}.",
+        ))
+        requires_env: list = []
+    elif requires is None:
+        requires_env = []
+    else:
+        re_env = requires.get("env")
+        if re_env is None:
+            requires_env = []
+        elif not isinstance(re_env, list):
+            report.add(Finding(
+                "frontmatter.invalid_requires_env", "critical",
+                "SKILL.md", 1,
+                f"`metadata.openclaw.requires.env` must be a list, got {type(re_env).__name__}.",
+            ))
+            requires_env = []
+        else:
+            requires_env = re_env
     if primary and requires_env and primary not in requires_env:
         report.add(Finding(
             "frontmatter.primary_env_not_in_requires", "warn",
@@ -653,6 +746,7 @@ def lint_skill(skill_dir: Path) -> SkillReport:
     report = SkillReport(slug=skill_dir.name, path=str(skill_dir))
     fm = check_frontmatter(report, skill_dir)
     check_bundle(report, skill_dir)
+    check_clawhubignore(report, skill_dir)
 
     for p in iter_skill_files(skill_dir):
         rel = str(p.relative_to(skill_dir))

--- a/claws/README.md
+++ b/claws/README.md
@@ -1,0 +1,23 @@
+# Claws
+
+Skills, plugins, and extensions that `ox` publishes to third-party "Claw"
+runtimes. Each subdirectory targets one runtime and contains the artifacts
+that runtime consumes.
+
+| Claw | Directory | What it contains |
+|---|---|---|
+| [OpenClaw](https://openclaw.ai) | [`openclaw/`](openclaw/) | Skills published to [ClawHub](https://clawhub.ai) |
+
+## Adding a new claw
+
+1. Create a `claws/<claw-name>/` subdirectory.
+2. Add a `README.md` explaining the runtime and linking to its docs.
+3. Add a `PUBLISHING.md` documenting how artifacts in this directory get
+   released to the claw's registry (commands, auth, state maintained in
+   this repo).
+4. Add one subdirectory per artifact (skill, plugin, extension).
+5. Update the table above.
+
+Each claw directory is self-contained — its layout, naming, and publish
+workflow follow the conventions of its target runtime, not `ox`'s own
+release pipeline.

--- a/claws/openclaw/PUBLISHING.md
+++ b/claws/openclaw/PUBLISHING.md
@@ -102,8 +102,12 @@ Only text-based files. Server-side limits:
   TOML, JS, TS, SVG, plus anything with a `text/*` MIME type)
 
 Each skill folder's `.clawhubignore` excludes `README.md` and any other
-repo-facing files that shouldn't ship to consumers. The `SKILL.md` itself
-is always included.
+repo-facing files that shouldn't ship to consumers.
+
+**Do not add `SKILL.md` to `.clawhubignore`.** The publish would fail
+server-side without it. The local linter (`clawhub-skill-lint`) will
+flag any `.clawhubignore` entry that lists `SKILL.md` as a critical
+finding before the bad bundle ever leaves your machine.
 
 ## Troubleshooting
 

--- a/claws/openclaw/PUBLISHING.md
+++ b/claws/openclaw/PUBLISHING.md
@@ -1,0 +1,121 @@
+# Publishing OpenClaw skills to ClawHub
+
+This directory's skills are published to [ClawHub](https://clawhub.ai) via
+the `clawhub` CLI. This doc is the operator runbook.
+
+## One-time setup
+
+Install the `clawhub` CLI (see
+[openclaw/clawhub](https://github.com/openclaw/clawhub)), then authenticate:
+
+```bash
+clawhub login                     # browser flow
+# or for headless / CI:
+clawhub login --token clh_xxx
+clawhub whoami                    # verify
+```
+
+The token is stored in `~/Library/Application Support/clawhub/config.json`
+on macOS; override via `CLAWHUB_CONFIG_PATH`.
+
+**GitHub requirement:** your GitHub account must be at least one week old
+to publish.
+
+## State maintained in this repo
+
+| Where | What | Who updates |
+|---|---|---|
+| `<skill>/SKILL.md` → `version:` | Source of truth for the next publish | Manually, or auto-bumped by `clawhub sync --bump` |
+| `<skill>/.clawhubignore` | Files to exclude from the published bundle | Manually |
+
+**Not in this repo:**
+
+- Auth tokens — `clawhub login` writes them to the user's config dir.
+- `.clawhub/lock.json` — that's *consumer-side install state*, not
+  publisher state. Do not commit it.
+- `.clawhub/origin.json` — same.
+
+## Publishing workflow
+
+### Preview (dry run)
+
+Always do this first — it shows the plan without uploading anything.
+
+```bash
+clawhub sync --root claws/openclaw --dry-run
+```
+
+### Publish all changed skills
+
+```bash
+clawhub sync --root claws/openclaw --all \
+  --bump patch \
+  --changelog "Describe the change for this release"
+```
+
+`sync` computes a fingerprint from each skill's local files and only
+publishes the ones that changed since the last known version on the
+registry. `--all` skips the interactive confirmation for each skill.
+
+### Publish a single skill explicitly
+
+```bash
+clawhub skill publish claws/openclaw/sageox-distill \
+  --version 0.2.0 \
+  --tags latest \
+  --changelog "Describe the change"
+```
+
+Use this when you need exact control over the version (e.g., a minor or
+major bump rather than the default patch).
+
+## Versioning rules
+
+All skills follow semver. The rules match how [`ox` itself is versioned](../../CLAUDE.md#versioning),
+scoped per skill:
+
+| Bump | When |
+|---|---|
+| patch | Prose tweaks, prereq fixes, new platform support that doesn't change the contract |
+| minor | New user-visible behavior (new commands the skill runs, new memory keys, new config fields) |
+| major | Breaking changes to the `~/.openclaw/.env` contract, memory file schema, or skill invocation model |
+
+The first publish of each skill is `0.1.0`.
+
+## Slug reservation
+
+Slugs are global on ClawHub (`^[a-z0-9][a-z0-9-]*$`). This repo owns:
+
+- `sageox-distill`
+- `sageox-summary`
+
+Derived automatically from the skill folder name. Once claimed, renames
+are possible via `clawhub skill rename <old> <new>` (the old slug becomes
+a redirect).
+
+## What gets uploaded
+
+Only text-based files. Server-side limits:
+
+- Bundle ≤ 50 MB
+- Each file must be in the text-file allowlist (Markdown, JSON, YAML,
+  TOML, JS, TS, SVG, plus anything with a `text/*` MIME type)
+
+Each skill folder's `.clawhubignore` excludes `README.md` and any other
+repo-facing files that shouldn't ship to consumers. The `SKILL.md` itself
+is always included.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `account too new` | GitHub account < 1 week old; wait it out. |
+| `metadata mismatch` warning | The skill references an env var or binary not declared under `requires.env` / `requires.bins`. Fix the frontmatter. |
+| `bundle too large` | Something got included it shouldn't have. Add it to `.clawhubignore`. |
+| `fingerprint matches existing version` | Nothing changed since the last publish. Either make a real change or manually bump `version:` in `SKILL.md`. |
+
+## References
+
+- [ClawHub skill format](https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md)
+- [ClawHub CLI reference](https://github.com/openclaw/clawhub/blob/main/docs/cli.md)
+- [ClawHub quickstart](https://github.com/openclaw/clawhub/blob/main/docs/quickstart.md)

--- a/claws/openclaw/README.md
+++ b/claws/openclaw/README.md
@@ -1,0 +1,175 @@
+# OpenClaw skills
+
+Skills in this directory are published from the `ox` repo to
+[ClawHub](https://clawhub.ai), the public skill registry for
+[OpenClaw](https://openclaw.ai).
+
+## Skills
+
+| Slug | Emoji | What it does |
+|---|---|---|
+| [`sageox-distill`](sageox-distill/) | 🔬 | Sync team contexts, index GitHub activity, and run `ox distill` across multiple SageOx repos. |
+| [`sageox-summary`](sageox-summary/) | 📰 | Generate a Slack-ready cross-team summary of the last 24 hours from distilled daily files. |
+
+The two skills pair: **distill** writes the source material, **summary**
+synthesizes it. You can use either independently, but using both gives you
+an end-to-end pipeline from raw repo activity → daily team digests → a
+unified cross-team readout.
+
+## Install (consumers)
+
+```bash
+clawhub install sageox-distill
+clawhub install sageox-summary
+```
+
+Both skills run in OpenClaw and require a one-time setup of
+`~/.openclaw/.env` — see [Environment setup](#environment-setup) below.
+
+## Environment setup
+
+Both skills declare `ANTHROPIC_API_KEY` in their `requires.env` and
+`primaryEnv`. OpenClaw can supply that key to each skill in two ways —
+pick whichever matches your setup.
+
+### Anthropic API key
+
+#### Recommended: per-skill config in `~/.openclaw/openclaw.json`
+
+This lets you use a **different** Anthropic key for SageOx skills than for
+your host agent (different account, different rate limits, different
+billing). OpenClaw injects the key into the skill's process environment for
+the duration of the run, then reverts it.
+
+```json5
+{
+  skills: {
+    entries: {
+      "sageox-distill": {
+        apiKey: "sk-ant-..."
+      },
+      "sageox-summary": {
+        apiKey: "sk-ant-..."
+      }
+    }
+  }
+}
+```
+
+If you don't want to keep the key in plaintext JSON, use a SecretRef
+instead and store the actual value in your shell or `~/.openclaw/.env`:
+
+```json5
+{
+  skills: {
+    entries: {
+      "sageox-distill": {
+        apiKey: { source: "env", provider: "default", id: "MY_SAGEOX_KEY" }
+      }
+    }
+  }
+}
+```
+
+```sh
+# in ~/.openclaw/.env or your shell rc
+MY_SAGEOX_KEY=sk-ant-...
+```
+
+See [`docs.openclaw.ai/tools/skills-config`](https://docs.openclaw.ai/tools/skills-config)
+for the full schema.
+
+#### ⚠️ Critical precedence rule
+
+OpenClaw injects the per-skill `apiKey` **only if `ANTHROPIC_API_KEY` is
+not already set in its process environment** (see `env-overrides.ts` in
+the openclaw repo). If your login shell exports `ANTHROPIC_API_KEY` (e.g.,
+from `~/.zshrc`), the host value passes through to the skill and **the
+per-skill `apiKey` is silently ignored.**
+
+To use Option A (separate keys), verify before launching OpenClaw:
+
+```sh
+env | grep ANTHROPIC_API_KEY    # should print nothing
+```
+
+If it prints a value, find where it's exported (`~/.zshrc`, `~/.bashrc`,
+`~/.profile`, your terminal app's env settings) and remove it.
+
+#### Fallback: shared shell env
+
+If you're fine with your host agent and SageOx skills sharing one
+Anthropic key, you can skip the per-skill config entirely and just have
+`ANTHROPIC_API_KEY` set in your shell or `~/.openclaw/.env`:
+
+```sh
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+The skills pick it up either way.
+
+#### Sandboxed runs (Docker)
+
+Per-skill `apiKey` does **not** apply when OpenClaw runs skills inside a
+sandbox — `process.env` is not inherited into the container. For sandboxed
+sessions, configure the key under `agents.defaults.sandbox.docker.env`
+(or per-agent `agents.list[].sandbox.docker.env`) instead:
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        docker: {
+          env: { ANTHROPIC_API_KEY: "sk-ant-..." }
+        }
+      }
+    }
+  }
+}
+```
+
+### PATH (required if you installed `ox` from git)
+
+If you chose the **git clone + build** option for `ox` (see the install
+flow in each skill's `SKILL.md`), you must add a `PATH=` line that
+includes both the Go toolchain and Go's install-output directory.
+
+Absolute paths only — `.env` files do not reliably expand `$PATH`.
+
+```sh
+# macOS (Homebrew Go):
+PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/Users/you/go/bin
+
+# macOS (Go from go.dev):
+# PATH=/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin:/Users/you/go/bin
+
+# Linux (apt golang-go):
+# PATH=/usr/lib/go-1.24/bin:/usr/local/bin:/usr/bin:/bin:/home/you/go/bin
+
+# Linux (Go from go.dev):
+# PATH=/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin:/home/you/go/bin
+```
+
+To find your paths:
+
+```sh
+which go              # Go toolchain dir (parent of the go binary)
+go env GOBIN          # Go install-output dir; fallback: $HOME/go/bin
+```
+
+If you chose the **curl install** option for `ox`, you do **not** need a
+PATH line — `ox` installs to `/usr/local/bin` (Linux) or
+`/opt/homebrew/bin` / `/usr/local/bin` (macOS), which are normally on PATH
+already.
+
+## Publishing (maintainers)
+
+See [PUBLISHING.md](PUBLISHING.md).
+
+## Links
+
+- [OpenClaw docs](https://docs.openclaw.ai)
+- [ClawHub](https://clawhub.ai)
+- [SageOx](https://sageox.ai)
+- [`ox` repo](https://github.com/sageox/ox)

--- a/claws/openclaw/sageox-distill/.clawhubignore
+++ b/claws/openclaw/sageox-distill/.clawhubignore
@@ -1,0 +1,2 @@
+README.md
+CHANGELOG.md

--- a/claws/openclaw/sageox-distill/README.md
+++ b/claws/openclaw/sageox-distill/README.md
@@ -1,0 +1,78 @@
+# sageox-distill
+
+🔬 **Sync, index, and distill team activity across SageOx-enabled repositories.**
+
+`sageox-distill` keeps a team's SageOx knowledge base current. Given a list
+of repos, it groups them by team, syncs each team's context, indexes recent
+GitHub PRs and issues, and runs `ox distill` to produce daily summary files
+that capture what the team built and decided in the last day.
+
+Pairs with [`sageox-summary`](../sageox-summary/) — distill writes the daily
+source files; summary synthesizes them into a Slack-ready cross-team digest.
+You can use either independently, but together they form a complete pipeline
+from raw repo activity → daily team digests → unified readout.
+
+## Install
+
+```bash
+clawhub install sageox-distill
+```
+
+Then complete the one-time environment setup in
+[`claws/openclaw/README.md` § Environment setup](../README.md#environment-setup) —
+specifically:
+
+- Configure `ANTHROPIC_API_KEY` for the skill via either per-skill
+  `apiKey` in `~/.openclaw/openclaw.json` (recommended; lets you use a
+  separate key from your host agent) or via shell env. **Mind the
+  precedence rule** documented in the link above.
+- (If you choose to build `ox` from git source) extend `PATH` in
+  `~/.openclaw/.env` so the skill subprocess can find `go` and the built
+  `ox` binary
+
+## Use
+
+Once installed, ask your OpenClaw agent things like:
+
+- "Distill all my SageOx repos."
+- "Add `~/src/sageox/ox` to the distill manifest."
+- "Schedule distillation every 4 hours."
+- "Show me the distill repos."
+- "Switch ox install method." (re-runs the curl-vs-git setup)
+- "Update ox now." (forces a git pull + rebuild on the git install path)
+
+## What it does
+
+1. **Loads the repo manifest** from `~/.openclaw/memory/sageox-distill-repos.json`
+   (or builds it interactively on first run).
+2. **Syncs each team's context** via `ox sync --all-teams`.
+3. **Indexes GitHub activity** for each repo via `ox index github`.
+4. **Waits for the SageOx daemon** to finish processing.
+5. **Distills each team** via `ox distill --sync --layer daily`.
+
+`ox distill` reads `ANTHROPIC_API_KEY` from its process environment.
+OpenClaw can supply that key per-skill (recommended, via the `apiKey`
+field in `~/.openclaw/openclaw.json`) or you can use a shell-level
+`ANTHROPIC_API_KEY` shared with your host agent. See
+[Environment setup](../README.md#environment-setup) for details and the
+critical precedence rule.
+
+## Requirements
+
+- OS: macOS or Linux
+- Binaries: `ox`, `git`, `gh`
+- Env: `ANTHROPIC_API_KEY` (supplied via per-skill `apiKey` config or
+  shell env — see [Environment setup](../README.md#environment-setup))
+- A SageOx account (sign up at <https://sageox.ai>)
+- A GitHub account with `gh` authenticated
+
+The skill will walk you through installing any missing pieces on first
+run, including an interactive choice for how to install `ox` itself
+(curl-pinned-release or git-clone-and-build).
+
+## Links
+
+- **Repo:** <https://github.com/sageox/ox>
+- **SageOx:** <https://sageox.ai>
+- **Pair skill:** [`sageox-summary`](../sageox-summary/)
+- **Publishing this skill:** [`../PUBLISHING.md`](../PUBLISHING.md)

--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -137,6 +137,35 @@ next section.
 
 After install, the user runs `gh auth login` once.
 
+#### Path validation rules
+
+Several steps below ask the user for a path (repo path, clone path) or
+read a path from a JSON state file. Before interpolating any such value
+into a shell command, the agent **must** validate it against these rules:
+
+1. **Absolute path required.** Must start with `/` or `~`. Reject relative
+   paths and bare names.
+2. **No `..` segments.** Reject anything containing `..`.
+3. **No shell metacharacters.** Reject anything containing any of these
+   characters: `;` `$` `` ` `` `|` `&` `<` `>` `(` `)` `{` `}` `*` `?`
+   `[` `]` `!` `\` newline.
+4. **For clone paths used by the auto-update flow** (see Option 2 below),
+   apply two additional checks:
+   - Must be **under `$HOME`**. Reject `/tmp`, `/var/tmp`, `/dev/shm`,
+     `/private/tmp`, network mounts, and any other location not owned by
+     the current user.
+   - The path must already exist as a directory and contain a `.git`
+     subdirectory before any `git pull` / `make install` runs.
+
+On any validation failure: print a clear error to the user explaining
+which rule failed and ask them to provide a different path. **Do not
+attempt to "fix up" or sanitize the input** — reject and re-prompt.
+
+Treat values read from `~/.openclaw/memory/*.json` files as untrusted
+even though this skill writes them: the user (or a process running as
+the user) may have edited the file by hand or by another tool between
+runs. Re-validate every read.
+
 #### Installing `ox` — interactive setup
 
 The `ox` CLI install method is a one-time choice stored in
@@ -171,7 +200,8 @@ so the user can sanity-check what is about to run:
 ```bash
 # Download to a temp file. -f makes curl fail on HTTP errors instead of
 # executing an HTML error page; --max-time bounds a stalled connection.
-INSTALL_SCRIPT="$(mktemp -t ox-install.XXXXXX.sh)"
+# Use the template form for mktemp — portable across GNU (Linux) and BSD (macOS).
+INSTALL_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
 curl -fsSL --max-time 60 \
   https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh \
   -o "$INSTALL_SCRIPT"
@@ -226,6 +256,18 @@ check their shell PATH.
    - **Linux (Arch):** `sudo pacman -S --noconfirm go`
 
 2. Ask the user for a clone path. Default: `$HOME/src/sageox/ox`.
+   **Validate** the input against the Path validation rules above,
+   including the additional rule that the path must be under `$HOME`.
+   Re-prompt on failure.
+
+   ⚠️ **The clone path becomes a privileged location.** If auto-update is
+   enabled, this skill will run `make build && make install` from it on
+   every invocation. Anyone with write access to the clone path can run
+   arbitrary code in the user's environment. Strongly recommend a
+   personal directory under `$HOME` (the default `$HOME/src/sageox/ox`
+   is a good choice). Refuse anything in `/tmp`, `/var/tmp`, `/dev/shm`,
+   shared filesystems, or world-writable directories — these checks are
+   already part of the validation rules; do not bypass them.
 
 3. Ask the user whether to auto-update from git on every run (yes/no).
    Default: yes.
@@ -287,18 +329,27 @@ check their shell PATH.
 ##### Updating `ox` from git (auto-update flow)
 
 On every subsequent run, if the memory file says
-`install_method == "git"` and `auto_update == true`, pull and rebuild
-before running the rest of the skill:
+`install_method == "git"` and `auto_update == true`:
 
-```bash
-CLONE_PATH="$(jq -r .clone_path ~/.openclaw/memory/sageox-ox-install.json)"
-(cd "$CLONE_PATH" && git pull --ff-only && make build && make install) || {
-  echo "ox auto-update failed; continuing with existing binary" >&2
-}
-```
+1. Read `clone_path` from `~/.openclaw/memory/sageox-ox-install.json`.
+2. **Re-validate** it against the Path validation rules in Prerequisites
+   § 4, including the additional clone-path checks (must be under
+   `$HOME`, must exist, must contain a `.git` subdirectory). The memory
+   file is user-writable and may have been edited externally between
+   runs — never trust persisted values without re-validation.
+3. **If validation fails**, log a clear error naming the failing rule,
+   skip the auto-update entirely, and fall back to the existing `ox`
+   binary on PATH. Do not proceed with `cd` / `git pull` / `make install`.
+4. If validation passes, run:
 
-Auto-update failures are non-fatal — fall back to the existing binary and
-surface the error to the user.
+   ```bash
+   (cd "$CLONE_PATH" && git pull --ff-only && make build && make install) || {
+     echo "ox auto-update failed; continuing with existing binary" >&2
+   }
+   ```
+
+Auto-update failures (validation or build) are non-fatal — fall back to
+the existing binary and surface the error to the user.
 
 The user can say **"switch ox install method"** or **"update ox now"** at
 any time to re-run the interactive flow.
@@ -333,11 +384,21 @@ The manifest format is:
   before proceeding.
 - If the manifest does not exist, ask the user which repos to include. For
   each repo path provided:
-  1. Verify the directory exists
-  2. Verify `.sageox/config.json` exists (confirms `ox init` was run)
-  3. Read `team_id` from `.sageox/config.json`
-  4. If `.sageox/config.json` is missing, ask if the user wants to run
-     `ox init` in that repo
+  1. **Validate the path against the Path validation rules in
+     Prerequisites § 4.** Reject and re-prompt on failure.
+  2. Verify the directory exists.
+  3. Verify `.sageox/config.json` exists (confirms `ox init` was run).
+  4. Read `team_id` from `.sageox/config.json`. **Treat the value as
+     untrusted** — do not interpolate it into shell commands. If you
+     need to use it as an argument, pass it as a separate argv element
+     (not via string concatenation) and refuse values containing shell
+     metacharacters.
+  5. If `.sageox/config.json` is missing, ask if the user wants to run
+     `ox init` in that repo.
+
+- When loading an existing manifest, **re-validate every repo path** in
+  it against the Path validation rules. The manifest file is
+  user-writable and may have been edited externally between runs.
 - Write the manifest after collecting all repos.
 - The user can say "add repo", "remove repo", or "show repos" at any
   time to manage the manifest.

--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -1,0 +1,431 @@
+---
+name: sageox-distill
+description: "Sync, index, and distill team activity across SageOx-enabled repositories. Keeps your team's knowledge base up to date by syncing repo contexts, indexing GitHub PRs/issues, and running the SageOx distillation pipeline."
+version: 0.1.0
+metadata:
+  openclaw:
+    emoji: "🔬"
+    os: ["macos", "linux"]
+    primaryEnv: ANTHROPIC_API_KEY
+    requires:
+      env:
+        - ANTHROPIC_API_KEY
+      bins:
+        - ox
+        - git
+        - gh
+    install:
+      - kind: brew
+        formula: gh
+        bins: [gh]
+    homepage: https://sageox.ai
+---
+
+# SageOx Distill
+
+You are an agent that keeps a team's SageOx knowledge base current by syncing
+repo contexts, indexing GitHub activity, and running the distillation pipeline.
+
+Pairs with the [`sageox-summary`](https://clawhub.ai/skills/sageox-summary)
+skill — distill writes the daily source files that summary synthesizes.
+
+## Prerequisites
+
+Before doing anything else, verify the user's environment. Run every check in
+order. If any required check fails, explain precisely what's missing and stop.
+Do not proceed until the user has fixed it.
+
+### 1. Environment variables
+
+Verify `ANTHROPIC_API_KEY` is set and non-empty in the skill's process
+environment:
+
+```bash
+test -n "$ANTHROPIC_API_KEY"
+```
+
+This skill declares `ANTHROPIC_API_KEY` in `requires.env` and `primaryEnv`,
+which means OpenClaw will inject it from per-skill config when configured.
+Never echo the key value — only confirm its presence.
+
+If the var is missing, tell the user one of the following options:
+
+**Option A — Per-skill config in `~/.openclaw/openclaw.json` (recommended).**
+Lets the user use a different Anthropic key for this skill than for their
+host agent:
+
+```json5
+{
+  skills: {
+    entries: {
+      "sageox-distill": {
+        apiKey: "sk-ant-..."
+        // or with a SecretRef:
+        // apiKey: { source: "env", provider: "default", id: "MY_SAGEOX_KEY" }
+      }
+    }
+  }
+}
+```
+
+OpenClaw injects this as `ANTHROPIC_API_KEY` into the skill's process
+environment for the duration of the run, then reverts it. Subprocesses
+spawned by the skill (`ox distill`, etc.) inherit it naturally.
+
+**Option B — Shell env / `~/.openclaw/.env`.** If the user is fine with the
+host agent and this skill sharing one Anthropic key, just export
+`ANTHROPIC_API_KEY` from the shell or add it to `~/.openclaw/.env`:
+
+```sh
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**⚠️ Critical precedence rule:** OpenClaw injects the per-skill `apiKey`
+**only if `ANTHROPIC_API_KEY` is not already set** in its process
+environment. If the user's login shell exports it (e.g., from `~/.zshrc`),
+the host value passes through and the per-skill key is silently ignored.
+To verify before launching OpenClaw: `env | grep ANTHROPIC_API_KEY` should
+print nothing if Option A is in use.
+
+**Sandboxed runs (Docker).** Per-skill `apiKey` does NOT apply inside the
+sandbox — `process.env` is not inherited. For sandboxed sessions, configure
+`agents.defaults.sandbox.docker.env.ANTHROPIC_API_KEY` instead.
+
+### 2. Detect the operating system
+
+```bash
+uname -s
+```
+
+- `Darwin` → macOS
+- `Linux` → Linux
+
+Use the detected OS to choose install commands for any missing tools below.
+
+### 3. Required binaries
+
+Check each required binary is on the skill subprocess PATH:
+
+```bash
+command -v git
+command -v gh
+command -v ox
+```
+
+If any are missing, install them using the OS-appropriate commands in the
+next section.
+
+### 4. Installing missing tools
+
+#### Installing `git`
+
+- **macOS:** `brew install git` (Homebrew) or use the Xcode Command Line
+  Tools: `xcode-select --install`
+- **Linux (Debian/Ubuntu):** `sudo apt-get update && sudo apt-get install -y git`
+- **Linux (Fedora/RHEL):** `sudo dnf install -y git`
+- **Linux (Arch):** `sudo pacman -S --noconfirm git`
+- **Linux (Alpine):** `sudo apk add git`
+
+#### Installing `gh` (GitHub CLI)
+
+- **macOS:** `brew install gh`
+- **Linux (Debian/Ubuntu):** follow the apt instructions at
+  <https://github.com/cli/cli/blob/trunk/docs/install_linux.md>
+- **Linux (Fedora/RHEL):** `sudo dnf install -y gh`
+- **Linux (Arch):** `sudo pacman -S --noconfirm github-cli`
+- **Linux (Alpine):** `sudo apk add github-cli`
+
+After install, the user runs `gh auth login` once.
+
+#### Installing `ox` — interactive setup
+
+The `ox` CLI install method is a one-time choice stored in
+`~/.openclaw/memory/sageox-ox-install.json`. Check that file first:
+
+```bash
+cat ~/.openclaw/memory/sageox-ox-install.json 2>/dev/null
+```
+
+**If the file exists:** read `install_method` and (for the git method)
+`clone_path` + `auto_update`. If `install_method == "git"` and
+`auto_update == true`, update ox before proceeding (see "Updating ox from
+git" below).
+
+**If the file does not exist:** prompt the user to choose an install method:
+
+> How do you want to install the `ox` CLI?
+>
+> 1. **curl install** (recommended) — downloads the latest release tarball
+>    and installs the pinned binary. Fastest, no build toolchain needed.
+> 2. **Build from git source** — clones `github.com/sageox/ox` and builds
+>    with `make install`. Gives you latest `main`. Requires Go ≥ 1.24.
+
+Ask the user to pick 1 or 2. Save the choice to the memory file.
+
+##### Option 1: curl install
+
+Run the ox install script:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh | bash
+```
+
+After it completes, verify `command -v ox` succeeds. Then persist:
+
+```bash
+mkdir -p ~/.openclaw/memory
+cat > ~/.openclaw/memory/sageox-ox-install.json <<EOF
+{
+  "install_method": "curl",
+  "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+```
+
+`ox` lands in a standard system dir (`/usr/local/bin` on Linux,
+`/opt/homebrew/bin` or `/usr/local/bin` on macOS) that is normally already
+on PATH. If `command -v ox` still fails after install, ask the user to
+check their shell PATH.
+
+##### Option 2: build from git source
+
+1. Verify Go ≥ 1.24 is installed:
+
+   ```bash
+   command -v go && go version
+   ```
+
+   If missing, print OS-appropriate install commands and stop until the
+   user installs Go:
+
+   - **macOS:** `brew install go` or download from <https://go.dev/dl/>
+   - **Linux (Debian/Ubuntu):** `sudo apt-get install -y golang-go`
+     (verify the version; use <https://go.dev/dl/> if the distro package
+     is older than 1.24)
+   - **Linux (Fedora/RHEL):** `sudo dnf install -y golang`
+   - **Linux (Arch):** `sudo pacman -S --noconfirm go`
+
+2. Ask the user for a clone path. Default: `$HOME/src/sageox/ox`.
+
+3. Ask the user whether to auto-update from git on every run (yes/no).
+   Default: yes.
+
+4. Clone and build:
+
+   ```bash
+   CLONE_PATH="<user-chosen path>"
+   mkdir -p "$(dirname "$CLONE_PATH")"
+   if [ ! -d "$CLONE_PATH/.git" ]; then
+     git clone https://github.com/sageox/ox.git "$CLONE_PATH"
+   fi
+   (cd "$CLONE_PATH" && make build && make install)
+   ```
+
+5. Detect Go's paths so the user can configure PATH in `~/.openclaw/.env`:
+
+   ```bash
+   GO_BIN_DIR="$(dirname "$(command -v go)")"
+   GO_INSTALL_DIR="$(go env GOBIN)"
+   [ -z "$GO_INSTALL_DIR" ] && GO_INSTALL_DIR="$HOME/go/bin"
+   ```
+
+6. Persist the memory file:
+
+   ```bash
+   mkdir -p ~/.openclaw/memory
+   cat > ~/.openclaw/memory/sageox-ox-install.json <<EOF
+   {
+     "install_method": "git",
+     "clone_path": "$CLONE_PATH",
+     "auto_update": true,
+     "go_bin_dir": "$GO_BIN_DIR",
+     "go_install_dir": "$GO_INSTALL_DIR",
+     "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+   }
+   EOF
+   ```
+
+7. Verify `ox` is on the current subprocess PATH:
+
+   ```bash
+   command -v ox
+   ```
+
+   If it is **not** on PATH, print a copy-pasteable block tailored to the
+   user's detected paths and tell them to add it to `~/.openclaw/.env`:
+
+   ```
+   Add this to ~/.openclaw/.env:
+
+   PATH=<GO_BIN_DIR>:/usr/local/bin:/usr/bin:/bin:<GO_INSTALL_DIR>
+   ```
+
+   Stop and ask the user to confirm once they've updated `.env` and
+   restarted the skill. OpenClaw loads `.env` into the skill subprocess,
+   so an updated PATH takes effect on the next invocation.
+
+##### Updating `ox` from git (auto-update flow)
+
+On every subsequent run, if the memory file says
+`install_method == "git"` and `auto_update == true`, pull and rebuild
+before running the rest of the skill:
+
+```bash
+CLONE_PATH="$(jq -r .clone_path ~/.openclaw/memory/sageox-ox-install.json)"
+(cd "$CLONE_PATH" && git pull --ff-only && make build && make install) || {
+  echo "ox auto-update failed; continuing with existing binary" >&2
+}
+```
+
+Auto-update failures are non-fatal — fall back to the existing binary and
+surface the error to the user.
+
+The user can say **"switch ox install method"** or **"update ox now"** at
+any time to re-run the interactive flow.
+
+### 5. Authentication and git config
+
+After all binaries are present, verify credentials:
+
+1. `ox status` — confirm ox is authenticated. If not, tell the user to
+   run `ox login` and try again.
+2. `gh auth status` — confirm GitHub credentials are available.
+3. `git config user.name` — confirm git identity is set.
+
+Do not proceed until all three pass.
+
+## Repo Manifest
+
+The list of repos to distill is stored in
+`~/.openclaw/memory/sageox-distill-repos.json`.
+
+The manifest format is:
+
+```json
+{
+  "repos": [
+    { "path": "/home/user/repos/my-project", "team_id": "my-team" }
+  ]
+}
+```
+
+- If the manifest exists, read it and confirm the repos with the user
+  before proceeding.
+- If the manifest does not exist, ask the user which repos to include. For
+  each repo path provided:
+  1. Verify the directory exists
+  2. Verify `.sageox/config.json` exists (confirms `ox init` was run)
+  3. Read `team_id` from `.sageox/config.json`
+  4. If `.sageox/config.json` is missing, ask if the user wants to run
+     `ox init` in that repo
+- Write the manifest after collecting all repos.
+- The user can say "add repo", "remove repo", or "show repos" at any
+  time to manage the manifest.
+
+## Distill Pipeline
+
+When the user asks to distill (or when triggered by a cron job), run the
+following phases in order.
+
+### Phase 1: Sync and Index
+
+Group repos by `team_id` from the manifest.
+
+For each team:
+
+1. **Sync team context** — run from the first repo in the team group:
+
+   ```bash
+   ox sync --all-teams
+   ```
+
+   This syncs all team contexts via the SageOx daemon.
+
+2. **Index GitHub activity** — run for EACH repo in the team group:
+
+   ```bash
+   ox index github
+   ```
+
+   This indexes PRs, issues, and comments for the specific repo.
+
+Both commands are non-fatal. If one fails, log the error and continue
+with the next repo or team. Do not abort the pipeline.
+
+Neither of these commands needs `ANTHROPIC_API_KEY` — ox uses its own
+auth token for SageOx API calls. Do not set it in their environment.
+
+### Phase 2: Wait for Daemon Sync
+
+After all sync and index commands have been issued, the SageOx daemon
+processes them asynchronously. Before distilling, verify that processing
+is complete.
+
+For each repo in the manifest:
+
+1. Run `ox daemon status` in the repo directory
+2. Check the output for sync/index completion status
+3. If the daemon reports it is still processing:
+   - Wait 10 seconds
+   - Check again
+   - Repeat up to 30 times (5 minutes max)
+4. If after 30 attempts the daemon is still not finished:
+   - Report which repos are still pending
+   - Ask the user whether to proceed with distill anyway or abort
+5. If the daemon reports an error:
+   - Surface the full error message to the user
+   - Ask the user whether to proceed with distill anyway or abort
+
+### Phase 3: Distill
+
+For each unique team (grouped by `team_id`), run distill from the first
+repo in that team's group. `ANTHROPIC_API_KEY` is already set in the
+skill's process environment (either by OpenClaw's per-skill `apiKey`
+injection or inherited from the host shell — see Prerequisites § 1), so
+`ox distill` picks it up naturally:
+
+```bash
+ox distill --sync --layer daily --concurrency 3 --model sonnet
+```
+
+Report the output of each distill run to the user. Include the team ID
+and which repo was used as the working directory.
+
+If a distill fails, report the error and continue with the next team.
+Do not abort the pipeline for a single team failure.
+
+## Scheduling
+
+When the user asks to schedule distillation:
+
+1. Create a cron job that runs the full distill pipeline (phases 1-3) at
+   the requested frequency.
+2. Suggest a default of every 4 hours if the user doesn't specify.
+3. Confirm the schedule with the user before creating it.
+
+Common schedules:
+
+- Every 4 hours: `0 */4 * * *`
+- Three times daily (morning, midday, evening): `0 8,12,18 * * *`
+- Every 2 hours during work hours: `0 */2 9-17 * * 1-5`
+
+The cron job must source `~/.openclaw/.env` before running (cron has a
+minimal environment by default). A typical crontab line:
+
+```cron
+0 */4 * * * set -a; . $HOME/.openclaw/.env; set +a; openclaw run sageox-distill
+```
+
+Adjust the invocation to match however OpenClaw runs skills on the
+user's system.
+
+## Output
+
+After each distill run, provide a brief status summary:
+
+- How many teams were processed
+- How many repos were synced and indexed
+- Any errors or warnings encountered
+- Whether the daemon sync completed or timed out
+
+Keep the output concise. The user can ask for details if needed.

--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -164,10 +164,30 @@ Ask the user to pick 1 or 2. Save the choice to the memory file.
 
 ##### Option 1: curl install
 
-Run the ox install script:
+Download and run the ox install script. The agent should print the source
+URL and a head/tail preview of the downloaded script before executing it,
+so the user can sanity-check what is about to run:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh | bash
+# Download to a temp file. -f makes curl fail on HTTP errors instead of
+# executing an HTML error page; --max-time bounds a stalled connection.
+INSTALL_SCRIPT="$(mktemp -t ox-install.XXXXXX.sh)"
+curl -fsSL --max-time 60 \
+  https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh \
+  -o "$INSTALL_SCRIPT"
+
+# Surface what is about to run.
+echo "Downloaded ox install script:"
+echo "  Source: https://github.com/sageox/ox/blob/main/scripts/install.sh"
+ls -lh "$INSTALL_SCRIPT"
+echo "--- first 5 lines ---"
+head -5 "$INSTALL_SCRIPT"
+echo "--- last 5 lines ---"
+tail -5 "$INSTALL_SCRIPT"
+
+# Execute and clean up.
+bash "$INSTALL_SCRIPT"
+rm -f "$INSTALL_SCRIPT"
 ```
 
 After it completes, verify `command -v ox` succeeds. Then persist:

--- a/claws/openclaw/sageox-summary/.clawhubignore
+++ b/claws/openclaw/sageox-summary/.clawhubignore
@@ -1,0 +1,2 @@
+README.md
+CHANGELOG.md

--- a/claws/openclaw/sageox-summary/README.md
+++ b/claws/openclaw/sageox-summary/README.md
@@ -1,0 +1,84 @@
+# sageox-summary
+
+📰 **Generate a Slack-ready cross-team summary of the last 24 hours from SageOx distilled activity.**
+
+`sageox-summary` reads the daily summary files that `ox distill` produces
+for each team, feeds them to `claude -p`, and returns a structured
+Slack-formatted digest organized by what shipped, what's blocked, what
+the team learned, and what's next.
+
+Pairs with [`sageox-distill`](../sageox-distill/) — distill writes the
+daily source files; this skill synthesizes them. You can use either
+independently, but together they form a complete pipeline from raw repo
+activity → daily team digests → unified readout.
+
+## Install
+
+```bash
+clawhub install sageox-summary
+```
+
+Then complete the one-time environment setup in
+[`claws/openclaw/README.md` § Environment setup](../README.md#environment-setup) —
+specifically:
+
+- Configure `ANTHROPIC_API_KEY` for the skill via either per-skill
+  `apiKey` in `~/.openclaw/openclaw.json` (recommended; lets you use a
+  separate key from your host agent) or via shell env. **Mind the
+  precedence rule** documented in the link above.
+- (If you choose to build `ox` from git source) extend `PATH` in
+  `~/.openclaw/.env` so the skill subprocess can find `go` and the built
+  `ox` binary
+
+## Use
+
+Once installed, ask your OpenClaw agent things like:
+
+- "Give me the daily SageOx summary."
+- "Schedule a summary every morning at 9am."
+- "Switch ox install method." (re-runs the curl-vs-git setup)
+- "Update ox now." (forces a git pull + rebuild on the git install path)
+
+## What it does
+
+1. **Loads the repo manifest** from `~/.openclaw/memory/sageox-distill-repos.json`
+   (shared with [`sageox-distill`](../sageox-distill/)).
+2. **Computes the team context directories** from the SageOx endpoint
+   slug.
+3. **Builds a prompt** from `assets/SUMMARIZE.md`, substituting per-team
+   directories.
+4. **Runs `claude -p`** with read-only access to each team's context dir.
+   `ANTHROPIC_API_KEY` is supplied by OpenClaw's per-skill `apiKey`
+   injection (or by your shell, if configured that way) — see
+   [Environment setup](../README.md#environment-setup).
+5. **Returns the summary** — already formatted for Slack mrkdwn.
+
+The output is structured into four sections:
+
+- *Where we are* — progress relative to goals + what shipped
+- *What's getting in the way* — blockers, friction, unresolved issues
+- *What we've learned* — techniques, discoveries, decisions
+- *What's next* — queued work and follow-ups
+
+## Requirements
+
+- OS: macOS or Linux
+- Binaries: `ox`, `claude`, `jq`
+- Env: `ANTHROPIC_API_KEY` (supplied via per-skill `apiKey` config or
+  shell env — see [Environment setup](../README.md#environment-setup))
+- A SageOx account with at least one distilled team (run
+  [`sageox-distill`](../sageox-distill/) first)
+
+The skill will walk you through installing any missing pieces on first
+run, including an interactive choice for how to install `ox` itself
+(curl-pinned-release or git-clone-and-build).
+
+This skill does **not** require `claude login` — it provides an explicit
+API key on every invocation.
+
+## Links
+
+- **Repo:** <https://github.com/sageox/ox>
+- **SageOx:** <https://sageox.ai>
+- **Pair skill:** [`sageox-distill`](../sageox-distill/)
+- **Publishing this skill:** [`../PUBLISHING.md`](../PUBLISHING.md)

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -1,0 +1,479 @@
+---
+name: sageox-summary
+description: "Generate an overall team summary covering the last 24 hours across all SageOx-enabled teams. Reads distilled daily summary files from each team's context directory and produces a structured, Slack-ready overview."
+version: 0.1.0
+metadata:
+  openclaw:
+    emoji: "📰"
+    os: ["macos", "linux"]
+    primaryEnv: ANTHROPIC_API_KEY
+    requires:
+      env:
+        - ANTHROPIC_API_KEY
+      bins:
+        - ox
+        - claude
+        - jq
+    install:
+      - kind: node
+        package: "@anthropic-ai/claude-code"
+        bins: [claude]
+      - kind: brew
+        formula: jq
+        bins: [jq]
+    homepage: https://sageox.ai
+---
+
+# SageOx Summary
+
+You are an agent that generates a cross-team summary of the last 24 hours of
+SageOx distilled activity. You read the daily summary files that `ox distill`
+produces for each team, feed them to Claude via the `claude -p` CLI, and
+return a structured Slack-formatted summary.
+
+This skill pairs with the [`sageox-distill`](https://clawhub.ai/skills/sageox-distill)
+skill — distill writes the source material, this skill synthesizes it.
+
+## Prerequisites
+
+Before doing anything else, verify the user's environment. Run every check
+in order. If any required check fails, explain precisely what's missing
+and stop. Do not proceed until the user has fixed it.
+
+### 1. Environment variables
+
+Verify `ANTHROPIC_API_KEY` is set and non-empty in the skill's process
+environment:
+
+```bash
+test -n "$ANTHROPIC_API_KEY"
+```
+
+This skill declares `ANTHROPIC_API_KEY` in `requires.env` and `primaryEnv`,
+which means OpenClaw will inject it from per-skill config when configured.
+Never echo the key value — only confirm its presence.
+
+If the var is missing, tell the user one of the following options:
+
+**Option A — Per-skill config in `~/.openclaw/openclaw.json` (recommended).**
+Lets the user use a different Anthropic key for this skill than for their
+host agent:
+
+```json5
+{
+  skills: {
+    entries: {
+      "sageox-summary": {
+        apiKey: "sk-ant-..."
+        // or with a SecretRef:
+        // apiKey: { source: "env", provider: "default", id: "MY_SAGEOX_KEY" }
+      }
+    }
+  }
+}
+```
+
+OpenClaw injects this as `ANTHROPIC_API_KEY` into the skill's process
+environment for the duration of the run, then reverts it. Subprocesses
+spawned by the skill (`claude -p`, etc.) inherit it naturally.
+
+**Option B — Shell env / `~/.openclaw/.env`.** If the user is fine with the
+host agent and this skill sharing one Anthropic key, just export
+`ANTHROPIC_API_KEY` from the shell or add it to `~/.openclaw/.env`:
+
+```sh
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**⚠️ Critical precedence rule:** OpenClaw injects the per-skill `apiKey`
+**only if `ANTHROPIC_API_KEY` is not already set** in its process
+environment. If the user's login shell exports it (e.g., from `~/.zshrc`),
+the host value passes through and the per-skill key is silently ignored.
+To verify before launching OpenClaw: `env | grep ANTHROPIC_API_KEY` should
+print nothing if Option A is in use.
+
+**Sandboxed runs (Docker).** Per-skill `apiKey` does NOT apply inside the
+sandbox — `process.env` is not inherited. For sandboxed sessions, configure
+`agents.defaults.sandbox.docker.env.ANTHROPIC_API_KEY` instead.
+
+### 2. Detect the operating system
+
+```bash
+uname -s
+```
+
+- `Darwin` → macOS
+- `Linux` → Linux
+
+Use the detected OS to choose install commands for any missing tools below.
+
+### 3. Required binaries
+
+Check each required binary is on the skill subprocess PATH:
+
+```bash
+command -v ox
+command -v claude
+command -v jq
+```
+
+If any are missing, install them using the OS-appropriate commands in the
+next section.
+
+### 4. Installing missing tools
+
+#### Installing `jq`
+
+- **macOS:** `brew install jq`
+- **Linux (Debian/Ubuntu):** `sudo apt-get update && sudo apt-get install -y jq`
+- **Linux (Fedora/RHEL):** `sudo dnf install -y jq`
+- **Linux (Arch):** `sudo pacman -S --noconfirm jq`
+- **Linux (Alpine):** `sudo apk add jq`
+
+#### Installing `claude` (Claude Code CLI)
+
+Claude Code ships as an npm package and works the same on macOS and Linux:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+If `npm` is not installed:
+
+- **macOS:** `brew install node`
+- **Linux (Debian/Ubuntu):** `sudo apt-get install -y nodejs npm`
+- **Linux (Fedora/RHEL):** `sudo dnf install -y nodejs npm`
+- **Linux (Arch):** `sudo pacman -S --noconfirm nodejs npm`
+
+After installing the CLI, verify:
+
+```bash
+claude --version
+```
+
+This skill does **not** require `claude login` — `claude -p` reads
+`ANTHROPIC_API_KEY` from its process environment, which OpenClaw injects
+from per-skill config (or which the user supplies via shell env).
+
+#### Installing `ox` — interactive setup
+
+The `ox` CLI install method is a one-time choice stored in
+`~/.openclaw/memory/sageox-ox-install.json`. Check that file first:
+
+```bash
+cat ~/.openclaw/memory/sageox-ox-install.json 2>/dev/null
+```
+
+**If the file exists:** read `install_method` and (for the git method)
+`clone_path` + `auto_update`. If `install_method == "git"` and
+`auto_update == true`, update ox before proceeding (see "Updating ox from
+git" below).
+
+**If the file does not exist:** prompt the user to choose an install method:
+
+> How do you want to install the `ox` CLI?
+>
+> 1. **curl install** (recommended) — downloads the latest release tarball
+>    and installs the pinned binary. Fastest, no build toolchain needed.
+> 2. **Build from git source** — clones `github.com/sageox/ox` and builds
+>    with `make install`. Gives you latest `main`. Requires Go ≥ 1.24.
+
+Ask the user to pick 1 or 2. Save the choice to the memory file.
+
+##### Option 1: curl install
+
+Run the ox install script:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh | bash
+```
+
+After it completes, verify `command -v ox` succeeds. Then persist:
+
+```bash
+mkdir -p ~/.openclaw/memory
+cat > ~/.openclaw/memory/sageox-ox-install.json <<EOF
+{
+  "install_method": "curl",
+  "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+```
+
+`ox` lands in a standard system dir (`/usr/local/bin` on Linux,
+`/opt/homebrew/bin` or `/usr/local/bin` on macOS) that is normally already
+on PATH. If `command -v ox` still fails after install, ask the user to
+check their shell PATH.
+
+##### Option 2: build from git source
+
+1. Verify Go ≥ 1.24 is installed:
+
+   ```bash
+   command -v go && go version
+   ```
+
+   If missing, print OS-appropriate install commands and stop until the
+   user installs Go:
+
+   - **macOS:** `brew install go` or download from <https://go.dev/dl/>
+   - **Linux (Debian/Ubuntu):** `sudo apt-get install -y golang-go`
+     (verify the version; use <https://go.dev/dl/> if the distro package
+     is older than 1.24)
+   - **Linux (Fedora/RHEL):** `sudo dnf install -y golang`
+   - **Linux (Arch):** `sudo pacman -S --noconfirm go`
+
+2. Ask the user for a clone path. Default: `$HOME/src/sageox/ox`.
+
+3. Ask the user whether to auto-update from git on every run (yes/no).
+   Default: yes.
+
+4. Clone and build:
+
+   ```bash
+   CLONE_PATH="<user-chosen path>"
+   mkdir -p "$(dirname "$CLONE_PATH")"
+   if [ ! -d "$CLONE_PATH/.git" ]; then
+     git clone https://github.com/sageox/ox.git "$CLONE_PATH"
+   fi
+   (cd "$CLONE_PATH" && make build && make install)
+   ```
+
+5. Detect Go's paths so the user can configure PATH in `~/.openclaw/.env`:
+
+   ```bash
+   GO_BIN_DIR="$(dirname "$(command -v go)")"
+   GO_INSTALL_DIR="$(go env GOBIN)"
+   [ -z "$GO_INSTALL_DIR" ] && GO_INSTALL_DIR="$HOME/go/bin"
+   ```
+
+6. Persist the memory file:
+
+   ```bash
+   mkdir -p ~/.openclaw/memory
+   cat > ~/.openclaw/memory/sageox-ox-install.json <<EOF
+   {
+     "install_method": "git",
+     "clone_path": "$CLONE_PATH",
+     "auto_update": true,
+     "go_bin_dir": "$GO_BIN_DIR",
+     "go_install_dir": "$GO_INSTALL_DIR",
+     "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+   }
+   EOF
+   ```
+
+7. Verify `ox` is on the current subprocess PATH:
+
+   ```bash
+   command -v ox
+   ```
+
+   If it is **not** on PATH, print a copy-pasteable block tailored to the
+   user's detected paths and tell them to add it to `~/.openclaw/.env`:
+
+   ```
+   Add this to ~/.openclaw/.env:
+
+   PATH=<GO_BIN_DIR>:/usr/local/bin:/usr/bin:/bin:<GO_INSTALL_DIR>
+   ```
+
+   Stop and ask the user to confirm once they've updated `.env` and
+   restarted the skill. OpenClaw loads `.env` into the skill subprocess,
+   so an updated PATH takes effect on the next invocation.
+
+##### Updating `ox` from git (auto-update flow)
+
+On every subsequent run, if the memory file says
+`install_method == "git"` and `auto_update == true`, pull and rebuild
+before running the rest of the skill:
+
+```bash
+CLONE_PATH="$(jq -r .clone_path ~/.openclaw/memory/sageox-ox-install.json)"
+(cd "$CLONE_PATH" && git pull --ff-only && make build && make install) || {
+  echo "ox auto-update failed; continuing with existing binary" >&2
+}
+```
+
+Auto-update failures are non-fatal — fall back to the existing binary and
+surface the error to the user.
+
+The user can say **"switch ox install method"** or **"update ox now"** at
+any time to re-run the interactive flow.
+
+### 5. Authentication
+
+1. `ox status` — confirm ox is authenticated. If not, tell the user to
+   run `ox login` and try again.
+2. Smoke-test `claude -p` with the injected key:
+
+   ```bash
+   claude -p "say hi" --model claude-sonnet-4-6
+   ```
+
+   If it fails with an auth error, either the per-skill `apiKey` in
+   `~/.openclaw/openclaw.json` is wrong/expired, or the host shell's
+   `ANTHROPIC_API_KEY` (if set) is wrong/expired and is shadowing the
+   per-skill config. Tell the user to fix whichever applies and try again.
+
+## Configuration
+
+The skill uses two pieces of state:
+
+1. **Repo manifest** — `~/.openclaw/memory/sageox-distill-repos.json`
+   (shared with the `sageox-distill` skill). Format:
+
+   ```json
+   {
+     "repos": [
+       { "path": "/home/user/repos/my-project", "team_id": "my-team" }
+     ]
+   }
+   ```
+
+2. **SageOx endpoint** — `~/.openclaw/memory/sageox-endpoint.txt` (a
+   single line containing the endpoint URL, e.g.
+   `https://test.sageox.ai`). Default if missing: `https://test.sageox.ai`.
+   Ask the user to confirm the endpoint on first run and persist it.
+
+If the manifest does not exist, tell the user to run the `sageox-distill`
+skill first to set up the repos, or ask for paths directly and populate
+it.
+
+## Summary Pipeline
+
+When the user asks for a summary (or when triggered by a cron job), run
+the following steps in order.
+
+### Step 1: Load the Manifest and Endpoint
+
+1. Read `~/.openclaw/memory/sageox-distill-repos.json` with `jq`.
+2. Read `~/.openclaw/memory/sageox-endpoint.txt` (or use default).
+3. Group repos by `team_id` using `jq`.
+4. Collect the unique team IDs.
+
+### Step 2: Compute Team Context Directories
+
+For each unique `team_id`, compute the team context directory:
+
+```
+~/.local/share/sageox/<slug>/teams/<team_id>/
+```
+
+Where `<slug>` is derived from the endpoint URL:
+
+1. Strip scheme (`https://`, `http://`)
+2. Strip trailing slash
+3. Strip port
+4. Strip these prefixes if present: `api.`, `www.`, `app.`, `git.`
+5. Normalize `127.0.0.1` to `localhost`
+
+Examples:
+
+- `https://test.sageox.ai` → `test.sageox.ai`
+- `https://api.sageox.ai` → `sageox.ai`
+- `http://127.0.0.1:8080` → `localhost`
+
+The daily summary files live at:
+
+```
+~/.local/share/sageox/<slug>/teams/<team_id>/memory/daily/
+```
+
+Verify each daily directory exists before proceeding. If a team's
+directory is missing, log it and continue with the remaining teams.
+
+### Step 3: Build the Prompt
+
+1. Read the template from the skill's assets directory:
+   `./assets/SUMMARIZE.md` (relative to this SKILL.md file). The file
+   path on disk depends on where OpenClaw loaded the skill from —
+   typically one of:
+   - `~/.openclaw/skills/sageox-summary/assets/SUMMARIZE.md`
+   - `./skills/sageox-summary/assets/SUMMARIZE.md` (workspace skill)
+
+2. Substitute template placeholders:
+   - `{{DIR_LIST}}` — a list of entries, one per team, in this format:
+
+     ```
+     - Team "<team_id>": <daily_dir>/
+     ```
+
+   - `{{MULTI_TEAM_RULES}}` — if there are 2+ teams, replace with:
+
+     ```
+     - Organize the summary by team, using each team ID as a section header
+     - Attribute insights to the correct team
+     ```
+
+     Otherwise, replace with an empty string.
+
+### Step 4: Run Claude
+
+Invoke `claude -p` with:
+
+- `--add-dir <team_dir>` for EACH team context directory (the parent
+  `teams/<team_id>/` dir, not the `memory/daily/` subdirectory)
+- `--allowedTools Read` (summary is read-only)
+- `--model claude-sonnet-4-6`
+- The substituted prompt passed via stdin
+
+`ANTHROPIC_API_KEY` is already set in the skill's process environment
+(either by OpenClaw's per-skill `apiKey` injection or inherited from the
+host shell — see Prerequisites § 1), so `claude -p` picks it up naturally:
+
+```bash
+claude -p \
+  --add-dir "$TEAM_DIR_1" \
+  --add-dir "$TEAM_DIR_2" \
+  --allowedTools Read \
+  --model claude-sonnet-4-6 <<< "$PROMPT"
+```
+
+Timeout the command at 2 minutes. If it fails, surface the error to the
+user.
+
+### Step 5: Return the Summary
+
+Return Claude's stdout to the user directly. It is already formatted for
+Slack mrkdwn. Do not reformat or annotate — just show it.
+
+## Scheduling
+
+When the user asks to schedule summaries:
+
+1. Suggest a default of daily at 9am local time if the user doesn't
+   specify.
+2. Confirm the schedule with the user before creating it.
+3. Create a cron job that runs this skill's summary pipeline.
+
+Common schedules:
+
+- Daily at 9am: `0 9 * * *`
+- Weekdays at 8am: `0 8 * * 1-5`
+- Twice daily (morning + afternoon): `0 9,16 * * 1-5`
+
+If the user also has a distill schedule, suggest running summaries on a
+schedule that trails the distill by at least 30 minutes so the daily
+files are up to date before summarization.
+
+The cron job must source `~/.openclaw/.env` before running (cron has a
+minimal environment by default). A typical crontab line:
+
+```cron
+0 9 * * * set -a; . $HOME/.openclaw/.env; set +a; openclaw run sageox-summary
+```
+
+Adjust the invocation to match however OpenClaw runs skills on the
+user's system.
+
+## Output
+
+The primary output is the Claude-generated summary. Prefix it with a
+brief one-line header showing:
+
+- How many teams were summarized
+- The endpoint used
+- Any teams that were skipped (and why)
+
+Keep any preamble or postamble minimal. The summary itself is the value.

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -182,10 +182,30 @@ Ask the user to pick 1 or 2. Save the choice to the memory file.
 
 ##### Option 1: curl install
 
-Run the ox install script:
+Download and run the ox install script. The agent should print the source
+URL and a head/tail preview of the downloaded script before executing it,
+so the user can sanity-check what is about to run:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh | bash
+# Download to a temp file. -f makes curl fail on HTTP errors instead of
+# executing an HTML error page; --max-time bounds a stalled connection.
+INSTALL_SCRIPT="$(mktemp -t ox-install.XXXXXX.sh)"
+curl -fsSL --max-time 60 \
+  https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh \
+  -o "$INSTALL_SCRIPT"
+
+# Surface what is about to run.
+echo "Downloaded ox install script:"
+echo "  Source: https://github.com/sageox/ox/blob/main/scripts/install.sh"
+ls -lh "$INSTALL_SCRIPT"
+echo "--- first 5 lines ---"
+head -5 "$INSTALL_SCRIPT"
+echo "--- last 5 lines ---"
+tail -5 "$INSTALL_SCRIPT"
+
+# Execute and clean up.
+bash "$INSTALL_SCRIPT"
+rm -f "$INSTALL_SCRIPT"
 ```
 
 After it completes, verify `command -v ox` succeeds. Then persist:

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -501,8 +501,10 @@ claude -p \
   --model claude-sonnet-4-6 <<< "$PROMPT"
 ```
 
-Timeout the command at 2 minutes. If it fails, surface the error to the
-user.
+Timeout the command at 10 minutes. This matches the timeout used by
+`pkg/sessionsummary/claude.go` in the `ox` repo for comparable Claude
+synthesis work and gives the model enough headroom for cross-team summaries
+that pull in many daily files. If it fails, surface the error to the user.
 
 ### Step 5: Return the Summary
 

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -155,6 +155,35 @@ This skill does **not** require `claude login` — `claude -p` reads
 `ANTHROPIC_API_KEY` from its process environment, which OpenClaw injects
 from per-skill config (or which the user supplies via shell env).
 
+#### Path validation rules
+
+Several steps below ask the user for a path (clone path) or read a path
+from a JSON state file. Before interpolating any such value into a shell
+command, the agent **must** validate it against these rules:
+
+1. **Absolute path required.** Must start with `/` or `~`. Reject relative
+   paths and bare names.
+2. **No `..` segments.** Reject anything containing `..`.
+3. **No shell metacharacters.** Reject anything containing any of these
+   characters: `;` `$` `` ` `` `|` `&` `<` `>` `(` `)` `{` `}` `*` `?`
+   `[` `]` `!` `\` newline.
+4. **For clone paths used by the auto-update flow** (see Option 2 below),
+   apply two additional checks:
+   - Must be **under `$HOME`**. Reject `/tmp`, `/var/tmp`, `/dev/shm`,
+     `/private/tmp`, network mounts, and any other location not owned by
+     the current user.
+   - The path must already exist as a directory and contain a `.git`
+     subdirectory before any `git pull` / `make install` runs.
+
+On any validation failure: print a clear error to the user explaining
+which rule failed and ask them to provide a different path. **Do not
+attempt to "fix up" or sanitize the input** — reject and re-prompt.
+
+Treat values read from `~/.openclaw/memory/*.json` files as untrusted
+even though this skill writes them: the user (or a process running as
+the user) may have edited the file by hand or by another tool between
+runs. Re-validate every read.
+
 #### Installing `ox` — interactive setup
 
 The `ox` CLI install method is a one-time choice stored in
@@ -189,7 +218,8 @@ so the user can sanity-check what is about to run:
 ```bash
 # Download to a temp file. -f makes curl fail on HTTP errors instead of
 # executing an HTML error page; --max-time bounds a stalled connection.
-INSTALL_SCRIPT="$(mktemp -t ox-install.XXXXXX.sh)"
+# Use the template form for mktemp — portable across GNU (Linux) and BSD (macOS).
+INSTALL_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
 curl -fsSL --max-time 60 \
   https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh \
   -o "$INSTALL_SCRIPT"
@@ -244,6 +274,18 @@ check their shell PATH.
    - **Linux (Arch):** `sudo pacman -S --noconfirm go`
 
 2. Ask the user for a clone path. Default: `$HOME/src/sageox/ox`.
+   **Validate** the input against the Path validation rules above,
+   including the additional rule that the path must be under `$HOME`.
+   Re-prompt on failure.
+
+   ⚠️ **The clone path becomes a privileged location.** If auto-update is
+   enabled, this skill will run `make build && make install` from it on
+   every invocation. Anyone with write access to the clone path can run
+   arbitrary code in the user's environment. Strongly recommend a
+   personal directory under `$HOME` (the default `$HOME/src/sageox/ox`
+   is a good choice). Refuse anything in `/tmp`, `/var/tmp`, `/dev/shm`,
+   shared filesystems, or world-writable directories — these checks are
+   already part of the validation rules; do not bypass them.
 
 3. Ask the user whether to auto-update from git on every run (yes/no).
    Default: yes.
@@ -305,18 +347,27 @@ check their shell PATH.
 ##### Updating `ox` from git (auto-update flow)
 
 On every subsequent run, if the memory file says
-`install_method == "git"` and `auto_update == true`, pull and rebuild
-before running the rest of the skill:
+`install_method == "git"` and `auto_update == true`:
 
-```bash
-CLONE_PATH="$(jq -r .clone_path ~/.openclaw/memory/sageox-ox-install.json)"
-(cd "$CLONE_PATH" && git pull --ff-only && make build && make install) || {
-  echo "ox auto-update failed; continuing with existing binary" >&2
-}
-```
+1. Read `clone_path` from `~/.openclaw/memory/sageox-ox-install.json`.
+2. **Re-validate** it against the Path validation rules in Prerequisites
+   § 4, including the additional clone-path checks (must be under
+   `$HOME`, must exist, must contain a `.git` subdirectory). The memory
+   file is user-writable and may have been edited externally between
+   runs — never trust persisted values without re-validation.
+3. **If validation fails**, log a clear error naming the failing rule,
+   skip the auto-update entirely, and fall back to the existing `ox`
+   binary on PATH. Do not proceed with `cd` / `git pull` / `make install`.
+4. If validation passes, run:
 
-Auto-update failures are non-fatal — fall back to the existing binary and
-surface the error to the user.
+   ```bash
+   (cd "$CLONE_PATH" && git pull --ff-only && make build && make install) || {
+     echo "ox auto-update failed; continuing with existing binary" >&2
+   }
+   ```
+
+Auto-update failures (validation or build) are non-fatal — fall back to
+the existing binary and surface the error to the user.
 
 The user can say **"switch ox install method"** or **"update ox now"** at
 any time to re-run the interactive flow.

--- a/claws/openclaw/sageox-summary/assets/SUMMARIZE.md
+++ b/claws/openclaw/sageox-summary/assets/SUMMARIZE.md
@@ -1,0 +1,37 @@
+# Team Summary
+
+You are generating a team summary from distilled session logs covering the last 24 hours. The summary will be read by people across all functions — engineering, product, marketing, and leadership. Your job is to help the team stay aligned and quickly identify what conversations need to happen and what work may need adjusting.
+
+## Workflow
+
+1. Read the distilled daily summary files for the last 24 hours from the directories listed below (grouped by team).
+2. Produce a structured summary following the format described below.
+
+## Team context directories
+
+{{DIR_LIST}}
+
+## Summary structure
+
+You MUST use exactly these four section headings. Each section should have 2–5 bullets. Prioritize signal over detail — a product manager and a marketer will read this alongside engineers. Synthesize across PRs and sessions; do not enumerate individual PRs unless they represent a meaningful milestone.
+
+*Where we are*
+Progress relative to what we set out to do. Cover both macro (goals, initiatives — are we on track?) and micro (what shipped in the last 24 hours). Name people and repos, but summarize themes rather than listing every PR.
+
+*What's getting in the way*
+Blockers, friction, unresolved issues, failed attempts, or things that took longer than expected. Flag patterns. This section drives the conversations the team needs to have.
+
+*What we've learned*
+This is one of the most valuable sections — don't skip or thin it out. Include: techniques or approaches someone used that others should adopt, non-obvious discoveries about the codebase or infrastructure, important team discussions and the conclusions reached, and shifts in thinking about how we build or ship. If someone solved a hard problem, explain the insight — not just that they fixed it.
+
+*What's next*
+Work queued up, drafts in progress, or follow-ups called out. Anything that signals upcoming changes others should prepare for.
+
+## Formatting rules
+
+- Format for Slack mrkdwn: use *bold*, _italic_, `code`, bullet points with •
+- Keep it scannable — each bullet should be 1–2 sentences max
+- Skip anything older than 24 hours
+- Link to notable sessions where they add context
+- Surface important discussions, debates, and decisions the team had
+{{MULTI_TEAM_RULES}}


### PR DESCRIPTION
## Summary

- **Two ClawHub-publishable OpenClaw skills** at `claws/openclaw/`: [`sageox-distill`](https://github.com/sageox/ox/blob/worktree-claws-openclaw-skills/claws/openclaw/sageox-distill/SKILL.md) (sync + index + distill across SageOx repos) and [`sageox-summary`](https://github.com/sageox/ox/blob/worktree-claws-openclaw-skills/claws/openclaw/sageox-summary/SKILL.md) (Slack-ready cross-team digest from distilled daily files). Both pair with each other and ship with a first-run interactive `ox` install (curl-pinned-release **or** git-clone-and-build with optional auto-update).
- **Pre-publish lint tool** at `.claude/skills/clawhub-skill-lint/` — a directory-based Claude skill that runs a Python validator re-implementing every rule from openclaw/clawhub's server-side static scanner. Catches publish-time failures locally without needing the `clawhub` CLI or a network round-trip.
- **Forward-compatible `claws/` namespace** for future OpenClaw / Clawdbot / etc. skill packs published from this repo.

## Why

We want to publish two existing SageOx skills (currently in `~/src/sageox/factory/skills/`) to [ClawHub](https://clawhub.ai), the public skill registry for [OpenClaw](https://openclaw.ai). The factory copies were macOS-only, brew-dependent, and used `ANTHROPIC_API_KEY` directly (which collides with the host agent's key). This PR brings them into the `ox` repo at `claws/openclaw/`, fixes cross-platform / dependency / env-collision issues, hardens against ClawHub's static scanner, and adds the publishing workflow.

## Layout

```
claws/                                  # forward-compatible namespace for claws
├── README.md                           # what claws/ means; index of claws
└── openclaw/
    ├── README.md                       # OpenClaw skill index + Environment setup
    ├── PUBLISHING.md                   # ClawHub publish runbook
    ├── sageox-distill/
    │   ├── SKILL.md
    │   ├── README.md
    │   └── .clawhubignore
    └── sageox-summary/
        ├── SKILL.md
        ├── README.md
        ├── .clawhubignore
        └── assets/SUMMARIZE.md

.claude/skills/
└── clawhub-skill-lint/                 # pre-publish validator (Claude skill)
    ├── SKILL.md                        # agent-facing prompt + trigger phrases
    └── scripts/
        ├── lint.py                     # ~570 lines, no deps beyond stdlib
        └── .gitignore                  # __pycache__/
```

`claws/<claw-name>/<skill-slug>/` scales to future claws (`claws/clawdbot/`, `claws/lobster/`, etc.).

## Anthropic API key isolation via OpenClaw's per-skill `apiKey`

Both skills declare `primaryEnv: ANTHROPIC_API_KEY` and `requires.env: [ANTHROPIC_API_KEY]`. Users supply the key via OpenClaw's per-skill `apiKey` field in `~/.openclaw/openclaw.json`:

```json5
{
  skills: {
    entries: {
      "sageox-distill": { apiKey: "sk-ant-..." },
      "sageox-summary": { apiKey: "sk-ant-..." }
    }
  }
}
```

OpenClaw injects this into `process.env` for the duration of the skill's run and reverts on completion (see [`src/agents/skills/env-overrides.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/skills/env-overrides.ts)). This lets users bill SageOx work to a different Anthropic account than their host agent.

**Critical caveat — documented prominently in the README:** OpenClaw's injection is gated on `process.env[primaryEnv]` being **unset**. If the host shell exports `ANTHROPIC_API_KEY`, the per-skill value is silently ignored:

```mermaid
flowchart LR
    A[User starts OpenClaw] --> B{ANTHROPIC_API_KEY<br/>already in process.env?}
    B -->|YES, externally set| C[Host value passes through<br/>to skill subprocess]
    B -->|NO, unset| D[Per-skill apiKey<br/>from openclaw.json]
    D --> E[Inject into process.env<br/>for skill duration]
    E --> F[Revert on skill exit]
    C -.->|silently ignored| D
```

The README tells users to verify with `env | grep ANTHROPIC_API_KEY` before launching OpenClaw and find/remove any externally exported value if they want per-skill isolation.

## `ox` install: interactive curl OR git-clone, no Homebrew

The factory skills used `kind: brew formula: sageox/tap/ox`. Dropped in favor of an interactive choice on first run, persisted in `~/.openclaw/memory/sageox-ox-install.json`:

1. **curl install** — downloads `scripts/install.sh` from the public `sageox/ox` GitHub raw URL and runs it. **Hardened to download-then-execute** (see Security § below) so the curl-pipe-sh substring is no longer present in the bundle.
2. **Build from git source** — clones, runs `make build && make install`, optionally auto-updates on every run via `git pull --ff-only && make build && make install`.

The auto-update flow re-validates the persisted clone path on every read because the memory file is user-writable.

## Security review

Both SKILL.md files were validated against [openclaw/clawhub's server-side static scanner](https://github.com/openclaw/clawhub/blob/main/convex/lib/moderationEngine.ts). Findings + fixes:

| Risk | Fix |
|---|---|
| ClawHub's `hasMaliciousInstallPrompt` rule could fire on `curl ... \| sh` patterns combined with terminal-instruction language, raw IP, or installer-package label | Refactored to download-then-execute (`mktemp` → `curl -fsSL --max-time 60 -o $tmp` → preview `head`/`tail` → `bash $tmp`). The curl-pipe-sh substring is no longer present in the bundle at all. |
| `mktemp -t` portability across GNU and BSD (macOS) — the `-t` flag has different semantics, leaving literal `XXXXXX` in macOS filenames | Switched to `mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX"` (template form, portable across both). |
| Command injection via user-provided paths (repo paths, clone paths) | New "Path validation rules" section in both SKILL.md: must be absolute, no `..`, no shell metacharacters; agent rejects-and-re-prompts on failure. Don't sanitize, reject. |
| Trust boundary on the auto-update clone path (anyone with write access to it can run arbitrary code via `make install`) | Additional validation rule: clone path must be under `$HOME`, never `/tmp`, `/var/tmp`, `/dev/shm`, or shared filesystems. Trust-boundary warning in the prompt. |
| Persisted JSON values (`clone_path` from memory file) treated as trusted | Auto-update flow re-validates the persisted path on every read. Prose explicitly tells the agent the memory file is user-writable and untrusted. |
| `ANTHROPIC_API_KEY` collision with the host agent | Per-skill `apiKey` mechanism via `~/.openclaw/openclaw.json` (described above). |

**Verified clean against every static-scanner rule** via the bundled lint tool (see Test plan § below). The remaining risk is the opaque VT Code Insight (Gemini) LLM scan, which can only be tested via a throwaway-slug publish — see PUBLISHING.md.

## Pre-publish lint tool

`.claude/skills/clawhub-skill-lint/` is a directory-based Claude skill that bundles a Python validator re-implementing:

- **Frontmatter spec** from [`docs/skill-format.md`](https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md) — required fields, semver, slug regex, allowed `os` values, allowed `install.kind` values (only `brew`/`node`/`go`/`uv`), `primaryEnv` consistency, `always: true` warning
- **All static-scanner rules** from [`convex/lib/moderationEngine.ts`](https://github.com/openclaw/clawhub/blob/main/convex/lib/moderationEngine.ts) — `hasMaliciousInstallPrompt` (full TI + curl|sh + rawIP/installer-package logic), prompt-injection bait, generated-source placeholder + code-context, hardcoded `connection_id` UUIDs, URL shorteners, raw IPs in manifests, code-file rules (exec, eval, crypto mining, exfiltration, credential harvest, obfuscated payloads)
- **Bundle limits** — 50 MB cap, text-file extension allowlist
- **A custom recursive-descent YAML parser** that handles nested maps, lists of maps (for `install:`), folded scalars (for `description: >`) — no PyYAML dependency

Usage:

```bash
python3 .claude/skills/clawhub-skill-lint/scripts/lint.py [--json] [--strict] [--no-color] <path>...
```

Exit codes: `0` clean, `1` findings, `2` usage error. The Claude skill (`SKILL.md`) tells agents when to invoke the linter and how to interpret findings.

## Test plan

- [x] `python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw` → PASS, 0 critical, 0 warnings
- [x] Frontmatter validates: `name`, `description`, `version` (semver), `primaryEnv`, `requires.env`/`bins`, `os`, install kinds (only `brew`/`node`)
- [x] Bundle sizes within ClawHub's 50 MB limit (16 KB / 19 KB)
- [x] Slug regex matches: `sageox-distill`, `sageox-summary`
- [x] Linter catches deliberate violations (bad slug, missing fields, invalid semver, wrong install kind, curl|sh+rawIP, prompt-injection bait) — verified with `/tmp` fixtures
- [x] All `--json`, `--strict`, single-skill, parent-dir, and error-path modes of the linter work
- [ ] Cross-machine OpenClaw test: pull this branch on the OpenClaw machine, add `claws/openclaw` to `skills.load.extraDirs` in `~/.openclaw/openclaw.json`, verify both skills appear and run end-to-end against a test SageOx team
- [ ] Throwaway-slug publish to ClawHub: publish under `sageox-distill-scantest-<ts>` and `sageox-summary-scantest-<ts>`, query `/api/v1/skills/<slug>/scan`, confirm verdict is `clean`, then soft-delete
- [ ] Real publish: `clawhub sync --root claws/openclaw --all --bump patch --changelog "Initial release"`

## Out of scope for this PR

- No CI workflow for ClawHub publish — local publish for the first release; CI is a follow-up
- No removal of the factory copies at `~/src/sageox/factory/skills/` (separate repo)
- Throwaway-slug pre-flight publish itself (Test plan items 7–9 are post-merge)

## References

- [openclaw/clawhub `docs/skill-format.md`](https://github.com/openclaw/clawhub/blob/main/docs/skill-format.md) — frontmatter spec
- [openclaw/clawhub `docs/cli.md`](https://github.com/openclaw/clawhub/blob/main/docs/cli.md) — `clawhub sync` / `skill publish`
- [openclaw/clawhub `convex/lib/moderationEngine.ts`](https://github.com/openclaw/clawhub/blob/main/convex/lib/moderationEngine.ts) — server-side static scanner (source of truth for the lint rules)
- [openclaw/openclaw `docs/tools/skills-config.md`](https://github.com/openclaw/openclaw/blob/main/docs/tools/skills-config.md) — per-skill `apiKey` schema
- [openclaw/openclaw `src/agents/skills/env-overrides.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/skills/env-overrides.ts) — env injection mechanism + precedence rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-publish skill validator with static checks, bundle limits, and JSON/text report output.
  * Added two OpenClaw skills: sageox-distill (daily distill pipeline) and sageox-summary (Slack-ready cross-team summaries).

* **Documentation**
  * Added Claws overview and OpenClaw publishing runbook.
  * Added per-skill READMEs, skill definitions, and a team-summary template; updated packaging ignore patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->