### PR TITLE
feat(daemon): add periodic recording reminder whispers

### DIFF
--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -193,6 +193,23 @@ Rate-limited to 60 invocations/hour, 4 concurrent.`,
 		Default:     "auto",
 		Levels:      []ConfigLevel{ConfigLevelUser},
 	},
+	{
+		Key:         "recording_reminder",
+		Description: "Periodic recording status reminders",
+		LongDescription: `Controls whether AI coworkers receive periodic reminders
+that their session is being recorded.
+
+  on  - Whisper recording status (turn count, duration) periodically (default)
+  off - No periodic reminders (startup banner still appears)
+
+Useful for confirming sessions are actively being captured, especially
+during long-running sessions. Reminders appear roughly once per hour
+as whispers in the agent's context.`,
+		Category:    "Sessions",
+		ValidValues: []string{"on", "off"},
+		Default:     "on",
+		Levels:      []ConfigLevel{ConfigLevelUser, ConfigLevelRepo},
+	},
 	// NOTE: attribution.plan and attribution.session are intentionally not exposed
 	// in ox config — they are always-on transparency requirements, not user preferences.
 	{
@@ -328,6 +345,14 @@ func ResolveConfigValue(key string, projectRoot string) (*ConfigValue, error) {
 		}
 		if repoCfg != nil && repoCfg.MurmurReceive != "" {
 			cv.RepoVal = config.NormalizeMurmurReceive(repoCfg.MurmurReceive)
+		}
+
+	case "recording_reminder":
+		if userCfg != nil && userCfg.RecordingReminder != "" {
+			cv.UserVal = config.NormalizeRecordingReminder(userCfg.RecordingReminder)
+		}
+		if repoCfg != nil && repoCfg.RecordingReminder != "" {
+			cv.RepoVal = config.NormalizeRecordingReminder(repoCfg.RecordingReminder)
 		}
 
 	case "telemetry":
@@ -569,6 +594,9 @@ func setUserConfig(key, value string) error {
 	case "murmur_receive":
 		cfg.SetMurmurReceive(value)
 
+	case "recording_reminder":
+		cfg.RecordingReminder = value
+
 	case "agent_worker":
 		if value == "auto" {
 			cfg.SetAgentWorkerAgent("") // empty = auto-detect
@@ -629,6 +657,9 @@ func setRepoConfig(key, value, projectRoot string) error {
 
 	case "murmur_receive":
 		cfg.MurmurReceive = value
+
+	case "recording_reminder":
+		cfg.RecordingReminder = value
 
 	case "attribution.commit":
 		if cfg.Attribution == nil {
@@ -741,6 +772,9 @@ func unsetUserConfig(key string) error {
 	case "murmur_receive":
 		cfg.SetMurmurReceive("")
 
+	case "recording_reminder":
+		cfg.RecordingReminder = ""
+
 	case "agent_worker":
 		cfg.AgentWorker = nil
 
@@ -794,6 +828,9 @@ func unsetRepoConfig(key, projectRoot string) error {
 
 	case "murmur_receive":
 		cfg.MurmurReceive = ""
+
+	case "recording_reminder":
+		cfg.RecordingReminder = ""
 
 	case "attribution.commit":
 		if cfg.Attribution != nil {

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -125,7 +125,8 @@ type ProjectConfig struct {
 	// this project's whisper stream.
 	// Values: "on" (receive murmurs as whispers), "off" (suppress murmur whispers)
 	// Empty string defaults to "on".
-	MurmurReceive string `json:"murmur_receive,omitempty"`
+	MurmurReceive     string `json:"murmur_receive,omitempty"`
+	RecordingReminder string `json:"recording_reminder,omitempty"`
 
 	// GitHubSync controls GitHub data extraction to the ledger (master toggle).
 	// Values: "enabled" (default), "disabled"

--- a/internal/config/recording_reminder.go
+++ b/internal/config/recording_reminder.go
@@ -1,0 +1,40 @@
+package config
+
+// RecordingReminder mode constants.
+const (
+	RecordingReminderOff = "off"
+	RecordingReminderOn  = "on"
+)
+
+// NormalizeRecordingReminder returns the canonical recording reminder mode.
+// Empty string and unrecognized values default to "on".
+func NormalizeRecordingReminder(mode string) string {
+	switch mode {
+	case RecordingReminderOff:
+		return RecordingReminderOff
+	default:
+		return RecordingReminderOn
+	}
+}
+
+// ResolveRecordingReminder determines the effective recording reminder mode.
+// Priority: User config > Project config > Default ("on").
+// No caching — called infrequently by daemon whisper source.
+func ResolveRecordingReminder(projectRoot string) string {
+	userCfg, _ := LoadUserConfig()
+	if userCfg != nil && userCfg.RecordingReminder != "" {
+		return NormalizeRecordingReminder(userCfg.RecordingReminder)
+	}
+	if projectRoot != "" {
+		cfg, _ := LoadProjectConfig(projectRoot)
+		if cfg != nil && cfg.RecordingReminder != "" {
+			return NormalizeRecordingReminder(cfg.RecordingReminder)
+		}
+	}
+	return RecordingReminderOn
+}
+
+// RecordingReminderEnabled returns true if recording reminders are active.
+func RecordingReminderEnabled(projectRoot string) bool {
+	return ResolveRecordingReminder(projectRoot) == RecordingReminderOn
+}

--- a/internal/config/recording_reminder_test.go
+++ b/internal/config/recording_reminder_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeRecordingReminder(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"on", RecordingReminderOn},
+		{"off", RecordingReminderOff},
+		{"", RecordingReminderOn},
+		{"garbage", RecordingReminderOn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, NormalizeRecordingReminder(tt.input))
+		})
+	}
+}
+
+func TestResolveRecordingReminder_Default(t *testing.T) {
+	// no config files → default "on"
+	tmpDir := t.TempDir()
+	result := ResolveRecordingReminder(tmpDir)
+	assert.Equal(t, RecordingReminderOn, result)
+}
+
+func TestResolveRecordingReminder_ProjectConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	sageoxDir := filepath.Join(tmpDir, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0o755))
+
+	// write project config with recording_reminder=off
+	configData := `{"recording_reminder": "off"}`
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(configData), 0o644))
+
+	result := ResolveRecordingReminder(tmpDir)
+	assert.Equal(t, RecordingReminderOff, result)
+}
+
+func TestRecordingReminderEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	// default is on
+	assert.True(t, RecordingReminderEnabled(tmpDir))
+}

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -329,6 +329,7 @@ type UserConfig struct {
 	Murmuring         string             `yaml:"murmur_send,omitempty"`     // "auto", "manual"
 	LegacyMurmuring   string             `yaml:"murmuring,omitempty"`       // deprecated: read old key on upgrade
 	MurmurReceive     string             `yaml:"murmur_receive,omitempty"`  // "on", "off"
+	RecordingReminder string             `yaml:"recording_reminder,omitempty"` // "on", "off"
 
 }
 

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -80,6 +80,17 @@ type Config struct {
 	// Zero disables nudging (used when murmuring config is "manual").
 	MurmurNudgeInterval time.Duration
 
+	// RecordingReminderInterval is how often to remind agents that their
+	// session is being recorded. Default 1 hour. Not user-visible in
+	// ox config but settable via daemon config for testing (e.g., 1 minute).
+	// Zero disables reminders.
+	RecordingReminderInterval time.Duration
+
+	// RecordingReminderTick is how often the reminder source checks for
+	// agents that need reminding. Default 1 minute. Set lower for testing.
+	// Zero uses the source default (1 minute).
+	RecordingReminderTick time.Duration
+
 	// SocketCheckInterval is how often the daemon checks the registry to see if
 	// its PID is still registered. If a different PID is registered, the daemon
 	// assumes it has been superseded and exits gracefully.
@@ -114,6 +125,7 @@ func DefaultConfig() *Config {
 		LedgerCheckInterval:     15 * time.Minute, // check if ledger index needs rebuild every 15 minutes
 		GitHubSyncInterval:      15 * time.Minute, // sync PRs/issues every 15 minutes
 		MurmurNudgeInterval:     15 * time.Minute, // nudge agents to self-report every 15 minutes
+		RecordingReminderInterval: 1 * time.Hour,  // remind agents recording is active
 		InactivityTimeout:       1 * time.Hour,    // exit after 1 hour of inactivity
 		SocketCheckInterval:     30 * time.Second, // detect socket takeover by new daemon
 		PendingWorkGracePeriod:  10 * time.Minute, // max time to stay alive for pending finalization

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1151,6 +1151,16 @@ func (d *Daemon) startWorkers() {
 			d.murmurNudgeSource = NewMurmurNudgeSource(d.whisperRegistry.LedgerStore(), d.heartbeat, d.config.MurmurNudgeInterval, d.config.ProjectRoot)
 			ws.RegisterSource(d.murmurNudgeSource)
 		}
+		if d.config.RecordingReminderInterval > 0 {
+			src := NewRecordingReminderSource(
+				d.whisperRegistry.LedgerStore(), d.heartbeat,
+				d.config.RecordingReminderInterval, d.config.ProjectRoot,
+			)
+			if d.config.RecordingReminderTick > 0 {
+				src.SetTick(d.config.RecordingReminderTick)
+			}
+			ws.RegisterSource(src)
+		}
 		if d.config.ProjectRoot != "" && d.config.LedgerPath != "" {
 			accumulator := NewChangeAccumulator(3 * time.Second)
 			tracker := NewGitTrackedMatcher(d.config.ProjectRoot, d.logger)

--- a/internal/daemon/whisper_recording_reminder.go
+++ b/internal/daemon/whisper_recording_reminder.go
@@ -1,0 +1,170 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/session"
+	whisperstore "github.com/sageox/ox/internal/whisper/store"
+)
+
+// RecordingReminderSource periodically checks active recording agents and
+// produces whisper entries reminding them that their session is being recorded.
+// Includes turn count and duration for visibility into recording health.
+//
+// On the first tick after recording starts (no prior reminder in store),
+// it produces an immediate reminder — this serves as the startup notification
+// that the agent sees on its first UserPromptSubmit.
+type RecordingReminderSource struct {
+	store       *whisperstore.Store
+	heartbeat   *HeartbeatHandler
+	interval    time.Duration // how often to produce reminders per agent (default 1h)
+	tick        time.Duration // how often the scheduler calls Produce (default 1m)
+	projectRoot string
+}
+
+// NewRecordingReminderSource creates a source that reminds agents about active recording.
+func NewRecordingReminderSource(store *whisperstore.Store, heartbeat *HeartbeatHandler, interval time.Duration, projectRoot string) *RecordingReminderSource {
+	return &RecordingReminderSource{
+		store:       store,
+		heartbeat:   heartbeat,
+		interval:    interval,
+		tick:        1 * time.Minute,
+		projectRoot: projectRoot,
+	}
+}
+
+// SetTick overrides the scheduler tick interval. Useful for testing
+// where the default 1-minute tick is too slow.
+func (s *RecordingReminderSource) SetTick(d time.Duration) {
+	s.tick = d
+}
+
+func (s *RecordingReminderSource) Name() string { return "recording-reminder" }
+
+// Interval returns the tick frequency. Defaults to 1 minute — frequent enough
+// to catch new recordings quickly, while only producing entries when the
+// configured reminder interval has elapsed per agent. Override with SetTick
+// for testing.
+func (s *RecordingReminderSource) Interval() time.Duration { return s.tick }
+
+func (s *RecordingReminderSource) Produce(_ context.Context) []whisperstore.WhisperEntry {
+	if s.heartbeat == nil || s.store == nil {
+		return nil
+	}
+	if !config.RecordingReminderEnabled(s.projectRoot) {
+		return nil
+	}
+
+	summary := s.heartbeat.GetActivitySummary()
+	if len(summary.Agents) == 0 {
+		return nil
+	}
+
+	now := time.Now()
+	var entries []whisperstore.WhisperEntry
+	for _, agent := range summary.Agents {
+		agentID := agent.Key
+		if agentID == "" {
+			continue
+		}
+
+		state, err := session.LoadRecordingStateForAgent(s.projectRoot, agentID)
+		if err != nil || state == nil {
+			continue // not recording
+		}
+		if state.StoppedAt != nil {
+			continue // recording already stopped
+		}
+
+		if !s.shouldRemind(agentID, agent, now) {
+			continue
+		}
+
+		content := formatReminderContent(state)
+
+		id, err := uuid.NewV7()
+		if err != nil {
+			id = uuid.New()
+		}
+
+		entries = append(entries, whisperstore.WhisperEntry{
+			ID:         id.String(),
+			Scope:      "ledger",
+			Type:       whisperstore.WhisperTimeBased,
+			Source:     "recording-reminder",
+			Topic:      "recording-status",
+			Content:    content,
+			Importance: whisperstore.ImportanceNormal,
+			CreatedAt:  now,
+			AgentID:    agentID,
+		})
+	}
+
+	return entries
+}
+
+// claudeCodeMinHeartbeats is the heartbeat count threshold before producing
+// the first recording reminder for Claude Code. The SessionStart hook does
+// not deliver whispers to the model, so we wait until at least one heartbeat
+// after SessionStart (count >= 2) to ensure the reminder lands on a
+// UserPromptSubmit, which does inject stdout into model context.
+//
+// TODO: remove this workaround when Claude Code fixes SessionStart stdout
+// injection. Gate on agent version when a fix ships.
+const claudeCodeMinHeartbeats = 2
+
+// shouldRemind checks the whisper store to decide if an agent needs a reminder.
+// Returns true on first call (no prior reminder) or after the configured interval.
+func (s *RecordingReminderSource) shouldRemind(agentID string, agent ActivityEntry, now time.Time) bool {
+	// Claude Code's SessionStart hook doesn't deliver whispers — wait
+	// until the first prompt has fired. Other agents whisper immediately.
+	agentType := s.heartbeat.GetAgentType(agentID)
+	if agentType == "claude-code" && agent.Count < claudeCodeMinHeartbeats {
+		return false
+	}
+
+	lastReminder, err := s.store.LatestWhisperTime("recording-reminder", "recording-status", agentID)
+	if err != nil {
+		return false // store error — skip this tick
+	}
+
+	if lastReminder.IsZero() {
+		return true // never reminded — produce immediately (startup reminder)
+	}
+
+	return now.Sub(lastReminder) >= s.interval
+}
+
+// formatReminderContent builds the whisper message from recording state.
+// Instructs the agent to surface the recording status to the user in one line.
+func formatReminderContent(state *session.RecordingState) string {
+	duration := state.Duration()
+	turns := state.EntryCount
+
+	return fmt.Sprintf(
+		"Tell the user in one short line: \"SageOx recording active: %d turns, %s. Session will be shared with your team.\"",
+		turns, formatDuration(duration))
+}
+
+// formatDuration renders a duration as human-readable "Xh Ym" or "Xm".
+func formatDuration(d time.Duration) string {
+	d = d.Round(time.Minute)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+
+	if h > 0 && m > 0 {
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+	if h > 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm", m)
+	}
+	return "<1m"
+}

--- a/internal/daemon/whisper_recording_reminder_test.go
+++ b/internal/daemon/whisper_recording_reminder_test.go
@@ -2,10 +2,15 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sageox/ox/internal/session"
 )
@@ -61,4 +66,230 @@ func TestRecordingReminderSource_Interval(t *testing.T) {
 func TestRecordingReminderSource_Produce_NilDeps(t *testing.T) {
 	s := &RecordingReminderSource{}
 	assert.Nil(t, s.Produce(context.Background()))
+}
+
+// --- Integration tests: full Produce pipeline with real store + heartbeat ---
+
+// initRecordingReminderProject creates a project root with .sageox/config.json
+// and XDG cache pointing to a temp dir so LoadRecordingStateForAgent can find
+// recording state written under the sessions/ cache path.
+func initRecordingReminderProject(t *testing.T) (projectRoot string, sessionsBase string) {
+	t.Helper()
+	cacheDir := t.TempDir()
+	projectRoot = t.TempDir()
+	repoID := "test-recording-reminder"
+
+	// create .sageox/config.json with repo_id
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0o755))
+	cfgData, _ := json.Marshal(map[string]string{
+		"config_version":     "2",
+		"repo_id":            repoID,
+		"recording_reminder": "on",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), cfgData, 0o644))
+
+	// point XDG cache to temp dir
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("HOME", cacheDir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	// compute sessions base (same path sessionsSearchPaths resolves)
+	sessionsBase = filepath.Join(session.GetContextPath(repoID), "sessions")
+	return projectRoot, sessionsBase
+}
+
+// writeTestRecordingState creates a .recording.json for a fake agent session.
+func writeTestRecordingState(t *testing.T, projectRoot, sessionsBase, agentID string, entryCount int, startedAt time.Time) {
+	t.Helper()
+	sessionName := "2026-01-01T00-00-test-" + agentID
+	sessionPath := filepath.Join(sessionsBase, sessionName)
+	require.NoError(t, os.MkdirAll(sessionPath, 0o755))
+
+	state := &session.RecordingState{
+		AgentID:     agentID,
+		StartedAt:   startedAt,
+		EntryCount:  entryCount,
+		SessionPath: sessionPath,
+	}
+	require.NoError(t, session.SaveRecordingState(projectRoot, state))
+}
+
+func TestRecordingReminderSource_Produce_FirstReminder(t *testing.T) {
+	// Verifies: an agent with active recording and enough heartbeats
+	// receives a recording reminder on the first Produce tick.
+	projectRoot, sessionsBase := initRecordingReminderProject(t)
+	store := openTestWhisperStore(t)
+	hb := NewHeartbeatHandler(slog.Default())
+
+	agentID := "OxRem1"
+
+	// write recording state: 12 turns, started 5 minutes ago
+	writeTestRecordingState(t, projectRoot, sessionsBase, agentID, 12, time.Now().Add(-5*time.Minute))
+
+	// send heartbeats to exceed Claude Code threshold (>= 2)
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+
+	src := NewRecordingReminderSource(store, hb, 1*time.Hour, projectRoot)
+	entries := src.Produce(context.Background())
+
+	require.Len(t, entries, 1, "first tick should produce exactly one reminder")
+	assert.Equal(t, "recording-reminder", entries[0].Source)
+	assert.Equal(t, "recording-status", entries[0].Topic)
+	assert.Equal(t, agentID, entries[0].AgentID)
+	assert.Contains(t, entries[0].Content, "12 turns")
+	assert.Contains(t, entries[0].Content, "SageOx recording active")
+}
+
+func TestRecordingReminderSource_Produce_SuppressedUntilHeartbeatThreshold(t *testing.T) {
+	// Verifies: Claude Code agents don't get reminders until heartbeat count >= 2.
+	projectRoot, sessionsBase := initRecordingReminderProject(t)
+	store := openTestWhisperStore(t)
+	hb := NewHeartbeatHandler(slog.Default())
+
+	agentID := "OxRem2"
+	writeTestRecordingState(t, projectRoot, sessionsBase, agentID, 5, time.Now().Add(-2*time.Minute))
+
+	// only 1 heartbeat — below threshold
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+
+	src := NewRecordingReminderSource(store, hb, 1*time.Hour, projectRoot)
+	entries := src.Produce(context.Background())
+
+	assert.Empty(t, entries, "should not produce reminder with only 1 heartbeat for claude-code")
+
+	// second heartbeat crosses threshold
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+	entries = src.Produce(context.Background())
+
+	require.Len(t, entries, 1, "should produce reminder after 2 heartbeats")
+}
+
+func TestRecordingReminderSource_Produce_NonClaudeAgent_ImmediateReminder(t *testing.T) {
+	// Verifies: non-Claude agents get reminders immediately (no heartbeat gate).
+	projectRoot, sessionsBase := initRecordingReminderProject(t)
+	store := openTestWhisperStore(t)
+	hb := NewHeartbeatHandler(slog.Default())
+
+	agentID := "OxRem3"
+	writeTestRecordingState(t, projectRoot, sessionsBase, agentID, 3, time.Now().Add(-1*time.Minute))
+
+	// single heartbeat — should be enough for non-Claude agents
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "gemini", Timestamp: time.Now()})
+
+	src := NewRecordingReminderSource(store, hb, 1*time.Hour, projectRoot)
+	entries := src.Produce(context.Background())
+
+	require.Len(t, entries, 1, "non-claude agent should get immediate reminder")
+	assert.Contains(t, entries[0].Content, "3 turns")
+}
+
+func TestRecordingReminderSource_Produce_IntervalGating(t *testing.T) {
+	// Verifies: after the first reminder, subsequent reminders are gated by interval.
+	projectRoot, sessionsBase := initRecordingReminderProject(t)
+	store := openTestWhisperStore(t)
+	hb := NewHeartbeatHandler(slog.Default())
+
+	agentID := "OxRem4"
+	writeTestRecordingState(t, projectRoot, sessionsBase, agentID, 20, time.Now().Add(-30*time.Minute))
+
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+
+	src := NewRecordingReminderSource(store, hb, 1*time.Hour, projectRoot)
+
+	// first produce — should create reminder
+	entries := src.Produce(context.Background())
+	require.Len(t, entries, 1)
+
+	// persist the whisper to the store (simulates what WhisperScheduler does)
+	require.NoError(t, store.Add(entries...))
+
+	// second produce immediately — should be suppressed (interval not elapsed)
+	entries = src.Produce(context.Background())
+	assert.Empty(t, entries, "should not produce another reminder before interval elapses")
+}
+
+func TestRecordingReminderSource_Produce_StoppedRecording(t *testing.T) {
+	// Verifies: agents with stopped recordings don't get reminders.
+	projectRoot, sessionsBase := initRecordingReminderProject(t)
+	store := openTestWhisperStore(t)
+	hb := NewHeartbeatHandler(slog.Default())
+
+	agentID := "OxRem5"
+	sessionName := "2026-01-01T00-00-test-" + agentID
+	sessionPath := filepath.Join(sessionsBase, sessionName)
+	require.NoError(t, os.MkdirAll(sessionPath, 0o755))
+
+	stoppedAt := time.Now()
+	state := &session.RecordingState{
+		AgentID:     agentID,
+		StartedAt:   time.Now().Add(-1 * time.Hour),
+		EntryCount:  50,
+		SessionPath: sessionPath,
+		StoppedAt:   &stoppedAt,
+	}
+	require.NoError(t, session.SaveRecordingState(projectRoot, state))
+
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+
+	src := NewRecordingReminderSource(store, hb, 1*time.Hour, projectRoot)
+	entries := src.Produce(context.Background())
+
+	assert.Empty(t, entries, "stopped recording should not produce reminders")
+}
+
+func TestRecordingReminderSource_Produce_NoActiveAgents(t *testing.T) {
+	// Verifies: no whispers produced when no agents are active.
+	projectRoot, _ := initRecordingReminderProject(t)
+	store := openTestWhisperStore(t)
+	hb := NewHeartbeatHandler(slog.Default())
+
+	src := NewRecordingReminderSource(store, hb, 1*time.Hour, projectRoot)
+	entries := src.Produce(context.Background())
+
+	assert.Empty(t, entries)
+}
+
+func TestRecordingReminderSource_Produce_AgentWithoutRecording(t *testing.T) {
+	// Verifies: agents that are active but not recording get no reminders.
+	projectRoot, _ := initRecordingReminderProject(t)
+	store := openTestWhisperStore(t)
+	hb := NewHeartbeatHandler(slog.Default())
+
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: "OxNoRec", AgentType: "claude-code", Timestamp: time.Now()})
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: "OxNoRec", AgentType: "claude-code", Timestamp: time.Now()})
+
+	src := NewRecordingReminderSource(store, hb, 1*time.Hour, projectRoot)
+	entries := src.Produce(context.Background())
+
+	assert.Empty(t, entries, "agent without recording state should not get reminders")
+}
+
+func TestRecordingReminderSource_Produce_DisabledConfig(t *testing.T) {
+	// Verifies: reminders are suppressed when recording_reminder=off.
+	projectRoot, sessionsBase := initRecordingReminderProject(t)
+
+	// override config to disable reminders
+	cfgData, _ := json.Marshal(map[string]string{
+		"config_version":     "2",
+		"repo_id":            "test-recording-reminder",
+		"recording_reminder": "off",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(projectRoot, ".sageox", "config.json"), cfgData, 0o644))
+
+	store := openTestWhisperStore(t)
+	hb := NewHeartbeatHandler(slog.Default())
+
+	agentID := "OxOff1"
+	writeTestRecordingState(t, projectRoot, sessionsBase, agentID, 10, time.Now().Add(-5*time.Minute))
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+	sendHeartbeat(t, hb, HeartbeatPayload{AgentID: agentID, AgentType: "claude-code", Timestamp: time.Now()})
+
+	src := NewRecordingReminderSource(store, hb, 1*time.Hour, projectRoot)
+	entries := src.Produce(context.Background())
+
+	assert.Empty(t, entries, "should not produce reminders when config is off")
 }

