### PR TITLE
fix(session): surface silent recording failures (#519)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ demo/playwright/node_modules/
 # Never commit age private keys
 *-age-key.txt
 *.age-key
+issues.jsonl

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -400,12 +400,27 @@ func handleAfterTool(ctx *HookContext) error {
 		return nil // not recording for this agent, silent noop
 	}
 
+	// Track every afterTool invocation + its terminal reason so `ox session status`
+	// can distinguish a healthy idle session (status=ok) from a broken recording
+	// (status=session-file-not-found, adapter-missing, etc.) when EntryCount=0.
+	recordHookStatus := func(status string) {
+		_ = session.UpdateRecordingStateForAgent(ctx.ProjectRoot, agentID, func(s *session.RecordingState) {
+			s.HookInvocations++
+			s.LastHookStatus = status
+			now := time.Now().UTC()
+			s.LastHookAt = &now
+		})
+	}
+
 	adapter, adapterErr := adapters.GetAdapter(state.AdapterName)
 	if adapterErr != nil {
+		slog.Info("hook: afterTool adapter not found", "agentID", agentID, "adapter", state.AdapterName, "err", adapterErr)
+		recordHookStatus("adapter-not-found")
 		return nil
 	}
 	reader, ok := adapter.(adapters.IncrementalReader)
 	if !ok {
+		recordHookStatus("adapter-no-incremental-reader")
 		return nil // adapter doesn't support incremental reads
 	}
 
@@ -421,7 +436,8 @@ func handleAfterTool(ctx *HookContext) error {
 			Since:    state.StartedAt,
 		})
 		if findErr != nil || sf == "" {
-			slog.Debug("hook: session file not found", "agentID", agentID, "err", findErr)
+			slog.Info("hook: session file not found", "agentID", agentID, "adapter", state.AdapterName, "repo", repoRoot, "err", findErr)
+			recordHookStatus("session-file-not-found")
 			return nil // session file not available yet
 		}
 		state.SessionFile = sf
