### PR TITLE
fix(daemon): close DirtyOverlayDebouncer stale-timer race

### DIFF
--- a/internal/daemon/codedb_dirty_watcher.go
+++ b/internal/daemon/codedb_dirty_watcher.go
@@ -31,7 +31,21 @@ type DirtyOverlayDebouncer struct {
 	timer    *time.Timer
 	lastFire time.Time
 	ctx      context.Context
-	stopped  bool // prevents stale fire() callbacks from mutating state
+	stopped  bool
+	// generation increments on every OnSettled and Stop. Each scheduled fire
+	// captures the generation in which it was created; when the fire callback
+	// runs, a generation mismatch means a newer OnSettled has superseded it
+	// and the fire must be dropped. This replaces relying on time.Timer.Stop()
+	// alone, which can't cancel a timer whose callback has already been
+	// started in its own goroutine but not yet acquired d.mu.
+	generation uint64
+
+	// fireHook is called with the captured lastFire timestamp after the fire
+	// has committed. Test-only; nil in production. Exists so tests can observe
+	// the exact moment the debouncer considers a fire to have happened,
+	// instead of measuring wall-clock time downstream inside RefreshDirtyOverlay
+	// where scheduler jitter can compress observed gaps far below minGap.
+	fireHook func(time.Time)
 }
 
 // NewDirtyOverlayDebouncer creates a debouncer that triggers dirty overlay
