### PR TITLE
feat(distill): honor --quiet by suppressing stdout

### DIFF
--- a/cmd/ox/memory_distill.go
+++ b/cmd/ox/memory_distill.go
@@ -34,6 +34,9 @@ When run by an AI coworker, it delegates to 'ox agent <id> distill'.`,
 	RunE: runMemoryDistill,
 }
 
+// runMemoryDistill is the RunE handler for `ox memory distill`. It prints a
+// short explainer when invoked by a human (no agent context detected) and
+// otherwise delegates to runAgentDistill to perform the real work.
 func runMemoryDistill(cmd *cobra.Command, _ []string) error {
 	if errMsg := agentx.RequireAgent("ox memory distill"); errMsg != "" {
 		if !distillQuiet() {

--- a/cmd/ox/memory_distill.go
+++ b/cmd/ox/memory_distill.go
@@ -36,20 +36,29 @@ When run by an AI coworker, it delegates to 'ox agent <id> distill'.`,
 
 func runMemoryDistill(cmd *cobra.Command, _ []string) error {
 	if errMsg := agentx.RequireAgent("ox memory distill"); errMsg != "" {
-		fmt.Fprintln(cmd.OutOrStdout(), "Memory distillation is an automated process run by AI coworkers.")
-		fmt.Fprintln(cmd.OutOrStdout(), "")
-		fmt.Fprintln(cmd.OutOrStdout(), "How it works:")
-		fmt.Fprintln(cmd.OutOrStdout(), "  1. AI coworkers record observations via 'ox memory put'")
-		fmt.Fprintln(cmd.OutOrStdout(), "  2. Observations accumulate in the team context")
-		fmt.Fprintln(cmd.OutOrStdout(), "  3. Periodically, an AI coworker runs 'ox agent <id> distill'")
-		fmt.Fprintln(cmd.OutOrStdout(), "     to aggregate observations into team memory summaries")
-		fmt.Fprintln(cmd.OutOrStdout(), "")
-		fmt.Fprintln(cmd.OutOrStdout(), "This happens automatically — no human action needed.")
+		if !distillQuiet() {
+			fmt.Fprintln(cmd.OutOrStdout(), "Memory distillation is an automated process run by AI coworkers.")
+			fmt.Fprintln(cmd.OutOrStdout(), "")
+			fmt.Fprintln(cmd.OutOrStdout(), "How it works:")
+			fmt.Fprintln(cmd.OutOrStdout(), "  1. AI coworkers record observations via 'ox memory put'")
+			fmt.Fprintln(cmd.OutOrStdout(), "  2. Observations accumulate in the team context")
+			fmt.Fprintln(cmd.OutOrStdout(), "  3. Periodically, an AI coworker runs 'ox agent <id> distill'")
+			fmt.Fprintln(cmd.OutOrStdout(), "     to aggregate observations into team memory summaries")
+			fmt.Fprintln(cmd.OutOrStdout(), "")
+			fmt.Fprintln(cmd.OutOrStdout(), "This happens automatically — no human action needed.")
+		}
 		return nil
 	}
 
 	// running in agent context — delegate to the agent distill flow
 	return runAgentDistill(nil, cmd)
+}
+
+// distillQuiet reports whether --quiet is in effect for this invocation.
+// Under --quiet, distill emits no stdout — only error conditions reach stderr
+// via the RunE return path handled in main.printError.
+func distillQuiet() bool {
+	return cfg != nil && cfg.Quiet
 }
 
 // distillState tracks what has been distilled to avoid reprocessing.
@@ -97,7 +106,9 @@ func runAgentDistill(inst *agentinstance.Instance, cmd *cobra.Command) error {
 	}
 
 	if len(observations) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to distill — no pending observations")
+		if !distillQuiet() {
+			fmt.Fprintln(cmd.OutOrStdout(), "Nothing to distill — no pending observations")
+		}
 		return nil
 	}
 
@@ -155,9 +166,11 @@ func runAgentDistill(inst *agentinstance.Instance, cmd *cobra.Command) error {
 		slog.Warn("failed to save distill state", "error", err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Distilled %d observations\n", len(observations))
-	if resp.Summary != "" {
-		fmt.Fprintf(cmd.OutOrStdout(), "Summary: %s\n", resp.Summary)
+	if !distillQuiet() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Distilled %d observations\n", len(observations))
+		if resp.Summary != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "Summary: %s\n", resp.Summary)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- `ox memory distill` (and the `ox agent <id> distill` delegation) now honors the global `--quiet` / `-q` flag.
- Previously the flag parsed without error but was a no-op: the command still unconditionally printed the human explainer, "Nothing to distill", "Distilled N observations", and "Summary: ..." to stdout.
- Under `--quiet`, all stdout is suppressed. Error conditions still reach stderr via `RunE` returns handled by `main.printError` — matching the flag's advertised behavior ("suppress non-error output").

## Implementation

Single-file change in `cmd/ox/memory_distill.go`:
- Added a nil-safe `distillQuiet()` helper that reads `cfg.Quiet` (populated by the root `PersistentPreRunE` from the global flag).
- Wrapped the three stdout print sites behind `if !distillQuiet()`:
  - The non-agent human explainer branch in `runMemoryDistill`
  - The "Nothing to distill" short-circuit in `runAgentDistill`
  - The post-API "Distilled N" / "Summary:" success prints

Error returns are unchanged — cobra has `SilenceErrors=true` on the root, and `main.printError` writes them to `os.Stderr`, so `--quiet` naturally ends up with "stderr for errors only."

## Test plan

- [x] `go build ./cmd/ox/` — clean
- [x] `go vet ./cmd/ox/` — clean
- [x] `gofmt` — clean
- [x] Existing distill tests pass (`TestScanPending*`, `TestParseObservation*`, `TestDistillState*`)
- [ ] Manual: `ox memory distill --quiet` emits nothing to stdout when not in an agent context
- [ ] Manual: `ox agent <id> distill --quiet` emits nothing on the empty-observations and success paths; errors still surface on stderr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a quiet mode for memory distillation that suppresses user-facing progress and summary messages while preserving API calls, state saving, and error handling. Messages about "nothing to distill" and final summaries are now only shown when not in quiet mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->