### PR TITLE
fix(claws): trim openclaw skill prose, adopt distill --quiet

### DIFF
--- a/claws/openclaw/sageox-distill/README.md
+++ b/claws/openclaw/sageox-distill/README.md
@@ -36,7 +36,6 @@ Once installed, ask your OpenClaw agent things like:
 
 - "Distill all my SageOx repos."
 - "Add `~/src/sageox/ox` to the distill manifest."
-- "Schedule distillation every 4 hours."
 - "Show me the distill repos."
 - "Switch ox install method." (re-runs the curl-vs-git setup)
 - "Update ox now." (forces a git pull + rebuild on the git install path)

--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -37,107 +37,29 @@ Do not proceed until the user has fixed it.
 
 ### 1. Environment variables
 
-Verify `ANTHROPIC_API_KEY` is set and non-empty in the skill's process
-environment:
+This skill declares `ANTHROPIC_API_KEY` in `primaryEnv`, so OpenClaw
+injects it from per-skill config or shell env before the skill runs.
+Verify it landed:
 
 ```bash
 test -n "$ANTHROPIC_API_KEY"
 ```
 
-This skill declares `ANTHROPIC_API_KEY` in `requires.env` and `primaryEnv`,
-which means OpenClaw will inject it from per-skill config when configured.
-Never echo the key value — only confirm its presence.
+Never echo the key value — only confirm its presence. If the check
+fails, point the user at the setup guide and stop:
+<https://github.com/sageox/ox/blob/main/claws/openclaw/README.md#environment-setup>
+(covers per-skill `apiKey`, shell env, the precedence rule, and
+sandboxed Docker runs).
 
-If the var is missing, tell the user one of the following options:
+### 2. Required binaries
 
-**Option A — Per-skill config in `~/.openclaw/openclaw.json` (recommended).**
-Lets the user use a different Anthropic key for this skill than for their
-host agent:
+`git`, `gh`, and `ox` are declared in the front matter's `requires.bins`,
+so OpenClaw checks them before running the skill. `gh` has a declarative
+brew install in the front matter; `git` and `ox` do not. If OpenClaw
+reports a missing bin, surface its message to the user and stop — except
+for `ox`, which has the interactive install flow in § 4 below.
 
-```json5
-{
-  skills: {
-    entries: {
-      "sageox-distill": {
-        apiKey: "sk-ant-..."
-        // or with a SecretRef:
-        // apiKey: { source: "env", provider: "default", id: "MY_SAGEOX_KEY" }
-      }
-    }
-  }
-}
-```
-
-OpenClaw injects this as `ANTHROPIC_API_KEY` into the skill's process
-environment for the duration of the run, then reverts it. Subprocesses
-spawned by the skill (`ox distill`, etc.) inherit it naturally.
-
-**Option B — Shell env / `~/.openclaw/.env`.** If the user is fine with the
-host agent and this skill sharing one Anthropic key, just export
-`ANTHROPIC_API_KEY` from the shell or add it to `~/.openclaw/.env`:
-
-```sh
-ANTHROPIC_API_KEY=sk-ant-...
-```
-
-**⚠️ Critical precedence rule:** OpenClaw injects the per-skill `apiKey`
-**only if `ANTHROPIC_API_KEY` is not already set** in its process
-environment. If the user's login shell exports it (e.g., from `~/.zshrc`),
-the host value passes through and the per-skill key is silently ignored.
-To verify before launching OpenClaw: `env | grep ANTHROPIC_API_KEY` should
-print nothing if Option A is in use.
-
-**Sandboxed runs (Docker).** Per-skill `apiKey` does NOT apply inside the
-sandbox — `process.env` is not inherited. For sandboxed sessions, configure
-`agents.defaults.sandbox.docker.env.ANTHROPIC_API_KEY` instead.
-
-### 2. Detect the operating system
-
-```bash
-uname -s
-```
-
-- `Darwin` → macOS
-- `Linux` → Linux
-
-Use the detected OS to choose install commands for any missing tools below.
-
-### 3. Required binaries
-
-Check each required binary is on the skill subprocess PATH:
-
-```bash
-command -v git
-command -v gh
-command -v ox
-```
-
-If any are missing, install them using the OS-appropriate commands in the
-next section.
-
-### 4. Installing missing tools
-
-#### Installing `git`
-
-- **macOS:** `brew install git` (Homebrew) or use the Xcode Command Line
-  Tools: `xcode-select --install`
-- **Linux (Debian/Ubuntu):** `sudo apt-get update && sudo apt-get install -y git`
-- **Linux (Fedora/RHEL):** `sudo dnf install -y git`
-- **Linux (Arch):** `sudo pacman -S --noconfirm git`
-- **Linux (Alpine):** `sudo apk add git`
-
-#### Installing `gh` (GitHub CLI)
-
-- **macOS:** `brew install gh`
-- **Linux (Debian/Ubuntu):** follow the apt instructions at
-  <https://github.com/cli/cli/blob/trunk/docs/install_linux.md>
-- **Linux (Fedora/RHEL):** `sudo dnf install -y gh`
-- **Linux (Arch):** `sudo pacman -S --noconfirm github-cli`
-- **Linux (Alpine):** `sudo apk add github-cli`
-
-After install, the user runs `gh auth login` once.
-
-#### Path validation rules
+### 3. Path validation rules
 
 Several steps below ask the user for a path (repo path, clone path) or
 read a path from a JSON state file. Before interpolating any such value
