### PR TITLE
feat(kb): ADR-017 KB-as-workspace primitive — resolver, config, flocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ TEST_GIT_ISOLATION := \
 	GIT_CONFIG_NOSYSTEM=1 \
 	GIT_TERMINAL_PROMPT=0 \
 	GIT_AUTHOR_NAME=ox-test \
-	GIT_AUTHOR_EMAIL=test@sageox.ai \
+	GIT_AUTHOR_EMAIL=test@test.sageox.ai \
 	GIT_COMMITTER_NAME=ox-test \
-	GIT_COMMITTER_EMAIL=test@sageox.ai
+	GIT_COMMITTER_EMAIL=test@test.sageox.ai
 
 # Targets below are agent-friendly by default (quiet). V=1 for verbose.
 test: ## Run fast tests — unit tests <500ms, race detection, no coverage (every commit)

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,23 @@ GOTESTSUM := $(shell which gotestsum 2>/dev/null || echo "go run gotest.tools/go
 # in internal/codedb/index, internal/doctor, internal/repotools,
 # internal/secrets, etc.
 #
+# Disabling global config also wipes the runner's `user.name`/`user.email`,
+# so we supply identity via the GIT_{AUTHOR,COMMITTER}_{NAME,EMAIL} env
+# vars — git respects these in lieu of config and they cannot be hijacked
+# by signing/passphrase machinery.
+#
 # GIT_CONFIG_GLOBAL=/dev/null  → ignore $HOME/.gitconfig
 # GIT_CONFIG_NOSYSTEM=1        → ignore /etc/gitconfig
 # GIT_TERMINAL_PROMPT=0        → never prompt; fail fast on missing creds
-TEST_GIT_ISOLATION := GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0
+# GIT_AUTHOR_*  / GIT_COMMITTER_*  → identity without needing config
+TEST_GIT_ISOLATION := \
+	GIT_CONFIG_GLOBAL=/dev/null \
+	GIT_CONFIG_NOSYSTEM=1 \
+	GIT_TERMINAL_PROMPT=0 \
+	GIT_AUTHOR_NAME=ox-test \
+	GIT_AUTHOR_EMAIL=test@sageox.ai \
+	GIT_COMMITTER_NAME=ox-test \
+	GIT_COMMITTER_EMAIL=test@sageox.ai
 
 # Targets below are agent-friendly by default (quiet). V=1 for verbose.
 test: ## Run fast tests — unit tests <500ms, race detection, no coverage (every commit)

--- a/Makefile
+++ b/Makefile
@@ -109,22 +109,36 @@ run: build ## Build and run ox
 #
 GOTESTSUM := $(shell which gotestsum 2>/dev/null || echo "go run gotest.tools/gotestsum@latest")
 
+# Isolate test `git` invocations from the developer's global config.
+# Many tests build scratch repos in t.TempDir() and run `git init` +
+# `git commit`. Without isolation, git inherits the user's `~/.gitconfig`
+# — including `commit.gpgsign=true` and `user.signingkey` pointing at an
+# encrypted SSH key — and `git commit` blocks on a passphrase prompt
+# that the test runner can't satisfy. This manifests as cascade failures
+# in internal/codedb/index, internal/doctor, internal/repotools,
+# internal/secrets, etc.
+#
+# GIT_CONFIG_GLOBAL=/dev/null  → ignore $HOME/.gitconfig
+# GIT_CONFIG_NOSYSTEM=1        → ignore /etc/gitconfig
+# GIT_TERMINAL_PROMPT=0        → never prompt; fail fast on missing creds
+TEST_GIT_ISOLATION := GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0
+
 # Targets below are agent-friendly by default (quiet). V=1 for verbose.
 test: ## Run fast tests — unit tests <500ms, race detection, no coverage (every commit)
 	$(call say,"Running fast tests (skipping >500ms, no coverage)...")
-	@$(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -short -race -p 8 -parallel 32 ./...
+	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -short -race -p 8 -parallel 32 ./...
 
 test-cover: ## Run fast tests with coverage collection (~15-20% slower than `make test`)
 	$(call say,"Running fast tests with coverage...")
-	@$(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -short -race -p 8 -parallel 32 -coverprofile=coverage.out -covermode=atomic ./...
+	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -short -race -p 8 -parallel 32 -coverprofile=coverage.out -covermode=atomic ./...
 
 test-all: ## Run all unit tests including expensive ones (git clone, SQLite, LFS) with coverage
 	$(call say,"Running all tests including expensive tests...")
-	@$(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -race -p 8 -parallel 32 -coverprofile=coverage.out -covermode=atomic ./...
+	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -race -p 8 -parallel 32 -coverprofile=coverage.out -covermode=atomic ./...
 
 test-slow: ## Run slow tests (build tag: slow) — requires real ox binary, no Claude needed
 	$(call say,"Running slow tests (requires built ox binary)...")
-	@$(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -tags=slow -race -timeout=10m ./...
+	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -tags=slow -race -timeout=10m ./...
 
 test-integration: ## Integration tests live in sageox/ox-test-harness
 	@echo "Coding agent integration tests are in sageox/ox-test-harness."

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sageox/agentx"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/proc"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
@@ -218,7 +219,8 @@ func emitStartupBanner(w io.Writer, ctx *HookContext) {
 	default:
 		return
 	}
-	recording := config.ResolveSessionRecording(ctx.ProjectRoot)
+	kbID, kbType := kb.ResolveCurrentKBIDAndType(ctx.ProjectRoot)
+	recording := config.ResolveSessionRecording(ctx.ProjectRoot, kbID, kbType)
 	canonicalType := agentx.ResolveAgentENV(ctx.AgentType)
 	if canonicalType == agentx.AgentTypeUnknown {
 		canonicalType = agentx.AgentType(ctx.AgentType)
@@ -755,7 +757,8 @@ func buildPrimeEnv(agentID string) []string {
 // startSessionRecordingIfConfigured attempts to start session recording
 // if the configuration enables auto-recording.
 func startSessionRecordingIfConfigured(ctx *HookContext) {
-	resolved := config.ResolveSessionRecording(ctx.ProjectRoot)
+	kbID, kbType := kb.ResolveCurrentKBIDAndType(ctx.ProjectRoot)
+	resolved := config.ResolveSessionRecording(ctx.ProjectRoot, kbID, kbType)
 	if !resolved.IsAuto() {
 		return
 	}

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -219,7 +219,14 @@ func emitStartupBanner(w io.Writer, ctx *HookContext) {
 	default:
 		return
 	}
-	kbID, kbType := kb.ResolveCurrentKBIDAndType(ctx.ProjectRoot)
+	// resolve KB binding from the hook's actual working directory so nested
+	// KB bindings in subdirectories are honored. Fall back to project root
+	// if Getwd fails (e.g., directory deleted out from under the process).
+	resolveFrom := ctx.ProjectRoot
+	if wd, wdErr := os.Getwd(); wdErr == nil && wd != "" {
+		resolveFrom = wd
+	}
+	kbID, kbType := kb.ResolveCurrentKBIDAndType(resolveFrom)
 	recording := config.ResolveSessionRecording(ctx.ProjectRoot, kbID, kbType)
 	canonicalType := agentx.ResolveAgentENV(ctx.AgentType)
 	if canonicalType == agentx.AgentTypeUnknown {
@@ -757,7 +764,13 @@ func buildPrimeEnv(agentID string) []string {
 // startSessionRecordingIfConfigured attempts to start session recording
 // if the configuration enables auto-recording.
 func startSessionRecordingIfConfigured(ctx *HookContext) {
-	kbID, kbType := kb.ResolveCurrentKBIDAndType(ctx.ProjectRoot)
+	// resolve KB binding from the hook's actual working directory so nested
+	// KB bindings are honored. Falls back to project root if Getwd fails.
+	resolveFrom := ctx.ProjectRoot
+	if wd, wdErr := os.Getwd(); wdErr == nil && wd != "" {
+		resolveFrom = wd
+	}
+	kbID, kbType := kb.ResolveCurrentKBIDAndType(resolveFrom)
 	resolved := config.ResolveSessionRecording(ctx.ProjectRoot, kbID, kbType)
 	if !resolved.IsAuto() {
 		return

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -572,8 +572,14 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 
 	// ADR-017: surface the binding the agent's CWD currently resolves to.
 	// Look it up in the KB list so the emitted entry carries the same
-	// type/slug/path enrichment as the matching row.
-	output.CurrentKB = resolveCurrentKBEntry(projectRoot, output.KB)
+	// type/slug/path enrichment as the matching row. Resolve from the
+	// actual working directory so nested/subtree KB bindings win over the
+	// repo root binding when applicable.
+	kbResolveFrom := projectRoot
+	if wd, wdErr := os.Getwd(); wdErr == nil && wd != "" {
+		kbResolveFrom = wd
+	}
+	output.CurrentKB = resolveCurrentKBEntry(kbResolveFrom, output.KB)
 
 	// populate cumulative context stats from daemon (best-effort).
 	// read BEFORE sending this command's heartbeat — intentional: these report
@@ -1004,7 +1010,13 @@ func repoSlugFromRemoteOrDir(projectRoot string) string {
 func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string) *sessionStatus {
 	// resolve session mode from config hierarchy; KB binding (when present)
 	// participates in precedence + safety-inversion via ResolveSessionRecording.
-	kbID, kbType := kb.ResolveCurrentKBIDAndType(projectRoot)
+	// Resolve the KB binding from the agent's actual working directory so
+	// nested/subtree bindings win over the repo root binding.
+	kbResolveFrom := projectRoot
+	if wd, wdErr := os.Getwd(); wdErr == nil && wd != "" {
+		kbResolveFrom = wd
+	}
+	kbID, kbType := kb.ResolveCurrentKBIDAndType(kbResolveFrom)
 	resolved := config.ResolveSessionRecording(projectRoot, kbID, kbType)
 
 	// only auto-start recording when config is explicitly set to "auto"

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sageox/ox/internal/doctor"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/identity"
+	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/prime"
@@ -569,6 +570,11 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		CurrentUserAliases: currentUserAliases,
 	}
 
+	// ADR-017: surface the binding the agent's CWD currently resolves to.
+	// Look it up in the KB list so the emitted entry carries the same
+	// type/slug/path enrichment as the matching row.
+	output.CurrentKB = resolveCurrentKBEntry(projectRoot, output.KB)
+
 	// populate cumulative context stats from daemon (best-effort).
 	// read BEFORE sending this command's heartbeat — intentional: these report
 	// "consumed so far", not including the prime output about to be emitted.
@@ -996,8 +1002,10 @@ func repoSlugFromRemoteOrDir(projectRoot string) string {
 // Returns the session status for inclusion in prime output.
 // Errors are logged but not fatal - session recording is optional.
 func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string) *sessionStatus {
-	// resolve session mode from config hierarchy
-	resolved := config.ResolveSessionRecording(projectRoot)
+	// resolve session mode from config hierarchy; KB binding (when present)
+	// participates in precedence + safety-inversion via ResolveSessionRecording.
+	kbID, kbType := kb.ResolveCurrentKBIDAndType(projectRoot)
+	resolved := config.ResolveSessionRecording(projectRoot, kbID, kbType)
 
 	// only auto-start recording when config is explicitly set to "auto"
 	// "manual" mode requires the user to run `ox session start` themselves
@@ -2141,4 +2149,30 @@ func ensureClaudeHooks(projectRoot string) bool {
 		return false
 	}
 	return true
+}
+
+// resolveCurrentKBEntry returns the KB row matching the binding resolved from
+// cwd, or nil when:
+//   - cwd is empty,
+//   - ResolveCurrentKB returns (nil, nil) — outside any KB-bound tree,
+//   - ResolveCurrentKB returns an error — malformed marker, etc.,
+//   - the binding's kb_id is not present in kbList (revoked or unsynced).
+//
+// Extracted from runAgentPrime so the current_kb envelope field can be
+// unit-tested without standing up the full prime pipeline. Pure function:
+// no I/O beyond the resolver's filesystem walk.
+func resolveCurrentKBEntry(cwd string, kbList []prime.KBInfo) *prime.KBInfo {
+	binding, err := kb.ResolveCurrentKB(cwd)
+	if err != nil || binding == nil {
+		return nil
+	}
+	for i := range kbList {
+		if kbList[i].KBID == binding.KBID {
+			cur := kbList[i]
+			return &cur
+		}
+	}
+	// binding's kb_id doesn't match any row — kb was revoked or hasn't synced.
+	slog.Warn("current_kb_not_in_list", "kb_id", binding.KBID)
+	return nil
 }

--- a/cmd/ox/agent_prime_current_kb_test.go
+++ b/cmd/ox/agent_prime_current_kb_test.go
@@ -1,0 +1,109 @@
+package main
+
+// agent_prime_current_kb_test.go — tests for the resolveCurrentKBEntry
+// helper extracted from runAgentPrime. The helper is the unit boundary that
+// runAgentPrime calls to populate output.CurrentKB — testing it directly
+// avoids spinning up the full prime pipeline (auth, daemon, instance store)
+// just to assert one field is populated.
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/prime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeKBBindingYAML writes a minimal .sageox/config.yaml carrying the given
+// kb_id. Returns the project root so the caller can pass it as cwd.
+func writeKBBindingYAML(t *testing.T, kbID string) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".sageox"), 0o755))
+	body := "kb_id: " + kbID + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".sageox", "config.yaml"), []byte(body), 0o644))
+	return root
+}
+
+// TestResolveCurrentKBEntry_CurrentKBPresent verifies the happy path: a
+// project with a binding kb_id that matches a row in the KB list returns the
+// matched row.
+//
+// Failure prevented: a regression in the resolver wiring — or in the lookup
+// loop's KBID equality check — would silently leave output.CurrentKB nil,
+// stranding agents in a no-current-KB state even when the binding is valid.
+func TestResolveCurrentKBEntry_CurrentKBPresent(t *testing.T) {
+	root := writeKBBindingYAML(t, "kb_test123")
+
+	kbList := []prime.KBInfo{
+		{KBID: "kb_other", Type: "team", Slug: "platform"},
+		{KBID: "kb_test123", Type: "personal", Slug: "personal-abc", Name: "Ryan's Personal"},
+	}
+
+	got := resolveCurrentKBEntry(root, kbList)
+	require.NotNil(t, got, "binding kb_id present in list must produce a CurrentKB")
+	assert.Equal(t, "kb_test123", got.KBID)
+	assert.Equal(t, "personal-abc", got.Slug)
+	assert.Equal(t, "personal", got.Type)
+}
+
+// TestResolveCurrentKBEntry_CurrentKBNil_OutsideTree verifies that a cwd
+// with no .sageox/ marker on the upward walk returns nil — the documented
+// "outside any KB-bound tree" case from ADR-017.
+//
+// Failure prevented: a resolver bug that fabricated a binding for an
+// uninitialized directory would attach the wrong KB to a prime session,
+// causing recording to land in the wrong bubble.
+func TestResolveCurrentKBEntry_CurrentKBNil_OutsideTree(t *testing.T) {
+	// fresh tempdir with no .sageox/ anywhere on the path.
+	bare := t.TempDir()
+
+	kbList := []prime.KBInfo{
+		{KBID: "kb_anything", Type: "team", Slug: "platform"},
+	}
+
+	got := resolveCurrentKBEntry(bare, kbList)
+	assert.Nil(t, got, "cwd outside any KB-bound tree must yield nil CurrentKB")
+}
+
+// TestResolveCurrentKBEntry_BindingNotInList_WarnsAndReturnsNil verifies the
+// revoked / unsynced case: a binding kb_id that isn't present in the KB list
+// logs a warn and returns nil so the agent doesn't reference a vanished row.
+//
+// Failure prevented: a silent regression here would either crash on nil
+// access downstream or, worse, attribute work to a kb_id the agent can't
+// actually read — exactly the post-revocation footgun ADR-017 §7 calls out.
+func TestResolveCurrentKBEntry_BindingNotInList_WarnsAndReturnsNil(t *testing.T) {
+	root := writeKBBindingYAML(t, "kb_revoked")
+
+	// capture slog so we can assert the warn path fires.
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	buf := &bytes.Buffer{}
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	kbList := []prime.KBInfo{
+		{KBID: "kb_other", Type: "team", Slug: "platform"},
+	}
+
+	got := resolveCurrentKBEntry(root, kbList)
+	assert.Nil(t, got, "binding not in list must return nil")
+	assert.Contains(t, buf.String(), "current_kb_not_in_list", "warn must fire so operators see the mismatch")
+	assert.Contains(t, buf.String(), "kb_revoked", "warn must carry the missing kb_id for diagnosis")
+}
+
+// TestResolveCurrentKBEntry_EmptyCwd verifies a defensive guard: an empty
+// cwd (caller passed "") returns nil rather than treating the filesystem
+// root as a binding anchor.
+//
+// Failure prevented: a code path that forgot to populate projectRoot would
+// otherwise walk from "" — which ResolveCurrentKB normalizes — but the
+// helper's contract is "no binding, no result" for the empty input.
+func TestResolveCurrentKBEntry_EmptyCwd(t *testing.T) {
+	got := resolveCurrentKBEntry("", []prime.KBInfo{{KBID: "kb_x"}})
+	assert.Nil(t, got)
+}

--- a/cmd/ox/agent_prime_current_kb_test.go
+++ b/cmd/ox/agent_prime_current_kb_test.go
@@ -29,81 +29,77 @@ func writeKBBindingYAML(t *testing.T, kbID string) string {
 	return root
 }
 
-// TestResolveCurrentKBEntry_CurrentKBPresent verifies the happy path: a
-// project with a binding kb_id that matches a row in the KB list returns the
-// matched row.
-//
-// Failure prevented: a regression in the resolver wiring — or in the lookup
-// loop's KBID equality check — would silently leave output.CurrentKB nil,
-// stranding agents in a no-current-KB state even when the binding is valid.
-func TestResolveCurrentKBEntry_CurrentKBPresent(t *testing.T) {
-	root := writeKBBindingYAML(t, "kb_test123")
-
-	kbList := []prime.KBInfo{
-		{KBID: "kb_other", Type: "team", Slug: "platform"},
-		{KBID: "kb_test123", Type: "personal", Slug: "personal-abc", Name: "Ryan's Personal"},
+func TestResolveCurrentKBEntry_Table(t *testing.T) {
+	tests := []struct {
+		name         string
+		cwd          func(t *testing.T) string
+		kbList       []prime.KBInfo
+		wantNil      bool
+		wantKBID     string
+		wantSlug     string
+		wantType     string
+		wantLogParts []string
+	}{
+		{
+			name: "current kb present",
+			cwd: func(t *testing.T) string {
+				return writeKBBindingYAML(t, "kb_test123")
+			},
+			kbList: []prime.KBInfo{
+				{KBID: "kb_other", Type: "team", Slug: "platform"},
+				{KBID: "kb_test123", Type: "personal", Slug: "personal-abc", Name: "Ryan's Personal"},
+			},
+			wantKBID: "kb_test123",
+			wantSlug: "personal-abc",
+			wantType: "personal",
+		},
+		{
+			name: "outside tree",
+			cwd: func(t *testing.T) string {
+				return t.TempDir()
+			},
+			kbList:  []prime.KBInfo{{KBID: "kb_anything", Type: "team", Slug: "platform"}},
+			wantNil: true,
+		},
+		{
+			name: "binding not in list warns",
+			cwd: func(t *testing.T) string {
+				return writeKBBindingYAML(t, "kb_revoked")
+			},
+			kbList:       []prime.KBInfo{{KBID: "kb_other", Type: "team", Slug: "platform"}},
+			wantNil:      true,
+			wantLogParts: []string{"current_kb_not_in_list", "kb_revoked"},
+		},
+		{
+			name:    "empty cwd",
+			cwd:     func(t *testing.T) string { return "" },
+			kbList:  []prime.KBInfo{{KBID: "kb_x"}},
+			wantNil: true,
+		},
 	}
 
-	got := resolveCurrentKBEntry(root, kbList)
-	require.NotNil(t, got, "binding kb_id present in list must produce a CurrentKB")
-	assert.Equal(t, "kb_test123", got.KBID)
-	assert.Equal(t, "personal-abc", got.Slug)
-	assert.Equal(t, "personal", got.Type)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prev := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(prev) })
 
-// TestResolveCurrentKBEntry_CurrentKBNil_OutsideTree verifies that a cwd
-// with no .sageox/ marker on the upward walk returns nil — the documented
-// "outside any KB-bound tree" case from ADR-017.
-//
-// Failure prevented: a resolver bug that fabricated a binding for an
-// uninitialized directory would attach the wrong KB to a prime session,
-// causing recording to land in the wrong bubble.
-func TestResolveCurrentKBEntry_CurrentKBNil_OutsideTree(t *testing.T) {
-	// fresh tempdir with no .sageox/ anywhere on the path.
-	bare := t.TempDir()
+			buf := &bytes.Buffer{}
+			if len(tt.wantLogParts) > 0 {
+				slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			}
 
-	kbList := []prime.KBInfo{
-		{KBID: "kb_anything", Type: "team", Slug: "platform"},
+			got := resolveCurrentKBEntry(tt.cwd(t), tt.kbList)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, tt.wantKBID, got.KBID)
+				assert.Equal(t, tt.wantSlug, got.Slug)
+				assert.Equal(t, tt.wantType, got.Type)
+			}
+			for _, want := range tt.wantLogParts {
+				assert.Contains(t, buf.String(), want)
+			}
+		})
 	}
-
-	got := resolveCurrentKBEntry(bare, kbList)
-	assert.Nil(t, got, "cwd outside any KB-bound tree must yield nil CurrentKB")
-}
-
-// TestResolveCurrentKBEntry_BindingNotInList_WarnsAndReturnsNil verifies the
-// revoked / unsynced case: a binding kb_id that isn't present in the KB list
-// logs a warn and returns nil so the agent doesn't reference a vanished row.
-//
-// Failure prevented: a silent regression here would either crash on nil
-// access downstream or, worse, attribute work to a kb_id the agent can't
-// actually read — exactly the post-revocation footgun ADR-017 §7 calls out.
-func TestResolveCurrentKBEntry_BindingNotInList_WarnsAndReturnsNil(t *testing.T) {
-	root := writeKBBindingYAML(t, "kb_revoked")
-
-	// capture slog so we can assert the warn path fires.
-	prev := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(prev) })
-	buf := &bytes.Buffer{}
-	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-
-	kbList := []prime.KBInfo{
-		{KBID: "kb_other", Type: "team", Slug: "platform"},
-	}
-
-	got := resolveCurrentKBEntry(root, kbList)
-	assert.Nil(t, got, "binding not in list must return nil")
-	assert.Contains(t, buf.String(), "current_kb_not_in_list", "warn must fire so operators see the mismatch")
-	assert.Contains(t, buf.String(), "kb_revoked", "warn must carry the missing kb_id for diagnosis")
-}
-
-// TestResolveCurrentKBEntry_EmptyCwd verifies a defensive guard: an empty
-// cwd (caller passed "") returns nil rather than treating the filesystem
-// root as a binding anchor.
-//
-// Failure prevented: a code path that forgot to populate projectRoot would
-// otherwise walk from "" — which ResolveCurrentKB normalizes — but the
-// helper's contract is "no binding, no result" for the empty input.
-func TestResolveCurrentKBEntry_EmptyCwd(t *testing.T) {
-	got := resolveCurrentKBEntry("", []prime.KBInfo{{KBID: "kb_x"}})
-	assert.Nil(t, got)
 }

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -662,4 +662,13 @@ func init() {
 		Description: "Flags subscribed bubbles whose meta.json last_sync is older than 1h; auto-fix kicks an immediate daemon sync",
 		Run:         checkKBStaleSync,
 	})
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugKBProjectConfigMigrate,
+		Name:        "kb project config migrate",
+		Category:    "Knowledge Bubbles",
+		FixLevel:    FixLevelAuto,
+		Description: "Migrates legacy .sageox/config.json projects to the new config.yaml binding format (ADR-017)",
+		Run:         checkKBProjectConfigMigrate,
+	})
 }

--- a/cmd/ox/doctor_kb.go
+++ b/cmd/ox/doctor_kb.go
@@ -526,7 +526,7 @@ func runKBChecks(opts doctorOptions) []checkResult {
 		return nil
 	}
 
-	results := make([]checkResult, 0, 3)
+	results := make([]checkResult, 0, 4)
 	for _, fn := range []struct {
 		name string
 		run  func() checkResult
@@ -534,6 +534,9 @@ func runKBChecks(opts doctorOptions) []checkResult {
 		{"orphans", func() checkResult { return checkKBOrphans(opts.shouldFix(CheckSlugKBOrphans)) }},
 		{"provisioning", func() checkResult { return checkKBFailedProvision(false) }},
 		{"stale-sync", func() checkResult { return checkKBStaleSync(opts.shouldFix(CheckSlugKBStaleSync)) }},
+		{"global-sync-owner", func() checkResult {
+			return checkKBGlobalSyncNoOwner(opts.shouldFix(CheckSlugKBGlobalSyncNoOwner))
+		}},
 	} {
 		// per-check recover so a panic in one doesn't silence the others.
 		func(name string, run func() checkResult) {

--- a/cmd/ox/doctor_kb_global_sync.go
+++ b/cmd/ox/doctor_kb_global_sync.go
@@ -1,0 +1,121 @@
+package main
+
+// Doctor check for per-(user, endpoint) global-sync leader election
+// (ox-6zme). Exactly one running daemon per endpoint should hold the
+// global-sync flock lease — that daemon is the one running
+// team-context pulls and KB ListBubbles. 0 owners (no daemon claimed
+// the lease) or >1 owners (lease accounting drifted, only possible if
+// flock semantics broke or the registry was hand-edited) are both
+// anomalies.
+//
+// Detection reads internal/daemon's on-disk registry. The
+// GlobalSyncOwner flag is set on each daemon entry during
+// initComponents (see daemon.go::acquireGlobalSyncLease). The check
+// groups daemons by normalized endpoint and validates each group.
+//
+// AutoFix posture: the 0-owner case self-heals on the next daemon
+// startup attempting acquisition, so we don't take destructive action
+// here. We log loud (warning) and let the operator decide whether to
+// restart a daemon. The >1-owner case is impossible if flock works
+// correctly; we still surface it as a warning rather than a panic.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/endpoint"
+)
+
+// daemonRegistryReader is the seam tests use to substitute a fake
+// registry. Production wires it to daemon.ListRunningDaemons. Returning
+// (nil, err) skips the check rather than failing it: a missing
+// registry on a fresh install is not a doctor warning.
+type daemonRegistryReader func() ([]daemon.DaemonInfo, error)
+
+// kbGlobalSyncReader is the active hook; tests override via
+// SetKBGlobalSyncReader. nil means "use production wiring."
+var kbGlobalSyncReader daemonRegistryReader
+
+// SetKBGlobalSyncReader installs a registry reader hook. Pass nil to
+// reset to production behavior. Intended for tests only.
+func SetKBGlobalSyncReader(r daemonRegistryReader) {
+	kbGlobalSyncReader = r
+}
+
+// checkKBGlobalSyncNoOwner verifies that for every endpoint with a
+// running daemon, exactly one daemon holds the global-sync lease.
+//
+// Skips silently when:
+//   - the registry can't be read (fresh install, no daemon ever started)
+//   - no daemons are running
+//   - every running daemon has Endpoint="" (older daemon versions that
+//     don't populate Endpoint in DaemonInfo)
+//
+// Returns a Warning when any endpoint group has 0 or >1 owners.
+// AutoFix is intentionally a no-op: the next daemon's startup attempt
+// will pick up the lease if it's free, and we don't want doctor to
+// kill or restart daemons under the user's feet.
+func checkKBGlobalSyncNoOwner(_ bool) checkResult {
+	const name = "kb global-sync owner"
+
+	reader := kbGlobalSyncReader
+	if reader == nil {
+		reader = daemon.ListRunningDaemons
+	}
+
+	daemons, err := reader()
+	if err != nil {
+		return SkippedCheck(name, "registry unreadable", err.Error())
+	}
+	if len(daemons) == 0 {
+		return SkippedCheck(name, "no running daemons", "")
+	}
+
+	// Group daemons by normalized endpoint. Daemons with empty endpoint
+	// are skipped — older daemon versions didn't populate the field,
+	// and we'd rather have a quiet skip than a false-positive warning
+	// during the rollout window.
+	groups := make(map[string][]daemon.DaemonInfo)
+	skipped := 0
+	for _, d := range daemons {
+		if d.Endpoint == "" {
+			skipped++
+			continue
+		}
+		ep := endpoint.NormalizeEndpoint(d.Endpoint)
+		groups[ep] = append(groups[ep], d)
+	}
+	if len(groups) == 0 {
+		// All daemons predate the endpoint field. Not an error.
+		return SkippedCheck(name, "no daemons report endpoint",
+			fmt.Sprintf("%d daemon(s) on older version; restart to populate", skipped))
+	}
+
+	var anomalies []string
+	for ep, group := range groups {
+		owners := 0
+		for _, d := range group {
+			if d.GlobalSyncOwner {
+				owners++
+			}
+		}
+		switch {
+		case owners == 0:
+			anomalies = append(anomalies, fmt.Sprintf("%s: 0 owners across %d daemon(s)", ep, len(group)))
+		case owners > 1:
+			anomalies = append(anomalies, fmt.Sprintf("%s: %d owners across %d daemon(s)", ep, owners, len(group)))
+		}
+	}
+
+	if len(anomalies) == 0 {
+		return PassedCheck(name, fmt.Sprintf("%d endpoint(s) with single owner", len(groups)))
+	}
+
+	sort.Strings(anomalies)
+	msg := fmt.Sprintf("%d endpoint(s) with global-sync ownership anomaly", len(anomalies))
+	detail := strings.Join(anomalies, "; ") +
+		". Restart one daemon to retry lease acquisition; flock auto-releases on process death."
+	return WarningCheck(name, msg, detail)
+}

--- a/cmd/ox/doctor_kb_global_sync_test.go
+++ b/cmd/ox/doctor_kb_global_sync_test.go
@@ -1,0 +1,161 @@
+package main
+
+// Tests for cmd/ox/doctor_kb_global_sync.go. Each test installs a fake
+// daemon-registry reader via SetKBGlobalSyncReader so no real daemon is
+// required. Failure modes covered: 0 owners (all daemons followers),
+// >1 owners (flock semantics broken or registry hand-edited), the
+// healthy single-owner case, and graceful skip when daemons predate
+// the Endpoint field.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/daemon"
+)
+
+// kbGlobalSyncSetup installs a fake registry reader and resets at
+// teardown so the next test starts clean.
+func kbGlobalSyncSetup(t *testing.T, daemons []daemon.DaemonInfo, err error) {
+	t.Helper()
+	SetKBGlobalSyncReader(func() ([]daemon.DaemonInfo, error) {
+		return daemons, err
+	})
+	t.Cleanup(func() { SetKBGlobalSyncReader(nil) })
+}
+
+// TestCheckKBGlobalSyncNoOwner_SingleOwnerPasses verifies the healthy
+// steady state: one daemon per endpoint, that daemon owns the lease.
+// Failure prevented: doctor spuriously warns when everything is fine.
+func TestCheckKBGlobalSyncNoOwner_SingleOwnerPasses(t *testing.T) {
+	kbGlobalSyncSetup(t, []daemon.DaemonInfo{
+		{WorkspaceID: "ws1", Endpoint: "sageox.ai", GlobalSyncOwner: true},
+		{WorkspaceID: "ws2", Endpoint: "sageox.ai", GlobalSyncOwner: false},
+	}, nil)
+	res := checkKBGlobalSyncNoOwner(false)
+	if !res.passed || res.warning {
+		t.Errorf("want passed=true warning=false; got passed=%v warning=%v msg=%q",
+			res.passed, res.warning, res.message)
+	}
+}
+
+// TestCheckKBGlobalSyncNoOwner_ZeroOwnersWarns verifies the 0-owner
+// anomaly: daemons exist for an endpoint but none claims the lease.
+// Failure prevented: team-context tickers silently stop running when
+// the lease is unowned and nothing surfaces the gap to the user.
+func TestCheckKBGlobalSyncNoOwner_ZeroOwnersWarns(t *testing.T) {
+	kbGlobalSyncSetup(t, []daemon.DaemonInfo{
+		{WorkspaceID: "ws1", Endpoint: "sageox.ai", GlobalSyncOwner: false},
+		{WorkspaceID: "ws2", Endpoint: "sageox.ai", GlobalSyncOwner: false},
+	}, nil)
+	res := checkKBGlobalSyncNoOwner(false)
+	if !res.warning || res.skipped {
+		t.Errorf("want warning=true skipped=false; got warning=%v skipped=%v msg=%q",
+			res.warning, res.skipped, res.message)
+	}
+	if res.detail == "" {
+		t.Error("detail should describe the affected endpoint(s)")
+	}
+}
+
+// TestCheckKBGlobalSyncNoOwner_MultipleOwnersWarns verifies the >1
+// owner anomaly. This should be impossible if flock works correctly;
+// the check still surfaces it as a warning rather than asserting.
+// Failure prevented: a registry hand-edit or a flock semantics
+// regression goes unnoticed because no check ever asserted invariance.
+func TestCheckKBGlobalSyncNoOwner_MultipleOwnersWarns(t *testing.T) {
+	kbGlobalSyncSetup(t, []daemon.DaemonInfo{
+		{WorkspaceID: "ws1", Endpoint: "sageox.ai", GlobalSyncOwner: true},
+		{WorkspaceID: "ws2", Endpoint: "sageox.ai", GlobalSyncOwner: true},
+	}, nil)
+	res := checkKBGlobalSyncNoOwner(false)
+	if !res.warning || res.skipped {
+		t.Errorf("want warning=true skipped=false; got warning=%v skipped=%v msg=%q",
+			res.warning, res.skipped, res.message)
+	}
+}
+
+// TestCheckKBGlobalSyncNoOwner_PerEndpointGrouping verifies that two
+// endpoints are checked independently — a healthy sageox.ai owner and
+// a broken localhost:8080 0-owner case both surface.
+// Failure prevented: a fix at one endpoint masks a problem at another.
+func TestCheckKBGlobalSyncNoOwner_PerEndpointGrouping(t *testing.T) {
+	kbGlobalSyncSetup(t, []daemon.DaemonInfo{
+		{WorkspaceID: "prod1", Endpoint: "sageox.ai", GlobalSyncOwner: true},
+		{WorkspaceID: "prod2", Endpoint: "sageox.ai", GlobalSyncOwner: false},
+		{WorkspaceID: "local1", Endpoint: "localhost:8080", GlobalSyncOwner: false},
+		{WorkspaceID: "local2", Endpoint: "localhost:8080", GlobalSyncOwner: false},
+	}, nil)
+	res := checkKBGlobalSyncNoOwner(false)
+	if !res.warning || res.skipped {
+		t.Fatalf("want warning=true skipped=false; got warning=%v skipped=%v msg=%q",
+			res.warning, res.skipped, res.message)
+	}
+	// the warning detail must mention localhost (the 0-owner endpoint)
+	// but not sageox.ai (which is healthy).
+	if !strings.Contains(res.detail, "localhost") {
+		t.Errorf("detail = %q, want it to mention localhost", res.detail)
+	}
+}
+
+// TestCheckKBGlobalSyncNoOwner_NoRunningDaemonsSkips verifies the
+// check skips quietly on a fresh install or stopped-daemon state.
+// Failure prevented: doctor noise on first run before any daemon
+// has started.
+func TestCheckKBGlobalSyncNoOwner_NoRunningDaemonsSkips(t *testing.T) {
+	kbGlobalSyncSetup(t, nil, nil)
+	res := checkKBGlobalSyncNoOwner(false)
+	if !res.skipped {
+		t.Errorf("want skipped=true; got skipped=%v passed=%v warning=%v msg=%q",
+			res.skipped, res.passed, res.warning, res.message)
+	}
+}
+
+// TestCheckKBGlobalSyncNoOwner_RegistryUnreadableSkips verifies the
+// check skips when the registry read fails. We never escalate
+// infrastructure errors to a doctor warning — the user can't act on
+// them.
+func TestCheckKBGlobalSyncNoOwner_RegistryUnreadableSkips(t *testing.T) {
+	kbGlobalSyncSetup(t, nil, errors.New("registry corrupt"))
+	res := checkKBGlobalSyncNoOwner(false)
+	if !res.skipped {
+		t.Errorf("want skipped=true; got skipped=%v passed=%v warning=%v msg=%q",
+			res.skipped, res.passed, res.warning, res.message)
+	}
+}
+
+// TestCheckKBGlobalSyncNoOwner_OldDaemonsWithoutEndpointSkip verifies
+// that daemons predating the Endpoint field don't trigger false
+// positives during the rollout window.
+// Failure prevented: rolling upgrade where some daemons report
+// Endpoint and others don't generates spurious warnings.
+func TestCheckKBGlobalSyncNoOwner_OldDaemonsWithoutEndpointSkip(t *testing.T) {
+	kbGlobalSyncSetup(t, []daemon.DaemonInfo{
+		{WorkspaceID: "old1", Endpoint: "", GlobalSyncOwner: false},
+		{WorkspaceID: "old2", Endpoint: "", GlobalSyncOwner: false},
+	}, nil)
+	res := checkKBGlobalSyncNoOwner(false)
+	if !res.skipped {
+		t.Errorf("want skipped=true (all daemons pre-Endpoint field); got skipped=%v passed=%v warning=%v msg=%q",
+			res.skipped, res.passed, res.warning, res.message)
+	}
+}
+
+// TestCheckKBGlobalSyncNoOwner_PrefixedEndpointsNormalize verifies
+// api.sageox.ai and sageox.ai are grouped together (per the
+// endpoint-normalization rule).
+// Failure prevented: a daemon configured with the prefixed form and
+// another with the bare form both look like single-endpoint daemons
+// but are tallied separately, hiding a real 0-owner case.
+func TestCheckKBGlobalSyncNoOwner_PrefixedEndpointsNormalize(t *testing.T) {
+	kbGlobalSyncSetup(t, []daemon.DaemonInfo{
+		{WorkspaceID: "ws1", Endpoint: "api.sageox.ai", GlobalSyncOwner: false},
+		{WorkspaceID: "ws2", Endpoint: "sageox.ai", GlobalSyncOwner: false},
+	}, nil)
+	res := checkKBGlobalSyncNoOwner(false)
+	if !res.warning || res.skipped {
+		t.Fatalf("want warning=true skipped=false (0 owners after normalization); got warning=%v skipped=%v msg=%q",
+			res.warning, res.skipped, res.message)
+	}
+}

--- a/cmd/ox/doctor_kb_migrate.go
+++ b/cmd/ox/doctor_kb_migrate.go
@@ -66,8 +66,14 @@ func checkKBProjectConfigMigrate(fix bool) checkResult {
 	jsonPath := filepath.Join(sageoxPath, "config.json")
 	yamlPath := filepath.Join(sageoxPath, "config.yaml")
 
-	jsonExists := pathExists(jsonPath)
-	yamlExists := pathExists(yamlPath)
+	jsonExists, err := pathExists(jsonPath)
+	if err != nil {
+		return SkippedCheck(name, "config.json status unreadable", err.Error())
+	}
+	yamlExists, err := pathExists(yamlPath)
+	if err != nil {
+		return SkippedCheck(name, "config.yaml status unreadable", err.Error())
+	}
 
 	switch {
 	case !jsonExists && !yamlExists:
@@ -128,10 +134,8 @@ func migrateJSONOnly(name string, fix bool, gitRoot, sageoxPath, _, yamlPath str
 			"re-run `ox init` or wait for the server to provision a knowledge bubble for this repo")
 	}
 
-	payload := config.ProjectConfigYAML{
-		KBID:   kbID,
-		RepoID: cfg.RepoID,
-	}
+	payload := *cfg
+	payload.KBID = kbID
 	if err := writeProjectYAMLAtomic(sageoxPath, yamlPath, payload); err != nil {
 		return FailedCheck(name, "write config.yaml failed", err.Error())
 	}
@@ -256,7 +260,9 @@ func readYAMLConfigBinding(path string) (config.ProjectConfigYAML, error) {
 //
 // Returns the final backup path so callers can log it.
 func archiveJSON(sageoxDir, jsonPath string) (string, error) {
-	ts := time.Now().UTC().Format(time.RFC3339)
+	// RFC3339 contains ":" which is invalid in Windows filenames; use a
+	// filesystem-safe layout that still sorts lexicographically.
+	ts := time.Now().UTC().Format("20060102T150405Z")
 	finalBackup := filepath.Join(sageoxDir, "config.json.bak."+ts)
 	tmpBackup := finalBackup + ".tmp"
 
@@ -281,11 +287,18 @@ func archiveJSON(sageoxDir, jsonPath string) (string, error) {
 }
 
 // pathExists is a small predicate used to keep the dispatch switch readable.
-// os.Stat with errors.Is(err, os.ErrNotExist) inlined would obscure the four-
-// way intent of the case labels in checkKBProjectConfigMigrate.
-func pathExists(path string) bool {
+// Distinguishes ENOENT (legitimately absent) from other stat errors
+// (permission/IO) so a misconfigured directory doesn't silently route to the
+// wrong migration branch.
+func pathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat %s: %w", path, err)
 }
 
 // resolveKBIDForRepo asks the kb API for all bubbles the caller can access
@@ -306,11 +319,11 @@ func resolveKBIDForRepo(ctx context.Context, repoID string) (string, error) {
 	return "", nil
 }
 
-// writeProjectYAMLAtomic marshals the binding YAML and writes it via a
+// writeProjectYAMLAtomic marshals the project-side YAML and writes it via a
 // temp + rename so a crash mid-write cannot leave a half-written
 // config.yaml behind. Permissions match the existing config.json (0644)
 // because this file is intended to be committed to git.
-func writeProjectYAMLAtomic(sageoxDir, finalPath string, payload config.ProjectConfigYAML) error {
+func writeProjectYAMLAtomic(sageoxDir, finalPath string, payload any) error {
 	data, err := yaml.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal yaml: %w", err)

--- a/cmd/ox/doctor_kb_migrate.go
+++ b/cmd/ox/doctor_kb_migrate.go
@@ -1,0 +1,327 @@
+package main
+
+// Knowledge-bubble project-config migration check (ADR-017).
+//
+// This check graduates a repo from "JSON only" (legacy) to "YAML present"
+// (ADR-017). The hybrid loader (LoadProjectConfig) keeps both formats working
+// during the staged migration window, but doctor is what actually moves repos
+// forward. Four on-disk shapes are handled:
+//
+//   - neither file present → no-op pass (nothing to migrate)
+//   - JSON only            → resolve kb_id via API, write config.yaml. Orphan
+//                            repos (no matching kb row) return a Warning so
+//                            the user can re-run `ox init` or wait for the
+//                            server to provision.
+//   - YAML only            → no-op pass (migration already complete)
+//   - both present         → reconcile. If kb_id+repo_id are equivalent across
+//                            the two files, archive the JSON. If they diverge,
+//                            YAML wins (per ADR-017 §6) and the JSON is still
+//                            archived but a divergence line is logged.
+//
+// Archiving = copy JSON to `.sageox/config.json.bak.<RFC3339>` then delete the
+// original. We deliberately never delete without first writing the archive —
+// the staged-deprecation plan in ADR-017 §7 promises the legacy data is
+// recoverable until release N+3.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/config"
+)
+
+// CheckSlugKBProjectConfigMigrate is the doctor check slug for the
+// JSON-to-YAML project-config migration. AutoFix because every write the
+// check performs is non-destructive in the recoverable sense: new files
+// (config.yaml) live next to the legacy JSON, and the JSON itself is
+// archived to a timestamped `.bak` before removal.
+const CheckSlugKBProjectConfigMigrate = "kb-project-config-migrate"
+
+// kbMigrateAPITimeout caps the kb-API call. The check runs synchronously
+// inside `ox doctor`, so a slow API must not block the user — a missed
+// migration this pass just retries on the next doctor run.
+const kbMigrateAPITimeout = 10 * time.Second
+
+// checkKBProjectConfigMigrate dispatches to one of four handlers based on
+// which files exist under .sageox/. Each handler is responsible for its own
+// no-op / warning / fix path so the dispatcher stays trivial to audit.
+func checkKBProjectConfigMigrate(fix bool) checkResult {
+	const name = "kb project config migrate"
+
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(name, "not in a git repo", "")
+	}
+
+	sageoxPath := filepath.Join(gitRoot, ".sageox")
+	jsonPath := filepath.Join(sageoxPath, "config.json")
+	yamlPath := filepath.Join(sageoxPath, "config.yaml")
+
+	jsonExists := pathExists(jsonPath)
+	yamlExists := pathExists(yamlPath)
+
+	switch {
+	case !jsonExists && !yamlExists:
+		return PassedCheck(name, "no project config files")
+	case jsonExists && !yamlExists:
+		return migrateJSONOnly(name, fix, gitRoot, sageoxPath, jsonPath, yamlPath)
+	case !jsonExists && yamlExists:
+		return PassedCheck(name, "yaml-only — migration complete")
+	default: // both present
+		return reconcileBoth(name, fix, sageoxPath, jsonPath, yamlPath)
+	}
+}
+
+// migrateJSONOnly handles the legacy → new format transition. Orphan repos
+// (no kb row matching repo_id) surface as a Warning rather than Failed: the
+// repo still functions through the JSON config; what's missing is the
+// server-side provisioning that would make the YAML binding possible.
+func migrateJSONOnly(name string, fix bool, gitRoot, sageoxPath, _, yamlPath string) checkResult {
+	cfg, err := config.LoadProjectConfig(gitRoot)
+	if err != nil {
+		return SkippedCheck(name, "project config unreadable", err.Error())
+	}
+	if cfg == nil || cfg.RepoID == "" {
+		// No repo_id means the project was never fully initialized via
+		// `ox init`. Skip rather than invent a binding.
+		return SkippedCheck(name, "project missing repo_id", "")
+	}
+
+	if !fix {
+		return WarningCheck(name,
+			"legacy .sageox/config.json without config.yaml",
+			"run `ox doctor --fix` to write the new YAML binding (ADR-017)")
+	}
+
+	// Resolve kb_id from repo_id via the kb API. ErrKBAPIUnavailable is the
+	// "feature flag off / no auth" sentinel — treat it as "try again later"
+	// so offline doctor runs stay silent.
+	ctx, cancel := context.WithTimeout(context.Background(), kbMigrateAPITimeout)
+	defer cancel()
+	kbID, lookupErr := resolveKBIDForRepo(ctx, cfg.RepoID)
+	if lookupErr != nil {
+		if errors.Is(lookupErr, api.ErrKBAPIUnavailable) {
+			slog.Default().Debug("kb_doctor migrate: api unavailable, will retry next run",
+				"repo_id", cfg.RepoID)
+			return PassedCheck(name, "api unavailable; will retry next doctor run")
+		}
+		return WarningCheck(name, "kb lookup failed", lookupErr.Error())
+	}
+	if kbID == "" {
+		// Orphan repo: repo_id exists locally but the server has no matching
+		// knowledge bubble. The CLI cannot fix this — the user needs to
+		// re-run init or wait for server-side provisioning. Warning, not
+		// Failed: the repo continues to function via the JSON config.
+		slog.Default().Info("kb_doctor migrate: orphan repo, no matching kb",
+			"repo_id", cfg.RepoID)
+		return WarningCheck(name,
+			"orphan repo: repo_id="+cfg.RepoID+" has no matching kb in the API",
+			"re-run `ox init` or wait for the server to provision a knowledge bubble for this repo")
+	}
+
+	payload := config.ProjectConfigYAML{
+		KBID:   kbID,
+		RepoID: cfg.RepoID,
+	}
+	if err := writeProjectYAMLAtomic(sageoxPath, yamlPath, payload); err != nil {
+		return FailedCheck(name, "write config.yaml failed", err.Error())
+	}
+
+	slog.Default().Info("kb_doctor migrate wrote config.yaml",
+		"git_root", gitRoot,
+		"kb_id", kbID,
+		"repo_id", cfg.RepoID)
+	return PassedCheck(name, "wrote .sageox/config.yaml (kb_id="+kbID+")")
+}
+
+// reconcileBoth handles the "both files present" case. The two files are
+// considered equivalent when their kb_id and repo_id agree — those are the
+// only fields the narrow YAML binding carries (ADR-017 §2), so any other
+// JSON-only fields are preserved by the archive itself.
+//
+// On equivalence: archive JSON, done.
+// On divergence: YAML wins (per ADR-017 §6), archive JSON, log which fields
+// differed so the user has an audit trail of what was discarded.
+func reconcileBoth(name string, fix bool, sageoxPath, jsonPath, yamlPath string) checkResult {
+	jsonCfg, jsonErr := readJSONConfigBinding(jsonPath)
+	if jsonErr != nil {
+		return SkippedCheck(name, "config.json unreadable", jsonErr.Error())
+	}
+	yamlCfg, yamlErr := readYAMLConfigBinding(yamlPath)
+	if yamlErr != nil {
+		return SkippedCheck(name, "config.yaml unreadable", yamlErr.Error())
+	}
+
+	identical := configsEquivalent(jsonCfg, yamlCfg)
+
+	if !fix {
+		if identical {
+			return WarningCheck(name,
+				"legacy config.json present alongside config.yaml (identical)",
+				"run `ox doctor --fix` to archive the legacy .sageox/config.json")
+		}
+		return WarningCheck(name,
+			"config.json and config.yaml diverge",
+			"run `ox doctor --fix` to archive the legacy JSON (YAML wins per ADR-017)")
+	}
+
+	if !identical {
+		// Single-line key=value divergence log so it survives grep/log
+		// aggregation. The archive itself is the recoverable record; the log
+		// is the human-readable "here's what was different" trail.
+		slog.Default().Info("kb_doctor migrate divergence",
+			"json_kb_id", jsonCfg.KBID,
+			"yaml_kb_id", yamlCfg.KBID,
+			"json_repo_id", jsonCfg.RepoID,
+			"yaml_repo_id", yamlCfg.RepoID,
+			"winner", "yaml")
+	}
+
+	backupPath, err := archiveJSON(sageoxPath, jsonPath)
+	if err != nil {
+		return FailedCheck(name, "archive config.json failed", err.Error())
+	}
+
+	if identical {
+		slog.Default().Info("kb_doctor migrate archived identical json",
+			"backup", backupPath)
+		return PassedCheck(name, "archived legacy config.json (identical to yaml)")
+	}
+	slog.Default().Info("kb_doctor migrate archived divergent json",
+		"backup", backupPath)
+	return PassedCheck(name, "archived legacy config.json (yaml won divergence)")
+}
+
+// configsEquivalent compares the JSON and YAML binding-relevant fields. The
+// narrow YAML carries only kb_id + repo_id, so those are the only fields
+// that have a meaningful "diverged" notion. An empty YAML kb_id when the
+// JSON has one is treated as divergent — that's the case where the YAML was
+// written incompletely (e.g. an interrupted migration) and the JSON would
+// actually be carrying more information.
+func configsEquivalent(jsonCfg, yamlCfg config.ProjectConfigYAML) bool {
+	if jsonCfg.KBID != yamlCfg.KBID {
+		return false
+	}
+	if jsonCfg.RepoID != yamlCfg.RepoID {
+		return false
+	}
+	return true
+}
+
+// readJSONConfigBinding extracts just the kb_id + repo_id from a config.json,
+// returned in the same shape as a YAML binding so the equivalence comparison
+// is symmetric. ProjectConfig.KBID isn't JSON-serialized (it's a yaml-only
+// tag), so we read both kb_id and repo_id by re-decoding the raw JSON.
+func readJSONConfigBinding(path string) (config.ProjectConfigYAML, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return config.ProjectConfigYAML{}, err
+	}
+	var raw struct {
+		KBID   string `json:"kb_id,omitempty"`
+		RepoID string `json:"repo_id,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return config.ProjectConfigYAML{}, fmt.Errorf("parse json: %w", err)
+	}
+	return config.ProjectConfigYAML{KBID: raw.KBID, RepoID: raw.RepoID}, nil
+}
+
+// readYAMLConfigBinding loads the narrow project-side YAML binding.
+func readYAMLConfigBinding(path string) (config.ProjectConfigYAML, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return config.ProjectConfigYAML{}, err
+	}
+	var y config.ProjectConfigYAML
+	if err := yaml.Unmarshal(data, &y); err != nil {
+		return config.ProjectConfigYAML{}, fmt.Errorf("parse yaml: %w", err)
+	}
+	return y, nil
+}
+
+// archiveJSON copies the legacy JSON to `.sageox/config.json.bak.<RFC3339>`
+// then removes the original. The copy is done via temp + rename so a crash
+// mid-archive cannot leave the project with neither file (the original is
+// only unlinked after the backup is durably renamed into place).
+//
+// Returns the final backup path so callers can log it.
+func archiveJSON(sageoxDir, jsonPath string) (string, error) {
+	ts := time.Now().UTC().Format(time.RFC3339)
+	finalBackup := filepath.Join(sageoxDir, "config.json.bak."+ts)
+	tmpBackup := finalBackup + ".tmp"
+
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return "", fmt.Errorf("read json: %w", err)
+	}
+	if err := os.WriteFile(tmpBackup, data, 0o644); err != nil {
+		return "", fmt.Errorf("write backup tmp: %w", err)
+	}
+	if err := os.Rename(tmpBackup, finalBackup); err != nil {
+		_ = os.Remove(tmpBackup)
+		return "", fmt.Errorf("rename backup: %w", err)
+	}
+	if err := os.Remove(jsonPath); err != nil {
+		// Backup is durable; surface the unlink failure but don't roll back
+		// (the project is now in a "both backup + original" state, which is
+		// strictly safer than "neither").
+		return finalBackup, fmt.Errorf("remove original json: %w", err)
+	}
+	return finalBackup, nil
+}
+
+// pathExists is a small predicate used to keep the dispatch switch readable.
+// os.Stat with errors.Is(err, os.ErrNotExist) inlined would obscure the four-
+// way intent of the case labels in checkKBProjectConfigMigrate.
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// resolveKBIDForRepo asks the kb API for all bubbles the caller can access
+// and returns the kb_id of the kb_type=repo row whose repo_id matches. Empty
+// string + nil error means "the kb API responded but no matching bubble
+// exists" — surfaced to the user via the orphan-repo Warning in migrateJSONOnly.
+func resolveKBIDForRepo(ctx context.Context, repoID string) (string, error) {
+	listFn := kbHookList()
+	bubbles, err := listFn(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, b := range bubbles {
+		if b.KBType == api.KBTypeRepo && b.RepoID == repoID {
+			return b.KBID, nil
+		}
+	}
+	return "", nil
+}
+
+// writeProjectYAMLAtomic marshals the binding YAML and writes it via a
+// temp + rename so a crash mid-write cannot leave a half-written
+// config.yaml behind. Permissions match the existing config.json (0644)
+// because this file is intended to be committed to git.
+func writeProjectYAMLAtomic(sageoxDir, finalPath string, payload config.ProjectConfigYAML) error {
+	data, err := yaml.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal yaml: %w", err)
+	}
+	tmp := filepath.Join(sageoxDir, "config.yaml.tmp")
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := os.Rename(tmp, finalPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename temp: %w", err)
+	}
+	return nil
+}

--- a/cmd/ox/doctor_kb_migrate.go
+++ b/cmd/ox/doctor_kb_migrate.go
@@ -324,7 +324,7 @@ func resolveKBIDForRepo(ctx context.Context, repoID string) (string, error) {
 // config.yaml behind. Permissions match the existing config.json (0644)
 // because this file is intended to be committed to git.
 func writeProjectYAMLAtomic(sageoxDir, finalPath string, payload any) error {
-	data, err := yaml.Marshal(payload)
+	data, err := marshalProjectYAML(payload)
 	if err != nil {
 		return fmt.Errorf("marshal yaml: %w", err)
 	}
@@ -337,4 +337,47 @@ func writeProjectYAMLAtomic(sageoxDir, finalPath string, payload any) error {
 		return fmt.Errorf("rename temp: %w", err)
 	}
 	return nil
+}
+
+func marshalProjectYAML(payload any) ([]byte, error) {
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	raw := map[string]any{}
+	if len(jsonData) > 0 {
+		if err := json.Unmarshal(jsonData, &raw); err != nil {
+			return nil, err
+		}
+	}
+
+	switch p := payload.(type) {
+	case config.ProjectConfig:
+		if p.KBID != "" {
+			raw["kb_id"] = p.KBID
+		}
+	case *config.ProjectConfig:
+		if p != nil && p.KBID != "" {
+			raw["kb_id"] = p.KBID
+		}
+	case config.ProjectConfigYAML:
+		if p.KBID != "" {
+			raw["kb_id"] = p.KBID
+		}
+		if p.RepoID != "" {
+			raw["repo_id"] = p.RepoID
+		}
+	case *config.ProjectConfigYAML:
+		if p != nil {
+			if p.KBID != "" {
+				raw["kb_id"] = p.KBID
+			}
+			if p.RepoID != "" {
+				raw["repo_id"] = p.RepoID
+			}
+		}
+	}
+
+	return yaml.Marshal(raw)
 }

--- a/cmd/ox/doctor_kb_migrate_test.go
+++ b/cmd/ox/doctor_kb_migrate_test.go
@@ -1,0 +1,315 @@
+package main
+
+// Tests for the kb-project-config-migrate doctor check (ADR-017).
+//
+// Each test enforces one observable contract of the migration:
+//
+//   - JSON only + matching kb_id            → write config.yaml
+//   - JSON only + API unavailable           → silent retry-next-run pass
+//   - JSON only + no matching kb (orphan)   → Warning, no migration attempted
+//   - YAML only                             → no-op pass (already migrated)
+//   - Both present, identical kb_id+repo_id → archive JSON to .bak.<ts>
+//   - Both present, divergent values        → archive JSON, YAML wins, log
+//
+// All tests use the kbDoctorHooks seam — production wiring (real kb API,
+// real auth) never runs in unit tests.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/config"
+)
+
+// kbMigrateProject scaffolds a minimal initialized .sageox project rooted in
+// a real git working tree so findGitRoot() resolves to it. Returns the
+// project root so each test can drive its own JSON/YAML layout.
+func kbMigrateProject(t *testing.T, repoID string) string {
+	t.Helper()
+	root := t.TempDir()
+	// Resolve symlinks (macOS /var → /private/var) so the path matches what
+	// git rev-parse --show-toplevel returns.
+	resolved, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	root = resolved
+
+	// findGitRoot() shells out to `git rev-parse --show-toplevel`, so we need
+	// a real git repo (not just a .git directory).
+	gitInit := exec.Command("git", "init", "-q", root)
+	require.NoError(t, gitInit.Run())
+
+	sageox := filepath.Join(root, ".sageox")
+	require.NoError(t, os.MkdirAll(sageox, 0o755))
+
+	cfg := map[string]any{
+		"config_version":         "2",
+		"repo_id":                repoID,
+		"update_frequency_hours": 24,
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(sageox, "config.json"), data, 0o600))
+
+	// findGitRoot() uses the current working directory — chdir into the
+	// scaffolded project for the duration of the test.
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(root))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	return root
+}
+
+// TestCheckKBProjectConfigMigrate_JSONOnlyWritesYAML verifies the happy path:
+// a JSON-only project with a known repo_id gets a config.yaml written next to
+// it carrying the resolved kb_id, and the original JSON is untouched.
+//
+// Failure prevented: ADR-017 migration silently skipping JSON-only repos, so
+// the cohort never finishes migrating and the deprecation window can't close.
+func TestCheckKBProjectConfigMigrate_JSONOnlyWritesYAML(t *testing.T) {
+	root := kbMigrateProject(t, "repo_abc")
+
+	SetKBDoctorHooks(kbDoctorHooks{
+		List: func(_ context.Context) ([]api.KB, error) {
+			return []api.KB{
+				{KBID: "kb_xyz", KBType: api.KBTypeRepo, RepoID: "repo_abc"},
+				{KBID: "kb_other", KBType: api.KBTypeRepo, RepoID: "repo_other"},
+			}, nil
+		},
+	})
+	t.Cleanup(func() { SetKBDoctorHooks(kbDoctorHooks{}) })
+
+	result := checkKBProjectConfigMigrate(true)
+	require.True(t, result.passed && !result.warning, "expected clean pass, got %+v", result)
+
+	yamlPath := filepath.Join(root, ".sageox", "config.yaml")
+	data, err := os.ReadFile(yamlPath)
+	require.NoError(t, err, "config.yaml must be written")
+
+	var got config.ProjectConfigYAML
+	require.NoError(t, yaml.Unmarshal(data, &got))
+	assert.Equal(t, "kb_xyz", got.KBID)
+	assert.Equal(t, "repo_abc", got.RepoID)
+
+	// Legacy JSON must survive — deletion is deferred to release N+3.
+	_, err = os.Stat(filepath.Join(root, ".sageox", "config.json"))
+	assert.NoError(t, err, "legacy config.json must not be deleted by the migration")
+}
+
+// TestCheckKBProjectConfigMigrate_APIUnavailableIsNoop verifies that an
+// offline / flag-gated kb API does not produce a doctor warning and does not
+// leave a partially-written YAML behind.
+//
+// Failure prevented: a flapping kb-API feature flag would turn doctor red on
+// every run for users who never see the API succeed.
+func TestCheckKBProjectConfigMigrate_APIUnavailableIsNoop(t *testing.T) {
+	root := kbMigrateProject(t, "repo_abc")
+
+	SetKBDoctorHooks(kbDoctorHooks{
+		List: func(_ context.Context) ([]api.KB, error) {
+			return nil, api.ErrKBAPIUnavailable
+		},
+	})
+	t.Cleanup(func() { SetKBDoctorHooks(kbDoctorHooks{}) })
+
+	result := checkKBProjectConfigMigrate(true)
+	assert.True(t, result.passed && !result.warning, "expected silent pass, got %+v", result)
+
+	_, err := os.Stat(filepath.Join(root, ".sageox", "config.yaml"))
+	assert.True(t, os.IsNotExist(err), "config.yaml must not be created when API is unavailable")
+}
+
+// TestCheckKBProjectConfigMigrate_YAMLOnlyIsNoop verifies that a project
+// which has already completed migration (yaml only, json archived away) is
+// left alone and reports a clean pass.
+//
+// Failure prevented: running doctor on a fully-migrated repo touching the
+// filesystem (or hitting the API) for no reason.
+func TestCheckKBProjectConfigMigrate_YAMLOnlyIsNoop(t *testing.T) {
+	root := kbMigrateProject(t, "repo_abc")
+	// kbMigrateProject scaffolds a JSON. For YAML-only we delete the JSON
+	// and write the YAML directly.
+	jsonPath := filepath.Join(root, ".sageox", "config.json")
+	require.NoError(t, os.Remove(jsonPath))
+	yamlPath := filepath.Join(root, ".sageox", "config.yaml")
+	require.NoError(t, os.WriteFile(yamlPath,
+		[]byte("kb_id: kb_xyz\nrepo_id: repo_abc\n"), 0o644))
+
+	apiCalls := 0
+	SetKBDoctorHooks(kbDoctorHooks{
+		List: func(_ context.Context) ([]api.KB, error) {
+			apiCalls++
+			return nil, nil
+		},
+	})
+	t.Cleanup(func() { SetKBDoctorHooks(kbDoctorHooks{}) })
+
+	result := checkKBProjectConfigMigrate(true)
+	assert.True(t, result.passed && !result.warning, "expected clean pass, got %+v", result)
+	assert.Equal(t, 0, apiCalls, "API must not be called when yaml is already present")
+}
+
+// TestCheckKBProjectConfigMigrate_BothIdenticalArchivesJSON verifies the
+// "both present, kb_id+repo_id agree" reconciliation: doctor archives the
+// legacy JSON to `.sageox/config.json.bak.<RFC3339>` and removes the
+// original, leaving only the YAML in place.
+//
+// Failure prevented: the legacy JSON staying behind forever, blocking the
+// staged-deprecation window from ever closing.
+func TestCheckKBProjectConfigMigrate_BothIdenticalArchivesJSON(t *testing.T) {
+	root := kbMigrateProject(t, "repo_abc")
+
+	// Add a matching kb_id to the existing JSON so it's identical to the YAML
+	// we're about to write.
+	jsonPath := filepath.Join(root, ".sageox", "config.json")
+	rewriteJSONWithKBID(t, jsonPath, "repo_abc", "kb_xyz")
+	yamlPath := filepath.Join(root, ".sageox", "config.yaml")
+	require.NoError(t, os.WriteFile(yamlPath,
+		[]byte("kb_id: kb_xyz\nrepo_id: repo_abc\n"), 0o644))
+
+	apiCalls := 0
+	SetKBDoctorHooks(kbDoctorHooks{
+		List: func(_ context.Context) ([]api.KB, error) {
+			apiCalls++
+			return nil, nil
+		},
+	})
+	t.Cleanup(func() { SetKBDoctorHooks(kbDoctorHooks{}) })
+
+	result := checkKBProjectConfigMigrate(true)
+	require.True(t, result.passed && !result.warning, "expected clean pass, got %+v", result)
+	assert.Equal(t, 0, apiCalls, "API must not be called when both files exist")
+
+	// Legacy JSON must be removed (archived elsewhere).
+	_, err := os.Stat(jsonPath)
+	assert.True(t, os.IsNotExist(err), "config.json must be removed after archive")
+
+	// A timestamped backup must exist.
+	bak := findBackup(t, filepath.Join(root, ".sageox"))
+	require.NotEmpty(t, bak, "expected a config.json.bak.<ts> file")
+
+	// YAML must survive untouched.
+	yamlData, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(yamlData), "kb_id: kb_xyz")
+}
+
+// TestCheckKBProjectConfigMigrate_BothDivergentYAMLWins verifies that when
+// JSON and YAML disagree on kb_id (or repo_id), YAML wins per ADR-017 §6,
+// the JSON is archived (not silently deleted), and a divergence record is
+// emitted to the slog default logger as a single-line key=value entry.
+//
+// Failure prevented: a stale JSON quietly overriding the canonical YAML
+// binding because the operator never knew there was a conflict.
+func TestCheckKBProjectConfigMigrate_BothDivergentYAMLWins(t *testing.T) {
+	root := kbMigrateProject(t, "repo_abc")
+
+	jsonPath := filepath.Join(root, ".sageox", "config.json")
+	rewriteJSONWithKBID(t, jsonPath, "repo_abc", "kb_old")
+	yamlPath := filepath.Join(root, ".sageox", "config.yaml")
+	require.NoError(t, os.WriteFile(yamlPath,
+		[]byte("kb_id: kb_new\nrepo_id: repo_abc\n"), 0o644))
+
+	SetKBDoctorHooks(kbDoctorHooks{
+		List: func(_ context.Context) ([]api.KB, error) { return nil, nil },
+	})
+	t.Cleanup(func() { SetKBDoctorHooks(kbDoctorHooks{}) })
+
+	result := checkKBProjectConfigMigrate(true)
+	require.True(t, result.passed && !result.warning, "expected clean pass, got %+v", result)
+
+	// JSON removed, backup written.
+	_, err := os.Stat(jsonPath)
+	assert.True(t, os.IsNotExist(err), "config.json must be removed after archive")
+	bak := findBackup(t, filepath.Join(root, ".sageox"))
+	require.NotEmpty(t, bak, "expected a config.json.bak.<ts> file")
+
+	// Backup should be the divergent JSON content (kb_old), not the YAML.
+	bakData, err := os.ReadFile(filepath.Join(root, ".sageox", bak))
+	require.NoError(t, err)
+	assert.Contains(t, string(bakData), "kb_old",
+		"backup must preserve the divergent JSON content for recoverability")
+
+	// YAML must remain the winner.
+	yamlData, err := os.ReadFile(yamlPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(yamlData), "kb_id: kb_new")
+}
+
+// TestCheckKBProjectConfigMigrate_OrphanRepoIsWarning verifies that a
+// JSON-only project whose repo_id has no matching kb on the server surfaces
+// as a Warning (not a Failed check). The repo still functions through the
+// JSON config — what's missing is the server-side provisioning the user (or
+// support) needs to act on.
+//
+// Failure prevented: doctor turning red on orphan repos that the CLI is
+// powerless to fix, or worse, fabricating a fake kb_id binding.
+func TestCheckKBProjectConfigMigrate_OrphanRepoIsWarning(t *testing.T) {
+	root := kbMigrateProject(t, "repo_orphan")
+
+	SetKBDoctorHooks(kbDoctorHooks{
+		List: func(_ context.Context) ([]api.KB, error) {
+			// API responds successfully but has no row for repo_orphan.
+			return []api.KB{
+				{KBID: "kb_other", KBType: api.KBTypeRepo, RepoID: "repo_other"},
+			}, nil
+		},
+	})
+	t.Cleanup(func() { SetKBDoctorHooks(kbDoctorHooks{}) })
+
+	result := checkKBProjectConfigMigrate(true)
+	assert.True(t, result.warning, "expected Warning for orphan repo, got %+v", result)
+	assert.Contains(t, result.message, "orphan",
+		"warning message must identify the orphan condition")
+
+	// No yaml should have been written — we don't fabricate bindings.
+	_, err := os.Stat(filepath.Join(root, ".sageox", "config.yaml"))
+	assert.True(t, os.IsNotExist(err), "config.yaml must not be created for orphan repos")
+
+	// JSON must be left intact (archive is only for the both-present case).
+	_, err = os.Stat(filepath.Join(root, ".sageox", "config.json"))
+	assert.NoError(t, err, "legacy config.json must not be removed when migration could not complete")
+}
+
+// rewriteJSONWithKBID rewrites the JSON config the kbMigrateProject helper
+// scaffolds, adding a kb_id field (which the test fixture omits by default).
+// Used by the "both present" reconciliation tests where we need the JSON's
+// kb_id to compare against the YAML's.
+func rewriteJSONWithKBID(t *testing.T, jsonPath, repoID, kbID string) {
+	t.Helper()
+	cfg := map[string]any{
+		"config_version":         "2",
+		"repo_id":                repoID,
+		"kb_id":                  kbID,
+		"update_frequency_hours": 24,
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(jsonPath, data, 0o600))
+}
+
+// findBackup returns the name of the first config.json.bak.<ts> file under
+// dir, or "" if none exists. Used to assert the archive was created without
+// hardcoding the timestamp into the test.
+func findBackup(t *testing.T, dir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "config.json.bak.") &&
+			!strings.HasSuffix(e.Name(), ".tmp") {
+			return e.Name()
+		}
+	}
+	return ""
+}

--- a/cmd/ox/doctor_kb_migrate_test.go
+++ b/cmd/ox/doctor_kb_migrate_test.go
@@ -45,7 +45,8 @@ func kbMigrateProject(t *testing.T, repoID string) string {
 
 	// findGitRoot() shells out to `git rev-parse --show-toplevel`, so we need
 	// a real git repo (not just a .git directory).
-	gitInit := exec.Command("git", "init", "-q", root)
+	gitInit := exec.Command("git", "init", "-q")
+	gitInit.Dir = root
 	require.NoError(t, gitInit.Run())
 
 	sageox := filepath.Join(root, ".sageox")
@@ -104,6 +105,42 @@ func TestCheckKBProjectConfigMigrate_JSONOnlyWritesYAML(t *testing.T) {
 	// Legacy JSON must survive — deletion is deferred to release N+3.
 	_, err = os.Stat(filepath.Join(root, ".sageox", "config.json"))
 	assert.NoError(t, err, "legacy config.json must not be deleted by the migration")
+}
+
+func TestCheckKBProjectConfigMigrate_JSONOnlyPreservesProjectSettingsInYAML(t *testing.T) {
+	root := kbMigrateProject(t, "repo_abc")
+
+	jsonPath := filepath.Join(root, ".sageox", "config.json")
+	cfg := map[string]any{
+		"config_version":         "2",
+		"repo_id":                "repo_abc",
+		"endpoint":               "https://test.sageox.ai",
+		"session_recording":      "auto",
+		"update_frequency_hours": 24,
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(jsonPath, data, 0o600))
+
+	SetKBDoctorHooks(kbDoctorHooks{
+		List: func(_ context.Context) ([]api.KB, error) {
+			return []api.KB{{KBID: "kb_xyz", KBType: api.KBTypeRepo, RepoID: "repo_abc"}}, nil
+		},
+	})
+	t.Cleanup(func() { SetKBDoctorHooks(kbDoctorHooks{}) })
+
+	result := checkKBProjectConfigMigrate(true)
+	require.True(t, result.passed && !result.warning, "expected clean pass, got %+v", result)
+
+	require.NoError(t, os.Remove(jsonPath), "test simulates the follow-up archive step")
+	loaded, err := config.LoadProjectConfig(root)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "yaml", loaded.Format)
+	assert.Equal(t, "kb_xyz", loaded.KBID)
+	assert.Equal(t, "repo_abc", loaded.RepoID)
+	assert.Equal(t, "https://test.sageox.ai", loaded.Endpoint)
+	assert.Equal(t, "auto", loaded.SessionRecording)
 }
 
 // TestCheckKBProjectConfigMigrate_APIUnavailableIsNoop verifies that an

--- a/cmd/ox/doctor_kb_test.go
+++ b/cmd/ox/doctor_kb_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/daemon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -350,8 +351,15 @@ func TestRunKBChecks_SkipsAPIChecksWhenAPIUnavailable_RunsStaleSync(t *testing.T
 	}
 	applyHooks(h)
 
+	// stub the global-sync owner registry reader so this test doesn't
+	// race against the developer's real running daemons.
+	SetKBGlobalSyncReader(func() ([]daemon.DaemonInfo, error) { return nil, nil })
+	t.Cleanup(func() { SetKBGlobalSyncReader(nil) })
+
 	results := runKBChecks(doctorOptions{fix: false})
-	require.Len(t, results, 3, "all three checks must run")
+	// Four checks expected: orphans, provisioning, stale-sync,
+	// global-sync-owner (added in ox-6zme).
+	require.Len(t, results, 4, "all four checks must run")
 
 	// orphans (idx 0) and provisioning (idx 1) must be skipped
 	assert.True(t, results[0].skipped, "orphans must skip when API unavailable")
@@ -360,6 +368,12 @@ func TestRunKBChecks_SkipsAPIChecksWhenAPIUnavailable_RunsStaleSync(t *testing.T
 	// stale-sync (idx 2) must still produce a real signal
 	assert.True(t, results[2].warning, "stale-sync must surface even without API; got %+v", results[2])
 	assert.Contains(t, results[2].message, "kb_stale")
+
+	// global-sync-owner (idx 3) is independent of the kb API; it reads
+	// the daemon registry. In this test the registry is not stubbed and
+	// will skip with "no daemons report endpoint" or "no running
+	// daemons" depending on the host. Just assert it ran (no panic).
+	assert.NotEmpty(t, results[3].name, "global-sync-owner check must run")
 }
 
 // TestRunKBChecks_PanicInOneCheckDoesNotCascade verifies the per-check
@@ -378,8 +392,15 @@ func TestRunKBChecks_PanicInOneCheckDoesNotCascade(t *testing.T) {
 	}
 	applyHooks(h)
 
+	// stub the global-sync owner registry reader so this test doesn't
+	// race against the developer's real running daemons.
+	SetKBGlobalSyncReader(func() ([]daemon.DaemonInfo, error) { return nil, nil })
+	t.Cleanup(func() { SetKBGlobalSyncReader(nil) })
+
 	results := runKBChecks(doctorOptions{fix: false})
-	require.Len(t, results, 3, "every check must run independently")
+	// Four checks expected: orphans, provisioning, stale-sync,
+	// global-sync-owner (added in ox-6zme).
+	require.Len(t, results, 4, "every check must run independently")
 
 	// orphan check (which calls List) panicked → recovered → reported as failure
 	assert.False(t, results[0].passed, "orphan check should fail after panic")
@@ -387,4 +408,7 @@ func TestRunKBChecks_PanicInOneCheckDoesNotCascade(t *testing.T) {
 	// stale-sync (idx 2) is local-only; panic in orphan must not affect it
 	assert.True(t, results[2].warning, "stale-sync must run even after orphan panic")
 	assert.Contains(t, results[2].message, "kb_stale")
+
+	// global-sync-owner (idx 3) is independent of the kb API panic.
+	assert.NotEmpty(t, results[3].name, "global-sync-owner check must run despite orphan panic")
 }

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -202,4 +202,9 @@ const (
 	CheckSlugKBOrphans         = "kb-orphans"
 	CheckSlugKBFailedProvision = "kb-failed-provision"
 	CheckSlugKBStaleSync       = "kb-stale-sync"
+	// CheckSlugKBProjectConfigMigrate is co-located with its impl in
+	// doctor_kb_migrate.go to keep the v1 migration check self-contained.
+
+	// Global-sync leader-election checks (ox-6zme)
+	CheckSlugKBGlobalSyncNoOwner = "kb-global-sync-no-owner"
 )

--- a/cmd/ox/gitenv_test.go
+++ b/cmd/ox/gitenv_test.go
@@ -1,0 +1,13 @@
+package main
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/cmd/ox/init_empty_repo_test.go
+++ b/cmd/ox/init_empty_repo_test.go
@@ -124,6 +124,29 @@ func TestEnsureInitialCommit_RepoWithExistingCommits(t *testing.T) {
 func TestEnsureInitialCommit_WithoutGitUserConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 
+	// This test validates that ensureInitialCommit's SageOx fallback identity
+	// is used when the user has no git identity configured anywhere. The
+	// testenv package (loaded process-wide) supplies GIT_AUTHOR_NAME/EMAIL +
+	// GIT_COMMITTER_NAME/EMAIL so cascade tests don't fail on hostile dev
+	// machines — but those env vars MASK the fallback path this test exists
+	// to exercise. Unset them entirely for the duration of the test so the
+	// production code's identity-resolution falls through to SageOx defaults.
+	// (t.Setenv to "" is NOT equivalent — git sees empty-string as "explicit
+	// empty identity" and errors with `empty ident name`. We need the var
+	// actually absent from the env so git falls through to its config /
+	// command-line `-c` identity resolution.)
+	for _, k := range []string{
+		"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+		"GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+	} {
+		if v, ok := os.LookupEnv(k); ok {
+			t.Cleanup(func() { _ = os.Setenv(k, v) })
+		} else {
+			t.Cleanup(func() { _ = os.Unsetenv(k) })
+		}
+		_ = os.Unsetenv(k)
+	}
+
 	// init repo WITHOUT configuring user.name/user.email
 	cmd := exec.Command("git", "init")
 	cmd.Dir = tmpDir

--- a/cmd/ox/kb_config.go
+++ b/cmd/ox/kb_config.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sageox/ox/internal/api/kbconfig"
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/kb"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/spf13/cobra"
+)
+
+// kbConfigCmd is the parent for read-only KB config commands.
+//
+// `ox kb config get <key>` and `ox kb config list` resolve effective values
+// across env / kb / user / default layers. No `set` verb in v1 — KB-layer
+// writes go through the sageox-mono PATCH /config endpoint; user-layer writes
+// go through the existing `ox config set` surface.
+var kbConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Inspect KB configuration values (read-only)",
+	Long: `Inspect the effective value of a KB configuration key across precedence layers.
+
+Layers (highest precedence first):
+  env      OX_SESSION_RECORDING (session_recording.mode only)
+  kb       .sageox/config.yaml inside the KB checkout
+  user     ~/.config/sageox/config.yaml (or ~/.sageox/config/config.yaml)
+  default  per-KB-type fallback
+
+session_recording.mode has a safety inversion: a "disabled" on either kb OR
+user layer wins regardless of precedence. ` + "`--show-origin`" + ` marks the layer
+that triggered the inversion.`,
+}
+
+var kbConfigGetCmd = &cobra.Command{
+	Use:   "get <key>",
+	Short: "Print the effective value of a KB config key",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runKBConfigGet,
+}
+
+var kbConfigListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List effective values for all known KB config keys",
+	Args:  cobra.NoArgs,
+	RunE:  runKBConfigList,
+}
+
+func init() {
+	kbCmd.AddCommand(kbConfigCmd)
+	kbConfigCmd.AddCommand(kbConfigGetCmd)
+	kbConfigCmd.AddCommand(kbConfigListCmd)
+
+	for _, c := range []*cobra.Command{kbConfigGetCmd, kbConfigListCmd} {
+		c.Flags().String("kb", "", "Target KB by slug, #slug, or kb_id (default: resolve from cwd)")
+		c.Flags().Bool("show-origin", false, "Print each layer's value with origin")
+		c.Flags().Bool("json", false, "Emit JSON output")
+	}
+	kbConfigGetCmd.Flags().String("at", "", "Print only the value at this scope (env|kb|user|default)")
+}
+
+// kbConfigContext captures resolved inputs shared by get/list.
+type kbConfigContext struct {
+	kbID       string
+	kbType     string // best-effort; "" when unknown (defaults to manual)
+	kbConfig   *kbconfig.ConfigYAMLEnvelope
+	kbCfgPath  string // absolute path of the kb-layer config.yaml (whether or not it exists)
+	userCfg    *config.UserConfig
+	userCfgSrc string // human label for the user layer
+}
+
+// kbConfigResolver lets tests stub the slug→kb_id resolution without standing
+// up a real kb-API client. Production wiring calls resolveKBInputForCmd, which
+// reuses the same dependency tree kb_path.go uses (see kb_resolve.go).
+var kbConfigResolver = func(ctx context.Context, raw string) (string, error) {
+	return resolveKBInputForCmd(ctx, raw)
+}
+
+func loadKBConfigContext(cmd *cobra.Command) (*kbConfigContext, error) {
+	stderr := cmd.ErrOrStderr()
+
+	kbFlag, _ := cmd.Flags().GetString("kb")
+	kbFlagRaw := kbFlag // preserve original form for error formatting (`#marketing` vs `marketing`).
+	kbFlag = strings.TrimSpace(kb.NormalizeSlugArg(kbFlag))
+
+	var kbID string
+	if kbFlag != "" {
+		// Accept kb_id, bare slug, or `#slug`. The shared resolver in
+		// kb_resolve.go mirrors `ox kb path` semantics exactly so users get a
+		// uniform --kb argument surface across every kb subcommand.
+		if strings.HasPrefix(kbFlag, "kb_") {
+			kbID = kbFlag
+		} else {
+			resolved, err := kbConfigResolver(cmd.Context(), kbFlagRaw)
+			if err != nil {
+				msg, retErr := formatKBInputError(kbFlagRaw, err)
+				fmt.Fprint(stderr, msg)
+				return nil, retErr
+			}
+			kbID = resolved
+		}
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("get cwd: %w", err)
+		}
+		binding, err := kb.ResolveCurrentKB(cwd)
+		if err != nil {
+			return nil, err
+		}
+		if binding == nil {
+			fmt.Fprintln(stderr, "no current KB. Run from inside a .sageox/-mapped tree, or pass --kb=<slug>.")
+			return nil, cli.ErrSilent
+		}
+		kbID = binding.KBID
+	}
+
+	ctx := &kbConfigContext{kbID: kbID}
+
+	// KB-layer config.yaml lives at <KBDir>/.sageox/config.yaml.
+	ctx.kbCfgPath = filepath.Join(paths.KBDir(kbID), kbconfig.ConfigYAMLPath)
+	if data, err := os.ReadFile(ctx.kbCfgPath); err == nil {
+		env, err := kbconfig.UnmarshalConfigYAML(data)
+		if err != nil {
+			fmt.Fprintf(stderr, "kb config: parse %s: %v\n", ctx.kbCfgPath, err)
+			return nil, cli.ErrSilent
+		}
+		ctx.kbConfig = env
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read %s: %w", ctx.kbCfgPath, err)
+	}
+
+	// User layer.
+	userCfg, _ := config.LoadUserConfig()
+	if userCfg == nil {
+		userCfg = &config.UserConfig{}
+	}
+	ctx.userCfg = userCfg
+	if envPath := os.Getenv(config.EnvUserConfig); envPath != "" {
+		ctx.userCfgSrc = envPath
+	} else {
+		ctx.userCfgSrc = filepath.Join(config.GetUserConfigDir(), "config.yaml")
+	}
+
+	// KBType: best-effort. v1 stays offline — defaults that depend on type
+	// (session_recording for personal/team/repo = auto, else manual) fall back
+	// to DefaultSessionRecordingMode("") which is manual. Users on personal/
+	// team/repo bubbles can still see the value via the kb-layer column when
+	// it's set explicitly; the `default` column reads "manual" in v1.
+	ctx.kbType = ""
+
+	return ctx, nil
+}
+
+// extractLayerValue returns the value for a known key at a single layer.
+// Empty string means "not set at this layer".
+func extractLayerValue(key, scope string, ctx *kbConfigContext) string {
+	switch key {
+	case kb.KeySessionRecordingMode:
+		switch scope {
+		case kb.LayerScopeEnv:
+			return os.Getenv(config.EnvSessionRecording)
+		case kb.LayerScopeKB:
+			if ctx.kbConfig == nil {
+				return ""
+			}
+			m := ctx.kbConfig.Features.SessionRecording.Mode
+			if m == nil {
+				return ""
+			}
+			return *m
+		case kb.LayerScopeUser:
+			if ctx.userCfg == nil || ctx.userCfg.Sessions == nil {
+				return ""
+			}
+			mode := ctx.userCfg.Sessions.GetMode()
+			if mode == "none" {
+				// "none" is the SessionsConfig zero-value, not an opt-out.
+				return ""
+			}
+			return mode
+		case kb.LayerScopeDefault:
+			return kbconfig.DefaultSessionRecordingMode(ctx.kbType)
+		}
+	case kb.KeyMurmursEnabled:
+		switch scope {
+		case kb.LayerScopeKB:
+			if ctx.kbConfig == nil || ctx.kbConfig.Features.Murmurs.Enabled == nil {
+				return ""
+			}
+			if *ctx.kbConfig.Features.Murmurs.Enabled {
+				return "true"
+			}
+			return "false"
+		}
+		return ""
+	case kb.KeyVisibility:
+		switch scope {
+		case kb.LayerScopeKB:
+			if ctx.kbConfig == nil {
+				return ""
+			}
+			return ctx.kbConfig.Features.Visibility
+		case kb.LayerScopeDefault:
+			return kbconfig.VisibilityPrivate
+		}
+		return ""
+	}
+	return ""
+}
+
+// labelSource returns the human-readable source string for a layer.
+func (ctx *kbConfigContext) labelSource(key, scope string) string {
+	switch scope {
+	case kb.LayerScopeEnv:
+		if key == kb.KeySessionRecordingMode {
+			return config.EnvSessionRecording
+		}
+		return ""
+	case kb.LayerScopeKB:
+		return ctx.kbCfgPath
+	case kb.LayerScopeUser:
+		return ctx.userCfgSrc
+	case kb.LayerScopeDefault:
+		return "built-in default"
+	}
+	return ""
+}
+
+func resolveOneKey(key string, ctx *kbConfigContext) kb.EffectiveValue {
+	envVal := extractLayerValue(key, kb.LayerScopeEnv, ctx)
+	kbVal := extractLayerValue(key, kb.LayerScopeKB, ctx)
+	userVal := extractLayerValue(key, kb.LayerScopeUser, ctx)
+	defaultVal := extractLayerValue(key, kb.LayerScopeDefault, ctx)
+
+	ev := kb.ResolveEffective(key, envVal, kbVal, userVal, defaultVal)
+	// Stamp human source labels.
+	for i := range ev.Layers {
+		ev.Layers[i].Source = ctx.labelSource(key, ev.Layers[i].Scope)
+	}
+	return ev
+}
+
+func runKBConfigGet(cmd *cobra.Command, args []string) error {
+	stderr := cmd.ErrOrStderr()
+	stdout := cmd.OutOrStdout()
+
+	key := args[0]
+	if !kb.IsKnownKey(key) {
+		fmt.Fprintf(stderr, "error: unknown key %q. Known keys: %s\n", key, strings.Join(kb.KnownKeys, ", "))
+		return cli.ErrSilent
+	}
+
+	ctx, err := loadKBConfigContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	ev := resolveOneKey(key, ctx)
+
+	at, _ := cmd.Flags().GetString("at")
+	showOrigin, _ := cmd.Flags().GetBool("show-origin")
+	jsonMode, _ := cmd.Flags().GetBool("json")
+
+	if at != "" {
+		var atVal string
+		var matched bool
+		for _, l := range ev.Layers {
+			if l.Scope == at {
+				atVal = l.Value
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			fmt.Fprintf(stderr, "error: unknown scope %q. Valid: env, kb, user, default\n", at)
+			return cli.ErrSilent
+		}
+		if jsonMode {
+			return writeJSON(stdout, map[string]any{
+				"key":   key,
+				"scope": at,
+				"value": atVal,
+				"kb_id": ctx.kbID,
+			})
+		}
+		fmt.Fprintln(stdout, atVal)
+		return nil
+	}
+
+	if jsonMode {
+		return writeJSON(stdout, jsonEffective(ctx.kbID, ev))
+	}
+
+	if showOrigin {
+		writeShowOrigin(stdout, ev)
+		return nil
+	}
+
+	fmt.Fprintln(stdout, ev.Effective)
+	return nil
+}
+
+func runKBConfigList(cmd *cobra.Command, args []string) error {
+	stdout := cmd.OutOrStdout()
+
+	ctx, err := loadKBConfigContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	keys := append([]string(nil), kb.KnownKeys...)
+	sort.Strings(keys)
+
+	showOrigin, _ := cmd.Flags().GetBool("show-origin")
+	jsonMode, _ := cmd.Flags().GetBool("json")
+
+	results := make([]kb.EffectiveValue, 0, len(keys))
+	for _, k := range keys {
+		results = append(results, resolveOneKey(k, ctx))
+	}
+
+	if jsonMode {
+		out := map[string]any{
+			"kb_id": ctx.kbID,
+			"keys":  make([]any, 0, len(results)),
+		}
+		arr := out["keys"].([]any)
+		for _, ev := range results {
+			arr = append(arr, jsonEffective("", ev))
+		}
+		out["keys"] = arr
+		return writeJSON(stdout, out)
+	}
+
+	for i, ev := range results {
+		if showOrigin {
+			if i > 0 {
+				fmt.Fprintln(stdout)
+			}
+			writeShowOrigin(stdout, ev)
+			continue
+		}
+		fmt.Fprintf(stdout, "%s=%s\n", ev.Key, ev.Effective)
+	}
+	return nil
+}
+
+func writeShowOrigin(w io.Writer, ev kb.EffectiveValue) {
+	fmt.Fprintf(w, "%s=%s\n", ev.Key, ev.Effective)
+	// Determine winning scope (first layer whose value equals Effective and is non-empty).
+	winnerIdx := -1
+	for i, l := range ev.Layers {
+		if l.Value != "" && l.Value == ev.Effective {
+			winnerIdx = i
+			break
+		}
+	}
+	// If safety inversion fired and no non-empty layer matches (e.g. effective
+	// came purely from kbconfig.ResolveEffectiveMode logic), fall back to the
+	// trigger layer.
+	if winnerIdx == -1 {
+		for i, l := range ev.Layers {
+			if l.Trigger {
+				winnerIdx = i
+				break
+			}
+		}
+	}
+	for i, l := range ev.Layers {
+		annot := ""
+		switch {
+		case l.Trigger:
+			annot = " [trigger]"
+		case i == winnerIdx:
+			annot = " [winner]"
+		}
+		val := l.Value
+		if val == "" {
+			val = "(unset)"
+		}
+		src := l.Source
+		if src == "" {
+			src = "-"
+		}
+		fmt.Fprintf(w, "  %-7s %s  (%s)%s\n", l.Scope, val, src, annot)
+	}
+	if ev.SafetyInversion {
+		fmt.Fprintln(w, "  note: safety inversion — \"disabled\" on either kb or user layer vetoes the other.")
+	}
+}
+
+func jsonEffective(kbID string, ev kb.EffectiveValue) map[string]any {
+	layers := make([]map[string]any, 0, len(ev.Layers))
+	for _, l := range ev.Layers {
+		layer := map[string]any{
+			"scope":  l.Scope,
+			"source": l.Source,
+			"value":  l.Value,
+		}
+		if l.Trigger {
+			layer["trigger"] = true
+		}
+		layers = append(layers, layer)
+	}
+	out := map[string]any{
+		"key":              ev.Key,
+		"effective":        ev.Effective,
+		"layers":           layers,
+		"safety_inversion": ev.SafetyInversion,
+	}
+	if kbID != "" {
+		out["kb_id"] = kbID
+	}
+	return out
+}
+
+func writeJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/cmd/ox/kb_config.go
+++ b/cmd/ox/kb_config.go
@@ -84,6 +84,10 @@ var kbConfigResolver = func(ctx context.Context, raw string) (string, error) {
 	return resolveKBInputForCmd(ctx, raw)
 }
 
+type kbMetaSummary struct {
+	Type string `json:"type"`
+}
+
 func loadKBConfigContext(cmd *cobra.Command) (*kbConfigContext, error) {
 	stderr := cmd.ErrOrStderr()
 
@@ -150,14 +154,28 @@ func loadKBConfigContext(cmd *cobra.Command) (*kbConfigContext, error) {
 		ctx.userCfgSrc = filepath.Join(config.GetUserConfigDir(), "config.yaml")
 	}
 
-	// KBType: best-effort. v1 stays offline — defaults that depend on type
-	// (session_recording for personal/team/repo = auto, else manual) fall back
-	// to DefaultSessionRecordingMode("") which is manual. Users on personal/
-	// team/repo bubbles can still see the value via the kb-layer column when
-	// it's set explicitly; the `default` column reads "manual" in v1.
-	ctx.kbType = ""
+	// KBType: best-effort from the daemon-written local metadata. This keeps
+	// `ox kb config` offline while still surfacing correct per-type defaults
+	// for synced bubbles.
+	ctx.kbType = loadKBTypeFromMeta(kbID)
 
 	return ctx, nil
+}
+
+func loadKBTypeFromMeta(kbID string) string {
+	if kbID == "" {
+		return ""
+	}
+	metaPath := filepath.Join(paths.KBDir(kbID), ".sageox", "meta.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return ""
+	}
+	var meta kbMetaSummary
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return ""
+	}
+	return meta.Type
 }
 
 // extractLayerValue returns the value for a known key at a single layer.

--- a/cmd/ox/kb_config_test.go
+++ b/cmd/ox/kb_config_test.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/config"
+)
+
+// withKBConfigResolver swaps the package-level resolver used by `ox kb config`
+// for the duration of a test and restores it on Cleanup. Tests use this to
+// avoid hitting the real kb-API (which would require an authenticated
+// endpoint).
+func withKBConfigResolver(t *testing.T, fn func(ctx context.Context, raw string) (string, error)) {
+	t.Helper()
+	prev := kbConfigResolver
+	kbConfigResolver = fn
+	t.Cleanup(func() { kbConfigResolver = prev })
+}
+
+// kb_config_test.go exercises the cobra command surface enough to catch
+// argument-validation and JSON-shape regressions. The deep precedence + safety
+// inversion logic is covered by internal/kb/effective_test.go; these tests
+// focus on the CLI plumbing (unknown key, missing --kb outside a binding, etc.)
+// without requiring a real KB checkout or network call.
+
+func TestKBConfigGet_UnknownKey(t *testing.T) {
+	cmd := newRootForTest(t)
+	out, errOut, err := executeCmd(cmd, "kb", "config", "get", "--kb=kb_test", "features.nope")
+	_ = out
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+	if !strings.Contains(errOut.String(), "unknown key") {
+		t.Errorf("stderr=%q; want 'unknown key'", errOut.String())
+	}
+}
+
+// TestKBConfigGet_BareSlugResolves verifies that `--kb=marketing` (no prefix)
+// is routed through the shared resolver and accepted.
+//
+// Failure prevented: regression to the v1 "kb_id only" behavior that forced
+// users to look up an opaque kb_id before they could read their own config.
+func TestKBConfigGet_BareSlugResolves(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "config.yaml"))
+	t.Setenv(config.EnvSessionRecording, "")
+
+	calls := 0
+	withKBConfigResolver(t, func(_ context.Context, raw string) (string, error) {
+		calls++
+		if raw != "marketing" {
+			t.Errorf("resolver got raw=%q; want %q", raw, "marketing")
+		}
+		return "kb_marketing_resolved", nil
+	})
+
+	cmd := newRootForTest(t)
+	stdout, stderr, err := executeCmd(cmd, "kb", "config", "get", "--kb=marketing", "features.visibility")
+	if err != nil {
+		t.Fatalf("unexpected error: %v; stderr=%q", err, stderr.String())
+	}
+	if calls != 1 {
+		t.Errorf("resolver called %d times; want 1", calls)
+	}
+	// Built-in default for visibility is "private" — proves we resolved a kb
+	// and ran the rest of the pipeline.
+	if got := strings.TrimSpace(stdout.String()); got != "private" {
+		t.Errorf("stdout=%q; want 'private'", got)
+	}
+}
+
+// TestKBConfigGet_HashPrefixedSlugResolves verifies that `--kb=#marketing`
+// is normalized (the `#` is stripped before resolution) and accepted.
+//
+// Failure prevented: copy-pasting a slug from `ox kb list` (which renders
+// slugs as `#name`) would otherwise error out — a confusing DX moment.
+func TestKBConfigGet_HashPrefixedSlugResolves(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "config.yaml"))
+	t.Setenv(config.EnvSessionRecording, "")
+
+	gotRaw := ""
+	withKBConfigResolver(t, func(_ context.Context, raw string) (string, error) {
+		gotRaw = raw
+		return "kb_hash_resolved", nil
+	})
+
+	cmd := newRootForTest(t)
+	_, stderr, err := executeCmd(cmd, "kb", "config", "get", "--kb=#marketing", "features.visibility")
+	if err != nil {
+		t.Fatalf("unexpected error: %v; stderr=%q", err, stderr.String())
+	}
+	// The resolver itself is called with the original form; NormalizeSlugArg
+	// happens inside resolveKBInput.
+	if gotRaw != "#marketing" {
+		t.Errorf("resolver raw arg=%q; want %q", gotRaw, "#marketing")
+	}
+}
+
+// TestKBConfigGet_KBIDBypassesResolver verifies that a kb_*-prefixed argument
+// short-circuits the resolver entirely.
+//
+// Failure prevented: a regression that routes kb_id through the kb-API would
+// break offline / flag-off users for whom kb_id is the documented escape
+// hatch.
+func TestKBConfigGet_KBIDBypassesResolver(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "config.yaml"))
+	t.Setenv(config.EnvSessionRecording, "")
+
+	withKBConfigResolver(t, func(_ context.Context, raw string) (string, error) {
+		t.Fatalf("resolver must not be called for kb_id input; got %q", raw)
+		return "", nil
+	})
+
+	cmd := newRootForTest(t)
+	_, stderr, err := executeCmd(cmd, "kb", "config", "get", "--kb=kb_direct", "features.visibility")
+	if err != nil {
+		t.Fatalf("unexpected error: %v; stderr=%q", err, stderr.String())
+	}
+}
+
+// TestKBConfigGet_UnknownSlug verifies the user-facing error format when the
+// resolver reports kb-not-found.
+//
+// Failure prevented: a typo'd slug returning a confusing internal error
+// instead of the canonical `kb not found: #<slug>` form.
+func TestKBConfigGet_UnknownSlug(t *testing.T) {
+	withKBConfigResolver(t, func(_ context.Context, _ string) (string, error) {
+		return "", errKBNotFound
+	})
+
+	cmd := newRootForTest(t)
+	_, stderr, err := executeCmd(cmd, "kb", "config", "get", "--kb=nonexistent", "features.visibility")
+	if err == nil {
+		t.Fatal("expected error for unknown slug")
+	}
+	if !strings.Contains(stderr.String(), "kb not found: #nonexistent") {
+		t.Errorf("stderr=%q; want 'kb not found: #nonexistent'", stderr.String())
+	}
+}
+
+// TestKBConfigList_SlugAccepted verifies the slug acceptance generalizes to
+// `kb config list` (the spec asks for both commands).
+//
+// Failure prevented: get/list diverging on argument acceptance — they share
+// loadKBConfigContext but a future split could re-introduce drift.
+func TestKBConfigList_SlugAccepted(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "config.yaml"))
+	t.Setenv(config.EnvSessionRecording, "")
+
+	withKBConfigResolver(t, func(_ context.Context, raw string) (string, error) {
+		if raw != "marketing" {
+			t.Errorf("resolver raw=%q; want %q", raw, "marketing")
+		}
+		return "kb_list_resolved", nil
+	})
+
+	cmd := newRootForTest(t)
+	stdout, stderr, err := executeCmd(cmd, "kb", "config", "list", "--kb=marketing", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v; stderr=%q", err, stderr.String())
+	}
+
+	var got struct {
+		KBID string `json:"kb_id"`
+	}
+	if jerr := json.Unmarshal(stdout.Bytes(), &got); jerr != nil {
+		t.Fatalf("json parse: %v\nstdout=%q", jerr, stdout.String())
+	}
+	if got.KBID != "kb_list_resolved" {
+		t.Errorf("kb_id=%q; want kb_list_resolved", got.KBID)
+	}
+}
+
+// TestKBConfigGet_APIUnreachable verifies the helpful error message when the
+// resolver bails on api-unreachable rather than not-found.
+//
+// Failure prevented: users staring at "kb not found" when their network/
+// daemon is the actual problem, with no hint that `--kb=kb_<id>` would work.
+func TestKBConfigGet_APIUnreachable(t *testing.T) {
+	withKBConfigResolver(t, func(_ context.Context, _ string) (string, error) {
+		// Wrap so errors.Is(_, errKBAPIUnreachable) trips in formatKBInputError.
+		return "", wrapForTest(errKBAPIUnreachable, "kb api unreachable: HTTP 500")
+	})
+
+	cmd := newRootForTest(t)
+	_, stderr, err := executeCmd(cmd, "kb", "config", "get", "--kb=marketing", "features.visibility")
+	if err == nil {
+		t.Fatal("expected error when kb-API is unreachable")
+	}
+	if !strings.Contains(stderr.String(), "kb-API unavailable") {
+		t.Errorf("stderr=%q; want hint about kb-API unavailable", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--kb=kb_<id>") {
+		t.Errorf("stderr=%q; want kb_id escape-hatch hint", stderr.String())
+	}
+}
+
+// wrapForTest is a tiny helper to produce errors that satisfy errors.Is(err, target).
+func wrapForTest(target error, msg string) error {
+	return &wrappedTestErr{target: target, msg: msg}
+}
+
+type wrappedTestErr struct {
+	target error
+	msg    string
+}
+
+func (w *wrappedTestErr) Error() string { return w.msg }
+func (w *wrappedTestErr) Unwrap() error { return w.target }
+
+func TestKBConfigGet_DefaultVisibility(t *testing.T) {
+	// Point user config at an empty temp dir so the user layer never lights up.
+	tmp := t.TempDir()
+	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "config.yaml"))
+	t.Setenv(config.EnvSessionRecording, "")
+
+	cmd := newRootForTest(t)
+	stdout, _, err := executeCmd(cmd, "kb", "config", "get", "--kb=kb_test", "features.visibility")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "private" {
+		t.Errorf("stdout=%q; want 'private' (built-in default)", got)
+	}
+}
+
+func TestKBConfigList_JSONShape(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "config.yaml"))
+	t.Setenv(config.EnvSessionRecording, "")
+
+	cmd := newRootForTest(t)
+	stdout, _, err := executeCmd(cmd, "kb", "config", "list", "--kb=kb_test", "--json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got struct {
+		KBID string `json:"kb_id"`
+		Keys []struct {
+			Key       string `json:"key"`
+			Effective string `json:"effective"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json parse: %v\nstdout=%q", err, stdout.String())
+	}
+	if got.KBID != "kb_test" {
+		t.Errorf("kb_id=%q; want kb_test", got.KBID)
+	}
+	if len(got.Keys) != 3 {
+		t.Errorf("len(keys)=%d; want 3 (one per known key)", len(got.Keys))
+	}
+}
+
+func TestKBConfigGet_KBLayerReadsFromConfigYAML(t *testing.T) {
+	// Build a KB checkout with a config.yaml that pins visibility=team, and
+	// point OX endpoint resolution at the temp dir via XDG_DATA_HOME.
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "user-config.yaml"))
+	t.Setenv(config.EnvSessionRecording, "")
+
+	// kb checkout path mirrors paths.KBDir(kbID) layout under XDG.
+	kbDir := filepath.Join(tmp, "sageox", os.Getenv("OX_ENDPOINT"), "kb", "kb_xyz", ".sageox")
+	if os.Getenv("OX_ENDPOINT") == "" {
+		// paths.KBDir nests endpoint slug — accept whatever ends up there.
+		kbDir = ""
+	}
+	if kbDir != "" {
+		if err := os.MkdirAll(kbDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "version: 1\nfeatures:\n  visibility: team\n"
+		if err := os.WriteFile(filepath.Join(kbDir, "config.yaml"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := newRootForTest(t)
+	stdout, _, err := executeCmd(cmd, "kb", "config", "get", "--kb=kb_xyz", "features.visibility")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// We don't assert "team" here because paths.KBDir layout depends on the
+	// endpoint config which is not stable in this test environment. The
+	// assertion that matters is that the command runs cleanly.
+	_ = stdout
+}
+
+// newRootForTest builds a fresh root command tree for a test invocation. The
+// global rootCmd in this package is fine to reuse across tests because cobra
+// resets state in Execute, but we wrap it so SetArgs / SetOut don't bleed.
+func newRootForTest(_ *testing.T) *cobraCommandLike {
+	return &cobraCommandLike{cmd: rootCmd}
+}
+
+type cobraCommandLike struct{ cmd interface{} }
+
+// executeCmd drives the rootCmd cobra surface with the given args, capturing
+// stdout/stderr. It's a thin helper that mirrors patterns used in the
+// existing cmd/ox tests (e.g. kb_path_test.go).
+func executeCmd(c *cobraCommandLike, args ...string) (stdout, stderr *bytes.Buffer, err error) {
+	stdout = &bytes.Buffer{}
+	stderr = &bytes.Buffer{}
+
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	defer func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	}()
+
+	err = rootCmd.ExecuteContext(context.Background())
+	return stdout, stderr, err
+}

--- a/cmd/ox/kb_config_test.go
+++ b/cmd/ox/kb_config_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/stretchr/testify/require"
 )
 
 // withKBConfigResolver swaps the package-level resolver used by `ox kb config`
@@ -263,28 +265,24 @@ func TestKBConfigList_JSONShape(t *testing.T) {
 }
 
 func TestKBConfigGet_KBLayerReadsFromConfigYAML(t *testing.T) {
-	// Build a KB checkout with a config.yaml that pins visibility=team, and
-	// point OX endpoint resolution at the temp dir via XDG_DATA_HOME.
+	// Build a KB checkout with config.yaml pinning visibility=team and assert
+	// that the KB-layer read surfaces "team". Use paths.KBDir as the canonical
+	// helper so the test stays in sync with on-disk layout, and pin a known
+	// endpoint so the path under XDG is deterministic.
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("SAGEOX_ENDPOINT", "test-endpoint")
 	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "user-config.yaml"))
 	t.Setenv(config.EnvSessionRecording, "")
 
-	// kb checkout path mirrors paths.KBDir(kbID) layout under XDG.
-	kbDir := filepath.Join(tmp, "sageox", os.Getenv("OX_ENDPOINT"), "kb", "kb_xyz", ".sageox")
-	if os.Getenv("OX_ENDPOINT") == "" {
-		// paths.KBDir nests endpoint slug — accept whatever ends up there.
-		kbDir = ""
+	kbCfgDir := filepath.Join(paths.KBDir("kb_xyz"), ".sageox")
+	if err := os.MkdirAll(kbCfgDir, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if kbDir != "" {
-		if err := os.MkdirAll(kbDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		body := "version: 1\nfeatures:\n  visibility: team\n"
-		if err := os.WriteFile(filepath.Join(kbDir, "config.yaml"), []byte(body), 0o644); err != nil {
-			t.Fatal(err)
-		}
+	body := "version: 1\nfeatures:\n  visibility: team\n"
+	if err := os.WriteFile(filepath.Join(kbCfgDir, "config.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
 	}
 
 	cmd := newRootForTest(t)
@@ -292,10 +290,35 @@ func TestKBConfigGet_KBLayerReadsFromConfigYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// We don't assert "team" here because paths.KBDir layout depends on the
-	// endpoint config which is not stable in this test environment. The
-	// assertion that matters is that the command runs cleanly.
-	_ = stdout
+	if got := strings.TrimSpace(stdout.String()); got != "team" {
+		t.Fatalf("stdout=%q; want %q", got, "team")
+	}
+}
+
+func TestKBConfigGet_DefaultSessionRecordingUsesLocalKBType(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("SAGEOX_ENDPOINT", "test-endpoint")
+	t.Setenv(config.EnvUserConfig, filepath.Join(tmp, "user-config.yaml"))
+	t.Setenv(config.EnvSessionRecording, "")
+
+	metaDir := filepath.Join(paths.KBDir("kb_personal"), ".sageox")
+	require.NoError(t, os.MkdirAll(metaDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(metaDir, "meta.json"),
+		[]byte(`{"type":"personal","slug":"my-personal"}`),
+		0o644,
+	))
+
+	cmd := newRootForTest(t)
+	stdout, stderr, err := executeCmd(cmd, "kb", "config", "get", "--kb=kb_personal", "features.session_recording.mode")
+	if err != nil {
+		t.Fatalf("unexpected error: %v; stderr=%q", err, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "auto" {
+		t.Fatalf("stdout=%q; want %q", got, "auto")
+	}
 }
 
 // newRootForTest builds a fresh root command tree for a test invocation. The

--- a/cmd/ox/kb_hydrate.go
+++ b/cmd/ox/kb_hydrate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/gitserver"
+	internalkb "github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/spf13/cobra"
@@ -156,7 +157,10 @@ func runKBHydrate(cmd *cobra.Command, args []string) error {
 	if len(args) == 2 {
 		relPath = args[1]
 	}
-	return runKBHydrateWithDeps(cmd, args[0], relPath, jsonMode, projectRoot, deps)
+	// Strip the optional human-display `#` prefix from the slug-or-id arg
+	// before handing it to the resolver; slugs are looked up bare.
+	query := internalkb.NormalizeSlugArg(args[0])
+	return runKBHydrateWithDeps(cmd, query, relPath, jsonMode, projectRoot, deps)
 }
 
 // runKBHydrateWithDeps is the dependency-injected core. Returns cli.ErrSilent
@@ -172,7 +176,11 @@ func runKBHydrateWithDeps(cmd *cobra.Command, query, relPath string, jsonMode bo
 	kb, slug, err := deps.resolveBubble(ctx, query, deps)
 	if err != nil {
 		if errors.Is(err, errKBNotFound) {
-			fmt.Fprintf(stderr, "kb not found: %s\n", query)
+			display := query
+			if !hasKBIDPrefix(query) {
+				display = cli.FormatKBSlug(query)
+			}
+			fmt.Fprintf(stderr, "kb not found: %s\n", display)
 			return cli.ErrSilent
 		}
 		fmt.Fprintf(stderr, "kb hydrate: %v\n", err)
@@ -300,9 +308,15 @@ func writeKBHydrateJSON(w io.Writer, out kbHydrateOutput) error {
 }
 
 func writeKBHydrateHuman(stdout, stderr io.Writer, query, slug string, out kbHydrateOutput) {
+	// Resolved slug wins over the user's original query for display. kb_id
+	// inputs (no resolvable slug) show bare; slug inputs get the human-
+	// display `#` prefix.
 	display := slug
 	if display == "" {
 		display = query
+	}
+	if !hasKBIDPrefix(display) {
+		display = cli.FormatKBSlug(display)
 	}
 	if len(out.Hydrated) == 0 && len(out.Failed) == 0 {
 		fmt.Fprintf(stdout, "Nothing to hydrate in %s\n", display)

--- a/cmd/ox/kb_list.go
+++ b/cmd/ox/kb_list.go
@@ -268,9 +268,13 @@ func kbTypePriority(t api.KBType) int {
 		return 3
 	case api.KBTypeCustom:
 		return 4
+	case api.KBType("channel"):
+		// channel slots between custom and unknown until KBTypeChannel is
+		// promoted into internal/api. Kept in sync with internal/prime/kb.go.
+		return 5
 	default:
 		// "" and KBTypeUnknown
-		return 5
+		return 6
 	}
 }
 
@@ -354,7 +358,8 @@ func printKBListRow(w io.Writer, b kb.Bubble) {
 	typeStr := formatKBType(b.Type, b.Legacy)
 	typeCol := fmt.Sprintf("%-*s", kbListColTypeWidth, truncateForColumn(typeStr, kbListColTypeWidth))
 
-	slugCol := fmt.Sprintf("%-*s", kbListColSlugWidth, truncateForColumn(b.Slug, kbListColSlugWidth))
+	// Human-display form is `#<slug>`; storage and JSON keep the bare slug.
+	slugCol := fmt.Sprintf("%-*s", kbListColSlugWidth, truncateForColumn(cli.FormatKBSlug(b.Slug), kbListColSlugWidth))
 
 	name := b.Name
 	if name == "" {

--- a/cmd/ox/kb_path.go
+++ b/cmd/ox/kb_path.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/spf13/cobra"
 )
@@ -153,7 +154,10 @@ func runKBPathWithDeps(cmd *cobra.Command, query string, jsonMode bool, deps kbP
 	stdout := cmd.OutOrStdout()
 	stderr := cmd.ErrOrStderr()
 
-	query = strings.TrimSpace(query)
+	// Strip the optional human-display `#` prefix; resolvers look slugs up
+	// bare. STDOUT of this command MUST stay bare regardless (shell
+	// composition); only the input is normalized.
+	query = strings.TrimSpace(kb.NormalizeSlugArg(query))
 	if query == "" {
 		fmt.Fprintln(stderr, "kb path: argument is required")
 		return cli.ErrSilent
@@ -165,8 +169,14 @@ func runKBPathWithDeps(cmd *cobra.Command, query string, jsonMode bool, deps kbP
 	kb, err := resolveKB(ctx, query, deps)
 	if err != nil {
 		// kb-not-found: the canonical message format the spec asks for.
+		// Stderr only — stdout stays empty so a failed `$(ox kb path ...)`
+		// substitutes the empty string, not a help message.
 		if errors.Is(err, errKBNotFound) {
-			fmt.Fprintf(stderr, "kb not found: %s\n", query)
+			display := query
+			if !strings.HasPrefix(query, "kb_") {
+				display = cli.FormatKBSlug(query)
+			}
+			fmt.Fprintf(stderr, "kb not found: %s\n", display)
 			return cli.ErrSilent
 		}
 		fmt.Fprintf(stderr, "kb path: %v\n", err)

--- a/cmd/ox/kb_path_test.go
+++ b/cmd/ox/kb_path_test.go
@@ -249,7 +249,9 @@ func TestKBPath_NotFound(t *testing.T) {
 	if stdout.Len() != 0 {
 		t.Errorf("stdout must stay empty on failure (no half-printed paths), got %q", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "kb not found: missing-slug") {
+	// Canonical not-found uses the human-display `#<slug>` form for
+	// slug-style inputs. Storage and stdout remain bare; this is stderr.
+	if !strings.Contains(stderr.String(), "kb not found: #missing-slug") {
 		t.Errorf("stderr missing canonical not-found message; got %q", stderr.String())
 	}
 }
@@ -318,7 +320,9 @@ func TestKBPath_LegacyFallbackMissesAlsoMissesOverall(t *testing.T) {
 	if stdout.Len() != 0 {
 		t.Errorf("stdout must stay empty on failure, got %q", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "kb not found: totally-missing") {
+	// Canonical not-found uses the human-display `#<slug>` form for
+	// slug-style inputs.
+	if !strings.Contains(stderr.String(), "kb not found: #totally-missing") {
 		t.Errorf("stderr missing canonical not-found message; got %q", stderr.String())
 	}
 	// the internal sentinel must not leak.

--- a/cmd/ox/kb_resolve.go
+++ b/cmd/ox/kb_resolve.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/kb"
+)
+
+// kb_resolve.go centralizes the "user-supplied --kb argument → kb_id" mapping
+// used by every `ox kb <verb>` command. It mirrors the resolution rules
+// implemented in kb_path.go (kb_* prefix → direct, otherwise → kb-API lookup
+// with legacy fallback) so the surface area users see is uniform regardless
+// of which subcommand they invoked.
+//
+// Why a shared helper rather than per-command inlining: when kb_config landed
+// it accepted only kb_*-prefixed inputs, while kb_path accepted bare slugs
+// and `#`-prefixed slugs. The divergence was a DX bug — users who learned
+// `ox kb path #marketing` reasonably tried `ox kb config get … --kb=#marketing`
+// and hit a hand-written rejection. Putting one resolver behind both commands
+// is the only way to keep them in sync.
+
+// errKBAPIUnreachable is the user-facing sentinel for "we tried to resolve a
+// slug, but the kb API is unreachable (flag off, offline, 5xx, etc.)". Callers
+// surface it with a help string that points at the kb_id escape hatch.
+var errKBAPIUnreachable = errors.New("kb api unreachable")
+
+// resolveKBInput maps a raw --kb argument (kb_id, bare slug, or "#slug") to a
+// kb_id. The lookup matches kb_path semantics:
+//
+//   - kb_* prefix → returned as-is, no API round trip.
+//   - otherwise → NormalizeSlugArg + kb-API ListBubbles, with legacy
+//     team-context fallback when the API is unavailable.
+//
+// Returns errKBNotFound if no resolver/legacy entry matches, or
+// errKBAPIUnreachable if every available path requires the kb API and the
+// API itself failed in a way the legacy fallback couldn't paper over.
+func resolveKBInput(ctx context.Context, raw string, deps kbPathDeps) (string, error) {
+	normalized := strings.TrimSpace(kb.NormalizeSlugArg(raw))
+	if normalized == "" {
+		return "", fmt.Errorf("kb argument is required")
+	}
+
+	// kb_id direct: no API needed, no slug lookup, no legacy fallback. This
+	// keeps `--kb=kb_xxx` fully offline, matching kb_path.go.
+	if strings.HasPrefix(normalized, "kb_") {
+		return normalized, nil
+	}
+
+	resolved, err := resolveKB(ctx, normalized, deps)
+	if err == nil {
+		return resolved.KBID, nil
+	}
+	if errors.Is(err, errKBNotFound) {
+		return "", errKBNotFound
+	}
+	// resolveKB only surfaces non-not-found errors when the kb API failed
+	// with something other than ErrKBAPIUnavailable AND the legacy fallback
+	// didn't satisfy the lookup. From a user's perspective that's "API
+	// unreachable for this slug" — give them the kb_id escape hatch.
+	return "", fmt.Errorf("%w: %w", errKBAPIUnreachable, err)
+}
+
+// resolveKBInputForCmd is the convenience wrapper most callers want: derive
+// the project root, build the default deps, apply a sensible timeout, and
+// return the resolved kb_id. The deps are returned too so callers in test
+// can override them via the lower-level resolveKBInput entry point if needed.
+func resolveKBInputForCmd(parentCtx context.Context, raw string) (string, error) {
+	projectRoot, _ := findProjectRoot()
+	deps := newDefaultKBPathDeps(projectRoot)
+	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
+	defer cancel()
+	return resolveKBInput(ctx, raw, deps)
+}
+
+// formatKBInputError converts a resolveKBInput error into the canonical
+// stderr line(s) the user should see, returning the cli.ErrSilent sentinel
+// so cobra doesn't print its own "Error: …" wrapper on top. `raw` is the
+// original user-supplied argument so the message preserves their input form
+// (e.g. they typed `marketing` → message says `#marketing`).
+func formatKBInputError(raw string, err error) (string, error) {
+	display := cli.FormatKBSlug(strings.TrimSpace(kb.NormalizeSlugArg(raw)))
+	switch {
+	case errors.Is(err, errKBNotFound):
+		return fmt.Sprintf("kb not found: %s\n", display), cli.ErrSilent
+	case errors.Is(err, errKBAPIUnreachable):
+		// Help users out of the wedge: kb_id always works offline, so tell
+		// them that. The "wait for next daemon sync" line nods to the fact
+		// that the daemon eventually refreshes the local kb registry.
+		return fmt.Sprintf(
+			"cannot resolve slug %s — kb-API unavailable. Use --kb=kb_<id> directly, or wait for next daemon sync.\n",
+			display,
+		), cli.ErrSilent
+	default:
+		return fmt.Sprintf("kb config: %v\n", err), cli.ErrSilent
+	}
+}
+
+// Compile-time sanity: api.ErrKBAPIUnavailable wrapping is handled by
+// resolveKB; we only need this constant referenced somewhere in the package
+// to make the linter happy if a future refactor stops using it. Removing
+// this no-op reference is safe.
+var _ = api.ErrKBAPIUnavailable

--- a/cmd/ox/kb_show.go
+++ b/cmd/ox/kb_show.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/spf13/cobra"
 )
@@ -81,7 +82,9 @@ type kbShowOutput struct {
 }
 
 func runKBShow(cmd *cobra.Command, args []string) error {
-	input := strings.TrimSpace(args[0])
+	// Strip the optional human-display `#` prefix before resolution. Slugs
+	// are stored and looked up bare; the prefix is presentation-only.
+	input := strings.TrimSpace(kb.NormalizeSlugArg(args[0]))
 	if input == "" {
 		return fmt.Errorf("kb identifier required\nUsage: ox kb show <slug|id>")
 	}
@@ -147,13 +150,13 @@ func resolveKBIdentifier(ctx context.Context, client *api.KBClient, input string
 
 	matches := filterKBsBySlug(bubbles, input)
 	if len(matches) == 0 {
-		return "", fmt.Errorf("no knowledge bubble found matching %q\nRun 'ox kb list' to see available bubbles", input)
+		return "", fmt.Errorf("no knowledge bubble found matching %q\nRun 'ox kb list' to see available bubbles", cli.FormatKBSlug(input))
 	}
 
 	chosen := pickKBByPriority(matches)
 	if chosen == nil {
 		// shouldn't happen given non-empty matches, but guard anyway
-		return "", fmt.Errorf("no knowledge bubble found matching %q", input)
+		return "", fmt.Errorf("no knowledge bubble found matching %q", cli.FormatKBSlug(input))
 	}
 	return chosen.KBID, nil
 }
@@ -226,7 +229,13 @@ func handleKBShowError(w io.Writer, err error, input string, jsonOutput bool) er
 	// not "this specific id doesn't exist"). Detect by content so the
 	// user gets actionable copy.
 	if strings.Contains(err.Error(), "HTTP 404") {
-		return fmt.Errorf("no knowledge bubble found matching %q\nRun 'ox kb list' to see available bubbles", input)
+		// kb_id-prefixed inputs are immutable identifiers — show them bare.
+		// Slug-style inputs get the human-display `#` prefix.
+		display := input
+		if !strings.HasPrefix(input, kbIDPrefix) {
+			display = cli.FormatKBSlug(input)
+		}
+		return fmt.Errorf("no knowledge bubble found matching %q\nRun 'ox kb list' to see available bubbles", display)
 	}
 	return err
 }
@@ -245,7 +254,7 @@ func renderKBShow(w io.Writer, bubble *api.KB, localPath, ep string) {
 		fmt.Fprintf(w, "  %s %s\n", keyStyle.Render("type:            "), string(bubble.KBType))
 	}
 	if bubble.Slug != "" {
-		fmt.Fprintf(w, "  %s %s\n", keyStyle.Render("slug:            "), bubble.Slug)
+		fmt.Fprintf(w, "  %s %s\n", keyStyle.Render("slug:            "), cli.FormatKBSlug(bubble.Slug))
 	}
 	if bubble.Name != "" {
 		fmt.Fprintf(w, "  %s %s\n", keyStyle.Render("name:            "), bubble.Name)

--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -64,6 +64,7 @@ var statusBubblesTypeOrder = []api.KBType{
 	api.KBTypeTeam,
 	api.KBTypeRepo,
 	api.KBTypeCustom,
+	api.KBType("channel"),
 	api.KBTypeUnknown,
 }
 

--- a/docs/adr/ADR-017-kb-as-workspace-primitive.md
+++ b/docs/adr/ADR-017-kb-as-workspace-primitive.md
@@ -1,0 +1,170 @@
+# ADR-017: Knowledge Bubble (KB) as the Unifying Workspace Primitive
+
+**Status**: Proposed
+**Date**: 2026-05-18
+
+## Context
+
+ox today has two implicit, separately-modeled concepts of "where am I working":
+
+1. **Legacy ledger binding.** A directory tree with a `.sageox/` directory at its root is bound to a `repo_id`, which in turn resolves to a per-project ledger git repo on disk. Session recording, murmurs, and several other behaviors target that ledger. The discovery rule is a classic path-walk: walk up from `cwd` looking for `.sageox/`, read `repo_id` from `.sageox/config.json`, and use that. Outside any such tree, the behaviors silently no-op (no session recording, no murmur target).
+
+2. **Knowledge Bubble (KB) catalog.** A newer, unified surface where every piece of structured knowledge — personal scratchpad, team conventions, public profile, repo-specific archive (the ledger!), and ad-hoc custom bubbles — is a row in a single typed table (`KBType ∈ {personal, profile, team, repo, custom}`). KBs are auto-synced by the daemon, sparse-checked-out under `~/.local/share/sageox/<endpoint>/kb/<kb_id>/`, and listed by `ox kb list`. See ADR-006 (context fallback layers) and the recent KB CLI work (`feat(kb): unified kb CLI with personal + clone parity`, #595).
+
+These two models overlap on exactly one point: the legacy ledger is, conceptually, a `kb_type=repo` KB. Everywhere else they diverge — a personal KB has no "directory I can `cd` into and have it become my recording target"; a team KB cannot be the target of `ox session start` from within the team KB's own working tree; a non-git directory cannot be tagged as belonging to any KB at all.
+
+The divergence is starting to cause concrete pain:
+
+- **`ox-43q0.3`** ("Add KB-API tier to `ResolveSessionRecording` precedence chain") assumes a function exists that returns "which KB does this session belong to." None exists for non-repo KB types — the implementation silently delegates to the legacy ledger lookup, which only handles `kb_type=repo`.
+- **`ox-xkr3`** ("ox agent prime — narrative guidance for KBs") wants `ox agent prime` to tell the agent which KB it is currently operating inside. Today the envelope lists all available KBs but cannot answer "which one is current?" outside of a git-rooted project.
+- **`ox-43q0`** (epic: unified KB config like `git config`) explicitly models `.sageox/config.yaml` as the per-KB local-config layer, but only if the KB happens to have a directory at the user's CWD root. Personal and team KBs have no such anchor today.
+- The forward-looking case the founder raised: a future where a directory tree can be bound to a KB without containing a `.git` repository at all (a scratch dir, a documentation subtree, a Conductor parent workspace).
+
+The honest framing: **what we called "the ledger" was always a KB — specifically a `kb_type=repo` KB — we just hadn't yet recognized the general type**. The path-walk algorithm and the "outside the tree → silent no-op" semantics were correct then and remain correct; what's changed is our understanding of the population being resolved against. The ledger was the first concrete instance of a primitive we hadn't yet named. Continuing to layer additional KB types on top of a ledger-shaped resolver — without promoting the resolver to operate over KBs generally — guarantees that every new KB-type-aware behavior either reimplements the path-walk or special-cases `kb_type=repo`.
+
+## Decision
+
+Adopt **Knowledge Bubble (KB) as the canonical workspace primitive**, with a single resolver that maps any path on disk to its bound KB (or `nil`).
+
+### 1. "Current KB" is a first-class concept
+
+Introduce `kb.ResolveCurrentKB(cwd string) (*KBBinding, error)` in `internal/kb/resolve.go`. The function walks upward from `cwd` searching for KB-binding markers and returns the first one found, or `(nil, nil)` if none.
+
+```go
+type KBBinding struct {
+    KBID       string  // kb_xxx — immutable identifier
+    KBType     string  // personal | profile | team | repo | custom
+    Source     string  // ".sageox/config.yaml" | ".sageox/config.json"
+    Anchor     string  // absolute path of the marker that bound this tree
+    Scope      string  // "exclusive" (default) | "subtree" (reserved; see §6)
+}
+```
+
+The return value is the only sanctioned answer to "which KB am I operating against?" — across session recording, murmurs, prime envelopes, and any future KB-scoped behavior. Outside any KB-bound tree, the resolver returns `(nil, nil)` and the caller must implement the no-op fallback.
+
+### 2. One marker shape: the `.sageox/` directory
+
+The resolver looks for exactly one marker — a directory named `.sageox/` containing
+a `config.yaml` file with at minimum a `kb_id` field. The same shape covers both
+workspace and binding-only trees; the difference is what *else* lives inside the
+directory, not the marker shape.
+
+| Tree | Minimum `.sageox/` payload | Additional payload (workspace) |
+|------|---------------------------|--------------------------------|
+| Binding-only | `config.yaml` with `kb_id: kb_xxx` | (none) |
+| Workspace | `config.yaml` with `kb_id: kb_xxx` | `cache/`, `ledger/`, `kb/<slug>` symlinks, indexing artifacts |
+
+The resolver tries marker formats in priority order within a directory before
+walking to the parent:
+
+1. `.sageox/config.yaml` (current)
+2. `.sageox/config.json` (legacy; readable for a deprecation window; see §7)
+
+There is no separate `SAGEOX.yml`-style file marker. Callers that need to
+distinguish workspace from binding-only call `KBBinding.IsWorkspace()` (returns
+true if `cache/` or other workspace-only paths exist alongside `config.yaml`).
+
+### 3. The binding's payload is minimal
+
+The marker carries the minimum content needed to resolve to a KB and nothing more:
+
+```yaml
+# .sageox/config.yaml (minimum)
+kb_id: kb_01H...
+
+# .sageox/config.yaml (with explicit endpoint — for multi-endpoint users)
+kb_id: kb_01H...
+endpoint: sageox.ai
+```
+
+The `endpoint:` field is optional. If absent, the resolver uses the user's current default endpoint via `endpoint.Get()`. Multi-endpoint users (running prod and dev simultaneously) include the field to disambiguate which endpoint owns the `kb_id`; single-endpoint users omit it. A new doctor check `kb-binding-endpoint-mismatch` surfaces ambiguity (binding's `endpoint:` differs from the user's default, or `endpoint:` is absent but the `kb_id` is not resolvable under the default endpoint), but doctor never auto-rewrites the field — endpoint disambiguation is a user decision.
+
+Workspace `.sageox/config.yaml` files may additionally carry workspace-scoped fields (`repo_id`, ledger settings, indexing options, etc.) as they do today. A binding-only `.sageox/config.yaml` is just `kb_id` (and optionally `endpoint`).
+
+### 4. Behaviors that resolve through `ResolveCurrentKB`
+
+The following behaviors switch from their current type-specific lookups to the unified resolver:
+
+| Behavior                          | Today                                                                   | After ADR-017                                                                |
+|-----------------------------------|-------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| Session recording target          | Path-walk for `.sageox/` → `repo_id` → legacy ledger                    | `ResolveCurrentKB(cwd)` → KB. Records into that KB, regardless of type.      |
+| Auto-recording on/off             | Recording enabled iff inside a `.sageox/` tree                          | Recording enabled iff `ResolveCurrentKB(cwd) != nil`. Same semantics, broader reach. |
+| Murmur target                     | Legacy ledger only                                                      | Current KB (any type).                                                       |
+| `ox agent prime` envelope         | Emits all KBs; agent does not know which is "current"                   | Adds `current_kb` field populated from `ResolveCurrentKB(cwd)`.              |
+| `ox kb config` local layer        | `.sageox/config.yaml` (only inside a project root)                      | Read-only resolution from the binding's KB layer (`.sageox/config.yaml`) via `ox kb config get/list`. Writes happen via hand-edit + git push or the web UI; ox does not mediate writes. |
+| `config.IsInitialized(root)`      | Returns bool                                                            | Retained for callers that need workspace-vs-binding distinction; new callers prefer `ResolveCurrentKB`. |
+
+### 5. Daemon spawn semantics
+
+The ox daemon is per-workspace today, keyed by `workspace_id = hash(repo_id)`
+(see ADR-002 §1). With `.sageox/` now also marking binding-only trees, the
+question is whether binding-only trees also spawn daemons. They do not.
+
+| Tree resolved by `ResolveCurrentKB` | `ox agent prime` behavior |
+|------------------------------------|----------------------------|
+| nil (no marker found) | Status `unavailable`. No daemon. |
+| Workspace `.sageox/` | Spawn per-workspace daemon as today. Daemon may also hold the per-(user, endpoint) global-sync lease (see daemon-debate). |
+| Binding-only `.sageox/` | Do NOT spawn a daemon. If any workspace daemon for this endpoint is alive on the machine, rely on it for global sync. Otherwise fire `ox kb sync --all --quiet &` as a one-shot subprocess and return. |
+
+Rationale: binding-only trees have no local state requiring a long-lived
+process (no ledger, no code index, no session recording state). Spawning a
+daemon per binding-only tree multiplies daemon processes for no benefit. The
+leader-election lease (daemon-debate PR2) ensures one workspace daemon per
+endpoint handles global sync; binding-only trees consume that daemon's output.
+The one-shot fallback covers the case where the user has no workspace open
+on the machine.
+
+### 6. Subtree overrides — design space reserved, implementation deferred
+
+A nested `.sageox/` directory inside another `.sageox/`-rooted tree should be able to remap a subtree to a different KB (e.g. `docs/.sageox/` binding `docs/` to a team-docs KB while the rest of the repo binds to the repo KB). The `KBBinding.Scope` field reserves this design space (`"subtree"`), but the v1 implementation rejects subtree overrides with a clear error. The semantics — what about nested subtree overrides, what about session-state that straddles a boundary — are non-trivial and worth getting right separately.
+
+### 7. Backward compatibility
+
+- `.sageox/config.json` (legacy JSON, repo-only) continues to resolve correctly. The resolver reads `repo_id` from it and synthesizes a `kb_type=repo` `KBBinding` from the merger's ledger-legacy row.
+- Every code path that today calls `config.IsInitialized(root)` keeps working — the function is unchanged. New code that needs the *identity* of the current KB calls `ResolveCurrentKB` instead.
+- No on-disk file is renamed or moved. Existing `.sageox/` directories keep working; binding-only trees use the same `.sageox/` marker shape with a minimum `config.yaml` payload.
+
+## Consequences
+
+### Benefits
+
+- **One mental model.** "Which KB am I in?" has a single answer derived from one resolver. Ledger discovery is no longer a special case; it is the `kb_type=repo` branch of the resolver's output.
+- **Session recording becomes uniform.** `ox session start` inside `$(ox kb path team-conventions)` records into the team bubble — the same way it records into the project ledger today. No new code path per KB type.
+- **Non-git workspaces become first-class.** A scratch directory with a `.sageox/config.yaml` binding is now a legitimate place to do recorded work. Conductor parent dirs, doc trees, learning sandboxes, anywhere a `.git/` would feel heavyweight.
+- **Prime gets stronger.** Adding `current_kb` to the prime envelope answers the question "where does my work go right now?" — a much stronger handoff than the today's flat list of available KBs.
+- **Future-proofs the KB config epic.** `ox-43q0` (`kb config` like `git config`) gets the precedence chain it needs: `defaults → user → KB-API → local marker → env`, with "local marker" being whichever of the two formats the resolver found.
+- **Cheaper to add KB-aware features.** Anything that needs "current KB context" becomes a one-line call instead of a path-walk reimplementation.
+
+### Tradeoffs
+
+- **Two file formats means two parser paths.** The resolver must handle `.sageox/config.yaml` and `.sageox/config.json` (legacy). Each format we accept is a place a bug can live. Mitigated by routing both through a single `loadBinding(path)` helper that returns a normalized `KBBinding`.
+- **Subtree overrides will be tempting before they are ready.** Reserving the design space (`Scope` field) creates a forward-compatibility contract that limits future flexibility. Acceptable because rejecting `subtree` in v1 keeps the door open and doesn't ship broken semantics.
+- **More places for a misconfigured marker to break things.** A user who hand-writes a `.sageox/config.yaml` with a non-existent `kb_id` gets "no current KB" behavior even though a marker exists. Doctor must surface this: new check `kb-binding-invalid` that detects markers referencing unknown `kb_id`s and offers to fix or remove. Auto-fix level `CheckOnly` (this is user-authored content; we don't silently rewrite it).
+- **The legacy `repo_id`-in-`.sageox/config.json` model is now load-bearing for slightly less.** That field used to be the only thing that mattered for binding; now it's one resolver input alongside `kb_id`. The deprecation path for `.sageox/config.json` becomes slightly more delicate because it now interacts with the resolver, not just session recording.
+
+### Risks explicitly accepted
+
+- Users who have hand-written tooling that greps for `.sageox/config.json` will not see `.sageox/config.yaml` markers. We accept this — third-party tooling can adopt the new format on its own schedule.
+- The resolver walks the filesystem on every `ox` command that needs current-KB context. We accept the cost (it's the same walk we do today) and will revisit caching if profiling shows it.
+
+## Implementation tracking
+
+This ADR establishes the *concept*. Implementation is decomposed across beads:
+
+- **`ox: internal/kb.ResolveCurrentKB resolver + .sageox/ marker parsing`** — the resolver itself, with `KBBinding` type and path-walk logic.
+- **`ox: vendor KBConfig Go types + KBTypeChannel + drift detector`** — supersedes ox-43q0.1; vendors the canonical Go schema from sageox-mono, pre-ships KBTypeChannel, includes the drift-detection script.
+- **`ox: ox kb config get/list with --show-origin/--at/--json`** — supersedes ox-43q0.5; read-only CLI for inspecting effective config. No `set` verb.
+- **`ox: ResolveSessionRecording integrates ResolveCurrentKB + safety inversion`** — supersedes ox-43q0.3.
+- **`ox: prime envelope adds current_kb field`** — extends ox-xkr3.
+- **`ox: ox doctor migration of project-side .sageox/config.json → .yaml`** — extends ox-43q0.4 with the (D) hybrid-read + staged-deprecation timeline.
+- **`fix(kb): cross-process flock guards on shared KB working trees`** — daemon-debate PR1; closes the Tier 1 silent-corruption race.
+- **`feat(daemon): leader-elect per-(user, endpoint) global-sync owner via flock lease`** — daemon-debate PR2; closes the redundant-sync problem without adding a global daemon flavor.
+- **`[HUMAN] kb config: revisit committed_at + banner with mono team`** — cross-repo pushback; the in-file `committed_at` and banner are redundant with git metadata and bloat hand-edits.
+
+## References
+
+- ADR-006: Context Fallback Layers — established the precedence model that this ADR extends to apply to KB-resolution.
+- `internal/kb/merge.go` — three-source merger (kb-API + team-legacy + ledger-legacy) whose output is the population this ADR's resolver maps a directory to.
+- `internal/paths/paths.go:514-600` — canonical KB on-disk layout (`KBDir`, `ProjectKBLink`).
+- `cmd/ox/agent_prime.go:2071-2093` — `buildPrimeKBEnvelope`, which gains the `current_kb` field per §4.
+- Beads epic `ox-43q0` — KB config (like `git config`) — the implementation track for the unified config layer this ADR's binding format participates in.

--- a/internal/api/kbconfig/constants.go
+++ b/internal/api/kbconfig/constants.go
@@ -1,0 +1,45 @@
+package kbconfig
+
+// Session recording modes. Text slugs per project convention (no enums).
+// These mirror sageox-mono's packages/kb/config.go constants. Drift checked
+// by scripts/check-kbconfig-drift.sh.
+const (
+	SessionRecordingAuto     = "auto"
+	SessionRecordingManual   = "manual"
+	SessionRecordingDisabled = "disabled"
+)
+
+// ValidSessionRecordingModes is the closed set of allowed values.
+var ValidSessionRecordingModes = []string{
+	SessionRecordingAuto,
+	SessionRecordingManual,
+	SessionRecordingDisabled,
+}
+
+// Visibility values. Text slugs per project convention (no enums).
+const (
+	VisibilityPrivate = "private"
+	VisibilityTeam    = "team"
+)
+
+// ValidVisibilities is the closed set of allowed visibility slugs.
+var ValidVisibilities = []string{VisibilityPrivate, VisibilityTeam}
+
+// KB type constants vendored from mono. The canonical ox KBType definition
+// lives in internal/api/kb.go (typed as api.KBType); this package keeps a
+// parallel set of untyped string constants so kbconfig-internal logic
+// (defaults, validation, drift) doesn't pull in the api package and create
+// an import cycle.
+//
+// KBTypeChannel is pre-shipped here ahead of mono's channel rollout per
+// /grill-me Q12: defaulting unknown-type-to-manual is the privacy-safe
+// behavior, but having the constant lets us hard-code the expected default
+// and exercise it in tests.
+const (
+	KBTypePersonal = "personal"
+	KBTypeProfile  = "profile"
+	KBTypeTeam     = "team"
+	KBTypeRepo     = "repo"
+	KBTypeCustom   = "custom"
+	KBTypeChannel  = "channel" // pre-shipped before mono rollout
+)

--- a/internal/api/kbconfig/defaults.go
+++ b/internal/api/kbconfig/defaults.go
@@ -1,0 +1,27 @@
+package kbconfig
+
+// DefaultSessionRecordingMode returns the per-KB-type default recording mode.
+// Mirrors mono's packages/kb/config.go DefaultSessionRecordingMode byte-for-byte.
+//
+// Work surfaces default to auto (personal, team, repo) — these are the
+// bubbles people actively work *in* and recording is the value.
+//
+// Presence surfaces default to manual (profile, custom, channel) — these are
+// curated public/broadcast bubbles where silent auto-recording would
+// surprise contributors.
+//
+// Unknown / forward-compat KB types fall through to manual: when in doubt,
+// the privacy-safer choice is to require an explicit opt-in to recording.
+//
+// Changing a default here flips behavior for every bubble that omits the
+// field. Don't move a type from manual to auto without a comms plan and a
+// one-shot migration that stamps the previous default into still-unset rows.
+func DefaultSessionRecordingMode(kbType string) string {
+	switch kbType {
+	case KBTypePersonal, KBTypeTeam, KBTypeRepo:
+		return SessionRecordingAuto
+	case KBTypeProfile, KBTypeCustom, KBTypeChannel:
+		return SessionRecordingManual
+	}
+	return SessionRecordingManual
+}

--- a/internal/api/kbconfig/defaults_test.go
+++ b/internal/api/kbconfig/defaults_test.go
@@ -1,0 +1,34 @@
+package kbconfig
+
+import "testing"
+
+func TestDefaultSessionRecordingMode_PerType(t *testing.T) {
+	cases := map[string]string{
+		KBTypePersonal: SessionRecordingAuto,
+		KBTypeTeam:     SessionRecordingAuto,
+		KBTypeRepo:     SessionRecordingAuto,
+		KBTypeProfile:  SessionRecordingManual,
+		KBTypeCustom:   SessionRecordingManual,
+		KBTypeChannel:  SessionRecordingManual,
+	}
+	for kt, want := range cases {
+		t.Run(kt, func(t *testing.T) {
+			if got := DefaultSessionRecordingMode(kt); got != want {
+				t.Errorf("DefaultSessionRecordingMode(%q) = %q, want %q", kt, got, want)
+			}
+		})
+	}
+}
+
+// TestDefaultSessionRecordingMode_UnknownTypeFallsBackToManual asserts the
+// privacy-safe fallback for forward-compat KB types ox doesn't recognize
+// yet. Manual is the conservative choice — auto-recording an unknown bubble
+// type would surprise contributors.
+func TestDefaultSessionRecordingMode_UnknownTypeFallsBackToManual(t *testing.T) {
+	for _, unknown := range []string{"", "future-type", "garbage", "PERSONAL"} {
+		if got := DefaultSessionRecordingMode(unknown); got != SessionRecordingManual {
+			t.Errorf("DefaultSessionRecordingMode(%q) = %q, want %q (fallback)",
+				unknown, got, SessionRecordingManual)
+		}
+	}
+}

--- a/internal/api/kbconfig/resolve.go
+++ b/internal/api/kbconfig/resolve.go
@@ -1,0 +1,39 @@
+package kbconfig
+
+// ResolveEffectiveMode combines the user-layer and KB-layer recording modes
+// into the single mode that governs a session. THE only function call site
+// for combining recording layers — every consumer (ox CLI session start,
+// daemon recording gate, future MCP handlers) MUST route through here so
+// the safety-inversion invariant cannot be sidestepped.
+//
+// INVARIANT (load-bearing — privacy guarantee):
+//
+//	If EITHER userMode == "disabled" OR kbMode == "disabled", the result is
+//	"disabled". This is a logical OR, NOT a precedence rule. A user opting
+//	out of recording cannot be overridden by a KB admin; a KB admin
+//	disabling recording cannot be overridden by an individual user. Both
+//	sides have veto power. Standard precedence (user > kb) only applies
+//	when neither side is "disabled".
+//
+// Empty string for either layer means "use the other layer's value";
+// callers that want a default should resolve it before calling this
+// function (see DefaultSessionRecordingMode).
+//
+// This function MUST stay byte-identical to mono's
+// packages/kb/config.go ResolveEffectiveMode. Drift here is a security bug;
+// scripts/check-kbconfig-drift.sh runs in CI to catch it.
+func ResolveEffectiveMode(userMode, kbMode string) string {
+	// Safety inversion first — either veto wins regardless of precedence.
+	// Do NOT move this below the precedence logic; the order IS the
+	// semantics.
+	if userMode == SessionRecordingDisabled || kbMode == SessionRecordingDisabled {
+		return SessionRecordingDisabled
+	}
+	// Standard precedence: user-layer wins when set. If user didn't set
+	// anything, fall back to KB-layer. If neither, return empty (caller
+	// should have resolved a default first).
+	if userMode != "" {
+		return userMode
+	}
+	return kbMode
+}

--- a/internal/api/kbconfig/resolve_test.go
+++ b/internal/api/kbconfig/resolve_test.go
@@ -1,0 +1,84 @@
+package kbconfig
+
+import "testing"
+
+// TestResolveEffectiveMode_SafetyInversionMatrix exercises the full 4x4
+// matrix of (userMode, kbMode) combinations across {"", auto, manual,
+// disabled}. The invariant under test is the safety-inversion property:
+// if EITHER side is "disabled", the result is "disabled". Otherwise the
+// user layer wins when non-empty, falling back to the KB layer.
+//
+// This is the privacy-critical test in this package. Any change to
+// ResolveEffectiveMode that breaks a case here is, by construction, a
+// privacy regression — the corresponding test in mono's
+// packages/kb/config_test.go covers the same surface.
+func TestResolveEffectiveMode_SafetyInversionMatrix(t *testing.T) {
+	const empty = ""
+	cases := []struct {
+		userMode string
+		kbMode   string
+		want     string
+	}{
+		// user = ""
+		{empty, empty, empty},
+		{empty, SessionRecordingAuto, SessionRecordingAuto},
+		{empty, SessionRecordingManual, SessionRecordingManual},
+		{empty, SessionRecordingDisabled, SessionRecordingDisabled},
+		// user = auto
+		{SessionRecordingAuto, empty, SessionRecordingAuto},
+		{SessionRecordingAuto, SessionRecordingAuto, SessionRecordingAuto},
+		{SessionRecordingAuto, SessionRecordingManual, SessionRecordingAuto},
+		{SessionRecordingAuto, SessionRecordingDisabled, SessionRecordingDisabled},
+		// user = manual
+		{SessionRecordingManual, empty, SessionRecordingManual},
+		{SessionRecordingManual, SessionRecordingAuto, SessionRecordingManual},
+		{SessionRecordingManual, SessionRecordingManual, SessionRecordingManual},
+		{SessionRecordingManual, SessionRecordingDisabled, SessionRecordingDisabled},
+		// user = disabled (veto in all columns)
+		{SessionRecordingDisabled, empty, SessionRecordingDisabled},
+		{SessionRecordingDisabled, SessionRecordingAuto, SessionRecordingDisabled},
+		{SessionRecordingDisabled, SessionRecordingManual, SessionRecordingDisabled},
+		{SessionRecordingDisabled, SessionRecordingDisabled, SessionRecordingDisabled},
+	}
+	if len(cases) != 16 {
+		t.Fatalf("matrix coverage incomplete: have %d cases, want 16", len(cases))
+	}
+	for _, c := range cases {
+		name := "user=" + c.userMode + "/kb=" + c.kbMode
+		if c.userMode == "" {
+			name = "user=empty/kb=" + c.kbMode
+		}
+		if c.kbMode == "" {
+			name = "user=" + c.userMode + "/kb=empty"
+		}
+		if c.userMode == "" && c.kbMode == "" {
+			name = "user=empty/kb=empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			got := ResolveEffectiveMode(c.userMode, c.kbMode)
+			if got != c.want {
+				t.Errorf("ResolveEffectiveMode(%q, %q) = %q, want %q",
+					c.userMode, c.kbMode, got, c.want)
+			}
+		})
+	}
+}
+
+// TestResolveEffectiveMode_DisabledVetoIsCommutative pins down the
+// "either side wins" property symmetrically: swapping the arguments must
+// not change the disabled outcome.
+func TestResolveEffectiveMode_DisabledVetoIsCommutative(t *testing.T) {
+	pairs := [][2]string{
+		{SessionRecordingDisabled, SessionRecordingAuto},
+		{SessionRecordingDisabled, SessionRecordingManual},
+		{SessionRecordingDisabled, ""},
+	}
+	for _, p := range pairs {
+		if ResolveEffectiveMode(p[0], p[1]) != SessionRecordingDisabled {
+			t.Errorf("ResolveEffectiveMode(%q, %q) lost veto", p[0], p[1])
+		}
+		if ResolveEffectiveMode(p[1], p[0]) != SessionRecordingDisabled {
+			t.Errorf("ResolveEffectiveMode(%q, %q) lost veto (swapped)", p[1], p[0])
+		}
+	}
+}

--- a/internal/api/kbconfig/types.go
+++ b/internal/api/kbconfig/types.go
@@ -1,0 +1,90 @@
+// Package kbconfig vendors the canonical KBConfig Go types from sageox-mono's
+// packages/kb/config.go into the ox CLI. The mono package is the source of
+// truth — ox imports nothing from mono (mono is not a Go module dependency),
+// so this is a hand-maintained vendored copy.
+//
+// Drift between this file and packages/kb/config.go in mono is a security
+// concern: ResolveEffectiveMode encodes a privacy invariant (safety
+// inversion on session_recording) and field names participate in the wire
+// format read by ox. Run scripts/check-kbconfig-drift.sh on every PR that
+// touches this directory.
+//
+// ox is a READER of the KB config envelope. The mono service writes
+// .sageox/config.yaml during reconcile; the public PATCH /config endpoint
+// validates inputs. ox does NOT write the envelope and does NOT carry the
+// banner-comment generation or the committed_at field on writes.
+package kbconfig
+
+import "time"
+
+// ConfigVersion mirrors mono's packages/kb/config.go ConfigVersion. Bump only
+// when the schema semantics change (additive fields are backward-compatible).
+const ConfigVersion = 1
+
+// KBConfig is the per-bubble dynamic configuration. Two namespaces with
+// different write paths in mono:
+//
+//   - Features (user-facing) — owners toggle these from the KB settings page.
+//   - System (internal)      — set by mono workflows / watchman only.
+//
+// ox reads both namespaces; ox never writes either.
+type KBConfig struct {
+	// Version tracks the schema shape so future migrations can detect old
+	// payloads. Reads tolerate Version==0 (treat as current).
+	Version int `json:"version" yaml:"version"`
+
+	// Features is the user-controllable namespace.
+	Features FeaturesConfig `json:"features" yaml:"features"`
+
+	// System is the internal namespace. Mono mutates it via internal code
+	// paths only; ox treats it as read-only and tolerates new fields.
+	System SystemConfig `json:"system" yaml:"system"`
+}
+
+// FeaturesConfig is the user-facing toggle set. Mirrors mono.
+type FeaturesConfig struct {
+	// Murmurs controls the murmur feature on this bubble.
+	Murmurs MurmursConfig `json:"murmurs" yaml:"murmurs"`
+
+	// Visibility controls bubble discoverability. See VisibilityPrivate /
+	// VisibilityTeam. Empty string is treated as VisibilityPrivate by
+	// downstream consumers.
+	Visibility string `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+
+	// SessionRecording controls AI-coworker session recording for the
+	// bubble. Tri-state per ox CLI's existing vocabulary so the two
+	// surfaces stay in lockstep. Defaults vary by KB type — see
+	// DefaultSessionRecordingMode.
+	SessionRecording SessionRecordingConfig `json:"session_recording" yaml:"session_recording"`
+}
+
+// SessionRecordingConfig holds the per-bubble recording policy.
+//
+// Mode is *string so a patch can distinguish "field omitted, keep current
+// value" from "explicitly set". After defaults are applied the pointer is
+// non-nil.
+type SessionRecordingConfig struct {
+	Mode *string `json:"mode,omitempty" yaml:"mode,omitempty"`
+}
+
+// MurmursConfig holds murmur-feature toggles. Enabled is a *bool for the same
+// "omitted vs explicit false" reason as SessionRecordingConfig.Mode.
+type MurmursConfig struct {
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+}
+
+// SystemConfig is the internal namespace.
+//
+// Mono's current SystemConfig is an empty struct — the earlier
+// ConfigCommittedAt field was removed in favor of relying on git history.
+// ox keeps a tolerated, read-only ConfigCommittedAt pointer here so that
+// envelopes written by older mono builds (or by hand-edited test files)
+// don't trip strict-unmarshal errors. ox never writes this field; it is
+// preserved on read for forward/backward compatibility and ignored by all
+// downstream consumers. See bead ox-jzlm and the [HUMAN] pushback bead.
+type SystemConfig struct {
+	// ConfigCommittedAt is tolerated on read. ox does not populate it on
+	// any write path. Treat as advisory metadata only — git history is the
+	// canonical "when did this last change" source.
+	ConfigCommittedAt *time.Time `json:"config_committed_at,omitempty" yaml:"config_committed_at,omitempty"`
+}

--- a/internal/api/kbconfig/validate.go
+++ b/internal/api/kbconfig/validate.go
@@ -1,0 +1,60 @@
+package kbconfig
+
+import "fmt"
+
+// ValidateConfig is the semantic gate for a parsed KBConfig. Every code path
+// that reads a config from disk or the wire and intends to act on it should
+// route through here. ox does not write configs, but ValidateConfig still
+// runs on every read so an upstream-malformed value surfaces before
+// downstream code makes a decision based on it.
+//
+// Intentionally LENIENT on unknown fields — forward compat for fields a
+// newer mono build wrote that this ox binary doesn't know about. The YAML /
+// JSON decoder enforces structure; ValidateConfig enforces semantics of
+// known fields.
+//
+// Returns a wrapped error naming the offending field so the message threads
+// through to UI / log without ambiguity.
+func ValidateConfig(c KBConfig) error {
+	if c.Features.SessionRecording.Mode != nil {
+		if err := ValidateSessionRecordingMode(*c.Features.SessionRecording.Mode); err != nil {
+			return fmt.Errorf("features.session_recording: %w", err)
+		}
+	}
+	if c.Features.Visibility != "" {
+		if err := ValidateVisibility(c.Features.Visibility); err != nil {
+			return fmt.Errorf("features.visibility: %w", err)
+		}
+	}
+	// Negative versions or absurdly-future versions almost certainly
+	// indicate a malformed file or wire-format attack — reject. Zero is
+	// tolerated (treated as "pre-versioned row" by readers).
+	if c.Version < 0 || c.Version > ConfigVersion+10 {
+		return fmt.Errorf("version: implausible value %d (current=%d)", c.Version, ConfigVersion)
+	}
+	return nil
+}
+
+// ValidateSessionRecordingMode returns nil if m is one of the known mode
+// slugs. Empty string is rejected — callers that want "not set" should not
+// invoke validation in the first place (Mode is a *string for that reason).
+func ValidateSessionRecordingMode(m string) error {
+	for _, v := range ValidSessionRecordingModes {
+		if m == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid session_recording mode %q (allowed: %v)", m, ValidSessionRecordingModes)
+}
+
+// ValidateVisibility returns nil if v is a known visibility slug. Empty
+// string is rejected — Visibility uses omitempty on its tag, so an unset
+// value never reaches validation.
+func ValidateVisibility(v string) error {
+	switch v {
+	case VisibilityPrivate, VisibilityTeam:
+		return nil
+	default:
+		return fmt.Errorf("invalid visibility %q (allowed: %q, %q)", v, VisibilityPrivate, VisibilityTeam)
+	}
+}

--- a/internal/api/kbconfig/validate_test.go
+++ b/internal/api/kbconfig/validate_test.go
@@ -1,0 +1,87 @@
+package kbconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSessionRecordingMode(t *testing.T) {
+	for _, ok := range []string{SessionRecordingAuto, SessionRecordingManual, SessionRecordingDisabled} {
+		if err := ValidateSessionRecordingMode(ok); err != nil {
+			t.Errorf("ValidateSessionRecordingMode(%q) returned error: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "ON", "off", "enabled", "always", "  auto  ", "AUTO"} {
+		if err := ValidateSessionRecordingMode(bad); err == nil {
+			t.Errorf("ValidateSessionRecordingMode(%q) returned nil, want error", bad)
+		}
+	}
+}
+
+func TestValidateVisibility(t *testing.T) {
+	for _, ok := range []string{VisibilityPrivate, VisibilityTeam} {
+		if err := ValidateVisibility(ok); err != nil {
+			t.Errorf("ValidateVisibility(%q) returned error: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "Public", "PRIVATE", "team-internal", " private "} {
+		if err := ValidateVisibility(bad); err == nil {
+			t.Errorf("ValidateVisibility(%q) returned nil, want error", bad)
+		}
+	}
+}
+
+func TestValidateConfig_AcceptsCanonicalValues(t *testing.T) {
+	mode := SessionRecordingAuto
+	cfg := KBConfig{
+		Version: ConfigVersion,
+		Features: FeaturesConfig{
+			Visibility:       VisibilityPrivate,
+			SessionRecording: SessionRecordingConfig{Mode: &mode},
+		},
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Errorf("ValidateConfig on canonical input returned: %v", err)
+	}
+}
+
+func TestValidateConfig_ZeroAndOmittedAreLenient(t *testing.T) {
+	// Version=0 (pre-versioned row), missing Mode pointer, empty
+	// Visibility all need to pass — ValidateConfig is intentionally
+	// lenient on "not set" values.
+	if err := ValidateConfig(KBConfig{}); err != nil {
+		t.Errorf("ValidateConfig on zero value returned: %v", err)
+	}
+}
+
+func TestValidateConfig_RejectsBadFields(t *testing.T) {
+	t.Run("bad session_recording", func(t *testing.T) {
+		bad := "always"
+		cfg := KBConfig{Features: FeaturesConfig{SessionRecording: SessionRecordingConfig{Mode: &bad}}}
+		err := ValidateConfig(cfg)
+		if err == nil || !strings.Contains(err.Error(), "session_recording") {
+			t.Errorf("expected session_recording error, got %v", err)
+		}
+	})
+	t.Run("bad visibility", func(t *testing.T) {
+		cfg := KBConfig{Features: FeaturesConfig{Visibility: "world-readable"}}
+		err := ValidateConfig(cfg)
+		if err == nil || !strings.Contains(err.Error(), "visibility") {
+			t.Errorf("expected visibility error, got %v", err)
+		}
+	})
+	t.Run("implausible version", func(t *testing.T) {
+		cfg := KBConfig{Version: 9999}
+		err := ValidateConfig(cfg)
+		if err == nil || !strings.Contains(err.Error(), "version") {
+			t.Errorf("expected version error, got %v", err)
+		}
+	})
+	t.Run("negative version", func(t *testing.T) {
+		cfg := KBConfig{Version: -1}
+		err := ValidateConfig(cfg)
+		if err == nil || !strings.Contains(err.Error(), "version") {
+			t.Errorf("expected version error, got %v", err)
+		}
+	})
+}

--- a/internal/api/kbconfig/yaml.go
+++ b/internal/api/kbconfig/yaml.go
@@ -58,6 +58,17 @@ func UnmarshalConfigYAML(data []byte) (*ConfigYAMLEnvelope, error) {
 		}
 		return nil, fmt.Errorf("kbconfig: unmarshal config yaml: %w", err)
 	}
+	// Reject trailing YAML documents to avoid ambiguous/ignored config
+	// payloads. KnownFields(true) only covers stray keys inside a single
+	// document; a second `---`-separated doc would otherwise be silently
+	// dropped on the floor.
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, fmt.Errorf("kbconfig: unmarshal config yaml: trailing YAML document is not allowed")
+		}
+		return nil, fmt.Errorf("kbconfig: unmarshal config yaml: %w", err)
+	}
 	return &env, nil
 }
 

--- a/internal/api/kbconfig/yaml.go
+++ b/internal/api/kbconfig/yaml.go
@@ -1,0 +1,78 @@
+package kbconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigYAMLPath is the path inside a KB's git repo for the canonical config
+// file. Mirrors mono's packages/kb/config_yaml.go ConfigYAMLPath.
+const ConfigYAMLPath = ".sageox/config.yaml"
+
+// ConfigYAMLEnvelope is the on-disk shape of .sageox/config.yaml in a KB
+// tree (NOT the project-side binding file). Mirrors mono's envelope.
+//
+// ox reads this format; ox does NOT write it. Writes are server-side
+// (mono reconcile) or hand-edit only. The banner header that mono prepends
+// is a YAML comment — yaml.v3 ignores comments on parse so no special
+// handling is needed.
+//
+// committed_at is tolerated on read for forward/backward compatibility with
+// older mono builds that may have written the field; it is intentionally
+// surfaced at the envelope level (rather than embedded inside SystemConfig)
+// because mono's current schema places it at the file root. ox callers
+// should ignore this value — git history is the canonical source for "when
+// did this last change".
+type ConfigYAMLEnvelope struct {
+	// CommittedAt is tolerated on read. Treat as advisory metadata only.
+	CommittedAt *time.Time `yaml:"committed_at,omitempty"`
+
+	Version  int            `yaml:"version,omitempty"`
+	Features FeaturesConfig `yaml:"features"`
+	System   SystemConfig   `yaml:"system,omitempty"`
+}
+
+// UnmarshalConfigYAML parses a .sageox/config.yaml body into an envelope.
+//
+// Strict by default via KnownFields(true) — mirrors mono's read-side
+// strictness so a typo or wrong field name surfaces immediately rather than
+// silently zeroing out a value. The envelope itself is intentionally a
+// superset of mono's KBConfig (it carries committed_at), so the strict
+// decode still tolerates files written by mono today.
+func UnmarshalConfigYAML(data []byte) (*ConfigYAMLEnvelope, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var env ConfigYAMLEnvelope
+	if err := dec.Decode(&env); err != nil {
+		// yaml.v3 returns io.EOF when the input has no YAML nodes (e.g.
+		// banner-only file with all comments). Treat that as a zero-value
+		// envelope rather than a parse error — the caller can still apply
+		// defaults and validate the result.
+		if errors.Is(err, io.EOF) {
+			return &env, nil
+		}
+		return nil, fmt.Errorf("kbconfig: unmarshal config yaml: %w", err)
+	}
+	return &env, nil
+}
+
+// ToKBConfig projects an envelope onto the canonical KBConfig type, dropping
+// the read-only committed_at envelope field. Callers that need the parsed
+// KBConfig (for ValidateConfig, ResolveEffectiveMode inputs, etc.) should
+// go through this method so committed_at semantics stay isolated to the
+// envelope.
+func (e *ConfigYAMLEnvelope) ToKBConfig() KBConfig {
+	if e == nil {
+		return KBConfig{}
+	}
+	return KBConfig{
+		Version:  e.Version,
+		Features: e.Features,
+		System:   e.System,
+	}
+}

--- a/internal/api/kbconfig/yaml_test.go
+++ b/internal/api/kbconfig/yaml_test.go
@@ -1,0 +1,160 @@
+package kbconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestUnmarshalConfigYAML_FullEnvelope reads a config payload shaped exactly
+// like what mono's MarshalConfigYAML produces (banner + KBConfig body) and
+// verifies all known fields decode.
+func TestUnmarshalConfigYAML_FullEnvelope(t *testing.T) {
+	body := `# THIS FILE IS THE SOURCE OF TRUTH FOR THIS KNOWLEDGE BUBBLE'S CONFIG.
+# (banner comments are ignored on parse)
+version: 1
+features:
+  murmurs:
+    enabled: true
+  visibility: private
+  session_recording:
+    mode: auto
+system: {}
+`
+	env, err := UnmarshalConfigYAML([]byte(body))
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.Version != 1 {
+		t.Errorf("Version = %d, want 1", env.Version)
+	}
+	if env.Features.Murmurs.Enabled == nil || !*env.Features.Murmurs.Enabled {
+		t.Errorf("Murmurs.Enabled = %v, want true", env.Features.Murmurs.Enabled)
+	}
+	if env.Features.Visibility != VisibilityPrivate {
+		t.Errorf("Visibility = %q, want %q", env.Features.Visibility, VisibilityPrivate)
+	}
+	if env.Features.SessionRecording.Mode == nil || *env.Features.SessionRecording.Mode != SessionRecordingAuto {
+		t.Errorf("SessionRecording.Mode = %v, want %q", env.Features.SessionRecording.Mode, SessionRecordingAuto)
+	}
+}
+
+// TestUnmarshalConfigYAML_BannerOnlyParsesEmpty verifies that yaml.v3
+// ignores leading comments and that an otherwise-empty file decodes to a
+// zero-value envelope without erroring.
+func TestUnmarshalConfigYAML_BannerOnlyParsesEmpty(t *testing.T) {
+	body := `# banner only
+# nothing else here
+`
+	env, err := UnmarshalConfigYAML([]byte(body))
+	if err != nil {
+		t.Fatalf("unmarshal banner-only: %v", err)
+	}
+	if env.Version != 0 {
+		t.Errorf("expected zero envelope, got Version=%d", env.Version)
+	}
+}
+
+// TestUnmarshalConfigYAML_ToleratesCommittedAt confirms ox reads (but
+// does not require) the legacy committed_at field. Older mono builds
+// wrote this; current mono does not.
+func TestUnmarshalConfigYAML_ToleratesCommittedAt(t *testing.T) {
+	body := `committed_at: 2026-05-19T12:34:56Z
+version: 1
+features:
+  murmurs:
+    enabled: true
+  visibility: team
+  session_recording:
+    mode: manual
+system: {}
+`
+	env, err := UnmarshalConfigYAML([]byte(body))
+	if err != nil {
+		t.Fatalf("unmarshal with committed_at: %v", err)
+	}
+	if env.CommittedAt == nil {
+		t.Error("expected CommittedAt to be parsed, got nil")
+	}
+	if env.Features.Visibility != VisibilityTeam {
+		t.Errorf("Visibility = %q, want %q", env.Features.Visibility, VisibilityTeam)
+	}
+}
+
+// TestUnmarshalConfigYAML_MalformedReturnsError covers the must-fail case
+// for genuinely broken YAML.
+func TestUnmarshalConfigYAML_MalformedReturnsError(t *testing.T) {
+	body := `features:
+  murmurs:
+    enabled: [this is, not, valid: at all
+`
+	if _, err := UnmarshalConfigYAML([]byte(body)); err == nil {
+		t.Error("expected error for malformed YAML, got nil")
+	}
+}
+
+// TestUnmarshalConfigYAML_UnknownFieldsRejected pins the strict-decode
+// behavior. mono's MarshalConfigYAML is also strict on read; we match the
+// posture so an upstream typo doesn't silently zero out a field.
+func TestUnmarshalConfigYAML_UnknownFieldsRejected(t *testing.T) {
+	body := `version: 1
+features:
+  murmurs:
+    enabled: true
+  visibility: private
+  session_recording:
+    mode: auto
+  totally_made_up_field: 42
+`
+	_, err := UnmarshalConfigYAML([]byte(body))
+	if err == nil {
+		t.Error("expected strict decode to reject unknown field, got nil")
+		return
+	}
+	if !strings.Contains(err.Error(), "totally_made_up_field") {
+		t.Errorf("error should name the unknown field, got: %v", err)
+	}
+}
+
+// TestEnvelopeToKBConfig_DropsCommittedAt confirms the projection helper
+// strips the read-only envelope field so downstream KBConfig consumers
+// don't accidentally depend on it.
+func TestEnvelopeToKBConfig_DropsCommittedAt(t *testing.T) {
+	body := `committed_at: 2026-05-19T12:34:56Z
+version: 1
+features:
+  murmurs:
+    enabled: true
+  visibility: private
+  session_recording:
+    mode: auto
+system: {}
+`
+	env, err := UnmarshalConfigYAML([]byte(body))
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cfg := env.ToKBConfig()
+	if cfg.Version != 1 {
+		t.Errorf("Version = %d, want 1", cfg.Version)
+	}
+	if cfg.Features.Visibility != VisibilityPrivate {
+		t.Errorf("Visibility = %q, want %q", cfg.Features.Visibility, VisibilityPrivate)
+	}
+	if cfg.System.ConfigCommittedAt != nil {
+		// envelope-level committed_at must NOT leak into SystemConfig
+		t.Errorf("ToKBConfig leaked committed_at into System: %v", cfg.System.ConfigCommittedAt)
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		t.Errorf("projected config failed validation: %v", err)
+	}
+}
+
+// TestEnvelopeToKBConfig_NilSafe ensures the helper handles a nil receiver
+// gracefully — callers may forward a nil parse result.
+func TestEnvelopeToKBConfig_NilSafe(t *testing.T) {
+	var env *ConfigYAMLEnvelope
+	cfg := env.ToKBConfig()
+	if cfg.Version != 0 {
+		t.Errorf("nil envelope projection should be zero, got Version=%d", cfg.Version)
+	}
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strings"
 
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/mattn/go-isatty"
@@ -342,6 +343,20 @@ func OpenInBrowser(url string) error {
 		return ErrHeadless
 	}
 	return browser.OpenURL(url)
+}
+
+// FormatKBSlug returns the canonical human-display form of a KB slug: "#<slug>".
+// Use in CLI tables, headers, banners, and error messages.
+// Do NOT use in JSON envelope fields, on-disk paths, or shell-composable stdout
+// (e.g. `ox kb path`); those stay bare.
+func FormatKBSlug(slug string) string {
+	if slug == "" {
+		return ""
+	}
+	if strings.HasPrefix(slug, "#") {
+		return slug // already prefixed; idempotent
+	}
+	return "#" + slug
 }
 
 // SilentError is an error type that signals the error was already displayed.

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -11,6 +11,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestFormatKBSlug pins the canonical "#<slug>" human-display formatter
+// used across kb list, kb show, and kb hydrate. Failure prevented: drift
+// between command surfaces showing a slug without the prefix, or double-
+// prefixing when a caller passes "#foo" by mistake.
+func TestFormatKBSlug(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"bare", "marketing", "#marketing"},
+		{"already-prefixed", "#marketing", "#marketing"},
+		{"hyphenated", "ryan-personal", "#ryan-personal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatKBSlug(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestFormatTipText_HighlightsBackticks(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/codedb/index/gitenv_test.go
+++ b/internal/codedb/index/gitenv_test.go
@@ -1,0 +1,13 @@
+package index
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/codedb/index/worktree_test.go
+++ b/internal/codedb/index/worktree_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -43,10 +44,13 @@ func initGitRepo(t *testing.T, numCommits int) (string, string) {
 		// or emits transient object-DB errors ("bad tree object",
 		// "invalid object", "Error building trees") when packed
 		// objects haven't reached disk yet. External-tool defect,
-		// transient under load — single retry is enough to keep the
-		// test suite from flaking. Real non-zero exits surface on the
-		// retry attempt.
-		if err != nil && (isGitSignalCrash(err) || isGitTransientObjectError(out)) {
+		// transient under load. The original workaround retried once;
+		// under -p 8 -parallel 32 (make test) the transient was
+		// observed surviving a single retry. Retry up to 4 times with
+		// linear backoff to let packed objects settle. Real non-zero
+		// exits surface on the final attempt.
+		for attempt := 1; err != nil && attempt <= 4 && (isGitSignalCrash(err) || isGitTransientObjectError(out)); attempt++ {
+			time.Sleep(time.Duration(attempt*25) * time.Millisecond)
 			out, err = mkCmd().CombinedOutput()
 		}
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/internal/codedb/index/worktree_test.go
+++ b/internal/codedb/index/worktree_test.go
@@ -32,9 +32,9 @@ func initGitRepo(t *testing.T, numCommits int) (string, string) {
 			cmd.Dir = dir
 			cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
 				"GIT_AUTHOR_NAME=test",
-				"GIT_AUTHOR_EMAIL=test@sageox.ai",
+				"GIT_AUTHOR_EMAIL=test@test.sageox.ai",
 				"GIT_COMMITTER_NAME=test",
-				"GIT_COMMITTER_EMAIL=test@sageox.ai",
+				"GIT_COMMITTER_EMAIL=test@test.sageox.ai",
 			)
 			return cmd
 		}
@@ -164,9 +164,9 @@ func TestResolveDefaultBranchGit_Worktree(t *testing.T) {
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
 			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_AUTHOR_EMAIL=test@test.sageox.ai",
 			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_EMAIL=test@test.sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)
@@ -237,9 +237,9 @@ func TestIndexLocalRepo_LinkedWorktree(t *testing.T) {
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir needs inherited PATH
 			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_AUTHOR_EMAIL=test@test.sageox.ai",
 			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_EMAIL=test@test.sageox.ai",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -173,17 +173,12 @@ const (
 	defaultOfflineSnapshotStaleDays = 7
 )
 
-// ProjectConfigYAML is the on-disk shape of .sageox/config.yaml (ADR-017).
-// This is the project-side YAML — NOT the KB-side envelope (which carries
-// banners and committed_at). The project-side YAML is intentionally narrow:
-// it binds a directory tree to a kb_id, with repo_id retained as a one-
-// release safety net so offline resolution still works while the kb API
-// is unreachable.
-//
-// All other ProjectConfig fields are preserved across migration by
-// round-tripping through JSON tags via yaml.Marshal of the canonical
-// ProjectConfig struct. We keep this narrow type strictly for the
-// minimum-payload binding-only trees described in ADR-017 §2.
+// ProjectConfigYAML is the binding subset of the project-side
+// .sageox/config.yaml (ADR-017). The file itself may contain the full
+// ProjectConfig shape; yaml.v3 honors json tags, so LoadProjectConfig can
+// unmarshal directly into ProjectConfig and preserve existing per-project
+// settings. This narrower view is kept for code paths that only need the
+// binding fields (kb_id + repo_id), such as doctor reconciliation tests.
 type ProjectConfigYAML struct {
 	KBID   string `yaml:"kb_id,omitempty"`
 	RepoID string `yaml:"repo_id,omitempty"`
@@ -264,12 +259,12 @@ func GetDefaultProjectConfig() *ProjectConfig {
 // Hybrid read posture during the staged migration window (ADR-017 §7):
 //
 //   - JSON only present  → Format="json".
-//   - YAML only present  → Format="yaml"; translate ProjectConfigYAML into the
-//     canonical struct (KBID + RepoID are the only fields the narrow YAML
-//     binding carries).
+//   - YAML only present  → Format="yaml"; unmarshal YAML directly into the
+//     canonical struct, preserving all project-scoped settings that were
+//     migrated across.
 //   - Both present       → Format="both"; JSON is the base, YAML overrides on
-//     conflict (kb_id, repo_id). This lets the doctor migration write the YAML
-//     alongside the legacy JSON without losing information either way.
+//     conflict for every field it carries. This lets the doctor migration
+//     write the YAML alongside the legacy JSON without losing information.
 //   - Neither present    → return default config with Format unset (callers
 //     keep treating this as "not initialized" via IsInitialized).
 //
@@ -291,13 +286,13 @@ func LoadProjectConfig(gitRoot string) (*ProjectConfig, error) {
 	jsonExists := false
 	if _, err := os.Stat(jsonPath); err == nil {
 		jsonExists = true
-	} else if !os.IsNotExist(err) {
+	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("failed to stat config file: %w", err)
 	}
 	yamlExists := false
 	if _, err := os.Stat(yamlPath); err == nil {
 		yamlExists = true
-	} else if !os.IsNotExist(err) {
+	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("failed to stat yaml config: %w", err)
 	}
 
@@ -325,18 +320,8 @@ func LoadProjectConfig(gitRoot string) (*ProjectConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read yaml config: %w", err)
 		}
-		var y ProjectConfigYAML
-		if err := yaml.Unmarshal(data, &y); err != nil {
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse yaml config: %w", err)
-		}
-		// YAML overrides on conflict (ADR-017 §7). Only override when the YAML
-		// actually carries a value — an empty kb_id in the YAML must not blank
-		// out the JSON-derived field during the transition.
-		if y.KBID != "" {
-			cfg.KBID = y.KBID
-		}
-		if y.RepoID != "" {
-			cfg.RepoID = y.RepoID
 		}
 	}
 
@@ -491,15 +476,22 @@ func FindProjectRoot() string {
 	}
 }
 
-// findProjectConfigPathFromDir walks up from the given directory looking for .sageox/config.json
+// findProjectConfigPathFromDir walks up from the given directory looking for
+// .sageox/config.json, or .sageox/config.yaml when JSON is absent (ADR-017).
+// Prefer JSON during the migration window so existing tooling/callers that
+// expect a JSON path keep working; fall back to YAML so YAML-only repos are
+// still discoverable.
 func findProjectConfigPathFromDir(startDir string) (string, error) {
 	currentDir := startDir
 
 	for {
-		// check if .sageox/config.json exists in current directory
-		configPath := filepath.Join(currentDir, sageoxDir, projectConfigFilename)
-		if _, err := os.Stat(configPath); err == nil {
-			return configPath, nil
+		jsonPath := filepath.Join(currentDir, sageoxDir, projectConfigFilename)
+		if _, err := os.Stat(jsonPath); err == nil {
+			return jsonPath, nil
+		}
+		yamlPath := filepath.Join(currentDir, sageoxDir, projectConfigYAMLFilename)
+		if _, err := os.Stat(yamlPath); err == nil {
+			return yamlPath, nil
 		}
 
 		// get parent directory

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
@@ -140,6 +141,18 @@ type ProjectConfig struct {
 	// GitHubSyncIssues controls issue sync independently.
 	// Values: "enabled" (default), "disabled"
 	GitHubSyncIssues string `json:"github_sync_issues,omitempty"`
+
+	// KBID is the immutable knowledge-bubble identifier this project is bound
+	// to (ADR-017). Populated when the project has been migrated to the new
+	// .sageox/config.yaml format. Empty for legacy JSON-only projects that
+	// haven't been migrated yet.
+	KBID string `json:"-" yaml:"kb_id,omitempty"`
+
+	// Format records which on-disk format the loader treated as authoritative
+	// when constructing this struct. Values: "json", "yaml", "both", "none".
+	// Useful for doctor to decide whether a migration is pending.
+	// NOT serialized — derived at load time.
+	Format string `json:"-" yaml:"-"`
 }
 
 // NeedsUpgrade returns true if the config version is older than CurrentConfigVersion
@@ -155,16 +168,42 @@ func (c *ProjectConfig) SetCurrentVersion() {
 const (
 	defaultUpdateFrequencyHours     = 24
 	projectConfigFilename           = "config.json"
+	projectConfigYAMLFilename       = "config.yaml"
 	sageoxDir                       = ".sageox"
 	defaultOfflineSnapshotStaleDays = 7
 )
 
+// ProjectConfigYAML is the on-disk shape of .sageox/config.yaml (ADR-017).
+// This is the project-side YAML — NOT the KB-side envelope (which carries
+// banners and committed_at). The project-side YAML is intentionally narrow:
+// it binds a directory tree to a kb_id, with repo_id retained as a one-
+// release safety net so offline resolution still works while the kb API
+// is unreachable.
+//
+// All other ProjectConfig fields are preserved across migration by
+// round-tripping through JSON tags via yaml.Marshal of the canonical
+// ProjectConfig struct. We keep this narrow type strictly for the
+// minimum-payload binding-only trees described in ADR-017 §2.
+type ProjectConfigYAML struct {
+	KBID   string `yaml:"kb_id,omitempty"`
+	RepoID string `yaml:"repo_id,omitempty"`
+}
+
 // IsInitialized checks if SageOx is initialized in the given git root directory.
-// Returns true if .sageox/config.json exists (the canonical file created by ox init).
+// Returns true if .sageox/config.json OR .sageox/config.yaml exists. Both
+// formats co-exist during the staged deprecation window (ADR-017 §7).
+//
+// TODO(release N+3): drop the JSON fallback once all repos have migrated.
 func IsInitialized(gitRoot string) bool {
-	configPath := filepath.Join(gitRoot, sageoxDir, projectConfigFilename)
-	_, err := os.Stat(configPath)
-	return err == nil
+	jsonPath := filepath.Join(gitRoot, sageoxDir, projectConfigFilename)
+	if _, err := os.Stat(jsonPath); err == nil {
+		return true
+	}
+	yamlPath := filepath.Join(gitRoot, sageoxDir, projectConfigYAMLFilename)
+	if _, err := os.Stat(yamlPath); err == nil {
+		return true
+	}
+	return false
 }
 
 // IsInitializedInCwd checks if SageOx is initialized by walking up from current directory.
@@ -219,36 +258,85 @@ func GetDefaultProjectConfig() *ProjectConfig {
 	}
 }
 
-// LoadProjectConfig loads the project configuration from .sageox/config.json relative to gitRoot
+// LoadProjectConfig loads the project configuration from .sageox/config.json,
+// then merges in .sageox/config.yaml (ADR-017) when present.
+//
+// Hybrid read posture during the staged migration window (ADR-017 §7):
+//
+//   - JSON only present  → Format="json".
+//   - YAML only present  → Format="yaml"; translate ProjectConfigYAML into the
+//     canonical struct (KBID + RepoID are the only fields the narrow YAML
+//     binding carries).
+//   - Both present       → Format="both"; JSON is the base, YAML overrides on
+//     conflict (kb_id, repo_id). This lets the doctor migration write the YAML
+//     alongside the legacy JSON without losing information either way.
+//   - Neither present    → return default config with Format unset (callers
+//     keep treating this as "not initialized" via IsInitialized).
+//
+// TODO(release N+3): drop the JSON read path entirely once all repos are
+// migrated and the legacy files have been removed.
 func LoadProjectConfig(gitRoot string) (*ProjectConfig, error) {
 	if gitRoot == "" {
 		return nil, errors.New("git root cannot be empty")
 	}
 
-	configPath := filepath.Join(gitRoot, sageoxDir, projectConfigFilename)
+	jsonPath := filepath.Join(gitRoot, sageoxDir, projectConfigFilename)
+	yamlPath := filepath.Join(gitRoot, sageoxDir, projectConfigYAMLFilename)
 
-	// check if file exists
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		// return default config if file doesn't exist
+	_, jsonStatErr := os.Stat(jsonPath)
+	jsonExists := jsonStatErr == nil
+	_, yamlStatErr := os.Stat(yamlPath)
+	yamlExists := yamlStatErr == nil
+
+	// Neither file exists — preserve the legacy "return defaults" contract so
+	// callers that load eagerly (daemon, IPC discovery) don't have to special-case
+	// uninitialized repos. IsInitialized() is the canonical existence gate.
+	if !jsonExists && !yamlExists {
 		return GetDefaultProjectConfig(), nil
 	}
 
-	// read the file
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config file: %w", err)
+	cfg := ProjectConfig{}
+
+	if jsonExists {
+		data, err := os.ReadFile(jsonPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read config file: %w", err)
+		}
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("failed to parse config file: %w", err)
+		}
 	}
 
-	// parse JSON
-	var cfg ProjectConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	if yamlExists {
+		data, err := os.ReadFile(yamlPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read yaml config: %w", err)
+		}
+		var y ProjectConfigYAML
+		if err := yaml.Unmarshal(data, &y); err != nil {
+			return nil, fmt.Errorf("failed to parse yaml config: %w", err)
+		}
+		// YAML overrides on conflict (ADR-017 §7). Only override when the YAML
+		// actually carries a value — an empty kb_id in the YAML must not blank
+		// out the JSON-derived field during the transition.
+		if y.KBID != "" {
+			cfg.KBID = y.KBID
+		}
+		if y.RepoID != "" {
+			cfg.RepoID = y.RepoID
+		}
 	}
 
-	// apply defaults for missing fields
+	switch {
+	case jsonExists && yamlExists:
+		cfg.Format = "both"
+	case yamlExists:
+		cfg.Format = "yaml"
+	default:
+		cfg.Format = "json"
+	}
+
 	applyDefaults(&cfg)
-
-	// normalize endpoint defensively (handles configs saved by older versions)
 	cfg.Endpoint = endpoint.NormalizeEndpoint(cfg.Endpoint)
 
 	return &cfg, nil

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -283,10 +283,23 @@ func LoadProjectConfig(gitRoot string) (*ProjectConfig, error) {
 	jsonPath := filepath.Join(gitRoot, sageoxDir, projectConfigFilename)
 	yamlPath := filepath.Join(gitRoot, sageoxDir, projectConfigYAMLFilename)
 
-	_, jsonStatErr := os.Stat(jsonPath)
-	jsonExists := jsonStatErr == nil
-	_, yamlStatErr := os.Stat(yamlPath)
-	yamlExists := yamlStatErr == nil
+	// Distinguish ENOENT (file genuinely missing) from EACCES / other
+	// stat failures (parent dir unreadable, broken symlink, etc.). The
+	// legacy LoadProjectConfig used os.IsNotExist; mirroring that here
+	// keeps ensureSageoxConfig's "permission-denied → configError"
+	// contract intact under hostile filesystem state.
+	jsonExists := false
+	if _, err := os.Stat(jsonPath); err == nil {
+		jsonExists = true
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to stat config file: %w", err)
+	}
+	yamlExists := false
+	if _, err := os.Stat(yamlPath); err == nil {
+		yamlExists = true
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to stat yaml config: %w", err)
+	}
 
 	// Neither file exists — preserve the legacy "return defaults" contract so
 	// callers that load eagerly (daemon, IPC discovery) don't have to special-case

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -320,7 +320,7 @@ func LoadProjectConfig(gitRoot string) (*ProjectConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read yaml config: %w", err)
 		}
-		if err := yaml.Unmarshal(data, &cfg); err != nil {
+		if err := mergeProjectConfigYAML(data, &cfg); err != nil {
 			return nil, fmt.Errorf("failed to parse yaml config: %w", err)
 		}
 	}
@@ -338,6 +338,38 @@ func LoadProjectConfig(gitRoot string) (*ProjectConfig, error) {
 	cfg.Endpoint = endpoint.NormalizeEndpoint(cfg.Endpoint)
 
 	return &cfg, nil
+}
+
+func mergeProjectConfigYAML(data []byte, cfg *ProjectConfig) error {
+	if cfg == nil {
+		return errors.New("config cannot be nil")
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw) > 0 {
+		jsonData, err := json.Marshal(raw)
+		if err != nil {
+			return fmt.Errorf("yaml to json bridge: %w", err)
+		}
+		if err := json.Unmarshal(jsonData, cfg); err != nil {
+			return fmt.Errorf("yaml to project config: %w", err)
+		}
+	}
+
+	var binding ProjectConfigYAML
+	if err := yaml.Unmarshal(data, &binding); err != nil {
+		return err
+	}
+	if binding.KBID != "" {
+		cfg.KBID = binding.KBID
+	}
+	if binding.RepoID != "" {
+		cfg.RepoID = binding.RepoID
+	}
+	return nil
 }
 
 // SaveProjectConfig saves the project configuration to .sageox/config.json relative to gitRoot

--- a/internal/config/project_config_test.go
+++ b/internal/config/project_config_test.go
@@ -209,6 +209,37 @@ func TestLoadProjectConfig_AppliesDefaults(t *testing.T) {
 	assert.Equal(t, defaultUpdateFrequencyHours, cfg.UpdateFrequencyHours, "expected default UpdateFrequencyHours")
 }
 
+func TestLoadProjectConfig_YAMLOnlyPreservesProjectFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	RequireSageoxDir(t, tmpDir)
+
+	yamlBody := `config_version: "2"
+repo_id: repo_abc
+kb_id: kb_repo_abc
+endpoint: https://test.sageox.ai
+session_recording: auto
+github_sync: disabled
+update_frequency_hours: 12
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, sageoxDir, projectConfigYAMLFilename),
+		[]byte(yamlBody),
+		0o644,
+	))
+
+	cfg, err := LoadProjectConfig(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, "yaml", cfg.Format)
+	assert.Equal(t, "repo_abc", cfg.RepoID)
+	assert.Equal(t, "kb_repo_abc", cfg.KBID)
+	assert.Equal(t, "https://test.sageox.ai", cfg.Endpoint)
+	assert.Equal(t, "auto", cfg.SessionRecording)
+	assert.Equal(t, "disabled", cfg.GitHubSync)
+	assert.Equal(t, 12, cfg.UpdateFrequencyHours)
+}
+
 func TestFindProjectConfigPathFromDir_WalksUpDirectories(t *testing.T) {
 	// create a temporary directory structure
 	tmpDir, err := os.MkdirTemp("", "sageox-test-*")

--- a/internal/config/session_recording.go
+++ b/internal/config/session_recording.go
@@ -175,10 +175,7 @@ func ResolveSessionRecording(projectRoot string, kbID, kbType string) *ResolvedS
 		}
 
 		// neither layer set anything — fall through to per-KB-type default.
-		defaultMode := kbconfig.DefaultSessionRecordingMode(kbType)
-		if defaultMode == "" {
-			defaultMode = SessionRecordingManual
-		}
+		defaultMode := defaultKBSessionRecordingMode(projectRoot, kbID, kbType)
 		return &ResolvedSessionRecording{
 			Mode:   NormalizeSessionRecording(defaultMode),
 			Source: SessionRecordingSourceDefault,
@@ -231,6 +228,28 @@ func ResolveSessionRecording(projectRoot string, kbID, kbType string) *ResolvedS
 	}
 }
 
+// defaultKBSessionRecordingMode returns the fallback mode for a KB-aware
+// resolution when neither env/user/kb layers are set.
+//
+// If kbType is known, the per-type default is authoritative. When kbType is
+// still unknown because local KB metadata has not synced yet, preserve the
+// legacy repo-root behavior for the project's own bound KB so migration to
+// YAML does not silently flip initialized repos from auto to manual.
+func defaultKBSessionRecordingMode(projectRoot, kbID, kbType string) string {
+	if kbType != "" {
+		if mode := kbconfig.DefaultSessionRecordingMode(kbType); mode != "" {
+			return mode
+		}
+	}
+	if projectRoot != "" && kbID != "" {
+		if projectCfg, err := LoadProjectConfig(projectRoot); err == nil &&
+			projectCfg != nil && projectCfg.KBID == kbID {
+			return SessionRecordingAuto
+		}
+	}
+	return SessionRecordingManual
+}
+
 // loadUserSessionRecordingMode returns the normalized user-layer mode, or "" if unset.
 //
 // SessionsConfig.GetMode() returns "none" both when the field is absent AND when
@@ -270,6 +289,12 @@ func loadKBSessionRecordingMode(kbID string) string {
 	}
 	env, err := kbconfig.UnmarshalConfigYAML(data)
 	if err != nil || env == nil {
+		return ""
+	}
+	// Validate before trusting the mode string — malformed config should be
+	// treated as unset rather than silently coerced (which normalizes to
+	// "manual" downstream, turning recording ON for an invalid KB config).
+	if err := kbconfig.ValidateConfig(env.ToKBConfig()); err != nil {
 		return ""
 	}
 	if env.Features.SessionRecording.Mode == nil {

--- a/internal/config/session_recording.go
+++ b/internal/config/session_recording.go
@@ -1,6 +1,12 @@
 package config
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sageox/ox/internal/api/kbconfig"
+	"github.com/sageox/ox/internal/paths"
+)
 
 // SessionRecording constants: disabled -> manual -> auto
 const (
@@ -73,12 +79,28 @@ const (
 	SessionRecordingSourceUser    SessionRecordingSource = "user"    // from user config
 	SessionRecordingSourceTeam    SessionRecordingSource = "team"    // from team defaults (future)
 	SessionRecordingSourceRepo    SessionRecordingSource = "repo"    // from .sageox/config.json
+	SessionRecordingSourceKB      SessionRecordingSource = "kb"      // from KB-local .sageox/config.yaml
 )
 
 // ResolvedSessionRecording contains the effective mode and its source.
 type ResolvedSessionRecording struct {
 	Mode   string                 // effective mode: "disabled", "manual", or "auto"
 	Source SessionRecordingSource // where the setting came from
+
+	// SafetyInversion is true when "disabled" was forced by the either-side veto
+	// in kbconfig.ResolveEffectiveMode — i.e. the precedence-winning layer was
+	// NOT disabled, but the other layer was, and that other layer's veto
+	// overrode standard precedence. Surfaced for doctor/diagnostics so the
+	// origin layer can be reported accurately.
+	SafetyInversion bool
+
+	// KBID is the current KB binding's id, if any. Empty when the caller did
+	// not pass a KB binding (legacy path).
+	KBID string
+
+	// KBType is the current KB binding's type, if any. Used for default-mode
+	// resolution via kbconfig.DefaultSessionRecordingMode.
+	KBType string
 }
 
 // ShouldRecord returns true if the mode enables any recording.
@@ -97,35 +119,84 @@ func (r *ResolvedSessionRecording) IsManual() bool {
 }
 
 // ResolveSessionRecording determines the effective session recording mode.
-// Priority: OX_SESSION_RECORDING env > user config > project config > team config > "manual"
 //
-// This priority ensures env vars (for pipelines) override everything,
-// users can override team/repo settings, and teams can set defaults.
-func ResolveSessionRecording(projectRoot string) *ResolvedSessionRecording {
-	// 0. check OX_SESSION_RECORDING env var - highest priority (for pipelines/automation)
+// Precedence (low → high):
+//  1. per-KB-type default (kbconfig.DefaultSessionRecordingMode) when kbType set,
+//     else legacy default (manual, or auto for ox-initialized repos).
+//  2. user config (~/.config/sageox/config.yaml).
+//  3. KB-local .sageox/config.yaml (when kbID != "").
+//  4. legacy project / team config (only when kbID == "" — preserves pre-KB behavior).
+//  5. OX_SESSION_RECORDING env var (highest).
+//
+// Safety inversion: when both user and KB layers are set, kbconfig.ResolveEffectiveMode
+// applies an either-side "disabled" veto regardless of standard precedence. Env still
+// overrides everything (it is the pipeline/automation escape hatch).
+//
+// kbID/kbType are passed in by the caller to avoid an import cycle
+// (internal/config cannot import internal/kb). Callers without a KB binding
+// pass empty strings; behavior then matches the legacy resolver.
+func ResolveSessionRecording(projectRoot string, kbID, kbType string) *ResolvedSessionRecording {
+	// 0. OX_SESSION_RECORDING env var — highest priority (pipelines / automation).
 	if envMode := os.Getenv(EnvSessionRecording); envMode != "" {
-		normalized := NormalizeSessionRecording(envMode)
 		return &ResolvedSessionRecording{
-			Mode:   normalized,
+			Mode:   NormalizeSessionRecording(envMode),
 			Source: SessionRecordingSourceEnv,
+			KBID:   kbID,
+			KBType: kbType,
 		}
 	}
 
-	// 1. check user config (~/.config/sageox/config.yaml) - USER ALWAYS WINS
-	userCfg, err := LoadUserConfig()
-	if err == nil && userCfg != nil && userCfg.Sessions != nil {
-		mode := userCfg.Sessions.GetMode()
-		if mode != "" && mode != "none" {
-			normalized := NormalizeSessionRecording(mode)
-			// user setting takes priority, including "disabled"
+	// user layer (raw — pre-normalization, empty means "unset")
+	userMode := loadUserSessionRecordingMode()
+
+	// KB-aware path: only when a KB binding was passed in.
+	if kbID != "" {
+		kbMode := loadKBSessionRecordingMode(kbID)
+
+		// safety-inversion-aware combine. Empty inputs are tolerated.
+		combined := kbconfig.ResolveEffectiveMode(userMode, kbMode)
+		if combined != "" {
+			// safety inversion: result is "disabled" AND the precedence-winning
+			// layer (user when set, else kb) was NOT itself disabled. That means
+			// the OTHER layer's veto flipped the result.
+			precedenceLayer := userMode
+			if precedenceLayer == "" {
+				precedenceLayer = kbMode
+			}
+			safetyInv := combined == SessionRecordingDisabled && precedenceLayer != SessionRecordingDisabled
+
 			return &ResolvedSessionRecording{
-				Mode:   normalized,
-				Source: SessionRecordingSourceUser,
+				Mode:            NormalizeSessionRecording(combined),
+				Source:          pickKBChainSource(userMode, kbMode, combined),
+				SafetyInversion: safetyInv,
+				KBID:            kbID,
+				KBType:          kbType,
 			}
 		}
+
+		// neither layer set anything — fall through to per-KB-type default.
+		defaultMode := kbconfig.DefaultSessionRecordingMode(kbType)
+		if defaultMode == "" {
+			defaultMode = SessionRecordingManual
+		}
+		return &ResolvedSessionRecording{
+			Mode:   NormalizeSessionRecording(defaultMode),
+			Source: SessionRecordingSourceDefault,
+			KBID:   kbID,
+			KBType: kbType,
+		}
 	}
 
-	// 2. check project config (.sageox/config.json)
+	// Legacy path (no KB binding): preserve pre-KB resolver behavior so existing
+	// callers and tests are unaffected.
+	if userMode != "" && userMode != "none" {
+		return &ResolvedSessionRecording{
+			Mode:   NormalizeSessionRecording(userMode),
+			Source: SessionRecordingSourceUser,
+		}
+	}
+
+	// project config (.sageox/config.json)
 	isInitialized := projectRoot != "" && IsInitialized(projectRoot)
 	if isInitialized {
 		projectCfg, err := LoadProjectConfig(projectRoot)
@@ -137,7 +208,7 @@ func ResolveSessionRecording(projectRoot string) *ResolvedSessionRecording {
 		}
 	}
 
-	// 3. check team config (from team context)
+	// team config (from team context)
 	if projectRoot != "" {
 		if teamMode := loadTeamSessionRecording(projectRoot); teamMode != "" {
 			return &ResolvedSessionRecording{
@@ -147,7 +218,7 @@ func ResolveSessionRecording(projectRoot string) *ResolvedSessionRecording {
 		}
 	}
 
-	// 4. ox-initialized repos default to auto; non-initialized default to manual
+	// ox-initialized repos default to auto; non-initialized default to manual.
 	if isInitialized {
 		return &ResolvedSessionRecording{
 			Mode:   SessionRecordingAuto,
@@ -158,6 +229,75 @@ func ResolveSessionRecording(projectRoot string) *ResolvedSessionRecording {
 		Mode:   SessionRecordingManual,
 		Source: SessionRecordingSourceDefault,
 	}
+}
+
+// loadUserSessionRecordingMode returns the normalized user-layer mode, or "" if unset.
+//
+// SessionsConfig.GetMode() returns "none" both when the field is absent AND when
+// it's explicitly set to "none". To preserve the legacy resolver semantics
+// (absence = inherit, explicit "none" = veto), we inspect the raw fields:
+//   - explicit Mode == "none" or Enabled == &false → "disabled" (veto)
+//   - everything else producing "none" → "" (unset / inherit)
+func loadUserSessionRecordingMode() string {
+	uc, err := LoadUserConfig()
+	if err != nil || uc == nil || uc.Sessions == nil {
+		return ""
+	}
+	mode := uc.Sessions.GetMode()
+	switch mode {
+	case "", "none":
+		// only treat as an explicit veto if a raw field is actually set
+		if uc.Sessions.Mode == "none" || (uc.Sessions.Enabled != nil && !*uc.Sessions.Enabled) {
+			return SessionRecordingDisabled
+		}
+		return ""
+	default:
+		return NormalizeSessionRecording(mode)
+	}
+}
+
+// loadKBSessionRecordingMode reads the KB-local .sageox/config.yaml and returns
+// the configured mode, or "" if unset / unreadable. Missing files and parse
+// errors are treated as "unset" — they're not fatal; defaults take over.
+func loadKBSessionRecordingMode(kbID string) string {
+	if kbID == "" {
+		return ""
+	}
+	cfgPath := filepath.Join(paths.KBDir(kbID), kbconfig.ConfigYAMLPath)
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return ""
+	}
+	env, err := kbconfig.UnmarshalConfigYAML(data)
+	if err != nil || env == nil {
+		return ""
+	}
+	if env.Features.SessionRecording.Mode == nil {
+		return ""
+	}
+	return *env.Features.SessionRecording.Mode
+}
+
+// pickKBChainSource determines which layer the combined value came from after
+// kbconfig.ResolveEffectiveMode applied. Useful for diagnostics.
+func pickKBChainSource(userMode, kbMode, combined string) SessionRecordingSource {
+	// safety inversion: either-side veto → "disabled" wins. Attribute to the
+	// vetoing layer so doctor / --show-origin reports the actual source.
+	if combined == SessionRecordingDisabled {
+		switch {
+		case userMode == SessionRecordingDisabled && kbMode == SessionRecordingDisabled:
+			return SessionRecordingSourceUser // tie → user (precedence)
+		case userMode == SessionRecordingDisabled:
+			return SessionRecordingSourceUser
+		case kbMode == SessionRecordingDisabled:
+			return SessionRecordingSourceKB
+		}
+	}
+	// standard precedence: user wins when set, else kb.
+	if userMode != "" {
+		return SessionRecordingSourceUser
+	}
+	return SessionRecordingSourceKB
 }
 
 // loadTeamSessionRecording loads session recording setting from team context.
@@ -179,8 +319,9 @@ func loadTeamSessionRecording(projectRoot string) string {
 }
 
 // GetSessionRecording is a convenience function that returns just the mode string.
+// Callers without a KB binding pass empty kbID/kbType.
 func GetSessionRecording(projectRoot string) string {
-	resolved := ResolveSessionRecording(projectRoot)
+	resolved := ResolveSessionRecording(projectRoot, "", "")
 	return resolved.Mode
 }
 

--- a/internal/config/session_recording_test.go
+++ b/internal/config/session_recording_test.go
@@ -58,7 +58,7 @@ func TestResolveSessionRecording_NoProjectConfig_DefaultsToManual(t *testing.T) 
 	t.Setenv("OX_XDG_ENABLE", "1")
 	t.Setenv("XDG_CONFIG_HOME", userConfigDir)
 
-	resolved := ResolveSessionRecording(tmpDir)
+	resolved := ResolveSessionRecording(tmpDir, "", "")
 
 	assert.Equal(t, SessionRecordingManual, resolved.Mode)
 	assert.Equal(t, SessionRecordingSourceDefault, resolved.Source)
@@ -83,7 +83,7 @@ func TestResolveSessionRecording_ReadsFromProjectConfig(t *testing.T) {
 	}`
 	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(configContent), 0644))
 
-	resolved := ResolveSessionRecording(tmpDir)
+	resolved := ResolveSessionRecording(tmpDir, "", "")
 
 	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
 	assert.Equal(t, SessionRecordingSourceRepo, resolved.Source)
@@ -106,7 +106,7 @@ func TestResolveSessionRecording_EmptyProjectConfig_DefaultsToAuto(t *testing.T)
 	}`
 	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(configContent), 0644))
 
-	resolved := ResolveSessionRecording(tmpDir)
+	resolved := ResolveSessionRecording(tmpDir, "", "")
 
 	// ox-initialized repo with no explicit setting defaults to auto
 	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
@@ -203,7 +203,7 @@ func TestResolveSessionRecording_EnvVarOverridesAll(t *testing.T) {
 			configContent := `{"config_version": "2", "session_recording": "manual"}`
 			require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(configContent), 0644))
 
-			resolved := ResolveSessionRecording(tmpDir)
+			resolved := ResolveSessionRecording(tmpDir, "", "")
 
 			assert.Equal(t, tt.wantMode, resolved.Mode)
 			assert.Equal(t, SessionRecordingSourceEnv, resolved.Source)
@@ -225,7 +225,7 @@ func TestResolveSessionRecording_EnvVarDisabledOverridesAutoConfig(t *testing.T)
 	configContent := `{"config_version": "2", "session_recording": "auto"}`
 	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(configContent), 0644))
 
-	resolved := ResolveSessionRecording(tmpDir)
+	resolved := ResolveSessionRecording(tmpDir, "", "")
 
 	assert.Equal(t, SessionRecordingDisabled, resolved.Mode)
 	assert.Equal(t, SessionRecordingSourceEnv, resolved.Source)
@@ -257,7 +257,7 @@ func TestResolveSessionRecording_UserOverridesProject(t *testing.T) {
 		0644,
 	))
 
-	resolved := ResolveSessionRecording(tmpDir)
+	resolved := ResolveSessionRecording(tmpDir, "", "")
 	// NormalizeSessionRecording maps "disabled" → "disabled"
 	// but sessions.GetMode() returns "disabled" for mode: disabled
 	// The function checks if mode != "" && mode != "none"
@@ -276,7 +276,7 @@ func TestResolveSessionRecording_DefaultIsManual(t *testing.T) {
 	t.Setenv("OX_SESSION_RECORDING", "")
 
 	// no .sageox/ project config, no user config → should default to manual
-	resolved := ResolveSessionRecording(tmpDir)
+	resolved := ResolveSessionRecording(tmpDir, "", "")
 	assert.Equal(t, SessionRecordingManual, resolved.Mode)
 	assert.Equal(t, SessionRecordingSourceDefault, resolved.Source)
 }
@@ -311,4 +311,120 @@ func TestNormalizeSessionPublishing(t *testing.T) {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+// --- KB-aware precedence + safety inversion ---
+//
+// These tests exercise the kbID/kbType code path. They write a real
+// .sageox/config.yaml under the XDG_DATA_HOME tree so paths.KBDir resolves
+// to a tmp location and the resolver reads the fixture for real.
+
+// writeKBConfig drops a minimal config.yaml under the location paths.KBDir
+// will compute given the env. dataHome must be the value of XDG_DATA_HOME.
+func writeKBConfig(t *testing.T, dataHome, endpointSlug, kbID, mode string) {
+	t.Helper()
+	kbDir := filepath.Join(dataHome, "sageox", endpointSlug, "kb", kbID, ".sageox")
+	require.NoError(t, os.MkdirAll(kbDir, 0755))
+	yaml := "version: 1\nfeatures:\n  session_recording:\n    mode: " + mode + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(kbDir, "config.yaml"), []byte(yaml), 0644))
+}
+
+// kbTestEnv isolates user config, endpoint, and KB data home for a test.
+// Returns the dataHome path so the test can stage a KB config fixture.
+func kbTestEnv(t *testing.T) (tmpDir, dataHome, endpointSlug string) {
+	t.Helper()
+	tmpDir = t.TempDir()
+	userConfigDir := t.TempDir()
+	dataHome = t.TempDir()
+	endpointSlug = "test.sageox.ai"
+
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_CONFIG_HOME", userConfigDir)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("SAGEOX_ENDPOINT", endpointSlug)
+	t.Setenv("OX_SESSION_RECORDING", "")
+	return
+}
+
+func writeUserMode(t *testing.T, mode string) {
+	t.Helper()
+	xdg := os.Getenv("XDG_CONFIG_HOME")
+	require.NotEmpty(t, xdg, "XDG_CONFIG_HOME must be set first")
+	dir := filepath.Join(xdg, "sageox")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	body := "sessions:\n  mode: " + mode + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(body), 0644))
+}
+
+func TestResolveSessionRecording_KB_EnvWinsOverEverything(t *testing.T) {
+	tmpDir, dataHome, ep := kbTestEnv(t)
+	t.Setenv("OX_SESSION_RECORDING", "auto")
+	writeUserMode(t, "disabled")
+	writeKBConfig(t, dataHome, ep, "kb_test", "disabled")
+
+	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
+	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
+	assert.Equal(t, SessionRecordingSourceEnv, resolved.Source)
+	assert.False(t, resolved.SafetyInversion)
+	assert.Equal(t, "kb_test", resolved.KBID)
+	assert.Equal(t, "personal", resolved.KBType)
+}
+
+func TestResolveSessionRecording_KB_UserWinsOverKB(t *testing.T) {
+	tmpDir, dataHome, ep := kbTestEnv(t)
+	writeUserMode(t, "auto")
+	writeKBConfig(t, dataHome, ep, "kb_test", "manual")
+
+	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
+	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
+	assert.Equal(t, SessionRecordingSourceUser, resolved.Source)
+	assert.False(t, resolved.SafetyInversion)
+}
+
+func TestResolveSessionRecording_KB_KBSetUserUnset(t *testing.T) {
+	tmpDir, dataHome, ep := kbTestEnv(t)
+	writeKBConfig(t, dataHome, ep, "kb_test", "auto")
+
+	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
+	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
+	assert.Equal(t, SessionRecordingSourceKB, resolved.Source)
+	assert.False(t, resolved.SafetyInversion)
+}
+
+func TestResolveSessionRecording_KB_SafetyInversion_UserDisabledKBAuto(t *testing.T) {
+	tmpDir, dataHome, ep := kbTestEnv(t)
+	writeUserMode(t, "disabled")
+	writeKBConfig(t, dataHome, ep, "kb_test", "auto")
+
+	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
+	assert.Equal(t, SessionRecordingDisabled, resolved.Mode)
+	// user's veto wins precedence too, so source is user. No inversion needed —
+	// precedence layer (user) was itself disabled.
+	assert.Equal(t, SessionRecordingSourceUser, resolved.Source)
+	assert.False(t, resolved.SafetyInversion)
+}
+
+func TestResolveSessionRecording_KB_SafetyInversion_UserAutoKBDisabled(t *testing.T) {
+	tmpDir, dataHome, ep := kbTestEnv(t)
+	writeUserMode(t, "auto")
+	writeKBConfig(t, dataHome, ep, "kb_test", "disabled")
+
+	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
+	assert.Equal(t, SessionRecordingDisabled, resolved.Mode)
+	// KB's veto inverted what precedence would otherwise pick — flag it.
+	assert.Equal(t, SessionRecordingSourceKB, resolved.Source)
+	assert.True(t, resolved.SafetyInversion)
+}
+
+func TestResolveSessionRecording_KB_DefaultFromKBType(t *testing.T) {
+	tmpDir, _, _ := kbTestEnv(t)
+	// no user, no KB config file — fall through to per-KB-type default.
+	resolved := ResolveSessionRecording(tmpDir, "kb_missing", "personal")
+	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
+	assert.Equal(t, SessionRecordingSourceDefault, resolved.Source)
+	assert.Equal(t, "personal", resolved.KBType)
+
+	resolved2 := ResolveSessionRecording(tmpDir, "kb_missing", "profile")
+	assert.Equal(t, SessionRecordingManual, resolved2.Mode)
+	assert.Equal(t, SessionRecordingSourceDefault, resolved2.Source)
 }

--- a/internal/config/session_recording_test.go
+++ b/internal/config/session_recording_test.go
@@ -356,75 +356,120 @@ func writeUserMode(t *testing.T, mode string) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(body), 0644))
 }
 
-func TestResolveSessionRecording_KB_EnvWinsOverEverything(t *testing.T) {
-	tmpDir, dataHome, ep := kbTestEnv(t)
-	t.Setenv("OX_SESSION_RECORDING", "auto")
-	writeUserMode(t, "disabled")
-	writeKBConfig(t, dataHome, ep, "kb_test", "disabled")
+func TestResolveSessionRecording_KB_PrecedenceMatrix(t *testing.T) {
+	tests := []struct {
+		name          string
+		envMode       string
+		userMode      string
+		kbMode        string
+		kbID          string
+		kbType        string
+		wantMode      string
+		wantSource    SessionRecordingSource
+		wantInversion bool
+	}{
+		{
+			name:          "env wins over everything",
+			envMode:       "auto",
+			userMode:      "disabled",
+			kbMode:        "disabled",
+			kbID:          "kb_test",
+			kbType:        "personal",
+			wantMode:      SessionRecordingAuto,
+			wantSource:    SessionRecordingSourceEnv,
+			wantInversion: false,
+		},
+		{
+			name:          "user beats kb",
+			userMode:      "auto",
+			kbMode:        "manual",
+			kbID:          "kb_test",
+			kbType:        "personal",
+			wantMode:      SessionRecordingAuto,
+			wantSource:    SessionRecordingSourceUser,
+			wantInversion: false,
+		},
+		{
+			name:          "kb set user unset",
+			kbMode:        "auto",
+			kbID:          "kb_test",
+			kbType:        "personal",
+			wantMode:      SessionRecordingAuto,
+			wantSource:    SessionRecordingSourceKB,
+			wantInversion: false,
+		},
+		{
+			name:          "user disabled vetoes kb auto",
+			userMode:      "disabled",
+			kbMode:        "auto",
+			kbID:          "kb_test",
+			kbType:        "personal",
+			wantMode:      SessionRecordingDisabled,
+			wantSource:    SessionRecordingSourceUser,
+			wantInversion: false,
+		},
+		{
+			name:          "kb disabled vetoes user auto",
+			userMode:      "auto",
+			kbMode:        "disabled",
+			kbID:          "kb_test",
+			kbType:        "personal",
+			wantMode:      SessionRecordingDisabled,
+			wantSource:    SessionRecordingSourceKB,
+			wantInversion: true,
+		},
+		{
+			name:          "default from personal kb type",
+			kbID:          "kb_missing",
+			kbType:        "personal",
+			wantMode:      SessionRecordingAuto,
+			wantSource:    SessionRecordingSourceDefault,
+			wantInversion: false,
+		},
+		{
+			name:          "default from profile kb type",
+			kbID:          "kb_missing",
+			kbType:        "profile",
+			wantMode:      SessionRecordingManual,
+			wantSource:    SessionRecordingSourceDefault,
+			wantInversion: false,
+		},
+	}
 
-	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
-	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
-	assert.Equal(t, SessionRecordingSourceEnv, resolved.Source)
-	assert.False(t, resolved.SafetyInversion)
-	assert.Equal(t, "kb_test", resolved.KBID)
-	assert.Equal(t, "personal", resolved.KBType)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, dataHome, ep := kbTestEnv(t)
+			if tt.envMode != "" {
+				t.Setenv("OX_SESSION_RECORDING", tt.envMode)
+			}
+			if tt.userMode != "" {
+				writeUserMode(t, tt.userMode)
+			}
+			if tt.kbMode != "" {
+				writeKBConfig(t, dataHome, ep, tt.kbID, tt.kbMode)
+			}
+
+			resolved := ResolveSessionRecording(tmpDir, tt.kbID, tt.kbType)
+			assert.Equal(t, tt.wantMode, resolved.Mode)
+			assert.Equal(t, tt.wantSource, resolved.Source)
+			assert.Equal(t, tt.wantInversion, resolved.SafetyInversion)
+			assert.Equal(t, tt.kbID, resolved.KBID)
+			assert.Equal(t, tt.kbType, resolved.KBType)
+		})
+	}
 }
 
-func TestResolveSessionRecording_KB_UserWinsOverKB(t *testing.T) {
-	tmpDir, dataHome, ep := kbTestEnv(t)
-	writeUserMode(t, "auto")
-	writeKBConfig(t, dataHome, ep, "kb_test", "manual")
-
-	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
-	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
-	assert.Equal(t, SessionRecordingSourceUser, resolved.Source)
-	assert.False(t, resolved.SafetyInversion)
-}
-
-func TestResolveSessionRecording_KB_KBSetUserUnset(t *testing.T) {
-	tmpDir, dataHome, ep := kbTestEnv(t)
-	writeKBConfig(t, dataHome, ep, "kb_test", "auto")
-
-	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
-	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
-	assert.Equal(t, SessionRecordingSourceKB, resolved.Source)
-	assert.False(t, resolved.SafetyInversion)
-}
-
-func TestResolveSessionRecording_KB_SafetyInversion_UserDisabledKBAuto(t *testing.T) {
-	tmpDir, dataHome, ep := kbTestEnv(t)
-	writeUserMode(t, "disabled")
-	writeKBConfig(t, dataHome, ep, "kb_test", "auto")
-
-	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
-	assert.Equal(t, SessionRecordingDisabled, resolved.Mode)
-	// user's veto wins precedence too, so source is user. No inversion needed —
-	// precedence layer (user) was itself disabled.
-	assert.Equal(t, SessionRecordingSourceUser, resolved.Source)
-	assert.False(t, resolved.SafetyInversion)
-}
-
-func TestResolveSessionRecording_KB_SafetyInversion_UserAutoKBDisabled(t *testing.T) {
-	tmpDir, dataHome, ep := kbTestEnv(t)
-	writeUserMode(t, "auto")
-	writeKBConfig(t, dataHome, ep, "kb_test", "disabled")
-
-	resolved := ResolveSessionRecording(tmpDir, "kb_test", "personal")
-	assert.Equal(t, SessionRecordingDisabled, resolved.Mode)
-	// KB's veto inverted what precedence would otherwise pick — flag it.
-	assert.Equal(t, SessionRecordingSourceKB, resolved.Source)
-	assert.True(t, resolved.SafetyInversion)
-}
-
-func TestResolveSessionRecording_KB_DefaultFromKBType(t *testing.T) {
+func TestResolveSessionRecording_KB_BoundProjectDefaultsToAutoWhileTypeUnknown(t *testing.T) {
 	tmpDir, _, _ := kbTestEnv(t)
-	// no user, no KB config file — fall through to per-KB-type default.
-	resolved := ResolveSessionRecording(tmpDir, "kb_missing", "personal")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".sageox"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, ".sageox", "config.yaml"),
+		[]byte("kb_id: kb_project\nrepo_id: repo_abc\n"),
+		0o644,
+	))
+
+	resolved := ResolveSessionRecording(tmpDir, "kb_project", "")
 	assert.Equal(t, SessionRecordingAuto, resolved.Mode)
 	assert.Equal(t, SessionRecordingSourceDefault, resolved.Source)
-	assert.Equal(t, "personal", resolved.KBType)
-
-	resolved2 := ResolveSessionRecording(tmpDir, "kb_missing", "profile")
-	assert.Equal(t, SessionRecordingManual, resolved2.Mode)
-	assert.Equal(t, SessionRecordingSourceDefault, resolved2.Source)
+	assert.Equal(t, "kb_project", resolved.KBID)
 }

--- a/internal/daemon/agentwork/gitenv_test.go
+++ b/internal/daemon/agentwork/gitenv_test.go
@@ -1,0 +1,13 @@
+package agentwork
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -723,6 +723,16 @@ func (d *Daemon) shutdown() error {
 		d.cancel()
 	}
 
+	// Release the global-sync lease as soon as global work is canceled so a
+	// replacement daemon can acquire ownership during its startup path —
+	// well before the CodeDB drain + wg.Wait below complete. cleanup() also
+	// calls Release() (idempotent) for the supersession + early-failure
+	// paths that bypass shutdown().
+	d.releaseGlobalSyncLease()
+	if d.scheduler != nil {
+		d.scheduler.ReleaseGlobalSyncLease()
+	}
+
 	// CodeDB drain: the CheckFreshness indexing goroutine is NOT tracked by
 	// d.wg (it owns its own per-pass context). Killing the daemon mid-bleve-
 	// batch leaves a torn `_mapping` doc — store.openOrCreateBleveIndex
@@ -848,6 +858,9 @@ func (d *Daemon) cleanup() {
 	// auto-released on process exit, but Release() also unblocks the
 	// next daemon's acquire attempt promptly when shutdown is graceful.
 	d.releaseGlobalSyncLease()
+	if d.scheduler != nil {
+		d.scheduler.ReleaseGlobalSyncLease()
+	}
 	if !d.wasSuperseded {
 		if err := UnregisterDaemon(); err != nil {
 			d.logger.Warn("failed to unregister daemon", "error", err)
@@ -1141,7 +1154,7 @@ func (d *Daemon) initComponents() time.Duration {
 	// to acquire is not a startup error — non-owner daemons keep doing
 	// per-repo work and just skip team-context + KB ListBubbles ticks.
 	d.acquireGlobalSyncLease(projectEndpoint)
-	d.scheduler.SetGlobalSyncLease(d.globalSyncLease)
+	d.scheduler.SetGlobalSyncLease(endpoint.NormalizeEndpoint(projectEndpoint), d.globalSyncLease)
 	if err := UpdateGlobalSyncOwnership(endpoint.NormalizeEndpoint(projectEndpoint), d.globalSyncLease != nil); err != nil {
 		d.logger.Debug("failed to update global-sync ownership in registry", "error", err)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -206,6 +206,13 @@ type Daemon struct {
 	// pass; concurrent callers get AlreadyRunning=true and no work.
 	// The goroutine clears it via Store(false) on exit.
 	doctorRunning atomic.Bool
+
+	// globalSyncLease is the per-(user, endpoint) flock lease that
+	// authorizes this daemon to do team-context pulls and KB
+	// ListBubbles. nil when another daemon owns the lease — the
+	// daemon still runs every per-repo ticker. Acquired in
+	// initComponents and released in shutdown. See bead ox-6zme.
+	globalSyncLease *Lease
 }
 
 // New creates a new daemon instance.
@@ -788,10 +795,59 @@ func (d *Daemon) writePidFile() error {
 	return os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", os.Getpid())), 0600)
 }
 
+// acquireGlobalSyncLease attempts to claim the per-endpoint global-sync
+// flock for this daemon's lifetime. On success d.globalSyncLease is set
+// and the scheduler will run team-context + KB ListBubbles ticks; on
+// ErrNotOwner d.globalSyncLease stays nil and another daemon owns those
+// responsibilities. Any other error is treated like ErrNotOwner — we'd
+// rather have a daemon with degraded global sync than a daemon that
+// refuses to start.
+//
+// Endpoint is normalized via NormalizeEndpoint before path resolution
+// (the lease file path uses NormalizeSlug internally). An empty
+// endpoint short-circuits without attempting the flock; there is no
+// "global sync" to coordinate for an unconfigured daemon.
+func (d *Daemon) acquireGlobalSyncLease(projectEndpoint string) {
+	if projectEndpoint == "" {
+		d.logger.Debug("global-sync lease: no endpoint, skipping acquire")
+		return
+	}
+	ep := endpoint.NormalizeEndpoint(projectEndpoint)
+	lease, err := AcquireGlobalSyncLease(ep)
+	if err != nil {
+		if errors.Is(err, ErrNotOwner) {
+			d.logger.Info("global-sync lease held by another daemon", "endpoint", ep)
+			return
+		}
+		d.logger.Warn("global-sync lease acquire failed; running as non-owner", "endpoint", ep, "error", err)
+		return
+	}
+	d.globalSyncLease = lease
+	d.logger.Info("global-sync lease acquired", "endpoint", ep)
+}
+
+// releaseGlobalSyncLease releases the per-endpoint flock if held. Safe
+// to call when the lease was never acquired (nil receiver inside).
+func (d *Daemon) releaseGlobalSyncLease() {
+	if d.globalSyncLease == nil {
+		return
+	}
+	if err := d.globalSyncLease.Release(); err != nil {
+		d.logger.Warn("global-sync lease release failed", "error", err)
+	} else {
+		d.logger.Info("global-sync lease released", "endpoint", d.globalSyncLease.Endpoint())
+	}
+	d.globalSyncLease = nil
+}
+
 // cleanup removes PID and socket files.
 // When the daemon was superseded by a new instance, skip removing the socket
 // and registry entry — those now belong to the replacement daemon.
 func (d *Daemon) cleanup() {
+	// Release the global-sync lease regardless of supersession. flock is
+	// auto-released on process exit, but Release() also unblocks the
+	// next daemon's acquire attempt promptly when shutdown is graceful.
+	d.releaseGlobalSyncLease()
 	if !d.wasSuperseded {
 		if err := UnregisterDaemon(); err != nil {
 			d.logger.Warn("failed to unregister daemon", "error", err)
@@ -1078,6 +1134,17 @@ func (d *Daemon) initComponents() time.Duration {
 	d.scheduler = NewSyncScheduler(d.config, d.logger)
 	d.scheduler.SetTracer(d.tracer)
 	d.scheduler.SetEventBus(d.eventBus)
+
+	// Per-(user, endpoint) global-sync leader election (ox-6zme).
+	// Acquire the flock lease BEFORE the scheduler runs so the first
+	// teamContextChan tick sees the correct ownership state. Failure
+	// to acquire is not a startup error — non-owner daemons keep doing
+	// per-repo work and just skip team-context + KB ListBubbles ticks.
+	d.acquireGlobalSyncLease(projectEndpoint)
+	d.scheduler.SetGlobalSyncLease(d.globalSyncLease)
+	if err := UpdateGlobalSyncOwnership(endpoint.NormalizeEndpoint(projectEndpoint), d.globalSyncLease != nil); err != nil {
+		d.logger.Debug("failed to update global-sync ownership in registry", "error", err)
+	}
 
 	// code index manager
 	if d.config.ProjectRoot != "" {

--- a/internal/daemon/gitenv_test.go
+++ b/internal/daemon/gitenv_test.go
@@ -1,0 +1,13 @@
+package daemon
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/daemon/global_lease.go
+++ b/internal/daemon/global_lease.go
@@ -1,0 +1,196 @@
+package daemon
+
+// Cross-process leader election for global-sync work (team-context pulls
+// and the KB ListBubbles API call). Both operations touch shared XDG state
+// that is the same for every project the user has open, so when N
+// per-repo daemons run concurrently they would otherwise each hit the
+// same APIs every 15s — wasted bandwidth and rate-limit risk.
+//
+// We use a per-(user, endpoint) advisory POSIX flock(2) on a single lease
+// file. Exactly one daemon per endpoint can hold LOCK_EX|LOCK_NB at any
+// time; the rest skip the global-sync ticker calls and keep doing their
+// per-repo work (ledger pull, code index, sessions, github sync,
+// whispers, heartbeats — all unchanged).
+//
+// The lease is acquired once at daemon startup and held for the daemon's
+// lifetime. On process death the kernel auto-releases the lock, so the
+// next daemon's next acquire attempt picks up the lease. No explicit
+// hand-off, no heartbeat, no RPC between daemons.
+//
+// Per `.claude/rules/lfs-no-git-lfs-binary.md` and the existing kb_lock.go
+// design, we use stdlib `syscall.Flock` rather than a third-party lock
+// library, keeping the dependency surface minimal.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/paths"
+)
+
+// ErrNotOwner is returned by AcquireGlobalSyncLease when another daemon
+// process already holds the lease for the given endpoint. The caller
+// should set its in-memory lease handle to nil and skip global-sync
+// tickers for the daemon's lifetime; the next daemon-level retry happens
+// implicitly the next time a new daemon process starts up.
+var ErrNotOwner = errors.New("another daemon owns the global-sync lease for this endpoint")
+
+// globalLeaseDirName is the subdirectory under DaemonStateDir() that
+// holds per-endpoint lease files. Kept distinct from kbLockDirName so a
+// future endpoint rename / kb migration doesn't blow up both lock dirs
+// at once.
+const globalLeaseDirName = "global-sync-leases"
+
+// globalLeaseFileName is the filename of the lease file inside the
+// per-endpoint subdirectory. The endpoint slug is the parent directory
+// name, so this constant is the same for every endpoint.
+const globalLeaseFileName = "global-sync.lease"
+
+// Lease is a per-(user, endpoint) advisory lock claiming ownership of
+// global-sync work. Only the daemon that successfully Acquired the lease
+// runs team-context pulls and KB ListBubbles; other daemons set their
+// lease handle to nil and skip those tickers.
+//
+// Lease lifetime is the daemon's lifetime — acquired in initComponents
+// and released in shutdown. Process death releases the lock at the
+// kernel level via flock semantics, so a crashed owner doesn't strand
+// global sync.
+type Lease struct {
+	file     *os.File
+	endpoint string
+
+	// held is set to 1 while we still own the lock. Release uses
+	// CompareAndSwap to make repeated calls a no-op (the file would
+	// already be closed; double-Close is harmless but logging twice on
+	// shutdown is noise).
+	held atomic.Int32
+}
+
+// globalLeaseDirOnce guards lazy creation of the lease parent dir. We
+// only need to attempt MkdirAll once per process; the per-endpoint
+// subdirectory is created on demand inside AcquireGlobalSyncLease.
+var (
+	globalLeaseDirOnce   sync.Once
+	globalLeaseDirCached string
+	globalLeaseDirErr    error
+)
+
+// globalLeaseDir returns the directory containing per-endpoint lease
+// subdirectories, creating it on first call. Lives under
+// paths.DaemonStateDir() so it inherits the project's XDG vs legacy
+// resolution and the daemon's existing state cleanup posture.
+func globalLeaseDir() (string, error) {
+	globalLeaseDirOnce.Do(func() {
+		base := paths.DaemonStateDir()
+		if base == "" {
+			globalLeaseDirErr = errors.New("daemon state dir unresolved")
+			return
+		}
+		dir := filepath.Join(base, globalLeaseDirName)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			globalLeaseDirErr = fmt.Errorf("create global lease dir: %w", err)
+			return
+		}
+		globalLeaseDirCached = dir
+	})
+	if globalLeaseDirErr != nil {
+		return "", globalLeaseDirErr
+	}
+	return globalLeaseDirCached, nil
+}
+
+// globalLeasePath returns the absolute path to the lease file for the
+// given endpoint. The endpoint string is run through NormalizeSlug to
+// produce a filesystem-safe path component (strips scheme, port,
+// subdomain prefixes per .claude/rules/endpoints.md). Empty endpoint
+// returns an error rather than a generic "default" path — the caller
+// almost certainly has a bug if they got here with no endpoint.
+func globalLeasePath(ep string) (string, error) {
+	if ep == "" {
+		return "", errors.New("empty endpoint")
+	}
+	slug := endpoint.NormalizeSlug(ep)
+	if slug == "" || slug == "unknown" {
+		return "", fmt.Errorf("invalid endpoint for lease path: %q", ep)
+	}
+	// defense in depth: a slug containing a path separator would escape
+	// the lease dir. NormalizeSlug strips ports and schemes so this
+	// shouldn't happen, but a stray bad input must not be able to flock
+	// arbitrary files.
+	if filepath.Base(slug) != slug {
+		return "", fmt.Errorf("invalid endpoint slug for lease path: %q", slug)
+	}
+	dir, err := globalLeaseDir()
+	if err != nil {
+		return "", err
+	}
+	endpointDir := filepath.Join(dir, slug)
+	if err := os.MkdirAll(endpointDir, 0o700); err != nil {
+		return "", fmt.Errorf("create endpoint lease dir: %w", err)
+	}
+	return filepath.Join(endpointDir, globalLeaseFileName), nil
+}
+
+// AcquireGlobalSyncLease attempts a non-blocking exclusive flock on the
+// per-endpoint lease file. Returns:
+//
+//   - (lease, nil) on success — caller MUST defer lease.Release() on
+//     daemon shutdown.
+//   - (nil, ErrNotOwner) when another daemon already holds the lease for
+//     this endpoint. The daemon is still healthy — it just won't run
+//     team-context or KB ListBubbles ticks.
+//   - (nil, err) on filesystem failure or invalid endpoint.
+func AcquireGlobalSyncLease(ep string) (*Lease, error) {
+	path, err := globalLeasePath(ep)
+	if err != nil {
+		return nil, err
+	}
+	f, acquired, err := platformAcquireGlobalLease(path)
+	if err != nil {
+		return nil, err
+	}
+	if !acquired {
+		return nil, ErrNotOwner
+	}
+	l := &Lease{file: f, endpoint: ep}
+	l.held.Store(1)
+	return l, nil
+}
+
+// Release releases the underlying flock and closes the file. Idempotent:
+// repeated calls after the first return nil without re-closing the fd.
+// Safe to defer at daemon shutdown even if the daemon failed to start.
+func (l *Lease) Release() error {
+	if l == nil {
+		return nil
+	}
+	if !l.held.CompareAndSwap(1, 0) {
+		return nil
+	}
+	return platformReleaseGlobalLease(l.file)
+}
+
+// IsHeld returns true while this Lease still owns the lock. Used by
+// doctor checks and tests; daemon code should compare `d.lease != nil`
+// directly since a non-nil lease that's been Released has already
+// triggered daemon shutdown.
+func (l *Lease) IsHeld() bool {
+	if l == nil {
+		return false
+	}
+	return l.held.Load() == 1
+}
+
+// Endpoint returns the endpoint string the lease was acquired for. For
+// logging / doctor surfacing only.
+func (l *Lease) Endpoint() string {
+	if l == nil {
+		return ""
+	}
+	return l.endpoint
+}

--- a/internal/daemon/global_lease.go
+++ b/internal/daemon/global_lease.go
@@ -172,7 +172,13 @@ func (l *Lease) Release() error {
 	if !l.held.CompareAndSwap(1, 0) {
 		return nil
 	}
-	return platformReleaseGlobalLease(l.file)
+	if err := platformReleaseGlobalLease(l.file); err != nil {
+		// Restore held-state so callers can retry — otherwise a transient
+		// flock release failure strands lock ownership until process exit.
+		l.held.Store(1)
+		return fmt.Errorf("release global sync lease: %w", err)
+	}
+	return nil
 }
 
 // IsHeld returns true while this Lease still owns the lock. Used by

--- a/internal/daemon/global_lease_test.go
+++ b/internal/daemon/global_lease_test.go
@@ -12,6 +12,7 @@ package daemon
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -171,6 +172,7 @@ func TestSyncScheduler_ReacquiresGlobalLeaseAfterOwnerExit(t *testing.T) {
 	if err := owner.Release(); err != nil {
 		t.Fatalf("owner release: %v", err)
 	}
+	s.logger = slog.Default()
 	if !s.IsGlobalSyncOwner() {
 		t.Fatal("scheduler should acquire the lease once the previous owner exits")
 	}

--- a/internal/daemon/global_lease_test.go
+++ b/internal/daemon/global_lease_test.go
@@ -151,6 +151,32 @@ func TestGlobalLeasePerEndpoint(t *testing.T) {
 	}
 }
 
+func TestSyncScheduler_ReacquiresGlobalLeaseAfterOwnerExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows lease backend is a no-op (ADR-017 §5)")
+	}
+	withIsolatedLeaseDir(t)
+
+	owner, err := AcquireGlobalSyncLease("sageox.ai")
+	if err != nil {
+		t.Fatalf("owner acquire: %v", err)
+	}
+
+	s := NewSyncScheduler(DefaultConfig(), nil)
+	s.SetGlobalSyncLease("sageox.ai", nil)
+	if s.IsGlobalSyncOwner() {
+		t.Fatal("scheduler should remain follower while another daemon owns the lease")
+	}
+
+	if err := owner.Release(); err != nil {
+		t.Fatalf("owner release: %v", err)
+	}
+	if !s.IsGlobalSyncOwner() {
+		t.Fatal("scheduler should acquire the lease once the previous owner exits")
+	}
+	s.ReleaseGlobalSyncLease()
+}
+
 // TestGlobalLeaseNormalizesEndpoint verifies prefix-equivalent endpoints
 // (api.sageox.ai vs sageox.ai vs www.sageox.ai) collapse to the same
 // lease file. Without this, a daemon configured with api.sageox.ai and

--- a/internal/daemon/global_lease_test.go
+++ b/internal/daemon/global_lease_test.go
@@ -1,0 +1,331 @@
+package daemon
+
+// Cross-process verification of the per-(user, endpoint) global-sync
+// flock lease introduced for ox-6zme. The lease uses the same POSIX
+// flock(2) primitive as kb_lock.go, so the test surface mirrors
+// kb_lock_test.go: in-process contention, cross-endpoint independence,
+// and a subprocess-based owner-death failover.
+//
+// All tests redirect the lease directory via t.Setenv on XDG_STATE_HOME
+// (paths.DaemonStateDir resolves under StateDir → XDG_STATE_HOME) so the
+// developer's real ~/.local/state/ox state is never touched.
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// withIsolatedLeaseDir redirects paths.DaemonStateDir → tmp dir via
+// XDG_STATE_HOME for the duration of the test. Also resets the
+// package-level globalLeaseDirOnce so a fresh per-test directory is
+// created instead of reusing a cached one from a previous test.
+func withIsolatedLeaseDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	// reset memoized state so this test sees the redirected XDG path.
+	globalLeaseDirOnce = sync.Once{}
+	globalLeaseDirCached = ""
+	globalLeaseDirErr = nil
+	t.Cleanup(func() {
+		// reset again after the test so the next test gets its own dir.
+		globalLeaseDirOnce = sync.Once{}
+		globalLeaseDirCached = ""
+		globalLeaseDirErr = nil
+	})
+	return dir
+}
+
+// TestGlobalLeaseAcquireRelease verifies a single daemon can acquire,
+// release, and re-acquire the lease for an endpoint. This is the
+// "steady state on a single host" path.
+func TestGlobalLeaseAcquireRelease(t *testing.T) {
+	withIsolatedLeaseDir(t)
+
+	l, err := AcquireGlobalSyncLease("sageox.ai")
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if !l.IsHeld() {
+		t.Fatal("lease should be held after acquire")
+	}
+	if l.Endpoint() != "sageox.ai" {
+		t.Errorf("endpoint = %q, want sageox.ai", l.Endpoint())
+	}
+
+	if err := l.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if l.IsHeld() {
+		t.Error("lease should not be held after release")
+	}
+
+	// Release is idempotent — second call must not error.
+	if err := l.Release(); err != nil {
+		t.Errorf("second release: %v", err)
+	}
+
+	// Re-acquire after release succeeds.
+	l2, err := AcquireGlobalSyncLease("sageox.ai")
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	defer l2.Release()
+	if !l2.IsHeld() {
+		t.Error("re-acquired lease should be held")
+	}
+}
+
+// TestGlobalLeaseInProcessContention verifies that a second acquire on
+// the same endpoint while the first is still held returns ErrNotOwner.
+// flock locks are per-open-file-description, so two opens of the same
+// path in the same process still contend correctly.
+func TestGlobalLeaseInProcessContention(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows lease backend is a no-op (ADR-017 §5)")
+	}
+	withIsolatedLeaseDir(t)
+
+	owner, err := AcquireGlobalSyncLease("sageox.ai")
+	if err != nil {
+		t.Fatalf("owner acquire: %v", err)
+	}
+	defer owner.Release()
+
+	follower, err := AcquireGlobalSyncLease("sageox.ai")
+	if !errors.Is(err, ErrNotOwner) {
+		t.Fatalf("follower err = %v, want ErrNotOwner", err)
+	}
+	if follower != nil {
+		t.Error("follower lease should be nil on contention")
+	}
+
+	// Release owner — follower can now acquire.
+	if err := owner.Release(); err != nil {
+		t.Fatalf("owner release: %v", err)
+	}
+	follower2, err := AcquireGlobalSyncLease("sageox.ai")
+	if err != nil {
+		t.Fatalf("follower re-acquire after owner release: %v", err)
+	}
+	defer follower2.Release()
+}
+
+// TestGlobalLeasePerEndpoint verifies the lease is scoped per-endpoint:
+// two daemons against different endpoints can both hold a lease at the
+// same time. This is the multi-environment case (user logged into
+// sageox.ai for $work and localhost for $devtest).
+func TestGlobalLeasePerEndpoint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows lease backend is a no-op (ADR-017 §5)")
+	}
+	withIsolatedLeaseDir(t)
+
+	prod, err := AcquireGlobalSyncLease("sageox.ai")
+	if err != nil {
+		t.Fatalf("prod acquire: %v", err)
+	}
+	defer prod.Release()
+
+	staging, err := AcquireGlobalSyncLease("staging.sageox.ai")
+	if err != nil {
+		t.Fatalf("staging acquire: %v", err)
+	}
+	defer staging.Release()
+
+	local, err := AcquireGlobalSyncLease("localhost:8080")
+	if err != nil {
+		t.Fatalf("local acquire: %v", err)
+	}
+	defer local.Release()
+
+	if !prod.IsHeld() || !staging.IsHeld() || !local.IsHeld() {
+		t.Error("all three per-endpoint leases should be held simultaneously")
+	}
+}
+
+// TestGlobalLeaseNormalizesEndpoint verifies prefix-equivalent endpoints
+// (api.sageox.ai vs sageox.ai vs www.sageox.ai) collapse to the same
+// lease file. Without this, a daemon configured with api.sageox.ai and
+// another with sageox.ai would both think they own the lease.
+func TestGlobalLeaseNormalizesEndpoint(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows lease backend is a no-op (ADR-017 §5)")
+	}
+	withIsolatedLeaseDir(t)
+
+	owner, err := AcquireGlobalSyncLease("api.sageox.ai")
+	if err != nil {
+		t.Fatalf("acquire api.sageox.ai: %v", err)
+	}
+	defer owner.Release()
+
+	// sageox.ai normalizes to the same slug — should contend.
+	_, err = AcquireGlobalSyncLease("sageox.ai")
+	if !errors.Is(err, ErrNotOwner) {
+		t.Errorf("sageox.ai should contend with api.sageox.ai; got err = %v", err)
+	}
+
+	// www.sageox.ai also normalizes to sageox.ai.
+	_, err = AcquireGlobalSyncLease("www.sageox.ai")
+	if !errors.Is(err, ErrNotOwner) {
+		t.Errorf("www.sageox.ai should contend with api.sageox.ai; got err = %v", err)
+	}
+
+	// https://app.sageox.ai/v1 normalizes to the same slug too.
+	_, err = AcquireGlobalSyncLease("https://app.sageox.ai/v1")
+	if !errors.Is(err, ErrNotOwner) {
+		t.Errorf("https://app.sageox.ai/v1 should contend; got err = %v", err)
+	}
+}
+
+// TestGlobalLeaseEmptyEndpoint guards against accidental flock of a
+// "default" path when the daemon is misconfigured. Empty endpoint must
+// return an error rather than silently succeed.
+func TestGlobalLeaseEmptyEndpoint(t *testing.T) {
+	withIsolatedLeaseDir(t)
+	l, err := AcquireGlobalSyncLease("")
+	if err == nil {
+		t.Error("empty endpoint should error")
+		_ = l.Release()
+	}
+}
+
+// TestGlobalLeaseSubprocessFailover verifies that when the owning daemon
+// process dies (here: a child subprocess that exits while holding the
+// lock), the next acquire from the parent succeeds. The kernel auto-
+// releases flock on process termination, so no explicit hand-off is
+// needed.
+func TestGlobalLeaseSubprocessFailover(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows lease backend is a no-op (ADR-017 §5)")
+	}
+	dir := withIsolatedLeaseDir(t)
+
+	// The subprocess invokes the same test binary with a special env
+	// var that triggers the holder loop in TestMain → holdLease branch.
+	// Standard Go subprocess pattern (see net/http/httptest, exec_test).
+	cmd := exec.Command(os.Args[0], "-test.run=TestGlobalLeaseHoldHelper")
+	cmd.Env = append(os.Environ(), // safe: re-execs test binary, not ox CLI
+		"OX_TEST_HOLD_LEASE=1",
+		"OX_TEST_HOLD_ENDPOINT=sageox.ai",
+		"XDG_STATE_HOME="+dir,
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start subprocess: %v", err)
+	}
+
+	// Wait for the subprocess to have acquired the lease. The helper
+	// writes a marker file when ready; polling that is more reliable
+	// than a sleep.
+	marker := filepath.Join(dir, "lease-acquired")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("subprocess did not acquire lease in 5s")
+	}
+
+	// While the subprocess holds the lease, our acquire must fail.
+	if _, err := AcquireGlobalSyncLease("sageox.ai"); !errors.Is(err, ErrNotOwner) {
+		t.Errorf("expected ErrNotOwner while subprocess holds lease; got %v", err)
+	}
+
+	// Kill the subprocess — the kernel releases the flock on death.
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill subprocess: %v", err)
+	}
+	_ = cmd.Wait()
+
+	// Re-acquire should now succeed. Poll briefly because the kernel
+	// flock release happens during process teardown, which is fast
+	// but not instantaneous on macOS.
+	deadline = time.Now().Add(2 * time.Second)
+	var l *Lease
+	var err error
+	for time.Now().Before(deadline) {
+		l, err = AcquireGlobalSyncLease("sageox.ai")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("acquire after subprocess death: %v", err)
+	}
+	defer l.Release()
+}
+
+// TestGlobalLeaseHoldHelper is the subprocess entry point invoked by
+// TestGlobalLeaseSubprocessFailover. Skips itself unless the magic env
+// var is set, so normal test runs ignore it.
+func TestGlobalLeaseHoldHelper(t *testing.T) {
+	if os.Getenv("OX_TEST_HOLD_LEASE") != "1" {
+		t.Skip("helper test — only runs as subprocess")
+	}
+	ep := os.Getenv("OX_TEST_HOLD_ENDPOINT")
+	if ep == "" {
+		t.Fatal("OX_TEST_HOLD_ENDPOINT not set")
+	}
+	// reset the memoized dir so the subprocess sees its own
+	// XDG_STATE_HOME (the parent sets it via exec.Env).
+	globalLeaseDirOnce = sync.Once{}
+	globalLeaseDirCached = ""
+	globalLeaseDirErr = nil
+
+	l, err := AcquireGlobalSyncLease(ep)
+	if err != nil {
+		t.Fatalf("subprocess acquire: %v", err)
+	}
+	// signal the parent we have the lease.
+	dir := os.Getenv("XDG_STATE_HOME")
+	if err := os.WriteFile(filepath.Join(dir, "lease-acquired"), nil, 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	// hold forever (parent will kill us). Sleep in 100ms chunks so a
+	// stray test timeout still wakes us to exit cleanly.
+	for {
+		time.Sleep(100 * time.Millisecond)
+		_ = l // keep reference alive; the linter would otherwise flag the holder loop
+	}
+}
+
+// TestGlobalLeasePathStableAcrossCalls is a regression guard: two
+// successive globalLeasePath calls with the same endpoint must return
+// the same path. If memoization or normalization drifted, two daemons
+// for the same endpoint could end up with different lease files and
+// neither would see the other's lock.
+func TestGlobalLeasePathStableAcrossCalls(t *testing.T) {
+	withIsolatedLeaseDir(t)
+
+	p1, err := globalLeasePath("sageox.ai")
+	if err != nil {
+		t.Fatalf("first path: %v", err)
+	}
+	p2, err := globalLeasePath("sageox.ai")
+	if err != nil {
+		t.Fatalf("second path: %v", err)
+	}
+	if p1 != p2 {
+		t.Errorf("path not stable: %q vs %q", p1, p2)
+	}
+	if !strings.Contains(p1, "global-sync-leases") {
+		t.Errorf("path missing lease dir component: %q", p1)
+	}
+	if !strings.HasSuffix(p1, "global-sync.lease") {
+		t.Errorf("path missing lease filename: %q", p1)
+	}
+}

--- a/internal/daemon/global_lease_unix.go
+++ b/internal/daemon/global_lease_unix.go
@@ -1,0 +1,51 @@
+//go:build unix
+
+package daemon
+
+// POSIX flock(2) backend for AcquireGlobalSyncLease. Mirrors the
+// kb_lock_unix.go strategy: stdlib syscall.Flock, LOCK_EX|LOCK_NB, both
+// EWOULDBLOCK and EAGAIN treated as "another holder."
+//
+// Unlike kb_lock.go, the lease file is held open for the daemon's
+// lifetime and only released on shutdown; there is no per-tick acquire
+// path here. The file is created with mode 0600 on first acquisition
+// and never deleted (deleting it would create a TOCTOU race with another
+// daemon's acquire).
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// platformAcquireGlobalLease opens (or creates) the lease file and
+// attempts a non-blocking exclusive flock. Returns the open *os.File on
+// success so Release can flock(LOCK_UN) + close the same fd; otherwise
+// returns (nil, false, nil) for "another holder" or (nil, false, err)
+// for unexpected filesystem failure.
+func platformAcquireGlobalLease(path string) (*os.File, bool, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, fmt.Errorf("open global lease file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("flock global lease file: %w", err)
+	}
+	return f, true, nil
+}
+
+// platformReleaseGlobalLease releases the flock and closes the fd. Errors
+// from LOCK_UN (EBADF on already-closed fd) are swallowed; the caller's
+// lifecycle is unaffected.
+func platformReleaseGlobalLease(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return f.Close()
+}

--- a/internal/daemon/global_lease_windows.go
+++ b/internal/daemon/global_lease_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package daemon
+
+// Windows fallback for AcquireGlobalSyncLease. Daemon support on Windows
+// is POSIX-first and single-daemon-per-host, so the cross-process race
+// the unix backend prevents doesn't materialize in the current shipping
+// posture. Return acquired=true so the caller proceeds with global-sync
+// work.
+//
+// TODO: implement via LockFileEx when Windows multi-daemon support
+// lands. See ADR-017 §5 and bead ox-6zme.
+
+import "os"
+
+func platformAcquireGlobalLease(path string) (*os.File, bool, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, err
+	}
+	return f, true, nil
+}
+
+func platformReleaseGlobalLease(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+	return f.Close()
+}

--- a/internal/daemon/global_lease_windows.go
+++ b/internal/daemon/global_lease_windows.go
@@ -11,12 +11,15 @@ package daemon
 // TODO: implement via LockFileEx when Windows multi-daemon support
 // lands. See ADR-017 §5 and bead ox-6zme.
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 func platformAcquireGlobalLease(path string) (*os.File, bool, error) {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("open global lease file %s: %w", path, err)
 	}
 	return f, true, nil
 }

--- a/internal/daemon/kb_lock.go
+++ b/internal/daemon/kb_lock.go
@@ -1,0 +1,113 @@
+package daemon
+
+// Cross-process serialization for per-kb_id work on the shared XDG kb
+// working tree at paths.KBDir(kb_id). N per-repo daemons (one per
+// workspace_id) all read from the same canonical bubble directory; an
+// in-process sync.Mutex / sync.Map is therefore insufficient. Without a
+// kernel-level file lock, two daemons can call cloneBubble on the same
+// path simultaneously (corrupting the working tree) or GC can rename the
+// active clone into .trash/ mid-write (yanking the inode out from under
+// the other daemon's git process).
+//
+// We use advisory POSIX flock(2) on a lock file per kb_id. flock locks
+// are per-open-file-description: even within a single process, opening
+// the same lock file twice and attempting LOCK_EX|LOCK_NB on the second
+// fd correctly returns EWOULDBLOCK. Locks are released on process death
+// by the kernel — no stale-lock recovery code needed.
+//
+// Per .claude/rules/lfs-no-git-lfs-binary.md, this code does not depend
+// on the git-lfs binary. Per project conventions, we use stdlib
+// `syscall.Flock` rather than `golang.org/x/sys/unix` to keep the
+// dependency surface minimal.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/sageox/ox/internal/paths"
+)
+
+// kbLockDirOnce guards lazy creation of the lock parent dir; we only need
+// to attempt MkdirAll once per process to keep the hot path allocation-free.
+var kbLockDirOnce sync.Once
+var kbLockDirCached string
+var kbLockDirErr error
+
+// kbLockDirName is the subdirectory under DaemonStateDir() that holds the
+// per-kb_id advisory lock files.
+const kbLockDirName = "kb-locks"
+
+// kbLockDir returns the directory containing per-kb_id flock files,
+// creating it on first call. The directory lives under
+// paths.DaemonStateDir() so it inherits the project's XDG vs legacy
+// resolution and the existing daemon state cleanup posture.
+func kbLockDir() (string, error) {
+	kbLockDirOnce.Do(func() {
+		base := paths.DaemonStateDir()
+		if base == "" {
+			kbLockDirErr = errors.New("daemon state dir unresolved")
+			return
+		}
+		dir := filepath.Join(base, kbLockDirName)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			kbLockDirErr = fmt.Errorf("create kb lock dir: %w", err)
+			return
+		}
+		kbLockDirCached = dir
+	})
+	if kbLockDirErr != nil {
+		return "", kbLockDirErr
+	}
+	return kbLockDirCached, nil
+}
+
+// kbLockPath returns the absolute path to the lock file for a kb_id.
+// Filename is `<kb_id>.lock`; kb_ids are URL-safe slugs (see kb API) so
+// no further sanitization is needed.
+func kbLockPath(kbID string) (string, error) {
+	dir, err := kbLockDir()
+	if err != nil {
+		return "", err
+	}
+	// defense in depth: a kb_id containing a path separator would escape
+	// the lock dir. The kb API does not emit such ids, but a stray bad
+	// input must not be able to flock arbitrary files.
+	if filepath.Base(kbID) != kbID || kbID == "" {
+		return "", fmt.Errorf("invalid kb_id for lock: %q", kbID)
+	}
+	return filepath.Join(dir, kbID+".lock"), nil
+}
+
+// AcquireKBLock attempts a non-blocking exclusive flock on the kb_id's
+// lock file. Returns:
+//
+//   - (unlock, true, nil) on success; the caller MUST invoke unlock
+//     when finished (or rely on process exit; the kernel releases flock
+//     on fd close / process termination).
+//   - (nil, false, nil) when another holder (any process, including this
+//     one via a different fd) holds the lock. The caller should skip
+//     this kb_id this pass.
+//   - (nil, false, err) on unexpected error (filesystem failure,
+//     unresolvable state dir, invalid kb_id). The caller should log and
+//     skip; we never escalate lock-infrastructure errors to a panic.
+//
+// The lock file is created with mode 0600 on first acquisition; it is
+// never removed (the file is a name on which we hold a lock, removing
+// it would create a TOCTOU race with another acquirer).
+func AcquireKBLock(kbID string) (unlock func(), acquired bool, err error) {
+	path, err := kbLockPath(kbID)
+	if err != nil {
+		return nil, false, err
+	}
+	return acquireKBLockAt(path)
+}
+
+// acquireKBLockAt is the platform-specific lock acquisition. Split out so
+// tests can target a tmp lock dir without going through kbLockDir.
+// Implementation lives in kb_lock_unix.go / kb_lock_windows.go.
+func acquireKBLockAt(path string) (unlock func(), acquired bool, err error) {
+	return platformAcquireKBLock(path)
+}

--- a/internal/daemon/kb_lock_test.go
+++ b/internal/daemon/kb_lock_test.go
@@ -1,0 +1,273 @@
+package daemon
+
+// Tests for the per-kb_id flock primitive. Verifies:
+//
+//   - Single-process acquire / release / re-acquire.
+//   - Same-process double-acquire returns acquired=false (no deadlock).
+//   - Cross-process acquire blocks while another process holds the lock.
+//   - Kernel auto-release on process death (no stale-lock recovery
+//     needed) — verified by SIGKILL'ing the holder.
+//
+// We exercise AcquireKBLock through the lower-level acquireKBLockAt
+// helper so each test can target a tmp directory and not contend with
+// other tests sharing paths.DaemonStateDir().
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// kbLockTestFile returns a unique lock-file path inside t.TempDir().
+func kbLockTestFile(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "kb.lock")
+}
+
+func TestAcquireKBLock_SingleProcess(t *testing.T) {
+	path := kbLockTestFile(t)
+
+	unlock, acquired, err := acquireKBLockAt(path)
+	if err != nil {
+		t.Fatalf("first acquire: unexpected err: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("first acquire: expected acquired=true on empty file")
+	}
+	unlock()
+
+	// Re-acquire after explicit release must succeed.
+	unlock2, acquired2, err := acquireKBLockAt(path)
+	if err != nil {
+		t.Fatalf("re-acquire: unexpected err: %v", err)
+	}
+	if !acquired2 {
+		t.Fatalf("re-acquire: expected acquired=true after release")
+	}
+	unlock2()
+}
+
+func TestAcquireKBLock_SameProcessDoubleAcquireFails(t *testing.T) {
+	// Even within one process, a second LOCK_EX|LOCK_NB on the same
+	// file via a different fd must report contention. This is the
+	// in-process equivalent of two goroutines racing into cloneBubble.
+	path := kbLockTestFile(t)
+
+	unlock1, acquired1, err := acquireKBLockAt(path)
+	if err != nil || !acquired1 {
+		t.Fatalf("first acquire failed: acquired=%v err=%v", acquired1, err)
+	}
+	defer unlock1()
+
+	unlock2, acquired2, err := acquireKBLockAt(path)
+	if err != nil {
+		t.Fatalf("second acquire returned unexpected err: %v", err)
+	}
+	if acquired2 {
+		// Defensive: release before failing so we don't leak the lock.
+		if unlock2 != nil {
+			unlock2()
+		}
+		t.Fatalf("second acquire: expected acquired=false while first lock held")
+	}
+}
+
+// --- Cross-process behaviors ---
+
+// kbLockSubprocessEnvVar selects the helper subprocess behavior so we
+// can re-exec the test binary as the lock holder without ambiguity.
+const kbLockSubprocessEnvVar = "OX_KB_LOCK_TEST_HOLDER_PATH"
+
+// TestKBLockHolderSubprocess is the helper entry point invoked via
+// re-exec by the cross-process tests. When OX_KB_LOCK_TEST_HOLDER_PATH
+// is set, it acquires the lock at that path, prints "locked" to stdout,
+// then sleeps until SIGTERM/SIGKILL. The test that re-execs us also
+// sets a hold-time env var to avoid relying on signal plumbing in
+// short-running tests.
+func TestKBLockHolderSubprocess(t *testing.T) {
+	path := os.Getenv(kbLockSubprocessEnvVar)
+	if path == "" {
+		t.Skip("not invoked as kb-lock holder subprocess")
+	}
+	unlock, acquired, err := acquireKBLockAt(path)
+	if err != nil || !acquired {
+		// Subprocess can't use t.Fatal-as-signal; print and exit non-zero.
+		fmt.Fprintf(os.Stderr, "holder: acquire failed: acquired=%v err=%v\n", acquired, err)
+		os.Exit(2)
+	}
+	defer unlock()
+	// Signal the parent that we have the lock. The parent reads stdout
+	// line-by-line; "locked\n" is the handshake.
+	fmt.Println("locked")
+	// Hold for a bounded duration. The parent kills us before this
+	// fires in the SIGKILL test; the bound is just a backstop so a
+	// runaway subprocess can't outlive the test binary.
+	hold := 5 * time.Second
+	if v := os.Getenv("OX_KB_LOCK_TEST_HOLD_MS"); v != "" {
+		var ms int
+		_, _ = fmt.Sscanf(v, "%d", &ms)
+		if ms > 0 {
+			hold = time.Duration(ms) * time.Millisecond
+		}
+	}
+	time.Sleep(hold)
+}
+
+// startKBLockHolder re-execs the test binary so it runs
+// TestKBLockHolderSubprocess against the given lock path. Returns the
+// running *exec.Cmd; callers must Kill+Wait to clean up.
+func startKBLockHolder(t *testing.T, lockPath string, holdMS int) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0],
+		"-test.run", "^TestKBLockHolderSubprocess$",
+		"-test.v",
+	)
+	cmd.Env = append(os.Environ(), // safe: re-execs test binary, not ox CLI
+		kbLockSubprocessEnvVar+"="+lockPath,
+		fmt.Sprintf("OX_KB_LOCK_TEST_HOLD_MS=%d", holdMS),
+	)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start holder: %v", err)
+	}
+	// Wait for the "locked" handshake. The subprocess prints other
+	// `go test` framing lines first ("=== RUN ..."), so scan until
+	// we see our token or timeout.
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 4096)
+		deadline := time.Now().Add(5 * time.Second)
+		acc := make([]byte, 0, 4096)
+		for time.Now().Before(deadline) {
+			n, readErr := stdout.Read(buf)
+			if n > 0 {
+				acc = append(acc, buf[:n]...)
+				for i := 0; i+len("locked") <= len(acc); i++ {
+					if string(acc[i:i+len("locked")]) == "locked" {
+						done <- nil
+						return
+					}
+				}
+			}
+			if readErr != nil {
+				done <- fmt.Errorf("read holder stdout: %w", readErr)
+				return
+			}
+		}
+		done <- fmt.Errorf("timed out waiting for holder handshake")
+	}()
+	if err := <-done; err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		t.Fatalf("holder handshake: %v", err)
+	}
+	return cmd
+}
+
+func TestAcquireKBLock_CrossProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: re-execs test binary")
+	}
+	path := kbLockTestFile(t)
+	cmd := startKBLockHolder(t, path, 2000)
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// Subprocess holds the lock; parent attempt must report contention.
+	unlock, acquired, err := acquireKBLockAt(path)
+	if err != nil {
+		t.Fatalf("parent acquire: unexpected err: %v", err)
+	}
+	if acquired {
+		if unlock != nil {
+			unlock()
+		}
+		t.Fatalf("parent acquire: expected acquired=false while subprocess holds lock")
+	}
+
+	// After subprocess exits, parent must be able to acquire.
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	_, _ = cmd.Process.Wait()
+
+	unlock2, acquired2, err := acquireKBLockAt(path)
+	if err != nil {
+		t.Fatalf("parent re-acquire after subprocess exit: err=%v", err)
+	}
+	if !acquired2 {
+		t.Fatalf("parent re-acquire after subprocess exit: expected acquired=true")
+	}
+	unlock2()
+}
+
+func TestAcquireKBLock_StaleLockAfterCrash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: re-execs test binary and SIGKILLs it")
+	}
+	path := kbLockTestFile(t)
+	cmd := startKBLockHolder(t, path, 30000)
+
+	// Confirm contention while subprocess is alive.
+	unlock, acquired, err := acquireKBLockAt(path)
+	if err != nil {
+		t.Fatalf("contended acquire: err=%v", err)
+	}
+	if acquired {
+		if unlock != nil {
+			unlock()
+		}
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		t.Fatalf("contended acquire: expected acquired=false before SIGKILL")
+	}
+
+	// SIGKILL the holder; kernel must release the flock as the fd
+	// closes. There is no graceful unlock — this proves we don't need
+	// stale-lock recovery code.
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill holder: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	// Re-acquire should succeed promptly. We retry briefly because the
+	// fd close + kernel flock cleanup is asynchronous w.r.t. SIGKILL
+	// delivery on some kernels; the window is tens of microseconds in
+	// practice.
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		unlock2, acquired2, err := acquireKBLockAt(path)
+		if err == nil && acquired2 {
+			unlock2()
+			return
+		}
+		lastErr = err
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("re-acquire after SIGKILL did not succeed within 2s; lastErr=%v", lastErr)
+}
+
+// TestKBReconcileCrossDaemonRace and TestKBGCRespectsCloneInFlight are
+// the higher-level integration scenarios called out in bead ox-kdt2.
+// Wiring them through the full daemon test harness (SyncScheduler +
+// fake KB lister + fake gitserver) is non-trivial; the lock-primitive
+// tests above prove the underlying serialization, and the existing
+// TestKBGC_RespectsCloneInFlight_DoesNotTriageActiveClone already
+// covers the in-process variant. Tracked as a follow-up; gated as a
+// skip so the intent is searchable.
+func TestKBReconcileCrossDaemonRace(t *testing.T) {
+	t.Skip("requires daemon integration harness — see bead ox-kdt2 follow-up")
+}
+
+func TestKBGCRespectsCloneInFlight_CrossProcess(t *testing.T) {
+	t.Skip("requires daemon integration harness — see bead ox-kdt2 follow-up")
+}

--- a/internal/daemon/kb_lock_unix.go
+++ b/internal/daemon/kb_lock_unix.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package daemon
+
+// POSIX flock(2) backend for AcquireKBLock. Uses stdlib syscall — we
+// deliberately avoid golang.org/x/sys/unix here since `syscall.Flock` is
+// available on Linux, macOS, and the BSDs and the project rule is to
+// keep the dependency surface minimal when stdlib suffices.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// platformAcquireKBLock opens (or creates) the lock file and attempts a
+// non-blocking exclusive flock. On EWOULDBLOCK / EAGAIN the file is
+// closed and (nil, false, nil) is returned. On success the unlock
+// closure releases the lock and closes the fd; both are safe to call
+// from a defer.
+func platformAcquireKBLock(path string) (unlock func(), acquired bool, err error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, fmt.Errorf("open kb lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		// Both EWOULDBLOCK and EAGAIN signal "another holder" on POSIX
+		// systems; they are the same value on Linux but distinct on some
+		// BSDs. Treat both as the expected contention case.
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("flock kb lock file: %w", err)
+	}
+	unlock = func() {
+		// LOCK_UN may return EBADF if the fd was already closed; not a
+		// real failure for the caller's lifecycle, swallow it.
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+	return unlock, true, nil
+}

--- a/internal/daemon/kb_lock_windows.go
+++ b/internal/daemon/kb_lock_windows.go
@@ -12,7 +12,10 @@ package daemon
 // LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY) when Windows
 // daemon support lands. See ADR-017 §5 / bead ox-kdt2.
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 func platformAcquireKBLock(path string) (unlock func(), acquired bool, err error) {
 	// Touch the file so the path exists on disk (parity with unix path)
@@ -20,7 +23,7 @@ func platformAcquireKBLock(path string) (unlock func(), acquired bool, err error
 	// current Windows posture.
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("open kb lock file %s: %w", path, err)
 	}
 	unlock = func() { _ = f.Close() }
 	return unlock, true, nil

--- a/internal/daemon/kb_lock_windows.go
+++ b/internal/daemon/kb_lock_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package daemon
+
+// Windows fallback for AcquireKBLock. The daemon's KB sync path is
+// POSIX-first (XDG paths, flock(2), Unix-style sockets). Until cross-
+// process locking is wired up via LockFileEx, return acquired=true so
+// the caller proceeds. The race the unix backend prevents is still
+// possible on Windows; documented as a known gap.
+//
+// TODO: implement via LockFileEx (windows.LockFileEx with
+// LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY) when Windows
+// daemon support lands. See ADR-017 §5 / bead ox-kdt2.
+
+import "os"
+
+func platformAcquireKBLock(path string) (unlock func(), acquired bool, err error) {
+	// Touch the file so the path exists on disk (parity with unix path)
+	// but do not actually serialize — single-daemon-per-host is the
+	// current Windows posture.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, err
+	}
+	unlock = func() { _ = f.Close() }
+	return unlock, true, nil
+}

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -20,6 +20,19 @@ type DaemonInfo struct {
 	PID           int       `json:"pid"`
 	Version       string    `json:"version"`
 	StartedAt     time.Time `json:"started_at"`
+
+	// Endpoint is the project endpoint slug (NormalizeEndpoint'd) this
+	// daemon talks to. Recorded so doctor checks can group daemons by
+	// endpoint and verify exactly one global-sync owner per endpoint
+	// (ox-6zme).
+	Endpoint string `json:"endpoint,omitempty"`
+
+	// GlobalSyncOwner is true if this daemon holds the per-endpoint
+	// global-sync flock lease — i.e. it is the daemon responsible for
+	// team-context pulls and KB ListBubbles for this user+endpoint.
+	// Doctor cross-references this against the running-daemons list to
+	// flag "0 owners" or ">1 owner" anomalies. See bead ox-6zme.
+	GlobalSyncOwner bool `json:"global_sync_owner,omitempty"`
 }
 
 // Registry tracks all running ox daemons on the host.
@@ -173,6 +186,33 @@ func RegisterDaemon(workspacePath, version string) error {
 		return err
 	}
 	return reg.Register(info)
+}
+
+// UpdateGlobalSyncOwnership refreshes the current daemon's endpoint and
+// global-sync ownership flag in the registry. Called after the lease is
+// acquired (or refused) during initComponents, after the initial
+// RegisterDaemon. Best-effort: a registry write failure logs but does
+// not abort daemon startup, because the in-memory lease state is the
+// real source of truth — the registry entry is for doctor visibility.
+func UpdateGlobalSyncOwnership(endpoint string, isOwner bool) error {
+	workspaceID := CurrentWorkspaceID()
+	reg, err := LoadRegistry()
+	if err != nil {
+		return err
+	}
+	reg.mu.Lock()
+	info, ok := reg.Daemons[workspaceID]
+	if !ok {
+		reg.mu.Unlock()
+		// Daemon never registered or got pruned — nothing to update.
+		// Caller treats this as a soft failure.
+		return nil
+	}
+	info.Endpoint = endpoint
+	info.GlobalSyncOwner = isOwner
+	reg.Daemons[workspaceID] = info
+	reg.mu.Unlock()
+	return reg.Save()
 }
 
 // UnregisterDaemon removes the current daemon from the registry.

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -221,7 +221,18 @@ type SyncScheduler struct {
 	// scheduler must skip those global tickers — per-repo work
 	// (pullChanges, codedb, github sync, sessions) is unaffected. See
 	// bead ox-6zme.
-	globalSyncLease *Lease
+	//
+	// globalSyncLeaseSet tracks whether SetGlobalSyncLease was ever
+	// invoked. We must distinguish "production daemon attempted
+	// acquisition and got nil (follower)" from "no leader-election
+	// wiring ran yet (test harness, single-daemon legacy)". Before any
+	// SetGlobalSyncLease call, the scheduler behaves as owner so legacy
+	// single-daemon tests and any code path that constructs a scheduler
+	// without going through the daemon's leader-election startup keep
+	// working. The production daemon always calls SetGlobalSyncLease
+	// (success or failure) before Start, so followers correctly skip.
+	globalSyncLease    *Lease
+	globalSyncLeaseSet bool
 }
 
 // syncError tracks a sync error with timestamp.
@@ -393,18 +404,34 @@ func (s *SyncScheduler) SetEventBus(bus *hooks.EventBus) {
 // handle. Pass nil when the daemon failed to acquire the lease — the
 // scheduler will skip team-context pulls and KB ListBubbles ticks, but
 // continue running every per-repo ticker. See bead ox-6zme.
+//
+// Calling this method — even with nil — flips the scheduler out of
+// "legacy owner" mode and into explicit leader-election mode. Before
+// any call, IsGlobalSyncOwner defaults to true (preserves single-daemon
+// behavior for tests and call sites that don't go through the daemon's
+// leader-election startup).
 func (s *SyncScheduler) SetGlobalSyncLease(l *Lease) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.globalSyncLease = l
+	s.globalSyncLeaseSet = true
 }
 
-// IsGlobalSyncOwner reports whether this scheduler currently holds the
-// global-sync lease for its endpoint. Used by doctor checks and status
-// reporting; the in-loop gates compare s.globalSyncLease directly.
+// IsGlobalSyncOwner reports whether this scheduler should run
+// global-sync work (team-context pulls + KB ListBubbles).
+//
+// Three states, only the first is "follower":
+//   - SetGlobalSyncLease(nil) was called — explicit follower, skip global ticks.
+//   - SetGlobalSyncLease(lease) was called and the lease is held — owner.
+//   - SetGlobalSyncLease was never called — legacy owner (default).
+//     Preserves the pre-ox-6zme behavior for tests and any path that
+//     constructs a scheduler without wiring leader election.
 func (s *SyncScheduler) IsGlobalSyncOwner() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if !s.globalSyncLeaseSet {
+		return true
+	}
 	return s.globalSyncLease != nil && s.globalSyncLease.IsHeld()
 }
 

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -232,6 +232,7 @@ type SyncScheduler struct {
 	// working. The production daemon always calls SetGlobalSyncLease
 	// (success or failure) before Start, so followers correctly skip.
 	globalSyncLease    *Lease
+	globalSyncEndpoint string
 	globalSyncLeaseSet bool
 }
 
@@ -410,11 +411,28 @@ func (s *SyncScheduler) SetEventBus(bus *hooks.EventBus) {
 // any call, IsGlobalSyncOwner defaults to true (preserves single-daemon
 // behavior for tests and call sites that don't go through the daemon's
 // leader-election startup).
-func (s *SyncScheduler) SetGlobalSyncLease(l *Lease) {
+func (s *SyncScheduler) SetGlobalSyncLease(endpoint string, l *Lease) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.globalSyncEndpoint = endpoint
 	s.globalSyncLease = l
 	s.globalSyncLeaseSet = true
+}
+
+// ReleaseGlobalSyncLease releases any lease currently held by the scheduler.
+// Idempotent and safe to call alongside daemon-level release logic.
+func (s *SyncScheduler) ReleaseGlobalSyncLease() {
+	s.mu.Lock()
+	lease := s.globalSyncLease
+	s.globalSyncLease = nil
+	s.mu.Unlock()
+
+	if lease == nil {
+		return
+	}
+	if err := lease.Release(); err != nil {
+		s.logger.Warn("global-sync lease release failed", "error", err)
+	}
 }
 
 // IsGlobalSyncOwner reports whether this scheduler should run
@@ -428,11 +446,46 @@ func (s *SyncScheduler) SetGlobalSyncLease(l *Lease) {
 //     constructs a scheduler without wiring leader election.
 func (s *SyncScheduler) IsGlobalSyncOwner() bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if !s.globalSyncLeaseSet {
+		s.mu.Unlock()
 		return true
 	}
-	return s.globalSyncLease != nil && s.globalSyncLease.IsHeld()
+	if s.globalSyncLease != nil && s.globalSyncLease.IsHeld() {
+		s.mu.Unlock()
+		return true
+	}
+	endpoint := s.globalSyncEndpoint
+	s.mu.Unlock()
+	return s.tryAcquireGlobalSyncLease(endpoint)
+}
+
+func (s *SyncScheduler) tryAcquireGlobalSyncLease(endpoint string) bool {
+	if endpoint == "" {
+		return false
+	}
+
+	lease, err := AcquireGlobalSyncLease(endpoint)
+	if err != nil {
+		if !errors.Is(err, ErrNotOwner) {
+			s.logger.Debug("global-sync lease retry failed", "endpoint", endpoint, "error", err)
+		}
+		return false
+	}
+
+	s.mu.Lock()
+	if s.globalSyncLease != nil && s.globalSyncLease.IsHeld() {
+		s.mu.Unlock()
+		_ = lease.Release()
+		return true
+	}
+	s.globalSyncLease = lease
+	s.mu.Unlock()
+
+	if err := UpdateGlobalSyncOwnership(endpoint, true); err != nil {
+		s.logger.Debug("failed to update global-sync ownership after retry", "endpoint", endpoint, "error", err)
+	}
+	s.logger.Info("global-sync lease acquired after retry", "endpoint", endpoint)
+	return true
 }
 
 // captureHEAD returns the current HEAD SHA for a git repo.

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -213,6 +213,15 @@ type SyncScheduler struct {
 
 	// event bus for emitting sync events to hooks/notifications
 	eventBus *hooks.EventBus
+
+	// globalSyncLease is the per-(user, endpoint) leader-election handle
+	// for global-sync work (team-context pulls + KB ListBubbles). Owned
+	// by the daemon; injected via SetGlobalSyncLease at startup. nil
+	// means another daemon owns the lease for this endpoint and this
+	// scheduler must skip those global tickers — per-repo work
+	// (pullChanges, codedb, github sync, sessions) is unaffected. See
+	// bead ox-6zme.
+	globalSyncLease *Lease
 }
 
 // syncError tracks a sync error with timestamp.
@@ -378,6 +387,25 @@ func (s *SyncScheduler) SetTracer(t *observability.DaemonTracer) {
 // SetEventBus sets the event bus for emitting sync events.
 func (s *SyncScheduler) SetEventBus(bus *hooks.EventBus) {
 	s.eventBus = bus
+}
+
+// SetGlobalSyncLease wires the per-endpoint global-sync leader-election
+// handle. Pass nil when the daemon failed to acquire the lease — the
+// scheduler will skip team-context pulls and KB ListBubbles ticks, but
+// continue running every per-repo ticker. See bead ox-6zme.
+func (s *SyncScheduler) SetGlobalSyncLease(l *Lease) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.globalSyncLease = l
+}
+
+// IsGlobalSyncOwner reports whether this scheduler currently holds the
+// global-sync lease for its endpoint. Used by doctor checks and status
+// reporting; the in-loop gates compare s.globalSyncLease directly.
+func (s *SyncScheduler) IsGlobalSyncOwner() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.globalSyncLease != nil && s.globalSyncLease.IsHeld()
 }
 
 // captureHEAD returns the current HEAD SHA for a git repo.
@@ -678,9 +706,14 @@ func (s *SyncScheduler) Start(ctx context.Context) {
 			"heartbeat_interval", heartbeatInterval,
 		)
 
-		// delayed team context sync for regular pulls (not just cloning)
+		// delayed team context sync for regular pulls (not just cloning).
+		// Gated on global-sync ownership — non-owner daemons leave team
+		// contexts to the owning daemon for this endpoint (ox-6zme).
 		go func() {
 			time.Sleep(5 * time.Second)
+			if !s.IsGlobalSyncOwner() {
+				return
+			}
 			s.pullTeamContexts(ctx)
 		}()
 	} else {
@@ -789,13 +822,22 @@ func (s *SyncScheduler) Start(ctx context.Context) {
 
 		case <-teamContextChan:
 			// not traced: high-frequency sync dominates span volume with little diagnostic value
-			s.pullTeamContexts(ctx)
-			// kb bubbles share the team-context cadence (15s). Per-bubble
-			// FETCH_HEAD dedup inside pullManagedRepo (threshold =
-			// max(SyncInterval/2, MinFetchHeadAge)) gates repo/custom
-			// bubbles down to the slower read cadence automatically — see
-			// kbSyncIntervalFor in sync_bubbles.go.
-			s.syncBubbles(ctx)
+			//
+			// Global-sync gate (ox-6zme): only the daemon holding the
+			// per-endpoint flock lease runs team-context pulls and KB
+			// ListBubbles. Other daemons consume the on-disk state the
+			// owner keeps fresh — every daemon still resolves its own
+			// per-project KB symlinks from whatever is on disk via the
+			// existing reconciler.
+			if s.IsGlobalSyncOwner() {
+				s.pullTeamContexts(ctx)
+				// kb bubbles share the team-context cadence (15s). Per-bubble
+				// FETCH_HEAD dedup inside pullManagedRepo (threshold =
+				// max(SyncInterval/2, MinFetchHeadAge)) gates repo/custom
+				// bubbles down to the slower read cadence automatically — see
+				// kbSyncIntervalFor in sync_bubbles.go.
+				s.syncBubbles(ctx)
+			}
 			if teamContextTicker != nil {
 				teamContextTicker.Reset(jitteredDuration(s.config.TeamContextSyncInterval, 0.10))
 			}

--- a/internal/daemon/sync_bubbles.go
+++ b/internal/daemon/sync_bubbles.go
@@ -26,20 +26,16 @@ import (
 	"github.com/sageox/ox/internal/paths"
 )
 
-// kbReconcileLocks serializes concurrent reconcileBubble passes for the
-// same kb_id. Without this, two overlapping syncBubbles invocations can
-// both observe target/.git absent, both kick off cloneBubble, and the
-// second clone trashes the first one's freshly-populated tree (caught by
-// TestSyncBubbles_ConcurrentPasses_NoPanic on Linux CI). Per-kb_id rather
-// than global so independent bubbles still reconcile in parallel.
-var kbReconcileLocks sync.Map // map[kb_id]*sync.Mutex
-
-// kbCloneInFlight tracks kb_ids whose initial clone is mid-flight so the
-// GC triage pass can skip them. Without this guard, a GC tick during a
-// transient API-list hiccup could rename a partially-cloned target into
-// .trash/ while git is still writing to the old inode — silent half-
-// cloned bubble. Set in cloneBubble via markKBCloneStart, cleared via
-// markKBCloneDone (deferred).
+// kbCloneInFlight is a same-process marker used by GC triage as a cheap
+// pre-check before attempting the cross-process kb flock. The flock
+// (AcquireKBLock) is what actually serializes concurrent reconcileBubble
+// passes — both within one daemon and across the N per-repo daemons
+// that share the canonical paths.KBDir(kb_id) working tree. The marker
+// is kept because (a) it makes GC's "skip clones in flight" branch a
+// constant-time map lookup before the syscall, and (b) several existing
+// tests assert on it. Without the flock, two daemons can race into
+// cloneBubble on the same path and corrupt the working tree; the marker
+// alone is useless across processes. See bead ox-kdt2.
 var kbCloneInFlight sync.Map // map[kb_id]struct{}
 
 // markKBCloneStart records that a clone for kb_id is in progress.
@@ -243,12 +239,24 @@ func (s *SyncScheduler) reconcileBubble(ctx context.Context, b api.KB) {
 		return
 	}
 
-	// Serialize concurrent reconciles for the same kb_id so overlapping
-	// syncBubbles passes don't race each other into a half-cloned state.
-	muIface, _ := kbReconcileLocks.LoadOrStore(b.KBID, &sync.Mutex{})
-	mu := muIface.(*sync.Mutex)
-	mu.Lock()
-	defer mu.Unlock()
+	// Serialize concurrent reconciles for the same kb_id across BOTH the
+	// in-process goroutine case AND the N-per-host daemon case. POSIX
+	// flock semantics give us both for the price of one syscall — a
+	// second LOCK_EX|LOCK_NB on the same file (different fd, same or
+	// different process) returns EWOULDBLOCK. If another reconciler
+	// already owns the lock we skip this pass entirely; the next tick
+	// will retry. Lock auto-releases on process death via the kernel
+	// (no stale-lock recovery code needed). See bead ox-kdt2.
+	unlock, acquired, lockErr := AcquireKBLock(b.KBID)
+	if lockErr != nil {
+		s.logger.Warn("kb_sync lock acquire failed", "kb_id", b.KBID, "type", string(b.KBType), "error", lockErr)
+		return
+	}
+	if !acquired {
+		s.logger.Debug("kb_sync skip: another reconciler holds kb lock", "kb_id", b.KBID, "type", string(b.KBType))
+		return
+	}
+	defer unlock()
 
 	// per-bubble cadence routing: high-mutation bubbles (personal/profile/team)
 	// should be reconciled at the team-context cadence; repo/custom at the

--- a/internal/daemon/sync_gc_kb.go
+++ b/internal/daemon/sync_gc_kb.go
@@ -172,19 +172,37 @@ func (s *SyncScheduler) kbGCTriage(ctx context.Context, kbRoot, trashDir string,
 		if _, ok := want[name]; ok {
 			continue // still authorized — leave alone
 		}
-		// Clone-in-flight guard: if cloneBubble is mid-flight for this
-		// kb_id, the target dir may LOOK like an orphan (not yet in the
-		// API list, freshly mkdir'd, no .git yet) but renaming it to
-		// .trash/ would race the active git clone and leave a silent
-		// half-cloned bubble. Skip and let the next GC pass re-evaluate
-		// once cloneBubble has either finished or been canceled.
+		// Clone-in-flight guard (in-process, cheap): if cloneBubble is
+		// mid-flight for this kb_id in this daemon, the target dir may
+		// LOOK like an orphan (not yet in the API list, freshly
+		// mkdir'd, no .git yet) but renaming it to .trash/ would race
+		// the active git clone and leave a silent half-cloned bubble.
 		if kbCloneActive(name) {
-			s.logger.Debug("kb_gc triage skip: clone in flight", "kb_id", name)
+			s.logger.Debug("kb_gc triage skip: clone in flight (same process)", "kb_id", name)
+			continue
+		}
+
+		// Cross-process guard: the in-process marker above only sees
+		// clones started by THIS daemon. With N per-repo daemons all
+		// reconciling the shared paths.KBDir(kb_id) tree, another
+		// daemon may be mid-clone or mid-pull on this kb_id right now
+		// — os.Rename into .trash/ would yank the inode out from under
+		// its git process. We use the same kb flock as reconcileBubble;
+		// EWOULDBLOCK means "someone is working on it, leave it alone
+		// this pass". See bead ox-kdt2.
+		unlock, acquired, lockErr := AcquireKBLock(name)
+		if lockErr != nil {
+			s.logger.Warn("kb_gc triage lock acquire failed", "kb_id", name, "error", lockErr)
+			continue
+		}
+		if !acquired {
+			s.logger.Debug("kb_gc triage skip: another process holds kb lock", "kb_id", name)
 			continue
 		}
 
 		// orphan — move into .trash/<kb_id>-<RFC3339>
 		if err := os.MkdirAll(trashDir, 0o755); err != nil {
+			unlock()
 			s.logger.Warn("kb_gc triage mkdir trash failed", "path", trashDir, "error", err)
 			return
 		}
@@ -193,8 +211,14 @@ func (s *SyncScheduler) kbGCTriage(ctx context.Context, kbRoot, trashDir string,
 		// need a replacement, but the daemon's GC path is POSIX-first.
 		dest := filepath.Join(trashDir, fmt.Sprintf("%s-%s", name, ts))
 		src := filepath.Join(kbRoot, name)
-		if err := os.Rename(src, dest); err != nil {
-			s.logger.Warn("kb_gc triage rename failed", "kb_id", name, "src", src, "dest", dest, "error", err)
+		renameErr := os.Rename(src, dest)
+		// release the kb lock immediately after the rename completes
+		// (success or failure). The reaper phase does not need it —
+		// once the path is under .trash/<kb_id>-<ts> there is no
+		// canonical-path collision to guard against.
+		unlock()
+		if renameErr != nil {
+			s.logger.Warn("kb_gc triage rename failed", "kb_id", name, "src", src, "dest", dest, "error", renameErr)
 			continue
 		}
 		moved++

--- a/internal/daemon/sync_symlinks.go
+++ b/internal/daemon/sync_symlinks.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/paths"
 )
@@ -86,6 +87,29 @@ func (s *SyncScheduler) reconcileAllProjectSymlinks(ctx context.Context, bubbles
 	if len(roots) == 0 {
 		s.logger.Debug("kb_symlink: no initialized projects discovered")
 		return
+	}
+
+	// Scope reconciliation to projects on the current daemon's endpoint —
+	// global-sync ownership is per-endpoint, so the owner for endpoint A
+	// must never create/prune .sageox/kb links in projects configured for
+	// endpoint B. Empty current-endpoint short-circuits (unconfigured
+	// daemon → no global sync to reconcile).
+	currentEndpoint := endpoint.NormalizeSlug(endpoint.GetForProject(s.config.ProjectRoot))
+	if currentEndpoint != "" {
+		filtered := roots[:0]
+		for _, root := range roots {
+			projectEndpoint := endpoint.NormalizeSlug(endpoint.GetForProject(root))
+			if projectEndpoint == "" || projectEndpoint == currentEndpoint {
+				filtered = append(filtered, root)
+				continue
+			}
+			s.logger.Debug("kb_symlink: skipping project on different endpoint",
+				"project", root, "project_endpoint", projectEndpoint, "current_endpoint", currentEndpoint)
+		}
+		roots = filtered
+		if len(roots) == 0 {
+			return
+		}
 	}
 
 	for _, root := range roots {

--- a/internal/daemon/sync_symlinks.go
+++ b/internal/daemon/sync_symlinks.go
@@ -17,7 +17,8 @@ package daemon
 //                            access, so a team row implies membership)
 //   - repo               -> link only in its OWN project, matched by
 //                            kb.repo_id == projectConfig.repo_id
-//   - custom, unknown    -> skip (deferred until explicit subscribe)
+//   - custom, channel,
+//     unknown            -> skip (deferred until explicit subscribe)
 //
 // Critical safety:
 //   - We only ever create/replace/remove symlinks. The canonical kb
@@ -254,6 +255,11 @@ func desiredSymlinks(bubbles []api.KB, projectRepoID string) map[string]string {
 			if projectRepoID == "" || b.RepoID == "" || b.RepoID != projectRepoID {
 				continue
 			}
+		case api.KBType("channel"):
+			// channel is defined in kbconfig but not yet promoted into
+			// internal/api as a typed KBType. Same policy as custom: skip
+			// until explicit subscribe.
+			continue
 		default:
 			// custom, unknown — deferred, skip.
 			continue

--- a/internal/daemon/sync_symlinks_test.go
+++ b/internal/daemon/sync_symlinks_test.go
@@ -410,6 +410,7 @@ func TestDesiredSymlinks_PolicyMatrix(t *testing.T) {
 		{KBID: "kb_their_repo", KBType: api.KBTypeRepo, Slug: "their-app", RepoID: "repo_other"},
 		{KBID: "kb_legacy_repo", KBType: api.KBTypeRepo, Slug: "legacy"}, // missing repo_id
 		{KBID: "kb_custom", KBType: api.KBTypeCustom, Slug: "custom-thing"},
+		{KBID: "kb_channel", KBType: api.KBType("channel"), Slug: "wip-broadcast"},
 		{KBID: "kb_unknown", KBType: api.KBTypeUnknown, Slug: "future-kind"},
 		{KBID: "", KBType: api.KBTypePersonal, Slug: "no-id"}, // dropped: empty kb_id
 	}
@@ -429,6 +430,9 @@ func TestDesiredSymlinks_PolicyMatrix(t *testing.T) {
 
 	_, hasCustom := got["custom-thing"]
 	assert.False(t, hasCustom, "custom bubbles are deferred")
+
+	_, hasChannel := got["wip-broadcast"]
+	assert.False(t, hasChannel, "channel bubbles are deferred until explicit subscribe")
 
 	_, hasUnknown := got["future-kind"]
 	assert.False(t, hasUnknown, "unknown bubbles are skipped")

--- a/internal/doctor/autofix/gitenv_test.go
+++ b/internal/doctor/autofix/gitenv_test.go
@@ -1,0 +1,13 @@
+package autofix
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/doctor/checks/gitenv_test.go
+++ b/internal/doctor/checks/gitenv_test.go
@@ -1,0 +1,13 @@
+package checks
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/doctor/gitenv_test.go
+++ b/internal/doctor/gitenv_test.go
@@ -1,0 +1,13 @@
+package doctor
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/doctor/session.go
+++ b/internal/doctor/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/ledger"
 	session "github.com/sageox/ox/internal/session"
 )
@@ -469,7 +470,8 @@ func (c *SessionModeCheck) Category() string {
 
 // Run executes the session recording check.
 func (c *SessionModeCheck) Run(_ context.Context, _ bool) CheckResult {
-	resolved := config.ResolveSessionRecording(c.gitRoot)
+	kbID, kbType := kb.ResolveCurrentKBIDAndType(c.gitRoot)
+	resolved := config.ResolveSessionRecording(c.gitRoot, kbID, kbType)
 
 	// format source for display
 	sourceStr := formatModeSource(resolved.Source)
@@ -522,7 +524,8 @@ func (c *SessionLedgerCheck) Category() string {
 
 // Run executes the ledger check.
 func (c *SessionLedgerCheck) Run(_ context.Context, _ bool) CheckResult {
-	resolved := config.ResolveSessionRecording(c.gitRoot)
+	kbID, kbType := kb.ResolveCurrentKBIDAndType(c.gitRoot)
+	resolved := config.ResolveSessionRecording(c.gitRoot, kbID, kbType)
 
 	// skip if session recording is disabled
 	if !resolved.ShouldRecord() {

--- a/internal/gitserver/gitenv_test.go
+++ b/internal/gitserver/gitenv_test.go
@@ -1,0 +1,13 @@
+package gitserver
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/gitutil/gitenv_test.go
+++ b/internal/gitutil/gitenv_test.go
@@ -1,0 +1,13 @@
+package gitutil
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/kb/effective.go
+++ b/internal/kb/effective.go
@@ -1,0 +1,129 @@
+package kb
+
+// effective.go — precedence + safety-inversion resolver for `ox kb config get/list`.
+//
+// Layer values are pre-resolved by the caller (CLI reads env, KB config file,
+// user config; this function only applies the layering rules so the safety
+// inversion invariant on session_recording stays load-bearing in one place).
+//
+// Precedence for non-recording keys: env > kb > user > default.
+// For session_recording.mode the user/kb layers are combined via
+// kbconfig.ResolveEffectiveMode, which OR-vetoes "disabled" on either side
+// before applying precedence. Env still wins when set; default backstops.
+
+import "github.com/sageox/ox/internal/api/kbconfig"
+
+// KeySessionRecordingMode is the dotted key for the session recording mode.
+const (
+	KeySessionRecordingMode = "features.session_recording.mode"
+	KeyMurmursEnabled       = "features.murmurs.enabled"
+	KeyVisibility           = "features.visibility"
+)
+
+// Layer scope labels — short, stable, used by --show-origin and JSON output.
+const (
+	LayerScopeEnv     = "env"
+	LayerScopeKB      = "kb"
+	LayerScopeUser    = "user"
+	LayerScopeDefault = "default"
+)
+
+// LayerValue is one layer in the precedence chain.
+type LayerValue struct {
+	Scope   string // "env" | "kb" | "user" | "default"
+	Source  string // human label e.g. "OX_SESSION_RECORDING", ".sageox/config.yaml"
+	Value   string // empty if unset at this layer
+	Trigger bool   // true when safety-inversion fired *because of* this layer
+}
+
+// EffectiveValue is the computed result for one key.
+type EffectiveValue struct {
+	Key             string
+	Effective       string
+	Layers          []LayerValue
+	SafetyInversion bool
+}
+
+// ResolveEffective computes the effective value for a key given pre-resolved
+// per-layer string values. The caller is responsible for extracting each
+// layer's string from its underlying config; this function applies precedence
+// and safety inversion only.
+//
+// For session_recording.mode: kb/user layers combine via
+// kbconfig.ResolveEffectiveMode so a "disabled" on either side vetoes the
+// other. Env wins outright when set; default backstops when everything else
+// is empty.
+//
+// For all other keys: env > kb > user > default precedence.
+func ResolveEffective(key string, envVal, kbVal, userVal, defaultVal string) EffectiveValue {
+	ev := EffectiveValue{Key: key}
+
+	// Record raw layer values first; Trigger/SafetyInversion get stamped below.
+	ev.Layers = []LayerValue{
+		{Scope: LayerScopeEnv, Value: envVal},
+		{Scope: LayerScopeKB, Value: kbVal},
+		{Scope: LayerScopeUser, Value: userVal},
+		{Scope: LayerScopeDefault, Value: defaultVal},
+	}
+
+	if key == KeySessionRecordingMode {
+		// Env wins when set (pipelines/automation).
+		if envVal != "" {
+			ev.Effective = envVal
+			return ev
+		}
+		// Combine kb + user via the safety-inversion-aware resolver.
+		combined := kbconfig.ResolveEffectiveMode(userVal, kbVal)
+		// Safety inversion fired when one side carries "disabled" AND the
+		// other side carries a different non-empty value (i.e. the disabled
+		// side actually vetoed an opposing preference). When both sides agree,
+		// or only one side is set, there's no inversion to surface.
+		oneDisabled := kbVal == kbconfig.SessionRecordingDisabled || userVal == kbconfig.SessionRecordingDisabled
+		opposingNonEmpty := (kbVal != "" && userVal != "" && kbVal != userVal)
+		if oneDisabled && opposingNonEmpty {
+			ev.SafetyInversion = true
+			for i := range ev.Layers {
+				if (ev.Layers[i].Scope == LayerScopeKB || ev.Layers[i].Scope == LayerScopeUser) &&
+					ev.Layers[i].Value == kbconfig.SessionRecordingDisabled {
+					ev.Layers[i].Trigger = true
+				}
+			}
+		}
+		if combined != "" {
+			ev.Effective = combined
+			return ev
+		}
+		ev.Effective = defaultVal
+		return ev
+	}
+
+	// Standard precedence for all other keys.
+	switch {
+	case envVal != "":
+		ev.Effective = envVal
+	case kbVal != "":
+		ev.Effective = kbVal
+	case userVal != "":
+		ev.Effective = userVal
+	default:
+		ev.Effective = defaultVal
+	}
+	return ev
+}
+
+// KnownKeys is the whitelist of keys `ox kb config get/list` accepts in v1.
+var KnownKeys = []string{
+	KeySessionRecordingMode,
+	KeyMurmursEnabled,
+	KeyVisibility,
+}
+
+// IsKnownKey reports whether key is in the v1 whitelist.
+func IsKnownKey(key string) bool {
+	for _, k := range KnownKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/kb/effective_test.go
+++ b/internal/kb/effective_test.go
@@ -1,0 +1,104 @@
+package kb
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/internal/api/kbconfig"
+)
+
+func TestResolveEffective_Precedence_NonRecording(t *testing.T) {
+	tests := []struct {
+		name        string
+		env, kb, u  string
+		def         string
+		wantEffectv string
+	}{
+		{"env wins", "team", "private", "", "private", "team"},
+		{"kb beats user", "", "team", "private", "private", "team"},
+		{"user beats default", "", "", "team", "private", "team"},
+		{"default fallback", "", "", "", "private", "private"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := ResolveEffective(KeyVisibility, tt.env, tt.kb, tt.u, tt.def)
+			if ev.Effective != tt.wantEffectv {
+				t.Errorf("Effective=%q want=%q", ev.Effective, tt.wantEffectv)
+			}
+			if ev.SafetyInversion {
+				t.Errorf("non-recording key should never set SafetyInversion")
+			}
+		})
+	}
+}
+
+func TestResolveEffective_SessionRecording_SafetyInversion_KBVetoes(t *testing.T) {
+	// user wants auto, but kb says disabled — kb vetoes.
+	ev := ResolveEffective(KeySessionRecordingMode, "", "disabled", "auto", "manual")
+	if ev.Effective != kbconfig.SessionRecordingDisabled {
+		t.Fatalf("Effective=%q want disabled", ev.Effective)
+	}
+	if !ev.SafetyInversion {
+		t.Fatalf("expected SafetyInversion=true")
+	}
+	var kbLayer *LayerValue
+	for i := range ev.Layers {
+		if ev.Layers[i].Scope == LayerScopeKB {
+			kbLayer = &ev.Layers[i]
+		}
+	}
+	if kbLayer == nil || !kbLayer.Trigger {
+		t.Errorf("expected kb layer to be Trigger=true")
+	}
+}
+
+func TestResolveEffective_SessionRecording_SafetyInversion_UserVetoes(t *testing.T) {
+	// kb wants auto, but user says disabled — user vetoes.
+	ev := ResolveEffective(KeySessionRecordingMode, "", "auto", "disabled", "manual")
+	if ev.Effective != kbconfig.SessionRecordingDisabled {
+		t.Fatalf("Effective=%q want disabled", ev.Effective)
+	}
+	if !ev.SafetyInversion {
+		t.Fatalf("expected SafetyInversion=true")
+	}
+}
+
+func TestResolveEffective_SessionRecording_EnvWins(t *testing.T) {
+	// env is set — wins outright, no safety inversion (env is trusted as
+	// pipeline override).
+	ev := ResolveEffective(KeySessionRecordingMode, "auto", "disabled", "disabled", "manual")
+	if ev.Effective != "auto" {
+		t.Fatalf("Effective=%q want auto", ev.Effective)
+	}
+}
+
+func TestResolveEffective_SessionRecording_UserBeatsKBWhenNeitherDisabled(t *testing.T) {
+	ev := ResolveEffective(KeySessionRecordingMode, "", "manual", "auto", "manual")
+	if ev.Effective != "auto" {
+		t.Fatalf("Effective=%q want auto", ev.Effective)
+	}
+	if ev.SafetyInversion {
+		t.Errorf("no safety inversion when neither side is disabled")
+	}
+}
+
+func TestResolveEffective_SessionRecording_BothEmpty_UseDefault(t *testing.T) {
+	ev := ResolveEffective(KeySessionRecordingMode, "", "", "", "manual")
+	if ev.Effective != "manual" {
+		t.Fatalf("Effective=%q want manual (default)", ev.Effective)
+	}
+}
+
+func TestIsKnownKey(t *testing.T) {
+	if !IsKnownKey(KeySessionRecordingMode) {
+		t.Errorf("session_recording.mode should be known")
+	}
+	if !IsKnownKey(KeyMurmursEnabled) {
+		t.Errorf("murmurs.enabled should be known")
+	}
+	if !IsKnownKey(KeyVisibility) {
+		t.Errorf("visibility should be known")
+	}
+	if IsKnownKey("features.bogus") {
+		t.Errorf("bogus key should not be known")
+	}
+}

--- a/internal/kb/effective_test.go
+++ b/internal/kb/effective_test.go
@@ -69,6 +69,9 @@ func TestResolveEffective_SessionRecording_EnvWins(t *testing.T) {
 	if ev.Effective != "auto" {
 		t.Fatalf("Effective=%q want auto", ev.Effective)
 	}
+	if ev.SafetyInversion {
+		t.Fatalf("expected SafetyInversion=false when env overrides")
+	}
 }
 
 func TestResolveEffective_SessionRecording_UserBeatsKBWhenNeitherDisabled(t *testing.T) {

--- a/internal/kb/gitenv_test.go
+++ b/internal/kb/gitenv_test.go
@@ -1,0 +1,13 @@
+package kb
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/kb/parse.go
+++ b/internal/kb/parse.go
@@ -1,0 +1,20 @@
+package kb
+
+// parse.go — input-parsing helpers for KB slug arguments received from the
+// CLI. Storage and JSON shapes intentionally stay bare ("marketing"); the
+// "#" prefix is purely a human-display convention. NormalizeSlugArg lets
+// users type `#marketing` or `marketing` interchangeably without leaking the
+// prefix into resolvers, paths, or wire formats.
+
+import "strings"
+
+// NormalizeSlugArg strips a leading "#" from a user-supplied slug argument.
+// Use on input received from CLI argv before resolving the slug.
+// "#marketing" -> "marketing"; "marketing" -> "marketing"; "" -> "".
+//
+// Only one leading "#" is stripped — "##weird" becomes "#weird". That is
+// intentional: a double-prefix is almost certainly a typo we'd rather
+// surface as a "kb not found" error than silently coerce away.
+func NormalizeSlugArg(s string) string {
+	return strings.TrimPrefix(s, "#")
+}

--- a/internal/kb/parse_test.go
+++ b/internal/kb/parse_test.go
@@ -1,0 +1,33 @@
+package kb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNormalizeSlugArg pins the input-parsing rule that a single leading
+// "#" in a CLI slug argument is stripped before resolution.
+// Failure prevented: the resolver would treat "#marketing" as a literal
+// slug and never match the bare "marketing" stored on disk and in the API.
+func TestNormalizeSlugArg(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"bare", "marketing", "marketing"},
+		{"prefixed", "#marketing", "marketing"},
+		// Only one leading "#" is stripped — documents intent so a
+		// double-prefix typo surfaces as "kb not found" instead of
+		// being silently coerced.
+		{"double-prefix-not-stripped", "##weird", "#weird"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeSlugArg(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/kb/resolve.go
+++ b/internal/kb/resolve.go
@@ -1,0 +1,287 @@
+package kb
+
+// resolve.go — the canonical "which KB am I in?" resolver.
+//
+// ADR-017 promotes the Knowledge Bubble (KB) to the unifying workspace
+// primitive. Where today's code path-walks for .sageox/ and reads repo_id
+// from config.json to discover the legacy ledger binding, this resolver
+// walks up from cwd looking for a .sageox/ marker that names a kb_id and
+// returns a KBBinding the caller can use to scope session recording,
+// murmurs, prime envelopes, and any other KB-aware behavior.
+//
+// The resolver intentionally does NOT make network calls. KB type and
+// slug enrichment from /api/v1/kb is a separate concern (see Merger in
+// merge.go); resolve only inspects on-disk markers. Callers that need
+// type/slug enrichment compose this with KBClient.ListBubbles.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/sageox/ox/internal/endpoint"
+)
+
+// KBBinding is the resolved binding for the directory tree rooted at Anchor.
+// It is the only sanctioned answer to "which KB does this path belong to?" —
+// session recording, murmurs, prime, etc. all consume this struct.
+//
+// Field semantics match ADR-017 §1, with one addition (Endpoint) called out
+// below.
+type KBBinding struct {
+	// KBID is the immutable kb identifier (kb_xxx) from the binding file.
+	// Required; empty values are treated as "no binding".
+	KBID string
+
+	// KBType is the kb_type bucket (personal|profile|team|repo|custom|channel).
+	// The resolver does NOT populate this — it requires a kb-API lookup or
+	// merge.go output to determine type from kb_id. Callers enrich as needed;
+	// the field exists on the struct so the resolver's return value can carry
+	// it once enrichment has happened.
+	KBType string
+
+	// Source is the relative path of the marker file that produced this
+	// binding, either ".sageox/config.yaml" (current) or ".sageox/config.json"
+	// (legacy). Used by doctor and `ox kb config --show-origin` to attribute
+	// values to their on-disk source.
+	Source string
+
+	// Anchor is the absolute path of the directory containing the .sageox/
+	// marker — i.e. the workspace root, not the marker file itself.
+	Anchor string
+
+	// Scope is "exclusive" (default) for now. ADR-017 §6 reserves "subtree"
+	// for nested overrides; the v1 resolver rejects nested markers entirely.
+	Scope string
+
+	// Endpoint is the SageOx API endpoint this binding belongs to (normalized
+	// via endpoint.NormalizeEndpoint). If the binding file carries an explicit
+	// `endpoint:` field, that value is used; otherwise the resolver falls back
+	// to endpoint.Get() so callers always have a non-empty value.
+	//
+	// Note: this field is not in ADR-017 §1's struct diagram but the bead
+	// description (ox-z526) requires it for downstream consumers (doctor's
+	// kb-binding-endpoint-mismatch check, multi-endpoint dispatch). It is
+	// always populated by ResolveCurrentKB.
+	Endpoint string
+}
+
+// Scope values. Only ScopeExclusive is honored in v1; ScopeSubtree is
+// reserved and rejected at resolve time (see ErrSubtreeOverridesNotSupported).
+const (
+	ScopeExclusive = "exclusive"
+	ScopeSubtree   = "subtree"
+)
+
+// Marker file names, in priority order within a single directory.
+const (
+	markerDir      = ".sageox"
+	markerYAMLName = "config.yaml"
+	markerJSONName = "config.json"
+)
+
+// ErrSubtreeOverridesNotSupported is returned when the resolver finds a
+// .sageox/ marker that is itself nested inside another .sageox/-rooted tree.
+// ADR-017 §6 reserves the design space for subtree overrides but v1 rejects
+// them rather than ship undefined semantics around session state straddling
+// a boundary.
+var ErrSubtreeOverridesNotSupported = errors.New("subtree overrides are reserved in ADR-017 v1; nested .sageox/ markers are not supported")
+
+// bindingFile is the on-disk shape of a .sageox/config.{yaml,json} payload.
+// Workspace markers carry many more fields (repo_id, ledger settings, etc.) —
+// the resolver only needs kb_id and the optional endpoint. Other fields are
+// ignored here; ProjectConfig owns the full schema.
+type bindingFile struct {
+	KBID     string `json:"kb_id" yaml:"kb_id"`
+	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+}
+
+// ResolveCurrentKB walks up from cwd searching for a .sageox/ marker and
+// returns the nearest binding, or (nil, nil) if no marker is found.
+//
+// Return semantics:
+//   - (nil, nil)   — no marker found between cwd and the filesystem root.
+//     This is the normal "outside any KB-bound tree" case and is not an error.
+//   - (b, nil)     — marker found, binding parsed successfully.
+//   - (nil, err)   — filesystem read error, malformed binding file, or a
+//     subtree override (ErrSubtreeOverridesNotSupported).
+//
+// Marker priority within a single directory: config.yaml > config.json. Once
+// the resolver finds a marker, it then checks ancestors for additional
+// markers — any nested-marker arrangement returns ErrSubtreeOverridesNotSupported
+// rather than silently picking one.
+//
+// Endpoint resolution: if the binding file carries `endpoint:`, that value is
+// used (normalized). Otherwise endpoint.Get() supplies the default. Callers
+// can detect "no explicit endpoint" by comparing against the file source if
+// they need to surface a kb-binding-endpoint-mismatch warning.
+//
+// This function does NOT make network calls. KBType remains empty; callers
+// enrich via the kb merger or KBClient.ListBubbles.
+func ResolveCurrentKB(cwd string) (*KBBinding, error) {
+	if cwd == "" {
+		return nil, nil
+	}
+
+	// resolve to an absolute, symlink-evaluated path so the upward walk is
+	// deterministic. EvalSymlinks failure (e.g. dangling symlink) is
+	// tolerated — fall back to the cleaned absolute path.
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("resolve cwd: %w", err)
+	}
+	if evaled, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = evaled
+	} else {
+		abs = filepath.Clean(abs)
+	}
+
+	// walk upward looking for the nearest marker.
+	anchor, source, payload, err := findNearestMarker(abs)
+	if err != nil {
+		return nil, err
+	}
+	if anchor == "" {
+		return nil, nil
+	}
+
+	// check ancestors above the anchor for additional markers — nested
+	// .sageox/ trees are reserved per ADR-017 §6 and rejected in v1.
+	parent := filepath.Dir(anchor)
+	if parent != anchor {
+		nested, _, _, err := findNearestMarker(parent)
+		if err != nil {
+			return nil, err
+		}
+		if nested != "" {
+			return nil, ErrSubtreeOverridesNotSupported
+		}
+	}
+
+	if payload.KBID == "" {
+		// a marker with no kb_id is a legacy ledger-only binding. ADR-017 §7
+		// says we still resolve it (the kb_type=repo branch is synthesized
+		// from the legacy ledger row), but we cannot return a KBBinding
+		// without a kb_id. Treat as "no current KB" rather than an error so
+		// pre-ADR-017 repos continue to no-op cleanly.
+		return nil, nil
+	}
+
+	ep := endpoint.NormalizeEndpoint(payload.Endpoint)
+	if ep == "" {
+		// endpoint.Get is the documented fallback per ADR-017 §3. We don't
+		// have a projectRoot to feed GetForProject (the binding IS the
+		// project marker), so Get is correct here.
+		ep = endpoint.NormalizeEndpoint(endpoint.Get())
+	}
+
+	return &KBBinding{
+		KBID:     payload.KBID,
+		Source:   filepath.Join(markerDir, source),
+		Anchor:   anchor,
+		Scope:    ScopeExclusive,
+		Endpoint: ep,
+	}, nil
+}
+
+// IsWorkspace reports whether the binding's anchor is a full workspace
+// (ledger + cache + indexing state) vs a binding-only tree (just config.yaml).
+//
+// A workspace has at least one of:
+//   - .sageox/cache/  (codedb, whisper, session state)
+//   - .sageox/ledger/ (ledger checkout symlink target)
+//   - .sageox/kb/*    (per-project kb symlinks)
+//
+// Binding-only trees omit all three. Per ADR-017 §5, binding-only trees do
+// NOT spawn a daemon; workspace trees do.
+func (b *KBBinding) IsWorkspace() bool {
+	if b == nil || b.Anchor == "" {
+		return false
+	}
+	base := filepath.Join(b.Anchor, markerDir)
+
+	// cache/ and ledger/ are direct workspace markers.
+	for _, name := range []string{"cache", "ledger"} {
+		if info, err := os.Stat(filepath.Join(base, name)); err == nil && info.IsDir() {
+			return true
+		}
+	}
+
+	// any entry under kb/ counts (symlinks are the canonical kind, but a
+	// real directory created by a future tool also qualifies).
+	if entries, err := os.ReadDir(filepath.Join(base, "kb")); err == nil && len(entries) > 0 {
+		return true
+	}
+
+	return false
+}
+
+// findNearestMarker walks up from startDir looking for the nearest directory
+// containing a parseable .sageox/ marker. Returns the anchor (the directory
+// containing .sageox/), the marker filename (config.yaml or config.json), and
+// the parsed payload. Returns ("", "", _, nil) if no marker is found between
+// startDir and the filesystem root.
+//
+// Within a single directory, config.yaml is tried before config.json. A
+// directory that contains .sageox/ but neither marker file is skipped (we
+// keep walking upward) — this matches today's behavior where bare .sageox/
+// directories left over from partial init don't constitute a binding.
+func findNearestMarker(startDir string) (anchor, source string, payload bindingFile, err error) {
+	current := startDir
+	for {
+		sageoxPath := filepath.Join(current, markerDir)
+		info, statErr := os.Stat(sageoxPath)
+		if statErr == nil && info.IsDir() {
+			// try yaml first, then json
+			for _, name := range []string{markerYAMLName, markerJSONName} {
+				path := filepath.Join(sageoxPath, name)
+				data, readErr := os.ReadFile(path)
+				if errors.Is(readErr, os.ErrNotExist) {
+					continue
+				}
+				if readErr != nil {
+					return "", "", bindingFile{}, fmt.Errorf("read %s: %w", path, readErr)
+				}
+				parsed, parseErr := parseBinding(name, data)
+				if parseErr != nil {
+					return "", "", bindingFile{}, fmt.Errorf("parse %s: %w", path, parseErr)
+				}
+				return current, name, parsed, nil
+			}
+			// .sageox/ exists but neither marker is present — keep walking.
+		} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			// surface unexpected stat errors (e.g. permission denied) rather
+			// than silently skipping a directory.
+			return "", "", bindingFile{}, fmt.Errorf("stat %s: %w", sageoxPath, statErr)
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", "", bindingFile{}, nil
+		}
+		current = parent
+	}
+}
+
+// parseBinding decodes a marker payload. The two formats share a struct shape
+// since we only consume kb_id + endpoint; ProjectConfig owns the rest.
+func parseBinding(name string, data []byte) (bindingFile, error) {
+	var b bindingFile
+	switch name {
+	case markerYAMLName:
+		if err := yaml.Unmarshal(data, &b); err != nil {
+			return bindingFile{}, err
+		}
+	case markerJSONName:
+		if err := json.Unmarshal(data, &b); err != nil {
+			return bindingFile{}, err
+		}
+	default:
+		return bindingFile{}, fmt.Errorf("unknown marker format: %s", name)
+	}
+	return b, nil
+}

--- a/internal/kb/resolve.go
+++ b/internal/kb/resolve.go
@@ -173,10 +173,12 @@ func ResolveCurrentKB(cwd string) (*KBBinding, error) {
 
 	ep := endpoint.NormalizeEndpoint(payload.Endpoint)
 	if ep == "" {
-		// endpoint.Get is the documented fallback per ADR-017 §3. We don't
-		// have a projectRoot to feed GetForProject (the binding IS the
-		// project marker), so Get is correct here.
-		ep = endpoint.NormalizeEndpoint(endpoint.Get())
+		// Prefer the project-aware fallback so the resolved endpoint
+		// matches the repo's recorded endpoint (.sageox/config.json), not
+		// whatever the global SAGEOX_ENDPOINT env var happens to be.
+		// GetForProject falls back to endpoint.Get() internally when the
+		// project config is missing, so this strictly widens correctness.
+		ep = endpoint.NormalizeEndpoint(endpoint.GetForProject(anchor))
 	}
 
 	return &KBBinding{

--- a/internal/kb/resolve_enrich.go
+++ b/internal/kb/resolve_enrich.go
@@ -1,0 +1,84 @@
+package kb
+
+// resolve_enrich.go — local-only KB type/slug enrichment for the binding
+// returned by ResolveCurrentKB.
+//
+// The plain resolver intentionally avoids network calls and never knows the
+// KB type — only the marker file's kb_id and endpoint. Many CLI code paths
+// (session recording defaults, doctor displays, agent_hook banners) need the
+// type for per-type behavior. The daemon writes a small meta.json into the
+// KB checkout during sync (see internal/daemon/sync_bubbles.go:writeKBMeta);
+// reading that file is the canonical local enrichment path.
+//
+// Keeping enrichment in internal/kb/ (not in internal/config/) is what lets
+// callers like internal/doctor/ and cmd/ox/ pass real kbID/kbType to
+// config.ResolveSessionRecording without re-introducing the
+// config → kb → api → config import cycle.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/sageox/ox/internal/paths"
+)
+
+// kbMetaOnDisk mirrors the daemon's kbMeta payload at
+// <paths.KBDir(kbID)>/.sageox/meta.json. Field tags match the writer so the
+// daemon and reader stay in lock-step. Only fields the enrichment helper
+// consumes are surfaced; additional fields the daemon writes (owner,
+// viewer_role, last_sync) are accepted-and-ignored.
+type kbMetaOnDisk struct {
+	Type string `json:"type"`
+	Slug string `json:"slug"`
+}
+
+// ResolveCurrentKBEnriched walks up from cwd like ResolveCurrentKB, then
+// enriches the binding's KBType (and any slug surfaced through the
+// binding's Source path) from the local KB metadata at
+// <paths.KBDir(KBID)>/.sageox/meta.json (written by the daemon during sync).
+//
+// Local-only — no network. If meta.json is missing or unreadable, KBType
+// remains empty (the resolver still returns the KBID/Endpoint). This is the
+// expected state for brand-new bubbles the daemon hasn't synced yet.
+func ResolveCurrentKBEnriched(cwd string) (*KBBinding, error) {
+	binding, err := ResolveCurrentKB(cwd)
+	if err != nil || binding == nil {
+		return binding, err
+	}
+	if binding.KBID == "" {
+		return binding, nil
+	}
+
+	// Read the daemon-written meta.json. Any I/O or parse error is treated
+	// as "unenriched" — callers must already tolerate empty KBType because
+	// the plain resolver never populates it.
+	metaPath := filepath.Join(paths.KBDir(binding.KBID), ".sageox", "meta.json")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return binding, nil
+	}
+	var meta kbMetaOnDisk
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return binding, nil
+	}
+
+	binding.KBType = meta.Type
+	return binding, nil
+}
+
+// ResolveCurrentKBIDAndType returns (kbID, kbType) for the current cwd, or
+// ("", "") if no current KB. Convenience wrapper for callers that just want
+// to pass these two values to config.ResolveSessionRecording.
+//
+// Errors are intentionally swallowed: callers in this position
+// (session-recording resolution, hook banners, doctor) always have a
+// well-defined fallback when there is no binding, so a resolver failure
+// should degrade to "no KB" rather than propagate up.
+func ResolveCurrentKBIDAndType(cwd string) (kbID, kbType string) {
+	binding, err := ResolveCurrentKBEnriched(cwd)
+	if err != nil || binding == nil {
+		return "", ""
+	}
+	return binding.KBID, binding.KBType
+}

--- a/internal/kb/resolve_enrich_test.go
+++ b/internal/kb/resolve_enrich_test.go
@@ -1,0 +1,76 @@
+package kb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/paths"
+)
+
+// setupEnrichEnv pins endpoint + XDG_DATA_HOME so paths.KBDir resolves into a
+// tmp tree owned by the test rather than the user's real ~/.local/share.
+func setupEnrichEnv(t *testing.T) string {
+	t.Helper()
+	t.Setenv(endpoint.EnvVar, "https://test.sageox.ai")
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	return dataHome
+}
+
+func TestResolveCurrentKBEnriched_WithMeta(t *testing.T) {
+	// happy path: marker resolves to a KB whose checkout has a daemon-written
+	// meta.json — KBType + KBID populated.
+	setupEnrichEnv(t)
+
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_01abc\n")
+
+	// stage meta.json in the KB checkout (mirrors daemon's writeKBMeta).
+	kbCheckout := paths.KBDir("kb_01abc")
+	require.NoError(t, os.MkdirAll(filepath.Join(kbCheckout, ".sageox"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(kbCheckout, ".sageox", "meta.json"),
+		[]byte(`{"type":"team","slug":"team-conventions","last_sync":"2026-05-19T00:00:00Z"}`),
+		0o600,
+	))
+
+	got, err := ResolveCurrentKBEnriched(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "kb_01abc", got.KBID)
+	require.Equal(t, "team", got.KBType)
+}
+
+func TestResolveCurrentKBEnriched_MissingMeta(t *testing.T) {
+	// missing meta.json: still returns a binding (KBID populated), but KBType
+	// is left empty. This is the brand-new-bubble-pre-daemon-sync state and
+	// must NOT surface as an error.
+	setupEnrichEnv(t)
+
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_02xyz\n")
+
+	got, err := ResolveCurrentKBEnriched(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "kb_02xyz", got.KBID)
+	require.Equal(t, "", got.KBType)
+}
+
+func TestResolveCurrentKBIDAndType_NoBinding(t *testing.T) {
+	// outside any binding: helper degrades to ("", "") so callers can pass
+	// straight through to config.ResolveSessionRecording without branching.
+	setupEnrichEnv(t)
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "no-marker-here")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	kbID, kbType := ResolveCurrentKBIDAndType(sub)
+	require.Equal(t, "", kbID)
+	require.Equal(t, "", kbType)
+}

--- a/internal/kb/resolve_test.go
+++ b/internal/kb/resolve_test.go
@@ -1,0 +1,241 @@
+package kb
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/endpoint"
+)
+
+// writeMarker is a tiny helper that creates `<dir>/.sageox/<name>` with the
+// given contents. Returns the anchor (i.e. dir).
+func writeMarker(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	sageoxPath := filepath.Join(dir, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxPath, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxPath, name), []byte(contents), 0o600))
+	return dir
+}
+
+func TestResolveCurrentKB_NoMarker(t *testing.T) {
+	// cwd in a tmpdir with no .sageox/ anywhere up to root — must return
+	// (nil, nil), not an error. This is the "outside any KB" no-op case.
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "nested", "deeper")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	got, err := ResolveCurrentKB(sub)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestResolveCurrentKB_WorkspaceJSON(t *testing.T) {
+	// Legacy .sageox/config.json with kb_id (and repo_id, which the resolver
+	// ignores). Workspace artifacts (cache/) make IsWorkspace true.
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.json",
+		`{"kb_id":"kb_01abc","repo_id":"repo_xyz","endpoint":"sageox.ai"}`)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sageox", "cache"), 0o755))
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "kb_01abc", got.KBID)
+	require.Equal(t, filepath.Join(".sageox", "config.json"), got.Source)
+	require.Equal(t, ScopeExclusive, got.Scope)
+	require.Equal(t, "https://sageox.ai", got.Endpoint)
+	require.True(t, got.IsWorkspace())
+}
+
+func TestResolveCurrentKB_BindingOnlyYAML(t *testing.T) {
+	// Minimum binding-only marker: just kb_id in config.yaml, no cache/ledger.
+	// IsWorkspace must be false.
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_personal_01\n")
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "kb_personal_01", got.KBID)
+	require.Equal(t, filepath.Join(".sageox", "config.yaml"), got.Source)
+	require.False(t, got.IsWorkspace())
+}
+
+func TestResolveCurrentKB_YAMLPriorityOverJSON(t *testing.T) {
+	// Both formats present in the same directory: yaml wins per ADR-017 §2.
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.json", `{"kb_id":"kb_legacy"}`)
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_current\n")
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "kb_current", got.KBID)
+	require.Equal(t, filepath.Join(".sageox", "config.yaml"), got.Source)
+}
+
+func TestResolveCurrentKB_EndpointExplicit(t *testing.T) {
+	// Explicit endpoint in the marker file propagates (and is normalized —
+	// www.dev.sageox.ai → dev.sageox.ai per endpoints rule).
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_01\nendpoint: www.dev.sageox.ai\n")
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "https://dev.sageox.ai", got.Endpoint)
+}
+
+func TestResolveCurrentKB_EndpointFallback(t *testing.T) {
+	// No endpoint: in the file → endpoint.Get() is used. We exercise the
+	// "env var wins" branch of endpoint.Get to make this deterministic
+	// without depending on the user's logged-in endpoints or default.
+	t.Setenv(endpoint.EnvVar, "https://fallback.sageox.ai")
+
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_01\n")
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, endpoint.NormalizeEndpoint("https://fallback.sageox.ai"), got.Endpoint)
+}
+
+func TestResolveCurrentKB_NestedMarkersRejected(t *testing.T) {
+	// docs/.sageox inside a repo .sageox/ → subtree override, rejected in v1.
+	outer := t.TempDir()
+	writeMarker(t, outer, "config.yaml", "kb_id: kb_outer\n")
+
+	inner := filepath.Join(outer, "docs")
+	writeMarker(t, inner, "config.yaml", "kb_id: kb_inner\n")
+
+	got, err := ResolveCurrentKB(inner)
+	require.Nil(t, got)
+	require.ErrorIs(t, err, ErrSubtreeOverridesNotSupported)
+}
+
+func TestResolveCurrentKB_NearestWinsWithoutNesting(t *testing.T) {
+	// A marker only at the outer dir: walking up from a subdir finds it.
+	// (No inner marker, so subtree-override doesn't trigger.)
+	outer := t.TempDir()
+	writeMarker(t, outer, "config.yaml", "kb_id: kb_outer\n")
+
+	deep := filepath.Join(outer, "src", "pkg")
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+
+	got, err := ResolveCurrentKB(deep)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "kb_outer", got.KBID)
+	// resolved anchor uses the real path; on macOS t.TempDir lives under
+	// /private/var, so compare via EvalSymlinks rather than literal equality.
+	wantAnchor, err := filepath.EvalSymlinks(outer)
+	require.NoError(t, err)
+	require.Equal(t, wantAnchor, got.Anchor)
+}
+
+func TestResolveCurrentKB_MalformedYAML(t *testing.T) {
+	// Malformed YAML → parse error, not silently nil. The bead description
+	// explicitly calls this out: a hand-edited bad marker must surface.
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: [unterminated\n")
+
+	got, err := ResolveCurrentKB(dir)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestResolveCurrentKB_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.json", `{"kb_id":`)
+
+	got, err := ResolveCurrentKB(dir)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestResolveCurrentKB_LegacyMarkerWithoutKBID(t *testing.T) {
+	// Pre-ADR-017 config.json with only repo_id is not a KB binding. ADR-017
+	// §7 says this synthesizes kb_type=repo via the merger; the resolver itself
+	// returns (nil, nil) so callers fall through to legacy code paths cleanly.
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.json", `{"repo_id":"repo_abc"}`)
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestResolveCurrentKB_EmptyCwd(t *testing.T) {
+	got, err := ResolveCurrentKB("")
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestIsWorkspace_CacheDir(t *testing.T) {
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_01\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sageox", "cache"), 0o755))
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.IsWorkspace())
+}
+
+func TestIsWorkspace_LedgerDir(t *testing.T) {
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_01\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sageox", "ledger"), 0o755))
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.IsWorkspace())
+}
+
+func TestIsWorkspace_KBLink(t *testing.T) {
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_01\n")
+	kbDir := filepath.Join(dir, ".sageox", "kb")
+	require.NoError(t, os.MkdirAll(kbDir, 0o755))
+	// any entry under kb/ counts as a workspace marker.
+	require.NoError(t, os.Symlink("/tmp/nonexistent-target", filepath.Join(kbDir, "team-conventions")))
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.IsWorkspace())
+}
+
+func TestIsWorkspace_BindingOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeMarker(t, dir, "config.yaml", "kb_id: kb_01\n")
+
+	got, err := ResolveCurrentKB(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.False(t, got.IsWorkspace())
+}
+
+func TestIsWorkspace_NilReceiver(t *testing.T) {
+	var b *KBBinding
+	require.False(t, b.IsWorkspace())
+}
+
+// TestErrSubtreeOverridesNotSupported_ErrorsIs makes sure callers can identify
+// the sentinel via errors.Is — it would be unfortunate if a future refactor
+// wrapped the error in a way that broke this.
+func TestErrSubtreeOverridesNotSupported_ErrorsIs(t *testing.T) {
+	outer := t.TempDir()
+	writeMarker(t, outer, "config.yaml", "kb_id: kb_outer\n")
+	inner := filepath.Join(outer, "nested")
+	writeMarker(t, inner, "config.yaml", "kb_id: kb_inner\n")
+
+	_, err := ResolveCurrentKB(inner)
+	require.True(t, errors.Is(err, ErrSubtreeOverridesNotSupported))
+}

--- a/internal/kb/resolve_test.go
+++ b/internal/kb/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -199,6 +200,13 @@ func TestIsWorkspace_LedgerDir(t *testing.T) {
 }
 
 func TestIsWorkspace_KBLink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// os.Symlink requires elevated privileges or Developer Mode on
+		// Windows; the workspace-marker semantics are platform-agnostic
+		// (the function just looks for any dir entry), so skipping here
+		// is safe.
+		t.Skip("symlink creation may require elevated privileges on Windows")
+	}
 	dir := t.TempDir()
 	writeMarker(t, dir, "config.yaml", "kb_id: kb_01\n")
 	kbDir := filepath.Join(dir, ".sageox", "kb")

--- a/internal/ledger/gitenv_test.go
+++ b/internal/ledger/gitenv_test.go
@@ -1,0 +1,13 @@
+package ledger
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/lfs/gitenv_test.go
+++ b/internal/lfs/gitenv_test.go
@@ -1,0 +1,13 @@
+package lfs
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -3,16 +3,23 @@ package logger
 import (
 	"log/slog"
 	"os"
+	"sync/atomic"
 )
 
-var log *slog.Logger
+// log is the package-level logger. Stored as atomic.Pointer so concurrent
+// reads (every Debug/Info/Warn/Error call across goroutines, including the
+// telemetry flush worker) cannot race with Init's write at CLI startup.
+// Plain *slog.Logger here trips the race detector under test runs that
+// drive cobra (each new test invocation re-runs Init while a previous
+// test's telemetry goroutine is still logging).
+var log atomic.Pointer[slog.Logger]
 
 func init() {
-	// initialize with a default logger (warn level, text handler)
-	// this ensures log is never nil, even if Init() is not called
-	log = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	// initialize with a default logger (warn level, text handler) so log
+	// is never nil even if Init() is not called.
+	log.Store(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelWarn,
-	}))
+	})))
 }
 
 func Init(verbose bool) {
@@ -33,22 +40,23 @@ func Init(verbose bool) {
 		})
 	}
 
-	log = slog.New(handler)
-	slog.SetDefault(log)
+	newLog := slog.New(handler)
+	log.Store(newLog)
+	slog.SetDefault(newLog)
 }
 
 func Info(msg string, args ...any) {
-	log.Info(msg, args...)
+	log.Load().Info(msg, args...)
 }
 
 func Debug(msg string, args ...any) {
-	log.Debug(msg, args...)
+	log.Load().Debug(msg, args...)
 }
 
 func Warn(msg string, args ...any) {
-	log.Warn(msg, args...)
+	log.Load().Warn(msg, args...)
 }
 
 func Error(msg string, args ...any) {
-	log.Error(msg, args...)
+	log.Load().Error(msg, args...)
 }

--- a/internal/manifest/gitenv_test.go
+++ b/internal/manifest/gitenv_test.go
@@ -1,0 +1,13 @@
+package manifest
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/prime/kb.go
+++ b/internal/prime/kb.go
@@ -22,6 +22,7 @@ const (
 	hintTeam     = "team-wide decisions/conventions; read with 'ox agent team-ctx'"
 	hintRepoSyn  = "ledger archive — read on demand"
 	hintCustom   = "custom knowledge bubble"
+	hintChannel  = "channel bubble — broadcast/presence surface; manual session recording"
 )
 
 // BuildKBInfos converts a merger result into the prime KB envelope.
@@ -126,6 +127,11 @@ func hintForType(t api.KBType, legacy bool) string {
 		return hintRepoSyn
 	case api.KBTypeCustom:
 		return hintCustom
+	case "channel":
+		// channel is defined in internal/api/kbconfig but not yet in
+		// internal/api as a typed KBType — match on the string slug so
+		// rows that arrive as kb_type="channel" still get the right hint.
+		return hintChannel
 	default:
 		_ = legacy // intentionally unused; reserved for future per-source nuance
 		return ""
@@ -147,8 +153,12 @@ func kbTypePriority(t string) int {
 		return 3
 	case string(api.KBTypeCustom):
 		return 4
-	default:
+	case "channel":
+		// channel slots between custom and unknown until KBTypeChannel is
+		// promoted into internal/api.
 		return 5
+	default:
+		return 6
 	}
 }
 

--- a/internal/prime/kb_test.go
+++ b/internal/prime/kb_test.go
@@ -292,6 +292,34 @@ func captureSlog(t *testing.T) *bytes.Buffer {
 	return buf
 }
 
+// TestBuildKBInfos_ChannelTypeHintAndSort verifies a channel bubble carries
+// the channel-specific hint and sorts between custom and unknown — the slot
+// reserved for it before KBTypeChannel is promoted into internal/api.
+//
+// Failure prevented: a channel row arriving from the kb-API source (after the
+// mono rollout) would either lose its agent-facing hint (default empty string)
+// or sort into the wrong bucket, surprising agents that index by position.
+func TestBuildKBInfos_ChannelTypeHintAndSort(t *testing.T) {
+	res := kb.MergeResult{
+		Bubbles: []kb.Bubble{
+			{Type: api.KBTypeCustom, Slug: "custom-thing", Source: kb.SourceKB},
+			{Type: api.KBType("channel"), Slug: "wip-broadcast", Source: kb.SourceKB},
+			{Type: api.KBTypeUnknown, Slug: "future-kind", Source: kb.SourceKB},
+		},
+	}
+
+	got := BuildKBInfos(res, nil)
+	require.Len(t, got, 3)
+
+	// custom (4) → channel (5) → unknown (6)
+	assert.Equal(t, "custom-thing", got[0].Slug)
+	assert.Equal(t, "wip-broadcast", got[1].Slug)
+	assert.Equal(t, "channel", got[1].Type)
+	assert.Contains(t, got[1].Hint, "channel bubble")
+	assert.Contains(t, got[1].Hint, "manual session recording")
+	assert.Equal(t, "future-kind", got[2].Slug)
+}
+
 // sanity: ensure captureSlog actually captures (a meta-test for the helper
 // so a broken capture doesn't hide a missing-warn assertion).
 func TestCaptureSlog_RoundTrips(t *testing.T) {

--- a/internal/prime/types.go
+++ b/internal/prime/types.go
@@ -299,31 +299,35 @@ type UserNotice struct {
 
 // Output is the structured response for agent bootstrap (prime)
 type Output struct {
-	Status            string                     `json:"status"` // fresh, degraded, unavailable
-	AgentID           string                     `json:"agent_id"`
-	Guidance          *Guidance                  `json:"guidance,omitempty"` // intent-to-command lookup (scan first)
-	SessionID         string                     `json:"session_id,omitempty"`
-	AgentType         string                     `json:"agent_type,omitempty"`     // detected or specified agent type
-	AgentSupported    bool                       `json:"agent_supported"`          // true if agent is officially supported
-	SupportNotice     string                     `json:"support_notice,omitempty"` // warning for unsupported agents
-	Content           string                     `json:"content"`
-	Attribution       config.ResolvedAttribution `json:"attribution"`                 // commit/PR attribution for ox-guided work
-	PlanFooter        string                     `json:"plan_footer,omitempty"`       // exact text for plan footer ("Guided by SageOx")
-	ProjectGuidance   *ProjectGuidance           `json:"project_guidance,omitempty"`  // AGENTS.md content if found
-	TeamInstructions  *TeamInstructions          `json:"team_instructions,omitempty"` // team AGENTS.md/CLAUDE.md content if found
-	CapturePrior      *CapturePriorGuidance      `json:"capture_prior,omitempty"`     // instructions for capturing prior history
-	Message           string                     `json:"message,omitempty"`
-	TokenEstimate     int                        `json:"token_estimate,omitempty"`      // estimated token count
-	ContentLength     int                        `json:"content_length,omitempty"`      // raw byte length
-	Session           *SessionStatus             `json:"session,omitempty"`             // session recording status
-	KB                []KBInfo                   `json:"kb,omitempty"`                  // unified knowledge-bubble envelope (kb-API + legacy team-contexts + legacy ledgers, deduped)
-	Ledger            *LedgerInfo                `json:"ledger,omitempty"`              // legacy mirror; new callers should use KB (see LedgerInfo godoc)
-	Important         string                     `json:"important"`                     // always-present disambiguation of knowledge sources
-	TeamContext       *TeamContextInfo           `json:"team_context,omitempty"`        // legacy mirror; new callers should use KB (see TeamContextInfo godoc)
-	TeamContextStatus string                     `json:"team_context_status,omitempty"` // "synced", "syncing", or empty; set when team_context is null but sync is expected
-	OtherTeams        *OtherTeams                `json:"other_teams,omitempty"`         // non-primary teams (nil when only 1 team)
-	UserNotification  string                     `json:"user_notification,omitempty"`   // pre-built status summary for agent to relay to user
-	AgentTip          string                     `json:"agent_tip,omitempty"`           // contextual tip for the agent itself (not for the user)
+	Status           string                     `json:"status"` // fresh, degraded, unavailable
+	AgentID          string                     `json:"agent_id"`
+	Guidance         *Guidance                  `json:"guidance,omitempty"` // intent-to-command lookup (scan first)
+	SessionID        string                     `json:"session_id,omitempty"`
+	AgentType        string                     `json:"agent_type,omitempty"`     // detected or specified agent type
+	AgentSupported   bool                       `json:"agent_supported"`          // true if agent is officially supported
+	SupportNotice    string                     `json:"support_notice,omitempty"` // warning for unsupported agents
+	Content          string                     `json:"content"`
+	Attribution      config.ResolvedAttribution `json:"attribution"`                 // commit/PR attribution for ox-guided work
+	PlanFooter       string                     `json:"plan_footer,omitempty"`       // exact text for plan footer ("Guided by SageOx")
+	ProjectGuidance  *ProjectGuidance           `json:"project_guidance,omitempty"`  // AGENTS.md content if found
+	TeamInstructions *TeamInstructions          `json:"team_instructions,omitempty"` // team AGENTS.md/CLAUDE.md content if found
+	CapturePrior     *CapturePriorGuidance      `json:"capture_prior,omitempty"`     // instructions for capturing prior history
+	Message          string                     `json:"message,omitempty"`
+	TokenEstimate    int                        `json:"token_estimate,omitempty"` // estimated token count
+	ContentLength    int                        `json:"content_length,omitempty"` // raw byte length
+	Session          *SessionStatus             `json:"session,omitempty"`        // session recording status
+	KB               []KBInfo                   `json:"kb,omitempty"`             // unified knowledge-bubble envelope (kb-API + legacy team-contexts + legacy ledgers, deduped)
+	// CurrentKB is the KB the agent is currently operating inside, resolved
+	// from the cwd via kb.ResolveCurrentKB. Nil if the cwd is not inside a
+	// .sageox/-mapped tree.
+	CurrentKB         *KBInfo          `json:"current_kb,omitempty"`
+	Ledger            *LedgerInfo      `json:"ledger,omitempty"`              // legacy mirror; new callers should use KB (see LedgerInfo godoc)
+	Important         string           `json:"important"`                     // always-present disambiguation of knowledge sources
+	TeamContext       *TeamContextInfo `json:"team_context,omitempty"`        // legacy mirror; new callers should use KB (see TeamContextInfo godoc)
+	TeamContextStatus string           `json:"team_context_status,omitempty"` // "synced", "syncing", or empty; set when team_context is null but sync is expected
+	OtherTeams        *OtherTeams      `json:"other_teams,omitempty"`         // non-primary teams (nil when only 1 team)
+	UserNotification  string           `json:"user_notification,omitempty"`   // pre-built status summary for agent to relay to user
+	AgentTip          string           `json:"agent_tip,omitempty"`           // contextual tip for the agent itself (not for the user)
 	// Prime call tracking
 	PrimeCallCount       int    `json:"prime_call_count,omitempty"`       // number of prime calls this session
 	PrimeExcessiveNotice string `json:"prime_excessive_notice,omitempty"` // warning if prime called excessively

--- a/internal/repotools/gitenv_test.go
+++ b/internal/repotools/gitenv_test.go
@@ -1,0 +1,13 @@
+package repotools
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/session/gitenv_test.go
+++ b/internal/session/gitenv_test.go
@@ -1,0 +1,13 @@
+package session
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -100,11 +101,24 @@ func WithProjectRoot(projectRoot string) ClientOption {
 
 // NewClient creates a new telemetry client.
 // Telemetry is enabled by default unless user has opted out.
+//
+// Opt-out is honored from three sources, in order:
+//  1. DO_NOT_TRACK=1 env var (matches daemon-side collector + ecosystem
+//     convention from https://consoledonottrack.com/).
+//  2. SAGEOX_TELEMETRY=false env var (ox-specific override; matches
+//     daemon-side collector).
+//  3. UserConfig.TelemetryEnabled (persisted setting).
 func NewClient(sessionID string, opts ...ClientOption) *Client {
-	// check user preference
 	enabled := true
-	if cfg, err := config.LoadUserConfig(); err == nil {
-		enabled = cfg.IsTelemetryEnabled()
+	switch {
+	case os.Getenv("DO_NOT_TRACK") == "1":
+		enabled = false
+	case strings.EqualFold(os.Getenv("SAGEOX_TELEMETRY"), "false"):
+		enabled = false
+	default:
+		if cfg, err := config.LoadUserConfig(); err == nil {
+			enabled = cfg.IsTelemetryEnabled()
+		}
 	}
 
 	client := &Client{

--- a/internal/testenv/gitenv.go
+++ b/internal/testenv/gitenv.go
@@ -1,0 +1,46 @@
+// Package testenv provides shared process-environment isolation for
+// test binaries. Blank-import this from any test package whose tests
+// invoke `git` so the developer's global git config (`~/.gitconfig`)
+// does not leak into the subprocess environment.
+//
+// What this avoids: when a developer has `commit.gpgsign=true` and a
+// passphrase-protected SSH/GPG signing key configured globally, every
+// `git commit` in a test fixture inherits that config and blocks
+// waiting for a passphrase prompt the test runner cannot satisfy.
+// Result: cascade failures across `internal/codedb/index`,
+// `internal/doctor`, `internal/repotools`, `internal/uninstall`,
+// `internal/secrets`, etc.
+//
+// The Makefile (`TEST_GIT_ISOLATION` in the `test`/`test-cover`/
+// `test-all`/`test-slow` recipes) sets the same env vars at the
+// `make`-driver level. This package covers the direct `go test ./pkg/`
+// case — which IDE-driven runs and ad-hoc `go test` use — so the
+// passing/failing posture is identical whether tests are invoked via
+// make or go.
+//
+// Usage:
+//
+//	package mypkg_test
+//
+//	import (
+//	    _ "github.com/sageox/ox/internal/testenv"
+//	)
+//
+// init() honors existing env vars; if the Makefile or a CI environment
+// already set them, we leave those values in place.
+package testenv
+
+import "os"
+
+func init() {
+	setIfUnset("GIT_CONFIG_GLOBAL", "/dev/null")
+	setIfUnset("GIT_CONFIG_NOSYSTEM", "1")
+	setIfUnset("GIT_TERMINAL_PROMPT", "0")
+}
+
+func setIfUnset(name, value string) {
+	if _, set := os.LookupEnv(name); set {
+		return
+	}
+	_ = os.Setenv(name, value)
+}

--- a/internal/testenv/gitenv.go
+++ b/internal/testenv/gitenv.go
@@ -36,6 +36,18 @@ func init() {
 	setIfUnset("GIT_CONFIG_GLOBAL", "/dev/null")
 	setIfUnset("GIT_CONFIG_NOSYSTEM", "1")
 	setIfUnset("GIT_TERMINAL_PROMPT", "0")
+
+	// Disabling global config wipes the developer's (or CI runner's)
+	// `user.name`/`user.email`. Production code paths invoked by tests
+	// — e.g. EnsureCheckoutGitignore in internal/daemon — call `git
+	// commit`, which fails with "Author identity unknown" without one
+	// of: per-repo config, global config, or these env vars. Supplying
+	// the env vars is the only one that works without per-test setup
+	// AND survives our isolation.
+	setIfUnset("GIT_AUTHOR_NAME", "ox-test")
+	setIfUnset("GIT_AUTHOR_EMAIL", "test@sageox.ai")
+	setIfUnset("GIT_COMMITTER_NAME", "ox-test")
+	setIfUnset("GIT_COMMITTER_EMAIL", "test@sageox.ai")
 }
 
 func setIfUnset(name, value string) {

--- a/internal/testenv/gitenv.go
+++ b/internal/testenv/gitenv.go
@@ -45,9 +45,9 @@ func init() {
 	// the env vars is the only one that works without per-test setup
 	// AND survives our isolation.
 	setIfUnset("GIT_AUTHOR_NAME", "ox-test")
-	setIfUnset("GIT_AUTHOR_EMAIL", "test@sageox.ai")
+	setIfUnset("GIT_AUTHOR_EMAIL", "test@test.sageox.ai")
 	setIfUnset("GIT_COMMITTER_NAME", "ox-test")
-	setIfUnset("GIT_COMMITTER_EMAIL", "test@sageox.ai")
+	setIfUnset("GIT_COMMITTER_EMAIL", "test@test.sageox.ai")
 }
 
 func setIfUnset(name, value string) {

--- a/internal/uninstall/gitenv_test.go
+++ b/internal/uninstall/gitenv_test.go
@@ -1,0 +1,13 @@
+package uninstall
+
+// gitenv_test.go: blank-import internal/testenv so this package's test
+// binary inherits the git-isolation env vars (GIT_CONFIG_GLOBAL=/dev/null,
+// GIT_CONFIG_NOSYSTEM=1, GIT_TERMINAL_PROMPT=0). Without these, `git commit`
+// invocations in test fixtures inherit the developer's global gpgsign /
+// signingkey config and block on a passphrase prompt. The Makefile sets
+// the same vars for `make test`/`test-all`/`test-slow`; this file covers
+// direct `go test` runs and IDE-driven workflows.
+//
+// See internal/testenv/gitenv.go.
+
+import _ "github.com/sageox/ox/internal/testenv"

--- a/scripts/check-kbconfig-drift.sh
+++ b/scripts/check-kbconfig-drift.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# check-kbconfig-drift.sh
+#
+# Verifies internal/api/kbconfig/{types.go,constants.go,defaults.go,resolve.go}
+# stay in sync with sageox-mono's packages/kb/config.go. ox vendors the canonical
+# KBConfig Go types (no Go module link to mono is possible — see bead ox-jzlm),
+# so drift here turns into wire-format mismatches against the mono service.
+# The ResolveEffectiveMode safety-inversion logic is privacy-critical; drift in
+# that function is a security bug.
+#
+# Run on every PR touching internal/api/kbconfig/* and weekly via cron.
+#
+# Exit codes:
+#   0  parity (ok to merge)
+#   1  drift detected (fix vendored copy or update allowlist)
+#   2  setup error (mono path not found, files missing, etc.)
+#
+# Configuration:
+#   MONO_REPO  path to a sageox-mono checkout. Defaults to ../sageox-mono
+#              relative to the ox repo root.
+
+set -uo pipefail
+
+ox_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mono_repo="${MONO_REPO:-${ox_root}/../sageox-mono}"
+
+# Resolve mono path. The conductor-style mono checkout may be nested one
+# level deeper (a sibling workspace directory containing the actual repo);
+# probe both shapes.
+mono_config=""
+for candidate in \
+    "${mono_repo}/packages/kb/config.go" \
+    "${mono_repo}"/*/packages/kb/config.go; do
+    if [[ -f "$candidate" ]]; then
+        mono_config="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$mono_config" ]]; then
+    echo "ERROR: could not locate packages/kb/config.go under MONO_REPO=${mono_repo}" >&2
+    echo "Set MONO_REPO to a sageox-mono checkout root." >&2
+    exit 2
+fi
+
+ox_types="${ox_root}/internal/api/kbconfig/types.go"
+ox_constants="${ox_root}/internal/api/kbconfig/constants.go"
+ox_defaults="${ox_root}/internal/api/kbconfig/defaults.go"
+ox_resolve="${ox_root}/internal/api/kbconfig/resolve.go"
+
+for f in "$ox_types" "$ox_constants" "$ox_defaults" "$ox_resolve"; do
+    if [[ ! -f "$f" ]]; then
+        echo "ERROR: missing ox file: $f" >&2
+        exit 2
+    fi
+done
+
+echo "Comparing:"
+echo "  mono: $mono_config"
+echo "  ox:   internal/api/kbconfig/"
+echo
+
+# Drift accumulator. Stays 0 on parity, set to 1 on any mismatch.
+drift=0
+
+# Extract struct field declarations (field name + type, ignoring tags) for a
+# named struct from a Go file. The matcher is intentionally regex-based and
+# tolerant of formatting — it normalises whitespace, drops struct tags, drops
+# pure-comment lines, and emits "field type" pairs sorted alphabetically so
+# field-order changes don't trigger drift.
+#
+# Portable awk only (no 3-arg match): we rely on POSIX awk plus a small bit
+# of shell glue. BSD awk on macOS does not support gawk's match(s, re, arr)
+# 3-arg form, so we capture the struct name via a literal-prefix check
+# instead.
+extract_struct_fields() {
+    local file="$1"
+    local struct_name="$2"
+    awk -v target="$struct_name" '
+        # Inline empty struct on a single line: "type Foo struct{}" — emit
+        # nothing (zero fields) and immediately leave the context. Must come
+        # before the multi-line opener so the opener does not match first.
+        $0 ~ ("^type[[:space:]]+" target "[[:space:]]+struct[[:space:]]*\\{[[:space:]]*\\}") {
+            in_struct = 0
+            next
+        }
+        $0 ~ ("^type[[:space:]]+" target "[[:space:]]+struct[[:space:]]*\\{[[:space:]]*$") {
+            in_struct = 1
+            next
+        }
+        # any *other* type declaration ends the previous struct context
+        /^type[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]+struct/ {
+            in_struct = 0
+            next
+        }
+        in_struct && /^\}/ { in_struct = 0; next }
+        in_struct {
+            line = $0
+            # strip leading/trailing whitespace
+            sub(/^[[:space:]]+/, "", line)
+            sub(/[[:space:]]+$/, "", line)
+            # skip blank lines and pure-comment lines
+            if (line == "" || line ~ /^\/\//) next
+            # drop struct tags (backtick-delimited)
+            sub(/`[^`]*`/, "", line)
+            # drop trailing line comments
+            sub(/[[:space:]]*\/\/.*$/, "", line)
+            # collapse internal whitespace
+            gsub(/[[:space:]]+/, " ", line)
+            sub(/[[:space:]]+$/, "", line)
+            if (line != "") print line
+        }
+    ' "$file" | sort
+}
+
+compare_struct() {
+    local struct_name="$1"
+    local mono_fields ox_fields
+    mono_fields=$(extract_struct_fields "$mono_config" "$struct_name")
+    ox_fields=$(extract_struct_fields "$ox_types" "$struct_name")
+
+    # SystemConfig has an intentional ox-side addition: ConfigCommittedAt is
+    # tolerated on read but absent from mono. Strip it from ox's view before
+    # comparing so the rest of the struct still gets a strict diff. Add new
+    # whitelisted entries here with a justification comment.
+    if [[ "$struct_name" == "SystemConfig" ]]; then
+        ox_fields=$(grep -v -F 'ConfigCommittedAt *time.Time' <<<"$ox_fields" || true)
+    fi
+
+    if [[ "$mono_fields" == "$ox_fields" ]]; then
+        printf '  OK   %-26s (%d fields)\n' "$struct_name" "$(printf '%s\n' "$mono_fields" | grep -c '.' || true)"
+        return 0
+    fi
+
+    printf '  DRIFT %s\n' "$struct_name"
+    echo "    mono fields:"
+    printf '      %s\n' "${mono_fields:-<none>}"
+    echo "    ox fields (after allowlist):"
+    printf '      %s\n' "${ox_fields:-<none>}"
+    echo "    diff (mono → ox):"
+    diff <(printf '%s\n' "$mono_fields") <(printf '%s\n' "$ox_fields") | sed 's/^/      /'
+    drift=1
+}
+
+echo "Struct field parity:"
+compare_struct "KBConfig"
+compare_struct "FeaturesConfig"
+compare_struct "MurmursConfig"
+compare_struct "SessionRecordingConfig"
+compare_struct "SystemConfig"
+echo
+
+# Constant parity. Mono's constants live in config.go; ox's live in
+# constants.go. Compare value strings only — the names are stable and the
+# point is to catch a renamed slug ("auto" → "automatic" would silently
+# break the wire format).
+compare_const_values() {
+    local label="$1"
+    local mono_pat="$2"
+    local ox_pat="$3"
+    local mono_vals ox_vals
+    mono_vals=$(grep -E "^[[:space:]]*${mono_pat}" "$mono_config" \
+        | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/' | sort -u)
+    ox_vals=$(grep -E "^[[:space:]]*${ox_pat}" "$ox_constants" \
+        | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/' | sort -u)
+    if [[ "$mono_vals" == "$ox_vals" ]]; then
+        printf '  OK   %-26s (%s)\n' "$label" "$(echo "$mono_vals" | paste -sd, -)"
+    else
+        printf '  DRIFT %s\n' "$label"
+        echo "    mono: $(echo "$mono_vals" | paste -sd, -)"
+        echo "    ox:   $(echo "$ox_vals" | paste -sd, -)"
+        drift=1
+    fi
+}
+
+echo "Constant value parity:"
+compare_const_values "SessionRecording*" \
+    "SessionRecording(Auto|Manual|Disabled)[[:space:]]+=" \
+    "SessionRecording(Auto|Manual|Disabled)[[:space:]]+="
+compare_const_values "Visibility*" \
+    "Visibility(Private|Team)[[:space:]]+=" \
+    "Visibility(Private|Team)[[:space:]]+="
+echo
+
+# KB type values. Mono declares them as typed constants ("KBType = " in
+# types.go), ox vendors them as untyped string constants. Compare values.
+mono_types_file="$(dirname "$mono_config")/types.go"
+if [[ -f "$mono_types_file" ]]; then
+    mono_kb_types=$(grep -E '^[[:space:]]*KBType(Personal|Profile|Team|Repo|Custom|Channel)[[:space:]]+KBType[[:space:]]*=' "$mono_types_file" \
+        | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/' | sort -u)
+    ox_kb_types=$(grep -E '^[[:space:]]*KBType(Personal|Profile|Team|Repo|Custom|Channel)[[:space:]]+=' "$ox_constants" \
+        | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/' | sort -u)
+    if [[ "$mono_kb_types" == "$ox_kb_types" ]]; then
+        printf 'KB type parity: OK (%s)\n' "$(echo "$mono_kb_types" | paste -sd, -)"
+    else
+        echo "KB type parity: DRIFT"
+        echo "  mono: $(echo "$mono_kb_types" | paste -sd, -)"
+        echo "  ox:   $(echo "$ox_kb_types" | paste -sd, -)"
+        drift=1
+    fi
+else
+    echo "WARN: $mono_types_file not found; skipping KB-type comparison"
+fi
+echo
+
+# ResolveEffectiveMode safety-inversion check. Extract the function body
+# from both files and compare the key invariant: the "either side disabled
+# wins" check must be present and listed FIRST. Pattern-match rather than
+# token-diff because formatting may differ slightly across copies.
+check_resolve_invariant() {
+    local label="$1"
+    local file="$2"
+    local local_drift=0
+    # Pull lines between "func ResolveEffectiveMode" and the matching close brace.
+    local body
+    body=$(awk '
+        /^func ResolveEffectiveMode\(/ { in_fn = 1; depth = 0 }
+        in_fn {
+            print
+            n = gsub(/\{/, "{")
+            depth += n
+            n = gsub(/\}/, "}")
+            depth -= n
+            if (depth == 0 && /\}/) { in_fn = 0 }
+        }
+    ' "$file")
+    if [[ -z "$body" ]]; then
+        echo "  ERROR $label: ResolveEffectiveMode not found ($file)"
+        drift=1
+        return
+    fi
+    # The veto must reference both userMode and kbMode with == SessionRecordingDisabled.
+    if ! grep -qE 'userMode[[:space:]]*==[[:space:]]*SessionRecordingDisabled' <<<"$body"; then
+        echo "  DRIFT $label: missing userMode == SessionRecordingDisabled check"
+        local_drift=1
+    fi
+    if ! grep -qE 'kbMode[[:space:]]*==[[:space:]]*SessionRecordingDisabled' <<<"$body"; then
+        echo "  DRIFT $label: missing kbMode == SessionRecordingDisabled check"
+        local_drift=1
+    fi
+    # The veto must come before the precedence "userMode != \"\"" check.
+    local veto_line prec_line
+    veto_line=$(grep -nE '(userMode|kbMode)[[:space:]]*==[[:space:]]*SessionRecordingDisabled' <<<"$body" | head -1 | cut -d: -f1)
+    prec_line=$(grep -nE 'userMode[[:space:]]*!=[[:space:]]*""' <<<"$body" | head -1 | cut -d: -f1)
+    if [[ -n "$veto_line" && -n "$prec_line" && "$veto_line" -ge "$prec_line" ]]; then
+        echo "  DRIFT $label: safety inversion (veto) is below precedence check; ORDER IS SEMANTICS"
+        local_drift=1
+    fi
+    if (( local_drift == 0 )); then
+        echo "  OK   $label: veto-first + precedence intact"
+    else
+        drift=1
+    fi
+}
+
+echo "ResolveEffectiveMode safety-inversion:"
+check_resolve_invariant "mono" "$mono_config"
+check_resolve_invariant "ox  " "$ox_resolve"
+echo
+
+# DefaultSessionRecordingMode per-type defaults. Pull the switch arms from
+# both files and compare which constants land in which return.
+extract_default_arms() {
+    local file="$1"
+    awk '
+        /^func DefaultSessionRecordingMode/ { in_fn = 1; next }
+        in_fn && /^\}/ { in_fn = 0; next }
+        in_fn { print }
+    ' "$file" | grep -E 'KBType|return Session' | tr -s ' \t' ' '
+}
+
+mono_arms=$(extract_default_arms "$mono_config")
+ox_arms=$(extract_default_arms "$ox_defaults")
+if [[ "$mono_arms" == "$ox_arms" ]]; then
+    echo "DefaultSessionRecordingMode arms: OK"
+else
+    echo "DefaultSessionRecordingMode arms: DRIFT"
+    diff <(echo "$mono_arms") <(echo "$ox_arms") | sed 's/^/  /'
+    drift=1
+fi
+echo
+
+if (( drift == 0 )); then
+    echo "Result: PARITY — vendored kbconfig is in sync with mono."
+    exit 0
+fi
+
+echo "Result: DRIFT DETECTED — update internal/api/kbconfig/* to match mono," >&2
+echo "       or update the allowlist in this script with justification." >&2
+exit 1

--- a/scripts/check-kbconfig-drift.sh
+++ b/scripts/check-kbconfig-drift.sh
@@ -239,10 +239,16 @@ check_resolve_invariant() {
         local_drift=1
     fi
     # The veto must come before the precedence "userMode != \"\"" check.
-    local veto_line prec_line
-    veto_line=$(grep -nE '(userMode|kbMode)[[:space:]]*==[[:space:]]*SessionRecordingDisabled' <<<"$body" | head -1 | cut -d: -f1)
+    # Track BOTH veto patterns (userMode/kbMode) separately and validate the
+    # LAST veto occurrence against the precedence check — otherwise a config
+    # with the first veto above precedence and a second veto below it would
+    # still pass, even though the second one is in the wrong place.
+    local user_veto_line kb_veto_line prec_line last_veto_line
+    user_veto_line=$(grep -nE 'userMode[[:space:]]*==[[:space:]]*SessionRecordingDisabled' <<<"$body" | head -1 | cut -d: -f1)
+    kb_veto_line=$(grep -nE 'kbMode[[:space:]]*==[[:space:]]*SessionRecordingDisabled' <<<"$body" | head -1 | cut -d: -f1)
+    last_veto_line=$(printf '%s\n%s\n' "$user_veto_line" "$kb_veto_line" | grep -E '^[0-9]+$' | sort -n | tail -1)
     prec_line=$(grep -nE 'userMode[[:space:]]*!=[[:space:]]*""' <<<"$body" | head -1 | cut -d: -f1)
-    if [[ -n "$veto_line" && -n "$prec_line" && "$veto_line" -ge "$prec_line" ]]; then
+    if [[ -n "$last_veto_line" && -n "$prec_line" && "$last_veto_line" -ge "$prec_line" ]]; then
         echo "  DRIFT $label: safety inversion (veto) is below precedence check; ORDER IS SEMANTICS"
         local_drift=1
     fi


### PR DESCRIPTION
## Summary

Lands ADR-017 (KB as the unifying workspace primitive) end-to-end: a path-walking resolver (`kb.ResolveCurrentKB`) for "which KB am I in?", vendored Go types + drift detector for the new `KBConfig` schema (including pre-shipped `KBTypeChannel`), a read-only `ox kb config get/list` CLI (accepts slug, `#slug`, or `kb_id`), doctor-driven `.sageox/config.json` → `.sageox/config.yaml` migration with hybrid read + staged deprecation, two daemon-hardening primitives (per-`kb_id` `flock(2)` to kill silent corruption when N daemons race on shared KB working trees, per-(user, endpoint) lease for global-sync leader election), and prime-envelope plumbing that finally tells the agent which KB it is working in.

## Beads closed (9)

- `ox-kdt2` (P0) — cross-process `flock(2)` on KB working trees + GC trash rename
- `ox-z526` — `kb.ResolveCurrentKB` resolver with `.sageox/` marker walk
- `ox-jzlm` — vendored `internal/api/kbconfig/` types + `KBTypeChannel` + drift detector
- `ox-9g7f` — `ox kb config get/list` (read-only; `--show-origin`, `--at`, `--json`)
- `ox-0s8k` — `ResolveSessionRecording` with safety-inversion via vendored `ResolveEffectiveMode`
- `ox-gant` — doctor migration: JSON-only, YAML-only, both-identical, both-divergent, orphan
- `ox-acqo` — prime envelope `current_kb` field + `KBTypeChannel` touches in prime/symlink/sort
- `ox-c0gd` — `#`-prefix slug formatting in human surfaces (bare in JSON and composable stdout)
- `ox-6zme` — per-(user, endpoint) `flock` lease for global-sync leader election

Companion ADR: `docs/adr/ADR-017-kb-as-workspace-primitive.md`. Open HUMAN bead `ox-7uxm` for cross-repo coordination with sageox-mono on dropping `committed_at` + the YAML banner.

## Architecture

```mermaid
flowchart LR
  CWD(["cwd"])
  MARKER[".sageox/config.{yaml,json}"]
  RES["kb.ResolveCurrentKB (path-walk)"]
  META["KB meta.json (type, slug)"]
  BIND["KBBinding"]
  RSR["config.ResolveSessionRecording"]
  PRIME["ox agent prime: current_kb"]
  CFG["ox kb config get/list"]
  KBFLOCK["per kb_id flock"]
  LEASE["per endpoint lease"]
  SYNC["daemon syncBubbles"]
  KBGC["daemon kb GC"]

  CWD --> RES
  MARKER --> RES
  RES --> BIND
  META -.enrich.-> BIND
  BIND --> RSR
  BIND --> PRIME
  BIND --> CFG

  SYNC --acquire--> KBFLOCK
  KBGC --acquire--> KBFLOCK
  SYNC --acquire--> LEASE
```

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` — 0 issues
- [x] Tests pass: `internal/kb`, `internal/api/kbconfig`, `internal/config`, `internal/prime`, `internal/daemon` (flock + lease + symlinks), `cmd/ox` (kb_config, doctor_kb_migrate, current_kb, slug resolver)
- [x] `scripts/check-kbconfig-drift.sh` against sageox-mono `ryan/kb-config` branch — exit 0 (parity)
- Pre-existing `internal/doctor/*` SSH-dependent tests fail in this env (git-commit prompts for local SSH passphrase); confirmed not introduced by this PR.

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add `ox kb config get`/`list` with layered precedence, origin info and JSON output.
  * KB-aware session recording: per-KB defaults, safety-inversion detection, and KB-specific auto-recording behavior.
  * `ox kb` CLI accepts/normalizes slugs with optional `#` and improves "not found" messages.
  * "Channel" KB type surfaces in listings and is deferred by default.
  * Cross-process per-KB locks and per-endpoint global-sync lease to serialize background work.
  * Agent now reports the current KB context.

* **Doctor**
  * New checks: KB project-config migration and global-sync leader-election health.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->