### PR TITLE
fix(agentinstance): fix flaky TestGetExpired tempdir cleanup race

### DIFF
--- a/internal/agentinstance/store.go
+++ b/internal/agentinstance/store.go
@@ -105,6 +105,7 @@ type Store struct {
 	instancesPath string
 	userSlug      string
 	mu            sync.RWMutex
+	pruneWG       sync.WaitGroup // tracks background Prune goroutines launched by Get/List
 }
 
 // NewStore initializes an instance store for the given project root.
@@ -303,7 +304,7 @@ func (s *Store) Get(agentID string) (*Instance, error) {
 
 	// trigger compaction if needed after read
 	if s.shouldCompact(totalCount, expiredCount) {
-		go s.Prune()
+		s.launchBackgroundPrune()
 	}
 
 	// scan backwards (newest first) for the matching agent_id
@@ -326,10 +327,20 @@ func (s *Store) List() ([]*Instance, error) {
 
 	// trigger compaction if needed
 	if s.shouldCompact(totalCount, expiredCount) {
-		go s.Prune()
+		s.launchBackgroundPrune()
 	}
 
 	return instances, nil
+}
+
+// launchBackgroundPrune fires Prune() in a goroutine and tracks it on pruneWG
+// so callers (and tests) can wait for in-flight compactions to complete.
+func (s *Store) launchBackgroundPrune() {
+	s.pruneWG.Add(1)
+	go func() {
+		defer s.pruneWG.Done()
+		_, _ = s.Prune()
+	}()
 }
 
 // Count returns the number of active instances

--- a/internal/agentinstance/store_test.go
+++ b/internal/agentinstance/store_test.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewStoreForUser(t *testing.T) {
@@ -109,12 +107,7 @@ func TestGetNotFound(t *testing.T) {
 }
 
 func TestGetExpired(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	store, err := NewStoreForUser(tmpDir, "testuser")
-	if err != nil {
-		t.Fatalf("failed to create store: %v", err)
-	}
+	store := newTestStore(t)
 
 	inst := &Instance{
 		AgentID:         "OxOld1",
@@ -128,16 +121,9 @@ func TestGetExpired(t *testing.T) {
 		t.Fatalf("failed to add instance: %v", err)
 	}
 
-	_, err = store.Get("OxOld1")
-	if err == nil {
+	if _, err := store.Get("OxOld1"); err == nil {
 		t.Error("expected error for expired instance")
 	}
-
-	// Get triggers background compaction via go s.Prune(); wait for it
-	// to finish so t.TempDir() cleanup doesn't race with it.
-	require.Eventually(t, func() bool {
-		return store.Count() == 0
-	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestList(t *testing.T) {
@@ -487,11 +473,9 @@ func newTestStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
 	}
-	t.Cleanup(func() {
-		// remove lock/tmp files that background Prune() goroutines may create,
-		// which would otherwise race with t.TempDir() cleanup
-		os.RemoveAll(filepath.Dir(store.instancesPath))
-	})
+	// Get/List fire go s.Prune() which creates flock/tmp files in the temp
+	// dir; wait for them to finish so t.TempDir() cleanup doesn't race.
+	t.Cleanup(func() { store.pruneWG.Wait() })
 	return store
 }
 
@@ -772,12 +756,6 @@ func TestListFiltersExpired(t *testing.T) {
 	if list[0].AgentID != "OxLive" {
 		t.Errorf("expected OxLive, got %q", list[0].AgentID)
 	}
-
-	// background compaction may fire; wait for it so t.TempDir() cleanup
-	// doesn't race with the Prune goroutine.
-	require.Eventually(t, func() bool {
-		return store.Count() == 1
-	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestShouldCompact(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Root cause**: `Store.Get()` / `Store.List()` fire `go s.Prune()` whenever compaction thresholds are hit. The goroutine creates flock + `.tmp` files in the test temp dir. `TestGetExpired` and `TestListFiltersExpired` tried to wait for the goroutine using `require.Eventually` on `store.Count()`, but `Count()` already filters expired entries in `readInstances` — so it returns the expected value *immediately* without ever waiting for the background Prune. The goroutine then races with `t.TempDir()` cleanup, producing `unlinkat .../.sageox/agent_instances/testuser: directory not empty` (seen on PR #495 CI).
- **Fix**: Add a `sync.WaitGroup` to `Store` and route the background Prune through a new `launchBackgroundPrune()` helper that tracks Add/Done. Tests wait on `store.pruneWG.Wait()` in the `newTestStore` cleanup, which runs before `t.TempDir()` removal.
- **Test cleanup**: `TestGetExpired` now uses the `newTestStore` helper (instead of an inline store with a broken `require.Eventually`), and `TestListFiltersExpired` drops its own broken `Eventually` workaround — the helper's deterministic wait covers both.

No production-behavior change: Prune is still fire-and-forget from the caller's perspective; the waitgroup only exposes a handle for orderly shutdown and tests.

## Why not part of PR #495

PR #495 is scoped to openclaw skill prose changes. This flake surfaces in the full test matrix but is unrelated to the openclaw edits — tracked as its own fix.

## Test plan

- [x] `go test -race -count=50 -run 'TestGetExpired|TestListFiltersExpired' ./internal/agentinstance/` — 50 runs clean
- [x] `go test -race -count=20 ./internal/agentinstance/` — full package 20x clean
- [x] `make lint` — 0 issues
- [ ] CI green on this branch

## Known adjacent flake (not fixed here)

`make test` also surfaced an intermittent `internal/session/TestCleanupStaleScores_RemovesInactive` failure (`expected 2, actual 5`). That's a separate parallel-test contamination issue — the test's `CleanupStaleScores` sees leftover score files from sibling tests. Runs clean in isolation (`-count=5`). Worth filing as its own bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background maintenance operation handling to ensure proper synchronization and graceful resource cleanup during shutdown, preventing potential race conditions and resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->