### PR TITLE
fix(codedb): self-heal corrupt bleve sub-index without full reindex

### DIFF
--- a/cmd/ox/doctor_codedb.go
+++ b/cmd/ox/doctor_codedb.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/sageox/ox/internal/codedb"
@@ -37,6 +38,20 @@ func checkCodeIndexAtDir(dataDir string, fix bool) checkResult {
 
 	db, err := codedb.Open(dataDir)
 	if err != nil {
+		// Targeted self-heal: a single bleve sub-index with an empty mapping
+		// document is independently recoverable without nuking the whole
+		// dataDir (~1GB+ on real repos). Detect via typed MappingCorruptError
+		// from store.openOrCreateBleveIndex; rebuild only that sub-index.
+		var mce *store.MappingCorruptError
+		if errors.As(err, &mce) {
+			if fix {
+				if rbErr := store.RebuildBleveSubIndex(dataDir, mce.Name); rbErr != nil {
+					return FailedCheck("Code index", fmt.Sprintf("rebuild %s sub-index failed: %v", mce.Name, rbErr), "run 'ox code index --full' to rebuild from scratch")
+				}
+				return PassedCheck("Code index", fmt.Sprintf("%s sub-index rebuilt; run 'ox code index' to repopulate", mce.Name))
+			}
+			return FailedCheck("Code index", fmt.Sprintf("%s sub-index mapping is empty/corrupt", mce.Name), "run 'ox doctor --fix' to rebuild only the affected sub-index")
+		}
 		if fix {
 			_ = os.RemoveAll(dataDir)
 			return PassedCheck("Code index", "corrupt index removed, run 'ox code index' to rebuild")

--- a/cmd/ox/doctor_codedb.go
+++ b/cmd/ox/doctor_codedb.go
@@ -42,15 +42,23 @@ func checkCodeIndexAtDir(dataDir string, fix bool) checkResult {
 		// document is independently recoverable without nuking the whole
 		// dataDir (~1GB+ on real repos). Detect via typed MappingCorruptError
 		// from store.openOrCreateBleveIndex; rebuild only that sub-index.
+		// "comment" repairs surgically; "code"/"diff" fall back to full
+		// dataDir wipe (the original behavior) since they cannot be
+		// repopulated from SQL alone.
 		var mce *store.MappingCorruptError
 		if errors.As(err, &mce) {
 			if fix {
-				if rbErr := store.RebuildBleveSubIndex(dataDir, mce.Name); rbErr != nil {
-					return FailedCheck("Code index", fmt.Sprintf("rebuild %s sub-index failed: %v", mce.Name, rbErr), "run 'ox code index --full' to rebuild from scratch")
+				rbErr := store.RebuildBleveSubIndex(dataDir, mce.Name)
+				if rbErr == nil {
+					return PassedCheck("Code index", fmt.Sprintf("%s sub-index rebuilt; run 'ox code index' to repopulate", mce.Name))
 				}
-				return PassedCheck("Code index", fmt.Sprintf("%s sub-index rebuilt; run 'ox code index' to repopulate", mce.Name))
+				if errors.Is(rbErr, store.ErrFullReindexRequired) {
+					_ = os.RemoveAll(dataDir)
+					return PassedCheck("Code index", fmt.Sprintf("%s sub-index needs full reindex; dataDir wiped, run 'ox code index'", mce.Name))
+				}
+				return FailedCheck("Code index", fmt.Sprintf("rebuild %s sub-index failed: %v", mce.Name, rbErr), "run 'ox code index --full' to rebuild from scratch")
 			}
-			return FailedCheck("Code index", fmt.Sprintf("%s sub-index mapping is empty/corrupt", mce.Name), "run 'ox doctor --fix' to rebuild only the affected sub-index")
+			return FailedCheck("Code index", fmt.Sprintf("%s sub-index is structurally corrupt", mce.Name), "run 'ox doctor --fix' to rebuild only the affected sub-index")
 		}
 		if fix {
 			_ = os.RemoveAll(dataDir)

--- a/cmd/ox/doctor_codedb_test.go
+++ b/cmd/ox/doctor_codedb_test.go
@@ -122,7 +122,6 @@ func corruptCommentMapping(t *testing.T, boltPath string) {
 	t.Helper()
 	db, err := bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: 2 * time.Second})
 	require.NoError(t, err)
-	t.Cleanup(func() { db.Close() })
 	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
 		snaps := tx.Bucket([]byte{'s'})
 		require.NotNil(t, snaps)

--- a/cmd/ox/doctor_codedb_test.go
+++ b/cmd/ox/doctor_codedb_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sageox/ox/internal/codedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 )
 
 // TestCheckCodeIndexAtDir_EmptyIndex is a regression test for the case where the index
@@ -62,4 +64,85 @@ func TestCheckCodeIndexAtDir_NoIndex(t *testing.T) {
 	result := checkCodeIndexAtDir(nonExistent, false)
 
 	assert.True(t, result.passed, "missing index dir should be a pass, not failure")
+}
+
+// TestCheckCodeIndexAtDir_CorruptMapping_TargetedRebuild verifies that an
+// empty bleve mapping doc (single sub-index) is repaired surgically: only the
+// affected sub-index dir is recreated, while peer sub-indexes survive byte-for-byte.
+//
+// Failure prevented: doctor's previous remedy was os.RemoveAll(dataDir),
+// destroying ~600MB of code data + ~600MB of diff data to recover from a
+// few-byte mapping corruption that only affected the comment sub-index.
+func TestCheckCodeIndexAtDir_CorruptMapping_TargetedRebuild(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: SQLite + Bleve operations")
+	}
+
+	tmp := t.TempDir()
+	db, err := codedb.Open(tmp)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// truncate the comment sub-index's persisted mapping doc
+	boltPath := filepath.Join(tmp, "bleve", "comment", "store", "root.bolt")
+	corruptCommentMapping(t, boltPath)
+
+	// without --fix: must report the targeted condition, not a generic open failure
+	result := checkCodeIndexAtDir(tmp, false)
+	assert.False(t, result.passed, "corrupt mapping must not pass without --fix")
+
+	// snapshot code/diff state BEFORE fix (after the failed read above, which
+	// is the only thing that could have touched them prior to fix)
+	codeBoltPath := filepath.Join(tmp, "bleve", "code", "store", "root.bolt")
+	diffBoltPath := filepath.Join(tmp, "bleve", "diff", "store", "root.bolt")
+	codeBefore := mustStatSize(t, codeBoltPath)
+	diffBefore := mustStatSize(t, diffBoltPath)
+
+	// with --fix: rebuild only the comment sub-index
+	result = checkCodeIndexAtDir(tmp, true)
+	assert.True(t, result.passed, "fix must succeed: message=%q detail=%q", result.message, result.detail)
+
+	// peer sub-indexes must survive (size unchanged is sufficient — a full
+	// nuke would have removed the file entirely)
+	codeAfter := mustStatSize(t, codeBoltPath)
+	diffAfter := mustStatSize(t, diffBoltPath)
+	assert.Equal(t, codeBefore, codeAfter, "code sub-index must not be touched by targeted rebuild")
+	assert.Equal(t, diffBefore, diffAfter, "diff sub-index must not be touched by targeted rebuild")
+
+	// post-rebuild Open must succeed
+	db2, err := codedb.Open(tmp)
+	require.NoError(t, err, "Open must succeed after targeted rebuild")
+	require.NoError(t, db2.Close())
+}
+
+// corruptCommentMapping zeroes the latest snapshot's mapping doc in the
+// comment sub-index — same on-disk state observed in production.
+func corruptCommentMapping(t *testing.T, boltPath string) {
+	t.Helper()
+	db, err := bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: 2 * time.Second})
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		snaps := tx.Bucket([]byte{'s'})
+		require.NotNil(t, snaps)
+		var lastKey []byte
+		require.NoError(t, snaps.ForEach(func(k, _ []byte) error {
+			lastKey = append(lastKey[:0], k...)
+			return nil
+		}))
+		snap := snaps.Bucket(lastKey)
+		require.NotNil(t, snap)
+		internal := snap.Bucket([]byte{'i'})
+		require.NotNil(t, internal)
+		return internal.Put([]byte("_mapping"), []byte{})
+	}))
+	require.NoError(t, db.Close())
+}
+
+func mustStatSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return info.Size()
 }

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/zalando/go-keyring v0.2.8
+	go.etcd.io/bbolt v1.4.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -168,7 +169,6 @@ require (
 	github.com/yuin/goldmark v1.7.8 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.etcd.io/bbolt v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -404,7 +404,11 @@ func isBleveIndexCorrupt(boltPath string) bool {
 	defer db.Close()
 
 	storeDir := filepath.Dir(boltPath)
-	zapsOnDisk := zapFilesInDir(storeDir)
+	zapsOnDisk, listErr := zapFilesInDir(storeDir)
+	if listErr != nil {
+		// can't enumerate segments — won't claim corruption without proof
+		return false
+	}
 
 	var corrupt bool
 	_ = db.View(func(tx *bbolt.Tx) error {
@@ -451,12 +455,15 @@ func isBleveIndexCorrupt(boltPath string) bool {
 }
 
 // zapFilesInDir returns a set of *.zap filenames in dir for fast lookup.
-func zapFilesInDir(dir string) map[string]struct{} {
-	out := map[string]struct{}{}
+// On any os.ReadDir error returns the error so the caller can refuse to
+// flag corruption based on incomplete information — a transient read
+// failure must not be misread as "every segment is missing."
+func zapFilesInDir(dir string) (map[string]struct{}, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return out
+		return nil, err
 	}
+	out := map[string]struct{}{}
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -466,7 +473,7 @@ func zapFilesInDir(dir string) map[string]struct{} {
 			out[name] = struct{}{}
 		}
 	}
-	return out
+	return out, nil
 }
 
 // decodeSegmentEpoch parses scorch's varint-style segment epoch encoding from
@@ -533,8 +540,13 @@ func RebuildBleveSubIndex(root, name string) error {
 
 	dbPath := filepath.Join(root, MetadataDBFile)
 	if _, statErr := os.Stat(dbPath); statErr != nil {
-		// no metadata.db means no blobs to mark — nothing to do (e.g. fresh dataDir)
-		return nil
+		if errors.Is(statErr, os.ErrNotExist) {
+			// no metadata.db means no blobs to mark — nothing to do (e.g. fresh dataDir)
+			return nil
+		}
+		// permission/IO error: must not silently skip the SQL reset, which
+		// would leave the rebuilt comment shard unable to repopulate.
+		return fmt.Errorf("stat metadata.db for comment rebuild: %w", statErr)
 	}
 	db, openErr := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
 	if openErr != nil {

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -10,17 +10,50 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/blevesearch/bleve/v2"
 	codedbsqlc "github.com/sageox/ox/internal/codedb/sqlc"
+	"go.etcd.io/bbolt"
 	_ "modernc.org/sqlite"
 )
 
 // ErrCorrupt indicates the index is corrupted and needs re-indexing.
 var ErrCorrupt = fmt.Errorf("codedb index is corrupt")
 
+// MappingCorruptError indicates that a Bleve sub-index is in a structurally
+// broken state that bleve.Open cannot recover from on its own. The Name
+// identifies which sub-index ("code", "diff", or "comment") so callers can
+// perform a targeted rebuild via RebuildBleveSubIndex without nuking the
+// whole dataDir.
+//
+// Detected conditions (see isBleveIndexCorrupt):
+//   - persisted `_mapping` doc is empty/missing in the latest snapshot, or
+//   - the latest snapshot references segment IDs whose `.zap` files are
+//     missing on disk (the field-observed poison pill: bolt + mapping intact
+//     but a previous incomplete write left the snapshot pointing at segments
+//     that never landed)
+//
+// Distinct from "real lock contention" (another goroutine/process actively
+// writing): we only return this after a successful read-only bbolt open with
+// 100ms timeout — a held exclusive lock blocks the read and we stay in the
+// safe lock-contention path.
+type MappingCorruptError struct {
+	Name string
+	Path string
+}
+
+func (e *MappingCorruptError) Error() string {
+	return fmt.Sprintf("bleve %s index is structurally corrupt at %s", e.Name, e.Path)
+}
+
 // MetadataDBFile is the filename of the SQLite database inside a CodeDB directory.
 const MetadataDBFile = "metadata.db"
+
+// BleveSubIndexNames lists the bleve sub-indexes managed by Store, in the same
+// order they are opened. Used by self-heal callers (daemon, doctor) so they
+// don't have to hardcode the names.
+var BleveSubIndexNames = []string{"code", "diff", "comment"}
 
 // Store wraps a SQLite database and Bleve full-text search indexes.
 // All SQL access goes through the convenience methods below.
@@ -88,20 +121,20 @@ func Open(root string) (*Store, error) {
 		return nil, fmt.Errorf("create schema: %w", err)
 	}
 
-	codeIndex, err := openOrCreateBleveIndex(bleveCodeDir)
+	codeIndex, err := openOrCreateBleveIndex(bleveCodeDir, "code")
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("open code index: %w", err)
 	}
 
-	diffIndex, err := openOrCreateBleveIndex(bleveDiffDir)
+	diffIndex, err := openOrCreateBleveIndex(bleveDiffDir, "diff")
 	if err != nil {
 		db.Close()
 		codeIndex.Close()
 		return nil, fmt.Errorf("open diff index: %w", err)
 	}
 
-	commentIndex, err := openOrCreateBleveIndex(bleveCommentDir)
+	commentIndex, err := openOrCreateBleveIndex(bleveCommentDir, "comment")
 	if err != nil {
 		db.Close()
 		codeIndex.Close()
@@ -279,7 +312,7 @@ func removeSQLiteFiles(dbPath string) {
 	}
 }
 
-func openOrCreateBleveIndex(path string) (bleve.Index, error) {
+func openOrCreateBleveIndex(path, name string) (bleve.Index, error) {
 	idx, err := safeOpenBleve(path)
 	if err == nil {
 		return idx, nil
@@ -290,19 +323,27 @@ func openOrCreateBleveIndex(path string) (bleve.Index, error) {
 	}
 
 	// Before treating as corruption, check if the bbolt file exists.
-	// If it does, the error is likely a lock-timeout (another goroutine or process
-	// has the index open with bbolt's exclusive flock). Nuking in that case destroys
-	// an index that is actively being written — the correct action is to return an
-	// error and let the caller retry later.
+	// If it does, the error is most often lock contention (another goroutine
+	// or process holds the bbolt exclusive flock). Nuking in that case destroys
+	// an index that is actively being written.
+	//
+	// But there's a separate failure mode hiding behind the same surface error:
+	// the bolt file exists, the snapshots are present, yet the persisted mapping
+	// document is empty (observed: `error parsing mapping JSON: unexpected end
+	// of JSON input` while the worktree's diff/code shards are healthy). That
+	// state is unrecoverable by waiting — the daemon will spin forever — so we
+	// peek the mapping non-blocking and surface a typed MappingCorruptError
+	// when the mapping is provably empty. The peek uses a read-only open with
+	// a 100ms timeout: a real exclusive lock blocks the read, the peek bails
+	// out, and we keep the safe lock-contention behavior.
 	boltPath := filepath.Join(path, "store", "root.bolt")
-	_, statErr := os.Stat(boltPath)
-	if statErr == nil {
+	if _, statErr := os.Stat(boltPath); statErr == nil {
+		if isBleveIndexCorrupt(boltPath) {
+			return nil, &MappingCorruptError{Name: name, Path: path}
+		}
 		return nil, fmt.Errorf("bleve index appears to be in use (lock contention): %w", err)
-	}
-	// only nuke when the bolt file is provably absent (ENOENT) or the path structure
-	// is broken (ENOTDIR: a directory was replaced by a file). Permission and I/O
-	// errors (EPERM, EIO, etc.) are transient — nuking would cause data loss.
-	if !os.IsNotExist(statErr) && !errors.Is(statErr, syscall.ENOTDIR) {
+	} else if !os.IsNotExist(statErr) && !errors.Is(statErr, syscall.ENOTDIR) {
+		// permission/IO errors are transient — nuking would cause data loss
 		return nil, fmt.Errorf("stat bleve bolt file %s: %w", boltPath, statErr)
 	}
 
@@ -313,6 +354,188 @@ func openOrCreateBleveIndex(path string) (bleve.Index, error) {
 	}
 	mapping := bleve.NewIndexMapping()
 	return bleve.New(path, mapping)
+}
+
+// isBleveIndexCorrupt opens root.bolt read-only with a short timeout and
+// affirmatively checks for two on-disk failure modes that present as the
+// same opaque "error parsing mapping JSON" surface error:
+//
+//  1. Empty/missing `_mapping` doc in every snapshot.
+//  2. Latest snapshot references segment IDs whose `.zap` shard files are
+//     missing on disk. (Observed in the field on a real poison pill: bolt is
+//     fully readable, mapping is intact, yet `bleve.Open` still fails because
+//     scorch can't load the snapshot's segments — and downstream the mapping
+//     read returns empty bytes through the degraded reader.)
+//
+// Returns true only when we successfully read the bolt AND can prove one of
+// the two conditions. On any access error (read-only open timeout, permission,
+// unparseable bolt structure) returns false — we never flag corruption
+// without proof, so a real exclusive write lock stays in the lock-contention
+// path.
+//
+// scorch's bbolt layout (verified against bleve v2.5.7):
+//
+//	bucket "s" (snapshots)
+//	  └── bucket <8-byte BE epoch>
+//	         ├── bucket "i" (internal)        — `_mapping` key here
+//	         ├── bucket "m" (meta)
+//	         └── bucket <0xf7-prefixed segId>  — one per .zap segment in snapshot
+//
+// Segment bucket keys are 0xf7 followed by a varint-encoded segment epoch
+// (two-byte minimum we see in practice). Segment epochs match the lower bits
+// of the .zap filename (e.g. segment epoch 0x521 → 000000000521.zap).
+func isBleveIndexCorrupt(boltPath string) bool {
+	db, err := bbolt.Open(boltPath, 0600, &bbolt.Options{
+		ReadOnly: true,
+		Timeout:  100 * time.Millisecond,
+	})
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+
+	storeDir := filepath.Dir(boltPath)
+	zapsOnDisk := zapFilesInDir(storeDir)
+
+	var corrupt bool
+	_ = db.View(func(tx *bbolt.Tx) error {
+		snaps := tx.Bucket([]byte{'s'})
+		if snaps == nil {
+			return nil
+		}
+		// pick the latest snapshot (highest 8-byte BE epoch — last in cursor order)
+		c := snaps.Cursor()
+		var latestKey []byte
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			latestKey = append(latestKey[:0], k...)
+		}
+		if latestKey == nil {
+			return nil
+		}
+		snap := snaps.Bucket(latestKey)
+		if snap == nil {
+			return nil
+		}
+
+		// (1) mapping doc empty/missing
+		internal := snap.Bucket([]byte{'i'})
+		if internal == nil || len(internal.Get([]byte("_mapping"))) == 0 {
+			corrupt = true
+			return nil
+		}
+
+		// (2) any referenced segment's .zap is missing on disk
+		_ = snap.ForEach(func(name []byte, _ []byte) error {
+			if len(name) == 0 || name[0] != 0xf7 {
+				return nil
+			}
+			segEpoch := decodeSegmentEpoch(name[1:])
+			zapName := fmt.Sprintf("%012x.zap", segEpoch)
+			if _, ok := zapsOnDisk[zapName]; !ok {
+				corrupt = true
+			}
+			return nil
+		})
+		return nil
+	})
+	return corrupt
+}
+
+// zapFilesInDir returns a set of *.zap filenames in dir for fast lookup.
+func zapFilesInDir(dir string) map[string]struct{} {
+	out := map[string]struct{}{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if len(name) >= 4 && name[len(name)-4:] == ".zap" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+// decodeSegmentEpoch parses scorch's varint-style segment epoch encoding from
+// the bytes after the 0xf7 prefix. The encoding is a packed big-endian-ish
+// integer; observed instances:
+//
+//	0x02 0x09       → 0x209  → 521
+//	0x03 0x6d       → 0x36d  → 877
+//	0x04 0x81       → 0x481  → 1153
+//	0x05 0x21       → 0x521  → 1313
+//
+// Implementation: build the integer by left-shifting 8 bits per byte (i.e.
+// big-endian). This matches every observed case and the on-disk .zap naming
+// (lower-cased hex of the epoch zero-padded to 12 nibbles).
+func decodeSegmentEpoch(b []byte) uint64 {
+	var v uint64
+	for _, x := range b {
+		v = (v << 8) | uint64(x)
+	}
+	return v
+}
+
+// RebuildBleveSubIndex removes the named bleve sub-index directory and
+// recreates it empty. It also resets the SQL flags that control which blobs
+// are re-fed into the rebuilt bleve, so the next indexing pass repopulates
+// the sub-index from existing SQL data without re-walking git history or
+// touching unrelated indexes.
+//
+// Supported names: "code", "diff", "comment".
+//
+// Per-sub-index repopulation strategy:
+//   - "comment": clear blobs.comments_parsed → ParseComments re-extracts and
+//     re-bleves from existing blobs. Full coverage on next indexing pass.
+//   - "code"/"diff": these sub-indexes are populated during the per-commit
+//     walk in IndexRepo, gated on `commits` SQL rows. Re-populating them from
+//     SQL alone (without re-walking git) requires a "rebleve from blobs"
+//     pass that does not yet exist. Until that lands, this function recreates
+//     the bleve directory empty; callers needing full code/diff search after
+//     a rebuild should trigger a full reindex (--full / wipe dataDir).
+//
+// This function works without an open Store — by design, since Open fails
+// when a sub-index has the empty-mapping condition we are recovering from.
+func RebuildBleveSubIndex(root, name string) error {
+	switch name {
+	case "code", "diff", "comment":
+	default:
+		return fmt.Errorf("unknown bleve sub-index %q", name)
+	}
+
+	bleveDir := filepath.Join(root, "bleve", name)
+	if err := os.RemoveAll(bleveDir); err != nil {
+		return fmt.Errorf("remove %s bleve dir: %w", name, err)
+	}
+	mapping := bleve.NewIndexMapping()
+	idx, err := bleve.New(bleveDir, mapping)
+	if err != nil {
+		return fmt.Errorf("recreate %s bleve index: %w", name, err)
+	}
+	if err := idx.Close(); err != nil {
+		return fmt.Errorf("close recreated %s bleve index: %w", name, err)
+	}
+
+	if name == "comment" {
+		dbPath := filepath.Join(root, MetadataDBFile)
+		if _, statErr := os.Stat(dbPath); statErr == nil {
+			db, openErr := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+			if openErr != nil {
+				slog.Warn("rebuild comment: open metadata.db", "err", openErr)
+				return nil
+			}
+			defer db.Close()
+			if _, exErr := db.Exec(`UPDATE blobs SET comments_parsed = 0`); exErr != nil {
+				slog.Warn("rebuild comment: clear comments_parsed", "err", exErr)
+			}
+		}
+	}
+
+	return nil
 }
 
 // safeOpenBleve wraps bleve.Open with panic recovery.

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -21,6 +21,15 @@ import (
 // ErrCorrupt indicates the index is corrupted and needs re-indexing.
 var ErrCorrupt = fmt.Errorf("codedb index is corrupt")
 
+// ErrFullReindexRequired is returned by RebuildBleveSubIndex when the
+// requested sub-index (code/diff) cannot be repopulated from existing SQL
+// data alone. Callers that hit this should fall back to a full reindex
+// (wipe dataDir + run IndexLocalRepo) — the rebuild path is currently only
+// safe for "comment" because ParseComments is gated on a per-blob SQL flag
+// we can reset, while code/diff are populated only during the per-commit
+// walk in IndexRepo and have no rebleve-from-blobs path yet.
+var ErrFullReindexRequired = errors.New("full reindex required")
+
 // MappingCorruptError indicates that a Bleve sub-index is in a structurally
 // broken state that bleve.Open cannot recover from on its own. The Name
 // identifies which sub-index ("code", "diff", or "comment") so callers can
@@ -480,29 +489,31 @@ func decodeSegmentEpoch(b []byte) uint64 {
 	return v
 }
 
-// RebuildBleveSubIndex removes the named bleve sub-index directory and
-// recreates it empty. It also resets the SQL flags that control which blobs
-// are re-fed into the rebuilt bleve, so the next indexing pass repopulates
-// the sub-index from existing SQL data without re-walking git history or
-// touching unrelated indexes.
+// RebuildBleveSubIndex performs a targeted rebuild of a single bleve
+// sub-index. Currently supported only for "comment", which can be fully
+// repopulated from existing SQL data via the comments_parsed flag.
 //
-// Supported names: "code", "diff", "comment".
+// For "code" and "diff", this function returns ErrFullReindexRequired
+// without modifying state — those sub-indexes are populated during the
+// per-commit walk in IndexRepo, gated on `commits` SQL rows, and there is
+// no rebleve-from-blobs path that could refill them from SQL alone. A
+// surgical rebuild would leave search permanently empty; callers must fall
+// back to a full reindex (wipe dataDir + IndexLocalRepo).
 //
-// Per-sub-index repopulation strategy:
-//   - "comment": clear blobs.comments_parsed → ParseComments re-extracts and
-//     re-bleves from existing blobs. Full coverage on next indexing pass.
-//   - "code"/"diff": these sub-indexes are populated during the per-commit
-//     walk in IndexRepo, gated on `commits` SQL rows. Re-populating them from
-//     SQL alone (without re-walking git) requires a "rebleve from blobs"
-//     pass that does not yet exist. Until that lands, this function recreates
-//     the bleve directory empty; callers needing full code/diff search after
-//     a rebuild should trigger a full reindex (--full / wipe dataDir).
+// On success for "comment": removes bleve/comment/, recreates empty, and
+// resets blobs.comments_parsed=0 so ParseComments re-extracts every blob
+// on the next indexing pass. SQL/Open failures during the flag reset are
+// surfaced as errors — a rebuild that "succeeds" with comments_parsed
+// still set would silently leave search empty forever.
 //
 // This function works without an open Store — by design, since Open fails
-// when a sub-index has the empty-mapping condition we are recovering from.
+// when the sub-index is in the corrupt state we are recovering from.
 func RebuildBleveSubIndex(root, name string) error {
 	switch name {
-	case "code", "diff", "comment":
+	case "comment":
+		// continue
+	case "code", "diff":
+		return fmt.Errorf("%s sub-index: %w", name, ErrFullReindexRequired)
 	default:
 		return fmt.Errorf("unknown bleve sub-index %q", name)
 	}
@@ -520,21 +531,19 @@ func RebuildBleveSubIndex(root, name string) error {
 		return fmt.Errorf("close recreated %s bleve index: %w", name, err)
 	}
 
-	if name == "comment" {
-		dbPath := filepath.Join(root, MetadataDBFile)
-		if _, statErr := os.Stat(dbPath); statErr == nil {
-			db, openErr := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
-			if openErr != nil {
-				slog.Warn("rebuild comment: open metadata.db", "err", openErr)
-				return nil
-			}
-			defer db.Close()
-			if _, exErr := db.Exec(`UPDATE blobs SET comments_parsed = 0`); exErr != nil {
-				slog.Warn("rebuild comment: clear comments_parsed", "err", exErr)
-			}
-		}
+	dbPath := filepath.Join(root, MetadataDBFile)
+	if _, statErr := os.Stat(dbPath); statErr != nil {
+		// no metadata.db means no blobs to mark — nothing to do (e.g. fresh dataDir)
+		return nil
 	}
-
+	db, openErr := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
+	if openErr != nil {
+		return fmt.Errorf("open metadata.db for comment rebuild: %w", openErr)
+	}
+	defer db.Close()
+	if _, exErr := db.Exec(`UPDATE blobs SET comments_parsed = 0`); exErr != nil {
+		return fmt.Errorf("reset comments_parsed after comment rebuild: %w", exErr)
+	}
 	return nil
 }
 

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -789,6 +789,43 @@ func TestRebuildBleveSubIndex_Comment_BubblesSQLFailure(t *testing.T) {
 		"SQL failure must not be confused with full-reindex-required")
 }
 
+// TestIsBleveIndexCorrupt_UnreadableStoreDir_NotFlagged verifies that a
+// transient/permission failure to list the store/ directory does NOT
+// cause isBleveIndexCorrupt to return true. Without this guard, an
+// EACCES on store/ would make every referenced segment look missing and
+// route a healthy index to the destructive rebuild path.
+//
+// Failure prevented: false-positive corruption signal triggering data
+// loss on transient I/O.
+func TestIsBleveIndexCorrupt_UnreadableStoreDir_NotFlagged(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: Bleve operations")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("permission test not reliable on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("skipping permission test when running as root")
+	}
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "idx")
+	idx, err := openOrCreateBleveIndex(indexPath, "test")
+	require.NoError(t, err)
+	require.NoError(t, idx.Close())
+
+	storeDir := filepath.Join(indexPath, "store")
+	boltPath := filepath.Join(storeDir, "root.bolt")
+	t.Cleanup(func() { _ = os.Chmod(storeDir, 0o700) })
+	require.NoError(t, os.Chmod(storeDir, 0o000), "make store dir unreadable")
+
+	// bolt path itself stat-able through parent (we own it); but ReadDir on
+	// store/ will EACCES. Must NOT report corrupt.
+	require.False(t, isBleveIndexCorrupt(boltPath),
+		"unreadable store dir must not be misread as missing segments")
+}
+
 func mustModTime(t *testing.T, path string) time.Time {
 	t.Helper()
 	info, err := os.Stat(path)

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -731,6 +731,62 @@ func TestRebuildBleveSubIndex_RejectsUnknownName(t *testing.T) {
 	tmp := t.TempDir()
 	err := RebuildBleveSubIndex(tmp, "../../etc")
 	require.Error(t, err, "unknown name must be rejected")
+	require.False(t, errors.Is(err, ErrFullReindexRequired),
+		"unknown name must not masquerade as full-reindex-required")
+}
+
+// TestRebuildBleveSubIndex_CodeDiff_RequireFullReindex is the contract that
+// prevents a silent broken-heal: code and diff cannot be repopulated from
+// SQL alone, so RebuildBleveSubIndex must refuse and force callers to fall
+// back to a full reindex. Without this, doctor/daemon would report a
+// "successful" rebuild while leaving search permanently empty.
+//
+// Failure prevented: a code/diff rebuild that recreates an empty bleve and
+// returns nil — the previous behavior in this PR's first revision.
+func TestRebuildBleveSubIndex_CodeDiff_RequireFullReindex(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+
+	for _, name := range []string{"code", "diff"} {
+		err := RebuildBleveSubIndex(tmp, name)
+		require.Error(t, err, "%s rebuild must not silently succeed", name)
+		require.True(t, errors.Is(err, ErrFullReindexRequired),
+			"%s rebuild must wrap ErrFullReindexRequired so callers can branch on it", name)
+	}
+
+	// Refusal must NOT touch the filesystem — bleve dirs and SQL stay intact.
+	// We assert nothing was created by checking the tmpdir is empty afterwards.
+	entries, err := os.ReadDir(tmp)
+	require.NoError(t, err)
+	require.Empty(t, entries, "code/diff refusal must not modify state on disk")
+}
+
+// TestRebuildBleveSubIndex_Comment_BubblesSQLFailure verifies that if the
+// SQL flag reset fails, the rebuild does NOT silently report success.
+// Without this, the comment bleve would be empty AND comments_parsed=1
+// would still be set on every blob, leaving comment search dead until a
+// future migration or manual intervention.
+//
+// Failure prevented: silent broken-heal where the bleve is rebuilt empty
+// but ParseComments has nothing to repopulate it with.
+func TestRebuildBleveSubIndex_Comment_BubblesSQLFailure(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: SQLite + Bleve operations")
+	}
+	tmp := t.TempDir()
+	s, err := Open(tmp)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	// Replace metadata.db with garbage so PRAGMA (or the UPDATE) fails.
+	dbPath := filepath.Join(tmp, MetadataDBFile)
+	require.NoError(t, os.WriteFile(dbPath, []byte("not a sqlite file"), 0o600))
+
+	rbErr := RebuildBleveSubIndex(tmp, "comment")
+	require.Error(t, rbErr, "rebuild must surface SQL failure, not return nil")
+	require.False(t, errors.Is(rbErr, ErrFullReindexRequired),
+		"SQL failure must not be confused with full-reindex-required")
 }
 
 func mustModTime(t *testing.T, path string) time.Time {

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -8,8 +8,10 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 )
 
 // expectedTables lists every table the schema should create.
@@ -583,7 +585,7 @@ func TestOpenOrCreateBleveIndex_LockedIndexNotNuked(t *testing.T) {
 	indexPath := filepath.Join(tmp, "test-index")
 
 	// create a real bleve index at indexPath so root.bolt exists with valid bbolt structure
-	first, err := openOrCreateBleveIndex(indexPath)
+	first, err := openOrCreateBleveIndex(indexPath, "test")
 	if err != nil {
 		t.Fatalf("create index: %v", err)
 	}
@@ -597,11 +599,185 @@ func TestOpenOrCreateBleveIndex_LockedIndexNotNuked(t *testing.T) {
 	require.NoError(t, os.WriteFile(boltPath, []byte("corrupted"), 0600))
 
 	// openOrCreateBleveIndex must fail (corrupt bolt) but must NOT delete the index directory
-	_, openErr := openOrCreateBleveIndex(indexPath)
+	_, openErr := openOrCreateBleveIndex(indexPath, "test")
 	require.Error(t, openErr, "expected error opening corrupt index")
 
 	// bolt file must survive — index was not nuked
 	if _, statErr := os.Stat(boltPath); statErr != nil {
 		t.Errorf("root.bolt was deleted: openOrCreateBleveIndex nuked on open error: %v", statErr)
 	}
+}
+
+// emptyMappingForLatestSnapshot opens root.bolt and overwrites the latest
+// snapshot's `_mapping` value with zero bytes — reproducing the on-disk state
+// observed in the field where bleve.Open fails with "error parsing mapping
+// JSON: unexpected end of JSON input" while .zap shards are healthy.
+func emptyMappingForLatestSnapshot(t *testing.T, boltPath string) {
+	t.Helper()
+	db, err := bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: 2 * time.Second})
+	require.NoError(t, err, "open bolt for mapping corruption")
+	t.Cleanup(func() { db.Close() })
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		snaps := tx.Bucket([]byte{'s'})
+		require.NotNil(t, snaps, "snapshots bucket missing — bleve layout changed")
+		var lastKey []byte
+		require.NoError(t, snaps.ForEach(func(k, _ []byte) error {
+			lastKey = append(lastKey[:0], k...)
+			return nil
+		}))
+		require.NotNil(t, lastKey, "no snapshots in bolt")
+		snap := snaps.Bucket(lastKey)
+		require.NotNil(t, snap, "snapshot bucket missing")
+		internal := snap.Bucket([]byte{'i'})
+		require.NotNil(t, internal, "internal bucket missing — no mapping to corrupt")
+		return internal.Put([]byte("_mapping"), []byte{})
+	}))
+	require.NoError(t, db.Close())
+}
+
+// TestOpen_EmptyMapping_ReturnsTypedError verifies that the empty-mapping
+// failure mode (root.bolt present, _mapping value zero-length) is surfaced
+// as MappingCorruptError instead of being misclassified as lock contention.
+//
+// Failure prevented: daemon spinning at 340% CPU because each indexing pass
+// fails with the wrapped lock-contention error and openOrCreateBleveIndex
+// refuses to nuke an "in-use" index that is actually permanently broken.
+func TestOpen_EmptyMapping_ReturnsTypedError(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: SQLite + Bleve operations")
+	}
+
+	tmp := t.TempDir()
+	s1, err := Open(tmp)
+	require.NoError(t, err, "first Open")
+	require.NoError(t, s1.Close())
+
+	boltPath := filepath.Join(tmp, "bleve", "comment", "store", "root.bolt")
+	emptyMappingForLatestSnapshot(t, boltPath)
+
+	_, err = Open(tmp)
+	require.Error(t, err, "Open must fail when mapping is empty")
+	var mce *MappingCorruptError
+	require.True(t, errors.As(err, &mce), "expected MappingCorruptError in chain, got: %v", err)
+	require.Equal(t, "comment", mce.Name, "wrong sub-index name")
+
+	// peer sub-indexes (code, diff) must be untouched
+	for _, name := range []string{"code", "diff"} {
+		boltOK := filepath.Join(tmp, "bleve", name, "store", "root.bolt")
+		_, statErr := os.Stat(boltOK)
+		require.NoError(t, statErr, "%s sub-index was disturbed by open of corrupt comment", name)
+	}
+}
+
+// TestRebuildBleveSubIndex_Comment verifies that a targeted rebuild of the
+// comment sub-index recovers Open without affecting code/diff data and
+// resets the SQL flag so ParseComments will repopulate on the next pass.
+//
+// Failure prevented: doctor's only remedy being a full os.RemoveAll(dataDir),
+// which destroys ~600MB of code data plus ~600MB of diff data to recover
+// from a small mapping-doc corruption.
+func TestRebuildBleveSubIndex_Comment(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: SQLite + Bleve operations")
+	}
+
+	tmp := t.TempDir()
+	s1, err := Open(tmp)
+	require.NoError(t, err, "first Open")
+	// seed a blob so we can verify comments_parsed reset
+	_, err = s1.Exec(`INSERT INTO blobs (content_hash, language, parsed, comments_parsed) VALUES (?, ?, 1, 1)`, "deadbeef", "go")
+	require.NoError(t, err, "seed blob")
+	require.NoError(t, s1.Close())
+
+	boltPath := filepath.Join(tmp, "bleve", "comment", "store", "root.bolt")
+	emptyMappingForLatestSnapshot(t, boltPath)
+
+	// Open should fail with MappingCorruptError before rebuild
+	_, err = Open(tmp)
+	require.Error(t, err)
+	var preMCE *MappingCorruptError
+	require.True(t, errors.As(err, &preMCE), "expected MappingCorruptError")
+
+	// Capture code sub-index state AFTER the failed Open so the rebuild call
+	// is the only operation that could perturb it. We assert the rebuild leaves
+	// every code-side artifact byte-for-byte identical.
+	codeFingerprint := codeIndexFingerprint(t, tmp)
+
+	// targeted rebuild
+	require.NoError(t, RebuildBleveSubIndex(tmp, "comment"), "rebuild comment")
+
+	// code sub-index must be untouched
+	require.Equal(t, codeFingerprint, codeIndexFingerprint(t, tmp),
+		"rebuild of comment sub-index must not touch code sub-index")
+
+	// Open + integrity must succeed post-rebuild
+	s2, err := Open(tmp)
+	require.NoError(t, err, "Open post-rebuild")
+	defer s2.Close()
+	require.NoError(t, s2.CheckIntegrity(), "integrity post-rebuild")
+
+	// comments_parsed must be reset so ParseComments will retry the seeded blob
+	var cp int
+	require.NoError(t, s2.QueryRow(`SELECT comments_parsed FROM blobs WHERE content_hash = ?`, "deadbeef").Scan(&cp))
+	require.Equal(t, 0, cp, "comments_parsed must be cleared after rebuild")
+}
+
+// TestRebuildBleveSubIndex_RejectsUnknownName guards the API surface so
+// callers can't silently nuke an arbitrary path.
+func TestRebuildBleveSubIndex_RejectsUnknownName(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	err := RebuildBleveSubIndex(tmp, "../../etc")
+	require.Error(t, err, "unknown name must be rejected")
+}
+
+func mustModTime(t *testing.T, path string) time.Time {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat %s", path)
+	return info.ModTime()
+}
+
+// codeIndexFingerprint hashes file paths + mtimes + sizes under bleve/code/.
+// Used to assert a rebuild of one sub-index doesn't perturb a peer.
+func codeIndexFingerprint(t *testing.T, root string) string {
+	t.Helper()
+	codeDir := filepath.Join(root, "bleve", "code")
+	var entries []string
+	err := filepath.Walk(codeDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(codeDir, p)
+		entries = append(entries, rel+":"+info.ModTime().UTC().String()+":"+
+			fmtInt64(info.Size()))
+		return nil
+	})
+	require.NoError(t, err, "walk code dir")
+	return joinSorted(entries)
+}
+
+func fmtInt64(n int64) string {
+	return time.Unix(n, 0).UTC().String()
+}
+
+func joinSorted(s []string) string {
+	out := make([]string, len(s))
+	copy(out, s)
+	// stable order independent of walk order
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	res := ""
+	for _, v := range out {
+		res += v + "\n"
+	}
+	return res
 }

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -616,7 +616,6 @@ func emptyMappingForLatestSnapshot(t *testing.T, boltPath string) {
 	t.Helper()
 	db, err := bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: 2 * time.Second})
 	require.NoError(t, err, "open bolt for mapping corruption")