@@ -166,7 +88,7 @@ even though this skill writes them: the user (or a process running as
 the user) may have edited the file by hand or by another tool between
 runs. Re-validate every read.
 
-#### Installing `ox` — interactive setup
+### 4. Installing `ox` — interactive setup
 
 The `ox` CLI install method is a one-time choice stored in
 `~/.openclaw/memory/sageox-ox-install.json`. Check that file first:
@@ -215,7 +137,7 @@ and Linux; pick based on whether the user wants a pinned release or
 `main` with optional auto-update, **not** based on their operating
 system.
 
-##### Option 1: curl install
+#### Option 1: curl install
 
 Download and run the ox install script. The agent should print the source
 URL and a head/tail preview of the downloaded script before executing it,
@@ -268,7 +190,7 @@ EOF
 on PATH. If `command -v ox` still fails after install, ask the user to
 check their shell PATH.
 
-##### Option 2: build from git source
+#### Option 2: build from git source
 
 1. Verify Go ≥ 1.24 is installed:
 
@@ -357,14 +279,14 @@ check their shell PATH.
    restarted the skill. OpenClaw loads `.env` into the skill subprocess,
    so an updated PATH takes effect on the next invocation.
 
-##### Updating `ox` from git (auto-update flow)
+#### Updating `ox` from git (auto-update flow)
 
 On every subsequent run, if the memory file says
 `install_method == "git"` and `auto_update == true`:
 
 1. Read `clone_path` from `~/.openclaw/memory/sageox-ox-install.json`.
 2. **Re-validate** it against the Path validation rules in Prerequisites
-   § 4, including the additional clone-path checks (must be under
+   § 3, including the additional clone-path checks (must be under
    `$HOME`, must exist, must contain a `.git` subdirectory). The memory
    file is user-writable and may have been edited externally between
    runs — never trust persisted values without re-validation.
@@ -416,7 +338,7 @@ The manifest format is:
 - If the manifest does not exist, ask the user which repos to include. For
   each repo path provided:
   1. **Validate the path against the Path validation rules in
-     Prerequisites § 4.** Reject and re-prompt on failure.
+     Prerequisites § 3.** Reject and re-prompt on failure.
   2. Verify the directory exists.
   3. Verify `.sageox/config.json` exists (confirms `ox init` was run).
   4. Read `team_id` from `.sageox/config.json`. **Treat the value as
@@ -436,8 +358,7 @@ The manifest format is:
 
 ## Distill Pipeline
 
-When the user asks to distill (or when triggered by a cron job), run the
-following phases in order.
+When the user asks to distill, run the following phases in order.
 
 ### Phase 1: Sync and Index
 
@@ -497,47 +418,18 @@ injection or inherited from the host shell — see Prerequisites § 1), so
 `ox distill` picks it up naturally:
 
 ```bash
-ox distill --sync --layer daily --concurrency 3 --model sonnet
+ox distill --sync --layer daily --concurrency 3 --model sonnet --quiet
 ```
 
