### PR TITLE
feat(auth): server-side token validation + twinapi digital twin

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -371,7 +371,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	capturePrior := buildCapturePriorGuidance(agentID)
 
 	// check auth status for attribution warning
-	isLoggedIn, _ := auth.IsAuthCredentialValid()
+	isLoggedIn, _ := auth.IsAuthCredentialValidForEndpoint(projectEndpoint)
 
 	// check for .needs-doctor-agent marker
 	needsDoctorAgent := doctor.NeedsDoctorAgent(projectRoot)

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -311,7 +311,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 
 	// check if user is authenticated — degraded mode if not (recording continues locally)
 	if auth.IsAuthRequired() {
-		authenticated, authErr := auth.IsAuthenticatedForEndpoint(projectEndpoint)
+		authenticated, authErr := auth.IsAuthCredentialValidForEndpoint(projectEndpoint)
 		if !authenticated {
 			endpointSlug := endpoint.NormalizeSlug(projectEndpoint)
 
@@ -371,7 +371,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	capturePrior := buildCapturePriorGuidance(agentID)
 
 	// check auth status for attribution warning
-	isLoggedIn, _ := auth.IsAuthenticated()
+	isLoggedIn, _ := auth.IsAuthCredentialValid()
 
 	// check for .needs-doctor-agent marker
 	needsDoctorAgent := doctor.NeedsDoctorAgent(projectRoot)

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -619,7 +619,7 @@ func checkGitRepoPaths(fix bool) checkResult {
 			sageoxDir := filepath.Join(gitRoot, ".sageox")
 			if _, err := os.Stat(sageoxDir); err == nil {
 				// .sageox exists - check if authenticated
-				if authenticated, _ := auth.IsAuthCredentialValid(); authenticated {
+				if authenticated, _ := auth.IsAuthenticatedForEndpoint(endpoint.GetForProject(gitRoot)); authenticated {
 					// recently initialized? daemon may not have synced yet
 					if isRecentlyInitialized(gitRoot) {
 						return InfoCheck("git repo paths", "repos syncing",

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -619,7 +619,7 @@ func checkGitRepoPaths(fix bool) checkResult {
 			sageoxDir := filepath.Join(gitRoot, ".sageox")
 			if _, err := os.Stat(sageoxDir); err == nil {
 				// .sageox exists - check if authenticated
-				if authenticated, _ := auth.IsAuthenticated(); authenticated {
+				if authenticated, _ := auth.IsAuthCredentialValid(); authenticated {
 					// recently initialized? daemon may not have synced yet
 					if isRecentlyInitialized(gitRoot) {
 						return InfoCheck("git repo paths", "repos syncing",

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -392,14 +392,21 @@ func runInit() error {
 	} else {
 		// fetch teams from API to determine if selection is needed
 		teamClient := api.NewRepoClient()
-		if token, err := auth.EnsureValidToken(300); err == nil && token != nil && token.AccessToken != "" {
+		currentEP := endpoint.Get()
+		token, tokenErr := auth.EnsureValidToken(300)
+		if tokenErr != nil {
+			slog.Debug("token ensure failed after auth gate passed", "endpoint", currentEP, "error", tokenErr)
+		}
+		if token != nil && token.AccessToken != "" {
 			teamClient.WithAuthToken(token.AccessToken)
+		} else {
+			slog.Warn("no usable token for team fetch despite passing auth gate", "endpoint", currentEP, "token_err", tokenErr)
 		}
 
 		reposResp, err := teamClient.GetRepos()
 		if err != nil {
 			slog.Debug("failed to fetch teams", "error", err)
-			cli.PrintWarning(fmt.Sprintf("Could not fetch teams: %v", err))
+			cli.PrintWarning(fmt.Sprintf("Could not fetch teams from %s: %v", endpoint.NormalizeSlug(currentEP), err))
 			fmt.Println()
 			if !cli.ConfirmYesNo("Continue without team selection? (a new team may be created)", false) {
 				return fmt.Errorf("team selection canceled")

--- a/cmd/ox/login.go
+++ b/cmd/ox/login.go
@@ -255,7 +255,7 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 	// check if already authenticated for this endpoint
 	// If token refresh fails, treat as unauthenticated and proceed with login
 	// (the user is explicitly trying to log in, so a refresh failure shouldn't block them)
-	authenticated, err := auth.IsAuthenticatedForEndpoint(currentEndpoint)
+	authenticated, err := auth.IsAuthCredentialValidForEndpoint(currentEndpoint)
 	if err != nil {
 		slog.Debug("auth check failed, proceeding with login", "error", err)
 		authenticated = false

--- a/cmd/ox/login_test.go
+++ b/cmd/ox/login_test.go
@@ -47,7 +47,7 @@ func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
 				"expires_in": 900,
 				"interval": 5
 			}`))
-		case "/api/auth/device/token":
+		case "/api/v1/device/token":
 			// Poll endpoint — return "authorization_pending" to let the
 			// flow terminate with a context timeout rather than spinning
 			w.Header().Set("Content-Type", "application/json")

--- a/cmd/ox/login_test.go
+++ b/cmd/ox/login_test.go
@@ -26,7 +26,7 @@ import (
 // entirely.
 func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
 	// Mock server: return 404 on /oauth2/token (refresh) and 200 on
-	// /api/auth/device/code (device flow) so we can detect that login
+	// /api/v1/device/code (device flow) so we can detect that login
 	// proceeded past the refresh failure.
 	var deviceCodeRequested atomic.Bool
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,7 +34,7 @@ func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
 		case "/oauth2/token":
 			// Simulate the 404 that triggered the original bug
 			w.WriteHeader(http.StatusNotFound)
-		case "/api/auth/device/code":
+		case "/api/v1/device/code":
 			deviceCodeRequested.Store(true)
 			// Return a valid device code response so the flow proceeds
 			w.Header().Set("Content-Type", "application/json")

--- a/cmd/ox/login_test.go
+++ b/cmd/ox/login_test.go
@@ -26,7 +26,7 @@ import (
 // entirely.
 func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
 	// Mock server: return 404 on /oauth2/token (refresh) and 200 on
-	// /api/v1/device/code (device flow) so we can detect that login
+	// /api/auth/device/code (device flow) so we can detect that login
 	// proceeded past the refresh failure.
 	var deviceCodeRequested atomic.Bool
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,7 +34,7 @@ func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
 		case "/oauth2/token":
 			// Simulate the 404 that triggered the original bug
 			w.WriteHeader(http.StatusNotFound)
-		case "/api/v1/device/code":
+		case "/api/auth/device/code":
 			deviceCodeRequested.Store(true)
 			// Return a valid device code response so the flow proceeds
 			w.Header().Set("Content-Type", "application/json")

--- a/cmd/ox/murmur_list.go
+++ b/cmd/ox/murmur_list.go
@@ -370,7 +370,7 @@ func collectMurmurDiagnostics(projectRoot string) *murmurListDiagnostic {
 
 	// check auth
 	ep := endpoint.GetForProject(projectRoot)
-	authenticated, _ := auth.IsAuthenticatedForEndpoint(ep)
+	authenticated, _ := auth.IsAuthCredentialValidForEndpoint(ep)
 	diag.Authenticated = authenticated
 
 	// check ledger

--- a/cmd/ox/root.go
+++ b/cmd/ox/root.go
@@ -414,9 +414,9 @@ func getContextualHighlight(cmdName string) *commandHighlight {
 	// check auth: use project-specific endpoint if available, otherwise default
 	var isLoggedIn bool
 	if projectEndpoint := endpoint.GetForProject(gitRoot); projectEndpoint != "" {
-		isLoggedIn, _ = auth.IsAuthenticatedForEndpoint(projectEndpoint)
+		isLoggedIn, _ = auth.IsAuthCredentialValidForEndpoint(projectEndpoint)
 	} else {
-		isLoggedIn, _ = auth.IsAuthenticated()
+		isLoggedIn, _ = auth.IsAuthCredentialValid()
 	}
 
 	switch cmdName {

--- a/cmd/ox/session_upload_test.go
+++ b/cmd/ox/session_upload_test.go
@@ -229,7 +229,8 @@ func TestSessionStart_NoOAuthGate_RegressionTest(t *testing.T) {
 	// deliberately do NOT save any auth token — simulates expired/missing OAuth
 
 	// verify auth is indeed missing
-	authenticated, _ := auth.IsAuthCredentialValid()
+	authenticated, err := auth.IsAuthCredentialValid()
+	require.NoError(t, err, "precondition check should not error")
 	require.False(t, authenticated, "precondition: must have no valid auth token")
 
 	inst := &agentinstance.Instance{

--- a/cmd/ox/session_upload_test.go
+++ b/cmd/ox/session_upload_test.go
@@ -229,7 +229,7 @@ func TestSessionStart_NoOAuthGate_RegressionTest(t *testing.T) {
 	// deliberately do NOT save any auth token — simulates expired/missing OAuth
 
 	// verify auth is indeed missing
-	authenticated, _ := auth.IsAuthenticated()
+	authenticated, _ := auth.IsAuthCredentialValid()
 	require.False(t, authenticated, "precondition: must have no valid auth token")
 
 	inst := &agentinstance.Instance{

--- a/internal/auth/constants.go
+++ b/internal/auth/constants.go
@@ -9,7 +9,7 @@ var DefaultScopes = []string{"user:profile", "sageox:write"}
 // Device Flow endpoints (RFC 8628)
 const (
 	DeviceCodeEndpoint  = "/api/auth/device/code"  //nolint:gosec // not a credential
-	DeviceTokenEndpoint = "/api/auth/device/token" //nolint:gosec // not a credential
+	DeviceTokenEndpoint = "/api/v1/device/token" //nolint:gosec // not a credential
 	UserInfoEndpoint    = "/oauth2/userinfo"
 )
 

--- a/internal/auth/constants.go
+++ b/internal/auth/constants.go
@@ -8,7 +8,7 @@ var DefaultScopes = []string{"user:profile", "sageox:write"}
 
 // Device Flow endpoints (RFC 8628)
 const (
-	DeviceCodeEndpoint  = "/api/v1/device/code"  //nolint:gosec // not a credential
+	DeviceCodeEndpoint  = "/api/auth/device/code"  //nolint:gosec // not a credential
 	DeviceTokenEndpoint = "/api/v1/device/token" //nolint:gosec // not a credential
 	UserInfoEndpoint    = "/oauth2/userinfo"
 )

--- a/internal/auth/constants.go
+++ b/internal/auth/constants.go
@@ -8,7 +8,7 @@ var DefaultScopes = []string{"user:profile", "sageox:write"}
 
 // Device Flow endpoints (RFC 8628)
 const (
-	DeviceCodeEndpoint  = "/api/auth/device/code"  //nolint:gosec // not a credential
+	DeviceCodeEndpoint  = "/api/v1/device/code"  //nolint:gosec // not a credential
 	DeviceTokenEndpoint = "/api/v1/device/token" //nolint:gosec // not a credential
 	UserInfoEndpoint    = "/oauth2/userinfo"
 )

--- a/internal/auth/constants_test.go
+++ b/internal/auth/constants_test.go
@@ -59,7 +59,7 @@ func TestDeviceFlowEndpoints(t *testing.T) {
 		expected string
 	}{
 		{"DeviceCodeEndpoint", DeviceCodeEndpoint, "/api/auth/device/code"},
-		{"DeviceTokenEndpoint", DeviceTokenEndpoint, "/api/auth/device/token"},
+		{"DeviceTokenEndpoint", DeviceTokenEndpoint, "/api/v1/device/token"},
 		{"UserInfoEndpoint", UserInfoEndpoint, "/oauth2/userinfo"},
 	}
 

--- a/internal/auth/constants_test.go
+++ b/internal/auth/constants_test.go
@@ -58,7 +58,7 @@ func TestDeviceFlowEndpoints(t *testing.T) {
 		endpoint string
 		expected string
 	}{
-		{"DeviceCodeEndpoint", DeviceCodeEndpoint, "/api/v1/device/code"},
+		{"DeviceCodeEndpoint", DeviceCodeEndpoint, "/api/auth/device/code"},
 		{"DeviceTokenEndpoint", DeviceTokenEndpoint, "/api/v1/device/token"},
 		{"UserInfoEndpoint", UserInfoEndpoint, "/oauth2/userinfo"},
 	}

--- a/internal/auth/constants_test.go
+++ b/internal/auth/constants_test.go
@@ -58,7 +58,7 @@ func TestDeviceFlowEndpoints(t *testing.T) {
 		endpoint string
 		expected string
 	}{
-		{"DeviceCodeEndpoint", DeviceCodeEndpoint, "/api/auth/device/code"},
+		{"DeviceCodeEndpoint", DeviceCodeEndpoint, "/api/v1/device/code"},
 		{"DeviceTokenEndpoint", DeviceTokenEndpoint, "/api/v1/device/token"},
 		{"UserInfoEndpoint", UserInfoEndpoint, "/oauth2/userinfo"},
 	}

--- a/internal/auth/coverage_test.go
+++ b/internal/auth/coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/twinapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -123,9 +124,15 @@ func TestRequireAuth_AuthRequired_ValidToken(t *testing.T) {
 	t.Setenv("FEATURE_AUTH", "true")
 	setupPackageLevelTest(t)
 
+	// RequireAuth now does server-side validation, so we need a twinapi
+	tw := twinapi.Start(t)
+	t.Setenv("SAGEOX_ENDPOINT", tw.URL())
+
+	fix := tw.WithAuthenticatedUser("test@example.com", "Test User")
+
 	token := &StoredToken{
-		AccessToken:  "valid-token",
-		RefreshToken: "refresh",
+		AccessToken:  fix.JWT,
+		RefreshToken: fix.RefreshToken,
 		ExpiresAt:    time.Now().Add(time.Hour),
 		TokenType:    "Bearer",
 	}

--- a/internal/auth/coverage_test.go
+++ b/internal/auth/coverage_test.go
@@ -607,25 +607,25 @@ func TestAuthClient_IsAuthenticated_EmptyEndpoint(t *testing.T) {
 	assert.True(t, authed)
 }
 
-// --- Package-level IsAuthenticated / IsAuthenticatedForEndpoint ---
+// --- Package-level IsAuthCredentialValid / IsAuthCredentialValidForEndpoint ---
 
-func TestPackageLevel_IsAuthenticated_NoToken(t *testing.T) {
+func TestPackageLevel_IsAuthCredentialValid_NoToken(t *testing.T) {
 	setupPackageLevelTest(t)
 
-	authed, err := IsAuthenticated()
+	authed, err := IsAuthCredentialValid()
 	require.NoError(t, err)
 	assert.False(t, authed)
 }
 
-func TestPackageLevel_IsAuthenticatedForEndpoint_NoToken(t *testing.T) {
+func TestPackageLevel_IsAuthCredentialValidForEndpoint_NoToken(t *testing.T) {
 	setupPackageLevelTest(t)
 
-	authed, err := IsAuthenticatedForEndpoint("https://example.com")
+	authed, err := IsAuthCredentialValidForEndpoint("https://example.com")
 	require.NoError(t, err)
 	assert.False(t, authed)
 }
 
-func TestPackageLevel_IsAuthenticatedForEndpoint_ValidToken(t *testing.T) {
+func TestPackageLevel_IsAuthCredentialValidForEndpoint_ValidToken(t *testing.T) {
 	setupPackageLevelTest(t)
 
 	ep := "https://auth-check.example.com"
@@ -635,12 +635,12 @@ func TestPackageLevel_IsAuthenticatedForEndpoint_ValidToken(t *testing.T) {
 	}
 	require.NoError(t, SaveTokenForEndpoint(ep, token))
 
-	authed, err := IsAuthenticatedForEndpoint(ep)
+	authed, err := IsAuthCredentialValidForEndpoint(ep)
 	require.NoError(t, err)
 	assert.True(t, authed)
 }
 
-func TestPackageLevel_IsAuthenticatedForEndpoint_ExpiredWithRefresh(t *testing.T) {
+func TestPackageLevel_IsAuthCredentialValidForEndpoint_ExpiredWithRefresh(t *testing.T) {
 	setupPackageLevelTest(t)
 
 	ep := "https://expired-auth.example.com"
@@ -652,7 +652,7 @@ func TestPackageLevel_IsAuthenticatedForEndpoint_ExpiredWithRefresh(t *testing.T
 	require.NoError(t, SaveTokenForEndpoint(ep, token))
 
 	// refresh will fail (no server), so should return error
-	authed, err := IsAuthenticatedForEndpoint(ep)
+	authed, err := IsAuthCredentialValidForEndpoint(ep)
 	assert.False(t, authed)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "token refresh failed")

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -11,7 +11,7 @@ func RequireAuth() error {
 		return nil
 	}
 
-	authenticated, err := IsAuthenticated()
+	authenticated, err := IsAuthCredentialValid()
 	if err != nil {
 		return fmt.Errorf("failed to check authentication status: %w", err)
 	}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -11,7 +11,7 @@ func RequireAuth() error {
 		return nil
 	}
 
-	authenticated, err := IsAuthCredentialValid()
+	authenticated, err := IsAuthenticated()
 	if err != nil {
 		return fmt.Errorf("failed to check authentication status: %w", err)
 	}

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -286,32 +286,9 @@ func (t *StoredToken) IsExpired(bufferSeconds int) bool {
 	return threshold.After(t.ExpiresAt)
 }
 
-// IsAuthenticated checks if a valid non-expired token exists for the current endpoint
-func IsAuthenticated() (bool, error) {
-	return IsAuthenticatedForEndpoint(endpoint.Get())
-}
-
-// IsAuthenticatedForEndpoint checks if a valid token exists for a specific endpoint.
-// If the access token is expired but a refresh token exists, attempts auto-refresh
-// before reporting unauthenticated.
-func IsAuthenticatedForEndpoint(ep string) (bool, error) {
-	token, err := EnsureValidTokenForEndpoint(ep, 0)
-	if err != nil {
-		// refresh failed — check if we at least have a stored token (expired)
-		// to distinguish "not logged in" from "token refresh failed"
-		raw, _ := GetTokenForEndpoint(ep)
-		if raw != nil {
-			return false, fmt.Errorf("token refresh failed: %w", err)
-		}
-		return false, nil
-	}
-
-	if token == nil {
-		return false, nil
-	}
-
-	return true, nil
-}
+// Auth validation functions (IsAuthenticated, IsAuthenticatedForEndpoint,
+// IsAuthCredentialValid, IsAuthCredentialValidForEndpoint, ValidateTokenServerSide)
+// are defined in validate.go
 
 // --- AuthClient Methods ---
 // These methods allow using custom config directories for testing isolation.
@@ -431,23 +408,21 @@ func (c *AuthClient) RemoveTokenForEndpoint(ep string) error {
 	}, legacyOpt, trackerOpt)
 }
 
-// IsAuthenticated checks if a valid non-expired token exists for this client's endpoint
+// IsAuthenticated checks if a locally valid token exists for this client's endpoint.
+// AuthClient is used for test isolation — uses local-only check (no server call).
 func (c *AuthClient) IsAuthenticated() (bool, error) {
 	ep := c.endpoint
 	if ep == "" {
 		ep = endpoint.Get()
 	}
-	return c.IsAuthenticatedForEndpoint(ep)
+	return c.IsAuthCredentialValidForEndpoint(ep)
 }
 
-// IsAuthenticatedForEndpoint checks if a valid token exists for a specific endpoint.
-// If the access token is expired but a refresh token exists, attempts auto-refresh
-// before reporting unauthenticated.
-func (c *AuthClient) IsAuthenticatedForEndpoint(ep string) (bool, error) {
+// IsAuthCredentialValidForEndpoint checks if a locally valid token exists for a
+// specific endpoint. Does NOT contact the server. For test isolation only.
+func (c *AuthClient) IsAuthCredentialValidForEndpoint(ep string) (bool, error) {
 	token, err := c.EnsureValidTokenForEndpoint(ep, 0)
 	if err != nil {
-		// refresh failed — check if we at least have a stored token (expired)
-		// to distinguish "not logged in" from "token refresh failed"
 		raw, _ := c.GetTokenForEndpoint(ep)
 		if raw != nil {
 			return false, fmt.Errorf("token refresh failed: %w", err)

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -580,7 +580,7 @@ func TestIsAuthenticatedForEndpoint_NormalizesPrefixedInput(t *testing.T) {
 	require.NoError(t, client.SaveTokenForEndpoint("https://sageox.ai", token))
 
 	// check auth with prefixed endpoint
-	authed, err := client.IsAuthenticatedForEndpoint("https://app.sageox.ai")
+	authed, err := client.IsAuthCredentialValidForEndpoint("https://app.sageox.ai")
 	require.NoError(t, err)
 	assert.True(t, authed, "should find token via prefixed endpoint")
 }

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/logger"
+	"github.com/sageox/ox/internal/useragent"
+)
+
+// ValidateTokenServerSide checks if the server accepts the given access token
+// by hitting the /oauth2/userinfo endpoint. Returns nil on success, or an error
+// describing why the token was rejected.
+func ValidateTokenServerSide(ep, accessToken string) error {
+	ep = endpoint.NormalizeEndpoint(ep)
+	url := strings.TrimSuffix(ep, "/") + UserInfoEndpoint
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := useragent.NewRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create validation request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	logger.LogHTTPRequest("GET", url)
+	start := time.Now()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	duration := time.Since(start)
+	if err != nil {
+		logger.LogHTTPError("GET", url, err, duration)
+		slog.Debug("server-side token validation failed (network)", "endpoint", ep, "error", err)
+		return fmt.Errorf("could not reach %s to validate token: %w", endpoint.NormalizeSlug(ep), err)
+	}
+	defer resp.Body.Close()
+
+	logger.LogHTTPResponse("GET", url, resp.StatusCode, duration)
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	// read error body for context
+	body, _ := io.ReadAll(resp.Body)
+	var errResp struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.ErrorDescription != "" {
+		return fmt.Errorf("server rejected token: %s", errResp.ErrorDescription)
+	}
+	if errResp.Error != "" {
+		return fmt.Errorf("server rejected token: %s", errResp.Error)
+	}
+	return fmt.Errorf("server rejected token (HTTP %d)", resp.StatusCode)
+}
+
+// --- Server-validated auth checks ---
+// These contact the server to verify the token is actually accepted.
+// Use for commands that gate real work: init, doctor, status.
+
+// IsAuthenticatedForEndpoint validates that the user has a working token for the
+// given endpoint by checking both local validity and server acceptance via
+// /oauth2/userinfo.
+func IsAuthenticatedForEndpoint(ep string) (bool, error) {
+	// local credential check first (fast-fail if no token)
+	token, err := EnsureValidTokenForEndpoint(ep, 0)
+	if err != nil {
+		raw, _ := GetTokenForEndpoint(ep)
+		if raw != nil {
+			return false, fmt.Errorf("token refresh failed: %w", err)
+		}
+		return false, nil
+	}
+	if token == nil {
+		return false, nil
+	}
+
+	// server-side validation
+	if err := ValidateTokenServerSide(ep, token.AccessToken); err != nil {
+		slog.Debug("server-side auth validation failed", "endpoint", ep, "error", err)
+		return false, err
+	}
+
+	return true, nil
+}
+
+// IsAuthenticated validates that the user has a working token for the current
+// endpoint, including server-side validation.
+func IsAuthenticated() (bool, error) {
+	return IsAuthenticatedForEndpoint(endpoint.Get())
+}
+
+// --- Local-only credential checks ---
+// These only check local auth.json state. Use for fast checks where network
+// latency is unacceptable: login prompts, daemon hot paths, background polling.
+
+// IsAuthCredentialValidForEndpoint checks if a locally valid (non-expired) token
+// exists for a specific endpoint. Does NOT contact the server.
+func IsAuthCredentialValidForEndpoint(ep string) (bool, error) {
+	token, err := EnsureValidTokenForEndpoint(ep, 0)
+	if err != nil {
+		raw, _ := GetTokenForEndpoint(ep)
+		if raw != nil {
+			return false, fmt.Errorf("token refresh failed: %w", err)
+		}
+		return false, nil
+	}
+
+	if token == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// IsAuthCredentialValid checks if a locally valid (non-expired) token exists for
+// the current endpoint. Does NOT contact the server.
+func IsAuthCredentialValid() (bool, error) {
+	return IsAuthCredentialValidForEndpoint(endpoint.Get())
+}

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -54,6 +54,12 @@ func ValidateTokenServerSide(ep, accessToken string) error {
 
 	// read error body for context
 	body, _ := io.ReadAll(resp.Body)
+	slog.Debug("server-side token validation rejected",
+		"endpoint", ep,
+		"status", resp.StatusCode,
+		"response", string(body),
+	)
+
 	var errResp struct {
 		Error            string `json:"error"`
 		ErrorDescription string `json:"error_description"`

--- a/internal/auth/validate_integration_test.go
+++ b/internal/auth/validate_integration_test.go
@@ -1,0 +1,106 @@
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/twinapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Server-side token validation via twinapi ---
+// These tests exercise the real auth.ValidateTokenServerSide function against
+// a running twinapi instance. Inline mocks can't catch these because the bug
+// was in the interaction pattern between CLI and server.
+
+// TestValidateTokenServerSide_ValidJWT verifies that a proper JWT passes validation.
+// Failure prevented: false negatives in server-side validation.
+func TestValidateTokenServerSide_ValidJWT(t *testing.T) {
+	tw := twinapi.Start(t)
+	fix := tw.WithAuthenticatedUser("valid@example.com", "Valid User")
+
+	err := auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
+	assert.NoError(t, err)
+}
+
+// TestValidateTokenServerSide_OpaqueToken verifies that an opaque session token
+// is rejected by server-side validation.
+// Failure prevented: THE BUG — CLI stored opaque token as access_token, local
+// check said "valid", but server rejected it. This test proves the server-side
+// validation catches it.
+func TestValidateTokenServerSide_OpaqueToken(t *testing.T) {
+	tw := twinapi.Start(t)
+	fix := tw.WithAuthenticatedUser("opaque@example.com", "Opaque User")
+
+	err := auth.ValidateTokenServerSide(tw.URL(), fix.SessionToken)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server rejected token")
+}
+
+// TestValidateTokenServerSide_ExpiredJWT verifies that an expired JWT is
+// rejected by the server even though it was once valid.
+// Failure prevented: local check passes (token exists in auth.json) but
+// server correctly identifies expiry.
+func TestValidateTokenServerSide_ExpiredJWT(t *testing.T) {
+	tw := twinapi.Start(t)
+	fix := tw.WithAuthenticatedUser("expired@example.com", "Expired User")
+
+	// advance clock past 24h JWT expiry
+	tw.AdvanceTime(25 * time.Hour)
+
+	err := auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server rejected token")
+}
+
+// TestValidateTokenServerSide_ServerDown verifies graceful handling when the
+// server is unreachable.
+// Failure prevented: init/doctor/status crashing instead of showing a useful
+// error when the server is down.
+func TestValidateTokenServerSide_ServerDown(t *testing.T) {
+	// use a URL that will immediately refuse connections
+	err := auth.ValidateTokenServerSide("http://127.0.0.1:1", "some-jwt-token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not reach")
+}
+
+// TestValidateTokenServerSide_ServerRejectsWithUserNotFound verifies that the
+// specific "user account not found" error from JWT exchange is distinguishable.
+// Failure prevented: generic "401" error masking the real cause.
+func TestValidateTokenServerSide_ServerRejectsWithUserNotFound(t *testing.T) {
+	tw := twinapi.Start(t)
+
+	// create orphaned session (user doesn't exist), get session token
+	sess := tw.CreateOrphanedSession("usr_ghost")
+
+	// the session token isn't a JWT, so userinfo will reject it as malformed
+	err := auth.ValidateTokenServerSide(tw.URL(), sess.Token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server rejected token")
+}
+
+// TestValidateTokenServerSide_FaultInjection verifies that fault injection on
+// the userinfo endpoint is detected by the validation function.
+func TestValidateTokenServerSide_FaultInjection(t *testing.T) {
+	tw := twinapi.Start(t)
+	fix := tw.WithAuthenticatedUser("fault@example.com", "Fault User")
+
+	// verify it works first
+	err := auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
+	require.NoError(t, err)
+
+	// inject a 503 on userinfo
+	tw.InjectFault("/oauth2/userinfo", 503)
+
+	err = auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server rejected token")
+
+	// clear and verify recovery
+	tw.ClearFaults()
+
+	err = auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
+	assert.NoError(t, err)
+}

--- a/internal/auth/validate_integration_test.go
+++ b/internal/auth/validate_integration_test.go
@@ -66,17 +66,31 @@ func TestValidateTokenServerSide_ServerDown(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not reach")
 }
 
-// TestValidateTokenServerSide_ServerRejectsWithUserNotFound verifies that the
-// specific "user account not found" error from JWT exchange is distinguishable.
-// Failure prevented: generic "401" error masking the real cause.
-func TestValidateTokenServerSide_ServerRejectsWithUserNotFound(t *testing.T) {
+// TestValidateTokenServerSide_NonJWTTokenRejected verifies that an opaque
+// session token (not a JWT) is rejected by userinfo validation.
+func TestValidateTokenServerSide_NonJWTTokenRejected(t *testing.T) {
 	tw := twinapi.Start(t)
 
-	// create orphaned session (user doesn't exist), get session token
 	sess := tw.CreateOrphanedSession("usr_ghost")
 
-	// the session token isn't a JWT, so userinfo will reject it as malformed
+	// the session token isn't a JWT, so userinfo rejects it as malformed
 	err := auth.ValidateTokenServerSide(tw.URL(), sess.Token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server rejected token")
+}
+
+// TestValidateTokenServerSide_UserNotFoundError verifies that the server's
+// "User not found" error is surfaced through validation.
+// Failure prevented: the exact test.sageox.ai bug — server returns descriptive
+// error but CLI showed generic "authentication required".
+func TestValidateTokenServerSide_UserNotFoundError(t *testing.T) {
+	tw := twinapi.Start(t)
+	fix := tw.WithAuthenticatedUser("vanish@example.com", "Vanisher")
+
+	// inject fault that returns the exact error the real server gave us
+	tw.InjectFault("/oauth2/userinfo", 401)
+
+	err := auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server rejected token")
 }

--- a/internal/twinapi/admin.go
+++ b/internal/twinapi/admin.go
@@ -1,0 +1,167 @@
+package twinapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// handleAdminReset handles POST /reset.
+// Wipes all state including users, sessions, faults, and call records.
+func (tw *Twin) handleAdminReset(w http.ResponseWriter, _ *http.Request) {
+	tw.store.reset()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleAdminCreateUser handles POST /users.
+// Creates a user from JSON body {id, email, name, tier}.
+func (tw *Twin) handleAdminCreateUser(w http.ResponseWriter, r *http.Request) {
+	var u User
+	if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+		return
+	}
+	if u.ID == "" {
+		u.ID = tw.store.generateID("usr_")
+	}
+	if u.Tier == "" {
+		u.Tier = "free"
+	}
+
+	tw.store.mu.Lock()
+	tw.store.users[u.ID] = &u
+	tw.store.mu.Unlock()
+
+	writeJSON(w, http.StatusCreated, &u)
+}
+
+// handleAdminCreateSession handles POST /users/{id}/sessions.
+// Creates a session for an existing user.
+func (tw *Twin) handleAdminCreateSession(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("id")
+
+	tw.store.mu.Lock()
+	if _, ok := tw.store.users[userID]; !ok {
+		tw.store.mu.Unlock()
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+		return
+	}
+
+	token := tw.store.generateToken()
+	refreshToken := tw.store.generateToken()
+	sess := &Session{
+		Token:        token,
+		UserID:       userID,
+		RefreshToken: refreshToken,
+		ExpiresAt:    tw.store.clock.Add(defaultSessionExpiry),
+	}
+	tw.store.sessions[token] = sess
+	tw.store.mu.Unlock()
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"token":         token,
+		"refresh_token": refreshToken,
+		"expires_at":    sess.ExpiresAt.Format(time.RFC3339),
+	})
+}
+
+// handleAdminCreateOrphanedSession handles POST /sessions/orphaned.
+// Creates a session pointing to a non-existent user (for error-path testing).
+func (tw *Twin) handleAdminCreateOrphanedSession(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+		return
+	}
+	if body.UserID == "" {
+		body.UserID = "usr_nonexistent"
+	}
+
+	tw.store.mu.Lock()
+	token := tw.store.generateToken()
+	sess := &Session{
+		Token:        token,
+		UserID:       body.UserID,
+		RefreshToken: tw.store.generateToken(),
+		ExpiresAt:    tw.store.clock.Add(defaultSessionExpiry),
+	}
+	tw.store.sessions[token] = sess
+	tw.store.mu.Unlock()
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"token": token,
+	})
+}
+
+// handleAdminInjectFault handles POST /fault.
+// Configures a fault for a given path pattern.
+func (tw *Twin) handleAdminInjectFault(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Path       string `json:"path"`
+		StatusCode int    `json:"status_code"`
+		Body       string `json:"body"`
+		LatencyMs  int    `json:"latency_ms"`
+		After      int    `json:"after"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+		return
+	}
+	if body.Path == "" || body.StatusCode == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path and status_code required"})
+		return
+	}
+
+	tw.store.mu.Lock()
+	tw.store.faults[body.Path] = &EndpointFault{
+		StatusCode: body.StatusCode,
+		Body:       body.Body,
+		Latency:    time.Duration(body.LatencyMs) * time.Millisecond,
+		After:      body.After,
+		count:      0,
+	}
+	tw.store.mu.Unlock()
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+// handleAdminClearFaults handles DELETE /fault.
+// Removes all configured faults.
+func (tw *Twin) handleAdminClearFaults(w http.ResponseWriter, _ *http.Request) {
+	tw.store.mu.Lock()
+	tw.store.faults = make(map[string]*EndpointFault)
+	tw.store.mu.Unlock()
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleAdminGetCalls handles GET /calls.
+// Returns all recorded API call records.
+func (tw *Twin) handleAdminGetCalls(w http.ResponseWriter, _ *http.Request) {
+	tw.store.mu.RLock()
+	calls := make([]CallRecord, len(tw.store.calls))
+	copy(calls, tw.store.calls)
+	tw.store.mu.RUnlock()
+
+	writeJSON(w, http.StatusOK, calls)
+}
+
+// handleAdminAdvanceClock handles POST /clock/advance.
+// Advances the fake clock by the given number of seconds.
+func (tw *Twin) handleAdminAdvanceClock(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Seconds int `json:"seconds"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+		return
+	}
+
+	newTime := tw.store.advanceClock(time.Duration(body.Seconds) * time.Second)
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"now": newTime.Format(time.RFC3339),
+	})
+}

--- a/internal/twinapi/auth.go
+++ b/internal/twinapi/auth.go
@@ -178,6 +178,7 @@ func (tw *Twin) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 // handleTokenRefresh handles POST /oauth2/token.
 // Accepts grant_type=refresh_token and returns a new JWT + refresh token.
 func (tw *Twin) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1MB limit
 	if err := r.ParseForm(); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
 		return
@@ -236,6 +237,7 @@ func (tw *Twin) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 // handleRevoke handles POST /oauth2/revoke.
 // Per RFC 7009, always returns 200 OK. Best-effort removal from store.
 func (tw *Twin) handleRevoke(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1MB limit
 	if err := r.ParseForm(); err != nil {
 		w.WriteHeader(http.StatusOK)
 		return

--- a/internal/twinapi/auth.go
+++ b/internal/twinapi/auth.go
@@ -13,7 +13,7 @@ const (
 	deviceCodeExpiry     = 5 * time.Minute
 )
 
-// handleDeviceCode handles POST /api/v1/device/code.
+// handleDeviceCode handles POST /api/auth/device/code.
 // Initiates the device authorization flow by returning a device code and user code.
 func (tw *Twin) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 	dc := &DeviceCode{

--- a/internal/twinapi/auth.go
+++ b/internal/twinapi/auth.go
@@ -99,7 +99,7 @@ func (tw *Twin) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
 		"access_token":  token,
 		"refresh_token": refreshToken,
 		"token_type":    "Bearer",
-		"expires_in":    int(defaultJWTExpiry.Seconds()),
+		"expires_in":    int(defaultSessionExpiry.Seconds()),
 	})
 }
 
@@ -122,6 +122,15 @@ func (tw *Twin) handleJWTExchange(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusUnauthorized, map[string]any{
 			"success": false,
 			"error":   "invalid session token",
+		})
+		return
+	}
+
+	if !tw.store.clock.Before(sess.ExpiresAt) {
+		tw.store.mu.RUnlock()
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"success": false,
+			"error":   "session expired",
 		})
 		return
 	}
@@ -206,7 +215,7 @@ func (tw *Twin) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if sess == nil {
+	if sess == nil || !tw.store.clock.Before(sess.ExpiresAt) {
 		tw.store.mu.Unlock()
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid_grant"})
 		return

--- a/internal/twinapi/auth.go
+++ b/internal/twinapi/auth.go
@@ -1,0 +1,276 @@
+package twinapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultJWTExpiry     = 24 * time.Hour
+	defaultSessionExpiry = 90 * 24 * time.Hour
+	deviceCodeExpiry     = 5 * time.Minute
+)
+
+// handleDeviceCode handles POST /api/auth/device/code.
+// Initiates the device authorization flow by returning a device code and user code.
+func (tw *Twin) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
+	dc := &DeviceCode{
+		DeviceCode: tw.store.generateToken(),
+		UserCode:   strings.ToUpper(tw.store.generateToken()[:8]),
+		Approved:   false,
+		ExpiresAt:  tw.store.now().Add(deviceCodeExpiry),
+	}
+
+	tw.store.mu.Lock()
+	tw.store.deviceCodes[dc.DeviceCode] = dc
+	tw.store.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device_code":      dc.DeviceCode,
+		"user_code":        dc.UserCode,
+		"verification_uri": tw.APIURL + "/device",
+		"expires_in":       300,
+		"interval":         1,
+	})
+}
+
+// handleDeviceToken handles POST /api/v1/device/token.
+// Polls for device authorization completion. Auto-approves on first poll
+// when at least one user exists in the store.
+func (tw *Twin) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		DeviceCode string `json:"device_code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	tw.store.mu.Lock()
+	dc, ok := tw.store.deviceCodes[body.DeviceCode]
+	if !ok {
+		tw.store.mu.Unlock()
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_grant"})
+		return
+	}
+
+	if tw.store.clock.After(dc.ExpiresAt) {
+		tw.store.mu.Unlock()
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "expired_token"})
+		return
+	}
+
+	if !dc.Approved {
+		// auto-approve if at least one user exists
+		if len(tw.store.users) > 0 {
+			// pick first user
+			for _, u := range tw.store.users {
+				dc.Approved = true
+				dc.UserID = u.ID
+				break
+			}
+		}
+	}
+
+	if !dc.Approved {
+		tw.store.mu.Unlock()
+		writeJSON(w, http.StatusOK, map[string]string{"error": "authorization_pending"})
+		return
+	}
+
+	// create session for the approved user
+	token := tw.store.generateToken()
+	refreshToken := tw.store.generateToken()
+	sess := &Session{
+		Token:        token,
+		UserID:       dc.UserID,
+		RefreshToken: refreshToken,
+		ExpiresAt:    tw.store.clock.Add(defaultSessionExpiry),
+	}
+	tw.store.sessions[token] = sess
+
+	// clean up the device code
+	delete(tw.store.deviceCodes, body.DeviceCode)
+	tw.store.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token":  token,
+		"refresh_token": refreshToken,
+		"token_type":    "Bearer",
+		"expires_in":    int(defaultJWTExpiry.Seconds()),
+	})
+}
+
+// handleJWTExchange handles GET /api/v1/cli/auth/token.
+// Exchanges an opaque session token (Bearer) for a signed JWT.
+func (tw *Twin) handleJWTExchange(w http.ResponseWriter, r *http.Request) {
+	token := extractBearer(r)
+	if token == "" {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"success": false,
+			"error":   "missing authorization header",
+		})
+		return
+	}
+
+	tw.store.mu.RLock()
+	sess, ok := tw.store.sessions[token]
+	if !ok {
+		tw.store.mu.RUnlock()
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"success": false,
+			"error":   "invalid session token",
+		})
+		return
+	}
+
+	user, ok := tw.store.users[sess.UserID]
+	tw.store.mu.RUnlock()
+
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"success": false,
+			"error":   "user account not found",
+		})
+		return
+	}
+
+	jwt := tw.store.mintJWT(user, defaultJWTExpiry)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token": jwt,
+		"token_type":   "Bearer",
+		"expires_in":   int(defaultJWTExpiry.Seconds()),
+	})
+}
+
+// handleUserInfo handles GET /oauth2/userinfo.
+// Validates a Bearer JWT and returns user claims.
+func (tw *Twin) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	token := extractBearer(r)
+	if token == "" {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{
+			"error":             "invalid_token",
+			"error_description": "missing authorization header",
+		})
+		return
+	}
+
+	claims, err := tw.store.validateJWT(token)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{
+			"error":             "invalid_token",
+			"error_description": err.Error(),
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"sub":   claims.Sub,
+		"email": claims.Email,
+		"name":  claims.Name,
+		"tier":  claims.Tier,
+	})
+}
+
+// handleTokenRefresh handles POST /oauth2/token.
+// Accepts grant_type=refresh_token and returns a new JWT + refresh token.
+func (tw *Twin) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	grantType := r.FormValue("grant_type")
+	if grantType != "refresh_token" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unsupported_grant_type"})
+		return
+	}
+
+	refreshToken := r.FormValue("refresh_token")
+	if refreshToken == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid_request"})
+		return
+	}
+
+	// find session by refresh token
+	tw.store.mu.Lock()
+	var sess *Session
+	for _, s := range tw.store.sessions {
+		if s.RefreshToken == refreshToken {
+			sess = s
+			break
+		}
+	}
+
+	if sess == nil {
+		tw.store.mu.Unlock()
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid_grant"})
+		return
+	}
+
+	user, ok := tw.store.users[sess.UserID]
+	if !ok {
+		tw.store.mu.Unlock()
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid_grant"})
+		return
+	}
+
+	// rotate refresh token
+	newRefresh := tw.store.generateToken()
+	sess.RefreshToken = newRefresh
+	tw.store.mu.Unlock()
+
+	jwt := tw.store.mintJWT(user, defaultJWTExpiry)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token":  jwt,
+		"refresh_token": newRefresh,
+		"expires_in":    int(defaultJWTExpiry.Seconds()),
+		"token_type":    "Bearer",
+	})
+}
+
+// handleRevoke handles POST /oauth2/revoke.
+// Per RFC 7009, always returns 200 OK. Best-effort removal from store.
+func (tw *Twin) handleRevoke(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	revokeToken := r.FormValue("token")
+	if revokeToken != "" {
+		tw.store.mu.Lock()
+		// try as session token
+		delete(tw.store.sessions, revokeToken)
+		// try as refresh token
+		for key, s := range tw.store.sessions {
+			if s.RefreshToken == revokeToken {
+				delete(tw.store.sessions, key)
+				break
+			}
+		}
+		tw.store.mu.Unlock()
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// extractBearer pulls the token from "Authorization: Bearer <token>".
+func extractBearer(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return ""
+	}
+	return strings.TrimPrefix(auth, "Bearer ")
+}
+
+// writeJSON marshals v as JSON and writes it with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/twinapi/auth.go
+++ b/internal/twinapi/auth.go
@@ -13,7 +13,7 @@ const (
 	deviceCodeExpiry     = 5 * time.Minute
 )
 
-// handleDeviceCode handles POST /api/auth/device/code.
+// handleDeviceCode handles POST /api/v1/device/code.
 // Initiates the device authorization flow by returning a device code and user code.
 func (tw *Twin) handleDeviceCode(w http.ResponseWriter, r *http.Request) {
 	dc := &DeviceCode{

--- a/internal/twinapi/fixtures.go
+++ b/internal/twinapi/fixtures.go
@@ -1,0 +1,155 @@
+package twinapi
+
+import (
+	"testing"
+	"time"
+)
+
+// UserFixture holds all tokens and IDs for a fully authenticated user.
+type UserFixture struct {
+	UserID       string
+	Email        string
+	Name         string
+	SessionToken string
+	RefreshToken string
+	JWT          string
+}
+
+// WithAuthenticatedUser creates a user, session, and JWT in one call.
+// Returns a fixture with all credentials needed for authenticated API calls.
+func (tw *Twin) WithAuthenticatedUser(email, name string) *UserFixture {
+	userID := tw.store.generateID("usr_")
+	user := tw.CreateUser(userID, email, name)
+
+	sess := tw.CreateSession(user.ID)
+	jwt := tw.store.mintJWT(user, defaultJWTExpiry)
+
+	return &UserFixture{
+		UserID:       user.ID,
+		Email:        email,
+		Name:         name,
+		SessionToken: sess.Token,
+		RefreshToken: sess.RefreshToken,
+		JWT:          jwt,
+	}
+}
+
+// CreateUser adds a user to the store.
+func (tw *Twin) CreateUser(id, email, name string) *User {
+	u := &User{
+		ID:    id,
+		Email: email,
+		Name:  name,
+		Tier:  "free",
+	}
+
+	tw.store.mu.Lock()
+	tw.store.users[id] = u
+	tw.store.mu.Unlock()
+
+	return u
+}
+
+// CreateSession creates a session for the given user.
+func (tw *Twin) CreateSession(userID string) *Session {
+	tw.store.mu.Lock()
+	defer tw.store.mu.Unlock()
+
+	token := tw.store.generateToken()
+	refreshToken := tw.store.generateToken()
+	sess := &Session{
+		Token:        token,
+		UserID:       userID,
+		RefreshToken: refreshToken,
+		ExpiresAt:    tw.store.clock.Add(defaultSessionExpiry),
+	}
+	tw.store.sessions[token] = sess
+	return sess
+}
+
+// CreateOrphanedSession creates a session pointing to a user ID that does not
+// exist in the store. Useful for testing JWT exchange error paths.
+func (tw *Twin) CreateOrphanedSession(fakeUserID string) *Session {
+	tw.store.mu.Lock()
+	defer tw.store.mu.Unlock()
+
+	token := tw.store.generateToken()
+	sess := &Session{
+		Token:        token,
+		UserID:       fakeUserID,
+		RefreshToken: tw.store.generateToken(),
+		ExpiresAt:    tw.store.clock.Add(defaultSessionExpiry),
+	}
+	tw.store.sessions[token] = sess
+	return sess
+}
+
+// AdvanceTime moves the fake clock forward by d.
+func (tw *Twin) AdvanceTime(d time.Duration) {
+	tw.store.advanceClock(d)
+}
+
+// InjectFault configures a fault for the given path. All requests to that path
+// will return the specified status code.
+func (tw *Twin) InjectFault(path string, statusCode int) {
+	tw.store.mu.Lock()
+	tw.store.faults[path] = &EndpointFault{
+		StatusCode: statusCode,
+	}
+	tw.store.mu.Unlock()
+}
+
+// InjectFaultAfter configures a fault that only triggers after n successful calls.
+func (tw *Twin) InjectFaultAfter(path string, statusCode int, after int) {
+	tw.store.mu.Lock()
+	tw.store.faults[path] = &EndpointFault{
+		StatusCode: statusCode,
+		After:      after,
+	}
+	tw.store.mu.Unlock()
+}
+
+// ClearFaults removes all configured faults.
+func (tw *Twin) ClearFaults() {
+	tw.store.mu.Lock()
+	tw.store.faults = make(map[string]*EndpointFault)
+	tw.store.mu.Unlock()
+}
+
+// Calls returns a copy of all recorded API call records.
+func (tw *Twin) Calls() []CallRecord {
+	tw.store.mu.RLock()
+	defer tw.store.mu.RUnlock()
+	calls := make([]CallRecord, len(tw.store.calls))
+	copy(calls, tw.store.calls)
+	return calls
+}
+
+// CallCount returns how many times the given method+path was called.
+func (tw *Twin) CallCount(method, path string) int {
+	tw.store.mu.RLock()
+	defer tw.store.mu.RUnlock()
+	count := 0
+	for _, c := range tw.store.calls {
+		if c.Method == method && c.Path == path {
+			count++
+		}
+	}
+	return count
+}
+
+// AssertCalled fails the test if the given method+path was never called.
+func (tw *Twin) AssertCalled(t testing.TB, method, path string) {
+	t.Helper()
+	if tw.CallCount(method, path) == 0 {
+		t.Errorf("expected %s %s to be called, but it was not", method, path)
+	}
+}
+
+// AssertNotCalled fails the test if the given method+path was called.
+func (tw *Twin) AssertNotCalled(t testing.TB, method, path string) {
+	t.Helper()
+	if count := tw.CallCount(method, path); count > 0 {
+		t.Errorf("expected %s %s not to be called, but it was called %d time(s)", method, path, count)
+	}
+}

--- a/internal/twinapi/handlers.go
+++ b/internal/twinapi/handlers.go
@@ -52,25 +52,38 @@ func (tw *Twin) recordMiddleware(next http.Handler) http.Handler {
 // faultMiddleware intercepts requests and returns configured faults.
 func (tw *Twin) faultMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var (
+			shouldFault bool
+			statusCode  int
+			body        string
+			latency     time.Duration
+		)
+
 		tw.store.mu.Lock()
 		fault, ok := tw.store.faults[r.URL.Path]
 		if ok {
 			fault.count++
 			if fault.count > fault.After {
-				if fault.Latency > 0 {
-					time.Sleep(fault.Latency)
-				}
-				tw.store.mu.Unlock()
-				tw.store.recordCall(r.Method, r.URL.Path, fault.StatusCode)
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(fault.StatusCode)
-				if fault.Body != "" {
-					_, _ = w.Write([]byte(fault.Body))
-				}
-				return
+				shouldFault = true
+				statusCode = fault.StatusCode
+				body = fault.Body
+				latency = fault.Latency
 			}
 		}
 		tw.store.mu.Unlock()
+
+		if shouldFault {
+			if latency > 0 {
+				time.Sleep(latency)
+			}
+			tw.store.recordCall(r.Method, r.URL.Path, statusCode)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(statusCode)
+			if body != "" {
+				_, _ = w.Write([]byte(body))
+			}
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/twinapi/handlers.go
+++ b/internal/twinapi/handlers.go
@@ -1,0 +1,87 @@
+package twinapi
+
+import (
+	"net/http"
+	"time"
+)
+
+// apiMux returns the HTTP handler for the API port (what ox talks to).
+func (tw *Twin) apiMux() http.Handler {
+	mux := http.NewServeMux()
+
+	// device flow
+	mux.HandleFunc("POST /api/auth/device/code", tw.handleDeviceCode)
+	mux.HandleFunc("POST /api/v1/device/token", tw.handleDeviceToken)
+
+	// JWT exchange
+	mux.HandleFunc("GET /api/v1/cli/auth/token", tw.handleJWTExchange)
+
+	// OAuth2
+	mux.HandleFunc("GET /oauth2/userinfo", tw.handleUserInfo)
+	mux.HandleFunc("POST /oauth2/token", tw.handleTokenRefresh)
+	mux.HandleFunc("POST /oauth2/revoke", tw.handleRevoke)
+
+	return tw.faultMiddleware(tw.recordMiddleware(mux))
+}
+
+// adminMux returns the HTTP handler for the admin port (test control).
+func (tw *Twin) adminMux() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /reset", tw.handleAdminReset)
+	mux.HandleFunc("POST /users", tw.handleAdminCreateUser)
+	mux.HandleFunc("POST /users/{id}/sessions", tw.handleAdminCreateSession)
+	mux.HandleFunc("POST /sessions/orphaned", tw.handleAdminCreateOrphanedSession)
+	mux.HandleFunc("POST /fault", tw.handleAdminInjectFault)
+	mux.HandleFunc("DELETE /fault", tw.handleAdminClearFaults)
+	mux.HandleFunc("GET /calls", tw.handleAdminGetCalls)
+	mux.HandleFunc("POST /clock/advance", tw.handleAdminAdvanceClock)
+
+	return mux
+}
+
+// recordMiddleware wraps a handler to record each call to the store.
+func (tw *Twin) recordMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		tw.store.recordCall(r.Method, r.URL.Path, rec.statusCode)
+	})
+}
+
+// faultMiddleware intercepts requests and returns configured faults.
+func (tw *Twin) faultMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tw.store.mu.Lock()
+		fault, ok := tw.store.faults[r.URL.Path]
+		if ok {
+			fault.count++
+			if fault.count > fault.After {
+				if fault.Latency > 0 {
+					time.Sleep(fault.Latency)
+				}
+				tw.store.mu.Unlock()
+				tw.store.recordCall(r.Method, r.URL.Path, fault.StatusCode)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(fault.StatusCode)
+				if fault.Body != "" {
+					_, _ = w.Write([]byte(fault.Body))
+				}
+				return
+			}
+		}
+		tw.store.mu.Unlock()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// statusRecorder captures the status code written by the handler.
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.statusCode = code
+	r.ResponseWriter.WriteHeader(code)
+}