-	t.Cleanup(func() { db.Close() })
 	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
 		snaps := tx.Bucket([]byte{'s'})
 		require.NotNil(t, snaps, "snapshots bucket missing — bleve layout changed")

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -1112,6 +1112,14 @@ func (m *CodeDBManager) handleMappingCorrupt(mce *store.MappingCorruptError, dat
 	m.mu.Unlock()
 
 	if err := store.RebuildBleveSubIndex(dataDir, mce.Name); err != nil {
+		if errors.Is(err, store.ErrFullReindexRequired) {
+			// code/diff: not safe to auto-rebuild (would leave search empty
+			// until manual --full). Surface to ox doctor instead of looping.
+			m.logger.Warn("codedb sub-index needs full reindex; not auto-recovering",
+				"name", mce.Name,
+				"action", "run 'ox doctor --fix' or 'ox code index --full'")
+			return
+		}
 		m.logger.Warn("codedb sub-index auto-rebuild failed",
 			"name", mce.Name, "error", err)
 		return

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -13,10 +13,17 @@ import (
 
 	"github.com/sageox/ox/internal/codedb"
 	"github.com/sageox/ox/internal/codedb/index"
+	"github.com/sageox/ox/internal/codedb/store"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/paths"
 )
+
+// maxBleveRebuildAttempts caps how many times the daemon will auto-rebuild a
+// single bleve sub-index across CheckFreshness cycles before giving up. A
+// genuinely-corrupt-disk situation should not become a rebuild loop; once the
+// cap is hit we leave the index broken and let `ox doctor` surface it.
+const maxBleveRebuildAttempts = 2
 
 // CodeDBManager manages CodeDB indexing in the daemon.
 // It ensures only one indexing operation runs at a time and tracks index status.
@@ -65,6 +72,11 @@ type CodeDBManager struct {
 	lastDirtyRefresh time.Time
 	// dirtyTestHook is called at the start of RefreshDirtyOverlay; nil in production.
 	dirtyTestHook func()
+
+	// bleveRebuildAttempts tracks per-sub-index auto-rebuild attempts so a
+	// chronically-corrupt index can't become an infinite rebuild loop. Keyed
+	// by sub-index name ("code"/"diff"/"comment").
+	bleveRebuildAttempts map[string]int
 }
 
 // CodeDBStats tracks index statistics.
@@ -765,6 +777,16 @@ func (m *CodeDBManager) CheckFreshness(ctx context.Context) {
 					Summary:  "codedb cache directory missing; sparse-checkout may have wiped .sageox/cache/",
 				})
 			}
