### PR TITLE
feat(tracing): enrich CLI spans with version, host.os, exit code, redacted args, agent env, result count

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -280,12 +280,23 @@ var validSessionSubcommands = map[string]bool{
 	"recover":           true,
 }
 
-// hookEventNamePattern matches the canonical shape of a coding-agent
-// hook event name (e.g. "SessionStart", "PostToolUse", "BeforeAgent").
-// Adapter protocols use PascalCase ASCII identifiers; anything outside
-// that shape is rejected so the dispatcher can't be tricked into
-// minting arbitrary span names from caller-controlled input.
-var hookEventNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,63}$`)
+// hookEventNamePattern matches the canonical PascalCase shape of a
+// coding-agent hook event name (e.g. "SessionStart", "PostToolUse",
+// "BeforeAgent"). Adapter protocols use PascalCase ASCII identifiers
+// composed of 1..16 segments where each segment is one uppercase
+// letter followed by zero or more lowercase letters or digits.
+//
+// Strict PascalCase (uppercase initial, no lowercase-first names) is
+// what every real adapter uses. Allowing lowercase-first input like
+// `foo` or `abc123` would let arbitrary lowercase tokens through,
+// which is exactly the cardinality leak this guard is meant to close.
+var hookEventNamePattern = regexp.MustCompile(`^(?:[A-Z][a-z0-9]*){1,16}$`)
+
+// hookEventNameMaxLen caps total event-name length, layered on top of
+// the regex's segment count. The regex limits SEGMENTS to 16, but each
+// segment can be arbitrarily long, so a 10000-character single segment
+// would still match without a separate length check.
+const hookEventNameMaxLen = 64
 
 // isKnownHookEventName reports whether name matches the canonical
 // PascalCase identifier shape used by every adapter's hook event names.
@@ -297,6 +308,9 @@ var hookEventNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,63}$`)
 // the whole space cheaply while still rejecting arbitrary user input
 // like paths, strings with spaces, or shell metacharacters.
 func isKnownHookEventName(name string) bool {
+	if len(name) == 0 || len(name) > hookEventNameMaxLen {
+		return false
+	}
 	return hookEventNamePattern.MatchString(name)
 }
 
