### PR TITLE
chore(release): bump version to 0.6.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.6.3"
+      "version": "0.6.4"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.6.3"
+	Version   = "0.6.4"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
Bumps version 0.6.3 → 0.6.4 across the canonical source (`internal/version/version.go`), the Claude plugin marketplace manifest, and the plugin manifest. Generated via `scripts/version-bump.sh 0.6.4`.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.6.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->