### PR TITLE
fix(daemon): plug per-file FD leak in ProjectWatcher (fsnotify userspace mirror)

### DIFF
--- a/cmd/ox/doctor_daemon.go
+++ b/cmd/ox/doctor_daemon.go
@@ -54,6 +54,7 @@ func checkDaemonHealth(opts doctorOptions) []checkResult {
 		doctor.NewDaemonSyncErrorsCheck(),
 		doctor.NewDaemonGitHubAuthCheck(),
 		doctor.NewDaemonDirtyTeamContextCheck(),
+		doctor.NewDaemonFDPressureCheck(),
 	}
 
 	// add heartbeat checks for monitored repos

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1444,6 +1444,8 @@ func (s *daemonServiceImpl) Status() *StatusData {
 		Issues:             issues,
 		StartupDurationMs:  s.d.startupDurationMs.Load(),
 		ThrottleDurationMs: s.d.throttleDurationMs.Load(),
+		OpenFDs:            CurrentProcessFDCount(),
+		OpenFDLimit:        CurrentProcessFDLimit(),
 		CodeDB:             codeDBStats,
 		AgentWork:          agentWorkStatus,
 		Callers:            callers,

--- a/internal/daemon/fd_count.go
+++ b/internal/daemon/fd_count.go
@@ -1,14 +1,11 @@
 package daemon
 
-import (
-	"os"
-	"runtime"
-	"syscall"
-)
+import "os"
 
 // CurrentProcessFDCount returns the number of open file descriptors for the
 // current process, or -1 if it cannot be determined. Portable across macOS
-// (/dev/fd) and Linux (/proc/self/fd).
+// (/dev/fd) and Linux (/proc/self/fd); on Windows neither path exists and
+// the function returns -1 (the doctor check skips silently in that case).
 //
 // Used by the daemon status to surface FD growth as a first-class metric.
 // The whole reason the project_watcher FD leak got bad enough in production
@@ -44,19 +41,4 @@ func countFDsAt(path string) (int, bool) {
 		n = 0
 	}
 	return n, true
-}
-
-// CurrentProcessFDLimit returns the soft RLIMIT_NOFILE for the current
-// process, or 0 if it cannot be determined. Used to compute FD-pressure
-// percentage rather than hard-coding thresholds: a daemon at 4096 open FDs
-// is fine on a host with a 1M limit, alarming on a host with a 4500 limit.
-func CurrentProcessFDLimit() uint64 {
-	if runtime.GOOS == "windows" {
-		return 0
-	}
-	var rlim syscall.Rlimit
-	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
-		return 0
-	}
-	return uint64(rlim.Cur)
 }

--- a/internal/daemon/fd_count.go
+++ b/internal/daemon/fd_count.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+)
+
+// CurrentProcessFDCount returns the number of open file descriptors for the
+// current process, or -1 if it cannot be determined. Portable across macOS
+// (/dev/fd) and Linux (/proc/self/fd).
+//
+// Used by the daemon status to surface FD growth as a first-class metric.
+// The whole reason the project_watcher FD leak got bad enough in production
+// to hang lsof was that nothing surfaced the growth — make it visible so
+// future regressions in our deps (or our code) get caught in hours, not
+// months.
+func CurrentProcessFDCount() int {
+	paths := []string{"/dev/fd", "/proc/self/fd"}
+	for _, p := range paths {
+		if n, ok := countFDsAt(p); ok {
+			return n
+		}
+	}
+	return -1
+}
+
+// countFDsAt enumerates entries via Readdirnames so we don't fstat each FD
+// (some macOS kernel-only FD types fail fstatat with "bad file descriptor").
+// Returns the count and true on success, false if the dir can't be opened.
+func countFDsAt(path string) (int, bool) {
+	d, err := os.Open(path)
+	if err != nil {
+		return 0, false
+	}
+	defer d.Close()
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return 0, false
+	}
+	// Subtract 1 for the FD held by 'd' itself.
+	n := len(names) - 1
+	if n < 0 {
+		n = 0
+	}
+	return n, true
+}
+
+// CurrentProcessFDLimit returns the soft RLIMIT_NOFILE for the current
+// process, or 0 if it cannot be determined. Used to compute FD-pressure
+// percentage rather than hard-coding thresholds: a daemon at 4096 open FDs
+// is fine on a host with a 1M limit, alarming on a host with a 4500 limit.
+func CurrentProcessFDLimit() uint64 {
+	if runtime.GOOS == "windows" {
+		return 0
+	}
+	var rlim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
+		return 0
+	}
+	return uint64(rlim.Cur)
+}

--- a/internal/daemon/fd_limit_unix.go
+++ b/internal/daemon/fd_limit_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package daemon
+
+import "syscall"
+
+// CurrentProcessFDLimit returns the soft RLIMIT_NOFILE for the current
+// process, or 0 if it cannot be determined. Used to compute FD-pressure
+// percentage rather than hard-coding thresholds: a daemon at 4096 open FDs
+// is fine on a host with a 1M limit, alarming on a host with a 4500 limit.
+//
+// Unix-only because syscall.Getrlimit / syscall.Rlimit / syscall.RLIMIT_NOFILE
+// are guarded by `//go:build unix` upstream and don't exist for GOOS=windows.
+// See fd_limit_windows.go for the Windows stub.
+func CurrentProcessFDLimit() uint64 {
+	var rlim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
+		return 0
+	}
+	return uint64(rlim.Cur)
+}

--- a/internal/daemon/fd_limit_windows.go
+++ b/internal/daemon/fd_limit_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package daemon
+
+// CurrentProcessFDLimit returns 0 on Windows. Windows does not expose a
+// RLIMIT_NOFILE-equivalent through Go's syscall package, so we report
+// "unknown" and the doctor FD-pressure check skips. The daemon's primary
+// supported platforms are macOS and Linux; Windows is a build-only target.
+func CurrentProcessFDLimit() uint64 {
+	return 0
+}

