### PR TITLE
fix(claws): harden ox install scripts against symlink escape and foreign checkouts

### DIFF
--- a/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
@@ -170,8 +170,10 @@ if [ -L "$REAL_CLONE_PATH" ]; then
   exit 2
 fi
 
+JUST_CLONED=0
 if [ ! -d "$REAL_CLONE_PATH/.git" ]; then
   git clone https://github.com/sageox/ox.git "$REAL_CLONE_PATH"
+  JUST_CLONED=1
 fi
 
 # Defense-in-depth canonicalization. The ancestor validation above
@@ -223,6 +225,41 @@ case "$ORIGIN_URL" in
     exit 2
     ;;
 esac
+
+# If we're adopting an existing directory (not a fresh clone above),
+# the origin URL check is necessary but not sufficient: `.git/config`
+# is just a text file, and the working tree content is unsigned. A
+# hand-edited Makefile could execute arbitrary code under the user's
+# UID. Re-fetch from the allow-listed origin and `reset --hard` the
+# working tree to the fetched default-branch tip, so `make install`
+# runs the official code.
+#
+# Gated on `git status --porcelain` being empty: contributors who run
+# this script on their own dev clone (iterating on ox itself with
+# auto_update=true) would otherwise lose uncommitted work on every
+# invocation. If the tree is dirty, refuse and ask them to commit or
+# stash. A fresh clone never hits this path.
+if [ "$JUST_CLONED" = "0" ]; then
+  if [ -n "$(git -C "$REAL_CLONE_PATH" status --porcelain 2>/dev/null)" ]; then
+    echo "error: $REAL_CLONE_PATH has uncommitted or untracked files; refusing to reset" >&2
+    echo "       commit or stash your changes, then re-run" >&2
+    exit 2
+  fi
+  # `fetch origin` updates all `origin/*` tracking refs; `remote
+  # set-head origin --auto` refreshes the symbolic `origin/HEAD` to
+  # match the remote's current default branch, so we reset to
+  # whatever upstream calls its default (main/master/trunk) without
+  # hardcoding a name.
+  if ! git -C "$REAL_CLONE_PATH" fetch --quiet origin; then
+    echo "error: git fetch origin failed in $REAL_CLONE_PATH" >&2
+    exit 3
+  fi
+  git -C "$REAL_CLONE_PATH" remote set-head origin --auto >/dev/null 2>&1 || true
+  if ! git -C "$REAL_CLONE_PATH" reset --hard --quiet origin/HEAD; then
+    echo "error: git reset --hard origin/HEAD failed in $REAL_CLONE_PATH" >&2
+    exit 3
+  fi
+fi
 
 # Build and install in a subshell so the cd doesn't leak.
 ( cd "$REAL_CLONE_PATH" && make build && make install )

--- a/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
@@ -157,14 +157,43 @@ REAL_PARENT="$(cd "$PARENT_DIR" && pwd -P)"
 # path on every future run.
 REAL_CLONE_PATH="$REAL_PARENT/$(basename "$CLONE_PATH")"
 
+# Reject a symlinked final path component. A symlink at REAL_CLONE_PATH
+# could point at a user-owned sageox/ox checkout anywhere on disk — the
+# `test -O` and `git -C` checks below both follow symlinks, so they'd
+# both pass, and `make install` would run in the escaped tree while
+# the state file recorded only the alias. Policy: the clone target is
+# either a plain directory we create, or an existing plain directory
+# we adopt. Never a symlink. Users who want to reorganize their clone
+# should move it and re-run the interactive install.
+if [ -L "$REAL_CLONE_PATH" ]; then
+  echo "error: clone target must not be a symlink: $REAL_CLONE_PATH" >&2
+  exit 2
+fi
+
 if [ ! -d "$REAL_CLONE_PATH/.git" ]; then
   git clone https://github.com/sageox/ox.git "$REAL_CLONE_PATH"
 fi
 
