### PR TITLE
chore(release): bump version to 0.6.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.6.4"
+      "version": "0.6.5"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - Unreleased
+
+_No changes yet. Populate as changes land during the 0.6.5 cycle._
+
 ## [0.6.4] - 2026-04-22
 
 ### Fixed

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.6.4"
+	Version   = "0.6.5"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## Summary

Bumps `internal/version/version.go`, the two plugin manifests, and adds a `## [0.6.5] - Unreleased` changelog stub so `make verify-version` stays green on main throughout the 0.6.5 cycle.

## Why the stub

Previous bump commit (`d22e641`, bump to 0.6.4) didn't touch the CHANGELOG, which left `make verify-version` failing on main from then until v0.6.4 shipped. This PR keeps the invariant intact: version.go and the CHANGELOG head always agree.

## Next cycle

As changes merge to main, append them under the `## [0.6.5] - Unreleased` section. When we're ready to cut 0.6.5, swap `Unreleased` for a date, then run the `/release` skill.

## Test plan

- [x] `make verify-version` — all four sources at 0.6.5
- [x] `make build` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.6.5 across plugin manifests and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->