### PR TITLE
fix(distill): carry source links through summary citations (#476)

### DIFF
--- a/cmd/ox/discussion_url.go
+++ b/cmd/ox/discussion_url.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/sageox/ox/internal/endpoint"
+)
+
+// buildDiscussionURL constructs the canonical web URL for viewing a discussion
+// recording. Returns empty string if any required input is missing — including
+// recording_id, which is absent for legacy or audio-only discussions.
+//
+// Mirrors buildSessionURL in cmd/ox/session_url.go. Used by the citation
+// pipeline to render clickable links in distilled summaries.
+//
+// URL shape: <endpoint>/team/<team_id>/media/recordings/<recording_id>
+func buildDiscussionURL(ep, teamID, recordingID string) string {
+	if teamID == "" || recordingID == "" {
+		return ""
+	}
+	ep = endpoint.NormalizeEndpoint(ep)
+	if ep == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/team/%s/media/recordings/%s",
+		ep,
+		url.PathEscape(teamID),
+		url.PathEscape(recordingID),
+	)
+}

--- a/cmd/ox/discussion_url_test.go
+++ b/cmd/ox/discussion_url_test.go
@@ -1,0 +1,89 @@
+package main
+
+import "testing"
+
+// TestBuildDiscussionURL covers the failure modes that would silently produce
+// broken citation links: missing inputs, prefixed endpoints, and edge characters.
+func TestBuildDiscussionURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		endpoint    string
+		teamID      string
+		recordingID string
+		want        string
+	}{
+		{
+			name:        "happy path with https endpoint",
+			endpoint:    "https://sageox.ai",
+			teamID:      "team_jihjpfkt8b",
+			recordingID: "rec_019d69d9-0243-706a-8455-080a47ffcba0",
+			want:        "https://sageox.ai/team/team_jihjpfkt8b/media/recordings/rec_019d69d9-0243-706a-8455-080a47ffcba0",
+		},
+		{
+			name:        "endpoint with api prefix is normalized",
+			endpoint:    "https://api.sageox.ai",
+			teamID:      "team_abc",
+			recordingID: "rec_xyz",
+			want:        "https://sageox.ai/team/team_abc/media/recordings/rec_xyz",
+		},
+		{
+			name:        "endpoint with www prefix is normalized",
+			endpoint:    "https://www.sageox.ai",
+			teamID:      "team_abc",
+			recordingID: "rec_xyz",
+			want:        "https://sageox.ai/team/team_abc/media/recordings/rec_xyz",
+		},
+		{
+			name:        "self-hosted endpoint preserved",
+			endpoint:    "https://sageox.example.com",
+			teamID:      "team_abc",
+			recordingID: "rec_xyz",
+			want:        "https://sageox.example.com/team/team_abc/media/recordings/rec_xyz",
+		},
+		{
+			name:        "missing team_id returns empty (audio-only / legacy)",
+			endpoint:    "https://sageox.ai",
+			teamID:      "",
+			recordingID: "rec_xyz",
+			want:        "",
+		},
+		{
+			name:        "missing recording_id returns empty",
+			endpoint:    "https://sageox.ai",
+			teamID:      "team_abc",
+			recordingID: "",
+			want:        "",
+		},
+		{
+			name:        "missing endpoint returns empty",
+			endpoint:    "",
+			teamID:      "team_abc",
+			recordingID: "rec_xyz",
+			want:        "",
+		},
+		{
+			name:        "all empty returns empty",
+			endpoint:    "",
+			teamID:      "",
+			recordingID: "",
+			want:        "",
+		},
+		{
+			name:        "team_id with unusual characters is escaped",
+			endpoint:    "https://sageox.ai",
+			teamID:      "team with spaces",
+			recordingID: "rec_xyz",
+			want:        "https://sageox.ai/team/team%20with%20spaces/media/recordings/rec_xyz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildDiscussionURL(tt.endpoint, tt.teamID, tt.recordingID)
+			if got != tt.want {
+				t.Errorf("buildDiscussionURL(%q, %q, %q)\n got: %q\nwant: %q",
+					tt.endpoint, tt.teamID, tt.recordingID, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -584,11 +584,14 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// resolve project endpoint once — used for the deferred push and for
+	// building per-fact citation URLs (gh #476) at extraction time.
+	ep := endpoint.GetForProject(projectRoot)
+
 	// push team context commits to remote when we're done — even if the
 	// pipeline partially fails, earlier stages may have committed facts or
 	// distilled summaries that should be synced.
 	if !distillDryRun && !distillNoPush {
-		ep := endpoint.GetForProject(projectRoot)
 		defer func() {
 			if err := pushTeamContext(context.Background(), tc.Path, ep); err != nil {
 				slog.Warn("failed to push team context after distill", "error", err)
@@ -695,7 +698,7 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 	// extract facts from unprocessed discussions before daily distill
 	// (discussions live in team context, not per-ledger — no multi-repo loop needed)
 	if plan.Daily {
-		if err := extractDiscussionFacts(ctx, cmd, backend, tc, extractGuidelines, extractSince); err != nil {
+		if err := extractDiscussionFacts(ctx, cmd, backend, tc, extractGuidelines, ep, extractSince); err != nil {
 			slog.Warn("discussion fact extraction failed", "error", err)
 		}
 	}
@@ -708,7 +711,7 @@ func runDistill(cmd *cobra.Command, _ []string) error {
 				fmt.Fprintf(cmd.OutOrStdout(), "Processing repo %s (%s)...\n", repo.RepoID, repo.ProjectRoot)
 			}
 
-			if err := extractSessionFacts(cmd, tc, repo.RepoID, repo.LedgerPath, extractSince); err != nil {
+			if err := extractSessionFacts(cmd, tc, repo.RepoID, repo.LedgerPath, ep, extractSince); err != nil {
 				slog.Warn("session fact extraction failed", "repo", repoLabel, "error", err)
 			}
 
@@ -861,7 +864,10 @@ func enumerateMonths(lastTime, now time.Time, tz *time.Location) []string {
 // extractDiscussionFacts scans for unprocessed discussions and writes fact files.
 // Each discussion gets a fact file in memory/.discussion-facts/{dirName}.md.
 // Uses LLM to extract structured facts, or writes stub if in dry-run mode.
-func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, guidelines string, since time.Time) error {
+//
+// ep is the endpoint for building per-fact SourceURL (clickable citation links
+// in distilled summaries — gh #476). Empty endpoint degrades to label-only.
+func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, tc *config.TeamContext, guidelines, ep string, since time.Time) error {
 	pending, err := scanPendingDiscussions(tc.Path, since)
 	if err != nil {
 		return fmt.Errorf("scan discussions: %w", err)
@@ -888,7 +894,7 @@ func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend age
 		// compute source hash before extraction for embedding in the fact file
 		sourceHash := discussionContentHash(filepath.Join(tc.Path, "discussions", d.DirName))
 
-		factContent, err := extractSingleDiscussionFacts(ctx, cmd, backend, d, guidelines, sourceHash)
+		factContent, err := extractSingleDiscussionFacts(ctx, cmd, backend, d, guidelines, sourceHash, tc.TeamID, ep)
 		if err != nil {
 			// non-fatal per discussion — log and continue
 			slog.Warn("skip discussion fact extraction", "dir", d.DirName, "error", err)
@@ -925,10 +931,11 @@ func extractDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend age
 // When server-generated summary.json exists, extracts facts directly from
 // structured data without an LLM call. Falls back to LLM via JSONL output.
 // sourceHash is embedded in the fact file header for stateless change detection.
-func extractSingleDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, d discussionInput, guidelines, sourceHash string) (string, error) {
+// teamID + ep populate per-fact SourceURL for clickable citations (gh #476).
+func extractSingleDiscussionFacts(ctx context.Context, cmd *cobra.Command, backend agentcli.Backend, d discussionInput, guidelines, sourceHash, teamID, ep string) (string, error) {
 	// if server-generated summary.json exists, extract facts directly without LLM
 	if d.SummaryJSONDir != "" {
-		result, err := extractFactsFromSummaryJSON(d, sourceHash)
+		result, err := extractFactsFromSummaryJSON(d, sourceHash, teamID, ep)
 		if err == nil {
 			slog.Info("extracted facts from summary.json", "discussion", d.DirName)
 			return result, nil
@@ -950,6 +957,19 @@ func extractSingleDiscussionFacts(ctx context.Context, cmd *cobra.Command, backe
 	}
 	if len(parsedFacts) == 0 {
 		return "", nil // no valid facts extracted
+	}
+
+	// LLM extractor doesn't know about citation links — fill in deterministic
+	// SourceURL/SourceTitle for every fact so the daily summary can cite them.
+	// (gh #476)
+	sourceURL := buildDiscussionURL(ep, teamID, d.RecordingID)
+	for i := range parsedFacts {
+		if parsedFacts[i].SourceURL == "" {
+			parsedFacts[i].SourceURL = sourceURL
+		}
+		if parsedFacts[i].SourceTitle == "" {
+			parsedFacts[i].SourceTitle = d.Title
+		}
 	}
 
 	header := facts.FileHeader{
@@ -1084,22 +1104,24 @@ func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Back
 		dayObs := obsByDay[day]
 		dayFacts := factsByDay[day]
 
-		// extract observation content strings
+		// extract observation content strings (no citation numbers — observations
+		// are weaved into narrative prose; only facts get [N] markers)
 		contents := make([]string, len(dayObs))
 		for i, obs := range dayObs {
 			contents[i] = obs.Content
 		}
 
-		// extract fact paths for the prompt
-		var factPaths []string
-		for _, f := range dayFacts {
-			factPaths = append(factPaths, f.RelPath)
-		}
+		// parse fact files into a flat []facts.Fact and build the citation list
+		// (gh #476). Citations are deduped by source URL/ref so multiple facts
+		// from the same discussion share one [N].
+		flatFacts, factOriginPaths := loadDayFacts(tc.Path, dayFacts)
+		cites, factToCiteNum := buildCitationsFromFacts(flatFacts)
+		citedFacts := buildFactCitationsForPrompt(flatFacts, factToCiteNum)
 
-		prompt := agentcli.DailyPrompt(contents, day, guidelines, factPaths...)
+		prompt := agentcli.DailyPrompt(contents, day, guidelines, citedFacts)
 		logPrompt(cmd, "daily:"+day, prompt)
 		fmt.Fprintf(cmd.OutOrStdout(), "Distilling %d observations and %d facts into daily summary for %s...\n",
-			len(dayObs), len(dayFacts), day)
+			len(dayObs), len(flatFacts), day)
 
 		output, err := backend.Run(ctx, prompt)
 		if err != nil {
@@ -1112,14 +1134,16 @@ func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Back
 			return fmt.Errorf("generate daily file ID: %w", err)
 		}
 
-		// collect source paths for frontmatter
-		var sources []string
-		for _, f := range dayFacts {
-			sources = append(sources, f.RelPath)
-		}
+		// collect source paths for frontmatter — both fact files and observation
+		// files. The frontmatter is the cache-index input list (used by
+		// distill_index.distilledSources to skip already-processed files).
+		// Observations were previously not tracked here; gh #476 adds them so
+		// the cache can detect already-distilled observation files too.
+		sources := append([]string(nil), factOriginPaths...)
+		sources = append(sources, observationSourcePaths(tc.Path, dayObs)...)
 
 		filePath := filepath.Join("memory", "daily", day+"-"+id.String()+".md")
-		content := formatDailyMemory(day, output, len(dayObs), len(dayFacts), sources)
+		content := formatDailyMemory(day, output, len(dayObs), len(flatFacts), sources, cites)
 
 		if err := writeMemoryFile(tc.Path, filePath, content); err != nil {
 			return fmt.Errorf("write daily memory: %w", err)
@@ -1163,9 +1187,16 @@ func distillWeekly(ctx context.Context, cmd *cobra.Command, backend agentcli.Bac
 		return nil
 	}
 
-	prompt := agentcli.WeeklyPrompt(dailySummaries, weekID, guidelines)
+	// Parse Sources sections from each daily, merge into a unified citation
+	// list, and renumber the daily prose to use the unified numbers (gh #476).
+	// The LLM then sees globally-numbered markers and only has to preserve
+	// them — no arithmetic.
+	rewrittenDailies, mergedCites := mergeCitationsFromMarkdown(dailySummaries)
+	hasCitations := len(mergedCites) > 0
+
+	prompt := agentcli.WeeklyPrompt(rewrittenDailies, weekID, guidelines, hasCitations)
 	logPrompt(cmd, "weekly:"+weekID, prompt)
-	slog.Info("distill weekly: sending to AI coworker", "week", weekID, "daily_count", len(dailySummaries), "daily_files", dailyFiles, "prompt_bytes", len(prompt))
+	slog.Info("distill weekly: sending to AI coworker", "week", weekID, "daily_count", len(dailySummaries), "daily_files", dailyFiles, "prompt_bytes", len(prompt), "cites", len(mergedCites))
 	fmt.Fprintf(cmd.OutOrStdout(), "Synthesizing %d daily summaries into weekly %s...\n", len(dailySummaries), weekID)
 
 	output, err := backend.Run(ctx, prompt)
@@ -1176,8 +1207,8 @@ func distillWeekly(ctx context.Context, cmd *cobra.Command, backend agentcli.Bac
 
 	wuid, _ := uuid.NewV7() // error only if crypto/rand fails — zero UUID collision is acceptable
 	filePath := filepath.Join("memory", "weekly", weekID+"-"+wuid.String()+".md")
-	content := fmt.Sprintf("# Weekly Memory — %s\n\n%s\n\n---\n*Synthesized from %d daily summaries (%s)*\n",
-		weekID, output, len(dailySummaries), strings.Join(dailyFiles, ", "))
+	content := formatLayeredMemory("Weekly Memory", weekID, output, mergedCites,
+		fmt.Sprintf("Synthesized from %d daily summaries (%s)", len(dailySummaries), strings.Join(dailyFiles, ", ")))
 
 	if err := writeMemoryFile(tc.Path, filePath, content); err != nil {
 		return fmt.Errorf("write weekly memory: %w", err)
@@ -1216,7 +1247,12 @@ func distillMonthly(ctx context.Context, cmd *cobra.Command, backend agentcli.Ba
 		return nil
 	}
 
-	prompt := agentcli.MonthlyPrompt(weeklySummaries, month, guidelines)
+	// Parse Sources sections from each weekly, merge into a unified citation
+	// list, renumber prose markers (gh #476). Same pattern as weekly.
+	rewrittenWeeklies, mergedCites := mergeCitationsFromMarkdown(weeklySummaries)
+	hasCitations := len(mergedCites) > 0
+
+	prompt := agentcli.MonthlyPrompt(rewrittenWeeklies, month, guidelines, hasCitations)
 	logPrompt(cmd, "monthly:"+month, prompt)
 	fmt.Fprintf(cmd.OutOrStdout(), "Synthesizing %d weekly summaries into monthly %s...\n", len(weeklySummaries), month)
 
@@ -1227,8 +1263,8 @@ func distillMonthly(ctx context.Context, cmd *cobra.Command, backend agentcli.Ba
 
 	muid, _ := uuid.NewV7() // error only if crypto/rand fails — zero UUID collision is acceptable
 	filePath := filepath.Join("memory", "monthly", month+"-"+muid.String()+".md")
-	content := fmt.Sprintf("# Monthly Memory — %s\n\n%s\n\n---\n*Synthesized from %d weekly summaries (%s)*\n",
-		month, output, len(weeklySummaries), strings.Join(weeklyFiles, ", "))
+	content := formatLayeredMemory("Monthly Memory", month, output, mergedCites,
+		fmt.Sprintf("Synthesized from %d weekly summaries (%s)", len(weeklySummaries), strings.Join(weeklyFiles, ", ")))
 
 	if err := writeMemoryFile(tc.Path, filePath, content); err != nil {
 		return fmt.Errorf("write monthly memory: %w", err)
@@ -1284,7 +1320,20 @@ func readRecentMemoryFiles(dir string, maxFiles int) ([]string, []string, error)
 	return contents, names, nil
 }
 
-func formatDailyMemory(date, content string, obsCount, factCount int, sources []string) string {
+// formatDailyMemory builds the on-disk daily summary file.
+//
+// The output has four parts:
+//  1. YAML frontmatter with `sources:` — the cache-index input list (file
+//     paths to observation/fact JSONLs that fed this distill, used by
+//     distill_index.distilledSources for dedup across runs)
+//  2. The "# Daily Memory — <date>" heading and LLM-generated body
+//  3. A "## Sources" section (gh #476) with numbered citations and
+//     reference-link definitions, so readers can drill down into the original
+//     discussion / PR / session
+//  4. The "*Distilled from N observations and M facts*" footer
+//
+// The Sources section is suppressed when there are no facts to cite.
+func formatDailyMemory(date, content string, obsCount, factCount int, sources []string, cites []citation) string {
 	var sb strings.Builder
 	if len(sources) > 0 {
 		sb.WriteString("---\nsources:\n")
@@ -1303,8 +1352,119 @@ func formatDailyMemory(date, content string, obsCount, factCount int, sources []
 	default:
 		source = fmt.Sprintf("%d observations", obsCount)
 	}
-	fmt.Fprintf(&sb, "# Daily Memory — %s\n\n%s\n\n---\n*Distilled from %s*\n", date, content, source)
+	fmt.Fprintf(&sb, "# Daily Memory — %s\n\n%s\n", date, strings.TrimRight(content, "\n"))
+	if section := renderSourcesSection(cites); section != "" {
+		sb.WriteString("\n")
+		sb.WriteString(section)
+	}
+	fmt.Fprintf(&sb, "\n---\n*Distilled from %s*\n", source)
 	return sb.String()
+}
+
+// loadDayFacts parses each fact file in entries and returns a flat slice of
+// facts plus the relative paths of files that contributed at least one fact.
+// Files that fail to parse are logged and skipped — the daily summary should
+// degrade gracefully rather than abort.
+func loadDayFacts(tcPath string, entries []discussionFactEntry) ([]facts.Fact, []string) {
+	var flat []facts.Fact
+	var paths []string
+	for _, entry := range entries {
+		_, parsedFacts, err := facts.ReadFacts(filepath.Join(tcPath, entry.RelPath))
+		if err != nil {
+			slog.Warn("skip unparseable fact file in daily distill", "path", entry.RelPath, "error", err)
+			continue
+		}
+		if len(parsedFacts) == 0 {
+			// empty marker file — record the path for the index but no facts to cite
+			paths = append(paths, entry.RelPath)
+			continue
+		}
+		flat = append(flat, parsedFacts...)
+		paths = append(paths, entry.RelPath)
+	}
+	return flat, paths
+}
+
+// buildFactCitationsForPrompt converts parsed facts into the FactCitation
+// shape that agentcli.DailyPrompt expects, attaching citation numbers from
+// factToCiteNum. Facts without a citation number (uncitable — no source
+// URL/ref) are omitted from the prompt entirely.
+func buildFactCitationsForPrompt(flat []facts.Fact, factToCiteNum map[int]int) []agentcli.FactCitation {
+	out := make([]agentcli.FactCitation, 0, len(flat))
+	for i, f := range flat {
+		num, ok := factToCiteNum[i]
+		if !ok {
+			continue
+		}
+		out = append(out, agentcli.FactCitation{
+			Num:         num,
+			Headline:    f.Headline,
+			Summary:     f.Summary,
+			Rationale:   f.Rationale,
+			Who:         f.Who,
+			SourceType:  f.SourceType,
+			SourceTitle: f.SourceTitle,
+			Date:        citationDate(f.Timestamp),
+			Category:    f.Category,
+		})
+	}
+	return out
+}
+
+// mergeCitationsFromMarkdown parses the "## Sources" section out of each
+// input markdown file, merges them into a unified deduplicated citation list,
+// and rewrites each input's prose markers from per-input numbering to the
+// unified numbering. Used by weekly and monthly distill stages (gh #476).
+//
+// Inputs without a Sources section pass through unchanged with no contribution
+// to the merged list.
+func mergeCitationsFromMarkdown(inputs []string) ([]string, []citation) {
+	mergeInputs := make([]mergeInput, len(inputs))
+	for i, in := range inputs {
+		mergeInputs[i] = mergeInput{
+			Text:  in,
+			Cites: parseSourcesSection(in),
+		}
+	}
+	return mergeCitations(mergeInputs)
+}
+
+// formatLayeredMemory builds a weekly or monthly memory file. Same shape as
+// formatDailyMemory but without the YAML frontmatter (weekly/monthly aren't
+// tracked in the cache index — they're regenerated from dailies/weeklies).
+func formatLayeredMemory(heading, label, body string, cites []citation, footer string) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s — %s\n\n%s\n", heading, label, strings.TrimRight(body, "\n"))
+	if section := renderSourcesSection(cites); section != "" {
+		sb.WriteString("\n")
+		sb.WriteString(section)
+	}
+	fmt.Fprintf(&sb, "\n---\n*%s*\n", footer)
+	return sb.String()
+}
+
+// observationSourcePaths returns the relative paths of observation files that
+// contributed to a daily distill. Used to track observations in the daily
+// frontmatter so the cache index can dedup them on subsequent runs (gh #476).
+// Falls back to absolute path if the file isn't under tcPath.
+func observationSourcePaths(tcPath string, obs []distillObservation) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, o := range obs {
+		if o.SourceFile == "" {
+			continue
+		}
+		rel, err := filepath.Rel(tcPath, o.SourceFile)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			rel = o.SourceFile // fall back to absolute path
+		}
+		if seen[rel] {
+			continue
+		}
+		seen[rel] = true
+		out = append(out, rel)
+	}
+	return out
 }
 
 // parseDailySources extracts source paths from YAML frontmatter in a daily summary.

--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -959,11 +959,22 @@ func extractSingleDiscussionFacts(ctx context.Context, cmd *cobra.Command, backe
 		return "", nil // no valid facts extracted
 	}
 
-	// LLM extractor doesn't know about citation links — fill in deterministic
-	// SourceURL/SourceTitle for every fact so the daily summary can cite them.
-	// (gh #476)
+	// LLM extractor doesn't reliably emit source_type / source_ref / URL —
+	// backfill all four source fields from the discussion's metadata so the
+	// daily citation pipeline (gh #476) can always render a citation, even
+	// when buildDiscussionURL returns empty (legacy / audio-only / missing
+	// team or endpoint). Without this backfill, those facts would have an
+	// empty source_ref and citationKey() would return empty, dropping them
+	// from the daily prompt entirely.
 	sourceURL := buildDiscussionURL(ep, teamID, d.RecordingID)
+	sourceRef := "discussions/" + d.DirName
 	for i := range parsedFacts {
+		if parsedFacts[i].SourceType == "" {
+			parsedFacts[i].SourceType = facts.SourceDiscussion
+		}
+		if parsedFacts[i].SourceRef == "" {
+			parsedFacts[i].SourceRef = sourceRef
+		}
 		if parsedFacts[i].SourceURL == "" {
 			parsedFacts[i].SourceURL = sourceURL
 		}

--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -1126,6 +1126,33 @@ func distillDaily(ctx context.Context, cmd *cobra.Command, backend agentcli.Back
 		// (gh #476). Citations are deduped by source URL/ref so multiple facts
 		// from the same discussion share one [N].
 		flatFacts, factOriginPaths := loadDayFacts(tc.Path, dayFacts)
+
+		// Empty-marker short-circuit (CodeRabbit round-2 #7): if all the day's
+		// fact files are empty markers AND there are no observations, the
+		// only thing distillation can do is hallucinate. Skip the LLM call
+		// and write a tiny placeholder daily so the marker file paths are
+		// recorded in the cache index — otherwise they'd get re-processed
+		// every run.
+		if len(flatFacts) == 0 && len(dayObs) == 0 {
+			id, err := uuid.NewV7()
+			if err != nil {
+				return fmt.Errorf("generate daily file ID: %w", err)
+			}
+			sources := append([]string(nil), factOriginPaths...)
+			filePath := filepath.Join("memory", "daily", day+"-"+id.String()+".md")
+			placeholder := "*No signal extracted for this day — only empty fact markers were present.*"
+			content := formatDailyMemory(day, placeholder, 0, 0, sources, nil)
+			if err := writeMemoryFile(tc.Path, filePath, content); err != nil {
+				return fmt.Errorf("write daily memory: %w", err)
+			}
+			if err := commitMemoryFile(tc.Path, filePath, fmt.Sprintf("memory: empty daily %s (markers only)", day)); err != nil {
+				slog.Warn("failed to commit empty daily memory", "error", err)
+			}
+			idx.addDailySummary(filePath, sources)
+			fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s (empty markers only — skipped AI coworker call)\n", filePath)
+			continue
+		}
+
 		cites, factToCiteNum := buildCitationsFromFacts(flatFacts)
 		citedFacts := buildFactCitationsForPrompt(flatFacts, factToCiteNum)
 

--- a/cmd/ox/distill_citations.go
+++ b/cmd/ox/distill_citations.go
@@ -1,0 +1,659 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/facts"
+)
+
+// citation is a single source we link from a distilled summary.
+//
+// One citation per unique source (deduped by URL when present, otherwise by
+// source_ref). The citation pipeline (gh #476) carries these through every
+// distill layer: facts → daily Sources section → weekly Sources section →
+// monthly Sources section. The Num field is layer-local — at each layer the
+// citation list is rebuilt from scratch and renumbered.
+type citation struct {
+	Num   int    // 1-based, used in [N] markers and ref-link definitions
+	Label string // human-friendly text (e.g., "Discussion: 2026-03-10 — Architecture sync")
+	URL   string // empty if no clickable URL is available — citation still rendered without link
+	Key   string // dedup key: URL if non-empty, else source_ref
+}
+
+// buildCitationsFromFacts builds a deduplicated, ordered citation list from
+// a flat slice of facts. Order is stable: timestamp ascending, then label lex.
+//
+// Returns the citation list AND a map from each fact's index in the input
+// slice to its citation number. Multiple facts that share the same source
+// (same dedup key) map to the same citation number.
+//
+// Facts with no resolvable source (no URL and no source_ref) are skipped —
+// they cannot be cited.
+func buildCitationsFromFacts(fs []facts.Fact) ([]citation, map[int]int) {
+	type pendingFact struct {
+		idx   int
+		fact  facts.Fact
+		key   string
+		label string
+	}
+
+	// first pass: compute key and label for each fact, skip uncitable
+	var pending []pendingFact
+	for i, f := range fs {
+		key := citationKey(f)
+		if key == "" {
+			continue
+		}
+		pending = append(pending, pendingFact{
+			idx:   i,
+			fact:  f,
+			key:   key,
+			label: citationLabel(f),
+		})
+	}
+
+	// dedup by key, keeping the earliest timestamp for ordering and the first label seen
+	type bucket struct {
+		key   string
+		label string
+		url   string
+		ts    string // earliest timestamp across grouped facts
+		idxs  []int  // input indices that belong to this bucket
+	}
+	bucketsByKey := make(map[string]*bucket)
+	var keyOrder []string
+	for _, p := range pending {
+		b, ok := bucketsByKey[p.key]
+		if !ok {
+			b = &bucket{
+				key:   p.key,
+				label: p.label,
+				url:   p.fact.SourceURL,
+				ts:    p.fact.Timestamp,
+			}
+			bucketsByKey[p.key] = b
+			keyOrder = append(keyOrder, p.key)
+		} else {
+			// keep the earliest timestamp so chronological ordering is stable
+			if p.fact.Timestamp != "" && (b.ts == "" || p.fact.Timestamp < b.ts) {
+				b.ts = p.fact.Timestamp
+			}
+			// promote a non-empty URL if we hadn't seen one
+			if b.url == "" && p.fact.SourceURL != "" {
+				b.url = p.fact.SourceURL
+			}
+		}
+		b.idxs = append(b.idxs, p.idx)
+	}
+
+	buckets := make([]*bucket, 0, len(bucketsByKey))
+	for _, k := range keyOrder {
+		buckets = append(buckets, bucketsByKey[k])
+	}
+	// stable sort: timestamp ascending, then label lex
+	sort.SliceStable(buckets, func(i, j int) bool {
+		if buckets[i].ts != buckets[j].ts {
+			return buckets[i].ts < buckets[j].ts
+		}
+		return buckets[i].label < buckets[j].label
+	})
+
+	cites := make([]citation, 0, len(buckets))
+	factToNum := make(map[int]int, len(pending))
+	for i, b := range buckets {
+		num := i + 1
+		cites = append(cites, citation{
+			Num:   num,
+			Label: b.label,
+			URL:   b.url,
+			Key:   b.key,
+		})
+		for _, idx := range b.idxs {
+			factToNum[idx] = num
+		}
+	}
+
+	return cites, factToNum
+}
+
+// citationKey returns the dedup key for a fact: URL if available, else source_ref.
+// Returns empty string for facts that cannot be cited (no URL, no ref).
+func citationKey(f facts.Fact) string {
+	if f.SourceURL != "" {
+		return f.SourceURL
+	}
+	return f.SourceRef
+}
+
+// citationLabel produces a short human-readable label for a citation.
+// Strategy depends on source type — see #476 design notes.
+func citationLabel(f facts.Fact) string {
+	date := citationDate(f.Timestamp)
+	switch f.SourceType {
+	case facts.SourceGitHub:
+		return githubShortLabel(f.SourceURL, f.SourceRef, f.SourceTitle)
+	case facts.SourceDiscussion:
+		title := f.SourceTitle
+		if title == "" {
+			title = trimDirnameDate(f.SourceRef)
+		}
+		if date != "" && title != "" {
+			return fmt.Sprintf("Discussion: %s — %s", date, title)
+		}
+		if title != "" {
+			return "Discussion: " + title
+		}
+		return "Discussion"
+	case facts.SourceSession:
+		title := f.SourceTitle
+		if title == "" {
+			title = trimDirnameDate(f.SourceRef)
+		}
+		if date != "" && title != "" {
+			return fmt.Sprintf("Session: %s — %s", date, title)
+		}
+		if title != "" {
+			return "Session: " + title
+		}
+		return "Session"
+	case facts.SourceObservation:
+		if date != "" {
+			return "Observation " + date
+		}
+		return "Observation"
+	}
+	// fallback: source_ref or generic label
+	if f.SourceTitle != "" {
+		return f.SourceTitle
+	}
+	if f.SourceRef != "" {
+		return f.SourceRef
+	}
+	return "Source"
+}
+
+// citationDate extracts a YYYY-MM-DD slice from an ISO 8601 timestamp.
+// Returns empty if the timestamp is empty or unparseable.
+func citationDate(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t.Format("2006-01-02")
+	}
+	// already a date?
+	if t, err := time.Parse("2006-01-02", ts); err == nil {
+		return t.Format("2006-01-02")
+	}
+	return ""
+}
+
+// trimDirnameDate strips a leading "<path>/" prefix and a "YYYY-MM-DD-HHMM-"
+// or "YYYY-MM-DDTHH-MM-" prefix from a dirname-style ref so the remainder
+// can be used as a label. Falls back to the original ref if no pattern matches.
+func trimDirnameDate(ref string) string {
+	if ref == "" {
+		return ""
+	}
+	// strip leading "type/" prefix (e.g. "discussions/", "sessions/")
+	if i := strings.IndexByte(ref, '/'); i >= 0 {
+		ref = ref[i+1:]
+	}
+	// session: YYYY-MM-DDTHH-MM-<who>-<id>
+	if m := sessionDirNameRe.FindStringSubmatch(ref); m != nil {
+		return m[2] // who-id portion
+	}
+	// discussion: YYYY-MM-DD-HHMM-<who>
+	if m := discussionDirNameRe.FindStringSubmatch(ref); m != nil {
+		return m[2]
+	}
+	return ref
+}
+
+var (
+	sessionDirNameRe    = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})T\d{2}-\d{2}-(.+)$`)
+	discussionDirNameRe = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})-\d{4}-(.+)$`)
+)
+
+// githubShortLabel converts a github URL to a short label like "owner/repo#152"
+// or "owner/repo@abc1234". Falls back to title or URL if parsing fails.
+//
+// Inputs:
+//   - urlStr: the URL to parse (preferred)
+//   - ref: source_ref (often the same as urlStr for github)
+//   - title: PR/issue title from source_title
+func githubShortLabel(urlStr, ref, title string) string {
+	if urlStr == "" {
+		urlStr = ref
+	}
+	if urlStr != "" {
+		if label := parseGitHubURLLabel(urlStr); label != "" {
+			return label
+		}
+	}
+	if title != "" {
+		return title
+	}
+	if ref != "" {
+		return ref
+	}
+	return "GitHub"
+}
+
+// parseGitHubURLLabel extracts a short label from a github URL. Supports:
+//   - https://github.com/<owner>/<repo>/pull/<n>   → owner/repo#n
+//   - https://github.com/<owner>/<repo>/issues/<n> → owner/repo#n
+//   - https://github.com/<owner>/<repo>/commit/<sha> → owner/repo@<sha[:7]>
+//
+// Returns empty string for unrecognized URL shapes.
+func parseGitHubURLLabel(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	if u.Host != "github.com" && !strings.HasSuffix(u.Host, ".github.com") {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 {
+		return ""
+	}
+	owner, repo, kind, id := parts[0], parts[1], parts[2], parts[3]
+	switch kind {
+	case "pull", "issues":
+		// strip non-numeric suffixes (e.g. /files, /commits) — only the number matters
+		if num, err := strconv.Atoi(id); err == nil {
+			return fmt.Sprintf("%s/%s#%d", owner, repo, num)
+		}
+	case "commit":
+		short := id
+		if len(short) > 7 {
+			short = short[:7]
+		}
+		return fmt.Sprintf("%s/%s@%s", owner, repo, short)
+	}
+	return ""
+}
+
+// citationMarkerRe matches a `[N]` token (bare reference OR the trailing `[N]`
+// of a `[anchor][N]` reference link). Captures the digits.
+//
+// We deliberately match a narrow shape — just `[<digits>]` — so the same regex
+// covers both citation forms. The trade-off is that any bracketed number in
+// the body matches, including incidental ones like `arr[10]` or `args[2]` if
+// they appear in code samples. To avoid corrupting code, renumberCitationMarkers
+// skips content inside fenced code blocks.
+var citationMarkerRe = regexp.MustCompile(`\[(\d+)\]`)
+
+// codeFenceRe matches a triple-backtick line (the start or end of a fenced
+// code block). The fence may have a language tag or trailing whitespace.
+var codeFenceRe = regexp.MustCompile("(?m)^```[^\n]*$")
+
+// inlineCodeRe matches a markdown inline code span: a single-backtick run
+// containing no backticks or newlines. Used to skip `arr[1]`-style content
+// during citation marker renumbering.
+//
+// Limitation: doesn't recognize multi-backtick spans (`` `` ` `` ``) — those
+// are rare in distilled prose. CommonMark allows them but our LLM output
+// doesn't emit them.
+var inlineCodeRe = regexp.MustCompile("`[^`\n]+`")
+
+// renumberCitationMarkers rewrites every `[N]` marker in text using oldToNew.
+// Numbers not in the map are left untouched (defensive — shouldn't happen in
+// practice, but we'd rather leave a stale marker than corrupt the document).
+//
+// Content inside markdown fenced code blocks (``` ... ```) AND inline code
+// spans (`...`) is left untouched, so bracketed numerics in code samples
+// like `arr[10]` are not corrupted.
+//
+// Both bare `[N]` and the trailing `[N]` of a `[anchor][N]` reference link
+// match the regex and get rewritten — that's exactly what we want.
+func renumberCitationMarkers(text string, oldToNew map[int]int) string {
+	if len(oldToNew) == 0 {
+		return text
+	}
+	rewrite := func(seg string) string {
+		return citationMarkerRe.ReplaceAllStringFunc(seg, func(match string) string {
+			// match is "[N]" — extract N
+			inner := match[1 : len(match)-1]
+			old, err := strconv.Atoi(inner)
+			if err != nil {
+				return match
+			}
+			new, ok := oldToNew[old]
+			if !ok {
+				return match
+			}
+			return fmt.Sprintf("[%d]", new)
+		})
+	}
+	// Skip both fenced blocks and inline code spans. Inline-code skipping is
+	// done as a second-level walk inside each non-fenced segment.
+	return walkOutsideCodeFences(text, func(seg string) string {
+		return walkOutsideInlineCode(seg, rewrite)
+	})
+}
+
+// walkOutsideInlineCode applies fn to every part of seg that is OUTSIDE an
+// inline backtick code span, leaving spans verbatim. Used by
+// renumberCitationMarkers to avoid renumbering bracketed numerics in
+// inline-code samples like `arr[1]`.
+func walkOutsideInlineCode(seg string, fn func(string) string) string {
+	spans := inlineCodeRe.FindAllStringIndex(seg, -1)
+	if len(spans) == 0 {
+		return fn(seg)
+	}
+	var sb strings.Builder
+	cursor := 0
+	for _, sp := range spans {
+		sb.WriteString(fn(seg[cursor:sp[0]]))
+		sb.WriteString(seg[sp[0]:sp[1]]) // inline code verbatim
+		cursor = sp[1]
+	}
+	sb.WriteString(fn(seg[cursor:]))
+	return sb.String()
+}
+
+// walkOutsideCodeFences applies fn to every section of text that's OUTSIDE a
+// fenced code block, leaving fenced sections verbatim. Fences are matched on
+// their own line (per CommonMark) by codeFenceRe.
+//
+// If the text has an odd number of fences (unterminated block), everything
+// after the last fence is treated as code and left alone.
+func walkOutsideCodeFences(text string, fn func(string) string) string {
+	fences := codeFenceRe.FindAllStringIndex(text, -1)
+	if len(fences) == 0 {
+		return fn(text)
+	}
+	var sb strings.Builder
+	cursor := 0
+	insideCode := false
+	for _, m := range fences {
+		// segment from cursor to fence start
+		if !insideCode {
+			sb.WriteString(fn(text[cursor:m[0]]))
+		} else {
+			sb.WriteString(text[cursor:m[0]])
+		}
+		// the fence line itself: write verbatim (it's structural markdown)
+		sb.WriteString(text[m[0]:m[1]])
+		cursor = m[1]
+		insideCode = !insideCode
+	}
+	// tail after the last fence
+	if !insideCode {
+		sb.WriteString(fn(text[cursor:]))
+	} else {
+		// unterminated fence — leave verbatim to avoid corrupting code
+		sb.WriteString(text[cursor:])
+	}
+	return sb.String()
+}
+
+// renderSourcesSection produces the Sources block appended to every distilled
+// summary file. Format:
+//
+//	## Sources
+//
+//	1. [Discussion: 2026-03-10 — Architecture sync][1]
+//	2. [sageox/ox#152][2]
+//	3. Session: 2026-03-11 — stateless refactor   ← no URL, no link
+//
+//	[1]: https://sageox.ai/team/team_xxx/media/recordings/rec_yyy
+//	[2]: https://github.com/sageox/ox/pull/152
+//
+// The numbered list is the human-scannable index. The reference definitions
+// underneath let `[anchor][N]` and bare `[N]` markers in the body resolve to
+// real links. Entries without a URL render as plain text — still cited, just
+// not clickable.
+//
+// Returns empty string if cites is empty (caller suppresses the section
+// entirely in that case).
+func renderSourcesSection(cites []citation) string {
+	if len(cites) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("## Sources\n\n")
+	// numbered list
+	for _, c := range cites {
+		if c.URL != "" {
+			fmt.Fprintf(&sb, "%d. [%s][%d]\n", c.Num, escapeMarkdownLinkText(c.Label), c.Num)
+		} else {
+			fmt.Fprintf(&sb, "%d. %s\n", c.Num, c.Label)
+		}
+	}
+	// reference link definitions (only for cites with a URL)
+	hasURL := false
+	for _, c := range cites {
+		if c.URL != "" {
+			hasURL = true
+			break
+		}
+	}
+	if hasURL {
+		sb.WriteString("\n")
+		for _, c := range cites {
+			if c.URL == "" {
+				continue
+			}
+			fmt.Fprintf(&sb, "[%d]: %s\n", c.Num, c.URL)
+		}
+	}
+	return sb.String()
+}
+
+// escapeMarkdownLinkText escapes the closing bracket so labels containing `]`
+// don't break the markdown link syntax. We don't need to escape `[` because
+// markdown only requires escaping the closer.
+func escapeMarkdownLinkText(s string) string {
+	return strings.ReplaceAll(s, "]", `\]`)
+}
+
+// parseSourcesSection extracts citation entries from a "## Sources" section
+// previously written by renderSourcesSection. Returns nil if no Sources
+// section is present in the input markdown.
+//
+// Used by the weekly/monthly distill stages: each layer parses the previous
+// layer's Sources, merges them, renumbers, and emits a fresh Sources section.
+//
+// Tolerant parser: numbered entries with reference-style links are parsed
+// fully; bare-text entries (no URL) are parsed with empty URL; malformed
+// lines are skipped.
+func parseSourcesSection(md string) []citation {
+	// locate "## Sources" header
+	const header = "## Sources"
+	headerIdx := strings.Index(md, header)
+	if headerIdx == -1 {
+		return nil
+	}
+	// take everything from header to next "## " heading or end of file
+	rest := md[headerIdx+len(header):]
+	if next := nextH2HeadingIndex(rest); next >= 0 {
+		rest = rest[:next]
+	}
+
+	// collect URL definitions: [N]: url
+	urls := make(map[int]string)
+	for _, line := range strings.Split(rest, "\n") {
+		line = strings.TrimSpace(line)
+		if m := refLinkDefRe.FindStringSubmatch(line); m != nil {
+			if num, err := strconv.Atoi(m[1]); err == nil {
+				urls[num] = m[2]
+			}
+		}
+	}
+
+	// collect numbered list entries: "1. [label][N]" or "1. label"
+	var cites []citation
+	for _, line := range strings.Split(rest, "\n") {
+		line = strings.TrimSpace(line)
+		if m := numberedRefEntryRe.FindStringSubmatch(line); m != nil {
+			num, _ := strconv.Atoi(m[1])
+			label := unescapeMarkdownLinkText(m[2])
+			refNum, _ := strconv.Atoi(m[3])
+			url := urls[refNum]
+			// If the matching ref definition is missing (malformed input),
+			// fall back to a synthetic label-based key so dedup still works
+			// — never leave Key empty for downstream callers.
+			key := url
+			if key == "" {
+				key = "label:" + label
+			}
+			cites = append(cites, citation{
+				Num:   num,
+				Label: label,
+				URL:   url,
+				Key:   key,
+			})
+			continue
+		}
+		if m := numberedPlainEntryRe.FindStringSubmatch(line); m != nil {
+			num, _ := strconv.Atoi(m[1])
+			label := strings.TrimSpace(m[2])
+			cites = append(cites, citation{
+				Num:   num,
+				Label: label,
+				Key:   "label:" + label, // synthetic key for label-only entries
+			})
+		}
+	}
+	return cites
+}
+
+var (
+	// refLinkDefRe matches `[N]: url`
+	refLinkDefRe = regexp.MustCompile(`^\[(\d+)\]:\s*(\S+)\s*$`)
+	// numberedRefEntryRe matches `1. [label][N]`. Label uses a non-greedy
+	// negated character class so labels containing `\]` (the escape produced
+	// by escapeMarkdownLinkText) parse correctly.
+	numberedRefEntryRe = regexp.MustCompile(`^(\d+)\.\s+\[((?:\\\]|[^\]])+)\]\[(\d+)\]\s*$`)
+	// numberedPlainEntryRe matches `1. plain text label` (no link)
+	numberedPlainEntryRe = regexp.MustCompile(`^(\d+)\.\s+(.+)$`)
+)
+
+func unescapeMarkdownLinkText(s string) string {
+	return strings.ReplaceAll(s, `\]`, "]")
+}
+
+// nextH2HeadingIndex returns the byte offset of the next "## " heading in s,
+// or -1 if none. Looks for a "##" at the start of a line followed by a space.
+func nextH2HeadingIndex(s string) int {
+	// search for "\n## " — the simple case. Also handle the edge where the
+	// next heading is at the very start of the slice (shouldn't happen since
+	// we just consumed "## Sources", but harmless).
+	if i := strings.Index(s, "\n## "); i >= 0 {
+		return i
+	}
+	return -1
+}
+
+// mergeInput is one (text, citations) pair fed into mergeCitations. Used by
+// the weekly and monthly distill stages: each daily/weekly is parsed into
+// one of these and the slice is merged into a unified global citation list.
+type mergeInput struct {
+	Text  string     // the input text — citation markers will be renumbered
+	Cites []citation // citations parsed from the input's "## Sources" section
+}
+
+// mergeCitations takes a slice of (text, citations) pairs from a previous layer
+// and produces:
+//   - a slice of rewritten input texts with citation markers renumbered to a
+//     unified global numbering
+//   - the merged, deduplicated, renumbered global citation list
+//
+// Dedup is by citation Key (URL if present, else label-synthetic key). Order
+// in the merged list is preserved by first appearance.
+//
+// **Forward-upgrade dedup**: a citation can appear in one input as label-only
+// (`Key: "label:Foo"`, no URL) and in a later input as URL-keyed
+// (`Key: "https://..."`) — this happens during a mid-release upgrade where
+// older daily files were generated before #476 added source URLs and newer
+// daily files have them. When a LATER input has the same label AND a URL, we
+// promote the earlier label-only entry to use that URL and dedupe under the
+// URL key. The old label key is intentionally retained in keyToGlobalNum so
+// the second pass can still renumber the earlier input's bare markers.
+//
+// We deliberately do NOT do the reverse: a label-only citation that appears
+// AFTER a URL-keyed one with the same label is kept as a separate entry,
+// because label collisions are real (two PRs titled "Add rate limiting" in
+// different repos). The forward direction is safe because pre-#476 daily
+// files have no URLs at all — every label-only entry necessarily predates
+// any URL-keyed entry for the same source. Reversed-direction "duplicates"
+// can only arise from genuinely different sources sharing a label.
+//
+// This is the core of the weekly/monthly citation propagation logic. The LLM
+// at each layer never has to do arithmetic — it just preserves whatever
+// numbers it sees in the input.
+func mergeCitations(inputs []mergeInput) ([]string, []citation) {
+	// build the merged citation list, first-appearance ordered, deduped by key
+	var merged []citation
+	keyToGlobalNum := make(map[string]int)
+	// labelToGlobalNum lets us promote a label-only first-seen entry to use a
+	// URL key when a later input provides the URL for the same label.
+	labelToGlobalNum := make(map[string]int)
+	for _, in := range inputs {
+		for _, c := range in.Cites {
+			if c.Key == "" {
+				c.Key = "label:" + c.Label
+			}
+			if _, exists := keyToGlobalNum[c.Key]; exists {
+				continue
+			}
+			// Upgrade path: this is a URL-keyed citation, but we previously
+			// saw the same label as label-only. Promote the existing entry
+			// to the URL and dedupe under both keys.
+			//
+			// IMPORTANT: keep the OLD label key in keyToGlobalNum pointing at
+			// the same globalNum so that the second pass (renumbering markers
+			// in earlier inputs) can still resolve the label-only key. Without
+			// this, an earlier input's `[K]` marker for the label-only Foo
+			// would silently become a stale number pointing at the wrong cite.
+			if c.URL != "" {
+				if existingNum, ok := labelToGlobalNum[c.Label]; ok {
+					existing := &merged[existingNum-1]
+					if existing.URL == "" {
+						// promote the existing label-only entry to use the URL
+						existing.URL = c.URL
+						existing.Key = c.Key
+						keyToGlobalNum[c.Key] = existingNum
+						// (old label key intentionally retained)
+						continue
+					}
+				}
+			}
+			globalNum := len(merged) + 1
+			keyToGlobalNum[c.Key] = globalNum
+			labelToGlobalNum[c.Label] = globalNum
+			merged = append(merged, citation{
+				Num:   globalNum,
+				Label: c.Label,
+				URL:   c.URL,
+				Key:   c.Key,
+			})
+		}
+	}
+
+	// rewrite each input's markers from local-to-input numbers to global numbers
+	rewritten := make([]string, len(inputs))
+	for i, in := range inputs {
+		oldToNew := make(map[int]int, len(in.Cites))
+		for _, c := range in.Cites {
+			key := c.Key
+			if key == "" {
+				key = "label:" + c.Label
+			}
+			if global, ok := keyToGlobalNum[key]; ok {
+				oldToNew[c.Num] = global
+			}
+		}
+		rewritten[i] = renumberCitationMarkers(in.Text, oldToNew)
+	}
+	return rewritten, merged
+}

--- a/cmd/ox/distill_citations.go
+++ b/cmd/ox/distill_citations.go
@@ -706,22 +706,27 @@ type mergeInput struct {
 // Dedup is by citation Key (URL if present, else label-synthetic key). Order
 // in the merged list is preserved by first appearance.
 //
-// **Forward-upgrade dedup**: a citation can appear in one input as label-only
-// (`Key: "label:Foo"`, no URL) and in a later input as URL-keyed
-// (`Key: "https://..."`) — this happens during a mid-release upgrade where
-// older daily files were generated before #476 added source URLs and newer
-// daily files have them. When a LATER input has the same label AND a URL, we
-// promote the earlier label-only entry to use that URL and dedupe under the
-// URL key. The old label key is intentionally retained in keyToGlobalNum so
-// the second pass can still renumber the earlier input's bare markers.
+// **Forward-upgrade dedup (synthetic labels only)**: a citation can appear
+// in one input as a SYNTHETIC label-only entry (`Key: "label:Foo"`, no URL,
+// no stable identifier — the shape produced by pre-#476 daily files) and in
+// a later input as URL-keyed (`Key: "https://..."`). When that happens, we
+// promote the synthetic entry to use the URL and dedupe under the URL key.
+// The old synthetic label key is intentionally retained in keyToGlobalNum
+// so the second pass can still renumber the earlier input's bare markers.
 //
-// We deliberately do NOT do the reverse: a label-only citation that appears
-// AFTER a URL-keyed one with the same label is kept as a separate entry,
-// because label collisions are real (two PRs titled "Add rate limiting" in
-// different repos). The forward direction is safe because pre-#476 daily
-// files have no URLs at all — every label-only entry necessarily predates
-// any URL-keyed entry for the same source. Reversed-direction "duplicates"
-// can only arise from genuinely different sources sharing a label.
+// We do NOT promote stable-keyed label-only entries (e.g., `Key:
+// "discussions/2026-03-10-1000-alice"`) by label match. Two distinct
+// discussions can share a title — promoting by label alone would attach a
+// URL to the wrong source. Once a citation has a stable key from its
+// origin, it stays distinct unless the keys themselves match.
+//
+// We also do NOT do the reverse direction: a label-only citation that
+// appears AFTER a URL-keyed one with the same label is kept as a separate
+// entry, because label collisions are real (two PRs titled "Add rate
+// limiting" in different repos). The forward direction for synthetic labels
+// is only safe because pre-#476 daily files have no URLs OR stable keys at
+// all — every synthetic-label entry necessarily predates any URL-keyed
+// entry for the same source.
 //
 // This is the core of the weekly/monthly citation propagation logic. The LLM
 // at each layer never has to do arithmetic — it just preserves whatever
@@ -730,9 +735,17 @@ func mergeCitations(inputs []mergeInput) ([]string, []citation) {
 	// build the merged citation list, first-appearance ordered, deduped by key
 	var merged []citation
 	keyToGlobalNum := make(map[string]int)
-	// labelToGlobalNum lets us promote a label-only first-seen entry to use a
-	// URL key when a later input provides the URL for the same label.
-	labelToGlobalNum := make(map[string]int)
+	// syntheticLabelToGlobalNum tracks ONLY entries whose Key is a synthetic
+	// "label:..." form (legacy daily files written before #476 added stable
+	// keys to label-only citations). These are the only entries safe to
+	// upgrade by label match — entries with stable keys are NOT touched
+	// because the label alone can't disambiguate between them.
+	//
+	// Example of why this matters: two distinct discussions with the same
+	// title (key=discussions/A and key=discussions/B), then a later URL-backed
+	// citation with the same title. We have NO information linking the URL
+	// to A vs B, so we must NOT promote either of them by label alone.
+	syntheticLabelToGlobalNum := make(map[string]int)
 	for _, in := range inputs {
 		for _, c := range in.Cites {
 			if c.Key == "" {
@@ -742,8 +755,8 @@ func mergeCitations(inputs []mergeInput) ([]string, []citation) {
 				continue
 			}
 			// Upgrade path: this is a URL-keyed citation, but we previously
-			// saw the same label as label-only. Promote the existing entry
-			// to the URL and dedupe under both keys.
+			// saw the same label as a SYNTHETIC label-only entry (no stable
+			// key). Promote that synthetic entry to use the URL.
 			//
 			// IMPORTANT: keep the OLD label key in keyToGlobalNum pointing at
 			// the same globalNum so that the second pass (renumbering markers
@@ -751,21 +764,30 @@ func mergeCitations(inputs []mergeInput) ([]string, []citation) {
 			// this, an earlier input's `[K]` marker for the label-only Foo
 			// would silently become a stale number pointing at the wrong cite.
 			if c.URL != "" {
-				if existingNum, ok := labelToGlobalNum[c.Label]; ok {
+				if existingNum, ok := syntheticLabelToGlobalNum[c.Label]; ok {
 					existing := &merged[existingNum-1]
-					if existing.URL == "" {
-						// promote the existing label-only entry to use the URL
+					if existing.URL == "" && strings.HasPrefix(existing.Key, "label:") {
+						// promote the synthetic label-only entry to use the URL
 						existing.URL = c.URL
 						existing.Key = c.Key
 						keyToGlobalNum[c.Key] = existingNum
-						// (old label key intentionally retained)
+						// (old synthetic label key intentionally retained)
+						// Drop the label→num index now that the synthetic
+						// slot has been consumed; future URL entries with
+						// the same label must NOT promote it again.
+						delete(syntheticLabelToGlobalNum, c.Label)
 						continue
 					}
 				}
 			}
 			globalNum := len(merged) + 1
 			keyToGlobalNum[c.Key] = globalNum
-			labelToGlobalNum[c.Label] = globalNum
+			// Only synthetic label-only entries are eligible for future
+			// label-based promotion. Stable-keyed and URL-keyed entries are
+			// NOT recorded here.
+			if strings.HasPrefix(c.Key, "label:") && c.URL == "" {
+				syntheticLabelToGlobalNum[c.Label] = globalNum
+			}
 			merged = append(merged, citation{
 				Num:   globalNum,
 				Label: c.Label,

--- a/cmd/ox/distill_citations.go
+++ b/cmd/ox/distill_citations.go
@@ -449,11 +449,15 @@ func renderSourcesSection(cites []citation) string {
 	return sb.String()
 }
 
-// escapeMarkdownLinkText escapes the closing bracket so labels containing `]`
-// don't break the markdown link syntax. We don't need to escape `[` because
-// markdown only requires escaping the closer.
+// escapeMarkdownLinkText escapes both `[` and `]` so labels containing either
+// bracket don't break the markdown link syntax. A label like `Foo [bar]` would
+// otherwise turn into `[Foo [bar\]][1]`, which markdown parsers see as a nested
+// link and render incorrectly. Escaping both ends keeps the link clickable.
 func escapeMarkdownLinkText(s string) string {
-	return strings.ReplaceAll(s, "]", `\]`)
+	return strings.NewReplacer(
+		`[`, `\[`,
+		`]`, `\]`,
+	).Replace(s)
 }
 
 // parseSourcesSection extracts citation entries from a "## Sources" section
@@ -467,14 +471,14 @@ func escapeMarkdownLinkText(s string) string {
 // fully; bare-text entries (no URL) are parsed with empty URL; malformed
 // lines are skipped.
 func parseSourcesSection(md string) []citation {
-	// locate "## Sources" header
-	const header = "## Sources"
-	headerIdx := strings.Index(md, header)
-	if headerIdx == -1 {
+	// locate the "## Sources" line — anchored to a real heading rather than
+	// a raw substring so a body that mentions "## Sources" in prose / code
+	// doesn't trick the parser into slicing the wrong region.
+	loc := sourcesHeadingRe.FindStringIndex(md)
+	if loc == nil {
 		return nil
 	}
-	// take everything from header to next "## " heading or end of file
-	rest := md[headerIdx+len(header):]
+	rest := md[loc[1]:]
 	if next := nextH2HeadingIndex(rest); next >= 0 {
 		rest = rest[:next]
 	}
@@ -528,18 +532,26 @@ func parseSourcesSection(md string) []citation {
 }
 
 var (
+	// sourcesHeadingRe matches a real `## Sources` heading on its own line.
+	// Multi-line mode + `\s*$` allows trailing whitespace but rejects any
+	// non-heading occurrence of the literal in body text.
+	sourcesHeadingRe = regexp.MustCompile(`(?m)^## Sources\s*$`)
 	// refLinkDefRe matches `[N]: url`
 	refLinkDefRe = regexp.MustCompile(`^\[(\d+)\]:\s*(\S+)\s*$`)
-	// numberedRefEntryRe matches `1. [label][N]`. Label uses a non-greedy
-	// negated character class so labels containing `\]` (the escape produced
-	// by escapeMarkdownLinkText) parse correctly.
-	numberedRefEntryRe = regexp.MustCompile(`^(\d+)\.\s+\[((?:\\\]|[^\]])+)\]\[(\d+)\]\s*$`)
+	// numberedRefEntryRe matches `1. [label][N]`. Label accepts escaped
+	// brackets `\[` and `\]` (produced by escapeMarkdownLinkText) plus any
+	// non-bracket character. Without the escape branch, a label like
+	// `Foo \[bar\]` would terminate the label early at the unescaped close.
+	numberedRefEntryRe = regexp.MustCompile(`^(\d+)\.\s+\[((?:\\\[|\\\]|[^\[\]])+)\]\[(\d+)\]\s*$`)
 	// numberedPlainEntryRe matches `1. plain text label` (no link)
 	numberedPlainEntryRe = regexp.MustCompile(`^(\d+)\.\s+(.+)$`)
 )
 
 func unescapeMarkdownLinkText(s string) string {
-	return strings.ReplaceAll(s, `\]`, "]")
+	return strings.NewReplacer(
+		`\[`, `[`,
+		`\]`, `]`,
+	).Replace(s)
 }
 
 // nextH2HeadingIndex returns the byte offset of the next "## " heading in s,

--- a/cmd/ox/distill_citations.go
+++ b/cmd/ox/distill_citations.go
@@ -403,7 +403,7 @@ func walkOutsideCodeFences(text string, fn func(string) string) string {
 //
 //	1. [Discussion: 2026-03-10 — Architecture sync][1]
 //	2. [sageox/ox#152][2]
-//	3. Session: 2026-03-11 — stateless refactor   ← no URL, no link
+//	3. Session: 2026-03-11 — stateless refactor <!-- ref:sessions/2026-03-11T09-00-ryan-Oxabcd -->
 //
 //	[1]: https://sageox.ai/team/team_xxx/media/recordings/rec_yyy
 //	[2]: https://github.com/sageox/ox/pull/152
@@ -412,6 +412,14 @@ func walkOutsideCodeFences(text string, fn func(string) string) string {
 // underneath let `[anchor][N]` and bare `[N]` markers in the body resolve to
 // real links. Entries without a URL render as plain text — still cited, just
 // not clickable.
+//
+// Label-only entries (no URL) get a trailing HTML comment containing the
+// citation Key (typically the source_ref like `sessions/<dirname>` or
+// `discussions/<dirname>`). Most markdown renderers strip HTML comments, so
+// the human reader sees only the label — but parseSourcesSection reads the
+// comment back to recover the stable identifier. Without this, two distinct
+// label-only sources that happen to share a label (e.g., two short
+// discussion titles) would collapse during weekly/monthly merging.
 //
 // Returns empty string if cites is empty (caller suppresses the section
 // entirely in that case).
@@ -426,7 +434,14 @@ func renderSourcesSection(cites []citation) string {
 		if c.URL != "" {
 			fmt.Fprintf(&sb, "%d. [%s][%d]\n", c.Num, escapeMarkdownLinkText(c.Label), c.Num)
 		} else {
-			fmt.Fprintf(&sb, "%d. %s\n", c.Num, c.Label)
+			// label-only: append a hidden ref comment so the parser can
+			// recover the stable Key on round-trip. Skip the comment if the
+			// Key looks like the synthetic "label:..." form (no useful info).
+			if c.Key != "" && !strings.HasPrefix(c.Key, "label:") {
+				fmt.Fprintf(&sb, "%d. %s <!-- ref:%s -->\n", c.Num, c.Label, c.Key)
+			} else {
+				fmt.Fprintf(&sb, "%d. %s\n", c.Num, c.Label)
+			}
 		}
 	}
 	// reference link definitions (only for cites with a URL)
@@ -495,18 +510,29 @@ func parseSourcesSection(md string) []citation {
 	}
 
 	// collect numbered list entries: "1. [label][N]" or "1. label"
+	// Each line may end with a hidden ` <!-- ref:<key> -->` comment carrying
+	// a stable identifier (e.g., source_ref) for label-only entries. Strip
+	// it before matching the line so the regexes don't have to know about it.
 	var cites []citation
 	for _, line := range strings.Split(rest, "\n") {
 		line = strings.TrimSpace(line)
+		var refKey string
+		if m := refCommentRe.FindStringSubmatchIndex(line); m != nil {
+			refKey = strings.TrimSpace(line[m[2]:m[3]])
+			line = strings.TrimSpace(line[:m[0]])
+		}
 		if m := numberedRefEntryRe.FindStringSubmatch(line); m != nil {
 			num, _ := strconv.Atoi(m[1])
 			label := unescapeMarkdownLinkText(m[2])
 			refNum, _ := strconv.Atoi(m[3])
 			url := urls[refNum]
-			// If the matching ref definition is missing (malformed input),
-			// fall back to a synthetic label-based key so dedup still works
-			// — never leave Key empty for downstream callers.
-			key := url
+			// Key priority: hidden ref comment > URL > label fallback. The
+			// comment wins when present so a label-only entry that was
+			// later upgraded to URL still has a stable Key from its origin.
+			key := refKey
+			if key == "" {
+				key = url
+			}
 			if key == "" {
 				key = "label:" + label
 			}
@@ -521,10 +547,19 @@ func parseSourcesSection(md string) []citation {
 		if m := numberedPlainEntryRe.FindStringSubmatch(line); m != nil {
 			num, _ := strconv.Atoi(m[1])
 			label := strings.TrimSpace(m[2])
+			// Prefer the hidden ref comment as the Key so two distinct
+			// label-only sources that share a label don't collapse during
+			// cross-layer merging. Falls back to "label:" only when no
+			// comment was present (legacy daily files written before this
+			// change, or render paths that didn't have a Key).
+			key := refKey
+			if key == "" {
+				key = "label:" + label
+			}
 			cites = append(cites, citation{
 				Num:   num,
 				Label: label,
-				Key:   "label:" + label, // synthetic key for label-only entries
+				Key:   key,
 			})
 		}
 	}
@@ -545,6 +580,10 @@ var (
 	numberedRefEntryRe = regexp.MustCompile(`^(\d+)\.\s+\[((?:\\\[|\\\]|[^\[\]])+)\]\[(\d+)\]\s*$`)
 	// numberedPlainEntryRe matches `1. plain text label` (no link)
 	numberedPlainEntryRe = regexp.MustCompile(`^(\d+)\.\s+(.+)$`)
+	// refCommentRe matches a trailing ` <!-- ref:<key> -->` HTML comment
+	// used to carry a stable Key for label-only citation entries across
+	// render→parse cycles (CodeRabbit round-2 feedback).
+	refCommentRe = regexp.MustCompile(`\s*<!--\s*ref:([^>]*?)\s*-->\s*$`)
 )
 
 func unescapeMarkdownLinkText(s string) string {

--- a/cmd/ox/distill_citations.go
+++ b/cmd/ox/distill_citations.go
@@ -63,26 +63,31 @@ func buildCitationsFromFacts(fs []facts.Fact) ([]citation, map[int]int) {
 		key   string
 		label string
 		url   string
-		ts    string // earliest timestamp across grouped facts
-		idxs  []int  // input indices that belong to this bucket
+		ts    time.Time // earliest parsed timestamp; zero if no fact had a parseable one
+		idxs  []int     // input indices that belong to this bucket
 	}
 	bucketsByKey := make(map[string]*bucket)
 	var keyOrder []string
 	for _, p := range pending {
+		// Parse the fact's timestamp into a real time.Time so multi-offset
+		// RFC3339 inputs sort chronologically. Lexical comparison of raw
+		// strings would order "2026-03-10T15:00:00-05:00" (20:00 UTC) BEFORE
+		// "2026-03-10T13:00:00-07:00" (20:00 UTC) — same instant, wrong shape.
+		factTime := parseFactTimestamp(p.fact.Timestamp)
 		b, ok := bucketsByKey[p.key]
 		if !ok {
 			b = &bucket{
 				key:   p.key,
 				label: p.label,
 				url:   p.fact.SourceURL,
-				ts:    p.fact.Timestamp,
+				ts:    factTime,
 			}
 			bucketsByKey[p.key] = b
 			keyOrder = append(keyOrder, p.key)
 		} else {
 			// keep the earliest timestamp so chronological ordering is stable
-			if p.fact.Timestamp != "" && (b.ts == "" || p.fact.Timestamp < b.ts) {
-				b.ts = p.fact.Timestamp
+			if !factTime.IsZero() && (b.ts.IsZero() || factTime.Before(b.ts)) {
+				b.ts = factTime
 			}
 			// promote a non-empty URL if we hadn't seen one
 			if b.url == "" && p.fact.SourceURL != "" {
@@ -96,10 +101,11 @@ func buildCitationsFromFacts(fs []facts.Fact) ([]citation, map[int]int) {
 	for _, k := range keyOrder {
 		buckets = append(buckets, bucketsByKey[k])
 	}
-	// stable sort: timestamp ascending, then label lex
+	// stable sort: timestamp ascending (parsed), then label lex.
+	// Zero timestamps sort first so untimestamped facts cluster at the top.
 	sort.SliceStable(buckets, func(i, j int) bool {
-		if buckets[i].ts != buckets[j].ts {
-			return buckets[i].ts < buckets[j].ts
+		if !buckets[i].ts.Equal(buckets[j].ts) {
+			return buckets[i].ts.Before(buckets[j].ts)
 		}
 		return buckets[i].label < buckets[j].label
 	})
@@ -181,17 +187,32 @@ func citationLabel(f facts.Fact) string {
 // citationDate extracts a YYYY-MM-DD slice from an ISO 8601 timestamp.
 // Returns empty if the timestamp is empty or unparseable.
 func citationDate(ts string) string {
-	if ts == "" {
-		return ""
-	}
-	if t, err := time.Parse(time.RFC3339, ts); err == nil {
-		return t.Format("2006-01-02")
-	}
-	// already a date?
-	if t, err := time.Parse("2006-01-02", ts); err == nil {
+	if t := parseFactTimestamp(ts); !t.IsZero() {
 		return t.Format("2006-01-02")
 	}
 	return ""
+}
+
+// parseFactTimestamp parses a fact's Timestamp field into a time.Time.
+// Accepts RFC3339 (with any offset) and bare YYYY-MM-DD. Returns zero time
+// for empty / unparseable input — chronological sort callers should treat
+// zero as "earliest" or "unknown".
+//
+// Lexical comparison of raw RFC3339 strings is wrong for mixed-offset inputs
+// (e.g., "...T15:00:00-05:00" and "...T13:00:00-07:00" are the same instant
+// but sort apart), so callers needing chronological order MUST go through
+// this helper, not direct string comparison.
+func parseFactTimestamp(ts string) time.Time {
+	if ts == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t.UTC()
+	}
+	if t, err := time.Parse("2006-01-02", ts); err == nil {
+		return t.UTC()
+	}
+	return time.Time{}
 }
 
 // trimDirnameDate strips a leading "<path>/" prefix and a "YYYY-MM-DD-HHMM-"
@@ -340,6 +361,47 @@ func renumberCitationMarkers(text string, oldToNew map[int]int) string {
 	})
 }
 
+// findSourcesHeadingEnd returns the byte offset just AFTER the first
+// `## Sources` heading line that lies OUTSIDE any fenced code block.
+// Returns -1 if no real heading is found.
+//
+// A body that quotes the distilled format in a markdown code sample (e.g.,
+// agent guidance describing the format) would otherwise produce a
+// false-positive match inside the fence and slice from the wrong region.
+func findSourcesHeadingEnd(md string) int {
+	// Scan line by line so we can track fence state cheaply. CommonMark
+	// fences are recognized only at the start of a line.
+	cursor := 0
+	insideCode := false
+	for cursor < len(md) {
+		nl := strings.IndexByte(md[cursor:], '\n')
+		var line string
+		var lineEnd int
+		if nl < 0 {
+			line = md[cursor:]
+			lineEnd = len(md)
+		} else {
+			line = md[cursor : cursor+nl]
+			lineEnd = cursor + nl + 1
+		}
+		// fence toggle: a line starting with ``` (CommonMark fence)
+		if strings.HasPrefix(line, "```") {
+			insideCode = !insideCode
+		} else if !insideCode {
+			// match the heading shape ourselves: "## Sources" possibly
+			// followed by trailing whitespace.
+			if line == "## Sources" || (strings.HasPrefix(line, "## Sources") && strings.TrimSpace(line[len("## Sources"):]) == "") {
+				if nl < 0 {
+					return len(md)
+				}
+				return cursor + nl + 1 // position right after the newline
+			}
+		}
+		cursor = lineEnd
+	}
+	return -1
+}
+
 // walkOutsideInlineCode applies fn to every part of seg that is OUTSIDE an
 // inline backtick code span, leaving spans verbatim. Used by
 // renumberCitationMarkers to avoid renumbering bracketed numerics in
@@ -486,14 +548,15 @@ func escapeMarkdownLinkText(s string) string {
 // fully; bare-text entries (no URL) are parsed with empty URL; malformed
 // lines are skipped.
 func parseSourcesSection(md string) []citation {
-	// locate the "## Sources" line — anchored to a real heading rather than
-	// a raw substring so a body that mentions "## Sources" in prose / code
-	// doesn't trick the parser into slicing the wrong region.
-	loc := sourcesHeadingRe.FindStringIndex(md)
-	if loc == nil {
+	// locate the "## Sources" line — anchored to a real heading on its own
+	// line AND outside any fenced code block. The fence check prevents a
+	// body that quotes the format string in a markdown sample from tricking
+	// the parser into slicing from inside the fence.
+	headerEnd := findSourcesHeadingEnd(md)
+	if headerEnd < 0 {
 		return nil
 	}
-	rest := md[loc[1]:]
+	rest := md[headerEnd:]
 	if next := nextH2HeadingIndex(rest); next >= 0 {
 		rest = rest[:next]
 	}
@@ -567,10 +630,6 @@ func parseSourcesSection(md string) []citation {
 }
 
 var (
-	// sourcesHeadingRe matches a real `## Sources` heading on its own line.
-	// Multi-line mode + `\s*$` allows trailing whitespace but rejects any
-	// non-heading occurrence of the literal in body text.
-	sourcesHeadingRe = regexp.MustCompile(`(?m)^## Sources\s*$`)
 	// refLinkDefRe matches `[N]: url`
 	refLinkDefRe = regexp.MustCompile(`^\[(\d+)\]:\s*(\S+)\s*$`)
 	// numberedRefEntryRe matches `1. [label][N]`. Label accepts escaped

--- a/cmd/ox/distill_citations.go
+++ b/cmd/ox/distill_citations.go
@@ -186,7 +186,21 @@ func citationLabel(f facts.Fact) string {
 
 // citationDate extracts a YYYY-MM-DD slice from an ISO 8601 timestamp.
 // Returns empty if the timestamp is empty or unparseable.
+//
+// IMPORTANT: returns the SOURCE-LOCAL calendar date, not the UTC date. For
+// `2026-03-10T23:30:00-08:00` we want the human-facing label to read
+// `2026-03-10` (the local day), not `2026-03-11` (the UTC day after the
+// offset shift). We rely on the YYYY-MM-DD prefix from the raw string
+// because parseFactTimestamp normalizes to UTC (correct for sorting, wrong
+// for display). Only fall back to the parsed date for non-RFC3339 inputs
+// that don't have a leading date.
 func citationDate(ts string) string {
+	if len(ts) >= 10 {
+		prefix := ts[:10]
+		if _, err := time.Parse("2006-01-02", prefix); err == nil {
+			return prefix
+		}
+	}
 	if t := parseFactTimestamp(ts); !t.IsZero() {
 		return t.Format("2006-01-02")
 	}
@@ -243,18 +257,26 @@ var (
 )
 
 // githubShortLabel converts a github URL to a short label like "owner/repo#152"
-// or "owner/repo@abc1234". Falls back to title or URL if parsing fails.
+// or "owner/repo@abc1234".
+//
+// Fallback chain (in order):
+//  1. parseGitHubURLLabel(urlStr || ref) — short form for github.com URLs
+//  2. title — the PR/issue title verbatim
+//  3. ref — the raw source_ref (usually the URL)
+//  4. urlStr — the raw URL when ref is empty but URL is unparseable
+//  5. "GitHub" — final placeholder so a citation never has an empty label
 //
 // Inputs:
 //   - urlStr: the URL to parse (preferred)
 //   - ref: source_ref (often the same as urlStr for github)
 //   - title: PR/issue title from source_title
 func githubShortLabel(urlStr, ref, title string) string {
-	if urlStr == "" {
-		urlStr = ref
+	tryURL := urlStr
+	if tryURL == "" {
+		tryURL = ref
 	}
-	if urlStr != "" {
-		if label := parseGitHubURLLabel(urlStr); label != "" {
+	if tryURL != "" {
+		if label := parseGitHubURLLabel(tryURL); label != "" {
 			return label
 		}
 	}
@@ -263,6 +285,9 @@ func githubShortLabel(urlStr, ref, title string) string {
 	}
 	if ref != "" {
 		return ref
+	}
+	if urlStr != "" {
+		return urlStr
 	}
 	return "GitHub"
 }

--- a/cmd/ox/distill_citations_test.go
+++ b/cmd/ox/distill_citations_test.go
@@ -413,6 +413,77 @@ func TestSourcesSectionRoundTrip_LabelsWithBrackets(t *testing.T) {
 	}
 }
 
+// TestBuildCitationsFromFacts_OrdersByParsedTimeNotLexical — CodeRabbit
+// round-3: timestamps with different RFC3339 offsets must sort by their
+// real chronological instant, not by their raw string form. The two facts
+// below represent the same wall-clock day but at different offsets — the
+// EAST coast 9am instant happens BEFORE the west coast 9am instant.
+//
+// Failure prevented: distilled summaries renumber multi-region facts in the
+// wrong order, breaking the chronological narrative the LLM relies on.
+func TestBuildCitationsFromFacts_OrdersByParsedTimeNotLexical(t *testing.T) {
+	// Both timestamps lexically: "2026-03-10T09:00:00-05:00" sorts AFTER
+	// "2026-03-10T09:00:00-08:00" because "-05:00" > "-08:00" string-wise.
+	// But chronologically, -05:00 9am is 14:00 UTC and -08:00 9am is 17:00 UTC,
+	// so the -05:00 fact comes FIRST.
+	fs := []facts.Fact{
+		{
+			Headline:   "west coast",
+			SourceType: facts.SourceDiscussion,
+			SourceURL:  "url-west",
+			Timestamp:  "2026-03-10T09:00:00-08:00", // 17:00 UTC — should be #2
+		},
+		{
+			Headline:   "east coast",
+			SourceType: facts.SourceDiscussion,
+			SourceURL:  "url-east",
+			Timestamp:  "2026-03-10T09:00:00-05:00", // 14:00 UTC — should be #1
+		},
+	}
+	cites, _ := buildCitationsFromFacts(fs)
+	if len(cites) != 2 {
+		t.Fatalf("expected 2 citations, got %d", len(cites))
+	}
+	if cites[0].URL != "url-east" {
+		t.Errorf("first citation should be east coast (earlier UTC instant); got URL=%q", cites[0].URL)
+	}
+	if cites[1].URL != "url-west" {
+		t.Errorf("second citation should be west coast; got URL=%q", cites[1].URL)
+	}
+}
+
+// TestParseSourcesSection_IgnoresHeadingInsideCodeFence — CodeRabbit round-3:
+// a body containing a markdown sample with `## Sources` inside a fenced code
+// block must not trick the parser. Only headings OUTSIDE fences count.
+//
+// Failure prevented: agent guidance documenting the distilled format includes
+// a code sample showing `## Sources`. parseSourcesSection slices from inside
+// the fence, misses the real Sources section, and weekly merges silently
+// drop all citations from that daily.
+func TestParseSourcesSection_IgnoresHeadingInsideCodeFence(t *testing.T) {
+	doc := "# Daily\n\n" +
+		"## What We Learned\n\n" +
+		"Here is what a Sources section looks like:\n\n" +
+		"```markdown\n" +
+		"## Sources\n\n" +
+		"1. [Fake citation in code sample][1]\n\n" +
+		"[1]: https://fake.example.com\n" +
+		"```\n\n" +
+		"## Sources\n\n" +
+		"1. [Real citation][1]\n\n" +
+		"[1]: https://real.example.com\n"
+	cites := parseSourcesSection(doc)
+	if len(cites) != 1 {
+		t.Fatalf("expected 1 real citation, got %d: %+v", len(cites), cites)
+	}
+	if cites[0].URL != "https://real.example.com" {
+		t.Errorf("parser sliced from code fence, got URL %q", cites[0].URL)
+	}
+	if cites[0].Label != "Real citation" {
+		t.Errorf("parser picked up fake label, got %q", cites[0].Label)
+	}
+}
+
 // TestSourcesSection_LabelOnlyKeyRoundTrip — CodeRabbit round-2 #6: label-only
 // citations with distinct stable Keys (e.g., source_ref) must round-trip
 // through render → parse without collapsing. The hidden ` <!-- ref:... -->`

--- a/cmd/ox/distill_citations_test.go
+++ b/cmd/ox/distill_citations_test.go
@@ -413,6 +413,70 @@ func TestSourcesSectionRoundTrip_LabelsWithBrackets(t *testing.T) {
 	}
 }
 
+// TestSourcesSection_LabelOnlyKeyRoundTrip — CodeRabbit round-2 #6: label-only
+// citations with distinct stable Keys (e.g., source_ref) must round-trip
+// through render → parse without collapsing. The hidden ` <!-- ref:... -->`
+// HTML comment carries the Key. Without this, two label-only sources sharing
+// a label would silently merge during weekly/monthly distillation.
+//
+// Failure prevented: legacy / audio-only discussions with similar titles get
+// merged into a single citation, losing one of the sources from the weekly.
+func TestSourcesSection_LabelOnlyKeyRoundTrip(t *testing.T) {
+	cites := []citation{
+		{Num: 1, Label: "Discussion: 2026-03-10 — Sync", Key: "discussions/2026-03-10-1000-alice"},
+		{Num: 2, Label: "Discussion: 2026-03-10 — Sync", Key: "discussions/2026-03-10-1500-bob"}, // SAME label, DIFFERENT source
+	}
+	rendered := renderSourcesSection(cites)
+	if !strings.Contains(rendered, "<!-- ref:discussions/2026-03-10-1000-alice -->") {
+		t.Errorf("expected ref comment for first cite:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "<!-- ref:discussions/2026-03-10-1500-bob -->") {
+		t.Errorf("expected ref comment for second cite:\n%s", rendered)
+	}
+
+	// Round-trip: parse should preserve the distinct keys
+	parsed := parseSourcesSection("# Daily\n\n" + rendered)
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 parsed citations, got %d: %+v", len(parsed), parsed)
+	}
+	if parsed[0].Key != "discussions/2026-03-10-1000-alice" {
+		t.Errorf("parsed[0].Key = %q, want %q", parsed[0].Key, "discussions/2026-03-10-1000-alice")
+	}
+	if parsed[1].Key != "discussions/2026-03-10-1500-bob" {
+		t.Errorf("parsed[1].Key = %q, want %q", parsed[1].Key, "discussions/2026-03-10-1500-bob")
+	}
+
+	// Cross-layer merge: these two distinct sources must NOT collapse
+	_, merged := mergeCitations([]mergeInput{
+		{Text: "x [1] [2]", Cites: parsed},
+	})
+	if len(merged) != 2 {
+		t.Errorf("two distinct label-only sources collapsed during merge: got %d, want 2", len(merged))
+	}
+}
+
+// TestParseSourcesSection_LegacyDailyWithoutRefComment — backwards compat:
+// daily files written before the ref-comment change MUST still parse. Their
+// label-only entries fall back to "label:" synthetic keys (and may collapse
+// across distinct sources sharing a label, but that's a transient issue
+// resolved on next regeneration).
+func TestParseSourcesSection_LegacyDailyWithoutRefComment(t *testing.T) {
+	doc := `# Daily
+
+## Sources
+
+1. Discussion: legacy entry
+2. Session: another legacy
+`
+	parsed := parseSourcesSection(doc)
+	if len(parsed) != 2 {
+		t.Fatalf("expected 2 parsed citations, got %d", len(parsed))
+	}
+	if !strings.HasPrefix(parsed[0].Key, "label:") {
+		t.Errorf("legacy entry should have label: key, got %q", parsed[0].Key)
+	}
+}
+
 // TestParseSourcesSection_IgnoresBodyMentionOfHeading — CodeRabbit #2: a body
 // that mentions "## Sources" in prose or a code sample (e.g., agent guidance
 // describing the format) must not trick the parser into slicing the wrong

--- a/cmd/ox/distill_citations_test.go
+++ b/cmd/ox/distill_citations_test.go
@@ -413,6 +413,61 @@ func TestSourcesSectionRoundTrip_LabelsWithBrackets(t *testing.T) {
 	}
 }
 
+// TestCitationDate_PreservesSourceLocalDay — CodeRabbit round-4: citationDate
+// must return the SOURCE-LOCAL calendar day, not the UTC day. For an offset
+// timestamp near midnight, formatting after parseFactTimestamp's UTC
+// normalization shifts the displayed day forward — wrong for human labels.
+//
+// Failure prevented: a discussion recorded at "2026-03-10 23:30 PST" appears
+// in the daily summary as "Discussion: 2026-03-11" instead of "2026-03-10".
+func TestCitationDate_PreservesSourceLocalDay(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   string
+		want string
+	}{
+		{"PST near midnight stays on local day", "2026-03-10T23:30:00-08:00", "2026-03-10"},
+		{"EST near midnight stays on local day", "2026-03-10T23:30:00-05:00", "2026-03-10"},
+		{"UTC midday", "2026-03-10T12:00:00Z", "2026-03-10"},
+		{"date-only string", "2026-03-10", "2026-03-10"},
+		{"empty input", "", ""},
+		{"unparseable input", "not a date", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := citationDate(tt.ts)
+			if got != tt.want {
+				t.Errorf("citationDate(%q) = %q, want %q", tt.ts, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGithubShortLabel_FallbackChain — CodeRabbit round-4: documents the
+// full fallback chain so that a citation NEVER renders with an empty label,
+// and an unparseable github URL still produces something readable.
+func TestGithubShortLabel_FallbackChain(t *testing.T) {
+	tests := []struct {
+		name        string
+		url, ref, t string
+		want        string
+	}{
+		{"parseable PR url", "https://github.com/sageox/ox/pull/486", "", "", "sageox/ox#486"},
+		{"unparseable url falls back to title", "not a url", "", "Add rate limiting", "Add rate limiting"},
+		{"unparseable url falls back to ref", "not a url", "ref-only", "", "ref-only"},
+		{"unparseable url falls back to url itself when ref empty", "https://example.com/weird", "", "", "https://example.com/weird"},
+		{"all empty falls back to GitHub", "", "", "", "GitHub"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := githubShortLabel(tt.url, tt.ref, tt.t)
+			if got != tt.want {
+				t.Errorf("githubShortLabel(%q, %q, %q) = %q, want %q", tt.url, tt.ref, tt.t, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestBuildCitationsFromFacts_OrdersByParsedTimeNotLexical — CodeRabbit
 // round-3: timestamps with different RFC3339 offsets must sort by their
 // real chronological instant, not by their raw string form. The two facts

--- a/cmd/ox/distill_citations_test.go
+++ b/cmd/ox/distill_citations_test.go
@@ -766,6 +766,79 @@ func TestMergeCitations_DoesNotDedupeDifferentURLsWithSameLabel(t *testing.T) {
 	}
 }
 
+// TestMergeCitations_DoesNotUpgradeStableKeyedByLabelAlone — CodeRabbit
+// round-5: after #476 added stable keys to label-only citations (the hidden
+// `<!-- ref:... -->` comment carries source_ref), promoting any
+// label-matching entry by label alone is wrong. Two distinct discussions
+// with the same title (different stable keys) followed by a URL-backed
+// citation with the same title MUST stay as three distinct entries — we
+// have no information linking the URL to either of the two stable keys.
+//
+// Failure prevented: a third-party URL silently attaches to whichever
+// label-only source happened to be processed last, corrupting that
+// citation's link target during weekly/monthly merges.
+func TestMergeCitations_DoesNotUpgradeStableKeyedByLabelAlone(t *testing.T) {
+	inputs := []mergeInput{
+		{
+			Text: "x [1]",
+			Cites: []citation{
+				{Num: 1, Label: "Foo", Key: "discussions/2026-03-10-1000-alice"}, // stable, no URL
+			},
+		},
+		{
+			Text: "y [1]",
+			Cites: []citation{
+				{Num: 1, Label: "Foo", Key: "discussions/2026-03-10-1500-bob"}, // stable, no URL
+			},
+		},
+		{
+			Text: "z [1]",
+			Cites: []citation{
+				{Num: 1, Label: "Foo", URL: "https://example.com/foo", Key: "https://example.com/foo"},
+			},
+		},
+	}
+	_, merged := mergeCitations(inputs)
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 distinct merged citations (two stable label-only + one URL), got %d: %+v", len(merged), merged)
+	}
+
+	// Specifically: Alice's entry should NOT have been upgraded to the URL
+	// (we can't know whether it's the right Foo).
+	for _, c := range merged {
+		if c.Key == "discussions/2026-03-10-1000-alice" && c.URL != "" {
+			t.Errorf("Alice's stable-keyed entry was wrongly upgraded with URL %q", c.URL)
+		}
+		if c.Key == "discussions/2026-03-10-1500-bob" && c.URL != "" {
+			t.Errorf("Bob's stable-keyed entry was wrongly upgraded with URL %q", c.URL)
+		}
+	}
+}
+
+// TestMergeCitations_SyntheticLabelOnlyOnceUpgraded — defensive: even with
+// the synthetic-label restriction, once a synthetic entry has been upgraded
+// it must NOT be upgraded a second time by a different URL with the same
+// label. The second URL must become its own separate entry.
+func TestMergeCitations_SyntheticLabelOnlyOnceUpgraded(t *testing.T) {
+	inputs := []mergeInput{
+		{Text: "a [1]", Cites: []citation{{Num: 1, Label: "Foo", Key: "label:Foo"}}}, // synthetic, no URL
+		{Text: "b [1]", Cites: []citation{{Num: 1, Label: "Foo", URL: "https://example.com/first", Key: "https://example.com/first"}}},
+		{Text: "c [1]", Cites: []citation{{Num: 1, Label: "Foo", URL: "https://example.com/second", Key: "https://example.com/second"}}},
+	}
+	_, merged := mergeCitations(inputs)
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 merged citations (synthetic upgraded to first URL, second URL distinct), got %d: %+v", len(merged), merged)
+	}
+	// merged[0] = upgraded synthetic → first URL
+	if merged[0].URL != "https://example.com/first" {
+		t.Errorf("first merged URL = %q, want %q", merged[0].URL, "https://example.com/first")
+	}
+	// merged[1] = second URL, separate entry
+	if merged[1].URL != "https://example.com/second" {
+		t.Errorf("second merged URL = %q, want %q", merged[1].URL, "https://example.com/second")
+	}
+}
+
 // TestMergeCitations_DoesNotMergeReverseDirection pins the deliberate
 // asymmetry: when a URL-keyed entry comes FIRST and a label-only entry with
 // the same label comes SECOND, they stay distinct. We can't safely assume

--- a/cmd/ox/distill_citations_test.go
+++ b/cmd/ox/distill_citations_test.go
@@ -378,8 +378,68 @@ func TestRenderSourcesSection_LabelEscapesBracket(t *testing.T) {
 		{Num: 1, Label: "Discussion: brackets [in title]", URL: "https://example.com/x", Key: "https://example.com/x"},
 	}
 	out := renderSourcesSection(cites)
-	if !strings.Contains(out, `[in title\]`) {
-		t.Errorf("expected escaped bracket in label:\n%s", out)
+	if !strings.Contains(out, `\[in title\]`) {
+		t.Errorf("expected both brackets escaped in label:\n%s", out)
+	}
+}
+
+// TestSourcesSectionRoundTrip_LabelsWithBrackets — CodeRabbit #1: a label
+// like `Foo [bar]` must round-trip cleanly. Previously only `]` was escaped,
+// which produced `[Foo [bar\]][1]` — broken markdown that parsers see as a
+// nested link. Now both ends are escaped.
+//
+// Failure prevented: PR/discussion titles containing brackets render as
+// non-clickable link fragments in the Sources section.
+func TestSourcesSectionRoundTrip_LabelsWithBrackets(t *testing.T) {
+	cites := []citation{
+		{Num: 1, Label: "Foo [bar]", URL: "https://example.com/foo", Key: "https://example.com/foo"},
+		{Num: 2, Label: "Has [both] brackets", URL: "https://example.com/b", Key: "https://example.com/b"},
+		{Num: 3, Label: "Trailing ]", URL: "https://example.com/t", Key: "https://example.com/t"},
+		{Num: 4, Label: "Leading [", URL: "https://example.com/l", Key: "https://example.com/l"},
+	}
+	rendered := renderSourcesSection(cites)
+	doc := "# Daily\n\n" + rendered
+	parsed := parseSourcesSection(doc)
+	if len(parsed) != len(cites) {
+		t.Fatalf("round-trip lost entries: got %d, want %d", len(parsed), len(cites))
+	}
+	for i, want := range cites {
+		if parsed[i].Label != want.Label {
+			t.Errorf("entry %d: Label = %q, want %q", i, parsed[i].Label, want.Label)
+		}
+		if parsed[i].URL != want.URL {
+			t.Errorf("entry %d: URL = %q, want %q", i, parsed[i].URL, want.URL)
+		}
+	}
+}
+
+// TestParseSourcesSection_IgnoresBodyMentionOfHeading — CodeRabbit #2: a body
+// that mentions "## Sources" in prose or a code sample (e.g., agent guidance
+// describing the format) must not trick the parser into slicing the wrong
+// region. Only a real H2 heading on its own line counts.
+//
+// Failure prevented: distill of a daily that quotes the format string itself
+// produces a Sources section parsed from the wrong file region — citations
+// silently disappear from weekly merges.
+func TestParseSourcesSection_IgnoresBodyMentionOfHeading(t *testing.T) {
+	doc := `# Daily Memory
+
+## What We Learned
+
+The format guide says "the file ends with ## Sources, like this:".
+
+## Sources
+
+1. [Real citation][1]
+
+[1]: https://example.com/real
+`
+	cites := parseSourcesSection(doc)
+	if len(cites) != 1 {
+		t.Fatalf("expected 1 citation from real Sources section, got %d: %+v", len(cites), cites)
+	}
+	if cites[0].URL != "https://example.com/real" {
+		t.Errorf("parser sliced from wrong location, got URL %q", cites[0].URL)
 	}
 }
 

--- a/cmd/ox/distill_citations_test.go
+++ b/cmd/ox/distill_citations_test.go
@@ -1,0 +1,569 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/facts"
+)
+
+// --- A. Label generation ---
+
+// TestCitationLabel covers the label format for every source type.
+// Failure prevented: distilled summaries cite sources with ugly URLs or empty labels.
+func TestCitationLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		fact facts.Fact
+		want string
+	}{
+		{
+			name: "discussion with title and date",
+			fact: facts.Fact{
+				SourceType:  facts.SourceDiscussion,
+				SourceTitle: "Architecture sync",
+				Timestamp:   "2026-03-10T14:23:00Z",
+			},
+			want: "Discussion: 2026-03-10 — Architecture sync",
+		},
+		{
+			name: "discussion without title falls back to dirname",
+			fact: facts.Fact{
+				SourceType: facts.SourceDiscussion,
+				SourceRef:  "discussions/2026-03-10-1423-ryan",
+				Timestamp:  "2026-03-10T14:23:00Z",
+			},
+			want: "Discussion: 2026-03-10 — ryan",
+		},
+		{
+			name: "session with title and date",
+			fact: facts.Fact{
+				SourceType:  facts.SourceSession,
+				SourceTitle: "stateless refactor",
+				Timestamp:   "2026-03-11T09:00:00Z",
+			},
+			want: "Session: 2026-03-11 — stateless refactor",
+		},
+		{
+			name: "session without title falls back to dirname who-id",
+			fact: facts.Fact{
+				SourceType: facts.SourceSession,
+				SourceRef:  "sessions/2026-01-06T14-32-ryan-Ox7f3a",
+				Timestamp:  "2026-01-06T14:32:00Z",
+			},
+			want: "Session: 2026-01-06 — ryan-Ox7f3a",
+		},
+		{
+			name: "github PR with URL",
+			fact: facts.Fact{
+				SourceType: facts.SourceGitHub,
+				SourceRef:  "https://github.com/sageox/ox/pull/152",
+				SourceURL:  "https://github.com/sageox/ox/pull/152",
+			},
+			want: "sageox/ox#152",
+		},
+		{
+			name: "github issue with URL",
+			fact: facts.Fact{
+				SourceType: facts.SourceGitHub,
+				SourceRef:  "https://github.com/sageox/ox/issues/476",
+				SourceURL:  "https://github.com/sageox/ox/issues/476",
+			},
+			want: "sageox/ox#476",
+		},
+		{
+			name: "github commit shortens sha",
+			fact: facts.Fact{
+				SourceType: facts.SourceGitHub,
+				SourceURL:  "https://github.com/sageox/ox/commit/a1b2c3d4e5f6789",
+			},
+			want: "sageox/ox@a1b2c3d",
+		},
+		{
+			name: "github fallback to title when URL unparseable",
+			fact: facts.Fact{
+				SourceType:  facts.SourceGitHub,
+				SourceURL:   "not a url",
+				SourceTitle: "Add rate limiting",
+			},
+			want: "Add rate limiting",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := citationLabel(tt.fact)
+			if got != tt.want {
+				t.Errorf("citationLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- B. Citation list construction ---
+
+// TestBuildCitationsFromFacts_DedupesByURL ensures multiple facts pointing at
+// the same source produce a single citation entry.
+// Failure prevented: a discussion with 5 facts produces 5 duplicate citations,
+// inflating the Sources section.
+func TestBuildCitationsFromFacts_DedupesByURL(t *testing.T) {
+	url := "https://sageox.ai/team/team_x/media/recordings/rec_y"
+	fs := []facts.Fact{
+		{Headline: "fact 1", SourceType: facts.SourceDiscussion, SourceURL: url, SourceTitle: "Sync", Timestamp: "2026-03-10T10:00:00Z"},
+		{Headline: "fact 2", SourceType: facts.SourceDiscussion, SourceURL: url, SourceTitle: "Sync", Timestamp: "2026-03-10T10:00:00Z"},
+		{Headline: "fact 3", SourceType: facts.SourceDiscussion, SourceURL: url, SourceTitle: "Sync", Timestamp: "2026-03-10T10:00:00Z"},
+	}
+	cites, factToNum := buildCitationsFromFacts(fs)
+	if len(cites) != 1 {
+		t.Fatalf("expected 1 citation after dedup, got %d", len(cites))
+	}
+	if cites[0].URL != url {
+		t.Errorf("citation URL = %q, want %q", cites[0].URL, url)
+	}
+	for i := 0; i < 3; i++ {
+		if factToNum[i] != 1 {
+			t.Errorf("fact[%d] mapped to %d, want 1", i, factToNum[i])
+		}
+	}
+}
+
+// TestBuildCitationsFromFacts_OrderingByTimestamp verifies stable chronological order.
+// Failure prevented: citation numbering jumps around between runs.
+func TestBuildCitationsFromFacts_OrderingByTimestamp(t *testing.T) {
+	fs := []facts.Fact{
+		{SourceType: facts.SourceDiscussion, SourceURL: "url-c", SourceTitle: "C", Timestamp: "2026-03-12T00:00:00Z"},
+		{SourceType: facts.SourceDiscussion, SourceURL: "url-a", SourceTitle: "A", Timestamp: "2026-03-10T00:00:00Z"},
+		{SourceType: facts.SourceDiscussion, SourceURL: "url-b", SourceTitle: "B", Timestamp: "2026-03-11T00:00:00Z"},
+	}
+	cites, _ := buildCitationsFromFacts(fs)
+	if len(cites) != 3 {
+		t.Fatalf("got %d citations", len(cites))
+	}
+	if cites[0].URL != "url-a" || cites[1].URL != "url-b" || cites[2].URL != "url-c" {
+		t.Errorf("ordering wrong: %v", []string{cites[0].URL, cites[1].URL, cites[2].URL})
+	}
+}
+
+// TestBuildCitationsFromFacts_FallsBackToSourceRef ensures facts without a URL
+// still get cited (just without a clickable link).
+// Failure prevented: legacy fact files (no source_url) silently dropped from Sources.
+func TestBuildCitationsFromFacts_FallsBackToSourceRef(t *testing.T) {
+	fs := []facts.Fact{
+		{SourceType: facts.SourceDiscussion, SourceRef: "discussions/2026-03-10-1423-ryan", Timestamp: "2026-03-10T00:00:00Z"},
+	}
+	cites, factToNum := buildCitationsFromFacts(fs)
+	if len(cites) != 1 {
+		t.Fatalf("expected 1 citation, got %d", len(cites))
+	}
+	if cites[0].URL != "" {
+		t.Errorf("expected empty URL for ref-only fact, got %q", cites[0].URL)
+	}
+	if cites[0].Label == "" {
+		t.Errorf("expected non-empty label even without URL")
+	}
+	if factToNum[0] != 1 {
+		t.Errorf("fact[0] mapped to %d, want 1", factToNum[0])
+	}
+}
+
+// TestBuildCitationsFromFacts_SkipsUncitableFacts ensures facts with no source
+// info at all are skipped (rather than producing an empty citation).
+// Failure prevented: a Sources section entry "1." with no label.
+func TestBuildCitationsFromFacts_SkipsUncitableFacts(t *testing.T) {
+	fs := []facts.Fact{
+		{SourceType: facts.SourceObservation}, // no URL, no ref — uncitable
+		{SourceType: facts.SourceDiscussion, SourceURL: "url-a", SourceTitle: "A", Timestamp: "2026-03-10T00:00:00Z"},
+	}
+	cites, factToNum := buildCitationsFromFacts(fs)
+	if len(cites) != 1 {
+		t.Fatalf("expected 1 citation, got %d", len(cites))
+	}
+	if _, ok := factToNum[0]; ok {
+		t.Errorf("uncitable fact[0] should not be in factToNum, but got %d", factToNum[0])
+	}
+	if factToNum[1] != 1 {
+		t.Errorf("fact[1] should map to 1, got %d", factToNum[1])
+	}
+}
+
+// --- C. Marker renumbering ---
+
+// TestRenumberCitationMarkers covers all the marker shapes the LLM emits.
+// Failure prevented: weekly summary inherits stale per-day numbers and the
+// reference definitions don't resolve.
+func TestRenumberCitationMarkers(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		oldToNew map[int]int
+		want     string
+	}{
+		{
+			name:     "bare marker rewritten",
+			text:     "The team chose Postgres. [3]",
+			oldToNew: map[int]int{3: 7},
+			want:     "The team chose Postgres. [7]",
+		},
+		{
+			name:     "ref-link tail rewritten",
+			text:     "We merged [PR #152][2] last week.",
+			oldToNew: map[int]int{2: 9},
+			want:     "We merged [PR #152][9] last week.",
+		},
+		{
+			name:     "chained markers both rewritten",
+			text:     "Adopted rate limiting [1][3] after debate.",
+			oldToNew: map[int]int{1: 4, 3: 6},
+			want:     "Adopted rate limiting [4][6] after debate.",
+		},
+		{
+			name:     "unknown number left untouched (defensive)",
+			text:     "Strange marker [99] in body.",
+			oldToNew: map[int]int{1: 2},
+			want:     "Strange marker [99] in body.",
+		},
+		{
+			name:     "no markers at all",
+			text:     "Just plain prose.",
+			oldToNew: map[int]int{1: 2},
+			want:     "Just plain prose.",
+		},
+		{
+			name:     "empty map leaves text unchanged",
+			text:     "Has [1] marker.",
+			oldToNew: map[int]int{},
+			want:     "Has [1] marker.",
+		},
+		{
+			name:     "multiple markers in one line",
+			text:     "First [1] middle [2] last [3].",
+			oldToNew: map[int]int{1: 10, 2: 20, 3: 30},
+			want:     "First [10] middle [20] last [30].",
+		},
+		{
+			// gh #476 review finding: don't corrupt array indices in code samples.
+			name:     "code fence content untouched",
+			text:     "Body [1].\n\n```go\narr[1] = arr[2]\n```\n\nMore [1].",
+			oldToNew: map[int]int{1: 9, 2: 8},
+			want:     "Body [9].\n\n```go\narr[1] = arr[2]\n```\n\nMore [9].",
+		},
+		{
+			name:     "multiple code fences with markers in between",
+			text:     "Pre [1].\n```\nx[2]\n```\nMid [1].\n```py\ny[2]\n```\nPost [1].",
+			oldToNew: map[int]int{1: 5, 2: 6},
+			want:     "Pre [5].\n```\nx[2]\n```\nMid [5].\n```py\ny[2]\n```\nPost [5].",
+		},
+		{
+			// defensive: an unterminated fence (should not happen in distilled
+			// output, but markdown does allow it) — everything after the lone
+			// fence is treated as code and left alone.
+			name:     "unterminated code fence treats tail as code",
+			text:     "Pre [1].\n```\ncode [1] tail",
+			oldToNew: map[int]int{1: 7},
+			want:     "Pre [7].\n```\ncode [1] tail",
+		},
+		{
+			// gh #476 review round-2: inline backtick spans must also be
+			// protected so prose like `arr[1]` doesn't get renumbered.
+			name:     "inline backtick code span untouched",
+			text:     "The lookup `arr[1]` is fine but cite [1] should renumber.",
+			oldToNew: map[int]int{1: 4},
+			want:     "The lookup `arr[1]` is fine but cite [4] should renumber.",
+		},
+		{
+			name:     "multiple inline code spans on one line",
+			text:     "See `args[2]` and `argv[1]`, then [1] [2].",
+			oldToNew: map[int]int{1: 5, 2: 6},
+			want:     "See `args[2]` and `argv[1]`, then [5] [6].",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renumberCitationMarkers(tt.text, tt.oldToNew)
+			if got != tt.want {
+				t.Errorf("renumberCitationMarkers() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- D. Sources section round-trip ---
+
+// TestSourcesSectionRoundTrip verifies that render → parse produces the same
+// citation list back. This is the contract weekly/monthly distillation relies on.
+// Failure prevented: weekly stage cannot read the Sources section it needs to merge.
+func TestSourcesSectionRoundTrip(t *testing.T) {
+	cites := []citation{
+		{Num: 1, Label: "Discussion: 2026-03-10 — Architecture sync", URL: "https://sageox.ai/team/t/media/recordings/rec_a", Key: "https://sageox.ai/team/t/media/recordings/rec_a"},
+		{Num: 2, Label: "sageox/ox#152", URL: "https://github.com/sageox/ox/pull/152", Key: "https://github.com/sageox/ox/pull/152"},
+		{Num: 3, Label: "Session: 2026-03-11 — refactor", URL: "https://sageox.ai/repo/r/sessions/s/view", Key: "https://sageox.ai/repo/r/sessions/s/view"},
+	}
+	rendered := renderSourcesSection(cites)
+	if rendered == "" {
+		t.Fatal("expected non-empty rendered section")
+	}
+	// wrap in a fake document to test header detection
+	doc := "# Daily Memory — 2026-03-10\n\nBody text.\n\n" + rendered
+	parsed := parseSourcesSection(doc)
+	if len(parsed) != len(cites) {
+		t.Fatalf("round-trip lost entries: got %d, want %d", len(parsed), len(cites))
+	}
+	for i, want := range cites {
+		if parsed[i].Num != want.Num {
+			t.Errorf("entry %d: Num = %d, want %d", i, parsed[i].Num, want.Num)
+		}
+		if parsed[i].Label != want.Label {
+			t.Errorf("entry %d: Label = %q, want %q", i, parsed[i].Label, want.Label)
+		}
+		if parsed[i].URL != want.URL {
+			t.Errorf("entry %d: URL = %q, want %q", i, parsed[i].URL, want.URL)
+		}
+	}
+}
+
+// TestParseSourcesSection_AbsentReturnsNil — defensive: weekly distill on a
+// daily file with no Sources section must not panic.
+func TestParseSourcesSection_AbsentReturnsNil(t *testing.T) {
+	got := parseSourcesSection("# Daily Memory\n\nJust prose, no Sources section.\n")
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+// TestParseSourcesSection_StopsAtNextHeading ensures we don't grab content
+// from a section after Sources (e.g., a future appendix).
+func TestParseSourcesSection_StopsAtNextHeading(t *testing.T) {
+	doc := `# Daily
+
+## Sources
+
+1. [Foo][1]
+
+[1]: https://example.com
+
+## Appendix
+
+2. [Bar][2]
+
+[2]: https://other.example.com
+`
+	cites := parseSourcesSection(doc)
+	if len(cites) != 1 {
+		t.Fatalf("expected 1 citation (Appendix excluded), got %d", len(cites))
+	}
+	if cites[0].Label != "Foo" {
+		t.Errorf("got label %q, want Foo", cites[0].Label)
+	}
+}
+
+// TestRenderSourcesSection_NoURLsRendersPlain ensures label-only entries
+// (legacy facts without URLs) still appear in the section.
+// Failure prevented: legacy data silently disappears from Sources.
+func TestRenderSourcesSection_NoURLsRendersPlain(t *testing.T) {
+	cites := []citation{
+		{Num: 1, Label: "Discussion: legacy", Key: "discussions/legacy"},
+	}
+	out := renderSourcesSection(cites)
+	if !strings.Contains(out, "1. Discussion: legacy") {
+		t.Errorf("expected plain numbered entry, got:\n%s", out)
+	}
+	if strings.Contains(out, "[1]:") {
+		t.Errorf("did not expect ref definitions for label-only entries:\n%s", out)
+	}
+}
+
+// TestRenderSourcesSection_LabelEscapesBracket ensures labels containing `]`
+// don't break the markdown link syntax.
+func TestRenderSourcesSection_LabelEscapesBracket(t *testing.T) {
+	cites := []citation{
+		{Num: 1, Label: "Discussion: brackets [in title]", URL: "https://example.com/x", Key: "https://example.com/x"},
+	}
+	out := renderSourcesSection(cites)
+	if !strings.Contains(out, `[in title\]`) {
+		t.Errorf("expected escaped bracket in label:\n%s", out)
+	}
+}
+
+// --- E. Multi-layer citation propagation ---
+
+// TestMergeCitations_DedupesAcrossLayers is the core property the weekly /
+// monthly stages rely on: a single source cited in multiple inputs ends up
+// as ONE entry in the merged list, with all input markers rewritten to the
+// same global number.
+//
+// Failure prevented: weekly summary has duplicate entries because day1 and
+// day3 used different per-day numbering for the same discussion.
+func TestMergeCitations_DedupesAcrossLayers(t *testing.T) {
+	// day 1: discussion is [2]
+	day1Text := "Architecture decision was made [2]."
+	day1Cites := []citation{
+		{Num: 1, Label: "Other", URL: "https://example.com/other", Key: "https://example.com/other"},
+		{Num: 2, Label: "The discussion", URL: "https://example.com/disc", Key: "https://example.com/disc"},
+	}
+	// day 3: same discussion is [1]
+	day3Text := "Following the [discussion][1], we shipped."
+	day3Cites := []citation{
+		{Num: 1, Label: "The discussion", URL: "https://example.com/disc", Key: "https://example.com/disc"},
+	}
+
+	rewritten, merged := mergeCitations([]mergeInput{
+		{Text: day1Text, Cites: day1Cites},
+		{Text: day3Text, Cites: day3Cites},
+	})
+
+	// expect exactly 2 unique citations (Other + The discussion)
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 merged citations, got %d: %+v", len(merged), merged)
+	}
+
+	// "The discussion" should have ONE global number across both inputs
+	var discNum int
+	for _, c := range merged {
+		if c.Label == "The discussion" {
+			discNum = c.Num
+		}
+	}
+	if discNum == 0 {
+		t.Fatal("'The discussion' not found in merged list")
+	}
+
+	// both inputs should reference that global number
+	day1Want := "Architecture decision was made [" + itoa(discNum) + "]."
+	if rewritten[0] != day1Want {
+		t.Errorf("day1 rewrite:\n got: %q\nwant: %q", rewritten[0], day1Want)
+	}
+	day3Want := "Following the [discussion][" + itoa(discNum) + "], we shipped."
+	if rewritten[1] != day3Want {
+		t.Errorf("day3 rewrite:\n got: %q\nwant: %q", rewritten[1], day3Want)
+	}
+}
+
+// TestMergeCitations_UpgradesLabelOnlyToURLKeyed simulates a mid-release
+// upgrade where day1 was distilled BEFORE #476 added source URLs (citation
+// stored as label-only) and day2 was distilled AFTER (same source now has a
+// URL). The merged weekly should:
+//   1. Dedupe to ONE entry, not two
+//   2. Use the URL so the merged Sources section is clickable
+//   3. Renumber day1's bare marker to the unified global number, not leave
+//      it pointing at a stale slot
+//
+// Failure prevented: weekly Sources sections produced during a release
+// upgrade have duplicate Foo entries, OR earlier daily prose markers point
+// at wrong/stale citations after merge.
+func TestMergeCitations_UpgradesLabelOnlyToURLKeyed(t *testing.T) {
+	// day1: 3 leading citations then Foo as label-only
+	day1Text := "Y [1] Z [2] W [3] then Foo [4]."
+	day1Cites := []citation{
+		{Num: 1, Label: "Y", URL: "url:y", Key: "url:y"},
+		{Num: 2, Label: "Z", URL: "url:z", Key: "url:z"},
+		{Num: 3, Label: "W", URL: "url:w", Key: "url:w"},
+		{Num: 4, Label: "Foo", Key: "label:Foo"}, // legacy: no URL
+	}
+	// day2: Foo NOW has a URL — should upgrade day1's label-only entry
+	day2Text := "Foo [1]."
+	day2Cites := []citation{
+		{Num: 1, Label: "Foo", URL: "https://example.com/foo", Key: "https://example.com/foo"},
+	}
+
+	rewritten, merged := mergeCitations([]mergeInput{
+		{Text: day1Text, Cites: day1Cites},
+		{Text: day2Text, Cites: day2Cites},
+	})
+
+	// 1. Exactly 4 unique merged citations (dedupe Foo, not 5)
+	if len(merged) != 4 {
+		t.Fatalf("expected 4 merged citations after upgrade dedupe, got %d: %+v", len(merged), merged)
+	}
+
+	// 2. Foo's merged entry has the URL from day2
+	var fooEntry *citation
+	for i := range merged {
+		if merged[i].Label == "Foo" {
+			fooEntry = &merged[i]
+		}
+	}
+	if fooEntry == nil {
+		t.Fatal("Foo not in merged list")
+	}
+	if fooEntry.URL != "https://example.com/foo" {
+		t.Errorf("Foo URL not upgraded: got %q, want %q", fooEntry.URL, "https://example.com/foo")
+	}
+	if fooEntry.Num != 4 {
+		t.Errorf("Foo globalNum should stay at 4 after upgrade, got %d", fooEntry.Num)
+	}
+
+	// 3. Day1's [4] marker should still resolve to Foo's global number (4)
+	if rewritten[0] != "Y [1] Z [2] W [3] then Foo [4]." {
+		t.Errorf("day1 rewrite wrong:\n got: %q\nwant: %q", rewritten[0], "Y [1] Z [2] W [3] then Foo [4].")
+	}
+	// Day2's [1] marker should be renumbered to 4
+	if rewritten[1] != "Foo [4]." {
+		t.Errorf("day2 rewrite wrong:\n got: %q\nwant: %q", rewritten[1], "Foo [4].")
+	}
+}
+
+// TestMergeCitations_DoesNotDedupeDifferentURLsWithSameLabel verifies the
+// upgrade doesn't accidentally merge two genuinely different sources just
+// because they share a label. Two PRs with the same title in different repos
+// MUST stay distinct.
+func TestMergeCitations_DoesNotDedupeDifferentURLsWithSameLabel(t *testing.T) {
+	inputs := []mergeInput{
+		{Text: "x [1]", Cites: []citation{{Num: 1, Label: "Add rate limiting", URL: "https://github.com/a/r/pull/1", Key: "https://github.com/a/r/pull/1"}}},
+		{Text: "y [1]", Cites: []citation{{Num: 1, Label: "Add rate limiting", URL: "https://github.com/b/r/pull/1", Key: "https://github.com/b/r/pull/1"}}},
+	}
+	_, merged := mergeCitations(inputs)
+	if len(merged) != 2 {
+		t.Fatalf("two distinct URLs with same label should stay separate, got %d: %+v", len(merged), merged)
+	}
+}
+
+// TestMergeCitations_DoesNotMergeReverseDirection pins the deliberate
+// asymmetry: when a URL-keyed entry comes FIRST and a label-only entry with
+// the same label comes SECOND, they stay distinct. We can't safely assume
+// the label-only is the same source — label collisions are real (two PRs
+// titled identically in different repos). The forward direction is only
+// safe because pre-#476 fact files have no URLs at all, so a label-only
+// entry necessarily comes from before any URL-keyed entry for that source.
+//
+// Future maintainer note: if you're tempted to "fix" this asymmetry by
+// deduping reversed-order entries too, read the docstring on mergeCitations
+// first. This test will fail if you do — that failure is intentional.
+func TestMergeCitations_DoesNotMergeReverseDirection(t *testing.T) {
+	inputs := []mergeInput{
+		{Text: "x [1]", Cites: []citation{{Num: 1, Label: "Foo", URL: "https://example.com/foo", Key: "https://example.com/foo"}}},
+		{Text: "y [1]", Cites: []citation{{Num: 1, Label: "Foo", Key: "label:Foo"}}}, // legacy / different source
+	}
+	_, merged := mergeCitations(inputs)
+	if len(merged) != 2 {
+		t.Fatalf("URL-first then label-only-second must stay distinct (label collision risk), got %d: %+v", len(merged), merged)
+	}
+}
+
+// TestMergeCitations_PreservesFirstAppearanceOrder — ordering by first
+// appearance keeps the merged Sources section stable across runs.
+func TestMergeCitations_PreservesFirstAppearanceOrder(t *testing.T) {
+	inputs := []mergeInput{
+		{Text: "x [1]", Cites: []citation{{Num: 1, Label: "Alpha", URL: "u-a", Key: "u-a"}}},
+		{Text: "y [1]", Cites: []citation{{Num: 1, Label: "Beta", URL: "u-b", Key: "u-b"}}},
+		{Text: "z [1]", Cites: []citation{{Num: 1, Label: "Alpha", URL: "u-a", Key: "u-a"}}},
+	}
+	_, merged := mergeCitations(inputs)
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 unique merged citations, got %d", len(merged))
+	}
+	if merged[0].Label != "Alpha" || merged[1].Label != "Beta" {
+		t.Errorf("first-appearance order broken: %v", []string{merged[0].Label, merged[1].Label})
+	}
+}
+
+func itoa(n int) string {
+	if n < 10 {
+		return string(rune('0' + n))
+	}
+	// quick hack for the test — this won't be called with large values
+	var out []byte
+	for n > 0 {
+		out = append([]byte{byte('0' + n%10)}, out...)
+		n /= 10
+	}
+	return string(out)
+}

--- a/cmd/ox/distill_coverage_test.go
+++ b/cmd/ox/distill_coverage_test.go
@@ -339,7 +339,7 @@ func TestFormatDailyMemory_AllCombinations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatDailyMemory(tt.date, tt.content, tt.obsCount, tt.factCount, nil)
+			got := formatDailyMemory(tt.date, tt.content, tt.obsCount, tt.factCount, nil, nil)
 			if len(got) == 0 {
 				t.Fatal("formatDailyMemory returned empty string")
 			}

--- a/cmd/ox/distill_discussions.go
+++ b/cmd/ox/distill_discussions.go
@@ -28,6 +28,7 @@ const highImportanceThreshold = 0.5
 type discussionInput struct {
 	DirName        string // directory name (e.g., "2026-03-10-1423-ryan")
 	Title          string
+	RecordingID    string // from metadata.json; empty for legacy/audio-only discussions
 	CreatedAt      time.Time
 	Summary        string
 	Transcript     string // formatted speaker text from VTT, or empty
@@ -103,6 +104,7 @@ func scanPendingDiscussions(tcPath string, since time.Time) ([]discussionInput, 
 		di := discussionInput{
 			DirName:     dirName,
 			Title:       meta.Title,
+			RecordingID: meta.RecordingID,
 			CreatedAt:   createdAt,
 			Summary:     loadDiscussionSummary(dirPath),
 			Transcript:  loadDiscussionTranscript(dirPath),
@@ -265,7 +267,11 @@ func categorizeAnnotations(af *discussion.AnnotationsFile) (decisions, learnings
 // Works with both v1 and v2 server summary formats. The top-level fact categories
 // (decisions, learnings, etc.) are identical in both versions. Chapters are only
 // present in v2 and contribute to context facts when available.
-func extractFactsFromSummaryJSON(d discussionInput, sourceHash string) (string, error) {
+//
+// teamID and ep are used to populate per-fact SourceURL for clickable citations
+// in distilled summaries (gh #476). Either may be empty — buildDiscussionURL
+// returns empty in that case and citations degrade gracefully to label-only.
+func extractFactsFromSummaryJSON(d discussionInput, sourceHash, teamID, ep string) (string, error) {
 	summary, err := discussion.LoadSummary(d.SummaryJSONDir)
 	if err != nil {
 		return "", fmt.Errorf("load summary.json: %w", err)
@@ -279,53 +285,38 @@ func extractFactsFromSummaryJSON(d discussionInput, sourceHash string) (string, 
 
 	ts := d.CreatedAt.Format(time.RFC3339)
 	sourceRef := fmt.Sprintf("discussions/%s", d.DirName)
+	// recording_id may be empty for legacy / audio-only discussions; buildDiscussionURL handles that
+	sourceURL := buildDiscussionURL(ep, teamID, summary.RecordingID)
+	sourceTitle := summary.Title // already loaded; no extra I/O
+
+	mkFact := func(headline, category string) facts.Fact {
+		return facts.Fact{
+			Headline:    headline,
+			SourceType:  facts.SourceDiscussion,
+			SourceRef:   sourceRef,
+			SourceURL:   sourceURL,
+			SourceTitle: sourceTitle,
+			Timestamp:   ts,
+			Category:    category,
+		}
+	}
 
 	var parsedFacts []facts.Fact
 
 	for _, item := range summary.Decisions {
-		parsedFacts = append(parsedFacts, facts.Fact{
-			Headline:   item.Text(),
-			SourceType: facts.SourceDiscussion,
-			SourceRef:  sourceRef,
-			Timestamp:  ts,
-			Category:   facts.CategoryDecision,
-		})
+		parsedFacts = append(parsedFacts, mkFact(item.Text(), facts.CategoryDecision))
 	}
 	for _, item := range summary.Learnings {
-		parsedFacts = append(parsedFacts, facts.Fact{
-			Headline:   item.Text(),
-			SourceType: facts.SourceDiscussion,
-			SourceRef:  sourceRef,
-			Timestamp:  ts,
-			Category:   facts.CategoryLearning,
-		})
+		parsedFacts = append(parsedFacts, mkFact(item.Text(), facts.CategoryLearning))
 	}
 	for _, item := range summary.ActionItems {
-		parsedFacts = append(parsedFacts, facts.Fact{
-			Headline:   item.Text(),
-			SourceType: facts.SourceDiscussion,
-			SourceRef:  sourceRef,
-			Timestamp:  ts,
-			Category:   facts.CategoryActionItem,
-		})
+		parsedFacts = append(parsedFacts, mkFact(item.Text(), facts.CategoryActionItem))
 	}
 	for _, item := range summary.OpenQuestions {
-		parsedFacts = append(parsedFacts, facts.Fact{
-			Headline:   item.Text(),
-			SourceType: facts.SourceDiscussion,
-			SourceRef:  sourceRef,
-			Timestamp:  ts,
-			Category:   facts.CategoryOpenQuestion,
-		})
+		parsedFacts = append(parsedFacts, mkFact(item.Text(), facts.CategoryOpenQuestion))
 	}
 	for _, item := range summary.Requirements {
-		parsedFacts = append(parsedFacts, facts.Fact{
-			Headline:   item.Text(),
-			SourceType: facts.SourceDiscussion,
-			SourceRef:  sourceRef,
-			Timestamp:  ts,
-			Category:   facts.CategoryContext,
-		})
+		parsedFacts = append(parsedFacts, mkFact(item.Text(), facts.CategoryContext))
 	}
 
 	// key context from TechnicalContext, Constraints, NonGoals, and (v2 only) high-importance chapters
@@ -344,13 +335,7 @@ func extractFactsFromSummaryJSON(d discussionInput, sourceHash string) (string, 
 		}
 	}
 	for _, item := range keyContext {
-		parsedFacts = append(parsedFacts, facts.Fact{
-			Headline:   item,
-			SourceType: facts.SourceDiscussion,
-			SourceRef:  sourceRef,
-			Timestamp:  ts,
-			Category:   facts.CategoryContext,
-		})
+		parsedFacts = append(parsedFacts, mkFact(item, facts.CategoryContext))
 	}
 
 	header := facts.FileHeader{

--- a/cmd/ox/distill_discussions.go
+++ b/cmd/ox/distill_discussions.go
@@ -285,9 +285,20 @@ func extractFactsFromSummaryJSON(d discussionInput, sourceHash, teamID, ep strin
 
 	ts := d.CreatedAt.Format(time.RFC3339)
 	sourceRef := fmt.Sprintf("discussions/%s", d.DirName)
-	// recording_id may be empty for legacy / audio-only discussions; buildDiscussionURL handles that
-	sourceURL := buildDiscussionURL(ep, teamID, summary.RecordingID)
-	sourceTitle := summary.Title // already loaded; no extra I/O
+	// Prefer summary.json (canonical) but fall back to metadata.json values
+	// that scanPendingDiscussions already loaded into d. Older or partially
+	// populated server summaries can omit recording_id / title; without this
+	// fallback, those discussions silently lose clickable links.
+	recordingID := summary.RecordingID
+	if recordingID == "" {
+		recordingID = d.RecordingID
+	}
+	sourceTitle := summary.Title
+	if sourceTitle == "" {
+		sourceTitle = d.Title
+	}
+	// recording_id may still be empty for legacy / audio-only discussions; buildDiscussionURL handles that
+	sourceURL := buildDiscussionURL(ep, teamID, recordingID)
 
 	mkFact := func(headline, category string) facts.Fact {
 		return facts.Fact{

--- a/cmd/ox/distill_discussions_test.go
+++ b/cmd/ox/distill_discussions_test.go
@@ -928,6 +928,43 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			t.Error("low-importance chapter should be excluded")
 		}
 	})
+
+	// CodeRabbit #3: when summary.json omits recording_id / title, fall back
+	// to the metadata.json values that scanPendingDiscussions already loaded
+	// into discussionInput. Older or partial server summaries should still
+	// produce clickable citations.
+	//
+	// Failure prevented: a discussion with metadata.json but a stripped-down
+	// summary.json silently loses its recording link in distilled summaries.
+	t.Run("metadata.json fallback when summary.json omits recording_id and title", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSummaryJSON(t, dir, map[string]any{
+			"schema_version": 2,
+			// recording_id and title intentionally absent / empty
+			"recording_id":  "",
+			"title":         "",
+			"human_summary": "summary",
+			"decisions":     []map[string]any{{"description": "ship the demo"}},
+		})
+
+		d := discussionInput{
+			DirName:        "2026-03-20-1423-person",
+			Title:          "Title from metadata.json",
+			RecordingID:    "rec_from_metadata",
+			CreatedAt:      time.Date(2026, 3, 20, 14, 23, 0, 0, time.UTC),
+			SummaryJSONDir: dir,
+		}
+
+		output, err := extractFactsFromSummaryJSON(d, "test-hash", "team_test", "https://sageox.ai")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// source_url should be built from the metadata.json fallback recording_id
+		assertContains(t, output, `"source_url":"https://sageox.ai/team/team_test/media/recordings/rec_from_metadata"`)
+		// source_title should fall back to the metadata.json title
+		assertContains(t, output, `"source_title":"Title from metadata.json"`)
+	})
 }
 
 // test helpers

--- a/cmd/ox/distill_discussions_test.go
+++ b/cmd/ox/distill_discussions_test.go
@@ -549,7 +549,7 @@ func TestFormatDailyMemoryWithDiscussions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content := formatDailyMemory("2026-03-11", "content", tt.obsCount, tt.discCount, nil)
+			content := formatDailyMemory("2026-03-11", "content", tt.obsCount, tt.discCount, nil, nil)
 			if !strings.Contains(content, tt.wantSource) {
 				t.Errorf("expected %q in output, got:\n%s", tt.wantSource, content)
 			}
@@ -668,7 +668,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d, "test-hash-123")
+		output, err := extractFactsFromSummaryJSON(d, "test-hash-123", "team_test", "https://sageox.ai")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -689,6 +689,49 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 		assertContains(t, output, "token service is stateless")
 		assertContains(t, output, "Okta SAML provider")
 		assertContains(t, output, "latency budget is 50ms")
+
+		// gh #476 regression: every fact line MUST carry source_url and
+		// source_title so the citation pipeline can render clickable links
+		// in the final daily summary. The recording_id comes from summary.json
+		// (set by v2Base() helper as "rec-test").
+		wantURL := "https://sageox.ai/team/team_test/media/recordings/rec-test"
+		assertContains(t, output, `"source_url":"`+wantURL+`"`)
+		// title comes from summary.json title field (set by v2Base() as "Test")
+		assertContains(t, output, `"source_title":"Test"`)
+	})
+
+	// TestExtractFactsFromSummaryJSON_NoRecordingID covers the audio-only /
+	// legacy fallback: when summary.json has no recording_id, source_url is
+	// empty (graceful degradation — citation pipeline renders label-only).
+	// Failure prevented: panic / broken URL when discussions lack a recording.
+	t.Run("missing recording_id leaves source_url empty", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSummaryJSON(t, dir, map[string]any{
+			"schema_version": 2,
+			"recording_id":   "", // legacy / audio-only
+			"title":          "Audio-only sync",
+			"human_summary":  "summary",
+			"decisions":      []map[string]any{{"description": "ship the demo"}},
+		})
+
+		d := discussionInput{
+			DirName:        "2026-03-20-1423-person",
+			Title:          "Audio-only sync",
+			CreatedAt:      time.Date(2026, 3, 20, 14, 23, 0, 0, time.UTC),
+			SummaryJSONDir: dir,
+		}
+
+		output, err := extractFactsFromSummaryJSON(d, "test-hash", "team_test", "https://sageox.ai")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertContains(t, output, "ship the demo")
+		// source_url should be omitted (empty) — JSON omitempty drops the field entirely
+		if strings.Contains(output, `"source_url":`) {
+			t.Errorf("expected source_url omitted when recording_id is empty, got:\n%s", output)
+		}
+		// source_title should still be present
+		assertContains(t, output, `"source_title":"Audio-only sync"`)
 	})
 
 	t.Run("v1 summary with categorized facts — succeeds without chapters", func(t *testing.T) {
@@ -709,7 +752,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d, "v1-hash")
+		output, err := extractFactsFromSummaryJSON(d, "v1-hash", "team_test", "https://sageox.ai")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -734,7 +777,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		_, err := extractFactsFromSummaryJSON(d, "test-hash")
+		_, err := extractFactsFromSummaryJSON(d, "test-hash", "team_test", "https://sageox.ai")
 		if err == nil {
 			t.Fatal("expected error for empty facts")
 		}
@@ -751,7 +794,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		_, err := extractFactsFromSummaryJSON(d, "test-hash")
+		_, err := extractFactsFromSummaryJSON(d, "test-hash", "team_test", "https://sageox.ai")
 		if err == nil {
 			t.Fatal("expected error for missing summary.json")
 		}
@@ -780,7 +823,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d, "test-hash")
+		output, err := extractFactsFromSummaryJSON(d, "test-hash", "team_test", "https://sageox.ai")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -812,7 +855,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d, "test-hash")
+		output, err := extractFactsFromSummaryJSON(d, "test-hash", "team_test", "https://sageox.ai")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -847,7 +890,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d, "test-hash")
+		output, err := extractFactsFromSummaryJSON(d, "test-hash", "team_test", "https://sageox.ai")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -875,7 +918,7 @@ func TestExtractFactsFromSummaryJSON(t *testing.T) {
 			SummaryJSONDir: dir,
 		}
 
-		output, err := extractFactsFromSummaryJSON(d, "test-hash")
+		output, err := extractFactsFromSummaryJSON(d, "test-hash", "team_test", "https://sageox.ai")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/ox/distill_gh476_regression_test.go
+++ b/cmd/ox/distill_gh476_regression_test.go
@@ -311,7 +311,80 @@ func TestObservationSourcePaths_ConvertsToRelative(t *testing.T) {
 	}
 }
 
-// --- G. Type-check sentinel: agentcli.FactCitation roundtrip ---
+// --- G. mirrorGitHubSourceURL (CodeRabbit round-1 #4) ---
+
+// TestMirrorGitHubSourceURL covers the cases mirrorGitHubSourceURL is
+// expected to handle: http(s) URLs are mirrored, non-URL refs are skipped,
+// existing source_url is never overwritten, and leading/trailing whitespace
+// in source_ref is trimmed before the scheme check.
+//
+// Failure prevented: github fact files with stray whitespace in source_ref
+// (LLM extractor occasionally emits these) silently produce linkless citations.
+func TestMirrorGitHubSourceURL(t *testing.T) {
+	tests := []struct {
+		name           string
+		in             facts.Fact
+		wantURL        string
+		wantNormalized string // expected source_ref after the function returns (may be trimmed)
+	}{
+		{
+			name:           "https url mirrored",
+			in:             facts.Fact{SourceType: facts.SourceGitHub, SourceRef: "https://github.com/sageox/ox/pull/152"},
+			wantURL:        "https://github.com/sageox/ox/pull/152",
+			wantNormalized: "https://github.com/sageox/ox/pull/152",
+		},
+		{
+			name:           "http url mirrored",
+			in:             facts.Fact{SourceType: facts.SourceGitHub, SourceRef: "http://example.com/x"},
+			wantURL:        "http://example.com/x",
+			wantNormalized: "http://example.com/x",
+		},
+		{
+			name:           "leading whitespace trimmed and mirrored",
+			in:             facts.Fact{SourceType: facts.SourceGitHub, SourceRef: "  https://github.com/sageox/ox/pull/1"},
+			wantURL:        "https://github.com/sageox/ox/pull/1",
+			wantNormalized: "https://github.com/sageox/ox/pull/1",
+		},
+		{
+			name:           "trailing whitespace trimmed and mirrored",
+			in:             facts.Fact{SourceType: facts.SourceGitHub, SourceRef: "https://github.com/sageox/ox/pull/1\n"},
+			wantURL:        "https://github.com/sageox/ox/pull/1",
+			wantNormalized: "https://github.com/sageox/ox/pull/1",
+		},
+		{
+			name:           "non-url ref skipped",
+			in:             facts.Fact{SourceType: facts.SourceGitHub, SourceRef: "github.com/sageox/ox/pull/1"},
+			wantURL:        "",
+			wantNormalized: "github.com/sageox/ox/pull/1",
+		},
+		{
+			name:           "empty ref skipped",
+			in:             facts.Fact{SourceType: facts.SourceGitHub, SourceRef: ""},
+			wantURL:        "",
+			wantNormalized: "",
+		},
+		{
+			name:           "existing source_url not overwritten",
+			in:             facts.Fact{SourceType: facts.SourceGitHub, SourceRef: "https://github.com/a/b/pull/1", SourceURL: "https://override.example.com"},
+			wantURL:        "https://override.example.com",
+			wantNormalized: "https://github.com/a/b/pull/1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := []facts.Fact{tt.in}
+			mirrorGitHubSourceURL(fs)
+			if fs[0].SourceURL != tt.wantURL {
+				t.Errorf("SourceURL = %q, want %q", fs[0].SourceURL, tt.wantURL)
+			}
+			if fs[0].SourceRef != tt.wantNormalized {
+				t.Errorf("SourceRef = %q, want %q", fs[0].SourceRef, tt.wantNormalized)
+			}
+		})
+	}
+}
+
+// --- H. Type-check sentinel: agentcli.FactCitation roundtrip ---
 
 // TestAgentcliFactCitation_FieldNames is a sentinel test that the FactCitation
 // struct exposes the fields buildFactCitationsForPrompt populates. If the

--- a/cmd/ox/distill_gh476_regression_test.go
+++ b/cmd/ox/distill_gh476_regression_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/agentcli"
+	"github.com/sageox/ox/internal/facts"
+)
+
+// --- A. End-to-end formatDailyMemory with citations ---
+
+// TestFormatDailyMemory_AppendsSourcesSection — gh #476 happy path. Given a
+// citation list, the rendered daily contains both the Sources numbered list
+// AND the reference link definitions, plus the existing frontmatter.
+//
+// Failure prevented: the bug from #476 — daily summary cites a discussion
+// learning but the reader has no way to drill into the original recording.
+func TestFormatDailyMemory_AppendsSourcesSection(t *testing.T) {
+	cites := []citation{
+		{
+			Num:   1,
+			Label: "Discussion: 2026-03-10 — Architecture sync",
+			URL:   "https://sageox.ai/team/team_x/media/recordings/rec_y",
+			Key:   "https://sageox.ai/team/team_x/media/recordings/rec_y",
+		},
+		{
+			Num:   2,
+			Label: "sageox/ox#152",
+			URL:   "https://github.com/sageox/ox/pull/152",
+			Key:   "https://github.com/sageox/ox/pull/152",
+		},
+	}
+	body := "## What We Learned\n\n- Natural language is more merge-friendly than code. [1]\n\n## What Shipped\n\n- Adopted rate limiting in [PR #152][2]."
+	out := formatDailyMemory("2026-03-10", body, 0, 5, []string{"memory/.discussion-facts/x.jsonl", "memory/.github-facts/y.jsonl"}, cites)
+
+	// Frontmatter still present (cache index input list)
+	if !strings.HasPrefix(out, "---\nsources:\n") {
+		t.Errorf("missing YAML frontmatter, got:\n%s", out)
+	}
+	if !strings.Contains(out, "memory/.discussion-facts/x.jsonl") {
+		t.Errorf("frontmatter missing fact file path")
+	}
+
+	// Body preserved with citation markers intact
+	if !strings.Contains(out, "Natural language is more merge-friendly than code. [1]") {
+		t.Errorf("body lost bare citation marker")
+	}
+	if !strings.Contains(out, "Adopted rate limiting in [PR #152][2]") {
+		t.Errorf("body lost ref-link citation")
+	}
+
+	// Sources section present
+	if !strings.Contains(out, "## Sources") {
+		t.Errorf("missing Sources section")
+	}
+	if !strings.Contains(out, "1. [Discussion: 2026-03-10 — Architecture sync][1]") {
+		t.Errorf("missing numbered citation 1")
+	}
+	if !strings.Contains(out, "2. [sageox/ox#152][2]") {
+		t.Errorf("missing numbered citation 2")
+	}
+
+	// Reference link definitions present so [1] / [PR #152][2] resolve when rendered
+	if !strings.Contains(out, "[1]: https://sageox.ai/team/team_x/media/recordings/rec_y") {
+		t.Errorf("missing ref definition for [1]")
+	}
+	if !strings.Contains(out, "[2]: https://github.com/sageox/ox/pull/152") {
+		t.Errorf("missing ref definition for [2]")
+	}
+
+	// Footer is still last
+	if !strings.HasSuffix(strings.TrimRight(out, "\n"), "*Distilled from 5 facts*") {
+		t.Errorf("footer missing or not last, got tail:\n%s", out[max(0, len(out)-200):])
+	}
+}
+
+// TestFormatDailyMemory_OmitsSourcesSectionWhenNoCites — when no facts are
+// citable, no Sources section is appended. Don't print an empty heading.
+func TestFormatDailyMemory_OmitsSourcesSectionWhenNoCites(t *testing.T) {
+	out := formatDailyMemory("2026-03-10", "Just narrative.", 3, 0, nil, nil)
+	if strings.Contains(out, "## Sources") {
+		t.Errorf("expected no Sources section when no cites:\n%s", out)
+	}
+}
+
+// --- B. Pipeline: facts → prompt-input ---
+
+// TestBuildFactCitationsForPrompt_RoundTrip ensures that flat facts → citations
+// → prompt-input attaches the right citation number to each fact, and that
+// uncitable facts are excluded entirely.
+//
+// Failure prevented: a fact-with-no-source silently becomes a [N] marker
+// pointing at someone else's source, OR an uncitable fact gets a [0] number.
+func TestBuildFactCitationsForPrompt_RoundTrip(t *testing.T) {
+	flat := []facts.Fact{
+		{
+			Headline:    "Decision A",
+			SourceType:  facts.SourceDiscussion,
+			SourceURL:   "https://sageox.ai/team/t/media/recordings/rec_a",
+			SourceTitle: "Discussion A",
+			Timestamp:   "2026-03-10T00:00:00Z",
+		},
+		{
+			// uncitable: no URL, no ref
+			Headline:   "Stray observation",
+			SourceType: facts.SourceObservation,
+		},
+		{
+			Headline:    "Decision B",
+			SourceType:  facts.SourceGitHub,
+			SourceURL:   "https://github.com/sageox/ox/pull/152",
+			SourceTitle: "Add rate limiting",
+			Timestamp:   "2026-03-11T00:00:00Z",
+		},
+	}
+	cites, factToNum := buildCitationsFromFacts(flat)
+	citedFacts := buildFactCitationsForPrompt(flat, factToNum)
+
+	if len(cites) != 2 {
+		t.Fatalf("expected 2 citations (uncitable excluded), got %d", len(cites))
+	}
+	if len(citedFacts) != 2 {
+		t.Fatalf("expected 2 cited facts in prompt input, got %d", len(citedFacts))
+	}
+
+	// fact[0] (Decision A) should map to citation 1
+	if citedFacts[0].Num != 1 || citedFacts[0].Headline != "Decision A" {
+		t.Errorf("fact[0] mapping wrong: num=%d headline=%q", citedFacts[0].Num, citedFacts[0].Headline)
+	}
+	// fact[2] (Decision B) — fact[1] was skipped — should map to citation 2
+	if citedFacts[1].Num != 2 || citedFacts[1].Headline != "Decision B" {
+		t.Errorf("fact[1] mapping wrong: num=%d headline=%q", citedFacts[1].Num, citedFacts[1].Headline)
+	}
+	// SourceTitle and Date should be threaded through to the prompt
+	if citedFacts[0].SourceTitle != "Discussion A" {
+		t.Errorf("SourceTitle not threaded: got %q", citedFacts[0].SourceTitle)
+	}
+	if citedFacts[0].Date != "2026-03-10" {
+		t.Errorf("Date not extracted: got %q", citedFacts[0].Date)
+	}
+}
+
+// --- C. Backwards compatibility with legacy fact files ---
+
+// TestBuildCitationsFromFacts_LegacyFactsHaveNoSourceURL covers fact files
+// written before #476 (no source_url field). They should still produce
+// citations using source_ref as the dedup key — just without clickable URLs.
+//
+// Failure prevented: an existing team context with old fact files breaks
+// catastrophically when distilled with the new pipeline.
+func TestBuildCitationsFromFacts_LegacyFactsHaveNoSourceURL(t *testing.T) {
+	// pre-#476 fact: source_ref only, no source_url, no source_title
+	legacy := []facts.Fact{
+		{
+			Headline:   "old decision",
+			SourceType: facts.SourceDiscussion,
+			SourceRef:  "discussions/2026-01-15-1000-alice",
+			Timestamp:  "2026-01-15T10:00:00Z",
+		},
+	}
+	cites, factToNum := buildCitationsFromFacts(legacy)
+	if len(cites) != 1 {
+		t.Fatalf("expected 1 citation for legacy fact, got %d", len(cites))
+	}
+	if cites[0].URL != "" {
+		t.Errorf("legacy fact should have empty URL (graceful), got %q", cites[0].URL)
+	}
+	// label should still be human-readable
+	if !strings.Contains(cites[0].Label, "Discussion") {
+		t.Errorf("legacy fact label should still mention source type, got %q", cites[0].Label)
+	}
+	if factToNum[0] != 1 {
+		t.Errorf("legacy fact should still get citation number")
+	}
+}
+
+// --- D. Multi-layer citation propagation ---
+
+// TestMergeCitationsFromMarkdown_RealisticDailies simulates the weekly distill
+// reading two daily summary files. Each has its own per-day numbering, and a
+// shared discussion appears in both. After mergeCitationsFromMarkdown:
+//   - the shared discussion appears ONCE in the merged list
+//   - both dailies' prose markers point at the same global number
+//
+// This is the gh #476 cross-layer property the weekly stage relies on.
+func TestMergeCitationsFromMarkdown_RealisticDailies(t *testing.T) {
+	day1 := `# Daily Memory — 2026-03-10
+
+## What We Learned
+
+- Natural language is more merge-friendly than code. [1]
+- Adopted rate limiting in [PR #152][2].
+
+## Sources
+
+1. [Discussion: 2026-03-10 — Architecture sync][1]
+2. [sageox/ox#152][2]
+
+[1]: https://sageox.ai/team/t/media/recordings/rec_arch
+[2]: https://github.com/sageox/ox/pull/152
+
+---
+*Distilled from 0 observations and 2 facts*
+`
+	day2 := `# Daily Memory — 2026-03-11
+
+## What Shipped
+
+- Following the [architecture decision][1], rolled out the new auth layer.
+
+## Sources
+
+1. [Discussion: 2026-03-10 — Architecture sync][1]
+
+[1]: https://sageox.ai/team/t/media/recordings/rec_arch
+
+---
+*Distilled from 0 observations and 1 facts*
+`
+
+	rewritten, merged := mergeCitationsFromMarkdown([]string{day1, day2})
+
+	// Architecture sync was [1] in day1 and [1] in day2 — should dedupe to ONE entry
+	archCount := 0
+	prCount := 0
+	for _, c := range merged {
+		if strings.Contains(c.Label, "Architecture sync") {
+			archCount++
+		}
+		if strings.Contains(c.Label, "sageox/ox#152") {
+			prCount++
+		}
+	}
+	if archCount != 1 {
+		t.Errorf("expected Architecture sync to appear once in merged, got %d", archCount)
+	}
+	if prCount != 1 {
+		t.Errorf("expected PR #152 to appear once in merged, got %d", prCount)
+	}
+	if len(merged) != 2 {
+		t.Errorf("expected exactly 2 merged citations, got %d", len(merged))
+	}
+
+	// both dailies' arch-discussion markers should now point at the same global number.
+	// In day1 the arch was [1]; in day2 it was [1] too — they should match in the rewritten output.
+	if !strings.Contains(rewritten[0], "Natural language is more merge-friendly than code. [1]") {
+		t.Errorf("day1 marker should still be [1] after merge, got:\n%s", rewritten[0])
+	}
+	if !strings.Contains(rewritten[1], "[architecture decision][1]") {
+		t.Errorf("day2 should reference the merged citation [1], got:\n%s", rewritten[1])
+	}
+	// PR #152 was [2] in day1 and absent in day2 — stays as [2] in day1
+	if !strings.Contains(rewritten[0], "[PR #152][2]") {
+		t.Errorf("day1 PR marker should still be [2], got:\n%s", rewritten[0])
+	}
+}
+
+// --- E. Cache index regression: frontmatter still parseable ---
+
+// TestFormatDailyMemory_FrontmatterStillParseable — gh #476 explicitly preserved
+// the YAML frontmatter for cache-index dedup. Make sure parseDailySources can
+// still read it back after we add the Sources section in the body.
+//
+// Failure prevented: cache index can't track inputs → infinite re-distillation
+// loops that re-process every fact on every run.
+func TestFormatDailyMemory_FrontmatterStillParseable(t *testing.T) {
+	cites := []citation{
+		{Num: 1, Label: "Discussion: x", URL: "https://example.com/x", Key: "https://example.com/x"},
+	}
+	sources := []string{
+		"memory/.discussion-facts/2026-03-10-abc.jsonl",
+		"memory/.github-facts/2026-03-10-def.jsonl",
+		"memory/.observations/2026-03-10/ghi.jsonl",
+	}
+	out := formatDailyMemory("2026-03-10", "Body. [1]", 1, 2, sources, cites)
+
+	parsed := parseDailySources(out)
+	if len(parsed) != 3 {
+		t.Fatalf("parseDailySources lost entries: got %v", parsed)
+	}
+	for i, want := range sources {
+		if parsed[i] != want {
+			t.Errorf("source[%d] = %q, want %q", i, parsed[i], want)
+		}
+	}
+}
+
+// --- F. Observations in frontmatter, not in citations (per #476 design) ---
+
+// TestObservationSourcePaths_ConvertsToRelative ensures observation source
+// files are recorded in the frontmatter as relative paths (so the cache index
+// keys match across machines), but observations don't appear in the citation
+// list (per design — they're weaved into prose without [N] markers).
+func TestObservationSourcePaths_ConvertsToRelative(t *testing.T) {
+	tcPath := "/team/context"
+	obs := []distillObservation{
+		{Content: "obs 1", SourceFile: "/team/context/memory/.observations/2026-03-10/abc.jsonl"},
+		{Content: "obs 2", SourceFile: "/team/context/memory/.observations/2026-03-10/abc.jsonl"}, // duplicate file
+		{Content: "obs 3", SourceFile: "/team/context/memory/.observations/2026-03-10/def.jsonl"},
+	}
+	got := observationSourcePaths(tcPath, obs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unique source paths, got %d: %v", len(got), got)
+	}
+	if got[0] != "memory/.observations/2026-03-10/abc.jsonl" {
+		t.Errorf("got[0] = %q, want relative path", got[0])
+	}
+	if got[1] != "memory/.observations/2026-03-10/def.jsonl" {
+		t.Errorf("got[1] = %q, want relative path", got[1])
+	}
+}
+
+// --- G. Type-check sentinel: agentcli.FactCitation roundtrip ---
+
+// TestAgentcliFactCitation_FieldNames is a sentinel test that the FactCitation
+// struct exposes the fields buildFactCitationsForPrompt populates. If the
+// struct is renamed without updating callers, this test pins the contract.
+func TestAgentcliFactCitation_FieldNames(t *testing.T) {
+	fc := agentcli.FactCitation{
+		Num:         1,
+		Headline:    "h",
+		Summary:     "s",
+		Rationale:   "r",
+		Who:         "w",
+		SourceType:  "discussion",
+		SourceTitle: "t",
+		Date:        "2026-03-10",
+		Category:    "decision",
+	}
+	if fc.Num != 1 || fc.Headline != "h" {
+		t.Fatal("FactCitation field check failed")
+	}
+}

--- a/cmd/ox/distill_github.go
+++ b/cmd/ox/distill_github.go
@@ -488,12 +488,19 @@ func extractGitHubCommitBatch(ctx context.Context, cmd *cobra.Command, mu *sync.
 // in source_ref (it's required by the extractor prompt), so this gives the
 // citation pipeline (gh #476) a uniform place to look. Skips facts whose
 // source_ref is not http(s)://, and never overwrites a populated source_url.
+//
+// SourceRef is trimmed before the scheme check (and the trimmed value is
+// written back) so an LLM-extracted ref like " https://..." with stray
+// whitespace doesn't silently produce a linkless citation.
 func mirrorGitHubSourceURL(fs []facts.Fact) {
 	for i := range fs {
 		if fs[i].SourceURL != "" {
 			continue
 		}
-		ref := fs[i].SourceRef
+		ref := strings.TrimSpace(fs[i].SourceRef)
+		if ref != fs[i].SourceRef {
+			fs[i].SourceRef = ref // normalize the stored ref too
+		}
 		if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
 			fs[i].SourceURL = ref
 		}

--- a/cmd/ox/distill_github.go
+++ b/cmd/ox/distill_github.go
@@ -89,6 +89,7 @@ For each meaningful event in the batch, produce a raw fact object:
   "who": "The primary author. If a reviewer significantly shaped the outcome, include them: 'Sarah (reviewed by Jake)'",
   "source_type": "github",
   "source_ref": "The URL of the primary GitHub object (usually the PR)",
+  "source_title": "The PR or issue title verbatim from the source — used as a citation label in distilled summaries. For commit batches, use a brief description like 'commits on <date>'.",
   "timestamp": "ISO 8601 timestamp of the most recent meaningful event (merge time for shipped PRs, latest review comment for in-progress PRs, creation time for new issues)",
   "category": "ship|decision|blocker|direction_change — the type of signal (optional)"
 }
@@ -370,6 +371,10 @@ func extractSingleGitHubItem(ctx context.Context, cmd *cobra.Command, mu *sync.M
 		return nil
 	}
 
+	// github source_ref is already a URL — mirror it to source_url so the
+	// citation pipeline (gh #476) has a uniform field across all source types.
+	mirrorGitHubSourceURL(parsedFacts)
+
 	header := facts.FileHeader{
 		Meta: facts.FileMeta{
 			SchemaVersion: facts.SchemaVersion,
@@ -460,6 +465,10 @@ func extractGitHubCommitBatch(ctx context.Context, cmd *cobra.Command, mu *sync.
 		return nil
 	}
 
+	// github source_ref is already a URL — mirror it to source_url so the
+	// citation pipeline (gh #476) has a uniform field across all source types.
+	mirrorGitHubSourceURL(parsedFacts)
+
 	if err := facts.WriteFacts(fullPath, header, parsedFacts); err != nil {
 		return fmt.Errorf("write github facts: %w", err)
 	}
@@ -472,6 +481,23 @@ func extractGitHubCommitBatch(ctx context.Context, cmd *cobra.Command, mu *sync.
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s (%d facts)\n", factFile, len(parsedFacts))
 	return nil
+}
+
+// mirrorGitHubSourceURL copies source_ref → source_url for github facts that
+// don't already have a URL set. github facts always carry their PR/issue URL
+// in source_ref (it's required by the extractor prompt), so this gives the
+// citation pipeline (gh #476) a uniform place to look. Skips facts whose
+// source_ref is not http(s)://, and never overwrites a populated source_url.
+func mirrorGitHubSourceURL(fs []facts.Fact) {
+	for i := range fs {
+		if fs[i].SourceURL != "" {
+			continue
+		}
+		ref := fs[i].SourceRef
+		if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+			fs[i].SourceURL = ref
+		}
+	}
 }
 
 // findLatestFactFileSourceHash globs factsDir for files matching pattern, picks the

--- a/cmd/ox/distill_pure_test.go
+++ b/cmd/ox/distill_pure_test.go
@@ -230,7 +230,7 @@ func TestFormatDailyMemory_SourceVariants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := formatDailyMemory("2026-03-25", "Distilled content here.", tt.obsCount, tt.factCount, nil)
+			result := formatDailyMemory("2026-03-25", "Distilled content here.", tt.obsCount, tt.factCount, nil, nil)
 			assert.Contains(t, result, "# Daily Memory")
 			assert.Contains(t, result, "2026-03-25")
 			assert.Contains(t, result, "Distilled content here.")

--- a/cmd/ox/distill_sessions.go
+++ b/cmd/ox/distill_sessions.go
@@ -45,9 +45,11 @@ type sessionInput struct {
 //
 // repoID identifies the repo for per-repo state tracking.
 // ledgerPath is the path to the ledger directory containing sessions/.
+// ep is the endpoint used to build per-fact SourceURL for clickable citations
+// in distilled summaries (gh #476). Empty endpoint degrades to label-only.
 //
 // No LLM calls — pure data transformation from structured summary.json.
-func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, repoID, ledgerPath string, since time.Time) error {
+func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, repoID, ledgerPath, ep string, since time.Time) error {
 	if ledgerPath == "" {
 		slog.Debug("no ledger path, skipping session fact extraction", "repo", repoID)
 		return nil
@@ -82,7 +84,7 @@ func extractSessionFacts(cmd *cobra.Command, tc *config.TeamContext, repoID, led
 			recordedAt = s.StartedAt.UTC().Format(time.RFC3339)
 		}
 
-		extractedFacts := sessionSummaryToFacts(s)
+		extractedFacts := sessionSummaryToFacts(s, repoID, ep)
 		if len(extractedFacts) == 0 {
 			slog.Debug("no facts extracted from session", "session", s.DirName)
 			// write empty marker so scanPendingSessions skips this session
@@ -292,7 +294,14 @@ func sessionContentHash(ledgerPath, dirName string) string {
 
 // sessionSummaryToFacts transforms a session summary into uniform facts.
 // Pure data transformation — no LLM calls.
-func sessionSummaryToFacts(input sessionInput) []facts.Fact {
+//
+// repoID + ep populate per-fact SourceURL for clickable citations in distilled
+// summaries (gh #476). When either is empty, SourceURL is left empty and the
+// citation pipeline degrades to a label-only entry. We deliberately do NOT
+// fall through to buildSessionURL with an empty cfg, because that helper's
+// cfg.GetEndpoint() would resolve to the SAGEOX_ENDPOINT env var or the
+// default — silently producing a wrong URL in tests / unconfigured runs.
+func sessionSummaryToFacts(input sessionInput, repoID, ep string) []facts.Fact {
 	var result []facts.Fact
 	s := input.Summary
 	ts := input.Date
@@ -300,6 +309,26 @@ func sessionSummaryToFacts(input sessionInput) []facts.Fact {
 		ts = input.StartedAt.UTC().Format(time.RFC3339)
 	}
 	ref := "sessions/" + input.DirName
+	var sourceURL string
+	if repoID != "" && ep != "" {
+		sourceURL = buildSessionURL(&config.ProjectConfig{RepoID: repoID, Endpoint: ep}, input.DirName)
+	}
+	sourceTitle := s.Title // already loaded; falls back to dirname-derived label at citation time
+
+	mkFact := func(headline, summary, rationale, who, category string) facts.Fact {
+		return facts.Fact{
+			Headline:    headline,
+			Summary:     summary,
+			Rationale:   rationale,
+			SourceType:  facts.SourceSession,
+			SourceRef:   ref,
+			SourceURL:   sourceURL,
+			SourceTitle: sourceTitle,
+			Timestamp:   ts,
+			Category:    category,
+			Who:         who,
+		}
+	}
 
 	// session context fact (title + summary)
 	if s.Title != "" && s.Summary != "" {
@@ -307,15 +336,7 @@ func sessionSummaryToFacts(input sessionInput) []facts.Fact {
 		if len(s.KeyActions) > 0 {
 			summary += " Key actions: " + strings.Join(s.KeyActions, "; ")
 		}
-		result = append(result, facts.Fact{
-			Headline:   s.Title,
-			Summary:    summary,
-			SourceType: facts.SourceSession,
-			SourceRef:  ref,
-			Timestamp:  ts,
-			Category:   facts.CategoryContext,
-			Who:        input.Who,
-		})
+		result = append(result, mkFact(s.Title, summary, "", input.Who, facts.CategoryContext))
 	}
 
 	if s.AgentSummary != nil {
@@ -325,15 +346,7 @@ func sessionSummaryToFacts(input sessionInput) []facts.Fact {
 			if who == "" {
 				who = input.Who
 			}
-			result = append(result, facts.Fact{
-				Headline:   d.What,
-				Rationale:  d.Why,
-				SourceType: facts.SourceSession,
-				SourceRef:  ref,
-				Timestamp:  ts,
-				Category:   facts.CategoryDecision,
-				Who:        who,
-			})
+			result = append(result, mkFact(d.What, "", d.Why, who, facts.CategoryDecision))
 		}
 
 		// action items
@@ -346,28 +359,12 @@ func sessionSummaryToFacts(input sessionInput) []facts.Fact {
 			if a.Priority != "" {
 				summary = fmt.Sprintf("Priority: %s", a.Priority)
 			}
-			result = append(result, facts.Fact{
-				Headline:   a.Task,
-				Summary:    summary,
-				SourceType: facts.SourceSession,
-				SourceRef:  ref,
-				Timestamp:  ts,
-				Category:   facts.CategoryActionItem,
-				Who:        who,
-			})
+			result = append(result, mkFact(a.Task, summary, "", who, facts.CategoryActionItem))
 		}
 
 		// open questions
 		for _, q := range s.AgentSummary.OpenQuestions {
-			result = append(result, facts.Fact{
-				Headline:   q.Question,
-				Summary:    q.Context,
-				SourceType: facts.SourceSession,
-				SourceRef:  ref,
-				Timestamp:  ts,
-				Category:   facts.CategoryOpenQuestion,
-				Who:        input.Who,
-			})
+			result = append(result, mkFact(q.Question, q.Context, "", input.Who, facts.CategoryOpenQuestion))
 		}
 	}
 
@@ -375,25 +372,9 @@ func sessionSummaryToFacts(input sessionInput) []facts.Fact {
 	for _, aha := range s.AhaMoments {
 		switch aha.Type {
 		case "insight", "breakthrough", "synthesis":
-			result = append(result, facts.Fact{
-				Headline:   aha.Highlight,
-				Summary:    aha.Why,
-				SourceType: facts.SourceSession,
-				SourceRef:  ref,
-				Timestamp:  ts,
-				Category:   facts.CategoryLearning,
-				Who:        input.Who,
-			})
+			result = append(result, mkFact(aha.Highlight, aha.Why, "", input.Who, facts.CategoryLearning))
 		case "decision":
-			result = append(result, facts.Fact{
-				Headline:   aha.Highlight,
-				Summary:    aha.Why,
-				SourceType: facts.SourceSession,
-				SourceRef:  ref,
-				Timestamp:  ts,
-				Category:   facts.CategoryDecision,
-				Who:        input.Who,
-			})
+			result = append(result, mkFact(aha.Highlight, aha.Why, "", input.Who, facts.CategoryDecision))
 		}
 	}
 

--- a/cmd/ox/distill_sessions_test.go
+++ b/cmd/ox/distill_sessions_test.go
@@ -306,7 +306,7 @@ func TestSessionSummaryToFacts(t *testing.T) {
 			Summary: testSummary("Database Migration", 0.8),
 		}
 
-		result := sessionSummaryToFacts(input)
+		result := sessionSummaryToFacts(input, "repo_test", "https://sageox.ai")
 
 		// Expected: 1 context + 1 decision + 1 action_item + 1 open_question
 		//         + 1 learning (insight) + 1 decision (aha decision)
@@ -391,7 +391,7 @@ func TestSessionSummaryToFacts(t *testing.T) {
 			},
 		}
 
-		result := sessionSummaryToFacts(input)
+		result := sessionSummaryToFacts(input, "repo_test", "https://sageox.ai")
 		if len(result) != 2 { // 1 context + 1 learning
 			t.Fatalf("got %d facts, want 2", len(result))
 		}
@@ -405,7 +405,7 @@ func TestSessionSummaryToFacts(t *testing.T) {
 			Summary: &sessionsummary.SummarizeResponse{},
 		}
 
-		result := sessionSummaryToFacts(input)
+		result := sessionSummaryToFacts(input, "repo_test", "https://sageox.ai")
 		if len(result) != 0 {
 			t.Errorf("got %d facts, want 0 for empty summary", len(result))
 		}
@@ -426,7 +426,7 @@ func TestSessionSummaryToFacts(t *testing.T) {
 			},
 		}
 
-		result := sessionSummaryToFacts(input)
+		result := sessionSummaryToFacts(input, "repo_test", "https://sageox.ai")
 		// 1 context fact only; question-type aha moments skipped
 		if len(result) != 1 {
 			t.Fatalf("got %d facts, want 1 (context only)", len(result))
@@ -452,7 +452,7 @@ func TestSessionSummaryToFacts(t *testing.T) {
 			},
 		}
 
-		result := sessionSummaryToFacts(input)
+		result := sessionSummaryToFacts(input, "repo_test", "https://sageox.ai")
 		// context + action_item = 2
 		if len(result) != 2 {
 			t.Fatalf("got %d facts, want 2", len(result))
@@ -478,7 +478,7 @@ func TestSessionSummaryToFacts(t *testing.T) {
 			},
 		}
 
-		result := sessionSummaryToFacts(input)
+		result := sessionSummaryToFacts(input, "repo_test", "https://sageox.ai")
 		// context + decision = 2 facts
 		if len(result) != 2 {
 			t.Fatalf("got %d facts, want 2", len(result))
@@ -807,7 +807,7 @@ func TestSessionSummaryToFactsStartedAt(t *testing.T) {
 			},
 		}
 
-		result := sessionSummaryToFacts(input)
+		result := sessionSummaryToFacts(input, "repo_test", "https://sageox.ai")
 		if len(result) != 1 {
 			t.Fatalf("got %d facts, want 1", len(result))
 		}
@@ -828,7 +828,7 @@ func TestSessionSummaryToFactsStartedAt(t *testing.T) {
 			},
 		}
 
-		result := sessionSummaryToFacts(input)
+		result := sessionSummaryToFacts(input, "repo_test", "https://sageox.ai")
 		if len(result) != 1 {
 			t.Fatalf("got %d facts, want 1", len(result))
 		}

--- a/cmd/ox/distill_test.go
+++ b/cmd/ox/distill_test.go
@@ -184,7 +184,7 @@ func TestWriteMemoryFile(t *testing.T) {
 }
 
 func TestFormatDailyMemory(t *testing.T) {
-	content := formatDailyMemory("2026-03-11", "Some distilled content", 5, 0, nil)
+	content := formatDailyMemory("2026-03-11", "Some distilled content", 5, 0, nil, nil)
 	if content == "" {
 		t.Error("expected non-empty content")
 	}

--- a/cmd/ox/distill_uuid7_twin_test.go
+++ b/cmd/ox/distill_uuid7_twin_test.go
@@ -78,7 +78,7 @@ func TestExtractSessionFacts_WritesUUID7Filename(t *testing.T) {
 	assert.NotEmpty(t, pending[0].Hash, "content hash must be computed")
 
 	// --- Step 2: sessionSummaryToFacts transforms to facts (pure, no LLM) ---
-	extractedFacts := sessionSummaryToFacts(pending[0])
+	extractedFacts := sessionSummaryToFacts(pending[0], "repo_test", "https://sageox.ai")
 	require.NotEmpty(t, extractedFacts, "must extract facts from summary")
 
 	// Verify fact categories match input data
@@ -200,7 +200,7 @@ func TestExtractDiscussionFacts_WritesUUID7Filename(t *testing.T) {
 	sourceHash := discussionContentHash(discussionDir)
 	require.NotEmpty(t, sourceHash)
 
-	factContent, err := extractFactsFromSummaryJSON(pending[0], sourceHash)
+	factContent, err := extractFactsFromSummaryJSON(pending[0], sourceHash, "team_test", "https://sageox.ai")
 	require.NoError(t, err)
 	require.NotEmpty(t, factContent)
 
@@ -307,7 +307,7 @@ func TestExtractDiscussionFacts_LLMPath_WritesUUID7Filename(t *testing.T) {
 	// We need a cobra command for logging — create a minimal one
 	cmd := &cobra.Command{}
 	cmd.SetOut(os.Stdout)
-	factContent, err := extractSingleDiscussionFacts(ctx, cmd, backend, pending[0], "", sourceHash)
+	factContent, err := extractSingleDiscussionFacts(ctx, cmd, backend, pending[0], "", sourceHash, "team_test", "https://sageox.ai")
 	require.NoError(t, err)
 	require.NotEmpty(t, factContent)
 
@@ -613,7 +613,7 @@ func TestSessionFacts_UUID7_RealCodePath_NoGitConflict(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pendingA, 1, "node A must find the pending session")
 
-	factsA := sessionSummaryToFacts(pendingA[0])
+	factsA := sessionSummaryToFacts(pendingA[0], "repo_a", "https://sageox.ai")
 	require.NotEmpty(t, factsA)
 
 	uidA, err := uuid.NewV7()
@@ -638,7 +638,7 @@ func TestSessionFacts_UUID7_RealCodePath_NoGitConflict(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, pendingB, 1, "node B must find the pending session")
 
-	factsB := sessionSummaryToFacts(pendingB[0])
+	factsB := sessionSummaryToFacts(pendingB[0], "repo_b", "https://sageox.ai")
 	require.NotEmpty(t, factsB)
 
 	uidB, err := uuid.NewV7()
@@ -748,7 +748,7 @@ func TestDiscussionFacts_UUID7_RealCodePath_NoGitConflict(t *testing.T) {
 	sourceHashA := discussionContentHash(filepath.Join(nodeAPath, "discussions", discussionDirName))
 	require.NotEmpty(t, sourceHashA)
 
-	factContentA, err := extractFactsFromSummaryJSON(pendingA[0], sourceHashA)
+	factContentA, err := extractFactsFromSummaryJSON(pendingA[0], sourceHashA, "team_test", "https://sageox.ai")
 	require.NoError(t, err)
 	require.NotEmpty(t, factContentA)
 
@@ -770,7 +770,7 @@ func TestDiscussionFacts_UUID7_RealCodePath_NoGitConflict(t *testing.T) {
 	sourceHashB := discussionContentHash(filepath.Join(nodeBPath, "discussions", discussionDirName))
 	require.NotEmpty(t, sourceHashB)
 
-	factContentB, err := extractFactsFromSummaryJSON(pendingB[0], sourceHashB)
+	factContentB, err := extractFactsFromSummaryJSON(pendingB[0], sourceHashB, "team_test", "https://sageox.ai")
 	require.NoError(t, err)
 	require.NotEmpty(t, factContentB)
 

--- a/internal/agentcli/agentcli_test.go
+++ b/internal/agentcli/agentcli_test.go
@@ -30,7 +30,7 @@ func TestDailyPromptFormat(t *testing.T) {
 		"Decided to use PostgreSQL for analytics",
 		"Auth module needs refactoring",
 	}
-	prompt := DailyPrompt(obs, "2026-03-11", "")
+	prompt := DailyPrompt(obs, "2026-03-11", "", nil)
 
 	if !strings.Contains(prompt, "2026-03-11") {
 		t.Error("prompt should contain the date")
@@ -51,7 +51,7 @@ func TestWeeklyPromptFormat(t *testing.T) {
 		"## Key Decisions\n- Use PostgreSQL",
 		"## Progress\n- Auth module refactored",
 	}
-	prompt := WeeklyPrompt(summaries, "2026-W11", "")
+	prompt := WeeklyPrompt(summaries, "2026-W11", "", false)
 
 	if !strings.Contains(prompt, "2026-W11") {
 		t.Error("prompt should contain the week ID")
@@ -68,7 +68,7 @@ func TestMonthlyPromptFormat(t *testing.T) {
 	summaries := []string{
 		"## Week highlights\n- Major refactor completed",
 	}
-	prompt := MonthlyPrompt(summaries, "2026-03", "")
+	prompt := MonthlyPrompt(summaries, "2026-03", "", false)
 
 	if !strings.Contains(prompt, "2026-03") {
 		t.Error("prompt should contain the month")
@@ -81,7 +81,7 @@ func TestMonthlyPromptFormat(t *testing.T) {
 func TestDailyPromptWithGuidelines(t *testing.T) {
 	obs := []string{"observation 1"}
 	guidelines := "Always highlight security decisions.\nIgnore dependency update noise."
-	prompt := DailyPrompt(obs, "2026-03-11", guidelines)
+	prompt := DailyPrompt(obs, "2026-03-11", guidelines, nil)
 
 	if !strings.Contains(prompt, "<team-guidelines>") {
 		t.Error("prompt should contain guidelines header")
@@ -96,32 +96,56 @@ func TestDailyPromptWithGuidelines(t *testing.T) {
 
 func TestDailyPromptWithoutGuidelines(t *testing.T) {
 	obs := []string{"observation 1"}
-	prompt := DailyPrompt(obs, "2026-03-11", "")
+	prompt := DailyPrompt(obs, "2026-03-11", "", nil)
 
 	if strings.Contains(prompt, "<team-guidelines>") {
 		t.Error("prompt should not contain guidelines header when empty")
 	}
 }
 
-func TestDailyPromptWithFactPaths(t *testing.T) {
+// TestDailyPromptWithCitedFacts verifies the new gh #476 prompt shape: facts
+// are rendered inline with citation numbers and the LLM is instructed to use
+// markdown reference-link syntax.
+func TestDailyPromptWithCitedFacts(t *testing.T) {
 	obs := []string{"observation 1"}
-	paths := []string{"memory/.discussion-facts/2026-03-10.jsonl", "memory/.github-facts/2026-03-10-uuid.jsonl"}
-	prompt := DailyPrompt(obs, "2026-03-11", "", paths...)
+	cited := []FactCitation{
+		{
+			Num:         1,
+			Headline:    "Team chose Postgres for analytics",
+			SourceType:  "discussion",
+			SourceTitle: "Architecture sync",
+			Date:        "2026-03-10",
+		},
+		{
+			Num:         2,
+			Headline:    "Adopted token bucket rate limiting",
+			SourceType:  "github",
+			SourceTitle: "Add rate limiting",
+			Date:        "2026-03-11",
+		},
+	}
+	prompt := DailyPrompt(obs, "2026-03-11", "", cited)
 
-	if !strings.Contains(prompt, "## Fact Files") {
-		t.Error("prompt should contain Fact Files section")
+	if !strings.Contains(prompt, "## Facts") {
+		t.Error("prompt should contain Facts section")
 	}
-	if !strings.Contains(prompt, "memory/.discussion-facts/2026-03-10.jsonl") {
-		t.Error("prompt should contain discussion fact path")
+	if !strings.Contains(prompt, "[1]") || !strings.Contains(prompt, "[2]") {
+		t.Error("prompt should contain citation numbers [1] and [2]")
 	}
-	if !strings.Contains(prompt, "memory/.github-facts/2026-03-10-uuid.jsonl") {
-		t.Error("prompt should contain github fact path")
+	if !strings.Contains(prompt, "Team chose Postgres for analytics") {
+		t.Error("prompt should contain fact headline inline")
 	}
-	if !strings.Contains(prompt, "Read each fact file") {
-		t.Error("prompt should instruct reading of fact files")
+	if !strings.Contains(prompt, "reference-link") {
+		t.Error("prompt should mention reference-link syntax")
 	}
-	if !strings.Contains(prompt, "ALL sources") {
-		t.Error("prompt should instruct incorporating all fact sources")
+	if !strings.Contains(prompt, "[PR #152][2]") {
+		t.Error("prompt should include the reference-link example")
+	}
+	if !strings.Contains(prompt, "Do NOT invent citation numbers") {
+		t.Error("prompt should warn against inventing citation numbers")
+	}
+	if !strings.Contains(prompt, "Do NOT write a Sources section") {
+		t.Error("prompt should warn against writing a Sources section")
 	}
 	if !strings.Contains(prompt, "1. observation 1") {
 		t.Error("prompt should still contain observations")
@@ -130,13 +154,35 @@ func TestDailyPromptWithFactPaths(t *testing.T) {
 
 func TestDailyPromptWithoutFacts(t *testing.T) {
 	obs := []string{"observation 1"}
-	prompt := DailyPrompt(obs, "2026-03-11", "")
+	prompt := DailyPrompt(obs, "2026-03-11", "", nil)
 
-	if strings.Contains(prompt, "Fact Files") {
-		t.Error("prompt should not contain Fact Files section when empty")
+	if strings.Contains(prompt, "## Facts") {
+		t.Error("prompt should not contain Facts section when no facts")
 	}
-	if strings.Contains(prompt, "Read each fact file") {
-		t.Error("prompt should not mention reading files when no facts")
+	if strings.Contains(prompt, "citation marker") {
+		t.Error("prompt should not mention citation markers when no facts")
+	}
+}
+
+// TestWeeklyPromptPreservesCitations verifies the gh #476 weekly prompt
+// instruction set: when hasCitations=true, the LLM is told to keep [N]
+// markers verbatim and not write its own Sources section.
+func TestWeeklyPromptPreservesCitations(t *testing.T) {
+	prompt := WeeklyPrompt([]string{"day 1 [1] body"}, "2026-W11", "", true)
+	if !strings.Contains(prompt, "Preserve these markers VERBATIM") {
+		t.Error("weekly prompt should instruct preserving citation markers when hasCitations=true")
+	}
+	if !strings.Contains(prompt, "Do NOT write a Sources section") {
+		t.Error("weekly prompt should warn against writing a Sources section")
+	}
+}
+
+// TestWeeklyPromptNoCitationsClause omits the preserve instruction when there
+// are no citations to preserve (avoids confusing LLM with irrelevant rules).
+func TestWeeklyPromptNoCitationsClause(t *testing.T) {
+	prompt := WeeklyPrompt([]string{"day 1 body"}, "2026-W11", "", false)
+	if strings.Contains(prompt, "Preserve these markers") {
+		t.Error("weekly prompt should NOT include preserve clause when hasCitations=false")
 	}
 }
 

--- a/internal/agentcli/prompts.go
+++ b/internal/agentcli/prompts.go
@@ -51,25 +51,56 @@ func WriteGuidelines(sb *strings.Builder, guidelines, stage string) {
 	sb.WriteString("</team-guidelines>\n\n")
 }
 
+// FactCitation is a fact-with-citation-number passed into DailyPrompt for
+// inline rendering. The Num field is the citation marker the LLM should use
+// when referencing this fact in its synthesis. Multiple facts may share the
+// same Num if they originate from the same source (deduped by URL upstream).
+//
+// Added for gh #476: distill summaries must carry source links so readers
+// can drill down to the original discussion / PR / session.
+type FactCitation struct {
+	Num         int    // 1-based citation number (the [N] the LLM should emit)
+	Headline    string // required
+	Summary     string // optional
+	Rationale   string // optional
+	Who         string // optional
+	SourceType  string // "discussion" | "github" | "session" | "observation"
+	SourceTitle string // optional human label (e.g., PR or discussion title)
+	Date        string // YYYY-MM-DD slice of the fact's timestamp
+	Category    string // optional: decision | learning | ship | ...
+}
+
 // DailyPrompt builds a prompt for distilling observations into a daily memory summary.
 // If guidelines is non-empty, it is prepended as team-specific distillation preferences.
-// Optional factPaths are relative file paths to fact JSONL files (discussion, github, etc.)
-// that the AI coworker should read and incorporate into the summary.
-func DailyPrompt(observations []string, date, guidelines string, factPaths ...string) string {
+//
+// Facts are rendered inline with citation numbers. The LLM is instructed to
+// include `[N]` markers (or `[anchor][N]` reference links) in its synthesis;
+// the caller post-processes the output to append a "## Sources" section with
+// resolved URLs. See cmd/ox/distill_citations.go for the rendering side.
+func DailyPrompt(observations []string, date, guidelines string, citedFacts []FactCitation) string {
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
 	WriteGuidelines(&sb, guidelines, "distill-daily")
 
 	sb.WriteString("<task>\n")
-	sb.WriteString("Distill these team observations into a daily memory summary.\n")
+	sb.WriteString("Distill these team observations and facts into a daily memory summary.\n")
 	sb.WriteString("Focus on decisions, patterns, and learnings. Omit routine actions.\n")
-	if len(factPaths) > 0 {
-		sb.WriteString("Read each fact file listed below and synthesize their content\n")
-		sb.WriteString("together with the observations into a cohesive summary.\n")
-		sb.WriteString("Fact files are JSONL — each line is a JSON object with a headline, summary, and category.\n")
-		sb.WriteString("Incorporate facts from ALL sources (discussions, github activity, etc.).\n")
-		sb.WriteString("Exception: You MAY use the Read tool to access the fact files listed below.\n")
+	if len(citedFacts) > 0 {
+		sb.WriteString("\n")
+		sb.WriteString("Each fact below has a citation number in brackets, like [3].\n")
+		sb.WriteString("When you reference a fact in your summary, attach its citation marker.\n")
+		sb.WriteString("Prefer markdown reference-link syntax with a NATURAL anchor from the sentence:\n")
+		sb.WriteString("    \"We merged [PR #152][2] last week.\"\n")
+		sb.WriteString("    \"Following the [architecture discussion][1], the storage layer was rewritten.\"\n")
+		sb.WriteString("If no natural anchor fits, end the sentence with a bare marker:\n")
+		sb.WriteString("    \"Natural language is more merge-friendly than code. [1]\"\n")
+		sb.WriteString("Combine multiple sources at one point as chained markers: [1][3].\n")
+		sb.WriteString("\n")
+		sb.WriteString("Rules:\n")
+		sb.WriteString("- Do NOT invent citation numbers — only use numbers from the Facts list below.\n")
+		sb.WriteString("- Do NOT write a Sources section yourself; it is appended programmatically.\n")
+		sb.WriteString("- Observations have NO citation numbers — weave them into the narrative without markers.\n")
 	}
 	sb.WriteString("</task>\n\n")
 
@@ -78,16 +109,75 @@ func DailyPrompt(observations []string, date, guidelines string, factPaths ...st
 		for i, obs := range observations {
 			fmt.Fprintf(&sb, "%d. %s\n", i+1, obs)
 		}
+		sb.WriteString("\n")
 	}
 
-	if len(factPaths) > 0 {
-		sb.WriteString("\n## Fact Files\n\n")
-		for _, path := range factPaths {
-			fmt.Fprintf(&sb, "- [%s](%s)\n", path, path)
+	if len(citedFacts) > 0 {
+		sb.WriteString("## Facts\n\n")
+		for _, f := range citedFacts {
+			writeFactCitationLine(&sb, f)
 		}
 	}
 
 	return sb.String()
+}
+
+// writeFactCitationLine renders a single fact for the daily prompt.
+// Format: "[N] (source_type · date · title · who · category) headline. summary. Rationale: rationale."
+// Fields are omitted when empty so short facts stay short.
+//
+// Multiline fact content (LLM-extracted github PR descriptions can contain
+// literal newlines) is collapsed to a single line so each fact occupies
+// exactly one prompt line — keeps the [N]-per-line layout parseable.
+func writeFactCitationLine(sb *strings.Builder, f FactCitation) {
+	fmt.Fprintf(sb, "[%d] (", f.Num)
+	sb.WriteString(f.SourceType)
+	if f.Date != "" {
+		sb.WriteString(" · ")
+		sb.WriteString(f.Date)
+	}
+	if f.SourceTitle != "" {
+		sb.WriteString(" · ")
+		sb.WriteString(collapseWhitespace(f.SourceTitle))
+	}
+	if f.Who != "" {
+		sb.WriteString(" · ")
+		sb.WriteString(collapseWhitespace(f.Who))
+	}
+	if f.Category != "" {
+		sb.WriteString(" · ")
+		sb.WriteString(f.Category)
+	}
+	sb.WriteString(") ")
+	headline := collapseWhitespace(f.Headline)
+	sb.WriteString(headline)
+	if !strings.HasSuffix(headline, ".") {
+		sb.WriteString(".")
+	}
+	if f.Summary != "" {
+		summary := collapseWhitespace(f.Summary)
+		sb.WriteString(" ")
+		sb.WriteString(summary)
+		if !strings.HasSuffix(summary, ".") {
+			sb.WriteString(".")
+		}
+	}
+	if f.Rationale != "" {
+		rationale := collapseWhitespace(f.Rationale)
+		sb.WriteString(" Rationale: ")
+		sb.WriteString(rationale)
+		if !strings.HasSuffix(rationale, ".") {
+			sb.WriteString(".")
+		}
+	}
+	sb.WriteString("\n")
+}
+
+// collapseWhitespace replaces runs of whitespace (including newlines) with a
+// single space and trims. Used to sanitize fact fields that may contain
+// embedded newlines from LLM extraction (notably github PR descriptions).
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // DiscussionFactsPrompt builds a prompt for extracting structured facts from a discussion.
@@ -142,7 +232,13 @@ func DiscussionFactsPrompt(title, summary, transcript, guidelines, annotations s
 }
 
 // WeeklyPrompt builds a prompt for synthesizing daily summaries into a weekly memory.
-func WeeklyPrompt(dailySummaries []string, weekID, guidelines string) string {
+//
+// hasCitations should be true when the daily summaries contain `[N]` citation
+// markers (the new format from gh #476). When true, the prompt instructs the
+// LLM to preserve those markers verbatim — the caller has already renumbered
+// them to a unified weekly numbering, and a fresh "## Sources" section will
+// be appended after the LLM returns.
+func WeeklyPrompt(dailySummaries []string, weekID, guidelines string, hasCitations bool) string {
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
@@ -151,6 +247,9 @@ func WeeklyPrompt(dailySummaries []string, weekID, guidelines string) string {
 	sb.WriteString("<task>\n")
 	sb.WriteString("Synthesize these daily summaries into a weekly memory.\n")
 	sb.WriteString("Identify themes, key decisions, and unresolved work. Compress — shorter than the combined input.\n")
+	if hasCitations {
+		writePreserveCitationsInstruction(&sb)
+	}
 	sb.WriteString("</task>\n\n")
 
 	fmt.Fprintf(&sb, "## Dailies (%s)\n\n", weekID)
@@ -162,7 +261,11 @@ func WeeklyPrompt(dailySummaries []string, weekID, guidelines string) string {
 }
 
 // MonthlyPrompt builds a prompt for synthesizing weekly summaries into a monthly memory.
-func MonthlyPrompt(weeklySummaries []string, month, guidelines string) string {
+//
+// hasCitations behaves the same way as in WeeklyPrompt — when true, the LLM
+// is instructed to preserve `[N]` markers and the caller appends a unified
+// "## Sources" section after generation.
+func MonthlyPrompt(weeklySummaries []string, month, guidelines string, hasCitations bool) string {
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
@@ -171,6 +274,9 @@ func MonthlyPrompt(weeklySummaries []string, month, guidelines string) string {
 	sb.WriteString("<task>\n")
 	sb.WriteString("Synthesize these weekly summaries into a monthly memory.\n")
 	sb.WriteString("Focus on milestones, architecture changes, and strategic direction. Omit day-to-day details.\n")
+	if hasCitations {
+		writePreserveCitationsInstruction(&sb)
+	}
 	sb.WriteString("</task>\n\n")
 
 	fmt.Fprintf(&sb, "## Weeklies (%s)\n\n", month)
@@ -179,4 +285,14 @@ func MonthlyPrompt(weeklySummaries []string, month, guidelines string) string {
 	}
 
 	return sb.String()
+}
+
+// writePreserveCitationsInstruction appends the standard preserve-markers
+// guidance to a weekly or monthly prompt body.
+func writePreserveCitationsInstruction(sb *strings.Builder) {
+	sb.WriteString("\n")
+	sb.WriteString("The summaries below contain markdown reference-link citations like `[N]` and\n")
+	sb.WriteString("`[anchor][N]`. Preserve these markers VERBATIM in any text you carry forward.\n")
+	sb.WriteString("Do NOT invent new numbers, do NOT renumber, do NOT remove them.\n")
+	sb.WriteString("Do NOT write a Sources section — it is appended programmatically.\n")
 }

--- a/internal/facts/types.go
+++ b/internal/facts/types.go
@@ -2,15 +2,24 @@ package facts
 
 // Fact is the unified fact record across all sources (github, discussion, observation).
 // All fact JSONL files use this schema for data lines.
+//
+// SourceRef is the stable canonical identifier (path or URL).
+// SourceURL is the human-clickable URL for drill-down (added in PR for #476).
+// SourceTitle is a short human label for citations (e.g., a discussion or PR title).
+// SourceURL and SourceTitle are populated at extraction time when available;
+// older fact files without these fields are still valid — the citation pipeline
+// degrades gracefully (link omitted, label derived from other fields).
 type Fact struct {
-	Headline   string `json:"headline"`
-	Summary    string `json:"summary,omitempty"`
-	Rationale  string `json:"rationale,omitempty"`
-	Who        string `json:"who,omitempty"`
-	SourceType string `json:"source_type"`
-	SourceRef  string `json:"source_ref,omitempty"`
-	Timestamp  string `json:"timestamp"`
-	Category   string `json:"category,omitempty"`
+	Headline    string `json:"headline"`
+	Summary     string `json:"summary,omitempty"`
+	Rationale   string `json:"rationale,omitempty"`
+	Who         string `json:"who,omitempty"`
+	SourceType  string `json:"source_type"`
+	SourceRef   string `json:"source_ref,omitempty"`
+	SourceURL   string `json:"source_url,omitempty"`
+	SourceTitle string `json:"source_title,omitempty"`
+	Timestamp   string `json:"timestamp"`
+	Category    string `json:"category,omitempty"`
 }
 
 // FileHeader is the first line of a v2 fact JSONL file.


### PR DESCRIPTION
## Summary

Closes #476.

The distill pipeline (`ox distill`) generates daily/weekly/monthly markdown summaries from team observations, discussions, GitHub activity, and coding sessions. Until now, the LLM-synthesized summaries cited source material in prose but **never linked back to the source** — a reader of "What We Learned" couldn't drill into the original recording, PR, or session.

This PR threads source URLs through the entire pipeline so every citation becomes a clickable markdown reference link.

## What changed

### Output shape

Every distilled file now ends with a Sources section using markdown reference-link syntax. Body prose uses `[anchor][N]` (preferred, natural anchor) or bare `[N]` (fallback) — both resolve to the same URL definition.

```markdown
## What We Learned

- Natural language is more merge-friendly than code. [1]
- Adopted token-bucket rate limiting in [PR #152][2].

## Sources

1. [Discussion: 2026-03-10 — Architecture sync][1]
2. [sageox/ox#152][2]

[1]: https://sageox.ai/team/team_xxx/media/recordings/rec_yyy
[2]: https://github.com/sageox/ox/pull/152
```

### Schema

`internal/facts/types.go` — added optional `SourceURL` and `SourceTitle` fields to `Fact`. Both `omitempty`, so legacy fact files keep working (verified by `TestBuildCitationsFromFacts_LegacyFactsHaveNoSourceURL`).

### Extraction-time URL/title population

| Source type | URL builder | Title source |
|---|---|---|
| Discussion | new `buildDiscussionURL(ep, teamID, recordingID)` (mirrors `session_url.go`) | `summary.Title` from already-loaded `summary.json` |
| Session | existing `buildSessionURL` | session summary `Title` |
| GitHub | new `mirrorGitHubSourceURL` (source_ref is already a URL) | LLM extractor prompt now requests `source_title` |
| Observation | n/a | n/a |

### Pipeline

1. **Daily** (`distillDaily`): parses fact JSONLs in-process via `facts.ReadFacts`, builds a deduped citation list, calls `DailyPrompt` with structured `[]FactCitation`, appends a `## Sources` section with reference-link definitions. Observations get added to the YAML frontmatter `sources:` list (cache index input) but **not** cited with `[N]` markers in body prose.
2. **Weekly / Monthly**: parses each prior layer's `## Sources` section, merges/dedupes/renumbers via `mergeCitations`, instructs the LLM to "preserve `[N]` markers verbatim", appends a unified Sources section. The LLM never has to do citation arithmetic.

### Prompt change

`agentcli.DailyPrompt` now takes `[]FactCitation` (new struct) instead of variadic file paths. Facts are inlined with `[N]` markers; the prompt teaches the LLM to use markdown reference-link syntax `[anchor][N]` when there's a natural anchor in the sentence, or bare `[N]` at end of sentence when there isn't.

`WeeklyPrompt`/`MonthlyPrompt` take a new `hasCitations bool` and conditionally append a "preserve markers verbatim" instruction.

### Citation infrastructure (`cmd/ox/distill_citations.go`, ~620 lines)

- `Citation` type with `Num`/`Label`/`URL`/`Key`
- `buildCitationsFromFacts` — deduped, ordered by timestamp + label
- `citationLabel` — produces `Discussion: 2026-03-10 — Architecture sync`, `sageox/ox#152`, `sageox/ox@a1b2c3d`, etc.
- `parseSourcesSection` / `renderSourcesSection` — round-trippable
- `renumberCitationMarkers` — regex-based, safely skips fenced code blocks AND inline backtick spans (so prose like `` `arr[1]` `` doesn't get renumbered)
- `mergeCitations` — cross-layer dedup with forward-direction label-only → URL-keyed upgrade

### Backwards compatibility

- Legacy fact files without `source_url`/`source_title` produce label-only citations (no clickable link). Tested.
- Audio-only / legacy discussions with no `recording_id` get an empty `source_url` and degrade to label-only. Tested.
- Frontmatter `sources:` block preserved for `distill_index` cache dedup. The Sources section is **additive** — it does not replace the frontmatter.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go vet ./...` — clean
- [x] `go vet -tags slow ./...` — clean (fixed 6 stale call sites in `distill_uuid7_twin_test.go`)
- [x] `go test ./internal/facts/... ./internal/agentcli/... ./cmd/ox/...` — green (~125s)
- [x] `go test -tags slow -run TestExtractSessionFacts_WritesUUID7Filename|TestExtractDiscussionFacts_WritesUUID7Filename|TestExtractDiscussionFacts_LLMPath ./cmd/ox/` — green
- [x] **3 rounds of code review** by the `code-reviewer` coworker — all Must/Should/Consider findings addressed
- [x] **70+ new test cases** organized by behavioral domain, each documenting the failure mode it prevents:
  - URL helpers: happy path, endpoint normalization (`api.`/`www.` strip), missing inputs, URL escaping
  - Citation labels: every source type, fallbacks, GitHub PR/issue/commit URL parsing
  - Citation building: dedup by URL, ordering, fallback to source_ref, skip uncitable
  - Marker renumbering: bare `[N]`, ref-link `[anchor][N]`, chained, code fences, inline backticks, unterminated fences, unknown numbers (defensive)
  - Sources section round-trip: render → parse → render
  - Cross-layer merge: dedup, first-appearance order, label-only → URL upgrade, distinct-URLs-with-same-label stay separate, **deliberate** non-dedup of reverse-direction (label-only after URL-keyed) with future-maintainer warning
  - End-to-end regression for the exact #476 failure mode
  - Frontmatter cache-index round-trip preserved

Manual verification deferred to a real distill run on a populated team context (no LLM available in CI for this).

## Notes

- Per CLAUDE.md, no `bd` issue filed in this PR — the worktree branch broke the local Dolt connection. Will file from main after merge.
- An unrelated pre-existing flake in `internal/session/sageox_score_test.go::TestCleanupStaleScores_RemovesInactive` was observed in `make test` (counts wrong: 3 vs 2). Reads/writes shared filesystem state. Not in any package this PR touches; passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable source URLs and titles added to facts across discussions, sessions, and GitHub; discussion links are constructed and safely escaped.
  * Prompts now accept structured cited facts and a new fact-citation type to render inline fact lists.

* **Improvements**
  * Automatic citation deduplication, stable global numbering, renumbering across layers, richer "Sources" rendering, and mirroring of GitHub source URLs.

* **Tests**
  * Extensive new and updated tests covering citation construction, parsing/merging, renumbering, prompt behavior, and end-to-end distillation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->