--- a/internal/daemon/whisper_recording_reminder_test.go
+++ b/internal/daemon/whisper_recording_reminder_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sageox/ox/internal/session"
+)
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{"zero", 0, "<1m"},
+		{"30 seconds rounds up", 30 * time.Second, "1m"},
+		{"sub-30 seconds", 20 * time.Second, "<1m"},
+		{"one minute", 1 * time.Minute, "1m"},
+		{"minutes", 23 * time.Minute, "23m"},
+		{"one hour", 60 * time.Minute, "1h"},
+		{"hours and minutes", 1*time.Hour + 23*time.Minute, "1h 23m"},
+		{"multiple hours", 3*time.Hour + 45*time.Minute, "3h 45m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, formatDuration(tt.duration))
+		})
+	}
+}
+
+func TestFormatReminderContent(t *testing.T) {
+	state := &session.RecordingState{
+		StartedAt:  time.Now().Add(-1*time.Hour - 23*time.Minute),
+		EntryCount: 45,
+	}
+	content := formatReminderContent(state)
+	assert.Contains(t, content, "Tell the user")
+	assert.Contains(t, content, "SageOx recording active")
+	assert.Contains(t, content, "45 turns")
+	assert.Contains(t, content, "1h 23m")
+	assert.Contains(t, content, "shared with your team")
+}
+
+func TestRecordingReminderSource_Name(t *testing.T) {
+	s := &RecordingReminderSource{}
+	assert.Equal(t, "recording-reminder", s.Name())
+}
+
+func TestRecordingReminderSource_Interval(t *testing.T) {
+	s := NewRecordingReminderSource(nil, nil, time.Hour, "")
+	assert.Equal(t, 1*time.Minute, s.Interval(), "default tick is 1 minute")
+
+	s.SetTick(5 * time.Second)
+	assert.Equal(t, 5*time.Second, s.Interval(), "tick is configurable")
+}
+
+func TestRecordingReminderSource_Produce_NilDeps(t *testing.T) {
+	s := &RecordingReminderSource{}
+	assert.Nil(t, s.Produce(context.Background()))
+}

