### PR TITLE
feat(adapter-pi): detect via PI_CODING_AGENT env var

### DIFF
--- a/cmd/ox-adapter-pi/detect.go
+++ b/cmd/ox-adapter-pi/detect.go
@@ -14,6 +14,15 @@ func handleDetect() (*adapterprotocol.DetectResponse, error) {
 		return &adapterprotocol.DetectResponse{Detected: true, Reason: "AGENT_ENV=pi"}, nil
 	}
 
+	// pi-mono's CLI entry sets process.env.PI_CODING_AGENT = "true"
+	// (packages/coding-agent/src/cli.ts) and Node child_process inherits
+	// process.env, so this propagates to every subprocess pi spawns —
+	// including the bash tool. Strongest available signal that we're
+	// running inside pi right now.
+	if v := os.Getenv("PI_CODING_AGENT"); v == "true" || v == "1" {
+		return &adapterprotocol.DetectResponse{Detected: true, Reason: "PI_CODING_AGENT=" + v}, nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return &adapterprotocol.DetectResponse{Detected: false, Reason: "cannot determine home directory"}, nil

--- a/cmd/ox-adapter-pi/detect_test.go
+++ b/cmd/ox-adapter-pi/detect_test.go
@@ -21,71 +21,77 @@ func isolateDetectEnv(t *testing.T) {
 	t.Setenv("PI_CODING_AGENT", "")
 }
 
-// TestDetect_PICodingAgentTrue confirms handleDetect recognizes pi when
-// PI_CODING_AGENT=true is propagated by pi's bash subprocess.
-//
-// Failure prevented: ox CLI invoked from inside pi (which sets
-// process.env.PI_CODING_AGENT="true" at cli.ts:13) reports
-// "must be run from within a coding agent" because detection misses
+// TestDetect_HandleDetectSignals exercises every signal handleDetect knows
+// about, in priority order. The original motivating failure: ox CLI invoked
+// from inside pi (which sets process.env.PI_CODING_AGENT="true" at cli.ts:13)
+// reports "must be run from within a coding agent" because detection misses
 // the only env signal pi actually exports.
-func TestDetect_PICodingAgentTrue(t *testing.T) {
-	isolateDetectEnv(t)
-	t.Setenv("PI_CODING_AGENT", "true")
+//
+// Each case below names the specific regression it guards against — losing
+// one of these branches must surface as a failed subtest, not a silent drift.
+func TestDetect_HandleDetectSignals(t *testing.T) {
+	tests := []struct {
+		name          string
+		agentEnv      string
+		piCodingAgent string
+		wantDetected  bool
+		wantReason    string
+		// failure prevented: short note on what real-world breakage this case
+		// would let through if removed. Documented per .claude/rules/testing.md.
+		failurePrevented string
+	}{
+		{
+			name:             "PI_CODING_AGENT=true",
+			piCodingAgent:    "true",
+			wantDetected:     true,
+			wantReason:       "PI_CODING_AGENT=true",
+			failurePrevented: "ox unable to detect pi sessions on default pi-mono installs",
+		},
+		{
+			name:             "PI_CODING_AGENT=1",
+			piCodingAgent:    "1",
+			wantDetected:     true,
+			wantReason:       "PI_CODING_AGENT=1",
+			failurePrevented: "callers using the boolean-1 convention silently fail detection",
+		},
+		{
+			name:             "PI_CODING_AGENT=false",
+			piCodingAgent:    "false",
+			wantDetected:     false,
+			failurePrevented: "treating any non-empty value as truthy false-positives PI_CODING_AGENT=false",
+		},
+		{
+			name:             "AGENT_ENV=pi wins over PI_CODING_AGENT",
+			agentEnv:         "pi",
+			piCodingAgent:    "true",
+			wantDetected:     true,
+			wantReason:       "AGENT_ENV=pi",
+			failurePrevented: "downstream callers keying off Reason break if priority order shifts",
+		},
+		{
+			name:             "no signals",
+			wantDetected:     false,
+			wantReason:       "~/.pi/ not found and pi not in PATH",
+			failurePrevented: "default-true detection forces pi adapter onto Claude Code/Cursor sessions",
+		},
+	}
 
-	resp, err := handleDetect()
-	require.NoError(t, err)
-	assert.True(t, resp.Detected)
-	assert.Equal(t, "PI_CODING_AGENT=true", resp.Reason)
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDetectEnv(t)
+			if tc.agentEnv != "" {
+				t.Setenv("AGENT_ENV", tc.agentEnv)
+			}
+			if tc.piCodingAgent != "" {
+				t.Setenv("PI_CODING_AGENT", tc.piCodingAgent)
+			}
 
-// TestDetect_PICodingAgentOne accepts "1" alongside "true" so callers that
-// follow the more common boolean-env convention still match.
-func TestDetect_PICodingAgentOne(t *testing.T) {
-	isolateDetectEnv(t)
-	t.Setenv("PI_CODING_AGENT", "1")
-
-	resp, err := handleDetect()
-	require.NoError(t, err)
-	assert.True(t, resp.Detected)
-	assert.Equal(t, "PI_CODING_AGENT=1", resp.Reason)
-}
-
-// TestDetect_PICodingAgentFalse must NOT trigger detection — explicitly
-// disabling the flag should behave like "unset", otherwise we false-positive
-// for any process that happens to forward PI_CODING_AGENT=false from elsewhere.
-func TestDetect_PICodingAgentFalse(t *testing.T) {
-	isolateDetectEnv(t)
-	t.Setenv("PI_CODING_AGENT", "false")
-
-	resp, err := handleDetect()
-	require.NoError(t, err)
-	assert.False(t, resp.Detected, "PI_CODING_AGENT=false must not be treated as detection signal")
-}
-
-// TestDetect_AGENTEnvWinsOverPICodingAgent — when both signals are present,
-// the existing AGENT_ENV=pi short-circuit must still fire first so the Reason
-// stays stable for callers that key off it.
-func TestDetect_AGENTEnvWinsOverPICodingAgent(t *testing.T) {
-	isolateDetectEnv(t)
-	t.Setenv("AGENT_ENV", "pi")
-	t.Setenv("PI_CODING_AGENT", "true")
-
-	resp, err := handleDetect()
-	require.NoError(t, err)
-	assert.True(t, resp.Detected)
-	assert.Equal(t, "AGENT_ENV=pi", resp.Reason)
-}
-
-// TestDetect_NoSignals — clean machine, nothing claiming pi: must report
-// not-detected with the original "~/.pi/ not found and pi not in PATH" reason.
-// Failure prevented: silently flipping default detection to true would force
-// pi adapter onto Claude-Code/Cursor sessions on machines that incidentally
-// have neither pi nor PI_CODING_AGENT set.
-func TestDetect_NoSignals(t *testing.T) {
-	isolateDetectEnv(t)
-
-	resp, err := handleDetect()
-	require.NoError(t, err)
-	assert.False(t, resp.Detected)
-	assert.Equal(t, "~/.pi/ not found and pi not in PATH", resp.Reason)
+			resp, err := handleDetect()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantDetected, resp.Detected, tc.failurePrevented)
+			if tc.wantReason != "" {
+				assert.Equal(t, tc.wantReason, resp.Reason, tc.failurePrevented)
+			}
+		})
+	}
 }

