### PR TITLE
feat(hooks): daemon event hooks for extensible automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,15 @@ When asked if you're using SageOx: if you have an agent ID from running `ox agen
 **Rules:** Work is NOT complete until `git push` succeeds. NEVER stop before pushing. NEVER say "ready to push when you are" — YOU must push. If push fails, resolve and retry.
 
 <!-- ox:prime --> Run SageOx `ox agent prime` on session start, after compaction, or clear. (DO NOT REMOVE)
+
+<!-- ox:prime:start -->
+## SageOx Team Context
+
+This project uses [SageOx](https://sageox.ai) for team context. Run the following command at the start of every session to load team knowledge:
+
+```bash
+AGENT_ENV=pi ox agent prime
+```
+
+This provides architectural decisions, coding conventions, and session history from your team.
+<!-- ox:prime:end -->

--- a/cmd/ox/agent_hooks.go
+++ b/cmd/ox/agent_hooks.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// agentHooksCmd is the canonical path for deterministic git/CI hooks
+// that agent integrations call into ox. This replaces the legacy
+// direct 'ox hooks <git-subcommand>' path for new integrations.
+//
+// The old 'ox hooks pre-commit' etc. still work for backward compat.
+var agentHooksCmd = &cobra.Command{
+	Use:   "hooks",
+	Short: "Git and CI hooks for agent integrations",
+	Long: `Deterministic hooks called by git and CI tooling via agent integrations.
+
+This is the canonical path for git hooks. Legacy 'ox hooks <git-subcommand>'
+still works for backward compatibility.
+
+Available subcommands are registered by the same hooks that serve 'ox hooks'.
+Use 'ox hooks --help' to see all available git hook subcommands.
+
+Examples:
+  ox agent hooks pre-commit
+  ox agent hooks post-commit
+  ox agent hooks commit-msg`,
+}
+
+func init() {
+	agentCmd.AddCommand(agentHooksCmd)
+}

--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -456,6 +456,7 @@ func ResolveConfigValue(key string, projectRoot string) (*ConfigValue, error) {
 		if repoCfg != nil && repoCfg.Attribution != nil && repoCfg.Attribution.IsScoreThresholdSet() {
 			cv.RepoVal = strconv.FormatFloat(repoCfg.Attribution.GetScoreThreshold(), 'f', -1, 64)
 		}
+
 	}
 
 	// determine effective value and source (User > Repo > Team > Default)

--- a/cmd/ox/hooks_cmd.go
+++ b/cmd/ox/hooks_cmd.go
@@ -4,16 +4,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// hooksCmd is the parent command for deterministic git/tooling hooks.
+// hooksCmd is the parent command for event hooks and git/CI hooks.
 //
-// These are traditional hooks called by git or CI — predictable input/output,
-// no AI reasoning involved. Compare with "ox agent <id> hook" which handles
-// AI coworker lifecycle events (SessionStart, PreCompact, etc.) where output
-// is consumed by AI agents and may include non-deterministic guidance.
+// User-facing subcommands (list, add, test, log) manage daemon event hooks.
+// Git/CI subcommands (pre-commit, post-commit, etc.) are called by agent
+// integrations — prefer "ox agent hooks" for new integrations.
 var hooksCmd = &cobra.Command{
-	Use:    "hooks",
-	Short:  "Deterministic hooks for git and CI tooling",
-	Hidden: true, // called by git hooks, not users directly
+	Use:   "hooks",
+	Short: "Manage event hooks for daemon notifications",
+	Long: `Manage event hooks triggered by daemon events (session uploads, murmurs, sync).
+
+Event hook subcommands:
+  ox hooks list              List registered event hooks
+  ox hooks add <event> <cmd> Register a new event hook
+  ox hooks test <event>      Fire a synthetic event to test hooks
+  ox hooks log               Show how to view hook execution logs
+
+Git/CI hooks (backward compat, prefer 'ox agent hooks'):
+  ox hooks pre-commit        Run pre-commit checks
+  ox hooks post-commit       Run post-commit actions
+  ox hooks commit-msg        Validate commit messages`,
 }
 
 func init() {

--- a/cmd/ox/hooks_events_add.go
+++ b/cmd/ox/hooks_events_add.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sageox/ox/internal/daemon/hooks"
+	"github.com/spf13/cobra"
+)
+
+var hooksEventsAddCmd = &cobra.Command{
+	Use:   "add <event> <command>",
+	Short: "Register a new event hook",
+	Long: `Register a hook script to run when a daemon event fires.
+
+The command receives the event as JSON on stdin and has a 500ms timeout.
+
+Valid events:
+  ` + strings.Join(hooks.AllEventNames(), "\n  ") + `
+  * (matches all events)
+
+Examples:
+  ox hooks add murmur.received 'notify-send "Murmur" "$(cat)"'
+  ox hooks add session.uploaded 'curl -X POST https://slack.example.com/hook -d @-'
+  ox hooks add '*' 'logger -t ox'`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		event := args[0]
+		command := args[1]
+
+		if event != "*" && !hooks.ValidEvent(event) {
+			return fmt.Errorf("unknown event %q; valid events:\n  %s\n  *", event, strings.Join(hooks.AllEventNames(), "\n  "))
+		}
+
+		hook := hooks.HookConfig{Event: event, Command: command}
+		if err := hooks.SaveHook(hook); err != nil {
+			return fmt.Errorf("failed to save hook: %w", err)
+		}
+
+		fmt.Printf("Hook added: %s → %s\n", event, command)
+		fmt.Printf("Config: %s\n", hooks.HooksFilePath())
+		fmt.Println("Note: restart the daemon to pick up new hooks (ox daemon restart)")
+		return nil
+	},
+}
+
+func init() {
+	hooksCmd.AddCommand(hooksEventsAddCmd)
+}

--- a/cmd/ox/hooks_events_list.go
+++ b/cmd/ox/hooks_events_list.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sageox/ox/internal/daemon/hooks"
+	"github.com/spf13/cobra"
+)
+
+var hooksEventsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered event hooks",
+	Long:  `Lists all event hooks registered in hooks.yaml.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfgs, err := hooks.LoadHooks()
+		if err != nil {
+			return fmt.Errorf("failed to load hooks: %w", err)
+		}
+
+		jsonOut, _ := cmd.Flags().GetBool("json")
+
+		if jsonOut {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if cfgs == nil {
+				cfgs = []hooks.HookConfig{}
+			}
+			return enc.Encode(cfgs)
+		}
+
+		if len(cfgs) == 0 {
+			fmt.Println("No event hooks configured.")
+			fmt.Printf("Use 'ox hooks add <event> <command>' to register one.\n")
+			fmt.Printf("Config: %s\n", hooks.HooksFilePath())
+			return nil
+		}
+
+		fmt.Printf("%-25s %s\n", "EVENT", "COMMAND")
+		for _, c := range cfgs {
+			fmt.Printf("%-25s %s\n", c.Event, c.Command)
+		}
+		fmt.Printf("\nConfig: %s\n", hooks.HooksFilePath())
+		return nil
+	},
+}
+
+func init() {
+	hooksEventsListCmd.Flags().Bool("json", false, "Output as JSON")
+	hooksCmd.AddCommand(hooksEventsListCmd)
+}

--- a/cmd/ox/hooks_events_log.go
+++ b/cmd/ox/hooks_events_log.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var hooksEventsLogCmd = &cobra.Command{
+	Use:   "log",
+	Short: "Show how to view hook execution logs",
+	Long:  `Hook execution is logged to the daemon log. This command shows how to find those entries.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Hook execution is logged to the daemon log.")
+		fmt.Println()
+		fmt.Println("View hook entries:")
+		fmt.Println("  ox doctor --logs | grep hook")
+		fmt.Println()
+		fmt.Println("Hook log levels:")
+		fmt.Println("  DEBUG  hook completed (exit 0)")
+		fmt.Println("  WARN   hook failed (non-zero exit)")
+		fmt.Println("  WARN   hook timed out (>500ms)")
+		return nil
+	},
+}
+
+func init() {
+	hooksCmd.AddCommand(hooksEventsLogCmd)
+}

--- a/cmd/ox/hooks_events_test_cmd.go
+++ b/cmd/ox/hooks_events_test_cmd.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/sageox/ox/internal/daemon/hooks"
+	"github.com/spf13/cobra"
+)
+
+var hooksEventsTestCmd = &cobra.Command{
+	Use:   "test <event>",
+	Short: "Fire a synthetic event to test hooks",
+	Long: `Fires a synthetic event through the hook runner to verify hooks work.
+
+The event is dispatched to all matching hooks with a test payload.
+Hooks have a 500ms timeout. Results are printed after ~700ms.
+
+Example:
+  ox hooks test murmur.received
+  ox hooks test daemon.started`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		eventName := args[0]
+		if eventName != "*" && !hooks.ValidEvent(eventName) {
+			return fmt.Errorf("unknown event %q", eventName)
+		}
+
+		cfgs, err := hooks.LoadHooks()
+		if err != nil {
+			return fmt.Errorf("failed to load hooks: %w", err)
+		}
+
+		if len(cfgs) == 0 {
+			fmt.Println("No hooks configured. Use 'ox hooks add' first.")
+			return nil
+		}
+
+		// count matching hooks
+		var matching int
+		for _, c := range cfgs {
+			if c.Event == "*" || c.Event == eventName {
+				matching++
+			}
+		}
+
+		if matching == 0 {
+			fmt.Printf("No hooks match event %q.\n", eventName)
+			return nil
+		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		runner := hooks.NewHookRunner(cfgs, logger)
+
+		event := hooks.Event{
+			Name:    eventName,
+			Project: "/tmp/ox-hooks-test",
+			RepoID:  "repo_test",
+			Payload: map[string]any{"test": true},
+		}
+
+		fmt.Printf("Firing %q to %d hook(s)...\n", eventName, matching)
+		runner.Dispatch(context.Background(), event)
+
+		// wait for hooks to complete (500ms timeout + margin)
+		time.Sleep(700 * time.Millisecond)
+		fmt.Printf("Done. Check stderr for hook execution logs.\n")
+		return nil
+	},
+}
+
+func init() {
+	hooksCmd.AddCommand(hooksEventsTestCmd)
+}

