### PR TITLE
fix(claws): enforce 24h window and dedupe state in sageox-summary

### DIFF
--- a/claws/openclaw/sageox-summary/README.md
+++ b/claws/openclaw/sageox-summary/README.md
@@ -44,13 +44,25 @@ Once installed, ask your OpenClaw agent things like:
    (shared with [`sageox-distill`](../sageox-distill/)).
 2. **Computes the team context directories** from the SageOx endpoint
    slug.
-3. **Builds a prompt** from `assets/SUMMARIZE.md`, substituting per-team
-   directories.
-4. **Runs `claude -p`** with read-only access to each team's context dir.
+3. **Selects new daily files** for the last 24 hours by UTC date prefix,
+   via the bundled `scripts/select-new-files.sh`. The window covers
+   both today and yesterday's date-prefixed files to cleanly handle the
+   day boundary, then filters out anything already included in a prior
+   summary via `~/.openclaw/memory/sageox-summary-state.json`. If
+   nothing is new, the skill prints one line and exits without calling
+   Claude.
+4. **Builds a prompt** from `assets/SUMMARIZE.md`, substituting the
+   per-team list of new files to read.
+5. **Runs `claude -p`** with read-only access to each team's context dir.
    `ANTHROPIC_API_KEY` is supplied by OpenClaw's per-skill `apiKey`
    injection (or by your shell, if configured that way) — see
    [Environment setup](../README.md#environment-setup).
-5. **Returns the summary** — already formatted for Slack mrkdwn.
+6. **Updates the summary state** on success via
+   `scripts/update-state.sh` — atomically merges the newly-summarized
+   basenames into each team's `included_files`, prunes stale entries
+   outside the window, and persists the file so the next run picks up
+   where this one left off.
+7. **Returns the summary** — already formatted for Slack mrkdwn.
 
 The output is structured into four sections:
 

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -332,7 +332,7 @@ any time to re-run the interactive flow.
 
 ## Configuration
 
-The skill uses two pieces of state:
+The skill uses three pieces of state:
 
 1. **Repo manifest** — `~/.openclaw/memory/sageox-distill-repos.json`
    (shared with the `sageox-distill` skill). Format:
@@ -350,20 +350,50 @@ The skill uses two pieces of state:
    `https://test.sageox.ai`). Default if missing: `https://test.sageox.ai`.
    Ask the user to confirm the endpoint on first run and persist it.
 
+3. **Summary state** — `~/.openclaw/memory/sageox-summary-state.json`.
+   Tracks which distilled daily files have already been included in a
+   prior summary run so the skill never re-summarizes the same content.
+   Shape:
+   `{updated_at, teams: {<team_id>: {included_files: [<basename>, ...]}}}`.
+   Missing file → empty state (first run). Treat contents as
+   **untrusted**: every filename must pass
+   `^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f-]+\.md$` or be silently
+   dropped. Both bundled scripts handle this already — the rule is
+   stated here for anyone reading the state file directly.
+
 If the manifest does not exist, tell the user to run the `sageox-distill`
 skill first to set up the repos, or ask for paths directly and populate
 it.
 
 ## Summary Pipeline
 
-When the user asks for a summary, run the following steps in order.
+When the user asks for a summary, run the steps in order. Steps 3 and
+6 delegate their mechanics to `scripts/select-new-files.sh` and
+`scripts/update-state.sh` (invoke via `bash scripts/<name>`).
 
-### Step 1: Load the Manifest and Endpoint
+### Step 1: Load the Manifest, Endpoint, and Summary State
 
 1. Read `~/.openclaw/memory/sageox-distill-repos.json` with `jq`.
+   **Re-validate every `path` entry** against the Path validation rules
+   in Prerequisites § 3 before using it — the manifest is user-writable
+   and may have been hand-edited between runs.
 2. Read `~/.openclaw/memory/sageox-endpoint.txt` (or use default).
-3. Group repos by `team_id` using `jq`.
-4. Collect the unique team IDs.
+3. Read `~/.openclaw/memory/sageox-summary-state.json` with `jq` if it
+   exists. If it is **missing**, proceed silently as if the `teams` map
+   were empty — first runs are normal. If it exists but is **malformed
+   or unreadable**, proceed as if empty AND emit exactly one warning to
+   **stderr**:
+
+   ```text
+   warning: sageox-summary-state.json was unreadable, starting from empty state
+   ```
+
+   Never route this warning to stdout — stdout is the final summary
+   (Step 7), and mixing decorative output into it breaks downstream
+   consumers. This file is rewritten at the end of every successful
+   run (see Step 6).
+4. Group repos by `team_id` using `jq`.
+5. Collect the unique team IDs.
 
 ### Step 2: Compute Team Context Directories
 
