### PR TITLE
fix(init): dedupe Claude Code option in agent selection

### DIFF
--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -1676,6 +1676,10 @@ func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
 	// discover external adapters and check which are actually installed
 	externalAdapters := adapters.DiscoverExternalAdapters()
 	for _, ea := range externalAdapters {
+		if ea.Name() == "claude-code" {
+			// already represented by the hardcoded option above
+			continue
+		}
 		if !ea.Detect() {
 			continue
 		}


### PR DESCRIPTION
## Problem

`ox init` showed "Claude Code" twice in the AI coworker multi-select:

```
> [x] Claude Code
  [ ] Claude Code        <-- duplicate
  [ ] OpenAI Codex CLI
  [ ] Gemini CLI
  ...
```

## Cause

`selectAgentsForInit` in `cmd/ox/init.go` hardcodes a "Claude Code" option (default-selected), then appends every detected external adapter. The new `ox-adapter-claude-code` binary (`Name = "claude-code"`, `DisplayName = "Claude Code"`) gets appended as a second entry.

## Fix

Skip the discovered adapter when `Name() == "claude-code"` — the hardcoded entry already represents it, and the rest of init.go (hooks, non-interactive default at line 1667) is keyed on that same value. Removing the hardcoded entry would be cleaner long-term but expands scope into hook installation and default-selection paths.

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate agent appearing in the interactive selection menu, providing a cleaner, more streamlined list of available agent options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->