### PR TITLE
fix(lfs): populate meta.json.Title on session summary push (ox-g5zw)

### DIFF
--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -274,15 +274,34 @@ func NewFileRef(content []byte) FileRef {
 	}
 }
 
-// UpdateMetaSummary reads meta.json from sessionPath, updates the Summary field,
-// and re-writes it atomically. Used by push-summary to replace the local summary
-// with the AI-generated title.
-func UpdateMetaSummary(sessionPath, summary string) error {
+// UpdateMetaSummary reads meta.json from sessionPath, updates BOTH the
+// Title and Summary fields with the given string, and re-writes
+// atomically. The caller always passes an AI-generated title — both
+// fields get set so meta.json stays consistent regardless of which
+// consumer reads which field.
+//
+// # Why both fields
+//
+// meta.Title is the canonical short descriptor (5-10 word session name).
+// meta.Summary historically held a short descriptive string too, before
+// meta.Title existed. Some consumers (older ox versions, tools downstream)
+// read meta.Summary for display; newer ones read meta.Title. Setting
+// both closes the ox-g5zw distiller bug where meta.Title was left empty
+// because this function only touched Summary despite its callers always
+// passing a Title. Result: 91/155 sessions shipped with empty titles on
+// the ox team's ledger before a mass backfill. Fixing at source ensures
+// the bug can't recur on new sessions.
+//
+// If a separate short-summary string is ever needed alongside the title,
+// add a distinct UpdateMetaSummaryOnly function; don't reintroduce the
+// single-field ambiguity.
+func UpdateMetaSummary(sessionPath, title string) error {
 	meta, err := ReadSessionMeta(sessionPath)
 	if err != nil {
-		return fmt.Errorf("read meta for summary update: %w", err)
+		return fmt.Errorf("read meta for title update: %w", err)
 	}
-	meta.Summary = summary
+	meta.Title = title
+	meta.Summary = title
 	return WriteSessionMeta(sessionPath, meta)
 }
 

--- a/internal/lfs/meta_test.go
+++ b/internal/lfs/meta_test.go
@@ -618,3 +618,47 @@ func TestWriteSessionMeta_WritesPointers_WriteSessionMetaOnlyDoesNot(t *testing.
 			"summary.md must become a pointer stub after WriteSessionMeta")
 	})
 }
+
+// TestUpdateMetaSummary_SetsTitleAndSummary locks in the ox-g5zw fix.
+// Before this fix, the function only populated meta.Summary despite all
+// callers passing an AI-generated title — which is why 91/155 sessions
+// on the ox team ledger shipped with empty meta.Title. After the fix,
+// both fields are set from the same source string so the bug can't recur.
+func TestUpdateMetaSummary_SetsTitleAndSummary(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write an initial meta with Title empty (simulating the state
+	// immediately after processAgentSession before a summary exists).
+	initial := &SessionMeta{
+		Version:   "1.0",
+		AgentID:   "Ox000",
+		CreatedAt: timeFromString("2026-04-24T12:00:00Z"),
+		Title:     "",
+		Summary:   "",
+	}
+	if err := WriteSessionMeta(dir, initial); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate push-summary calling the function with an AI-generated title.
+	const aiTitle = "Fix 19 golangci-lint issues across 10 files"
+	if err := UpdateMetaSummary(dir, aiTitle); err != nil {
+		t.Fatalf("UpdateMetaSummary: %v", err)
+	}
+
+	got, err := ReadSessionMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != aiTitle {
+		t.Errorf("meta.Title: got %q, want %q (this is the ox-g5zw regression guard)", got.Title, aiTitle)
+	}
+	if got.Summary != aiTitle {
+		t.Errorf("meta.Summary: got %q, want %q", got.Summary, aiTitle)
+	}
+}
+
+func timeFromString(s string) time.Time {
+	t, _ := time.Parse(time.RFC3339, s)
+	return t
+}


### PR DESCRIPTION
## Summary
Root-cause fix for **ox-g5zw** — the bug where `meta.json.title` shipped empty on 91/155 sessions across the ox team ledger. Also matches your "daemon anti-entropy should always produce the best output possible" concern; after this, every summary-producing path leaves both `meta.Title` and `meta.Summary` populated.

Closes **ox-g5zw**.

## Root cause
`lfs.UpdateMetaSummary` was misnamed: every caller passed an AI-generated title, but the function only wrote `meta.Summary`, never `meta.Title`. Callers trusted the function; the function silently dropped half the data.

```go
// Before
func UpdateMetaSummary(sessionPath, summary string) error {
    meta, _ := ReadSessionMeta(sessionPath)
    meta.Summary = summary  // ← only one field
    return WriteSessionMeta(sessionPath, meta)
}
```

Three client-side call sites were affected:
- `cmd/ox/session_push_summary.go` (sync-mode, Claude Code agent → push)
- `cmd/ox/session_regenerate.go` (manual `--summary` re-summarization)
- `cmd/ox/distill_discussions.go` (discussion distill pipeline)

The daemon anti-entropy path was **not** affected — it builds meta via `NewSessionMeta().Title().Summary()` directly and already populated both fields correctly.

## Fix

```go
// After — sets both fields from the same title string
func UpdateMetaSummary(sessionPath, title string) error {
    meta, _ := ReadSessionMeta(sessionPath)
    meta.Title = title
    meta.Summary = title
    return WriteSessionMeta(sessionPath, meta)
}
```

**Why both fields:** `meta.Summary` predates `meta.Title` — it's been used as the short title-like descriptor in `ox session list` since before a proper Title field existed. A single AI-generated short string belongs in both; older consumers read `.Summary`, newer ones read `.Title`.

Inline docstring calls out the ox-g5zw history so future changes don't accidentally revert to the single-field write.

## Ledger already backfilled
Earlier this session I bulk-synced the 92 historical sessions by copying `summary.json.title → meta.json.title`. This PR prevents the bug from recurring on new sessions.

## Test plan
- [x] New regression test `TestUpdateMetaSummary_SetsTitleAndSummary` asserts both fields populated
- [x] `go test ./internal/lfs/ ./cmd/ox/` — all green
- [x] `make lint` 0 issues
- [x] Existing tests on `session_push_summary` and `session_regenerate` still pass with no modifications (call signature unchanged)

## What's not in this PR
- Server-side anti-entropy re-summarization for legacy sessions that are missing richness (key_actions, aha_moments). Tracked separately; this PR prevents the accumulation; a sweep closes the historical gap. Phase-2 sweep was kicked off earlier this session but hit a separate LFS-hydration bug in `ox session regenerate`; investigating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session title and summary fields are now synchronized when updated.

* **Tests**
  * Added regression test to verify title and summary field synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->