### PR TITLE
fix(session): commit LFS pointer rewrite to close autostash race window

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1306,10 +1306,13 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 
 	// push succeeded — now safe to replace content files with LFS pointer stubs
 	if len(meta.Files) > 0 {
-		written, err := lfs.WritePointerFiles(sessionDir, meta.Files)
-		if err != nil {
-			slog.Warn("LFS pointer file write failed after push", "error", err, "session", sessionName)
-		} else if len(written) > 0 {
+		// WritePointerFiles can return both a partial `written` slice AND a
+		// non-nil error (internal/lfs/pointer.go:100 returns paths-so-far on
+		// the first failure). Always commit whatever pointers DID land — any
+		// rewritten pointer left uncommitted re-opens the autostash race for
+		// that file, even if other files in the same call failed.
+		written, writeErr := lfs.WritePointerFiles(sessionDir, meta.Files)
+		if len(written) > 0 {
 			// Commit the pointer rewrite so it doesn't sit dirty in the worktree.
 			// A dirty worktree here races against the daemon's sync-timer pull:
 			// `git pull --rebase --autostash` would stash the pointer, and if a
@@ -1320,6 +1323,9 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 			if err := commitPointerRewriteAndPush(ledgerPath, sessionName, written); err != nil {
 				slog.Warn("LFS pointer rewrite commit failed", "error", err, "session", sessionName)
 			}
+		}
+		if writeErr != nil {
+			slog.Warn("LFS pointer file write failed after push", "error", writeErr, "session", sessionName)
 		}
 	}
 

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1306,8 +1306,20 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 
 	// push succeeded — now safe to replace content files with LFS pointer stubs
 	if len(meta.Files) > 0 {
-		if _, err := lfs.WritePointerFiles(sessionDir, meta.Files); err != nil {
+		written, err := lfs.WritePointerFiles(sessionDir, meta.Files)
+		if err != nil {
 			slog.Warn("LFS pointer file write failed after push", "error", err, "session", sessionName)
+		} else if len(written) > 0 {
+			// Commit the pointer rewrite so it doesn't sit dirty in the worktree.
+			// A dirty worktree here races against the daemon's sync-timer pull:
+			// `git pull --rebase --autostash` would stash the pointer, and if a
+			// peer pushed an incompatible change to the same file in the meantime,
+			// the stash-pop yields conflict markers that ox doctor's auto-commit
+			// will eventually freeze into a permanent commit on main.
+			// (Tactical fix; pointer-first commit ordering is a separate discussion.)
+			if err := commitPointerRewriteAndPush(ledgerPath, sessionName, written); err != nil {
+				slog.Warn("LFS pointer rewrite commit failed", "error", err, "session", sessionName)
+			}
 		}
 	}
 

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -177,6 +177,48 @@ func commitAndPushLedger(ledgerPath, sessionName string) error {
 	return pushLedger(context.Background(), ledgerPath)
 }
 
+// commitPointerRewriteAndPush commits the post-upload LFS pointer rewrite and
+// pushes it. Called immediately after lfs.WritePointerFiles in the session-stop
+// pipeline to close the dirty-worktree window that would otherwise race against
+// the daemon's sync-timer pull (`git pull --rebase --autostash`).
+//
+// Stages only the explicit pointer paths returned by WritePointerFiles — does
+// not re-glob the manifest — so any concurrent unrelated change to the session
+// dir between the initial commit and this one cannot be silently folded into
+// the "lfs: pointerize <name>" commit.
+//
+// Returns nil if pointerPaths is empty (nothing to commit) or if git reports
+// "nothing to commit" (idempotent).
+func commitPointerRewriteAndPush(ledgerPath, sessionName string, pointerPaths []string) error {
+	if len(pointerPaths) == 0 {
+		return nil
+	}
+
+	// --sparse: ledger repos use sparse-checkout (cone mode)
+	addArgs := append([]string{"-C", ledgerPath, "add", "--sparse"}, pointerPaths...)
+	addCmd := exec.Command("git", addArgs...)
+	if output, err := addCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add failed: %s: %w", string(output), err)
+	}
+
+	// commit under a distinct subject so it doesn't shadow the canonical
+	// "session: <name>" commit in git log
+	commitMsg := fmt.Sprintf("lfs: pointerize %s", sessionName)
+	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "--no-verify", "-m", commitMsg)
+	if output, err := commitCmd.CombinedOutput(); err != nil {
+		if strings.Contains(string(output), "nothing to commit") {
+			return nil
+		}
+		return fmt.Errorf("git commit failed: %s: %w", string(output), err)
+	}
+
+	// push with pull --rebase retry. If the remote has independently modified
+	// the same path (the very race this guards against), PushWithRetry will
+	// abort the rebase cleanly (internal/gitutil/push.go:191) — no conflict
+	// markers can survive into a commit. Caller (slog.Warn) handles the error.
+	return pushLedger(context.Background(), ledgerPath)
+}
+
 // commitAndPushLedgerWithExtras is a thin compatibility shim around
 // commitAndPushLedger, retained for the doctor retry path. Pre-manifest,
 // commitAndPushLedger only globbed *.jsonl/*.html/*.md and missed

