### PR TITLE
docs: tag fenced code blocks for MD040 (CodeRabbit)

### DIFF
--- a/.claude/commands/ox-session-review.md
+++ b/.claude/commands/ox-session-review.md
@@ -116,7 +116,7 @@ highest-value sessions first when buckets are large.
 ## Phase 4 — Execute Approved Actions
 
 ### Removals
-```
+```bash
 ox session remove <session_name> --force
 ```
 
@@ -143,7 +143,7 @@ raw.jsonl unchanged — but the long-term intent is documented so future
 implementers (or a future `ox session token-optimize` subcommand) know
 the contract:
 
-```
+```text
 # token_optimize(raw_jsonl) -> optimized_jsonl
 #
 # Goal: reduce token footprint 5-10x while preserving all signal needed
@@ -181,7 +181,7 @@ Split the optimized jsonl into ordered chunks sized to fit a single LLM
 context window (target ~60k tokens; roughly 1500-2000 lines depending on
 turn size). Per chunk produce:
 
-```
+```json
 {
   "chunk_index": N,
   "local_actions": [...],

--- a/.claude/commands/ox-session-review.md
+++ b/.claude/commands/ox-session-review.md
@@ -116,7 +116,7 @@ highest-value sessions first when buckets are large.
 ## Phase 4 — Execute Approved Actions
 
 ### Removals
-```bash
+```
 ox session remove <session_name> --force
 ```
 
@@ -143,7 +143,7 @@ raw.jsonl unchanged — but the long-term intent is documented so future
 implementers (or a future `ox session token-optimize` subcommand) know
 the contract:
 
-```text
+```
 # token_optimize(raw_jsonl) -> optimized_jsonl
 #
 # Goal: reduce token footprint 5-10x while preserving all signal needed
@@ -181,7 +181,7 @@ Split the optimized jsonl into ordered chunks sized to fit a single LLM
 context window (target ~60k tokens; roughly 1500-2000 lines depending on
 turn size). Per chunk produce:
 
-```json
+```
 {
   "chunk_index": N,
   "local_actions": [...],

--- a/cmd/ox-adapter-droid/rules.go
+++ b/cmd/ox-adapter-droid/rules.go
@@ -100,7 +100,7 @@ Sessions auto-record when ` + "`ox agent prime`" + ` runs. Discussions may be sh
 
 Publish WIP to teammates so they stay in sync:
 
-` + "```" + `
+` + "```bash" + `
 ox murmur --topic=wip "what you're building, which files you're modifying"
 ` + "```" + `
 

--- a/extensions/claude/commands/ox-session-review.md
+++ b/extensions/claude/commands/ox-session-review.md
@@ -116,7 +116,7 @@ highest-value sessions first when buckets are large.
 ## Phase 4 — Execute Approved Actions
 
 ### Removals
-```
+```bash
 ox session remove <session_name> --force
 ```
 
@@ -143,7 +143,7 @@ raw.jsonl unchanged — but the long-term intent is documented so future
 implementers (or a future `ox session token-optimize` subcommand) know
 the contract:
 
-```
+```text
 # token_optimize(raw_jsonl) -> optimized_jsonl
 #
 # Goal: reduce token footprint 5-10x while preserving all signal needed
@@ -181,7 +181,7 @@ Split the optimized jsonl into ordered chunks sized to fit a single LLM
 context window (target ~60k tokens; roughly 1500-2000 lines depending on
 turn size). Per chunk produce:
 
-```
+```json
 {
   "chunk_index": N,
   "local_actions": [...],


### PR DESCRIPTION
## Summary
- Address CodeRabbit MD040 findings from `ox doctor` review: untagged fenced code blocks.
- Tag the three fences in `.claude/commands/ox-session-review.md` as `bash`, `text`, and `json`.
- Tag the `ox murmur` fence in `cmd/ox-adapter-droid/rules.go` (the static template that generates `.factory/rules/ox.md`) as `bash`.

## Test plan
- [x] `go build ./cmd/ox-adapter-droid/` — clean build
- [x] `go test ./cmd/ox-adapter-droid/ -run TestHandleInstallRules` — passes (rules install + agentx stamp regenerates with new content)
- [x] CI lint/test green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced session quality audit and regeneration workflow documentation with comprehensive operational procedures for scanning, analysis, and execution phases.
  * Refined code block formatting in rule documentation for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->