### PR TITLE
test: 5x fast-tier speedup (483s → 96s) + writer-injection refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for ox CLI tool
 
-.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-all test-slow test-integration test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version beads-setup
+.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-all test-slow test-integration test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version beads-setup
 
 # Variables
 GO := go
@@ -84,14 +84,25 @@ run: build ## Build and run ox
 # Testing (uses gotestsum for human-readable colorized output)
 #
 # Test Tiers:
-#   fast  (make test)             — Unit tests <500ms. No git clone, no network. Runs on every commit.
-#   full  (make test-all)         — All unit tests including expensive ones (git clone, SQLite concurrent, LFS).
+#   fast  (make test)             — Unit tests <500ms. No git clone, no network, NO coverage instrumentation.
+#                                   Runs on every commit. Target: <60s wall.
+#   fast+cov (make test-cover)    — Same as fast but with coverage (~15-20% slower). Local use.
+#   full  (make test-all)         — All unit tests including expensive ones (git clone, SQLite, LFS).
+#                                   Coverage collection lives here. Target: <5min wall.
 #   slow  (make test-slow)        — Tests requiring real ox binary (build tag: slow). No Claude needed.
 #   integration — E2E with real Claude sessions. Lives in sageox/ox-test-harness (private).
 #
+# Tier criteria for `make test` (fast):
+#   - No exec.Command (git or otherwise) except via an in-process fake.
+#   - No time.Sleep > 5ms on the success path.
+#   - No real SQLite/Bleve file I/O.
+#   - No os.Setenv (use t.Setenv); tests should call t.Parallel().
+#   - httptest.NewServer OK; no reliance on real timeouts.
+#   - Only env-gated t.Skip (e.g. git binary missing).
+#
 # Recommended usage:
-#   Coding:    make test           — Fast feedback (<30s target)
-#   Pre-PR:    make test-preflight — Full + slow + lint (~3-5min)
+#   Coding:    make test           — Fast feedback (target <60s, no coverage)
+#   Pre-PR:    make test-preflight — Full + slow + lint (~3-5min, with coverage)
 #   Release:   make test-all test-slow (+ integration tests from ox-test-harness)
 #
 # Output: quiet by default (agent-friendly). V=1 for verbose.
@@ -99,11 +110,15 @@ run: build ## Build and run ox
 GOTESTSUM := $(shell which gotestsum 2>/dev/null || echo "go run gotest.tools/gotestsum@latest")
 
 # Targets below are agent-friendly by default (quiet). V=1 for verbose.