--- a/cmd/ox/session_upload_push_test.go
+++ b/cmd/ox/session_upload_push_test.go
@@ -603,3 +603,116 @@ func TestCommitAndPushLedger_EmptySessionDir(t *testing.T) {
 	assert.Contains(t, err.Error(), "git add failed",
 		"error should indicate files were missing for git add")
 }
+
+// TestCommitPointerRewriteAndPush_CleanWorktreeAfterPointerCommit verifies the
+// load-bearing invariant introduced by the post-WritePointerFiles commit step:
+// after the pointer-rewrite commit lands, the ledger working tree must be
+// clean. A dirty pointer file post-push is what produced the autostash race
+// observed in the scribe ledger (e77a7c84) — daemon's sync-timer pull would
+// stash the pointer, and a peer's incompatible push to the same path would
+// turn the stash-pop into permanent conflict markers via ox doctor's auto-
+// commit. This test ensures we don't regress to that state.
+func TestCommitPointerRewriteAndPush_CleanWorktreeAfterPointerCommit(t *testing.T) {
+	_, clonePath := createBareAndClone(t)
+	isolatePushEnv(t, clonePath)
+
+	sessionName := "2026-01-01T00-00-testuser-OxPtr1"
+	sessionsDir := filepath.Join(clonePath, "sessions")
+	sessionDir := filepath.Join(sessionsDir, sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+
+	// stage 1: write meta.json and a fake "full content" raw.jsonl, commit + push
+	// (mirrors what commitAndPushLedger does at session-stop step 5)
+	meta := fmt.Sprintf(`{"session_name":"%s","agent_id":"OxTest","files":{"raw.jsonl":{"oid":"sha256:0000000000000000000000000000000000000000000000000000000000000000","size":42,"storage":"lfs"}}}`, sessionName)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "meta.json"), []byte(meta), 0644))
+	rawPath := filepath.Join(sessionDir, "raw.jsonl")
+	fullContent := []byte("full content body that pretends to be the recorded session\n")
+	require.NoError(t, os.WriteFile(rawPath, fullContent, 0644))
+	require.NoError(t, ensureSessionsGitignore(sessionsDir))
+	require.NoError(t, commitAndPushLedger(clonePath, sessionName))
+
+	// stage 2: simulate WritePointerFiles by overwriting raw.jsonl with a pointer.
+	// the worktree is now dirty (pointer != HEAD's full content blob).
+	pointerBytes := []byte("version https://git-lfs.github.com/spec/v1\noid sha256:0000000000000000000000000000000000000000000000000000000000000000\nsize 42\n")
+	require.NoError(t, os.WriteFile(rawPath, pointerBytes, 0644))
+
+	statusBefore := runGit(t, clonePath, "status", "--porcelain")
+	require.NotEmpty(t, statusBefore, "precondition: worktree must be dirty after simulated WritePointerFiles")
+
+	// stage 3: the actual code under test — commit the pointer rewrite
+	err := commitPointerRewriteAndPush(clonePath, sessionName, []string{rawPath})
+	require.NoError(t, err)
+
+	// invariant: worktree is clean
+	statusAfter := runGit(t, clonePath, "status", "--porcelain")
+	assert.Empty(t, statusAfter, "worktree must be clean after pointer-rewrite commit (autostash-race precondition)")
+
+	// invariant: the new commit has the distinct subject
+	subject := runGit(t, clonePath, "log", "-1", "--format=%s")
+	assert.Equal(t, fmt.Sprintf("lfs: pointerize %s", sessionName), subject)
+
+	// invariant: the previous commit is the canonical session: commit, untouched
+	prevSubject := runGit(t, clonePath, "log", "-1", "--format=%s", "HEAD~1")
+	assert.Equal(t, fmt.Sprintf("session: %s", sessionName), prevSubject)
+}
+
+// TestCommitPointerRewriteAndPush_EmptyPathsIsNoop verifies that calling with
+// no pointer paths is a clean no-op — neither stages, commits, nor pushes.
+// The session-stop call site short-circuits via len(written) > 0, but defense
+// in depth: if a future caller passes an empty slice, we don't generate an
+// empty commit or hit `git add` with no args.
+func TestCommitPointerRewriteAndPush_EmptyPathsIsNoop(t *testing.T) {
+	_, clonePath := createBareAndClone(t)
+	isolatePushEnv(t, clonePath)
+
+	headBefore := runGit(t, clonePath, "rev-parse", "HEAD")
+	err := commitPointerRewriteAndPush(clonePath, "any-session", nil)
+	require.NoError(t, err)
+	headAfter := runGit(t, clonePath, "rev-parse", "HEAD")
+	assert.Equal(t, headBefore, headAfter, "no-op input must not advance HEAD")
+}
+
+// TestCommitPointerRewriteAndPush_StagesOnlyExplicitPaths verifies the H1
+// fix from the code review: the pointer-rewrite commit must NOT silently
+// fold in unrelated changes that happened to be in the session dir between
+// the initial commit and the pointer rewrite. Stages only the paths
+// returned by WritePointerFiles.
+func TestCommitPointerRewriteAndPush_StagesOnlyExplicitPaths(t *testing.T) {
+	_, clonePath := createBareAndClone(t)
+	isolatePushEnv(t, clonePath)
+
+	sessionName := "2026-01-01T00-00-testuser-OxPtr2"
+	sessionsDir := filepath.Join(clonePath, "sessions")
+	sessionDir := filepath.Join(sessionsDir, sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+
+	// initial commit with two files: raw.jsonl (LFS) and summary.md (LFS)
+	meta := fmt.Sprintf(`{"session_name":"%s","agent_id":"OxTest","files":{"raw.jsonl":{"oid":"sha256:1111111111111111111111111111111111111111111111111111111111111111","size":10,"storage":"lfs"},"summary.md":{"oid":"sha256:2222222222222222222222222222222222222222222222222222222222222222","size":20,"storage":"lfs"}}}`, sessionName)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "meta.json"), []byte(meta), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"), []byte("raw-original\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "summary.md"), []byte("summary-original\n"), 0644))
+	require.NoError(t, ensureSessionsGitignore(sessionsDir))
+	require.NoError(t, commitAndPushLedger(clonePath, sessionName))
+
+	// rewrite ONLY raw.jsonl to a pointer; ALSO modify summary.md as if some
+	// other process touched it concurrently. The pointer-rewrite commit must
+	// NOT include the summary.md change.
+	rawPath := filepath.Join(sessionDir, "raw.jsonl")
+	summaryPath := filepath.Join(sessionDir, "summary.md")
+	require.NoError(t, os.WriteFile(rawPath, []byte("version https://git-lfs.github.com/spec/v1\noid sha256:1111111111111111111111111111111111111111111111111111111111111111\nsize 10\n"), 0644))
+	require.NoError(t, os.WriteFile(summaryPath, []byte("summary-CONCURRENTLY-MODIFIED\n"), 0644))
+
+	// only raw.jsonl is the "WritePointerFiles output"
+	err := commitPointerRewriteAndPush(clonePath, sessionName, []string{rawPath})
+	require.NoError(t, err)
+
+	// the pointer-rewrite commit must touch raw.jsonl only
+	changedFiles := runGit(t, clonePath, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")
+	assert.Contains(t, changedFiles, "raw.jsonl", "raw.jsonl pointer must be in the commit")
+	assert.NotContains(t, changedFiles, "summary.md",
+		"unrelated concurrent change to summary.md must NOT be folded into the pointer-rewrite commit")
+
+	// summary.md is still dirty (not staged, not committed) — caller's responsibility
+	status := runGit(t, clonePath, "status", "--porcelain")
+	assert.Contains(t, status, "summary.md", "summary.md should remain in worktree-modified state")
+}


