### PR TITLE
fix(daemon): filter gitignored files from murmur file-change notifications

### DIFF
--- a/internal/daemon/fd_limit_unix.go
+++ b/internal/daemon/fd_limit_unix.go
@@ -17,5 +17,5 @@ func CurrentProcessFDLimit() uint64 {
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
 		return 0
 	}
-	return uint64(rlim.Cur)
+	return rlim.Cur
 }

--- a/internal/daemon/file_change_source.go
+++ b/internal/daemon/file_change_source.go
@@ -1,10 +1,13 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -202,6 +205,7 @@ func (p *FileChangeMurmurPublisher) publish() {
 
 	// filter infrastructure noise before formatting
 	changes = filterFileChangeNoise(changes)
+	changes = filterGitIgnored(p.projectRoot, changes, p.logger)
 	if len(changes) == 0 {
 		return
 	}
@@ -542,4 +546,84 @@ func isFileChangeNoise(path string) bool {
 		}
 	}
 	return false
+}
+
+// gitCheckIgnoreTimeout bounds the git check-ignore subprocess. Murmur publish
+// runs every 10 minutes and feeds at most ~50 paths, so this should always
+// finish in milliseconds; the timeout exists purely to prevent a wedged git
+// subprocess from blocking the daemon's publish loop.
+const gitCheckIgnoreTimeout = 5 * time.Second
+
+// filterGitIgnored drops paths that git would consider ignored (build
+// artifacts, caches, anything matched by a .gitignore rule). Without this,
+// fsnotify events for files like *.pyc leak into murmurs and look to teammates
+// like an engineer touched that area of the repo.
+//
+// On any error (git missing, non-git directory, exec failure), returns the
+// input unchanged. Murmurs are best-effort — over-reporting beats crashing the
+// daemon's publish loop.
+func filterGitIgnored(projectRoot string, changes []FileChange, logger *slog.Logger) []FileChange {
+	if len(changes) == 0 {
+		return changes
+	}
+
+	ignored, err := gitCheckIgnore(projectRoot, changes)
+	if err != nil {
+		if logger != nil {
+			logger.Debug("file change murmur: gitignore filter skipped", "error", err)
+		}
+		return changes
+	}
+	if len(ignored) == 0 {
+		return changes
+	}
+
+	filtered := changes[:0]
+	for _, c := range changes {
+		if _, drop := ignored[c.Path]; drop {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered
+}
+
+// gitCheckIgnore returns the set of paths from changes that git considers
+// ignored. Calls `git -C <projectRoot> check-ignore --stdin -z` once with all
+// paths NUL-separated. Exit code 0 means at least one ignored path; 1 means
+// none matched (success-with-empty-output, not an error); >1 is a real error.
+func gitCheckIgnore(projectRoot string, changes []FileChange) (map[string]struct{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitCheckIgnoreTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", projectRoot, "check-ignore", "--stdin", "-z")
+
+	var stdin bytes.Buffer
+	for _, c := range changes {
+		stdin.WriteString(c.Path)
+		stdin.WriteByte(0)
+	}
+	cmd.Stdin = &stdin
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			// exit 1 = no paths matched any ignore rule
+			return nil, nil
+		}
+		return nil, fmt.Errorf("git check-ignore: %w (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	ignored := make(map[string]struct{})
+	for _, p := range strings.Split(stdout.String(), "\x00") {
+		if p != "" {
+			ignored[p] = struct{}{}
+		}
+	}
+	return ignored, nil
 }

--- a/internal/daemon/file_change_source_test.go
+++ b/internal/daemon/file_change_source_test.go
@@ -2,6 +2,9 @@ package daemon
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -429,4 +432,115 @@ func TestFilterFileChangeNoise(t *testing.T) {
 	assert.Equal(t, 2, len(filtered))
 	assert.Equal(t, "cmd/ox/main.go", filtered[0].Path)
 	assert.Equal(t, "internal/foo.go", filtered[1].Path)
+}
+
+// --- E. gitignore filter ---
+//
+// Failure prevented: build artifacts (.pyc, dist/, node_modules/) leaking into
+// murmurs, falsely warning teammates that an engineer touched that area.
+
+// initGitRepoForFilter creates a tmp dir with `git init` for testing the gitignore
+// filter. Uses cmd.Dir to keep the test isolated from the user's git config.
+func initGitRepoForFilter(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "-q", "-b", "main")
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run(), "git init failed")
+	return dir
+}
+
+// TestFilterGitIgnored_DropsIgnoredPaths verifies that paths matching a
+// .gitignore pattern (build artifacts) are filtered out of the change set.
+func TestFilterGitIgnored_DropsIgnoredPaths(t *testing.T) {
+	root := initGitRepoForFilter(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.pyc\nbuild/\n"), 0o644))
+
+	changes := []FileChange{
+		{Path: "main.go", ChangeType: ChangeModified},
+		{Path: "cache.pyc", ChangeType: ChangeCreated},
+		{Path: "build/out", ChangeType: ChangeCreated},
+		{Path: "README.md", ChangeType: ChangeModified},
+	}
+
+	filtered := filterGitIgnored(root, changes, slogDiscard())
+
+	paths := make([]string, len(filtered))
+	for i, c := range filtered {
+		paths[i] = c.Path
+	}
+	assert.ElementsMatch(t, []string{"main.go", "README.md"}, paths,
+		"only non-ignored paths should survive")
+}
+
+// TestFilterGitIgnored_NestedGitignore verifies per-directory .gitignore files
+// are respected (e.g. subdir/.gitignore only applies inside subdir).
+func TestFilterGitIgnored_NestedGitignore(t *testing.T) {
+	root := initGitRepoForFilter(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "subdir", ".gitignore"), []byte("secrets.txt\n"), 0o644))
+
+	changes := []FileChange{
+		{Path: "secrets.txt", ChangeType: ChangeCreated},        // top-level: not ignored
+		{Path: "subdir/secrets.txt", ChangeType: ChangeCreated}, // nested: ignored
+		{Path: "subdir/code.go", ChangeType: ChangeModified},
+	}
+
+	filtered := filterGitIgnored(root, changes, slogDiscard())
+
+	paths := make([]string, len(filtered))
+	for i, c := range filtered {
+		paths[i] = c.Path
+	}
+	assert.ElementsMatch(t, []string{"secrets.txt", "subdir/code.go"}, paths,
+		"nested .gitignore should only apply within its directory")
+}
+
+// TestFilterGitIgnored_NoGitignore verifies that when no .gitignore exists,
+// every path is preserved (no false-positive filtering).
+func TestFilterGitIgnored_NoGitignore(t *testing.T) {
+	root := initGitRepoForFilter(t)
+	changes := []FileChange{
+		{Path: "main.go", ChangeType: ChangeModified},
+		{Path: "anything.pyc", ChangeType: ChangeCreated},
+	}
+
+	filtered := filterGitIgnored(root, changes, slogDiscard())
+	assert.Len(t, filtered, 2, "no .gitignore means nothing is filtered")
+}
+
+// TestFilterGitIgnored_EmptyInput verifies short-circuit on empty input
+// (no subprocess spawned, no error).
+func TestFilterGitIgnored_EmptyInput(t *testing.T) {
+	// Use a path that doesn't exist — proves we never invoke git.
+	filtered := filterGitIgnored("/nonexistent/path", nil, slogDiscard())
+	assert.Empty(t, filtered)
+}
+
+// TestFilterGitIgnored_NonGitDir verifies graceful degradation when the
+// project root isn't a git repo: returns input unchanged rather than
+// crashing the daemon's publish loop.
+func TestFilterGitIgnored_NonGitDir(t *testing.T) {
+	dir := t.TempDir() // no `git init`
+	changes := []FileChange{
+		{Path: "main.go", ChangeType: ChangeModified},
+		{Path: "cache.pyc", ChangeType: ChangeCreated},
+	}
+
+	filtered := filterGitIgnored(dir, changes, slogDiscard())
+	assert.Len(t, filtered, 2,
+		"non-git directory should fail open, not drop everything")
+}
+
+// TestFilterGitIgnored_GitBinaryMissing verifies graceful degradation when
+// `git` isn't on PATH. Murmur is best-effort; over-reporting beats crashing.
+func TestFilterGitIgnored_GitBinaryMissing(t *testing.T) {
+	t.Setenv("PATH", "")
+	changes := []FileChange{
+		{Path: "main.go", ChangeType: ChangeModified},
+		{Path: "cache.pyc", ChangeType: ChangeCreated},
+	}
+
+	filtered := filterGitIgnored(t.TempDir(), changes, slogDiscard())
+	assert.Len(t, filtered, 2, "missing git binary should fail open")
 }


