### PR TITLE
fix(codedb): recover Bleve.Batch panics; probe field FSTs in CheckIntegrity

### DIFF
--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -132,7 +132,7 @@ func (st *indexState) flushCodeBatch(force bool) error {
 	if !force && st.codeBatchN < bleveBatchSize {
 		return nil
 	}
-	if err := st.store.CodeIndex.Batch(st.codeBatch); err != nil {
+	if err := safeBatch(func() error { return st.store.CodeIndex.Batch(st.codeBatch) }); err != nil {
 		return fmt.Errorf("flush code batch: %w", err)
 	}
 	st.codeBatch = st.store.CodeIndex.NewBatch()
@@ -152,7 +152,7 @@ func (st *indexState) flushDiffBatch(force bool) error {
 	if !force && st.diffBatchN < bleveBatchSize {
 		return nil
 	}
-	if err := st.store.DiffIndex.Batch(st.diffBatch); err != nil {
+	if err := safeBatch(func() error { return st.store.DiffIndex.Batch(st.diffBatch) }); err != nil {
 		st.diffIndexFailed = true
 		slog.Warn("codedb: diff index write failed, type:diff search will be incomplete for this run", "err", err)
 		st.diffBatch = st.store.DiffIndex.NewBatch()
@@ -477,7 +477,7 @@ func BuildDirtyIndex(ctx context.Context, localPath, dirtyPath string, opts Inde
 	}
 
 	if indexed > 0 {
-		if err := dirtyIdx.Batch(batch); err != nil {
+		if err := safeBatch(func() error { return dirtyIdx.Batch(batch) }); err != nil {
 			dirtyIdx.Close()
 			_ = os.RemoveAll(tmpPath)
 			return 0, fmt.Errorf("batch dirty index: %w", err)
@@ -2071,7 +2071,7 @@ sendLoop2:
 				stats.CommentsExtracted++
 
 				if commentBatchN >= bleveBatchSize {
-					if err := s.CommentIndex.Batch(commentBatch); err != nil {
+					if err := safeBatch(func() error { return s.CommentIndex.Batch(commentBatch) }); err != nil {
 						rows.Close()
 						return stats, fmt.Errorf("flush comment batch: %w", err)
 					}
@@ -2102,7 +2102,7 @@ sendLoop2:
 
 	// flush remaining bleve batch after SQL commit
 	if commentBatchN > 0 {
-		if err := s.CommentIndex.Batch(commentBatch); err != nil {
+		if err := safeBatch(func() error { return s.CommentIndex.Batch(commentBatch) }); err != nil {
 			return stats, fmt.Errorf("flush final comment batch: %w", err)
 		}
 	}

--- a/internal/codedb/index/safebatch.go
+++ b/internal/codedb/index/safebatch.go
@@ -1,0 +1,26 @@
+package index
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// safeBatch runs fn (a bleve.Index.Batch call) with panic recovery.
+//
+// Why: a corrupt Bleve segment — observed in production as a nil FST left by
+// partial-write disk corruption — panics deep inside vellum during batch
+// processing. Without recovery the panic unwinds through the caller's
+// deferred db.Close(), which contends for the same bbolt lock the batch was
+// holding, producing a self-deadlock that pins the daemon (one incident:
+// 39 minutes wedged in sync.Mutex.Lock while indexing_now stayed true).
+//
+// Recovering at the batch boundary converts the panic into a normal error
+// return so the caller's Close path runs and the failure surfaces.
+func safeBatch(fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("bleve batch panicked (likely corrupt index): %v\n%s", r, debug.Stack())
+		}
+	}()
+	return fn()
+}

--- a/internal/codedb/index/safebatch_test.go
+++ b/internal/codedb/index/safebatch_test.go
@@ -1,0 +1,71 @@
+package index
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// --- safeBatch ---
+
+// TestSafeBatch_RecoversPanic verifies that a panic inside the batch closure
+// is converted to a normal error return.
+//
+// Failure prevented: a nil-FST panic in Bleve.Batch escapes the call site,
+// unwinds through doIndex's deferred db.Close(), and deadlocks the daemon on
+// the bbolt mutex still held by the panicked batch (observed wedge:
+// 39 minutes in sync.Mutex.Lock with indexing_now reporting true).
+func TestSafeBatch_RecoversPanic(t *testing.T) {
+	t.Parallel()
+	err := safeBatch(func() error {
+		panic("simulated vellum nil FST")
+	})
+	if err == nil {
+		t.Fatal("expected error from panicking batch, got nil")
+	}
+	if !strings.Contains(err.Error(), "panicked") {
+		t.Errorf("error should mention panic, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "simulated vellum nil FST") {
+		t.Errorf("error should preserve panic value, got: %v", err)
+	}
+}
+
+// TestSafeBatch_PassesThroughError ensures normal (non-panic) errors from the
+// batch closure flow through unchanged so callers' errors.Is/As checks keep
+// working.
+func TestSafeBatch_PassesThroughError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("real batch error")
+	got := safeBatch(func() error { return want })
+	if !errors.Is(got, want) {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+// TestSafeBatch_NilOnSuccess ensures the happy path returns nil with no
+// allocation surprises from the recover defer.
+func TestSafeBatch_NilOnSuccess(t *testing.T) {
+	t.Parallel()
+	if err := safeBatch(func() error { return nil }); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+// TestSafeBatch_RecoversNonStringPanic verifies the recover handles arbitrary
+// panic values (e.g. runtime.Error from a nil pointer dereference), not just
+// string panics.
+func TestSafeBatch_RecoversNonStringPanic(t *testing.T) {
+	t.Parallel()
+	err := safeBatch(func() error {
+		var p *int
+		_ = *p // nil pointer deref → runtime.Error
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error from nil-deref panic, got nil")
+	}
+	if !strings.Contains(err.Error(), "panicked") {
+		t.Errorf("error should mention panic, got: %v", err)
+	}
+}

--- a/internal/codedb/store/integrity_test.go
+++ b/internal/codedb/store/integrity_test.go
@@ -1,0 +1,140 @@
+package store
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2"
+)
+
+// --- probeBleveIndex ---
+
+// TestProbeBleveIndex_EmptyIndexPasses verifies a fresh empty Bleve index
+// (no segments) passes the probe. Document() on a non-existent ID against
+// an empty index returns (nil, nil) without touching any FST.
+//
+// Failure prevented: probe rejects freshly-opened indexes and triggers
+// needless full reindexes during normal daemon startup.
+func TestProbeBleveIndex_EmptyIndexPasses(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: bleve open")
+	}
+	mapping := bleve.NewIndexMapping()
+	idx, err := bleve.NewMemOnly(mapping)
+	if err != nil {
+		t.Fatalf("NewMemOnly: %v", err)
+	}
+	defer idx.Close()
+
+	if err := probeBleveIndex(idx, "code"); err != nil {
+		t.Errorf("expected nil for empty index, got: %v", err)
+	}
+}
+
+// TestProbeBleveIndex_PopulatedIndexExercisesFST indexes a real document so
+// segments exist with _id and field FSTs, then probes. Document() forces
+// segment.Dictionary("_id") loading via TermFieldReader (synchronous,
+// caller goroutine). If the probe was regressed to bypass FST loading
+// (e.g. silently switched back to a doc-id-bitmap query), this test would
+// still pass — but a real corrupt-bytes scenario in CI would catch a
+// real-world miss.
+//
+// Failure prevented: the probe is rewritten to skip segment dictionary
+// loading and silently passes on indexes whose FST is unloadable.
+func TestProbeBleveIndex_PopulatedIndexExercisesFST(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: bleve open + index")
+	}
+	mapping := bleve.NewIndexMapping()
+	idx, err := bleve.NewMemOnly(mapping)
+	if err != nil {
+		t.Fatalf("NewMemOnly: %v", err)
+	}
+	defer idx.Close()
+
+	if err := idx.Index("doc1", map[string]string{"content": "hello world"}); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+
+	if err := probeBleveIndex(idx, "code"); err != nil {
+		t.Errorf("expected nil for healthy populated index, got: %v", err)
+	}
+}
+
+// --- runBleveProbe ---
+
+// TestRunBleveProbe_RecoversPanicAsErrCorrupt verifies that a panic from
+// the probe closure (e.g. nil FST in a corrupt segment) is converted to
+// ErrCorrupt instead of crashing the daemon.
+//
+// Failure prevented: nil-FST panic during the integrity check kills the
+// daemon process rather than reporting corruption — and the deferred
+// db.Close() in doIndex deadlocks on the still-held bbolt mutex.
+func TestRunBleveProbe_RecoversPanicAsErrCorrupt(t *testing.T) {
+	t.Parallel()
+	err := runBleveProbe("comment", func() error {
+		panic("simulated vellum.(*FST).GetMaxKey nil deref")
+	})
+	if err == nil {
+		t.Fatal("expected error from panicking probe, got nil")
+	}
+	if !errors.Is(err, ErrCorrupt) {
+		t.Errorf("expected ErrCorrupt, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "panic") {
+		t.Errorf("error should mention panic, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "comment") {
+		t.Errorf("error should name the failing index, got: %v", err)
+	}
+}
+
+// TestRunBleveProbe_SearchErrorWrappedAsErrCorrupt verifies that a normal
+// (non-panic) error returned by the probe is wrapped as ErrCorrupt —
+// preserves the pre-existing behavior of CheckIntegrity treating any
+// probe failure as corruption.
+func TestRunBleveProbe_SearchErrorWrappedAsErrCorrupt(t *testing.T) {
+	t.Parallel()
+	err := runBleveProbe("diff", func() error {
+		return errors.New("search subsystem broken")
+	})
+	if err == nil {
+		t.Fatal("expected error from erroring probe, got nil")
+	}
+	if !errors.Is(err, ErrCorrupt) {
+		t.Errorf("expected ErrCorrupt, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "diff") {
+		t.Errorf("error should name the failing index, got: %v", err)
+	}
+}
+
+// TestRunBleveProbe_NilOnSuccess verifies the happy path returns nil.
+func TestRunBleveProbe_NilOnSuccess(t *testing.T) {
+	t.Parallel()
+	if err := runBleveProbe("code", func() error { return nil }); err != nil {
+		t.Errorf("expected nil, got: %v", err)
+	}
+}
+
+// TestRunBleveProbe_RecoversNonStringPanic verifies the recover handles
+// runtime panics (e.g. nil pointer deref), not just string panics. This is
+// the actual shape of the in-the-wild incident: vellum dereferences a nil
+// FST pointer, which raises runtime.Error rather than a string.
+func TestRunBleveProbe_RecoversNonStringPanic(t *testing.T) {
+	t.Parallel()
+	err := runBleveProbe("code", func() error {
+		var p *int
+		_ = *p
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected error from nil-deref panic, got nil")
+	}
+	if !errors.Is(err, ErrCorrupt) {
+		t.Errorf("expected ErrCorrupt, got: %v", err)
+	}
+}

--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -286,16 +286,88 @@ func (s *Store) CheckIntegrity() error {
 		return fmt.Errorf("sqlite: %w", ErrCorrupt)
 	}
 
-	// validate bleve indexes can serve a basic query
 	for name, idx := range map[string]bleve.Index{"code": s.CodeIndex, "diff": s.DiffIndex, "comment": s.CommentIndex} {
-		q := bleve.NewMatchNoneQuery()
-		req := bleve.NewSearchRequest(q)
-		req.Size = 0
-		if _, err := idx.Search(req); err != nil {
-			return fmt.Errorf("bleve %s index: %w", name, ErrCorrupt)
+		if err := probeBleveIndex(idx, name); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+// probeBleveIndex runs an FST-touching probe against every indexed field
+// and reports ErrCorrupt if the FST cannot be loaded or the probe panics.
+//
+// What this probes: each indexed field has a term dictionary backed by a
+// vellum FST (Finite State Transducer) per segment. Partial-write disk
+// corruption can leave a segment whose FST bytes are unloadable — the
+// failure mode that wedges the daemon when the next batch write hits it.
+//
+// Strategy: get the raw IndexReader via Advanced() and call
+// TermFieldReader(field) directly for every field returned by Fields().
+// TermFieldReader iterates segments and calls segment.Dictionary(field)
+// inline on the calling goroutine, so each field's vellum.Load runs where
+// runBleveProbe's recover can catch a panic.
+//
+// Why not Document / FieldDict / MatchAll / MatchNone:
+//   - MatchNone short-circuits with no segment work at all.
+//   - MatchAll in scorch is served from the live-docs bitmap via
+//     DocIDReaderAll(), bypassing the FST.
+//   - FieldDict in scorch spawns one goroutine per segment for the
+//     Dictionary(field) call (see
+//     scorch.IndexSnapshot.newIndexSnapshotFieldDict). A panic in any of
+//     those goroutines escapes the recover in runBleveProbe and crashes
+//     the process.
+//   - Document(id) only loads the "_id" dictionary, so a corrupt FST on
+//     the searchable content field (where most ox queries land) would
+//     pass.
+//
+// Scope: catches FST loading failures (corrupt vellum bytes, bad dict
+// offsets) for every field in the index. The narrower "segment marks
+// field present but dictStart==0, fst is nil" pattern only panics during
+// write-path DocNumbers calls — that path is covered by safeBatch in
+// internal/codedb/index.
+func probeBleveIndex(idx bleve.Index, name string) error {
+	return runBleveProbe(name, func() error {
+		fields, err := idx.Fields()
+		if err != nil {
+			return err
+		}
+		adv, err := idx.Advanced()
+		if err != nil {
+			return err
+		}
+		reader, err := adv.Reader()
+		if err != nil {
+			return err
+		}
+		defer reader.Close()
+
+		probeTerm := []byte("__sageox_codedb_integrity_probe__")
+		for _, field := range fields {
+			tfr, tfrErr := reader.TermFieldReader(context.Background(), probeTerm, field, false, false, false)
+			if tfrErr != nil {
+				return tfrErr
+			}
+			_ = tfr.Close()
+		}
+		return nil
+	})
+}
+
+// runBleveProbe wraps a probe function with the panic-recovery and
+// ErrCorrupt-wrapping policy used by CheckIntegrity. Factored out so the
+// recovery contract can be tested without stubbing the whole bleve.Index
+// interface.
+func runBleveProbe(name string, probe func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("bleve %s index: panic during FST probe (%v): %w", name, r, ErrCorrupt)
+		}
+	}()
+	if sErr := probe(); sErr != nil {
+		return fmt.Errorf("bleve %s index: %w", name, errors.Join(ErrCorrupt, sErr))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Diagnosed in session [2026-05-11T23-30-galexy-OxMfxG](https://sageox.ai): a partial-write disk-corrupted Bleve segment left a vellum FST nil. The next `ParseComments` batch panicked in `vellum.(*FST).GetMaxKey`, unwound through `doIndex`'s deferred `db.Close()`, and the bbolt mutex still held by `Batch()` produced a self-deadlock. The daemon wedged for 39 minutes in `sync.Mutex.Lock` while still reporting `indexing_now: true` to every CLI call.

This PR addresses both halves of the failure: it stops the panic from escaping `Batch()`, and it makes `ox doctor` actually capable of detecting the precondition before the daemon hits it.

```mermaid
flowchart LR
    A[ParseComments] --> B["bleve.Batch()"]
    B -->|holds bbolt mutex| C["vellum.GetMaxKey(nil)"]
    C -->|panic| D["doIndex defer db.Close()"]
    D -->|"contends for same mutex"| E[Deadlock — 39 min wedge]
    style E fill:#fdd,stroke:#a00
```

## Changes

**1. `safeBatch` wrapper at every Bleve `Index.Batch` call site** — `internal/codedb/index/indexer.go` + `internal/codedb/index/safebatch.go`
- Recovers panics from `Batch()` and converts them to errors so the caller's deferred `db.Close()` runs normally instead of deadlocking.
- Applied to all 5 sites: code batch flush, diff batch flush, dirty-index batch, comment batch (mid-loop and final).

**2. `CheckIntegrity` probe rewrite** — `internal/codedb/store/store.go`
- Old probe used `bleve.NewMatchNoneQuery()` with `Size=0`, which never touched the FST — the corruption it was supposed to catch was invisible.
- New probe path: `idx.Fields()` → `idx.Advanced()` → `adv.Reader()` → for each field, `reader.TermFieldReader(ctx, probeTerm, field, ...)`. Each `segment.Dictionary(field)` (where `vellum.Load` happens) runs inline on the calling goroutine. Critically, this avoids `FieldDict`, which scorch implements by spawning one goroutine per segment whose panic would escape our `recover`.
- Walks every indexed field, not just `_id`, so corruption on the searchable `content` field is detected.
- Wrapped in `runBleveProbe` which `recover()`s panics and returns `ErrCorrupt`.

### Iteration history

The probe went through four review rounds with Codex before landing here:
1. `MatchAllQuery` — but scorch serves it from `DocIDReaderAll()`, bypassing the FST.
2. `FieldDict.Next()` — but `Close()` was non-deferred, leaking the index read lock on panic.
3. `FieldDict` with `defer Close()` — but scorch's `newIndexSnapshotFieldDict` spawns a goroutine per segment for `Dictionary(field)`; panics in those goroutines escape recover.
4. `Document(id)` — synchronous, but only loads the `_id` FST; misses corruption on `content`.
5. `Advanced() + Reader() + TermFieldReader` per field — synchronous and covers every field. ← shipped

## Scope and known limits

- The probe catches FST loading failures (bad vellum bytes, dict-offset errors).
- It does **not** catch the niche "field present in fieldsMap but `dictStart == 0`, returns a dict with `fst == nil`" pattern — that one only panics during write-path `DocNumbers` calls. `safeBatch` covers it at the actual call site.
- A separate hardening pass (bounded `db.Close()` defer in `doIndex`) is intentionally **not** in this PR — different shape of change, deserves its own review.

## Test plan

- [x] `make lint` clean on touched files
- [x] `go test ./internal/codedb/...` all green
- [x] `safebatch_test.go` — panic, error pass-through, success, non-string runtime panic
- [x] `integrity_test.go` — empty index passes; populated index passes; panic/error/runtime-panic in probe → `ErrCorrupt`
- [ ] Manual: run `ox code index --full` on a real repo, verify no regressions
- [ ] Manual: simulate corruption (truncate a `.zap` segment file mid-FST), confirm `ox doctor` reports `ErrCorrupt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for database batch operations to prevent crashes and convert panics into recoverable errors.
  * Enhanced database integrity checks with more thorough validation to detect corruption earlier.

* **Tests**
  * Added comprehensive test coverage for error recovery and database integrity validation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/607)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->