### PR TITLE
fix(whisper): route recording-reminder to recipient only (#538)

### DIFF
--- a/internal/daemon/whisper_recording_reminder.go
+++ b/internal/daemon/whisper_recording_reminder.go
@@ -136,7 +136,7 @@ func (s *RecordingReminderSource) shouldRemind(agentID string, agent ActivityEnt
 		return false
 	}
 
-	lastReminder, err := s.store.LatestWhisperTime("recording-reminder", "recording-status", agentID)
+	lastReminder, err := s.store.LatestWhisperTime(whisperstore.SourceRecordingReminder, "recording-status", agentID)
 	if err != nil {
 		return false // store error — skip this tick
 	}

--- a/internal/daemon/whisper_recording_reminder.go
+++ b/internal/daemon/whisper_recording_reminder.go
@@ -44,7 +44,7 @@ func (s *RecordingReminderSource) SetTick(d time.Duration) {
 	s.tick = d
 }
 
-func (s *RecordingReminderSource) Name() string { return "recording-reminder" }
+func (s *RecordingReminderSource) Name() string { return whisperstore.SourceRecordingReminder }
 
 // Interval returns the tick frequency. Defaults to 1 minute — frequent enough
 // to catch new recordings quickly, while only producing entries when the
@@ -96,12 +96,20 @@ func (s *RecordingReminderSource) Produce(_ context.Context) []whisperstore.Whis
 			ID:         id.String(),
 			Scope:      "ledger",
 			Type:       whisperstore.WhisperTimeBased,
-			Source:     "recording-reminder",
+			Source:     whisperstore.SourceRecordingReminder,
 			Topic:      "recording-status",
 			Content:    content,
 			Importance: whisperstore.ImportanceNormal,
 			CreatedAt:  now,
-			AgentID:    agentID,
+			// AgentID is the intended recipient. Unlike murmurs and
+			// announcements (which fan out to every listener), this whisper's
+			// Content embeds this agent's own turn count and duration — it
+			// is meaningless and misleading if rendered by any other agent.
+			// Store.GetWhispers uses Source == whisperstore.SourceRecordingReminder
+			// together with this AgentID to route delivery to the recipient
+			// only (see #538). Keep Source tied to the constant above; the
+			// store's SQL filter is keyed on it.
+			AgentID: agentID,
 		})
 	}
 

--- a/internal/whisper/store/store.go
+++ b/internal/whisper/store/store.go
@@ -53,6 +53,21 @@ const (
 	WhisperTrigger    WhisperType = "trigger"
 )
 