--- a/internal/auth/auth_client.go
+++ b/internal/auth/auth_client.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
@@ -12,13 +14,21 @@ import (
 type AuthClient struct {
 	configDir string // base config directory (e.g., ~/.config or test temp dir)
 	endpoint  string // API endpoint URL
+
+	// knownEndpoints tracks endpoints seen in previous loads within this
+	// client's lifetime. Used to detect when another process overwrites
+	// auth.json and removes credentials. Instance-scoped so parallel tests
+	// with isolated AuthClients don't cross-contaminate.
+	knownEndpointsMu sync.Mutex
+	knownEndpoints   map[string]struct{}
 }
 
 // NewAuthClient creates an AuthClient using the default config directory and endpoint.
 func NewAuthClient() *AuthClient {
 	return &AuthClient{
-		configDir: "", // empty means use default from config.GetUserConfigDir()
-		endpoint:  endpoint.Get(),
+		configDir:      "", // empty means use default from config.GetUserConfigDir()
+		endpoint:       endpoint.Get(),
+		knownEndpoints: make(map[string]struct{}),
 	}
 }
 
@@ -26,8 +36,9 @@ func NewAuthClient() *AuthClient {
 // Primarily used for testing to isolate each test's auth storage.
 func NewAuthClientWithDir(configDir string) *AuthClient {
 	return &AuthClient{
-		configDir: configDir,
-		endpoint:  endpoint.Get(),
+		configDir:      configDir,
+		endpoint:       endpoint.Get(),
+		knownEndpoints: make(map[string]struct{}),
 	}
 }
 
@@ -35,8 +46,9 @@ func NewAuthClientWithDir(configDir string) *AuthClient {
 // Trailing slashes are stripped to prevent double slashes in URL paths.
 func (c *AuthClient) WithEndpoint(ep string) *AuthClient {
 	return &AuthClient{
-		configDir: c.configDir,
-		endpoint:  strings.TrimSuffix(ep, "/"),
+		configDir:      c.configDir,
+		endpoint:       strings.TrimSuffix(ep, "/"),
+		knownEndpoints: make(map[string]struct{}),
 	}
 }
 
@@ -51,6 +63,31 @@ func (c *AuthClient) getConfigDir() string {
 // Endpoint returns the configured API endpoint.
 func (c *AuthClient) Endpoint() string {
 	return c.endpoint
+}
+
+// checkKnownEndpoints compares the loaded store against endpoints this client
+// has previously seen. Logs an ERROR if any previously-known endpoint has
+// disappeared — this indicates another process may have overwritten auth.json.
+func (c *AuthClient) checkKnownEndpoints(store *AuthStore) {
+	c.knownEndpointsMu.Lock()
+	defer c.knownEndpointsMu.Unlock()
+
+	if c.knownEndpoints == nil {
+		c.knownEndpoints = make(map[string]struct{})
+	}
+
+	for ep := range c.knownEndpoints {
+		if _, ok := store.Tokens[ep]; !ok {
+			slog.Error("auth: credential disappeared between loads",
+				"endpoint", ep,
+				"remaining_endpoints", len(store.Tokens),
+				"action", "investigate — another process may have overwritten auth.json")
+		}
+	}
+
+	for ep := range store.Tokens {
+		c.knownEndpoints[ep] = struct{}{}
+	}
 }
 
 // defaultClient is the package-level client for backward compatibility.

--- a/internal/auth/authfile.go
+++ b/internal/auth/authfile.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -25,6 +24,9 @@ type authFileHandle struct {
 	// legacyMigrationEndpoint overrides the endpoint used when migrating
 	// legacy single-token auth files. If empty, uses endpoint.Get().
 	legacyMigrationEndpoint string
+	// endpointTracker is the owning AuthClient, used for per-instance
+	// disappearance detection. Nil for package-level functions (no tracking).
+	endpointTracker *AuthClient
 }
 
 const (
@@ -41,6 +43,13 @@ type authFileOption func(*authFileHandle)
 func withLegacyMigrationEndpoint(ep string) authFileOption {
 	return func(h *authFileHandle) {
 		h.legacyMigrationEndpoint = ep
+	}
+}
+
+// withEndpointTracker sets the AuthClient used for disappearance detection.
+func withEndpointTracker(c *AuthClient) authFileOption {
+	return func(h *authFileHandle) {
+		h.endpointTracker = c
 	}
 }
 
@@ -110,7 +119,9 @@ func (h *authFileHandle) load() (*AuthStore, error) {
 		return nil, err
 	}
 
-	checkKnownEndpoints(store)
+	if h.endpointTracker != nil {
+		h.endpointTracker.checkKnownEndpoints(store)
+	}
 	return store, nil
 }
 
@@ -227,41 +238,6 @@ func (h *authFileHandle) readRaw() (*AuthStore, error) {
 	return &store, nil
 }
 
-// --- In-process credential disappearance detection ---
-
-var (
-	knownEndpointsMu sync.Mutex
-	knownEndpoints   = make(map[string]struct{})
-)
-
-// checkKnownEndpoints compares the loaded store against endpoints this process
-// has previously seen. Logs an ERROR if any previously-known endpoint has
-// disappeared — this indicates another process may have overwritten auth.json.
-func checkKnownEndpoints(store *AuthStore) {
-	knownEndpointsMu.Lock()
-	defer knownEndpointsMu.Unlock()
-
-	for ep := range knownEndpoints {
-		if _, ok := store.Tokens[ep]; !ok {
-			slog.Error("auth: credential disappeared between loads",
-				"endpoint", ep,
-				"remaining_endpoints", len(store.Tokens),
-				"action", "investigate — another process may have overwritten auth.json")
-		}
-	}
-
-	for ep := range store.Tokens {
-		knownEndpoints[ep] = struct{}{}
-	}
-}
-
-// resetKnownEndpoints clears the in-process endpoint tracking.
-// Called between tests to prevent cross-test leakage.
-func resetKnownEndpoints() {
-	knownEndpointsMu.Lock()
-	defer knownEndpointsMu.Unlock()
-	knownEndpoints = make(map[string]struct{})
-}
 
 // callerInfo returns the file:line of the caller at the given skip depth.
 func callerInfo(skip int) string {

--- a/internal/auth/authfile_test.go
+++ b/internal/auth/authfile_test.go
@@ -469,32 +469,33 @@ func TestSaveDetection_NormalizedEndpointMatch(t *testing.T) {
 
 // --- C. Credential disappearance detection (load-side, in-process) ---
 // These tests verify that checkKnownEndpoints detects when endpoints
-// vanish between loads within the same process.
+// vanish between loads within the same AuthClient instance.
 
 // TestLoadDetection_ErrorOnDisappearance verifies an ERROR is logged
 // when a previously-seen endpoint vanishes on reload.
 // Failure prevented: another process silently overwrites auth.json unnoticed.
 func TestLoadDetection_ErrorOnDisappearance(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
 
-	dir := t.TempDir()
-	authPath := filepath.Join(dir, "auth.json")
+	client := NewTestClient(t)
+	authPath, err := client.GetAuthFilePath()
+	require.NoError(t, err)
 
 	// first load — two endpoints
 	store1 := &AuthStore{Tokens: map[string]*StoredToken{
 		"https://disappear-a.example.com": {AccessToken: "a"},
 		"https://disappear-b.example.com": {AccessToken: "b"},
 	}}
-	err := withAuthFileLocked(authPath, func(h *authFileHandle) error {
+	err = withAuthFileLocked(authPath, func(h *authFileHandle) error {
 		return h.writeFile(store1)
 	})
 	require.NoError(t, err)
 
+	trackerOpt := withEndpointTracker(client)
 	err = withAuthFileRLocked(authPath, func(h *authFileHandle) error {
 		_, err := h.load()
 		return err
-	})
+	}, trackerOpt)
 	require.NoError(t, err)
 
 	// externally truncate to one endpoint
@@ -510,8 +511,16 @@ func TestLoadDetection_ErrorOnDisappearance(t *testing.T) {
 	err = withAuthFileRLocked(authPath, func(h *authFileHandle) error {
 		_, err := h.load()
 		return err
-	})
+	}, trackerOpt)
 	require.NoError(t, err, "load must succeed even when disappearance is detected")
+
+	// verify the client tracked the endpoints
+	client.knownEndpointsMu.Lock()
+	_, hasA := client.knownEndpoints["https://disappear-a.example.com"]
+	_, hasB := client.knownEndpoints["https://disappear-b.example.com"]
+	client.knownEndpointsMu.Unlock()
+	assert.True(t, hasA, "endpoint A should be tracked")
+	assert.True(t, hasB, "endpoint B should be tracked from first load")
 }
 
 // TestLoadDetection_NoErrorOnFirstLoad verifies no ERROR on the first
@@ -519,23 +528,24 @@ func TestLoadDetection_ErrorOnDisappearance(t *testing.T) {
 // Failure prevented: spurious errors on startup.
 func TestLoadDetection_NoErrorOnFirstLoad(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
 
-	dir := t.TempDir()
-	authPath := filepath.Join(dir, "auth.json")
+	client := NewTestClient(t)
+	authPath, err := client.GetAuthFilePath()
+	require.NoError(t, err)
 
 	store := &AuthStore{Tokens: map[string]*StoredToken{
 		"https://first-load.example.com": {AccessToken: "token"},
 	}}
-	err := withAuthFileLocked(authPath, func(h *authFileHandle) error {
+	err = withAuthFileLocked(authPath, func(h *authFileHandle) error {
 		return h.writeFile(store)
 	})
 	require.NoError(t, err)
 
+	trackerOpt := withEndpointTracker(client)
 	err = withAuthFileRLocked(authPath, func(h *authFileHandle) error {
 		_, err := h.load()
 		return err
-	})
+	}, trackerOpt)
 	require.NoError(t, err, "first load must not error")
 }
 
@@ -544,23 +554,25 @@ func TestLoadDetection_NoErrorOnFirstLoad(t *testing.T) {
 // Failure prevented: false errors when user logs in to new endpoints.
 func TestLoadDetection_NoErrorOnNewEndpoint(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
 
-	dir := t.TempDir()
-	authPath := filepath.Join(dir, "auth.json")
+	client := NewTestClient(t)
+	authPath, err := client.GetAuthFilePath()
+	require.NoError(t, err)
 
 	// first load
 	store1 := &AuthStore{Tokens: map[string]*StoredToken{
 		"https://grow-a.example.com": {AccessToken: "a"},
 	}}
-	err := withAuthFileLocked(authPath, func(h *authFileHandle) error {
+	err = withAuthFileLocked(authPath, func(h *authFileHandle) error {
 		return h.writeFile(store1)
 	})
 	require.NoError(t, err)
+
+	trackerOpt := withEndpointTracker(client)
 	_ = withAuthFileRLocked(authPath, func(h *authFileHandle) error {
 		_, err := h.load()
 		return err
-	})
+	}, trackerOpt)
 
 	// second load with new endpoint added
 	store2 := &AuthStore{Tokens: map[string]*StoredToken{
@@ -575,29 +587,29 @@ func TestLoadDetection_NoErrorOnNewEndpoint(t *testing.T) {
 	err = withAuthFileRLocked(authPath, func(h *authFileHandle) error {
 		_, err := h.load()
 		return err
-	})
+	}, trackerOpt)
 	require.NoError(t, err, "new endpoint appearing must not cause error")
 }
 
-// TestLoadDetection_IsolatedBetweenTests verifies resetKnownEndpoints
-// prevents cross-test leakage of the in-process tracking set.
-// Failure prevented: test ordering affects detection results.
-func TestLoadDetection_IsolatedBetweenTests(t *testing.T) {
+// TestLoadDetection_IsolatedBetweenClients verifies that separate
+// AuthClient instances have independent endpoint tracking.
+// Failure prevented: cross-client leakage causes spurious disappearance errors.
+func TestLoadDetection_IsolatedBetweenClients(t *testing.T) {
 	t.Parallel()
 
-	// add some endpoints
-	knownEndpointsMu.Lock()
-	knownEndpoints["https://stale.example.com"] = struct{}{}
-	knownEndpointsMu.Unlock()
+	clientA := NewTestClient(t)
+	clientB := NewTestClient(t)
 
-	// reset
-	resetKnownEndpoints()
+	// seed client A with an endpoint
+	clientA.knownEndpointsMu.Lock()
+	clientA.knownEndpoints["https://only-in-a.example.com"] = struct{}{}
+	clientA.knownEndpointsMu.Unlock()
 
-	knownEndpointsMu.Lock()
-	count := len(knownEndpoints)
-	knownEndpointsMu.Unlock()
-
-	assert.Equal(t, 0, count, "resetKnownEndpoints must clear all entries")
+	// client B should have no tracked endpoints
+	clientB.knownEndpointsMu.Lock()
+	count := len(clientB.knownEndpoints)
+	clientB.knownEndpointsMu.Unlock()
+	assert.Equal(t, 0, count, "separate clients must have independent tracking")
 }
 
 // --- D. Structural enforcement ---
@@ -742,7 +754,7 @@ func TestAtomicity_OriginalSurvivesWriteError(t *testing.T) {
 // Failure prevented: users upgrading from old ox lose their token.
 func TestLegacyMigration_SingleTokenFormat(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")
@@ -781,7 +793,7 @@ func TestLegacyMigration_SingleTokenFormat(t *testing.T) {
 // Failure prevented: credential wipe when tokens field is null.
 func TestLegacyMigration_NullTokensField(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")
@@ -805,7 +817,7 @@ func TestLegacyMigration_NullTokensField(t *testing.T) {
 // Failure prevented: empty tokens object causes nil pointer.
 func TestLegacyMigration_EmptyTokensObject(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")
@@ -828,7 +840,7 @@ func TestLegacyMigration_EmptyTokensObject(t *testing.T) {
 // Failure prevented: legacy token stored under wrong endpoint for AuthClient users.
 func TestLegacyMigration_CustomEndpoint(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")
@@ -860,7 +872,7 @@ func TestLegacyMigration_CustomEndpoint(t *testing.T) {
 // Failure prevented: concurrent migration corrupts the file.
 func TestLegacyMigration_ConcurrentMigration(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")
@@ -1080,7 +1092,7 @@ func TestE2E_RapidFireSaveLoad(t *testing.T) {
 // Failure prevented: empty store causes nil pointer on subsequent operations.
 func TestEdge_EmptyStore(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")
@@ -1107,7 +1119,7 @@ func TestEdge_EmptyStore(t *testing.T) {
 // Failure prevented: nil token value causes panic in save/load path.
 func TestEdge_NilTokenValue(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")
@@ -1162,7 +1174,7 @@ func TestEdge_VeryLongEndpointURL(t *testing.T) {
 // Failure prevented: first-time user gets an error instead of clean empty state.
 func TestEdge_NoFile(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "nonexistent", "auth.json")
@@ -1184,7 +1196,7 @@ func TestEdge_NoFile(t *testing.T) {
 // Failure prevented: corrupt file silently returns empty store.
 func TestEdge_CorruptJSON(t *testing.T) {
 	t.Parallel()
-	resetKnownEndpoints()
+
 
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -346,6 +346,7 @@ func (c *AuthClient) GetTokenForEndpoint(ep string) (*StoredToken, error) {
 
 	var token *StoredToken
 	legacyOpt := withLegacyMigrationEndpoint(c.endpoint)
+	trackerOpt := withEndpointTracker(c)
 	err = withAuthFileRLocked(authPath, func(h *authFileHandle) error {
 		store, loadErr := h.load()
 		if loadErr != nil {
@@ -356,7 +357,7 @@ func (c *AuthClient) GetTokenForEndpoint(ep string) (*StoredToken, error) {
 			token = t
 		}
 		return nil
-	}, legacyOpt)
+	}, legacyOpt, trackerOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -383,6 +384,7 @@ func (c *AuthClient) SaveTokenForEndpoint(ep string, token *StoredToken) error {
 	}
 
 	legacyOpt := withLegacyMigrationEndpoint(c.endpoint)
+	trackerOpt := withEndpointTracker(c)
 	return withAuthFileLocked(authPath, func(h *authFileHandle) error {
 		store, loadErr := h.load()
 		if loadErr != nil {
@@ -393,7 +395,7 @@ func (c *AuthClient) SaveTokenForEndpoint(ep string, token *StoredToken) error {
 		}
 		store.Tokens[ep] = token
 		return h.save(store)
-	}, legacyOpt)
+	}, legacyOpt, trackerOpt)
 }
 
 // RemoveToken deletes the authentication token for this client's endpoint
@@ -415,6 +417,7 @@ func (c *AuthClient) RemoveTokenForEndpoint(ep string) error {
 	}
 
 	legacyOpt := withLegacyMigrationEndpoint(c.endpoint)
+	trackerOpt := withEndpointTracker(c)
 	return withAuthFileLocked(authPath, func(h *authFileHandle) error {
 		store, loadErr := h.load()
 		if loadErr != nil {
@@ -425,7 +428,7 @@ func (c *AuthClient) RemoveTokenForEndpoint(ep string) error {
 		}
 		delete(store.Tokens, ep)
 		return h.save(store)
-	}, legacyOpt)
+	}, legacyOpt, trackerOpt)
 }
 
 // IsAuthenticated checks if a valid non-expired token exists for this client's endpoint

--- a/internal/auth/testutil_test.go
+++ b/internal/auth/testutil_test.go
@@ -15,7 +15,6 @@ import (
 // This allows permission tests to verify directory creation with 0700.
 func NewTestClient(t *testing.T) *AuthClient {
 	t.Helper()
-	resetKnownEndpoints()
 	return NewAuthClientWithDir(filepath.Join(t.TempDir(), "sageox"))
 }
 

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -329,6 +329,7 @@ type UserConfig struct {
 	Murmuring         string             `yaml:"murmur_send,omitempty"`     // "auto", "manual"
 	LegacyMurmuring   string             `yaml:"murmuring,omitempty"`       // deprecated: read old key on upgrade
 	MurmurReceive     string             `yaml:"murmur_receive,omitempty"`  // "on", "off"
+
 }
 
 // BadgeConfig tracks badge suggestion state across all projects.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -20,10 +20,11 @@ import (
 
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
-	"github.com/sageox/ox/internal/endpoint"
-	"github.com/sageox/ox/internal/observability"
 	"github.com/sageox/ox/internal/daemon/agentwork"
+	"github.com/sageox/ox/internal/daemon/hooks"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/flags"
+	"github.com/sageox/ox/internal/observability"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
@@ -176,6 +177,7 @@ type Daemon struct {
 	projectWatcher         *ProjectWatcher
 	dbMaintenance          *DBMaintenanceScheduler
 	settingsFetcher        *SettingsFetcher
+	eventBus               *hooks.EventBus
 	tracer                 *observability.DaemonTracer
 
 	// state
@@ -639,6 +641,15 @@ func (d *Daemon) Stop() error {
 func (d *Daemon) shutdown() error {
 	d.logger.Info("shutting down")
 
+	// emit daemon.stopped event before tearing down
+	if d.eventBus != nil {
+		d.eventBus.Emit(context.Background(), hooks.Event{
+			Name:    hooks.EventDaemonStopped,
+			Project: d.config.ProjectRoot,
+			RepoID:  config.GetRepoID(d.config.ProjectRoot),
+		})
+	}
+
 	// record shutdown telemetry and flush before stopping
 	if d.telemetry != nil {
 		uptime := time.Since(d.startTime)
@@ -997,9 +1008,21 @@ func (d *Daemon) initComponents() time.Duration {
 		d.heartbeat.SetInitialCredentials(hbCreds)
 	}
 
+	// event bus for hooks (must init before wiring to scheduler/relay)
+	d.eventBus = hooks.New(d.logger)
+	hookCfgs, err := hooks.LoadHooks()
+	if err != nil {
+		d.logger.Warn("failed to load hooks config", "error", err)
+	}
+	if len(hookCfgs) > 0 {
+		runner := hooks.NewHookRunner(hookCfgs, d.logger)
+		d.eventBus.SetHookDispatch(runner.Dispatch)
+	}
+
 	// sync scheduler
 	d.scheduler = NewSyncScheduler(d.config, d.logger)
 	d.scheduler.SetTracer(d.tracer)
+	d.scheduler.SetEventBus(d.eventBus)
 
 	// code index manager
 	if d.config.ProjectRoot != "" {
@@ -1072,6 +1095,7 @@ func (d *Daemon) initComponents() time.Duration {
 		// on every tick so config changes take effect without daemon restart
 		murmurRelay := NewMurmurRelay(d.whisperRegistry, d.config.ProjectRoot, d.logger)
 		d.scheduler.SetMurmurRelay(murmurRelay)
+		murmurRelay.SetEventBus(d.eventBus)
 	}
 	if d.codedb != nil {
 		d.codedb.SetIssueTracker(d.issues)
@@ -1107,6 +1131,15 @@ func (d *Daemon) startWorkers() {
 	d.telemetry.Start()
 	d.friction.Start()
 	d.telemetry.RecordDaemonStartup()
+
+	// emit daemon.started event
+	if d.eventBus != nil {
+		d.eventBus.Emit(d.ctx, hooks.Event{
+			Name:    hooks.EventDaemonStarted,
+			Project: d.config.ProjectRoot,
+			RepoID:  config.GetRepoID(d.config.ProjectRoot),
+		})
+	}
 
 	// initialize whisper sources before IPC server starts, so pause/resume
 	// handlers can safely read d.murmurNudgeSource without a data race
@@ -1592,3 +1625,15 @@ func (s *daemonServiceImpl) ResumeMurmuring(agentID string) {
 		s.d.logger.Debug("murmur nudging resumed", "agent_id", agentID)
 	}
 }
+
+func (s *daemonServiceImpl) SessionUploaded(name, url, agentID string, dur time.Duration) {
+	if s.d.eventBus != nil {
+		s.d.eventBus.Emit(context.Background(), hooks.Event{
+			Name:    hooks.EventSessionUploaded,
+			Project: s.d.config.ProjectRoot,
+			RepoID:  config.GetRepoID(s.d.config.ProjectRoot),
+			Payload: hooks.SessionUploadedPayload(name, url, agentID, dur),
+		})
+	}
+}
+

--- a/internal/daemon/hooks/bus.go
+++ b/internal/daemon/hooks/bus.go
@@ -1,0 +1,46 @@
+package hooks
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// EventBus dispatches daemon events to hook scripts.
+// All dispatch is asynchronous — Emit() never blocks the caller.
+type EventBus struct {
+	hookMu       sync.RWMutex
+	hookDispatch func(ctx context.Context, event Event) // set via SetHookDispatch
+	logger       *slog.Logger
+}
+
+// New creates an EventBus.
+func New(logger *slog.Logger) *EventBus {
+	return &EventBus{
+		logger: logger,
+	}
+}
+
+// SetHookDispatch sets the function called to dispatch events to hook scripts.
+func (b *EventBus) SetHookDispatch(fn func(ctx context.Context, event Event)) {
+	b.hookMu.Lock()
+	defer b.hookMu.Unlock()
+	b.hookDispatch = fn
+}
+
+// Emit dispatches an event asynchronously. It never blocks the caller.
+func (b *EventBus) Emit(ctx context.Context, event Event) {
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+
+	b.logger.Debug("event emitted", "event", event.Name)
+
+	b.hookMu.RLock()
+	dispatch := b.hookDispatch
+	b.hookMu.RUnlock()
+	if dispatch != nil {
+		dispatch(ctx, event)
+	}
+}

--- a/internal/daemon/hooks/bus_test.go
+++ b/internal/daemon/hooks/bus_test.go
@@ -1,0 +1,198 @@
+package hooks_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/daemon/hooks"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, nil))
+}
+
+func TestEmitCallsHookDispatch(t *testing.T) {
+	t.Parallel()
+
+	bus := hooks.New(testLogger())
+
+	var dispatched hooks.Event
+	bus.SetHookDispatch(func(_ context.Context, event hooks.Event) {
+		dispatched = event
+	})
+
+	event := hooks.Event{
+		Name:    hooks.EventDaemonStarted,
+		Project: "/tmp/test-project",
+	}
+
+	bus.Emit(context.Background(), event)
+
+	if dispatched.Name != hooks.EventDaemonStarted {
+		t.Fatalf("hookDispatch not called; got event name %q", dispatched.Name)
+	}
+}
+
+func TestEmitSetsTimestamp(t *testing.T) {
+	t.Parallel()
+
+	bus := hooks.New(testLogger())
+
+	var captured hooks.Event
+	bus.SetHookDispatch(func(_ context.Context, event hooks.Event) {
+		captured = event
+	})
+
+	before := time.Now()
+	bus.Emit(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	after := time.Now()
+
+	if captured.Timestamp.IsZero() {
+		t.Fatal("timestamp should be set when emitting with zero timestamp")
+	}
+	if captured.Timestamp.Before(before) || captured.Timestamp.After(after) {
+		t.Fatalf("timestamp %v not between %v and %v", captured.Timestamp, before, after)
+	}
+}
+
+func TestEmitPreservesExistingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	bus := hooks.New(testLogger())
+
+	var captured hooks.Event
+	bus.SetHookDispatch(func(_ context.Context, event hooks.Event) {
+		captured = event
+	})
+
+	fixed := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	bus.Emit(context.Background(), hooks.Event{
+		Name:      hooks.EventDaemonStarted,
+		Timestamp: fixed,
+	})
+
+	if !captured.Timestamp.Equal(fixed) {
+		t.Fatalf("timestamp changed from %v to %v", fixed, captured.Timestamp)
+	}
+}
+
+// TestEmitHookDispatchPanic verifies a panicking hookDispatch function
+// doesn't crash the test process. hookDispatch runs synchronously in Emit(),
+// so the panic propagates to the caller.
+// Failure prevented: hook dispatch panic takes down the event bus.
+func TestEmitHookDispatchPanic(t *testing.T) {
+	t.Parallel()
+
+	bus := hooks.New(testLogger())
+	bus.SetHookDispatch(func(_ context.Context, _ hooks.Event) {
+		panic("hookDispatch exploded")
+	})
+
+	recovered := make(chan bool, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				recovered <- true
+			} else {
+				recovered <- false
+			}
+		}()
+		bus.Emit(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	}()
+
+	select {
+	case didPanic := <-recovered:
+		if !didPanic {
+			t.Log("hookDispatch panic was not observed (may be caught internally)")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Emit with panicking hookDispatch hung")
+	}
+}
+
+// TestEmitNilHookDispatch verifies Emit works when hookDispatch is nil
+// (the default state before SetHookDispatch is called).
+// Failure prevented: nil function call panic on fresh EventBus.
+func TestEmitNilHookDispatch(t *testing.T) {
+	t.Parallel()
+
+	bus := hooks.New(testLogger())
+	// should not panic
+	bus.Emit(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+}
+
+// TestEmitAfterSetHookDispatchNil verifies Emit works after hookDispatch
+// is explicitly set to nil.
+// Failure prevented: nil function call panic after explicit nil assignment.
+func TestEmitAfterSetHookDispatchNil(t *testing.T) {
+	t.Parallel()
+
+	bus := hooks.New(testLogger())
+	bus.SetHookDispatch(func(_ context.Context, _ hooks.Event) {})
+	bus.SetHookDispatch(nil)
+
+	// should not panic
+	bus.Emit(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+}
+
+// TestEmitConcurrent verifies many goroutines can Emit simultaneously without
+// races or deadlocks. Run with -race.
+// Failure prevented: data race on EventBus fields during concurrent emit.
+func TestEmitConcurrent(t *testing.T) {
+	t.Parallel()
+
+	bus := hooks.New(testLogger())
+
+	var dispatched sync.WaitGroup
+	bus.SetHookDispatch(func(_ context.Context, _ hooks.Event) {
+		dispatched.Done()
+	})
+
+	events := []hooks.Event{
+		{Name: hooks.EventSessionUploaded, Payload: hooks.SessionUploadedPayload("s", "url", "a", time.Second)},
+		{Name: hooks.EventMurmurReceived, Payload: hooks.MurmurPayload("m", "a", "p", "t", "n", "content")},
+		{Name: hooks.EventDaemonStarted},
+		{Name: hooks.EventSyncCompleted, Payload: hooks.SyncPayload("ws", "pull", time.Second)},
+	}
+
+	const goroutines = 20
+	dispatched.Add(goroutines)
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			bus.Emit(context.Background(), events[n%len(events)])
+		}(i)
+	}
+
+	wg.Wait()
+	dispatched.Wait()
+}
+
+// TestEmitNilPayload verifies an event with nil payload dispatches cleanly.
+// Failure prevented: nil map iteration panic during marshal.
+func TestEmitNilPayload(t *testing.T) {
+	t.Parallel()
+
+	bus := hooks.New(testLogger())
+
+	var captured hooks.Event
+	bus.SetHookDispatch(func(_ context.Context, event hooks.Event) {
+		captured = event
+	})
+
+	bus.Emit(context.Background(), hooks.Event{
+		Name:    hooks.EventSessionUploaded,
+		Payload: nil,
+	})
+
+	if captured.Name != hooks.EventSessionUploaded {
+		t.Fatalf("event not dispatched; got %q", captured.Name)
+	}
+}

--- a/internal/daemon/hooks/config.go
+++ b/internal/daemon/hooks/config.go
@@ -1,0 +1,116 @@
+package hooks
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/sageox/ox/internal/paths"
+	"gopkg.in/yaml.v3"
+)
+
+// HookConfig defines a user-registered hook script triggered by daemon events.
+type HookConfig struct {
+	Event   string `yaml:"event" json:"event"`
+	Command string `yaml:"command" json:"command"`
+}
+
+type hooksFile struct {
+	Hooks []HookConfig `yaml:"hooks"`
+}
+
+// HooksFilePath returns the path to the hooks.yaml config file.
+func HooksFilePath() string {
+	return filepath.Join(paths.ConfigDir(), "hooks.yaml")
+}
+
+// LoadHooks reads and validates hook configurations from hooks.yaml.
+// Returns an empty slice (not error) if the file doesn't exist.
+func LoadHooks() ([]HookConfig, error) {
+	return LoadHooksFrom(HooksFilePath())
+}
+
+// LoadHooksFrom reads hooks from a specific file path. Exported for testing.
+func LoadHooksFrom(path string) ([]HookConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var f hooksFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, err
+	}
+
+	return validateAndDedup(f.Hooks), nil
+}
+
+func validateAndDedup(hooks []HookConfig) []HookConfig {
+	seen := make(map[string]bool)
+	var result []HookConfig
+
+	for _, h := range hooks {
+		if h.Command == "" {
+			slog.Warn("hook skipped: empty command", "event", h.Event)
+			continue
+		}
+		if h.Event != "*" && !ValidEvent(h.Event) {
+			slog.Warn("hook skipped: unknown event", "event", h.Event, "command", h.Command)
+			continue
+		}
+
+		key := h.Event + "\x00" + h.Command
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, h)
+	}
+
+	return result
+}
+
+// SaveHook appends a hook to the hooks.yaml file.
+// Creates the file if it doesn't exist. Uses atomic write-via-rename
+// to prevent corruption from crashes or concurrent writers.
+func SaveHook(hook HookConfig) error {
+	existing, err := LoadHooks()
+	if err != nil {
+		return err
+	}
+
+	existing = append(existing, hook)
+	f := hooksFile{Hooks: existing}
+	data, err := yaml.Marshal(&f)
+	if err != nil {
+		return err
+	}
+
+	path := HooksFilePath()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(dir, ".hooks-*.yaml.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
+	return os.Rename(tmpPath, path)
+}

--- a/internal/daemon/hooks/config_test.go
+++ b/internal/daemon/hooks/config_test.go
@@ -1,0 +1,366 @@
+package hooks_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/daemon/hooks"
+)
+
+func TestLoadHooksFromEmpty(t *testing.T) {
+	t.Parallel()
+
+	cfgs, err := hooks.LoadHooksFrom("/nonexistent/path/hooks.yaml")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got: %v", err)
+	}
+	if cfgs != nil {
+		t.Fatalf("expected nil hooks for missing file, got: %v", cfgs)
+	}
+}
+
+func TestLoadHooksFromValid(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	content := `hooks:
+  - event: murmur.received
+    command: echo hello
+  - event: session.uploaded
+    command: notify-send "uploaded"
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("LoadHooksFrom error: %v", err)
+	}
+	if len(cfgs) != 2 {
+		t.Fatalf("expected 2 hooks, got %d", len(cfgs))
+	}
+	if cfgs[0].Event != "murmur.received" || cfgs[0].Command != "echo hello" {
+		t.Errorf("hook[0] = %+v", cfgs[0])
+	}
+}
+
+func TestLoadHooksDedup(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	content := `hooks:
+  - event: daemon.started
+    command: echo test
+  - event: daemon.started
+    command: echo test
+  - event: daemon.started
+    command: echo different
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(cfgs) != 2 {
+		t.Fatalf("expected 2 hooks after dedup, got %d", len(cfgs))
+	}
+}
+
+func TestLoadHooksSkipInvalidEvent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	content := `hooks:
+  - event: invalid.event.name
+    command: echo test
+  - event: daemon.started
+    command: echo valid
+  - event: "*"
+    command: echo wildcard
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	// invalid event skipped, valid + wildcard kept
+	if len(cfgs) != 2 {
+		t.Fatalf("expected 2 hooks (invalid skipped), got %d: %+v", len(cfgs), cfgs)
+	}
+}
+
+func TestLoadHooksSkipEmptyCommand(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	content := `hooks:
+  - event: daemon.started
+    command: ""
+  - event: daemon.started
+    command: echo valid
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 hook (empty command skipped), got %d", len(cfgs))
+	}
+}
+
+// --- Malformed YAML ---
+
+// TestLoadHooksMalformedYAML verifies invalid YAML content returns an error.
+// Failure prevented: unparseable config silently produces empty hook list.
+func TestLoadHooksMalformedYAML(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	content := `hooks:
+  - event: [invalid yaml
+    command: broken
+  unterminated: {
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := hooks.LoadHooksFrom(path)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+}
+
+// --- Empty YAML file ---
+
+// TestLoadHooksEmptyFile verifies an empty file returns empty slice, not error.
+// Failure prevented: empty config file treated as corruption.
+func TestLoadHooksEmptyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	if err := os.WriteFile(path, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error for empty file: %v", err)
+	}
+	if len(cfgs) != 0 {
+		t.Fatalf("expected 0 hooks for empty file, got %d", len(cfgs))
+	}
+}
+
+// --- YAML with empty hooks list ---
+
+// TestLoadHooksEmptyList verifies `hooks: []` returns empty slice.
+// Failure prevented: explicit empty list treated differently from missing file.
+func TestLoadHooksEmptyList(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	if err := os.WriteFile(path, []byte("hooks: []\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfgs) != 0 {
+		t.Fatalf("expected 0 hooks, got %d", len(cfgs))
+	}
+}
+
+// --- YAML with extra/unknown fields ---
+
+// TestLoadHooksExtraFields verifies unknown YAML fields are silently ignored.
+// Failure prevented: strict parsing rejects valid configs with forward-compatible fields.
+func TestLoadHooksExtraFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	content := `hooks:
+  - event: daemon.started
+    command: echo test
+    description: this is an extra field
+    timeout: 5000
+    unknown_field: should be ignored
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error with extra fields: %v", err)
+	}
+	if len(cfgs) != 1 {
+		t.Fatalf("expected 1 hook, got %d", len(cfgs))
+	}
+	if cfgs[0].Event != "daemon.started" {
+		t.Errorf("event = %q, want daemon.started", cfgs[0].Event)
+	}
+}
+
+// --- Large hooks file ---
+
+// TestLoadHooksLargeFile verifies loading 1000+ hooks completes in reasonable time.
+// Failure prevented: O(n^2) dedup or validation causes timeout on large configs.
+func TestLoadHooksLargeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: large file performance")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+
+	var b strings.Builder
+	b.WriteString("hooks:\n")
+	for i := 0; i < 1000; i++ {
+		fmt.Fprintf(&b, "  - event: daemon.started\n    command: echo hook-%d\n", i)
+	}
+
+	if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// all 1000 have unique commands, so none should be deduped
+	if len(cfgs) != 1000 {
+		t.Fatalf("expected 1000 hooks, got %d", len(cfgs))
+	}
+}
+
+// --- Wildcard with valid events in same file ---
+
+// TestLoadHooksWildcardPreserved verifies wildcard "*" event passes validation.
+// Failure prevented: wildcard incorrectly rejected by ValidEvent check.
+func TestLoadHooksWildcardPreserved(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	content := `hooks:
+  - event: "*"
+    command: echo all-events
+  - event: daemon.started
+    command: echo specific
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfgs) != 2 {
+		t.Fatalf("expected 2 hooks (wildcard + specific), got %d", len(cfgs))
+	}
+	if cfgs[0].Event != "*" {
+		t.Errorf("first hook event = %q, want '*'", cfgs[0].Event)
+	}
+}
+
+// --- Dedup with different events same command ---
+
+// TestLoadHooksDedupSameCommandDifferentEvents verifies that the same command
+// with different events is NOT deduped.
+// Failure prevented: dedup key ignores event name, collapsing distinct hooks.
+func TestLoadHooksDedupSameCommandDifferentEvents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	content := `hooks:
+  - event: daemon.started
+    command: echo test
+  - event: daemon.stopped
+    command: echo test
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfgs) != 2 {
+		t.Fatalf("expected 2 hooks (same command, different events), got %d", len(cfgs))
+	}
+}
+
+// --- Permission error ---
+
+// TestLoadHooksPermissionError verifies an unreadable file returns an error.
+// Failure prevented: permission error silently returns empty hooks.
+func TestLoadHooksPermissionError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	if err := os.WriteFile(path, []byte("hooks:\n  - event: daemon.started\n    command: echo test\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// remove read permission
+	if err := os.Chmod(path, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(path, 0600) }) // restore for cleanup
+
+	_, err := hooks.LoadHooksFrom(path)
+	if err == nil {
+		t.Fatal("expected error for unreadable file, got nil")
+	}
+}
+
+// --- YAML with only hooks key but no entries ---
+
+// TestLoadHooksNullHooksKey verifies `hooks:` with no value returns empty slice.
+// Failure prevented: null YAML value causes nil pointer dereference.
+func TestLoadHooksNullHooksKey(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.yaml")
+	if err := os.WriteFile(path, []byte("hooks:\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgs, err := hooks.LoadHooksFrom(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfgs) != 0 {
+		t.Fatalf("expected 0 hooks, got %d", len(cfgs))
+	}
+}

--- a/internal/daemon/hooks/events.go
+++ b/internal/daemon/hooks/events.go
@@ -1,0 +1,73 @@
+package hooks
+
+import (
+	"encoding/json"
+	"sort"
+	"time"
+)
+
+// Event name constants. Dot-separated: category.action.
+const (
+	EventDaemonStarted    = "daemon.started"
+	EventDaemonStopped    = "daemon.stopped"
+	EventSessionStarted   = "session.started"
+	EventSessionStopped   = "session.stopped"
+	EventSessionUploaded  = "session.uploaded"
+	EventSessionAvailable = "session.available"
+	EventMurmurReceived   = "murmur.received"
+	EventMurmurCritical   = "murmur.critical"
+	EventSyncCompleted    = "sync.completed"
+	EventSyncFailed       = "sync.failed"
+	EventAgentRegistered  = "agent.registered"
+	EventAgentIdle        = "agent.idle"
+)
+
+var allEvents = map[string]bool{
+	EventDaemonStarted: true, EventDaemonStopped: true,
+	EventSessionStarted: true, EventSessionStopped: true,
+	EventSessionUploaded: true, EventSessionAvailable: true,
+	EventMurmurReceived: true, EventMurmurCritical: true,
+	EventSyncCompleted: true, EventSyncFailed: true,
+	EventAgentRegistered: true, EventAgentIdle: true,
+}
+
+// ValidEvent returns true if name is a known event name.
+func ValidEvent(name string) bool { return allEvents[name] }
+
+// AllEventNames returns all valid event names sorted alphabetically.
+func AllEventNames() []string {
+	names := make([]string, 0, len(allEvents))
+	for name := range allEvents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Event represents a daemon event that can trigger notifications and hooks.
+type Event struct {
+	Name      string         `json:"event"`
+	Timestamp time.Time      `json:"timestamp"`
+	Project   string         `json:"project_root"`
+	RepoID    string         `json:"repo_id"`
+	Payload   map[string]any `json:"-"` // merged into top-level JSON, not nested
+}
+
+// Marshal serializes the event into JSON, merging the common envelope
+// with the Payload fields at the top level.
+func (e Event) Marshal() ([]byte, error) {
+	merged := map[string]any{
+		"event":        e.Name,
+		"timestamp":    e.Timestamp.UTC().Format(time.RFC3339),
+		"project_root": e.Project,
+		"repo_id":      e.RepoID,
+	}
+	for k, v := range e.Payload {
+		// don't let payload overwrite envelope fields
+		if k == "event" || k == "timestamp" || k == "project_root" || k == "repo_id" {
+			continue
+		}
+		merged[k] = v
+	}
+	return json.Marshal(merged)
+}

--- a/internal/daemon/hooks/payloads.go
+++ b/internal/daemon/hooks/payloads.go
@@ -1,0 +1,83 @@
+package hooks
+
+import "time"
+
+// MurmurPayload builds the payload for murmur.received and murmur.critical events.
+func MurmurPayload(id, agentID, principal, topic, importance, content string) map[string]any {
+	return map[string]any{
+		"murmur": map[string]any{
+			"id": id, "agent_id": agentID, "principal": principal,
+			"topic": topic, "importance": importance, "content": content,
+		},
+	}
+}
+
+// SessionUploadedPayload builds the payload for session.uploaded events.
+func SessionUploadedPayload(name, url, agentID string, dur time.Duration) map[string]any {
+	return map[string]any{
+		"session": map[string]any{
+			"name": name, "url": url, "agent_id": agentID,
+			"duration_seconds": int(dur.Seconds()),
+		},
+	}
+}
+
+// SessionAvailablePayload builds the payload for session.available events.
+func SessionAvailablePayload(name, url, principal, agentID string) map[string]any {
+	return map[string]any{
+		"session": map[string]any{
+			"name": name, "url": url, "principal": principal, "agent_id": agentID,
+		},
+	}
+}
+
+// SessionPayload builds the payload for session.started events.
+func SessionPayload(name, agentID string) map[string]any {
+	return map[string]any{
+		"session": map[string]any{"name": name, "agent_id": agentID},
+	}
+}
+
+// SessionStoppedPayload builds the payload for session.stopped with duration.
+func SessionStoppedPayload(name, agentID string, dur time.Duration) map[string]any {
+	return map[string]any{
+		"session": map[string]any{
+			"name": name, "agent_id": agentID,
+			"duration_seconds": int(dur.Seconds()),
+		},
+	}
+}
+
+// SyncPayload builds the payload for sync.completed events.
+func SyncPayload(workspace, syncType string, dur time.Duration) map[string]any {
+	return map[string]any{
+		"sync": map[string]any{
+			"workspace": workspace, "type": syncType, "duration_ms": dur.Milliseconds(),
+		},
+	}
+}
+
+// SyncFailedPayload builds the payload for sync.failed events.
+func SyncFailedPayload(workspace, syncType, errMsg string) map[string]any {
+	return map[string]any{
+		"sync": map[string]any{
+			"workspace": workspace, "type": syncType, "error": errMsg,
+		},
+	}
+}
+
+// AgentPayload builds the payload for agent.registered events.
+func AgentPayload(id, agentType, principal string) map[string]any {
+	return map[string]any{
+		"agent": map[string]any{"id": id, "type": agentType, "principal": principal},
+	}
+}
+
+// AgentIdlePayload builds the payload for agent.idle events.
+func AgentIdlePayload(id string, idleSince time.Time) map[string]any {
+	return map[string]any{
+		"agent": map[string]any{
+			"id": id, "idle_since": idleSince.UTC().Format(time.RFC3339),
+		},
+	}
+}

--- a/internal/daemon/hooks/payloads_test.go
+++ b/internal/daemon/hooks/payloads_test.go
@@ -1,0 +1,428 @@
+package hooks_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/daemon/hooks"
+)
+
+func TestEventMarshal(t *testing.T) {
+	t.Parallel()
+
+	event := hooks.Event{
+		Name:      hooks.EventSessionUploaded,
+		Timestamp: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+		Project:   "/tmp/test-project",
+		RepoID:    "repo_test123",
+		Payload:   hooks.SessionUploadedPayload("my-session", "https://example.com", "agent-1", 60*time.Second),
+	}
+
+	data, err := event.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// envelope fields at top level
+	if parsed["event"] != "session.uploaded" {
+		t.Errorf("event = %v, want session.uploaded", parsed["event"])
+	}
+	if parsed["project_root"] != "/tmp/test-project" {
+		t.Errorf("project_root = %v", parsed["project_root"])
+	}
+	if parsed["repo_id"] != "repo_test123" {
+		t.Errorf("repo_id = %v", parsed["repo_id"])
+	}
+
+	// payload merged at top level (no nested "payload" key)
+	if _, hasPayload := parsed["payload"]; hasPayload {
+		t.Error("payload should be merged at top level, not nested")
+	}
+
+	// session data present at top level
+	sess, ok := parsed["session"].(map[string]any)
+	if !ok {
+		t.Fatal("session key missing or wrong type")
+	}
+	if sess["name"] != "my-session" {
+		t.Errorf("session.name = %v, want my-session", sess["name"])
+	}
+}
+
+func TestMurmurPayload(t *testing.T) {
+	t.Parallel()
+
+	p := hooks.MurmurPayload("m-1", "agent-1", "Person A", "wip", "normal", "working on things")
+	murmur, ok := p["murmur"].(map[string]any)
+	if !ok {
+		t.Fatal("expected murmur key")
+	}
+	if murmur["id"] != "m-1" {
+		t.Errorf("id = %v", murmur["id"])
+	}
+	if murmur["topic"] != "wip" {
+		t.Errorf("topic = %v", murmur["topic"])
+	}
+}
+
+func TestSyncPayload(t *testing.T) {
+	t.Parallel()
+
+	p := hooks.SyncPayload("ledger", "pull", 1500*time.Millisecond)
+	sync, ok := p["sync"].(map[string]any)
+	if !ok {
+		t.Fatal("expected sync key")
+	}
+	if sync["duration_ms"] != int64(1500) {
+		t.Errorf("duration_ms = %v, want 1500", sync["duration_ms"])
+	}
+}
+
+func TestAllEventNamesComplete(t *testing.T) {
+	t.Parallel()
+
+	names := hooks.AllEventNames()
+
+	// verify every name is a valid event and there are no duplicates
+	seen := make(map[string]bool)
+	for _, n := range names {
+		if !hooks.ValidEvent(n) {
+			t.Errorf("AllEventNames() returned invalid event %q", n)
+		}
+		if seen[n] {
+			t.Errorf("AllEventNames() returned duplicate %q", n)
+		}
+		seen[n] = true
+	}
+
+	if len(names) == 0 {
+		t.Fatal("AllEventNames() returned empty slice")
+	}
+}
+
+func TestValidEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"daemon.started", true},
+		{"session.uploaded", true},
+		{"murmur.received", true},
+		{"sync.completed", true},
+		{"unknown.event", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := hooks.ValidEvent(tt.name); got != tt.valid {
+			t.Errorf("ValidEvent(%q) = %v, want %v", tt.name, got, tt.valid)
+		}
+	}
+}
+
+// --- Marshal edge cases ---
+
+// TestEventMarshalEmptyPayload verifies marshaling with nil/empty payload
+// produces valid JSON with just the envelope fields.
+// Failure prevented: nil map iteration causes panic during marshal.
+func TestEventMarshalEmptyPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload map[string]any
+	}{
+		{"nil_payload", nil},
+		{"empty_payload", map[string]any{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			event := hooks.Event{
+				Name:      hooks.EventDaemonStarted,
+				Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				Project:   "/tmp/test",
+				RepoID:    "repo-1",
+				Payload:   tt.payload,
+			}
+
+			data, err := event.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error: %v", err)
+			}
+
+			var parsed map[string]any
+			if err := json.Unmarshal(data, &parsed); err != nil {
+				t.Fatalf("invalid JSON: %v\ncontent: %s", err, data)
+			}
+
+			// envelope fields must always be present
+			if parsed["event"] != "daemon.started" {
+				t.Errorf("event = %v", parsed["event"])
+			}
+			if parsed["project_root"] != "/tmp/test" {
+				t.Errorf("project_root = %v", parsed["project_root"])
+			}
+		})
+	}
+}
+
+// TestEventMarshalEnvelopeProtectedFromPayload verifies that envelope keys
+// (event, timestamp, project_root, repo_id) cannot be overwritten by payload.
+// Failure prevented: payload data corrupts event metadata delivered to hooks.
+func TestEventMarshalEnvelopeProtectedFromPayload(t *testing.T) {
+	t.Parallel()
+
+	event := hooks.Event{
+		Name:      hooks.EventDaemonStarted,
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Project:   "/tmp/test",
+		RepoID:    "repo-123",
+		Payload: map[string]any{
+			"event":        "overridden.value",
+			"timestamp":    "bogus",
+			"project_root": "/evil",
+			"repo_id":      "fake",
+			"extra":        "kept",
+		},
+	}
+
+	data, err := event.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// envelope fields must not be overridden by payload
+	if parsed["event"] != hooks.EventDaemonStarted {
+		t.Errorf("envelope 'event' was overridden: got %v", parsed["event"])
+	}
+	if parsed["project_root"] != "/tmp/test" {
+		t.Errorf("envelope 'project_root' was overridden: got %v", parsed["project_root"])
+	}
+	if parsed["repo_id"] != "repo-123" {
+		t.Errorf("envelope 'repo_id' was overridden: got %v", parsed["repo_id"])
+	}
+	// non-reserved payload keys are preserved
+	if parsed["extra"] != "kept" {
+		t.Errorf("non-reserved payload key 'extra' was dropped: got %v", parsed["extra"])
+	}
+}
+
+// TestEventMarshalLargePayload verifies marshaling a payload with many keys
+// doesn't truncate.
+// Failure prevented: buffer size limit silently drops payload data.
+func TestEventMarshalLargePayload(t *testing.T) {
+	t.Parallel()
+
+	payload := make(map[string]any)
+	for i := 0; i < 100; i++ {
+		payload[fmt.Sprintf("key_%d", i)] = fmt.Sprintf("value_%d", i)
+	}
+
+	event := hooks.Event{
+		Name:      hooks.EventDaemonStarted,
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Payload:   payload,
+	}
+
+	data, err := event.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// 100 payload keys + 4 envelope keys
+	if len(parsed) != 104 {
+		t.Errorf("expected 104 keys, got %d", len(parsed))
+	}
+}
+
+// TestEventMarshalNilValues verifies payload with nil values marshals as null.
+// Failure prevented: nil interface{} causes marshal error or omission.
+func TestEventMarshalNilValues(t *testing.T) {
+	t.Parallel()
+
+	event := hooks.Event{
+		Name:      hooks.EventDaemonStarted,
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Payload: map[string]any{
+			"nullable_field": nil,
+			"nested":         map[string]any{"inner": nil},
+		},
+	}
+
+	data, err := event.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if parsed["nullable_field"] != nil {
+		t.Errorf("nullable_field should be null, got %v", parsed["nullable_field"])
+	}
+}
+
+// --- Payload builder coverage ---
+
+// TestAllPayloadBuilders verifies every payload builder returns well-formed data.
+// Failure prevented: payload builder returns wrong keys or types.
+func TestAllPayloadBuilders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		payload   map[string]any
+		topKey    string
+		innerKeys []string
+	}{
+		{
+			"murmur",
+			hooks.MurmurPayload("m-1", "a-1", "Person A", "wip", "normal", "content"),
+			"murmur",
+			[]string{"id", "agent_id", "principal", "topic", "importance", "content"},
+		},
+		{
+			"session_uploaded",
+			hooks.SessionUploadedPayload("s-1", "https://example.com", "a-1", 60*time.Second),
+			"session",
+			[]string{"name", "url", "agent_id", "duration_seconds"},
+		},
+		{
+			"session_available",
+			hooks.SessionAvailablePayload("s-1", "https://example.com", "Person A", "a-1"),
+			"session",
+			[]string{"name", "url", "principal", "agent_id"},
+		},
+		{
+			"session_started",
+			hooks.SessionPayload("s-1", "a-1"),
+			"session",
+			[]string{"name", "agent_id"},
+		},
+		{
+			"session_stopped",
+			hooks.SessionStoppedPayload("s-1", "a-1", 120*time.Second),
+			"session",
+			[]string{"name", "agent_id", "duration_seconds"},
+		},
+		{
+			"sync_completed",
+			hooks.SyncPayload("ledger", "pull", 1500*time.Millisecond),
+			"sync",
+			[]string{"workspace", "type", "duration_ms"},
+		},
+		{
+			"sync_failed",
+			hooks.SyncFailedPayload("ledger", "pull", "connection refused"),
+			"sync",
+			[]string{"workspace", "type", "error"},
+		},
+		{
+			"agent_registered",
+			hooks.AgentPayload("a-1", "claude-code", "Person A"),
+			"agent",
+			[]string{"id", "type", "principal"},
+		},
+		{
+			"agent_idle",
+			hooks.AgentIdlePayload("a-1", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+			"agent",
+			[]string{"id", "idle_since"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			inner, ok := tt.payload[tt.topKey].(map[string]any)
+			if !ok {
+				t.Fatalf("expected top-level key %q with map value", tt.topKey)
+			}
+
+			for _, key := range tt.innerKeys {
+				if _, exists := inner[key]; !exists {
+					t.Errorf("missing expected key %q in %s payload", key, tt.name)
+				}
+			}
+		})
+	}
+}
+
+// TestSessionStoppedPayloadDuration verifies duration is correctly converted to seconds.
+// Failure prevented: wrong unit conversion (ms vs s) in duration field.
+func TestSessionStoppedPayloadDuration(t *testing.T) {
+	t.Parallel()
+
+	p := hooks.SessionStoppedPayload("s-1", "a-1", 90*time.Second)
+	sess := p["session"].(map[string]any)
+	if sess["duration_seconds"] != 90 {
+		t.Errorf("duration_seconds = %v, want 90", sess["duration_seconds"])
+	}
+}
+
+// TestAgentIdlePayloadTimestamp verifies idle_since is RFC3339 UTC.
+// Failure prevented: timezone-dependent timestamp breaks hook parsing.
+func TestAgentIdlePayloadTimestamp(t *testing.T) {
+	t.Parallel()
+
+	eastern, _ := time.LoadLocation("America/New_York")
+	localTime := time.Date(2026, 6, 15, 14, 30, 0, 0, eastern)
+
+	p := hooks.AgentIdlePayload("a-1", localTime)
+	agent := p["agent"].(map[string]any)
+	idle := agent["idle_since"].(string)
+
+	if idle != "2026-06-15T18:30:00Z" {
+		t.Errorf("idle_since = %q, want UTC RFC3339", idle)
+	}
+}
+
+// TestAllEventNamesSorted verifies AllEventNames returns sorted list.
+// Failure prevented: unsorted list breaks binary search or display assumptions.
+func TestAllEventNamesSorted(t *testing.T) {
+	t.Parallel()
+
+	names := hooks.AllEventNames()
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Fatalf("event names not sorted: %q comes after %q", names[i], names[i-1])
+		}
+	}
+}
+
+// TestValidEventAllKnownEvents verifies every event from AllEventNames() is valid.
+// Failure prevented: AllEventNames and ValidEvent disagree on the event set.
+func TestValidEventAllKnownEvents(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range hooks.AllEventNames() {
+		if !hooks.ValidEvent(name) {
+			t.Errorf("AllEventNames includes %q but ValidEvent returns false", name)
+		}
+	}
+}

--- a/internal/daemon/hooks/runner.go
+++ b/internal/daemon/hooks/runner.go
@@ -1,0 +1,119 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	hookTimeout        = 500 * time.Millisecond
+	hookKillDelay      = 500 * time.Millisecond
+	maxConcurrentHooks = 4
+)
+
+// HookRunner executes user-defined hook scripts for matching events.
+// Scripts receive the event as JSON on stdin with a hard 500ms timeout.
+type HookRunner struct {
+	mu     sync.RWMutex
+	hooks  []HookConfig
+	sem    chan struct{}
+	logger *slog.Logger
+}
+
+// NewHookRunner creates a HookRunner with the given hooks.
+func NewHookRunner(hooks []HookConfig, logger *slog.Logger) *HookRunner {
+	return &HookRunner{
+		hooks:  hooks,
+		sem:    make(chan struct{}, maxConcurrentHooks),
+		logger: logger,
+	}
+}
+
+// SetHooks replaces the current hook configuration.
+func (r *HookRunner) SetHooks(hooks []HookConfig) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hooks = hooks
+}
+
+// Dispatch finds hooks matching the event and runs each in a background goroutine.
+// Never blocks the caller.
+func (r *HookRunner) Dispatch(ctx context.Context, event Event) {
+	r.mu.RLock()
+	hooks := r.hooks
+	r.mu.RUnlock()
+
+	for _, hook := range hooks {
+		if hook.Event != "*" && hook.Event != event.Name {
+			continue
+		}
+		h := hook
+		go r.run(ctx, event, h)
+	}
+}
+
+func (r *HookRunner) run(ctx context.Context, event Event, hook HookConfig) {
+	r.sem <- struct{}{}
+	defer func() { <-r.sem }()
+
+	start := time.Now()
+
+	eventJSON, err := event.Marshal()
+	if err != nil {
+		r.logger.Warn("hook marshal failed", "event", event.Name, "command", hook.Command, "error", err)
+		return
+	}
+
+	cmd := exec.Command("sh", "-c", hook.Command)
+	cmd.Stdin = bytes.NewReader(eventJSON)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Env = append(os.Environ(),
+		"OX_EVENT="+event.Name,
+		"OX_EVENT_TIMESTAMP="+event.Timestamp.UTC().Format(time.RFC3339),
+	)
+
+	if err := cmd.Start(); err != nil {
+		r.logger.Warn("hook start failed", "event", event.Name, "command", hook.Command, "error", err)
+		return
+	}
+
+	// signal the entire process group so forked children are also terminated
+	pgid := cmd.Process.Pid
+	termTimer := time.AfterFunc(hookTimeout, func() {
+		_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	})
+	killTimer := time.AfterFunc(hookTimeout+hookKillDelay, func() {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	})
+
+	waitErr := cmd.Wait()
+	elapsed := time.Since(start)
+	termTimer.Stop()
+	killTimer.Stop()
+
+	if waitErr == nil {
+		r.logger.Debug("hook completed", "event", event.Name, "command", hook.Command, "duration", elapsed)
+		return
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		if exitErr.ExitCode() == -1 {
+			r.logger.Warn("hook timed out", "event", event.Name, "command", hook.Command, "duration", elapsed)
+		} else {
+			r.logger.Warn("hook failed", "event", event.Name, "command", hook.Command, "exit", exitErr.ExitCode(), "duration", elapsed)
+		}
+	} else {
+		r.logger.Warn("hook error", "event", event.Name, "command", hook.Command, "error", waitErr, "duration", elapsed)
+	}
+}

--- a/internal/daemon/hooks/runner_test.go
+++ b/internal/daemon/hooks/runner_test.go
@@ -1,0 +1,626 @@
+package hooks_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/daemon/hooks"
+)
+
+func TestRunnerJSONOnStdin(t *testing.T) {
+	t.Parallel()
+
+	tmpFile := filepath.Join(t.TempDir(), "output.json")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "cat > " + tmpFile},
+	}, testLogger())
+
+	event := hooks.Event{
+		Name:    hooks.EventDaemonStarted,
+		Project: "/tmp/test",
+		RepoID:  "repo_test",
+	}
+
+	runner.Dispatch(context.Background(), event)
+	time.Sleep(300 * time.Millisecond)
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON on stdin: %v\ncontent: %s", err, data)
+	}
+
+	if parsed["event"] != "daemon.started" {
+		t.Errorf("event = %v, want daemon.started", parsed["event"])
+	}
+	if parsed["project_root"] != "/tmp/test" {
+		t.Errorf("project_root = %v, want /tmp/test", parsed["project_root"])
+	}
+}
+
+func TestRunnerTimeout(t *testing.T) {
+	t.Parallel()
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "sleep 10"},
+	}, testLogger())
+
+	start := time.Now()
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	// wait for the hook to be killed (500ms SIGTERM + 500ms SIGKILL + margin)
+	time.Sleep(1500 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	if elapsed > 3*time.Second {
+		t.Fatalf("hook took %v, expected <3s (timeout should kill it)", elapsed)
+	}
+}
+
+func TestRunnerExitCode(t *testing.T) {
+	t.Parallel()
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "exit 1"},
+	}, testLogger())
+
+	// should not panic
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	time.Sleep(200 * time.Millisecond)
+}
+
+func TestRunnerWildcard(t *testing.T) {
+	t.Parallel()
+
+	tmpFile := filepath.Join(t.TempDir(), "wildcard.json")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "*", Command: "cat > " + tmpFile},
+	}, testLogger())
+
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventSyncCompleted, Project: "/tmp/test"})
+	time.Sleep(300 * time.Millisecond)
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("wildcard hook did not fire: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if parsed["event"] != "sync.completed" {
+		t.Errorf("event = %v, want sync.completed", parsed["event"])
+	}
+}
+
+func TestRunnerNoMatch(t *testing.T) {
+	t.Parallel()
+
+	tmpFile := filepath.Join(t.TempDir(), "nomatch.txt")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "touch " + tmpFile},
+	}, testLogger())
+
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventSessionUploaded})
+	time.Sleep(200 * time.Millisecond)
+
+	if _, err := os.Stat(tmpFile); err == nil {
+		t.Fatal("hook should not have run for non-matching event")
+	}
+}
+
+func TestRunnerConcurrencyCap(t *testing.T) {
+	t.Parallel()
+
+	// 8 hooks that each sleep 200ms, with concurrency cap of 4
+	// should complete in ~400ms (2 batches), not 200ms (all parallel) or 1600ms (serial)
+	var cfgs []hooks.HookConfig
+	for i := 0; i < 8; i++ {
+		cfgs = append(cfgs, hooks.HookConfig{Event: "*", Command: "sleep 0.2"})
+	}
+
+	runner := hooks.NewHookRunner(cfgs, testLogger())
+
+	start := time.Now()
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	// wait for all to complete
+	time.Sleep(800 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	// should take ~400ms (2 batches of 4) + overhead, not 1600ms (serial)
+	if elapsed > 1200*time.Millisecond {
+		t.Fatalf("took %v, expected <1.2s (concurrency cap should batch, not serialize)", elapsed)
+	}
+}
+
+// --- Stuck process / signal handling ---
+
+// TestRunnerSIGTERMIgnored verifies a hook that traps SIGTERM is killed by SIGKILL.
+// Failure prevented: a misbehaving hook hangs the runner forever.
+func TestRunnerSIGTERMIgnored(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: subprocess signal handling")
+	}
+	t.Parallel()
+
+	// trap SIGTERM and keep running; only SIGKILL will stop it
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "trap '' TERM; sleep 10"},
+	}, testLogger())
+
+	done := make(chan struct{})
+	go func() {
+		runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+		// dispatch is fire-and-forget; wait for semaphore release by trying to fill it
+		for i := 0; i < 4; i++ {
+			runner.Dispatch(context.Background(), hooks.Event{Name: "nonexistent.event"})
+		}
+		close(done)
+	}()
+
+	// total budget: 500ms SIGTERM + 500ms SIGKILL + generous margin
+	select {
+	case <-time.After(3 * time.Second):
+		t.Fatal("hook that ignores SIGTERM was not killed within 3s")
+	case <-done:
+		// passed
+	}
+}
+
+// --- Pipe / stdin edge cases ---
+
+// TestRunnerHookDoesNotReadStdin verifies the runner doesn't hang when
+// the hook ignores stdin entirely.
+// Failure prevented: runner blocks on pipe write to an uncooperative hook.
+func TestRunnerHookDoesNotReadStdin(t *testing.T) {
+	t.Parallel()
+
+	markerFile := filepath.Join(t.TempDir(), "done.txt")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "echo ok > " + markerFile},
+	}, testLogger())
+
+	runner.Dispatch(context.Background(), hooks.Event{
+		Name:    hooks.EventDaemonStarted,
+		Payload: hooks.MurmurPayload("m-1", "a-1", "Person A", "test", "normal", "content"),
+	})
+	time.Sleep(300 * time.Millisecond)
+
+	if _, err := os.Stat(markerFile); err != nil {
+		t.Fatal("hook that ignores stdin should still complete")
+	}
+}
+
+// TestRunnerHookMassiveStdout verifies a hook that floods stdout doesn't hang.
+// Failure prevented: pipe buffer fills and blocks the hook subprocess.
+func TestRunnerHookMassiveStdout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: subprocess stdout stress")
+	}
+	t.Parallel()
+
+	// generate ~1MB of stdout; since runner doesn't capture it, the OS should
+	// discard or buffer it without blocking
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "dd if=/dev/zero bs=1024 count=1024 2>/dev/null; exit 0"},
+	}, testLogger())
+
+	done := make(chan struct{})
+	go func() {
+		runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+		time.Sleep(1500 * time.Millisecond) // generous time for hook + timeout
+		close(done)
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("hook with massive stdout appears to be hanging")
+	case <-done:
+	}
+}
+
+// --- Empty / no-op dispatch ---
+
+// TestRunnerEmptyHooksList verifies dispatch with zero hooks is an instant no-op.
+// Failure prevented: unnecessary goroutine or channel operations on empty config.
+func TestRunnerEmptyHooksList(t *testing.T) {
+	t.Parallel()
+
+	runner := hooks.NewHookRunner(nil, testLogger())
+
+	start := time.Now()
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	elapsed := time.Since(start)
+
+	if elapsed > 1*time.Millisecond {
+		t.Fatalf("dispatch with empty hooks took %v, expected near-instant", elapsed)
+	}
+}
+
+// --- Command resolution ---
+
+// TestRunnerCommandNotFound verifies a nonexistent command fails gracefully.
+// Failure prevented: panic or goroutine leak on exec failure.
+func TestRunnerCommandNotFound(t *testing.T) {
+	t.Parallel()
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "nonexistent-command-xyz-12345"},
+	}, testLogger())
+
+	// should not panic, should log a warning
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	time.Sleep(300 * time.Millisecond)
+}
+
+// --- Background process / orphan handling ---
+
+// TestRunnerHookForksBackground verifies a hook that forks a background child
+// doesn't block the runner (parent exits immediately, orphan is reaped by init).
+// Failure prevented: runner waits for orphaned child process.
+func TestRunnerHookForksBackground(t *testing.T) {
+	t.Parallel()
+
+	markerFile := filepath.Join(t.TempDir(), "parent-done.txt")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "sleep 100 & echo done > " + markerFile},
+	}, testLogger())
+
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	time.Sleep(300 * time.Millisecond)
+
+	if _, err := os.Stat(markerFile); err != nil {
+		t.Fatal("parent process should have exited immediately despite forked child")
+	}
+}
+
+// --- Rapid-fire / goroutine leak ---
+
+// TestRunnerRapidFireNoLeak verifies that emitting many events rapidly doesn't
+// leak goroutines. Uses fewer events to ensure they drain within the wait period.
+// Failure prevented: unbounded goroutine growth on sustained event traffic.
+func TestRunnerRapidFireNoLeak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: goroutine leak check")
+	}
+	t.Parallel()
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "*", Command: "true"},
+	}, testLogger())
+
+	// let any pre-existing goroutines settle
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	// dispatch 20 events (20 goroutines, 4 concurrent via semaphore)
+	// "true" completes in ~10ms so 20/4 = 5 batches * ~10ms = ~50ms
+	for i := 0; i < 20; i++ {
+		runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	}
+
+	// generous wait for all hooks to drain
+	time.Sleep(5 * time.Second)
+
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	// allow a margin of 10 goroutines for runtime background activity and
+	// other parallel tests
+	if after > before+10 {
+		t.Fatalf("goroutine leak: before=%d, after=%d (delta=%d)", before, after, after-before)
+	}
+}
+
+// --- Context cancellation ---
+
+// TestRunnerContextCancelDoesNotPreventDispatch verifies hooks still fire
+// even when the parent context is already canceled (fire-and-forget semantics).
+// Failure prevented: context propagation accidentally suppresses hook execution.
+func TestRunnerContextCancelDoesNotPreventDispatch(t *testing.T) {
+	t.Parallel()
+
+	markerFile := filepath.Join(t.TempDir(), "fired.txt")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: "touch " + markerFile},
+	}, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	runner.Dispatch(ctx, hooks.Event{Name: hooks.EventDaemonStarted})
+	time.Sleep(300 * time.Millisecond)
+
+	// the runner doesn't check ctx before starting the hook, so it should still fire
+	if _, err := os.Stat(markerFile); err != nil {
+		t.Fatal("hook should fire even with canceled context (fire-and-forget)")
+	}
+}
+
+// --- Special characters in event JSON ---
+
+// TestRunnerSpecialCharsInPayload verifies unicode, quotes, and newlines
+// in payload values are correctly delivered as JSON on stdin.
+// Failure prevented: JSON encoding/escaping errors corrupt hook input.
+func TestRunnerSpecialCharsInPayload(t *testing.T) {
+	t.Parallel()
+
+	tmpFile := filepath.Join(t.TempDir(), "output.json")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "murmur.received", Command: "cat > " + tmpFile},
+	}, testLogger())
+
+	event := hooks.Event{
+		Name:    hooks.EventMurmurReceived,
+		Project: "/tmp/test",
+		Payload: hooks.MurmurPayload(
+			"m-1", "agent-1", "Person A", "design",
+			"normal",
+			"line1\nline2\ttab \"quoted\" and unicode: \u00e9\u00e0\u00fc \U0001f600",
+		),
+	}
+
+	runner.Dispatch(context.Background(), event)
+	time.Sleep(300 * time.Millisecond)
+
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON with special chars: %v\ncontent: %s", err, data)
+	}
+
+	murmur, ok := parsed["murmur"].(map[string]any)
+	if !ok {
+		t.Fatal("missing murmur key in parsed JSON")
+	}
+	content := murmur["content"].(string)
+	if !strings.Contains(content, "quoted") {
+		t.Errorf("content should contain 'quoted', got: %s", content)
+	}
+	if !strings.Contains(content, "\n") {
+		t.Errorf("content should contain newline, got: %s", content)
+	}
+}
+
+// --- Environment variables ---
+
+// TestRunnerEnvironmentVariables verifies OX_EVENT and OX_EVENT_TIMESTAMP
+// are set correctly on hook subprocesses.
+// Failure prevented: hooks that rely on env vars get empty/wrong values.
+func TestRunnerEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	envFile := filepath.Join(t.TempDir(), "env.txt")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "daemon.started", Command: fmt.Sprintf(
+			`printf "%%s\n%%s" "$OX_EVENT" "$OX_EVENT_TIMESTAMP" > %s`, envFile)},
+	}, testLogger())
+
+	ts := time.Date(2026, 3, 15, 10, 30, 0, 0, time.UTC)
+	runner.Dispatch(context.Background(), hooks.Event{
+		Name:      hooks.EventDaemonStarted,
+		Timestamp: ts,
+	})
+	time.Sleep(300 * time.Millisecond)
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("failed to read env output: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), string(data))
+	}
+	if lines[0] != "daemon.started" {
+		t.Errorf("OX_EVENT = %q, want %q", lines[0], "daemon.started")
+	}
+	if lines[1] != "2026-03-15T10:30:00Z" {
+		t.Errorf("OX_EVENT_TIMESTAMP = %q, want %q", lines[1], "2026-03-15T10:30:00Z")
+	}
+}
+
+// --- Concurrent Dispatch calls ---
+
+// TestRunnerConcurrentDispatch verifies multiple goroutines can call Dispatch
+// simultaneously without races or panics.
+// Failure prevented: data race on runner.hooks slice during concurrent dispatch.
+func TestRunnerConcurrentDispatch(t *testing.T) {
+	t.Parallel()
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "*", Command: "true"},
+	}, testLogger())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			runner.Dispatch(context.Background(), hooks.Event{
+				Name:    hooks.EventDaemonStarted,
+				Project: fmt.Sprintf("/tmp/project-%d", n),
+			})
+		}(i)
+	}
+	wg.Wait()
+	// allow hooks to drain
+	time.Sleep(1 * time.Second)
+}
+
+// --- SetHooks while Dispatch is running (race detector check) ---
+
+// TestRunnerSetHooksDuringDispatch verifies that concurrent SetHooks and
+// Dispatch calls don't race. HookRunner.hooks is protected by sync.RWMutex.
+// Failure prevented: data race between SetHooks write and Dispatch read.
+func TestRunnerSetHooksDuringDispatch(t *testing.T) {
+	t.Parallel()
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "*", Command: "true"},
+	}, testLogger())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			runner.SetHooks([]hooks.HookConfig{
+				{Event: "*", Command: "true"},
+			})
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		runner.Dispatch(context.Background(), hooks.Event{
+			Name: hooks.EventDaemonStarted,
+		})
+	}
+	<-done
+}
+
+// --- Semaphore enforcement ---
+
+// TestRunnerSemaphoreBoundsEnforced verifies that hooks are batched by the
+// semaphore by measuring total wall-clock time. 12 hooks sleeping 200ms each
+// with cap 4 should take ~600ms (3 batches), not 200ms (all parallel).
+// This complements TestRunnerConcurrencyCap with a larger batch.
+// Failure prevented: semaphore bypass allows unbounded subprocess fan-out.
+func TestRunnerSemaphoreBoundsEnforced(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: concurrency timing")
+	}
+	t.Parallel()
+
+	var cfgs []hooks.HookConfig
+	for i := 0; i < 12; i++ {
+		cfgs = append(cfgs, hooks.HookConfig{Event: "*", Command: "sleep 0.2"})
+	}
+
+	runner := hooks.NewHookRunner(cfgs, testLogger())
+
+	start := time.Now()
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+
+	// 12 hooks / 4 concurrent = 3 batches * 200ms = 600ms minimum
+	time.Sleep(1500 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	// if all 12 ran in parallel (no semaphore), it would take ~200ms
+	// we expect >=500ms (3 batches minus timing slack)
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("completed in %v, expected >=500ms (semaphore should batch to ~600ms)", elapsed)
+	}
+}
+
+// --- Multiple hooks for same event ---
+
+// TestRunnerMultipleHooksForSameEvent verifies all matching hooks fire,
+// not just the first one.
+// Failure prevented: early-return bug in dispatch loop skips later hooks.
+func TestRunnerMultipleHooksForSameEvent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	var cfgs []hooks.HookConfig
+	for i := 0; i < 5; i++ {
+		cfgs = append(cfgs, hooks.HookConfig{
+			Event:   "daemon.started",
+			Command: fmt.Sprintf("touch %s/hook-%d.txt", dir, i),
+		})
+	}
+
+	runner := hooks.NewHookRunner(cfgs, testLogger())
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	time.Sleep(500 * time.Millisecond)
+
+	for i := 0; i < 5; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("hook-%d.txt", i))
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("hook %d did not fire (missing %s)", i, path)
+		}
+	}
+}
+
+// --- Mixed matching: specific + wildcard ---
+
+// TestRunnerMixedWildcardAndSpecific verifies both wildcard and specific hooks
+// fire for the same event.
+// Failure prevented: wildcard matching excludes specific hooks or vice versa.
+func TestRunnerMixedWildcardAndSpecific(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		{Event: "*", Command: "touch " + filepath.Join(dir, "wildcard.txt")},
+		{Event: "daemon.started", Command: "touch " + filepath.Join(dir, "specific.txt")},
+	}, testLogger())
+
+	runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+	time.Sleep(300 * time.Millisecond)
+
+	for _, f := range []string{"wildcard.txt", "specific.txt"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			t.Errorf("expected %s to exist", f)
+		}
+	}
+}
+
+// --- Hook exit codes ---
+
+// TestRunnerVariousExitCodes verifies different exit codes are handled
+// gracefully without panics.
+// Failure prevented: unexpected exit code causes unhandled error type.
+func TestRunnerVariousExitCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{"exit_0", "exit 0"},
+		{"exit_1", "exit 1"},
+		{"exit_2", "exit 2"},
+		{"exit_127", "exit 127"},
+		{"exit_255", "exit 255"},
+		{"signal_segfault", "kill -SEGV $$"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := hooks.NewHookRunner([]hooks.HookConfig{
+				{Event: "daemon.started", Command: tt.command},
+			}, testLogger())
+
+			// must not panic
+			runner.Dispatch(context.Background(), hooks.Event{Name: hooks.EventDaemonStarted})
+			time.Sleep(300 * time.Millisecond)
+		})
+	}
+}

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -57,6 +57,7 @@ const (
 	MsgTypeSessionWatchStart  = "session_watch_start"  // one-way, start tailing a hookless agent session
 	MsgTypeSessionWatchStop   = "session_watch_stop"   // one-way, stop tailing a session
 	MsgTypeSettingsGet        = "settings_get"         // get cached CLI feature flag settings
+	MsgTypeSessionUploaded    = "session_uploaded"     // one-way, session pushed to ledger
 )
 
 // Protocol Design Decision: NDJSON (Newline-Delimited JSON)
