### PR TITLE
ADR-018: index-only Bleve for CodeDB memory (proposal)

### DIFF
--- a/docs/adr/ADR-018-codedb-index-only-bleve.md
+++ b/docs/adr/ADR-018-codedb-index-only-bleve.md
@@ -1,0 +1,151 @@
+# ADR-018: Index-Only Bleve — Drop Stored Content & Highlighting in CodeDB
+
+**Status**: Proposed (needs Ryan — changes data-access ergonomics)
+**Date**: 2026-05-25
+
+## Context
+
+CodeDB's on-disk and runtime memory footprint is dominated by Bleve. Real
+measurements:
+
+| Repo (ledger cache) | bleve | sqlite | total codedb |
+|---|---|---|---|
+| largest (`repo_019c6d2e…`) | **2.0 GB** | 156 MB | 3.0 GB |
+| `repo_019d56e0…` | 529 MB | 67 MB | 1.9 GB (+1.3 GB ledger sub-store) |
+| ox repo (fresh index) | 438 MB | 56 MB | 534 MB |
+
+A heap profile of a fresh ox-repo index (harness:
+`internal/codedb/index/memory_profile_test.go`, build tag `memprofile`) shows the
+parse phases peak at **1.1–1.5 GB** live heap, and the process retains a
+**~1.67 GB `heapSys`** high-water afterward.
+
+**Why Bleve is so large:** every Bleve index (code/diff/comment) uses the default
+`bleve.NewIndexMapping()`, whose text fields have `Store=true`. So the **full
+source text, full diff text, and full comment text are stored inside Bleve** —
+in addition to living in git (code), SQLite (`comments.text`), or being
+regenerable (diffs). The stored copy exists for exactly one purpose: producing
+the ANSI **highlight fragment** that becomes a search result's snippet.
+
+**But CodeDB's consumers are AI coworkers, not humans.** The agent-facing search
+path already throws the highlighting away:
+
+```go
+// cmd/ox/code.go:204
+snippet := stripANSIEscapes(r.Content)   // generate ANSI … then strip it
+snippet = compactSnippet(snippet, 120)   // plain ≤120-char snippet is all agents get
+```
+
+So we pay (a) the compute to highlight on every search and (b) ~74% of the Bleve
+index to store content — to produce an ANSI string we immediately discard.
+
+**Measured savings** (`TestBleveStoredContentCost`, 1707 ox `.go` files):
+
+```
+stored (default)            = 39.9 MB
+index-only (Store=false, no term vectors) = 10.3 MB
+saving = 74%
+```
+
+Extrapolated: ox bleve 438 MB → ~115 MB; the 2 GB repo → ~520 MB.
+
+## Decision
+
+Switch CodeDB's Bleve content fields to **index-only** (`Store=false`,
+`IncludeTermVectors=false`), stop generating ANSI highlighting, and **re-derive
+the plain snippet from the source** at search time. As a bonus, populate real
+**line numbers** for code hits (today `assembleCodeHit` leaves `Line=0`; the
+snippet is the only locator).
+
+### Mapping change (`internal/codedb/store/store.go`)
+
+Replace the bare `bleve.NewIndexMapping()` for the code/comment (and possibly
+diff — see open questions) indexes with a mapping whose `content` field is
+index-only:
+
+```go
+m := bleve.NewIndexMapping()
+ft := bleve.NewTextFieldMapping()
+ft.Store = false
+ft.IncludeTermVectors = false
+dm := bleve.NewDocumentMapping()
+dm.AddFieldMappingsAt("content", ft)
+m.DefaultMapping = dm
+```
+
+### Search read-path change
+
+```mermaid
+flowchart LR
+  Q[query] --> B[Bleve match: doc id + score]
+  B --> E[SQL enrich: path, lang, repo  (already batched)]
+  E --> S{snippet source}
+  S -->|code| G[read git blob, locate match → line + ±ctx]
+  S -->|comment| C[comments.text from SQLite]
+  S -->|diff| D[regenerate from old/new blob OR keep stored]
+  G --> R[Result: file, line, plain snippet]
+  C --> R
+  D --> R
+```
+
+- **code**: Bleve no longer returns content. Read the blob (existing
+  `repoPool`/git path), locate the match (literal scan or regex from the parsed
+  query), return the matching line + small context, set `Line`.
+- **comment**: snippet comes from `comments.text` (already the fallback in
+  `assembleCommentHit`).
+- **diff**: diff text currently lives **only** in Bleve (the `diffs` SQLite table
+  is metadata-only). Either regenerate from `old_blob_id`/`new_blob_id` or leave
+  the diff index stored for now (open question).
+
+### Reindex / versioning
+
+A mapping change only affects newly written docs; existing indexes keep their
+stored segments until rebuilt. Add a **bleve mapping version** marker; on open,
+if the stored version is older, trigger a rebuild via the existing self-heal /
+reindex path. Realizing the 74% on existing caches is a one-time rebuild cost.
+
+## Consequences
+
+**Positive**
+- ~74% smaller code/comment Bleve indexes → large on-disk + RSS reduction
+  (≈2 GB → ≈0.5 GB on the biggest repo).
+- No more highlight compute per search; no ANSI bytes shipped to agents.
+- Code hits gain real `file:line` (more actionable than a fragment).
+
+**Negative / risk**
+- **+1 blob read + match-scan per result** at search time (≤ limit results, in
+  process, with warm git packfiles — negligible, but non-zero).
+- **Diff** needs a regeneration path or stays stored (partial win).
+- **One-time reindex** to shrink existing stores.
+- Highlighting is gone for any future human TTY consumer (acceptable: CodeDB is
+  agent-facing; a human path could re-highlight the re-derived snippet cheaply).
+- **Data-access ergonomics change** (search result `Content`/`Line` semantics) —
+  the reason this is an ADR for Ryan.
+
+## Alternatives considered
+
+1. **Keep term vectors, drop stored content.** Bleve can highlight from term
+   vectors without the full stored field. Saves less (term vectors are bulky),
+   keeps highlight compute. Rejected: smaller win, keeps dead ANSI path.
+2. **Store content only for diff, index-only for code/comment.** Pragmatic middle
+   ground that avoids diff regeneration. Viable as phase 1.
+3. **Do nothing; attack peak RAM only** (chunked streaming + `FreeOSMemory`).
+   Independent, complementary — does not reduce on-disk/steady Bleve size.
+
+## Related work (not part of this ADR)
+
+Profile-driven memory targets tracked separately: (1) chunked streaming
+prefetch/extract/insert to bound parse-phase peak (~1.5 GB → chunk size);
+(2) `debug.FreeOSMemory()`/`GOMEMLIMIT` to return the heap high-water to the OS;
+(3) prune low-value SQLite indexes (`idx_comments_kind`, redundant `symbol_refs`
+index). These need no data-access review.
+
+## Open questions for review
+
+1. **Diff**: regenerate from blobs, or keep the diff index stored (phase the
+   change)?
+2. **Snippet at all?** Is `file:line` + symbol enough for agents, or is the
+   ≤120-char snippet worth the per-result blob read?
+3. **Reindex trigger**: piggyback on the existing mapping/self-heal version, or an
+   explicit `ox code index --rebuild`?
+4. Sign-off on the search-result schema change (`Content` now re-derived plain
+   text; `Line` populated for code).