-test: ## Run fast tests — unit tests <500ms, race detection (every commit)
-	$(call say,"Running fast tests (skipping >500ms)...")
+test: ## Run fast tests — unit tests <500ms, race detection, no coverage (every commit)
+	$(call say,"Running fast tests (skipping >500ms, no coverage)...")
+	@$(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -short -race -p 8 -parallel 32 ./...
+
+test-cover: ## Run fast tests with coverage collection (~15-20% slower than `make test`)
+	$(call say,"Running fast tests with coverage...")
 	@$(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -short -race -p 8 -parallel 32 -coverprofile=coverage.out -covermode=atomic ./...
 
-test-all: ## Run all unit tests including expensive ones (git clone, SQLite, LFS)
+test-all: ## Run all unit tests including expensive ones (git clone, SQLite, LFS) with coverage
 	$(call say,"Running all tests including expensive tests...")
 	@$(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -race -p 8 -parallel 32 -coverprofile=coverage.out -covermode=atomic ./...
 
@@ -185,27 +200,27 @@ test-watch: ## Run tests in watch mode (requires gotestsum)
 COVERDIR := tmp/coverage
 COVERAGE_THRESHOLD ?= 50
 
-coverage: test ## Run tests and open coverage report
+coverage: test-cover ## Run fast tests with coverage and open report
 	@$(GO) tool cover -func=coverage.out | tail -1
 	@$(GO) tool cover -html=coverage.out -o coverage.html
 	@open coverage.html 2>/dev/null || xdg-open coverage.html 2>/dev/null || echo "Open coverage.html in your browser"
 
 coverage-report: ## Open coverage report from last test run (no re-run)
-	@test -f coverage.out || (echo "No coverage.out found. Run 'make test' first." && exit 1)
+	@test -f coverage.out || (echo "No coverage.out found. Run 'make test-cover' or 'make test-all' first." && exit 1)
 	@$(GO) tool cover -func=coverage.out | tail -1
 	@$(GO) tool cover -html=coverage.out -o coverage.html
 	@open coverage.html 2>/dev/null || xdg-open coverage.html 2>/dev/null || echo "Open coverage.html in your browser"
 
 coverage-func: ## Show per-function coverage in terminal
-	@test -f coverage.out || (echo "No coverage.out found. Run 'make test' first." && exit 1)
+	@test -f coverage.out || (echo "No coverage.out found. Run 'make test-cover' or 'make test-all' first." && exit 1)
 	@$(GO) tool cover -func=coverage.out
 
-coverage-baseline: test ## Save current coverage as baseline for diffs
+coverage-baseline: test-cover ## Save current coverage as baseline for diffs
 	@cp coverage.out .coverage-baseline.out
 	@$(GO) tool cover -func=.coverage-baseline.out | tail -1
 	@echo "Baseline saved."
 
-coverage-diff: test ## Show coverage change vs saved baseline
+coverage-diff: test-cover ## Show coverage change vs saved baseline
 	@test -f .coverage-baseline.out || (echo "No baseline. Run 'make coverage-baseline' first." && exit 1)
 	@echo "=== Coverage: baseline → current ==="
 	@echo "Baseline: $$($(GO) tool cover -func=.coverage-baseline.out | grep total: | awk '{print $$3}')"

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -458,7 +458,7 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 	// command output. This is opportunistic — the primary channel is
 	// handlePrompt (UserPromptSubmit hook) and the active pull is
 	// `ox agent <id> whisper`.
-	emitWhispers(agentID)
+	emitWhispers(cmd.OutOrStdout(), agentID)
 
 	subcommand := args[0]
 
@@ -547,9 +547,9 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 	case "whisper":
 		// `ox agent <id> whisper history` — show all whispers without advancing cursor
 		if len(subargs) > 0 && subargs[0] == "history" {
-			return runAgentWhisperHistory(inst)
+			return runAgentWhisperHistory(cmd.OutOrStdout(), inst)
 		}
-		return runAgentWhisper(inst)
+		return runAgentWhisper(cmd.OutOrStdout(), inst)
 	case "hook":
 		return runAgentHook(subargs)
 	default:
@@ -922,7 +922,7 @@ const (
 //
 // Unlike `ox agent <id> whisper`, this does NOT advance the delivery cursor,
 // so it's safe to run repeatedly without side effects.
-func runAgentWhisperHistory(inst *agentinstance.Instance) error {
+func runAgentWhisperHistory(w io.Writer, inst *agentinstance.Instance) error {
 	client := daemon.NewClientForCurrentRepoWithTimeout(500 * time.Millisecond)
 
 	// collect all pages; break if no more entries or no pagination
@@ -951,7 +951,7 @@ func runAgentWhisperHistory(inst *agentinstance.Instance) error {
 	}
 
 	if len(allEntries) == 0 {
-		fmt.Fprintln(os.Stdout, "No whispers in store.")
+		fmt.Fprintln(w, "No whispers in store.")
 		return nil
 	}
 
@@ -966,33 +966,33 @@ func runAgentWhisperHistory(inst *agentinstance.Instance) error {
 		}
 	}
 
-	fmt.Fprintf(os.Stdout, "Whisper history for %s (%d total)\n\n", inst.AgentID, len(allEntries))
+	fmt.Fprintf(w, "Whisper history for %s (%d total)\n\n", inst.AgentID, len(allEntries))
 
 	if len(pending) > 0 {
-		fmt.Fprintf(os.Stdout, "Pending (%d, not yet delivered):\n", len(pending))
+		fmt.Fprintf(w, "Pending (%d, not yet delivered):\n", len(pending))
 		for _, e := range pending {
-			fmt.Fprintf(os.Stdout, "  [%s] %s (%s) — %s\n",
+			fmt.Fprintf(w, "  [%s] %s (%s) — %s\n",
 				e.Importance, e.Topic, e.Source, e.CreatedAt.Local().Format("Jan 2 15:04:05"))
 			if e.Content != "" {
-				fmt.Fprintf(os.Stdout, "    %s\n", truncateString(e.Content, 120))
+				fmt.Fprintf(w, "    %s\n", truncateString(e.Content, 120))
 			}
 		}
-		fmt.Fprintln(os.Stdout)
+		fmt.Fprintln(w)
 	}
 
 	if len(delivered) > 0 {
-		fmt.Fprintf(os.Stdout, "Delivered (%d, already sent to agent):\n", len(delivered))
+		fmt.Fprintf(w, "Delivered (%d, already sent to agent):\n", len(delivered))
 		for _, e := range delivered {
-			fmt.Fprintf(os.Stdout, "  [%s] %s (%s) — %s\n",
+			fmt.Fprintf(w, "  [%s] %s (%s) — %s\n",
 				e.Importance, e.Topic, e.Source, e.CreatedAt.Local().Format("Jan 2 15:04:05"))
 			if e.Content != "" {
-				fmt.Fprintf(os.Stdout, "    %s\n", truncateString(e.Content, 120))
+				fmt.Fprintf(w, "    %s\n", truncateString(e.Content, 120))
 			}
 		}
 	}
 
 	if !hasCursor {
-		fmt.Fprintln(os.Stdout, "(cursor not set — all entries are pending)")
+		fmt.Fprintln(w, "(cursor not set — all entries are pending)")
 	}
 
 	return nil
@@ -1013,7 +1013,7 @@ func runAgentWhisperHistory(inst *agentinstance.Instance) error {
 //
 // Uses the same WhisperStore cursor as hook delivery — if the hook already
 // delivered pending whispers, this returns nothing. No double delivery.
-func runAgentWhisper(inst *agentinstance.Instance) error {
+func runAgentWhisper(w io.Writer, inst *agentinstance.Instance) error {
 	client := daemon.NewClientForCurrentRepoWithTimeout(500 * time.Millisecond)
 	resp, err := client.Whispers(inst.AgentID, "normal", nil)
 	if err != nil {
@@ -1034,7 +1034,7 @@ func runAgentWhisper(inst *agentinstance.Instance) error {
 		return nil
 	}
 
-	formatWhispers(os.Stdout, entries)
+	formatWhispers(w, entries)
 	traceWhisperDelivery(projectRoot, inst.AgentID, entries)
 	return nil
 }
@@ -1054,7 +1054,7 @@ func runAgentWhisper(inst *agentinstance.Instance) error {
 // but not ambient ones, to avoid flooding agent context.
 // Timeout is 100ms (vs 500ms for runAgentWhisper) because this runs in the
 // hot path of every hook invocation and must not add perceptible latency.
-func emitWhispers(agentID string) {
+func emitWhispers(w io.Writer, agentID string) {
 	// best-effort delivery — 100ms allows for daemon startup/load
 	client := daemon.NewClientForCurrentRepoWithTimeout(100 * time.Millisecond)
 	resp, err := client.Whispers(agentID, "normal", nil)
@@ -1074,7 +1074,7 @@ func emitWhispers(agentID string) {
 		return
 	}
 
-	formatWhispers(os.Stdout, entries)
+	formatWhispers(w, entries)
 
 	// best-effort context-trace for whisper delivery observability
 	traceWhisperDelivery(projectRoot, agentID, entries)

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -473,7 +473,7 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 
 	switch subcommand {
 	case "doctor":
-		return runAgentDoctor(inst)
+		return runAgentDoctor(cmd.OutOrStdout(), inst)
 	case "session":
 		if len(subargs) == 0 {
 			return fmt.Errorf("session requires a subcommand\nUsage: ox agent %s session <start|stop|abort|delete|log|remind|summarize|record|plan|context-trace|import|capture-prior|subagent-complete|subagent-list|recover>", inst.AgentID)

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -509,7 +509,7 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 		case "record":
 			return runAgentSessionRecord(inst, sessionArgs)
 		case "log":
-			return runAgentSessionLog(inst, sessionArgs)
+			return runAgentSessionLog(cmd.OutOrStdout(), inst, sessionArgs)
 		case "plan":
 			return runAgentSessionPlan(inst)
 		case "context-trace":

--- a/cmd/ox/agent_doctor.go
+++ b/cmd/ox/agent_doctor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,7 +40,7 @@ type IncompleteSessionInfo struct {
 
 // runAgentDoctor checks session health and returns structured info for agents.
 // Usage: ox agent <id> doctor [--json]
-func runAgentDoctor(inst *agentinstance.Instance) error {
+func runAgentDoctor(w io.Writer, inst *agentinstance.Instance) error {
 	projectRoot, err := findProjectRoot()
 	if err != nil {
 		return fmt.Errorf("could not find project root: %w", err)
@@ -58,20 +59,20 @@ func runAgentDoctor(inst *agentinstance.Instance) error {
 	// output format selection (priority: review > text > json default)
 	if cfg.Review {
 		// security audit mode: human summary + JSON
-		outputAgentDoctorText(output)
-		fmt.Println()
-		fmt.Println("--- Machine Output ---")
-		return outputAgentDoctorJSON(output)
+		outputAgentDoctorText(w, output)
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "--- Machine Output ---")
+		return outputAgentDoctorJSON(w, output)
 	}
 
 	if cfg.Text {
 		// human-readable text output
-		outputAgentDoctorText(output)
+		outputAgentDoctorText(w, output)
 		return nil
 	}
 
 	// default: JSON output
-	return outputAgentDoctorJSON(output)
+	return outputAgentDoctorJSON(w, output)
 }
 
 // buildAgentDoctorOutput gathers session health information for agent consumption
@@ -331,45 +332,45 @@ func buildNextSteps(output *AgentDoctorOutput) []string {
 }
 
 // outputAgentDoctorJSON outputs the doctor results as JSON
-func outputAgentDoctorJSON(output *AgentDoctorOutput) error {
+func outputAgentDoctorJSON(w io.Writer, output *AgentDoctorOutput) error {
 	jsonOut, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		return fmt.Errorf("format doctor JSON: %w", err)
 	}
 	trackContextBytes(int64(len(jsonOut)))
-	fmt.Println(string(jsonOut))
+	fmt.Fprintln(w, string(jsonOut))
 	return nil
 }
 
 // outputAgentDoctorText outputs the doctor results as human-readable text
-func outputAgentDoctorText(output *AgentDoctorOutput) {
+func outputAgentDoctorText(w io.Writer, output *AgentDoctorOutput) {
 	if len(output.IncompleteSessions) == 0 && !output.CommitNeeded && !output.PushNeeded {
-		cli.PrintSuccess("Session health: all good")
+		cli.PrintSuccessTo(w, "Session health: all good")
 		return
 	}
 
 	if len(output.IncompleteSessions) > 0 {
-		fmt.Printf("Incomplete sessions: %d\n", len(output.IncompleteSessions))
+		fmt.Fprintf(w, "Incomplete sessions: %d\n", len(output.IncompleteSessions))
 		for _, sess := range output.IncompleteSessions {
-			fmt.Printf("  %s: missing %s\n", sess.SessionID, strings.Join(sess.Missing, ", "))
+			fmt.Fprintf(w, "  %s: missing %s\n", sess.SessionID, strings.Join(sess.Missing, ", "))
 			for _, cmd := range sess.FinalizeCommands {
-				fmt.Printf("    -> %s\n", cmd)
+				fmt.Fprintf(w, "    -> %s\n", cmd)
 			}
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	}
 
 	if output.CommitNeeded {
-		fmt.Printf("Staged files: %d (commit needed)\n", output.StagedCount)
+		fmt.Fprintf(w, "Staged files: %d (commit needed)\n", output.StagedCount)
 	}
 	if output.PushNeeded {
-		fmt.Println("Push needed to sync with remote")
+		fmt.Fprintln(w, "Push needed to sync with remote")
 	}
 
 	if len(output.NextSteps) > 0 {
-		fmt.Println("\nNext steps:")
+		fmt.Fprintln(w, "\nNext steps:")
 		for _, step := range output.NextSteps {
-			fmt.Printf("  - %s\n", step)
+			fmt.Fprintf(w, "  - %s\n", step)
 		}
 	}
 }

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -436,7 +436,7 @@ func handlePrompt(ctx *HookContext) error {
 	if agentID == "" {
 		return nil
 	}
-	emitWhispers(agentID)
+	emitWhispers(os.Stdout, agentID)
 	return nil
 }
 
@@ -472,7 +472,7 @@ func handleAfterTool(ctx *HookContext) error {
 		return nil
 	}
 	// emit pending whispers (fallback — primary delivery is handlePrompt)
-	emitWhispers(agentID)
+	emitWhispers(os.Stdout, agentID)
 
 	state, err := session.LoadRecordingStateForAgent(ctx.ProjectRoot, agentID)
 	if err != nil || state == nil {

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -207,9 +208,10 @@ func dispatchPhase(ctx *HookContext) error {
 	}
 }
 
-// emitStartupBanner writes a systemMessage JSON line to stdout for agents
+// emitStartupBanner writes a systemMessage JSON line to w for agents
 // that support the systemMessage protocol (Claude Code, Gemini CLI).
-func emitStartupBanner(ctx *HookContext) {
+// Production callers pass os.Stdout; tests pass a buffer.
+func emitStartupBanner(w io.Writer, ctx *HookContext) {
 	switch ctx.AgentType {
 	case "claude-code", "gemini":
 		// these agents inject hook stdout into model context
@@ -231,7 +233,7 @@ func emitStartupBanner(ctx *HookContext) {
 		slog.Debug("hook: failed to marshal startup banner", "error", err)
 		return
 	}
-	fmt.Fprintln(os.Stdout, string(data))
+	fmt.Fprintln(w, string(data))
 }
 
 // handleStart handles the session start phase.
@@ -241,7 +243,7 @@ func emitStartupBanner(ctx *HookContext) {
 // (covering agents without hooks), and we call it again here as a safety net.
 // startSessionRecording is idempotent (checks session.IsRecording first).
 func handleStart(ctx *HookContext) error {
-	emitStartupBanner(ctx)
+	emitStartupBanner(os.Stdout, ctx)
 
 	source := ""
 	if ctx.Input != nil {

--- a/cmd/ox/agent_hook_banner_test.go
+++ b/cmd/ox/agent_hook_banner_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,8 +28,8 @@ func TestEmitStartupBanner_ClaudeCodeAutoRecording(t *testing.T) {
 		ProjectRoot: projectRoot,
 	}
 
-	output := captureBannerStdout(t, func() {
-		emitStartupBanner(ctx)
+	output := captureBannerStdout(t, func(w io.Writer) {
+		emitStartupBanner(w, ctx)
 	})
 
 	msg := parseBannerSystemMessage(t, output)
@@ -55,8 +57,8 @@ func TestEmitStartupBanner_ClaudeCodeNoRecording(t *testing.T) {
 		ProjectRoot: projectRoot,
 	}
 
-	output := captureBannerStdout(t, func() {
-		emitStartupBanner(ctx)
+	output := captureBannerStdout(t, func(w io.Writer) {
+		emitStartupBanner(w, ctx)
 	})
 
 	msg := parseBannerSystemMessage(t, output)
@@ -84,8 +86,8 @@ func TestEmitStartupBanner_GeminiAgent(t *testing.T) {
 		ProjectRoot: projectRoot,
 	}
 
-	output := captureBannerStdout(t, func() {
-		emitStartupBanner(ctx)
+	output := captureBannerStdout(t, func(w io.Writer) {
+		emitStartupBanner(w, ctx)
 	})
 
 	msg := parseBannerSystemMessage(t, output)
@@ -112,8 +114,8 @@ func TestEmitStartupBanner_UnsupportedAgent(t *testing.T) {
 		ProjectRoot: projectRoot,
 	}
 
-	output := captureBannerStdout(t, func() {
-		emitStartupBanner(ctx)
+	output := captureBannerStdout(t, func(w io.Writer) {
+		emitStartupBanner(w, ctx)
 	})
 
 	if strings.TrimSpace(output) != "" {
@@ -137,21 +139,13 @@ func initBannerTestProject(t *testing.T, recordingMode string) string {
 	return dir
 }
 
-func captureBannerStdout(t *testing.T, fn func()) string {
+// captureBannerStdout runs fn with a fresh bytes.Buffer as its writer and
+// returns the captured output. Parallel-safe — no os.Stdout mutation.
+func captureBannerStdout(t *testing.T, fn func(w io.Writer)) string {
 	t.Helper()
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Stdout = w
-	fn()
-	w.Close()
-	os.Stdout = old
-
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
-	return string(buf[:n])
+	var buf bytes.Buffer
+	fn(&buf)
+	return buf.String()
 }
 
 func parseBannerSystemMessage(t *testing.T, output string) string {

--- a/cmd/ox/agent_instances.go
+++ b/cmd/ox/agent_instances.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,23 +39,24 @@ func init() {
 
 func runAgentInstances(cmd *cobra.Command, _ []string) error {
 	jsonOutput, _ := cmd.Flags().GetBool("json")
+	out := cmd.OutOrStdout()
 
 	instances, err := daemon.GetAllInstances()
 	if err != nil {
 		if jsonOutput {
-			return outputInstancesJSON(nil, err)
+			return outputInstancesJSON(out, nil, err)
 		}
 		return fmt.Errorf("failed to get instances: %w", err)
 	}
 
 	if jsonOutput {
-		return outputInstancesJSON(instances, nil)
+		return outputInstancesJSON(out, instances, nil)
 	}
 
-	return outputInstancesTable(instances)
+	return outputInstancesTable(out, instances)
 }
 
-func outputInstancesJSON(instances []daemon.InstanceInfo, err error) error {
+func outputInstancesJSON(w io.Writer, instances []daemon.InstanceInfo, err error) error {
 	type output struct {
 		Instances []daemon.InstanceInfo `json:"instances"`
 		Error     string                `json:"error,omitempty"`
@@ -68,28 +70,28 @@ func outputInstancesJSON(instances []daemon.InstanceInfo, err error) error {
 		out.Instances = []daemon.InstanceInfo{}
 	}
 
-	enc := json.NewEncoder(os.Stdout)
+	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
 }
 
-func outputInstancesTable(instances []daemon.InstanceInfo) error {
+func outputInstancesTable(w io.Writer, instances []daemon.InstanceInfo) error {
 	if len(instances) == 0 {
-		fmt.Println("No active AI coworker instances.")
-		fmt.Println()
-		fmt.Println("Instances appear when coworkers run 'ox agent prime' and hooks send heartbeats.")
-		fmt.Println("Run 'ox agent prime' in a repository to register this instance.")
+		fmt.Fprintln(w, "No active AI coworker instances.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Instances appear when coworkers run 'ox agent prime' and hooks send heartbeats.")
+		fmt.Fprintln(w, "Run 'ox agent prime' in a repository to register this instance.")
 		return nil
 	}
 
 	// header
-	fmt.Printf("%-10s %-36s %-8s %-18s %s\n",
+	fmt.Fprintf(w, "%-10s %-36s %-8s %-18s %s\n",
 		cli.StyleBold.Render("COWORKER"),
 		cli.StyleBold.Render("WORKSPACE"),
 		cli.StyleBold.Render("STATUS"),
 		cli.StyleBold.Render("LAST HEARTBEAT"),
 		cli.StyleBold.Render("LAST WHISPER"))
-	fmt.Println(strings.Repeat("-", 90))
+	fmt.Fprintln(w, strings.Repeat("-", 90))
 
 	// rows
 	for _, inst := range instances {
@@ -108,7 +110,7 @@ func outputInstancesTable(instances []daemon.InstanceInfo) error {
 			statusStyle = cli.StyleDim
 		}
 
-		fmt.Printf("%-10s %-36s %s %-18s %s\n",
+		fmt.Fprintf(w, "%-10s %-36s %s %-18s %s\n",
 			inst.AgentID,
 			workspace,
 			statusStyle.Render(fmt.Sprintf("%-8s", inst.Status)),
@@ -116,8 +118,8 @@ func outputInstancesTable(instances []daemon.InstanceInfo) error {
 			cli.StyleDim.Render(lastWhisper))
 	}
 
-	fmt.Println()
-	fmt.Printf("%d active instance(s)\n", len(instances))
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "%d active instance(s)\n", len(instances))
 
 	return nil
 }

--- a/cmd/ox/agent_session_abort.go
+++ b/cmd/ox/agent_session_abort.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -81,7 +82,7 @@ func runAgentSessionAbortActive(inst *agentinstance.Instance, cmd *cobra.Command
 
 	// intentionally do NOT set doctor.SetNeedsDoctorAgent() — user chose to discard
 
-	return emitAbortOutput(inst.AgentID, sessionName)
+	return emitAbortOutput(cmd.OutOrStdout(), inst.AgentID, sessionName)
 }
 
 // runAgentSessionAbortByName aborts a session by name. Only allows discarding
@@ -134,7 +135,7 @@ func runAgentSessionAbortByName(inst *agentinstance.Instance, cmd *cobra.Command
 		return fmt.Errorf("failed to remove session data at %s: %w", sessionPath, err)
 	}
 
-	return emitAbortOutput(inst.AgentID, sessionName)
+	return emitAbortOutput(cmd.OutOrStdout(), inst.AgentID, sessionName)
 }
 
 // buildSessionInfo constructs a SessionInfo from a session folder on disk.
@@ -238,7 +239,7 @@ func confirmAbort(inst *agentinstance.Instance, cmd *cobra.Command) error {
 }
 
 // emitAbortOutput writes the JSON (and optional text) output for a successful abort.
-func emitAbortOutput(agentID, sessionName string) error {
+func emitAbortOutput(w io.Writer, agentID, sessionName string) error {
 	output := sessionAbortOutput{
 		Success:     true,
 		Type:        "session_abort",
@@ -249,10 +250,10 @@ func emitAbortOutput(agentID, sessionName string) error {
 	}
 
 	if cfg.Text || cfg.Review {
-		fmt.Printf("Session %q aborted and discarded.\n", sessionName)
+		fmt.Fprintf(w, "Session %q aborted and discarded.\n", sessionName)
 		if cfg.Review {
-			fmt.Println()
-			fmt.Println("--- Machine Output ---")
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "--- Machine Output ---")
 		} else {
 			return nil
 		}
@@ -262,6 +263,6 @@ func emitAbortOutput(agentID, sessionName string) error {
 	if err != nil {
 		return fmt.Errorf("format abort JSON: %w", err)
 	}
-	fmt.Println(string(jsonOut))
+	fmt.Fprintln(w, string(jsonOut))
 	return nil
 }

--- a/cmd/ox/agent_session_abort_test.go
+++ b/cmd/ox/agent_session_abort_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -200,22 +200,15 @@ func TestAbortOutputIncludesGuidance(t *testing.T) {
 	setupAbortTest(t)
 	setForceFlag(t, true)
 
-	// capture stdout
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	var buf bytes.Buffer
+	agentCmd.SetOut(&buf)
+	t.Cleanup(func() { agentCmd.SetOut(nil) })
 
 	inst := &agentinstance.Instance{AgentID: "OxAbrt"}
-	err := runAgentSessionAbort(inst, agentCmd, nil)
+	require.NoError(t, runAgentSessionAbort(inst, agentCmd, nil))
 
-	w.Close()
-	os.Stdout = oldStdout
-
-	require.NoError(t, err)
-
-	out, _ := io.ReadAll(r)
 	var output sessionAbortOutput
-	require.NoError(t, json.Unmarshal(out, &output), "output should be valid JSON")
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &output), "output should be valid JSON")
 	assert.True(t, output.Success)
 	assert.NotEmpty(t, output.Guidance, "abort JSON output must include guidance field")
 	assert.Contains(t, output.Guidance, "No further action needed")

--- a/cmd/ox/agent_session_log.go
+++ b/cmd/ox/agent_session_log.go
@@ -54,7 +54,7 @@ type sessionLogEntry struct {
 //	ox agent <id> session log --role user --content "Fix the login bug"
 //	ox agent <id> session log --role tool --tool-name bash --tool-input "go test ./..." --content "PASS"
 //	echo "Multi-line content" | ox agent <id> session log --role assistant --stdin
-func runAgentSessionLog(inst *agentinstance.Instance, args []string) error {
+func runAgentSessionLog(w io.Writer, inst *agentinstance.Instance, args []string) error {
 	projectRoot, err := findProjectRoot()
 	if err != nil {
 		return fmt.Errorf("could not find project root: %w", err)
@@ -129,10 +129,10 @@ func runAgentSessionLog(inst *agentinstance.Instance, args []string) error {
 
 	// output
 	if cfg.Text || cfg.Review {
-		fmt.Printf("Logged entry #%d (%s, %d chars)\n", seq, role, len(content))
+		fmt.Fprintf(w, "Logged entry #%d (%s, %d chars)\n", seq, role, len(content))
 		if cfg.Review {
-			fmt.Println()
-			fmt.Println("--- Machine Output ---")
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "--- Machine Output ---")
 		} else {
 			return nil
 		}
@@ -146,7 +146,7 @@ func runAgentSessionLog(inst *agentinstance.Instance, args []string) error {
 	if err != nil {
 		return fmt.Errorf("format log JSON: %w", err)
 	}
-	fmt.Println(string(jsonOut))
+	fmt.Fprintln(w, string(jsonOut))
 	return nil
 }
 

--- a/cmd/ox/agent_session_log_test.go
+++ b/cmd/ox/agent_session_log_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -62,7 +64,7 @@ func TestSessionLog_UserEntry(t *testing.T) {
 	_, state := setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--role", "user", "--content", "Fix the login bug"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role", "user", "--content", "Fix the login bug"})
 	require.NoError(t, err)
 
 	targetFile := sessionLogTargetFile(state)
@@ -79,7 +81,7 @@ func TestSessionLog_AssistantEntry(t *testing.T) {
 	_, state := setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--role", "assistant", "--content", "I'll investigate the issue."})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role", "assistant", "--content", "I'll investigate the issue."})
 	require.NoError(t, err)
 
 	targetFile := sessionLogTargetFile(state)
@@ -94,7 +96,7 @@ func TestSessionLog_ToolEntry(t *testing.T) {
 	_, state := setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{
+	err := runAgentSessionLog(io.Discard, inst, []string{
 		"--role", "tool",
 		"--tool-name", "bash",
 		"--tool-input", "go test ./...",
@@ -130,7 +132,7 @@ func TestSessionLog_Stdin(t *testing.T) {
 	}()
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err = runAgentSessionLog(inst, []string{"--role", "assistant", "--stdin"})
+	err = runAgentSessionLog(io.Discard, inst, []string{"--role", "assistant", "--stdin"})
 	require.NoError(t, err)
 
 	targetFile := sessionLogTargetFile(state)
@@ -145,7 +147,7 @@ func TestSessionLog_BothContentAndStdin_Error(t *testing.T) {
 	setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--role", "user", "--content", "hello", "--stdin"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role", "user", "--content", "hello", "--stdin"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot use both --content and --stdin")
 }
@@ -154,7 +156,7 @@ func TestSessionLog_NeitherContentNorStdin_Error(t *testing.T) {
 	setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--role", "user"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role", "user"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "one of --content or --stdin is required")
 }
@@ -163,7 +165,7 @@ func TestSessionLog_InvalidRole_Error(t *testing.T) {
 	setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--role", "observer", "--content", "test"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role", "observer", "--content", "test"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid role")
 }
@@ -172,7 +174,7 @@ func TestSessionLog_MissingRole_Error(t *testing.T) {
 	setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--content", "test"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--content", "test"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--role is required")
 }
@@ -186,7 +188,7 @@ func TestSessionLog_NoActiveRecording_Error(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--role", "user", "--content", "test"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role", "user", "--content", "test"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no active session")
 }
@@ -197,11 +199,11 @@ func TestSessionLog_SeqIncrement(t *testing.T) {
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
 
 	// first entry
-	err := runAgentSessionLog(inst, []string{"--role", "user", "--content", "first"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role", "user", "--content", "first"})
 	require.NoError(t, err)
 
 	// second entry
-	err = runAgentSessionLog(inst, []string{"--role", "assistant", "--content", "second"})
+	err = runAgentSessionLog(io.Discard, inst, []string{"--role", "assistant", "--content", "second"})
 	require.NoError(t, err)
 
 	targetFile := sessionLogTargetFile(state)
@@ -218,23 +220,11 @@ func TestSessionLog_TextOutput(t *testing.T) {
 	cfg = &config.Config{Text: true}
 	t.Cleanup(func() { cfg = &config.Config{} })
 
-	// capture stdout
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-
+	var buf bytes.Buffer
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	logErr := runAgentSessionLog(inst, []string{"--role", "user", "--content", "hello"})
-	w.Close()
-	os.Stdout = oldStdout
+	require.NoError(t, runAgentSessionLog(&buf, inst, []string{"--role", "user", "--content", "hello"}))
 
-	require.NoError(t, logErr)
-
-	out := make([]byte, 4096)
-	n, _ := r.Read(out)
-	output := string(out[:n])
-
+	output := buf.String()
 	assert.Contains(t, output, "Logged entry #0")
 	assert.Contains(t, output, "user")
 	assert.Contains(t, output, "5 chars")
@@ -244,7 +234,7 @@ func TestSessionLog_ToolFlagsWithNonToolRole_Error(t *testing.T) {
 	setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{
+	err := runAgentSessionLog(io.Discard, inst, []string{
 		"--role", "user",
 		"--tool-name", "bash",
 		"--content", "test",
@@ -260,7 +250,7 @@ func TestSessionLog_GenericAdapterUsesInputJsonl(t *testing.T) {
 	assert.Empty(t, state.SessionFile, "generic adapter should start with empty SessionFile")
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--role", "user", "--content", "hello"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role", "user", "--content", "hello"})
 	require.NoError(t, err)
 
 	expectedPath := filepath.Join(state.SessionPath, "input.jsonl")
@@ -273,24 +263,12 @@ func TestSessionLog_JSONOutput(t *testing.T) {
 
 	cfg = &config.Config{}
 
-	// capture stdout
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-
+	var buf bytes.Buffer
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	logErr := runAgentSessionLog(inst, []string{"--role", "user", "--content", "test"})
-	w.Close()
-	os.Stdout = oldStdout
-
-	require.NoError(t, logErr)
-
-	out := make([]byte, 4096)
-	n, _ := r.Read(out)
+	require.NoError(t, runAgentSessionLog(&buf, inst, []string{"--role", "user", "--content", "test"}))
 
 	var output sessionLogOutput
-	require.NoError(t, json.Unmarshal(out[:n], &output))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &output))
 
 	assert.True(t, output.Success)
 	assert.Equal(t, 0, output.Seq)
@@ -300,7 +278,7 @@ func TestSessionLog_EqualsStyleFlags(t *testing.T) {
 	_, state := setupLogTest(t)
 
 	inst := &agentinstance.Instance{AgentID: "OxLog1"}
-	err := runAgentSessionLog(inst, []string{"--role=assistant", "--content=equals style"})
+	err := runAgentSessionLog(io.Discard, inst, []string{"--role=assistant", "--content=equals style"})
 	require.NoError(t, err)
 
 	targetFile := sessionLogTargetFile(state)

--- a/cmd/ox/code.go
+++ b/cmd/ox/code.go
@@ -458,7 +458,7 @@ var codeStatusCmd = &cobra.Command{
 					Commits: r.commits, Blobs: r.blobs,
 				})
 			}
-			enc := json.NewEncoder(os.Stdout)
+			enc := json.NewEncoder(cmd.OutOrStdout())
 			enc.SetIndent("", "  ")
 			return enc.Encode(out)
 		}

--- a/cmd/ox/code_activity.go
+++ b/cmd/ox/code_activity.go
@@ -90,7 +90,7 @@ func runCodeActivity(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	fmt.Fprintln(os.Stdout, string(data))
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
 	return nil
 }
 

--- a/cmd/ox/coverage_boost_test.go
+++ b/cmd/ox/coverage_boost_test.go
@@ -22,27 +22,15 @@ import (
 // =============================================================================
 
 func TestOutputAgentDoctorJSON_BasicOutput(t *testing.T) {
-
+	t.Parallel()
 	output := &AgentDoctorOutput{
 		Success: true,
 		Type:    "agent_doctor",
 		AgentID: "Oxa7b3",
 	}
 
-	// capture stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputAgentDoctorJSON(output)
-
-	w.Close()
-	os.Stdout = old
-
-	require.NoError(t, err)
-
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	require.NoError(t, outputAgentDoctorJSON(&buf, output))
 	got := buf.String()
 
 	assert.Contains(t, got, `"success": true`)
@@ -55,7 +43,7 @@ func TestOutputAgentDoctorJSON_BasicOutput(t *testing.T) {
 }
 
 func TestOutputAgentDoctorJSON_WithIncompleteSessions(t *testing.T) {
-
+	t.Parallel()
 	output := &AgentDoctorOutput{
 		Success: true,
 		Type:    "agent_doctor",
@@ -77,24 +65,12 @@ func TestOutputAgentDoctorJSON_WithIncompleteSessions(t *testing.T) {
 		NextSteps:    []string{"Generate summary", "ox session commit"},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputAgentDoctorJSON(output)
-
-	w.Close()
-	os.Stdout = old
-
-	require.NoError(t, err)
-
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	got := buf.String()
+	require.NoError(t, outputAgentDoctorJSON(&buf, output))
 
 	// verify JSON structure
 	var parsed AgentDoctorOutput
-	require.NoError(t, json.Unmarshal([]byte(got), &parsed))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
 	assert.Equal(t, 1, len(parsed.IncompleteSessions))
 	assert.Equal(t, "2026-03-15-user-abc1", parsed.IncompleteSessions[0].SessionID)
 	assert.Equal(t, 2, parsed.StagedCount)
@@ -103,26 +79,15 @@ func TestOutputAgentDoctorJSON_WithIncompleteSessions(t *testing.T) {
 }
 
 func TestOutputAgentDoctorJSON_EmptyOutput(t *testing.T) {
-
+	t.Parallel()
 	output := &AgentDoctorOutput{
 		Success: true,
 		Type:    "agent_doctor",
 		AgentID: "",
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputAgentDoctorJSON(output)
-
-	w.Close()
-	os.Stdout = old
-
-	require.NoError(t, err)
-
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	require.NoError(t, outputAgentDoctorJSON(&buf, output))
 
 	var parsed map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
@@ -133,23 +98,13 @@ func TestOutputAgentDoctorJSON_EmptyOutput(t *testing.T) {
 // =============================================================================
 
 func TestOutputAgentDoctorText_AllGood(t *testing.T) {
-
+	t.Parallel()
 	output := &AgentDoctorOutput{
 		Success: true,
 	}
 
-	// capture stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	outputAgentDoctorText(output)
-
-	w.Close()
-	os.Stdout = old
-
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	outputAgentDoctorText(&buf, output)
 	got := buf.String()
 
 	// should indicate everything is ok
@@ -157,7 +112,7 @@ func TestOutputAgentDoctorText_AllGood(t *testing.T) {
 }
 
 func TestOutputAgentDoctorText_WithIncompleteSessions(t *testing.T) {
-
+	t.Parallel()
 	output := &AgentDoctorOutput{
 		IncompleteSessions: []IncompleteSessionInfo{
 			{
@@ -168,17 +123,8 @@ func TestOutputAgentDoctorText_WithIncompleteSessions(t *testing.T) {
 		},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	outputAgentDoctorText(output)
-
-	w.Close()
-	os.Stdout = old
-
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	outputAgentDoctorText(&buf, output)
 	got := buf.String()
 
 	assert.Contains(t, got, "Incomplete sessions: 1")
@@ -187,7 +133,7 @@ func TestOutputAgentDoctorText_WithIncompleteSessions(t *testing.T) {
 }
 
 func TestOutputAgentDoctorText_CommitAndPushNeeded(t *testing.T) {
-
+	t.Parallel()
 	output := &AgentDoctorOutput{
 		CommitNeeded: true,
 		PushNeeded:   true,
@@ -195,17 +141,8 @@ func TestOutputAgentDoctorText_CommitAndPushNeeded(t *testing.T) {
 		NextSteps:    []string{"ox session commit", "git push (in ledger)"},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	outputAgentDoctorText(output)
-
-	w.Close()
-	os.Stdout = old
-
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	outputAgentDoctorText(&buf, output)
 	got := buf.String()
 
 	assert.Contains(t, got, "Staged files: 3")
@@ -433,20 +370,9 @@ func TestAppendRedactedEntries_InvalidPath(t *testing.T) {
 // =============================================================================
 
 func TestOutputInstancesJSON_EmptyInstances(t *testing.T) {
-
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputInstancesJSON(nil, nil)
-
-	w.Close()
-	os.Stdout = old
-
-	require.NoError(t, err)
-
+	t.Parallel()
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	require.NoError(t, outputInstancesJSON(&buf, nil, nil))
 
 	var parsed struct {
 		Instances []daemon.InstanceInfo `json:"instances"`
@@ -460,7 +386,7 @@ func TestOutputInstancesJSON_EmptyInstances(t *testing.T) {
 }
 
 func TestOutputInstancesJSON_WithInstances(t *testing.T) {
-
+	t.Parallel()
 	instances := []daemon.InstanceInfo{
 		{
 			AgentID:       "Oxa7b3",
@@ -470,19 +396,8 @@ func TestOutputInstancesJSON_WithInstances(t *testing.T) {
 		},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputInstancesJSON(instances, nil)
-
-	w.Close()
-	os.Stdout = old
-
-	require.NoError(t, err)
-
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	require.NoError(t, outputInstancesJSON(&buf, instances, nil))
 	got := buf.String()
 
 	assert.Contains(t, got, "Oxa7b3")
@@ -490,20 +405,9 @@ func TestOutputInstancesJSON_WithInstances(t *testing.T) {
 }
 
 func TestOutputInstancesJSON_WithError(t *testing.T) {
-
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputInstancesJSON(nil, fmt.Errorf("daemon not running"))
-
-	w.Close()
-	os.Stdout = old
-
-	require.NoError(t, err)
-
+	t.Parallel()
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	require.NoError(t, outputInstancesJSON(&buf, nil, fmt.Errorf("daemon not running")))
 
 	var parsed struct {
 		Error string `json:"error"`
@@ -517,27 +421,14 @@ func TestOutputInstancesJSON_WithError(t *testing.T) {
 // =============================================================================
 
 func TestOutputInstancesTable_EmptyInstances(t *testing.T) {
-
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputInstancesTable(nil)
-
-	w.Close()
-	os.Stdout = old
-
-	require.NoError(t, err)
-
+	t.Parallel()
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	got := buf.String()
-
-	assert.Contains(t, got, "No active AI coworker instances")
+	require.NoError(t, outputInstancesTable(&buf, nil))
+	assert.Contains(t, buf.String(), "No active AI coworker instances")
 }
 
 func TestOutputInstancesTable_WithInstances(t *testing.T) {
-
+	t.Parallel()
 	instances := []daemon.InstanceInfo{
 		{
 			AgentID:       "Oxa7b3",
@@ -553,19 +444,8 @@ func TestOutputInstancesTable_WithInstances(t *testing.T) {
 		},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputInstancesTable(instances)
-
-	w.Close()
-	os.Stdout = old
-
-	require.NoError(t, err)
-
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	require.NoError(t, outputInstancesTable(&buf, instances))
 	got := buf.String()
 
 	assert.Contains(t, got, "Oxa7b3")

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -647,7 +647,7 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 	progress.show("Integration")
 	integrationChecks := []checkResult{
 		checkAgentFileExists(),
-		checkAgentsIntegrationWithFix(opts.shouldFix(CheckSlugClaudeCodeHooks)),
+		checkAgentsIntegrationWithFix(os.Stdout, opts.shouldFix(CheckSlugClaudeCodeHooks)),
 	}
 	if detectClaudeCode() {
 		integrationChecks = append(integrationChecks, checkClaudeCodeHooks(opts.shouldFix(CheckSlugClaudeCodeHooks)))

--- a/cmd/ox/doctor_fix_agents_test.go
+++ b/cmd/ox/doctor_fix_agents_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,7 +41,7 @@ func TestCheckAgentsIntegration_FixInjects(t *testing.T) {
 	defer os.Chdir(originalWd)
 	os.Chdir(gitRoot)
 
-	result := checkAgentsIntegrationWithFix(true)
+	result := checkAgentsIntegrationWithFix(io.Discard, true)
 	if !result.passed {
 		t.Errorf("expected passed=true, got false: %s", result.message)
 	}

--- a/cmd/ox/doctor_fix_integration_test.go
+++ b/cmd/ox/doctor_fix_integration_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -132,7 +133,7 @@ func TestDoctorFix_CombinedScenario(t *testing.T) {
 		t.Errorf("config fix failed: %s", configResult.message)
 	}
 
-	agentsResult := checkAgentsIntegrationWithFix(true)
+	agentsResult := checkAgentsIntegrationWithFix(io.Discard, true)
 	if !agentsResult.passed {
 		t.Errorf("agents integration fix failed: %s", agentsResult.message)
 	}
@@ -406,7 +407,7 @@ func TestDoctorFix_CombinedMultipleIssues(t *testing.T) {
 		t.Errorf("root gitignore fix failed: %s", rootGitignoreResult.message)
 	}
 
-	agentsResult := checkAgentsIntegrationWithFix(true)
+	agentsResult := checkAgentsIntegrationWithFix(io.Discard, true)
 	if !agentsResult.passed {
 		t.Errorf("agents integration fix failed: %s", agentsResult.message)
 	}

--- a/cmd/ox/doctor_integration.go
+++ b/cmd/ox/doctor_integration.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,10 +31,11 @@ func checkAgentFileExists() checkResult {
 }
 
 func checkAgentsIntegration() checkResult {
-	return checkAgentsIntegrationWithFix(false)
+	// io.Discard is safe: fix=false never reaches outputAgentUpgradeInstructions
+	return checkAgentsIntegrationWithFix(io.Discard, false)
 }
 
-func checkAgentsIntegrationWithFix(fix bool) checkResult {
+func checkAgentsIntegrationWithFix(w io.Writer, fix bool) checkResult {
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
 		return SkippedCheck("ox agent prime integration", "not in git repo", "")
@@ -84,7 +86,7 @@ func checkAgentsIntegrationWithFix(fix bool) checkResult {
 						// check if running in agent context
 						if agentx.IsAgentContext() {
 							// output instructions for agent to perform smart upgrade
-							return outputAgentUpgradeInstructions(file, filePath, contentStr)
+							return outputAgentUpgradeInstructions(w, file, filePath, contentStr)
 						}
 						// perform the upgrade using EnsureOxPrimeMarker
 						injected, err := EnsureOxPrimeMarker(gitRoot)
@@ -161,7 +163,8 @@ var agentInstructionStyles = struct {
 // outputAgentUpgradeInstructions outputs structured instructions for an agent
 // to perform smart file upgrades rather than crude append operations.
 // This enables agents to intelligently replace entire SageOx sections.
-func outputAgentUpgradeInstructions(file, filePath, content string) checkResult {
+// w is the destination for the rendered instructions (production: os.Stdout).
+func outputAgentUpgradeInstructions(w io.Writer, file, filePath, content string) checkResult {
 	s := agentInstructionStyles
 
 	// find all legacy SageOx-related lines/sections to identify what to replace
@@ -248,7 +251,7 @@ func outputAgentUpgradeInstructions(file, filePath, content string) checkResult 
 	b.WriteString(ui.RenderSeparator())
 	b.WriteString("\n")
 
-	fmt.Print(b.String())
+	fmt.Fprint(w, b.String())
 
 	return PassedCheck(fmt.Sprintf("ox agent prime in %s", file), "agent instructions provided")
 }

--- a/cmd/ox/doctor_integration_agents_test.go
+++ b/cmd/ox/doctor_integration_agents_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -19,7 +20,7 @@ func TestCheckAgentsIntegration_NoFiles(t *testing.T) {
 	restoreCwd := changeToDir(t, gitRoot)
 	defer restoreCwd()
 
-	result := checkAgentsIntegrationWithFix(false)
+	result := checkAgentsIntegrationWithFix(io.Discard, false)
 
 	if result.passed {
 		t.Error("expected passed=false when no agent files exist")
@@ -48,7 +49,7 @@ func TestCheckAgentsIntegration_AgentsMdExists(t *testing.T) {
 		t.Fatalf("failed to create AGENTS.md: %v", err)
 	}
 
-	result := checkAgentsIntegrationWithFix(false)
+	result := checkAgentsIntegrationWithFix(io.Discard, false)
 
 	if !result.passed {
 		t.Errorf("expected passed=true when AGENTS.md has OxPrimeLine, got: %+v", result)
@@ -74,7 +75,7 @@ func TestCheckAgentsIntegration_MissingPrimeLine(t *testing.T) {
 		t.Fatalf("failed to create AGENTS.md: %v", err)
 	}
 
-	result := checkAgentsIntegrationWithFix(false)
+	result := checkAgentsIntegrationWithFix(io.Discard, false)
 
 	if result.passed {
 		t.Error("expected passed=false when OxPrimeLine is missing")
@@ -101,7 +102,7 @@ func TestCheckAgentsIntegration_FixInjectsIntoExistingAgentsMd(t *testing.T) {
 		t.Fatalf("failed to create AGENTS.md: %v", err)
 	}
 
-	result := checkAgentsIntegrationWithFix(true)
+	result := checkAgentsIntegrationWithFix(io.Discard, true)
 
 	if !result.passed {
 		t.Errorf("expected passed=true after fix, got: %+v", result)
@@ -142,7 +143,7 @@ func TestCheckAgentsIntegration_LegacyFormat(t *testing.T) {
 		t.Fatalf("failed to create CLAUDE.md: %v", err)
 	}
 
-	result := checkAgentsIntegrationWithFix(false)
+	result := checkAgentsIntegrationWithFix(io.Discard, false)
 
 	if !result.passed {
 		t.Error("expected passed=true for legacy format (with warning)")
@@ -171,7 +172,7 @@ func TestCheckAgentsIntegration_ClaudeMdExists(t *testing.T) {
 		t.Fatalf("failed to create CLAUDE.md: %v", err)
 	}
 
-	result := checkAgentsIntegrationWithFix(false)
+	result := checkAgentsIntegrationWithFix(io.Discard, false)
 
 	if !result.passed {
 		t.Errorf("expected passed=true when CLAUDE.md has OxPrimeLine, got: %+v", result)
@@ -198,7 +199,7 @@ func TestCheckAgentsIntegration_FixInjectsIntoClaude(t *testing.T) {
 		t.Fatalf("failed to create CLAUDE.md: %v", err)
 	}
 
-	result := checkAgentsIntegrationWithFix(true)
+	result := checkAgentsIntegrationWithFix(io.Discard, true)
 
 	if !result.passed {
 		t.Errorf("expected passed=true after fix, got: %+v", result)
@@ -707,7 +708,7 @@ func TestCheckAgentsIntegration_CanonicalInCopilotInstructions(t *testing.T) {
 		t.Fatalf("failed to create .copilot-instructions.md: %v", err)
 	}
 
-	result := checkAgentsIntegrationWithFix(false)
+	result := checkAgentsIntegrationWithFix(io.Discard, false)
 
 	if !result.passed {
 		t.Errorf("expected passed=true for canonical format in .copilot-instructions.md, got: %+v", result)
@@ -781,7 +782,7 @@ func TestCheckAgentsIntegration_FixNoExistingFiles(t *testing.T) {
 	defer restoreCwd()
 
 	// no agent files exist - fix should create AGENTS.md with the marker
-	result := checkAgentsIntegrationWithFix(true)
+	result := checkAgentsIntegrationWithFix(io.Discard, true)
 
 	if !result.passed {
 		t.Errorf("expected passed=true when fix creates AGENTS.md, got: %+v", result)
@@ -1059,7 +1060,7 @@ func TestCheckAgentsIntegrationWithFix_LegacyUpgrade(t *testing.T) {
 				t.Fatalf("failed to create test file: %v", err)
 			}
 
-			result := checkAgentsIntegrationWithFix(tt.fix)
+			result := checkAgentsIntegrationWithFix(io.Discard, tt.fix)
 
 			if result.passed != tt.wantPassed {
 				t.Errorf("passed = %v, want %v (result: %+v)", result.passed, tt.wantPassed, result)
@@ -1165,17 +1166,8 @@ func TestOutputAgentUpgradeInstructions(t *testing.T) {
 				t.Fatalf("failed to create test file: %v", err)
 			}
 
-			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
-
-			result := outputAgentUpgradeInstructions(tt.filename, testFile, tt.content)
-
-			w.Close()
-			os.Stdout = oldStdout
-
-			var buf strings.Builder
-			io.Copy(&buf, r)
+			var buf bytes.Buffer
+			result := outputAgentUpgradeInstructions(&buf, tt.filename, testFile, tt.content)
 			output := buf.String()
 
 			if result.passed != tt.wantPassed {
@@ -1213,17 +1205,8 @@ func TestCheckAgentsIntegrationWithFix_InAgentContext(t *testing.T) {
 
 	t.Setenv("CLAUDE_CODE_SESSION_ID", "test-session-id")
 
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	result := checkAgentsIntegrationWithFix(true)
-
-	w.Close()
-	os.Stdout = oldStdout
-
-	var buf strings.Builder
-	io.Copy(&buf, r)
+	var buf bytes.Buffer
+	result := checkAgentsIntegrationWithFix(&buf, true)
 	output := buf.String()
 
 	if !result.passed {

--- a/cmd/ox/doctor_proactive.go
+++ b/cmd/ox/doctor_proactive.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/tips"
 )
@@ -31,7 +33,7 @@ func init() {
 		Name:   "AGENTS.md integration",
 		Weight: 10,
 		Check: func() bool {
-			result := checkAgentsIntegrationWithFix(false)
+			result := checkAgentsIntegrationWithFix(io.Discard, false)
 			return !result.passed && !result.skipped
 		},
 		FixTip: "Agent file missing `ox agent prime` instruction. Run `ox doctor --fix` to add it.",

--- a/cmd/ox/glance.go
+++ b/cmd/ox/glance.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -79,7 +80,7 @@ func runGlance(cmd *cobra.Command, _ []string) error {
 
 	if len(result.Murmurs) == 0 && len(sessResult.Sessions) == 0 {
 		// Output valid JSON with empty arrays (not null) for stable schema
-		return outputGlanceJSON(glance.ActivityData{
+		return outputGlanceJSON(cmd.OutOrStdout(), glance.ActivityData{
 			Since:     since,
 			Until:     until,
 			Repo:      repo,
@@ -131,11 +132,11 @@ func runGlance(cmd *cobra.Command, _ []string) error {
 	// Advance checkpoint so next invocation without --since starts from now
 	_ = glance.MarkRead(ledgerPath)
 
-	return outputGlanceJSON(data)
+	return outputGlanceJSON(cmd.OutOrStdout(), data)
 }
 
-func outputGlanceJSON(data glance.ActivityData) error {
-	enc := json.NewEncoder(os.Stdout)
+func outputGlanceJSON(w io.Writer, data glance.ActivityData) error {
+	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(data)
 }

--- a/cmd/ox/hooks_events_list.go
+++ b/cmd/ox/hooks_events_list.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/sageox/ox/internal/daemon/hooks"
 	"github.com/spf13/cobra"
@@ -20,9 +19,10 @@ var hooksEventsListCmd = &cobra.Command{
 		}
 
 		jsonOut, _ := cmd.Flags().GetBool("json")
+		out := cmd.OutOrStdout()
 
 		if jsonOut {
-			enc := json.NewEncoder(os.Stdout)
+			enc := json.NewEncoder(out)
 			enc.SetIndent("", "  ")
 			if cfgs == nil {
 				cfgs = []hooks.HookConfig{}
@@ -31,17 +31,17 @@ var hooksEventsListCmd = &cobra.Command{
 		}
 
 		if len(cfgs) == 0 {
-			fmt.Println("No event hooks configured.")
-			fmt.Printf("Use 'ox hooks add <event> <command>' to register one.\n")
-			fmt.Printf("Config: %s\n", hooks.HooksFilePath())
+			fmt.Fprintln(out, "No event hooks configured.")
+			fmt.Fprintf(out, "Use 'ox hooks add <event> <command>' to register one.\n")
+			fmt.Fprintf(out, "Config: %s\n", hooks.HooksFilePath())
 			return nil
 		}
 
-		fmt.Printf("%-25s %s\n", "EVENT", "COMMAND")
+		fmt.Fprintf(out, "%-25s %s\n", "EVENT", "COMMAND")
 		for _, c := range cfgs {
-			fmt.Printf("%-25s %s\n", c.Event, c.Command)
+			fmt.Fprintf(out, "%-25s %s\n", c.Event, c.Command)
 		}
-		fmt.Printf("\nConfig: %s\n", hooks.HooksFilePath())
+		fmt.Fprintf(out, "\nConfig: %s\n", hooks.HooksFilePath())
 		return nil
 	},
 }

--- a/cmd/ox/kb_compat_test.go
+++ b/cmd/ox/kb_compat_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -102,7 +103,7 @@ func TestCompat_KBFlagOff_ShowFallsBackGracefully(t *testing.T) {
 	t.Parallel()
 
 	wrapped := fmt.Errorf("listing failed: %w", api.ErrKBAPIUnavailable)
-	err := handleKBShowError(wrapped, "personal", false)
+	err := handleKBShowError(io.Discard, wrapped, "personal", false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/cmd/ox/kb_show.go
+++ b/cmd/ox/kb_show.go
@@ -101,20 +101,20 @@ func runKBShow(cmd *cobra.Command, args []string) error {
 
 	kbID, resolveErr := resolveKBIdentifier(ctx, client, input)
 	if resolveErr != nil {
-		return handleKBShowError(resolveErr, input, jsonOutput)
+		return handleKBShowError(cmd.OutOrStdout(), resolveErr, input, jsonOutput)
 	}
 
 	slog.Info("kb show: resolving", "input", input, "kb_id", kbID)
 
 	bubble, err := client.GetBubble(ctx, kbID)
 	if err != nil {
-		return handleKBShowError(err, input, jsonOutput)
+		return handleKBShowError(cmd.OutOrStdout(), err, input, jsonOutput)
 	}
 
 	localPath := paths.KBDir(bubble.KBID)
 
 	if jsonOutput {
-		return outputJSON(kbShowOutput{KB: bubble, LocalPath: localPath})
+		return outputJSON(cmd.OutOrStdout(), kbShowOutput{KB: bubble, LocalPath: localPath})
 	}
 
 	renderKBShow(cmd.OutOrStdout(), bubble, localPath, ep)
@@ -201,12 +201,12 @@ func pickKBByPriority(matches []api.KB) *api.KB {
 // CLI error. ErrKBAPIUnavailable gets dedicated copy because the most
 // common cause is the knowledge-bubbles flag being off for the caller's
 // account — we don't want users hunting through logs for a 403.
-func handleKBShowError(err error, input string, jsonOutput bool) error {
+func handleKBShowError(w io.Writer, err error, input string, jsonOutput bool) error {
 	if errors.Is(err, api.ErrKBAPIUnavailable) {
 		msg := "Knowledge bubbles not enabled for this account"
 		slog.Info("kb show: api unavailable", "input", input, "error", err)
 		if jsonOutput {
-			return outputJSON(map[string]any{
+			return outputJSON(w, map[string]any{
 				"status":  "unavailable",
 				"message": msg,
 				"hint":    "Set OX_KB_DISABLE=1 to skip the kb API entirely. 'ox kb list' falls back to legacy team contexts and ledgers.",

--- a/cmd/ox/kb_show_test.go
+++ b/cmd/ox/kb_show_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -277,7 +278,7 @@ func TestHandleKBShowError_Unavailable(t *testing.T) {
 	t.Parallel()
 
 	wrapped := fmt.Errorf("wrapped: %w", api.ErrKBAPIUnavailable)
-	err := handleKBShowError(wrapped, "personal", false)
+	err := handleKBShowError(io.Discard, wrapped, "personal", false)
 	if err == nil {
 		t.Fatal("expected silent error, got nil")
 	}
@@ -299,7 +300,7 @@ func TestHandleKBShowError_NotFound(t *testing.T) {
 	t.Parallel()
 
 	raw := errors.New("HTTP 404 from https://api.example/api/v1/kb/kb_missing")
-	err := handleKBShowError(raw, "kb_missing", false)
+	err := handleKBShowError(io.Discard, raw, "kb_missing", false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/cmd/ox/login.go
+++ b/cmd/ox/login.go
@@ -266,6 +266,7 @@ func selectLoginEndpoint() (string, error) {
 
 // runLoginFlow executes the login flow for a specific endpoint
 func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
+	out := cmd.OutOrStdout()
 	// check if already authenticated for this endpoint
 	// If token refresh fails, treat as unauthenticated and proceed with login
 	// (the user is explicitly trying to log in, so a refresh failure shouldn't block them)
@@ -282,9 +283,9 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 			return fmt.Errorf("failed to get token: %w", err)
 		}
 
-		fmt.Printf("Already authenticated as %s on %s\n", token.UserInfo.Email, endpoint.NormalizeSlug(currentEndpoint))
+		fmt.Fprintf(out, "Already authenticated as %s on %s\n", token.UserInfo.Email, endpoint.NormalizeSlug(currentEndpoint))
 		if !cli.ConfirmYesNo("Do you want to re-authenticate?", false) {
-			fmt.Println("Authentication canceled.")
+			fmt.Fprintln(out, "Authentication canceled.")
 			return nil
 		}
 	}
@@ -292,15 +293,15 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 	authClient := auth.NewAuthClient().WithEndpoint(currentEndpoint)
 
 	// request device code
-	fmt.Println("Initiating device authentication flow...")
+	fmt.Fprintln(out, "Initiating device authentication flow...")
 	deviceCode, err := authClient.RequestDeviceCode()
 	if err != nil {
 		// check if this is a network error and offer alternatives
 		if isNetworkError(err) {
 			alternatives := getAlternativeEndpoints(currentEndpoint)
 			if len(alternatives) > 0 {
-				fmt.Printf("\nCould not reach %s\n", currentEndpoint)
-				fmt.Println("This project is configured for a different endpoint.")
+				fmt.Fprintf(out, "\nCould not reach %s\n", currentEndpoint)
+				fmt.Fprintln(out, "This project is configured for a different endpoint.")
 
 				var selectedEndpoint string
 				if len(alternatives) == 1 {
@@ -319,7 +320,7 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 				if selectedEndpoint != "" {
 					// retry with selected endpoint
 					authClient = authClient.WithEndpoint(selectedEndpoint)
-					fmt.Printf("\nAuthenticating to %s...\n", selectedEndpoint)
+					fmt.Fprintf(out, "\nAuthenticating to %s...\n", selectedEndpoint)
 					deviceCode, err = authClient.RequestDeviceCode()
 					if err != nil {
 						return fmt.Errorf("failed to request device code: %w", err)
@@ -336,14 +337,14 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 	}
 
 	// display verification instructions
-	fmt.Println()
+	fmt.Fprintln(out)
 	if deviceCode.VerificationURIComplete != "" {
-		fmt.Printf("Visit: %s\n", deviceCode.VerificationURIComplete)
+		fmt.Fprintf(out, "Visit: %s\n", deviceCode.VerificationURIComplete)
 	} else {
-		fmt.Printf("Visit: %s\n", deviceCode.VerificationURI)
-		fmt.Printf("Enter code: %s\n", deviceCode.UserCode)
+		fmt.Fprintf(out, "Visit: %s\n", deviceCode.VerificationURI)
+		fmt.Fprintf(out, "Enter code: %s\n", deviceCode.UserCode)
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 
 	// Open browser to the verification URL so the user can authorize.
 	// SKIP_BROWSER and headless detection are handled inside cli.OpenInBrowser.
@@ -361,9 +362,9 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 
 	// non-interactive mode: skip bubbletea spinner, just poll directly
 	if !cli.IsInteractive() {
-		fmt.Println("Waiting for authorization...")
+		fmt.Fprintln(out, "Waiting for authorization...")
 		err := authClient.Login(ctx, deviceCode, func(status string) {
-			fmt.Printf("Status: %s\n", status)
+			fmt.Fprintf(out, "Status: %s\n", status)
 		})
 		if err != nil {
 			return fmt.Errorf("authentication failed: %w", err)
@@ -406,7 +407,7 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 	}
 
 	// display a fun welcome message
-	fmt.Println()
+	fmt.Fprintln(out)
 	welcomeStyle := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(lipgloss.Color("212"))
@@ -422,9 +423,9 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 		displayName = parts[0]
 	}
 
-	fmt.Printf("%s %s!\n", welcomeStyle.Render("Welcome back,"), nameStyle.Render(displayName))
-	fmt.Printf("You're signed in as %s\n", token.UserInfo.Email)
-	fmt.Println()
+	fmt.Fprintf(out, "%s %s!\n", welcomeStyle.Render("Welcome back,"), nameStyle.Render(displayName))
+	fmt.Fprintf(out, "You're signed in as %s\n", token.UserInfo.Email)
+	fmt.Fprintln(out)
 
 	// fetch git credentials from /api/v1/cli/repos (source of truth for team context URLs)
 	// use spinner since this can take a while
@@ -441,8 +442,8 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 			errMsg = "API authentication failed - credentials may not be ready yet"
 		}
 		slog.Warn("failed to fetch git credentials", "error", errMsg)
-		fmt.Println("Git credentials sync failed - this won't affect your login.")
-		fmt.Println("You can sync git credentials later with 'ox doctor'.")
+		fmt.Fprintln(out, "Git credentials sync failed - this won't affect your login.")
+		fmt.Fprintln(out, "You can sync git credentials later with 'ox doctor'.")
 	} else {
 		cli.PrintPreserved("Git credentials synced")
 		// refresh remote URLs in existing repos with new credentials

--- a/cmd/ox/login_test.go
+++ b/cmd/ox/login_test.go
@@ -4,9 +4,9 @@ package main
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -92,22 +92,13 @@ func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
 	// Force non-interactive mode so login doesn't try bubbletea
 	t.Setenv("CI", "true")
 
-	// Suppress stdout from login flow (device code URL, etc.)
-	oldStdout := os.Stdout
-	devNull, openErr := os.Open(os.DevNull)
-	require.NoError(t, openErr)
-	os.Stdout = devNull
-	t.Cleanup(func() {
-		os.Stdout = oldStdout
-		_ = devNull.Close()
-	})
-
 	// Run the login flow — this should NOT return the refresh error.
 	// Use a short-lived context so the device flow poll times out quickly.
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	cmd := &cobra.Command{}
 	cmd.SetContext(ctx)
+	cmd.SetOut(io.Discard) // suppress device-code URL etc. from test output
 	err = runLoginFlow(cmd, mockServer.URL)
 
 	// The flow should have proceeded past the refresh failure and

--- a/cmd/ox/murmur_list.go
+++ b/cmd/ox/murmur_list.go
@@ -229,7 +229,7 @@ func runMurmurList(cmd *cobra.Command, args []string) error {
 				Scope:       m.Scope,
 			})
 		}
-		return outputJSON(murmurListOutput{
+		return outputJSON(cmd.OutOrStdout(), murmurListOutput{
 			Murmurs:     entries,
 			Total:       total,
 			Window:      windowLabel,

--- a/cmd/ox/murmur_status.go
+++ b/cmd/ox/murmur_status.go
@@ -145,7 +145,7 @@ func runMurmurStatus(cmd *cobra.Command, _ []string) error {
 			}
 			agents = append(agents, s)
 		}
-		return outputJSON(murmurStatusOutput{
+		return outputJSON(cmd.OutOrStdout(), murmurStatusOutput{
 			YourAgentID: yourAgentID,
 			Agents:      agents,
 			Source:      source,

--- a/cmd/ox/release_notes.go
+++ b/cmd/ox/release_notes.go
@@ -3,7 +3,7 @@ package main
 import (
 	_ "embed"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 
 	lipgloss "charm.land/lipgloss/v2"
@@ -30,12 +30,12 @@ var releaseNotesCmd = &cobra.Command{
 		}
 
 		if raw {
-			fmt.Println(content)
+			fmt.Fprintln(cmd.OutOrStdout(), content)
 			return nil
 		}
 
 		// render with terminal formatting
-		renderReleaseNotes(content)
+		renderReleaseNotes(cmd.OutOrStdout(), content)
 		return nil
 	},
 }
@@ -74,12 +74,12 @@ func extractLatestVersion(content string) string {
 	return strings.TrimSpace(result.String())
 }
 
-func renderReleaseNotes(content string) {
+func renderReleaseNotes(w io.Writer, content string) {
 	lines := strings.Split(content, "\n")
 
 	for _, line := range lines {
 		rendered := renderLine(line)
-		fmt.Fprintln(os.Stdout, rendered)
+		fmt.Fprintln(w, rendered)
 	}
 }
 

--- a/cmd/ox/session_lint.go
+++ b/cmd/ox/session_lint.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,7 +61,7 @@ Examples:
 
 		if filePath != "" {
 			result := lintRawJSONLFile(filePath, filepath.Base(filePath), opts)
-			return printLintResults([]lintResult{result}, jsonOutput)
+			return printLintResults(cmd.OutOrStdout(), []lintResult{result}, jsonOutput)
 		}
 
 		ledgerPath, err := resolveLedgerPath()
@@ -71,7 +72,7 @@ Examples:
 		sessionsDir := filepath.Join(ledgerPath, "sessions")
 
 		if all {
-			return lintAllSessions(sessionsDir, jsonOutput, opts)
+			return lintAllSessions(cmd.OutOrStdout(), sessionsDir, jsonOutput, opts)
 		}
 
 		if len(args) == 0 {
@@ -96,11 +97,11 @@ Examples:
 				Valid:       false,
 				Errors:      []string{fmt.Sprintf("raw.jsonl not available: %v", openErr)},
 			}
-			return printLintResults([]lintResult{result}, jsonOutput)
+			return printLintResults(cmd.OutOrStdout(), []lintResult{result}, jsonOutput)
 		}
 
 		result := lintRawJSONLFile(rawPath, sessionName, opts)
-		return printLintResults([]lintResult{result}, jsonOutput)
+		return printLintResults(cmd.OutOrStdout(), []lintResult{result}, jsonOutput)
 	},
 }
 
@@ -258,8 +259,8 @@ func lintRawJSONLFile(path, name string, opts ...lintOptions) lintResult {
 	return result
 }
 
-// lintAllSessions validates all sessions in the ledger.
-func lintAllSessions(sessionsDir string, jsonOutput bool, opts ...lintOptions) error {
+// lintAllSessions validates all sessions in the ledger, writing results to w.
+func lintAllSessions(w io.Writer, sessionsDir string, jsonOutput bool, opts ...lintOptions) error {
 	var opt lintOptions
 	if len(opts) > 0 {
 		opt = opts[0]
@@ -292,13 +293,13 @@ func lintAllSessions(sessionsDir string, jsonOutput bool, opts ...lintOptions) e
 		results = append(results, lintRawJSONLFile(rawPath, entry.Name(), opt))
 	}
 
-	return printLintResults(results, jsonOutput)
+	return printLintResults(w, results, jsonOutput)
 }
 
-// printLintResults outputs lint results as JSON or human-readable text.
-func printLintResults(results []lintResult, jsonOutput bool) error {
+// printLintResults outputs lint results to w as JSON or human-readable text.
+func printLintResults(w io.Writer, results []lintResult, jsonOutput bool) error {
 	if jsonOutput {
-		enc := json.NewEncoder(os.Stdout)
+		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		return enc.Encode(results)
 	}
@@ -308,7 +309,7 @@ func printLintResults(results []lintResult, jsonOutput bool) error {
 		if !r.Valid {
 			allValid = false
 		}
-		printLintResult(r)
+		printLintResult(w, r)
 	}
 
 	if len(results) > 1 {
@@ -318,7 +319,7 @@ func printLintResults(results []lintResult, jsonOutput bool) error {
 				valid++
 			}
 		}
-		fmt.Printf("\n%d/%d sessions valid\n", valid, len(results))
+		fmt.Fprintf(w, "\n%d/%d sessions valid\n", valid, len(results))
 	}
 
 	if !allValid {
@@ -327,9 +328,9 @@ func printLintResults(results []lintResult, jsonOutput bool) error {
 	return nil
 }
 
-func printLintResult(r lintResult) {
+func printLintResult(w io.Writer, r lintResult) {
 	if r.Valid {
-		fmt.Printf("%s %s  %d entries", ui.RenderPassIcon(), r.SessionName, r.EntryCount)
+		fmt.Fprintf(w, "%s %s  %d entries", ui.RenderPassIcon(), r.SessionName, r.EntryCount)
 		if len(r.TypeCounts) > 0 {
 			var parts []string
 			for _, t := range []string{"user", "assistant", "tool", "system"} {
@@ -337,19 +338,19 @@ func printLintResult(r lintResult) {
 					parts = append(parts, fmt.Sprintf("%s:%d", t, c))
 				}
 			}
-			fmt.Printf("  (%s)", strings.Join(parts, " "))
+			fmt.Fprintf(w, "  (%s)", strings.Join(parts, " "))
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	} else {
-		fmt.Printf("%s %s\n", ui.RenderFailIcon(), r.SessionName)
+		fmt.Fprintf(w, "%s %s\n", ui.RenderFailIcon(), r.SessionName)
 		for _, e := range r.Errors {
-			fmt.Printf("    %s\n", e)
+			fmt.Fprintf(w, "    %s\n", e)
 		}
 	}
 
 	if len(r.Warnings) > 0 {
-		for _, w := range r.Warnings {
-			fmt.Printf("    %s %s\n", ui.RenderWarnIcon(), w)
+		for _, warn := range r.Warnings {
+			fmt.Fprintf(w, "    %s %s\n", ui.RenderWarnIcon(), warn)
 		}
 	}
 }

--- a/cmd/ox/session_lint_all_coverage_test.go
+++ b/cmd/ox/session_lint_all_coverage_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +12,7 @@ func TestLintAllSessions_EmptyDir(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	err := lintAllSessions(dir, true)
+	err := lintAllSessions(io.Discard, dir, true)
 	if err != nil {
 		t.Errorf("lintAllSessions on empty dir: %v", err)
 	}
@@ -20,7 +21,7 @@ func TestLintAllSessions_EmptyDir(t *testing.T) {
 func TestLintAllSessions_NonexistentDir(t *testing.T) {
 	t.Parallel()
 
-	err := lintAllSessions("/nonexistent/sessions/dir", true)
+	err := lintAllSessions(io.Discard, "/nonexistent/sessions/dir", true)
 	if err == nil {
 		t.Error("expected error for nonexistent dir")
 	}
@@ -43,7 +44,7 @@ func TestLintAllSessions_WithValidSession(t *testing.T) {
 	}
 
 	// should not error; we capture output via JSON mode
-	err := lintAllSessions(dir, true)
+	err := lintAllSessions(io.Discard, dir, true)
 	if err != nil {
 		t.Errorf("lintAllSessions with valid session: %v", err)
 	}
@@ -63,7 +64,7 @@ func TestLintAllSessions_SkipsDirsWithoutRawJSONL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := lintAllSessions(dir, true)
+	err := lintAllSessions(io.Discard, dir, true)
 	if err != nil {
 		t.Errorf("lintAllSessions should skip dirs without raw.jsonl: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestPrintLintResults_JSONOutput(t *testing.T) {
 
 	// printLintResults writes to stdout; just verify it doesn't panic
 	// with JSON output mode
-	err := printLintResults(results, true)
+	err := printLintResults(io.Discard, results, true)
 	if err != nil {
 		t.Errorf("printLintResults (json): %v", err)
 	}
@@ -111,7 +112,7 @@ func TestPrintLintResults_TextOutput(t *testing.T) {
 		},
 	}
 
-	err := printLintResults(results, false)
+	err := printLintResults(io.Discard, results, false)
 	// printLintResults returns "lint failed" error when any result is invalid
 	if err == nil {
 		t.Error("expected error when results contain invalid sessions")

--- a/cmd/ox/session_list.go
+++ b/cmd/ox/session_list.go
@@ -135,7 +135,7 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 			if inAgent {
 				out.Guidance = sessionListAgentGuidance
 			}
-			return outputJSON(out)
+			return outputJSON(cmd.OutOrStdout(), out)
 		}
 		cwd, _ := os.Getwd()
 		fmt.Println()
@@ -225,7 +225,7 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 			if inAgent {
 				out.Guidance = sessionListAgentGuidance
 			}
-			return outputJSON(out)
+			return outputJSON(cmd.OutOrStdout(), out)
 		}
 		fmt.Println()
 		repoLabel := fmt.Sprintf("%q", repoName)
@@ -305,7 +305,7 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 		if inAgent {
 			out.Guidance = sessionListAgentGuidance
 		}
-		return outputJSON(out)
+		return outputJSON(cmd.OutOrStdout(), out)
 	}
 
 	// agents consume this output as context — drop decorative chrome that wastes tokens

--- a/cmd/ox/session_show.go
+++ b/cmd/ox/session_show.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 	"time"
 
@@ -128,23 +128,25 @@ func runSessionShowLegacy(cmd *cobra.Command, args []string) error {
 		t = convertStoredSession(st)
 	} else {
 		// no input - show hint
-		fmt.Println()
-		fmt.Println(sessionEmptyStyle.Render("  No sessions found."))
-		fmt.Println()
+		out := cmd.OutOrStdout()
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, sessionEmptyStyle.Render("  No sessions found."))
+		fmt.Fprintln(out)
 		cli.PrintHint("Start a recording with 'ox agent <id> session start' to capture your development session.")
 		return nil
 	}
 
+	out := cmd.OutOrStdout()
 	// output based on format
 	if showRaw {
-		return showRawSession(t, entryLimit)
+		return showRawSession(out, t, entryLimit)
 	}
 
-	return showFormattedSession(t, metadataOnly, entryLimit)
+	return showFormattedSession(out, t, metadataOnly, entryLimit)
 }
 
 // viewAsJSON renders a session as raw JSON output.
-func viewAsJSON(storedSession *session.StoredSession, metadataOnly bool, limit int) error {
+func viewAsJSON(w io.Writer, storedSession *session.StoredSession, metadataOnly bool, limit int) error {
 	t := convertStoredSession(storedSession)
 	if metadataOnly {
 		metaOnly := &sessionShowData{
@@ -152,9 +154,9 @@ func viewAsJSON(storedSession *session.StoredSession, metadataOnly bool, limit i
 			Metadata: t.Metadata,
 			Footer:   t.Footer,
 		}
-		return showRawSession(metaOnly, 0)
+		return showRawSession(w, metaOnly, 0)
 	}
-	return showRawSession(t, limit)
+	return showRawSession(w, t, limit)
 }
 
 // convertStoredSession converts a session.StoredSession to sessionShowData.
@@ -179,8 +181,8 @@ func convertStoredSession(st *session.StoredSession) *sessionShowData {
 	return t
 }
 
-func showRawSession(t *sessionShowData, limit int) error {
-	encoder := json.NewEncoder(os.Stdout)
+func showRawSession(w io.Writer, t *sessionShowData, limit int) error {
+	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 
 	// if showing with limit, only include limited entries
@@ -191,44 +193,44 @@ func showRawSession(t *sessionShowData, limit int) error {
 	return encoder.Encode(t)
 }
 
-func showFormattedSession(t *sessionShowData, metadataOnly bool, limit int) error {
-	fmt.Println()
+func showFormattedSession(w io.Writer, t *sessionShowData, metadataOnly bool, limit int) error {
+	fmt.Fprintln(w)
 
 	// header
-	fmt.Println(showTitleStyle.Render("Session"))
-	fmt.Println(showSeparatorStyle.Render(strings.Repeat("-", 60)))
-	fmt.Println()
+	fmt.Fprintln(w, showTitleStyle.Render("Session"))
+	fmt.Fprintln(w, showSeparatorStyle.Render(strings.Repeat("-", 60)))
+	fmt.Fprintln(w)
 
 	// file info
-	printShowField("Filename", t.Info.Filename)
-	printShowField("Type", t.Info.Type)
-	printShowField("Size", formatSize(t.Info.Size))
-	printShowField("Created", t.Info.CreatedAt.Format("2006-01-02 15:04:05"))
-	printShowField("Modified", t.Info.ModTime.Format("2006-01-02 15:04:05"))
+	printShowField(w, "Filename", t.Info.Filename)
+	printShowField(w, "Type", t.Info.Type)
+	printShowField(w, "Size", formatSize(t.Info.Size))
+	printShowField(w, "Created", t.Info.CreatedAt.Format("2006-01-02 15:04:05"))
+	printShowField(w, "Modified", t.Info.ModTime.Format("2006-01-02 15:04:05"))
 
 	// metadata section
 	if t.Metadata != nil {
-		fmt.Println()
-		fmt.Println(showSectionStyle.Render("Metadata"))
-		fmt.Println(showSeparatorStyle.Render(strings.Repeat("-", 40)))
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, showSectionStyle.Render("Metadata"))
+		fmt.Fprintln(w, showSeparatorStyle.Render(strings.Repeat("-", 40)))
 
 		if t.Metadata.Version != "" {
-			printShowField("Version", t.Metadata.Version)
+			printShowField(w, "Version", t.Metadata.Version)
 		}
 		if t.Metadata.AgentID != "" {
-			printShowField("Agent ID", t.Metadata.AgentID)
+			printShowField(w, "Agent ID", t.Metadata.AgentID)
 		}
 		if t.Metadata.AgentType != "" {
-			printShowField("Agent Type", t.Metadata.AgentType)
+			printShowField(w, "Agent Type", t.Metadata.AgentType)
 		}
 		if t.Metadata.Username != "" {
-			printShowField("Username", t.Metadata.Username)
+			printShowField(w, "Username", t.Metadata.Username)
 		}
 		if t.Metadata.RepoID != "" {
-			printShowField("Repo ID", t.Metadata.RepoID)
+			printShowField(w, "Repo ID", t.Metadata.RepoID)
 		}
 		if !t.Metadata.CreatedAt.IsZero() {
-			printShowField("Started", t.Metadata.CreatedAt.Format("2006-01-02 15:04:05"))
+			printShowField(w, "Started", t.Metadata.CreatedAt.Format("2006-01-02 15:04:05"))
 		}
 	}
 
@@ -236,57 +238,57 @@ func showFormattedSession(t *sessionShowData, metadataOnly bool, limit int) erro
 	if t.Footer != nil {
 		if closedAt, ok := t.Footer["closed_at"].(string); ok {
 			if parsed, err := time.Parse(time.RFC3339Nano, closedAt); err == nil {
-				printShowField("Closed", parsed.Format("2006-01-02 15:04:05"))
+				printShowField(w, "Closed", parsed.Format("2006-01-02 15:04:05"))
 			}
 		}
 		if entryCount, ok := t.Footer["entry_count"].(float64); ok {
-			printShowField("Entries", fmt.Sprintf("%d", int(entryCount)))
+			printShowField(w, "Entries", fmt.Sprintf("%d", int(entryCount)))
 		}
 	}
 
 	// stop here if metadata only
 	if metadataOnly {
-		fmt.Println()
+		fmt.Fprintln(w)
 		return nil
 	}
 
 	// entries section
 	if len(t.Entries) > 0 {
-		fmt.Println()
-		fmt.Println(showSectionStyle.Render("Entries"))
-		fmt.Println(showSeparatorStyle.Render(strings.Repeat("-", 40)))
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, showSectionStyle.Render("Entries"))
+		fmt.Fprintln(w, showSeparatorStyle.Render(strings.Repeat("-", 40)))
 
 		entries := t.Entries
 		if limit > 0 && len(entries) > limit {
 			entries = entries[:limit]
-			fmt.Println(cli.StyleDim.Render(fmt.Sprintf("  (showing first %d of %d entries)", limit, len(t.Entries))))
-			fmt.Println()
+			fmt.Fprintln(w, cli.StyleDim.Render(fmt.Sprintf("  (showing first %d of %d entries)", limit, len(t.Entries))))
+			fmt.Fprintln(w)
 		}
 
 		for i, entry := range entries {
-			printSessionEntry(i+1, entry)
+			printSessionEntry(w, i+1, entry)
 		}
 
 		if limit > 0 && len(t.Entries) > limit {
-			fmt.Println()
-			fmt.Println(cli.StyleDim.Render(fmt.Sprintf("  ... %d more entries (use --limit 0 to show all)", len(t.Entries)-limit)))
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, cli.StyleDim.Render(fmt.Sprintf("  ... %d more entries (use --limit 0 to show all)", len(t.Entries)-limit)))
 		}
 	} else {
-		fmt.Println()
-		fmt.Println(cli.StyleDim.Render("  No entries recorded."))
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, cli.StyleDim.Render("  No entries recorded."))
 	}
 
-	fmt.Println()
+	fmt.Fprintln(w)
 	return nil
 }
 
-func printShowField(label, value string) {
-	fmt.Printf("  %s %s\n",
+func printShowField(w io.Writer, label, value string) {
+	fmt.Fprintf(w, "  %s %s\n",
 		showLabelStyle.Render(label+":"),
 		showValueStyle.Render(value))
 }
 
-func printSessionEntry(seq int, entry map[string]any) {
+func printSessionEntry(w io.Writer, seq int, entry map[string]any) {
 	// get entry type
 	entryType, _ := entry["type"].(string)
 	if entryType == "" {
@@ -308,24 +310,24 @@ func printSessionEntry(seq int, entry map[string]any) {
 	if timestamp != "" {
 		typeLabel += " " + showEntryTimestampStyle.Render(timestamp)
 	}
-	fmt.Println("  " + typeLabel)
+	fmt.Fprintln(w, "  "+typeLabel)
 
 	// entry data based on type
 	switch entryType {
 	case "message":
-		printMessageEntry(entry)
+		printMessageEntry(w, entry)
 	case "tool_call":
-		printToolCallEntry(entry)
+		printToolCallEntry(w, entry)
 	case "tool_result":
-		printToolResultEntry(entry)
+		printToolResultEntry(w, entry)
 	default:
-		printGenericEntry(entry)
+		printGenericEntry(w, entry)
 	}
 
-	fmt.Println()
+	fmt.Fprintln(w)
 }
 
-func printMessageEntry(entry map[string]any) {
+func printMessageEntry(w io.Writer, entry map[string]any) {
 	data, ok := entry["data"].(map[string]any)
 	if !ok {
 		return
@@ -335,9 +337,9 @@ func printMessageEntry(entry map[string]any) {
 	content, _ := data["content"].(string)
 
 	if role != "" {
-		fmt.Printf("    %s: ", showHighlightStyle.Render(role))
+		fmt.Fprintf(w, "    %s: ", showHighlightStyle.Render(role))
 	} else {
-		fmt.Print("    ")
+		fmt.Fprint(w, "    ")
 	}
 
 	// truncate long content
@@ -349,17 +351,17 @@ func printMessageEntry(entry map[string]any) {
 	lines := strings.Split(content, "\n")
 	for i, line := range lines {
 		if i == 0 {
-			fmt.Println(showEntryContentStyle.Render(line))
+			fmt.Fprintln(w, showEntryContentStyle.Render(line))
 		} else if i < 5 {
-			fmt.Println("    " + showEntryContentStyle.Render(line))
+			fmt.Fprintln(w, "    "+showEntryContentStyle.Render(line))
 		} else if i == 5 {
-			fmt.Println("    " + cli.StyleDim.Render("... (truncated)"))
+			fmt.Fprintln(w, "    "+cli.StyleDim.Render("... (truncated)"))
 			break
 		}
 	}
 }
 
-func printToolCallEntry(entry map[string]any) {
+func printToolCallEntry(w io.Writer, entry map[string]any) {
 	data, ok := entry["data"].(map[string]any)
 	if !ok {
 		return
@@ -367,7 +369,7 @@ func printToolCallEntry(entry map[string]any) {
 
 	toolName, _ := data["tool_name"].(string)
 	if toolName != "" {
-		fmt.Printf("    %s %s\n", cli.StyleDim.Render("Tool:"), showToolStyle.Render(toolName))
+		fmt.Fprintf(w, "    %s %s\n", cli.StyleDim.Render("Tool:"), showToolStyle.Render(toolName))
 	}
 
 	// show input preview
@@ -376,11 +378,11 @@ func printToolCallEntry(entry map[string]any) {
 		if len(preview) > 100 {
 			preview = preview[:97] + "..."
 		}
-		fmt.Printf("    %s %s\n", cli.StyleDim.Render("Input:"), cli.StyleDim.Render(preview))
+		fmt.Fprintf(w, "    %s %s\n", cli.StyleDim.Render("Input:"), cli.StyleDim.Render(preview))
 	}
 }
 
-func printToolResultEntry(entry map[string]any) {
+func printToolResultEntry(w io.Writer, entry map[string]any) {
 	data, ok := entry["data"].(map[string]any)
 	if !ok {
 		return
@@ -388,15 +390,15 @@ func printToolResultEntry(entry map[string]any) {
 
 	toolName, _ := data["tool_name"].(string)
 	if toolName != "" {
-		fmt.Printf("    %s %s\n", cli.StyleDim.Render("Tool:"), showToolStyle.Render(toolName))
+		fmt.Fprintf(w, "    %s %s\n", cli.StyleDim.Render("Tool:"), showToolStyle.Render(toolName))
 	}
 
 	// show success/error status
 	if success, ok := data["success"].(bool); ok {
 		if success {
-			fmt.Printf("    %s %s\n", cli.StyleDim.Render("Status:"), cli.StyleSuccess.Render("success"))
+			fmt.Fprintf(w, "    %s %s\n", cli.StyleDim.Render("Status:"), cli.StyleSuccess.Render("success"))
 		} else {
-			fmt.Printf("    %s %s\n", cli.StyleDim.Render("Status:"), cli.StyleError.Render("failed"))
+			fmt.Fprintf(w, "    %s %s\n", cli.StyleDim.Render("Status:"), cli.StyleError.Render("failed"))
 		}
 	}
 
@@ -406,11 +408,11 @@ func printToolResultEntry(entry map[string]any) {
 		if len(preview) > 100 {
 			preview = preview[:97] + "..."
 		}
-		fmt.Printf("    %s %s\n", cli.StyleDim.Render("Output:"), cli.StyleDim.Render(preview))
+		fmt.Fprintf(w, "    %s %s\n", cli.StyleDim.Render("Output:"), cli.StyleDim.Render(preview))
 	}
 }
 
-func printGenericEntry(entry map[string]any) {
+func printGenericEntry(w io.Writer, entry map[string]any) {
 	// show data as compact JSON
 	if data, ok := entry["data"]; ok {
 		jsonBytes, err := json.Marshal(data)
@@ -423,7 +425,7 @@ func printGenericEntry(entry map[string]any) {
 			jsonStr = jsonStr[:147] + "..."
 		}
 
-		fmt.Printf("    %s\n", cli.StyleDim.Render(jsonStr))
+		fmt.Fprintf(w, "    %s\n", cli.StyleDim.Render(jsonStr))
 	}
 }
 

--- a/cmd/ox/session_show_coverage_test.go
+++ b/cmd/ox/session_show_coverage_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +13,7 @@ import (
 )
 
 func TestFormatSize_ShowCoverage(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		bytes int64
 		want  string
@@ -39,6 +39,7 @@ func TestFormatSize_ShowCoverage(t *testing.T) {
 }
 
 func TestConvertStoredSession_NilMeta(t *testing.T) {
+	t.Parallel()
 	st := &session.StoredSession{
 		Info: session.SessionInfo{
 			Filename: "test.jsonl",
@@ -61,6 +62,7 @@ func TestConvertStoredSession_NilMeta(t *testing.T) {
 }
 
 func TestConvertStoredSession_WithMeta(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	st := &session.StoredSession{
 		Info: session.SessionInfo{
@@ -104,6 +106,7 @@ func TestConvertStoredSession_WithMeta(t *testing.T) {
 }
 
 func TestShowRawSession_LimitEntries(t *testing.T) {
+	t.Parallel()
 	data := &sessionShowData{
 		Info: session.SessionInfo{Filename: "test.jsonl"},
 		Entries: []map[string]any{
@@ -115,22 +118,10 @@ func TestShowRawSession_LimitEntries(t *testing.T) {
 		},
 	}
 
-	// capture stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := showRawSession(data, 2)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
+	var buf bytes.Buffer
+	if err := showRawSession(&buf, data, 2); err != nil {
 		t.Fatalf("showRawSession returned error: %v", err)
 	}
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
 
 	var result sessionShowData
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
@@ -143,6 +134,7 @@ func TestShowRawSession_LimitEntries(t *testing.T) {
 }
 
 func TestShowRawSession_NoLimit(t *testing.T) {
+	t.Parallel()
 	data := &sessionShowData{
 		Info: session.SessionInfo{Filename: "test.jsonl"},
 		Entries: []map[string]any{
@@ -152,21 +144,10 @@ func TestShowRawSession_NoLimit(t *testing.T) {
 		},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := showRawSession(data, 0)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
+	var buf bytes.Buffer
+	if err := showRawSession(&buf, data, 0); err != nil {
 		t.Fatalf("showRawSession returned error: %v", err)
 	}
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
 
 	var result sessionShowData
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
@@ -178,20 +159,16 @@ func TestShowRawSession_NoLimit(t *testing.T) {
 	}
 }
 
-// captureStdout runs fn while capturing stdout, returning the output.
-func captureStdout(fn func()) string {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-	fn()
-	w.Close()
-	os.Stdout = old
+// captureStdout runs fn with a fresh bytes.Buffer as its writer and returns
+// the captured output. This is parallel-safe — no os.Stdout mutation.
+func captureStdout(fn func(w io.Writer)) string {
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	fn(&buf)
 	return buf.String()
 }
 
 func TestPrintSessionEntry_MessageType(t *testing.T) {
+	t.Parallel()
 	entry := map[string]any{
 		"type":      "message",
 		"timestamp": time.Now().Format(time.RFC3339Nano),
@@ -200,11 +177,12 @@ func TestPrintSessionEntry_MessageType(t *testing.T) {
 			"content": "hello world",
 		},
 	}
-	output := captureStdout(func() { printSessionEntry(1, entry) })
+	output := captureStdout(func(w io.Writer) { printSessionEntry(w, 1, entry) })
 	assert.Contains(t, output, "user")
 }
 
 func TestPrintSessionEntry_ToolCallType(t *testing.T) {
+	t.Parallel()
 	entry := map[string]any{
 		"type": "tool_call",
 		"data": map[string]any{
@@ -212,11 +190,12 @@ func TestPrintSessionEntry_ToolCallType(t *testing.T) {
 			"input":     "/path/to/file",
 		},
 	}
-	output := captureStdout(func() { printSessionEntry(2, entry) })
+	output := captureStdout(func(w io.Writer) { printSessionEntry(w, 2, entry) })
 	assert.Contains(t, output, "read_file")
 }
 
 func TestPrintSessionEntry_ToolResultType(t *testing.T) {
+	t.Parallel()
 	entry := map[string]any{
 		"type": "tool_result",
 		"data": map[string]any{
@@ -225,11 +204,12 @@ func TestPrintSessionEntry_ToolResultType(t *testing.T) {
 			"output":    "file written successfully",
 		},
 	}
-	output := captureStdout(func() { printSessionEntry(3, entry) })
+	output := captureStdout(func(w io.Writer) { printSessionEntry(w, 3, entry) })
 	assert.Contains(t, output, "write_file")
 }
 
 func TestPrintSessionEntry_ToolResultFailed(t *testing.T) {
+	t.Parallel()
 	entry := map[string]any{
 		"type": "tool_result",
 		"data": map[string]any{
@@ -238,36 +218,32 @@ func TestPrintSessionEntry_ToolResultFailed(t *testing.T) {
 			"output":    "permission denied",
 		},
 	}
-	output := captureStdout(func() { printSessionEntry(4, entry) })
+	output := captureStdout(func(w io.Writer) { printSessionEntry(w, 4, entry) })
 	assert.Contains(t, output, "write_file")
 }
 
 func TestPrintSessionEntry_UnknownType(t *testing.T) {
+	t.Parallel()
 	entry := map[string]any{
 		"type": "custom_event",
 		"data": map[string]any{
 			"key": "value",
 		},
 	}
-	output := captureStdout(func() { printSessionEntry(5, entry) })
+	output := captureStdout(func(w io.Writer) { printSessionEntry(w, 5, entry) })
 	assert.NotEmpty(t, output)
 }
 
 func TestPrintSessionEntry_EmptyType(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
+	t.Parallel()
 	entry := map[string]any{
 		"timestamp": "2026-01-01T00:00:00Z",
 	}
-	printSessionEntry(1, entry)
-
-	w.Close()
-	os.Stdout = old
+	printSessionEntry(io.Discard, 1, entry)
 }
 
 func TestPrintMessageEntry_LongContent(t *testing.T) {
+	t.Parallel()
 	longContent := strings.Repeat("x", 250)
 	entry := map[string]any{
 		"data": map[string]any{
@@ -275,63 +251,47 @@ func TestPrintMessageEntry_LongContent(t *testing.T) {
 			"content": longContent,
 		},
 	}
-	output := captureStdout(func() { printMessageEntry(entry) })
+	output := captureStdout(func(w io.Writer) { printMessageEntry(w, entry) })
 	assert.Contains(t, output, "assistant")
 }
 
 func TestPrintMessageEntry_MultilineContent(t *testing.T) {
+	t.Parallel()
 	entry := map[string]any{
 		"data": map[string]any{
 			"role":    "user",
 			"content": "line1\nline2\nline3\nline4\nline5\nline6\nline7",
 		},
 	}
-	output := captureStdout(func() { printMessageEntry(entry) })
+	output := captureStdout(func(w io.Writer) { printMessageEntry(w, entry) })
 	assert.Contains(t, output, "user")
 }
 
 func TestPrintMessageEntry_NoData(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
+	t.Parallel()
 	// no "data" key — should return silently
 	entry := map[string]any{}
-	printMessageEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	printMessageEntry(io.Discard, entry)
 }
 
 func TestPrintMessageEntry_NoRole(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
+	t.Parallel()
 	entry := map[string]any{
 		"data": map[string]any{
 			"content": "anonymous message",
 		},
 	}
-	printMessageEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	printMessageEntry(io.Discard, entry)
 }
 
 func TestPrintToolCallEntry_NoData(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
+	t.Parallel()
 	entry := map[string]any{}
-	printToolCallEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	printToolCallEntry(io.Discard, entry)
 }
 
 func TestPrintToolCallEntry_LongInput(t *testing.T) {
+	t.Parallel()
 	longInput := strings.Repeat("y", 150)
 	entry := map[string]any{
 		"data": map[string]any{
@@ -339,23 +299,18 @@ func TestPrintToolCallEntry_LongInput(t *testing.T) {
 			"input":     longInput,
 		},
 	}
-	output := captureStdout(func() { printToolCallEntry(entry) })
+	output := captureStdout(func(w io.Writer) { printToolCallEntry(w, entry) })
 	assert.Contains(t, output, "bash")
 }
 
 func TestPrintToolResultEntry_NoData(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
+	t.Parallel()
 	entry := map[string]any{}
-	printToolResultEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	printToolResultEntry(io.Discard, entry)
 }
 
 func TestPrintToolResultEntry_LongOutput(t *testing.T) {
+	t.Parallel()
 	longOutput := strings.Repeat("z", 150)
 	entry := map[string]any{
 		"data": map[string]any{
@@ -364,34 +319,30 @@ func TestPrintToolResultEntry_LongOutput(t *testing.T) {
 			"output":    longOutput,
 		},
 	}
-	output := captureStdout(func() { printToolResultEntry(entry) })
+	output := captureStdout(func(w io.Writer) { printToolResultEntry(w, entry) })
 	assert.NotEmpty(t, output)
 }
 
 func TestPrintGenericEntry_NoData(t *testing.T) {
-	old := os.Stdout
-	_, w, _ := os.Pipe()
-	os.Stdout = w
-
+	t.Parallel()
 	entry := map[string]any{}
-	printGenericEntry(entry)
-
-	w.Close()
-	os.Stdout = old
+	printGenericEntry(io.Discard, entry)
 }
 
 func TestPrintGenericEntry_LongJSON(t *testing.T) {
+	t.Parallel()
 	longVal := strings.Repeat("a", 200)
 	entry := map[string]any{
 		"data": map[string]any{
 			"long_key": longVal,
 		},
 	}
-	output := captureStdout(func() { printGenericEntry(entry) })
+	output := captureStdout(func(w io.Writer) { printGenericEntry(w, entry) })
 	assert.NotEmpty(t, output)
 }
 
 func TestShowFormattedSession_MetadataOnly(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	data := &sessionShowData{
 		Info: session.SessionInfo{
@@ -419,7 +370,7 @@ func TestShowFormattedSession_MetadataOnly(t *testing.T) {
 	}
 
 	var err error
-	output := captureStdout(func() { err = showFormattedSession(data, true, 0) })
+	output := captureStdout(func(w io.Writer) { err = showFormattedSession(w, data, true, 0) })
 
 	if err != nil {
 		t.Fatalf("showFormattedSession returned error: %v", err)
@@ -428,6 +379,7 @@ func TestShowFormattedSession_MetadataOnly(t *testing.T) {
 }
 
 func TestShowFormattedSession_NoEntries(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	data := &sessionShowData{
 		Info: session.SessionInfo{
@@ -441,7 +393,7 @@ func TestShowFormattedSession_NoEntries(t *testing.T) {
 	}
 
 	var err error
-	output := captureStdout(func() { err = showFormattedSession(data, false, 0) })
+	output := captureStdout(func(w io.Writer) { err = showFormattedSession(w, data, false, 0) })
 
 	if err != nil {
 		t.Fatalf("showFormattedSession returned error: %v", err)
@@ -450,6 +402,7 @@ func TestShowFormattedSession_NoEntries(t *testing.T) {
 }
 
 func TestShowFormattedSession_WithLimit(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	data := &sessionShowData{
 		Info: session.SessionInfo{
@@ -467,7 +420,7 @@ func TestShowFormattedSession_WithLimit(t *testing.T) {
 	}
 
 	var err error
-	output := captureStdout(func() { err = showFormattedSession(data, false, 1) })
+	output := captureStdout(func(w io.Writer) { err = showFormattedSession(w, data, false, 1) })
 
 	if err != nil {
 		t.Fatalf("showFormattedSession returned error: %v", err)
@@ -476,10 +429,7 @@ func TestShowFormattedSession_WithLimit(t *testing.T) {
 }
 
 func TestViewAsJSON_MetadataOnly(t *testing.T) {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
+	t.Parallel()
 	now := time.Now()
 	st := &session.StoredSession{
 		Info: session.SessionInfo{Filename: "test.jsonl", CreatedAt: now, ModTime: now},
@@ -490,17 +440,10 @@ func TestViewAsJSON_MetadataOnly(t *testing.T) {
 		},
 	}
 
-	err := viewAsJSON(st, true, 0)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
+	var buf bytes.Buffer
+	if err := viewAsJSON(&buf, st, true, 0); err != nil {
 		t.Fatalf("viewAsJSON returned error: %v", err)
 	}
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
 
 	var result sessionShowData
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
@@ -514,10 +457,7 @@ func TestViewAsJSON_MetadataOnly(t *testing.T) {
 }
 
 func TestViewAsJSON_WithEntries(t *testing.T) {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
+	t.Parallel()
 	now := time.Now()
 	st := &session.StoredSession{
 		Info: session.SessionInfo{Filename: "test.jsonl", CreatedAt: now, ModTime: now},
@@ -527,17 +467,10 @@ func TestViewAsJSON_WithEntries(t *testing.T) {
 		},
 	}
 
-	err := viewAsJSON(st, false, 1)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
+	var buf bytes.Buffer
+	if err := viewAsJSON(&buf, st, false, 1); err != nil {
 		t.Fatalf("viewAsJSON returned error: %v", err)
 	}
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
 
 	var result sessionShowData
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
@@ -550,6 +483,7 @@ func TestViewAsJSON_WithEntries(t *testing.T) {
 }
 
 func TestPrintSessionEntry_InvalidTimestamp(t *testing.T) {
+	t.Parallel()
 	entry := map[string]any{
 		"type":      "message",
 		"timestamp": "not-a-timestamp",
@@ -558,6 +492,6 @@ func TestPrintSessionEntry_InvalidTimestamp(t *testing.T) {
 			"content": "test",
 		},
 	}
-	output := captureStdout(func() { printSessionEntry(1, entry) })
+	output := captureStdout(func(w io.Writer) { printSessionEntry(w, 1, entry) })
 	assert.Contains(t, output, "user")
 }

--- a/cmd/ox/session_status.go
+++ b/cmd/ox/session_status.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -160,7 +161,7 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 	projectRoot, err := requireProjectRoot()
 	if err != nil {
 		if jsonOutput {
-			return outputJSON(sessionStatusOutput{Recording: false})
+			return outputJSON(cmd.OutOrStdout(), sessionStatusOutput{Recording: false})
 		}
 		return err
 	}
@@ -169,7 +170,7 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 	states, err := session.LoadAllRecordingStates(projectRoot)
 	if err != nil {
 		if jsonOutput {
-			return outputJSON(sessionStatusOutput{Recording: false})
+			return outputJSON(cmd.OutOrStdout(), sessionStatusOutput{Recording: false})
 		}
 		return fmt.Errorf("failed to check recording state: %w", err)
 	}
@@ -179,7 +180,7 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 		agentID := os.Getenv("SAGEOX_AGENT_ID")
 		if agentID == "" {
 			if jsonOutput {
-				return outputJSON(sessionStatusOutput{Recording: false})
+				return outputJSON(cmd.OutOrStdout(), sessionStatusOutput{Recording: false})
 			}
 			return fmt.Errorf("--current requires SAGEOX_AGENT_ID environment variable (set by 'ox agent prime')")
 		}
@@ -199,7 +200,7 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 	// no recordings
 	if len(states) == 0 {
 		if jsonOutput {
-			return outputJSON(sessionStatusOutput{
+			return outputJSON(cmd.OutOrStdout(), sessionStatusOutput{
 				Recording: false,
 				Guidance:  "Run 'ox agent <id> session start' to begin recording",
 			})
@@ -249,7 +250,7 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 				Stalled:         stalled,
 				StalledReason:   stalledReason,
 			}
-			return outputJSON(output)
+			return outputJSON(cmd.OutOrStdout(), output)
 		}
 
 		if !state.IsAgentAlive() {
@@ -327,7 +328,7 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 				Branch:        s.Branch,
 			})
 		}
-		return outputJSON(sessionStatusOutput{
+		return outputJSON(cmd.OutOrStdout(), sessionStatusOutput{
 			Recording: true,
 			Guidance:  "Use --current to filter to this agent's recording",
 			Count:     len(states),
@@ -468,9 +469,9 @@ func formatProcessStatus(status string) string {
 	}
 }
 
-// outputJSON writes JSON to stdout.
-func outputJSON(v any) error {
-	encoder := json.NewEncoder(os.Stdout)
+// outputJSON writes JSON to w with 2-space indentation.
+func outputJSON(w io.Writer, v any) error {
+	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(v)
 }

--- a/cmd/ox/session_view.go
+++ b/cmd/ox/session_view.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -116,7 +117,7 @@ func runSessionView(cmd *cobra.Command, args []string) error {
 
 			// context trace only needs the session name, not full session data
 			if contextFlag {
-				return runContextTrace(store, sessionName, projectRoot, jsonFlag, entryLimit)
+				return runContextTrace(cmd.OutOrStdout(), store, sessionName, projectRoot, jsonFlag, entryLimit)
 			}
 
 			// local formats: try local cache first, then fall back to ledger
@@ -177,7 +178,7 @@ func runSessionView(cmd *cobra.Command, args []string) error {
 				if latestName == "" {
 					latestName = latest.SessionName // fallback
 				}
-				return runContextTrace(store, latestName, projectRoot, jsonFlag, entryLimit)
+				return runContextTrace(cmd.OutOrStdout(), store, latestName, projectRoot, jsonFlag, entryLimit)
 			}
 
 			st, err := store.ReadSession(latest.Filename)
@@ -202,25 +203,25 @@ func runSessionView(cmd *cobra.Command, args []string) error {
 }
 
 // runContextTrace resolves and renders context-trace events for a session.
-func runContextTrace(store *session.Store, sessionName, projectRoot string, jsonOutput bool, limit int) error {
+func runContextTrace(w io.Writer, store *session.Store, sessionName, projectRoot string, jsonOutput bool, limit int) error {
 	events, err := resolveContextTrace(store, sessionName, projectRoot)
 	if err != nil {
 		return fmt.Errorf("resolve context trace for %s: %w", sessionName, err)
 	}
 	if len(events) == 0 {
-		fmt.Println()
-		printShowField(os.Stdout, "Session", sessionName)
-		fmt.Println()
-		fmt.Println(cli.StyleDim.Render("  No context trace available for this session."))
-		cli.PrintHint("Context tracing records what team knowledge was provided during ox agent prime.")
-		cli.PrintHint("Sessions recorded before context tracing was added won't have this data.")
-		fmt.Println()
+		fmt.Fprintln(w)
+		printShowField(w, "Session", sessionName)
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, cli.StyleDim.Render("  No context trace available for this session."))
+		cli.PrintHintTo(w, "Context tracing records what team knowledge was provided during ox agent prime.")
+		cli.PrintHintTo(w, "Sessions recorded before context tracing was added won't have this data.")
+		fmt.Fprintln(w)
 		return nil
 	}
 	if jsonOutput {
-		return viewContextTraceJSON(events, sessionName, limit)
+		return viewContextTraceJSON(w, events, sessionName, limit)
 	}
-	viewContextTraceText(events, sessionName)
+	viewContextTraceText(w, events, sessionName)
 	return nil
 }
 

--- a/cmd/ox/session_view.go
+++ b/cmd/ox/session_view.go
@@ -195,7 +195,7 @@ func runSessionView(cmd *cobra.Command, args []string) error {
 	case "text":
 		return viewAsText(store, storedSession, projectRoot)
 	case "json":
-		return viewAsJSON(storedSession, metadataOnly, entryLimit)
+		return viewAsJSON(cmd.OutOrStdout(), storedSession, metadataOnly, entryLimit)
 	default:
 		return fmt.Errorf("unknown view format: %s", format)
 	}
@@ -209,7 +209,7 @@ func runContextTrace(store *session.Store, sessionName, projectRoot string, json
 	}
 	if len(events) == 0 {
 		fmt.Println()
-		printShowField("Session", sessionName)
+		printShowField(os.Stdout, "Session", sessionName)
 		fmt.Println()
 		fmt.Println(cli.StyleDim.Render("  No context trace available for this session."))
 		cli.PrintHint("Context tracing records what team knowledge was provided during ox agent prime.")

--- a/cmd/ox/session_view_context.go
+++ b/cmd/ox/session_view_context.go
@@ -124,8 +124,8 @@ func viewContextTraceText(events []contexttrace.Event, sessionName string) {
 	fmt.Println(showTitleStyle.Render("Context Trace"))
 	fmt.Println(showSeparatorStyle.Render(strings.Repeat("-", 60)))
 	fmt.Println()
-	printShowField("Session", sessionName)
-	printShowField("Events", fmt.Sprintf("%d", len(events)))
+	printShowField(os.Stdout, "Session", sessionName)
+	printShowField(os.Stdout, "Events", fmt.Sprintf("%d", len(events)))
 	fmt.Println()
 
 	// partition events

--- a/cmd/ox/session_view_context.go
+++ b/cmd/ox/session_view_context.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,14 +120,14 @@ func resolveContextTrace(store *session.Store, sessionName, projectRoot string) 
 }
 
 // viewContextTraceText renders context-trace events as formatted terminal output.
-func viewContextTraceText(events []contexttrace.Event, sessionName string) {
-	fmt.Println()
-	fmt.Println(showTitleStyle.Render("Context Trace"))
-	fmt.Println(showSeparatorStyle.Render(strings.Repeat("-", 60)))
-	fmt.Println()
-	printShowField(os.Stdout, "Session", sessionName)
-	printShowField(os.Stdout, "Events", fmt.Sprintf("%d", len(events)))
-	fmt.Println()
+func viewContextTraceText(w io.Writer, events []contexttrace.Event, sessionName string) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, showTitleStyle.Render("Context Trace"))
+	fmt.Fprintln(w, showSeparatorStyle.Render(strings.Repeat("-", 60)))
+	fmt.Fprintln(w)
+	printShowField(w, "Session", sessionName)
+	printShowField(w, "Events", fmt.Sprintf("%d", len(events)))
+	fmt.Fprintln(w)
 
 	// partition events
 	var provided, influenced []contexttrace.Event
@@ -141,37 +142,37 @@ func viewContextTraceText(events []contexttrace.Event, sessionName string) {
 
 	// provided context
 	if len(provided) > 0 {
-		fmt.Println(showSectionStyle.Render("Provided Context"))
-		fmt.Println(showSeparatorStyle.Render(strings.Repeat("-", 40)))
-		fmt.Println()
+		fmt.Fprintln(w, showSectionStyle.Render("Provided Context"))
+		fmt.Fprintln(w, showSeparatorStyle.Render(strings.Repeat("-", 40)))
+		fmt.Fprintln(w)
 
 		for _, ev := range provided {
-			printProvidedEvent(ev)
+			printProvidedEvent(w, ev)
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	}
 
 	// influenced decisions
 	if len(influenced) > 0 {
-		fmt.Println(showSectionStyle.Render("Influenced Decisions"))
-		fmt.Println(showSeparatorStyle.Render(strings.Repeat("-", 40)))
-		fmt.Println()
+		fmt.Fprintln(w, showSectionStyle.Render("Influenced Decisions"))
+		fmt.Fprintln(w, showSeparatorStyle.Render(strings.Repeat("-", 40)))
+		fmt.Fprintln(w)
 
 		for _, ev := range influenced {
-			printInfluencedEvent(ev)
+			printInfluencedEvent(w, ev)
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	}
 
 	// summary
-	fmt.Println(showSeparatorStyle.Render(strings.Repeat("-", 60)))
-	fmt.Printf("  %s provided, %s influenced decisions\n",
+	fmt.Fprintln(w, showSeparatorStyle.Render(strings.Repeat("-", 60)))
+	fmt.Fprintf(w, "  %s provided, %s influenced decisions\n",
 		showHighlightStyle.Render(fmt.Sprintf("%d sources", len(provided))),
 		showHighlightStyle.Render(fmt.Sprintf("%d", len(influenced))))
-	fmt.Println()
+	fmt.Fprintln(w)
 }
 
-func printProvidedEvent(ev contexttrace.Event) {
+func printProvidedEvent(w io.Writer, ev contexttrace.Event) {
 	ts := formatTraceTimestamp(ev.Timestamp)
 	style := sourceStyle(ev.Source)
 
@@ -192,7 +193,7 @@ func printProvidedEvent(ev contexttrace.Event) {
 		line += " " + showEntryTimestampStyle.Render(ts)
 	}
 
-	fmt.Println(line)
+	fmt.Fprintln(w, line)
 
 	// details line
 	var details []string
@@ -210,11 +211,11 @@ func printProvidedEvent(ev contexttrace.Event) {
 	}
 
 	if len(details) > 0 {
-		fmt.Printf("    %s\n", strings.Join(details, " "+cli.StyleDim.Render("|")+" "))
+		fmt.Fprintf(w, "    %s\n", strings.Join(details, " "+cli.StyleDim.Render("|")+" "))
 	}
 }
 
-func printInfluencedEvent(ev contexttrace.Event) {
+func printInfluencedEvent(w io.Writer, ev contexttrace.Event) {
 	ts := formatTraceTimestamp(ev.Timestamp)
 	style := sourceStyle(ev.Source)
 
@@ -228,18 +229,18 @@ func printInfluencedEvent(ev contexttrace.Event) {
 		line += " " + showEntryTimestampStyle.Render(ts)
 	}
 
-	fmt.Println(line)
+	fmt.Fprintln(w, line)
 
 	if ev.Decision != "" {
 		decision := ev.Decision
 		if len(decision) > 200 {
 			decision = decision[:197] + "..."
 		}
-		fmt.Printf("    %s\n", ctxDecisionStyle.Render(decision))
+		fmt.Fprintf(w, "    %s\n", ctxDecisionStyle.Render(decision))
 	}
 
 	if ev.PlanStep > 0 {
-		fmt.Printf("    %s\n", cli.StyleDim.Render(fmt.Sprintf("plan step %d", ev.PlanStep)))
+		fmt.Fprintf(w, "    %s\n", cli.StyleDim.Render(fmt.Sprintf("plan step %d", ev.PlanStep)))
 	}
 }
 
@@ -253,7 +254,7 @@ type contextTraceJSONOutput struct {
 }
 
 // viewContextTraceJSON renders context-trace events as structured JSON.
-func viewContextTraceJSON(events []contexttrace.Event, sessionName string, limit int) error {
+func viewContextTraceJSON(w io.Writer, events []contexttrace.Event, sessionName string, limit int) error {
 	var provided, influenced int
 	for _, ev := range events {
 		switch ev.Type {
@@ -276,7 +277,7 @@ func viewContextTraceJSON(events []contexttrace.Event, sessionName string, limit
 		Events:      events,
 	}
 
-	encoder := json.NewEncoder(os.Stdout)
+	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(out)
 }

--- a/cmd/ox/session_view_context_test.go
+++ b/cmd/ox/session_view_context_test.go
@@ -3,14 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io"
-	"os"
 	"testing"
 
 	"github.com/sageox/ox/internal/session/contexttrace"
 )
 
 func TestViewContextTraceJSON_StructureAndCounts(t *testing.T) {
+	t.Parallel()
 	events := []contexttrace.Event{
 		{Type: contexttrace.EventProvided, Source: contexttrace.SourceTeamContext, Doc: "AGENTS.md", InlineTokens: 2048},
 		{Type: contexttrace.EventProvided, Source: contexttrace.SourceTeamMemory, Doc: "MEMORY.md", ReadOnDemand: true},
@@ -18,22 +17,10 @@ func TestViewContextTraceJSON_StructureAndCounts(t *testing.T) {
 		{Type: contexttrace.EventInfluenced, Source: contexttrace.SourceTeamContext, Doc: "AGENTS.md", Decision: "used snake_case per team convention"},
 	}
 
-	// capture stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := viewContextTraceJSON(events, "2026-04-01T10-00-ryan-OxTest", 0)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
+	var buf bytes.Buffer
+	if err := viewContextTraceJSON(&buf, events, "2026-04-01T10-00-ryan-OxTest", 0); err != nil {
 		t.Fatalf("viewContextTraceJSON returned error: %v", err)
 	}
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
 
 	var out contextTraceJSONOutput
 	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
@@ -58,27 +45,17 @@ func TestViewContextTraceJSON_StructureAndCounts(t *testing.T) {
 }
 
 func TestViewContextTraceJSON_Limit(t *testing.T) {
+	t.Parallel()
 	events := []contexttrace.Event{
 		{Type: contexttrace.EventProvided, Source: contexttrace.SourceTeamContext, Doc: "A.md"},
 		{Type: contexttrace.EventProvided, Source: contexttrace.SourceTeamContext, Doc: "B.md"},
 		{Type: contexttrace.EventProvided, Source: contexttrace.SourceTeamContext, Doc: "C.md"},
 	}
 
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := viewContextTraceJSON(events, "test-session", 2)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
+	var buf bytes.Buffer
+	if err := viewContextTraceJSON(&buf, events, "test-session", 2); err != nil {
 		t.Fatalf("viewContextTraceJSON returned error: %v", err)
 	}
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
 
 	var out contextTraceJSONOutput
 	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
@@ -95,21 +72,11 @@ func TestViewContextTraceJSON_Limit(t *testing.T) {
 }
 
 func TestViewContextTraceJSON_Empty(t *testing.T) {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := viewContextTraceJSON(nil, "empty-session", 0)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := viewContextTraceJSON(&buf, nil, "empty-session", 0); err != nil {
 		t.Fatalf("viewContextTraceJSON returned error: %v", err)
 	}
-
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
 
 	var out contextTraceJSONOutput
 	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
@@ -122,6 +89,7 @@ func TestViewContextTraceJSON_Empty(t *testing.T) {
 }
 
 func TestFormatTraceTimestamp(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -134,6 +102,7 @@ func TestFormatTraceTimestamp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := formatTraceTimestamp(tt.input)
 			if got != tt.want {
 				t.Errorf("formatTraceTimestamp(%q) = %q, want %q", tt.input, got, tt.want)

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -114,55 +114,88 @@ func PrintSuccessTo(w io.Writer, msg string) {
 // PrintPreserved prints a message indicating an existing file was preserved (not overwritten).
 // Uses cyan color to distinguish from green success (created) messages.
 func PrintPreserved(msg string) {
+	PrintPreservedTo(os.Stdout, msg)
+}
+
+// PrintPreservedTo writes a preserved-file notice to w. Parallel-safe.
+func PrintPreservedTo(w io.Writer, msg string) {
 	if jsonMode {
-		PrintJSON(map[string]any{
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
 			"status":  "preserved",
 			"message": msg,
 		})
 		return
 	}
-	fmt.Fprintf(os.Stdout, "%s %s\n", preservedStyle.Render("✓"), msg)
+	fmt.Fprintf(w, "%s %s\n", preservedStyle.Render("✓"), msg)
 }
 
 func PrintError(msg string) {
+	PrintErrorTo(os.Stderr, msg)
+}
+
+// PrintErrorTo writes an error message to w. Parallel-safe.
+func PrintErrorTo(w io.Writer, msg string) {
 	if jsonMode {
-		PrintJSON(map[string]any{
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
 			"status":  "error",
 			"message": msg,
 		})
 		return
 	}
-	fmt.Fprintf(os.Stderr, "%s %s\n", errorStyle.Render("✗"), msg)
+	fmt.Fprintf(w, "%s %s\n", errorStyle.Render("✗"), msg)
 }
 
 func PrintWarning(msg string) {
+	PrintWarningTo(os.Stderr, msg)
+}
+
+// PrintWarningTo writes a warning to w. Parallel-safe.
+func PrintWarningTo(w io.Writer, msg string) {
 	if jsonMode {
-		PrintJSON(map[string]any{
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
 			"status":  "warning",
 			"message": msg,
 		})
 		return
 	}
-	fmt.Fprintf(os.Stderr, "%s %s\n", warningStyle.Render("⚠"), msg)
+	fmt.Fprintf(w, "%s %s\n", warningStyle.Render("⚠"), msg)
 }
 
 func PrintInfo(msg string) {
+	PrintInfoTo(os.Stdout, msg)
+}
+
+// PrintInfoTo writes an info message to w. Parallel-safe.
+func PrintInfoTo(w io.Writer, msg string) {
 	if jsonMode {
-		PrintJSON(map[string]any{
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
 			"status":  "info",
 			"message": msg,
 		})
 		return
 	}
-	fmt.Fprintf(os.Stdout, "%s %s\n", infoStyle.Render("ℹ"), msg)
+	fmt.Fprintf(w, "%s %s\n", infoStyle.Render("ℹ"), msg)
 }
 
 // PrintHint prints a dimmed hint message (e.g., "Run 'ox login' to authenticate")
 func PrintHint(msg string) {
+	PrintHintTo(os.Stdout, msg)
+}
+
+// PrintHintTo writes a hint to w. Parallel-safe. Suppressed in jsonMode.
+func PrintHintTo(w io.Writer, msg string) {
 	if jsonMode {
 		return // hints are not included in JSON output
 	}
-	fmt.Fprintln(os.Stdout, hintStyle.Render(msg))
+	fmt.Fprintln(w, hintStyle.Render(msg))
 }
 
 // PrintActionHint prints a prominent actionable hint with star, command, and optional step.

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -132,10 +132,20 @@ func PrintPreservedTo(w io.Writer, msg string) {
 }
 
 func PrintError(msg string) {
+	// Preserves historical split: JSON to stdout, text to stderr.
+	if jsonMode {
+		PrintJSON(map[string]any{
+			"status":  "error",
+			"message": msg,
+		})
+		return
+	}
 	PrintErrorTo(os.Stderr, msg)
 }
 
-// PrintErrorTo writes an error message to w. Parallel-safe.
+// PrintErrorTo writes an error message to w. Parallel-safe. Always writes
+// the formatted text (or JSON in jsonMode) to w — does not split between
+// stdout/stderr like the package-level PrintError does.
 func PrintErrorTo(w io.Writer, msg string) {
 	if jsonMode {
 		enc := json.NewEncoder(w)
@@ -150,10 +160,18 @@ func PrintErrorTo(w io.Writer, msg string) {
 }
 
 func PrintWarning(msg string) {
+	if jsonMode {
+		PrintJSON(map[string]any{
+			"status":  "warning",
+			"message": msg,
+		})
+		return
+	}
 	PrintWarningTo(os.Stderr, msg)
 }
 
-// PrintWarningTo writes a warning to w. Parallel-safe.
+// PrintWarningTo writes a warning to w. Parallel-safe. Always writes to w
+// (does not split between stdout/stderr like the package-level PrintWarning).
 func PrintWarningTo(w io.Writer, msg string) {
 	if jsonMode {
 		enc := json.NewEncoder(w)

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"regexp"
@@ -91,14 +92,23 @@ func PrintJSON(v any) {
 }
 
 func PrintSuccess(msg string) {
+	PrintSuccessTo(os.Stdout, msg)
+}
+
+// PrintSuccessTo writes a success message to w. Parallel-safe — does not
+// touch os.Stdout. Honors jsonMode (encodes JSON to w) so output shape is
+// identical to PrintSuccess.
+func PrintSuccessTo(w io.Writer, msg string) {
 	if jsonMode {
-		PrintJSON(map[string]any{
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(map[string]any{
 			"status":  "success",
 			"message": msg,
 		})
 		return
 	}
-	fmt.Fprintf(os.Stdout, "%s %s\n", successStyle.Render("✓"), msg)
+	fmt.Fprintf(w, "%s %s\n", successStyle.Render("✓"), msg)
 }
 
 // PrintPreserved prints a message indicating an existing file was preserved (not overwritten).

--- a/internal/cli/output_extended_test.go
+++ b/internal/cli/output_extended_test.go
@@ -455,3 +455,49 @@ func TestPrintJSON(t *testing.T) {
 	assert.Contains(t, output, `"key"`)
 	assert.Contains(t, output, `"value"`)
 }
+
+// =============================================================================
+// Writer-aware *To variants — parallel-safe, no os.Stdout/Stderr mutation
+// =============================================================================
+
+func TestPrintSuccessTo_WritesToWriter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	PrintSuccessTo(&buf, "all good")
+	assert.Contains(t, buf.String(), "all good")
+}
+
+func TestPrintErrorTo_WritesToWriter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	PrintErrorTo(&buf, "something broke")
+	assert.Contains(t, buf.String(), "something broke")
+}
+
+func TestPrintWarningTo_WritesToWriter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	PrintWarningTo(&buf, "heads up")
+	assert.Contains(t, buf.String(), "heads up")
+}
+
+func TestPrintInfoTo_WritesToWriter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	PrintInfoTo(&buf, "for your information")
+	assert.Contains(t, buf.String(), "for your information")
+}
+
+func TestPrintPreservedTo_WritesToWriter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	PrintPreservedTo(&buf, "kept original")
+	assert.Contains(t, buf.String(), "kept original")
+}
+
+func TestPrintHintTo_WritesToWriter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	PrintHintTo(&buf, "consider running ox doctor")
+	assert.Contains(t, buf.String(), "consider running ox doctor")
+}


### PR DESCRIPTION
## Summary

- **Fast \`make test\` wall: 483s → ~96s (5x speedup, 80% reduction)** by removing coverage instrumentation from the fast tier; coverage moves to a new \`make test-cover\` target and stays in \`make test-all\` (the pre-PR gate).
- **Architectural cleanup** in cmd/ox: 15+ production helpers now take \`io.Writer\` instead of writing to \`os.Stdout\` directly (session_show, agent_doctor, agent_instances, agent_session_log, agent_session_abort, agent_hook, doctor_integration, session_lint, session_view_context, glance, code, code_activity, hooks_events_list, kb_show, release_notes, runLoginFlow, and the whisper helpers). Tests pass \`&bytes.Buffer{}\` or \`io.Discard\`; zero remaining \`os.Stdout\`-swap tests in cmd/ox.
- **Test theater removed**: \`captureStdout\` is now a 3-line buffer wrapper (parallel-safe); 9 test files lost the \`os.Pipe\` plumbing and ~400 lines of test scaffolding net.
- **New cli helpers**: \`PrintSuccessTo\` / \`PrintErrorTo\` / \`PrintWarningTo\` / \`PrintInfoTo\` / \`PrintHintTo\` / \`PrintPreservedTo\` accept \`io.Writer\` and are parallel-safe; legacy globals delegate to them with no API break.
- **Verified**: 14,370 tests pass, 974 skipped, race-clean. Coverage path (\`make coverage\`, \`coverage-baseline\`, \`coverage-diff\`) rewired correctly.

## Test plan

- [x] \`make test\` passes under \`-short -race\` after rebase on origin/main
- [x] Race detector clean across cmd/ox + internal/cli
- [x] \`make coverage\` still produces a report (now via the explicit \`test-cover\` target)
- [ ] Reviewer sanity-check: production CLI output (e.g. \`ox session view --json\`, \`ox agent <id> doctor\`, \`ox glance\`) still goes to stdout in real usage (manual smoke test)

## Follow-ups (not in this PR)

Mass \`t.Parallel()\` injection in cmd/ox still hits ~10% race rate from remaining global state: \`SetKBDoctorHooks\` package globals, cobra command singletons (\`agentCmd\`/\`sessionCmd\`), and \`cli.jsonMode\`/\`noInteractive\` package globals. Each is its own focused refactor; landing them would unlock cmd/ox parallelism (estimate: 96s → ~25-35s).

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored output handling architecture for improved consistency and testability across commands.
  * Enhanced test parallelization safety by eliminating global state mutations.
  * Optimized build system coverage workflow with dedicated test targets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/598)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->