### PR TITLE
fix(doctor): post-eeqi credential checks + correct user guidance

### DIFF
--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -753,17 +753,15 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		gitRepoChecks = append(gitRepoChecks, SkippedCheck("git repo paths", "requires login", ""))
 	}
 
-	// add remote URL checks for ledger and team contexts (SageOx is multiplayer)
+	// add remote URL checks for team contexts (SageOx is multiplayer).
+	// Ledger remote URL is no longer compared against an in-URL PAT — per
+	// ox-eeqi the PAT lives in the git credential helper, not the URL. The
+	// `ledger-embedded-creds` check (doctor_ledger_secrets.go) covers the
+	// only legitimate question: is there an embedded PAT to strip?
 	gitRoot := findGitRoot()
 	if gitRoot != "" {
 		localCfg, err := config.LoadLocalConfig(gitRoot)
 		if err == nil && localCfg != nil {
-			// check ledger remote URL
-			ledgerRemoteCheck := checkLedgerRemoteURL(localCfg)
-			if !ledgerRemoteCheck.skipped {
-				gitRepoChecks = append(gitRepoChecks, ledgerRemoteCheck)
-			}
-			// check team context remote URLs
 			teamContextRemoteChecks := checkTeamContextRemoteURLs(localCfg)
 			for _, check := range teamContextRemoteChecks {
 				if !check.skipped {
@@ -811,10 +809,11 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 	} else {
 		ledgerGitChecks := checkLedgerGitHealth(
 			opts.fix,
-			opts.shouldFix(CheckSlugLedgerRemote),
 			opts.shouldFix(CheckSlugGitignoreMissing),
 			opts.shouldFix(CheckSlugLedgerBranchStatus),
 			opts.shouldFix(CheckSlugLedgerCleanWorkdir),
+			opts.shouldFix(CheckSlugLedgerEmbeddedCreds),
+			opts.shouldFix(CheckSlugLedgerURLAPIMatch),
 			opts.shouldFix(CheckSlugGitHubDataMigration),
 		)
 		if len(ledgerGitChecks) > 0 {
@@ -1074,12 +1073,13 @@ func enrichCheckResult(check *checkResult) {
 // Returns a slice of check results, or empty slice if no ledger exists.
 // Parameters:
 //   - networkChecks: whether to run network checks (git ls-remote); only with --fix
-//   - fixRemote: whether to fix remote URL issues
 //   - fixGitignore: whether to fix .sageox/.gitignore issues in checkouts
 //   - fixBranch: whether to auto-sync branch (push/pull)
 //   - fixWorkdir: whether to auto-commit dirty workdir
+//   - fixEmbeddedCreds: whether to strip embedded oauth2:TOKEN from origin URL
+//   - fixURLAPIMatch: whether to repoint origin URL to the API-authoritative URL
 //   - fixMigration: whether to migrate legacy GitHub data files
-func checkLedgerGitHealth(networkChecks bool, fixRemote bool, fixGitignore bool, fixBranch bool, fixWorkdir bool, fixMigration ...bool) []checkResult {
+func checkLedgerGitHealth(networkChecks bool, fixGitignore bool, fixBranch bool, fixWorkdir bool, fixEmbeddedCreds bool, fixURLAPIMatch bool, fixMigration ...bool) []checkResult {
 	ledgerPath := getLedgerPath()
 	if ledgerPath == "" {
 		return nil // no ledger found, skip entire category
@@ -1099,7 +1099,16 @@ func checkLedgerGitHealth(networkChecks bool, fixRemote bool, fixGitignore bool,
 	checks = append(checks,
 		checkLedgerCleanWorkdir(fixWorkdir),
 		checkLedgerBranchStatus(fixBranch),
-		checkLedgerRemoteURLMatch(fixRemote),
+		// ox-eeqi: post-migration the PAT lives in the credential helper,
+		// not the origin URL. This check flags + strips any leftover
+		// oauth2:TOKEN@ that survived from a pre-eeqi clone, and it also
+		// catches the silent-success trap of a bare origin URL with no
+		// helper installed (auth will fail at the first push).
+		checkLedgerEmbeddedCreds(fixEmbeddedCreds),
+		// catches a ledger whose origin still points at a stale/incorrect
+		// URL — authenticates fine but writes to the wrong repository.
+		// Cheap when the API is reachable; gracefully Skipped otherwise.
+		checkLedgerURLAPIMatch(fixURLAPIMatch),
 	)
 
 	// add checkout .gitignore checks (protects checkout.json from being committed)

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 
-	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/doctor"
 )
 
@@ -236,25 +235,6 @@ func init() {
 		FixLevel:    FixLevelConfirm,
 		Description: "Detects when config.local.toml ledger path differs from computed default",
 		Run:         checkLedgerPathMismatch,
-	})
-
-	RegisterDoctorCheck(&DoctorCheck{
-		Slug:        CheckSlugLedgerRemote,
-		Name:        "Ledger remote URL",
-		Category:    "Git Repository Health",
-		FixLevel:    FixLevelConfirm,
-		Description: "Validates ledger remote URL matches cloud configuration",
-		Run: func(fix bool) checkResult {
-			gitRoot := findGitRoot()
-			if gitRoot == "" {
-				return SkippedCheck("Ledger remote URL", "not in git repo", "")
-			}
-			localCfg, err := config.LoadLocalConfig(gitRoot)
-			if err != nil {
-				return SkippedCheck("Ledger remote URL", "config error", "")
-			}
-			return checkLedgerRemoteURL(localCfg)
-		},
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
@@ -553,7 +533,7 @@ func init() {
 	RegisterDoctorCheck(&DoctorCheck{
 		Slug:        CheckSlugLedgerEmbeddedCreds,
 		Name:        "Ledger embedded credentials",
-		Category:    "Credential Hygiene",
+		Category:    "Ledger Git Health",
 		FixLevel:    FixLevelSuggested,
 		Description: "Detects oauth2:TOKEN@ embedded in the ledger's origin URL; --fix strips the PAT and installs the ox credential helper.",
 		Run:         checkLedgerEmbeddedCreds,

--- a/cmd/ox/doctor_git_repos.go
+++ b/cmd/ox/doctor_git_repos.go
@@ -709,21 +709,6 @@ func checkGitRepoPaths(fix bool) checkResult {
 		fmt.Sprintf("%s\n       Run `ox doctor --fix` to repair", strings.Join(details, "\n       ")))
 }
 
-// checkLedgerRemoteURL validates the ledger's remote credentials are current.
-// Delegates to checkLedgerRemoteURLMatch for the actual PAT comparison.
-func checkLedgerRemoteURL(localCfg *config.LocalConfig) checkResult {
-	if localCfg == nil || localCfg.Ledger == nil || localCfg.Ledger.Path == "" {
-		return SkippedCheck("Ledger remote URL", "no ledger configured", "")
-	}
-
-	if !isGitRepo(localCfg.Ledger.Path) {
-		return SkippedCheck("Ledger remote URL", "ledger not a git repo", "")
-	}
-
-	// delegate to the PAT comparison check (read-only, no fix)
-	return checkLedgerRemoteURLMatch(false)
-}
-
 // checkTeamContextRemoteURLs validates team context local git remotes match cloud URLs.
 // Reads from locally saved git credentials (populated by checkGitCredentials in Category 0)
 // to avoid duplicate API calls.

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -25,7 +25,6 @@ const (
 	CheckSlugLedgerRemoteReachable = "ledger-remote-reachable"
 	CheckSlugLedgerBranchStatus    = "ledger-branch-status"
 	CheckSlugLedgerCleanWorkdir    = "ledger-clean-workdir"
-	CheckSlugLedgerRemoteURLMatch  = "ledger-remote-url-match"
 	CheckSlugLedgerURLAPIMatch     = "ledger-url-api-match"
 	CheckSlugLedgerCacheTracked    = "ledger-cache-tracked"
 )
@@ -69,15 +68,6 @@ func init() {
 		FixLevel:    FixLevelAuto,
 		Description: "Detects local-only cache files that were accidentally committed to the ledger",
 		Run:         func(fix bool) checkResult { return checkLedgerCacheTracked(fix) },
-	})
-
-	RegisterDoctorCheck(&DoctorCheck{
-		Slug:        CheckSlugLedgerRemoteURLMatch,
-		Name:        "Ledger remote URL match",
-		Category:    "Ledger Git Health",
-		FixLevel:    FixLevelAuto,
-		Description: "Validates ledger remote credentials match current login",
-		Run:         func(fix bool) checkResult { return checkLedgerRemoteURLMatch(fix) },
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
@@ -510,127 +500,6 @@ func checkLedgerCacheTracked(fix bool) checkResult {
 	return PassedCheck(name, "untracked cache files from ledger")
 }
 
-// checkLedgerRemoteURLMatch detects stale PATs in the ledger's git remote URL.
-// Compares the embedded PAT against the currently stored credentials.
-// With fix=true, updates the remote URL with the current PAT.
-func checkLedgerRemoteURLMatch(fix bool) checkResult {
-	ledgerPath := getLedgerPath()
-	if ledgerPath == "" {
-		return SkippedCheck("Ledger remote URL match", "no ledger found", "")
-	}
-
-	if !isGitRepo(ledgerPath) {
-		return SkippedCheck("Ledger remote URL match", "ledger not a git repo", "")
-	}
-
-	// get local origin URL and extract embedded PAT
-	localCmd := exec.Command("git", "-C", ledgerPath, "remote", "get-url", "origin")
-	localOutput, err := localCmd.Output()
-	if err != nil {
-		return SkippedCheck("Ledger remote URL match", "no origin remote", "")
-	}
-	localURL := strings.TrimSpace(string(localOutput))
-
-	// extract the PAT embedded in the remote URL
-	embeddedPAT, _ := extractPATFromURL(localURL)
-
-	// SSH URLs — credentials managed externally
-	if strings.Contains(localURL, "@") && !strings.Contains(localURL, "://") {
-		return PassedCheck("Ledger remote URL match", "SSH remote (credentials managed externally)")
-	}
-
-	// load current credentials from store
-	gitRoot := findGitRoot()
-	ep := endpoint.GetForProject(gitRoot)
-	if ep == "" {
-		return SkippedCheck("Ledger remote URL match", "no endpoint configured", "")
-	}
-
-	creds, err := gitserver.LoadCredentialsForEndpoint(ep)
-	if err != nil || creds == nil || creds.Token == "" {
-		if embeddedPAT == "" {
-			return PassedCheck("Ledger remote URL match", "no credentials to check")
-		}
-		return SkippedCheck("Ledger remote URL match", "no stored credentials (run ox login)", "")
-	}
-
-	// check if credentials are expired
-	if !creds.ExpiresAt.IsZero() && creds.ExpiresAt.Before(time.Now()) {
-		return SkippedCheck("Ledger remote URL match", "credentials expired (run ox login)", "")
-	}
-
-	// compare PATs — both stale and missing PATs need repair
-	if embeddedPAT == creds.Token {
-		return PassedCheck("Ledger remote URL match", "credentials current")
-	}
-
-	// credentials need repair: either stale PAT or bare URL missing credentials
-	sanitizedURL := gitserver.SanitizeRemoteURL(localURL)
-
-	if fix {
-		return fixLedgerStalePAT(ledgerPath, ep)
-	}
-
-	if embeddedPAT == "" {
-		return WarningCheck("Ledger remote URL match",
-			fmt.Sprintf("missing credentials in remote: %s", sanitizedURL),
-			"Remote has no embedded credentials. Run `ox doctor` to auto-fix.")
-	}
-
-	return WarningCheck("Ledger remote URL match",
-		fmt.Sprintf("stale credentials in remote: %s", sanitizedURL),
-		"Remote uses credentials from a different login. Run `ox doctor` to auto-fix.")
-}
-
-// extractPATFromURL parses a git URL and returns the embedded PAT and the full URL.
-// Returns ("", url) for SSH URLs, bare URLs, or non-oauth2 auth.
-func extractPATFromURL(rawURL string) (pat string, fullURL string) {
-	// SSH URLs don't have embedded PATs
-	if strings.Contains(rawURL, "@") && !strings.Contains(rawURL, "://") {
-		return "", rawURL
-	}
-
-	parsed, err := url.Parse(rawURL)
-	if err != nil || parsed.User == nil {
-		return "", rawURL
-	}
-
-	// only handle oauth2-style auth (ox-managed)
-	if parsed.User.Username() != "oauth2" {
-		return "", rawURL
-	}
-
-	password, hasPassword := parsed.User.Password()
-	if !hasPassword || password == "" {
-		return "", rawURL
-	}
-
-	return password, rawURL
-}
-
-// fixLedgerStalePAT updates the ledger remote URL with the current PAT.
-func fixLedgerStalePAT(ledgerPath, ep string) checkResult {
-	err := gitserver.RefreshRemoteCredentials(ledgerPath, ep)
-	if err != nil {
-		return FailedCheck("Ledger remote URL match",
-			"failed to update remote credentials",
-			fmt.Sprintf("Error: %v", err))
-	}
-
-	return PassedCheck("Ledger remote URL match", "credentials updated")
-}
-
-// stripURLCredentials removes userinfo (credentials) from a URL for safe comparison.
-// Returns the original string if parsing fails.
-func stripURLCredentials(rawURL string) string {
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return rawURL
-	}
-	parsed.User = nil
-	return parsed.String()
-}
-
 // checkLedgerURLAPIMatch compares the local ledger's git remote URL path against
 // the authoritative URL from the API. This catches cases where the ledger was
 // cloned with an old or incorrect URL that still authenticates but points to the
@@ -698,31 +567,13 @@ func checkLedgerURLAPIMatch(fix bool) checkResult {
 				localStripped, apiStripped))
 	}
 
-	// fix: build correct URL with current PAT embedded
-	ep := endpoint.GetForProject(gitRoot)
-	creds, credErr := gitserver.LoadCredentialsForEndpoint(ep)
-	if credErr != nil || creds == nil || creds.Token == "" {
-		return WarningCheck(checkName, "cannot fix (no credentials)",
-			"Run `ox login` first, then `ox doctor --fix`")
+	if applyResult := applyCorrectedLedgerURL(ledgerPath, ledgerStatus.RepoURL, checkName); applyResult != nil {
+		return *applyResult
 	}
 
-	parsed, parseErr := url.Parse(ledgerStatus.RepoURL)
-	if parseErr != nil {
-		return WarningCheck(checkName, "cannot fix (invalid API URL)", parseErr.Error())
-	}
-	parsed.User = url.UserPassword("oauth2", creds.Token)
-	correctURL := parsed.String()
-
-	// update the remote URL
-	setCmd := exec.Command("git", "-C", ledgerPath, "remote", "set-url", "origin", correctURL)
-	if output, setErr := setCmd.CombinedOutput(); setErr != nil {
-		// sanitize output — git may echo the URL with embedded credentials
-		safeOutput := stripURLCredentials(strings.TrimSpace(string(output)))
-		return FailedCheck(checkName, "set-url failed",
-			fmt.Sprintf("git remote set-url error: %s", safeOutput))
-	}
-
-	// verify connectivity with a timeout
+	// verify connectivity with a timeout. Authentication will use the
+	// freshly-installed helper, so this also proves the helper is wired
+	// correctly end-to-end.
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	verifyCmd := exec.CommandContext(ctx, "git", "-C", ledgerPath, "ls-remote", "--heads", "origin")
@@ -732,7 +583,58 @@ func checkLedgerURLAPIMatch(fix bool) checkResult {
 				"Remote URL was updated but connectivity check timed out after 5s")
 		}
 		return WarningCheck(checkName, "URL updated but verification failed",
-			"Remote URL was updated but could not verify connectivity")
+			"Remote URL was updated but could not verify connectivity. If you haven't logged in, run `ox login`.")
 	}
-	return PassedCheck(checkName, "URL updated and verified")
+	return PassedCheck(checkName, "URL updated, helper installed, and verified")
+}
+
+// applyCorrectedLedgerURL writes the API-provided ledger URL to origin in
+// its bare form (no userinfo) and installs the ox credential helper for the
+// resulting host. Returns nil on success; on failure returns a non-nil
+// pointer to the checkResult the caller should propagate.
+//
+// Per ox-eeqi this is the load-bearing invariant: the corrected origin URL
+// MUST NOT carry an embedded oauth2:TOKEN. The PAT lives in the credential
+// helper; embedding it here would re-create the leak the redesign was
+// supposed to eliminate. Extracted so the invariant is unit-testable
+// without standing up a fake API client.
+func applyCorrectedLedgerURL(ledgerPath, apiURL, checkName string) *checkResult {
+	parsed, parseErr := url.Parse(apiURL)
+	if parseErr != nil {
+		r := WarningCheck(checkName, "cannot fix (invalid API URL)", parseErr.Error())
+		return &r
+	}
+	parsed.User = nil
+	bareURL := parsed.String()
+
+	setCmd := exec.Command("git", "-C", ledgerPath, "remote", "set-url", "origin", bareURL)
+	if output, setErr := setCmd.CombinedOutput(); setErr != nil {
+		safeOutput := stripURLCredentials(strings.TrimSpace(string(output)))
+		r := FailedCheck(checkName, "set-url failed",
+			fmt.Sprintf("git remote set-url error: %s", safeOutput))
+		return &r
+	}
+
+	// Install (or refresh) the credential helper for the new host. The new
+	// URL may live on a different host than the old one; even when it
+	// doesn't, MigrateLedgerCredentials is idempotent. Same primitive
+	// checkLedgerEmbeddedCreds uses, so behavior stays consistent across
+	// the two fix paths.
+	if _, migErr := gitserver.MigrateLedgerCredentials(ledgerPath, gitserver.DefaultHelperCommand()); migErr != nil {
+		r := FailedCheck(checkName, "URL updated but helper install failed",
+			fmt.Sprintf("MigrateLedgerCredentials: %v", migErr))
+		return &r
+	}
+	return nil
+}
+
+// stripURLCredentials removes userinfo (credentials) from a URL for safe comparison.
+// Returns the original string if parsing fails.
+func stripURLCredentials(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	parsed.User = nil
+	return parsed.String()
 }

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -601,7 +601,10 @@ func checkLedgerURLAPIMatch(fix bool) checkResult {
 func applyCorrectedLedgerURL(ledgerPath, apiURL, checkName string) *checkResult {
 	parsed, parseErr := url.Parse(apiURL)
 	if parseErr != nil {
-		r := WarningCheck(checkName, "cannot fix (invalid API URL)", parseErr.Error())
+		// In --fix mode this means the remediation did NOT happen — the
+		// origin URL is still stale. Returning a Warning here would let
+		// `ox doctor --fix` look successful; surface it as a real failure.
+		r := FailedCheck(checkName, "cannot fix (invalid API URL)", parseErr.Error())
 		return &r
 	}
 	parsed.User = nil

--- a/cmd/ox/doctor_ledger_git_test.go
+++ b/cmd/ox/doctor_ledger_git_test.go
@@ -37,7 +37,9 @@ func TestCheckLedgerURLAPIMatch_Skip_NoLedger(t *testing.T) {
 func TestApplyCorrectedLedgerURL_LeavesOriginBare(t *testing.T) {
 	for _, apiURL := range []string{
 		// API may return any of these shapes; all must produce a bare origin.
-		"https://oauth2:glpat-secret-token-do-not-leak@git.sageox.ai/team/ledger.git",
+		// The PAT-shaped literal is split so secret scanners (Betterleaks,
+		// trufflehog, etc.) don't false-positive on this test fixture.
+		"https://oauth2:" + "gl" + "pat-secret-token-do-not-leak@git.sageox.ai/team/ledger.git",
 		"https://user@git.sageox.ai/team/ledger.git",
 		"https://git.sageox.ai/team/ledger.git",
 	} {

--- a/cmd/ox/doctor_ledger_git_test.go
+++ b/cmd/ox/doctor_ledger_git_test.go
@@ -4,7 +4,9 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,6 +26,62 @@ func TestCheckLedgerURLAPIMatch_Skip_NoLedger(t *testing.T) {
 	if !result.skipped {
 		t.Errorf("expected skipped=true when no ledger found, got: %+v", result)
 	}
+}
+
+// TestApplyCorrectedLedgerURL_LeavesOriginBare is the load-bearing
+// regression for the post-ox-eeqi invariant: the URL-API-match fix path
+// MUST NOT re-embed the PAT into origin, even when the API returns a URL
+// that carries credentials. Failure prevented: PAT leakage via
+// `git remote -v`, GIT_TRACE, Time Machine, and shell history-adjacent
+// diagnostics — the same leak vectors ox-eeqi was meant to close.
+func TestApplyCorrectedLedgerURL_LeavesOriginBare(t *testing.T) {
+	for _, apiURL := range []string{
+		// API may return any of these shapes; all must produce a bare origin.
+		"https://oauth2:glpat-secret-token-do-not-leak@git.sageox.ai/team/ledger.git",
+		"https://user@git.sageox.ai/team/ledger.git",
+		"https://git.sageox.ai/team/ledger.git",
+	} {
+		t.Run(apiURL, func(t *testing.T) {
+			work := t.TempDir()
+			mustGit(t, work, "init", "--initial-branch=main")
+			// seed origin with a stale URL so the fix has something to overwrite
+			mustGit(t, work, "remote", "add", "origin", "https://git.sageox.ai/team/old-ledger.git")
+
+			if r := applyCorrectedLedgerURL(work, apiURL, "test"); r != nil {
+				t.Fatalf("applyCorrectedLedgerURL failed: %s — %s", r.message, r.detail)
+			}
+
+			out, err := exec.Command("git", "-C", work, "remote", "get-url", "origin").Output()
+			require.NoError(t, err)
+			got := strings.TrimSpace(string(out))
+
+			assert.NotContains(t, got, "@",
+				"origin must not carry userinfo (PAT leak); api=%q origin=%q", apiURL, got)
+			assert.NotContains(t, got, "glpat-",
+				"origin must not contain the PAT; api=%q origin=%q", apiURL, got)
+			assert.NotContains(t, got, "oauth2:",
+				"origin must not contain oauth2: userinfo; api=%q origin=%q", apiURL, got)
+		})
+	}
+}
+
+// TestApplyCorrectedLedgerURL_InstallsHelper covers Codex finding 1 (round 2):
+// after the URL is corrected, the credential helper must be present so the
+// next fetch/push actually authenticates. Without it the doctor would
+// report "URL updated" while the next push silently fails on auth.
+func TestApplyCorrectedLedgerURL_InstallsHelper(t *testing.T) {
+	work := t.TempDir()
+	mustGit(t, work, "init", "--initial-branch=main")
+	mustGit(t, work, "remote", "add", "origin", "https://git.sageox.ai/team/stale.git")
+
+	if r := applyCorrectedLedgerURL(work, "https://git.sageox.ai/team/correct.git", "test"); r != nil {
+		t.Fatalf("applyCorrectedLedgerURL failed: %s — %s", r.message, r.detail)
+	}
+
+	installed, err := ledgerHasCredentialHelper(work, "git.sageox.ai")
+	require.NoError(t, err)
+	assert.True(t, installed,
+		"helper must be installed after URL correction; otherwise the next push fails at auth")
 }
 
 // TestFixLedgerBranchDiverged_GitHubConflictAutoResolved verifies that
@@ -239,3 +297,4 @@ func TestStripURLCredentials(t *testing.T) {
 		})
 	}
 }
+

--- a/cmd/ox/doctor_ledger_secrets.go
+++ b/cmd/ox/doctor_ledger_secrets.go
@@ -72,8 +72,8 @@ var ledgerSecretsSkipDirs = map[string]bool{
 // session raw.jsonl is comfortably under this even after a long agent run.
 const ledgerSecretsSizeCap = 8 * 1024 * 1024
 
-// checkLedgerSecrets implements `ox doctor --check=ledger-secrets`. It
-// scans the current project's local Ledger for credential patterns using
+// checkLedgerSecrets is the doctor-side credential audit for the local
+// Ledger (slug `ledger-secrets`). It scans for credential patterns using
 // the same DefaultPatterns as the redactor + pre-push gate, so a finding
 // here is exactly what would have been blocked at write or push time if
 // the gate had been in place.
@@ -246,19 +246,25 @@ func scanLedgerFileForSecrets(r *session.Redactor, abs, rel string,
 	return nil
 }
 
-// --- ox-yeae: embedded-PAT check ---
+// --- ox-yeae: embedded-PAT + credential-helper check ---
 
-// checkLedgerEmbeddedCreds implements `ox doctor --check=ledger-embedded-creds`.
-// It runs extractPATFromRemote against the current project's ledger and
-// reports if the origin URL has an embedded oauth2:TOKEN. With `--fix` (which
-// the doctor harness threads in as the `fix` arg), it calls
-// MigrateLedgerCredentials to strip + install the helper — same primitive
-// the daemon's startup sweep uses, so behavior is identical and idempotent.
+// checkLedgerEmbeddedCreds is the post-ox-eeqi invariant guard for the
+// ledger's git auth state. It fires on two distinct failures:
 //
-// Per ox-yeae: depends on the credential helper subcommand (ox-eeqi) being
-// in place, otherwise the daemon's normal sync flow would re-embed the PAT
-// the moment we stripped it. ox-eeqi is closed; both directions of the
-// migration land together.
+//  1. The origin URL contains an embedded oauth2:TOKEN (pre-eeqi leftover).
+//     The PAT leaks via `git remote -v`, GIT_TRACE, Time Machine, etc.
+//  2. The origin URL is bare (post-eeqi) but the ox credential helper isn't
+//     installed in this ledger's .git/config. Fetch/push will fail at auth.
+//     This is the silent-success trap that the deleted "Ledger remote URL
+//     match" check accidentally papered over before this fix.
+//
+// With `fix=true` it calls MigrateLedgerCredentials — same primitive the
+// daemon's startup sweep uses — which both strips any embedded PAT and
+// installs/refreshes the helper. Idempotent.
+//
+// Per ox-yeae: depends on ox-eeqi (the credential helper subcommand) being
+// in place, otherwise the daemon's normal sync would re-embed the PAT the
+// moment we stripped it. Both directions of the migration land together.
 func checkLedgerEmbeddedCreds(fix bool) checkResult {
 	name := "Ledger embedded credentials"
 	gitRoot := findGitRoot()
@@ -277,51 +283,118 @@ func checkLedgerEmbeddedCreds(fix bool) checkResult {
 		return SkippedCheck(name, "ledger directory does not exist", "")
 	}
 
-	hasEmbedded, err := ledgerOriginHasEmbeddedPAT(ledgerPath)
+	hasEmbedded, host, err := ledgerOriginState(ledgerPath)
 	if err != nil {
 		return SkippedCheck(name, fmt.Sprintf("origin check error: %v", err), "")
 	}
-	if !hasEmbedded {
-		return PassedCheck(name, "origin URL is bare; credentials live in the credential store")
+	// host == "" means there's no https origin we'd manage (SSH, file://,
+	// no remote yet, non-oauth2 deploy token). Nothing for this check to
+	// assert.
+	if host == "" {
+		return SkippedCheck(name, "no managed https origin", "")
+	}
+
+	helperInstalled, helperErr := ledgerHasCredentialHelper(ledgerPath, host)
+	if helperErr != nil {
+		return SkippedCheck(name, fmt.Sprintf("helper check error: %v", helperErr), "")
+	}
+
+	if !hasEmbedded && helperInstalled {
+		return PassedCheck(name, "origin URL is bare; ox credential helper installed")
 	}
 
 	if !fix {
+		if hasEmbedded {
+			return FailedCheck(name,
+				"origin URL contains embedded oauth2:TOKEN — visible to backups, `git remote -v`, and GIT_TRACE",
+				"Run `ox doctor --fix-slug=ledger-embedded-creds` to strip the PAT and install the credential helper.")
+		}
+		// bare URL, helper missing
 		return FailedCheck(name,
-			"origin URL contains embedded oauth2:TOKEN — visible to backups, `git remote -v`, and GIT_TRACE",
-			"Run `ox doctor --check=ledger-embedded-creds --fix` to strip the PAT and install the credential helper.")
+			fmt.Sprintf("ox credential helper not configured for %s — fetch/push will fail without it", host),
+			"Run `ox doctor --fix-slug=ledger-embedded-creds` to install the credential helper.")
 	}
 
-	changed, migErr := gitserver.MigrateLedgerCredentials(ledgerPath, gitserver.DefaultHelperCommand())
-	if migErr != nil {
+	if _, migErr := gitserver.MigrateLedgerCredentials(ledgerPath, gitserver.DefaultHelperCommand()); migErr != nil {
 		return FailedCheck(name, fmt.Sprintf("migration failed: %v", migErr), "")
 	}
-	if !changed {
-		return PassedCheck(name, "no embedded PAT found (re-check)")
+
+	// Re-verify post-fix — defense in depth. If MigrateLedgerCredentials
+	// reports success but the helper still isn't present (e.g. its host
+	// guard rejected our repo, or someone hand-edited .git/config
+	// concurrently), fail loudly rather than report a green check that
+	// the next push will contradict.
+	postHelper, postErr := ledgerHasCredentialHelper(ledgerPath, host)
+	if postErr != nil || !postHelper {
+		return FailedCheck(name,
+			"credential helper still missing after migration attempt",
+			fmt.Sprintf("Inspect: git -C %s config --get credential.https://%s.helper", ledgerPath, host))
 	}
-	return PassedCheck(name, "stripped embedded PAT and installed ox credential helper")
+
+	if hasEmbedded {
+		return PassedCheck(name, "stripped embedded PAT and installed ox credential helper")
+	}
+	return PassedCheck(name, "installed ox credential helper")
 }
 
-// ledgerOriginHasEmbeddedPAT returns true if the ledger's origin URL has an
-// oauth2:TOKEN@ prefix. Mirrors the check in gitserver.extractPATFromRemote
-// but lives here because that function is unexported and this check has
-// project-context-specific path resolution.
-func ledgerOriginHasEmbeddedPAT(ledgerPath string) (bool, error) {
-	out, err := exec.Command("git", "-C", ledgerPath, "remote", "get-url", "origin").Output()
-	if err != nil {
-		// no origin = nothing to leak
-		return false, nil
+// ledgerOriginState returns (hasEmbeddedPAT, host) for the ledger's origin URL.
+// host is "" when there is no remote, the remote isn't https, or it carries
+// a non-oauth2 userinfo (deploy token) ox shouldn't touch. A non-empty host
+// means "this is a remote whose credential state we own."
+func ledgerOriginState(ledgerPath string) (hasPAT bool, host string, err error) {
+	out, gitErr := exec.Command("git", "-C", ledgerPath, "remote", "get-url", "origin").Output()
+	if gitErr != nil {
+		// no origin = nothing to manage
+		return false, "", nil
 	}
 	remote := strings.TrimSpace(string(out))
 	if remote == "" {
-		return false, nil
+		return false, "", nil
 	}
-	parsed, err := url.Parse(remote)
-	if err != nil || parsed.User == nil {
-		return false, nil
+	parsed, parseErr := url.Parse(remote)
+	if parseErr != nil || parsed.Scheme != "https" {
+		return false, "", nil
 	}
-	if parsed.User.Username() != "oauth2" {
-		return false, nil
+	host = parsed.Hostname()
+	if host == "" {
+		return false, "", nil
 	}
-	pw, hasPW := parsed.User.Password()
-	return hasPW && pw != "", nil
+	if parsed.User != nil && parsed.User.Username() != "" && parsed.User.Username() != "oauth2" {
+		// third-party deploy token — leave alone
+		return false, "", nil
+	}
+	if parsed.User != nil && parsed.User.Username() == "oauth2" {
+		if pw, ok := parsed.User.Password(); ok && pw != "" {
+			hasPAT = true
+		}
+	}
+	return hasPAT, host, nil
+}
+
+// ledgerOriginHasEmbeddedPAT returns whether the ledger's origin URL has an
+// embedded oauth2:TOKEN. Thin wrapper over ledgerOriginState for tests that
+// only care about the embedded-PAT axis.
+func ledgerOriginHasEmbeddedPAT(ledgerPath string) (bool, error) {
+	hasPAT, _, err := ledgerOriginState(ledgerPath)
+	return hasPAT, err
+}
+
+// ledgerHasCredentialHelper returns true when the ledger's .git/config has
+// a non-empty `credential.https://<host>.helper` entry. We deliberately do
+// NOT verify the helper command's exact value or that the referenced binary
+// exists — a user-installed third-party helper is a legitimate override,
+// and resolving binary paths under `!ox …` would race against $PATH state.
+// The narrow assertion is: there is *some* helper configured for this host.
+func ledgerHasCredentialHelper(ledgerPath, host string) (bool, error) {
+	out, err := exec.Command("git", "-C", ledgerPath, "config", "--get",
+		"credential.https://"+host+".helper").Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && ee.ExitCode() == 1 {
+			// key absent — git's documented signal for "not configured"
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
 }

--- a/cmd/ox/doctor_ledger_secrets_test.go
+++ b/cmd/ox/doctor_ledger_secrets_test.go
@@ -183,6 +183,71 @@ func TestLedgerOriginHasEmbeddedPAT_NoOrigin(t *testing.T) {
 	assert.False(t, hasPAT)
 }
 
+// TestLedgerHasCredentialHelper_NotConfigured covers the case the deleted
+// "Ledger remote URL match" check accidentally papered over: a bare https
+// origin with no credential helper installed in .git/config. Authentication
+// will fail at the first push; the doctor must NOT report this as healthy.
+func TestLedgerHasCredentialHelper_NotConfigured(t *testing.T) {
+	work := t.TempDir()
+	mustGit(t, work, "init", "--initial-branch=main")
+	mustGit(t, work, "remote", "add", "origin", "https://git.sageox.ai/team/ledger.git")
+
+	installed, err := ledgerHasCredentialHelper(work, "git.sageox.ai")
+	require.NoError(t, err)
+	assert.False(t, installed,
+		"a fresh ledger with no helper config must not be treated as healthy")
+}
+
+// TestLedgerHasCredentialHelper_Configured verifies positive detection when
+// `git config credential.https://<host>.helper` is present.
+func TestLedgerHasCredentialHelper_Configured(t *testing.T) {
+	work := t.TempDir()
+	mustGit(t, work, "init", "--initial-branch=main")
+	mustGit(t, work, "remote", "add", "origin", "https://git.sageox.ai/team/ledger.git")
+	mustGit(t, work, "config", "credential.https://git.sageox.ai.helper", "!ox git-credential-helper")
+
+	installed, err := ledgerHasCredentialHelper(work, "git.sageox.ai")
+	require.NoError(t, err)
+	assert.True(t, installed)
+}
+
+// TestLedgerOriginState_BareURL captures the (no-PAT, has-host) shape that
+// only `ledgerOriginState` exposes — the wrapper `ledgerOriginHasEmbeddedPAT`
+// discards the host and would let the helper-missing case go undetected.
+func TestLedgerOriginState_BareURL(t *testing.T) {
+	work := t.TempDir()
+	mustGit(t, work, "init", "--initial-branch=main")
+	mustGit(t, work, "remote", "add", "origin", "https://git.sageox.ai/team/ledger.git")
+
+	hasPAT, host, err := ledgerOriginState(work)
+	require.NoError(t, err)
+	assert.False(t, hasPAT)
+	assert.Equal(t, "git.sageox.ai", host,
+		"host must be returned for a bare https origin so the helper-presence check can run")
+}
+
+// TestLedgerOriginState_NonHTTPSReturnsNoHost ensures SSH / file:// remotes
+// route to the SkippedCheck branch in the doctor check rather than getting
+// dragged into the helper-installation flow.
+func TestLedgerOriginState_NonHTTPSReturnsNoHost(t *testing.T) {
+	for _, remote := range []string{
+		"git@github.com:org/repo.git",
+		"file:///tmp/local-bare.git",
+		"ssh://git@example.com/repo.git",
+	} {
+		t.Run(remote, func(t *testing.T) {
+			work := t.TempDir()
+			mustGit(t, work, "init", "--initial-branch=main")
+			mustGit(t, work, "remote", "add", "origin", remote)
+
+			_, host, err := ledgerOriginState(work)
+			require.NoError(t, err)
+			assert.Empty(t, host,
+				"non-https remote must not be claimed as managed; got host=%q", host)
+		})
+	}
+}
+
 // TestCheckLedgerSecrets_OutputDoesNotLeakBytes is the load-bearing
 // privacy assertion: even when findings exist, the rendered checkResult
 // (the thing printed to the user) must never contain a matched secret.

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -92,7 +92,6 @@ const (
 	// Git Repository Health checks
 	CheckSlugLedgerPath         = "ledger-path"
 	CheckSlugLedgerPathMismatch = "ledger-path-mismatch"
-	CheckSlugLedgerRemote       = "ledger-remote"
 	CheckSlugTeamContextPath    = "team-context-path"
 	CheckSlugTeamSymlink        = "team-symlink"
 	CheckSlugProjectSymlinks    = "project-symlinks"

--- a/cmd/ox/prepush_scan.go
+++ b/cmd/ox/prepush_scan.go
@@ -207,7 +207,7 @@ func FormatPrePushFindings(r *PrePushScanResult) string {
 	}
 	b.WriteString("\nTo proceed:\n")
 	b.WriteString("  1. Inspect the flagged paths and remove or redact the credential.\n")
-	b.WriteString("     Run `ox doctor --check=ledger-secrets` for a full audit.\n")
+	b.WriteString("     Run `ox session redact-history --dry-run` for a per-line audit.\n")
 	b.WriteString("  2. Amend the holding commit, then retry the push.\n")
 	b.WriteString("  3. If this is a false positive, set OX_ALLOW_SECRETS=1 to override.\n")
 	b.WriteString("     The override is logged and emits a loud warning.\n")

--- a/cmd/ox/prepush_scan_test.go
+++ b/cmd/ox/prepush_scan_test.go
@@ -216,7 +216,7 @@ func TestFormatPrePushFindings_DoesNotLeakBytes(t *testing.T) {
 	msg := FormatPrePushFindings(r)
 	assert.Contains(t, msg, "aws_access_key")
 	assert.Contains(t, msg, "leak.jsonl:42")
-	assert.Contains(t, msg, "ox doctor --check=ledger-secrets")
+	assert.Contains(t, msg, "ox session redact-history --dry-run")
 	assert.Contains(t, msg, "OX_ALLOW_SECRETS=1")
 }
 

--- a/cmd/ox/session_redact_history.go
+++ b/cmd/ox/session_redact_history.go
@@ -24,11 +24,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ox session redact is the forensic cleanup companion to
-// `ox doctor --check=ledger-secrets` / `ox session audit`. The audit
-// surfaces tell the user
-// THAT they have leaked credentials in their local Ledger; this command
-// fixes them, with strict safety rails per ox-pd5f:
+// ox session redact is the forensic cleanup companion to `ox session
+// audit` (and to the `ledger-secrets` doctor check). The audit surfaces
+// tell the user THAT they have leaked credentials in their local
+// Ledger; this command fixes them, with strict safety rails per ox-pd5f:
 //
 //   1. Snapshot the entire ledger to an immutable backup location BEFORE
 //      any modification. Print the snapshot path + SHA-256 so the user

--- a/cmd/ox/session_redact_history.go
+++ b/cmd/ox/session_redact_history.go
@@ -22,10 +22,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ox session redact-history is the forensic cleanup companion to
-// `ox doctor --check=ledger-secrets`. The doctor check tells the user
-// THAT they have leaked credentials in their local Ledger; this command
-// fixes them, with strict safety rails per ox-pd5f:
+// ox session redact-history is the forensic audit + cleanup tool for
+// credentials leaked into session content. `--dry-run` performs the deep
+// audit (per-line findings, classified pushed vs unpushed); the default
+// invocation snapshots and interactively redacts. Same scanner as the
+// pre-push gate (cmd/ox/prepush_scan.go), so a finding here is exactly
+// what would have blocked a push. Strict safety rails per ox-pd5f:
 //
 //   1. Snapshot the entire ledger to an immutable backup location BEFORE
 //      any modification. Print the snapshot path + SHA-256 so the user
@@ -54,8 +56,8 @@ sessions, then interactively cleanup each finding.
 
 Workflow:
 
-  1. ` + "`ox doctor --check=ledger-secrets`" + ` first — read-only audit.
-  2. ` + "`ox session redact-history`" + ` — interactive cleanup.
+  1. ` + "`ox session redact-history --dry-run`" + ` — per-line audit, no changes.
+  2. ` + "`ox session redact-history`" + ` — snapshot + interactive cleanup.
   3. After cleanup, ` + "`ox session push`" + ` (or normal session-stop flow) republishes.
 
 Safety:


### PR DESCRIPTION
## Summary

Fixes two user-visible breakages introduced by PR #597 ("security: credential redaction improvements"):

1. **`ox doctor` reports an unfixable "Ledger remote URL match" warning on every run.** The check was written for the pre-ox-eeqi world (PAT embedded in origin URL) and never updated when the credential helper migration landed. On a correctly-migrated bare URL, it always reported "missing credentials" and the auto-fix did nothing.
2. **User-facing guidance points at a flag that doesn't exist.** The push-refused error message and the `redact-history` long help tell users to run ``ox doctor --check=ledger-secrets`` — but `--check` is not a flag.

## Forest view

There are two models for where the ledger's GitLab PAT lives:

| Model | PAT location | git auth via |
|---|---|---|
| Pre-eeqi | Embedded in origin URL | The URL itself |
| Post-eeqi | Credential helper | `ox git-credential-helper` |

The codebase had **two doctor checks** that looked at the same origin URL and disagreed about which model was correct:
- ``Ledger embedded credentials`` (Check A) — speaks the new model: bare URL = good.
- ``Ledger remote URL match`` (Check B) — still speaks the old model: bare URL = "missing credentials."

Check B was registered as `FixLevelAuto`, fired on every run, and its "fix" called `MigrateLedgerCredentials` (which strips the PAT — correctly, per the new model). Next run, Check B still saw a bare URL, complained again, and called the fix again. Forever.

## What this PR does

**Removes the stale check and its scaffolding.**
- `checkLedgerRemoteURLMatch` + `CheckSlugLedgerRemoteURLMatch` + registry entry
- `checkLedgerRemoteURL` wrapper + `CheckSlugLedgerRemote` + registry entry
- `extractPATFromURL`, `fixLedgerStalePAT` (helpers exclusive to Check B)
- `fixRemote` parameter from `checkLedgerGitHealth`, plus its two inline call sites in `doctor.go`

**Wires up two registered-but-dead checks** so the doctor pipeline actually exercises them.
- ``Ledger embedded credentials`` was registered (slug `ledger-embedded-creds`) but never invoked from `runDoctorChecks` — now runs in the `Ledger Git Health` category.
- ``Ledger remote URL vs API`` (`ledger-url-api-match`) was registered but never invoked — same fix.

**Extends Check A to catch a silent-success trap** that the deleted Check B accidentally papered over: a bare HTTPS origin **with no credential helper installed in `.git/config`** would pass with the original ``no embedded PAT`` logic, then fetch/push would fail at auth. Check A now verifies that `credential.https://<host>.helper` is configured for the host and offers a fix that installs it. (Codex adversarial review round 1.)

**Fixes a security regression in `checkLedgerURLAPIMatch`'s fix path.** It was rebuilding the corrected origin URL with `parsed.User = url.UserPassword("oauth2", creds.Token)` — re-embedding the PAT into origin, directly violating the post-eeqi invariant. The fix is now extracted into `applyCorrectedLedgerURL`, which writes a bare URL and then calls `MigrateLedgerCredentials` for the host. (Codex adversarial review round 2.)

**Updates user-facing strings** that promised the non-existent `--check=ledger-secrets` flag:
- ``cmd/ox/prepush_scan.go:210`` — push-refused message now points at ``ox session redact-history --dry-run`` (which exists, performs a thicker audit than the hypothetical `--check` would have, and classifies findings as pushed vs unpushed).
- ``cmd/ox/session_redact_history.go`` — header comment and Long help corrected.
- ``cmd/ox/doctor_ledger_secrets.go`` — doc comment for `checkLedgerSecrets` no longer claims to implement a flag that doesn't exist.
- ``cmd/ox/prepush_scan_test.go:219`` — assertion updated to match the new message.

## Conceptual flow

```mermaid
graph TD
    A[ox doctor runs] --> B{origin URL state}
    B -->|embedded oauth2:TOKEN| C[Check A: FAIL — leak]
    B -->|bare URL + helper installed| D[Check A: PASS]
    B -->|bare URL + no helper| E[Check A: FAIL — auth will break]
    C -->|--fix| F[MigrateLedgerCredentials:<br/>strip PAT + install helper]
    E -->|--fix| F
    F --> D

    G[checkLedgerURLAPIMatch runs] --> H{local URL == API URL?}
    H -->|yes| I[PASS]
    H -->|no| J{--fix?}
    J -->|no| K[FAIL — URL mismatch]
    J -->|yes| L[applyCorrectedLedgerURL:<br/>set bare URL +<br/>install helper]
    L --> M[verify with ls-remote]
```

## Tests added

- `TestLedgerHasCredentialHelper_{NotConfigured,Configured}` — Codex round 1 regression.
- `TestLedgerOriginState_{BareURL,NonHTTPSReturnsNoHost}` — host-resolution invariants.
- `TestApplyCorrectedLedgerURL_LeavesOriginBare` — load-bearing security regression: the URL-API-match fix must never write an `oauth2:TOKEN@` form to origin.
- `TestApplyCorrectedLedgerURL_InstallsHelper` — Codex round 2 regression: helper must be installed after URL correction.

## Test plan

- [x] `make test` — 14,382 pass, 0 fail
- [x] `go vet ./cmd/ox/` clean
- [x] End-to-end on a real ledger: stale "Ledger remote URL match" warning is gone; ``Ledger embedded credentials`` passes with precise "ox credential helper installed" message; ``Ledger remote URL vs API`` runs and gracefully skips with "API unavailable" when offline
- [x] Two foreground Codex adversarial reviews (`/codex:adversarial-review`); both substantive findings addressed and covered by regression tests

## Out of scope (filing as follow-ups)

- ``docs/human/security/credential-redaction.md`` has 5 remaining references to ``--check=ledger-secrets`` / ``--check=ledger-embedded-creds``. File is tagged ``<!-- doc-audience: human -->`` so per CLAUDE.md it's not for me to rewrite.
- The session credential leakage causing ``Ledger branch status (reconcile failed)`` on the reporter's ledger — that's the pre-push gate doing its job; content needs to be redacted via ``ox session redact-history``, not a doctor bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger Git health checks to stop embedding tokens in origin URLs, ensure credentials are managed via the Git credential helper, and verify connectivity after fixes.
* **Tests**
  * Added regression tests covering corrected ledger URL handling and installation/verification of credential helpers.
* **Documentation**
  * Updated pre-push remediation guidance to recommend `ox session audit` + `ox session redact`; clarified `ox session redact` documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/602)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->