### PR TITLE
fix(distill): drop mtime filter on session facts, path-based filtering

### DIFF
--- a/cmd/ox/distill_discussions.go
+++ b/cmd/ox/distill_discussions.go
@@ -384,13 +384,27 @@ type discussionFactEntry struct {
 // factFooterDateRe matches the "(created YYYY-MM-DD)" footer in discussion fact files.
 var factFooterDateRe = regexp.MustCompile(`\(created (\d{4}-\d{2}-\d{2})\)`)
 
-// factFilenameDateRe matches YYYY-MM-DD prefix in discussion fact filenames / dirnames.
-var factFilenameDateRe = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})`)
+// factFilenameDateRe matches a YYYY-MM-DD prefix in discussion/github fact
+// filenames / dirnames. Requires a trailing separator (dash, dot, slash, or
+// end-of-string) so an accidental run-on like "20260310foo" is NOT matched
+// as "2026-03-10".
+var factFilenameDateRe = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})(?:[-./]|$)`)
 
 // readPendingDiscussionFacts reads fact files from memory/.discussion-facts/
-// that were created since the given timestamp, grouped by parsed date.
-// Dates are parsed from content (footer) or filename, not filesystem mtime.
-// Dates are always UTC.
+// within the lookback window, grouped by their content-derived date.
+//
+// The authoritative date for each fact is parsed from the file's content
+// (JSONL _meta.recorded_at → markdown footer → filename prefix, in that
+// order). Filesystem mtime is never consulted — it is not clone-stable.
+//
+// Unlike the github reader, there is intentionally NO filename-prefix
+// fast-path: the discussion directory name is server-assigned and its
+// YYYY-MM-DD prefix is not guaranteed to match the UTC day of the event's
+// recorded_at. A fast path would silently drop facts in timezone-edge
+// cases. Discussion fact files are small, so opening every candidate is
+// cheap. See readPendingGitHubFacts for the symmetric path where filename
+// ↔ content consistency is structurally guaranteed.
+//
 // Returns a map of YYYY-MM-DD → []discussionFactEntry.
 func readPendingDiscussionFacts(tcPath string, since time.Time) (map[string][]discussionFactEntry, error) {
 	factsDir := filepath.Join(tcPath, "memory", ".discussion-facts")
@@ -416,6 +430,15 @@ func readPendingDiscussionFacts(tcPath string, since time.Time) (map[string][]di
 			continue
 		}
 
+		// NOTE: no filename-prefix fast path here. The discussion directory
+		// name is server-assigned and ox cannot enforce that the YYYY-MM-DD
+		// prefix matches the UTC day of the content's recorded_at. In the
+		// timezone-edge case (e.g., a local-date-prefixed dir whose event
+		// rolls into the next UTC day) a filename fast-path would silently
+		// drop facts. Discussion fact files are small, so the content-date
+		// check below is cheap enough. See github-facts for the symmetric
+		// path where filename ↔ content consistency IS structurally
+		// guaranteed and a fast path is safe.
 		data, err := os.ReadFile(filepath.Join(factsDir, entry.Name()))
 		if err != nil {
 			continue
@@ -431,7 +454,7 @@ func readPendingDiscussionFacts(tcPath string, since time.Time) (map[string][]di
 			continue
 		}
 
-		// filter by since (UTC date comparison)
+		// filter by since (UTC date comparison on content-derived date)
 		if cutoffDate != "" && date < cutoffDate {
 			continue
 		}

--- a/cmd/ox/distill_discussions_test.go
+++ b/cmd/ox/distill_discussions_test.go
@@ -388,6 +388,67 @@ func TestReadDiscussionFacts_SinceFilter(t *testing.T) {
 	}
 }
 
+// Failure prevented: the discussion directory name is server-assigned and its
+// YYYY-MM-DD prefix may not match the UTC day of the event's recorded_at (e.g.
+// a local-timezone-prefixed directory whose event rolls into the next UTC day).
+// The content-derived date must win; a filename-prefix fast-path would silently
+// drop the fact. See ox-vhm and the code-reviewer finding on the distill
+// mtime-fix PR.
+func TestReadDiscussionFacts_FilenameOlderThanContent(t *testing.T) {
+	tcPath := t.TempDir()
+	factsDir := filepath.Join(tcPath, "memory", ".discussion-facts")
+	if err := os.MkdirAll(factsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// filename prefix = 2026-03-10 (local-date), content recorded_at = 2026-03-11 UTC.
+	// The fact should land in the 2026-03-11 bucket and survive a cutoff of 2026-03-11.
+	name := "2026-03-10-2345-ryan-019d6da5-5835-7261-baa5-e8bc3983beff.jsonl"
+	content := `{"_meta":{"schema_version":"2","source_type":"discussion","recorded_at":"2026-03-11T06:45:00Z"}}
+{"headline":"late-night decision","category":"decision","timestamp":"2026-03-11T06:45:00Z"}
+`
+	if err := os.WriteFile(filepath.Join(factsDir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	since := time.Date(2026, 3, 11, 0, 0, 0, 0, time.UTC)
+	result, err := readPendingDiscussionFacts(tcPath, since)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result["2026-03-11"]) != 1 {
+		t.Errorf("content-date bucket (2026-03-11) should contain 1 entry, got %d", len(result["2026-03-11"]))
+	}
+	if _, ok := result["2026-03-10"]; ok {
+		t.Error("filename-prefix bucket (2026-03-10) must not appear: content date is authoritative")
+	}
+}
+
+// Failure prevented: legacy discussion fact files without a YYYY-MM-DD prefix
+// (e.g. a manually-authored arch-review note) must still be read and parsed
+// from content, not skipped because the filename has no prefix.
+func TestReadDiscussionFacts_LegacyFilenameNoPrefix(t *testing.T) {
+	tcPath := t.TempDir()
+	factsDir := filepath.Join(tcPath, "memory", ".discussion-facts")
+	if err := os.MkdirAll(factsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(factsDir, "arch-review.md"),
+		[]byte("Architecture decisions\n\n---\n*(created 2026-03-11)*\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	since := time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC)
+	result, err := readPendingDiscussionFacts(tcPath, since)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result["2026-03-11"]) != 1 {
+		t.Errorf("legacy unprefixed file with content-date 2026-03-11 should be included, got %d", len(result["2026-03-11"]))
+	}
+}
+
 func TestReadPendingDiscussionFactsEmptyDir(t *testing.T) {
 	tcPath := t.TempDir() // no .discussion-facts dir
 

--- a/cmd/ox/distill_github.go
+++ b/cmd/ox/distill_github.go
@@ -615,6 +615,18 @@ func readPendingGitHubFacts(tcPath string, since time.Time) (map[string][]discus
 			continue
 		}
 
+		// fast path: the github fact filename prefix is structurally the
+		// same `day` string that gets written into the content header as
+		// `RecordedAt: day + "T00:00:00Z"` (see extractGitHubFacts). Filename
+		// and content date can't disagree, so skipping pre-cutoff files by
+		// name is safe and avoids opening them. Legacy files without a
+		// parseable prefix fall through to the content-date check below.
+		if cutoffDate != "" {
+			if m := factFilenameDateRe.FindStringSubmatch(name); m != nil && m[1] < cutoffDate {
+				continue
+			}
+		}
+
 		data, err := os.ReadFile(filepath.Join(factsDir, entry.Name()))
 		if err != nil {
 			continue
@@ -629,7 +641,8 @@ func readPendingGitHubFacts(tcPath string, since time.Time) (map[string][]discus
 			continue
 		}
 
-		// filter by since (UTC date comparison)
+		// belt-and-suspenders content check, for legacy files without a
+		// filename-prefix date.
 		if cutoffDate != "" && date < cutoffDate {
 			continue
 		}

--- a/cmd/ox/distill_github_test.go
+++ b/cmd/ox/distill_github_test.go
@@ -608,6 +608,53 @@ func TestReadPendingGitHubFacts_FiltersBySince(t *testing.T) {
 	assert.Len(t, result["2026-03-20"], 1)
 }
 
+// Failure prevented: legacy github fact files that lack the YYYY-MM-DD
+// filename prefix (hand-written or produced before the current naming
+// convention) must still be read and parsed from content. The filename-prefix
+// fast-path in readPendingGitHubFacts must only short-circuit when the regex
+// actually matches; otherwise the file falls through to the content check.
+func TestReadPendingGitHubFacts_LegacyFilenameNoPrefix(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factsDir := filepath.Join(dir, "memory", ".github-facts")
+	require.NoError(t, os.MkdirAll(factsDir, 0o755))
+
+	content := `{"_meta":{"schema_version":"2","source_type":"github","recorded_at":"2026-03-11T00:00:00Z"}}
+{"headline":"legacy","source_type":"github","timestamp":"2026-03-11T00:00:00Z"}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(factsDir, "manual-github-notes.jsonl"), []byte(content), 0o644))
+
+	since := time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC)
+	result, err := readPendingGitHubFacts(dir, since)
+	require.NoError(t, err)
+	require.Len(t, result["2026-03-11"], 1, "legacy unprefixed file with content-date 2026-03-11 should be included")
+}
+
+// Failure prevented: the filename-prefix fast path must actually cut off
+// pre-cutoff files. If the fast path regresses (e.g. someone widens the
+// match incorrectly), a 2026-03-05 file with a valid prefix should still
+// NOT appear when cutoff = 2026-03-10.
+func TestReadPendingGitHubFacts_FastPathSkipsPreCutoff(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	factsDir := filepath.Join(dir, "memory", ".github-facts")
+	require.NoError(t, os.MkdirAll(factsDir, 0o755))
+
+	content := `{"_meta":{"schema_version":"2","source_type":"github","recorded_at":"2026-03-05T00:00:00Z"}}
+{"headline":"old","source_type":"github","timestamp":"2026-03-05T00:00:00Z"}
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(factsDir, "2026-03-05-019526a0-1111-7abc-8def-0123456789ab-commits.jsonl"),
+		[]byte(content), 0o644))
+
+	since := time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC)
+	result, err := readPendingGitHubFacts(dir, since)
+	require.NoError(t, err)
+	require.Empty(t, result, "2026-03-05 fact must be excluded by cutoff 2026-03-10")
+}
+
 func TestReadPendingGitHubFacts_UUID7Filenames(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/ox/distill_sessions.go
+++ b/cmd/ox/distill_sessions.go
@@ -382,12 +382,20 @@ func sessionSummaryToFacts(input sessionInput, repoID, ep string) []facts.Fact {
 }
 
 // readPendingSessionFacts reads fact files from memory/.session-facts/<date>/
-// that were written since the given timestamp, grouped by session date.
-// Uses file mtime (not directory date) for the since filter so that
-// late-arriving sessions (e.g., March 10 session synced on March 27)
-// are included even when since is past the session date.
-// Returns a map of YYYY-MM-DD → []discussionFactEntry for seamless merge
-// with discussion and github facts in distillDaily.
+// within the lookback window, grouped by session date.
+//
+// The parent directory name is the authoritative session date.
+// extractSessionFacts writes each fact under .session-facts/<s.Date>/, where
+// s.Date comes from the session's parsed StartedAt. Directory-level filtering
+// lets us skip whole old directories without opening any file inside them.
+//
+// We deliberately do NOT filter by file mtime. mtime is not clone-stable:
+// git clone resets every file's mtime to checkout time, so on a fresh clone
+// (blue/green GC, new machine) an mtime filter would let every historical
+// fact through regardless of the session's actual date. Path-based filtering
+// is identical across clones, and the alreadyDistilled check in distillDaily
+// (via idx.distilledSources) handles dedup of facts already consumed by
+// existing daily summaries.
 func readPendingSessionFacts(tcPath string, since time.Time) (map[string][]discussionFactEntry, error) {
 	sessionFactsDir := filepath.Join(tcPath, "memory", ".session-facts")
 	dateDirs, err := os.ReadDir(sessionFactsDir)
@@ -396,6 +404,11 @@ func readPendingSessionFacts(tcPath string, since time.Time) (map[string][]discu
 			return nil, nil
 		}
 		return nil, fmt.Errorf("read session-facts dir: %w", err)
+	}
+
+	var cutoffDate string
+	if !since.IsZero() {
+		cutoffDate = since.UTC().Format("2006-01-02")
 	}
 
 	result := make(map[string][]discussionFactEntry)
@@ -410,7 +423,11 @@ func readPendingSessionFacts(tcPath string, since time.Time) (map[string][]discu
 			continue
 		}
 
-		// read all .jsonl files in this date directory
+		// path-based filter: skip the whole directory if it's before the cutoff
+		if cutoffDate != "" && date < cutoffDate {
+			continue
+		}
+
 		datePath := filepath.Join(sessionFactsDir, date)
 		files, err := os.ReadDir(datePath)
 		if err != nil {
@@ -422,15 +439,6 @@ func readPendingSessionFacts(tcPath string, since time.Time) (map[string][]discu
 				continue
 			}
 
-			// filter by file mtime — includes late-arriving sessions
-			// whose session date is older than since
-			if !since.IsZero() {
-				info, err := f.Info()
-				if err == nil && info.ModTime().Before(since) {
-					continue
-				}
-			}
-
 			data, err := os.ReadFile(filepath.Join(datePath, f.Name()))
 			if err != nil {
 				continue
@@ -440,17 +448,10 @@ func readPendingSessionFacts(tcPath string, since time.Time) (map[string][]discu
 				continue
 			}
 
-			// Use parseFactDate to extract the UTC date from content metadata.
-			// Falls back to directory name if no parseable date in content.
-			factDate := parseFactDate(content, f.Name())
-			if factDate == "" {
-				factDate = date // fallback to directory name
-			}
-
-			result[factDate] = append(result[factDate], discussionFactEntry{
+			result[date] = append(result[date], discussionFactEntry{
 				Content: content,
 				RelPath: filepath.Join("memory", ".session-facts", date, f.Name()),
-				Date:    factDate,
+				Date:    date,
 			})
 		}
 	}

--- a/cmd/ox/distill_sessions_test.go
+++ b/cmd/ox/distill_sessions_test.go
@@ -525,10 +525,14 @@ func TestReadPendingSessionFacts(t *testing.T) {
 		}
 	})
 
-	t.Run("filters by file mtime not directory date", func(t *testing.T) {
+	// Failure prevented: on a fresh clone (blue/green GC), git resets every
+	// file mtime to checkout time, so an mtime-based filter would pass every
+	// historical fact through and re-distill months of old dailies.
+	// See ox-97v / ox-wt4.
+	t.Run("filters by directory date not mtime (fresh-clone regression)", func(t *testing.T) {
 		tcPath := t.TempDir()
 
-		// create two files: one old (backdate mtime), one new (current mtime)
+		// two files: old directory date (2026-03-09), new directory date (2026-03-11)
 		for _, item := range []struct {
 			date, name string
 		}{
@@ -545,47 +549,66 @@ func TestReadPendingSessionFacts(t *testing.T) {
 			}
 		}
 
-		// backdate the old file's mtime to before since
-		oldFile := filepath.Join(tcPath, "memory", ".session-facts", "2026-03-09", "2026-03-09T14-23-ryan-Ox7f3a.jsonl")
-		oldTime := time.Date(2026, 3, 8, 0, 0, 0, 0, time.UTC)
-		os.Chtimes(oldFile, oldTime, oldTime)
+		// simulate a fresh clone: force BOTH files to have mtime = now.
+		// Under the old mtime-based filter both would pass; under path-based
+		// filtering the 2026-03-09 directory is excluded by its name alone.
+		now := time.Now()
+		for _, rel := range []string{
+			"memory/.session-facts/2026-03-09/2026-03-09T14-23-ryan-Ox7f3a.jsonl",
+			"memory/.session-facts/2026-03-11/2026-03-11T09-00-alice-OxABCD.jsonl",
+		} {
+			if err := os.Chtimes(filepath.Join(tcPath, rel), now, now); err != nil {
+				t.Fatal(err)
+			}
+		}
 
-		// since = 1 second ago — new file (current mtime) is after since, old file is before
-		since := time.Now().Add(-time.Second)
+		// cutoff = 2026-03-10 → 2026-03-09 dir excluded, 2026-03-11 dir included
+		since, _ := time.Parse("2006-01-02", "2026-03-10")
 		result, err := readPendingSessionFacts(tcPath, since)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(result) != 1 {
-			t.Errorf("got %d date groups, want 1 (only fresh file)", len(result))
+			t.Errorf("got %d date groups, want 1", len(result))
 		}
 		if _, ok := result["2026-03-11"]; !ok {
-			t.Error("expected 2026-03-11 in results (fresh mtime)")
+			t.Error("expected 2026-03-11 in results (directory >= cutoff)")
+		}
+		if _, ok := result["2026-03-09"]; ok {
+			t.Error("2026-03-09 should be excluded (directory < cutoff) regardless of mtime")
 		}
 	})
 
-	t.Run("late-arriving session included despite old date", func(t *testing.T) {
+	// Failure prevented: stale-mtime files (e.g., after a long-lived workspace
+	// sits idle and since jumps forward on the next distill run) should STILL
+	// be surfaced if their directory date is inside the window. mtime is not
+	// consulted at all.
+	t.Run("stale mtime inside window still included", func(t *testing.T) {
 		tcPath := t.TempDir()
-
-		// simulate a March 10 session extracted today (fresh mtime)
-		dir := filepath.Join(tcPath, "memory", ".session-facts", "2026-03-10")
+		dir := filepath.Join(tcPath, "memory", ".session-facts", "2026-03-11")
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(dir, "2026-03-10T14-23-ryan-Ox7f3a.jsonl"),
-			[]byte(`{"_meta":{"schema_version":"2","source_type":"session","recorded_at":"2026-03-10T00:00:00Z"}}
-{"headline":"late fact","source_type":"session"}`), 0o644); err != nil {
+		file := filepath.Join(dir, "2026-03-11T09-00-alice-OxABCD.jsonl")
+		if err := os.WriteFile(file,
+			[]byte(`{"_meta":{"schema_version":"2","source_type":"session","recorded_at":"2026-03-11T00:00:00Z"}}
+{"headline":"fact","source_type":"session"}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
 
-		// since = March 25 — file mtime is now (fresh), so it should be included
-		since, _ := time.Parse("2006-01-02", "2026-03-25")
+		// force file mtime to a year ago — path-based filter must ignore it
+		ancient := time.Now().AddDate(-1, 0, 0)
+		if err := os.Chtimes(file, ancient, ancient); err != nil {
+			t.Fatal(err)
+		}
+
+		since, _ := time.Parse("2006-01-02", "2026-03-10")
 		result, err := readPendingSessionFacts(tcPath, since)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(result["2026-03-10"]) != 1 {
-			t.Errorf("late-arriving session should be included, got %d entries", len(result["2026-03-10"]))
+		if len(result["2026-03-11"]) != 1 {
+			t.Errorf("stale-mtime file inside window should be included, got %d entries", len(result["2026-03-11"]))
 		}
 	})
 


### PR DESCRIPTION
## Summary

- `readPendingSessionFacts` re-queued every historical daily on fresh clones because it filtered session facts by `os.FileInfo.ModTime()`, which git resets to checkout time. Replaces mtime filter with a directory-name date filter so the blue/green GC flow no longer triggers months of unwanted LLM calls.
- Adds a filename-prefix fast path to `readPendingGitHubFacts` (structurally safe — the `day` string in the filename is literally the same string written into `RecordedAt`). **Does not** add a fast path to `readPendingDiscussionFacts`: the discussion directory name is server-assigned and could disagree with UTC content date in timezone-edge cases.
- Regression gates: four new tests covering fresh-clone mtime drift, filename/content divergence, and legacy unprefixed files.

## Motivation

On any fresh clone of the team context repo (which happens routinely during our blue/green GC cycle), `ox distill --dry-run --layer daily` produced output like:

```
Skipped 204 already-distilled facts
Daily distill: 0 observations and 1 facts for 2026-02-18
Daily distill: 0 observations and 1 facts for 2026-02-20
Daily distill: 0 observations and 1 facts for 2026-02-24
...
Daily distill: 1 observations and 0 facts for 2026-04-13
```

Despite a nominal 7-day lookback window, daily distill was planning to regenerate summaries for arbitrarily old historical dates. Root cause: `readPendingSessionFacts` filtered by `info.ModTime().Before(since)`. `git clone` writes every file's mtime to checkout time, so on any fresh clone the filter was a no-op and every historical session fact passed through, got bucketed by its content-date, and produced a new daily for that date. The only thing preventing unbounded re-distillation was `alreadyDistilled` dedup — a last-line safety net doing the filter's job.

mtime is not a clone-stable signal. The fact files on disk already encode the date at the path layer (parent directory for session facts, filename prefix for github facts). Filtering at the path layer is identical across clones and also cheaper — we avoid opening files we're about to discard.

## What changed

### `readPendingSessionFacts` (main fix)
- Drops the per-file `info.ModTime().Before(since)` filter entirely.
- Parses the parent directory name (`.session-facts/YYYY-MM-DD/`) as the authoritative session date.
- Skips whole directories when `dirDate < cutoffDate` before opening any file inside them.
- Uses the directory name as the fact bucket (the extractor already writes files under `s.Date`, so directory name is structurally consistent with content `recorded_at`).
- Rewrites the doc comment with the blue/green rationale so this doesn't silently get reverted.

### `readPendingGitHubFacts` (fast path, safe)
Adds a filename-prefix cutoff check before `os.ReadFile`. Safe because github fact filenames are constructed from the same `day` string that gets written into the content header as `RecordedAt: day + \"T00:00:00Z\"` — there's no way for them to disagree.

### `readPendingDiscussionFacts` (deliberately no fast path)
Originally added a symmetric filename-prefix fast path here, but the code-reviewer agent flagged a plausible timezone-edge regression: if the discussion server names directories with a local-date prefix (`2026-03-10-2345-ryan`) for an event whose UTC `created_at` falls on the next day (`2026-03-11T06:45:00Z`), the fast path would silently drop the fact. Dropped the fast path, kept the content-date check as before. Discussion fact files are small and there are few of them — the optimization isn't worth the silent-drop risk. The doc comment explicitly explains why the two readers are asymmetric.

### Regex tightening
`factFilenameDateRe` was `^(\d{4}-\d{2}-\d{2})`, which would spuriously match `20260310foo` as `2026-03-10`. Tightened to `^(\d{4}-\d{2}-\d{2})(?:[-./]|$)` to require a separator. All three callers (`readPendingGitHubFacts` fast path, `parseFactDate` filename fallback, `BuildDiscussionIndex`) only ever pass filenames/dirnames with a real separator after the date, so this is a correctness win with no behavior change on real input.

## Pipeline

```mermaid
flowchart LR
    A[extractSessionFacts] -->|writes .session-facts/YYYY-MM-DD/| B[fact files]
    C[extractGitHubFacts] -->|writes YYYY-MM-DD-<uid>.jsonl| B
    D[extractDiscussionFacts] -->|writes YYYY-MM-DD-HHMM-user-<uid>.jsonl| B
    B -->|dir name| E[readPendingSessionFacts<br/>path-based, no mtime]
    B -->|filename prefix| F[readPendingGitHubFacts<br/>fast path: structurally safe]
    B -->|content recorded_at| G[readPendingDiscussionFacts<br/>no fast path: server dirname]
    E --> H[distillDaily]
    F --> H
    G --> H
    H -->|alreadyDistilled dedup| I[daily .md + sources frontmatter]
```

## Test plan

- [x] `go test ./cmd/ox/ -run \"Distill|Fact|ReadPending|ParseFact\" -count=1` — green
- [x] `go test ./cmd/ox/ -count=1` — green (135s)
- [x] `make lint` — 0 issues
- [x] End-to-end `ox distill --dry-run --layer daily` against real `~/src/sageox/ox`:
  - **Before:** 204 already-distilled + 11 historical date entries spanning 2026-02-18 → 2026-04-13
  - **After:** 2 already-distilled + only today (2026-04-13)
- [x] Regression gate proven: code-reviewer re-ran `TestReadDiscussionFacts_FilenameOlderThanContent` with the discussion fast path re-injected — test **fails** as intended. With the fast path removed, test passes. Confirms the gate is real, not vacuous.
- [x] Two code-reviewer passes (non-nit findings from round 1 addressed, round 2 clean)

### New regression tests

| File | Test | Failure prevented |
|---|---|---|
| `distill_sessions_test.go` | `filters_by_directory_date_not_mtime_(fresh-clone_regression)` | fresh-clone mtime drift causing historical catch-up |
| `distill_sessions_test.go` | `stale_mtime_inside_window_still_included` | future reader stat-avoiding mistakenly re-introducing mtime |
| `distill_discussions_test.go` | `TestReadDiscussionFacts_FilenameOlderThanContent` | timezone-edge silent-drop if fast path is re-added |
| `distill_discussions_test.go` | `TestReadDiscussionFacts_LegacyFilenameNoPrefix` | legacy unprefixed files being dropped |
| `distill_github_test.go` | `TestReadPendingGitHubFacts_LegacyFilenameNoPrefix` | `m != nil` guard on github fast path |
| `distill_github_test.go` | `TestReadPendingGitHubFacts_FastPathSkipsPreCutoff` | github fast path cutoff behavior |

Fixes: ox-wt4, ox-97v, ox-vhm, ox-tkl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filename date parsing to prevent accidental pattern matches.
  * Improved date filtering accuracy by prioritizing content-derived dates (metadata fields) over filesystem information.
  * Ensured consistent behavior for legacy fact files without date prefixes in filenames.
  * Refined session fact grouping to use directory names for date determination instead of file timestamps.

* **Tests**
  * Added test coverage for date priority scenarios and legacy filename handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->