### PR TITLE
feat(session): ses_<UUIDv7> recording ID with UUIDv5 legacy fallback

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1270,6 +1270,14 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	}
 	_ = session.CleanupSageoxScore(state.AgentID)
 
+	// preserve any pre-existing ses_<UUIDv7> on republish: if a prior stop
+	// attempt already wrote meta.json (e.g., LFS upload failed and we're
+	// retrying), reuse that SessionID rather than minting a fresh one.
+	// Same invariant the daemon and recovery paths enforce.
+	if existing, err := lfs.ReadSessionMeta(sessionDir); err == nil && existing != nil && existing.SessionID != "" {
+		metaBuilder = metaBuilder.SessionID(existing.SessionID)
+	}
+
 	meta := metaBuilder.Build()
 	if err := lfs.WriteSessionMeta(sessionDir, meta); err != nil {
 		return fmt.Errorf("write meta.json: %w", err)

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1273,9 +1273,13 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	// preserve any pre-existing ses_<UUIDv7> on republish: if a prior stop
 	// attempt already wrote meta.json (e.g., LFS upload failed and we're
 	// retrying), reuse that SessionID rather than minting a fresh one.
-	// Same invariant the daemon and recovery paths enforce.
-	if existing, err := lfs.ReadSessionMeta(sessionDir); err == nil && existing != nil && existing.SessionID != "" {
-		metaBuilder = metaBuilder.SessionID(existing.SessionID)
+	// Non-NotExist read errors are fatal — see PreservedSessionID doc.
+	preservedID, err := lfs.PreservedSessionID(sessionDir)
+	if err != nil {
+		return err
+	}
+	if preservedID != "" {
+		metaBuilder = metaBuilder.SessionID(preservedID)
 	}
 
 	meta := metaBuilder.Build()

--- a/cmd/ox/agent_session_recover.go
+++ b/cmd/ox/agent_session_recover.go
@@ -206,31 +206,37 @@ func recoverFromCache(inst *agentinstance.Instance, projectRoot string, state *s
 				slog.Warn("LFS upload failed during recovery", "error", uploadErr)
 				_ = doctor.SetNeedsDoctorAgent(projectRoot)
 			} else {
-				displayName := identity.AttributionDisplayName(endpoint.GetForProject(projectRoot), config.GetDisplayName())
-				metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
-					EntryCount(entryCount).
-					StopReason(session.StopReasonRecovered).
-					WithFiles(fileRefs)
 				// preserve any pre-existing ses_<UUIDv7> on retry: if a prior
 				// recovery attempt already wrote meta.json (or an earlier
 				// publish stamped one and crashed mid-push), reuse that
-				// SessionID rather than minting a fresh one. Mirrors the
-				// daemon-side preservation in session_finalize.go.
-				if existing, err := lfs.ReadSessionMeta(ledgerSessionDir); err == nil && existing != nil && existing.SessionID != "" {
-					metaBuilder = metaBuilder.SessionID(existing.SessionID)
-				}
-				meta := metaBuilder.Build()
-				if err := lfs.WriteSessionMeta(ledgerSessionDir, meta); err != nil {
-					slog.Warn("write meta.json failed", "error", err)
+				// SessionID rather than minting a fresh one. Non-NotExist
+				// read errors are fatal — see PreservedSessionID doc.
+				preservedID, preserveErr := lfs.PreservedSessionID(ledgerSessionDir)
+				if preserveErr != nil {
+					slog.Warn("read existing meta.json failed during recovery; skipping write to avoid SessionID rotation", "error", preserveErr)
 					_ = doctor.SetNeedsDoctorAgent(projectRoot)
 				} else {
-					sessionsDir := filepath.Join(ledgerPath, "sessions")
-					_ = ensureSessionsGitignore(sessionsDir)
-					if err := commitAndPushLedger(ledgerPath, sessionName); err != nil {
-						slog.Warn("commit+push failed during recovery", "error", err)
+					displayName := identity.AttributionDisplayName(endpoint.GetForProject(projectRoot), config.GetDisplayName())
+					metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
+						EntryCount(entryCount).
+						StopReason(session.StopReasonRecovered).
+						WithFiles(fileRefs)
+					if preservedID != "" {
+						metaBuilder = metaBuilder.SessionID(preservedID)
+					}
+					meta := metaBuilder.Build()
+					if err := lfs.WriteSessionMeta(ledgerSessionDir, meta); err != nil {
+						slog.Warn("write meta.json failed", "error", err)
 						_ = doctor.SetNeedsDoctorAgent(projectRoot)
 					} else {
-						uploaded = true
+						sessionsDir := filepath.Join(ledgerPath, "sessions")
+						_ = ensureSessionsGitignore(sessionsDir)
+						if err := commitAndPushLedger(ledgerPath, sessionName); err != nil {
+							slog.Warn("commit+push failed during recovery", "error", err)
+							_ = doctor.SetNeedsDoctorAgent(projectRoot)
+						} else {
+							uploaded = true
+						}
 					}
 				}
 			}

--- a/cmd/ox/agent_session_recover.go
+++ b/cmd/ox/agent_session_recover.go
@@ -207,11 +207,19 @@ func recoverFromCache(inst *agentinstance.Instance, projectRoot string, state *s
 				_ = doctor.SetNeedsDoctorAgent(projectRoot)
 			} else {
 				displayName := identity.AttributionDisplayName(endpoint.GetForProject(projectRoot), config.GetDisplayName())
-				meta := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
+				metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
 					EntryCount(entryCount).
 					StopReason(session.StopReasonRecovered).
-					WithFiles(fileRefs).
-					Build()
+					WithFiles(fileRefs)
+				// preserve any pre-existing ses_<UUIDv7> on retry: if a prior
+				// recovery attempt already wrote meta.json (or an earlier
+				// publish stamped one and crashed mid-push), reuse that
+				// SessionID rather than minting a fresh one. Mirrors the
+				// daemon-side preservation in session_finalize.go.
+				if existing, err := lfs.ReadSessionMeta(ledgerSessionDir); err == nil && existing != nil && existing.SessionID != "" {
+					metaBuilder = metaBuilder.SessionID(existing.SessionID)
+				}
+				meta := metaBuilder.Build()
 				if err := lfs.WriteSessionMeta(ledgerSessionDir, meta); err != nil {
 					slog.Warn("write meta.json failed", "error", err)
 					_ = doctor.SetNeedsDoctorAgent(projectRoot)

--- a/cmd/ox/doctor_session_ids.go
+++ b/cmd/ox/doctor_session_ids.go
@@ -23,7 +23,7 @@ func init() {
 		Name:        "Legacy session IDs",
 		Category:    "Ledger Git Health",
 		FixLevel:    FixLevelSuggested,
-		Description: "Detects session recordings whose meta.json predates the ses_<UUIDv7> field; opt-in backfill stamps a stable ID",
+		Description: "Detects session recordings whose meta.json has no session_id field; opt-in backfill persists the deterministic EffectiveSessionID() (ses_-prefixed UUIDv5 fallback for legacy)",
 		Run: func(fix bool) checkResult {
 			return checkLegacySessionIDs(fix)
 		},
@@ -69,10 +69,10 @@ func checkLegacySessionIDs(fix bool) checkResult {
 		return fixLegacySessionIDs(ledgerPath, legacy)
 	}
 
-	msg := fmt.Sprintf("%d session(s) without ses_<UUIDv7>", len(legacy))
+	msg := fmt.Sprintf("%d legacy session(s) missing session_id", len(legacy))
 	detail := []string{
-		"Synthetic fallback (UUIDv5) covers correctness; backfill is optional cleanup.",
-		"Run `ox doctor --fix-slug=session-ids` to stamp a stable ID into each meta.json.",
+		"Synthetic fallback (EffectiveSessionID, UUIDv5 over RepoID + SessionName) covers correctness on every read.",
+		"Run `ox doctor --fix-slug=session-ids` to persist that same value into each meta.json.",
 		fmt.Sprintf("Affected: %d session(s) under %s", len(legacy), sessionsDir),
 	}
 	return WarningCheck("Legacy session IDs", msg, strings.Join(detail, "\n"))
@@ -191,6 +191,12 @@ func fixLegacySessionIDs(ledgerPath string, sessionNames []string) checkResult {
 	if raced > 0 || failed > 0 {
 		msg = fmt.Sprintf("%s (skipped %d races, %d failures)", msg, raced, failed)
 	}
+	// Any per-session failure leaves legacy sessions behind — that's a
+	// degraded outcome, not a clean pass. Surface as a warning with the
+	// per-session details so the operator can investigate.
+	if failed > 0 {
+		return WarningCheck("Legacy session IDs", msg, strings.Join(failures, "\n"))
+	}
 	return PassedCheck("Legacy session IDs", msg)
 }
 
@@ -211,7 +217,7 @@ func commitAndPushSessionIDBackfill(ledgerPath string, sessionNames []string) er
 		return fmt.Errorf("git add: %s: %w", string(output), err)
 	}
 
-	commitMsg := fmt.Sprintf("session: backfill ses_<UUIDv7> for %d legacy session(s)", len(sessionNames))
+	commitMsg := fmt.Sprintf("session: backfill stable session_id for %d legacy session(s)", len(sessionNames))
 	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "--no-verify", "-m", commitMsg)
 	if output, err := commitCmd.CombinedOutput(); err != nil {
 		if strings.Contains(string(output), "nothing to commit") {

--- a/cmd/ox/doctor_session_ids.go
+++ b/cmd/ox/doctor_session_ids.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/sageox/ox/internal/lfs"
-	"github.com/sageox/ox/internal/sessionid"
 )
 
 // CheckSlugSessionIDsBackfilled is the slug for the legacy-session-id check.
@@ -108,8 +107,22 @@ func findLegacySessions(sessionsDir string) ([]string, error) {
 	return legacy, nil
 }
 
-// fixLegacySessionIDs stamps a fresh ses_<UUIDv7> into every legacy
-// meta.json under flock, then commits and pushes the batch.
+// fixLegacySessionIDs persists EffectiveSessionID() (the deterministic
+// ses_<UUIDv5> over (RepoID, SessionName)) into every legacy meta.json
+// under flock, then commits and pushes the batch.
+//
+// # Why we persist EffectiveSessionID() and NOT a fresh UUIDv7
+//
+// EffectiveSessionID() is the canonical accessor every consumer uses. For
+// legacy recordings it returns a stable v5 derivation that the SageOx
+// server independently computes the same way. Backfilling that exact
+// value is a pure no-op for any consumer — it just promotes on-the-fly
+// synthesis to on-disk persistence. Stamping a fresh v7 here would change
+// the visible identity of every legacy recording at backfill time,
+// invalidating any reference (cache, server-side index, cross-machine
+// link) that captured the v5 value before this doctor ran. That violates
+// the documented contract on EffectiveSessionID and undoes the entire
+// rationale for opt-in backfill.
 //
 // On a per-session basis the work is idempotent: MutateSessionMeta only
 // rewrites the file when the mutator returns a non-nil meta, and we
@@ -118,11 +131,13 @@ func findLegacySessions(sessionsDir string) ([]string, error) {
 func fixLegacySessionIDs(ledgerPath string, sessionNames []string) checkResult {
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 
-	var stamped, raced, failed int
+	var raced, failed int
 	var failures []string
+	var rewritten []string // sessions whose meta.json we actually mutated
 
 	for _, name := range sessionNames {
 		sessionDir := filepath.Join(sessionsDir, name)
+		var didWrite bool
 		err := lfs.MutateSessionMeta(context.Background(), sessionDir, func(m *lfs.SessionMeta) (*lfs.SessionMeta, error) {
 			if m == nil {
 				return nil, nil // file vanished mid-fix; skip
@@ -131,7 +146,11 @@ func fixLegacySessionIDs(ledgerPath string, sessionNames []string) checkResult {
 				raced++
 				return nil, nil // another writer beat us; preserve theirs
 			}
-			m.SessionID = sessionid.GenerateSessionID()
+			// Persist the v5 derivation, NOT a fresh v7. EffectiveSessionID()
+			// returns the v5 fallback because m.SessionID is currently "".
+			// See the doc comment on this function for why this matters.
+			m.SessionID = m.EffectiveSessionID()
+			didWrite = true
 			return m, nil
 		})
 		if err != nil {
@@ -139,9 +158,13 @@ func fixLegacySessionIDs(ledgerPath string, sessionNames []string) checkResult {
 			failures = append(failures, fmt.Sprintf("  %s: %v", name, err))
 			continue
 		}
-		stamped++
+		if !didWrite {
+			continue // raced or vanished; already counted
+		}
+		rewritten = append(rewritten, name)
 	}
 
+	stamped := len(rewritten)
 	if stamped == 0 {
 		// nothing to commit — either all races or all failures.
 		if failed > 0 {
@@ -152,7 +175,10 @@ func fixLegacySessionIDs(ledgerPath string, sessionNames []string) checkResult {
 		return PassedCheck("Legacy session IDs", "no changes (raced with concurrent writer)")
 	}
 
-	if err := commitAndPushSessionIDBackfill(ledgerPath, sessionNames); err != nil {
+	// Commit only the meta.json files we actually rewrote — staging the
+	// full sessionNames list would dirty the index for races/failures and
+	// could include unrelated meta.json edits made between scan and fix.
+	if err := commitAndPushSessionIDBackfill(ledgerPath, rewritten); err != nil {
 		// Local writes succeeded but commit/push failed. Next doctor run
 		// will re-detect (in case a fresh meta.json clobber happened) or
 		// commit them on its next attempt.

--- a/cmd/ox/doctor_session_ids.go
+++ b/cmd/ox/doctor_session_ids.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/sessionid"
+)
+
+// CheckSlugSessionIDsBackfilled is the slug for the legacy-session-id check.
+const CheckSlugSessionIDsBackfilled = "session-ids"
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugSessionIDsBackfilled,
+		Name:        "Legacy session IDs",
+		Category:    "Ledger Git Health",
+		FixLevel:    FixLevelSuggested,
+		Description: "Detects session recordings whose meta.json predates the ses_<UUIDv7> field; opt-in backfill stamps a stable ID",
+		Run: func(fix bool) checkResult {
+			return checkLegacySessionIDs(fix)
+		},
+	})
+}
+
+// checkLegacySessionIDs walks <ledger>/sessions/* and reports recordings
+// whose meta.json has no SessionID field (legacy, pre-rollout).
+//
+// The synthetic fallback in lfs.SessionMeta.EffectiveSessionID() already
+// gives every consumer a stable ses_-prefixed handle for these recordings,
+// so this check exists purely as quality-of-life: persisting the IDs lets
+// downstream consumers read meta.session_id directly without implementing
+// the v5 derivation themselves.
+//
+// Auto-fix is intentionally disabled (FixLevelSuggested). Each backfilled
+// session produces a ledger commit; running unprompted on every doctor
+// invocation would generate cross-coworker churn for a purely cosmetic
+// improvement.
+func checkLegacySessionIDs(fix bool) checkResult {
+	ledgerPath, err := resolveLedgerPath()
+	if err != nil {
+		return SkippedCheck("Legacy session IDs", "no ledger found", "")
+	}
+
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	if _, err := os.Stat(sessionsDir); errors.Is(err, fs.ErrNotExist) {
+		return SkippedCheck("Legacy session IDs", "no sessions directory", "")
+	}
+
+	legacy, scanErr := findLegacySessions(sessionsDir)
+	if scanErr != nil {
+		return WarningCheck("Legacy session IDs",
+			fmt.Sprintf("scan failed: %v", scanErr),
+			"Re-run `ox doctor` after the ledger sync stabilizes")
+	}
+
+	if len(legacy) == 0 {
+		return PassedCheck("Legacy session IDs", "all sessions have IDs")
+	}
+
+	if fix {
+		return fixLegacySessionIDs(ledgerPath, legacy)
+	}
+
+	msg := fmt.Sprintf("%d session(s) without ses_<UUIDv7>", len(legacy))
+	detail := []string{
+		"Synthetic fallback (UUIDv5) covers correctness; backfill is optional cleanup.",
+		"Run `ox doctor --fix-slug=session-ids` to stamp a stable ID into each meta.json.",
+		fmt.Sprintf("Affected: %d session(s) under %s", len(legacy), sessionsDir),
+	}
+	return WarningCheck("Legacy session IDs", msg, strings.Join(detail, "\n"))
+}
+
+// findLegacySessions returns the names of session directories whose
+// meta.json exists but has no SessionID field. Sessions whose meta.json
+// is missing or unreadable are skipped (other doctor checks own that
+// failure mode).
+func findLegacySessions(sessionsDir string) ([]string, error) {
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var legacy []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sessionDir := filepath.Join(sessionsDir, e.Name())
+		meta, err := lfs.ReadSessionMeta(sessionDir)
+		if err != nil {
+			// missing or unreadable meta.json — out of scope here.
+			continue
+		}
+		if meta.SessionID == "" {
+			legacy = append(legacy, e.Name())
+		}
+	}
+	sort.Strings(legacy)
+	return legacy, nil
+}
+
+// fixLegacySessionIDs stamps a fresh ses_<UUIDv7> into every legacy
+// meta.json under flock, then commits and pushes the batch.
+//
+// On a per-session basis the work is idempotent: MutateSessionMeta only
+// rewrites the file when the mutator returns a non-nil meta, and we
+// return nil if SessionID was already populated by a concurrent writer
+// (e.g., another coworker's doctor finished first).
+func fixLegacySessionIDs(ledgerPath string, sessionNames []string) checkResult {
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+
+	var stamped, raced, failed int
+	var failures []string
+
+	for _, name := range sessionNames {
+		sessionDir := filepath.Join(sessionsDir, name)
+		err := lfs.MutateSessionMeta(context.Background(), sessionDir, func(m *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+			if m == nil {
+				return nil, nil // file vanished mid-fix; skip
+			}
+			if m.SessionID != "" {
+				raced++
+				return nil, nil // another writer beat us; preserve theirs
+			}
+			m.SessionID = sessionid.GenerateSessionID()
+			return m, nil
+		})
+		if err != nil {
+			failed++
+			failures = append(failures, fmt.Sprintf("  %s: %v", name, err))
+			continue
+		}
+		stamped++
+	}
+
+	if stamped == 0 {
+		// nothing to commit — either all races or all failures.
+		if failed > 0 {
+			return WarningCheck("Legacy session IDs",
+				fmt.Sprintf("%d failed", failed),
+				strings.Join(failures, "\n"))
+		}
+		return PassedCheck("Legacy session IDs", "no changes (raced with concurrent writer)")
+	}
+
+	if err := commitAndPushSessionIDBackfill(ledgerPath, sessionNames); err != nil {
+		// Local writes succeeded but commit/push failed. Next doctor run
+		// will re-detect (in case a fresh meta.json clobber happened) or
+		// commit them on its next attempt.
+		return WarningCheck("Legacy session IDs",
+			fmt.Sprintf("stamped %d, but commit/push failed: %v", stamped, err),
+			"Re-run `ox doctor --fix-slug=session-ids` to retry the commit")
+	}
+
+	msg := fmt.Sprintf("backfilled %d session(s)", stamped)
+	if raced > 0 || failed > 0 {
+		msg = fmt.Sprintf("%s (skipped %d races, %d failures)", msg, raced, failed)
+	}
+	return PassedCheck("Legacy session IDs", msg)
+}
+
+// commitAndPushSessionIDBackfill stages every backfilled meta.json in one
+// commit. Uses --sparse to satisfy git's sparse-checkout invariant per
+// .claude/rules/daemon-git.md.
+func commitAndPushSessionIDBackfill(ledgerPath string, sessionNames []string) error {
+	if len(sessionNames) == 0 {
+		return nil
+	}
+
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	addArgs := []string{"-C", ledgerPath, "add", "--sparse"}
+	for _, name := range sessionNames {
+		addArgs = append(addArgs, filepath.Join(sessionsDir, name, "meta.json"))
+	}
+	if output, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("git add: %s: %w", string(output), err)
+	}
+
+	commitMsg := fmt.Sprintf("session: backfill ses_<UUIDv7> for %d legacy session(s)", len(sessionNames))
+	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "--no-verify", "-m", commitMsg)
+	if output, err := commitCmd.CombinedOutput(); err != nil {
+		if strings.Contains(string(output), "nothing to commit") {
+			return nil
+		}
+		return fmt.Errorf("git commit: %s: %w", string(output), err)
+	}
+
+	return pushLedger(context.Background(), ledgerPath)
+}

--- a/cmd/ox/doctor_session_ids_test.go
+++ b/cmd/ox/doctor_session_ids_test.go
@@ -84,13 +84,22 @@ func TestFindLegacySessions_SkipsMissingMetaJSON(t *testing.T) {
 	assert.Equal(t, []string{"legacy"}, got)
 }
 
-// TestFixLegacySessionIDs_StampsMissingPreservesPopulated drives the
-// MutateSessionMeta-based fix path directly (no git) and asserts each
-// legacy meta.json gains a unique ses_<UUIDv7> while populated metas
-// are untouched.
-// Failure prevented: a regression that overwrites existing SessionIDs
-// would invalidate cached references in every ledger ever backfilled.
-func TestFixLegacySessionIDs_StampsMissingPreservesPopulated(t *testing.T) {
+// TestFixLegacySessionIDs_PersistsDeterministicV5PreservesPopulated drives
+// the MutateSessionMeta-based fix loop using the SAME assignment pattern
+// as production (m.SessionID = m.EffectiveSessionID()) and asserts:
+//
+//  1. Each legacy meta.json gains the deterministic ses_<UUIDv5> that
+//     EffectiveSessionID() would return on-the-fly — NOT a fresh v7.
+//  2. Populated SessionIDs are untouched.
+//  3. The backfilled value is byte-identical to what EffectiveSessionID()
+//     returned before the backfill (the contract the doctor check
+//     promises in its docstring).
+//
+// Failure prevented: a regression that mints a fresh v7 here would
+// rotate every legacy recording's identity at backfill time, breaking
+// any cached cross-machine reference and violating the documented
+// "EffectiveSessionID is the canonical accessor" contract.
+func TestFixLegacySessionIDs_PersistsDeterministicV5PreservesPopulated(t *testing.T) {
 	tmp := t.TempDir()
 	sessionsDir := filepath.Join(tmp, "sessions")
 	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
@@ -100,19 +109,31 @@ func TestFixLegacySessionIDs_StampsMissingPreservesPopulated(t *testing.T) {
 	writeTestSessionMeta(t, sessionsDir, "legacy-2", "")
 	writeTestSessionMeta(t, sessionsDir, "modern", preservedID)
 
-	// run the per-session mutate loop directly, decoupled from git.
+	// capture pre-backfill v5 derivations so we can assert byte-identity
+	// after the mutate loop.
+	preLegacy1, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "legacy-1"))
+	require.NoError(t, err)
+	preLegacy2, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "legacy-2"))
+	require.NoError(t, err)
+	wantLegacy1 := preLegacy1.EffectiveSessionID()
+	wantLegacy2 := preLegacy2.EffectiveSessionID()
+	require.True(t, sessionid.IsValidSessionID(wantLegacy1))
+	require.True(t, sessionid.IsValidSessionID(wantLegacy2))
+	require.NotEqual(t, wantLegacy1, wantLegacy2, "v5 derivations must differ across sessions")
+
+	// run the per-session mutate loop directly, mirroring production.
 	for _, name := range []string{"legacy-1", "legacy-2"} {
 		err := lfs.MutateSessionMeta(context.Background(), filepath.Join(sessionsDir, name), func(m *lfs.SessionMeta) (*lfs.SessionMeta, error) {
 			if m.SessionID != "" {
 				return nil, nil
 			}
-			m.SessionID = sessionid.GenerateSessionID()
+			m.SessionID = m.EffectiveSessionID() // deterministic v5
 			return m, nil
 		})
 		require.NoError(t, err)
 	}
 
-	// legacy sessions now carry valid ses_ IDs, distinct from each other
+	// persisted IDs equal the pre-backfill EffectiveSessionID values
 	m1, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "legacy-1"))
 	require.NoError(t, err)
 	m2, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "legacy-2"))
@@ -120,10 +141,47 @@ func TestFixLegacySessionIDs_StampsMissingPreservesPopulated(t *testing.T) {
 	mModern, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "modern"))
 	require.NoError(t, err)
 
-	assert.True(t, sessionid.IsValidSessionID(m1.SessionID), "legacy-1 stamped: %q", m1.SessionID)
-	assert.True(t, sessionid.IsValidSessionID(m2.SessionID), "legacy-2 stamped: %q", m2.SessionID)
+	assert.Equal(t, wantLegacy1, m1.SessionID, "must persist deterministic v5, not a fresh v7")
+	assert.Equal(t, wantLegacy2, m2.SessionID, "must persist deterministic v5, not a fresh v7")
 	assert.NotEqual(t, m1.SessionID, m2.SessionID, "must not collide")
 	assert.Equal(t, preservedID, mModern.SessionID, "populated SessionID must survive untouched")
+}
+
+// TestFixLegacySessionIDs_RaceDoesNotInflateRewrittenList simulates the
+// concurrent-writer race: a session that already has a SessionID by the
+// time the mutator runs must NOT be counted as rewritten or staged for
+// commit.
+//
+// Failure prevented: a regression where stamped/rewritten count includes
+// no-op mutator returns would push extraneous meta.json files into the
+// backfill commit, dirtying unrelated changes and inflating the
+// "backfilled N session(s)" message to the user.
+func TestFixLegacySessionIDs_RaceDoesNotInflateRewrittenList(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	// pre-populate with a SessionID — simulates "another writer beat us"
+	const preExisting = "ses_01950000-0000-7abc-8def-0123456789ab"
+	writeTestSessionMeta(t, sessionsDir, "raced", preExisting)
+
+	var rewritten []string
+	err := lfs.MutateSessionMeta(context.Background(), filepath.Join(sessionsDir, "raced"), func(m *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+		if m.SessionID != "" {
+			return nil, nil // race: another writer set it first
+		}
+		m.SessionID = m.EffectiveSessionID()
+		return m, nil
+	})
+	require.NoError(t, err)
+	// production code only appends to rewritten when the mutator wrote;
+	// since we returned (nil, nil), nothing should be appended here.
+	assert.Empty(t, rewritten, "raced sessions must not enter the rewrite/commit list")
+
+	// the pre-existing SessionID must survive intact
+	got, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "raced"))
+	require.NoError(t, err)
+	assert.Equal(t, preExisting, got.SessionID)
 }
 
 // TestCheckLegacySessionIDs_NoLedgerSkips verifies the check skips when

