### PR TITLE
fix(prepush): never-block credential gate — scope to sessions/, auto-redact JSONL, quarantine the rest (0.8.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.8.0"
+      "version": "0.8.1"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -539,6 +539,19 @@ func init() {
 		Run:         checkLedgerEmbeddedCreds,
 	})
 
+	// ox-y3ok: surface sessions that the pre-push secret gate
+	// auto-quarantined because it couldn't auto-redact them. Read-only;
+	// recovery is user-driven (interactive `ox session redact` or
+	// manual scrub + restore from .sageox/cache/quarantine/).
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugLedgerRedactionDebt,
+		Name:        "Ledger redaction debt",
+		Category:    "Credential Hygiene",
+		FixLevel:    FixLevelCheckOnly,
+		Description: "Surfaces sessions quarantined by the pre-push secret gate (preserved under .sageox/cache/quarantine/, dropped from pushes until redacted).",
+		Run:         checkLedgerRedactionDebt,
+	})
+
 	// ox-9y4k: scan installed adapter hook content for known-suspicious
 	// shapes that have no legitimate use in a commit/prompt hook.
 	RegisterDoctorCheck(&DoctorCheck{

--- a/cmd/ox/doctor_redaction_debt.go
+++ b/cmd/ox/doctor_redaction_debt.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ledger"
+)
+
+// checkLedgerRedactionDebt surfaces sessions that the pre-push secret
+// gate auto-quarantined because it could not redact them through the
+// canonical chokepoint. See cmd/ox/prepush_autoredact.go for the
+// quarantine pipeline: bytes are moved to
+// <ledger>/.sageox/cache/quarantine/<session>/<file> and a JSON marker
+// is written under <ledger>/.sageox/cache/redaction-debt/<session>.json.
+//
+// This check is read-only and local-only. It does not re-scan content;
+// the markers are authoritative — they were produced by a fresh scan at
+// quarantine time. If the user manually moves a quarantined file back
+// to its in-place ledger path or removes the marker, the check
+// gracefully reflects the new state.
+//
+// --fix is intentionally a no-op: the recovery action is either
+// `ox session redact <session>` (interactive cleanup) or the user
+// manually moving the quarantined file back. The doctor command cannot
+// safely choose between those for the user; it surfaces the state and
+// gets out of the way.
+func checkLedgerRedactionDebt(fix bool) checkResult {
+	name := "Ledger redaction debt"
+	_ = fix // recovery is intentionally user-driven; see doc above.
+
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(name, "not in git repo", "")
+	}
+	localCfg, err := config.LoadLocalConfig(gitRoot)
+	if err != nil {
+		return SkippedCheck(name, "config error", "")
+	}
+	ledgerPath := resolveLedgerPathForAudit(localCfg)
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger configured", "")
+	}
+	if !ledger.Exists(ledgerPath) {
+		return SkippedCheck(name, "ledger directory does not exist", "")
+	}
+
+	debtDir := filepath.Join(ledgerPath, ".sageox", "cache", "redaction-debt")
+	if _, err := os.Stat(debtDir); err != nil {
+		if os.IsNotExist(err) {
+			return PassedCheck(name, "no quarantined sessions")
+		}
+		return FailedCheck(name, fmt.Sprintf("stat debt dir: %v", err), "")
+	}
+	summaries, malformed := readDebtSummaries(debtDir)
+
+	if len(summaries) == 0 && len(malformed) == 0 {
+		return PassedCheck(name, "no quarantined sessions")
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d session(s) quarantined; bytes preserved under .sageox/cache/quarantine/",
+		len(summaries))
+	if len(malformed) > 0 {
+		fmt.Fprintf(&b, "; %d marker(s) unreadable", len(malformed))
+	}
+	msg := b.String()
+
+	var detail strings.Builder
+	for _, s := range summaries {
+		fmt.Fprintf(&detail, "  %s — %d finding(s) across %d file(s); detectors: %s\n",
+			s.session, s.findings, s.files, strings.Join(s.detectors, ", "))
+	}
+	detail.WriteString("\nNext steps for each session:\n")
+	detail.WriteString("  1. Inspect bytes at .sageox/cache/quarantine/<session>/\n")
+	detail.WriteString("  2. Run `ox session redact <session>` for interactive cleanup, OR\n")
+	detail.WriteString("     manually scrub the file and move it back to sessions/<session>/\n")
+	detail.WriteString("  3. Re-stage and commit; the next push will publish the cleaned bytes\n")
+	if len(malformed) > 0 {
+		detail.WriteString("\nUnreadable markers (remove and re-run if no quarantined bytes exist):\n")
+		for _, m := range malformed {
+			fmt.Fprintf(&detail, "  .sageox/cache/redaction-debt/%s\n", m)
+		}
+	}
+
+	// Use WarningCheck (passed=true, warning=true) rather than
+	// FailedCheck — debt is a state the user opted into by attempting to
+	// push something the gate couldn't clean, and the system already
+	// handled it gracefully (rest of push proceeded). Doctor shouldn't
+	// treat this as an error; it's a reminder.
+	return WarningCheck(name, msg, detail.String())
+}
+
+// debtSummary is the per-marker shape produced by readDebtSummaries.
+// Aggregates the parts of redactionDebtRecord the doctor surface uses;
+// hides the full record from the caller (markers carry filenames and
+// line numbers, never matched bytes — ox-zyg7).
+type debtSummary struct {
+	session   string
+	marker    string
+	findings  int
+	files     int
+	detectors []string
+}
+
+// readDebtSummaries walks debtDir and parses every *.json marker into
+// a debtSummary. Returns (summaries, malformed) — malformed lists
+// filenames whose contents could not be parsed as a redactionDebtRecord.
+// Separated from checkLedgerRedactionDebt so a unit test can exercise
+// the parse + aggregation logic without needing a full project /
+// ledger-config harness.
+func readDebtSummaries(debtDir string) (summaries []debtSummary, malformed []string) {
+	entries, err := os.ReadDir(debtDir)
+	if err != nil {
+		return nil, nil
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		markerAbs := filepath.Join(debtDir, entry.Name())
+		buf, err := os.ReadFile(markerAbs)
+		if err != nil {
+			malformed = append(malformed, entry.Name())
+			continue
+		}
+		var rec redactionDebtRecord
+		if err := json.Unmarshal(buf, &rec); err != nil {
+			malformed = append(malformed, entry.Name())
+			continue
+		}
+		detSet := map[string]struct{}{}
+		for _, f := range rec.Findings {
+			detSet[f.Detector] = struct{}{}
+		}
+		dets := make([]string, 0, len(detSet))
+		for d := range detSet {
+			dets = append(dets, d)
+		}
+		sort.Strings(dets)
+		summaries = append(summaries, debtSummary{
+			session:   rec.SessionName,
+			marker:    entry.Name(),
+			findings:  len(rec.Findings),
+			files:     len(rec.QuarantinePaths),
+			detectors: dets,
+		})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].session < summaries[j].session
+	})
+	return summaries, malformed
+}

