### PR TITLE
feat(amp): record sessions via user-global ox-bridge plugin

### DIFF
--- a/cmd/ox-adapter-amp/detect.go
+++ b/cmd/ox-adapter-amp/detect.go
@@ -63,5 +63,23 @@ func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.Diagnose
 		}
 	}
 
+	// User-global ox-bridge plugin must exist for the adapter to read
+	// any sessions on current Amp. install-hooks installs it as a
+	// side-effect, so the same fix-it command surfaces it.
+	if _, err := os.Stat(userBridgePluginPath()); os.IsNotExist(err) {
+		fix := "ox-adapter-amp install-hooks --scope project"
+		if p.RepoRoot != "" {
+			fix = "ox-adapter-amp install-hooks --repo-root " + p.RepoRoot + " --scope project"
+		}
+		issues = append(issues, adapterprotocol.DiagnoseIssue{
+			Slug:     "amp:bridge-plugin-missing",
+			Severity: "warning",
+			Title:    "Amp ox-bridge plugin not installed",
+			Detail:   "~/.config/amp/plugins/ox-bridge.ts is missing; the adapter has no session transcripts to read until install-hooks runs.",
+			Fix:      fix,
+			FixSafe:  true,
+		})
+	}
+
 	return &adapterprotocol.DiagnoseResult{OK: len(issues) == 0, Issues: issues}, nil
 }

--- a/cmd/ox-adapter-amp/detect.go
+++ b/cmd/ox-adapter-amp/detect.go
@@ -65,20 +65,24 @@ func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.Diagnose
 
 	// User-global ox-bridge plugin must exist for the adapter to read
 	// any sessions on current Amp. install-hooks installs it as a
-	// side-effect, so the same fix-it command surfaces it.
-	if _, err := os.Stat(userBridgePluginPath()); os.IsNotExist(err) {
-		fix := "ox-adapter-amp install-hooks --scope project"
-		if p.RepoRoot != "" {
-			fix = "ox-adapter-amp install-hooks --repo-root " + p.RepoRoot + " --scope project"
+	// side-effect, so the same fix-it command surfaces it. If the home
+	// directory itself can't be resolved, skip this check rather than
+	// reporting a misleading "missing" issue — install would fail too.
+	if bridgePath, err := userBridgePluginPath(); err == nil {
+		if _, statErr := os.Stat(bridgePath); os.IsNotExist(statErr) {
+			fix := "ox-adapter-amp install-hooks --scope project"
+			if p.RepoRoot != "" {
+				fix = "ox-adapter-amp install-hooks --repo-root " + p.RepoRoot + " --scope project"
+			}
+			issues = append(issues, adapterprotocol.DiagnoseIssue{
+				Slug:     "amp:bridge-plugin-missing",
+				Severity: "warning",
+				Title:    "Amp ox-bridge plugin not installed",
+				Detail:   "~/.config/amp/plugins/ox-bridge.ts is missing; the adapter has no session transcripts to read until install-hooks runs.",
+				Fix:      fix,
+				FixSafe:  true,
+			})
 		}
-		issues = append(issues, adapterprotocol.DiagnoseIssue{
-			Slug:     "amp:bridge-plugin-missing",
-			Severity: "warning",
-			Title:    "Amp ox-bridge plugin not installed",
-			Detail:   "~/.config/amp/plugins/ox-bridge.ts is missing; the adapter has no session transcripts to read until install-hooks runs.",
-			Fix:      fix,
-			FixSafe:  true,
-		})
 	}
 
 	return &adapterprotocol.DiagnoseResult{OK: len(issues) == 0, Issues: issues}, nil

--- a/cmd/ox-adapter-amp/hooks.go
+++ b/cmd/ox-adapter-amp/hooks.go
@@ -59,60 +59,56 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 		}, fmt.Errorf("amp does not support user-level hooks (no user-level AGENTS.md)")
 	}
 
+	// Project: AGENTS.md marker block (idempotent).
 	agentsPath := resolveAgentsMDPath(p.RepoRoot)
-
 	existing, err := os.ReadFile(agentsPath)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to read AGENTS.md: %w", err)
 	}
-
 	content := string(existing)