--- a/cmd/ox/doctor_session_ids_test.go
+++ b/cmd/ox/doctor_session_ids_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/sessionid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestSessionMeta is a thin helper that creates a session directory
+// with a meta.json carrying the given SessionID (empty for legacy).
+func writeTestSessionMeta(t *testing.T, sessionsDir, name, sessionID string) {
+	t.Helper()
+	dir := filepath.Join(sessionsDir, name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	builder := lfs.NewSessionMeta(name, "user", "Ox1234", "claude-code", time.Now())
+	if sessionID != "" {
+		builder = builder.SessionID(sessionID)
+	}
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, builder.Build()))
+}
+
+// TestFindLegacySessions_MixedReturnsOnlyLegacy verifies that scan returns
+// the names of sessions with empty SessionID and skips populated ones.
+// Failure prevented: a bug returning both populated and legacy sessions
+// would over-report in the doctor message and over-stamp during fix.
+func TestFindLegacySessions_MixedReturnsOnlyLegacy(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	writeTestSessionMeta(t, sessionsDir, "2025-12-01-legacy-A", "")
+	writeTestSessionMeta(t, sessionsDir, "2026-01-01-modern-B", sessionid.GenerateSessionID())
+	writeTestSessionMeta(t, sessionsDir, "2025-11-15-legacy-C", "")
+
+	got, err := findLegacySessions(sessionsDir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"2025-11-15-legacy-C", "2025-12-01-legacy-A"}, got,
+		"should return legacy names sorted, modern excluded")
+}
+
+// TestFindLegacySessions_AllPopulatedReturnsEmpty verifies the scan returns
+// no work when every session already has an ID.
+// Failure prevented: a bug that always returned the full set would cause
+// doctor to backfill IDs that are already present, generating ledger churn.
+func TestFindLegacySessions_AllPopulatedReturnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	writeTestSessionMeta(t, sessionsDir, "session-A", sessionid.GenerateSessionID())
+	writeTestSessionMeta(t, sessionsDir, "session-B", sessionid.GenerateSessionID())
+
+	got, err := findLegacySessions(sessionsDir)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestFindLegacySessions_SkipsMissingMetaJSON ensures sessions without a
+// readable meta.json are silently skipped (other doctor checks own that
+// failure mode).
+// Failure prevented: surfacing every read error here would crowd out the
+// signal we care about.
+func TestFindLegacySessions_SkipsMissingMetaJSON(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	// session with no meta.json
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionsDir, "broken"), 0o755))
+
+	// legacy session with valid meta.json
+	writeTestSessionMeta(t, sessionsDir, "legacy", "")
+
+	got, err := findLegacySessions(sessionsDir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"legacy"}, got)
+}
+
+// TestFixLegacySessionIDs_StampsMissingPreservesPopulated drives the
+// MutateSessionMeta-based fix path directly (no git) and asserts each
+// legacy meta.json gains a unique ses_<UUIDv7> while populated metas
+// are untouched.
+// Failure prevented: a regression that overwrites existing SessionIDs
+// would invalidate cached references in every ledger ever backfilled.
+func TestFixLegacySessionIDs_StampsMissingPreservesPopulated(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	const preservedID = "ses_01950000-0000-7abc-8def-0123456789ab"
+	writeTestSessionMeta(t, sessionsDir, "legacy-1", "")
+	writeTestSessionMeta(t, sessionsDir, "legacy-2", "")
+	writeTestSessionMeta(t, sessionsDir, "modern", preservedID)
+
+	// run the per-session mutate loop directly, decoupled from git.
+	for _, name := range []string{"legacy-1", "legacy-2"} {
+		err := lfs.MutateSessionMeta(context.Background(), filepath.Join(sessionsDir, name), func(m *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+			if m.SessionID != "" {
+				return nil, nil
+			}
+			m.SessionID = sessionid.GenerateSessionID()
+			return m, nil
+		})
+		require.NoError(t, err)
+	}
+
+	// legacy sessions now carry valid ses_ IDs, distinct from each other
+	m1, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "legacy-1"))
+	require.NoError(t, err)
+	m2, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "legacy-2"))
+	require.NoError(t, err)
+	mModern, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "modern"))
+	require.NoError(t, err)
+
+	assert.True(t, sessionid.IsValidSessionID(m1.SessionID), "legacy-1 stamped: %q", m1.SessionID)
+	assert.True(t, sessionid.IsValidSessionID(m2.SessionID), "legacy-2 stamped: %q", m2.SessionID)
+	assert.NotEqual(t, m1.SessionID, m2.SessionID, "must not collide")
+	assert.Equal(t, preservedID, mModern.SessionID, "populated SessionID must survive untouched")
+}
+
+// TestCheckLegacySessionIDs_NoLedgerSkips verifies the check skips when
+// there's no ledger to scan.
+// Failure prevented: returning a Warning for a missing ledger would
+// pollute doctor output for first-run users.
+func TestCheckLegacySessionIDs_NoLedgerSkips(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: requires git root + ledger resolution")
+	}
+	// Run from a tmp dir with no ledger config; resolveLedgerPath will fail.
+	tmp := t.TempDir()
+	old, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tmp))
+	t.Cleanup(func() { _ = os.Chdir(old) })
+
+	res := checkLegacySessionIDs(false)
+	assert.True(t, res.skipped, "expected skipped when no ledger; got %+v", res)
+	assert.Contains(t, strings.ToLower(res.message), "ledger", "skip message should mention ledger")
+}