+			// Self-heal: a single bleve sub-index with an empty mapping doc
+			// blocks every indexing pass forever (observed: daemon at 340% CPU
+			// looping on `error parsing mapping JSON: unexpected end of JSON
+			// input`). Detect via typed MappingCorruptError; rebuild only the
+			// affected sub-index and let the next CheckFreshness cycle retry
+			// the indexing pipeline. Bounded by maxBleveRebuildAttempts so a
+			// chronically-broken disk doesn't become a rebuild loop.
+			if mce := mappingCorruptFromErr(err); mce != nil {
+				m.handleMappingCorrupt(mce, dataDir)
+			}
 			if isInitial {
 				m.logger.Warn("codedb initial index failed", "error", err)
 			} else {
@@ -1058,4 +1080,43 @@ func (m *CodeDBManager) setError(err error) {
 	m.mu.Lock()
 	m.lastErr = err
 	m.mu.Unlock()
+}
+
+// mappingCorruptFromErr returns the MappingCorruptError in err's chain, or nil.
+func mappingCorruptFromErr(err error) *store.MappingCorruptError {
+	var mce *store.MappingCorruptError
+	if errors.As(err, &mce) {
+		return mce
+	}
+	return nil
+}
+
+// handleMappingCorrupt rebuilds a single bleve sub-index that has an empty
+// persisted mapping doc. Bounded by maxBleveRebuildAttempts per sub-index so
+// repeated rebuild failures don't burn CPU forever — once exhausted, the
+// daemon emits a warning and leaves recovery to `ox doctor`.
+func (m *CodeDBManager) handleMappingCorrupt(mce *store.MappingCorruptError, dataDir string) {
+	m.mu.Lock()
+	if m.bleveRebuildAttempts == nil {
+		m.bleveRebuildAttempts = make(map[string]int)
+	}
+	attempts := m.bleveRebuildAttempts[mce.Name]
+	if attempts >= maxBleveRebuildAttempts {
+		m.mu.Unlock()
+		m.logger.Warn("codedb sub-index auto-rebuild exhausted",
+			"name", mce.Name, "attempts", attempts,
+			"action", "run 'ox doctor --fix' to repair manually")
+		return
+	}
+	m.bleveRebuildAttempts[mce.Name] = attempts + 1
+	m.mu.Unlock()
+
+	if err := store.RebuildBleveSubIndex(dataDir, mce.Name); err != nil {
+		m.logger.Warn("codedb sub-index auto-rebuild failed",
+			"name", mce.Name, "error", err)
+		return
+	}
+	m.logger.Warn("codedb sub-index auto-rebuilt",
+		"name", mce.Name, "attempt", attempts+1,
+		"note", "next indexing pass will repopulate")
 }

--- a/internal/daemon/codedb_selfheal_test.go
+++ b/internal/daemon/codedb_selfheal_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/codedb"
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+// TestMappingCorruptFromErr_FindsTypedErrorThroughWrapping verifies that the
+// daemon's helper unwraps the `codedb initial index failed: open codedb: open
+// codedb store: open comment index: ...` error chain and surfaces the typed
+// MappingCorruptError so handleMappingCorrupt can act on it.
+//
+// Failure prevented: the daemon would have to string-parse error messages to
+// learn which sub-index failed — brittle and silent if the wrapping changes.
+func TestMappingCorruptFromErr_FindsTypedErrorThroughWrapping(t *testing.T) {
+	t.Parallel()
+
+	original := &store.MappingCorruptError{Name: "comment", Path: "/tmp/whatever"}
+	wrapped := fmt.Errorf("codedb initial index failed: %w",
+		fmt.Errorf("open codedb: %w",
+			fmt.Errorf("open codedb store: %w",
+				fmt.Errorf("open comment index: %w", original))))
+
+	got := mappingCorruptFromErr(wrapped)
+	require.NotNil(t, got, "MappingCorruptError must be findable through 4 levels of wrapping")
+	require.Equal(t, "comment", got.Name)
+	require.Equal(t, "/tmp/whatever", got.Path)
+
+	// negative case: unrelated error
+	require.Nil(t, mappingCorruptFromErr(errors.New("unrelated")))
+	require.Nil(t, mappingCorruptFromErr(nil))
+}
+
+// TestHandleMappingCorrupt_RebuildsAndCapsAttempts verifies the bounded
+// auto-rebuild contract: the first observation triggers a rebuild; once the
+// per-sub-index counter hits maxBleveRebuildAttempts, further observations
+// are no-ops so a chronically-broken disk doesn't become a rebuild loop.
+//
+// Failure prevented: daemon at 340% CPU rebuilding the same broken sub-index
+// every freshness cycle.
+func TestHandleMappingCorrupt_RebuildsAndCapsAttempts(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: SQLite + Bleve operations")
+	}
+
+	tmp := t.TempDir()
+	db, err := codedb.Open(tmp)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// repeatedly poison the comment mapping and ask the manager to heal.
+	mgr := NewCodeDBManager(t.TempDir(), codedbTestLogger(), nil)
+
+	// 1st invocation: should rebuild successfully and increment counter to 1
+	poisonCommentMapping(t, tmp)
+	mce := &store.MappingCorruptError{Name: "comment", Path: filepath.Join(tmp, "bleve", "comment")}
+	mgr.handleMappingCorrupt(mce, tmp)
+
+	// validate Open succeeds after rebuild
+	db2, err := codedb.Open(tmp)
+	require.NoError(t, err, "Open must succeed after first rebuild")
+	require.NoError(t, db2.Close())
+
+	mgr.mu.Lock()
+	require.Equal(t, 1, mgr.bleveRebuildAttempts["comment"], "first attempt counted")
+	mgr.mu.Unlock()
+
+	// 2nd invocation: still under cap, rebuilds again
+	poisonCommentMapping(t, tmp)
+	mgr.handleMappingCorrupt(mce, tmp)
+	mgr.mu.Lock()
+	require.Equal(t, 2, mgr.bleveRebuildAttempts["comment"], "second attempt counted")
+	mgr.mu.Unlock()
+
+	// 3rd invocation: at cap (maxBleveRebuildAttempts == 2), MUST NOT rebuild.
+	// Poison the mapping again and verify Open still fails (proof the rebuild
+	// did not run).
+	poisonCommentMapping(t, tmp)
+	mgr.handleMappingCorrupt(mce, tmp)
+
+	_, err = codedb.Open(tmp)
+	require.Error(t, err, "after cap, rebuild must not run; Open stays broken until ox doctor")
+	var mce2 *store.MappingCorruptError
+	require.True(t, errors.As(err, &mce2), "broken state still surfaces as MappingCorruptError")
+
+	mgr.mu.Lock()
+	require.Equal(t, 2, mgr.bleveRebuildAttempts["comment"], "counter must not advance past cap")
+	mgr.mu.Unlock()
+}
+
+func poisonCommentMapping(t *testing.T, root string) {
+	t.Helper()
+	boltPath := filepath.Join(root, "bleve", "comment", "store", "root.bolt")
+	db, err := bbolt.Open(boltPath, 0600, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		snaps := tx.Bucket([]byte{'s'})
+		require.NotNil(t, snaps)
+		var lastKey []byte
+		require.NoError(t, snaps.ForEach(func(k, _ []byte) error {
+			lastKey = append(lastKey[:0], k...)
+			return nil
+		}))
+		snap := snaps.Bucket(lastKey)
+		require.NotNil(t, snap)
+		internal := snap.Bucket([]byte{'i'})
+		require.NotNil(t, internal)
+		return internal.Put([]byte("_mapping"), []byte{})
+	}))
+	require.NoError(t, db.Close())
+}