--- a/cmd/ox-adapter-pi/detect_test.go
+++ b/cmd/ox-adapter-pi/detect_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateDetectEnv pins HOME away from any real ~/.pi and clears PATH so
+// exec.LookPath("pi") deterministically fails. Without this, handleDetect's
+// later fallbacks (~/.pi present, pi binary in PATH) can mask the env-var
+// detection logic these tests are trying to verify.
+func isolateDetectEnv(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("PATH", filepath.Join(tmp, "no-such-bin"))
+	t.Setenv("AGENT_ENV", "")
+	t.Setenv("PI_CODING_AGENT", "")
+}
+
+// TestDetect_PICodingAgentTrue confirms handleDetect recognizes pi when
+// PI_CODING_AGENT=true is propagated by pi's bash subprocess.
+//
+// Failure prevented: ox CLI invoked from inside pi (which sets
+// process.env.PI_CODING_AGENT="true" at cli.ts:13) reports
+// "must be run from within a coding agent" because detection misses
+// the only env signal pi actually exports.
+func TestDetect_PICodingAgentTrue(t *testing.T) {
+	isolateDetectEnv(t)
+	t.Setenv("PI_CODING_AGENT", "true")
+
+	resp, err := handleDetect()
+	require.NoError(t, err)
+	assert.True(t, resp.Detected)
+	assert.Equal(t, "PI_CODING_AGENT=true", resp.Reason)
+}
+
+// TestDetect_PICodingAgentOne accepts "1" alongside "true" so callers that
+// follow the more common boolean-env convention still match.
+func TestDetect_PICodingAgentOne(t *testing.T) {
+	isolateDetectEnv(t)
+	t.Setenv("PI_CODING_AGENT", "1")
+
+	resp, err := handleDetect()
+	require.NoError(t, err)
+	assert.True(t, resp.Detected)
+	assert.Equal(t, "PI_CODING_AGENT=1", resp.Reason)
+}
+
+// TestDetect_PICodingAgentFalse must NOT trigger detection — explicitly
+// disabling the flag should behave like "unset", otherwise we false-positive
+// for any process that happens to forward PI_CODING_AGENT=false from elsewhere.
+func TestDetect_PICodingAgentFalse(t *testing.T) {
+	isolateDetectEnv(t)
+	t.Setenv("PI_CODING_AGENT", "false")
+
+	resp, err := handleDetect()
+	require.NoError(t, err)
+	assert.False(t, resp.Detected, "PI_CODING_AGENT=false must not be treated as detection signal")
+}
+
+// TestDetect_AGENTEnvWinsOverPICodingAgent — when both signals are present,
+// the existing AGENT_ENV=pi short-circuit must still fire first so the Reason
+// stays stable for callers that key off it.
+func TestDetect_AGENTEnvWinsOverPICodingAgent(t *testing.T) {
+	isolateDetectEnv(t)
+	t.Setenv("AGENT_ENV", "pi")
+	t.Setenv("PI_CODING_AGENT", "true")
+
+	resp, err := handleDetect()
+	require.NoError(t, err)
+	assert.True(t, resp.Detected)
+	assert.Equal(t, "AGENT_ENV=pi", resp.Reason)
+}
+
+// TestDetect_NoSignals — clean machine, nothing claiming pi: must report
+// not-detected with the original "~/.pi/ not found and pi not in PATH" reason.
+// Failure prevented: silently flipping default detection to true would force
+// pi adapter onto Claude-Code/Cursor sessions on machines that incidentally
+// have neither pi nor PI_CODING_AGENT set.
+func TestDetect_NoSignals(t *testing.T) {
+	isolateDetectEnv(t)
+
+	resp, err := handleDetect()
+	require.NoError(t, err)
+	assert.False(t, resp.Detected)
+	assert.Equal(t, "~/.pi/ not found and pi not in PATH", resp.Reason)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/AlexanderGrooff/mermaid-ascii v0.0.0-20251230110936-0ccc8d6547f7
 	github.com/Microsoft/go-winio v0.6.2
+	github.com/bbalet/stopwords v1.0.0
 	github.com/blevesearch/bleve/v2 v2.5.7
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/docker/docker v28.5.2+incompatible
@@ -26,7 +27,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/sageox/agentx v0.1.9
+	github.com/sageox/agentx v0.1.10
 	github.com/sageox/frictionax v0.1.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -54,7 +55,6 @@ require (
 	github.com/RoaringBitmap/roaring/v2 v2.4.5 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/bbalet/stopwords v1.0.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/blevesearch/bleve_index_api v1.2.11 // indirect
 	github.com/blevesearch/geo v0.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sageox/agentx v0.1.9 h1:Hm5voAzQweoSmT3Zc0qgv0hHKH3p9fx46tYv1gbA7GQ=
-github.com/sageox/agentx v0.1.9/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
+github.com/sageox/agentx v0.1.10 h1:uLDo3p5YdKThMIHqcq+vPApI8n484UODNu/RVZzG92g=
+github.com/sageox/agentx v0.1.10/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
 github.com/sageox/frictionax v0.1.2 h1:iQfssC1g/vVdGXi55smMfY5/4JKcQbJXRzcwrQWiNLo=
 github.com/sageox/frictionax v0.1.2/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=


### PR DESCRIPTION
## Summary

Adds `PI_CODING_AGENT=true` detection to `ox-adapter-pi`'s `handleDetect()` so `ox` correctly identifies pi sessions running on a developer's machine.

## Motivation

When running `pi` (the @earendil-works/pi-coding-agent CLI) and invoking `ox agent prime` from pi's bash tool, detection currently fails with:

> Error: 'ox agent prime' must be run from within a coding agent (Claude Code, Cursor, etc.).
> If your agent doesn't set standard env vars, set AGENT_ENV=<agent-name> before running.

Root cause: the existing pi-detection signals all miss this case.

| Signal | Result inside pi's bash subprocess |
|---|---|
| `AGENT_ENV=pi` | not set (pi never exports it) |
| `PI_CODING_AGENT_DIR` | only set when the user explicitly overrides config dir |
| `~/.pi/` exists | works, but only if pi is *installed* — not a runtime "are we IN pi" signal |
| `pi` in `$PATH` | same caveat — installation, not runtime |

But pi-mono's CLI entry point sets:

```ts
// packages/coding-agent/src/cli.ts:13
process.env.PI_CODING_AGENT = "true";
```

Node's `child_process.spawn` inherits `process.env` by default, and pi's bash tool spawns with `env: env ?? getShellEnv()` (`getShellEnv()` returns `{ ...process.env, PATH: ... }` at `packages/coding-agent/src/utils/shell.ts:108`), so `PI_CODING_AGENT=true` propagates to every subprocess pi spawns. This is the strongest available runtime signal that we're inside pi *right now* (not just on a machine where pi happens to be installed).

## Change

`cmd/ox-adapter-pi/detect.go` — new check between the existing `AGENT_ENV=pi` short-circuit and the `~/.pi/` fallback:

```go
if v := os.Getenv("PI_CODING_AGENT"); v == "true" || v == "1" {
    return &adapterprotocol.DetectResponse{Detected: true, Reason: "PI_CODING_AGENT=" + v}, nil
}
```

Strict truthy match (`"true"` or `"1"`) rather than non-empty so an explicit `PI_CODING_AGENT=false` doesn't false-positive.

## Layered fix

This PR is **Layer 2** of a two-layer plan. Layer 1 (the upstream fix) is to teach `github.com/sageox/agentx`'s `PiAgent.DetectRuntime()` the same signal so all consumers — not just `ox-adapter-pi` — benefit. Tracked separately; not in this PR.

## Test plan

New `cmd/ox-adapter-pi/detect_test.go` covering:

- [x] `PI_CODING_AGENT=true` → detected, reason `PI_CODING_AGENT=true`
- [x] `PI_CODING_AGENT=1` → detected, reason `PI_CODING_AGENT=1`
- [x] `PI_CODING_AGENT=false` → **not** detected (regression guard against treating any non-empty value as truthy)
- [x] `AGENT_ENV=pi` and `PI_CODING_AGENT=true` both set → existing `AGENT_ENV=pi` short-circuit wins (stable Reason for downstream)
- [x] no signals → not detected, original `~/.pi/ not found and pi not in PATH` reason preserved

Each test pins `HOME` to a tmpdir and clears `PATH` so an ambient `~/.pi/` or `pi` binary on the developer's machine cannot mask the env-var detection logic these tests are verifying.

- [x] `go test ./cmd/ox-adapter-pi/` — all green (new + existing)
- [x] `go build ./cmd/ox-adapter-pi/` — clean
- [x] `make lint` — 0 issues

## Manual verification

From an `m5 + MLX (Qwen3.6-27B-MLX-8bit) + pi` setup running `ox agent prime` with no `AGENT_ENV` prefix should now succeed, where it previously errored with the message above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection now recognizes pi-mono via an additional environment signal, preserving existing signals and clear precedence when multiple signals are present.

* **Tests**
  * Consolidated and expanded unit tests cover environment-detection scenarios and precedence rules in a single table-driven test.

* **Chores**
  * Module dependency declarations updated and an internal module version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->