### PR TITLE
fix(claws): harden lint.py YAML parser and pin ox installer URL

### DIFF
--- a/.claude/skills/clawhub-skill-lint/scripts/lint.py
+++ b/.claude/skills/clawhub-skill-lint/scripts/lint.py
@@ -165,8 +165,12 @@ class SkillReport:
 
 
 def parse_frontmatter(text: str) -> dict | None:
-    """Extract and parse the YAML frontmatter from a SKILL.md file."""
-    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    """Extract and parse the YAML frontmatter from a SKILL.md file.
+
+    Accepts LF or CRLF line endings and tolerates a missing trailing
+    newline after the closing `---`.
+    """
+    m = re.match(r"^---\r?\n(.*?)\r?\n---(?:\r?\n|$)", text, re.DOTALL)
     if not m:
         return None
     return _parse_yaml_subset(m.group(1))
@@ -229,7 +233,7 @@ def _parse_yaml_subset(text: str) -> dict:
                 pos[0] += 1
                 continue
             key, _, val = stripped.partition(":")
-            key = key.strip()
+            key = _strip_quotes(key.strip())
             val = val.strip()
             pos[0] += 1
             if not val:
@@ -258,7 +262,7 @@ def _parse_yaml_subset(text: str) -> dict:
                 inner_indent = min_indent + 2
                 item: dict = {}
                 key, _, val = item_content.partition(":")
-                key = key.strip()
+                key = _strip_quotes(key.strip())
                 val = val.strip()
                 if not val:
                     item[key] = parse_value_after_key(inner_indent)
@@ -566,11 +570,12 @@ def check_bundle(report: SkillReport, skill_dir: Path) -> None:
         total += size
         count += 1
         ext = p.suffix.lower()
-        if ext and ext not in TEXT_FILE_EXTS and p.name not in TEXT_FILE_EXTS:
+        if ext not in TEXT_FILE_EXTS and p.name not in TEXT_FILE_EXTS:
+            label = ext if ext else "(none)"
             report.add(Finding(
                 "bundle.non_text_file", "warn",
                 str(p.relative_to(skill_dir)), 1,
-                f"File extension `{ext}` is not in the ClawHub text-file allowlist. "
+                f"File extension `{label}` is not in the ClawHub text-file allowlist. "
                 f"Server may reject the bundle.",
             ))
     report.bundle_bytes = total

--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -197,18 +197,25 @@ Download and run the ox install script. The agent should print the source
 URL and a head/tail preview of the downloaded script before executing it,
 so the user can sanity-check what is about to run:
 
+The URL is **pinned to a specific release tag** (not `main`) so the install
+path is reproducible and can't be silently changed by an upstream commit. Bump
+`OX_INSTALL_REF` when a newer release of `sageox/ox` is available.
+
 ```bash
+# Pinned release tag. Bump this when a newer sageox/ox release is published.
+OX_INSTALL_REF="v0.6.1"
+
 # Download to a temp file. -f makes curl fail on HTTP errors instead of
 # executing an HTML error page; --max-time bounds a stalled connection.
 # Use the template form for mktemp — portable across GNU (Linux) and BSD (macOS).
 INSTALL_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
 curl -fsSL --max-time 60 \
-  https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh \
+  "https://raw.githubusercontent.com/sageox/ox/${OX_INSTALL_REF}/scripts/install.sh" \
   -o "$INSTALL_SCRIPT"
 
 # Surface what is about to run.
 echo "Downloaded ox install script:"
-echo "  Source: https://github.com/sageox/ox/blob/main/scripts/install.sh"
+echo "  Source: https://github.com/sageox/ox/blob/${OX_INSTALL_REF}/scripts/install.sh"
 ls -lh "$INSTALL_SCRIPT"
 echo "--- first 5 lines ---"
 head -5 "$INSTALL_SCRIPT"

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -215,18 +215,25 @@ Download and run the ox install script. The agent should print the source
 URL and a head/tail preview of the downloaded script before executing it,
 so the user can sanity-check what is about to run:
 
+The URL is **pinned to a specific release tag** (not `main`) so the install
+path is reproducible and can't be silently changed by an upstream commit. Bump
+`OX_INSTALL_REF` when a newer release of `sageox/ox` is available.
+
 ```bash
+# Pinned release tag. Bump this when a newer sageox/ox release is published.
+OX_INSTALL_REF="v0.6.1"
+
 # Download to a temp file. -f makes curl fail on HTTP errors instead of
 # executing an HTML error page; --max-time bounds a stalled connection.
 # Use the template form for mktemp — portable across GNU (Linux) and BSD (macOS).
 INSTALL_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
 curl -fsSL --max-time 60 \
-  https://raw.githubusercontent.com/sageox/ox/main/scripts/install.sh \
+  "https://raw.githubusercontent.com/sageox/ox/${OX_INSTALL_REF}/scripts/install.sh" \
   -o "$INSTALL_SCRIPT"
 
 # Surface what is about to run.
 echo "Downloaded ox install script:"
-echo "  Source: https://github.com/sageox/ox/blob/main/scripts/install.sh"
+echo "  Source: https://github.com/sageox/ox/blob/${OX_INSTALL_REF}/scripts/install.sh"
 ls -lh "$INSTALL_SCRIPT"
 echo "--- first 5 lines ---"
 head -5 "$INSTALL_SCRIPT"
@@ -334,7 +341,7 @@ check their shell PATH.
    If it is **not** on PATH, print a copy-pasteable block tailored to the
    user's detected paths and tell them to add it to `~/.openclaw/.env`:
 