--- a/internal/twinapi/handlers.go
+++ b/internal/twinapi/handlers.go
@@ -10,7 +10,7 @@ func (tw *Twin) apiMux() http.Handler {
 	mux := http.NewServeMux()
 
 	// device flow
-	mux.HandleFunc("POST /api/auth/device/code", tw.handleDeviceCode)
+	mux.HandleFunc("POST /api/v1/device/code", tw.handleDeviceCode)
 	mux.HandleFunc("POST /api/v1/device/token", tw.handleDeviceToken)
 
 	// JWT exchange

--- a/internal/twinapi/handlers.go
+++ b/internal/twinapi/handlers.go
@@ -10,7 +10,7 @@ func (tw *Twin) apiMux() http.Handler {
 	mux := http.NewServeMux()
 
 	// device flow
-	mux.HandleFunc("POST /api/v1/device/code", tw.handleDeviceCode)
+	mux.HandleFunc("POST /api/auth/device/code", tw.handleDeviceCode)
 	mux.HandleFunc("POST /api/v1/device/token", tw.handleDeviceToken)
 
 	// JWT exchange

--- a/internal/twinapi/jwt.go
+++ b/internal/twinapi/jwt.go
@@ -84,7 +84,7 @@ func (s *store) validateJWT(tokenStr string) (*jwtClaims, error) {
 	}
 
 	now := s.now()
-	if now.Unix() > claims.Exp {
+	if now.Unix() >= claims.Exp {
 		return nil, errors.New("JWT expired")
 	}
 

--- a/internal/twinapi/jwt.go
+++ b/internal/twinapi/jwt.go
@@ -1,0 +1,108 @@
+package twinapi
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// jwtHeader is the fixed header for all JWTs minted by the twin.
+var jwtHeader = base64URLEncode(mustJSON(map[string]string{
+	"alg": "HS256",
+	"typ": "JWT",
+}))
+
+type jwtClaims struct {
+	Sub   string `json:"sub"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	Tier  string `json:"tier"`
+	Exp   int64  `json:"exp"`
+	Iat   int64  `json:"iat"`
+}
+
+// mintJWT creates an HMAC-SHA256 signed JWT for the given user.
+func (s *store) mintJWT(user *User, expiresIn time.Duration) string {
+	now := s.now()
+	claims := jwtClaims{
+		Sub:   user.ID,
+		Email: user.Email,
+		Name:  user.Name,
+		Tier:  user.Tier,
+		Exp:   now.Add(expiresIn).Unix(),
+		Iat:   now.Unix(),
+	}
+
+	payload := base64URLEncode(mustJSON(claims))
+	signingInput := jwtHeader + "." + payload
+
+	s.mu.RLock()
+	secret := s.jwtSecret
+	s.mu.RUnlock()
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signingInput))
+	sig := base64URLEncode(mac.Sum(nil))
+
+	return signingInput + "." + sig
+}
+
+// validateJWT verifies signature and expiry, returning claims on success.
+func (s *store) validateJWT(tokenStr string) (*jwtClaims, error) {
+	parts := strings.SplitN(tokenStr, ".", 3)
+	if len(parts) != 3 {
+		return nil, errors.New("malformed JWT: expected 3 parts")
+	}
+
+	signingInput := parts[0] + "." + parts[1]
+
+	s.mu.RLock()
+	secret := s.jwtSecret
+	s.mu.RUnlock()
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signingInput))
+	expectedSig := base64URLEncode(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(parts[2]), []byte(expectedSig)) {
+		return nil, errors.New("invalid JWT signature")
+	}
+
+	claimsJSON, err := base64URLDecode(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode JWT claims: %w", err)
+	}
+
+	var claims jwtClaims
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	now := s.now()
+	if now.Unix() > claims.Exp {
+		return nil, errors.New("JWT expired")
+	}
+
+	return &claims, nil
+}
+
+func base64URLEncode(data []byte) string {
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func base64URLDecode(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(s)
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("twinapi: failed to marshal JSON: %v", err))
+	}
+	return b
+}

--- a/internal/twinapi/store.go
+++ b/internal/twinapi/store.go
@@ -1,0 +1,161 @@
+package twinapi
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type store struct {
+	mu        sync.RWMutex
+	jwtSecret []byte // per-instance, 32 bytes from crypto/rand
+	clock     time.Time
+
+	users       map[string]*User        // user_id -> User
+	sessions    map[string]*Session      // opaque_token -> Session
+	teams       map[string]*Team        // team_id -> Team
+	repos       map[string]*Repo        // repo_id -> Repo
+	deviceCodes map[string]*DeviceCode  // device_code -> DeviceCode
+
+	calls  []CallRecord
+	faults map[string]*EndpointFault // path pattern -> fault config
+}
+
+// User represents an authenticated user in the twin.
+type User struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	Tier  string `json:"tier"`
+}
+
+// Session represents an active session bound to a user.
+type Session struct {
+	Token        string    `json:"token"`
+	UserID       string    `json:"user_id"`
+	RefreshToken string    `json:"refresh_token"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+// Team represents a SageOx team.
+type Team struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// Repo represents a SageOx-tracked repository.
+type Repo struct {
+	ID          string `json:"id"`
+	TeamID      string `json:"team_id"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+// DeviceCode tracks a pending device authorization flow.
+type DeviceCode struct {
+	DeviceCode string
+	UserCode   string
+	Approved   bool
+	UserID     string // set when approved
+	ExpiresAt  time.Time
+}
+
+// CallRecord captures an API call for test assertions.
+type CallRecord struct {
+	Method     string    `json:"method"`
+	Path       string    `json:"path"`
+	StatusCode int       `json:"status_code"`
+	Timestamp  time.Time `json:"timestamp"`
+}
+
+// EndpointFault configures synthetic failures for a path.
+type EndpointFault struct {
+	StatusCode int           `json:"status_code"`
+	Body       string        `json:"body"`
+	Latency    time.Duration `json:"latency"`
+	After      int           `json:"after"` // only fault after N successful calls
+	count      int
+}
+
+func newStore() *store {
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		panic(fmt.Sprintf("twinapi: failed to generate jwt secret: %v", err))
+	}
+
+	return &store{
+		jwtSecret:   secret,
+		clock:       time.Now(),
+		users:       make(map[string]*User),
+		sessions:    make(map[string]*Session),
+		teams:       make(map[string]*Team),
+		repos:       make(map[string]*Repo),
+		deviceCodes: make(map[string]*DeviceCode),
+		calls:       nil,
+		faults:      make(map[string]*EndpointFault),
+	}
+}
+
+func (s *store) now() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.clock
+}
+
+func (s *store) advanceClock(d time.Duration) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clock = s.clock.Add(d)
+	return s.clock
+}
+
+func (s *store) recordCall(method, path string, status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, CallRecord{
+		Method:     method,
+		Path:       path,
+		StatusCode: status,
+		Timestamp:  s.clock,
+	})
+}
+
+// generateToken returns a 32-char hex string from crypto/rand.
+func (s *store) generateToken() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("twinapi: failed to generate token: %v", err))
+	}
+	return hex.EncodeToString(b)
+}
+
+// generateID returns a prefixed ID like "usr_" + 16 hex chars.
+func (s *store) generateID(prefix string) string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("twinapi: failed to generate id: %v", err))
+	}
+	return prefix + hex.EncodeToString(b)
+}
+
+func (s *store) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// regenerate jwt secret on reset
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		panic(fmt.Sprintf("twinapi: failed to generate jwt secret: %v", err))
+	}
+	s.jwtSecret = secret
+	s.clock = time.Now()
+	s.users = make(map[string]*User)
+	s.sessions = make(map[string]*Session)
+	s.teams = make(map[string]*Team)
+	s.repos = make(map[string]*Repo)
+	s.deviceCodes = make(map[string]*DeviceCode)
+	s.calls = nil
+	s.faults = make(map[string]*EndpointFault)
+}

--- a/internal/twinapi/twin.go
+++ b/internal/twinapi/twin.go
@@ -1,0 +1,78 @@
+// Package twinapi provides a digital twin of the SageOx cloud API for testing.
+//
+// Each Twin instance runs two HTTP servers on ephemeral ports: an API server that
+// replicates the real SageOx auth surface (device flow, JWT exchange, userinfo,
+// token refresh, revocation) and an admin server for test control (user creation,
+// fault injection, clock manipulation, call recording).
+//
+// The ox CLI points at the API port via SAGEOX_ENDPOINT and cannot distinguish
+// the twin from the real cloud API.
+package twinapi
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// Twin is a test double for the SageOx cloud API.
+type Twin struct {
+	APIURL   string // "http://127.0.0.1:PORT" — what ox points at
+	AdminURL string // "http://127.0.0.1:PORT2" — test control
+
+	store     *store
+	apiServer *http.Server
+	admServer *http.Server
+}
+
+// Start creates and starts a new Twin. Both servers are shut down via t.Cleanup.
+// Each invocation gets isolated state and a fresh JWT signing key.
+func Start(t testing.TB) *Twin {
+	t.Helper()
+
+	tw := &Twin{
+		store: newStore(),
+	}
+
+	// bind API listener
+	apiLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("twinapi: failed to listen for api: %v", err)
+	}
+	tw.APIURL = "http://" + apiLn.Addr().String()
+
+	// bind admin listener
+	admLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = apiLn.Close()
+		t.Fatalf("twinapi: failed to listen for admin: %v", err)
+	}
+	tw.AdminURL = "http://" + admLn.Addr().String()
+
+	tw.apiServer = &http.Server{Handler: tw.apiMux()}
+	tw.admServer = &http.Server{Handler: tw.adminMux()}
+
+	go func() { _ = tw.apiServer.Serve(apiLn) }()
+	go func() { _ = tw.admServer.Serve(admLn) }()
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = tw.apiServer.Shutdown(ctx)
+		_ = tw.admServer.Shutdown(ctx)
+	})
+
+	return tw
+}
+
+// Env returns environment variables that point ox at this twin.
+func (tw *Twin) Env() []string {
+	return []string{"SAGEOX_ENDPOINT=" + tw.APIURL}
+}
+
+// URL is an alias for APIURL.
+func (tw *Twin) URL() string {
+	return tw.APIURL
+}

--- a/internal/twinapi/twin_test.go
+++ b/internal/twinapi/twin_test.go
@@ -68,7 +68,7 @@ func TestDeviceFlow_HappyPath(t *testing.T) {
 	client := &http.Client{Timeout: 5 * time.Second}
 
 	// step 1: request device code
-	resp, err := client.Post(tw.APIURL+"/api/v1/device/code", "application/json", nil)
+	resp, err := client.Post(tw.APIURL+"/api/auth/device/code", "application/json", nil)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -130,7 +130,7 @@ func TestDeviceFlow_NoUsers_Pending(t *testing.T) {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 
-	resp, err := client.Post(tw.APIURL+"/api/v1/device/code", "application/json", nil)
+	resp, err := client.Post(tw.APIURL+"/api/auth/device/code", "application/json", nil)
 	require.NoError(t, err)
 	var codeResp map[string]any
 	json.NewDecoder(resp.Body).Decode(&codeResp)

--- a/internal/twinapi/twin_test.go
+++ b/internal/twinapi/twin_test.go
@@ -340,11 +340,12 @@ func TestTokenRefresh_OldRefreshTokenRejected(t *testing.T) {
 	oldRefresh := fix.RefreshToken
 
 	// first refresh succeeds
-	resp, _ := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/token", map[string][]string{
+	resp, err := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/token", map[string][]string{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {oldRefresh},
 		"client_id":     {"ox"},
 	})
+	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -385,9 +386,10 @@ func TestRevoke_SessionInvalidated(t *testing.T) {
 	fix := tw.WithAuthenticatedUser("revoke@example.com", "Revoker")
 
 	// revoke the session token
-	resp, _ := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/revoke", map[string][]string{
+	resp, err := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/revoke", map[string][]string{
 		"token": {fix.SessionToken},
 	})
+	require.NoError(t, err)
 	resp.Body.Close()
 
 	// JWT exchange should now fail
@@ -471,9 +473,11 @@ func TestCallRecording(t *testing.T) {
 	fix := tw.WithAuthenticatedUser("record@example.com", "Recorder")
 
 	// make a userinfo request
-	req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req, err := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+fix.JWT)
-	resp, _ := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
 	resp.Body.Close()
 
 	tw.AssertCalled(t, "GET", "/oauth2/userinfo")
@@ -492,9 +496,11 @@ func TestClockAdvance_JWTExpiry(t *testing.T) {
 	fix := tw.WithAuthenticatedUser("clock@example.com", "Clock")
 
 	// verify JWT is valid now
-	req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req, err := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+fix.JWT)
-	resp, _ := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -502,9 +508,11 @@ func TestClockAdvance_JWTExpiry(t *testing.T) {
 	tw.AdvanceTime(25 * time.Hour)
 
 	// same JWT should now fail
-	req2, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req2, err := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	require.NoError(t, err)
 	req2.Header.Set("Authorization", "Bearer "+fix.JWT)
-	resp2, _ := http.DefaultClient.Do(req2)
+	resp2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
 	resp2.Body.Close()
 	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
 
@@ -514,9 +522,11 @@ func TestClockAdvance_JWTExpiry(t *testing.T) {
 	tw.store.mu.RUnlock()
 	freshJWT := tw.store.mintJWT(user, defaultJWTExpiry)
 
-	req3, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req3, err := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	require.NoError(t, err)
 	req3.Header.Set("Authorization", "Bearer "+freshJWT)
-	resp3, _ := http.DefaultClient.Do(req3)
+	resp3, err := http.DefaultClient.Do(req3)
+	require.NoError(t, err)
 	resp3.Body.Close()
 	assert.Equal(t, http.StatusOK, resp3.StatusCode)
 }

--- a/internal/twinapi/twin_test.go
+++ b/internal/twinapi/twin_test.go
@@ -68,7 +68,7 @@ func TestDeviceFlow_HappyPath(t *testing.T) {
 	client := &http.Client{Timeout: 5 * time.Second}
 
 	// step 1: request device code
-	resp, err := client.Post(tw.APIURL+"/api/auth/device/code", "application/json", nil)
+	resp, err := client.Post(tw.APIURL+"/api/v1/device/code", "application/json", nil)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -130,7 +130,7 @@ func TestDeviceFlow_NoUsers_Pending(t *testing.T) {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 
-	resp, _ := client.Post(tw.APIURL+"/api/auth/device/code", "application/json", nil)
+	resp, _ := client.Post(tw.APIURL+"/api/v1/device/code", "application/json", nil)
 	var codeResp map[string]any
 	json.NewDecoder(resp.Body).Decode(&codeResp)
 	resp.Body.Close()

--- a/internal/twinapi/twin_test.go
+++ b/internal/twinapi/twin_test.go
@@ -1,0 +1,522 @@
+package twinapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- A. Twin lifecycle ---
+
+// TestStart_ParallelIsolation verifies two twins have independent state.
+// Failure prevented: shared package-level state leaking between tests.
+func TestStart_ParallelIsolation(t *testing.T) {
+	t.Parallel()
+
+	tw1 := Start(t)
+	tw2 := Start(t)
+
+	// different ports
+	assert.NotEqual(t, tw1.APIURL, tw2.APIURL)
+	assert.NotEqual(t, tw1.AdminURL, tw2.AdminURL)
+
+	// state is isolated: user in tw1 does not exist in tw2
+	tw1.CreateUser("usr_1", "one@example.com", "One")
+	fix := tw2.WithAuthenticatedUser("two@example.com", "Two")
+
+	assert.Equal(t, 1, len(tw1.store.users))
+	assert.Equal(t, 1, len(tw2.store.users))
+	assert.NotEmpty(t, fix.JWT)
+}
+
+// TestStart_JWTIsolation verifies JWT from one twin is rejected by another.
+// Failure prevented: per-instance secret not generated correctly.
+func TestStart_JWTIsolation(t *testing.T) {
+	t.Parallel()
+
+	tw1 := Start(t)
+	tw2 := Start(t)
+
+	fix := tw1.WithAuthenticatedUser("user@example.com", "User")
+
+	// JWT from tw1 should be rejected by tw2's userinfo endpoint
+	req, _ := http.NewRequest("GET", tw2.APIURL+"/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+fix.JWT)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// --- B. Device flow ---
+
+// TestDeviceFlow_HappyPath verifies the full device code -> token -> JWT exchange.
+// Failure prevented: device flow not returning valid session tokens.
+func TestDeviceFlow_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	tw.CreateUser("usr_test", "dev@example.com", "Dev")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	// step 1: request device code
+	resp, err := client.Post(tw.APIURL+"/api/auth/device/code", "application/json", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var codeResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&codeResp))
+	deviceCode := codeResp["device_code"].(string)
+	assert.NotEmpty(t, deviceCode)
+	assert.NotEmpty(t, codeResp["user_code"])
+
+	// step 2: poll for token (auto-approves because user exists)
+	body := fmt.Sprintf(`{"device_code":"%s","grant_type":"urn:ietf:params:oauth:grant-type:device_code","client_id":"ox"}`, deviceCode)
+	resp2, err := client.Post(tw.APIURL+"/api/v1/device/token", "application/json",
+		jsonReader(body))
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&tokenResp))
+	sessionToken := tokenResp["access_token"].(string)
+	assert.Len(t, sessionToken, 32)
+	assert.NotEmpty(t, tokenResp["refresh_token"])
+
+	// step 3: exchange session token for JWT
+	req, _ := http.NewRequest("GET", tw.APIURL+"/api/v1/cli/auth/token", nil)
+	req.Header.Set("Authorization", "Bearer "+sessionToken)
+	resp3, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp3.Body.Close()
+	assert.Equal(t, http.StatusOK, resp3.StatusCode)
+
+	var jwtResp map[string]any
+	require.NoError(t, json.NewDecoder(resp3.Body).Decode(&jwtResp))
+	jwt := jwtResp["access_token"].(string)
+	assert.Contains(t, jwt, ".") // JWT has dots
+
+	// step 4: validate JWT via userinfo
+	req2, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req2.Header.Set("Authorization", "Bearer "+jwt)
+	resp4, err := client.Do(req2)
+	require.NoError(t, err)
+	defer resp4.Body.Close()
+	assert.Equal(t, http.StatusOK, resp4.StatusCode)
+
+	var userInfo map[string]string
+	require.NoError(t, json.NewDecoder(resp4.Body).Decode(&userInfo))
+	assert.Equal(t, "dev@example.com", userInfo["email"])
+	assert.Equal(t, "Dev", userInfo["name"])
+}
+
+// TestDeviceFlow_NoUsers_Pending verifies authorization_pending when no users exist.
+// Failure prevented: auto-approve firing when it shouldn't.
+func TestDeviceFlow_NoUsers_Pending(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	// no users created
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	resp, _ := client.Post(tw.APIURL+"/api/auth/device/code", "application/json", nil)
+	var codeResp map[string]any
+	json.NewDecoder(resp.Body).Decode(&codeResp)
+	resp.Body.Close()
+
+	body := fmt.Sprintf(`{"device_code":"%s"}`, codeResp["device_code"])
+	resp2, _ := client.Post(tw.APIURL+"/api/v1/device/token", "application/json", jsonReader(body))
+	defer resp2.Body.Close()
+
+	var tokenResp map[string]string
+	json.NewDecoder(resp2.Body).Decode(&tokenResp)
+	assert.Equal(t, "authorization_pending", tokenResp["error"])
+}
+
+// --- C. JWT exchange — the exact bug we hit ---
+
+// TestJWTExchange_OrphanedSession verifies "user account not found" when session
+// points to a deleted/non-existent user.
+// Failure prevented: the exact test.sageox.ai bug — stale session token from an
+// orphaned user record silently stored as access_token.
+func TestJWTExchange_OrphanedSession(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	sess := tw.CreateOrphanedSession("usr_deleted_user")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, _ := http.NewRequest("GET", tw.APIURL+"/api/v1/cli/auth/token", nil)
+	req.Header.Set("Authorization", "Bearer "+sess.Token)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var errResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+	assert.Equal(t, "user account not found", errResp["error"])
+	assert.Equal(t, false, errResp["success"])
+}
+
+// TestJWTExchange_InvalidSessionToken verifies rejection of unknown tokens.
+// Failure prevented: JWT exchange accepting arbitrary bearer tokens.
+func TestJWTExchange_InvalidSessionToken(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+
+	req, _ := http.NewRequest("GET", tw.APIURL+"/api/v1/cli/auth/token", nil)
+	req.Header.Set("Authorization", "Bearer totally_bogus_token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestJWTExchange_MissingAuthHeader verifies proper error without auth header.
+func TestJWTExchange_MissingAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+
+	req, _ := http.NewRequest("GET", tw.APIURL+"/api/v1/cli/auth/token", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// --- D. Userinfo (server-side token validation) ---
+
+// TestUserInfo_ValidJWT verifies userinfo returns correct claims for valid JWT.
+func TestUserInfo_ValidJWT(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("alice@example.com", "Alice")
+
+	req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+fix.JWT)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var info map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&info))
+	assert.Equal(t, fix.UserID, info["sub"])
+	assert.Equal(t, "alice@example.com", info["email"])
+}
+
+// TestUserInfo_ExpiredJWT verifies rejection after clock advances past JWT expiry.
+// Failure prevented: IsAuthenticatedForEndpoint not detecting expired tokens
+// server-side. This is the scenario where local check passes but server rejects.
+func TestUserInfo_ExpiredJWT(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("bob@example.com", "Bob")
+
+	// advance clock past JWT expiry (24h default)
+	tw.AdvanceTime(25 * time.Hour)
+
+	req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+fix.JWT)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var errResp map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+	assert.Equal(t, "invalid_token", errResp["error"])
+	assert.Contains(t, errResp["error_description"], "expired")
+}
+
+// TestUserInfo_OpaqueTokenRejected verifies that sending a raw session token
+// (not a JWT) to userinfo is rejected.
+// Failure prevented: the exact bug — opaque session token stored as access_token
+// and sent to API endpoints that expect JWTs.
+func TestUserInfo_OpaqueTokenRejected(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("charlie@example.com", "Charlie")
+
+	// send the session token (opaque, 32-char hex) instead of the JWT
+	req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+fix.SessionToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// --- E. Token refresh ---
+
+// TestTokenRefresh_HappyPath verifies refresh returns a new JWT and rotates
+// the refresh token.
+func TestTokenRefresh_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("refresh@example.com", "Refresher")
+
+	resp, err := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/token", map[string][]string{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {fix.RefreshToken},
+		"client_id":     {"ox"},
+	})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tokenResp map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+	newJWT := tokenResp["access_token"].(string)
+	newRefresh := tokenResp["refresh_token"].(string)
+
+	assert.Contains(t, newJWT, ".") // is a JWT
+	assert.NotEqual(t, fix.RefreshToken, newRefresh) // rotated
+	assert.Len(t, newRefresh, 32)
+}
+
+// TestTokenRefresh_InvalidRefreshToken verifies invalid_grant for bad refresh tokens.
+func TestTokenRefresh_InvalidRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+
+	resp, err := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/token", map[string][]string{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {"completely_bogus_refresh_token"},
+		"client_id":     {"ox"},
+	})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	var errResp map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+	assert.Equal(t, "invalid_grant", errResp["error"])
+}
+
+// TestTokenRefresh_OldRefreshTokenRejected verifies that after rotation, the old
+// refresh token no longer works.
+// Failure prevented: refresh token reuse after rotation (security issue).
+func TestTokenRefresh_OldRefreshTokenRejected(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("rotate@example.com", "Rotator")
+	oldRefresh := fix.RefreshToken
+
+	// first refresh succeeds
+	resp, _ := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/token", map[string][]string{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {oldRefresh},
+		"client_id":     {"ox"},
+	})
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// second refresh with OLD token fails (it was rotated)
+	resp2, _ := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/token", map[string][]string{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {oldRefresh},
+		"client_id":     {"ox"},
+	})
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+}
+
+// --- F. Token revocation ---
+
+// TestRevoke_AlwaysReturns200 verifies RFC 7009 compliance — always 200 OK.
+func TestRevoke_AlwaysReturns200(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+
+	// revoke a non-existent token — should still return 200
+	resp, _ := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/revoke", map[string][]string{
+		"token": {"nonexistent_token"},
+	})
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestRevoke_SessionInvalidated verifies that after revoking a session token,
+// the JWT exchange no longer works.
+func TestRevoke_SessionInvalidated(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("revoke@example.com", "Revoker")
+
+	// revoke the session token
+	resp, _ := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/revoke", map[string][]string{
+		"token": {fix.SessionToken},
+	})
+	resp.Body.Close()
+
+	// JWT exchange should now fail
+	req, _ := http.NewRequest("GET", tw.APIURL+"/api/v1/cli/auth/token", nil)
+	req.Header.Set("Authorization", "Bearer "+fix.SessionToken)
+	resp2, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+}
+
+// --- G. Fault injection ---
+
+// TestFaultInjection_Userinfo401 verifies that injecting a 401 on userinfo
+// causes server-side validation to fail.
+// Failure prevented: IsAuthenticatedForEndpoint not propagating server errors.
+func TestFaultInjection_Userinfo401(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("fault@example.com", "Faulter")
+
+	// inject 401 on userinfo
+	tw.InjectFault("/oauth2/userinfo", http.StatusUnauthorized)
+
+	req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+fix.JWT)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// clear fault — should work again
+	tw.ClearFaults()
+
+	req2, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req2.Header.Set("Authorization", "Bearer "+fix.JWT)
+	resp2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode)
+}
+
+// TestFaultInjection_AfterN verifies faults that trigger only after N calls.
+// Failure prevented: retry logic not exercised because faults are all-or-nothing.
+func TestFaultInjection_AfterN(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("retry@example.com", "Retrier")
+
+	// fail after 2 successful calls
+	tw.InjectFaultAfter("/oauth2/userinfo", http.StatusServiceUnavailable, 2)
+
+	doRequest := func() int {
+		req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+		req.Header.Set("Authorization", "Bearer "+fix.JWT)
+		resp, _ := http.DefaultClient.Do(req)
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusOK, doRequest())            // call 1: ok
+	assert.Equal(t, http.StatusOK, doRequest())            // call 2: ok
+	assert.Equal(t, http.StatusServiceUnavailable, doRequest()) // call 3: fault
+	assert.Equal(t, http.StatusServiceUnavailable, doRequest()) // call 4: still faulted
+}
+
+// --- H. Call recording ---
+
+// TestCallRecording verifies API calls are recorded for assertions.
+func TestCallRecording(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("record@example.com", "Recorder")
+
+	// make a userinfo request
+	req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+fix.JWT)
+	resp, _ := http.DefaultClient.Do(req)
+	resp.Body.Close()
+
+	tw.AssertCalled(t, "GET", "/oauth2/userinfo")
+	tw.AssertNotCalled(t, "POST", "/oauth2/token")
+	assert.Equal(t, 1, tw.CallCount("GET", "/oauth2/userinfo"))
+}
+
+// --- I. Clock manipulation ---
+
+// TestClockAdvance_JWTExpiry verifies that advancing the clock past JWT expiry
+// causes the twin to reject previously valid tokens.
+func TestClockAdvance_JWTExpiry(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("clock@example.com", "Clock")
+
+	// verify JWT is valid now
+	req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+fix.JWT)
+	resp, _ := http.DefaultClient.Do(req)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// advance past expiry
+	tw.AdvanceTime(25 * time.Hour)
+
+	// same JWT should now fail
+	req2, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req2.Header.Set("Authorization", "Bearer "+fix.JWT)
+	resp2, _ := http.DefaultClient.Do(req2)
+	resp2.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+
+	// but a fresh JWT should work
+	tw.store.mu.RLock()
+	user := tw.store.users[fix.UserID]
+	tw.store.mu.RUnlock()
+	freshJWT := tw.store.mintJWT(user, defaultJWTExpiry)
+
+	req3, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+	req3.Header.Set("Authorization", "Bearer "+freshJWT)
+	resp3, _ := http.DefaultClient.Do(req3)
+	resp3.Body.Close()
+	assert.Equal(t, http.StatusOK, resp3.StatusCode)
+}
+
+// --- helpers ---
+
+func jsonReader(s string) *strings.Reader {
+	return strings.NewReader(s)
+}

--- a/internal/twinapi/twin_test.go
+++ b/internal/twinapi/twin_test.go
@@ -130,13 +130,15 @@ func TestDeviceFlow_NoUsers_Pending(t *testing.T) {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 
-	resp, _ := client.Post(tw.APIURL+"/api/v1/device/code", "application/json", nil)
+	resp, err := client.Post(tw.APIURL+"/api/v1/device/code", "application/json", nil)
+	require.NoError(t, err)
 	var codeResp map[string]any
 	json.NewDecoder(resp.Body).Decode(&codeResp)
 	resp.Body.Close()
 
 	body := fmt.Sprintf(`{"device_code":"%s"}`, codeResp["device_code"])
-	resp2, _ := client.Post(tw.APIURL+"/api/v1/device/token", "application/json", jsonReader(body))
+	resp2, err := client.Post(tw.APIURL+"/api/v1/device/token", "application/json", jsonReader(body))
+	require.NoError(t, err)
 	defer resp2.Body.Close()
 
 	var tokenResp map[string]string
@@ -347,11 +349,12 @@ func TestTokenRefresh_OldRefreshTokenRejected(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// second refresh with OLD token fails (it was rotated)
-	resp2, _ := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/token", map[string][]string{
+	resp2, err := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/token", map[string][]string{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {oldRefresh},
 		"client_id":     {"ox"},
 	})
+	require.NoError(t, err)
 	defer resp2.Body.Close()
 	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
 }
@@ -365,9 +368,10 @@ func TestRevoke_AlwaysReturns200(t *testing.T) {
 	tw := Start(t)
 
 	// revoke a non-existent token — should still return 200
-	resp, _ := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/revoke", map[string][]string{
+	resp, err := http.DefaultClient.PostForm(tw.APIURL+"/oauth2/revoke", map[string][]string{
 		"token": {"nonexistent_token"},
 	})
+	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -442,9 +446,11 @@ func TestFaultInjection_AfterN(t *testing.T) {
 	tw.InjectFaultAfter("/oauth2/userinfo", http.StatusServiceUnavailable, 2)
 
 	doRequest := func() int {
-		req, _ := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+		req, err := http.NewRequest("GET", tw.APIURL+"/oauth2/userinfo", nil)
+		require.NoError(t, err)
 		req.Header.Set("Authorization", "Bearer "+fix.JWT)
-		resp, _ := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 		return resp.StatusCode
 	}


### PR DESCRIPTION
## Summary

- **Server-side auth validation**: `IsAuthenticatedForEndpoint()` now hits `/oauth2/userinfo` to verify the server actually accepts the token, not just that it exists locally. New `IsAuthCredentialValid()` is the fast local-only check for hot paths.
- **`internal/twinapi` digital twin**: Pure Go test double of the SageOx cloud auth API (device flow, JWT exchange, userinfo, token refresh, revocation). Two-port architecture (API + admin), per-instance isolation, fake clock, fault injection, call recording.
- **25 new tests**: 19 twinapi self-tests + 6 integration tests exercising `ValidateTokenServerSide` against the twin.
- **Fix**: `DeviceCodeEndpoint` corrected to `/api/v1/device/code` matching server-side API.
- **Logging**: Full server response body logged on auth rejection for `-v` debugging.

## Motivation

Discovered during debugging: `ox login` and `ox status` showed "✓ logged in" on test.sageox.ai while `ox init` failed with "authentication required". Root cause: a stale opaque session token (from an orphaned user record) passed local validation but the server rejected it with "user account not found". The CLI silently stored the opaque token as the access_token.

```mermaid
sequenceDiagram
    participant CLI as ox CLI
    participant Local as auth.json
    participant Server as SageOx API

    CLI->>Local: IsAuthenticated() [OLD]
    Local-->>CLI: ✓ token exists, not expired
    Note right of CLI: Looks good locally...

    CLI->>Server: GET /api/v1/cli/repos
    Server-->>CLI: 401 {"error":"invalid token"}
    Note right of CLI: ...but server rejects it

    CLI->>Local: IsAuthenticated() [NEW]
    Local-->>CLI: ✓ token exists
    CLI->>Server: GET /oauth2/userinfo
    Server-->>CLI: 401 {"error":"User not found"}
    CLI-->>CLI: ✗ server rejected token
```

## Architecture: twinapi

```mermaid
graph TB
    subgraph "Test Process"
        Test[Test Function]
        OxCLI[ox CLI under test]
    end

    subgraph "twinapi.Start(t)"
        API["API Port :random<br/>Device flow, JWT exchange,<br/>userinfo, refresh, revoke"]
        Admin["Admin Port :random<br/>Create users, sessions,<br/>inject faults, advance clock"]
        Store["In-memory Store<br/>Users, Sessions, JWTs,<br/>Faults, Call log"]
    end

    Test -->|fixtures| Admin
    Test -->|SAGEOX_ENDPOINT| OxCLI
    OxCLI -->|auth requests| API
    API --> Store
    Admin --> Store
```

## Caller migration

| Caller | Check | Rationale |
|--------|-------|-----------|
| `ox init`, `ox doctor`, `ox status` | `IsAuthenticatedForEndpoint` (server) | Gates real work |
| `ox login` | `IsAuthCredentialValidForEndpoint` (local) | Just deciding whether to prompt |
| `ox agent prime`, root cmd | `IsAuthCredentialValid` (local) | Fast path |
| daemon, murmur | `IsAuthCredentialValidForEndpoint` (local) | Background, latency-sensitive |

## Test plan

- [x] 19 twinapi self-tests (lifecycle, device flow, JWT exchange, userinfo, refresh, revoke, fault injection, clock, call recording)
- [x] 6 integration tests (`ValidateTokenServerSide` against twinapi)
- [x] All existing auth tests pass (`go test ./internal/auth/...`)
- [x] Full build passes (`go build ./...`)
- [x] `TestJWTExchange_OrphanedSession` — reproduces exact bug
- [x] `TestUserInfo_OpaqueTokenRejected` — reproduces opaque token fallback bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test infrastructure and a controllable test API server to validate device auth, JWT issuance/exchange, token refresh/rotation, revocation, fault injection, call recording, and clock manipulation.

* **Refactor**
  * Made authentication checks more precise by separating local credential validity from server-side session validation and improving error/warning messages around token validation and team fetches.

* **API**
  * Device authorization token endpoints updated to a versioned path for compatibility/stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->