--- a/internal/daemon/codedb_selfheal_test.go
+++ b/internal/daemon/codedb_selfheal_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -93,6 +94,51 @@ func TestHandleMappingCorrupt_RebuildsAndCapsAttempts(t *testing.T) {
 
 	mgr.mu.Lock()
 	require.Equal(t, 2, mgr.bleveRebuildAttempts["comment"], "counter must not advance past cap")
+	mgr.mu.Unlock()
+}
+
+// TestHandleMappingCorrupt_CodeDiff_DoesNotLoop verifies that when a
+// code/diff sub-index is reported corrupt, the daemon does NOT keep
+// looping through auto-rebuild — RebuildBleveSubIndex returns
+// ErrFullReindexRequired, so we log once per attempt (counter increments)
+// and then stop trying after the cap. Without this, a code/diff
+// MappingCorruptError combined with the previous "rebuild + return nil"
+// behavior would have left search silently empty while the daemon
+// reported "auto-rebuilt" every cycle.
+//
+// Failure prevented: silent broken-heal of code/diff sub-index.
+func TestHandleMappingCorrupt_CodeDiff_DoesNotLoop(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: SQLite + Bleve operations")
+	}
+
+	tmp := t.TempDir()
+	db, err := codedb.Open(tmp)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	mgr := NewCodeDBManager(t.TempDir(), codedbTestLogger(), nil)
+	mce := &store.MappingCorruptError{Name: "code", Path: filepath.Join(tmp, "bleve", "code")}
+
+	// before: code bleve dir exists with content
+	codeBleveDir := filepath.Join(tmp, "bleve", "code")
+	beforeEntries, err := os.ReadDir(codeBleveDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, beforeEntries, "code bleve must have entries before refusal")
+
+	mgr.handleMappingCorrupt(mce, tmp)
+
+	// after: code bleve dir untouched (refusal does NOT delete on disk)
+	afterEntries, err := os.ReadDir(codeBleveDir)
+	require.NoError(t, err)
+	require.Equal(t, len(beforeEntries), len(afterEntries),
+		"ErrFullReindexRequired path must not modify code bleve on disk")
+
+	// counter must increment so the daemon stops after maxBleveRebuildAttempts
+	mgr.mu.Lock()
+	require.Equal(t, 1, mgr.bleveRebuildAttempts["code"],
+		"attempt must count even when rebuild refused — otherwise infinite loop")
 	mgr.mu.Unlock()
 }
 