--- a/cmd/ox/doctor_redaction_debt_test.go
+++ b/cmd/ox/doctor_redaction_debt_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckLedgerRedactionDebt_PassesWhenNoMarkers covers the steady
+// state: a ledger with no .sageox/cache/redaction-debt/ dir (or an empty
+// one) must report Passed. Anything else would print a spurious warning
+// every doctor run on a healthy ledger.
+func TestCheckLedgerRedactionDebt_PassesWhenNoMarkers(t *testing.T) {
+	// We don't need the gate's recovery; we just need a ledger-shaped
+	// project so the check's preconditions (gitRoot, localCfg, ledger
+	// path) all resolve. Use makeLedgerWithCommit + the unified
+	// config helpers won't apply here because the doctor check looks
+	// up the ledger from a real project config. Instead, write the
+	// marker into an absolute path under a tempdir and call the check
+	// implementation directly via a helper that we expose for tests.
+	//
+	// The easier path: test the parsing surface of the check directly
+	// with handcrafted markers. checkLedgerRedactionDebt is the cobra
+	// glue + filesystem walk; separate the file-walk piece into a
+	// helper for a focused unit. For now we exercise the structure of
+	// the marker round-trip — the e2e wiring is covered by the gate
+	// tests in prepush_autoredact_test.go (they emit real markers and
+	// assert the doctor check can see them via the same file layout).
+
+	tmp := t.TempDir()
+	debtDir := filepath.Join(tmp, ".sageox", "cache", "redaction-debt")
+	require.NoError(t, os.MkdirAll(debtDir, 0o700))
+	// empty dir → no markers → no debt
+	summaries, malformed := readDebtSummaries(debtDir)
+	assert.Empty(t, summaries)
+	assert.Empty(t, malformed)
+}
+
+// TestCheckLedgerRedactionDebt_SurfacesMarker is the load-bearing
+// assertion: a written marker becomes a doctor warning that names the
+// session, its detectors, and the next-step recovery commands.
+func TestCheckLedgerRedactionDebt_SurfacesMarker(t *testing.T) {
+	tmp := t.TempDir()
+	debtDir := filepath.Join(tmp, ".sageox", "cache", "redaction-debt")
+	require.NoError(t, os.MkdirAll(debtDir, 0o700))
+
+	rec := redactionDebtRecord{
+		SessionName:   "2026-05-12-quarantined",
+		QuarantinedAt: time.Now().UTC(),
+		Reason:        "pre-push secret gate could not auto-redact",
+		Findings: []redactionDebtFinding{
+			{Detector: "aws_access_key", Filename: "notes.md", Line: 3},
+			{Detector: "generic_secret", Filename: "notes.md", Line: 9},
+		},
+		QuarantinePaths: []redactionDebtLocation{
+			{From: "sessions/2026-05-12-quarantined/notes.md",
+				To: ".sageox/cache/quarantine/2026-05-12-quarantined/notes.md"},
+		},
+	}
+	buf, err := json.MarshalIndent(rec, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(debtDir, rec.SessionName+".json"), buf, 0o600))
+
+	summaries, malformed := readDebtSummaries(debtDir)
+	require.Len(t, summaries, 1)
+	require.Empty(t, malformed)
+	got := summaries[0]
+	assert.Equal(t, "2026-05-12-quarantined", got.session)
+	assert.Equal(t, 2, got.findings)
+	assert.Equal(t, 1, got.files)
+	assert.Equal(t, []string{"aws_access_key", "generic_secret"}, got.detectors)
+}
+
+// TestCheckLedgerRedactionDebt_FlagsMalformedMarkers ensures a corrupt
+// or non-JSON file in the debt dir is surfaced — silently dropping it
+// would mean a user could lose track of a quarantined session if its
+// marker got partially written by an interrupted process.
+func TestCheckLedgerRedactionDebt_FlagsMalformedMarkers(t *testing.T) {
+	tmp := t.TempDir()
+	debtDir := filepath.Join(tmp, ".sageox", "cache", "redaction-debt")
+	require.NoError(t, os.MkdirAll(debtDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(debtDir, "broken.json"), []byte("not json"), 0o600))
+
+	summaries, malformed := readDebtSummaries(debtDir)
+	assert.Empty(t, summaries)
+	assert.Equal(t, []string{"broken.json"}, malformed)
+}

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -186,6 +186,7 @@ const (
 	// credential exposure without uploading findings off-machine.
 	CheckSlugLedgerSecrets       = "ledger-secrets"
 	CheckSlugLedgerEmbeddedCreds = "ledger-embedded-creds"
+	CheckSlugLedgerRedactionDebt = "ledger-redaction-debt"
 
 	// Hook content integrity (ox-9y4k): scan installed adapter hook
 	// content for suspicious shapes (curl|sh, eval $(…), base64 -d|sh).

--- a/cmd/ox/prepush_autoredact.go
+++ b/cmd/ox/prepush_autoredact.go
@@ -1,0 +1,449 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+)
+
+// Pre-push auto-redact + quarantine pipeline (ox-y3ok).
+//
+// The pre-push secret gate (cmd/ox/prepush_scan.go::runPrePushSecretGate)
+// MUST NOT block the push. This file implements the recovery path it
+// runs instead:
+//
+//   1. autoRedactSessionFindings — for each affected session, redact
+//      JSONL files in-place via the canonical chokepoint, append a
+//      RedactionPass to meta.json, stage + amend the holding commit.
+//      Reuses redactFileInPlace, writeRedactionPassesPerSession, and
+//      stageAndAmendRedactedFiles so behavior matches `ox session redact`.
+//
+//   2. quarantineUnredactableFindings — for any remaining findings
+//      (non-JSONL paths, IO errors), atomically move the offending file
+//      to <ledger>/.sageox/cache/quarantine/<name>/<file> so the data
+//      isn't lost; carve the path out of the holding commit so the rest
+//      of the push proceeds; write a marker under
+//      <ledger>/.sageox/cache/redaction-debt/ so `ox doctor` can surface
+//      it.
+//
+// The daemon's session-finalize watches <ledger>/.sageox/cache/sessions/
+// and <ledger>/sessions/ — the quarantine path (cache/quarantine/) is
+// outside both, so anti-entropy won't re-add the quarantined file.
+
+// redactionDebtRecord is the on-disk format for a quarantined session.
+// Lives at <ledger>/.sageox/cache/redaction-debt/<session>.json.
+// Recomputable in principle (re-scan finds the same bytes), persisted so
+// `ox doctor` and future tooling don't have to re-hydrate every session
+// to find them.
+type redactionDebtRecord struct {
+	SessionName     string                  `json:"session_name"`
+	QuarantinedAt   time.Time               `json:"quarantined_at"`
+	Reason          string                  `json:"reason"`
+	Findings        []redactionDebtFinding  `json:"findings"`
+	QuarantinePaths []redactionDebtLocation `json:"quarantine_paths"`
+}
+
+// redactionDebtFinding records WHAT detector fired on WHICH line.
+// Never carries matched bytes (ox-zyg7).
+type redactionDebtFinding struct {
+	Detector string `json:"detector"`
+	Filename string `json:"filename"`
+	Line     int    `json:"line"`
+}
+
+// redactionDebtLocation maps the original in-place ledger-relative path
+// to its current quarantine ledger-relative path. Lets the user (or a
+// future `ox session accept-unredacted`) move bytes back to publish.
+type redactionDebtLocation struct {
+	From string `json:"from"` // sessions/<name>/<file>
+	To   string `json:"to"`   // .sageox/cache/quarantine/<name>/<file>
+}
+
+// autoRedactResult summarizes one auto-redact pass.
+type autoRedactResult struct {
+	// RedactedSessions is the set of session names whose JSONL files
+	// were rewritten through the canonical chokepoint. Their meta.json
+	// carries a RedactionPass entry; the holding commit was amended.
+	RedactedSessions []string
+	// FixedPaths is the set of ledger-relative paths whose findings
+	// were cleared by the redact pass. Subset of the original findings'
+	// paths.
+	FixedPaths []string
+	// CatalogVersion + CatalogHash identify the rule set that did the
+	// rewrite. Persisted in meta.json via writeRedactionPassesPerSession.
+	CatalogVersion string
+	CatalogHash    string
+}
+
+// autoRedactSessionFindings groups findings by session, redacts each
+// JSONL file in-place via the canonical chokepoint (redactFileInPlace),
+// appends a RedactionPass to each affected session's meta.json, and
+// stages + amends the holding commit so the next push carries the
+// scrubbed bytes.
+//
+// Non-JSONL paths are skipped here and surface as remaining findings on
+// the caller's re-scan — they get the quarantine path instead.
+//
+// Returns a summary so the caller can format a user-facing message.
+// Errors are returned only for catastrophic failures (commit amend
+// rejected, meta.json mutation failed). Per-file errors degrade
+// gracefully: that file stays in the "remaining findings" bucket and
+// the caller quarantines it.
+func autoRedactSessionFindings(ctx context.Context, ledgerPath string, result *PrePushScanResult) (*autoRedactResult, error) {
+	if result == nil || len(result.Findings) == 0 {
+		return &autoRedactResult{}, nil
+	}
+
+	redactor := session.NewRedactor()
+	out := &autoRedactResult{
+		CatalogVersion: redactor.CatalogVersion(),
+		CatalogHash:    redactor.CatalogHash(),
+	}
+
+	// Group findings by (session, file). For each (session, file) we
+	// rewrite the file once; for each session we append one meta entry.
+	type fileKey struct{ session, filename, rel string }
+	byFile := map[fileKey][]PrePushFinding{}
+	for _, f := range result.Findings {
+		sess, fname, ok := splitSessionPath(f.Path)
+		if !ok {
+			// Not a session path — shouldn't happen post-cqdo scope fix,
+			// but defense in depth: leave it for the quarantine pass.
+			continue
+		}
+		key := fileKey{session: sess, filename: fname, rel: f.Path}
+		byFile[key] = append(byFile[key], f)
+	}
+
+	bySession := map[string][]lfs.RedactionEntry{}
+	var redactedRels []string
+
+	// Deterministic order so failures are reproducible.
+	keys := make([]fileKey, 0, len(byFile))
+	for k := range byFile {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].session != keys[j].session {
+			return keys[i].session < keys[j].session
+		}
+		return keys[i].filename < keys[j].filename
+	})
+
+	for _, k := range keys {
+		if !isJSONLPath(k.filename) {
+			// Only JSONL goes through the canonical chokepoint today.
+			// Anything else falls through to quarantine.
+			continue
+		}
+		abs := filepath.Join(ledgerPath, k.rel)
+		if err := redactFileInPlace(abs, redactor); err != nil {
+			slog.Warn("pre-push auto-redact: file rewrite failed; will quarantine",
+				"path", k.rel, "error", err)
+			continue
+		}
+		redactedRels = append(redactedRels, k.rel)
+		for _, f := range byFile[k] {
+			bySession[k.session] = append(bySession[k.session], lfs.RedactionEntry{
+				File:     k.filename,
+				Line:     f.Line,
+				Detector: f.Detector,
+			})
+		}
+	}
+
+	if len(bySession) == 0 {
+		// Nothing redacted — caller will quarantine everything.
+		return out, nil
+	}
+
+	// Persist the audit trail BEFORE staging so the amend captures it.
+	metaPaths, err := writeRedactionPassesPerSession(ctx, ledgerPath,
+		bySession, out.CatalogVersion, out.CatalogHash)
+	if err != nil {
+		return out, fmt.Errorf("write redaction passes: %w", err)
+	}
+
+	// Stage + amend in one go. Reuses the same primitive `ox session
+	// redact` uses; auditors get one consistent shape regardless of
+	// whether the redaction was interactive or automatic.
+	byPath := map[string][]redactHistoryFinding{}
+	for _, rel := range redactedRels {
+		byPath[rel] = nil
+	}
+	for _, mp := range metaPaths {
+		byPath[mp] = nil
+	}
+	if err := stageAndAmendRedactedFiles(ledgerPath, byPath); err != nil {
+		return out, fmt.Errorf("stage/amend redacted files: %w", err)
+	}
+
+	out.FixedPaths = redactedRels
+	out.RedactedSessions = sortedKeys(bySession)
+	slog.Info("pre-push auto-redact: redacted in-place via canonical chokepoint",
+		"sessions", out.RedactedSessions,
+		"files", len(out.FixedPaths),
+		"catalog_version", out.CatalogVersion)
+	return out, nil
+}
+
+// quarantineResult summarizes what was carved out of the holding commit.
+type quarantineResult struct {
+	QuarantinedRels []string // ledger-relative ORIGINAL paths that were quarantined
+	DebtMarkers     []string // ledger-relative paths to the marker .json files written
+}
+
+// quarantineUnredactableFindings handles findings that the auto-redact
+// pass could not clear. For each affected file:
+//
+//  1. Atomically rename `<ledger>/sessions/<name>/<file>` →
+//     `<ledger>/.sageox/cache/quarantine/<name>/<file>` so the bytes
+//     remain on the user's machine but outside the daemon's
+//     session-finalize watch surface (cache/quarantine/ is not scanned
+//     by detectInDir; only cache/sessions/ and sessions/ are).
+//
+//  2. Drop the path from the holding commit (`git reset HEAD~ -- <path>`
+//     when a parent exists, `git rm --cached --ignore-unmatch` otherwise)
+//     so the next push carries the rest of the commit's changes.
+//
+//  3. Write a redactionDebtRecord under
+//     `<ledger>/.sageox/cache/redaction-debt/<session>.json` so
+//     `ox doctor` can surface the persistent state. One marker per
+//     affected session aggregates all that session's quarantined files.
+//
+// Returns the carved-out paths + marker locations. Per-file errors are
+// logged and skipped — the goal is to never block the push; partial
+// quarantine is better than full block.
+func quarantineUnredactableFindings(ledgerPath string, findings []PrePushFinding) (*quarantineResult, error) {
+	out := &quarantineResult{}
+	if len(findings) == 0 {
+		return out, nil
+	}
+
+	// Group findings by session for the marker write.
+	type sessionGroup struct {
+		findings        []PrePushFinding
+		quarantineLocs  []redactionDebtLocation
+	}
+	groups := map[string]*sessionGroup{}
+	for _, f := range findings {
+		sess, _, ok := splitSessionPath(f.Path)
+		if !ok {
+			slog.Warn("pre-push quarantine: finding outside sessions/ scope; ignored",
+				"path", f.Path)
+			continue
+		}
+		if groups[sess] == nil {
+			groups[sess] = &sessionGroup{}
+		}
+		groups[sess].findings = append(groups[sess].findings, f)
+	}
+
+	// Deduplicate moves per file (multiple findings per file → one move).
+	seenPaths := map[string]bool{}
+	for sess, g := range groups {
+		for _, f := range g.findings {
+			if seenPaths[f.Path] {
+				continue
+			}
+			seenPaths[f.Path] = true
+
+			fromRel := f.Path
+			fromAbs := filepath.Join(ledgerPath, fromRel)
+			// We only move the in-place ledger file (already scanned).
+			// LFS pointer-bytes never match detectors, so anything we're
+			// quarantining is hydrated content sitting in-place — moving
+			// it is safe (the canonical state on disk for this session
+			// is the LFS blob or the original local cache, depending on
+			// the lifecycle stage).
+			info, err := os.Stat(fromAbs)
+			if err != nil {
+				slog.Warn("pre-push quarantine: stat failed; skipping",
+					"path", fromRel, "error", err)
+				continue
+			}
+			if info.IsDir() {
+				continue
+			}
+			_, fname, _ := splitSessionPath(fromRel)
+			toRel := filepath.ToSlash(filepath.Join(".sageox", "cache", "quarantine", sess, fname))
+			toAbs := filepath.Join(ledgerPath, toRel)
+			if err := os.MkdirAll(filepath.Dir(toAbs), 0o700); err != nil {
+				slog.Warn("pre-push quarantine: mkdir failed; skipping",
+					"path", toRel, "error", err)
+				continue
+			}
+			if err := os.Rename(fromAbs, toAbs); err != nil {
+				slog.Warn("pre-push quarantine: rename failed; skipping",
+					"from", fromRel, "to", toRel, "error", err)
+				continue
+			}
+			if err := unstagePath(ledgerPath, fromRel); err != nil {
+				slog.Warn("pre-push quarantine: unstage failed; bytes are quarantined but path may remain in commit",
+					"path", fromRel, "error", err)
+				// Don't return — best-effort. The push will still likely
+				// succeed because the moved-aside file no longer exists
+				// at the staged path; git may auto-detect the deletion.
+			}
+			g.quarantineLocs = append(g.quarantineLocs, redactionDebtLocation{
+				From: fromRel,
+				To:   toRel,
+			})
+			out.QuarantinedRels = append(out.QuarantinedRels, fromRel)
+		}
+	}
+
+	// If we unstaged anything, amend the holding commit once so its
+	// tree matches the now-quarantined working state.
+	if len(out.QuarantinedRels) > 0 {
+		if err := amendDroppingPaths(ledgerPath); err != nil {
+			slog.Warn("pre-push quarantine: amend failed; push may still surface the bad paths",
+				"error", err)
+		}
+	}
+
+	// Write one marker per session aggregating its quarantined files +
+	// finding metadata. Markers are recomputable, so write errors are
+	// logged-not-returned.
+	for sess, g := range groups {
+		if len(g.quarantineLocs) == 0 {
+			continue
+		}
+		markerRel := filepath.ToSlash(filepath.Join(".sageox", "cache", "redaction-debt", sess+".json"))
+		markerAbs := filepath.Join(ledgerPath, markerRel)
+		if err := os.MkdirAll(filepath.Dir(markerAbs), 0o700); err != nil {
+			slog.Warn("pre-push quarantine: marker mkdir failed",
+				"session", sess, "error", err)
+			continue
+		}
+		rec := redactionDebtRecord{
+			SessionName:     sess,
+			QuarantinedAt:   time.Now().UTC(),
+			Reason:          "pre-push secret gate could not auto-redact; bytes preserved in quarantine. Inspect, redact manually, and move back to publish.",
+			QuarantinePaths: g.quarantineLocs,
+		}
+		for _, f := range g.findings {
+			_, fname, _ := splitSessionPath(f.Path)
+			rec.Findings = append(rec.Findings, redactionDebtFinding{
+				Detector: f.Detector,
+				Filename: fname,
+				Line:     f.Line,
+			})
+		}
+		buf, err := json.MarshalIndent(rec, "", "  ")
+		if err != nil {
+			slog.Warn("pre-push quarantine: marker marshal failed",
+				"session", sess, "error", err)
+			continue
+		}
+		if err := writeFileAtomic(markerAbs, buf, 0o600); err != nil {
+			slog.Warn("pre-push quarantine: marker write failed",
+				"session", sess, "error", err)
+			continue
+		}
+		out.DebtMarkers = append(out.DebtMarkers, markerRel)
+	}
+	return out, nil
+}
+
+// unstagePath removes a single path from the index, leaving the working
+// tree alone. Uses `git reset HEAD~` when a parent commit exists, falling
+// back to `git rm --cached --ignore-unmatch` for the first-commit case.
+func unstagePath(ledgerPath, rel string) error {
+	// Try to resolve HEAD~ first. If it doesn't exist (single-commit
+	// repo), fall back to the cached-remove path.
+	if err := exec.Command("git", "-C", ledgerPath, "rev-parse", "--verify", "HEAD~").Run(); err == nil {
+		// `git reset HEAD~ -- <path>` rewinds the index entry for this
+		// path to its HEAD~ state. WT untouched (the file is already
+		// moved aside; this just rewrites the staged tree).
+		if out, err := exec.Command("git", "-C", ledgerPath, "reset", "HEAD~", "--", rel).CombinedOutput(); err != nil {
+			return fmt.Errorf("git reset HEAD~ %s: %s: %w", rel, strings.TrimSpace(string(out)), err)
+		}
+		return nil
+	}
+	if out, err := exec.Command("git", "-C", ledgerPath, "rm", "--cached", "--ignore-unmatch", "--", rel).CombinedOutput(); err != nil {
+		return fmt.Errorf("git rm --cached %s: %s: %w", rel, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// amendDroppingPaths runs `git commit --amend --no-edit --no-verify`
+// after the caller has already mutated the index (via unstagePath calls).
+// `--no-verify` matches stageAndAmendRedactedFiles' behavior; the secret
+// gate is the verifier and it's the one driving this flow.
+func amendDroppingPaths(ledgerPath string) error {
+	out, err := exec.Command("git", "-C", ledgerPath, "commit", "--amend", "--no-edit", "--no-verify").CombinedOutput()
+	if err != nil {
+		// "nothing to commit" can happen if the amend would produce an
+		// empty commit (we dropped every staged path). Tolerate it —
+		// the push will simply carry nothing new, which is correct.
+		if strings.Contains(string(out), "nothing to commit") {
+			return nil
+		}
+		return fmt.Errorf("git commit --amend: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// writeFileAtomic writes data to path via a tmpfile + rename so a reader
+// (e.g. doctor) never sees a half-written marker.
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-")
+	if err != nil {
+		return err
+	}
+	cleanup := true
+	tmpName := tmp.Name()
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+// isJSONLPath returns true for filenames the canonical redactFileInPlace
+// chokepoint can rewrite. Today that's `*.jsonl` (the session raw stream).
+// Other text files (md, html, txt) are scanned but go to quarantine
+// instead — the chokepoint applies the raw-writer redaction stack and
+// expects each line to be a JSON record.
+func isJSONLPath(filename string) bool {
+	return strings.EqualFold(filepath.Ext(filename), ".jsonl")
+}
+
+// sortedKeys returns the keys of m in sorted order. Stable output for
+// logs and tests.
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/ox/prepush_autoredact_test.go
+++ b/cmd/ox/prepush_autoredact_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Failure prevented across this file (ox-y3ok): the pre-push secret gate
+// must never block the push. Auto-redact what it can, quarantine what it
+// can't, but always return nil so unrelated commits and other sessions
+// keep flowing.
+
+// seedSessionMeta writes a minimal valid meta.json at sessions/<name>/.
+// Required because the canonical RedactionPass writer
+// (writeRedactionPassesPerSession → lfs.MutateSessionMeta) refuses to
+// synthesize a meta.json from scratch — see the comment at meta.go.
+func seedSessionMeta(t *testing.T, sessionDir, sessionName string) {
+	t.Helper()
+	meta := lfs.SessionMeta{
+		Version:     "1.0",
+		SessionName: sessionName,
+		AgentID:     "test-agent",
+		AgentType:   "claude-code",
+		CreatedAt:   time.Now().UTC(),
+	}
+	buf, err := json.MarshalIndent(meta, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "meta.json"), buf, 0o644))
+}
+
+// TestRunPrePushSecretGate_AutoRedactsJSONLAndAllowsPush is the happy
+// path of the recovery pipeline: a JSONL session file with a planted
+// canary gets rewritten through the canonical chokepoint, a
+// RedactionPass lands in meta.json, the holding commit is amended,
+// and the gate returns nil so the push proceeds.
+//
+// Failure prevented: a single session with a chokepoint-recoverable
+// finding holds up the entire push — defeating both the "never block"
+// directive and the canonical chokepoint's idempotency guarantee.
+func TestRunPrePushSecretGate_AutoRedactsJSONLAndAllowsPush(t *testing.T) {
+	t.Setenv("OX_ALLOW_SECRETS", "") // ensure no override
+	const sessionName = "2026-05-12-autoredact"
+	const canary = "AKIAIOSFODNN7EXAMPLE"
+	rec := `{"type":"text","value":"` + canary + `"}` + "\n"
+
+	work := makeLedgerWithCommit(t, map[string]string{
+		filepath.ToSlash(filepath.Join("sessions", sessionName, "raw.jsonl")): rec,
+	})
+	seedSessionMeta(t, filepath.Join(work, "sessions", sessionName), sessionName)
+	mustGit(t, work, "add", "--sparse", filepath.Join("sessions", sessionName, "meta.json"))
+	mustGit(t, work, "commit", "--amend", "--no-edit", "--no-verify")
+
+	err := runPrePushSecretGate(context.Background(), work)
+	require.NoError(t, err, "gate must NEVER block the push")
+
+	// raw.jsonl on disk must no longer contain the canary bytes.
+	rawAbs := filepath.Join(work, "sessions", sessionName, "raw.jsonl")
+	bytes, readErr := os.ReadFile(rawAbs)
+	require.NoError(t, readErr)
+	assert.NotContains(t, string(bytes), canary,
+		"canary still on disk; auto-redact did not run or did not scrub")
+
+	// Re-scan must come back clean — the chokepoint and the scanner
+	// share a detector catalog; if redact says it cleared, scan must
+	// agree, otherwise we'd loop forever on a future iteration.
+	rescan, scanErr := scanPrePushForSecrets(context.Background(), work)
+	require.NoError(t, scanErr)
+	assert.Empty(t, rescan.Findings, "scanner still finds the canary after auto-redact: %v", rescan.Findings)
+
+	// meta.json must carry a RedactionPass entry recording the catalog
+	// identity and the per-line finding metadata (file/line/detector).
+	metaBuf, err := os.ReadFile(filepath.Join(work, "sessions", sessionName, "meta.json"))
+	require.NoError(t, err)
+	var meta lfs.SessionMeta
+	require.NoError(t, json.Unmarshal(metaBuf, &meta))
+	require.NotEmpty(t, meta.Redactions, "meta.json missing RedactionPass entry")
+	pass := meta.Redactions[len(meta.Redactions)-1]
+	assert.NotEmpty(t, pass.PassID)
+	assert.NotEmpty(t, pass.CatalogVersion)
+	assert.NotEmpty(t, pass.CatalogHash)
+	assert.GreaterOrEqual(t, len(pass.Entries), 1, "expected at least one per-line entry")
+	for _, e := range pass.Entries {
+		assert.Equal(t, "raw.jsonl", e.File)
+		assert.NotEmpty(t, e.Detector)
+		// MUST NEVER carry matched bytes — ox-zyg7.
+		assert.NotContains(t, e.Detector, canary)
+	}
+
+	// The amend should have updated HEAD with the redacted bytes —
+	// `git diff HEAD~..HEAD --stat` should show raw.jsonl changed.
+	// (We don't strictly assert content here; the disk-bytes check above
+	// covers the load-bearing claim.)
+}
+
+// TestRunPrePushSecretGate_QuarantinesNonJSONLAndAllowsPush exercises
+// the recovery path that auto-redact cannot service. A planted canary
+// in a non-JSONL file (the chokepoint only rewrites JSONL) must be
+// preserved on disk, moved to the quarantine cache, dropped from the
+// holding commit, and surfaced via a debt marker — all without
+// returning an error.
+//
+// Failure prevented: a non-JSONL session file with a finding blocks
+// the push of ALL other sessions and unrelated commits, and either
+// data is lost or the user has no on-disk record of what was carved out.
+func TestRunPrePushSecretGate_QuarantinesNonJSONLAndAllowsPush(t *testing.T) {
+	t.Setenv("OX_ALLOW_SECRETS", "")
+	const sessionName = "2026-05-12-quarantine"
+	const canary = "AKIAIOSFODNN7EXAMPLE"
+	relMD := filepath.ToSlash(filepath.Join("sessions", sessionName, "notes.md"))
+
+	work := makeLedgerWithCommit(t, map[string]string{
+		// Also include an UNRELATED file in the same commit so we can
+		// assert that the rest of the push survives.
+		"unrelated.txt": "hello world\n",
+		relMD:           "# Notes\n\nfound a token: " + canary + "\n",
+	})
+	seedSessionMeta(t, filepath.Join(work, "sessions", sessionName), sessionName)
+	mustGit(t, work, "add", "--sparse", filepath.Join("sessions", sessionName, "meta.json"))
+	mustGit(t, work, "commit", "--amend", "--no-edit", "--no-verify")
+
+	err := runPrePushSecretGate(context.Background(), work)
+	require.NoError(t, err, "gate must NEVER block, even on non-JSONL findings")
+
+	// Original in-place path must be gone (moved aside).
+	_, statErr := os.Stat(filepath.Join(work, relMD))
+	assert.True(t, os.IsNotExist(statErr),
+		"original notes.md should have been moved to quarantine; stat err=%v", statErr)
+
+	// Quarantine path must hold the bytes.
+	quarRel := filepath.Join(".sageox", "cache", "quarantine", sessionName, "notes.md")
+	quarAbs := filepath.Join(work, quarRel)
+	bytes, readErr := os.ReadFile(quarAbs)
+	require.NoError(t, readErr, "quarantine path missing")
+	assert.Contains(t, string(bytes), canary,
+		"bytes must be preserved verbatim in quarantine; the point of quarantine is no data loss")
+
+	// Debt marker must exist and parse.
+	markerRel := filepath.Join(".sageox", "cache", "redaction-debt", sessionName+".json")
+	markerBuf, err := os.ReadFile(filepath.Join(work, markerRel))
+	require.NoError(t, err, "debt marker missing")
+	var rec redactionDebtRecord
+	require.NoError(t, json.Unmarshal(markerBuf, &rec))
+	assert.Equal(t, sessionName, rec.SessionName)
+	require.NotEmpty(t, rec.Findings, "marker missing findings")
+	require.NotEmpty(t, rec.QuarantinePaths, "marker missing quarantine path mapping")
+	assert.Equal(t, relMD, rec.QuarantinePaths[0].From)
+	assert.Equal(t, filepath.ToSlash(quarRel), rec.QuarantinePaths[0].To)
+
+	// The holding commit must NOT carry the quarantined path anymore.
+	mustGit(t, work, "rev-parse", "HEAD")
+	if mustGitCapture(t, work, "ls-tree", "--name-only", "HEAD", filepath.ToSlash(relMD)) != "" {
+		t.Fatalf("notes.md still tracked at HEAD; carve-out failed")
+	}
+	// And the rest of the commit must survive: unrelated.txt and the
+	// session's meta.json should still be in HEAD's tree.
+	if mustGitCapture(t, work, "ls-tree", "--name-only", "HEAD", "unrelated.txt") == "" {
+		t.Fatalf("unrelated.txt missing from HEAD; quarantine over-reached")
+	}
+}
+
+// TestRunPrePushSecretGate_OverrideStillSkipsRecovery confirms
+// OX_ALLOW_SECRETS=1 still short-circuits the recovery pipeline.
+// Required so emergency overrides don't get auto-redacted or
+// auto-quarantined — when a user explicitly says "publish as-is," the
+// gate must respect that, not silently rewrite their bytes.
+func TestRunPrePushSecretGate_OverrideStillSkipsRecovery(t *testing.T) {
+	t.Setenv("OX_ALLOW_SECRETS", "1")
+	const sessionName = "2026-05-12-override"
+	const canary = "AKIAIOSFODNN7EXAMPLE"
+	relJSONL := filepath.ToSlash(filepath.Join("sessions", sessionName, "raw.jsonl"))
+	rec := `{"type":"text","value":"` + canary + `"}` + "\n"
+
+	work := makeLedgerWithCommit(t, map[string]string{relJSONL: rec})
+	err := runPrePushSecretGate(context.Background(), work)
+	require.NoError(t, err)
+
+	// With override, raw.jsonl must NOT have been rewritten.
+	bytes, readErr := os.ReadFile(filepath.Join(work, relJSONL))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(bytes), canary,
+		"override must NOT auto-redact; bytes go to cloud as-is")
+}
+
+// mustGitCapture runs git and returns trimmed stdout. Helper for tests
+// that need to assert on tree contents.
+func mustGitCapture(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := captureGit(dir, args...)
+	require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+	return strings.TrimSpace(out)
+}
+
+func captureGit(dir string, args ...string) (string, error) {
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	return string(out), err
+}

--- a/cmd/ox/prepush_scan.go
+++ b/cmd/ox/prepush_scan.go
@@ -283,16 +283,29 @@ func prePushSecretsAllowed() bool {
 	return true
 }
 
-// runPrePushSecretGate is the entry point used by pushLedger. Returns nil
-// if push may proceed; returns a formatted error if findings are present
-// and OX_ALLOW_SECRETS is not set.
+// runPrePushSecretGate is the entry point used by pushLedger. As of
+// ox-y3ok the gate NEVER blocks the push: a single bad session must not
+// hold up other sessions and unrelated commits from syncing. Instead the
+// gate runs a recovery pipeline:
+//
+//  1. Scan (scoped to sessions/ per ox-cqdo).
+//  2. Auto-redact every JSONL finding via the canonical chokepoint
+//     (autoRedactSessionFindings → redactFileInPlace + meta.json
+//     RedactionPass + amend). Re-scan.
+//  3. Anything still remaining is quarantined: the file is atomically
+//     moved to <ledger>/.sageox/cache/quarantine/ (preserved, just
+//     outside the daemon's session-finalize surface) and its path is
+//     carved out of the holding commit. A debt marker is written under
+//     <ledger>/.sageox/cache/redaction-debt/ so `ox doctor` can surface
+//     the persistent state.
+//
+// Always returns nil. Scan errors and recovery errors are logged and
+// the push proceeds; making the gate impassable is a worse outcome than
+// publishing whatever the chokepoint missed (the same content already
+// hit the chokepoint at write time).
 func runPrePushSecretGate(ctx context.Context, ledgerPath string) error {
 	result, err := scanPrePushForSecrets(ctx, ledgerPath)
 	if err != nil {
-		// Scan-side error (e.g. git command failed). Fail OPEN here rather
-		// than blocking the push — the scanner is a guardrail, not an oracle,
-		// and the user has no way to recover if a transient git problem makes
-		// the gate impassable.
 		slog.Warn("pre-push secret gate: scan failed, allowing push", "error", err)
 		return nil
 	}
@@ -304,13 +317,71 @@ func runPrePushSecretGate(ctx context.Context, ledgerPath string) error {
 		slog.Warn("pre-push secret gate: OVERRIDDEN by OX_ALLOW_SECRETS",
 			"findings", len(result.Findings),
 			"files", countDistinctPaths(result.Findings))
-		// emit a loud stderr line so the override isn't invisible in
-		// non-structured logs.
 		fmt.Fprintln(os.Stderr,
 			"WARNING: ox pre-push secret gate overridden by OX_ALLOW_SECRETS — "+
 				"credentials may be published to the cloud Ledger")
 		return nil
 	}
-	return fmt.Errorf("%s", FormatPrePushFindings(result))
+
+	// Try the canonical chokepoint first; it can clear anything the
+	// scanner found (they share a detector catalog).
+	auto, redactErr := autoRedactSessionFindings(ctx, ledgerPath, result)
+	if redactErr != nil {
+		slog.Warn("pre-push secret gate: auto-redact failed; will quarantine remainder",
+			"error", redactErr)
+	}
+
+	// Re-scan post-redact. Anything left is either non-JSONL or hit a
+	// per-file error in the redact pass.
+	rescan, rescanErr := scanPrePushForSecrets(ctx, ledgerPath)
+	if rescanErr != nil {
+		slog.Warn("pre-push secret gate: rescan after auto-redact failed; allowing push",
+			"error", rescanErr)
+		return nil
+	}
+	if len(rescan.Findings) == 0 {
+		if auto != nil && len(auto.FixedPaths) > 0 {
+			fmt.Fprintf(os.Stderr,
+				"ox pre-push: auto-redacted %d file(s) across %d session(s) before push (catalog %s).\n",
+				len(auto.FixedPaths), len(auto.RedactedSessions), auto.CatalogVersion)
+		}
+		return nil
+	}
+
+	// Quarantine the remainder so the rest of the push can proceed.
+	q, qErr := quarantineUnredactableFindings(ledgerPath, rescan.Findings)
+	if qErr != nil {
+		slog.Warn("pre-push secret gate: quarantine partial; push will still proceed",
+			"error", qErr)
+	}
+
+	// Loud user-visible summary. Stderr (not the structured slog) so
+	// `ox session stop` callers see it even when slog is at WARN level.
+	emitQuarantineWarning(os.Stderr, auto, q, rescan)
+	return nil
+}
+
+// emitQuarantineWarning prints the user-facing summary of what was
+// auto-redacted, what was quarantined, and what to do next. Centralized
+// so the format stays consistent if call sites change.
+func emitQuarantineWarning(w *os.File, auto *autoRedactResult, q *quarantineResult, rescan *PrePushScanResult) {
+	var b strings.Builder
+	b.WriteString("\nox pre-push: credential findings detected in session content.\n")
+	if auto != nil && len(auto.FixedPaths) > 0 {
+		fmt.Fprintf(&b, "  Auto-redacted in place via canonical chokepoint: %d file(s) across %d session(s).\n",
+			len(auto.FixedPaths), len(auto.RedactedSessions))
+	}
+	if q != nil && len(q.QuarantinedRels) > 0 {
+		fmt.Fprintf(&b, "  Quarantined (preserved on disk, dropped from this push): %d file(s).\n",
+			len(q.QuarantinedRels))
+		for _, p := range q.QuarantinedRels {
+			fmt.Fprintf(&b, "    %s\n", p)
+		}
+		b.WriteString("  Bytes preserved under .sageox/cache/quarantine/<session>/.\n")
+		b.WriteString("  Run `ox doctor` for next steps. Other sessions and unrelated commits will sync normally.\n")
+	} else if rescan != nil && len(rescan.Findings) > 0 {
+		b.WriteString("  Some findings could not be quarantined; they remain in the push.\n")
+	}
+	fmt.Fprint(w, b.String())
 }
 

--- a/cmd/ox/prepush_scan.go
+++ b/cmd/ox/prepush_scan.go
@@ -53,6 +53,46 @@ var prePushScannerSkipExts = map[string]bool{
 // session content always fits.
 const prePushScannerSizeCap = 8 * 1024 * 1024 // 8 MiB
 
+// prePushScannerScopePrefixes restricts the gate to ledger paths the
+// recovery tooling can actually fix. As of ox-cqdo:
+//
+//   - sessions/      raw AI session recordings — assistant chat and tool
+//                    I/O. The one path where unscrubbed credentials can
+//                    plausibly land in a ledger from ox-controlled writes.
+//                    Covered by `ox session audit` / `ox session redact`.
+//
+// Out of scope (intentionally not gated):
+//
+//   - data/github/   verbatim cache of PR/Issue bytes already published on
+//                    GitHub. Replicating them into the ledger is the same
+//                    exposure surface as ingesting the PR at all; rewriting
+//                    them at write time produced a false-positive class
+//                    that blocked routine pushes (the regression that drove
+//                    this fix).
+//   - kb/            user-curated knowledge bubbles. User-authored content
+//                    is the user's responsibility; not an ox write path.
+//   - team-context/  same — user-edited markdown.
+//
+// If you widen this list, also widen the recovery surface in
+// FormatPrePushFindings. The test
+// TestFormatPrePushFindings_RecoveryMatchesScannerScope pins that contract.
+var prePushScannerScopePrefixes = []string{
+	"sessions/",
+}
+
+// inPrePushScannerScope returns true iff rel (a forward-slash-relative path
+// from the ledger root) sits inside one of prePushScannerScopePrefixes.
+// Paths produced by `git diff --name-only` and `git ls-tree` are already
+// forward-slash, so no normalization is needed.
+func inPrePushScannerScope(rel string) bool {
+	for _, prefix := range prePushScannerScopePrefixes {
+		if strings.HasPrefix(rel, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // scanPrePushForSecrets enumerates files that the next push would publish
 // (between `origin/main` and `HEAD`) and runs the credential detectors
 // against each file's current working-tree content.
@@ -110,14 +150,18 @@ func scanAllTrackedFiles(ctx context.Context, ledgerPath string) (*PrePushScanRe
 
 // scanPaths runs the redactor against the working-tree content of every
 // path in paths, recording detector matches as PrePushFindings. Skip rules:
-// binary extensions, files over prePushScannerSizeCap, files that no longer
-// exist in the working tree (legitimately deleted in the commit range).
+// out-of-scope paths (see prePushScannerScopePrefixes), binary extensions,
+// files over prePushScannerSizeCap, files that no longer exist in the
+// working tree (legitimately deleted in the commit range).
 func scanPaths(ledgerPath string, paths []string) (*PrePushScanResult, error) {
 	redactor := session.NewRedactor()
 	result := &PrePushScanResult{}
 
 	for _, rel := range paths {
 		if rel == "" {
+			continue
+		}
+		if !inPrePushScannerScope(rel) {
 			continue
 		}
 		if prePushScannerSkipExts[strings.ToLower(filepath.Ext(rel))] {

--- a/cmd/ox/prepush_scan_test.go
+++ b/cmd/ox/prepush_scan_test.go
@@ -118,34 +118,28 @@ func TestScanPrePushForSecrets_ScansOnlyDiffFiles(t *testing.T) {
 	}
 }
 
-// TestRunPrePushSecretGate_RefusesWhenSecretsPresent verifies the gate
-// returns a formatted error and the error contains the detector name and
-// path (but NOT the secret bytes themselves).
-func TestRunPrePushSecretGate_RefusesWhenSecretsPresent(t *testing.T) {
-	t.Setenv("OX_ALLOW_SECRETS", "") // ensure override off
+// TestRunPrePushSecretGate_NeverBlocks_FlatPathNoOpsRecovery covers the
+// degenerate-path case (file directly under sessions/ with no session
+// subdir). After ox-y3ok, neither auto-redact nor quarantine recognize
+// that shape (splitSessionPath returns ok=false), but the gate still
+// MUST return nil — that's the load-bearing "never block" invariant.
+//
+// Failure prevented: a malformed session path causes the gate to error
+// and block routine pushes because the recovery path can't run.
+func TestRunPrePushSecretGate_NeverBlocks_FlatPathNoOpsRecovery(t *testing.T) {
+	t.Setenv("OX_ALLOW_SECRETS", "")
 	work := makeLedgerWithCommit(t, map[string]string{
 		"sessions/leak.jsonl": "token=ghp_alphabetabcdefghijklmnopqrstuvwxyz12\n",
 	})
 
 	err := runPrePushSecretGate(context.Background(), work)
-	require.Error(t, err)
-
-	msg := err.Error()
-	assert.Contains(t, msg, "Push refused")
-	// After ox-def1 the broad `github_token` detector was split per-prefix;
-	// a full-shape ghp_<36> matches the personal-access-token variant.
-	assert.Contains(t, msg, "github_personal_access_token")
-	assert.Contains(t, msg, "sessions/leak.jsonl")
-	// MUST NOT include the secret bytes
-	assert.NotContains(t, msg, "alphabetabcdefghijklmnopqrstuvwxyz")
-	// remediation guidance must be present
-	assert.Contains(t, msg, "OX_ALLOW_SECRETS=1")
+	assert.NoError(t, err, "gate must NEVER return an error; recovery may no-op but push proceeds")
 }
 
-// TestRunPrePushSecretGate_AllowSecretsOverride verifies the env-var escape
-// hatch lets the push through with a loud warning. Required for emergency
-// overrides — without this, the gate would be a permanent block in any
-// scenario the detectors mis-classify.
+// TestRunPrePushSecretGate_AllowSecretsOverride verifies the env-var
+// override still short-circuits the recovery pipeline. Under the
+// never-block policy this is just a faster path: no scan, no
+// auto-redact, no quarantine — publish as-is per user request.
 func TestRunPrePushSecretGate_AllowSecretsOverride(t *testing.T) {
 	t.Setenv("OX_ALLOW_SECRETS", "1")
 	work := makeLedgerWithCommit(t, map[string]string{
@@ -154,21 +148,6 @@ func TestRunPrePushSecretGate_AllowSecretsOverride(t *testing.T) {
 
 	err := runPrePushSecretGate(context.Background(), work)
 	assert.NoError(t, err, "OX_ALLOW_SECRETS=1 must allow push")
-}
-
-// TestRunPrePushSecretGate_AllowSecretsRecognizesFalse verifies that values
-// that look like "off" (0, false, no, off, "") do NOT bypass the gate.
-func TestRunPrePushSecretGate_AllowSecretsRecognizesFalse(t *testing.T) {
-	work := makeLedgerWithCommit(t, map[string]string{
-		"sessions/leak.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
-	})
-	for _, off := range []string{"", "0", "false", "no", "OFF"} {
-		t.Run("OX_ALLOW_SECRETS="+off, func(t *testing.T) {
-			t.Setenv("OX_ALLOW_SECRETS", off)
-			err := runPrePushSecretGate(context.Background(), work)
-			assert.Error(t, err, "off-like value %q should NOT bypass gate", off)
-		})
-	}
 }
 
 // TestPrePushScanner_SkipsBinaryExtensions verifies binary blobs are skipped.

--- a/cmd/ox/prepush_scan_test.go
+++ b/cmd/ox/prepush_scan_test.go
@@ -88,14 +88,17 @@ func TestScanPrePushForSecrets_CleanLedgerPasses(t *testing.T) {
 	work := makeLedgerWithCommit(t, map[string]string{
 		"sessions/2026-05-10/raw.jsonl": `{"text":"hello world, just a chat message"}` + "\n",
 		"sessions/2026-05-10/meta.json": `{"agent_type":"claude-code","files":[]}` + "\n",
-		"docs/README.md":                "# Sessions\n\nProse with no credentials.\n",
+		// docs/ is out of scope (see prePushScannerScopePrefixes) and must
+		// not be counted in FilesScanned.
+		"docs/README.md": "# Sessions\n\nProse with no credentials.\n",
 	})
 
 	result, err := scanPrePushForSecrets(context.Background(), work)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Findings, "false-positive: %v", result.Findings)
-	assert.GreaterOrEqual(t, result.FilesScanned, 3, "expected to scan all 3 files")
+	assert.Equal(t, 2, result.FilesScanned,
+		"expected only the two sessions/ files; docs/ is out of scope")
 }
 
 func TestScanPrePushForSecrets_ScansOnlyDiffFiles(t *testing.T) {
@@ -192,6 +195,9 @@ func TestPrePushScanner_SkipsBinaryExtensions(t *testing.T) {
 // ledger has no origin/main yet — scanner falls back to scanning all
 // tracked files. Without this, brand-new ledgers (first push) would skip
 // the gate entirely.
+//
+// The canary lives under sessions/ — the fresh-ledger fallback respects
+// the same scope filter as the diff path (see ox-cqdo).
 func TestPrePushScanner_NoUpstreamFallsBackToHead(t *testing.T) {
 	// Bare repo + working clone, but DON'T configure origin or push.
 	tmp := t.TempDir()
@@ -200,7 +206,9 @@ func TestPrePushScanner_NoUpstreamFallsBackToHead(t *testing.T) {
 	mustGit(t, work, "init", "--initial-branch=main")
 	mustGit(t, work, "config", "user.email", "test@example.com")
 	mustGit(t, work, "config", "user.name", "test")
-	require.NoError(t, os.WriteFile(filepath.Join(work, "leak.txt"), []byte("AKIAIOSFODNN7EXAMPLE\n"), 0644))
+	leakPath := filepath.Join(work, "sessions", "fresh", "raw.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(leakPath), 0755))
+	require.NoError(t, os.WriteFile(leakPath, []byte("AKIAIOSFODNN7EXAMPLE\n"), 0644))
 	mustGit(t, work, "add", ".")
 	mustGit(t, work, "commit", "-m", "first")
 
@@ -240,6 +248,100 @@ func TestPrePushSecretsAllowed_Truthy(t *testing.T) {
 			assert.Equal(t, want, prePushSecretsAllowed())
 		})
 	}
+}
+
+// TestScanPrePushForSecrets_OnlyScansSessionsScope is the scope contract.
+//
+// Failure prevented (ox-cqdo, 2026-05-12): in PR #597 the gate was unscoped
+// and would scan every changed file in the push range. A daemon-written
+// data/github/<date>/pr/<n>.json containing PR copy that happens to match
+// `aws_sts_session_key` or `generic_secret` blocked every subsequent push
+// of a healthy ledger — and the gate's recovery message pointed the user
+// at `ox session audit` / `ox session redact`, which only operate on
+// sessions/. The fix scoped the scanner to prePushScannerScopePrefixes;
+// this test pins that contract so a future widening of scope must come
+// with a deliberate broadening of the recovery surface.
+func TestScanPrePushForSecrets_OnlyScansSessionsScope(t *testing.T) {
+	// Same canary in both a sessions/ path (must be flagged) and a
+	// data/github/ path (must NOT be flagged — it's a verbatim cache of
+	// bytes already published on GitHub, intentionally not gated; see
+	// prePushScannerScopePrefixes for the policy).
+	canary := `{"text":"AKIAIOSFODNN7EXAMPLE"}` + "\n"
+	work := makeLedgerWithCommit(t, map[string]string{
+		"sessions/2026-05-12/raw.jsonl":      canary,
+		"data/github/2026/05/09/pr/42.json":  canary,
+		"data/github/2026/05/11/issue/7.json": canary,
+		"kb/notes.md":                        canary,
+		"team-context/conventions.md":        canary,
+	})
+
+	result, err := scanPrePushForSecrets(context.Background(), work)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// exactly one path is in scope; it must be the only one scanned and
+	// the only one with findings.
+	assert.Equal(t, 1, result.FilesScanned,
+		"only sessions/ should be scanned; got FilesScanned=%d", result.FilesScanned)
+	require.NotEmpty(t, result.Findings)
+	for _, f := range result.Findings {
+		assert.True(t, strings.HasPrefix(f.Path, "sessions/"),
+			"finding outside sessions/ scope: %s (%s)", f.Path, f.Detector)
+	}
+}
+
+// TestInPrePushScannerScope pins the scope predicate itself. Cheap to run
+// and keeps the contract surface visible — the production scanner is built
+// on top of this function, so widening it without a deliberate test edit
+// would let new paths into the gate silently.
+func TestInPrePushScannerScope(t *testing.T) {
+	cases := map[string]bool{
+		"sessions/abc/raw.jsonl":              true,
+		"sessions/2026-05-12/meta.json":       true,
+		"data/github/2026/05/11/pr/1.json":    false,
+		"data/github/issue/x.json":            false,
+		"kb/notes.md":                         false,
+		"team-context/conventions.md":         false,
+		"docs/README.md":                      false,
+		".sageox/config.json":                 false,
+		"":                                    false,
+		"session/typo/raw.jsonl":              false, // singular: not the prefix
+		"sessionsfoo/raw.jsonl":               false, // no trailing slash
+	}
+	for path, want := range cases {
+		t.Run(path, func(t *testing.T) {
+			assert.Equal(t, want, inPrePushScannerScope(path))
+		})
+	}
+}
+
+// TestFormatPrePushFindings_RecoveryMatchesScannerScope encodes the
+// writer-vs-message contract that the original bug exposed: the recovery
+// message tells the user to run `ox session audit` and `ox session redact`.
+// Those commands operate on the same path prefix that the scanner inspects.
+// If a future change widens prePushScannerScopePrefixes beyond what the
+// recovery commands can fix, the user is again handed instructions that
+// don't apply to the flagged path — exactly the symptom that prompted this
+// fix.
+//
+// We pin both directions: every scope prefix must appear in some recovery
+// command surface, and the recovery message must continue to reference
+// session-scoped tooling.
+func TestFormatPrePushFindings_RecoveryMatchesScannerScope(t *testing.T) {
+	r := &PrePushScanResult{
+		Findings: []PrePushFinding{
+			{Detector: "aws_access_key", Path: "sessions/x/raw.jsonl", Line: 1},
+		},
+	}
+	msg := FormatPrePushFindings(r)
+	assert.Contains(t, msg, "ox session audit",
+		"recovery message must reference the audit command that covers sessions/")
+	assert.Contains(t, msg, "ox session redact",
+		"recovery message must reference the redact command that covers sessions/")
+	// If the scanner is ever widened, the recovery surface must widen too.
+	// Today only "sessions/" is in scope.
+	assert.Equal(t, []string{"sessions/"}, prePushScannerScopePrefixes,
+		"scope widened without updating recovery message; see ox-cqdo")
 }
 
 // TestPrePushScanner_LargeFileExceedsCap verifies that files over the size

--- a/cmd/ox/redactor_wiring.go
+++ b/cmd/ox/redactor_wiring.go
@@ -2,33 +2,28 @@ package main
 
 import (
 	"github.com/sageox/ox/internal/gitserver"
-	"github.com/sageox/ox/internal/ledger"
-	"github.com/sageox/ox/internal/session"
 )
 
 // init wires cross-cutting hooks that internal packages need but cannot
-// resolve themselves without creating import cycles. Two hooks today:
+// resolve themselves without creating import cycles.
 //
-//   1. ledger.SetFieldRedactor — credential redaction for GitHub PR/Issue
-//      cache writers (ox-8bkk). internal/ledger can't import
-//      internal/session (cycle via session/health → ledger).
-//
-//   2. gitserver.SetHelperCommand — the shell command git invokes to
+//   1. gitserver.SetHelperCommand — the shell command git invokes to
 //      resolve credentials via ox-managed credential storage (ox-eeqi).
 //      internal/gitserver can't import cmd/ox to discover the running
 //      binary's absolute path.
 //
-// Both hooks apply to every ox CLI invocation, including the embedded
+// Previously also wired `ledger.SetFieldRedactor` (ox-8bkk) to scrub
+// credential patterns from GitHub PR/Issue cache fields at write time.
+// Removed per ox-cqdo (2026-05-12): `data/github/**` is a verbatim cache
+// of bytes already published on GitHub. Replicating those bytes into the
+// ledger is the same exposure surface we already accept by ingesting the
+// PR/Issue at all — rewriting them on the way to disk introduces a
+// false-positive class that blocks pushes for no actual security gain.
+// The `FieldRedactor` plumbing in internal/ledger is retained as a
+// no-op pass-through so a future warn-on-detect mode can re-use it.
+//
+// This hook applies to every ox CLI invocation, including the embedded
 // daemon — the daemon does not have a separate main package.
 func init() {
-	r := session.NewRedactor()
-	ledger.SetFieldRedactor(func(s string) string {
-		if s == "" {
-			return s
-		}
-		out, _ := r.RedactString(s)
-		return out
-	})
-
 	gitserver.SetHelperCommand(HelperCommandString())
 }

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-12
+
+### Fixed
+
+**Pre-push credential gate no longer blocks routine pushes on legacy `data/github/` content**
+- 0.8.0 introduced a pre-push secret scanner that ran against every file in the push range, including `data/github/**` PR/Issue caches. PR titles, bodies, and comments often contain text that matches credential heuristics (sample `Authorization: Bearer` snippets, the literal phrase "STS session key", and other public bytes already on GitHub). The result was a persistent block: `ox doctor` reconcile failed with messages like *"Push refused: 3 credential pattern(s) detected in 2 file(s)"* pointing at PR cache JSON the user did not author and could not fix by running `ox session audit` or `ox session redact` — the recovery commands the gate's error message names. On clean machines the only escape was setting `OX_ALLOW_SECRETS=1`, which defeats the gate's purpose.
+- The fix is two-part:
+  - The pre-push scanner is now scoped to `sessions/**` only — the path where genuinely unscrubbed AI session content can land. `data/github/**`, `kb/**`, and `team-context/**` are intentionally out of scope (verbatim caches or user-authored content).
+  - The companion writer-side redactor that 0.8.0 wired into `WriteGitHubPR` / `WriteGitHubIssue` is unwired. PR/Issue bytes are now stored verbatim. Rewriting bytes that are already public on GitHub never gave a real security gain and was the upstream cause of the false-positive class.
+- Existing in-flight sessions with real findings are still gated. The recovery message (`ox session audit` / `ox session redact`) now corresponds to the actual flagged paths, so users can follow it.
+- New scope-contract tests in `cmd/ox/prepush_scan_test.go` pin the policy: any future widening of the scanner must come with a deliberate broadening of the recovery surface.
+
 ## [0.8.0] - 2026-05-12
 
 ### Added

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -11,13 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-**Pre-push credential gate no longer blocks routine pushes on legacy `data/github/` content**
-- 0.8.0 introduced a pre-push secret scanner that ran against every file in the push range, including `data/github/**` PR/Issue caches. PR titles, bodies, and comments often contain text that matches credential heuristics (sample `Authorization: Bearer` snippets, the literal phrase "STS session key", and other public bytes already on GitHub). The result was a persistent block: `ox doctor` reconcile failed with messages like *"Push refused: 3 credential pattern(s) detected in 2 file(s)"* pointing at PR cache JSON the user did not author and could not fix by running `ox session audit` or `ox session redact` — the recovery commands the gate's error message names. On clean machines the only escape was setting `OX_ALLOW_SECRETS=1`, which defeats the gate's purpose.
-- The fix is two-part:
-  - The pre-push scanner is now scoped to `sessions/**` only — the path where genuinely unscrubbed AI session content can land. `data/github/**`, `kb/**`, and `team-context/**` are intentionally out of scope (verbatim caches or user-authored content).
-  - The companion writer-side redactor that 0.8.0 wired into `WriteGitHubPR` / `WriteGitHubIssue` is unwired. PR/Issue bytes are now stored verbatim. Rewriting bytes that are already public on GitHub never gave a real security gain and was the upstream cause of the false-positive class.
-- Existing in-flight sessions with real findings are still gated. The recovery message (`ox session audit` / `ox session redact`) now corresponds to the actual flagged paths, so users can follow it.
-- New scope-contract tests in `cmd/ox/prepush_scan_test.go` pin the policy: any future widening of the scanner must come with a deliberate broadening of the recovery surface.
+**Pre-push credential gate no longer blocks routine pushes**
+
+0.8.0 introduced a pre-push secret scanner that scanned every file in the push range and refused the push on any finding. In practice this had two failure modes:
+
+1. The scanner ran against `data/github/**` PR/Issue caches. PR titles, bodies, and comments often contain text that matches credential heuristics (sample `Authorization: Bearer` snippets, phrases like "STS session key", and other public bytes already on GitHub). `ox doctor` reconcile failed with *"Push refused: 3 credential pattern(s) detected in 2 file(s)"* pointing at JSON the user did not author. The recovery message named `ox session audit` / `ox session redact` — commands that only operate on `sessions/`, leaving the user unable to follow the instructions for paths outside `sessions/`.
+
+2. Even after scoping, a single session with a finding the chokepoint had missed would refuse the entire push, holding up every other session and unrelated commit.
+
+The gate is now scoped + recoverable + never-blocking:
+
+- **Scoped:** the scanner only inspects paths under `sessions/`. `data/github/**` (verbatim cache of bytes already public on GitHub), `kb/**` (user-curated), and `team-context/**` (user-authored markdown) are intentionally out of scope. The companion writer-side redactor that 0.8.0 wired into `WriteGitHubPR` / `WriteGitHubIssue` is unwired for the same reason.
+- **Auto-recovers:** on a finding in a session's JSONL, the gate rewrites the file in place through the canonical chokepoint, appends a `RedactionPass` audit-trail entry to the session's `meta.json`, amends the holding commit, and re-scans. The push then proceeds with scrubbed bytes.
+- **Quarantines what can't be auto-redacted:** findings in non-JSONL session paths (notes, summaries, transcripts) are moved to `.sageox/cache/quarantine/<session>/` — bytes preserved verbatim on disk — and dropped from the holding commit. The rest of the push proceeds normally; other sessions and unrelated commits sync as before.
+- **Surfaces persistent state in doctor:** a new `ledger-redaction-debt` check reports every quarantined session with the affected detectors and next-step recovery commands. The check is read-only; recovery is a deliberate user gesture (`ox session redact`, or manually inspect + restore from `.sageox/cache/quarantine/`).
+- **Never blocks:** the gate always returns nil. Recovery errors are logged, not propagated.
+
+`OX_ALLOW_SECRETS=1` still short-circuits the recovery pipeline for explicit "publish as-is" overrides.
+
+New tests pin the scope contract, the auto-redact happy path, the quarantine path with data preservation, and the doctor surface.
 
 ## [0.8.0] - 2026-05-12
 

--- a/internal/ledger/github_data.go
+++ b/internal/ledger/github_data.go
@@ -128,18 +128,25 @@ func DateDir(ledgerPath string, t time.Time, dataType string) string {
 	)
 }
 
-// FieldRedactor is an optional function that scrubs credential patterns from
-// user-authored text fields before a PR or Issue is serialized to disk.
-// `internal/ledger` cannot import `internal/session` (cycle via session/health),
-// so the secret redactor lives in a sibling package and is injected from above.
-// When SetFieldRedactor has not been called, WriteGitHubPR/WriteGitHubIssue
-// passes content through unchanged — but every CLI/daemon entry point that can
-// reach these writers MUST set a redactor at startup (see cmd/ox/main.go).
+// FieldRedactor is an optional hook that can rewrite user-authored text
+// fields (PR/Issue title, body, comments, commit messages) before they
+// are serialized to disk. `internal/ledger` cannot import
+// `internal/session` (cycle via session/health), so the hook is injected
+// from above.
 //
-// Per ox-8bkk: the forensic scan on 2026-05-10 found 16 Authorization: Bearer
-// headers across 8 PR cache files. They came from PR descriptions and comments
-// (user-authored text that pasted curl examples), not from any HTTP-header
-// capture in ox itself. Redaction at the cache writer closes that hole.
+// As of ox-cqdo (2026-05-12) no entry point installs a redactor, so
+// these calls are pass-throughs. The plumbing is retained so a future
+// warn-on-detect mode can re-use the same chokepoint without re-plumbing
+// the package boundary.
+//
+// History: ox-8bkk briefly installed a credential-redacting hook here on
+// the theory that the 2026-05-10 forensic scan's hits in PR cache files
+// (16 `Authorization: Bearer` strings across 8 files) warranted scrubbing
+// at the cache writer. That reasoning was wrong: the bytes in question
+// were already public on GitHub, and rewriting them in the local cache
+// drove a false-positive class in the push-time gate (cmd/ox/prepush_scan.go)
+// that blocked routine pushes. The pre-push gate is now scoped to
+// `sessions/**` only and the cache writer no longer rewrites content.
 type FieldRedactor func(string) string
 
 var fieldRedactor FieldRedactor
@@ -205,10 +212,12 @@ func redactIssue(issue *IssueFile) *IssueFile {
 // WriteGitHubPR writes a PR to its date-partitioned directory based on created_at.
 // Creates the directory structure if it does not exist.
 //
-// Credentials in user-authored fields (Title, Body, Comments, commit messages)
-// are redacted before serialization when a FieldRedactor has been installed via
-// SetFieldRedactor. Per ox-8bkk, this closes the cache-side credential leak that
-// forensic scans observed in PR JSON files.
+// Content is serialized verbatim. The optional FieldRedactor hook is a
+// no-op pass-through in production today (see ox-cqdo) — `data/github/**`
+// is a cache of bytes already published on GitHub, and rewriting them
+// here is a net negative (false-positive class in the push-time gate, no
+// real security gain). The hook is retained for a future warn-on-detect
+// mode.
 //
 // Design decision: files stay in the created_at date directory permanently — we do NOT
 // move them on close/merge. This means long-lived open issues may fall outside the

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.8.0"
+	Version   = "0.8.1"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## Summary

The 0.8.0 pre-push secret gate (`cmd/ox/prepush_scan.go`, introduced in #597) refused the whole push on any detector hit anywhere in the push range. Two compounding problems shipped together:

1. The scanner ran against `data/github/**` PR/Issue caches. PR titles, bodies, and comments contain text matching credential heuristics — sample `Authorization: Bearer` snippets, the literal phrase "STS session key", and other bytes already public on GitHub. `ox doctor` reconcile failed on clean machines with *"Push refused: 3 credential pattern(s) detected in 2 file(s)"* pointing at JSON the user did not author and could not fix via `ox session audit` / `ox session redact` (the recovery commands the gate's error message names — neither operates on `data/github/`).
2. Even after scoping, a single session with a finding would refuse every other session and unrelated commit in the same push.

### What this PR changes

| Layer | Before (0.8.0) | After (0.8.1) |
|---|---|---|
| Scanner scope | Every file in `origin/main...HEAD` | `sessions/**` only |
| `data/github/**` writer-side redactor | Wired (rewrites PR/Issue bytes on every `WriteGitHubPR`/`WriteGitHubIssue`) | Unwired — pass-through |
| On finding in JSONL session | Refuse push | Rewrite via canonical chokepoint, append `RedactionPass` to `meta.json`, amend holding commit, push proceeds |
| On finding the chokepoint can't fix | Refuse push | Atomically move to `.sageox/cache/quarantine/<session>/<file>`, carve path out of holding commit, write a debt marker, push proceeds with the rest of the commit |
| Doctor surface | None | New `ledger-redaction-debt` check surfaces every quarantined session + next-step recovery |
| Return contract | Returns error when findings present | Never returns an error — recovery errors are logged, push proceeds |

`OX_ALLOW_SECRETS=1` keeps its short-circuit semantics for explicit "publish as-is" overrides.

### Pre-push gate flow

```mermaid
flowchart TD
    A[pushLedger] --> B[runPrePushSecretGate]
    B --> C{scan sessions/ only}
    C -- clean --> Z[return nil]
    C -- findings --> D{OX_ALLOW_SECRETS=1?}
    D -- yes --> W[warn loudly to stderr] --> Z
    D -- no --> E[autoRedactSessionFindings: per session run redactFileInPlace, append RedactionPass to meta.json, stage --sparse, amend]
    E --> F{re-scan}
    F -- clean --> G[stderr: redacted N files] --> Z
    F -- findings remain --> H[quarantineUnredactableFindings]
    H --> H1[move file to .sageox/cache/quarantine/session/]
    H1 --> H2[git reset HEAD~ -- path, or git rm --cached if no HEAD~]
    H2 --> H3[git commit --amend]
    H3 --> H4[write .sageox/cache/redaction-debt/session.json]
    H4 --> I[stderr: quarantined N files, names listed, points at ox doctor]
    I --> Z
```

### Why quarantine, not block

The daemon's session-finalize watches `<ledger>/sessions/` and `<ledger>/.sageox/cache/sessions/` (see `internal/daemon/agentwork/session_finalize.go`). The quarantine path `<ledger>/.sageox/cache/quarantine/` is outside both, so anti-entropy will not re-introduce a quarantined file. Bytes are preserved verbatim on disk for forensic inspection or manual recovery; the holding commit drops only those paths.

### Why unwire the `data/github/**` writer-side redactor

`data/github/**` is a verbatim cache of bytes already published on GitHub. Replicating those bytes into the ledger has the same exposure surface as ingesting the PR/Issue at all. Rewriting them at write time:
- Adds no real security gain (bytes are already public).
- Is the upstream cause of the false-positive class — legacy unredacted bytes already on `origin/main` keep tripping the scanner on every re-touch.

The `FieldRedactor` plumbing is retained as a no-op pass-through so a future warn-on-detect mode can re-use the same chokepoint without re-plumbing the package boundary.

### Scope contract

`TestFormatPrePushFindings_RecoveryMatchesScannerScope` pins the policy: any future widening of `prePushScannerScopePrefixes` must come with a deliberate broadening of the recovery message surface. `TestInPrePushScannerScope` table-tests the scope predicate. `TestScanPrePushForSecrets_OnlyScansSessionsScope` exercises end-to-end that `data/github/**`, `kb/**`, and `team-context/**` paths are not scanned even when they carry planted canaries.

### What's deferred

- **`ox-tduv`** — daemon anti-entropy interactions for sessions quarantined long-term + an optional `ox session accept-unredacted <name>` command for explicit "I reviewed it, publish as-is" flow. Today the user manually moves the quarantined bytes back to `sessions/<name>/` and commits, or uses `OX_ALLOW_SECRETS=1` per-push.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go vet ./...` — clean
- [x] `go test ./cmd/ox ./internal/ledger -short -count=1` — all green
- [x] `make verify-version` — 0.8.1 across version.go, marketplace.json, plugin.json, CHANGELOG
- [x] New tests cover: JSONL auto-redact happy path + meta.json provenance + bytes-scrubbed-on-disk; non-JSONL quarantine path + bytes-preserved-in-quarantine + commit-carve-out + sibling-paths-survive; doctor marker parse / aggregate / malformed handling; `OX_ALLOW_SECRETS=1` still short-circuits recovery
- [x] Existing scope-contract suite still green
- [ ] Reviewer to validate on a real ledger with legacy `data/github/` content: `ox doctor` reconcile should now pass; `ox doctor` should surface any quarantined sessions under "Ledger redaction debt"

## Files

| Path | Change |
|---|---|
| `cmd/ox/prepush_scan.go` | Scope filter to `sessions/`; `runPrePushSecretGate` now never blocks — auto-redact + quarantine flow |
| `cmd/ox/prepush_autoredact.go` | New — `autoRedactSessionFindings`, `quarantineUnredactableFindings`, `redactionDebtRecord` |
| `cmd/ox/prepush_scan_test.go` | Scope-contract tests; replaced blocking-behavior tests with never-block assertions |
| `cmd/ox/prepush_autoredact_test.go` | New — JSONL auto-redact, non-JSONL quarantine, override semantics |
| `cmd/ox/doctor_redaction_debt.go` | New — `ledger-redaction-debt` check |
| `cmd/ox/doctor_redaction_debt_test.go` | New — marker parse / aggregate / malformed handling |
| `cmd/ox/doctor_check_registry.go` + `doctor_types.go` | Register new check |
| `cmd/ox/redactor_wiring.go` | Unwire `ledger.SetFieldRedactor` |
| `internal/ledger/github_data.go` | Update doc comments; `redactPR` / `redactIssue` now no-op pass-through |
| `internal/version/version.go`, `.claude-plugin/marketplace.json`, `claude-plugin/.claude-plugin/plugin.json`, `CHANGELOG.md` | Version bump 0.8.0 → 0.8.1 + release notes |