--- a/scripts/smoketest/smoke-test-recording-reminder.sh
+++ b/scripts/smoketest/smoke-test-recording-reminder.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# smoke-test-recording-reminder.sh - Verify recording reminder whispers are produced and delivered
+#
+# Tests the full recording reminder pipeline:
+#   1. Prime an agent (registers with daemon, starts recording)
+#   2. Send heartbeats to simulate prompt activity
+#   3. Wait for the daemon's RecordingReminderSource to tick (~1 min)
+#   4. Pull whispers via ox agent <id> whisper
+#   5. Assert the recording reminder appears
+#
+# NOTE: This test takes up to 90s because the whisper source ticks every 60s.
+# Run independently or as an optional slow test — not included in the default
+# smoke test suite for CI.
+#
+# Usage: SAGEOX_ENDPOINT=... SMOKE_TEST_WORKDIR=... OX=./bin/ox bash smoke-test-recording-reminder.sh
+#
+# Required environment variables (set by smoke-test.sh):
+#   SAGEOX_ENDPOINT - API endpoint
+#   SMOKE_TEST_WORKDIR - Temp directory for test
+#   OX - Path to ox binary
+
+set -euo pipefail
+
+: "${SAGEOX_ENDPOINT:?SAGEOX_ENDPOINT is required}"
+: "${SMOKE_TEST_WORKDIR:?SMOKE_TEST_WORKDIR is required}"
+: "${OX:?OX is required}"
+
+TEST_REPO="$SMOKE_TEST_WORKDIR/test-init-repo"
+
+if [[ ! -d "$TEST_REPO/.sageox" ]]; then
+    echo "error: test-init-repo not initialized (run init test first)"
+    exit 1
+fi
+
+cd "$TEST_REPO"
+
+# ensure recording is enabled
+$OX config set session_recording auto 2>/dev/null || true
+$OX config set recording_reminder on 2>/dev/null || true
+
+echo "Step 1: Prime agent to start recording..."
+
+set +e
+prime_output=$(AGENT_ENV=claude-code $OX agent prime 2>&1)
+prime_exit=$?
+set -e
+
+if [[ $prime_exit -ne 0 ]]; then
+    echo "error: ox agent prime failed (exit $prime_exit)"
+    echo "$prime_output"
+    exit 1
+fi
+
+agent_id=$(echo "$prime_output" | jq -r '.agent_id // empty')
+if [[ -z "$agent_id" ]]; then
+    echo "error: no agent_id in prime output"
+    echo "$prime_output"
+    exit 1
+fi
+
+echo "  agent_id=$agent_id"
+
+echo "Step 2: Send heartbeats to simulate prompt activity..."
+
+# send 3 heartbeats to exceed the Claude Code threshold (>= 2)
+for i in 1 2 3; do
+    AGENT_ENV=claude-code $OX agent "$agent_id" heartbeat 2>/dev/null || true
+    sleep 0.5
+done
+
+echo "  sent 3 heartbeats"
+
+echo "Step 3: Wait for recording reminder source to produce whisper..."
+echo "  (source ticks every 60s, polling whispers every 5s for up to 90s)"
+
+reminder_found=false
+for attempt in $(seq 1 18); do
+    set +e
+    whisper_output=$(AGENT_ENV=claude-code $OX agent "$agent_id" whisper 2>&1)
+    set -e
+
+    if echo "$whisper_output" | grep -qi "SageOx recording active"; then
+        reminder_found=true
+        echo "  reminder found on attempt $attempt"
+        break
+    fi
+
+    # also check whisper history (doesn't advance cursor, catches already-delivered)
+    set +e
+    history_output=$(AGENT_ENV=claude-code $OX agent "$agent_id" whisper history 2>&1)
+    set -e
+
+    if echo "$history_output" | grep -qi "SageOx recording active"; then
+        reminder_found=true
+        echo "  reminder found in history on attempt $attempt"
+        break
+    fi
+
+    sleep 5
+done
+
+if [[ "$reminder_found" != "true" ]]; then
+    echo "error: recording reminder whisper not delivered after 90s"
+    echo "last whisper output: $whisper_output"
+    echo "last history output: $history_output"
+    exit 1
+fi
+
+echo "Step 4: Validate whisper content..."
+
+# the content should mention turns and duration
+combined_output="${whisper_output}${history_output}"
+if ! echo "$combined_output" | grep -qE "turns.*shared|SageOx recording active"; then
+    echo "error: whisper content missing expected fields"
+    echo "$combined_output"
+    exit 1
+fi
+
+echo "  content validated"
+echo "recording reminder smoke test passed"
+exit 0

