### PR TITLE
fix(session): default regenerate writes to ledger path for team sessions

### DIFF
--- a/cmd/ox/session_regenerate.go
+++ b/cmd/ox/session_regenerate.go
@@ -112,7 +112,12 @@ func regenerateSingleSessionArtifacts(store *session.Store, projectRoot, name st
 		return fmt.Errorf("session %q: %w\nRun 'ox session list' to see available sessions", name, err)
 	}
 
-	sessionPath := store.GetSessionPath(sessionName)
+	// Resolve the artifact-write path. For sessions authored locally,
+	// store.GetSessionPath returns the local managed-store path. For
+	// sessions authored by other team members and synced via the ledger,
+	// that path doesn't exist on this machine — write directly to the
+	// ledger sessions/<name>/ path instead, matching the --summary path.
+	sessionPath := artifactWriteDir(store, sessionName)
 	if err := regenerateSessionArtifacts(storedSession, sessionPath); err != nil {
 		return err
 	}
@@ -123,6 +128,33 @@ func regenerateSingleSessionArtifacts(store *session.Store, projectRoot, name st
 
 	cli.PrintSuccess(fmt.Sprintf("Regenerated artifacts for %s", sessionName))
 	return nil
+}
+
+// artifactWriteDir returns the directory where regenerated .md artifacts
+// should be written for a session. Locally-authored sessions live in the
+// project's managed store; team-uploaded sessions only exist in the ledger.
+//
+// We prefer the local managed-store path when it exists (so an in-progress
+// recording's artifacts stay co-located with raw.jsonl). Otherwise we fall
+// back to the ledger sessions/<name>/ directory, which is where any
+// team-synced session lives.
+func artifactWriteDir(store *session.Store, sessionName string) string {
+	if store != nil {
+		local := store.GetSessionPath(sessionName)
+		if _, err := os.Stat(local); err == nil {
+			return local
+		}
+	}
+	ledgerPath, err := resolveLedgerPath()
+	if err != nil {
+		// last resort — return the local path even if missing; caller's
+		// write will fail with a clear error.
+		if store != nil {
+			return store.GetSessionPath(sessionName)
+		}
+		return sessionName
+	}
+	return filepath.Join(ledgerPath, "sessions", sessionName)
 }
 
 // readSessionViaCache reads raw.jsonl through the cache-only resolver,
@@ -181,7 +213,7 @@ func regenerateAllSessionsArtifacts(store *session.Store, projectRoot string, fo
 			continue
 		}
 
-		sessionPath := store.GetSessionPath(sessionName)
+		sessionPath := artifactWriteDir(store, sessionName)
 		if regenErr := regenerateSessionArtifacts(storedSession, sessionPath); regenErr != nil {
 			slog.Warn("failed to regenerate session", "session", sessionName, "error", regenErr)
 			skipped++


### PR DESCRIPTION
## Summary

Latent bug exposed during the post-#562 backfill: \`ox session regenerate\` (default mode, no \`--summary\`) was writing summary.md and session.md to the project's local managed-store path. That path only exists for sessions the local user authored. For team-uploaded sessions synced via the ledger, the write failed with \`no such file or directory\`.

## Why this surfaced now

#562 made the default-mode regenerate path read team-uploaded sessions correctly via \`openSessionContent\`. The READ side worked. The WRITE side (artifact emission) still assumed locally-authored sessions, hitting:

\`\`\`
.../Library/Caches/sageox/sessions/<repo>/sessions/<name>/session.md
\`\`\`

— which is the local recording cache, missing for team sessions.

## Fix

Added \`artifactWriteDir(store, sessionName)\` which:
1. Prefers the local managed-store path when it exists (preserves co-location with raw.jsonl for in-progress recordings).
2. Falls back to \`<ledger>/sessions/<name>/\` otherwise.

Both call sites (single + \`--all\`) routed through it. Mirrors what \`--summary\` mode already does.

## Verified

\`\`\`
$ ox session regenerate 2026-02-27T22-12-rupak-OxaTg6 --force
✓ Regenerated artifacts for 2026-02-27T22-12-rupak-OxaTg6

# raw.jsonl still a pointer (cache-only invariant preserved)
$ git status sessions/2026-02-27T22-12-rupak-OxaTg6/  # clean
$ wc -c sessions/2026-02-27T22-12-rupak-OxaTg6/raw.jsonl  # 130 bytes
$ wc -c sessions/2026-02-27T22-12-rupak-OxaTg6/summary.md  # 1140 bytes (substantive)
\`\`\`

## Test plan

- [x] go build ./... clean
- [x] Manual end-to-end on one team session
- [ ] CI green
- [ ] After merge: re-run the summary.md backfill on the 71-session list (no LLM cost — pure markdown re-derivation from existing summary.json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session artifact regeneration now correctly supports team-synced sessions that exist only in shared storage on the current machine, improving collaboration workflows
  * Improved artifact directory resolution logic with intelligent fallback behavior for edge cases
  * Fixed both single-session and all-sessions regeneration modes to consistently use the correct artifact storage location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->