### PR TITLE
fix(session): stop uploading empty sessions the LLM scored 0 (#525)

### DIFF
--- a/cmd/ox/session_push_summary.go
+++ b/cmd/ox/session_push_summary.go
@@ -107,7 +107,15 @@ func pushSummaryToLedger(filePath, sessionDir string) *pushSummaryOutput {
 		}
 	}
 
-	// parse and validate the summary JSON
+	// parse and validate the summary JSON. Detect whether quality_score was
+	// actually present in the file so a missing field is treated as "unscored"
+	// (default to upload) rather than flowing through the discard gate as an
+	// explicit 0 — otherwise pre-existing summary.json files written by older
+	// ox versions (no quality_score field) would be silently discarded (#525).
+	var rawFields map[string]json.RawMessage
+	_ = json.Unmarshal(data, &rawFields)
+	_, qualityScorePresent := rawFields["quality_score"]
+
 	var summaryParsed session.SummarizeResponse
 	_ = json.Unmarshal(data, &summaryParsed)
 
@@ -140,7 +148,14 @@ func pushSummaryToLedger(filePath, sessionDir string) *pushSummaryOutput {
 		discardThreshold = awCfg.GetQualityDiscardThreshold()
 	}
 
-	disposition := session.EvaluateQuality(summaryParsed.QualityScore, uploadThreshold, discardThreshold)
+	// unscored summaries (field absent from JSON) default to upload; scored
+	// summaries flow through the quality thresholds.
+	var disposition session.QualityDisposition
+	if qualityScorePresent {
+		disposition = session.EvaluateQuality(summaryParsed.QualityScore, uploadThreshold, discardThreshold)
+	} else {
+		disposition = session.QualityUpload
+	}
 
 	if disposition == session.QualityDiscard {
 		slog.Info("session below discard threshold, skipping push",

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -625,15 +625,19 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 		return nil
 	}
 
-	// parse LLM output into SummarizeResponse
+	// parse LLM output into SummarizeResponse. Track whether we produced a real
+	// summary or a fallback stub so the quality gate only runs on real scores
+	// — a fallback with QualityScore=0 must NOT flow through EvaluateQuality
+	// and get discarded, otherwise transient LLM failures lose sessions (#525).
 	var summaryResp *session.SummarizeResponse
+	scored := true
 	parsed, parseErr := sessionsummary.ParseSummaryJSON(llmOutput)
 	if parseErr != nil {
 		preview := llmOutput
 		if len(preview) > 200 {
 			preview = preview[:200]
 		}
-		h.logger.Warn("LLM output not parsable as summary JSON, discarding",
+		h.logger.Warn("LLM output not parsable as summary JSON, using fallback stub",
 			"err", parseErr,
 			"output_len", len(llmOutput),
 			"output_preview", preview,
@@ -643,24 +647,32 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 			QualityScore: 0.0,
 			ScoreReason:  "unparsable LLM output",
 		}
+		scored = false
 	} else {
 		summaryResp = parsed
 	}
 
 	// validate summary content for agent meta-output contamination
 	if valErr := sessionsummary.ValidateSummaryContent(summaryResp); valErr != nil {
-		h.logger.Warn("summary content validation failed, discarding",
+		h.logger.Warn("summary content validation failed, using fallback stub",
 			"session", filepath.Base(payload.SessionDir),
 			"error", valErr,
 		)
 		summaryResp.QualityScore = 0.0
 		summaryResp.ScoreReason = fmt.Sprintf("content validation failed: %v", valErr)
+		scored = false
 	}
 
 	sessionName := filepath.Base(payload.SessionDir)
 
-	// evaluate quality using shared function
-	disposition := session.EvaluateQuality(summaryResp.QualityScore, h.qualityUploadThreshold, h.qualityDiscardThreshold)
+	// unscored fallbacks default to upload (preserve stub for teammates / doctor).
+	// Only real LLM-scored summaries are gated by the quality thresholds.
+	var disposition session.QualityDisposition
+	if scored {
+		disposition = session.EvaluateQuality(summaryResp.QualityScore, h.qualityUploadThreshold, h.qualityDiscardThreshold)
+	} else {
+		disposition = session.QualityUpload
+	}
 
 	if disposition == session.QualityDiscard {
 		h.logger.Info("session below discard threshold, removing",

--- a/internal/daemon/agentwork/session_finalize_summary_test.go
+++ b/internal/daemon/agentwork/session_finalize_summary_test.go
@@ -172,7 +172,7 @@ func TestProcessResult_WithRealGitRepo(t *testing.T) {
 	handler := NewSessionFinalizeHandler(slog.Default())
 	// skipGit=false — exercises the real git commit path
 
-	llmOutput := `{"title":"Git Test","summary":"Testing git commit path.","key_actions":["tested git"],"outcome":"success","topics_found":["git"]}`
+	llmOutput := `{"title":"Git Test","summary":"Testing git commit path.","key_actions":["tested git"],"outcome":"success","topics_found":["git"],"quality_score":0.9}`
 
 	item := &WorkItem{
 		ID:   "test-git",
@@ -291,6 +291,88 @@ func TestProcessResult_QualityScoreDiscard(t *testing.T) {
 	// session dir should be removed
 	if _, statErr := os.Stat(sessionDir); !os.IsNotExist(statErr) {
 		t.Error("expected session directory to be removed for quality below discard threshold")
+	}
+}
+
+// TestProcessResult_ValidationFailure_UploadsFallbackStub pins down the
+// validation-failure branch: when a parsed LLM response fails content
+// validation, the session must still be uploaded with the fallback stub —
+// never discarded as though it had a real quality_score of 0. Guards against
+// a future refactor sending validation-failures through the discard gate.
+func TestProcessResult_ValidationFailure_UploadsFallbackStub(t *testing.T) {
+	ledgerPath := createTestSession(t, "test-valfail", nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", "test-valfail")
+
+	handler := NewSessionFinalizeHandlerForTest(slog.Default())
+	handler.SetQualityThresholds(0.3, 0.1)
+
+	item := &WorkItem{
+		ID:       "test-valfail",
+		Type:     sessionFinalizeType,
+		DedupKey: "session-finalize:test-valfail",
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    []string{"summary.md", "summary.json", "session.md"},
+			LedgerPath: ledgerPath,
+		},
+	}
+
+	// valid JSON but summary is too short — trips ValidateSummaryContent.
+	result := &RunResult{
+		Output: `{"title":"x","summary":"too short","key_actions":[],"outcome":"success","topics_found":[],"quality_score":0.9}`,
+	}
+
+	if err := handler.ProcessResult(item, result); err != nil {
+		t.Fatalf("ProcessResult: %v", err)
+	}
+
+	// validation failed → fallback stub → upload path → artifacts written, dir retained
+	if _, statErr := os.Stat(sessionDir); os.IsNotExist(statErr) {
+		t.Fatal("validation failure must not discard the session")
+	}
+	if _, statErr := os.Stat(filepath.Join(sessionDir, "summary.json")); os.IsNotExist(statErr) {
+		t.Error("summary.json should be written for validation-failure fallback")
+	}
+}
+
+// TestProcessResult_EmptySessionLLMScoreZero_Discarded is the #525 regression:
+// when the LLM correctly scores an empty session as 0 (not missing, explicit 0),
+// the session must flow through the discard gate and be removed — not uploaded.
+// Before the fix, EvaluateQuality's `score <= 0` short-circuit classified these
+// as QualityUpload, causing empty "No Activity Recorded" sessions to reach the
+// team ledger.
+func TestProcessResult_EmptySessionLLMScoreZero_Discarded(t *testing.T) {
+	ledgerPath := createTestSession(t, "test-empty-zero", nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", "test-empty-zero")
+
+	handler := NewSessionFinalizeHandlerForTest(slog.Default())
+	handler.SetQualityThresholds(0.3, 0.1)
+
+	item := &WorkItem{
+		ID:       "test-525",
+		Type:     sessionFinalizeType,
+		DedupKey: "session-finalize:test-empty-zero",
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    []string{"summary.md"},
+			LedgerPath: ledgerPath,
+		},
+	}
+
+	// shape of LLM output for an empty session, verbatim from the on-disk
+	// summary.json of one of the 42 leaked sessions observed in the wild.
+	result := &RunResult{
+		Output: `{"title":"Empty Session - No Activity Recorded","summary":"This session contained no dialog or activity. Only a session header was recorded, indicating the session was opened but no work was performed.","key_actions":[],"outcome":"failed","topics_found":[],"quality_score":0,"score_reason":"Session contained only a header with no dialog or work performed."}`,
+	}
+
+	if err := handler.ProcessResult(item, result); err != nil {
+		t.Fatalf("ProcessResult: %v", err)
+	}
+
+	if _, statErr := os.Stat(sessionDir); !os.IsNotExist(statErr) {
+		t.Error("empty session scored 0 by LLM must be discarded, not uploaded")
 	}
 }
 

--- a/internal/session/quality.go
+++ b/internal/session/quality.go
@@ -12,12 +12,17 @@ const (
 	QualityDiscard QualityDisposition = "discard"
 )
 
-// EvaluateQuality determines what to do with a session based on its quality score.
-// A score of 0 means the LLM didn't provide one — default to upload (backward compat).
+// EvaluateQuality maps a quality score to a disposition using the two thresholds.
+//
+// The score argument is a real, scored value (0.0–1.0). Callers must not pass
+// a negative sentinel or similar "unscored" placeholder: if the LLM did not
+// produce a score, decide disposition at the callsite (typically
+// QualityUpload with a stub summary) rather than routing through this
+// function. An older version of this code treated score <= 0 as "unscored →
+// upload," which conflated an empty session the LLM correctly scored 0 with
+// the truly-unscored case and quietly published header-only sessions to the
+// team ledger (see #525).
 func EvaluateQuality(score, uploadThreshold, discardThreshold float64) QualityDisposition {
-	if score <= 0 {
-		return QualityUpload
-	}
 	if score < discardThreshold {
 		return QualityDiscard
 	}

--- a/internal/session/quality_test.go
+++ b/internal/session/quality_test.go
@@ -10,8 +10,11 @@ func TestEvaluateQuality(t *testing.T) {
 		discard float64
 		want    QualityDisposition
 	}{
-		{"zero score defaults to upload", 0.0, 0.3, 0.1, QualityUpload},
-		{"negative score defaults to upload", -1.0, 0.3, 0.1, QualityUpload},
+		// Regression for #525: a real LLM score of 0 (e.g. empty session
+		// correctly scored 0) must flow through the discard gate. The function
+		// no longer has an "unscored sentinel" branch — "unscored" decisions
+		// are the caller's responsibility.
+		{"explicit zero is discarded below discard threshold", 0.0, 0.3, 0.1, QualityDiscard},
 		{"below discard threshold", 0.05, 0.3, 0.1, QualityDiscard},
 		{"at discard threshold boundary", 0.1, 0.3, 0.1, QualityLocalOnly},
 		{"between thresholds", 0.2, 0.3, 0.1, QualityLocalOnly},


### PR DESCRIPTION
## Summary

Closes #525 — empty sessions (header-only `raw.jsonl`) no longer reach the team ledger when the LLM correctly scores them as 0.

## Root cause (from forensics — see #525 comment for full trail)

`EvaluateQuality` at `internal/session/quality.go:17` had `if score <= 0 { return QualityUpload }` as a "LLM didn't provide a score → default to upload" backward-compat short-circuit. But the LLM reliably emits `"quality_score": 0` for empty sessions (`title: "Empty Session - No Activity Recorded"` — verified against 42 leaked on-disk sessions across three ledgers). The short-circuit conflated "unscored" with "scored exactly 0" and bypassed the `< discardThreshold` gate.

Three in-tree call sites were affected:

1. **Daemon finalize** (`internal/daemon/agentwork/session_finalize.go`) — anti-entropy detect + IPC finalize both feed `ProcessResult`, which called `EvaluateQuality` on the LLM-returned score of 0.
2. **Parse-failure / validation-failure fallbacks** in the same file, which set `QualityScore: 0.0` and relied on the short-circuit to force upload-with-stub.
3. **Push-summary CLI** (`cmd/ox/session_push_summary.go`) — reads `summary.json` from disk; pre-existing files without a `quality_score` field unmarshal to `0.0` and relied on the same short-circuit.

## Fix

Sentinel eliminated entirely. Dispositions are decided at the callsite where "scored vs. unscored" is already known.

```mermaid
flowchart TD
    A[LLM output] --> B{ParseSummaryJSON}
    B -->|error| C[stub: QualityScore=0, scored=false]
    B -->|ok| D{ValidateSummaryContent}
    D -->|error| E[reset score=0, scored=false]
    D -->|ok| F[parsed, scored=true]
    C --> G{scored?}
    E --> G
    F --> G
    G -->|true| H[EvaluateQuality score,up,down]
    G -->|false| I[QualityUpload]
    H --> J[discard / local / upload]
    I --> J
```

- `quality.go` — `EvaluateQuality` is pure threshold logic. Godoc explicitly forbids sentinel inputs and points readers at #525.
- `session_finalize.go` — tracks a local `scored bool`; fallback branches keep `QualityScore: 0.0` on disk (no sentinel leaks onto the ledger or into downstream gates like `distill_sessions.go`).
- `session_push_summary.go` — pre-pass unmarshal into `map[string]json.RawMessage` detects whether `quality_score` was present in the source JSON. Missing → upload; present (even explicit 0) → threshold gate.

## Review trail

Hypothesis testing isolated the exact SQL/Go line via on-disk forensics of 42 leaked sessions in the scribe, sageox-monorepo, and this repo's ledger. Initial fix used a `-1` sentinel; code-review (round 1) flagged that `-1` would leak to `summary.json` and corrupt `distill_sessions.go:251` and the dashboard. Refactored to eliminate the sentinel entirely; round 2 review returned "Ship it."

## Scoped out (follow-ups, noted in #525)

- `writeMetaAndUploadLFS` unconditionally sets `StopReasonRecovered` at `session_finalize.go:792` — wrong for non-recovery daemon finalizes.
- `SessionMeta.EntryCount int \`json:"entry_count,omitempty\"\`` — zero becomes missing on the wire; dashboard can't distinguish "0 entries" from "old schema."
- `HasSubstantiveEntries` is a line-count check that diverges from the post-parse `len(stored.Entries)` count — why the upstream enqueue guards let these through in the first place.

## Test plan

- [x] `go test ./internal/session/... ./internal/daemon/... ./cmd/ox/... -count=1 -short` — green
- [x] `go test ./... -count=1 -short` across the repo — green
- [x] `make lint` — 0 issues
- [x] New regression test `TestProcessResult_EmptySessionLLMScoreZero_Discarded` uses verbatim LLM output from a real leaked session; fails on main, passes here.
- [x] New coverage test `TestProcessResult_ValidationFailure_UploadsFallbackStub` pins validation-failure upload semantics.
- [ ] Post-merge: watch the `recovered` stop-reason rate on the dashboard; confirm no new "Entry Count: 0" sessions appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling when quality scores are missing or validation fails; fallback summaries are now properly uploaded instead of being discarded.
  * Explicit zero quality scores are correctly evaluated against quality thresholds rather than bypassed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->