@@ -255,6 +256,7 @@ type CheckoutResult struct {
 	AlreadyExists bool   `json:"already_exists"` // true if repo already existed
 	Cloned        bool   `json:"cloned"`         // true if we performed a clone
 }
+
 
 // CheckoutProgress is sent during long-running checkout operations.
 type CheckoutProgress struct {
@@ -603,6 +605,7 @@ type DaemonService interface {
 	PublishMurmur(payload MurmurPayload)
 	PauseMurmuring(agentID string)
 	ResumeMurmuring(agentID string)
+	SessionUploaded(name, url, agentID string, dur time.Duration)
 }
 
 // CallbackService implements DaemonService using individual callback functions.
@@ -909,6 +912,11 @@ func (c *CallbackService) ResumeMurmuring(agentID string) {
 	}
 }
 
+func (c *CallbackService) SessionUploaded(_, _, _ string, _ time.Duration) {
+	// no-op for callback service; daemon wires via daemonServiceImpl
+}
+
+
 // Server handles IPC requests from clients.
 type Server struct {
 	logger   *slog.Logger
@@ -983,6 +991,7 @@ func (s *Server) buildRouter() *MessageRouter {
 	router.Register(MsgTypeSessionWatchStart, handleSessionWatchStart)
 	router.Register(MsgTypeSessionWatchStop, handleSessionWatchStop)
 	router.Register(MsgTypeSettingsGet, handleSettingsGet)
+	router.Register(MsgTypeSessionUploaded, handleSessionUploaded)
 
 	return router
 }

--- a/internal/daemon/ipc_handlers.go
+++ b/internal/daemon/ipc_handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"time"
 
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
@@ -422,3 +423,19 @@ func handleWhisperHistory(s *Server, msg Message, _ net.Conn) HandlerResult {
 	}
 	return HandlerResult{Response: marshalResponse(result)}
 }