-
-	// already installed — idempotent (current or legacy markers)
-	if ampBlockAlreadyPresent(content) {
-		return &adapterprotocol.InstallHooksResponse{
-			Installed:    true,
-			FilesWritten: []string{agentsPath},
-		}, nil
+	if !ampBlockAlreadyPresent(content) {
+		var newContent string
+		if content == "" {
+			newContent = ampPrimeBlock + "\n"
+		} else {
+			newContent = strings.TrimRight(content, "\n") + "\n\n" + ampPrimeBlock + "\n"
+		}
+		if err := fileutil.AtomicWriteBytes(agentsPath, []byte(newContent), 0644); err != nil {
+			return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
+		}
 	}
 
-	var newContent string
-	if content == "" {
-		newContent = ampPrimeBlock + "\n"
-	} else {
-		newContent = strings.TrimRight(content, "\n") + "\n\n" + ampPrimeBlock + "\n"
+	// User-global: ox-bridge.ts plugin. Installed once per machine
+	// regardless of which project triggered install-hooks — Amp loads
+	// ~/.config/amp/plugins/ for every session, so we don't need (and
+	// shouldn't) drop a plugin file into each repo.
+	bridgePath := userBridgePluginPath()
+	if err := os.MkdirAll(filepath.Dir(bridgePath), 0755); err != nil {
+		return nil, fmt.Errorf("failed to create plugin dir: %w", err)
 	}
-
-	if err := fileutil.AtomicWriteBytes(agentsPath, []byte(newContent), 0644); err != nil {
-		return nil, fmt.Errorf("failed to write AGENTS.md: %w", err)
+	if err := fileutil.AtomicWriteBytes(bridgePath, oxBridgePluginSrc, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write ox-bridge plugin: %w", err)
 	}
 
 	return &adapterprotocol.InstallHooksResponse{
 		Installed:    true,
-		FilesWritten: []string{agentsPath},
+		FilesWritten: []string{agentsPath, bridgePath},
 	}, nil
 }
 
 func handleCheckHooks(p adapterprotocol.HookParams) (*adapterprotocol.CheckHooksResponse, error) {
 	if p.Scope == "user" {
-		return &adapterprotocol.CheckHooksResponse{
-			Installed: false,
-			Scope:     p.Scope,
-		}, nil
+		return &adapterprotocol.CheckHooksResponse{Installed: false, Scope: p.Scope}, nil
 	}
 
 	agentsPath := resolveAgentsMDPath(p.RepoRoot)
 	data, err := os.ReadFile(agentsPath)
 	if err != nil {
-		return &adapterprotocol.CheckHooksResponse{
-			Installed: false,
-			Scope:     p.Scope,
-		}, nil
+		return &adapterprotocol.CheckHooksResponse{Installed: false, Scope: p.Scope}, nil
 	}
 
-	installed := ampBlockAlreadyPresent(string(data))
 	return &adapterprotocol.CheckHooksResponse{
-		Installed: installed,
+		Installed: ampBlockAlreadyPresent(string(data)),
 		Scope:     p.Scope,
 		HookFiles: []string{agentsPath},
 	}, nil
@@ -123,6 +119,9 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 		return &adapterprotocol.UninstallHooksResponse{Uninstalled: true}, nil
 	}
 
+	// Only project-scope state is touched here. The user-global bridge
+	// plugin is intentionally left in place — other repos on the same
+	// machine may still be using it.
 	agentsPath := resolveAgentsMDPath(p.RepoRoot)
 	data, err := os.ReadFile(agentsPath)
 	if err != nil {
@@ -133,10 +132,6 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 	}
 
 	content := string(data)
-
-	// remove both the current-marker block and any legacy-marker block —
-	// a pre-#527 installation may carry the generic <!-- ox:prime:start -->
-	// pair that we no longer emit.
 	cleaned := removePrimeBlock(content, ampPrimeMarkerStart, ampPrimeMarkerEnd)
 	cleaned = removePrimeBlock(cleaned, ampLegacyPrimeMarkerStart, ampLegacyPrimeMarkerEnd)
 

--- a/cmd/ox-adapter-amp/hooks.go
+++ b/cmd/ox-adapter-amp/hooks.go
@@ -82,7 +82,10 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 	// regardless of which project triggered install-hooks — Amp loads
 	// ~/.config/amp/plugins/ for every session, so we don't need (and
 	// shouldn't) drop a plugin file into each repo.
-	bridgePath := userBridgePluginPath()
+	bridgePath, err := userBridgePluginPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve plugin path: %w", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(bridgePath), 0755); err != nil {
 		return nil, fmt.Errorf("failed to create plugin dir: %w", err)
 	}

--- a/cmd/ox-adapter-amp/hooks_test.go
+++ b/cmd/ox-adapter-amp/hooks_test.go
@@ -90,7 +90,8 @@ func TestAmpInstall_WritesUserBridgePlugin(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.Installed)
 
-	bridge := userBridgePluginPath()
+	bridge, err := userBridgePluginPath()
+	require.NoError(t, err)
 	data, err := os.ReadFile(bridge)
 	require.NoError(t, err, "user-global bridge plugin must be written")
 	assert.Equal(t, oxBridgePluginSrc, data)
@@ -107,7 +108,8 @@ func TestAmpUninstall_PreservesUserBridgePlugin(t *testing.T) {
 
 	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
 	require.NoError(t, err)
-	bridge := userBridgePluginPath()
+	bridge, err := userBridgePluginPath()
+	require.NoError(t, err)
 	require.FileExists(t, bridge)
 
 	_, err = handleUninstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})

