### PR TITLE
fix(daemon): cast rlim.Cur to uint64 for freebsd build

### DIFF
--- a/internal/daemon/fd_limit_unix.go
+++ b/internal/daemon/fd_limit_unix.go
@@ -12,10 +12,14 @@ import "syscall"
 // Unix-only because syscall.Getrlimit / syscall.Rlimit / syscall.RLIMIT_NOFILE
 // are guarded by `//go:build unix` upstream and don't exist for GOOS=windows.
 // See fd_limit_windows.go for the Windows stub.
+//
+// rlim.Cur is uint64 on linux and darwin but int64 on freebsd; cast to keep
+// the cross-GOOS return type stable. Negative values can't occur for
+// RLIMIT_NOFILE in practice.
 func CurrentProcessFDLimit() uint64 {
 	var rlim syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
 		return 0
 	}
-	return rlim.Cur
+	return uint64(rlim.Cur)
 }


### PR DESCRIPTION
## Summary

The `internal/daemon/fd_limit_unix.go` helper introduced in #580 returns `uint64`, but `syscall.Rlimit.Cur` is `int64` on freebsd (it's `uint64` on linux and darwin). goreleaser builds `freebsd/amd64` as one of its release targets, so the v0.7.0, v0.7.1, and v0.7.2 release workflows all fail at:

```
internal/daemon/fd_limit_unix.go:20:9: cannot use rlim.Cur (variable of type int64) as uint64 value in return statement
```

This blocks signed-binary uploads on every release page since v0.7.0.

Fix: explicit `uint64(rlim.Cur)` cast. Negative values can't occur for `RLIMIT_NOFILE` in practice. Comment updated to flag the platform difference.

## Test plan

- [x] `GOOS=freebsd GOARCH=amd64 go build ./internal/daemon/` — passes
- [x] `GOOS=linux GOARCH=amd64 go build ./internal/daemon/` — passes
- [x] `GOOS=darwin GOARCH=arm64 go build ./internal/daemon/` — passes
- [x] `go test ./internal/daemon/` — passes
- [ ] Once merged: force-move `v0.7.2` tag, recreate GH release, verify `release.yml` produces signed binaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file descriptor limit handling to ensure consistent behavior across different Unix-based operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->