### PR TITLE
refactor(claws): progressive-disclose ox install into references/

### DIFF
--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -88,224 +88,40 @@ even though this skill writes them: the user (or a process running as
 the user) may have edited the file by hand or by another tool between
 runs. Re-validate every read.
 
-### 4. Installing `ox` — interactive setup
+### 4. Installing and updating `ox`
 
 The `ox` CLI install method is a one-time choice stored in
-`~/.openclaw/memory/sageox-ox-install.json`. Check that file first:
+`~/.openclaw/memory/sageox-ox-install.json`. On every run of this
+skill, invoke the bundled state checker:
 
 ```bash
-cat ~/.openclaw/memory/sageox-ox-install.json 2>/dev/null
+bash scripts/update-ox.sh
 ```
 
-**If the file exists:** read `install_method` and (for the git method)
-`clone_path` + `auto_update`. If `install_method == "git"` and
-`auto_update == true`, update ox before proceeding (see "Updating ox from
-git" below).
+Contract:
 
-**If the file does not exist:** STOP. This is a one-time decision that
-gets persisted to disk and affects every future run of this skill — the
-user must own it. You **MUST** ask the user which method they want and
-**wait for their response**. Do not pick a default. Do not guess. Do not
-run any install commands yet. Present both options verbatim, then stop
-and wait:
+- **Stdout:** nothing on success
+- **Stderr:** one-line warnings on update failures (non-fatal) and the
+  "needs install" signal
+- **Exit:** `0` ox is ready (continue to § 5); `2` install state is
+  missing — STOP, read [`references/INSTALL.md`](references/INSTALL.md)
+  and follow the interactive setup, then re-run this script to confirm
 
-> How do you want to install the `ox` CLI? Pick one — I won't choose for
-> you, because this gets saved to
-> `~/.openclaw/memory/sageox-ox-install.json` and reused every run.
->
-> 1. **curl install** — runs the official install script from a pinned
->    release tag. Fastest, no build toolchain needed. Lands in
->    `/usr/local/bin` (Linux) or `/opt/homebrew/bin` or `/usr/local/bin`
->    (macOS). No auto-update; you'll re-run this flow to upgrade.
-> 2. **Build from git source** — clones `github.com/sageox/ox` to a
->    directory you choose and builds with `make install`. Gives you
->    latest `main`, and optionally auto-updates on every run. Requires
->    Go ≥ 1.24.
->
-> Reply `1` or `2`.
+`update-ox.sh` handles the auto-update flow for the git install method
+(re-validates the recorded clone path against the rules in § 3 above,
+runs `git pull --ff-only && make build && make install`, falls back to
+the existing binary on any failure with a stderr warning + a tail of
+the build log). Curl-method users hit a silent no-op — there is
+nothing to update on a per-run basis.
 
-**Blocking rule:** do not proceed until the user replies with `1` or
-`2`. If they say "you choose", "whatever", or try to skip, ask again and
-explain that this is a persisted choice. Once they answer, save it to
-the memory file.
+The user can say **"switch ox install method"** or **"update ox now"**
+at any time — both re-enter the flow in
+[`references/INSTALL.md`](references/INSTALL.md).
 
 **Do not install `ox` via Homebrew or any package manager** (e.g.
 `brew install sageox/tap/ox`, `apt`, `dnf`, `pacman`). The tap exists
 for general use but is not supported inside OpenClaw skills — only
-`curl` and `git source` are. These two options work the same on macOS
-and Linux; pick based on whether the user wants a pinned release or
-`main` with optional auto-update, **not** based on their operating
-system.
-
-#### Option 1: curl install
-
-Download and run the ox install script. The agent should print the source
-URL and a head/tail preview of the downloaded script before executing it,
-so the user can sanity-check what is about to run:
-
-The URL is **pinned to a specific release tag** (not `main`) so the install
-path is reproducible and can't be silently changed by an upstream commit. Bump
-`OX_INSTALL_REF` when a newer release of `sageox/ox` is available.
-
-```bash
-# Pinned release tag. Bump this when a newer sageox/ox release is published.
-OX_INSTALL_REF="v0.6.1"
-
-# Download to a temp file. -f makes curl fail on HTTP errors instead of
-# executing an HTML error page; --max-time bounds a stalled connection.
-# Use the template form for mktemp — portable across GNU (Linux) and BSD (macOS).
-INSTALL_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
-curl -fsSL --max-time 60 \
-  "https://raw.githubusercontent.com/sageox/ox/${OX_INSTALL_REF}/scripts/install.sh" \
-  -o "$INSTALL_SCRIPT"
-
-# Surface what is about to run.
-echo "Downloaded ox install script:"
-echo "  Source: https://github.com/sageox/ox/blob/${OX_INSTALL_REF}/scripts/install.sh"
-ls -lh "$INSTALL_SCRIPT"
-echo "--- first 5 lines ---"
-head -5 "$INSTALL_SCRIPT"
-echo "--- last 5 lines ---"
-tail -5 "$INSTALL_SCRIPT"
-
-# Execute and clean up.
-bash "$INSTALL_SCRIPT"
-rm -f "$INSTALL_SCRIPT"
-```
-
-After it completes, verify `command -v ox` succeeds. Then persist:
-
-```bash
-mkdir -p ~/.openclaw/memory
-cat > ~/.openclaw/memory/sageox-ox-install.json <<EOF
-{
-  "install_method": "curl",
-  "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-}
-EOF
-```
-
-`ox` lands in a standard system dir (`/usr/local/bin` on Linux,
-`/opt/homebrew/bin` or `/usr/local/bin` on macOS) that is normally already
-on PATH. If `command -v ox` still fails after install, ask the user to
-check their shell PATH.
-
-#### Option 2: build from git source
-
-1. Verify Go ≥ 1.24 is installed:
-
-   ```bash
-   command -v go && go version
-   ```
-
-   If missing, print OS-appropriate install commands and stop until the
-   user installs Go:
-
-   - **macOS:** `brew install go` or download from <https://go.dev/dl/>
-   - **Linux (Debian/Ubuntu):** `sudo apt-get install -y golang-go`
-     (verify the version; use <https://go.dev/dl/> if the distro package
-     is older than 1.24)
-   - **Linux (Fedora/RHEL):** `sudo dnf install -y golang`
-   - **Linux (Arch):** `sudo pacman -S --noconfirm go`
-
-2. Ask the user for a clone path. Default: `$HOME/src/sageox/ox`.
-   **Validate** the input against the Path validation rules above,
-   including the additional rule that the path must be under `$HOME`.
-   Re-prompt on failure.
-
-   ⚠️ **The clone path becomes a privileged location.** If auto-update is
-   enabled, this skill will run `make build && make install` from it on
-   every invocation. Anyone with write access to the clone path can run
-   arbitrary code in the user's environment. Strongly recommend a
-   personal directory under `$HOME` (the default `$HOME/src/sageox/ox`
-   is a good choice). Refuse anything in `/tmp`, `/var/tmp`, `/dev/shm`,
-   shared filesystems, or world-writable directories — these checks are
-   already part of the validation rules; do not bypass them.
-
-3. Ask the user whether to auto-update from git on every run (yes/no).
-   Default: yes.
-
-4. Clone and build:
-
-   ```bash
-   CLONE_PATH="<user-chosen path>"
-   mkdir -p "$(dirname "$CLONE_PATH")"
-   if [ ! -d "$CLONE_PATH/.git" ]; then
-     git clone https://github.com/sageox/ox.git "$CLONE_PATH"
-   fi
-   (cd "$CLONE_PATH" && make build && make install)
-   ```
-
-5. Detect Go's paths so the user can configure PATH in `~/.openclaw/.env`:
-
-   ```bash
-   GO_BIN_DIR="$(dirname "$(command -v go)")"
-   GO_INSTALL_DIR="$(go env GOBIN)"
-   [ -z "$GO_INSTALL_DIR" ] && GO_INSTALL_DIR="$HOME/go/bin"
-   ```
-
-6. Persist the memory file:
-
-   ```bash
-   mkdir -p ~/.openclaw/memory
-   cat > ~/.openclaw/memory/sageox-ox-install.json <<EOF
-   {
-     "install_method": "git",
-     "clone_path": "$CLONE_PATH",
-     "auto_update": true,
-     "go_bin_dir": "$GO_BIN_DIR",
-     "go_install_dir": "$GO_INSTALL_DIR",
-     "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-   }
-   EOF
-   ```
-
-7. Verify `ox` is on the current subprocess PATH:
-
-   ```bash
-   command -v ox
-   ```
-
-   If it is **not** on PATH, print a copy-pasteable block tailored to the
-   user's detected paths and tell them to add it to `~/.openclaw/.env`:
-
-   ```
-   Add this to ~/.openclaw/.env:
-
-   PATH=<GO_BIN_DIR>:/usr/local/bin:/usr/bin:/bin:<GO_INSTALL_DIR>
-   ```
-
-   Stop and ask the user to confirm once they've updated `.env` and
-   restarted the skill. OpenClaw loads `.env` into the skill subprocess,
-   so an updated PATH takes effect on the next invocation.
-
-#### Updating `ox` from git (auto-update flow)
-
-On every subsequent run, if the memory file says
-`install_method == "git"` and `auto_update == true`:
-
-1. Read `clone_path` from `~/.openclaw/memory/sageox-ox-install.json`.
-2. **Re-validate** it against the Path validation rules in Prerequisites
-   § 3, including the additional clone-path checks (must be under
-   `$HOME`, must exist, must contain a `.git` subdirectory). The memory
-   file is user-writable and may have been edited externally between
-   runs — never trust persisted values without re-validation.
-3. **If validation fails**, log a clear error naming the failing rule,
-   skip the auto-update entirely, and fall back to the existing `ox`
-   binary on PATH. Do not proceed with `cd` / `git pull` / `make install`.
-4. If validation passes, run:
-
-   ```bash
-   (cd "$CLONE_PATH" && git pull --ff-only && make build && make install) || {
-     echo "ox auto-update failed; continuing with existing binary" >&2
-   }
-   ```
-
-Auto-update failures (validation or build) are non-fatal — fall back to
-the existing binary and surface the error to the user.
-
-The user can say **"switch ox install method"** or **"update ox now"** at
-any time to re-run the interactive flow.
+`curl` and `git source` are.
 
 ### 5. Authentication and git config
 

--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -14,10 +14,14 @@ metadata:
         - ox
         - git
         - gh
+        - jq
     install:
       - kind: brew
         formula: gh
         bins: [gh]
+      - kind: brew
+        formula: jq
+        bins: [jq]
     homepage: https://sageox.ai
 ---
 
@@ -103,9 +107,11 @@ Contract:
 - **Stdout:** nothing on success
 - **Stderr:** one-line warnings on update failures (non-fatal) and the
   "needs install" signal
-- **Exit:** `0` ox is ready (continue to § 5); `2` install state is
-  missing — STOP, read [`references/INSTALL.md`](references/INSTALL.md)
-  and follow the interactive setup, then re-run this script to confirm
+- **Exit:** `0` ox is ready (continue to § 5); `2` ox is not usable
+  (no install state, or state records ox as installed but it isn't on
+  PATH) — STOP, read
+  [`references/INSTALL.md`](references/INSTALL.md), follow the
+  interactive setup, then re-run this script to confirm
 
 `update-ox.sh` handles the auto-update flow for the git install method
 (re-validates the recorded clone path against the rules in § 3 above,

--- a/claws/openclaw/sageox-distill/references/INSTALL.md
+++ b/claws/openclaw/sageox-distill/references/INSTALL.md
@@ -1,0 +1,142 @@
+# Installing `ox` — interactive setup
+
+Invoked when `bash scripts/update-ox.sh` exits `2` (no install state
+recorded). The deterministic shell lives in `scripts/install-ox-curl.sh`
+and `scripts/install-ox-git.sh`; this file covers the user-facing
+choice and validation. Path validation rules are defined in SKILL.md
+§ 3.
+
+## The choice
+
+You **MUST** ask the user which method they want and **wait for their
+response**. Do not pick a default. Do not guess. Do not run any install
+commands yet. Present both options verbatim, then stop and wait:
+
+> How do you want to install the `ox` CLI? Pick one — I won't choose for
+> you, because this gets saved to
+> `~/.openclaw/memory/sageox-ox-install.json` and reused every run.
+>
+> 1. **curl install** — runs the official install script from a pinned
+>    release tag. Fastest, no build toolchain needed. Lands in
+>    `/usr/local/bin` (Linux) or `/opt/homebrew/bin` or `/usr/local/bin`
+>    (macOS). No auto-update; you'll re-run this flow to upgrade.
+> 2. **Build from git source** — clones `github.com/sageox/ox` to a
+>    directory you choose and builds with `make install`. Gives you
+>    latest `main`, and optionally auto-updates on every run. Requires
+>    Go ≥ 1.24.
+>
+> Reply `1` or `2`.
+
+**Blocking rule:** do not proceed until the user replies with `1` or
+`2`. If they say "you choose", "whatever", or try to skip, ask again
+and explain that this is a persisted choice that affects every future
+run.
+
+**Do not install `ox` via Homebrew or any package manager** (e.g.
+`brew install sageox/tap/ox`, `apt`, `dnf`, `pacman`). The tap exists
+for general use but is not supported inside OpenClaw skills — only
+`curl` and `git source` are. These two options work the same on macOS
+and Linux; pick based on whether the user wants a pinned release or
+`main` with optional auto-update, **not** based on their operating
+system.
+
+## Option 1: curl install
+
+Invoke the bundled helper. It downloads the install script from a
+pinned release tag, prints a head/tail preview so the user can sanity-
+check what is about to run, executes it, verifies `command -v ox`
+succeeds, and writes `~/.openclaw/memory/sageox-ox-install.json` with
+`install_method: curl`.
+
+```bash
+bash scripts/install-ox-curl.sh
+```
+
+Contract:
+
+- **Args:** none
+- **Stdout:** human-readable progress (download URL, head/tail preview,
+  install script output)
+- **Stderr:** errors
+- **Exit:** `0` success; `3` internal (curl missing, install script
+  failed, or `ox` not on PATH after install)
+
+If the script exits non-zero, surface its stderr to the user and stop.
+Do not silently retry.
+
+## Option 2: build from git source
+
+Three things must happen before the script can run, and the agent owns
+all of them:
+
+1. **Verify Go ≥ 1.24:**
+
+   ```bash
+   command -v go && go version
+   ```
+
+   If missing, print OS-appropriate install commands and stop until the
+   user installs Go:
+
+   - **macOS:** `brew install go` or download from <https://go.dev/dl/>
+   - **Linux (Debian/Ubuntu):** `sudo apt-get install -y golang-go`
+     (verify the version; use <https://go.dev/dl/> if the distro
+     package is older than 1.24)
+   - **Linux (Fedora/RHEL):** `sudo dnf install -y golang`
+   - **Linux (Arch):** `sudo pacman -S --noconfirm go`
+
+2. **Ask the user for a clone path.** Default: `$HOME/src/sageox/ox`.
+   **Validate** the input against the Path validation rules in
+   SKILL.md § 3, including the additional rule that the path must be
+   under `$HOME`. Re-prompt on failure. Expand `~` to `$HOME` before
+   passing to the script — the script's defensive re-check requires a
+   path starting with `$HOME/`.
+
+   ⚠️ **The clone path becomes a privileged location.** If auto-update
+   is enabled, this skill will run `make build && make install` from
+   it on every invocation. Anyone with write access to the clone path
+   can run arbitrary code in the user's environment. Strongly
+   recommend a personal directory under `$HOME` (the default
+   `$HOME/src/sageox/ox` is a good choice). Refuse anything in `/tmp`,
+   `/var/tmp`, `/dev/shm`, shared filesystems, or world-writable
+   directories — these are already in the validation rules; do not
+   bypass them.
+
+3. **Ask the user whether to auto-update from git on every run**
+   (yes/no). Default: yes.
+
+Then invoke the bundled helper with the validated clone path and the
+literal string `true` or `false`:
+
+```bash
+bash scripts/install-ox-git.sh "$CLONE_PATH" "true"
+```
+
+Contract:
+
+- **Args:** `<clone_path>` `<auto_update: true|false>`
+- **Stdout:** clone/build progress
+- **Stderr:** errors and PATH-configuration guidance
+- **Exit:** `0` success; `2` usage / bad arg; `3` internal (Go missing
+  or too old, build failed)
+
+The script re-validates the clone path defensively, clones if needed,
+runs `make build && make install`, detects Go's bin/install dirs,
+persists the memory file, and warns to **stderr** if `command -v ox`
+doesn't succeed in the current subprocess. If you see that warning,
+surface the PATH guidance from the script's stderr to the user
+verbatim, then stop and ask them to confirm once they've updated
+`~/.openclaw/.env` and restarted the skill. OpenClaw loads `.env` into
+the skill subprocess, so the updated PATH takes effect on the next
+invocation.
+
+## After installation
+
+Re-run the state checker to confirm:
+
+```bash
+bash scripts/update-ox.sh
+```
+
+It should exit `0` with no stderr. Continue with the rest of the
+prerequisites in SKILL.md (authentication, etc.).

--- a/claws/openclaw/sageox-distill/scripts/install-ox-curl.sh
+++ b/claws/openclaw/sageox-distill/scripts/install-ox-curl.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install-ox-curl.sh — download and run the official ox install script
+# from a pinned release tag, then persist the chosen install method to
+# the OpenClaw memory file.
+#
+# Usage: install-ox-curl.sh
+#
+# Stdout: human-readable progress (download URL, head/tail preview,
+#         install script output)
+# Stderr: errors
+# Exit:
+#   0 — success, ox installed and memory file written
+#   3 — internal error (curl missing, install script failed, ox not on
+#       PATH after install)
+#
+# The pinned release tag below makes this script reproducible: future
+# upstream commits to install.sh on main can't change what this skill
+# fetches. Bump OX_INSTALL_REF when a newer sageox/ox release ships.
+
+set -euo pipefail
+
+OX_INSTALL_REF="v0.6.1"
+INSTALL_URL="https://raw.githubusercontent.com/sageox/ox/${OX_INSTALL_REF}/scripts/install.sh"
+SOURCE_BLOB="https://github.com/sageox/ox/blob/${OX_INSTALL_REF}/scripts/install.sh"
+
+command -v curl >/dev/null 2>&1 || { echo "error: curl is required" >&2; exit 3; }
+
+# Use the template form for mktemp — portable across GNU (Linux) and BSD (macOS).
+INSTALL_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
+trap 'rm -f "$INSTALL_SCRIPT" 2>/dev/null' EXIT
+
+# -f makes curl fail on HTTP errors instead of executing an HTML error page;
+# --max-time bounds a stalled connection.
+curl -fsSL --max-time 60 "$INSTALL_URL" -o "$INSTALL_SCRIPT"
+
+# Surface what is about to run so the user can sanity-check it.
+echo "Downloaded ox install script:"
+echo "  Source: $SOURCE_BLOB"
+ls -lh "$INSTALL_SCRIPT"
+echo "--- first 5 lines ---"
+head -5 "$INSTALL_SCRIPT"
+echo "--- last 5 lines ---"
+tail -5 "$INSTALL_SCRIPT"
+
+# Execute.
+bash "$INSTALL_SCRIPT"
+
+# Verify the result before we persist anything.
+if ! command -v ox >/dev/null 2>&1; then
+  echo "error: ox install script ran but 'ox' is not on PATH" >&2
+  exit 3
+fi
+
+# Persist the install method.
+mkdir -p "$HOME/.openclaw/memory"
+INSTALLED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat > "$HOME/.openclaw/memory/sageox-ox-install.json" <<EOF
+{
+  "install_method": "curl",
+  "ox_install_ref": "$OX_INSTALL_REF",
+  "installed_at": "$INSTALLED_AT"
+}
+EOF

--- a/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
@@ -10,7 +10,10 @@
 #   <clone_path>   Absolute path under $HOME where the repo will live.
 #                  The agent has already prompted the user and validated
 #                  this against the Path validation rules in SKILL.md
-#                  § 3 — this script re-checks defensively.
+#                  § 3 — this script re-checks defensively, then
+#                  physically resolves the parent directory (via
+#                  `cd && pwd -P`) to reject symlink escapes before
+#                  touching the filesystem.
 #   <auto_update>  Literal string "true" or "false" — whether to run
 #                  git pull + make install on every future invocation.
 #
@@ -19,8 +22,9 @@
 #         subprocess's PATH after install
 # Exit:
 #   0 — success, ox installed and memory file written
-#   2 — usage error (wrong arg count or bad arg value)
-#   3 — internal error (Go missing or too old, build failed)
+#   2 — usage error (wrong arg count, bad arg value, path validation
+#       failure, or symlink escape)
+#   3 — internal error (Go or jq missing or too old, build failed)
 
 set -euo pipefail
 
@@ -40,10 +44,10 @@ case "$AUTO_UPDATE" in
     ;;
 esac
 
-# Defensive path re-validation. The agent has already validated this
-# against the full Path validation rules in SKILL.md § 3 and re-prompted
-# on failure; this script only guards against being called with bad
-# input from a buggy caller or a hand-edited script invocation.
+# Defensive text-level path re-validation. The agent has already
+# validated this against the full Path validation rules in SKILL.md § 3
+# and re-prompted on failure; this script only guards against being
+# called with bad input from a buggy caller or a hand-edited invocation.
 case "$CLONE_PATH" in
   "$HOME"/*) ;;
   *)
@@ -57,7 +61,7 @@ case "$CLONE_PATH" in
     exit 2
     ;;
 esac
-for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '\'; do
+for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '"' '\'; do
   case "$CLONE_PATH" in
     *"$ch"*)
       echo "error: clone path contains shell metacharacter: $CLONE_PATH" >&2
@@ -73,8 +77,14 @@ case "$CLONE_PATH" in
     ;;
 esac
 
-# Verify Go ≥ 1.24. The agent prose handles the user-facing "go install"
-# prompt; this is the executable check.
+# Required tools. `jq` is used below to emit the install state as JSON
+# (a heredoc would mis-encode any filesystem path containing `"` or
+# `\`); `go` must be ≥ 1.24 for `make build`.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but is not on PATH" >&2
+  exit 3
+fi
+
 if ! command -v go >/dev/null 2>&1; then
   echo "error: go is required (≥ 1.24) but is not on PATH" >&2
   exit 3
@@ -94,32 +104,84 @@ if [ "$GO_MAJOR" -lt 1 ] || { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 24 ]; }
   exit 3
 fi
 
-mkdir -p "$(dirname "$CLONE_PATH")"
-if [ ! -d "$CLONE_PATH/.git" ]; then
-  git clone https://github.com/sageox/ox.git "$CLONE_PATH"
+# Physical path resolution. The textual `case "$HOME/*"` check above
+# only validates the prefix string — a path like `$HOME/link` where
+# `link → /tmp/foo` would pass that check while the real clone target
+# sits outside $HOME. Resolve the PARENT directory physically (the
+# clone path itself may not exist yet) and confirm the resolved
+# location is still under the resolved $HOME and is owned by the
+# current user before we create or write anything.
+#
+# `cd && pwd -P` is the portable resolver — works on BSD/macOS and
+# GNU/Linux with no `readlink -f` / `realpath` dependency.
+PARENT_DIR="$(dirname "$CLONE_PATH")"
+mkdir -p "$PARENT_DIR"
+REAL_HOME="$(cd "$HOME" && pwd -P)"
+if ! REAL_PARENT="$(cd "$PARENT_DIR" && pwd -P)"; then
+  echo "error: could not resolve parent directory: $PARENT_DIR" >&2
+  exit 2
+fi
+case "$REAL_PARENT" in
+  "$REAL_HOME"|"$REAL_HOME"/*) ;;
+  *)
+    echo "error: parent directory escapes \$HOME via symlink: $REAL_PARENT" >&2
+    exit 2
+    ;;
+esac
+if [ ! -O "$REAL_PARENT" ]; then
+  echo "error: parent directory not owned by current user: $REAL_PARENT" >&2
+  exit 2
+fi
+
+# Reassemble the canonical clone path from the resolved parent + the
+# basename. We use this canonical form everywhere below (clone target,
+# build subshell, state file) so update-ox.sh re-reads a symlink-free
+# path on every future run.
+REAL_CLONE_PATH="$REAL_PARENT/$(basename "$CLONE_PATH")"
+
+if [ ! -d "$REAL_CLONE_PATH/.git" ]; then
+  git clone https://github.com/sageox/ox.git "$REAL_CLONE_PATH"
+fi
+
+# After clone, the target itself must also be owned by the current
+# user. `git clone` inherits parent-directory ownership by default but
+# this catches the case where someone pre-created the target as a
+# symlink to a foreign tree.
+if [ ! -O "$REAL_CLONE_PATH" ]; then
+  echo "error: clone target not owned by current user: $REAL_CLONE_PATH" >&2
+  exit 2
 fi
 
 # Build and install in a subshell so the cd doesn't leak.
-( cd "$CLONE_PATH" && make build && make install )
+( cd "$REAL_CLONE_PATH" && make build && make install )
 
 # Detect Go's paths for the PATH guidance below.
 GO_BIN_DIR="$(dirname "$(command -v go)")"
 GO_INSTALL_DIR="$(go env GOBIN)"
 [ -z "$GO_INSTALL_DIR" ] && GO_INSTALL_DIR="$HOME/go/bin"
 
-# Persist the memory file.
+# Persist the memory file via `jq -n` so that path values containing
+# `"` or `\` (or any other JSON-special character) cannot produce
+# malformed state that `update-ox.sh` then fails to parse. --argjson
+# for auto_update lets us pass the literal true/false through without
+# re-quoting.
 mkdir -p "$HOME/.openclaw/memory"
 INSTALLED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-cat > "$HOME/.openclaw/memory/sageox-ox-install.json" <<EOF
-{
-  "install_method": "git",
-  "clone_path": "$CLONE_PATH",
-  "auto_update": $AUTO_UPDATE,
-  "go_bin_dir": "$GO_BIN_DIR",
-  "go_install_dir": "$GO_INSTALL_DIR",
-  "installed_at": "$INSTALLED_AT"
-}
-EOF
+jq -n \
+  --arg install_method "git" \
+  --arg clone_path "$REAL_CLONE_PATH" \
+  --argjson auto_update "$AUTO_UPDATE" \
+  --arg go_bin_dir "$GO_BIN_DIR" \
+  --arg go_install_dir "$GO_INSTALL_DIR" \
+  --arg installed_at "$INSTALLED_AT" \
+  '{
+    install_method: $install_method,
+    clone_path: $clone_path,
+    auto_update: $auto_update,
+    go_bin_dir: $go_bin_dir,
+    go_install_dir: $go_install_dir,
+    installed_at: $installed_at
+  }' > "$HOME/.openclaw/memory/sageox-ox-install.json"
 
 # Verify ox is reachable from this subprocess. If not, print copy-paste
 # guidance for ~/.openclaw/.env as a stderr warning — the install itself

--- a/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# install-ox-git.sh — clone sageox/ox to a user-chosen path, build and
+# install via `make install`, detect Go's bin/install dirs for PATH
+# guidance, and persist the chosen install method to the OpenClaw
+# memory file.
+#
+# Usage: install-ox-git.sh <clone_path> <auto_update>
+#
+# Arguments:
+#   <clone_path>   Absolute path under $HOME where the repo will live.
+#                  The agent has already prompted the user and validated
+#                  this against the Path validation rules in SKILL.md
+#                  § 3 — this script re-checks defensively.
+#   <auto_update>  Literal string "true" or "false" — whether to run
+#                  git pull + make install on every future invocation.
+#
+# Stdout: human-readable progress (clone, build, detected paths)
+# Stderr: errors and PATH-configuration guidance if ox is not on this
+#         subprocess's PATH after install
+# Exit:
+#   0 — success, ox installed and memory file written
+#   2 — usage error (wrong arg count or bad arg value)
+#   3 — internal error (Go missing or too old, build failed)
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "usage: $(basename "$0") <clone_path> <auto_update>" >&2
+  exit 2
+fi
+
+CLONE_PATH="$1"
+AUTO_UPDATE="$2"
+
+case "$AUTO_UPDATE" in
+  true|false) ;;
+  *)
+    echo "error: <auto_update> must be 'true' or 'false', got '$AUTO_UPDATE'" >&2
+    exit 2
+    ;;
+esac
+
+# Defensive path re-validation. The agent has already validated this
+# against the full Path validation rules in SKILL.md § 3 and re-prompted
+# on failure; this script only guards against being called with bad
+# input from a buggy caller or a hand-edited script invocation.
+case "$CLONE_PATH" in
+  "$HOME"/*) ;;
+  *)
+    echo "error: clone path must be absolute and under \$HOME: $CLONE_PATH" >&2
+    exit 2
+    ;;
+esac
+case "$CLONE_PATH" in
+  *..*)
+    echo "error: clone path must not contain '..': $CLONE_PATH" >&2
+    exit 2
+    ;;
+esac
+for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '\'; do
+  case "$CLONE_PATH" in
+    *"$ch"*)
+      echo "error: clone path contains shell metacharacter: $CLONE_PATH" >&2
+      exit 2
+      ;;
+  esac
+done
+case "$CLONE_PATH" in
+  *"
+"*)
+    echo "error: clone path contains a newline: $CLONE_PATH" >&2
+    exit 2
+    ;;
+esac
+
+# Verify Go ≥ 1.24. The agent prose handles the user-facing "go install"
+# prompt; this is the executable check.
+if ! command -v go >/dev/null 2>&1; then
+  echo "error: go is required (≥ 1.24) but is not on PATH" >&2
+  exit 3
+fi
+GO_VERSION="$(go version | awk '{print $3}' | sed 's/^go//')"
+GO_MAJOR="${GO_VERSION%%.*}"
+GO_REST="${GO_VERSION#*.}"
+GO_MINOR="${GO_REST%%.*}"
+# Strip any trailing -beta / -rc suffix from the minor.
+GO_MINOR="${GO_MINOR%%[^0-9]*}"
+if [ -z "$GO_MAJOR" ] || [ -z "$GO_MINOR" ]; then
+  echo "error: could not parse go version: $GO_VERSION" >&2
+  exit 3
+fi
+if [ "$GO_MAJOR" -lt 1 ] || { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 24 ]; }; then
+  echo "error: go ≥ 1.24 required, found $GO_VERSION" >&2
+  exit 3
+fi
+
+mkdir -p "$(dirname "$CLONE_PATH")"
+if [ ! -d "$CLONE_PATH/.git" ]; then
+  git clone https://github.com/sageox/ox.git "$CLONE_PATH"
+fi
+
+# Build and install in a subshell so the cd doesn't leak.
+( cd "$CLONE_PATH" && make build && make install )
+
+# Detect Go's paths for the PATH guidance below.
+GO_BIN_DIR="$(dirname "$(command -v go)")"
+GO_INSTALL_DIR="$(go env GOBIN)"
+[ -z "$GO_INSTALL_DIR" ] && GO_INSTALL_DIR="$HOME/go/bin"
+
+# Persist the memory file.
+mkdir -p "$HOME/.openclaw/memory"
+INSTALLED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat > "$HOME/.openclaw/memory/sageox-ox-install.json" <<EOF
+{
+  "install_method": "git",
+  "clone_path": "$CLONE_PATH",
+  "auto_update": $AUTO_UPDATE,
+  "go_bin_dir": "$GO_BIN_DIR",
+  "go_install_dir": "$GO_INSTALL_DIR",
+  "installed_at": "$INSTALLED_AT"
+}
+EOF
+
+# Verify ox is reachable from this subprocess. If not, print copy-paste
+# guidance for ~/.openclaw/.env as a stderr warning — the install itself
+# succeeded, but the user has follow-up to do.
+if ! command -v ox >/dev/null 2>&1; then
+  cat >&2 <<EOF
+warning: ox built and installed, but is not on this subprocess's PATH.
+Add this line to ~/.openclaw/.env and restart the skill:
+
+  PATH=$GO_BIN_DIR:/usr/local/bin:/usr/bin:/bin:$GO_INSTALL_DIR
+
+OpenClaw loads .env into the skill subprocess, so the updated PATH
+will take effect on the next invocation.
+EOF
+fi

--- a/claws/openclaw/sageox-distill/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-distill/scripts/update-ox.sh
@@ -3,10 +3,17 @@
 # the "is ox installed at all?" check for every invocation of this skill.
 #
 # Reads ~/.openclaw/memory/sageox-ox-install.json. If the install method
-# is git with auto_update enabled, runs git pull + make install from the
-# recorded clone path. Falls back silently to the existing binary on any
+# is git with auto_update enabled, resolves the recorded clone_path to
+# its physical location, verifies ownership, and runs git pull + make
+# install there. Falls back silently to the existing binary on any
 # failure (validation, network, build) — a bad update must never block
 # a working invocation.
+#
+# Before returning `0`, always re-confirms that `ox` is actually on the
+# subprocess PATH. A stale state file + a missing PATH entry is a common
+# failure mode on the curl install path and on git installs whose
+# ~/.openclaw/.env was lost, and reporting "ready" in either case would
+# just push the failure to the next `ox status` call.
 #
 # Usage: update-ox.sh
 #
@@ -14,9 +21,9 @@
 # Stderr: one-line warnings on failure modes; the "needs install" signal
 # Exit:
 #   0 — ox is ready, agent should proceed to next prerequisite
-#   2 — install state file is missing; agent must read
-#       references/INSTALL.md and run the interactive install flow
-#       before continuing
+#   2 — ox is not usable (no state file, or state says installed but
+#       'ox' is not on PATH); agent must read references/INSTALL.md and
+#       run the interactive install flow before continuing
 
 set -euo pipefail
 
@@ -27,87 +34,133 @@ if [ ! -f "$STATE_FILE" ]; then
   exit 2
 fi
 
-# Without jq we can't read the state file, but ox itself may still be
-# on PATH from a prior install. Don't fail — let the caller verify.
-if ! command -v jq >/dev/null 2>&1; then
-  echo "warning: jq not found; cannot read $STATE_FILE; skipping update check" >&2
-  exit 0
-fi
+# Resolve $HOME to its physical path once — used by the symlink-escape
+# check below. If $HOME itself is under a symlink (e.g. /Users/foo →
+# /Volumes/Data/Users/foo), the real clone_path must still resolve under
+# the resolved $HOME, not the textual one.
+REAL_HOME="$(cd "$HOME" && pwd -P)"
 
-INSTALL_METHOD="$(jq -r '.install_method // empty' "$STATE_FILE" 2>/dev/null || true)"
-if [ -z "$INSTALL_METHOD" ]; then
-  echo "warning: $STATE_FILE has no install_method; skipping update check" >&2
-  exit 0
-fi
+# Wrap the whole git-mode update path in a function so that early-exit
+# on any validation failure falls THROUGH to the final command -v ox
+# readiness gate at the bottom of the script. Using `return` here (not
+# `exit 0`) is what makes the gate load-bearing.
+try_git_update() {
+  local clone_path real_clone_path ch log
+  clone_path="$(jq -r '.clone_path // empty' "$STATE_FILE")"
+  if [ -z "$clone_path" ]; then
+    echo "warning: $STATE_FILE missing clone_path; skipping auto-update" >&2
+    return
+  fi
 
-# Curl install: nothing to update on a per-run basis. The user re-runs
-# the interactive flow to bump the pinned release.
-if [ "$INSTALL_METHOD" = "curl" ]; then
-  exit 0
-fi
-
-if [ "$INSTALL_METHOD" != "git" ]; then
-  echo "warning: unknown install_method '$INSTALL_METHOD' in $STATE_FILE; skipping update check" >&2
-  exit 0
-fi
-
-AUTO_UPDATE="$(jq -r '.auto_update // false' "$STATE_FILE")"
-if [ "$AUTO_UPDATE" != "true" ]; then
-  exit 0
-fi
-
-CLONE_PATH="$(jq -r '.clone_path // empty' "$STATE_FILE")"
-if [ -z "$CLONE_PATH" ]; then
-  echo "warning: $STATE_FILE missing clone_path; skipping auto-update" >&2
-  exit 0
-fi
-
-# Re-validate the clone path. The state file is user-writable and may
-# have been edited externally between runs — never trust persisted
-# values without re-checking. Validation failure is non-fatal: skip the
-# update and fall back to the existing ox binary.
-case "$CLONE_PATH" in
-  "$HOME"/*) ;;
-  *)
-    echo "warning: clone_path not under \$HOME; skipping auto-update: $CLONE_PATH" >&2
-    exit 0
-    ;;
-esac
-case "$CLONE_PATH" in
-  *..*)
-    echo "warning: clone_path contains '..'; skipping auto-update: $CLONE_PATH" >&2
-    exit 0
-    ;;
-esac
-for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '\'; do
-  case "$CLONE_PATH" in
-    *"$ch"*)
-      echo "warning: clone_path contains shell metacharacter; skipping auto-update" >&2
-      exit 0
+  # Text-level validation. Cheap to run; catches obvious hand-edits
+  # before we go near the filesystem.
+  case "$clone_path" in
+    "$HOME"/*) ;;
+    *)
+      echo "warning: clone_path not under \$HOME; skipping auto-update: $clone_path" >&2
+      return
       ;;
   esac
-done
-case "$CLONE_PATH" in
-  *"
+  case "$clone_path" in
+    *..*)
+      echo "warning: clone_path contains '..'; skipping auto-update: $clone_path" >&2
+      return
+      ;;
+  esac
+  for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '"' '\'; do
+    case "$clone_path" in
+      *"$ch"*)
+        echo "warning: clone_path contains shell metacharacter; skipping auto-update" >&2
+        return
+        ;;
+    esac
+  done
+  case "$clone_path" in
+    *"
 "*)
-    echo "warning: clone_path contains a newline; skipping auto-update" >&2
-    exit 0
-    ;;
-esac
-if [ ! -d "$CLONE_PATH/.git" ]; then
-  echo "warning: clone_path missing or not a git repo; skipping auto-update: $CLONE_PATH" >&2
-  exit 0
+      echo "warning: clone_path contains a newline; skipping auto-update" >&2
+      return
+      ;;
+  esac
+
+  # Physical path resolution. `cd && pwd -P` is the portable way to
+  # follow every symlink — works on BSD/macOS and GNU/Linux without
+  # depending on `readlink -f` or `realpath`, neither of which are
+  # guaranteed on older macOS. If the path doesn't exist or we can't
+  # enter it, treat the recorded state as stale and skip the update.
+  local real_clone_path
+  if ! real_clone_path="$(cd "$clone_path" 2>/dev/null && pwd -P)"; then
+    echo "warning: clone_path does not exist or is inaccessible; skipping auto-update: $clone_path" >&2
+    return
+  fi
+
+  # Resolved clone path must still be under the resolved $HOME — this
+  # is the check that catches `~/link → /tmp/foo` symlink escapes.
+  case "$real_clone_path" in
+    "$REAL_HOME"/*) ;;
+    *)
+      echo "warning: clone_path escapes \$HOME via symlink; skipping auto-update: $real_clone_path" >&2
+      return
+      ;;
+  esac
+
+  # Ownership check. `test -O` returns true iff the file is owned by
+  # the effective user ID — POSIX, portable across BSD and GNU. This
+  # blocks the case where a symlink inside $HOME points to a directory
+  # owned by root or another user (shared /opt, /var, etc.).
+  if [ ! -O "$real_clone_path" ]; then
+    echo "warning: clone_path not owned by current user; skipping auto-update: $real_clone_path" >&2
+    return
+  fi
+
+  if [ ! -d "$real_clone_path/.git" ]; then
+    echo "warning: resolved clone_path missing .git subdirectory; skipping auto-update: $real_clone_path" >&2
+    return
+  fi
+
+  # Run the update from the RESOLVED path. Non-fatal on failure — fall
+  # back to the existing binary. Capture output so we can show a useful
+  # tail-of-log on failure without polluting stdout on the success path.
+  log="$(mktemp "${TMPDIR:-/tmp}/ox-update.XXXXXXXX")"
+  trap 'rm -f "$log" 2>/dev/null' RETURN
+  if ! ( cd "$real_clone_path" && git pull --ff-only && make build && make install ) > "$log" 2>&1; then
+    echo "warning: ox auto-update failed; continuing with existing binary" >&2
+    echo "--- last 10 lines of update log ---" >&2
+    tail -10 "$log" >&2
+  fi
+}
+
+# Without jq we can't read the state file, but ox itself may still be
+# on PATH from a prior install. Don't fail — let the final readiness
+# gate decide.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "warning: jq not found; cannot read $STATE_FILE; skipping update check" >&2
+else
+  INSTALL_METHOD="$(jq -r '.install_method // empty' "$STATE_FILE" 2>/dev/null || true)"
+  if [ -z "$INSTALL_METHOD" ]; then
+    echo "warning: $STATE_FILE has no install_method; skipping update check" >&2
+  elif [ "$INSTALL_METHOD" = "curl" ]; then
+    : # Nothing to update on a per-run basis. The user re-runs the
+      # interactive flow to bump the pinned release.
+  elif [ "$INSTALL_METHOD" = "git" ]; then
+    AUTO_UPDATE="$(jq -r '.auto_update // false' "$STATE_FILE")"
+    if [ "$AUTO_UPDATE" = "true" ]; then
+      try_git_update
+    fi
+  else
+    echo "warning: unknown install_method '$INSTALL_METHOD' in $STATE_FILE; skipping update check" >&2
+  fi
 fi
 
-# Run the update. Non-fatal on failure — fall back to existing binary.
-# Capture output so we can show useful tail-of-log on failure without
-# polluting stdout on the success path.
-LOG="$(mktemp "${TMPDIR:-/tmp}/ox-update.XXXXXXXX")"
-trap 'rm -f "$LOG" 2>/dev/null' EXIT
-if ! ( cd "$CLONE_PATH" && git pull --ff-only && make build && make install ) > "$LOG" 2>&1; then
-  echo "warning: ox auto-update failed; continuing with existing binary" >&2
-  echo "--- last 10 lines of update log ---" >&2
-  tail -10 "$LOG" >&2
+# Final readiness gate. Whatever install method the state file records,
+# `ox` must actually be on the subprocess PATH for the rest of the
+# skill to function. A stale state file + a misconfigured ~/.openclaw/.env
+# is a common failure mode that used to only surface on the next
+# `ox status` call — make it surface here instead, with actionable
+# next-step guidance.
+if ! command -v ox >/dev/null 2>&1; then
+  echo "error: 'ox' is not on PATH (install state: ${INSTALL_METHOD:-unknown})" >&2
+  echo "fix: re-read references/INSTALL.md to re-run install or update ~/.openclaw/.env" >&2
+  exit 2
 fi
-
 exit 0

--- a/claws/openclaw/sageox-distill/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-distill/scripts/update-ox.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# update-ox.sh — non-fatal auto-update for the git install method, and
+# the "is ox installed at all?" check for every invocation of this skill.
+#
+# Reads ~/.openclaw/memory/sageox-ox-install.json. If the install method
+# is git with auto_update enabled, runs git pull + make install from the
+# recorded clone path. Falls back silently to the existing binary on any
+# failure (validation, network, build) — a bad update must never block
+# a working invocation.
+#
+# Usage: update-ox.sh
+#
+# Stdout: nothing on success
+# Stderr: one-line warnings on failure modes; the "needs install" signal
+# Exit:
+#   0 — ox is ready, agent should proceed to next prerequisite
+#   2 — install state file is missing; agent must read
+#       references/INSTALL.md and run the interactive install flow
+#       before continuing
+
+set -euo pipefail
+
+STATE_FILE="$HOME/.openclaw/memory/sageox-ox-install.json"
+
+if [ ! -f "$STATE_FILE" ]; then
+  echo "ox install state not configured — run interactive install flow from references/INSTALL.md" >&2
+  exit 2
+fi
+
+# Without jq we can't read the state file, but ox itself may still be
+# on PATH from a prior install. Don't fail — let the caller verify.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "warning: jq not found; cannot read $STATE_FILE; skipping update check" >&2
+  exit 0
+fi
+
+INSTALL_METHOD="$(jq -r '.install_method // empty' "$STATE_FILE" 2>/dev/null || true)"
+if [ -z "$INSTALL_METHOD" ]; then
+  echo "warning: $STATE_FILE has no install_method; skipping update check" >&2
+  exit 0
+fi
+
+# Curl install: nothing to update on a per-run basis. The user re-runs
+# the interactive flow to bump the pinned release.
+if [ "$INSTALL_METHOD" = "curl" ]; then
+  exit 0
+fi
+
+if [ "$INSTALL_METHOD" != "git" ]; then
+  echo "warning: unknown install_method '$INSTALL_METHOD' in $STATE_FILE; skipping update check" >&2
+  exit 0
+fi
+
+AUTO_UPDATE="$(jq -r '.auto_update // false' "$STATE_FILE")"
+if [ "$AUTO_UPDATE" != "true" ]; then
+  exit 0
+fi
+
+CLONE_PATH="$(jq -r '.clone_path // empty' "$STATE_FILE")"
+if [ -z "$CLONE_PATH" ]; then
+  echo "warning: $STATE_FILE missing clone_path; skipping auto-update" >&2
+  exit 0
+fi
+
+# Re-validate the clone path. The state file is user-writable and may
+# have been edited externally between runs — never trust persisted
+# values without re-checking. Validation failure is non-fatal: skip the
+# update and fall back to the existing ox binary.
+case "$CLONE_PATH" in
+  "$HOME"/*) ;;
+  *)
+    echo "warning: clone_path not under \$HOME; skipping auto-update: $CLONE_PATH" >&2
+    exit 0
+    ;;
+esac
+case "$CLONE_PATH" in
+  *..*)
+    echo "warning: clone_path contains '..'; skipping auto-update: $CLONE_PATH" >&2
+    exit 0
+    ;;
+esac
+for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '\'; do
+  case "$CLONE_PATH" in
+    *"$ch"*)
+      echo "warning: clone_path contains shell metacharacter; skipping auto-update" >&2
+      exit 0
+      ;;
+  esac
+done
+case "$CLONE_PATH" in
+  *"
+"*)
+    echo "warning: clone_path contains a newline; skipping auto-update" >&2
+    exit 0
+    ;;
+esac
+if [ ! -d "$CLONE_PATH/.git" ]; then
+  echo "warning: clone_path missing or not a git repo; skipping auto-update: $CLONE_PATH" >&2
+  exit 0
+fi
+
+# Run the update. Non-fatal on failure — fall back to existing binary.
+# Capture output so we can show useful tail-of-log on failure without
+# polluting stdout on the success path.
+LOG="$(mktemp "${TMPDIR:-/tmp}/ox-update.XXXXXXXX")"
+trap 'rm -f "$LOG" 2>/dev/null' EXIT
+if ! ( cd "$CLONE_PATH" && git pull --ff-only && make build && make install ) > "$LOG" 2>&1; then
+  echo "warning: ox auto-update failed; continuing with existing binary" >&2
+  echo "--- last 10 lines of update log ---" >&2
+  tail -10 "$LOG" >&2
+fi
+
+exit 0

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -96,224 +96,40 @@ even though this skill writes them: the user (or a process running as
 the user) may have edited the file by hand or by another tool between
 runs. Re-validate every read.
 
-### 4. Installing `ox` — interactive setup
+### 4. Installing and updating `ox`
 
 The `ox` CLI install method is a one-time choice stored in
-`~/.openclaw/memory/sageox-ox-install.json`. Check that file first:
+`~/.openclaw/memory/sageox-ox-install.json`. On every run of this
+skill, invoke the bundled state checker:
 
 ```bash
-cat ~/.openclaw/memory/sageox-ox-install.json 2>/dev/null
+bash scripts/update-ox.sh
 ```
 
-**If the file exists:** read `install_method` and (for the git method)
-`clone_path` + `auto_update`. If `install_method == "git"` and
-`auto_update == true`, update ox before proceeding (see "Updating ox from
-git" below).
+Contract:
 
-**If the file does not exist:** STOP. This is a one-time decision that
-gets persisted to disk and affects every future run of this skill — the
-user must own it. You **MUST** ask the user which method they want and
-**wait for their response**. Do not pick a default. Do not guess. Do not
-run any install commands yet. Present both options verbatim, then stop
-and wait:
+- **Stdout:** nothing on success
+- **Stderr:** one-line warnings on update failures (non-fatal) and the
+  "needs install" signal
+- **Exit:** `0` ox is ready (continue to § 5); `2` install state is
+  missing — STOP, read [`references/INSTALL.md`](references/INSTALL.md)
+  and follow the interactive setup, then re-run this script to confirm
 
-> How do you want to install the `ox` CLI? Pick one — I won't choose for
-> you, because this gets saved to
-> `~/.openclaw/memory/sageox-ox-install.json` and reused every run.
->
-> 1. **curl install** — runs the official install script from a pinned
->    release tag. Fastest, no build toolchain needed. Lands in
->    `/usr/local/bin` (Linux) or `/opt/homebrew/bin` or `/usr/local/bin`
->    (macOS). No auto-update; you'll re-run this flow to upgrade.
-> 2. **Build from git source** — clones `github.com/sageox/ox` to a
->    directory you choose and builds with `make install`. Gives you
->    latest `main`, and optionally auto-updates on every run. Requires
->    Go ≥ 1.24.
->
-> Reply `1` or `2`.
+`update-ox.sh` handles the auto-update flow for the git install method
+(re-validates the recorded clone path against the rules in § 3 above,
+runs `git pull --ff-only && make build && make install`, falls back to
+the existing binary on any failure with a stderr warning + a tail of
+the build log). Curl-method users hit a silent no-op — there is
+nothing to update on a per-run basis.
 
-**Blocking rule:** do not proceed until the user replies with `1` or
-`2`. If they say "you choose", "whatever", or try to skip, ask again and
-explain that this is a persisted choice. Once they answer, save it to
-the memory file.
+The user can say **"switch ox install method"** or **"update ox now"**
+at any time — both re-enter the flow in
+[`references/INSTALL.md`](references/INSTALL.md).
 
 **Do not install `ox` via Homebrew or any package manager** (e.g.
 `brew install sageox/tap/ox`, `apt`, `dnf`, `pacman`). The tap exists
 for general use but is not supported inside OpenClaw skills — only
-`curl` and `git source` are. These two options work the same on macOS
-and Linux; pick based on whether the user wants a pinned release or
-`main` with optional auto-update, **not** based on their operating
-system.
-
-#### Option 1: curl install
-
-Download and run the ox install script. The agent should print the source
-URL and a head/tail preview of the downloaded script before executing it,
-so the user can sanity-check what is about to run:
-
-The URL is **pinned to a specific release tag** (not `main`) so the install
-path is reproducible and can't be silently changed by an upstream commit. Bump
-`OX_INSTALL_REF` when a newer release of `sageox/ox` is available.
-
-```bash
-# Pinned release tag. Bump this when a newer sageox/ox release is published.
-OX_INSTALL_REF="v0.6.1"
-
-# Download to a temp file. -f makes curl fail on HTTP errors instead of
-# executing an HTML error page; --max-time bounds a stalled connection.
-# Use the template form for mktemp — portable across GNU (Linux) and BSD (macOS).
-INSTALL_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
-curl -fsSL --max-time 60 \
-  "https://raw.githubusercontent.com/sageox/ox/${OX_INSTALL_REF}/scripts/install.sh" \
-  -o "$INSTALL_SCRIPT"
-
-# Surface what is about to run.
-echo "Downloaded ox install script:"
-echo "  Source: https://github.com/sageox/ox/blob/${OX_INSTALL_REF}/scripts/install.sh"
-ls -lh "$INSTALL_SCRIPT"
-echo "--- first 5 lines ---"
-head -5 "$INSTALL_SCRIPT"
-echo "--- last 5 lines ---"
-tail -5 "$INSTALL_SCRIPT"
-
-# Execute and clean up.
-bash "$INSTALL_SCRIPT"
-rm -f "$INSTALL_SCRIPT"
-```
-
-After it completes, verify `command -v ox` succeeds. Then persist:
-
-```bash
-mkdir -p ~/.openclaw/memory
-cat > ~/.openclaw/memory/sageox-ox-install.json <<EOF
-{
-  "install_method": "curl",
-  "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-}
-EOF
-```
-
-`ox` lands in a standard system dir (`/usr/local/bin` on Linux,
-`/opt/homebrew/bin` or `/usr/local/bin` on macOS) that is normally already
-on PATH. If `command -v ox` still fails after install, ask the user to
-check their shell PATH.
-
-#### Option 2: build from git source
-
-1. Verify Go ≥ 1.24 is installed:
-
-   ```bash
-   command -v go && go version
-   ```
-
-   If missing, print OS-appropriate install commands and stop until the
-   user installs Go:
-
-   - **macOS:** `brew install go` or download from <https://go.dev/dl/>
-   - **Linux (Debian/Ubuntu):** `sudo apt-get install -y golang-go`
-     (verify the version; use <https://go.dev/dl/> if the distro package
-     is older than 1.24)
-   - **Linux (Fedora/RHEL):** `sudo dnf install -y golang`
-   - **Linux (Arch):** `sudo pacman -S --noconfirm go`
-
-2. Ask the user for a clone path. Default: `$HOME/src/sageox/ox`.
-   **Validate** the input against the Path validation rules above,
-   including the additional rule that the path must be under `$HOME`.
-   Re-prompt on failure.
-
-   ⚠️ **The clone path becomes a privileged location.** If auto-update is
-   enabled, this skill will run `make build && make install` from it on
-   every invocation. Anyone with write access to the clone path can run
-   arbitrary code in the user's environment. Strongly recommend a
-   personal directory under `$HOME` (the default `$HOME/src/sageox/ox`
-   is a good choice). Refuse anything in `/tmp`, `/var/tmp`, `/dev/shm`,
-   shared filesystems, or world-writable directories — these checks are
-   already part of the validation rules; do not bypass them.
-
-3. Ask the user whether to auto-update from git on every run (yes/no).
-   Default: yes.
-
-4. Clone and build:
-
-   ```bash
-   CLONE_PATH="<user-chosen path>"
-   mkdir -p "$(dirname "$CLONE_PATH")"
-   if [ ! -d "$CLONE_PATH/.git" ]; then
-     git clone https://github.com/sageox/ox.git "$CLONE_PATH"
-   fi
-   (cd "$CLONE_PATH" && make build && make install)
-   ```
-
-5. Detect Go's paths so the user can configure PATH in `~/.openclaw/.env`:
-
-   ```bash
-   GO_BIN_DIR="$(dirname "$(command -v go)")"
-   GO_INSTALL_DIR="$(go env GOBIN)"
-   [ -z "$GO_INSTALL_DIR" ] && GO_INSTALL_DIR="$HOME/go/bin"
-   ```
-
-6. Persist the memory file:
-
-   ```bash
-   mkdir -p ~/.openclaw/memory
-   cat > ~/.openclaw/memory/sageox-ox-install.json <<EOF
-   {
-     "install_method": "git",
-     "clone_path": "$CLONE_PATH",
-     "auto_update": true,
-     "go_bin_dir": "$GO_BIN_DIR",
-     "go_install_dir": "$GO_INSTALL_DIR",
-     "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-   }
-   EOF
-   ```
-
-7. Verify `ox` is on the current subprocess PATH:
-
-   ```bash
-   command -v ox
-   ```
-
-   If it is **not** on PATH, print a copy-pasteable block tailored to the
-   user's detected paths and tell them to add it to `~/.openclaw/.env`:
-
-   ```text
-   Add this to ~/.openclaw/.env:
-
-   PATH=<GO_BIN_DIR>:/usr/local/bin:/usr/bin:/bin:<GO_INSTALL_DIR>
-   ```
-
-   Stop and ask the user to confirm once they've updated `.env` and
-   restarted the skill. OpenClaw loads `.env` into the skill subprocess,
-   so an updated PATH takes effect on the next invocation.
-
-#### Updating `ox` from git (auto-update flow)
-
-On every subsequent run, if the memory file says
-`install_method == "git"` and `auto_update == true`:
-
-1. Read `clone_path` from `~/.openclaw/memory/sageox-ox-install.json`.
-2. **Re-validate** it against the Path validation rules in Prerequisites
-   § 3, including the additional clone-path checks (must be under
-   `$HOME`, must exist, must contain a `.git` subdirectory). The memory
-   file is user-writable and may have been edited externally between
-   runs — never trust persisted values without re-validation.
-3. **If validation fails**, log a clear error naming the failing rule,
-   skip the auto-update entirely, and fall back to the existing `ox`
-   binary on PATH. Do not proceed with `cd` / `git pull` / `make install`.
-4. If validation passes, run:
-
-   ```bash
-   (cd "$CLONE_PATH" && git pull --ff-only && make build && make install) || {
-     echo "ox auto-update failed; continuing with existing binary" >&2
-   }
-   ```
-
-Auto-update failures (validation or build) are non-fatal — fall back to
-the existing binary and surface the error to the user.
-
-The user can say **"switch ox install method"** or **"update ox now"** at
-any time to re-run the interactive flow.
+`curl` and `git source` are.
 
 ### 5. Authentication
 

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -111,9 +111,11 @@ Contract:
 - **Stdout:** nothing on success
 - **Stderr:** one-line warnings on update failures (non-fatal) and the
   "needs install" signal
-- **Exit:** `0` ox is ready (continue to § 5); `2` install state is
-  missing — STOP, read [`references/INSTALL.md`](references/INSTALL.md)
-  and follow the interactive setup, then re-run this script to confirm
+- **Exit:** `0` ox is ready (continue to § 5); `2` ox is not usable
+  (no install state, or state records ox as installed but it isn't on
+  PATH) — STOP, read
+  [`references/INSTALL.md`](references/INSTALL.md), follow the
+  interactive setup, then re-run this script to confirm
 
 `update-ox.sh` handles the auto-update flow for the git install method
 (re-validates the recorded clone path against the rules in § 3 above,

--- a/claws/openclaw/sageox-summary/references/INSTALL.md
+++ b/claws/openclaw/sageox-summary/references/INSTALL.md
@@ -1,0 +1,142 @@
+# Installing `ox` — interactive setup
+
+Invoked when `bash scripts/update-ox.sh` exits `2` (no install state
+recorded). The deterministic shell lives in `scripts/install-ox-curl.sh`
+and `scripts/install-ox-git.sh`; this file covers the user-facing
+choice and validation. Path validation rules are defined in SKILL.md
+§ 3.
+
+## The choice
+
+You **MUST** ask the user which method they want and **wait for their
+response**. Do not pick a default. Do not guess. Do not run any install
+commands yet. Present both options verbatim, then stop and wait:
+
+> How do you want to install the `ox` CLI? Pick one — I won't choose for
+> you, because this gets saved to
+> `~/.openclaw/memory/sageox-ox-install.json` and reused every run.
+>
+> 1. **curl install** — runs the official install script from a pinned
+>    release tag. Fastest, no build toolchain needed. Lands in
+>    `/usr/local/bin` (Linux) or `/opt/homebrew/bin` or `/usr/local/bin`
+>    (macOS). No auto-update; you'll re-run this flow to upgrade.
+> 2. **Build from git source** — clones `github.com/sageox/ox` to a
+>    directory you choose and builds with `make install`. Gives you
+>    latest `main`, and optionally auto-updates on every run. Requires
+>    Go ≥ 1.24.
+>
+> Reply `1` or `2`.
+
+**Blocking rule:** do not proceed until the user replies with `1` or
+`2`. If they say "you choose", "whatever", or try to skip, ask again
+and explain that this is a persisted choice that affects every future
+run.
+
+**Do not install `ox` via Homebrew or any package manager** (e.g.
+`brew install sageox/tap/ox`, `apt`, `dnf`, `pacman`). The tap exists
+for general use but is not supported inside OpenClaw skills — only
+`curl` and `git source` are. These two options work the same on macOS
+and Linux; pick based on whether the user wants a pinned release or
+`main` with optional auto-update, **not** based on their operating
+system.
+
+## Option 1: curl install
+
+Invoke the bundled helper. It downloads the install script from a
+pinned release tag, prints a head/tail preview so the user can sanity-
+check what is about to run, executes it, verifies `command -v ox`
+succeeds, and writes `~/.openclaw/memory/sageox-ox-install.json` with
+`install_method: curl`.
+
+```bash
+bash scripts/install-ox-curl.sh
+```
+
+Contract:
+
+- **Args:** none
+- **Stdout:** human-readable progress (download URL, head/tail preview,
+  install script output)
+- **Stderr:** errors
+- **Exit:** `0` success; `3` internal (curl missing, install script
+  failed, or `ox` not on PATH after install)
+
+If the script exits non-zero, surface its stderr to the user and stop.
+Do not silently retry.
+
+## Option 2: build from git source
+
+Three things must happen before the script can run, and the agent owns
+all of them:
+
+1. **Verify Go ≥ 1.24:**
+
+   ```bash
+   command -v go && go version
+   ```
+
+   If missing, print OS-appropriate install commands and stop until the
+   user installs Go:
+
+   - **macOS:** `brew install go` or download from <https://go.dev/dl/>
+   - **Linux (Debian/Ubuntu):** `sudo apt-get install -y golang-go`
+     (verify the version; use <https://go.dev/dl/> if the distro
+     package is older than 1.24)
+   - **Linux (Fedora/RHEL):** `sudo dnf install -y golang`
+   - **Linux (Arch):** `sudo pacman -S --noconfirm go`
+
+2. **Ask the user for a clone path.** Default: `$HOME/src/sageox/ox`.
+   **Validate** the input against the Path validation rules in
+   SKILL.md § 3, including the additional rule that the path must be
+   under `$HOME`. Re-prompt on failure. Expand `~` to `$HOME` before
+   passing to the script — the script's defensive re-check requires a
+   path starting with `$HOME/`.
+
+   ⚠️ **The clone path becomes a privileged location.** If auto-update
+   is enabled, this skill will run `make build && make install` from
+   it on every invocation. Anyone with write access to the clone path
+   can run arbitrary code in the user's environment. Strongly
+   recommend a personal directory under `$HOME` (the default
+   `$HOME/src/sageox/ox` is a good choice). Refuse anything in `/tmp`,
+   `/var/tmp`, `/dev/shm`, shared filesystems, or world-writable
+   directories — these are already in the validation rules; do not
+   bypass them.
+
+3. **Ask the user whether to auto-update from git on every run**
+   (yes/no). Default: yes.
+
+Then invoke the bundled helper with the validated clone path and the
+literal string `true` or `false`:
+
+```bash
+bash scripts/install-ox-git.sh "$CLONE_PATH" "true"
+```
+
+Contract:
+
+- **Args:** `<clone_path>` `<auto_update: true|false>`
+- **Stdout:** clone/build progress
+- **Stderr:** errors and PATH-configuration guidance
+- **Exit:** `0` success; `2` usage / bad arg; `3` internal (Go missing
+  or too old, build failed)
+
+The script re-validates the clone path defensively, clones if needed,
+runs `make build && make install`, detects Go's bin/install dirs,
+persists the memory file, and warns to **stderr** if `command -v ox`
+doesn't succeed in the current subprocess. If you see that warning,
+surface the PATH guidance from the script's stderr to the user
+verbatim, then stop and ask them to confirm once they've updated
+`~/.openclaw/.env` and restarted the skill. OpenClaw loads `.env` into
+the skill subprocess, so the updated PATH takes effect on the next
+invocation.
+
+## After installation
+
+Re-run the state checker to confirm:
+
+```bash
+bash scripts/update-ox.sh
+```
+
+It should exit `0` with no stderr. Continue with the rest of the
+prerequisites in SKILL.md (authentication, etc.).

--- a/claws/openclaw/sageox-summary/scripts/install-ox-curl.sh
+++ b/claws/openclaw/sageox-summary/scripts/install-ox-curl.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install-ox-curl.sh — download and run the official ox install script
+# from a pinned release tag, then persist the chosen install method to
+# the OpenClaw memory file.
+#
+# Usage: install-ox-curl.sh
+#
+# Stdout: human-readable progress (download URL, head/tail preview,
+#         install script output)
+# Stderr: errors
+# Exit:
+#   0 — success, ox installed and memory file written
+#   3 — internal error (curl missing, install script failed, ox not on
+#       PATH after install)
+#
+# The pinned release tag below makes this script reproducible: future
+# upstream commits to install.sh on main can't change what this skill
+# fetches. Bump OX_INSTALL_REF when a newer sageox/ox release ships.
+
+set -euo pipefail
+
+OX_INSTALL_REF="v0.6.1"
+INSTALL_URL="https://raw.githubusercontent.com/sageox/ox/${OX_INSTALL_REF}/scripts/install.sh"
+SOURCE_BLOB="https://github.com/sageox/ox/blob/${OX_INSTALL_REF}/scripts/install.sh"
+
+command -v curl >/dev/null 2>&1 || { echo "error: curl is required" >&2; exit 3; }
+
+# Use the template form for mktemp — portable across GNU (Linux) and BSD (macOS).
+INSTALL_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
+trap 'rm -f "$INSTALL_SCRIPT" 2>/dev/null' EXIT
+
+# -f makes curl fail on HTTP errors instead of executing an HTML error page;
+# --max-time bounds a stalled connection.
+curl -fsSL --max-time 60 "$INSTALL_URL" -o "$INSTALL_SCRIPT"
+
+# Surface what is about to run so the user can sanity-check it.
+echo "Downloaded ox install script:"
+echo "  Source: $SOURCE_BLOB"
+ls -lh "$INSTALL_SCRIPT"
+echo "--- first 5 lines ---"
+head -5 "$INSTALL_SCRIPT"
+echo "--- last 5 lines ---"
+tail -5 "$INSTALL_SCRIPT"
+
+# Execute.
+bash "$INSTALL_SCRIPT"
+
+# Verify the result before we persist anything.
+if ! command -v ox >/dev/null 2>&1; then
+  echo "error: ox install script ran but 'ox' is not on PATH" >&2
+  exit 3
+fi
+
+# Persist the install method.
+mkdir -p "$HOME/.openclaw/memory"
+INSTALLED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat > "$HOME/.openclaw/memory/sageox-ox-install.json" <<EOF
+{
+  "install_method": "curl",
+  "ox_install_ref": "$OX_INSTALL_REF",
+  "installed_at": "$INSTALLED_AT"
+}
+EOF

--- a/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
@@ -10,7 +10,10 @@
 #   <clone_path>   Absolute path under $HOME where the repo will live.
 #                  The agent has already prompted the user and validated
 #                  this against the Path validation rules in SKILL.md
-#                  § 3 — this script re-checks defensively.
+#                  § 3 — this script re-checks defensively, then
+#                  physically resolves the parent directory (via
+#                  `cd && pwd -P`) to reject symlink escapes before
+#                  touching the filesystem.
 #   <auto_update>  Literal string "true" or "false" — whether to run
 #                  git pull + make install on every future invocation.
 #
@@ -19,8 +22,9 @@
 #         subprocess's PATH after install
 # Exit:
 #   0 — success, ox installed and memory file written
-#   2 — usage error (wrong arg count or bad arg value)
-#   3 — internal error (Go missing or too old, build failed)
+#   2 — usage error (wrong arg count, bad arg value, path validation
+#       failure, or symlink escape)
+#   3 — internal error (Go or jq missing or too old, build failed)
 
 set -euo pipefail
 
@@ -40,10 +44,10 @@ case "$AUTO_UPDATE" in
     ;;
 esac
 
-# Defensive path re-validation. The agent has already validated this
-# against the full Path validation rules in SKILL.md § 3 and re-prompted
-# on failure; this script only guards against being called with bad
-# input from a buggy caller or a hand-edited script invocation.
+# Defensive text-level path re-validation. The agent has already
+# validated this against the full Path validation rules in SKILL.md § 3
+# and re-prompted on failure; this script only guards against being
+# called with bad input from a buggy caller or a hand-edited invocation.
 case "$CLONE_PATH" in
   "$HOME"/*) ;;
   *)
@@ -57,7 +61,7 @@ case "$CLONE_PATH" in
     exit 2
     ;;
 esac
-for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '\'; do
+for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '"' '\'; do
   case "$CLONE_PATH" in
     *"$ch"*)
       echo "error: clone path contains shell metacharacter: $CLONE_PATH" >&2
@@ -73,8 +77,14 @@ case "$CLONE_PATH" in
     ;;
 esac
 
-# Verify Go ≥ 1.24. The agent prose handles the user-facing "go install"
-# prompt; this is the executable check.
+# Required tools. `jq` is used below to emit the install state as JSON
+# (a heredoc would mis-encode any filesystem path containing `"` or
+# `\`); `go` must be ≥ 1.24 for `make build`.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but is not on PATH" >&2
+  exit 3
+fi
+
 if ! command -v go >/dev/null 2>&1; then
   echo "error: go is required (≥ 1.24) but is not on PATH" >&2
   exit 3
@@ -94,32 +104,84 @@ if [ "$GO_MAJOR" -lt 1 ] || { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 24 ]; }
   exit 3
 fi
 
-mkdir -p "$(dirname "$CLONE_PATH")"
-if [ ! -d "$CLONE_PATH/.git" ]; then
-  git clone https://github.com/sageox/ox.git "$CLONE_PATH"
+# Physical path resolution. The textual `case "$HOME/*"` check above
+# only validates the prefix string — a path like `$HOME/link` where
+# `link → /tmp/foo` would pass that check while the real clone target
+# sits outside $HOME. Resolve the PARENT directory physically (the
+# clone path itself may not exist yet) and confirm the resolved
+# location is still under the resolved $HOME and is owned by the
+# current user before we create or write anything.
+#
+# `cd && pwd -P` is the portable resolver — works on BSD/macOS and
+# GNU/Linux with no `readlink -f` / `realpath` dependency.
+PARENT_DIR="$(dirname "$CLONE_PATH")"
+mkdir -p "$PARENT_DIR"
+REAL_HOME="$(cd "$HOME" && pwd -P)"
+if ! REAL_PARENT="$(cd "$PARENT_DIR" && pwd -P)"; then
+  echo "error: could not resolve parent directory: $PARENT_DIR" >&2
+  exit 2
+fi
+case "$REAL_PARENT" in
+  "$REAL_HOME"|"$REAL_HOME"/*) ;;
+  *)
+    echo "error: parent directory escapes \$HOME via symlink: $REAL_PARENT" >&2
+    exit 2
+    ;;
+esac
+if [ ! -O "$REAL_PARENT" ]; then
+  echo "error: parent directory not owned by current user: $REAL_PARENT" >&2
+  exit 2
+fi
+
+# Reassemble the canonical clone path from the resolved parent + the
+# basename. We use this canonical form everywhere below (clone target,
+# build subshell, state file) so update-ox.sh re-reads a symlink-free
+# path on every future run.
+REAL_CLONE_PATH="$REAL_PARENT/$(basename "$CLONE_PATH")"
+
+if [ ! -d "$REAL_CLONE_PATH/.git" ]; then
+  git clone https://github.com/sageox/ox.git "$REAL_CLONE_PATH"
+fi
+
+# After clone, the target itself must also be owned by the current
+# user. `git clone` inherits parent-directory ownership by default but
+# this catches the case where someone pre-created the target as a
+# symlink to a foreign tree.
+if [ ! -O "$REAL_CLONE_PATH" ]; then
+  echo "error: clone target not owned by current user: $REAL_CLONE_PATH" >&2
+  exit 2
 fi
 
 # Build and install in a subshell so the cd doesn't leak.
-( cd "$CLONE_PATH" && make build && make install )
+( cd "$REAL_CLONE_PATH" && make build && make install )
 
 # Detect Go's paths for the PATH guidance below.
 GO_BIN_DIR="$(dirname "$(command -v go)")"
 GO_INSTALL_DIR="$(go env GOBIN)"
 [ -z "$GO_INSTALL_DIR" ] && GO_INSTALL_DIR="$HOME/go/bin"
 
-# Persist the memory file.
+# Persist the memory file via `jq -n` so that path values containing
+# `"` or `\` (or any other JSON-special character) cannot produce
+# malformed state that `update-ox.sh` then fails to parse. --argjson
+# for auto_update lets us pass the literal true/false through without
+# re-quoting.
 mkdir -p "$HOME/.openclaw/memory"
 INSTALLED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-cat > "$HOME/.openclaw/memory/sageox-ox-install.json" <<EOF
-{
-  "install_method": "git",
-  "clone_path": "$CLONE_PATH",
-  "auto_update": $AUTO_UPDATE,
-  "go_bin_dir": "$GO_BIN_DIR",
-  "go_install_dir": "$GO_INSTALL_DIR",
-  "installed_at": "$INSTALLED_AT"
-}
-EOF
+jq -n \
+  --arg install_method "git" \
+  --arg clone_path "$REAL_CLONE_PATH" \
+  --argjson auto_update "$AUTO_UPDATE" \
+  --arg go_bin_dir "$GO_BIN_DIR" \
+  --arg go_install_dir "$GO_INSTALL_DIR" \
+  --arg installed_at "$INSTALLED_AT" \
+  '{
+    install_method: $install_method,
+    clone_path: $clone_path,
+    auto_update: $auto_update,
+    go_bin_dir: $go_bin_dir,
+    go_install_dir: $go_install_dir,
+    installed_at: $installed_at
+  }' > "$HOME/.openclaw/memory/sageox-ox-install.json"
 
 # Verify ox is reachable from this subprocess. If not, print copy-paste
 # guidance for ~/.openclaw/.env as a stderr warning — the install itself

--- a/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# install-ox-git.sh — clone sageox/ox to a user-chosen path, build and
+# install via `make install`, detect Go's bin/install dirs for PATH
+# guidance, and persist the chosen install method to the OpenClaw
+# memory file.
+#
+# Usage: install-ox-git.sh <clone_path> <auto_update>
+#
+# Arguments:
+#   <clone_path>   Absolute path under $HOME where the repo will live.
+#                  The agent has already prompted the user and validated
+#                  this against the Path validation rules in SKILL.md
+#                  § 3 — this script re-checks defensively.
+#   <auto_update>  Literal string "true" or "false" — whether to run
+#                  git pull + make install on every future invocation.
+#
+# Stdout: human-readable progress (clone, build, detected paths)
+# Stderr: errors and PATH-configuration guidance if ox is not on this
+#         subprocess's PATH after install
+# Exit:
+#   0 — success, ox installed and memory file written
+#   2 — usage error (wrong arg count or bad arg value)
+#   3 — internal error (Go missing or too old, build failed)
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "usage: $(basename "$0") <clone_path> <auto_update>" >&2
+  exit 2
+fi
+
+CLONE_PATH="$1"
+AUTO_UPDATE="$2"
+
+case "$AUTO_UPDATE" in
+  true|false) ;;
+  *)
+    echo "error: <auto_update> must be 'true' or 'false', got '$AUTO_UPDATE'" >&2
+    exit 2
+    ;;
+esac
+
+# Defensive path re-validation. The agent has already validated this
+# against the full Path validation rules in SKILL.md § 3 and re-prompted
+# on failure; this script only guards against being called with bad
+# input from a buggy caller or a hand-edited script invocation.
+case "$CLONE_PATH" in
+  "$HOME"/*) ;;
+  *)
+    echo "error: clone path must be absolute and under \$HOME: $CLONE_PATH" >&2
+    exit 2
+    ;;
+esac
+case "$CLONE_PATH" in
+  *..*)
+    echo "error: clone path must not contain '..': $CLONE_PATH" >&2
+    exit 2
+    ;;
+esac
+for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '\'; do
+  case "$CLONE_PATH" in
+    *"$ch"*)
+      echo "error: clone path contains shell metacharacter: $CLONE_PATH" >&2
+      exit 2
+      ;;
+  esac
+done
+case "$CLONE_PATH" in
+  *"
+"*)
+    echo "error: clone path contains a newline: $CLONE_PATH" >&2
+    exit 2
+    ;;
+esac
+
+# Verify Go ≥ 1.24. The agent prose handles the user-facing "go install"
+# prompt; this is the executable check.
+if ! command -v go >/dev/null 2>&1; then
+  echo "error: go is required (≥ 1.24) but is not on PATH" >&2
+  exit 3
+fi
+GO_VERSION="$(go version | awk '{print $3}' | sed 's/^go//')"
+GO_MAJOR="${GO_VERSION%%.*}"
+GO_REST="${GO_VERSION#*.}"
+GO_MINOR="${GO_REST%%.*}"
+# Strip any trailing -beta / -rc suffix from the minor.
+GO_MINOR="${GO_MINOR%%[^0-9]*}"
+if [ -z "$GO_MAJOR" ] || [ -z "$GO_MINOR" ]; then
+  echo "error: could not parse go version: $GO_VERSION" >&2
+  exit 3
+fi
+if [ "$GO_MAJOR" -lt 1 ] || { [ "$GO_MAJOR" -eq 1 ] && [ "$GO_MINOR" -lt 24 ]; }; then
+  echo "error: go ≥ 1.24 required, found $GO_VERSION" >&2
+  exit 3
+fi
+
+mkdir -p "$(dirname "$CLONE_PATH")"
+if [ ! -d "$CLONE_PATH/.git" ]; then
+  git clone https://github.com/sageox/ox.git "$CLONE_PATH"
+fi
+
+# Build and install in a subshell so the cd doesn't leak.
+( cd "$CLONE_PATH" && make build && make install )
+
+# Detect Go's paths for the PATH guidance below.
+GO_BIN_DIR="$(dirname "$(command -v go)")"
+GO_INSTALL_DIR="$(go env GOBIN)"
+[ -z "$GO_INSTALL_DIR" ] && GO_INSTALL_DIR="$HOME/go/bin"
+
+# Persist the memory file.
+mkdir -p "$HOME/.openclaw/memory"
+INSTALLED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat > "$HOME/.openclaw/memory/sageox-ox-install.json" <<EOF
+{
+  "install_method": "git",
+  "clone_path": "$CLONE_PATH",
+  "auto_update": $AUTO_UPDATE,
+  "go_bin_dir": "$GO_BIN_DIR",
+  "go_install_dir": "$GO_INSTALL_DIR",
+  "installed_at": "$INSTALLED_AT"
+}
+EOF
+
+# Verify ox is reachable from this subprocess. If not, print copy-paste
+# guidance for ~/.openclaw/.env as a stderr warning — the install itself
+# succeeded, but the user has follow-up to do.
+if ! command -v ox >/dev/null 2>&1; then
+  cat >&2 <<EOF
+warning: ox built and installed, but is not on this subprocess's PATH.
+Add this line to ~/.openclaw/.env and restart the skill:
+
+  PATH=$GO_BIN_DIR:/usr/local/bin:/usr/bin:/bin:$GO_INSTALL_DIR
+
+OpenClaw loads .env into the skill subprocess, so the updated PATH
+will take effect on the next invocation.
+EOF
+fi

--- a/claws/openclaw/sageox-summary/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-summary/scripts/update-ox.sh
@@ -3,10 +3,17 @@
 # the "is ox installed at all?" check for every invocation of this skill.
 #
 # Reads ~/.openclaw/memory/sageox-ox-install.json. If the install method
-# is git with auto_update enabled, runs git pull + make install from the
-# recorded clone path. Falls back silently to the existing binary on any
+# is git with auto_update enabled, resolves the recorded clone_path to
+# its physical location, verifies ownership, and runs git pull + make
+# install there. Falls back silently to the existing binary on any
 # failure (validation, network, build) — a bad update must never block
 # a working invocation.
+#
+# Before returning `0`, always re-confirms that `ox` is actually on the
+# subprocess PATH. A stale state file + a missing PATH entry is a common
+# failure mode on the curl install path and on git installs whose
+# ~/.openclaw/.env was lost, and reporting "ready" in either case would
+# just push the failure to the next `ox status` call.
 #
 # Usage: update-ox.sh
 #
@@ -14,9 +21,9 @@
 # Stderr: one-line warnings on failure modes; the "needs install" signal
 # Exit:
 #   0 — ox is ready, agent should proceed to next prerequisite
-#   2 — install state file is missing; agent must read
-#       references/INSTALL.md and run the interactive install flow
-#       before continuing
+#   2 — ox is not usable (no state file, or state says installed but
+#       'ox' is not on PATH); agent must read references/INSTALL.md and
+#       run the interactive install flow before continuing
 
 set -euo pipefail
 
@@ -27,87 +34,133 @@ if [ ! -f "$STATE_FILE" ]; then
   exit 2
 fi
 
-# Without jq we can't read the state file, but ox itself may still be
-# on PATH from a prior install. Don't fail — let the caller verify.
-if ! command -v jq >/dev/null 2>&1; then
-  echo "warning: jq not found; cannot read $STATE_FILE; skipping update check" >&2
-  exit 0
-fi
+# Resolve $HOME to its physical path once — used by the symlink-escape
+# check below. If $HOME itself is under a symlink (e.g. /Users/foo →
+# /Volumes/Data/Users/foo), the real clone_path must still resolve under
+# the resolved $HOME, not the textual one.
+REAL_HOME="$(cd "$HOME" && pwd -P)"
 
-INSTALL_METHOD="$(jq -r '.install_method // empty' "$STATE_FILE" 2>/dev/null || true)"
-if [ -z "$INSTALL_METHOD" ]; then
-  echo "warning: $STATE_FILE has no install_method; skipping update check" >&2
-  exit 0
-fi
+# Wrap the whole git-mode update path in a function so that early-exit
+# on any validation failure falls THROUGH to the final command -v ox
+# readiness gate at the bottom of the script. Using `return` here (not
+# `exit 0`) is what makes the gate load-bearing.
+try_git_update() {
+  local clone_path real_clone_path ch log
+  clone_path="$(jq -r '.clone_path // empty' "$STATE_FILE")"
+  if [ -z "$clone_path" ]; then
+    echo "warning: $STATE_FILE missing clone_path; skipping auto-update" >&2
+    return
+  fi
 
-# Curl install: nothing to update on a per-run basis. The user re-runs
-# the interactive flow to bump the pinned release.
-if [ "$INSTALL_METHOD" = "curl" ]; then
-  exit 0
-fi
-
-if [ "$INSTALL_METHOD" != "git" ]; then
-  echo "warning: unknown install_method '$INSTALL_METHOD' in $STATE_FILE; skipping update check" >&2
-  exit 0
-fi
-
-AUTO_UPDATE="$(jq -r '.auto_update // false' "$STATE_FILE")"
-if [ "$AUTO_UPDATE" != "true" ]; then
-  exit 0
-fi
-
-CLONE_PATH="$(jq -r '.clone_path // empty' "$STATE_FILE")"
-if [ -z "$CLONE_PATH" ]; then
-  echo "warning: $STATE_FILE missing clone_path; skipping auto-update" >&2
-  exit 0
-fi
-
-# Re-validate the clone path. The state file is user-writable and may
-# have been edited externally between runs — never trust persisted
-# values without re-checking. Validation failure is non-fatal: skip the
-# update and fall back to the existing ox binary.
-case "$CLONE_PATH" in
-  "$HOME"/*) ;;
-  *)
-    echo "warning: clone_path not under \$HOME; skipping auto-update: $CLONE_PATH" >&2
-    exit 0
-    ;;
-esac
-case "$CLONE_PATH" in
-  *..*)
-    echo "warning: clone_path contains '..'; skipping auto-update: $CLONE_PATH" >&2
-    exit 0
-    ;;
-esac
-for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '\'; do
-  case "$CLONE_PATH" in
-    *"$ch"*)
-      echo "warning: clone_path contains shell metacharacter; skipping auto-update" >&2
-      exit 0
+  # Text-level validation. Cheap to run; catches obvious hand-edits
+  # before we go near the filesystem.
+  case "$clone_path" in
+    "$HOME"/*) ;;
+    *)
+      echo "warning: clone_path not under \$HOME; skipping auto-update: $clone_path" >&2
+      return
       ;;
   esac
-done
-case "$CLONE_PATH" in
-  *"
+  case "$clone_path" in
+    *..*)
+      echo "warning: clone_path contains '..'; skipping auto-update: $clone_path" >&2
+      return
+      ;;
+  esac
+  for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '"' '\'; do
+    case "$clone_path" in
+      *"$ch"*)
+        echo "warning: clone_path contains shell metacharacter; skipping auto-update" >&2
+        return
+        ;;
+    esac
+  done
+  case "$clone_path" in
+    *"
 "*)
-    echo "warning: clone_path contains a newline; skipping auto-update" >&2
-    exit 0
-    ;;
-esac
-if [ ! -d "$CLONE_PATH/.git" ]; then
-  echo "warning: clone_path missing or not a git repo; skipping auto-update: $CLONE_PATH" >&2
-  exit 0
+      echo "warning: clone_path contains a newline; skipping auto-update" >&2
+      return
+      ;;
+  esac
+
+  # Physical path resolution. `cd && pwd -P` is the portable way to
+  # follow every symlink — works on BSD/macOS and GNU/Linux without
+  # depending on `readlink -f` or `realpath`, neither of which are
+  # guaranteed on older macOS. If the path doesn't exist or we can't
+  # enter it, treat the recorded state as stale and skip the update.
+  local real_clone_path
+  if ! real_clone_path="$(cd "$clone_path" 2>/dev/null && pwd -P)"; then
+    echo "warning: clone_path does not exist or is inaccessible; skipping auto-update: $clone_path" >&2
+    return
+  fi
+
+  # Resolved clone path must still be under the resolved $HOME — this
+  # is the check that catches `~/link → /tmp/foo` symlink escapes.
+  case "$real_clone_path" in
+    "$REAL_HOME"/*) ;;
+    *)
+      echo "warning: clone_path escapes \$HOME via symlink; skipping auto-update: $real_clone_path" >&2
+      return
+      ;;
+  esac
+
+  # Ownership check. `test -O` returns true iff the file is owned by
+  # the effective user ID — POSIX, portable across BSD and GNU. This
+  # blocks the case where a symlink inside $HOME points to a directory
+  # owned by root or another user (shared /opt, /var, etc.).
+  if [ ! -O "$real_clone_path" ]; then
+    echo "warning: clone_path not owned by current user; skipping auto-update: $real_clone_path" >&2
+    return
+  fi
+
+  if [ ! -d "$real_clone_path/.git" ]; then
+    echo "warning: resolved clone_path missing .git subdirectory; skipping auto-update: $real_clone_path" >&2
+    return
+  fi
+
+  # Run the update from the RESOLVED path. Non-fatal on failure — fall
+  # back to the existing binary. Capture output so we can show a useful
+  # tail-of-log on failure without polluting stdout on the success path.
+  log="$(mktemp "${TMPDIR:-/tmp}/ox-update.XXXXXXXX")"
+  trap 'rm -f "$log" 2>/dev/null' RETURN
+  if ! ( cd "$real_clone_path" && git pull --ff-only && make build && make install ) > "$log" 2>&1; then
+    echo "warning: ox auto-update failed; continuing with existing binary" >&2
+    echo "--- last 10 lines of update log ---" >&2
+    tail -10 "$log" >&2
+  fi
+}
+
+# Without jq we can't read the state file, but ox itself may still be
+# on PATH from a prior install. Don't fail — let the final readiness
+# gate decide.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "warning: jq not found; cannot read $STATE_FILE; skipping update check" >&2
+else
+  INSTALL_METHOD="$(jq -r '.install_method // empty' "$STATE_FILE" 2>/dev/null || true)"
+  if [ -z "$INSTALL_METHOD" ]; then
+    echo "warning: $STATE_FILE has no install_method; skipping update check" >&2
+  elif [ "$INSTALL_METHOD" = "curl" ]; then
+    : # Nothing to update on a per-run basis. The user re-runs the
+      # interactive flow to bump the pinned release.
+  elif [ "$INSTALL_METHOD" = "git" ]; then
+    AUTO_UPDATE="$(jq -r '.auto_update // false' "$STATE_FILE")"
+    if [ "$AUTO_UPDATE" = "true" ]; then
+      try_git_update
+    fi
+  else
+    echo "warning: unknown install_method '$INSTALL_METHOD' in $STATE_FILE; skipping update check" >&2
+  fi
 fi
 
-# Run the update. Non-fatal on failure — fall back to existing binary.
-# Capture output so we can show useful tail-of-log on failure without
-# polluting stdout on the success path.
-LOG="$(mktemp "${TMPDIR:-/tmp}/ox-update.XXXXXXXX")"
-trap 'rm -f "$LOG" 2>/dev/null' EXIT
-if ! ( cd "$CLONE_PATH" && git pull --ff-only && make build && make install ) > "$LOG" 2>&1; then
-  echo "warning: ox auto-update failed; continuing with existing binary" >&2
-  echo "--- last 10 lines of update log ---" >&2
-  tail -10 "$LOG" >&2
+# Final readiness gate. Whatever install method the state file records,
+# `ox` must actually be on the subprocess PATH for the rest of the
+# skill to function. A stale state file + a misconfigured ~/.openclaw/.env
+# is a common failure mode that used to only surface on the next
+# `ox status` call — make it surface here instead, with actionable
+# next-step guidance.
+if ! command -v ox >/dev/null 2>&1; then
+  echo "error: 'ox' is not on PATH (install state: ${INSTALL_METHOD:-unknown})" >&2
+  echo "fix: re-read references/INSTALL.md to re-run install or update ~/.openclaw/.env" >&2
+  exit 2
 fi
-
 exit 0

--- a/claws/openclaw/sageox-summary/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-summary/scripts/update-ox.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# update-ox.sh — non-fatal auto-update for the git install method, and
+# the "is ox installed at all?" check for every invocation of this skill.
+#
+# Reads ~/.openclaw/memory/sageox-ox-install.json. If the install method
+# is git with auto_update enabled, runs git pull + make install from the
+# recorded clone path. Falls back silently to the existing binary on any
+# failure (validation, network, build) — a bad update must never block
+# a working invocation.
+#
+# Usage: update-ox.sh
+#
+# Stdout: nothing on success
+# Stderr: one-line warnings on failure modes; the "needs install" signal
+# Exit:
+#   0 — ox is ready, agent should proceed to next prerequisite
+#   2 — install state file is missing; agent must read
+#       references/INSTALL.md and run the interactive install flow
+#       before continuing
+
+set -euo pipefail
+
+STATE_FILE="$HOME/.openclaw/memory/sageox-ox-install.json"
+
+if [ ! -f "$STATE_FILE" ]; then
+  echo "ox install state not configured — run interactive install flow from references/INSTALL.md" >&2
+  exit 2
+fi
+
+# Without jq we can't read the state file, but ox itself may still be
+# on PATH from a prior install. Don't fail — let the caller verify.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "warning: jq not found; cannot read $STATE_FILE; skipping update check" >&2
+  exit 0
+fi
+
+INSTALL_METHOD="$(jq -r '.install_method // empty' "$STATE_FILE" 2>/dev/null || true)"
+if [ -z "$INSTALL_METHOD" ]; then
+  echo "warning: $STATE_FILE has no install_method; skipping update check" >&2
+  exit 0
+fi
+
+# Curl install: nothing to update on a per-run basis. The user re-runs
+# the interactive flow to bump the pinned release.
+if [ "$INSTALL_METHOD" = "curl" ]; then
+  exit 0
+fi
+
+if [ "$INSTALL_METHOD" != "git" ]; then
+  echo "warning: unknown install_method '$INSTALL_METHOD' in $STATE_FILE; skipping update check" >&2
+  exit 0
+fi
+
+AUTO_UPDATE="$(jq -r '.auto_update // false' "$STATE_FILE")"
+if [ "$AUTO_UPDATE" != "true" ]; then
+  exit 0
+fi
+
+CLONE_PATH="$(jq -r '.clone_path // empty' "$STATE_FILE")"
+if [ -z "$CLONE_PATH" ]; then
+  echo "warning: $STATE_FILE missing clone_path; skipping auto-update" >&2
+  exit 0
+fi
+
+# Re-validate the clone path. The state file is user-writable and may
+# have been edited externally between runs — never trust persisted
+# values without re-checking. Validation failure is non-fatal: skip the
+# update and fall back to the existing ox binary.
+case "$CLONE_PATH" in
+  "$HOME"/*) ;;
+  *)
+    echo "warning: clone_path not under \$HOME; skipping auto-update: $CLONE_PATH" >&2
+    exit 0
+    ;;
+esac
+case "$CLONE_PATH" in
+  *..*)
+    echo "warning: clone_path contains '..'; skipping auto-update: $CLONE_PATH" >&2
+    exit 0
+    ;;
+esac
+for ch in ';' '$' '`' '|' '&' '<' '>' '(' ')' '{' '}' '*' '?' '[' ']' '!' '\'; do
+  case "$CLONE_PATH" in
+    *"$ch"*)
+      echo "warning: clone_path contains shell metacharacter; skipping auto-update" >&2
+      exit 0
+      ;;
+  esac
+done
+case "$CLONE_PATH" in
+  *"
+"*)
+    echo "warning: clone_path contains a newline; skipping auto-update" >&2
+    exit 0
+    ;;
+esac
+if [ ! -d "$CLONE_PATH/.git" ]; then
+  echo "warning: clone_path missing or not a git repo; skipping auto-update: $CLONE_PATH" >&2
+  exit 0
+fi
+
+# Run the update. Non-fatal on failure — fall back to existing binary.
+# Capture output so we can show useful tail-of-log on failure without
+# polluting stdout on the success path.
+LOG="$(mktemp "${TMPDIR:-/tmp}/ox-update.XXXXXXXX")"
+trap 'rm -f "$LOG" 2>/dev/null' EXIT
+if ! ( cd "$CLONE_PATH" && git pull --ff-only && make build && make install ) > "$LOG" 2>&1; then
+  echo "warning: ox auto-update failed; continuing with existing binary" >&2
+  echo "--- last 10 lines of update log ---" >&2
+  tail -10 "$LOG" >&2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- **Shrinks `SKILL.md` by ~40% in `sageox-distill` (435→251) and ~31% in `sageox-summary` (587→403)** by pulling the one-time `ox` install flow out of every invocation's resident context. On every run, each skill now invokes `bash scripts/update-ox.sh` — a short state check that handles the git auto-update path non-fatally, or exits `2` to signal "no install yet, read `references/INSTALL.md`."
- **Extracts the deterministic shell into three helpers**, mirroring the split #504 did for `sageox-summary`'s 24h-window math:
  - `scripts/install-ox-curl.sh` — pinned curl install (`OX_INSTALL_REF=v0.6.1`), head/tail preview, persists the memory file.
  - `scripts/install-ox-git.sh <clone_path> <auto_update>` — defensive path re-validation (same rules as SKILL.md § 3), Go ≥ 1.24 check, clone + `make install`, Go-path detection, `~/.openclaw/.env` guidance on stderr when `ox` is not on the subprocess PATH.
  - `scripts/update-ox.sh` — reads the memory file; curl mode = silent no-op; git mode = re-validate recorded clone path, run `git pull --ff-only && make build && make install`, fall back to existing binary on any failure with a 10-line tail of the build log on stderr; missing state file = exit `2`.
- **Relocates the interactive install prose to `references/INSTALL.md`** per the [Agent Skills spec § Directory structure](https://agentskills.io/specification) (`references/` is the spec's bucket for on-demand docs; `assets/` is reserved for templates/images/data, which is why `sageox-summary`'s `SUMMARIZE.md` stays under `assets/`). Progressive disclosure is the spec default for `references/` and `scripts/`, so there's no prose explaining *why* `INSTALL.md` isn't preloaded — that's just how the runtime works.

## Why

The install flow is a one-time decision that gets persisted to `~/.openclaw/memory/sageox-ox-install.json` and reused forever. Until now, ~218 lines of interactive-prompt prose + both option walkthroughs + the auto-update flow sat in the skill's resident context on every invocation, even though the actual install work runs once per user per machine. Extracting to `references/INSTALL.md` means the install prose only loads on the single run where it actually runs, and extracting the deterministic shell to `scripts/` means the executing agent no longer has to parse bash, handle BSD-vs-GNU `date` portability, or get atomic path validation right — it just invokes three helpers with documented contracts.

This is the same pattern #504 applied to the 24h-window math in `sageox-summary`.

## Script contracts

| Script | Args | Exit codes |
|---|---|---|
| `update-ox.sh` | none | `0` ready (continue); `2` no install state — read `references/INSTALL.md` |
| `install-ox-curl.sh` | none | `0` success; `3` curl missing / install failed / `ox` not on PATH |
| `install-ox-git.sh` | `<clone_path> <auto_update>` | `0` success; `2` usage / bad arg; `3` Go missing or too old, build failed |

All three scripts treat the persisted state file (`~/.openclaw/memory/sageox-ox-install.json`) as untrusted and re-validate every path read from it — the file is user-writable and may have been edited externally between runs.

## Test plan

- [x] `bash scripts/update-ox.sh` with no state file → exit `2`, stderr points at `references/INSTALL.md`
- [x] curl-mode state file → silent exit `0`
- [x] git mode with `auto_update=false` → silent exit `0`
- [x] git mode with `clone_path=/tmp/escape` (outside `$HOME`) → stderr warning, exit `0`, falls back
- [x] git mode with `clone_path` containing `..` → stderr warning, exit `0`, falls back
- [x] git mode with `clone_path` containing each of 17 shell metacharacters → stderr warning, exit `0`, falls back
- [x] git mode with `clone_path` missing `.git` subdirectory → stderr warning, exit `0`, falls back
- [x] Unknown `install_method` value → stderr warning, exit `0`
- [x] Malformed state JSON → stderr warning, exit `0`
- [x] `install-ox-git.sh` with no args → exit `2` usage
- [x] `install-ox-git.sh` with `auto_update=maybe` → exit `2` bad arg
- [x] `install-ox-git.sh` with `clone_path=/tmp/escape` → exit `2` defensive re-check
- [x] `install-ox-git.sh` with `clone_path` containing `;` → exit `2` defensive re-check
- [x] `install-ox-git.sh` with Go missing from PATH → exit `3`
- [x] Metachar loop iterates all 17 characters (verified via `bash -x | grep -c "for ch in"`)
- [x] Duplicated scripts + `INSTALL.md` are byte-identical between `sageox-distill` and `sageox-summary` (`diff -q` clean)
- [x] `clawhub-skill-lint` PASS on both skills — 0 critical, 0 warnings, 6 files / 24 KB and 9 files / 38 KB respectively
- [ ] End-to-end first-run install against a throwaway `~/.openclaw/memory/` — to be run by the reviewer before publish

## Follow-ups (not in this PR)

- Bump `OX_INSTALL_REF` in `install-ox-curl.sh` whenever a newer `sageox/ox` release lands. Right now it's pinned to `v0.6.1` matching the prior inline value.
- Throwaway-slug publish test before the next `clawhub skill publish` — see `claws/openclaw/PUBLISHING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified per-run readiness check that verifies the CLI and performs git auto-updates when enabled
  * Two install options exposed to users: curl-based release install or git source build
  * Installer now records a single remembered install choice for future checks

* **Documentation**
  * New interactive installation guide covering both install methods, prerequisites, PATH guidance, and re-entry commands

* **Chores**
  * Added requirement: `jq` is used for state handling and improved validation flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->