-   ```
+   ```text
    Add this to ~/.openclaw/.env:
 
    PATH=<GO_BIN_DIR>:/usr/local/bin:/usr/bin:/bin:<GO_INSTALL_DIR>
@@ -427,7 +434,7 @@ the following steps in order.
 
 For each unique `team_id`, compute the team context directory:
 
-```
+```text
 ~/.local/share/sageox/<slug>/teams/<team_id>/
 ```
 
@@ -447,7 +454,7 @@ Examples:
 
 The daily summary files live at:
 
-```
+```text
 ~/.local/share/sageox/<slug>/teams/<team_id>/memory/daily/
 ```
 
@@ -466,13 +473,13 @@ directory is missing, log it and continue with the remaining teams.
 2. Substitute template placeholders:
    - `{{DIR_LIST}}` — a list of entries, one per team, in this format:
 
-     ```
+     ```text
      - Team "<team_id>": <daily_dir>/
      ```
 
    - `{{MULTI_TEAM_RULES}}` — if there are 2+ teams, replace with:
 
-     ```
+     ```text
      - Organize the summary by team, using each team ID as a section header
      - Attribute insights to the correct team
      ```


### PR DESCRIPTION
## Summary

Addresses 5 unaddressed [CodeRabbit review comments](https://github.com/sageox/ox/pull/485) from the already-merged PR #485.

### `.claude/skills/clawhub-skill-lint/scripts/lint.py` — 3 parser hardening fixes

1. **Frontmatter detection too strict for newline variants** ([comment](https://github.com/sageox/ox/pull/485#discussion_r3062124739))
   - Old regex: `^---\n(.*?)\n---\n` rejected CRLF files and files without a trailing newline after the closing `---`.
   - New regex: `^---\r?\n(.*?)\r?\n---(?:\r?\n|$)` — accepts LF/CRLF and allows the final newline to be missing.

2. **Quoted YAML keys parsed under the wrong key** ([comment](https://github.com/sageox/ox/pull/485#discussion_r3062124744))
   - `"name": test` was kept as key `"name"` (with quotes), so all downstream field validations silently misfired.
   - Applied `_strip_quotes()` to keys in both `parse_map` (line 232) and `parse_list` (line 261).

3. **Extensionless files bypass the bundle allowlist** ([comment](https://github.com/sageox/ox/pull/485#discussion_r3062124752))
   - `if ext and ext not in TEXT_FILE_EXTS ...` short-circuited on empty extensions, so `Makefile`, `Dockerfile`, etc. were silently accepted even if not in the allowlist.
   - Dropped the `ext and` guard. Empty extensions now render as `(none)` in the finding message.

### `claws/openclaw/{sageox-distill,sageox-summary}/SKILL.md` — installer URL pinning ([comment](https://github.com/sageox/ox/pull/485#discussion_r3062124756))

The curl install flow fetched `scripts/install.sh` from `main`, making the install path non-reproducible and vulnerable to upstream drift. Both skills now:

- Declare `OX_INSTALL_REF="v0.6.1"` at the top of the install block
- Interpolate the ref into both the download URL and the displayed source URL
- Include a prose note about why it's pinned and how to bump it

The CodeRabbit comment only flagged `sageox-summary/SKILL.md`, but `sageox-distill/SKILL.md` has the identical install block — same fix applied for consistency.

### `claws/openclaw/sageox-summary/SKILL.md` — MD040 fenced-code languages ([comment](https://github.com/sageox/ox/pull/485#discussion_r3062124759))

Added explicit `text` language identifiers to 5 unlabeled fenced code blocks that were tripping markdownlint MD040:

- The PATH-configuration block under "Option 2: build from git source"
- Two team-context-directory path blocks under "Step 2: Compute Team Context Directories"
- Two `{{DIR_LIST}}` / `{{MULTI_TEAM_RULES}}` template blocks under "Step 3: Build the Prompt"

## Verification

```console
$ python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw
=== PASS sageox-distill
    claws/openclaw/sageox-distill
    2 files, 17 KB / 50 MB limit
    no findings

=== PASS sageox-summary
    claws/openclaw/sageox-summary
    3 files, 20 KB / 50 MB limit
    no findings

PASS — 2 skill(s) scanned, 0 critical, 0 warning(s)
```

Parser changes exercised against fresh fixtures:

| Input | Result |
|---|---|
| CRLF frontmatter (`---\r\n...\r\n---\r\n`) | parsed ✓ |
| LF frontmatter | parsed ✓ |
| No trailing newline after `---` | parsed ✓ |
| `"name": test` (quoted key) | stored under key `name`, not `"name"` ✓ |
| Directory containing empty `Makefile` | `bundle.non_text_file` warning with label `(none)` ✓ |

## Test plan

- [x] `python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw` → PASS, 0 critical, 0 warnings
- [x] Parser smoke tests for CRLF / LF / no-trailing-nl / quoted-keys
- [x] Extensionless-file detection smoke test (fixture with empty `Makefile`)
- [ ] Re-run markdownlint against `claws/openclaw/sageox-summary/SKILL.md` to confirm MD040 is clean (follow-up, not blocking — the linter change is mechanical)

## Out of scope

- Install URL pinning in other docs (`README.md`, etc.) — only the two skill files were flagged and they're what ships in the ClawHub bundle.
- CodeRabbit comments that were already addressed inline on PR #485 (installer-package regex, nested frontmatter guards, PUBLISHING.md SKILL.md enforcement, summary timeout bump, and the two "not changing" replies for GitHub casing and `claude-sonnet-4-6` model ID).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation instructions now reference pinned release versions instead of development branches for improved stability.
  * Added guidance on updating to new releases.
  * Enhanced code snippet formatting for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->