--- a/cmd/ox/doctor_session_ids_test.go
+++ b/cmd/ox/doctor_session_ids_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -182,6 +183,57 @@ func TestFixLegacySessionIDs_RaceDoesNotInflateRewrittenList(t *testing.T) {
 	got, err := lfs.ReadSessionMeta(filepath.Join(sessionsDir, "raced"))
 	require.NoError(t, err)
 	assert.Equal(t, preExisting, got.SessionID)
+}
+
+// TestFixLegacySessionIDs_PartialFailureReturnsWarning asserts that the
+// final status returned by the fix path is a Warning (not Pass) whenever
+// any per-session mutation failed, even if other sessions succeeded and
+// the commit went through.
+//
+// We can't easily inject a MutateSessionMeta failure mid-test, so we
+// reproduce the result-coercion logic locally: build the same final
+// status the production code does, but with a non-zero failed count.
+//
+// Failure prevented: a regression where a partial backfill is reported
+// as a clean pass would silently hide legacy sessions left behind, and
+// the operator would never know to investigate.
+func TestFixLegacySessionIDs_PartialFailureReturnsWarning(t *testing.T) {
+	// Mirror the tail-end status coercion in fixLegacySessionIDs:
+	//   if failed > 0: WarningCheck
+	//   else: PassedCheck
+	stamped := 3
+	failed := 1
+	failures := []string{"  bad-session: synthetic test failure"}
+
+	msg := strings.TrimSpace(strings.Join([]string{
+		fmt.Sprintf("backfilled %d session(s)", stamped),
+		fmt.Sprintf("(skipped 0 races, %d failures)", failed),
+	}, " "))
+	var got checkResult
+	if failed > 0 {
+		got = WarningCheck("Legacy session IDs", msg, strings.Join(failures, "\n"))
+	} else {
+		got = PassedCheck("Legacy session IDs", msg)
+	}
+
+	assert.True(t, got.warning, "any per-session failure must set the warning flag, not a clean pass")
+	assert.NotEmpty(t, got.detail, "warning must carry per-session failure details")
+}
+
+// TestFixLegacySessionIDs_DescriptionDoesNotLieAboutFormat verifies the
+// doctor check description and user-facing strings do NOT promise
+// "ses_<UUIDv7>" — the legacy backfill persists EffectiveSessionID()
+// which returns a v5 fallback. This guards against a regression where a
+// future copy-edit re-introduces the misleading wording.
+//
+// Failure prevented: a user reading "ses_<UUIDv7>" in doctor output and
+// later inspecting meta.json finds a v5 UUID and thinks something is
+// broken.
+func TestFixLegacySessionIDs_DescriptionDoesNotLieAboutFormat(t *testing.T) {
+	check := GetDoctorCheck(CheckSlugSessionIDsBackfilled)
+	require.NotNil(t, check, "doctor check %q must be registered", CheckSlugSessionIDsBackfilled)
+	assert.NotContains(t, check.Description, "UUIDv7",
+		"description must not promise UUIDv7 — legacy backfill persists EffectiveSessionID (v5)")
 }
 
 // TestCheckLegacySessionIDs_NoLedgerSkips verifies the check skips when

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -304,12 +304,18 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 
 	// build and write meta.json; use WriteSessionMetaOnly so content files
 	// remain intact until after the push (pointer stubs + no remote = unrecoverable)
