### PR TITLE
feat(init): interactive agent selection during ox init and integrate

### DIFF
--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -34,6 +34,7 @@ var initQuiet bool
 var initTeamFlag string
 var initForce bool
 var initEndpointFlag string
+var initAgentsFlag string
 
 // configResult indicates what happened when ensuring config exists
 type configResult int
@@ -119,6 +120,7 @@ func init() {
 	initCmd.Flags().StringVar(&initTeamFlag, "team", "", "team ID to associate this repo with")
 	initCmd.Flags().BoolVar(&initForce, "force", false, "initialize even if .sageox/ exists on remote")
 	initCmd.Flags().StringVar(&initEndpointFlag, "endpoint", "", "SageOx endpoint URL (overrides SAGEOX_ENDPOINT)")
+	initCmd.Flags().StringVar(&initAgentsFlag, "agents", "", "comma-separated list of agents to configure (e.g., 'gemini,codex')")
 }
 
 // initialCommitReadmeContent is the README placed in .sageox/ when creating
@@ -588,45 +590,63 @@ func runInit() error {
 		}
 	}
 
-	// === AGENT INTEGRATION (Claude Code only for now) ===
+	// === AGENT INTEGRATION ===
+
+	// prompt for which agents to configure
+	selectedAgents, agentSelectErr := selectAgentsForInit(gitRoot)
+	if agentSelectErr != nil {
+		// user canceled — default to Claude Code only
+		if !initQuiet {
+			cli.PrintWarning("Agent selection canceled, defaulting to Claude Code")
+		}
+		selectedAgents = map[string]bool{"claude-code": true}
+	}
+
 	if !initQuiet {
 		fmt.Println()
-		fmt.Println(ui.RenderCategory("Claude Code Integration"))
+		fmt.Println(ui.RenderCategory("AI Coworker Integration"))
 	}
 
-	// snapshot AGENTS.md / CLAUDE.md before injection (for rollback of modifications)
-	for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
-		p := filepath.Join(gitRoot, name)
-		if fileExists(p) {
-			tracker.trackModifiedFile(p)
+	// inject ox agent prime into agent config (only if Claude Code selected)
+	var injectionResults []fileInjectionResult
+	if selectedAgents["claude-code"] {
+		// snapshot AGENTS.md / CLAUDE.md before injection (for rollback of modifications)
+		for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
+			p := filepath.Join(gitRoot, name)
+			if fileExists(p) {
+				tracker.trackModifiedFile(p)
+			}
 		}
-	}
 