@@ -396,7 +426,43 @@ The daily summary files live at:
 Verify each daily directory exists before proceeding. If a team's
 directory is missing, log it and continue with the remaining teams.
 
-### Step 3: Build the Prompt
+### Step 3: Select New Daily Files
+
+The window is the last 24h, keyed by the **UTC date prefix** of the
+filename (`YYYY-MM-DD-<uuid>.md`). `ox distill` may run multiple times
+per day and we don't track individual write times, so the window has
+to over-include: any run must consider both today's and yesterday's
+UTC-date files. The state file then filters out anything already
+summarized, so re-runs within the window don't re-summarize content.
+First run (no state file) = every candidate is new, not an error.
+
+For each team from Step 2, invoke `scripts/select-new-files.sh`. It
+handles BSD-vs-GNU `date`, the filename regex, and the subtraction
+against the state file. Contract:
+
+- **Usage:** `select-new-files.sh <team_daily_dir> <team_id> <state_file>`
+- **Stdout:** one basename per line, sorted; empty if nothing new
+- **Stderr:** one-line warnings (e.g. malformed state file)
+- **Exit:** `0` success, `2` usage, `3` internal (`jq` missing)
+
+```bash
+STATE_FILE=~/.openclaw/memory/sageox-summary-state.json
+NEW_FILES="$(bash scripts/select-new-files.sh \
+  "$TEAM_DIR/memory/daily" "$TEAM_ID" "$STATE_FILE")"
+```
+
+Then:
+
+1. If `NEW_FILES` is empty for a team, skip it this run — log
+   `<team_id>: no new files since last summary` to **stderr** and
+   continue with the remaining teams.
+2. If **every** team ends up with zero new files, stop the pipeline
+   before invoking Claude. Print one line to stdout —
+   `No new distilled content since last summary.` — and exit. Do
+   not modify the state file; Step 6's prune on the next
+   successful run will collect any stale entries.
+
+### Step 4: Build the Prompt
 
 1. Read the template from the skill's assets directory:
    `./assets/SUMMARIZE.md` (relative to this SKILL.md file). The file
@@ -406,13 +472,25 @@ directory is missing, log it and continue with the remaining teams.
    - `./skills/sageox-summary/assets/SUMMARIZE.md` (workspace skill)
 
 2. Substitute template placeholders:
-   - `{{DIR_LIST}}` — a list of entries, one per team, in this format:
+   - `{{FILE_LIST}}` — one section per team that has a non-empty
+     `new_files` set, in this format. The team's absolute context
+     directory is named **once** in the heading, and each file bullet
+     is **relative to that directory**. Do not repeat the absolute
+     prefix on every bullet — Claude has the team dir via `--add-dir`
+     in Step 5, and duplicating ~100 chars of path on every line is
+     pure token bloat.
 
      ```text
-     - Team "<team_id>": <daily_dir>/
+     ### Team "<team_id>" (files under <absolute_team_dir>/)
+     - memory/daily/2026-04-12-019d40b9-....md
+     - memory/daily/2026-04-13-019d4129-....md
      ```
 
-   - `{{MULTI_TEAM_RULES}}` — if there are 2+ teams, replace with:
+     Teams with zero new files were already dropped in Step 3 and
+     must not appear in `{{FILE_LIST}}`.
+
+   - `{{MULTI_TEAM_RULES}}` — if **two or more** teams survived Step 3
+     with non-empty `new_files`, replace with:
 
      ```text
      - Organize the summary by team, using each team ID as a section header
@@ -421,34 +499,73 @@ directory is missing, log it and continue with the remaining teams.
 
      Otherwise, replace with an empty string.
 
-### Step 4: Run Claude
+### Step 5: Run Claude
 
 Invoke `claude -p` with:
 
-- `--add-dir <team_dir>` for EACH team context directory (the parent
-  `teams/<team_id>/` dir, not the `memory/daily/` subdirectory)
+- `--add-dir <team_dir>` for EACH team that has new files in this run
+  (the parent `teams/<team_id>/` dir, not the `memory/daily/`
+  subdirectory). Teams dropped in Step 3 must NOT be passed — nothing
+  in their tree should be reachable.
 - `--allowedTools Read` (summary is read-only)
 - `--model claude-sonnet-4-6`
 - The substituted prompt passed via stdin
 
+The prompt enumerates the exact files Claude should read. Claude must
+not open any other file under `memory/daily/` — the enumerated list
+is the authoritative set for this run.
+
 `ANTHROPIC_API_KEY` is already set in the skill's process environment
 (either by OpenClaw's per-skill `apiKey` injection or inherited from the
-host shell — see Prerequisites § 1), so `claude -p` picks it up naturally:
+host shell — see Prerequisites § 1), so `claude -p` picks it up naturally.
+Wrap the invocation in `timeout 600` (10 minutes) — this matches the
+timeout used by `pkg/sessionsummary/claude.go` in the `ox` repo for
+comparable Claude synthesis work and gives the model enough headroom for
+cross-team summaries that pull in many daily files:
 
 ```bash
