### PR TITLE
fix(prime): drop sole-active-recording agent_id fallback (#528)

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -340,9 +340,16 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	// detect parent agent early: if SAGEOX_AGENT_ID is already set, this is a subagent
 	// and the existing value identifies the parent (orchestrator inherits env vars).
 	// Must happen before startSessionRecording so parent info is recorded in session state.
+	// Only trust the env value if it maps to a currently-alive recording — a stale
+	// SAGEOX_AGENT_ID from a previous, unrelated session would otherwise cross-link
+	// this session as a child of a dead parent (#528).
 	parentAgentID := ""
 	if existing := os.Getenv("SAGEOX_AGENT_ID"); existing != "" && existing != agentID {
-		parentAgentID = existing
+		if states, err := session.LoadAllRecordingStates(projectRoot); err == nil {
+			if hasAliveRecordingForID(states, existing) {
+				parentAgentID = existing
+			}
+		}
 	}
 
 	// attempt to start session recording if enabled (local, no auth needed)
@@ -765,13 +772,26 @@ func resolveAgentIDFromStates(states []*session.RecordingState, envID string) st
 	if envID == "" {
 		return ""
 	}
-	for _, s := range states {
-		if s.AgentID == envID && s.IsAgentAlive() {
-			slog.Debug("prime: reusing agent ID from SAGEOX_AGENT_ID env", "agent_id", envID)
-			return envID
-		}
+	if hasAliveRecordingForID(states, envID) {
+		slog.Debug("prime: reusing agent ID from SAGEOX_AGENT_ID env", "agent_id", envID)
+		return envID
 	}
 	return ""
+}
+
+// hasAliveRecordingForID reports whether agentID corresponds to a currently-alive
+// recording in states. Used by callers that need to distinguish a real, live
+// agent reference from a stale SAGEOX_AGENT_ID left over in the environment.
+func hasAliveRecordingForID(states []*session.RecordingState, agentID string) bool {
+	if agentID == "" {
+		return false
+	}
+	for _, s := range states {
+		if s.AgentID == agentID && s.IsAgentAlive() {
+			return true
+		}
+	}
+	return false
 }
 
 // loadResolvedAttribution loads and merges attribution from user and project configs.

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -309,7 +309,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// fallback: check SAGEOX_AGENT_ID env and sole-active-recording.
+	// fallback: reuse agent_id from SAGEOX_AGENT_ID if it matches an alive recording.
 	// Covers: (a) prime called from CLAUDE.md BLOCKING instruction after /clear
 	// (CLAUDE_ENV_FILE persists the var), (b) prime subprocess called from hook
 	// with the env var passed explicitly by runPrimeForHook.
@@ -758,29 +758,18 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-// resolveAgentIDFromStates attempts to find a reusable agent ID from active recordings.
-// Checks envID first (from SAGEOX_AGENT_ID), then falls back to sole-active-recording.
-// Returns empty string if no match found.
+// resolveAgentIDFromStates returns envID if it matches an alive recording, otherwise "".
+// Intentionally does not fall back to a sole active recording: two concurrent Claude Code
+// sessions in different worktrees must not collide on agent_id (#528).
 func resolveAgentIDFromStates(states []*session.RecordingState, envID string) string {
-	// try env-provided ID first
-	if envID != "" {
-		for _, s := range states {
-			if s.AgentID == envID && s.IsAgentAlive() {
-				slog.Debug("prime: reusing agent ID from SAGEOX_AGENT_ID env", "agent_id", envID)
-				return envID
-			}
-		}
+	if envID == "" {
+		return ""
 	}
-	// last resort: if exactly one active recording exists, reuse it
-	var alive []*session.RecordingState
 	for _, s := range states {
-		if s.IsAgentAlive() {
-			alive = append(alive, s)
+		if s.AgentID == envID && s.IsAgentAlive() {
+			slog.Debug("prime: reusing agent ID from SAGEOX_AGENT_ID env", "agent_id", envID)
+			return envID
 		}
-	}
-	if len(alive) == 1 {
-		slog.Debug("prime: reusing sole active recording agent ID", "agent_id", alive[0].AgentID)
-		return alive[0].AgentID
 	}
 	return ""
 }

--- a/cmd/ox/agent_prime_id_reuse_test.go
+++ b/cmd/ox/agent_prime_id_reuse_test.go
@@ -48,20 +48,19 @@ func TestPrimeIgnoresEnv_WhenRecordingDead(t *testing.T) {
 
 // --- B. Sole active recording fallback ---
 
-// TestPrimeFallback_SoleActiveRecording verifies that when there is exactly
-// one active recording and no other reuse source, prime falls back to it.
-// Failure prevented: after /clear with no env var or marker, session is orphaned.
-func TestPrimeFallback_SoleActiveRecording(t *testing.T) {
+// TestPrimeNoFallback_SoleActiveRecording verifies that a single alive
+// recording is NOT auto-adopted when no env ID and no PID match.
+// Failure prevented: a concurrent Claude Code session in a sibling worktree
+// silently inheriting another session's agent_id (#528).
+func TestPrimeNoFallback_SoleActiveRecording(t *testing.T) {
 	projectRoot, repoID := setupTestProject(t)
-
-	agentID := "OxSole1"
-	createActiveRecording(t, projectRoot, repoID, agentID)
+	createActiveRecording(t, projectRoot, repoID, "OxSole1")
 
 	states, err := session.LoadAllRecordingStates(projectRoot)
 	require.NoError(t, err)
 
 	resolved := resolveAgentIDFromStates(states, "")
-	assert.Equal(t, agentID, resolved, "sole active recording should be reused when no env ID available")
+	assert.Empty(t, resolved, "sole active recording must not be auto-adopted without correlation (#528)")
 }
 
 // TestPrimeNoFallback_MultipleActiveRecordings verifies that when multiple
@@ -78,6 +77,21 @@ func TestPrimeNoFallback_MultipleActiveRecordings(t *testing.T) {
 
 	resolved := resolveAgentIDFromStates(states, "")
 	assert.Empty(t, resolved, "multiple active recordings should not trigger sole-recording fallback")
+}
+
+// TestResolve_EnvMismatch_DoesNotFallThrough verifies that a non-matching
+// envID does not silently fall through to a sole alive recording.
+// Failure prevented: a stale SAGEOX_AGENT_ID from a different agent process
+// silently coercing to whatever sole recording happens to be alive (#528).
+func TestResolve_EnvMismatch_DoesNotFallThrough(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+	createActiveRecording(t, projectRoot, repoID, "OxLive1")
+
+	states, err := session.LoadAllRecordingStates(projectRoot)
+	require.NoError(t, err)
+
+	resolved := resolveAgentIDFromStates(states, "OxStaleEnv")
+	assert.Empty(t, resolved, "non-matching env ID must not fall through to sole-active (#528)")
 }
 
 // --- C. Session stop on /clear ---

--- a/cmd/ox/agent_prime_id_reuse_test.go
+++ b/cmd/ox/agent_prime_id_reuse_test.go
@@ -94,6 +94,40 @@ func TestResolve_EnvMismatch_DoesNotFallThrough(t *testing.T) {
 	assert.Empty(t, resolved, "non-matching env ID must not fall through to sole-active (#528)")
 }
 
+// TestHasAliveRecordingForID_StaleEnvNotTreatedAsAliveParent guards the
+// parent-agent gating at runAgentPrime's SAGEOX_AGENT_ID check: without this
+// helper returning false for a stale env, a new top-level session would be
+// recorded as a child of a dead agent.
+// Failure prevented: stale SAGEOX_AGENT_ID cross-linking an unrelated new
+// session to a dead orchestrator (#528 CodeRabbit follow-up).
+func TestHasAliveRecordingForID_StaleEnvNotTreatedAsAliveParent(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+	createActiveRecording(t, projectRoot, repoID, "OxLive1")
+
+	states, err := session.LoadAllRecordingStates(projectRoot)
+	require.NoError(t, err)
+
+	assert.True(t, hasAliveRecordingForID(states, "OxLive1"),
+		"live recording must be recognized")
+	assert.False(t, hasAliveRecordingForID(states, "OxStaleEnv"),
+		"stale env value must not be reported as an alive parent")
+	assert.False(t, hasAliveRecordingForID(states, ""),
+		"empty id must never match")
+}
+
+// TestHasAliveRecordingForID_DeadParentRejected verifies that a recording
+// whose parent process has exited is not treated as an alive parent.
+func TestHasAliveRecordingForID_DeadParentRejected(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+	createDeadRecording(t, projectRoot, repoID, "OxDead1")
+
+	states, err := session.LoadAllRecordingStates(projectRoot)
+	require.NoError(t, err)
+
+	assert.False(t, hasAliveRecordingForID(states, "OxDead1"),
+		"recording with dead PID past grace period must not count as alive")
+}
+
 // --- C. Session stop on /clear ---
 
 // TestStopSessionForClear_SetsStoppedAtAndClears verifies that stopSessionForClear
@@ -185,6 +219,14 @@ func setupTestProject(t *testing.T) (string, string) {
 
 func createActiveRecording(t *testing.T, projectRoot, repoID, agentID string) {
 	t.Helper()
+	createActiveRecordingWithPID(t, projectRoot, repoID, agentID, os.Getpid())
+}
+
+// createActiveRecordingWithPID creates an alive recording whose ParentPID is
+// caller-chosen. Use os.Getpid() to simulate "this process owns the recording"
+// or a non-ancestor PID (e.g. 1) to simulate a concurrent, unrelated session.
+func createActiveRecordingWithPID(t *testing.T, projectRoot, repoID, agentID string, parentPID int) {
+	t.Helper()
 	sessionsBase := filepath.Join(session.GetContextPath(repoID), "sessions")
 	sessionPath := filepath.Join(sessionsBase, "2026-04-01T10-00-user-"+agentID)
 
@@ -194,7 +236,7 @@ func createActiveRecording(t *testing.T, projectRoot, repoID, agentID string) {
 		AdapterName: "claude-code",
 		SessionPath: sessionPath,
 		OutputFile:  filepath.Join(sessionPath, "raw.jsonl"),
-		ParentPID:   os.Getpid(), // current process is alive
+		ParentPID:   parentPID,
 	}
 	require.NoError(t, session.SaveRecordingState(projectRoot, state))
 }

--- a/cmd/ox/agent_session_intent_test.go
+++ b/cmd/ox/agent_session_intent_test.go
@@ -283,7 +283,10 @@ func TestIntent_PrimeRequiresCorrelationToReuseAgentID(t *testing.T) {
 	projectRoot, repoID := setupTestProject(t)
 
 	agentID := "OxExisting1"
-	createActiveRecording(t, projectRoot, repoID, agentID)
+	// ParentPID=1 (init): alive but not an ancestor of this test process, so the
+	// strict PID-match branch in runAgentPrime would also miss. This keeps the
+	// fixture honest to the test's "no correlation signal" claim.
+	createActiveRecordingWithPID(t, projectRoot, repoID, agentID, 1)
 
 	// simulate prime's fallback chain: marker → parent PID → env
 	// with none available (worst case: no marker, no env, no PID match)

--- a/cmd/ox/agent_session_intent_test.go
+++ b/cmd/ox/agent_session_intent_test.go
@@ -274,22 +274,23 @@ func TestIntent_GhostCleanupRespectsGracePeriod(t *testing.T) {
 	assert.NotNil(t, state, "recording must survive ghost cleanup within grace period")
 }
 
-// TestIntent_PrimeNeverGeneratesNewIDWhenActiveRecordingExists verifies that
-// prime's ID resolution chain always finds an existing active recording before
-// falling through to generate a new ID.
-// Failure prevented: new agent ID orphans active session.
-func TestIntent_PrimeNeverGeneratesNewIDWhenActiveRecordingExists(t *testing.T) {
+// TestIntent_PrimeRequiresCorrelationToReuseAgentID verifies that prime's ID
+// resolution refuses to adopt an alive recording without an explicit correlation
+// signal (marker, parent-PID match, or matching SAGEOX_AGENT_ID).
+// Failure prevented: silent cross-session adoption where a concurrent Claude Code
+// session in a sibling worktree inherits another session's agent_id (#528).
+func TestIntent_PrimeRequiresCorrelationToReuseAgentID(t *testing.T) {
 	projectRoot, repoID := setupTestProject(t)
 
 	agentID := "OxExisting1"
 	createActiveRecording(t, projectRoot, repoID, agentID)
 
-	// simulate prime's fallback chain: marker → parent PID → env → sole-active
-	// with only sole-active available (worst case: no marker, no env, no PID match)
+	// simulate prime's fallback chain: marker → parent PID → env
+	// with none available (worst case: no marker, no env, no PID match)
 	states, err := session.LoadAllRecordingStates(projectRoot)
 	require.NoError(t, err)
 
-	// INVARIANT: when exactly one active recording exists, prime must find it
+	// INVARIANT: with no correlation signal, prime must not reuse an unrelated recording
 	resolved := resolveAgentIDFromStates(states, "")
-	assert.Equal(t, agentID, resolved, "sole active recording must be discoverable by prime")
+	assert.Empty(t, resolved, "prime must not adopt an unrelated active recording without an explicit correlation signal (#528)")
 }


### PR DESCRIPTION
## Summary

- Concurrent Claude Code sessions in sibling worktrees of the same ox repo no longer collide on `agent_id`.
- `resolveAgentIDFromStates` now returns the `SAGEOX_AGENT_ID` env value only when it matches an alive recording — otherwise `""`. The "if exactly one active recording exists, adopt it" fallback is gone.
- Re-prime paths (marker, strict parent-PID ancestry, env match) are untouched.

## Motivation

Fixes #528. A second Claude Code session started in a different worktree was silently adopting the first session's `agent_id`. Both sessions shared state, the second session's turns were never recorded (overlapping symptoms with #519), and `ox session status` could not distinguish them.

Root cause was the last-resort branch of `resolveAgentIDFromStates` in `cmd/ox/agent_prime.go`: if exactly one alive recording existed and no other reuse source matched, prime reused it — with zero correlation to the current PID, workspace, or env. The legitimate "re-prime in the same process after `/clear`" case is already covered by three earlier branches of the resolution chain:

1. Marker reuse (`agent_prime.go:289-293`)
2. Strict parent-PID ancestry match (`agent_prime.go:299-309`)
3. `SAGEOX_AGENT_ID` env match (env branch of `resolveAgentIDFromStates`)

The deleted branch only ever fired when all three missed — in that narrow window, silently adopting an unrelated session is strictly worse than minting a fresh `agent_id`. Issue #528's own "Fix direction" section recommends this exact minimum change.

## Test plan

- [x] New regression: `TestPrimeNoFallback_SoleActiveRecording` — one alive recording + empty envID must return `""`.
- [x] New regression: `TestResolve_EnvMismatch_DoesNotFallThrough` — a stale env ID must not silently coerce onto the sole alive recording.
- [x] Rewritten invariant: `TestIntent_PrimeRequiresCorrelationToReuseAgentID` (replaces `TestIntent_PrimeNeverGeneratesNewIDWhenActiveRecordingExists`) — without a correlation signal, prime must not reuse an unrelated recording.
- [x] Red→green verified: all three new/rewritten tests fail against the unchanged code, pass after the fix.
- [x] `make test` green (13141 tests).
- [x] `make lint` green (0 issues).
- [ ] Live repro follow-up in `sageox/ox-test-harness`: spawn two real `ox agent prime` in different worktrees, assert distinct agent_ids. Out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent ID reuse now only occurs when an explicit environment correlation is present; sole active-recording fallback was removed to avoid cross-session ID reuse.
* **Tests**
  * Updated and added tests to assert no implicit agent ID adoption and to validate liveness-based resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->