### PR TITLE
fix(daemon): preserve socket file on superseded daemon shutdown

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -70,9 +70,13 @@ jobs:
           OX_SECURITY_BIN_CACHE: ${{ runner.temp }}/security-bin
 
       - name: Run deterministic security scanners
-        run: make sec-fast
-        env:
-          PATH: ${{ github.workspace }}/bin:${{ env.PATH }}
+        # `env.PATH` is not populated by GitHub Actions, so setting
+        # `PATH: ${{ github.workspace }}/bin:${{ env.PATH }}` truncates to
+        # `${workspace}/bin:` and drops /usr/bin (where `make` lives).
+        # Extend PATH inside the shell instead.
+        run: |
+          export PATH="${GITHUB_WORKSPACE}/bin:${PATH}"
+          make sec-fast
 
       - name: Upload SARIF to GitHub Security tab
         if: always()

--- a/internal/codedb/index/worktree_test.go
+++ b/internal/codedb/index/worktree_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -38,11 +39,14 @@ func initGitRepo(t *testing.T, numCommits int) (string, string) {
 		}
 		out, err := mkCmd().CombinedOutput()
 		// ox-a9ak: under heavy preflight parallelism the system git
-		// binary occasionally crashes mid-command (SIGSEGV / SIGBUS).
-		// External-tool defect, transient under load — single retry
-		// is enough to keep the test suite from flaking. Real
-		// non-zero exits still surface immediately.
-		if err != nil && isGitSignalCrash(err) {
+		// binary occasionally crashes mid-command (SIGSEGV / SIGBUS)
+		// or emits transient object-DB errors ("bad tree object",
+		// "invalid object", "Error building trees") when packed
+		// objects haven't reached disk yet. External-tool defect,
+		// transient under load — single retry is enough to keep the
+		// test suite from flaking. Real non-zero exits surface on the
+		// retry attempt.
+		if err != nil && (isGitSignalCrash(err) || isGitTransientObjectError(out)) {
 			out, err = mkCmd().CombinedOutput()
 		}
 		require.NoError(t, err, "git %v: %s", args, out)
@@ -313,4 +317,17 @@ func isGitSignalCrash(err error) bool {
 		return true
 	}
 	return false
+}
+
+// isGitTransientObjectError reports whether git's combined output matches
+// the transient object-DB corruption pattern observed under heavy parallel
+// CI load (ox-a9ak family). Symptoms include "bad tree object HEAD",
+// "invalid object", and "Error building trees" emitted mid-loop in a long
+// sequence of `git commit` calls. These resolve on retry once pending
+// writes settle; real corruption persists across retries and surfaces then.
+func isGitTransientObjectError(out []byte) bool {
+	s := string(out)
+	return strings.Contains(s, "bad tree object") ||
+		strings.Contains(s, "invalid object") ||
+		strings.Contains(s, "Error building trees")
 }

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -1483,7 +1483,12 @@ func (s *Server) Start(ctx context.Context) error {
 	// wait for all connection handlers to finish
 	s.connWg.Wait()
 
-	cleanupSocket(socketPath)
+	// socket file removal is owned by Daemon.cleanup, which knows whether
+	// this daemon was superseded. when supersede happens, the file at the
+	// socket path now belongs to the replacement daemon — unlinking it here
+	// would leave the new daemon unreachable (kernel-side socket survives,
+	// on-disk path gone). the legitimate pre-bind unlink of stale paths
+	// still happens in listen() for the next daemon to start at this path.
 	return ctx.Err()
 }
 

--- a/internal/daemon/ipc_unix.go
+++ b/internal/daemon/ipc_unix.go
@@ -42,8 +42,21 @@ func listen(path string) (net.Listener, error) {
 	oldMask := syscall.Umask(0077)
 	listener, err := net.Listen("unix", path)
 	syscall.Umask(oldMask)
+	if err != nil {
+		return nil, err
+	}
 
-	return listener, err
+	// Go's *net.UnixListener.Close() unlinks the socket file by default.
+	// That's wrong for ox: when a daemon is superseded by a replacement that
+	// has already rebound the same path, our shutdown would delete the new
+	// daemon's socket file, leaving it running but unreachable. Socket-file
+	// lifetime is owned by Daemon.cleanup (which respects wasSuperseded);
+	// listener shutdown must not unlink.
+	if unixL, ok := listener.(*net.UnixListener); ok {
+		unixL.SetUnlinkOnClose(false)
+	}
+
+	return listener, nil
 }
 
 // dial connects to a Unix socket with a timeout.

