### PR TITLE
fix(claude-hooks): stop rewriting .claude/settings.json on every session

### DIFF
--- a/cmd/ox/doctor_fix_hooks.go
+++ b/cmd/ox/doctor_fix_hooks.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,10 +56,22 @@ func checkClaudeHooksFormat(fix bool) checkResult {
 		return FailedCheck("Claude hooks format", "re-marshal failed", err.Error())
 	}
 
-	// Compare canonical bytes (post-MarshalIndent) against on-disk. If
-	// already canonical, nothing to do — keeps the check idempotent so
-	// repeated `doctor --fix` runs don't churn the file.
-	if bytes.Equal(bytes.TrimSpace(data), bytes.TrimSpace(canonical)) {
+	// "Already canonical" requires two things:
+	//   1. On-disk hooks values parse strictly into the array shape Claude
+	//      Code reads (no parseHooksMixed legacy-string fallback).
+	//   2. Semantic content matches what we'd emit — ignoring encoder
+	//      cosmetics (HTML escaping of <, >, &; trailing newline; \uXXXX
+	//      vs literal rune; key order; indentation inside opaque blocks).
+	//
+	// Byte equality alone is too strict (cosmetic drift triggers rewrites
+	// forever); semantic equality alone is too permissive (legacy string-
+	// form parses to the same in-memory shape as canonical array form, so
+	// the check would refuse to migrate broken files). Combining both gives
+	// the property users actually want: idempotent on any file Claude Code
+	// will accept, repairing only the ones it won't.
+	canonicalOnDisk, _ := claude.IsCanonicalHooksFormat(data)
+	semEqual, _ := claude.SettingsSemanticallyEqual(data, canonical)
+	if canonicalOnDisk && semEqual {
 		return PassedCheck("Claude hooks format", "canonical")
 	}
 

--- a/cmd/ox/doctor_fix_hooks_test.go
+++ b/cmd/ox/doctor_fix_hooks_test.go
@@ -204,3 +204,161 @@ func TestCheckClaudeHooksFormat_DetectsWithoutFix(t *testing.T) {
 		t.Error("expected actionable detail pointing the user at `ox doctor --fix`")
 	}
 }