--- a/internal/codedb/index/bleve_store_experiment_test.go
+++ b/internal/codedb/index/bleve_store_experiment_test.go
@@ -1,0 +1,75 @@
+//go:build memprofile
+
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/mapping"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBleveStoredContentCost measures how much of the code Bleve index is the
+// stored field content (kept only to produce highlight fragments) vs the
+// inverted index needed for matching. Quantifies the win of switching the
+// content field to index-only (Store=false, no term vectors).
+//
+//	go test -tags=memprofile -run TestBleveStoredContentCost -v ./internal/codedb/index/
+func TestBleveStoredContentCost(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	root := findRepoRoot(cwd)
+	if root == "" {
+		t.Skip("no repo found")
+	}
+
+	var docs []string
+	_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(p, ".go") && info.Size() < (1<<20) {
+			if b, e := os.ReadFile(p); e == nil {
+				docs = append(docs, string(b))
+			}
+		}
+		return nil
+	})
+	t.Logf("corpus: %d .go files", len(docs))
+
+	idxDir := func(t *testing.T, m mapping.IndexMapping) uint64 {
+		dir := filepath.Join(t.TempDir(), "idx")
+		idx, err := bleve.New(dir, m)
+		require.NoError(t, err)
+		batch := idx.NewBatch()
+		for i, d := range docs {
+			require.NoError(t, batch.Index(strconv.Itoa(i), BleveCodeDoc{Content: d}))
+			if (i+1)%500 == 0 {
+				require.NoError(t, idx.Batch(batch))
+				batch = idx.NewBatch()
+			}
+		}
+		require.NoError(t, idx.Batch(batch))
+		require.NoError(t, idx.Close())
+		return dirSize(dir)
+	}
+
+	stored := idxDir(t, bleve.NewIndexMapping())
+
+	m := bleve.NewIndexMapping()
+	ft := bleve.NewTextFieldMapping()
+	ft.Store = false
+	ft.IncludeTermVectors = false
+	dm := bleve.NewDocumentMapping()
+	dm.AddFieldMappingsAt("content", ft)
+	m.DefaultMapping = dm
+	indexOnly := idxDir(t, m)
+
+	t.Logf("stored(default)=%.1f MB  index-only(Store=false,noTV)=%.1f MB  saving=%.0f%%",
+		mb(stored), mb(indexOnly), 100*(1-float64(indexOnly)/float64(stored)))
+}