--- a/scripts/smoketest/smoke-test.sh
+++ b/scripts/smoketest/smoke-test.sh
@@ -138,6 +138,11 @@ main() {
     # skip checkout test for now - requires team setup
     # run_test "ox team context add" "smoke-test-checkout.sh" || true
 
+    # optional slow tests (take 60-90s due to daemon tick intervals)
+    if [[ "${SMOKE_TEST_SLOW:-}" == "true" ]]; then
+        run_test "Recording reminder" "smoke-test-recording-reminder.sh" || true
+    fi
+
     # summary
     echo ""
     echo "========================================"


### PR DESCRIPTION
## Summary

Adds a new whisper source that periodically reminds AI coworkers their session is being recorded, with turn count and duration. This gives users and agents ongoing confidence that session capture is working, replacing the fragile one-time startup banner.

- **New `recording_reminder` config setting** (on/off, default on) — user-visible via `ox config set recording_reminder off`
- **`RecordingReminderSource`** daemon whisper source following the `MurmurNudgeSource` pattern: 1-minute tick (configurable for testing), hourly reminder production per agent
- **Claude Code workaround**: defers first reminder until heartbeat count >= 2 since `SessionStart` hook doesn't deliver whispers. Other agents get immediate reminders. TODO to remove when Claude fixes this.
- **Configurable tick interval** (`RecordingReminderTick`) for fast testing — the default 1-minute tick can be dialed down to seconds
- **Smoke test** (`smoke-test-recording-reminder.sh`) validates the full pipeline: prime → heartbeats → whisper delivery. Gated behind `SMOKE_TEST_SLOW=true`.

```mermaid
sequenceDiagram
    participant Agent as AI Coworker
    participant Hook as ox agent hook
    participant Daemon as ox daemon
    participant Source as RecordingReminderSource

    Agent->>Hook: SessionStart
    Hook->>Daemon: heartbeat (count=1)
    Agent->>Hook: UserPromptSubmit
    Hook->>Daemon: heartbeat (count=2)
    Note over Source: tick fires, count≥2, no prior reminder
    Source->>Daemon: WhisperEntry (recording-status)
    Agent->>Hook: UserPromptSubmit
    Hook->>Daemon: emitWhispers()
    Daemon-->>Hook: "Tell the user: SageOx recording active..."
    Hook-->>Agent: <system-reminder> injected
    Agent-->>Agent: Surfaces to user
    Note over Source: next reminder after 1 hour
```

## Test plan

- [x] `make build` — compiles
- [x] `make lint` — 0 issues
- [x] `go test ./internal/config/...` — all pass
- [x] `go test ./internal/daemon/...` — all pass
- [ ] Manual: `ox config set recording_reminder on`, start session, verify whisper appears after ~1 min
- [ ] `SMOKE_TEST_SLOW=true` run `smoke-test-recording-reminder.sh`

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recording reminder feature with on/off setting at user and project levels to notify when recording sessions are active
  * Reminders display active recording session details including turn count and formatted duration, with configurable intervals and immediate startup notifications delivered via whisper system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->