+
+func handleSessionUploaded(s *Server, msg Message, _ net.Conn) HandlerResult {
+	var payload struct {
+		SessionName string `json:"session_name"`
+		URL         string `json:"url"`
+		AgentID     string `json:"agent_id"`
+		DurationSec int    `json:"duration_seconds"`
+	}
+	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+		s.logger.Debug("failed to parse session_uploaded payload", "error", err)
+	} else {
+		s.service.SessionUploaded(payload.SessionName, payload.URL, payload.AgentID, time.Duration(payload.DurationSec)*time.Second)
+	}
+	return HandlerResult{SkipDefault: true}
+}
+

--- a/internal/daemon/murmur_relay.go
+++ b/internal/daemon/murmur_relay.go
@@ -1,9 +1,12 @@
 package daemon
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon/hooks"
 	"github.com/sageox/ox/internal/ledger"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
@@ -17,6 +20,12 @@ type MurmurRelay struct {
 	projectRoot   string          // re-checked on every relay to pick up config changes
 	lastRelayAt   time.Time
 	logger        *slog.Logger
+	eventBus      *hooks.EventBus
+}
+
+// SetEventBus sets the event bus for emitting murmur events.
+func (r *MurmurRelay) SetEventBus(bus *hooks.EventBus) {
+	r.eventBus = bus
 }
 
 // NewMurmurRelay creates a relay that scans murmur files and converts them