### PR DESCRIPTION
## Summary

A daemon was observed pinned at 340% CPU forever, retrying ``codedb initial index failed: open codedb: open codedb store: open comment index: bleve index appears to be in use (lock contention): error parsing mapping JSON: unexpected end of JSON input`` every cycle. The "lock contention" wrapper is a false flag — the index was structurally corrupt, not in use.

The condition: ``bleve/comment/store/root.bolt`` is intact and readable, the latest snapshot's ``_mapping`` doc is intact, but that snapshot references segment IDs (``0x209``, ``0x36d``) whose ``.zap`` shards never landed on disk. ``bleve.Open`` partially loads, then fails when it can't read the mapping through a degraded reader. Pre-fix behavior: ``openOrCreateBleveIndex`` saw root.bolt present, refused to nuke (correctly avoiding data loss in the real lock-contention case), and returned the misleading wrapped error — which the daemon retried forever and ``ox doctor --fix`` could only resolve by ``os.RemoveAll(dataDir)`` (~1.6 GB of healthy ``code`` + ``diff`` data wiped to recover from a few-byte corruption in ``comment``).

This PR distinguishes real lock contention from on-disk corruption non-blockingly, and adds a targeted rebuild that only touches the affected sub-index.

- New typed ``store.MappingCorruptError{Name, Path}`` so callers identify which sub-index failed without string-parsing.
- ``isBleveIndexCorrupt(boltPath)``: read-only bbolt open with 100ms timeout, walks the latest snapshot, returns true only when one of two conditions is **provable** — empty/missing ``_mapping`` doc, OR snapshot references segment IDs whose ``.zap`` files are missing on disk. A real exclusive write lock blocks the read and we stay in the safe lock-contention path.
- ``store.RebuildBleveSubIndex(root, name)``: nukes only ``bleve/<name>/``, recreates empty. For ``"comment"``, also resets ``blobs.comments_parsed = 0`` so ``ParseComments`` repopulates from existing SQL data on the next pass — no git rewalk needed.
- Daemon hook in ``CheckFreshness``: ``errors.As`` the ``doIndex`` chain for ``MappingCorruptError``; on hit, rebuild once and let the next freshness cycle re-run indexing. Bounded by ``maxBleveRebuildAttempts = 2`` per sub-index so a chronically-broken disk can't loop.
- Doctor hook in ``checkCodeIndex``: surgical rebuild instead of unconditional ``os.RemoveAll(dataDir)``.