+# Defense-in-depth canonicalization. The ancestor validation above
+# guarantees REAL_PARENT is physical, and the -L check immediately
+# above rejects a symlinked leaf, so `cd && pwd -P` here should be a
+# no-op — but run it anyway and re-check against $REAL_HOME so that
+# any residual aliasing (e.g., a future change that adds a
+# code path that doesn't go through the walk-up) still fails closed.
+REAL_CLONE_PATH="$(cd "$REAL_CLONE_PATH" && pwd -P)"
+case "$REAL_CLONE_PATH" in
+  "$REAL_HOME"/*) ;;
+  *)
+    echo "error: clone target escapes \$HOME via symlink: $REAL_CLONE_PATH" >&2
+    exit 2
+    ;;
+esac
+
 # After clone (or existing-dir detection), the target itself must be
 # owned by the current user. `git clone` inherits parent-directory
 # ownership by default, but this catches the case where someone
-# pre-created the target as a symlink to a foreign tree.
+# pre-created the target as a directory owned by another user (shared
+# /opt, /var, etc.).
 if [ ! -O "$REAL_CLONE_PATH" ]; then
   echo "error: clone target not owned by current user: $REAL_CLONE_PATH" >&2
   exit 2
@@ -178,10 +207,17 @@ fi
 # footgun. A fresh clone a few lines up guarantees the origin is
 # correct, but the existing-dir branch and "switch ox install method"
 # re-runs do not.
+#
+# Accept the three canonical origin forms: HTTPS, scp-style SSH, and
+# URI-style SSH (with and without the `.git` suffix). `git remote
+# get-url` emits exactly what's stored in config — it does NOT
+# normalize between scp-style and URI-style — so the allow-list has
+# to cover the variants users actually configure.
 ORIGIN_URL="$(git -C "$REAL_CLONE_PATH" remote get-url origin 2>/dev/null || true)"
 case "$ORIGIN_URL" in
   https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
   git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
+  ssh://git@github.com/sageox/ox|ssh://git@github.com/sageox/ox.git) ;;
   *)
     echo "error: $REAL_CLONE_PATH is not a sageox/ox checkout (origin: ${ORIGIN_URL:-<none>})" >&2
     exit 2

--- a/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-distill/scripts/install-ox-git.sh
@@ -107,31 +107,49 @@ fi
 # Physical path resolution. The textual `case "$HOME/*"` check above
 # only validates the prefix string — a path like `$HOME/link` where
 # `link → /tmp/foo` would pass that check while the real clone target
-# sits outside $HOME. Resolve the PARENT directory physically (the
-# clone path itself may not exist yet) and confirm the resolved
-# location is still under the resolved $HOME and is owned by the
-# current user before we create or write anything.
+# sits outside $HOME. Resolve the path physically and verify ownership
+# before we create or write anything.
 #
 # `cd && pwd -P` is the portable resolver — works on BSD/macOS and
 # GNU/Linux with no `readlink -f` / `realpath` dependency.
-PARENT_DIR="$(dirname "$CLONE_PATH")"
-mkdir -p "$PARENT_DIR"
+#
+# Critically, we must validate BEFORE `mkdir -p` runs. A symlinked
+# ancestor would otherwise let `mkdir -p` create directories in a
+# foreign tree BEFORE the physical check has a chance to reject the
+# path. Walk up from PARENT_DIR to the deepest existing ancestor,
+# resolve IT, and validate the resolved location there — anything
+# mkdir creates beneath a validated ancestor is guaranteed to stay
+# inside it, because mkdir never creates symlinks.
 REAL_HOME="$(cd "$HOME" && pwd -P)"
-if ! REAL_PARENT="$(cd "$PARENT_DIR" && pwd -P)"; then
-  echo "error: could not resolve parent directory: $PARENT_DIR" >&2
-  exit 2
-fi
-case "$REAL_PARENT" in
+PARENT_DIR="$(dirname "$CLONE_PATH")"
+
+ANCESTOR="$PARENT_DIR"
+while [ ! -d "$ANCESTOR" ]; do
+  NEXT="$(dirname "$ANCESTOR")"
+  if [ "$NEXT" = "$ANCESTOR" ]; then
+    echo "error: no existing ancestor found for parent directory: $PARENT_DIR" >&2
+    exit 2
+  fi
+  ANCESTOR="$NEXT"
+done
+REAL_ANCESTOR="$(cd "$ANCESTOR" && pwd -P)"
+case "$REAL_ANCESTOR" in
   "$REAL_HOME"|"$REAL_HOME"/*) ;;
   *)
-    echo "error: parent directory escapes \$HOME via symlink: $REAL_PARENT" >&2
+    echo "error: ancestor directory escapes \$HOME via symlink: $REAL_ANCESTOR" >&2
     exit 2
     ;;
 esac
-if [ ! -O "$REAL_PARENT" ]; then
-  echo "error: parent directory not owned by current user: $REAL_PARENT" >&2
+if [ ! -O "$REAL_ANCESTOR" ]; then
+  echo "error: ancestor directory not owned by current user: $REAL_ANCESTOR" >&2
   exit 2
 fi
+
+# Safe to create missing parents now. mkdir -p creates plain
+# directories under REAL_ANCESTOR, which we've already confirmed is
+# under $HOME and owned by the user.
+mkdir -p "$PARENT_DIR"
+REAL_PARENT="$(cd "$PARENT_DIR" && pwd -P)"
 
 # Reassemble the canonical clone path from the resolved parent + the
 # basename. We use this canonical form everywhere below (clone target,
@@ -143,14 +161,32 @@ if [ ! -d "$REAL_CLONE_PATH/.git" ]; then
   git clone https://github.com/sageox/ox.git "$REAL_CLONE_PATH"
 fi
 
-# After clone, the target itself must also be owned by the current
-# user. `git clone` inherits parent-directory ownership by default but
-# this catches the case where someone pre-created the target as a
-# symlink to a foreign tree.
+# After clone (or existing-dir detection), the target itself must be
+# owned by the current user. `git clone` inherits parent-directory
+# ownership by default, but this catches the case where someone
+# pre-created the target as a symlink to a foreign tree.
 if [ ! -O "$REAL_CLONE_PATH" ]; then
   echo "error: clone target not owned by current user: $REAL_CLONE_PATH" >&2
   exit 2
 fi
+
+# Defense-in-depth: confirm this is actually a sageox/ox checkout
+# before running its Makefile. If the caller pointed us at a
+# pre-existing user-owned git repo that happens to live at
+# REAL_CLONE_PATH, the existing-dir branch above would skip `git
+# clone` and run THAT repo's `make install` — a code-execution
+# footgun. A fresh clone a few lines up guarantees the origin is
+# correct, but the existing-dir branch and "switch ox install method"
+# re-runs do not.
+ORIGIN_URL="$(git -C "$REAL_CLONE_PATH" remote get-url origin 2>/dev/null || true)"
+case "$ORIGIN_URL" in
+  https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
+  git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
+  *)
+    echo "error: $REAL_CLONE_PATH is not a sageox/ox checkout (origin: ${ORIGIN_URL:-<none>})" >&2
+    exit 2
+    ;;
+esac
 
 # Build and install in a subshell so the cd doesn't leak.
 ( cd "$REAL_CLONE_PATH" && make build && make install )

--- a/claws/openclaw/sageox-distill/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-distill/scripts/update-ox.sh
@@ -143,12 +143,41 @@ try_git_update() {
       ;;
   esac
 
-  # Run the update from the RESOLVED path. Non-fatal on failure — fall
-  # back to the existing binary. Capture output so we can show a useful
-  # tail-of-log on failure without polluting stdout on the success path.
+  # Refuse to reset a dirty working tree. The fetch + reset below
+  # would otherwise silently destroy uncommitted contributor work on
+  # every auto_update=true invocation — users iterating on ox locally
+  # would lose edits between saves. Skip the update instead and let
+  # the final readiness gate decide whether the existing binary is
+  # still usable; the user can commit/stash and re-run explicitly.
+  if [ -n "$(git -C "$real_clone_path" status --porcelain 2>/dev/null)" ]; then
+    echo "warning: $real_clone_path has uncommitted or untracked files; skipping auto-update" >&2
+    return
+  fi
+
+  # Update the working tree via fetch + reset --hard instead of
+  # `git pull --ff-only`. The origin URL check above only verifies
+  # `.git/config`; the working tree content is unsigned and
+  # hand-editable, so a tampered Makefile would otherwise run under
+  # `make install`. Fetching from the allow-listed origin and
+  # resetting to its default-branch tip enforces that we build only
+  # what is actually on upstream. `remote set-head origin --auto`
+  # refreshes the symbolic `origin/HEAD` ref so we reset to whatever
+  # the remote calls its default (main/master/trunk), without
+  # hardcoding a name that could drift.
+  #
+  # Still non-fatal on failure — fall back to the existing binary.
+  # Capture output so we can show a useful tail-of-log on failure
+  # without polluting stdout on the success path.
   log="$(mktemp "${TMPDIR:-/tmp}/ox-update.XXXXXXXX")"
   trap 'rm -f "$log" 2>/dev/null' RETURN
-  if ! ( cd "$real_clone_path" && git pull --ff-only && make build && make install ) > "$log" 2>&1; then
+  if ! (
+    cd "$real_clone_path"
+    git fetch --quiet origin
+    git remote set-head origin --auto >/dev/null 2>&1 || true
+    git reset --hard --quiet origin/HEAD
+    make build
+    make install
+  ) > "$log" 2>&1; then
     echo "warning: ox auto-update failed; continuing with existing binary" >&2
     echo "--- last 10 lines of update log ---" >&2
     tail -10 "$log" >&2

--- a/claws/openclaw/sageox-distill/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-distill/scripts/update-ox.sh
@@ -53,9 +53,15 @@ try_git_update() {
   fi
 
   # Text-level validation. Cheap to run; catches obvious hand-edits
-  # before we go near the filesystem.
+  # before we go near the filesystem. Accept both the textual $HOME
+  # prefix and the resolved $REAL_HOME prefix — install-ox-git.sh
+  # writes the state file with the PHYSICAL clone path, so on a
+  # system where $HOME itself is symlinked (e.g. /Users/foo →
+  # /Volumes/Data/Users/foo) the stored path will start with
+  # $REAL_HOME and the textual check against $HOME alone would
+  # reject every legitimate auto-update.
   case "$clone_path" in
-    "$HOME"/*) ;;
+    "$HOME"/*|"$REAL_HOME"/*) ;;
     *)
       echo "warning: clone_path not under \$HOME; skipping auto-update: $clone_path" >&2
       return
@@ -117,6 +123,19 @@ try_git_update() {
     echo "warning: resolved clone_path missing .git subdirectory; skipping auto-update: $real_clone_path" >&2
     return
   fi
+
+  # Defense-in-depth: confirm this is actually a sageox/ox checkout
+  # before running its Makefile. The state file is user-writable and
+  # could point at any user-owned git repo under $HOME; `git pull &&
+  # make install` on a random repo is a code-execution footgun.
+  case "$(git -C "$real_clone_path" remote get-url origin 2>/dev/null || true)" in
+    https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
+    git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
+    *)
+      echo "warning: clone_path is not a sageox/ox checkout; skipping auto-update: $real_clone_path" >&2
+      return
+      ;;
+  esac
 
   # Run the update from the RESOLVED path. Non-fatal on failure — fall
   # back to the existing binary. Capture output so we can show a useful

--- a/claws/openclaw/sageox-distill/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-distill/scripts/update-ox.sh
@@ -128,9 +128,15 @@ try_git_update() {
   # before running its Makefile. The state file is user-writable and
   # could point at any user-owned git repo under $HOME; `git pull &&
   # make install` on a random repo is a code-execution footgun.
+  #
+  # Accept HTTPS, scp-style SSH, and URI-style SSH — `git remote
+  # get-url` emits exactly what's stored in config without
+  # normalizing between the SSH variants, so the allow-list has to
+  # cover each form users actually configure.
   case "$(git -C "$real_clone_path" remote get-url origin 2>/dev/null || true)" in
     https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
     git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
+    ssh://git@github.com/sageox/ox|ssh://git@github.com/sageox/ox.git) ;;
     *)
       echo "warning: clone_path is not a sageox/ox checkout; skipping auto-update: $real_clone_path" >&2
       return

--- a/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
@@ -170,8 +170,10 @@ if [ -L "$REAL_CLONE_PATH" ]; then
   exit 2
 fi
 
+JUST_CLONED=0
 if [ ! -d "$REAL_CLONE_PATH/.git" ]; then
   git clone https://github.com/sageox/ox.git "$REAL_CLONE_PATH"
+  JUST_CLONED=1
 fi
 
 # Defense-in-depth canonicalization. The ancestor validation above
@@ -223,6 +225,41 @@ case "$ORIGIN_URL" in
     exit 2
     ;;
 esac
+
+# If we're adopting an existing directory (not a fresh clone above),
+# the origin URL check is necessary but not sufficient: `.git/config`
+# is just a text file, and the working tree content is unsigned. A
+# hand-edited Makefile could execute arbitrary code under the user's
+# UID. Re-fetch from the allow-listed origin and `reset --hard` the
+# working tree to the fetched default-branch tip, so `make install`
+# runs the official code.
+#
+# Gated on `git status --porcelain` being empty: contributors who run
+# this script on their own dev clone (iterating on ox itself with
+# auto_update=true) would otherwise lose uncommitted work on every
+# invocation. If the tree is dirty, refuse and ask them to commit or
+# stash. A fresh clone never hits this path.
+if [ "$JUST_CLONED" = "0" ]; then
+  if [ -n "$(git -C "$REAL_CLONE_PATH" status --porcelain 2>/dev/null)" ]; then
+    echo "error: $REAL_CLONE_PATH has uncommitted or untracked files; refusing to reset" >&2
+    echo "       commit or stash your changes, then re-run" >&2
+    exit 2
+  fi
+  # `fetch origin` updates all `origin/*` tracking refs; `remote
+  # set-head origin --auto` refreshes the symbolic `origin/HEAD` to
+  # match the remote's current default branch, so we reset to
+  # whatever upstream calls its default (main/master/trunk) without
+  # hardcoding a name.
+  if ! git -C "$REAL_CLONE_PATH" fetch --quiet origin; then
+    echo "error: git fetch origin failed in $REAL_CLONE_PATH" >&2
+    exit 3
+  fi
+  git -C "$REAL_CLONE_PATH" remote set-head origin --auto >/dev/null 2>&1 || true
+  if ! git -C "$REAL_CLONE_PATH" reset --hard --quiet origin/HEAD; then
+    echo "error: git reset --hard origin/HEAD failed in $REAL_CLONE_PATH" >&2
+    exit 3
+  fi
+fi
 
 # Build and install in a subshell so the cd doesn't leak.
 ( cd "$REAL_CLONE_PATH" && make build && make install )

--- a/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
@@ -157,14 +157,43 @@ REAL_PARENT="$(cd "$PARENT_DIR" && pwd -P)"
 # path on every future run.
 REAL_CLONE_PATH="$REAL_PARENT/$(basename "$CLONE_PATH")"
 
+# Reject a symlinked final path component. A symlink at REAL_CLONE_PATH
+# could point at a user-owned sageox/ox checkout anywhere on disk — the
+# `test -O` and `git -C` checks below both follow symlinks, so they'd
+# both pass, and `make install` would run in the escaped tree while
+# the state file recorded only the alias. Policy: the clone target is
+# either a plain directory we create, or an existing plain directory
+# we adopt. Never a symlink. Users who want to reorganize their clone
+# should move it and re-run the interactive install.
+if [ -L "$REAL_CLONE_PATH" ]; then
+  echo "error: clone target must not be a symlink: $REAL_CLONE_PATH" >&2
+  exit 2
+fi
+
 if [ ! -d "$REAL_CLONE_PATH/.git" ]; then
   git clone https://github.com/sageox/ox.git "$REAL_CLONE_PATH"
 fi
 
+# Defense-in-depth canonicalization. The ancestor validation above
+# guarantees REAL_PARENT is physical, and the -L check immediately
+# above rejects a symlinked leaf, so `cd && pwd -P` here should be a
+# no-op — but run it anyway and re-check against $REAL_HOME so that
+# any residual aliasing (e.g., a future change that adds a
+# code path that doesn't go through the walk-up) still fails closed.
+REAL_CLONE_PATH="$(cd "$REAL_CLONE_PATH" && pwd -P)"
+case "$REAL_CLONE_PATH" in
+  "$REAL_HOME"/*) ;;
+  *)
+    echo "error: clone target escapes \$HOME via symlink: $REAL_CLONE_PATH" >&2
+    exit 2
+    ;;
+esac
+
 # After clone (or existing-dir detection), the target itself must be
 # owned by the current user. `git clone` inherits parent-directory
 # ownership by default, but this catches the case where someone
-# pre-created the target as a symlink to a foreign tree.
+# pre-created the target as a directory owned by another user (shared
+# /opt, /var, etc.).
 if [ ! -O "$REAL_CLONE_PATH" ]; then
   echo "error: clone target not owned by current user: $REAL_CLONE_PATH" >&2
   exit 2
@@ -178,10 +207,17 @@ fi
 # footgun. A fresh clone a few lines up guarantees the origin is
 # correct, but the existing-dir branch and "switch ox install method"
 # re-runs do not.
+#
+# Accept the three canonical origin forms: HTTPS, scp-style SSH, and
+# URI-style SSH (with and without the `.git` suffix). `git remote
+# get-url` emits exactly what's stored in config — it does NOT
+# normalize between scp-style and URI-style — so the allow-list has
+# to cover the variants users actually configure.
 ORIGIN_URL="$(git -C "$REAL_CLONE_PATH" remote get-url origin 2>/dev/null || true)"
 case "$ORIGIN_URL" in
   https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
   git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
+  ssh://git@github.com/sageox/ox|ssh://git@github.com/sageox/ox.git) ;;
   *)
     echo "error: $REAL_CLONE_PATH is not a sageox/ox checkout (origin: ${ORIGIN_URL:-<none>})" >&2
     exit 2

--- a/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
+++ b/claws/openclaw/sageox-summary/scripts/install-ox-git.sh
@@ -107,31 +107,49 @@ fi
 # Physical path resolution. The textual `case "$HOME/*"` check above
 # only validates the prefix string — a path like `$HOME/link` where
 # `link → /tmp/foo` would pass that check while the real clone target
-# sits outside $HOME. Resolve the PARENT directory physically (the
-# clone path itself may not exist yet) and confirm the resolved
-# location is still under the resolved $HOME and is owned by the
-# current user before we create or write anything.
+# sits outside $HOME. Resolve the path physically and verify ownership
+# before we create or write anything.
 #
 # `cd && pwd -P` is the portable resolver — works on BSD/macOS and
 # GNU/Linux with no `readlink -f` / `realpath` dependency.
-PARENT_DIR="$(dirname "$CLONE_PATH")"
-mkdir -p "$PARENT_DIR"
+#
+# Critically, we must validate BEFORE `mkdir -p` runs. A symlinked
+# ancestor would otherwise let `mkdir -p` create directories in a
+# foreign tree BEFORE the physical check has a chance to reject the
+# path. Walk up from PARENT_DIR to the deepest existing ancestor,
+# resolve IT, and validate the resolved location there — anything
+# mkdir creates beneath a validated ancestor is guaranteed to stay
+# inside it, because mkdir never creates symlinks.
 REAL_HOME="$(cd "$HOME" && pwd -P)"
-if ! REAL_PARENT="$(cd "$PARENT_DIR" && pwd -P)"; then
-  echo "error: could not resolve parent directory: $PARENT_DIR" >&2
-  exit 2
-fi
-case "$REAL_PARENT" in
+PARENT_DIR="$(dirname "$CLONE_PATH")"
+
+ANCESTOR="$PARENT_DIR"
+while [ ! -d "$ANCESTOR" ]; do
+  NEXT="$(dirname "$ANCESTOR")"
+  if [ "$NEXT" = "$ANCESTOR" ]; then
+    echo "error: no existing ancestor found for parent directory: $PARENT_DIR" >&2
+    exit 2
+  fi
+  ANCESTOR="$NEXT"
+done
+REAL_ANCESTOR="$(cd "$ANCESTOR" && pwd -P)"
+case "$REAL_ANCESTOR" in
   "$REAL_HOME"|"$REAL_HOME"/*) ;;
   *)
-    echo "error: parent directory escapes \$HOME via symlink: $REAL_PARENT" >&2
+    echo "error: ancestor directory escapes \$HOME via symlink: $REAL_ANCESTOR" >&2
     exit 2
     ;;
 esac
-if [ ! -O "$REAL_PARENT" ]; then
-  echo "error: parent directory not owned by current user: $REAL_PARENT" >&2
+if [ ! -O "$REAL_ANCESTOR" ]; then
+  echo "error: ancestor directory not owned by current user: $REAL_ANCESTOR" >&2
   exit 2
 fi
+
+# Safe to create missing parents now. mkdir -p creates plain
+# directories under REAL_ANCESTOR, which we've already confirmed is
+# under $HOME and owned by the user.
+mkdir -p "$PARENT_DIR"
+REAL_PARENT="$(cd "$PARENT_DIR" && pwd -P)"
 
 # Reassemble the canonical clone path from the resolved parent + the
 # basename. We use this canonical form everywhere below (clone target,
@@ -143,14 +161,32 @@ if [ ! -d "$REAL_CLONE_PATH/.git" ]; then
   git clone https://github.com/sageox/ox.git "$REAL_CLONE_PATH"
 fi
 
-# After clone, the target itself must also be owned by the current
-# user. `git clone` inherits parent-directory ownership by default but
-# this catches the case where someone pre-created the target as a
-# symlink to a foreign tree.
+# After clone (or existing-dir detection), the target itself must be
+# owned by the current user. `git clone` inherits parent-directory
+# ownership by default, but this catches the case where someone
+# pre-created the target as a symlink to a foreign tree.
 if [ ! -O "$REAL_CLONE_PATH" ]; then
   echo "error: clone target not owned by current user: $REAL_CLONE_PATH" >&2
   exit 2
 fi
+
+# Defense-in-depth: confirm this is actually a sageox/ox checkout
+# before running its Makefile. If the caller pointed us at a
+# pre-existing user-owned git repo that happens to live at
+# REAL_CLONE_PATH, the existing-dir branch above would skip `git
+# clone` and run THAT repo's `make install` — a code-execution
+# footgun. A fresh clone a few lines up guarantees the origin is
+# correct, but the existing-dir branch and "switch ox install method"
+# re-runs do not.
+ORIGIN_URL="$(git -C "$REAL_CLONE_PATH" remote get-url origin 2>/dev/null || true)"
+case "$ORIGIN_URL" in
+  https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
+  git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
+  *)
+    echo "error: $REAL_CLONE_PATH is not a sageox/ox checkout (origin: ${ORIGIN_URL:-<none>})" >&2
+    exit 2
+    ;;
+esac
 
 # Build and install in a subshell so the cd doesn't leak.
 ( cd "$REAL_CLONE_PATH" && make build && make install )

--- a/claws/openclaw/sageox-summary/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-summary/scripts/update-ox.sh
@@ -143,12 +143,41 @@ try_git_update() {
       ;;
   esac
 
-  # Run the update from the RESOLVED path. Non-fatal on failure — fall
-  # back to the existing binary. Capture output so we can show a useful
-  # tail-of-log on failure without polluting stdout on the success path.
+  # Refuse to reset a dirty working tree. The fetch + reset below
+  # would otherwise silently destroy uncommitted contributor work on
+  # every auto_update=true invocation — users iterating on ox locally
+  # would lose edits between saves. Skip the update instead and let
+  # the final readiness gate decide whether the existing binary is
+  # still usable; the user can commit/stash and re-run explicitly.
+  if [ -n "$(git -C "$real_clone_path" status --porcelain 2>/dev/null)" ]; then
+    echo "warning: $real_clone_path has uncommitted or untracked files; skipping auto-update" >&2
+    return
+  fi
+
+  # Update the working tree via fetch + reset --hard instead of
+  # `git pull --ff-only`. The origin URL check above only verifies
+  # `.git/config`; the working tree content is unsigned and
+  # hand-editable, so a tampered Makefile would otherwise run under
+  # `make install`. Fetching from the allow-listed origin and
+  # resetting to its default-branch tip enforces that we build only
+  # what is actually on upstream. `remote set-head origin --auto`
+  # refreshes the symbolic `origin/HEAD` ref so we reset to whatever
+  # the remote calls its default (main/master/trunk), without
+  # hardcoding a name that could drift.
+  #
+  # Still non-fatal on failure — fall back to the existing binary.
+  # Capture output so we can show a useful tail-of-log on failure
+  # without polluting stdout on the success path.
   log="$(mktemp "${TMPDIR:-/tmp}/ox-update.XXXXXXXX")"
   trap 'rm -f "$log" 2>/dev/null' RETURN
-  if ! ( cd "$real_clone_path" && git pull --ff-only && make build && make install ) > "$log" 2>&1; then
+  if ! (
+    cd "$real_clone_path"
+    git fetch --quiet origin
+    git remote set-head origin --auto >/dev/null 2>&1 || true
+    git reset --hard --quiet origin/HEAD
+    make build
+    make install
+  ) > "$log" 2>&1; then
     echo "warning: ox auto-update failed; continuing with existing binary" >&2
     echo "--- last 10 lines of update log ---" >&2
     tail -10 "$log" >&2

--- a/claws/openclaw/sageox-summary/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-summary/scripts/update-ox.sh
@@ -53,9 +53,15 @@ try_git_update() {
   fi
 
   # Text-level validation. Cheap to run; catches obvious hand-edits
-  # before we go near the filesystem.
+  # before we go near the filesystem. Accept both the textual $HOME
+  # prefix and the resolved $REAL_HOME prefix — install-ox-git.sh
+  # writes the state file with the PHYSICAL clone path, so on a
+  # system where $HOME itself is symlinked (e.g. /Users/foo →
+  # /Volumes/Data/Users/foo) the stored path will start with
+  # $REAL_HOME and the textual check against $HOME alone would
+  # reject every legitimate auto-update.
   case "$clone_path" in
-    "$HOME"/*) ;;
+    "$HOME"/*|"$REAL_HOME"/*) ;;
     *)
       echo "warning: clone_path not under \$HOME; skipping auto-update: $clone_path" >&2
       return
@@ -117,6 +123,19 @@ try_git_update() {
     echo "warning: resolved clone_path missing .git subdirectory; skipping auto-update: $real_clone_path" >&2
     return
   fi
+
+  # Defense-in-depth: confirm this is actually a sageox/ox checkout
+  # before running its Makefile. The state file is user-writable and
+  # could point at any user-owned git repo under $HOME; `git pull &&
+  # make install` on a random repo is a code-execution footgun.
+  case "$(git -C "$real_clone_path" remote get-url origin 2>/dev/null || true)" in
+    https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
+    git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
+    *)
+      echo "warning: clone_path is not a sageox/ox checkout; skipping auto-update: $real_clone_path" >&2
+      return
+      ;;
+  esac
 
   # Run the update from the RESOLVED path. Non-fatal on failure — fall
   # back to the existing binary. Capture output so we can show a useful

--- a/claws/openclaw/sageox-summary/scripts/update-ox.sh
+++ b/claws/openclaw/sageox-summary/scripts/update-ox.sh
@@ -128,9 +128,15 @@ try_git_update() {
   # before running its Makefile. The state file is user-writable and
   # could point at any user-owned git repo under $HOME; `git pull &&
   # make install` on a random repo is a code-execution footgun.
+  #
+  # Accept HTTPS, scp-style SSH, and URI-style SSH — `git remote
+  # get-url` emits exactly what's stored in config without
+  # normalizing between the SSH variants, so the allow-list has to
+  # cover each form users actually configure.
   case "$(git -C "$real_clone_path" remote get-url origin 2>/dev/null || true)" in
     https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
     git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
+    ssh://git@github.com/sageox/ox|ssh://git@github.com/sageox/ox.git) ;;
     *)
       echo "warning: clone_path is not a sageox/ox checkout; skipping auto-update: $real_clone_path" >&2
       return


### PR DESCRIPTION
## Summary

Round-2 follow-up to #511. CodeRabbit re-reviewed after the first round of fixes and flagged **3 criticals + 1 major** that I acked before the merge — filing them now as a separate PR.

| # | Severity | Where | Problem |
|---|---|---|---|
| 1 | 🔴 critical | `install-ox-git.sh` | `mkdir -p` ran BEFORE the symlink-escape check — a symlinked ancestor could let `mkdir` create dirs in a foreign tree before validation fired. |
| 2 | 🔴 critical | `install-ox-git.sh` | An existing `.git` at the target path was accepted without verifying `remote.origin.url`, so a hand-edited invocation pointing at any user-owned repo would happily run its `make install`. |
| 3 | 🟠 major | `update-ox.sh` | Text-level `"$HOME"/*` prefix check broke when `$HOME` was symlinked: `install-ox-git.sh` writes the PHYSICAL `REAL_CLONE_PATH` into state, so the stored path starts with `$REAL_HOME` and the textual `$HOME` check rejected every legit auto-update. |
| 4 | 🔴 critical | `update-ox.sh` | `git pull && make build && make install` ran on the recorded `clone_path` without verifying it's actually `sageox/ox`. A hand-edited state file pointing at any user-owned repo under `$HOME` would execute that repo's Makefile on every invocation. |

## Fix shapes

**#1 — walk up to the deepest existing ancestor, validate there, THEN mkdir.**
Walking up from `PARENT_DIR` to the first directory that exists lets us resolve `cd … && pwd -P` on a real path, check it against `$REAL_HOME`, and verify ownership BEFORE any filesystem mutation. Once the ancestor is confirmed inside `$HOME` and user-owned, `mkdir -p` can only create plain directories underneath it — `mkdir` never creates symlinks, so the final physical parent is guaranteed to stay inside the validated ancestor.

**#2 & #4 — \`git -C <path> remote get-url origin\` check.**
Both scripts now gate `make build && make install` on an origin-URL allow-list:

```bash
case "$(git -C "$real_clone_path" remote get-url origin 2>/dev/null || true)" in
  https://github.com/sageox/ox|https://github.com/sageox/ox.git) ;;
  git@github.com:sageox/ox|git@github.com:sageox/ox.git) ;;
  *) # reject / skip
esac
```

Covers HTTPS and SSH, with and without the `.git` suffix. Forks are intentionally rejected — users with forks can still use the curl install method or adjust their state file manually after understanding what they're opting into.

**#3 — accept both \`$HOME/*\` and \`$REAL_HOME/*\` prefixes.**
The text-level prefix check in `update-ox.sh` now accepts either form, so the resolved physical path stored by `install-ox-git.sh` passes through to the physical-resolution + ownership check below, which is where the real security decision happens. The text check stays as a cheap early filter for obviously-bad hand-edits.

## Test plan

Smoke-tested each fix in isolation:

- [x] **Fix 1** — created `$HOME/escape-link → /tmp/ox-foreign`, invoked `install-ox-git.sh "$HOME/escape-link/deep/subdir" true`. Before the fix, `mkdir -p $HOME/escape-link/deep` would create `/tmp/ox-foreign/deep` before validation. After the fix: script emits `error: ancestor directory escapes $HOME via symlink: /private/tmp/ox-foreign` and `/tmp/ox-foreign/` stays empty.
- [x] **Fix 2** — created a fake git repo at `$HOME/fake-repo` with `origin=https://github.com/someone-else/not-ox.git`, invoked `install-ox-git.sh "$HOME/fake-repo" true`. Script emits `error: … is not a sageox/ox checkout (origin: https://github.com/someone-else/not-ox.git)` and exits before touching Make.
- [x] **Fix 3** — set `HOME=/tmp/symlink-to-real-home` where the symlink resolves to `/tmp/ox-hardening-test`, wrote state with `clone_path=/private/tmp/ox-hardening-test/src/sageox-ox` (the physical form), ran `update-ox.sh`. Script gets past the text prefix check and into the physical validation, which is what we want. (Before the fix, it would have emitted `warning: clone_path not under $HOME` and skipped every time.)
- [x] **Fix 4** — set state `clone_path` to a git repo whose `origin` is `https://github.com/someone-else/not-ox.git`, ran `update-ox.sh`. Script emits `warning: clone_path is not a sageox/ox checkout; skipping auto-update` and falls through to the final readiness gate — `make install` never runs.
- [x] `clawhub-skill-lint` — PASS on both skills, 0 critical, 0 warnings.
- [x] Scripts byte-identical between `sageox-distill` and `sageox-summary`.
- [ ] End-to-end first-run install against a throwaway `~/.openclaw/memory/` — deferred to reviewer.

## Notes

- The fix for #3 is deliberately permissive: accept both `$HOME/*` and `$REAL_HOME/*` rather than canonicalizing one side. The physical-resolution check below is where the real decision happens; the text check is only an early filter for obvious hand-edits.
- For #1, the re-check after `mkdir -p` (which existed in the previous version) is now redundant since the ancestor validation already guarantees the outcome, so the final `REAL_PARENT` is computed but not re-validated. That simplification is intentional.

Closes the round-2 findings on #511.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stronger filesystem-safety checks to avoid installing/updating into aliased, symlinked, or otherwise unsafe paths.
  * Installer/updater now refuse unknown or altered repositories and will skip or reject non-matching origins.
  * Updater refuses to proceed with uncommitted changes and now reliably aligns checkouts to the remote default before building.
  * Update mechanism hardened for more consistent build/install outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->