### PR TITLE
fix(session): hydrate LFS stubs in regenerate; skip stub summaries on disk

### DIFF
--- a/cmd/ox/session_regenerate.go
+++ b/cmd/ox/session_regenerate.go
@@ -286,9 +286,20 @@ func regenerateSingleSessionSummary(nameArg string) error {
 		return fmt.Errorf("session %s has no entries", sessionName)
 	}
 
+	// Mirror the live `ox session stop` path: tokenopt-compress raw.jsonl
+	// into the ledger cache before building the prompt. ConversationOnly
+	// keeps user+assistant turns verbatim, compacts tool entries, drops
+	// system entries — typically 50-80% smaller. Without this, large
+	// sessions (>100k tokens) can blow Claude's context on regenerate.
+	// Falls back to rawPath on any failure (helper returns "").
+	summaryInputPath := writeOptimizedJSONLForSummary(rawPath, ledgerPath, sessionName)
+	if summaryInputPath == "" {
+		summaryInputPath = rawPath
+	}
+
 	// build summary prompt using shared template
 	entries := sessionsummary.EntriesFromRaw(rawSession.Entries)
-	prompt := sessionsummary.BuildSummaryPrompt(entries, rawPath, "")
+	prompt := sessionsummary.BuildSummaryPrompt(entries, summaryInputPath, "")
 
 	cli.PrintInfo(fmt.Sprintf("Generating summary for %s...", sessionName))
 
@@ -300,6 +311,28 @@ func regenerateSingleSessionSummary(nameArg string) error {
 	summaryResp, err := sessionsummary.ParseSummaryJSON(resultText)
 	if err != nil {
 		return fmt.Errorf("parse summary from claude output: %w", err)
+	}
+
+	// Mirror the daemon path's content + richness gates. Both REPLACE the
+	// parsed response with a failure-marker stub on validation failure so
+	// the bad summary doesn't get persisted as the teammate-visible
+	// artifact. ScoreReason is set so internal/session.IsStubSummary
+	// recognizes these as deliberate failure markers (which DO get
+	// written) rather than silent LocalSummary stubs (which don't).
+	if valErr := sessionsummary.ValidateSummaryContent(summaryResp); valErr != nil {
+		cli.PrintWarning(fmt.Sprintf("content validation failed for %s: %v", sessionName, valErr))
+		summaryResp = &sessionsummary.SummarizeResponse{
+			Summary:      fmt.Sprintf("Summary failed content validation: %v", valErr),
+			QualityScore: 0.0,
+			ScoreReason:  fmt.Sprintf("content validation failed: %v", valErr),
+		}
+	} else if richErr := sessionsummary.ValidateSummaryRichness(summaryResp, len(rawSession.Entries)); richErr != nil {
+		cli.PrintWarning(fmt.Sprintf("richness validation failed for %s: %v", sessionName, richErr))
+		summaryResp = &sessionsummary.SummarizeResponse{
+			Summary:      fmt.Sprintf("Summary failed richness validation: %v", richErr),
+			QualityScore: 0.0,
+			ScoreReason:  fmt.Sprintf("richness validation failed: %v", richErr),
+		}
 	}
 
 	// enrich with computed fields (files_changed, chapters) before writing

--- a/cmd/ox/session_regenerate.go
+++ b/cmd/ox/session_regenerate.go
@@ -222,6 +222,22 @@ func syncRegeneratedSession(projectRoot, sessionPath, sessionName string) error 
 	return nil
 }
 
+// needsHydration reports whether the file at rawPath is missing OR is an
+// LFS pointer stub rather than the real session bytes. Both cases require
+// a Batch API fetch before the file can be read as session content.
+//
+// The os.Stat-only check this replaced silently passed for LFS stubs:
+// pointer files exist on disk (~140 bytes of "version https://..." text)
+// so existence-only gating skipped the download and the next
+// ReadSessionFromPath failed parsing pointer bytes as JSONL. This was
+// the bug that blocked Phase 2 of the 71-session richness regen.
+func needsHydration(rawPath string) bool {
+	if _, err := os.Stat(rawPath); err != nil {
+		return true
+	}
+	return lfs.IsPointerFile(rawPath)
+}
+
 // --- Summary regeneration (--summary) ---
 
 // regenerateSingleSessionSummary re-generates summary.json for a session by