### PR DESCRIPTION
## Summary

`ox murmur` was warning teammates of false conflicts because fsnotify picks up build artifacts (`.pyc`, `__pycache__/`, `node_modules/`, etc.) in tracked directories and the existing noise filter at `internal/daemon/file_change_source.go:508` only skipped `.tmp` files and local tool dirs — never `.gitignore`d paths. A customer hit this with a Python test harness writing `.pyc` next to source files; teammates got murmurs claiming the engineer had touched that area of the repo.

## Fix

Added `filterGitIgnored()` (`internal/daemon/file_change_source.go:561`), wired into `publish()` after the existing `filterFileChangeNoise()` call. Each murmur publish (every 10 minutes, ≤50 paths) batches all paths through one `git -C <root> check-ignore --stdin -z` subprocess and drops the matches. Failures fail open — missing `git`, non-git directory, transient errors, or 5s timeout return the input unchanged so the daemon never crashes the publish loop.

## Data flow

```mermaid
flowchart LR
    A[fsnotify event] --> B[ProjectWatcher]
    B --> C[ChangeAccumulator]
    C --> D[publish drain every 10m]
    D --> E["filterFileChangeNoise<br/>(existing: .tmp, .sageox/, .beads/)"]
    E --> F["filterGitIgnored<br/>(NEW: git check-ignore)"]
    F --> G[murmur written to ledger]
    G --> H["teammates see files=..."]
```

