### PR TITLE
feat(summarization): pin Haiku 4.5, prefilter, observability, token wins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.7.1"
+      "version": "0.7.2"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -58,6 +58,7 @@ var activePhaseBehavior = map[string]bool{
 	phaseAfterTool: true,
 	phaseStop:      true,
 	phasePrompt:    true,
+	phaseEnd:       true,
 }
 
 // HookContext carries everything a phase handler needs.
@@ -199,6 +200,8 @@ func dispatchPhase(ctx *HookContext) error {
 		return handleAfterTool(ctx)
 	case phaseStop:
 		return handleStop(ctx)
+	case phaseEnd:
+		return handleEnd(ctx)
 	default:
 		return nil
 	}
@@ -320,6 +323,81 @@ func stopSessionForClear(ctx *HookContext, agentID string) {
 	}
 
 	slog.Debug("hook: stopped session for clear", "agent_id", agentID)
+}
+
+// handleEnd handles the SessionEnd phase — fires when the calling agent
+// (Claude Code, Gemini CLI, etc.) is exiting. Auto-finalizes the active
+// recording so the user doesn't have to remember to run `ox session stop`.
+//
+// Without this handler, sessions only finalize via:
+//   - manual `ox agent <id> session stop` (most users never run it)
+//   - the daemon's 24h stale-recording sweep
+//
+// Most users just close their agent and walk away — leaving the recording
+// stranded in the cache for up to a day. handleEnd closes that gap.
+//
+// SessionEnd MUST use the `delegated` mode regardless of the user's
+// `agent.summarizer` setting: at this point the calling agent process is
+// being torn down, so `inline` (which whispers a prompt back to the agent
+// for it to run the LLM in its warm cache) has no agent left to whisper to.
+// The daemon IPC dispatch below is the only viable path in this window.
+//
+// Idempotency: SessionEnd can fire multiple times (window close, debugger
+// reattach, IDE reload). The handler is safe to call repeatedly — the
+// first call sets StoppedAt and clears recording state; subsequent calls
+// see no state and return immediately.
+func handleEnd(ctx *HookContext) error {
+	agentID := ""
+	if ctx.Marker != nil {
+		agentID = ctx.Marker.AgentID
+	}
+	if agentID == "" {
+		slog.Debug("hook: end skipped, no agent ID")
+		return nil
+	}
+
+	state, err := session.LoadRecordingStateForAgent(ctx.ProjectRoot, agentID)
+	if err != nil || state == nil {
+		slog.Debug("hook: end no recording state", "agent_id", agentID)
+		return nil
+	}
+
+	if state.StoppedAt != nil {
+		slog.Debug("hook: end already finalized", "agent_id", agentID, "stopped_at", *state.StoppedAt)
+		return nil
+	}
+
+	now := time.Now()
+	if updateErr := session.UpdateRecordingStateForAgent(ctx.ProjectRoot, agentID, func(s *session.RecordingState) {
+		s.StoppedAt = &now
+	}); updateErr != nil {
+		slog.Debug("hook: end could not set StoppedAt", "agent_id", agentID, "error", updateErr)
+	}
+
+	// dispatch delegated finalization via daemon IPC. Best-effort: if the
+	// daemon is unreachable, the daemon's anti-entropy sweep will still
+	// pick up the StoppedAt-marked recording within the 24h stale window.
+	if state.SessionPath != "" {
+		if ledgerPath := deriveLedgerPath(state.SessionPath); ledgerPath != "" {
+			client := daemon.NewClientForCurrentRepoWithTimeout(100 * time.Millisecond)
+			sessionName := filepath.Base(state.SessionPath)
+			if ipcErr := client.SessionFinalize(daemon.SessionFinalizeIPCPayload{
+				SessionName: sessionName,
+				LedgerPath:  ledgerPath,
+				CachePath:   state.SessionPath,
+				ProjectRoot: ctx.ProjectRoot,
+			}); ipcErr != nil {
+				slog.Debug("hook: end finalize IPC failed", "error", ipcErr)
+			}
+		}
+	}
+
+	if clearErr := session.ClearRecordingStateForAgent(ctx.ProjectRoot, agentID); clearErr != nil {
+		slog.Debug("hook: end could not remove recording state", "agent_id", agentID, "error", clearErr)
+	}
+
+	slog.Info("hook: finalized session on agent end", "agent_id", agentID)
+	return nil
 }
 
 // handlePrompt handles the user prompt submission phase.