@@ -249,8 +265,9 @@ func regenerateSingleSessionSummary(nameArg string) error {
 	sessionPath := filepath.Join(sessionsDir, sessionName)
 	rawPath := filepath.Join(sessionPath, ledgerFileRaw)
 
-	// ensure raw.jsonl is available locally (download from LFS if stub)
-	if _, statErr := os.Stat(rawPath); statErr != nil {
+	// ensure raw.jsonl is hydrated locally — missing OR an LFS stub means
+	// we need to fetch the real bytes via the Batch API.
+	if needsHydration(rawPath) {
 		meta, metaErr := lfs.ReadSessionMeta(sessionPath)
 		if metaErr != nil {
 			return fmt.Errorf("read meta.json for %s: %w", sessionName, metaErr)
@@ -511,9 +528,9 @@ func regenerateSessionRedact(projectRoot, ledgerPath, sessionsDir, nameArg strin
 		return nil, fmt.Errorf("read meta.json for %s: %w", sessionName, err)
 	}
 
-	// ensure raw.jsonl is available locally
+	// ensure raw.jsonl is hydrated locally
 	rawPath := filepath.Join(sessionPath, ledgerFileRaw)
-	if _, err := os.Stat(rawPath); err != nil {
+	if needsHydration(rawPath) {
 		if err := downloadFileFromLFS(projectRoot, sessionPath, meta, ledgerFileRaw); err != nil {
 			return nil, fmt.Errorf("download %s for %s: %w", ledgerFileRaw, sessionName, err)
 		}

--- a/cmd/ox/session_regenerate.go
+++ b/cmd/ox/session_regenerate.go
@@ -238,6 +238,37 @@ func needsHydration(rawPath string) bool {
 	return lfs.IsPointerFile(rawPath)
 }
 
+// applyValidationGates runs ValidateSummaryContent then ValidateSummaryRichness.
+// On any failure it REPLACES the response with a failure-marker stub
+// (ScoreReason set, so internal/session.IsStubSummary recognizes it as
+// a deliberate failure artifact that DOES get persisted, distinct from a
+// silent LocalSummary stub which doesn't).
+//
+// This mirrors the daemon's session-finalize path so regenerate produces
+// the same teammate-visible failure semantics — no silent regression to
+// thin summaries when the LLM under-fills the prompt schema.
+//
+// Returns the (possibly replaced) response and a short human-readable
+// message ("" when validation passed). The caller decides what to do
+// with the message — log, print, or ignore.
+func applyValidationGates(resp *sessionsummary.SummarizeResponse, entryCount int) (*sessionsummary.SummarizeResponse, string) {
+	if valErr := sessionsummary.ValidateSummaryContent(resp); valErr != nil {
+		return &sessionsummary.SummarizeResponse{
+			Summary:      fmt.Sprintf("Summary failed content validation: %v", valErr),
+			QualityScore: 0.0,
+			ScoreReason:  fmt.Sprintf("content validation failed: %v", valErr),
+		}, fmt.Sprintf("content validation failed: %v", valErr)
+	}
+	if richErr := sessionsummary.ValidateSummaryRichness(resp, entryCount); richErr != nil {
+		return &sessionsummary.SummarizeResponse{
+			Summary:      fmt.Sprintf("Summary failed richness validation: %v", richErr),
+			QualityScore: 0.0,
+			ScoreReason:  fmt.Sprintf("richness validation failed: %v", richErr),
+		}, fmt.Sprintf("richness validation failed: %v", richErr)
+	}
+	return resp, ""
+}
+
 // --- Summary regeneration (--summary) ---
 
 // regenerateSingleSessionSummary re-generates summary.json for a session by
@@ -313,27 +344,12 @@ func regenerateSingleSessionSummary(nameArg string) error {
 		return fmt.Errorf("parse summary from claude output: %w", err)
 	}
 
-	// Mirror the daemon path's content + richness gates. Both REPLACE the
-	// parsed response with a failure-marker stub on validation failure so
-	// the bad summary doesn't get persisted as the teammate-visible
-	// artifact. ScoreReason is set so internal/session.IsStubSummary
-	// recognizes these as deliberate failure markers (which DO get
-	// written) rather than silent LocalSummary stubs (which don't).
-	if valErr := sessionsummary.ValidateSummaryContent(summaryResp); valErr != nil {
-		cli.PrintWarning(fmt.Sprintf("content validation failed for %s: %v", sessionName, valErr))
-		summaryResp = &sessionsummary.SummarizeResponse{
-			Summary:      fmt.Sprintf("Summary failed content validation: %v", valErr),
-			QualityScore: 0.0,
-			ScoreReason:  fmt.Sprintf("content validation failed: %v", valErr),
-		}
-	} else if richErr := sessionsummary.ValidateSummaryRichness(summaryResp, len(rawSession.Entries)); richErr != nil {
-		cli.PrintWarning(fmt.Sprintf("richness validation failed for %s: %v", sessionName, richErr))
-		summaryResp = &sessionsummary.SummarizeResponse{
-			Summary:      fmt.Sprintf("Summary failed richness validation: %v", richErr),
-			QualityScore: 0.0,
-			ScoreReason:  fmt.Sprintf("richness validation failed: %v", richErr),
-		}
+	// Mirror the daemon path's content + richness gates.
+	gated, gateMsg := applyValidationGates(summaryResp, len(rawSession.Entries))
+	if gateMsg != "" {
+		cli.PrintWarning(fmt.Sprintf("%s for %s", gateMsg, sessionName))
 	}
+	summaryResp = gated
 
 	// enrich with computed fields (files_changed, chapters) before writing
 	session.EnrichSummary(rawSession, summaryResp)

--- a/cmd/ox/session_regenerate_hydration_test.go
+++ b/cmd/ox/session_regenerate_hydration_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// TestNeedsHydration_LFSStubBug is the regression for the LFS-stub bug
+// that blocked Phase 2 of the 71-session richness regen. Before the fix,
+// the regen path gated download on `os.Stat(rawPath) != nil`, which
+// passed for LFS pointer files because they exist on disk — they just
+// contain ~140 bytes of "version https://..." text instead of session
+// JSONL. Result: download skipped, ReadSessionFromPath failed parsing
+// pointer bytes as JSONL, every stub-form session erroring out.
+//
+// The fix routes through needsHydration(), which combines the existence
+// check with lfs.IsPointerFile(). This test asserts both branches.
+func TestNeedsHydration_LFSStubBug(t *testing.T) {
+	t.Run("missing file needs hydration", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "raw.jsonl")
+		if !needsHydration(path) {
+			t.Errorf("missing file should need hydration")
+		}
+	})
+
+	t.Run("LFS pointer stub needs hydration (the actual bug)", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "raw.jsonl")
+		ref := lfs.FileRef{
+			OID:  "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			Size: 4096,
+		}
+		if err := lfs.WritePointerFile(path, ref); err != nil {
+			t.Fatalf("WritePointerFile: %v", err)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("stub file should exist on disk; this is the whole point of the bug: %v", err)
+		}
+		if !needsHydration(path) {
+			t.Errorf("LFS pointer stub MUST report needsHydration=true; this is the ox session regenerate Phase-2 bug")
+		}
+	})
+
+	t.Run("real session bytes do not need hydration", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "raw.jsonl")
+		body := []byte(`{"type":"user","content":"hello","seq":1}` + "\n" +
+			`{"type":"assistant","content":"hi","seq":2}` + "\n")
+		if err := os.WriteFile(path, body, 0644); err != nil {
+			t.Fatalf("write raw: %v", err)
+		}
+		if needsHydration(path) {
+			t.Errorf("hydrated session bytes should NOT need hydration")
+		}
+	})
+}

--- a/cmd/ox/session_regenerate_validation_test.go
+++ b/cmd/ox/session_regenerate_validation_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	intsess "github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/pkg/sessionsummary"
+)
+
+// substantiveSummary builds a SummarizeResponse that passes both
+// ValidateSummaryContent and ValidateSummaryRichness for a non-trivial
+// session. Used as the positive-control fixture across the gate tests.
+func substantiveSummary() *sessionsummary.SummarizeResponse {
+	return &sessionsummary.SummarizeResponse{
+		Title:   "Wire tokenopt + validation gates into ox session regenerate",
+		Summary: "Threaded the live ox-session-stop pipeline through the regenerate path so Phase 2 LLM regen produces the same artifact quality the daemon enforces. Added IsStubSummary structural detector and validation-gate replacement.",
+		KeyActions: []string{
+			"Extracted needsHydration helper to detect LFS pointer stubs",
+			"Wired writeOptimizedJSONLForSummary into regenerate before BuildSummaryPrompt",
+			"Mirrored daemon validation gates (content + richness) into regenerate",
+		},
+		Outcome:    "success",
+		AhaMoments: []sessionsummary.AhaMoment{{Seq: 1, Type: "decision"}},
+	}
+}
+
+// TestApplyValidationGates_PassThroughOnSubstantive: positive control.
+// A summary that satisfies both content and richness validators must
+// be returned unchanged with no warning message.
+func TestApplyValidationGates_PassThroughOnSubstantive(t *testing.T) {
+	in := substantiveSummary()
+	out, msg := applyValidationGates(in, 100)
+	if msg != "" {
+		t.Errorf("expected empty message on valid input; got %q", msg)
+	}
+	if out != in {
+		t.Errorf("expected identity pass-through on valid input; got replacement")
+	}
+}
+
+// TestApplyValidationGates_ContentFailureReplacesWithStub: when
+// ValidateSummaryContent rejects (e.g. empty title — the ox-g5zw
+// fingerprint), the gate must REPLACE the response with a failure-
+// marker stub so the bad summary doesn't get persisted on the ledger.
+//
+// The replacement carries ScoreReason — that's the load-bearing
+// distinction so internal/session.IsStubSummary recognizes it as a
+// deliberate failure marker (which DOES write to disk) rather than a
+// silent LocalSummary stub (which doesn't). Without ScoreReason set,
+// WriteSessionArtifacts would skip writing summary.json/.md and the
+// teammate-visible artifact would just go missing.
+func TestApplyValidationGates_ContentFailureReplacesWithStub(t *testing.T) {
+	in := substantiveSummary()
+	in.Title = "" // tripping ValidateSummaryContent's title-required rule
+
+	out, msg := applyValidationGates(in, 100)
+	if out == in {
+		t.Fatal("content-failure must REPLACE the response, not flag it; original would otherwise leak to ledger")
+	}
+	if msg == "" {
+		t.Error("expected a non-empty message naming the validation failure")
+	}
+	if !strings.Contains(msg, "content validation failed") {
+		t.Errorf("message should name content validation; got %q", msg)
+	}
+	if out.ScoreReason == "" {
+		t.Error("ScoreReason must be set so IsStubSummary recognizes this as a failure marker, not a silent stub")
+	}
+	if intsess.IsStubSummary(out) {
+		t.Errorf("ScoreReason-bearing failure marker must NOT match IsStubSummary (or its summary.json gets dropped); got IsStubSummary=true")
+	}
+}
+
+// TestApplyValidationGates_RichnessFailureReplacesWithStub: same
+// replacement contract for richness failures (the ox-0pxt fingerprint:
+// missing key_actions on a non-trivial session).
+func TestApplyValidationGates_RichnessFailureReplacesWithStub(t *testing.T) {
+	in := substantiveSummary()
+	in.KeyActions = nil // tripping ValidateSummaryRichness on a 100-entry session
+
+	out, msg := applyValidationGates(in, 100)
+	if out == in {
+		t.Fatal("richness-failure must REPLACE the response, not flag it")
+	}
+	if !strings.Contains(msg, "richness validation failed") {
+		t.Errorf("message should name richness validation; got %q", msg)
+	}
+	if out.ScoreReason == "" {
+		t.Error("ScoreReason must be set so the failure marker survives WriteSessionArtifacts")
+	}
+	if intsess.IsStubSummary(out) {
+		t.Errorf("richness-failure stub must persist (ScoreReason set); got IsStubSummary=true")
+	}
+}
+
+// TestApplyValidationGates_TrivialSessionSkipsRichness: a thin summary
+// on a TRIVIAL session (entry_count below RichnessMinEntries) must not
+// be replaced — the validator deliberately exempts short sessions where
+// there genuinely may not be 3 key_actions to enumerate.
+//
+// Without this carve-out, every quick one-turn-question session would
+// fail richness and ship a failure marker instead of its real summary.
+func TestApplyValidationGates_TrivialSessionSkipsRichness(t *testing.T) {
+	in := substantiveSummary()
+	in.KeyActions = nil
+	in.AhaMoments = nil
+
+	// entryCount well below RichnessMinEntries (=20) — richness skipped.
+	out, msg := applyValidationGates(in, 5)
+	if out != in {
+		t.Errorf("trivial session must pass through unchanged; got replacement (msg=%q)", msg)
+	}
+	if msg != "" {
+		t.Errorf("trivial session should produce no message; got %q", msg)
+	}
+}
+
+// TestApplyValidationGates_ContentBeforeRichness: when both gates would
+// fail, content runs first. This matters because content failures
+// indicate something fundamentally broken (no title, contaminated text)
+// — surfacing that diagnostic is more useful than burying it under a
+// "missing key_actions" complaint.
+func TestApplyValidationGates_ContentBeforeRichness(t *testing.T) {
+	in := substantiveSummary()
+	in.Title = ""      // content failure
+	in.KeyActions = nil // richness failure too
+
+	_, msg := applyValidationGates(in, 100)
+	if !strings.Contains(msg, "content validation failed") {
+		t.Errorf("content gate must run before richness; got %q", msg)
+	}
+	if strings.Contains(msg, "richness") {
+		t.Errorf("only the first failing gate's message should surface; got %q", msg)
+	}
+}