@@ -108,6 +117,19 @@ func (r *MurmurRelay) RelayFromPath(baseDir, scope string) int {
 
 		if err := r.registry.MarkRelayed(m.ID, scope); err != nil {
 			r.logger.Warn("failed to mark murmur relayed", "murmur_id", m.ID, "err", err)
+		}
+
+		if r.eventBus != nil {
+			eventName := hooks.EventMurmurReceived
+			if m.Importance == "critical" {
+				eventName = hooks.EventMurmurCritical
+			}
+			r.eventBus.Emit(context.Background(), hooks.Event{
+				Name:    eventName,
+				Project: r.projectRoot,
+				RepoID:  config.GetRepoID(r.projectRoot),
+				Payload: hooks.MurmurPayload(m.ID, m.AgentID, m.PrincipalID, m.Topic, m.Importance, m.Content),
+			})
 		}
 
 		relayed++

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -36,8 +36,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sageox/ox/internal/auth"
-	"github.com/sageox/ox/internal/observability"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/daemon/hooks"
 	"github.com/sageox/ox/internal/flags"
+	"github.com/sageox/ox/internal/observability"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
@@ -184,6 +186,9 @@ type SyncScheduler struct {
 
 	// OTel tracer for per-task trace contexts (nil = tracing disabled)
 	tracer *observability.DaemonTracer
+
+	// event bus for emitting sync events to hooks/notifications
+	eventBus *hooks.EventBus
 }
 
 // syncError tracks a sync error with timestamp.
@@ -328,6 +333,11 @@ func (s *SyncScheduler) SetSettingsFetcher(f *SettingsFetcher) {
 // SetTracer sets the OTel daemon tracer for per-task trace contexts.
 func (s *SyncScheduler) SetTracer(t *observability.DaemonTracer) {
 	s.tracer = t
+}
+
+// SetEventBus sets the event bus for emitting sync events.
+func (s *SyncScheduler) SetEventBus(bus *hooks.EventBus) {
+	s.eventBus = bus
 }
 
 // captureHEAD returns the current HEAD SHA for a git repo.
@@ -1142,6 +1152,14 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 				s.issues.SetIssue(*result.Issue)
 			}
 		}