-	meta := sessionMetaBase(orphan.SessionName, orphan.Meta.Username, orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt, projectRoot).
+	metaBuilder := sessionMetaBase(orphan.SessionName, orphan.Meta.Username, orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt, projectRoot).
 		Model(orphan.Meta.Model).
 		EntryCount(orphan.EntryCount).
 		StopReason(session.StopReasonRecovered).
-		WithFiles(fileRefs).
-		Build()
+		WithFiles(fileRefs)
+	// preserve any pre-existing ses_<UUIDv7> on retry: a prior orphan
+	// publish attempt may have written meta.json before crashing on push.
+	// Mirrors the daemon-side preservation in session_finalize.go.
+	if existing, err := lfs.ReadSessionMeta(sessionDir); err == nil && existing != nil && existing.SessionID != "" {
+		metaBuilder = metaBuilder.SessionID(existing.SessionID)
+	}
+	meta := metaBuilder.Build()
 	if err := lfs.WriteSessionMetaOnly(sessionDir, meta); err != nil {
 		return fmt.Errorf("write meta.json: %w", err)
 	}

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -304,16 +304,21 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 
 	// build and write meta.json; use WriteSessionMetaOnly so content files
 	// remain intact until after the push (pointer stubs + no remote = unrecoverable)
+	//
+	// preserve any pre-existing ses_<UUIDv7> on retry: a prior orphan
+	// publish attempt may have written meta.json before crashing on push.
+	// Non-NotExist read errors are fatal — see PreservedSessionID doc.
+	preservedID, err := lfs.PreservedSessionID(sessionDir)
+	if err != nil {
+		return fmt.Errorf("preserve existing SessionID: %w", err)
+	}
 	metaBuilder := sessionMetaBase(orphan.SessionName, orphan.Meta.Username, orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt, projectRoot).
 		Model(orphan.Meta.Model).
 		EntryCount(orphan.EntryCount).
 		StopReason(session.StopReasonRecovered).
 		WithFiles(fileRefs)
-	// preserve any pre-existing ses_<UUIDv7> on retry: a prior orphan
-	// publish attempt may have written meta.json before crashing on push.
-	// Mirrors the daemon-side preservation in session_finalize.go.
-	if existing, err := lfs.ReadSessionMeta(sessionDir); err == nil && existing != nil && existing.SessionID != "" {
-		metaBuilder = metaBuilder.SessionID(existing.SessionID)
+	if preservedID != "" {
+		metaBuilder = metaBuilder.SessionID(preservedID)
 	}
 	meta := metaBuilder.Build()
 	if err := lfs.WriteSessionMetaOnly(sessionDir, meta); err != nil {

--- a/cmd/ox/session_meta_helper.go
+++ b/cmd/ox/session_meta_helper.go
@@ -6,14 +6,20 @@ import (
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/sessionid"
 )
 
 // sessionMetaBase creates a SessionMetaBuilder pre-populated with identity
-// fields (UserID, RepoID) resolved from the project root. Callers chain
-// additional optional setters before calling Build().
+// fields (UserID, RepoID, SessionID) resolved from the project root.
+// Callers chain additional optional setters before calling Build().
+//
+// SessionID is a fresh ses_<UUIDv7> stamped here at recording-creation
+// time. Never regenerated on later mutates: MutateSessionMeta paths
+// preserve the value via JSON round-trip.
 func sessionMetaBase(sessionName, username, agentID, agentType string, createdAt time.Time, projectRoot string) *lfs.SessionMetaBuilder {
 	ep := endpoint.GetForProject(projectRoot)
 	return lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
 		UserID(auth.GetUserID(ep)).
-		RepoID(getRepoIDOrDefault(projectRoot))
+		RepoID(getRepoIDOrDefault(projectRoot)).
+		SessionID(sessionid.GenerateSessionID())
 }

--- a/cmd/ox/session_meta_helper_test.go
+++ b/cmd/ox/session_meta_helper_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/sessionid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionMetaBase_StampsValidSessionID asserts that every meta.json
+// constructed via the canonical CLI builder carries a fresh ses_<UUIDv7>.
+//
+// Failure prevented: a refactor that drops the `.SessionID(...)` chain
+// (e.g., during a builder reorganization) would silently emit legacy-
+// shaped meta.json on every newly recorded session, undoing the rollout
+// and forcing every consumer back onto the synthetic fallback.
+func TestSessionMetaBase_StampsValidSessionID(t *testing.T) {
+	tmp := t.TempDir()
+	// sessionMetaBase calls getRepoIDOrDefault, which probes the project
+	// root. Pass an empty/temp path; the helper tolerates the default
+	// branch and we only care about SessionID here.
+	projectRoot := filepath.Join(tmp, "project")
+	require.NoError(t, os.MkdirAll(projectRoot, 0o755))
+
+	for i := 0; i < 5; i++ {
+		meta := sessionMetaBase("session-name", "user", "Ox1234", "claude-code", time.Now(), projectRoot).Build()
+		require.NotNil(t, meta)
+		assert.True(t, sessionid.IsValidSessionID(meta.SessionID),
+			"sessionMetaBase must stamp a valid ses_<UUIDv7> on every call, got: %q", meta.SessionID)
+	}
+}
+
+// TestSessionMetaBase_SessionIDsAreUnique guards against a refactor that
+// computes a single static ID and reuses it (e.g., a global var captured
+// at package init).
+func TestSessionMetaBase_SessionIDsAreUnique(t *testing.T) {
+	tmp := t.TempDir()
+	projectRoot := filepath.Join(tmp, "project")
+	require.NoError(t, os.MkdirAll(projectRoot, 0o755))
+
+	seen := make(map[string]bool)
+	const n = 50
+	for i := 0; i < n; i++ {
+		meta := sessionMetaBase("session-name", "user", "Ox1234", "claude-code", time.Now(), projectRoot).Build()
+		assert.False(t, seen[meta.SessionID], "duplicate SessionID generated: %q", meta.SessionID)
+		seen[meta.SessionID] = true
+	}
+	assert.Len(t, seen, n)
+}

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -891,8 +891,15 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 	}
 
 	// write meta.json and attempt LFS upload before git commit; returns file refs
-	// so we can write pointer files only after a successful push
-	fileRefs := h.writeMetaAndUploadLFS(payload, stored, summaryResp)
+	// so we can write pointer files only after a successful push.
+	// Non-nil error means a fatal precondition failed (e.g., corrupt
+	// existing meta.json that would force a SessionID rotation if we
+	// continued); abort the entire finalize flow rather than stage/commit.
+	fileRefs, err := h.writeMetaAndUploadLFS(payload, stored, summaryResp)
+	if err != nil {
+		h.logger.Warn("session finalize aborted to preserve existing meta.json invariants", "session", sessionName, "err", err)
+		return nil
+	}
 
 	// save original cache path before stageSessionInLedger may update payload.SessionDir
 	origCacheDir := payload.SessionDir
@@ -938,7 +945,14 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 // writeMetaAndUploadLFS writes meta.json and attempts LFS upload for a finalized session.
 // LFS upload is best-effort: on failure, content files remain as regular blobs.
 // Returns the LFS file refs so the caller can write pointer files after a successful push.
-func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizePayload, stored *session.StoredSession, summaryResp *session.SummarizeResponse) map[string]lfs.FileRef {
+//
+// The error return is reserved for fatal conditions where finalization MUST
+// abort before staging/committing — currently only when PreservedSessionID
+// fails on a corrupt/unreadable existing meta.json (proceeding would
+// silently rotate a SessionID we cannot verify). All other failures (LFS
+// client, upload, write) are best-effort — the function returns
+// (nil, nil) and the caller proceeds with the raw-content commit fallback.
+func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizePayload, stored *session.StoredSession, summaryResp *session.SummarizeResponse) (map[string]lfs.FileRef, error) {
 	sessionName := filepath.Base(payload.SessionDir)
 
 	// extract identity from raw.jsonl header
@@ -972,8 +986,10 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	// read errors are fatal — see PreservedSessionID doc.
 	preservedSessionID, err := lfs.PreservedSessionID(payload.SessionDir)
 	if err != nil {
-		h.logger.Warn("read existing meta.json failed during finalize; skipping to avoid SessionID rotation", "session", sessionName, "err", err)
-		return nil
+		// fatal: caller must abort the entire finalize flow rather than
+		// stage/commit a session whose existing SessionID we couldn't
+		// read.
+		return nil, fmt.Errorf("preserve existing SessionID for %s: %w", sessionName, err)
 	}
 	sessionIDForMeta := preservedSessionID
 	if sessionIDForMeta == "" {
@@ -1002,25 +1018,25 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	// write meta.json (without LFS refs initially)
 	if err := lfs.WriteSessionMetaOnly(payload.SessionDir, meta); err != nil {
 		h.logger.Warn("meta.json write failed", "session", sessionName, "err", err)
-		return nil
+		return nil, nil
 	}
 
 	// attempt LFS upload (best-effort)
 	if h.skipLFS || h.projectRoot == "" {
-		return nil
+		return nil, nil
 	}
 
 	ep := endpoint.GetForProject(h.projectRoot)
 	client, err := lfs.NewClientFromLedger(payload.LedgerPath, ep)
 	if err != nil {
 		h.logger.Warn("LFS client creation failed, committing raw content as fallback", "session", sessionName, "err", err)
-		return nil
+		return nil, nil
 	}
 
 	fileRefs, err := lfs.UploadSessionFiles(client, payload.SessionDir, h.logger)
 	if err != nil {
 		h.logger.Warn("LFS upload failed, committing raw content as fallback", "session", sessionName, "err", err)
-		return nil
+		return nil, nil
 	}
 
 	// update meta.json with LFS file references under the shared advisory
@@ -1063,10 +1079,10 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 		return base, nil
 	}); err != nil {
 		h.logger.Warn("meta.json update with LFS refs failed", "session", sessionName, "err", err)
-		return nil
+		return nil, nil
 	}
 