--- a/cmd/ox-adapter-amp/hooks_test.go
+++ b/cmd/ox-adapter-amp/hooks_test.go
@@ -75,3 +75,42 @@ func TestAmpUninstall_RemovesCurrentAndLegacyBlocks(t *testing.T) {
 		assert.NotContains(t, got, ampLegacyPrimeMarkerStart)
 	}
 }
+
+// TestAmpInstall_WritesUserBridgePlugin guards the new architecture:
+// install-hooks writes the embedded plugin to ~/.config/amp/plugins/
+// once per machine, regardless of which project triggered the install.
+// Failure prevented: silent regression to the old "marker-only" install
+// that leaves users with a broken adapter (Amp persists no transcripts
+// on its own; the bridge is the only source of session data).
+func TestAmpInstall_WritesUserBridgePlugin(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	resp, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+	require.True(t, resp.Installed)
+
+	bridge := userBridgePluginPath()
+	data, err := os.ReadFile(bridge)
+	require.NoError(t, err, "user-global bridge plugin must be written")
+	assert.Equal(t, oxBridgePluginSrc, data)
+	assert.Contains(t, resp.FilesWritten, bridge)
+}
+
+// TestAmpUninstall_PreservesUserBridgePlugin protects the multi-project
+// invariant: removing the marker from project A must NOT delete the
+// user-global plugin, because project B on the same machine may still
+// rely on it. Failure prevented: cross-project breakage on uninstall.
+func TestAmpUninstall_PreservesUserBridgePlugin(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+	bridge := userBridgePluginPath()
+	require.FileExists(t, bridge)
+
+	_, err = handleUninstallHooks(adapterprotocol.HookParams{RepoRoot: dir, Scope: "project"})
+	require.NoError(t, err)
+	assert.FileExists(t, bridge, "user-global bridge plugin must survive project uninstall")
+}

--- a/cmd/ox-adapter-amp/main.go
+++ b/cmd/ox-adapter-amp/main.go
@@ -5,9 +5,10 @@
 //
 //  1. an AGENTS.md "ox prime" marker block so the model knows to run
 //     `ox agent prime` at session start, and
-//  2. a Bun plugin at .amp/plugins/ox-bridge.ts (embedded via go:embed)
-//     that subscribes to Amp's plugin events and writes a per-thread
-//     JSONL sidecar to ~/.cache/amp/ox-sessions/<thread-id>.jsonl.
+//  2. a Bun plugin at ~/.config/amp/plugins/ox-bridge.ts (embedded via
+//     go:embed, installed user-globally so one plugin serves every
+//     project) that subscribes to Amp's plugin events and writes a
+//     per-thread JSONL sidecar to ~/.cache/amp/ox-sessions/<thread-id>.jsonl.
 //
 // The adapter discovers and tails those sidecar files via FindSession +
 // Serve. For pre-2026 Amp installs that wrote ~/.amp/sessions/*.jsonl

--- a/cmd/ox-adapter-amp/main.go
+++ b/cmd/ox-adapter-amp/main.go
@@ -1,7 +1,18 @@
 // ox-adapter-amp is the external adapter binary for Sourcegraph Amp sessions.
 //
