### PR TITLE
feat(claws): add unified sageox OpenClaw skill

### DIFF
--- a/claws/openclaw/sageox/.clawhubignore
+++ b/claws/openclaw/sageox/.clawhubignore
@@ -1,0 +1,5 @@
+README.md
+CHANGELOG.md
+deploy-to-vps.sh
+test-skill.py
+test-results-*.csv

--- a/claws/openclaw/sageox/README.md
+++ b/claws/openclaw/sageox/README.md
@@ -1,0 +1,37 @@
+# sageox
+
+Complete interactive toolkit for [SageOx](https://sageox.ai) team knowledge.
+
+## Capabilities
+
+| Capability | What it does |
+|---|---|
+| **Query** | Search team discussions, docs, sessions, and code |
+| **Coworkers** | Discover, load, create, and remove expert AI agents |
+| **Distill** | Interactive single-repo observation distillation |
+| **Distill Pipeline** | Multi-repo automated sync + index + distill |
+| **Summary** | Cross-team 24h summary generation |
+| **Glance** | Real-time AI coworker activity and collision detection |
+| **Catchup** | Structured briefing after being away |
+| **Import/Export** | Import docs/recordings, export knowledge as local files |
+
+## Prerequisites
+
+- `ox` — installed via bundled curl script (not Homebrew)
+- `git`, `gh`, `jq`, `claude` — declared in skill metadata
+
+## Install
+
+```bash
+clawhub install sageox
+```
+
+## Testing locally
+
+```bash
+# Lint before deploying
+python3 .claude/skills/clawhub-skill-lint/scripts/lint.py claws/openclaw/sageox
+
+# Deploy to VPS for testing
+bash claws/openclaw/sageox/deploy-to-vps.sh
+```

--- a/claws/openclaw/sageox/SKILL.md
+++ b/claws/openclaw/sageox/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: sageox
+description: "Complete toolkit for SageOx team knowledge. Query team context, manage AI coworkers, distill and summarize activity, see what coworkers are working on, catch up after time away, import/export knowledge, and manage configured repos. Use when: searching team discussions, loading expert agents, running distillation, generating summaries, checking coworker activity, catching up, importing documents or recordings, exporting decisions, showing or managing sageox repos. Keywords: SageOx, team context, query, coworker, distill, summary, glance, catchup, import, export, repos, manifest"
+version: 0.1.0
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🐂",
+        "os": ["macos", "linux"],
+        "requires": { "bins": ["ox", "git", "gh", "jq", "claude"] },
+        "install":
+          [
+            {
+              "id": "node-claude",
+              "kind": "node",
+              "package": "@anthropic-ai/claude-code",
+              "bins": ["claude"],
+              "label": "Install Claude Code CLI (npm)",
+            },
+            {
+              "id": "brew-gh",
+              "kind": "brew",
+              "formula": "gh",
+              "bins": ["gh"],
+              "label": "Install GitHub CLI (brew)",
+            },
+            {
+              "id": "brew-jq",
+              "kind": "brew",
+              "formula": "jq",
+              "bins": ["jq"],
+              "label": "Install jq (brew)",
+            },
+          ],
+        "homepage": "https://sageox.ai",
+      },
+  }
+---
+
+# SageOx
+
+You are an interactive SageOx toolkit agent. You help users query team
+knowledge, manage AI coworkers, distill observations, generate summaries,
+see coworker activity, catch up after being away, and import/export
+knowledge. Route each request to the appropriate capability below.
+
+## Prerequisites
+
+Before doing anything else, verify the environment. Run every check in
+order. If any fails, explain what's missing and stop.
+
+### 1. Path validation rules
+
+Before interpolating any user-provided or state-file path into a shell
+command, validate it:
+
+1. **Absolute path required.** Must start with `/` or `~`.
+2. **No `..` segments.** Reject anything containing `..`.
+3. **No shell metacharacters.** Reject: `;` `$` `` ` `` `|` `&` `<` `>`
+   `(` `)` `{` `}` `*` `?` `[` `]` `!` `\` newline.
+
+On failure: print which rule failed and re-prompt. **Do not sanitize.**
+Treat all `~/.openclaw/memory/*.json` values as untrusted.
+
+### 2. Installing `ox`
+
+On every run, invoke `bash scripts/update-ox.sh`. Exit `0` means proceed.
+Exit `2` means ox is not usable — read `references/setup.md` and follow
+the install flow, then re-run the script to confirm.
+
+**Do not install ox via Homebrew or any package manager.** Only the
+pinned-release curl flow in `scripts/install-ox-curl.sh` is supported.
+
+### 3. Authentication
+
+1. `ox status` — confirm authenticated. If not: `ox login`.
+2. `gh auth status` — confirm GitHub credentials.
+3. `git config user.name` — confirm git identity.
+4. `claude` credentials — either `claude login` (Pro/Max) or
+   `ANTHROPIC_API_KEY` exported.
+
+### 4. Repo manifest (context anchor)
+
+All capabilities require project context. The repo manifest at
+`~/.openclaw/memory/sageox-distill-repos.json` is the central anchor.
+
+```json
+{"repos": [{"path": "/home/user/repos/project", "team_id": "my-team"}]}
+```
+
+- **If manifest missing:** ask the user for repo paths. For each: validate
+  path (§ 1), verify directory exists, verify `.sageox/config.json` exists,
+  read `team_id`. Write the manifest.
+- **If manifest exists:** re-validate every path on each run.
+- **One repo:** `cd` to it automatically.
+- **Multiple repos:** ask the user which repo/team is relevant, then `cd`.
+- The user can say "add repo", "remove repo", or "show repos" to manage.
+
+After resolving context, all ox commands run from the selected repo directory.
+
+## Capabilities
+
+When the user's intent matches a row, read the reference doc before acting.
+If ambiguous, ask. If the user says "reinstall ox", read `references/setup.md`.
+
+| User wants to... | Reference | Key command |
+|---|---|---|
+| Search team knowledge | `references/query.md` | `ox query` |
+| List/load/create/remove expert agents | `references/coworkers.md` | `ox coworker` |
+| Distill interactively (this repo) | `references/distill.md` | `ox distill` |
+| Run multi-repo distill pipeline | `references/distill-pipeline.md` | orchestrated |
+| Generate cross-team summary | `references/summary.md` | `ox distill history` + `claude -p` |
+| See what AI coworkers are doing | `references/glance.md` | `ox glance` |
+| Catch up after being away | `references/catchup.md` | orchestrated |
+| Import or export knowledge | `references/import-export.md` | `ox import` |
+| Show/add/remove configured repos | *(handled inline — see § 4)* | read manifest |
+
+**Repo manifest requests** ("show repos", "add repo", "remove repo") do NOT
+load a reference doc. Handle them directly using the repo manifest at
+`~/.openclaw/memory/sageox-distill-repos.json` as described in § 4 above.
+
+## State files
+
+| File | Purpose |
+|---|---|
+| `sageox-ox-install.json` | ox binary install state (shared) |
+| `sageox-distill-repos.json` | Repo manifest with team_id + paths |
+| `sageox-summary-state.json` | Tracks summarized entry IDs |
+| `sageox-bridge-state.json` | Import/export tracking |
+
+All under `~/.openclaw/memory/`.

--- a/claws/openclaw/sageox/assets/CATCHUP.md
+++ b/claws/openclaw/sageox/assets/CATCHUP.md
@@ -1,0 +1,44 @@
+You are a team activity summarizer. The user has been away for {{DURATION}}
+and needs to catch up on what happened. Synthesize the following data
+sources into a structured briefing.
+
+## Instructions
+
+- Write in clear, concise language
+- Attribute work to specific people when names are available
+- Highlight decisions that may affect the user's work
+- Flag potential conflicts with common work areas
+- Do not include raw data dumps — synthesize into narrative
+- Use Slack mrkdwn formatting (*bold*, _italic_, `code`)
+
+## Output structure
+
+Organize your summary into exactly these four sections:
+
+### What shipped
+Completed work, merged PRs, resolved issues. Focus on outcomes.
+
+### What's in progress
+Active work, open PRs, ongoing efforts. Include who is working on what.
+
+### What you should know
+Decisions made, blockers encountered, surprises, convention changes,
+or anything that might affect how the user approaches their next task.
+
+### Potential conflicts
+Files or areas that multiple people have been touching. If the user's
+likely work areas overlap with recent activity, call it out.
+
+---
+
+## Distilled team activity
+
+{{DISTILLED}}
+
+## Recent coding sessions
+
+{{SESSIONS}}
+
+## Code insights (hotspots, PRs, issues)
+
+{{INSIGHTS}}

--- a/claws/openclaw/sageox/assets/SUMMARIZE.md
+++ b/claws/openclaw/sageox/assets/SUMMARIZE.md
@@ -1,0 +1,37 @@
+# Team Summary
+
+You are generating a team summary from a curated set of distilled session entries. The calling skill has already selected exactly which entries are new since the previous summary run and inlined each entry's full text below — you do not need to read any files and you have no filesystem access.
+
+## Workflow
+
+1. Synthesize the entries under `## Entries` below, grouped by team.
+2. Entries are delimited by their `<!-- entry: <id> -->` header; treat that id as the citation anchor for anything you carry into the summary.
+3. Produce a structured summary following the format described below.
+
+## Entries
+
+{{ENTRIES}}
+
+## Summary structure
+
+You MUST use exactly these four section headings. Each section should have 2–5 bullets. Prioritize signal over detail — a product manager and a marketer will read this alongside engineers. Synthesize across PRs and sessions; do not enumerate individual PRs unless they represent a meaningful milestone.
+
+*Where we are*
+Progress relative to what we set out to do. Cover both macro (goals, initiatives — are we on track?) and micro (what shipped recently). Name people and repos, but summarize themes rather than listing every PR.
+
+*What's getting in the way*
+Blockers, friction, unresolved issues, failed attempts, or things that took longer than expected. Flag patterns. This section drives the conversations the team needs to have.
+
+*What we've learned*
+This is one of the most valuable sections — don't skip or thin it out. Include: techniques or approaches someone used that others should adopt, non-obvious discoveries about the codebase or infrastructure, important team discussions and the conclusions reached, and shifts in thinking about how we build or ship. If someone solved a hard problem, explain the insight — not just that they fixed it.
+
+*What's next*
+Work queued up, drafts in progress, or follow-ups called out. Anything that signals upcoming changes others should prepare for.
+
+## Formatting rules
+
+- Format for Slack mrkdwn: use *bold*, _italic_, `code`, bullet points with •
+- Keep it scannable — each bullet should be 1–2 sentences max
+- Link to notable sessions where they add context
+- Surface important discussions, debates, and decisions the team had
+{{MULTI_TEAM_RULES}}

--- a/claws/openclaw/sageox/deploy-to-vps.sh
+++ b/claws/openclaw/sageox/deploy-to-vps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# deploy-to-vps.sh — rsync the sageox skill to the VPS for testing.
+# NOT published to ClawHub (excluded via .clawhubignore).
+set -euo pipefail
+
+VPS_KEY="$HOME/.ssh/ox-bot.pem"
+VPS_HOST="ubuntu@35.164.224.156"
+SKILL_DIR="~/.openclaw/workspace/skills/sageox"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+rsync -avz --delete \
+  -e "ssh -i $VPS_KEY" \
+  --exclude deploy-to-vps.sh \
+  --exclude README.md \
+  "$SCRIPT_DIR/" \
+  "$VPS_HOST:$SKILL_DIR/"
+
+echo "deployed to $VPS_HOST:$SKILL_DIR"

--- a/claws/openclaw/sageox/references/catchup.md
+++ b/claws/openclaw/sageox/references/catchup.md
@@ -55,7 +55,8 @@ Build a prompt by substituting gathered data into `assets/CATCHUP.md`:
 Run synthesis:
 
 ```bash
-timeout 600 claude -p --model claude-sonnet-4-6 <<< "$PROMPT"
+TIMEOUT_BIN="$(command -v timeout || command -v gtimeout)"
+"$TIMEOUT_BIN" 600 claude -p --model claude-sonnet-4-6 <<< "$PROMPT"
 ```
 
 `claude -p` uses whatever credentials `claude` already has — either

--- a/claws/openclaw/sageox/references/catchup.md
+++ b/claws/openclaw/sageox/references/catchup.md
@@ -1,0 +1,94 @@
+# Catchup — What Happened While You Were Away
+
+Orchestrates multiple ox commands to generate a structured briefing of
+team and repo activity since the user was last active.
+
+## Workflow
+
+### Step 1: Determine time window
+
+Ask: "How long were you away?" Parse into a duration:
+- "since yesterday" → `24h`
+- "a few days" → `3d`
+- "a week" → `7d`
+- Default if unclear: `24h`
+
+### Step 2: Gather data
+
+Run these commands from the selected repo directory. Each is non-fatal —
+if one fails, log the error and continue with the rest.
+
+**Distilled history:**
+
+```bash
+ox distill history list --since <duration> --layer daily --format json
+```
+
+If entries exist, fetch their content:
+
+```bash
+ox distill history show --team <team_id> --format content <entry-ids>
+```
+
+**Recent sessions:**
+
+```bash
+ox session list --since <duration>
+```
+
+**Code insights:**
+
+```bash
+ox code insights --days <N> --json
+```
+
+Where `<N>` matches the duration (24h → 1, 3d → 3, 7d → 7).
+
+### Step 3: Synthesize
+
+Build a prompt by substituting gathered data into `assets/CATCHUP.md`:
+- `{{DISTILLED}}` — distilled daily entries (content from step 2)
+- `{{SESSIONS}}` — session list output
+- `{{INSIGHTS}}` — code insights JSON
+- `{{DURATION}}` — how long they were away
+
+Run synthesis:
+
+```bash
+timeout 600 claude -p --model claude-sonnet-4-6 <<< "$PROMPT"
+```
+
+`claude -p` uses whatever credentials `claude` already has — either
+OAuth from `claude login` or `ANTHROPIC_API_KEY` from the shell.
+
+If synthesis fails (non-zero exit, timeout exit 124), surface the error
+to the user and offer to show the raw data instead.
+
+### Step 4: Present
+
+Return Claude's output directly. The output should follow this structure:
+
+- **What shipped** — completed work, merged PRs
+- **What's in progress** — active work, open PRs
+- **What you should know** — decisions, blockers, surprises
+- **Potential conflicts** — overlap with the user's likely work areas
+
+## Handling missing data
+
+- **No distilled history:** skip that section, note "No distilled
+  entries for this period. Run the distill capability to generate them."
+- **No sessions:** skip that section, note "No recorded sessions."
+- **No code insights:** skip that section.
+- **All empty:** tell the user "No recorded activity found for the last
+  <duration>. This could mean no sessions were recorded, or distillation
+  hasn't been run. Try the distill capability first."
+
+## Multi-repo catchup
+
+If the manifest has multiple repos and the user wants to catch up across
+all of them, iterate through each repo:
+1. `cd` to each repo path
+2. Gather data from each
+3. Include all data in the synthesis prompt, grouped by repo
+
+This produces a cross-repo briefing. Label each section by repo name.

--- a/claws/openclaw/sageox/references/coworkers.md
+++ b/claws/openclaw/sageox/references/coworkers.md
@@ -1,0 +1,135 @@
+# Coworkers — Expert Agent Management
+
+Discover, load, create, and remove expert AI coworkers from your team
+context using `ox coworker`.
+
+## Commands
+
+### List available coworkers
+
+```bash
+ox coworker list [--json] [--team <id>]
+```
+
+Shows all expert agents available in the team context with their name,
+description, model, and team. Use `--json` for structured output.
+
+### Load a coworker
+
+`ox coworker load` is designed for coding agent sessions (Claude Code,
+Cursor) and will not inject into an OpenClaw session. Instead, use
+`ox coworker load <name> --raw` to print the coworker's full prompt,
+then read and embody the expertise directly in this conversation.
+
+**Workflow:**
+
+```bash
+ox coworker load <name> --raw [--team <id>]
+```
+
+If `--raw` is not available, fall back to reading the coworker file
+directly from the team context repo:
+
+```bash
+# Find the coworker file
+ox coworker list --json | jq -r '.[] | select(.name=="<name>") | .path'
+# Then read the file at that path
+```
+
+Once you have the coworker's prompt content, tell the user:
+"I've loaded **<name>**'s expertise into this session. I'll apply their
+approach to our conversation. What would you like help with?"
+
+Use `--model` to note the coworker's preferred model (informational only
+in this context).
+
+### Add a coworker
+
+```bash
+ox coworker add <file>.md [--team <id>]
+```
+
+Validates the file has correct YAML frontmatter, copies it to the team's
+`coworkers/agents/` directory, and commits it. The coworker name is
+derived from the filename (e.g., `security-reviewer.md` → `security-reviewer`).
+
+### Remove a coworker
+
+```bash
+ox coworker remove <name> [--force] [--team <id>]
+```
+
+Removes the coworker from team context. Use `--force` to skip
+confirmation.
+
+## Authoring wizard
+
+When the user wants to create a new coworker, guide them through this
+flow:
+
+### Step 1: Domain and specialty
+
+Ask: "What domain should this coworker specialize in?" Examples:
+- Security review
+- Database optimization
+- Frontend accessibility
+- API design
+
+### Step 2: Description
+
+Ask: "What's the one-line description?" This is **required** for the
+YAML frontmatter and is what other coworkers see when listing available
+experts.
+
+### Step 3: Model preference
+
+Ask: "Which model should this coworker use?"
+- `opus` — complex reasoning, deep analysis
+- `sonnet` — balanced speed and capability (recommended default)
+- `haiku` — lightweight, fast responses
+- *inherit* — use whatever model the caller is using (omit field)
+
+### Step 4: Generate the agent file
+
+Write a temporary file with this format:
+
+```yaml
+---
+description: "<one-line description from step 2>"
+model: "<model from step 3>"  # omit this line if inherit
+---
+
+# <Coworker Name>
+
+You are an expert in <domain from step 1>...
+
+## Expertise
+
+<List key areas of expertise>
+
+## Approach
+
+<Describe how this coworker should approach problems>
+```
+
+### Step 5: Confirm and add
+
+Show the generated file to the user for review. Once confirmed:
+
+```bash
+ox coworker add /tmp/<name>.md
+```
+
+### Step 6: Verify
+
+```bash
+ox coworker list
+```
+
+Confirm the new coworker appears in the list.
+
+## Multi-team handling
+
+If the repo has multiple teams configured, use `--team <id>` on all
+commands. If the user doesn't specify a team, ask which one they want
+to manage coworkers for.

--- a/claws/openclaw/sageox/references/distill-pipeline.md
+++ b/claws/openclaw/sageox/references/distill-pipeline.md
@@ -1,0 +1,71 @@
+# Distill Pipeline — Multi-Repo Automated Distillation
+
+Sync team contexts, index GitHub activity, and run the distillation
+pipeline across all repos in the manifest.
+
+Pairs with the **Summary** capability — this pipeline writes the daily
+source files that summary synthesizes.
+
+## Repo manifest
+
+The list of repos is stored in
+`~/.openclaw/memory/sageox-distill-repos.json` (shared with the
+manifest gate in the main SKILL.md). The user can say "add repo",
+"remove repo", or "show repos" to manage it.
+
+## Pipeline phases
+
+Run all phases in order. Each phase is non-fatal for individual repos —
+log errors and continue.
+
+### Phase 1: Sync and Index
+
+Group repos by `team_id` from the manifest.
+
+For each team:
+
+1. **Sync team context** — run from the first repo in the team group:
+   ```bash
+   ox sync --all-teams
+   ```
+
+2. **Index GitHub activity** — run for EACH repo in the team group:
+   ```bash
+   ox index github
+   ```
+
+Both commands run from the repo's directory (`cd` to the path from
+the manifest). Neither needs Claude credentials.
+
+### Phase 2: Wait for daemon sync
+
+After all sync and index commands, the SageOx daemon processes them
+asynchronously. Before distilling, verify completion.
+
+For each repo:
+1. Run `ox daemon status` in the repo directory.
+2. If still processing: wait 10 seconds, check again.
+3. Repeat up to 30 times (5 minutes max).
+4. If still not finished after 30 attempts: report which repos are
+   pending, ask the user whether to proceed or abort.
+5. If daemon reports an error: surface the full message, ask whether
+   to proceed or abort.
+
+### Phase 3: Distill
+
+For each unique team (grouped by `team_id`), run distill from the first
+repo in that team's group:
+
+```bash
+ox distill --sync --layer daily --concurrency 3 --model sonnet --quiet
+```
+
+`--quiet` suppresses non-error output. If `ox distill` exits 0, report
+`<team_id>: ok`. If non-zero, report `<team_id>: failed — <reason>`
+and continue with the next team.
+
+## Output
+
+After all teams have run, print one line per team (`<team_id>: ok` or
+`<team_id>: failed — <reason>`). If every team passed, `all ok` is
+sufficient.

--- a/claws/openclaw/sageox/references/distill.md
+++ b/claws/openclaw/sageox/references/distill.md
@@ -1,0 +1,95 @@
+# Distill — Interactive Single-Repo Distillation
+
+Distill team observations into structured memory summaries for the
+current repo using `ox distill`.
+
+## How distillation works
+
+ox distill reads observations, session facts, discussion facts, and
+GitHub facts, then uses an LLM to synthesize them into memory layers:
+
+- **Daily** — `memory/daily/YYYY-MM-DD-{uuid}.md` — raw activity summaries
+- **Weekly** — `memory/weekly/YYYY-Www-{uuid}.md` — synthesis of daily
+- **Monthly** — `memory/monthly/YYYY-MM-{uuid}.md` — synthesis of weekly
+
+## Running a distill
+
+### Basic usage
+
+```bash
+ox distill
+```
+
+Runs daily distillation for the last 7 days. Automatically runs weekly
+and monthly roll-ups if layer boundaries have been crossed.
+
+### With options
+
+```bash
+ox distill --layer <layer> --model <model> [--sync] [--concurrency N] [--quiet]
+```
+
+**Layer selection:**
+- `daily` — recent activity (most common)
+- `weekly` — roll up daily summaries into weekly
+- `monthly` — roll up weekly summaries into monthly
+
+**Model selection:**
+- `sonnet` (default) — good balance of speed and quality
+- `opus` — deeper analysis, slower
+- `haiku` — fast, lightweight
+
+**Other flags:**
+- `--sync` — sync ledger and team context before distilling
+- `--concurrency N` — parallel LLM calls (1-8, default 1)
+- `--dry-run` — show what would be distilled without LLM calls
+- `--all` — process full history (default: last 7 days)
+- `--no-push` — skip pushing results to remote
+- `--verbose` — log full prompts to stderr
+
+### Guided workflow
+
+When the user asks to distill, guide them:
+
+1. "Which layer? daily (default), weekly, or monthly?"
+2. "Which model? sonnet (default), opus, or haiku?"
+3. "Sync first? (pulls latest team context before distilling)"
+4. Run the distill with chosen options.
+5. Report results: success or failure per team.
+
+## Viewing distilled history
+
+### List entries
+
+```bash
+ox distill history list --since 7d [--layer daily] [--format json|text]
+ox distill history list --all-teams --since 30d
+```
+
+### Show specific entry
+
+```bash
+ox distill history show <id> --format content
+```
+
+### Show recent history as narrative
+
+```bash
+ox distill history since 7d --format content
+```
+
+## Examples
+
+```bash
+# Interactive daily distill with sync
+ox distill --layer daily --model sonnet --sync
+
+# Dry run to preview
+ox distill --dry-run
+
+# View last week's distilled entries
+ox distill history list --since 7d --layer daily --format text
+
+# Read a specific entry
+ox distill history show 2026-04-20-abc123 --format content
+```

--- a/claws/openclaw/sageox/references/glance.md
+++ b/claws/openclaw/sageox/references/glance.md
@@ -1,0 +1,85 @@
+# Glance — Real-Time AI Coworker Activity
+
+See what your team's AI coworkers are working on and detect file-level
+collisions using `ox glance`.
+
+## Usage
+
+```bash
+ox glance [--since <duration>] [--until <duration>]
+```
+
+**Defaults:** since last checkpoint (or 4 hours if no checkpoint).
+
+**Duration formats:** `3d`, `7d`, `24h`, `1w`, or ISO date `2026-04-20`.
+
+## Output structure
+
+`ox glance` returns JSON. Key fields:
+
+### `authors[]`
+
+Each active coworker with:
+- Name and agent type
+- Recent murmurs (WIP updates)
+- Files they're touching
+- Session activity
+
+### `conflicts[]`
+
+File-level collision detection. Each entry lists:
+- The file path
+- Which coworkers are touching it
+- Overlap type (concurrent modification risk)
+
+Surface these as **warnings** when non-empty:
+> "You and [coworker] are both touching `internal/auth/handler.go` —
+> consider coordinating."
+
+### `overlap[]`
+
+Pairs of coworkers with overlapping file activity. Useful for
+identifying who should coordinate.
+
+### `patterns[]`
+
+Detected activity patterns across the team (e.g., concentrated work
+in one package, distributed changes across many files).
+
+### `velocity`
+
+Conflict velocity over time — trend of how many file overlaps are
+occurring. Rising velocity suggests coordination is needed.
+
+### `stats`
+
+Totals: `totalMurmurs`, `totalSessions`, `totalAuthors`,
+`totalConflicts`, `wipCount`, `fileChangeCount`.
+
+## Workflow
+
+1. Run `ox glance` (or with `--since` for a wider window).
+2. Parse the JSON output.
+3. Synthesize into an actionable narrative:
+   - **Active coworkers:** who's working, on what
+   - **Collision warnings:** files with multiple editors
+   - **Coordination suggestions:** who should talk to whom
+   - **Activity patterns:** where work is concentrated
+
+4. If the user wants more detail on specific murmurs:
+   ```bash
+   ox murmur list
+   ```
+
+## Examples
+
+```bash
+# Default: since last checkpoint
+ox glance
+
+# Last 3 days
+ox glance --since 3d
+
+# Specific window
+ox glance --since 2026-04-18 --until 2026-04-22
+```

--- a/claws/openclaw/sageox/references/import-export.md
+++ b/claws/openclaw/sageox/references/import-export.md
@@ -1,0 +1,117 @@
+# Import/Export — Knowledge Bridge
+
+Import documents, recordings, and OpenClaw memory into SageOx. Export
+SageOx knowledge as portable local files.
+
+## Import into SageOx
+
+### File import
+
+```bash
+ox import <file> [--text <extracted.md>] [--date YYYY-MM-DD] [--team <id>] [--force]
+```
+
+Import documents (PDF, markdown, Word, etc.) into team context. Files
+are stored as LFS pointers with metadata in `data/docs/YYYY/MM/DD/{slug}/`.
+
+- `--text` — path to pre-extracted text/markdown for indexing
+- `--date` — override file modification date
+- `--force` — re-import even if content hash matches an existing import
+- `--team` — explicit team (auto-discovers if single team)
+
+### Video/URL import
+
+```bash
+ox import <url> --title "..." [--team <id>]
+```
+
+Import video URLs (Loom, Cap, direct video links) for cloud processing.
+The server transcribes, summarizes, and extracts facts.
+
+**Check processing status:**
+
+```bash
+ox import --status <recording_id> [--watch]
+```
+
+`--watch` polls until processing completes or fails.
+
+**List all imports:**
+
+```bash
+ox import --list
+```
+
+### Bridge: OpenClaw memory → SageOx
+
+To push knowledge from OpenClaw memory into SageOx team context:
+
+1. Read the relevant `~/.openclaw/memory/*.json` file.
+2. Extract the content to import.
+3. Choose the import method:
+
+   **As an observation** (for facts, decisions, conventions):
+   ```bash
+   ox memory put '{"content": "<extracted content>"}'
+   ```
+   Observations are processed during the next distill run and become
+   part of the team's memory layers.
+
+   **As a document** (for structured content):
+   Write the content to a temp markdown file, then:
+   ```bash
+   ox import /tmp/extracted-knowledge.md --team <team_id>
+   ```
+
+4. If multiple teams exist, ask the user which team to import into.
+5. Track the import in `~/.openclaw/memory/sageox-bridge-state.json`:
+   ```json
+   {
+     "updated_at": "RFC3339",
+     "imports": [
+       {"source": "~/.openclaw/memory/file.json", "team_id": "...", "imported_at": "RFC3339"}
+     ]
+   }
+   ```
+
+## Export from SageOx (portable extraction)
+
+There is no `ox export` command. Knowledge flows out via query, distill
+history, and fetch. The agent orchestrates the extraction:
+
+### Extract a decision or convention
+
+1. `ox query "<topic>" --source team --limit 5`
+2. Present results to the user.
+3. If the user wants to save: write the relevant content to a local
+   markdown file at a user-chosen path.
+
+### Extract distilled insights
+
+1. `ox distill history list --since <duration> --layer daily --format json`
+2. Show available entries.
+3. `ox distill history show <id> --format content`
+4. Write content to a local file at user-chosen path.
+
+### Hydrate an imported file
+
+```bash
+ox fetch <pointer-file> [-o <output-path>]
+```
+
+Downloads the actual content behind an LFS pointer (PDF, image, etc.)
+from the LFS server. Caches locally and verifies SHA256.
+
+### Track exports
+
+Record exports in `~/.openclaw/memory/sageox-bridge-state.json`:
+
+```json
+{
+  "exports": [
+    {"query": "auth patterns", "team_id": "...", "output_path": "/path/to/file.md", "exported_at": "RFC3339"}
+  ]
+}
+```
+
+This prevents re-exporting the same content and provides an audit trail.

--- a/claws/openclaw/sageox/references/query.md
+++ b/claws/openclaw/sageox/references/query.md
@@ -1,0 +1,66 @@
+# Query — Search Team Knowledge
+
+Search across team discussions, docs, session history, and local code
+using `ox query`.
+
+## Usage
+
+```bash
+ox query "<text>" [--source team|code|all] [--limit N] [--mode hybrid|knn|bm25]
+```
+
+## Source selection
+
+| Source | What it searches | When to use |
+|---|---|---|
+| `team` (default) | Team discussions, docs, decisions, session history | "How do we handle auth?" — team knowledge |
+| `code` | Local code index (symbols, git history, diffs) | "Where is the auth middleware?" — codebase |
+| `all` | Both team context and code index | Broad searches spanning knowledge + code |
+
+## Search modes
+
+| Mode | How it works | When to use |
+|---|---|---|
+| `hybrid` (default) | Combines semantic + keyword matching | Best general-purpose mode |
+| `knn` | Pure semantic similarity (vector search) | Conceptual questions, fuzzy matches |
+| `bm25` | Pure keyword matching | Exact terms, specific names |
+
+## Workflow
+
+1. Accept the user's natural language question.
+2. Choose source based on the question:
+   - Questions about decisions, conventions, processes → `--source team`
+   - Questions about code structure, symbols, implementations → `--source code`
+   - Unclear → `--source all`
+3. Run: `ox query "<question>" --source <src> --limit 10`
+4. Present results with source attribution (which discussion, session,
+   or code file each result came from).
+5. Offer follow-up:
+   - "Want to refine the query?"
+   - "Try a different source (team/code/all)?"
+   - "Try a different mode (knn for semantic, bm25 for exact)?"
+
+## Iterative refinement
+
+If results are sparse:
+- Broaden the query (fewer specific terms)
+- Try `--source all` if only searching one source
+- Switch mode: `knn` finds conceptual matches that keyword search misses
+
+If results are noisy:
+- Narrow the query (more specific terms)
+- Try `--mode bm25` for exact keyword matching
+- Reduce `--limit` to surface only the strongest matches
+
+## Examples
+
+```bash
+# Team knowledge
+ox query "how do we handle database migrations" --source team --limit 10
+
+# Code search
+ox query "authentication middleware" --source code --limit 5
+
+# Combined search with semantic mode
+ox query "error handling patterns" --source all --mode knn --limit 10
+```

--- a/claws/openclaw/sageox/references/setup.md
+++ b/claws/openclaw/sageox/references/setup.md
@@ -1,0 +1,86 @@
+# Installing and Configuring `ox`
+
+Invoked when `bash scripts/update-ox.sh` exits `2` (no install state
+recorded, or `ox` is not on PATH). The deterministic install shell lives
+in `scripts/install-ox-curl.sh`; this file covers the user-facing flow
+and PATH recovery.
+
+## Install
+
+Invoke the bundled helper. It downloads the `ox` release tarball
+directly from GitHub Releases at a tag pinned in the script source,
+verifies it against an sha256 checksum embedded in the script, extracts
+it into `$HOME/.local/bin`, and records the install state (pinned
+release tag, install directory, install timestamp) in
+`~/.openclaw/memory/sageox-ox-install.json`. No sudo, no shell-script
+piping, no dynamic "latest" resolution.
+
+```bash
+bash scripts/install-ox-curl.sh
+```
+
+Contract:
+
+- **Args:** none
+- **Stdout:** human-readable progress (download URL, checksum
+  verification, extract, install dir)
+- **Stderr:** errors and PATH-configuration guidance
+- **Exit:** `0` success; `3` internal (curl/tar missing, download
+  failed, checksum mismatch, unsupported platform, or `ox` not
+  runnable after install)
+
+**Do not install `ox` via Homebrew or any package manager** (e.g.
+`brew install sageox/tap/ox`, `apt`, `dnf`, `pacman`). The tap exists
+for general use but is not supported inside OpenClaw skills — only the
+pinned-release curl flow is.
+
+If the script exits non-zero, surface its stderr to the user and stop.
+Do not silently retry.
+
+## PATH configuration
+
+`install-ox-curl.sh` installs into `$HOME/.local/bin`. This directory
+is not on `PATH` by default on every distro. If the script prints a
+warning to stderr that `$HOME/.local/bin` is not on `PATH`, surface its
+guidance verbatim and ask the user to add the following line to
+`~/.openclaw/.env`:
+
+```sh
+PATH=$HOME/.local/bin:$PATH
+```
+
+OpenClaw loads `.env` into the skill subprocess, so the updated `PATH`
+takes effect on the next invocation. After the user confirms they've
+updated the file, re-run the state checker to confirm `ox` is reachable:
+
+```bash
+bash scripts/update-ox.sh
+```
+
+It should exit `0` with no stderr.
+
+## Authentication
+
+After ox is installed and on PATH, verify all credentials:
+
+1. `ox status` — confirm ox is authenticated. If not, tell the user to
+   run `ox login` and try again.
+2. `gh auth status` — confirm GitHub credentials are available. If not,
+   tell the user to run `gh auth login`.
+3. `git config user.name` — confirm git identity is set. If empty,
+   tell the user to run `git config --global user.name "Name"`.
+4. Confirm `claude` has credentials. Either `claude login` was run
+   (Pro/Max OAuth, stored under `~/.claude/`) or `ANTHROPIC_API_KEY` is
+   exported in the shell that launched OpenClaw.
+
+Do not proceed until all four pass.
+
+## Upgrading `ox`
+
+The curl flow pins a specific `ox` release by tag and sha256. There is
+no per-run auto-update. To pick up a newer release, re-run
+`scripts/install-ox-curl.sh` from a version of this skill that pins the
+newer release — typically by re-running `clawhub install` for the
+skill after a new skill version publishes.
+
+The user can say **"reinstall ox"** at any time to re-enter this flow.

--- a/claws/openclaw/sageox/references/summary.md
+++ b/claws/openclaw/sageox/references/summary.md
@@ -24,7 +24,7 @@ If it fails with an auth error, tell the user to either run
 2. Read `~/.openclaw/memory/sageox-summary-state.json` if it exists.
    Missing file → empty state (first run). Malformed → proceed as empty
    and emit one warning to **stderr** (not stdout):
-   ```
+   ```text
    warning: sageox-summary-state.json was unreadable, starting from empty state
    ```
 
@@ -55,14 +55,14 @@ TEAM_BLOCK="$(ox distill history show \
 Read the template from `assets/SUMMARIZE.md`. Substitute:
 
 - `{{ENTRIES}}` — one section per team:
-  ```
+  ```text
   ### Team "<team_id>"
 
   <TEAM_BLOCK>
   ```
 
 - `{{MULTI_TEAM_RULES}}` — if two or more teams have content:
-  ```
+  ```text
   - Organize the summary by team, using each team ID as a section header
   - Attribute insights to the correct team
   ```
@@ -73,7 +73,8 @@ Do not re-wrap or mutate the markdown inside `TEAM_BLOCK`.
 ### Step 4: Run Claude
 
 ```bash
-timeout 600 claude -p --model claude-sonnet-4-6 <<< "$PROMPT"
+TIMEOUT_BIN="$(command -v timeout || command -v gtimeout)"
+"$TIMEOUT_BIN" 600 claude -p --model claude-sonnet-4-6 <<< "$PROMPT"
 ```
 
 No `--add-dir`, no `--allowedTools` — content is inline. If it fails

--- a/claws/openclaw/sageox/references/summary.md
+++ b/claws/openclaw/sageox/references/summary.md
@@ -1,0 +1,98 @@
+# Summary — Cross-Team Activity Summary
+
+Generate a summary of the last 24 hours of SageOx distilled activity
+across all configured teams.
+
+## Prerequisites
+
+This capability requires `claude -p` for synthesis. Verify Claude
+credentials work before proceeding:
+
+```bash
+claude -p "say hi" --model claude-sonnet-4-6
+```
+
+If it fails with an auth error, tell the user to either run
+`claude login` (Pro/Max OAuth) or export `ANTHROPIC_API_KEY`.
+
+## Pipeline
+
+### Step 1: Load manifest and summary state
+
+1. Read `~/.openclaw/memory/sageox-distill-repos.json` — extract unique
+   `team_id` values.
+2. Read `~/.openclaw/memory/sageox-summary-state.json` if it exists.
+   Missing file → empty state (first run). Malformed → proceed as empty
+   and emit one warning to **stderr** (not stdout):
+   ```
+   warning: sageox-summary-state.json was unreadable, starting from empty state
+   ```
+
+### Step 2: Select new entries per team
+
+For each unique `team_id`, run the bundled selection script:
+
+```bash
+STATE_FILE=~/.openclaw/memory/sageox-summary-state.json
+NEW_IDS="$(bash scripts/select-new-entries.sh "$TEAM_ID" 24h "$STATE_FILE")"
+```
+
+- Empty `NEW_IDS` for a team → skip it, log to stderr.
+- **All** teams empty → stop. Print one line to stdout:
+  `No new distilled content since last summary.` Do not invoke Claude.
+
+### Step 3: Fetch content and build prompt
+
+For each team with new entries:
+
+```bash
+TEAM_BLOCK="$(ox distill history show \
+  --team "$TEAM_ID" \
+  --format content \
+  $NEW_IDS)"
+```
+
+Read the template from `assets/SUMMARIZE.md`. Substitute:
+
+- `{{ENTRIES}}` — one section per team:
+  ```
+  ### Team "<team_id>"
+
+  <TEAM_BLOCK>
+  ```
+
+- `{{MULTI_TEAM_RULES}}` — if two or more teams have content:
+  ```
+  - Organize the summary by team, using each team ID as a section header
+  - Attribute insights to the correct team
+  ```
+  Otherwise, empty string.
+
+Do not re-wrap or mutate the markdown inside `TEAM_BLOCK`.
+
+### Step 4: Run Claude
+
+```bash
+timeout 600 claude -p --model claude-sonnet-4-6 <<< "$PROMPT"
+```
+
+No `--add-dir`, no `--allowedTools` — content is inline. If it fails
+(non-zero, timeout 124, network error), surface the error and **do not**
+proceed to step 5.
+
+### Step 5: Update summary state
+
+Only if Claude succeeded. For each team with new entries:
+
+```bash
+printf '%s\n' "$NEW_IDS" \
+  | bash scripts/update-state.sh "$STATE_FILE" "$TEAM_ID"
+```
+
+Teams skipped in step 2 are not touched here.
+
+### Step 6: Return the summary
+
+Return Claude's stdout directly. It is formatted for Slack mrkdwn.
+Prefix with a one-line header showing how many teams were summarized
+and any that were skipped.

--- a/claws/openclaw/sageox/scripts/install-ox-curl.sh
+++ b/claws/openclaw/sageox/scripts/install-ox-curl.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# install-ox-curl.sh — download a pinned ox release binary directly from
+# GitHub Releases, verify it against an embedded sha256 checksum, and
+# install to $HOME/.local/bin. No sudo, no shell-script piping, no
+# dynamic "latest" resolution.
+#
+# Why this shape: scanners flag `curl | bash` of a remote shell script,
+# and skills that sudo into system paths. This script avoids both. The
+# release tag and per-platform sha256s are pinned in the source below, so
+# an attacker cannot substitute a different binary without also editing
+# this file (which is reviewed on skill publish).
+#
+# Bumping: when a newer sageox/ox release ships, update OX_INSTALL_REF
+# and the OX_SHA256_* constants. Fetch checksums.txt from
+# https://github.com/sageox/ox/releases/download/<tag>/checksums.txt
+#
+# Usage: install-ox-curl.sh
+#
+# Stdout: human-readable progress
+# Stderr: errors
+# Exit:
+#   0 — success, ox installed and memory file written
+#   3 — internal error (curl/tar missing, download failed, checksum
+#       mismatch, unsupported platform, or ox not runnable after install)
+
+set -euo pipefail
+
+OX_INSTALL_REF="v0.6.3"
+OX_VERSION="${OX_INSTALL_REF#v}"
+OX_REPO="sageox/ox"
+
+# sha256(ox_<version>_<os>_<arch>.tar.gz) — from the checksums.txt asset
+# on the pinned release. Lock these when bumping OX_INSTALL_REF.
+OX_SHA256_darwin_amd64="4518b40aa7a59bc24b9b5fab324fb0a46f37129d5cf5b1f7cd1402aa6767acf4"
+OX_SHA256_darwin_arm64="3836fc5b1ac6ae6c50c1c80289ba8f1bf703a55b1afe9a446071ba8e960b6865"
+OX_SHA256_linux_amd64="c0de7c16db770206b19fa387708719f6f9b847d24110be14569c33b9ea24bd54"
+OX_SHA256_linux_arm64="f4324c1a0cbeb394e6c0443e4361eb1dc4f36f74e472a5b33df089467cfbdf30"
+OX_SHA256_freebsd_amd64="ff05f45616f08918ac9c0fa3bc6fe45d8a7341e43d203d27f9000ddbcfb30427"
+
+command -v curl >/dev/null 2>&1 || { echo "error: curl is required" >&2; exit 3; }
+command -v tar  >/dev/null 2>&1 || { echo "error: tar is required"  >&2; exit 3; }
+
+case "$(uname -s)" in
+  Darwin)  OS="darwin"  ;;
+  Linux)   OS="linux"   ;;
+  FreeBSD) OS="freebsd" ;;
+  *)
+    echo "error: unsupported OS $(uname -s); skill supports macOS, Linux, and FreeBSD" >&2
+    exit 3
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64)  ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *)
+    echo "error: unsupported architecture $(uname -m)" >&2
+    exit 3
+    ;;
+esac
+
+PLATFORM="${OS}_${ARCH}"
+SHA_VAR="OX_SHA256_${PLATFORM}"
+EXPECTED_SHA="${!SHA_VAR:-}"
+if [ -z "$EXPECTED_SHA" ]; then
+  echo "error: no pinned checksum for platform ${PLATFORM} in ${OX_INSTALL_REF}" >&2
+  exit 3
+fi
+
+ARCHIVE_NAME="ox_${OX_VERSION}_${PLATFORM}.tar.gz"
+DOWNLOAD_URL="https://github.com/${OX_REPO}/releases/download/${OX_INSTALL_REF}/${ARCHIVE_NAME}"
+
+# Portable mktemp template — works on both GNU (Linux) and BSD (macOS).
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
+trap 'rm -rf "$WORK_DIR" 2>/dev/null' EXIT
+
+echo "Downloading ox ${OX_INSTALL_REF} for ${PLATFORM}"
+echo "  from: ${DOWNLOAD_URL}"
+
+# -f fails on HTTP errors, --max-time bounds a stalled connection.
+if ! curl -fsSL --max-time 120 "$DOWNLOAD_URL" -o "$WORK_DIR/$ARCHIVE_NAME"; then
+  echo "error: failed to download ${DOWNLOAD_URL}" >&2
+  exit 3
+fi
+
+echo "Verifying sha256 checksum..."
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL_SHA="$(sha256sum "$WORK_DIR/$ARCHIVE_NAME" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL_SHA="$(shasum -a 256 "$WORK_DIR/$ARCHIVE_NAME" | awk '{print $1}')"
+else
+  echo "error: neither sha256sum nor shasum is available; refusing to install unverified binary" >&2
+  exit 3
+fi
+
+if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+  echo "error: sha256 mismatch for ${ARCHIVE_NAME}" >&2
+  echo "  expected: $EXPECTED_SHA" >&2
+  echo "  actual:   $ACTUAL_SHA" >&2
+  exit 3
+fi
+echo "  ok: $ACTUAL_SHA"
+
+echo "Extracting archive..."
+if ! tar -xzf "$WORK_DIR/$ARCHIVE_NAME" -C "$WORK_DIR"; then
+  echo "error: failed to extract $ARCHIVE_NAME" >&2
+  exit 3
+fi
+
+INSTALL_DIR="$HOME/.local/bin"
+mkdir -p "$INSTALL_DIR"
+
+# Install ox and every ox-adapter-* binary shipped in the tarball. We
+# glob rather than hardcode the adapter list so new adapters added in
+# future releases work without re-editing this file.
+shopt -s nullglob
+installed=0
+for src in "$WORK_DIR/ox" "$WORK_DIR"/ox-adapter-*; do
+  [ -f "$src" ] || continue
+  name="$(basename "$src")"
+  dest="$INSTALL_DIR/$name"
+  mv "$src" "$dest"
+  chmod +x "$dest"
+
+  # macOS ad-hoc re-sign: avoids slow Gatekeeper checks on first run.
+  # Non-fatal — a failure here does not block install.
+  if [ "$OS" = "darwin" ] && command -v codesign >/dev/null 2>&1; then
+    codesign --remove-signature "$dest" 2>/dev/null || true
+    codesign --force --sign - "$dest" 2>/dev/null || true
+  fi
+
+  installed=$((installed + 1))
+done
+shopt -u nullglob
+
+if [ "$installed" -eq 0 ]; then
+  echo "error: tarball contained no ox binaries" >&2
+  exit 3
+fi
+
+echo "Installed $installed binaries to $INSTALL_DIR"
+
+# PATH guidance — $HOME/.local/bin isn't on PATH by default on every
+# distro. Surface this before the readiness gate so the user sees the
+# fix in context.
+if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+  echo ""
+  echo "warning: $INSTALL_DIR is not on your PATH" >&2
+  echo "fix: add this line to ~/.openclaw/.env (OpenClaw loads it into the skill subprocess):" >&2
+  echo "  PATH=\"$INSTALL_DIR:\$PATH\"" >&2
+  echo "then restart the skill." >&2
+fi
+
+# Readiness gate: the binary at $INSTALL_DIR/ox must exist, be
+# executable, run, and report the pinned release version. The sha256
+# check earlier guarantees the extracted bytes are exactly what GitHub
+# Releases published for this tag, but those bytes might still fail to
+# execute on the host (libc mismatch, unsupported OS version, stripped
+# dependency, etc.) — catch that now, before we write state claiming a
+# successful install.
+#
+# Invoke the literal $INSTALL_DIR/ox path rather than using PATH
+# lookup. If for any reason the install loop above didn't actually
+# write the ox binary (e.g. a future tarball ships only adapters, or
+# the upstream release was mis-packaged), a PATH-based check could
+# silently fall through to a pre-existing system ox and claim success
+# against the wrong binary.
+if [ ! -x "$INSTALL_DIR/ox" ]; then
+  echo "error: expected ox binary missing at $INSTALL_DIR/ox" >&2
+  exit 3
+fi
+
+if ! version_output="$("$INSTALL_DIR/ox" version 2>&1)"; then
+  echo "error: $INSTALL_DIR/ox failed to run" >&2
+  echo "$version_output" >&2
+  exit 3
+fi
+
+# `ox version` prints "ox <version>\n..." on stdout. Compare the first
+# line exactly rather than substring-matching — a loose *"$OX_VERSION"*
+# pattern would false-positive when e.g. 0.6.3 is a suffix of 10.6.3.
+first_line="$(printf '%s\n' "$version_output" | head -n1)"
+if [ "$first_line" != "ox $OX_VERSION" ]; then
+  echo "error: $INSTALL_DIR/ox reports '$first_line', expected 'ox $OX_VERSION'" >&2
+  exit 3
+fi
+
+# Record install state so update-ox.sh can confirm the skill has a
+# known-good ox install on subsequent runs. Only factual state — what
+# was installed, where, when — no preference fields.
+#
+# Use `jq -n --arg` rather than a heredoc so JSON-special characters in
+# values (e.g. `"` or `\` in a pathological $HOME) get escaped correctly
+# instead of producing a malformed state file. `jq` is a hard skill
+# dependency (declared in SKILL.md `requires.bins`), so OpenClaw has
+# already ensured it's available by the time this script runs.
+#
+# Write to a temp file in the same directory, then rename into place.
+# update-ox.sh reads this file, so an interrupted write that left a
+# zero-byte or partial JSON file would break the readiness gate.
+# Same-directory rename is atomic at the directory-entry level, which
+# is all we need here.
+STATE_DIR="$HOME/.openclaw/memory"
+STATE_FILE="$STATE_DIR/sageox-ox-install.json"
+mkdir -p "$STATE_DIR"
+TMP_STATE_FILE="$(mktemp "${STATE_DIR}/sageox-ox-install.json.XXXXXXXX")"
+INSTALLED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -n \
+  --arg ox_install_ref "$OX_INSTALL_REF" \
+  --arg install_dir    "$INSTALL_DIR" \
+  --arg installed_at   "$INSTALLED_AT" \
+  '{
+    ox_install_ref: $ox_install_ref,
+    install_dir:    $install_dir,
+    installed_at:   $installed_at
+  }' > "$TMP_STATE_FILE"
+mv "$TMP_STATE_FILE" "$STATE_FILE"
+
+echo "ox ${OX_INSTALL_REF} installed successfully"

--- a/claws/openclaw/sageox/scripts/install-ox-curl.sh
+++ b/claws/openclaw/sageox/scripts/install-ox-curl.sh
@@ -73,7 +73,8 @@ DOWNLOAD_URL="https://github.com/${OX_REPO}/releases/download/${OX_INSTALL_REF}/
 
 # Portable mktemp template — works on both GNU (Linux) and BSD (macOS).
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ox-install.XXXXXXXX")"
-trap 'rm -rf "$WORK_DIR" 2>/dev/null' EXIT
+trap 'rm -rf "$WORK_DIR" 2>/dev/null; rm -f "$TMP_STATE_FILE" 2>/dev/null' EXIT
+TMP_STATE_FILE=""  # set later; trap is safe if unset
 
 echo "Downloading ox ${OX_INSTALL_REF} for ${PLATFORM}"
 echo "  from: ${DOWNLOAD_URL}"

--- a/claws/openclaw/sageox/scripts/install-ox-curl.sh
+++ b/claws/openclaw/sageox/scripts/install-ox-curl.sh
@@ -39,6 +39,7 @@ OX_SHA256_freebsd_amd64="ff05f45616f08918ac9c0fa3bc6fe45d8a7341e43d203d27f9000dd
 
 command -v curl >/dev/null 2>&1 || { echo "error: curl is required" >&2; exit 3; }
 command -v tar  >/dev/null 2>&1 || { echo "error: tar is required"  >&2; exit 3; }
+command -v jq   >/dev/null 2>&1 || { echo "error: jq is required"   >&2; exit 3; }
 
 case "$(uname -s)" in
   Darwin)  OS="darwin"  ;;

--- a/claws/openclaw/sageox/scripts/select-new-entries.sh
+++ b/claws/openclaw/sageox/scripts/select-new-entries.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# select-new-entries.sh — print ox distill history entry ids for a team
+# that fall within the --since window and have NOT yet been included in a
+# prior summary run.
+#
+# Usage: select-new-entries.sh <team_id> <since> <state_file>
+#
+# Arguments:
+#   <team_id>     Team slug, id, or name. Passed verbatim to
+#                 `ox distill history list --team`, and used as the key
+#                 inside the state file's .teams map.
+#   <since>       Window duration (e.g. 24h). Passed verbatim to
+#                 `--since`. Anything ox's flag parser accepts works.
+#                 ox auto-expands the window around the UTC day
+#                 boundary, so `24h` is the pipeline's default.
+#   <state_file>  Absolute path to sageox-summary-state.json (need not
+#                 exist — a missing file is treated as empty state).
+#
+# Stdout: one entry id per line, sorted ascending. Empty if nothing new.
+# Stderr: single-line warnings (malformed state, failed ox call).
+# Exit:
+#   0 — success (empty output is not a failure, including when the ox
+#       call fails — the caller skips the team and continues)
+#   2 — usage error
+#   3 — internal error (required tool missing)
+
+set -euo pipefail
+
+if [ $# -ne 3 ]; then
+  echo "usage: $(basename "$0") <team_id> <since> <state_file>" >&2
+  exit 2
+fi
+
+TEAM_ID="$1"
+SINCE="$2"
+STATE_FILE="$3"
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 3; }
+command -v ox >/dev/null 2>&1 || { echo "error: ox is required" >&2; exit 3; }
+
+ID_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f-]+$'
+
+# Ask ox which distilled daily entries fall in the window. We pin the
+# layer to `daily` because weekly/monthly roll-ups would double-count
+# material the summary already synthesized from the daily layer.
+CANDIDATES=""
+if OX_OUT="$(ox distill history list \
+  --team "$TEAM_ID" \
+  --since "$SINCE" \
+  --layer daily \
+  --format json 2>/dev/null)"; then
+  CANDIDATES="$(
+    printf '%s' "$OX_OUT" \
+      | jq -r '.data.entries[]?.id // empty' 2>/dev/null \
+      | grep -E "$ID_RE" \
+      | sort -u || true
+  )"
+else
+  echo "warning: ox distill history list failed for team $TEAM_ID" >&2
+fi
+
+# Already-summarized set for this team. Missing state → empty
+# (first run). Malformed → empty + stderr warning.
+ALREADY_INCLUDED=""
+if [ -f "$STATE_FILE" ]; then
+  if ! jq -e . "$STATE_FILE" >/dev/null 2>&1; then
+    echo "warning: $STATE_FILE was unreadable, starting from empty state" >&2
+  else
+    ALREADY_INCLUDED="$(
+      jq -r --arg tid "$TEAM_ID" \
+        '.teams[$tid].included_ids[]? // empty' "$STATE_FILE" \
+      | grep -E "$ID_RE" \
+      | sort -u || true
+    )"
+  fi
+fi
+
+# Set difference: CANDIDATES − ALREADY_INCLUDED. Both sides are already
+# sorted and regex-validated; temp files avoid multi-line `awk -v`
+# quirks on BSD.
+CAND_TMP="$(mktemp)"
+INCL_TMP="$(mktemp)"
+trap 'rm -f "$CAND_TMP" "$INCL_TMP" 2>/dev/null' EXIT
+
+printf '%s\n' "$CANDIDATES"       | grep -v '^$' > "$CAND_TMP" || true
+printf '%s\n' "$ALREADY_INCLUDED" | grep -v '^$' > "$INCL_TMP" || true
+
+comm -23 "$CAND_TMP" "$INCL_TMP"

--- a/claws/openclaw/sageox/scripts/update-ox.sh
+++ b/claws/openclaw/sageox/scripts/update-ox.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# update-ox.sh — "is the pinned ox install usable?" readiness gate for
+# every invocation of this skill.
+#
+# Reads ~/.openclaw/memory/sageox-ox-install.json to confirm the install
+# state exists, then verifies that `ox` on PATH resolves to the pinned
+# install at $HOME/.local/bin/ox. A bare `command -v ox` is insufficient:
+# if an older system ox (e.g. /usr/local/bin/ox) appears before
+# $HOME/.local/bin on PATH, `command -v` would silently resolve to it
+# and defeat the pinned-release contract. The curl install path has no
+# per-run update — users re-run install-ox-curl.sh to bump the pinned
+# release.
+#
+# Usage: update-ox.sh
+#
+# Stdout: nothing on success
+# Stderr: one-line "needs install", "not at pinned path", or "PATH
+#         order wrong" signal
+# Exit:
+#   0 — pinned ox is ready, agent should proceed to the next prerequisite
+#   2 — ox is not usable (no state file, binary missing at pinned path,
+#       or PATH resolves to a different ox); agent must read
+#       references/INSTALL.md and run the install flow before continuing
+
+set -euo pipefail
+
+STATE_FILE="$HOME/.openclaw/memory/sageox-ox-install.json"
+EXPECTED_OX="$HOME/.local/bin/ox"
+
+if [ ! -f "$STATE_FILE" ]; then
+  echo "ox install state not configured — run install flow from references/INSTALL.md" >&2
+  exit 2
+fi
+
+# The pinned install must actually exist at the expected path. Anything
+# else (deleted, wrong permissions, never installed by this skill) means
+# the state file is stale and the install flow needs to be re-run.
+if [ ! -x "$EXPECTED_OX" ]; then
+  echo "error: ox is not installed at $EXPECTED_OX" >&2
+  echo "fix: re-run the install flow from references/INSTALL.md" >&2
+  exit 2
+fi
+
+# `command -v` must resolve to the pinned install — not some other ox
+# earlier on PATH. If an older system install shadows the pinned one,
+# running the skill against it would defeat the whole point of the
+# pinned-release contract, so fail with a PATH-order hint.
+resolved_ox="$(command -v ox 2>/dev/null || true)"
+if [ "$resolved_ox" != "$EXPECTED_OX" ]; then
+  echo "error: 'ox' resolves to '${resolved_ox:-<not on PATH>}', not $EXPECTED_OX" >&2
+  echo "fix: prepend \$HOME/.local/bin to PATH in ~/.openclaw/.env so the pinned install wins" >&2
+  exit 2
+fi
+
+# Verify the binary itself still reports the pinned version. The path
+# check above proves PATH order is right; this check proves the bytes
+# behind the path haven't been replaced or corrupted since install.
+# `jq` is required by the skill (see SKILL.md § 2), so it's guaranteed
+# present by the time this script runs.
+expected_ref="$(jq -r '.ox_install_ref // empty' "$STATE_FILE" 2>/dev/null || true)"
+if [ -z "$expected_ref" ]; then
+  echo "error: $STATE_FILE is missing ox_install_ref" >&2
+  echo "fix: re-run the install flow from references/INSTALL.md" >&2
+  exit 2
+fi
+expected_version="${expected_ref#v}"
+
+if ! version_output="$("$EXPECTED_OX" version 2>&1)"; then
+  echo "error: $EXPECTED_OX failed to run" >&2
+  echo "$version_output" >&2
+  echo "fix: re-run the install flow from references/INSTALL.md" >&2
+  exit 2
+fi
+
+first_line="$(printf '%s\n' "$version_output" | head -n1)"
+if [ "$first_line" != "ox $expected_version" ]; then
+  echo "error: $EXPECTED_OX reports '$first_line', expected 'ox $expected_version'" >&2
+  echo "fix: re-run the install flow from references/INSTALL.md" >&2
+  exit 2
+fi
+
+exit 0

--- a/claws/openclaw/sageox/scripts/update-ox.sh
+++ b/claws/openclaw/sageox/scripts/update-ox.sh
@@ -20,7 +20,7 @@
 #   0 — pinned ox is ready, agent should proceed to the next prerequisite
 #   2 — ox is not usable (no state file, binary missing at pinned path,
 #       or PATH resolves to a different ox); agent must read
-#       references/INSTALL.md and run the install flow before continuing
+#       references/setup.md and run the install flow before continuing
 
 set -euo pipefail
 
@@ -28,7 +28,7 @@ STATE_FILE="$HOME/.openclaw/memory/sageox-ox-install.json"
 EXPECTED_OX="$HOME/.local/bin/ox"
 
 if [ ! -f "$STATE_FILE" ]; then
-  echo "ox install state not configured — run install flow from references/INSTALL.md" >&2
+  echo "ox install state not configured — run install flow from references/setup.md" >&2
   exit 2
 fi
 
@@ -37,7 +37,7 @@ fi
 # the state file is stale and the install flow needs to be re-run.
 if [ ! -x "$EXPECTED_OX" ]; then
   echo "error: ox is not installed at $EXPECTED_OX" >&2
-  echo "fix: re-run the install flow from references/INSTALL.md" >&2
+  echo "fix: re-run the install flow from references/setup.md" >&2
   exit 2
 fi
 
@@ -60,7 +60,7 @@ fi
 expected_ref="$(jq -r '.ox_install_ref // empty' "$STATE_FILE" 2>/dev/null || true)"
 if [ -z "$expected_ref" ]; then
   echo "error: $STATE_FILE is missing ox_install_ref" >&2
-  echo "fix: re-run the install flow from references/INSTALL.md" >&2
+  echo "fix: re-run the install flow from references/setup.md" >&2
   exit 2
 fi
 expected_version="${expected_ref#v}"
@@ -68,14 +68,14 @@ expected_version="${expected_ref#v}"
 if ! version_output="$("$EXPECTED_OX" version 2>&1)"; then
   echo "error: $EXPECTED_OX failed to run" >&2
   echo "$version_output" >&2
-  echo "fix: re-run the install flow from references/INSTALL.md" >&2
+  echo "fix: re-run the install flow from references/setup.md" >&2
   exit 2
 fi
 
 first_line="$(printf '%s\n' "$version_output" | head -n1)"
 if [ "$first_line" != "ox $expected_version" ]; then
   echo "error: $EXPECTED_OX reports '$first_line', expected 'ox $expected_version'" >&2
-  echo "fix: re-run the install flow from references/INSTALL.md" >&2
+  echo "fix: re-run the install flow from references/setup.md" >&2
   exit 2
 fi
 

--- a/claws/openclaw/sageox/scripts/update-state.sh
+++ b/claws/openclaw/sageox/scripts/update-state.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# update-state.sh — atomically merge a set of newly-summarized entry ids
+# into the per-team included_ids list, prune stale entries, and write
+# the result back via a temp-file rename.
+#
+# Usage: update-state.sh <state_file> <team_id>
+#        (reads newline-separated entry ids from stdin)
+#
+# Arguments:
+#   <state_file>  Absolute path to sageox-summary-state.json
+#   <team_id>     Team id key to merge under
+#
+# Stdin: one entry id per line (may be empty). Lines not matching the
+# distill-output id regex are silently dropped.
+#
+# Stdout: nothing on success.
+# Stderr: single-line warnings (e.g. malformed prior state).
+# Exit:
+#   0 — success
+#   2 — usage error
+#   3 — internal error (required tool missing, write failed)
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "usage: $(basename "$0") <state_file> <team_id>" >&2
+  exit 2
+fi
+
+STATE_FILE="$1"
+TEAM_ID="$2"
+
+command -v jq >/dev/null 2>&1 || { echo "error: jq is required" >&2; exit 3; }
+
+ID_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f-]+$'
+
+# Prune cutoff: drop entries whose date prefix is strictly older than
+# YESTERDAY_UTC. `ox distill history list --since 24h` auto-expands its
+# window around the day boundary, so the candidate set spans at most
+# today + yesterday UTC; keeping state at `>= yesterday` guarantees no
+# id in range is ever dropped. BSD `date` uses `-v`; GNU uses `-d`.
+CUTOFF_UTC="$(date -u -v-1d +%Y-%m-%d 2>/dev/null \
+  || date -u -d 'yesterday' +%Y-%m-%d)"
+NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Read and regex-filter added entry ids from stdin.
+ADDED="$(grep -E "$ID_RE" || true)"
+
+# Load existing state. Missing → {}. Malformed → {} + stderr warning.
+if [ -f "$STATE_FILE" ]; then
+  if ! EXISTING="$(jq -c . "$STATE_FILE" 2>/dev/null)"; then
+    echo "warning: $STATE_FILE was unreadable, starting from empty state" >&2
+    EXISTING='{}'
+  fi
+else
+  EXISTING='{}'
+fi
+
+# Merge + prune + dedupe in a single jq pass. Preserves other teams'
+# entries verbatim — only the target team's included_ids is rewritten.
+NEW_STATE="$(
+  jq -n \
+    --argjson existing "$EXISTING" \
+    --arg tid "$TEAM_ID" \
+    --arg added "$ADDED" \
+    --arg cutoff "$CUTOFF_UTC" \
+    --arg now "$NOW_UTC" \
+    --arg re "$ID_RE" \
+    '
+      ($existing // {}) as $e
+    | ($e.teams // {}) as $teams
+    | ($teams[$tid].included_ids // []) as $prior
+    | ($added | split("\n") | map(select(. != ""))) as $new
+    | (($prior + $new)
+        | map(select(test($re)))
+        | map(select(.[0:10] >= $cutoff))
+        | unique
+      ) as $merged
+    | $e
+      | .teams = ($teams | .[$tid] = {included_ids: $merged})
+      | .updated_at = $now
+    '
+)"
+
+# Atomic write: temp file in the same directory, then rename.
+STATE_DIR="$(dirname "$STATE_FILE")"
+mkdir -p "$STATE_DIR"
+TMP_FILE="${STATE_FILE}.tmp.$$"
+trap 'rm -f "$TMP_FILE" 2>/dev/null' EXIT
+printf '%s\n' "$NEW_STATE" > "$TMP_FILE"
+mv -f "$TMP_FILE" "$STATE_FILE"

--- a/claws/openclaw/sageox/scripts/update-state.sh
+++ b/claws/openclaw/sageox/scripts/update-state.sh
@@ -85,7 +85,7 @@ NEW_STATE="$(
 # Atomic write: temp file in the same directory, then rename.
 STATE_DIR="$(dirname "$STATE_FILE")"
 mkdir -p "$STATE_DIR"
-TMP_FILE="${STATE_FILE}.tmp.$$"
+TMP_FILE="$(mktemp "${STATE_FILE}.tmp.XXXXXXXX")"
 trap 'rm -f "$TMP_FILE" 2>/dev/null' EXIT
 printf '%s\n' "$NEW_STATE" > "$TMP_FILE"
 mv -f "$TMP_FILE" "$STATE_FILE"

--- a/claws/openclaw/sageox/test-skill.py
+++ b/claws/openclaw/sageox/test-skill.py
@@ -15,6 +15,7 @@ Requires:
 
 import csv
 import os
+import shlex
 import subprocess
 import sys
 import time
@@ -28,7 +29,7 @@ sys.stderr.reconfigure(line_buffering=True)
 # --- Config ---
 VPS_KEY = Path.home() / ".ssh" / "ox-bot.pem"
 VPS_HOST = "ubuntu@35.164.224.156"
-OUTPUT_DIR = Path("/tmp/sageox-test-results")
+OUTPUT_DIR = Path.home() / ".sageox-test-results"
 TIMEOUT_SECONDS = 300  # max wait per prompt (agent responses can be slow)
 
 # --- Test cases ---
@@ -92,10 +93,10 @@ def send_prompt(prompt: str, session_id: str) -> dict:
     ssh_cmd = [
         "ssh",
         "-i", str(VPS_KEY),
-        "-o", "StrictHostKeyChecking=no",
+        "-o", "StrictHostKeyChecking=accept-new",
         "-o", "ConnectTimeout=10",
         VPS_HOST,
-        f'openclaw agent --session-id {session_id} --message {repr(prompt)} 2>&1',
+        f"openclaw agent --session-id {shlex.quote(session_id)} --message {shlex.quote(prompt)} 2>&1",
     ]
 
     try:
@@ -123,7 +124,7 @@ def run_tests():
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     csv_path = OUTPUT_DIR / f"test-results-{timestamp}.csv"
 
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
 
     # Verify SSH connectivity first
     print("Verifying SSH connection...")

--- a/claws/openclaw/sageox/test-skill.py
+++ b/claws/openclaw/sageox/test-skill.py
@@ -125,11 +125,12 @@ def run_tests():
     csv_path = OUTPUT_DIR / f"test-results-{timestamp}.csv"
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(OUTPUT_DIR, 0o700)
 
     # Verify SSH connectivity first
     print("Verifying SSH connection...")
     check = subprocess.run(
-        ["ssh", "-i", str(VPS_KEY), "-o", "ConnectTimeout=5", VPS_HOST, "echo ok"],
+        ["ssh", "-i", str(VPS_KEY), "-o", "StrictHostKeyChecking=accept-new", "-o", "ConnectTimeout=5", VPS_HOST, "echo ok"],
         capture_output=True, text=True, timeout=15,
     )
     if check.stdout.strip() != "ok":

--- a/claws/openclaw/sageox/test-skill.py
+++ b/claws/openclaw/sageox/test-skill.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Batch test runner for the sageox OpenClaw skill.
+
+Sends test prompts to the OpenClaw instance via SSH + `openclaw agent --message`,
+captures responses, and saves results as CSV.
+
+Usage:
+    python3 claws/openclaw/sageox/test-skill.py
+
+Requires:
+    - SSH access to VPS (~/.ssh/ox-bot.pem)
+    - OpenClaw gateway running on VPS
+"""
+
+import csv
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+# Force unbuffered stdout so output streams in real-time
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
+# --- Config ---
+VPS_KEY = Path.home() / ".ssh" / "ox-bot.pem"
+VPS_HOST = "ubuntu@35.164.224.156"
+OUTPUT_DIR = Path("/tmp/sageox-test-results")
+TIMEOUT_SECONDS = 300  # max wait per prompt (agent responses can be slow)
+
+# --- Test cases ---
+# (name, prompt, expected_behavior)
+TEST_CASES = [
+    (
+        "skill_routing",
+        "what can you do with sageox",
+        "Should describe the 8 capabilities",
+    ),
+    (
+        "query",
+        "search my team context for recent architecture decisions",
+        "Should load references/query.md and run ox query",
+    ),
+    (
+        "coworkers_list",
+        "list my coworkers",
+        "Should run ox coworker list",
+    ),
+    (
+        "coworkers_load",
+        "load the go-pro coworker",
+        "Should read coworker prompt and embody it",
+    ),
+    (
+        "distill",
+        "distill this repo with daily layer and sonnet model",
+        "Should run ox distill --layer daily --model sonnet",
+    ),
+    (
+        "glance",
+        "what are my AI coworkers doing right now",
+        "Should run ox glance and synthesize output",
+    ),
+    (
+        "catchup",
+        "catch me up on the last 24 hours",
+        "Should orchestrate distill history + session list + code insights",
+    ),
+    (
+        "summary",
+        "generate a cross-team summary",
+        "Should run summary pipeline with select-new-entries.sh",
+    ),
+    (
+        "import",
+        "how do I import a document into sageox",
+        "Should load references/import-export.md and explain ox import",
+    ),
+    (
+        "manifest_management",
+        "show my sageox configured repos",
+        "Should read and display sageox-distill-repos.json manifest",
+    ),
+]
+
+
+def send_prompt(prompt: str, session_id: str) -> dict:
+    """Send a prompt to OpenClaw via SSH and return the response."""
+    ssh_cmd = [
+        "ssh",
+        "-i", str(VPS_KEY),
+        "-o", "StrictHostKeyChecking=no",
+        "-o", "ConnectTimeout=10",
+        VPS_HOST,
+        f'openclaw agent --session-id {session_id} --message {repr(prompt)} 2>&1',
+    ]
+
+    try:
+        result = subprocess.run(
+            ssh_cmd,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+
+        output = result.stdout.strip()
+        if result.returncode != 0:
+            error = result.stderr.strip() or output
+            return {"status": "error", "response": f"exit {result.returncode}: {error}"}
+
+        return {"status": "ok", "response": output}
+
+    except subprocess.TimeoutExpired:
+        return {"status": "timeout", "response": f"Timed out after {TIMEOUT_SECONDS}s"}
+    except Exception as e:
+        return {"status": "error", "response": str(e)}
+
+
+def run_tests():
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    csv_path = OUTPUT_DIR / f"test-results-{timestamp}.csv"
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Verify SSH connectivity first
+    print("Verifying SSH connection...")
+    check = subprocess.run(
+        ["ssh", "-i", str(VPS_KEY), "-o", "ConnectTimeout=5", VPS_HOST, "echo ok"],
+        capture_output=True, text=True, timeout=15,
+    )
+    if check.stdout.strip() != "ok":
+        print(f"SSH connection failed: {check.stderr}", file=sys.stderr)
+        sys.exit(1)
+    print("SSH connection verified.\n")
+
+    # Each test gets its own session so they don't share context
+    session_prefix = f"sageox-test-{timestamp}"
+
+    results = []
+    total = len(TEST_CASES)
+
+    for i, (name, prompt, expected) in enumerate(TEST_CASES, 1):
+        session_id = f"{session_prefix}-{name}"
+        print(f"[{i}/{total}] {name}")
+        print(f"  Prompt: {prompt}")
+        print(f"  Expected: {expected}")
+        print(f"  Session: {session_id}")
+
+        start = time.time()
+        resp = send_prompt(prompt, session_id)
+        elapsed = round(time.time() - start, 1)
+
+        status = resp["status"]
+        response_text = resp["response"]
+
+        # Truncate for display
+        preview = response_text[:300].replace("\n", " ")
+        print(f"  Status: {status} ({elapsed}s)")
+        print(f"  Response: {preview}")
+        print()
+
+        results.append({
+            "test_name": name,
+            "prompt": prompt,
+            "expected": expected,
+            "status": status,
+            "response_time_s": elapsed,
+            "response": response_text,
+            "timestamp": datetime.now().isoformat(),
+        })
+
+        # Delay between tests so sessions don't collide
+        if i < total:
+            time.sleep(5)
+
+    # Write CSV
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "test_name", "prompt", "expected", "status",
+                "response_time_s", "response", "timestamp",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(results)
+
+    # Print summary
+    print("=" * 60)
+    print(f"Results saved to: {csv_path}")
+    print(f"Total tests: {total}")
+    ok = sum(1 for r in results if r["status"] == "ok")
+    errors = sum(1 for r in results if r["status"] == "error")
+    timeouts = sum(1 for r in results if r["status"] == "timeout")
+    print(f"OK: {ok}  Errors: {errors}  Timeouts: {timeouts}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
## Summary

- Adds a single unified `sageox` OpenClaw skill with 8 capabilities, replacing the separate `sageox-distill` and `sageox-summary` skills
- Capabilities: query, coworkers, distill, distill-pipeline, summary, glance, catchup, import/export
- Thin SKILL.md intent router (~1,250 tokens) with detailed reference docs loaded on demand
- Repo manifest (`sageox-distill-repos.json`) as central context anchor — all ox commands `cd` to a manifest repo before running
- Includes deploy script for VPS testing and Python batch test runner

## Capabilities

| Capability | What it does |
|---|---|
| **Query** | Search team discussions, docs, sessions via `ox query` |
| **Coworkers** | List, load, create, remove expert AI agents via `ox coworker` |
| **Distill** | Interactive single-repo distillation via `ox distill` |
| **Distill Pipeline** | Multi-repo automated sync + index + distill |
| **Summary** | Cross-team 24h summary generation via `claude -p` |
| **Glance** | Real-time AI coworker activity via `ox glance` |
| **Catchup** | Structured briefing after being away (orchestrated) |
| **Import/Export** | Import docs/recordings, export knowledge as local files |

## Test plan

- [x] Linter passes clean (0 critical, 0 warnings)
- [x] SKILL.md under 3,000 token limit
- [x] Deployed to VPS OpenClaw instance via rsync
- [x] Batch tested all 10 test cases via `openclaw agent --session-id` — 10/10 passing
- [x] Verified skill routing, prerequisites gate, multi-team handling, and manifest management

Co-Authored-By: [SageOx](https://github.com/SageOx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SageOx toolkit: query team knowledge, manage AI coworkers, generate summaries and catch-ups, distill insights, and import/export content.
* **Documentation**
  * Comprehensive guides for setup, workflows (distill, glance, query, import/export, summary, catchup, coworkers) and templates for summaries/catchups.
* **Tools/Scripts**
  * Installer/updater for core CLI, deploy-to-VPS, state/update utilities, and selection helpers.
* **Tests**
  * Added a standalone test runner for validating skill prompts and connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->