--- a/internal/daemon/fsnotify_kqueue_mirror.go
+++ b/internal/daemon/fsnotify_kqueue_mirror.go
@@ -25,19 +25,29 @@ import (
 // capped at maxFilesPerWatchedDir. Errors are logged at Debug and treated as
 // "no children" — drift is recovered by the periodic re-snapshot in
 // pruneStaleWatches and by event-driven incremental updates.
+//
+// Uses the streaming ReadDirN so a pathological million-entry directory
+// can't materialize the full listing just to truncate. We read cap+1
+// entries to detect truncation: if we got more than cap regular files we
+// log a Warn so the operator can investigate.
 func snapshotKqueueChildren(fs FileSystem, path string, logger *slog.Logger) []string {
 	if !childMirrorEnabled {
 		return nil
 	}
-	entries, err := fs.ReadDir(path)
+	// Read cap+1 entries: enough to know whether we hit the cap, no more.
+	// Note that "entries" includes both files and dirs, and we filter dirs
+	// below. In the worst case where most entries are dirs we still might
+	// not fill our cap from the first batch — but the cap is meant as a
+	// hard upper bound on memory, not a strict guarantee that we capture
+	// exactly cap files. Dirs in a watched-dir snapshot are normally rare
+	// in source repos.
+	const probe = maxFilesPerWatchedDir + 1
+	entries, err := fs.ReadDirN(path, probe)
 	if err != nil {
-		logger.Debug("kqueue mirror: ReadDir failed during snapshot",
+		logger.Debug("kqueue mirror: ReadDirN failed during snapshot",
 			"path", path, "error", err)
 		return nil
 	}
-	// Cap allocation up front so a pathological directory (millions of
-	// generated files) can't dominate startup memory or snapshot cost.
-	// Memory bound is independent of directory cardinality.
 	capLen := len(entries)
 	if capLen > maxFilesPerWatchedDir {
 		capLen = maxFilesPerWatchedDir
@@ -57,7 +67,6 @@ func snapshotKqueueChildren(fs FileSystem, path string, logger *slog.Logger) []s
 	if truncated {
 		logger.Warn("kqueue mirror: per-dir child snapshot truncated",
 			"path", path, "cap", maxFilesPerWatchedDir,
-			"total_entries", len(entries),
 			"impact", "FD-leak guarantee weakened for files beyond cap")
 	}
 	return out

--- a/internal/daemon/fsnotify_kqueue_mirror.go
+++ b/internal/daemon/fsnotify_kqueue_mirror.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"log/slog"
+	"path/filepath"
+)
+
+// Helpers for plugging fsnotify v1.9.0's kqueue per-file FD leak on macOS.
+// Shared between ProjectWatcher (which watches many directories under a repo
+// root) and Watcher (which watches a single ledger directory). On both, when
+// a watched directory is renamed or removed mid-watch, fsnotify's kqueue
+// backend at backend_kqueue.go:489 calls w.remove(name, false) — closing the
+// dir's own FD but leaving the per-file FDs that watchDirectoryFiles
+// auto-opened. We compensate by snapshotting the file set ourselves and
+// calling watcher.Remove(child) per file, which routes through w.remove(name,
+// true) and closes the FD via unix.Close at backend_kqueue.go:302.
+//
+// Returns nil unconditionally on non-Darwin: inotify uses one FD per watch,
+// not per file, so there's nothing to mirror.
+//
+// See internal/daemon/project_watcher.go for the full diagnosis (host
+// symptom: lsof on the daemon PID hung because the FD table was overflowing).
+
+// snapshotKqueueChildren reads absolute paths of regular files inside path,
+// capped at maxFilesPerWatchedDir. Errors are logged at Debug and treated as
+// "no children" — drift is recovered by the periodic re-snapshot in
+// pruneStaleWatches and by event-driven incremental updates.
+func snapshotKqueueChildren(fs FileSystem, path string, logger *slog.Logger) []string {
+	if !childMirrorEnabled {
+		return nil
+	}
+	entries, err := fs.ReadDir(path)
+	if err != nil {
+		logger.Debug("kqueue mirror: ReadDir failed during snapshot",
+			"path", path, "error", err)
+		return nil
+	}
+	// Cap allocation up front so a pathological directory (millions of
+	// generated files) can't dominate startup memory or snapshot cost.
+	// Memory bound is independent of directory cardinality.
+	capLen := len(entries)
+	if capLen > maxFilesPerWatchedDir {
+		capLen = maxFilesPerWatchedDir
+	}
+	out := make([]string, 0, capLen)
+	truncated := false
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if len(out) >= maxFilesPerWatchedDir {
+			truncated = true
+			break
+		}
+		out = append(out, filepath.Join(path, e.Name()))
+	}
+	if truncated {
+		logger.Warn("kqueue mirror: per-dir child snapshot truncated",
+			"path", path, "cap", maxFilesPerWatchedDir,
+			"total_entries", len(entries),
+			"impact", "FD-leak guarantee weakened for files beyond cap")
+	}
+	return out
+}
+
+// unionKqueueChildren merges two child-path slices, preserving order from the
+// first and de-duplicating. Used to combine pre-Add and post-Add snapshots
+// and close the TOCTOU race against fsnotify's watchDirectoryFiles.
+func unionKqueueChildren(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, s := range a {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	for _, s := range b {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -155,6 +155,15 @@ type StatusData struct {
 	StartupDurationMs  int64 `json:"startup_duration_ms,omitempty"`
 	ThrottleDurationMs int64 `json:"throttle_duration_ms,omitempty"`
 
+	// open file descriptor count for the daemon process (sampled at status
+	// query time). -1 if the platform can't expose it. OpenFDLimit is the
+	// soft RLIMIT_NOFILE (0 if unknown). Used to surface FD pressure before
+	// the daemon hits the wall — see internal/daemon/fd_count.go for the
+	// rationale (a leak that hung lsof in prod went undetected for months
+	// because nothing graphed FD count).
+	OpenFDs     int    `json:"open_fds,omitempty"`
+	OpenFDLimit uint64 `json:"open_fd_limit,omitempty"`
+
 	// code index status
 	CodeDB *CodeDBStats `json:"code_db,omitempty"`
 

--- a/internal/daemon/project_watcher.go
+++ b/internal/daemon/project_watcher.go
@@ -502,48 +502,10 @@ func (pw *ProjectWatcher) addDir(watcher FileSystemWatcher, path string) {
 	pw.mu.Unlock()
 }
 
-// snapshotDirFiles returns absolute child file paths for path. Best-effort:
-// errors are logged at Debug and returned as nil. Truncated to
-// maxFilesPerWatchedDir with a single Warn log so we can tell from telemetry
-// which dirs are pathological.
-//
-// Returns nil unconditionally on non-Darwin — the mirror is only used to
-// compensate for fsnotify's kqueue per-file FD leak on macOS.
+// snapshotDirFiles delegates to the package-level kqueue mirror helper. Kept
+// as a method so the existing call sites and tests don't need to change.
 func (pw *ProjectWatcher) snapshotDirFiles(path string) []string {
-	if !childMirrorEnabled {
-		return nil
-	}
-	entries, err := pw.fs.ReadDir(path)
-	if err != nil {
-		pw.logger.Debug("project watcher: ReadDir failed during snapshot",
-			"path", path, "error", err)
-		return nil
-	}
-	// Cap allocation up front: even if entries has millions of items, we
-	// only ever retain maxFilesPerWatchedDir of them and stop iterating
-	// once full. Memory bound is independent of directory cardinality.
-	capLen := len(entries)
-	if capLen > maxFilesPerWatchedDir {
-		capLen = maxFilesPerWatchedDir
-	}
-	out := make([]string, 0, capLen)
-	truncated := false
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if len(out) >= maxFilesPerWatchedDir {
-			truncated = true
-			break
-		}
-		out = append(out, filepath.Join(path, e.Name()))
-	}
-	if truncated {
-		pw.logger.Warn("project watcher: per-dir child snapshot truncated",
-			"path", path, "cap", maxFilesPerWatchedDir, "total_entries", len(entries),
-			"impact", "FD-leak guarantee weakened for files beyond cap")
-	}
-	return out
+	return snapshotKqueueChildren(pw.fs, path, pw.logger)
 }
 
 // dirMtime returns the directory mtime, used by pruneStaleWatches as a cheap
@@ -560,33 +522,11 @@ func (pw *ProjectWatcher) dirMtime(path string) time.Time {
 	return info.ModTime()
 }
 
-// unionChildren merges two child-path slices, preserving order from the first
-// and de-duplicating. Used by addDir to combine pre-Add and post-Add
-// snapshots and close the TOCTOU race against fsnotify's watchDirectoryFiles.
+// unionChildren is a thin wrapper around the package-level kqueue mirror
+// helper, kept so the existing call sites in addDir/acquireDir don't need
+// renaming.
 func unionChildren(a, b []string) []string {
-	if len(a) == 0 {
-		return b
-	}
-	if len(b) == 0 {
-		return a
-	}
-	seen := make(map[string]struct{}, len(a)+len(b))
-	out := make([]string, 0, len(a)+len(b))
-	for _, s := range a {
-		if _, dup := seen[s]; dup {
-			continue
-		}
-		seen[s] = struct{}{}
-		out = append(out, s)
-	}
-	for _, s := range b {
-		if _, dup := seen[s]; dup {
-			continue
-		}
-		seen[s] = struct{}{}
-		out = append(out, s)
-	}
-	return out
+	return unionKqueueChildren(a, b)
 }
 
 // handleEvent processes a single fsnotify event.

--- a/internal/daemon/project_watcher.go
+++ b/internal/daemon/project_watcher.go
@@ -567,6 +567,34 @@ func (pw *ProjectWatcher) handleEvent(watcher FileSystemWatcher, event fsnotify.
 		}
 	}
 
+	// individual file Create inside a watched dir — add to the parent's
+	// child snapshot. fsnotify v1.9.0's kqueue backend reacts to NOTE_WRITE
+	// on the directory by calling dirChange → sendCreateIfNew, which opens
+	// a per-file kqueue FD for any new file. So files created post-Add do
+	// have FDs we'll need to release if the parent later disappears. Skip
+	// if the parent isn't tracked or we're already at the snapshot cap.
+	// Darwin-only.
+	if childMirrorEnabled && !isDir && event.Op&fsnotify.Create != 0 {
+		parent := filepath.Dir(event.Name)
+		pw.mu.Lock()
+		if _, watched := pw.watchedDirs[parent]; watched {
+			children := pw.dirChildren[parent]
+			if len(children) < maxFilesPerWatchedDir {
+				present := false
+				for _, c := range children {
+					if c == event.Name {
+						present = true
+						break
+					}
+				}
+				if !present {
+					pw.dirChildren[parent] = append(children, event.Name)
+				}
+			}
+		}
+		pw.mu.Unlock()
+	}
+
 	// individual file Remove/Rename inside a watched dir — drop the file
 	// from the parent's child snapshot. fsnotify's kqueue backend already
 	// closed the per-file FD via the file's own NOTE_DELETE; keeping it in

--- a/internal/daemon/project_watcher.go
+++ b/internal/daemon/project_watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/sageox/ox/internal/gitutil"
 )
+
+// childMirrorEnabled reports whether we maintain a userspace mirror of
+// fsnotify's per-file child set. Only useful on macOS where fsnotify's
+// kqueue backend opens 1+N FDs per watched directory and skips closing the
+// per-file FDs on dir Remove/Rename. On Linux/inotify each watch is a single
+// FD (not per-file), so the mirror is dead weight.
+var childMirrorEnabled = runtime.GOOS == "darwin"
 
 // ChangeType categorizes a filesystem change.
 type ChangeType string
@@ -342,7 +350,15 @@ type ProjectWatcher struct {
 	// forcing fsnotify down its file-Remove path which closes the FD via
 	// unix.Close. Keyed by absolute directory path; values are absolute
 	// child file paths.
+	//
+	// Empty on Linux (childMirrorEnabled=false) — inotify uses one FD per
+	// watch, not per file, so there's nothing to mirror.
 	dirChildren map[string][]string
+	// dirMtimes tracks the directory mtime captured at snapshot time so the
+	// periodic re-sync in pruneStaleWatches can detect drift cheaply (one
+	// stat call per dir vs a full ReadDir). Only populated when
+	// childMirrorEnabled.
+	dirMtimes map[string]time.Time
 }
 
 // NewProjectWatcher creates a new project watcher.
@@ -363,6 +379,7 @@ func NewProjectWatcher(
 		tracker:        tracker,
 		watchedDirs:    make(map[string]struct{}),
 		dirChildren:    make(map[string][]string),
+		dirMtimes:      make(map[string]time.Time),
 	}
 }
 
@@ -458,35 +475,58 @@ func (pw *ProjectWatcher) walkAndWatch(watcher FileSystemWatcher) {
 	}
 }
 
-// addDir adds a single directory to the watcher and snapshots the per-file
-// child set that fsnotify will auto-watch. The snapshot is consulted on
-// Remove/Rename to force fsnotify to close each child FD.
+// addDir adds a single directory to the watcher and (on macOS) snapshots the
+// per-file child set that fsnotify will auto-watch. The snapshot is consulted
+// on Remove/Rename to force fsnotify to close each child FD.
+//
+// To close the TOCTOU window between snapshot and Add, we snapshot twice
+// (pre-Add and post-Add) and union the results. A file racing into the dir
+// will be present in at least one snapshot; a file racing out leaves a
+// harmless ErrNonExistentWatch on its eventual Remove.
 func (pw *ProjectWatcher) addDir(watcher FileSystemWatcher, path string) {
+	pre := pw.snapshotDirFiles(path)
 	if err := watcher.Add(path); err != nil {
 		pw.logger.Debug("project watcher: failed to watch dir",
 			"path", path, "error", err)
 		return
 	}
-	children := pw.snapshotDirFiles(path)
+	post := pw.snapshotDirFiles(path)
+	children := unionChildren(pre, post)
+	mtime := pw.dirMtime(path)
 	pw.mu.Lock()
 	pw.watchedDirs[path] = struct{}{}
-	pw.dirChildren[path] = children
+	if childMirrorEnabled {
+		pw.dirChildren[path] = children
+		pw.dirMtimes[path] = mtime
+	}
 	pw.mu.Unlock()
 }
 
 // snapshotDirFiles returns absolute child file paths for path. Best-effort:
-// errors are logged at Debug and treated as "no children" — drift is recovered
-// by pruneStaleWatches and by per-file Create events that update the snapshot
-// in addDir. Truncated to maxFilesPerWatchedDir with a single Warn log so we
-// can tell from telemetry which dirs are pathological.
+// errors are logged at Debug and returned as nil. Truncated to
+// maxFilesPerWatchedDir with a single Warn log so we can tell from telemetry
+// which dirs are pathological.
+//
+// Returns nil unconditionally on non-Darwin — the mirror is only used to
+// compensate for fsnotify's kqueue per-file FD leak on macOS.
 func (pw *ProjectWatcher) snapshotDirFiles(path string) []string {
+	if !childMirrorEnabled {
+		return nil
+	}
 	entries, err := pw.fs.ReadDir(path)
 	if err != nil {
 		pw.logger.Debug("project watcher: ReadDir failed during snapshot",
 			"path", path, "error", err)
 		return nil
 	}
-	out := make([]string, 0, len(entries))
+	// Cap allocation up front: even if entries has millions of items, we
+	// only ever retain maxFilesPerWatchedDir of them and stop iterating
+	// once full. Memory bound is independent of directory cardinality.
+	capLen := len(entries)
+	if capLen > maxFilesPerWatchedDir {
+		capLen = maxFilesPerWatchedDir
+	}
+	out := make([]string, 0, capLen)
 	truncated := false
 	for _, e := range entries {
 		if e.IsDir() {
@@ -502,6 +542,49 @@ func (pw *ProjectWatcher) snapshotDirFiles(path string) []string {
 		pw.logger.Warn("project watcher: per-dir child snapshot truncated",
 			"path", path, "cap", maxFilesPerWatchedDir, "total_entries", len(entries),
 			"impact", "FD-leak guarantee weakened for files beyond cap")
+	}
+	return out
+}
+
+// dirMtime returns the directory mtime, used by pruneStaleWatches as a cheap
+// drift detector. Returns zero time on error or non-Darwin (where we don't
+// use it).
+func (pw *ProjectWatcher) dirMtime(path string) time.Time {
+	if !childMirrorEnabled {
+		return time.Time{}
+	}
+	info, err := pw.fs.Stat(path)
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
+}
+
+// unionChildren merges two child-path slices, preserving order from the first
+// and de-duplicating. Used by addDir to combine pre-Add and post-Add
+// snapshots and close the TOCTOU race against fsnotify's watchDirectoryFiles.
+func unionChildren(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, s := range a {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	for _, s := range b {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
 	}
 	return out
 }
@@ -544,6 +627,27 @@ func (pw *ProjectWatcher) handleEvent(watcher FileSystemWatcher, event fsnotify.
 		}
 	}
 
+	// individual file Remove/Rename inside a watched dir — drop the file
+	// from the parent's child snapshot. fsnotify's kqueue backend already
+	// closed the per-file FD via the file's own NOTE_DELETE; keeping it in
+	// the snapshot would cause a noisy ErrNonExistentWatch on the next dir
+	// Remove and waste effort. Darwin-only since dirChildren is empty on
+	// other platforms.
+	if childMirrorEnabled && !isDir && event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		parent := filepath.Dir(event.Name)
+		pw.mu.Lock()
+		if children, ok := pw.dirChildren[parent]; ok {
+			out := children[:0]
+			for _, c := range children {
+				if c != event.Name {
+					out = append(out, c)
+				}
+			}
+			pw.dirChildren[parent] = out
+		}
+		pw.mu.Unlock()
+	}
+
 	// directory removed — remove from tracked set and release kqueue/inotify FDs.
 	// fsnotify v1.9.0's kqueue backend (backend_kqueue.go:489) calls
 	// w.remove(name, false) on NOTE_DELETE, which does NOT recursively close
@@ -561,6 +665,7 @@ func (pw *ProjectWatcher) handleEvent(watcher FileSystemWatcher, event fsnotify.
 		delete(pw.watchedDirs, event.Name)
 		childFiles := pw.dirChildren[event.Name]
 		delete(pw.dirChildren, event.Name)
+		delete(pw.dirMtimes, event.Name)
 
 		prefix := event.Name + string(filepath.Separator)
 		var descendantDirs []string
@@ -573,6 +678,7 @@ func (pw *ProjectWatcher) handleEvent(watcher FileSystemWatcher, event fsnotify.
 			childFiles = append(childFiles, pw.dirChildren[d]...)
 			delete(pw.watchedDirs, d)
 			delete(pw.dirChildren, d)
+			delete(pw.dirMtimes, d)
 		}
 		pw.mu.Unlock()
 
@@ -585,7 +691,8 @@ func (pw *ProjectWatcher) handleEvent(watcher FileSystemWatcher, event fsnotify.
 		// The crucial bit: explicitly Remove each tracked child file so
 		// fsnotify closes its per-file kqueue FD. Tolerates ErrNonExistentWatch
 		// for files that the kernel already auto-cleaned via individual
-		// NOTE_DELETE — that's a no-op on our side.
+		// NOTE_DELETE — that's a no-op on our side. childFiles is empty on
+		// non-Darwin so this loop costs nothing there.
 		for _, f := range childFiles {
 			_ = watcher.Remove(f)
 		}
@@ -624,20 +731,56 @@ func (pw *ProjectWatcher) pruneStaleWatches(watcher FileSystemWatcher) {
 			children := pw.dirChildren[absDir]
 			delete(pw.watchedDirs, absDir)
 			delete(pw.dirChildren, absDir)
+			delete(pw.dirMtimes, absDir)
 			pw.mu.Unlock()
 			_ = watcher.Remove(absDir)
 			// Force fsnotify to close per-file kqueue FDs for any child files
 			// it auto-watched on Add. Without this, pruning a stale dir leaks
 			// the same per-file FDs that the Remove/Rename handler plugs.
+			// children is empty on non-Darwin — no-op there.
 			for _, f := range children {
 				_ = watcher.Remove(f)
 			}
 			pruned++
+			continue
+		}
+
+		// Still-tracked dir: re-snapshot if mtime advanced since last check.
+		// This is the safety net for any drift the event-driven incremental
+		// updates miss (e.g., events the kernel coalesced under churn).
+		// Cheap on Darwin (one stat per watched dir per refresh), no-op on
+		// other platforms because the mirror is unused there.
+		if childMirrorEnabled {
+			pw.resnapshotIfChanged(absDir)
 		}
 	}
 	if pruned > 0 {
 		pw.logger.Info("project watcher: pruned stale watches", "count", pruned)
 	}
+}
+
+// resnapshotIfChanged re-reads the per-file child snapshot for absDir if its
+// directory mtime has advanced since the last snapshot. Catches drift from
+// kernel-event coalescing without requiring a full ReadDir on every cycle.
+// Caller must NOT hold pw.mu.
+func (pw *ProjectWatcher) resnapshotIfChanged(absDir string) {
+	currentMtime := pw.dirMtime(absDir)
+	if currentMtime.IsZero() {
+		return // dir gone or unstattable; Remove/Rename handler will catch up
+	}
+	pw.mu.Lock()
+	last, known := pw.dirMtimes[absDir]
+	pw.mu.Unlock()
+	if known && !currentMtime.After(last) {
+		return // no drift since last snapshot
+	}
+	fresh := pw.snapshotDirFiles(absDir)
+	pw.mu.Lock()
+	if _, stillWatched := pw.watchedDirs[absDir]; stillWatched {
+		pw.dirChildren[absDir] = fresh
+		pw.dirMtimes[absDir] = currentMtime
+	}
+	pw.mu.Unlock()
 }
 
 // WatchedDirCount returns the number of directories being watched.
@@ -665,18 +808,26 @@ type watchedDirHandle struct {
 }
 
 // acquireDir wraps addDir, returning a handle whose Release is paired with
-// the underlying Add. Equivalent in effect to addDir but enforces the
-// register-and-release pairing through the type system rather than convention.
+// the underlying Add. Equivalent in effect to addDir (including the pre/post
+// snapshot to close the TOCTOU window with watchDirectoryFiles) but enforces
+// the register-and-release pairing through the type system rather than
+// convention.
 func (pw *ProjectWatcher) acquireDir(watcher FileSystemWatcher, path string) (*watchedDirHandle, error) {
+	pre := pw.snapshotDirFiles(path)
 	if err := watcher.Add(path); err != nil {
 		pw.logger.Debug("project watcher: acquireDir failed",
 			"path", path, "error", err)
 		return nil, err
 	}
-	children := pw.snapshotDirFiles(path)
+	post := pw.snapshotDirFiles(path)
+	children := unionChildren(pre, post)
+	mtime := pw.dirMtime(path)
 	pw.mu.Lock()
 	pw.watchedDirs[path] = struct{}{}
-	pw.dirChildren[path] = children
+	if childMirrorEnabled {
+		pw.dirChildren[path] = children
+		pw.dirMtimes[path] = mtime
+	}
 	pw.mu.Unlock()
 	return &watchedDirHandle{watcher: watcher, path: path, pw: pw}, nil
 }
@@ -690,6 +841,7 @@ func (h *watchedDirHandle) Release() {
 	h.pw.mu.Lock()
 	children := h.pw.dirChildren[h.path]
 	delete(h.pw.dirChildren, h.path)
+	delete(h.pw.dirMtimes, h.path)
 	delete(h.pw.watchedDirs, h.path)
 	h.pw.mu.Unlock()
 	for _, f := range children {

--- a/internal/daemon/project_watcher.go
+++ b/internal/daemon/project_watcher.go
@@ -306,6 +306,16 @@ func (m *GitTrackedMatcher) TrackedDirs() []string {
 const (
 	maxWatchedDirs = 10_000
 
+	// maxFilesPerWatchedDir caps the per-dir child snapshot. fsnotify's kqueue
+	// backend opens 1+N FDs per watched directory (1 for the dir, N per file via
+	// watchDirectoryFiles). On Remove/Rename we replay this set to force fsnotify
+	// to close the per-file FDs. A pathological directory with millions of files
+	// would balloon both startup memory and the snapshot cost — cap it. Truncated
+	// dirs lose the leak guarantee for any file beyond the cap, but those FDs
+	// are bounded by file count regardless, and any single dir with >10k tracked
+	// files almost certainly wants .gitignore tuning anyway.
+	maxFilesPerWatchedDir = 10_000
+
 	// gitRefreshInterval controls how often the git-tracked file set is refreshed.
 	gitRefreshInterval = 30 * time.Second
 )
@@ -323,6 +333,16 @@ type ProjectWatcher struct {
 
 	mu          sync.Mutex
 	watchedDirs map[string]struct{}
+	// dirChildren mirrors the per-directory child file set that fsnotify's
+	// kqueue backend opens internally via watchDirectoryFiles. We need our
+	// own copy because fsnotify's set is private and on Remove/Rename its
+	// kqueue backend (backend_kqueue.go:489) calls w.remove(name, false) —
+	// the false flag skips closing the per-file FDs. By replaying this
+	// snapshot on Remove/Rename we issue watcher.Remove(child) per file,
+	// forcing fsnotify down its file-Remove path which closes the FD via
+	// unix.Close. Keyed by absolute directory path; values are absolute
+	// child file paths.
+	dirChildren map[string][]string
 }
 
 // NewProjectWatcher creates a new project watcher.
@@ -342,6 +362,7 @@ func NewProjectWatcher(
 		accumulator:    accumulator,
 		tracker:        tracker,
 		watchedDirs:    make(map[string]struct{}),
+		dirChildren:    make(map[string][]string),
 	}
 }
 
@@ -437,16 +458,52 @@ func (pw *ProjectWatcher) walkAndWatch(watcher FileSystemWatcher) {
 	}
 }
 
-// addDir adds a single directory to the watcher.
+// addDir adds a single directory to the watcher and snapshots the per-file
+// child set that fsnotify will auto-watch. The snapshot is consulted on
+// Remove/Rename to force fsnotify to close each child FD.
 func (pw *ProjectWatcher) addDir(watcher FileSystemWatcher, path string) {
 	if err := watcher.Add(path); err != nil {
 		pw.logger.Debug("project watcher: failed to watch dir",
 			"path", path, "error", err)
 		return
 	}
+	children := pw.snapshotDirFiles(path)
 	pw.mu.Lock()
 	pw.watchedDirs[path] = struct{}{}
+	pw.dirChildren[path] = children
 	pw.mu.Unlock()
+}
+
+// snapshotDirFiles returns absolute child file paths for path. Best-effort:
+// errors are logged at Debug and treated as "no children" — drift is recovered
+// by pruneStaleWatches and by per-file Create events that update the snapshot
+// in addDir. Truncated to maxFilesPerWatchedDir with a single Warn log so we
+// can tell from telemetry which dirs are pathological.
+func (pw *ProjectWatcher) snapshotDirFiles(path string) []string {
+	entries, err := pw.fs.ReadDir(path)
+	if err != nil {
+		pw.logger.Debug("project watcher: ReadDir failed during snapshot",
+			"path", path, "error", err)
+		return nil
+	}
+	out := make([]string, 0, len(entries))
+	truncated := false
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if len(out) >= maxFilesPerWatchedDir {
+			truncated = true
+			break
+		}
+		out = append(out, filepath.Join(path, e.Name()))
+	}
+	if truncated {
+		pw.logger.Warn("project watcher: per-dir child snapshot truncated",
+			"path", path, "cap", maxFilesPerWatchedDir, "total_entries", len(entries),
+			"impact", "FD-leak guarantee weakened for files beyond cap")
+	}
+	return out
 }
 
 // handleEvent processes a single fsnotify event.
@@ -490,29 +547,47 @@ func (pw *ProjectWatcher) handleEvent(watcher FileSystemWatcher, event fsnotify.
 	// directory removed — remove from tracked set and release kqueue/inotify FDs.
 	// fsnotify v1.9.0's kqueue backend (backend_kqueue.go:489) calls
 	// w.remove(name, false) on NOTE_DELETE, which does NOT recursively close
-	// children added via watchDirectoryFiles. Without explicit recursion we
-	// leak one FD per descendant on every rm-rf; over a long-lived daemon
-	// against churning build-output dirs, FDs accumulate without bound.
+	// the per-file FDs that watchDirectoryFiles auto-opened. We compensate by
+	// replaying our snapshot of those file paths and calling watcher.Remove on
+	// each — which routes through w.remove(name, true) in fsnotify, closing
+	// the FD via unix.Close. We also walk descendant watched dirs (in case
+	// the kernel only fires a single Remove for the top of an rm -rf), and
+	// flush their snapshots too. Without this, a long-lived daemon against
+	// churning build-output dirs accumulates FDs without bound — the host
+	// symptom we saw was lsof itself hanging on the daemon PID.
 	if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
 		pw.mu.Lock()
 		_, wasWatched := pw.watchedDirs[event.Name]
 		delete(pw.watchedDirs, event.Name)
+		childFiles := pw.dirChildren[event.Name]
+		delete(pw.dirChildren, event.Name)
+
 		prefix := event.Name + string(filepath.Separator)
-		var children []string
+		var descendantDirs []string
 		for d := range pw.watchedDirs {
 			if strings.HasPrefix(d, prefix) {
-				children = append(children, d)
+				descendantDirs = append(descendantDirs, d)
 			}
 		}
-		for _, d := range children {
+		for _, d := range descendantDirs {
+			childFiles = append(childFiles, pw.dirChildren[d]...)
 			delete(pw.watchedDirs, d)
+			delete(pw.dirChildren, d)
 		}
 		pw.mu.Unlock()
+
 		if wasWatched {
 			_ = watcher.Remove(event.Name)
 		}
-		for _, d := range children {
+		for _, d := range descendantDirs {
 			_ = watcher.Remove(d)
+		}
+		// The crucial bit: explicitly Remove each tracked child file so
+		// fsnotify closes its per-file kqueue FD. Tolerates ErrNonExistentWatch
+		// for files that the kernel already auto-cleaned via individual
+		// NOTE_DELETE — that's a no-op on our side.
+		for _, f := range childFiles {
+			_ = watcher.Remove(f)
 		}
 	}
 
@@ -545,10 +620,18 @@ func (pw *ProjectWatcher) pruneStaleWatches(watcher FileSystemWatcher) {
 			continue
 		}
 		if !pw.tracker.IsTrackedDir(relDir) {
-			_ = watcher.Remove(absDir)
 			pw.mu.Lock()
+			children := pw.dirChildren[absDir]
 			delete(pw.watchedDirs, absDir)
+			delete(pw.dirChildren, absDir)
 			pw.mu.Unlock()
+			_ = watcher.Remove(absDir)
+			// Force fsnotify to close per-file kqueue FDs for any child files
+			// it auto-watched on Add. Without this, pruning a stale dir leaks
+			// the same per-file FDs that the Remove/Rename handler plugs.
+			for _, f := range children {
+				_ = watcher.Remove(f)
+			}
 			pruned++
 		}
 	}
@@ -562,4 +645,55 @@ func (pw *ProjectWatcher) WatchedDirCount() int {
 	pw.mu.Lock()
 	defer pw.mu.Unlock()
 	return len(pw.watchedDirs)
+}
+
+// watchedDirHandle pairs a watcher.Add with the per-file child snapshot and a
+// matching Release that closes everything fsnotify opened, including the
+// per-file FDs its kqueue backend auto-opens via watchDirectoryFiles.
+//
+// This is NOT RAII — Go has no scope-bound deterministic cleanup that survives
+// the function in which the resource is held — and the daemon's watcher must
+// outlive any single function. The handle is a discipline helper: a future
+// caller that grabs a watch through acquireDir cannot forget to register the
+// children for cleanup, because the only path to a watch goes through this
+// type. Callers must call Release explicitly (or via defer) before the handle
+// is dropped.
+type watchedDirHandle struct {
+	watcher FileSystemWatcher
+	path    string
+	pw      *ProjectWatcher
+}
+
+// acquireDir wraps addDir, returning a handle whose Release is paired with
+// the underlying Add. Equivalent in effect to addDir but enforces the
+// register-and-release pairing through the type system rather than convention.
+func (pw *ProjectWatcher) acquireDir(watcher FileSystemWatcher, path string) (*watchedDirHandle, error) {
+	if err := watcher.Add(path); err != nil {
+		pw.logger.Debug("project watcher: acquireDir failed",
+			"path", path, "error", err)
+		return nil, err
+	}
+	children := pw.snapshotDirFiles(path)
+	pw.mu.Lock()
+	pw.watchedDirs[path] = struct{}{}
+	pw.dirChildren[path] = children
+	pw.mu.Unlock()
+	return &watchedDirHandle{watcher: watcher, path: path, pw: pw}, nil
+}
+
+// Release closes the watch on the dir AND every per-file FD fsnotify opened
+// for it. Safe to call multiple times.
+func (h *watchedDirHandle) Release() {
+	if h == nil || h.pw == nil {
+		return
+	}
+	h.pw.mu.Lock()
+	children := h.pw.dirChildren[h.path]
+	delete(h.pw.dirChildren, h.path)
+	delete(h.pw.watchedDirs, h.path)
+	h.pw.mu.Unlock()
+	for _, f := range children {
+		_ = h.watcher.Remove(f)
+	}
+	_ = h.watcher.Remove(h.path)
 }

--- a/internal/daemon/project_watcher_test.go
+++ b/internal/daemon/project_watcher_test.go
@@ -879,6 +879,19 @@ func TestProjectWatcher_CreateSkipsAlreadyWatched(t *testing.T) {
 
 // --- Per-file FD-leak tests (epic ox-5pwx) ---
 
+// forceChildMirrorForTest enables the kqueue child mirror for the duration
+// of the test, regardless of GOOS. The mirror is gated by
+// childMirrorEnabled = (runtime.GOOS == "darwin") in production, so without
+// this helper the mock-based tests below would silently no-op on Linux CI
+// runners and still pass — which would defeat their purpose. Restored in
+// t.Cleanup so test order doesn't matter.
+func forceChildMirrorForTest(t *testing.T) {
+	t.Helper()
+	old := childMirrorEnabled
+	childMirrorEnabled = true
+	t.Cleanup(func() { childMirrorEnabled = old })
+}
+
 // TestProjectWatcher_AddDir_SnapshotsChildren verifies that addDir captures
 // the per-file child set so Remove/Rename can replay it. fsnotify's kqueue
 // backend opens 1+N FDs per watched dir (1 dir + N per file via
@@ -887,6 +900,7 @@ func TestProjectWatcher_CreateSkipsAlreadyWatched(t *testing.T) {
 // Failure prevented: per-file FD leak invisible to userspace because
 // fsnotify exposes it only through a package-private map.
 func TestProjectWatcher_AddDir_SnapshotsChildren(t *testing.T) {
+	forceChildMirrorForTest(t)
 	mockWatcher := NewMockFileSystemWatcher()
 	mockFS := NewMockFileSystem()
 
@@ -930,6 +944,7 @@ func TestProjectWatcher_AddDir_SnapshotsChildren(t *testing.T) {
 // Failure prevented: long-lived daemon FD growth from build-output churn,
 // the reproducible host symptom that made `lsof` itself hang on the daemon PID.
 func TestProjectWatcher_RemoveCallsUnwatchOnChildFiles(t *testing.T) {
+	forceChildMirrorForTest(t)
 	mockWatcher := NewMockFileSystemWatcher()
 	mockFS := NewMockFileSystem()
 
@@ -995,6 +1010,7 @@ func TestProjectWatcher_RemoveCallsUnwatchOnChildFiles(t *testing.T) {
 // Failure prevented: gitignore changes / branch switches accumulate per-file
 // FDs over the lifetime of the daemon.
 func TestProjectWatcher_PruneStaleWatches_RemovesChildFiles(t *testing.T) {
+	forceChildMirrorForTest(t)
 	mockWatcher := NewMockFileSystemWatcher()
 	mockFS := NewMockFileSystem()
 
@@ -1049,6 +1065,7 @@ func TestProjectWatcher_PruneStaleWatches_RemovesChildFiles(t *testing.T) {
 // Failure prevented: cold-start memory/CPU spike on monorepos with one
 // pathological generated-files directory.
 func TestProjectWatcher_SnapshotChildren_BoundedAtCap(t *testing.T) {
+	forceChildMirrorForTest(t)
 	mockWatcher := NewMockFileSystemWatcher()
 	mockFS := NewMockFileSystem()
 
@@ -1092,6 +1109,7 @@ func TestProjectWatcher_SnapshotChildren_BoundedAtCap(t *testing.T) {
 // Failure prevented: future caller adds a watch via the handle but forgets
 // the children-cleanup half of the contract.
 func TestProjectWatcher_AcquireRelease_TypedHandle(t *testing.T) {
+	forceChildMirrorForTest(t)
 	mockWatcher := NewMockFileSystemWatcher()
 	mockFS := NewMockFileSystem()
 

--- a/internal/daemon/project_watcher_test.go
+++ b/internal/daemon/project_watcher_test.go
@@ -1211,26 +1211,44 @@ func TestProjectWatcher_NoFDLeak_RealWatcher_Darwin(t *testing.T) {
 
 	// Churn: 50 iterations of mkdir + N files + rm-rf. Each iteration
 	// pre-fix would open (1 + 5) kqueue FDs and only release 1 — net +5/round.
+	//
+	// Wait for an observable readiness signal between mkdir and rm-rf
+	// (the watcher actually registers the new dir) instead of a fixed sleep.
+	// Fixed sleeps were racy on slow Darwin runners — if rm-rf fires before
+	// fsnotify attaches the per-file watches, the test becomes a false
+	// negative. require.Eventually polls cheaply.
 	const iterations = 50
 	const filesPerDir = 5
+	const churnReadyTimeout = 500 * time.Millisecond
+	const churnReadyPoll = 1 * time.Millisecond
 	for i := 0; i < iterations; i++ {
 		sub := filepath.Join(dir, fmt.Sprintf("churn-%04d", i))
+		preCount := pw.WatchedDirCount()
 		require.NoError(t, os.MkdirAll(sub, 0o755))
 		for j := 0; j < filesPerDir; j++ {
 			f := filepath.Join(sub, fmt.Sprintf("f%d.go", j))
 			require.NoError(t, os.WriteFile(f, []byte("package x\n"), 0o644))
 		}
-		// Give fsnotify a beat to register the dir + auto-watch the files
-		// before we delete them. Without this, the kernel may coalesce events
-		// and we don't exercise the per-file FD path.
-		time.Sleep(2 * time.Millisecond)
+		// Wait until the daemon has actually added the new dir to its watch
+		// set. WatchedDirCount() advancing past preCount is the observable
+		// proxy for "fsnotify Add() returned and watchDirectoryFiles ran."
+		// Falling back to a short sleep if the count never advances would
+		// silently turn this into a no-op test, so we require strictly.
+		require.Eventually(t, func() bool {
+			return pw.WatchedDirCount() > preCount
+		}, churnReadyTimeout, churnReadyPoll, "watcher should register churn dir %d (preCount=%d)", i, preCount)
+
 		require.NoError(t, os.RemoveAll(sub))
-		time.Sleep(2 * time.Millisecond)
+
+		// Wait for the Remove handler to drain back to the pre-mkdir count
+		// (give or take 1 for any stragglers from prior iterations).
+		require.Eventually(t, func() bool {
+			return pw.WatchedDirCount() <= preCount
+		}, churnReadyTimeout, churnReadyPoll, "watcher should drain churn dir %d (preCount=%d, current=%d)", i, preCount, pw.WatchedDirCount())
 	}
 
-	// Allow handler to drain.
+	// Allow handler to drain any residual events.
 	require.Eventually(t, func() bool {
-		// All churn dirs should have been removed from watchedDirs.
 		return pw.WatchedDirCount() <= 5
 	}, 5*time.Second, 50*time.Millisecond, "watcher should drain churn dirs")
 	time.Sleep(200 * time.Millisecond)

--- a/internal/daemon/project_watcher_test.go
+++ b/internal/daemon/project_watcher_test.go
@@ -2,9 +2,11 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -873,4 +875,397 @@ func TestProjectWatcher_CreateSkipsAlreadyWatched(t *testing.T) {
 	assert.Equal(t, 1, addsForPath, "Add must be called exactly once per path")
 	assert.Equal(t, beforeAdds, len(mockWatcher.AddedPaths()),
 		"redundant Create events must not call Add again")
+}
+
+// --- Per-file FD-leak tests (epic ox-5pwx) ---
+
+// TestProjectWatcher_AddDir_SnapshotsChildren verifies that addDir captures
+// the per-file child set so Remove/Rename can replay it. fsnotify's kqueue
+// backend opens 1+N FDs per watched dir (1 dir + N per file via
+// watchDirectoryFiles); without the snapshot we can't tell fsnotify to close
+// the per-file FDs on rm-rf.
+// Failure prevented: per-file FD leak invisible to userspace because
+// fsnotify exposes it only through a package-private map.
+func TestProjectWatcher_AddDir_SnapshotsChildren(t *testing.T) {
+	mockWatcher := NewMockFileSystemWatcher()
+	mockFS := NewMockFileSystem()
+
+	dir := t.TempDir()
+	pkgDir := filepath.Join(dir, "pkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+	mockFS.AddDir(pkgDir, []string{"a.go", "b.go", "c.go"})
+
+	pw := NewProjectWatcher(
+		dir, slogDiscard(),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS, NewChangeAccumulator(50*time.Millisecond),
+		&GitTrackedMatcher{
+			projectRoot: dir, trackedDirs: map[string]struct{}{}, trackedFiles: map[string]struct{}{},
+			logger: slogDiscard(),
+		},
+	)
+
+	pw.addDir(mockWatcher, pkgDir)
+
+	pw.mu.Lock()
+	children := append([]string(nil), pw.dirChildren[pkgDir]...)
+	pw.mu.Unlock()
+
+	assert.ElementsMatch(t,
+		[]string{
+			filepath.Join(pkgDir, "a.go"),
+			filepath.Join(pkgDir, "b.go"),
+			filepath.Join(pkgDir, "c.go"),
+		},
+		children,
+		"addDir must snapshot all non-dir entries as absolute paths")
+}
+
+// TestProjectWatcher_RemoveCallsUnwatchOnChildFiles verifies the actual leak
+// fix: on Remove/Rename of a watched directory, watcher.Remove must be called
+// for every child file we knew about, not just the directory itself. This is
+// what forces fsnotify's kqueue backend down its file-Remove path
+// (backend_kqueue.go:283 → unix.Close at :302). Without per-file Remove calls,
+// fsnotify v1.9.0 leaks one FD per child on every dir Remove/Rename.
+// Failure prevented: long-lived daemon FD growth from build-output churn,
+// the reproducible host symptom that made `lsof` itself hang on the daemon PID.
+func TestProjectWatcher_RemoveCallsUnwatchOnChildFiles(t *testing.T) {
+	mockWatcher := NewMockFileSystemWatcher()
+	mockFS := NewMockFileSystem()
+
+	dir := t.TempDir()
+	pkg := filepath.Join(dir, "pkg")
+	subPkg := filepath.Join(pkg, "internal")
+	require.NoError(t, os.MkdirAll(subPkg, 0o755))
+	mockFS.AddDir(pkg, []string{"a.go", "b.go"})
+	mockFS.AddDir(subPkg, []string{"x.go"})
+
+	tracker := &GitTrackedMatcher{
+		projectRoot: dir,
+		trackedDirs: map[string]struct{}{
+			"pkg":          {},
+			"pkg/internal": {},
+		},
+		trackedFiles: map[string]struct{}{},
+		logger:       slogDiscard(),
+	}
+
+	pw := NewProjectWatcher(
+		dir, slogDiscard(),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS, NewChangeAccumulator(50*time.Millisecond), tracker,
+	)
+
+	pw.walkAndWatch(mockWatcher)
+	require.Equal(t, 3, pw.WatchedDirCount(), "root + pkg + pkg/internal")
+
+	// simulate rm -rf pkg — single Remove event for pkg
+	mockFS.SetStatError(pkg, os.ErrNotExist)
+	pw.handleEvent(mockWatcher, fsnotify.Event{Name: pkg, Op: fsnotify.Remove})
+
+	removed := mockWatcher.RemovedPaths()
+
+	// Dir-level removes: pkg and pkg/internal
+	assert.Contains(t, removed, pkg, "pkg dir must be unwatched")
+	assert.Contains(t, removed, subPkg, "descendant dir must be unwatched")
+
+	// THE NEW INVARIANT: per-file Remove calls. fsnotify v1.9.0 won't close
+	// these FDs on its own — we must ask explicitly.
+	assert.Contains(t, removed, filepath.Join(pkg, "a.go"),
+		"pkg/a.go must be Remove'd to close fsnotify's per-file FD")
+	assert.Contains(t, removed, filepath.Join(pkg, "b.go"),
+		"pkg/b.go must be Remove'd to close fsnotify's per-file FD")
+	assert.Contains(t, removed, filepath.Join(subPkg, "x.go"),
+		"descendant child files must be Remove'd too (descendant snapshots flushed)")
+
+	// And the maps are cleaned up.
+	pw.mu.Lock()
+	_, dirStillTracked := pw.watchedDirs[pkg]
+	_, childrenStillTracked := pw.dirChildren[pkg]
+	_, descendantStillTracked := pw.dirChildren[subPkg]
+	pw.mu.Unlock()
+	assert.False(t, dirStillTracked, "watchedDirs entry must be cleared")
+	assert.False(t, childrenStillTracked, "dirChildren entry must be cleared")
+	assert.False(t, descendantStillTracked, "descendant dirChildren must be cleared")
+}
+
+// TestProjectWatcher_PruneStaleWatches_RemovesChildFiles verifies the same
+// invariant via the periodic-prune path: a dir falling out of git-tracked set
+// must drop its per-file FDs too, not just the dir's own FD.
+// Failure prevented: gitignore changes / branch switches accumulate per-file
+// FDs over the lifetime of the daemon.
+func TestProjectWatcher_PruneStaleWatches_RemovesChildFiles(t *testing.T) {
+	mockWatcher := NewMockFileSystemWatcher()
+	mockFS := NewMockFileSystem()
+
+	dir := t.TempDir()
+	buildDir := filepath.Join(dir, "build")
+	require.NoError(t, os.MkdirAll(buildDir, 0o755))
+	mockFS.AddDir(buildDir, []string{"out1.o", "out2.o", "out3.o"})
+
+	tracker := &GitTrackedMatcher{
+		projectRoot:  dir,
+		trackedDirs:  map[string]struct{}{"build": {}},
+		trackedFiles: map[string]struct{}{},
+		logger:       slogDiscard(),
+	}
+
+	pw := NewProjectWatcher(
+		dir, slogDiscard(),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS, NewChangeAccumulator(50*time.Millisecond), tracker,
+	)
+
+	pw.walkAndWatch(mockWatcher)
+	require.Equal(t, 2, pw.WatchedDirCount(), "root + build")
+
+	// build/ is no longer tracked (e.g., added to .gitignore)
+	tracker.mu.Lock()
+	delete(tracker.trackedDirs, "build")
+	tracker.mu.Unlock()
+
+	pw.pruneStaleWatches(mockWatcher)
+
+	removed := mockWatcher.RemovedPaths()
+	assert.Contains(t, removed, buildDir, "build dir must be unwatched")
+	assert.Contains(t, removed, filepath.Join(buildDir, "out1.o"),
+		"per-file FD must be released on prune")
+	assert.Contains(t, removed, filepath.Join(buildDir, "out2.o"),
+		"per-file FD must be released on prune")
+	assert.Contains(t, removed, filepath.Join(buildDir, "out3.o"),
+		"per-file FD must be released on prune")
+
+	pw.mu.Lock()
+	_, stillInChildren := pw.dirChildren[buildDir]
+	pw.mu.Unlock()
+	assert.False(t, stillInChildren, "dirChildren entry must be cleared on prune")
+}
+
+// TestProjectWatcher_SnapshotChildren_BoundedAtCap verifies the
+// maxFilesPerWatchedDir cap. A pathological dir (millions of generated files)
+// would otherwise dominate startup memory and snapshot cost. The cap is a
+// safe-degradation: files beyond the cap lose the leak guarantee, but the
+// ungranted FDs are bounded by file count regardless.
+// Failure prevented: cold-start memory/CPU spike on monorepos with one
+// pathological generated-files directory.
+func TestProjectWatcher_SnapshotChildren_BoundedAtCap(t *testing.T) {
+	mockWatcher := NewMockFileSystemWatcher()
+	mockFS := NewMockFileSystem()
+
+	dir := t.TempDir()
+	bigDir := filepath.Join(dir, "generated")
+	require.NoError(t, os.MkdirAll(bigDir, 0o755))
+
+	// Create a dir with maxFilesPerWatchedDir + 100 entries. ReadDir returns
+	// all of them; the cap should kick in inside snapshotDirFiles.
+	overflow := 100
+	names := make([]string, 0, maxFilesPerWatchedDir+overflow)
+	for i := 0; i < maxFilesPerWatchedDir+overflow; i++ {
+		names = append(names, fmt.Sprintf("f%06d.go", i))
+	}
+	mockFS.AddDir(bigDir, names)
+
+	pw := NewProjectWatcher(
+		dir, slogDiscard(),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS, NewChangeAccumulator(50*time.Millisecond),
+		&GitTrackedMatcher{
+			projectRoot: dir, trackedDirs: map[string]struct{}{}, trackedFiles: map[string]struct{}{},
+			logger: slogDiscard(),
+		},
+	)
+
+	pw.addDir(mockWatcher, bigDir)
+
+	pw.mu.Lock()
+	got := len(pw.dirChildren[bigDir])
+	pw.mu.Unlock()
+	assert.Equal(t, maxFilesPerWatchedDir, got,
+		"snapshotDirFiles must cap at maxFilesPerWatchedDir; got %d", got)
+}
+
+// TestProjectWatcher_AcquireRelease_TypedHandle verifies the watchedDirHandle
+// discipline helper: acquireDir+Release must produce the same effect as
+// addDir+Remove-with-children, with no extra leaks and no extra dirs left in
+// the maps. Not RAII (Go has no RAII for resources outliving function scope),
+// but enforces register-and-release pairing through the type system.
+// Failure prevented: future caller adds a watch via the handle but forgets
+// the children-cleanup half of the contract.
+func TestProjectWatcher_AcquireRelease_TypedHandle(t *testing.T) {
+	mockWatcher := NewMockFileSystemWatcher()
+	mockFS := NewMockFileSystem()
+
+	dir := t.TempDir()
+	pkg := filepath.Join(dir, "pkg")
+	require.NoError(t, os.MkdirAll(pkg, 0o755))
+	mockFS.AddDir(pkg, []string{"main.go", "main_test.go"})
+
+	pw := NewProjectWatcher(
+		dir, slogDiscard(),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS, NewChangeAccumulator(50*time.Millisecond),
+		&GitTrackedMatcher{
+			projectRoot: dir, trackedDirs: map[string]struct{}{}, trackedFiles: map[string]struct{}{},
+			logger: slogDiscard(),
+		},
+	)
+
+	h, err := pw.acquireDir(mockWatcher, pkg)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+
+	pw.mu.Lock()
+	_, watched := pw.watchedDirs[pkg]
+	childCount := len(pw.dirChildren[pkg])
+	pw.mu.Unlock()
+	assert.True(t, watched, "acquireDir must register the dir")
+	assert.Equal(t, 2, childCount, "acquireDir must snapshot children")
+
+	h.Release()
+
+	pw.mu.Lock()
+	_, stillWatched := pw.watchedDirs[pkg]
+	_, stillChildren := pw.dirChildren[pkg]
+	pw.mu.Unlock()
+	assert.False(t, stillWatched, "Release must clear watchedDirs entry")
+	assert.False(t, stillChildren, "Release must clear dirChildren entry")
+
+	removed := mockWatcher.RemovedPaths()
+	assert.Contains(t, removed, pkg, "Release must Remove the dir")
+	assert.Contains(t, removed, filepath.Join(pkg, "main.go"),
+		"Release must Remove each tracked child file")
+	assert.Contains(t, removed, filepath.Join(pkg, "main_test.go"),
+		"Release must Remove each tracked child file")
+
+	// Idempotent: second Release is a no-op (children list now empty).
+	preCount := len(mockWatcher.RemovedPaths())
+	h.Release()
+	postCount := len(mockWatcher.RemovedPaths())
+	// Second Release issues a single Remove for the dir itself (harmless,
+	// fsnotify returns ErrNonExistentWatch which we ignore). What matters
+	// is that no new per-file Removes happen.
+	assert.LessOrEqual(t, postCount-preCount, 1, "Release must be idempotent for child files")
+}
+
+// TestProjectWatcher_NoFDLeak_RealWatcher_Darwin is the production-grade
+// regression test. It uses a REAL fsnotify watcher, real os.MkdirAll +
+// os.RemoveAll, and counts open FDs on the test process via /dev/fd. This
+// is the test that would have caught the original leak — the mock-based
+// tests can't, because the mock has no internal per-file FDs to leak.
+//
+// macOS-only: fsnotify's kqueue backend is the source of the leak. Linux's
+// inotify uses one FD per watch (not per file), so the leak doesn't exist
+// there.
+//
+// Failure prevented: regression of the FD leak that, in production, made
+// the daemon's FD table grow unbounded and `lsof` hang on the daemon PID.
+func TestProjectWatcher_NoFDLeak_RealWatcher_Darwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("kqueue per-file FD leak is macOS-specific")
+	}
+	if testing.Short() {
+		t.Skip("short: real-watcher FD test runs many churn cycles")
+	}
+
+	dir := t.TempDir()
+	logger := slogDiscard()
+
+	tracker := &GitTrackedMatcher{
+		projectRoot: dir, trackedDirs: map[string]struct{}{}, trackedFiles: map[string]struct{}{},
+		logger: logger,
+	}
+	pw := NewProjectWatcher(
+		dir, logger,
+		DefaultWatcherFactory,
+		&RealFileSystem{},
+		NewChangeAccumulator(20*time.Millisecond),
+		tracker,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		pw.Start(ctx)
+		close(done)
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	// Wait until root is being watched.
+	require.Eventually(t, func() bool {
+		return pw.WatchedDirCount() >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Settle and capture baseline. Run a few warmup cycles first because the
+	// fsnotify goroutine and kqueue itself open FDs on first use.
+	for i := 0; i < 3; i++ {
+		warmDir := filepath.Join(dir, fmt.Sprintf("warmup-%d", i))
+		require.NoError(t, os.MkdirAll(warmDir, 0o755))
+		require.NoError(t, os.RemoveAll(warmDir))
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	baseline := countOpenFDs(t)
+
+	// Churn: 50 iterations of mkdir + N files + rm-rf. Each iteration
+	// pre-fix would open (1 + 5) kqueue FDs and only release 1 — net +5/round.
+	const iterations = 50
+	const filesPerDir = 5
+	for i := 0; i < iterations; i++ {
+		sub := filepath.Join(dir, fmt.Sprintf("churn-%04d", i))
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+		for j := 0; j < filesPerDir; j++ {
+			f := filepath.Join(sub, fmt.Sprintf("f%d.go", j))
+			require.NoError(t, os.WriteFile(f, []byte("package x\n"), 0o644))
+		}
+		// Give fsnotify a beat to register the dir + auto-watch the files
+		// before we delete them. Without this, the kernel may coalesce events
+		// and we don't exercise the per-file FD path.
+		time.Sleep(2 * time.Millisecond)
+		require.NoError(t, os.RemoveAll(sub))
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Allow handler to drain.
+	require.Eventually(t, func() bool {
+		// All churn dirs should have been removed from watchedDirs.
+		return pw.WatchedDirCount() <= 5
+	}, 5*time.Second, 50*time.Millisecond, "watcher should drain churn dirs")
+	time.Sleep(200 * time.Millisecond)
+
+	final := countOpenFDs(t)
+	delta := final - baseline
+
+	// Pre-fix: delta ≈ iterations*filesPerDir = 250 leaked FDs (and growing
+	// unbounded across runs). Post-fix: delta should be small — bounded by
+	// transient watch state, sleep timers, and any long-tail handler queue.
+	// Tolerance of 30 is generous for noise but catches the leak by 8x.
+	const tolerance = 30
+	assert.Less(t, delta, tolerance,
+		"FD count grew by %d (baseline %d, final %d). Pre-fix this is ~%d. Tolerance: <%d.",
+		delta, baseline, final, iterations*filesPerDir, tolerance)
+}
+
+// countOpenFDs returns the number of FDs open on the current process.
+// Uses /dev/fd via Readdirnames (not os.ReadDir) — on macOS, ReadDir's
+// per-entry fstatat fails on some kernel-only FD types with "bad file
+// descriptor". Readdirnames just enumerates names from the directory
+// stream, no per-entry stat. We subtract 1 because the readdir itself
+// holds a transient FD on /dev/fd.
+func countOpenFDs(t *testing.T) int {
+	t.Helper()
+	d, err := os.Open("/dev/fd")
+	require.NoError(t, err, "failed to open /dev/fd for FD count")
+	defer d.Close()
+	names, err := d.Readdirnames(-1)
+	require.NoError(t, err, "failed to enumerate /dev/fd")
+	// Subtract 1 for the FD held by 'd' itself, which is closed before
+	// the caller checks the next sample.
+	n := len(names) - 1
+	if n < 0 {
+		n = 0
+	}
+	return n
 }

--- a/internal/daemon/status_display.go
+++ b/internal/daemon/status_display.go
@@ -419,6 +419,14 @@ func FormatStatusVerbose(status *StatusData, history []SyncEvent, cliVersion str
 	if status.AuthenticatedUser != nil && status.AuthenticatedUser.Email != "" {
 		out += formatKV("User", status.AuthenticatedUser.Email) + "\n"
 	}
+	if status.OpenFDs > 0 {
+		fdStr := fmt.Sprintf("%d", status.OpenFDs)
+		if status.OpenFDLimit > 0 {
+			pct := float64(status.OpenFDs) * 100 / float64(status.OpenFDLimit)
+			fdStr = fmt.Sprintf("%d / %d (%.0f%%)", status.OpenFDs, status.OpenFDLimit, pct)
+		}
+		out += formatKV("FDs open", fdStr) + "\n"
+	}
 	if status.StartupDurationMs > 0 {
 		startupStr := fmt.Sprintf("%dms", status.StartupDurationMs)
 		if status.ThrottleDurationMs > 0 {

--- a/internal/daemon/watcher.go
+++ b/internal/daemon/watcher.go
@@ -40,6 +40,12 @@ type FileSystem interface {
 
 	// ReadDir reads a directory and returns its entries.
 	ReadDir(name string) ([]fs.DirEntry, error)
+
+	// ReadDirN reads up to n entries from a directory and returns them.
+	// If n <= 0 returns all entries (equivalent to ReadDir). Used by the
+	// kqueue mirror so a pathological million-entry directory doesn't
+	// materialize the full listing just to truncate to maxFilesPerWatchedDir.
+	ReadDirN(name string, n int) ([]fs.DirEntry, error)
 }
 
 // RealFileSystemWatcher implements FileSystemWatcher using fsnotify.
@@ -92,6 +98,23 @@ func (r *RealFileSystem) Stat(name string) (fs.FileInfo, error) {
 // ReadDir reads a directory and returns its entries.
 func (r *RealFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
 	return os.ReadDir(name)
+}
+
+// ReadDirN reads up to n entries from a directory using *os.File.ReadDir(n),
+// which streams entries from the underlying readdir(3) without materializing
+// the full listing. This lets the kqueue mirror bound BOTH memory and read
+// cost for pathological directories with millions of entries. Falls back to
+// ReadDir when n <= 0.
+func (r *RealFileSystem) ReadDirN(name string, n int) ([]fs.DirEntry, error) {
+	if n <= 0 {
+		return os.ReadDir(name)
+	}
+	d, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer d.Close()
+	return d.ReadDir(n)
 }
 
 // WatcherFactory creates FileSystemWatcher instances.
@@ -189,11 +212,39 @@ func (w *Watcher) Start(ctx context.Context, onChange func()) {
 				w.Stop()
 				return
 			}
+			// Keep our child mirror in sync with fsnotify's: kqueue's
+			// dirChange watches new files via sendCreateIfNew on
+			// NOTE_WRITE for the dir, and closes per-file FDs on
+			// individual NOTE_DELETE. The post-Add snapshot would
+			// otherwise drift from fsnotify's actual watch set, missing
+			// FDs for files created during daemon operation. Darwin-only.
+			if childMirrorEnabled && filepath.Dir(event.Name) == w.path && event.Name != w.path {
+				switch {
+				case event.Op&fsnotify.Create != 0 && len(children) < maxFilesPerWatchedDir:
+					present := false
+					for _, c := range children {
+						if c == event.Name {
+							present = true
+							break
+						}
+					}
+					if !present {
+						children = append(children, event.Name)
+					}
+				case event.Op&(fsnotify.Remove|fsnotify.Rename) != 0:
+					out := children[:0]
+					for _, c := range children {
+						if c != event.Name {
+							out = append(out, c)
+						}
+					}
+					children = out
+				}
+			}
 			// Plug fsnotify v1.9.0 kqueue per-file FD leak: when our
 			// watched dir is removed/renamed (e.g., blue-green GC reclone
 			// of the ledger), force fsnotify to close each per-file kqueue
-			// FD by replaying our snapshot. childMirrorEnabled is false
-			// outside Darwin so this loop costs nothing on Linux.
+			// FD by replaying our (now-up-to-date) snapshot.
 			if childMirrorEnabled && event.Name == w.path &&
 				event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
 				for _, f := range children {
@@ -475,6 +526,18 @@ func (m *MockFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
 		return result, nil
 	}
 	return nil, os.ErrNotExist
+}
+
+// ReadDirN reads up to n entries from a mock directory. n <= 0 returns all.
+func (m *MockFileSystem) ReadDirN(name string, n int) ([]fs.DirEntry, error) {
+	all, err := m.ReadDir(name)
+	if err != nil {
+		return nil, err
+	}
+	if n <= 0 || n >= len(all) {
+		return all, nil
+	}
+	return all[:n], nil
 }
 
 // AddFile adds a mock file to the filesystem.

--- a/internal/daemon/watcher.go
+++ b/internal/daemon/watcher.go
@@ -157,11 +157,23 @@ func (w *Watcher) Start(ctx context.Context, onChange func()) {
 	w.stopped = false
 	w.mu.Unlock()
 
-	// add path to watch
+	// Snapshot the per-file children that fsnotify's kqueue backend will
+	// auto-open via watchDirectoryFiles when we Add a directory on macOS.
+	// We need our own copy because fsnotify's set is private and on
+	// Remove/Rename of the watched dir its kqueue backend
+	// (backend_kqueue.go:489) calls w.remove(name, false) — which leaves
+	// the per-file FDs open. They'd remain open until our defer Close()
+	// fires, which for the ledger watcher means the entire daemon
+	// lifetime after the first reclone. Snapshot pre AND post Add to
+	// close the TOCTOU race against watchDirectoryFiles. No-op on
+	// non-Darwin (snapshotKqueueChildren returns nil there).
+	preChildren := snapshotKqueueChildren(w.fs, w.path, w.logger)
 	if err := watcher.Add(w.path); err != nil {
 		w.logger.Error("failed to watch path", "path", w.path, "error", err)
 		return
 	}
+	postChildren := snapshotKqueueChildren(w.fs, w.path, w.logger)
+	children := unionKqueueChildren(preChildren, postChildren)
 
 	w.logger.Info("watching ledger directory", "path", w.path)
 
@@ -176,6 +188,18 @@ func (w *Watcher) Start(ctx context.Context, onChange func()) {
 			if !ok {
 				w.Stop()
 				return
+			}
+			// Plug fsnotify v1.9.0 kqueue per-file FD leak: when our
+			// watched dir is removed/renamed (e.g., blue-green GC reclone
+			// of the ledger), force fsnotify to close each per-file kqueue
+			// FD by replaying our snapshot. childMirrorEnabled is false
+			// outside Darwin so this loop costs nothing on Linux.
+			if childMirrorEnabled && event.Name == w.path &&
+				event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+				for _, f := range children {
+					_ = watcher.Remove(f)
+				}
+				children = nil
 			}
 			w.handleEvent(event)
 

--- a/internal/daemon/watcher_test.go
+++ b/internal/daemon/watcher_test.go
@@ -903,3 +903,92 @@ func TestMockFileSystemWatcher_Remove(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, 3, len(mock.RemovedPaths()), "path still recorded even on error")
 }
+
+// TestWatcher_LedgerDirRemove_FlushesPerFileFDs verifies that when the
+// watched ledger directory is removed mid-watch (the blue-green GC reclone
+// case), the singleton ledger Watcher explicitly Removes each child file
+// from fsnotify so its kqueue per-file FDs get closed via unix.Close.
+//
+// Without this, fsnotify v1.9.0's kqueue backend on macOS leaves per-file
+// FDs open until the daemon's defer Close() fires — for a long-lived
+// daemon that's effectively forever, accumulating FDs across reclones.
+//
+// Mock-level test: MockFileSystemWatcher tracks Remove calls regardless of
+// platform, so we drive a Remove event for the watched path and assert the
+// per-file Removes were issued. Skipped on non-Darwin since the production
+// code is gated by childMirrorEnabled (no children snapshotted on Linux,
+// no per-file Removes expected).
+//
+// Failure prevented: regression of the per-file FD leak pattern that, in
+// production, made `lsof` itself hang on the daemon PID.
+func TestWatcher_LedgerDirRemove_FlushesPerFileFDs(t *testing.T) {
+	if !childMirrorEnabled {
+		t.Skip("kqueue per-file FD leak is macOS-specific")
+	}
+
+	tmp := t.TempDir()
+	ledgerDir := filepath.Join(tmp, "ledger")
+	require.NoError(t, os.MkdirAll(ledgerDir, 0o755))
+
+	// Create children fsnotify would auto-watch via watchDirectoryFiles.
+	// MockFileSystem's ReadDir is what snapshotKqueueChildren calls — it
+	// must return these as non-dir entries.
+	mockFS := NewMockFileSystem()
+	mockFS.AddDir(ledgerDir, []string{"a.json", "b.json", "c.json"})
+
+	mockWatcher := NewMockFileSystemWatcher()
+	w := NewWatcherWithFS(
+		ledgerDir,
+		50*time.Millisecond,
+		slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		func() (FileSystemWatcher, error) { return mockWatcher, nil },
+		mockFS,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Start(ctx, func() {})
+		close(done)
+	}()
+
+	// Wait until Add has been recorded (Start has snapshotted children).
+	require.Eventually(t, func() bool {
+		for _, p := range mockWatcher.AddedPaths() {
+			if p == ledgerDir {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 5*time.Millisecond, "Watcher should have called Add on ledgerDir")
+
+	// Simulate the kernel firing NOTE_DELETE on the watched dir (blue-green
+	// GC just rm'd it to make way for the new clone). Pre-fix this would
+	// be silently absorbed and the per-file FDs would orphan.
+	mockWatcher.SendEvent(fsnotify.Event{Name: ledgerDir, Op: fsnotify.Remove})
+
+	require.Eventually(t, func() bool {
+		removed := mockWatcher.RemovedPaths()
+		need := []string{
+			filepath.Join(ledgerDir, "a.json"),
+			filepath.Join(ledgerDir, "b.json"),
+			filepath.Join(ledgerDir, "c.json"),
+		}
+		for _, want := range need {
+			found := false
+			for _, got := range removed {
+				if got == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}, 2*time.Second, 5*time.Millisecond, "Watcher must Remove each child file to close fsnotify's per-file FD on dir-removed event")
+
+	cancel()
+	<-done
+}

--- a/internal/daemon/watcher_test.go
+++ b/internal/daemon/watcher_test.go
@@ -922,9 +922,11 @@ func TestMockFileSystemWatcher_Remove(t *testing.T) {
 // Failure prevented: regression of the per-file FD leak pattern that, in
 // production, made `lsof` itself hang on the daemon PID.
 func TestWatcher_LedgerDirRemove_FlushesPerFileFDs(t *testing.T) {
-	if !childMirrorEnabled {
-		t.Skip("kqueue per-file FD leak is macOS-specific")
-	}
+	// Force the mirror on so this mock-based regression runs (and fails
+	// against broken code) on Linux CI as well as Darwin. Production
+	// behavior is unchanged — the mirror still no-ops on non-Darwin in
+	// real binaries.
+	forceChildMirrorForTest(t)
 
 	tmp := t.TempDir()
 	ledgerDir := filepath.Join(tmp, "ledger")

--- a/internal/doctor/daemon.go
+++ b/internal/doctor/daemon.go
@@ -575,6 +575,79 @@ func splitCompositeID(id string) (repoID, workspaceID string) {
 	return id[:lastIdx], id[lastIdx+1:]
 }
 
+// DaemonFDPressureCheck warns when the daemon is consuming a worrying
+// fraction of its open-file-descriptor limit. Surfaces FD leaks within hours
+// instead of months — see internal/daemon/fd_count.go for the rationale.
+type DaemonFDPressureCheck struct{}
+
+// NewDaemonFDPressureCheck creates an FD-pressure check for the daemon.
+func NewDaemonFDPressureCheck() *DaemonFDPressureCheck {
+	return &DaemonFDPressureCheck{}
+}
+
+// Name returns the check name.
+func (c *DaemonFDPressureCheck) Name() string {
+	return "fd pressure"
+}
+
+// Category returns the check category.
+func (c *DaemonFDPressureCheck) Category() string {
+	return "Daemon"
+}
+
+// FD-pressure thresholds, expressed as a fraction of the soft RLIMIT_NOFILE.
+// Crossing 50% warns; crossing 80% fails. Computed against the current limit
+// rather than hard-coded numbers so the check stays meaningful across very
+// different host configs (macOS default 256 vs Linux container 1M+).
+const (
+	fdPressureWarn = 0.50
+	fdPressureFail = 0.80
+)
+
+// Run executes the FD-pressure check.
+func (c *DaemonFDPressureCheck) Run(_ context.Context, _ bool) CheckResult {
+	if !daemon.IsRunning() {
+		return CheckResult{Name: c.Name(), Status: StatusSkip}
+	}
+	client := daemon.NewClientForCurrentRepoWithTimeout(500 * time.Millisecond)
+	status, err := client.Status()
+	if err != nil {
+		return CheckResult{Name: c.Name(), Status: StatusSkip}
+	}
+	if status.OpenFDs <= 0 {
+		// platform doesn't surface FD count (e.g. windows) — skip silently
+		return CheckResult{Name: c.Name(), Status: StatusSkip}
+	}
+	if status.OpenFDLimit == 0 {
+		// no limit info — report raw count without a verdict
+		return CheckResult{
+			Name:    c.Name(),
+			Status:  StatusPass,
+			Message: fmt.Sprintf("%d FDs open (limit unknown)", status.OpenFDs),
+		}
+	}
+	pct := float64(status.OpenFDs) / float64(status.OpenFDLimit)
+	msg := fmt.Sprintf("%d / %d open (%.0f%%)", status.OpenFDs, status.OpenFDLimit, pct*100)
+	switch {
+	case pct >= fdPressureFail:
+		return CheckResult{
+			Name:    c.Name(),
+			Status:  StatusFail,
+			Message: msg,
+			Fix:  "Daemon is approaching its file-descriptor limit. Restart with `ox daemon restart` while we investigate the leak source.",
+		}
+	case pct >= fdPressureWarn:
+		return CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarn,
+			Message: msg,
+			Fix:  "FD count is climbing toward the soft limit. Worth monitoring; check `ox status --verbose` over the next hour.",
+		}
+	default:
+		return CheckResult{Name: c.Name(), Status: StatusPass, Message: msg}
+	}
+}
+
 // formatDuration formats a duration for display.
 func formatDuration(d time.Duration) string {
 	if d < time.Minute {

--- a/pkg/adapterruntime/watcher.go
+++ b/pkg/adapterruntime/watcher.go
@@ -62,8 +62,13 @@ func (fw *FileWatcher) Watch(agentID, sessionFile string, offset int64) error {
 		if existing.timer != nil {
 			existing.timer.Stop()
 		}
-		// only remove from fsnotify if no other session uses this file
-		if !fw.fileInUse(sessionFile, agentID) {
+		// only remove from fsnotify if no other session uses the
+		// existing file. The previous arg here was sessionFile (the NEW
+		// file), which was wrong: when re-Watching agent A from file X
+		// to file Y while another agent B watches Y, fileInUse(Y, A)
+		// returns true and we'd skip Remove(X), orphaning fsnotify's
+		// entry for X forever. Fixed to consult existing.sessionFile.
+		if !fw.fileInUse(existing.sessionFile, agentID) {
 			_ = fw.watcher.Remove(existing.sessionFile)
 		}
 	}


### PR DESCRIPTION
## Summary

PR #567 attempted to fix the `ox daemon` FD leak but its cleanup iterates `pw.watchedDirs` (only user-added dirs, never the per-file paths fsnotify auto-opens via `watchDirectoryFiles`) and races with fsnotify's internal Remove — the host symptom got bad enough that `lsof` itself hung on the daemon PID. This PR maintains a userspace `dirChildren` mirror populated by `os.ReadDir` at `addDir` time, replays it on Remove/Rename and during stale-prune to issue explicit `watcher.Remove(child)` per file (forcing fsnotify down `unix.Close`), caps each snapshot at 10k files with a Warn log, and adds a typed `watchedDirHandle` to keep future call sites from regressing. Five new mock-based tests cover the snapshot/Remove/Prune/cap/acquire-Release invariants, plus `TestProjectWatcher_NoFDLeak_RealWatcher_Darwin` runs 50 churn iterations through a real `fsnotify.Watcher` and asserts FD count stays within 30 of baseline (pre-fix would leak ~250).

## Why

```mermaid
sequenceDiagram
  participant Caller
  participant ProjectWatcher
  participant fsnotify
  participant kqueue

  Caller->>ProjectWatcher: addDir(/repo/pkg)
  ProjectWatcher->>fsnotify: Add(/repo/pkg)
  fsnotify->>kqueue: open dir FD
  fsnotify->>kqueue: open per-file FD × N (watchDirectoryFiles)
  ProjectWatcher->>ProjectWatcher: dirChildren[/repo/pkg] = [a.go, b.go, ...]

  Note over Caller,kqueue: rm -rf /repo/pkg
  fsnotify-->>ProjectWatcher: Event{Remove, /repo/pkg}
  ProjectWatcher->>fsnotify: Remove(/repo/pkg)
  fsnotify->>kqueue: close dir FD ✓
  ProjectWatcher->>fsnotify: Remove(a.go), Remove(b.go), ...
  fsnotify->>kqueue: unix.Close per-file FD ✓ (the fix)
```

## Test plan
- [x] `go test ./internal/daemon/ -run TestProjectWatcher` (existing + new mock tests)
- [x] `go test ./internal/daemon/ -run TestProjectWatcher_NoFDLeak_RealWatcher_Darwin` (real fsnotify + real FS, 50 churn cycles, FD delta < 30)
- [ ] `make test-preflight` (lint + full + slow) before un-drafting

Beads: closes `ox-x60c`, `ox-lanl`, `ox-ght5`, `ox-6b44` under epic `ox-5pwx`. Open follow-ups: `ox-fk3s` (track upstream fsnotify), `ox-0fue` (FSEvents-direct alternative on macOS).

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed per-file file-descriptor leaks in the filesystem watcher, improving long-running stability and cleanup (notably on macOS).

* **New Features**
  * Daemon now reports open-FD count and FD limit in status and verbose output.
  * Added a daemon health check that warns/fails on high FD utilization with actionable guidance.

* **Tests**
  * Added regression and platform-specific tests validating FD leak fixes, snapshot bounds, and handle-based cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->