-// Amp stores sessions as JSONL in ~/.amp/sessions/*.jsonl.
-// Hooks are installed via AGENTS.md markers in the project root.
+// Current Amp does not persist conversation transcripts to disk on its
+// own. install-hooks therefore drops two artifacts into a project:
+//
+//  1. an AGENTS.md "ox prime" marker block so the model knows to run
+//     `ox agent prime` at session start, and
+//  2. a Bun plugin at .amp/plugins/ox-bridge.ts (embedded via go:embed)
+//     that subscribes to Amp's plugin events and writes a per-thread
+//     JSONL sidecar to ~/.cache/amp/ox-sessions/<thread-id>.jsonl.
+//
+// The adapter discovers and tails those sidecar files via FindSession +
+// Serve. For pre-2026 Amp installs that wrote ~/.amp/sessions/*.jsonl
+// directly, discovery falls back to the legacy directory so existing
+// users keep working without a reinstall.
 package main
 
 import (

--- a/cmd/ox-adapter-amp/plugin/ox-bridge.ts
+++ b/cmd/ox-adapter-amp/plugin/ox-bridge.ts
@@ -1,0 +1,70 @@
+/**
+ * ox-bridge — minimal SageOx ↔ Amp session-recording plugin.
+ *
+ * Amp does not persist conversation transcripts. This plugin tails Amp's
+ * Plugin API events and appends one JSONL line per event to
+ * `~/.cache/amp/ox-sessions/<thread-id>.jsonl`, in the schema the
+ * `ox-adapter-amp` Go binary already understands (`session_meta`,
+ * `user`, `assistant`, `tool_use`, `tool_result`).
+ *
+ * Installed by `ox-adapter-amp install-hooks` into the user-scope plugin
+ * dir (`~/.config/amp/plugins/`) so one plugin serves every project.
+ */
+
+import type { PluginAPI } from '@ampcode/plugin';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const DIR = join(homedir(), '.cache', 'amp', 'ox-sessions');
+mkdirSync(DIR, { recursive: true });
+
+const write = (tid: string, obj: Record<string, unknown>): void =>
+  appendFileSync(
+    join(DIR, `${tid}.jsonl`),
+    JSON.stringify({ ...obj, timestamp: new Date().toISOString() }) + '\n'
+  );
+
+const str = (v: unknown): string =>
+  v == null ? '' : typeof v === 'string' ? v : JSON.stringify(v);
+
+const assistantText = (m: unknown): string => {
+  const c = (m as { content?: unknown })?.content;
+  if (typeof c === 'string') return c;
+  if (Array.isArray(c))
+    return c
+      .map((b) => (typeof b === 'string' ? b : (b as { text?: string })?.text ?? ''))
+      .join('\n');
+  return '';
+};
+
+export default function (amp: PluginAPI) {
+  amp.on('session.start', (e) => {
+    if (e.thread?.id) write(e.thread.id, { type: 'session_meta', session_id: e.thread.id });
+  });
+  amp.on('agent.start', (e) => write(e.thread.id, { type: 'user', content: e.message }));
+  amp.on('tool.call', (e) => {
+    write(e.thread.id, {
+      type: 'tool_use',
+      tool_name: e.tool,
+      tool_input: str(e.input),
+      call_id: e.toolUseID,
+    });
+    return { action: 'allow' as const };
+  });
+  amp.on('tool.result', (e) =>
+    write(e.thread.id, {
+      type: 'tool_result',
+      content: str(e.output ?? e.error ?? ''),
+      is_error: e.status === 'error',
+      call_id: e.toolUseID,
+    })
+  );
+  amp.on('agent.end', (e) => {
+    for (const m of e.messages ?? []) {
+      if ((m as { role?: string }).role !== 'assistant') continue;
+      const text = assistantText(m).trim();
+      if (text) write(e.thread.id, { type: 'assistant', content: text });
+    }
+  });
+}

--- a/cmd/ox-adapter-amp/plugin_embed.go
+++ b/cmd/ox-adapter-amp/plugin_embed.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	_ "embed"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -13,9 +14,21 @@ import (
 var oxBridgePluginSrc []byte
 
 // userBridgePluginPath returns the canonical user-scope path for the
-// bridge plugin. Amp's plugin loader scans this directory automatically
-// (see https://ampcode.com/manual#plugins).
-func userBridgePluginPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", "amp", "plugins", "ox-bridge.ts")
+// bridge plugin (~/.config/amp/plugins/ox-bridge.ts). Amp's plugin
+// loader scans this directory automatically — see
+// https://ampcode.com/manual#plugins.
+//
+// Returns an error rather than silently producing a cwd-relative path
+// when the home directory cannot be resolved, so install-hooks won't
+// drop the plugin in the wrong location. Tries os.UserHomeDir first
+// (honors $HOME on unix, $USERPROFILE on windows), falls back to $HOME
+// directly for environments where UserHomeDir is unhappy.
+func userBridgePluginPath() (string, error) {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".config", "amp", "plugins", "ox-bridge.ts"), nil
+	}
+	if home := os.Getenv("HOME"); home != "" {
+		return filepath.Join(home, ".config", "amp", "plugins", "ox-bridge.ts"), nil
+	}
+	return "", fmt.Errorf("cannot determine user home directory")
 }

--- a/cmd/ox-adapter-amp/plugin_embed.go
+++ b/cmd/ox-adapter-amp/plugin_embed.go
@@ -1,0 +1,21 @@
+// plugin_embed.go bundles the canonical ox-bridge Amp plugin into the
+// adapter binary. The plugin is installed user-globally — Amp loads it
+// for every project automatically, so it doesn't pollute individual repos.
+package main
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+)
+
+//go:embed plugin/ox-bridge.ts
+var oxBridgePluginSrc []byte
+
+// userBridgePluginPath returns the canonical user-scope path for the
+// bridge plugin. Amp's plugin loader scans this directory automatically
+// (see https://ampcode.com/manual#plugins).
+func userBridgePluginPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "amp", "plugins", "ox-bridge.ts")
+}

--- a/cmd/ox-adapter-amp/session.go
+++ b/cmd/ox-adapter-amp/session.go
@@ -202,27 +202,13 @@ func ampSessionsDirs(home string) []string {
 	}
 }
 
