### PR TITLE
fix(doctor): make --force-session-uploads actually repair past failures

### DIFF
--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -386,23 +386,46 @@ func runForceSessionUploads(cmd *cobra.Command) error {
 	if err := daemon.EnsureDaemon(); err != nil {
 		return fmt.Errorf("daemon required for session finalization: %w", err)
 	}
-	client := daemon.NewClientForCurrentRepo()
+	// Doctor() runs synchronously in the daemon: anti-entropy + full ledger scan
+	// (ForceDetect) + session-watcher detect/restart/cleanup. On real ledgers
+	// this routinely exceeds the 50ms default IPC timeout, so use a generous
+	// ceiling and retry once on timeout (mirrors the pattern in daemonStatusCmd).
 	resp, err := cli.WithSpinner("Scanning for incomplete sessions...", func() (*daemon.DoctorResponse, error) {
-		return client.Doctor()
+		client := daemon.NewClientForCurrentRepoWithTimeout(5 * time.Second)
+		r, err := client.Doctor()
+		if err != nil && isTimeoutErr(err) {
+			client = daemon.NewClientForCurrentRepoWithTimeout(30 * time.Second)
+			r, err = client.Doctor()
+		}
+		return r, err
 	})
 	if err != nil {
+		if isTimeoutErr(err) {
+			return fmt.Errorf("daemon is busy (likely scanning sessions), try again in a moment")
+		}
 		return fmt.Errorf("session finalization trigger failed: %w", err)
 	}
 
 	w := cmd.OutOrStdout()
+	// surface what autofix did (meta.json repairs from clean summary.json titles,
+	// retry counter bumps, terminal flips) before the LLM-retry queue counter,
+	// because they happened synchronously in the daemon already.
+	for _, summary := range resp.AutofixSummaries {
+		fmt.Fprintf(w, "%s  %s\n",
+			ui.PassStyle.Render(ui.TimelineDot), summary)
+	}
 	if resp.SessionFinalizeQueued > 0 {
 		fmt.Fprintf(w, "%s  Queued %d session(s) for finalization\n",
 			ui.PassStyle.Render(ui.TimelineDot), resp.SessionFinalizeQueued)
 		fmt.Fprintf(w, "%s  Sessions will be finalized in the background by the daemon\n",
 			ui.MutedStyle.Render(ui.TimelineBar))
-	} else {
+	} else if len(resp.AutofixSummaries) == 0 {
 		fmt.Fprintf(w, "%s  No incomplete sessions found\n",
 			ui.PassStyle.Render(ui.TimelineDot))
+	}
+	for _, e := range resp.Errors {
+		fmt.Fprintf(w, "%s  %s\n",
+			ui.WarnStyle.Render(ui.TimelineDot), e)
 	}
 	return nil
 }

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -382,15 +382,20 @@ func init() {
 }
 
 // runForceSessionUploads triggers the daemon to detect and upload incomplete sessions.
