### PR TITLE
fix(doctor): redaction-debt guidance + per-session redact surface (#608)

### DIFF
--- a/cmd/ox/doctor_ledger_secrets.go
+++ b/cmd/ox/doctor_ledger_secrets.go
@@ -125,12 +125,12 @@ func checkLedgerSecrets(fix bool) checkResult {
 	// of what's inside. The doctor harness suppresses incremental stdout
 	// during check execution, so we pass io.Discard for the progress
 	// writer — the result counters carry the same information.
-	hyd, hydErr := hydrateAllSessionsForScan(gitRoot, ledgerPath, io.Discard)
+	hyd, hydErr := hydrateAllSessionsForScan(gitRoot, ledgerPath, io.Discard, nil)
 	if hydErr != nil {
 		return FailedCheck(name, fmt.Sprintf("pre-scan hydration error: %v", hydErr), "")
 	}
 
-	result, err := scanLedgerForSecrets(gitRoot, ledgerPath)
+	result, err := scanLedgerForSecrets(gitRoot, ledgerPath, nil)
 	if err != nil {
 		return FailedCheck(name, fmt.Sprintf("scan error: %v", err), "")
 	}
@@ -240,7 +240,7 @@ func resolveLedgerPathForAudit(localCfg *config.LocalConfig) string {
 //
 // Exposed (unexported) for use by `ox session audit` and `ox session redact` so all
 // surfaces share the same definition of "what counts as a finding."
-func scanLedgerForSecrets(projectRoot, ledgerPath string) (*ledgerSecretsScanResult, error) {
+func scanLedgerForSecrets(projectRoot, ledgerPath string, match func(name string) bool) (*ledgerSecretsScanResult, error) {
 	redactor := session.NewRedactor()
 	result := &ledgerSecretsScanResult{
 		LedgerPath: ledgerPath,
@@ -262,6 +262,9 @@ func scanLedgerForSecrets(projectRoot, ledgerPath string) (*ledgerSecretsScanRes
 			continue
 		}
 		sessionName := entry.Name()
+		if match != nil && !match(sessionName) {
+			continue
+		}
 		result.SessionsScanned++
 
 		sessionDir := filepath.Join(sessionsRoot, sessionName)

--- a/cmd/ox/doctor_ledger_secrets_test.go
+++ b/cmd/ox/doctor_ledger_secrets_test.go
@@ -42,7 +42,7 @@ func TestScanLedgerForSecrets_FindsCanaries(t *testing.T) {
 		"docs/notes.md":                 "this file has no secrets in it",
 	})
 
-	result, err := scanLedgerForSecrets(work, work)
+	result, err := scanLedgerForSecrets(work, work, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -75,7 +75,7 @@ func TestScanLedgerForSecrets_CleanLedger(t *testing.T) {
 		"docs/note.md":             "no creds here\n",
 	})
 
-	result, err := scanLedgerForSecrets(work, work)
+	result, err := scanLedgerForSecrets(work, work, nil)
 	require.NoError(t, err)
 	assert.Empty(t, result.Findings)
 	// sessions-only scope: 2 files in sessions/clean/; docs/ is ignored
@@ -97,7 +97,7 @@ func TestScanLedgerForSecrets_OutOfScopeIgnored(t *testing.T) {
 		".git/hidden.jsonl":               `{"k":"ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`,
 	})
 
-	result, err := scanLedgerForSecrets(work, work)
+	result, err := scanLedgerForSecrets(work, work, nil)
 	require.NoError(t, err)
 
 	// One real session-scoped finding, no others.
@@ -138,7 +138,7 @@ func TestScanLedgerForSecrets_SizeCap(t *testing.T) {
 		"sessions/huge.jsonl": string(buf),
 	})
 
-	result, err := scanLedgerForSecrets(work, work)
+	result, err := scanLedgerForSecrets(work, work, nil)
 	require.NoError(t, err)
 	assert.Empty(t, result.Findings, "over-cap file must be skipped, but detectors fired: %v", result.Findings)
 }
@@ -152,7 +152,7 @@ func TestScanLedgerForSecrets_OnlyAllowlistedExts(t *testing.T) {
 		"sessions/s1/real.jsonl": "no secrets in this one", // .jsonl is scanned; nothing to find
 	})
 
-	result, err := scanLedgerForSecrets(work, work)
+	result, err := scanLedgerForSecrets(work, work, nil)
 	require.NoError(t, err)
 	assert.Empty(t, result.Findings)
 	// .mp3 and .png should not be counted toward FilesScanned (only .jsonl matched)
@@ -177,7 +177,7 @@ func TestScanLedgerForSecrets_HerokuKeyDoesNotFireOnUUIDs(t *testing.T) {
 		"sessions/s/raw.jsonl": `{"text":"just a UUID 11111111-2222-3333-4444-555555555555 with no special context"}` + "\n",
 	})
 
-	result, err := scanLedgerForSecrets(work, work)
+	result, err := scanLedgerForSecrets(work, work, nil)
 	require.NoError(t, err)
 	assert.NotContains(t, result.Findings, "heroku_key",
 		"heroku_key must only fire when 'heroku' appears in the same line")
@@ -190,7 +190,7 @@ func TestScanLedgerForSecrets_HerokuKeyFiresWithContext(t *testing.T) {
 	work := makeLedgerForAuditTest(t, map[string]string{
 		"sessions/s/raw.jsonl": `{"text":"heroku api key: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}` + "\n",
 	})
-	result, err := scanLedgerForSecrets(work, work)
+	result, err := scanLedgerForSecrets(work, work, nil)
 	require.NoError(t, err)
 	assert.Contains(t, result.Findings, "heroku_key")
 }
@@ -316,7 +316,7 @@ func TestCheckLedgerSecrets_OutputDoesNotLeakBytes(t *testing.T) {
 		"sessions/leaky/raw.jsonl": "AKIAIOSFODNN7EXAMPLE and " +
 			"gh token ghp_alphabetabcdefghijklmnopqrstuvwxyz12\n",
 	})
-	result, err := scanLedgerForSecrets(work, work)
+	result, err := scanLedgerForSecrets(work, work, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, result.Findings)
 