-Report the output of each distill run to the user. Include the team ID
-and which repo was used as the working directory.
-
-If a distill fails, report the error and continue with the next team.
-Do not abort the pipeline for a single team failure.
-
-## Scheduling
-
-When the user asks to schedule distillation:
-
-1. Create a cron job that runs the full distill pipeline (phases 1-3) at
-   the requested frequency.
-2. Suggest a default of every 4 hours if the user doesn't specify.
-3. Confirm the schedule with the user before creating it.
-
-Common schedules:
-
-- Every 4 hours: `0 */4 * * *`
-- Three times daily (morning, midday, evening): `0 8,12,18 * * *`
-- Every 2 hours during work hours: `0 */2 9-17 * * 1-5`
-
-The cron job must source `~/.openclaw/.env` before running (cron has a
-minimal environment by default). A typical crontab line:
-
-```cron
-0 */4 * * * set -a; . $HOME/.openclaw/.env; set +a; openclaw run sageox-distill
-```
-
-Adjust the invocation to match however OpenClaw runs skills on the
-user's system.
+`--quiet` suppresses non-error output, so a successful run prints
+nothing and a failed run prints only the error. If `ox distill` exits
+0, report `<team_id>: ok`. If it exits non-zero, report
+`<team_id>: failed — <first line of stderr>` and continue with the
+next team. Do not abort the pipeline for a single team failure.
 
 ## Output
 
-After each distill run, provide a brief status summary:
-
-- How many teams were processed
-- How many repos were synced and indexed
-- Any errors or warnings encountered
-- Whether the daemon sync completed or timed out
-
-Keep the output concise. The user can ask for details if needed.
+After all teams have run, print one line per team (`<team_id>: ok` or
+`<team_id>: failed — <reason>`) and nothing else. No preamble, no
+counts, no daemon-sync recap. If every team passed, a single `all ok`
+line is fine. The user can ask for details if they want them.

--- a/claws/openclaw/sageox-summary/README.md
+++ b/claws/openclaw/sageox-summary/README.md
@@ -35,7 +35,6 @@ specifically:
 Once installed, ask your OpenClaw agent things like:
 
 - "Give me the daily SageOx summary."
-- "Schedule a summary every morning at 9am."
 - "Switch ox install method." (re-runs the curl-vs-git setup)
 - "Update ox now." (forces a git pull + rebuild on the git install path)
 

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -42,120 +42,32 @@ and stop. Do not proceed until the user has fixed it.
 
 ### 1. Environment variables
 
-Verify `ANTHROPIC_API_KEY` is set and non-empty in the skill's process
-environment:
+This skill declares `ANTHROPIC_API_KEY` in `primaryEnv`, so OpenClaw
+injects it from per-skill config or shell env before the skill runs.
+Verify it landed:
 
 ```bash
 test -n "$ANTHROPIC_API_KEY"
 ```
 
-This skill declares `ANTHROPIC_API_KEY` in `requires.env` and `primaryEnv`,
-which means OpenClaw will inject it from per-skill config when configured.
-Never echo the key value — only confirm its presence.
+Never echo the key value — only confirm its presence. If the check
+fails, point the user at the setup guide and stop:
+<https://github.com/sageox/ox/blob/main/claws/openclaw/README.md#environment-setup>
+(covers per-skill `apiKey`, shell env, the precedence rule, and
+sandboxed Docker runs).
 
-If the var is missing, tell the user one of the following options:
+### 2. Required binaries
 
-**Option A — Per-skill config in `~/.openclaw/openclaw.json` (recommended).**
-Lets the user use a different Anthropic key for this skill than for their
-host agent:
+`ox`, `claude`, and `jq` are declared in the front matter's
+`requires.bins`, so OpenClaw checks them before running the skill.
+`claude` (npm) and `jq` (brew) have declarative installs in the front
+matter; `ox` does not. If OpenClaw reports a missing bin, surface its
+message to the user and stop — except for `ox`, which has the
+interactive install flow in § 4 below. `claude -p` reads
+`ANTHROPIC_API_KEY` from its process environment, so no `claude login`
+is required.
 