--- a/internal/session/artifacts.go
+++ b/internal/session/artifacts.go
@@ -14,22 +14,60 @@ type ArtifactPaths struct {
 	SessionMD   string // session.md — full session transcript in markdown
 }
 
+// IsStubSummary reports whether resp is a stats-only LocalSummary stub
+// rather than a substantive LLM-generated summary or a deliberate
+// daemon-side failure marker. Stubs have no Title, no KeyActions, no
+// AhaMoments, no Diagrams, no SageoxInsights, no AgentSummary, AND no
+// ScoreReason — they're the silent-placeholder shape the heuristic
+// LocalSummary generator produces while the LLM path hasn't run yet.
+//
+// Detection is structural, not text-pattern-based, so a future change to
+// LocalSummary's wording wouldn't bypass this guard.
+//
+// ScoreReason is the load-bearing distinction from daemon validation-
+// failure stubs: those also lack structured fields, but the daemon
+// explicitly fills ScoreReason ("content validation failed: …",
+// "richness validation failed: …") to mark the stub as a deliberate
+// failure artifact that MUST be persisted so teammates see the failure
+// in the ledger rather than a missing file.
+func IsStubSummary(resp *SummarizeResponse) bool {
+	if resp == nil {
+		return true
+	}
+	if resp.ScoreReason != "" {
+		return false
+	}
+	return resp.Title == "" &&
+		len(resp.KeyActions) == 0 &&
+		len(resp.AhaMoments) == 0 &&
+		len(resp.Diagrams) == 0 &&
+		len(resp.SageoxInsights) == 0 &&
+		resp.AgentSummary == nil
+}
+
 // WriteSessionArtifacts generates the standard set of session artifacts from
 // a stored session and summary response. Both the CLI stop path and daemon
 // anti-entropy finalization call this to ensure identical output.
 //