--- a/internal/codedb/index/memory_profile_test.go
+++ b/internal/codedb/index/memory_profile_test.go
@@ -1,0 +1,177 @@
+//go:build memprofile
+
+// Memory accounting harness for the codedb indexing pipeline.
+//
+// It measures the *peak* live heap of each phase (a phase-boundary snapshot
+// misses in-phase spikes like the all-at-once blob prefetch), the bytes
+// allocated per phase, GC pressure, and the resulting on-disk index sizes.
+//
+// Run against the current repo:
+//
+//	go test -tags=memprofile -run TestMemoryProfile_Pipeline -v -timeout 30m ./internal/codedb/index/
+//
+// Against another repo, and/or dump a pprof heap profile for drill-down:
+//
+//	CODEDB_PROFILE_REPO=/path/to/repo \
+//	CODEDB_PROFILE_HEAP=/tmp/codedb.heap \
+//	go test -tags=memprofile -run TestMemoryProfile_Pipeline -v -timeout 30m ./internal/codedb/index/
+//	go tool pprof -top -sample_index=alloc_space /tmp/codedb.heap
+package index
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/codedb/store"
+)
+
+func mb(b uint64) float64 { return float64(b) / (1024 * 1024) }
+
+// peakSampler polls runtime.MemStats on an interval and records the maximum
+// live heap (HeapInuse) observed, so an in-phase transient spike is captured
+// even when the heap is reclaimed by the time the phase returns.
+type peakSampler struct {
+	stop     chan struct{}
+	wg       sync.WaitGroup
+	peakHeap atomic.Uint64
+}
+
+func startPeakSampler(every time.Duration) *peakSampler {
+	ps := &peakSampler{stop: make(chan struct{})}
+	ps.wg.Add(1)
+	go func() {
+		defer ps.wg.Done()
+		var m runtime.MemStats
+		t := time.NewTicker(every)
+		defer t.Stop()
+		for {
+			select {
+			case <-ps.stop:
+				return
+			case <-t.C:
+				runtime.ReadMemStats(&m)
+				for {
+					cur := ps.peakHeap.Load()
+					if m.HeapInuse <= cur || ps.peakHeap.CompareAndSwap(cur, m.HeapInuse) {
+						break
+					}
+				}
+			}
+		}
+	}()
+	return ps
+}
+
+func (ps *peakSampler) stopAndPeak() uint64 {
+	close(ps.stop)
+	ps.wg.Wait()
+	return ps.peakHeap.Load()
+}
+
+// phase runs fn while sampling peak heap and reports per-phase memory.
+func phase(t *testing.T, name string, fn func() error) {
+	t.Helper()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	ps := startPeakSampler(10 * time.Millisecond)
+	start := time.Now()
+	err := fn()
+	dur := time.Since(start)
+	peak := ps.stopAndPeak()
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	require.NoError(t, err)
+
+	t.Logf("%-16s dur=%-9s peakHeapInuse=%7.1f MB  endHeapInuse=%7.1f MB  alloc=%8.1f MB  numGC=%d",
+		name, dur.Round(time.Millisecond),
+		mb(peak), mb(after.HeapInuse), mb(after.TotalAlloc-before.TotalAlloc),
+		after.NumGC-before.NumGC)
+}
+
+// findRepoRoot walks up from start until it finds a directory containing .git.
+func findRepoRoot(start string) string {
+	dir := start
+	for {
+		if fi, err := os.Stat(filepath.Join(dir, ".git")); err == nil && (fi.IsDir() || fi.Mode().IsRegular()) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func dirSize(root string) uint64 {
+	var total uint64
+	_ = filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			total += uint64(info.Size())
+		}
+		return nil
+	})
+	return total
+}
+
+// TestMemoryProfile_Pipeline indexes a real repo end-to-end and reports the
+// peak heap of each phase plus the resulting on-disk footprint. It is opt-in
+// (build tag memprofile) and never runs in the normal suite.
+func TestMemoryProfile_Pipeline(t *testing.T) {
+	repoPath := os.Getenv("CODEDB_PROFILE_REPO")
+	if repoPath == "" {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		repoPath = findRepoRoot(cwd)
+	}
+	if repoPath == "" {
+		t.Skip("no repo found; set CODEDB_PROFILE_REPO")
+	}
+	t.Logf("profiling repo: %s", repoPath)
+
+	codedbDir := t.TempDir()
+	s, err := store.Open(codedbDir)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Close()) }()
+
+	ctx := context.Background()
+
+	phase(t, "IndexLocalRepo", func() error { return IndexLocalRepo(ctx, s, repoPath, IndexOptions{}) })
+	phase(t, "ParseSymbols", func() error { _, e := ParseSymbols(ctx, s, nil); return e })
+	phase(t, "ParseComments", func() error { _, e := ParseComments(ctx, s, nil); return e })
+	dirtyPath := DirtyIndexPath(s.Root, repoPath)
+	phase(t, "BuildDirtyIndex", func() error { _, e := BuildDirtyIndex(ctx, repoPath, dirtyPath, IndexOptions{}); return e })
+
+	// Steady-state: live heap after a forced GC, and on-disk index sizes.
+	runtime.GC()
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	t.Logf("STEADY-STATE     liveHeapInuse=%7.1f MB  heapSys=%7.1f MB  totalSys=%7.1f MB",
+		mb(ms.HeapInuse), mb(ms.HeapSys), mb(ms.Sys))
+
+	bleveBytes := dirSize(filepath.Join(codedbDir, "bleve"))
+	sqlBytes := dirSize(filepath.Join(codedbDir, "metadata.db"))
+	t.Logf("ON-DISK          bleve=%7.1f MB  sqlite=%7.1f MB  total=%7.1f MB",
+		mb(bleveBytes), mb(sqlBytes), mb(dirSize(codedbDir)))
+
+	if out := os.Getenv("CODEDB_PROFILE_HEAP"); out != "" {
+		f, err := os.Create(out)
+		require.NoError(t, err)
+		defer f.Close()
+		runtime.GC()
+		require.NoError(t, pprof.WriteHeapProfile(f))
+		t.Logf("heap profile written: %s (go tool pprof -top -sample_index=alloc_space %s)", out, out)
+	}
+}