--- a/cmd/ox/agent_hook_coverage_test.go
+++ b/cmd/ox/agent_hook_coverage_test.go
@@ -72,8 +72,11 @@ func TestDispatchPhase_UnknownPhase(t *testing.T) {
 
 func TestActivePhaseBehavior_Coverage(t *testing.T) {
 	t.Parallel()
-	// verify the known active phases are registered
-	expectedActive := []string{phaseStart, phaseCompact, phaseAfterTool, phaseStop, phasePrompt}
+	// verify the known active phases are registered. phaseEnd was added when
+	// the SessionEnd hook handler was wired up to auto-finalize recordings on
+	// agent exit (previously: hook entry installed in .claude/settings.json
+	// but dispatchPhase silently no-op'd). See cmd/ox/agent_hook.go:handleEnd.
+	expectedActive := []string{phaseStart, phaseCompact, phaseAfterTool, phaseStop, phasePrompt, phaseEnd}
 	for _, phase := range expectedActive {
 		if !activePhaseBehavior[phase] {
 			t.Errorf("expected phase %q to be active", phase)
@@ -81,7 +84,7 @@ func TestActivePhaseBehavior_Coverage(t *testing.T) {
 	}
 
 	// verify some phases are NOT active
-	expectedInactive := []string{phaseEnd, phaseBeforeTool}
+	expectedInactive := []string{phaseBeforeTool}
 	for _, phase := range expectedInactive {
 		if activePhaseBehavior[phase] {
 			t.Errorf("expected phase %q to be inactive", phase)

--- a/cmd/ox/agent_hook_end_test.go
+++ b/cmd/ox/agent_hook_end_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- SessionEnd hook tests ---
+//
+// handleEnd auto-finalizes the active recording when the calling agent exits.
+// Without it, sessions only finalize via manual `ox session stop` (rarely used)
+// or the daemon's 24h stale-recording sweep — leaving recordings stranded for
+// up to a day in the common case where the user just closes their agent.
+//
+// The handler must be:
+//   1. idempotent — SessionEnd can fire multiple times (window close, debugger
+//      reattach, IDE reload). Only the first call should mark StoppedAt and
+//      dispatch finalization.
+//   2. graceful — if no recording exists or it's already finalized, no error.
+//   3. delegated-only — at SessionEnd the calling agent process is gone, so
+//      inline summarization (which whispers a prompt back to the agent) has
+//      no agent to whisper to. Routing through the daemon IPC is the only
+//      viable mode in this window. The handler does not consult
+//      `agent.summarizer`; it always dispatches via daemon.
+
+// TestHandleEnd_FinalizesActiveRecording verifies that handleEnd marks the
+// recording as stopped on the first call.
+// Failure prevented: user closes their agent, recording sits unfinalized in
+// the cache for up to 24h until the daemon's anti-entropy sweep notices.
+func TestHandleEnd_FinalizesActiveRecording(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+
+	agentID := "OxEndTest"
+	createActiveRecording(t, projectRoot, repoID, agentID)
+
+	loaded, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Nil(t, loaded.StoppedAt, "precondition: StoppedAt nil before end")
+
+	ctx := &HookContext{
+		Phase:       phaseEnd,
+		AgentType:   "claude-code",
+		ProjectRoot: projectRoot,
+		Marker:      &SessionMarker{AgentID: agentID},
+	}
+	require.NoError(t, handleEnd(ctx))
+
+	// recording state should be cleared (so subsequent ox calls don't see a
+	// zombie active recording). LoadRecordingStateForAgent returns nil with
+	// no error when the state file doesn't exist.
+	cleared, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	assert.Nil(t, cleared, "handleEnd must clear recording state after dispatch")
+}
+
+// TestHandleEnd_Idempotent_NoStateAfterFirstCall verifies that handleEnd is
+// safe to call multiple times — the first call clears state, subsequent calls
+// are no-ops.
+// Failure prevented: SessionEnd fires twice (e.g., on IDE reload), the second
+// call double-dispatches to the daemon or corrupts state.
+func TestHandleEnd_Idempotent_NoStateAfterFirstCall(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+
+	agentID := "OxEndIdem"
+	createActiveRecording(t, projectRoot, repoID, agentID)
+
+	ctx := &HookContext{
+		Phase:       phaseEnd,
+		AgentType:   "claude-code",
+		ProjectRoot: projectRoot,
+		Marker:      &SessionMarker{AgentID: agentID},
+	}
+
+	// fire SessionEnd 3 times in a row — handler must not error on any
+	for i := 0; i < 3; i++ {
+		require.NoErrorf(t, handleEnd(ctx), "handleEnd call %d should not error", i+1)
+	}
+
+	cleared, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	assert.Nil(t, cleared, "recording state should remain cleared after multiple end calls")
+}
+
+// TestHandleEnd_AlreadyStopped_NoOp verifies that handleEnd respects an
+// already-set StoppedAt and does not redispatch.
+// Failure prevented: a recording explicitly stopped via `ox session stop` is
+// then re-finalized when SessionEnd subsequently fires, racing with the
+// inline-mode finalization that's already in flight.
+func TestHandleEnd_AlreadyStopped_NoOp(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+
+	agentID := "OxEndAlreadyStopped"
+	createActiveRecording(t, projectRoot, repoID, agentID)
+
+	earlier := time.Now().Add(-1 * time.Minute)
+	require.NoError(t, session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+		s.StoppedAt = &earlier
+	}))
+
+	ctx := &HookContext{
+		Phase:       phaseEnd,
+		AgentType:   "claude-code",
+		ProjectRoot: projectRoot,
+		Marker:      &SessionMarker{AgentID: agentID},
+	}
+	require.NoError(t, handleEnd(ctx))
+
+	// state must remain (was not cleared) and StoppedAt must remain pinned to
+	// the original timestamp — the no-op path skipped both clear and re-stamp.
+	loaded, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded, "already-stopped recording state should not be cleared by no-op end")
+	require.NotNil(t, loaded.StoppedAt)
+	assert.WithinDuration(t, earlier, *loaded.StoppedAt, time.Second,
+		"already-set StoppedAt must not be overwritten")
+}
+
+// TestHandleEnd_NoRecording_NoError verifies that handleEnd gracefully handles
+// the case where no recording exists for the agent (e.g., the agent exited
+// before ever starting a session).
+func TestHandleEnd_NoRecording_NoError(t *testing.T) {
+	projectRoot, _ := setupTestProject(t)
+
+	ctx := &HookContext{
+		Phase:       phaseEnd,
+		AgentType:   "claude-code",
+		ProjectRoot: projectRoot,
+		Marker:      &SessionMarker{AgentID: "OxEndNoRec"},
+	}
+	assert.NoError(t, handleEnd(ctx))
+}
+
+// TestHandleEnd_NoAgentID_NoError verifies that handleEnd is a silent no-op
+// when there's no agent ID to identify the recording.
+func TestHandleEnd_NoAgentID_NoError(t *testing.T) {
+	ctx := &HookContext{
+		Phase:       phaseEnd,
+		AgentType:   "claude-code",
+		ProjectRoot: t.TempDir(),
+	}
+	assert.NoError(t, handleEnd(ctx))
+}
+
+// TestPhaseEnd_HasActiveBehavior verifies that the SessionEnd phase is wired
+// into activePhaseBehavior — without this, the hook fires but dispatchPhase
+// short-circuits and silently noops, which is exactly the bug this work fixes.
+func TestPhaseEnd_HasActiveBehavior(t *testing.T) {
+	assert.True(t, activePhaseBehavior[phaseEnd],
+		"phaseEnd must be marked active so dispatchPhase routes it to handleEnd")
+}

--- a/cmd/ox/agent_hook_test.go
+++ b/cmd/ox/agent_hook_test.go
@@ -46,15 +46,17 @@ func TestResolvePhase(t *testing.T) {
 }
 
 func TestActivePhaseBehavior(t *testing.T) {
-	// phases with behavior
+	// phases with behavior. phaseEnd was added when SessionEnd hook
+	// auto-finalization was wired up — see cmd/ox/agent_hook.go:handleEnd
+	// and the regression test TestPhaseEnd_HasActiveBehavior.
 	assert.True(t, activePhaseBehavior[phaseStart])
 	assert.True(t, activePhaseBehavior[phaseCompact])
 	assert.True(t, activePhaseBehavior[phaseAfterTool])
 	assert.True(t, activePhaseBehavior[phaseStop])
 	assert.True(t, activePhaseBehavior[phasePrompt])
+	assert.True(t, activePhaseBehavior[phaseEnd])
 
 	// noop phases
-	assert.False(t, activePhaseBehavior[phaseEnd])
 	assert.False(t, activePhaseBehavior[phaseBeforeTool])
 }
 
@@ -65,7 +67,7 @@ func TestDispatchPhase_NoopPhases(t *testing.T) {
 	}
 
 	// noop phases should return nil
-	for _, phase := range []string{phaseEnd, phaseBeforeTool} {
+	for _, phase := range []string{phaseBeforeTool} {
 		ctx.Phase = phase
 		err := dispatchPhase(ctx)
 		assert.NoError(t, err, "phase %s should be noop", phase)

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1158,10 +1158,12 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 	//
 	// Default is `inline` because the cost asymmetry is too large to default
 	// to the expensive path. Users who want non-blocking session-stop and are
-	// OK paying the token cost can opt into `delegated`. The dispatch is
-	// gated behind `SAGEOX_ASYNC_SESSION_UPLOAD=1` until the `agent.summarizer`
-	// config key lands; the env var will stay as a deprecated alias.
-	asyncUpload := os.Getenv("SAGEOX_ASYNC_SESSION_UPLOAD") == "1"
+	// OK paying the token cost can opt into `delegated`. ResolveAgentSummarizer
+	// honors (in priority order): the legacy SAGEOX_ASYNC_SESSION_UPLOAD /
+	// OX_SESSION_INLINE_SUMMARY env vars (deprecated, one-release shim), the
+	// `agent.summarizer` user-config key, and finally the inline default.
+	summarizerMode := config.GetAgentSummarizer(projectRoot)
+	asyncUpload := summarizerMode == config.AgentSummarizerDelegated
 
 	if ledgerErr != nil {
 		// couldn't resolve ledger path - skip upload

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1133,31 +1133,34 @@ func processAgentSession(projectRoot string, state *session.RecordingState) (*ag
 	// This is best-effort -- session processing already succeeded.
 	// No spinner here -- bubbletea conflicts with Claude Code's own epoll on stdin.
 	//
-	// SESSION SUMMARIZATION DELEGATION — see ADR-016 for full rationale.
+	// SESSION SUMMARIZATION — see ADR-016 for full rationale.
 	//
-	// Two paths produce summary.json:
+	// Three modes are recognized; only the first two are implemented:
 	//
-	//   1. Inline (default today): SummaryPrompt is returned to the calling
-	//      agent. The agent runs the LLM on its existing conversation context
-	//      and pipes the result to `ox session push-summary`. Free in input
-	//      tokens, agent-agnostic, no extra binary required — but blocks the
-	//      user in the foreground for 30–120s at exactly the moment they
-	//      signaled "I'm done" and wanted to /clear or close the agent.
+	//   inline    — the CLI drives summarization. SummaryPrompt is returned
+	//               to the calling agent, which runs the LLM in its existing
+	//               warm conversation context and pipes the result to
+	//               `ox session push-summary`. Cheap (input tokens are mostly
+	//               cache-reads from the agent's existing context); blocks
+	//               the user in the foreground for 30–120s. **Default.**
 	//
-	//   2. Daemon-delegated (this branch when asyncUpload is true): CLI
-	//      uploads raw.jsonl + meta.json synchronously (small, durability-
-	//      critical), then signals the daemon and returns immediately.
-	//      `internal/daemon/agentwork/session_finalize.go` spawns the user's
-	//      configured LLM CLI (claude/codex/gemini), generates the summary,
-	//      and calls back into the shared pushSummaryToLedger flow.
+	//   delegated — the daemon drives summarization. CLI uploads raw.jsonl +
+	//               meta.json synchronously (small, durability-critical),
+	//               signals the daemon, and returns immediately. The daemon
+	//               (`internal/daemon/agentwork/session_finalize.go`) spawns
+	//               the user's configured LLM CLI (claude/codex/gemini)
+	//               against the cached raw.jsonl — every call is a *fresh*
+	//               cold prompt, ~10× more expensive than inline on the same
+	//               session. The only thing this buys the user is getting
+	//               their terminal back immediately at session-stop.
 	//
-	// Delegating to the calling agent is the right default *technically*, but
-	// only when the user has not specified an LLM agent for daemon callouts.
-	// When the user *has* a usable runner configured (or auto-detectable on
-	// PATH), forcing the inline path is pure user-visible latency for no
-	// architectural benefit. The plan is to lift this env var to a first-class
-	// `agent.summarizer` config key with `auto` (PATH detection) as the
-	// default. The current env var stays as a compatibility alias.
+	//   cloud     — RESERVED. SageOx cloud-side summarization. Not implemented.
+	//
+	// Default is `inline` because the cost asymmetry is too large to default
+	// to the expensive path. Users who want non-blocking session-stop and are
+	// OK paying the token cost can opt into `delegated`. The dispatch is
+	// gated behind `SAGEOX_ASYNC_SESSION_UPLOAD=1` until the `agent.summarizer`
+	// config key lands; the env var will stay as a deprecated alias.
 	asyncUpload := os.Getenv("SAGEOX_ASYNC_SESSION_UPLOAD") == "1"
 
 	if ledgerErr != nil {

--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -174,6 +174,44 @@ Override per-invocation with --html, --text, or --json flags.`,
 		Levels:      []ConfigLevel{ConfigLevelUser},
 	},
 	{
+		Key:         "agent.summarizer",
+		Description: "Who runs the session-stop summarization (inline/delegated)",
+		LongDescription: `Selects who runs the LLM call that summarizes a session at stop.
+
+  inline    — The calling agent (Claude Code, Cursor, etc.) runs the LLM
+              in its already-warm prompt cache. Cheap (input tokens are
+              mostly cache reads). Blocks the user in the foreground for
+              ~30–120s while the agent finishes. **Default.**
+
+  delegated — The daemon runs the LLM in a fresh subprocess against the
+              cached raw.jsonl. Every call is a *cold* prompt — input
+              tokens are paid in full, roughly 10× the cost of inline on
+              the same session. The only thing this buys you is getting
+              your terminal back immediately at session-stop.
+
+  off       — Skip LLM summarization entirely. Sessions are still uploaded
+              to the ledger, but team-context surfacing and search will
+              be degraded for these recordings.
+
+  cloud     — Reserved for future SageOx cloud-side summarization. Not
+              yet implemented; rejected by 'ox config set'.
+
+Default is 'inline' because the cost asymmetry is too large to default
+to 'delegated'. Switch to 'delegated' only if you want session-stop to
+return immediately and you're OK paying the token cost on every close.
+
+When the SessionEnd hook fires (Claude Code exit), summarization always
+goes through 'delegated' regardless of this setting — at that moment the
+calling agent process is being torn down, so 'inline' has no agent to
+whisper back to.
+
+See ADR-016 for full rationale.`,
+		Category:    "Sessions",
+		ValidValues: []string{"inline", "delegated", "off"}, // "cloud" intentionally absent — reserved
+		Default:     "inline",
+		Levels:      []ConfigLevel{ConfigLevelUser},
+	},
+	{
 		Key:         "agent_worker",
 		Description: "Daemon AI coworker for background tasks",
 		LongDescription: `Selects which agent CLI the daemon uses for background tasks like
@@ -409,6 +447,11 @@ func ResolveConfigValue(key string, projectRoot string) (*ConfigValue, error) {
 			}
 		}
 
+	case "agent.summarizer":
+		if userCfg != nil && userCfg.AgentSummarizer != "" {
+			cv.UserVal = config.NormalizeAgentSummarizer(userCfg.AgentSummarizer)
+		}
+
 	case "attribution.commit":
 		if userCfg != nil && userCfg.Attribution != nil && userCfg.Attribution.IsCommitSet() {
 			if v := userCfg.Attribution.GetCommit(); v == "" {
@@ -604,6 +647,16 @@ func setUserConfig(key, value string) error {
 			cfg.SetAgentWorkerAgent(value)
 		}
 
+	case "agent.summarizer":
+		// `cloud` is the future SageOx cloud-side path; rejected here so users
+		// don't silently set a value that won't take effect. ValidValues in
+		// AllSettings already prevents this for fresh users, but the explicit
+		// guard catches scripts and direct YAML edits.
+		if value == config.AgentSummarizerCloud {
+			return fmt.Errorf("agent.summarizer=cloud is reserved for future SageOx cloud-side summarization and is not yet implemented; pick inline, delegated, or off")
+		}
+		cfg.AgentSummarizer = value
+
 	case "attribution.commit":
 		if cfg.Attribution == nil {
 			cfg.Attribution = &config.Attribution{}
@@ -777,6 +830,9 @@ func unsetUserConfig(key string) error {
 
 	case "agent_worker":
 		cfg.AgentWorker = nil
+
+	case "agent.summarizer":
+		cfg.AgentSummarizer = ""
 
 	case "attribution.commit":
 		if cfg.Attribution != nil {

--- a/cmd/ox/helpers_coverage_test.go
+++ b/cmd/ox/helpers_coverage_test.go
@@ -658,16 +658,17 @@ func TestResolvePhase_UnknownEvent(t *testing.T) {
 // --- activePhaseBehavior coverage ---
 
 func TestActivePhaseBehavior_KnownPhases(t *testing.T) {
-	// verify the phases that should have behavior
+	// verify the phases that should have behavior. phaseEnd was added when
+	// SessionEnd hook auto-finalization was wired up.
 	assert.True(t, activePhaseBehavior[phaseStart])
 	assert.True(t, activePhaseBehavior[phaseCompact])
 	assert.True(t, activePhaseBehavior[phaseAfterTool])
 	assert.True(t, activePhaseBehavior[phaseStop])
 	assert.True(t, activePhaseBehavior[phasePrompt])
+	assert.True(t, activePhaseBehavior[phaseEnd])
 
 	// phases without behavior
 	assert.False(t, activePhaseBehavior[phaseBeforeTool])
-	assert.False(t, activePhaseBehavior[phaseEnd])
 }
 
 // --- dispatchPhase noop default ---

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-05-04
+
+### Added
+
+**Session summarization is now configurable and observable**
+- New `agent.summarizer` setting picks who runs the LLM that summarizes a session at stop. `inline` (default) runs it in the calling agent's already-warm prompt cache — cheap, but blocks the user for ~30–120s. `delegated` runs it in the daemon as a background subprocess — non-blocking, but pays the full input-token cost on every stop. `off` skips LLM summarization. `cloud` is reserved for future SageOx cloud-side summarization.
+- The legacy `SAGEOX_ASYNC_SESSION_UPLOAD` and `OX_SESSION_INLINE_SUMMARY` env vars still work for one release as deprecation aliases, with a warning pointing at `ox config set agent.summarizer`.
+- `ox session stop` now finalizes automatically when you exit Claude Code. Previously the SessionEnd hook fired but had no handler, leaving recordings stranded in the cache for up to 24 hours until the daemon's anti-entropy sweep noticed.
+- New `summarization` telemetry event captures input/output tokens, model, duration, and quality score for every delegated summarization call. When the LLM-as-judge runs, its tokens piggyback on the same event.
+
+### Changed
+
+**Cheaper session summarization on the delegated path**
+- Delegated summarization now defaults to Claude Haiku 4.5 instead of inheriting the user's local default (typically Sonnet). The summarization task is structured JSON extraction over a fixed schema — well within Haiku's capabilities and 5–15× cheaper. `OX_SUMMARY_MODEL` overrides the default.
+- The summary-input optimizer now strips tool entries down to bare `{type:"tool_mark"}` markers (with `count:N` when adjacent runs collapse). Tool name, brief, and I/O are no longer carried — assistant prose already names concrete actions, and the marker only needs to signal "the agent acted between these two messages." On a realistic 300-entry session this is an 87% byte/token reduction over the previous shape.
+
+[0.7.2]: https://github.com/sageox/ox/releases/tag/v0.7.2
+
 ## [0.7.1] - 2026-05-03
 
 ### Fixed

--- a/cmd/ox/session_optimize_for_summary.go
+++ b/cmd/ox/session_optimize_for_summary.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sageox/ox/internal/telemetry"
 	"github.com/sageox/ox/pkg/sessionpipeline"
+	"github.com/sageox/ox/pkg/sessionsummary"
 	"github.com/sageox/ox/pkg/tokenopt"
 	"github.com/sageox/ox/pkg/tokenstrip"
 )
@@ -44,14 +45,43 @@ func (tokenoptStage) Apply(ctx context.Context, r io.Reader, w io.Writer) (sessi
 //
 // Enabled by default; opt-out via OX_SUMMARY_INPUT_TOKEN_STRIP=off. See
 // summaryInputTokenStripDisabled() for the gate.
+//
+// DropThinkingMode is selected from OX_SUMMARY_INPUT_DROP_THINKING:
+//
+//	(unset|none): preserve thinking blocks (current default).
+//	first|first_sentence: keep first sentence, elide rest. Conservative.
+//	all|drop: remove blocks entirely. Aggressive.
+//
+// Recommended rollout: keep the default at none for one release while
+// the EventTokenoptRun + EventSummarization correlation lets us A/B
+// quality_score against compression-ratio. Flip to first_sentence as
+// the default once telemetry shows quality is unaffected.
 type tokenstripStage struct{}
 
 func (tokenstripStage) Name() string { return "tokenstrip" }
 
 func (tokenstripStage) Apply(ctx context.Context, r io.Reader, w io.Writer) (sessionpipeline.Stats, error) {
 	_ = ctx
-	stats, err := tokenstrip.Compress(r, w)
+	stats, err := tokenstrip.CompressWith(r, w, tokenstrip.Options{
+		DropThinkingMode: dropThinkingModeFromEnv(),
+	})
 	return stats, err
+}
+
+// summaryInputDropThinkingEnvVar selects how aggressively <thinking>
+// blocks in assistant content are reduced before the LLM sees them.
+// See tokenstripStage docstring for values + rollout guidance.
+const summaryInputDropThinkingEnvVar = "OX_SUMMARY_INPUT_DROP_THINKING"
+
+func dropThinkingModeFromEnv() tokenstrip.DropThinkingMode {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(summaryInputDropThinkingEnvVar))) {
+	case "first", "first_sentence", "firstsentence":
+		return tokenstrip.DropThinkingFirstSentence
+	case "all", "drop":
+		return tokenstrip.DropThinkingAll
+	default:
+		return tokenstrip.DropThinkingNone
+	}
 }
 
 // Cache-budget knobs. Exceeding either triggers LRU pruning by mtime.
@@ -133,7 +163,7 @@ func writeOptimizedJSONLForSummary(rawPath, ledgerPath, sessionName string) stri
 	}
 	if summaryInputOptimizeDisabled() {
 		slog.Info("tokenopt: disabled via env, using raw.jsonl", "env", summaryInputOptimizeEnvVar)
-		emitTokenoptTelemetry(rawPath, tokenopt.Stats{}, "disabled")
+		emitTokenoptTelemetry(rawPath, tokenopt.Stats{}, tokenstrip.Stats{}, false, "disabled")
 		return ""
 	}
 	in, err := os.Open(rawPath)
@@ -153,7 +183,7 @@ func writeOptimizedJSONLForSummary(rawPath, ledgerPath, sessionName string) stri
 	out, err := os.Create(optPath)
 	if err != nil {
 		slog.Debug("tokenopt: create optimized file failed", "path", optPath, "error", err)
-		emitTokenoptTelemetry(rawPath, tokenopt.Stats{}, "create_failed")
+		emitTokenoptTelemetry(rawPath, tokenopt.Stats{}, tokenstrip.Stats{}, false, "create_failed")
 		return ""
 	}
 
@@ -176,21 +206,35 @@ func writeOptimizedJSONLForSummary(rawPath, ledgerPath, sessionName string) stri
 	}
 
 	// Recover tokenopt.Stats from the first stage result for the sanity
-	// gate and telemetry. The sanity gate checks invariants produced by
-	// tokenopt (EntriesIn - SystemDropped == EntriesOut); subsequent
-	// stages don't modify those invariants, so scoring from stage[0] is
-	// sufficient.
+	// gate. The sanity gate checks invariants produced by tokenopt
+	// (EntriesIn - SystemDropped - HeaderDropped - ToolsBatched ==
+	// EntriesOut); subsequent stages don't change those invariants, so
+	// stage[0] is sufficient for sanity.
 	var stats tokenopt.Stats
 	if len(stageResults) > 0 && stageResults[0].Stats != nil {
 		if ts, ok := stageResults[0].Stats.(tokenopt.Stats); ok {
 			stats = ts
 		}
 	}
+	// Recover tokenstrip.Stats from stage[1] when present, so telemetry
+	// can report the FINAL bytes/tokens that reached the LLM — not the
+	// intermediate bytes after tokenopt but before tokenstrip's NFC /
+	// zero-width / whitespace / thinking-block transforms. Without this
+	// the tokenopt_run event understates compression effectiveness by
+	// however much tokenstrip removed.
+	var stripStats tokenstrip.Stats
+	var stripStatsValid bool
+	if len(stageResults) > 1 && stageResults[1].Stats != nil {
+		if ts, ok := stageResults[1].Stats.(tokenstrip.Stats); ok {
+			stripStats = ts
+			stripStatsValid = true
+		}
+	}
 
 	if runErr != nil {
 		slog.Warn("tokenopt: compress failed, summary will use raw.jsonl", "error", runErr)
 		_ = os.Remove(optPath)
-		emitTokenoptTelemetry(rawPath, stats, "compress_failed")
+		emitTokenoptTelemetry(rawPath, stats, stripStats, stripStatsValid, "compress_failed")
 		return ""
 	}
 
@@ -201,7 +245,7 @@ func writeOptimizedJSONLForSummary(rawPath, ledgerPath, sessionName string) stri
 		slog.Warn("tokenopt: sanity gate rejected optimized file, falling back to raw.jsonl",
 			"reason", reason, "path", optPath, "stats", stats)
 		_ = os.Remove(optPath)
-		emitTokenoptTelemetry(rawPath, stats, "sanity_rejected:"+reason)
+		emitTokenoptTelemetry(rawPath, stats, stripStats, stripStatsValid, "sanity_rejected:"+reason)
 		return ""
 	}
 
@@ -213,7 +257,10 @@ func writeOptimizedJSONLForSummary(rawPath, ledgerPath, sessionName string) stri
 	}
 
 	slog.Info("tokenopt", "path", optPath, "stats", stats)
-	emitTokenoptTelemetry(rawPath, stats, "ok")
+	if stripStatsValid {
+		slog.Info("tokenstrip", "path", optPath, "stats", stripStats)
+	}
+	emitTokenoptTelemetry(rawPath, stats, stripStats, stripStatsValid, "ok")
 	_, pct := stats.Reduction()
 	fmt.Fprintf(os.Stderr, "session summary input optimized: %d→%d entries, %d→%d bytes (%.1f%% smaller)\n",
 		stats.EntriesIn, stats.EntriesOut, stats.BytesIn, stats.BytesOut, pct)
@@ -226,27 +273,60 @@ func writeOptimizedJSONLForSummary(rawPath, ledgerPath, sessionName string) stri
 // gives us compression-rate distribution, error rate, and fallback rate
 // across the user base. Best-effort: no-op when telemetry client not available
 // (offline, opted-out, etc.).
-func emitTokenoptTelemetry(rawPath string, stats tokenopt.Stats, outcome string) {
+func emitTokenoptTelemetry(rawPath string, stats tokenopt.Stats, stripStats tokenstrip.Stats, stripValid bool, outcome string) {
 	if cliCtx == nil || cliCtx.TelemetryClient == nil {
 		return
 	}
-	_, pct := stats.Reduction()
+	_, bytePct := stats.Reduction()
+	_, tokPct := stats.TokenReduction()
 	success := outcome == "ok"
 	meta := map[string]string{
-		"outcome":            outcome,
-		"entries_in":         strconv.Itoa(stats.EntriesIn),
-		"entries_out":        strconv.Itoa(stats.EntriesOut),
-		"bytes_in":           strconv.FormatInt(stats.BytesIn, 10),
-		"bytes_out":          strconv.FormatInt(stats.BytesOut, 10),
-		"reduction_pct":      strconv.FormatFloat(pct, 'f', 1, 64),
-		"tools_marked":       strconv.Itoa(stats.ToolsMarked),
-		"system_dropped":     strconv.Itoa(stats.SystemDropped),
-		"ansi_stripped":      strconv.Itoa(stats.ANSIStripped),
-		"images_elided":      strconv.Itoa(stats.ImagesElided),
-		"large_reads_elided": strconv.Itoa(stats.LargeReadsElided),
-		"reminders_deduped":  strconv.Itoa(stats.RemindersDeduped),
-		"tool_results_refd":  strconv.Itoa(stats.ToolResultsRefd),
+		"outcome":             outcome,
+		"entries_in":          strconv.Itoa(stats.EntriesIn),
+		"entries_out":         strconv.Itoa(stats.EntriesOut),
+		"bytes_in":            strconv.FormatInt(stats.BytesIn, 10),
+		"bytes_out":           strconv.FormatInt(stats.BytesOut, 10),
+		"byte_reduction_pct":  strconv.FormatFloat(bytePct, 'f', 1, 64),
+		"tokens_in_est":       strconv.FormatInt(stats.TokensInEstimate, 10),
+		"tokens_out_est":      strconv.FormatInt(stats.TokensOutEstimate, 10),
+		"token_reduction_pct": strconv.FormatFloat(tokPct, 'f', 1, 64),
+		"tools_marked":        strconv.Itoa(stats.ToolsMarked),
+		"tools_batched":       strconv.Itoa(stats.ToolsBatched),
+		"system_dropped":      strconv.Itoa(stats.SystemDropped),
+		"header_dropped":      strconv.Itoa(stats.HeaderDropped),
+		"ansi_stripped":       strconv.Itoa(stats.ANSIStripped),
+		"images_elided":       strconv.Itoa(stats.ImagesElided),
+		"large_reads_elided":  strconv.Itoa(stats.LargeReadsElided),
+		"reminders_deduped":   strconv.Itoa(stats.RemindersDeduped),
+		"tool_results_refd":   strconv.Itoa(stats.ToolResultsRefd),
+		// session_hash correlates this event with the summarization event
+		// emitted by the daemon's session_finalize handler. Hash of the
+		// session NAME (not content, not path), so privacy is preserved
+		// while server-side joins become possible.
+		"session_hash": sessionsummary.SessionHashFromRawPath(rawPath),
 	}
+	// Backwards-compat: keep the historical "reduction_pct" key as an
+	// alias for byte_reduction_pct so dashboards built before tokens
+	// existed don't blank out. Drop after one release.
+	meta["reduction_pct"] = meta["byte_reduction_pct"]
+
+	// Final-stage stats: bytes/tokens AFTER the tokenstrip pass, which
+	// is what the LLM actually receives. Without these, the dashboard
+	// understates compression effectiveness by however much tokenstrip
+	// removed (NFC, zero-width, whitespace canon, thinking-block trim).
+	// Only emitted when tokenstrip ran (skipped if env opt-out is set).
+	if stripValid {
+		_, finalBytePct := stripStats.Reduction()
+		_, finalTokPct := stripStats.TokenReduction()
+		meta["final_bytes_out"] = strconv.FormatInt(stripStats.BytesOut, 10)
+		meta["final_tokens_out_est"] = strconv.FormatInt(stripStats.TokensOutEstimate, 10)
+		meta["tokenstrip_byte_reduction_pct"] = strconv.FormatFloat(finalBytePct, 'f', 1, 64)
+		meta["tokenstrip_token_reduction_pct"] = strconv.FormatFloat(finalTokPct, 'f', 1, 64)
+		meta["thinking_blocks_trimmed"] = strconv.Itoa(stripStats.ThinkingBlocksTrimmed)
+		meta["thinking_blocks_dropped"] = strconv.Itoa(stripStats.ThinkingBlocksDropped)
+		meta["stop_words_removed"] = strconv.Itoa(stripStats.StopWordsRemoved)
+	}
+
 	cliCtx.TelemetryClient.TrackAsync(telemetry.Event{
 		Type:     telemetry.EventTokenoptRun,
 		Command:  "session_stop",
@@ -255,15 +335,21 @@ func emitTokenoptTelemetry(rawPath string, stats tokenopt.Stats, outcome string)
 	})
 }
 
+
 // sanityCheckOptimized returns a non-empty reason string when the compressed
 // file looks wrong and should not be trusted. Empty string = pass.
 //
 // Invariants checked:
 //   - file exists and is non-empty
 //   - entries were actually emitted (non-zero EntriesOut)
-//   - EntriesOut matches EntriesIn - SystemDropped. ConversationOnly drops
-//     only system entries; anything else disappearing means a regression is
-//     silently eating user or assistant turns.
+//   - EntriesOut == EntriesIn - SystemDropped - HeaderDropped - ToolsBatched.
+//     ConversationOnly's accounted reductions are: system entries dropped,
+//     header entries dropped (the LLM doesn't need them; daemon stamps
+//     them into meta.json directly from stored.Meta), and adjacent
+//     identical tool_marks collapsed via batching. Anything else
+//     disappearing means a regression is silently eating user or assistant
+//     turns — which would corrupt the summary in a way the LLM can't
+//     recover from.
 func sanityCheckOptimized(path string, stats tokenopt.Stats) string {
 	if stats.EntriesIn == 0 {
 		// Empty input → empty output is legitimate.
@@ -279,10 +365,10 @@ func sanityCheckOptimized(path string, stats tokenopt.Stats) string {
 	if stats.EntriesOut == 0 {
 		return "zero entries emitted from a non-empty input"
 	}
-	expected := stats.EntriesIn - stats.SystemDropped
+	expected := stats.EntriesIn - stats.SystemDropped - stats.HeaderDropped - stats.ToolsBatched
 	if stats.EntriesOut != expected {
-		return fmt.Sprintf("entry-count mismatch: got %d, want %d (EntriesIn=%d - SystemDropped=%d)",
-			stats.EntriesOut, expected, stats.EntriesIn, stats.SystemDropped)
+		return fmt.Sprintf("entry-count mismatch: got %d, want %d (EntriesIn=%d - SystemDropped=%d - HeaderDropped=%d - ToolsBatched=%d)",
+			stats.EntriesOut, expected, stats.EntriesIn, stats.SystemDropped, stats.HeaderDropped, stats.ToolsBatched)
 	}
 	return ""
 }

--- a/cmd/ox/session_push_summary.go
+++ b/cmd/ox/session_push_summary.go
@@ -1,28 +1,34 @@
-// session_push_summary.go is the inline-summarization endpoint: it accepts a
+// session_push_summary.go is the `inline` summarization endpoint: it accepts a
 // summary JSON produced by the calling agent (in response to the summary_prompt
 // returned by `ox session stop`), validates and enriches it, then commits and
 // pushes summary.json to the ledger.
 //
 // # Why two execution sites exist for summarization
 //
-// Delegating summarization back to the calling agent is the right default
-// *technically*: the agent already has the conversation in context (so input
-// tokens are effectively free), no extra binary is required, and it works for
-// every supported agent (Claude Code, Cursor, Aider, Codex CLI, …).
+// `inline` (this file) — the CLI hands the SummaryPrompt back to the calling
+// agent. The agent runs the LLM with the conversation already cached, so
+// input tokens are mostly cache reads. Cheap (~1/10th the cost of the
+// `delegated` path on the same session) and agent-agnostic. Tradeoff: it
+// blocks the user in the foreground for 30–120s while the agent finishes,
+// at the moment they have just signaled "I'm done."
 //
-// But it blocks the user at exactly the wrong moment. They have just signaled
-// "I'm done" and want to close the agent or `/clear` and move on; an inline
-// LLM call holds them in the foreground for 30–120s for a ~1–4KB JSON output.
-// We should only force the inline path when the user has not specified (and
-// ox cannot auto-detect) an LLM agent for daemon callouts.
+// `delegated` — the daemon drives summarization out-of-process. Its
+// implementation lives in `internal/daemon/agentwork/session_finalize.go`
+// and calls back into the shared `pushSummaryToLedger` flow below — so
+// prompt construction and validation live in exactly one place. The
+// daemon spawns a fresh `claude`/`codex`/`gemini` CLI subprocess against
+// the cached raw.jsonl, which means every call is a *cold* prompt with
+// no agent cache to amortize against. Roughly 10× more expensive on
+// large sessions; the only thing it buys the user is getting their
+// terminal back immediately at session-stop.
 //
-// The daemon-side equivalent lives in
-// `internal/daemon/agentwork/session_finalize.go` and calls back into the
-// shared `pushSummaryToLedger` flow below — so prompt construction and
-// validation live in exactly one place. Today the dispatch is gated behind
-// `SAGEOX_ASYNC_SESSION_UPLOAD=1` (see `cmd/ox/agent_session.go`); the plan
-// is to lift that to a first-class `agent.summarizer` user-config key with
-// `auto` as the default.
+// `cloud` is reserved for future SageOx cloud-side summarization and is
+// not implemented today.
+//
+// `inline` is the default. The dispatch is currently gated behind
+// `SAGEOX_ASYNC_SESSION_UPLOAD=1` (see `cmd/ox/agent_session.go`); the
+// plan is to lift that to a first-class `agent.summarizer` user-config
+// key (`inline` | `delegated` | `cloud` (reserved) | `off`).
 //
 // See ADR-016 (docs/adr/ADR-016-session-summarization-delegation.md) for the
 // full rationale, behavior matrix, and tradeoffs.

--- a/cmd/ox/session_push_summary.go
+++ b/cmd/ox/session_push_summary.go
@@ -203,12 +203,22 @@ func pushSummaryToLedger(filePath, sessionDir string) *pushSummaryOutput {
 		discardThreshold = awCfg.GetQualityDiscardThreshold()
 	}
 
-	// unscored summaries (field absent from JSON) default to upload; scored
-	// summaries flow through the quality thresholds.
+	// Disposition routing — three-way precedence:
+	//   1. QualityCategory (canonical, categorical) — used when present.
+	//      LLMs emitting the new schema set this; deterministic prefilter
+	//      sets it to "skip" on local-only stub generation.
+	//   2. QualityScore (legacy numeric) — used when category is absent
+	//      and the score field was present in the JSON. Reads existing
+	//      summary.json files written before categorical scoring shipped.
+	//   3. Unscored fallback — default to upload so teammates / doctor
+	//      see the artifact and can act on it.
 	var disposition session.QualityDisposition
-	if qualityScorePresent {
+	switch {
+	case summaryParsed.QualityCategory != "":
+		disposition = session.EvaluateQualityCategory(summaryParsed.QualityCategory)
+	case qualityScorePresent:
 		disposition = session.EvaluateQuality(summaryParsed.QualityScore, uploadThreshold, discardThreshold)
-	} else {
+	default:
 		disposition = session.QualityUpload
 	}
 

--- a/cmd/ox/session_regenerate.go
+++ b/cmd/ox/session_regenerate.go
@@ -374,7 +374,7 @@ func regenerateSingleSessionSummary(nameArg string) error {
 
 	cli.PrintInfo(fmt.Sprintf("Generating summary for %s...", sessionName))
 
-	if _, err := sessionsummary.InvokeClaude(context.Background(), prompt, sessionPath); err != nil {
+	if _, err := sessionsummary.InvokeClaude(context.Background(), prompt, sessionPath, sessionsummary.DefaultSummaryModel()); err != nil {
 		return fmt.Errorf("claude invocation: %w", err)
 	}
 

--- a/internal/config/agent_summarizer.go
+++ b/internal/config/agent_summarizer.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"log/slog"
+	"os"
+)
+
+// AgentSummarizer modes — see ADR-016.
+//
+// inline    — the CLI hands a SummaryPrompt back to the calling agent, which
+//             runs the LLM in its already-warm conversation context. Cheap
+//             (input tokens are mostly cache reads); blocks the user in the
+//             foreground for ~30–120s while the agent finishes. **Default.**
+//
+// delegated — the daemon spawns a fresh `claude`/`codex`/`gemini` subprocess
+//             against the cached raw.jsonl. Every call is a cold prompt, so
+//             input tokens are paid in full — roughly 10× the cost of inline
+//             on the same session. The only thing this buys the user is
+//             returning the terminal immediately at session-stop.
+//
+// off       — disables LLM summarization entirely. The session is uploaded
+//             without a summary; downstream features that depend on the
+//             summary (team-context surfacing, session search) will be
+//             degraded for that recording.
+//
+// cloud     — RESERVED for future SageOx cloud-side summarization. Not
+//             implemented; rejected at validation.
+const (
+	AgentSummarizerInline    = "inline"
+	AgentSummarizerDelegated = "delegated"
+	AgentSummarizerOff       = "off"
+	// AgentSummarizerCloud is reserved for future SageOx cloud-side summarization.
+	// It is intentionally NOT in ValidAgentSummarizerModes — attempts to set it
+	// via `ox config set` are rejected with a clear "not yet implemented" error.
+	// The constant exists so callers can pattern-match on the eventual value
+	// without typo risk.
+	AgentSummarizerCloud = "cloud"
+)
+
+// ValidAgentSummarizerModes lists the modes accepted by user configuration.
+// `cloud` is intentionally absent until the cloud path is implemented.
+var ValidAgentSummarizerModes = []string{AgentSummarizerInline, AgentSummarizerDelegated, AgentSummarizerOff}
+
+// IsValidAgentSummarizer returns true if the mode is a recognized + currently-
+// implementable value. Returns true for "" (callers can leave unset to take
+// the default) but false for the reserved `cloud` value.
+func IsValidAgentSummarizer(mode string) bool {
+	switch mode {
+	case AgentSummarizerInline, AgentSummarizerDelegated, AgentSummarizerOff, "":
+		return true
+	}
+	return false
+}
+
+// NormalizeAgentSummarizer returns the canonical mode string. Unrecognized
+// values fall back to the default (inline). Empty input returns inline so
+// the resolver can short-circuit on no-config-set without a separate "" case.
+func NormalizeAgentSummarizer(mode string) string {
+	switch mode {
+	case AgentSummarizerInline, AgentSummarizerDelegated, AgentSummarizerOff:
+		return mode
+	default:
+		return AgentSummarizerInline
+	}
+}
+
+// AgentSummarizerSource indicates where the resolved value came from.
+type AgentSummarizerSource string
+
+const (
+	// AgentSummarizerSourceDefault — no config set, returning the built-in default (inline).
+	AgentSummarizerSourceDefault AgentSummarizerSource = "default"
+	// AgentSummarizerSourceUserConfig — set via `ox config set agent.summarizer ...`.
+	AgentSummarizerSourceUserConfig AgentSummarizerSource = "user"
+	// AgentSummarizerSourceEnvDeprecated — set via the legacy SAGEOX_ASYNC_SESSION_UPLOAD
+	// or OX_SESSION_INLINE_SUMMARY env vars. These remain as one-release
+	// compatibility shims; the resolver logs a deprecation warning.
+	AgentSummarizerSourceEnvDeprecated AgentSummarizerSource = "env-deprecated"
+)
+
+// ResolvedAgentSummarizer is the effective mode plus its provenance.
+type ResolvedAgentSummarizer struct {
+	Mode   string
+	Source AgentSummarizerSource
+}
+
+// ResolveAgentSummarizer determines the effective summarizer mode for the
+// given project. Resolution order:
+//
+//  1. Legacy env vars (SAGEOX_ASYNC_SESSION_UPLOAD=1 → delegated;
+//     OX_SESSION_INLINE_SUMMARY=1 → inline). Logs a deprecation warning when
+//     either is set, pointing at `ox config set agent.summarizer`. These
+//     shims will be removed one release after the config knob ships.
+//  2. User config (agent.summarizer key in user config.yaml).
+//  3. Built-in default: inline.
+//
+// Default is inline because the cost asymmetry between inline (warm cache)
+// and delegated (cold prompt every call) is too large to default to the
+// expensive path. Users who want non-blocking session-stop and are OK paying
+// the token cost can opt into delegated explicitly.
+func ResolveAgentSummarizer(projectRoot string) *ResolvedAgentSummarizer {
+	// 1. legacy env vars — short-lived compat shim
+	if os.Getenv("OX_SESSION_INLINE_SUMMARY") == "1" {
+		slog.Warn("OX_SESSION_INLINE_SUMMARY is deprecated; use 'ox config set agent.summarizer inline'")
+		return &ResolvedAgentSummarizer{Mode: AgentSummarizerInline, Source: AgentSummarizerSourceEnvDeprecated}
+	}
+	if os.Getenv("SAGEOX_ASYNC_SESSION_UPLOAD") == "1" {
+		slog.Warn("SAGEOX_ASYNC_SESSION_UPLOAD is deprecated; use 'ox config set agent.summarizer delegated'")
+		return &ResolvedAgentSummarizer{Mode: AgentSummarizerDelegated, Source: AgentSummarizerSourceEnvDeprecated}
+	}
+
+	// 2. user config
+	if userCfg, err := LoadUserConfig(); err == nil && userCfg != nil && userCfg.AgentSummarizer != "" {
+		mode := NormalizeAgentSummarizer(userCfg.AgentSummarizer)
+		return &ResolvedAgentSummarizer{Mode: mode, Source: AgentSummarizerSourceUserConfig}
+	}
+
+	// 3. default
+	return &ResolvedAgentSummarizer{Mode: AgentSummarizerInline, Source: AgentSummarizerSourceDefault}
+}
+
+// GetAgentSummarizer is a convenience wrapper that returns just the resolved mode.
+func GetAgentSummarizer(projectRoot string) string {
+	return ResolveAgentSummarizer(projectRoot).Mode
+}

--- a/internal/config/agent_summarizer_test.go
+++ b/internal/config/agent_summarizer_test.go
@@ -1,0 +1,171 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAgentSummarizerDefaults_Inline verifies that, with no env vars and no
+// user config, the resolver returns `inline`. This is the load-bearing default —
+// we deliberately favor cheap-by-default over non-blocking-by-default.
+// Failure prevented: a future refactor flips the default to `delegated`,
+// silently 10×-ing the token bill for every user on session-stop.
+func TestAgentSummarizerDefaults_Inline(t *testing.T) {
+	t.Setenv("OX_SESSION_INLINE_SUMMARY", "")
+	t.Setenv("SAGEOX_ASYNC_SESSION_UPLOAD", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	resolved := ResolveAgentSummarizer("")
+
+	assert.Equal(t, AgentSummarizerInline, resolved.Mode,
+		"default must be inline — see ADR-016 cost rationale")
+	assert.Equal(t, AgentSummarizerSourceDefault, resolved.Source)
+}
+
+// TestAgentSummarizerEnvShim_Inline verifies that the legacy env var
+// OX_SESSION_INLINE_SUMMARY=1 still forces inline, with the source labeled
+// as deprecated so the resolver can log a deprecation warning.
+// Failure prevented: removing the env var shim before users have migrated
+// to `ox config set agent.summarizer ...`.
+func TestAgentSummarizerEnvShim_Inline(t *testing.T) {
+	t.Setenv("OX_SESSION_INLINE_SUMMARY", "1")
+	t.Setenv("SAGEOX_ASYNC_SESSION_UPLOAD", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	resolved := ResolveAgentSummarizer("")
+	assert.Equal(t, AgentSummarizerInline, resolved.Mode)
+	assert.Equal(t, AgentSummarizerSourceEnvDeprecated, resolved.Source)
+}
+
+// TestAgentSummarizerEnvShim_Delegated verifies that the legacy
+// SAGEOX_ASYNC_SESSION_UPLOAD=1 still forces delegated.
+func TestAgentSummarizerEnvShim_Delegated(t *testing.T) {
+	t.Setenv("OX_SESSION_INLINE_SUMMARY", "")
+	t.Setenv("SAGEOX_ASYNC_SESSION_UPLOAD", "1")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	resolved := ResolveAgentSummarizer("")
+	assert.Equal(t, AgentSummarizerDelegated, resolved.Mode)
+	assert.Equal(t, AgentSummarizerSourceEnvDeprecated, resolved.Source)
+}
+
+// TestAgentSummarizerEnvShim_InlineWinsOverDelegated verifies that when both
+// legacy env vars are set (a confused user state), the inline-forcing one
+// takes precedence — the cheap path wins ties, matching the cheap-by-default
+// philosophy.
+func TestAgentSummarizerEnvShim_InlineWinsOverDelegated(t *testing.T) {
+	t.Setenv("OX_SESSION_INLINE_SUMMARY", "1")
+	t.Setenv("SAGEOX_ASYNC_SESSION_UPLOAD", "1")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	resolved := ResolveAgentSummarizer("")
+	assert.Equal(t, AgentSummarizerInline, resolved.Mode,
+		"when both legacy env vars are set, the cheap path wins")
+}
+
+// TestAgentSummarizerUserConfig_Delegated verifies that user config can
+// override the default to `delegated`.
+func TestAgentSummarizerUserConfig_Delegated(t *testing.T) {
+	t.Setenv("OX_SESSION_INLINE_SUMMARY", "")
+	t.Setenv("SAGEOX_ASYNC_SESSION_UPLOAD", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cfg := &UserConfig{AgentSummarizer: AgentSummarizerDelegated}
+	require.NoError(t, SaveUserConfig(cfg))
+
+	resolved := ResolveAgentSummarizer("")
+	assert.Equal(t, AgentSummarizerDelegated, resolved.Mode)
+	assert.Equal(t, AgentSummarizerSourceUserConfig, resolved.Source)
+}
+
+// TestAgentSummarizerUserConfig_Off verifies that user config can disable
+// LLM summarization entirely.
+func TestAgentSummarizerUserConfig_Off(t *testing.T) {
+	t.Setenv("OX_SESSION_INLINE_SUMMARY", "")
+	t.Setenv("SAGEOX_ASYNC_SESSION_UPLOAD", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cfg := &UserConfig{AgentSummarizer: AgentSummarizerOff}
+	require.NoError(t, SaveUserConfig(cfg))
+
+	resolved := ResolveAgentSummarizer("")
+	assert.Equal(t, AgentSummarizerOff, resolved.Mode)
+}
+
+// TestAgentSummarizerEnvShim_OverridesUserConfig verifies that the legacy env
+// vars take precedence over user config. This is intentional: power users
+// can scope-test alternate modes without touching their persisted config.
+// Failure prevented: a user setting agent.summarizer=delegated then trying
+// to test inline via env var unexpectedly gets delegated.
+func TestAgentSummarizerEnvShim_OverridesUserConfig(t *testing.T) {
+	t.Setenv("OX_SESSION_INLINE_SUMMARY", "1")
+	t.Setenv("SAGEOX_ASYNC_SESSION_UPLOAD", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cfg := &UserConfig{AgentSummarizer: AgentSummarizerDelegated}
+	require.NoError(t, SaveUserConfig(cfg))
+
+	resolved := ResolveAgentSummarizer("")
+	assert.Equal(t, AgentSummarizerInline, resolved.Mode,
+		"env shim must override user config so power users can scope-test modes")
+	assert.Equal(t, AgentSummarizerSourceEnvDeprecated, resolved.Source)
+}
+
+func TestIsValidAgentSummarizer(t *testing.T) {
+	tests := []struct {
+		mode string
+		want bool
+	}{
+		{"inline", true},
+		{"delegated", true},
+		{"off", true},
+		{"", true}, // unset is valid (callers pick default)
+		{"cloud", false},
+		{"bogus", false},
+		{"INLINE", false}, // case-sensitive
+	}
+	for _, tc := range tests {
+		t.Run(tc.mode, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsValidAgentSummarizer(tc.mode))
+		})
+	}
+}
+
+// TestNormalizeAgentSummarizer_FallsBackToInline verifies that any unrecognized
+// or empty value normalizes to inline — the cheap default. Important because
+// upstream config readers may pass through stale or hand-edited YAML; we
+// don't want a typo to silently flip the user to the expensive path.
+func TestNormalizeAgentSummarizer_FallsBackToInline(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"inline", "inline"},
+		{"delegated", "delegated"},
+		{"off", "off"},
+		{"", "inline"},      // unset → default
+		{"cloud", "inline"}, // reserved → fall back, never silently activate
+		{"DELEGATED", "inline"},
+		{"   inline   ", "inline"}, // no fancy trimming today; if you need it, normalize at the source
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got := NormalizeAgentSummarizer(tc.in)
+			// the trim case is intentionally not handled — assert what we actually do:
+			if tc.in == "   inline   " {
+				assert.Equal(t, "inline", got, "untrimmed input falls through to default")
+			} else {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -330,7 +330,14 @@ type UserConfig struct {
 	LegacyMurmuring   string             `yaml:"murmuring,omitempty"`          // deprecated: read old key on upgrade
 	MurmurReceive     string             `yaml:"murmur_receive,omitempty"`     // "on", "off"
 	RecordingReminder string             `yaml:"recording_reminder,omitempty"` // "on", "off"
-
+	// AgentSummarizer selects who runs the session-stop LLM summarization call.
+	// "inline" (default): the calling agent runs it in its warm prompt cache —
+	// cheap but blocks the user for ~30–120s at session-stop. "delegated": the
+	// daemon runs it in a fresh subprocess — non-blocking but ~10× more expensive.
+	// "off": disable LLM summarization entirely. "cloud" is reserved for future
+	// SageOx cloud-side summarization and is rejected at validation today. See
+	// internal/config/agent_summarizer.go and ADR-016.
+	AgentSummarizer string `yaml:"agent_summarizer,omitempty"`
 }
 
 // BadgeConfig tracks badge suggestion state across all projects.

--- a/internal/daemon/agentwork/claude_runner.go
+++ b/internal/daemon/agentwork/claude_runner.go
@@ -88,7 +88,11 @@ func (r *ClaudeRunner) Run(ctx context.Context, req RunRequest) (*RunResult, err
 	// permission prompt and produces narration that fails validation,
 	// resulting in the failure-marker-stub output that clobbered 31
 	// Phase 2 sessions on 2026-04-25 (bd ox-5cc9, ox-91sl).
-	args := []string{"--output-format", "stream-json", "--verbose", "--permission-mode", "bypassPermissions", "-p", req.Prompt}
+	args := []string{"--output-format", "stream-json", "--verbose", "--permission-mode", "bypassPermissions"}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+	args = append(args, "-p", req.Prompt)
 
 	cmd := exec.CommandContext(ctx, r.binaryPath, args...)
 	if req.WorkDir != "" {

--- a/internal/daemon/agentwork/claude_runner_test.go
+++ b/internal/daemon/agentwork/claude_runner_test.go
@@ -210,9 +210,19 @@ func TestClaudeRunner_Run_ModelFlag(t *testing.T) {
 	script := filepath.Join(tmp, "claude")
 	// Fake claude: dump argv (one arg per line) to argsFile, then emit a
 	// minimal valid stream-json result so Run() succeeds normally.
+	//
+	// The trailing `sleep 0.1` exists to defuse a CI-only race in
+	// claude_runner.go between cmd.Wait() and the parse goroutine
+	// reading stdout. When the fake script exits within microseconds,
+	// the kernel can close the stdout pipe before the goroutine's
+	// scanner.Scan() runs, producing "file already closed" instead of
+	// the expected EOF. Real claude takes seconds so the race never
+	// manifests in production. We slow the fake just enough to give
+	// the goroutine time to drain the pipe before exit.
 	body := `#!/bin/sh
 for a in "$@"; do printf '%s\n' "$a" >> "` + argsFile + `"; done
 printf '%s\n' '{"type":"result","result":"ok","usage":{"input_tokens":1,"output_tokens":1}}'
+sleep 0.1
 `
 	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
 

--- a/internal/daemon/agentwork/claude_runner_test.go
+++ b/internal/daemon/agentwork/claude_runner_test.go
@@ -198,6 +198,71 @@ func TestClaudeRunner_Run_SuccessfulInvocation(t *testing.T) {
 	assert.True(t, result.Duration > 0)
 }
 
+// TestClaudeRunner_Run_ModelFlag verifies that req.Model becomes a
+// `--model <id>` pair in the argv passed to claude, and that an empty
+// req.Model omits the flag entirely. Failure prevented: the cost-saving
+// Haiku pin silently no-ops because the runner ignored the model field;
+// or the rollback path (empty Model = user's default) regresses by
+// always passing some flag.
+func TestClaudeRunner_Run_ModelFlag(t *testing.T) {
+	tmp := t.TempDir()
+	argsFile := filepath.Join(tmp, "args.txt")
+	script := filepath.Join(tmp, "claude")
+	// Fake claude: dump argv (one arg per line) to argsFile, then emit a
+	// minimal valid stream-json result so Run() succeeds normally.
+	body := `#!/bin/sh
+for a in "$@"; do printf '%s\n' "$a" >> "` + argsFile + `"; done
+printf '%s\n' '{"type":"result","result":"ok","usage":{"input_tokens":1,"output_tokens":1}}'
+`
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	r := &ClaudeRunner{binaryPath: script, logger: slog.Default()}
+
+	cases := []struct {
+		name      string
+		model     string
+		wantFlag  bool
+		wantValue string
+	}{
+		{"haiku pinned", "claude-haiku-4-5", true, "claude-haiku-4-5"},
+		{"empty defers to local default", "", false, ""},
+		{"sonnet override", "claude-sonnet-4-6", true, "claude-sonnet-4-6"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Truncate (or create) the args file before each subtest run.
+			require.NoError(t, os.WriteFile(argsFile, nil, 0o644))
+
+			_, err := r.Run(context.Background(), RunRequest{
+				Prompt: "x", Model: c.model, TimeoutOverride: 5 * time.Second,
+			})
+			require.NoError(t, err)
+
+			data, err := os.ReadFile(argsFile)
+			require.NoError(t, err)
+			argv := strings.Split(strings.TrimSpace(string(data)), "\n")
+
+			if c.wantFlag {
+				idx := -1
+				for i, a := range argv {
+					if a == "--model" {
+						idx = i
+						break
+					}
+				}
+				require.GreaterOrEqual(t, idx, 0, "--model flag missing; argv=%v", argv)
+				require.Less(t, idx+1, len(argv), "--model has no value; argv=%v", argv)
+				assert.Equal(t, c.wantValue, argv[idx+1])
+			} else {
+				for _, a := range argv {
+					assert.NotEqual(t, "--model", a, "expected no --model flag; argv=%v", argv)
+				}
+			}
+		})
+	}
+}
+
 func TestClaudeRunner_Run_ContextCancellation(t *testing.T) {
 	tmp := t.TempDir()
 	script := filepath.Join(tmp, "claude")

--- a/internal/daemon/agentwork/runner.go
+++ b/internal/daemon/agentwork/runner.go
@@ -18,6 +18,11 @@ type RunRequest struct {
 	Prompt          string
 	WorkDir         string
 	TimeoutOverride time.Duration
+	// Model pins a specific model for the runner (e.g., "claude-haiku-4-5").
+	// Empty means defer to the runner's default — for ClaudeRunner that's
+	// whatever the local Claude Code CLI selects, typically Sonnet. Set
+	// explicitly for cost-sensitive workloads like summarization.
+	Model string
 	// SkipLLM bypasses the LLM runner entirely. The manager calls
 	// ProcessResult directly with an empty RunResult. Use this when
 	// the work item has all the information it needs to proceed without

--- a/internal/daemon/agentwork/runner.go
+++ b/internal/daemon/agentwork/runner.go
@@ -39,3 +39,15 @@ type RunResult struct {
 	TokensOut int    // output tokens
 	ModelUsed string // model identifier the runner reports (for attribution in logs and judge verdicts)
 }
+
+// TelemetryRecorder is the minimal surface agentwork needs to emit telemetry.
+// Implemented by *daemon.TelemetryCollector. The interface lives here so the
+// agentwork package doesn't import daemon (which would create a cycle: daemon
+// already imports agentwork).
+//
+// Record must be safe for concurrent use and non-blocking — handlers fire
+// telemetry from the LLM completion path and cannot afford to wait on a
+// network round-trip.
+type TelemetryRecorder interface {
+	Record(event string, props map[string]any)
+}

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -660,6 +660,7 @@ func (h *SessionFinalizeHandler) BuildPrompt(item *WorkItem) (RunRequest, error)
 	return RunRequest{
 		Prompt:  prompt,
 		WorkDir: payload.LedgerPath,
+		Model:   sessionsummary.DefaultSummaryModel(),
 	}, nil
 }
 

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -65,6 +65,20 @@ type SessionFinalizePayload struct {
 	// storedSession is populated by BuildPrompt and reused by ProcessResult
 	// to avoid reading raw.jsonl twice.
 	storedSession *session.StoredSession `json:"-"`
+
+	// prefilterSummary holds a deterministic summary built by
+	// sessionsummary.MaybeBuildSkipSummary when BuildPrompt determined
+	// the session was too thin for an LLM-generated summary to be
+	// meaningful. When non-nil, BuildPrompt returned RunRequest{SkipLLM:
+	// true} and ProcessResult uses this struct directly instead of
+	// parsing LLM output. Saves the entire claude -p call (input prompt
+	// guidelines + tokens, validation pass, retry potential) for
+	// sessions that would have been quality-gated to discard anyway.
+	//
+	// See pkg/sessionsummary/prefilter.go for the heuristics and
+	// rationale; the trigger conditions are intentionally conservative
+	// to avoid skipping real sessions.
+	prefilterSummary *session.SummarizeResponse `json:"-"`
 }
 
 // SessionFinalizeHandler detects and finalizes incomplete sessions in the ledger.
@@ -664,6 +678,62 @@ func (h *SessionFinalizeHandler) BuildPrompt(item *WorkItem) (RunRequest, error)
 	payload.storedSession = stored
 
 	entries := sessionsummary.EntriesFromRaw(stored.Entries)
+
+	// Pre-LLM low-value short-circuit. Sessions whose entries are too thin
+	// for a meaningful LLM-generated summary (very few entries, no
+	// assistant response, near-empty user content) get a deterministic
+	// stub built from user prompts — no claude -p invocation, no input
+	// prompt-guidelines tokens, no Haiku call. The stub's QualityScore
+	// is set low so the existing quality gate routes it to discard and
+	// it never reaches the team ledger. Saves the entire LLM round-trip
+	// on the long tail of exploratory pings that quality-gate to discard
+	// anyway.
+	//
+	// Implementation: when MaybeBuildSkipSummary returns ok=true, we
+	// stash the stub on the payload and signal SkipLLM=true so the
+	// manager skips runner.Run() entirely. ProcessResult then detects
+	// payload.prefilterSummary and uses it directly. See:
+	//   - pkg/sessionsummary/prefilter.go for heuristics + thresholds
+	//   - ProcessResult above for the consumption path
+	if skip, ok := sessionsummary.MaybeBuildSkipSummary(entries); ok {
+		payload.prefilterSummary = skip
+		sessionName := filepath.Base(payload.SessionDir)
+		h.logger.Info("session_finalize prefilter triggered, will skip LLM",
+			"session", sessionName,
+			"entry_count", len(entries),
+			"reason", skip.ScoreReason,
+		)
+
+		// Emit a `summarization_skipped` event so dashboards can count
+		// prefilter skips directly instead of inferring them from missing
+		// `summarization` events. Absent events are ambiguous (telemetry
+		// off, daemon restart, network drop) — an explicit marker is the
+		// only reliable signal for a per-window prefilter-skip rate.
+		//
+		// Privacy: scalars + categoricals only, plus the session_hash
+		// correlator (sha256 of the session name; see SessionHash). The
+		// `reason` field carries the prefilter's structured ScoreReason
+		// which names the heuristic that fired ("fewer than N entries",
+		// "no assistant response", "user content under N chars") — no
+		// content, no paths, no quoted prompt text.
+		if h.telemetry != nil {
+			userPromptCount := 0
+			for _, e := range entries {
+				if e.Type == sessionsummary.EntryTypeUser {
+					userPromptCount++
+				}
+			}
+			h.telemetry.Record("summarization_skipped", map[string]any{
+				"session_hash":      sessionsummary.SessionHash(sessionName),
+				"reason":            skip.ScoreReason,
+				"entry_count":       len(entries),
+				"user_prompt_count": userPromptCount,
+			})
+		}
+
+		return RunRequest{SkipLLM: true}, nil
+	}
+
 	// Daemon owns persistence (ProcessResult writes summary.json + meta.json
 	// and gitCommitAndPush commits). Pass empty ledgerSessionDir so the prompt
 	// drops the "save to file + run ox session push-summary" steps and the LLM
@@ -727,7 +797,43 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 
 	llmOutput := result.Output
 
-	// non-zero exit = summarization failed; don't trust the output at all
+	var summaryResp *session.SummarizeResponse
+	// scored gates whether EvaluateQuality runs against summaryResp.QualityScore.
+	// True when the score is meaningful — i.e. a real LLM evaluation OR the
+	// deterministic prefilter (which intentionally scores low to route to
+	// discard). Fallback stubs from validation failures stay scored=false
+	// so the quality gate doesn't double-penalize them.
+	scored := true
+
+	// Prefilter short-circuit. BuildPrompt called
+	// sessionsummary.MaybeBuildSkipSummary and decided this session was too
+	// thin for a meaningful LLM-generated summary. The synthesized stub it
+	// produced (echoing user prompts with quality_score 0.05, status OK) is
+	// what we use here directly — no LLM call happened, so result.Output is
+	// empty and the parse/validate pipeline below would only fail.
+	//
+	// Why injection at this point: artifact writing, LFS upload, git commit,
+	// and quality gating below this block are identical regardless of how
+	// summaryResp got populated. Wrapping the LLM-output handling in
+	// `if payload.prefilterSummary == nil { ... }` is the smallest invasive
+	// change that re-uses every downstream step.
+	//
+	// scored=true so EvaluateQuality runs and routes the 0.05 score to
+	// QualityDiscard (default discard threshold 0.1). Skipping the LLM AND
+	// uploading the stub would defeat the entire optimization.
+	//
+	// See pkg/sessionsummary/prefilter.go for the heuristics and rationale.
+	if payload.prefilterSummary != nil {
+		summaryResp = payload.prefilterSummary
+		scored = true
+		h.logger.Info("session prefilter skipped LLM summarization",
+			"session", filepath.Base(payload.SessionDir),
+			"reason", summaryResp.ScoreReason,
+			"quality_score", summaryResp.QualityScore,
+		)
+	} else {
+
+	// non-zero exit = summarization failed; don't trust the output at all.
 	if result.ExitCode != 0 {
 		h.logger.Warn("summarization agent exited with error, discarding output",
 			"session", filepath.Base(payload.SessionDir),
@@ -741,8 +847,6 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 	// summary or a fallback stub so the quality gate only runs on real scores
 	// — a fallback with QualityScore=0 must NOT flow through EvaluateQuality
 	// and get discarded, otherwise transient LLM failures lose sessions (#525).
-	var summaryResp *session.SummarizeResponse
-	scored := true
 	parsed, parseErr := sessionsummary.ParseSummaryJSON(llmOutput)
 	if parseErr != nil {
 		preview := llmOutput
@@ -860,6 +964,8 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 		summaryResp.ValidationError = ""
 		h.maybeRunJudge(sessionName, payload.LedgerPath, summaryResp)
 	}
+
+	} // end of else — LLM-output handling. Prefilter path skips here directly.
 
 	// unscored fallbacks default to upload (preserve stub for teammates / doctor).
 	// Only real LLM-scored summaries are gated by the quality thresholds.
@@ -1916,6 +2022,12 @@ func (h *SessionFinalizeHandler) emitSummarizationTelemetry(sessionName, mode st
 		"duration_ms":   result.Duration.Milliseconds(),
 		"exit_code":     result.ExitCode,
 		"scored":        scored,
+		// session_hash correlates this event with the EventTokenoptRun
+		// emitted by cmd/ox/session_optimize_for_summary.go. Same hash
+		// algorithm (sha256 of session name, first 8 bytes hex) so server-
+		// side joins between compression metrics and LLM cost shape are
+		// possible without exposing names or paths.
+		"session_hash": sessionsummary.SessionHash(sessionName),
 	}
 	if summaryResp != nil {
 		props["quality_score"] = summaryResp.QualityScore

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -127,6 +127,15 @@ type SessionFinalizeHandler struct {
 	// ErrShutdownTimeout. Defaults to context.Background() when unset,
 	// which preserves behavior for tests that don't call SetDaemonContext.
 	daemonCtx context.Context
+	// telemetry is an optional sink for the per-summarization cost-shape
+	// event (see telemetry.EventSummarization). nil disables emission;
+	// the daemon wires its TelemetryCollector here at startup.
+	telemetry TelemetryRecorder
+	// lastJudgeResult stashes the most recent judge verdict so it can be
+	// piggybacked on the next summarization telemetry event. Cleared
+	// after each emit. Single-threaded by construction: judge and emit
+	// both run synchronously inside ProcessResult.
+	lastJudgeResult *summaryeval.JudgeResult
 }
 
 // NewSessionFinalizeHandler creates a handler with the given logger.
@@ -184,6 +193,15 @@ func (h *SessionFinalizeHandler) SetJudgeCompleter(c summaryeval.Completer) {
 // deadlines — triggering ErrShutdownTimeout that operators see as hangs.
 func (h *SessionFinalizeHandler) SetDaemonContext(ctx context.Context) {
 	h.daemonCtx = ctx
+}
+
+// SetTelemetry installs an optional telemetry sink. The handler emits a
+// `summarization` event after every LLM summarization call so the cost
+// shape (mode, model, tokens, duration, quality score) is observable in
+// production. Nil disables emission entirely — fine for tests and for the
+// privacy-conscious user (telemetry honors the existing opt-out gate).
+func (h *SessionFinalizeHandler) SetTelemetry(t TelemetryRecorder) {
+	h.telemetry = t
 }
 
 // NewSessionFinalizeHandlerForTest creates a handler with git and LFS operations disabled.
@@ -895,7 +913,18 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 		"summary_json", artifactPaths.SummaryJSON,
 		"session_md", artifactPaths.SessionMD,
 		"quality_score", summaryResp.QualityScore,
+		"input_tokens", result.TokensIn,
+		"output_tokens", result.TokensOut,
+		"model", result.ModelUsed,
+		"duration_ms", result.Duration.Milliseconds(),
 	)
+
+	// Emit the cost-shape telemetry event. Privacy-by-design: only scalar
+	// numeric + categorical fields. Never include session content, repo
+	// paths, file paths, model output text, or anything derived from
+	// the user's conversation. Validators that aggregate this server-side
+	// rely on this guarantee.
+	h.emitSummarizationTelemetry(sessionName, "delegated", result, summaryResp, scored)
 
 	if disposition == session.QualityLocalOnly {
 		h.logger.Info("session below upload threshold, keeping locally",
@@ -1851,4 +1880,60 @@ func (h *SessionFinalizeHandler) maybeRunJudge(sessionName, ledgerPath string, s
 		"completion_tokens", result.CompletionTokens,
 		"suggestion_count", len(result.Suggestions),
 	)
+
+	// Stash the judge result on the handler so the per-summarization
+	// telemetry event (emitted from ProcessResult) can include judge
+	// fields without a separate event. Goroutine-safe via the same
+	// implicit ordering as the rest of finalize: judge runs synchronously
+	// inside ProcessResult before emitSummarizationTelemetry.
+	stashed := result
+	h.lastJudgeResult = &stashed
+}
+
+// emitSummarizationTelemetry records a single `summarization` event with the
+// cost shape (tokens, model, duration, quality_score) and judge tokens if a
+// judge run produced a verdict in the same ProcessResult call.
+//
+// The handler.telemetry field is optional — nil sink (tests, telemetry
+// disabled, daemon not wired) is a silent no-op. The TelemetryRecorder
+// implementation auto-attaches app_type and app_version, so this code
+// only sets the summarization-specific fields.
+//
+// Privacy: scalars and categoricals only. Never include session content,
+// model output text, file paths, or anything derived from the user's
+// conversation. The model identifier and quality_score are safe — they're
+// configuration / numeric measurements, not user data.
+func (h *SessionFinalizeHandler) emitSummarizationTelemetry(sessionName, mode string, result *RunResult, summaryResp *session.SummarizeResponse, scored bool) {
+	if h.telemetry == nil {
+		return
+	}
+
+	props := map[string]any{
+		"mode":          mode,
+		"model":         result.ModelUsed,
+		"input_tokens":  result.TokensIn,
+		"output_tokens": result.TokensOut,
+		"duration_ms":   result.Duration.Milliseconds(),
+		"exit_code":     result.ExitCode,
+		"scored":        scored,
+	}
+	if summaryResp != nil {
+		props["quality_score"] = summaryResp.QualityScore
+		props["summary_status"] = string(summaryResp.SummaryStatus)
+	}
+
+	// piggyback judge fields on the same event when the judge ran during
+	// this finalize. The judge is gated on OX_SUMMARY_JUDGE=on; when off,
+	// lastJudgeResult stays nil and these fields are omitted.
+	if jr := h.lastJudgeResult; jr != nil {
+		props["judge_overall"] = jr.Overall
+		props["judge_model"] = jr.ModelUsed
+		props["judge_duration_ms"] = jr.DurationMs
+		props["judge_input_tokens"] = jr.PromptTokens
+		props["judge_output_tokens"] = jr.CompletionTokens
+		// clear so next session's emit doesn't double-count this judge run
+		h.lastJudgeResult = nil
+	}
+
+	h.telemetry.Record("summarization", props)
 }

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -71,28 +71,35 @@ type SessionFinalizePayload struct {
 // It generates missing artifacts: summary.md (via LLM), summary.json,
 // and session.md (deterministic exports).
 //
-// SESSION SUMMARIZATION DELEGATION — see ADR-016.
+// SESSION SUMMARIZATION — see ADR-016. This handler implements the
+// `delegated` mode (the daemon drives summarization, in contrast to `inline`
+// where the CLI hands the prompt back to the calling agent's warm cache —
+// see `cmd/ox/session_push_summary.go`).
 //
-// This handler is the daemon-owned alternative to inline summarization in
-// `cmd/ox/session_push_summary.go`. The motivating problem with inline-only
-// summarization: it forces the calling agent to run a 30–120s LLM call in the
-// foreground at the exact moment the user has just said "I'm done" and wants
-// to close the agent or `/clear` and start something new. Delegating to the
-// calling agent is the right default *technically* (the agent already has
-// context loaded, no extra binary is required, every agent type works), but
-// it should only be the *forced* path when the user has not specified — and
-// ox cannot auto-detect — an LLM agent for daemon callouts.
+// Cost shape: every call is a *fresh* cold prompt against the user's
+// configured LLM CLI (claude/codex/gemini). On a 10K-entry session, that
+// runs roughly 30–80K input tokens through the model — ~10× the cost of
+// the equivalent `inline` call against an agent with the conversation
+// already cached. The cost is bounded by:
+//   - tokenopt (`pkg/tokenopt`) drops tool I/O / system entries before
+//     the call, typically a 40–60% reduction
+//   - judge gating discards low-quality summaries below a score threshold
+//     so we don't repeatedly re-summarize unsalvageable sessions
+//   - quality_score thresholds keep us from spinning on bad output
 //
 // When this handler runs, `ox session stop` returns immediately with an
-// empty `summary_prompt`. The daemon spawns the user's configured LLM CLI
-// (claude/codex/gemini), runs the same prompt the inline path would have
-// used, validates richness/content, and calls into the shared
-// `pushSummaryToLedger` flow. Prompt construction and validation live in
-// exactly one place (`pkg/sessionsummary`) — there is no second
-// implementation to drift.
+// empty `summary_prompt`. The daemon runs the same prompt the inline path
+// would have used and calls into the shared `pushSummaryToLedger` flow.
+// Prompt construction and validation live in exactly one place
+// (`pkg/sessionsummary`) — there is no second implementation to drift.
 //
 // `ox doctor` enqueues missing summaries into this same handler, so the
 // repair path is the same as the happy path.
+//
+// SessionEnd hook (Claude Code exit) also routes here regardless of the
+// user's `agent.summarizer` setting: at exit the calling agent process is
+// being torn down, so `inline` literally has no agent to whisper back to.
+// `delegated` is the only viable mode in that window.
 type SessionFinalizeHandler struct {
 	logger *slog.Logger
 	// skipGit disables git add/commit/push in tests

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -2076,7 +2076,8 @@ func (h *SessionFinalizeHandler) emitSummarizationTelemetry(sessionName, mode st
 	}
 	if summaryResp != nil {
 		props["quality_score"] = summaryResp.QualityScore
-		props["summary_status"] = string(summaryResp.SummaryStatus)
+		// SummaryStatus is already a string-typed alias, no conversion needed.
+		props["summary_status"] = summaryResp.SummaryStatus
 	}
 
 	// piggyback judge fields on the same event when the judge ran during

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -728,6 +728,11 @@ func (h *SessionFinalizeHandler) BuildPrompt(item *WorkItem) (RunRequest, error)
 				"reason":            skip.ScoreReason,
 				"entry_count":       len(entries),
 				"user_prompt_count": userPromptCount,
+				// skip_kind segments deterministic-prefilter skips (this path)
+				// from LLM-judged skips (when the LLM emits quality_category=skip
+				// from the summarization call itself). Lets dashboards measure
+				// each rate independently and alert if either drifts.
+				"skip_kind": "deterministic",
 			})
 		}
 
@@ -967,12 +972,52 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 
 	} // end of else — LLM-output handling. Prefilter path skips here directly.
 
-	// unscored fallbacks default to upload (preserve stub for teammates / doctor).
-	// Only real LLM-scored summaries are gated by the quality thresholds.
+	// LLM-judged skip event. When the LLM ran (delegated path) and itself
+	// returned QualityCategory == "skip", emit summarization_skipped with
+	// skip_kind=llm_judged. The deterministic prefilter emits the same
+	// event from BuildPrompt with skip_kind=deterministic. Dashboards
+	// segment by skip_kind to monitor each path independently — a
+	// regression in either (LLM over-skipping, prefilter under-firing)
+	// surfaces as a divergence in those two rates.
+	//
+	// We don't emit on the prefilter path here because BuildPrompt
+	// already did — payload.prefilterSummary != nil means the
+	// deterministic event fired earlier in the lifecycle.
+	if h.telemetry != nil &&
+		payload.prefilterSummary == nil &&
+		sessionsummary.IsSkipCategory(summaryResp) {
+
+		entryCount := 0
+		if payload.storedSession != nil {
+			entryCount = len(payload.storedSession.Entries)
+		}
+		h.telemetry.Record("summarization_skipped", map[string]any{
+			"session_hash": sessionsummary.SessionHash(sessionName),
+			"reason":       summaryResp.ScoreReason,
+			"entry_count":  entryCount,
+			"skip_kind":    "llm_judged",
+		})
+	}
+
+	// Disposition routing.
+	//
+	// Three-way precedence:
+	//   1. QualityCategory (canonical, categorical) — used when present.
+	//      Maps cleanly to QualityDiscard/LocalOnly/Upload via
+	//      EvaluateQualityCategory. This is how new summaries flow.
+	//   2. QualityScore (legacy numeric) — used when category is absent
+	//      and the summary was scored. Reads existing summary.json files
+	//      written before categorical scoring shipped.
+	//   3. Unscored fallback (validation failure stubs) — default to
+	//      upload so teammates/doctor see the stub and can act on it.
+	//      Only real LLM-scored summaries are gated by thresholds.
 	var disposition session.QualityDisposition
-	if scored {
+	switch {
+	case summaryResp.QualityCategory != "":
+		disposition = session.EvaluateQualityCategory(summaryResp.QualityCategory)
+	case scored:
 		disposition = session.EvaluateQuality(summaryResp.QualityScore, h.qualityUploadThreshold, h.qualityDiscardThreshold)
-	} else {
+	default:
 		disposition = session.QualityUpload
 	}
 

--- a/internal/daemon/agentwork/session_finalize_ctrlc_test.go
+++ b/internal/daemon/agentwork/session_finalize_ctrlc_test.go
@@ -27,11 +27,15 @@ func TestCtrlC_FullFinalizationPipeline(t *testing.T) {
 	}
 
 	// raw.jsonl with multi-turn content (as if PostToolUse hooks wrote entries)
+	// Longer user prompts so the combined user content clears the
+	// prefilter's minUserContentChars floor (80 chars). Without this
+	// the new pre-LLM low-value short-circuit triggers and the test
+	// asserts on artifacts that the LLM path would have produced.
 	rawContent := `{"metadata":{"agent_id":"OxABRT","agent_type":"claude","created_at":"2026-01-10T09:30:00-07:00","version":"1.0"},"type":"header"}
-{"type":"user","content":"Read the README and summarize it","seq":0,"timestamp":"2026-01-10T16:30:01Z"}
+{"type":"user","content":"Read the README and summarize the architecture sections so I understand the framework's main building blocks","seq":0,"timestamp":"2026-01-10T16:30:01Z"}
 {"type":"tool","content":"","seq":1,"timestamp":"2026-01-10T16:30:05Z","tool_name":"Read","tool_input":"{\"file_path\":\"/project/README.md\"}"}
 {"type":"assistant","content":"The README describes a web application framework with REST API support.","seq":2,"timestamp":"2026-01-10T16:30:08Z"}
-{"type":"user","content":"Now add error handling to the main handler","seq":3,"timestamp":"2026-01-10T16:30:15Z"}
+{"type":"user","content":"Now add error handling to the main handler so unexpected panics turn into 500 responses with structured logs","seq":3,"timestamp":"2026-01-10T16:30:15Z"}
 {"type":"tool","content":"","seq":4,"timestamp":"2026-01-10T16:30:20Z","tool_name":"Edit","tool_input":"{\"file_path\":\"/project/handler.go\"}"}
 {"type":"assistant","content":"I've added error handling with proper HTTP status codes.","seq":5,"timestamp":"2026-01-10T16:30:25Z"}
 `
@@ -135,9 +139,13 @@ func TestCtrlC_FullFinalizationPipeline_WritesMetaJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Substantive user content + 3 entries so the new pre-LLM
+	// prefilter (sessionsummary.MaybeBuildSkipSummary) does NOT trigger
+	// — this test exercises the full LLM-output pipeline.
 	rawContent := `{"metadata":{"agent_id":"OxMETA","agent_type":"claude-code","created_at":"2026-01-10T11:00:00Z"},"type":"header"}
-{"type":"user","content":"implement feature X","seq":0}
-{"type":"assistant","content":"done implementing","seq":1}
+{"type":"user","content":"Implement feature X with proper error handling and add unit tests for the failure modes I just described","seq":0}
+{"type":"assistant","content":"Got it — I'll add the feature and write tests covering the error paths.","seq":1}
+{"type":"assistant","content":"Done. Feature X is implemented and tests are passing.","seq":2}
 `
 	rawPath := filepath.Join(sessionDir, "raw.jsonl")
 	if err := os.WriteFile(rawPath, []byte(rawContent), 0644); err != nil {
@@ -199,8 +207,8 @@ func TestCtrlC_FullFinalizationPipeline_WritesMetaJSON(t *testing.T) {
 	if meta.Title != "Feature X Implementation" {
 		t.Errorf("title: got %q, want %q", meta.Title, "Feature X Implementation")
 	}
-	if meta.EntryCount != 2 {
-		t.Errorf("entry_count: got %d, want 2", meta.EntryCount)
+	if meta.EntryCount != 3 {
+		t.Errorf("entry_count: got %d, want 3", meta.EntryCount)
 	}
 	if meta.AgentID != "OxMETA" {
 		t.Errorf("agent_id: got %q, want %q", meta.AgentID, "OxMETA")

--- a/internal/daemon/agentwork/session_finalize_summary_test.go
+++ b/internal/daemon/agentwork/session_finalize_summary_test.go
@@ -768,8 +768,8 @@ func TestProcessResult_WritesMetaJSON(t *testing.T) {
 	if meta.Summary != "Testing meta.json generation" {
 		t.Errorf("summary mismatch: got %q", meta.Summary)
 	}
-	if meta.EntryCount != 2 { // 2 entries in createTestSession raw.jsonl
-		t.Errorf("entry_count mismatch: got %d, want 2", meta.EntryCount)
+	if meta.EntryCount != 3 { // 3 entries in createTestSession raw.jsonl (user + 2 assistant)
+		t.Errorf("entry_count mismatch: got %d, want 3", meta.EntryCount)
 	}
 }
 
@@ -944,10 +944,19 @@ func createTestSession(t *testing.T, sessionName string, includeArtifacts []stri
 		t.Fatal(err)
 	}
 
-	// always create raw.jsonl with minimal content
+	// raw.jsonl with substantive content. Two important properties:
+	//
+	//   1. User content is long enough (> 80 chars) that
+	//      sessionsummary.MaybeBuildSkipSummary does NOT trigger — these
+	//      tests exercise the LLM-output path, not the prefilter path.
+	//      Tests targeting the prefilter use createThinTestSession below.
+	//
+	//   2. At least 3 entries (header + user + assistant) so the
+	//      entry-count floor in the prefilter is also cleared.
 	rawContent := `{"_meta":{"schema_version":"1","agent_type":"claude-code"}}
-{"type":"user","content":"hello","seq":1}
-{"type":"assistant","content":"hi there","seq":2}
+{"type":"user","content":"Walk me through how the daemon's session-finalize loop interacts with the manager's queue and ProcessResult callback","seq":1}
+{"type":"assistant","content":"Sure — the daemon polls for orphaned sessions, BuildPrompt constructs a RunRequest, the manager runs it through claude, and ProcessResult parses the output and writes artifacts.","seq":2}
+{"type":"assistant","content":"Want me to walk through the queue invariants too, or just the happy path?","seq":3}
 `
 	if err := os.WriteFile(filepath.Join(sessionsDir, "raw.jsonl"), []byte(rawContent), 0644); err != nil {
 		t.Fatal(err)
@@ -982,9 +991,12 @@ func createTestSessionInGitRepo(t *testing.T, sessionName string) (string, strin
 	sessionsDir := filepath.Join(ledgerPath, "sessions", sessionName)
 	require.NoError(t, os.MkdirAll(sessionsDir, 0755))
 
+	// Same substantive content as createTestSession — keeps the LLM
+	// path active rather than triggering the pre-LLM prefilter.
 	rawContent := `{"_meta":{"schema_version":"1","agent_type":"claude-code"}}
-{"type":"user","content":"hello","seq":1}
-{"type":"assistant","content":"hi there","seq":2}
+{"type":"user","content":"Walk me through how the daemon's session-finalize loop interacts with the manager's queue and ProcessResult callback","seq":1}
+{"type":"assistant","content":"Sure — the daemon polls for orphaned sessions, BuildPrompt constructs a RunRequest, the manager runs it through claude, and ProcessResult parses the output and writes artifacts.","seq":2}
+{"type":"assistant","content":"Want me to walk through the queue invariants too, or just the happy path?","seq":3}
 `
 	require.NoError(t, os.WriteFile(filepath.Join(sessionsDir, "raw.jsonl"), []byte(rawContent), 0644))
 

--- a/internal/daemon/agentwork/session_finalize_telemetry_test.go
+++ b/internal/daemon/agentwork/session_finalize_telemetry_test.go
@@ -1,6 +1,9 @@
 package agentwork
 
 import (
+	"log/slog"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -114,6 +117,101 @@ func TestEmitSummarizationTelemetry_NilSummaryResp(t *testing.T) {
 		"quality_score must be omitted when summaryResp is nil")
 	assert.NotContains(t, got.props, "summary_status",
 		"summary_status must be omitted when summaryResp is nil")
+}
+
+// TestBuildPrompt_PrefilterEmitsSkippedEvent verifies that when the
+// prefilter triggers (low-value session), BuildPrompt emits a
+// `summarization_skipped` telemetry event with the expected fields.
+//
+// Failure prevented: the prefilter quietly skips the LLM call but no
+// event is recorded, so dashboards measuring "we saved tokens" can
+// only infer skips from absent `summarization` events — which is
+// indistinguishable from any other emission failure (telemetry off,
+// daemon restart, network drop). An explicit marker keeps the
+// skip-rate signal honest.
+func TestBuildPrompt_PrefilterEmitsSkippedEvent(t *testing.T) {
+	tel := &fakeTelemetry{}
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.SetTelemetry(tel)
+
+	// Build a thin session that's guaranteed to trip the prefilter:
+	// short user content (< 80 chars) and only 2 entries (header + user)
+	// — no assistant, no tool. Hits all three prefilter heuristics.
+	ledgerPath := t.TempDir()
+	sessionName := "2026-05-04T15-00-testuser-OxThIN"
+	sessionsDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(sessionsDir, 0755))
+	rawContent := `{"_meta":{"schema_version":"1","agent_type":"claude-code"}}
+{"type":"user","content":"hi","seq":1}
+`
+	rawPath := filepath.Join(sessionsDir, "raw.jsonl")
+	require.NoError(t, os.WriteFile(rawPath, []byte(rawContent), 0644))
+
+	item := &WorkItem{
+		ID:   "test-prefilter",
+		Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionsDir,
+			RawPath:    rawPath,
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+
+	req, err := handler.BuildPrompt(item)
+	require.NoError(t, err)
+	require.True(t, req.SkipLLM, "prefilter must short-circuit via SkipLLM")
+
+	got := tel.lastByName("summarization_skipped")
+	require.NotNil(t, got, "summarization_skipped event must be emitted on prefilter trigger")
+
+	// Fields the dashboard needs to compute prefilter-skip rate and segment
+	// by reason. Pinning their presence here so a future refactor that
+	// drops one is caught at test-time, not when the dashboard goes silent.
+	assert.Equal(t, sessionsummary.SessionHash(sessionName), got.props["session_hash"],
+		"session_hash must match the same hash emitted by EventTokenoptRun, so server-side joins work")
+	assert.NotEmpty(t, got.props["reason"], "reason must carry the prefilter's ScoreReason")
+	// entry_count is the count of post-EntriesFromRaw entries handed to
+	// the prefilter — the _meta header is consumed by ReadSessionFromPath
+	// into stored.Meta, not surfaced as a regular entry, so a session
+	// with just a header + 1 user line produces 1 entry here.
+	assert.Equal(t, 1, got.props["entry_count"])
+	assert.Equal(t, 1, got.props["user_prompt_count"])
+}
+
+// TestBuildPrompt_NormalSession_NoSkippedEvent verifies the inverse:
+// real sessions that pass the prefilter do NOT emit a
+// summarization_skipped event. Failure prevented: prefilter starts
+// over-firing on real sessions and we don't notice because the event
+// fires for everything.
+func TestBuildPrompt_NormalSession_NoSkippedEvent(t *testing.T) {
+	tel := &fakeTelemetry{}
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.SetTelemetry(tel)
+
+	// createTestSession produces a session intentionally above all prefilter
+	// thresholds (substantive user prompt + assistant response). See its
+	// docstring for the invariant.
+	ledgerPath := createTestSession(t, "2026-05-04T15-00-testuser-OxRealS", nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", "2026-05-04T15-00-testuser-OxRealS")
+	rawPath := filepath.Join(sessionDir, "raw.jsonl")
+
+	item := &WorkItem{
+		ID:   "test-normal",
+		Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    rawPath,
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+
+	req, err := handler.BuildPrompt(item)
+	require.NoError(t, err)
+	assert.False(t, req.SkipLLM, "normal session should not trigger SkipLLM")
+	assert.Nil(t, tel.lastByName("summarization_skipped"),
+		"summarization_skipped event must NOT fire on a real session")
 }
 
 // TestEmitSummarizationTelemetry_JudgePiggyback verifies that a stashed

--- a/internal/daemon/agentwork/session_finalize_telemetry_test.go
+++ b/internal/daemon/agentwork/session_finalize_telemetry_test.go
@@ -1,0 +1,160 @@
+package agentwork
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/pkg/sessionsummary"
+	"github.com/sageox/ox/pkg/summaryeval"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTelemetry captures Record() calls for assertions.
+//
+// Concurrent-safe because the agentwork TelemetryRecorder contract requires
+// it (the daemon's real implementation is goroutine-safe). Tests typically
+// drive a single ProcessResult call so the lock is uncontended in practice;
+// keeping it correct still costs nothing and prevents flakes if a future
+// change adds parallel emit paths.
+type fakeTelemetry struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+type recordedEvent struct {
+	name  string
+	props map[string]any
+}
+
+func (f *fakeTelemetry) Record(event string, props map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// copy props so test assertions are stable if the caller mutates the map after.
+	clone := make(map[string]any, len(props))
+	for k, v := range props {
+		clone[k] = v
+	}
+	f.events = append(f.events, recordedEvent{name: event, props: clone})
+}
+
+func (f *fakeTelemetry) lastByName(name string) *recordedEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := len(f.events) - 1; i >= 0; i-- {
+		if f.events[i].name == name {
+			cp := f.events[i]
+			return &cp
+		}
+	}
+	return nil
+}
+
+// TestEmitSummarizationTelemetry_BasicFields verifies the canonical event
+// shape: mode, model, input_tokens, output_tokens, duration_ms, exit_code,
+// quality_score, summary_status, scored. Failure prevented: a future refactor
+// drops one of the fields and the cost-vs-quality dashboards go silent.
+func TestEmitSummarizationTelemetry_BasicFields(t *testing.T) {
+	tel := &fakeTelemetry{}
+	h := &SessionFinalizeHandler{telemetry: tel}
+
+	result := &RunResult{
+		Output:    "{}",
+		Duration:  742 * time.Millisecond,
+		ExitCode:  0,
+		TokensIn:  18234,
+		TokensOut: 1450,
+		ModelUsed: "claude-haiku-4-5-20251001",
+	}
+	resp := &session.SummarizeResponse{
+		QualityScore:  0.78,
+		SummaryStatus: sessionsummary.SummaryStatusOK,
+	}
+
+	h.emitSummarizationTelemetry("2026-04-01T10-00-user-OxTest", "delegated", result, resp, true)
+
+	got := tel.lastByName("summarization")
+	require.NotNil(t, got, "summarization event must be emitted")
+	assert.Equal(t, "delegated", got.props["mode"])
+	assert.Equal(t, "claude-haiku-4-5-20251001", got.props["model"])
+	assert.Equal(t, 18234, got.props["input_tokens"])
+	assert.Equal(t, 1450, got.props["output_tokens"])
+	assert.Equal(t, int64(742), got.props["duration_ms"])
+	assert.Equal(t, 0, got.props["exit_code"])
+	assert.Equal(t, true, got.props["scored"])
+	assert.Equal(t, 0.78, got.props["quality_score"])
+	assert.Equal(t, "ok", got.props["summary_status"])
+}
+
+// TestEmitSummarizationTelemetry_NilSink_NoOp verifies that handlers without
+// telemetry wired (tests, telemetry opt-out) silently no-op rather than
+// panic. Failure prevented: forgetting to wire the sink in the test harness
+// crashes the entire finalize path.
+func TestEmitSummarizationTelemetry_NilSink_NoOp(t *testing.T) {
+	h := &SessionFinalizeHandler{telemetry: nil}
+	// just verify it doesn't panic
+	h.emitSummarizationTelemetry("session", "delegated", &RunResult{}, &session.SummarizeResponse{}, false)
+}
+
+// TestEmitSummarizationTelemetry_NilSummaryResp verifies the event still
+// emits when summaryResp is nil (defensive — the early failure paths in
+// ProcessResult build a stub before reaching emit, but a future regression
+// might call this with nil).
+func TestEmitSummarizationTelemetry_NilSummaryResp(t *testing.T) {
+	tel := &fakeTelemetry{}
+	h := &SessionFinalizeHandler{telemetry: tel}
+
+	h.emitSummarizationTelemetry("s", "delegated", &RunResult{TokensIn: 10}, nil, false)
+
+	got := tel.lastByName("summarization")
+	require.NotNil(t, got)
+	assert.NotContains(t, got.props, "quality_score",
+		"quality_score must be omitted when summaryResp is nil")
+	assert.NotContains(t, got.props, "summary_status",
+		"summary_status must be omitted when summaryResp is nil")
+}
+
+// TestEmitSummarizationTelemetry_JudgePiggyback verifies that a stashed
+// judge result is folded into the summarization event and then cleared
+// (so the next session's emit doesn't double-count this judge run).
+// Failure prevented: judge tokens leak into the wrong session's event,
+// or stay attached forever and pollute every subsequent emit.
+func TestEmitSummarizationTelemetry_JudgePiggyback(t *testing.T) {
+	tel := &fakeTelemetry{}
+	h := &SessionFinalizeHandler{telemetry: tel}
+
+	jr := summaryeval.JudgeResult{
+		Overall:          0.71,
+		ModelUsed:        "claude-haiku-4-5-20251001",
+		DurationMs:       320,
+		PromptTokens:     5400,
+		CompletionTokens: 220,
+	}
+	h.lastJudgeResult = &jr
+
+	h.emitSummarizationTelemetry("s1", "delegated", &RunResult{
+		TokensIn: 1, TokensOut: 1, ModelUsed: "claude-haiku-4-5-20251001",
+	}, &session.SummarizeResponse{}, true)
+
+	first := tel.lastByName("summarization")
+	require.NotNil(t, first)
+	assert.Equal(t, 0.71, first.props["judge_overall"])
+	assert.Equal(t, "claude-haiku-4-5-20251001", first.props["judge_model"])
+	assert.Equal(t, int64(320), first.props["judge_duration_ms"])
+	assert.Equal(t, 5400, first.props["judge_input_tokens"])
+	assert.Equal(t, 220, first.props["judge_output_tokens"])
+
+	// stash should be cleared — second emit must NOT carry judge fields
+	assert.Nil(t, h.lastJudgeResult, "judge stash must be cleared after emit")
+
+	h.emitSummarizationTelemetry("s2", "delegated", &RunResult{
+		TokensIn: 1, TokensOut: 1, ModelUsed: "claude-haiku-4-5-20251001",
+	}, &session.SummarizeResponse{}, true)
+
+	second := tel.events[1]
+	assert.NotContains(t, second.props, "judge_overall",
+		"second emit must not carry the previous session's judge tokens")
+	assert.NotContains(t, second.props, "judge_input_tokens")
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1083,6 +1083,11 @@ func (d *Daemon) initComponents() time.Duration {
 		// on daemon shutdown instead of blocking up to its 3-minute
 		// deadline and triggering ErrShutdownTimeout.
 		sfh.SetDaemonContext(d.ctx)
+		// Wire the cost-shape telemetry sink. Auto-disabled when telemetry
+		// is opt-out; the recorder no-ops on the daemon side.
+		if d.telemetry != nil {
+			sfh.SetTelemetry(d.telemetry)
+		}
 		awCfg := configLoader()
 		sfh.SetQualityThresholds(awCfg.GetQualityUploadThreshold(), awCfg.GetQualityDiscardThreshold())
 		d.sessionFinalizeHandler = sfh

--- a/internal/session/quality.go
+++ b/internal/session/quality.go
@@ -31,3 +31,29 @@ func EvaluateQuality(score, uploadThreshold, discardThreshold float64) QualityDi
 	}
 	return QualityUpload
 }
+
+// EvaluateQualityCategory maps a categorical quality label to a
+// disposition. Categorical scoring is the canonical signal as of 2026-05
+// — numeric scales cluster on round numbers and ignore fine-grained
+// rubric distinctions, while LLMs are far more reliable picking from a
+// small named set with anchored examples.
+//
+// Unknown / empty category returns QualityUpload by design: an
+// unrecognized string from a legacy or future summary should default to
+// preserving the artifact, not silently discarding it. Callers that have
+// a numeric score on hand should use EvaluateQuality instead — this
+// function refuses to guess. The decision to upload an unknown category
+// matches the existing "unscored fallbacks default to upload" policy in
+// session_finalize.go's ProcessResult.
+func EvaluateQualityCategory(category string) QualityDisposition {
+	switch category {
+	case "skip":
+		return QualityDiscard
+	case "local_only":
+		return QualityLocalOnly
+	case "share":
+		return QualityUpload
+	default:
+		return QualityUpload
+	}
+}

--- a/internal/session/quality_test.go
+++ b/internal/session/quality_test.go
@@ -36,3 +36,35 @@ func TestEvaluateQuality(t *testing.T) {
 		})
 	}
 }
+
+// TestEvaluateQualityCategory pins the categorical → disposition mapping.
+// Failure prevented: a future change to category names or to the
+// disposition mapping would silently misroute sessions (e.g. skip
+// being treated as upload would leak useless stubs onto the team
+// ledger; share being treated as discard would lose real work).
+func TestEvaluateQualityCategory(t *testing.T) {
+	tests := []struct {
+		category string
+		want     QualityDisposition
+	}{
+		{"skip", QualityDiscard},
+		{"local_only", QualityLocalOnly},
+		{"share", QualityUpload},
+		// Defensive defaults — unknown / future / empty categories must
+		// preserve the artifact (upload) rather than silently discard.
+		// "Don't lose work" beats "be strict about labels."
+		{"", QualityUpload},
+		{"unknown_future_category", QualityUpload},
+		{"SHARE", QualityUpload}, // case-sensitive on purpose; LLM was instructed to emit lowercase
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.category, func(t *testing.T) {
+			got := EvaluateQualityCategory(tt.category)
+			if got != tt.want {
+				t.Errorf("EvaluateQualityCategory(%q) = %q, want %q",
+					tt.category, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -78,6 +78,26 @@ const (
 	// piggyback on the same event when the judge ran (judge_input_tokens,
 	// judge_output_tokens, judge_model, judge_overall).
 	EventSummarization = "summarization"
+
+	// EventSummarizationSkipped is emitted by the daemon when the
+	// prefilter (pkg/sessionsummary.MaybeBuildSkipSummary) determined a
+	// session was too thin for the LLM to produce a meaningful summary
+	// and synthesized a deterministic stub from user prompts instead.
+	// No claude -p call was made.
+	//
+	// Why a separate event instead of inferring from absent
+	// EventSummarization: absent events are an indistinguishable signal
+	// from any other emission failure (telemetry off, network drop,
+	// daemon restart mid-run). An explicit skip event lets dashboards
+	// compute a real prefilter-skip rate, segment skipped sessions by
+	// reason, and watch for regressions where the prefilter starts
+	// over-firing on real sessions.
+	//
+	// Standard props: session_hash (joins to EventTokenoptRun for the
+	// same session), reason (free-form ScoreReason from the prefilter
+	// — names which heuristic fired), entry_count, user_prompt_count.
+	// No content fields, no paths.
+	EventSummarizationSkipped = "summarization_skipped"
 )
 
 // Batch represents a batch of events for efficient transmission

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -60,6 +60,24 @@ const (
 
 	// summarization preprocessing events
 	EventTokenoptRun = "tokenopt_run" // summary-input optimization pass (cmd/ox/session_optimize_for_summary.go)
+
+	// EventSummarization is emitted once per LLM summarization call (delegated path
+	// today; inline coverage is a follow-up). It captures the cost shape of every
+	// session-stop summary so we can:
+	//
+	//   1. quantify the inline-vs-delegated cost gap in production (currently
+	//      asserted in ADR-016 from theory; this turns it into a measurement)
+	//   2. detect quality regressions if the Haiku-4.5 default drifts
+	//   3. catch model-ID mismatches between what the daemon thinks it's using
+	//      and what the local CLI actually picked
+	//
+	// Standard daemon-event props: app_type, app_version (auto-attached by
+	// TelemetryCollector.Record). Summarization-specific props live in the
+	// metadata payload and include at minimum: mode (inline|delegated|off|cloud),
+	// model, input_tokens, output_tokens, duration_ms, quality_score. Judge tokens
+	// piggyback on the same event when the judge ran (judge_input_tokens,
+	// judge_output_tokens, judge_model, judge_overall).
+	EventSummarization = "summarization"
 )
 
 // Batch represents a batch of events for efficient transmission

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.7.1"
+	Version   = "0.7.2"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )

--- a/pkg/sessionsummary/claude.go
+++ b/pkg/sessionsummary/claude.go
@@ -6,11 +6,37 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"time"
 )
 
 const invokeTimeout = 10 * time.Minute
+
+// defaultSummaryModel is the floating Haiku 4.5 alias. Pinned for
+// summarization because the task is structured JSON extraction over a
+// fixed schema — well within Haiku's capabilities and 5–15× cheaper
+// than the user's local Sonnet/Opus default. Floating (not dated) so
+// new Haiku 4.5 point releases roll forward without code changes.
+const defaultSummaryModel = "claude-haiku-4-5"
+
+// summaryModelEnv overrides defaultSummaryModel. Empty value (export
+// OX_SUMMARY_MODEL=) is meaningful: it restores pre-Haiku behavior by
+// passing no --model flag to claude, deferring to the user's local
+// default. Useful as a fast rollback.
+const summaryModelEnv = "OX_SUMMARY_MODEL"
+
+// DefaultSummaryModel returns the model identifier to pass to `claude -p`
+// for summarization. Reads OX_SUMMARY_MODEL if set (including empty), else
+// returns "claude-haiku-4-5". Callers pass the result to InvokeClaude.
+//
+// Empty string return = no --model flag = user's local Claude Code default.
+func DefaultSummaryModel() string {
+	if v, ok := os.LookupEnv(summaryModelEnv); ok {
+		return v // explicit override, including empty for rollback
+	}
+	return defaultSummaryModel
+}
 
 // claudeResultMessage is the minimal structure for parsing Claude's stream-json output.
 type claudeResultMessage struct {
@@ -21,7 +47,11 @@ type claudeResultMessage struct {
 // InvokeClaude runs `claude --output-format stream-json -p <prompt>` and returns
 // the result text. Uses a 10-minute timeout. Returns an error if the claude binary
 // is not found, the invocation times out, or no result message appears in output.
-func InvokeClaude(ctx context.Context, prompt, workDir string) (string, error) {
+//
+// model pins the underlying LLM (e.g. "claude-haiku-4-5"). Empty string omits
+// --model and defers to the local Claude Code default. Use DefaultSummaryModel()
+// for the standard summarization model selection with env-var override.
+func InvokeClaude(ctx context.Context, prompt, workDir, model string) (string, error) {
 	claudePath, err := exec.LookPath("claude")
 	if err != nil {
 		return "", fmt.Errorf("claude binary not found in PATH — ensure Claude Code CLI is installed")
@@ -36,7 +66,12 @@ func InvokeClaude(ctx context.Context, prompt, workDir string) (string, error) {
 	// Summary regen has tightly-scoped writes (one /tmp file + one
 	// `ox session push-summary` exec) — the permission prompt adds no
 	// safety in this context, only failure modes. Filed as bd ox-5cc9.
-	cmd := exec.CommandContext(ctx, claudePath, "--output-format", "stream-json", "--verbose", "--permission-mode", "bypassPermissions", "-p", prompt)
+	args := []string{"--output-format", "stream-json", "--verbose", "--permission-mode", "bypassPermissions"}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	args = append(args, "-p", prompt)
+	cmd := exec.CommandContext(ctx, claudePath, args...)
 	if workDir != "" {
 		cmd.Dir = workDir
 	}

--- a/pkg/sessionsummary/claude_test.go
+++ b/pkg/sessionsummary/claude_test.go
@@ -1,0 +1,44 @@
+package sessionsummary
+
+import (
+	"os"
+	"testing"
+)
+
+// TestDefaultSummaryModel_NoEnv verifies the floating Haiku 4.5 alias is
+// returned when OX_SUMMARY_MODEL is unset. Failure prevented: silent
+// regression to user's local default (Sonnet/Opus) on a fresh install,
+// erasing the cost win this code exists to deliver.
+func TestDefaultSummaryModel_NoEnv(t *testing.T) {
+	// Setenv registers cleanup; Unsetenv puts us in the "unset" state for
+	// the body of the test. Cleanup restores prior value either way.
+	t.Setenv("OX_SUMMARY_MODEL", "sentinel")
+	if err := os.Unsetenv("OX_SUMMARY_MODEL"); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
+	if got := DefaultSummaryModel(); got != "claude-haiku-4-5" {
+		t.Errorf("DefaultSummaryModel() = %q, want claude-haiku-4-5", got)
+	}
+}
+
+// TestDefaultSummaryModel_Override verifies an explicit model override
+// is honored. Failure prevented: env-var rollback path silently broken,
+// trapping users on Haiku if quality issues emerge in production.
+func TestDefaultSummaryModel_Override(t *testing.T) {
+	t.Setenv("OX_SUMMARY_MODEL", "claude-sonnet-4-6")
+	if got := DefaultSummaryModel(); got != "claude-sonnet-4-6" {
+		t.Errorf("DefaultSummaryModel() = %q, want claude-sonnet-4-6", got)
+	}
+}
+
+// TestDefaultSummaryModel_EmptyOverride verifies that OX_SUMMARY_MODEL=
+// (set to empty) is distinct from unset — it returns "" so InvokeClaude
+// omits --model and defers to the user's local default. Failure
+// prevented: rollback to pre-Haiku behavior unavailable, blocking ops
+// from fast-rolling back if Haiku quality regresses.
+func TestDefaultSummaryModel_EmptyOverride(t *testing.T) {
+	t.Setenv("OX_SUMMARY_MODEL", "")
+	if got := DefaultSummaryModel(); got != "" {
+		t.Errorf("DefaultSummaryModel() = %q with empty override, want empty string", got)
+	}
+}

--- a/pkg/sessionsummary/prefilter.go
+++ b/pkg/sessionsummary/prefilter.go
@@ -135,14 +135,14 @@ func MaybeBuildSkipSummary(entries []Entry) (*SummarizeResponse, bool) {
 	scoreReason := buildSkipReason(thin, silent, terseUser, len(userPrompts))
 
 	return &SummarizeResponse{
-		Title:         "Brief session",
-		Summary:       summary,
-		KeyActions:    nil,    // intentionally empty — no LLM means no inferred actions
-		Outcome:       "",     // unknown without LLM analysis
-		TopicsFound:   nil,    // see KeyActions
-		QualityScore:  0.05,   // below default discard threshold (0.1)
-		ScoreReason:   scoreReason,
-		SummaryStatus: SummaryStatusOK, // the deterministic summary IS valid; it's just not LLM-generated
+		Title:           "Brief session",
+		Summary:         summary,
+		KeyActions:      nil, // intentionally empty — no LLM means no inferred actions
+		Outcome:         "",  // unknown without LLM analysis
+		TopicsFound:     nil, // see KeyActions
+		QualityCategory: QualityCategorySkip,
+		ScoreReason:     scoreReason,
+		SummaryStatus:   SummaryStatusOK, // the deterministic summary IS valid; it's just not LLM-generated
 	}, true
 }
 

--- a/pkg/sessionsummary/prefilter.go
+++ b/pkg/sessionsummary/prefilter.go
@@ -1,0 +1,245 @@
+package sessionsummary
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Prefilter thresholds. Tuned conservatively — the goal is to skip
+// sessions whose LLM-generated summary would be hallucinated, not to
+// aggressively skip anything that *might* be thin. Err on the side of
+// letting the LLM try; the existing quality gate (EvaluateQuality with
+// thresholds at 0.1 / 0.3) will discard or local-only the result if the
+// LLM correctly assesses it as low value.
+//
+// Tighten these only with telemetry data showing the prefilter's skip
+// rate stays well below the LLM's "quality_score < 0.3" rate (i.e. we
+// only skip what the LLM was going to discard anyway).
+const (
+	// minMeaningfulEntries is the floor below which any summary would be
+	// guesswork. A real interaction has at minimum: 1 user prompt + 1
+	// assistant response. Below 2 entries we have nothing to summarize.
+	// Set to 3 to also reject sessions where a single tool call followed
+	// a single user prompt with no assistant text — those are usually
+	// agent test invocations or accidental session starts.
+	minMeaningfulEntries = 3
+
+	// minUserContentChars is the floor on combined user-turn length. A
+	// user typing "ok" or pressing enter to dismiss a hook starts a
+	// session technically but contributes no intent worth summarizing.
+	// 80 chars = roughly one short sentence; below that, the conversation
+	// is unlikely to produce anything beyond what the user literally
+	// typed (which we can echo deterministically without an LLM).
+	minUserContentChars = 80
+
+	// maxPromptsToEcho is the upper bound on how many user prompts we
+	// echo into the deterministic skip-summary. Past this we just use
+	// the first one — at that point the session is long enough that
+	// echoing all prompts produces a meandering paragraph, not a summary.
+	// (And if the session is THAT long, it probably won't trigger the
+	// prefilter at all because of the entry-count threshold.)
+	maxPromptsToEcho = 3
+)
+
+// MaybeBuildSkipSummary inspects a session's entries and, if the session
+// is too thin to produce a meaningful LLM-generated summary, returns a
+// deterministic stand-in summary built from user prompts. The boolean
+// return is true when the LLM call should be skipped.
+//
+// # Why this exists
+//
+// At session-stop scale, a non-trivial fraction of sessions are
+// exploratory pings: the user runs `ox agent session start` and asks one
+// quick question, the agent answers it, the session ends. There is no
+// architecture, no decision, no aha moment — just a Q&A that doesn't
+// belong in the team ledger. Today every such session pays the full
+// summarization cost: the prompt template's ~5KB of guidelines, the
+// optimized session bytes, the Haiku call, the validation pass — all to
+// produce an LLM summary that the quality gate then routes to "discard"
+// or "local-only" anyway.
+//
+// This function short-circuits that path for sessions whose schema
+// fields (chapter_titles, decisions, aha_moments) cannot meaningfully
+// be filled even by a perfect LLM. Saves the entire LLM round-trip.
+//
+// # Detection heuristics (intentionally conservative)
+//
+//   - Entry count < minMeaningfulEntries: not enough conversation to
+//     have a narrative arc.
+//   - No assistant entries: the agent never responded, so there's
+//     nothing to summarize beyond the user's question.
+//   - Combined user content < minUserContentChars: user contributed
+//     too little intent for any summary to capture more than what was
+//     literally typed.
+//
+// All three are AND-equivalent in spirit (a session has to fail just
+// ONE to be flagged) — a session can be thin in any dimension and still
+// not produce useful output. We don't require all three.
+//
+// # The deterministic summary
+//
+// When skipping, we synthesize a SummarizeResponse where:
+//   - Title is a generic "Brief session" marker.
+//   - Summary echoes the user's first prompt, or all prompts up to
+//     maxPromptsToEcho if there are few. This preserves the actual
+//     intent the user expressed without LLM-fabricated commentary.
+//   - QualityScore is set to 0.05, well below the discard threshold
+//     (0.1 by default) — so the existing quality gate will route this
+//     to QualityDiscard via session.EvaluateQuality. The session does
+//     NOT reach the team ledger. This is intentional: low-value
+//     sessions never had a place in the team's shared knowledge anyway,
+//     and the prefilter just makes that judgment cheaper.
+//   - ScoreReason explains what happened so the local consumer
+//     (`ox session view`) shows the user *why* their session got the
+//     stub treatment — not a mystery.
+//   - SummaryStatus is set to SummaryStatusOK because the summary IS
+//     a valid one, just deterministic. Distinguishing prefilter-stub
+//     from LLM-stub matters for telemetry segmentation: a high
+//     prefilter rate is a signal of healthy cost optimization; a high
+//     LLM-stub rate is a signal of LLM trouble.
+//
+// # What it does NOT do
+//
+// It does NOT touch the user's intent semantics with heuristics — no
+// stripping, no rephrasing, no synthesis. Echo only. The LLM is the
+// only thing in this codebase allowed to write summary prose, and when
+// it's not running we don't fake it.
+func MaybeBuildSkipSummary(entries []Entry) (*SummarizeResponse, bool) {
+	if len(entries) == 0 {
+		return nil, false // empty session is handled elsewhere; not our case
+	}
+
+	userPrompts := collectUserPrompts(entries)
+	totalUserContent := totalLen(userPrompts)
+	hasAssistant := hasEntryOfType(entries, EntryTypeAssistant)
+
+	// The session is "low-value" if any of these floor conditions hits.
+	// Each captures a distinct failure mode where LLM summary would
+	// either hallucinate or echo the trivial input.
+	thin := len(entries) < minMeaningfulEntries
+	silent := !hasAssistant
+	terseUser := totalUserContent < minUserContentChars
+
+	if !thin && !silent && !terseUser {
+		// Not low-value by any criterion — let the LLM produce a real summary.
+		return nil, false
+	}
+
+	// Build the deterministic summary from user prompts. This is the
+	// only place in the codebase that synthesizes summary prose without
+	// an LLM; the rationale is documented above. If userPrompts is
+	// empty we still return a stub with a placeholder so the caller has
+	// a valid SummarizeResponse to write — better than crashing the
+	// finalize flow over an edge case.
+	summary := buildPromptEcho(userPrompts)
+	scoreReason := buildSkipReason(thin, silent, terseUser, len(userPrompts))
+
+	return &SummarizeResponse{
+		Title:         "Brief session",
+		Summary:       summary,
+		KeyActions:    nil,    // intentionally empty — no LLM means no inferred actions
+		Outcome:       "",     // unknown without LLM analysis
+		TopicsFound:   nil,    // see KeyActions
+		QualityScore:  0.05,   // below default discard threshold (0.1)
+		ScoreReason:   scoreReason,
+		SummaryStatus: SummaryStatusOK, // the deterministic summary IS valid; it's just not LLM-generated
+	}, true
+}
+
+// collectUserPrompts returns the trimmed content of every user-typed
+// entry. Order preserved (chronological) so the echo summary reads in
+// the order the user typed.
+func collectUserPrompts(entries []Entry) []string {
+	out := make([]string, 0, 4)
+	for _, e := range entries {
+		if e.Type != EntryTypeUser {
+			continue
+		}
+		c := strings.TrimSpace(e.Content)
+		if c == "" {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func totalLen(strs []string) int {
+	n := 0
+	for _, s := range strs {
+		n += len(s)
+	}
+	return n
+}
+
+func hasEntryOfType(entries []Entry, t string) bool {
+	for _, e := range entries {
+		if e.Type == t {
+			return true
+		}
+	}
+	return false
+}
+
+// buildPromptEcho composes the deterministic summary text from the
+// collected user prompts. Format choice: a leading sentence framing
+// the echo, then the prompts. The leading sentence is critical — without
+// it the summary reads like a verbatim user prompt, which is confusing
+// to teammates browsing the ledger.
+func buildPromptEcho(prompts []string) string {
+	if len(prompts) == 0 {
+		return "Session was too short for a meaningful summary; no user prompt was recorded."
+	}
+
+	if len(prompts) == 1 {
+		return fmt.Sprintf("Session was too short for a meaningful summary. The user's prompt was: %q", prompts[0])
+	}
+
+	if len(prompts) <= maxPromptsToEcho {
+		var sb strings.Builder
+		sb.WriteString("Session was too short for a meaningful summary. The user's prompts were:")
+		for _, p := range prompts {
+			sb.WriteString("\n  - ")
+			sb.WriteString(p)
+		}
+		return sb.String()
+	}
+
+	// More than maxPromptsToEcho — echo only the first one and note the
+	// rest. Sessions hitting this branch have a lot of user input but
+	// failed some other low-value criterion (e.g. zero assistant entries,
+	// which usually means the agent crashed early). Echoing all prompts
+	// would produce a wall of text; the first one captures the original
+	// intent.
+	return fmt.Sprintf(
+		"Session was too short for a meaningful summary. The user's first prompt was: %q (plus %d more).",
+		prompts[0], len(prompts)-1,
+	)
+}
+
+// buildSkipReason produces a human-readable score_reason explaining
+// why the prefilter triggered. Ops needs this to distinguish "we saved
+// money on a thin session" from "the summarizer is broken." Multiple
+// criteria can fire at once; we list them all so the diagnostic is
+// honest.
+func buildSkipReason(thin, silent, terseUser bool, promptCount int) string {
+	var reasons []string
+	if thin {
+		reasons = append(reasons, fmt.Sprintf("fewer than %d entries", minMeaningfulEntries))
+	}
+	if silent {
+		reasons = append(reasons, "no assistant response")
+	}
+	if terseUser {
+		reasons = append(reasons, fmt.Sprintf("user content under %d chars", minUserContentChars))
+	}
+	if len(reasons) == 0 {
+		// Defensive — caller should have early-returned, but fall through gracefully.
+		reasons = append(reasons, "low-value heuristics matched")
+	}
+	return fmt.Sprintf(
+		"prefilter skip — %s; %d user prompt(s) echoed; LLM summarization skipped to save tokens",
+		strings.Join(reasons, ", "),
+		promptCount,
+	)
+}

--- a/pkg/sessionsummary/prefilter_test.go
+++ b/pkg/sessionsummary/prefilter_test.go
@@ -1,0 +1,176 @@
+package sessionsummary
+
+import (
+	"strings"
+	"testing"
+)
+
+func mkEntry(typ, content string) Entry {
+	return Entry{Type: typ, Content: content}
+}
+
+// TestPrefilter_RealSession_LetItThrough verifies the prefilter does NOT
+// trigger on a normal substantive session. Failure prevented: the
+// prefilter starts skipping real sessions, hiding actual work from the
+// team ledger and breaking the cost-savings argument (we'd be saving
+// tokens by losing summaries we wanted).
+func TestPrefilter_RealSession_LetItThrough(t *testing.T) {
+	entries := []Entry{
+		mkEntry("user", "Help me investigate the daemon's session-finalize loop. It looks like sessions are getting stuck in pending."),
+		mkEntry("assistant", "I'll start by looking at the workflow in session_finalize.go and the manager's queue logic."),
+		mkEntry("tool", ""),
+		mkEntry("assistant", "Found it — there's a race in the queue.Complete path."),
+		mkEntry("tool", ""),
+		mkEntry("assistant", "Fixed by adding a mutex around the dedup-key map. Tests pass."),
+	}
+	resp, skip := MaybeBuildSkipSummary(entries)
+	if skip {
+		t.Fatalf("prefilter triggered on substantive session; resp=%+v", resp)
+	}
+	if resp != nil {
+		t.Errorf("expected nil response when not skipping, got %+v", resp)
+	}
+}
+
+// TestPrefilter_TooFewEntries verifies the entry-count floor. Failure
+// prevented: a session with one user prompt and an empty agent (e.g.,
+// the agent crashed before responding) sails through to an LLM call
+// that hallucinates an aha_moments list from nothing.
+func TestPrefilter_TooFewEntries(t *testing.T) {
+	entries := []Entry{
+		// One substantive user prompt, no assistant — agent died.
+		mkEntry("user", "Investigate why my deploy is failing on the auth service. The error mentions JWT signature validation."),
+	}
+	resp, skip := MaybeBuildSkipSummary(entries)
+	if !skip {
+		t.Fatal("expected prefilter to trigger on single-entry session")
+	}
+	if resp == nil || resp.Summary == "" {
+		t.Fatalf("expected populated stub summary, got %+v", resp)
+	}
+	if !strings.Contains(resp.Summary, "JWT signature validation") {
+		t.Errorf("expected user prompt echoed in summary, got: %q", resp.Summary)
+	}
+	if resp.QualityScore >= 0.1 {
+		t.Errorf("QualityScore=%.2f should route this to discard via the quality gate; want <0.1", resp.QualityScore)
+	}
+	if resp.SummaryStatus != SummaryStatusOK {
+		t.Errorf("SummaryStatus=%q, want %q (deterministic summary IS valid)", resp.SummaryStatus, SummaryStatusOK)
+	}
+}
+
+// TestPrefilter_NoAssistant verifies sessions with zero assistant turns
+// trigger the prefilter even when entry count is otherwise OK. Failure
+// prevented: agent crash or hook failure produces a session that's
+// "long" only in the system/header/tool entries — no actual response
+// to the user. LLM summary of that is hallucination.
+func TestPrefilter_NoAssistant(t *testing.T) {
+	entries := []Entry{
+		mkEntry("user", "Walk me through the codebase structure and explain how the daemon and CLI talk to each other through IPC."),
+		mkEntry("system", "system reminder content"),
+		mkEntry("tool", ""),
+		mkEntry("tool", ""),
+		mkEntry("user", "Are you still there?"),
+	}
+	_, skip := MaybeBuildSkipSummary(entries)
+	if !skip {
+		t.Fatal("expected prefilter to trigger when no assistant response present")
+	}
+}
+
+// TestPrefilter_TerseUser verifies sessions where the user said almost
+// nothing get skipped. Failure prevented: a one-word user prompt ("ok",
+// "thanks") followed by some assistant chatter is not worth a real
+// summary; we'd burn tokens producing one.
+func TestPrefilter_TerseUser(t *testing.T) {
+	entries := []Entry{
+		mkEntry("user", "ok"),
+		mkEntry("assistant", "anything else?"),
+		mkEntry("user", "no"),
+		mkEntry("assistant", "okay, ending session."),
+	}
+	resp, skip := MaybeBuildSkipSummary(entries)
+	if !skip {
+		t.Fatal("expected prefilter to trigger on near-empty user content")
+	}
+	// Both prompts should be echoed — they're under maxPromptsToEcho.
+	if !strings.Contains(resp.Summary, "ok") || !strings.Contains(resp.Summary, "no") {
+		t.Errorf("expected both prompts echoed in summary, got: %q", resp.Summary)
+	}
+}
+
+// TestPrefilter_FewPromptsEchoedAsList verifies that with multiple short
+// prompts (<= maxPromptsToEcho), the summary lists them all. Failure
+// prevented: only the first prompt being echoed loses the user's
+// actual sequence of asks, which is the only signal a low-value
+// session HAS.
+func TestPrefilter_FewPromptsEchoedAsList(t *testing.T) {
+	entries := []Entry{
+		mkEntry("user", "hi"),
+		mkEntry("user", "what's the time"),
+		mkEntry("user", "thanks"),
+	}
+	resp, skip := MaybeBuildSkipSummary(entries)
+	if !skip {
+		t.Fatal("expected prefilter to trigger")
+	}
+	want := []string{"hi", "what's the time", "thanks"}
+	for _, w := range want {
+		if !strings.Contains(resp.Summary, w) {
+			t.Errorf("missing prompt %q in summary: %q", w, resp.Summary)
+		}
+	}
+}
+
+// TestPrefilter_ManyPromptsEchoFirst verifies that with > maxPromptsToEcho
+// prompts, only the first is echoed (rest summarized as count). Failure
+// prevented: long lists of prompts make the summary unreadable wall of
+// text; the first prompt is usually where the intent is anyway.
+func TestPrefilter_ManyPromptsEchoFirst(t *testing.T) {
+	entries := []Entry{
+		mkEntry("user", "first prompt with the original intent expressed clearly"),
+		mkEntry("user", "second"),
+		mkEntry("user", "third"),
+		mkEntry("user", "fourth"),
+		mkEntry("user", "fifth"),
+		// no assistant — triggers silent criterion
+	}
+	resp, skip := MaybeBuildSkipSummary(entries)
+	if !skip {
+		t.Fatal("expected prefilter to trigger")
+	}
+	if !strings.Contains(resp.Summary, "first prompt with the original intent") {
+		t.Errorf("first prompt not echoed: %q", resp.Summary)
+	}
+	if !strings.Contains(resp.Summary, "plus 4 more") {
+		t.Errorf("expected 'plus 4 more' note, got: %q", resp.Summary)
+	}
+}
+
+// TestPrefilter_EmptySession verifies the empty-entries case returns
+// (nil, false). The empty case is handled by the caller (it has its
+// own existing path); we don't claim it.
+func TestPrefilter_EmptySession(t *testing.T) {
+	resp, skip := MaybeBuildSkipSummary(nil)
+	if skip || resp != nil {
+		t.Errorf("expected (nil, false) for empty session, got resp=%+v skip=%v", resp, skip)
+	}
+}
+
+// TestPrefilter_QualityScoreBelowDiscardGate verifies the synthesized
+// summary's quality_score is below the default discard threshold (0.1)
+// so the existing EvaluateQuality path routes it to QualityDiscard.
+// Failure prevented: prefilter-generated stubs leak onto the team
+// ledger because their score is high enough to pass the upload gate.
+// This test pins the contract: prefilter outputs are local-only at best.
+func TestPrefilter_QualityScoreBelowDiscardGate(t *testing.T) {
+	entries := []Entry{mkEntry("user", "hi")}
+	resp, skip := MaybeBuildSkipSummary(entries)
+	if !skip {
+		t.Fatal("expected skip")
+	}
+	const defaultDiscardThreshold = 0.1
+	if resp.QualityScore >= defaultDiscardThreshold {
+		t.Errorf("QualityScore=%.3f >= discard threshold %.3f; would leak to ledger", resp.QualityScore, defaultDiscardThreshold)
+	}
+}

--- a/pkg/sessionsummary/prefilter_test.go
+++ b/pkg/sessionsummary/prefilter_test.go
@@ -51,8 +51,9 @@ func TestPrefilter_TooFewEntries(t *testing.T) {
 	if !strings.Contains(resp.Summary, "JWT signature validation") {
 		t.Errorf("expected user prompt echoed in summary, got: %q", resp.Summary)
 	}
-	if resp.QualityScore >= 0.1 {
-		t.Errorf("QualityScore=%.2f should route this to discard via the quality gate; want <0.1", resp.QualityScore)
+	if resp.QualityCategory != QualityCategorySkip {
+		t.Errorf("QualityCategory=%q, want %q so EvaluateQualityCategory routes this to discard",
+			resp.QualityCategory, QualityCategorySkip)
 	}
 	if resp.SummaryStatus != SummaryStatusOK {
 		t.Errorf("SummaryStatus=%q, want %q (deterministic summary IS valid)", resp.SummaryStatus, SummaryStatusOK)
@@ -157,20 +158,23 @@ func TestPrefilter_EmptySession(t *testing.T) {
 	}
 }
 
-// TestPrefilter_QualityScoreBelowDiscardGate verifies the synthesized
-// summary's quality_score is below the default discard threshold (0.1)
-// so the existing EvaluateQuality path routes it to QualityDiscard.
-// Failure prevented: prefilter-generated stubs leak onto the team
-// ledger because their score is high enough to pass the upload gate.
-// This test pins the contract: prefilter outputs are local-only at best.
-func TestPrefilter_QualityScoreBelowDiscardGate(t *testing.T) {
+// TestPrefilter_QualityCategorySkip verifies the synthesized summary's
+// quality_category is "skip" so EvaluateQualityCategory routes it to
+// QualityDiscard. Failure prevented: prefilter-generated stubs leak
+// onto the team ledger because their category is treated as upload-
+// worthy. This test pins the contract: prefilter outputs always
+// flag as skip.
+func TestPrefilter_QualityCategorySkip(t *testing.T) {
 	entries := []Entry{mkEntry("user", "hi")}
 	resp, skip := MaybeBuildSkipSummary(entries)
 	if !skip {
 		t.Fatal("expected skip")
 	}
-	const defaultDiscardThreshold = 0.1
-	if resp.QualityScore >= defaultDiscardThreshold {
-		t.Errorf("QualityScore=%.3f >= discard threshold %.3f; would leak to ledger", resp.QualityScore, defaultDiscardThreshold)
+	if resp.QualityCategory != QualityCategorySkip {
+		t.Errorf("QualityCategory=%q, want %q so it routes to QualityDiscard",
+			resp.QualityCategory, QualityCategorySkip)
+	}
+	if !IsSkipCategory(resp) {
+		t.Error("IsSkipCategory(resp) returned false on a prefilter-generated stub")
 	}
 }

--- a/pkg/sessionsummary/prompt.go
+++ b/pkg/sessionsummary/prompt.go
@@ -169,6 +169,14 @@ The score_reason should be a single sentence explaining the rating.
 //
 // Callers pick the path; the prompt stays agnostic.
 //
+// # Cost note: inline vs delegated
+//
+// In `inline` mode, this prompt runs against an agent that already has the
+// conversation in its prompt cache, so input tokens are predominantly
+// cached reads — the calling agent's warm cache is the primary cost
+// mitigation. In `delegated` mode the daemon spawns a fresh subprocess,
+// the prompt cache is cold, and every call pays the full input cost.
+//
 // # Contract mismatch with ValidateSummaryContent (historical note)
 //
 // The prompt below REQUESTS a rich schema: title, summary, key_actions,

--- a/pkg/sessionsummary/prompt.go
+++ b/pkg/sessionsummary/prompt.go
@@ -68,7 +68,7 @@ Create a JSON object with this structure:
     "constraints": ["Technical or business constraints identified"],
     "non_goals": ["Things explicitly decided NOT to do"]
   },
-  "quality_score": 0.75,
+  "quality_category": "share",
   "score_reason": "New feature with architectural decision and test coverage"
 }
 
@@ -128,29 +128,59 @@ and cross-session knowledge aggregation.
 
 Only include fields with actual content. Omit empty arrays.
 
-## Quality Score Guidelines
+## Quality Category Guidelines (read this BEFORE writing any other field)
 
-Rate the session's value to the team on a 0.0-1.0 scale. This determines whether the session
-is shared with the team (uploaded to ledger) or kept locally/discarded.
+Pick exactly one category for ` + "`quality_category`" + `. This is the most
+important field — it determines whether the session is shared with the team,
+kept locally, or discarded entirely. Categorical (not numeric) because
+fine-grained 0.0-1.0 scores cluster on round numbers and ignore real
+distinctions; LLM-based rubric scoring works better with a small named set.
+Pick the category whose anchor examples best match the session.
 
-**Score high (0.7-1.0):**
+**share** — A teammate would benefit from reading this. Examples:
 - Architectural decisions or design rationale documented
-- Bugs found with root cause analysis
+- Bugs found with root cause analysis (not just the fix)
 - Reusable patterns or approaches discovered
-- Knowledge that would save a future coworker time
+- Novel debugging techniques or non-obvious gotchas
+- Important context for ongoing initiatives
 
-**Score medium (0.3-0.7):**
-- Routine feature implementation with some decisions
-- Bug fixes without broader insights
-- Configuration or setup with team-relevant details
+**local_only** — Real work, but primarily individual. Examples:
+- Routine feature implementation following an existing pattern
+- Bug fixes without broader insight (the fix is in the diff)
+- Configuration or environment setup
+- Refactoring with no architectural shift
 
-**Score low (0.0-0.3):**
-- Routine maintenance (version bumps, formatting, rebasing)
-- Abandoned sessions (started, backed out, no real work)
+**skip** — Not worth recording at all. Examples:
+- Routine maintenance (version bumps, formatting, mechanical rebases)
+- Abandoned sessions (started, backed out, no real work happened)
 - Boilerplate-only (just ran prime, asked one question, left)
 - Repetitive work already captured in a prior session
+- Single Q&A with a one-shot answer; no decisions, no work performed
 
-The score_reason should be a single sentence explaining the rating.
+## Skip-Shape Output (saves tokens when the answer is obvious)
+
+When ` + "`quality_category`" + ` is **skip**, you MAY emit a minimal JSON object
+instead of the full schema:
+
+` + "```" + `json
+{
+  "quality_category": "skip",
+  "score_reason": "<one sentence: why this session is not worth a real summary>",
+  "title": "<optional 5-10 word descriptor of what was attempted>"
+}
+` + "```" + `
+
+The full schema fields (key_actions, aha_moments, decisions, ...) cost
+output tokens and produce nothing teammates can use on a session that's
+being skipped. Don't write them. The downstream pipeline recognizes the
+skip-shape and routes it the same place a deterministic prefilter skip
+would (discarded, not shared).
+
+For ` + "`local_only`" + ` and ` + "`share`" + ` categories, emit the full schema above.
+
+` + "`score_reason`" + ` is a single sentence explaining the category choice —
+useful for telemetry and ops investigation when reviewing skipped or
+local-only sessions.
 `
 
 // BuildSummaryPrompt builds a prompt for the calling agent to generate a session summary.

--- a/pkg/sessionsummary/prompt.go
+++ b/pkg/sessionsummary/prompt.go
@@ -163,9 +163,16 @@ The score_reason should be a single sentence explaining the rating.
 //   - raw.jsonl: every entry captured during the session (user, assistant, tool,
 //     system, header).
 //   - summary-input jsonl (produced by pkg/tokenopt in ConversationOnly mode):
-//     user + assistant + header kept verbatim, tool entries collapsed to
-//     `{type:"tool_mark", tool_name, brief}`, system entries dropped. May have
-//     fewer lines than len(entries).
+//     user + assistant kept verbatim; every tool entry replaced with a bare
+//     `{type:"tool_mark"}` marker (or `{type:"tool_mark", count:N}` when
+//     adjacent runs of tool entries collapse). The marker carries no
+//     tool_name, brief, or output — its only job is to tell the summarizer
+//     "the agent acted between these two messages, N times." BOTH system
+//     and header entries are dropped. The header is gone because the
+//     schema fields it carries (agent_type, model, ox_version, created_at,
+//     ...) are stamped into meta.json by the daemon directly and don't
+//     need a round-trip through the LLM. The optimized stream is
+//     typically much shorter than the original entry count.
 //
 // Callers pick the path; the prompt stays agnostic.
 //
@@ -202,13 +209,13 @@ func BuildSummaryPrompt(entries []Entry, rawPath, ledgerSessionDir string) strin
 	sb.WriteString("## Session to Analyze\n\n")
 	fmt.Fprintf(&sb, "Read the session recording at: `%s`\n\n", rawPath)
 	sb.WriteString("The file is JSONL format — one JSON object per line. Possible entry shapes:\n\n")
-	sb.WriteString("- `{type:\"header\", metadata:{...}}` — session metadata, one per file\n")
 	sb.WriteString("- `{type:\"user\", content:\"...\", timestamp:\"...\"}` — human input\n")
 	sb.WriteString("- `{type:\"assistant\", content:\"...\", timestamp:\"...\"}` — AI response prose\n")
 	sb.WriteString("- `{type:\"tool\", tool_name:\"...\", tool_input:\"...\", tool_output:\"...\"}` — full tool invocation (only in unoptimized files)\n")
-	sb.WriteString("- `{type:\"tool_mark\", tool_name:\"...\", brief:\"...\"}` — compact tool marker (in summary-input files: carries the tool name + a short gist of what was invoked; full tool I/O is not preserved)\n")
+	sb.WriteString("- `{type:\"tool_mark\", count?:N}` — bare tool-activity marker (in summary-input files: signals the agent paused to act between messages). The marker is intentionally minimal: tool name, inputs, and outputs are NOT preserved here. The optional `count` field, when present, means N adjacent tool calls were collapsed into this single entry — read it as \"the agent did N tool things between these two messages.\" Recover concrete actions (file paths, commands, decisions) from surrounding assistant prose, not from these markers.\n")
 	sb.WriteString("- `{type:\"system\", content:\"...\"}` — system reminder (may be absent in summary-input files; they are dropped by the pre-summarize pass)\n\n")
-	sb.WriteString("Focus on user/assistant dialog to recover the session narrative; use tool and tool_mark entries as scaffolding for what the agent did between messages. Line count may be smaller than the original entry_count if the file has been pre-processed.\n\n")
+	sb.WriteString("Note: `header` entries (session metadata) and `system` entries are stripped from summary-input files; you do NOT need to read or echo them. Session metadata (agent type, version, model, username, created_at) is stamped into meta.json by the daemon directly, not by you.\n\n")
+	sb.WriteString("Focus on user/assistant dialog to recover the session narrative; use tool_mark entries as scaffolding for what the agent did between messages. A tool_mark with count=20 says more compactly than 20 separate marks would: \"the agent did this 20 times,\" which often signals an iterative refactor or polling loop worth reflecting in a chapter title. Line count may be smaller than the original entry_count if the file has been pre-processed.\n\n")
 
 	sb.WriteString("## Instructions\n\n")
 	sb.WriteString("1. Read the session recording file at the path above\n")

--- a/pkg/sessionsummary/prompt_test.go
+++ b/pkg/sessionsummary/prompt_test.go
@@ -21,10 +21,13 @@ func TestBuildSummaryPrompt(t *testing.T) {
 	t.Run("describes both raw and summary-input entry shapes", func(t *testing.T) {
 		// Prompt must stay agnostic to which file it points at, because
 		// callers pass either raw.jsonl or the tokenopt-optimized file.
-		// Summarizer needs to recognize tool_mark + brief in the optimized case.
+		// The summarizer needs to recognize tool_mark in the optimized
+		// case (and the optional `count` field for batched runs); since
+		// the design dropped tool_name/brief/output, the prompt no longer
+		// mentions "brief" — only "tool_mark" and the count semantics.
 		result := BuildSummaryPrompt(entries, "/tmp/raw.jsonl", "")
 		assert.Contains(t, result, `"tool_mark"`)
-		assert.Contains(t, result, "brief")
+		assert.Contains(t, result, "count")
 		assert.Contains(t, result, `"user"`)
 		assert.Contains(t, result, `"assistant"`)
 	})

--- a/pkg/sessionsummary/prompt_test.go
+++ b/pkg/sessionsummary/prompt_test.go
@@ -58,9 +58,12 @@ func TestBuildSummaryPrompt(t *testing.T) {
 		assert.Contains(t, result, "/tmp/my session/raw.jsonl")
 	})
 
-	t.Run("includes agent_summary guidelines", func(t *testing.T) {
+	t.Run("includes agent_summary and quality_category guidelines", func(t *testing.T) {
 		result := BuildSummaryPrompt(entries, "/tmp/raw.jsonl", "")
 		assert.True(t, strings.Contains(result, "agent_summary"))
-		assert.True(t, strings.Contains(result, "quality_score"))
+		// quality_category replaced quality_score as of 2026-05; numeric LLM
+		// rubric scoring clusters on round numbers and ignores fine
+		// distinctions (April 2026 best practices).
+		assert.True(t, strings.Contains(result, "quality_category"))
 	})
 }

--- a/pkg/sessionsummary/telemetry.go
+++ b/pkg/sessionsummary/telemetry.go
@@ -1,0 +1,50 @@
+package sessionsummary
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+)
+
+// SessionHash returns a short stable correlation key for telemetry events
+// that touch the same session at different points in the pipeline.
+//
+// Used by:
+//   - cmd/ox/session_optimize_for_summary.go (EventTokenoptRun)
+//   - internal/daemon/agentwork/session_finalize.go (EventSummarization)
+//
+// Both events emit this hash so operators can answer questions like
+// "for sessions with >70% token reduction, what's the LLM input_tokens
+// distribution?" — joining the compression-metrics event with the
+// LLM-cost-shape event server-side.
+//
+// Privacy: hashes the session NAME, not the path. The session name is a
+// per-session token (e.g. 2026-05-04T15-00-ryan-OxXyz1) that's safe to
+// hash; the full path may contain a username and shouldn't be exposed
+// in telemetry, even hashed (small hash space + known username pattern
+// = recoverable). 8 bytes (64 bits) is collision-safe at per-user
+// session volumes — a user generating 1000 sessions/day for 100 years
+// has a collision probability under 1 in a billion.
+func SessionHash(sessionName string) string {
+	if sessionName == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(sessionName))
+	return hex.EncodeToString(sum[:8])
+}
+
+// SessionHashFromRawPath extracts the session name from rawPath
+// (.../<sessionName>/raw.jsonl) and returns its hash. Convenience for
+// callers that have the path on hand. Returns "" when the path doesn't
+// resolve to a recognizable session name.
+func SessionHashFromRawPath(rawPath string) string {
+	if rawPath == "" {
+		return ""
+	}
+	dir := filepath.Dir(rawPath)
+	name := filepath.Base(dir)
+	if name == "" || name == "." {
+		return ""
+	}
+	return SessionHash(name)
+}

--- a/pkg/sessionsummary/types.go
+++ b/pkg/sessionsummary/types.go
@@ -40,6 +40,51 @@ const (
 	SummaryStatusUnrecoverable = "unrecoverable"
 )
 
+// QualityCategory values describe the LLM-judged team-value of a session.
+// Categorical (not numeric) because as of April 2026 best practices on LLM
+// rubric scoring: numeric scales cluster on round numbers and ignore the
+// fine-grained distinctions they pretend to capture; LLMs are far more
+// reliable at picking from a small named set with anchored examples.
+//
+// Three categories matching session.QualityDisposition 1:1 — adding more
+// categories invites the same fine-distinction problem numeric had. The
+// rubric in the summarization prompt anchors each category with concrete
+// examples so the LLM can place a session unambiguously.
+//
+// Older summaries on the ledger may have empty QualityCategory and
+// non-zero QualityScore. Readers MUST treat empty as "category unknown,
+// fall back to numeric score via session.EvaluateQuality" — see
+// EvaluateQualityCategory for the canonical mapping.
+const (
+	// QualityCategorySkip — the session has no content worth recording
+	// at all. Routine maintenance, abandoned attempts, single-Q&A
+	// pings with no decisions or learnings. Maps to QualityDiscard.
+	// When the LLM emits this category it MAY also emit a minimal
+	// skip-shape (no title/summary/key_actions/...) — saves output
+	// tokens that would otherwise produce a stub teammates can't use.
+	QualityCategorySkip = "skip"
+
+	// QualityCategoryLocalOnly — there was real work, but it's primarily
+	// individual: routine feature implementation, bug fixes without
+	// broader insight, configuration that isn't team-level. Useful to
+	// the coworker who did it; not worth pushing to the team ledger.
+	// Maps to QualityLocalOnly.
+	QualityCategoryLocalOnly = "local_only"
+
+	// QualityCategoryShare — contains content a teammate would benefit
+	// from: architectural decisions, root-cause analyses, novel
+	// approaches, reusable patterns, important context for ongoing
+	// work. Maps to QualityUpload.
+	QualityCategoryShare = "share"
+)
+
+// IsSkipCategory reports whether resp's quality category indicates the
+// LLM (or prefilter) decided this session should not be summarized.
+// Centralized so callers don't sniff the literal string in five places.
+func IsSkipCategory(resp *SummarizeResponse) bool {
+	return resp != nil && resp.QualityCategory == QualityCategorySkip
+}
+
 // Entry is a minimal session entry for summarization.
 // Uses plain strings for the Type field (not an enum) so this package
 // has no dependency on internal/session.
@@ -85,8 +130,19 @@ type SummarizeResponse struct {
 	SageoxInsights []SageoxInsight  `json:"sageox_insights,omitempty"` // moments where SageOx guidance provided value
 
 	// Quality gate
-	QualityScore float64 `json:"quality_score"`          // 0.0-1.0 session value for team sharing
-	ScoreReason  string  `json:"score_reason,omitempty"` // brief explanation of the quality score
+	//
+	// QualityCategory is the canonical quality signal as of 2026-05.
+	// Values: QualityCategorySkip, QualityCategoryLocalOnly,
+	// QualityCategoryShare. See those constants for rubric.
+	// Empty on legacy summaries — readers fall back to QualityScore.
+	QualityCategory string `json:"quality_category,omitempty"`
+	// QualityScore is the legacy 0.0-1.0 numeric value. Retained for
+	// backward compatibility with existing summary.json files on the
+	// ledger; new summaries do NOT populate this. Numeric scoring is
+	// against April 2026 best practices for LLM rubric evaluation —
+	// see QualityCategory.
+	QualityScore float64 `json:"quality_score,omitempty"`
+	ScoreReason  string  `json:"score_reason,omitempty"` // brief explanation of the quality decision
 
 	// SageOx contribution (injected from cache file, not LLM-generated)
 	SageoxScore         *float64 `json:"sageox_score,omitempty"`          // 0.0-1.0 self-reported contribution score

--- a/pkg/sessionsummary/validate.go
+++ b/pkg/sessionsummary/validate.go
@@ -108,6 +108,21 @@ func ValidateSummaryContent(resp *SummarizeResponse) error {
 		return fmt.Errorf("nil summary response")
 	}
 
+	// Skip-shape contract: when QualityCategory == "skip", the LLM is
+	// explicitly allowed to emit a minimal response without title/summary/
+	// outcome content. Validating those structural floors here would force
+	// the LLM to fabricate placeholder text just to pass the gate, which
+	// defeats the whole point of the skip path (saving output tokens).
+	// The skip route still gets disposed via EvaluateQualityCategory →
+	// QualityDiscard, so nothing leaks onto the ledger. Red-flag scans
+	// below still apply on whatever fields are present.
+	if IsSkipCategory(resp) {
+		// Run the red-flag scan defensively in case the skip-shape
+		// title/summary contains adversarial or contaminated content
+		// (rare but possible). Structural floors are skipped.
+		return validateRedFlags(resp)
+	}
+
 	// structural: title required
 	title := strings.TrimSpace(resp.Title)
 	if len(title) < 3 {
@@ -133,7 +148,21 @@ func ValidateSummaryContent(resp *SummarizeResponse) error {
 		return fmt.Errorf("invalid outcome %q (must be success, partial, or failed)", resp.Outcome)
 	}
 
-	// heuristic: check title for red flags
+	if err := validateRedFlags(resp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateRedFlags applies the title/summary contamination patterns
+// (permission requests, tool-call artifacts, self-referential agent
+// text) without enforcing structural minimums. Used by both the
+// full-shape ValidateSummaryContent path and the skip-shape relaxed
+// path so contamination is still caught when the LLM emits skip-shape
+// output that includes a title or summary.
+func validateRedFlags(resp *SummarizeResponse) error {
+	title := strings.TrimSpace(resp.Title)
 	titleLower := strings.ToLower(title)
 	for _, rf := range titleRedFlags {
 		if strings.Contains(titleLower, rf.pattern) {
@@ -141,14 +170,13 @@ func ValidateSummaryContent(resp *SummarizeResponse) error {
 		}
 	}
 
-	// heuristic: check summary for red flags
+	summary := strings.TrimSpace(resp.Summary)
 	summaryLower := strings.ToLower(summary)
 	for _, rf := range summaryRedFlags {
 		if strings.Contains(summaryLower, rf.pattern) {
 			return fmt.Errorf("summary contains %s: %q", rf.reason, truncateStr(summary, 120))
 		}
 	}
-
 	return nil
 }
 
@@ -172,6 +200,12 @@ func ValidateSummaryContent(resp *SummarizeResponse) error {
 func ValidateSummaryRichness(resp *SummarizeResponse, entryCount int) error {
 	if resp == nil {
 		return fmt.Errorf("nil summary response")
+	}
+	// Skip-shape sessions are exempt from richness — the LLM (or the
+	// deterministic prefilter) explicitly decided this session shouldn't
+	// be summarized. Demanding key_actions on a skip is a contradiction.
+	if IsSkipCategory(resp) {
+		return nil
 	}
 	if entryCount <= RichnessMinEntries {
 		return nil // trivial session — no richness requirement

--- a/pkg/sessionsummary/validate_test.go
+++ b/pkg/sessionsummary/validate_test.go
@@ -217,6 +217,90 @@ func TestValidateSummaryContent(t *testing.T) {
 	}
 }
 
+// TestValidateSummaryContent_SkipShape verifies the skip-shape relaxation:
+// when QualityCategory == "skip", the structural floors on title/summary/
+// outcome are skipped so the LLM can emit a minimal response without
+// fabricating placeholder text. Red-flag scans still apply.
+//
+// Failure prevented: skip-shape outputs (intentionally minimal) get
+// rejected by the structural validators and replaced with a failure-stub,
+// defeating the entire token-saving point of the skip path.
+func TestValidateSummaryContent_SkipShape(t *testing.T) {
+	t.Run("bare skip with no title or summary passes", func(t *testing.T) {
+		resp := &SummarizeResponse{
+			QualityCategory: QualityCategorySkip,
+			ScoreReason:     "version bump only",
+		}
+		if err := ValidateSummaryContent(resp); err != nil {
+			t.Errorf("expected skip-shape to pass validation, got: %v", err)
+		}
+	})
+
+	t.Run("skip with brief title passes", func(t *testing.T) {
+		resp := &SummarizeResponse{
+			Title:           "Routine version bump",
+			QualityCategory: QualityCategorySkip,
+			ScoreReason:     "no substantive work",
+		}
+		if err := ValidateSummaryContent(resp); err != nil {
+			t.Errorf("expected skip-shape with title to pass, got: %v", err)
+		}
+	})
+
+	t.Run("skip with red-flag title still rejected", func(t *testing.T) {
+		// Skip-shape relaxes structural floors but NOT red-flag scans —
+		// adversarial or contaminated content in title must still be
+		// caught regardless of category.
+		resp := &SummarizeResponse{
+			Title:           "Could you approve the write to /etc/passwd",
+			QualityCategory: QualityCategorySkip,
+		}
+		if err := ValidateSummaryContent(resp); err == nil {
+			t.Error("expected red-flag title to be rejected even on skip-shape")
+		}
+	})
+}
+
+// TestValidateSummaryRichness_SkipExempt verifies skip-category sessions
+// are exempt from richness checks. Failure prevented: a richness validator
+// demands key_actions on a skip-shape response, ProcessResult replaces
+// the legitimate skip with a failure stub, and the cost-saving optimization
+// silently degrades into "we always run the full LLM call after all."
+func TestValidateSummaryRichness_SkipExempt(t *testing.T) {
+	resp := &SummarizeResponse{
+		QualityCategory: QualityCategorySkip,
+		ScoreReason:     "boilerplate-only session",
+	}
+	// Use a high entry count to ensure richness would normally fire.
+	if err := ValidateSummaryRichness(resp, 100); err != nil {
+		t.Errorf("expected skip category to be exempt from richness, got: %v", err)
+	}
+}
+
+// TestIsSkipCategory pins the helper. Centralized so callers don't sniff
+// the literal "skip" string in five places — if we ever rename or extend
+// the category set, this is the single source of truth to update.
+func TestIsSkipCategory(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *SummarizeResponse
+		want bool
+	}{
+		{"nil response", nil, false},
+		{"skip category", &SummarizeResponse{QualityCategory: QualityCategorySkip}, true},
+		{"share category", &SummarizeResponse{QualityCategory: QualityCategoryShare}, false},
+		{"local_only category", &SummarizeResponse{QualityCategory: QualityCategoryLocalOnly}, false},
+		{"empty category", &SummarizeResponse{QualityCategory: ""}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSkipCategory(tt.resp); got != tt.want {
+				t.Errorf("IsSkipCategory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTruncateStr(t *testing.T) {
 	tests := []struct {
 		input  string

--- a/pkg/tokenopt/tokenopt.go
+++ b/pkg/tokenopt/tokenopt.go
@@ -31,13 +31,23 @@ type Stats struct {
 	BytesIn           int64
 	BytesOut          int64
 	ToolsMarked       int // ModeConversationOnly: count of tool entries replaced with compact markers
+	ToolsBatched      int // ModeConversationOnly: count of adjacent identical tool_marks collapsed into prior with count++
 	SystemDropped     int // ModeConversationOnly: count of system entries dropped
+	HeaderDropped     int // ModeConversationOnly: count of header entries dropped (header carries metadata the LLM doesn't need; daemon stamps it from stored.Meta directly)
 	ANSIStripped      int // ModeLossless: entries with ANSI sequences removed
 	ProgressCollapsed int // ModeLossless: entries with \r progress frames collapsed
 	ImagesElided      int // ModeLossless: base64 image payloads replaced
 	LargeReadsElided  int // ModeLossless: large Read tool_result bodies truncated
 	RemindersDeduped  int // ModeLossless: <system-reminder> blocks replaced with a ref
 	ToolResultsRefd   int // ModeLossless: tool_result bodies replaced with a tool_ref
+
+	// Token estimates use a ~4 chars/token heuristic from internal/tokens.
+	// They exist so callers can log a token-reduction number alongside the
+	// byte-reduction one. Tokens are the actual LLM cost driver; bytes are
+	// a proxy. Swap the estimator (or wire in a real BPE tokenizer) without
+	// changing any caller — the field shape stays stable.
+	TokensInEstimate  int64
+	TokensOutEstimate int64
 }
 
 // Reduction returns bytes saved and percentage. Safe to call when BytesIn is 0.
@@ -49,6 +59,18 @@ func (s Stats) Reduction() (saved int64, pct float64) {
 	return saved, float64(saved) / float64(s.BytesIn) * 100
 }
 
+// TokenReduction returns estimated tokens saved and percentage. The cost
+// dashboard wants this — bytes are a proxy, tokens are the actual LLM
+// cost. Code-heavy sessions tokenize at a different ratio than prose-heavy
+// ones, so byte-percentage trends mislead operators on cost.
+func (s Stats) TokenReduction() (saved int64, pct float64) {
+	saved = s.TokensInEstimate - s.TokensOutEstimate
+	if s.TokensInEstimate == 0 {
+		return saved, 0
+	}
+	return saved, float64(saved) / float64(s.TokensInEstimate) * 100
+}
+
 // Add accumulates other into s. Useful for aggregating across many sessions
 // (e.g., a daemon summarizing a nightly batch).
 func (s *Stats) Add(other Stats) {
@@ -57,13 +79,17 @@ func (s *Stats) Add(other Stats) {
 	s.BytesIn += other.BytesIn
 	s.BytesOut += other.BytesOut
 	s.ToolsMarked += other.ToolsMarked
+	s.ToolsBatched += other.ToolsBatched
 	s.SystemDropped += other.SystemDropped
+	s.HeaderDropped += other.HeaderDropped
 	s.ANSIStripped += other.ANSIStripped
 	s.ProgressCollapsed += other.ProgressCollapsed
 	s.ImagesElided += other.ImagesElided
 	s.LargeReadsElided += other.LargeReadsElided
 	s.RemindersDeduped += other.RemindersDeduped
 	s.ToolResultsRefd += other.ToolResultsRefd
+	s.TokensInEstimate += other.TokensInEstimate
+	s.TokensOutEstimate += other.TokensOutEstimate
 }
 
 // LogValue implements slog.LogValuer. Enables callers (CLI, daemon) to emit
@@ -71,15 +97,21 @@ func (s *Stats) Add(other Stats) {
 //
 //	slog.Info("token_optimize", "stats", stats)
 func (s Stats) LogValue() slog.Value {
-	_, pct := s.Reduction()
+	_, bytePct := s.Reduction()
+	_, tokPct := s.TokenReduction()
 	return slog.GroupValue(
 		slog.Int("entries_in", s.EntriesIn),
 		slog.Int("entries_out", s.EntriesOut),
 		slog.Int64("bytes_in", s.BytesIn),
 		slog.Int64("bytes_out", s.BytesOut),
-		slog.Float64("reduction_pct", pct),
+		slog.Float64("byte_reduction_pct", bytePct),
+		slog.Int64("tokens_in_est", s.TokensInEstimate),
+		slog.Int64("tokens_out_est", s.TokensOutEstimate),
+		slog.Float64("token_reduction_pct", tokPct),
 		slog.Int("tools_marked", s.ToolsMarked),
+		slog.Int("tools_batched", s.ToolsBatched),
 		slog.Int("system_dropped", s.SystemDropped),
+		slog.Int("header_dropped", s.HeaderDropped),
 		slog.Int("ansi_stripped", s.ANSIStripped),
 		slog.Int("progress_collapsed", s.ProgressCollapsed),
 		slog.Int("images_elided", s.ImagesElided),
@@ -93,10 +125,14 @@ func (s Stats) LogValue() slog.Value {
 type Mode int
 
 const (
-	// ModeConversationOnly (default) emits header + user + assistant entries
-	// verbatim and replaces every tool/system entry with a compact marker
-	// (name + brief gist of the input). Optimal for downstream summarization:
-	// the summarizer needs the conversation arc, not tool I/O.
+	// ModeConversationOnly (default) emits user + assistant entries verbatim,
+	// drops header and system entries, and replaces every tool entry with a
+	// bare `{type:"tool_mark"}` marker (or `{type:"tool_mark", count:N}`
+	// when adjacent tool entries collapse). The marker's only job is to tell
+	// the summarizer "the agent acted between these two messages, N times" —
+	// no tool_name, no input gist, no output. Optimal for downstream
+	// summarization: the summarizer needs the conversation arc, not tool I/O,
+	// and assistant prose already names the concrete actions ("I'll edit X").
 	ModeConversationOnly Mode = 0
 
 	// ModeLossless keeps every entry but applies content-level transforms
@@ -177,6 +213,24 @@ func CompressWith(r io.Reader, w io.Writer, opts Options) (Stats, error) {
 	br := bufio.NewReader(r)
 	bw := bufio.NewWriter(w)
 
+	// emit writes out (followed by a newline) and updates byte/token/entry
+	// stats. Centralized so the four call sites — transform's actEmit,
+	// pending flush before a non-batchable emission, EOF flush, and the
+	// (currently absent) error-recovery path — share one accounting code
+	// path. Drift here is silently corrupted telemetry.
+	emit := func(out []byte) error {
+		if _, werr := bw.Write(out); werr != nil {
+			return werr
+		}
+		if _, werr := bw.Write([]byte{'\n'}); werr != nil {
+			return werr
+		}
+		stats.EntriesOut++
+		stats.BytesOut += int64(len(out)) + 1
+		stats.TokensOutEstimate += estimateTokens(out)
+		return nil
+	}
+
 	seq := 0
 	for {
 		line, err := br.ReadBytes('\n')
@@ -191,20 +245,36 @@ func CompressWith(r io.Reader, w io.Writer, opts Options) (Stats, error) {
 			}
 			stats.EntriesIn++
 			stats.BytesIn += int64(len(line))
+			stats.TokensInEstimate += estimateTokens(line)
 
-			out, emit, terr := state.transform(entryBytes, seq, &stats)
+			out, action, terr := state.transform(entryBytes, seq, &stats)
 			if terr != nil {
 				return stats, fmt.Errorf("entry %d: %w", seq, terr)
 			}
-			if emit {
-				if _, werr := bw.Write(out); werr != nil {
+
+			switch action {
+			case actDrop:
+				// Drop quietly. Pending tool_mark (if any) STAYS pending —
+				// dropping a system or header entry is not a real
+				// interruption between two identical tool calls; the
+				// agent's behavior is what we're modeling, and a system
+				// reminder appearing mid-batch is not a behavior change.
+			case actHold:
+				// transform updated state.pending; nothing to write yet.
+			case actEmit:
+				// Anything that emits flushes any held tool_mark first so
+				// adjacency in the output stream matches adjacency in the
+				// agent's behavior. user/assistant turns are real
+				// interruptions; do not let them appear after a batched
+				// tool_mark that semantically came after them.
+				if pending := state.flushPending(&stats); pending != nil {
+					if werr := emit(pending); werr != nil {
+						return stats, werr
+					}
+				}
+				if werr := emit(out); werr != nil {
 					return stats, werr
 				}
-				if _, werr := bw.Write([]byte{'\n'}); werr != nil {
-					return stats, werr
-				}
-				stats.EntriesOut++
-				stats.BytesOut += int64(len(out)) + 1
 			}
 		}
 		if err != nil {
@@ -212,6 +282,15 @@ func CompressWith(r io.Reader, w io.Writer, opts Options) (Stats, error) {
 				break
 			}
 			return stats, err
+		}
+	}
+
+	// EOF — flush any tool_mark still held in pending. Without this, a
+	// session that ENDS on a run of identical tool calls would silently
+	// drop the entire run from the optimized output.
+	if pending := state.flushPending(&stats); pending != nil {
+		if werr := emit(pending); werr != nil {
+			return stats, werr
 		}
 	}
 
@@ -235,9 +314,11 @@ type entry struct {
 	IsError    bool            `json:"is_error,omitempty"`
 	Metadata   json.RawMessage `json:"metadata,omitempty"`
 
-	// Brief is emitted in ModeConversationOnly on tool_mark entries: a compact
-	// gist of the tool input (e.g., the bash command, file path, grep pattern).
-	Brief string `json:"brief,omitempty"`
+	// Count is set on tool_mark entries when adjacent tool_marks were
+	// collapsed into one entry. A missing/zero count means 1 (single
+	// occurrence). Lets the summarizer see "agent did N tool things
+	// between these messages" without N redundant entries.
+	Count int `json:"count,omitempty"`
 
 	// ref fields for ModeLossless tool_ref entries.
 	RefType   string `json:"ref_type,omitempty"`
@@ -251,3 +332,41 @@ func hashContent(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:12]) // 12 bytes = 96 bits, plenty for in-session dedup
 }
+
+// estimateTokens is the same ~4-chars-per-token heuristic pkg/tokenstrip
+// uses (and that internal/tokens.EstimateTokens documents). Vendored here
+// rather than imported because pkg/tokenopt's package doc advertises
+// stdlib-only dependencies. Swap for a real BPE tokenizer in one place
+// when accuracy matters more than dependency hygiene.
+func estimateTokens(b []byte) int64 {
+	if len(b) == 0 {
+		return 0
+	}
+	// Integer division rounds down; any non-empty input deserves at
+	// least 1 token, otherwise non-empty content can produce TokensIn=0
+	// and skew TokenReduction percentages.
+	t := int64(len(b)) / 4
+	if t == 0 {
+		return 1
+	}
+	return t
+}
+
+// emitAction tells the Compress outer loop what to do with a transformed
+// entry. Three states because tool_mark batching needs a way to "hold this
+// entry, see if the next one matches" that isn't either drop or emit.
+type emitAction int
+
+const (
+	// actDrop: this entry is gone from the stream (system/header).
+	// Pending tool_mark (if any) is NOT flushed — see Compress for why.
+	actDrop emitAction = iota
+
+	// actEmit: emit the returned bytes. Compress flushes any pending
+	// tool_mark FIRST so adjacency is preserved.
+	actEmit
+
+	// actHold: state.pending was updated; outer loop should not write
+	// anything this iteration. Used exclusively by tool_mark batching.
+	actHold
+)

--- a/pkg/tokenopt/tokenopt.go
+++ b/pkg/tokenopt/tokenopt.go
@@ -126,13 +126,21 @@ type Mode int
 
 const (
 	// ModeConversationOnly (default) emits user + assistant entries verbatim,
-	// drops header and system entries, and replaces every tool entry with a
-	// bare `{type:"tool_mark"}` marker (or `{type:"tool_mark", count:N}`
-	// when adjacent tool entries collapse). The marker's only job is to tell
-	// the summarizer "the agent acted between these two messages, N times" —
-	// no tool_name, no input gist, no output. Optimal for downstream
-	// summarization: the summarizer needs the conversation arc, not tool I/O,
-	// and assistant prose already names the concrete actions ("I'll edit X").
+	// drops header and system entries, and selectively replaces tool entries:
+	//
+	//   - Tool calls with a non-empty `description` field in tool_input
+	//     (Bash, Agent, Task, WebFetch, ...) emit
+	//     `{type:"tool_mark", description:"..."}`. Adjacent calls with the
+	//     same description collapse via the count field.
+	//
+	//   - Tool calls without a description (Edit, Read, Write, Glob, Grep, ...)
+	//     produce NO tool_mark at all. Their actions are recoverable from
+	//     surrounding assistant prose ("I'll edit foo.go and run tests"),
+	//     so the marker would only be redundant noise.
+	//
+	// The descriptions are agent-authored intent strings — high
+	// signal-per-byte, and far cheaper than the previous 120-char brief
+	// extracted heuristically from the most-meaningful input field.
 	ModeConversationOnly Mode = 0
 
 	// ModeLossless keeps every entry but applies content-level transforms
@@ -314,10 +322,17 @@ type entry struct {
 	IsError    bool            `json:"is_error,omitempty"`
 	Metadata   json.RawMessage `json:"metadata,omitempty"`
 
-	// Count is set on tool_mark entries when adjacent tool_marks were
-	// collapsed into one entry. A missing/zero count means 1 (single
-	// occurrence). Lets the summarizer see "agent did N tool things
-	// between these messages" without N redundant entries.
+	// Description is the agent-authored intent string for a tool call,
+	// emitted only on tool_mark entries when the source tool_input had a
+	// non-empty `description` field. Tools that don't carry a description
+	// (Edit, Read, Write, Glob, Grep, etc.) produce no tool_mark at all —
+	// their actions are recoverable from surrounding assistant prose.
+	Description string `json:"description,omitempty"`
+
+	// Count is set on tool_mark entries when adjacent tool_marks with the
+	// same description were collapsed into one entry. A missing/zero count
+	// means 1 (single occurrence). Lets the summarizer see "agent did
+	// $description ×N" without N redundant entries.
 	Count int `json:"count,omitempty"`
 
 	// ref fields for ModeLossless tool_ref entries.

--- a/pkg/tokenopt/tokenopt_test.go
+++ b/pkg/tokenopt/tokenopt_test.go
@@ -237,6 +237,8 @@ func TestCompress_MalformedJSONLinesPassThrough(t *testing.T) {
 func TestConversationOnly_KeepsUserAndAssistantDropsToolsAndSystem(t *testing.T) {
 	userLine, _ := json.Marshal(map[string]any{"type": "user", "content": "fix the lint errors"})
 	asstLine, _ := json.Marshal(map[string]any{"type": "assistant", "content": "I'll run make lint first"})
+	// Bash carries a `description` field — emits a tool_mark with that
+	// description as the only narrative field.
 	toolInput, _ := json.Marshal(map[string]any{"command": "make lint", "description": "run lint"})
 	toolLine, _ := json.Marshal(map[string]any{"type": "tool", "tool_name": "Bash", "tool_input": string(toolInput)})
 	sysLine, _ := json.Marshal(map[string]any{"type": "system", "content": "reminder: commit soon"})
@@ -259,8 +261,10 @@ func TestConversationOnly_KeepsUserAndAssistantDropsToolsAndSystem(t *testing.T)
 	if stats.ToolsMarked != 1 {
 		t.Errorf("expected ToolsMarked=1, got %d", stats.ToolsMarked)
 	}
+	// SystemDropped counts the actual system entry plus any
+	// description-less tool drops (none here, since Bash had a description).
 	if stats.SystemDropped != 1 {
-		t.Errorf("expected SystemDropped=1, got %d", stats.SystemDropped)
+		t.Errorf("expected SystemDropped=1 (the system entry only), got %d", stats.SystemDropped)
 	}
 	if stats.HeaderDropped != 1 {
 		t.Errorf("expected HeaderDropped=1, got %d", stats.HeaderDropped)
@@ -276,21 +280,83 @@ func TestConversationOnly_KeepsUserAndAssistantDropsToolsAndSystem(t *testing.T)
 		t.Errorf("assistant content not verbatim: %q", asst.Content)
 	}
 
-	// Tool entry becomes a bare tool_mark — no tool_name, no brief, no
-	// is_error. The summarizer recovers what was done from surrounding
-	// assistant prose; the marker only signals the agent paused to act.
+	// Tool entry becomes a tool_mark carrying ONLY the description.
+	// Failure prevented: a regression that re-introduces tool_name, brief,
+	// or raw input fields silently re-inflates the optimized stream.
 	var mark entry
 	_ = json.Unmarshal([]byte(lines[2]), &mark)
 	if mark.Type != "tool_mark" {
 		t.Errorf("tool_mark type mismatch: %+v", mark)
 	}
+	if mark.Description != "run lint" {
+		t.Errorf("tool_mark description=%q, want %q", mark.Description, "run lint")
+	}
 	if mark.ToolName != "" {
 		t.Errorf("tool_mark must not carry tool_name (cost-driven; see ModeConversationOnly doc): %+v", mark)
 	}
-	// Verify the JSON shape directly — Brief was removed from the entry
-	// struct; assert the wire format never carries a "brief" key.
-	if strings.Contains(lines[2], "\"brief\"") {
-		t.Errorf("tool_mark JSON must not include brief field: %s", lines[2])
+	// Wire-format guards against silent re-inflation.
+	for _, banned := range []string{"\"brief\"", "\"tool_name\"", "\"tool_input\"", "\"tool_output\"", "\"is_error\""} {
+		if strings.Contains(lines[2], banned) {
+			t.Errorf("tool_mark JSON must not include %s: %s", banned, lines[2])
+		}
+	}
+}
+
+// TestConversationOnly_ToolWithoutDescriptionDropped verifies that tool
+// entries lacking a `description` field in tool_input (Edit, Read, Write,
+// Glob, Grep, ...) are dropped from the optimized stream entirely.
+//
+// Failure prevented: a regression that re-emits content-free tool_marks
+// for description-less tools, inflating the optimized stream with markers
+// the summarizer can't extract any narrative from anyway.
+func TestConversationOnly_ToolWithoutDescriptionDropped(t *testing.T) {
+	asst, _ := json.Marshal(map[string]any{"type": "assistant", "content": "ok"})
+	editInput, _ := json.Marshal(map[string]any{"file_path": "/foo.go", "old_string": "x", "new_string": "y"})
+	editLine, _ := json.Marshal(map[string]any{"type": "tool", "tool_name": "Edit", "tool_input": string(editInput)})
+	asst2, _ := json.Marshal(map[string]any{"type": "assistant", "content": "done"})
+	input := string(asst) + "\n" + string(editLine) + "\n" + string(asst2) + "\n"
+
+	var out bytes.Buffer
+	stats, err := Compress(strings.NewReader(input), &out)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+
+	// Output should be assistant + assistant — the Edit dropped entirely.
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 output lines (asst + asst, no tool_mark), got %d: %v", len(lines), lines)
+	}
+	if strings.Contains(out.String(), "tool_mark") {
+		t.Errorf("description-less tool must produce no tool_mark; output: %s", out.String())
+	}
+	// ToolsMarked still increments (we observed a tool entry); the
+	// drop is recorded under SystemDropped (the "dropped without
+	// replacement" counter).
+	if stats.ToolsMarked != 1 {
+		t.Errorf("ToolsMarked=%d, want 1", stats.ToolsMarked)
+	}
+}
+
+// TestConversationOnly_DescriptionTrimmedAndCapped verifies that the
+// description field is trimmed of surrounding whitespace and capped at
+// 200 chars to bound pathological agent output.
+func TestConversationOnly_DescriptionTrimmedAndCapped(t *testing.T) {
+	long := strings.Repeat("very long description ", 30) // ~660 chars
+	toolInput, _ := json.Marshal(map[string]any{"description": "  " + long + "  "})
+	toolLine, _ := json.Marshal(map[string]any{"type": "tool", "tool_name": "Agent", "tool_input": string(toolInput)})
+
+	var out bytes.Buffer
+	if _, err := Compress(strings.NewReader(string(toolLine)+"\n"), &out); err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+	var mark entry
+	_ = json.Unmarshal(bytes.TrimSpace(out.Bytes()), &mark)
+	if len(mark.Description) > 200 {
+		t.Errorf("description not capped at 200 chars: len=%d", len(mark.Description))
+	}
+	if strings.HasPrefix(mark.Description, " ") || strings.HasSuffix(mark.Description, " ") {
+		t.Errorf("description not whitespace-trimmed: %q", mark.Description)
 	}
 }
 
@@ -332,39 +398,46 @@ func TestConversationOnly_HeaderDropped(t *testing.T) {
 	}
 }
 
-// TestConversationOnly_ToolMarkBatching verifies that an entire run of
-// tool entries between assistant turns collapses into a single bare
-// tool_mark with a count field. Pre-slim, distinct tool_name+brief groups
-// stayed separate; today every tool entry produces an identical bare mark,
-// so all 6 calls in a single run collapse into one entry with count=6.
+// TestConversationOnly_ToolMarkBatching verifies the description-batching
+// pipeline:
 //
-// Failure prevented: a regression that re-introduces per-call tool_marks
-// (or worse, leaks tool_name/brief into the optimized stream) silently
-// re-inflates the input-token bill on every delegated finalize.
+//   - Edits without descriptions drop entirely (no tool_mark)
+//   - Adjacent Bash calls with identical descriptions collapse into one
+//     tool_mark with count=N
+//   - Bash calls with different descriptions stay as separate marks
+//
+// Failure prevented: a regression that batches across distinct
+// descriptions (collapsing "run tests" + "run lint" into a single
+// indistinguishable mark) loses real intent signal in the summary;
+// or one that fails to drop description-less tools, re-inflating the
+// stream with content-free markers.
 func TestConversationOnly_ToolMarkBatching(t *testing.T) {
 	mk := func(m map[string]any) string {
 		b, _ := json.Marshal(m)
 		return string(b)
 	}
+	// description-less Edit: should drop entirely
 	editFoo := mk(map[string]any{
 		"type": "tool", "tool_name": "Edit",
 		"tool_input": `{"file_path":"/foo.go"}`,
 	})
-	editBar := mk(map[string]any{
-		"type": "tool", "tool_name": "Edit",
-		"tool_input": `{"file_path":"/bar.go"}`,
-	})
-	bash := mk(map[string]any{
+	// Bash with description "run tests": batchable run
+	bashTests := mk(map[string]any{
 		"type": "tool", "tool_name": "Bash",
-		"tool_input": `{"command":"make test"}`,
+		"tool_input": `{"command":"make test","description":"run tests"}`,
+	})
+	// Bash with description "run lint": different run, must NOT batch with above
+	bashLint := mk(map[string]any{
+		"type": "tool", "tool_name": "Bash",
+		"tool_input": `{"command":"make lint","description":"run lint"}`,
 	})
 
 	input := strings.Join([]string{
 		mk(map[string]any{"type": "user", "content": "go"}),
 		mk(map[string]any{"type": "assistant", "content": "ok"}),
-		editFoo, editFoo, editFoo,
-		editBar,
-		bash, bash,
+		editFoo, editFoo, editFoo, // 3 description-less Edits → all dropped
+		bashTests, bashTests, // 2 same-description → collapse to count=2
+		bashLint, // different description → separate mark
 		mk(map[string]any{"type": "assistant", "content": "done"}),
 		"",
 	}, "\n")
@@ -375,30 +448,27 @@ func TestConversationOnly_ToolMarkBatching(t *testing.T) {
 		t.Fatalf("Compress: %v", err)
 	}
 
-	// 9 input entries → user + assistant + tool_mark(count=6) + assistant
-	// = 4 output entries. All 6 tool calls between the two assistant turns
-	// are now indistinguishable (no tool_name, no brief), so they collapse
-	// into a single mark.
-	if stats.EntriesOut != 4 {
-		t.Errorf("EntriesOut=%d, want 4 (user + asst + bare tool_mark + asst)", stats.EntriesOut)
+	// 9 input entries → user + asst + tool_mark("run tests" ×2) +
+	// tool_mark("run lint") + asst = 5 output entries. The 3 Edits drop.
+	if stats.EntriesOut != 5 {
+		t.Errorf("EntriesOut=%d, want 5", stats.EntriesOut)
 	}
 	if stats.ToolsMarked != 6 {
-		t.Errorf("ToolsMarked=%d, want 6 (counts every input tool entry)", stats.ToolsMarked)
+		t.Errorf("ToolsMarked=%d, want 6 (counts every input tool entry, including dropped ones)", stats.ToolsMarked)
 	}
-	if stats.ToolsBatched != 5 {
-		t.Errorf("ToolsBatched=%d, want 5 (6 marks, 1 emitted, 5 absorbed)", stats.ToolsBatched)
+	// ToolsBatched: only the second bashTests is absorbed into pending
+	// (1 absorption). The Edits drop without going through pending.
+	if stats.ToolsBatched != 1 {
+		t.Errorf("ToolsBatched=%d, want 1 (only 1 same-description duplicate)", stats.ToolsBatched)
 	}
 
-	// Decode emitted lines and verify the single tool_mark carries
-	// count=6 and ZERO per-call detail.
 	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
-	var foundMark bool
+	descriptions := map[string]int{} // description → count
 	for _, line := range lines {
 		if !strings.Contains(line, `"type":"tool_mark"`) {
 			continue
 		}
-		foundMark = true
-		// Must NOT contain any per-call detail.
+		// Must NOT contain any banned per-call detail.
 		for _, banned := range []string{"\"tool_name\"", "\"brief\"", "\"tool_input\"", "\"tool_output\"", "\"is_error\""} {
 			if strings.Contains(line, banned) {
 				t.Errorf("tool_mark must not carry %s; got: %s", banned, line)
@@ -408,12 +478,17 @@ func TestConversationOnly_ToolMarkBatching(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
 			t.Fatalf("unmarshal %q: %v", line, err)
 		}
-		if e.Count != 6 {
-			t.Errorf("tool_mark count=%d, want 6 (3 editFoo + 1 editBar + 2 bash collapsed into one mark)", e.Count)
+		c := e.Count
+		if c == 0 {
+			c = 1 // omitted count == 1
 		}
+		descriptions[e.Description] = c
 	}
-	if !foundMark {
-		t.Errorf("expected exactly one tool_mark entry; got lines: %v", lines)
+	if descriptions["run tests"] != 2 {
+		t.Errorf("run tests count=%d, want 2 (two adjacent same-description calls collapsed)", descriptions["run tests"])
+	}
+	if descriptions["run lint"] != 1 {
+		t.Errorf("run lint count=%d, want 1 (single occurrence)", descriptions["run lint"])
 	}
 }
 

--- a/pkg/tokenopt/tokenopt_test.go
+++ b/pkg/tokenopt/tokenopt_test.go
@@ -251,9 +251,10 @@ func TestConversationOnly_KeepsUserAndAssistantDropsToolsAndSystem(t *testing.T)
 	}
 
 	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
-	// header + user + assistant + tool_mark (system dropped) = 4
-	if len(lines) != 4 {
-		t.Fatalf("expected 4 output lines, got %d: %v", len(lines), lines)
+	// user + assistant + tool_mark (header AND system both dropped in
+	// ConversationOnly) = 3
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 output lines, got %d: %v", len(lines), lines)
 	}
 	if stats.ToolsMarked != 1 {
 		t.Errorf("expected ToolsMarked=1, got %d", stats.ToolsMarked)
@@ -261,22 +262,197 @@ func TestConversationOnly_KeepsUserAndAssistantDropsToolsAndSystem(t *testing.T)
 	if stats.SystemDropped != 1 {
 		t.Errorf("expected SystemDropped=1, got %d", stats.SystemDropped)
 	}
-	if stats.EntriesOut != 4 {
-		t.Errorf("expected EntriesOut=4, got %d", stats.EntriesOut)
+	if stats.HeaderDropped != 1 {
+		t.Errorf("expected HeaderDropped=1, got %d", stats.HeaderDropped)
+	}
+	if stats.EntriesOut != 3 {
+		t.Errorf("expected EntriesOut=3, got %d", stats.EntriesOut)
 	}
 
 	// Assistant passes through verbatim.
 	var asst entry
-	_ = json.Unmarshal([]byte(lines[2]), &asst)
+	_ = json.Unmarshal([]byte(lines[1]), &asst)
 	if asst.Content != "I'll run make lint first" {
 		t.Errorf("assistant content not verbatim: %q", asst.Content)
 	}
 
-	// Tool entry becomes tool_mark with a brief.
+	// Tool entry becomes a bare tool_mark — no tool_name, no brief, no
+	// is_error. The summarizer recovers what was done from surrounding
+	// assistant prose; the marker only signals the agent paused to act.
 	var mark entry
-	_ = json.Unmarshal([]byte(lines[3]), &mark)
-	if mark.Type != "tool_mark" || mark.ToolName != "Bash" || mark.Brief != "make lint" {
-		t.Errorf("tool_mark mismatch: %+v", mark)
+	_ = json.Unmarshal([]byte(lines[2]), &mark)
+	if mark.Type != "tool_mark" {
+		t.Errorf("tool_mark type mismatch: %+v", mark)
+	}
+	if mark.ToolName != "" {
+		t.Errorf("tool_mark must not carry tool_name (cost-driven; see ModeConversationOnly doc): %+v", mark)
+	}
+	// Verify the JSON shape directly — Brief was removed from the entry
+	// struct; assert the wire format never carries a "brief" key.
+	if strings.Contains(lines[2], "\"brief\"") {
+		t.Errorf("tool_mark JSON must not include brief field: %s", lines[2])
+	}
+}
+
+// TestConversationOnly_HeaderDropped verifies header entries are dropped
+// from the optimized stream in ConversationOnly mode. Failure prevented:
+// silent regression that puts the ~50-token header back into every
+// summarization prompt — wasted tokens with zero downstream consumer.
+// Failure prevented (more important): header NOT dropped from
+// ModeLossless, where replay/debug consumers expect every entry.
+func TestConversationOnly_HeaderDropped(t *testing.T) {
+	hdr := `{"type":"header","metadata":{"agent_type":"claude-code","model":"claude-sonnet-4","ox_version":"0.7.1"}}`
+	user, _ := json.Marshal(map[string]any{"type": "user", "content": "hi"})
+	asst, _ := json.Marshal(map[string]any{"type": "assistant", "content": "hello"})
+	input := hdr + "\n" + string(user) + "\n" + string(asst) + "\n"
+
+	var out bytes.Buffer
+	stats, err := Compress(strings.NewReader(input), &out)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+	if stats.HeaderDropped != 1 {
+		t.Errorf("ConversationOnly: HeaderDropped=%d, want 1", stats.HeaderDropped)
+	}
+	if strings.Contains(out.String(), `"type":"header"`) {
+		t.Errorf("ConversationOnly: header survived in output: %s", out.String())
+	}
+
+	// Lossless mode preserves header.
+	var outL bytes.Buffer
+	statsL, err := CompressWith(strings.NewReader(input), &outL, Options{Mode: ModeLossless})
+	if err != nil {
+		t.Fatalf("CompressWith Lossless: %v", err)
+	}
+	if statsL.HeaderDropped != 0 {
+		t.Errorf("Lossless: HeaderDropped=%d, want 0", statsL.HeaderDropped)
+	}
+	if !strings.Contains(outL.String(), `"type":"header"`) {
+		t.Errorf("Lossless: header missing from output: %s", outL.String())
+	}
+}
+
+// TestConversationOnly_ToolMarkBatching verifies that an entire run of
+// tool entries between assistant turns collapses into a single bare
+// tool_mark with a count field. Pre-slim, distinct tool_name+brief groups
+// stayed separate; today every tool entry produces an identical bare mark,
+// so all 6 calls in a single run collapse into one entry with count=6.
+//
+// Failure prevented: a regression that re-introduces per-call tool_marks
+// (or worse, leaks tool_name/brief into the optimized stream) silently
+// re-inflates the input-token bill on every delegated finalize.
+func TestConversationOnly_ToolMarkBatching(t *testing.T) {
+	mk := func(m map[string]any) string {
+		b, _ := json.Marshal(m)
+		return string(b)
+	}
+	editFoo := mk(map[string]any{
+		"type": "tool", "tool_name": "Edit",
+		"tool_input": `{"file_path":"/foo.go"}`,
+	})
+	editBar := mk(map[string]any{
+		"type": "tool", "tool_name": "Edit",
+		"tool_input": `{"file_path":"/bar.go"}`,
+	})
+	bash := mk(map[string]any{
+		"type": "tool", "tool_name": "Bash",
+		"tool_input": `{"command":"make test"}`,
+	})
+
+	input := strings.Join([]string{
+		mk(map[string]any{"type": "user", "content": "go"}),
+		mk(map[string]any{"type": "assistant", "content": "ok"}),
+		editFoo, editFoo, editFoo,
+		editBar,
+		bash, bash,
+		mk(map[string]any{"type": "assistant", "content": "done"}),
+		"",
+	}, "\n")
+
+	var out bytes.Buffer
+	stats, err := Compress(strings.NewReader(input), &out)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+
+	// 9 input entries → user + assistant + tool_mark(count=6) + assistant
+	// = 4 output entries. All 6 tool calls between the two assistant turns
+	// are now indistinguishable (no tool_name, no brief), so they collapse
+	// into a single mark.
+	if stats.EntriesOut != 4 {
+		t.Errorf("EntriesOut=%d, want 4 (user + asst + bare tool_mark + asst)", stats.EntriesOut)
+	}
+	if stats.ToolsMarked != 6 {
+		t.Errorf("ToolsMarked=%d, want 6 (counts every input tool entry)", stats.ToolsMarked)
+	}
+	if stats.ToolsBatched != 5 {
+		t.Errorf("ToolsBatched=%d, want 5 (6 marks, 1 emitted, 5 absorbed)", stats.ToolsBatched)
+	}
+
+	// Decode emitted lines and verify the single tool_mark carries
+	// count=6 and ZERO per-call detail.
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	var foundMark bool
+	for _, line := range lines {
+		if !strings.Contains(line, `"type":"tool_mark"`) {
+			continue
+		}
+		foundMark = true
+		// Must NOT contain any per-call detail.
+		for _, banned := range []string{"\"tool_name\"", "\"brief\"", "\"tool_input\"", "\"tool_output\"", "\"is_error\""} {
+			if strings.Contains(line, banned) {
+				t.Errorf("tool_mark must not carry %s; got: %s", banned, line)
+			}
+		}
+		var e entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		if e.Count != 6 {
+			t.Errorf("tool_mark count=%d, want 6 (3 editFoo + 1 editBar + 2 bash collapsed into one mark)", e.Count)
+		}
+	}
+	if !foundMark {
+		t.Errorf("expected exactly one tool_mark entry; got lines: %v", lines)
+	}
+}
+
+// TestConversationOnly_TokenEstimateSane verifies TokensInEstimate and
+// TokensOutEstimate are populated and reflect a real reduction.
+// Failure prevented: telemetry reports zero token counts, breaking the
+// cost dashboard that downstream beads (#1, #2) depend on.
+func TestConversationOnly_TokenEstimateSane(t *testing.T) {
+	mk := func(m map[string]any) string {
+		b, _ := json.Marshal(m)
+		return string(b)
+	}
+	bigInput, _ := json.Marshal(map[string]any{"command": strings.Repeat("echo x; ", 200)})
+	tool := mk(map[string]any{
+		"type": "tool", "tool_name": "Bash", "tool_input": string(bigInput),
+	})
+	input := strings.Join([]string{
+		mk(map[string]any{"type": "user", "content": "go"}),
+		tool, tool, tool, tool, tool,
+		"",
+	}, "\n")
+
+	var out bytes.Buffer
+	stats, err := Compress(strings.NewReader(input), &out)
+	if err != nil {
+		t.Fatalf("Compress: %v", err)
+	}
+	if stats.TokensInEstimate <= 0 {
+		t.Errorf("TokensInEstimate=%d, want >0", stats.TokensInEstimate)
+	}
+	if stats.TokensOutEstimate <= 0 {
+		t.Errorf("TokensOutEstimate=%d, want >0", stats.TokensOutEstimate)
+	}
+	if stats.TokensOutEstimate >= stats.TokensInEstimate {
+		t.Errorf("expected token reduction; in=%d out=%d", stats.TokensInEstimate, stats.TokensOutEstimate)
+	}
+	saved, pct := stats.TokenReduction()
+	if saved <= 0 || pct <= 0 {
+		t.Errorf("TokenReduction reports no savings: saved=%d pct=%.1f", saved, pct)
 	}
 }
 
@@ -313,30 +489,6 @@ func TestConversationOnly_ReducesBytesSubstantially(t *testing.T) {
 	}
 	if stats.ToolsMarked != 20 {
 		t.Errorf("expected ToolsMarked=20, got %d", stats.ToolsMarked)
-	}
-}
-
-func TestBriefForTool(t *testing.T) {
-	cases := []struct {
-		name       string
-		tool       string
-		input      string
-		wantSubstr string
-	}{
-		{"bash command", "Bash", `{"command":"make lint","description":"x"}`, "make lint"},
-		{"read file_path", "Read", `{"file_path":"/a/b.go","limit":50}`, "/a/b.go"},
-		{"grep pattern", "Grep", `{"pattern":"foo.*bar","path":"."}`, "foo.*bar"},
-		{"agent description", "Agent", `{"description":"fix bugs","prompt":"long..."}`, "fix bugs"},
-		{"unknown tool falls back to first string", "WeirdTool", `{"x":"hello","y":1}`, "hello"},
-		{"truncates long briefs", "Bash", `{"command":"` + strings.Repeat("x", 200) + `"}`, "…"},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := briefForTool(c.tool, c.input)
-			if !strings.Contains(got, c.wantSubstr) {
-				t.Errorf("got %q, want substring %q", got, c.wantSubstr)
-			}
-		})
 	}
 }
 
@@ -412,24 +564,6 @@ func TestCompressLossless_PreservesUnknownTopLevelFields(t *testing.T) {
 	// Content was mutated (ANSI stripped), so that field should reflect change.
 	if s, _ := got["content"].(string); strings.Contains(s, "\x1b") {
 		t.Errorf("expected ANSI stripped from content, got: %q", s)
-	}
-}
-
-// TestBriefForTool_DeterministicForUnknownTool verifies unknown-tool briefs
-// don't flip based on Go's randomized map iteration.
-func TestBriefForTool_DeterministicForUnknownTool(t *testing.T) {
-	input := `{"z_last":"zeta","a_first":"alpha","m_mid":"mu"}`
-	// Many invocations — same input must produce same brief every time.
-	first := briefForTool("UnknownTool", input)
-	for i := 0; i < 50; i++ {
-		got := briefForTool("UnknownTool", input)
-		if got != first {
-			t.Fatalf("non-deterministic: iter %d got %q, first was %q", i, got, first)
-		}
-	}
-	// Sorted-key order means "a_first" wins.
-	if first != "alpha" {
-		t.Errorf("expected sorted-key 'alpha' to be selected, got %q", first)
 	}
 }
 

--- a/pkg/tokenopt/transforms.go
+++ b/pkg/tokenopt/transforms.go
@@ -91,49 +91,58 @@ func (s *state) transform(line []byte, seq int, stats *Stats) ([]byte, emitActio
 	return out, actEmit, err
 }
 
-// transformConversationOnly keeps assistant turns verbatim, replaces tool
-// entries with bare-marker placeholders, and drops system entries.
+// transformConversationOnly keeps assistant turns verbatim, selectively
+// replaces tool entries with description-bearing tool_marks, and drops
+// system entries.
 //
-// tool_mark shape today is intentionally minimal: just `{type:"tool_mark"}`,
-// optionally `{type:"tool_mark", count:N}` when adjacent calls collapse.
-// No tool_name, no brief, no is_error.
+// Tool entries with a non-empty `description` in tool_input (Bash, Agent,
+// Task, WebFetch, ...) emit `{type:"tool_mark", description:"..."}` — the
+// agent-authored intent string is high-signal narrative scaffolding that's
+// already a one-line summary of WHY the tool was invoked. Adjacent calls
+// with the same description collapse via the count field (e.g., a polling
+// loop that keeps re-running the same probe).
 //
-// Reasoning: the brief was a 120-char-per-call tax (6–11K input tokens on
-// real sessions) that paid back unevenly. Most of what the brief carried —
-// the bash command, the file path, the grep pattern — is also in the
-// surrounding assistant prose ("I'll edit foo.go and run tests"). What the
-// summarizer actually needs from these entries is *narrative scaffolding*:
-// "the agent paused and acted between these two messages, N times." A bare
-// `tool_mark` (with `count` when batched) preserves that signal at <1% of
-// the previous cost. If `quality_score` / `judge_overall` regresses on
-// tool-heavy sessions when this lands, the next step is option 3 from the
-// design discussion: a single tail digest of tool_name → count.
+// Tool entries WITHOUT a description (Edit, Read, Write, Glob, Grep, ...)
+// produce no tool_mark at all. Those tools' actions are reliably narrated
+// in surrounding assistant prose ("I'll edit foo.go and run tests"), so a
+// content-free marker would just be noise.
+//
+// The previous shape (bare `{type:"tool_mark"}` for every tool, no detail)
+// was maximally aggressive but threw away free narrative — descriptions
+// cost very little and recover meaningful key_actions signal that pure
+// assistant prose can miss (e.g., when the agent runs commands silently).
+// If `quality_score` / `judge_overall` regresses on description-heavy
+// sessions, the next step is a single tail digest of description → count
+// rather than per-call entries.
 func (s *state) transformConversationOnly(e *entry, line []byte, stats *Stats) ([]byte, emitAction, error) {
 	switch e.Type {
 	case "assistant":
 		// Pass through verbatim — assistant prose IS the narrative.
 		return line, actEmit, nil
 	case "tool":
-		// Always the same shape — no per-call detail. Every tool entry
-		// produces an identical mark, which means adjacency batching
-		// collapses every contiguous run of tool calls between assistant
-		// turns into a single `{type:"tool_mark", count:N}` entry.
-		mark := entry{Type: "tool_mark"}
 		stats.ToolsMarked++
+		desc := descriptionForTool(e.ToolInput)
+		if desc == "" {
+			// No description — drop the entry entirely. Most editor /
+			// reader tools fall here (Edit, Read, Write, Glob, Grep);
+			// their actions are recovered from assistant prose, so a
+			// content-free tool_mark would only inflate token cost.
+			stats.SystemDropped++ // reuse the "dropped without replacement" counter
+			return nil, actDrop, nil
+		}
+		mark := entry{Type: "tool_mark", Description: desc}
 
 		if s.pending != nil {
-			// All marks are identical now, so every continuation is a
-			// batchable duplicate. The pendingMatches check is kept as a
-			// no-op call site for symmetry with other modes / future
-			// variants that may reintroduce per-call distinctions.
+			// Batch only when the description matches exactly (e.g., a
+			// retry loop running the same probe). Different descriptions
+			// stay separate — they represent distinct intents and the
+			// summarizer should see them as such.
 			if pendingMatches(s.pending, &mark) {
 				s.pendingCount++
 				stats.ToolsBatched++
 				return nil, actHold, nil
 			}
-			// Unreachable today (all marks match), but kept for safety:
-			// flush old pending, hold new one. Same shape as the original
-			// implementation so future modes can reintroduce a distinction.
+			// Different description — flush old pending, hold new one.
 			oldFlushed := s.marshalPending()
 			s.pending = &mark
 			s.pendingCount = 1
@@ -152,13 +161,56 @@ func (s *state) transformConversationOnly(e *entry, line []byte, stats *Stats) (
 	}
 }
 
-// pendingMatches reports whether two tool_marks are batchable. Today every
-// tool_mark has the same shape (`{type:"tool_mark"}`), so this returns true
-// for any two tool→tool transitions. Kept as a function (rather than inlined
-// `true`) to make the batching policy explicit and to leave a single place
-// to reintroduce per-call distinctions if the digest experiment regresses.
+// pendingMatches reports whether two tool_marks are batchable. With the
+// description-bearing tool_mark shape, two marks are batchable iff their
+// descriptions match exactly (typically: a polling loop or retry running
+// the same probe).
 func pendingMatches(a, b *entry) bool {
-	return a.Type == b.Type
+	return a.Type == b.Type && a.Description == b.Description
+}
+
+// descriptionForTool extracts the agent-authored `description` field from
+// a tool_input JSON payload. Returns "" if tool_input is missing,
+// unparseable, or has no non-empty description — signaling the caller to
+// drop the tool_mark entirely.
+//
+// We intentionally check ONLY the literal "description" key. We do not
+// derive descriptions for tools that don't carry one (Edit, Read, Write,
+// etc.) — those are dropped, on the policy that assistant prose already
+// names their concrete actions. Adding heuristic derivations would
+// reintroduce the lossy 120-char brief shape this design replaced.
+//
+// The 200-char ceiling is a safety bound against pathological agent output
+// (paragraph-long descriptions). Real Claude Code descriptions are
+// typically 5–15 words.
+func descriptionForTool(toolInput string) string {
+	const maxDescription = 200
+	if toolInput == "" {
+		return ""
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(toolInput), &raw); err != nil {
+		return ""
+	}
+	v, ok := raw["description"]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Account for the 3-byte UTF-8 ellipsis when truncating: 197 bytes of
+	// content + "…" (3 bytes) = 200 bytes total.
+	const ellipsis = "…"
+	if len(s) > maxDescription {
+		s = s[:maxDescription-len(ellipsis)] + ellipsis
+	}
+	return s
 }
 
 // marshalPending serializes state.pending with its accumulated count into

--- a/pkg/tokenopt/transforms.go
+++ b/pkg/tokenopt/transforms.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 )
 
@@ -17,6 +16,17 @@ type state struct {
 	reminderRe  *regexp.Regexp // matches <system-reminder> ... </system-reminder>
 	ansiRe      *regexp.Regexp // matches ANSI CSI/SGR sequences
 	base64ImgRe *regexp.Regexp // matches data:image/...;base64,<payload>
+
+	// pending and pendingCount are the in-flight tool_mark held for
+	// adjacency-batching. When the next entry is another tool_mark with
+	// matching tool_name + brief + is_error, pendingCount increments and
+	// the duplicate is silently absorbed. When the next entry is anything
+	// else (assistant, user, different tool_mark), Compress flushes
+	// pending — emitting it once with `count` set if pendingCount > 1.
+	//
+	// Invariant: pending is non-nil iff pendingCount > 0.
+	pending      *entry
+	pendingCount int
 }
 
 func newState(opts Options) *state {
@@ -33,53 +43,156 @@ func newState(opts Options) *state {
 	}
 }
 
-// transform applies the streaming pipeline to a single jsonl line. Returns the
-// bytes to emit (if emit=true) or signals the entry should be dropped.
-// On parse failure the line passes through untouched.
-func (s *state) transform(line []byte, seq int, stats *Stats) ([]byte, bool, error) {
+// transform applies the streaming pipeline to a single jsonl line. Returns
+// the bytes to emit (when action == actEmit), or signals drop / hold.
+// On JSON parse failure the line passes through unchanged.
+//
+// Pending tool_mark batching: in ModeConversationOnly, transform may set
+// state.pending and return actHold. The Compress outer loop is responsible
+// for flushing pending on actEmit (so adjacency in the output stream matches
+// adjacency in the agent's behavior) and at EOF.
+func (s *state) transform(line []byte, seq int, stats *Stats) ([]byte, emitAction, error) {
 	var e entry
 	if err := json.Unmarshal(line, &e); err != nil {
-		return line, true, nil
+		return line, actEmit, nil
 	}
 
-	// Header and user turns are always preserved verbatim in every mode.
-	if e.Type == "user" || e.Type == "header" {
-		return line, true, nil
+	// User turns are sacred — intent signal, never altered. Always emit
+	// verbatim in every mode.
+	if e.Type == "user" {
+		return line, actEmit, nil
+	}
+
+	// Header was historically preserved verbatim. In ModeConversationOnly
+	// we drop it: the summarizer's schema (title, summary, key_actions,
+	// aha_moments, chapter_titles, agent_summary, ...) needs none of the
+	// header fields (agent_type, agent_version, model, ox_username,
+	// ox_version, created_at). The daemon's writeMetaAndUploadLFS stamps
+	// those into meta.json directly from stored.Meta — the LLM never
+	// reads or writes them. ~50 tokens once per session, free win.
+	//
+	// In ModeLossless we still preserve the header to stay true to the
+	// "every entry survives" contract for replay/debug consumers.
+	if e.Type == "header" {
+		if s.opts.Mode == ModeConversationOnly {
+			stats.HeaderDropped++
+			return nil, actDrop, nil
+		}
+		return line, actEmit, nil
 	}
 
 	if s.opts.Mode == ModeConversationOnly {
 		return s.transformConversationOnly(&e, line, stats)
 	}
-	return s.transformLossless(line, &e, seq, stats)
+	out, emit, err := s.transformLossless(line, &e, seq, stats)
+	if !emit {
+		return nil, actDrop, err
+	}
+	return out, actEmit, err
 }
 
 // transformConversationOnly keeps assistant turns verbatim, replaces tool
-// entries with compact markers, and drops system entries.
-func (s *state) transformConversationOnly(e *entry, line []byte, stats *Stats) ([]byte, bool, error) {
+// entries with bare-marker placeholders, and drops system entries.
+//
+// tool_mark shape today is intentionally minimal: just `{type:"tool_mark"}`,
+// optionally `{type:"tool_mark", count:N}` when adjacent calls collapse.
+// No tool_name, no brief, no is_error.
+//
+// Reasoning: the brief was a 120-char-per-call tax (6–11K input tokens on
+// real sessions) that paid back unevenly. Most of what the brief carried —
+// the bash command, the file path, the grep pattern — is also in the
+// surrounding assistant prose ("I'll edit foo.go and run tests"). What the
+// summarizer actually needs from these entries is *narrative scaffolding*:
+// "the agent paused and acted between these two messages, N times." A bare
+// `tool_mark` (with `count` when batched) preserves that signal at <1% of
+// the previous cost. If `quality_score` / `judge_overall` regresses on
+// tool-heavy sessions when this lands, the next step is option 3 from the
+// design discussion: a single tail digest of tool_name → count.
+func (s *state) transformConversationOnly(e *entry, line []byte, stats *Stats) ([]byte, emitAction, error) {
 	switch e.Type {
 	case "assistant":
 		// Pass through verbatim — assistant prose IS the narrative.
-		return line, true, nil
+		return line, actEmit, nil
 	case "tool":
-		marker := entry{
-			Type:     "tool_mark",
-			ToolName: e.ToolName,
-			Brief:    briefForTool(e.ToolName, e.ToolInput),
-			IsError:  e.IsError,
-		}
-		out, err := json.Marshal(&marker)
-		if err != nil {
-			return line, true, nil
-		}
+		// Always the same shape — no per-call detail. Every tool entry
+		// produces an identical mark, which means adjacency batching
+		// collapses every contiguous run of tool calls between assistant
+		// turns into a single `{type:"tool_mark", count:N}` entry.
+		mark := entry{Type: "tool_mark"}
 		stats.ToolsMarked++
-		return out, true, nil
+
+		if s.pending != nil {
+			// All marks are identical now, so every continuation is a
+			// batchable duplicate. The pendingMatches check is kept as a
+			// no-op call site for symmetry with other modes / future
+			// variants that may reintroduce per-call distinctions.
+			if pendingMatches(s.pending, &mark) {
+				s.pendingCount++
+				stats.ToolsBatched++
+				return nil, actHold, nil
+			}
+			// Unreachable today (all marks match), but kept for safety:
+			// flush old pending, hold new one. Same shape as the original
+			// implementation so future modes can reintroduce a distinction.
+			oldFlushed := s.marshalPending()
+			s.pending = &mark
+			s.pendingCount = 1
+			return oldFlushed, actEmit, nil
+		}
+
+		s.pending = &mark
+		s.pendingCount = 1
+		return nil, actHold, nil
 	case "system":
 		stats.SystemDropped++
-		return nil, false, nil
+		return nil, actDrop, nil
 	default:
 		// Unknown types: preserve to stay safe.
-		return line, true, nil
+		return line, actEmit, nil
 	}
+}
+
+// pendingMatches reports whether two tool_marks are batchable. Today every
+// tool_mark has the same shape (`{type:"tool_mark"}`), so this returns true
+// for any two tool→tool transitions. Kept as a function (rather than inlined
+// `true`) to make the batching policy explicit and to leave a single place
+// to reintroduce per-call distinctions if the digest experiment regresses.
+func pendingMatches(a, b *entry) bool {
+	return a.Type == b.Type
+}
+
+// marshalPending serializes state.pending with its accumulated count into
+// the bytes Compress should write. Caller is responsible for clearing
+// pending afterwards (or via flushPending which does both).
+func (s *state) marshalPending() []byte {
+	if s.pending == nil {
+		return nil
+	}
+	out := *s.pending
+	if s.pendingCount > 1 {
+		out.Count = s.pendingCount
+	}
+	bytes, err := json.Marshal(&out)
+	if err != nil {
+		// Fall back to an unbatched marshal of just the type/name —
+		// losing the count is preferable to losing the entry entirely.
+		return []byte(`{"type":"tool_mark","tool_name":"` + out.ToolName + `"}`)
+	}
+	return bytes
+}
+
+// flushPending returns the bytes for the held tool_mark (if any) and
+// clears state. Returns nil when nothing is pending. Called from Compress
+// at EOF and before any actEmit.
+func (s *state) flushPending(stats *Stats) []byte {
+	if s.pending == nil {
+		return nil
+	}
+	out := s.marshalPending()
+	s.pending = nil
+	s.pendingCount = 0
+	_ = stats // reserved for future per-flush counters
+	return out
 }
 
 // transformLossless is the content-preserving pipeline. Preserves unknown
@@ -276,69 +389,6 @@ func (s *state) truncateLargeBody(body, tool string) (string, bool) {
 	sb.WriteString("\n")
 	sb.WriteString(strings.Join(tail, "\n"))
 	return sb.String(), true
-}
-
-// briefForTool extracts a short human-readable gist from a tool_input payload.
-// Used by ModeConversationOnly to give the summarizer narrative scaffolding
-// (what the agent DID between messages) without the full I/O.
-//
-// tool_input is itself a JSON string, so we parse it and pick the field most
-// representative of the action. Falls back to a truncated view.
-func briefForTool(toolName, toolInput string) string {
-	const maxBrief = 120
-	if toolInput == "" {
-		return ""
-	}
-	var raw map[string]any
-	if err := json.Unmarshal([]byte(toolInput), &raw); err != nil {
-		return truncate(toolInput, maxBrief)
-	}
-
-	primary := map[string]string{
-		"Bash":         "command",
-		"Read":         "file_path",
-		"Write":        "file_path",
-		"Edit":         "file_path",
-		"MultiEdit":    "file_path",
-		"NotebookEdit": "notebook_path",
-		"Glob":         "pattern",
-		"Grep":         "pattern",
-		"Agent":        "description",
-		"Task":         "description",
-		"WebFetch":     "url",
-		"WebSearch":    "query",
-	}
-	if field, ok := primary[toolName]; ok {
-		if v, ok := raw[field]; ok {
-			if s, ok := v.(string); ok {
-				return truncate(s, maxBrief)
-			}
-		}
-	}
-
-	// Unknown tool: pick the first string field in sorted-key order.
-	// Sorting makes the brief deterministic; Go map iteration is randomized
-	// and this package advertises deterministic output.
-	keys := make([]string, 0, len(raw))
-	for k, v := range raw {
-		if s, ok := v.(string); ok && s != "" {
-			keys = append(keys, k)
-		}
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		if s, ok := raw[k].(string); ok {
-			return truncate(s, maxBrief)
-		}
-	}
-	return truncate(toolInput, maxBrief)
-}
-
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	return s[:max-1] + "…"
 }
 
 // toolResultBody returns whichever field of the entry carries a tool result

--- a/pkg/tokenstrip/tokenstrip.go
+++ b/pkg/tokenstrip/tokenstrip.go
@@ -21,6 +21,13 @@ type Stats struct {
 	StopWordsRemoved        int // <thinking> blocks where stop words were removed
 	SynonymsSubstituted     int // <thinking> blocks where synonym substitution fired
 
+	// ThinkingBlocksTrimmed counts <thinking> blocks reduced under
+	// DropThinkingFirstSentence (kept first sentence only).
+	ThinkingBlocksTrimmed int
+	// ThinkingBlocksDropped counts <thinking> blocks removed entirely
+	// under DropThinkingAll.
+	ThinkingBlocksDropped int
+
 	// Token estimates use a ~4 chars/token heuristic (Anthropic's rule of
 	// thumb). They exist so callers can log a rough token-reduction number
 	// without pulling in a BPE-heavy tokenizer. When a real tokenizer is
@@ -59,6 +66,8 @@ func (s *Stats) Add(other Stats) {
 	s.WhitespaceCanonicalized += other.WhitespaceCanonicalized
 	s.StopWordsRemoved += other.StopWordsRemoved
 	s.SynonymsSubstituted += other.SynonymsSubstituted
+	s.ThinkingBlocksTrimmed += other.ThinkingBlocksTrimmed
+	s.ThinkingBlocksDropped += other.ThinkingBlocksDropped
 	s.TokensInEstimate += other.TokensInEstimate
 	s.TokensOutEstimate += other.TokensOutEstimate
 }
@@ -83,17 +92,46 @@ func (s Stats) LogValue() slog.Value {
 		slog.Int("whitespace_canonicalized", s.WhitespaceCanonicalized),
 		slog.Int("stop_words_removed", s.StopWordsRemoved),
 		slog.Int("synonyms_substituted", s.SynonymsSubstituted),
+		slog.Int("thinking_blocks_trimmed", s.ThinkingBlocksTrimmed),
+		slog.Int("thinking_blocks_dropped", s.ThinkingBlocksDropped),
 	)
 }
 
 // Options configures a Compress run. Zero value is a reasonable default
-// (English stop words, synonym substitution OFF).
+// (English stop words, synonym substitution OFF, thinking blocks kept).
 type Options struct {
 	// EnableSynonymSub turns on phrase→synonym substitution inside assistant
 	// <thinking> blocks. Off by default even when tokenstrip itself is on,
 	// because the table is opinionated and can produce awkward reasoning
 	// text; callers should opt in explicitly.
 	EnableSynonymSub bool
+
+	// DropThinkingMode controls whether <thinking>...</thinking> blocks in
+	// assistant content are reduced more aggressively than the default
+	// stop-word strip. Default is DropThinkingNone (preserve current
+	// behavior — full block kept, with stop-word removal applied to its
+	// contents).
+	//
+	// On long Sonnet/Opus sessions, thinking blocks can be 30–50% of
+	// total assistant prose. The summary schema (title, key_actions,
+	// chapter_titles, aha_moments) doesn't require them, but the chain
+	// of reasoning sometimes contains the framing for an aha_moment, so
+	// we offer a conservative middle ground:
+	//
+	//   - DropThinkingNone: keep the entire block (current behavior).
+	//   - DropThinkingFirstSentence: keep only the first sentence of
+	//     each block (typically the framing — "Let me work out X" or
+	//     "I need to figure out Y") and elide the body. Preserves the
+	//     hint of where the reasoning was going without the deliberation
+	//     cost.
+	//   - DropThinkingAll: drop the block entirely. Maximum savings,
+	//     maximum risk.
+	//
+	// Recommended rollout: DropThinkingFirstSentence behind an env-var
+	// flag for a few weeks, A/B against EventSummarization quality_score
+	// distribution, flip to default if there's no measurable quality
+	// drop on the cohort that has it enabled.
+	DropThinkingMode DropThinkingMode
 
 	// SynonymTable overrides the default substitution table. Keys are
 	// matched case-insensitively as whole words. A nil map falls back to
@@ -104,6 +142,26 @@ type Options struct {
 	// Empty string defaults to "en".
 	StopWordLanguage string
 }
+
+// DropThinkingMode controls the aggressive reduction of <thinking> blocks.
+// See Options.DropThinkingMode for the rationale.
+type DropThinkingMode int
+
+const (
+	// DropThinkingNone preserves the entire <thinking> block (default).
+	// Stop-word removal still applies to the inner text.
+	DropThinkingNone DropThinkingMode = 0
+
+	// DropThinkingFirstSentence keeps the first sentence of each block
+	// and replaces the rest with an elision marker. Sentence boundary
+	// is the first ".", "!", or "?" followed by whitespace or end-of-block.
+	DropThinkingFirstSentence DropThinkingMode = 1
+
+	// DropThinkingAll removes the entire block (including the surrounding
+	// <thinking> tags). Maximum aggression — use only with telemetry-
+	// backed evidence that quality_score isn't impacted.
+	DropThinkingAll DropThinkingMode = 2
+)
 
 // DefaultSynonymTable returns the baseline high-token phrase → shorter form
 // mapping. Kept short and conservative; callers wanting more aggressive

--- a/pkg/tokenstrip/tokenstrip_test.go
+++ b/pkg/tokenstrip/tokenstrip_test.go
@@ -117,6 +117,103 @@ func TestThinkingBlockStopWordsRemoved(t *testing.T) {
 	}
 }
 
+// TestDropThinkingFirstSentence verifies that with
+// DropThinkingMode=DropThinkingFirstSentence the inner thinking text is
+// trimmed to its first sentence and an elision marker is appended.
+// Failure prevented: the env-gated rollout silently regresses to keeping
+// all thinking content (no token savings) or strips it entirely (loss
+// of reasoning framing for aha_moments).
+func TestDropThinkingFirstSentence(t *testing.T) {
+	content := "Answer: 42.\n<thinking>Let me work out the answer. First I need X. Then Y. Then Z.</thinking>\nDone."
+	asst := map[string]any{"type": "assistant", "content": content}
+	line := mustJSON(t, asst)
+
+	got, stats := runCompress(t, []string{line}, Options{
+		DropThinkingMode: DropThinkingFirstSentence,
+	})
+
+	if stats.ThinkingBlocksTrimmed != 1 {
+		t.Fatalf("ThinkingBlocksTrimmed=%d, want 1", stats.ThinkingBlocksTrimmed)
+	}
+	var e struct {
+		Content string `json:"content"`
+	}
+	_ = json.Unmarshal([]byte(got[0]), &e)
+
+	// First sentence "Let me work out the answer." must survive.
+	if !strings.Contains(e.Content, "Let me work out the answer.") {
+		t.Errorf("first sentence missing from trimmed thinking: %q", e.Content)
+	}
+	// Subsequent sentences must be elided.
+	if strings.Contains(e.Content, "First I need X") {
+		t.Errorf("subsequent sentences should be elided: %q", e.Content)
+	}
+	// Elision marker must be present.
+	if !strings.Contains(e.Content, "[reasoning elided]") {
+		t.Errorf("elision marker missing: %q", e.Content)
+	}
+	// Surrounding prose untouched.
+	if !strings.Contains(e.Content, "Answer: 42.") || !strings.Contains(e.Content, "Done.") {
+		t.Errorf("prose outside thinking altered: %q", e.Content)
+	}
+}
+
+// TestDropThinkingAll verifies the most aggressive variant — block + tags
+// removed entirely. Failure prevented: variant promoted to default-on
+// before telemetry justifies it.
+func TestDropThinkingAll(t *testing.T) {
+	content := "Answer: 42.\n<thinking>any deliberation here</thinking>\nDone."
+	asst := map[string]any{"type": "assistant", "content": content}
+	line := mustJSON(t, asst)
+
+	got, stats := runCompress(t, []string{line}, Options{
+		DropThinkingMode: DropThinkingAll,
+	})
+
+	if stats.ThinkingBlocksDropped != 1 {
+		t.Fatalf("ThinkingBlocksDropped=%d, want 1", stats.ThinkingBlocksDropped)
+	}
+	var e struct {
+		Content string `json:"content"`
+	}
+	_ = json.Unmarshal([]byte(got[0]), &e)
+
+	if strings.Contains(e.Content, "<thinking>") || strings.Contains(e.Content, "</thinking>") {
+		t.Errorf("thinking tags should be gone with DropThinkingAll: %q", e.Content)
+	}
+	if strings.Contains(e.Content, "any deliberation") {
+		t.Errorf("thinking content should be gone: %q", e.Content)
+	}
+	if !strings.Contains(e.Content, "Answer: 42.") || !strings.Contains(e.Content, "Done.") {
+		t.Errorf("surrounding prose altered: %q", e.Content)
+	}
+}
+
+// TestDropThinkingNone_DefaultPreservesBlock verifies the zero value of
+// Options.DropThinkingMode preserves the existing behavior (stop-word
+// strip on the inner text, block kept). Failure prevented: a future
+// change to defaults silently flipping production sessions onto the
+// aggressive path without operator opt-in.
+func TestDropThinkingNone_DefaultPreservesBlock(t *testing.T) {
+	content := "<thinking>I should think about the problem before I respond</thinking>"
+	asst := map[string]any{"type": "assistant", "content": content}
+	line := mustJSON(t, asst)
+
+	got, stats := runCompress(t, []string{line}, Options{}) // zero value
+
+	if stats.ThinkingBlocksDropped != 0 || stats.ThinkingBlocksTrimmed != 0 {
+		t.Errorf("default mode should not drop or trim: dropped=%d trimmed=%d", stats.ThinkingBlocksDropped, stats.ThinkingBlocksTrimmed)
+	}
+	var e struct {
+		Content string `json:"content"`
+	}
+	_ = json.Unmarshal([]byte(got[0]), &e)
+
+	if !strings.Contains(e.Content, "<thinking>") || !strings.Contains(e.Content, "</thinking>") {
+		t.Errorf("default mode must keep thinking tags: %q", e.Content)
+	}
+}
+
 // TestNFCNormalization verifies NFD (decomposed) input becomes NFC.
 func TestNFCNormalization(t *testing.T) {
 	// "café" with combining acute accent (NFD form).

--- a/pkg/tokenstrip/transforms.go
+++ b/pkg/tokenstrip/transforms.go
@@ -141,33 +141,57 @@ func (s *state) transform(line []byte, stats *Stats) ([]byte, error) {
 		newContent = canon
 	}
 
-	// Thinking-block-only transforms. Apply stop-word removal and
-	// (optionally) synonym substitution only to the captured inner text.
+	// Thinking-block-only transforms. The transform applied depends on
+	// DropThinkingMode:
+	//   - None (default): stop-word + synonym strip on inner text;
+	//     block structure preserved.
+	//   - FirstSentence: keep just the first sentence of inner text;
+	//     elide the rest. Token savings without losing reasoning framing.
+	//   - All: drop the whole block (including tags). Maximum savings.
+	//
+	// The summary schema doesn't require thinking content, but on long
+	// Sonnet/Opus sessions thinking blocks can be 30–50% of assistant
+	// prose. The first-sentence variant is the conservative middle:
+	// keeps the hint of what reasoning was happening without the cost.
 	newContent = s.thinkingRe.ReplaceAllStringFunc(newContent, func(block string) string {
 		m := s.thinkingRe.FindStringSubmatch(block)
 		if len(m) < 2 {
 			return block
 		}
 		inner := m[1]
-		before := inner
 
-		stripped := stopwords.CleanString(inner, s.opts.StopWordLanguage, false)
-		if stripped != inner {
-			stats.StopWordsRemoved++
-			inner = stripped
-		}
-
-		if s.opts.EnableSynonymSub {
-			subbed := s.applySynonyms(inner)
-			if subbed != inner {
-				stats.SynonymsSubstituted++
-				inner = subbed
+		switch s.opts.DropThinkingMode {
+		case DropThinkingAll:
+			stats.ThinkingBlocksDropped++
+			return ""
+		case DropThinkingFirstSentence:
+			trimmed := firstSentence(inner)
+			if trimmed != inner {
+				stats.ThinkingBlocksTrimmed++
+				return "<thinking>" + trimmed + " ...[reasoning elided]</thinking>"
 			}
+			// Single-sentence thinking block — fall through to stop-word
+			// strip so the entry still benefits from baseline reduction.
+			fallthrough
+		default:
+			before := inner
+			stripped := stopwords.CleanString(inner, s.opts.StopWordLanguage, false)
+			if stripped != inner {
+				stats.StopWordsRemoved++
+				inner = stripped
+			}
+			if s.opts.EnableSynonymSub {
+				subbed := s.applySynonyms(inner)
+				if subbed != inner {
+					stats.SynonymsSubstituted++
+					inner = subbed
+				}
+			}
+			if inner == before {
+				return block
+			}
+			return "<thinking>" + inner + "</thinking>"
 		}
-		if inner == before {
-			return block
-		}
-		return "<thinking>" + inner + "</thinking>"
 	})
 
 	if newContent == origContent {
@@ -239,6 +263,36 @@ func (s *state) applySynonyms(in string) string {
 		out = rule.re.ReplaceAllString(out, rule.replace)
 	}
 	return out
+}
+
+// firstSentence returns the first sentence of s, defined as everything
+// up to and including the first ".", "!", or "?" followed by whitespace
+// or end-of-string. Returns s unchanged if no sentence boundary is found
+// (caller should fall through to the per-sentence transforms).
+//
+// Why a custom function instead of a sentence-boundary library: thinking
+// blocks are short (rarely > a few sentences), the heuristic is good
+// enough for "keep the framing line," and pulling in NLP dependencies
+// would violate this package's stdlib-mostly contract.
+func firstSentence(s string) string {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != '.' && c != '!' && c != '?' {
+			continue
+		}
+		// Sentence boundary requires whitespace or EOS after the punct.
+		// Catches "I'll do X. Then Y." (split after first period) but
+		// not "version 1.0" (no whitespace after the dot, stays together).
+		next := i + 1
+		if next >= len(s) {
+			return s[:next] // punct at end is its own sentence
+		}
+		nc := s[next]
+		if nc == ' ' || nc == '\t' || nc == '\n' || nc == '\r' {
+			return s[:next]
+		}
+	}
+	return s
 }
 
 // estimateTokens is a coarse "~4 chars per token" heuristic. Anthropic's


### PR DESCRIPTION
## Summary

- **Pin Haiku 4.5** as the daemon's summarization model, overridable via `OX_SUMMARY_MODEL` (empty = local default for fast rollback). New `agent.summarizer` config knob defaults to `inline`; SessionEnd hook auto-finalizes recordings.
- **Pre-LLM prefilter** (`pkg/sessionsummary/prefilter.go`) skips `claude -p` entirely on sessions too thin to summarize meaningfully — synthesizes a deterministic stub from user prompts, scored low so the existing quality gate routes it to discard. Saves the entire LLM round-trip (input prompt guidelines + Haiku call + validation) on the long tail of exploratory pings.
- **Token-aware compaction**: `tool_mark` entries reduced to bare placeholders with adjacency batching (long Edit/Read runs collapse into one entry with `count`); `header` entries dropped from the optimized stream; new env-gated `<thinking>`-block reduction in `tokenstrip` (`OX_SUMMARY_INPUT_DROP_THINKING=first|all`); estimated-token metrics alongside bytes everywhere.
- **Observability**: new `summarization`, `summarization_skipped`, and tokens-aware `tokenopt_run` telemetry events with a privacy-safe `session_hash` correlator that joins compression metrics, LLM cost shape, and prefilter skips into one server-side dataset.
- **Tests**: ~25 new cases across `pkg/sessionsummary`, `pkg/tokenopt`, `pkg/tokenstrip`, and `internal/daemon/agentwork` covering the prefilter, model plumbing, header drop, tool_mark batching, and the new telemetry events; full suite green.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable session summarization with `agent.summarizer` setting (inline/delegated/off modes)
  * Automatic session finalization when exiting Claude Code
  * Intelligent session filtering that skips LLM summarization for thin sessions
  * Customizable summarization model via environment configuration

* **Improvements**
  * Quality categorization for summaries enabling better content routing
  * Enhanced telemetry for summarization events with cost metrics
  * Optimized summary input reducing token costs

* **Chores**
  * Version bumped to 0.7.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->