+//
+// As of 0.7.2 the daemon's Doctor() RPC is asynchronous: it kicks off
+// anti-entropy + autofix + ForceDetect + session-watcher cleanup in a
+// background goroutine and returns within milliseconds. This function
+// reports the kick-off and routes the user to where the actual results
+// land (`ox daemon status` for autofix issues + queued counts,
+// `ox daemon logs -f` for per-session detail). The 5s/30s retry
+// scaffolding remains so a busy daemon (initial sync, GC) still gets
+// a fair chance to respond.
 func runForceSessionUploads(cmd *cobra.Command) error {
 	if err := daemon.EnsureDaemon(); err != nil {
 		return fmt.Errorf("daemon required for session finalization: %w", err)
 	}
-	// Doctor() runs synchronously in the daemon: anti-entropy + full ledger scan
-	// (ForceDetect) + session-watcher detect/restart/cleanup. On real ledgers
-	// this routinely exceeds the 50ms default IPC timeout, so use a generous
-	// ceiling and retry once on timeout (mirrors the pattern in daemonStatusCmd).
-	resp, err := cli.WithSpinner("Scanning for incomplete sessions...", func() (*daemon.DoctorResponse, error) {
+	resp, err := cli.WithSpinner("Triggering doctor pass...", func() (*daemon.DoctorResponse, error) {
 		client := daemon.NewClientForCurrentRepoWithTimeout(5 * time.Second)
 		r, err := client.Doctor()
 		if err != nil && isTimeoutErr(err) {
@@ -401,27 +406,44 @@ func runForceSessionUploads(cmd *cobra.Command) error {
 	})
 	if err != nil {
 		if isTimeoutErr(err) {
-			return fmt.Errorf("daemon is busy (likely scanning sessions), try again in a moment")
+			return fmt.Errorf("daemon is busy, try again in a moment")
 		}
-		return fmt.Errorf("session finalization trigger failed: %w", err)
+		return fmt.Errorf("doctor trigger failed: %w", err)
 	}
 
 	w := cmd.OutOrStdout()
-	// surface what autofix did (meta.json repairs from clean summary.json titles,
-	// retry counter bumps, terminal flips) before the LLM-retry queue counter,
-	// because they happened synchronously in the daemon already.
-	for _, summary := range resp.AutofixSummaries {
-		fmt.Fprintf(w, "%s  %s\n",
-			ui.PassStyle.Render(ui.TimelineDot), summary)
-	}
-	if resp.SessionFinalizeQueued > 0 {
-		fmt.Fprintf(w, "%s  Queued %d session(s) for finalization\n",
-			ui.PassStyle.Render(ui.TimelineDot), resp.SessionFinalizeQueued)
-		fmt.Fprintf(w, "%s  Sessions will be finalized in the background by the daemon\n",
-			ui.MutedStyle.Render(ui.TimelineBar))
-	} else if len(resp.AutofixSummaries) == 0 {
-		fmt.Fprintf(w, "%s  No incomplete sessions found\n",
+	switch {
+	case resp.AlreadyRunning:
+		fmt.Fprintf(w, "%s  Doctor pass already in progress; this call was a no-op\n",
 			ui.PassStyle.Render(ui.TimelineDot))
+	case resp.BackgroundStarted:
+		fmt.Fprintf(w, "%s  Doctor pass started in the background\n",
+			ui.PassStyle.Render(ui.TimelineDot))
+	default:
+		// Older daemon ran the work inline; surface what we got.
+		for _, summary := range resp.AutofixSummaries {
+			fmt.Fprintf(w, "%s  %s\n",
+				ui.PassStyle.Render(ui.TimelineDot), summary)
+		}
+		if resp.SessionFinalizeQueued > 0 {
+			fmt.Fprintf(w, "%s  Queued %d session(s) for finalization\n",
+				ui.PassStyle.Render(ui.TimelineDot), resp.SessionFinalizeQueued)
+		} else if len(resp.AutofixSummaries) == 0 {
+			fmt.Fprintf(w, "%s  No incomplete sessions found\n",
+				ui.PassStyle.Render(ui.TimelineDot))
+		}
+	}
+
+	// Route the user to where the async results land.
+	if resp.BackgroundStarted || resp.AlreadyRunning {
+		fmt.Fprintf(w, "%s  Anti-entropy, autofix (meta.title recovery), ForceDetect, watcher cleanup\n",
+			ui.MutedStyle.Render(ui.TimelineBar))
+		fmt.Fprintf(w, "%s  Run %s to see autofix issues + queue\n",
+			ui.MutedStyle.Render(ui.TimelineBar),
+			ui.MutedStyle.Render("`ox daemon status`"))
+		fmt.Fprintf(w, "%s  Run %s for per-session detail\n",
+			ui.MutedStyle.Render(ui.TimelineBar),
+			ui.MutedStyle.Render("`ox daemon logs -f`"))
 	}
 	for _, e := range resp.Errors {
 		fmt.Fprintf(w, "%s  %s\n",

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -441,6 +441,36 @@ func (h *SessionFinalizeHandler) detectInDir(sessionsDir, ledgerPath string) ([]
 				continue
 			}
 
+			// All artifacts exist, no .needs-summary marker, but a prior daemon
+			// summarization run may have written failure-marker stubs into them
+			// (empty title in summary.json + empty meta.title + status !=
+			// unrecoverable). The autofix scheduler's session-meta-titles check
+			// can recover meta.json from a clean summary.json title — but only
+			// when summary.json itself has one. When summary.json is _also_
+			// empty, the only path forward is re-running the LLM.
+			//
+			// Bound by lfs.MaxSummaryAttempts via the shared finalize path:
+			// each LLM retry that fails increments meta.SummaryAttempts and
+			// flips to "unrecoverable" at the cap, after which this branch
+			// short-circuits via shouldRetryEmptySummary.
+			if h.shouldRetryEmptySummary(sessionDir) {
+				h.logger.Info("session has empty-title summary stub, queuing LLM retry",
+					"session", name,
+				)
+				items = append(items, &WorkItem{
+					Type:     sessionFinalizeType,
+					Priority: sessionFinalizePriority,
+					DedupKey: sessionFinalizeType + ":" + name,
+					Payload: &SessionFinalizePayload{
+						SessionDir: sessionDir,
+						RawPath:    rawPath,
+						Missing:    requiredArtifacts, // regenerate all artifacts
+						LedgerPath: ledgerPath,
+					},
+				})
+				continue
+			}
+
 			// Truly finalized. If this session is in the ledger cache
 			// but not yet in the git-tracked sessions/ dir, it needs to be pushed.
 			if isInLedgerCacheDir(sessionDir, ledgerPath) {
@@ -1658,6 +1688,55 @@ func missingArtifacts(sessionDir string) []string {
 // terminal — the daemon already exhausted MaxSummaryAttempts on it
 // and further retries would just burn tokens. Treat unrecoverable as
 // "work no longer needed" even when title is empty.
+// shouldRetryEmptySummary reports whether a session whose artifact files
+// all exist on disk is actually a failure-marker stub from a prior daemon
+// summarization run, and is therefore eligible for an LLM retry.
+//
+// The signature of this state:
+//   - All required artifacts present (caller already established this).
+//   - No `.needs-summary` marker (CLI didn't punt — daemon ran and "completed").
+//   - meta.SummaryStatus is NOT "unrecoverable" (terminal failures stay terminal;
+//     bounded by lfs.MaxSummaryAttempts).
+//   - meta.SummaryAttempts < lfs.MaxSummaryAttempts (haven't burned the budget).
+//   - summary.json has empty/whitespace-only title (autofix can't recover meta
+//     from this either — only an LLM rerun can produce content).
+//
+// Returns false (don't enqueue) if any of the above is wrong, including
+// the meta.json being unreadable — better to skip a confusing session
+// than enqueue work the worker will then refuse via workNoLongerNeeded.
+func (h *SessionFinalizeHandler) shouldRetryEmptySummary(sessionDir string) bool {
+	meta, err := lfs.ReadSessionMeta(sessionDir)
+	if err != nil || meta == nil {
+		return false
+	}
+	if meta.SummaryStatus == sessionsummary.SummaryStatusUnrecoverable {
+		return false
+	}
+	if meta.SummaryAttempts >= lfs.MaxSummaryAttempts {
+		return false
+	}
+	// If meta.title is already populated, autofix or a prior good run
+	// already settled this session — nothing to retry.
+	if strings.TrimSpace(meta.Title) != "" {
+		return false
+	}
+	// summary.json must exist (caller said missing == 0) and have an
+	// empty title. An empty title here is the LLM-retry signal; a
+	// non-empty title is the autofix-can-recover-meta signal handled
+	// separately by checkSessionMetaTitles.
+	data, err := os.ReadFile(filepath.Join(sessionDir, "summary.json"))
+	if err != nil {
+		return false
+	}
+	var head struct {
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(data, &head); err != nil {
+		return false
+	}
+	return strings.TrimSpace(head.Title) == ""
+}
+
 func (h *SessionFinalizeHandler) workNoLongerNeeded(sessionDir string) bool {
 	if len(missingArtifacts(sessionDir)) > 0 {
 		return false

--- a/internal/daemon/agentwork/session_finalize_detect_test.go
+++ b/internal/daemon/agentwork/session_finalize_detect_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/pkg/sessionsummary"
 )
 
 func TestDetect(t *testing.T) {
@@ -879,5 +881,115 @@ func TestDetect_NeedsSummaryMarkerTriggersRefinalization(t *testing.T) {
 	}
 	if len(payload.Missing) != len(requiredArtifacts) {
 		t.Errorf("expected all artifacts in Missing (for regeneration), got %d: %v", len(payload.Missing), payload.Missing)
+	}
+}
+
+// TestDetect_EmptyTitleSummaryStubTriggersRetry verifies that sessions which
+// "completed" finalization but ended up with a failure-marker stub
+// (summary.json present but with empty title, no .needs-summary marker,
+// meta.summary_attempts < cap) get re-enqueued for an LLM retry. Without
+// this, the only repair path was to delete artifacts by hand or wait for
+// the autofix scheduler — which can't help when summary.json itself is
+// also empty.
+//
+// Failure prevented: silent loss of session summaries when daemon
+// summarization fails partway through; user runs --force-session-uploads
+// expecting repair and gets "No incomplete sessions found".
+func TestDetect_EmptyTitleSummaryStubTriggersRetry(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+
+	ledgerPath := t.TempDir()
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+
+	// Three sessions that exercise the boundary:
+	//   1. retryable: empty-title summary.json, attempts < cap → enqueue
+	//   2. terminal: empty-title summary.json, status unrecoverable → skip
+	//   3. autofix-recoverable: clean-title summary.json, empty meta.title → skip
+	//      (autofix scheduler handles this case, not Detect — Detect would
+	//      double-process and burn LLM tokens unnecessarily)
+	rawContent := `{"_meta":{"schema_version":"1","agent_type":"claude-code","session_id":"x","started_at":"2026-04-01T10:00:00Z"}}
+{"type":"user","content":"hello","seq":1}
+{"type":"assistant","content":"hi","seq":2}
+`
+
+	mkSession := func(name string, summaryTitle string, meta *lfs.SessionMeta) string {
+		dir := filepath.Join(sessionsDir, name)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(rawContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+		// summary.json with the requested title (may be empty)
+		sj, err := json.Marshal(struct {
+			Title   string `json:"title"`
+			Summary string `json:"summary"`
+		}{Title: summaryTitle})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "summary.json"), sj, 0644); err != nil {
+			t.Fatal(err)
+		}
+		// summary.md / session.md / session.html stubs — content irrelevant,
+		// Detect only checks for presence
+		for _, name := range []string{artifactSummaryMD, artifactSessionMD} {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("stub"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := lfs.WriteSessionMetaOnly(dir, meta); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+
+	retrySession := "2026-04-01T10-00-testuser-OxRTRY"
+	mkSession(retrySession, "" /* empty title */, &lfs.SessionMeta{
+		SessionName:     retrySession,
+		Title:           "",
+		SummaryStatus:   sessionsummary.SummaryStatusFailedValidation,
+		SummaryAttempts: 1, // below cap
+	})
+
+	terminalSession := "2026-04-01T11-00-testuser-OxTERM"
+	mkSession(terminalSession, "", &lfs.SessionMeta{
+		SessionName:     terminalSession,
+		Title:           "",
+		SummaryStatus:   sessionsummary.SummaryStatusUnrecoverable,
+		SummaryAttempts: lfs.MaxSummaryAttempts,
+	})
+
+	autofixableSession := "2026-04-01T12-00-testuser-OxAFIX"
+	mkSession(autofixableSession, "good clean title", &lfs.SessionMeta{
+		SessionName:     autofixableSession,
+		Title:           "", // empty meta.title but summary.json has good title
+		SummaryStatus:   sessionsummary.SummaryStatusFailedValidation,
+		SummaryAttempts: 1,
+	})
+
+	items, err := handler.Detect(ledgerPath)
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	if len(items) != 1 {
+		names := make([]string, 0, len(items))
+		for _, it := range items {
+			names = append(names, filepath.Base(it.Payload.(*SessionFinalizePayload).SessionDir))
+		}
+		t.Fatalf("expected 1 item (only retrySession), got %d: %v", len(items), names)
+	}
+
+	payload := items[0].Payload.(*SessionFinalizePayload)
+	if filepath.Base(payload.SessionDir) != retrySession {
+		t.Errorf("expected %s to be enqueued, got %s",
+			retrySession, filepath.Base(payload.SessionDir))
+	}
+	if payload.UploadOnly {
+		t.Error("retry should NOT be upload-only — needs LLM regeneration")
+	}
+	if len(payload.Missing) != len(requiredArtifacts) {
+		t.Errorf("expected all artifacts in Missing for full regeneration, got %v", payload.Missing)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -180,6 +181,7 @@ type Daemon struct {
 	settingsFetcher        *SettingsFetcher
 	eventBus               *hooks.EventBus
 	tracer                 *observability.DaemonTracer
+	autofixSched           *autofix.Scheduler
 
 	// state
 	mu               sync.Mutex
@@ -1260,7 +1262,7 @@ func (d *Daemon) startWorkers() {
 	// auto-safe checks happens in follow-up beads.
 	if d.config.ProjectRoot != "" {
 		autofixReg := autofix.Default()
-		autofixSched := autofix.NewScheduler(autofixReg, d.logger,
+		d.autofixSched = autofix.NewScheduler(autofixReg, d.logger,
 			func() []string { return []string{d.config.ProjectRoot} },
 			func(r autofix.CheckResult) {
 				if d.issues == nil {
@@ -1280,7 +1282,7 @@ func (d *Daemon) startWorkers() {
 		d.wg.Add(1)
 		go func() {
 			defer d.wg.Done()
-			autofixSched.Run(d.ctx)
+			d.autofixSched.Run(d.ctx)
 		}()
 	}
 
@@ -1557,6 +1559,31 @@ func (s *daemonServiceImpl) Doctor() *DoctorResponse {
 	// trigger anti-entropy (self-healing for missing repos)
 	s.d.scheduler.TriggerAntiEntropy()
 	resp := &DoctorResponse{AntiEntropyTriggered: true}
+
+	// Run the auto-fix-safe checks NOW (bypassing the 30m throttle) so
+	// the user-triggered Doctor() RPC actually performs meta.json
+	// recovery instead of waiting for the next slow tick. This catches
+	// the common "summary.json has a clean title but meta.title is
+	// empty / leaky" case that the LLM-retry path can't see.
+	if s.d.autofixSched != nil {
+		results := s.d.autofixSched.RunNow(s.d.ctx)
+		resp.AutofixRan = true
+		for _, r := range results {
+			if r.Status == autofix.StatusClean {
+				continue
+			}
+			if r.Summary != "" {
+				resp.AutofixSummaries = append(resp.AutofixSummaries, r.Summary)
+			}
+			if r.Slug == "session-meta-titles" {
+				resp.MetaTitlesRepaired += parseRecoveredCount(r.Summary)
+			}
+			if r.Status == autofix.StatusError {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("autofix %s: %s", r.Slug, r.Summary))
+			}
+		}
+	}
+
 	// trigger session finalization detection (bypasses hourly cooldown)
 	if s.d.agentWorker != nil {
 		queued := s.d.agentWorker.ForceDetect()
@@ -1570,6 +1597,32 @@ func (s *daemonServiceImpl) Doctor() *DoctorResponse {
 		s.d.sessionWatcher.Cleanup()
 	}
 	return resp
+}
+
+// parseRecoveredCount extracts the "recovered=N" integer from the
+// session-meta-titles check summary. The summary shape is fixed by
+// internal/doctor/autofix/default_checks.go, so a small regex-free
+// scan is sufficient. Returns 0 on any parse failure — the value is
+// informational, not load-bearing for control flow.
+func parseRecoveredCount(summary string) int {
+	const key = "recovered="
+	i := strings.Index(summary, key)
+	if i < 0 {
+		return 0
+	}
+	rest := summary[i+len(key):]
+	end := 0
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(rest[:end])
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 func (s *daemonServiceImpl) SessionFinalize(payload SessionFinalizeIPCPayload) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -10,7 +10,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -199,6 +198,12 @@ type Daemon struct {
 	// startup timing (written once in Start(), read by IPC status handler)
 	startupDurationMs  atomic.Int64
 	throttleDurationMs atomic.Int64
+
+	// doctorRunning is the single-flight guard for the async Doctor()
+	// RPC. CompareAndSwap from false→true claims the slot for a new
+	// pass; concurrent callers get AlreadyRunning=true and no work.
+	// The goroutine clears it via Store(false) on exit.
+	doctorRunning atomic.Bool
 }
 
 // New creates a new daemon instance.
@@ -1555,74 +1560,82 @@ func (s *daemonServiceImpl) CodeIndex(payload CodeIndexPayload, progress *Progre
 	return result, err
 }
 
+// Doctor kicks off a doctor pass (anti-entropy + autofix RunNow +
+// ForceDetect + session-watcher cleanup) in a background goroutine and
+// returns immediately. On large ledgers this work walks thousands of
+// session directories and would routinely exceed the IPC read timeout
+// if invoked synchronously; results surface instead via the daemon's
+// IssueTracker (visible in `ox daemon status`) and the agent worker
+// queue.
+//
+// Single-flight: concurrent Doctor() calls while a pass is already
+// running return AlreadyRunning=true and do not start a second pass.
+// That keeps the autofix walk + ForceDetect from racing themselves on
+// the same ledger when a user mashes the button.
 func (s *daemonServiceImpl) Doctor() *DoctorResponse {
-	// trigger anti-entropy (self-healing for missing repos)
-	s.d.scheduler.TriggerAntiEntropy()
-	resp := &DoctorResponse{AntiEntropyTriggered: true}
+	if !s.d.doctorRunning.CompareAndSwap(false, true) {
+		return &DoctorResponse{AlreadyRunning: true}
+	}
+	s.d.wg.Add(1)
+	go func() {
+		defer s.d.wg.Done()
+		defer s.d.doctorRunning.Store(false)
+		s.runDoctorPass()
+	}()
+	return &DoctorResponse{BackgroundStarted: true}
+}
+
+// runDoctorPass performs the heavy doctor work. Side effects only:
+// results land in the autofix scheduler's emit callback (which writes
+// to d.issues), in the agent worker queue, and in the daemon log.
+// Always called on a goroutine owned by Doctor(); never call directly.
+func (s *daemonServiceImpl) runDoctorPass() {
+	logger := s.d.logger.With("op", "doctor")
+	logger.Info("doctor pass starting")
+	start := time.Now()
+
+	// trigger anti-entropy (self-healing for missing repos). Already
+	// internally async — returns immediately. Nil-guarded for tests
+	// that drive Doctor() against a zero-value Daemon.
+	if s.d.scheduler != nil {
+		s.d.scheduler.TriggerAntiEntropy()
+	}
 
 	// Run the auto-fix-safe checks NOW (bypassing the 30m throttle) so
 	// the user-triggered Doctor() RPC actually performs meta.json
 	// recovery instead of waiting for the next slow tick. This catches
-	// the common "summary.json has a clean title but meta.title is
-	// empty / leaky" case that the LLM-retry path can't see.
+	// the "summary.json has a clean title but meta.title is empty /
+	// leaky" case that the LLM-retry path can't see.
 	if s.d.autofixSched != nil {
 		results := s.d.autofixSched.RunNow(s.d.ctx)
-		resp.AutofixRan = true
+		nonClean := 0
 		for _, r := range results {
 			if r.Status == autofix.StatusClean {
 				continue
 			}
-			if r.Summary != "" {
-				resp.AutofixSummaries = append(resp.AutofixSummaries, r.Summary)
-			}
-			if r.Slug == "session-meta-titles" {
-				resp.MetaTitlesRepaired += parseRecoveredCount(r.Summary)
-			}
+			nonClean++
 			if r.Status == autofix.StatusError {
-				resp.Errors = append(resp.Errors, fmt.Sprintf("autofix %s: %s", r.Slug, r.Summary))
+				logger.Warn("autofix check error",
+					"slug", r.Slug, "summary", r.Summary, "repo", r.Repo)
 			}
 		}
+		logger.Info("autofix RunNow complete",
+			"checks", len(results), "non_clean", nonClean)
 	}
 
-	// trigger session finalization detection (bypasses hourly cooldown)
+	// trigger session finalization detection (bypasses ticker cooldown)
 	if s.d.agentWorker != nil {
 		queued := s.d.agentWorker.ForceDetect()
-		resp.SessionFinalizeTriggered = true
-		resp.SessionFinalizeQueued = queued
+		logger.Info("ForceDetect complete", "queued", queued)
 	}
-	// restart tail-mode watchers for recordings that lost their watcher (daemon restart)
-	// and clean up watchers for sessions that have been stopped or orphaned
+	// restart tail-mode watchers for recordings that lost their watcher
+	// (daemon restart) and clean up watchers for stopped/orphaned sessions
 	if s.d.sessionWatcher != nil {
 		s.d.sessionWatcher.DetectAndRestart(s.d.config.LedgerPath)
 		s.d.sessionWatcher.Cleanup()
 	}
-	return resp
-}
 
-// parseRecoveredCount extracts the "recovered=N" integer from the
-// session-meta-titles check summary. The summary shape is fixed by
-// internal/doctor/autofix/default_checks.go, so a small regex-free
-// scan is sufficient. Returns 0 on any parse failure — the value is
-// informational, not load-bearing for control flow.
-func parseRecoveredCount(summary string) int {
-	const key = "recovered="
-	i := strings.Index(summary, key)
-	if i < 0 {
-		return 0
-	}
-	rest := summary[i+len(key):]
-	end := 0
-	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
-		end++
-	}
-	if end == 0 {
-		return 0
-	}
-	n, err := strconv.Atoi(rest[:end])
-	if err != nil {
-		return 0
-	}
-	return n
+	logger.Info("doctor pass complete", "duration_ms", time.Since(start).Milliseconds())
 }
 
 func (s *daemonServiceImpl) SessionFinalize(payload SessionFinalizeIPCPayload) {

--- a/internal/daemon/daemon_doctor_test.go
+++ b/internal/daemon/daemon_doctor_test.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDoctor_AsyncSingleFlight pins the contract that Doctor() returns
+// immediately (BackgroundStarted=true) on the first call and returns
+// AlreadyRunning=true on a concurrent second call without starting a
+// second pass. Without this, two concurrent Doctor() invocations would
+// race two ForceDetect walks across the same ledger and double-process
+// the same sessions.
+//
+// Failure prevented: regression that re-introduces synchronous Doctor()
+// or drops the single-flight guard, causing IPC timeouts on large
+// ledgers and racing finalize work.
+func TestDoctor_AsyncSingleFlight(t *testing.T) {
+	// Use a zero-value Daemon: scheduler nil-guarded, autofixSched/
+	// agentWorker/sessionWatcher already nil-guarded in runDoctorPass.
+	// We just need the doctorRunning atomic and the wg, both zero-value safe.
+	d := &Daemon{logger: slog.New(slog.NewTextHandler(testWriter{t}, nil))}
+	svc := &daemonServiceImpl{d: d}
+
+	// First call: claims the slot, kicks off a goroutine.
+	resp1 := svc.Doctor()
+	assert.True(t, resp1.BackgroundStarted, "first call must report BackgroundStarted")
+	assert.False(t, resp1.AlreadyRunning, "first call must NOT be AlreadyRunning")
+
+	// Race: while the first goroutine is running, fire many concurrent
+	// follow-up calls. Each must return AlreadyRunning=true and NOT
+	// start its own goroutine.
+	const concurrent = 20
+	var wg sync.WaitGroup
+	results := make([]*DoctorResponse, concurrent)
+	for i := 0; i < concurrent; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = svc.Doctor()
+		}()
+	}
+	wg.Wait()
+
+	// At least some of the concurrent calls must have hit the in-flight
+	// guard. (We can't assert ALL of them because the first goroutine
+	// may have completed before a particular follow-up landed — that's
+	// fine: those return BackgroundStarted=true for a fresh pass.)
+	var alreadyRunning, started int
+	for _, r := range results {
+		switch {
+		case r.AlreadyRunning:
+			alreadyRunning++
+		case r.BackgroundStarted:
+			started++
+		default:
+			t.Errorf("call returned neither AlreadyRunning nor BackgroundStarted: %+v", r)
+		}
+	}
+	if alreadyRunning == 0 {
+		t.Errorf("expected at least one of %d concurrent calls to see AlreadyRunning, got 0", concurrent)
+	}
+
+	// Wait for all spawned goroutines to drain before returning so the
+	// test doesn't leak. wg.Wait() on Daemon's wg covers any goroutines
+	// the daemon started internally.
+	done := make(chan struct{})
+	go func() {
+		d.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("doctor goroutines did not drain within 2s")
+	}
+
+	// After draining, doctorRunning must be cleared so a future call
+	// can start a fresh pass — otherwise we'd permanently lock out
+	// the user after one Doctor() call.
+	assert.False(t, d.doctorRunning.Load(),
+		"doctorRunning must be cleared after the goroutine exits")
+}
+
+// testWriter routes slog output to t.Log so test failures include the
+// daemon logs without polluting normal stderr.
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}

--- a/internal/daemon/fd_limit_freebsd.go
+++ b/internal/daemon/fd_limit_freebsd.go
@@ -1,0 +1,20 @@
+//go:build freebsd
+
+package daemon
+
+import "syscall"
+
+// CurrentProcessFDLimit returns the soft RLIMIT_NOFILE for the current
+// process, or 0 if it cannot be determined.
+//
+// On freebsd syscall.Rlimit.Cur is int64 (vs uint64 on linux/darwin), so
+// the conversion is required here. Kept in its own file so the unconvert
+// linter doesn't flag it on the platforms where the cast is a no-op.
+// Negative values can't occur for RLIMIT_NOFILE in practice.
+func CurrentProcessFDLimit() uint64 {
+	var rlim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
+		return 0
+	}
+	return uint64(rlim.Cur)
+}

--- a/internal/daemon/fd_limit_unix.go
+++ b/internal/daemon/fd_limit_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !freebsd
 
 package daemon
 
@@ -11,15 +11,12 @@ import "syscall"
 //
 // Unix-only because syscall.Getrlimit / syscall.Rlimit / syscall.RLIMIT_NOFILE
 // are guarded by `//go:build unix` upstream and don't exist for GOOS=windows.
-// See fd_limit_windows.go for the Windows stub.
-//
-// rlim.Cur is uint64 on linux and darwin but int64 on freebsd; cast to keep
-// the cross-GOOS return type stable. Negative values can't occur for
-// RLIMIT_NOFILE in practice.
+// See fd_limit_windows.go for the Windows stub and fd_limit_freebsd.go for
+// the freebsd variant where rlim.Cur is signed and needs an explicit cast.
 func CurrentProcessFDLimit() uint64 {
 	var rlim syscall.Rlimit
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
 		return 0
 	}
-	return uint64(rlim.Cur)
+	return rlim.Cur
 }

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -473,21 +473,35 @@ type WhisperHistoryResponse struct {
 }
 
 // DoctorResponse is the response for the doctor IPC message.
+//
+// The Doctor RPC is asynchronous: the daemon kicks off the heavy work
+// (autofix scheduler RunNow, ForceDetect across all session caches,
+// session-watcher detect/restart/cleanup) in a background goroutine and
+// returns immediately. Results surface via the daemon's IssueTracker
+// (visible in `ox daemon status`) and the agent worker queue (also
+// reflected in status). This shape exists so the IPC ping itself is a
+// few milliseconds even on ledgers with thousands of sessions.
+//
+// The legacy synchronous result fields (Autofix*, SessionFinalize*) are
+// retained for backwards compatibility with any caller that still reads
+// them, but newly written code should rely on BackgroundStarted /
+// AlreadyRunning and route the user to status/logs for results.
 type DoctorResponse struct {
+	// Async lifecycle indicators (preferred).
+	BackgroundStarted bool `json:"background_started,omitempty"` // a fresh doctor pass was kicked off
+	AlreadyRunning    bool `json:"already_running,omitempty"`    // a prior pass is still in progress; this call was a no-op
+
+	// Legacy synchronous fields. Populated only when the daemon ran
+	// the work inline (e.g., older daemon versions, or unit tests
+	// driving the impl synchronously). Production callers in 0.7.2+
+	// see these empty.
 	AntiEntropyTriggered     bool     `json:"anti_entropy_triggered"`
 	ClonesTriggered          int      `json:"clones_triggered"`
 	SessionFinalizeTriggered bool     `json:"session_finalize_triggered"`
 	SessionFinalizeQueued    int      `json:"session_finalize_queued"`
-
-	// Autofix breakdown — populated when the daemon runs its
-	// auto-fix-safe checks (e.g., session-meta-titles repair) on the
-	// caller's workspace as part of Doctor(). Surfaced separately from
-	// SessionFinalizeQueued because these don't run the LLM — they
-	// only rewrite meta.json from already-good summary.json titles or
-	// bump the bounded retry counter toward "unrecoverable."
-	AutofixRan        bool     `json:"autofix_ran,omitempty"`
-	AutofixSummaries  []string `json:"autofix_summaries,omitempty"` // one summary per non-clean check, e.g. "session meta titles: recovered=2 ..."
-	MetaTitlesRepaired int     `json:"meta_titles_repaired,omitempty"`
+	AutofixRan               bool     `json:"autofix_ran,omitempty"`
+	AutofixSummaries         []string `json:"autofix_summaries,omitempty"`
+	MetaTitlesRepaired       int      `json:"meta_titles_repaired,omitempty"`
 
 	Errors []string `json:"errors,omitempty"`
 }

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -478,7 +478,18 @@ type DoctorResponse struct {
 	ClonesTriggered          int      `json:"clones_triggered"`
 	SessionFinalizeTriggered bool     `json:"session_finalize_triggered"`
 	SessionFinalizeQueued    int      `json:"session_finalize_queued"`
-	Errors                   []string `json:"errors,omitempty"`
+
+	// Autofix breakdown — populated when the daemon runs its
+	// auto-fix-safe checks (e.g., session-meta-titles repair) on the
+	// caller's workspace as part of Doctor(). Surfaced separately from
+	// SessionFinalizeQueued because these don't run the LLM — they
+	// only rewrite meta.json from already-good summary.json titles or
+	// bump the bounded retry counter toward "unrecoverable."
+	AutofixRan        bool     `json:"autofix_ran,omitempty"`
+	AutofixSummaries  []string `json:"autofix_summaries,omitempty"` // one summary per non-clean check, e.g. "session meta titles: recovered=2 ..."
+	MetaTitlesRepaired int     `json:"meta_titles_repaired,omitempty"`
+
+	Errors []string `json:"errors,omitempty"`
 }
 
 // TriggerGCResponse is the response for trigger_gc requests.

--- a/internal/doctor/autofix/registry.go
+++ b/internal/doctor/autofix/registry.go
@@ -128,3 +128,12 @@ func (c *Check) shouldRun(now time.Time) bool {
 	c.lastRunAt = now
 	return true
 }
+
+// markRun records a forced invocation in lastRunAt without consulting
+// MinInterval. Used by Scheduler.RunNow to keep the throttle clock
+// honest after a user-triggered bypass.
+func (c *Check) markRun(now time.Time) {
+	c.lastRunMu.Lock()
+	defer c.lastRunMu.Unlock()
+	c.lastRunAt = now
+}

--- a/internal/doctor/autofix/scheduler.go
+++ b/internal/doctor/autofix/scheduler.go
@@ -100,7 +100,30 @@ func (s *Scheduler) Run(ctx context.Context) {
 // so callers get the same observable side-effects whether the
 // scheduler is running on its ticker or invoked imperatively.
 func (s *Scheduler) RunOnce(ctx context.Context) []CheckResult {
-	results := s.tickCollect(ctx)
+	results := s.tickCollect(ctx, false)
+	if s.emit != nil {
+		for _, r := range results {
+			if r.Status == StatusClean {
+				continue
+			}
+			s.emit(r)
+		}
+	}
+	return results
+}
+
+// RunNow is RunOnce with the per-check MinInterval throttle disabled.
+// Intended for explicit user-triggered invocations like
+// `ox doctor --force-session-uploads`, where the user has asked the
+// daemon to do its anti-entropy work _right now_ regardless of when
+// the slow ticker last ran.
+//
+// Throttling exists to keep the unattended ticker from spamming work;
+// it should not gate explicit human-triggered runs. RunNow advances
+// each check's lastRunAt so the next ticker round still respects the
+// throttle relative to this call.
+func (s *Scheduler) RunNow(ctx context.Context) []CheckResult {
+	results := s.tickCollect(ctx, true)
 	if s.emit != nil {
 		for _, r := range results {
 			if r.Status == StatusClean {
@@ -113,7 +136,7 @@ func (s *Scheduler) RunOnce(ctx context.Context) []CheckResult {
 }
 
 func (s *Scheduler) tick(ctx context.Context) {
-	results := s.tickCollect(ctx)
+	results := s.tickCollect(ctx, false)
 	for _, r := range results {
 		if r.Status == StatusClean {
 			continue
@@ -129,7 +152,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 	}
 }
 
-func (s *Scheduler) tickCollect(ctx context.Context) []CheckResult {
+func (s *Scheduler) tickCollect(ctx context.Context, force bool) []CheckResult {
 	checks := s.registry.All()
 	var paths []string
 	if s.workspace != nil {
@@ -143,8 +166,11 @@ func (s *Scheduler) tickCollect(ctx context.Context) []CheckResult {
 	now := time.Now()
 	results := make([]CheckResult, 0, len(checks)*len(paths))
 	for _, c := range checks {
-		if !c.shouldRun(now) {
+		if !force && !c.shouldRun(now) {
 			continue
+		}
+		if force {
+			c.markRun(now)
 		}
 		for _, p := range paths {
 			select {

--- a/internal/doctor/autofix/scheduler_test.go
+++ b/internal/doctor/autofix/scheduler_test.go
@@ -137,6 +137,56 @@ func TestCheck_ShouldRun_RespectsMinInterval(t *testing.T) {
 	}
 }
 
+// TestScheduler_RunNow_BypassesThrottle pins the contract that
+// user-triggered Doctor() RPCs (e.g., `ox doctor --force-session-uploads`)
+// actually perform their auto-fix work even when the slow ticker just
+// finished a round. Without this, the user-facing button silently
+// becomes a no-op for 30 minutes after every scheduler tick.
+//
+// Failure prevented: a future refactor that gates RunNow on shouldRun
+// ships a regressed user experience.
+func TestScheduler_RunNow_BypassesThrottle(t *testing.T) {
+	var calls atomic.Int32
+	reg := NewRegistry()
+	reg.Register(&Check{
+		Slug:        "throttled",
+		MinInterval: time.Hour,
+		Run: func(_ context.Context, _ string) CheckResult {
+			calls.Add(1)
+			return CheckResult{Status: StatusFixed, Summary: "did the thing"}
+		},
+	})
+	s := NewScheduler(reg, nil, func() []string { return []string{"/x"} }, nil)
+
+	// First RunOnce establishes the throttle clock.
+	_ = s.RunOnce(context.Background())
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("first RunOnce: calls=%d, want 1", got)
+	}
+
+	// Second RunOnce within MinInterval should be throttled — no call.
+	_ = s.RunOnce(context.Background())
+	if got := calls.Load(); got != 1 {
+		t.Errorf("RunOnce within throttle: calls=%d, want still 1", got)
+	}
+
+	// RunNow MUST run the check despite the throttle.
+	results := s.RunNow(context.Background())
+	if got := calls.Load(); got != 2 {
+		t.Errorf("RunNow within throttle: calls=%d, want 2", got)
+	}
+	if len(results) != 1 || results[0].Slug != "throttled" {
+		t.Errorf("RunNow results = %+v, want one result for slug=throttled", results)
+	}
+
+	// And after RunNow, the throttle clock advances — a follow-up RunOnce
+	// is throttled again, not perpetually open.
+	_ = s.RunOnce(context.Background())
+	if got := calls.Load(); got != 2 {
+		t.Errorf("RunOnce after RunNow within throttle: calls=%d, want still 2", got)
+	}
+}
+
 // TestRegistry_Register_OverwritesSlug guarantees the test-stub use
 // case: a test can swap a check by re-registering its slug, without
 // having to invent a removal API. Documenting via test so a future


### PR DESCRIPTION
## Summary

`ox doctor --force-session-uploads` was a near-no-op for the case it was supposed to repair. Three coupled gaps, plus an async refactor of the IPC:

1. **50ms IPC timeout** in `runForceSessionUploads` made the call error with `read unix … i/o timeout` on real ledgers. Now uses 5s with a 30s retry on timeout (mirrors `daemonStatusCmd`).
2. **Autofix scheduler was 30m-throttled only.** The `session-meta-titles` check (recovers `meta.title` from a clean `summary.json`) never ran on user-trigger. Added `Scheduler.RunNow` that bypasses the per-check throttle (advancing `lastRunAt` so the next tick still respects it), wired into `Doctor()`.
3. **`Detect()` blind spot.** Sessions with all artifacts present, no `.needs-summary` marker, but a failure-stub `summary.json` (empty title, `meta.SummaryStatus != unrecoverable`, `meta.SummaryAttempts < MaxSummaryAttempts`) were silently skipped — no repair path short of deleting artifacts by hand. `Detect` now enqueues these for full LLM re-finalization, gated by `MaxSummaryAttempts`.
4. **Async Doctor() with single-flight guard.** Even with the timeout fix, a full doctor pass on a real ledger walks ~290 sessions twice (autofix + ForceDetect) and didn't fit in 30s. Doctor() now kicks the heavy work off in a goroutine and returns in milliseconds with `BackgroundStarted: true`. Concurrent calls during an in-flight pass return `AlreadyRunning: true` and do NOT start a second pass — preventing two ForceDetect walks from racing on the same ledger. Results surface via the daemon's IssueTracker (`ox daemon status`) and agent worker queue (visible in status + `ox daemon logs -f`).

## Trigger flow

```mermaid
sequenceDiagram
  participant CLI as ox doctor --force-session-uploads
  participant Daemon
  participant Goroutine as doctor goroutine (single-flight)
  participant Autofix as autofix.Scheduler
  participant Detect as SessionFinalizeHandler.Detect
  participant Worker as agentWorker queue
  CLI->>Daemon: Doctor() RPC
  alt no pass running
    Daemon->>Goroutine: kick off
    Daemon-->>CLI: BackgroundStarted=true (instant)
    Goroutine->>Autofix: RunNow(ctx) — bypass 30m throttle
    Autofix-->>Goroutine: meta-titles {recovered, bumped, flipped}
    Goroutine->>Detect: ForceDetect()
    Note over Detect: now also catches empty-title<br/>summary.json stubs
    Detect-->>Worker: enqueue full re-finalize
  else pass already running
    Daemon-->>CLI: AlreadyRunning=true (instant, no-op)
  end
  CLI->>CLI: print kick-off + route to ox daemon status / logs
```

## Test plan

- [x] `TestDetect_EmptyTitleSummaryStubTriggersRetry` — three boundary cases (retryable enqueued, unrecoverable skipped, autofix-recoverable left alone).
- [x] `TestScheduler_RunNow_BypassesThrottle` — pins user-triggered runs always execute and the throttle clock advances afterward.
- [x] `TestDoctor_AsyncSingleFlight` — 20 concurrent Doctor() calls; at least some must hit `AlreadyRunning`, guard must clear after goroutine drains.
- [x] `make build` + `go test -short ./internal/daemon/... ./internal/doctor/... ./internal/lfs/... ./cmd/ox/` — all pass.
- [x] E2E on real ledger (speaker, ~290 sessions): prior behavior errored with `i/o timeout` even at 30s. New behavior returns instantly; daemon goroutine completes a full pass in ~305ms; 34 sessions queued for LLM retry that prior code silently dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doctor pass now runs asynchronously in the background with improved status reporting.
  * Sessions with empty summary titles now automatically retry finalization.
  * Autofix scheduler can now force immediate execution, bypassing normal throttling.
  * Added FreeBSD support for system resource monitoring.

* **Improvements**
  * Enhanced concurrent protection prevents duplicate simultaneous doctor operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->