+		if s.eventBus != nil {
+			s.eventBus.Emit(ctx, hooks.Event{
+				Name:    hooks.EventSyncFailed,
+				Project: s.config.ProjectRoot,
+				RepoID:  config.GetRepoID(s.config.ProjectRoot),
+				Payload: hooks.SyncFailedPayload("ledger", "pull", result.Err.Error()),
+			})
+		}
 		return fmt.Errorf("ledger %w", result.Err)
 	}
 
@@ -1167,6 +1185,15 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 	s.recordSync("pull", "ledger", duration, 0)
 	s.metrics.RecordPullSuccess(duration)
 	s.recordActivity()
+
+	if s.eventBus != nil {
+		s.eventBus.Emit(ctx, hooks.Event{
+			Name:    hooks.EventSyncCompleted,
+			Project: s.config.ProjectRoot,
+			RepoID:  config.GetRepoID(s.config.ProjectRoot),
+			Payload: hooks.SyncPayload("ledger", "pull", duration),
+		})
+	}
 
 	s.mu.Lock()
 	s.lastSync = time.Now()

--- a/internal/daemon/testutil/mock_service.go
+++ b/internal/daemon/testutil/mock_service.go
@@ -249,3 +249,5 @@ func (m *MockService) ResumeMurmuring(agentID string) {
 		m.ResumeMurmuringFunc(agentID)
 	}
 }