@@ -467,11 +483,13 @@ func handleAfterTool(ctx *HookContext) error {
 
 	entries, newOffset, readErr := reader.ReadFromOffset(state.SessionFile, readOffset)
 	if readErr != nil {
-		slog.Debug("hook: incremental read failed", "error", readErr)
+		slog.Info("hook: incremental read failed", "agentID", agentID, "adapter", state.AdapterName, "file", state.SessionFile, "offset", readOffset, "error", readErr)
+		recordHookStatus("read-error")
 		return nil // non-fatal, will catch up at stop
 	}
 
 	if len(entries) == 0 {
+		recordHookStatus("no-new-entries")
 		return nil
 	}
 
@@ -489,8 +507,12 @@ func handleAfterTool(ctx *HookContext) error {
 
 	if len(entries) == 0 {
 		// update offset even if no entries passed filter
+		now := time.Now().UTC()
 		_ = session.UpdateRecordingStateForAgent(ctx.ProjectRoot, agentID, func(s *session.RecordingState) {
 			s.SourceOffset = newOffset
+			s.HookInvocations++
+			s.LastHookStatus = "no-entries-after-filter"
+			s.LastHookAt = &now
 		})
 		return nil
 	}
@@ -525,13 +547,18 @@ func handleAfterTool(ctx *HookContext) error {
 	}
 
 	if appendErr := appendRedactedEntries(rawPath, sessionEntries); appendErr != nil {
-		slog.Debug("hook: append entries failed", "error", appendErr)
+		slog.Info("hook: append entries failed", "agentID", agentID, "path", rawPath, "error", appendErr)
+		recordHookStatus("append-failed")
 		return nil // non-fatal
 	}
 
+	now := time.Now().UTC()
 	_ = session.UpdateRecordingStateForAgent(ctx.ProjectRoot, agentID, func(s *session.RecordingState) {
 		s.SourceOffset = newOffset
 		s.EntryCount += len(sessionEntries)
+		s.HookInvocations++
+		s.LastHookStatus = "ok"
+		s.LastHookAt = &now
 		// Refresh parent_pid only if the stored PID is dead — each hook call runs in a
 		// new transient shell, so blindly overwriting with os.Getppid() would store a dead
 		// PID. FindAgentAncestorPID walks the tree to find the long-lived agent process.

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -877,7 +877,14 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 	// Discover external adapters and run their diagnose subcommands.
 	// Independent of daemon -- works as one-shot subprocess per adapter.
 	progress.show("External Adapters")
-	if adapterChecks := checkExternalAdapters(opts); len(adapterChecks) > 0 {
+	adapterChecks := checkExternalAdapters(opts)
+	// Also verify that every active recording's adapter is discoverable —
+	// catches the #519 failure mode where the adapter binary is missing
+	// from PATH and every hook silently no-ops.
+	if projectRoot := findGitRoot(); projectRoot != "" {
+		adapterChecks = append(adapterChecks, checkRecordingAdapters(projectRoot)...)
+	}
+	if len(adapterChecks) > 0 {
 		categories = append(categories, checkCategory{
 			name:   "External Adapters",
 			checks: adapterChecks,

--- a/cmd/ox/doctor_adapters.go
+++ b/cmd/ox/doctor_adapters.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/internal/version"
 	"github.com/sageox/ox/pkg/adapterprotocol"
@@ -94,6 +95,60 @@ func checkExternalAdapters(opts doctorOptions) []checkResult {
 
 			results = append(results, cr)
 		}
+	}
+
+	return results
+}
+
+// checkRecordingAdapters verifies that every active recording's named adapter
+// is discoverable. When brew ships `ox` but fails to link `ox-adapter-<name>`
+// onto the user's PATH (or the bundled dir), recording state is created under
+// the adapter's name but every hook invocation silently no-ops because the
+// binary can't be forked. This was the top root-cause hypothesis for issue
+// #519 (header-only raw.jsonl across every session).
+func checkRecordingAdapters(projectRoot string) []checkResult {
+	if projectRoot == "" {
+		return nil
+	}
+	states, err := session.LoadAllRecordingStates(projectRoot)
+	if err != nil || len(states) == 0 {
+		return nil
+	}
+
+	// collect unique adapter names from active recordings
+	needed := make(map[string]bool)
+	for _, s := range states {
+		if s.AdapterName != "" && s.AdapterName != "generic" {
+			needed[s.AdapterName] = true
+		}
+	}
+	if len(needed) == 0 {
+		return nil
+	}
+
+	// ensure registry is populated with any external adapters on disk
+	_ = adapters.RegisterExternalAdapters()
+
+	var results []checkResult
+	for name := range needed {
+		if _, gerr := adapters.GetAdapter(name); gerr == nil {
+			results = append(results, PassedCheck(
+				"adapter "+name+" available",
+				"registered for active recordings",
+			))
+			continue
+		}
+		detail := fmt.Sprintf(
+			"active recording uses adapter %q but ox-adapter-%s is not discoverable. "+
+				"Session hooks will silently skip every turn (see issue #519). "+
+				"Check OX_ADAPTER_PATH, ~/.local/share/ox/adapters, or the directory containing the ox binary.",
+			name, name,
+		)
+		results = append(results, CriticalCheck(
+			"adapter "+name+" missing",
+			"adapter binary not found for active recording",
+			detail,
+		).WithFixInfo("adapter:"+name+":missing", FixLevelCheckOnly))
 	}
 
 	return results

--- a/cmd/ox/doctor_adapters_recording_test.go
+++ b/cmd/ox/doctor_adapters_recording_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+)
+
+// TestCheckRecordingAdapters_MissingAdapter verifies the doctor surfaces a
+// critical finding when an active recording names an adapter that isn't
+// discoverable. This catches the #519 RC hypothesis where ox-adapter-claude-code
+// is missing from the user's $PATH.
+// Failure prevented: silent hook no-ops on every session.
+func TestCheckRecordingAdapters_MissingAdapter(t *testing.T) {
+	projectRoot := t.TempDir()
+	// use the legacy read-fallback path so LoadAllRecordingStates sees our state
+	// without needing a full ledger/XDG setup.
+	sessionsDir := filepath.Join(projectRoot, "sessions", "2026-04-17-test")
+	state := &session.RecordingState{
+		AgentID:     "Oxtest1",
+		AdapterName: "totally-not-a-real-adapter",
+		SessionPath: sessionsDir,
+		StartedAt:   time.Now().UTC(),
+	}
+	if err := session.SaveRecordingState(projectRoot, state); err != nil {
+		t.Fatalf("SaveRecordingState: %v", err)
+	}
+
+	results := checkRecordingAdapters(projectRoot)
+	if len(results) == 0 {
+		t.Fatal("expected at least one check result, got none")
+	}
+
+	var hit bool
+	for _, r := range results {
+		if strings.Contains(r.name, "totally-not-a-real-adapter") {
+			hit = true
+			if r.passed {
+				t.Errorf("expected failed check, got passed (name=%q)", r.name)
+			}
+			if r.priority != "critical" {
+				t.Errorf("expected priority=critical, got %q (name=%q)", r.priority, r.name)
+			}
+			if !strings.Contains(r.detail, "#519") {
+				t.Errorf("expected detail to cross-link issue #519 for discoverability: detail=%q", r.detail)
+			}
+		}
+	}
+	if !hit {
+		t.Errorf("expected a check result for the missing adapter, got %d results", len(results))
+	}
+}
+
+// TestCheckRecordingAdapters_NoRecordings verifies the check is a silent no-op
+// when no recordings are active — we shouldn't spam doctor output for idle
+// projects.
+func TestCheckRecordingAdapters_NoRecordings(t *testing.T) {
+	results := checkRecordingAdapters(t.TempDir())
+	if len(results) != 0 {
+		t.Errorf("expected no results with no active recordings, got %d", len(results))
+	}
+}

--- a/cmd/ox/session_status.go
+++ b/cmd/ox/session_status.go
@@ -1,15 +1,85 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/session"
 	"github.com/spf13/cobra"
 )
+
+// countRawEntries counts turn entries in a raw.jsonl file — total lines minus
+// the header line (if present). Returns -1 if the file can't be read; the
+// caller should treat that as "unknown" and skip cross-checking.
+//
+// Used to cross-check against RecordingState.EntryCount so `ox session status`
+// can warn when the two disagree — the failure mode from issue #519 where the
+// state said "recording" but raw.jsonl only contained the header.
+func countRawEntries(rawPath string) int {
+	f, err := os.Open(rawPath)
+	if err != nil {
+		return -1
+	}
+	defer f.Close()
+
+	n := 0
+	scanner := bufio.NewScanner(f)
+	// raise the default 64KB line cap — some entries (large tool outputs) can
+	// legitimately exceed it and we'd rather count than miss.
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		n++
+	}
+	if scanner.Err() != nil {
+		return -1
+	}
+	if n == 0 {
+		return 0
+	}
+	return n - 1 // subtract header line
+}
+
+// stallGracePeriod is how long a recording can run with 0 entries before we
+// flag it as stalled. Generous because quiet sessions (user reading, thinking)
+// legitimately have few hooks. The stall condition requires BOTH (a) significant
+// hook activity AND (b) zero captured entries — both must be true.
+const stallGracePeriod = 3 * time.Minute
+
+// stallHookThreshold: require at least this many hook invocations with zero
+// entries before warning. Filters out fresh sessions that have only had one
+// or two hook fires.
+const stallHookThreshold = 5
+
+// sessionStallStatus returns (stalled, human-readable reason) for a recording.
+// A session is "stalled" when hooks have been firing but no entries have been
+// captured — the silent-failure class of bug exposed by issue #519.
+func sessionStallStatus(state *session.RecordingState) (bool, string) {
+	if state == nil {
+		return false, ""
+	}
+	if state.EntryCount > 0 {
+		return false, ""
+	}
+	if state.HookInvocations < stallHookThreshold {
+		return false, ""
+	}
+	if state.Duration() < stallGracePeriod {
+		return false, ""
+	}
+	reason := state.LastHookStatus
+	if reason == "" {
+		reason = "hooks fired but no entries captured"
+	} else {
+		reason = fmt.Sprintf("hooks fired %d× with 0 entries (last status: %s)", state.HookInvocations, reason)
+	}
+	return true, reason
+}
 
 var sessionStatusCmd = &cobra.Command{
 	Use:   "status",
@@ -50,6 +120,13 @@ type sessionStatusOutput struct {
 	StartedAt     string                  `json:"started_at,omitempty"`
 	WorkspacePath string                  `json:"workspace_path,omitempty"`
 	Branch        string                  `json:"branch,omitempty"`
+
+	// Hook observability (see RecordingState for details)
+	HookInvocations int    `json:"hook_invocations,omitempty"`
+	LastHookStatus  string `json:"last_hook_status,omitempty"`
+	LastHookAt      string `json:"last_hook_at,omitempty"`
+	Stalled         bool   `json:"stalled,omitempty"` // hooks fired but no entries captured
+	StalledReason   string `json:"stalled_reason,omitempty"`
 }
 
 // sessionRecordingEntry represents one active recording in the multi-session output.
@@ -140,26 +217,37 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 		durationStr := formatDurationHuman(duration)
 		alive, status := agentLivenessFor(agentAlive, state.AgentID)
 
+		stalled, stalledReason := sessionStallStatus(state)
+		lastHookAtStr := ""
+		if state.LastHookAt != nil {
+			lastHookAtStr = state.LastHookAt.Format("2006-01-02T15:04:05Z07:00")
+		}
+
 		if jsonOutput {
 			output := sessionStatusOutput{
-				Recording:     true,
-				AgentAlive:    agentAlivePtr(state),
-				Guidance:      "Run 'ox agent <id> session stop' to save the recording",
-				Count:         1,
-				Title:         state.Title,
-				DurationSecs:  int(duration.Seconds()),
-				Duration:      durationStr,
-				EntryCount:    state.EntryCount,
-				FilterMode:    state.FilterMode,
-				Model:         state.Model,
-				Agent:         state.AdapterName,
-				AgentID:       state.AgentID,
-				ProcessAlive:  alive,
-				ProcessStatus: status,
-				SessionFile:   state.SessionFile,
-				StartedAt:     state.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
-				WorkspacePath: state.WorkspacePath,
-				Branch:        state.Branch,
+				Recording:       true,
+				AgentAlive:      agentAlivePtr(state),
+				Guidance:        "Run 'ox agent <id> session stop' to save the recording",
+				Count:           1,
+				Title:           state.Title,
+				DurationSecs:    int(duration.Seconds()),
+				Duration:        durationStr,
+				EntryCount:      state.EntryCount,
+				FilterMode:      state.FilterMode,
+				Model:           state.Model,
+				Agent:           state.AdapterName,
+				AgentID:         state.AgentID,
+				ProcessAlive:    alive,
+				ProcessStatus:   status,
+				SessionFile:     state.SessionFile,
+				StartedAt:       state.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+				WorkspacePath:   state.WorkspacePath,
+				Branch:          state.Branch,
+				HookInvocations: state.HookInvocations,
+				LastHookStatus:  state.LastHookStatus,
+				LastHookAt:      lastHookAtStr,
+				Stalled:         stalled,
+				StalledReason:   stalledReason,
 			}
 			return outputJSON(output)
 		}
@@ -174,13 +262,29 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  Title:    %s\n", state.Title)
 		}
 		fmt.Printf("  Duration: %s\n", durationStr)
-		fmt.Printf("  Entries:  %d\n", state.EntryCount)
+		rawEntries := -1
+		if state.SessionPath != "" {
+			rawEntries = countRawEntries(filepath.Join(state.SessionPath, "raw.jsonl"))
+		}
+		if rawEntries >= 0 && rawEntries != state.EntryCount {
+			fmt.Printf("  Entries:  %d %s\n", state.EntryCount,
+				cli.StyleWarning.Render(fmt.Sprintf("(raw.jsonl has %d — state may be stale)", rawEntries)))
+		} else {
+			fmt.Printf("  Entries:  %d\n", state.EntryCount)
+		}
 		fmt.Printf("  Agent:    %s\n", state.AdapterName)
 		fmt.Printf("  Started:  %s\n", state.StartedAt.Format("15:04:05"))
 		if state.AgentID != "" {
 			fmt.Printf("  Agent ID: %s\n", state.AgentID)
 		}
 		fmt.Printf("  Process:  %s\n", formatProcessStatus(status))
+		if state.HookInvocations > 0 || state.LastHookStatus != "" {
+			fmt.Printf("  Hooks:    %d invocations", state.HookInvocations)
+			if state.LastHookStatus != "" {
+				fmt.Printf(", last=%s", state.LastHookStatus)
+			}
+			fmt.Println()
+		}
 		if state.WorkspacePath != "" {
 			fmt.Printf("  Workspace: %s\n", state.WorkspacePath)
 		}
@@ -188,7 +292,10 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  Branch:   %s\n", state.Branch)
 		}
 		fmt.Println()
-		if status == "dead" {
+		if stalled {
+			fmt.Println(cli.StyleWarning.Render("⚠ Recording is stalled: " + stalledReason))
+			fmt.Println(cli.StyleDim.Render("  Run 'ox doctor' to diagnose."))
+		} else if status == "dead" {
 			fmt.Println(cli.StyleWarning.Render("Agent process is no longer running. Run 'ox agent <id> session stop' to finalize."))
 		} else {
 			fmt.Println(cli.StyleDim.Render("Run 'ox agent <id> session stop' to save the recording"))

--- a/cmd/ox/session_status_stall_test.go
+++ b/cmd/ox/session_status_stall_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+)
+
+// TestCountRawEntries verifies the raw.jsonl line counter used to cross-check
+// RecordingState.EntryCount against on-disk reality.
+// Failure prevented: the #519 symptom where state.EntryCount=0 masked the
+// fact that raw.jsonl had only the header line — we need a direct count.
+func TestCountRawEntries(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{"missing file", "", -1},
+		{"empty file", "<EMPTY>", 0},
+		{"header only", `{"type":"header"}` + "\n", 0},
+		{"header + 2 entries", `{"type":"header"}
+{"type":"user","content":"hi"}
+{"type":"assistant","content":"hello"}
+`, 2},
+		{"header + 5 entries, no trailing newline", `{"type":"header"}
+{"type":"user"}
+{"type":"assistant"}
+{"type":"tool"}
+{"type":"assistant"}
+{"type":"user"}`, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, tt.name+".jsonl")
+			switch tt.content {
+			case "":
+				// leave missing
+			case "<EMPTY>":
+				if err := os.WriteFile(path, []byte{}, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			default:
+				if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := countRawEntries(path)
+			if got != tt.want {
+				t.Errorf("countRawEntries(%q) = %d, want %d", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSessionStallStatus verifies the stall heuristic used by `ox session status`
+// to surface the #519 silent-failure mode: hooks firing but no entries captured.
+// Failure prevented: regressing to the pre-#519 UX where a broken recording
+// chain looked identical to a healthy idle session.
+func TestSessionStallStatus(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name     string
+		state    *session.RecordingState
+		wantStall bool
+	}{
+		{
+			name:  "nil state is never stalled",
+			state: nil,
+		},
+		{
+			name: "fresh session with no hooks is not stalled",
+			state: &session.RecordingState{
+				StartedAt: now.Add(-10 * time.Second),
+			},
+		},
+		{
+			name: "session with entries is not stalled",
+			state: &session.RecordingState{
+				StartedAt:       now.Add(-10 * time.Minute),
+				EntryCount:      5,
+				HookInvocations: 20,
+			},
+		},
+		{
+			name: "few hook invocations not enough to stall",
+			state: &session.RecordingState{
+				StartedAt:       now.Add(-10 * time.Minute),
+				HookInvocations: 2,
+				LastHookStatus:  "session-file-not-found",
+			},
+		},
+		{
+			name: "within grace period not stalled",
+			state: &session.RecordingState{
+				StartedAt:       now.Add(-30 * time.Second),
+				HookInvocations: 20,
+				LastHookStatus:  "session-file-not-found",
+			},
+		},
+		{
+			name: "hooks firing past threshold and grace period with zero entries IS stalled",
+			state: &session.RecordingState{
+				StartedAt:       now.Add(-10 * time.Minute),
+				HookInvocations: 20,
+				LastHookStatus:  "session-file-not-found",
+			},
+			wantStall: true,
+		},
+		{
+			name: "stall with no last status still reports",
+			state: &session.RecordingState{
+				StartedAt:       now.Add(-10 * time.Minute),
+				HookInvocations: 20,
+			},
+			wantStall: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStall, gotReason := sessionStallStatus(tt.state)
+			if gotStall != tt.wantStall {
+				t.Errorf("sessionStallStatus stalled = %v, want %v (reason=%q)", gotStall, tt.wantStall, gotReason)
+			}
+			if tt.wantStall && gotReason == "" {
+				t.Errorf("sessionStallStatus returned stalled=true but empty reason")
+			}
+		})
+	}
+}

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -61,6 +61,14 @@ type RecordingState struct {
 
 	WatchMode string     `json:"watch_mode,omitempty"` // how entries are captured: "hook" (CLI-driven) or "tail" (daemon-driven)
 	StoppedAt *time.Time `json:"stopped_at,omitempty"` // set by ox session stop to signal daemon to finalize
+
+	// Hook observability: lets `ox session status` show whether hooks are firing
+	// and why they're skipping. Without these, a broken recording path (e.g.
+	// adapter binary missing, session file not discoverable) looks identical to
+	// a healthy idle session — both show EntryCount=0 with no signal of cause.
+	HookInvocations int        `json:"hook_invocations,omitempty"` // total afterTool hook calls since recording started
+	LastHookStatus  string     `json:"last_hook_status,omitempty"` // stable reason code from last afterTool: "ok", "session-file-not-found", "read-error", etc.
+	LastHookAt      *time.Time `json:"last_hook_at,omitempty"`     // timestamp of last afterTool invocation
 }
 
 // Duration returns how long the recording has been running.


### PR DESCRIPTION
Closes #519 for observability; lays groundwork for diagnosing the missing-adapter root cause.

## Summary
- **Hook observability**: `RecordingState` now tracks `HookInvocations`, `LastHookStatus`, `LastHookAt`. Every early-exit in `handleAfterTool` records a stable status code (`adapter-not-found`, `session-file-not-found`, `read-error`, `no-new-entries`, `ok`, etc.) instead of silently returning nil.
- **Stall detection**: `ox session status` surfaces a ⚠ warning when hooks fire past threshold with zero entries captured — the exact #519 signature. Previously a broken recording chain looked identical to a healthy idle session.
- **Doctor check (#521)**: `ox doctor` verifies each active recording's adapter binary is discoverable; critical finding with fix hints pointing at `OX_ADAPTER_PATH` / `~/.local/share/ox/adapters`.
- **raw.jsonl cross-check (#522)**: `session status` tail-counts `raw.jsonl` and flags drift when `state.EntryCount` disagrees with on-disk reality.

## Test plan
- [x] `go test ./cmd/ox/... ./internal/session/...` — green
- [x] `make lint` — 0 issues
- [x] New tests: `TestSessionStallStatus`, `TestCountRawEntries`, `TestCheckRecordingAdapters_MissingAdapter`, `TestCheckRecordingAdapters_NoRecordings`
- [ ] Manual repro: remove `ox-adapter-claude-code` from PATH, start a session, confirm `ox doctor` + `ox session status` both surface the failure

```mermaid
flowchart LR
    A[PostToolUse hook] --> B{adapter discoverable?}
    B -->|no| C[record: adapter-not-found]
    B -->|yes| D{find session file}
    D -->|miss| E[record: session-file-not-found]
    D -->|hit| F{read entries}
    F -->|err| G[record: read-error]
    F -->|0| H[record: no-new-entries]
    F -->|n>0| I[record: ok + append]
    C & E & G & H & I --> J[session status / doctor]
    J --> K[user sees cause]
```

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hook execution tracking with status codes and timestamps to monitor session activity
  * Implemented session stall detection to identify inactive recordings based on hook activity
  * Enhanced diagnostic checks to verify recording adapters are properly discoverable

* **Tests**
  * Added test coverage for session stall detection and entry counting
  * Added test coverage for recording adapter validation in diagnostics

* **Chores**
  * Updated ignore patterns for generated files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->