-```json5
-{
-  skills: {
-    entries: {
-      "sageox-summary": {
-        apiKey: "sk-ant-..."
-        // or with a SecretRef:
-        // apiKey: { source: "env", provider: "default", id: "MY_SAGEOX_KEY" }
-      }
-    }
-  }
-}
-```
-
-OpenClaw injects this as `ANTHROPIC_API_KEY` into the skill's process
-environment for the duration of the run, then reverts it. Subprocesses
-spawned by the skill (`claude -p`, etc.) inherit it naturally.
-
-**Option B — Shell env / `~/.openclaw/.env`.** If the user is fine with the
-host agent and this skill sharing one Anthropic key, just export
-`ANTHROPIC_API_KEY` from the shell or add it to `~/.openclaw/.env`:
-
-```sh
-ANTHROPIC_API_KEY=sk-ant-...
-```
-
-**⚠️ Critical precedence rule:** OpenClaw injects the per-skill `apiKey`
-**only if `ANTHROPIC_API_KEY` is not already set** in its process
-environment. If the user's login shell exports it (e.g., from `~/.zshrc`),
-the host value passes through and the per-skill key is silently ignored.
-To verify before launching OpenClaw: `env | grep ANTHROPIC_API_KEY` should
-print nothing if Option A is in use.
-
-**Sandboxed runs (Docker).** Per-skill `apiKey` does NOT apply inside the
-sandbox — `process.env` is not inherited. For sandboxed sessions, configure
-`agents.defaults.sandbox.docker.env.ANTHROPIC_API_KEY` instead.
-
-### 2. Detect the operating system
-
-```bash
-uname -s
-```
-
-- `Darwin` → macOS
-- `Linux` → Linux
-
-Use the detected OS to choose install commands for any missing tools below.
-
-### 3. Required binaries
-
-Check each required binary is on the skill subprocess PATH:
-
-```bash
-command -v ox
-command -v claude
-command -v jq
-```
-
-If any are missing, install them using the OS-appropriate commands in the
-next section.
-
-### 4. Installing missing tools
-
-#### Installing `jq`
-
-- **macOS:** `brew install jq`
-- **Linux (Debian/Ubuntu):** `sudo apt-get update && sudo apt-get install -y jq`
-- **Linux (Fedora/RHEL):** `sudo dnf install -y jq`
-- **Linux (Arch):** `sudo pacman -S --noconfirm jq`
-- **Linux (Alpine):** `sudo apk add jq`
-
-#### Installing `claude` (Claude Code CLI)
-
-Claude Code ships as an npm package and works the same on macOS and Linux:
-
-```bash
-npm install -g @anthropic-ai/claude-code
-```
-
-If `npm` is not installed:
-
-- **macOS:** `brew install node`
-- **Linux (Debian/Ubuntu):** `sudo apt-get install -y nodejs npm`
-- **Linux (Fedora/RHEL):** `sudo dnf install -y nodejs npm`
-- **Linux (Arch):** `sudo pacman -S --noconfirm nodejs npm`
-
-After installing the CLI, verify:
-
-```bash
-claude --version
-```
-
-This skill does **not** require `claude login` — `claude -p` reads
-`ANTHROPIC_API_KEY` from its process environment, which OpenClaw injects
-from per-skill config (or which the user supplies via shell env).
-
-#### Path validation rules
+### 3. Path validation rules
 
 Several steps below ask the user for a path (clone path) or read a path
 from a JSON state file. Before interpolating any such value into a shell
@@ -184,7 +96,7 @@ even though this skill writes them: the user (or a process running as
 the user) may have edited the file by hand or by another tool between
 runs. Re-validate every read.
 
-#### Installing `ox` — interactive setup
+### 4. Installing `ox` — interactive setup
 
 The `ox` CLI install method is a one-time choice stored in
 `~/.openclaw/memory/sageox-ox-install.json`. Check that file first:
@@ -233,7 +145,7 @@ and Linux; pick based on whether the user wants a pinned release or
 `main` with optional auto-update, **not** based on their operating
 system.
 
-##### Option 1: curl install
+#### Option 1: curl install
 
 Download and run the ox install script. The agent should print the source
 URL and a head/tail preview of the downloaded script before executing it,
@@ -286,7 +198,7 @@ EOF
 on PATH. If `command -v ox` still fails after install, ask the user to
 check their shell PATH.
 
