### PR TITLE
feat(session): show titles in list; default JSON in agent context

### DIFF
--- a/cmd/ox/session_list.go
+++ b/cmd/ox/session_list.go
@@ -256,15 +256,22 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 			if user == "" {
 				user = localUser
 			}
+			// legacy sessions leave SessionName empty — fall back to the filename so
+			// agents always have a usable identifier for the 'ox session view <name>'
+			// follow-up step described in the guidance hint.
+			name := t.SessionName
+			if name == "" {
+				name = t.Filename
+			}
 			entries = append(entries, sessionListEntry{
-				Name:            t.SessionName,
+				Name:            name,
 				Date:            t.CreatedAt.Format("2006-01-02"),
 				Time:            t.CreatedAt.Format("15:04"),
 				User:            user,
 				Status:          status,
 				Recording:       t.Recording,
-				Title:           t.Title,
-				Summary:         t.Summary,
+				Title:           sanitizeSessionText(t.Title),
+				Summary:         sanitizeSessionText(t.Summary),
 				EntryCount:      t.EntryCount,
 				IsSubagent:      t.IsSubagent,
 				Origin:          t.Origin,
@@ -455,10 +462,13 @@ func printSessionRow(t session.SessionInfo, uploaded bool, localUser string) {
 // meta.Summary. Returns empty when neither is useful.
 func sessionBlurb(s session.SessionInfo) string {
 	const maxLen = 100
-	if t := strings.TrimSpace(s.Title); t != "" {
+	// Title/Summary come verbatim from meta.json written by other coworkers —
+	// strip ANSI and control bytes before rendering so a shared ledger can't
+	// spoof the terminal.
+	if t := sanitizeSessionText(strings.TrimSpace(s.Title)); t != "" {
 		return truncateSingleLine(t, maxLen)
 	}
-	sum := strings.TrimSpace(s.Summary)
+	sum := sanitizeSessionText(strings.TrimSpace(s.Summary))
 	if sum == "" || strings.HasPrefix(sum, "Summary generation failed") {
 		return ""
 	}
@@ -475,6 +485,43 @@ func sessionBlurb(s session.SessionInfo) string {
 		return truncateSingleLine(line, maxLen)
 	}
 	return ""
+}
+
+// sanitizeSessionText strips ANSI CSI escape sequences and other C0/C1 control
+// bytes from text originating in a shared ledger's meta.json. Preserves tabs
+// and newlines (callers flatten newlines separately when rendering single-line).
+func sanitizeSessionText(s string) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		// ESC: skip the whole CSI / OSC / other escape sequence.
+		if r == 0x1b {
+			// consume until a likely terminator (@-~ for CSI, BEL/ESC\ for OSC).
+			// conservative: drop until the next printable letter or end of input.
+			for i+1 < len(runes) {
+				i++
+				nr := runes[i]
+				if (nr >= '@' && nr <= '~') || nr == 0x07 {
+					break
+				}
+			}
+			continue
+		}
+		// drop C0 controls except \t and \n; drop DEL and C1 (0x80-0x9f).
+		if r < 0x20 && r != '\t' && r != '\n' {
+			continue
+		}
+		if r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // isMarkdownStructure reports whether a line is markdown syntax rather than

--- a/cmd/ox/session_list.go
+++ b/cmd/ox/session_list.go
@@ -125,12 +125,16 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		if jsonOutput {
 			cwd, _ := os.Getwd()
-			return outputJSON(sessionListOutput{
+			out := sessionListOutput{
 				Sessions:        []sessionListEntry{},
 				RepoName:        filepath.Base(cwd),
 				RepoID:          "",
 				LedgerAvailable: false,
-			})
+			}
+			if inAgent {
+				out.Guidance = sessionListAgentGuidance
+			}
+			return outputJSON(out)
 		}
 		cwd, _ := os.Getwd()
 		fmt.Println()
@@ -210,13 +214,17 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 			if showAll {
 				window = "all"
 			}
-			return outputJSON(sessionListOutput{
+			out := sessionListOutput{
 				Sessions:        []sessionListEntry{},
 				RepoName:        repoName,
 				RepoID:          repoID,
 				LedgerAvailable: ledgerAvailable,
 				Window:          window,
-			})
+			}
+			if inAgent {
+				out.Guidance = sessionListAgentGuidance
+			}
+			return outputJSON(out)
 		}
 		fmt.Println()
 		repoLabel := fmt.Sprintf("%q", repoName)
@@ -487,9 +495,10 @@ func sessionBlurb(s session.SessionInfo) string {
 	return ""
 }
 
-// sanitizeSessionText strips ANSI CSI escape sequences and other C0/C1 control
-// bytes from text originating in a shared ledger's meta.json. Preserves tabs
-// and newlines (callers flatten newlines separately when rendering single-line).
+// sanitizeSessionText strips ANSI CSI/OSC escape sequences and other C0/C1
+// control bytes from text originating in a shared ledger's meta.json. Preserves
+// tabs and newlines (callers flatten newlines separately when rendering
+// single-line).
 func sanitizeSessionText(s string) string {
 	if s == "" {
 		return s
@@ -499,16 +508,33 @@ func sanitizeSessionText(s string) string {
 	runes := []rune(s)
 	for i := 0; i < len(runes); i++ {
 		r := runes[i]
-		// ESC: skip the whole CSI / OSC / other escape sequence.
-		if r == 0x1b {
-			// consume until a likely terminator (@-~ for CSI, BEL/ESC\ for OSC).
-			// conservative: drop until the next printable letter or end of input.
-			for i+1 < len(runes) {
-				i++
-				nr := runes[i]
-				if (nr >= '@' && nr <= '~') || nr == 0x07 {
-					break
+		if r == 0x1b && i+1 < len(runes) {
+			// consume the introducer byte first so its value is not treated as
+			// a sequence terminator (e.g. '[' is itself in the CSI final-byte
+			// range @-~, which would otherwise end the CSI on byte one).
+			i++
+			switch runes[i] {
+			case '[': // CSI — params then final byte in 0x40..0x7e
+				for i+1 < len(runes) {
+					nr := runes[i+1]
+					i++
+					if nr >= '@' && nr <= '~' {
+						break
+					}
 				}
+			case ']': // OSC — payload then BEL or ST (ESC \)
+				for i+1 < len(runes) {
+					i++
+					if runes[i] == 0x07 {
+						break
+					}
+					if runes[i] == 0x1b && i+1 < len(runes) && runes[i+1] == '\\' {
+						i++
+						break
+					}
+				}
+			default:
+				// two-byte escape (e.g. ESC =, ESC 7) — introducer already consumed
 			}
 			continue
 		}

--- a/cmd/ox/session_list.go
+++ b/cmd/ox/session_list.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	lipgloss "charm.land/lipgloss/v2"
+	"github.com/sageox/agentx"
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
@@ -76,26 +77,45 @@ type sessionListOutput struct {
 	RepoName        string             `json:"repo_name"`
 	RepoID          string             `json:"repo_id"`
 	LedgerAvailable bool               `json:"ledger_available"`
+	Guidance        string             `json:"guidance,omitempty"`
 }
 
 // sessionListEntry is a single session in JSON output.
 type sessionListEntry struct {
-	Name       string `json:"name"`
-	Date       string `json:"date"`
-	Time       string `json:"time"`
-	User       string `json:"user,omitempty"`
-	Status     string `json:"status"`
-	Recording  bool   `json:"recording,omitempty"`
-	Summary    string `json:"summary,omitempty"`
-	EntryCount int    `json:"entry_count,omitempty"`
-	IsSubagent bool   `json:"is_subagent,omitempty"`
-	Origin     string `json:"origin,omitempty"`
+	Name            string `json:"name"`
+	Date            string `json:"date"`
+	Time            string `json:"time"`
+	User            string `json:"user,omitempty"`
+	Status          string `json:"status"`
+	Recording       bool   `json:"recording,omitempty"`
+	Title           string `json:"title,omitempty"`
+	Summary         string `json:"summary,omitempty"`
+	EntryCount      int    `json:"entry_count,omitempty"`
+	IsSubagent      bool   `json:"is_subagent,omitempty"`
+	Origin          string `json:"origin,omitempty"`
+	HydrationStatus string `json:"hydration_status,omitempty"`
+	StopReason      string `json:"stop_reason,omitempty"`
+	HasRawData      bool   `json:"has_raw_data,omitempty"`
 }
+
+// sessionListAgentGuidance is the hint returned in JSON output when the caller
+// is an agent. Keep terse — it ships to every agent invocation.
+const sessionListAgentGuidance = "Pick sessions by title/summary; run 'ox session view <name>' to dig in. If hydration_status='dehydrated', run 'ox session download <name>' first."
 
 func runSessionList(cmd *cobra.Command, args []string) error {
 	limit, _ := cmd.Flags().GetInt("limit")
 	showAll, _ := cmd.Flags().GetBool("all")
 	jsonOutput, _ := cmd.Root().PersistentFlags().GetBool("json")
+
+	// Agents (AGENT_ENV=claude-code / codex / etc.) consume this output as
+	// context. Default to JSON since it carries title, summary, entry_count,
+	// hydration_status, and stop_reason — everything needed to decide which
+	// session to dig into. Users can still force text with --json=false.
+	jsonFlagSet := cmd.Root().PersistentFlags().Changed("json")
+	inAgent := agentx.IsAgentContext()
+	if inAgent && !jsonFlagSet {
+		jsonOutput = true
+	}
 
 	if showAll {
 		limit = 0
@@ -237,31 +257,42 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 				user = localUser
 			}
 			entries = append(entries, sessionListEntry{
-				Name:       t.SessionName,
-				Date:       t.CreatedAt.Format("2006-01-02"),
-				Time:       t.CreatedAt.Format("15:04"),
-				User:       user,
-				Status:     status,
-				Recording:  t.Recording,
-				Summary:    t.Summary,
-				EntryCount: t.EntryCount,
-				IsSubagent: t.IsSubagent,
-				Origin:     t.Origin,
+				Name:            t.SessionName,
+				Date:            t.CreatedAt.Format("2006-01-02"),
+				Time:            t.CreatedAt.Format("15:04"),
+				User:            user,
+				Status:          status,
+				Recording:       t.Recording,
+				Title:           t.Title,
+				Summary:         t.Summary,
+				EntryCount:      t.EntryCount,
+				IsSubagent:      t.IsSubagent,
+				Origin:          t.Origin,
+				HydrationStatus: string(t.HydrationStatus),
+				StopReason:      t.StopReason,
+				HasRawData:      t.HasRawData,
 			})
 		}
-		return outputJSON(sessionListOutput{
+		out := sessionListOutput{
 			Sessions:        entries,
 			Total:           len(entries),
 			Window:          window,
 			RepoName:        repoName,
 			RepoID:          repoID,
 			LedgerAvailable: ledgerAvailable,
-		})
+		}
+		if inAgent {
+			out.Guidance = sessionListAgentGuidance
+		}
+		return outputJSON(out)
 	}
+
+	// agents consume this output as context — drop decorative chrome that wastes tokens
+	terse := agentx.IsAgentContext()
 
 	// print header
 	fmt.Println()
-	printSessionTableHeader()
+	printSessionTableHeader(terse)
 
 	// print each session
 	for _, t := range sessions {
@@ -270,6 +301,10 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println()
+
+	if terse {
+		return nil
+	}
 
 	// summary
 	fmt.Printf("%s %d session(s) shown",
@@ -286,7 +321,7 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printSessionTableHeader() {
+func printSessionTableHeader(terse bool) {
 	// column headers
 	dateCol := fmt.Sprintf("%-12s", "DATE")
 	timeCol := fmt.Sprintf("%-8s", "TIME")
@@ -297,6 +332,10 @@ func printSessionTableHeader() {
 
 	header := sessionHeaderStyle.Render(dateCol + timeCol + userCol + turnsCol + statusCol + nameCol)
 	fmt.Println("  " + header)
+
+	if terse {
+		return
+	}
 
 	// underline
 	underline := strings.Repeat("-", 128)
@@ -403,6 +442,61 @@ func printSessionRow(t session.SessionInfo, uploaded bool, localUser string) {
 	row += sessionSummaryStyle.Render(name)
 
 	fmt.Println("  " + row)
+
+	// emit a second line with the session's title (or summary snippet) so agents
+	// and humans can tell sessions apart without having to open each one.
+	if blurb := sessionBlurb(t); blurb != "" {
+		fmt.Println("    " + sessionEmptyStyle.Render(blurb))
+	}
+}
+
+// sessionBlurb returns a short, single-line description of the session for display
+// under the row. Prefers meta.Title, falls back to the first real sentence of
+// meta.Summary. Returns empty when neither is useful.
+func sessionBlurb(s session.SessionInfo) string {
+	const maxLen = 100
+	if t := strings.TrimSpace(s.Title); t != "" {
+		return truncateSingleLine(t, maxLen)
+	}
+	sum := strings.TrimSpace(s.Summary)
+	if sum == "" || strings.HasPrefix(sum, "Summary generation failed") {
+		return ""
+	}
+	// skip markdown structure (headings, bullets, tables, metadata lines) and
+	// find the first real prose sentence so the blurb is actually informative.
+	for line := range strings.SplitSeq(sum, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || isMarkdownStructure(line) {
+			continue
+		}
+		if i := strings.Index(line, ". "); i > 0 {
+			line = line[:i+1]
+		}
+		return truncateSingleLine(line, maxLen)
+	}
+	return ""
+}
+
+// isMarkdownStructure reports whether a line is markdown syntax rather than
+// narrative prose (headings, bullets, tables, blockquotes, code fences, or
+// bold metadata like "**Key:** value").
+func isMarkdownStructure(line string) bool {
+	if line == "" {
+		return true
+	}
+	switch line[0] {
+	case '#', '-', '*', '|', '>', '`':
+		return true
+	}
+	return strings.HasPrefix(line, "**")
+}
+
+func truncateSingleLine(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
 }
 
 func formatSessionDuration(d time.Duration) string {

--- a/cmd/ox/session_list_test.go
+++ b/cmd/ox/session_list_test.go
@@ -69,3 +69,33 @@ func TestMergeSessionSources(t *testing.T) {
 		assert.Equal(t, "old", result[2].SessionName)
 	})
 }
+
+// TestSanitizeSessionText guards the ANSI/control-byte sanitizer applied to
+// meta.json Title/Summary from the shared ledger. Failure prevented: a hostile
+// or malformed escape sequence rendered verbatim in the session list, spoofing
+// the terminal or leaking control bytes into agent-consumed JSON.
+func TestSanitizeSessionText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain ascii", "hello world", "hello world"},
+		{"preserves tab and newline", "a\tb\nc", "a\tb\nc"},
+		{"strips CSI color payload", "\x1b[31mred\x1b[0m text", "red text"},
+		{"strips CSI with params", "before\x1b[1;2;3Hafter", "beforeafter"},
+		{"strips OSC 8 hyperlink (BEL terminator)", "\x1b]8;;https://evil.example\x07visible\x1b]8;;\x07", "visible"},
+		{"strips OSC with ST terminator", "\x1b]0;title\x1b\\after", "after"},
+		{"strips DEL", "a\x7fbc", "abc"},
+		{"strips C1 codepoint U+009C", "xy", "xy"},
+		{"strips C0 except tab/newline", "x\x00y\x08z", "xyz"},
+		{"two-byte ESC (ESC =)", "hi\x1b=bye", "hibye"},
+		{"lone ESC at end", "trailing\x1b", "trailing"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sanitizeSessionText(tc.in))
+		})
+	}
+}

--- a/cmd/ox/session_list_test.go
+++ b/cmd/ox/session_list_test.go
@@ -88,7 +88,7 @@ func TestSanitizeSessionText(t *testing.T) {
 		{"strips OSC 8 hyperlink (BEL terminator)", "\x1b]8;;https://evil.example\x07visible\x1b]8;;\x07", "visible"},
 		{"strips OSC with ST terminator", "\x1b]0;title\x1b\\after", "after"},
 		{"strips DEL", "a\x7fbc", "abc"},
-		{"strips C1 codepoint U+009C", "xy", "xy"},
+		{"strips C1 codepoint U+009C", "x\u009cy", "xy"},
 		{"strips C0 except tab/newline", "x\x00y\x08z", "xyz"},
 		{"two-byte ESC (ESC =)", "hi\x1b=bye", "hibye"},
 		{"lone ESC at end", "trailing\x1b", "trailing"},

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -313,6 +313,7 @@ type SessionInfo struct {
 	ModTime         time.Time           `json:"mod_time"`
 	HydrationStatus lfs.HydrationStatus `json:"hydration_status,omitempty"` // hydrated/dehydrated/partial
 	Username        string              `json:"username,omitempty"`         // from meta.json
+	Title           string              `json:"title,omitempty"`            // from meta.json
 	Summary         string              `json:"summary,omitempty"`          // from meta.json
 	Recording       bool                `json:"recording,omitempty"`        // true if session is actively being recorded
 	AgentID         string              `json:"agent_id,omitempty"`         // from .recording.json when recording
@@ -389,13 +390,14 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 
 		// check hydration status from meta.json if present
 		var hydrationStatus lfs.HydrationStatus
-		var username, summary string
+		var username, title, summary string
 		var createdAt time.Time
 		meta, metaErr := lfs.ReadSessionMeta(sessionPath)
 		if metaErr == nil && meta != nil {
 			cachePath := filepath.Join(s.cacheBasePath, name)
 			hydrationStatus = lfs.CheckHydrationStatusWithCache(sessionPath, cachePath, meta)
 			username = meta.Username
+			title = meta.Title
 			summary = meta.Summary
 			createdAt = meta.CreatedAt
 		}
@@ -493,6 +495,7 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 			ModTime:         modTime,
 			HydrationStatus: hydrationStatus,
 			Username:        username,
+			Title:           title,
 			Summary:         summary,
 			Recording:       isRecording,
 			AgentID:         recordingAgentID,


### PR DESCRIPTION
## Summary

- Each session row now has a second indented line with the session title (or first prose sentence of summary as a fallback), so agents and humans can tell sessions apart at a glance.
- When `AGENT_ENV` is set (via `agentx.IsAgentContext()`), `ox session list` defaults to JSON output carrying `title`, `summary`, `hydration_status`, `stop_reason`, `has_raw_data`, and a top-level `guidance` hint. `--json=false` remains the escape hatch.

## Motivation

Agents consuming `ox session list` output as context need machine-readable fields (title, summary, hydration status) to pick which session to dig into. Humans also benefit from seeing a one-line descriptor under each row without having to open each session.

## Test plan

- [ ] `ox session list` in a terminal (no AGENT_ENV) → text table with blurb lines
- [ ] `ox session list` inside Claude Code / agent context → JSON with `guidance` hint
- [ ] `ox session list --json=false` inside agent context → forces text output
- [ ] Sessions with only failed-summary stubs show nothing in the blurb (text mode)

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session listings show title, hydration status, stop reason, and raw-data availability.
  * Per-session single-line blurb (from title or first sentence of summary) displayed under each row for quicker identification.
  * Agent-mode: JSON-first output and a terse display that omits table underlines and final summary.

* **Other**
  * Session text fields are sanitized before display and JSON output.

* **Tests**
  * Added tests validating sanitization of control and escape sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->