### PR TITLE
release: prep v0.6.4

### DIFF
--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -5,7 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.3] - 2026-04-13
+## [0.6.4] - 2026-04-22
+
+### Fixed
+
+**AI coworker isolation**
+- `AGENTS.md` no longer leaks one coworker's active-recording context into another's view — each coworker sees only its own stamp, preventing accidental cross-agent contamination
+- Recording-reminder whispers now reach only their intended recipient instead of fanning out to every coworker on the team
+- `ox agent prime` no longer falls back to attributing a session to the sole active-recording agent when the real ID can't be resolved, which previously credited the wrong coworker
+
+**Session capture**
+- Silent recording failures now surface as clear errors instead of producing empty session artifacts
+- Sessions that the LLM scores 0 are discarded and their cache cleaned up instead of being uploaded as empty entries to the ledger
+- The Claude Code adapter now wires `ReadFromOffset` correctly in one-shot mode so mid-session captures pick up from the right point
+
+**Daemon correctness**
+- Fixed a data race during scheduler shutdown where an in-flight clone trigger could panic `sync: WaitGroup is reused before previous Wait has returned`
+- Fixed a race between two concurrent GC reclones on the same workspace that could destroy each other's in-flight artifacts
+- Fixed GC reclone of a repo with an empty working tree — previously the captured diff deleted all restored files; now the empty tree is treated as corruption and the remote content is restored cleanly
+- Added a 30-second lock-mtime heartbeat during GC so long reclones don't have their lock reclaimed by the stale-lock watchdog
+
+### Changed
+- Claude Code stamp prefix and rewrite rules updated with team-first framing in team-aware repos
+- `ox init` and related installers now require the `claude` binary (the `primaryEnv` fallback has been removed from SageOx ClawHub skills)
+- ClawHub ox install is now pinned to a specific tarball with an embedded sha256 instead of a floating reference
+
+### Added
+- Session-capture architecture documentation
 
 ### Added
 

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-**Critical: Claude Code session recording captured zero turns (#519)**
-- In 0.6.3, every Claude Code session on macOS captured **zero turns** — `raw.jsonl` contained only the session header regardless of how much work happened. 17 consecutive sessions across hours of active use could produce empty recordings with no visible error. Root cause: the one-shot adapter path never wired its `ReadFromOffset` handler, so every `PostToolUse` hook silently returned "not implemented" and appended nothing. **Fixed — Claude Code sessions capture turns in real time again.**
-- Companion observability: silent recording failures are no longer silent. If a recording is active but hooks fire without making progress, the daemon now surfaces an error instead of letting an empty session file masquerade as a successful recording. This is what would have caught #519 immediately instead of after hours of lost sessions.
-- Sessions the LLM scores 0 are now discarded and their cache cleaned up, rather than being uploaded as empty entries to the ledger.
+**Session recording**
+- Claude Code session recording was producing header-only `raw.jsonl` files with no turn entries — the one-shot adapter path didn't wire its `ReadFromOffset` handler, so every `PostToolUse` hook no-op'd. Turns are captured again.
+- Silent recording failures now surface as errors instead of producing an empty session file.
+- Sessions the LLM scores 0 are discarded rather than uploaded as empty entries.
 
 **AI coworker isolation**
 - `AGENTS.md` no longer leaks one coworker's active-recording context into another's view — each coworker sees only its own stamp, preventing accidental cross-agent contamination

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -9,15 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+**Critical: Claude Code session recording captured zero turns (#519)**
+- In 0.6.3, every Claude Code session on macOS captured **zero turns** — `raw.jsonl` contained only the session header regardless of how much work happened. 17 consecutive sessions across hours of active use could produce empty recordings with no visible error. Root cause: the one-shot adapter path never wired its `ReadFromOffset` handler, so every `PostToolUse` hook silently returned "not implemented" and appended nothing. **Fixed — Claude Code sessions capture turns in real time again.**
+- Companion observability: silent recording failures are no longer silent. If a recording is active but hooks fire without making progress, the daemon now surfaces an error instead of letting an empty session file masquerade as a successful recording. This is what would have caught #519 immediately instead of after hours of lost sessions.
+- Sessions the LLM scores 0 are now discarded and their cache cleaned up, rather than being uploaded as empty entries to the ledger.
+
 **AI coworker isolation**
 - `AGENTS.md` no longer leaks one coworker's active-recording context into another's view — each coworker sees only its own stamp, preventing accidental cross-agent contamination
 - Recording-reminder whispers now reach only their intended recipient instead of fanning out to every coworker on the team
 - `ox agent prime` no longer falls back to attributing a session to the sole active-recording agent when the real ID can't be resolved, which previously credited the wrong coworker
-
-**Session capture**
-- Silent recording failures now surface as clear errors instead of producing empty session artifacts
-- Sessions that the LLM scores 0 are discarded and their cache cleaned up instead of being uploaded as empty entries to the ledger
-- The Claude Code adapter now wires `ReadFromOffset` correctly in one-shot mode so mid-session captures pick up from the right point
 
 **Daemon correctness**
 - Fixed a data race during scheduler shutdown where an in-flight clone trigger could panic `sync: WaitGroup is reused before previous Wait has returned`
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Session-capture architecture documentation
+
+[0.6.4]: https://github.com/sageox/ox/releases/tag/v0.6.4
+
+## [0.6.3] - 2026-04-13
 
 ### Added
 


### PR DESCRIPTION
## Summary

Release prep for **v0.6.4**. Version files already aligned (`internal/version/version.go`, the two plugin manifests); this PR is the CHANGELOG entry.

## Release gates

| Gate | Result |
|---|---|
| `make lint` | ✅ |
| `make build` | ✅ |
| `make test-all` | ✅ — 13,452 tests, 0 failures |
| `make test-slow` | ✅ — 13,609 tests, 0 failures |
| `make test-digital-twin` | ✅ (ledger-twin) |
| `make test-integration` | ✅ — run separately in `sageox/ox-test-harness` |
| `make smoke-test` | ⏭️ skipped (explicit user decision) |
| Run Walks | ✅ — passed on real machine |

## Release-note highlights

Mostly correctness fixes. Two notable daemon ones:

- **Data race on scheduler shutdown** — in-flight clone trigger could panic `sync: WaitGroup is reused before previous Wait has returned`. Fix guards `cloneWg.Add` behind a shutdown flag.
- **GC concurrent-lock race + empty-tree misbehavior** — two concurrent GCs on the same workspace could destroy each other's in-flight artifacts; GC on an empty working tree was wiping all restored content after reclone. Both fixed, with a 30s lock heartbeat so long reclones don't get their lock reclaimed by the stale-lock watchdog.

Plus several user-facing fixes to AI coworker isolation (cross-agent AGENTS.md contamination, recording-reminder fan-out, wrong-agent attribution on prime) and session capture (silent failures now surfaced, zero-scored sessions discarded, claude-code `ReadFromOffset` in one-shot mode).

See `cmd/ox/release_notes.md` for the full entry.

## Post-merge

1. I'll tag `v0.6.4` and push the tag
2. I'll create a **draft** GitHub release (`gh release create v0.6.4 --draft --notes-file -`)
3. You review the draft release
4. You publish → GoReleaser handles binaries + signing

## Notes

- v0.6.4 instead of v0.7.0 per your explicit call. Note the release skill's default convention is middle-number bumps (`0.<release>.0`); this PR honors your override.
- `internal/version/version.go` was already at `0.6.4` (bumped in commit d22e641 and carried on main since). Only the CHANGELOG entry was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session recording to properly capture turns and handle silent failures
  * Prevented context leakage between AI coworkers and corrected whisper routing
  * Resolved daemon race conditions and improved garbage collection stability
  * Enhanced handling for empty working trees and long-running operations

* **Documentation**
  * Added session-capture architecture documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->