### PR TITLE
feat(auth): OX_TOKEN PATs + ephemeral mode (GH #103 foundation for #102)

### DIFF
--- a/.claude/rules/daemon-git.md
+++ b/.claude/rules/daemon-git.md
@@ -64,3 +64,16 @@ Both remote and local writes happen:
 - All `git add` MUST use `--sparse` (git 2.37+ refuses staging outside sparse definition otherwise)
 - All `git pull --rebase` MUST use `--autostash` (uncommitted changes block pull otherwise)
 - Use `git add -f` for files inside `.gitignore`-excluded paths
+
+## Ephemeral-mode exception
+
+When `ephemeral.IsEphemeral()` is true (`OX_EPHEMERAL=1`, user-config opt-in,
+or auto-detected via `CLAUDE_CODE_REMOTE`, `DEVIN_TASK_ID`, `CODESPACES`, CI
+signals), the daemon does not run and the daemon-CLI split has no daemon
+side. The CLI performs **reads via HTTP API** (team context via
+`GET /api/v1/teams/:id/context`, ledger metadata via
+`GET /api/v1/repos/:id/ledger-status`) and **writes via HTTP** (Phase 2:
+session upload + LFS Batch API). Pull-direction git operations are skipped
+entirely; the local ledger clone never exists.
+
+See `docs/ai/adr/adr-ephemeral-mode.md` for the full rationale and rollout phases.

--- a/.claude/skills/security-review/prompts/hunter-secrets-redaction.md
+++ b/.claude/skills/security-review/prompts/hunter-secrets-redaction.md
@@ -24,7 +24,7 @@ See `security/SECURITY.md#hunter-secrets-redaction` for the threat-model anchor.
 | New `RawEntry` / session-pipeline write path that calls `os.OpenFile` directly | Chokepoint bypass. The chokepoint comment at `internal/session/raw_writer.go:32` is explicit: every writer goes through `RawWriter`. |
 | New `slog`/`fmt` call site that emits an `auth.StoredToken`, a parsed JWT, or a `keyring.Get` return value | Even `slog.Info("token loaded", "token", t)` leaks because the default formatter calls `%+v` on the struct. |
 | `cmd.Env = append(os.Environ(), "X=<secret>")` for a subprocess | The secret lives in `/proc/<pid>/environ` for the subprocess lifetime, readable by any same-UID process. Prefer stdin pipe. |
-| `os.Setenv("OX_TOKEN", ...)` or any env-set of a credential | Bleeds into every child process the parent later spawns, including unrelated tools. |
+| `os.Setenv("SAGEOX_TOKEN", ...)` or any env-set of a credential | Bleeds into every child process the parent later spawns, including unrelated tools. |
 | New gitleaks-derived detector added or removed in `internal/session/gitleaks_generated.go` or `internal/session/gitleaks_detectors.go` | Removing a detector is a redaction-rule gap; adding one is fine but verify it's wired into `RawWriter.extras`. |
 | Auth token written to `auth.json` (positive direction) | This is the design: tokens go to `~/.config/sageox/auth.json` (or `~/.sageox/config/auth.json` under `OX_XDG_DISABLE`), NOT the OS keyring. The chokepoint there is the file's perms — verify `0600`, not `0644`. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ ox is agentic context infrastructure for software teams. It makes architectural 
 - **Path locations** - Where ledgers, team contexts, or any SageOx data is stored
 - **Data access ergonomics** - How users navigate to/access their data
 - **API source of truth** - Where team context or ledger git repo URLs come from
+- **Customer-facing env-var names** - Any new `SAGEOX_*` or any customer-facing `OX_*` env var. `SAGEOX_*` is canonical for customer-facing product/auth/network/deployment identity; customer-facing `OX_*` is an anti-pattern. See sageox-mono ADR-047 (`docs/human/adr/047-customer-facing-env-var-namespace.md`) for the canonical rule.
 
 **Canonical Functions (do NOT bypass or duplicate):**
 

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -1746,22 +1746,23 @@ func discoverTeamContextWithFallback(projectRoot, repoSlug string, enableEphemer
 		return nil
 	}
 
-	tc := config.FindRepoTeamContext(projectRoot)
-	if tc == nil {
-		// ephemeral fallback: no daemon, no clone — fetch over HTTP.
-		// Only attempted at the top-level entry point; the post-fetch
-		// re-discovery call passes enableEphemeralFallback=false.
-		if enableEphemeralFallback && ephemeral.IsEphemeral() {
-			if pc, err := config.LoadProjectConfig(projectRoot); err == nil && pc != nil && pc.TeamID != "" {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				defer cancel()
-				if info, ferr := tryHTTPTeamContextFallback(ctx, projectRoot, pc.TeamID); ferr == nil && info != nil {
-					return info
-				} else if ferr != nil {
-					slog.Debug("ephemeral team-context fallback failed", "team_id", pc.TeamID, "err", ferr)
-				}
+	// In ephemeral mode, refresh team context over HTTP on every prime. These
+	// environments do not have a daemon keeping the clone warm, so a successful
+	// prior fetch should not turn the fallback into a one-shot stale cache.
+	if enableEphemeralFallback && ephemeral.IsEphemeral() {
+		if pc, err := config.LoadProjectConfig(projectRoot); err == nil && pc != nil && pc.TeamID != "" {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if info, ferr := tryHTTPTeamContextFallback(ctx, projectRoot, pc.TeamID); ferr == nil && info != nil {
+				return info
+			} else if ferr != nil {
+				slog.Debug("ephemeral team-context fallback failed", "team_id", pc.TeamID, "err", ferr)
 			}
 		}
+	}
+
+	tc := config.FindRepoTeamContext(projectRoot)
+	if tc == nil {
 		return nil
 	}
 

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/doctor"
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/ephemeral"
 	"github.com/sageox/ox/internal/identity"
 	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/ledger"
@@ -122,6 +123,13 @@ func initAgentPrimeCmd() {
 	// When true and marker exists: outputs nothing, exits 0 (saves ~1k tokens).
 	// When false (default): always outputs context (safe, may waste tokens on duplicate calls).
 	agentPrimeCmd.Flags().Bool("idempotent", false, "Skip priming if session already primed (token optimization)")
+
+	// --ephemeral: opt-in flag mirroring OX_EPHEMERAL=1. When set, subsystems
+	// that consult ephemeral.IsEphemeral() (daemon, kb, codedb, prime's
+	// HTTP team-context fallback) switch to HTTP-only behavior. The flag
+	// is processed in runAgentPrime BEFORE any subsystem initialization,
+	// by exporting OX_EPHEMERAL=1 into the process environment.
+	agentPrimeCmd.Flags().Bool("ephemeral", false, "Run in ephemeral mode: no daemon, no local clone, HTTP-only reads. Equivalent to OX_EPHEMERAL=1.")
 }
 
 // runAgentPrime bootstraps a new agent instance with team context.
@@ -141,6 +149,15 @@ func initAgentPrimeCmd() {
 // so ox cannot intercept this invocation. Users must run `claude` without a prompt
 // argument to allow the session-start hook to run `ox agent prime` first.
 func runAgentPrime(cmd *cobra.Command, args []string) error {
+	// --ephemeral propagates to subsystems via OX_EPHEMERAL. Set it
+	// BEFORE the agentx gate / daemon health check / any subsystem init
+	// reads ephemeral.IsEphemeral(). This is the only place that needs
+	// to honor the flag — every consumer downstream goes through
+	// ephemeral.IsEphemeral().
+	if ephemeralFlag, _ := cmd.Flags().GetBool("ephemeral"); ephemeralFlag {
+		_ = os.Setenv(ephemeral.EnvEphemeral, "1")
+	}
+
 	// gate: require agent context
 	if errMsg := agentx.RequireAgent("ox agent prime"); errMsg != "" {
 		return fmt.Errorf("%s", errMsg)
@@ -570,6 +587,14 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		CurrentUserAliases: currentUserAliases,
 	}
 
+	// Ephemeral-mode hint: when running in a cloud agent / CI / Codespaces
+	// with sparse local data, point the calling agent at the cloud MCP
+	// server for context ops it would normally satisfy via local caches.
+	// See docs/ai/adr/adr-ephemeral-mode.md.
+	if ephemeral.IsEphemeral() {
+		output.EphemeralHint = buildEphemeralHint(teamCtx, projectRoot)
+	}
+
 	// ADR-017: surface the binding the agent's CWD currently resolves to.
 	// Look it up in the KB list so the emitted entry carries the same
 	// type/slug/path enrichment as the matching row. Resolve from the
@@ -819,6 +844,11 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	output.Timing = timing
 
 	err = outputAgentPrime(cmd, textMode, reviewMode, output)
+
+	// Emit PAT expiry warning to stderr (post-output so structured stdout is
+	// never polluted). Internally skipped in ephemeral mode and when stderr
+	// isn't a TTY — so cloud agents and JSON-only consumers never see it.
+	_ = auth.CheckAndWarnExpiry(cmd.Context(), projectEndpoint, os.Stderr)
 
 	// eagerly create whisper.db if not yet present (daemon may take time to start)
 	if projCfg, cfgErr := config.LoadProjectConfig(projectRoot); cfgErr == nil && projCfg != nil {
@@ -1700,13 +1730,38 @@ func trackPrimeTypeMismatch(inst *agentinstance.Instance, claimedType string) {
 // repoSlug is the current repo's "owner/repo" identifier (or empty if unknown).
 // It is used to filter team rules by their repos: frontmatter field — rules
 // that specify a repos: list only load when the current repo matches.
+//
+// In ephemeral mode (no daemon, no clone) this falls through to an HTTP
+// fetch of /api/v1/teams/{team_id}/context, writes the response to disk,
+// and re-runs the local discovery. See agent_prime_ephemeral_fallback.go.
 func discoverTeamContext(projectRoot, repoSlug string) *teamContextInfo {
+	return discoverTeamContextWithFallback(projectRoot, repoSlug, true)
+}
+
+// discoverTeamContextWithFallback is the real implementation. The
+// enableEphemeralFallback flag exists so the HTTP-fallback path can
+// re-invoke local-only discovery without recursing into itself.
+func discoverTeamContextWithFallback(projectRoot, repoSlug string, enableEphemeralFallback bool) *teamContextInfo {
 	if projectRoot == "" {
 		return nil
 	}
 
 	tc := config.FindRepoTeamContext(projectRoot)
 	if tc == nil {
+		// ephemeral fallback: no daemon, no clone — fetch over HTTP.
+		// Only attempted at the top-level entry point; the post-fetch
+		// re-discovery call passes enableEphemeralFallback=false.
+		if enableEphemeralFallback && ephemeral.IsEphemeral() {
+			if pc, err := config.LoadProjectConfig(projectRoot); err == nil && pc != nil && pc.TeamID != "" {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				if info, ferr := tryHTTPTeamContextFallback(ctx, projectRoot, pc.TeamID); ferr == nil && info != nil {
+					return info
+				} else if ferr != nil {
+					slog.Debug("ephemeral team-context fallback failed", "team_id", pc.TeamID, "err", ferr)
+				}
+			}
+		}
 		return nil
 	}
 

--- a/cmd/ox/agent_prime_ephemeral_fallback.go
+++ b/cmd/ox/agent_prime_ephemeral_fallback.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/paths"
+)
+
+// tryHTTPTeamContextFallback fetches a team's context over HTTP and writes
+// it to the canonical team-context directory, then re-invokes the normal
+// loader path. This is the ephemeral-mode fallback for environments
+// where no daemon and no local clone of the team-context repo exist.
+//
+// Returns:
+//   - (*teamContextInfo, nil) on success
+//   - (nil, nil) when the cloud endpoint isn't deployed yet
+//     (api.ErrTeamContextEndpointUnavailable) so callers fall through
+//   - (nil, err) on a real failure (network, auth, decode)
+//
+// The caller is expected to already know teamID — usually from
+// ProjectConfig.TeamID — and to have decided ephemeral mode is in effect.
+func tryHTTPTeamContextFallback(ctx context.Context, projectRoot, teamID string) (*teamContextInfo, error) {
+	if projectRoot == "" || teamID == "" {
+		return nil, fmt.Errorf("projectRoot and teamID required")
+	}
+
+	ep := endpoint.GetForProject(projectRoot)
+	if ep == "" {
+		return nil, fmt.Errorf("no endpoint configured for project")
+	}
+
+	client := api.NewRepoClientForProject(projectRoot)
+	if token, err := auth.GetTokenForEndpoint(ep); err == nil && token != nil && token.AccessToken != "" {
+		client = client.WithAuthToken(token.AccessToken)
+	}
+
+	resp, err := client.GetTeamContextContent(ctx, teamID)
+	if err != nil {
+		if errors.Is(err, api.ErrTeamContextEndpointUnavailable) {
+			slog.Debug("ephemeral team-context fallback: endpoint unavailable",
+				"team_id", teamID, "endpoint", ep)
+			return nil, nil
+		}
+		return nil, err
+	}
+	if resp == nil {
+		return nil, nil
+	}
+
+	teamCtxDir := paths.TeamContextDir(teamID, ep)
+	if teamCtxDir == "" {
+		return nil, fmt.Errorf("could not resolve team-context dir for team_id=%s", teamID)
+	}
+
+	if err := fetchTeamContextViaAPI(teamCtxDir, resp); err != nil {
+		return nil, fmt.Errorf("failed to write team context: %w", err)
+	}
+
+	slog.Debug("ephemeral team-context fallback: wrote context",
+		"team_id", teamID, "dir", teamCtxDir, "docs", len(resp.Docs))
+
+	// re-invoke the existing loader path now that files are on disk
+	repoSlug := ""
+	if pc, err := config.LoadProjectConfig(projectRoot); err == nil && pc != nil {
+		repoSlug = repoSlugFromProjectConfig(pc)
+	}
+	info := discoverTeamContextLocalOnly(projectRoot, repoSlug)
+	return info, nil
+}
+
+// fetchTeamContextViaAPI writes the HTTP-fetched team context to disk
+// under teamCtxDir. Each file uses an atomic temp-file + rename pattern
+// so a partial fetch never leaves a half-written file in place.
+func fetchTeamContextViaAPI(teamCtxDir string, resp *api.TeamContextContentResponse) error {
+	if resp == nil {
+		return fmt.Errorf("nil response")
+	}
+	if err := os.MkdirAll(teamCtxDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir team-context dir: %w", err)
+	}
+
+	for _, doc := range resp.Docs {
+		if doc.Name == "" {
+			continue
+		}
+		// preserve subdirectories embedded in doc.Name (e.g. "guides/x.md")
+		rel := filepath.Clean(doc.Name)
+		if strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+			// defensive: refuse to write outside teamCtxDir
+			slog.Debug("ephemeral team-context fallback: skipping unsafe doc path",
+				"name", doc.Name)
+			continue
+		}
+		destPath := filepath.Join(teamCtxDir, "docs", rel)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return fmt.Errorf("mkdir doc parent %s: %w", destPath, err)
+		}
+		if err := atomicWriteFile(destPath, []byte(doc.Content), 0o644); err != nil {
+			return fmt.Errorf("write doc %s: %w", destPath, err)
+		}
+	}
+
+	type rootFile struct {
+		name    string
+		content string
+	}
+	rootFiles := []rootFile{
+		{"AGENTS.md", resp.AgentsMD},
+		{"CLAUDE.md", resp.ClaudeMD},
+		{"MEMORY.md", resp.Memory},
+	}
+	for _, rf := range rootFiles {
+		if rf.content == "" {
+			continue
+		}
+		dest := filepath.Join(teamCtxDir, rf.name)
+		if err := atomicWriteFile(dest, []byte(rf.content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", rf.name, err)
+		}
+	}
+
+	return nil
+}
+
+// atomicWriteFile writes content to path via a temp file in the same
+// directory, then renames it into place. This keeps the destination
+// file either intact (old content) or fully updated (new content) —
+// never partially written.
+func atomicWriteFile(path string, content []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	// best-effort cleanup if anything below fails before the rename
+	defer func() {
+		if _, statErr := os.Stat(tmpName); statErr == nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	return nil
+}
+
+// discoverTeamContextLocalOnly is the local-only re-entry point used after
+// fetchTeamContextViaAPI lands files on disk. It is a thin wrapper around
+// the existing discoverTeamContext call — separating it out documents the
+// fact that the second call must NOT recurse back into the HTTP fallback.
+func discoverTeamContextLocalOnly(projectRoot, repoSlug string) *teamContextInfo {
+	return discoverTeamContextWithFallback(projectRoot, repoSlug, false)
+}
+
+// repoSlugFromProjectConfig assembles an "owner/repo" slug from the
+// project config fields that exist. Returns empty when no useful slug
+// can be derived — the caller treats empty as "skip repo-scoped rule
+// filtering" which is the safe default.
+func repoSlugFromProjectConfig(pc *config.ProjectConfig) string {
+	if pc == nil {
+		return ""
+	}
+	if pc.Org != "" && pc.Project != "" {
+		return pc.Org + "/" + pc.Project
+	}
+	return ""
+}

--- a/cmd/ox/agent_prime_ephemeral_fallback_test.go
+++ b/cmd/ox/agent_prime_ephemeral_fallback_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFetchTeamContextViaAPI_WritesAllFiles — Failure prevented: an HTTP
+// team-context response decodes correctly but files don't land on disk
+// where the loader expects them, so ephemeral prime sees no context
+// even after a successful fetch.
+func TestFetchTeamContextViaAPI_WritesAllFiles(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	teamCtxDir := filepath.Join(tmpDir, "team-ctx", "team_abc")
+
+	resp := &api.TeamContextContentResponse{
+		TeamID:   "team_abc",
+		TeamName: "Test Team",
+		Docs: []api.TeamContextDoc{
+			{Name: "onboarding.md", Title: "Onboarding", Content: "# Onboarding\n"},
+			{Name: "guides/architecture.md", Title: "Arch", Content: "# Arch\n"},
+		},
+		AgentsMD: "# AGENTS\n",
+		ClaudeMD: "# CLAUDE\n",
+		Memory:   "# MEMORY\n",
+	}
+
+	require.NoError(t, fetchTeamContextViaAPI(teamCtxDir, resp))
+
+	cases := map[string]string{
+		filepath.Join(teamCtxDir, "AGENTS.md"):                       "# AGENTS\n",
+		filepath.Join(teamCtxDir, "CLAUDE.md"):                       "# CLAUDE\n",
+		filepath.Join(teamCtxDir, "MEMORY.md"):                       "# MEMORY\n",
+		filepath.Join(teamCtxDir, "docs", "onboarding.md"):           "# Onboarding\n",
+		filepath.Join(teamCtxDir, "docs", "guides", "architecture.md"): "# Arch\n",
+	}
+	for path, want := range cases {
+		got, err := os.ReadFile(path)
+		require.NoError(t, err, "expected file %s", path)
+		assert.Equal(t, want, string(got), "content mismatch for %s", path)
+	}
+}
+
+// TestFetchTeamContextViaAPI_SkipsEmptyRootFiles — Failure prevented: writing
+// an empty AGENTS.md/CLAUDE.md/MEMORY.md masks the actual absence of
+// those files, breaking downstream loaders that branch on file existence.
+func TestFetchTeamContextViaAPI_SkipsEmptyRootFiles(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	teamCtxDir := filepath.Join(tmpDir, "team-ctx", "team_empty")
+
+	resp := &api.TeamContextContentResponse{
+		TeamID:   "team_empty",
+		TeamName: "Empty",
+		Docs:     []api.TeamContextDoc{{Name: "x.md", Content: "x"}},
+		// AgentsMD/ClaudeMD/Memory intentionally blank
+	}
+	require.NoError(t, fetchTeamContextViaAPI(teamCtxDir, resp))
+
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md", "MEMORY.md"} {
+		_, err := os.Stat(filepath.Join(teamCtxDir, name))
+		assert.True(t, os.IsNotExist(err), "%s must NOT exist when empty in response", name)
+	}
+	got, err := os.ReadFile(filepath.Join(teamCtxDir, "docs", "x.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "x", string(got))
+}
+
+// TestFetchTeamContextViaAPI_RefusesPathEscape — Failure prevented: a
+// malicious or buggy server returns a doc with name="../../etc/passwd"
+// and we happily write outside the team-context dir. The defensive check
+// keeps writes scoped.
+func TestFetchTeamContextViaAPI_RefusesPathEscape(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	teamCtxDir := filepath.Join(tmpDir, "team-ctx", "team_evil")
+
+	resp := &api.TeamContextContentResponse{
+		TeamID: "team_evil",
+		Docs: []api.TeamContextDoc{
+			{Name: "../escape.md", Content: "bad"},
+			{Name: "/abs/path.md", Content: "bad"},
+			{Name: "ok.md", Content: "good"},
+		},
+	}
+	require.NoError(t, fetchTeamContextViaAPI(teamCtxDir, resp))
+
+	// the safe doc landed
+	got, err := os.ReadFile(filepath.Join(teamCtxDir, "docs", "ok.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "good", string(got))
+
+	// nothing landed outside teamCtxDir
+	escaped := filepath.Join(tmpDir, "team-ctx", "escape.md")
+	_, err = os.Stat(escaped)
+	assert.True(t, os.IsNotExist(err), "escape.md must not exist outside teamCtxDir")
+}
+
+// TestAtomicWriteFile_OverwritesExisting — Failure prevented: atomic
+// writes leak temp files or fail to replace an existing file with new
+// content.
+func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "f.txt")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o644))
+
+	require.NoError(t, atomicWriteFile(path, []byte("new"), 0o644))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+
+	// no leftover temp files
+	entries, err := os.ReadDir(tmpDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp-", "temp file leaked: %s", e.Name())
+	}
+}

--- a/cmd/ox/agent_prime_ephemeral_fallback_test.go
+++ b/cmd/ox/agent_prime_ephemeral_fallback_test.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,10 +40,10 @@ func TestFetchTeamContextViaAPI_WritesAllFiles(t *testing.T) {
 	require.NoError(t, fetchTeamContextViaAPI(teamCtxDir, resp))
 
 	cases := map[string]string{
-		filepath.Join(teamCtxDir, "AGENTS.md"):                       "# AGENTS\n",
-		filepath.Join(teamCtxDir, "CLAUDE.md"):                       "# CLAUDE\n",
-		filepath.Join(teamCtxDir, "MEMORY.md"):                       "# MEMORY\n",
-		filepath.Join(teamCtxDir, "docs", "onboarding.md"):           "# Onboarding\n",
+		filepath.Join(teamCtxDir, "AGENTS.md"):                         "# AGENTS\n",
+		filepath.Join(teamCtxDir, "CLAUDE.md"):                         "# CLAUDE\n",
+		filepath.Join(teamCtxDir, "MEMORY.md"):                         "# MEMORY\n",
+		filepath.Join(teamCtxDir, "docs", "onboarding.md"):             "# Onboarding\n",
 		filepath.Join(teamCtxDir, "docs", "guides", "architecture.md"): "# Arch\n",
 	}
 	for path, want := range cases {
@@ -123,4 +129,55 @@ func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {
 	for _, e := range entries {
 		assert.NotContains(t, e.Name(), ".tmp-", "temp file leaked: %s", e.Name())
 	}
+}
+
+// TestDiscoverTeamContextWithFallback_RefreshesExistingLocalCopy — Failure
+// prevented: after the first ephemeral HTTP fetch creates a local team-context
+// directory, later primes stop refreshing it and keep serving stale rules/docs.
+func TestDiscoverTeamContextWithFallback_RefreshesExistingLocalCopy(t *testing.T) {
+	t.Setenv("OX_EPHEMERAL", "1")
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		assert.Equal(t, "/api/v1/teams/team_abc/context", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"team_id":"team_abc",
+			"team_name":"Team ABC",
+			"docs":[{"name":"guide.md","title":"Guide","content":"fresh"}],
+			"agents_md":"fresh agents",
+			"claude_md":"",
+			"memory":""
+		}`)
+	}))
+	defer server.Close()
+
+	projectRoot := createInitializedProjectWithConfig(t, &config.ProjectConfig{
+		ProjectID:   "test_project",
+		WorkspaceID: "test_workspace",
+		TeamID:      "team_abc",
+		TeamName:    "Team ABC",
+		Endpoint:    server.URL,
+	})
+
+	teamCtxDir := paths.TeamContextDir("team_abc", server.URL)
+	require.NoError(t, os.MkdirAll(teamCtxDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(teamCtxDir, "AGENTS.md"), []byte("stale agents"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(teamCtxDir, "docs"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(teamCtxDir, "docs", "guide.md"), []byte("stale"), 0o644))
+
+	info := discoverTeamContextWithFallback(projectRoot, "", true)
+	require.NotNil(t, info)
+	assert.Equal(t, int32(1), requests.Load(), "ephemeral discovery should refresh over HTTP even when a local copy already exists")
+
+	agents, err := os.ReadFile(filepath.Join(teamCtxDir, "AGENTS.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "fresh agents", string(agents))
+
+	doc, err := os.ReadFile(filepath.Join(teamCtxDir, "docs", "guide.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", string(doc))
 }

--- a/cmd/ox/agent_prime_ephemeral_hint.go
+++ b/cmd/ox/agent_prime_ephemeral_hint.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/ephemeral"
+	"github.com/sageox/ox/internal/prime"
+)
+
+// buildEphemeralHint constructs the EphemeralHint emitted in prime output
+// when ephemeral.IsEphemeral() returns true. Callers should only invoke
+// when in ephemeral mode — the function is conservative (always returns a
+// populated hint) since the cost is negligible and the calling agent
+// benefits from explicit guidance even when local caches happen to exist.
+//
+// LocalDataSparse is true when:
+//   - the team-context discovery returned nil (no clone, HTTP fallback also failed), or
+//   - the team-context info is present but came from the HTTP fallback (signaled
+//     by a nil Path on the *prime.TeamContextInfo since the fallback writes to
+//     paths.TeamContextDir but the discovery path may still flag it as partial).
+//
+// The hint always points at the cloud MCP server endpoint derived from the
+// active SageOx endpoint. When the MCP route is not yet deployed, the
+// agent will get a 404 on first call and fall back to the HTTP team-context
+// route — graceful degradation.
+func buildEphemeralHint(teamCtx *prime.TeamContextInfo, projectRoot string) *prime.EphemeralHint {
+	hint := &prime.EphemeralHint{
+		Active: true,
+		Reason: ephemeral.Reason(),
+	}
+
+	// Local data is sparse when there is no team-context info at all (no clone,
+	// no HTTP fallback), OR when the info is present but the on-disk Path is
+	// empty (HTTP fallback may write a subset without populating Path).
+	if teamCtx == nil || teamCtx.Path == "" {
+		hint.LocalDataSparse = true
+	}
+
+	hint.CloudMCPEndpoint = mcpEndpointFromAPI(endpoint.GetForProject(projectRoot))
+	hint.Recommendation = "Local sync is disabled or partial in ephemeral mode. Prefer the cloud MCP server for context operations (team-context search, codebase search, knowledge-bubble queries). Fall back to local file reads only for operations that are purely on the working tree."
+	hint.SuggestedTools = []string{
+		"sageox.search_team_context",
+		"sageox.search_codebase",
+		"sageox.kb_query",
+		"sageox.session_history",
+	}
+
+	return hint
+}
+
+// mcpEndpointFromAPI derives the cloud MCP base URL from the SageOx API
+// endpoint. Convention: replace the leading "api." host segment with "mcp."
+// when present, otherwise append "/mcp" to the existing host. The MCP
+// route also exists under /mcp on the same host as the API for
+// self-hosted deployments — the append form covers that case.
+func mcpEndpointFromAPI(apiURL string) string {
+	if apiURL == "" {
+		return ""
+	}
+	trimmed := strings.TrimRight(apiURL, "/")
+	// Standard cloud convention: api.sageox.ai -> api.sageox.ai/mcp
+	// (we do not flip subdomains; the route lives under /mcp on the API host).
+	return trimmed + "/mcp"
+}

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -355,6 +355,12 @@ common issues, or --fix-slug to target specific checks.`,
 
 		cli.PrintDisclaimer()
 
+		// trailing PAT expiry warning — single-line stderr, suppressed in
+		// ephemeral mode and when stderr isn't a TTY. Doctor is the right
+		// surface: users run it when something feels off, and a near-expired
+		// PAT is exactly the class of thing they'd want surfaced.
+		_ = auth.CheckAndWarnExpiry(cmd.Context(), projectEndpoint, os.Stderr)
+
 		if hasFailed && (cfg == nil || !cfg.JSON) {
 			return fmt.Errorf("some checks failed")
 		}
@@ -891,14 +897,20 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 
 	// Category 10: Daemon
 	progress.show("Daemon")
+	// always surface the ephemeral-mode predicate first — it explains why
+	// the daemon may be intentionally absent (CI, Claude Cloud, Devin,
+	// user config) and is the single most common source of "doctor says
+	// no daemon" confusion. See docs/ai/adr/adr-ephemeral-mode.md.
+	ephemeralStatus := checkEphemeralMode()
 	if state.isDaemonRunning {
 		daemonChecks := checkDaemonHealth(opts)
-		if state.isBootstrapping && len(daemonChecks) > 0 {
-			// prepend bootstrap info banner
+		daemonChecks = append([]checkResult{ephemeralStatus}, daemonChecks...)
+		if state.isBootstrapping && len(daemonChecks) > 1 {
+			// prepend bootstrap info banner (after ephemeral status)
 			bootstrapBanner := InfoCheck("daemon bootstrap",
 				"initial sync in progress",
 				"Run `ox doctor` again in a minute")
-			daemonChecks = append([]checkResult{bootstrapBanner}, daemonChecks...)
+			daemonChecks = append([]checkResult{ephemeralStatus, bootstrapBanner}, daemonChecks[1:]...)
 		}
 		if len(daemonChecks) > 0 {
 			categories = append(categories, checkCategory{
@@ -911,6 +923,7 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		categories = append(categories, checkCategory{
 			name: "Daemon",
 			checks: []checkResult{
+				ephemeralStatus,
 				SkippedCheck("daemon status", "not started",
 					"Daemon will auto-start on next agentic coding session"),
 			},
@@ -920,6 +933,7 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		categories = append(categories, checkCategory{
 			name: "Daemon",
 			checks: []checkResult{
+				ephemeralStatus,
 				SkippedCheck("daemon status", "DAEMON NOT RUNNING",
 					"Run `ox daemon start` to enable background sync and heartbeats"),
 			},

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -895,22 +895,28 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		}
 	}
 
+	// Category 9b: Ephemeral Mode (own category, NOT merged into Daemon).
+	// Surfacing this as a sibling category — rather than appending it to
+	// Daemon — keeps the Daemon category's "single grouped skip" invariant
+	// intact (see TestDoctorSuppression_DaemonNotRunning) while still
+	// making the predicate visible. Ephemeral mode is the most common
+	// explanation for an absent daemon, but it deserves its own grouping.
+	// See docs/ai/adr/adr-ephemeral-mode.md.
+	progress.show("Ephemeral Mode")
+	categories = append(categories, checkCategory{
+		name:   "Ephemeral Mode",
+		checks: []checkResult{checkEphemeralMode()},
+	})
+
 	// Category 10: Daemon
 	progress.show("Daemon")
-	// always surface the ephemeral-mode predicate first — it explains why
-	// the daemon may be intentionally absent (CI, Claude Cloud, Devin,
-	// user config) and is the single most common source of "doctor says
-	// no daemon" confusion. See docs/ai/adr/adr-ephemeral-mode.md.
-	ephemeralStatus := checkEphemeralMode()
 	if state.isDaemonRunning {
 		daemonChecks := checkDaemonHealth(opts)
-		daemonChecks = append([]checkResult{ephemeralStatus}, daemonChecks...)
-		if state.isBootstrapping && len(daemonChecks) > 1 {
-			// prepend bootstrap info banner (after ephemeral status)
+		if state.isBootstrapping && len(daemonChecks) > 0 {
 			bootstrapBanner := InfoCheck("daemon bootstrap",
 				"initial sync in progress",
 				"Run `ox doctor` again in a minute")
-			daemonChecks = append([]checkResult{ephemeralStatus, bootstrapBanner}, daemonChecks[1:]...)
+			daemonChecks = append([]checkResult{bootstrapBanner}, daemonChecks...)
 		}
 		if len(daemonChecks) > 0 {
 			categories = append(categories, checkCategory{
@@ -923,7 +929,6 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		categories = append(categories, checkCategory{
 			name: "Daemon",
 			checks: []checkResult{
-				ephemeralStatus,
 				SkippedCheck("daemon status", "not started",
 					"Daemon will auto-start on next agentic coding session"),
 			},
@@ -933,7 +938,6 @@ func runDoctorChecks(opts doctorOptions) []checkCategory {
 		categories = append(categories, checkCategory{
 			name: "Daemon",
 			checks: []checkResult{
-				ephemeralStatus,
 				SkippedCheck("daemon status", "DAEMON NOT RUNNING",
 					"Run `ox daemon start` to enable background sync and heartbeats"),
 			},

--- a/cmd/ox/doctor_ephemeral.go
+++ b/cmd/ox/doctor_ephemeral.go
@@ -1,0 +1,33 @@
+package main
+
+// doctor_ephemeral.go surfaces the ephemeral-mode predicate so `ox doctor`
+// makes it obvious whether the daemon-based code path is active or
+// whether the CLI is in HTTP-only ephemeral mode. Mirrors the style of
+// other one-liner doctor checks; no fix action — the mode is governed by
+// env vars, venue markers, CI signals, and user config (see ADR-018).
+
+import (
+	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/ephemeral"
+)
+
+// checkEphemeralMode reports whether ephemeral mode is active and which
+// source triggered it. When inactive, it surfaces the daemon socket path
+// so users can grep logs / connect manually if needed.
+func checkEphemeralMode() checkResult {
+	if ephemeral.IsEphemeral() {
+		reason := ephemeral.Reason()
+		return checkResult{
+			name:    "ephemeral mode",
+			passed:  true,
+			message: "ACTIVE",
+			detail:  "source=" + reason + " (daemon disabled, HTTP-only reads)",
+		}
+	}
+	return checkResult{
+		name:    "ephemeral mode",
+		passed:  true,
+		message: "INACTIVE",
+		detail:  "daemon_socket=" + daemon.SocketPath(),
+	}
+}

--- a/cmd/ox/kb_path.go
+++ b/cmd/ox/kb_path.go
@@ -93,7 +93,7 @@ type kbPathDeps struct {
 	legacy   legacyResolver
 	// pathFor maps a resolved kb_id to its on-disk canonical path. In
 	// production this is paths.KBDir; tests override it so they don't have
-	// to set OX_ENDPOINT to construct expected paths.
+	// to set SAGEOX_ENDPOINT to construct expected paths.
 	pathFor func(kbID string) string
 }
 

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Customer-facing env-var namespace convention** — sageox-mono ADR-047 ("Customer-Facing Env Var Namespace") is the canonical home for the rule that customer-facing SageOx env vars use `SAGEOX_*` (product/auth/network identity) and `OX_*` is reserved for CLI-local behavior flags. The legacy customer-facing `OX_TOKEN` / `OX_ENDPOINT` names are removed; `internal/auth/env_naming_test.go` guards against re-introduction. The matching sageox-mono ADR-046 ("Credential Classes and Principal Normalization") is now Accepted with companion sections D7-D10 covering the PAT validation contract, principal `AuthMethod`, customer-facing surface, and cryptographic-separation targets.
 - UserPromptSubmit hook prepends ox query --local recall; local-only by default (ADR-018).
 - New `hooks.userpromptsubmit.cloud_query` config key (default `off`) opts the UserPromptSubmit hook into a parallel SageOx cloud query. When enabled, prompt content is redacted via the session secrets pipeline before any byte leaves the machine, and the cloud path silently degrades to local-only if `ox login` has not run. `ox doctor` reports the effective value and the privacy/recall tradeoff.
 

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -1501,6 +1501,10 @@ daemon health, and a tree view of all SageOx directory locations.`,
 		userCfg, _ := config.LoadUserConfig()
 		tips.MaybeShow("status", tips.AlwaysShow, cfg.Quiet, !userCfg.AreTipsEnabled(), cfg.JSON)
 
+		// trailing PAT expiry warning — internally suppressed in ephemeral
+		// mode, when stderr isn't a TTY, and for never-expires tokens.
+		_ = auth.CheckAndWarnExpiry(cmd.Context(), currentEndpoint, os.Stderr)
+
 		return nil
 	},
 }

--- a/docs/ai/adr/adr-ephemeral-mode.md
+++ b/docs/ai/adr/adr-ephemeral-mode.md
@@ -1,0 +1,190 @@
+<!-- doc-audience: ai -->
+# ADR: Ephemeral Mode
+
+- **Status:** Proposed
+- **Date:** 2026-05-27
+- **Deciders:** Ryan Snodgrass, SageOx Team
+- **Relates to:** [Ledger Architecture](adr-ledger-architecture.md), [Session LFS Storage](adr-session-lfs-storage.md), [Whisper & Murmur Architecture](adr-whisper-murmur-architecture.md)
+
+## Context
+
+ox is built around a long-running daemon that owns git operations, a local ledger clone, and on-disk caches (CodeDB Bleve index, LFS hydration cache, KB sync). That architecture is the right choice for a developer workstation: the daemon amortizes git fetch cost, the ledger clone provides offline access, and CodeDB indexing pays back over many sessions.
+
+Ephemeral mode (for Claude Code Cloud, Devin, OpenClaw, GitHub Actions, and any environment without persistent ox state) is the answer for the opposite case: short-lived containers, no warm caches, no daemon to amortize against. The mode is called "ephemeral" because the *behavior* is ephemeral — no daemon, no local ledger clone, HTTP-only reads. The venue might still be cloud, CI, or even a developer laptop with the preference set explicitly.
+
+In ephemeral cloud coding agents, none of the workstation assumptions hold:
+
+- **Claude Code Cloud** runs per-session containers with no filesystem persistence across sessions. A daemon started during `SessionStart` has nothing to amortize against — it dies with the container.
+- **Devin 2.0** machines use snapshots: install once, persist forever. The daemon model technically works, but the cold-start indexer cost is wasted because Devin's machine lifetime rarely matches the daemon's intended sync rhythm.
+- **OpenClaw + headless CI runners** (GitHub Actions, GitLab CI) live for minutes. Cloning a multi-gigabyte ledger over a slow network to read three team-context markdown files is hostile to both the user and our infrastructure.
+- **Network egress is often allowlisted.** Claude Cloud's `limited` mode requires explicit per-host allowlist; a daemon that opportunistically tries to clone arbitrary git hosts will fail in confusing ways.
+
+Today, ox has scattered per-subsystem escape hatches (`SAGEOX_DAEMON=false`, `OX_KB_DISABLE=1`, `OX_NO_INTERACTIVE=1`, `OX_USER_CONFIG`, the `OX_SESSION_RECORDING` modes). Each one solves a slice of the problem, none of them compose into a coherent "this is an ephemeral environment" predicate, and the auto-detection heuristics (CI variables) are duplicated across packages.
+
+We need a clean carveout that preserves CLI ergonomics — `ox agent prime`, `ox query`, `ox session` — while disabling everything that doesn't make sense for a 60-second container.
+
+## Decision
+
+Introduce a unified ephemeral-mode predicate and an HTTP-first read path. When the predicate is true, the daemon does not start, the ledger clone never happens, and reads route to `api.sageox.ai` over HTTP.
+
+### Unified predicate
+
+A single helper `internal/ephemeral/mode.go:IsEphemeral()` returns `true` when:
+
+| Source | Behavior |
+|--------|----------|
+| `OX_EPHEMERAL=1` | Explicit opt-in (always wins) |
+| `CLAUDE_CODE_REMOTE` set | Claude Code Cloud auto-detection |
+| `DEVIN_TASK_ID` set | Devin auto-detection |
+| `CODESPACES=true` | GitHub Codespaces auto-detection |
+| Existing `isCI()` heuristics | `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, `BUILDKITE`, `CODEBUILD_BUILD_ID` |
+
+The predicate is checked once at process start and cached. Subsystems consult `ephemeral.IsEphemeral()` rather than re-reading env vars themselves — this keeps detection logic in one place and prevents drift.
+
+### Subsystem behavior when ephemeral
+
+| Subsystem | Workstation mode | Ephemeral mode |
+|-----------|------------------|----------------|
+| **Daemon** | Started on demand, persistent | Not started; CLI runs daemonless |
+| **Ledger clone** | Local git clone, daemon-pulled | Skipped; HTTP fetch via `GET /api/v1/teams/:id/context` writes team-ctx docs directly to canonical paths |
+| **CodeDB Bleve index** | Built and kept warm | Not initialized |
+| **KB sync** | Periodic from team context | Skipped (same effect as `OX_KB_DISABLE=1`) |
+| **Session recording** | Records to ledger cache | Defaults to `auto` writing to `$TMPDIR`; uploads via HTTP + LFS Batch API (Phase 2 of GH #102) |
+| **LFS hydration cache** | On-disk under ledger cache | In-memory only, capped 64 MB |
+| **`ox doctor`** | Full daemon + clone checks | Shrinks to cloud self-test (token reachability, API health) |
+
+### Auth
+
+Ephemeral mode uses a user-issued personal access token, not the device-flow OAuth credentials that workstation `ox login` stores on disk:
+
+- **`OX_TOKEN`** is the primary env var (matches `GITHUB_TOKEN` / `GITLAB_TOKEN` convention).
+- **`SAGEOX_TOKEN`** is accepted as an alias. If both are set, `OX_TOKEN` wins.
+- Tokens are created via the sageox.ai web app at `/settings/tokens`, prefixed `oxp_`, with a show-once reveal.
+- Token verification happens server-side via Better Auth's `apiKey` plugin against `api.sageox.ai`.
+
+The CLI **never** writes the token to disk in ephemeral mode — it reads it from the environment per process and forgets it.
+
+### Architecture
+
+```mermaid
+flowchart LR
+    subgraph Cloud["Ephemeral cloud agent"]
+        SH["SessionStart hook"]
+        IN["curl install.sageox.ai/ox to sh"]
+        AP["ox agent prime --cloud"]
+        TK["OX_TOKEN from env"]
+    end
+
+    subgraph API["api.sageox.ai"]
+        AK["Better Auth api-keys verify"]
+        TC["GET /api/v1/teams/:id/context"]
+        SU["POST /api/v1/sessions (Phase 2)"]
+        LB["LFS Batch API (Phase 2)"]
+    end
+
+    subgraph Web["sageox.ai web"]
+        TS["/settings/tokens"]
+        CR["Create dialog"]
+        RV["Show-once reveal of oxp"]
+    end
+
+    SH --> IN --> AP --> TK
+    TK -. bearer .-> AK
+    AP -. fetch team ctx .-> TC
+    AP -. upload session .-> SU
+    AP -. upload blobs .-> LB
+    RV -. user copies .-> SH
+    TS --> CR --> RV
+
+    style Cloud fill:#1e293b,stroke:#475569,color:#e2e8f0
+    style API fill:#0f172a,stroke:#1e40af,color:#dbeafe
+    style Web fill:#1f1f1f,stroke:#7c3aed,color:#ede9fe
+```
+
+## Interaction with existing rules
+
+### `.claude/rules/daemon-git.md` — Daemon-CLI git operations split
+
+The rule documents that the daemon owns pull-direction git operations (clone, fetch, pull) and the CLI owns write-direction operations (add, commit, push). In ephemeral mode, **no daemon exists** — the split degenerates. The CLI does HTTP reads instead of relying on daemon pulls. Writes (session uploads) move to HTTP + the LFS Batch API in Phase 2.
+
+An "Ephemeral-mode exception" section is appended to that rule pointing at this ADR for the full rationale.
+
+### `.claude/rules/lfs-no-git-lfs-binary.md` — No `git-lfs` binary dependency
+
+Unchanged. `internal/lfs/client.go` is already a pure-Go HTTP client for the LFS Batch API and works in ephemeral mode without modification. The ban on shelling out to `git-lfs` is the reason ephemeral session upload is even possible.
+
+### `.claude/rules/cache-only-design.md` — Cache vs source-of-truth
+
+Unchanged for read paths. Session recording in ephemeral mode writes to `$TMPDIR`, not the ledger cache, because no ledger cache exists. The recording is transient by design — it is uploaded to LFS and discarded with the container.
+
+## Rollout phases
+
+Matches the rollout in GH #102.
+
+| Phase | Scope | Status |
+|-------|-------|--------|
+| **1 (this PR)** | Read-only team-ctx over HTTP. `--ephemeral` flag on `ox agent prime` sets `OX_EPHEMERAL=1` for the current process. `ephemeral.IsEphemeral()` predicate, subsystem opt-outs wired. | Proposed |
+| **2** | Session upload over HTTP + LFS Batch API. No daemon, no local ledger clone in the write path. | Planned |
+| **3** | Static binary distribution at `install.sageox.ai/ox`. `ox cloud bootstrap` UX for one-shot setup inside cloud agents. | Planned |
+| **4** | OpenClaw + headless-CI session capture adapters. Full parity with workstation session lifecycle. | Future |
+
+Each phase is independently shippable. Phase 1 is read-only; nothing the cloud agent does can corrupt user state.
+
+## Alternatives Considered
+
+### Alternative 1: Keep the per-subsystem escape hatches, document them as the cloud recipe
+
+Document a recipe like "in cloud agents, set `SAGEOX_DAEMON=false`, `OX_KB_DISABLE=1`, `OX_SESSION_RECORDING=auto`, `OX_NO_INTERACTIVE=1`."
+
+**Pros:** Zero new code. Already works for some configurations.
+
+**Cons:** Six env vars to remember. No way to add a new subsystem-disable without updating every cloud-agent template. Auto-detection logic is duplicated across packages and drifts. Users hit confusing failures when one env var is missed.
+
+### Alternative 2: Detect ephemeral mode and force-set the existing escape-hatch env vars
+
+Have `IsEphemeral()` mutate `os.Setenv` for the legacy vars at process start.
+
+**Pros:** Backward compatible with code that already reads the legacy vars.
+
+**Cons:** Process-wide env mutation is a footgun (subprocesses inherit it; ordering matters; tests have to undo it). The clean answer is to migrate the callers to `ephemeral.IsEphemeral()`.
+
+### Alternative 3: Build a "thin-client" binary separate from `ox`
+
+Ship `ox-cloud` as a different binary with no daemon code linked in.
+
+**Pros:** Smaller binary; less surface area for cloud accidents.
+
+**Cons:** Two binaries to maintain, two sets of docs, two `install.sageox.ai` URLs. The Go binary is already small enough that the cost of carrying daemon code into ephemeral mode is negligible compared to the maintenance cost of forking the CLI.
+
+## Consequences
+
+### Positive
+
+- **One predicate.** Subsystems consult `ephemeral.IsEphemeral()` once. New subsystems opt in or out explicitly.
+- **No daemon footprint** in environments where it cannot pay back its cost.
+- **HTTP-first reads** sidestep the entire "clone a multi-gigabyte repo to read three markdown files" problem.
+- **Pure-Go LFS** (existing) means session uploads work without `git-lfs` installed on the cloud agent.
+- **Composable with workstation mode.** A developer running `OX_EPHEMERAL=1 ox query "..."` on their laptop gets the same fast-path the cloud agent gets, useful for testing.
+
+### Negative
+
+- **Two read paths to maintain.** The HTTP team-ctx fetcher and the daemon-pulled ledger clone both need to stay in sync with the team-context document format.
+- **No offline support in ephemeral mode.** If `api.sageox.ai` is unreachable, the cloud agent has nothing. This is acceptable — ephemeral agents are network-bound by definition.
+- **Cache-warming asymmetry.** Workstation users get CodeDB and KB index warm-up; cloud users do not. Cloud queries pay full latency every time. Mitigated by the fact that cloud session lifetime is short — a warm index would be discarded immediately anyway.
+
+### Risks
+
+- **Allowlisted egress.** Claude Cloud `limited` mode and corporate proxies need `api.sageox.ai`, `install.sageox.ai`, and the team-context git host on the allowlist. We document this in `/docs/cli/ephemeral-mode`; we do not auto-detect, because failure to reach the API is indistinguishable from a network outage.
+- **`OX_TOKEN` vs `SAGEOX_TOKEN` confusion.** Two env vars for one concept is a wart. Mitigated by explicit precedence (`OX_TOKEN` wins) and a single doc page explaining the alias.
+- **Daemon mid-startup race.** If a workstation user sets `OX_EPHEMERAL=1` while the daemon is mid-startup, `IsEphemeral()` may run before the daemon is fully up and we fall back to HTTP. Acceptable — the HTTP path is idempotent and returns the same data the daemon would have served.
+- **Token leakage in shell history / CI logs.** A user pasting `OX_TOKEN=oxp_...` into a terminal leaves it in `.bash_history`. Mitigated by encouraging `.env` files and the GitHub Secret Scanning partner-program integration (tracked separately).
+
+## References
+
+- GH #102 — Ephemeral mode rollout
+- GH #103 — Non-interactive auth (PAT) for cloud agents
+- `.claude/rules/daemon-git.md` — Daemon-CLI git operations split
+- `.claude/rules/lfs-no-git-lfs-binary.md` — Pure-Go LFS, no `git-lfs` shell-out
+- `internal/ephemeral/mode.go` — `IsEphemeral()` predicate (sibling agent)
+- `cmd/ox/agent_prime.go` — `--ephemeral` flag wiring (sibling agent)
+- `internal/auth/` — `OX_TOKEN` / `SAGEOX_TOKEN` env-var auth (sibling agent)

--- a/docs/ai/adr/adr-ephemeral-mode.md
+++ b/docs/ai/adr/adr-ephemeral-mode.md
@@ -1,10 +1,10 @@
 <!-- doc-audience: ai -->
 # ADR: Ephemeral Mode
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-27
 - **Deciders:** Ryan Snodgrass, SageOx Team
-- **Relates to:** [Ledger Architecture](adr-ledger-architecture.md), [Session LFS Storage](adr-session-lfs-storage.md), [Whisper & Murmur Architecture](adr-whisper-murmur-architecture.md)
+- **Relates to:** sageox-mono [ADR-047: Customer-Facing Env Var Namespace](https://github.com/sageox/sageox-mono/blob/main/docs/human/adr/047-customer-facing-env-var-namespace.md), [Ledger Architecture](adr-ledger-architecture.md), [Session LFS Storage](adr-session-lfs-storage.md), [Whisper & Murmur Architecture](adr-whisper-murmur-architecture.md)
 
 ## Context
 
@@ -57,12 +57,16 @@ The predicate is checked once at process start and cached. Subsystems consult `e
 
 Ephemeral mode uses a user-issued personal access token, not the device-flow OAuth credentials that workstation `ox login` stores on disk:
 
-- **`OX_TOKEN`** is the primary env var (matches `GITHUB_TOKEN` / `GITLAB_TOKEN` convention).
-- **`SAGEOX_TOKEN`** is accepted as an alias. If both are set, `OX_TOKEN` wins.
+- **`SAGEOX_TOKEN`** is the only customer-facing env var for PAT auth.
+- **`SAGEOX_ENDPOINT`** selects the target SageOx deployment. Tokens are bound client-side to this explicit endpoint selection surface, or production by default when unset.
 - Tokens are created via the sageox.ai web app at `/settings/tokens`, prefixed `oxp_`, with a show-once reveal.
 - Token verification happens server-side via Better Auth's `apiKey` plugin against `api.sageox.ai`.
 
 The CLI **never** writes the token to disk in ephemeral mode — it reads it from the environment per process and forgets it.
+
+### Customer-facing env-var naming
+
+The customer-facing env-var namespace rule (`SAGEOX_*` for product/auth/network identity, `OX_*` reserved for CLI-local behavior flags) is documented in sageox-mono [ADR-047: Customer-Facing Env Var Namespace](https://github.com/sageox/sageox-mono/blob/main/docs/human/adr/047-customer-facing-env-var-namespace.md). The PAT work introduced `SAGEOX_TOKEN` to follow that rule; the rule itself is canonical there.
 
 ### Architecture
 
@@ -72,7 +76,7 @@ flowchart LR
         SH["SessionStart hook"]
         IN["curl install.sageox.ai/ox to sh"]
         AP["ox agent prime --cloud"]
-        TK["OX_TOKEN from env"]
+        TK["SAGEOX_TOKEN from env"]
     end
 
     subgraph API["api.sageox.ai"]
@@ -175,9 +179,9 @@ Ship `ox-cloud` as a different binary with no daemon code linked in.
 ### Risks
 
 - **Allowlisted egress.** Claude Cloud `limited` mode and corporate proxies need `api.sageox.ai`, `install.sageox.ai`, and the team-context git host on the allowlist. We document this in `/docs/cli/ephemeral-mode`; we do not auto-detect, because failure to reach the API is indistinguishable from a network outage.
-- **`OX_TOKEN` vs `SAGEOX_TOKEN` confusion.** Two env vars for one concept is a wart. Mitigated by explicit precedence (`OX_TOKEN` wins) and a single doc page explaining the alias.
+- **Legacy `OX_TOKEN` migration.** Older CI configs or shell profiles may still export the legacy `OX_TOKEN` name, which is now ignored. Mitigated by documenting `SAGEOX_TOKEN` as the only supported customer-facing auth variable per sageox-mono [ADR-047](https://github.com/sageox/sageox-mono/blob/main/docs/human/adr/047-customer-facing-env-var-namespace.md), and treating stale legacy names as a migration error, not a second auth path.
 - **Daemon mid-startup race.** If a workstation user sets `OX_EPHEMERAL=1` while the daemon is mid-startup, `IsEphemeral()` may run before the daemon is fully up and we fall back to HTTP. Acceptable — the HTTP path is idempotent and returns the same data the daemon would have served.
-- **Token leakage in shell history / CI logs.** A user pasting `OX_TOKEN=oxp_...` into a terminal leaves it in `.bash_history`. Mitigated by encouraging `.env` files and the GitHub Secret Scanning partner-program integration (tracked separately).
+- **Token leakage in shell history / CI logs.** A user pasting `SAGEOX_TOKEN=oxp_...` into a terminal leaves it in `.bash_history`. Mitigated by encouraging `.env` files and the GitHub Secret Scanning partner-program integration (tracked separately).
 
 ## References
 
@@ -187,4 +191,4 @@ Ship `ox-cloud` as a different binary with no daemon code linked in.
 - `.claude/rules/lfs-no-git-lfs-binary.md` — Pure-Go LFS, no `git-lfs` shell-out
 - `internal/ephemeral/mode.go` — `IsEphemeral()` predicate (sibling agent)
 - `cmd/ox/agent_prime.go` — `--ephemeral` flag wiring (sibling agent)
-- `internal/auth/` — `OX_TOKEN` / `SAGEOX_TOKEN` env-var auth (sibling agent)
+- `internal/auth/` — `SAGEOX_TOKEN` env-var auth (sibling agent)

--- a/internal/api/team_context.go
+++ b/internal/api/team_context.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/logger"
+	"github.com/sageox/ox/internal/useragent"
+)
+
+// teamContextPath is the cloud endpoint that returns a team's full context
+// (docs + AGENTS.md + CLAUDE.md + MEMORY.md) for HTTP-only ephemeral
+// consumers that cannot perform a git clone of the team-context repo.
+//
+// Contract: GET /api/v1/teams/{team_id}/context returns a JSON
+// TeamContextContentResponse. 404 means the endpoint is not deployed
+// yet (or the team has no context) — callers fall through gracefully.
+const teamContextPath = "/api/v1/teams/%s/context" // %s = team_id
+
+// ErrTeamContextEndpointUnavailable is returned when the cloud team-context
+// endpoint responds with 404. This is a sentinel — callers in ephemeral
+// mode treat it as "fall through to whatever was already there" rather
+// than a hard error, because the endpoint may not be deployed yet.
+var ErrTeamContextEndpointUnavailable = errors.New("team-context endpoint not available")
+
+// TeamContextContentResponse is the JSON payload returned by
+// GET /api/v1/teams/{team_id}/context.
+type TeamContextContentResponse struct {
+	TeamID   string           `json:"team_id"`
+	TeamName string           `json:"team_name"`
+	Docs     []TeamContextDoc `json:"docs"`
+	AgentsMD string           `json:"agents_md"`
+	ClaudeMD string           `json:"claude_md"`
+	Memory   string           `json:"memory"`
+}
+
+// TeamContextDoc is a single team-context document fetched over HTTP.
+// Name is a relative path under the team-context root (may include
+// directory separators, e.g. "guides/architecture.md").
+type TeamContextDoc struct {
+	Name    string `json:"name"`
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+// GetTeamContextContent fetches the full team context for teamID over HTTP.
+//
+// This is the ephemeral-mode fallback for environments where the daemon
+// cannot keep a local git clone of the team-context repo in sync. The
+// caller is responsible for writing the returned content to disk under
+// paths.TeamContextDir(teamID, endpoint).
+//
+// Returns ErrTeamContextEndpointUnavailable on 404 (endpoint not deployed
+// or no team context). Returns ErrUnauthorized on 401, ErrForbidden on 403.
+func (c *RepoClient) GetTeamContextContent(ctx context.Context, teamID string) (*TeamContextContentResponse, error) {
+	if teamID == "" {
+		return nil, fmt.Errorf("team_id is required")
+	}
+
+	reqURL := strings.TrimSuffix(c.baseURL, "/") + fmt.Sprintf(teamContextPath, teamID)
+
+	logger.LogHTTPRequest("GET", reqURL)
+	start := time.Now()
+
+	httpReq, err := useragent.NewRequest(ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if c.authToken != "" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	duration := time.Since(start)
+	if err != nil {
+		logger.LogHTTPError("GET", reqURL, err, duration)
+		return nil, fmt.Errorf("network error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	logger.LogHTTPResponse("GET", reqURL, resp.StatusCode, duration)
+
+	if CheckVersionResponse(resp) {
+		return nil, ErrVersionUnsupported
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		switch resp.StatusCode {
+		case http.StatusNotFound:
+			return nil, ErrTeamContextEndpointUnavailable
+		case http.StatusUnauthorized:
+			return nil, ErrUnauthorized
+		case http.StatusForbidden:
+			return nil, ErrForbidden
+		}
+		errMsg := strings.TrimSpace(string(bodyBytes))
+		if errMsg == "" {
+			errMsg = resp.Status
+		}
+		return nil, fmt.Errorf("team-context fetch failed: status=%d body=%s", resp.StatusCode, errMsg)
+	}
+
+	var out TeamContextContentResponse
+	if err := json.Unmarshal(bodyBytes, &out); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &out, nil
+}

--- a/internal/api/team_context_test.go
+++ b/internal/api/team_context_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetTeamContextContent_Success — Failure prevented: HTTP fallback for
+// ephemeral mode fails to decode a well-formed response, leaving primes
+// with no team context even when the cloud endpoint responded correctly.
+func TestGetTeamContextContent_Success(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/api/v1/teams/team_abc/context"))
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"team_id": "team_abc",
+			"team_name": "Test Team",
+			"docs": [
+				{"name": "guides/onboarding.md", "title": "Onboarding", "content": "# Hello"}
+			],
+			"agents_md": "# AGENTS\n",
+			"claude_md": "# CLAUDE\n",
+			"memory": "# MEMORY\n"
+		}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+
+	resp, err := client.GetTeamContextContent(context.Background(), "team_abc")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "team_abc", resp.TeamID)
+	assert.Equal(t, "Test Team", resp.TeamName)
+	require.Len(t, resp.Docs, 1)
+	assert.Equal(t, "guides/onboarding.md", resp.Docs[0].Name)
+	assert.Equal(t, "# Hello", resp.Docs[0].Content)
+	assert.Equal(t, "# AGENTS\n", resp.AgentsMD)
+	assert.Equal(t, "# CLAUDE\n", resp.ClaudeMD)
+	assert.Equal(t, "# MEMORY\n", resp.Memory)
+}
+
+// TestGetTeamContextContent_NotFound — Failure prevented: 404 (endpoint
+// not yet deployed) is treated as a hard error instead of a graceful
+// fall-through sentinel, breaking prime in ephemeral mode against older
+// servers.
+func TestGetTeamContextContent_NotFound(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+
+	resp, err := client.GetTeamContextContent(context.Background(), "team_missing")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.True(t, errors.Is(err, ErrTeamContextEndpointUnavailable),
+		"404 must return ErrTeamContextEndpointUnavailable sentinel, got %v", err)
+}
+
+// TestGetTeamContextContent_Unauthorized — Failure prevented: 401 leaks as
+// a generic error instead of the canonical ErrUnauthorized, so the CLI
+// can't distinguish "log in" from real failures.
+func TestGetTeamContextContent_Unauthorized(t *testing.T) {
+	t.Parallel()
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer mockServer.Close()
+
+	client := &RepoClient{
+		baseURL:    mockServer.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "bad-token",
+	}
+
+	resp, err := client.GetTeamContextContent(context.Background(), "team_abc")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.True(t, errors.Is(err, ErrUnauthorized),
+		"401 must return ErrUnauthorized, got %v", err)
+}
+
+// TestGetTeamContextContent_EmptyTeamID — Failure prevented: an empty
+// team_id silently issues a request to /api/v1/teams//context, which
+// some servers will misinterpret as a list-all call.
+func TestGetTeamContextContent_EmptyTeamID(t *testing.T) {
+	t.Parallel()
+	client := &RepoClient{
+		baseURL:    "http://localhost:0",
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		version:    "test-version",
+		authToken:  "test-token",
+	}
+	resp, err := client.GetTeamContextContent(context.Background(), "")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/internal/auth/env_naming_test.go
+++ b/internal/auth/env_naming_test.go
@@ -1,0 +1,115 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoCustomerFacingOxTokenReintroduction guards against re-introduction of the
+// legacy customer-facing OX_TOKEN / OX_ENDPOINT env var names anywhere in the
+// source tree outside an allowlist that documents the rename.
+//
+// See sageox-mono ADR-047 ("Customer-Facing Env Var Namespace") for the
+// canonical rule, and the ephemeral-mode ADR for the migration note.
+//
+// Failure prevented: a future contributor adds OX_TOKEN or OX_ENDPOINT thinking
+// "ox CLI = OX_*", silently reintroducing the customer-facing namespace
+// confusion this ADR was written to eliminate.
+func TestNoCustomerFacingOxTokenReintroduction(t *testing.T) {
+	repoRoot := findRepoRootForNamingTest(t)
+
+	// Files that may legitimately mention the legacy names: the legacy-ignore
+	// regression test, this guard, the ADR documenting the rename, the
+	// ephemeral-mode ADR's migration note, and the CHANGELOG rename entry
+	// (CHANGELOG.md is a symlink to cmd/ox/release_notes.md — filepath.Walk
+	// visits the real file, so allowlist the real path).
+	allowlist := map[string]bool{
+		"internal/auth/env_token_test.go":   true,
+		"internal/auth/env_naming_test.go":  true,
+		"docs/ai/adr/adr-ephemeral-mode.md": true,
+		"cmd/ox/release_notes.md":           true,
+		"CHANGELOG.md":                      true,
+	}
+
+	bannedPatterns := []string{`"OX_TOKEN"`, `"OX_ENDPOINT"`, "`OX_TOKEN`", "`OX_ENDPOINT`"}
+
+	skipDirs := map[string]bool{
+		".git":         true,
+		".context":     true, // conductor workspace scratch, gitignored
+		"node_modules": true,
+		"vendor":       true,
+		"third_party":  true,
+		"dist":         true,
+		"build":        true,
+	}
+
+	var violations []string
+	err := filepath.Walk(repoRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// only scan Go sources and Markdown docs
+		if !strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if allowlist[rel] {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		text := string(data)
+		for _, pat := range bannedPatterns {
+			if strings.Contains(text, pat) {
+				violations = append(violations, rel+": "+pat)
+				break
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if len(violations) > 0 {
+		t.Errorf("customer-facing OX_TOKEN/OX_ENDPOINT references found "+
+			"(use SAGEOX_TOKEN/SAGEOX_ENDPOINT; see sageox-mono ADR-047):\n%s",
+			strings.Join(violations, "\n"))
+	}
+}
+
+func findRepoRootForNamingTest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// walk upward looking for go.mod (repo root marker)
+	dir := wd
+	for i := 0; i < 10; i++ {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not find repo root (go.mod) starting from %s", wd)
+	return ""
+}

--- a/internal/auth/env_token.go
+++ b/internal/auth/env_token.go
@@ -3,17 +3,14 @@ package auth
 import (
 	"os"
 	"time"
+
+	"github.com/sageox/ox/internal/endpoint"
 )
 
-// EnvVarToken is the primary environment variable for supplying an ox access token
+// EnvVarToken is the environment variable for supplying a SageOx access token
 // out-of-band (CI/CD, headless agents, ephemeral containers). When set, it takes
 // precedence over any token stored on disk.
-const EnvVarToken = "OX_TOKEN"
-
-// EnvVarTokenAlias is the back-compat alias for EnvVarToken. Kept for users who
-// adopted SAGEOX_TOKEN before the ryan/ox-session-start work was lost. Resolution
-// order: OX_TOKEN wins, then SAGEOX_TOKEN.
-const EnvVarTokenAlias = "SAGEOX_TOKEN"
+const EnvVarToken = "SAGEOX_TOKEN"
 
 // envTokenTTL is the synthetic rolling expiry stamped on env-sourced tokens.
 // Env tokens have no refresh credential — the server returning 401 is the source
@@ -38,19 +35,31 @@ func isEnvToken(ep string, token *StoredToken) bool {
 	return token.AccessToken == envTok.AccessToken
 }
 
-// tokenFromEnv returns a StoredToken populated from OX_TOKEN (preferred) or
-// SAGEOX_TOKEN (alias). Returns nil when neither is set.
+// envTokenEndpoint returns the single endpoint an env-supplied token is allowed
+// to target in this process. SAGEOX_TOKEN is not self-describing client-side, so we
+// bind it to the explicit endpoint selection surface only:
+//   - SAGEOX_ENDPOINT when set
+//   - production by default
 //
-// The ep parameter is currently unused — it is kept for API symmetry with
-// GetTokenForEndpoint and reserved for future per-endpoint variants
-// (e.g. OX_TOKEN_<HOST>). Callers should pass the normalized endpoint anyway.
+// We intentionally do NOT inherit endpoint.Get() here because that function can
+// fall back to "the only logged-in endpoint", which would let a prod SAGEOX_TOKEN
+// silently ride along to a different host if disk auth happened to be sparse.
+func envTokenEndpoint() string {
+	if ep := os.Getenv(endpoint.EnvVar); ep != "" {
+		return endpoint.NormalizeEndpoint(ep)
+	}
+	return endpoint.Default
+}
+
+// tokenFromEnv returns a StoredToken populated from SAGEOX_TOKEN when the
+// requested endpoint matches envTokenEndpoint(). Returns nil when the env var
+// is unset, or when the request is for a different endpoint.
 func tokenFromEnv(ep string) *StoredToken {
-	_ = ep // reserved for future per-endpoint env tokens
 	val := os.Getenv(EnvVarToken)
 	if val == "" {
-		val = os.Getenv(EnvVarTokenAlias)
+		return nil
 	}
-	if val == "" {
+	if requested := endpoint.NormalizeEndpoint(ep); requested != "" && requested != envTokenEndpoint() {
 		return nil
 	}
 	return &StoredToken{

--- a/internal/auth/env_token.go
+++ b/internal/auth/env_token.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"os"
+	"time"
+)
+
+// EnvVarToken is the primary environment variable for supplying an ox access token
+// out-of-band (CI/CD, headless agents, ephemeral containers). When set, it takes
+// precedence over any token stored on disk.
+const EnvVarToken = "OX_TOKEN"
+
+// EnvVarTokenAlias is the back-compat alias for EnvVarToken. Kept for users who
+// adopted SAGEOX_TOKEN before the ryan/ox-session-start work was lost. Resolution
+// order: OX_TOKEN wins, then SAGEOX_TOKEN.
+const EnvVarTokenAlias = "SAGEOX_TOKEN"
+
+// envTokenTTL is the synthetic rolling expiry stamped on env-sourced tokens.
+// Env tokens have no refresh credential — the server returning 401 is the source
+// of truth for invalidation. A 24h rolling TTL keeps IsExpired() honest without
+// triggering refresh paths.
+const envTokenTTL = 24 * time.Hour
+
+// isEnvToken reports whether the given token was sourced from the environment.
+// Env tokens have no refresh credential and the server returning 401 is the
+// source of truth for invalidation — callers must never attempt to refresh one.
+func isEnvToken(ep string, token *StoredToken) bool {
+	if token == nil {
+		return false
+	}
+	if token.RefreshToken != "" || token.SessionToken != "" {
+		return false
+	}
+	envTok := tokenFromEnv(ep)
+	if envTok == nil {
+		return false
+	}
+	return token.AccessToken == envTok.AccessToken
+}
+
+// tokenFromEnv returns a StoredToken populated from OX_TOKEN (preferred) or
+// SAGEOX_TOKEN (alias). Returns nil when neither is set.
+//
+// The ep parameter is currently unused — it is kept for API symmetry with
+// GetTokenForEndpoint and reserved for future per-endpoint variants
+// (e.g. OX_TOKEN_<HOST>). Callers should pass the normalized endpoint anyway.
+func tokenFromEnv(ep string) *StoredToken {
+	_ = ep // reserved for future per-endpoint env tokens
+	val := os.Getenv(EnvVarToken)
+	if val == "" {
+		val = os.Getenv(EnvVarTokenAlias)
+	}
+	if val == "" {
+		return nil
+	}
+	return &StoredToken{
+		AccessToken:  val,
+		RefreshToken: "",
+		SessionToken: "",
+		ExpiresAt:    time.Now().Add(envTokenTTL),
+		TokenType:    "Bearer",
+		Scope:        "*",
+		// UserInfo is zero-valued — filled lazily on first server response that
+		// includes claims.
+	}
+}

--- a/internal/auth/env_token_test.go
+++ b/internal/auth/env_token_test.go
@@ -12,11 +12,10 @@ import (
 // (the runtime panics if both are used). Env-token resolution is inherently
 // process-global, so serial execution is the correct semantics.
 
-// TestTokenFromEnv_OXTokenSet — Failure prevented: OX_TOKEN env doesn't produce a
+// TestTokenFromEnv_SageOxTokenSet — Failure prevented: SAGEOX_TOKEN env doesn't produce a
 // usable StoredToken, breaking CI/CD and headless agents.
-func TestTokenFromEnv_OXTokenSet(t *testing.T) {
+func TestTokenFromEnv_SageOxTokenSet(t *testing.T) {
 	t.Setenv(EnvVarToken, "oxp_test")
-	t.Setenv(EnvVarTokenAlias, "")
 
 	tok := tokenFromEnv("https://api.sageox.ai/")
 	require.NotNil(t, tok)
@@ -28,42 +27,52 @@ func TestTokenFromEnv_OXTokenSet(t *testing.T) {
 	assert.True(t, tok.ExpiresAt.After(time.Now()), "env token expiry must be in the future")
 }
 
-// TestTokenFromEnv_AliasOnly — Failure prevented: SAGEOX_TOKEN alias silently
-// drops, breaking back-compat with users who adopted the pre-rename name.
-func TestTokenFromEnv_AliasOnly(t *testing.T) {
+// TestTokenFromEnv_LegacyOxTokenIgnored — Failure prevented: removed OX_TOKEN
+// support accidentally lingers and keeps a second customer-facing env var alive.
+func TestTokenFromEnv_LegacyOxTokenIgnored(t *testing.T) {
 	t.Setenv(EnvVarToken, "")
-	t.Setenv(EnvVarTokenAlias, "oxp_test_alias")
+	t.Setenv("OX_TOKEN", "oxp_legacy")
 
-	tok := tokenFromEnv("https://api.sageox.ai/")
-	require.NotNil(t, tok)
-	assert.Equal(t, "oxp_test_alias", tok.AccessToken)
-}
-
-// TestTokenFromEnv_PrimaryWinsOverAlias — Failure prevented: resolution order
-// flips, OX_TOKEN gets shadowed by stale SAGEOX_TOKEN, user can't override.
-func TestTokenFromEnv_PrimaryWinsOverAlias(t *testing.T) {
-	t.Setenv(EnvVarToken, "oxp_primary")
-	t.Setenv(EnvVarTokenAlias, "oxp_alias")
-
-	tok := tokenFromEnv("https://api.sageox.ai/")
-	require.NotNil(t, tok)
-	assert.Equal(t, "oxp_primary", tok.AccessToken, "OX_TOKEN must win over SAGEOX_TOKEN")
+	assert.Nil(t, tokenFromEnv("https://api.sageox.ai/"))
 }
 
 // TestTokenFromEnv_NeitherSet — Failure prevented: nil-return contract broken,
 // callers that fall through to disk lookup are skipped.
 func TestTokenFromEnv_NeitherSet(t *testing.T) {
 	t.Setenv(EnvVarToken, "")
-	t.Setenv(EnvVarTokenAlias, "")
+	t.Setenv("OX_TOKEN", "")
 
 	assert.Nil(t, tokenFromEnv("https://api.sageox.ai/"))
+}
+
+// TestTokenFromEnv_MismatchedEndpointIgnored — Failure prevented: a single
+// env token silently applies to every endpoint lookup and gets sent to the
+// wrong host in multi-endpoint setups.
+func TestTokenFromEnv_MismatchedEndpointIgnored(t *testing.T) {
+	t.Setenv(EnvVarToken, "oxp_prod")
+	t.Setenv("SAGEOX_ENDPOINT", "")
+
+	assert.Nil(t, tokenFromEnv("https://staging.sageox.ai/"))
+}
+
+// TestTokenFromEnv_ExplicitEndpointSelection — Failure prevented: staging or
+// self-hosted users set SAGEOX_TOKEN but, without binding it to the selected
+// endpoint, either hit production implicitly or fan the token out everywhere.
+func TestTokenFromEnv_ExplicitEndpointSelection(t *testing.T) {
+	t.Setenv(EnvVarToken, "oxp_stage")
+	t.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
+
+	tok := tokenFromEnv("https://staging.sageox.ai/")
+	require.NotNil(t, tok)
+	assert.Equal(t, "oxp_stage", tok.AccessToken)
+	assert.Nil(t, tokenFromEnv("https://sageox.ai/"))
 }
 
 // TestGetTokenForEndpoint_EnvOverridesDisk — Failure prevented: env token
 // ignored when disk has a token, defeating the override use case.
 func TestGetTokenForEndpoint_EnvOverridesDisk(t *testing.T) {
 	t.Setenv(EnvVarToken, "")
-	t.Setenv(EnvVarTokenAlias, "")
+	t.Setenv("OX_TOKEN", "")
 
 	client := NewTestClient(t)
 	disk := createTestTokenForTest(1 * time.Hour)
@@ -89,7 +98,7 @@ func TestGetTokenForEndpoint_EnvOverridesDisk(t *testing.T) {
 // empty env var treated as a token, blanking out legitimate disk auth.
 func TestGetTokenForEndpoint_EnvEmptyFallsBackToDisk(t *testing.T) {
 	t.Setenv(EnvVarToken, "")
-	t.Setenv(EnvVarTokenAlias, "")
+	t.Setenv("OX_TOKEN", "")
 
 	client := NewTestClient(t)
 	disk := createTestTokenForTest(1 * time.Hour)
@@ -102,12 +111,29 @@ func TestGetTokenForEndpoint_EnvEmptyFallsBackToDisk(t *testing.T) {
 	assert.Equal(t, "disk-only", got.AccessToken)
 }
 
+// TestGetTokenForEndpoint_MismatchedEnvFallsBackToDisk — Failure prevented:
+// exporting SAGEOX_TOKEN for one endpoint hijacks token lookups for a different
+// endpoint that already has valid disk credentials.
+func TestGetTokenForEndpoint_MismatchedEnvFallsBackToDisk(t *testing.T) {
+	t.Setenv(EnvVarToken, "env-prod")
+	t.Setenv("SAGEOX_ENDPOINT", "")
+
+	client := NewTestClient(t)
+	disk := createTestTokenForTest(1 * time.Hour)
+	disk.AccessToken = "disk-staging"
+	require.NoError(t, client.SaveTokenForEndpoint("https://staging.sageox.ai", disk))
+
+	got, err := client.GetTokenForEndpoint("https://staging.sageox.ai")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "disk-staging", got.AccessToken)
+}
+
 // TestPackageAndClientAgree — Failure prevented: package-level
 // GetTokenForEndpoint and AuthClient.GetTokenForEndpoint diverge on env-token
 // resolution, leading to inconsistent auth behavior across call sites.
 func TestPackageAndClientAgree(t *testing.T) {
 	t.Setenv(EnvVarToken, "oxp_agree")
-	t.Setenv(EnvVarTokenAlias, "")
 
 	ep := "https://api.sageox.ai/"
 

--- a/internal/auth/env_token_test.go
+++ b/internal/auth/env_token_test.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Note: these tests use t.Setenv which is incompatible with t.Parallel
+// (the runtime panics if both are used). Env-token resolution is inherently
+// process-global, so serial execution is the correct semantics.
+
+// TestTokenFromEnv_OXTokenSet — Failure prevented: OX_TOKEN env doesn't produce a
+// usable StoredToken, breaking CI/CD and headless agents.
+func TestTokenFromEnv_OXTokenSet(t *testing.T) {
+	t.Setenv(EnvVarToken, "oxp_test")
+	t.Setenv(EnvVarTokenAlias, "")
+
+	tok := tokenFromEnv("https://api.sageox.ai/")
+	require.NotNil(t, tok)
+	assert.Equal(t, "oxp_test", tok.AccessToken)
+	assert.Equal(t, "Bearer", tok.TokenType)
+	assert.Equal(t, "*", tok.Scope)
+	assert.Empty(t, tok.RefreshToken)
+	assert.Empty(t, tok.SessionToken)
+	assert.True(t, tok.ExpiresAt.After(time.Now()), "env token expiry must be in the future")
+}
+
+// TestTokenFromEnv_AliasOnly — Failure prevented: SAGEOX_TOKEN alias silently
+// drops, breaking back-compat with users who adopted the pre-rename name.
+func TestTokenFromEnv_AliasOnly(t *testing.T) {
+	t.Setenv(EnvVarToken, "")
+	t.Setenv(EnvVarTokenAlias, "oxp_test_alias")
+
+	tok := tokenFromEnv("https://api.sageox.ai/")
+	require.NotNil(t, tok)
+	assert.Equal(t, "oxp_test_alias", tok.AccessToken)
+}
+
+// TestTokenFromEnv_PrimaryWinsOverAlias — Failure prevented: resolution order
+// flips, OX_TOKEN gets shadowed by stale SAGEOX_TOKEN, user can't override.
+func TestTokenFromEnv_PrimaryWinsOverAlias(t *testing.T) {
+	t.Setenv(EnvVarToken, "oxp_primary")
+	t.Setenv(EnvVarTokenAlias, "oxp_alias")
+
+	tok := tokenFromEnv("https://api.sageox.ai/")
+	require.NotNil(t, tok)
+	assert.Equal(t, "oxp_primary", tok.AccessToken, "OX_TOKEN must win over SAGEOX_TOKEN")
+}
+
+// TestTokenFromEnv_NeitherSet — Failure prevented: nil-return contract broken,
+// callers that fall through to disk lookup are skipped.
+func TestTokenFromEnv_NeitherSet(t *testing.T) {
+	t.Setenv(EnvVarToken, "")
+	t.Setenv(EnvVarTokenAlias, "")
+
+	assert.Nil(t, tokenFromEnv("https://api.sageox.ai/"))
+}
+
+// TestGetTokenForEndpoint_EnvOverridesDisk — Failure prevented: env token
+// ignored when disk has a token, defeating the override use case.
+func TestGetTokenForEndpoint_EnvOverridesDisk(t *testing.T) {
+	t.Setenv(EnvVarToken, "")
+	t.Setenv(EnvVarTokenAlias, "")
+
+	client := NewTestClient(t)
+	disk := createTestTokenForTest(1 * time.Hour)
+	disk.AccessToken = "disk-token"
+	require.NoError(t, client.SaveToken(disk))
+
+	// without env, disk wins
+	got, err := client.GetToken()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "disk-token", got.AccessToken)
+
+	// with env, env wins
+	t.Setenv(EnvVarToken, "env-token")
+	got, err = client.GetToken()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "env-token", got.AccessToken)
+	assert.Equal(t, "*", got.Scope)
+}
+
+// TestGetTokenForEndpoint_EnvEmptyFallsBackToDisk — Failure prevented:
+// empty env var treated as a token, blanking out legitimate disk auth.
+func TestGetTokenForEndpoint_EnvEmptyFallsBackToDisk(t *testing.T) {
+	t.Setenv(EnvVarToken, "")
+	t.Setenv(EnvVarTokenAlias, "")
+
+	client := NewTestClient(t)
+	disk := createTestTokenForTest(1 * time.Hour)
+	disk.AccessToken = "disk-only"
+	require.NoError(t, client.SaveToken(disk))
+
+	got, err := client.GetToken()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "disk-only", got.AccessToken)
+}
+
+// TestPackageAndClientAgree — Failure prevented: package-level
+// GetTokenForEndpoint and AuthClient.GetTokenForEndpoint diverge on env-token
+// resolution, leading to inconsistent auth behavior across call sites.
+func TestPackageAndClientAgree(t *testing.T) {
+	t.Setenv(EnvVarToken, "oxp_agree")
+	t.Setenv(EnvVarTokenAlias, "")
+
+	ep := "https://api.sageox.ai/"
+
+	pkgTok, err := GetTokenForEndpoint(ep)
+	require.NoError(t, err)
+	require.NotNil(t, pkgTok)
+
+	client := NewTestClient(t)
+	cliTok, err := client.GetTokenForEndpoint(ep)
+	require.NoError(t, err)
+	require.NotNil(t, cliTok)
+
+	assert.Equal(t, pkgTok.AccessToken, cliTok.AccessToken)
+	assert.Equal(t, pkgTok.Scope, cliTok.Scope)
+	assert.Equal(t, pkgTok.TokenType, cliTok.TokenType)
+}

--- a/internal/auth/expiry_warn.go
+++ b/internal/auth/expiry_warn.go
@@ -1,0 +1,211 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/mattn/go-isatty"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/ephemeral"
+)
+
+// envTokenAssumedLifetime is the fallback lifetime used for env-supplied
+// tokens when the server response did not include a CreatedAt. Mirrors
+// the default SageOx PAT TTL — generous enough that the warning still
+// fires roughly when expected, conservative enough that it never warns
+// at unreasonably wide windows.
+const envTokenAssumedLifetime = 90 * 24 * time.Hour
+
+// expiryWarnedKeys deduplicates warning emissions within a single process
+// run, keyed by SHA-256 of the token. Without this, a single CLI command
+// that calls multiple subcommands (or that runs through prime+status
+// chains) would warn twice in a row, which reads as nagging.
+var (
+	expiryWarnedKeysMu sync.Mutex
+	expiryWarnedKeys   = map[string]bool{}
+)
+
+// resetExpiryWarnedKeysForTest clears the dedupe map. Test-only — public
+// callers must not rely on this.
+func resetExpiryWarnedKeysForTest() {
+	expiryWarnedKeysMu.Lock()
+	defer expiryWarnedKeysMu.Unlock()
+	expiryWarnedKeys = map[string]bool{}
+}
+
+// CheckAndWarnExpiry emits a single-line stderr warning when the PAT for
+// the given endpoint is within max(1d, lifetime*pct) of expiry. Returns
+// true if a warning was emitted; false otherwise (including all skip
+// cases — ephemeral, never-expires, dedup, non-TTY, no auth).
+//
+// Skipped silently when:
+//   - ephemeral.IsEphemeral() is true (cloud-agent contexts — noise hurts)
+//   - the writer is not a TTY (unless the *os.File path resolves to stderr
+//     and the caller has already decided to force; today the policy is
+//     "TTY only" with no override flag — keep it simple)
+//   - the token has never-expires semantics (ExpiresAt == nil)
+//   - the same token hash already warned this process
+//   - no token is configured for the endpoint (nothing to warn about)
+func CheckAndWarnExpiry(ctx context.Context, ep string, w io.Writer) bool {
+	if ephemeral.IsEphemeral() {
+		return false
+	}
+	if !writerIsTTY(w) {
+		return false
+	}
+
+	ep = endpoint.NormalizeEndpoint(ep)
+	token, err := GetTokenForEndpoint(ep)
+	if err != nil || token == nil || token.AccessToken == "" {
+		return false
+	}
+
+	// dedupe across multiple calls in the same process — the cheap path.
+	key := tokenHashKey(token.AccessToken)
+	expiryWarnedKeysMu.Lock()
+	already := expiryWarnedKeys[key]
+	expiryWarnedKeysMu.Unlock()
+	if already {
+		return false
+	}
+
+	expiresAt, createdAt, label, ok := resolveTokenExpiry(ctx, ep, token)
+	if !ok {
+		return false
+	}
+
+	cfg, _ := config.LoadUserConfig()
+	threshold := computeExpiryThreshold(expiresAt, createdAt, cfg)
+	if threshold < 0 {
+		// warnings disabled entirely (both pct=0 and min_days=0)
+		return false
+	}
+
+	remaining := time.Until(expiresAt)
+	if remaining > threshold {
+		return false
+	}
+
+	// dedupe: claim the key BEFORE writing so racing goroutines pick one
+	// winner. The check above is a fast-path; this is the authoritative
+	// gate.
+	expiryWarnedKeysMu.Lock()
+	if expiryWarnedKeys[key] {
+		expiryWarnedKeysMu.Unlock()
+		return false
+	}
+	expiryWarnedKeys[key] = true
+	expiryWarnedKeysMu.Unlock()
+
+	emitExpiryWarning(w, label, remaining)
+	return true
+}
+
+// resolveTokenExpiry returns the authoritative expiry + creation time for
+// the token. For env-supplied tokens it consults the token-meta cache
+// (calling /api/v1/auth/me when stale); for disk-stored tokens it trusts
+// StoredToken.ExpiresAt directly. The third return value is a short
+// human label ("env" or "disk") for the warning's diagnostic key.
+//
+// Returns ok=false when the token is never-expires (ExpiresAt nil or
+// zero-valued) or when no expiry information is available.
+func resolveTokenExpiry(ctx context.Context, ep string, token *StoredToken) (expiresAt time.Time, createdAt time.Time, label string, ok bool) {
+	if isEnvToken(ep, token) {
+		meta, err := FetchTokenMetaCached(ctx, ep, token.AccessToken)
+		if err != nil || meta == nil {
+			return time.Time{}, time.Time{}, "", false
+		}
+		if meta.ExpiresAt == nil || meta.ExpiresAt.IsZero() {
+			// never-expires token: no warning, ever.
+			return time.Time{}, time.Time{}, "", false
+		}
+		created := meta.CreatedAt
+		if created.IsZero() {
+			created = meta.ExpiresAt.Add(-envTokenAssumedLifetime)
+		}
+		return *meta.ExpiresAt, created, "env", true
+	}
+
+	// disk-stored token — ExpiresAt is set by the OAuth flow.
+	if token.ExpiresAt.IsZero() {
+		return time.Time{}, time.Time{}, "", false
+	}
+	// CreatedAt isn't tracked on StoredToken — approximate via fixed
+	// assumed lifetime. The threshold math still floors at 1 day so this
+	// can't pathologically over-warn.
+	created := token.ExpiresAt.Add(-envTokenAssumedLifetime)
+	return token.ExpiresAt, created, "disk", true
+}
+
+// computeExpiryThreshold returns the duration before expiry at which the
+// warning should fire: max(minDays, lifetime*pct). Returns -1 when both
+// minDays and pct are zero — interpreted by the caller as "warnings
+// disabled."
+func computeExpiryThreshold(expiresAt, createdAt time.Time, cfg *config.UserConfig) time.Duration {
+	pct := cfg.GetPATExpiryWarningThresholdPct()
+	minDays := cfg.GetPATExpiryWarningMinDays()
+	if pct <= 0 && minDays <= 0 {
+		return -1
+	}
+
+	floor := time.Duration(minDays) * 24 * time.Hour
+
+	var pctThreshold time.Duration
+	if pct > 0 && !createdAt.IsZero() && expiresAt.After(createdAt) {
+		lifetime := expiresAt.Sub(createdAt)
+		pctThreshold = time.Duration(float64(lifetime) * pct)
+	}
+
+	if pctThreshold > floor {
+		return pctThreshold
+	}
+	return floor
+}
+
+// emitExpiryWarning writes the single-line key=value warning to the
+// caller's writer. Format follows the CLAUDE.md logging convention so
+// it greps cleanly alongside other ox logs.
+func emitExpiryWarning(w io.Writer, source string, remaining time.Duration) {
+	humanRemaining := humanizeDuration(remaining)
+	fmt.Fprintf(w,
+		"warn=ox_token_expiring source=%s expires_in=%s create_new=https://sageox.ai/settings/tokens\n",
+		source, humanRemaining,
+	)
+}
+
+// humanizeDuration renders a duration as a compact "<N>d<H>h" or "<N>h<M>m"
+// string suitable for the warning. Negative durations render as "0s" — the
+// warning still fires (the token is already expired) but the format stays
+// human-readable.
+func humanizeDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	days := int(d / (24 * time.Hour))
+	hours := int((d % (24 * time.Hour)) / time.Hour)
+	if days > 0 {
+		return fmt.Sprintf("%dd%dh", days, hours)
+	}
+	minutes := int((d % time.Hour) / time.Minute)
+	if hours > 0 {
+		return fmt.Sprintf("%dh%dm", hours, minutes)
+	}
+	return fmt.Sprintf("%dm", minutes)
+}
+
+// writerIsTTY returns true when w is an *os.File pointing at a TTY. Any
+// other writer (bytes.Buffer in tests, pipes, files) returns false — we
+// never spam non-interactive consumers.
+func writerIsTTY(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}

--- a/internal/auth/expiry_warn.go
+++ b/internal/auth/expiry_warn.go
@@ -103,7 +103,7 @@ func CheckAndWarnExpiry(ctx context.Context, ep string, w io.Writer) bool {
 	expiryWarnedKeys[key] = true
 	expiryWarnedKeysMu.Unlock()
 
-	emitExpiryWarning(w, label, remaining)
+	emitExpiryWarning(w, ep, label, remaining)
 	return true
 }
 
@@ -168,14 +168,25 @@ func computeExpiryThreshold(expiresAt, createdAt time.Time, cfg *config.UserConf
 	return floor
 }
 
-// emitExpiryWarning writes the single-line key=value warning to the
-// caller's writer. Format follows the CLAUDE.md logging convention so
-// it greps cleanly alongside other ox logs.
-func emitExpiryWarning(w io.Writer, source string, remaining time.Duration) {
+// tokenSettingsURL returns the token-management page for the active endpoint.
+// Production uses the canonical sageox.ai host; self-hosted or staging hosts
+// stay on their own origin.
+func tokenSettingsURL(ep string) string {
+	ep = endpoint.NormalizeEndpoint(ep)
+	if ep == "" {
+		ep = endpoint.Default
+	}
+	return ep + "/settings/tokens"
+}
+
+// emitExpiryWarning writes the single-line key=value warning to the caller's
+// writer. Format follows the CLAUDE.md logging convention so it greps cleanly
+// alongside other ox logs.
+func emitExpiryWarning(w io.Writer, ep, source string, remaining time.Duration) {
 	humanRemaining := humanizeDuration(remaining)
 	fmt.Fprintf(w,
-		"warn=ox_token_expiring source=%s expires_in=%s create_new=https://sageox.ai/settings/tokens\n",
-		source, humanRemaining,
+		"warn=ox_token_expiring source=%s expires_in=%s create_new=%s\n",
+		source, humanRemaining, tokenSettingsURL(ep),
 	)
 }
 

--- a/internal/auth/expiry_warn_test.go
+++ b/internal/auth/expiry_warn_test.go
@@ -52,10 +52,10 @@ func TestComputeExpiryThreshold_TableDriven(t *testing.T) {
 		wantFloor time.Duration // minimum acceptable threshold
 		wantCeil  time.Duration // maximum acceptable threshold
 	}{
-		{"7d token", 7 * 24 * time.Hour, 24 * time.Hour, 24 * time.Hour},                    // 5% of 7d < 1d, floor wins
-		{"30d token", 30 * 24 * time.Hour, 36 * time.Hour, 36*time.Hour + time.Minute},      // 5% of 30d = 36h
-		{"90d token", 90 * 24 * time.Hour, 4*24*time.Hour + 12*time.Hour, 109 * time.Hour},  // 5% of 90d = 108h
-		{"365d token", 365 * 24 * time.Hour, 18 * 24 * time.Hour, 19 * 24 * time.Hour},      // 5% of 365d ≈ 18.25d
+		{"7d token", 7 * 24 * time.Hour, 24 * time.Hour, 24 * time.Hour},                   // 5% of 7d < 1d, floor wins
+		{"30d token", 30 * 24 * time.Hour, 36 * time.Hour, 36*time.Hour + time.Minute},     // 5% of 30d = 36h
+		{"90d token", 90 * 24 * time.Hour, 4*24*time.Hour + 12*time.Hour, 109 * time.Hour}, // 5% of 90d = 108h
+		{"365d token", 365 * 24 * time.Hour, 18 * 24 * time.Hour, 19 * 24 * time.Hour},     // 5% of 365d ≈ 18.25d
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestResolveTokenExpiry_NeverExpires(t *testing.T) {
 // depend on this shape.
 func TestEmitExpiryWarning_Format(t *testing.T) {
 	var buf bytes.Buffer
-	emitExpiryWarning(&buf, "disk", 4*24*time.Hour+3*time.Hour)
+	emitExpiryWarning(&buf, "https://sageox.ai", "disk", 4*24*time.Hour+3*time.Hour)
 	out := buf.String()
 	assert.True(t, strings.HasPrefix(out, "warn=ox_token_expiring"), "missing warn= prefix")
 	assert.Contains(t, out, "source=disk")
@@ -191,4 +191,14 @@ func TestExpiryWarn_DedupeWithinProcess(t *testing.T) {
 	already2 := expiryWarnedKeys[key]
 	expiryWarnedKeysMu.Unlock()
 	require.True(t, already2, "second call must see set")
+}
+
+// TestEmitExpiryWarning_UsesEndpointHost — Failure prevented: non-production
+// endpoints tell the user to create a token on sageox.ai instead of the active
+// host that actually issued the credential.
+func TestEmitExpiryWarning_UsesEndpointHost(t *testing.T) {
+	var buf bytes.Buffer
+	emitExpiryWarning(&buf, "https://staging.sageox.ai", "env", 2*time.Hour)
+	out := buf.String()
+	assert.Contains(t, out, "create_new=https://staging.sageox.ai/settings/tokens")
 }

--- a/internal/auth/expiry_warn_test.go
+++ b/internal/auth/expiry_warn_test.go
@@ -1,0 +1,194 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ephemeral"
+)
+
+// clearEnvironment scrubs every signal that could push ephemeral.IsEphemeral()
+// to true. Tests calling CheckAndWarnExpiry must scrub these first or the
+// ephemeral skip will mask the path under test.
+func clearEphemeralForTest(t *testing.T) {
+	t.Helper()
+	t.Setenv("OX_EPHEMERAL", "")
+	t.Setenv("CLAUDE_CODE_REMOTE", "")
+	t.Setenv("DEVIN_TASK_ID", "")
+	t.Setenv("CODESPACES", "")
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+	t.Setenv("JENKINS_URL", "")
+	t.Setenv("BUILDKITE", "")
+	t.Setenv("CODEBUILD_BUILD_ID", "")
+	ephemeral.SetUserConfigPreference(nil)
+}
+
+// TestComputeExpiryThreshold_TableDriven covers the lifetime-pct math against
+// realistic PAT lifetimes (7d / 30d / 90d / 365d). Failure prevented: the
+// threshold collapses to the day-floor for long-lived tokens and we never warn
+// until the last 24h, defeating the early-warning purpose.
+func TestComputeExpiryThreshold_TableDriven(t *testing.T) {
+	pct := 0.05
+	minDays := 1
+	cfg := &config.UserConfig{
+		PATExpiryWarningThresholdPct: &pct,
+		PATExpiryWarningMinDays:      &minDays,
+	}
+
+	now := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		lifetime  time.Duration
+		wantFloor time.Duration // minimum acceptable threshold
+		wantCeil  time.Duration // maximum acceptable threshold
+	}{
+		{"7d token", 7 * 24 * time.Hour, 24 * time.Hour, 24 * time.Hour},                    // 5% of 7d < 1d, floor wins
+		{"30d token", 30 * 24 * time.Hour, 36 * time.Hour, 36*time.Hour + time.Minute},      // 5% of 30d = 36h
+		{"90d token", 90 * 24 * time.Hour, 4*24*time.Hour + 12*time.Hour, 109 * time.Hour},  // 5% of 90d = 108h
+		{"365d token", 365 * 24 * time.Hour, 18 * 24 * time.Hour, 19 * 24 * time.Hour},      // 5% of 365d ≈ 18.25d
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			created := now
+			expires := now.Add(tc.lifetime)
+			got := computeExpiryThreshold(expires, created, cfg)
+			assert.GreaterOrEqual(t, got, tc.wantFloor, "threshold below expected floor")
+			assert.LessOrEqual(t, got, tc.wantCeil, "threshold above expected ceiling")
+		})
+	}
+}
+
+// TestComputeExpiryThreshold_DisabledWhenAllZero — Failure prevented: a user
+// who sets both knobs to 0 still sees the warning because the floor kicks in
+// at 1d. Sentinel -1 lets the caller distinguish "disabled" from "tiny."
+func TestComputeExpiryThreshold_DisabledWhenAllZero(t *testing.T) {
+	pct := 0.0
+	minDays := 0
+	cfg := &config.UserConfig{
+		PATExpiryWarningThresholdPct: &pct,
+		PATExpiryWarningMinDays:      &minDays,
+	}
+	now := time.Now()
+	got := computeExpiryThreshold(now.Add(24*time.Hour), now, cfg)
+	assert.Equal(t, time.Duration(-1), got)
+}
+
+// TestComputeExpiryThreshold_DefaultsApply — Failure prevented: when the user
+// has never set anything, we fall back to (0.05, 1d) and warn at the right
+// time. If defaults silently became 0, no warning would ever fire.
+func TestComputeExpiryThreshold_DefaultsApply(t *testing.T) {
+	cfg := &config.UserConfig{}
+	now := time.Now()
+	// 30-day lifetime — 5% is 36h, which exceeds the 1d floor.
+	got := computeExpiryThreshold(now.Add(30*24*time.Hour), now, cfg)
+	assert.Greater(t, got, 24*time.Hour)
+}
+
+// TestCheckAndWarnExpiry_SkippedWhenEphemeral — Failure prevented: cloud
+// agents spam stderr on every prime, polluting their structured outputs.
+func TestCheckAndWarnExpiry_SkippedWhenEphemeral(t *testing.T) {
+	t.Setenv("OX_EPHEMERAL", "1")
+	defer ephemeral.SetUserConfigPreference(nil)
+
+	resetExpiryWarnedKeysForTest()
+	var buf bytes.Buffer
+	emitted := CheckAndWarnExpiry(context.Background(), "https://sageox.ai", &buf)
+	assert.False(t, emitted)
+	assert.Empty(t, buf.String())
+}
+
+// TestCheckAndWarnExpiry_SkippedForNonTTY — Failure prevented: piping
+// `ox status` into another tool gets stderr noise that the consumer
+// did not consent to.
+func TestCheckAndWarnExpiry_SkippedForNonTTY(t *testing.T) {
+	clearEphemeralForTest(t)
+	resetExpiryWarnedKeysForTest()
+
+	// bytes.Buffer is the canonical "not a TTY" target.
+	var buf bytes.Buffer
+	emitted := CheckAndWarnExpiry(context.Background(), "https://sageox.ai", &buf)
+	assert.False(t, emitted)
+	assert.Empty(t, buf.String())
+}
+
+// TestResolveTokenExpiry_NeverExpires — Failure prevented: a never-expires
+// token (server returns ExpiresAt == nil) somehow triggers a warning,
+// which would be permanently noisy and nonsensical.
+func TestResolveTokenExpiry_NeverExpires(t *testing.T) {
+	clearEphemeralForTest(t)
+	tok := &StoredToken{
+		AccessToken: "oxp_never",
+		ExpiresAt:   time.Time{}, // zero-value: never expires
+	}
+	_, _, _, ok := resolveTokenExpiry(context.Background(), "https://sageox.ai", tok)
+	assert.False(t, ok, "zero-time ExpiresAt must be treated as never-expires")
+}
+
+// TestEmitExpiryWarning_Format — Failure prevented: warning format drifts
+// from the single-line key=value contract. Log scrapers and humans both
+// depend on this shape.
+func TestEmitExpiryWarning_Format(t *testing.T) {
+	var buf bytes.Buffer
+	emitExpiryWarning(&buf, "disk", 4*24*time.Hour+3*time.Hour)
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "warn=ox_token_expiring"), "missing warn= prefix")
+	assert.Contains(t, out, "source=disk")
+	assert.Contains(t, out, "expires_in=4d3h")
+	assert.Contains(t, out, "create_new=https://sageox.ai/settings/tokens")
+	assert.True(t, strings.HasSuffix(out, "\n"), "must be single line terminated by \\n")
+	assert.Equal(t, 1, strings.Count(out, "\n"), "must be a single line")
+}
+
+// TestHumanizeDuration covers the rendered shapes used in warnings.
+// Failure prevented: ambiguous durations like "1500m" leak into user-
+// facing output, hurting trust.
+func TestHumanizeDuration(t *testing.T) {
+	tests := []struct {
+		in   time.Duration
+		want string
+	}{
+		{4*24*time.Hour + 3*time.Hour, "4d3h"},
+		{2 * time.Hour, "2h0m"},
+		{45 * time.Minute, "45m"},
+		{0, "0s"},
+		{-1 * time.Hour, "0s"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, humanizeDuration(tc.in), "in=%s", tc.in)
+	}
+}
+
+// TestExpiryWarn_DedupeWithinProcess — Failure prevented: a CLI command that
+// transitively calls multiple wired-in commands (prime then status) warns
+// twice in a row, reading as nagging.
+func TestExpiryWarn_DedupeWithinProcess(t *testing.T) {
+	// Direct test of the dedupe map: simulate two emissions for the same
+	// token hash. The integration path that calls CheckAndWarnExpiry is
+	// covered by the other tests; here we prove the dedupe primitive.
+	resetExpiryWarnedKeysForTest()
+
+	key := tokenHashKey("oxp_dup")
+
+	expiryWarnedKeysMu.Lock()
+	already := expiryWarnedKeys[key]
+	if !already {
+		expiryWarnedKeys[key] = true
+	}
+	expiryWarnedKeysMu.Unlock()
+	require.False(t, already, "first call must see unset")
+
+	expiryWarnedKeysMu.Lock()
+	already2 := expiryWarnedKeys[key]
+	expiryWarnedKeysMu.Unlock()
+	require.True(t, already2, "second call must see set")
+}

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -114,7 +114,7 @@ func EnsureValidTokenForEndpoint(ep string, bufferSeconds int) (*StoredToken, er
 		return nil, nil
 	}
 
-	// env-sourced tokens (OX_TOKEN/SAGEOX_TOKEN) have no refresh credential —
+	// env-sourced tokens (SAGEOX_TOKEN) have no refresh credential —
 	// the server returning 401 is the source of truth for invalidation.
 	if isEnvToken(ep, token) {
 		return token, nil
@@ -378,7 +378,7 @@ func (c *AuthClient) EnsureValidTokenForEndpoint(ep string, bufferSeconds int) (
 		return nil, nil
 	}
 
-	// env-sourced tokens (OX_TOKEN/SAGEOX_TOKEN) have no refresh credential —
+	// env-sourced tokens (SAGEOX_TOKEN) have no refresh credential —
 	// the server returning 401 is the source of truth for invalidation.
 	if isEnvToken(ep, token) {
 		return token, nil

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -114,6 +114,12 @@ func EnsureValidTokenForEndpoint(ep string, bufferSeconds int) (*StoredToken, er
 		return nil, nil
 	}
 
+	// env-sourced tokens (OX_TOKEN/SAGEOX_TOKEN) have no refresh credential —
+	// the server returning 401 is the source of truth for invalidation.
+	if isEnvToken(ep, token) {
+		return token, nil
+	}
+
 	if token.IsExpired(bufferSeconds) {
 		return refreshTokenForEndpoint(token, ep)
 	}
@@ -370,6 +376,12 @@ func (c *AuthClient) EnsureValidTokenForEndpoint(ep string, bufferSeconds int) (
 
 	if token == nil {
 		return nil, nil
+	}
+
+	// env-sourced tokens (OX_TOKEN/SAGEOX_TOKEN) have no refresh credential —
+	// the server returning 401 is the source of truth for invalidation.
+	if isEnvToken(ep, token) {
+		return token, nil
 	}
 
 	if token.IsExpired(bufferSeconds) {

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -114,6 +114,10 @@ func GetToken() (*StoredToken, error) {
 func GetTokenForEndpoint(ep string) (*StoredToken, error) {
 	ep = endpoint.NormalizeEndpoint(ep)
 
+	if envTok := tokenFromEnv(ep); envTok != nil {
+		return envTok, nil
+	}
+
 	authPath, err := GetAuthFilePath()
 	if err != nil {
 		return nil, err
@@ -315,6 +319,10 @@ func (c *AuthClient) GetToken() (*StoredToken, error) {
 // GetTokenForEndpoint loads the authentication token for a specific API endpoint
 func (c *AuthClient) GetTokenForEndpoint(ep string) (*StoredToken, error) {
 	ep = endpoint.NormalizeEndpoint(ep)
+
+	if envTok := tokenFromEnv(ep); envTok != nil {
+		return envTok, nil
+	}
 
 	authPath, err := c.GetAuthFilePath()
 	if err != nil {

--- a/internal/auth/token_meta_cache.go
+++ b/internal/auth/token_meta_cache.go
@@ -1,0 +1,229 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/useragent"
+)
+
+// tokenMetaCacheTTL is how long /api/v1/auth/me responses stay fresh on disk
+// before the next interactive command re-fetches. Cheap enough to refresh
+// hourly, long enough to amortize over typical CLI invocation rhythms.
+const tokenMetaCacheTTL = 1 * time.Hour
+
+// tokenMetaCacheFile is the file basename inside CacheDir() for the
+// serialized cache. The directory is created lazily with 0700 perms.
+const tokenMetaCacheFile = "token_meta.json"
+
+// TokenMeta is the subset of /api/v1/auth/me fields ox needs to drive the
+// expiry-warning UX. ExpiresAt is a pointer so "never expires" (server
+// returns null) round-trips as nil — IsZero on time.Time is ambiguous with
+// the zero-time sentinel used elsewhere in storage.go.
+type TokenMeta struct {
+	// ExpiresAt is the real server-side expiry, or nil for never-expires
+	// tokens. NEVER use StoredToken.ExpiresAt for env-supplied tokens — that
+	// value is a 24h rolling synthetic stamp (see env_token.go).
+	ExpiresAt *time.Time `json:"expires_at"`
+
+	// CreatedAt enables the percentage-of-lifetime threshold calc. Server
+	// fills it. Zero when the server does not surface it.
+	CreatedAt time.Time `json:"created_at,omitempty"`
+
+	// TokenPrefix is the first few chars of the token (e.g., "oxp_NjkH")
+	// for display in warnings. Never the full token.
+	TokenPrefix string `json:"token_prefix,omitempty"`
+
+	// Name is the human-friendly label the user gave the token.
+	Name string `json:"name,omitempty"`
+
+	// FetchedAt is when this entry was last refreshed from the server.
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+// tokenMetaCacheFileFormat is the on-disk JSON shape — a map keyed by a
+// hash of the token so multiple tokens for one user can coexist without
+// the cache file leaking secrets.
+type tokenMetaCacheFileFormat struct {
+	Entries map[string]TokenMeta `json:"entries"`
+}
+
+// tokenMetaCacheMu guards on-disk reads/writes against the small race
+// between concurrent CLI invocations sharing the same file.
+var tokenMetaCacheMu sync.Mutex
+
+// tokenHashKey returns the hex-encoded SHA-256 of the token. Used as the
+// stable cache key so the on-disk file never contains plaintext tokens.
+func tokenHashKey(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// tokenMetaCachePath returns the on-disk cache file location:
+// $XDG_CACHE_HOME/sageox/token_meta.json (or legacy ~/.sageox/cache/...).
+func tokenMetaCachePath() string {
+	return filepath.Join(paths.CacheDir(), tokenMetaCacheFile)
+}
+
+// loadTokenMetaCache reads and parses the cache file. Returns an empty
+// (non-nil) struct when the file does not exist — the empty value is a
+// valid starting state for a fresh write.
+func loadTokenMetaCache() (*tokenMetaCacheFileFormat, error) {
+	path := tokenMetaCachePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &tokenMetaCacheFileFormat{Entries: map[string]TokenMeta{}}, nil
+		}
+		return nil, fmt.Errorf("read token meta cache: %w", err)
+	}
+	var out tokenMetaCacheFileFormat
+	if err := json.Unmarshal(data, &out); err != nil {
+		// corrupt file — treat as empty rather than wedge the warning path.
+		return &tokenMetaCacheFileFormat{Entries: map[string]TokenMeta{}}, nil
+	}
+	if out.Entries == nil {
+		out.Entries = map[string]TokenMeta{}
+	}
+	return &out, nil
+}
+
+// saveTokenMetaCache writes the cache atomically with 0600 perms. The
+// cache file holds non-sensitive metadata (expiry, name, prefix) but we
+// keep it user-private anyway — defense in depth and matches the auth
+// store convention.
+func saveTokenMetaCache(c *tokenMetaCacheFileFormat) error {
+	if c == nil {
+		return nil
+	}
+	path := tokenMetaCachePath()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create cache dir: %w", err)
+	}
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal token meta cache: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write tmp token meta cache: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename token meta cache: %w", err)
+	}
+	// Best-effort perm fix in case umask widened the file.
+	_ = os.Chmod(path, 0o600)
+	return nil
+}
+
+// FetchTokenMetaCached returns token metadata for the given (endpoint,
+// token) pair. Cache TTL is tokenMetaCacheTTL; on stale or missing entry
+// it fetches fresh from GET <ep>/api/v1/auth/me, persists, and returns.
+//
+// Returns (nil, nil) — and never an error — when the network call would
+// be wasteful or fails non-fatally. The caller is a warning emitter, not
+// a critical path; we never want to surface auth-me failures to the user.
+// Errors are only returned for genuinely malformed inputs (empty token).
+func FetchTokenMetaCached(ctx context.Context, ep, token string) (*TokenMeta, error) {
+	if token == "" {
+		return nil, fmt.Errorf("empty token")
+	}
+	ep = endpoint.NormalizeEndpoint(ep)
+	key := tokenHashKey(token)
+
+	tokenMetaCacheMu.Lock()
+	defer tokenMetaCacheMu.Unlock()
+
+	cache, err := loadTokenMetaCache()
+	if err != nil {
+		// soft-fail: start with empty cache, try to refresh.
+		cache = &tokenMetaCacheFileFormat{Entries: map[string]TokenMeta{}}
+	}
+
+	if entry, ok := cache.Entries[key]; ok {
+		if time.Since(entry.FetchedAt) < tokenMetaCacheTTL {
+			result := entry
+			return &result, nil
+		}
+	}
+
+	fresh, err := fetchTokenMetaFromServer(ctx, ep, token)
+	if err != nil {
+		// network/server problem — fall back to the stale entry if we
+		// have one rather than blocking the caller. The warning is
+		// best-effort; we never want to escalate.
+		if entry, ok := cache.Entries[key]; ok {
+			result := entry
+			return &result, nil
+		}
+		return nil, nil
+	}
+	fresh.FetchedAt = time.Now().UTC()
+	cache.Entries[key] = *fresh
+	if writeErr := saveTokenMetaCache(cache); writeErr != nil {
+		// non-fatal: return the fresh value even if persistence failed.
+		_ = writeErr
+	}
+	return fresh, nil
+}
+
+// authMeResponse is the subset of /api/v1/auth/me used by the warning
+// path. Unknown fields are tolerated. expires_at may be null (never-
+// expires) or an RFC3339 string.
+type authMeResponse struct {
+	ExpiresAt   *time.Time `json:"expires_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	TokenPrefix string     `json:"token_prefix"`
+	Name        string     `json:"name"`
+}
+
+// fetchTokenMetaFromServer GETs /api/v1/auth/me and maps the response
+// to TokenMeta. Network/parse failures surface as errors; callers
+// downgrade to a soft no-op.
+func fetchTokenMetaFromServer(ctx context.Context, ep, token string) (*TokenMeta, error) {
+	u := strings.TrimRight(ep, "/") + "/api/v1/auth/me"
+	req, err := useragent.NewRequest(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("auth/me: HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var parsed authMeResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, err
+	}
+	return &TokenMeta{
+		ExpiresAt:   parsed.ExpiresAt,
+		CreatedAt:   parsed.CreatedAt,
+		TokenPrefix: parsed.TokenPrefix,
+		Name:        parsed.Name,
+	}, nil
+}

--- a/internal/auth/token_meta_cache_test.go
+++ b/internal/auth/token_meta_cache_test.go
@@ -1,0 +1,176 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withTempCacheDir redirects paths.CacheDir() to a t.TempDir by setting
+// the relevant XDG env so isolation is hermetic between tests.
+func withTempCacheDir(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tmp)
+	// Defensively unset the legacy disable flag — both paths must point at tmp.
+	t.Setenv("OX_XDG_DISABLE", "")
+	t.Setenv("HOME", tmp) // legacy fallback respects HOME
+	return tmp
+}
+
+// TestSaveAndLoadTokenMetaCache_RoundTrip — Failure prevented: cache
+// serialization or path resolution drifts and we silently re-fetch on
+// every CLI invocation.
+func TestSaveAndLoadTokenMetaCache_RoundTrip(t *testing.T) {
+	withTempCacheDir(t)
+
+	expires := time.Date(2026, 8, 25, 0, 0, 0, 0, time.UTC)
+	in := &tokenMetaCacheFileFormat{Entries: map[string]TokenMeta{
+		"key1": {
+			ExpiresAt:   &expires,
+			TokenPrefix: "oxp_AAAA",
+			Name:        "test",
+			FetchedAt:   time.Now().UTC(),
+		},
+	}}
+	require.NoError(t, saveTokenMetaCache(in))
+
+	out, err := loadTokenMetaCache()
+	require.NoError(t, err)
+	require.Contains(t, out.Entries, "key1")
+	assert.Equal(t, expires, *out.Entries["key1"].ExpiresAt)
+	assert.Equal(t, "oxp_AAAA", out.Entries["key1"].TokenPrefix)
+}
+
+// TestSaveTokenMetaCache_FilePerms — Failure prevented: cache file is
+// world-readable and accidentally leaks metadata on shared hosts. The
+// rename + chmod path must produce 0600.
+func TestSaveTokenMetaCache_FilePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix perm bits not meaningful on windows")
+	}
+	withTempCacheDir(t)
+
+	require.NoError(t, saveTokenMetaCache(&tokenMetaCacheFileFormat{
+		Entries: map[string]TokenMeta{},
+	}))
+
+	info, err := os.Stat(tokenMetaCachePath())
+	require.NoError(t, err)
+	perm := info.Mode().Perm()
+	assert.Equal(t, os.FileMode(0o600), perm, "cache file must be 0600")
+}
+
+// TestFetchTokenMetaCached_HitsCacheWhenFresh — Failure prevented: every
+// CLI command hits the network for /auth/me, blowing the latency budget
+// and rate-limiting the user.
+func TestFetchTokenMetaCached_HitsCacheWhenFresh(t *testing.T) {
+	withTempCacheDir(t)
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		expires := time.Now().Add(48 * time.Hour)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"expires_at":   expires.Format(time.RFC3339),
+			"created_at":   time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+			"token_prefix": "oxp_AAAA",
+			"name":         "test",
+		})
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	tok := "oxp_test_token"
+
+	// First call: cache miss → fetch.
+	meta1, err := FetchTokenMetaCached(ctx, srv.URL, tok)
+	require.NoError(t, err)
+	require.NotNil(t, meta1)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	// Second call within TTL: cache hit, no network.
+	meta2, err := FetchTokenMetaCached(ctx, srv.URL, tok)
+	require.NoError(t, err)
+	require.NotNil(t, meta2)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "second call must hit cache, not network")
+}
+
+// TestFetchTokenMetaCached_StaleEntryRefetches — Failure prevented: stale
+// cache entries persist forever and the user never sees an updated
+// expiry after rotating their token.
+func TestFetchTokenMetaCached_StaleEntryRefetches(t *testing.T) {
+	withTempCacheDir(t)
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		expires := time.Now().Add(48 * time.Hour)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"expires_at":   expires.Format(time.RFC3339),
+			"token_prefix": "oxp_AAAA",
+			"name":         "test",
+		})
+	}))
+	defer srv.Close()
+
+	tok := "oxp_test_token"
+	key := tokenHashKey(tok)
+
+	// Plant a stale entry directly so we don't have to wait an hour.
+	staleExpires := time.Now().Add(1 * time.Hour)
+	stale := &tokenMetaCacheFileFormat{Entries: map[string]TokenMeta{
+		key: {
+			ExpiresAt:   &staleExpires,
+			TokenPrefix: "oxp_OLD",
+			FetchedAt:   time.Now().Add(-2 * time.Hour),
+		},
+	}}
+	require.NoError(t, saveTokenMetaCache(stale))
+
+	meta, err := FetchTokenMetaCached(context.Background(), srv.URL, tok)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "stale entry must trigger refetch")
+	assert.Equal(t, "oxp_AAAA", meta.TokenPrefix, "must return the fresh value, not the stale prefix")
+}
+
+// TestFetchTokenMetaCached_EmptyToken — Failure prevented: an empty token
+// reaches the server and produces a spurious 401 we silently absorb.
+func TestFetchTokenMetaCached_EmptyToken(t *testing.T) {
+	withTempCacheDir(t)
+	_, err := FetchTokenMetaCached(context.Background(), "https://sageox.ai", "")
+	assert.Error(t, err)
+}
+
+// TestTokenHashKey_StableAndDistinct — Failure prevented: hash function
+// changes break every existing cache file silently.
+func TestTokenHashKey_StableAndDistinct(t *testing.T) {
+	a := tokenHashKey("oxp_one")
+	b := tokenHashKey("oxp_one")
+	c := tokenHashKey("oxp_two")
+	assert.Equal(t, a, b, "same input must produce same hash")
+	assert.NotEqual(t, a, c, "different inputs must produce different hashes")
+	assert.Len(t, a, 64, "sha256 hex is 64 chars")
+}
+
+// TestTokenMetaCachePath_InsideCacheDir — Failure prevented: cache file
+// escapes to an unexpected location and bypasses XDG isolation.
+func TestTokenMetaCachePath_InsideCacheDir(t *testing.T) {
+	tmp := withTempCacheDir(t)
+	path := tokenMetaCachePath()
+	// path should sit somewhere under tmp.
+	rel, err := filepath.Rel(tmp, path)
+	require.NoError(t, err)
+	assert.NotContains(t, rel, "..", "path must be inside the configured XDG cache dir")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,12 +18,18 @@ type Config struct {
 // Load creates a Config from environment variables only.
 // Runtime flags (--verbose, --json, etc.) are applied by the cobra layer in cli/context.go.
 func Load() *Config {
+	// Seed the user-config ephemeral preference before any subsystem consults
+	// ephemeral.IsEphemeral(). Commands like `ox distill --sync` decide about
+	// daemon startup during PersistentPreRun, so the persisted preference must
+	// be visible here even if no later code explicitly loads user config.
+	_, _ = LoadUserConfig()
+
 	return &Config{
-		Verbose:       os.Getenv("OX_VERBOSE") == "1",
-		Quiet:         os.Getenv("OX_QUIET") == "1",
-		JSON:          os.Getenv("OX_JSON") == "1",
-		Text:          os.Getenv("OX_TEXT") == "1",
-		Review:        os.Getenv("OX_REVIEW") == "1",
+		Verbose: os.Getenv("OX_VERBOSE") == "1",
+		Quiet:   os.Getenv("OX_QUIET") == "1",
+		JSON:    os.Getenv("OX_JSON") == "1",
+		Text:    os.Getenv("OX_TEXT") == "1",
+		Review:  os.Getenv("OX_REVIEW") == "1",
 		// ephemeral cloud agents (Claude Cloud, Devin, Codespaces, CI) have
 		// no TTY and no human at the keyboard — see internal/ephemeral/mode.go
 		NoInteractive: os.Getenv("OX_NO_INTERACTIVE") == "1" || ephemeral.IsEphemeral(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,9 +30,12 @@ func Load() *Config {
 		JSON:    os.Getenv("OX_JSON") == "1",
 		Text:    os.Getenv("OX_TEXT") == "1",
 		Review:  os.Getenv("OX_REVIEW") == "1",
-		// ephemeral cloud agents (Claude Cloud, Devin, Codespaces, CI) have
-		// no TTY and no human at the keyboard — see internal/ephemeral/mode.go
-		NoInteractive: os.Getenv("OX_NO_INTERACTIVE") == "1" || ephemeral.IsEphemeral(),
+		// CI runners and ephemeral cloud agents (Claude Cloud, Devin,
+		// Codespaces) both lack a TTY and a human at the keyboard. CI
+		// alone does NOT imply ephemeral (CI filesystems persist), but
+		// it does imply non-interactive — see internal/ephemeral/mode.go
+		// for the distinction.
+		NoInteractive: os.Getenv("OX_NO_INTERACTIVE") == "1" || isCI() || ephemeral.IsEphemeral(),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+
+	"github.com/sageox/ox/internal/ephemeral"
 )
 
 type Config struct {
@@ -10,7 +12,7 @@ type Config struct {
 	JSON          bool
 	Text          bool // human-readable text output (overrides JSON default)
 	Review        bool // security audit mode: both human summary and machine output
-	NoInteractive bool // disable spinners and TUI elements (auto-enabled in CI)
+	NoInteractive bool // disable spinners and TUI elements (auto-enabled in CI/ephemeral)
 }
 
 // Load creates a Config from environment variables only.
@@ -22,12 +24,24 @@ func Load() *Config {
 		JSON:          os.Getenv("OX_JSON") == "1",
 		Text:          os.Getenv("OX_TEXT") == "1",
 		Review:        os.Getenv("OX_REVIEW") == "1",
-		NoInteractive: os.Getenv("OX_NO_INTERACTIVE") == "1" || isCI(),
+		// ephemeral cloud agents (Claude Cloud, Devin, Codespaces, CI) have
+		// no TTY and no human at the keyboard — see internal/ephemeral/mode.go
+		NoInteractive: os.Getenv("OX_NO_INTERACTIVE") == "1" || ephemeral.IsEphemeral(),
 	}
+}
+
+// IsCI returns true if running in a CI environment.
+// Checks standard CI environment variables used by major CI providers.
+// Kept as a separate predicate from ephemeral.IsEphemeral() because some callers
+// want the narrower "is CI specifically" answer (e.g. test fixtures that
+// behave differently under a buildkite agent vs a Claude Cloud sandbox).
+func IsCI() bool {
+	return isCI()
 }
 
 // isCI returns true if running in a CI environment.
 // Checks standard CI environment variables used by major CI providers.
+// Keep this list in sync with internal/ephemeral/mode.go (envCI).
 func isCI() bool {
 	ciVars := []string{"CI", "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "BUILDKITE", "CODEBUILD_BUILD_ID"}
 	for _, v := range ciVars {

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/ephemeral"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func clearEphemeralSignalsForConfigTest(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"OX_EPHEMERAL",
+		"CLAUDE_CODE_REMOTE",
+		"DEVIN_TASK_ID",
+		"CODESPACES",
+		"CI",
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"JENKINS_URL",
+		"BUILDKITE",
+		"CODEBUILD_BUILD_ID",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+// TestLoad_SeedsEphemeralPreferenceFromUserConfig — Failure prevented: the
+// persisted `ephemeral: true` preference is ignored during early config load,
+// so commands start the daemon or render interactive UI before user config is
+// ever read.
+func TestLoad_SeedsEphemeralPreferenceFromUserConfig(t *testing.T) {
+	clearEphemeralSignalsForConfigTest(t)
+	ephemeral.SetUserConfigPreference(nil)
+	t.Cleanup(func() { ephemeral.SetUserConfigPreference(nil) })
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	cfgDir := filepath.Join(tmpDir, "sageox")
+	require.NoError(t, os.MkdirAll(cfgDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("ephemeral: true\n"), 0o644))
+
+	cfg := Load()
+	assert.True(t, cfg.NoInteractive, "ephemeral user config should force non-interactive mode during config load")
+	assert.True(t, ephemeral.IsEphemeral(), "Load should publish the user-config preference before early daemon/UI decisions")
+}

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/sageox/ox/internal/ephemeral"
 	"github.com/sageox/ox/internal/paths"
 	"gopkg.in/yaml.v3"
 )
@@ -342,6 +343,54 @@ type UserConfig struct {
 	// Hooks holds per-hook-event policy switches. Today only carries the
 	// UserPromptSubmit cloud_query opt-in; see HooksConfig for rationale.
 	Hooks *HooksConfig `yaml:"hooks,omitempty"`
+
+	// Ephemeral is the persisted user preference for ephemeral mode (no
+	// daemon, no local ledger clone, HTTP-only reads). Pointer so we can
+	// distinguish unset (nil) from explicit false. When non-nil, the value
+	// is published to internal/ephemeral at load time via
+	// ephemeral.SetUserConfigPreference, which treats it as the
+	// lowest-precedence signal — any env var, venue marker, or CI
+	// signal still overrides it. See docs/ai/adr/adr-ephemeral-mode.md.
+	Ephemeral *bool `yaml:"ephemeral,omitempty"`
+
+	// PATExpiryWarningThresholdPct is the fraction of token lifetime remaining
+	// at which to emit a single-line stderr warning during interactive
+	// commands. Default 0.05 (warn at 5% remaining). The effective threshold
+	// is max(PATExpiryWarningMinDays, lifetime*pct) — the floor still applies
+	// when this is zero. Set both this AND PATExpiryWarningMinDays to 0 to
+	// disable warnings entirely. Pointer keeps the zero/unset distinction.
+	PATExpiryWarningThresholdPct *float64 `yaml:"pat_expiry_warning_threshold_pct,omitempty"`
+
+	// PATExpiryWarningMinDays is the floor in days for the PAT expiry
+	// warning threshold (default 1). Combined with PATExpiryWarningThresholdPct
+	// via max(). Set to 0 with pct==0 to disable warnings entirely.
+	PATExpiryWarningMinDays *int `yaml:"pat_expiry_warning_min_days,omitempty"`
+}
+
+// PATExpiryWarningDefaults returns the default warning threshold (5%) and
+// minimum days floor (1) for PAT expiry warnings.
+func PATExpiryWarningDefaults() (pct float64, minDays int) {
+	return 0.05, 1
+}
+
+// GetPATExpiryWarningThresholdPct returns the configured threshold percentage,
+// defaulting to 0.05 when unset.
+func (c *UserConfig) GetPATExpiryWarningThresholdPct() float64 {
+	if c == nil || c.PATExpiryWarningThresholdPct == nil {
+		pct, _ := PATExpiryWarningDefaults()
+		return pct
+	}
+	return *c.PATExpiryWarningThresholdPct
+}
+
+// GetPATExpiryWarningMinDays returns the configured minimum-days floor,
+// defaulting to 1 when unset.
+func (c *UserConfig) GetPATExpiryWarningMinDays() int {
+	if c == nil || c.PATExpiryWarningMinDays == nil {
+		_, days := PATExpiryWarningDefaults()
+		return days
+	}
+	return *c.PATExpiryWarningMinDays
 }
 
 // BadgeConfig tracks badge suggestion state across all projects.
@@ -528,14 +577,33 @@ func (c *UserConfig) SetMurmurReceive(mode string) {
 // LoadUserConfig loads user configuration using standard path discovery.
 // Checks OX_USER_CONFIG env var first, then XDG/default paths.
 //
+// Also publishes the user's ephemeral-mode preference into
+// internal/ephemeral so subsystem checks pick it up without forming a
+// reverse import edge.
+//
 // For tests that need to load from an explicit directory, use LoadUserConfigFrom.
 func LoadUserConfig() (*UserConfig, error) {
 	// OX_USER_CONFIG overrides all path discovery — for CI/ephemeral environments
 	if envPath := os.Getenv(EnvUserConfig); envPath != "" {
-		return loadUserConfigFromFile(envPath)
+		cfg, err := loadUserConfigFromFile(envPath)
+		publishEphemeralPreference(cfg)
+		return cfg, err
 	}
 
-	return LoadUserConfigFrom("")
+	cfg, err := LoadUserConfigFrom("")
+	publishEphemeralPreference(cfg)
+	return cfg, err
+}
+
+// publishEphemeralPreference forwards the user-config Ephemeral pointer to
+// the ephemeral package so its lowest-precedence signal stays in sync with
+// disk. Tolerates nil cfg.
+func publishEphemeralPreference(cfg *UserConfig) {
+	if cfg == nil {
+		ephemeral.SetUserConfigPreference(nil)
+		return
+	}
+	ephemeral.SetUserConfigPreference(cfg.Ephemeral)
 }
 
 // LoadUserConfigFrom loads user configuration from the specified config directory.

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ephemeral"
 	"github.com/sageox/ox/internal/paths"
 )
 
@@ -27,9 +28,18 @@ var (
 )
 
 // IsDaemonDisabled returns true if the daemon has been explicitly disabled
-// via the SAGEOX_DAEMON=false environment variable.
+// via SAGEOX_DAEMON=false, or implicitly disabled because ox is running in
+// an ephemeral cloud agent (Claude Cloud, Devin, Codespaces, CI). Daemon
+// does not run in ephemeral cloud agents; see internal/ephemeral/mode.go.
 func IsDaemonDisabled() bool {
-	return strings.ToLower(os.Getenv("SAGEOX_DAEMON")) == "false"
+	if strings.ToLower(os.Getenv("SAGEOX_DAEMON")) == "false" {
+		return true
+	}
+	if ephemeral.IsEphemeral() {
+		slog.Debug("daemon disabled by ephemeral mode", "reason", ephemeral.Reason())
+		return true
+	}
+	return false
 }
 
 // Config holds daemon configuration settings.

--- a/internal/daemon/sync_bubbles_integration_test.go
+++ b/internal/daemon/sync_bubbles_integration_test.go
@@ -163,7 +163,7 @@ func TestSyncBubblesIntegration_APIMockToOnDisk(t *testing.T) {
 // corrupt local state — each endpoint's bubble checkouts live under
 // distinct XDG paths. ox-gzp.25 explicitly calls this out.
 //
-// Failure prevented: a developer flipping OX_ENDPOINT between
+// Failure prevented: a developer flipping SAGEOX_ENDPOINT between
 // staging/prod sees one endpoint's bubbles overwritten by the other.
 func TestSyncBubblesIntegration_EndpointSwitchMidFlight(t *testing.T) {
 	if testing.Short() {

--- a/internal/ephemeral/mode.go
+++ b/internal/ephemeral/mode.go
@@ -1,0 +1,155 @@
+// Package ephemeral provides a single source of truth for detecting when ox
+// is running inside an ephemeral environment (Claude Code Cloud, Devin,
+// GitHub Codespaces, generic CI, user-config opt-in, or explicit env
+// override). Subsystems should consult IsEphemeral() instead of growing
+// their own ad-hoc env-var checks.
+//
+// The mode is named "ephemeral" because the *behavior* is ephemeral (no
+// persistent daemon, no local ledger clone, no on-disk caches). The venue
+// may still be a cloud agent — that's just one of several triggers.
+//
+// Consumers today:
+//   - internal/config: NoInteractive auto-fires when ephemeral
+//   - internal/daemon: short-circuits daemon spawn in ephemeral mode
+//   - internal/kb:     skips the kb merger's network fan-out
+//   - (future) internal/codedb: skips Bleve indexer startup
+//
+// Precedence for Reason() (highest to lowest):
+//
+//	OX_EPHEMERAL  >  CLAUDE_CODE_REMOTE  >  DEVIN_TASK_ID  >  CODESPACES  >  CI  >  user-config
+//
+// Setting OX_EPHEMERAL=0 (or "false"/"no") does NOT force-disable ephemeral
+// mode — other signals (CI, Codespaces, user-config opt-in) still take
+// effect. To force non-ephemeral, unset every signal and set the user-config
+// value to false. The "explicit override" is one-way: on.
+package ephemeral
+
+import (
+	"os"
+	"strings"
+)
+
+// EnvEphemeral is the explicit override env var. Setting it to a truthy
+// value ("1", "true", "yes" — case-insensitive) forces ephemeral mode on,
+// even if no other signal is present.
+const EnvEphemeral = "OX_EPHEMERAL"
+
+// reasonUserConfig is the synthetic reason name returned when ephemeral
+// mode was triggered solely by the user-config layer. Not an env var.
+const reasonUserConfig = "user-config"
+
+// envCI mirrors the CI detection vars in internal/config/config.go (isCI).
+// Duplicated here intentionally to keep internal/ephemeral self-contained
+// — it is consumed by internal/config, so importing back would form a
+// cycle. Keep this list in sync with internal/config/config.go on changes.
+var envCI = []string{
+	"CI",
+	"GITHUB_ACTIONS",
+	"GITLAB_CI",
+	"JENKINS_URL",
+	"BUILDKITE",
+	"CODEBUILD_BUILD_ID",
+}
+
+// userConfigEphemeral is overridden by the config layer at process start
+// to wire in the user's persisted `ephemeral: true|false` preference
+// without forming an import cycle. The value is a pointer so we can
+// distinguish "unset" (nil) from explicit false. nil = no opinion.
+//
+// Reads are not synchronized — config loading happens once at process
+// start before any subsystem calls IsEphemeral(). If we ever need to
+// reload mid-run, swap in a sync/atomic.Pointer.
+var userConfigEphemeral *bool
+
+// SetUserConfigPreference is called by the config-loading code (which
+// imports this package, so the dep arrow stays one-way) to publish the
+// user-config value. Passing nil clears any prior setting.
+func SetUserConfigPreference(value *bool) {
+	userConfigEphemeral = value
+}
+
+// IsEphemeral returns true when ox is running in a short-lived cloud agent
+// or CI environment and should disable interactive UI, background daemons,
+// and unnecessary network fan-out.
+func IsEphemeral() bool {
+	return Reason() != ""
+}
+
+// Reason returns the source name that triggered ephemeral mode, or "" if
+// not ephemeral. Useful for structured logging (key=ephemeral_reason).
+// The returned value is either an env var name, a venue marker, or the
+// synthetic "user-config" string.
+func Reason() string {
+	if explicitEphemeral() {
+		return EnvEphemeral
+	}
+	if isClaudeCloud() {
+		return "CLAUDE_CODE_REMOTE"
+	}
+	if isDevin() {
+		return "DEVIN_TASK_ID"
+	}
+	if isCodespaces() {
+		return "CODESPACES"
+	}
+	if ciVar := matchedCIVar(); ciVar != "" {
+		return ciVar
+	}
+	if userConfigSaysOn() {
+		return reasonUserConfig
+	}
+	return ""
+}
+
+// explicitEphemeral returns true when OX_EPHEMERAL is set to a truthy value.
+// Empty / "0" / "false" / "no" / "off" all leave the flag off so the value
+// behaves like a standard boolean toggle.
+func explicitEphemeral() bool {
+	v := strings.TrimSpace(os.Getenv(EnvEphemeral))
+	if v == "" {
+		return false
+	}
+	switch strings.ToLower(v) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// userConfigSaysOn returns true when the user-config layer has explicitly
+// opted into ephemeral mode. nil and explicit false both return false.
+// It is the lowest-precedence signal: any higher source (env var, venue
+// marker, CI) overrides it. An explicit `ephemeral: false` in user config
+// simply does not contribute — it neither forces on nor forces off.
+func userConfigSaysOn() bool {
+	return userConfigEphemeral != nil && *userConfigEphemeral
+}
+
+// isClaudeCloud detects Claude Code Cloud (remote sandbox) by the presence
+// of CLAUDE_CODE_REMOTE in the environment.
+func isClaudeCloud() bool {
+	return os.Getenv("CLAUDE_CODE_REMOTE") != ""
+}
+
+// isDevin detects a Devin task runner by the presence of DEVIN_TASK_ID.
+func isDevin() bool {
+	return os.Getenv("DEVIN_TASK_ID") != ""
+}
+
+// isCodespaces detects a GitHub Codespace by the CODESPACES=true signal
+// that the platform injects into every workspace.
+func isCodespaces() bool {
+	return os.Getenv("CODESPACES") == "true"
+}
+
+// matchedCIVar returns the first CI env var that's set to a truthy value,
+// or "" if none match. Mirrors the truthiness check in internal/config.isCI.
+func matchedCIVar() string {
+	for _, v := range envCI {
+		val := os.Getenv(v)
+		if val != "" && val != "false" && val != "0" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/ephemeral/mode.go
+++ b/internal/ephemeral/mode.go
@@ -27,6 +27,7 @@ package ephemeral
 import (
 	"os"
 	"strings"
+	"sync/atomic"
 )
 
 // EnvEphemeral is the explicit override env var. Setting it to a truthy
@@ -56,16 +57,22 @@ var envCI = []string{
 // without forming an import cycle. The value is a pointer so we can
 // distinguish "unset" (nil) from explicit false. nil = no opinion.
 //
-// Reads are not synchronized — config loading happens once at process
-// start before any subsystem calls IsEphemeral(). If we ever need to
-// reload mid-run, swap in a sync/atomic.Pointer.
-var userConfigEphemeral *bool
+// The pointer is atomic because config lookups can happen from concurrent
+// goroutines during tests and daemon hot paths; copy the bool on Store so
+// callers can pass stack-local pointers safely.
+var userConfigEphemeral atomic.Pointer[bool]
 
 // SetUserConfigPreference is called by the config-loading code (which
 // imports this package, so the dep arrow stays one-way) to publish the
 // user-config value. Passing nil clears any prior setting.
 func SetUserConfigPreference(value *bool) {
-	userConfigEphemeral = value
+	if value == nil {
+		userConfigEphemeral.Store(nil)
+		return
+	}
+	copy := new(bool)
+	*copy = *value
+	userConfigEphemeral.Store(copy)
 }
 
 // IsEphemeral returns true when ox is running in a short-lived cloud agent
@@ -122,7 +129,8 @@ func explicitEphemeral() bool {
 // marker, CI) overrides it. An explicit `ephemeral: false` in user config
 // simply does not contribute — it neither forces on nor forces off.
 func userConfigSaysOn() bool {
-	return userConfigEphemeral != nil && *userConfigEphemeral
+	value := userConfigEphemeral.Load()
+	return value != nil && *value
 }
 
 // isClaudeCloud detects Claude Code Cloud (remote sandbox) by the presence

--- a/internal/ephemeral/mode.go
+++ b/internal/ephemeral/mode.go
@@ -1,27 +1,33 @@
 // Package ephemeral provides a single source of truth for detecting when ox
 // is running inside an ephemeral environment (Claude Code Cloud, Devin,
-// GitHub Codespaces, generic CI, user-config opt-in, or explicit env
-// override). Subsystems should consult IsEphemeral() instead of growing
-// their own ad-hoc env-var checks.
+// GitHub Codespaces, user-config opt-in, or explicit env override).
+// Subsystems should consult IsEphemeral() instead of growing their own
+// ad-hoc env-var checks.
 //
 // The mode is named "ephemeral" because the *behavior* is ephemeral (no
 // persistent daemon, no local ledger clone, no on-disk caches). The venue
 // may still be a cloud agent — that's just one of several triggers.
 //
+// IMPORTANT: generic CI signals (CI, GITHUB_ACTIONS, GITLAB_CI, ...) are NOT
+// considered ephemeral here. CI runners have writable filesystems and within
+// a job their state persists. They do trigger non-interactive UX, but that's
+// driven separately by internal/config.IsCI() — keep the two concepts
+// distinct or kb merger / codedb / etc. break in CI test environments.
+//
 // Consumers today:
-//   - internal/config: NoInteractive auto-fires when ephemeral
+//   - internal/config: NoInteractive auto-fires when ephemeral OR isCI
 //   - internal/daemon: short-circuits daemon spawn in ephemeral mode
-//   - internal/kb:     skips the kb merger's network fan-out
+//   - internal/kb:     skips the kb merger's network fan-out in ephemeral mode
 //   - (future) internal/codedb: skips Bleve indexer startup
 //
 // Precedence for Reason() (highest to lowest):
 //
-//	OX_EPHEMERAL  >  CLAUDE_CODE_REMOTE  >  DEVIN_TASK_ID  >  CODESPACES  >  CI  >  user-config
+//	OX_EPHEMERAL  >  CLAUDE_CODE_REMOTE  >  DEVIN_TASK_ID  >  CODESPACES  >  user-config
 //
 // Setting OX_EPHEMERAL=0 (or "false"/"no") does NOT force-disable ephemeral
-// mode — other signals (CI, Codespaces, user-config opt-in) still take
-// effect. To force non-ephemeral, unset every signal and set the user-config
-// value to false. The "explicit override" is one-way: on.
+// mode — other signals (Codespaces, user-config opt-in) still take effect.
+// To force non-ephemeral, unset every signal and set the user-config value
+// to false. The "explicit override" is one-way: on.
 package ephemeral
 
 import (
@@ -38,19 +44,6 @@ const EnvEphemeral = "OX_EPHEMERAL"
 // reasonUserConfig is the synthetic reason name returned when ephemeral
 // mode was triggered solely by the user-config layer. Not an env var.
 const reasonUserConfig = "user-config"
-
-// envCI mirrors the CI detection vars in internal/config/config.go (isCI).
-// Duplicated here intentionally to keep internal/ephemeral self-contained
-// — it is consumed by internal/config, so importing back would form a
-// cycle. Keep this list in sync with internal/config/config.go on changes.
-var envCI = []string{
-	"CI",
-	"GITHUB_ACTIONS",
-	"GITLAB_CI",
-	"JENKINS_URL",
-	"BUILDKITE",
-	"CODEBUILD_BUILD_ID",
-}
 
 // userConfigEphemeral is overridden by the config layer at process start
 // to wire in the user's persisted `ephemeral: true|false` preference
@@ -99,9 +92,6 @@ func Reason() string {
 	if isCodespaces() {
 		return "CODESPACES"
 	}
-	if ciVar := matchedCIVar(); ciVar != "" {
-		return ciVar
-	}
 	if userConfigSaysOn() {
 		return reasonUserConfig
 	}
@@ -148,16 +138,4 @@ func isDevin() bool {
 // that the platform injects into every workspace.
 func isCodespaces() bool {
 	return os.Getenv("CODESPACES") == "true"
-}
-
-// matchedCIVar returns the first CI env var that's set to a truthy value,
-// or "" if none match. Mirrors the truthiness check in internal/config.isCI.
-func matchedCIVar() string {
-	for _, v := range envCI {
-		val := os.Getenv(v)
-		if val != "" && val != "false" && val != "0" {
-			return v
-		}
-	}
-	return ""
 }

--- a/internal/ephemeral/mode_test.go
+++ b/internal/ephemeral/mode_test.go
@@ -1,0 +1,220 @@
+package ephemeral
+
+import (
+	"testing"
+)
+
+// resetUserConfig clears the user-config preference between subtests so
+// each one starts from a known nil state. The package-level var is
+// process-global; tests that set it must restore it.
+func resetUserConfig(t *testing.T) {
+	t.Helper()
+	prev := userConfigEphemeral
+	t.Cleanup(func() { userConfigEphemeral = prev })
+	userConfigEphemeral = nil
+}
+
+// clearEnv unsets every env var that IsEphemeral consults, so each subtest
+// starts from a clean baseline. t.Setenv handles per-test isolation and
+// restoration; we just need to zero-out the inherited shell environment.
+func clearEnv(t *testing.T) {
+	t.Helper()
+	vars := []string{
+		EnvEphemeral,
+		"CLAUDE_CODE_REMOTE",
+		"DEVIN_TASK_ID",
+		"CODESPACES",
+	}
+	vars = append(vars, envCI...)
+	for _, v := range vars {
+		t.Setenv(v, "")
+	}
+}
+
+func TestIsEphemeral_CleanEnv(t *testing.T) {
+	clearEnv(t)
+	if IsEphemeral() {
+		t.Fatalf("expected IsEphemeral=false on clean env, got true (reason=%q)", Reason())
+	}
+	if got := Reason(); got != "" {
+		t.Fatalf("expected Reason=\"\" on clean env, got %q", got)
+	}
+}
+
+func TestIsEphemeral_ExplicitOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"one", "1", true},
+		{"true_lower", "true", true},
+		{"true_mixed", "True", true},
+		{"yes", "yes", true},
+		{"on", "on", true},
+		{"zero", "0", false},
+		{"false", "false", false},
+		{"no", "no", false},
+		{"empty", "", false},
+		{"whitespace_truthy", "  1  ", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			clearEnv(t)
+			t.Setenv(EnvEphemeral, tc.val)
+			if got := IsEphemeral(); got != tc.want {
+				t.Fatalf("OX_EPHEMERAL=%q: IsEphemeral=%v, want %v (reason=%q)", tc.val, got, tc.want, Reason())
+			}
+		})
+	}
+}
+
+func TestIsEphemeral_IndividualSignals(t *testing.T) {
+	cases := []struct {
+		name   string
+		env    string
+		val    string
+		want   bool
+		reason string
+	}{
+		{"claude_cloud", "CLAUDE_CODE_REMOTE", "1", true, "CLAUDE_CODE_REMOTE"},
+		{"claude_cloud_any_value", "CLAUDE_CODE_REMOTE", "task-abc", true, "CLAUDE_CODE_REMOTE"},
+		{"devin", "DEVIN_TASK_ID", "t_xyz", true, "DEVIN_TASK_ID"},
+		{"codespaces_true", "CODESPACES", "true", true, "CODESPACES"},
+		{"codespaces_other", "CODESPACES", "1", false, ""},
+		{"ci_generic", "CI", "true", true, "CI"},
+		{"github_actions", "GITHUB_ACTIONS", "true", true, "GITHUB_ACTIONS"},
+		{"gitlab_ci", "GITLAB_CI", "true", true, "GITLAB_CI"},
+		{"jenkins", "JENKINS_URL", "http://jenkins.example", true, "JENKINS_URL"},
+		{"buildkite", "BUILDKITE", "true", true, "BUILDKITE"},
+		{"codebuild", "CODEBUILD_BUILD_ID", "build:abc", true, "CODEBUILD_BUILD_ID"},
+		{"ci_false", "CI", "false", false, ""},
+		{"ci_zero", "CI", "0", false, ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			clearEnv(t)
+			t.Setenv(tc.env, tc.val)
+			if got := IsEphemeral(); got != tc.want {
+				t.Fatalf("%s=%q: IsEphemeral=%v, want %v", tc.env, tc.val, got, tc.want)
+			}
+			if got := Reason(); got != tc.reason {
+				t.Fatalf("%s=%q: Reason=%q, want %q", tc.env, tc.val, got, tc.reason)
+			}
+		})
+	}
+}
+
+func TestReason_Precedence(t *testing.T) {
+	// when multiple signals fire, Reason returns the highest-precedence one:
+	// OX_EPHEMERAL > CLAUDE_CODE_REMOTE > DEVIN_TASK_ID > CODESPACES > CI
+	clearEnv(t)
+	t.Setenv(EnvEphemeral, "1")
+	t.Setenv("CLAUDE_CODE_REMOTE", "1")
+	t.Setenv("DEVIN_TASK_ID", "x")
+	t.Setenv("CODESPACES", "true")
+	t.Setenv("CI", "true")
+	if got := Reason(); got != EnvEphemeral {
+		t.Fatalf("expected OX_EPHEMERAL to win precedence, got %q", got)
+	}
+
+	clearEnv(t)
+	t.Setenv("CLAUDE_CODE_REMOTE", "1")
+	t.Setenv("DEVIN_TASK_ID", "x")
+	t.Setenv("CODESPACES", "true")
+	t.Setenv("CI", "true")
+	if got := Reason(); got != "CLAUDE_CODE_REMOTE" {
+		t.Fatalf("expected CLAUDE_CODE_REMOTE to beat DEVIN/CODESPACES/CI, got %q", got)
+	}
+
+	clearEnv(t)
+	t.Setenv("DEVIN_TASK_ID", "x")
+	t.Setenv("CODESPACES", "true")
+	t.Setenv("CI", "true")
+	if got := Reason(); got != "DEVIN_TASK_ID" {
+		t.Fatalf("expected DEVIN_TASK_ID to beat CODESPACES/CI, got %q", got)
+	}
+
+	clearEnv(t)
+	t.Setenv("CODESPACES", "true")
+	t.Setenv("CI", "true")
+	if got := Reason(); got != "CODESPACES" {
+		t.Fatalf("expected CODESPACES to beat CI, got %q", got)
+	}
+}
+
+func TestIndividualHelpers(t *testing.T) {
+	clearEnv(t)
+	if isClaudeCloud() || isDevin() || isCodespaces() {
+		t.Fatalf("expected all individual helpers false on clean env")
+	}
+
+	t.Setenv("CLAUDE_CODE_REMOTE", "1")
+	if !isClaudeCloud() {
+		t.Fatalf("isClaudeCloud should be true")
+	}
+
+	clearEnv(t)
+	t.Setenv("DEVIN_TASK_ID", "t1")
+	if !isDevin() {
+		t.Fatalf("isDevin should be true")
+	}
+
+	clearEnv(t)
+	t.Setenv("CODESPACES", "true")
+	if !isCodespaces() {
+		t.Fatalf("isCodespaces should be true")
+	}
+	// only the literal "true" string activates Codespaces
+	t.Setenv("CODESPACES", "yes")
+	if isCodespaces() {
+		t.Fatalf("isCodespaces should require exact \"true\"")
+	}
+}
+
+// TestIsEphemeral_UserConfigOnly verifies that a user-config opt-in flips
+// IsEphemeral() to true even when no env var or venue marker is set.
+// Failure prevented: regression where the user-config layer is plumbed
+// in but Reason() forgets to consult it, so the persisted preference
+// silently does nothing.
+func TestIsEphemeral_UserConfigOnly(t *testing.T) {
+	clearEnv(t)
+	resetUserConfig(t)
+
+	if IsEphemeral() {
+		t.Fatalf("clean baseline must be non-ephemeral, got reason=%q", Reason())
+	}
+
+	on := true
+	SetUserConfigPreference(&on)
+
+	if !IsEphemeral() {
+		t.Fatalf("user-config=true must flip IsEphemeral() on")
+	}
+	if got := Reason(); got != reasonUserConfig {
+		t.Fatalf("expected Reason=%q, got %q", reasonUserConfig, got)
+	}
+}
+
+// TestIsEphemeral_EnvOverridesUserConfigDisable verifies that
+// OX_EPHEMERAL=1 wins even when the user has persisted ephemeral=false.
+// Failure prevented: a future refactor accidentally inverts precedence so
+// a stale user-config setting suppresses an explicit per-invocation
+// env override.
+func TestIsEphemeral_EnvOverridesUserConfigDisable(t *testing.T) {
+	clearEnv(t)
+	resetUserConfig(t)
+
+	off := false
+	SetUserConfigPreference(&off)
+	t.Setenv(EnvEphemeral, "1")
+
+	if !IsEphemeral() {
+		t.Fatalf("OX_EPHEMERAL=1 must override user-config=false, got reason=%q", Reason())
+	}
+	if got := Reason(); got != EnvEphemeral {
+		t.Fatalf("expected Reason=%q, got %q", EnvEphemeral, got)
+	}
+}

--- a/internal/ephemeral/mode_test.go
+++ b/internal/ephemeral/mode_test.go
@@ -17,6 +17,10 @@ func resetUserConfig(t *testing.T) {
 // clearEnv unsets every env var that IsEphemeral consults, so each subtest
 // starts from a clean baseline. t.Setenv handles per-test isolation and
 // restoration; we just need to zero-out the inherited shell environment.
+//
+// CI-related vars (CI, GITHUB_ACTIONS, ...) are also cleared so the test
+// suite is deterministic on CI runners; they no longer contribute to
+// IsEphemeral but presence here defends against future regressions.
 func clearEnv(t *testing.T) {
 	t.Helper()
 	vars := []string{
@@ -24,8 +28,13 @@ func clearEnv(t *testing.T) {
 		"CLAUDE_CODE_REMOTE",
 		"DEVIN_TASK_ID",
 		"CODESPACES",
+		"CI",
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"JENKINS_URL",
+		"BUILDKITE",
+		"CODEBUILD_BUILD_ID",
 	}
-	vars = append(vars, envCI...)
 	for _, v := range vars {
 		t.Setenv(v, "")
 	}
@@ -83,14 +92,16 @@ func TestIsEphemeral_IndividualSignals(t *testing.T) {
 		{"devin", "DEVIN_TASK_ID", "t_xyz", true, "DEVIN_TASK_ID"},
 		{"codespaces_true", "CODESPACES", "true", true, "CODESPACES"},
 		{"codespaces_other", "CODESPACES", "1", false, ""},
-		{"ci_generic", "CI", "true", true, "CI"},
-		{"github_actions", "GITHUB_ACTIONS", "true", true, "GITHUB_ACTIONS"},
-		{"gitlab_ci", "GITLAB_CI", "true", true, "GITLAB_CI"},
-		{"jenkins", "JENKINS_URL", "http://jenkins.example", true, "JENKINS_URL"},
-		{"buildkite", "BUILDKITE", "true", true, "BUILDKITE"},
-		{"codebuild", "CODEBUILD_BUILD_ID", "build:abc", true, "CODEBUILD_BUILD_ID"},
-		{"ci_false", "CI", "false", false, ""},
-		{"ci_zero", "CI", "0", false, ""},
+		// CI signals deliberately do NOT trigger ephemeral mode — CI runners
+		// have writable filesystems and within a job their state persists.
+		// They only drive non-interactive UX, which is handled separately by
+		// internal/config.IsCI. See package doc.
+		{"ci_generic", "CI", "true", false, ""},
+		{"github_actions", "GITHUB_ACTIONS", "true", false, ""},
+		{"gitlab_ci", "GITLAB_CI", "true", false, ""},
+		{"jenkins", "JENKINS_URL", "http://jenkins.example", false, ""},
+		{"buildkite", "BUILDKITE", "true", false, ""},
+		{"codebuild", "CODEBUILD_BUILD_ID", "build:abc", false, ""},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -109,13 +120,12 @@ func TestIsEphemeral_IndividualSignals(t *testing.T) {
 
 func TestReason_Precedence(t *testing.T) {
 	// when multiple signals fire, Reason returns the highest-precedence one:
-	// OX_EPHEMERAL > CLAUDE_CODE_REMOTE > DEVIN_TASK_ID > CODESPACES > CI
+	// OX_EPHEMERAL > CLAUDE_CODE_REMOTE > DEVIN_TASK_ID > CODESPACES > user-config
 	clearEnv(t)
 	t.Setenv(EnvEphemeral, "1")
 	t.Setenv("CLAUDE_CODE_REMOTE", "1")
 	t.Setenv("DEVIN_TASK_ID", "x")
 	t.Setenv("CODESPACES", "true")
-	t.Setenv("CI", "true")
 	if got := Reason(); got != EnvEphemeral {
 		t.Fatalf("expected OX_EPHEMERAL to win precedence, got %q", got)
 	}
@@ -124,24 +134,41 @@ func TestReason_Precedence(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_REMOTE", "1")
 	t.Setenv("DEVIN_TASK_ID", "x")
 	t.Setenv("CODESPACES", "true")
-	t.Setenv("CI", "true")
 	if got := Reason(); got != "CLAUDE_CODE_REMOTE" {
-		t.Fatalf("expected CLAUDE_CODE_REMOTE to beat DEVIN/CODESPACES/CI, got %q", got)
+		t.Fatalf("expected CLAUDE_CODE_REMOTE to beat DEVIN/CODESPACES, got %q", got)
 	}
 
 	clearEnv(t)
 	t.Setenv("DEVIN_TASK_ID", "x")
 	t.Setenv("CODESPACES", "true")
-	t.Setenv("CI", "true")
 	if got := Reason(); got != "DEVIN_TASK_ID" {
-		t.Fatalf("expected DEVIN_TASK_ID to beat CODESPACES/CI, got %q", got)
+		t.Fatalf("expected DEVIN_TASK_ID to beat CODESPACES, got %q", got)
 	}
 
 	clearEnv(t)
 	t.Setenv("CODESPACES", "true")
-	t.Setenv("CI", "true")
 	if got := Reason(); got != "CODESPACES" {
-		t.Fatalf("expected CODESPACES to beat CI, got %q", got)
+		t.Fatalf("expected CODESPACES to win when set alone, got %q", got)
+	}
+}
+
+// TestCISignalsDoNotTriggerEphemeral defends the invariant that CI=true
+// does NOT enable ephemeral mode. Regression: when this list was wired in,
+// every kb merge test failed in CI runs because kb sync was incorrectly
+// disabled. CI affects interactivity, not filesystem persistence.
+func TestCISignalsDoNotTriggerEphemeral(t *testing.T) {
+	ciVars := []string{
+		"CI", "GITHUB_ACTIONS", "GITLAB_CI",
+		"JENKINS_URL", "BUILDKITE", "CODEBUILD_BUILD_ID",
+	}
+	for _, v := range ciVars {
+		t.Run(v, func(t *testing.T) {
+			clearEnv(t)
+			t.Setenv(v, "true")
+			if IsEphemeral() {
+				t.Fatalf("%s=true must not enable ephemeral mode (reason=%q)", v, Reason())
+			}
+		})
 	}
 }
 

--- a/internal/ephemeral/mode_test.go
+++ b/internal/ephemeral/mode_test.go
@@ -9,9 +9,9 @@ import (
 // process-global; tests that set it must restore it.
 func resetUserConfig(t *testing.T) {
 	t.Helper()
-	prev := userConfigEphemeral
-	t.Cleanup(func() { userConfigEphemeral = prev })
-	userConfigEphemeral = nil
+	prev := userConfigEphemeral.Load()
+	t.Cleanup(func() { userConfigEphemeral.Store(prev) })
+	userConfigEphemeral.Store(nil)
 }
 
 // clearEnv unsets every env var that IsEphemeral consults, so each subtest

--- a/internal/kb/merge.go
+++ b/internal/kb/merge.go
@@ -36,6 +36,7 @@ import (
 	"sync"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/ephemeral"
 	"github.com/sageox/ox/internal/endpoint"
 )
 
@@ -188,9 +189,15 @@ func NewMerger(kb KBSource, teams LegacyTeamSource, ledger LedgerSource) *Merger
 }
 
 // kbDisabledByEnv returns true when OX_KB_DISABLE is set to a value
-// commonly understood as "on". Empty / "0" / "false" all leave the kb
-// source enabled.
+// commonly understood as "on", OR when ox is running in an ephemeral cloud
+// agent (Claude Cloud, Devin, Codespaces, CI) — see internal/ephemeral/mode.go.
+// Empty / "0" / "false" all leave the kb source enabled unless ephemeral
+// mode is on. Ephemeral agents skip the kb fan-out to avoid unnecessary
+// API calls during short-lived runs.
 func kbDisabledByEnv() bool {
+	if ephemeral.IsEphemeral() {
+		return true
+	}
 	v := strings.TrimSpace(os.Getenv(envDisableKBSource))
 	if v == "" {
 		return false

--- a/internal/prime/types.go
+++ b/internal/prime/types.go
@@ -297,6 +297,24 @@ type UserNotice struct {
 	Message string `json:"message"`
 }
 
+// EphemeralHint surfaces, in the prime payload, that ox is running in an
+// ephemeral environment (cloud agent, CI, Codespaces) with sparse local
+// data. When emitted, the calling agent should prefer the cloud MCP server
+// for context operations that would normally hit local codedb / KB / team-
+// context caches.
+//
+// Emitted only when ephemeral.IsEphemeral() returns true. LocalDataSparse
+// is true when no local team-context clone exists (HTTP fallback may have
+// written a subset) AND/OR no codedb index is available.
+type EphemeralHint struct {
+	Active           bool     `json:"active"`
+	Reason           string   `json:"reason,omitempty"`             // env var or venue marker that triggered ephemeral mode
+	LocalDataSparse  bool     `json:"local_data_sparse,omitempty"`  // true when local caches are missing/partial
+	CloudMCPEndpoint string   `json:"cloud_mcp_endpoint,omitempty"` // e.g. https://api.sageox.ai/mcp
+	Recommendation   string   `json:"recommendation,omitempty"`     // single-line guidance for the agent
+	SuggestedTools   []string `json:"suggested_tools,omitempty"`    // cloud MCP tool names to prefer
+}
+
 // Output is the structured response for agent bootstrap (prime)
 type Output struct {
 	Status           string                     `json:"status"` // fresh, degraded, unavailable
@@ -367,4 +385,8 @@ type Output struct {
 	// Per-step timing instrumentation
 	ElapsedMs int64            `json:"elapsed_ms,omitempty"` // total prime execution time
 	Timing    map[string]int64 `json:"timing,omitempty"`     // per-phase timing (ms)
+	// Ephemeral-mode hint: nil when not in ephemeral mode. When set, agents
+	// should prefer the cloud MCP server for context ops since local caches
+	// are sparse. See docs/ai/adr/adr-ephemeral-mode.md.
+	EphemeralHint *EphemeralHint `json:"ephemeral_hint,omitempty"`
 }

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -655,7 +655,7 @@ func isAllowlisted(name string) bool {
 		return true
 	}
 	// OX_* protocol vars are always passed through — EXCEPT names matching
-	// the credential denylist (e.g. OX_TOKEN), which must never leak to
+	// the credential denylist, which must never leak to
 	// adapter subprocesses regardless of prefix.
 	if strings.HasPrefix(name, "OX_") {
 		return !isDenylisted(name)

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -654,9 +654,11 @@ func isAllowlisted(name string) bool {
 	if allowlistedEnvVars[name] {
 		return true
 	}
-	// OX_* protocol vars are always passed through
+	// OX_* protocol vars are always passed through — EXCEPT names matching
+	// the credential denylist (e.g. OX_TOKEN), which must never leak to
+	// adapter subprocesses regardless of prefix.
 	if strings.HasPrefix(name, "OX_") {
-		return true
+		return !isDenylisted(name)
 	}
 	for _, prefix := range allowlistedEnvPrefixes {
 		if strings.HasPrefix(name, prefix) {

--- a/internal/session/adapters/sanitized_env_test.go
+++ b/internal/session/adapters/sanitized_env_test.go
@@ -38,7 +38,6 @@ func TestSanitizedEnv_AllowlistedVarsPassThrough(t *testing.T) {
 		"TMPDIR=/tmp",
 		"ANTHROPIC_API_KEY=sk-secret-key",
 		"SAGEOX_TOKEN=tok-abc123",
-		"OX_TOKEN=oxp-abc123",
 		"SECRET_TOKEN=hunter2",
 	}
 
@@ -53,7 +52,7 @@ func TestSanitizedEnv_AllowlistedVarsPassThrough(t *testing.T) {
 	}
 
 	// secrets must be stripped
-	for _, key := range []string{"ANTHROPIC_API_KEY", "SAGEOX_TOKEN", "OX_TOKEN", "SECRET_TOKEN"} {
+	for _, key := range []string{"ANTHROPIC_API_KEY", "SAGEOX_TOKEN", "SECRET_TOKEN"} {
 		if _, ok := m[key]; ok {
 			t.Errorf("%s must not be in sanitized env", key)
 		}
@@ -231,7 +230,6 @@ func TestSanitizedEnv_SecretsStripped(t *testing.T) {
 	secrets := []string{
 		"ANTHROPIC_API_KEY=sk-ant-secret",
 		"SAGEOX_TOKEN=tok-sageox",
-		"OX_TOKEN=oxp-test",
 		"SAGEOX_ENDPOINT=https://api.sageox.ai",
 		"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
 		"OPENAI_API_KEY=sk-openai",
@@ -376,7 +374,6 @@ func TestIsAllowlisted(t *testing.T) {
 		{"OX_TEAM_ID", true},
 		{"ANTHROPIC_API_KEY", false},
 		{"SAGEOX_TOKEN", false},
-		{"OX_TOKEN", false},
 		{"EDITOR", false},
 		{"SHELL", false},
 		{"XDGFAKE", false},  // no underscore, not a real XDG var

--- a/internal/session/adapters/sanitized_env_test.go
+++ b/internal/session/adapters/sanitized_env_test.go
@@ -38,6 +38,7 @@ func TestSanitizedEnv_AllowlistedVarsPassThrough(t *testing.T) {
 		"TMPDIR=/tmp",
 		"ANTHROPIC_API_KEY=sk-secret-key",
 		"SAGEOX_TOKEN=tok-abc123",
+		"OX_TOKEN=oxp-abc123",
 		"SECRET_TOKEN=hunter2",
 	}
 
@@ -52,7 +53,7 @@ func TestSanitizedEnv_AllowlistedVarsPassThrough(t *testing.T) {
 	}
 
 	// secrets must be stripped
-	for _, key := range []string{"ANTHROPIC_API_KEY", "SAGEOX_TOKEN", "SECRET_TOKEN"} {
+	for _, key := range []string{"ANTHROPIC_API_KEY", "SAGEOX_TOKEN", "OX_TOKEN", "SECRET_TOKEN"} {
 		if _, ok := m[key]; ok {
 			t.Errorf("%s must not be in sanitized env", key)
 		}
@@ -230,6 +231,7 @@ func TestSanitizedEnv_SecretsStripped(t *testing.T) {
 	secrets := []string{
 		"ANTHROPIC_API_KEY=sk-ant-secret",
 		"SAGEOX_TOKEN=tok-sageox",
+		"OX_TOKEN=oxp-test",
 		"SAGEOX_ENDPOINT=https://api.sageox.ai",
 		"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
 		"OPENAI_API_KEY=sk-openai",
@@ -374,6 +376,7 @@ func TestIsAllowlisted(t *testing.T) {
 		{"OX_TEAM_ID", true},
 		{"ANTHROPIC_API_KEY", false},
 		{"SAGEOX_TOKEN", false},
+		{"OX_TOKEN", false},
 		{"EDITOR", false},
 		{"SHELL", false},
 		{"XDGFAKE", false},  // no underscore, not a real XDG var


### PR DESCRIPTION
## Summary

Adds non-interactive auth (\`OX_TOKEN\`/\`SAGEOX_TOKEN\` env var) and a unified \`ephemeral.IsEphemeral()\` predicate so \`ox\` runs in Claude Code Cloud, Devin, Codespaces, and CI without daemon/clone/browser. New \`--ephemeral\` flag on \`ox agent prime\` + HTTP team-context fallback (\`GET /api/v1/teams/:id/context\`) when no daemon is available. Adds PAT expiry warnings (\`max(1d, 5%)\` threshold, configurable) with 1h \`/auth/me\` cache, cloud MCP guidance in prime payload when local data sparse, and ephemeral surfacing in \`ox doctor\`. Foundation for GH #103; sets up GH #102 Phase 2 (session upload over HTTP).

\`\`\`mermaid
flowchart LR
  subgraph Cloud["Ephemeral cloud agent (Claude Cloud, Devin, CI)"]
    A["SessionStart hook"] --> B["ox agent prime to ephemeral"]
    B --> C["OX_TOKEN from env"]
  end
  subgraph SageOx["api.sageox.ai"]
    E["Better Auth apiKey verify"]
    F["GET /api/v1/teams/:id/context"]
    G["GET /api/v1/auth/me"]
  end
  C -.bearer.-> E
  B -.fetch.-> F
  B -.expiry meta.-> G
\`\`\`

## Test Plan

- \`go build ./...\` clean
- \`go test ./internal/auth/... ./internal/ephemeral/... ./internal/api/... ./cmd/ox/...\` all green (17 new tests across env-token, expiry-warn, meta-cache, team-context, ephemeral fallback)
- Manual smoke: \`OX_EPHEMERAL=1 OX_TOKEN=fake go run ./cmd/ox agent prime --ephemeral --text\` runs to completion, daemon skipped, HTTP fallback exercised
- \`ox doctor\` surfaces \`Ephemeral mode: ACTIVE (<reason>)\` / \`INACTIVE — daemon socket: …\`
- \`OX_TOKEN\` confirmed denylisted from adapter subprocess env (caught by sanitized-env regression test)

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (17 new tests across 6 packages)
- [ ] CHANGELOG entry deferred to release-bump PR
- [x] Breaking change documented — none; \`OX_TOKEN\` is additive, env-token bypasses refresh
- [x] Ran \`/security-review\` self-attestation: touches \`internal/auth/\` heavily; mitigations include token-redaction across adapter env, env-token-skips-refresh contract, atomic 0600 cache file. Daily-batch will catch any residual.

</details>

Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ephemeral mode for short-lived/cloud environments (HTTP-first CLI, daemon/local ledger skipped).
  * Agent bootstrap now includes an ephemeral hint to guide ephemeral execution.
  * Team context can fall back to fetching from the cloud when no local repo/daemon exists.
  * Commands surface PAT expiry warnings to proactively alert about token expiry.

* **Documentation**
  * Added an ADR and changelog entries describing ephemeral-mode behavior and env-var guidance.

* **Tests**
  * Extensive tests added for ephemeral fallback, token/env handling, expiry warnings, and caching.

* **Chores**
  * Standardized customer-facing env vars to SAGEOX_* and blocked legacy OX_* usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->