### PR TITLE
fix(claws): clarify openclaw ox install choice and block brew

### DIFF
--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -180,16 +180,40 @@ cat ~/.openclaw/memory/sageox-ox-install.json 2>/dev/null
 `auto_update == true`, update ox before proceeding (see "Updating ox from
 git" below).
 
-**If the file does not exist:** prompt the user to choose an install method:
+**If the file does not exist:** STOP. This is a one-time decision that
+gets persisted to disk and affects every future run of this skill — the
+user must own it. You **MUST** ask the user which method they want and
+**wait for their response**. Do not pick a default. Do not guess. Do not
+run any install commands yet. Present both options verbatim, then stop
+and wait:
 
-> How do you want to install the `ox` CLI?
+> How do you want to install the `ox` CLI? Pick one — I won't choose for
+> you, because this gets saved to
+> `~/.openclaw/memory/sageox-ox-install.json` and reused every run.
 >
-> 1. **curl install** (recommended) — downloads the latest release tarball
->    and installs the pinned binary. Fastest, no build toolchain needed.
-> 2. **Build from git source** — clones `github.com/sageox/ox` and builds
->    with `make install`. Gives you latest `main`. Requires Go ≥ 1.24.
+> 1. **curl install** — runs the official install script from a pinned
+>    release tag. Fastest, no build toolchain needed. Lands in
+>    `/usr/local/bin` (Linux) or `/opt/homebrew/bin` or `/usr/local/bin`
+>    (macOS). No auto-update; you'll re-run this flow to upgrade.
+> 2. **Build from git source** — clones `github.com/sageox/ox` to a
+>    directory you choose and builds with `make install`. Gives you
+>    latest `main`, and optionally auto-updates on every run. Requires
+>    Go ≥ 1.24.
+>
+> Reply `1` or `2`.
 
-Ask the user to pick 1 or 2. Save the choice to the memory file.
+**Blocking rule:** do not proceed until the user replies with `1` or
+`2`. If they say "you choose", "whatever", or try to skip, ask again and
+explain that this is a persisted choice. Once they answer, save it to
+the memory file.
+
+**Do not install `ox` via Homebrew or any package manager** (e.g.
+`brew install sageox/tap/ox`, `apt`, `dnf`, `pacman`). The tap exists
+for general use but is not supported inside OpenClaw skills — only
+`curl` and `git source` are. These two options work the same on macOS
+and Linux; pick based on whether the user wants a pinned release or
+`main` with optional auto-update, **not** based on their operating
+system.
 
 ##### Option 1: curl install
 

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -198,16 +198,40 @@ cat ~/.openclaw/memory/sageox-ox-install.json 2>/dev/null
 `auto_update == true`, update ox before proceeding (see "Updating ox from
 git" below).
 
-**If the file does not exist:** prompt the user to choose an install method:
+**If the file does not exist:** STOP. This is a one-time decision that
+gets persisted to disk and affects every future run of this skill — the
+user must own it. You **MUST** ask the user which method they want and
+**wait for their response**. Do not pick a default. Do not guess. Do not
+run any install commands yet. Present both options verbatim, then stop
+and wait:
 
-> How do you want to install the `ox` CLI?
+> How do you want to install the `ox` CLI? Pick one — I won't choose for
+> you, because this gets saved to
+> `~/.openclaw/memory/sageox-ox-install.json` and reused every run.
 >
-> 1. **curl install** (recommended) — downloads the latest release tarball
->    and installs the pinned binary. Fastest, no build toolchain needed.
-> 2. **Build from git source** — clones `github.com/sageox/ox` and builds
->    with `make install`. Gives you latest `main`. Requires Go ≥ 1.24.
+> 1. **curl install** — runs the official install script from a pinned
+>    release tag. Fastest, no build toolchain needed. Lands in
+>    `/usr/local/bin` (Linux) or `/opt/homebrew/bin` or `/usr/local/bin`
+>    (macOS). No auto-update; you'll re-run this flow to upgrade.
+> 2. **Build from git source** — clones `github.com/sageox/ox` to a
+>    directory you choose and builds with `make install`. Gives you
+>    latest `main`, and optionally auto-updates on every run. Requires
+>    Go ≥ 1.24.
+>
+> Reply `1` or `2`.
 
-Ask the user to pick 1 or 2. Save the choice to the memory file.
+**Blocking rule:** do not proceed until the user replies with `1` or
+`2`. If they say "you choose", "whatever", or try to skip, ask again and
+explain that this is a persisted choice. Once they answer, save it to
+the memory file.
+
+**Do not install `ox` via Homebrew or any package manager** (e.g.
+`brew install sageox/tap/ox`, `apt`, `dnf`, `pacman`). The tap exists
+for general use but is not supported inside OpenClaw skills — only
+`curl` and `git source` are. These two options work the same on macOS
+and Linux; pick based on whether the user wants a pinned release or
+`main` with optional auto-update, **not** based on their operating
+system.
 
 ##### Option 1: curl install
 


### PR DESCRIPTION
## Summary
- **Force the agent to actually ask.** The `sageox-distill` and `sageox-summary` skills told the agent to "prompt the user to choose an install method" and labeled curl as `(recommended)` — agents were reading that as permission to silently pick curl and persist the choice to `~/.openclaw/memory/sageox-ox-install.json`. Replaced with a hard blocking gate: `STOP` / `MUST` / `wait for their response` / `Do not pick a default`, plus an explicit "Reply `1` or `2`" prompt and a follow-up rule for handling "you choose" / "whatever" answers.
- **Block Homebrew (and other package managers) for `ox`.** A `sageox/tap/ox` tap exists for general use, but it's not supported inside OpenClaw skills — the per-skill PATH / `~/.openclaw/.env` flow assumes curl or git-source installs. Added an explicit prohibition covering `brew`, `apt`, `dnf`, `pacman`.
- **Platform-agnostic framing.** Added a note that the two options work the same on macOS and Linux; the choice should be based on pinned-release vs `main` with auto-update, not OS.

No frontmatter, no schema, no skill behavior changed beyond the install setup prose. Both SKILL.md files get the same edit.

## Test plan
- [x] `python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw/sageox-distill claws/openclaw/sageox-summary` → PASS, 0 critical, 0 warnings
- [ ] Exercise the skill flow end-to-end in OpenClaw with a fresh `~/.openclaw/memory/` (no `sageox-ox-install.json`) and confirm the agent stops and asks rather than defaulting to curl
- [ ] Verify behavior when the user replies "you choose" — agent should re-ask, not pick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation flow to require explicit user input confirmation before proceeding.
  * Clarified installation method options with specifics on pinned releases versus auto-update behavior and installation destinations.
  * Added stricter validation rules preventing skipped or deferred choices.
  * Added explicit prohibition on alternative installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->