## Design choices

- **Filter at publish, not watcher.** The watcher deliberately lets through Create events for untracked files (`project_watcher.go:670`) so brand-new files surface as WIP. Filtering downstream keeps that intent.
- **Filter gitignored, not 'staged only'.** A new `feature.go` an engineer hasn't `git add`'d is exactly the WIP signal murmur exists for. Build artifacts already live in `.gitignore` in any sane repo — reuse git's decision.
- **Subprocess, not Go gitignore parser.** Per-directory `.gitignore` chains, `.git/info/exclude`, negation patterns, precedence — re-implementing this is a footgun. `go-git` has a matcher but wiring it correctly is more code than the subprocess at this cadence.

## Test plan

- [x] 6 new table-driven tests (`internal/daemon/file_change_source_test.go:434+`): drops ignored paths, respects nested `.gitignore`, no-`.gitignore` no-op, empty-input short-circuit, non-git dir fails open, missing `git` binary fails open
- [x] Existing `TestFilterFileChangeNoise` still passes
- [x] `go build ./...` clean
- [x] `golangci-lint` reports zero new issues in changed files
- [ ] Manual verification: in a scratch repo with `.gitignore` containing `*.pyc`, run the daemon, `touch foo.pyc bar.go`, confirm only `bar.go` appears in the next murmur

The two pre-existing daemon test failures (`TestTriggerLedgerIndexRebuild_ShaChanged`, `TestDetectChangedFiles_NoChanges_ReturnsNil`) reproduce on `main` — they're caused by an SSH commit-signing key passphrase prompt in the local env and are unrelated to this change.

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-change detection now filters out paths that Git treats as ignored, reducing noise from ignored files and build artifacts.

* **Tests**
  * Added tests covering Git ignore filtering: nested rules, no-git repos, empty inputs, missing Git binary, and graceful fallback on errors.

* **Refactor**
  * Minor internal refinement to process file-descriptor limit handling (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->