+
+func (m *MockService) SessionUploaded(_, _, _ string, _ time.Duration) {}


### PR DESCRIPTION
## Summary

Adds a two-layer daemon event system: an internal EventBus dispatches 12 dot-separated events (daemon lifecycle, sessions, murmurs, sync) to user-defined shell hook scripts configured via `hooks.yaml`. Hooks run with a 500ms SIGTERM + 500ms SIGKILL timeout, process-group isolation (`Setpgid`), semaphore-bounded concurrency (cap 4), and receive the event as JSON on stdin.

- **`internal/daemon/hooks/`** — EventBus, HookRunner, event constants, payload builders, YAML config with atomic write-via-rename
- **Daemon wiring** — emits events from sync scheduler, murmur relay, session upload, and daemon lifecycle
- **CLI** — `ox hooks list/add/test/log` for managing hooks; `ox agent hooks` as canonical path for git/CI hooks
- **Reliability** — `sync.RWMutex` on runner hooks, `defer/recover` in dispatch, process-group signals, `io.Discard` on stdout/stderr
- **~50 edge-case tests** covering stuck processes, signal handling, goroutine leaks, concurrent dispatch, malformed config, and payload edge cases

```mermaid
graph LR
    A[Daemon Events] --> B[EventBus]
    B --> C[HookRunner]
    C --> D[sh -c hook.Command]
    D -->|stdin| E[Event JSON]
    D -->|env| F[OX_EVENT + OX_EVENT_TIMESTAMP]
    C -->|timeout| G[SIGTERM → SIGKILL]
```

## Test plan

- [ ] `make lint` passes (0 issues)
- [ ] `make test` passes (12,893 tests)
- [ ] `go test -race ./internal/daemon/hooks/...` clean
- [ ] `ox hooks add '*' 'echo $OX_EVENT'` followed by daemon restart dispatches events
- [ ] `ox hooks list --json` shows registered hooks
- [ ] `ox hooks test murmur.received` fires synthetic event

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced hook management system with commands to add, list, test, and view logs for daemon event hooks
  * Added event emission for daemon lifecycle events, including session uploads, sync operations, and murmur notifications

* **Documentation**
  * Added team context setup guidance for agent sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->