### PR TITLE
fix(doctor): run claude-commands check so --fix restores ox-* slash commands

### DIFF
--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -610,6 +610,8 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		if !staleLocalCheck.skipped {
 			integrationChecks = append(integrationChecks, staleLocalCheck)
 		}
+		// verify ox-* slash commands are installed in .claude/commands/
+		integrationChecks = append(integrationChecks, checkClaudeCommands(opts.shouldFix(CheckSlugClaudeCommands)))
 	}
 	if detectOpenCode() {
 		integrationChecks = append(integrationChecks, checkOpenCodeHooks(opts.shouldFix(CheckSlugOpenCodeHooks)))


### PR DESCRIPTION
## Summary

`checkClaudeCommands` (`cmd/ox/doctor_commands.go:13`) registers itself in `DoctorCheckRegistry` via `init()`, but `runDoctorChecks` (`cmd/ox/doctor.go:518`) builds the Integration category by hand-appending check functions and never invoked it. Net effect: `ox doctor` silently ignored missing `ox-*` slash commands and `ox doctor --fix` could not restore them — `--fix-slug=claude-commands` even passed validation but was a no-op.

This wires the check into the `detectClaudeCode()` block alongside the other Claude-Code-specific integration checks.

## Motivation

Reproduced in `~/src/github.com/sageox/scribe`: 0 of 15 `ox-*` commands present, `ox doctor --fix` reported "Done" without touching them. The adapter (`/Users/galex/go/bin/ox-adapter-claude-code`) is discoverable and advertises `commands_installer`, so the install path itself was healthy — only the doctor wiring was missing.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./cmd/ox/ -run "Doctor|doctor"` — pass
- [x] In scribe (had no `ox-*` commands): rebuilt ox, ran `ox doctor --fix`, all 15 commands restored. `ox doctor --json` now reports `claude-commands | Claude commands | passed | 15 installed` in the Integration category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic check for Claude Code integration that validates slash command installation. The check automatically runs when Claude Code is detected and participates in targeted fix workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->