-	// inject ox agent prime into agent config
-	injectionResults, err := injectOxPrime(gitRoot)
-	if err != nil {
-		cli.PrintWarning(fmt.Sprintf("Could not set up Claude Code: %v", err))
-	} else {
-		for _, r := range injectionResults {
-			p := filepath.Join(gitRoot, r.file)
-			if r.status == injectedNew || r.status == symlinkCreated {
-				tracker.trackCreatedFile(p)
+		var injErr error
+		injectionResults, injErr = injectOxPrime(gitRoot)
+		if injErr != nil {
+			cli.PrintWarning(fmt.Sprintf("Could not set up Claude Code: %v", injErr))
+		} else {
+			for _, r := range injectionResults {
+				p := filepath.Join(gitRoot, r.file)
+				if r.status == injectedNew || r.status == symlinkCreated {
+					tracker.trackCreatedFile(p)
+				}
 			}
 		}
 	}
 
 	// detect and install agent hooks
-	installedHooks := installAgentHooks(gitRoot, true) // quiet — summarized below
+	installedHooks := installAgentHooks(gitRoot, true, selectedAgents) // quiet — summarized below
 	for _, hookFile := range installedHooks {
 		tracker.trackCreatedFile(filepath.Join(gitRoot, hookFile))
 		tracker.trackForceStage(filepath.Join(gitRoot, hookFile))
 	}
 
-	// install Claude Code slash commands
-	installedCommands := installClaudeCommands(gitRoot, true) // quiet — summarized below
-	for _, cmdFile := range installedCommands {
-		tracker.trackCreatedFile(filepath.Join(gitRoot, cmdFile))
-		tracker.trackForceStage(filepath.Join(gitRoot, cmdFile))
+	// install Claude Code slash commands (only if Claude Code selected)
+	var installedCommands []string
+	if selectedAgents["claude-code"] {
+		installedCommands = installClaudeCommands(gitRoot, true) // quiet — summarized below
+		for _, cmdFile := range installedCommands {
+			tracker.trackCreatedFile(filepath.Join(gitRoot, cmdFile))
+			tracker.trackForceStage(filepath.Join(gitRoot, cmdFile))
+		}
 	}
 
 	// rules are installed by external adapters via CapRulesInstaller
@@ -634,17 +654,17 @@ func runInit() error {
 
 	// single summary line for the entire integration section
 	if !initQuiet {
-		hasNew := err == nil && len(injectionResults) > 0
+		hasNew := len(injectionResults) > 0
 		for _, r := range injectionResults {
 			if r.status == injectedNew || r.status == injectedUpgrade {
 				hasNew = true
 				break
 			}
 		}
-		if hasNew || len(installedCommands) > 0 {
-			cli.PrintSuccess("Installed Claude Code hooks and commands")
+		if hasNew || len(installedCommands) > 0 || len(installedHooks) > 0 {
+			cli.PrintSuccess("Installed AI coworker hooks and commands")
 		} else {
-			cli.PrintPreserved("Claude Code hooks and commands")
+			cli.PrintPreserved("AI coworker hooks and commands")
 		}
 	}
 
@@ -1621,34 +1641,103 @@ func displayPath(absPath string) string {
 	return base
 }
 
-// installAgentHooks detects AI coding agents and installs project-level hooks.
+// selectAgentsForInit discovers available adapters and prompts the user to
+// choose which ones to configure. Claude Code defaults to selected; all
+// others default to off. Returns adapter names the user selected.
+func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
+	selected := map[string]bool{}
+
+	// if --agents flag provided, use it directly
+	if initAgentsFlag != "" {
+		for _, name := range strings.Split(initAgentsFlag, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				selected[name] = true
+			}
+		}
+		return selected, nil
+	}
+
+	// non-interactive: Claude Code only
+	if !cli.IsInteractive() {
+		selected["claude-code"] = true
+		return selected, nil
+	}
+
+	// Claude Code is always shown and defaults to selected
+	options := []cli.MultiSelectOption{
+		{Label: "Claude Code", Value: "claude-code", Selected: true},
+	}
+
+	// discover external adapters and check which are actually installed
+	externalAdapters := adapters.DiscoverExternalAdapters()
+	for _, ea := range externalAdapters {
+		if !ea.Detect() {
+			continue
+		}
+		label := ea.Name()
+		if info := ea.Info(); info != nil && info.DisplayName != "" {
+			label = info.DisplayName
+		}
+		options = append(options, cli.MultiSelectOption{
+			Label: label,
+			Value: ea.Name(),
+		})
+	}
+
+	// check for OpenCode separately (built-in detection)
+	openCodeDir := filepath.Join(gitRoot, ".opencode")
+	if _, err := os.Stat(openCodeDir); err == nil {
+		options = append(options, cli.MultiSelectOption{
+			Label: "OpenCode",
+			Value: "opencode",
+		})
+	}
+
+	if !initQuiet {
+		fmt.Println()
+	}
+
+	chosen, err := cli.SelectMany(
+		"Which AI coworkers should ox configure for this repo?",
+		options,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range chosen {
+		selected[name] = true
+	}
+	return selected, nil
+}
+
+// installAgentHooks installs project-level hooks for selected AI coding agents.
+// Only agents present in selectedAgents are installed.
 // Returns a list of relative paths to hook files that were created.
-func installAgentHooks(gitRoot string, quiet bool) []string {
+func installAgentHooks(gitRoot string, quiet bool, selectedAgents map[string]bool) []string {
 	var installedHooks []string
 
-	// always install Claude Code hooks (we assume Claude Code usage)
-	if HasProjectClaudeHooks(gitRoot) {
-		if !quiet {
-			cli.PrintPreserved("Claude Code integration")
-		}
-	} else {
-		if err := InstallProjectClaudeHooks(gitRoot); err != nil {
-			cli.PrintWarning(fmt.Sprintf("Could not install Claude Code integration: %v", err))
-		} else {
+	// install Claude Code hooks only if selected
+	if selectedAgents["claude-code"] {
+		if HasProjectClaudeHooks(gitRoot) {
 			if !quiet {
-				cli.PrintSuccess("Installed Claude Code integration")
+				cli.PrintPreserved("Claude Code integration")
 			}
-			installedHooks = append(installedHooks, ".claude/settings.json")
+		} else {
+			if err := InstallProjectClaudeHooks(gitRoot); err != nil {
+				cli.PrintWarning(fmt.Sprintf("Could not install Claude Code integration: %v", err))
+			} else {
+				if !quiet {
+					cli.PrintSuccess("Installed Claude Code integration")
+				}
+				installedHooks = append(installedHooks, ".claude/settings.json")
+			}
 		}
 	}
 
-	// detect OpenCode: .opencode directory exists
-	openCodeDir := filepath.Join(gitRoot, ".opencode")
-	_, openCodeErr := os.Stat(openCodeDir)
-	usesOpenCode := openCodeErr == nil
-
-	if usesOpenCode {
-		// check if integration already installed
+	// install OpenCode integration only if user selected it
+	if selectedAgents["opencode"] {
 		if HasProjectOpenCodeHooks(gitRoot) {
 			if !quiet {
 				cli.PrintPreserved("OpenCode integration")
@@ -1665,10 +1754,12 @@ func installAgentHooks(gitRoot string, quiet bool) []string {
 		}
 	}
 
-	// discover external adapter binaries and install hooks + rules for agents
-	// beyond Claude Code / OpenCode (e.g., droid, gemini, codex).
+	// install hooks + rules only for agents the user selected
 	externalAdapters := adapters.DiscoverExternalAdapters()
 	for _, ea := range externalAdapters {
+		if !selectedAgents[ea.Name()] {
+			continue
+		}
 		if ea.HasCapability(adapterprotocol.CapHookInstaller) {
 			result, err := ea.InstallHooks(gitRoot, "project")
 			if err != nil {

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"log/slog"
@@ -117,7 +119,148 @@ var integrateListCmd = &cobra.Command{
 	RunE:  runIntegrateList,
 }
 
+// hasAnyAgentFlag returns true if any agent-specific install flag was set.
+func hasAnyAgentFlag() bool {
+	return integratePiFlag || integrateAmpFlag || integrateCodexFlag ||
+		integrateGeminiFlag || integrateOpenCodeFlag || integrateUserFlag
+}
+
+// integrateAgentInfo pairs adapter metadata with its current install status.
+type integrateAgentInfo struct {
+	name        string // adapter name (e.g. "gemini")
+	displayName string
+	installed   bool
+	installFn   func() error
+}
+
+// runIntegrateInteractive shows a multi-select of detected agents and installs
+// the ones the user picks. Already-installed agents are shown greyed out.
+func runIntegrateInteractive() error {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return fmt.Errorf("not in a git repository — run from a project directory")
+	}
+
+	// build the list of agents with their install status
+	agents := []integrateAgentInfo{
+		{
+			name:        "claude-code",
+			displayName: "Claude Code",
+			installed:   HasProjectClaudeHooks(gitRoot),
+			installFn: func() error {
+				if err := InstallProjectClaudeHooks(gitRoot); err != nil {
+					return err
+				}
+				installAdapterRules(gitRoot)
+				return InstallGitHooks(gitRoot)
+			},
+		},
+	}
+
+	// discover external adapters that are detected on this machine
+	for _, ea := range adapters.DiscoverExternalAdapters() {
+		if !ea.Detect() {
+			continue
+		}
+		adapterName := ea.Name()
+		label := adapterName
+		if info := ea.Info(); info != nil && info.DisplayName != "" {
+			label = info.DisplayName
+		}
+		agents = append(agents, integrateAgentInfo{
+			name:        adapterName,
+			displayName: label,
+			installed:   checkExternalAdapterHooks(adapterName, false),
+			installFn: func() error {
+				return installExternalAdapterHooks(adapterName, false)
+			},
+		})
+	}
+
+	// check for OpenCode
+	openCodeDir := filepath.Join(gitRoot, ".opencode")
+	if _, err := os.Stat(openCodeDir); err == nil {
+		agents = append(agents, integrateAgentInfo{
+			name:        "opencode",
+			displayName: "OpenCode",
+			installed:   hasOpenCodeHooks(false),
+			installFn: func() error {
+				return installOpenCodeHooks(false)
+			},
+		})
+	}
+
+	// build multi-select options
+	var options []cli.MultiSelectOption
+	for _, a := range agents {
+		opt := cli.MultiSelectOption{
+			Label:    a.displayName,
+			Value:    a.name,
+			Selected: a.installed,
+			Disabled: a.installed,
+		}
+		if a.installed {
+			opt.Hint = "(installed)"
+		}
+		options = append(options, opt)
+	}
+
+	// if everything is already installed, just report status
+	allInstalled := true
+	for _, a := range agents {
+		if !a.installed {
+			allInstalled = false
+			break
+		}
+	}
+	if allInstalled {
+		fmt.Println("All detected AI coworkers are already integrated.")
+		for _, a := range agents {
+			fmt.Printf("  %s %s\n", ui.PassStyle.Render("✓"), a.displayName)
+		}
+		return nil
+	}
+
+	chosen, err := cli.SelectMany(
+		"Which AI coworkers should ox integrate with this repo?",
+		options,
+	)
+	if err != nil {
+		return fmt.Errorf("selection canceled")
+	}
+
+	// install only newly selected agents (skip already-installed)
+	chosenSet := map[string]bool{}
+	for _, name := range chosen {
+		chosenSet[name] = true
+	}
+
+	installed := 0
+	for _, a := range agents {
+		if a.installed || !chosenSet[a.name] {
+			continue
+		}
+		if err := a.installFn(); err != nil {
+			cli.PrintWarning(fmt.Sprintf("Could not install %s: %v", a.displayName, err))
+		} else {
+			cli.PrintSuccess(fmt.Sprintf("Installed %s integration", a.displayName))
+			installed++
+		}
+	}
+
+	if installed == 0 {
+		fmt.Println("No new integrations installed.")
+	}
+
+	return nil
+}
+
 func runIntegrateInstall(cmd *cobra.Command, args []string) error {
+	// if no agent-specific flags, show interactive multi-select
+	if !hasAnyAgentFlag() && cli.IsInteractive() {
+		return runIntegrateInteractive()
+	}
+
 	// Pi installation
 	if integratePiFlag {
 		if integrateUserFlag {
@@ -352,70 +495,62 @@ func runIntegrateUninstall(cmd *cobra.Command, args []string) error {
 }
 
 func runIntegrateList(cmd *cobra.Command, args []string) error {
-	// Claude Code status (project-level hooks)
-	fmt.Println("Claude Code (project):")
 	gitRoot := findGitRoot()
-	if gitRoot == "" {
-		fmt.Println("  (not in a git repo)")
-	} else if HasProjectClaudeHooks(gitRoot) {
-		fmt.Printf("  %s hooks: installed (.claude/settings.json)\n", ui.PassStyle.Render("✓"))
-	} else {
-		fmt.Printf("  %s hooks: not installed\n", ui.FailStyle.Render("✗"))
+
+	fmt.Println(ui.RenderCategory("AI Coworker Integrations"))
+	fmt.Println()
+
+	// Claude Code
+	printAgentStatus("Claude Code", gitRoot != "" && HasProjectClaudeHooks(gitRoot), gitRoot == "")
+
+	// all discovered external adapters (includes bundled ones)
+	for _, ea := range adapters.DiscoverExternalAdapters() {
+		label := ea.Name()
+		if info := ea.Info(); info != nil && info.DisplayName != "" {
+			label = info.DisplayName
+		}
+		installed := false
+		if gitRoot != "" {
+			installed = checkExternalAdapterHooks(ea.Name(), false)
+		}
+		printAgentStatus(label, installed, gitRoot == "")
 	}
 
-	// User-level CLAUDE.md marker
-	fmt.Println("Claude Code (user):")
-	if hasUserLevelOxPrime() {
-		fmt.Printf("  %s marker: enabled (~/.claude/CLAUDE.md)\n", ui.PassStyle.Render("✓"))
-	} else {
-		fmt.Printf("  %s marker: not enabled\n", ui.FailStyle.Render("✗"))
+	// OpenCode (built-in detection)
+	if gitRoot != "" {
+		openCodeDir := filepath.Join(gitRoot, ".opencode")
+		if _, err := os.Stat(openCodeDir); err == nil {
+			printAgentStatus("OpenCode", hasOpenCodeHooks(false), false)
+		}
 	}
 
 	fmt.Println()
 
-	// MVP: Only Claude Code integrations are supported for now.
-	// Other agents can use 'ox' via AGENTS.md/CLAUDE.md references.
-	//
-	// Commented out for MVP - uncomment when ready to support:
-	//
-	// // OpenCode status
-	// fmt.Println("OpenCode:")
-	// openCodeStatus := listOpenCodeHooks()
-	// for location, installed := range openCodeStatus {
-	// 	if installed {
-	// 		fmt.Printf("  %s %s: installed\n", ui.PassStyle.Render("✓"), location)
-	// 	} else {
-	// 		fmt.Printf("  %s %s: not installed\n", ui.FailStyle.Render("✗"), location)
-	// 	}
-	// }
-	//
-	// fmt.Println()
-	//
-	// // Gemini CLI status
-	// fmt.Println("Gemini CLI:")
-	// geminiStatus := listGeminiHooks()
-	// for location, installed := range geminiStatus {
-	// 	if installed {
-	// 		fmt.Printf("  %s %s: installed\n", ui.PassStyle.Render("✓"), location)
-	// 	} else {
-	// 		fmt.Printf("  %s %s: not installed\n", ui.FailStyle.Render("✗"), location)
-	// 	}
-	// }
-
-	// git commit hooks status
-	fmt.Println("Git commit hooks:")
+	// git commit hooks
+	fmt.Println(ui.RenderCategory("Git Hooks"))
+	fmt.Println()
 	if gitRoot == "" {
 		fmt.Println("  (not in a git repo)")
 	} else if HasGitHooks(gitRoot) {
-		fmt.Printf("  %s prepare-commit-msg: installed\n", ui.PassStyle.Render("✓"))
+		fmt.Printf("  %s prepare-commit-msg\n", ui.PassStyle.Render("✓"))
 	} else {
-		fmt.Printf("  %s prepare-commit-msg: not installed\n", ui.FailStyle.Render("✗"))
+		fmt.Printf("  %s prepare-commit-msg\n", ui.FailStyle.Render("✗"))
 	}
 
 	// show contextual tip
 	userCfg, _ := config.LoadUserConfig()
 	tips.MaybeShow("hooks", tips.WhenMinimal, false, !userCfg.AreTipsEnabled(), false)
 	return nil
+}
+
+func printAgentStatus(name string, installed bool, noRepo bool) {
+	if noRepo {
+		fmt.Printf("  %s %s (not in a git repo)\n", ui.FailStyle.Render("✗"), name)
+	} else if installed {
+		fmt.Printf("  %s %s\n", ui.PassStyle.Render("✓"), name)
+	} else {
+		fmt.Printf("  %s %s\n", ui.FailStyle.Render("✗"), name)
+	}
 }
 
 // uninstallAllIntegrations removes ox prime integrations from all AI agents

--- a/internal/cli/prompt.go
+++ b/internal/cli/prompt.go
@@ -179,6 +179,188 @@ func SelectOneValue[T comparable](title string, options []SelectOption[T], defau
 	return options[idx].Value, nil
 }
 
+// MultiSelectOption represents an item in a multi-select menu.
+type MultiSelectOption struct {
+	Label    string
+	Value    string
+	Selected bool
+	Disabled bool   // cannot be toggled (renders dimmed)
+	Hint     string // shown after label in dim text (e.g., "installed")
+}
+
+// multiSelectModel is the bubbletea model for checkbox-style selection.
+type multiSelectModel struct {
+	title   string
+	items   []MultiSelectOption
+	cursor  int
+	done    bool
+	canceled bool
+}
+
+func (m multiSelectModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			m.canceled = true
+			m.done = true
+			return m, tea.Quit
+		case "enter":
+			m.done = true
+			return m, tea.Quit
+		case " ", "space", "x":
+			if !m.items[m.cursor].Disabled {
+				m.items[m.cursor].Selected = !m.items[m.cursor].Selected
+			}
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.items)-1 {
+				m.cursor++
+			}
+		case "a":
+			for i := range m.items {
+				if !m.items[i].Disabled {
+					m.items[i].Selected = true
+				}
+			}
+		case "n":
+			for i := range m.items {
+				if !m.items[i].Disabled {
+					m.items[i].Selected = false
+				}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m multiSelectModel) View() tea.View {
+	if m.done {
+		return tea.NewView("")
+	}
+
+	var b strings.Builder
+
+	titleStyle := lipgloss.NewStyle().Bold(true)
+	selectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	cursorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+
+	b.WriteString(titleStyle.Render(m.title))
+	b.WriteString("\n\n")
+
+	for i, item := range m.items {
+		cursor := "  "
+		style := lipgloss.NewStyle()
+		if i == m.cursor {
+			cursor = cursorStyle.Render("> ")
+			style = selectedStyle
+		}
+
+		check := "[ ]"
+		if item.Selected {
+			check = "[x]"
+		}
+
+		label := check + " " + item.Label
+		if item.Hint != "" {
+			label += " " + dimStyle.Render(item.Hint)
+		}
+
+		if item.Disabled {
+			b.WriteString(cursor + dimStyle.Render(check+" "+item.Label))
+			if item.Hint != "" {
+				b.WriteString(" " + dimStyle.Render(item.Hint))
+			}
+			b.WriteString("\n")
+		} else {
+			b.WriteString(cursor + style.Render(check+" "+item.Label))
+			if item.Hint != "" {
+				b.WriteString(" " + dimStyle.Render(item.Hint))
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(dimStyle.Render("space toggle • a all • n none • enter confirm • esc skip"))
+
+	return tea.NewView(b.String())
+}
+
+// SelectMany displays an interactive multi-select with checkboxes.
+// Returns the Values of all selected options, or error if canceled.
+// Falls back to selectManySimple in non-TTY mode.
+func SelectMany(title string, options []MultiSelectOption) ([]string, error) {
+	if len(options) == 0 {
+		return nil, nil
+	}
+
+	// fall back to simple prompt if non-interactive or stdin is not a TTY
+	if !IsInteractive() || (!isatty.IsTerminal(os.Stdin.Fd()) && !isatty.IsCygwinTerminal(os.Stdin.Fd())) {
+		return selectManySimple(title, options)
+	}
+
+	items := make([]MultiSelectOption, len(options))
+	copy(items, options)
+
+	m := multiSelectModel{
+		title: title,
+		items: items,
+	}
+
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	result := finalModel.(multiSelectModel)
+	if result.canceled {
+		return nil, fmt.Errorf("selection canceled")
+	}
+
+	var selected []string
+	for _, item := range result.items {
+		if item.Selected {
+			selected = append(selected, item.Value)
+		}
+	}
+
+	return selected, nil
+}
+
+// selectManySimple is the fallback for non-TTY environments.
+// Returns only pre-selected defaults.
+func selectManySimple(title string, options []MultiSelectOption) ([]string, error) {
+	fmt.Println(title)
+	fmt.Println()
+	for i, opt := range options {
+		check := "[ ]"
+		if opt.Selected {
+			check = "[x]"
+		}
+		fmt.Printf("  %d. %s %s\n", i+1, check, opt.Label)
+	}
+	fmt.Println()
+	fmt.Println("Non-interactive mode: using defaults")
+
+	var selected []string
+	for _, opt := range options {
+		if opt.Selected {
+			selected = append(selected, opt.Value)
+		}
+	}
+	return selected, nil
+}
+
 // inputModel is the bubbletea model for text input.
 type inputModel struct {
 	title       string


### PR DESCRIPTION
## Summary

- `ox init` was aggressively installing hooks for ALL discovered adapter binaries (.codex, .factory, .gemini, .opencode) without asking — bad DX
- Adds a **multi-select TUI prompt** during `ox init` letting users choose which AI coworkers to configure
- Claude Code defaults to selected; all others default to off; only agents detected as installed on the machine are shown
- `ox integrate install` (no flags) now shows the same interactive selector, with already-installed agents greyed out
- `ox integrate list` dynamically shows status of all discovered adapters instead of hardcoded Claude Code only
- New `--agents` flag on `ox init` for scripted/CI usage (e.g., `ox init --agents claude-code,gemini`)
- Non-interactive/CI environments default to Claude Code only

```mermaid
flowchart TD
    A[ox init] --> B{--agents flag?}
    B -->|yes| C[parse flag, skip prompt]
    B -->|no| D{interactive TTY?}
    D -->|no| E[Claude Code only]
    D -->|yes| F[discover adapters]
    F --> G[filter by Detect]
    G --> H[multi-select prompt]
    H --> I[install selected agents]
```

## Test plan

- [ ] `ox init` in fresh repo — verify multi-select appears with Claude Code pre-checked
- [ ] Uncheck Claude Code — verify no `.claude/` directory created
- [ ] `ox init --agents gemini` — verify only Gemini + no prompt
- [ ] Piped stdin (`echo | ox init`) — verify Claude Code only, no prompt
- [ ] `ox integrate install` — verify interactive selector with installed agents greyed out
- [ ] `ox integrate list` — verify all discovered adapters shown with status
- [ ] `make lint && make test` — 13,097 tests pass, 0 lint issues

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--agents` CLI flag to specify agent adapters to configure during initialization
  * Interactive multi-select interface for choosing which agents to integrate into your project
  * Extended agent support beyond Claude Code to include external adapters and OpenCode
  * Enhanced integration list display with agent categories and installation status
  * New interactive checkbox UI for selecting multiple options with keyboard navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->