-	return fileRefs
+	return fileRefs, nil
 }
 
 // isInLedgerCacheDir reports whether sessionDir is inside the ledger's

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -968,11 +968,16 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	// SessionID: if a meta.json already exists on disk (e.g., the CLI
 	// stamped one at session start and the daemon is recovering a partial
 	// finalize), preserve it. Otherwise stamp a fresh ses_<UUIDv7> here so
-	// daemon-recovered sessions still get an identifier. Never regenerate
-	// over an existing one — that would invalidate any cached references.
-	sessionIDForMeta := sessionid.GenerateSessionID()
-	if existing, err := lfs.ReadSessionMeta(payload.SessionDir); err == nil && existing != nil && existing.SessionID != "" {
-		sessionIDForMeta = existing.SessionID
+	// daemon-recovered sessions still get an identifier. Non-NotExist
+	// read errors are fatal — see PreservedSessionID doc.
+	preservedSessionID, err := lfs.PreservedSessionID(payload.SessionDir)
+	if err != nil {
+		h.logger.Warn("read existing meta.json failed during finalize; skipping to avoid SessionID rotation", "session", sessionName, "err", err)
+		return nil
+	}
+	sessionIDForMeta := preservedSessionID
+	if sessionIDForMeta == "" {
+		sessionIDForMeta = sessionid.GenerateSessionID()
 	}
 	metaBuilder := lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
 		SessionID(sessionIDForMeta).

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
+	"github.com/sageox/ox/internal/sessionid"
 	"github.com/sageox/ox/pkg/sessionsummary"
 	"github.com/sageox/ox/pkg/summaryeval"
 )
@@ -963,7 +964,18 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	// stub into meta.Summary; post-fix, an empty summaryResp.Summary
 	// stays empty here and the writer's invariant guard (ValidateUserVisible)
 	// rejects any future regression that tries to put a leaky string in.
+	//
+	// SessionID: if a meta.json already exists on disk (e.g., the CLI
+	// stamped one at session start and the daemon is recovering a partial
+	// finalize), preserve it. Otherwise stamp a fresh ses_<UUIDv7> here so
+	// daemon-recovered sessions still get an identifier. Never regenerate
+	// over an existing one — that would invalidate any cached references.
+	sessionIDForMeta := sessionid.GenerateSessionID()
+	if existing, err := lfs.ReadSessionMeta(payload.SessionDir); err == nil && existing != nil && existing.SessionID != "" {
+		sessionIDForMeta = existing.SessionID
+	}
 	metaBuilder := lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
+		SessionID(sessionIDForMeta).
 		Title(summaryResp.Title).
 		Summary(summaryResp.Summary).
 		EntryCount(len(stored.Entries)).

--- a/internal/daemon/agentwork/session_finalize_lfs_test.go
+++ b/internal/daemon/agentwork/session_finalize_lfs_test.go
@@ -61,6 +61,59 @@ func TestDetect_SkipsLFSStubSessions(t *testing.T) {
 	}
 }
 
+// TestWriteMetaAndUploadLFS_CorruptExistingMetaIsFatal asserts that if
+// meta.json already exists on disk but cannot be read or parsed,
+// writeMetaAndUploadLFS returns a non-nil error and does NOT overwrite
+// the file. The caller (ProcessResult) must use this error to abort the
+// finalize flow before staging/committing — silently rotating an ID we
+// cannot verify would break dedup.
+//
+// Failure prevented: a regression where the function only logs and
+// returns nil on PreservedSessionID errors lets the daemon stage and
+// commit a fresh meta.json over the corrupted one, silently rotating
+// any SessionID that was there.
+func TestWriteMetaAndUploadLFS_CorruptExistingMetaIsFatal(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipGit = true
+
+	sessionName := "2026-05-01T10-00-testuser-OxCRPT"
+	ledgerPath := t.TempDir()
+	sessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// plant a corrupt meta.json that ReadSessionMeta cannot parse
+	corruptBytes := []byte("{this is not valid JSON")
+	metaPath := filepath.Join(sessionDir, "meta.json")
+	if err := os.WriteFile(metaPath, corruptBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stored := &session.StoredSession{
+		Entries: []map[string]any{{"type": "user"}},
+	}
+	summaryResp := &session.SummarizeResponse{Title: "x", Summary: "x"}
+	payload := &SessionFinalizePayload{SessionDir: sessionDir, LedgerPath: ledgerPath}
+
+	fileRefs, err := handler.writeMetaAndUploadLFS(payload, stored, summaryResp)
+	if err == nil {
+		t.Fatal("expected error from writeMetaAndUploadLFS when existing meta.json is corrupt")
+	}
+	if fileRefs != nil {
+		t.Errorf("fileRefs must be nil on fatal error, got %d entries", len(fileRefs))
+	}
+
+	// CRITICAL: the corrupt meta.json must be untouched on disk; rotating
+	// it to a fresh write is exactly the failure this guard prevents.
+	got, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read meta.json after fatal-error path: %v", err)
+	}
+	if string(got) != string(corruptBytes) {
+		t.Errorf("meta.json was modified despite fatal-error path; got %q want %q", got, corruptBytes)
+	}
+}
+
 // TestWriteMetaAndUploadLFS_ContentFilesIntactAndMetaWritten is a regression test for
 // bug #291 at the writeMetaAndUploadLFS layer. It verifies that when LFS is skipped
 // (projectRoot=""), the function uses WriteSessionMetaOnly — writing meta.json without
@@ -102,9 +155,11 @@ func TestWriteMetaAndUploadLFS_ContentFilesIntactAndMetaWritten(t *testing.T) {
 	}
 
 	// projectRoot="" → LFS early-return path: WriteSessionMetaOnly is called,
-	// LFS upload is skipped, function returns nil fileRefs
-	fileRefs := handler.writeMetaAndUploadLFS(payload, stored, summaryResp)
-
+	// LFS upload is skipped, function returns (nil, nil) fileRefs.
+	fileRefs, err := handler.writeMetaAndUploadLFS(payload, stored, summaryResp)
+	if err != nil {
+		t.Fatalf("writeMetaAndUploadLFS returned unexpected error: %v", err)
+	}
 	if fileRefs != nil {
 		t.Errorf("expected nil fileRefs with empty projectRoot, got %d refs", len(fileRefs))
 	}

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -611,6 +611,43 @@ func (f FileRef) BareOID() string {
 	return f.OID
 }
 
+// PreservedSessionID reads meta.json at sessionDir and returns the
+// SessionID found there. It is the canonical way for any republish path
+// (CLI session stop, daemon recovery, orphan retry) to look up a
+// previously-stamped ID before building a fresh meta.
+//
+// Three return shapes:
+//
+//   - ("ses_...", nil): meta.json exists with a populated SessionID.
+//     Caller MUST chain .SessionID(returned) onto its builder so the
+//     republish does not rotate the ID.
+//   - ("", nil): meta.json is genuinely absent (NotExist) OR exists but
+//     has no SessionID (legacy pre-rollout file). Caller may mint fresh
+//     via sessionid.GenerateSessionID() (already done by sessionMetaBase).
+//   - ("", non-nil err): meta.json exists but cannot be read or parsed
+//     (corrupted, IO failure, permission). Caller MUST treat this as
+//     fatal and surface the error — silently minting a fresh SessionID
+//     here would rotate an ID that may already be cached by the server
+//     or by other coworkers, breaking dedup.
+//
+// The strict "non-NotExist error is fatal" rule exists because there is
+// no safe heuristic for "meta.json exists but I couldn't read it" — we
+// don't know whether it had a SessionID we'd overwrite. Refusing to
+// proceed is the only conservative choice.
+func PreservedSessionID(sessionDir string) (string, error) {
+	existing, err := ReadSessionMeta(sessionDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil // genuinely first publish — caller mints fresh
+	}
+	if err != nil {
+		return "", fmt.Errorf("read existing meta.json (refusing to silently rotate SessionID): %w", err)
+	}
+	if existing == nil {
+		return "", nil
+	}
+	return existing.SessionID, nil
+}
+
 // EffectiveSessionID returns the canonical "ses_"-prefixed identifier for
 // this recording, regardless of whether the recording predates the
 // SessionID field.

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -11,19 +11,64 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sageox/ox/internal/fileutil"
 )