-// The summaryResp may come from LocalSummary (stats-only) or LLM (rich).
-// Either way, the same 3 files are produced.
+// When summaryResp is a stats-only LocalSummary stub (see IsStubSummary),
+// summary.json and summary.md are NOT written — leaving them absent signals
+// to push-summary / daemon anti-entropy that a real LLM summary still owes.
+// Persisting the stub on disk was the ox-0pxt fingerprint: galexy-account
+// sessions shipped with "N user messages, N assistant responses" because the
+// stub got committed to the ledger before the LLM path ran. session.md is
+// still emitted (it's the raw transcript, always useful).
 func WriteSessionArtifacts(sessionDir string, stored *StoredSession, summaryResp *SummarizeResponse) (*ArtifactPaths, error) {
 	paths := &ArtifactPaths{}
 
+	writeSummary := summaryResp != nil && !IsStubSummary(summaryResp)
+
 	// --- enrich summary.json with computed fields (files_changed, chapters) ---
-	if summaryResp != nil && stored != nil {
+	if writeSummary && stored != nil {
 		EnrichSummary(stored, summaryResp)
 	}
 
 	// --- summary.json ---
-	if summaryResp != nil {
+	if writeSummary {
 		summaryJSONPath := filepath.Join(sessionDir, "summary.json")
 		summaryJSON, err := json.MarshalIndent(summaryResp, "", "  ")
 		if err != nil {
@@ -42,7 +80,7 @@ func WriteSessionArtifacts(sessionDir string, stored *StoredSession, summaryResp
 	}
 
 	// --- summary.md (structured markdown from SummarizeResponse) ---
-	if summaryResp != nil {
+	if writeSummary {
 		summaryMDPath := filepath.Join(sessionDir, "summary.md")
 		summaryView := SummarizeResponseToSummaryView(summaryResp)
 		gen := NewSummaryMarkdownGenerator()

--- a/internal/session/artifacts_stub_test.go
+++ b/internal/session/artifacts_stub_test.go
@@ -1,0 +1,150 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIsStubSummary_RejectsLocalSummaryFingerprint is the ox-0pxt
+// regression: galexy-account sessions shipped to the team ledger with
+// summary.json containing the LocalSummary stats-only string ("N user
+// messages, N assistant responses"). The structural detector must flag
+// any SummarizeResponse that has only the free-text Summary field set.
+func TestIsStubSummary_RejectsLocalSummaryFingerprint(t *testing.T) {
+	stub := &SummarizeResponse{
+		Summary: "42 user messages, 38 assistant responses",
+		Outcome: "local",
+	}
+	if !IsStubSummary(stub) {
+		t.Errorf("LocalSummary-shaped stub must be detected; got IsStubSummary=false")
+	}
+}
+
+// TestIsStubSummary_AcceptsSubstantiveSummary is the positive control:
+// any LLM summary that populates *one* of the structured fields
+// (Title, KeyActions, AhaMoments, Diagrams, SageoxInsights, AgentSummary)
+// must NOT be flagged as a stub.
+func TestIsStubSummary_AcceptsSubstantiveSummary(t *testing.T) {
+	cases := []struct {
+		name string
+		resp *SummarizeResponse
+	}{
+		{"title only", &SummarizeResponse{Title: "Fix lint issues"}},
+		{"key actions only", &SummarizeResponse{KeyActions: []string{"ran tests"}}},
+		{"aha moments only", &SummarizeResponse{AhaMoments: []AhaMoment{{Seq: 1, Type: "insight"}}}},
+		{"diagrams only", &SummarizeResponse{Diagrams: []string{"graph TD\nA-->B"}}},
+		{"sageox insights only", &SummarizeResponse{SageoxInsights: []SageoxInsight{{Topic: "ldap"}}}},
+		{"agent summary only", &SummarizeResponse{AgentSummary: &AgentSummary{Constraints: []string{"x"}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsStubSummary(tc.resp) {
+				t.Errorf("substantive summary (%s) must not be flagged as stub", tc.name)
+			}
+		})
+	}
+}
+
+// TestIsStubSummary_NilIsStub: a nil response is treated as a stub so
+// callers can use IsStubSummary as a single guard.
+func TestIsStubSummary_NilIsStub(t *testing.T) {
+	if !IsStubSummary(nil) {
+		t.Errorf("nil response should be treated as stub")
+	}
+}
+
+// TestIsStubSummary_DaemonFailureMarkerIsNotStub guards the load-bearing
+// distinction between LocalSummary stubs (skip-write, daemon will replace)
+// and daemon-side validation-failure markers (explicit failure artifact
+// the daemon WANTS persisted so teammates see "Summary failed validation"
+// in the ledger). Both shapes look structurally similar — only ScoreReason
+// distinguishes them. Without this guard, validation-failure tests in
+// internal/daemon/agentwork would silently lose their failure-marker
+// summary.json/.md files.
+func TestIsStubSummary_DaemonFailureMarkerIsNotStub(t *testing.T) {
+	cases := []struct {
+		name string
+		resp *SummarizeResponse
+	}{
+		{
+			"unparsable LLM output",
+			&SummarizeResponse{
+				Summary:      "Summary generation failed: LLM output was not valid JSON",
+				QualityScore: 0.0,
+				ScoreReason:  "unparsable LLM output",
+			},
+		},
+		{
+			"content validation failure",
+			&SummarizeResponse{
+				Summary:     "Summary failed content validation: title too short",
+				ScoreReason: "content validation failed: title too short (0 chars, minimum 3)",
+			},
+		},
+		{
+			"richness validation failure",
+			&SummarizeResponse{
+				Summary:     "Summary failed richness validation: missing key_actions",
+				ScoreReason: "richness validation failed: missing key_actions",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsStubSummary(tc.resp) {
+				t.Errorf("daemon failure marker (%s) must persist on disk; IsStubSummary=true would silently drop it from the ledger", tc.name)
+			}
+		})
+	}
+}
+
+// TestWriteSessionArtifacts_SkipsStubSummaryJSON proves WriteSessionArtifacts
+// no longer persists the LocalSummary stub to disk. Before this fix,
+// summary.json was written unconditionally — the stats-only stub became
+// the "official" summary on the team ledger when no LLM path ran. After
+// the fix: stub in → no summary.json written, but session.md still emitted.
+func TestWriteSessionArtifacts_SkipsStubSummaryJSON(t *testing.T) {
+	dir := t.TempDir()
+	stub := &SummarizeResponse{
+		Summary: "42 user messages, 38 assistant responses",
+		Outcome: "local",
+	}
+	stored := &StoredSession{
+		Meta:    &StoreMeta{AgentID: "test"},
+		Entries: []map[string]any{},
+	}
+
+	paths, err := WriteSessionArtifacts(dir, stored, stub)
+	if err != nil {
+		t.Fatalf("WriteSessionArtifacts: %v", err)
+	}
+
+	if paths.SummaryJSON != "" {
+		t.Errorf("stub summary should NOT produce summary.json; got path=%q", paths.SummaryJSON)
+	}
+	if paths.SummaryMD != "" {
+		t.Errorf("stub summary should NOT produce summary.md; got path=%q", paths.SummaryMD)
+	}
+	// session.md is the raw transcript — always useful, always written.
+	if paths.SessionMD == "" {
+		t.Errorf("session.md must be written even when summary is a stub")
+	}
+
+	// Belt and suspenders: assert summary.json file truly absent on disk.
+	if _, err := os.Stat(filepath.Join(dir, "summary.json")); !os.IsNotExist(err) {
+		t.Errorf("summary.json should not exist on disk for stub input; stat err=%v", err)
+	}
+
+	// And confirm we didn't accidentally serialize the fingerprint anywhere
+	// else in the artifact set (e.g., via session.md which echoes user
+	// content but should never echo the stub Summary text).
+	if paths.SessionMD != "" {
+		body, _ := os.ReadFile(paths.SessionMD)
+		if strings.Contains(string(body), "user messages, ") &&
+			strings.Contains(string(body), "assistant responses") {
+			t.Errorf("session.md should not contain LocalSummary stub fingerprint")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two related fixes that together unblock Phase 2 of the 71-session richness regen on the team ledger.

### 1. LFS-stub bug in \`ox session regenerate\` (cmd/ox/session_regenerate.go)

\`os.Stat(rawPath) != nil\` was the only gate before downloading raw.jsonl. LFS pointer files exist on disk (~140 bytes of \`version https://git-lfs.github.com/...\` text), so the gate passed for stubs and the download was skipped — then \`ReadSessionFromPath\` errored trying to parse pointer text as JSONL. Every stub-form session in the team ledger was unregenerable.

Fix: extracted \`needsHydration(rawPath)\` that combines \`os.Stat\` with \`lfs.IsPointerFile\`. Both call sites in regenerate now route through it. Regression test writes a real LFS pointer and asserts the predicate fires.

### 2. ox-0pxt root cause in \`WriteSessionArtifacts\` (internal/session/artifacts.go)

\`WriteSessionArtifacts\` was writing summary.json and summary.md unconditionally from any non-nil \`SummarizeResponse\` — including the LocalSummary stub the CLI stop path passes in before any LLM has run. When the LLM path failed (or never ran), the stats-only stub got committed to the ledger as the \"official\" summary. This was the ox-0pxt fingerprint (~15 galexy-account sessions shipped with \"42 user messages, 38 assistant responses\").

Fix: added \`IsStubSummary(resp)\` — structural detector. Skips summary.json/.md when the response has no Title, KeyActions, AhaMoments, Diagrams, SageoxInsights, or AgentSummary, AND has no \`ScoreReason\`. session.md is still emitted.

\`ScoreReason\` is the load-bearing carve-out: the daemon uses three explicit failure-marker stubs (\"unparsable LLM output\", \"content validation failed: …\", \"richness validation failed: …\") that ARE meant to be persisted so teammates see the failure on the ledger. Those have ScoreReason set; LocalSummary stubs don't. Test \`TestIsStubSummary_DaemonFailureMarkerIsNotStub\` guards this distinction.

## Why structural, not text-pattern

A future change to LocalSummary's wording shouldn't bypass the guard. Any LLM summary that legitimately populates one structured field is trusted as substantive — same shape, different content.

## Flow after fix

\`\`\`mermaid
flowchart TD
    A[ox session stop] --> B[LocalSummary stub created]
    B --> C[WriteSessionArtifacts]
    C -->|IsStubSummary?| D{stub?}
    D -->|yes| E[skip summary.json/.md<br/>emit session.md only]
    D -->|no| F[write all 3 artifacts]
    E --> G[needs-summary marker set]
    G --> H[push-summary or daemon anti-entropy<br/>writes real summary.json later]
    F --> I[done]
\`\`\`

## Test plan

- [x] \`TestNeedsHydration_LFSStubBug\` — three subtests: missing file, real LFS pointer stub, hydrated bytes
- [x] \`TestIsStubSummary_RejectsLocalSummaryFingerprint\` — the exact ox-0pxt fingerprint
- [x] \`TestIsStubSummary_AcceptsSubstantiveSummary\` — six subtests, one per structured field
- [x] \`TestIsStubSummary_NilIsStub\`
- [x] \`TestIsStubSummary_DaemonFailureMarkerIsNotStub\` — three subtests covering all three daemon failure-marker shapes
- [x] \`TestWriteSessionArtifacts_SkipsStubSummaryJSON\` — asserts summary.json absent on disk for stub input
- [x] Existing \`internal/daemon/agentwork\` failure-marker tests continue to pass (validation-failure stubs still persist)
- [x] \`make lint\` — 0 issues
- [x] Targeted: \`internal/session\`, \`internal/daemon/agentwork\`, \`cmd/ox\` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generates an optimized JSONL input for summary generation (with fallback to original raw content).
  * Adds post-parse validation that marks invalid summaries as deliberate failures to prevent them being treated as successful outputs.

* **Bug Fixes**
  * Distinguishes LFS pointer stubs from real session content and triggers hydration when needed.
  * Prevents stub-only summaries from being written to disk while still producing session markdown.

* **Tests**
  * Added regression and end-to-end tests for hydration detection, validation gates, and artifact-writing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->