### PR TITLE
fix(adapter-claude-code): wire ReadFromOffset in one-shot mode (#519)

### DIFF
--- a/cmd/ox-adapter-claude-code/main.go
+++ b/cmd/ox-adapter-claude-code/main.go
@@ -23,25 +23,47 @@ const (
 
 func main() {
 	adapterruntime.Run(adapterruntime.Config{
-		Info:           handleInfo,
-		Detect:         handleDetect,
-		InstallHooks:   handleInstallHooks,
-		CheckHooks:     handleCheckHooks,
-		UninstallHooks: handleUninstallHooks,
-		Read:           handleRead,
-		ReadMetadata:   handleReadMetadata,
-		Diagnose:       handleDiagnose,
+		Info:              handleInfo,
+		Detect:            handleDetect,
+		InstallHooks:      handleInstallHooks,
+		CheckHooks:        handleCheckHooks,
+		UninstallHooks:    handleUninstallHooks,
+		Read:              handleRead,
+		ReadMetadata:      handleReadMetadata,
+		Diagnose:          handleDiagnose,
 		InstallRules:      handleInstallRules,
 		CheckRules:        handleCheckRules,
 		UninstallRules:    handleUninstallRules,
 		InstallCommands:   handleInstallCommands,
 		CheckCommands:     handleCheckCommands,
 		UninstallCommands: handleUninstallCommands,
-		FindSession:    handleFindSession,
-		ImportSession:  handleImportSession,
-		CapturePrior:   handleCapturePrior,
-		Serve:          handleServe,
+		FindSession:       handleFindSession,
+		ReadFromOffset:    handleReadFromOffset,
+		ImportSession:     handleImportSession,
+		CapturePrior:      handleCapturePrior,
+		Serve:             handleServe,
 	})
+}
+
+// handleReadFromOffset is the one-shot mode handler for read-from-offset.
+// The serve-mode handler lives in serve.go (srv.OnReadFromOffset). Hook
+// invocations of the adapter are one-shot — a fresh subprocess per Claude
+// Code PostToolUse — so they go through Config.ReadFromOffset here, not
+// through the serve-mode pipeline. This wiring was missing, which caused
+// issue #519: every hook returned "read-from-offset not implemented" and
+// raw.jsonl stayed header-only.
+func handleReadFromOffset(p adapterprotocol.ReadFromOffsetParams) (*adapterprotocol.ReadFromOffsetResult, error) {
+	if p.SessionFile == "" {
+		return nil, fmt.Errorf("--session-file is required")
+	}
+	entries, newOffset, err := readFromOffset(p.SessionFile, p.Offset)
+	if err != nil {
+		return nil, err
+	}
+	return &adapterprotocol.ReadFromOffsetResult{
+		Entries:   entries,
+		NewOffset: newOffset,
+	}, nil
 }
 
 func handleInfo() (*adapterprotocol.InfoResponse, error) {


### PR DESCRIPTION
## Summary

Fixes #519 — session recording produces an empty `raw.jsonl` (header-only, zero entries captured) on Claude Code. Every PostToolUse hook silently no-opped at the adapter layer.

## What was broken

When Claude Code runs a tool, it fires a hook that invokes `ox agent hook PostToolUse`. That hook's job is to read Claude Code's own session log file and copy any new entries into ox's recording.

ox doesn't parse Claude Code's log format itself. It delegates to a separate helper binary — `ox-adapter-claude-code` — that knows the format. The hook asks the adapter *"give me new entries starting at byte position N in this file,"* the adapter reads the file and returns them.

The adapter can be invoked two ways:

- **Serve mode** — one long-lived adapter process answering many requests.
- **One-shot mode** — a fresh adapter process per single request.

Hooks always use one-shot mode.

Inside the adapter, the `read-from-offset` handler was written and working — **but had only been registered with serve mode** (via `srv.OnReadFromOffset` in [`cmd/ox-adapter-claude-code/serve.go`](https://github.com/sageox/ox/blob/main/cmd/ox-adapter-claude-code/serve.go)). Nobody had wired it into the one-shot `adapterruntime.Config` in `main.go`. So when a hook asked, the one-shot adapter replied `"read-from-offset not implemented"` (via the nil-handler branch at [`pkg/adapterruntime/runtime.go:209`](https://github.com/sageox/ox/blob/main/pkg/adapterruntime/runtime.go#L209)).

`handleAfterTool` treated that reply as a read failure, recorded `last_hook_status=read-error`, and returned without appending anything. This happened on every tool call — the session's `raw.jsonl` therefore only ever contained the one header line written at recording start.

## The fix

Two additions to [`cmd/ox-adapter-claude-code/main.go`](cmd/ox-adapter-claude-code/main.go):

1. `ReadFromOffset: handleReadFromOffset` in the `adapterruntime.Config` literal.
2. A thin `handleReadFromOffset` that calls the existing `readFromOffset(path, offset)` function in [`session.go`](cmd/ox-adapter-claude-code/session.go) — the same function the serve-mode handler already uses.

No behavior change for serve mode. gofmt re-aligned the struct when the longer field name `ReadFromOffset:` was added, which accounts for most of the diff lines.

## Test plan

Manual reproduction before the fix (Claude Code 2.1.111, ox 0.6.3):

- `ox session status`: `Entries: 0` after hours of active Claude Code usage.
- `raw.jsonl`: 235 bytes (header only).
- `.recording.json.last_hook_status`: `read-error` on every PostToolUse invocation.

After the fix (locally built):

- Entries climb in real time on every tool call.
- `raw.jsonl` grows past the header; byte offset advances correctly.
- `.recording.json.last_hook_status`: `ok`; `hook_invocations` increments each hook.

## Follow-ups (separate issues, not in this PR)

- **Regression test**: add a lint-style test asserting every capability advertised in an adapter's `InfoResponse` has a corresponding non-nil handler in its one-shot `adapterruntime.Config`. This would catch the entire class of bug for every adapter.
- **Propagate fix to other adapters**: `ox-adapter-droid`, `ox-adapter-aider` and others should be audited for the same pattern.
- **Hook stderr goes into the void**: `slog.Info`/`slog.Debug` calls from hook paths are captured by Claude Code's hook runner and discarded, which is why this bug was invisible for so long. A dedicated file-based hook debug log would make future hook-chain diagnosis much faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced read-from-offset capability in the adapter runtime, enabling access to specific positions within session files.

* **Chores**
  * Updated adapter configuration structure and realigned field definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->