@@ -58,6 +72,7 @@ func (d *DirtyOverlayDebouncer) Stop() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.stopped = true
+	d.generation++
 	if d.timer != nil {
 		d.timer.Stop()
 		d.timer = nil
@@ -75,12 +90,18 @@ func (d *DirtyOverlayDebouncer) OnSettled() {
 		return
 	}
 
+	// Best-effort cancel of any currently-scheduled timer. Stop() may return
+	// false if the timer already expired and its callback goroutine has been
+	// started but is blocked on d.mu — in that case we can't reach it, and
+	// rely on the generation check in fire() to turn it into a no-op.
 	if d.timer != nil {
 		d.timer.Stop()
 	}
 
+	d.generation++
+	gen := d.generation
+
 	delay := d.debounce
-	// enforce minimum interval between rebuilds
 	if !d.lastFire.IsZero() {
 		sinceLastFire := time.Since(d.lastFire)
 		if sinceLastFire < d.minGap {
@@ -91,25 +112,33 @@ func (d *DirtyOverlayDebouncer) OnSettled() {
 		}
 	}
 
-	d.timer = time.AfterFunc(delay, d.fire)
+	d.timer = time.AfterFunc(delay, func() { d.fire(gen) })
 }
 
-// fire triggers the dirty overlay rebuild.
-// Checks the stopped flag to avoid mutating state after Stop() or when a stale
-// timer fires concurrently with OnSettled() installing a new timer.
-func (d *DirtyOverlayDebouncer) fire() {
+// fire triggers the dirty overlay rebuild. The gen parameter is the generation
+// value captured when this fire was scheduled. If OnSettled (or Stop) has run
+// since then, d.generation will have advanced and this fire is stale: it must
+// return without touching lastFire or running the refresh, so the next
+// generation's fire can enforce minGap against a consistent baseline.
+func (d *DirtyOverlayDebouncer) fire(gen uint64) {
 	d.mu.Lock()
-	if d.stopped {
+	if d.stopped || gen != d.generation {
 		d.mu.Unlock()
 		return
 	}
-	d.lastFire = time.Now()
+	now := time.Now()
+	d.lastFire = now
 	d.timer = nil
 	ctx := d.ctx
+	hook := d.fireHook
 	d.mu.Unlock()
 
 	if ctx == nil {
 		return
+	}
+
+	if hook != nil {
+		hook(now)
 	}
 
 	d.logger.Debug("dirty overlay debouncer: triggering refresh")

--- a/internal/daemon/codedb_dirty_watcher_test.go
+++ b/internal/daemon/codedb_dirty_watcher_test.go
@@ -108,6 +108,14 @@ func TestDirtyDebouncer_RapidSettles_OnlyOneRefresh(t *testing.T) {
 // TestDirtyDebouncer_MinInterval_VerifiesTimingGaps verifies that the minimum
 // interval enforces actual time gaps between rebuilds, not just a count limit.
 // Failure prevented: continuous file changes cause rebuilds every 5s instead of 30s.
+//
+// Timing is recorded via debouncer.fireHook, which captures the exact wall
+// clock that becomes lastFire — the same value the debouncer uses to enforce
+// minGap. Measuring downstream of RefreshDirtyOverlay (as earlier versions of
+// this test did via mgr.dirtyTestHook) is racy under CI contention because
+// RefreshDirtyOverlay spawns a goroutine and runs work of unpredictable
+// duration between lastFire and the hook firing, which can compress observed
+// gaps far below minGap even when the debouncer is behaving correctly.
 func TestDirtyDebouncer_MinInterval_VerifiesTimingGaps(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -117,17 +125,18 @@ func TestDirtyDebouncer_MinInterval_VerifiesTimingGaps(t *testing.T) {
 	dir := t.TempDir()
 	mgr := NewCodeDBManager(dir, codedbTestLogger(), nil)
 
-	var mu sync.Mutex
-	var fireTimes []time.Time
-	mgr.dirtyTestHook = func() {
-		mu.Lock()
-		fireTimes = append(fireTimes, time.Now())
-		mu.Unlock()
-	}
-
 	debouncer := NewDirtyOverlayDebouncer(mgr, debouncerTestLogger())
 	debouncer.debounce = 50 * time.Millisecond
 	debouncer.minGap = 500 * time.Millisecond
+
+	var mu sync.Mutex
+	var fireTimes []time.Time
+	debouncer.fireHook = func(ts time.Time) {
+		mu.Lock()
+		fireTimes = append(fireTimes, ts)
+		mu.Unlock()
+	}
+
 	debouncer.Start(context.Background())
 	defer debouncer.Stop()
 
@@ -149,15 +158,14 @@ func TestDirtyDebouncer_MinInterval_VerifiesTimingGaps(t *testing.T) {
 	require.GreaterOrEqual(t, len(times), 2, "should fire at least twice over 1.5s with 500ms minGap")
 	require.LessOrEqual(t, len(times), 5, "should not fire excessively")
 
-	// verify every consecutive pair respects the minimum interval;
-	// allow 50% tolerance because the test hook records time.Now() after
-	// RefreshDirtyOverlay completes, not when lastFire is set internally,
-	// so CI scheduler jitter can compress observed gaps significantly
+	// Each recorded time is the exact lastFire value the debouncer set.
+	// time.AfterFunc guarantees the timer fires no earlier than scheduled,
+	// and OnSettled schedules the next fire at lastFire+minGap (or later),
+	// so gap >= minGap must hold unconditionally on a correct debouncer.
 	for i := 1; i < len(times); i++ {
 		gap := times[i].Sub(times[i-1])
-		minAllowed := time.Duration(float64(debouncer.minGap) * 0.5)
-		assert.GreaterOrEqual(t, gap, minAllowed,
-			"gap between fire %d and %d was %v, expected >= %v", i-1, i, gap, minAllowed)
+		assert.GreaterOrEqual(t, gap, debouncer.minGap,
+			"gap between fire %d and %d was %v, expected >= %v", i-1, i, gap, debouncer.minGap)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `TestDirtyDebouncer_MinInterval_VerifiesTimingGaps` was flaking on CI with fire gaps of ~51ms against a `minGap` of 500ms. Investigation turned up a real race in `DirtyOverlayDebouncer`, not just a measurement artifact.
- Root cause: `time.Timer.Stop()` returns `false` when the timer has already expired but its callback goroutine hasn't yet acquired `d.mu`. `OnSettled` ignored that return value and installed a fresh timer on top, so both the already-started stale fire and the new fire ran back-to-back — producing gaps equal to the debounce window (~50ms) instead of `minGap`.
- Fix: add a `generation` counter. `OnSettled` and `Stop` bump it; each scheduled fire captures the current generation in its closure; on callback entry `fire()` returns early on mismatch so stale fires become no-ops. The new generation's fire then enforces `minGap` against a consistent baseline.
- Also fixes the test's measurement methodology: a new `debouncer.fireHook func(time.Time)` records the exact timestamp the debouncer commits to `lastFire`, replacing the previous approach of recording `time.Now()` inside `mgr.dirtyTestHook` — which runs downstream of `RefreshDirtyOverlay`'s goroutine and could drift arbitrarily from `lastFire` under CI contention. With the new hook, the 50% tolerance hedge is gone; the assertion is now `gap >= minGap` unconditionally.

## The race

```mermaid
sequenceDiagram
    participant T as Timer (expires T=590)
    participant O as OnSettled (T=600)
    participant F as fire() goroutine

    Note over T: lastFire = 50ms
    T->>F: callback scheduled at T=590
    F-->>F: goroutine started, blocked on d.mu
    O->>O: acquires d.mu first
    O->>O: d.timer.Stop() returns false (already expired)
    Note over O: OnSettled ignored that return value
    O->>O: sinceLastFire = 550 (lastFire still 50)
    O->>O: delay = debounce = 50ms
    O->>O: installs NEW timer at T=650
    O->>F: releases d.mu
    F->>F: acquires d.mu
    F->>F: lastFire = 600, d.timer = nil (clobbers new timer ref)
    F->>F: runs RefreshDirtyOverlay
    Note over T: NEW timer still pending in runtime
    T->>F: NEW timer fires at T=650
    F->>F: lastFire = 650, runs RefreshDirtyOverlay
    Note over F: gap between fires = 50ms, minGap violated
```

With the generation counter, the stale `fire(gen=N)` now sees `d.generation == N+1` and returns without touching `lastFire`, and the next fire is scheduled relative to the *actual* last committed fire — so `gap >= minGap` holds deterministically.

## Test plan

- [x] `go test -run TestDirtyDebouncer_MinInterval_VerifiesTimingGaps ./internal/daemon/ -count=30 -race` — 30/30 green (previously failed on the 1st or 2nd run)
- [x] `go test -run TestDirtyDebouncer ./internal/daemon/ -count=10 -race` — all debouncer lifecycle tests green
- [x] `go test ./internal/daemon/ -race -timeout=5m` — full daemon suite green
- [x] `go vet ./internal/daemon/...` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — only unrelated pre-existing flake (`TestCleanupStaleScores_RemovesInactive` in `internal/session`, passes 5× in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal debouncer reliability to prevent stale timer callbacks from affecting state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->