### PR DESCRIPTION
## Summary

- Adds the missing 'step 7' to `uploadSessionToLedger`: after `lfs.WritePointerFiles` rewrites in-place content files to LFS pointers, immediately commit + push the pointer rewrite under a distinct `lfs: pointerize <name>` subject. Previously this was left dirty in the worktree.
- Uses the explicit `[]string` returned by `WritePointerFiles` to stage only the rewritten pointer paths — no manifest glob, no `meta.json`, no `.gitignore` re-staging.
- Failures are non-fatal (`slog.Warn`), matching the existing posture for `WritePointerFiles` failures.

## Why

Live failure observed in scribe ledger commit [`e77a7c84 ox doctor: auto-commit ledger changes`](https://git.sageox.ai/) — the file `sessions/2026-04-26T20-09-galexy-Oxsmyh/session.md` was committed with literal `<<<<<<< Updated upstream / >>>>>>> Stashed changes` conflict markers in it, blocking every subsequent `ox doctor --fix` rebase.

The chain that produced it:

1. Galex's CLI ran `uploadSessionToLedger`. Steps 1-5 ran fine: full content copied to ledger dir, bytes uploaded to LFS (OID `9d33d596…`), `meta.Files` populated, initial `session: <name>` commit pushed.
2. Step 6 (`WritePointerFiles`) overwrote `session.md` in the worktree with a 3-line LFS pointer. **Worktree now dirty.** No follow-up commit.
3. Galex's daemon sync-timer fired `git pull --rebase --autostash`. Autostash captured the dirty pointer.
4. The remote had since received Ryan's daemon-anti-entropy `finalize session …galexy-Oxsmyh` commit (parallel finalize on the same session). The stash-pop produced an unmergeable 3-way conflict: `(base = Galex's full content)` vs. `(HEAD = Ryan's full content)` vs. `(stash = Galex's pointer)`.
5. Conflict markers landed in the worktree. Three days later, `ox doctor --fix` ran `checkLedgerCleanWorkdir`, did `git add --sparse -A; git commit`, and froze the markers into `e77a7c84`.

```mermaid
flowchart LR
  A[CLI: session: NAME commit + push] --> B[WritePointerFiles<br/>worktree dirty, uncommitted]
  B -.race.-> C[daemon pull --rebase --autostash]
  C --> D[autostash captures pointer]
  D --> E[stash-pop conflicts<br/>with peer's full-content rewrite]
  E --> F[conflict markers in worktree]
  F --> G[ox doctor --fix commits markers]
  G --> H[e77a7c84: permanent broken commit]

  B2[NEW: commitPointerRewriteAndPush] --> Z[worktree clean]
  B -.fix.-> B2
  style B2 fill:#cfc
  style Z fill:#cfc
```

The fix closes the dirty-worktree window. After the new commit, the worktree is clean — daemon pulls fast-forward without autostash, the multi-machine race cannot escalate to conflict markers, and `ox doctor --fix` doesn't get a chance to freeze anything broken.

## Worst-case after PR

If the new pointer-rewrite commit's push fails (peer pushed an incompatible change to the same path between step 5 and step 7), `gitutil.PushWithRetry` aborts the rebase cleanly (`internal/gitutil/push.go:191-196` — `sessions/` has no `AutoResolvePrefixes` configured, so the rebase aborts and returns an error). No conflict markers can survive into a commit. State: local has unpushed pointer commit, worktree clean, next push retry will redo the rebase. **Strictly better than pre-fix** (where the dirty worktree was the input to the auto-freeze pathway).

## Out of scope (deferred)

- **Pointer-first commit ordering** — write pointers to the ledger path BEFORE the initial commit, eliminating both the dirty-worktree window and the permanent full-content blob leak from the canonical `session: <name>` commits. Galex + Ryan to discuss separately.
- **Daemon-side parity** — `internal/daemon/agentwork/session_finalize.go:916` and `:1132` have the same shape (post-`gitCommitAndPush` `WritePointerFiles` outside `ledgerMu`'s lock window) and need the same fix in a follow-up.

## Test plan

- [x] `go build ./cmd/ox/`
- [x] `go vet ./cmd/ox/`
- [x] `make lint` — 0 issues
- [x] `go test ./cmd/ox/` — full suite (82s) passes
- [x] New tests in `cmd/ox/session_upload_push_test.go`:
  - `TestCommitPointerRewriteAndPush_CleanWorktreeAfterPointerCommit` — load-bearing invariant. Simulates the full session-stop sequence and asserts worktree is clean and commit subjects are correct.
  - `TestCommitPointerRewriteAndPush_EmptyPathsIsNoop` — defensive: nil paths must not advance HEAD.
  - `TestCommitPointerRewriteAndPush_StagesOnlyExplicitPaths` — H1 invariant. Verifies a concurrent unrelated change to `summary.md` is NOT folded into the pointer-rewrite commit.

## Review

Reviewed by ox `code-reviewer` coworker (two passes). H1 (explicit-paths staging) and S3 (regression tests) addressed in v2. H2 (rebase-conflict path audit) confirmed safe — no code change needed. Final verdict: "clean. No CRITICAL or HIGH issues. Ready to merge."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pointer file rewrites are now committed and pushed when at least some rewrites succeed, preventing leftover uncommitted changes after uploads; pointer write failures are logged without blocking successful commits.

* **Tests**
  * Added tests covering pointer-file commit flows, no-op behavior for empty pointer lists, and selective staging to ensure only intended files are committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->