### PR TITLE
fix(prime): harden AGENTS.md against cross-agent contamination (#527, #529)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,18 +204,6 @@ When asked if you're using SageOx: if you have an agent ID from running `ox agen
 
 <!-- ox:prime --> Run SageOx `ox agent prime` on session start, after compaction, or clear. (DO NOT REMOVE)
 
-<!-- ox:prime:start -->
-## SageOx Team Context
-
-This project uses [SageOx](https://sageox.ai) for team context. Run the following command at the start of every session to load team knowledge:
-
-```bash
-AGENT_ENV=pi ox agent prime
-```
-
-This provides architectural decisions, coding conventions, and session history from your team.
-<!-- ox:prime:end -->
-
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker
 

--- a/cmd/ox-adapter-aider/detect.go
+++ b/cmd/ox-adapter-aider/detect.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
@@ -46,7 +45,9 @@ func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.Diagnose
 	if p.RepoRoot != "" {
 		convPath := filepath.Join(p.RepoRoot, "CONVENTIONS.md")
 		if data, err := os.ReadFile(convPath); err == nil {
-			if !strings.Contains(string(data), aiderPrimeMarkerStart) {
+			// accept either the current or legacy Aider marker — a pre-#527
+			// install is still considered "installed" for diagnosis purposes
+			if !aiderBlockAlreadyPresent(string(data)) {
 				issues = append(issues, adapterprotocol.DiagnoseIssue{
 					Slug:     "aider:hooks-missing",
 					Severity: "warning",

--- a/cmd/ox-adapter-aider/hooks.go
+++ b/cmd/ox-adapter-aider/hooks.go
@@ -164,17 +164,24 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 
 // removePrimeBlock strips one start...end block (inclusive) from content,
 // collapsing surrounding blank lines so no orphan whitespace remains.
-// Returns content unchanged if either marker is absent.
+// Returns content unchanged if either marker is absent, or if no end
+// marker appears AFTER the start marker (which would indicate an orphan
+// end marker earlier in the file — hand-edits, partial pastes, merge
+// accidents can all produce this; we refuse to operate rather than
+// silently delete arbitrary content between an orphan end and a real
+// start). CodeRabbit review on #543.
 func removePrimeBlock(content, startMarker, endMarker string) string {
 	startIdx := strings.Index(content, startMarker)
 	if startIdx == -1 {
 		return content
 	}
-	endIdx := strings.Index(content, endMarker)
-	if endIdx == -1 {
+	// search for endMarker AFTER the start marker so an orphan end marker
+	// earlier in the file can't form an inverted range
+	rel := strings.Index(content[startIdx+len(startMarker):], endMarker)
+	if rel == -1 {
 		return content
 	}
-	endIdx += len(endMarker)
+	endIdx := startIdx + len(startMarker) + rel + len(endMarker)
 
 	before := strings.TrimRight(content[:startIdx], "\n")
 	after := strings.TrimLeft(content[endIdx:], "\n")

--- a/cmd/ox-adapter-aider/hooks.go
+++ b/cmd/ox-adapter-aider/hooks.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
@@ -84,7 +85,7 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 		newContent = strings.TrimRight(content, "\n") + "\n\n" + aiderPrimeBlock + "\n"
 	}
 
-	if err := os.WriteFile(convPath, []byte(newContent), 0644); err != nil {
+	if err := fileutil.AtomicWriteBytes(convPath, []byte(newContent), 0644); err != nil {
 		return nil, fmt.Errorf("failed to write CONVENTIONS.md: %w", err)
 	}
 
@@ -150,7 +151,7 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 			return nil, fmt.Errorf("failed to remove empty CONVENTIONS.md: %w", err)
 		}
 	} else {
-		if err := os.WriteFile(convPath, []byte(cleaned), 0644); err != nil {
+		if err := fileutil.AtomicWriteBytes(convPath, []byte(cleaned), 0644); err != nil {
 			return nil, fmt.Errorf("failed to write CONVENTIONS.md: %w", err)
 		}
 	}

--- a/cmd/ox-adapter-aider/hooks.go
+++ b/cmd/ox-adapter-aider/hooks.go
@@ -10,22 +10,48 @@ import (
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
-const aiderPrimeMarkerStart = "<!-- ox:prime:start -->"
-const aiderPrimeMarkerEnd = "<!-- ox:prime:end -->"
+// aiderPrimeMarkerStart / End are the Aider-specific block markers. Each
+// adapter uses a unique pair so installs/uninstalls don't collide across
+// adapters. Aider writes CONVENTIONS.md (not AGENTS.md), so today's risk
+// of collision is low, but the consistency simplifies shared helpers and
+// the #527 doctor repair logic. See #527.
+const aiderPrimeMarkerStart = "<!-- ox:prime:aider:start -->"
+const aiderPrimeMarkerEnd = "<!-- ox:prime:aider:end -->"
+
+// aiderLegacyPrimeMarkerStart / End are the pre-#527 generic markers.
+// Kept for backward-compat detection: check matches both; uninstall
+// removes both. New installs only emit the unique markers.
+const aiderLegacyPrimeMarkerStart = "<!-- ox:prime:start -->"
+const aiderLegacyPrimeMarkerEnd = "<!-- ox:prime:end -->"
 
 // aiderPrimeBlock is the content injected into CONVENTIONS.md for Aider.
 // Aider loads CONVENTIONS.md via the --read flag in .aider.conf.yml.
+//
+// NOTE: the prime command is intentionally adapter-agnostic — no hardcoded
+// AGENT_ENV=<adapter> prefix. Instruction files can leak across agents
+// (e.g. via shared symlinks), and a hardcoded AGENT_ENV in the block
+// poisons sessions running a different coding agent. Runtime detection
+// in agentx.CurrentAgent handles agent identification correctly. See #527.
 var aiderPrimeBlock = aiderPrimeMarkerStart + "\n" +
 	"## SageOx Team Context\n" +
 	"\n" +
 	"This project uses [SageOx](https://sageox.ai) for team context. Run the following command at the start of every session to load team knowledge:\n" +
 	"\n" +
 	"```bash\n" +
-	"AGENT_ENV=aider ox agent prime\n" +
+	"ox agent prime\n" +
 	"```\n" +
 	"\n" +
 	"This provides architectural decisions, coding conventions, and session history from your team.\n" +
 	aiderPrimeMarkerEnd
+
+// aiderBlockAlreadyPresent reports whether CONVENTIONS.md already carries
+// an Aider prime block under either the current or legacy marker pair.
+// Legacy markers are recognized so pre-#527 installations are treated as
+// "installed" and we don't stack a second block on top of them.
+func aiderBlockAlreadyPresent(content string) bool {
+	return strings.Contains(content, aiderPrimeMarkerStart) ||
+		strings.Contains(content, aiderLegacyPrimeMarkerStart)
+}
 
 func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallHooksResponse, error) {
 	if p.Scope == "user" {
@@ -43,8 +69,8 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 
 	content := string(existing)
 
-	// already installed — idempotent
-	if strings.Contains(content, aiderPrimeMarkerStart) {
+	// already installed — idempotent (current or legacy markers)
+	if aiderBlockAlreadyPresent(content) {
 		return &adapterprotocol.InstallHooksResponse{
 			Installed:    true,
 			FilesWritten: []string{convPath},
@@ -85,7 +111,7 @@ func handleCheckHooks(p adapterprotocol.HookParams) (*adapterprotocol.CheckHooks
 		}, nil
 	}
 
-	installed := strings.Contains(string(data), aiderPrimeMarkerStart)
+	installed := aiderBlockAlreadyPresent(string(data))
 	return &adapterprotocol.CheckHooksResponse{
 		Installed: installed,
 		Scope:     p.Scope,
@@ -109,29 +135,14 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 
 	content := string(data)
 
-	startIdx := strings.Index(content, aiderPrimeMarkerStart)
-	if startIdx == -1 {
+	// remove both the current-marker block and any legacy-marker block —
+	// a pre-#527 installation may carry the generic <!-- ox:prime:start -->
+	// pair that we no longer emit.
+	cleaned := removePrimeBlock(content, aiderPrimeMarkerStart, aiderPrimeMarkerEnd)
+	cleaned = removePrimeBlock(cleaned, aiderLegacyPrimeMarkerStart, aiderLegacyPrimeMarkerEnd)
+
+	if cleaned == content {
 		return &adapterprotocol.UninstallHooksResponse{Uninstalled: true}, nil
-	}
-
-	endIdx := strings.Index(content, aiderPrimeMarkerEnd)
-	if endIdx == -1 {
-		return &adapterprotocol.UninstallHooksResponse{Uninstalled: true}, nil
-	}
-	endIdx += len(aiderPrimeMarkerEnd)
-
-	before := strings.TrimRight(content[:startIdx], "\n")
-	after := strings.TrimLeft(content[endIdx:], "\n")
-
-	var cleaned string
-	if before == "" && after == "" {
-		cleaned = ""
-	} else if before == "" {
-		cleaned = after + "\n"
-	} else if after == "" {
-		cleaned = before + "\n"
-	} else {
-		cleaned = before + "\n\n" + after + "\n"
 	}
 
 	if strings.TrimSpace(cleaned) == "" {
@@ -148,6 +159,35 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 		Uninstalled:   true,
 		FilesModified: []string{convPath},
 	}, nil
+}
+
+// removePrimeBlock strips one start...end block (inclusive) from content,
+// collapsing surrounding blank lines so no orphan whitespace remains.
+// Returns content unchanged if either marker is absent.
+func removePrimeBlock(content, startMarker, endMarker string) string {
+	startIdx := strings.Index(content, startMarker)
+	if startIdx == -1 {
+		return content
+	}
+	endIdx := strings.Index(content, endMarker)
+	if endIdx == -1 {
+		return content
+	}
+	endIdx += len(endMarker)
+
+	before := strings.TrimRight(content[:startIdx], "\n")
+	after := strings.TrimLeft(content[endIdx:], "\n")
+
+	switch {
+	case before == "" && after == "":
+		return ""
+	case before == "":
+		return after + "\n"
+	case after == "":
+		return before + "\n"
+	default:
+		return before + "\n\n" + after + "\n"
+	}
 }
 
 func resolveConventionsPath(repoRoot string) string {

--- a/cmd/ox-adapter-amp/detect.go
+++ b/cmd/ox-adapter-amp/detect.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
@@ -49,7 +48,9 @@ func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.Diagnose
 	if p.RepoRoot != "" {
 		agentsPath := filepath.Join(p.RepoRoot, "AGENTS.md")
 		if data, err := os.ReadFile(agentsPath); err == nil {
-			if !strings.Contains(string(data), ampPrimeMarkerStart) {
+			// accept either the current or legacy Amp marker — a pre-#527
+			// install is still considered "installed" for diagnosis purposes
+			if !ampBlockAlreadyPresent(string(data)) {
 				issues = append(issues, adapterprotocol.DiagnoseIssue{
 					Slug:     "amp:hooks-missing",
 					Severity: "warning",

--- a/cmd/ox-adapter-amp/hooks.go
+++ b/cmd/ox-adapter-amp/hooks.go
@@ -170,17 +170,24 @@ func resolveAgentsMDPath(repoRoot string) string {
 
 // removePrimeBlock strips one start...end block (inclusive) from content,
 // collapsing surrounding blank lines so no orphan whitespace remains.
-// Returns content unchanged if either marker is absent.
+// Returns content unchanged if either marker is absent, or if no end
+// marker appears AFTER the start marker (which would indicate an orphan
+// end marker earlier in the file — hand-edits, partial pastes, merge
+// accidents can all produce this; we refuse to operate rather than
+// silently delete arbitrary content between an orphan end and a real
+// start). CodeRabbit review on #543.
 func removePrimeBlock(content, startMarker, endMarker string) string {
 	startIdx := strings.Index(content, startMarker)
 	if startIdx == -1 {
 		return content
 	}
-	endIdx := strings.Index(content, endMarker)
-	if endIdx == -1 {
+	// search for endMarker AFTER the start marker so an orphan end marker
+	// earlier in the file can't form an inverted range
+	rel := strings.Index(content[startIdx+len(startMarker):], endMarker)
+	if rel == -1 {
 		return content
 	}
-	endIdx += len(endMarker)
+	endIdx := startIdx + len(startMarker) + rel + len(endMarker)
 
 	before := strings.TrimRight(content[:startIdx], "\n")
 	after := strings.TrimLeft(content[endIdx:], "\n")

--- a/cmd/ox-adapter-amp/hooks.go
+++ b/cmd/ox-adapter-amp/hooks.go
@@ -10,22 +10,46 @@ import (
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
-const ampPrimeMarkerStart = "<!-- ox:prime:start -->"
-const ampPrimeMarkerEnd = "<!-- ox:prime:end -->"
+// ampPrimeMarkerStart / End are the Amp-specific block markers. Each
+// adapter uses a unique pair so installs/uninstalls don't collide across
+// adapters that share AGENTS.md. See #527.
+const ampPrimeMarkerStart = "<!-- ox:prime:amp:start -->"
+const ampPrimeMarkerEnd = "<!-- ox:prime:amp:end -->"
+
+// ampLegacyPrimeMarkerStart / End are the pre-#527 generic markers. Kept
+// for backward-compat detection: check matches both; uninstall removes
+// both. New installs only emit the unique markers.
+const ampLegacyPrimeMarkerStart = "<!-- ox:prime:start -->"
+const ampLegacyPrimeMarkerEnd = "<!-- ox:prime:end -->"
 
 // ampPrimeBlock is the content injected into AGENTS.md for Amp CLI.
 // Amp auto-loads AGENTS.md from the project root on every session.
+//
+// NOTE: the prime command is intentionally adapter-agnostic — no hardcoded
+// AGENT_ENV=<adapter> prefix. AGENTS.md is often shared across agents, so
+// any block that mis-routes AGENT_ENV poisons sessions running a different
+// coding agent. Runtime detection in agentx.CurrentAgent handles agent
+// identification correctly. See #527.
 var ampPrimeBlock = ampPrimeMarkerStart + "\n" +
 	"## SageOx Team Context\n" +
 	"\n" +
 	"This project uses [SageOx](https://sageox.ai) for team context. Run the following command at the start of every session to load team knowledge:\n" +
 	"\n" +
 	"```bash\n" +
-	"AGENT_ENV=amp ox agent prime\n" +
+	"ox agent prime\n" +
 	"```\n" +
 	"\n" +
 	"This provides architectural decisions, coding conventions, and session history from your team.\n" +
 	ampPrimeMarkerEnd
+
+// ampBlockAlreadyPresent reports whether AGENTS.md already carries an Amp
+// prime block under either the current or legacy marker pair. Legacy
+// markers are recognized so pre-#527 installations are treated as
+// "installed" and we don't stack a second block on top of them.
+func ampBlockAlreadyPresent(content string) bool {
+	return strings.Contains(content, ampPrimeMarkerStart) ||
+		strings.Contains(content, ampLegacyPrimeMarkerStart)
+}
 
 func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallHooksResponse, error) {
 	if p.Scope == "user" {
@@ -43,8 +67,8 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 
 	content := string(existing)
 
-	// already installed — idempotent
-	if strings.Contains(content, ampPrimeMarkerStart) {
+	// already installed — idempotent (current or legacy markers)
+	if ampBlockAlreadyPresent(content) {
 		return &adapterprotocol.InstallHooksResponse{
 			Installed:    true,
 			FilesWritten: []string{agentsPath},
@@ -85,7 +109,7 @@ func handleCheckHooks(p adapterprotocol.HookParams) (*adapterprotocol.CheckHooks
 		}, nil
 	}
 
-	installed := strings.Contains(string(data), ampPrimeMarkerStart)
+	installed := ampBlockAlreadyPresent(string(data))
 	return &adapterprotocol.CheckHooksResponse{
 		Installed: installed,
 		Scope:     p.Scope,
@@ -109,29 +133,14 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 
 	content := string(data)
 
-	startIdx := strings.Index(content, ampPrimeMarkerStart)
-	if startIdx == -1 {
+	// remove both the current-marker block and any legacy-marker block —
+	// a pre-#527 installation may carry the generic <!-- ox:prime:start -->
+	// pair that we no longer emit.
+	cleaned := removePrimeBlock(content, ampPrimeMarkerStart, ampPrimeMarkerEnd)
+	cleaned = removePrimeBlock(cleaned, ampLegacyPrimeMarkerStart, ampLegacyPrimeMarkerEnd)
+
+	if cleaned == content {
 		return &adapterprotocol.UninstallHooksResponse{Uninstalled: true}, nil
-	}
-
-	endIdx := strings.Index(content, ampPrimeMarkerEnd)
-	if endIdx == -1 {
-		return &adapterprotocol.UninstallHooksResponse{Uninstalled: true}, nil
-	}
-	endIdx += len(ampPrimeMarkerEnd)
-
-	before := strings.TrimRight(content[:startIdx], "\n")
-	after := strings.TrimLeft(content[endIdx:], "\n")
-
-	var cleaned string
-	if before == "" && after == "" {
-		cleaned = ""
-	} else if before == "" {
-		cleaned = after + "\n"
-	} else if after == "" {
-		cleaned = before + "\n"
-	} else {
-		cleaned = before + "\n\n" + after + "\n"
 	}
 
 	if strings.TrimSpace(cleaned) == "" {
@@ -156,4 +165,33 @@ func resolveAgentsMDPath(repoRoot string) string {
 		repoRoot, _ = os.Getwd()
 	}
 	return filepath.Join(repoRoot, "AGENTS.md")
+}
+
+// removePrimeBlock strips one start...end block (inclusive) from content,
+// collapsing surrounding blank lines so no orphan whitespace remains.
+// Returns content unchanged if either marker is absent.
+func removePrimeBlock(content, startMarker, endMarker string) string {
+	startIdx := strings.Index(content, startMarker)
+	if startIdx == -1 {
+		return content
+	}
+	endIdx := strings.Index(content, endMarker)
+	if endIdx == -1 {
+		return content
+	}
+	endIdx += len(endMarker)
+
+	before := strings.TrimRight(content[:startIdx], "\n")
+	after := strings.TrimLeft(content[endIdx:], "\n")
+
+	switch {
+	case before == "" && after == "":
+		return ""
+	case before == "":
+		return after + "\n"
+	case after == "":
+		return before + "\n"
+	default:
+		return before + "\n\n" + after + "\n"
+	}
 }

--- a/cmd/ox-adapter-amp/hooks.go
+++ b/cmd/ox-adapter-amp/hooks.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
@@ -82,7 +83,7 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 		newContent = strings.TrimRight(content, "\n") + "\n\n" + ampPrimeBlock + "\n"
 	}
 
-	if err := os.WriteFile(agentsPath, []byte(newContent), 0644); err != nil {
+	if err := fileutil.AtomicWriteBytes(agentsPath, []byte(newContent), 0644); err != nil {
 		return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
 	}
 
@@ -148,7 +149,7 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 			return nil, fmt.Errorf("failed to remove empty AGENTS.md: %w", err)
 		}
 	} else {
-		if err := os.WriteFile(agentsPath, []byte(cleaned), 0644); err != nil {
+		if err := fileutil.AtomicWriteBytes(agentsPath, []byte(cleaned), 0644); err != nil {
 			return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
 		}
 	}

--- a/cmd/ox-adapter-amp/hooks_test.go
+++ b/cmd/ox-adapter-amp/hooks_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAmpMarkers_AreUniqueToAmp guards the #527 fix: Amp must not share
+// marker strings with Pi (both write AGENTS.md). A shared marker causes
+// the second adapter's install to silently no-op via the other's idempotency
+// check, hiding bugs and confusing uninstall.
+// Failure prevented: Pi+Amp co-install collapsing to one block or wrong ownership.
+func TestAmpMarkers_AreUniqueToAmp(t *testing.T) {
+	assert.NotEqual(t, "<!-- ox:prime:start -->", ampPrimeMarkerStart,
+		"Amp must use a unique marker pair, not the generic legacy pair")
+	assert.Contains(t, ampPrimeMarkerStart, "amp",
+		"Amp's unique marker should name amp so cross-adapter collisions are visually obvious")
+	// sanity: amp's current marker must also differ from pi's unique marker
+	assert.NotEqual(t, "<!-- ox:prime:pi:start -->", ampPrimeMarkerStart,
+		"Amp and Pi must not share a marker")
+}
+
+func TestAmpInstall_IdempotentForCurrentMarker(t *testing.T) {
+	dir := t.TempDir()
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+	_, err = handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(string(data), ampPrimeMarkerStart))
+}
+
+// TestAmpInstall_IdempotentForLegacyMarker confirms a pre-#527 Amp install
+// (generic markers) is recognized so a fresh install doesn't stack a second
+// block alongside the legacy one.
+func TestAmpInstall_IdempotentForLegacyMarker(t *testing.T) {
+	dir := t.TempDir()
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+
+	seed := ampLegacyPrimeMarkerStart + "\nold block\n" + ampLegacyPrimeMarkerEnd + "\n"
+	require.NoError(t, os.WriteFile(agentsPath, []byte(seed), 0644))
+
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(agentsPath)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, ampLegacyPrimeMarkerStart)
+	assert.NotContains(t, content, ampPrimeMarkerStart)
+}
+
+func TestAmpUninstall_RemovesCurrentAndLegacyBlocks(t *testing.T) {
+	dir := t.TempDir()
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+
+	content := ampPrimeMarkerStart + "\ncurrent\n" + ampPrimeMarkerEnd + "\n\n" +
+		ampLegacyPrimeMarkerStart + "\nlegacy\n" + ampLegacyPrimeMarkerEnd + "\n"
+	require.NoError(t, os.WriteFile(agentsPath, []byte(content), 0644))
+
+	_, err := handleUninstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+
+	if data, readErr := os.ReadFile(agentsPath); readErr == nil {
+		got := string(data)
+		assert.NotContains(t, got, ampPrimeMarkerStart)
+		assert.NotContains(t, got, ampLegacyPrimeMarkerStart)
+	}
+}

--- a/cmd/ox-adapter-pi/detect.go
+++ b/cmd/ox-adapter-pi/detect.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
@@ -49,7 +48,9 @@ func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.Diagnose
 	if p.RepoRoot != "" {
 		agentsPath := filepath.Join(p.RepoRoot, "AGENTS.md")
 		if data, err := os.ReadFile(agentsPath); err == nil {
-			if !strings.Contains(string(data), piPrimeMarkerStart) {
+			// accept either the current or legacy Pi marker — a pre-#527
+			// install is still considered "installed" for diagnosis purposes
+			if !piBlockAlreadyPresent(string(data)) {
 				issues = append(issues, adapterprotocol.DiagnoseIssue{
 					Slug:     "pi:hooks-missing",
 					Severity: "warning",

--- a/cmd/ox-adapter-pi/hooks.go
+++ b/cmd/ox-adapter-pi/hooks.go
@@ -171,17 +171,24 @@ func resolveAgentsMDPath(repoRoot string) string {
 
 // removePrimeBlock strips one start...end block (inclusive) from content,
 // collapsing surrounding blank lines so no orphan whitespace remains.
-// Returns content unchanged if either marker is absent.
+// Returns content unchanged if either marker is absent, or if no end
+// marker appears AFTER the start marker (which would indicate an orphan
+// end marker earlier in the file — hand-edits, partial pastes, merge
+// accidents can all produce this; we refuse to operate rather than
+// silently delete arbitrary content between an orphan end and a real
+// start). CodeRabbit review on #543.
 func removePrimeBlock(content, startMarker, endMarker string) string {
 	startIdx := strings.Index(content, startMarker)
 	if startIdx == -1 {
 		return content
 	}
-	endIdx := strings.Index(content, endMarker)
-	if endIdx == -1 {
+	// search for endMarker AFTER the start marker so an orphan end marker
+	// earlier in the file can't form an inverted range
+	rel := strings.Index(content[startIdx+len(startMarker):], endMarker)
+	if rel == -1 {
 		return content
 	}
-	endIdx += len(endMarker)
+	endIdx := startIdx + len(startMarker) + rel + len(endMarker)
 
 	before := strings.TrimRight(content[:startIdx], "\n")
 	after := strings.TrimLeft(content[endIdx:], "\n")

--- a/cmd/ox-adapter-pi/hooks.go
+++ b/cmd/ox-adapter-pi/hooks.go
@@ -10,22 +10,46 @@ import (
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
-const piPrimeMarkerStart = "<!-- ox:prime:start -->"
-const piPrimeMarkerEnd = "<!-- ox:prime:end -->"
+// piPrimeMarkerStart / End are the Pi-specific block markers. Each adapter
+// uses a unique pair so installs/uninstalls don't collide across adapters
+// that share AGENTS.md. See #527.
+const piPrimeMarkerStart = "<!-- ox:prime:pi:start -->"
+const piPrimeMarkerEnd = "<!-- ox:prime:pi:end -->"
+
+// piLegacyPrimeMarkerStart / End are the pre-#527 generic markers. Kept
+// for backward-compat detection: check matches both; uninstall removes
+// both. New installs only emit the unique markers.
+const piLegacyPrimeMarkerStart = "<!-- ox:prime:start -->"
+const piLegacyPrimeMarkerEnd = "<!-- ox:prime:end -->"
 
 // piPrimeBlock is the content injected into AGENTS.md for Pi coding agent.
 // Pi auto-loads AGENTS.md from the project root and parent directories on every session.
+//
+// NOTE: the prime command is intentionally adapter-agnostic — no hardcoded
+// AGENT_ENV=<adapter> prefix. AGENTS.md is often shared across agents (e.g.
+// via a CLAUDE.md symlink), so any block that mis-routes AGENT_ENV poisons
+// sessions running a different coding agent. Runtime detection in
+// agentx.CurrentAgent handles agent identification correctly. See #527.
 var piPrimeBlock = piPrimeMarkerStart + "\n" +
 	"## SageOx Team Context\n" +
 	"\n" +
 	"This project uses [SageOx](https://sageox.ai) for team context. Run the following command at the start of every session to load team knowledge:\n" +
 	"\n" +
 	"```bash\n" +
-	"AGENT_ENV=pi ox agent prime\n" +
+	"ox agent prime\n" +
 	"```\n" +
 	"\n" +
 	"This provides architectural decisions, coding conventions, and session history from your team.\n" +
 	piPrimeMarkerEnd
+
+// piBlockAlreadyPresent reports whether AGENTS.md already carries a Pi
+// prime block under either the current or legacy marker pair. Legacy
+// markers are recognized so pre-#527 installations are treated as
+// "installed" and we don't stack a second block on top of them.
+func piBlockAlreadyPresent(content string) bool {
+	return strings.Contains(content, piPrimeMarkerStart) ||
+		strings.Contains(content, piLegacyPrimeMarkerStart)
+}
 
 func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallHooksResponse, error) {
 	if p.Scope == "user" {
@@ -43,8 +67,8 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 
 	content := string(existing)
 
-	// already installed — idempotent
-	if strings.Contains(content, piPrimeMarkerStart) {
+	// already installed — idempotent (current or legacy markers)
+	if piBlockAlreadyPresent(content) {
 		return &adapterprotocol.InstallHooksResponse{
 			Installed:    true,
 			FilesWritten: []string{agentsPath},
@@ -85,7 +109,7 @@ func handleCheckHooks(p adapterprotocol.HookParams) (*adapterprotocol.CheckHooks
 		}, nil
 	}
 
-	installed := strings.Contains(string(data), piPrimeMarkerStart)
+	installed := piBlockAlreadyPresent(string(data))
 	return &adapterprotocol.CheckHooksResponse{
 		Installed: installed,
 		Scope:     p.Scope,
@@ -109,29 +133,15 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 
 	content := string(data)
 
-	startIdx := strings.Index(content, piPrimeMarkerStart)
-	if startIdx == -1 {
+	// remove both the current-marker block and any legacy-marker block —
+	// a pre-#527 installation may carry the generic <!-- ox:prime:start -->
+	// pair that we no longer emit.
+	cleaned := removePrimeBlock(content, piPrimeMarkerStart, piPrimeMarkerEnd)
+	cleaned = removePrimeBlock(cleaned, piLegacyPrimeMarkerStart, piLegacyPrimeMarkerEnd)
+
+	if cleaned == content {
+		// nothing to uninstall
 		return &adapterprotocol.UninstallHooksResponse{Uninstalled: true}, nil
-	}
-
-	endIdx := strings.Index(content, piPrimeMarkerEnd)
-	if endIdx == -1 {
-		return &adapterprotocol.UninstallHooksResponse{Uninstalled: true}, nil
-	}
-	endIdx += len(piPrimeMarkerEnd)
-
-	before := strings.TrimRight(content[:startIdx], "\n")
-	after := strings.TrimLeft(content[endIdx:], "\n")
-
-	var cleaned string
-	if before == "" && after == "" {
-		cleaned = ""
-	} else if before == "" {
-		cleaned = after + "\n"
-	} else if after == "" {
-		cleaned = before + "\n"
-	} else {
-		cleaned = before + "\n\n" + after + "\n"
 	}
 
 	if strings.TrimSpace(cleaned) == "" {
@@ -156,4 +166,33 @@ func resolveAgentsMDPath(repoRoot string) string {
 		repoRoot, _ = os.Getwd()
 	}
 	return filepath.Join(repoRoot, "AGENTS.md")
+}
+
+// removePrimeBlock strips one start...end block (inclusive) from content,
+// collapsing surrounding blank lines so no orphan whitespace remains.
+// Returns content unchanged if either marker is absent.
+func removePrimeBlock(content, startMarker, endMarker string) string {
+	startIdx := strings.Index(content, startMarker)
+	if startIdx == -1 {
+		return content
+	}
+	endIdx := strings.Index(content, endMarker)
+	if endIdx == -1 {
+		return content
+	}
+	endIdx += len(endMarker)
+
+	before := strings.TrimRight(content[:startIdx], "\n")
+	after := strings.TrimLeft(content[endIdx:], "\n")
+
+	switch {
+	case before == "" && after == "":
+		return ""
+	case before == "":
+		return after + "\n"
+	case after == "":
+		return before + "\n"
+	default:
+		return before + "\n\n" + after + "\n"
+	}
 }

--- a/cmd/ox-adapter-pi/hooks.go
+++ b/cmd/ox-adapter-pi/hooks.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
@@ -82,7 +83,7 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 		newContent = strings.TrimRight(content, "\n") + "\n\n" + piPrimeBlock + "\n"
 	}
 
-	if err := os.WriteFile(agentsPath, []byte(newContent), 0644); err != nil {
+	if err := fileutil.AtomicWriteBytes(agentsPath, []byte(newContent), 0644); err != nil {
 		return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
 	}
 
@@ -149,7 +150,7 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 			return nil, fmt.Errorf("failed to remove empty AGENTS.md: %w", err)
 		}
 	} else {
-		if err := os.WriteFile(agentsPath, []byte(cleaned), 0644); err != nil {
+		if err := fileutil.AtomicWriteBytes(agentsPath, []byte(cleaned), 0644); err != nil {
 			return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
 		}
 	}

--- a/cmd/ox-adapter-pi/hooks_test.go
+++ b/cmd/ox-adapter-pi/hooks_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Marker uniqueness ---
+
+// TestPiMarkers_AreUniqueToPi guards the #527 fix: the current Pi marker
+// must not be the generic <!-- ox:prime:* --> pair that used to collide
+// with Amp in shared AGENTS.md.
+// Failure prevented: reintroducing a generic marker that silently no-ops
+// a second adapter's install via shared-marker idempotency.
+func TestPiMarkers_AreUniqueToPi(t *testing.T) {
+	assert.NotEqual(t, "<!-- ox:prime:start -->", piPrimeMarkerStart,
+		"Pi must use a unique marker pair, not the generic legacy pair")
+	assert.Contains(t, piPrimeMarkerStart, "pi",
+		"Pi's unique marker should name pi so cross-adapter collisions are visually obvious")
+}
+
+// --- Install idempotency across marker generations ---
+
+// TestInstall_IdempotentForCurrentMarker confirms a second install no-ops
+// when the current marker pair is already present.
+// Failure prevented: duplicate Pi blocks appearing in AGENTS.md across repeated installs.
+func TestInstall_IdempotentForCurrentMarker(t *testing.T) {
+	dir := t.TempDir()
+
+	// first install
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+
+	// second install — must be a no-op
+	_, err = handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+	content := string(data)
+	assert.Equal(t, 1, strings.Count(content, piPrimeMarkerStart),
+		"current Pi start marker must appear exactly once after two installs")
+}
+
+// TestInstall_IdempotentForLegacyInProcessMarker confirms a pre-#527
+// installation that only the in-process hooks_pi.go ever emitted
+// (<!-- ox:pi-prime:start -->) is recognized so a fresh install does
+// not add a duplicate current-marker block alongside it.
+// Failure prevented: repos with legacy markers get two blocks after upgrade.
+func TestInstall_IdempotentForLegacyGenericMarker(t *testing.T) {
+	dir := t.TempDir()
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+
+	// seed with the pre-#527 generic marker pair that the external
+	// adapter used to emit
+	seed := piLegacyPrimeMarkerStart + "\nold block\n" + piLegacyPrimeMarkerEnd + "\n"
+	require.NoError(t, os.WriteFile(agentsPath, []byte(seed), 0644))
+
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(agentsPath)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, piLegacyPrimeMarkerStart,
+		"legacy block should be preserved; doctor is responsible for cleanup")
+	assert.NotContains(t, content, piPrimeMarkerStart,
+		"legacy presence must prevent adding a second (current-marker) block")
+}
+
+// --- Uninstall sweeps all generations ---
+
+// TestUninstall_RemovesCurrentAndLegacyBlocks confirms a single uninstall
+// cleans up every recognized marker pair, even ones that pre-date the #527 fix.
+// Failure prevented: orphan legacy blocks surviving uninstall and corrupting
+// subsequent installs.
+func TestUninstall_RemovesCurrentAndLegacyBlocks(t *testing.T) {
+	dir := t.TempDir()
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+
+	// seed with both a current and a legacy block adjacent — simulating
+	// a repo that was installed pre-fix and then again post-fix
+	content := piPrimeMarkerStart + "\ncurrent\n" + piPrimeMarkerEnd + "\n\n" +
+		piLegacyPrimeMarkerStart + "\nlegacy\n" + piLegacyPrimeMarkerEnd + "\n"
+	require.NoError(t, os.WriteFile(agentsPath, []byte(content), 0644))
+
+	_, err := handleUninstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+
+	// file may be removed entirely since all content was our blocks
+	if data, readErr := os.ReadFile(agentsPath); readErr == nil {
+		got := string(data)
+		assert.NotContains(t, got, piPrimeMarkerStart)
+		assert.NotContains(t, got, piLegacyPrimeMarkerStart)
+	}
+}

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -187,7 +187,15 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	// hook already primed) typically has no hook stdin JSON, so the
 	// session-id-keyed lookup above misses. Walk to the agent ancestor PID
 	// and find a marker that references it. See #527/#529.
-	if existingMarker == nil {
+	//
+	// SAFETY: only trust the PID when agentx actually detected a coding
+	// agent. proc.FindAgentAncestorPID falls back to os.Getppid() when
+	// no known agent binary is found in the ancestor chain — in a plain
+	// shell that would be the shell PID, which could coincidentally
+	// match a stale marker from an unrelated prior session and silently
+	// cross-link identities. Requiring a live agent detection keeps the
+	// fallback limited to the scenario it was designed for.
+	if existingMarker == nil && agentx.CurrentAgent() != nil {
 		if agentPID := proc.FindAgentAncestorPID(); agentPID > 0 {
 			existingMarker = FindSessionMarkerByPID(agentPID)
 			if existingMarker != nil && agentSessionID == "" {
@@ -478,6 +486,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 					"agent_id", agentID,
 					"stored_agent_type", updated.AgentType,
 					"claimed_agent_type", agentType)
+				trackPrimeTypeMismatch(updated, agentType)
 				// honor the frozen type for the rest of this prime call
 				agentType = updated.AgentType
 			}
@@ -1609,6 +1618,28 @@ func trackPrimeExcessive(inst *agentinstance.Instance) {
 			Model:          inst.Model,
 			PrimeCallCount: inst.PrimeCallCount,
 			Success:        true,
+		})
+	}
+}
+
+// trackPrimeTypeMismatch tracks when a re-prime claimed a different
+// agent_type than the originally-registered instance. The classic #527
+// signature is a SessionStart hook registering agent_type=claude-code,
+// followed by a CLAUDE.md-driven re-prime that mis-routes as pi/amp/aider
+// via a hardcoded AGENT_ENV in a shared instruction file. Surfacing this
+// in telemetry makes adapter-block mis-routing visible across the fleet.
+func trackPrimeTypeMismatch(inst *agentinstance.Instance, claimedType string) {
+	if cliCtx != nil && cliCtx.TelemetryClient != nil {
+		cliCtx.TelemetryClient.Track(telemetry.Event{
+			Type:      telemetry.EventPrimeTypeMismatch,
+			AgentID:   inst.AgentID,
+			SessionID: inst.ServerSessionID,
+			AgentType: inst.AgentType, // stored / authoritative
+			Model:     inst.Model,
+			Success:   true,
+			Metadata: map[string]string{
+				"claimed_agent_type": claimedType,
+			},
 		})
 	}
 }

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -481,14 +481,28 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 			// stored value; surface the mismatch as a warning + telemetry so
 			// bad adapter configs become visible instead of silently rewriting
 			// the session's identity mid-flight.
+			//
+			// Note on the AgentType == "" case: instances registered by earlier
+			// ox versions may have an empty stored AgentType. We intentionally
+			// do NOT treat this as a mismatch — upgrading an unknown type into
+			// whatever the current prime claims would give silent identity
+			// promotion, exactly what this freeze is designed to prevent.
+			// The claimed type is used for this call's output / User-Agent but
+			// telemetry (via trackInstanceStart below) keeps using inst.AgentType.
 			if agentType != "" && updated.AgentType != "" && agentType != updated.AgentType {
 				slog.Warn("prime: agent_type mismatch on re-prime; keeping stored value",
 					"agent_id", agentID,
 					"stored_agent_type", updated.AgentType,
 					"claimed_agent_type", agentType)
 				trackPrimeTypeMismatch(updated, agentType)
-				// honor the frozen type for the rest of this prime call
+				// Honor the frozen type for the rest of this prime call,
+				// including the outbound User-Agent — an earlier call at
+				// the top of runAgentPrime primed the UA with the claimed
+				// (wrong) value before we knew about the conflict. Re-apply
+				// the authoritative stored type so any API calls this prime
+				// makes from here on carry the correct identity.
 				agentType = updated.AgentType
+				useragent.SetAgentType(agentType)
 			}
 		} else if !errors.Is(err, agentinstance.ErrInstanceNotFound) {
 			return fmt.Errorf("failed to update instance: %w", err)

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -181,11 +181,26 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	var existingMarker *SessionMarker
 	if agentSessionID != "" {
 		existingMarker, _ = ReadSessionMarker(agentSessionID)
-		if existingMarker != nil && idempotent {
-			// idempotent mode: session already primed, output nothing
-			// this saves ~1k tokens on redundant prime calls
-			return nil
+	}
+	// PID-based fallback: a second prime inside the same agent process
+	// (e.g. CLAUDE.md BLOCKING instruction running after the SessionStart
+	// hook already primed) typically has no hook stdin JSON, so the
+	// session-id-keyed lookup above misses. Walk to the agent ancestor PID
+	// and find a marker that references it. See #527/#529.
+	if existingMarker == nil {
+		if agentPID := proc.FindAgentAncestorPID(); agentPID > 0 {
+			existingMarker = FindSessionMarkerByPID(agentPID)
+			if existingMarker != nil && agentSessionID == "" {
+				// promote the marker's native session ID so downstream
+				// marker writes reuse the same key
+				agentSessionID = existingMarker.AgentSessionID
+			}
 		}
+	}
+	if existingMarker != nil && idempotent {
+		// idempotent mode: session already primed, output nothing
+		// this saves ~1k tokens on redundant prime calls
+		return nil
 	}
 
 	// use detected agent as fallback when --agent not provided
@@ -438,9 +453,13 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	var inst *agentinstance.Instance
 	var primeCallCount int
 
-	if existingMarker != nil && existingMarker.AgentID != "" {
-		// re-prime: increment existing instance's prime call count.
-		// Only fall through to fresh-prime on "not found"; real errors (lock, I/O) are returned.
+	// Try the re-prime path whenever we already have an agent_id from any
+	// source — session marker, PID-based fallback, or SAGEOX_AGENT_ID env.
+	// IncrementPrimeCallCount is the authoritative "is this agent already
+	// registered?" check; it returns ErrInstanceNotFound iff the store has
+	// no row for this agent_id, so using it here avoids duplicate inserts
+	// when marker lookup missed but the agent_id already exists (#527/#529).
+	if agentID != "" {
 		updated, isExcessive, err := store.IncrementPrimeCallCount(agentID)
 		if err == nil {
 			inst = updated
@@ -448,13 +467,27 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 			if isExcessive {
 				trackPrimeExcessive(updated)
 			}
+			// agent_type freeze: a re-prime that claims a different agent_type
+			// than the originally-registered one is almost always a bug
+			// (typically #527's symlink-driven adapter mis-routing). Keep the
+			// stored value; surface the mismatch as a warning + telemetry so
+			// bad adapter configs become visible instead of silently rewriting
+			// the session's identity mid-flight.
+			if agentType != "" && updated.AgentType != "" && agentType != updated.AgentType {
+				slog.Warn("prime: agent_type mismatch on re-prime; keeping stored value",
+					"agent_id", agentID,
+					"stored_agent_type", updated.AgentType,
+					"claimed_agent_type", agentType)
+				// honor the frozen type for the rest of this prime call
+				agentType = updated.AgentType
+			}
 		} else if !errors.Is(err, agentinstance.ErrInstanceNotFound) {
 			return fmt.Errorf("failed to update instance: %w", err)
 		}
 	}
 
 	if inst == nil {
-		// fresh prime (or re-prime where instance wasn't found): create new
+		// fresh prime: no prior instance for this agent_id. Create new.
 		serverSessionID := auth.NewServerSessionID()
 		inst = &agentinstance.Instance{
 			AgentID:         agentID,
@@ -478,28 +511,28 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	contentWithAttribution := withAttributionGuidance("", isLoggedIn, attribution)
 
 	output := agentPrimeOutput{
-		Status:           "fresh",
-		AgentID:          agentID,
-		Guidance:         guidance,
-		SessionID:        inst.ServerSessionID,
-		AgentType:        agentType,
-		AgentSupported:   isAgentSupported(agentType),
-		SupportNotice:    getAgentSupportNotice(agentType),
-		Content:          contentWithAttribution,
-		TokenEstimate:    tokens.EstimateTokens(contentWithAttribution),
-		ContentLength:    len(contentWithAttribution),
-		Attribution:      attribution,
-		PlanFooter:       config.DefaultPlanFooterAttribution(),
-		ProjectGuidance:  projectGuidance,
-		TeamInstructions: teamInstructions,
-		CapturePrior:     capturePrior,
-		Session:          sessionStat,
-		Ledger:           ledgerStatus,
-		TeamContext:      teamCtx,
-		PrimeCallCount:   primeCallCount,
-		NeedsDoctorAgent: needsDoctorAgent,
-		DoctorHint:       doctorHint,
-		HooksInstalled:   hooksInstalled,
+		Status:             "fresh",
+		AgentID:            agentID,
+		Guidance:           guidance,
+		SessionID:          inst.ServerSessionID,
+		AgentType:          agentType,
+		AgentSupported:     isAgentSupported(agentType),
+		SupportNotice:      getAgentSupportNotice(agentType),
+		Content:            contentWithAttribution,
+		TokenEstimate:      tokens.EstimateTokens(contentWithAttribution),
+		ContentLength:      len(contentWithAttribution),
+		Attribution:        attribution,
+		PlanFooter:         config.DefaultPlanFooterAttribution(),
+		ProjectGuidance:    projectGuidance,
+		TeamInstructions:   teamInstructions,
+		CapturePrior:       capturePrior,
+		Session:            sessionStat,
+		Ledger:             ledgerStatus,
+		TeamContext:        teamCtx,
+		PrimeCallCount:     primeCallCount,
+		NeedsDoctorAgent:   needsDoctorAgent,
+		DoctorHint:         doctorHint,
+		HooksInstalled:     hooksInstalled,
 		CurrentUserName:    currentUserName,
 		CurrentUserAliases: currentUserAliases,
 	}

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -625,6 +625,9 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 	}
 	// git commit hooks (prepare-commit-msg for trailers)
 	integrationChecks = append(integrationChecks, checkGitCommitHooks(opts.shouldFix(CheckSlugGitCommitHooks)))
+	// #527 repair: detect adapter-specific prime blocks that can mis-route
+	// Claude Code sessions through the wrong adapter.
+	integrationChecks = append(integrationChecks, checkAdapterPrimeBlocks(opts.shouldFix(CheckSlugAdapterPrimeBlocks)))
 	categories = append(categories, checkCategory{
 		name:   "Integration",
 		checks: integrationChecks,

--- a/cmd/ox/doctor_adapter_blocks.go
+++ b/cmd/ox/doctor_adapter_blocks.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// adapterBlockMarkers enumerates every marker pair ever emitted by an
+// ox adapter into AGENTS.md / CONVENTIONS.md. Each entry is "recognized"
+// for detection and removal purposes — whether the adapter still emits
+// the marker today or it's legacy.
+//
+// Keep this list in sync with the constants in:
+//   - cmd/ox-adapter-pi/hooks.go
+//   - cmd/ox-adapter-amp/hooks.go
+//   - cmd/ox-adapter-aider/hooks.go
+//   - cmd/ox/hooks_pi.go
+//
+// The universal markers <!-- ox:prime-check --> and <!-- ox:prime --> are
+// intentionally NOT in this list. They are the agent-agnostic contract and
+// must survive the fix.
+var adapterBlockMarkers = []struct {
+	startMarker string
+	endMarker   string
+	adapter     string // short human label for the finding detail
+}{
+	// current namespaced markers — one per adapter
+	{"<!-- ox:prime:pi:start -->", "<!-- ox:prime:pi:end -->", "Pi"},
+	{"<!-- ox:prime:amp:start -->", "<!-- ox:prime:amp:end -->", "Amp"},
+	{"<!-- ox:prime:aider:start -->", "<!-- ox:prime:aider:end -->", "Aider"},
+	// pre-#527 in-process-only Pi marker (hooks_pi.go used this before the unification)
+	{"<!-- ox:pi-prime:start -->", "<!-- ox:pi-prime:end -->", "Pi (legacy in-process marker)"},
+	// pre-#527 generic marker — used by Pi, Amp, and Aider external adapters.
+	// The block's authorship is ambiguous, so the finding simply labels it "generic".
+	// MUST be scanned LAST so namespaced markers are matched first when both happen
+	// to be present in the same file during a transitional upgrade.
+	{"<!-- ox:prime:start -->", "<!-- ox:prime:end -->", "generic (pre-#527)"},
+}
+
+// adapterBlockFinding summarizes what a single scan found in one file.
+type adapterBlockFinding struct {
+	file           string   // repo-relative path
+	blocks         []string // adapter labels, in discovery order
+	hasAgentEnv    bool     // true if any removed block contained AGENT_ENV=<adapter>
+	symlinkPartner string   // repo-relative path of the symlinked counterpart, if any
+}
+
+// checkAdapterPrimeBlocks scans AGENTS.md / CONVENTIONS.md / CLAUDE.md at
+// the repo root for adapter-specific prime blocks. With fix=true, it
+// removes them in-place while preserving the universal ox:prime-check
+// and ox:prime markers.
+//
+// Findings are elevated to warning severity when an AGENT_ENV=<adapter>
+// hardcode is present inside the block (the #527 cross-agent poisoning
+// pattern) or when the host file is symlinked to another instruction
+// file (the #527 symlink amplifier).
+func checkAdapterPrimeBlocks(fix bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Adapter prime blocks", "not in git repo", "")
+	}
+
+	// Candidate files and the symlink mapping between them. AGENTS.md and
+	// CLAUDE.md are often linked together via ox init; if one is a symlink
+	// we dedupe so we don't "find" and "fix" the same physical file twice.
+	candidates := []string{"AGENTS.md", "CLAUDE.md", "CONVENTIONS.md"}
+
+	// map real-path → repo-relative name we first encountered, so symlinked
+	// siblings collapse to one scan target
+	seen := map[string]string{}
+	// map repo-relative name → symlink partner (empty if not symlinked)
+	partners := map[string]string{}
+
+	var scanOrder []string
+	for _, name := range candidates {
+		path := filepath.Join(gitRoot, name)
+		lst, err := os.Lstat(path)
+		if err != nil {
+			continue
+		}
+		// resolve symlinks to detect AGENTS.md↔CLAUDE.md aliasing
+		realPath, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			realPath = path
+		}
+		if prior, dup := seen[realPath]; dup {
+			// this candidate points at the same file as `prior` — record
+			// the pairing as a partner for the finding detail
+			partners[prior] = name
+			continue
+		}
+		seen[realPath] = name
+		scanOrder = append(scanOrder, name)
+		if lst.Mode()&os.ModeSymlink != 0 {
+			// symlink — note its target for the partner mapping
+			if tgt, readErr := os.Readlink(path); readErr == nil {
+				partners[name] = filepath.Base(tgt)
+			}
+		}
+	}
+
+	var findings []adapterBlockFinding
+
+	for _, name := range scanOrder {
+		path := filepath.Join(gitRoot, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		finding := scanAdapterBlocks(content)
+		if len(finding.blocks) == 0 {
+			continue
+		}
+		finding.file = name
+		finding.symlinkPartner = partners[name]
+		findings = append(findings, finding)
+
+		if fix {
+			cleaned := content
+			for _, m := range adapterBlockMarkers {
+				cleaned = stripBlock(cleaned, m.startMarker, m.endMarker)
+			}
+			if cleaned != content {
+				if err := os.WriteFile(path, []byte(cleaned), 0644); err != nil {
+					return FailedCheck("Adapter prime blocks",
+						fmt.Sprintf("failed to write %s during fix", name),
+						err.Error())
+				}
+			}
+		}
+	}
+
+	if len(findings) == 0 {
+		return PassedCheck("Adapter prime blocks", "no adapter-specific blocks in AGENTS.md/CONVENTIONS.md")
+	}
+
+	// build the message + detail
+	msg := summarizeBlockFindings(findings)
+	detailLines := []string{
+		"Adapter-specific prime blocks in a shared instruction file can mis-route Claude Code (and other agents) through the wrong adapter. See #527.",
+	}
+	for _, f := range findings {
+		line := fmt.Sprintf("%s: %s", f.file, strings.Join(f.blocks, ", "))
+		if f.hasAgentEnv {
+			line += " — contains AGENT_ENV=<adapter> hardcode (active poisoning)"
+		}
+		if f.symlinkPartner != "" {
+			line += fmt.Sprintf(" — symlinked to %s (contaminates both)", f.symlinkPartner)
+		}
+		detailLines = append(detailLines, "  "+line)
+	}
+	if !fix {
+		detailLines = append(detailLines, "Run `ox doctor --fix` to remove these blocks while preserving the universal ox:prime markers.")
+	} else {
+		detailLines = append(detailLines, "Blocks were removed. Universal ox:prime markers were preserved.")
+	}
+	detail := strings.Join(detailLines, "\n")
+
+	if fix {
+		return PassedCheck("Adapter prime blocks", "removed "+msg)
+	}
+	return WarningCheck("Adapter prime blocks", msg, detail)
+}
+
+// scanAdapterBlocks returns the set of adapter blocks detected in content.
+// AGENT_ENV hardcodes are flagged when found inside any recognized block.
+func scanAdapterBlocks(content string) adapterBlockFinding {
+	var f adapterBlockFinding
+	seen := map[string]struct{}{}
+	for _, m := range adapterBlockMarkers {
+		startIdx := strings.Index(content, m.startMarker)
+		if startIdx == -1 {
+			continue
+		}
+		endIdx := strings.Index(content, m.endMarker)
+		if endIdx == -1 || endIdx < startIdx {
+			continue
+		}
+		if _, dup := seen[m.adapter]; !dup {
+			f.blocks = append(f.blocks, m.adapter)
+			seen[m.adapter] = struct{}{}
+		}
+		// look inside the block for a hardcoded AGENT_ENV=<adapter>
+		body := content[startIdx:endIdx]
+		for _, lit := range []string{"AGENT_ENV=pi", "AGENT_ENV=amp", "AGENT_ENV=aider", "AGENT_ENV=codex", "AGENT_ENV=gemini", "AGENT_ENV=droid", "AGENT_ENV=opencode"} {
+			if strings.Contains(body, lit) {
+				f.hasAgentEnv = true
+				break
+			}
+		}
+	}
+	return f
+}
+
+func summarizeBlockFindings(findings []adapterBlockFinding) string {
+	var total int
+	var files []string
+	for _, f := range findings {
+		total += len(f.blocks)
+		files = append(files, f.file)
+	}
+	plural := ""
+	if total != 1 {
+		plural = "s"
+	}
+	return fmt.Sprintf("%d adapter block%s found in %s", total, plural, strings.Join(files, ", "))
+}
+
+// stripBlock removes one start...end block (inclusive) from content,
+// collapsing surrounding blank lines. Returns content unchanged if either
+// marker is absent. Shared with the adapter hook uninstall flows.
+func stripBlock(content, startMarker, endMarker string) string {
+	startIdx := strings.Index(content, startMarker)
+	if startIdx == -1 {
+		return content
+	}
+	endIdx := strings.Index(content, endMarker)
+	if endIdx == -1 {
+		return content
+	}
+	endIdx += len(endMarker)
+
+	before := strings.TrimRight(content[:startIdx], "\n")
+	after := strings.TrimLeft(content[endIdx:], "\n")
+
+	switch {
+	case before == "" && after == "":
+		return ""
+	case before == "":
+		return after + "\n"
+	case after == "":
+		return before + "\n"
+	default:
+		return before + "\n\n" + after + "\n"
+	}
+}

--- a/cmd/ox/doctor_adapter_blocks.go
+++ b/cmd/ox/doctor_adapter_blocks.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sageox/ox/internal/fileutil"
 )
 
 // adapterBlockMarkers enumerates every marker pair ever emitted by an
@@ -102,6 +104,15 @@ func checkAdapterPrimeBlocks(fix bool) checkResult {
 	}
 
 	var findings []adapterBlockFinding
+	// fix-mode error accumulator: partial success is reported alongside
+	// failures so users see which files were repaired and which weren't,
+	// instead of aborting at the first bad write.
+	type fixFailure struct {
+		file string
+		err  error
+	}
+	var fixFailures []fixFailure
+	var fixSucceeded []string
 
 	for _, name := range scanOrder {
 		path := filepath.Join(gitRoot, name)
@@ -124,10 +135,10 @@ func checkAdapterPrimeBlocks(fix bool) checkResult {
 				cleaned = stripBlock(cleaned, m.startMarker, m.endMarker)
 			}
 			if cleaned != content {
-				if err := os.WriteFile(path, []byte(cleaned), 0644); err != nil {
-					return FailedCheck("Adapter prime blocks",
-						fmt.Sprintf("failed to write %s during fix", name),
-						err.Error())
+				if err := fileutil.AtomicWriteBytes(path, []byte(cleaned), 0644); err != nil {
+					fixFailures = append(fixFailures, fixFailure{file: name, err: err})
+				} else {
+					fixSucceeded = append(fixSucceeded, name)
 				}
 			}
 		}
@@ -152,14 +163,29 @@ func checkAdapterPrimeBlocks(fix bool) checkResult {
 		}
 		detailLines = append(detailLines, "  "+line)
 	}
-	if !fix {
+	switch {
+	case !fix:
 		detailLines = append(detailLines, "Run `ox doctor --fix` to remove these blocks while preserving the universal ox:prime markers.")
-	} else {
+	case len(fixFailures) == 0:
 		detailLines = append(detailLines, "Blocks were removed. Universal ox:prime markers were preserved.")
+	default:
+		if len(fixSucceeded) > 0 {
+			detailLines = append(detailLines,
+				fmt.Sprintf("Partial success — repaired: %s", strings.Join(fixSucceeded, ", ")))
+		}
+		for _, ff := range fixFailures {
+			detailLines = append(detailLines,
+				fmt.Sprintf("  FAILED to write %s: %v", ff.file, ff.err))
+		}
 	}
 	detail := strings.Join(detailLines, "\n")
 
 	if fix {
+		if len(fixFailures) > 0 {
+			return FailedCheck("Adapter prime blocks",
+				fmt.Sprintf("fix failed for %d of %d file(s)", len(fixFailures), len(fixFailures)+len(fixSucceeded)),
+				detail)
+		}
 		return PassedCheck("Adapter prime blocks", "removed "+msg)
 	}
 	return WarningCheck("Adapter prime blocks", msg, detail)

--- a/cmd/ox/doctor_adapter_blocks.go
+++ b/cmd/ox/doctor_adapter_blocks.go
@@ -237,17 +237,24 @@ func summarizeBlockFindings(findings []adapterBlockFinding) string {
 
 // stripBlock removes one start...end block (inclusive) from content,
 // collapsing surrounding blank lines. Returns content unchanged if either
-// marker is absent. Shared with the adapter hook uninstall flows.
+// marker is absent, or if no end marker appears AFTER the start marker —
+// the latter guards against an orphan end marker earlier in the file
+// silently dropping arbitrary text between the orphan and the real start
+// when `ox doctor --fix` runs on corrupted input (the exact scenario this
+// check is built for). Mirrors the guard in scanAdapterBlocks.
+// CodeRabbit review on #543.
 func stripBlock(content, startMarker, endMarker string) string {
 	startIdx := strings.Index(content, startMarker)
 	if startIdx == -1 {
 		return content
 	}
-	endIdx := strings.Index(content, endMarker)
-	if endIdx == -1 {
+	// search for endMarker AFTER the start marker so an orphan end marker
+	// earlier in the file can't form an inverted range
+	rel := strings.Index(content[startIdx+len(startMarker):], endMarker)
+	if rel == -1 {
 		return content
 	}
-	endIdx += len(endMarker)
+	endIdx := startIdx + len(startMarker) + rel + len(endMarker)
 
 	before := strings.TrimRight(content[:startIdx], "\n")
 	after := strings.TrimLeft(content[endIdx:], "\n")

--- a/cmd/ox/doctor_adapter_blocks_test.go
+++ b/cmd/ox/doctor_adapter_blocks_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupGitRepoWithFiles builds a throwaway git repo at t.TempDir, writes
+// the given files, and cd's into it. Restores cwd on cleanup. checkAdapterPrimeBlocks
+// relies on findGitRoot which uses cwd, hence the chdir.
+func setupGitRepoWithFiles(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	init := exec.Command("git", "init", "-q")
+	init.Dir = dir
+	require.NoError(t, init.Run(), "git init")
+
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	}
+
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	return dir
+}
+
+// --- Detection ---
+
+// TestCheckAdapterPrimeBlocks_NoBlocks_Passes confirms a clean repo with
+// only universal markers passes the check silently.
+// Failure prevented: false-positive noise in doctor output.
+func TestCheckAdapterPrimeBlocks_NoBlocks_Passes(t *testing.T) {
+	setupGitRepoWithFiles(t, map[string]string{
+		"AGENTS.md": "<!-- ox:prime-check -->\n# Agent\n<!-- ox:prime --> prime\n",
+	})
+
+	res := checkAdapterPrimeBlocks(false)
+	assert.True(t, res.passed, "expected pass, got %+v", res)
+	assert.False(t, res.warning, "clean repo should not warn")
+}
+
+// TestCheckAdapterPrimeBlocks_FlagsPiBlock detects a current-marker Pi
+// block and warns without modifying the file when fix=false.
+// Failure prevented: silent contamination of Claude Code sessions via Pi
+// block in shared AGENTS.md (the #527 pattern).
+func TestCheckAdapterPrimeBlocks_FlagsPiBlock(t *testing.T) {
+	dir := setupGitRepoWithFiles(t, map[string]string{
+		"AGENTS.md": "<!-- ox:prime-check -->\n\n<!-- ox:prime:pi:start -->\n## Pi block\nox agent prime\n<!-- ox:prime:pi:end -->\n<!-- ox:prime --> footer\n",
+	})
+
+	res := checkAdapterPrimeBlocks(false)
+	assert.True(t, res.warning, "expected warning, got %+v", res)
+	assert.Contains(t, res.message, "adapter block")
+	assert.Contains(t, res.detail, "Pi")
+
+	// file must not be modified in check-only mode
+	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "<!-- ox:prime:pi:start -->",
+		"check without --fix must not mutate the file")
+}
+
+// TestCheckAdapterPrimeBlocks_FlagsLegacyGenericBlock recognizes the
+// pre-#527 <!-- ox:prime:start --> pair as a legacy adapter block.
+// Failure prevented: repos with pre-#527 installations silently carrying
+// broken blocks after upgrade.
+func TestCheckAdapterPrimeBlocks_FlagsLegacyGenericBlock(t *testing.T) {
+	setupGitRepoWithFiles(t, map[string]string{
+		"AGENTS.md": "<!-- ox:prime-check -->\n\n<!-- ox:prime:start -->\nAGENT_ENV=pi ox agent prime\n<!-- ox:prime:end -->\n<!-- ox:prime --> footer\n",
+	})
+
+	res := checkAdapterPrimeBlocks(false)
+	assert.True(t, res.warning, "expected warning for legacy block, got %+v", res)
+	assert.Contains(t, res.detail, "generic",
+		"detail should label ambiguous pre-#527 block")
+	assert.Contains(t, res.detail, "AGENT_ENV",
+		"detail should highlight the active poisoning")
+}
+
+// TestCheckAdapterPrimeBlocks_SymlinkAmplifier surfaces the AGENTS.md ↔
+// CLAUDE.md symlink as an amplifier in the finding detail.
+// Failure prevented: users fix AGENTS.md but don't realize CLAUDE.md
+// pointed at the same physical file (or vice versa).
+func TestCheckAdapterPrimeBlocks_SymlinkAmplifier(t *testing.T) {
+	dir := setupGitRepoWithFiles(t, map[string]string{
+		"AGENTS.md": "<!-- ox:prime-check -->\n\n<!-- ox:prime:pi:start -->\npi block\n<!-- ox:prime:pi:end -->\n",
+	})
+	// create CLAUDE.md as a symlink to AGENTS.md (the #527 configuration)
+	require.NoError(t, os.Symlink("AGENTS.md", filepath.Join(dir, "CLAUDE.md")))
+
+	res := checkAdapterPrimeBlocks(false)
+	assert.True(t, res.warning)
+	assert.Contains(t, res.detail, "symlinked",
+		"detail should call out the symlink amplifier")
+}
+
+// --- Fix path ---
+
+// TestCheckAdapterPrimeBlocks_FixRemovesBlock confirms --fix strips the
+// adapter block and leaves the universal ox:prime-check / ox:prime
+// markers intact.
+// Failure prevented: the fix regresses by removing universal markers,
+// breaking priming everywhere.
+func TestCheckAdapterPrimeBlocks_FixRemovesBlock(t *testing.T) {
+	dir := setupGitRepoWithFiles(t, map[string]string{
+		"AGENTS.md": "<!-- ox:prime-check -->\nheader body\n\n<!-- ox:prime:amp:start -->\namp block\n<!-- ox:prime:amp:end -->\n\n<!-- ox:prime --> footer\n",
+	})
+
+	res := checkAdapterPrimeBlocks(true)
+	assert.True(t, res.passed, "fix mode should pass, got %+v", res)
+
+	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+	got := string(data)
+	assert.NotContains(t, got, "<!-- ox:prime:amp:start -->",
+		"adapter block should be removed")
+	assert.Contains(t, got, "<!-- ox:prime-check -->",
+		"universal header marker must survive the fix")
+	assert.Contains(t, got, "<!-- ox:prime -->",
+		"universal footer marker must survive the fix")
+}
+
+// TestCheckAdapterPrimeBlocks_FixSweepsAllMarkerGenerations removes
+// current, legacy-in-process, and legacy-generic blocks in one pass.
+// Failure prevented: partial cleanup leaving some adapter blocks behind.
+func TestCheckAdapterPrimeBlocks_FixSweepsAllMarkerGenerations(t *testing.T) {
+	dir := setupGitRepoWithFiles(t, map[string]string{
+		"AGENTS.md": strings.Join([]string{
+			"<!-- ox:prime-check -->",
+			"",
+			"<!-- ox:prime:pi:start -->", "pi", "<!-- ox:prime:pi:end -->",
+			"",
+			"<!-- ox:pi-prime:start -->", "legacy inproc", "<!-- ox:pi-prime:end -->",
+			"",
+			"<!-- ox:prime:start -->", "legacy generic", "<!-- ox:prime:end -->",
+			"",
+			"<!-- ox:prime --> footer",
+		}, "\n") + "\n",
+	})
+
+	res := checkAdapterPrimeBlocks(true)
+	assert.True(t, res.passed)
+
+	data, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	require.NoError(t, err)
+	got := string(data)
+	for _, lit := range []string{
+		"<!-- ox:prime:pi:start -->",
+		"<!-- ox:pi-prime:start -->",
+		"<!-- ox:prime:start -->",
+	} {
+		assert.NotContains(t, got, lit,
+			"every marker generation should be swept: %s", lit)
+	}
+	assert.Contains(t, got, "<!-- ox:prime-check -->", "universal header survives")
+	assert.Contains(t, got, "<!-- ox:prime -->", "universal footer survives")
+}
+
+// TestCheckAdapterPrimeBlocks_DedupesSymlinkedFiles confirms we don't
+// double-process when AGENTS.md and CLAUDE.md are the same physical file.
+// Failure prevented: duplicate findings or redundant writes on symlinked
+// instruction files.
+func TestCheckAdapterPrimeBlocks_DedupesSymlinkedFiles(t *testing.T) {
+	dir := setupGitRepoWithFiles(t, map[string]string{
+		"AGENTS.md": "<!-- ox:prime:pi:start -->\npi\n<!-- ox:prime:pi:end -->\n",
+	})
+	require.NoError(t, os.Symlink("AGENTS.md", filepath.Join(dir, "CLAUDE.md")))
+
+	res := checkAdapterPrimeBlocks(false)
+	assert.True(t, res.warning)
+	// The message should reference AGENTS.md once (not both AGENTS.md and CLAUDE.md)
+	assert.Equal(t, 1, strings.Count(res.message, "AGENTS.md"),
+		"AGENTS.md must appear exactly once in the summary (symlink dedup)")
+	assert.NotContains(t, res.message, "CLAUDE.md",
+		"symlinked CLAUDE.md should not appear as a separate file in findings")
+}

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -337,6 +337,15 @@ func init() {
 		Run:         func(fix bool) checkResult { return checkSessionStartHookBug() },
 	})
 
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugAdapterPrimeBlocks,
+		Name:        "Adapter prime blocks",
+		Category:    "Integration",
+		FixLevel:    FixLevelSuggested,
+		Description: "Detects adapter-specific prime blocks in AGENTS.md/CONVENTIONS.md that can mis-route Claude Code through the wrong adapter (#527); --fix removes them while preserving universal markers",
+		Run:         checkAdapterPrimeBlocks,
+	})
+
 	// ============================================================
 	// SageOx Configuration checks
 	// ============================================================

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -131,6 +131,7 @@ const (
 	CheckSlugStaleLocalHooks     = "stale-local-hooks"
 	CheckSlugSessionStartHookBug = "session-start-hook-bug"
 	CheckSlugGitCommitHooks      = "git-commit-hooks"
+	CheckSlugAdapterPrimeBlocks  = "adapter-prime-blocks"
 
 	// Team Context checks
 	CheckSlugTeamRegistration   = "team-registration"

--- a/cmd/ox/hooks_pi.go
+++ b/cmd/ox/hooks_pi.go
@@ -195,19 +195,25 @@ func listPiHooks() map[string]bool {
 
 // removePiPrimeBlock strips one start...end block (inclusive) from content,
 // collapsing surrounding blank lines so no orphan whitespace remains.
-// Returns content unchanged if either marker is absent. Named with the
-// pi-prefix to avoid collision with similarly-named helpers in other
-// cmd/ox files; logic matches the external-adapter helpers.
+// Returns content unchanged if either marker is absent, or if no end
+// marker appears AFTER the start marker (which would indicate an orphan
+// end marker earlier in the file — refuses to operate rather than
+// silently delete content between an orphan end and a real start).
+// Named with the pi-prefix to avoid collision with similarly-named
+// helpers in other cmd/ox files; logic matches the external-adapter
+// helpers. CodeRabbit review on #543.
 func removePiPrimeBlock(content, startMarker, endMarker string) string {
 	startIdx := strings.Index(content, startMarker)
 	if startIdx == -1 {
 		return content
 	}
-	endIdx := strings.Index(content, endMarker)
-	if endIdx == -1 {
+	// search for endMarker AFTER the start marker so an orphan end marker
+	// earlier in the file can't form an inverted range
+	rel := strings.Index(content[startIdx+len(startMarker):], endMarker)
+	if rel == -1 {
 		return content
 	}
-	endIdx += len(endMarker)
+	endIdx := startIdx + len(startMarker) + rel + len(endMarker)
 
 	before := strings.TrimRight(content[:startIdx], "\n")
 	after := strings.TrimLeft(content[endIdx:], "\n")

--- a/cmd/ox/hooks_pi.go
+++ b/cmd/ox/hooks_pi.go
@@ -8,18 +8,41 @@ import (
 	"github.com/sageox/ox/internal/ui"
 )
 
-const piPrimeMarkerStart = "<!-- ox:pi-prime:start -->"
-const piPrimeMarkerEnd = "<!-- ox:pi-prime:end -->"
+// piPrimeMarkerStart / End are the Pi-specific block markers. Must match
+// the unique marker the external ox-adapter-pi binary emits so that the
+// in-process install path (ox integrate install --pi) and the external
+// adapter-protocol path (ox init with pi selected) share one block
+// instead of each writing their own. See #527.
+const piPrimeMarkerStart = "<!-- ox:prime:pi:start -->"
+const piPrimeMarkerEnd = "<!-- ox:prime:pi:end -->"
+
+// piLegacyInProcessMarkerStart / End are the pre-#527 in-process markers
+// that only ever appeared in hooks_pi.go (distinct from the generic
+// <!-- ox:prime:start --> pair used by the external adapter before it
+// was also unified). Kept for backward-compat detection.
+const piLegacyInProcessMarkerStart = "<!-- ox:pi-prime:start -->"
+const piLegacyInProcessMarkerEnd = "<!-- ox:pi-prime:end -->"
+
+// piLegacyGenericMarkerStart / End are the pre-#527 generic markers the
+// external adapter used to emit, which may exist in older repos.
+const piLegacyGenericMarkerStart = "<!-- ox:prime:start -->"
+const piLegacyGenericMarkerEnd = "<!-- ox:prime:end -->"
 
 // piPrimeBlock is the content injected into AGENTS.md for Pi.
 // Pi auto-loads AGENTS.md from the project root on every session.
+//
+// NOTE: the prime command is intentionally adapter-agnostic — no hardcoded
+// AGENT_ENV=<adapter> prefix. AGENTS.md is often shared across agents (e.g.
+// via a CLAUDE.md symlink), so any block that mis-routes AGENT_ENV poisons
+// sessions running a different coding agent. Runtime detection in
+// agentx.CurrentAgent handles agent identification correctly. See #527.
 var piPrimeBlock = piPrimeMarkerStart + "\n" +
 	"## SageOx Team Context\n" +
 	"\n" +
 	"This project uses [SageOx](https://sageox.ai) for team context. Run the following command at the start of every session to load team knowledge:\n" +
 	"\n" +
 	"```bash\n" +
-	"AGENT_ENV=pi ox agent prime\n" +
+	"ox agent prime\n" +
 	"```\n" +
 	"\n" +
 	"This provides architectural decisions, coding conventions, and session history from your team.\n" +
@@ -29,6 +52,19 @@ var piPrimeBlock = piPrimeMarkerStart + "\n" +
 	"pi install npm:@sageox/pi-ox\n" +
 	"```\n" +
 	piPrimeMarkerEnd
+
+// piBlockAlreadyPresent reports whether AGENTS.md already carries a Pi
+// prime block under any recognized marker pair: the current
+// <!-- ox:prime:pi:* --> pair, the in-process legacy <!-- ox:pi-prime:* -->
+// pair (that only hooks_pi.go ever emitted), or the generic legacy
+// <!-- ox:prime:* --> pair the external adapter used to emit. All three
+// are accepted so we don't stack a duplicate block on top of any prior
+// installation style.
+func piBlockAlreadyPresent(content string) bool {
+	return strings.Contains(content, piPrimeMarkerStart) ||
+		strings.Contains(content, piLegacyInProcessMarkerStart) ||
+		strings.Contains(content, piLegacyGenericMarkerStart)
+}
 
 // hasPiHooks checks if the Pi ox prime marker exists in AGENTS.md.
 // user=true always returns false (no user-level AGENTS.md for Pi).
@@ -48,7 +84,7 @@ func hasPiHooks(user bool) bool {
 		return false
 	}
 
-	return strings.Contains(string(content), piPrimeMarkerStart)
+	return piBlockAlreadyPresent(string(content))
 }
 
 // installPiHooks installs the ox prime marker block into AGENTS.md for Pi.
@@ -73,8 +109,8 @@ func installPiHooks(user bool) error {
 
 	content := string(existing)
 
-	// already installed
-	if strings.Contains(content, piPrimeMarkerStart) {
+	// already installed (current or legacy markers)
+	if piBlockAlreadyPresent(content) {
 		fmt.Println(ui.PassStyle.Render("✓") + " Pi integration already installed in " + agentsPath)
 		return nil
 	}
@@ -120,36 +156,15 @@ func uninstallPiHooks(user bool) error {
 
 	content := string(data)
 
-	startIdx := strings.Index(content, piPrimeMarkerStart)
-	if startIdx == -1 {
+	// remove every recognized Pi block (current + both legacy forms) so
+	// a single uninstall fully cleans up any install era.
+	cleaned := removePiPrimeBlock(content, piPrimeMarkerStart, piPrimeMarkerEnd)
+	cleaned = removePiPrimeBlock(cleaned, piLegacyInProcessMarkerStart, piLegacyInProcessMarkerEnd)
+	cleaned = removePiPrimeBlock(cleaned, piLegacyGenericMarkerStart, piLegacyGenericMarkerEnd)
+
+	if cleaned == content {
 		fmt.Println("Pi integration not found in " + agentsPath)
 		return nil
-	}
-
-	endIdx := strings.Index(content, piPrimeMarkerEnd)
-	if endIdx == -1 {
-		fmt.Println("Pi integration not found in " + agentsPath)
-		return nil
-	}
-	endIdx += len(piPrimeMarkerEnd)
-
-	// remove the block plus any surrounding blank lines
-	before := content[:startIdx]
-	after := content[endIdx:]
-
-	// trim trailing newlines from before and leading newlines from after
-	before = strings.TrimRight(before, "\n")
-	after = strings.TrimLeft(after, "\n")
-
-	var cleaned string
-	if before == "" && after == "" {
-		cleaned = ""
-	} else if before == "" {
-		cleaned = after + "\n"
-	} else if after == "" {
-		cleaned = before + "\n"
-	} else {
-		cleaned = before + "\n\n" + after + "\n"
 	}
 
 	// if file is empty after removal, delete it
@@ -174,5 +189,36 @@ func listPiHooks() map[string]bool {
 	return map[string]bool{
 		"Project": hasPiHooks(false),
 		"User":    false,
+	}
+}
+
+// removePiPrimeBlock strips one start...end block (inclusive) from content,
+// collapsing surrounding blank lines so no orphan whitespace remains.
+// Returns content unchanged if either marker is absent. Named with the
+// pi-prefix to avoid collision with similarly-named helpers in other
+// cmd/ox files; logic matches the external-adapter helpers.
+func removePiPrimeBlock(content, startMarker, endMarker string) string {
+	startIdx := strings.Index(content, startMarker)
+	if startIdx == -1 {
+		return content
+	}
+	endIdx := strings.Index(content, endMarker)
+	if endIdx == -1 {
+		return content
+	}
+	endIdx += len(endMarker)
+
+	before := strings.TrimRight(content[:startIdx], "\n")
+	after := strings.TrimLeft(content[endIdx:], "\n")
+
+	switch {
+	case before == "" && after == "":
+		return ""
+	case before == "":
+		return after + "\n"
+	case after == "":
+		return before + "\n"
+	default:
+		return before + "\n\n" + after + "\n"
 	}
 }

--- a/cmd/ox/hooks_pi.go
+++ b/cmd/ox/hooks_pi.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/ui"
 )
 
@@ -124,7 +125,7 @@ func installPiHooks(user bool) error {
 		newContent = strings.TrimRight(content, "\n") + "\n\n" + piPrimeBlock + "\n"
 	}
 
-	if err := os.WriteFile(agentsPath, []byte(newContent), sharedSettingsPerm); err != nil {
+	if err := fileutil.AtomicWriteBytes(agentsPath, []byte(newContent), sharedSettingsPerm); err != nil {
 		return fmt.Errorf("failed to write %s: %w", agentsMDFileName, err)
 	}
 
@@ -176,7 +177,7 @@ func uninstallPiHooks(user bool) error {
 		return nil
 	}
 
-	if err := os.WriteFile(agentsPath, []byte(cleaned), sharedSettingsPerm); err != nil {
+	if err := fileutil.AtomicWriteBytes(agentsPath, []byte(cleaned), sharedSettingsPerm); err != nil {
 		return fmt.Errorf("failed to write %s: %w", agentsMDFileName, err)
 	}
 

--- a/cmd/ox/hooks_pi_test.go
+++ b/cmd/ox/hooks_pi_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPiBlockAlreadyPresent_RecognizesAllMarkerGenerations guards the
+// backward-compat legs of the #527 marker rename. The in-process
+// installPiHooks path must recognize repos carrying markers from any
+// of three install eras so it doesn't stack a duplicate block on top.
+//
+// Failure prevented: users upgrading through multiple ox versions end up
+// with two or three overlapping Pi blocks in their AGENTS.md, each from
+// a different install generation.
+func TestPiBlockAlreadyPresent_RecognizesAllMarkerGenerations(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"empty file", "", false},
+		{"unrelated content", "# readme\n\nhello", false},
+		{"current marker", piPrimeMarkerStart + "\n...\n" + piPrimeMarkerEnd, true},
+		{"legacy in-process marker", piLegacyInProcessMarkerStart + "\n...\n" + piLegacyInProcessMarkerEnd, true},
+		{"legacy generic marker", piLegacyGenericMarkerStart + "\n...\n" + piLegacyGenericMarkerEnd, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := piBlockAlreadyPresent(tc.content)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestPiMarkers_UseUniqueNamespace ensures the in-process marker agrees
+// with the external adapter's unique namespace so both paths converge
+// on one block per AGENTS.md.
+// Failure prevented: in-process and external Pi install paths write
+// different markers, producing two blocks when both run.
+func TestPiMarkers_UseUniqueNamespace(t *testing.T) {
+	assert.Contains(t, piPrimeMarkerStart, ":pi:",
+		"in-process Pi marker must carry :pi: namespace matching the external adapter")
+	assert.NotEqual(t, "<!-- ox:prime:start -->", piPrimeMarkerStart,
+		"must not revert to the generic pre-#527 pair")
+}

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -13,20 +13,21 @@ import (
 
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/auth"
-	"github.com/sageox/ox/internal/session/adapters"
-	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/constants"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/doctor"
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/identity"
 	"github.com/sageox/ox/internal/repotools"
+	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/internal/tips"
 	"github.com/sageox/ox/internal/ui"
 	"github.com/sageox/ox/internal/version"
+	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/spf13/cobra"
 )
 
@@ -1298,7 +1299,7 @@ func injectOxPrime(gitRoot string) ([]fileInjectionResult, error) {
 	default:
 		// neither exists - create AGENTS.md with both markers
 		content := OxPrimeCheckBlock + "\n# AI Agent Instructions\n\n" + OxPrimeLine + "\n"
-		if err := os.WriteFile(agentsPath, []byte(content), 0644); err != nil {
+		if err := fileutil.AtomicWriteBytes(agentsPath, []byte(content), 0644); err != nil {
 			return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
 		}
 		agentsExists = true

--- a/cmd/ox/prime_marker.go
+++ b/cmd/ox/prime_marker.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sageox/ox/internal/fileutil"
 )
 
 // OxPrimeMarker is the grep-able HTML comment marker for verification (footer).
@@ -128,7 +130,7 @@ func EnsureOxPrimeMarker(gitRoot string) (bool, error) {
 	_, agentsErr := os.Stat(agentsPath)
 	if os.IsNotExist(agentsErr) {
 		content := OxPrimeCheckBlock + "\n# AI Agent Instructions\n\n" + OxPrimeLine + "\n"
-		if err := os.WriteFile(agentsPath, []byte(content), 0644); err != nil {
+		if err := fileutil.AtomicWriteBytes(agentsPath, []byte(content), 0644); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -230,7 +232,7 @@ func ensureMarkersInFile(filePath, content string, needHeader, needFooter bool) 
 		return false, fmt.Errorf("safety check failed: modified content (%d bytes) is less than half of original (%d bytes), aborting to protect user content", len(cleaned), len(content))
 	}
 
-	if err := os.WriteFile(filePath, []byte(cleaned), 0644); err != nil {
+	if err := fileutil.AtomicWriteBytes(filePath, []byte(cleaned), 0644); err != nil {
 		return false, err
 	}
 

--- a/cmd/ox/prime_session_marker.go
+++ b/cmd/ox/prime_session_marker.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/sageox/agentx"
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/proc"
 )
 
 // SessionMarkerDir returns the per-user directory for session markers.
@@ -91,9 +93,18 @@ func FindSessionMarkerByPID(agentPID int) *SessionMarker {
 		if err := json.Unmarshal(data, &m); err != nil {
 			continue
 		}
-		if m.ParentPID == agentPID {
-			return &m
+		if m.ParentPID != agentPID {
+			continue
 		}
+		// belt-and-suspenders against PID recycling / stale markers:
+		// require the recorded agent process to still be alive. Without
+		// this, a marker from a crashed prior session whose PID happens
+		// to match the current shell/agent would silently cross-link
+		// identities — the exact class of bug we're fixing.
+		if !proc.IsAlive(m.ParentPID) {
+			continue
+		}
+		return &m
 	}
 	return nil
 }
@@ -216,9 +227,11 @@ func WriteToAgentEnvFile(vars map[string]string) error {
 	// CLAUDE.md BLOCKING re-prime — exactly the #527/#529 scenario) both
 	// read-modify-write this file. Without a lock, last-renamer-wins and
 	// the other prime's keys silently disappear. Serialize via flock on
-	// a sibling .lock file. 2s budget matches agentinstance.Store.
+	// a sibling .lock file. 5s budget matches agentinstance.Store's
+	// lockTimeout so behavior under contention is consistent across the
+	// two file-locked subsystems that prime touches.
 	lock := flock.New(envFilePath + ".lock")
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	locked, err := lock.TryLockContext(ctx, 100*time.Millisecond)
 	if err != nil {
@@ -258,14 +271,10 @@ func WriteToAgentEnvFile(vars map[string]string) error {
 		buf.WriteByte('\n')
 	}
 
-	// atomic write: temp file + rename
-	tmpPath := envFilePath + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(buf.String()), 0644); err != nil {
-		return fmt.Errorf("failed to write agent env temp: %w", err)
-	}
-	if err := os.Rename(tmpPath, envFilePath); err != nil {
-		os.Remove(tmpPath)
-		return fmt.Errorf("failed to rename agent env file: %w", err)
+	// atomic write with fsync via the shared helper (mirrors every other
+	// instruction-file/env-file write path and gets parent-dir fsync too).
+	if err := fileutil.AtomicWriteBytes(envFilePath, []byte(buf.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write agent env file: %w", err)
 	}
 	return nil
 }

--- a/cmd/ox/prime_session_marker.go
+++ b/cmd/ox/prime_session_marker.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -52,6 +54,46 @@ func markerPath(agentSessionID string) string {
 	sanitized = strings.ReplaceAll(sanitized, "\\", "_")
 	sanitized = strings.ReplaceAll(sanitized, "..", "_")
 	return filepath.Join(SessionMarkerDir(), sanitized+".json")
+}
+
+// FindSessionMarkerByPID scans the session marker directory for a marker whose
+// ParentPID matches the given agent-ancestor PID. Returns the first match, or
+// nil if no marker references this process.
+//
+// This is the fallback for #527/#529 re-entry detection when agent_session_id
+// is unavailable — e.g. a second prime invoked from a CLAUDE.md BLOCKING
+// instruction has no hook stdin JSON, so the session-id-keyed lookup misses.
+// Process identity is a reliable alternative key: the hook-driven prime wrote
+// the marker with the agent's PID, and any later prime inside the same agent
+// process can find it by walking up to that same PID.
+func FindSessionMarkerByPID(agentPID int) *SessionMarker {
+	if agentPID <= 0 {
+		return nil
+	}
+	entries, err := os.ReadDir(SessionMarkerDir())
+	if err != nil {
+		return nil
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), ".tmp") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(SessionMarkerDir(), entry.Name()))
+		if err != nil {
+			continue
+		}
+		var m SessionMarker
+		if err := json.Unmarshal(data, &m); err != nil {
+			continue
+		}
+		if m.ParentPID == agentPID {
+			return &m
+		}
+	}
+	return nil
 }
 
 // ReadSessionMarker reads a session marker from disk.
@@ -151,24 +193,100 @@ func ReadAgentHookInput() *AgentHookInput {
 // WriteToAgentEnvFile writes environment variables to the agent's env file if available.
 // Currently supports CLAUDE_ENV_FILE (Claude Code). Other agents may use different
 // mechanisms for injecting env vars into subsequent tool calls.
+//
+// Semantics: upsert. The file is read, existing `export KEY="VALUE"` lines are
+// parsed into a map, incoming vars are merged (incoming wins), and the result
+// is rewritten atomically via temp-file + rename. Duplicate keys from earlier
+// writes are collapsed. Non-export lines (comments, blanks, unrecognized
+// syntax) are preserved in their original order, appended after the exports.
+//
+// Why upsert instead of O_APPEND: a second prime that claims a different
+// agent_type would otherwise stack `export AGENT_ENV="pi"` after an earlier
+// `export AGENT_ENV="claude-code"`, poisoning every subsequent subprocess
+// until the next explicit prime. See #527.
 func WriteToAgentEnvFile(vars map[string]string) error {
 	envFilePath := os.Getenv("CLAUDE_ENV_FILE")
 	if envFilePath == "" {
 		return nil // not in an agent context with env file support
 	}
 
-	file, err := os.OpenFile(envFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		return fmt.Errorf("failed to open agent env file: %w", err)
-	}
-	defer file.Close()
-
-	for key, value := range vars {
-		// write as export statements for bash sourcing
-		fmt.Fprintf(file, "export %s=%q\n", key, value)
+	// read existing content (may not exist yet)
+	existing, err := os.ReadFile(envFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read agent env file: %w", err)
 	}
 
+	exports, preserved := parseEnvFile(string(existing))
+
+	// merge: incoming vars override existing values for same key
+	for k, v := range vars {
+		exports[k] = v
+	}
+
+	// emit: sorted keys for deterministic output, then preserved non-export lines
+	keys := make([]string, 0, len(exports))
+	for k := range exports {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&buf, "export %s=%q\n", k, exports[k])
+	}
+	for _, line := range preserved {
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+
+	// atomic write: temp file + rename
+	tmpPath := envFilePath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(buf.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write agent env temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, envFilePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename agent env file: %w", err)
+	}
 	return nil
+}
+
+// parseEnvFile splits a CLAUDE_ENV_FILE into a map of export KEY=VALUE pairs
+// plus a slice of preserved non-export lines (comments, blanks, unknown syntax).
+// Duplicate keys in the input are resolved by last-wins — matching how bash
+// source() evaluates the file.
+func parseEnvFile(content string) (map[string]string, []string) {
+	exports := make(map[string]string)
+	var preserved []string
+	for _, line := range strings.Split(content, "\n") {
+		if line == "" {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "export ") {
+			preserved = append(preserved, line)
+			continue
+		}
+		rest := strings.TrimPrefix(trimmed, "export ")
+		eq := strings.IndexByte(rest, '=')
+		if eq < 0 {
+			preserved = append(preserved, line)
+			continue
+		}
+		key := rest[:eq]
+		val := rest[eq+1:]
+		// strip surrounding double quotes if present (matches fmt.Fprintf %q shape)
+		if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
+			unquoted, err := strconv.Unquote(val)
+			if err == nil {
+				val = unquoted
+			} else {
+				val = val[1 : len(val)-1]
+			}
+		}
+		exports[key] = val
+	}
+	return exports, preserved
 }
 
 // IsAgentHookContext detects if we're running in a coding agent's hook context.

--- a/cmd/ox/prime_session_marker.go
+++ b/cmd/ox/prime_session_marker.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -202,16 +201,24 @@ func ReadAgentHookInput() *AgentHookInput {
 // Currently supports CLAUDE_ENV_FILE (Claude Code). Other agents may use different
 // mechanisms for injecting env vars into subsequent tool calls.
 //
-// Semantics: upsert. The file is read, existing `export KEY="VALUE"` lines are
-// parsed into a map, incoming vars are merged (incoming wins), and the result
-// is rewritten atomically via temp-file + rename. Duplicate keys from earlier
-// writes are collapsed. Non-export lines (comments, blanks, unrecognized
-// syntax) are preserved in their original order, appended after the exports.
+// Semantics: surgical upsert of SageOx-owned keys only. Lines unrelated to
+// the keys in `vars` are preserved verbatim — including unrelated exports,
+// comments, blank lines, and shell-expanding values like
+// `export PATH="$HOME/bin:$PATH"` that would break if reformatted through
+// Go's %q. Only keys in `vars` are replaced; the first occurrence of each
+// such key in the file is overwritten in place, later duplicates are
+// removed (dedup), and any key not present is appended at the end.
 //
-// Why upsert instead of O_APPEND: a second prime that claims a different
-// agent_type would otherwise stack `export AGENT_ENV="pi"` after an earlier
+// Why surgical: a second prime that claims a different agent_type would
+// otherwise stack `export AGENT_ENV="pi"` after an earlier
 // `export AGENT_ENV="claude-code"`, poisoning every subsequent subprocess
-// until the next explicit prime. See #527.
+// until the next explicit prime (#527). Earlier revisions re-emitted every
+// export line with %q, which could mangle complex shell syntax in unrelated
+// entries — the CodeRabbit review flagged this as a privacy + correctness
+// regression.
+//
+// Permissions: written with at most 0600. If the file already exists with a
+// more restrictive mode (e.g. 0400), that stricter mode is preserved.
 func WriteToAgentEnvFile(vars map[string]string) error {
 	envFilePath := os.Getenv("CLAUDE_ENV_FILE")
 	if envFilePath == "" {
@@ -237,79 +244,103 @@ func WriteToAgentEnvFile(vars map[string]string) error {
 	}
 	defer func() { _ = lock.Unlock() }()
 
-	// read existing content (may not exist yet)
+	// read existing content + mode (both may be absent)
 	existing, err := os.ReadFile(envFilePath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to read agent env file: %w", err)
 	}
 
-	exports, preserved := parseEnvFile(string(existing))
-
-	// merge: incoming vars override existing values for same key
-	for k, v := range vars {
-		exports[k] = v
+	// Default to 0600 (owner read/write). If the file already exists with a
+	// stricter mode, keep the stricter mode — we never loosen permissions
+	// because the env file can carry values callers consider private.
+	var perm os.FileMode = 0600
+	if info, statErr := os.Stat(envFilePath); statErr == nil {
+		if existing := info.Mode().Perm(); existing != 0 && existing < perm {
+			perm = existing
+		}
 	}
 
-	// emit: sorted keys for deterministic output, then preserved non-export lines
-	keys := make([]string, 0, len(exports))
-	for k := range exports {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	var buf strings.Builder
-	for _, k := range keys {
-		fmt.Fprintf(&buf, "export %s=%q\n", k, exports[k])
-	}
-	for _, line := range preserved {
-		buf.WriteString(line)
-		buf.WriteByte('\n')
-	}
+	out := upsertEnvFile(string(existing), vars)
 
 	// atomic write with fsync via the shared helper (mirrors every other
 	// instruction-file/env-file write path and gets parent-dir fsync too).
-	if err := fileutil.AtomicWriteBytes(envFilePath, []byte(buf.String()), 0644); err != nil {
+	if err := fileutil.AtomicWriteBytes(envFilePath, []byte(out), perm); err != nil {
 		return fmt.Errorf("failed to write agent env file: %w", err)
 	}
 	return nil
 }
 
-// parseEnvFile splits a CLAUDE_ENV_FILE into a map of export KEY=VALUE pairs
-// plus a slice of preserved non-export lines (comments, blanks, unknown syntax).
-// Duplicate keys in the input are resolved by last-wins — matching how bash
-// source() evaluates the file.
-func parseEnvFile(content string) (map[string]string, []string) {
-	exports := make(map[string]string)
-	var preserved []string
-	for _, line := range strings.Split(content, "\n") {
-		if line == "" {
-			continue
-		}
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, "export ") {
-			preserved = append(preserved, line)
-			continue
-		}
-		rest := strings.TrimPrefix(trimmed, "export ")
-		eq := strings.IndexByte(rest, '=')
-		if eq < 0 {
-			preserved = append(preserved, line)
-			continue
-		}
-		key := rest[:eq]
-		val := rest[eq+1:]
-		// strip surrounding double quotes if present (matches fmt.Fprintf %q shape)
-		if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
-			unquoted, err := strconv.Unquote(val)
-			if err == nil {
-				val = unquoted
-			} else {
-				val = val[1 : len(val)-1]
+// upsertEnvFile rewrites `content` so that each key in `vars` has a single
+// canonical `export KEY="VALUE"` line. Lines matching a key in `vars`
+// are overwritten in place on first occurrence and removed on subsequent
+// occurrences (dedup). All other lines — unrelated exports, comments,
+// blanks, shell expansions — are preserved verbatim, never reformatted.
+// Keys not already present are appended at the end in sorted order for
+// deterministic output.
+func upsertEnvFile(content string, vars map[string]string) string {
+	written := make(map[string]bool, len(vars))
+
+	var out strings.Builder
+	lines := strings.Split(content, "\n")
+	// preserve trailing-newline semantics: splitting "foo\n" yields ["foo",""].
+	// The "" sentinel lets us re-emit a final newline only if the source had one.
+	for i, line := range lines {
+		key, isExport := parseExportKey(line)
+		if isExport {
+			if newVal, owned := vars[key]; owned {
+				if !written[key] {
+					fmt.Fprintf(&out, "export %s=%q", key, newVal)
+					written[key] = true
+					// preserve newline if not the final sentinel
+					if i < len(lines)-1 {
+						out.WriteByte('\n')
+					}
+				}
+				// skip this line (either wrote replacement or deduping)
+				continue
 			}
 		}
-		exports[key] = val
+		out.WriteString(line)
+		if i < len(lines)-1 {
+			out.WriteByte('\n')
+		}
 	}
-	return exports, preserved
+
+	// append any owned keys that weren't already present, in sorted order
+	var missing []string
+	for k := range vars {
+		if !written[k] {
+			missing = append(missing, k)
+		}
+	}
+	sort.Strings(missing)
+	for _, k := range missing {
+		// ensure we start on a fresh line
+		s := out.String()
+		if len(s) > 0 && !strings.HasSuffix(s, "\n") {
+			out.WriteByte('\n')
+		}
+		fmt.Fprintf(&out, "export %s=%q\n", k, vars[k])
+	}
+
+	return out.String()
+}
+
+// parseExportKey returns (key, true) when line is of the shape
+// `export KEY=...`, otherwise ("", false). Only bare `export ` prefix
+// (possibly after leading whitespace) counts — `declare -x`, `readonly`,
+// etc. are left alone as foreign syntax.
+func parseExportKey(line string) (string, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "export ") {
+		return "", false
+	}
+	rest := strings.TrimPrefix(trimmed, "export ")
+	eq := strings.IndexByte(rest, '=')
+	if eq <= 0 {
+		return "", false
+	}
+	return rest[:eq], true
 }
 
 // IsAgentHookContext detects if we're running in a coding agent's hook context.

--- a/cmd/ox/prime_session_marker.go
+++ b/cmd/ox/prime_session_marker.go
@@ -140,7 +140,9 @@ func ReadSessionMarker(agentSessionID string) (*SessionMarker, error) {
 
 // WriteSessionMarker writes a session marker to disk.
 // Creates the marker directory if it doesn't exist.
-// Uses atomic write pattern (temp file + rename) for safety.
+// Uses atomic write (temp file + fsync + rename + parent-dir fsync) via
+// the shared fileutil helper for consistency with every other user-touching
+// write path in this file.
 func WriteSessionMarker(marker *SessionMarker) error {
 	if marker.AgentSessionID == "" {
 		return fmt.Errorf("agent session ID is required")
@@ -158,16 +160,9 @@ func WriteSessionMarker(marker *SessionMarker) error {
 		return fmt.Errorf("failed to marshal marker: %w", err)
 	}
 
-	// atomic write: temp file + rename
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
-		return fmt.Errorf("failed to write marker temp: %w", err)
+	if err := fileutil.AtomicWriteBytes(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write marker: %w", err)
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath) // clean up on failure
-		return fmt.Errorf("failed to rename marker: %w", err)
-	}
-
 	return nil
 }
 

--- a/cmd/ox/prime_session_marker.go
+++ b/cmd/ox/prime_session_marker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/sageox/agentx"
 	"github.com/sageox/ox/internal/paths"
 )
@@ -75,10 +77,10 @@ func FindSessionMarkerByPID(agentPID int) *SessionMarker {
 		return nil
 	}
 	for _, entry := range entries {
+		// WriteSessionMarker emits atomic temp files as "<sid>.json.tmp"
+		// and renames to "<sid>.json" — the .json suffix check here also
+		// excludes the .tmp variants, which end in .tmp not .json.
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
-			continue
-		}
-		if strings.HasSuffix(entry.Name(), ".tmp") {
 			continue
 		}
 		data, err := os.ReadFile(filepath.Join(SessionMarkerDir(), entry.Name()))
@@ -209,6 +211,23 @@ func WriteToAgentEnvFile(vars map[string]string) error {
 	if envFilePath == "" {
 		return nil // not in an agent context with env file support
 	}
+
+	// Concurrent primes (e.g. SessionStart hook racing against the
+	// CLAUDE.md BLOCKING re-prime — exactly the #527/#529 scenario) both
+	// read-modify-write this file. Without a lock, last-renamer-wins and
+	// the other prime's keys silently disappear. Serialize via flock on
+	// a sibling .lock file. 2s budget matches agentinstance.Store.
+	lock := flock.New(envFilePath + ".lock")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	locked, err := lock.TryLockContext(ctx, 100*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("failed to acquire agent env file lock: %w", err)
+	}
+	if !locked {
+		return fmt.Errorf("could not acquire agent env file lock within timeout")
+	}
+	defer func() { _ = lock.Unlock() }()
 
 	// read existing content (may not exist yet)
 	existing, err := os.ReadFile(envFilePath)

--- a/cmd/ox/prime_session_marker_test.go
+++ b/cmd/ox/prime_session_marker_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -371,11 +372,18 @@ func TestFindSessionMarkerByPID_MatchesParentPID(t *testing.T) {
 // must not be returned, even if their PID field matches the query. Stale
 // markers from crashed sessions are a primary source of cross-session
 // identity bleed — see code-reviewer round 2 SUGGESTION on #527 PID fallback.
+//
+// Spawns a short-lived child process and records its PID, then Wait()s to
+// reap it so we have a deterministically-dead PID to assert against —
+// strictly safer than a "probably unused" integer which could flake on
+// machines with long-running processes holding that PID.
 func TestFindSessionMarkerByPID_IgnoresDeadParentPID(t *testing.T) {
-	// a PID high enough to be unlikely to reference any live process
-	deadPID := 999901
-	sessionID := "findbyPIDdead_" + time.Now().Format("20060102150405.000")
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Start())
+	deadPID := cmd.Process.Pid
+	require.NoError(t, cmd.Wait()) // reap — PID is now guaranteed dead
 
+	sessionID := "findbyPIDdead_" + time.Now().Format("20060102150405.000")
 	marker := &SessionMarker{
 		AgentID:        "OxDead",
 		AgentSessionID: sessionID,

--- a/cmd/ox/prime_session_marker_test.go
+++ b/cmd/ox/prime_session_marker_test.go
@@ -257,9 +257,15 @@ func TestWriteToAgentEnvFile_WritesAgentIDWithoutSessionID(t *testing.T) {
 		"SAGEOX_AGENT_ID must be written to env file even when session ID is empty")
 }
 
-// TestWriteToAgentEnvFile_Idempotent verifies that multiple writes append entries
-// and that the last write wins for any given key on read. This covers the /clear
-// scenario where prime runs again after a session reset.
+// TestWriteToAgentEnvFile_Idempotent verifies upsert semantics: a second
+// write of the same key replaces the first, leaving exactly one definition
+// in the file rather than stacking duplicates.
+//
+// Failure prevented: #527/#529 cross-session AGENT_ENV poisoning. Without
+// upsert, a second prime that mis-claims AGENT_ENV=pi after an earlier
+// AGENT_ENV=claude-code would leave both lines in the file and any later
+// subprocess (re-sourcing the file) could inherit the wrong value
+// depending on ordering and shell semantics.
 func TestWriteToAgentEnvFile_Idempotent(t *testing.T) {
 	tmpDir := t.TempDir()
 	envFile := filepath.Join(tmpDir, "env")
@@ -286,7 +292,101 @@ func TestWriteToAgentEnvFile_Idempotent(t *testing.T) {
 
 	content, err := os.ReadFile(envFile)
 	require.NoError(t, err)
-	// both writes must be present; shell sources the file so last wins
-	assert.Contains(t, string(content), `export SAGEOX_AGENT_ID="OxFirst"`)
+	// second write wins; first is not retained
 	assert.Contains(t, string(content), `export SAGEOX_AGENT_ID="OxSecond"`)
+	assert.NotContains(t, string(content), `export SAGEOX_AGENT_ID="OxFirst"`,
+		"first write must be replaced, not stacked — append-and-stack is the #527/#529 bug class")
+	// exactly one export line for this key
+	assert.Equal(t, 1, strings.Count(string(content), `export SAGEOX_AGENT_ID=`),
+		"only one export line per key should remain after upsert")
+}
+
+// TestWriteToAgentEnvFile_AgentEnvUpsertAfterAdapterMismatch is a direct
+// reproducer for #527: the first prime (from the correct SessionStart hook)
+// sets AGENT_ENV=claude-code; a second prime driven by a tainted CLAUDE.md
+// block would have injected AGENT_ENV=pi. After upsert, only the latest
+// write should remain — and this test pins that contract.
+func TestWriteToAgentEnvFile_AgentEnvUpsertAfterAdapterMismatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	envFile := filepath.Join(tmpDir, "env")
+
+	origEnv := os.Getenv("CLAUDE_ENV_FILE")
+	os.Setenv("CLAUDE_ENV_FILE", envFile)
+	t.Cleanup(func() {
+		if origEnv != "" {
+			os.Setenv("CLAUDE_ENV_FILE", origEnv)
+		} else {
+			os.Unsetenv("CLAUDE_ENV_FILE")
+		}
+	})
+
+	// hook-driven prime: correct agent type
+	require.NoError(t, WriteToAgentEnvFile(map[string]string{
+		"AGENT_ENV": "claude-code",
+	}))
+
+	// CLAUDE.md-driven re-prime that wrongly claims pi (pre-fix #527 shape)
+	require.NoError(t, WriteToAgentEnvFile(map[string]string{
+		"AGENT_ENV": "pi",
+	}))
+
+	content, err := os.ReadFile(envFile)
+	require.NoError(t, err)
+	// only the last write should remain in the file
+	assert.Equal(t, 1, strings.Count(string(content), `export AGENT_ENV=`),
+		"AGENT_ENV must not stack across primes")
+}
+
+// TestFindSessionMarkerByPID_MatchesParentPID is the #527/#529 regression
+// guard for PID-based marker fallback: a second prime call that lacks a
+// native agent_session_id (e.g. invoked from a CLAUDE.md BLOCKING
+// instruction with no hook stdin) must still locate the marker the
+// hook-driven prime wrote earlier in the same agent process. Without this,
+// the second prime falls through to fresh-prime, appending a duplicate row
+// to agent_instances.jsonl.
+func TestFindSessionMarkerByPID_MatchesParentPID(t *testing.T) {
+	// use a PID value unlikely to collide with a real marker on the system
+	agentPID := 999901
+	sessionID := "findbyPIDtest_" + time.Now().Format("20060102150405.000")
+
+	marker := &SessionMarker{
+		AgentID:        "OxFindByPID",
+		AgentSessionID: sessionID,
+		PrimedAt:       time.Now().Truncate(time.Second),
+		ParentPID:      agentPID,
+	}
+	require.NoError(t, WriteSessionMarker(marker))
+	t.Cleanup(func() { DeleteSessionMarker(sessionID) })
+
+	found := FindSessionMarkerByPID(agentPID)
+	require.NotNil(t, found, "marker with matching ParentPID must be found")
+	assert.Equal(t, "OxFindByPID", found.AgentID)
+	assert.Equal(t, sessionID, found.AgentSessionID)
+}
+
+// TestFindSessionMarkerByPID_IgnoresNonMatchingPID confirms the scan is
+// strict: unrelated markers on the system must not be returned for a PID
+// they don't reference.
+func TestFindSessionMarkerByPID_IgnoresNonMatchingPID(t *testing.T) {
+	sessionID := "findbyPIDnomatch_" + time.Now().Format("20060102150405.000")
+	marker := &SessionMarker{
+		AgentID:        "OxOther",
+		AgentSessionID: sessionID,
+		PrimedAt:       time.Now().Truncate(time.Second),
+		ParentPID:      111111,
+	}
+	require.NoError(t, WriteSessionMarker(marker))
+	t.Cleanup(func() { DeleteSessionMarker(sessionID) })
+
+	// query for a PID that no marker references
+	got := FindSessionMarkerByPID(222222)
+	assert.Nil(t, got, "must not return a marker whose ParentPID differs")
+}
+
+// TestFindSessionMarkerByPID_RejectsInvalidPID guards against matching
+// placeholder / unset PID values (0, negative) against a stored marker
+// that happens to record PID 0 from an earlier buggy write.
+func TestFindSessionMarkerByPID_RejectsInvalidPID(t *testing.T) {
+	assert.Nil(t, FindSessionMarkerByPID(0))
+	assert.Nil(t, FindSessionMarkerByPID(-1))
 }

--- a/cmd/ox/prime_session_marker_test.go
+++ b/cmd/ox/prime_session_marker_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -333,9 +334,89 @@ func TestWriteToAgentEnvFile_AgentEnvUpsertAfterAdapterMismatch(t *testing.T) {
 
 	content, err := os.ReadFile(envFile)
 	require.NoError(t, err)
-	// only the last write should remain in the file
+	// only the last write should remain in the file, and it must be "pi"
+	// — a buggy implementation that kept "claude-code" and silently
+	// dropped the second write would satisfy a bare count check
+	// (CodeRabbit review on #543).
+	assert.Contains(t, string(content), `export AGENT_ENV="pi"`,
+		"last write value must survive")
+	assert.NotContains(t, string(content), `export AGENT_ENV="claude-code"`,
+		"earlier write must be replaced, not retained")
 	assert.Equal(t, 1, strings.Count(string(content), `export AGENT_ENV=`),
 		"AGENT_ENV must not stack across primes")
+}
+
+// TestWriteToAgentEnvFile_PreservesUnrelatedExportsVerbatim confirms the
+// surgical-upsert contract: lines unrelated to the keys being written
+// (including unrelated exports with shell-expansion values, comments,
+// blanks) must pass through byte-for-byte — never reformatted through
+// Go's %q, which would change quoting on constructs like
+// `export PATH="$HOME/bin:$PATH"` and silently break the caller's shell.
+//
+// Failure prevented: CodeRabbit review on #543 flagged this as a
+// privacy + correctness regression in the earlier parseEnvFile-based
+// approach. The env file can carry any export a parent shell injected.
+func TestWriteToAgentEnvFile_PreservesUnrelatedExportsVerbatim(t *testing.T) {
+	tmpDir := t.TempDir()
+	envFile := filepath.Join(tmpDir, "env")
+
+	// seed the file with content ox did not write: a comment, an
+	// unrelated export with a shell-expansion value, and a blank line.
+	seed := "# caller's settings\nexport PATH=\"$HOME/bin:$PATH\"\n\nexport UNRELATED='don'\\''t touch'\n"
+	require.NoError(t, os.WriteFile(envFile, []byte(seed), 0600))
+
+	t.Setenv("CLAUDE_ENV_FILE", envFile)
+
+	require.NoError(t, WriteToAgentEnvFile(map[string]string{
+		"SAGEOX_AGENT_ID": "OxNew",
+	}))
+
+	got, err := os.ReadFile(envFile)
+	require.NoError(t, err)
+	gotStr := string(got)
+
+	// Every seeded line must be present byte-for-byte.
+	for _, lit := range []string{
+		"# caller's settings",
+		`export PATH="$HOME/bin:$PATH"`,
+		`export UNRELATED='don'\''t touch'`,
+	} {
+		assert.Contains(t, gotStr, lit,
+			"caller's line %q must be preserved verbatim", lit)
+	}
+	// The new SageOx-owned key must be appended exactly once.
+	assert.Equal(t, 1, strings.Count(gotStr, "export SAGEOX_AGENT_ID="))
+	assert.Contains(t, gotStr, `export SAGEOX_AGENT_ID="OxNew"`)
+}
+
+// TestWriteToAgentEnvFile_NeverLoosensPermissions confirms the env
+// file gets written with no looser than 0600 — and if the existing
+// file was already stricter, the stricter mode is preserved.
+// Failure prevented: 0644 exposure of values the caller considers
+// private. CodeRabbit review on #543.
+func TestWriteToAgentEnvFile_NeverLoosensPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	envFile := filepath.Join(tmpDir, "env")
+
+	t.Setenv("CLAUDE_ENV_FILE", envFile)
+
+	t.Run("new file defaults to 0600", func(t *testing.T) {
+		require.NoError(t, WriteToAgentEnvFile(map[string]string{"AGENT_ENV": "claude-code"}))
+		info, err := os.Stat(envFile)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm(),
+			"default permissions should cap at 0600, not 0644")
+		require.NoError(t, os.Remove(envFile))
+	})
+
+	t.Run("preserves stricter existing mode", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(envFile, []byte(""), 0400))
+		require.NoError(t, WriteToAgentEnvFile(map[string]string{"AGENT_ENV": "claude-code"}))
+		info, err := os.Stat(envFile)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0400), info.Mode().Perm(),
+			"existing stricter mode (0400) must not be loosened")
+	})
 }
 
 // TestFindSessionMarkerByPID_MatchesParentPID is the #527/#529 regression
@@ -378,6 +459,14 @@ func TestFindSessionMarkerByPID_MatchesParentPID(t *testing.T) {
 // strictly safer than a "probably unused" integer which could flake on
 // machines with long-running processes holding that PID.
 func TestFindSessionMarkerByPID_IgnoresDeadParentPID(t *testing.T) {
+	// exec.Command("true") is POSIX-only. Windows has no /usr/bin/true,
+	// so on that platform skip rather than fabricate a fake PID that
+	// would defeat the liveness gate under test. The live-PID happy
+	// path is already covered by TestFindSessionMarkerByPID_MatchesParentPID.
+	if runtime.GOOS == "windows" {
+		t.Skip("test requires POSIX `true` to spawn-and-reap a guaranteed-dead PID")
+	}
+
 	cmd := exec.Command("true")
 	require.NoError(t, cmd.Start())
 	deadPID := cmd.Process.Pid

--- a/cmd/ox/prime_session_marker_test.go
+++ b/cmd/ox/prime_session_marker_test.go
@@ -344,9 +344,11 @@ func TestWriteToAgentEnvFile_AgentEnvUpsertAfterAdapterMismatch(t *testing.T) {
 // hook-driven prime wrote earlier in the same agent process. Without this,
 // the second prime falls through to fresh-prime, appending a duplicate row
 // to agent_instances.jsonl.
+//
+// Uses the current test process PID so the proc.IsAlive liveness gate
+// passes — a recycled/dead PID is specifically what the gate filters out.
 func TestFindSessionMarkerByPID_MatchesParentPID(t *testing.T) {
-	// use a PID value unlikely to collide with a real marker on the system
-	agentPID := 999901
+	agentPID := os.Getpid()
 	sessionID := "findbyPIDtest_" + time.Now().Format("20060102150405.000")
 
 	marker := &SessionMarker{
@@ -362,6 +364,29 @@ func TestFindSessionMarkerByPID_MatchesParentPID(t *testing.T) {
 	require.NotNil(t, found, "marker with matching ParentPID must be found")
 	assert.Equal(t, "OxFindByPID", found.AgentID)
 	assert.Equal(t, sessionID, found.AgentSessionID)
+}
+
+// TestFindSessionMarkerByPID_IgnoresDeadParentPID is the liveness regression
+// guard: markers whose ParentPID no longer corresponds to a running process
+// must not be returned, even if their PID field matches the query. Stale
+// markers from crashed sessions are a primary source of cross-session
+// identity bleed — see code-reviewer round 2 SUGGESTION on #527 PID fallback.
+func TestFindSessionMarkerByPID_IgnoresDeadParentPID(t *testing.T) {
+	// a PID high enough to be unlikely to reference any live process
+	deadPID := 999901
+	sessionID := "findbyPIDdead_" + time.Now().Format("20060102150405.000")
+
+	marker := &SessionMarker{
+		AgentID:        "OxDead",
+		AgentSessionID: sessionID,
+		PrimedAt:       time.Now().Truncate(time.Second),
+		ParentPID:      deadPID,
+	}
+	require.NoError(t, WriteSessionMarker(marker))
+	t.Cleanup(func() { DeleteSessionMarker(sessionID) })
+
+	got := FindSessionMarkerByPID(deadPID)
+	assert.Nil(t, got, "marker whose ParentPID is not alive must be rejected")
 }
 
 // TestFindSessionMarkerByPID_IgnoresNonMatchingPID confirms the scan is

--- a/cmd/ox/repo_agents_md_test.go
+++ b/cmd/ox/repo_agents_md_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestRepoAgentsMD_NoAdapterEnvHardcodes guards this repo's own AGENTS.md
+// against re-introduction of the #527 bug pattern: an adapter-specific
+// prime block hardcoding AGENT_ENV=<adapter> inside a file that Claude Code
+// (or any other agent) may read via the AGENTS.md/CLAUDE.md symlink.
+//
+// Failure prevented: a committed AGENTS.md that mis-routes Claude Code
+// sessions through the Pi/Amp/Aider adapter, producing wrong agent_type
+// rows in agent_instances.jsonl and poisoning CLAUDE_ENV_FILE with a
+// bogus AGENT_ENV for every subsequent Bash tool invocation.
+//
+// Scope: the repo-root AGENTS.md (and its CLAUDE.md symlink, if present).
+// The hook shell commands in internal/constants/agent.go legitimately
+// carry AGENT_ENV because they run in subprocess contexts; this test
+// does not look at those.
+func TestRepoAgentsMD_NoAdapterEnvHardcodes(t *testing.T) {
+	root := findOxRepoRootForTest(t)
+
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
+		path := filepath.Join(root, name)
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+
+		forbidden := []string{
+			"AGENT_ENV=pi",
+			"AGENT_ENV=amp",
+			"AGENT_ENV=aider",
+			"AGENT_ENV=codex",
+			"AGENT_ENV=gemini",
+			"AGENT_ENV=droid",
+			"AGENT_ENV=opencode",
+		}
+		content := string(data)
+		for _, lit := range forbidden {
+			if strings.Contains(content, lit) {
+				t.Errorf("%s contains forbidden literal %q — see #527: adapter-specific AGENT_ENV hardcodes in AGENTS.md poison cross-agent sessions", name, lit)
+			}
+		}
+	}
+}
+
+// findOxRepoRootForTest walks up from the current test file's directory
+// until it finds a go.mod, returning that directory. Fails the test if
+// not found. Named distinctly from production findRepoRoot() in doctor_git.go.
+func findOxRepoRootForTest(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed")
+	}
+	dir := filepath.Dir(thisFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod found walking up from %s", filepath.Dir(thisFile))
+		}
+		dir = parent
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/sageox/agentx v0.1.7
+	github.com/sageox/agentx v0.1.9
 	github.com/sageox/frictionax v0.1.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -319,6 +319,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sageox/agentx v0.1.7 h1:mzPLS0Cm13P3C11TxiVC6JKtKzClc0/JhTVR9jgflN8=
 github.com/sageox/agentx v0.1.7/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
+github.com/sageox/agentx v0.1.9 h1:Hm5voAzQweoSmT3Zc0qgv0hHKH3p9fx46tYv1gbA7GQ=
+github.com/sageox/agentx v0.1.9/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
 github.com/sageox/frictionax v0.1.2 h1:iQfssC1g/vVdGXi55smMfY5/4JKcQbJXRzcwrQWiNLo=
 github.com/sageox/frictionax v0.1.2/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/internal/fileutil/atomic.go
+++ b/internal/fileutil/atomic.go
@@ -12,8 +12,26 @@ import (
 // new inode entry survives a hard crash. Intended for user-facing files where
 // a crash-window partial write would destroy content — instruction files
 // (AGENTS.md / CONVENTIONS.md), env files, etc.
+//
+// If filePath is a symlink, the rename follows the symlink to its target so
+// the link itself is preserved and the underlying file is updated. The
+// CLAUDE.md → AGENTS.md pattern that ox init creates depends on this — a
+// naive rename would replace the symlink with a regular file and break the
+// link. Ordinary (non-symlink) paths are written directly as before.
 func AtomicWriteBytes(filePath string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(filePath)
+	// Follow symlinks so the link structure survives the write (e.g.
+	// CLAUDE.md → AGENTS.md). Lstat tells us whether filePath is itself a
+	// symlink; if it is, resolve to the real inode and write there.
+	writePath := filePath
+	if info, err := os.Lstat(filePath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		resolved, resolveErr := filepath.EvalSymlinks(filePath)
+		if resolveErr != nil {
+			return fmt.Errorf("resolve symlink %q: %w", filePath, resolveErr)
+		}
+		writePath = resolved
+	}
+
+	dir := filepath.Dir(writePath)
 
 	tmp, err := os.CreateTemp(dir, ".tmp-*")
 	if err != nil {
@@ -46,7 +64,7 @@ func AtomicWriteBytes(filePath string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("chmod: %w", err)
 	}
 
-	if err := os.Rename(tmpPath, filePath); err != nil {
+	if err := os.Rename(tmpPath, writePath); err != nil {
 		return fmt.Errorf("rename: %w", err)
 	}
 

--- a/internal/fileutil/atomic.go
+++ b/internal/fileutil/atomic.go
@@ -7,6 +7,52 @@ import (
 	"path/filepath"
 )
 
+// AtomicWriteBytes writes raw bytes to filePath atomically using temp+rename,
+// fsync'd before rename for durability. Intended for user-facing files where
+// a crash-window partial write would destroy content — instruction files
+// (AGENTS.md / CONVENTIONS.md), env files, etc.
+func AtomicWriteBytes(filePath string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(filePath)
+
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	success := false
+	defer func() {
+		if !success {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write bytes: %w", err)
+	}
+
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("fsync: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return fmt.Errorf("chmod: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		return fmt.Errorf("rename: %w", err)
+	}
+
+	success = true
+	return nil
+}
+
 // AtomicWriteJSON writes data as JSON to filePath atomically using temp+rename.
 // This prevents partial/corrupt files from concurrent reads during write.
 // The file is fsync'd before rename to ensure durability.

--- a/internal/fileutil/atomic.go
+++ b/internal/fileutil/atomic.go
@@ -8,7 +8,8 @@ import (
 )
 
 // AtomicWriteBytes writes raw bytes to filePath atomically using temp+rename,
-// fsync'd before rename for durability. Intended for user-facing files where
+// fsync'd before rename and the parent directory fsync'd after rename so the
+// new inode entry survives a hard crash. Intended for user-facing files where
 // a crash-window partial write would destroy content — instruction files
 // (AGENTS.md / CONVENTIONS.md), env files, etc.
 func AtomicWriteBytes(filePath string, data []byte, perm os.FileMode) error {
@@ -47,6 +48,15 @@ func AtomicWriteBytes(filePath string, data []byte, perm os.FileMode) error {
 
 	if err := os.Rename(tmpPath, filePath); err != nil {
 		return fmt.Errorf("rename: %w", err)
+	}
+
+	// fsync the parent directory so the rename's dirent update is durable
+	// even across a hard crash. Best-effort: directory fsync is not supported
+	// on every platform/filesystem (Windows, some network mounts), so log-and-
+	// continue rather than failing the write.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
 	}
 
 	success = true

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -99,6 +99,49 @@ func TestAtomicWriteBytes_ParentDirMissing(t *testing.T) {
 	}
 }
 
+// TestAtomicWriteBytes_PreservesSymlink is the CodeRabbit-review regression
+// for ox#543: when the target path is a symlink (ox init creates
+// CLAUDE.md → AGENTS.md), the atomic write must follow the link and
+// update the real file, not replace the link with a regular file.
+//
+// Failure prevented: a write to CLAUDE.md breaking the symlink to
+// AGENTS.md so the two files drift out of sync on the next write.
+func TestAtomicWriteBytes_PreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "AGENTS.md")
+	link := filepath.Join(dir, "CLAUDE.md")
+
+	if err := os.WriteFile(target, []byte("original"), 0644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if err := os.Symlink("AGENTS.md", link); err != nil {
+		t.Skipf("symlinks not supported on this platform: %v", err)
+	}
+
+	// write through the symlink — the link must survive, target updates
+	if err := AtomicWriteBytes(link, []byte("updated"), 0644); err != nil {
+		t.Fatalf("AtomicWriteBytes: %v", err)
+	}
+
+	// symlink still exists as a symlink (not replaced with regular file)
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("symlink was replaced with a regular file; got mode=%v", info.Mode())
+	}
+
+	// target file (the real inode) received the update
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("readback target: %v", err)
+	}
+	if string(got) != "updated" {
+		t.Errorf("target content = %q, want %q", got, "updated")
+	}
+}
+
 func TestAtomicWriteJSON_Success(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.json")

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -4,8 +4,100 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// --- AtomicWriteBytes ---
+
+// TestAtomicWriteBytes_RoundTrip verifies the happy path: bytes go in,
+// the exact same bytes come out, and the file has the requested mode.
+// Failure prevented: regressing the helper that backs every instruction-file
+// write (AGENTS.md, CONVENTIONS.md, CLAUDE_ENV_FILE) to leave partial or
+// wrongly-permissioned content.
+func TestAtomicWriteBytes_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "target.md")
+
+	want := []byte("<!-- ox:prime-check -->\n# hi\n")
+	if err := AtomicWriteBytes(path, want, 0644); err != nil {
+		t.Fatalf("AtomicWriteBytes: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("content mismatch: got %q, want %q", got, want)
+	}
+
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := st.Mode() & os.ModePerm; perm != 0644 {
+		t.Errorf("perm = %o, want 0644", perm)
+	}
+}
+
+// TestAtomicWriteBytes_OverwritesExisting verifies rewrite semantics:
+// an existing file is replaced wholesale, not appended to.
+// Failure prevented: a regression that leaves stale content behind
+// (the exact failure mode we're defending against in adapter hooks).
+func TestAtomicWriteBytes_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "target")
+
+	if err := os.WriteFile(path, []byte("original"), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := AtomicWriteBytes(path, []byte("replaced"), 0644); err != nil {
+		t.Fatalf("AtomicWriteBytes: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "replaced" {
+		t.Errorf("overwrite failed: got %q", got)
+	}
+}
+
+// TestAtomicWriteBytes_NoStrayTempFiles guards cleanup: every successful
+// write leaves only the target, no .tmp-* siblings.
+// Failure prevented: leaking temp files into user repos (and making the
+// next scan of AGENTS.md-class markers pick them up as real content).
+func TestAtomicWriteBytes_NoStrayTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "target")
+
+	if err := AtomicWriteBytes(path, []byte("data"), 0644); err != nil {
+		t.Fatalf("AtomicWriteBytes: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("unexpected temp file left in dir: %s", e.Name())
+		}
+	}
+}
+
+// TestAtomicWriteBytes_ParentDirMissing confirms the helper surfaces
+// errors rather than silently creating files in unexpected locations.
+// Failure prevented: a misconfigured caller getting an empty return
+// and believing the write landed when the parent directory was removed
+// between stat and call.
+func TestAtomicWriteBytes_ParentDirMissing(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist", "target")
+
+	err := AtomicWriteBytes(missing, []byte("data"), 0644)
+	if err == nil {
+		t.Fatalf("expected error for missing parent dir, got nil")
+	}
+}
 
 func TestAtomicWriteJSON_Success(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -47,6 +47,7 @@ const (
 	EventGuidanceFetchError = "guidance_fetch_error" // auth, 404, rate limit errors
 	EventAttributionShown   = "attribution_shown"    // attribution footer displayed
 	EventPrimeExcessive     = "prime_excessive"      // prime called more than threshold times
+	EventPrimeTypeMismatch  = "prime_type_mismatch"  // re-prime claimed a different agent_type than the stored instance (#527)
 
 	// daemon events (sent directly from CLI when daemon unavailable)
 	EventDaemonStartFailure = "daemon:start_failure" // daemon failed to start


### PR DESCRIPTION
## Summary

Closes #527 and #529. Fixes a class of bug where a Claude Code session with a stray `AGENT_ENV=pi` in a CLAUDE.md→AGENTS.md symlink silently mis-routed through the Pi adapter — corrupting `agent_instances.jsonl` with wrong `agent_type` rows, polluting `CLAUDE_ENV_FILE` with the bogus AGENT_ENV, and duplicating agent registrations on every re-prime.

## Root causes

1. **#527 — content contract:** Pi/Amp/Aider `handleInstallHooks` injected blocks containing a literal `AGENT_ENV=<adapter> ox agent prime` into the shared AGENTS.md (or its symlinked counterpart). Whichever agent read the file next would "helpfully" run that command, mis-identifying the session.
2. **#527 — collision:** Pi and Amp external adapters used the identical `<!-- ox:prime:start -->` / `<!-- ox:prime:end -->` marker pair in shared AGENTS.md, so their install-hook idempotency checks collided: the second adapter's install silently no-op'd against the first's block.
3. **#529 — re-entry:** A CLAUDE.md BLOCKING instruction re-runs `ox agent prime` after the SessionStart hook already primed. The second prime's marker lookup missed (no `agent_session_id` from stdin), fell through to `store.Add`, and appended a duplicate row. In parallel, `CLAUDE_ENV_FILE` grew unbounded via O_APPEND.

## What changed (5 commits, 20 files, +1,320/-174)

**1. AGENTS.md content contract** — stripped every `AGENT_ENV=<adapter>` literal from Pi/Amp/Aider install-hook injections. The universal `<!-- ox:prime-check -->` / `<!-- ox:prime -->` markers already cover priming.

**2. This repo's own AGENTS.md + regression pin** — removed the stale Pi block from the committed file; added `TestRepoAgentsMD_NoAdapterEnvHardcodes` that fails if any `AGENT_ENV=<adapter>` literal ever reappears.

**3. Prime re-entry hardening**:
- `FindSessionMarkerByPID` walks session-marker dir by ancestor-PID match as a fallback when `agent_session_id` is unavailable. Gated on `agentx.CurrentAgent() != nil` (so non-agent shells can't coincidentally match a stale marker) and a `proc.IsAlive` liveness check (so crashed-session PIDs don't cross-link).
- `store.IncrementPrimeCallCount` now runs before `store.Add` whenever we have an agent_id. Seals the duplicate-row bug class.
- `agent_type` is frozen on re-prime: mismatches log `slog.Warn` and emit a new `EventPrimeTypeMismatch` telemetry event rather than silently rewriting the stored type.
- `WriteToAgentEnvFile` now does read-parse-upsert-atomic-rewrite under `flock`, replacing the old O_APPEND stacking that caused the AGENT_ENV pollution.

**4. Unique marker pairs per adapter** — Pi/Amp/Aider external adapters now emit `<!-- ox:prime:pi:start -->` / `<!-- ox:prime:amp:start -->` / `<!-- ox:prime:aider:start -->`. The in-process `cmd/ox/hooks_pi.go` converges on the same Pi namespace. Legacy `<!-- ox:prime:start -->` and in-process `<!-- ox:pi-prime:start -->` pairs remain recognized for backward-compat install/uninstall.

**5. Doctor repair for in-the-wild corruption** — new `ox doctor` check `adapter-prime-blocks` detects any recognized adapter block in AGENTS.md / CONVENTIONS.md / CLAUDE.md, with `--fix` stripping them while preserving the universal markers. Surfaces the AGENTS.md↔CLAUDE.md symlink as an amplifier in the finding detail.

**Atomic-write hardening (discovered in review):** all `os.WriteFile` sites on user-facing files (AGENTS.md, CONVENTIONS.md, CLAUDE_ENV_FILE, session markers) now route through the new `fileutil.AtomicWriteBytes` helper (temp+fsync+rename+parent-dir-fsync).

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — full `./cmd/...` suite passes, including:
  - `TestRepoAgentsMD_NoAdapterEnvHardcodes` (repo-level pin)
  - `TestWriteToAgentEnvFile_AgentEnvUpsertAfterAdapterMismatch` (direct #527 reproducer)
  - `TestFindSessionMarkerByPID_*` (PID-fallback + liveness gate + dead-PID spawn test)
  - `TestCheckAdapterPrimeBlocks_*` (doctor check: detection, fix, symlink amplifier, dedup)
  - `TestPi/AmpMarkers_AreUniqueTo<Adapter>` (marker uniqueness)
  - `TestAtomicWriteBytes_*` (new fileutil helper)
- [x] 4 rounds of review with the `code-reviewer` coworker; converged to "Ready to merge" with zero CRITICAL/HIGH/SUGGESTION findings in the final round.

## Follow-ups (separate PRs)

- [sageox/agentx#9](https://github.com/sageox/agentx/pull/9) — `RuntimeDetector` interface so runtime signals (CLAUDECODE=1) outrank AGENT_ENV at the detection layer. Defense-in-depth upstream of this fix. Once merged+tagged, a small release-flow PR here will bump `go get github.com/sageox/agentx@<tag>`.
- sageox/ox-test-harness — baseline run + #527/#529 E2E reproducer tests across the agent matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a doctor check to find and optionally remove adapter-specific prime blocks from repo docs
  * Session priming more reliably preserves/associates sessions via PID-based fallback

* **Bug Fixes**
  * Prevent duplicate prime blocks and preserve/recognize legacy markers during install/uninstall
  * Removed hardcoded adapter env literals from repo docs and surfaced remediation guidance

* **Refactor**
  * Switched file writes to atomic operations for safer updates

* **Tests**
  * Added extensive tests for marker detection, idempotency, PID-marker behavior, and atomic writes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->