-// resolveSessionsDir picks the first existing candidate directory. If
-// none exist it returns the preferred (new) path so callers get a
-// meaningful "directory not found" error pointing at the place where
-// install-hooks should put a plugin.
-func resolveSessionsDir(home string) string {
-	candidates := ampSessionsDirs(home)
-	for _, d := range candidates {
-		if info, err := os.Stat(d); err == nil && info.IsDir() {
-			return d
-		}
-	}
-	return candidates[0]
-}
-
 func findAmpSession(_, agentID, since, agentSessionID string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
 
-	sessionsDir := resolveSessionsDir(home)
+	dirs := ampSessionsDirs(home)
 
 	// direct lookup by session ID
 	if agentSessionID != "" {
@@ -231,7 +217,7 @@ func findAmpSession(_, agentID, since, agentSessionID string) (string, error) {
 		}
 		// Search every candidate directory by ID — covers users mid-
 		// migration who have files in both locations.
-		for _, d := range ampSessionsDirs(home) {
+		for _, d := range dirs {
 			direct := filepath.Join(d, agentSessionID+".jsonl")
 			if _, err := os.Stat(direct); err == nil {
 				return direct, nil
@@ -246,34 +232,52 @@ func findAmpSession(_, agentID, since, agentSessionID string) (string, error) {
 		}
 	}
 
-	entries, err := os.ReadDir(sessionsDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to read sessions dir %s: %w "+
-			"(install the ox-bridge plugin via "+
-			"`ox-adapter-amp install-hooks --repo-root <path> --scope project`)",
-			sessionsDir, err)
-	}
-
+	// Walk each candidate dir in priority order; stop as soon as one
+	// yields usable session files. This makes the legacy fallback
+	// actually work when the bridge dir exists but is still empty
+	// (e.g. a fresh install where no session has flushed yet).
 	var candidates []sessionCandidate
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
-			continue
-		}
-		info, err := entry.Info()
+	var lastReadErr error
+	for _, sessionsDir := range dirs {
+		entries, err := os.ReadDir(sessionsDir)
 		if err != nil {
+			if !os.IsNotExist(err) {
+				lastReadErr = err
+			}
 			continue
 		}
-		if !sinceTime.IsZero() && !info.ModTime().After(sinceTime) {
-			continue
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+				continue
+			}
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			if !sinceTime.IsZero() && !info.ModTime().After(sinceTime) {
+				continue
+			}
+			candidates = append(candidates, sessionCandidate{
+				path:    filepath.Join(sessionsDir, entry.Name()),
+				modTime: info.ModTime(),
+			})
 		}
-		candidates = append(candidates, sessionCandidate{
-			path:    filepath.Join(sessionsDir, entry.Name()),
-			modTime: info.ModTime(),
-		})
+		if len(candidates) > 0 {
+			break
+		}
 	}
 
 	if len(candidates) == 0 {
-		return "", fmt.Errorf("no amp sessions found")
+		if lastReadErr != nil {
+			return "", fmt.Errorf("failed to read sessions dirs %v: %w "+
+				"(install the ox-bridge plugin via "+
+				"`ox-adapter-amp install-hooks --repo-root <path> --scope project`)",
+				dirs, lastReadErr)
+		}
+		return "", fmt.Errorf("no amp sessions found in %v "+
+			"(install the ox-bridge plugin via "+
+			"`ox-adapter-amp install-hooks --repo-root <path> --scope project`)",
+			dirs)
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {

--- a/cmd/ox-adapter-amp/session.go
+++ b/cmd/ox-adapter-amp/session.go
@@ -1,12 +1,19 @@
 // session.go handles Amp session reading, parsing, discovery, and types.
 //
-// Amp stores sessions as JSONL in ~/.amp/sessions/<session-id>.jsonl. Each line
-// is a JSON object with "type" field: "user", "assistant", "tool_use",
-// "tool_result", "system", or "session_meta". Tool entries use "tool_name",
-// "tool_input", and "call_id" for correlation. Session metadata (model,
-// agent_version) is in a "session_meta" entry.
+// Current Amp does not persist conversation transcripts to disk. The
+// `ox-bridge` Bun plugin (installed by install-hooks into a project's
+// .amp/plugins/) writes a JSONL sidecar per thread to
+// ~/.cache/amp/ox-sessions/<thread-id>.jsonl as Amp emits plugin
+// lifecycle events. This file is what the adapter discovers and tails.
 //
-// Format reference: https://sourcegraph.com/docs/amp
+// Each line is a JSON object with "type" field: "user", "assistant",
+// "tool_use", "tool_result", "system", or "session_meta". Tool entries
+// use "tool_name", "tool_input", and "call_id" for correlation. Session
+// metadata (model, agent_version) is in a "session_meta" entry.
+//
+// For users on the legacy pre-2026 Amp (which wrote
+// ~/.amp/sessions/*.jsonl directly), the discovery path falls back to
+// the old location so existing installs keep working.
 package main
 
 import (
@@ -184,22 +191,51 @@ func parseAmpLine(line []byte) *adapterprotocol.RawEntry {
 
 // --- session discovery ---
 
+// ampSessionsDirs returns the candidate sessions directories in priority
+// order. The first existing directory wins. New installs use
+// ~/.cache/amp/ox-sessions/ (written by the ox-bridge plugin); legacy
+// installs (pre-2026 Amp) used ~/.amp/sessions/ directly.
+func ampSessionsDirs(home string) []string {
+	return []string{
+		filepath.Join(home, ".cache", "amp", "ox-sessions"),
+		filepath.Join(home, ".amp", "sessions"),
+	}
+}
+
+// resolveSessionsDir picks the first existing candidate directory. If
+// none exist it returns the preferred (new) path so callers get a
+// meaningful "directory not found" error pointing at the place where
+// install-hooks should put a plugin.
+func resolveSessionsDir(home string) string {
+	candidates := ampSessionsDirs(home)
+	for _, d := range candidates {
+		if info, err := os.Stat(d); err == nil && info.IsDir() {
+			return d
+		}
+	}
+	return candidates[0]
+}
+
 func findAmpSession(_, agentID, since, agentSessionID string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
 
-	sessionsDir := filepath.Join(home, ".amp", "sessions")
+	sessionsDir := resolveSessionsDir(home)
 
 	// direct lookup by session ID
 	if agentSessionID != "" {
 		if err := adapterruntime.ValidateSessionID(agentSessionID); err != nil {
 			return "", err
 		}
-		direct := filepath.Join(sessionsDir, agentSessionID+".jsonl")
-		if _, err := os.Stat(direct); err == nil {
-			return direct, nil
+		// Search every candidate directory by ID — covers users mid-
+		// migration who have files in both locations.
+		for _, d := range ampSessionsDirs(home) {
+			direct := filepath.Join(d, agentSessionID+".jsonl")
+			if _, err := os.Stat(direct); err == nil {
+				return direct, nil
+			}
 		}
 	}
 
@@ -212,7 +248,10 @@ func findAmpSession(_, agentID, since, agentSessionID string) (string, error) {
 
 	entries, err := os.ReadDir(sessionsDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to read sessions dir: %w", err)
+		return "", fmt.Errorf("failed to read sessions dir %s: %w "+
+			"(install the ox-bridge plugin via "+
+			"`ox-adapter-amp install-hooks --repo-root <path> --scope project`)",
+			sessionsDir, err)
 	}
 
 	var candidates []sessionCandidate

--- a/cmd/ox-adapter-amp/session_test.go
+++ b/cmd/ox-adapter-amp/session_test.go
@@ -206,3 +206,68 @@ func TestFindAmpSession_NoSessions(t *testing.T) {
 		t.Error("expected error for no sessions")
 	}
 }
+
+// TestFindAmpSession_PrefersBridgeDir verifies the new sidecar directory
+// (~/.cache/amp/ox-sessions) is preferred over the legacy
+// ~/.amp/sessions when both exist. This is the migration path: a user
+// upgrades, install-hooks drops a bridge plugin, and from that moment
+// the adapter must read fresh sidecar JSONL — not stale legacy files.
+// Failure prevented: adapter reading stale legacy session after upgrade.
+func TestFindAmpSession_PrefersBridgeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	legacyDir := filepath.Join(home, ".amp", "sessions")
+	bridgeDir := filepath.Join(home, ".cache", "amp", "ox-sessions")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(bridgeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	data := `{"type":"user","timestamp":"2024-01-15T10:00:00Z","content":"x"}` + "\n"
+	legacyFile := filepath.Join(legacyDir, "old.jsonl")
+	bridgeFile := filepath.Join(bridgeDir, "new.jsonl")
+	if err := os.WriteFile(legacyFile, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bridgeFile, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findAmpSession("", "", "", "")
+	if err != nil {
+		t.Fatalf("findAmpSession: %v", err)
+	}
+	if got != bridgeFile {
+		t.Errorf("got %q, want %q (bridge dir must win over legacy)", got, bridgeFile)
+	}
+}
+
+// TestFindAmpSession_LegacyFallback verifies that on a host with no
+// bridge sidecar dir, discovery still finds files in the legacy
+// ~/.amp/sessions location. This is what keeps pre-2026 Amp users
+// working until they reinstall hooks.
+func TestFindAmpSession_LegacyFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	legacyDir := filepath.Join(home, ".amp", "sessions")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyFile := filepath.Join(legacyDir, "old.jsonl")
+	data := `{"type":"user","timestamp":"2024-01-15T10:00:00Z","content":"x"}` + "\n"
+	if err := os.WriteFile(legacyFile, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findAmpSession("", "", "", "")
+	if err != nil {
+		t.Fatalf("findAmpSession: %v", err)
+	}
+	if got != legacyFile {
+		t.Errorf("got %q, want %q (legacy fallback)", got, legacyFile)
+	}
+}

--- a/cmd/ox-adapter-amp/session_test.go
+++ b/cmd/ox-adapter-amp/session_test.go
@@ -245,6 +245,42 @@ func TestFindAmpSession_PrefersBridgeDir(t *testing.T) {
 	}
 }
 
+// TestFindAmpSession_EmptyBridgeFallsBackToLegacy guards the case where
+// the bridge dir exists but is still empty (e.g. install-hooks just
+// ran, no session has flushed yet) and the user has live legacy
+// sessions in ~/.amp/sessions. The previous implementation stopped
+// at the first existing dir and returned "no sessions found"; now we
+// continue walking until we get usable candidates.
+// Failure prevented: discovery returning "no sessions" when legacy
+// data is right there.
+func TestFindAmpSession_EmptyBridgeFallsBackToLegacy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bridgeDir := filepath.Join(home, ".cache", "amp", "ox-sessions")
+	legacyDir := filepath.Join(home, ".amp", "sessions")
+	if err := os.MkdirAll(bridgeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// bridge dir is intentionally empty
+	legacyFile := filepath.Join(legacyDir, "old.jsonl")
+	data := `{"type":"user","timestamp":"2024-01-15T10:00:00Z","content":"x"}` + "\n"
+	if err := os.WriteFile(legacyFile, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findAmpSession("", "", "", "")
+	if err != nil {
+		t.Fatalf("findAmpSession: %v", err)
+	}
+	if got != legacyFile {
+		t.Errorf("got %q, want %q (empty bridge must fall through to legacy)", got, legacyFile)
+	}
+}
+
 // TestFindAmpSession_LegacyFallback verifies that on a host with no
 // bridge sidecar dir, discovery still finds files in the legacy
 // ~/.amp/sessions location. This is what keeps pre-2026 Amp users


### PR DESCRIPTION
## Problem

On current Amp (validated against `0.0.1778080581-g3b0b56`, released 2026-05-06), the adapter is broken from the moment a user runs `install-hooks`:

```
$ ox-adapter-amp find-session --repo-root <repo>
session not found: failed to read sessions dir:
open /Users/<user>/.amp/sessions: no such file or directory
```

Amp no longer persists conversation transcripts to `~/.amp/sessions/*.jsonl`. The adapter's `findAmpSession` / `Serve` / `read-from-offset` pipeline therefore has nothing to discover or tail. `ox doctor` reports green because AGENTS.md carries the prime marker, but in practice no session data ever lands in ox.

## Fix

Ship a small Bun plugin embedded in the adapter binary. `install-hooks` drops it once into the **user-scope** plugin dir (`~/.config/amp/plugins/ox-bridge.ts`), Amp loads it for every session, and the plugin appends one JSONL line per lifecycle event to `~/.cache/amp/ox-sessions/<thread-id>.jsonl`. The adapter's existing discovery/tail pipeline points at that directory (with a fallback to legacy `~/.amp/sessions/` for pre-2026 installs).

Sidecar lines mirror what `parseAmpLine` already understands (`session_meta` / `user` / `assistant` / `tool_use` / `tool_result`), so no daemon-side changes are required.

### Why user-scope

A previous draft of this PR installed the plugin per-project at `<repo>/.amp/plugins/ox-bridge.ts`. User-scope is strictly better:

- One plugin per machine, not per repo. No generated `.ts` showing up in `git status`, PR diffs, or `.gitignore` debates.
- One upgrade lifts every project at once.
- `uninstall-hooks` against a single project no longer risks breaking other repos that share the same machine — the user-global plugin is intentionally preserved on uninstall.

The AGENTS.md marker block is still per-project (it's a project-specific instruction telling the agent to run `ox agent prime` for THIS project's context).

### Architecture

```
Amp UI ─plugin events─▶  ~/.config/amp/plugins/ox-bridge.ts (Bun, ~70 LOC)
                                  │
                                  ▼
                       ~/.cache/amp/ox-sessions/<tid>.jsonl
                                  │
                                  ▼
                ox-adapter-amp (find-session / serve / read)
                                  │
                                  ▼
                              ox daemon
```

### Changes

- **`cmd/ox-adapter-amp/plugin/ox-bridge.ts`** — new minimal Bun plugin (~70 LOC). Subscribes to `session.start`, `agent.start`, `tool.call`, `tool.result`, `agent.end`. Defensive about `ThreadMessage` shapes (handles plain string, Anthropic block array, plain text content array).
- **`plugin_embed.go`** — `//go:embed plugin/ox-bridge.ts` plus `userBridgePluginPath()` resolving `~/.config/amp/plugins/ox-bridge.ts`.
- **`hooks.go`** — `install-hooks` writes the user-global plugin alongside the existing per-project AGENTS.md marker. `check-hooks` is unchanged from main (just inspects AGENTS.md). `uninstall-hooks` intentionally leaves the user-global plugin in place.
- **`detect.go`** — `diagnose` surfaces a `amp:bridge-plugin-missing` fix-it issue when `~/.config/amp/plugins/ox-bridge.ts` is missing.
- **`session.go`** — `findAmpSession` prefers `~/.cache/amp/ox-sessions/` and falls back to `~/.amp/sessions/`. Direct lookup by `--session-id` searches both directories so users mid-migration are covered.
- **`main.go`** — package doc rewritten to describe the new architecture.

Net diff: **+303 / −45 across 8 files**. Plugin TS is 70 lines; the Go side adds ~75 lines of behavior plus tests.

### Tests

`go test ./cmd/ox-adapter-amp/...` — 18 tests pass, including:

- `TestAmpInstall_WritesUserBridgePlugin`
- `TestAmpUninstall_PreservesUserBridgePlugin` (multi-project safety)
- `TestFindAmpSession_PrefersBridgeDir` + `TestFindAmpSession_LegacyFallback`

`gofmt -l cmd/ox-adapter-amp/` is clean.

## Local validation

Validated end-to-end against the latest Amp release (`0.0.1778080581-g3b0b56`, 2026-05-06) and ox `0.7.2`:

1. `go build -o ~/.local/bin/ox-adapter-amp ./cmd/ox-adapter-amp`
2. `ox-adapter-amp install-hooks --repo-root <repo> --scope project`
   ```json
   {"installed":true,"files_written":["<repo>/AGENTS.md","/Users/<user>/.config/amp/plugins/ox-bridge.ts"]}
   ```
   ✅ User-global plugin written. ✅ No file dropped into `<repo>/.amp/plugins/`.
3. Reloaded plugins inside Amp.
4. Sent a message; sidecar appeared at `~/.cache/amp/ox-sessions/T-<tid>.jsonl` with real `session_meta`, `user`, `tool_use`, `tool_result`, and `assistant` entries:
   ```jsonl
   {"type":"session_meta","session_id":"T-019dfede-...","timestamp":"2026-05-06T23:02:36.931Z"}
   {"type":"user","content":"...","timestamp":"2026-05-06T23:02:36.938Z"}
   {"type":"tool_use","tool_name":"Bash","tool_input":"...","call_id":"TU-...","timestamp":"..."}
   {"type":"tool_result","content":"...","is_error":false,"call_id":"TU-...","timestamp":"..."}
   ```
5. `ox-adapter-amp find-session --repo-root <repo>` returned the live sidecar with the correct offset.

### Tool coverage matrix (verified live in a multi-tool session)

| Tool | Recorded? | Notes |
|---|---|---|
| `Bash` | ✅ | full input + output captured |
| `create_file` / `edit_file` / `Read` etc. | ✅ | standard client-side tool dispatch fires `tool.call` |
| `painter` | ✅ | LLM-backed but executes on the parent thread → records as a normal `tool_use` |
| `web_search` / `read_web_page` | ✅ | same `tool.call` dispatch path as Bash |
| `Task` (spawns sub-agent) | ❌ | server-side dispatch; no `tool.call` event reaches the parent thread's plugin runtime |
| `librarian`, `oracle`, `finder` | ❌ | same as Task — subagent-style tools that bypass the parent-thread plugin event stream |
| Agent modes (`smart` / `rush` / `deep`) | ✅ | model swap is transparent to the plugin |

Subagent-style tools (`Task` / `librarian` / `oracle` / `finder`) are a known gap and stem from Amp's plugin architecture — sub-agents have their own context windows; per the public Plugin API reference, `PluginEventMap` exposes only `session.start` / `tool.call` / `tool.result` / `agent.start` / `agent.end`, and subagent tool dispatch does not surface as a parent-thread `tool.call`. The recorded transcript still contains the assistant's narration and the synthesized return value (because `agent.end.messages` includes the assistant's textual reply), so the user-visible conversation flow is preserved. Closing this gap will likely require new event types from upstream Amp.

## Backward compatibility

- Pre-2026 Amp users with `~/.amp/sessions/*.jsonl` continue to work — discovery falls back to that directory when the bridge dir is absent or empty.
- Existing AGENTS.md installs (current and pre-#527 legacy markers) are preserved by the same idempotency logic.
- A user who installed before this change will get a `bridge-plugin-missing` issue from `diagnose` with a one-line fix; re-running `install-hooks` is enough.

## Notes for review

- The adapter version constant in `main.go` is unchanged. Happy to bump if upstream prefers.
- The plugin is intentionally minimal and dependency-free aside from `@ampcode/plugin` and `node:fs`/`node:os`/`node:path`. No build step required — Amp loads `.ts` directly via Bun.
- Tool input/output values are JSON-stringified defensively rather than coupled to a specific provider's schema.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic session transcript persistence through an embedded plugin
  * Enhanced session discovery to support both new and legacy storage locations

* **Bug Fixes**
  * Improved diagnostic warnings for missing plugin configuration
  * Made installation hooks idempotent with better error handling

* **Tests**
  * Added coverage for plugin installation and legacy session discovery scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->