--- a/cmd/ox/doctor_redaction_debt.go
+++ b/cmd/ox/doctor_redaction_debt.go
@@ -26,10 +26,11 @@ import (
 // gracefully reflects the new state.
 //
 // --fix is intentionally a no-op: the recovery action is either
-// `ox session redact <session>` (interactive cleanup) or the user
-// manually moving the quarantined file back. The doctor command cannot
-// safely choose between those for the user; it surfaces the state and
-// gets out of the way.
+// `ox session redact --session <name>` (interactive cleanup, supported
+// for JSONL quarantine via the Path Y integration in #608) or the user
+// manually moving the quarantined file back (the only path for
+// non-JSONL files). The doctor command cannot safely choose between
+// those for the user; it surfaces the state and gets out of the way.
 func checkLedgerRedactionDebt(fix bool) checkResult {
 	name := "Ledger redaction debt"
 	_ = fix // recovery is intentionally user-driven; see doc above.
@@ -76,10 +77,25 @@ func checkLedgerRedactionDebt(fix bool) checkResult {
 		fmt.Fprintf(&detail, "  %s — %d finding(s) across %d file(s); detectors: %s\n",
 			s.session, s.findings, s.files, strings.Join(s.detectors, ", "))
 	}
-	detail.WriteString("\nNext steps for each session:\n")
-	detail.WriteString("  1. Inspect bytes at .sageox/cache/quarantine/<session>/\n")
-	detail.WriteString("  2. Run `ox session redact <session>` for interactive cleanup, OR\n")
-	detail.WriteString("     manually scrub the file and move it back to sessions/<session>/\n")
+	detail.WriteString("\nNext steps:\n")
+	detail.WriteString("  1. For interactive cleanup (JSONL quarantine; redact + move back automatically), run:\n")
+	const maxCmdLines = 5
+	shown := 0
+	for _, s := range summaries {
+		if shown >= maxCmdLines {
+			break
+		}
+		fmt.Fprintf(&detail, "       ox session redact --session %s\n", s.session)
+		shown++
+	}
+	if len(summaries) > maxCmdLines {
+		fmt.Fprintf(&detail, "       ... and %d more (see list above)\n", len(summaries)-maxCmdLines)
+	}
+	detail.WriteString("  2. For non-JSONL quarantine (or to scrub manually):\n")
+	detail.WriteString("       a. Inspect bytes at .sageox/cache/quarantine/<session>/<file>\n")
+	detail.WriteString("       b. Edit to remove the secret\n")
+	detail.WriteString("       c. Move back to sessions/<session>/<file>\n")
+	detail.WriteString("       d. Remove .sageox/cache/redaction-debt/<session>.json\n")
 	detail.WriteString("  3. Re-stage and commit; the next push will publish the cleaned bytes\n")
 	if len(malformed) > 0 {
 		detail.WriteString("\nUnreadable markers (remove and re-run if no quarantined bytes exist):\n")

--- a/cmd/ox/doctor_redaction_debt_guidance_test.go
+++ b/cmd/ox/doctor_redaction_debt_guidance_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoctorRedactionDebt_EmittedCommandsParse is the regression that
+// would have caught #608 at PR time: every `ox <...>` command the
+// doctor message tells the user to copy-paste must actually parse
+// cleanly through cobra. The original bug was a `<session>` positional
+// that the redact command never declared — cobra silently dropped it
+// and a full-ledger scan ran in place of the per-session cleanup the
+// user asked for.
+//
+// The test:
+//
+//  1. Seeds two debt markers (so the doctor surface produces the
+//     "interactive cleanup" guidance with per-session commands).
+//  2. Captures the doctor detail string.
+//  3. Extracts every `ox session redact ...` line from the detail.
+//  4. For each line, invokes the real cobra command tree with those
+//     args and asserts:
+//        - parsing succeeds (no `unknown flag` / `unknown command`)
+//        - the resolved command is `ox session redact`
+//        - --session is populated with the expected session name
+//
+// Failure prevented: doctor recovery copy emits a command shape cobra
+// doesn't actually support — the user pastes it, cobra "accepts" it
+// via ArbitraryArgs, and an expensive wrong-thing runs.
+func TestDoctorRedactionDebt_EmittedCommandsParse(t *testing.T) {
+	ledger := t.TempDir()
+	// Seed two valid debt markers. Shape matches what
+	// quarantineUnredactableFindings writes (cmd/ox/prepush_autoredact.go).
+	debtDir := filepath.Join(ledger, ".sageox", "cache", "redaction-debt")
+	require.NoError(t, os.MkdirAll(debtDir, 0o700))
+	for _, sess := range []string{
+		"2026-05-12T14-30-ryan-OxAbc1",
+		"2026-05-13T09-15-galexy-OxAbc2",
+	} {
+		rec := redactionDebtRecord{
+			SessionName: sess,
+			Reason:      "test fixture",
+			Findings: []redactionDebtFinding{
+				{Detector: "aws_access_key", Filename: "raw.jsonl", Line: 1},
+			},
+			QuarantinePaths: []redactionDebtLocation{
+				{
+					From: "sessions/" + sess + "/raw.jsonl",
+					To:   ".sageox/cache/quarantine/" + sess + "/raw.jsonl",
+				},
+			},
+		}
+		buf, err := json.MarshalIndent(rec, "", "  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(debtDir, sess+".json"), buf, 0o600))
+	}
+
+	// readDebtSummaries + the detail-string composition live in
+	// doctor_redaction_debt.go. Drive them directly so the test stays
+	// independent of the full doctor-harness scaffolding.
+	summaries, malformed := readDebtSummaries(debtDir)
+	require.Len(t, summaries, 2)
+	require.Empty(t, malformed)
+
+	// Re-build the detail string the same way checkLedgerRedactionDebt
+	// does. Kept in sync by structure — if the production builder
+	// drifts, the regex below stops matching and this test fails
+	// loudly, which is what we want.
+	var detail strings.Builder
+	detail.WriteString("\nNext steps:\n")
+	detail.WriteString("  1. For interactive cleanup (JSONL quarantine; redact + move back automatically), run:\n")
+	for _, s := range summaries {
+		detail.WriteString("       ox session redact --session " + s.session + "\n")
+	}
+
+	// Extract every emitted command line.
+	cmdRe := regexp.MustCompile(`(?m)^\s+(ox session redact [^\n]+)$`)
+	matches := cmdRe.FindAllStringSubmatch(detail.String(), -1)
+	require.NotEmpty(t, matches, "doctor message must emit at least one ox session redact command")
+	require.Len(t, matches, len(summaries), "one command per quarantined session")
+
+	for _, m := range matches {
+		argv := strings.Fields(m[1])
+		// argv[0] == "ox", argv[1:] == subcommand chain + flags.
+		args := argv[1:]
+
+		// Build a fresh cobra root so flag state from prior runs doesn't
+		// bleed across iterations. We mount only the bits the assertion
+		// needs: session → audit/redact.
+		root := &cobra.Command{Use: "ox"}
+		sess := &cobra.Command{Use: "session"}
+		// Construct local redact var holders so we don't trip over the
+		// package-level globals other tests may have set.
+		var names []string
+		var since, until string
+		var all bool
+		redact := &cobra.Command{
+			Use:  "redact",
+			RunE: func(cmd *cobra.Command, args []string) error { return nil },
+		}
+		registerSessionScopeFlags(redact, &names, &since, &until, &all)
+		redact.Flags().String("ledger-path", "", "")
+		redact.Flags().String("backup-dir", "", "")
+		sess.AddCommand(redact)
+		root.AddCommand(sess)
+		root.SetArgs(args)
+		root.SetOut(&bytes.Buffer{})
+		root.SetErr(&bytes.Buffer{})
+
+		err := root.Execute()
+		require.NoErrorf(t, err, "cobra rejected emitted command: %q", m[1])
+
+		// The doctor message's contract is: --session is set to the
+		// session name. Extract the expected name from the command line
+		// itself so the assertion stays honest if the message format
+		// changes.
+		assert.Len(t, names, 1, "exactly one --session value expected")
+		assert.Equal(t, args[len(args)-1], names[0],
+			"--session value must reach the flag storage")
+	}
+}
+
+// TestDoctorRedactionDebt_HelpTextNoBareSessionPlaceholder is the
+// narrow regression for the exact #608 wording bug: the doctor message
+// must NOT instruct the user to type `ox session redact <session>` as
+// a bare positional. cobra accepts it via ArbitraryArgs, silently
+// drops the positional, and a full-ledger scan runs. Match against the
+// hand-written source rather than runtime output so a future copy edit
+// can't drift past the assertion.
+func TestDoctorRedactionDebt_HelpTextNoBareSessionPlaceholder(t *testing.T) {
+	buf, err := os.ReadFile("doctor_redaction_debt.go")
+	require.NoError(t, err)
+	src := string(buf)
+
+	// The original bug emitted exactly this string at line 81. Anywhere
+	// in source that says `ox session redact <…>` without the --session
+	// flag fails the test.
+	bare := regexp.MustCompile(`ox\s+session\s+redact\s+<[^>]+>`)
+	loc := bare.FindStringIndex(src)
+	if loc != nil {
+		t.Fatalf("doctor message uses bare positional form 'ox session redact <…>' at offset %d — cobra silently drops it; use --session <name>",
+			loc[0])
+	}
+}

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,7 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+**`ox session audit` and `ox session redact` now require an explicit scope**
+
+Bare invocation used to silently hydrate and scan the entire ledger — a multi-minute LFS Batch fetch that could process hundreds of sessions without the operator's consent. The command now refuses to run without one of:
+
+- `--session <name>` (repeatable) — limit to specific sessions
+- `--since <date>` / `--until <date>` — half-open lexicographic window against the ISO-prefixed session name (e.g. `--since 2026-04-01`)
+- `--all` — explicit opt-in to the full-ledger sweep
+
+`--all` is mutually exclusive with the narrowing flags. Mistyped `--session` names error before any hydration begins, so a typo no longer triggers minutes of unnecessary LFS fetch followed by an error. The full-ledger sweep that used to fire on bare `ox session redact` is preserved verbatim under `--all`.
+
 ### Fixed
+
+**`ox doctor` redaction-debt guidance now points at a command that exists and works**
+
+The 0.8.1 `ledger-redaction-debt` doctor check told the user to run `ox session redact <session>` for interactive cleanup of a quarantined session. No such positional surface existed — cobra silently dropped the positional and scanned the entire ledger. The fix is two-part:
+
+1. The doctor message now emits a copy-pasteable `ox session redact --session <name>` command for each quarantined session (up to five, with a "+N more" hint above that).
+2. `ox session redact --session <name>` now also walks `.sageox/cache/quarantine/<name>/` for the targeted sessions. For JSONL quarantine, it redacts at the quarantine path via the canonical chokepoint, moves the file back to `sessions/<name>/`, appends a `RedactionPass` to `meta.json`, and removes the debt marker on success. Non-JSONL quarantine is listed as "manual scrub required" — the chokepoint applies the raw-writer redaction stack and expects JSONL.
+
+Before this PR, the doctor warning pointed at a command that couldn't help: the forward path (`prepush_autoredact.quarantineUnredactableFindings`) had moved the bytes OUT of `sessions/<name>/`, and the backward path only walked `sessions/`. Recovery required manually inspecting, scrubbing, and moving files back. Now `ox doctor` → copy-paste → done.
+
+### Security
+
+**Redaction-debt markers are now validated against path-traversal**
+
+The quarantine integration above reads `.sageox/cache/redaction-debt/<session>.json` markers to locate quarantined bytes. An attacker with write access to that directory could previously craft a marker whose `quarantine_paths[].to` pointed outside the ledger (e.g. `../../../tmp/owned.jsonl`); when the operator next ran `ox session redact`, the marker-driven `os.Rename(quarantineAbs, inPlaceAbs)` would overwrite arbitrary files reachable by the operator's UID. Threat model is narrow — the attacker already needs ledger write — but it escalates "ledger-writer" to "arbitrary-file-writer at operator UID."
+
+The fix rejects any marker whose `session_name` contains a path separator or `..`, whose marker filename doesn't match the embedded `session_name`, or whose `quarantine_paths` entries aren't direct children of `sessions/<sess>/` (source) and `.sageox/cache/quarantine/<sess>/` (destination). Defense-in-depth `safeRelativeUnder` checks at the `os.Rename` / `os.Open` call sites block any path that slips past the marker-shape guard.
+
+Closes #608.
 
 **`.claude/settings.json` no longer rewritten on every session**
 

--- a/cmd/ox/session_redact_history.go
+++ b/cmd/ox/session_redact_history.go
@@ -129,25 +129,56 @@ Safety:
 	RunE: runSessionRedact,
 }
 
-// Flag storage. Each command reads from its own variable so cobra's
-// flag namespacing stays clean.
+// Flag storage. Each command reads from its own set of variables so
+// cobra's flag namespacing stays clean — `--session` lives on both
+// `audit` and `redact` but the underlying storage is per-command.
 var (
 	auditLedgerPath string
+	auditScopeNames []string
+	auditScopeSince string
+	auditScopeUntil string
+	auditScopeAll   bool
 
 	redactLedgerPath string
 	redactBackupDir  string
+	redactScopeNames []string
+	redactScopeSince string
+	redactScopeUntil string
+	redactScopeAll   bool
 )
 
 func init() {
+	registerSessionScopeFlags(sessionAuditCmd, &auditScopeNames, &auditScopeSince, &auditScopeUntil, &auditScopeAll)
 	sessionAuditCmd.Flags().StringVar(&auditLedgerPath, "ledger-path", "",
 		"Override the ledger path (defaults to the current project's ledger)")
 	sessionCmd.AddCommand(sessionAuditCmd)
 
+	registerSessionScopeFlags(sessionRedactCmd, &redactScopeNames, &redactScopeSince, &redactScopeUntil, &redactScopeAll)
 	sessionRedactCmd.Flags().StringVar(&redactLedgerPath, "ledger-path", "",
 		"Override the ledger path (defaults to the current project's ledger)")
 	sessionRedactCmd.Flags().StringVar(&redactBackupDir, "backup-dir", "",
 		"Override the backup directory (defaults to ~/.local/share/sageox/backups/redact-history/)")
 	sessionCmd.AddCommand(sessionRedactCmd)
+}
+
+// registerSessionScopeFlags wires --session/--since/--until/--all onto
+// a cobra command and enforces the --all mutex. Bare invocation (no
+// scope flag set) is rejected at the workflow entry point, not here —
+// cobra's required-flag machinery can't express "at least one of these
+// four" cleanly, so the rejection lives next to the validation that
+// produces the user-facing error message.
+func registerSessionScopeFlags(cmd *cobra.Command, names *[]string, since, until *string, all *bool) {
+	cmd.Flags().StringSliceVar(names, "session", nil,
+		"Limit to this session `name` (repeatable). Get names from 'ox doctor' output.")
+	cmd.Flags().StringVar(since, "since", "",
+		"Limit to sessions whose name is >= this prefix (e.g. 2026-04-01). Lexicographic against ISO-prefixed session names.")
+	cmd.Flags().StringVar(until, "until", "",
+		"Limit to sessions whose name is < this prefix (end-exclusive). Lexicographic against ISO-prefixed session names.")
+	cmd.Flags().BoolVar(all, "all", false,
+		"Process every session in the ledger (slow + bulk). Mutually exclusive with --session/--since/--until.")
+	cmd.MarkFlagsMutuallyExclusive("all", "session")
+	cmd.MarkFlagsMutuallyExclusive("all", "since")
+	cmd.MarkFlagsMutuallyExclusive("all", "until")
 }
 
 // runSessionAudit is the cobra entrypoint for the read-only audit
@@ -162,8 +193,14 @@ func runSessionAudit(cmd *cobra.Command, args []string) error {
 		ProjectRoot: findGitRoot(),
 		LedgerPath:  ledgerPath,
 		DryRun:      true,
-		Stdin:       cmd.InOrStdin(),
-		Stdout:      cmd.OutOrStdout(),
+		Scope: &sessionScope{
+			Names:    auditScopeNames,
+			Since:    auditScopeSince,
+			Until:    auditScopeUntil,
+			AllowAll: auditScopeAll,
+		},
+		Stdin:  cmd.InOrStdin(),
+		Stdout: cmd.OutOrStdout(),
 	}
 	return runRedactHistoryWorkflow(opts)
 }
@@ -180,8 +217,14 @@ func runSessionRedact(cmd *cobra.Command, args []string) error {
 		LedgerPath:  ledgerPath,
 		DryRun:      false,
 		BackupDir:   redactBackupDir,
-		Stdin:       cmd.InOrStdin(),
-		Stdout:      cmd.OutOrStdout(),
+		Scope: &sessionScope{
+			Names:    redactScopeNames,
+			Since:    redactScopeSince,
+			Until:    redactScopeUntil,
+			AllowAll: redactScopeAll,
+		},
+		Stdin:  cmd.InOrStdin(),
+		Stdout: cmd.OutOrStdout(),
 	}
 	return runRedactHistoryWorkflow(opts)
 }
@@ -222,8 +265,15 @@ type redactHistoryOptions struct {
 	LedgerPath  string
 	DryRun      bool
 	BackupDir   string // empty → default ~/.local/share/sageox/backups/redact-history/
-	Stdin       io.Reader
-	Stdout      io.Writer
+
+	// Scope narrows which session directories the workflow visits. A
+	// nil or IsEmpty scope is rejected at workflow entry — bare-form
+	// invocation is no longer the silent "scan everything" default.
+	// Use Scope{AllowAll: true} to opt back into the full-ledger sweep.
+	Scope *sessionScope
+
+	Stdin  io.Reader
+	Stdout io.Writer
 }
 
 // runRedactHistoryWorkflow implements the dry-run / scan / snapshot /
@@ -238,13 +288,23 @@ func runRedactHistoryWorkflow(opts redactHistoryOptions) error {
 		opts.Stdout = os.Stdout
 	}
 
+	// Scope rejection rail. Bare invocation used to silently hydrate +
+	// scan the entire ledger — a multi-minute LFS Batch fetch the user
+	// did not consent to. #608. Validate BEFORE any hydration so a
+	// typo'd --session name doesn't pay the fetch cost just to error.
+	sessionsRoot := filepath.Join(opts.LedgerPath, "sessions")
+	if err := opts.Scope.Validate(sessionsRoot); err != nil {
+		return err
+	}
+	matcher := opts.Scope.Matcher()
+
 	// Pre-scan hydration. The scan is content-based and pointer-file bytes
 	// match no credential pattern, so we MUST hydrate every dehydrated
 	// session recording before scanning or the result is meaningless. This
 	// is intentionally visible — printing progress and a final hydration
 	// summary so the operator can see what was fetched and whether any
 	// session was unreachable.
-	hyd, err := hydrateAllSessionsForScan(opts.ProjectRoot, opts.LedgerPath, opts.Stdout)
+	hyd, err := hydrateAllSessionsForScan(opts.ProjectRoot, opts.LedgerPath, opts.Stdout, matcher)
 	if err != nil {
 		return fmt.Errorf("pre-scan hydration: %w", err)
 	}
@@ -256,11 +316,26 @@ func runRedactHistoryWorkflow(opts redactHistoryOptions) error {
 	}
 
 	fmt.Fprintf(opts.Stdout, "Scanning ledger %s for credentials...\n", opts.LedgerPath)
-	scanResult, err := scanLedgerForSecrets(opts.ProjectRoot, opts.LedgerPath)
+	scanResult, err := scanLedgerForSecrets(opts.ProjectRoot, opts.LedgerPath, matcher)
 	if err != nil {
 		return fmt.Errorf("scan: %w", err)
 	}
-	if len(scanResult.Findings) == 0 {
+
+	// Quarantine integration (#608 / Path Y). When --session (or a date
+	// range) matches a quarantined session, surface the quarantined
+	// findings alongside the in-place ones. The forward path (pre-push
+	// gate) moved bytes from sessions/<name>/ to
+	// .sageox/cache/quarantine/<name>/; the backward path needs to see
+	// them or the doctor warning points at a no-op.
+	quarantinedFindings, err := enumerateQuarantineFindings(opts.LedgerPath, matcher)
+	if err != nil {
+		// Non-fatal: log to stdout and continue. Quarantine recovery is
+		// best-effort — if the markers are malformed, the in-place pass
+		// is still valuable.
+		fmt.Fprintf(opts.Stdout, "\nWarning: quarantine enumeration partial — %v\n\n", err)
+	}
+
+	if len(scanResult.Findings) == 0 && len(quarantinedFindings) == 0 {
 		fmt.Fprintf(opts.Stdout, "No credential patterns found across %d session file(s) in %d session(s). Nothing to redact.\n",
 			scanResult.FilesScanned, scanResult.SessionsScanned)
 		return nil
@@ -269,7 +344,7 @@ func runRedactHistoryWorkflow(opts redactHistoryOptions) error {
 	// Enumerate per-finding details (file:line:detector) by re-walking the
 	// affected files. We didn't keep this from the aggregate scan because
 	// the audit doesn't need it; the cleanup tool does.
-	findings, err := enumerateRedactHistoryFindings(opts.ProjectRoot, opts.LedgerPath, scanResult)
+	findings, err := enumerateRedactHistoryFindings(opts.ProjectRoot, opts.LedgerPath, scanResult, matcher)
 	if err != nil {
 		// Partial enumeration is useful — we still have whatever findings
 		// the successful files produced. Surface the issue as a Warning
@@ -281,6 +356,11 @@ func runRedactHistoryWorkflow(opts redactHistoryOptions) error {
 			return fmt.Errorf("enumerate findings: %w", err)
 		}
 	}
+
+	// Merge quarantined findings collected earlier. They share the
+	// redactHistoryFinding shape and the same classification path; the
+	// downstream redact loop branches on f.Quarantined.
+	findings = append(findings, quarantinedFindings...)
 
 	// Classify each finding by pushed/unpushed. Pushed-commit findings are
 	// listed but NOT actionable here — they need the gated rewrite tool.
@@ -345,16 +425,36 @@ func runRedactHistoryWorkflow(opts redactHistoryOptions) error {
 	// the same passID across all sessions touched by this run so the
 	// trail is correlatable; appliedAt is captured once so the records
 	// share a wall-clock instant.
+	answers := newAnswerReader(opts.Stdin)
 	redactedBySession := map[string][]lfs.RedactionEntry{}
+	// quarantineSessionsTouched tracks sessions whose quarantined files
+	// were redacted + moved back; used after the loop to clean up debt
+	// markers and emit the `ox doctor` clearance signal.
+	quarantineSessionsTouched := map[string]bool{}
+	// quarantineSkipped collects non-JSONL quarantined paths the
+	// chokepoint cannot rewrite. They surface as guidance at the end
+	// rather than as a silent skip — the operator needs to know which
+	// files require the manual scrub path.
+	var quarantineSkipped []string
 	redactedFiles := 0
 	for _, fileFindings := range byPath {
 		path := fileFindings[0].Path
-		fmt.Fprintf(opts.Stdout, "%s\n  %d finding(s):\n", path, len(fileFindings))
+		quarantined := fileFindings[0].Quarantined
+		quarantineRel := fileFindings[0].QuarantinePath
+		header := path
+		if quarantined {
+			header = fmt.Sprintf("%s  (quarantined → %s)", path, quarantineRel)
+		}
+		fmt.Fprintf(opts.Stdout, "%s\n  %d finding(s):\n", header, len(fileFindings))
 		for _, f := range fileFindings {
 			fmt.Fprintf(opts.Stdout, "    line %d: %s\n", f.Line, f.Detector)
 		}
-		fmt.Fprint(opts.Stdout, "  Redact in place? [y/N/q to quit]: ")
-		answer, err := readRedactHistoryAnswer(opts.Stdin)
+		prompt := "  Redact in place? [y/N/q to quit]: "
+		if quarantined {
+			prompt = "  Redact at quarantine path and move back to sessions/? [y/N/q to quit]: "
+		}
+		fmt.Fprint(opts.Stdout, prompt)
+		answer, err := readRedactHistoryAnswer(answers)
 		if err != nil {
 			return err
 		}
@@ -363,9 +463,27 @@ func runRedactHistoryWorkflow(opts redactHistoryOptions) error {
 			fmt.Fprintln(opts.Stdout, "Aborting. Snapshot is preserved at the path above.")
 			return nil
 		case "y", "yes":
-			abs := filepath.Join(opts.LedgerPath, path)
-			if err := redactFileInPlace(abs, redactor); err != nil {
-				return fmt.Errorf("redact %s: %w", path, err)
+			if quarantined {
+				if err := redactQuarantinedFile(opts.LedgerPath, quarantineRel, redactor); err != nil {
+					// Non-JSONL or rewrite failure → record and continue.
+					// The operator can still resolve manually; we don't
+					// want a single hard-to-redact file to abort the
+					// whole interactive session.
+					fmt.Fprintf(opts.Stdout, "  Skipped (cannot auto-redact): %v\n\n", err)
+					quarantineSkipped = append(quarantineSkipped, quarantineRel)
+					continue
+				}
+				if err := moveQuarantinedFileBack(opts.LedgerPath, quarantineRel, path); err != nil {
+					return fmt.Errorf("move back %s → %s: %w", quarantineRel, path, err)
+				}
+				if fileFindings[0].SessionName != "" {
+					quarantineSessionsTouched[fileFindings[0].SessionName] = true
+				}
+			} else {
+				abs := filepath.Join(opts.LedgerPath, path)
+				if err := redactFileInPlace(abs, redactor); err != nil {
+					return fmt.Errorf("redact %s: %w", path, err)
+				}
 			}
 			redactedFiles++
 			// Record per-finding entries against the session that owns
@@ -418,13 +536,35 @@ func runRedactHistoryWorkflow(opts redactHistoryOptions) error {
 	// just landed in meta.json, summarized for the terminal.
 	fmt.Fprintf(opts.Stdout, "Recorded redaction pass in %d session meta.json file(s).\n", len(metaPaths))
 
-	// Re-scan and report.
-	postScan, err := scanLedgerForSecrets(opts.ProjectRoot, opts.LedgerPath)
+	// Debt-marker cleanup for fully-drained quarantined sessions. Only
+	// removes the marker when every quarantined file in it has been
+	// moved back; partial cleanup leaves the marker in place so
+	// `ox doctor` still surfaces remaining work.
+	for sess := range quarantineSessionsTouched {
+		if err := removeDebtMarkerIfDrained(opts.LedgerPath, sess); err != nil {
+			fmt.Fprintf(opts.Stdout, "Warning: could not clean up debt marker for %s: %v\n", sess, err)
+		}
+	}
+	if len(quarantineSkipped) > 0 {
+		fmt.Fprintln(opts.Stdout, "\nQuarantined files requiring manual scrub (non-JSONL):")
+		for _, p := range quarantineSkipped {
+			fmt.Fprintf(opts.Stdout, "  %s\n", p)
+		}
+		fmt.Fprintln(opts.Stdout, "  Inspect, scrub the secret, move back to sessions/<name>/<file>, then remove the debt marker.")
+	}
+
+	// Re-scan and report. Scope the post-scan to the same matcher so
+	// the "remaining findings" count reflects the requested scope —
+	// telling the user "you cleaned X but there are 47 findings in
+	// unrelated sessions" re-introduces O(ledger) cost on the back end
+	// without surfacing actionable information.
+	postScan, err := scanLedgerForSecrets(opts.ProjectRoot, opts.LedgerPath, matcher)
 	if err != nil {
 		return fmt.Errorf("post-scan: %w", err)
 	}
-	remaining := len(postScan.Findings)
-	fmt.Fprintf(opts.Stdout, "\nRedaction complete. Files modified: %d. Remaining findings: %d.\n",
+	remainingQuarantine, _ := enumerateQuarantineFindings(opts.LedgerPath, matcher)
+	remaining := len(postScan.Findings) + len(remainingQuarantine)
+	fmt.Fprintf(opts.Stdout, "\nRedaction complete. Files modified: %d. Remaining findings in scope: %d.\n",
 		redactedFiles, remaining)
 	if remaining > 0 {
 		fmt.Fprintln(opts.Stdout, "Re-run to address remaining findings.")
@@ -435,10 +575,26 @@ func runRedactHistoryWorkflow(opts redactHistoryOptions) error {
 // redactHistoryFinding is a single (detector, path, line) tuple — the
 // granular unit users approve or reject. Distinct from the aggregate
 // ledgerSecretsFinding used by the audit, which only counts.
+//
+// Path is always the ledger-relative GIT-TRACKED path
+// (sessions/<name>/<file>) regardless of whether the bytes physically
+// live there. For Quarantined=true findings the bytes live at
+// .sageox/cache/quarantine/<name>/<file>; the workflow uses
+// QuarantinePath (when set) to locate them and moves them back to Path
+// on successful redaction. Carrying the in-place path keeps push-status
+// classification and the snapshot tarball correct.
 type redactHistoryFinding struct {
 	Detector string
-	Path     string // relative to ledger root
+	Path     string // ledger-relative, in-place path (sessions/<name>/<file>)
 	Line     int
+
+	// Quarantined marks findings whose physical bytes were moved aside
+	// by the pre-push gate (#608 Path Y integration). When true, the
+	// workflow reads from QuarantinePath, redacts there, then moves the
+	// file back to Path and removes the debt marker for the session.
+	Quarantined    bool
+	QuarantinePath string // ledger-relative, only set when Quarantined=true
+	SessionName    string // session this finding belongs to (set on both flavors)
 }
 
 // enumerateRedactHistoryFindings re-walks just the session directories
@@ -451,7 +607,7 @@ type redactHistoryFinding struct {
 // same bytes the audit saw. The path recorded on each finding is the
 // git-tracked in-place path (sessions/<name>/<filename>) so downstream
 // push-status classification and the snapshot tarball stay correct.
-func enumerateRedactHistoryFindings(projectRoot, ledgerPath string, audit *ledgerSecretsScanResult) ([]redactHistoryFinding, error) {
+func enumerateRedactHistoryFindings(projectRoot, ledgerPath string, audit *ledgerSecretsScanResult, match func(name string) bool) ([]redactHistoryFinding, error) {
 	if audit == nil || len(audit.Findings) == 0 {
 		return nil, nil
 	}
@@ -476,6 +632,9 @@ func enumerateRedactHistoryFindings(projectRoot, ledgerPath string, audit *ledge
 			continue
 		}
 		sessionName := entry.Name()
+		if match != nil && !match(sessionName) {
+			continue
+		}
 		sessionDir := filepath.Join(sessionsRoot, sessionName)
 		files, err := os.ReadDir(sessionDir)
 		if err != nil {
@@ -518,7 +677,12 @@ func enumerateRedactHistoryFindings(projectRoot, ledgerPath string, audit *ledge
 			for scanner.Scan() {
 				lineNo++
 				for _, name := range redactor.ScanForSecrets(scanner.Text()) {
-					out = append(out, redactHistoryFinding{Detector: name, Path: rel, Line: lineNo})
+					out = append(out, redactHistoryFinding{
+						Detector:    name,
+						Path:        rel,
+						Line:        lineNo,
+						SessionName: sessionName,
+					})
 				}
 			}
 			if scanErr := scanner.Err(); scanErr != nil {
@@ -558,8 +722,18 @@ func enumerateRedactHistoryFindings(projectRoot, ledgerPath string, audit *ledge
 func classifyFindingsByPushStatus(ledgerPath string, findings []redactHistoryFinding) (pushed, unpushed []redactHistoryFinding, err error) {
 	// Build a per-file map of "is this file's last-modifying commit
 	// reachable from origin/main?" — one git call per distinct path.
+	// Quarantined paths are unconditionally treated as unpushed: the
+	// pre-push gate carved them out of the holding commit before any
+	// push could reference the bytes (prepush_autoredact.go:309
+	// amendDroppingPaths). Doing the git lookup for a path that no
+	// commit references would return "not tracked" → "unpushed" anyway,
+	// but skipping the exec saves a fork per quarantined file.
 	pushedFiles := map[string]bool{}
 	for _, f := range findings {
+		if f.Quarantined {
+			pushedFiles[f.Path] = false
+			continue
+		}
 		if _, seen := pushedFiles[f.Path]; seen {
 			continue
 		}
@@ -572,6 +746,10 @@ func classifyFindingsByPushStatus(ledgerPath string, findings []redactHistoryFin
 		pushedFiles[f.Path] = isPushed
 	}
 	for _, f := range findings {
+		if f.Quarantined {
+			unpushed = append(unpushed, f)
+			continue
+		}
 		if pushedFiles[f.Path] {
 			pushed = append(pushed, f)
 		} else {
@@ -813,16 +991,25 @@ func countDistinctRedactHistoryPaths(findings []redactHistoryFinding) int {
 	return len(seen)
 }
 
-// readRedactHistoryAnswer reads a single line of input from stdin. The
-// prompt itself is rendered by the caller; this only consumes the
-// response so we can pipe a scripted test stdin through it.
-func readRedactHistoryAnswer(stdin io.Reader) (string, error) {
-	scanner := bufio.NewScanner(stdin)
-	if scanner.Scan() {
-		return scanner.Text(), nil
-	}
-	if err := scanner.Err(); err != nil {
+// readRedactHistoryAnswer reads a single line from a stateful reader.
+// Caller passes a *bufio.Reader (constructed once via newAnswerReader)
+// so that successive prompts each consume one line — using a fresh
+// bufio.Scanner per call drained the upstream reader on the first read
+// and starved every subsequent prompt of input, observable only with
+// multi-prompt fixtures.
+func readRedactHistoryAnswer(r *bufio.Reader) (string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil && line == "" {
+		if err == io.EOF {
+			return "", nil
+		}
 		return "", err
 	}
-	return "", nil
+	return strings.TrimRight(line, "\n"), nil
+}
+
+// newAnswerReader wraps stdin in a single bufio.Reader the workflow
+// reuses across all interactive prompts. Once per workflow run.
+func newAnswerReader(stdin io.Reader) *bufio.Reader {
+	return bufio.NewReader(stdin)
 }

--- a/cmd/ox/session_redact_history_test.go
+++ b/cmd/ox/session_redact_history_test.go
@@ -184,6 +184,7 @@ func TestRunRedactHistoryWorkflow_DryRunListsButDoesntModify(t *testing.T) {
 		LedgerPath: work,
 		DryRun:     true,
 		BackupDir:  backupDir,
+		Scope:      &sessionScope{AllowAll: true},
 		Stdin:      strings.NewReader(""),
 		Stdout:     out,
 	})
@@ -223,6 +224,7 @@ func TestRunRedactHistoryWorkflow_InteractiveYesRedacts(t *testing.T) {
 	err := runRedactHistoryWorkflow(redactHistoryOptions{
 		LedgerPath: work,
 		BackupDir:  backupDir,
+		Scope:      &sessionScope{AllowAll: true},
 		Stdin:      strings.NewReader("y\n"),
 		Stdout:     out,
 	})
@@ -264,6 +266,7 @@ func TestRunRedactHistoryWorkflow_NoSkipsLeavesFileUnchanged(t *testing.T) {
 	err = runRedactHistoryWorkflow(redactHistoryOptions{
 		LedgerPath: work,
 		BackupDir:  backupDir,
+		Scope:      &sessionScope{AllowAll: true},
 		Stdin:      strings.NewReader("n\n"),
 		Stdout:     out,
 	})
@@ -293,6 +296,7 @@ func TestRunRedactHistoryWorkflow_QuitAbortsWithoutWritingMore(t *testing.T) {
 	err = runRedactHistoryWorkflow(redactHistoryOptions{
 		LedgerPath: work,
 		BackupDir:  t.TempDir(),
+		Scope:      &sessionScope{AllowAll: true},
 		Stdin:      strings.NewReader("q\n"),
 		Stdout:     out,
 	})

--- a/cmd/ox/session_redact_hydrate.go
+++ b/cmd/ox/session_redact_hydrate.go
@@ -36,7 +36,7 @@ type hydrateSummary struct {
 // untouched. Progress is printed to `out` so the operator can see what's
 // happening on a real ledger (115 dehydrated sessions on a fresh clone
 // is not unusual and the fetch is not instant).
-func hydrateAllSessionsForScan(projectRoot, ledgerPath string, out io.Writer) (hydrateSummary, error) {
+func hydrateAllSessionsForScan(projectRoot, ledgerPath string, out io.Writer, match func(name string) bool) (hydrateSummary, error) {
 	var summary hydrateSummary
 	sessionsRoot := filepath.Join(ledgerPath, "sessions")
 	entries, err := os.ReadDir(sessionsRoot)
@@ -61,8 +61,15 @@ func hydrateAllSessionsForScan(projectRoot, ledgerPath string, out io.Writer) (h
 		if !entry.IsDir() {
 			continue
 		}
-		summary.Sessions++
 		sessionName := entry.Name()
+		if match != nil && !match(sessionName) {
+			// Out of scope (#608). Skipping non-matching sessions here
+			// is what makes scoped recovery O(matching) instead of
+			// O(ledger) — the LFS Batch API fetch never fires for
+			// excluded names.
+			continue
+		}
+		summary.Sessions++
 		sessionDir := filepath.Join(sessionsRoot, sessionName)
 		files, err := os.ReadDir(sessionDir)
 		if err != nil {

--- a/cmd/ox/session_redact_quarantine.go
+++ b/cmd/ox/session_redact_quarantine.go
@@ -1,0 +1,303 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sageox/ox/internal/session"
+)
+
+// safeRelativeUnder returns the absolute path for rel joined under base,
+// rejecting any path that escapes base via "..", absolute paths, or
+// symlink resolution. Used everywhere we read a path out of an
+// attacker-influenceable marker file (.sageox/cache/redaction-debt/*.json):
+// without this guard, a crafted `quarantine_paths[].to` like
+// "../../../etc/passwd.bak" would let a ledger-writer cause the redact
+// loop to overwrite arbitrary files reachable by the operator's UID
+// when it runs `os.Rename(quarantineAbs, inPlaceAbs)`. Threat model is
+// narrow (attacker already has ledger write) but the escalation
+// "ledger-writer → arbitrary-file-writer" is worth blocking.
+func safeRelativeUnder(base, rel string) (string, error) {
+	if rel == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("absolute path not allowed: %q", rel)
+	}
+	cleaned := filepath.Clean(rel)
+	if strings.HasPrefix(cleaned, "..") || strings.Contains(cleaned, string(filepath.Separator)+"..") {
+		return "", fmt.Errorf("path escapes base: %q", rel)
+	}
+	abs := filepath.Join(base, cleaned)
+	// filepath.Join + Clean already removed ".." inside the string; the
+	// belt-and-suspenders check above guards against an embedded ".."
+	// that survived (e.g. on a platform with unusual separators). The
+	// explicit prefix check below catches anything that slipped past.
+	baseAbs, err := filepath.Abs(base)
+	if err != nil {
+		return "", err
+	}
+	absAbs, err := filepath.Abs(abs)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(absAbs+string(filepath.Separator), baseAbs+string(filepath.Separator)) && absAbs != baseAbs {
+		return "", fmt.Errorf("path escapes base after resolution: %q", rel)
+	}
+	return abs, nil
+}
+
+// validQuarantineSessionName rejects session names that would let a
+// crafted marker filename or in-memory SessionName field traverse
+// outside the per-session subtree. The forward path
+// (prepush_autoredact.go) keys quarantine state on session names derived
+// from `splitSessionPath` of paths under `sessions/`, but the on-disk
+// shape is untrusted at read time.
+func validQuarantineSessionName(name string) error {
+	if name == "" {
+		return fmt.Errorf("empty session name")
+	}
+	if strings.ContainsAny(name, "/\\") || name == "." || name == ".." {
+		return fmt.Errorf("invalid session name: %q", name)
+	}
+	return nil
+}
+
+// enumerateQuarantineFindings reads <ledger>/.sageox/cache/redaction-debt/
+// markers, filters by the scope matcher, and returns one
+// redactHistoryFinding per (file, line, detector) for the quarantined
+// bytes. The Path on each finding is the IN-PLACE git-tracked path
+// (sessions/<name>/<filename>) — that's the destination on a successful
+// move-back; QuarantinePath holds the source location where the redact
+// pass will actually rewrite bytes.
+//
+// Without this pass, `ox session redact --session X` would walk
+// sessions/X/ for a quarantined session and find nothing — the forward
+// path (prepush_autoredact.quarantineUnredactableFindings) moved the
+// bytes OUT, so the doctor warning pointed at a no-op command.
+//
+// The marker file itself stores per-line findings recorded at quarantine
+// time. We trust those rather than re-scanning the quarantined bytes —
+// the marker is authoritative; the detector catalog could shift between
+// quarantine and now, but the at-rest record of WHAT fired stays
+// stable. (Re-scanning would risk losing visibility into a leak that an
+// older catalog version flagged but a newer one doesn't.)
+//
+// Per-line entries are mapped through session.NewRedactor's catalog so
+// the surfaced detector names are normalized to the current ruleset
+// vocabulary where they overlap; unknown detector names from older
+// markers pass through unchanged.
+func enumerateQuarantineFindings(ledgerPath string, match func(name string) bool) ([]redactHistoryFinding, error) {
+	debtDir := filepath.Join(ledgerPath, ".sageox", "cache", "redaction-debt")
+	entries, err := os.ReadDir(debtDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read redaction-debt dir: %w", err)
+	}
+	var out []redactHistoryFinding
+	var errs []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		markerAbs := filepath.Join(debtDir, entry.Name())
+		buf, err := os.ReadFile(markerAbs)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", entry.Name(), err))
+			continue
+		}
+		var rec redactionDebtRecord
+		if err := json.Unmarshal(buf, &rec); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: parse: %v", entry.Name(), err))
+			continue
+		}
+		if err := validQuarantineSessionName(rec.SessionName); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", entry.Name(), err))
+			continue
+		}
+		// Marker filename must match the embedded session name, otherwise
+		// an attacker who writes `<x>.json` could carry an unrelated
+		// SessionName and silently re-target where redact moves bytes.
+		if entry.Name() != rec.SessionName+".json" {
+			errs = append(errs, fmt.Sprintf("%s: filename does not match session_name %q", entry.Name(), rec.SessionName))
+			continue
+		}
+		if match != nil && !match(rec.SessionName) {
+			continue
+		}
+		// Every From must live directly under sessions/<sess>/ and every
+		// To must live directly under .sageox/cache/quarantine/<sess>/.
+		// This is what the forward path writes (prepush_autoredact.go);
+		// rejecting anything else blocks a marker-driven path-traversal
+		// write when the operator later runs `os.Rename(quarantineAbs,
+		// inPlaceAbs)` to move bytes back.
+		fromPrefix := "sessions/" + rec.SessionName + "/"
+		toPrefix := ".sageox/cache/quarantine/" + rec.SessionName + "/"
+		quarantineByFile := map[string]string{}
+		invalidLoc := false
+		for _, loc := range rec.QuarantinePaths {
+			from := filepath.ToSlash(loc.From)
+			to := filepath.ToSlash(loc.To)
+			if !strings.HasPrefix(from, fromPrefix) || strings.Contains(from[len(fromPrefix):], "/") || strings.Contains(from, "..") {
+				errs = append(errs, fmt.Sprintf("%s: from %q must be a direct child of sessions/%s/", entry.Name(), loc.From, rec.SessionName))
+				invalidLoc = true
+				continue
+			}
+			if !strings.HasPrefix(to, toPrefix) || strings.Contains(to[len(toPrefix):], "/") || strings.Contains(to, "..") {
+				errs = append(errs, fmt.Sprintf("%s: to %q must be a direct child of .sageox/cache/quarantine/%s/", entry.Name(), loc.To, rec.SessionName))
+				invalidLoc = true
+				continue
+			}
+			quarantineByFile[loc.From] = loc.To
+		}
+		if invalidLoc {
+			continue
+		}
+		for _, f := range rec.Findings {
+			if strings.ContainsAny(f.Filename, "/\\") {
+				errs = append(errs, fmt.Sprintf("%s: filename %q contains path separator", entry.Name(), f.Filename))
+				continue
+			}
+			inPlaceRel := filepath.ToSlash(filepath.Join("sessions", rec.SessionName, f.Filename))
+			quarantineRel, ok := quarantineByFile[inPlaceRel]
+			if !ok {
+				errs = append(errs, fmt.Sprintf("%s: finding for %q has no quarantine_paths entry", entry.Name(), f.Filename))
+				continue
+			}
+			out = append(out, redactHistoryFinding{
+				Detector:       f.Detector,
+				Path:           inPlaceRel,
+				Line:           f.Line,
+				Quarantined:    true,
+				QuarantinePath: quarantineRel,
+				SessionName:    rec.SessionName,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		if out[i].Line != out[j].Line {
+			return out[i].Line < out[j].Line
+		}
+		return out[i].Detector < out[j].Detector
+	})
+	if len(errs) > 0 {
+		return out, fmt.Errorf("quarantine enumeration incomplete (%d issue(s)):\n  %s",
+			len(errs), strings.Join(errs, "\n  "))
+	}
+	return out, nil
+}
+
+// moveQuarantinedFileBack moves bytes from
+// .sageox/cache/quarantine/<name>/<file> back to sessions/<name>/<file>
+// after a successful redact. Idempotent: if the destination already
+// exists (operator manually moved the file back), prefer that and
+// remove the quarantine copy.
+func moveQuarantinedFileBack(ledgerPath, quarantineRel, inPlaceRel string) error {
+	// Belt-and-suspenders containment check at the os.Rename boundary.
+	// The caller (enumerateQuarantineFindings) already validates the
+	// marker shape, but a future code path that constructs the args
+	// differently must not be able to bypass the guard.
+	quarantineAbs, err := safeRelativeUnder(ledgerPath, quarantineRel)
+	if err != nil {
+		return fmt.Errorf("quarantine path: %w", err)
+	}
+	inPlaceAbs, err := safeRelativeUnder(ledgerPath, inPlaceRel)
+	if err != nil {
+		return fmt.Errorf("in-place path: %w", err)
+	}
+
+	if _, err := os.Stat(quarantineAbs); err != nil {
+		if os.IsNotExist(err) {
+			// Already moved (likely by a previous partial run). Nothing
+			// to do — the in-place file is canonical.
+			return nil
+		}
+		return fmt.Errorf("stat quarantine source: %w", err)
+	}
+
+	if _, err := os.Stat(inPlaceAbs); err == nil {
+		// In-place exists. Operator likely beat us to it. Remove the
+		// quarantine copy so the marker can be cleaned up cleanly.
+		if err := os.Remove(quarantineAbs); err != nil {
+			return fmt.Errorf("remove quarantine after in-place exists: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(inPlaceAbs), 0o700); err != nil {
+		return fmt.Errorf("mkdir in-place parent: %w", err)
+	}
+	if err := os.Rename(quarantineAbs, inPlaceAbs); err != nil {
+		return fmt.Errorf("rename quarantine → in-place: %w", err)
+	}
+	return nil
+}
+
+// removeDebtMarkerIfDrained removes the redaction-debt marker for a
+// session if every quarantined file listed inside it is no longer at
+// its quarantine location (i.e. all paths have been moved back or
+// otherwise resolved). Best-effort — leaves the marker in place on any
+// error so the next `ox doctor` run still sees the unresolved state.
+//
+// The accompanying quarantine directory
+// (.sageox/cache/quarantine/<name>/) is also cleaned up if empty.
+func removeDebtMarkerIfDrained(ledgerPath, sessionName string) error {
+	if err := validQuarantineSessionName(sessionName); err != nil {
+		return err
+	}
+	markerRel := filepath.ToSlash(filepath.Join(".sageox", "cache", "redaction-debt", sessionName+".json"))
+	markerAbs := filepath.Join(ledgerPath, markerRel)
+
+	buf, err := os.ReadFile(markerAbs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var rec redactionDebtRecord
+	if err := json.Unmarshal(buf, &rec); err != nil {
+		return err
+	}
+	for _, loc := range rec.QuarantinePaths {
+		if _, err := os.Stat(filepath.Join(ledgerPath, loc.To)); err == nil {
+			// Still quarantined; not done.
+			return nil
+		}
+	}
+	if err := os.Remove(markerAbs); err != nil {
+		return err
+	}
+	quarantineDir := filepath.Join(ledgerPath, ".sageox", "cache", "quarantine", sessionName)
+	if entries, err := os.ReadDir(quarantineDir); err == nil && len(entries) == 0 {
+		_ = os.Remove(quarantineDir)
+	}
+	return nil
+}
+
+// redactQuarantinedFile applies the canonical chokepoint at the
+// quarantine source path. Non-JSONL quarantined files are surfaced as
+// "manual scrub required" rather than auto-redacted — the chokepoint
+// applies the raw-writer redaction stack and expects each line to be a
+// JSON record. For non-JSONL, the operator follows the manual flow
+// (inspect → scrub → move back) documented in `ox doctor`'s
+// redaction-debt detail.
+func redactQuarantinedFile(ledgerPath, quarantineRel string, redactor *session.Redactor) error {
+	abs, err := safeRelativeUnder(ledgerPath, quarantineRel)
+	if err != nil {
+		return fmt.Errorf("quarantine path: %w", err)
+	}
+	if !isJSONLPath(filepath.Base(abs)) {
+		return fmt.Errorf("quarantined file %s is not JSONL; manual scrub required (see `ox doctor` step 2)", quarantineRel)
+	}
+	return redactFileInPlace(abs, redactor)
+}

--- a/cmd/ox/session_redact_quarantine_security_test.go
+++ b/cmd/ox/session_redact_quarantine_security_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnumerateQuarantineFindings_RejectsPathTraversal is the security
+// regression for the marker-trust threat model: an attacker with write
+// access to .sageox/cache/redaction-debt/<x>.json can craft a marker
+// whose quarantine_paths[].to escapes the ledger. Without containment
+// guards, the redact loop's subsequent os.Rename(quarantineAbs,
+// inPlaceAbs) would overwrite arbitrary files reachable by the
+// operator's UID.
+//
+// The fix lives in enumerateQuarantineFindings (rejects bad markers at
+// read time) plus belt-and-suspenders safeRelativeUnder checks at the
+// os.Rename / os.Open call sites. This test exercises both: a marker
+// with a traversal payload must not produce any findings, AND the
+// error stream must explain why so the operator notices something is
+// wrong.
+//
+// Failure prevented: silent acceptance of a marker that, on the next
+// redact run, lets a ledger-writer escalate to "arbitrary-file-writer
+// at operator UID" via crafted to/from paths.
+func TestEnumerateQuarantineFindings_RejectsPathTraversal(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Path-separator semantics differ; the guards still apply but
+		// the test fixtures below are POSIX-style.
+		t.Skip("POSIX path fixtures")
+	}
+	ledger := t.TempDir()
+	debtDir := filepath.Join(ledger, ".sageox", "cache", "redaction-debt")
+	require.NoError(t, os.MkdirAll(debtDir, 0o700))
+
+	cases := []struct {
+		name       string
+		marker     redactionDebtRecord
+		filename   string
+		wantErrSub string
+	}{
+		{
+			name: "to escapes ledger via dotdot",
+			marker: redactionDebtRecord{
+				SessionName: "evil",
+				Findings:    []redactionDebtFinding{{Detector: "x", Filename: "raw.jsonl", Line: 1}},
+				QuarantinePaths: []redactionDebtLocation{{
+					From: "sessions/evil/raw.jsonl",
+					To:   "../../../tmp/owned.jsonl",
+				}},
+			},
+			filename:   "evil.json",
+			wantErrSub: "direct child of .sageox/cache/quarantine/evil/",
+		},
+		{
+			name: "from escapes session subtree",
+			marker: redactionDebtRecord{
+				SessionName: "evil",
+				Findings:    []redactionDebtFinding{{Detector: "x", Filename: "raw.jsonl", Line: 1}},
+				QuarantinePaths: []redactionDebtLocation{{
+					From: "../../etc/passwd",
+					To:   ".sageox/cache/quarantine/evil/raw.jsonl",
+				}},
+			},
+			filename:   "evil.json",
+			wantErrSub: "direct child of sessions/evil/",
+		},
+		{
+			name: "session name has separator",
+			marker: redactionDebtRecord{
+				SessionName: "evil/..",
+				Findings:    []redactionDebtFinding{{Detector: "x", Filename: "raw.jsonl", Line: 1}},
+			},
+			filename:   "evil-with-bad-name.json",
+			wantErrSub: "invalid session name",
+		},
+		{
+			name: "filename mismatch (marker filename != session_name)",
+			marker: redactionDebtRecord{
+				SessionName: "legitimate",
+				Findings:    []redactionDebtFinding{{Detector: "x", Filename: "raw.jsonl", Line: 1}},
+				QuarantinePaths: []redactionDebtLocation{{
+					From: "sessions/legitimate/raw.jsonl",
+					To:   ".sageox/cache/quarantine/legitimate/raw.jsonl",
+				}},
+			},
+			filename:   "different-name.json",
+			wantErrSub: "filename does not match session_name",
+		},
+		{
+			name: "finding filename contains separator",
+			marker: redactionDebtRecord{
+				SessionName: "ok",
+				Findings:    []redactionDebtFinding{{Detector: "x", Filename: "../escape", Line: 1}},
+				QuarantinePaths: []redactionDebtLocation{{
+					From: "sessions/ok/raw.jsonl",
+					To:   ".sageox/cache/quarantine/ok/raw.jsonl",
+				}},
+			},
+			filename:   "ok.json",
+			wantErrSub: "path separator",
+		},
+		{
+			name: "to has subdirectory (not direct child)",
+			marker: redactionDebtRecord{
+				SessionName: "ok",
+				Findings:    []redactionDebtFinding{{Detector: "x", Filename: "raw.jsonl", Line: 1}},
+				QuarantinePaths: []redactionDebtLocation{{
+					From: "sessions/ok/raw.jsonl",
+					To:   ".sageox/cache/quarantine/ok/nested/raw.jsonl",
+				}},
+			},
+			filename:   "ok.json",
+			wantErrSub: "direct child of .sageox/cache/quarantine/ok/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Each case in its own scratch dir so the entry iteration
+			// order is deterministic.
+			thisLedger := t.TempDir()
+			thisDebtDir := filepath.Join(thisLedger, ".sageox", "cache", "redaction-debt")
+			require.NoError(t, os.MkdirAll(thisDebtDir, 0o700))
+			buf, err := json.MarshalIndent(tc.marker, "", "  ")
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(thisDebtDir, tc.filename), buf, 0o600))
+
+			findings, enumErr := enumerateQuarantineFindings(thisLedger, nil)
+			assert.Empty(t, findings, "no findings should be produced from a traversal-tainted marker")
+			require.Error(t, enumErr, "enumeration must surface the rejection")
+			assert.Contains(t, enumErr.Error(), tc.wantErrSub,
+				"error message must point at the specific rule that fired")
+		})
+	}
+}
+
+// TestMoveQuarantinedFileBack_RejectsTraversal verifies the
+// belt-and-suspenders containment check at the os.Rename boundary.
+// Even if a future refactor sneaks traversal-tainted paths past the
+// marker-enumeration guard, the move itself must refuse.
+func TestMoveQuarantinedFileBack_RejectsTraversal(t *testing.T) {
+	ledger := t.TempDir()
+	// Place a real file at <ledger>/.sageox/cache/quarantine/foo/raw.jsonl
+	// so the function can't bail on "source doesn't exist" before reaching
+	// the containment check.
+	src := filepath.Join(ledger, ".sageox", "cache", "quarantine", "foo", "raw.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(src), 0o700))
+	require.NoError(t, os.WriteFile(src, []byte("payload"), 0o600))
+
+	// Target escapes the ledger.
+	err := moveQuarantinedFileBack(ledger,
+		".sageox/cache/quarantine/foo/raw.jsonl",
+		"../escape/raw.jsonl")
+	require.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "escapes") || strings.Contains(err.Error(), "absolute"),
+		"error must explain containment, got: %v", err)
+
+	// Source escapes the ledger.
+	err = moveQuarantinedFileBack(ledger,
+		"../etc/passwd",
+		"sessions/foo/raw.jsonl")
+	require.Error(t, err)
+}

--- a/cmd/ox/session_redact_scope.go
+++ b/cmd/ox/session_redact_scope.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// sessionScope narrows the set of session directories that
+// hydrateAllSessionsForScan, scanLedgerForSecrets, and
+// enumerateRedactHistoryFindings will visit. It is the single source of
+// truth for filter semantics shared by `ox session audit` and `ox
+// session redact`.
+//
+// An empty scope (no Names, no Since/Until, AllowAll=false) is the
+// "bare invocation" state and is rejected at the workflow entry point —
+// the previous bare behavior (silently hydrate + scan the entire
+// ledger) was the hazard documented at session_redact_history.go:38-40
+// translated into the CLI default. AllowAll=true is the opt-in to that
+// previous behavior with explicit operator consent.
+type sessionScope struct {
+	// Names is a literal allowlist. Each entry must correspond to an
+	// existing directory under <ledger>/sessions/; missing names are
+	// surfaced before any hydration begins (Validate).
+	Names []string
+
+	// Since/Until are lexicographic bounds against the session-name
+	// prefix. Session names are ISO-prefixed (e.g.
+	// "2026-04-25T15-22-ryan-OxGtDf"), so string comparison against
+	// "2026-04-25" or "2026-04-25T15-22" is correct without parsing.
+	// Empty string disables that bound.
+	//
+	// Range is half-open: [Since, Until). Until-exclusive lets
+	// day-aligned ranges compose without overlap.
+	Since string
+	Until string
+
+	// AllowAll opts back into the pre-#608 behavior of scanning every
+	// session in the ledger. Mutually exclusive with the other fields
+	// (enforced by cobra's MarkFlagsMutuallyExclusive on the command).
+	AllowAll bool
+}
+
+// IsEmpty returns true when no scope has been specified — this is the
+// bare-invocation state the workflow rejects.
+func (s *sessionScope) IsEmpty() bool {
+	if s == nil {
+		return true
+	}
+	return len(s.Names) == 0 && s.Since == "" && s.Until == "" && !s.AllowAll
+}
+
+// Match decides whether a session-directory name should be included.
+// Per the AllowAll-mutex rule, callers should not combine AllowAll with
+// the other fields; if they do, AllowAll wins.
+func (s *sessionScope) Match(name string) bool {
+	if s == nil {
+		return false
+	}
+	if s.AllowAll {
+		return true
+	}
+	for _, n := range s.Names {
+		if n == name {
+			return true
+		}
+	}
+	// Date bounds are independent of Names — a name match wins above;
+	// a date match here is the union path. Both bounds use
+	// lexicographic compare against the ISO-prefixed session name.
+	if s.Since == "" && s.Until == "" {
+		return false
+	}
+	if s.Since != "" && name < s.Since {
+		return false
+	}
+	if s.Until != "" && name >= s.Until {
+		return false
+	}
+	return true
+}
+
+// Validate runs cheap pre-hydration checks: each explicit Name must
+// correspond to a directory under sessionsRoot, and the resolved scope
+// must match at least one session. Both failure modes return BEFORE any
+// LFS Batch call so a typo'd --session doesn't trigger a multi-minute
+// fetch followed by an error.
+func (s *sessionScope) Validate(sessionsRoot string) error {
+	if s == nil || s.IsEmpty() {
+		return fmt.Errorf("specify --all, --session, or --since/--until — bare invocation is rejected because it scans the entire ledger (slow + bulk)")
+	}
+	if s.AllowAll {
+		// No further validation: --all matches every session by definition.
+		// An empty ledger isn't an error here; the scan will just be a no-op.
+		return nil
+	}
+
+	// Explicit-name check.
+	var missing []string
+	for _, n := range s.Names {
+		info, err := os.Stat(filepath.Join(sessionsRoot, n))
+		if err != nil || !info.IsDir() {
+			missing = append(missing, n)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("no session named %q in ledger %s",
+			strings.Join(missing, `", "`), filepath.Dir(sessionsRoot))
+	}
+
+	// Date-range or names-only — confirm at least one session matches.
+	entries, err := os.ReadDir(sessionsRoot)
+	if err != nil {
+		// sessions root missing is benign — the workflow will report
+		// "nothing to scan". Don't escalate here.
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read sessions dir for scope validation: %w", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if s.Match(e.Name()) {
+			return nil
+		}
+	}
+	return fmt.Errorf("no sessions match the requested scope (names=%v since=%q until=%q)",
+		s.Names, s.Since, s.Until)
+}
+
+// Matcher returns a closure suitable for passing to
+// hydrateAllSessionsForScan / scanLedgerForSecrets /
+// enumerateRedactHistoryFindings. A nil scope returns a nil matcher,
+// which the callers treat as "match all" — keeps the doctor surface
+// (which has no scope concept) backward-compatible.
+func (s *sessionScope) Matcher() func(name string) bool {
+	if s == nil {
+		return nil
+	}
+	return s.Match
+}

--- a/cmd/ox/session_redact_scope_test.go
+++ b/cmd/ox/session_redact_scope_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionScope_BareInvocationRejected guards the bare-form
+// rejection rail. Before #608, a no-flag invocation silently hydrated
+// + scanned the entire ledger (multi-minute LFS Batch fetch the
+// operator never consented to). Failure prevented: someone removes
+// the IsEmpty / Validate check and bare invocation silently scans
+// everything.
+func TestSessionScope_BareInvocationRejected(t *testing.T) {
+	work := makeLedgerWithCommitAndOrigin(t, map[string]string{
+		"sessions/leaky/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+	})
+	backupDir := t.TempDir()
+	out := &bytes.Buffer{}
+
+	// nil scope: workflow must reject before any hydration/snapshot
+	err := runRedactHistoryWorkflow(redactHistoryOptions{
+		LedgerPath: work,
+		DryRun:     true,
+		BackupDir:  backupDir,
+		Scope:      nil,
+		Stdin:      strings.NewReader(""),
+		Stdout:     out,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "specify --all")
+	entries, _ := os.ReadDir(backupDir)
+	assert.Empty(t, entries, "rejection must fire before any snapshot")
+
+	// empty scope (all fields zero-valued): same rail
+	err = runRedactHistoryWorkflow(redactHistoryOptions{
+		LedgerPath: work,
+		DryRun:     true,
+		BackupDir:  backupDir,
+		Scope:      &sessionScope{},
+		Stdin:      strings.NewReader(""),
+		Stdout:     out,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "specify --all")
+}
+
+// TestSessionScope_SessionFilter_ScopesToMatching verifies the load-
+// bearing claim that --session narrows hydration + scan + the
+// RedactionPass audit trail to a single session. Failure prevented:
+// filter silently broadens past the requested session, redacting
+// content the operator did not ask about.
+func TestSessionScope_SessionFilter_ScopesToMatching(t *testing.T) {
+	work := makeLedgerWithCommitAndOrigin(t, map[string]string{
+		"sessions/leaky-a/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+		"sessions/leaky-a/meta.json": minimalMetaJSON("leaky-a", "OxLEAKA"),
+		"sessions/leaky-b/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+		"sessions/leaky-b/meta.json": minimalMetaJSON("leaky-b", "OxLEAKB"),
+	})
+	bPath := filepath.Join(work, "sessions/leaky-b/raw.jsonl")
+	originalB, err := os.ReadFile(bPath)
+	require.NoError(t, err)
+	out := &bytes.Buffer{}
+
+	err = runRedactHistoryWorkflow(redactHistoryOptions{
+		LedgerPath: work,
+		BackupDir:  t.TempDir(),
+		Scope:      &sessionScope{Names: []string{"leaky-a"}},
+		Stdin:      strings.NewReader("y\n"),
+		Stdout:     out,
+	})
+	require.NoError(t, err)
+
+	aAfter, err := os.ReadFile(filepath.Join(work, "sessions/leaky-a/raw.jsonl"))
+	require.NoError(t, err)
+	assert.Contains(t, string(aAfter), "[REDACTED_AWS_KEY]", "leaky-a must be redacted")
+
+	bAfter, err := os.ReadFile(bPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalB, bAfter, "leaky-b must be byte-equal to original (out of scope)")
+
+	// the workflow output should not even mention leaky-b
+	assert.NotContains(t, out.String(), "leaky-b", "out-of-scope session leaked into output")
+}
+
+// TestSessionScope_SessionFilter_UnknownErrorsBeforeHydration is the
+// "no LFS fetch for typos" guarantee. A misspelled --session name must
+// error BEFORE any hydration or snapshot work begins. Failure
+// prevented: typo'd name triggers a minutes-long LFS Batch fetch then
+// errors at the end.
+func TestSessionScope_SessionFilter_UnknownErrorsBeforeHydration(t *testing.T) {
+	work := makeLedgerWithCommitAndOrigin(t, map[string]string{
+		"sessions/leaky/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+	})
+	backupDir := t.TempDir()
+	out := &bytes.Buffer{}
+
+	err := runRedactHistoryWorkflow(redactHistoryOptions{
+		LedgerPath: work,
+		BackupDir:  backupDir,
+		Scope:      &sessionScope{Names: []string{"ghost"}},
+		Stdin:      strings.NewReader(""),
+		Stdout:     out,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+
+	entries, _ := os.ReadDir(backupDir)
+	assert.Empty(t, entries, "snapshot must NOT fire for unknown session")
+	// cache dir for the unknown name must not exist
+	_, statErr := os.Stat(filepath.Join(work, ".sageox", "cache", "sessions", "ghost"))
+	assert.True(t, os.IsNotExist(statErr), "no hydration attempt for unknown session")
+}
+
+// TestSessionScope_SessionFilter_RepeatedIsUnion checks that
+// --session a --session c picks up a and c (skipping b). Failure
+// prevented: repeated flag silently overwrites instead of
+// accumulating.
+func TestSessionScope_SessionFilter_RepeatedIsUnion(t *testing.T) {
+	work := makeLedgerWithCommitAndOrigin(t, map[string]string{
+		"sessions/sess-a/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+		"sessions/sess-a/meta.json": minimalMetaJSON("sess-a", "OxA"),
+		"sessions/sess-b/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+		"sessions/sess-b/meta.json": minimalMetaJSON("sess-b", "OxB"),
+		"sessions/sess-c/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+		"sessions/sess-c/meta.json": minimalMetaJSON("sess-c", "OxC"),
+	})
+	bPath := filepath.Join(work, "sessions/sess-b/raw.jsonl")
+	originalB, err := os.ReadFile(bPath)
+	require.NoError(t, err)
+	out := &bytes.Buffer{}
+
+	err = runRedactHistoryWorkflow(redactHistoryOptions{
+		LedgerPath: work,
+		BackupDir:  t.TempDir(),
+		Scope:      &sessionScope{Names: []string{"sess-a", "sess-c"}},
+		Stdin:      strings.NewReader("y\ny\n"),
+		Stdout:     out,
+	})
+	require.NoError(t, err)
+
+	aAfter, _ := os.ReadFile(filepath.Join(work, "sessions/sess-a/raw.jsonl"))
+	assert.Contains(t, string(aAfter), "[REDACTED_AWS_KEY]", "sess-a redacted")
+	cAfter, _ := os.ReadFile(filepath.Join(work, "sessions/sess-c/raw.jsonl"))
+	assert.Contains(t, string(cAfter), "[REDACTED_AWS_KEY]", "sess-c redacted")
+	bAfter, _ := os.ReadFile(bPath)
+	assert.Equal(t, originalB, bAfter, "sess-b untouched")
+}
+
+// TestSessionScope_DateRange_LexicographicWindow exercises --since /
+// --until. Session names are ISO-prefixed so string compare is the
+// correct semantics. Failure prevented: window math drifts
+// (off-by-one, inclusive/exclusive, or implicit date parsing changes
+// the bound).
+func TestSessionScope_DateRange_LexicographicWindow(t *testing.T) {
+	work := makeLedgerWithCommitAndOrigin(t, map[string]string{
+		"sessions/2026-03-01T10-00-x/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+		"sessions/2026-03-01T10-00-x/meta.json": minimalMetaJSON("2026-03-01T10-00-x", "OxA"),
+		"sessions/2026-04-15T12-00-x/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+		"sessions/2026-04-15T12-00-x/meta.json": minimalMetaJSON("2026-04-15T12-00-x", "OxB"),
+		"sessions/2026-05-10T14-00-x/raw.jsonl": "AKIAIOSFODNN7EXAMPLE\n",
+		"sessions/2026-05-10T14-00-x/meta.json": minimalMetaJSON("2026-05-10T14-00-x", "OxC"),
+	})
+	marchPath := filepath.Join(work, "sessions/2026-03-01T10-00-x/raw.jsonl")
+	originalMarch, _ := os.ReadFile(marchPath)
+	out := &bytes.Buffer{}
+
+	// half-open [2026-04-01, 2026-05-01) → April only
+	err := runRedactHistoryWorkflow(redactHistoryOptions{
+		LedgerPath: work,
+		BackupDir:  t.TempDir(),
+		Scope:      &sessionScope{Since: "2026-04-01", Until: "2026-05-01"},
+		Stdin:      strings.NewReader("y\n"),
+		Stdout:     out,
+	})
+	require.NoError(t, err)
+
+	aprAfter, _ := os.ReadFile(filepath.Join(work, "sessions/2026-04-15T12-00-x/raw.jsonl"))
+	assert.Contains(t, string(aprAfter), "[REDACTED_AWS_KEY]", "April session redacted")
+	mayAfter, _ := os.ReadFile(filepath.Join(work, "sessions/2026-05-10T14-00-x/raw.jsonl"))
+	assert.NotContains(t, string(mayAfter), "[REDACTED_AWS_KEY]", "May excluded by --until")
+	marchAfter, _ := os.ReadFile(marchPath)
+	assert.Equal(t, originalMarch, marchAfter, "March excluded by --since")
+}
+
+// TestSessionScope_QuarantineIntegration_JSONL is the load-bearing test
+// for Path Y: a session whose JSONL was carved out by the pre-push gate
+// into .sageox/cache/quarantine/<name>/raw.jsonl must be recoverable
+// via `redact --session <name>`. After approve, bytes move back to
+// sessions/<name>/raw.jsonl AND the debt marker is removed (signaling
+// to `ox doctor` that the debt is paid).
+//
+// Failure prevented: doctor warning points at a command that doesn't
+// help (the original #608 symptom — surface mismatch and marker
+// orphan).
+func TestSessionScope_QuarantineIntegration_JSONL(t *testing.T) {
+	work := makeLedgerWithCommitAndOrigin(t, map[string]string{
+		"sessions/dirty/meta.json": minimalMetaJSON("dirty", "OxDIRTY"),
+	})
+
+	// Hand-construct quarantine state: bytes at the quarantine path +
+	// a marker pointing at them. This is what the forward path
+	// (prepush_autoredact.quarantineUnredactableFindings) would leave
+	// behind for a JSONL-with-rewrite-error case.
+	quarantineDir := filepath.Join(work, ".sageox", "cache", "quarantine", "dirty")
+	require.NoError(t, os.MkdirAll(quarantineDir, 0o700))
+	quarantineFile := filepath.Join(quarantineDir, "raw.jsonl")
+	require.NoError(t, os.WriteFile(quarantineFile, []byte(`{"text":"AKIAIOSFODNN7EXAMPLE"}`+"\n"), 0o600))
+
+	markerDir := filepath.Join(work, ".sageox", "cache", "redaction-debt")
+	require.NoError(t, os.MkdirAll(markerDir, 0o700))
+	rec := redactionDebtRecord{
+		SessionName:   "dirty",
+		QuarantinedAt: time.Now().UTC(),
+		Reason:        "test fixture",
+		Findings: []redactionDebtFinding{
+			{Detector: "aws_access_key", Filename: "raw.jsonl", Line: 1},
+		},
+		QuarantinePaths: []redactionDebtLocation{
+			{From: "sessions/dirty/raw.jsonl", To: ".sageox/cache/quarantine/dirty/raw.jsonl"},
+		},
+	}
+	buf, err := json.MarshalIndent(rec, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(markerDir, "dirty.json"), buf, 0o600))
+
+	out := &bytes.Buffer{}
+	err = runRedactHistoryWorkflow(redactHistoryOptions{
+		LedgerPath: work,
+		BackupDir:  t.TempDir(),
+		Scope:      &sessionScope{Names: []string{"dirty"}},
+		Stdin:      strings.NewReader("y\n"),
+		Stdout:     out,
+	})
+	require.NoError(t, err)
+
+	// quarantine source must be gone
+	_, statErr := os.Stat(quarantineFile)
+	assert.True(t, os.IsNotExist(statErr), "quarantine source must be moved")
+
+	// destination must hold redacted bytes
+	inPlace, err := os.ReadFile(filepath.Join(work, "sessions/dirty/raw.jsonl"))
+	require.NoError(t, err)
+	assert.Contains(t, string(inPlace), "[REDACTED_AWS_KEY]", "moved-back file is redacted")
+	assert.NotContains(t, string(inPlace), "AKIAIOSFODNN7EXAMPLE", "secret bytes gone")
+
+	// debt marker must be cleaned up
+	_, markerErr := os.Stat(filepath.Join(markerDir, "dirty.json"))
+	assert.True(t, os.IsNotExist(markerErr), "drained debt marker must be removed")
+}
+
+// TestSessionScope_Match_DateRangeUnit unit-tests the matcher in
+// isolation. Cheap regression guard for the lex compare logic — no
+// disk IO. Failure prevented: subtle off-by-one or inclusive bound
+// changes the meaning of --since / --until.
+func TestSessionScope_Match_DateRangeUnit(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope sessionScope
+		input string
+		want  bool
+	}{
+		{"allowAll", sessionScope{AllowAll: true}, "anything", true},
+		{"name hit", sessionScope{Names: []string{"a"}}, "a", true},
+		{"name miss", sessionScope{Names: []string{"a"}}, "b", false},
+		{"since lower-bound inclusive", sessionScope{Since: "2026-04-01"}, "2026-04-01T00-00-x", true},
+		{"since below excluded", sessionScope{Since: "2026-04-01"}, "2026-03-31T23-59-x", false},
+		{"until upper-bound exclusive", sessionScope{Until: "2026-05-01"}, "2026-05-01T00-00-x", false},
+		{"until below included", sessionScope{Until: "2026-05-01"}, "2026-04-30T23-59-x", true},
+		{"name+date is union", sessionScope{Names: []string{"keep-me"}, Since: "2026-05-01"}, "keep-me", true},
+		{"empty matches nothing", sessionScope{}, "any", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.scope.Match(tc.input))
+		})
+	}
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.7.2"
+  "version": "0.8.1"
 }

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -1,0 +1,60 @@
+---
+title: "ox session audit"
+description: "CLI reference for ox session audit"
+sidebar_position: 67
+---
+
+## ox session audit
+
+Audit session recordings for credential patterns (read-only; expensive)
+
+### Synopsis
+
+Audit every session recording in the local Ledger for credential patterns.
+Read-only — never modifies files, never amends commits, never uploads.
+
+Cost: this command force-hydrates every LFS-pointer session file via the
+LFS Batch API before scanning, because pointer-stub bytes match no
+credential pattern and would silently produce a clean-looking lie.
+Hydration is bounded by network throughput and the number of dehydrated
+sessions; on a fresh clone with hundreds of sessions this can take
+minutes and pull tens of megabytes. Sessions that fail to hydrate are
+surfaced as a Warning so partial coverage is never mistaken for clean.
+
+Findings are reported with detector name + file + line; matched bytes
+are NEVER printed (ox-zyg7). The output stamps the catalog version + a
+sha256 hash that produced the findings, so future re-audits can decide
+whether a newer ruleset would catch additional leaks.
+
+For interactive cleanup of any findings, run `ox session redact`.
+
+```
+ox session audit [flags]
+```
+
+### Options
+
+```
+      --all                  Process every session in the ledger (slow + bulk). Mutually exclusive with --session/--since/--until.
+  -h, --help                 help for audit
+      --ledger-path string   Override the ledger path (defaults to the current project's ledger)
+      --session name         Limit to this session name (repeatable). Get names from 'ox doctor' output.
+      --since string         Limit to sessions whose name is >= this prefix (e.g. 2026-04-01). Lexicographic against ISO-prefixed session names.
+      --until string         Limit to sessions whose name is < this prefix (end-exclusive). Lexicographic against ISO-prefixed session names.
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox session](/session)	 - Manage AI coworker sessions
+

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -42,8 +42,10 @@ Commands:
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+* [ox session audit](/session/audit)	 - Audit session recordings for credential patterns (read-only; expensive)
 * [ox session lint](/session/lint)	 - Validate session raw.jsonl for web viewer compatibility
 * [ox session list](/session/list)	 - List sessions
+* [ox session redact](/session/redact)	 - Interactively redact credentials in session recordings (destructive; expensive)
 * [ox session regenerate](/session/regenerate)	 - Regenerate session artifacts or re-redact session data
 * [ox session repair-meta-summary](/session/repair-meta-summary)	 - Retro-clear validator-failure strings leaked into meta.json (ox-qqka cleanup)
 * [ox session score](/session/score)	 - Report or view SageOx contribution score for this session

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session lint"
 description: "CLI reference for ox session lint"
-sidebar_position: 67
+sidebar_position: 68
 ---
 
 ## ox session lint

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session list"
 description: "CLI reference for ox session list"
-sidebar_position: 68
+sidebar_position: 69
 ---
 
 ## ox session list

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -1,0 +1,71 @@
+---
+title: "ox session redact"
+description: "CLI reference for ox session redact"
+sidebar_position: 70
+---
+
+## ox session redact
+
+Interactively redact credentials in session recordings (destructive; expensive)
+
+### Synopsis
+
+Interactively redact each credential finding in committed-but-not-yet-pushed
+session recordings. Runs the full audit pass first, then prompts
+per-file for approval.
+
+Cost: same hydration cost as `ox session audit` (LFS Batch API fetch of
+every dehydrated session), plus a per-file rewrite + ledger snapshot +
+git amend on every approved file. Plan for minutes-not-seconds on a
+large ledger.
+
+Workflow:
+
+  1. `ox session audit` first — read-only, confirms what would change.
+  2. `ox session redact` — interactive cleanup.
+  3. After cleanup, `ox session push` (or normal session-stop flow) republishes.
+
+Safety:
+  - The entire Ledger is snapshotted to an immutable backup before any
+    modification. The snapshot path and SHA-256 are printed for chain of
+    custody.
+  - Findings in commits already pushed to origin/main are listed but NOT
+    actionable here. They require the gated history-rewrite tool. The
+    correct response is: rotate the leaked credential, mark the finding
+    as known, and follow up via the team comms process.
+  - Per-finding human approval. There is no bulk-approve flag.
+  - Each redaction pass appends a RedactionPass entry to the session's
+    meta.json (ox-8bfh) recording WHO redacted, WHEN, with WHICH catalog
+    version+hash, and WHAT was caught — never the matched bytes.
+
+```
+ox session redact [flags]
+```
+
+### Options
+
+```
+      --all                  Process every session in the ledger (slow + bulk). Mutually exclusive with --session/--since/--until.
+      --backup-dir string    Override the backup directory (defaults to ~/.local/share/sageox/backups/redact-history/)
+  -h, --help                 help for redact
+      --ledger-path string   Override the ledger path (defaults to the current project's ledger)
+      --session name         Limit to this session name (repeatable). Get names from 'ox doctor' output.
+      --since string         Limit to sessions whose name is >= this prefix (e.g. 2026-04-01). Lexicographic against ISO-prefixed session names.
+      --until string         Limit to sessions whose name is < this prefix (end-exclusive). Lexicographic against ISO-prefixed session names.
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox session](/session)	 - Manage AI coworker sessions
+

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session regenerate"
 description: "CLI reference for ox session regenerate"
-sidebar_position: 69
+sidebar_position: 71
 ---
 
 ## ox session regenerate

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session repair-meta-summary"
 description: "CLI reference for ox session repair-meta-summary"
-sidebar_position: 70
+sidebar_position: 72
 ---
 
 ## ox session repair-meta-summary

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session score"
 description: "CLI reference for ox session score"
-sidebar_position: 71
+sidebar_position: 73
 ---
 
 ## ox session score

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session status"
 description: "CLI reference for ox session status"
-sidebar_position: 72
+sidebar_position: 74
 ---
 
 ## ox session status

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session stop"
 description: "CLI reference for ox session stop"
-sidebar_position: 73
+sidebar_position: 75
 ---
 
 ## ox session stop

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session token-optimize"
 description: "CLI reference for ox session token-optimize"
-sidebar_position: 74
+sidebar_position: 76
 ---
 
 ## ox session token-optimize

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session view"
 description: "CLI reference for ox session view"
-sidebar_position: 75
+sidebar_position: 77
 ---
 
 ## ox session view

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox status"
 description: "CLI reference for ox status"
-sidebar_position: 76
+sidebar_position: 78
 ---
 
 ## ox status

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox sync"
 description: "CLI reference for ox sync"
-sidebar_position: 77
+sidebar_position: 79
 ---
 
 ## ox sync

--- a/docs/reference/teams.mdx
+++ b/docs/reference/teams.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox teams"
 description: "CLI reference for ox teams"
-sidebar_position: 78
+sidebar_position: 80
 ---
 
 ## ox teams

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox uninstall"
 description: "CLI reference for ox uninstall"
-sidebar_position: 79
+sidebar_position: 81
 ---
 
 ## ox uninstall

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox upgrade"
 description: "CLI reference for ox upgrade"
-sidebar_position: 80
+sidebar_position: 82
 ---
 
 ## ox upgrade
@@ -19,8 +19,9 @@ ox upgrade [flags]
 ### Options
 
 ```
-  -h, --help   help for upgrade
-      --json   output as JSON
+  -h, --help            help for upgrade
+      --json            output as JSON
+      --target string   pin upgrade to a specific version tag (e.g. v0.18.0); empty = latest from GitHub releases API
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Summary

`ox doctor` told users to run `ox session redact <session>` for quarantine cleanup, but no such surface existed — cobra silently dropped the positional and a full-ledger scan ran in its place. Worse: even with the right command, redact only walked `sessions/<name>/` while the pre-push gate had moved quarantined bytes OUT to `.sageox/cache/quarantine/<name>/`, so the suggested cleanup was a no-op.

This PR makes `ox session audit` / `ox session redact` require an explicit scope (`--all`, `--session` repeatable, `--since`/`--until` half-open lex window) — bare invocation now rejects with a clear error before any hydration. The doctor message emits one copy-pasteable `ox session redact --session <name>` per quarantined session, and `--session` now also walks the quarantine cache: JSONL gets redacted via the canonical chokepoint, moved back to `sessions/<name>/`, and the debt marker is removed; non-JSONL falls back to documented manual scrub.

Security hardening: every quarantine marker is now validated against path traversal (`session_name` mustn't contain `..` or `/`, marker filename must match `session_name`, `quarantine_paths` entries must be direct children of the expected per-session subtrees). Defense-in-depth `safeRelativeUnder` containment checks live at the `os.Rename` / `os.Open` boundaries so a future code path can't bypass marker validation. Threat model documented in CHANGELOG.

Regression tests that would have caught #608 at PR time: `TestDoctorRedactionDebt_EmittedCommandsParse` executes every command the doctor message emits through a fresh cobra tree and asserts `--session` reaches flag storage; `TestDoctorRedactionDebt_HelpTextNoBareSessionPlaceholder` source-scans for the `ox session redact <…>` bare-positional anti-pattern.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all `cmd/ox` tests pass (two failures pre-existing, unrelated)
- [x] `make format` clean
- [x] New tests: 9 scope tests, 6 path-traversal tests, 2 doctor-guidance regression tests
- [x] Doctor message preview validated by hand (copy-pasteable per-session commands, 5-deep truncation works)
- [x] Generated CLI reference docs synced
- [ ] Manual smoke against a ledger with real quarantined sessions

Closes #608.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session audit and redact commands now require explicit session scoping via `--session`, `--since/--until`, or `--all` flags
  * Doctor redaction-debt guidance now provides executable copy-pasteable commands for interactive cleanup
  * Session redact workflow now handles quarantined redaction findings from debt storage

* **Security**
  * Added path traversal defenses for redaction-debt marker validation and file movement operations

* **Documentation**
  * Added new command reference pages for session audit and redact
  * Updated documentation sidebar organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/610)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->