-##### Option 2: build from git source
+#### Option 2: build from git source
 
 1. Verify Go ≥ 1.24 is installed:
 
@@ -375,14 +287,14 @@ check their shell PATH.
    restarted the skill. OpenClaw loads `.env` into the skill subprocess,
    so an updated PATH takes effect on the next invocation.
 
-##### Updating `ox` from git (auto-update flow)
+#### Updating `ox` from git (auto-update flow)
 
 On every subsequent run, if the memory file says
 `install_method == "git"` and `auto_update == true`:
 
 1. Read `clone_path` from `~/.openclaw/memory/sageox-ox-install.json`.
 2. **Re-validate** it against the Path validation rules in Prerequisites
-   § 4, including the additional clone-path checks (must be under
+   § 3, including the additional clone-path checks (must be under
    `$HOME`, must exist, must contain a `.git` subdirectory). The memory
    file is user-writable and may have been edited externally between
    runs — never trust persisted values without re-validation.
@@ -444,8 +356,7 @@ it.
 
 ## Summary Pipeline
 
-When the user asks for a summary (or when triggered by a cron job), run
-the following steps in order.
+When the user asks for a summary, run the following steps in order.
 
 ### Step 1: Load the Manifest and Endpoint
 
@@ -541,35 +452,6 @@ that pull in many daily files. If it fails, surface the error to the user.
 
 Return Claude's stdout to the user directly. It is already formatted for
 Slack mrkdwn. Do not reformat or annotate — just show it.
-
-## Scheduling
-
-When the user asks to schedule summaries:
-
-1. Suggest a default of daily at 9am local time if the user doesn't
-   specify.
-2. Confirm the schedule with the user before creating it.
-3. Create a cron job that runs this skill's summary pipeline.
-
-Common schedules:
-
-- Daily at 9am: `0 9 * * *`
-- Weekdays at 8am: `0 8 * * 1-5`
-- Twice daily (morning + afternoon): `0 9,16 * * 1-5`
-
-If the user also has a distill schedule, suggest running summaries on a
-schedule that trails the distill by at least 30 minutes so the daily
-files are up to date before summarization.
-
-The cron job must source `~/.openclaw/.env` before running (cron has a
-minimal environment by default). A typical crontab line:
-
-```cron
-0 9 * * * set -a; . $HOME/.openclaw/.env; set +a; openclaw run sageox-summary
-```
-
-Adjust the invocation to match however OpenClaw runs skills on the
-user's system.
 
 ## Output
 


### PR DESCRIPTION
## Summary

- **Remove scheduling sections** from both skills — openclaw cronjobs handle this now, so the skills don't need to teach crontab syntax.
- **Slim env var + bin install prose** — `primaryEnv` and `requires.bins`/`install` are declared in the front matter, so the body defers to those. The Anthropic key setup now points at the shared `claws/openclaw/README.md#environment-setup` (absolute URL, since sibling READMEs aren't shipped in the published skill bundle). The `ox` interactive install flow stays put — openclaw can't model curl-vs-git-clone + the memory-file state machine.
- **Adopt `ox distill --quiet`** in `sageox-distill` and trim the pipeline output to one line per team (`<team_id>: ok` / `<team_id>: failed — <reason>`, or `all ok` when everything passes).

Net: 56 insertions, 284 deletions across `SKILL.md` + `README.md` for both skills. `clawhub-skill-lint` passes both clean (0 critical / 0 warn).

## Test plan

- [x] `python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw` — both skills PASS
- [ ] Visual review of the two `SKILL.md` files — numbering flows § 1 → 5, cross-refs (`Prerequisites § 3`, `§ 4 below`) resolve
- [ ] Load each skill into a real OpenClaw and confirm the `ANTHROPIC_API_KEY` check + bin check still guard correctly
- [ ] Run `sageox-distill` end-to-end and verify the new terse pass/fail output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed scheduled execution instructions (cron-based scheduling) from distillation and summary skills.
  * Simplified setup documentation by consolidating environment configuration and binary prerequisite guidance into streamlined sections.
  * Updated cross-references and section numbering for consistency.

* **Changes**
  * Modified distillation output reporting to display minimal per-team status lines instead of verbose summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->