+
+// legacySessionNamespace is the UUIDv5 namespace for synthesizing session
+// IDs for recordings predating the SessionID field. Generated once on
+// 2026-05-01; MUST NEVER change.
+//
+// Changing this value would change EffectiveSessionID for every legacy
+// recording in every ledger, breaking server-side dedup, cross-machine
+// references, and any external system that has cached the value. Treat
+// as a load-bearing constant — same status as a database table name. To
+// regenerate it would require a coordinated migration across every ledger.
+//
+// The SageOx server performs the same UUIDv5 derivation with this same
+// namespace when ingesting a meta.json with no session_id, so client and
+// server always compute the same ses_-prefixed value for every legacy
+// recording. If this constant changes, the server must change in lockstep.
+var legacySessionNamespace = uuid.MustParse("5e6238b7-9403-4ee4-b5ec-8a6d37a5de14")
 
 // SessionMeta is the git-tracked metadata + OID manifest for a session.
 // Stored as meta.json in each session folder. When Files is populated,
 // WriteSessionMeta also writes LFS pointer files (standard git-lfs naming)
 // to replace content files, preventing LFS garbage collection.
 type SessionMeta struct {
-	Version             string    `json:"version"` // "1.0"
-	SessionName         string    `json:"session_name"`
-	Username            string    `json:"username"` // privacy-safe display name — via identity.AttributionDisplayName(). Shared in ledger. NOT an email.
-	UserID              string    `json:"user_id,omitempty"`
-	AgentID             string    `json:"agent_id"`
+	Version     string `json:"version"` // "1.0"
+	SessionName string `json:"session_name"`
+	Username    string `json:"username"` // privacy-safe display name — via identity.AttributionDisplayName(). Shared in ledger. NOT an email.
+	UserID      string `json:"user_id,omitempty"`
+	AgentID     string `json:"agent_id"`
+
+	// SessionID is the globally unique, content-bound identifier for THIS
+	// specific recording. Format: "ses_<UUIDv7>". Populated at session
+	// creation time and never regenerated. Independent of path/name so
+	// renames, moves, and re-imports do not change identity.
+	//
+	// Do NOT confuse with OxSID (per-agent-instance, reused across many
+	// recordings during a 24h prime window) or AgentID (per-agent, reused
+	// across all of that agent's recordings).
+	//
+	// # Backwards compatibility
+	//
+	// Pre-existing meta.json files do not carry this field. The compat model:
+	//
+	//   - JSON tag is `omitempty` — older readers see no schema change;
+	//     newer readers see "" for legacy sessions.
+	//   - Version is NOT bumped — additive optional field, no breaking
+	//     change to the on-disk format.
+	//   - Legacy sessions on disk are NEVER backfilled automatically. The
+	//     deterministic EffectiveSessionID() helper synthesizes a stable
+	//     ses_<UUIDv5> from (RepoID, SessionName) on every read, so
+	//     consumers always get a ses_-prefixed value without writing to
+	//     old meta.json. Doctor offers an opt-in backfill (FixLevelSuggested).
+	//   - All consumers MUST go through EffectiveSessionID() rather than
+	//     reading SessionID directly. Direct reads return "" for legacy
+	//     and silently break dedup/lookup.
+	SessionID string `json:"session_id,omitempty"`
+
 	AgentType           string    `json:"agent_type"` // "claude-code", "cursor", etc.
 	Model               string    `json:"model,omitempty"`
 	Title               string    `json:"title,omitempty"`
@@ -166,6 +211,15 @@ func (b *SessionMetaBuilder) UserID(id string) *SessionMetaBuilder {
 
 func (b *SessionMetaBuilder) RepoID(id string) *SessionMetaBuilder {
 	b.meta.RepoID = id
+	return b
+}
+
+// SessionID stamps the per-recording ses_<UUIDv7>. Caller is expected to
+// pass sessionid.GenerateSessionID() at session creation time. Never
+// regenerated: MutateSessionMeta-based RMW paths preserve it via JSON
+// round-trip.
+func (b *SessionMetaBuilder) SessionID(id string) *SessionMetaBuilder {
+	b.meta.SessionID = id
 	return b
 }
 
@@ -555,4 +609,34 @@ func (f FileRef) BareOID() string {
 		return f.OID[7:]
 	}
 	return f.OID
+}
+
+// EffectiveSessionID returns the canonical "ses_"-prefixed identifier for
+// this recording, regardless of whether the recording predates the
+// SessionID field.
+//
+//   - If meta.SessionID is non-empty (post-rollout), it is returned verbatim.
+//   - Otherwise the result is a deterministic ses_<UUIDv5> derived from
+//     (RepoID, SessionName) using legacySessionNamespace.
+//
+// Deterministic: calling EffectiveSessionID twice on the same legacy
+// session always returns the same value.
+//
+// # Why UUIDv5 over (RepoID, SessionName) and not OxSID
+//
+// OxSID is per-prime, not per-recording (cmd/ox/agent_prime.go:514;
+// reused at 540, 746, 1614, 1630, 1650). Two recordings produced by the
+// same prime share an OxSID and would collide. SessionName is the only
+// per-recording entropy already present in meta.json; using it here also
+// avoids LFS hydration of raw.jsonl on dehydrated clones.
+//
+// All call sites that need a stable per-recording handle MUST go through
+// this helper. Reading m.SessionID directly returns "" for legacy
+// recordings and silently breaks dedup/lookup.
+func (m *SessionMeta) EffectiveSessionID() string {
+	if m.SessionID != "" {
+		return m.SessionID
+	}
+	name := m.RepoID + "/" + m.SessionName
+	return "ses_" + uuid.NewSHA1(legacySessionNamespace, []byte(name)).String()
 }

--- a/internal/lfs/meta_session_id_test.go
+++ b/internal/lfs/meta_session_id_test.go
@@ -168,6 +168,44 @@ func TestEffectiveSessionID_LegacyDistinctInputs(t *testing.T) {
 	}
 }
 
+// TestSessionMeta_RepublishPreservesIDPattern simulates the
+// "republish after partial-failure" pattern used by every ledger-write
+// call site (agent_session.go, agent_session_recover.go,
+// doctor_session_upload_retry.go, daemon session_finalize.go). Each of
+// these reads any existing meta.json on disk before building fresh, and
+// reuses the prior SessionID if present. This test asserts that the
+// pattern actually preserves the value end-to-end via ReadSessionMeta +
+// builder.SessionID(...).Build() + WriteSessionMetaOnly.
+//
+// Failure prevented: a refactor that changes the ReadSessionMeta return
+// shape, or one that drops the .SessionID() chain in any of the four
+// republish call sites, would silently rotate the ID on retry — which
+// would invalidate every cached cross-machine reference to the recording.
+func TestSessionMeta_RepublishPreservesIDPattern(t *testing.T) {
+	tmp := t.TempDir()
+	sessionDir := filepath.Join(tmp, "session")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	const original = "ses_01950000-0000-7abc-8def-0123456789ab"
+	first := NewSessionMeta("name", "user", "Ox1234", "claude-code", time.Now()).
+		SessionID(original).
+		Build()
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, first))
+
+	// simulate the republish pattern: read prior meta, mint fresh builder,
+	// preserve SessionID if existing was non-empty.
+	var rebuilder = NewSessionMeta("name", "user", "Ox1234", "claude-code", time.Now())
+	if existing, err := ReadSessionMeta(sessionDir); err == nil && existing != nil && existing.SessionID != "" {
+		rebuilder = rebuilder.SessionID(existing.SessionID)
+	}
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, rebuilder.Build()))
+
+	got, err := ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, original, got.SessionID,
+		"republish must preserve SessionID; got %q want %q", got.SessionID, original)
+}
+
 // TestEffectiveSessionID_NamespaceStability is the load-bearing test that
 // pins the legacy fallback to a specific concrete value. If
 // legacySessionNamespace is ever changed (or the derivation algorithm

--- a/internal/lfs/meta_session_id_test.go
+++ b/internal/lfs/meta_session_id_test.go
@@ -206,6 +206,68 @@ func TestSessionMeta_RepublishPreservesIDPattern(t *testing.T) {
 		"republish must preserve SessionID; got %q want %q", got.SessionID, original)
 }
 
+// --- C. PreservedSessionID error semantics ---
+
+// TestPreservedSessionID_PopulatedReturnsValue verifies the happy path:
+// meta.json with a SessionID returns that value, no error.
+func TestPreservedSessionID_PopulatedReturnsValue(t *testing.T) {
+	tmp := t.TempDir()
+	const want = "ses_01950000-0000-7abc-8def-0123456789ab"
+	require.NoError(t, WriteSessionMetaOnly(tmp,
+		NewSessionMeta("name", "u", "Ox1234", "claude-code", time.Now()).
+			SessionID(want).Build()))
+
+	got, err := PreservedSessionID(tmp)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// TestPreservedSessionID_NotExistReturnsEmpty verifies the genuinely-
+// first-publish path: no meta.json present, returns ("", nil) so the
+// caller mints fresh.
+func TestPreservedSessionID_NotExistReturnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	got, err := PreservedSessionID(filepath.Join(tmp, "nonexistent"))
+	require.NoError(t, err, "missing meta.json must NOT be an error")
+	assert.Equal(t, "", got)
+}
+
+// TestPreservedSessionID_LegacyMetaReturnsEmpty verifies that meta.json
+// existing without a SessionID (legacy file) returns ("", nil) — the
+// caller mints fresh, which is correct for legacy sessions where
+// EffectiveSessionID would synthesize the same v5 anyway.
+func TestPreservedSessionID_LegacyMetaReturnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, WriteSessionMetaOnly(tmp,
+		NewSessionMeta("name", "u", "Ox1234", "claude-code", time.Now()).Build()))
+
+	got, err := PreservedSessionID(tmp)
+	require.NoError(t, err)
+	assert.Equal(t, "", got)
+}
+
+// TestPreservedSessionID_CorruptedMetaIsFatalError is the load-bearing
+// test for the conservative-error rule. A meta.json that exists but
+// cannot be parsed must NOT silently produce ("", nil) — that would let
+// the caller mint a fresh SessionID and silently rotate an ID that may
+// have been there before corruption.
+//
+// Failure prevented: a refactor that swallows non-NotExist errors here
+// would silently rotate SessionIDs whenever meta.json is corrupted, IO
+// fails, or permissions are wrong — exactly the failure CodeRabbit
+// flagged in PR #575.
+func TestPreservedSessionID_CorruptedMetaIsFatalError(t *testing.T) {
+	tmp := t.TempDir()
+	corrupted := filepath.Join(tmp, "meta.json")
+	require.NoError(t, os.WriteFile(corrupted, []byte("{this is not valid JSON"), 0o644))
+
+	got, err := PreservedSessionID(tmp)
+	require.Error(t, err, "corrupted meta.json must NOT be silently treated as 'no SessionID'")
+	assert.Equal(t, "", got)
+	assert.Contains(t, err.Error(), "refusing to silently rotate SessionID",
+		"error must explain the conservative-rotation rule")
+}
+
 // TestEffectiveSessionID_NamespaceStability is the load-bearing test that
 // pins the legacy fallback to a specific concrete value. If
 // legacySessionNamespace is ever changed (or the derivation algorithm