+
+// TestCheckClaudeHooksFormat_LeavesUserAuthoredFileUntouched is the regression
+// test for the "settings.json rewritten on every Claude Code session" bug
+// (ox-647t). Prior to the fix, MarshalSettings used encoding/json defaults
+// that HTML-escape <, >, & and strip trailing newlines, and both no-op
+// guards (here and in internal/doctor/autofix/default_checks.go) compared
+// bytes after re-marshaling. Any user-authored file that contained those
+// characters in a permission rule, or simply ended with a newline, would
+// be silently rewritten on every doctor / autofix pass — the rewrite
+// itself produced encoder output that drifted on the next pass too, so
+// the file churned forever even though no real content had changed.
+//
+// Failure prevented: doctor mutating a user's hand-written settings.json
+// on every session. Concretely: a file containing `<`, `>`, `&` literals
+// in a Bash() permission rule must remain byte-identical across two
+// consecutive checkClaudeHooksFormat(true) calls.
+//
+// This is the adversarial-input test that was missing — the existing
+// idempotency test seeded `{"hooks": {"PostToolUse": "echo legacy"}}`,
+// which has none of the bytes that exposed the bug. A test that only
+// round-trips the encoder's own output can never catch an encoder that
+// mistreats user input.
+func TestCheckClaudeHooksFormat_LeavesUserAuthoredFileUntouched(t *testing.T) {
+	gitRoot := testGitRepo(t)
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	if err := os.Chdir(gitRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	// User-authored settings.json: array-form hooks, literal HTML
+	// characters in a permission rule, hand-written \uXXXX escape,
+	// trailing newline, four-space indentation, top-level keys in
+	// insertion order (permissions before hooks). All of these are
+	// shapes the previous byte-equal guard would have rewritten.
+	userAuthored := "{\n" +
+		"    \"permissions\": {\n" +
+		"        \"allow\": [\n" +
+		"            \"Bash(grep '</script>':*)\",\n" +
+		"            \"Bash(curl 'https://example.com/?a=1\\u0026b=2':*)\"\n" +
+		"        ]\n" +
+		"    },\n" +
+		"    \"hooks\": {\n" +
+		"        \"SessionStart\": [\n" +
+		"            {\n" +
+		"                \"matcher\": \"\",\n" +
+		"                \"hooks\": [\n" +
+		"                    {\"command\": \"ox agent hook SessionStart\", \"type\": \"command\"}\n" +
+		"                ]\n" +
+		"            }\n" +
+		"        ]\n" +
+		"    }\n" +
+		"}\n"
+	path := writeRawSettings(t, gitRoot, userAuthored)
+
+	first := checkClaudeHooksFormat(true)
+	if !first.passed {
+		t.Fatalf("first pass should pass on a well-formed user file: %+v", first)
+	}
+	if strings.Contains(first.message, "repaired") {
+		t.Errorf("well-formed user file was rewritten on first pass: %q\n"+
+			"this is the regression — user content must not be mutated by the no-op path",
+			first.message)
+	}
+	afterFirst, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterFirst) != userAuthored {
+		t.Errorf("on-disk bytes changed after first checkClaudeHooksFormat(true)\nwant:\n%s\ngot:\n%s",
+			userAuthored, string(afterFirst))
+	}
+
+	second := checkClaudeHooksFormat(true)
+	if strings.Contains(second.message, "repaired") {
+		t.Errorf("idempotency broken — second pass rewrote: %q", second.message)
+	}
+	afterSecond, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterSecond) != string(afterFirst) {
+		t.Errorf("file mutated between consecutive passes\nfirst:\n%s\nsecond:\n%s",
+			string(afterFirst), string(afterSecond))
+	}
+}
+
+// TestCheckClaudeHooksFormat_RepairsThenStays verifies the two-pass invariant
+// for files that *do* need repair: the first pass rewrites into canonical
+// form, the second pass leaves the rewritten file alone. This is the
+// property the old TestCheckClaudeHooksFormat_Idempotent test attempted to
+// prove, but with an adversarial input (HTML chars in permissions) that
+// actually exercises the encoder's behavior on user content.
+//
+// Failure prevented: the daemon autofix scheduler rewriting a freshly
+// repaired file on the next tick because canonical form ≠ canonical form
+// when read back through the round-trip.
+func TestCheckClaudeHooksFormat_RepairsThenStays(t *testing.T) {
+	gitRoot := testGitRepo(t)
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	if err := os.Chdir(gitRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	// Legacy string-form hooks alongside HTML-bearing permissions: the
+	// file needs migration AND its content has the bytes the old encoder
+	// mishandled.
+	legacy := `{
+  "permissions": {"allow": ["Bash(grep '</style>':*)"]},
+  "hooks": {"PostToolUse": "ox agent hook PostToolUse"}
+}`
+	path := writeRawSettings(t, gitRoot, legacy)
+
+	first := checkClaudeHooksFormat(true)
+	if !first.passed {
+		t.Fatalf("first pass (repair) failed: %+v", first)
+	}
+	if !strings.Contains(first.message, "repaired") {
+		t.Errorf("expected repair message on legacy file, got: %q", first.message)
+	}
+	afterFirst, _ := os.ReadFile(path)
+
+	// Migrated file must still contain the literal HTML chars (not <,
+	// >, & escapes) and must parse as array-shape hooks.
+	if !strings.Contains(string(afterFirst), `</style>`) {
+		t.Errorf("repair re-escaped user content (<, >, & should stay literal):\n%s", afterFirst)
+	}
+	var probe struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+				Type    string `json:"type"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(afterFirst, &probe); err != nil {
+		t.Fatalf("repaired file does not parse as array-shape hooks: %v\n%s", err, afterFirst)
+	}
+	if len(probe.Hooks["PostToolUse"]) != 1 {
+		t.Errorf("PostToolUse not in array shape after repair:\n%s", afterFirst)
+	}
+
+	second := checkClaudeHooksFormat(true)
+	if strings.Contains(second.message, "repaired") {
+		t.Errorf("second pass rewrote a freshly canonical file: %q", second.message)
+	}
+	afterSecond, _ := os.ReadFile(path)
+	if string(afterFirst) != string(afterSecond) {
+		t.Errorf("file churned between consecutive passes:\nfirst:\n%s\nsecond:\n%s",
+			afterFirst, afterSecond)
+	}
+}

--- a/cmd/ox/doctor_ledger_git_test.go
+++ b/cmd/ox/doctor_ledger_git_test.go
@@ -299,4 +299,3 @@ func TestStripURLCredentials(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/ox/git_credential_helper.go
+++ b/cmd/ox/git_credential_helper.go
@@ -214,4 +214,3 @@ func EndpointURLForHost(scheme, host string) string {
 	host = strings.TrimPrefix(host, "git.")
 	return scheme + "://" + host
 }
-

--- a/cmd/ox/kb_hydrate_test.go
+++ b/cmd/ox/kb_hydrate_test.go
@@ -62,9 +62,9 @@ func newFakeLFSServer(t *testing.T, files map[string][]byte) *fakeLFSServer {
 		}
 		s.expectAuthOK = true
 		var req struct {
-			Operation string             `json:"operation"`
-			Objects   []lfs.BatchObject  `json:"objects"`
-			Transfers []string           `json:"transfers"`
+			Operation string            `json:"operation"`
+			Objects   []lfs.BatchObject `json:"objects"`
+			Transfers []string          `json:"transfers"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -482,4 +482,3 @@ func TestKBHydrate_KBIDDirect(t *testing.T) {
 		t.Fatalf("hydrate: %v", err)
 	}
 }
-

--- a/cmd/ox/login_trusted_endpoints_test.go
+++ b/cmd/ox/login_trusted_endpoints_test.go
@@ -16,12 +16,12 @@ import (
 // `ox login` becomes unusably noisy.
 func TestIsPreTrustedEndpoint(t *testing.T) {
 	cases := map[string]bool{
-		"https://sageox.ai":         true,
-		"https://test.sageox.ai":    true,
+		"https://sageox.ai":          true,
+		"https://test.sageox.ai":     true,
 		"https://api.test.sageox.ai": true,
-		"https://attacker.example":  false,
-		"http://localhost:8080":     false, // not pre-trusted; user must approve
-		"":                          false,
+		"https://attacker.example":   false,
+		"http://localhost:8080":      false, // not pre-trusted; user must approve
+		"":                           false,
 	}
 	for ep, want := range cases {
 		t.Run(ep, func(t *testing.T) {

--- a/cmd/ox/prepush_autoredact.go
+++ b/cmd/ox/prepush_autoredact.go
@@ -232,8 +232,8 @@ func quarantineUnredactableFindings(ledgerPath string, findings []PrePushFinding
 
 	// Group findings by session for the marker write.
 	type sessionGroup struct {
-		findings        []PrePushFinding
-		quarantineLocs  []redactionDebtLocation
+		findings       []PrePushFinding
+		quarantineLocs []redactionDebtLocation
 	}
 	groups := map[string]*sessionGroup{}
 	for _, f := range findings {

--- a/cmd/ox/prepush_scan.go
+++ b/cmd/ox/prepush_scan.go
@@ -57,20 +57,20 @@ const prePushScannerSizeCap = 8 * 1024 * 1024 // 8 MiB
 // recovery tooling can actually fix. As of ox-cqdo:
 //
 //   - sessions/      raw AI session recordings — assistant chat and tool
-//                    I/O. The one path where unscrubbed credentials can
-//                    plausibly land in a ledger from ox-controlled writes.
-//                    Covered by `ox session audit` / `ox session redact`.
+//     I/O. The one path where unscrubbed credentials can
+//     plausibly land in a ledger from ox-controlled writes.
+//     Covered by `ox session audit` / `ox session redact`.
 //
 // Out of scope (intentionally not gated):
 //
 //   - data/github/   verbatim cache of PR/Issue bytes already published on
-//                    GitHub. Replicating them into the ledger is the same
-//                    exposure surface as ingesting the PR at all; rewriting
-//                    them at write time produced a false-positive class
-//                    that blocked routine pushes (the regression that drove
-//                    this fix).
+//     GitHub. Replicating them into the ledger is the same
+//     exposure surface as ingesting the PR at all; rewriting
+//     them at write time produced a false-positive class
+//     that blocked routine pushes (the regression that drove
+//     this fix).
 //   - kb/            user-curated knowledge bubbles. User-authored content
-//                    is the user's responsibility; not an ox write path.
+//     is the user's responsibility; not an ox write path.
 //   - team-context/  same — user-edited markdown.
 //
 // If you widen this list, also widen the recovery surface in
@@ -384,4 +384,3 @@ func emitQuarantineWarning(w *os.File, auto *autoRedactResult, q *quarantineResu
 	}
 	fmt.Fprint(w, b.String())
 }
-

--- a/cmd/ox/prepush_scan_test.go
+++ b/cmd/ox/prepush_scan_test.go
@@ -247,11 +247,11 @@ func TestScanPrePushForSecrets_OnlyScansSessionsScope(t *testing.T) {
 	// prePushScannerScopePrefixes for the policy).
 	canary := `{"text":"AKIAIOSFODNN7EXAMPLE"}` + "\n"
 	work := makeLedgerWithCommit(t, map[string]string{
-		"sessions/2026-05-12/raw.jsonl":      canary,
-		"data/github/2026/05/09/pr/42.json":  canary,
+		"sessions/2026-05-12/raw.jsonl":       canary,
+		"data/github/2026/05/09/pr/42.json":   canary,
 		"data/github/2026/05/11/issue/7.json": canary,
-		"kb/notes.md":                        canary,
-		"team-context/conventions.md":        canary,
+		"kb/notes.md":                         canary,
+		"team-context/conventions.md":         canary,
 	})
 
 	result, err := scanPrePushForSecrets(context.Background(), work)
@@ -275,17 +275,17 @@ func TestScanPrePushForSecrets_OnlyScansSessionsScope(t *testing.T) {
 // would let new paths into the gate silently.
 func TestInPrePushScannerScope(t *testing.T) {
 	cases := map[string]bool{
-		"sessions/abc/raw.jsonl":              true,
-		"sessions/2026-05-12/meta.json":       true,
-		"data/github/2026/05/11/pr/1.json":    false,
-		"data/github/issue/x.json":            false,
-		"kb/notes.md":                         false,
-		"team-context/conventions.md":         false,
-		"docs/README.md":                      false,
-		".sageox/config.json":                 false,
-		"":                                    false,
-		"session/typo/raw.jsonl":              false, // singular: not the prefix
-		"sessionsfoo/raw.jsonl":               false, // no trailing slash
+		"sessions/abc/raw.jsonl":           true,
+		"sessions/2026-05-12/meta.json":    true,
+		"data/github/2026/05/11/pr/1.json": false,
+		"data/github/issue/x.json":         false,
+		"kb/notes.md":                      false,
+		"team-context/conventions.md":      false,
+		"docs/README.md":                   false,
+		".sageox/config.json":              false,
+		"":                                 false,
+		"session/typo/raw.jsonl":           false, // singular: not the prefix
+		"sessionsfoo/raw.jsonl":            false, // no trailing slash
 	}
 	for path, want := range cases {
 		t.Run(path, func(t *testing.T) {

--- a/cmd/ox/redactor_wiring.go
+++ b/cmd/ox/redactor_wiring.go
@@ -7,10 +7,10 @@ import (
 // init wires cross-cutting hooks that internal packages need but cannot
 // resolve themselves without creating import cycles.
 //
-//   1. gitserver.SetHelperCommand — the shell command git invokes to
-//      resolve credentials via ox-managed credential storage (ox-eeqi).
-//      internal/gitserver can't import cmd/ox to discover the running
-//      binary's absolute path.
+//  1. gitserver.SetHelperCommand — the shell command git invokes to
+//     resolve credentials via ox-managed credential storage (ox-eeqi).
+//     internal/gitserver can't import cmd/ox to discover the running
+//     binary's absolute path.
 //
 // Previously also wired `ledger.SetFieldRedactor` (ox-8bkk) to scrub
 // credential patterns from GitHub PR/Issue cache fields at write time.

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**`.claude/settings.json` no longer rewritten on every session**
+
+Before this fix, ox could silently rewrite a user's `.claude/settings.json` on every Claude Code lifecycle event (via the daemon's 30-minute autofix tick, and on session start when the hook set drifted). The rewrite came from running the file through `encoding/json`'s defaults: literal `<`, `>`, `&` inside a permission rule got escaped to `<`, `>`, `&`; hand-written `\uXXXX` source escapes were decoded to literal runes; trailing newlines were stripped; and indentation inside opaque blocks like `permissions` was normalized to two-space. Each rewrite produced bytes that drifted from on-disk on the *next* pass too, so the file churned in a loop even when no content had actually changed.
+
+The fix replaces the encoder with one that has `SetEscapeHTML(false)` and preserves a trailing newline, and switches the "already canonical?" guard from byte equality (which the previous tests proved was satisfiable in lockstep with the encoder's own output but never against real user content) to a combination of strict-shape detection plus semantic content comparison. Result: doctor and the daemon autofix now leave user-authored files alone if Claude Code can read them, and only rewrite when the on-disk hooks shape is one Claude Code actually rejects.
+
+Regression tests seed adversarial inputs that would have failed the byte-equal guard on every pass — literal HTML characters in permission rules, tab indentation, trailing newlines — and assert the file is byte-identical across two consecutive checks.
+
 ## [0.8.1] - 2026-05-12
 
 ### Fixed

--- a/cmd/ox/session_redact_history.go
+++ b/cmd/ox/session_redact_history.go
@@ -211,7 +211,6 @@ func resolveLedgerPathForSessionCmd(override string) (string, error) {
 	return path, nil
 }
 
-
 // redactHistoryOptions bundles inputs so the workflow can be unit-tested
 // with synthetic stdin/stdout and an override backup directory.
 type redactHistoryOptions struct {

--- a/cmd/ox/session_redact_hydrate.go
+++ b/cmd/ox/session_redact_hydrate.go
@@ -21,9 +21,9 @@ import (
 // (a) how much had to be fetched and (b) whether any session was
 // unreachable, which would make the resulting scan incomplete.
 type hydrateSummary struct {
-	Sessions     int // total sessions inspected
-	AlreadyOK    int // sessions where every scannable file was already real content
-	Hydrated     int // sessions where we fetched at least one file from LFS
+	Sessions      int // total sessions inspected
+	AlreadyOK     int // sessions where every scannable file was already real content
+	Hydrated      int // sessions where we fetched at least one file from LFS
 	HydratedFiles int
 	Failed        int // sessions where >=1 scannable file could not be hydrated
 	FailedFiles   int

--- a/cmd/ox/session_redact_record_test.go
+++ b/cmd/ox/session_redact_record_test.go
@@ -25,11 +25,11 @@ func TestSplitSessionPath(t *testing.T) {
 	}{
 		{"sessions/2026-05-11-abc/raw.jsonl", "2026-05-11-abc", "raw.jsonl", true},
 		{"sessions/X/meta.json", "X", "meta.json", true},
-		{"sessions/X/sub/nested.jsonl", "", "", false},   // nested unsupported
-		{"data/github/pr/1.json", "", "", false},         // wrong prefix
-		{"sessions//raw.jsonl", "", "", false},           // empty session name
-		{"sessions/onlysession/", "", "", false},         // trailing slash, no file
-		{"sessions/onlysession", "", "", false},          // no filename
+		{"sessions/X/sub/nested.jsonl", "", "", false}, // nested unsupported
+		{"data/github/pr/1.json", "", "", false},       // wrong prefix
+		{"sessions//raw.jsonl", "", "", false},         // empty session name
+		{"sessions/onlysession/", "", "", false},       // trailing slash, no file
+		{"sessions/onlysession", "", "", false},        // no filename
 	}
 	for _, tt := range tests {
 		s, f, ok := splitSessionPath(tt.in)

--- a/internal/daemon/sync_bubbles_clone_test.go
+++ b/internal/daemon/sync_bubbles_clone_test.go
@@ -43,8 +43,8 @@ func TestSyncBubbles_Clone_AllKinds(t *testing.T) {
 	kbTestEnv(t)
 
 	cases := []struct {
-		name    string
-		kbType  api.KBType
+		name     string
+		kbType   api.KBType
 		seedFile string
 		seedBody string
 	}{

--- a/internal/daemon/sync_bubbles_discovery_test.go
+++ b/internal/daemon/sync_bubbles_discovery_test.go
@@ -32,8 +32,8 @@ import (
 // passes — the simplest way to model "the API answer changed". The
 // existing fakeKBLister in sync_bubbles_test.go is fixed-response.
 type dynamicKBLister struct {
-	get      func() ([]api.KB, error)
-	calls    atomic.Int32
+	get   func() ([]api.KB, error)
+	calls atomic.Int32
 }
 
 func (d *dynamicKBLister) ListBubbles(_ context.Context) ([]api.KB, error) {

--- a/internal/daemon/sync_bubbles_network_test.go
+++ b/internal/daemon/sync_bubbles_network_test.go
@@ -224,9 +224,9 @@ func TestSyncBubbles_Network_ContextAlreadyCanceledIsNoOp(t *testing.T) {
 // error.
 func TestSyncBubbles_Network_HTTPMockServer_KnownStatuses(t *testing.T) {
 	cases := []struct {
-		name       string
-		status     int
-		body       string
+		name         string
+		status       int
+		body         string
 		wantSentinel bool
 		wantErr      bool
 	}{

--- a/internal/doctor/autofix/claude_hooks_format_test.go
+++ b/internal/doctor/autofix/claude_hooks_format_test.go
@@ -1,0 +1,153 @@
+package autofix
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckClaudeHooksFormat_NoChurnOnUserAuthored is the daemon-side
+// regression for ox-647t. The autofix scheduler runs every 30 minutes,
+// and the previous byte-equal no-op guard treated encoder cosmetics
+// (HTML-escaping of <, >, &; missing trailing newline; \uXXXX vs literal
+// rune; non-canonical indentation inside opaque permissions) as real
+// changes. The result was a perpetual rewrite loop on any user-authored
+// settings.json containing those bytes.
+//
+// Failure prevented: the daemon mutating the user's settings.json every
+// 30 minutes for the life of the session.
+//
+// The test seeds a file that exercises every drift pattern the broken
+// encoder produced, runs the check twice (simulating two scheduler
+// ticks), and asserts the on-disk bytes are byte-identical across both
+// runs. The cmd/ox-side analog lives in doctor_fix_hooks_test.go;
+// both must pass because the daemon and CLI share the underlying
+// MarshalSettings + SettingsSemanticallyEqual primitives but live in
+// independent call paths.
+func TestCheckClaudeHooksFormat_NoChurnOnUserAuthored(t *testing.T) {
+	repo := t.TempDir()
+	claudeDir := filepath.Join(repo, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	// Adversarial input: literal `<`, `>`, `&`; permissions value uses
+	// tab indentation; top-level keys in insertion order with permissions
+	// before hooks; trailing newline. Every one of these defeated the
+	// pre-fix byte-equal guard.
+	userAuthored := "{\n" +
+		"\t\"permissions\": {\n" +
+		"\t\t\"allow\": [\n" +
+		"\t\t\t\"Bash(grep '</body>':*)\",\n" +
+		"\t\t\t\"Bash(curl 'https://x?a=1&b=2':*)\"\n" +
+		"\t\t]\n" +
+		"\t},\n" +
+		"\t\"hooks\": {\n" +
+		"\t\t\"SessionStart\": [\n" +
+		"\t\t\t{\n" +
+		"\t\t\t\t\"matcher\": \"\",\n" +
+		"\t\t\t\t\"hooks\": [\n" +
+		"\t\t\t\t\t{\"command\": \"ox agent hook SessionStart\", \"type\": \"command\"}\n" +
+		"\t\t\t\t]\n" +
+		"\t\t\t}\n" +
+		"\t\t]\n" +
+		"\t}\n" +
+		"}\n"
+	if err := os.WriteFile(settingsPath, []byte(userAuthored), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	first := checkClaudeHooksFormat(context.Background(), repo)
+	if first.Status != StatusClean {
+		t.Errorf("first tick: status=%v summary=%q; well-formed user file must be reported clean (this is the regression)",
+			first.Status, first.Summary)
+	}
+	afterFirst, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterFirst) != userAuthored {
+		t.Errorf("autofix mutated user-authored file on first tick.\nwant:\n%s\ngot:\n%s",
+			userAuthored, string(afterFirst))
+	}
+
+	second := checkClaudeHooksFormat(context.Background(), repo)
+	if second.Status != StatusClean {
+		t.Errorf("second tick: status=%v summary=%q; should still be clean", second.Status, second.Summary)
+	}
+	afterSecond, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterFirst) != string(afterSecond) {
+		t.Errorf("autofix is not idempotent on user-authored file (would churn every 30 min).\nfirst tick wrote:\n%s\nsecond tick wrote:\n%s",
+			string(afterFirst), string(afterSecond))
+	}
+}
+
+// TestCheckClaudeHooksFormat_MigratesLegacyOnce verifies the other half of
+// the contract: when the on-disk shape is legacy (bare-string hook values
+// that Claude Code rejects), the autofix DOES rewrite it — but only once.
+// The repaired file must then be stable across subsequent ticks.
+//
+// Failure prevented: either (a) the autofix refuses to migrate broken
+// files because semantic equality says "they parse the same in memory"
+// (over-permissive no-op guard), or (b) the autofix migrates correctly
+// but the canonical output is itself non-idempotent (the original ox-647t
+// bug, just shifted to post-migration state).
+func TestCheckClaudeHooksFormat_MigratesLegacyOnce(t *testing.T) {
+	repo := t.TempDir()
+	claudeDir := filepath.Join(repo, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	legacy := `{
+  "permissions": {"allow": ["Bash(echo '<x>&y':*)"]},
+  "hooks": {"PostToolUse": "ox agent hook PostToolUse"}
+}
+`
+	if err := os.WriteFile(settingsPath, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	first := checkClaudeHooksFormat(context.Background(), repo)
+	if first.Status != StatusFixed {
+		t.Errorf("first tick: status=%v summary=%q; legacy string-form file must be repaired",
+			first.Status, first.Summary)
+	}
+	afterFirst, _ := os.ReadFile(settingsPath)
+	if string(afterFirst) == legacy {
+		t.Error("autofix reported Fixed but bytes are unchanged")
+	}
+	// HTML chars must survive the rewrite as literals.
+	for _, lit := range []string{"<x>", "&y"} {
+		if !contains(string(afterFirst), lit) {
+			t.Errorf("expected literal %q in repaired file (encoder must not HTML-escape user content):\n%s",
+				lit, afterFirst)
+		}
+	}
+
+	second := checkClaudeHooksFormat(context.Background(), repo)
+	if second.Status != StatusClean {
+		t.Errorf("second tick: status=%v summary=%q; freshly-repaired file must be Clean",
+			second.Status, second.Summary)
+	}
+	afterSecond, _ := os.ReadFile(settingsPath)
+	if string(afterFirst) != string(afterSecond) {
+		t.Errorf("post-migration file churned between ticks.\nfirst:\n%s\nsecond:\n%s",
+			afterFirst, afterSecond)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/doctor/autofix/default_checks.go
+++ b/internal/doctor/autofix/default_checks.go
@@ -124,7 +124,20 @@ func checkClaudeHooksFormat(_ context.Context, repoPath string) CheckResult {
 			Summary: fmt.Sprintf("re-marshal: %v", err),
 		}
 	}
-	if string(canonical) == string(data) {
+	// "Already canonical" requires both a strict on-disk shape check and a
+	// semantic content compare. Byte equality alone was the original guard
+	// and it failed forever on any file with HTML-escapable characters
+	// (<, >, & in a permission rule), hand-written \uXXXX escapes, missing
+	// trailing newline, or non-canonical indentation inside opaque
+	// permissions blocks — the autofix scheduler then rewrote the file
+	// every 30 minutes. Semantic equality alone is too permissive (legacy
+	// string-form hooks parse into the same in-memory shape as the array
+	// form Claude Code requires, so the check would refuse to migrate
+	// broken files). Combining both gives idempotency on any file Claude
+	// Code accepts and repair on any file it would reject.
+	canonicalOnDisk, _ := claude.IsCanonicalHooksFormat(data)
+	semEqual, _ := claude.SettingsSemanticallyEqual(data, canonical)
+	if canonicalOnDisk && semEqual {
 		return CheckResult{Status: StatusClean, Repo: repoPath}
 	}
 

--- a/internal/hooks/claude/parse.go
+++ b/internal/hooks/claude/parse.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -69,14 +70,29 @@ func parseHooksMixed(hooksRaw json.RawMessage) (map[string][]HookEntry, error) {
 }
 
 // MarshalSettings serializes Settings back into JSON, merging typed hooks into
-// the raw map to preserve all non-hook keys. Returns indented JSON.
+// the raw map to preserve all non-hook keys. Returns indented JSON with a
+// trailing newline.
+//
+// Uses json.Encoder with SetEscapeHTML(false) so that literal "<", ">", "&"
+// inside user-authored values (e.g. permission-rule globs containing HTML-like
+// substrings) survive the round-trip without being rewritten as <, >,
+// & on every doctor pass. The default json.Marshal / json.MarshalIndent
+// path HTML-escapes those bytes, which made every read-modify-write cycle
+// mutate user content and triggered perpetual rewrites under the autofix
+// scheduler.
+//
+// Note: encoding/json's Unmarshal still decodes any source \uXXXX escapes into
+// literal runes on the way in, so a file authored with " " will come back
+// out as the literal NBSP. That drift is one-way and cannot be prevented at
+// the encoder level — callers comparing to disk must use
+// SettingsSemanticallyEqual rather than byte equality.
 func MarshalSettings(settings *Settings, rawMap map[string]json.RawMessage) ([]byte, error) {
 	if rawMap == nil {
 		rawMap = make(map[string]json.RawMessage)
 	}
 
 	if len(settings.Hooks) > 0 {
-		hooksJSON, err := json.Marshal(settings.Hooks)
+		hooksJSON, err := marshalNoHTMLEscape(settings.Hooks)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal hooks: %w", err)
 		}
@@ -85,10 +101,181 @@ func MarshalSettings(settings *Settings, rawMap map[string]json.RawMessage) ([]b
 		delete(rawMap, "hooks")
 	}
 
-	data, err := json.MarshalIndent(rawMap, "", "  ")
+	data, err := marshalIndentedNoHTMLEscape(rawMap, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal settings: %w", err)
 	}
 
 	return data, nil
+}
+
+// marshalNoHTMLEscape encodes v as compact JSON with HTML escaping disabled.
+// The trailing newline that json.Encoder always appends is stripped so callers
+// can embed the result inside larger JSON values (e.g. as a json.RawMessage).
+func marshalNoHTMLEscape(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// marshalIndentedNoHTMLEscape encodes v as indented JSON with HTML escaping
+// disabled. Preserves the trailing newline json.Encoder emits — POSIX-friendly
+// and matches what most editors leave on the file.
+func marshalIndentedNoHTMLEscape(v any, prefix, indent string) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent(prefix, indent)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// IsCanonicalHooksFormat reports whether the on-disk bytes already parse
+// strictly into Claude Code's expected shape: every value under "hooks" is an
+// array of hook entries (never a bare string). The legacy string-form
+// ("PostToolUse": "echo cmd") that older ox versions emitted still parses
+// via parseHooksMixed's fallback, but Claude Code itself rejects it — so
+// "in-memory equivalent" is not enough; the bytes must be strictly canonical.
+//
+// Empty or absent hooks is trivially canonical. An unparseable file is
+// reported as non-canonical (with the parse error), so callers can decide
+// whether to rewrite or warn.
+func IsCanonicalHooksFormat(data []byte) (bool, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return true, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false, err
+	}
+	hooksRaw, ok := raw["hooks"]
+	if !ok {
+		return true, nil
+	}
+	var arrayShape map[string][]HookEntry
+	if err := json.Unmarshal(hooksRaw, &arrayShape); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+// SettingsSemanticallyEqual reports whether two settings byte streams parse
+// into the same logical content: identical typed hooks structure plus
+// identical non-hook keys (compared by canonical-compact JSON of each value,
+// so whitespace/indentation inside opaque blocks like "permissions" is
+// ignored). Both inputs are tolerated as empty/nil.
+//
+// This is the right comparison for "did anything actually change?" checks in
+// the autofix and doctor paths. Byte equality is too strict — it catches
+// encoder-cosmetic drift (HTML escaping, trailing newline, key order,
+// indentation choices) and reports false positives that cause the file to be
+// rewritten forever.
+func SettingsSemanticallyEqual(a, b []byte) (bool, error) {
+	settingsA, rawA, err := ParseSettingsRaw(a)
+	if err != nil {
+		return false, fmt.Errorf("parse a: %w", err)
+	}
+	settingsB, rawB, err := ParseSettingsRaw(b)
+	if err != nil {
+		return false, fmt.Errorf("parse b: %w", err)
+	}
+
+	if !hooksEqual(settingsA.Hooks, settingsB.Hooks) {
+		return false, nil
+	}
+
+	return rawMapEqual(rawA, rawB)
+}
+
+// hooksEqual deep-compares two parsed hook maps. We can't rely on
+// reflect.DeepEqual on the maps directly because empty slices vs nil and
+// missing keys (with empty value) should both compare equal.
+func hooksEqual(a, b map[string][]HookEntry) bool {
+	keys := make(map[string]struct{}, len(a)+len(b))
+	for k, v := range a {
+		if len(v) > 0 {
+			keys[k] = struct{}{}
+		}
+	}
+	for k, v := range b {
+		if len(v) > 0 {
+			keys[k] = struct{}{}
+		}
+	}
+	for k := range keys {
+		entriesA, entriesB := a[k], b[k]
+		if len(entriesA) != len(entriesB) {
+			return false
+		}
+		for i := range entriesA {
+			if entriesA[i].Matcher != entriesB[i].Matcher {
+				return false
+			}
+			if len(entriesA[i].Hooks) != len(entriesB[i].Hooks) {
+				return false
+			}
+			for j := range entriesA[i].Hooks {
+				if entriesA[i].Hooks[j] != entriesB[i].Hooks[j] {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// rawMapEqual compares two raw-key maps by canonical-compact bytes for every
+// non-hook key. The "hooks" key is skipped — its semantic content was already
+// compared via hooksEqual on the typed view, so any byte difference here is
+// purely cosmetic (key order, indentation, HTML escaping inside hook commands).
+func rawMapEqual(a, b map[string]json.RawMessage) (bool, error) {
+	keys := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		if k != "hooks" {
+			keys[k] = struct{}{}
+		}
+	}
+	for k := range b {
+		if k != "hooks" {
+			keys[k] = struct{}{}
+		}
+	}
+	for k := range keys {
+		va, oka := a[k]
+		vb, okb := b[k]
+		if oka != okb {
+			return false, nil
+		}
+		canonA, err := compactJSON(va)
+		if err != nil {
+			return false, fmt.Errorf("compact a[%q]: %w", k, err)
+		}
+		canonB, err := compactJSON(vb)
+		if err != nil {
+			return false, fmt.Errorf("compact b[%q]: %w", k, err)
+		}
+		if !bytes.Equal(canonA, canonB) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// compactJSON returns the canonical-compact form of a raw JSON value. Used
+// to compare two arbitrary JSON values ignoring whitespace differences.
+func compactJSON(raw json.RawMessage) ([]byte, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/internal/hooks/claude/parse_test.go
+++ b/internal/hooks/claude/parse_test.go
@@ -147,6 +147,148 @@ func TestMarshalSettings_NilRawMap(t *testing.T) {
 	assert.Contains(t, string(data), "cmd")
 }
 
+// TestMarshalSettings_DoesNotHTMLEscapeUserContent locks in the encoder
+// behavior that was broken before ox-647t: the stdlib default
+// json.MarshalIndent escapes <, >, & inside any string value, which
+// caused a rewrite-on-every-tick loop for users whose permission rules
+// contained those bytes. The fix replaces MarshalIndent with an Encoder
+// that has SetEscapeHTML(false).
+//
+// Failure prevented: doctor / autofix mutating user content. If this
+// test fails (the encoder re-escapes), the daemon would resume churning
+// settings.json on every 30-min tick.
+func TestMarshalSettings_DoesNotHTMLEscapeUserContent(t *testing.T) {
+	rawMap := map[string]json.RawMessage{
+		"permissions": json.RawMessage(`{"allow":["Bash(grep '</script>':*)","Bash(curl 'https://x?a=1&b=2':*)"]}`),
+	}
+	settings := &Settings{Hooks: map[string][]HookEntry{}}
+
+	out, err := MarshalSettings(settings, rawMap)
+	require.NoError(t, err)
+
+	s := string(out)
+	assert.Contains(t, s, "</script>", "encoder must not escape literal `<` and `>` (would churn user settings.json on every doctor pass)")
+	assert.Contains(t, s, "a=1&b=2", "encoder must not escape literal `&` (same churn issue)")
+	// build the six-character escape sequences via concatenation so the
+	// source can't accidentally collapse to the literal rune (which is
+	// what we want to keep, not what we want to forbid).
+	bs := string([]byte{'\\'})
+	assert.NotContains(t, s, bs+"u003c", "encoder must not emit the HTML escape for `<`")
+	assert.NotContains(t, s, bs+"u003e", "encoder must not emit the HTML escape for `>`")
+	assert.NotContains(t, s, bs+"u0026", "encoder must not emit the HTML escape for `&`")
+}
+
+// TestMarshalSettings_HasTrailingNewline confirms json.Encoder.Encode's
+// always-append-newline behavior is preserved in the output. POSIX-friendly,
+// matches what most editors leave on disk, and avoids "editor adds \n →
+// ox strips \n" oscillation. The semantic equality guard tolerates either
+// form, but the canonical emit should be the editor-friendly one.
+func TestMarshalSettings_HasTrailingNewline(t *testing.T) {
+	out, err := MarshalSettings(&Settings{Hooks: map[string][]HookEntry{}}, nil)
+	require.NoError(t, err)
+	assert.True(t, len(out) > 0 && out[len(out)-1] == '\n', "MarshalSettings output must end with a newline; got: %q", string(out))
+}
+
+// TestIsCanonicalHooksFormat_StrictArrayShape covers the predicate the doctor
+// and autofix guards rely on to decide whether a file needs migration even
+// when its in-memory shape is already canonical (because parseHooksMixed
+// promotes legacy strings).
+func TestIsCanonicalHooksFormat_StrictArrayShape(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty bytes", "", true},
+		{"whitespace only", "  \n\t", true},
+		{"no hooks key", `{"permissions":{"allow":["Read"]}}`, true},
+		{"array shape", `{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"command":"x","type":"command"}]}]}}`, true},
+		{"legacy string shape", `{"hooks":{"PostToolUse":"echo legacy"}}`, false},
+		{"mixed legacy + array", `{"hooks":{"PostToolUse":"x","SessionStart":[{"matcher":"","hooks":[{"command":"y","type":"command"}]}]}}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := IsCanonicalHooksFormat([]byte(tc.in))
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestSettingsSemanticallyEqual_IgnoresCosmetics verifies the no-op guard
+// tolerates encoder-cosmetic differences that don't affect what Claude Code
+// reads. These are exactly the cases that triggered perpetual rewrites
+// before the fix.
+func TestSettingsSemanticallyEqual_IgnoresCosmetics(t *testing.T) {
+	canonical := []byte(`{
+  "permissions": {"allow": ["Bash(curl 'a&b':*)"]},
+  "hooks": {"SessionStart": [{"matcher": "", "hooks": [{"command": "ox", "type": "command"}]}]}
+}
+`)
+	cases := []struct {
+		name  string
+		other []byte
+		want  bool
+	}{
+		{
+			name: "trailing newline absent",
+			other: []byte(`{
+  "permissions": {"allow": ["Bash(curl 'a&b':*)"]},
+  "hooks": {"SessionStart": [{"matcher": "", "hooks": [{"command": "ox", "type": "command"}]}]}
+}`),
+			want: true,
+		},
+		{
+			name: "html-escaped & in permissions",
+			other: []byte(`{
+  "permissions": {"allow": ["Bash(curl 'a&b':*)"]},
+  "hooks": {"SessionStart": [{"matcher": "", "hooks": [{"command": "ox", "type": "command"}]}]}
+}
+`),
+			want: true,
+		},
+		{
+			name: "different top-level key order",
+			other: []byte(`{
+  "hooks": {"SessionStart": [{"matcher": "", "hooks": [{"command": "ox", "type": "command"}]}]},
+  "permissions": {"allow": ["Bash(curl 'a&b':*)"]}
+}
+`),
+			want: true,
+		},
+		{
+			name:  "tab indentation inside permissions",
+			other: []byte("{\n\t\"permissions\": {\n\t\t\"allow\": [\"Bash(curl 'a&b':*)\"]\n\t},\n\t\"hooks\": {\"SessionStart\": [{\"matcher\": \"\", \"hooks\": [{\"command\": \"ox\", \"type\": \"command\"}]}]}\n}\n"),
+			want:  true,
+		},
+		{
+			name: "different hook command",
+			other: []byte(`{
+  "permissions": {"allow": ["Bash(curl 'a&b':*)"]},
+  "hooks": {"SessionStart": [{"matcher": "", "hooks": [{"command": "different", "type": "command"}]}]}
+}
+`),
+			want: false,
+		},
+		{
+			name: "extra permission rule",
+			other: []byte(`{
+  "permissions": {"allow": ["Bash(curl 'a&b':*)", "Bash(rm:*)"]},
+  "hooks": {"SessionStart": [{"matcher": "", "hooks": [{"command": "ox", "type": "command"}]}]}
+}
+`),
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SettingsSemanticallyEqual(canonical, tc.other)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got, "canonical:\n%s\nother:\n%s", canonical, tc.other)
+		})
+	}
+}
+
 func TestParseAndMarshalRoundtrip(t *testing.T) {
 	original := []byte(`{
   "permissions": {"allow": ["Read", "Write"]},

--- a/internal/ledger/automerge/llm_allowlist_test.go
+++ b/internal/ledger/automerge/llm_allowlist_test.go
@@ -9,17 +9,17 @@ import (
 // TestIsAllowedLLMBinary covers the ox-7esb allowlist semantics.
 func TestIsAllowedLLMBinary(t *testing.T) {
 	cases := map[string]bool{
-		"":                 false,
-		"claude":           true,
-		"gemini":           true,
-		"codex":            true,
-		"CLAUDE":           true, // case-insensitive bare name
-		"evil":             false,
-		"/usr/local/bin/claude": true, // absolute path passes through
-		"/tmp/evil":             true, // operator-chosen absolute paths trusted
-		"./evil":           false, // relative with separator refused
-		"bin/claude":       false, // any path component refused
-		"claude/../evil":   false, // path traversal style refused
+		"":                      false,
+		"claude":                true,
+		"gemini":                true,
+		"codex":                 true,
+		"CLAUDE":                true, // case-insensitive bare name
+		"evil":                  false,
+		"/usr/local/bin/claude": true,  // absolute path passes through
+		"/tmp/evil":             true,  // operator-chosen absolute paths trusted
+		"./evil":                false, // relative with separator refused
+		"bin/claude":            false, // any path component refused
+		"claude/../evil":        false, // path traversal style refused
 	}
 	for binary, want := range cases {
 		t.Run(binary, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Customer-reported: ox silently rewrites `.claude/settings.json` on every Claude Code lifecycle event. Root cause was `claude.MarshalSettings` running the file through `encoding/json`'s defaults — `SetEscapeHTML(true)` turned literal `<`, `>`, `&` in permission rules into `<`, `>`, `&`; `Unmarshal` decoded hand-written `\uXXXX` escapes to literal runes; `MarshalIndent` stripped trailing newlines and re-indented `RawMessage` values. Both no-op guards (the 30-min daemon autofix and `ox doctor --fix`) compared bytes for equality, which any of those drifts defeated, so the file churned forever.

The fix swaps the encoder for `json.Encoder` with `SetEscapeHTML(false)` and replaces the byte-equal guard with `IsCanonicalHooksFormat` (strict array-shape detector) AND `SettingsSemanticallyEqual` (parse-then-parse content compare that tolerates cosmetics). Regression tests seed adversarial inputs (literal `<`, tab indent, trailing newline) that would have failed the old guard on every pass and assert the file is byte-identical across two consecutive checks.

```mermaid
flowchart TB
    subgraph BEFORE["BEFORE — file churns every 30 min"]
        direction LR
        B1["user file<br/>literal &lt;, &gt;, &amp;<br/>trailing newline<br/>tab indent"] --> B2["MarshalIndent<br/>SetEscapeHTML=true"]
        B2 --> B3["canonical bytes:<br/>HTML-escaped<br/>no trailing newline<br/>2-space indent"]
        B3 --> B4{"bytes.Equal<br/>(disk, canonical)"}
        B4 -- "always false<br/>(cosmetic drift)" --> B5["WRITE file"]
        B5 -.->|"editor re-adds \n,<br/>next tick fires"| B1
    end

    subgraph AFTER["AFTER — user-authored files stay byte-identical"]
        direction LR
        A1["user file<br/>same shape"] --> A2["Encoder<br/>SetEscapeHTML(false)<br/>trailing newline kept"]
        A2 --> A3["canonical bytes:<br/>literals preserved"]
        A3 --> A4{"IsCanonicalHooksFormat<br/>AND<br/>SettingsSemanticallyEqual"}
        A4 -- "yes" --> A5["no-op<br/>file untouched"]
        A4 -- "only when on-disk<br/>shape is legacy string-form" --> A6["one-shot migrate,<br/>then stable"]
    end

    style BEFORE fill:#fde2e2,stroke:#c44
    style AFTER fill:#e2fde4,stroke:#4a4
```

The bundled gofmt-only diffs in unrelated files come from `make format` normalizing comment-block alignment under the current Go toolchain.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` (fast tier, race) — 14427 tests pass
- [x] `go test -short ./...` — clean modulo two pre-existing flakes (`TestCodeDBMaintainerNilManager`, `TestValidatePATLiveness_CredentialHelperSuppressed`), both pass on retry and on `main`
- [x] New `TestCheckClaudeHooksFormat_LeavesUserAuthoredFileUntouched` + `TestCheckClaudeHooksFormat_NoChurnOnUserAuthored` (daemon-side) added — both fail on `main`, pass here
- [ ] Manual: file with `</script>` in a `Bash()` permission rule survives two consecutive `ox doctor --fix` runs byte-identical

Closes ox-647t.

Co-Authored-By: SageOx <ox@sageox.ai>