### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.6.5"
+      "version": "0.7.0"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -5,9 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.5] - Unreleased
+## [0.7.0] - 2026-05-01
 
-_No changes yet. Populate as changes land during the 0.6.5 cycle._
+### Added
+
+**Globally unique session recording IDs**
+- Every session recording now carries a stable `ses_<UUIDv7>` identifier in `meta.json`, independent of path or name. Renames, moves, and re-imports no longer change identity.
+- Legacy recordings without the field get a deterministic `ses_<UUIDv5>` derived from `(repo_id, session_name)` via the `EffectiveSessionID()` accessor — client and server compute the same value byte-for-byte, so no backfill is required.
+- `ox doctor --fix-slug=session-ids` opt-in backfill persists the deterministic value into `meta.json` for cleaner ledgers.
+- Adapter coverage: ses_ IDs are stamped by ox core for sessions captured by every adapter (Claude Code, Aider, Amp, Codex, Droid, Gemini, OpenCode, Pi).
+
+**Session summary quality**
+- New evaluation harness scores summary richness against a curated 18-session golden corpus, catching distiller regressions before release.
+- LLM judge wired into the daemon for live summary validation; richness checks block stub or empty summaries from reaching the ledger.
+- Tokenstrip is now on by default, reducing recording sizes without losing detail.
+- Streaming compressor and `ox session token-optimize` shrink recordings for long-running agents.
+
+**Ledger resilience epic**
+- Multi-writer safety: structural protections against concurrent CLI/daemon writes corrupting `meta.json` or losing summary fields.
+- Daemon LLM tier and autofix scheduler proactively repair corrupted or missing artifacts.
+- `meta.json` manifest now carries an explicit `Storage` tag (`lfs` vs `git`) per file (ADR-016), preventing silent demotion of git-stored summaries to LFS pointers.
+
+**Session UX**
+- `ox session list` shows session titles by default; agent-context invocations default to JSON output.
+
+### Fixed
+
+**Session recording**
+- Regenerate now hydrates LFS-stub raw.jsonl files instead of producing stub summaries.
+- Regenerate writes to the canonical ledger path for team sessions instead of the local cache.
+- Validator errors no longer leak into user-visible `meta.title` or `meta.summary`.
+- `meta.json.title` is populated alongside `summary` so list views render correctly (previously 91/155 sessions on the ox team's ledger shipped with empty titles).
+- Session content readers unified behind `openSessionContent` to enforce the cache-only invariant — hydrated bytes never overwrite the in-place LFS pointer.
+- Closed an autostash race where the LFS pointer rewrite could be lost during commit.
+
+**Daemon**
+- Whisper SQLite handles are properly closed and child watches recursively unwatched, eliminating a file-descriptor leak under long uptimes.
+
+**Init and doctor**
+- `ox doctor --fix` now restores missing `ox-*` slash commands (the `claude-commands` check was previously registered but never run).
+- `ox init` no longer offers Claude Code twice when an external adapter is already installed.
+
+[0.7.0]: https://github.com/sageox/ox/releases/tag/v0.7.0
 
 ## [0.6.4] - 2026-04-22
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.6.5"
+	Version   = "0.7.0"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## Summary

Bumps version to **0.7.0** and replaces the empty `[0.6.5] - Unreleased` placeholder in `CHANGELOG.md` with a human-focused `[0.7.0] - 2026-05-01` entry covering every PR merged since v0.6.4 (#547–#575).

Per the project's beads-style versioning rule (`0.<release>.0`, middle number bumps each release), 0.6.5 was a placeholder that never received content; this release jumps to 0.7.0.

## Files

- `internal/version/version.go` — `0.6.5` → `0.7.0`
- `.claude-plugin/marketplace.json` — `0.6.5` → `0.7.0`
- `claude-plugin/.claude-plugin/plugin.json` — `0.6.5` → `0.7.0`
- `cmd/ox/release_notes.md` (a.k.a. `CHANGELOG.md`) — adds the 0.7.0 entry below

`make verify-version` confirms all four sources agree on `0.7.0`.

## Release notes (will become the GitHub release body)

### Added

**Globally unique session recording IDs**
- Every session recording now carries a stable `ses_<UUIDv7>` identifier in `meta.json`, independent of path or name. Renames, moves, and re-imports no longer change identity.
- Legacy recordings without the field get a deterministic `ses_<UUIDv5>` derived from `(repo_id, session_name)` via the `EffectiveSessionID()` accessor — client and server compute the same value byte-for-byte, so no backfill is required.
- `ox doctor --fix-slug=session-ids` opt-in backfill persists the deterministic value into `meta.json` for cleaner ledgers.
- Adapter coverage: ses_ IDs are stamped by ox core for sessions captured by every adapter (Claude Code, Aider, Amp, Codex, Droid, Gemini, OpenCode, Pi).

**Session summary quality**
- New evaluation harness scores summary richness against a curated 18-session golden corpus, catching distiller regressions before release.
- LLM judge wired into the daemon for live summary validation; richness checks block stub or empty summaries from reaching the ledger.
- Tokenstrip is now on by default, reducing recording sizes without losing detail.
- Streaming compressor and `ox session token-optimize` shrink recordings for long-running agents.

**Ledger resilience epic**
- Multi-writer safety: structural protections against concurrent CLI/daemon writes corrupting `meta.json` or losing summary fields.
- Daemon LLM tier and autofix scheduler proactively repair corrupted or missing artifacts.
- `meta.json` manifest now carries an explicit `Storage` tag (`lfs` vs `git`) per file (ADR-016), preventing silent demotion of git-stored summaries to LFS pointers.

**Session UX**
- `ox session list` shows session titles by default; agent-context invocations default to JSON output.

### Fixed

**Session recording**
- Regenerate now hydrates LFS-stub raw.jsonl files instead of producing stub summaries.
- Regenerate writes to the canonical ledger path for team sessions instead of the local cache.
- Validator errors no longer leak into user-visible `meta.title` or `meta.summary`.
- `meta.json.title` is populated alongside `summary` so list views render correctly (previously 91/155 sessions on the ox team's ledger shipped with empty titles).
- Session content readers unified behind `openSessionContent` to enforce the cache-only invariant — hydrated bytes never overwrite the in-place LFS pointer.
- Closed an autostash race where the LFS pointer rewrite could be lost during commit.

**Daemon**
- Whisper SQLite handles are properly closed and child watches recursively unwatched, eliminating a file-descriptor leak under long uptimes.

**Init and doctor**
- `ox doctor --fix` now restores missing `ox-*` slash commands (the `claude-commands` check was previously registered but never run).
- `ox init` no longer offers Claude Code twice when an external adapter is already installed.

## Next steps after merge

1. Tag `v0.7.0` on the merge commit, push tag
2. `gh release create v0.7.0` with the changelog body (draft per release rules; you publish)

Co-Authored-By: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.7.0

* **New Features**
  * Stable, globally unique session recording identifiers
  * Session size optimization with token compression
  * Enhanced reliability for session storage and recovery
  * New doctor tool option for session management

* **Bug Fixes**
  * Improved session regeneration consistency
  * Enhanced data integrity and corruption recovery
  * Fixed session metadata handling and validation
  * Resolved resource management issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->