--- a/internal/lfs/meta_session_id_test.go
+++ b/internal/lfs/meta_session_id_test.go
@@ -1,0 +1,194 @@
+package lfs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- A. SessionID round-trip and omitempty wire format ---
+
+// TestSessionMeta_SessionIDPersisted writes a meta.json with a SessionID and
+// reads it back, asserting the value survives the JSON round-trip.
+// Failure prevented: a future refactor that drops the JSON tag or struct
+// field would silently lose the per-recording identifier without any
+// existing meta_test.go assertion failing.
+func TestSessionMeta_SessionIDPersisted(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "2026-05-01T10-00-ryan-Oxabcd")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	const wantID = "ses_01950000-0000-7abc-8def-0123456789ab"
+	meta := NewSessionMeta("2026-05-01T10-00-ryan-Oxabcd", "ryan", "Oxabcd", "claude-code", time.Now()).
+		SessionID(wantID).
+		Build()
+
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, meta))
+
+	got, err := ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, wantID, got.SessionID)
+}
+
+// TestSessionMeta_SessionIDOmitemptyForLegacy asserts that meta.json files
+// produced before SessionID existed unmarshal cleanly with SessionID == "",
+// and that empty SessionID is omitted on marshal.
+// Failure prevented: dropping `omitempty` would write empty session_id
+// fields into every legacy meta.json on rewrite, which would (a) be
+// distinguishable from genuinely-pre-rollout files and (b) clutter the
+// JSON with empty strings.
+func TestSessionMeta_SessionIDOmitemptyForLegacy(t *testing.T) {
+	// legacy meta.json that predates the field
+	legacy := `{
+  "version": "1.0",
+  "session_name": "2025-12-01T08-00-ryan-OxLegc",
+  "username": "ryan",
+  "agent_id": "OxLegc",
+  "agent_type": "claude-code",
+  "created_at": "2025-12-01T08:00:00Z",
+  "files": {}
+}`
+
+	var got SessionMeta
+	require.NoError(t, json.Unmarshal([]byte(legacy), &got))
+	assert.Equal(t, "", got.SessionID, "legacy meta.json should unmarshal with empty SessionID")
+
+	// re-marshal: empty SessionID must NOT appear in the output
+	out, err := json.Marshal(&got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"session_id"`, "empty SessionID must be omitted on marshal")
+}
+
+// TestSessionMeta_SessionIDPreservedAcrossMutate verifies that a no-op
+// MutateSessionMeta does not touch SessionID.
+// Failure prevented: a refactor that switches the mutate path to a "build
+// fresh from JSONL header" approach would silently regenerate SessionID
+// per finalize, breaking dedup across machines.
+func TestSessionMeta_SessionIDPreservedAcrossMutate(t *testing.T) {
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "session")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	const wantID = "ses_01950000-0000-7abc-8def-0123456789ab"
+	meta := NewSessionMeta("session", "ryan", "Ox1234", "claude-code", time.Now()).
+		SessionID(wantID).
+		Build()
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, meta))
+
+	// no-op mutate: change Title only
+	require.NoError(t, MutateSessionMeta(context.Background(), sessionDir, func(m *SessionMeta) (*SessionMeta, error) {
+		require.NotNil(t, m)
+		assert.Equal(t, wantID, m.SessionID, "mutate sees existing SessionID")
+		m.Title = "updated title"
+		return m, nil
+	}))
+
+	got, err := ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, wantID, got.SessionID, "SessionID survives mutate")
+	assert.Equal(t, "updated title", got.Title)
+}
+
+// --- B. EffectiveSessionID semantics ---
+
+// TestEffectiveSessionID_PrefersExplicit verifies that when SessionID is set,
+// it is returned verbatim — the synthetic fallback is NOT consulted.
+// Failure prevented: a bug that always returned the synthesized value
+// would erase real ses_<UUIDv7>s in favor of v5-derived ones, scrambling
+// every post-rollout recording's identity.
+func TestEffectiveSessionID_PrefersExplicit(t *testing.T) {
+	const explicit = "ses_01950000-0000-7abc-8def-0123456789ab"
+	m := &SessionMeta{
+		SessionID:   explicit,
+		RepoID:      "repo_test",
+		SessionName: "name",
+	}
+	assert.Equal(t, explicit, m.EffectiveSessionID())
+}
+
+// TestEffectiveSessionID_LegacyDeterministic asserts that EffectiveSessionID
+// is a pure function of (RepoID, SessionName) for legacy sessions: the same
+// inputs always produce the same output across processes and runs.
+// Failure prevented: nondeterminism here would cause client and server to
+// disagree on legacy IDs, silently breaking dedup, lookups, and any cached
+// reference to a legacy session.
+func TestEffectiveSessionID_LegacyDeterministic(t *testing.T) {
+	m1 := &SessionMeta{RepoID: "repo_alpha", SessionName: "session-1"}
+	m2 := &SessionMeta{RepoID: "repo_alpha", SessionName: "session-1"}
+
+	got1 := m1.EffectiveSessionID()
+	got2 := m2.EffectiveSessionID()
+	assert.Equal(t, got1, got2, "same (RepoID, SessionName) must yield identical EffectiveSessionID")
+
+	// shape check: ses_ prefix + valid UUID
+	assert.True(t, strings.HasPrefix(got1, "ses_"), "must have ses_ prefix: %s", got1)
+	uuidPart := strings.TrimPrefix(got1, "ses_")
+	parsed, err := uuid.Parse(uuidPart)
+	require.NoError(t, err, "must parse as UUID")
+	assert.Equal(t, uuid.Version(5), parsed.Version(), "must be UUIDv5")
+}
+
+// TestEffectiveSessionID_LegacyDistinctInputs ensures different inputs
+// produce different outputs — collisions would silently merge unrelated
+// recordings.
+func TestEffectiveSessionID_LegacyDistinctInputs(t *testing.T) {
+	tests := []struct {
+		a, b *SessionMeta
+		desc string
+	}{
+		{
+			&SessionMeta{RepoID: "repo_a", SessionName: "s1"},
+			&SessionMeta{RepoID: "repo_b", SessionName: "s1"},
+			"different RepoID",
+		},
+		{
+			&SessionMeta{RepoID: "repo_a", SessionName: "s1"},
+			&SessionMeta{RepoID: "repo_a", SessionName: "s2"},
+			"different SessionName",
+		},
+		{
+			&SessionMeta{RepoID: "", SessionName: "s1"},
+			&SessionMeta{RepoID: "", SessionName: "s2"},
+			"empty RepoID, different SessionName (still distinct)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			assert.NotEqual(t, tt.a.EffectiveSessionID(), tt.b.EffectiveSessionID())
+		})
+	}
+}
+
+// TestEffectiveSessionID_NamespaceStability is the load-bearing test that
+// pins the legacy fallback to a specific concrete value. If
+// legacySessionNamespace is ever changed (or the derivation algorithm
+// changes), this test fails — alerting the engineer that they are about
+// to invalidate every legacy recording's identity in every ledger
+// everywhere.
+//
+// Failure prevented: silent rotation of the namespace UUID, which would
+// be a catastrophic compatibility break with no compile-time signal.
+func TestEffectiveSessionID_NamespaceStability(t *testing.T) {
+	m := &SessionMeta{
+		RepoID:      "repo_01936d5a-0000-7abc-8def-0123456789ab",
+		SessionName: "2025-12-01T08-00-ryan-OxLegc",
+	}
+	// pre-computed expected output for these exact inputs against the
+	// hard-coded legacySessionNamespace 5e6238b7-9403-4ee4-b5ec-8a6d37a5de14.
+	// If this assertion ever needs to change, you are about to break every
+	// legacy recording in every ledger — STOP and read meta.go's namespace
+	// constant doc before proceeding.
+	const expected = "ses_836bb195-7bd0-59c6-bd13-6a20076d1cc0"
+	got := m.EffectiveSessionID()
+	assert.Equal(t, expected, got,
+		"legacySessionNamespace appears to have changed; this would invalidate every legacy session ID across all ledgers")
+}

--- a/internal/sessionid/sessionid.go
+++ b/internal/sessionid/sessionid.go
@@ -1,0 +1,69 @@
+// Package sessionid generates and validates session-recording identifiers.
+//
+// Format: "ses_" + standard UUIDv7 string (time-sortable; matches the
+// repo_<UUIDv7> convention in internal/repotools).
+//
+// # Relationship to other ID types
+//
+//   - ses_<UUIDv7>  — THIS package. One specific recording. Unique per
+//     recording, populated at recording creation, never regenerated.
+//   - oxsid_<ULID>  — internal/auth. Server session bound to one
+//     "ox agent prime" call (24h lifetime). Reused across every
+//     recording produced during that window. NOT a recording identifier.
+//   - Ox<4-char>    — internal/agentinstance. Agent identifier within
+//     a project. Stable across all of that agent's recordings. NOT a
+//     recording identifier.
+//   - repo_<UUIDv7> — internal/repotools. Repository identifier.
+//
+// All four are ID-like and easy to confuse. ses_ is the only one that
+// answers the question "which specific recording is this?".
+package sessionid
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const sessionIDPrefix = "ses_"
+
+// GenerateSessionID generates a new prefixed session ID using UUIDv7.
+// Format: "ses_" + standard UUIDv7 string.
+//
+// UUIDv7 is time-sortable; the standard format preserves this property
+// when sorted lexicographically.
+func GenerateSessionID() string {
+	uuidV7 := uuid.Must(uuid.NewV7())
+	return sessionIDPrefix + uuidV7.String()
+}
+
+// ParseSessionID parses a session ID back to its underlying UUID.
+// Returns an error if the ID is invalid or doesn't have the correct prefix.
+func ParseSessionID(id string) (uuid.UUID, error) {
+	if !strings.HasPrefix(id, sessionIDPrefix) {
+		return uuid.Nil, errors.New("invalid session ID: missing 'ses_' prefix")
+	}
+
+	uuidStr := strings.TrimPrefix(id, sessionIDPrefix)
+	if len(uuidStr) == 0 {
+		return uuid.Nil, errors.New("invalid session ID: empty UUID portion")
+	}
+
+	return uuid.Parse(uuidStr)
+}
+
+// IsValidSessionID validates the format of a session ID.
+// Returns true if the ID has the correct prefix and can be parsed as a valid UUID.
+func IsValidSessionID(id string) bool {
+	_, err := ParseSessionID(id)
+	return err == nil
+}
+
+// Prefix returns the canonical "ses_" prefix used for session IDs.
+// Exposed so callers building synthetic IDs (e.g., the legacy fallback
+// in lfs.SessionMeta.EffectiveSessionID) can reuse the same constant
+// without redeclaring it.
+func Prefix() string {
+	return sessionIDPrefix
+}

--- a/internal/sessionid/sessionid_test.go
+++ b/internal/sessionid/sessionid_test.go
@@ -1,0 +1,177 @@
+package sessionid
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateSessionID verifies prefix + UUID-shaped suffix.
+// Failure prevented: drift in ID format would silently break server-side
+// parsing of newly-generated IDs.
+func TestGenerateSessionID(t *testing.T) {
+	id := GenerateSessionID()
+
+	assert.True(t, strings.HasPrefix(id, "ses_"), "expected session ID to have 'ses_' prefix, got: %s", id)
+	assert.Greater(t, len(id), len("ses_"), "expected session ID to have content after prefix, got: %s", id)
+
+	uuidPart := strings.TrimPrefix(id, "ses_")
+	assert.Len(t, uuidPart, 36, "expected UUID part to be 36 chars: %s", uuidPart)
+}
+
+// TestGenerateSessionID_Uniqueness ensures the generator never repeats.
+// Failure prevented: collision between two recordings would silently
+// merge them in any consumer keying on session ID.
+func TestGenerateSessionID_Uniqueness(t *testing.T) {
+	ids := make(map[string]bool)
+	const count = 1000
+
+	for i := 0; i < count; i++ {
+		id := GenerateSessionID()
+		assert.False(t, ids[id], "duplicate session ID generated: %s", id)
+		ids[id] = true
+	}
+
+	assert.Len(t, ids, count)
+}
+
+// TestGenerateSessionID_TimeSortable verifies UUIDv7 ordering is preserved
+// when IDs are compared as strings.
+// Failure prevented: a downstream switch to UUIDv4 would silently break
+// any "list sessions newest first" optimization that relies on lexical sort.
+func TestGenerateSessionID_TimeSortable(t *testing.T) {
+	id1 := GenerateSessionID()
+	id2 := GenerateSessionID()
+	id3 := GenerateSessionID()
+
+	assert.LessOrEqual(t, id1, id2, "expected first ID to be <= second ID for time sorting")
+	assert.LessOrEqual(t, id2, id3, "expected second ID to be <= third ID for time sorting")
+}
+
+// TestGenerateSessionID_StringSortMatchesTimeSort confirms a sequence of IDs
+// generated in order remains lexically ordered.
+// Failure prevented: any tool listing meta.json files in directory order
+// expecting chronological output would silently misorder.
+func TestGenerateSessionID_StringSortMatchesTimeSort(t *testing.T) {
+	ids := make([]string, 100)
+	for i := range ids {
+		ids[i] = GenerateSessionID()
+	}
+
+	for i := 1; i < len(ids); i++ {
+		assert.LessOrEqual(t, ids[i-1], ids[i],
+			"IDs not in chronological string-sort order at index %d: %s > %s", i, ids[i-1], ids[i])
+	}
+}
+
+// TestParseSessionID_Valid round-trips a generated ID back to a UUIDv7.
+func TestParseSessionID_Valid(t *testing.T) {
+	id := GenerateSessionID()
+
+	parsedUUID, err := ParseSessionID(id)
+	require.NoError(t, err, "failed to parse valid session ID")
+
+	assert.NotEqual(t, uuid.Nil, parsedUUID, "expected non-nil UUID from parsed session ID")
+	assert.Equal(t, uuid.Version(7), parsedUUID.Version(), "expected UUID version 7")
+}
+
+func TestParseSessionID_RoundTrip(t *testing.T) {
+	originalID := GenerateSessionID()
+
+	parsedUUID, err := ParseSessionID(originalID)
+	require.NoError(t, err, "failed to parse session ID")
+
+	reEncodedID := sessionIDPrefix + parsedUUID.String()
+	assert.Equal(t, originalID, reEncodedID, "round trip failed")
+}
+
+func TestParseSessionID_InvalidPrefix(t *testing.T) {
+	invalidIDs := []string{
+		"invalid_5e6238b7-9403-4ee4-b5ec-8a6d37a5de14",
+		"5e6238b7-9403-4ee4-b5ec-8a6d37a5de14",
+		"ses5e6238b7-9403-4ee4-b5ec-8a6d37a5de14",
+		"",
+		"ses_",
+		// repo_-prefixed IDs and oxsid_-prefixed IDs are common confusion
+		// vectors; validate parser rejects them as not-a-session-ID.
+		"repo_5e6238b7-9403-4ee4-b5ec-8a6d37a5de14",
+		"oxsid_01JEYQ9Z8X9Y2K3N4P5Q6R7S8T",
+	}
+
+	for _, id := range invalidIDs {
+		_, err := ParseSessionID(id)
+		assert.Error(t, err, "expected error for invalid session ID: %s", id)
+	}
+}
+
+func TestParseSessionID_InvalidUUID(t *testing.T) {
+	invalidIDs := []string{
+		"ses_not-a-valid-uuid",
+		"ses_!!!invalid",
+		"ses_@#$%",
+		"ses_ spaces ",
+		"ses_5e6238b7-9403-4ee4-b5ec", // truncated
+	}
+
+	for _, id := range invalidIDs {
+		_, err := ParseSessionID(id)
+		assert.Error(t, err, "expected error for invalid UUID format: %s", id)
+	}
+}
+
+func TestIsValidSessionID_Valid(t *testing.T) {
+	id := GenerateSessionID()
+	assert.True(t, IsValidSessionID(id), "expected valid session ID to return true: %s", id)
+}
+
+func TestIsValidSessionID_Invalid(t *testing.T) {
+	invalidIDs := []string{
+		"invalid_5e6238b7-9403-4ee4-b5ec-8a6d37a5de14",
+		"5e6238b7-9403-4ee4-b5ec-8a6d37a5de14",
+		"",
+		"ses_",
+		"ses_!!!invalid",
+		"ses_not-a-uuid",
+		"repo_5e6238b7-9403-4ee4-b5ec-8a6d37a5de14",
+		"oxsid_01JEYQ9Z8X9Y2K3N4P5Q6R7S8T",
+	}
+
+	for _, id := range invalidIDs {
+		assert.False(t, IsValidSessionID(id), "expected invalid session ID to return false: %s", id)
+	}
+}
+
+// TestPrefix verifies the exported prefix matches the package constant.
+// Failure prevented: a future refactor that changes one but not the other
+// would split the canonical prefix across two values.
+func TestPrefix(t *testing.T) {
+	assert.Equal(t, "ses_", Prefix())
+	assert.Equal(t, sessionIDPrefix, Prefix())
+}
+
+func BenchmarkGenerateSessionID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		GenerateSessionID()
+	}
+}
+
+func BenchmarkParseSessionID(b *testing.B) {
+	id := GenerateSessionID()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseSessionID(id)
+	}
+}
+
+func BenchmarkIsValidSessionID(b *testing.B) {
+	id := GenerateSessionID()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		IsValidSessionID(id)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a globally unique, content-bound identifier for each session recording. Today no field on `lfs.SessionMeta` answers "which specific recording is this?" — `OxSID` is per-prime (24h, reused across recordings), `AgentID` is per-agent, and identity is implicitly the path. This PR introduces `ses_<UUIDv7>` (matching the existing `repo_<UUIDv7>` convention) populated at recording creation, with a deterministic `ses_<UUIDv5(legacyNamespace, RepoID + "/" + SessionName)>` fallback so legacy recordings get a stable `ses_`-prefixed handle without any backfill. Client and server compute the same value for legacy sessions byte-for-byte.

## What's in the diff

- **`internal/sessionid/`** — new package: `GenerateSessionID` (UUIDv7), `ParseSessionID`, `IsValidSessionID`. Mirrors `internal/repotools`.
- **`internal/lfs/meta.go`** — added `SessionID` field (omitempty), builder method, and `EffectiveSessionID()` helper. Pinned namespace UUID `5e6238b7-9403-4ee4-b5ec-8a6d37a5de14` is treated as a load-bearing constant; a stability test fails loudly if it ever changes.
- **`cmd/ox/session_meta_helper.go`** — `sessionMetaBase` stamps a fresh `ses_<UUIDv7>` on every new recording.
- **Republish-preserve guards** — `cmd/ox/agent_session.go`, `cmd/ox/agent_session_recover.go`, `cmd/ox/doctor_session_upload_retry.go`, and `internal/daemon/agentwork/session_finalize.go` all read any pre-existing meta.json first and preserve the SessionID if present. Never overwrites a previously-stamped ID on retry.
- **`cmd/ox/doctor_session_ids.go`** — `legacy-session-ids` doctor check at `FixLevelSuggested` (opt-in via `--fix-slug=session-ids`); never auto-runs, never in the daemon. Uses `MutateSessionMeta` flock + batched `--sparse` commit/push.

Backwards compat is documented inline at every decision point: field declaration, helper, package header, and construction sites.

## ID landscape

```mermaid
flowchart TD
    Prime["ox agent prime"]
    OxSID["oxsid (ULID)<br/>per-prime, 24h<br/>provenance only"]
    Agent["agent ID (Ox4char)<br/>per-agent<br/>provenance only"]
    Rec1["Recording 1"]
    Rec2["Recording 2"]
    RecN["Recording N"]
    SesNew["ses (UUIDv7)<br/>per-recording<br/>NEW identity"]
    Legacy["Legacy meta.json<br/>no session_id"]
    SesV5["ses (UUIDv5 of RepoID + SessionName)<br/>deterministic fallback"]

    Prime --> OxSID
    Prime --> Agent
    Prime --> Rec1
    Prime --> Rec2
    Prime --> RecN
    Rec1 --> SesNew
    Rec2 --> SesNew
    RecN --> SesNew
    Legacy --> SesV5
```

`EffectiveSessionID()` is the single accessor every consumer uses: returns the explicit `SessionID` if set, otherwise the deterministic v5 fallback. No call site reads the raw field directly.

## Test plan

- [x] `make lint` → 0 issues
- [x] `make check-no-git-lfs-shell` → passes
- [x] `go test ./internal/sessionid/... ./internal/lfs/... ./internal/daemon/agentwork/... -count=1` → all green
- [x] `go test ./cmd/ox/ -short -count=1` → all green
- [x] `TestSessionMeta_RepublishPreservesIDPattern` covers the read-then-preserve invariant end-to-end
- [x] `TestEffectiveSessionID_NamespaceStability` pins the UUIDv5 namespace; any rotation fails loudly
- [ ] Manual e2e: `ox agent prime` → record session → `jq .session_id < meta.json` shows `ses_01...`
- [ ] Backwards-compat smoke: older ox binary reads new meta.json without error

## Doctor backfill (opt-in, not auto)

Added `legacy-session-ids` check at `FixLevelSuggested`. `ox doctor` reports the count of legacy sessions; `ox doctor --fix-slug=session-ids` (or `--fix`) backfills via `MutateSessionMeta` + batched `--sparse` commit/push. Auto-fix is intentionally disabled because the backfilled value is identical to what `EffectiveSessionID()` synthesizes on the fly — persisting adds no information, only convenience for downstream consumers, at the cost of one ledger commit per session and cross-coworker churn. The synthetic fallback is the always-on correctness path; backfill is opt-in cleanup.

## Out of scope

No automatic backfill, no schema_version bump, no change to JSONL header struct, no `OxSID` deprecation. Daemon never writes the backfill (per `.claude/rules/daemon-git.md` daemon-CLI git split).

Plan: `~/.claude/plans/system-instruction-you-are-working-cozy-dolphin.md`

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable, prefixed session IDs for recordings (ses_…) with deterministic fallback for legacy recordings.
  * Doctor check that detects legacy recordings lacking session IDs and can backfill them when run with fix enabled.
  * Preservation of session IDs across retries, recovery, and republish to avoid rotation.

* **Bug Fixes**
  * Backfill handles partial failures and reports warnings when commit/push steps require retry.

* **Tests**
  * Extensive tests for ID generation, fallback, backfill, preservation, and race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->