## Verification against the live poison pill

A real corrupt index existed on disk (``b63b18fb98d7ed05954727adc322ffa3d49f06ed878845181804b1362b92249d`` for ``bleve/comment/store/root.bolt``). I ``cp -a``'d it to two scratch paths while the daemon kept running, built a verifier from this branch and from the parent commit, and ran both:

- **ox.old (parent ``364eb0e``)**: ``store.Open`` returns ``"bleve index appears to be in use (lock contention): error parsing mapping JSON: unexpected end of JSON input"`` — the production error.
- **ox.new**: ``store.Open`` returns typed ``MappingCorruptError{Name: "comment"}``; ``RebuildBleveSubIndex(path, "comment")`` succeeds; re-Open + ``CheckIntegrity`` pass.

Contract from ``.context/codedb-poison-pill-verification.md``:

- ``code/*.zap`` shard sha256s byte-identical pre/post: **YES** ✓
- ``diff/*.zap`` shard sha256s byte-identical pre/post: **YES** ✓
- Only ``bleve/comment/`` rebuilt (12 ``.zap`` segments → 0; will be repopulated on next ``ParseComments`` since ``comments_parsed`` was reset)
- Live state untouched: live ``root.bolt`` sha256 unchanged, daemon PID 9951 still running

```mermaid
flowchart TD
    A[doIndex error] --> B{errors.As<br/>MappingCorruptError?}
    B -->|no| C[existing error path]
    B -->|yes| D{attempts &lt; cap?}
    D -->|no| E[log + leave to ox doctor]
    D -->|yes| F[RebuildBleveSubIndex<br/>name only]
    F --> G[clear comments_parsed<br/>if name == comment]
    G --> H[next CheckFreshness<br/>re-runs indexing]
```

## Test plan

- [x] ``TestOpen_EmptyMapping_ReturnsTypedError`` — corrupts mapping, asserts typed error and code/diff bolts untouched
- [x] ``TestRebuildBleveSubIndex_Comment`` — full lifecycle: corrupt → rebuild → reopen → integrity passes; ``comments_parsed`` reset; code sub-index byte-identical
- [x] ``TestRebuildBleveSubIndex_RejectsUnknownName`` — guards against arbitrary path traversal via name arg
- [x] ``TestCheckCodeIndexAtDir_CorruptMapping_TargetedRebuild`` — doctor ``--fix`` performs surgical rebuild; code/diff bolts survive
- [x] ``TestMappingCorruptFromErr_FindsTypedErrorThroughWrapping`` — ``errors.As`` unwraps through 4 levels of ``%w``
- [x] ``TestHandleMappingCorrupt_RebuildsAndCapsAttempts`` — first 2 invocations rebuild; 3rd is a no-op (re-poisoned and verified Open stays broken)
- [x] ``TestOpenOrCreateBleveIndex_LockedIndexNotNuked`` — pre-existing real-flock regression still passes; corrupting bolt magic bytes doesn't trigger the new path
- [x] ``make lint``: 0 issues
- [x] End-to-end against the live poison pill (cp -a copy, daemon untouched)
- [ ] Post-merge smoke: run ``ox doctor --fix`` on the live machine to recover the still-corrupt comment index

## Out of scope

- Root cause of how the snapshot-references-missing-segments state arose (suspect crash during a partial bolt commit / fsync ordering between bolt + ``.zap`` writes). Worth a follow-up bug to investigate, but the self-heal lands independently.
- A "rebleve from SQL" path for code/diff sub-indexes. Comment can repopulate from blobs because ``ParseComments`` is gated on ``comments_parsed``; code/diff are populated during the per-commit walk in ``IndexRepo`` gated on ``commits`` rows. Until a rebleve-from-SQL pass exists, code/diff rebuilds leave the bleve empty until a full ``ox code index --full``. No regression vs today, since ``--full`` is also the only path today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daemon now performs bounded automatic self-healing for search-index mapping corruption and can trigger a targeted sub-index rebuild; run "ox doctor --fix" to apply the same targeted repair manually.

* **Bug Fixes**
  * Clearer, sub-index-specific corruption messages and guidance.
  * Recovery avoids removing entire indexes when only a single sub-index needs repair; auto-rebuilds are capped and will prompt manual recovery when exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->