@@ -313,16 +327,24 @@ func isKnownHookEventName(name string) bool {
 // validSessionSubcommands — unknown tokens collapse to just "session"
 // so a typo or attacker input cannot mint arbitrary span names.
 //
-// Other subcommands (heartbeat, doctor, query, whisper, distill) are
-// kept as a single token — their next argument is either non-existent
-// or high-cardinality user input (e.g. a query string) that would
-// defeat span grouping if included.
+// "whisper" is expanded for the special "whisper history" form because
+// runWithAgentID treats it as a distinct operation (separate RunE path).
+// Collapsing both into one bucket would merge two fixed, low-cardinality
+// operations and lose the observability split this PR is adding.
+//
+// Other subcommands (heartbeat, doctor, query, distill) are kept as a
+// single token — their next argument is either non-existent or
+// high-cardinality user input (e.g. a query string) that would defeat
+// span grouping if included.
 func dispatchedCommandPath(subargs []string) []string {
 	if len(subargs) == 0 {
 		return nil
 	}
 	subcmd := subargs[0]
 	if subcmd == "session" && len(subargs) > 1 && validSessionSubcommands[subargs[1]] {
+		return []string{subcmd, subargs[1]}
+	}
+	if subcmd == "whisper" && len(subargs) > 1 && subargs[1] == "history" {
 		return []string{subcmd, subargs[1]}
 	}
 	return []string{subcmd}

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -202,11 +203,13 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 	// hooks fire before prime, so no agent ID exists yet.
 	if firstArg == "hook" {
 		// Hook phase is the second arg (e.g. "PostToolUse",
-		// "SessionStart"). Including it makes spans like
-		// "ox agent hook SessionStart" so phases are visible in the
-		// span name without bloating cardinality (the phase set is
-		// fixed by the adapter protocol).
-		if len(args) > 1 {
+		// "SessionStart"). Only include it in the span name when it
+		// matches the known event-name shape — otherwise an attacker
+		// or buggy hook could pass arbitrary tokens and inflate
+		// span-name cardinality, defeating the very grouping this
+		// rename is trying to add. Unknown phases collapse to just
+		// "ox agent hook".
+		if len(args) > 1 && isKnownHookEventName(args[1]) {
 			renameDispatcherSpan("hook", args[1])
 		} else {
 			renameDispatcherSpan("hook")
@@ -251,6 +254,52 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 	return fmt.Errorf("unknown command or invalid agent_id: %s\nRun 'ox agent --help' for usage", firstArg)
 }
 
+// validSessionSubcommands enumerates the session sub-subcommands the
+// dispatcher knows how to route in runWithAgentID. Used by
+// dispatchedCommandPath to clamp span-name cardinality: only known
+// session sub-subcommands are appended to the span name; an unknown
+// token (typo, attacker input) collapses to just "session" instead of
+// minting a new span-name bucket.
+//
+// Keep in sync with the case statement in runWithAgentID's `case "session"`.
+var validSessionSubcommands = map[string]bool{
+	"start":             true,
+	"stop":              true,
+	"abort":             true,
+	"delete":            true,
+	"log":               true,
+	"remind":            true,
+	"summarize":         true,
+	"record":            true,
+	"plan":              true,
+	"context-trace":     true,
+	"import":            true,
+	"capture-prior":     true,
+	"subagent-complete": true,
+	"subagent-list":     true,
+	"recover":           true,
+}
+
+// hookEventNamePattern matches the canonical shape of a coding-agent
+// hook event name (e.g. "SessionStart", "PostToolUse", "BeforeAgent").
+// Adapter protocols use PascalCase ASCII identifiers; anything outside
+// that shape is rejected so the dispatcher can't be tricked into
+// minting arbitrary span names from caller-controlled input.
+var hookEventNamePattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,63}$`)
+
+// isKnownHookEventName reports whether name matches the canonical
+// PascalCase identifier shape used by every adapter's hook event names.
+// Used by the dispatcher span-rename path to clamp cardinality.
+//
+// We deliberately validate by SHAPE rather than against a fixed
+// allowlist because the set of hook events is agent-specific and
+// extensible (each adapter can introduce new events). A regex covers
+// the whole space cheaply while still rejecting arbitrary user input
+// like paths, strings with spaces, or shell metacharacters.
+func isKnownHookEventName(name string) bool {
+	return hookEventNamePattern.MatchString(name)
+}
+
 // dispatchedCommandPath returns the subcommand path tokens that uniquely
 // identify a dispatcher invocation, e.g. ["session", "start"] for
 // `session start` or ["doctor"] for `doctor`. Used to label the root
@@ -260,6 +309,9 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 // is itself a router (start, stop, capture-prior, recover, ...) and
 // collapsing them all into "ox agent session" would lose the same
 // dispatcher-bucketing problem we're trying to fix at the agent level.
+// The sub-subcommand is only appended when it appears in
+// validSessionSubcommands — unknown tokens collapse to just "session"
+// so a typo or attacker input cannot mint arbitrary span names.
 //
 // Other subcommands (heartbeat, doctor, query, whisper, distill) are
 // kept as a single token — their next argument is either non-existent
@@ -270,7 +322,7 @@ func dispatchedCommandPath(subargs []string) []string {
 		return nil
 	}
 	subcmd := subargs[0]
-	if subcmd == "session" && len(subargs) > 1 {
+	if subcmd == "session" && len(subargs) > 1 && validSessionSubcommands[subargs[1]] {
 		return []string{subcmd, subargs[1]}
 	}
 	return []string{subcmd}

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/observability"
 	"github.com/sageox/ox/internal/repotools"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/contexttrace"
@@ -168,10 +170,18 @@ func init() {
 	rootCmd.AddCommand(agentCmd)
 }
 
-// runAgentDispatcher handles the ox agent <agent_id> <cmd> pattern
+// runAgentDispatcher handles the ox agent <agent_id> <cmd> pattern.
+//
+// Tracing note: cobra's PreRunE created the root span before this function
+// runs, with the bland name "ox agent" because cobra only sees agentCmd
+// when dispatching here. We rename the span as soon as we resolve what
+// was actually invoked — and we do it BEFORE any early-return paths
+// (help, hook fast-path, validation errors) so even fast failures get
+// the right span name in the trace backend.
 func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 	// no args = show help
 	if len(args) == 0 {
+		renameDispatcherSpan("help")
 		return cmd.Help()
 	}
 
@@ -180,7 +190,10 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 	// check if first arg is a known subcommand
 	for _, subcmd := range cmd.Commands() {
 		if subcmd.Name() == firstArg {
-			// let cobra handle it
+			// let cobra handle it — cobra will route to the leaf
+			// command and cli.NewContext already set a meaningful
+			// span name there ("ox agent prime", etc.), so no
+			// rename is needed here.
 			return nil
 		}
 	}
@@ -188,11 +201,27 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 	// "hook" dispatched directly — no agent_id required.
 	// hooks fire before prime, so no agent ID exists yet.
 	if firstArg == "hook" {
+		// Hook phase is the second arg (e.g. "PostToolUse",
+		// "SessionStart"). Including it makes spans like
+		// "ox agent hook SessionStart" so phases are visible in the
+		// span name without bloating cardinality (the phase set is
+		// fixed by the adapter protocol).
+		if len(args) > 1 {
+			renameDispatcherSpan("hook", args[1])
+		} else {
+			renameDispatcherSpan("hook")
+		}
 		return runAgentHook(args[1:])
 	}
 
 	// check if first arg looks like an agent_id (Ox<4-char>)
 	if agentinstance.IsValidAgentID(firstArg) {
+		// Rename based on the subcommand path AFTER the agent_id.
+		// We deliberately do not include the agent_id in the span
+		// name — it is high-cardinality and would defeat grouping.
+		// dispatchedCommandPath handles "session" specially to
+		// include its sub-subcommand (start/stop/capture-prior/...).
+		renameDispatcherSpan(dispatchedCommandPath(args[1:])...)
 		return runWithAgentID(cmd, firstArg, args[1:])
 	}
 
@@ -200,6 +229,10 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 	// a known agent subcommand (e.g. "session", "doctor") being called
 	// without an explicit agent ID: `ox agent session start`
 	if isAgentSubcommand(firstArg) {
+		// Same path-based naming as the agent-id case. Done before
+		// the env-var lookup so even the "missing agent id" error
+		// path gets the correct span name.
+		renameDispatcherSpan(dispatchedCommandPath(args)...)
 		envID := os.Getenv("SAGEOX_AGENT_ID")
 		if agentinstance.IsValidAgentID(envID) {
 			return runWithAgentID(cmd, envID, args)
@@ -207,11 +240,60 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no agent ID: %q requires an agent ID (run 'ox agent prime' first)", firstArg)
 	}
 
-	// unknown argument — check for common wrong-format patterns
+	// unknown argument — check for common wrong-format patterns.
+	// We deliberately do NOT rename the span here: the invocation is
+	// invalid and no meaningful subcommand was resolved. Leaving the
+	// span as "ox agent" surfaces these as a distinct bucket of
+	// "could not parse" failures in the trace backend.
 	if msg := agentinstance.ClassifyBadID(firstArg); msg != "" {
 		return fmt.Errorf("%s", msg)
 	}
 	return fmt.Errorf("unknown command or invalid agent_id: %s\nRun 'ox agent --help' for usage", firstArg)
+}
+
+// dispatchedCommandPath returns the subcommand path tokens that uniquely
+// identify a dispatcher invocation, e.g. ["session", "start"] for
+// `session start` or ["doctor"] for `doctor`. Used to label the root
+// span with a meaningful, low-cardinality name.
+//
+// "session" is expanded to include its sub-subcommand because session
+// is itself a router (start, stop, capture-prior, recover, ...) and
+// collapsing them all into "ox agent session" would lose the same
+// dispatcher-bucketing problem we're trying to fix at the agent level.
+//
+// Other subcommands (heartbeat, doctor, query, whisper, distill) are
+// kept as a single token — their next argument is either non-existent
+// or high-cardinality user input (e.g. a query string) that would
+// defeat span grouping if included.
+func dispatchedCommandPath(subargs []string) []string {
+	if len(subargs) == 0 {
+		return nil
+	}
+	subcmd := subargs[0]
+	if subcmd == "session" && len(subargs) > 1 {
+		return []string{subcmd, subargs[1]}
+	}
+	return []string{subcmd}
+}
+
+// renameDispatcherSpan rewrites the active root span name to
+// "ox agent <parts...>" and attaches an ox.command.subcommand attribute
+// with the joined parts. Empty parts are skipped — calling with no
+// parts is a no-op.
+func renameDispatcherSpan(parts ...string) {
+	// Filter empty tokens so a missing hook phase ("ox agent hook"
+	// with no second arg) doesn't produce "ox agent hook ".
+	clean := parts[:0]
+	for _, p := range parts {
+		if p != "" {
+			clean = append(clean, p)
+		}
+	}
+	if len(clean) == 0 {
+		return
+	}
+	sub := strings.Join(clean, " ")
+	observability.RenameRootSpan("ox agent "+sub, sub)
 }
 
 // agentSubcommands are commands valid inside `runWithAgentID`.

--- a/cmd/ox/agent_query.go
+++ b/cmd/ox/agent_query.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sageox/ox/internal/codedb/search"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/observability"
 )
 
 // queryArgs holds parsed arguments for the query command.
@@ -211,6 +212,16 @@ func executeQuery(qa *queryArgs, agentID string, agentType string) (int, error) 
 		resp.CodeResults = compact.Results
 		resp.Guidance = compact.Guidance
 	}
+
+	// Attach combined result count to the root span. Sums team-context
+	// hits and code hits since this command can search either or both
+	// (per --source). Counts the *raw* results before --limit so the
+	// metric reflects what the search actually returned.
+	totalResults := len(codeResults)
+	if combined.TeamContext != nil {
+		totalResults += len(combined.TeamContext.Results)
+	}
+	observability.SetResultCount(totalResults)
 
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)

--- a/cmd/ox/agent_test.go
+++ b/cmd/ox/agent_test.go
@@ -118,6 +118,101 @@ func TestReinjectSessionFlags(t *testing.T) {
 	})
 }
 
+// TestDispatchedCommandPath verifies that the dispatcher's span-naming
+// helper produces the right token sequence for each invocation shape.
+//
+// Why this matters: dispatchedCommandPath is what determines how a
+// dispatcher hit gets bucketed in trace backends. A regression that
+// silently returns the wrong tokens (or always returns the same single
+// token) re-creates the very "one giant ox agent bucket" problem the
+// dispatcher rename was added to fix.
+func TestDispatchedCommandPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// what real-world bucketing failure does this prevent
+		prevents string
+		in       []string
+		want     []string
+	}{
+		{
+			name:     "empty",
+			prevents: "panic on no-args dispatcher invocation",
+			in:       nil,
+			want:     nil,
+		},
+		{
+			name:     "doctor_alone",
+			prevents: "doctor calls collapsing into a single bucket with other commands",
+			in:       []string{"doctor"},
+			want:     []string{"doctor"},
+		},
+		{
+			name:     "heartbeat_alone",
+			prevents: "heartbeats hiding in the generic bucket — they are the highest-volume call",
+			in:       []string{"heartbeat"},
+			want:     []string{"heartbeat"},
+		},
+		{
+			name:     "session_with_subsubcommand",
+			prevents: "session start / stop / capture-prior all collapsing into one `session` bucket",
+			in:       []string{"session", "start"},
+			want:     []string{"session", "start"},
+		},
+		{
+			name:     "session_capture_prior",
+			prevents: "capture-prior latency / errors hiding inside the `session` bucket",
+			in:       []string{"session", "capture-prior", "--adapter=claude"},
+			want:     []string{"session", "capture-prior"},
+		},
+		{
+			name:     "session_alone",
+			prevents: "panic on bare `session` with no sub-subcommand (validation error path)",
+			in:       []string{"session"},
+			want:     []string{"session"},
+		},
+		{
+			name:     "query_does_not_include_query_text",
+			prevents: "high-cardinality query string blowing up span-name cardinality",
+			// query has its arg as the search text — must NOT be included
+			in:   []string{"query", "how do we handle auth"},
+			want: []string{"query"},
+		},
+		{
+			name:     "whisper_alone",
+			prevents: "whisper history vs whisper non-history collapsing — but query text would be worse",
+			in:       []string{"whisper"},
+			want:     []string{"whisper"},
+		},
+		{
+			name:     "whisper_history_collapses_to_whisper",
+			prevents: "treating `whisper history` as something it isn't (we deliberately keep one bucket)",
+			// We don't expand whisper because the second arg can be
+			// "history" or absent — keeping it as one bucket is fine.
+			in:   []string{"whisper", "history"},
+			want: []string{"whisper"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := dispatchedCommandPath(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("dispatchedCommandPath(%q) = %q, want %q\n(prevents: %s)",
+					tt.in, got, tt.want, tt.prevents)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("dispatchedCommandPath(%q)[%d] = %q, want %q\n(prevents: %s)",
+						tt.in, i, got[i], tt.want[i], tt.prevents)
+				}
+			}
+		})
+	}
+}
+
 func TestGenerateAgentID(t *testing.T) {
 	t.Run("generates valid agent ID with no existing IDs", func(t *testing.T) {
 		agentID, err := agentinstance.GenerateAgentID([]string{})

--- a/cmd/ox/agent_test.go
+++ b/cmd/ox/agent_test.go
@@ -173,6 +173,24 @@ func TestDispatchedCommandPath(t *testing.T) {
 			want:     []string{"session"},
 		},
 		{
+			name:     "session_unknown_subsubcommand_collapses",
+			prevents: "an unknown / typo / attacker-controlled session sub-subcommand minting an arbitrary span name (CodeRabbit PR488). Without the allowlist, `ox agent <id> session <typo>` would create a per-typo bucket.",
+			in:       []string{"session", "totally-bogus-subcommand"},
+			want:     []string{"session"},
+		},
+		{
+			name:     "session_recover_in_allowlist",
+			prevents: "regression that drops `recover` from validSessionSubcommands when adding new entries — keep this case in lock-step with runWithAgentID's case statement",
+			in:       []string{"session", "recover"},
+			want:     []string{"session", "recover"},
+		},
+		{
+			name:     "session_subagent_complete_in_allowlist",
+			prevents: "subagent-complete (hyphenated) accidentally getting filtered by an over-eager allowlist",
+			in:       []string{"session", "subagent-complete"},
+			want:     []string{"session", "subagent-complete"},
+		},
+		{
 			name:     "query_does_not_include_query_text",
 			prevents: "high-cardinality query string blowing up span-name cardinality",
 			// query has its arg as the search text — must NOT be included
@@ -208,6 +226,55 @@ func TestDispatchedCommandPath(t *testing.T) {
 					t.Errorf("dispatchedCommandPath(%q)[%d] = %q, want %q\n(prevents: %s)",
 						tt.in, i, got[i], tt.want[i], tt.prevents)
 				}
+			}
+		})
+	}
+}
+
+// TestIsKnownHookEventName covers the dispatcher's hook-phase clamping
+// rule. The dispatcher passes the second token of `ox agent hook <X>`
+// into the span name only when isKnownHookEventName(X) is true; an
+// invalid token collapses to just "ox agent hook".
+//
+// Failure prevented: a regression that loosens the regex (e.g.
+// removes the start anchor or allows whitespace) lets attacker-
+// controlled tokens flow into span names. Each test case names the
+// shape of input it defends against.
+func TestIsKnownHookEventName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		prevents string
+		in       string
+		want     bool
+	}{
+		{"PostToolUse", "happy path: real Claude Code event", "PostToolUse", true},
+		{"SessionStart", "happy path: common across adapters", "SessionStart", true},
+		{"SessionEnd", "happy path", "SessionEnd", true},
+		{"BeforeAgent", "gemini-style event name", "BeforeAgent", true},
+		{"UserPromptSubmit", "Claude Code event", "UserPromptSubmit", true},
+		{"single_letter", "minimum valid input", "A", true},
+		{"lowercase_start", "lowercase initial char allowed (defensive: future events)", "postToolUse", true},
+		{"empty_string", "empty token must not be a valid name", "", false},
+		{"with_space", "spaces let attacker-controlled strings into span names", "Post ToolUse", false},
+		{"with_slash", "path-like input must be rejected", "Post/Tool", false},
+		{"with_dash", "dashes are not used in adapter event names — reject to keep the regex tight", "Post-Tool-Use", false},
+		{"with_quote", "shell-quoted input must be rejected", "Post\"Tool", false},
+		{"with_semicolon", "shell metacharacters must be rejected", "Post;Tool", false},
+		{"with_newline", "newlines must be rejected", "Post\nTool", false},
+		{"starts_with_digit", "must start with letter to match identifier shape", "1ToolUse", false},
+		{"too_long", "64-char cap prevents pathologically long span names", strings.Repeat("A", 65), false},
+		{"max_length_ok", "exactly 64 chars (1 + 63 trailing) is allowed", strings.Repeat("A", 64), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isKnownHookEventName(tt.in)
+			if got != tt.want {
+				t.Errorf("isKnownHookEventName(%q) = %v, want %v\n(prevents: %s)",
+					tt.in, got, tt.want, tt.prevents)
 			}
 		})
 	}

--- a/cmd/ox/agent_test.go
+++ b/cmd/ox/agent_test.go
@@ -199,17 +199,21 @@ func TestDispatchedCommandPath(t *testing.T) {
 		},
 		{
 			name:     "whisper_alone",
-			prevents: "whisper history vs whisper non-history collapsing — but query text would be worse",
+			prevents: "bare whisper getting bucketed with whisper history despite being a different RunE path",
 			in:       []string{"whisper"},
 			want:     []string{"whisper"},
 		},
 		{
-			name:     "whisper_history_collapses_to_whisper",
-			prevents: "treating `whisper history` as something it isn't (we deliberately keep one bucket)",
-			// We don't expand whisper because the second arg can be
-			// "history" or absent — keeping it as one bucket is fine.
-			in:   []string{"whisper", "history"},
-			want: []string{"whisper"},
+			name:     "whisper_history_expanded",
+			prevents: "merging `whisper history` (its own RunE in runWithAgentID) into the bare `whisper` bucket and losing the observability split (CodeRabbit PR488)",
+			in:       []string{"whisper", "history"},
+			want:     []string{"whisper", "history"},
+		},
+		{
+			name:     "whisper_unknown_collapses",
+			prevents: "an unknown whisper sub-subcommand minting a per-typo span-name bucket — only `history` is a real branch",
+			in:       []string{"whisper", "totally-bogus"},
+			want:     []string{"whisper"},
 		},
 	}
 
@@ -249,23 +253,33 @@ func TestIsKnownHookEventName(t *testing.T) {
 		in       string
 		want     bool
 	}{
-		{"PostToolUse", "happy path: real Claude Code event", "PostToolUse", true},
-		{"SessionStart", "happy path: common across adapters", "SessionStart", true},
-		{"SessionEnd", "happy path", "SessionEnd", true},
+		// happy paths — all real adapter event names follow strict PascalCase
+		{"PostToolUse", "Claude Code post-tool event", "PostToolUse", true},
+		{"PreToolUse", "Claude Code pre-tool event", "PreToolUse", true},
+		{"SessionStart", "common across adapters", "SessionStart", true},
+		{"SessionEnd", "common lifecycle event", "SessionEnd", true},
 		{"BeforeAgent", "gemini-style event name", "BeforeAgent", true},
-		{"UserPromptSubmit", "Claude Code event", "UserPromptSubmit", true},
-		{"single_letter", "minimum valid input", "A", true},
-		{"lowercase_start", "lowercase initial char allowed (defensive: future events)", "postToolUse", true},
+		{"UserPromptSubmit", "Claude Code prompt event", "UserPromptSubmit", true},
+		{"AfterTool", "compact event name", "AfterTool", true},
+		{"single_uppercase", "minimum valid PascalCase input", "A", true},
+		{"single_segment", "one PascalCase segment", "Session", true},
+		{"with_digits_in_segment", "digits allowed inside a segment (e.g. event versions)", "Tool2Use", true},
+
+		// rejection paths — each prevents a different cardinality leak
 		{"empty_string", "empty token must not be a valid name", "", false},
+		{"lowercase_start", "lowercase-first input lets arbitrary tokens through (CodeRabbit PR488 — strict PascalCase rejects this)", "postToolUse", false},
+		{"all_lowercase", "single lowercase word reaches the regex but not PascalCase shape", "foo", false},
+		{"lowercase_with_digits", "alphanumeric lowercase still rejected", "abc123", false},
 		{"with_space", "spaces let attacker-controlled strings into span names", "Post ToolUse", false},
 		{"with_slash", "path-like input must be rejected", "Post/Tool", false},
-		{"with_dash", "dashes are not used in adapter event names — reject to keep the regex tight", "Post-Tool-Use", false},
+		{"with_dash", "dashes are not PascalCase", "Post-Tool-Use", false},
+		{"with_underscore", "snake_case is not PascalCase", "Post_Tool_Use", false},
 		{"with_quote", "shell-quoted input must be rejected", "Post\"Tool", false},
 		{"with_semicolon", "shell metacharacters must be rejected", "Post;Tool", false},
 		{"with_newline", "newlines must be rejected", "Post\nTool", false},
-		{"starts_with_digit", "must start with letter to match identifier shape", "1ToolUse", false},
-		{"too_long", "64-char cap prevents pathologically long span names", strings.Repeat("A", 65), false},
-		{"max_length_ok", "exactly 64 chars (1 + 63 trailing) is allowed", strings.Repeat("A", 64), true},
+		{"starts_with_digit", "must start with uppercase letter", "1ToolUse", false},
+		{"too_long", "length cap prevents pathologically long span names", strings.Repeat("A", 65), false},
+		{"too_many_segments", "16-segment cap on the regex prevents 64-uppercase-letter pathological input", strings.Repeat("A", 17), false},
 	}
 
 	for _, tt := range tests {

--- a/cmd/ox/code.go
+++ b/cmd/ox/code.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sageox/ox/internal/codedb/store"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/observability"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/repotools"
 	"github.com/sageox/ox/internal/status"
@@ -129,6 +130,11 @@ var codeSearchCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("search: %w", err)
 		}
+
+		// Attach result count to the root span. We record the *raw* count
+		// from the index, not the count after --limit truncation, so the
+		// metric reflects index recall and not display preferences.
+		observability.SetResultCount(len(results))
 
 		fullJSON, _ := cmd.Flags().GetBool("full-json")
 		limit, _ := cmd.Flags().GetInt("limit")

--- a/cmd/ox/main.go
+++ b/cmd/ox/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/sageox/agentx"
 	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/observability"
 
 	// registers all supported agents for detection
 	_ "github.com/sageox/agentx/setup"
@@ -97,6 +99,13 @@ func main() {
 
 	args := os.Args[1:]
 	exitCode := executeWithFrictionRecovery(args, 0)
+
+	// Record cli.exit_code on the root OTel span and flush. This runs on
+	// both success and error paths so failed commands appear in traces
+	// with the right exit code — PersistentPostRunE only fires on success
+	// in cobra, so it cannot be relied on for error reporting.
+	observability.SetExitCode(exitCode)
+	observability.Shutdown(context.Background())
 
 	// close pipe writers so ANSI-stripping goroutines see EOF and flush
 	os.Stdout.Close()

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/sageox/ox/internal/auth"
@@ -14,7 +15,9 @@ import (
 	"github.com/sageox/ox/internal/observability"
 	"github.com/sageox/ox/internal/signature"
 	"github.com/sageox/ox/internal/telemetry"
+	"github.com/sageox/ox/internal/version"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // Context holds common dependencies for CLI commands.
@@ -107,7 +110,16 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 		// See endpoint.Get() docs for why this is safe here.
 		apiEndpoint = endpoint.Get()
 	}
-	if err := observability.Init(cliCtx.Ctx, "ox-cli", apiEndpoint); err != nil {
+	// Resource-level attrs propagate to every span produced by this
+	// process (the root command span and any HTTP child spans), so they
+	// only need to be set once at init. Span-level attrs (set below via
+	// SetCommandAttrs) are added on top to keep cmd.args close to the
+	// command they describe.
+	if err := observability.Init(cliCtx.Ctx, "ox-cli", apiEndpoint,
+		attribute.String(observability.AttrOXVersion, version.Version),
+		attribute.String(observability.AttrHostOS, runtime.GOOS),
+		attribute.String(observability.AttrHostArch, runtime.GOARCH),
+	); err != nil {
 		slog.Debug("otel init failed, continuing without tracing", "error", err)
 	}
 
@@ -117,6 +129,14 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 		cmdPath = cmd.Parent().Name() + " " + cmdPath
 	}
 	cliCtx.Ctx, _ = observability.StartCommand(cliCtx.Ctx, observability.CommandName(cmdPath))
+
+	// Attach universal attributes to the root span: ox.version, host.os,
+	// host.arch, ox.command.args (with values redacted). This is the only
+	// place we have a clean handle on os.Args before any subcommand runs.
+	// cli.exit_code is set later from main() after Execute returns, so it
+	// is present even when PersistentPostRunE never runs (cobra skips
+	// PostRunE on errors).
+	observability.SetCommandAttrs(version.Version, os.Args[1:])
 
 	return cliCtx, nil
 }
@@ -198,11 +218,16 @@ func (c *Context) TrackCommandError(cmd *cobra.Command, err error) {
 
 // Shutdown performs cleanup operations.
 // Should be called in PersistentPostRunE or deferred.
+//
+// Note: this intentionally does NOT shut down OTel tracing. PostRunE only
+// runs on success — cobra skips it when RunE returns an error. To make
+// cli.exit_code observable on both success and error paths, the OTel root
+// span is ended from main() *after* Execute returns, where the final exit
+// code is known. See cmd/ox/main.go.
 func (c *Context) Shutdown() {
 	if c.TelemetryClient != nil {
 		c.TelemetryClient.Stop() // flush and shutdown (non-blocking, short timeout)
 	}
-	observability.Shutdown(c.Ctx)
 }
 
 // LogInfo logs an info-level message

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -115,11 +115,18 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 	// only need to be set once at init. Span-level attrs (set below via
 	// SetCommandAttrs) are added on top to keep cmd.args close to the
 	// command they describe.
-	if err := observability.Init(cliCtx.Ctx, "ox-cli", apiEndpoint,
+	resourceAttrs := []attribute.KeyValue{
 		attribute.String(observability.AttrOXVersion, version.Version),
 		attribute.String(observability.AttrHostOS, runtime.GOOS),
 		attribute.String(observability.AttrHostArch, runtime.GOARCH),
-	); err != nil {
+	}
+	// AGENT_ENV is set by adapter hooks (claude-code, aider, gemini, ...)
+	// to identify the AI coworker driving this invocation. Only attach it
+	// when present so human-driven invocations stay clean.
+	if env := os.Getenv("AGENT_ENV"); env != "" {
+		resourceAttrs = append(resourceAttrs, attribute.String(observability.AttrAgentEnv, env))
+	}
+	if err := observability.Init(cliCtx.Ctx, "ox-cli", apiEndpoint, resourceAttrs...); err != nil {
 		slog.Debug("otel init failed, continuing without tracing", "error", err)
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -930,6 +930,12 @@ func (d *Daemon) initComponents() time.Duration {
 			attribute.String("service.version", version.Version),
 			attribute.String("os.type", runtime.GOOS),
 			attribute.String("host.arch", runtime.GOARCH),
+			// Mirror the CLI attribute keys so dashboards can query
+			// "ox.version" and "host.os" uniformly across ox-cli and
+			// ox-daemon traces. The legacy service.version / os.type
+			// keys above are kept to avoid breaking existing queries.
+			attribute.String(observability.AttrOXVersion, version.Version),
+			attribute.String(observability.AttrHostOS, runtime.GOOS),
 		); err != nil {
 			d.logger.Warn("otel tracing init failed", "error", err)
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -924,7 +924,7 @@ func (d *Daemon) initComponents() time.Duration {
 	// Separate from the TelemetryCollector which handles product events.
 	if isTelemetryEnabled() && projectEndpoint != "" {
 		apiEndpoint := endpoint.GetForProject(d.config.ProjectRoot)
-		if err := observability.Init(d.ctx, "ox-daemon", apiEndpoint,
+		daemonAttrs := []attribute.KeyValue{
 			attribute.String("client.id", d.telemetry.clientID),
 			attribute.String("client.class", "daemon"),
 			attribute.String("service.version", version.Version),
@@ -936,7 +936,15 @@ func (d *Daemon) initComponents() time.Duration {
 			// keys above are kept to avoid breaking existing queries.
 			attribute.String(observability.AttrOXVersion, version.Version),
 			attribute.String(observability.AttrHostOS, runtime.GOOS),
-		); err != nil {
+		}
+		// AGENT_ENV is inherited from the parent process — typically the
+		// AI coworker that spawned the daemon via `ox agent prime`. Tag
+		// daemon traces with it so background work is attributable to
+		// the adapter that triggered it.
+		if env := os.Getenv("AGENT_ENV"); env != "" {
+			daemonAttrs = append(daemonAttrs, attribute.String(observability.AttrAgentEnv, env))
+		}
+		if err := observability.Init(d.ctx, "ox-daemon", apiEndpoint, daemonAttrs...); err != nil {
 			d.logger.Warn("otel tracing init failed", "error", err)
 		}
 		d.tracer = observability.NewDaemonTracer()

--- a/internal/observability/attrs.go
+++ b/internal/observability/attrs.go
@@ -1,0 +1,114 @@
+package observability
+
+import (
+	"runtime"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// Span attribute keys for ox CLI traces.
+//
+// These are exported as constants so call sites in cmd/ox don't typo a key
+// and end up with two attributes for the same concept. New keys belong here.
+//
+// Naming follows two conventions:
+//
+//   - OTel semantic conventions where they exist (host.os, cli.exit_code).
+//   - The "ox.*" namespace for everything else, mirroring how the daemon
+//     scopes its task spans.
+const (
+	// AttrOXVersion is the ox CLI/daemon version string. Always set on the
+	// root command span so traces can be sliced by release without joining
+	// against build metadata.
+	AttrOXVersion = "ox.version"
+
+	// AttrHostOS is the operating system the binary is running on
+	// (linux/darwin/windows). Always set on the root command span.
+	AttrHostOS = "host.os"
+
+	// AttrHostArch is the CPU architecture the binary was built for
+	// (amd64/arm64/...). Cheap to capture and useful for narrowing
+	// platform-specific regressions.
+	AttrHostArch = "host.arch"
+
+	// AttrCLIExitCode is the integer exit code the CLI process returned.
+	// Set unconditionally from main() after Execute returns, on both
+	// success (0) and error (non-zero) paths.
+	AttrCLIExitCode = "cli.exit_code"
+
+	// AttrCLIArgs is the redacted command-line arguments. Flag NAMES are
+	// preserved; flag VALUES and positional arguments are replaced with
+	// "<REDACTED>" by RedactArgs. The intent is to make "which flags do
+	// users pass to ox code search" queryable without ever exporting user
+	// content.
+	AttrCLIArgs = "ox.command.args"
+
+	// AttrResultCount is the size of the result set returned by a command
+	// that produces results (search, query, list). Set best-effort by
+	// individual commands via SetResultCount; not every command has one.
+	AttrResultCount = "result.count"
+)
+
+// SetCommandAttrs sets the universal attributes that should be present on
+// every CLI root span: ox.version, host.os, host.arch, and ox.command.args.
+//
+// Safe to call when tracing is disabled (no-op if there is no root span).
+// Args are redacted via RedactArgs before being attached.
+//
+// Should be called once per command, immediately after StartCommand. The
+// CLI bootstrap in internal/cli.NewContext does this; downstream code does
+// not need to.
+func SetCommandAttrs(version string, args []string) {
+	mu.RLock()
+	span := rootSpan
+	mu.RUnlock()
+	if span == nil {
+		return
+	}
+	redacted := RedactArgs(args)
+	span.SetAttributes(
+		attribute.String(AttrOXVersion, version),
+		attribute.String(AttrHostOS, runtime.GOOS),
+		attribute.String(AttrHostArch, runtime.GOARCH),
+		attribute.StringSlice(AttrCLIArgs, redacted),
+	)
+}
+
+// SetExitCode records the process exit code on the root command span.
+// Called from main() after rootCmd.Execute returns, so the attribute is
+// present on both success and error paths — even when PersistentPostRunE
+// never ran (cobra skips PostRunE on RunE errors).
+//
+// On non-zero exit codes the span status is also marked Error so backends
+// can filter for failed commands without inspecting the exit code field.
+//
+// Safe to call when tracing is disabled.
+func SetExitCode(code int) {
+	mu.RLock()
+	span := rootSpan
+	mu.RUnlock()
+	if span == nil {
+		return
+	}
+	span.SetAttributes(attribute.Int(AttrCLIExitCode, code))
+	if code != 0 {
+		span.SetStatus(codes.Error, "non-zero exit")
+	}
+}
+
+// SetResultCount attaches a result.count attribute to the root command
+// span. Best-effort: callers in commands that produce a result set
+// (search, query, list) call this once they know the count. Commands
+// without a natural result set should not call it.
+//
+// Safe to call when tracing is disabled.
+func SetResultCount(n int) {
+	mu.RLock()
+	span := rootSpan
+	mu.RUnlock()
+	if span == nil {
+		return
+	}
+	span.SetAttributes(attribute.Int(AttrResultCount, n))
+}

--- a/internal/observability/attrs.go
+++ b/internal/observability/attrs.go
@@ -1,6 +1,7 @@
 package observability
 
 import (
+	"os"
 	"runtime"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -48,10 +49,27 @@ const (
 	// that produces results (search, query, list). Set best-effort by
 	// individual commands via SetResultCount; not every command has one.
 	AttrResultCount = "result.count"
+
+	// AttrAgentEnv identifies the AI coworker that invoked ox, sourced
+	// from the AGENT_ENV environment variable that adapter hooks set
+	// (claude-code, aider, gemini, codex, ...). Only present when the
+	// command is being driven by an AI coworker — human-driven
+	// invocations leave this attribute off the span entirely so a
+	// `ox.agent.env exists` query in the trace backend cleanly isolates
+	// agent traffic from human traffic.
+	AttrAgentEnv = "ox.agent.env"
 )
 
+// agentEnv returns the value of the AGENT_ENV environment variable, or the
+// empty string if it is unset. Centralized in one place so the lookup
+// convention is consistent across resource attrs and span attrs.
+func agentEnv() string {
+	return os.Getenv("AGENT_ENV")
+}
+
 // SetCommandAttrs sets the universal attributes that should be present on
-// every CLI root span: ox.version, host.os, host.arch, and ox.command.args.
+// every CLI root span: ox.version, host.os, host.arch, ox.command.args,
+// and (when set) ox.agent.env.
 //
 // Safe to call when tracing is disabled (no-op if there is no root span).
 // Args are redacted via RedactArgs before being attached.
@@ -67,12 +85,19 @@ func SetCommandAttrs(version string, args []string) {
 		return
 	}
 	redacted := RedactArgs(args)
-	span.SetAttributes(
+	attrs := []attribute.KeyValue{
 		attribute.String(AttrOXVersion, version),
 		attribute.String(AttrHostOS, runtime.GOOS),
 		attribute.String(AttrHostArch, runtime.GOARCH),
 		attribute.StringSlice(AttrCLIArgs, redacted),
-	)
+	}
+	// Only attach ox.agent.env when the AGENT_ENV env var is set, so
+	// human-driven invocations don't pollute trace backends with empty
+	// strings. Filter "ox.agent.env exists" to find agent traffic.
+	if env := agentEnv(); env != "" {
+		attrs = append(attrs, attribute.String(AttrAgentEnv, env))
+	}
+	span.SetAttributes(attrs...)
 }
 
 // SetExitCode records the process exit code on the root command span.

--- a/internal/observability/attrs.go
+++ b/internal/observability/attrs.go
@@ -58,6 +58,16 @@ const (
 	// `ox.agent.env exists` query in the trace backend cleanly isolates
 	// agent traffic from human traffic.
 	AttrAgentEnv = "ox.agent.env"
+
+	// AttrCommandSubcommand is the resolved subcommand path for commands
+	// that go through a dispatcher. Cobra's PreRunE creates the root
+	// span before the dispatcher resolves what was actually invoked, so
+	// every dispatcher hit would otherwise share one bland span name
+	// (e.g. "ox agent"). RenameRootSpan attaches this attribute alongside
+	// the renamed span so backends can group by it even if a future
+	// refactor changes the span-name scheme — and so high-cardinality
+	// suffixes like hook phase names don't bloat span-name buckets.
+	AttrCommandSubcommand = "ox.command.subcommand"
 )
 
 // agentEnv returns the value of the AGENT_ENV environment variable, or the
@@ -136,4 +146,40 @@ func SetResultCount(n int) {
 		return
 	}
 	span.SetAttributes(attribute.Int(AttrResultCount, n))
+}
+
+// RenameRootSpan rewrites the name of the root command span and attaches
+// an ox.command.subcommand attribute. Used by command dispatchers — most
+// notably the `ox agent <agent_id> <cmd>` dispatcher in cmd/ox/agent.go —
+// that need to refine the span name once they have resolved the actual
+// invocation.
+//
+// Why this exists: cobra's PersistentPreRunE creates the root span before
+// the dispatcher's RunE runs, so the span starts life with a bland name
+// like "ox agent" because cobra only sees the agentCmd. Without renaming,
+// every dispatcher hit ends up in one giant bucket in the trace backend
+// and you can't answer "which dispatcher path is slow / erroring?".
+//
+// The subcommand string is also attached as an attribute (AttrCommandSubcommand)
+// so dashboards can group by it independently of the span name. Empty
+// subcommand strings are not attached.
+//
+// Should be called BEFORE any early-return paths in the dispatcher
+// (unknown agent_id, validation errors, help) so even fast failures end
+// up under the right span name.
+//
+// Safe to call when tracing is disabled.
+func RenameRootSpan(name, subcommand string) {
+	mu.RLock()
+	span := rootSpan
+	mu.RUnlock()
+	if span == nil {
+		return
+	}
+	if name != "" {
+		span.SetName(name)
+	}
+	if subcommand != "" {
+		span.SetAttributes(attribute.String(AttrCommandSubcommand, subcommand))
+	}
 }

--- a/internal/observability/attrs_test.go
+++ b/internal/observability/attrs_test.go
@@ -84,6 +84,10 @@ func hasAttr(span sdktrace.ReadOnlySpan, key string) bool {
 // would silently make every CLI trace miss the field, and operators
 // would only notice when querying for it after the regression shipped.
 func TestSetCommandAttrs_AttachesUniversalAttrs(t *testing.T) {
+	// Ensure AGENT_ENV is unset so this case isolates the universal-only
+	// path. The agent-env branches are covered by their own tests.
+	t.Setenv("AGENT_ENV", "")
+
 	recorder := installTestTracer(t)
 
 	SetCommandAttrs("0.99.0", []string{"code", "search", "--limit", "10"})
@@ -117,6 +121,63 @@ func TestSetCommandAttrs_AttachesUniversalAttrs(t *testing.T) {
 		if args[i] != wantArgs[i] {
 			t.Errorf("ox.command.args[%d] = %q, want %q", i, args[i], wantArgs[i])
 		}
+	}
+
+	// AGENT_ENV is unset, so ox.agent.env must be absent — not present
+	// as an empty string. This is the contract that lets backends use
+	// "ox.agent.env exists" to filter agent traffic from human traffic.
+	if hasAttr(span, AttrAgentEnv) {
+		t.Errorf("ox.agent.env present on human-driven invocation; have: %v",
+			span.Attributes())
+	}
+}
+
+// TestSetCommandAttrs_AttachesAgentEnv_WhenSet verifies that when the
+// AGENT_ENV environment variable is set (typical of an AI coworker
+// invocation via adapter hooks), the value lands on the root span as
+// ox.agent.env.
+//
+// Failure prevented: a refactor that loses the AGENT_ENV propagation
+// would silently make every agent-driven trace look like a human
+// invocation, breaking attribution dashboards.
+func TestSetCommandAttrs_AttachesAgentEnv_WhenSet(t *testing.T) {
+	t.Setenv("AGENT_ENV", "claude-code")
+
+	recorder := installTestTracer(t)
+
+	SetCommandAttrs("0.0.1", []string{"agent", "OxAAA1", "session", "start"})
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	span := recorder.Ended()[0]
+	if v := findAttr(t, span, AttrAgentEnv).AsString(); v != "claude-code" {
+		t.Errorf("ox.agent.env = %q, want %q", v, "claude-code")
+	}
+}
+
+// TestSetCommandAttrs_OmitsAgentEnv_WhenEmpty pins the inverse: when
+// AGENT_ENV is the empty string, the attribute is OMITTED from the span,
+// not set to "". The "exists" filter is the entire point of this design.
+//
+// Failure prevented: a "set anyway, downstream can filter" simplification
+// that would pollute every human invocation with ox.agent.env="".
+func TestSetCommandAttrs_OmitsAgentEnv_WhenEmpty(t *testing.T) {
+	t.Setenv("AGENT_ENV", "")
+
+	recorder := installTestTracer(t)
+
+	SetCommandAttrs("0.0.1", []string{"version"})
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	span := recorder.Ended()[0]
+	if hasAttr(span, AttrAgentEnv) {
+		t.Errorf("ox.agent.env present despite AGENT_ENV being empty; have: %v",
+			span.Attributes())
 	}
 }
 

--- a/internal/observability/attrs_test.go
+++ b/internal/observability/attrs_test.go
@@ -294,6 +294,87 @@ func TestSetResultCount_Zero(t *testing.T) {
 	}
 }
 
+// TestRenameRootSpan_RewritesNameAndSetsAttr verifies that
+// RenameRootSpan updates the active root span's name AND attaches the
+// ox.command.subcommand attribute. Both pieces of state are part of the
+// dispatcher's contract: the renamed name powers default span-name
+// grouping in trace backends, while the attribute lets dashboards
+// group by subcommand independently of any future naming scheme change.
+//
+// Failure prevented: a regression that updates only the name (or only
+// the attribute) would silently break one of the two query paths.
+// Users would only notice when their saved Honeycomb queries stopped
+// returning results.
+func TestRenameRootSpan_RewritesNameAndSetsAttr(t *testing.T) {
+	recorder := installTestTracer(t)
+
+	RenameRootSpan("ox agent session start", "session start")
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	span := recorder.Ended()[0]
+	if got := span.Name(); got != "ox agent session start" {
+		t.Errorf("span name = %q, want %q", got, "ox agent session start")
+	}
+	if v := findAttr(t, span, AttrCommandSubcommand).AsString(); v != "session start" {
+		t.Errorf("ox.command.subcommand = %q, want %q", v, "session start")
+	}
+}
+
+// TestRenameRootSpan_EmptyNameKeepsExistingName verifies that calling
+// RenameRootSpan with an empty name does not blank out the existing
+// span name. Lets callers set just the attribute (rare but possible)
+// without accidentally producing an unnamed span.
+//
+// Failure prevented: a defensive caller passing "" by mistake would
+// otherwise corrupt the span's identity in trace backends.
+func TestRenameRootSpan_EmptyNameKeepsExistingName(t *testing.T) {
+	recorder := installTestTracer(t)
+
+	// installTestTracer starts the span with name "test-root".
+	RenameRootSpan("", "subcommand-only")
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	span := recorder.Ended()[0]
+	if got := span.Name(); got != "test-root" {
+		t.Errorf("span name = %q, want %q (empty name should not overwrite)", got, "test-root")
+	}
+	if v := findAttr(t, span, AttrCommandSubcommand).AsString(); v != "subcommand-only" {
+		t.Errorf("ox.command.subcommand = %q, want %q", v, "subcommand-only")
+	}
+}
+
+// TestRenameRootSpan_EmptySubcommandSkipsAttr verifies the inverse:
+// passing an empty subcommand only renames the span and does not attach
+// an empty ox.command.subcommand attribute. This keeps the "exists"
+// filter clean — backends shouldn't see ox.command.subcommand="" rows.
+//
+// Failure prevented: a "set anyway, downstream can filter" simplification
+// that would pollute every renamed span with an empty subcommand.
+func TestRenameRootSpan_EmptySubcommandSkipsAttr(t *testing.T) {
+	recorder := installTestTracer(t)
+
+	RenameRootSpan("ox agent help", "")
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	span := recorder.Ended()[0]
+	if got := span.Name(); got != "ox agent help" {
+		t.Errorf("span name = %q, want %q", got, "ox agent help")
+	}
+	if hasAttr(span, AttrCommandSubcommand) {
+		t.Errorf("ox.command.subcommand present despite empty subcommand arg; have: %v",
+			span.Attributes())
+	}
+}
+
 // TestSetters_NoOpWhenTracingDisabled verifies that all three setter
 // helpers are safe to call when tracing was never initialized. They
 // must not panic and must not allocate spans on a nil tracer.
@@ -326,4 +407,5 @@ func TestSetters_NoOpWhenTracingDisabled(t *testing.T) {
 	SetCommandAttrs("0.0.0", []string{"foo", "bar"})
 	SetExitCode(7)
 	SetResultCount(99)
+	RenameRootSpan("ox agent foo", "foo")
 }

--- a/internal/observability/attrs_test.go
+++ b/internal/observability/attrs_test.go
@@ -1,0 +1,261 @@
+package observability
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// installTestTracer wires a tracetest.SpanRecorder into the package-global
+// tracer/rootSpan so the SetCommandAttrs / SetExitCode / SetResultCount
+// helpers can be exercised against a real OTel SDK without an exporter.
+//
+// Returns the recorder so tests can inspect ended spans, and a cleanup
+// function that ends the root span and restores the previous global state.
+//
+// NOT parallel-safe — tests using this helper must not call t.Parallel().
+func installTestTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	mu.Lock()
+	prevTracer := tracer
+	prevRootSpan := rootSpan
+	prevRootCtx := rootCtx
+	tracer = tp.Tracer("test")
+	mu.Unlock()
+
+	ctx, span := tracer.Start(context.Background(), "test-root")
+
+	mu.Lock()
+	rootCtx = ctx
+	rootSpan = span
+	mu.Unlock()
+
+	t.Cleanup(func() {
+		mu.Lock()
+		if rootSpan != nil {
+			rootSpan.End()
+		}
+		tracer = prevTracer
+		rootSpan = prevRootSpan
+		rootCtx = prevRootCtx
+		mu.Unlock()
+		_ = tp.Shutdown(context.Background())
+	})
+
+	return recorder
+}
+
+// findAttr returns the typed value of the first attribute with the given key.
+func findAttr(t *testing.T, span sdktrace.ReadOnlySpan, key string) attribute.Value {
+	t.Helper()
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value
+		}
+	}
+	t.Fatalf("attribute %q not found on span; have: %v", key, span.Attributes())
+	return attribute.Value{}
+}
+
+// hasAttr reports whether a span carries an attribute with the given key.
+func hasAttr(span sdktrace.ReadOnlySpan, key string) bool {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSetCommandAttrs_AttachesUniversalAttrs verifies that the four
+// universal attributes (ox.version, host.os, host.arch, ox.command.args)
+// land on the root span with the expected values.
+//
+// Failure prevented: a refactor that drops one of the universal attrs
+// would silently make every CLI trace miss the field, and operators
+// would only notice when querying for it after the regression shipped.
+func TestSetCommandAttrs_AttachesUniversalAttrs(t *testing.T) {
+	recorder := installTestTracer(t)
+
+	SetCommandAttrs("0.99.0", []string{"code", "search", "--limit", "10"})
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("expected 1 ended span, got %d", len(ended))
+	}
+	span := ended[0]
+
+	if v := findAttr(t, span, AttrOXVersion).AsString(); v != "0.99.0" {
+		t.Errorf("ox.version = %q, want %q", v, "0.99.0")
+	}
+	if v := findAttr(t, span, AttrHostOS).AsString(); v != runtime.GOOS {
+		t.Errorf("host.os = %q, want %q", v, runtime.GOOS)
+	}
+	if v := findAttr(t, span, AttrHostArch).AsString(); v != runtime.GOARCH {
+		t.Errorf("host.arch = %q, want %q", v, runtime.GOARCH)
+	}
+
+	args := findAttr(t, span, AttrCLIArgs).AsStringSlice()
+	wantArgs := []string{"<REDACTED>", "<REDACTED>", "--limit", "<REDACTED>"}
+	if len(args) != len(wantArgs) {
+		t.Fatalf("ox.command.args = %v, want %v", args, wantArgs)
+	}
+	for i := range wantArgs {
+		if args[i] != wantArgs[i] {
+			t.Errorf("ox.command.args[%d] = %q, want %q", i, args[i], wantArgs[i])
+		}
+	}
+}
+
+// TestSetCommandAttrs_RedactsValues is the contract test that proves the
+// args attribute never carries raw user input. We deliberately choose
+// inputs that look like secrets — if any of them appear verbatim in the
+// emitted attribute, the helper has leaked.
+//
+// Failure prevented: a future change that bypasses RedactArgs (e.g., a
+// "fast path for short arg lists") and exports values directly.
+func TestSetCommandAttrs_RedactsValues(t *testing.T) {
+	recorder := installTestTracer(t)
+
+	secrets := []string{"--token", "ghp_REAL_SECRET_VALUE", "search", "internal-codename-leaks"}
+	SetCommandAttrs("0.0.1", secrets)
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	args := recorder.Ended()[0].Attributes()
+	for _, kv := range args {
+		if string(kv.Key) != AttrCLIArgs {
+			continue
+		}
+		for _, tok := range kv.Value.AsStringSlice() {
+			if tok == "ghp_REAL_SECRET_VALUE" || tok == "internal-codename-leaks" {
+				t.Errorf("ox.command.args leaked a value token: %q (full slice: %v)",
+					tok, kv.Value.AsStringSlice())
+			}
+		}
+	}
+}
+
+// TestSetExitCode_SetsAttrAndStatus verifies cli.exit_code lands on the
+// span and that a non-zero code marks the span status as Error.
+//
+// Failure prevented: silently dropping exit_code or marking failures as
+// successful in OTel backends — both make it impossible to filter for
+// failed CLI invocations from traces.
+func TestSetExitCode_SetsAttrAndStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		code       int
+		wantStatus codes.Code
+	}{
+		{"success_zero", 0, codes.Unset},
+		{"failure_one", 1, codes.Error},
+		{"failure_other", 42, codes.Error},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := installTestTracer(t)
+
+			SetExitCode(tt.code)
+
+			mu.RLock()
+			rootSpan.End()
+			mu.RUnlock()
+
+			span := recorder.Ended()[0]
+			if v := findAttr(t, span, AttrCLIExitCode).AsInt64(); v != int64(tt.code) {
+				t.Errorf("cli.exit_code = %d, want %d", v, tt.code)
+			}
+			if span.Status().Code != tt.wantStatus {
+				t.Errorf("status = %v, want %v", span.Status().Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// TestSetResultCount_SetsAttr verifies result.count lands on the root span
+// with the right integer value.
+//
+// Failure prevented: a typo in the attribute key would still pass code
+// review but make the metric unqueryable in Honeycomb.
+func TestSetResultCount_SetsAttr(t *testing.T) {
+	recorder := installTestTracer(t)
+
+	SetResultCount(137)
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	span := recorder.Ended()[0]
+	if v := findAttr(t, span, AttrResultCount).AsInt64(); v != 137 {
+		t.Errorf("result.count = %d, want 137", v)
+	}
+}
+
+// TestSetResultCount_Zero verifies that zero is recorded as a real value,
+// not omitted. A "zero results" search is meaningful telemetry.
+//
+// Failure prevented: a "skip if empty" optimization would erase the
+// distinction between "no result.count attr" (untraced command) and
+// "result.count = 0" (search returned nothing).
+func TestSetResultCount_Zero(t *testing.T) {
+	recorder := installTestTracer(t)
+
+	SetResultCount(0)
+
+	mu.RLock()
+	rootSpan.End()
+	mu.RUnlock()
+
+	span := recorder.Ended()[0]
+	if !hasAttr(span, AttrResultCount) {
+		t.Error("result.count = 0 was omitted from span; want explicit zero")
+	}
+	if v := findAttr(t, span, AttrResultCount).AsInt64(); v != 0 {
+		t.Errorf("result.count = %d, want 0", v)
+	}
+}
+
+// TestSetters_NoOpWhenTracingDisabled verifies that all three setter
+// helpers are safe to call when tracing was never initialized. They
+// must not panic and must not allocate spans on a nil tracer.
+//
+// Failure prevented: tracing-disabled paths (no OTel endpoint, daemon
+// down, init failure) would panic on every command if the helpers
+// dereferenced a nil rootSpan.
+func TestSetters_NoOpWhenTracingDisabled(t *testing.T) {
+	// Snapshot and clear globals to simulate "tracing not initialized".
+	mu.Lock()
+	prevTracer := tracer
+	prevRootSpan := rootSpan
+	tracer = nil
+	rootSpan = nil
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		tracer = prevTracer
+		rootSpan = prevRootSpan
+		mu.Unlock()
+	})
+
+	// None of these should panic or do anything observable.
+	SetCommandAttrs("0.0.0", []string{"foo", "bar"})
+	SetExitCode(7)
+	SetResultCount(99)
+}

--- a/internal/observability/attrs_test.go
+++ b/internal/observability/attrs_test.go
@@ -187,7 +187,10 @@ func TestSetCommandAttrs_OmitsAgentEnv_WhenEmpty(t *testing.T) {
 // emitted attribute, the helper has leaked.
 //
 // Failure prevented: a future change that bypasses RedactArgs (e.g., a
-// "fast path for short arg lists") and exports values directly.
+// "fast path for short arg lists") and exports values directly. Also
+// catches the inverse — a refactor that drops AttrCLIArgs entirely
+// would otherwise pass this test silently because there'd be nothing
+// to scan for leaks. findAttr fails the test if the key is missing.
 func TestSetCommandAttrs_RedactsValues(t *testing.T) {
 	recorder := installTestTracer(t)
 
@@ -198,16 +201,14 @@ func TestSetCommandAttrs_RedactsValues(t *testing.T) {
 	rootSpan.End()
 	mu.RUnlock()
 
-	args := recorder.Ended()[0].Attributes()
-	for _, kv := range args {
-		if string(kv.Key) != AttrCLIArgs {
-			continue
-		}
-		for _, tok := range kv.Value.AsStringSlice() {
-			if tok == "ghp_REAL_SECRET_VALUE" || tok == "internal-codename-leaks" {
-				t.Errorf("ox.command.args leaked a value token: %q (full slice: %v)",
-					tok, kv.Value.AsStringSlice())
-			}
+	span := recorder.Ended()[0]
+	// findAttr fails the test if AttrCLIArgs is absent — this guards
+	// against a regression that drops the attribute entirely.
+	args := findAttr(t, span, AttrCLIArgs).AsStringSlice()
+	for _, tok := range args {
+		if tok == "ghp_REAL_SECRET_VALUE" || tok == "internal-codename-leaks" {
+			t.Errorf("ox.command.args leaked a value token: %q (full slice: %v)",
+				tok, args)
 		}
 	}
 }
@@ -301,17 +302,23 @@ func TestSetResultCount_Zero(t *testing.T) {
 // down, init failure) would panic on every command if the helpers
 // dereferenced a nil rootSpan.
 func TestSetters_NoOpWhenTracingDisabled(t *testing.T) {
-	// Snapshot and clear globals to simulate "tracing not initialized".
+	// Snapshot and clear ALL package-global tracing state to fully
+	// simulate "tracing not initialized". rootCtx is part of that
+	// state — leaving a stale value behind would let other tests in
+	// the package see leaked context across runs.
 	mu.Lock()
 	prevTracer := tracer
 	prevRootSpan := rootSpan
+	prevRootCtx := rootCtx
 	tracer = nil
 	rootSpan = nil
+	rootCtx = nil
 	mu.Unlock()
 	t.Cleanup(func() {
 		mu.Lock()
 		tracer = prevTracer
 		rootSpan = prevRootSpan
+		rootCtx = prevRootCtx
 		mu.Unlock()
 	})
 

--- a/internal/observability/redact.go
+++ b/internal/observability/redact.go
@@ -20,18 +20,31 @@ const RedactedPlaceholder = "<REDACTED>"
 //
 // Behavior:
 //
-//   - "--name=value"     -> "--name=<REDACTED>"
-//   - "--name", "value"  -> "--name", "<REDACTED>"
-//   - "-n", "value"      -> "-n", "<REDACTED>"
-//   - "positional"       -> "<REDACTED>"
-//   - "--bool-flag"      -> "--bool-flag" (untouched, no value)
-//   - "--", "rest..."    -> "--", "<REDACTED>", "<REDACTED>", ...
+//   - "--name=value"        -> "--name=<REDACTED>"
+//   - "--name", "value"     -> "--name", "<REDACTED>"
+//   - "--name", "-5"        -> "--name", "<REDACTED>"  (closes the
+//                              "value starts with -" leak)
+//   - "-n", "value"         -> "-n", "<REDACTED>"
+//   - "positional"          -> "<REDACTED>"
+//   - "--bool", "--other"   -> "--bool", "--other"     (chained long flags
+//                              are preserved as flag NAMES)
+//   - "--", "rest..."       -> "--", "<REDACTED>", "<REDACTED>", ...
 //
 // We do NOT have a flag schema here, so we cannot distinguish a boolean
-// flag from a value-taking flag. The heuristic: if the *next* token also
-// looks like a flag (starts with "-"), the current flag has no value;
-// otherwise the next token is treated as a value and redacted. This
-// matches what most shells and shell-history scrubbers do.
+// flag from a value-taking flag. The discriminator we use is whether the
+// next token starts with "--" — a true long flag begins with "--" by
+// convention, so this lets us preserve chained boolean long flags
+// (`--verbose --json`) without keeping anything that could plausibly be
+// a value. Tokens starting with a single "-" (e.g. "-5", "-k", "-foo")
+// are treated as values for the preceding flag and redacted.
+//
+// Known residual: a value that *literally* begins with "--" (e.g.
+// `--message --secret-token` where `--secret-token` is meant as a string
+// value, not a flag) will be preserved verbatim. This is statistically
+// vanishingly rare for real secrets and was an explicit trade-off to
+// keep `--verbose --json`-style chained long flags queryable. A
+// follow-up PR can take a flag schema from cobra at the call site and
+// disambiguate exactly.
 //
 // Pure function. Returns a fresh slice — the input is never mutated.
 func RedactArgs(args []string) []string {
@@ -70,12 +83,14 @@ func RedactArgs(args []string) []string {
 		}
 
 		// Bare long flag (--name) or bare short flag (-n).
-		// If the next token does not look like another flag, treat it
-		// as the value and redact it. Otherwise, leave the flag alone
-		// (it's a boolean / standalone flag).
+		// The next token is treated as the flag's value and redacted
+		// UNLESS it begins with "--", in which case it's another long
+		// flag we want to preserve in telemetry. This closes the
+		// "value starts with -" leak (e.g. --limit -5) while keeping
+		// chained boolean long flags queryable (e.g. --verbose --json).
 		if strings.HasPrefix(tok, "-") && len(tok) > 1 {
 			out = append(out, tok)
-			if i+1 < len(args) && !looksLikeFlag(args[i+1]) {
+			if i+1 < len(args) && !isLongFlag(args[i+1]) {
 				out = append(out, RedactedPlaceholder)
 				i++
 			}
@@ -88,11 +103,13 @@ func RedactArgs(args []string) []string {
 	return out
 }
 
-// looksLikeFlag returns true if tok would be parsed as a flag by most CLIs:
-// it begins with "-" and has at least one more character (so "-" alone — a
-// common stdin sentinel — is treated as a positional argument).
-func looksLikeFlag(tok string) bool {
-	return len(tok) >= 2 && tok[0] == '-'
+// isLongFlag returns true for tokens that begin with "--" and have at
+// least one name character after the dashes. Used as the discriminator
+// for "should I redact the next token as a value?": only chained long
+// flags survive as flag names, everything else is conservatively
+// treated as a value.
+func isLongFlag(tok string) bool {
+	return len(tok) >= 3 && tok[0] == '-' && tok[1] == '-'
 }
 
 // isShortFlag returns true for tokens like "-n" or "-n=value" (single-dash

--- a/internal/observability/redact.go
+++ b/internal/observability/redact.go
@@ -84,13 +84,18 @@ func RedactArgs(args []string) []string {
 
 		// Bare long flag (--name) or bare short flag (-n).
 		// The next token is treated as the flag's value and redacted
-		// UNLESS it begins with "--", in which case it's another long
-		// flag we want to preserve in telemetry. This closes the
-		// "value starts with -" leak (e.g. --limit -5) while keeping
-		// chained boolean long flags queryable (e.g. --verbose --json).
+		// UNLESS it is the "--" terminator OR begins with "--" (a
+		// chained long flag we want to preserve in telemetry). This
+		// closes the "value starts with -" leak (e.g. --limit -5)
+		// while keeping chained boolean long flags queryable (e.g.
+		// --verbose --json) AND honoring "--" as a real terminator
+		// even when it appears immediately after a flag (e.g.
+		// `--verbose -- positional` — the "--" must reach the
+		// terminator branch on the next iteration, not get consumed
+		// here as a value of --verbose).
 		if strings.HasPrefix(tok, "-") && len(tok) > 1 {
 			out = append(out, tok)
-			if i+1 < len(args) && !isLongFlag(args[i+1]) {
+			if i+1 < len(args) && args[i+1] != "--" && !isLongFlag(args[i+1]) {
 				out = append(out, RedactedPlaceholder)
 				i++
 			}

--- a/internal/observability/redact.go
+++ b/internal/observability/redact.go
@@ -1,0 +1,102 @@
+package observability
+
+import "strings"
+
+// RedactedPlaceholder is the string that replaces every redacted token in
+// the output of RedactArgs. Exposed as a constant so tests and downstream
+// code can match against it without hardcoding the literal.
+const RedactedPlaceholder = "<REDACTED>"
+
+// RedactArgs returns a copy of args suitable for tracing or telemetry,
+// preserving flag *names* but replacing every flag *value* and every
+// positional argument with RedactedPlaceholder.
+//
+// The goal is to make `ox.command.args` queryable ("which flags are users
+// passing to ox code search?") without leaking any user content
+// ("what is the user searching for?"). The conservative default is to
+// redact aggressively: free-form input belongs in command-specific
+// attributes (e.g. ox.code.search.query) where redaction can be tuned
+// to the field, not at the args level.
+//
+// Behavior:
+//
+//   - "--name=value"     -> "--name=<REDACTED>"
+//   - "--name", "value"  -> "--name", "<REDACTED>"
+//   - "-n", "value"      -> "-n", "<REDACTED>"
+//   - "positional"       -> "<REDACTED>"
+//   - "--bool-flag"      -> "--bool-flag" (untouched, no value)
+//   - "--", "rest..."    -> "--", "<REDACTED>", "<REDACTED>", ...
+//
+// We do NOT have a flag schema here, so we cannot distinguish a boolean
+// flag from a value-taking flag. The heuristic: if the *next* token also
+// looks like a flag (starts with "-"), the current flag has no value;
+// otherwise the next token is treated as a value and redacted. This
+// matches what most shells and shell-history scrubbers do.
+//
+// Pure function. Returns a fresh slice — the input is never mutated.
+func RedactArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(args))
+	afterDoubleDash := false
+
+	for i := 0; i < len(args); i++ {
+		tok := args[i]
+
+		// Everything after "--" is positional regardless of leading dashes.
+		if afterDoubleDash {
+			out = append(out, RedactedPlaceholder)
+			continue
+		}
+		if tok == "--" {
+			out = append(out, tok)
+			afterDoubleDash = true
+			continue
+		}
+
+		// Long flag with embedded value: --name=value
+		if strings.HasPrefix(tok, "--") && strings.Contains(tok, "=") {
+			eq := strings.IndexByte(tok, '=')
+			out = append(out, tok[:eq+1]+RedactedPlaceholder)
+			continue
+		}
+
+		// Short flag with embedded value: -n=value (rare but possible)
+		if isShortFlag(tok) && strings.Contains(tok, "=") {
+			eq := strings.IndexByte(tok, '=')
+			out = append(out, tok[:eq+1]+RedactedPlaceholder)
+			continue
+		}
+
+		// Bare long flag (--name) or bare short flag (-n).
+		// If the next token does not look like another flag, treat it
+		// as the value and redact it. Otherwise, leave the flag alone
+		// (it's a boolean / standalone flag).
+		if strings.HasPrefix(tok, "-") && len(tok) > 1 {
+			out = append(out, tok)
+			if i+1 < len(args) && !looksLikeFlag(args[i+1]) {
+				out = append(out, RedactedPlaceholder)
+				i++
+			}
+			continue
+		}
+
+		// Plain positional — redact.
+		out = append(out, RedactedPlaceholder)
+	}
+	return out
+}
+
+// looksLikeFlag returns true if tok would be parsed as a flag by most CLIs:
+// it begins with "-" and has at least one more character (so "-" alone — a
+// common stdin sentinel — is treated as a positional argument).
+func looksLikeFlag(tok string) bool {
+	return len(tok) >= 2 && tok[0] == '-'
+}
+
+// isShortFlag returns true for tokens like "-n" or "-n=value" (single-dash
+// followed by non-dash). Used to spot the rare `-x=value` form.
+func isShortFlag(tok string) bool {
+	return len(tok) >= 2 && tok[0] == '-' && tok[1] != '-'
+}

--- a/internal/observability/redact_test.go
+++ b/internal/observability/redact_test.go
@@ -1,0 +1,211 @@
+package observability
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestRedactArgs covers the contract: every test case names the failure mode
+// it prevents, so a future "simplification" of the redactor cannot quietly
+// regress to leaking values.
+//
+// The contract: flag NAMES are queryable in trace backends; flag VALUES and
+// positional arguments are NEVER queryable from this attribute. Any test
+// here failing means user content is at risk of being exported as telemetry.
+func TestRedactArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// what real-world failure does this case prevent
+		prevents string
+		in       []string
+		want     []string
+	}{
+		{
+			name:     "nil_input",
+			prevents: "panic on empty argv (e.g. ox with no subcommand)",
+			in:       nil,
+			want:     nil,
+		},
+		{
+			name:     "empty_slice",
+			prevents: "panic on len(args)==0",
+			in:       []string{},
+			want:     nil,
+		},
+		{
+			name:     "subcommand_only",
+			prevents: "leaking subcommand name (it is intentionally kept)",
+			in:       []string{"login"},
+			// "login" is a positional from argv's perspective; redact it.
+			// The subcommand path is captured by the span name, not by args.
+			want: []string{"<REDACTED>"},
+		},
+		{
+			name:     "long_flag_separate_value",
+			prevents: "search query leaking via `--query 'secret'`",
+			in:       []string{"code", "search", "--query", "internal codename"},
+			want:     []string{"<REDACTED>", "<REDACTED>", "--query", "<REDACTED>"},
+		},
+		{
+			name:     "long_flag_equals_value",
+			prevents: "secret leaking via `--token=ghp_xxx`",
+			in:       []string{"--token=ghp_realsecretvalue123"},
+			want:     []string{"--token=<REDACTED>"},
+		},
+		{
+			name:     "short_flag_separate_value",
+			prevents: "value leaking via `-k 10` style short flags",
+			in:       []string{"-k", "10"},
+			want:     []string{"-k", "<REDACTED>"},
+		},
+		{
+			name:     "short_flag_equals_value",
+			prevents: "value leaking via the `-x=value` short-flag form",
+			in:       []string{"-k=10"},
+			want:     []string{"-k=<REDACTED>"},
+		},
+		{
+			name:     "boolean_flag_followed_by_another_flag",
+			prevents: "redacting nothing after a boolean flag (false positive)",
+			in:       []string{"--verbose", "--json"},
+			want:     []string{"--verbose", "--json"},
+		},
+		{
+			name:     "boolean_flag_at_end_of_args",
+			prevents: "panic on trailing boolean flag",
+			in:       []string{"--verbose"},
+			want:     []string{"--verbose"},
+		},
+		{
+			name:     "mixed_flags_and_positionals",
+			prevents: "any positional leaking — only flag names should survive",
+			in:       []string{"query", "auth flow", "--limit", "5", "--source=team"},
+			want: []string{
+				"<REDACTED>",     // "query" (subcommand looks positional from argv)
+				"<REDACTED>",     // "auth flow"
+				"--limit",        // flag name kept
+				"<REDACTED>",     // "5"
+				"--source=<REDACTED>",
+			},
+		},
+		{
+			name:     "double_dash_terminator_redacts_everything_after",
+			prevents: "post-`--` content (commonly the actual user input) leaking",
+			in:       []string{"agent", "OxAAA1", "--", "--session-id", "real-id"},
+			want: []string{
+				"<REDACTED>",
+				"<REDACTED>",
+				"--",
+				"<REDACTED>",
+				"<REDACTED>",
+			},
+		},
+		{
+			name:     "stdin_sentinel_dash",
+			prevents: "treating bare `-` (stdin) as a flag and skipping next arg",
+			in:       []string{"import", "-", "extra"},
+			want:     []string{"<REDACTED>", "<REDACTED>", "<REDACTED>"},
+		},
+		{
+			name:     "input_is_not_mutated",
+			prevents: "RedactArgs mutating its caller's slice (caused by in-place edit)",
+			// covered by the explicit aliasing test below; this case just
+			// also exercises a typical capture-prior invocation
+			in:   []string{"agent", "Oxslow1", "session", "capture-prior", "--adapter", "claude", "--session-id", "abc"},
+			want: []string{"<REDACTED>", "<REDACTED>", "<REDACTED>", "<REDACTED>", "--adapter", "<REDACTED>", "--session-id", "<REDACTED>"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := RedactArgs(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RedactArgs(%q)\n got: %q\nwant: %q\n(test prevents: %s)",
+					tt.in, got, tt.want, tt.prevents)
+			}
+		})
+	}
+}
+
+// TestRedactArgs_DoesNotMutateInput is a separate, dedicated test for the
+// non-mutation invariant. Failure prevented: a future refactor that edits
+// args in place would alter os.Args (which is what callers will pass) and
+// silently change command-line parsing for the rest of the process.
+func TestRedactArgs_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	in := []string{"--adapter", "claude", "--session-id", "abc"}
+	snapshot := append([]string(nil), in...)
+
+	_ = RedactArgs(in)
+
+	if !reflect.DeepEqual(in, snapshot) {
+		t.Errorf("RedactArgs mutated input slice\n  in:  %q\n  was: %q", in, snapshot)
+	}
+}
+
+// TestRedactArgs_AllValuesAreReplaced is a fuzz-style invariant: for any
+// arg that is not a flag NAME or the literal "--" terminator, the output
+// must contain RedactedPlaceholder at that position.
+//
+// Failure prevented: a regex change or new branch that lets a positional
+// fall through unredacted. This test catches the *category* of bug rather
+// than enumerating every input shape.
+func TestRedactArgs_AllValuesAreReplaced(t *testing.T) {
+	t.Parallel()
+
+	cases := [][]string{
+		{"alpha", "beta", "gamma"},
+		{"--key", "secret"},
+		{"--key=secret"},
+		{"-k", "secret"},
+		{"-k=secret"},
+		{"cmd", "sub", "--", "anything", "goes"},
+	}
+	for _, in := range cases {
+		got := RedactArgs(in)
+		for i, tok := range got {
+			// Anything that is not a flag-name surface (e.g. "--key" or
+			// "--key=<REDACTED>") and not the bare "--" terminator must
+			// equal the placeholder.
+			isFlagName := len(tok) > 1 && tok[0] == '-' &&
+				(tok == "--" || !containsRune(tok, ' '))
+			isFlagWithRedactedValue := len(tok) > 0 && tok[len(tok)-1] == '>' &&
+				containsSubstr(tok, "=<REDACTED>")
+			isBareTerm := tok == "--"
+			isFullyRedacted := tok == RedactedPlaceholder
+			if !isFlagName && !isFlagWithRedactedValue && !isBareTerm && !isFullyRedacted {
+				t.Errorf("input %q -> output token %d = %q is neither a flag name nor redacted",
+					in, i, tok)
+			}
+		}
+	}
+}
+
+func containsRune(s string, r rune) bool {
+	for _, c := range s {
+		if c == r {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSubstr(s, sub string) bool {
+	return len(sub) <= len(s) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	if len(sub) == 0 {
+		return 0
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/observability/redact_test.go
+++ b/internal/observability/redact_test.go
@@ -127,6 +127,26 @@ func TestRedactArgs(t *testing.T) {
 			},
 		},
 		{
+			name:     "double_dash_immediately_after_flag",
+			prevents: "the `--` terminator being consumed as a flag value when it follows a flag (CodeRabbit PR488). Without the fix, `--verbose -- secret` would become `--verbose <REDACTED>` and silently drop `secret`.",
+			in:       []string{"--verbose", "--", "secret"},
+			want: []string{
+				"--verbose",
+				"--",
+				"<REDACTED>",
+			},
+		},
+		{
+			name:     "double_dash_immediately_after_short_flag",
+			prevents: "same `--`-as-value bug for short flags (e.g. `-v -- secret`)",
+			in:       []string{"-v", "--", "secret"},
+			want: []string{
+				"-v",
+				"--",
+				"<REDACTED>",
+			},
+		},
+		{
 			name:     "stdin_sentinel_dash",
 			prevents: "treating bare `-` (stdin) as a flag and skipping next arg",
 			in:       []string{"import", "-", "extra"},

--- a/internal/observability/redact_test.go
+++ b/internal/observability/redact_test.go
@@ -67,10 +67,34 @@ func TestRedactArgs(t *testing.T) {
 			want:     []string{"-k=<REDACTED>"},
 		},
 		{
-			name:     "boolean_flag_followed_by_another_flag",
-			prevents: "redacting nothing after a boolean flag (false positive)",
+			name:     "chained_long_flags_both_preserved",
+			prevents: "losing visibility into chained boolean long flags like `--verbose --json`",
 			in:       []string{"--verbose", "--json"},
 			want:     []string{"--verbose", "--json"},
+		},
+		{
+			name:     "long_flag_with_negative_number_value",
+			prevents: "leaking `--limit -5` style hyphen-prefixed values (CodeRabbit PR488)",
+			in:       []string{"--limit", "-5"},
+			want:     []string{"--limit", "<REDACTED>"},
+		},
+		{
+			name:     "short_flag_followed_by_short_flag_value",
+			prevents: "leaking values starting with `-` after short flags (e.g. `-k -1`)",
+			in:       []string{"-k", "-1"},
+			want:     []string{"-k", "<REDACTED>"},
+		},
+		{
+			name:     "long_flag_followed_by_short_flag_value",
+			prevents: "leaking single-dash values after long flags (e.g. `--name -foo`)",
+			in:       []string{"--name", "-foo"},
+			want:     []string{"--name", "<REDACTED>"},
+		},
+		{
+			name:     "short_flag_then_long_flag_preserves_long",
+			prevents: "false-redacting a chained long flag after a short flag (e.g. `-v --json`)",
+			in:       []string{"-v", "--json"},
+			want:     []string{"-v", "--json"},
 		},
 		{
 			name:     "boolean_flag_at_end_of_args",


### PR DESCRIPTION
## Summary

Adds the universal CLI span attributes that the recent CodeRabbit observation called out as missing on the ox-cli dataset:

> The ox-cli dataset schema is sparse — no cli.args, cli.query, or user attributes, so we can't see what was being searched or who ran it. Only the span name (ox code search) and duration are captured.

This PR closes the gap for the attributes the team explicitly approved. `enduser.id` is intentionally excluded.

## What lands on every CLI root span now

| Attribute | Source | Type |
|---|---|---|
| `ox.version` | `version.Version` | resource + span |
| `host.os` | `runtime.GOOS` | resource + span |
| `host.arch` | `runtime.GOARCH` | resource + span |
| `cli.exit_code` | `executeWithFrictionRecovery` return value | span (set from `main()`) |
| `ox.command.args` | `os.Args[1:]` after `RedactArgs` | span |
| `ox.agent.env` | `os.Getenv("AGENT_ENV")` when non-empty | resource + span |
| `result.count` | per-command, best-effort | span |

Resource-level attrs propagate to every child span (HTTP requests to the SageOx API), so backend queries can slice by these without joining against the root span.

`ox.agent.env` is **only set when AGENT_ENV is non-empty**. Human-driven invocations leave the attribute off the span entirely, so trace backends can use `ox.agent.env exists` to cleanly isolate agent traffic from human traffic.

## Argument redaction

`ox.command.args` is the most sensitive attribute — users paste tokens, paths, customer names into command lines. The contract:

- Flag **names** are preserved (`--limit`, `--adapter`).
- Flag **values** and positional args are replaced with `<REDACTED>`.
- Both `--name=value` and `--name value` forms are handled.
- Boolean flags are not falsely consumed (heuristic: if the next token starts with `-`, the current flag has no value).
- Everything after `--` is treated as positional and redacted.
- Bare `-` (stdin sentinel) is positional.

```mermaid
flowchart LR
    A["os.Args[1:]<br/>code search 'internal codename' --limit 10"] --> B[RedactArgs]
    B --> C["[<REDACTED>, <REDACTED>, <REDACTED>, --limit, <REDACTED>]"]
    C --> D[span.SetAttributes ox.command.args]
```

The intent is to make *which flags do users pass to ox code search* queryable in Honeycomb without ever exporting the search query itself. Free-form input like the actual query belongs in command-specific attributes (e.g. a future `ox.code.search.query` with field-level redaction), not in args.

## Exit code path

`cli.exit_code` runs from `main()` after `executeWithFrictionRecovery` returns, on **both** success and error paths. Cobra's `PersistentPostRunE` only fires on success, so the existing observability shutdown was never running on errors — this PR fixes a pre-existing bug where failed CLI invocations didn't end their root span at all. `Context.Shutdown` no longer calls `observability.Shutdown`; that's now `main()`'s responsibility.

Non-zero exit codes also mark the span status as `Error`.

## Result count

`result.count` is wired into the two highest-value commands the original observation called out:

- **`ox code search`** — raw recall count from `db.Search`, before `--limit` truncation, so the metric reflects index health.
- **`ox query`** — combined team-context + code result count, since `--source` can be either or both.

Other commands can adopt `observability.SetResultCount(n)` later; the helper is a single nil-safe call.

## Daemon parity

Two daemon parity changes piggyback on this PR:

1. `internal/daemon/daemon.go` now sets `ox.version` and `host.os` as resource attrs **alongside** the existing `service.version` and `os.type` keys. Legacy keys are preserved so existing dashboards don't break — the new keys exist so dashboards can query `ox-cli` and `ox-daemon` traces uniformly.
2. `AGENT_ENV` is also set as a daemon resource attribute when present (inherited from the parent process — typically the AI coworker that spawned the daemon via `ox agent prime`), so background work is attributable to the right adapter.

Per-task daemon attribute enrichment (e.g. `result.count` on `daemon:codedb_freshness`) is intentionally **out of scope** for this PR.

## Out of scope (deferred)

- `enduser.id` — explicitly excluded
- `ox.endpoint`, `ox.repo.id`, `ox.team.id` — follow-up
- `ox.code.search.query` and other command-specific attributes that need field-level redaction — follow-up
- Daemon per-task attributes (counts, status codes, retry attempts) — follow-up

## Tests

New test files in `internal/observability/`:

**`redact_test.go`** — 13-case `TestRedactArgs` table, every case names the failure it prevents:
- nil/empty inputs (panic prevention)
- `--name value`, `--name=value`, `-n value`, `-n=value` forms
- boolean flags followed by another flag, and at end of args
- `--` terminator (everything after is positional)
- bare `-` as stdin sentinel (not a flag)
- mixed flags + positionals

Plus dedicated tests for **non-mutation** of the input slice and a **fuzz-style invariant** that every non-flag-name token must be redacted.

**`attrs_test.go`** — uses `tracetest.SpanRecorder` to wire a real OTel SDK in-memory. Asserts attributes land on actual spans, not just helper return values:
- universal attrs (`ox.version`, `host.os`, `host.arch`, `ox.command.args`) all present with right values
- `ox.command.args` value-redaction contract (planted secrets must not appear in output)
- `cli.exit_code` for zero/one/other, with span status going `Error` on non-zero
- `result.count = 0` is recorded explicitly (not omitted — zero results are meaningful telemetry)
- `ox.agent.env` set when `AGENT_ENV=claude-code`
- `ox.agent.env` **omitted** when `AGENT_ENV` is empty (the "exists" filter is the entire point)
- All four setters are no-ops when tracing is disabled (tracing-disabled paths must not panic)

## Test plan

- [x] `go test ./internal/observability/...` — all passing
- [x] `go test ./internal/cli/...` — passing
- [x] `go test ./cmd/ox/...` — passing (~117s)
- [x] `make lint` — 0 issues
- [x] Build of real binary succeeds; `ox version` and basic invocations smoke-tested
- [ ] Reviewer: confirm `ox.agent.env` key naming matches your preferred convention (alternatives: `agent.env`, `ox.agent.type`)
- [ ] Reviewer: confirm we want resource-level attrs in addition to span-level for `ox.version`/`host.os` (slight redundancy in storage, big convenience in queries)
- [ ] Optional: a follow-up PR can add command-specific attributes (`ox.code.search.query` with field-level redaction, `ox.session.entry_count`, etc.) once we agree on per-field redaction policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated OpenTelemetry tracing across CLI and daemon with improved agent subcommand span naming.
  * Telemetry now records raw search result counts, exit codes, version, host OS/arch, and optional agent environment; telemetry is flushed on exit.
  * User-supplied command arguments are redacted in telemetry.

* **Tests**
  * Added unit tests for telemetry helpers, argument redaction, and dispatcher command-path logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->