### PR TITLE
fix(claws): drop primaryEnv from sageox skills, require claude bin

### DIFF
--- a/claws/openclaw/PUBLISHING.md
+++ b/claws/openclaw/PUBLISHING.md
@@ -114,7 +114,7 @@ finding before the bad bundle ever leaves your machine.
 | Symptom | Cause / fix |
 |---|---|
 | `account too new` | GitHub account < 1 week old; wait it out. |
-| `metadata mismatch` warning | The skill references an env var or binary not declared under `requires.env` / `requires.bins`. Fix the frontmatter. |
+| `metadata mismatch` warning | The skill references a binary not declared under `requires.bins`. Fix the frontmatter. |
 | `bundle too large` | Something got included it shouldn't have. Add it to `.clawhubignore`. |
 | `fingerprint matches existing version` | Nothing changed since the last publish. Either make a real change or manually bump `version:` in `SKILL.md`. |
 

--- a/claws/openclaw/README.md
+++ b/claws/openclaw/README.md
@@ -23,113 +23,32 @@ clawhub install sageox-distill
 clawhub install sageox-summary
 ```
 
-Both skills run in OpenClaw and require a one-time setup of
-`~/.openclaw/.env` — see [Environment setup](#environment-setup) below.
+Both skills require `claude` to be installed and authenticated, and
+possibly a `PATH=` line in `~/.openclaw/.env` if `$HOME/.local/bin` is
+not on your default `PATH`. See below.
 
-## Environment setup
+## Claude credentials
 
-Both skills declare `ANTHROPIC_API_KEY` in their `requires.env` and
-`primaryEnv`. OpenClaw can supply that key to each skill in two ways —
-pick whichever matches your setup.
+Both skills require the `claude` CLI for LLM calls — `sageox-summary`
+shells out to `claude -p` directly, and `sageox-distill` runs `ox
+distill`, which itself shells out to `claude`. The skills do **not**
+accept a per-skill `apiKey` — earlier versions tried this via
+OpenClaw's `apiKey` injection, but the mechanism is unreliable and has
+been removed.
 
-### Anthropic API key
+Authenticate `claude` once on the host, using either:
 
-#### Recommended: per-skill config in `~/.openclaw/openclaw.json`
+- **`claude login`** — Pro/Max OAuth, stored under `~/.claude/`. No
+  API key needed and recommended if you already have a Claude.ai
+  subscription.
+- **`ANTHROPIC_API_KEY=sk-ant-...`** exported in the shell (or
+  `~/.openclaw/.env`) that launches OpenClaw. `claude` and `ox
+  distill` both read it from the process environment.
 
-This lets you use a **different** Anthropic key for SageOx skills than for
-your host agent (different account, different rate limits, different
-billing). OpenClaw injects the key into the skill's process environment for
-the duration of the run, then reverts it.
+If neither is configured, the skill stops at its prerequisite check and
+tells you which one to set up.
 
-```json5
-{
-  skills: {
-    entries: {
-      "sageox-distill": {
-        apiKey: "sk-ant-..."
-      },
-      "sageox-summary": {
-        apiKey: "sk-ant-..."
-      }
-    }
-  }
-}
-```
-
-If you don't want to keep the key in plaintext JSON, use a SecretRef
-instead and store the actual value in your shell or `~/.openclaw/.env`:
-
-```json5
-{
-  skills: {
-    entries: {
-      "sageox-distill": {
-        apiKey: { source: "env", provider: "default", id: "MY_SAGEOX_KEY" }
-      }
-    }
-  }
-}
-```
-
-```sh
-# in ~/.openclaw/.env or your shell rc
-MY_SAGEOX_KEY=sk-ant-...
-```
-
-See [`docs.openclaw.ai/tools/skills-config`](https://docs.openclaw.ai/tools/skills-config)
-for the full schema.
-
-#### ⚠️ Critical precedence rule
-
-OpenClaw injects the per-skill `apiKey` **only if `ANTHROPIC_API_KEY` is
-not already set in its process environment** (see `env-overrides.ts` in
-the openclaw repo). If your login shell exports `ANTHROPIC_API_KEY` (e.g.,
-from `~/.zshrc`), the host value passes through to the skill and **the
-per-skill `apiKey` is silently ignored.**
-
-To use Option A (separate keys), verify before launching OpenClaw:
-
-```sh
-env | grep ANTHROPIC_API_KEY    # should print nothing
-```
-
-If it prints a value, find where it's exported (`~/.zshrc`, `~/.bashrc`,
-`~/.profile`, your terminal app's env settings) and remove it.
-
-#### Fallback: shared shell env
-
-If you're fine with your host agent and SageOx skills sharing one
-Anthropic key, you can skip the per-skill config entirely and just have
-`ANTHROPIC_API_KEY` set in your shell or `~/.openclaw/.env`:
-
-```sh
-ANTHROPIC_API_KEY=sk-ant-...
-```
-
-The skills pick it up either way.
-
-#### Sandboxed runs (Docker)
-
-Per-skill `apiKey` does **not** apply when OpenClaw runs skills inside a
-sandbox — `process.env` is not inherited into the container. For sandboxed
-sessions, configure the key under `agents.defaults.sandbox.docker.env`
-(or per-agent `agents.list[].sandbox.docker.env`) instead:
-
-```json5
-{
-  agents: {
-    defaults: {
-      sandbox: {
-        docker: {
-          env: { ANTHROPIC_API_KEY: "sk-ant-..." }
-        }
-      }
-    }
-  }
-}
-```
-
-### PATH (required if `$HOME/.local/bin` is not already on PATH)
+## PATH (required if `$HOME/.local/bin` is not already on PATH)
 
 The `ox` install flow shipped with the SageOx skills lands binaries in
 `$HOME/.local/bin`. Some distros (notably stock macOS and some minimal

--- a/claws/openclaw/sageox-distill/README.md
+++ b/claws/openclaw/sageox-distill/README.md
@@ -18,14 +18,13 @@ from raw repo activity → daily team digests → unified readout.
 clawhub install sageox-distill
 ```
 