### PR DESCRIPTION
## Summary

Proposal ADR (not an implementation) for the single biggest lever on CodeDB's memory/disk footprint. **Needs Ryan's sign-off** — it changes data-access ergonomics (what `ox code search` returns).

CodeDB's Bleve indexes store the **full source / diff / comment text** (default `bleve.NewIndexMapping()`, `Store=true`). That stored copy exists only to produce ANSI highlight fragments — which the agent path immediately strips (`cmd/ox/code.go:204`). CodeDB is agent-facing; highlighting is dead weight.

**Proposal:** flip content fields to index-only (`Store=false`, no term vectors), drop ANSI highlighting, re-derive the plain snippet from source at search time, and populate real `file:line` for code hits.

## Why it matters (measured, not estimated)

Heap profile of a fresh ox-repo index (harness `internal/codedb/index/memory_profile_test.go`, tag `memprofile`): parse phases peak **1.1–1.5 GB**; bleve on disk is **438 MB** (ox) up to **2.0 GB** (largest ledger repo).

`TestBleveStoredContentCost` (1707 ox `.go` files):

```
stored (default)                          = 39.9 MB
index-only (Store=false, no term vectors) = 10.3 MB
saving = 74%
```

Extrapolated: ox bleve 438 MB → ~115 MB; 2 GB repo → ~520 MB.

## What's in this PR

- `docs/adr/ADR-018-codedb-index-only-bleve.md` — the proposal.
- `internal/codedb/index/memory_profile_test.go` — phase-by-phase peak-heap harness (build tag `memprofile`, opt-in, no normal-suite impact).
- `internal/codedb/index/bleve_store_experiment_test.go` — the 74% measurement (reproducible).

No production code changes here.

## Open questions for review (in the ADR)

1. **Diff** text lives *only* in Bleve today — regenerate from blobs, or keep diff stored (phase the change)?
2. **Snippet at all?** Is `file:line`+symbol enough for agents, or worth a per-result blob read?
3. **Reindex trigger** — mapping/self-heal version vs explicit `ox code index --rebuild`?
4. Sign-off on the search-result schema change (`Content` re-derived plain; `Line` populated for code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Documented architectural strategy for CodeDB search indexing optimization, reducing storage overhead while improving search result accuracy and line number precision.

* **Tests**
  * Added benchmarking test to measure search index storage impact.
  * Added performance profiling test for indexing pipeline efficiency analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->