### PR TITLE
docs(session): add session capture architecture documents

### DIFF
--- a/docs/ai/architecture/session-capture-architecture.md
+++ b/docs/ai/architecture/session-capture-architecture.md
@@ -1,0 +1,599 @@
+<!-- doc-audience: ai -->
+# Session Capture — System Architecture
+
+> Audience: principal engineer onboarding onto the session subsystem. This document
+> assumes you've read [session-capture-concepts.md](session-capture-concepts.md). It
+> walks the components, the interfaces between them, and the *why* behind the major
+> design decisions. It does not repeat implementation details — see
+> [session-capture-components.md](session-capture-components.md) for those.
+
+---
+
+## 1. Component map
+
+```mermaid
+flowchart LR
+    subgraph AgentHost [Agent host e.g. Claude Code]
+        CC[claude-code process]
+        CCJ[~/.claude/.../sess-*.jsonl]
+        CC -.writes.-> CCJ
+    end
+
+    subgraph OxCLI [ox CLI - invoked per hook]
+        HOOK[cmd/ox/agent_hook.go]
+        PRIME[cmd/ox/agent_prime.go]
+        SESSCMD[cmd/ox/session_*.go]
+        AGSESS[cmd/ox/agent_session_*.go]
+    end
+
+    subgraph Adapters [Adapter binaries - external]
+        ADCC[ox-adapter-claude-code]
+        ADCX[ox-adapter-codex]
+        ADAM[ox-adapter-amp]
+        ADN[ox-adapter-...]
+    end
+
+    subgraph Core [internal/session - core library]
+        REC[recording.go<br/>RecordingState]
+        CAP[pipeline/<br/>incremental capture]
+        CLA[classify.go + entry.go]
+        RED[redact_rules.go + secrets.go]
+        ART[artifacts.go + markdown.go<br/>+ summary_md.go]
+        SUM[summarize.go]
+        PLAN[plan_extract.go]
+        CTX[contexttrace/]
+        SIGN[signing.go + manifest.go]
+        STORE[store.go + storage.go]
+    end
+
+    subgraph Ledger [internal/ledger + internal/lfs]
+        LDG[ledger.go]
+        PUSH[github_push.go]
+        LFSC[lfs/client.go<br/>Batch API]
+        META[lfs/meta.go<br/>SessionMeta]
+    end
+
+    subgraph Daemon [ox daemon]
+        DM[internal/daemon]
+    end
+
+    subgraph AgentInstance [internal/agentinstance]
+        AI[Store - JSONL per-user]
+    end
+
+    subgraph Identity [internal/identity + internal/auth]
+        IDN[ResolveAttribution]
+    end
+
+    CC -->|hook invoke| HOOK
+    HOOK --> PRIME
+    HOOK --> REC
+    HOOK --> ADCC
+    ADCC --> CCJ
+    HOOK --> CAP
+    CAP --> CLA
+    CAP --> RED
+    CAP --> REC
+    CAP -->|append| RAW[(raw.jsonl<br/>ledger cache)]
+    REC -->|state| RSTATE[(.recording.json)]
+
+    SESSCMD --> ART
+    SESSCMD --> SUM
+    SESSCMD --> PLAN
+    ART --> STORE
+    SUM --> STORE
+
+    SESSCMD --> LFSC
+    LFSC --> LFS[(LFS blob store)]
+    SESSCMD --> META
+    SESSCMD --> PUSH
+    PUSH --> LDGR[(Ledger git repo)]
+
+    DM -.pull.-> LDGR
+    PRIME --> AI
+    HOOK --> AI
+    SESSCMD --> IDN
+    SIGN -.signs.-> RED
+    CTX --> RAW2[(context-trace.jsonl)]
+```
+
+The diagram separates three *tiers*:
+
+- **Edge (left, yellow in diagrams):** the untrusted agent host. ox observes but does
+  not control it. Contract: the host calls `ox agent hook <event>` at lifecycle
+  points and does not rely on stdout from those calls.
+- **CLI (center):** the ox binary, invoked per hook. The CLI is stateless across
+  invocations; all continuity is in files on disk.
+- **Core and distribution (right):** Go packages linked into the CLI that do the real
+  work, plus the daemon that does background reads.
+
+The boundary between tiers is physical (separate processes). The boundary between
+packages inside the CLI is logical, but enforced by Go's import rules: `cmd/ox/`
+imports `internal/session/`, not the other way around.
+
+---
+
+## 2. The session recording state machine
+
+The state machine is stored in `.recording.json` and driven by hook invocations. It is
+the single most important piece of state in capture; everything else is derived from
+it.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Absent: (no .recording.json)
+    Absent --> Primed: SessionStart hook<br/>StartRecording writes header
+    Primed --> Recording: first PostToolUse hook<br/>finds session file
+    Recording --> Recording: each PostToolUse<br/>tails, appends, updates offset
+    Recording --> StoppedExplicit: user runs ox session stop
+    Recording --> StoppedCompact: PreCompact hook<br/>stopSessionForClear
+    Recording --> Ghost: parent PID dies<br/>(detected later)
+    Recording --> Aborted: ox session abort
+
+    StoppedExplicit --> Finalized: drain + artifacts
+    StoppedCompact --> Finalized: drain + artifacts
+    Ghost --> Finalized: ox session recover
+    Ghost --> Discarded: ghost cleanup (no recovery)
+    Aborted --> Discarded
+
+    Finalized --> Uploaded: LFS batch upload
+    Uploaded --> Published: ledger commit + push
+    Published --> [*]
+    Discarded --> [*]
+
+    note right of Recording
+        .recording.json holds:
+        AgentID, SessionPath, SessionFile,
+        SourceOffset (tail position),
+        EntryCount, HookInvocations,
+        LastHookAt, LastHookStatus,
+        ParentPID, StoppedAt
+    end note
+```
+
+### Key transitions
+
+- **Absent → Primed:** `StartRecording` in `internal/session/recording.go`. Allocates
+  the session path, writes the first line (header) of `raw.jsonl`, writes
+  `.recording.json`. Deduplicates by Agent ID — two `ox agent prime` calls on the same
+  host do not start two sessions.
+
+- **Primed → Recording:** The first PostToolUse hook discovers the agent's session
+  file via the adapter's `FindSessionFile` and locks the `SessionFile` + `StartOffset`
+  into state. Subsequent hooks never re-search.
+
+- **Recording → Recording (the hot loop):** This is the tightest inner loop in the
+  capture subsystem. On each hook: open source file at `SourceOffset`, parse new
+  lines, classify, redact, append. Updates to `.recording.json` use a write-to-temp +
+  atomic rename to be safe under concurrent reads. `LastHookStatus` records *why* a
+  hook was a no-op (e.g. `session-file-not-found`, `read-error`,
+  `adapter-no-incremental-reader`), which is what makes `ox session status` and
+  `ox doctor` actionable.
+
+- **Recording → Stopped*:** Two distinct exits. `StoppedAt` is set. An IPC
+  fire-and-forget to the daemon (`SessionFinalizeIPCPayload`) is a courtesy only —
+  finalization happens in the CLI. The IPC exists so that a crashed CLI still hands
+  off the session name to a healthy daemon for cleanup.
+
+- **Ghost detection:** `IsAgentAlive()` uses `kill(pid, 0)`. Eligible only after
+  `GhostGracePeriod` (10 min). Rationale: a new PID shows up briefly as a transient
+  shell before the long-lived agent process; without grace we'd cull real sessions
+  whose PID hadn't stabilized. See `recording_ghost_grace_test.go`.
+
+### Why observability fields live in `.recording.json`
+
+An earlier design pushed hook status to logs. That made triage miserable — users
+asking "why isn't my recording working?" had to grep logs in XDG state dir across
+multiple processes. Now a single `cat .recording.json` answers it. The tradeoff is
+one extra atomic write per hook, which is cheap compared to reading the source JSONL
+itself.
+
+---
+
+## 3. Path resolution: where things live
+
+Session storage is one of the places where getting the path wrong has historically
+been a serious bug — content has leaked into the user's source repo, and writes have
+landed in directories that never get cleaned up. The architecture pins a single
+canonical write path and a search path for reads.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Canonical write path (resolveSessionsWritePath)                 │
+│                                                                  │
+│    ~/.local/share/sageox/<endpoint>/ledgers/<repo_id>/           │
+│        .sageox/cache/sessions/<session-name>/                    │
+│                                                                  │
+│    Falls back (no repo_id or endpoint) to:                       │
+│    <XDG_CACHE_HOME>/sageox/context/<repo_id>/sessions/           │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Reads use a *search path ladder* (in order):
+
+1. Ledger cache (canonical, environment-independent).
+2. Current XDG cache.
+3. Alternate XDG caches (e.g. a Conductor GUI session and a terminal have different
+   `XDG_CACHE_HOME`; a ghost-cleanup from one shouldn't miss recordings from the
+   other).
+4. Legacy `projectRoot/sessions/` — read-only fallback for in-flight sessions started
+   on older ox versions.
+
+Writes **never** iterate the search path. That invariant is enforced by
+`resolveSessionsWritePath` having a different signature and return contract from
+`sessionsSearchPaths`. Doing otherwise is the bug that leaked sessions into the source
+repo; the rule is called out in a prominent comment in `recording.go`.
+
+### Two classes of path, one folder per session
+
+Within a session folder:
+
+```
+<session-name>/
+  .recording.json        # ephemeral, deleted on publish
+  raw.jsonl              # LFS-backed, .gitignored in ledger
+  summary.json           # LFS-backed
+  summary.md             # LFS-backed
+  session.md             # LFS-backed
+  plan.md                # LFS-backed (optional)
+  context-trace.jsonl    # LFS-backed (optional)
+  meta.json              # git-tracked in the ledger
+```
+
+Only `meta.json` is committed. The others are `.gitignore`d by the ledger's
+`.gitignore`. Pointer-less LFS (see §6) makes this consistent.
+
+---
+
+## 4. Adapter layer: abstracting the agent host
+
+An adapter is an external binary (`ox-adapter-<type>`) that ox invokes as a
+subprocess. The adapter surface, from `internal/session/adapters/adapter.go`:
+
+```
+Detect(ctx)                         → bool + metadata    (is this host present?)
+FindSessionFile(SessionLookup)      → path               (where is its JSONL?)
+ReadMetadata(path)                  → *SessionMetadata   (agent version, model)
+IncrementalReader.ReadFromOffset(path, offset)
+                                    → []RawEntry, newOffset
+CapturePrior(SessionLookup)         → CapturePriorResult (optional capability)
+Capabilities                        → []Capability       (CapCapturePrior, …)
+```
+
+### Why external binaries, not plugins?
+
+Three reasons from the commit history and ADR discussion:
+
+1. **Blast radius.** A buggy or malicious adapter cannot corrupt the ox process state
+   or the raw file. If the adapter exits non-zero, the hook records a `LastHookStatus`
+   and moves on.
+2. **Independent release cadence.** Claude Code's JSONL format changes faster than ox
+   releases. Shipping a fixed adapter as a separate binary means users can `brew
+   upgrade ox-adapter-claude-code` without touching ox.
+3. **Capability-based dispatch.** New agents register at runtime; ox does not need to
+   know their names at compile time. `adapters.RegisterExternalAdapters()` scans
+   `PATH` for `ox-adapter-*` and populates a registry.
+
+### Adapter protocol wire format
+
+Adapters communicate via line-delimited JSON on stdin/stdout (see
+`internal/adapterprotocol/`). A hook invocation roughly looks like:
+
+```
+ox sends:    {"op":"read_from_offset","path":"...","offset":4096}
+adapter:     {"entries":[...],"next_offset":8192}
+```
+
+Because this is a subprocess, the adapter can be in any language. Today they are all
+Go, sharing `pkg/adapterprotocol/` helpers, but that's a convention not a constraint.
+
+---
+
+## 5. Pipeline: from raw line to appended entry
+
+```mermaid
+flowchart LR
+    A[raw byte<br/>@ offset] --> B[adapter parse]
+    B --> C[classify<br/>type: user/assistant/system/tool]
+    C --> D[timestamp filter<br/>drop pre-StartedAt]
+    D --> E[secret redaction<br/>regex + literal + signed manifest]
+    E --> F[assign seq + eid<br/>5-char entry id]
+    F --> G[append to raw.jsonl]
+    G --> H[update .recording.json]
+```
+
+The pipeline has seven stages and is strictly linear. It lives in
+`internal/session/pipeline/` with supporting utilities in `classify.go`, `filter.go`,
+`redact_rules.go`, `secrets.go`, and `entry.go`.
+
+### Design decisions
+
+- **Classification before redaction.** Entry type determines which fields are
+  sensitive. A `tool` entry has an `output` field that needs regex sweeps; a `user`
+  entry can have inline credentials in natural language. Classifying first means
+  redaction doesn't have to guess what the entry is.
+
+- **`eid` is generated at append time, not at read time.** If the adapter re-emits an
+  entry (e.g. because the agent rewrote its own JSONL), we'd rather have a new `eid`
+  and let downstream dedup than silently collide. 5-char random IDs give 62⁵ ≈ 916M
+  combinations, which is ample per session.
+
+- **Footer is written at finalize, not maintained incrementally.** The footer has
+  `entry_count` and `closed_at` — mutating the last line on every append would ruin
+  the append-only guarantee.
+
+### Failure modes and what we keep
+
+| Failure | Consequence | Raw file state |
+|---|---|---|
+| Adapter binary missing | Hook logs status, returns 0 | raw unchanged (header only) |
+| Source JSONL moved / permissions | LastHookStatus: read-error | raw unchanged |
+| Partial read (EOF mid-entry) | Offset unchanged, retried next hook | raw unchanged |
+| Redactor regex panic | Entry dropped, others kept | raw may miss one entry |
+| Append fsync failure | Error surfaced; offset not advanced | raw unchanged |
+| CLI SIGKILL mid-append | Truncated last line on raw.jsonl | Truncated line is re-read next boot |
+
+The "raw unchanged" property across most failures is what makes session capture
+*cheap* — we don't have to second-guess correctness on retry.
+
+---
+
+## 6. Distribution: LFS without `git-lfs`
+
+This is one of the most distinctive decisions in the system. Full rationale is in
+[adr-session-lfs-storage.md](../adr/adr-session-lfs-storage.md). Summary:
+
+- Sessions can be dozens of MB (transcripts of hour-long agent runs). Committing that
+  into a git tree is intolerable.
+- Standard `git-lfs` requires a binary dependency (~70% of users don't have it) and
+  smudge/clean filters that auto-hydrate content on `git checkout`, which would
+  destroy the dehydrated-by-default model.
+- GitLab and GitHub both expose the LFS Batch API over plain HTTPS. A pure-Go client
+  (~400 LoC) handles upload and download. No subprocess, no `.gitattributes`.
+
+```mermaid
+sequenceDiagram
+    participant CLI as ox session upload
+    participant LFS as internal/lfs/client.go
+    participant Store as LFS blob store
+    participant Ledger as Ledger git repo
+
+    CLI->>LFS: UploadSessionFiles(filename -> content)
+    LFS->>LFS: compute SHA256(content) = OID
+    LFS->>Store: POST /info/lfs/objects/batch (upload)
+    Store-->>LFS: per-OID upload URLs
+    par Parallel uploads (up to 4)
+        LFS->>Store: PUT <upload_url> (body)
+    end
+    LFS-->>CLI: {filename -> FileRef{OID, Size}}
+    CLI->>CLI: build SessionMeta (filenames, OIDs, metadata)
+    CLI->>Ledger: write meta.json
+    CLI->>Ledger: git add --sparse meta.json
+    CLI->>Ledger: git commit -m "session: <name>"
+    CLI->>Ledger: git push (retry 3x)
+```
+
+### The `meta.json` object
+
+Replaces both a git-lfs pointer file *and* a git-lfs `.gitattributes` rule. Schema:
+
+```json
+{
+  "session_name": "2026-04-19T04-19-galexy-OxSk2e",
+  "username": "galex@sageox.ai",
+  "agent_id": "OxSk2e",
+  "agent_type": "claude-code",
+  "model": "claude-sonnet-4-20250514",
+  "created_at": "2026-04-19T04:19:00Z",
+  "entry_count": 312,
+  "summary": "one-line synopsis",
+  "stop_reason": "explicit",
+  "repo_id": "repo_…",
+  "sageox_score": "moderate",
+  "files": {
+    "raw.jsonl":   {"oid":"sha256:…","size":128934},
+    "summary.md":  {"oid":"sha256:…","size":5182},
+    "session.md":  {"oid":"sha256:…","size":98441}
+  }
+}
+```
+
+### Consistency model
+
+- **Upload-first, commit-after.** If LFS upload fails, there is no commit. If commit
+  succeeds but push fails, the CLI retries; the blobs are already in LFS, so a
+  succeeded later push is always referentially valid.
+- **No pointer files in the working tree.** A teammate's `git pull` on the ledger
+  downloads `meta.json` and nothing else. `ox session list` walks `sessions/*/meta.json`.
+- **Hydration is pull, not push.** `ox session hydrate <name>` reads `meta.json`,
+  issues a Batch download, streams to the local cache. Cache path is identical to
+  the write path from §3, so a hydrated session is indistinguishable from one
+  recorded locally.
+
+### Why the daemon doesn't do uploads
+
+The daemon-CLI split is covered in [adr-ledger-architecture.md](../adr/adr-ledger-architecture.md).
+For sessions specifically: uploads are bursty and happen exactly when the CLI already
+has the context (user, session path, auth). Routing through the daemon would require
+IPC for something that is trivially done in the calling process, with no concurrency
+benefit (one session per upload).
+
+---
+
+## 7. Context trace: parallel audit log
+
+A context trace is a separate JSONL file in the same session folder. It records:
+
+- **Provided events:** emitted during `ox agent prime`. For each team-context or
+  memory snippet injected into the agent, record source type, slug, token count, and
+  whether it was inlined vs referenced.
+- **Influenced events:** emitted by `ox agent <id> session context-trace` from inside
+  the agent's own turn. The agent declares "this decision was driven by
+  MEMORY/foo.md". This is how SageOx computes contribution scores.
+
+```
+context-trace.jsonl
+├── {type:"provided",source_type:"team-context",slug:"conventions",tokens:812,inlined:true}
+├── {type:"provided",source_type:"team-memory",slug:"soul",tokens:0,inlined:false}
+├── {type:"influenced",eid:"aB7x9",source_type:"team-context",slug:"conventions"}
+...
+```
+
+Separating this from `raw.jsonl` matters for two reasons:
+
+1. **Different retention.** A tracetracecan be re-derived for an old session, raw
+   cannot.
+2. **Different consumer.** The SageOx server reads context-trace for team-wide
+   attribution dashboards without needing to re-parse the raw conversation.
+
+The `eid` key ties an "influenced" event to a specific entry in raw. If raw is
+resummarized, the trace still points at a stable point.
+
+---
+
+## 8. Concurrency architecture
+
+### Three concurrency axes
+
+1. **Multiple agent hosts on one machine.** Solved by per-session folders keyed by
+   Agent ID. No shared mutable state outside `agentinstance.Store`, which is an
+   append-only JSONL with last-writer-wins semantics (safe because each writer
+   appends its own record).
+2. **Hook re-entry on one session.** Claude Code can fire hooks rapidly. Each hook
+   invocation is a new ox process. Atomic rename on `.recording.json` plus
+   append-only `raw.jsonl` means no locks. If two hooks race, the second sees the
+   first's offset and is a no-op for those bytes.
+3. **Daemon vs CLI on the ledger.** Split cleanly: daemon does pulls, CLI does
+   pushes. Conflict window is the few seconds of `git add / commit / push`; the
+   daemon's pull uses `--autostash` + `--rebase` to cope with local commits that
+   haven't been pushed yet.
+
+### Liveness
+
+The daemon checkpoints its own heartbeat to `~/.local/state/sageox/daemon.pid` +
+`state.json`. The CLI checkpoints per-agent via `LastHookAt`. A cleanup sweep only
+runs when `Duration() > GhostGracePeriod` *and* the parent PID is dead.
+
+### No two-phase commit
+
+Session publication is **not transactional** across `LFS upload` → `git commit` →
+`git push`. The ordering is chosen so partial failures leave valid states:
+
+- After upload, before commit: LFS blobs exist but no one knows about them. Garbage.
+  Re-running upload is safe (OID addressing means idempotent writes).
+- After commit, before push: meta.json committed locally, blobs in LFS, not visible
+  to teammates. Next push resolves it.
+
+The third failure mode — push succeeds but meta.json references an OID that isn't in
+LFS — cannot happen because upload is before commit.
+
+---
+
+## 9. Integration surfaces
+
+### Hooks (edge → CLI)
+
+Registered in the agent host's hook config (Claude Code's `settings.json` under
+`hooks`). ox's `ox agent hook` command is the universal entry point, with
+`resolvePhase()` in `agent_hook.go` mapping host-native event names to canonical
+phases (see [agent-support-matrix.md](../specs/agent-support-matrix.md) for the
+per-host table). The canonical phases are:
+
+- `phaseStart` — SessionStart
+- `phasePrompt` — UserPromptSubmit (the **only** reliable stdout channel for
+  whispers/system-reminders; PostToolUse stdout is discarded in Claude Code)
+- `phaseAfterTool` — PostToolUse (**primary capture trigger**)
+- `phaseCompact` — PreCompact
+- `phaseStop` — Stop (fires after every agent turn, not just session end)
+
+### IPC (CLI → daemon)
+
+One call only: `SessionFinalizeIPCPayload`. Fire-and-forget. Used at session stop to
+hand off cleanup context (session name, ledger path, cache path) so that if the CLI
+exits before it can fully publish, the daemon can pick up. See
+[ipc-architecture.md](../specs/ipc-architecture.md) for the general IPC model.
+
+### HTTP (CLI → LFS store)
+
+`internal/lfs/client.go` implements the LFS Batch API as an HTTP client. One POST to
+`/info/lfs/objects/batch`, N PUTs or GETs (up to 4 concurrent). Auth is Git PAT in
+`Authorization: Basic`. No OAuth required for LFS.
+
+### HTTP (CLI → git host)
+
+Standard `git push` / `git pull` over HTTPS using a PAT embedded in the remote URL.
+The daemon refreshes the PAT via `RefreshRemoteCredentials()`; the CLI reads whatever
+is on disk.
+
+### HTTP (CLI ↔ SageOx server)
+
+Two endpoints matter for sessions:
+
+- `POST /api/v1/repos/{repo_id}/sessions/{name}/summarize` — server-side summary
+  generation (optional path).
+- `GET /api/v1/repos/{repo_id}/sessions` — team-visible session listing, backed by
+  the same ledger `meta.json` files.
+
+OAuth bearer token. Optional — capture works without connectivity.
+
+---
+
+## 10. Evolution hooks
+
+Choices made to keep specific axes of change cheap.
+
+- **New agent hosts:** add a new `ox-adapter-<type>` binary. No ox changes.
+- **New entry types:** `type` is a string in the JSON; readers ignore unknown types
+  with a warn. `system-reminder` started as `user` and was promoted later with no
+  migration.
+- **New artifacts:** add a generator in `internal/session/` and a `ContentFiles` entry
+  in the upload pipeline. LFS is content-addressed, so new file names don't break
+  old sessions.
+- **New redaction patterns:** add to the manifest; bump schema version; re-sign.
+  Existing sessions record the old manifest hash, so readers can decide whether to
+  re-redact.
+- **New identity providers:** `internal/identity/` has a priority chain. Adding a new
+  provider means adding a new `Identity` variant and fitting it into `Resolve()`'s
+  ordering logic — no caller changes.
+
+---
+
+## 11. Anti-patterns that are actively guarded against
+
+These show up as comments, lint rules, or tests in the codebase:
+
+- Writing session data inside `projectRoot/sessions/` — caught by path-resolution
+  tests and a legacy-read-only rule. History: earlier ox versions did this and leaked
+  session bytes into users' source repos.
+- Shelling out to `git-lfs`, or writing `.gitattributes` with `filter=lfs` — caught
+  by `make check-no-git-lfs-shell`. See
+  [.claude/rules/lfs-no-git-lfs-binary.md](../../../.claude/rules/lfs-no-git-lfs-binary.md).
+- Reading pre-session entries from the adapter (entries before `StartedAt`) — the
+  timestamp filter in the pipeline catches these. A regression here would pollute
+  new sessions with stale conversation from before prime.
+- Using `os.Stat(".sageox/")` to decide initialization — use
+  `config.IsInitialized(gitRoot)`. An empty dir must be treated as broken, not
+  initialized. Same rule applies across the codebase, see top-level
+  [CLAUDE.md](../../../CLAUDE.md) §"Canonical Functions".
+- Discarding `.recording.json` on any error path — the file is the audit trail and is
+  explicitly preserved even when the session is otherwise abandoned, so that
+  `ox doctor` can diagnose later.
+
+---
+
+## 12. Reading plan for new contributors
+
+1. [session-capture-concepts.md](session-capture-concepts.md) — mental model.
+2. This document — map of components and why they're split.
+3. [session-capture-components.md](session-capture-components.md) — component
+   walkthroughs for the area you'll be touching.
+4. Spec files:
+   - [session-raw-jsonl.md](../specs/session-raw-jsonl.md)
+   - [session-summarization.md](../specs/session-summarization.md)
+   - [session-auth-model.md](../specs/session-auth-model.md)
+5. ADRs for the major load-bearing decisions:
+   - [adr-session-lfs-storage.md](../adr/adr-session-lfs-storage.md)
+   - [adr-ledger-architecture.md](../adr/adr-ledger-architecture.md)
+6. Source tour, in order: `internal/session/recording.go` →
+   `cmd/ox/agent_hook.go` → `internal/session/pipeline/` →
+   `cmd/ox/session_upload.go` → `internal/lfs/session_upload.go`.

--- a/docs/ai/architecture/session-capture-components.md
+++ b/docs/ai/architecture/session-capture-components.md
@@ -1,0 +1,498 @@
+<!-- doc-audience: ai -->
+# Session Capture — Component Walkthroughs
+
+> Audience: engineer onboarding onto a specific session-capture component. Each
+> section is a ~5-minute read and maps concepts from the
+> [architecture document](session-capture-architecture.md) to the files and types
+> that implement them. This is not a line-by-line tour — it is the minimum you need
+> to find your way and make non-breaking changes.
+
+**Conventions in this doc:**
+- Paths are relative to repo root.
+- `Type` references in the form `pkg.Type` point at a Go type in that package.
+- Non-obvious design choices are called out explicitly — most of the code is boring;
+  only the interesting bits are annotated.
+
+---
+
+## A. `internal/session/recording` — the lifecycle core
+
+**Purpose:** own the `.recording.json` state file and the StartRecording/StopRecording
+verbs. Every other component defers to this one for "is there a recording?" and
+"where does it live?"
+
+**Key files:**
+- [recording.go](../../../internal/session/recording.go) — state struct, start/stop,
+  path resolution.
+- [recording_helpers_test.go](../../../internal/session/recording_helpers_test.go) —
+  fixture helpers used widely across tests.
+- [recording_ghost_grace_test.go](../../../internal/session/recording_ghost_grace_test.go) —
+  spec of the 10-minute grace period.
+- [recording_concurrency_test.go](../../../internal/session/recording_concurrency_test.go) —
+  spec of multi-agent isolation.
+
+**Types & functions:**
+- `session.RecordingState` — the on-disk schema. All fields have `json:` tags; new
+  fields must be `omitempty` to stay backwards-compatible with older recordings.
+- `StartRecording(projectRoot, opts) (*RecordingState, error)` — the *only* function
+  that may write a recording. Resolves the canonical write path via
+  `resolveSessionsWritePath` (never via the search path ladder). Writes
+  `raw.jsonl` header and `.recording.json`.
+- `StopRecording(projectRoot, agentID) error` — marks `StoppedAt`, triggers the final
+  drain + artifact write via `artifacts.WriteSessionArtifacts`.
+- `LoadRecordingStateForAgent(projectRoot, agentID)` — returns the specific agent's
+  state. **Prefer over `LoadRecordingState`** when an agent ID is known; workspace
+  fallback picks arbitrarily across worktrees.
+- `LoadAllRecordingStates(projectRoot)` — iterates the search path, deduplicates by
+  canonical symlink resolution, returns all active recordings.
+- `CleanupGhostSessionsInDir(dir)` — called at hook time; respects
+  `GhostGracePeriod = 10*time.Minute`.
+
+**Non-obvious design choices:**
+1. **Search path is read-only.** The constant bug source historically has been writes
+   that iterate the search path and land in a wrong directory. Keep
+   `sessionsSearchPaths` strictly for reads.
+2. **Symlink resolution before comparison.** macOS `/tmp` is a symlink to
+   `/private/tmp`; without resolution a session started under one path and found
+   under the other is treated as two sessions.
+3. **`LastHookStatus` is a stable enum string** (e.g. `ok`, `session-file-not-found`,
+   `read-error`). It is the contract for `ox session status` and `ox doctor`; do not
+   rename existing values.
+
+**To change this component safely:**
+- Adding a state field: add with `omitempty`; do not require it in
+  `LoadRecordingState`'s validation.
+- Adding a new terminal state: add to the transition enum and map it through
+  `stopSessionForClear`/`StopRecording`; update `recording_ghost_grace_test.go`.
+- Tests must use `t.TempDir()` + explicit `projectRoot`; never `cwd` fallbacks.
+
+---
+
+## B. `cmd/ox/agent_hook` — the edge handler
+
+**Purpose:** the `ox agent hook <event>` command, called by Claude Code and other
+agent hosts on lifecycle events. Dispatches to phase handlers that read/write
+recording state.
+
+**Key files:**
+- [agent_hook.go](../../../cmd/ox/agent_hook.go) — phase dispatch and handlers.
+- [agent_hooks.go](../../../cmd/ox/agent_hooks.go) — wiring and event → phase map.
+- [agent_hook_banner_test.go](../../../cmd/ox/agent_hook_banner_test.go),
+  [agent_hook_stop_test.go](../../../cmd/ox/agent_hook_stop_test.go) — behavior tests.
+
+**Phases (canonical names):**
+| Phase | Trigger | What it does |
+|---|---|---|
+| `phaseStart` | `SessionStart` | Prime, StartRecording if none, heartbeat |
+| `phasePrompt` | `UserPromptSubmit` | Deliver whispers via stdout (ONLY reliable stdout channel) |
+| `phaseAfterTool` | `PostToolUse` | **Incremental drain** — tail source JSONL, append redacted entries |
+| `phaseCompact` | `PreCompact` | `stopSessionForClear` → IPC to daemon |
+| `phaseStop` | `Stop` | Every agent turn end; used for heartbeat, NOT session end |
+
+**Critical gotcha:** Claude Code *discards* PostToolUse stdout. Anything printed from
+a hook handler other than `phasePrompt` is invisible to the model. This is why
+whispers are delivered in `handlePrompt` and capture is not.
+
+**Non-obvious design choices:**
+1. `handleAfterTool` is the innermost loop — every microsecond here multiplies by
+   tool count. Tail read + classify + redact + append runs in the same process as
+   the hook; no IPC.
+2. `deriveLedgerPath(sessionPath)` is used to construct the IPC payload at compact
+   time. The session path format is stable, so we can derive `<ledger-root>` by
+   trimming.
+3. `handleStart` is idempotent — re-running `ox agent prime` on the same host does
+   not start a second session. The dedup key is `AgentID`.
+
+**To extend:**
+- New host event → canonical phase: update `agentx.BuildEventPhaseMap` (in the
+  `github.com/sageox/agentx` module).
+- New phase semantics: add handler + dispatch entry. Do not reuse existing phase
+  names.
+
+---
+
+## C. `internal/session/adapters` + `cmd/ox-adapter-*` — agent host abstraction
+
+**Purpose:** isolate per-host knowledge (session file location, JSONL dialect,
+entry field names) behind a small interface. External-binary model so bugs and
+releases are isolated from ox.
+
+**Key files:**
+- [internal/session/adapters/adapter.go](../../../internal/session/adapters/adapter.go) —
+  interface definitions and `SessionLookup`.
+- [internal/session/adapters/external.go](../../../internal/session/adapters/external.go) —
+  subprocess wire protocol.
+- [internal/adapterprotocol/](../../../internal/adapterprotocol/) — protocol types
+  shared by ox and adapters.
+- `cmd/ox-adapter-claude-code`, `cmd/ox-adapter-codex`, … — adapter binaries. Each is
+  its own `main` package.
+
+**Interface:**
+```go
+type Adapter interface {
+    Name() string
+    Capabilities() []Capability
+    Detect(context.Context) (bool, *Metadata, error)
+    FindSessionFile(SessionLookup) string
+    ReadMetadata(path string) *SessionMetadata
+}
+type IncrementalReader interface {
+    ReadFromOffset(path string, offset int64) ([]RawEntry, int64, error)
+}
+type CapturePriorCapable interface {
+    CapturePrior(SessionLookup) (*CapturePriorResult, error)
+}
+```
+
+**Non-obvious design choices:**
+1. **Capability flags, not type assertions on caller.** `adapter.HasCapability(...)`
+   keeps ox's caller code uniform and lets adapters opt in to advanced features.
+2. **`SessionLookup.Since`** lets ox ask "find session files newer than X" so that
+   stale or unrelated JSONL files in `~/.claude/` don't get picked.
+3. **Adapters register at runtime** via `adapters.RegisterExternalAdapters()`, which
+   scans `PATH` for `ox-adapter-*` binaries. Users without an adapter installed get
+   a clean `LastHookStatus = adapter-not-found`, not a panic.
+
+**To add an agent host:**
+1. Implement a binary under `cmd/ox-adapter-<type>/`.
+2. Honor `ox-adapter <type> detect | find-session-file | read-from-offset | …`
+   subcommands per `internal/adapterprotocol/`.
+3. Add a row to [agent-support-matrix.md](../specs/agent-support-matrix.md).
+4. Tests live in `internal/session/adapters/adapters_<type>_test.go` using a fake
+   session file.
+
+---
+
+## D. `internal/session/pipeline` + supporting utilities — the drain loop
+
+**Purpose:** transform raw bytes from the adapter into redacted `raw.jsonl` entries,
+and maintain the offset/counter state.
+
+**Key files:**
+- [internal/session/pipeline/](../../../internal/session/pipeline/) — the
+  composable drain pipeline.
+- [classify.go](../../../internal/session/classify.go) — entry type classification
+  (user/assistant/system/tool).
+- [filter.go](../../../internal/session/filter.go) — pre-session timestamp filter
+  and tool-spam filters for summarization (NOT for raw).
+- [entry.go](../../../internal/session/entry.go) — `SessionEntry`, `seq`/`eid`
+  assignment.
+- [redact_rules.go](../../../internal/session/redact_rules.go) — literal/regex
+  redaction rules; sources: builtin, team, repo, user.
+- [secrets.go](../../../internal/session/secrets.go) — the regex set for cloud keys,
+  JWTs, DB strings, etc.
+- [manifest.go](../../../internal/session/manifest.go) — canonical JSON serialization
+  + `Hash()`.
+- [signing.go](../../../internal/session/signing.go) — Ed25519 signing integration.
+
+**Pipeline stages (in order):**
+1. `adapter.ReadFromOffset` — bytes → `[]RawEntry`.
+2. Classify — fill `type` if missing; promote `<system-reminder>` content to
+   `type=system`.
+3. Timestamp filter — drop entries with `ts < StartedAt`.
+4. Redact — apply builtin manifest + custom rules; replace with
+   `[REDACTED:pattern_name]`.
+5. Assign `seq` (sequential) and `eid` (5-char random).
+6. Append line to `raw.jsonl`.
+7. Advance `SourceOffset` + `EntryCount` in `.recording.json`.
+
+**Non-obvious design choices:**
+1. **Raw gets everything (except secrets).** The summarization-side filter
+   (`FilterForSummarization`) lives in the *derivation* path, not here. A noisy
+   session is still a complete session.
+2. **Classification before redaction.** The redactor wants to know which fields to
+   scan — a `tool` entry has structured `tool_input`/`tool_output`; a `user` entry
+   is free-form.
+3. **`eid` is assigned at append, not at emit.** An adapter that re-emits an entry
+   (e.g. because the agent rewrote its own JSONL) gets a new `eid`. Downstream
+   dedupers can drop by content hash if needed.
+4. **Redaction manifest is signed.** `signing.RegisterArtifact("redaction",
+   generateRedactionManifest)` hooks the manifest into the Ed25519 signing path.
+   Session headers record the manifest hash so readers can verify.
+
+**To change:**
+- Adding a redaction rule: extend builtin rules in `secrets.go`, then
+  `make generate-manifest`. Sessions recorded before the change will still pass
+  verification because they reference the old hash.
+- Adding an entry type: update `classify.go`; readers of raw already ignore unknown
+  types with a warn.
+
+---
+
+## E. `internal/session/artifacts` + markdown/summarize — derivation
+
+**Purpose:** turn `raw.jsonl` into human-readable artifacts at finalize.
+
+**Key files:**
+- [artifacts.go](../../../internal/session/artifacts.go) —
+  `WriteSessionArtifacts(sessionPath)` is the orchestrator.
+- [enrich.go](../../../internal/session/enrich.go) — add computed fields
+  (`files_changed`, `chapters`) to `summary.json`.
+- [markdown.go](../../../internal/session/markdown.go) —
+  `MarkdownGenerator` renders full session.md.
+- [summary_md.go](../../../internal/session/summary_md.go) —
+  `SummaryMarkdownGenerator` renders summary.md.
+- [summarize.go](../../../internal/session/summarize.go) — shared prompt (via
+  `pkg/sessionsummary`), three execution paths.
+- [plan_extract.go](../../../internal/session/plan_extract.go) — plan priority
+  ladder.
+- [mermaid.go](../../../internal/session/mermaid.go) — extract Mermaid diagrams
+  from entries.
+
+**Summarization paths** (see [session-summarization.md](../specs/session-summarization.md)):
+1. **Server-side API** — network call to SageOx server, full LLM.
+2. **Client-side prompt embed** — prompt is baked into `raw.jsonl` for the agent to
+   summarize before stop (used when offline).
+3. **Resummary CLI** — `ox session resummary` prints prompt + raw to stdout so the
+   user can pipe into any LLM. No auto-exec — keeps the user in control.
+
+**Plan extraction priority ladder:**
+1. Entries with `is_plan: true` metadata.
+2. Entries with `## Final Plan` header.
+3. Entries with `## Implementation Plan` header.
+4. Entries with `## Plan` header.
+5. Last assistant message.
+
+**Non-obvious design choices:**
+1. **Artifacts are fully re-derivable.** `ox session regenerate` blows them away and
+   rebuilds from raw. Hence no migration logic on artifact format changes — just
+   re-regen.
+2. **`summary.json` has a validation step** (`validate.go`) — otherwise agents
+   occasionally echo meta-commentary into the summary, which breaks distillation.
+3. **Mermaid extraction is opportunistic.** Any ```mermaid fence is lifted into
+   `summary.md`'s diagrams section, regardless of whether the agent intended it to
+   be shown.
+
+**To add an artifact:**
+- Write a generator function that takes `sessionPath` and returns either bytes or
+  writes to a file.
+- Call from `WriteSessionArtifacts`.
+- Add the filename to `ContentFiles` in `cmd/ox/session_upload.go` so it uploads to
+  LFS.
+
+---
+
+## F. `internal/session/contexttrace` — provenance audit log
+
+**Purpose:** record which team-context snippets were made available to the agent and
+which the agent attributed a decision to. Distinct from `raw.jsonl` — it's a *peer*
+file, not nested.
+
+**Key files:**
+- [contexttrace/contexttrace.go](../../../internal/session/contexttrace/contexttrace.go) —
+  `Writer`, `EventType`, `SourceType`.
+- [cmd/ox/agent_prime_context_trace.go](../../../cmd/ox/agent_prime_context_trace.go) —
+  emits `provided` events during prime.
+- [cmd/ox/agent_session_context_trace.go](../../../cmd/ox/agent_session_context_trace.go) —
+  agent-invoked endpoint for `influenced` events.
+
+**Event types:**
+- `EventProvided` — ox injected this context (at prime time, mainly).
+- `EventInfluenced` — the agent says a decision was driven by this context; carries
+  the `eid` of the raw entry expressing the decision.
+
+**Source types:** `team-context`, `team-memory`, `team-docs`, `project-config`,
+`team-whisper`, `project-whisper`, `on-demand`.
+
+**Non-obvious design choices:**
+1. **`eid` is the stable join key** between raw entries and influenced events. Do
+   not use `seq` — `seq` changes if raw is ever re-normalized.
+2. **Provided events are written once at prime.** Later injections (on-demand tool
+   `ox agent team-ctx <slug>`) emit their own Provided events on invocation.
+3. **Trace is optional.** A session without `context-trace.jsonl` is valid; readers
+   must tolerate absence.
+
+---
+
+## G. `internal/agentinstance` — identity and lifetimes
+
+**Purpose:** allocate and persist Agent IDs (`OxSk2e`) and track the metadata for
+each agent instance across hook invocations.
+
+**Key files:**
+- [internal/agentinstance/agentid.go](../../../internal/agentinstance/agentid.go) —
+  ID generation (62⁴ space).
+- [internal/agentinstance/store.go](../../../internal/agentinstance/store.go) —
+  per-user JSONL append-only store.
+
+**Schema:**
+```go
+type Instance struct {
+    AgentID         string    // "Oxabcd"
+    ServerSessionID string    // full oxsid_… from server
+    CreatedAt       time.Time
+    ExpiresAt       time.Time
+    AgentType       string
+    AgentVer        string
+    Model           string
+    ParentPID       int
+    ParentAgentID   string
+    PrimeCallCount  int
+}
+```
+
+**Storage:** `~/.sageox/agent_instances/<user-slug>/agent_instances.jsonl`.
+Append-only, newest-first scan. 500-instance hard cap.
+
+**Non-obvious design choices:**
+1. **No registry of "current" instance.** Callers pass the AgentID in via env var
+   (`SAGEOX_AGENT_ID`) or CLI arg. There is no global "who am I" state.
+2. **Per-user slug in path** lets multi-user machines coexist without locking.
+3. **Hard cap with eviction** prevents runaway growth if sessions aren't reaped.
+
+---
+
+## H. `internal/lfs` — pure-Go LFS client
+
+**Purpose:** upload/download session blobs via the Git LFS Batch API over plain
+HTTPS. No `git-lfs` binary ever.
+
+**Key files:**
+- [internal/lfs/client.go](../../../internal/lfs/client.go) — Batch API client.
+- [internal/lfs/transfer.go](../../../internal/lfs/transfer.go) — upload/download
+  flows with concurrency.
+- [internal/lfs/session_upload.go](../../../internal/lfs/session_upload.go) —
+  session-specific orchestration.
+- [internal/lfs/pointer.go](../../../internal/lfs/pointer.go) — pointer I/O (used for
+  parsing historical pointers, not writing new ones).
+- [internal/lfs/meta.go](../../../internal/lfs/meta.go) — `SessionMeta`, `FileRef`,
+  `HydrationStatus`.
+
+**Key types:**
+- `SessionMeta` — built via builder: `NewSessionMeta(...).Title(...).Build()`. The
+  `files: {name -> FileRef}` map is the git-tracked manifest that replaces LFS
+  pointer files.
+- `FileRef{OID, Size}` — OID is `sha256:<hex>`.
+- `Client` — `NewClient(repoURL, user, token)`; `Batch(ctx, op, objects)`.
+
+**Non-obvious design choices:**
+1. **No pointer files, ever.** `WritePointerFile` is public but unused by the
+   session path; historical callers are being removed.
+2. **Up to 4 concurrent uploads.** Empirically the sweet spot for both GitHub and
+   GitLab; higher triggers throttling on smaller projects.
+3. **OID is the canonical filename in LFS.** Re-uploading a file produces the same
+   OID; idempotent by construction.
+4. **Hard rule: no `.gitattributes` with `filter=lfs`.** Enforced by
+   `make check-no-git-lfs-shell`. See
+   [.claude/rules/lfs-no-git-lfs-binary.md](../../../.claude/rules/lfs-no-git-lfs-binary.md).
+
+**To debug upload failures:** the GitLab error `LFS objects are missing` is a *false
+trail* — the fix is never `git lfs push --all`. See the rule file; the real fix is
+"find the pointer file that references an un-uploaded OID and upload it via
+`internal/lfs/client.go`."
+
+---
+
+## I. `internal/ledger` — sidecar repo
+
+**Purpose:** own the lifecycle of the per-project ledger git repository: clone it,
+push to it, push GitHub data. Session capture is one of several consumers.
+
+**Key files:**
+- [internal/ledger/ledger.go](../../../internal/ledger/ledger.go) — `Ledger` type,
+  `Open`, `Init`, `Exists`.
+- [internal/ledger/github_push.go](../../../internal/ledger/github_push.go) — the
+  `git add --sparse / commit / push` used by session upload.
+
+**Layout (relative to ledger repo root):**
+```
+sessions/<name>/meta.json          # committed
+sessions/<name>/[other files]      # .gitignore'd
+.sageox/cache/sessions/<name>/     # local-only, never committed
+data/, memory/, docs/              # team context (separate subsystem)
+.gitignore, .gitattributes         # .gitattributes never has filter=lfs
+```
+
+**Non-obvious design choices:**
+1. **Cloud-provisioned, never locally initialized.** `ledger.Init` clones from a
+   remote URL returned by the SageOx API; no `git init`.
+2. **Sparse checkout is default.** `git add --sparse` is mandatory (git ≥ 2.37).
+3. **Retry 3x on push.** Push failures beyond that are reported but not fatal to
+   the session — the raw file stays local and `ox session push <name>` can retry.
+
+---
+
+## J. `cmd/ox/session_*` — user-facing CLI surface
+
+**Purpose:** the commands users and agents invoke to manage sessions.
+
+**Command groups:**
+
+| Group | Commands | Notes |
+|---|---|---|
+| Lifecycle | `start`, `stop`, `force-stop`, `abort`, `recover` | `start`/`stop` are rarely typed by hand — hooks drive them |
+| Inspection | `list`, `show`, `view`, `status`, `url` | `view --text` renders locally if hydrated |
+| Derivation | `regenerate`, `resummary`, `resummary-batch` | Idempotent re-runs |
+| Distribution | `upload`, `push-summary`, `hydrate`, `migrate-lfs` | Upload is auto after stop; hydrate is on-demand |
+| Subagent hooks | `agent-session subagent`, `plan-history`, `capture-prior`, `context-trace`, `incremental` | Used by the agent itself, not humans |
+| Ops | `lint`, `validate`, `commit`, `remove`, `export`, `score` | Doctor integration + housekeeping |
+
+**Key files to start from:**
+- [session.go](../../../cmd/ox/session.go) — cobra tree root.
+- [session_start.go](../../../cmd/ox/session_start.go) — creates recording (usually
+  called from `handleStart` in the hook, not by hand).
+- [session_stop.go](../../../cmd/ox/session_stop.go) — the full finalize pipeline
+  including `WriteSessionArtifacts`, LFS upload, ledger push.
+- [session_upload.go](../../../cmd/ox/session_upload.go) — upload pipeline that
+  `stop` uses; can be re-invoked independently.
+- [agent_session.go](../../../cmd/ox/agent_session.go) — the `ox agent <id> session
+  …` namespace used by agents (capture-prior, subagent, context-trace).
+
+**Non-obvious design choices:**
+1. **Most "session" commands are safe to run on an already-published session.** They
+   re-derive artifacts or re-upload. The one that isn't is `abort` — it deletes.
+2. **`doctor session`** has a dedicated family (see `cmd/ox/doctor_session*.go`) for
+   finding incomplete, uncommitted, or failed-upload sessions. This is the primary
+   recovery surface.
+
+---
+
+## K. `cmd/ox/distill*` — downstream consumer
+
+**Purpose:** scan finalized sessions and extract structured facts for team memory.
+Not part of capture proper, but reads the same `summary.json` the capture pipeline
+produces.
+
+**Key files:**
+- [cmd/ox/distill.go](../../../cmd/ox/distill.go), [distill_sessions.go](../../../cmd/ox/distill_sessions.go) —
+  CLI entry.
+- [internal/distill/](../../../internal/distill/) — pipeline.
+
+**Contract with capture:** distillation reads `summary.json` via the Store interface.
+Anything that changes `summary.json`'s schema must update the distill consumer
+(`pkg/facts/`) in the same PR.
+
+**Non-obvious:** minimum-quality gate (`minSessionQuality = 0.2`) drops noisy
+sessions from distillation. A session can be published but not distilled.
+
+---
+
+## L. Test patterns worth knowing
+
+- **`t.TempDir()` + explicit `projectRoot`.** Never rely on cwd. Session tests that
+  don't pass an explicit repo root expose the `projectRoot/sessions/` leak bug.
+- **`cmd.Dir = tmpDir` for git ops.** Tests must never touch the real repo's git
+  config; see [.claude/rules/daemon-git.md](../../../.claude/rules/daemon-git.md).
+- **Table-driven for classify/redact/filter.** They take string input and produce
+  string output; table-driven is idiomatic and catches edge cases cheaply.
+- **Ghost grace & concurrency have dedicated tests.** When touching recording state,
+  extend `recording_ghost_grace_test.go` and `recording_concurrency_test.go`.
+- **Integration test** lives at
+  [internal/session/integration_test.go](../../../internal/session/integration_test.go) —
+  end-to-end StartRecording → drain → StopRecording → artifact shape. The slowest
+  but most load-bearing test; keep it green.
+
+---
+
+## M. Where to ask for help
+
+- **Recording state, lifecycle questions:** load the `tooling-engineer` coworker —
+  `ox coworker load tooling-engineer`.
+- **Adapter behavior, agent host quirks:** load `agent-ux`.
+- **LFS and git ops safety:** load `code-reviewer`.
+- **Go idioms and daemon concurrency:** load `go-pro`.
+- **Test design for new behavior:** load `test-architect`.
+
+Prior sessions often cover regressions in this area. Use `ox session list` with
+filters and `ox query "<question>"` to find teammate context before touching
+capture paths.

--- a/docs/ai/architecture/session-capture-concepts.md
+++ b/docs/ai/architecture/session-capture-concepts.md
@@ -1,0 +1,413 @@
+<!-- doc-audience: ai -->
+# Session Capture — Conceptual Model
+
+> Audience: a principal engineer with systems/DB/compiler background, new to LLM agent
+> tooling. This document builds the mental model. It defines the *nouns* of the system,
+> the constraints on them, and how features interact. It does not explain how the code
+> is organized — that's [session-capture-architecture.md](session-capture-architecture.md).
+
+---
+
+## 1. What problem is being solved?
+
+An **AI coworker** (e.g. Claude Code, Cursor, Codex, Aider) drives a terminal session: it
+reads files, runs tools, and iterates with a human. That process produces a rich,
+short-lived artifact — the *conversation* — which today is trapped inside the agent's
+local memory and then discarded when context resets. Teammates cannot see it; the same
+agent rediscovers the same context tomorrow from scratch.
+
+ox's session capture subsystem treats each of these conversations as a first-class,
+**durable, queryable, shareable, LFS-backed object** — like a git commit for
+agent-human collaboration. A session is captured incrementally while it is happening,
+finalized into derived artifacts on close, and published via a per-project sidecar git
+repository (the *ledger*) so every teammate and every future agent can read it.
+
+The design is dominated by one invariant: **the AI agent is the source of truth we are
+recording, not a system we control.** ox is an observer. It cannot modify Claude Code's
+data model, and must tolerate the agent crashing, being killed, entering `/clear`, or
+silently rotating its internal session file.
+
+---
+
+## 2. Core nouns
+
+Twelve concepts cover the entire surface. Everything in the codebase is expressible in
+terms of these.
+
+| Concept | One-line definition |
+|---|---|
+| **Coworker** | Any participant, human or AI, on a team. |
+| **Agent host** | The coding-agent process we observe (Claude Code, Codex, …). |
+| **Agent instance** | One lifetime of one agent host on one machine for one human. Identified by an **Agent ID** (`Ox` + 4 chars, e.g. `OxSk2e`). |
+| **Session** | A recording of one coherent span of agent-host work, from prime through stop/clear. Named `YYYY-MM-DDTHH-MM-<user>-<agentID>`. |
+| **Adapter** | A pluggable module that knows a specific agent host's session file format and lifecycle hooks. One adapter per agent type. |
+| **Recording state** | In-progress per-session bookkeeping (`.recording.json`) that tracks where we are in the agent's source JSONL and whether the host is alive. |
+| **Raw JSONL** | The complete, unfiltered conversation stream (`raw.jsonl`) — header + entries + footer. The source of truth for all derived artifacts. |
+| **Artifacts** | Derived, human-readable outputs generated from raw JSONL: `summary.json`, `summary.md`, `session.md`, `plan.md`, `context-trace.jsonl`. |
+| **Ledger** | A per-repo sidecar git repository that stores sessions, team context, memory, and cache. Cloud-provisioned; never created locally. |
+| **LFS manifest** (`meta.json`) | A small, git-tracked JSON file listing the OIDs + sizes of large session content stored out-of-band. Replaces git-lfs pointer files. |
+| **Hydration** | The act of fetching the out-of-band LFS content for a session on demand. A session is *hydrated* when its blobs are locally cached, *dehydrated* when only `meta.json` is present. |
+| **Context trace** | A parallel JSONL log of *which* team-context snippets were provided to the agent and *which* the agent said influenced a decision. Audit trail for SageOx attribution. |
+
+### Orthogonal axes
+
+These concepts are deliberately orthogonal; most features live at their intersection:
+
+- **Agent type ⊥ session lifecycle.** The adapter layer absorbs per-host quirks so the
+  recording, artifact, and ledger layers are agent-agnostic.
+- **Capture ⊥ finalization ⊥ distribution.** Capture produces `raw.jsonl`. Finalization
+  produces artifacts. Distribution uploads to LFS + commits `meta.json`. Each phase can
+  fail, retry, and be re-run independently. Losing the last phase never loses raw data.
+- **Local content ⊥ git-tracked metadata.** Content files (`raw.jsonl`, `session.md`,
+  …) live only in local cache + LFS blob store. Only `meta.json` is committed. This is
+  what makes sessions both durable-for-the-team and cheap-to-sync.
+- **Session-level isolation ⊥ multi-agent concurrency.** Each agent instance has its
+  own `.recording.json` in its own session folder. Two Claude Code processes in the
+  same repo do not collide; their recordings are keyed by Agent ID.
+
+---
+
+## 3. The session lifecycle
+
+A session passes through well-defined phases. Each transition is observable on disk.
+
+```
+  ┌─────────┐   prime   ┌────────┐  hook(afterTool)  ┌──────────┐
+  │ absent  │──────────▶│ primed │──────────────────▶│ recording│
+  └─────────┘           └────────┘                   └──────────┘
+                                                           │
+                  ┌────────────────────────────────────────┤
+                  │          │              │              │
+               stop        /clear         crash         abort
+                  │          │              │              │
+                  ▼          ▼              ▼              ▼
+            ┌──────────┐ ┌─────────┐  ┌─────────┐   ┌──────────┐
+            │ stopped  │ │stopped  │  │ ghost   │   │ discarded│
+            │(explicit)│ │(compact)│  │(stale)  │   │          │
+            └────┬─────┘ └────┬────┘  └────┬────┘   └──────────┘
+                 │            │            │
+                 └────────────┴────────────┘
+                              │
+                              ▼
+                       ┌──────────────┐
+                       │  finalized   │  (artifacts generated)
+                       └──────┬───────┘
+                              │ commit meta.json + LFS upload
+                              ▼
+                       ┌──────────────┐
+                       │  published   │  (visible team-wide)
+                       └──────────────┘
+```
+
+### Why four terminal transitions?
+
+- **stop (explicit):** the user ran `/ox-session-stop`. The agent host is still alive.
+- **stop (compact):** the agent host entered `/clear` or `/compact`. The host *reuses*
+  the process but discards its context; we must finalize and let the next prime begin a
+  fresh session.
+- **ghost:** the agent host died without stopping — common for SIGINT, terminal close,
+  or crashes. Detected later by a parent-PID liveness check, guarded by a 10-minute
+  grace period to avoid racing with still-starting agents.
+- **abort:** the user explicitly discards the session (corrupted, sensitive, …).
+
+All non-abort terminals converge on the same *finalized* and *published* steps, because
+what makes a session valuable — derived artifacts and team visibility — is independent
+of how it ended.
+
+---
+
+## 4. Capture model: incremental, observer-driven
+
+The single most important design decision in session capture is **how raw JSONL gets
+populated**. The choices in the design space:
+
+| Approach | Rejected / accepted | Why |
+|---|---|---|
+| Proxy the agent host's stdio | Rejected | Requires wrapping the process; fragile; doesn't work for sub-agents. |
+| Poll the agent's session file on a timer | Rejected | Latency/waste tradeoff; misses crashes. |
+| Ask the agent to push via API | Rejected | No such API across agents. |
+| **Hook-driven incremental tail** | **Accepted** | Works with any agent that exposes lifecycle hooks; zero dependency at runtime on ox being reachable. |
+
+ox registers as a *hook handler* on the agent host (e.g. Claude Code calls
+`ox agent hook <event>` at `SessionStart`, `UserPromptSubmit`, `PostToolUse`,
+`PreCompact`, `Stop`). On each invocation — primarily `PostToolUse` — ox:
+
+1. Loads `.recording.json` for this Agent ID.
+2. Opens the agent's native session file (e.g. Claude Code's `~/.claude/.../*.jsonl`).
+3. Reads from the last recorded byte offset (`SourceOffset`) to EOF.
+4. Applies entry classification, timestamp filtering, and secret redaction.
+5. Appends the redacted entries to `raw.jsonl`.
+6. Persists the new offset, entry count, hook status.
+
+This yields three important properties:
+
+- **Tailing is stateless across hook invocations.** If a hook invocation fails
+  (adapter missing, session file not found, permission error), only that invocation is
+  lost; the next hook picks up from the saved offset.
+- **Hook arrival is itself the heartbeat.** `LastHookAt` is updated on every hook, so
+  `ox session status` can distinguish "recording idle" from "recording broken."
+- **Secrets never hit disk unredacted.** Redaction runs *before* append, not on
+  finalize. The `manifest.go` pattern set is signed (Ed25519) so a tampered rule file
+  cannot silently exfiltrate.
+
+### What is in raw.jsonl
+
+```
+line 1:    {"type":"header","metadata":{agent_id, agent_type, model, user, repo_id,…}}
+lines 2-N: {"type":"user|assistant|system|tool","content":…,"timestamp":…,"seq":N,"eid":…}
+last:      {"type":"footer","closed_at":…,"entry_count":N}
+```
+
+The `eid` (entry ID, 5-char) is a stable key for cross-referencing from derived
+artifacts — if `summary.md` quotes a decision, it can point at a specific `eid` that
+still resolves after re-summarization.
+
+---
+
+## 5. Finalization and artifact derivation
+
+When a session terminates (any non-abort path), it is *finalized*:
+
+1. One final drain from the agent's source JSONL (capture-complete guarantee).
+2. Write footer line to `raw.jsonl`.
+3. Generate `summary.json` (LLM-backed if connected, stats-only locally otherwise).
+4. Generate `summary.md` (structured markdown: title, executive summary, key actions,
+   Mermaid diagrams, final plan, file modifications, topics).
+5. Generate `session.md` (full transcript with collapsible tool-output blocks).
+6. Optionally extract `plan.md` (markdown-aware priority ladder: `is_plan:true` →
+   `## Final Plan` → `## Implementation Plan` → last assistant message).
+7. Optionally emit `context-trace.jsonl` (what context was provided/influenced).
+
+Artifacts are *always re-derivable from raw*. `ox session regenerate` and
+`ox session resummary` exploit this — the raw file is immutable, artifacts are not.
+
+---
+
+## 6. Distribution model: LFS without git-lfs
+
+Sessions are distributed through the project's **ledger** — a sidecar git repository,
+not the user's source repo. The ledger avoids two bad outcomes: polluting the source
+repo with many binary-heavy files, and coupling session rights to source-repo rights.
+
+A session ships in two pieces:
+
+- **Small piece (`meta.json`, ~1 KB):** committed into the ledger git tree. Contains
+  session metadata and a `files: {name -> {oid, size}}` map. This is what teammates
+  receive on `git pull`.
+- **Large pieces (`raw.jsonl`, `session.md`, `summary.md`, …):** uploaded to the git
+  host's LFS blob store via the pure-Go LFS Batch client (`internal/lfs/client.go`). The
+  content files are `.gitignore`d in the ledger working tree — they never get tracked.
+
+**ox never shells out to `git-lfs`** and never writes `.gitattributes` with
+`filter=lfs`. The consequence is that dehydrated sessions stay dehydrated: a
+`git checkout` in the ledger doesn't trigger a smudge filter, so teammates don't
+accidentally download 500 MB of session bodies just by pulling. Hydration is explicit
+(`ox session hydrate` or the viewer on sageox.ai).
+
+### Why this split matters for the mental model
+
+- Dehydrated sessions are *index entries.* `ox session list` works on any machine with
+  the ledger pulled, even if no content was downloaded.
+- `meta.json` is the **commit-level** object. The LFS blobs are *referenced* but not
+  *required to be present* for the ledger to be consistent.
+- A session cannot be "partially committed." The CLI does
+  upload-to-LFS → commit `meta.json` → push. If LFS upload fails, no commit; if push
+  fails, commit stays local, retried next upload. There is no state where meta is
+  committed but content OIDs don't resolve.
+
+---
+
+## 7. Identity, attribution, and redaction
+
+Two orthogonal concerns that coexist in every published session.
+
+**Identity** resolves "who is this human?" via a priority chain:
+
+1. SageOx OAuth (verified).
+2. Git host identity (GitHub/GitLab/Bitbucket/AWS/GCP), but only for the provider
+   actually matching the repo's remote.
+3. Git config `user.name` / `user.email` (unverified, declarative).
+
+The highest-priority identity becomes `username` in the JSONL header and attribution
+display. Critically, **session start is not OAuth-gated** — a session can always record
+locally, and is published under whatever identity is available at finalization. This is
+the "capture first, authenticate later" invariant.
+
+**Redaction** is defensive: the input stream is untrusted.
+
+- A built-in regex manifest covers AWS/GCP/Azure keys, JWTs, API tokens, DB strings,
+  private keys, `key=value` heuristics.
+- Team and repo can add `REDACT.md` rules (literal or regex) that apply on top.
+- The manifest JSON is Ed25519-signed. A session header records the manifest hash; a
+  viewer can refuse to display sessions whose manifest hash isn't trusted.
+- Redaction runs *before* `raw.jsonl` append. Secrets cannot appear in `raw.jsonl`
+  even if capture crashes mid-stream.
+
+---
+
+## 8. Concurrency and isolation
+
+Multiple Claude Code processes may run at once — same repo, different worktrees,
+nested sub-agents, parallel terminals. The invariants:
+
+- **Session identity = Agent ID.** Each agent instance has its own 4-char suffix; two
+  hosts will not generate the same one (62⁴ ≈ 14.7M, capped at 500 live instances per
+  user).
+- **Recording state is per-session.** `.recording.json` lives *inside* the session
+  folder, not in a shared registry. No locking needed; each writer is the only writer.
+- **Ledger writes are per-session paths.** Session folder names include timestamp +
+  user + agent ID, so path collisions are astronomically unlikely; the CLI does a
+  simple retry-on-push if it happens.
+- **Daemon owns reads, CLI owns writes** (see
+  [.claude/rules/daemon-git.md](../../../.claude/rules/daemon-git.md)). The daemon
+  pulls the ledger on a timer; the CLI does `git add --sparse / commit / push` at
+  finalization. This removes the need for the CLI to coordinate with the daemon on
+  push, which is a common source of deadlocks in daemon-based designs.
+
+### Parent/child sessions
+
+Sub-agents (e.g. Claude Code's Agent tool launching a sub-task) produce their own
+sessions with `origin="subagent"` and `ParentSessionPath` / `ParentAgentID` set. The
+parent's aggregation pulls them in at finalization. Each child is independently
+recoverable.
+
+### Ghost sessions and grace
+
+A "ghost" is a session whose parent PID is dead. Ghost cleanup:
+
+- Skips any recording younger than `GhostGracePeriod` (10 min) to avoid killing an
+  agent whose PID tree is still being set up.
+- Resolves symlinks before comparing paths (macOS `/tmp` → `/private/tmp` trap).
+- Removes only the recording state, not the raw content — the raw file can still be
+  finalized manually via `ox session recover <name>`.
+
+---
+
+## 9. End-to-end sequence diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as Human
+    participant CC as Claude Code
+    participant OX as ox CLI (hook)
+    participant AD as Adapter<br/>(claude-code)
+    participant FS as Ledger cache<br/>(local)
+    participant D as ox daemon
+    participant LDG as Ledger git repo
+    participant LFS as LFS blob store
+
+    U->>CC: starts Claude Code
+    CC->>OX: hook SessionStart
+    OX->>OX: agentinstance.GetOrCreate → AgentID (e.g. OxSk2e)
+    OX->>AD: detect / find session file
+    OX->>FS: StartRecording → mkdir session, write header to raw.jsonl
+    OX-->>CC: (stdout) system-reminders, team context
+
+    loop Each tool call
+        CC->>CC: runs tool (Read/Bash/Edit/…)
+        CC->>OX: hook PostToolUse (stdout discarded)
+        OX->>AD: ReadFromOffset(sessionFile, SourceOffset)
+        AD-->>OX: new RawEntries, newOffset
+        OX->>OX: classify + timestamp filter + redact
+        OX->>FS: append to raw.jsonl
+        OX->>FS: update .recording.json (offset, count, LastHookAt)
+    end
+
+    alt Explicit stop
+        U->>OX: ox session stop
+    else /clear or /compact
+        CC->>OX: hook PreCompact
+        OX->>OX: stopSessionForClear
+    else Host crash
+        Note over CC,OX: no stop — ghost cleanup later
+    end
+
+    OX->>AD: final drain
+    OX->>FS: write footer + generate artifacts<br/>(summary.json, summary.md, session.md)
+    OX->>D: IPC SessionFinalize (fire-and-forget)
+
+    OX->>LFS: Batch upload raw.jsonl, session.md, summary.md, …
+    LFS-->>OX: OIDs + sizes
+    OX->>FS: write meta.json (ledger-committed)
+    OX->>LDG: git add --sparse meta.json → commit → push
+
+    D->>LDG: periodic git pull --rebase --autostash
+    Note over LDG,LFS: Teammates pull meta.json only (dehydrated)<br/>Hydrate on demand via ox session hydrate
+```
+
+### Why the diagram matters
+
+- **Steps 1–5** establish identity and the recording floor; everything downstream keys
+  off `AgentID` and `SessionPath`.
+- **Steps 6–10** are the hot loop, running synchronously with each tool. Latency here
+  directly hits the user, so the work is scoped to tailing a file + redacting +
+  appending.
+- **Steps 14–17** are finalize-time and can tolerate latency. If the CLI dies here, the
+  raw file still exists locally; `ox doctor` detects unfinalized sessions and offers
+  repair.
+- **Steps 18–21** are the distribution phase. They are intentionally the only writer;
+  the daemon (step 22) reads only. This avoids ambiguity on who owns commit state.
+
+---
+
+## 10. Constraints and interactions you can derive from the model
+
+1. **Session data outlives process crashes.** Because raw.jsonl is appended
+   incrementally and .recording.json is persisted on every hook, a crash loses only
+   the entries written between the last hook and the crash.
+
+2. **Re-priming the same host resumes, not restarts.** An ephemeral
+   `SessionMarker` in `/tmp/<user>/sageox/sessions/` keyed by the agent's *native*
+   session ID lets `ox agent prime` be idempotent within one host lifetime. A new
+   host (new PID) gets a new Agent ID.
+
+3. **`/clear` is a session boundary, not a noop.** The old session is finalized and
+   published; a new Agent ID is minted. This is why session history isn't a single
+   infinite conversation — it's a sequence of coherent capture spans.
+
+4. **Capture-prior (import) is the same pipeline, different entry point.** A planning
+   discussion before ox was primed can be shipped as a synthetic session via
+   `ox agent <id> session capture-prior`. Once the JSONL is written, it's an ordinary
+   session that finalizes and publishes like any other.
+
+5. **Redaction is before-persistence, not before-upload.** Therefore re-deriving
+   artifacts from a leaked raw file cannot unredact it, and the same raw file can be
+   republished safely.
+
+6. **Hydration status is monotone.** A session moves from dehydrated → partial →
+   hydrated as blobs download; it never silently rehydrates. Dehydrating back
+   (cache eviction) is a separate, explicit operation.
+
+7. **A session is owned by the ledger, not the source repo.** Rotating a source repo
+   (fork, migrate to new host) does not require moving sessions. They travel with
+   the ledger, which is keyed by `repo_id`.
+
+8. **Distillation is downstream of session publication.** `ox distill` reads
+   `summary.json` files across the ledger and derives team memory facts. Distillation
+   failures cannot affect capture — the pipeline is DAG-shaped, not cyclic.
+
+9. **Context trace and session raw are peers, not nested.** `context-trace.jsonl`
+   lives in the same folder as `raw.jsonl`. A trace event references an `eid` from
+   raw; raw does not reference trace.
+
+10. **Adapters are binaries, not libraries.** `ox-adapter-claude-code` and friends are
+    external processes. The consequence is that installing support for a new agent
+    host does not require rebuilding ox, and a buggy adapter cannot corrupt the ox
+    process.
+
+---
+
+## 11. What to read next
+
+- [session-capture-architecture.md](session-capture-architecture.md) — system
+  architecture: the components that implement this model, the interfaces between
+  them, and the design decisions that shape them.
+- [session-capture-components.md](session-capture-components.md) — component-level
+  walkthroughs for deeper dives (recording, adapters, pipeline, LFS, ledger).
+- [session-raw-jsonl.md](../specs/session-raw-jsonl.md) — canonical spec for the raw
+  file format.
+- [adr-session-lfs-storage.md](../adr/adr-session-lfs-storage.md) — ADR for the
+  pure-Go LFS-without-git-lfs distribution model.
+- [adr-ledger-architecture.md](../adr/adr-ledger-architecture.md) — ADR for the
+  daemon-CLI split on ledger git operations.


### PR DESCRIPTION
## Summary

Adds three layered architecture documents for the session capture subsystem under `docs/ai/architecture/`:

1. **[session-capture-concepts.md](docs/ai/architecture/session-capture-concepts.md)** — the conceptual model. Defines the twelve core nouns (coworker, agent host, agent instance, session, adapter, recording state, raw JSONL, artifacts, ledger, LFS manifest, hydration, context trace), the lifecycle state machine, orthogonal axes (capture ⊥ finalization ⊥ distribution, local content ⊥ git-tracked metadata, per-agent isolation ⊥ concurrency), and ten derivable invariants. Includes an end-to-end sequence diagram.

2. **[session-capture-architecture.md](docs/ai/architecture/session-capture-architecture.md)** — system architecture. Component map across four tiers (edge / CLI / core / ledger), the recording state machine, path-resolution rules that guard against historical leak bugs, the external-binary adapter model, the seven-stage pipeline with failure-mode table, the pure-Go LFS distribution model, three concurrency axes, and the five guarded anti-patterns.

3. **[session-capture-components.md](docs/ai/architecture/session-capture-components.md)** — thirteen component walkthroughs (A–M) for recording core, hook handler, adapters, pipeline, artifacts, context trace, agent instance, LFS client, ledger, CLI surface, distill consumer, test patterns, and where to ask for help. Each section lists key files, types, non-obvious design choices, and how to extend safely.

## Audience

Principal engineer with systems/DB/compiler background, new to LLM agent tooling. The three documents are sequenced: concepts → architecture → components, each assuming the previous.

## Placement

New `docs/ai/architecture/` directory, alongside existing `docs/ai/specs/` and `docs/ai/adr/`. Matches the project convention of `<!-- doc-audience: ai -->` front-matter.

## Provenance

Written after a research pass over `internal/session/`, `cmd/ox/session_*.go`, `cmd/ox/agent_session*.go`, `internal/ledger/`, `internal/lfs/`, plus existing specs and ADRs. Cross-referenced against recent commits (through `d22e641`) to ensure accuracy; verified representative functions and types still exist at cited paths.

## Test plan

- [ ] Spot-check a handful of code references still resolve (e.g. `internal/session/recording.go:StartRecording`, `cmd/ox/agent_hook.go:handleAfterTool`, `internal/lfs/client.go`).
- [ ] Confirm the Mermaid diagrams render in GitHub's markdown view (an earlier draft had a `;` inside a sequence note that parsed as a statement separator — caught and fixed before this PR).
- [ ] Skim for links that point at files with `<!-- doc-audience: human -->` or `preserve-voice` and confirm none are referenced as if AI-editable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation covering the session-capture system design, including component mapping, state machine definitions, storage rules, pipeline overview, distribution design, concurrency architecture, and integration surfaces. Includes implementation walkthrough and conceptual model reference guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->