-Then complete the one-time environment setup in
-[`claws/openclaw/README.md` § Environment setup](../README.md#environment-setup) —
-specifically:
+Then complete the one-time host setup documented in
+[`claws/openclaw/README.md`](../README.md):
 
-- Configure `ANTHROPIC_API_KEY` for the skill via either per-skill
-  `apiKey` in `~/.openclaw/openclaw.json` (recommended; lets you use a
-  separate key from your host agent) or via shell env. **Mind the
-  precedence rule** documented in the link above.
+- **Authenticate `claude`** — either run `claude login` (Pro/Max OAuth)
+  or export `ANTHROPIC_API_KEY` in the shell that launches OpenClaw.
+  `ox distill` shells out to `claude` and inherits its credentials.
+  The skill no longer accepts a per-skill `apiKey`.
 - Ensure `$HOME/.local/bin` is on `PATH` for the skill subprocess (the
   `ox` install helper lands binaries there) — add
   `PATH=$HOME/.local/bin:$PATH` to `~/.openclaw/.env` if needed.
@@ -48,19 +47,17 @@ Once installed, ask your OpenClaw agent things like:
 4. **Waits for the SageOx daemon** to finish processing.
 5. **Distills each team** via `ox distill --sync --layer daily`.
 
-`ox distill` reads `ANTHROPIC_API_KEY` from its process environment.
-OpenClaw can supply that key per-skill (recommended, via the `apiKey`
-field in `~/.openclaw/openclaw.json`) or you can use a shell-level
-`ANTHROPIC_API_KEY` shared with your host agent. See
-[Environment setup](../README.md#environment-setup) for details and the
-critical precedence rule.
+`ox distill` shells out to `claude` for LLM calls and inherits whatever
+credentials `claude` has — either an OAuth session from `claude login`
+or `ANTHROPIC_API_KEY` from the shell that launches OpenClaw. See
+[`claws/openclaw/README.md`](../README.md) for the full setup.
 
 ## Requirements
 
 - OS: macOS or Linux
-- Binaries: `ox`, `git`, `gh`
-- Env: `ANTHROPIC_API_KEY` (supplied via per-skill `apiKey` config or
-  shell env — see [Environment setup](../README.md#environment-setup))
+- Binaries: `ox`, `git`, `gh`, `jq`, `claude`
+- `claude` authenticated via `claude login` or `ANTHROPIC_API_KEY` in
+  the launching shell — see [`../README.md`](../README.md)
 - A SageOx account (sign up at <https://sageox.ai>)
 - A GitHub account with `gh` authenticated
 

--- a/claws/openclaw/sageox-distill/SKILL.md
+++ b/claws/openclaw/sageox-distill/SKILL.md
@@ -1,28 +1,41 @@
 ---
 name: sageox-distill
 description: "Sync, index, and distill team activity across SageOx-enabled repositories. Keeps your team's knowledge base up to date by syncing repo contexts, indexing GitHub PRs/issues, and running the SageOx distillation pipeline."
-version: 0.1.3
+version: 0.2.0
 metadata:
-  openclaw:
-    emoji: "🔬"
-    os: ["macos", "linux"]
-    primaryEnv: ANTHROPIC_API_KEY
-    requires:
-      env:
-        - ANTHROPIC_API_KEY
-      bins:
-        - ox
-        - git
-        - gh
-        - jq
-    install:
-      - kind: brew
-        formula: gh
-        bins: [gh]
-      - kind: brew
-        formula: jq
-        bins: [jq]
-    homepage: https://sageox.ai
+  {
+    "openclaw":
+      {
+        "emoji": "🔬",
+        "os": ["macos", "linux"],
+        "requires": { "bins": ["ox", "git", "gh", "jq", "claude"] },
+        "install":
+          [
+            {
+              "id": "node-claude",
+              "kind": "node",
+              "package": "@anthropic-ai/claude-code",
+              "bins": ["claude"],
+              "label": "Install Claude Code CLI (npm)",
+            },
+            {
+              "id": "brew-gh",
+              "kind": "brew",
+              "formula": "gh",
+              "bins": ["gh"],
+              "label": "Install GitHub CLI (brew)",
+            },
+            {
+              "id": "brew-jq",
+              "kind": "brew",
+              "formula": "jq",
+              "bins": ["jq"],
+              "label": "Install jq (brew)",
+            },
+          ],
+        "homepage": "https://sageox.ai",
+      },
+  }
 ---
 
 # SageOx Distill
@@ -39,31 +52,22 @@ Before doing anything else, verify the user's environment. Run every check in
 order. If any required check fails, explain precisely what's missing and stop.
 Do not proceed until the user has fixed it.
 
-### 1. Environment variables
+### 1. Required binaries
 
-This skill declares `ANTHROPIC_API_KEY` in `primaryEnv`, so OpenClaw
-injects it from per-skill config or shell env before the skill runs.
-Verify it landed:
+`git`, `gh`, `jq`, `claude`, and `ox` are declared in the front matter's
+`requires.bins`, so OpenClaw checks them before running the skill.
+`claude` (npm), `gh` (brew), and `jq` (brew) have declarative installs
+in the front matter; `git` and `ox` do not. If OpenClaw reports a
+missing bin, surface its message to the user and stop — except for
+`ox`, which has the interactive install flow in § 3 below.
 
-```bash
-test -n "$ANTHROPIC_API_KEY"
-```
+`claude` is required because `ox distill` shells out to it for LLM
+calls. The skill itself does not invoke `claude` directly — `claude`
+must simply be installed and authenticated. Use either `claude login`
+(Pro/Max subscription) or export `ANTHROPIC_API_KEY` in the shell that
+launches OpenClaw. The skill no longer accepts a per-skill `apiKey`.
 
-Never echo the key value — only confirm its presence. If the check
-fails, point the user at the setup guide and stop:
-<https://github.com/sageox/ox/blob/main/claws/openclaw/README.md#environment-setup>
-(covers per-skill `apiKey`, shell env, the precedence rule, and
-sandboxed Docker runs).
-
-### 2. Required binaries
-
-`git`, `gh`, and `ox` are declared in the front matter's `requires.bins`,
-so OpenClaw checks them before running the skill. `gh` has a declarative
-brew install in the front matter; `git` and `ox` do not. If OpenClaw
-reports a missing bin, surface its message to the user and stop — except
-for `ox`, which has the interactive install flow in § 4 below.
-
-### 3. Path validation rules
+### 2. Path validation rules
 
 Several steps below ask the user for a repo path or read a path from a
 JSON state file. Before interpolating any such value into a shell
@@ -85,7 +89,7 @@ even though this skill writes them: the user (or a process running as
 the user) may have edited the file by hand or by another tool between
 runs. Re-validate every read.
 
-### 4. Installing `ox`
+### 3. Installing `ox`
 
 The `ox` CLI install state is recorded in
 `~/.openclaw/memory/sageox-ox-install.json`. On every run of this
@@ -102,7 +106,7 @@ Contract:
   describing what's wrong, followed by a `fix:` line with the
   remediation. Surface both verbatim to the user.
 - **Exit:** `0` ox is pinned, installed, and reports the expected
-  version (continue to § 5); `2` ox is not usable — one of: state file
+  version (continue to § 4); `2` ox is not usable — one of: state file
   missing, binary missing at `$HOME/.local/bin/ox`, `ox` on PATH
   resolves to a different binary, binary fails to run, or binary
   reports a version other than the one recorded in
@@ -121,7 +125,7 @@ The user can say **"reinstall ox"** at any time to re-enter the flow in
 for general use but is not supported inside OpenClaw skills — only the
 pinned-release curl flow is.
 
-### 5. Authentication and git config
+### 4. Authentication and git config
 
 After all binaries are present, verify credentials:
 
@@ -129,8 +133,12 @@ After all binaries are present, verify credentials:
    run `ox login` and try again.
 2. `gh auth status` — confirm GitHub credentials are available.
 3. `git config user.name` — confirm git identity is set.
+4. Confirm `claude` has credentials. Either `claude login` was run
+   (Pro/Max OAuth, stored under `~/.claude/`) or `ANTHROPIC_API_KEY` is
+   exported in the shell that launched OpenClaw. `ox distill` will fail
+   without one of these. The skill cannot inject the key itself.
 
-Do not proceed until all three pass.
+Do not proceed until all four pass.
 
 ## Repo Manifest
 
@@ -152,7 +160,7 @@ The manifest format is:
 - If the manifest does not exist, ask the user which repos to include. For
   each repo path provided:
   1. **Validate the path against the Path validation rules in
-     Prerequisites § 3.** Reject and re-prompt on failure.
+     Prerequisites § 2.** Reject and re-prompt on failure.
   2. Verify the directory exists.
   3. Verify `.sageox/config.json` exists (confirms `ox init` was run).
   4. Read `team_id` from `.sageox/config.json`. **Treat the value as
@@ -199,8 +207,8 @@ For each team:
 Both commands are non-fatal. If one fails, log the error and continue
 with the next repo or team. Do not abort the pipeline.
 
-Neither of these commands needs `ANTHROPIC_API_KEY` — ox uses its own
-auth token for SageOx API calls. Do not set it in their environment.
+Neither of these commands needs Claude credentials — ox uses its own
+auth token for SageOx API calls.
 
 ### Phase 2: Wait for Daemon Sync
 
@@ -226,10 +234,10 @@ For each repo in the manifest:
 ### Phase 3: Distill
 
 For each unique team (grouped by `team_id`), run distill from the first
-repo in that team's group. `ANTHROPIC_API_KEY` is already set in the
-skill's process environment (either by OpenClaw's per-skill `apiKey`
-injection or inherited from the host shell — see Prerequisites § 1), so
-`ox distill` picks it up naturally:
+repo in that team's group. `ox distill` shells out to `claude` for LLM
+calls, so it inherits whatever credentials `claude` has — either an
+OAuth session from `claude login` or `ANTHROPIC_API_KEY` from the shell
+that launched OpenClaw (see Prerequisites § 1):
 
 ```bash
 ox distill --sync --layer daily --concurrency 3 --model sonnet --quiet

--- a/claws/openclaw/sageox-summary/README.md
+++ b/claws/openclaw/sageox-summary/README.md
@@ -18,14 +18,13 @@ activity → daily team digests → unified readout.
 clawhub install sageox-summary
 ```
 
-Then complete the one-time environment setup in
-[`claws/openclaw/README.md` § Environment setup](../README.md#environment-setup) —
-specifically:
+Then complete the one-time host setup documented in
+[`claws/openclaw/README.md`](../README.md):
 
-- Configure `ANTHROPIC_API_KEY` for the skill via either per-skill
-  `apiKey` in `~/.openclaw/openclaw.json` (recommended; lets you use a
-  separate key from your host agent) or via shell env. **Mind the
-  precedence rule** documented in the link above.
+- **Authenticate `claude`** — either run `claude login` (Pro/Max OAuth)
+  or export `ANTHROPIC_API_KEY` in the shell that launches OpenClaw.
+  `claude -p` inherits its own credentials; the skill no longer accepts
+  a per-skill `apiKey`.
 - Ensure `$HOME/.local/bin` is on `PATH` for the skill subprocess (the
   `ox` install helper lands binaries there) — add
   `PATH=$HOME/.local/bin:$PATH` to `~/.openclaw/.env` if needed.
@@ -57,9 +56,9 @@ Once installed, ask your OpenClaw agent things like:
    entry content directly into the prompt — no filesystem access
    needed.
 5. **Runs `claude -p`** with no `--add-dir` and no tool allowances.
-   `ANTHROPIC_API_KEY` is supplied by OpenClaw's per-skill `apiKey`
-   injection (or by your shell, if configured that way) — see
-   [Environment setup](../README.md#environment-setup).
+   `claude` uses whatever credentials it already has — either
+   `claude login` OAuth or `ANTHROPIC_API_KEY` from the launching
+   shell. See [`../README.md`](../README.md).
 6. **Updates the summary state** on success via
    `scripts/update-state.sh` — atomically merges the newly-summarized
    entry ids into each team's `included_ids`, prunes entries older
@@ -79,16 +78,13 @@ The output is structured into four sections:
 - OS: macOS or Linux
 - Binaries: `ox` with `ox distill history` support (landed in
   [PR #507](https://github.com/sageox/ox/pull/507)), `claude`, `jq`
-- Env: `ANTHROPIC_API_KEY` (supplied via per-skill `apiKey` config or
-  shell env — see [Environment setup](../README.md#environment-setup))
+- `claude` authenticated via `claude login` or `ANTHROPIC_API_KEY` in
+  the launching shell — see [`../README.md`](../README.md)
 - A SageOx account with at least one distilled team (run
   [`sageox-distill`](../sageox-distill/) first)
 
 The skill will walk you through installing any missing pieces on first
 run, including `ox` itself via a pinned-release curl install.
-
-This skill does **not** require `claude login` — it provides an explicit
-API key on every invocation.
 
 ## Links
 

--- a/claws/openclaw/sageox-summary/SKILL.md
+++ b/claws/openclaw/sageox-summary/SKILL.md
@@ -1,27 +1,34 @@
 ---
 name: sageox-summary
 description: "Generate an overall team summary covering the last 24 hours across all SageOx-enabled teams. Reads distilled daily entries via `ox distill history` and produces a structured, Slack-ready overview."
-version: 0.2.3
+version: 0.3.0
 metadata:
-  openclaw:
-    emoji: "📰"
-    os: ["macos", "linux"]
-    primaryEnv: ANTHROPIC_API_KEY
-    requires:
-      env:
-        - ANTHROPIC_API_KEY
-      bins:
-        - ox
-        - claude
-        - jq
-    install:
-      - kind: node
-        package: "@anthropic-ai/claude-code"
-        bins: [claude]
-      - kind: brew
-        formula: jq
-        bins: [jq]
-    homepage: https://sageox.ai
+  {
+    "openclaw":
+      {
+        "emoji": "📰",
+        "os": ["macos", "linux"],
+        "requires": { "bins": ["ox", "claude", "jq"] },
+        "install":
+          [
+            {
+              "id": "node-claude",
+              "kind": "node",
+              "package": "@anthropic-ai/claude-code",
+              "bins": ["claude"],
+              "label": "Install Claude Code CLI (npm)",
+            },
+            {
+              "id": "brew-jq",
+              "kind": "brew",
+              "formula": "jq",
+              "bins": ["jq"],
+              "label": "Install jq (brew)",
+            },
+          ],
+        "homepage": "https://sageox.ai",
+      },
+  }
 ---
 
 # SageOx Summary
@@ -37,7 +44,7 @@ skill — distill writes the source material, this skill synthesizes it.
 **ox version requirement:** this skill uses `ox distill history list` and
 `ox distill history show`, which landed in [PR #507](https://github.com/sageox/ox/pull/507).
 If `ox distill history --help` returns "unknown command" or similar, update
-`ox` (see § 4 below) before continuing.
+`ox` (see § 3 below) before continuing.
 
 ## Prerequisites
 
@@ -45,34 +52,21 @@ Before doing anything else, verify the user's environment. Run every check
 in order. If any required check fails, explain precisely what's missing
 and stop. Do not proceed until the user has fixed it.
 
-### 1. Environment variables
-
-This skill declares `ANTHROPIC_API_KEY` in `primaryEnv`, so OpenClaw
-injects it from per-skill config or shell env before the skill runs.
-Verify it landed:
-
-```bash
-test -n "$ANTHROPIC_API_KEY"
-```
-
-Never echo the key value — only confirm its presence. If the check
-fails, point the user at the setup guide and stop:
-<https://github.com/sageox/ox/blob/main/claws/openclaw/README.md#environment-setup>
-(covers per-skill `apiKey`, shell env, the precedence rule, and
-sandboxed Docker runs).
-
-### 2. Required binaries
+### 1. Required binaries
 
 `ox`, `claude`, and `jq` are declared in the front matter's
 `requires.bins`, so OpenClaw checks them before running the skill.
 `claude` (npm) and `jq` (brew) have declarative installs in the front
 matter; `ox` does not. If OpenClaw reports a missing bin, surface its
 message to the user and stop — except for `ox`, which has the
-interactive install flow in § 4 below. `claude -p` reads
-`ANTHROPIC_API_KEY` from its process environment, so no `claude login`
-is required.
+interactive install flow in § 3 below.
 
-### 3. Path validation rules
+`claude -p` will use whatever credentials `claude` already has — either
+an OAuth session from `claude login` (Pro/Max subscription) or
+`ANTHROPIC_API_KEY` exported in the shell that launched OpenClaw. The
+skill no longer accepts a per-skill `apiKey`.
+
+### 2. Path validation rules
 
 Several steps below read a path from a JSON state file. Before
 interpolating any such value into a shell command, the agent **must**
@@ -94,7 +88,7 @@ even though this skill writes them: the user (or a process running as
 the user) may have edited the file by hand or by another tool between
 runs. Re-validate every read.
 
-### 4. Installing `ox`
+### 3. Installing `ox`
 
 The `ox` CLI install state is recorded in
 `~/.openclaw/memory/sageox-ox-install.json`. On every run of this
@@ -111,7 +105,7 @@ Contract:
   describing what's wrong, followed by a `fix:` line with the
   remediation. Surface both verbatim to the user.
 - **Exit:** `0` ox is pinned, installed, and reports the expected
-  version (continue to § 5); `2` ox is not usable — one of: state file
+  version (continue to § 4); `2` ox is not usable — one of: state file
   missing, binary missing at `$HOME/.local/bin/ox`, `ox` on PATH
   resolves to a different binary, binary fails to run, or binary
   reports a version other than the one recorded in
@@ -130,20 +124,20 @@ The user can say **"reinstall ox"** at any time to re-enter the flow in
 for general use but is not supported inside OpenClaw skills — only the
 pinned-release curl flow is.
 
-### 5. Authentication
+### 4. Authentication
 
 1. `ox status` — confirm ox is authenticated. If not, tell the user to
    run `ox login` and try again.
-2. Smoke-test `claude -p` with the injected key:
+2. Smoke-test `claude -p`:
 
    ```bash
    claude -p "say hi" --model claude-sonnet-4-6
    ```
 
-   If it fails with an auth error, either the per-skill `apiKey` in
-   `~/.openclaw/openclaw.json` is wrong/expired, or the host shell's
-   `ANTHROPIC_API_KEY` (if set) is wrong/expired and is shadowing the
-   per-skill config. Tell the user to fix whichever applies and try again.
+   If it fails with an auth error, `claude` has no usable credentials.
+   Tell the user to either run `claude login` (Pro/Max OAuth) or
+   export `ANTHROPIC_API_KEY` in the shell that launches OpenClaw, then
+   re-run the skill. The skill cannot inject the key itself.
 
 ## Configuration
 
@@ -201,7 +195,7 @@ When the user asks for a summary, run the steps in order. Steps 2 and
 
 1. Read `~/.openclaw/memory/sageox-distill-repos.json` with `jq`.
    **Re-validate every `path` entry** against the Path validation rules
-   in Prerequisites § 3 before using it — the manifest is user-writable
+   in Prerequisites § 2 before using it — the manifest is user-writable
    and may have been hand-edited between runs. (The summary pipeline
    itself does not dereference the paths, but if the manifest looks
    corrupt we stop rather than guess at intent.)
@@ -330,10 +324,10 @@ access — do **not** pass `--add-dir` and do **not** grant read tools.
 - No `--allowedTools` (prompt is self-contained)
 - The substituted prompt passed via stdin
 
-`ANTHROPIC_API_KEY` is already set in the skill's process environment
-(either by OpenClaw's per-skill `apiKey` injection or inherited from the
-host shell — see Prerequisites § 1), so `claude -p` picks it up naturally.
-Wrap the invocation in `timeout 600` (10 minutes) — this matches the
+`claude -p` will use whatever credentials `claude` already has — either
+an OAuth session from `claude login` or `ANTHROPIC_API_KEY` from the
+shell that launched OpenClaw (see Prerequisites § 1). Wrap the
+invocation in `timeout 600` (10 minutes) — this matches the
 timeout used by `pkg/sessionsummary/claude.go` in the `ox` repo for
 comparable Claude synthesis work and gives the model enough headroom for
 cross-team summaries that inline many daily entries:


### PR DESCRIPTION
## Summary

- Convert `sageox-distill` and `sageox-summary` SKILL.md frontmatter to the JSON-style `metadata` shape used by openclaw's `coding-agent` skill, so `requires` / `install` parse the way ClawHub's scanner expects.
- Remove `primaryEnv: ANTHROPIC_API_KEY` and `requires.env: [ANTHROPIC_API_KEY]` from both skills. The OpenClaw per-skill `apiKey` injection mechanism didn't actually deliver the key into the skill's process environment, so users hit auth failures with a misleading "key is set" check.
- Add `claude` to `requires.bins` for both skills (sageox-summary already had it; sageox-distill now declares it because `ox distill` shells out to `claude`).
- Add a `node-claude` install entry (`@anthropic-ai/claude-code`) to `sageox-distill`, and add `id` / `label` fields to every install entry in both skills to match the coding-agent shape.

## Motivation

The skills' frontmatter was using a YAML shape that didn't match openclaw's current schema, and the `primaryEnv` injection path the prose described doesn't work in practice. Both skills would do a `test -n "$ANTHROPIC_API_KEY"` check, conclude the key was set, then fail on the actual Anthropic call. Aligning with `coding-agent`'s shape (which parses correctly) and dropping the broken injection language puts auth on the only path that actually works: `claude login` (Pro/Max OAuth) or shell-exported `ANTHROPIC_API_KEY`.

## What changed in the prose

- Both `SKILL.md` files: dropped the "§1 Environment variables" section, merged credential guidance into "§1 Required binaries", renumbered §3→§2, §4→§3, §5→§4, and rewrote the auth check to verify `claude login` *or* shell `ANTHROPIC_API_KEY` (the skill no longer claims to inject the key itself).
- `claws/openclaw/README.md`: replaced the long "Environment setup → Anthropic API key" section (per-skill `apiKey` config, precedence rule, sandboxed Docker block) with a short "Claude credentials" section.
- Both skill `README.md` files: removed broken `#environment-setup` anchors and per-skill `apiKey` language.
- `PUBLISHING.md`: dropped `requires.env` from the metadata-mismatch troubleshooting row.
- `references/INSTALL.md` and `scripts/install-ox-git.sh` in both skills: updated stale `§ 3` cross-references after the renumber.

## Versions

- `sageox-distill`: 0.1.0 → 0.2.0 (new required bin, dropped per-skill `apiKey` contract)
- `sageox-summary`: 0.2.0 → 0.3.0 (dropped per-skill `apiKey` contract)

## Test plan

- [x] `python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw/sageox-distill claws/openclaw/sageox-summary` → both PASS, 0 critical / 0 warnings
- [ ] Throwaway-slug pre-flight publish before claiming the canonical slug (per `PUBLISHING.md`)
- [ ] Run `sageox-distill` end-to-end against a real team with `ANTHROPIC_API_KEY` exported in the shell — confirm `ox distill` succeeds
- [ ] Run `sageox-summary` end-to-end with `claude login` only (no `ANTHROPIC_API_KEY`) — confirm `claude -p` inherits the OAuth session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated credential authentication approach: users must now authenticate the `claude` CLI via `claude login` or by exporting `ANTHROPIC_API_KEY` in their shell, instead of configuring per-skill API keys.
  * Simplified setup instructions across OpenClaw, sageox-distill, and sageox-summary skills.
  * Updated skill versions and metadata to reflect new authentication model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->