--- a/internal/daemon/server_shutdown_test.go
+++ b/internal/daemon/server_shutdown_test.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServerStart_DoesNotRemoveSocketOnShutdown verifies that Server.Start
+// does NOT unlink the socket file when its context is canceled. Socket-file
+// lifetime is owned by Daemon.cleanup, which knows whether the daemon was
+// superseded by a replacement (in which case the file at the shared path
+// belongs to the new daemon and must be preserved).
+//
+// Failure prevented: superseded daemon shutdown destroys the replacement
+// daemon's socket file, leaving it running but unreachable from CLI
+// (manifested as "Murmur not delivered (daemon unavailable)" even though
+// the daemon process holds the socket open in the kernel).
+func TestServerStart_DoesNotRemoveSocketOnShutdown(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "ox-server-shutdown-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	server := NewServer(logger)
+	server.SetHandlers(
+		func() error { return nil },
+		func() {},
+		func() *StatusData { return &StatusData{Running: true} },
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() { done <- server.Start(ctx) }()
+
+	// wait for the socket to be bound
+	socketPath := SocketPath()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_, err = os.Stat(socketPath)
+	require.NoError(t, err, "server should have created socket file")
+
+	// shut the server down by canceling its context
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not exit after context cancel")
+	}
+
+	// invariant: Server.Start must NOT unlink the socket file. Socket
+	// removal is Daemon.cleanup's job (which respects wasSuperseded).
+	_, err = os.Stat(socketPath)
+	assert.NoError(t, err, "socket file must survive Server.Start shutdown (Daemon.cleanup owns removal)")
+}
+
+// TestDaemonCleanup_SupersededPreservesSocket verifies the original bug's
+// invariant at the Daemon layer: a superseded daemon's cleanup must NOT
+// unlink the socket file, because the file at that path belongs to the
+// successor daemon.
+//
+// Failure prevented: regression of the cleanup branch that decides whether
+// to remove the socket based on wasSuperseded.
+func TestDaemonCleanup_SupersededPreservesSocket(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	d := New(nil, nil)
+	d.wasSuperseded = true
+
+	require.NoError(t, d.writePidFile())
+
+	socketPath := SocketPath()
+	f, err := os.Create(socketPath)
+	require.NoError(t, err)
+	f.Close()
+
+	d.cleanup()
+
+	_, err = os.Stat(socketPath)
+	assert.NoError(t, err, "superseded daemon must NOT unlink the socket file — it now belongs to the successor")
+	_, err = os.Stat(PidPath())
+	assert.True(t, os.IsNotExist(err) || err == nil, "PID file removal in superseded case is also skipped")
+}


### PR DESCRIPTION
## Summary

When two ox daemons for the same repo overlap (common with conductor workspaces), the predecessor's `listener.Close()` was unlinking the socket file that now belongs to its replacement. The new daemon kept running in the kernel but was unreachable from CLI — every `ox murmur` reported `Murmur not delivered (daemon unavailable)` even though `lsof` showed the daemon holding its socket open. Once `ListRunningDaemons()` pruned the registry entry, the daemon was effectively invisible to the CLI for the rest of its lifetime.

## Root cause

Two layers, both needed for the fix:

1. `Server.Start` called `cleanupSocket(socketPath)` unconditionally on ctx cancel.
2. The deeper culprit: Go's `*net.UnixListener.Close()` auto-unlinks the bound socket file by default.

```mermaid
sequenceDiagram
    participant New as new daemon (PID 472)
    participant Old as old daemon (PID 17214)
    participant FS as socket file
    participant CLI as ox murmur
    New->>FS: listen() — os.Remove + bind fresh socket
    Old->>Old: socket self-check sees new PID in registry
    Old->>FS: shutdown → listener.Close() unlinks path (bug)
    CLI->>FS: resolveSocketPath() → no file → daemon unavailable
```

## Fix

- `SetUnlinkOnClose(false)` on the listener so teardown never unlinks.
- Remove the redundant `cleanupSocket` from `Server.Start`.
- Socket-file lifetime is now solely owned by `Daemon.cleanup`, which already respects `wasSuperseded`. The pre-bind `os.Remove(path)` in `listen()` stays — that one is correct.
- Regression tests pin both invariants (listener-close path and Daemon.cleanup branch).

## Test plan

- [x] `go test ./internal/daemon/ -run 'TestServer|TestIPC|TestClient|TestPing|TestMurmur|TestCheckout|TestSocket|TestSupersed|TestEviction|TestFallback'` — all pass
- [x] `make lint` — 0 issues
- [x] New `TestServerStart_DoesNotRemoveSocketOnShutdown` fails without `SetUnlinkOnClose(false)` and passes with it
- [ ] End-to-end: kill all daemons, start two daemons for the same repo from different workspaces, confirm `ox murmur --topic=wip "..."` succeeds and the socket file remains on disk after supersede

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon reliability during shutdown and replacement scenarios—socket files are now properly preserved.
  * Enhanced resilience to transient data repository errors with automatic retry logic.

* **Chores**
  * Updated CI security scanning workflow to ensure tools remain accessible during execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->