+// Whisper source values that are load-bearing for delivery routing.
+//
+// Whisper sources are free-form strings; only sources that the transport
+// layer must identify by name live here. If you add a new personalized
+// (per-recipient) whisper source, add its constant here and extend the
+// guards in GetWhispers and GetWhispersPage.
+const (
+	// SourceRecordingReminder marks whispers produced by the daemon's
+	// periodic recording reminder. Content is personalized with the
+	// recipient agent's own turn count and duration, so GetWhispers and
+	// GetWhispersPage route delivery by agent_id for this source only.
+	// Everything else stays broadcast (see #538).
+	SourceRecordingReminder = "recording-reminder"
+)
+
 // WhisperEntry is a single whisper destined for agent delivery.
 type WhisperEntry struct {
 	ID            string            `json:"id"`
@@ -317,10 +332,24 @@ func (s *Store) GetWhispers(agentID string, attention Attention, topics []string
 	}
 
 	// build query with filters
+	//
+	// Whispers are fan-out by design — murmurs, announcements, and broadcasts
+	// are meant to reach every active agent so teammates can see each other's
+	// work. SourceRecordingReminder is the one exception: its content is
+	// personalized with the recipient agent's own turn count and duration,
+	// so delivering it to the wrong agent surfaces wrong numbers to the user
+	// (see #538). We narrow only that source to its intended recipient via
+	// agent_id; everything else stays broadcast.
+	//
+	// If a new personalized whisper source is added in the future, add its
+	// constant next to SourceRecordingReminder and extend this clause rather
+	// than flipping the default to filter-by-agent.
 	query := `SELECT id, scope, type, source, topic, content, importance, created_at,
 		agent_id, principal_id, principal_type, team_id, metadata
-		FROM whispers WHERE created_at > ?`
-	args := []any{cursor.UTC().Format(time.RFC3339Nano)}
+		FROM whispers
+		WHERE created_at > ?
+		  AND (source != ? OR agent_id = ?)`
+	args := []any{cursor.UTC().Format(time.RFC3339Nano), SourceRecordingReminder, agentID}
 
 	// attention filter
 	allowedImportance := importanceForAttention(attention)
@@ -516,6 +545,13 @@ func (s *Store) GetWhispersPage(agentID string, before time.Time, limit int) ([]
 		conditions = append(conditions, `(agent_id = ? OR agent_id IS NULL OR agent_id = '')`)
 		args = append(args, agentID)
 	}
+	// Recording-reminder whispers are personalized per-recipient (see #538).
+	// Exclude reminders targeted at a different agent from any inspection query,
+	// including unscoped ones (agentID=""), since their content embeds a
+	// specific agent's numbers. Mirrors the guard in GetWhispers — if you add
+	// a new personalized source constant, extend both clauses.
+	conditions = append(conditions, `(source != ? OR agent_id = ?)`)
+	args = append(args, SourceRecordingReminder, agentID)
 	if !before.IsZero() {
 		conditions = append(conditions, `created_at < ?`)
 		args = append(args, before.UTC().Format(time.RFC3339Nano))

--- a/internal/whisper/store/store.go
+++ b/internal/whisper/store/store.go
@@ -465,7 +465,13 @@ func (s *Store) MarkRelayed(murmurID, scope string) error {
 
 // GetAllWhispers returns all whisper entries for an agent without advancing the cursor.
 // Used for inspection/debugging — shows both pending and already-delivered whispers.
-// Pass agentID="" to get all whispers across all agents.
+//
+// Pass agentID="" for an unscoped view across all agents. Personalized
+// whispers (SourceRecordingReminder) targeted at a specific agent are
+// still omitted on unscoped queries — their content embeds per-agent
+// numbers and is meaningless when rendered without the recipient. See
+// GetWhispersPage for the predicate, and #538 for the original leak.
+//
 // Iterates pages until all entries are collected.
 func (s *Store) GetAllWhispers(agentID string) ([]WhisperEntry, error) {
 	var all []WhisperEntry

--- a/internal/whisper/store/store_test.go
+++ b/internal/whisper/store/store_test.go
@@ -356,6 +356,114 @@ func TestPrincipalFields(t *testing.T) {
 	}
 }
 
+// TestGetWhispers_RecordingReminderRoutedToRecipientOnly verifies that a
+// recording-reminder produced for agent A is not delivered to any other agent.
+// Failure prevented: cross-agent leak surfaces wrong turn count / duration to
+// the user (see #538) — the content is personalized with the recipient's own
+// recording state and is meaningless if rendered by another agent.
+func TestGetWhispers_RecordingReminderRoutedToRecipientOnly(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	reminder := makeEntry("reminder-A", "recording-status", ImportanceNormal, now)
+	reminder.Source = SourceRecordingReminder
+	reminder.AgentID = "OxAAAAAA"
+	s.Add(reminder)
+
+	// Wrong agent queries — must receive nothing.
+	got, err := s.GetWhispers("OxBBBBBB", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("GetWhispers(other): %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("recording-reminder for OxAAAAAA leaked to OxBBBBBB: got %d entries", len(got))
+	}
+
+	// Intended recipient queries — must still receive it.
+	got, err = s.GetWhispers("OxAAAAAA", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("GetWhispers(recipient): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("recipient OxAAAAAA should receive its reminder: got %d entries", len(got))
+	}
+	if got[0].Source != SourceRecordingReminder || got[0].AgentID != "OxAAAAAA" {
+		t.Fatalf("wrong entry returned: source=%q agent_id=%q", got[0].Source, got[0].AgentID)
+	}
+}
+
+// TestGetWhispers_NonReminderWhispersStayBroadcast verifies that whispers
+// whose source is not SourceRecordingReminder continue to fan out regardless
+// of the agent_id column — this is the original design for murmurs and
+// announcements.
+// Failure prevented: an over-broad agent_id filter silences cross-agent
+// murmur delivery (the feature that lets teammates see each other's WIP).
+func TestGetWhispers_NonReminderWhispersStayBroadcast(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	// A murmur tagged with its author in agent_id — any reader must see it.
+	murmur := makeEntry("m1", "wip", ImportanceNormal, now)
+	murmur.Source = "murmur"
+	murmur.AgentID = "OxAuthor"
+	s.Add(murmur)
+
+	got, err := s.GetWhispers("OxReader", AttentionAll, nil)
+	if err != nil {
+		t.Fatalf("GetWhispers: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("author-tagged murmur should fan out: got %d entries for OxReader", len(got))
+	}
+	if got[0].AgentID != "OxAuthor" {
+		t.Fatalf("unexpected agent_id on fanned-out murmur: %q", got[0].AgentID)
+	}
+}
+
+// TestGetWhispersPage_RecordingReminderExcludedFromOtherAgents mirrors the
+// GetWhispers guard for the inspection/admin reader. Even on an unscoped
+// query (agentID=""), recording-reminders targeted at specific agents must
+// not appear — their content embeds per-agent numbers that would mislead
+// anyone rendering them.
+// Failure prevented: inspection UIs surface another agent's personalized
+// reminder and render wrong turn count / duration (see #538).
+func TestGetWhispersPage_RecordingReminderExcludedFromOtherAgents(t *testing.T) {
+	s := mustOpen(t)
+	now := time.Now()
+
+	reminder := makeEntry("reminder-A", "recording-status", ImportanceNormal, now)
+	reminder.Source = SourceRecordingReminder
+	reminder.AgentID = "OxAAAAAA"
+	s.Add(reminder)
+
+	// Another agent inspecting — must not see OxAAAAAA's reminder.
+	page, _, err := s.GetWhispersPage("OxBBBBBB", time.Time{}, 0)
+	if err != nil {
+		t.Fatalf("GetWhispersPage(other): %v", err)
+	}
+	if len(page) != 0 {
+		t.Fatalf("recording-reminder leaked to OxBBBBBB via page: got %d entries", len(page))
+	}
+
+	// Unscoped inspection — must also exclude targeted reminders.
+	page, _, err = s.GetWhispersPage("", time.Time{}, 0)
+	if err != nil {
+		t.Fatalf("GetWhispersPage(unscoped): %v", err)
+	}
+	if len(page) != 0 {
+		t.Fatalf("unscoped page must exclude targeted recording-reminder: got %d entries", len(page))
+	}
+
+	// Recipient inspecting their own — must receive it.
+	page, _, err = s.GetWhispersPage("OxAAAAAA", time.Time{}, 0)
+	if err != nil {
+		t.Fatalf("GetWhispersPage(recipient): %v", err)
+	}
+	if len(page) != 1 {
+		t.Fatalf("recipient should see own reminder via page: got %d entries", len(page))
+	}
+}
+
 func TestEmptyStore(t *testing.T) {
 	s := mustOpen(t)
 


### PR DESCRIPTION
## Summary

- Fixes #538: personalized `recording-reminder` whispers leak to the wrong agent, surfacing wrong turn count / duration in their context.
- Narrow only that one source to its intended recipient via `agent_id`; keep all other whispers (murmurs, announcements, version-check) broadcast as designed.
- Extract `SourceRecordingReminder` constant so the filter and the producer can't silently drift apart.

## Root cause

Whispers were designed as a fan-out channel in #283: the live reader `Store.GetWhispers` deliberately doesn't filter by `agent_id` — everyone hears everything. That's how teammates see each other's murmurs, and why listening to other agents' announcements is the feature, not a leak.

#514 introduced the first **personalized per-recipient** whisper: the periodic recording reminder. Its content embeds `"SageOx recording active: N turns, Xh Ym"` — numbers pulled from that specific agent's own recording state. But the reader was never taught about this new category. So agent A's reminder fanned out to everyone, and a freshly-primed agent (e.g. `OxCh8K`) would render agent `OxSk2e`'s 23-hour-old numbers to the user.

## Fix

One predicate added to the two reader paths (`Store.GetWhispers` and `Store.GetWhispersPage`):

```sql
AND (source != 'recording-reminder' OR agent_id = ?)
```

- Non-reminder rows (`source != 'recording-reminder'`): still fan out. Murmurs, version-check, every other source unaffected.
- Recording-reminder rows: delivered only when `agent_id` matches the querying agent.

The source name is now a shared `whisperstore.SourceRecordingReminder` constant, referenced at the producer (`Name()`, `Source:`) and both reader predicates. A rename on one side now breaks compilation on the other side of the coupling.

Comments at the producer write site and both reader query sites explain the invariant and point future contributors at the clause to extend when adding another personalized source.

## Test plan

- [x] `go test ./internal/whisper/store/... ./internal/daemon/` — all pass
- [x] `go vet ./internal/whisper/store/ ./internal/daemon/` — clean
- [x] Regression tests verified to fail on pre-fix code and pass on fixed code (surgical revert of only the two filter predicates, keeping the constant):
  - `TestGetWhispers_RecordingReminderRoutedToRecipientOnly` — live-delivery path
  - `TestGetWhispersPage_RecordingReminderExcludedFromOtherAgents` — inspection path, including the `agentID=""` unscoped case
  - `TestGetWhispers_NonReminderWhispersStayBroadcast` — guards against over-correction silencing murmurs
- [ ] Integration smoke: run two concurrent sessions in sibling worktrees; confirm each sees only its own recording-reminder (manual, to be done on merge candidate)

## Design notes

- Not a schema change. `agent_id` retains its existing overloaded role — provenance for some sources, recipient for others. Only one source is load-bearing for delivery routing, and it is now documented at the constant's definition.
- If a second personalized source is ever added, extend both predicates (`GetWhispers` and `GetWhispersPage`) and add another constant next to `SourceRecordingReminder`. The comment blocks call this out.

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recording reminders are now delivered only to the intended recipient and no longer broadcast to other users or appear in unscoped/public whisper lists.

* **Tests**
  * Added tests to verify targeted recording-reminder delivery and to ensure other whispers continue to be broadcast as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->