### PR TITLE
chore(release): bump version to 0.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.7.0"
+      "version": "0.7.1"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-05-03
+
+### Fixed
+
+**Security hardening (#579)**
+- Closed several boundary issues in path handling, LFS size bounds, credential sanitization in logs, and authentication checks. Recommended upgrade for any team running ox in shared infrastructure.
+
+**Daemon reliability**
+- File watchers no longer leak a file descriptor per project file under long uptimes — the per-file handles in `ProjectWatcher` (fsnotify userspace mirror) are now released on directory teardown (#580).
+- `ox murmur` file-change notifications now respect `.gitignore`, so build artifacts and editor temp files no longer spam teammates (#581).
+
+**Session UX**
+- Sessions whose meta entry was missing a title (rendered as "Summary unavailable" in the UI) are now repaired automatically by the daemon (#578).
+
+[0.7.1]: https://github.com/sageox/ox/releases/tag/v0.7.1
+
 ## [0.7.0] - 2026-05-01
 
 ### Added

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -9,9 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-**Security hardening (#579)**
-- Closed several boundary issues in path handling, LFS size bounds, credential sanitization in logs, and authentication checks. Recommended upgrade for any team running ox in shared infrastructure.
-
 **Daemon reliability**
 - File watchers no longer leak a file descriptor per project file under long uptimes — the per-file handles in `ProjectWatcher` (fsnotify userspace mirror) are now released on directory teardown (#580).
 - `ox murmur` file-change notifications now respect `.gitignore`, so build artifacts and editor temp files no longer spam teammates (#581).

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.7.0"
+	Version   = "0.7.1"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## Summary

Patch release rolling up four fixes that landed on `main` since v0.7.0.

## Changes

- `internal/version/version.go` → `0.7.1`
- `.claude-plugin/marketplace.json` → `0.7.1`
- `claude-plugin/.claude-plugin/plugin.json` → `0.7.1`
- `cmd/ox/release_notes.md` — adds 0.7.1 section

## Commits in this release

| PR  | Summary |
|-----|---------|
| #581 | fix(daemon): filter gitignored files from murmur file-change notifications |
| #580 | fix(daemon): plug per-file FD leak in `ProjectWatcher` (fsnotify userspace mirror) |
| #579 | fix(security): path traversal, credential sanitization, LFS size bounds, auth hardening |
| #578 | fix(session): repair empty-title meta sessions ('Summary unavailable' UI bug) |

## Test plan

- [x] `make verify-version` — all four version touchpoints report `0.7.1`
- [ ] Post-merge: human creates GitHub release with tag `v0.7.1`; goreleaser handles binaries/signing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.7.1

* **Bug Fixes**
  * Fixed daemon reliability issues with file watcher descriptor leaks
  * Fixed `ox murmur` to properly respect `.gitignore` files
  * Improved session UX with automatic repair for missing session titles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->