-claude -p \
+timeout 600 claude -p \
   --add-dir "$TEAM_DIR_1" \
   --add-dir "$TEAM_DIR_2" \
   --allowedTools Read \
   --model claude-sonnet-4-6 <<< "$PROMPT"
 ```
 
-Timeout the command at 10 minutes. This matches the timeout used by
-`pkg/sessionsummary/claude.go` in the `ox` repo for comparable Claude
-synthesis work and gives the model enough headroom for cross-team summaries
-that pull in many daily files. If it fails, surface the error to the user.
+If the invocation fails (non-zero exit, timeout exit 124, network
+error), surface the error to the user and **do not** proceed to Step 6
+— leaving the state file untouched lets the next run retry exactly
+the same candidate set.
 
-### Step 5: Return the Summary
+### Step 6: Update Summary State
+
+Only run this step if Claude exited successfully. On any failure
+(non-zero exit, timeout, network error), skip it entirely — leaving
+the state file untouched lets the next run retry the same candidate set.
+
+For each team that had non-empty `NEW_FILES` in Step 3, pipe that
+team's basenames into `scripts/update-state.sh`. The script merges
+them into the team's `included_files`, prunes entries whose date
+prefix is strictly older than yesterday UTC, and writes the result
+atomically via a sibling temp file + `mv -f`. See the script header
+for full details; the short form:
+
+- **Usage:** `update-state.sh <state_file> <team_id>`
+- **Stdin:** one basename per line (regex-filtered on read)
+- **Stdout:** nothing on success
+- **Stderr:** one-line warnings (e.g. malformed prior state)
+- **Exit:** `0` success, `2` usage, `3` internal
+
+```bash
+printf '%s\n' "$NEW_FILES" \
+  | bash scripts/update-state.sh "$STATE_FILE" "$TEAM_ID"
+```
+
+Teams skipped in Step 3 are **not** invoked here — their prior state
+passes through unchanged because `update-state.sh` only rewrites the
+team_id it was given. Teams with no prior entry AND no new files are
+correctly never added to the state file.
+
+### Step 7: Return the Summary
 
 Return Claude's stdout to the user directly. It is already formatted for
 Slack mrkdwn. Do not reformat or annotate — just show it.
@@ -460,6 +577,11 @@ brief one-line header showing:
 
 - How many teams were summarized
 - The endpoint used
-- Any teams that were skipped (and why)
+- Any teams that were skipped (and why — typically "no new files since
+  last summary" from Step 3)
 
 Keep any preamble or postamble minimal. The summary itself is the value.
+
+If Step 3 short-circuited because every team had zero new files, the
+only output is the single line `No new distilled content since last
+summary.` — do not invoke Claude and do not print a header.

--- a/claws/openclaw/sageox-summary/assets/SUMMARIZE.md
+++ b/claws/openclaw/sageox-summary/assets/SUMMARIZE.md
@@ -1,22 +1,23 @@
 # Team Summary
 
-You are generating a team summary from distilled session logs covering the last 24 hours. The summary will be read by people across all functions — engineering, product, marketing, and leadership. Your job is to help the team stay aligned and quickly identify what conversations need to happen and what work may need adjusting.
+You are generating a team summary from a curated set of distilled session logs. The calling skill has already selected exactly which files are new since the previous summary run — you only need to synthesize them. The summary will be read by people across all functions — engineering, product, marketing, and leadership. Your job is to help the team stay aligned and quickly identify what conversations need to happen and what work may need adjusting.
 
 ## Workflow
 
-1. Read the distilled daily summary files for the last 24 hours from the directories listed below (grouped by team).
-2. Produce a structured summary following the format described below.
+1. Read ONLY the files listed below (grouped by team). Do not open any other file in these directories — the calling skill has already filtered out anything that was covered by a prior summary, and reading un-listed files will double-count content.
+2. Each team's section names its absolute context directory once in the heading; the file paths underneath are relative to that directory. Join them when reading (e.g. `<team_dir>/memory/daily/<file>`).
+3. Produce a structured summary following the format described below.
 
-## Team context directories
+## Files to read
 
-{{DIR_LIST}}
+{{FILE_LIST}}
 
 ## Summary structure
 
 You MUST use exactly these four section headings. Each section should have 2–5 bullets. Prioritize signal over detail — a product manager and a marketer will read this alongside engineers. Synthesize across PRs and sessions; do not enumerate individual PRs unless they represent a meaningful milestone.
 
 *Where we are*
-Progress relative to what we set out to do. Cover both macro (goals, initiatives — are we on track?) and micro (what shipped in the last 24 hours). Name people and repos, but summarize themes rather than listing every PR.
+Progress relative to what we set out to do. Cover both macro (goals, initiatives — are we on track?) and micro (what shipped recently). Name people and repos, but summarize themes rather than listing every PR.
 
 *What's getting in the way*
 Blockers, friction, unresolved issues, failed attempts, or things that took longer than expected. Flag patterns. This section drives the conversations the team needs to have.
@@ -31,7 +32,6 @@ Work queued up, drafts in progress, or follow-ups called out. Anything that sign
 
 - Format for Slack mrkdwn: use *bold*, _italic_, `code`, bullet points with •
 - Keep it scannable — each bullet should be 1–2 sentences max
-- Skip anything older than 24 hours
 - Link to notable sessions where they add context
 - Surface important discussions, debates, and decisions the team had
 {{MULTI_TEAM_RULES}}

--- a/claws/openclaw/sageox-summary/scripts/select-new-files.sh
+++ b/claws/openclaw/sageox-summary/scripts/select-new-files.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# select-new-files.sh — print distilled-daily filenames that fall in the last
+# 24h window (UTC date prefix) and have NOT yet been included in a prior
+# summary run.
+#
+# Usage: select-new-files.sh <team_daily_dir> <team_id> <state_file>
+#
+# Arguments:
+#   <team_daily_dir>  Absolute path to <team_context_dir>/memory/daily/
+#   <team_id>         Team id key used inside the state file's .teams map
+#   <state_file>      Absolute path to sageox-summary-state.json (need not
+#                     exist — a missing file is treated as empty state)
+#
+# Stdout: one basename per line, sorted ascending. Empty if nothing new.
+# Stderr: single-line warnings (e.g. malformed state file).
+# Exit:
+#   0 — success (empty output is not a failure)
+#   2 — usage error (wrong arg count)
+#   3 — internal error (required tool missing)
+
+set -euo pipefail
+
+if [ $# -ne 3 ]; then
+  echo "usage: $(basename "$0") <team_daily_dir> <team_id> <state_file>" >&2
+  exit 2
+fi
+
+TEAM_DAILY_DIR="$1"
+TEAM_ID="$2"
+STATE_FILE="$3"
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 3; }
+
+# BSD (macOS) uses -v; GNU (Linux) uses -d. Try BSD first.
+TODAY_UTC="$(date -u +%Y-%m-%d)"
+YESTERDAY_UTC="$(date -u -v-1d +%Y-%m-%d 2>/dev/null \
+  || date -u -d 'yesterday' +%Y-%m-%d)"
+
+FILENAME_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f-]+\.md$'
+
+# Candidate set: basenames whose date prefix is TODAY_UTC or YESTERDAY_UTC
+# and whose full shape matches the distill-output regex. A missing daily
+# dir is not fatal — the caller skips the team when output is empty.
+CANDIDATES=""
+if [ -d "$TEAM_DAILY_DIR" ]; then
+  CANDIDATES="$(
+    ( cd "$TEAM_DAILY_DIR" && ls -1 2>/dev/null ) \
+      | grep -E "^(${TODAY_UTC}|${YESTERDAY_UTC})-[0-9a-f-]+\.md$" \
+      | sort || true
+  )"
+fi
+
+# Already-summarized set for this team.
+# Missing state file → empty (first run, normal).
+# Malformed state file → empty + stderr warning (Step 6 will rewrite it).
+ALREADY_INCLUDED=""
+if [ -f "$STATE_FILE" ]; then
+  if ! jq -e . "$STATE_FILE" >/dev/null 2>&1; then
+    echo "warning: $STATE_FILE was unreadable, starting from empty state" >&2
+  else
+    ALREADY_INCLUDED="$(
+      jq -r --arg tid "$TEAM_ID" \
+        '.teams[$tid].included_files[]? // empty' "$STATE_FILE" \
+      | grep -E "$FILENAME_RE" \
+      | sort -u || true
+    )"
+  fi
+fi
+
+# new_files = CANDIDATES − ALREADY_INCLUDED
+# Both sides are already sorted and regex-validated. Write each side to a
+# temp file with empty lines stripped, then let `comm -23` do the set
+# difference. Using temp files avoids BSD awk's rejection of multi-line
+# values in `-v var=value`.
+CAND_TMP="$(mktemp)"
+INCL_TMP="$(mktemp)"
+trap 'rm -f "$CAND_TMP" "$INCL_TMP" 2>/dev/null' EXIT
+
+printf '%s\n' "$CANDIDATES"       | grep -v '^$' > "$CAND_TMP" || true
+printf '%s\n' "$ALREADY_INCLUDED" | grep -v '^$' > "$INCL_TMP" || true
+
+comm -23 "$CAND_TMP" "$INCL_TMP"

--- a/claws/openclaw/sageox-summary/scripts/update-state.sh
+++ b/claws/openclaw/sageox-summary/scripts/update-state.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# update-state.sh — atomically merge a set of newly-summarized basenames
+# into the per-team included_files list, prune stale entries, and write
+# the result back via a temp-file rename.
+#
+# Usage: update-state.sh <state_file> <team_id>
+#        (reads newline-separated basenames from stdin)
+#
+# Arguments:
+#   <state_file>  Absolute path to sageox-summary-state.json
+#   <team_id>     Team id key to merge under
+#
+# Stdin: one basename per line (may be empty). Lines not matching the
+# distill-output regex are silently dropped.
+#
+# Stdout: nothing on success.
+# Stderr: single-line warnings (e.g. malformed prior state).
+# Exit:
+#   0 — success
+#   2 — usage error
+#   3 — internal error (required tool missing, write failed)
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "usage: $(basename "$0") <state_file> <team_id>" >&2
+  exit 2
+fi
+
+STATE_FILE="$1"
+TEAM_ID="$2"
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 3; }
+
+FILENAME_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f-]+\.md$'
+
+# Compute the prune cutoff: any entry whose date prefix is strictly older
+# than YESTERDAY_UTC has fallen out of the 24h candidate window forever.
+YESTERDAY_UTC="$(date -u -v-1d +%Y-%m-%d 2>/dev/null \
+  || date -u -d 'yesterday' +%Y-%m-%d)"
+NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Read and regex-filter added basenames from stdin.
+ADDED="$(grep -E "$FILENAME_RE" || true)"
+
+# Load existing state. Missing → {}. Malformed → {} + stderr warning.
+if [ -f "$STATE_FILE" ]; then
+  if ! EXISTING="$(jq -c . "$STATE_FILE" 2>/dev/null)"; then
+    echo "warning: $STATE_FILE was unreadable, starting from empty state" >&2
+    EXISTING='{}'
+  fi
+else
+  EXISTING='{}'
+fi
+
+# Merge + prune + dedupe in a single jq pass. Preserves other teams'
+# entries verbatim — only the target team's included_files is rewritten.
+NEW_STATE="$(
+  jq -n \
+    --argjson existing "$EXISTING" \
+    --arg tid "$TEAM_ID" \
+    --arg added "$ADDED" \
+    --arg cutoff "$YESTERDAY_UTC" \
+    --arg now "$NOW_UTC" \
+    --arg re "$FILENAME_RE" \
+    '
+      ($existing // {}) as $e
+    | ($e.teams // {}) as $teams
+    | ($teams[$tid].included_files // []) as $prior
+    | ($added | split("\n") | map(select(. != ""))) as $new
+    | (($prior + $new)
+        | map(select(test($re)))
+        | map(select(.[0:10] >= $cutoff))
+        | unique
+      ) as $merged
+    | $e
+      | .teams = ($teams | .[$tid] = {included_files: $merged})
+      | .updated_at = $now
+    '
+)"
+
+# Atomic write: temp file in the same directory, then rename.
+STATE_DIR="$(dirname "$STATE_FILE")"
+mkdir -p "$STATE_DIR"
+TMP_FILE="${STATE_FILE}.tmp.$$"
+trap 'rm -f "$TMP_FILE" 2>/dev/null' EXIT
+printf '%s\n' "$NEW_STATE" > "$TMP_FILE"
+mv -f "$TMP_FILE" "$STATE_FILE"


### PR DESCRIPTION
## Summary

- Enforce the "last 24h" window in `sageox-summary` using the UTC date prefix in distilled filenames (`YYYY-MM-DD-<uuid>.md`). Over-includes today + yesterday to cleanly cover the day boundary, then filters against a new state file so repeated runs within the window never re-summarize the same content.
- Add `~/.openclaw/memory/sageox-summary-state.json`: a per-team `included_files` ledger with atomic write + window-based pruning. First run = empty state = everything in the window is new. Malformed state = stderr warning (never mixed into stdout), treated as empty, overwritten on the next successful run.
- Move mechanics out of SKILL.md into two deterministic helpers under `scripts/` following the [Agent Skills spec](https://agentskills.io/specification) `scripts/` convention: `scripts/select-new-files.sh` (enumeration + set-difference) and `scripts/update-state.sh` (merge + prune + atomic rename). SKILL.md carries orchestration and rationale; the scripts carry the shell plumbing.

## Why

The skill's prompt told Claude "read the last 24 hours", but nothing enforced the window — `claude -p` was pointed at the entire `memory/daily/` dir and trusted to filter by filename, which in practice meant every historical distill file was in scope. This PR makes the filter real, idempotent across re-runs, and atomic on state-file write so a kill mid-run can't silently poison the next invocation's candidate set.

The script extraction is an agent-UX win beyond just token count: the executing OpenClaw agent no longer needs to parse my bash, pick a set-difference method, handle BSD-vs-GNU `date` portability, or get atomic-write semantics right. It just invokes two scripts with documented contracts.

## Depends on

- #500 (`revert: delete team-timezone feature, hardcode UTC everywhere`) — distill's daily grouping is now UTC, which is what this PR's 24h window math assumes. Without #500 the window would be misaligned by up to a day for non-UTC teams. #500 is already merged to main.

## Test plan

- [ ] First run against a team with no state file — summarizes today+yesterday UTC-date files and creates `sageox-summary-state.json`
- [ ] Re-run within the same 24h — prints `No new distilled content since last summary.` and does not invoke Claude
- [ ] Add a new distill file and re-run — summarizes only the new file, leaves the prior ones alone
- [ ] Multi-team manifest — each team's `included_files` updates independently; teams with no new files pass through unchanged
- [ ] Malformed state file — stderr warning, treated as empty, overwritten on next successful run
- [ ] Kill the skill mid-Step-6 (SIGKILL during state write) — state file is either the pre-state or the post-state, never half-written
- [ ] End-to-end smoke via OpenClaw against a real manifest (the path I could not run from Claude Code)

## What I already verified locally

- `clawhub-skill-lint`: PASS, 5 files, 29 KB / 50 MB, 0 critical, 0 warning
- Smoke tests for both scripts covering: first run, idempotent re-run, new-file incremental, malformed state, multi-team isolation, pruning entries older than `yesterday_utc`, BSD-vs-GNU awk portability (a bug my first pass shipped that the smoke tests caught)
- `make lint` / `make test` not run — change is pure markdown + bash, no Go

## Agent-UX review summary

Ran the changes through an `agent-ux` coworker review before committing. All criticals (C1 atomic state-file write, C2 concrete enumeration recipe, C3 stderr warning on malformed state) and warnings (W1 relative paths in the file list, W2 drop dead read-order hint, W3 explicit `timeout 600`, W4 trust-model cross-ref) addressed in the same commit. The subsequent `scripts/` extraction then removed most of the inline shell entirely, so the W1/C2-level shell plumbing now lives in deterministic helpers instead of SKILL.md prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent per-team state to avoid re-summarizing previously processed files
  * Automatic pruning of stale entries outside the processing window
  * Daily-file selection now spans the UTC day boundary (today/yesterday) and short-circuits when no teams have new files
  * Prompt input switched from directory lists to an explicit file list; state updates are applied atomically

* **Documentation**
  * Updated workflow, input contract, and reporting guidance (including stderr warnings for malformed state)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->