### PR TITLE
feat(session): pause/resume + ADR-019/020 session entity lifecycle (#134)

### DIFF
--- a/.claude/commands/ox-session-pause.md
+++ b/.claude/commands/ox-session-pause.md
@@ -1,0 +1,12 @@
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
+Suspend the current session recording. Local cache continues to receive entries, but the upload at stop time will exclude the suspended range.
+
+## Post-Command
+
+After the command completes, check the JSON output for the `guidance` field. Tell the user the recording is suspended and how to resume (`/ox-session-resume`).
+
+While suspended, ox will inject a one-line reminder on each user prompt so the user can't forget.
+
+$ox agent session pause

--- a/.claude/commands/ox-session-resume.md
+++ b/.claude/commands/ox-session-resume.md
@@ -1,0 +1,10 @@
+<!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
+     belongs in the ox CLI JSON output (guidance field), not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
+Resume a previously suspended session recording. Closes the open pause range; the suspended interval will be excluded from upload at stop time.
+
+## Post-Command
+
+After the command completes, check the JSON output for the `guidance`, `excluded_entries`, and `paused_duration` fields. Tell the user that recording is resumed and briefly mention how much was excluded (e.g., "Recording resumed. 12 entries over 4m 30s excluded.").
+
+$ox agent session resume

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -277,6 +277,8 @@ var validSessionSubcommands = map[string]bool{
 	"start":             true,
 	"stop":              true,
 	"abort":             true,
+	"pause":             true,
+	"resume":            true,
 	"delete":            true,
 	"log":               true,
 	"remind":            true,
@@ -526,10 +528,14 @@ func runWithAgentID(cmd *cobra.Command, agentID string, args []string) error {
 			return runAgentSessionRecover(inst)
 		case "abort":
 			return runAgentSessionAbort(inst, cmd, sessionArgs)
+		case "pause":
+			return runAgentSessionPause(inst, sessionArgs)
+		case "resume":
+			return runAgentSessionResume(inst, sessionArgs)
 		case "delete":
 			return runAgentSessionDelete(inst, cmd, sessionArgs)
 		default:
-			return fmt.Errorf("unknown session command: %s\nAvailable: start, stop, abort, delete, log, remind, summarize, record, plan, context-trace, import, capture-prior, subagent-complete, subagent-list, recover", sessionCmd)
+			return fmt.Errorf("unknown session command: %s\nAvailable: start, stop, abort, pause, resume, delete, log, remind, summarize, record, plan, context-trace, import, capture-prior, subagent-complete, subagent-list, recover", sessionCmd)
 		}
 	case "query":
 		return runAgentQuery(inst, subargs)

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -71,6 +71,10 @@ type HookContext struct {
 	Input       *agentx.HookInput // parsed stdin JSON
 	Marker      *SessionMarker    // nil if not yet primed
 	ProjectRoot string            // git root with .sageox/
+
+	// ClearNotice carries finalized-prior-session info from stopSessionForClear
+	// to the prime subprocess so prime can emit a user-facing notice. See ADR-019.
+	ClearNotice *ClearNoticeInfo
 }
 
 // runAgentHook is the entry point for `ox agent hook <event>`.
@@ -299,11 +303,19 @@ func handleStart(ctx *HookContext) error {
 // This finalizes the old session so it gets uploaded, then prime starts a fresh one.
 // Sets StoppedAt, sends fire-and-forget IPC finalization to the daemon, and clears
 // recording state so prime can start a fresh session.
+//
+// As a side effect, populates ctx.ClearNotice with finalized-session info so the
+// downstream prime subprocess can render a user-facing notice describing the
+// boundary transition (see ADR-019).
 func stopSessionForClear(ctx *HookContext, agentID string) {
 	state, err := session.LoadRecordingStateForAgent(ctx.ProjectRoot, agentID)
 	if err != nil || state == nil {
 		return // not recording, nothing to stop
 	}
+
+	// capture finalized-session info for the post-clear notice (ADR-019).
+	// done before we mutate state so SessionPath is still accurate.
+	ctx.ClearNotice = buildClearNoticeFromState(state)
 
 	// set StoppedAt to signal this session is complete
 	now := time.Now()
@@ -474,8 +486,30 @@ func handlePrompt(ctx *HookContext) error {
 	if agentID == "" {
 		return nil
 	}
+
+	// ADR-020: emit a per-prompt nudge while the session is suspended. This
+	// fires on every UserPromptSubmit so the user cannot silently forget that
+	// recording is paused. Scoped to the current agent's suspended session
+	// only — other agents' paused sessions in this repo do not bleed into
+	// this terminal's nudge.
+	emitSuspendedNudge(os.Stdout, ctx.ProjectRoot, agentID)
+
 	emitWhispers(os.Stdout, agentID)
 	return nil
+}
+
+// emitSuspendedNudge writes a single-line system reminder to stdout when
+// the current agent's recording is suspended. No-op when not suspended.
+func emitSuspendedNudge(w io.Writer, projectRoot, agentID string) {
+	if projectRoot == "" || agentID == "" {
+		return
+	}
+	state, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	if err != nil || state == nil || state.SuspendedAt == nil {
+		return
+	}
+	dur := formatPausedDuration(time.Since(*state.SuspendedAt))
+	fmt.Fprintf(w, "<system-reminder>[ox] ⏸ Recording SUSPENDED (%s ago). Resume: /ox-session-resume · Stop: /ox-session-stop</system-reminder>\n", dur)
 }
 
 // handleCompact handles the compact phase.
@@ -760,6 +794,9 @@ func runPrimeForHook(agentID string, ctx *HookContext) error {
 
 	cmd := exec.Command(oxPath, args...)
 	env := buildPrimeEnv(agentID)
+	if pair := serializeClearNoticeEnv(ctx.ClearNotice); pair != "" {
+		env = append(env, pair)
+	}
 	cmd.Env = env
 	// pass original raw bytes to preserve unknown fields (not re-serialized)
 	if ctx.Input != nil && len(ctx.Input.RawBytes) > 0 {

--- a/cmd/ox/agent_hook_pause_nudge_test.go
+++ b/cmd/ox/agent_hook_pause_nudge_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// suspendedNudgeProject builds a minimal initialized project root + cache
+// directory wired the same way the hook tests do (XDG-rooted, .sageox/config.json
+// with repo_id and endpoint set so the canonical sessions write path resolves).
+func suspendedNudgeProject(t *testing.T) string {
+	t.Helper()
+	cacheDir := t.TempDir()
+	projectRoot := t.TempDir()
+
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0755))
+	cfg := `{"config_version":"2","repo_id":"test-repo-pause","endpoint":"http://test.sageox.local","session_publishing":"manual"}`
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(cfg), 0644))
+
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("HOME", cacheDir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+	t.Setenv("XDG_DATA_HOME", cacheDir)
+	return projectRoot
+}
+
+func TestEmitSuspendedNudge_WhileSuspended(t *testing.T) {
+	projectRoot := suspendedNudgeProject(t)
+	agentID := "Oxa7b3"
+
+	state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+		AgentID:     agentID,
+		AdapterName: "claude-code",
+		Username:    "testuser",
+	})
+	require.NoError(t, err)
+	paused := time.Now().UTC().Add(-3 * time.Minute)
+	state.SuspendedAt = &paused
+	require.NoError(t, session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+		s.SuspendedAt = &paused
+	}))
+
+	var buf bytes.Buffer
+	emitSuspendedNudge(&buf, projectRoot, agentID)
+
+	got := buf.String()
+	assert.Contains(t, got, "<system-reminder>")
+	assert.Contains(t, got, "Recording SUSPENDED")
+	assert.Contains(t, got, "/ox-session-resume")
+}
+
+func TestEmitSuspendedNudge_NotSuspended(t *testing.T) {
+	projectRoot := suspendedNudgeProject(t)
+	agentID := "Oxa7b3"
+
+	_, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+		AgentID:     agentID,
+		AdapterName: "claude-code",
+		Username:    "testuser",
+	})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	emitSuspendedNudge(&buf, projectRoot, agentID)
+	assert.Empty(t, buf.String(), "no nudge when recording is active (not suspended)")
+}
+
+func TestEmitSuspendedNudge_NoRecording(t *testing.T) {
+	projectRoot := suspendedNudgeProject(t)
+
+	var buf bytes.Buffer
+	emitSuspendedNudge(&buf, projectRoot, "Oxnone")
+	assert.Empty(t, buf.String())
+}
+
+func TestEmitSuspendedNudge_EmptyArgs(t *testing.T) {
+	var buf bytes.Buffer
+	emitSuspendedNudge(&buf, "", "Oxa")
+	emitSuspendedNudge(&buf, "/tmp", "")
+	assert.Empty(t, buf.String())
+}

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -1203,8 +1203,15 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string
 	if inheritedPause {
 		clearInfo := parseClearNoticeEnv()
 		priorSession := ""
+		// "inherited-from-clear" is only accurate when we actually saw a /clear
+		// handoff (OX_CLEAR_PRIOR_SESSION present); a surviving
+		// .session_paused.<agentID> marker can also come from a plain agent
+		// restart, in which case the persisted timeline should say "inherited"
+		// — not lie about the trigger.
+		reason := "inherited"
 		if clearInfo != nil {
 			priorSession = clearInfo.SessionName
+			reason = "inherited-from-clear"
 		}
 		if updateErr := session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
 			now := time.Now().UTC()
@@ -1216,7 +1223,7 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string
 				Action: session.LifecycleActionPause,
 				At:     now,
 				Seq:    0,
-				Reason: "inherited-from-clear",
+				Reason: reason,
 			})
 			_ = inheritedPauseAt // retained for telemetry if future fields need it
 			_ = inheritedPauseSeq

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -736,6 +736,26 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// ADR-020: surface the paused-parent subagent skip notice at the top level.
+	// startSessionRecording returns a sessionStatus with UserNotification set
+	// when a subagent's parent was paused; without this, the message lives only
+	// in the nested Session struct and the top-level prime output derives its
+	// "Session recording" hint from Session.Recording alone, so the agent ends
+	// up advertising "Session recording: available (/ox-session-start)" while
+	// the recording was just intentionally skipped. Lift the message into the
+	// canonical UserNotices channel so both --json and --text consumers see it.
+	if sessionStat != nil && !sessionStat.Recording && sessionStat.UserNotification != "" {
+		output.UserNotices = append(output.UserNotices, UserNotice{
+			Type:    "session-skipped",
+			Message: sessionStat.UserNotification,
+		})
+		if output.UserNotification == "" {
+			output.UserNotification = sessionStat.UserNotification
+		} else {
+			output.UserNotification = sessionStat.UserNotification + " " + output.UserNotification
+		}
+	}
+
 	// ADR-019: /clear is a session boundary. When this prime invocation follows
 	// a /clear that finalized a prior session, surface the transition to the
 	// user. The stopSessionForClear handoff is via OX_CLEAR_PRIOR_SESSION env.
@@ -1471,6 +1491,26 @@ func outputAgentPrimeText(cmd *cobra.Command, output agentPrimeOutput) error {
 			output.PrimeExcessiveNotice,
 			"",
 		)
+	}
+
+	// ADR-019/020: surface UserNotices that have no dedicated text-mode
+	// renderer. Without this, the /clear boundary notice and the paused-
+	// parent subagent-skipped notice land in output.UserNotices but
+	// outputAgentPrimeText was previously rendering only the typed boxes
+	// (HooksInstalled / SupportNotice / PrimeExcessiveNotice / upgrade),
+	// so --text mode would lose the lifecycle boundary handoff entirely.
+	// Skip notice types that are already rendered above to avoid dup.
+	renderedTypes := map[string]bool{
+		"restart": true, // HooksInstalled box already printed
+		"support": true, // SupportNotice box already printed
+		"upgrade": true, // UpdateAvailable box already printed
+	}
+	for _, n := range output.UserNotices {
+		if renderedTypes[n.Type] || n.Message == "" {
+			continue
+		}
+		fmt.Fprintln(cmd.OutOrStdout())
+		fmt.Fprintln(cmd.OutOrStdout(), n.Message)
 	}
 
 	// session status section

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -736,6 +736,27 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// ADR-019: /clear is a session boundary. When this prime invocation follows
+	// a /clear that finalized a prior session, surface the transition to the
+	// user. The stopSessionForClear handoff is via OX_CLEAR_PRIOR_SESSION env.
+	if clearInfo := parseClearNoticeEnv(); clearInfo != nil {
+		recordingOn := output.Session != nil && output.Session.Recording
+		notice := renderClearNotice(clearInfo, agentID, recordingOn)
+		if notice != "" {
+			output.UserNotices = append(output.UserNotices, UserNotice{
+				Type:    "clear-boundary",
+				Message: notice,
+			})
+			// also prepend to the pre-assembled UserNotification so JSON
+			// consumers without UserNotices support still see it.
+			if output.UserNotification == "" {
+				output.UserNotification = notice
+			} else {
+				output.UserNotification = notice + " " + output.UserNotification
+			}
+		}
+	}
+
 	if hooksInstalled {
 		output.HooksRestartNotice = "SageOx hooks were just installed. Tell the user to exit this session and start a new one so the hooks take effect."
 		output.UserNotices = append(output.UserNotices, UserNotice{
@@ -1042,6 +1063,31 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string
 		return nil
 	}
 
+	// ADR-020: subagent inheritance. When this prime call is for a subagent
+	// (parentAgentID set) and the parent's recording is currently suspended,
+	// the subagent skips recording entirely. Subagents are atomic units of
+	// work spawned within the parent's context window; if the parent has
+	// paused, the user's intent is "no recording" for this scope.
+	if parentAgentID != "" {
+		if _, _, parentPaused := session.PeekExplicitPause(projectRoot, parentAgentID); parentPaused {
+			return &sessionStatus{
+				Recording:        false,
+				Mode:             resolved.Mode,
+				Source:           string(resolved.Source),
+				UserNotification: "[ox] Parent session suspended. Recording skipped for this subagent.",
+			}
+		}
+		// also honor an in-flight pause without marker (defensive)
+		if parentState, _ := session.LoadRecordingStateForAgent(projectRoot, parentAgentID); parentState != nil && parentState.SuspendedAt != nil {
+			return &sessionStatus{
+				Recording:        false,
+				Mode:             resolved.Mode,
+				Source:           string(resolved.Source),
+				UserNotification: "[ox] Parent session suspended. Recording skipped for this subagent.",
+			}
+		}
+	}
+
 	// check if already recording
 	if existing, err := session.LoadRecordingStateForAgent(projectRoot, agentID); err == nil && existing != nil {
 		return &sessionStatus{
@@ -1099,6 +1145,13 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string
 		}
 	}
 
+	// ADR-020: per-agent pause stickiness. If a .session_paused.<agentID> marker
+	// exists for this agent (from a prior /clear or pause), the new session
+	// inherits the suspended state. We snapshot the existence here so the
+	// marker can outlive the StartRecording call; the marker itself is only
+	// cleared by explicit resume/stop/abort or daemon expiration.
+	inheritedPauseSeq, inheritedPauseAt, inheritedPause := session.PeekExplicitPause(projectRoot, agentID)
+
 	state, err := session.StartRecording(projectRoot, opts)
 	if err != nil {
 		// already recording is not an error
@@ -1121,6 +1174,39 @@ func startSessionRecording(projectRoot, agentID, agentType, parentAgentID string
 		// non-fatal but visible — agent sees stderr and can surface it
 		fmt.Fprintf(os.Stderr, "warning: session recording failed to start: %v\n", err)
 		return nil
+	}
+
+	// ADR-020: apply inherited pause state when a marker was present at start.
+	// Done before writeRawHeader so the header reflects the suspended lifecycle
+	// from entry 0. The marker survives — it is cleared only by explicit
+	// resume/stop/abort or daemon expiration.
+	if inheritedPause {
+		clearInfo := parseClearNoticeEnv()
+		priorSession := ""
+		if clearInfo != nil {
+			priorSession = clearInfo.SessionName
+		}
+		if updateErr := session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+			now := time.Now().UTC()
+			s.SuspendedAt = &now
+			s.InheritedPause = true
+			s.InheritedFromSession = priorSession
+			s.PauseCount++
+			s.Lifecycle = append(s.Lifecycle, session.LifecycleEvent{
+				Action: session.LifecycleActionPause,
+				At:     now,
+				Seq:    0,
+				Reason: "inherited-from-clear",
+			})
+			_ = inheritedPauseAt // retained for telemetry if future fields need it
+			_ = inheritedPauseSeq
+		}); updateErr != nil {
+			slog.Warn("inherited pause: failed to update recording state", "agent_id", agentID, "error", updateErr)
+		}
+		// reload so subsequent header write reflects suspended state
+		if reloaded, _ := session.LoadRecordingStateForAgent(projectRoot, agentID); reloaded != nil {
+			state = reloaded
+		}
 	}
 
 	// write raw.jsonl header immediately so incremental hooks can append entries

--- a/cmd/ox/agent_prime_text_notices_test.go
+++ b/cmd/ox/agent_prime_text_notices_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- ADR-019/020 text-mode notice rendering (PR #627 follow-up) ---
+// Failure prevented: outputAgentPrimeText previously rendered only the
+// typed notice boxes (HooksInstalled, SupportNotice, PrimeExcessiveNotice,
+// UpdateAvailable). UserNotices of types "clear-boundary" and
+// "session-skipped" had no dedicated renderer, so under --text mode the
+// /clear lifecycle boundary handoff and the paused-parent subagent skip
+// notice both vanished — the JSON path saw them, the text path did not.
+
+// TestOutputAgentPrimeText_RendersClearBoundaryNotice — Failure prevented:
+// the clear-boundary notice (post-/clear session transition) is silently
+// dropped under --text.
+func TestOutputAgentPrimeText_RendersClearBoundaryNotice(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	output := agentPrimeOutput{
+		AgentID: "Oxtest",
+		Status:  "fresh",
+		UserNotices: []UserNotice{
+			{Type: "clear-boundary", Message: "Prior session 2026-05-28-foo finalized. Recording: paused."},
+		},
+	}
+	require.NoError(t, outputAgentPrimeText(cmd, output))
+
+	got := buf.String()
+	assert.Contains(t, got, "Prior session 2026-05-28-foo finalized",
+		"clear-boundary notice must appear in --text output; previously it was silently dropped")
+}
+
+// TestOutputAgentPrimeText_RendersSessionSkippedNotice — Failure
+// prevented: paused-parent subagent skip notice silently dropped under
+// --text. The subagent agent ends up thinking recording is "available"
+// when it was just intentionally skipped.
+func TestOutputAgentPrimeText_RendersSessionSkippedNotice(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	output := agentPrimeOutput{
+		AgentID: "OxsubA",
+		Status:  "fresh",
+		UserNotices: []UserNotice{
+			{Type: "session-skipped", Message: "[ox] Parent session suspended. Recording skipped for this subagent."},
+		},
+	}
+	require.NoError(t, outputAgentPrimeText(cmd, output))
+
+	got := buf.String()
+	assert.Contains(t, got, "Recording skipped for this subagent",
+		"session-skipped notice must appear in --text output")
+}
+
+// TestOutputAgentPrimeText_FilterSkipsAlreadyRenderedTypes — Failure
+// prevented: appending to UserNotices for a type that already has a
+// dedicated renderer (upgrade box, hooks-restart box, support box) double-
+// renders under --text via the new UserNotices loop. The loop must skip
+// those types and only emit unrendered ones (clear-boundary, session-
+// skipped, future additions).
+func TestOutputAgentPrimeText_FilterSkipsAlreadyRenderedTypes(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	output := agentPrimeOutput{
+		AgentID:         "Oxfilt",
+		Status:          "fresh",
+		UpdateAvailable: true,
+		UpdateHint:      "v1.2.3 -> v1.2.4 upgrade hint",
+		UserNotices: []UserNotice{
+			{Type: "upgrade", Message: "UPGRADE_MSG_SENTINEL"},
+			{Type: "support", Message: "SUPPORT_MSG_SENTINEL"},
+			{Type: "restart", Message: "RESTART_MSG_SENTINEL"},
+			{Type: "clear-boundary", Message: "BOUNDARY_MSG_SENTINEL"},
+		},
+	}
+	require.NoError(t, outputAgentPrimeText(cmd, output))
+
+	got := buf.String()
+	// dedicated-box notices route to stderr, not to cmd.OutOrStdout; the
+	// filter MUST keep them out of the loop too so we don't double-render.
+	assert.NotContains(t, got, "UPGRADE_MSG_SENTINEL", "upgrade notice must not appear in the UserNotices loop output")
+	assert.NotContains(t, got, "SUPPORT_MSG_SENTINEL", "support notice must not appear in the UserNotices loop output")
+	assert.NotContains(t, got, "RESTART_MSG_SENTINEL", "restart notice must not appear in the UserNotices loop output")
+	// clear-boundary has no dedicated renderer — MUST appear.
+	assert.Contains(t, got, "BOUNDARY_MSG_SENTINEL", "clear-boundary notice must appear via the new UserNotices loop")
+}

--- a/cmd/ox/agent_session_pause.go
+++ b/cmd/ox/agent_session_pause.go
@@ -63,11 +63,25 @@ func runAgentSessionPause(inst *agentinstance.Instance, _ []string) error {
 	}
 
 	now := time.Now().UTC()
-	seq := state.EntryCount
 
+	// Capture seq + pause count INSIDE the update closure so the persisted
+	// LifecycleEvent.Seq matches the EntryCount the .recording.json is about
+	// to be saved with. Reading them beforehand opens a TOCTOU window where
+	// the tail-watcher appends entries between our read and Update's
+	// internal Load-modify-Save — and the persisted seq would silently
+	// trail the real entry stream, leaking paused entries into the upload
+	// at stop time.
+	var (
+		seq          int
+		pauseCount   int
+		sessionName  string
+	)
 	if err := session.UpdateRecordingStateForAgent(projectRoot, inst.AgentID, func(s *session.RecordingState) {
+		seq = s.EntryCount
 		s.SuspendedAt = &now
 		s.PauseCount++
+		pauseCount = s.PauseCount
+		sessionName = session.GetSessionName(s.SessionPath)
 		s.Lifecycle = append(s.Lifecycle, session.LifecycleEvent{
 			Action: session.LifecycleActionPause,
 			At:     now,
@@ -82,18 +96,11 @@ func runAgentSessionPause(inst *agentinstance.Instance, _ []string) error {
 		return fmt.Errorf("recording suspended but marker write failed: %w", err)
 	}
 
-	// reload to read back the persisted PauseCount for output accuracy
-	state, _ = session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
-	pauseCount := 1
-	if state != nil {
-		pauseCount = state.PauseCount
-	}
-
 	return emitPauseOutput(os.Stdout, &sessionPauseOutput{
 		Success:     true,
 		Type:        "session_pause",
 		AgentID:     inst.AgentID,
-		SessionName: session.GetSessionName(state.SessionPath),
+		SessionName: sessionName,
 		Status:      "paused",
 		Message:     fmt.Sprintf("session suspended at entry %d", seq),
 		Seq:         seq,

--- a/cmd/ox/agent_session_pause.go
+++ b/cmd/ox/agent_session_pause.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/sageox/ox/internal/agentinstance"
+	"github.com/sageox/ox/internal/session"
+)
+
+// sessionPauseOutput is the JSON output format for session pause.
+type sessionPauseOutput struct {
+	Success      bool   `json:"success"`
+	Type         string `json:"type"`
+	AgentID      string `json:"agent_id"`
+	SessionName  string `json:"session_name,omitempty"`
+	Status       string `json:"status"`  // "paused" | "already_paused" | "not_recording"
+	Message      string `json:"message"`
+	Guidance     string `json:"guidance,omitempty"`
+	Seq          int    `json:"seq,omitempty"`           // entry seq at pause point
+	PauseCount   int    `json:"pause_count,omitempty"`   // monotonic counter
+	SuspendedAt  string `json:"suspended_at,omitempty"`  // RFC3339
+}
+
+// runAgentSessionPause suspends an active recording. The local cache continues
+// to receive entries; upload at stop time will exclude the suspended range.
+//
+// Idempotent: pausing an already-suspended session is a no-op with a friendly
+// message and exit 0.
+//
+// See ADR-019 (session lifecycle) and ADR-020 (pause/resume).
+func runAgentSessionPause(inst *agentinstance.Instance, _ []string) error {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return fmt.Errorf("could not find project root: %w", err)
+	}
+
+	state, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
+	if err != nil {
+		return fmt.Errorf("failed to load recording state: %w", err)
+	}
+	if state == nil {
+		return fmt.Errorf("no active session to pause\nRun 'ox agent %s session start' to begin recording first", inst.AgentID)
+	}
+
+	// idempotent: already paused
+	if state.SuspendedAt != nil {
+		return emitPauseOutput(os.Stdout, &sessionPauseOutput{
+			Success:     true,
+			Type:        "session_pause",
+			AgentID:     inst.AgentID,
+			SessionName: session.GetSessionName(state.SessionPath),
+			Status:      "already_paused",
+			Message:     "session is already paused",
+			SuspendedAt: state.SuspendedAt.UTC().Format(time.RFC3339),
+			Seq:         state.EntryCount,
+			PauseCount:  state.PauseCount,
+			Guidance:    "No change. Resume with `ox session resume` (or /ox-session-resume).",
+		})
+	}
+
+	now := time.Now().UTC()
+	seq := state.EntryCount
+
+	if err := session.UpdateRecordingStateForAgent(projectRoot, inst.AgentID, func(s *session.RecordingState) {
+		s.SuspendedAt = &now
+		s.PauseCount++
+		s.Lifecycle = append(s.Lifecycle, session.LifecycleEvent{
+			Action: session.LifecycleActionPause,
+			At:     now,
+			Seq:    seq,
+		})
+	}); err != nil {
+		return fmt.Errorf("failed to mark recording suspended: %w", err)
+	}
+
+	// write per-agent marker so /clear inheritance and cross-process detection work.
+	if err := session.MarkExplicitPause(projectRoot, inst.AgentID, seq); err != nil {
+		return fmt.Errorf("recording suspended but marker write failed: %w", err)
+	}
+
+	// reload to read back the persisted PauseCount for output accuracy
+	state, _ = session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
+	pauseCount := 1
+	if state != nil {
+		pauseCount = state.PauseCount
+	}
+
+	return emitPauseOutput(os.Stdout, &sessionPauseOutput{
+		Success:     true,
+		Type:        "session_pause",
+		AgentID:     inst.AgentID,
+		SessionName: session.GetSessionName(state.SessionPath),
+		Status:      "paused",
+		Message:     fmt.Sprintf("session suspended at entry %d", seq),
+		Seq:         seq,
+		PauseCount:  pauseCount,
+		SuspendedAt: now.Format(time.RFC3339),
+		Guidance:    "Recording continues to local cache; the suspended range will be excluded from upload. Resume with `ox session resume` (or /ox-session-resume).",
+	})
+}
+
+func emitPauseOutput(w io.Writer, output *sessionPauseOutput) error {
+	if cfg.Text || cfg.Review {
+		fmt.Fprintf(w, "[ox] %s — %s\n", output.Status, output.Message)
+		if cfg.Review {
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "--- Machine Output ---")
+		} else {
+			return nil
+		}
+	}
+	jsonOut, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return fmt.Errorf("format pause JSON: %w", err)
+	}
+	fmt.Fprintln(w, string(jsonOut))
+	return nil
+}

--- a/cmd/ox/agent_session_pause_resume_toctou_test.go
+++ b/cmd/ox/agent_session_pause_resume_toctou_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/agentinstance"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pauseResumeProject builds a project the same way the suspended-nudge tests do
+// and additionally sets OX_PROJECT_ROOT so the runAgentSession{Pause,Resume}
+// helpers resolve to this project without depending on the test's CWD.
+func pauseResumeProject(t *testing.T) string {
+	t.Helper()
+	root := suspendedNudgeProject(t)
+	t.Setenv("OX_PROJECT_ROOT", root)
+	// cfg is normally initialized by PersistentPreRunE on the root cobra cmd;
+	// in unit tests we set a zero-value config so emitPause/Resume output's
+	// cfg.Text / cfg.Review checks don't nil-deref.
+	prev := cfg
+	cfg = &config.Config{}
+	t.Cleanup(func() { cfg = prev })
+	return root
+}
+
+// --- ADR-020 TOCTOU regression tests (PR #627 follow-up) ---
+// Failure prevented: the pause/resume commands originally read
+// state.EntryCount BEFORE calling UpdateRecordingStateForAgent, while the
+// canonical lifecycle Seq is set inside that update's load-modify-save
+// window. When a tail-watcher (or any other writer) appended entries
+// between the pre-read and the update, the persisted Pause/Resume Seq
+// trailed the actual EntryCount being saved — and paused-range entries
+// silently leaked across the boundary into the upload at stop time.
+//
+// The fix captures both seq AND the excluded-entry count INSIDE the
+// update closure. These tests pin the contract: every persisted
+// LifecycleEvent.Seq must equal the EntryCount the state was saved with.
+
+// TestPause_SeqMatchesPersistedEntryCount — Failure prevented: pause writes
+// a LifecycleEvent.Seq that does not match the EntryCount visible to the
+// next reader, leaving the segment-mask logic with a stale boundary.
+func TestPause_SeqMatchesPersistedEntryCount(t *testing.T) {
+	projectRoot := pauseResumeProject(t)
+	agentID := "Oxpause1"
+
+	state, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+		AgentID:     agentID,
+		AdapterName: "claude-code",
+		Username:    "testuser",
+	})
+	require.NoError(t, err)
+	require.NoError(t, session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+		s.EntryCount = 42 // simulate prior tail-watcher appends
+	}))
+	_ = state
+
+	inst := &agentinstance.Instance{AgentID: agentID}
+	require.NoError(t, runAgentSessionPause(inst, nil))
+
+	got, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.SuspendedAt)
+	require.NotEmpty(t, got.Lifecycle)
+	last := got.Lifecycle[len(got.Lifecycle)-1]
+	assert.Equal(t, session.LifecycleActionPause, last.Action)
+	assert.Equal(t, got.EntryCount, last.Seq,
+		"pause LifecycleEvent.Seq MUST equal the EntryCount the state is saved with — anything else means the upload mask boundary is stale")
+}
+
+// TestResume_SeqMatchesPersistedEntryCount — Failure prevented: resume
+// writes a LifecycleEvent.Seq < persisted EntryCount, so entries appended
+// while still SuspendedAt != nil leak into the post-resume range and ship
+// to the ledger.
+func TestResume_SeqMatchesPersistedEntryCount(t *testing.T) {
+	projectRoot := pauseResumeProject(t)
+	agentID := "Oxresume1"
+
+	_, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+		AgentID:     agentID,
+		AdapterName: "claude-code",
+		Username:    "testuser",
+	})
+	require.NoError(t, err)
+
+	// pause first so resume has something to do.
+	require.NoError(t, runAgentSessionPause(&agentinstance.Instance{AgentID: agentID}, nil))
+
+	// simulate tail-watcher appends DURING the paused window.
+	require.NoError(t, session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+		s.EntryCount += 17
+	}))
+
+	require.NoError(t, runAgentSessionResume(&agentinstance.Instance{AgentID: agentID}, nil))
+
+	got, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Nil(t, got.SuspendedAt, "resume must clear SuspendedAt")
+
+	// find the most recent resume event
+	var resumeSeq int
+	var found bool
+	for i := len(got.Lifecycle) - 1; i >= 0; i-- {
+		if got.Lifecycle[i].Action == session.LifecycleActionResume {
+			resumeSeq = got.Lifecycle[i].Seq
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "resume lifecycle event missing")
+	assert.Equal(t, got.EntryCount, resumeSeq,
+		"resume LifecycleEvent.Seq MUST equal the EntryCount the state is saved with — otherwise paused-range entries leak across the boundary")
+}
+
+// TestPauseResume_ConcurrentAppendsKeepLifecycleConsistent — Failure
+// prevented: under a tail-watcher race, EntryCount drifts between
+// pre-read and persisted state, leaving Pause Seq < Resume Seq and a
+// false "excluded entries" count. With seq captured inside the closure
+// the relationship Pause Seq <= Resume Seq <= persisted EntryCount
+// always holds.
+func TestPauseResume_ConcurrentAppendsKeepLifecycleConsistent(t *testing.T) {
+	projectRoot := pauseResumeProject(t)
+	agentID := "Oxrace1"
+
+	_, err := session.StartRecording(projectRoot, session.StartRecordingOptions{
+		AgentID:     agentID,
+		AdapterName: "claude-code",
+		Username:    "testuser",
+	})
+	require.NoError(t, err)
+
+	// hammer EntryCount in the background while pause+resume run.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tick := time.NewTicker(50 * time.Microsecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+				_ = session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+					s.EntryCount++
+				})
+			}
+		}
+	}()
+
+	inst := &agentinstance.Instance{AgentID: agentID}
+	require.NoError(t, runAgentSessionPause(inst, nil))
+	time.Sleep(2 * time.Millisecond) // let tail-watcher append during the pause
+	require.NoError(t, runAgentSessionResume(inst, nil))
+
+	close(stop)
+	wg.Wait()
+
+	got, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	var pauseSeq, resumeSeq int
+	var sawPause, sawResume bool
+	for _, ev := range got.Lifecycle {
+		switch ev.Action {
+		case session.LifecycleActionPause:
+			pauseSeq = ev.Seq
+			sawPause = true
+		case session.LifecycleActionResume:
+			resumeSeq = ev.Seq
+			sawResume = true
+		}
+	}
+	require.True(t, sawPause, "pause event missing")
+	require.True(t, sawResume, "resume event missing")
+	assert.LessOrEqual(t, pauseSeq, resumeSeq,
+		"pauseSeq must be <= resumeSeq; otherwise the excluded range is meaningless")
+	assert.LessOrEqual(t, resumeSeq, got.EntryCount,
+		"resumeSeq must be <= persisted EntryCount; otherwise resume claims entries that never existed")
+}

--- a/cmd/ox/agent_session_pause_resume_toctou_test.go
+++ b/cmd/ox/agent_session_pause_resume_toctou_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -136,8 +137,13 @@ func TestPauseResume_ConcurrentAppendsKeepLifecycleConsistent(t *testing.T) {
 	require.NoError(t, err)
 
 	// hammer EntryCount in the background while pause+resume run.
+	// Count successful appends so we can assert at the end that the
+	// background writer actually made progress — under scheduler
+	// starvation this test would otherwise vacuously pass and silently
+	// weaken the TOCTOU regression signal.
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
+	var appendOK atomic.Int64
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -148,9 +154,11 @@ func TestPauseResume_ConcurrentAppendsKeepLifecycleConsistent(t *testing.T) {
 			case <-stop:
 				return
 			case <-tick.C:
-				_ = session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
+				if err := session.UpdateRecordingStateForAgent(projectRoot, agentID, func(s *session.RecordingState) {
 					s.EntryCount++
-				})
+				}); err == nil {
+					appendOK.Add(1)
+				}
 			}
 		}
 	}()
@@ -162,6 +170,12 @@ func TestPauseResume_ConcurrentAppendsKeepLifecycleConsistent(t *testing.T) {
 
 	close(stop)
 	wg.Wait()
+
+	// If the background writer never made progress, this test cannot prove
+	// the TOCTOU invariant under concurrent appends — fail fast rather
+	// than report a false PASS.
+	require.Greater(t, appendOK.Load(), int64(0),
+		"concurrent appender did not record any updates; race coverage is vacuous")
 
 	got, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
 	require.NoError(t, err)

--- a/cmd/ox/agent_session_pause_test.go
+++ b/cmd/ox/agent_session_pause_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestComputeExcludedSinceLastPause exercises the helper that the resume
+// command uses to report how many entries were excluded between the most
+// recent open pause and the resume seq.
+func TestComputeExcludedSinceLastPause(t *testing.T) {
+	now := time.Now()
+
+	cases := []struct {
+		name      string
+		lifecycle []session.LifecycleEvent
+		resumeSeq int
+		want      int
+	}{
+		{
+			name:      "empty lifecycle",
+			lifecycle: nil,
+			resumeSeq: 10,
+			want:      0,
+		},
+		{
+			name: "pause at 5, resume at 10 → 5 excluded",
+			lifecycle: []session.LifecycleEvent{
+				{Action: session.LifecycleActionStart, Seq: 0, At: now},
+				{Action: session.LifecycleActionPause, Seq: 5, At: now},
+			},
+			resumeSeq: 10,
+			want:      5,
+		},
+		{
+			name: "last action is resume — no open pause",
+			lifecycle: []session.LifecycleEvent{
+				{Action: session.LifecycleActionPause, Seq: 5, At: now},
+				{Action: session.LifecycleActionResume, Seq: 10, At: now},
+			},
+			resumeSeq: 15,
+			want:      0,
+		},
+		{
+			name: "multi-cycle with last open pause",
+			lifecycle: []session.LifecycleEvent{
+				{Action: session.LifecycleActionPause, Seq: 5, At: now},
+				{Action: session.LifecycleActionResume, Seq: 7, At: now},
+				{Action: session.LifecycleActionPause, Seq: 12, At: now},
+			},
+			resumeSeq: 15,
+			want:      3,
+		},
+		{
+			name: "stop closes pause — no open pause",
+			lifecycle: []session.LifecycleEvent{
+				{Action: session.LifecycleActionPause, Seq: 5, At: now},
+				{Action: session.LifecycleActionStop, Seq: 10, At: now},
+			},
+			resumeSeq: 15,
+			want:      0,
+		},
+		{
+			name: "resume seq before pause seq → 0 (defensive)",
+			lifecycle: []session.LifecycleEvent{
+				{Action: session.LifecycleActionPause, Seq: 20, At: now},
+			},
+			resumeSeq: 10,
+			want:      0,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			got := computeExcludedSinceLastPause(c.lifecycle, c.resumeSeq)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// TestFormatPausedDuration exercises the duration formatter used in resume output.
+func TestFormatPausedDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{d: 30 * time.Second, want: "30s"},
+		{d: 4*time.Minute + 30*time.Second, want: "4m 30s"},
+		{d: 2 * time.Hour, want: "2h"},
+		{d: 1*time.Hour + 15*time.Minute, want: "1h 15m"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.want, func(t *testing.T) {
+			assert.Equal(t, c.want, formatPausedDuration(c.d))
+		})
+	}
+}

--- a/cmd/ox/agent_session_resume.go
+++ b/cmd/ox/agent_session_resume.go
@@ -59,14 +59,24 @@ func runAgentSessionResume(inst *agentinstance.Instance, _ []string) error {
 	}
 
 	pausedAt := *state.SuspendedAt
-	resumeSeq := state.EntryCount
 	now := time.Now().UTC()
 
-	// compute the excluded count: walk lifecycle to find the most recent open
-	// pause and count entries in [pause_seq, resume_seq). Done before update.
-	excluded := computeExcludedSinceLastPause(state.Lifecycle, resumeSeq)
-
+	// Capture resumeSeq + excluded count INSIDE the update closure so the
+	// persisted LifecycleEvent.Seq AND the excluded-range calculation both
+	// see the same EntryCount that .recording.json is about to be saved
+	// with. Reading either beforehand opens a TOCTOU window where entries
+	// appended while still SuspendedAt != nil get treated as resumed and
+	// silently uploaded — the exact failure ADR-020's "temporal redaction
+	// scope" claims to prevent.
+	var (
+		resumeSeq   int
+		excluded    int
+		sessionName string
+	)
 	if err := session.UpdateRecordingStateForAgent(projectRoot, inst.AgentID, func(s *session.RecordingState) {
+		resumeSeq = s.EntryCount
+		excluded = computeExcludedSinceLastPause(s.Lifecycle, resumeSeq)
+		sessionName = session.GetSessionName(s.SessionPath)
 		s.SuspendedAt = nil
 		s.Lifecycle = append(s.Lifecycle, session.LifecycleEvent{
 			Action: session.LifecycleActionResume,
@@ -85,7 +95,7 @@ func runAgentSessionResume(inst *agentinstance.Instance, _ []string) error {
 		Success:         true,
 		Type:            "session_resume",
 		AgentID:         inst.AgentID,
-		SessionName:     session.GetSessionName(state.SessionPath),
+		SessionName:     sessionName,
 		Status:          "resumed",
 		Message:         fmt.Sprintf("session resumed at entry %d", resumeSeq),
 		ResumedSeq:      resumeSeq,

--- a/cmd/ox/agent_session_resume.go
+++ b/cmd/ox/agent_session_resume.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/sageox/ox/internal/agentinstance"
+	"github.com/sageox/ox/internal/session"
+)
+
+// sessionResumeOutput is the JSON output format for session resume.
+type sessionResumeOutput struct {
+	Success         bool   `json:"success"`
+	Type            string `json:"type"`
+	AgentID         string `json:"agent_id"`
+	SessionName     string `json:"session_name,omitempty"`
+	Status          string `json:"status"` // "resumed" | "not_suspended"
+	Message         string `json:"message"`
+	Guidance        string `json:"guidance,omitempty"`
+	ResumedSeq      int    `json:"resumed_seq,omitempty"`      // entry seq at resume point
+	ExcludedEntries int    `json:"excluded_entries,omitempty"` // count of entries in the closed range
+	PausedDuration  string `json:"paused_duration,omitempty"`  // human-readable
+}
+
+// runAgentSessionResume reverses a prior pause. Appends a resume LifecycleEvent
+// with the current EntryCount as seq, clears SuspendedAt, and removes the
+// pause marker.
+//
+// Idempotent: resuming a non-suspended session is a no-op with a friendly
+// message and exit 0.
+func runAgentSessionResume(inst *agentinstance.Instance, _ []string) error {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		return fmt.Errorf("could not find project root: %w", err)
+	}
+
+	state, err := session.LoadRecordingStateForAgent(projectRoot, inst.AgentID)
+	if err != nil {
+		return fmt.Errorf("failed to load recording state: %w", err)
+	}
+	if state == nil {
+		return fmt.Errorf("no active session to resume\nRun 'ox agent %s session start' to begin recording first", inst.AgentID)
+	}
+
+	// idempotent: not suspended
+	if state.SuspendedAt == nil {
+		return emitResumeOutput(os.Stdout, &sessionResumeOutput{
+			Success:     true,
+			Type:        "session_resume",
+			AgentID:     inst.AgentID,
+			SessionName: session.GetSessionName(state.SessionPath),
+			Status:      "not_suspended",
+			Message:     "session is not suspended; nothing to resume",
+			Guidance:    "Already recording. Pause with `ox session pause` to suspend.",
+		})
+	}
+
+	pausedAt := *state.SuspendedAt
+	resumeSeq := state.EntryCount
+	now := time.Now().UTC()
+
+	// compute the excluded count: walk lifecycle to find the most recent open
+	// pause and count entries in [pause_seq, resume_seq). Done before update.
+	excluded := computeExcludedSinceLastPause(state.Lifecycle, resumeSeq)
+
+	if err := session.UpdateRecordingStateForAgent(projectRoot, inst.AgentID, func(s *session.RecordingState) {
+		s.SuspendedAt = nil
+		s.Lifecycle = append(s.Lifecycle, session.LifecycleEvent{
+			Action: session.LifecycleActionResume,
+			At:     now,
+			Seq:    resumeSeq,
+		})
+	}); err != nil {
+		return fmt.Errorf("failed to clear suspended state: %w", err)
+	}
+
+	// best-effort marker removal; idempotent if marker missing
+	session.ClearExplicitPause(projectRoot, inst.AgentID)
+
+	pausedDur := now.Sub(pausedAt)
+	return emitResumeOutput(os.Stdout, &sessionResumeOutput{
+		Success:         true,
+		Type:            "session_resume",
+		AgentID:         inst.AgentID,
+		SessionName:     session.GetSessionName(state.SessionPath),
+		Status:          "resumed",
+		Message:         fmt.Sprintf("session resumed at entry %d", resumeSeq),
+		ResumedSeq:      resumeSeq,
+		ExcludedEntries: excluded,
+		PausedDuration:  formatPausedDuration(pausedDur),
+		Guidance:        "Recording resumed. Paused range will be excluded from upload at stop time.",
+	})
+}
+
+// computeExcludedSinceLastPause walks the lifecycle in reverse to find the
+// most recent open pause and returns the count of entries that would be
+// excluded between that pause seq and the given resume seq.
+//
+// "Open" pause = not yet matched by a resume / stop / clear-finalize / expired
+// event later in the timeline.
+func computeExcludedSinceLastPause(lifecycle []session.LifecycleEvent, resumeSeq int) int {
+	for i := len(lifecycle) - 1; i >= 0; i-- {
+		switch lifecycle[i].Action {
+		case session.LifecycleActionPause:
+			diff := resumeSeq - lifecycle[i].Seq
+			if diff < 0 {
+				return 0
+			}
+			return diff
+		case session.LifecycleActionResume,
+			session.LifecycleActionStop,
+			session.LifecycleActionClearFinalize,
+			session.LifecycleActionExpired:
+			// any of these closes a pause; further-back pauses are not "open"
+			return 0
+		}
+	}
+	return 0
+}
+
+// formatPausedDuration formats a paused-window duration for the resume
+// notice. Mirrors formatClearDuration but applied to pause windows.
+func formatPausedDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) - m*60
+		if s == 0 {
+			return fmt.Sprintf("%dm", m)
+		}
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) - h*60
+	if m == 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh %dm", h, m)
+}
+
+func emitResumeOutput(w io.Writer, output *sessionResumeOutput) error {
+	if cfg.Text || cfg.Review {
+		fmt.Fprintf(w, "[ox] %s — %s\n", output.Status, output.Message)
+		if cfg.Review {
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "--- Machine Output ---")
+		} else {
+			return nil
+		}
+	}
+	jsonOut, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return fmt.Errorf("format resume JSON: %w", err)
+	}
+	fmt.Fprintln(w, string(jsonOut))
+	return nil
+}

--- a/cmd/ox/clear_notice.go
+++ b/cmd/ox/clear_notice.go
@@ -103,18 +103,21 @@ func renderClearNotice(info *ClearNoticeInfo, newAgentID string, recordingOn boo
 	if recordingOn {
 		recState = "on"
 	}
+	// newAgentID already carries the agent's "Ox" prefix from
+	// agentinstance.NewID — re-prefixing it produces "OxOxa7b3" in user-
+	// visible notices. Render the ID as-is.
 	if info.WasSuspended {
 		return fmt.Sprintf(
 			"[ox] /clear → previous session %s (suspended, %s) finalized. "+
 				"Paused range excluded from upload. "+
-				"New session Ox%s started — RECORDING SUSPENDED (carried from previous). "+
+				"New session %s started — RECORDING SUSPENDED (carried from previous). "+
 				"Resume: /ox-session-resume · Stop: /ox-session-stop",
 			info.SessionName, dur, newAgentID,
 		)
 	}
 	return fmt.Sprintf(
 		"[ox] /clear → previous session %s (%s, %s) finalized. "+
-			"New session Ox%s started. Recording: %s.",
+			"New session %s started. Recording: %s.",
 		info.SessionName, info.Status, dur, newAgentID, recState,
 	)
 }

--- a/cmd/ox/clear_notice.go
+++ b/cmd/ox/clear_notice.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+)
+
+// envClearNotice carries information about a session finalized by /clear from
+// the hook process to the prime subprocess so prime can include a user-facing
+// notice describing the boundary transition.
+//
+// See ADR-019 (session entity lifecycle) for why /clear is a session boundary
+// and why the user is told about the transition.
+const envClearNotice = "OX_CLEAR_PRIOR_SESSION"
+
+// ClearNoticeInfo describes the session that was finalized at a /clear boundary.
+type ClearNoticeInfo struct {
+	SessionName  string `json:"session_name"`            // e.g. "2026-05-27T07-12-ryan-Oxa7b3"
+	AgentID      string `json:"agent_id"`                // e.g. "Oxa7b3"
+	Status       string `json:"status"`                  // "recording" | "suspended"
+	DurationSecs int64  `json:"duration_secs,omitempty"` // session lifetime up to /clear
+	WasSuspended bool   `json:"was_suspended,omitempty"` // true if SuspendedAt was set on finalize
+}
+
+// buildClearNoticeFromState builds a ClearNoticeInfo from the recording state
+// being finalized at a /clear boundary. Returns nil if state is nil.
+func buildClearNoticeFromState(state *session.RecordingState) *ClearNoticeInfo {
+	if state == nil {
+		return nil
+	}
+	info := &ClearNoticeInfo{
+		AgentID: state.AgentID,
+	}
+	if state.SessionPath != "" {
+		info.SessionName = filepath.Base(state.SessionPath)
+	}
+	if !state.StartedAt.IsZero() {
+		info.DurationSecs = int64(time.Since(state.StartedAt).Seconds())
+	}
+	// ADR-020: when SuspendedAt is set, the prior session was actively paused.
+	// New post-/clear session inherits the suspended state via the pause marker.
+	if state.SuspendedAt != nil {
+		info.WasSuspended = true
+		info.Status = "suspended"
+	} else {
+		info.Status = "recording"
+	}
+	return info
+}
+
+// serializeClearNoticeEnv returns a "KEY=VAL" pair suitable for cmd.Env.
+// Returns empty string if info is nil.
+func serializeClearNoticeEnv(info *ClearNoticeInfo) string {
+	if info == nil {
+		return ""
+	}
+	b, err := json.Marshal(info)
+	if err != nil {
+		return ""
+	}
+	return envClearNotice + "=" + string(b)
+}
+
+// parseClearNoticeEnv reads OX_CLEAR_PRIOR_SESSION from the environment.
+// Returns nil if unset or malformed.
+func parseClearNoticeEnv() *ClearNoticeInfo {
+	raw := os.Getenv(envClearNotice)
+	if raw == "" {
+		return nil
+	}
+	var info ClearNoticeInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil
+	}
+	if info.SessionName == "" {
+		return nil
+	}
+	return &info
+}
+
+// renderClearNotice formats a user-facing notice describing the /clear boundary.
+//
+// Format:
+//
+//	[ox] /clear → previous session <name> (<status>, <duration>) finalized.
+//	     New session <newAgentID> started. Recording: <on|off>.
+//
+// When the prior session was suspended, the notice indicates the paused range
+// is excluded from upload (ADR-020 semantics; for ADR-019-only deploys the
+// extra line is still accurate since suspended-then-stopped sessions in this
+// codebase upload empty content for the suspended range).
+func renderClearNotice(info *ClearNoticeInfo, newAgentID string, recordingOn bool) string {
+	if info == nil {
+		return ""
+	}
+	dur := formatClearDuration(time.Duration(info.DurationSecs) * time.Second)
+	recState := "off"
+	if recordingOn {
+		recState = "on"
+	}
+	if info.WasSuspended {
+		return fmt.Sprintf(
+			"[ox] /clear → previous session %s (suspended, %s) finalized. "+
+				"Paused range excluded from upload. "+
+				"New session Ox%s started — RECORDING SUSPENDED (carried from previous). "+
+				"Resume: /ox-session-resume · Stop: /ox-session-stop",
+			info.SessionName, dur, newAgentID,
+		)
+	}
+	return fmt.Sprintf(
+		"[ox] /clear → previous session %s (%s, %s) finalized. "+
+			"New session Ox%s started. Recording: %s.",
+		info.SessionName, info.Status, dur, newAgentID, recState,
+	)
+}
+
+// formatClearDuration returns a compact human-readable duration like "3m 24s",
+// "1h 12m", or "47s". Used for the /clear notice.
+func formatClearDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) - m*60
+		if s == 0 {
+			return fmt.Sprintf("%dm", m)
+		}
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	h := int(d.Hours())
+	m := int(d.Minutes()) - h*60
+	if m == 0 {
+		return fmt.Sprintf("%dh", h)
+	}
+	return fmt.Sprintf("%dh %dm", h, m)
+}

--- a/cmd/ox/clear_notice_test.go
+++ b/cmd/ox/clear_notice_test.go
@@ -71,13 +71,15 @@ func TestRenderClearNotice_Recording(t *testing.T) {
 		Status:       "recording",
 		DurationSecs: 754, // 12m 34s
 	}
-	got := renderClearNotice(info, "b3x9", true)
+	got := renderClearNotice(info, "Oxb3x9", true)
 
 	assert.Contains(t, got, "/clear")
 	assert.Contains(t, got, "2026-05-27T07-12-ryan-Oxa7b3")
 	assert.Contains(t, got, "recording")
 	assert.Contains(t, got, "12m 34s")
 	assert.Contains(t, got, "Oxb3x9")
+	assert.NotContains(t, got, "OxOxb3x9",
+		"newAgentID already carries the Ox prefix; renderer must not re-prefix")
 	assert.Contains(t, got, "Recording: on")
 }
 
@@ -91,13 +93,15 @@ func TestRenderClearNotice_Suspended(t *testing.T) {
 		DurationSecs: 3600,
 		WasSuspended: true,
 	}
-	got := renderClearNotice(info, "b3x9", false)
+	got := renderClearNotice(info, "Oxb3x9", false)
 
 	assert.Contains(t, got, "suspended")
 	assert.Contains(t, got, "1h")
 	assert.Contains(t, got, "Paused range excluded from upload")
 	assert.Contains(t, got, "RECORDING SUSPENDED")
 	assert.Contains(t, got, "carried from previous")
+	assert.NotContains(t, got, "OxOxb3x9",
+		"newAgentID already carries the Ox prefix; renderer must not re-prefix")
 }
 
 // TestRenderClearNotice_Nil verifies graceful empty return.

--- a/cmd/ox/clear_notice_test.go
+++ b/cmd/ox/clear_notice_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSerializeAndParseClearNoticeEnv verifies round-trip of the env handoff
+// between stopSessionForClear (hook process) and prime (subprocess).
+func TestSerializeAndParseClearNoticeEnv(t *testing.T) {
+	info := &ClearNoticeInfo{
+		SessionName:  "2026-05-27T07-12-ryan-Oxa7b3",
+		AgentID:      "Oxa7b3",
+		Status:       "recording",
+		DurationSecs: 1234,
+		WasSuspended: false,
+	}
+
+	pair := serializeClearNoticeEnv(info)
+	require.NotEmpty(t, pair)
+	require.True(t, strings.HasPrefix(pair, envClearNotice+"="))
+
+	// install into env to simulate subprocess inheriting it
+	t.Setenv(envClearNotice, strings.TrimPrefix(pair, envClearNotice+"="))
+
+	got := parseClearNoticeEnv()
+	require.NotNil(t, got)
+	assert.Equal(t, info.SessionName, got.SessionName)
+	assert.Equal(t, info.AgentID, got.AgentID)
+	assert.Equal(t, info.Status, got.Status)
+	assert.Equal(t, info.DurationSecs, got.DurationSecs)
+	assert.Equal(t, info.WasSuspended, got.WasSuspended)
+}
+
+// TestSerializeClearNoticeEnv_Nil verifies nil returns empty string (caller
+// must not append an empty pair to cmd.Env).
+func TestSerializeClearNoticeEnv_Nil(t *testing.T) {
+	assert.Empty(t, serializeClearNoticeEnv(nil))
+}
+
+// TestParseClearNoticeEnv_MissingOrMalformed verifies graceful nil returns.
+func TestParseClearNoticeEnv_MissingOrMalformed(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		// ensure env var is unset for this sub-test
+		_ = os.Unsetenv(envClearNotice)
+		assert.Nil(t, parseClearNoticeEnv())
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		t.Setenv(envClearNotice, "{not json")
+		assert.Nil(t, parseClearNoticeEnv())
+	})
+
+	t.Run("missing session_name", func(t *testing.T) {
+		t.Setenv(envClearNotice, `{"agent_id":"Oxa7b3"}`)
+		assert.Nil(t, parseClearNoticeEnv(), "session_name is required")
+	})
+}
+
+// TestRenderClearNotice covers the standard recording-then-cleared transition.
+func TestRenderClearNotice_Recording(t *testing.T) {
+	info := &ClearNoticeInfo{
+		SessionName:  "2026-05-27T07-12-ryan-Oxa7b3",
+		AgentID:      "Oxa7b3",
+		Status:       "recording",
+		DurationSecs: 754, // 12m 34s
+	}
+	got := renderClearNotice(info, "b3x9", true)
+
+	assert.Contains(t, got, "/clear")
+	assert.Contains(t, got, "2026-05-27T07-12-ryan-Oxa7b3")
+	assert.Contains(t, got, "recording")
+	assert.Contains(t, got, "12m 34s")
+	assert.Contains(t, got, "Oxb3x9")
+	assert.Contains(t, got, "Recording: on")
+}
+
+// TestRenderClearNotice_Suspended verifies the suspended-prior-session variant
+// includes the paused-range-excluded line (ADR-020 semantics).
+func TestRenderClearNotice_Suspended(t *testing.T) {
+	info := &ClearNoticeInfo{
+		SessionName:  "2026-05-27T07-12-ryan-Oxa7b3",
+		AgentID:      "Oxa7b3",
+		Status:       "suspended",
+		DurationSecs: 3600,
+		WasSuspended: true,
+	}
+	got := renderClearNotice(info, "b3x9", false)
+
+	assert.Contains(t, got, "suspended")
+	assert.Contains(t, got, "1h")
+	assert.Contains(t, got, "Paused range excluded from upload")
+	assert.Contains(t, got, "RECORDING SUSPENDED")
+	assert.Contains(t, got, "carried from previous")
+}
+
+// TestRenderClearNotice_Nil verifies graceful empty return.
+func TestRenderClearNotice_Nil(t *testing.T) {
+	assert.Empty(t, renderClearNotice(nil, "Oxa7b3", true))
+}
+
+// TestFormatClearDuration exercises the duration formatter for the three
+// magnitude buckets used in the notice.
+func TestFormatClearDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{d: 47 * time.Second, want: "47s"},
+		{d: 1 * time.Minute, want: "1m"},
+		{d: 3*time.Minute + 24*time.Second, want: "3m 24s"},
+		{d: 1 * time.Hour, want: "1h"},
+		{d: 1*time.Hour + 12*time.Minute, want: "1h 12m"},
+		{d: 2 * time.Hour, want: "2h"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.want, func(t *testing.T) {
+			assert.Equal(t, c.want, formatClearDuration(c.d))
+		})
+	}
+}
+
+// TestBuildClearNoticeFromState verifies extraction from a RecordingState.
+func TestBuildClearNoticeFromState(t *testing.T) {
+	state := &session.RecordingState{
+		AgentID:     "Oxa7b3",
+		StartedAt:   time.Now().Add(-15 * time.Minute),
+		SessionPath: "/tmp/.sageox/cache/sessions/2026-05-27T07-12-ryan-Oxa7b3",
+	}
+	got := buildClearNoticeFromState(state)
+	require.NotNil(t, got)
+	assert.Equal(t, "Oxa7b3", got.AgentID)
+	assert.Equal(t, "2026-05-27T07-12-ryan-Oxa7b3", got.SessionName)
+	assert.InDelta(t, int64(15*60), got.DurationSecs, 5, "duration ~15 min")
+	assert.Equal(t, "recording", got.Status)
+	assert.False(t, got.WasSuspended)
+}
+
+// TestBuildClearNoticeFromState_Nil verifies nil-safe behavior.
+func TestBuildClearNoticeFromState_Nil(t *testing.T) {
+	assert.Nil(t, buildClearNoticeFromState(nil))
+}

--- a/cmd/ox/session_status.go
+++ b/cmd/ox/session_status.go
@@ -155,6 +155,54 @@ type sessionRecordingEntry struct {
 	SessionFile   string `json:"session_file,omitempty"`
 	WorkspacePath string `json:"workspace_path,omitempty"`
 	Branch        string `json:"branch,omitempty"`
+
+	// ADR-020 pause/resume surface — kept in sync with sessionStatusOutput.
+	// Multi-session JSON consumers (status dashboards, daemon, agents
+	// enumerating siblings) need to tell suspended sessions apart from
+	// actively-recording ones.
+	Suspended            bool   `json:"suspended,omitempty"`
+	SuspendedAt          string `json:"suspended_at,omitempty"`
+	SuspendedDuration    string `json:"suspended_duration,omitempty"`
+	PauseCount           int    `json:"pause_count,omitempty"`
+	InheritedPause       bool   `json:"inherited_pause,omitempty"`
+	InheritedFromSession string `json:"inherited_from_session,omitempty"`
+}
+
+// buildSessionRecordingEntry maps a RecordingState into the multi-session
+// JSON row, including ADR-020 pause-state fields. Extracted from
+// runSessionStatus so the mapping can be unit-tested without setting up
+// the full multi-recording fixture on disk.
+func buildSessionRecordingEntry(s *session.RecordingState, alive *bool, status string) sessionRecordingEntry {
+	d := s.Duration()
+	entry := sessionRecordingEntry{
+		AgentID:       s.AgentID,
+		AgentAlive:    agentAlivePtr(s),
+		Title:         s.Title,
+		Agent:         s.AdapterName,
+		DurationSecs:  int(d.Seconds()),
+		Duration:      formatDurationHuman(d),
+		EntryCount:    s.EntryCount,
+		FilterMode:    s.FilterMode,
+		Model:         s.Model,
+		ProcessAlive:  alive,
+		ProcessStatus: status,
+		StartedAt:     s.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
+		SessionFile:   s.SessionFile,
+		WorkspacePath: s.WorkspacePath,
+		Branch:        s.Branch,
+	}
+	// ADR-020: propagate pause state per-row so multi-session JSON
+	// consumers can distinguish suspended sessions from active ones.
+	// Mirrors the single-session output's pause surface.
+	if s.SuspendedAt != nil {
+		entry.Suspended = true
+		entry.SuspendedAt = s.SuspendedAt.Format("2006-01-02T15:04:05Z07:00")
+		entry.SuspendedDuration = formatPausedDuration(time.Since(*s.SuspendedAt))
+		entry.PauseCount = s.PauseCount
+		entry.InheritedPause = s.InheritedPause
+		entry.InheritedFromSession = s.InheritedFromSession
+	}
+	return entry
 }
 
 func init() {
@@ -326,25 +374,8 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 	if jsonOutput {
 		var entries []sessionRecordingEntry
 		for _, s := range states {
-			d := s.Duration()
 			alive, status := agentLivenessFor(agentAlive, s.AgentID)
-			entries = append(entries, sessionRecordingEntry{
-				AgentID:       s.AgentID,
-				AgentAlive:    agentAlivePtr(s),
-				Title:         s.Title,
-				Agent:         s.AdapterName,
-				DurationSecs:  int(d.Seconds()),
-				Duration:      formatDurationHuman(d),
-				EntryCount:    s.EntryCount,
-				FilterMode:    s.FilterMode,
-				Model:         s.Model,
-				ProcessAlive:  alive,
-				ProcessStatus: status,
-				StartedAt:     s.StartedAt.Format("2006-01-02T15:04:05Z07:00"),
-				SessionFile:   s.SessionFile,
-				WorkspacePath: s.WorkspacePath,
-				Branch:        s.Branch,
-			})
+			entries = append(entries, buildSessionRecordingEntry(s, alive, status))
 		}
 		return outputJSON(cmd.OutOrStdout(), sessionStatusOutput{
 			Recording: true,

--- a/cmd/ox/session_status.go
+++ b/cmd/ox/session_status.go
@@ -128,6 +128,14 @@ type sessionStatusOutput struct {
 	LastHookAt      string `json:"last_hook_at,omitempty"`
 	Stalled         bool   `json:"stalled,omitempty"` // hooks fired but no entries captured
 	StalledReason   string `json:"stalled_reason,omitempty"`
+
+	// ADR-020 pause/resume surface
+	Suspended            bool   `json:"suspended,omitempty"`              // true while SuspendedAt != nil
+	SuspendedAt          string `json:"suspended_at,omitempty"`           // RFC3339
+	SuspendedDuration    string `json:"suspended_duration,omitempty"`     // human-readable
+	PauseCount           int    `json:"pause_count,omitempty"`            // monotonic counter
+	InheritedPause       bool   `json:"inherited_pause,omitempty"`        // started suspended via /clear marker
+	InheritedFromSession string `json:"inherited_from_session,omitempty"` // session that finalized at /clear
 }
 
 // sessionRecordingEntry represents one active recording in the multi-session output.
@@ -249,6 +257,16 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 				LastHookAt:      lastHookAtStr,
 				Stalled:         stalled,
 				StalledReason:   stalledReason,
+			}
+			// ADR-020: surface pause state in status JSON
+			if state.SuspendedAt != nil {
+				output.Suspended = true
+				output.SuspendedAt = state.SuspendedAt.Format("2006-01-02T15:04:05Z07:00")
+				output.SuspendedDuration = formatPausedDuration(time.Since(*state.SuspendedAt))
+				output.PauseCount = state.PauseCount
+				output.InheritedPause = state.InheritedPause
+				output.InheritedFromSession = state.InheritedFromSession
+				output.Guidance = "Recording is SUSPENDED. Resume with `ox session resume` or stop with `ox session stop`."
 			}
 			return outputJSON(cmd.OutOrStdout(), output)
 		}

--- a/cmd/ox/session_status_pause_test.go
+++ b/cmd/ox/session_status_pause_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- ADR-020 multi-session pause-state surface (PR #627 follow-up) ---
+// Failure prevented: sessionRecordingEntry was missing all pause-related
+// fields, so `ox session status --json` with multiple recordings could not
+// tell which ones were suspended. The single-session JSON branch had the
+// fields; the multi-session loop dropped them silently.
+
+// TestBuildSessionRecordingEntry_PropagatesSuspendedFields — Failure
+// prevented: a suspended recording is indistinguishable from an active
+// one in the multi-session JSON.
+func TestBuildSessionRecordingEntry_PropagatesSuspendedFields(t *testing.T) {
+	pausedAt := time.Now().Add(-2 * time.Minute).UTC()
+	state := &session.RecordingState{
+		AgentID:              "OxsusA",
+		StartedAt:            time.Now().Add(-10 * time.Minute).UTC(),
+		EntryCount:           42,
+		SuspendedAt:          &pausedAt,
+		PauseCount:           3,
+		InheritedPause:       true,
+		InheritedFromSession: "2026-05-28-prev-session",
+	}
+
+	got := buildSessionRecordingEntry(state, nil, "unknown")
+
+	assert.True(t, got.Suspended, "Suspended must be true when SuspendedAt is set")
+	assert.NotEmpty(t, got.SuspendedAt, "SuspendedAt RFC3339 must be populated")
+	assert.NotEmpty(t, got.SuspendedDuration, "SuspendedDuration must be populated")
+	assert.Equal(t, 3, got.PauseCount)
+	assert.True(t, got.InheritedPause)
+	assert.Equal(t, "2026-05-28-prev-session", got.InheritedFromSession)
+}
+
+// TestBuildSessionRecordingEntry_ActiveSessionHasNoSuspendFields —
+// Failure prevented: pause fields leak onto non-suspended rows (e.g.,
+// stale memory from a prior iteration), confusing consumers that branch
+// on `suspended: true`.
+func TestBuildSessionRecordingEntry_ActiveSessionHasNoSuspendFields(t *testing.T) {
+	state := &session.RecordingState{
+		AgentID:    "OxactA",
+		StartedAt:  time.Now().Add(-5 * time.Minute).UTC(),
+		EntryCount: 7,
+		// SuspendedAt intentionally nil
+	}
+
+	got := buildSessionRecordingEntry(state, nil, "alive")
+
+	assert.False(t, got.Suspended)
+	assert.Empty(t, got.SuspendedAt)
+	assert.Empty(t, got.SuspendedDuration)
+	assert.Zero(t, got.PauseCount)
+	assert.False(t, got.InheritedPause)
+	assert.Empty(t, got.InheritedFromSession)
+}

--- a/cmd/ox/session_stop.go
+++ b/cmd/ox/session_stop.go
@@ -116,6 +116,24 @@ func processSession(projectRoot string, state *session.RecordingState) (*process
 		entries = append(entries, entry)
 	}
 
+	// ADR-020: apply pause/resume segment mask BEFORE secret redaction.
+	// The mask excludes entries whose 0-indexed position falls in any
+	// [pause_seq, resume_seq) range from the lifecycle timeline.
+	// Order matters only for performance (don't redact entries being dropped);
+	// correctness is identical either way.
+	if len(state.Lifecycle) > 0 {
+		originalCount := len(entries)
+		entries = session.ApplySegmentMask(entries, state.Lifecycle)
+		result.EntryCount = len(entries)
+
+		// validator: fail-closed if the mask result doesn't match what the
+		// lifecycle says should have been excluded. Aborts upload before
+		// any paused-range entries can leak.
+		if msg := validateMaskInvariant(originalCount, len(entries), state.Lifecycle); msg != "" {
+			return nil, fmt.Errorf("upload aborted: %s", msg)
+		}
+	}
+
 	// redact secrets from entries (modifies in place)
 	result.SecretsRedacted = redactor.RedactEntries(entries)
 

--- a/cmd/ox/session_validate.go
+++ b/cmd/ox/session_validate.go
@@ -73,10 +73,11 @@ func validateMaskInvariant(originalCount, postMaskCount int, lifecycle []session
 		return ""
 	}
 
-	// Build a synthetic slice the same size as original and use CountMaskedEntries
-	// to compute how many SHOULD be excluded.
-	stub := make([]session.SessionEntry, originalCount)
-	expectedMasked := session.CountMaskedEntries(stub, lifecycle)
+	// Compute how many entries SHOULD be excluded directly from the count —
+	// avoid allocating `originalCount` SessionEntry values just to drive a
+	// counting loop. Sessions on the upload path can be tens of thousands
+	// of entries; the allocation is pure GC pressure.
+	expectedMasked := session.CountMaskedEntriesByTotal(originalCount, lifecycle)
 	actualMasked := originalCount - postMaskCount
 
 	if expectedMasked != actualMasked {

--- a/cmd/ox/session_validate.go
+++ b/cmd/ox/session_validate.go
@@ -56,6 +56,35 @@ var invalidLeakedTypes = map[string]bool{
 	"last-prompt":           true,
 }
 
+// validateMaskInvariant verifies that ApplySegmentMask correctly removed
+// every entry that should have been excluded by the lifecycle timeline.
+//
+// Called by processSession AFTER mask application. Returns an error string
+// if the post-mask count doesn't match what CountMaskedEntries computed
+// against the pre-mask slice — that mismatch indicates the mask was
+// bypassed or malformed and paused work would otherwise leak to upload.
+//
+// See ADR-020 client-side validator.
+func validateMaskInvariant(originalCount, postMaskCount int, lifecycle []session.LifecycleEvent) string {
+	if len(lifecycle) == 0 {
+		if originalCount != postMaskCount {
+			return fmt.Sprintf("mask invariant: no lifecycle events but %d entries dropped", originalCount-postMaskCount)
+		}
+		return ""
+	}
+
+	// Build a synthetic slice the same size as original and use CountMaskedEntries
+	// to compute how many SHOULD be excluded.
+	stub := make([]session.SessionEntry, originalCount)
+	expectedMasked := session.CountMaskedEntries(stub, lifecycle)
+	actualMasked := originalCount - postMaskCount
+
+	if expectedMasked != actualMasked {
+		return fmt.Sprintf("mask invariant: lifecycle expects %d masked entries but %d were dropped (paused range may leak to upload)", expectedMasked, actualMasked)
+	}
+	return ""
+}
+
 // validateEntries checks processed session entries for data quality issues.
 // Runs after the adapter has converted raw entries but before upload.
 func validateEntries(entries []session.Entry) *sessionValidation {

--- a/cmd/ox/session_validate_mask_test.go
+++ b/cmd/ox/session_validate_mask_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateMaskInvariant_NoLifecycle(t *testing.T) {
+	// No lifecycle + counts match → no error.
+	assert.Empty(t, validateMaskInvariant(10, 10, nil))
+
+	// No lifecycle but entries dropped → error (something masked entries without lifecycle).
+	assert.Contains(t, validateMaskInvariant(10, 7, nil), "no lifecycle events but 3 entries dropped")
+}
+
+func TestValidateMaskInvariant_MatchingMask(t *testing.T) {
+	lifecycle := []session.LifecycleEvent{
+		{Action: session.LifecycleActionPause, Seq: 3, At: time.Now()},
+		{Action: session.LifecycleActionResume, Seq: 7, At: time.Now()},
+	}
+	// Original 10, after mask 6 (4 dropped: indices 3..6)
+	assert.Empty(t, validateMaskInvariant(10, 6, lifecycle))
+}
+
+func TestValidateMaskInvariant_LeakDetected(t *testing.T) {
+	lifecycle := []session.LifecycleEvent{
+		{Action: session.LifecycleActionPause, Seq: 3, At: time.Now()},
+		{Action: session.LifecycleActionResume, Seq: 7, At: time.Now()},
+	}
+	// Mask should drop 4 entries (indices 3..6) but caller passed 10→10 (no drop).
+	got := validateMaskInvariant(10, 10, lifecycle)
+	assert.Contains(t, got, "mask invariant")
+	assert.Contains(t, got, "lifecycle expects 4 masked entries but 0 were dropped")
+}
+
+func TestValidateMaskInvariant_OpenEndedPauseToEOS(t *testing.T) {
+	lifecycle := []session.LifecycleEvent{
+		{Action: session.LifecycleActionPause, Seq: 5, At: time.Now()},
+	}
+	// Original 10, open-ended pause from 5 → exclude indices 5..9 (5 entries) → 5 remain
+	assert.Empty(t, validateMaskInvariant(10, 5, lifecycle))
+
+	// Tampered: only 1 dropped instead of 5
+	got := validateMaskInvariant(10, 9, lifecycle)
+	assert.Contains(t, got, "lifecycle expects 5")
+}

--- a/docs/adr/ADR-019-session-entity-lifecycle.md
+++ b/docs/adr/ADR-019-session-entity-lifecycle.md
@@ -1,3 +1,5 @@
+<!-- doc-audience: ai -->
+
 # ADR-019: Session Entity Lifecycle
 
 **Status**: Accepted
@@ -27,7 +29,7 @@ Sessions are owned by **one** `SAGEOX_AGENT_ID`. Subagents have their own sessio
 
 ### State Machine
 
-```
+```text
                   ┌─────────────────┐
                   │ not-recording   │
                   └────────┬────────┘
@@ -106,7 +108,7 @@ The existing `StatusPaused` (`internal/session/classify.go:40`) labels a *stoppe
 **User-visible notice** (new in this ADR):
 The post-`/clear` prime invocation emits a `UserNotification` describing the boundary transition. Format:
 
-```
+```text
 [ox] /clear → previous session Ox{id} ({status}, {duration}) finalized.
      New session Ox{id} started. Recording: {on|off}.
 ```

--- a/docs/adr/ADR-019-session-entity-lifecycle.md
+++ b/docs/adr/ADR-019-session-entity-lifecycle.md
@@ -1,0 +1,161 @@
+# ADR-019: Session Entity Lifecycle
+
+**Status**: Accepted
+**Date**: 2026-05-27
+
+## Context
+
+ADR-004 codified the **hook→phase** mapping (start/prompt/aftertool/compact/stop) — how heterogeneous agent events resolve to a small canonical phase set. That ADR addresses *what hooks do during a session*.
+
+It does **not** address the higher-level question of what a "session" *is* as an entity, what states it can occupy, and how it moves between them. Multiple parts of the codebase — `internal/session/classify.go` (status enum), `internal/session/recording.go` (RecordingState), `internal/daemon/agentwork/session_finalize.go` (anti-entropy), `cmd/ox/agent_hook.go:stopSessionForClear` (clear boundary), `cmd/ox/agent_session_abort.go` (cancel) — each implement a *piece* of the entity lifecycle without a single source of truth.
+
+This has caused recurring confusion:
+- `/clear` is already a session boundary (`agent_hook.go:262-279`, `stopSessionForClear`), but no doc says so. New contributors assume `/clear` is invisible to ox.
+- `/compact` is **not** a session boundary (same `forceReprime` path stops + restarts, but the design intent for compact is "in-session" — and current behavior is inconsistent with that intent: compact today also calls `stopSessionForClear`, finalizing the session, which is wrong for token compression).
+- The `StatusPaused` constant means "user stopped, not uploaded" — a *classifier label*, not a lifecycle-active state. Adding pause/resume (ADR-020) requires a separate active state.
+- Marker files (`.session_stopped.<agentID>`) are scattered across `cmd/ox/agent_session.go` and `internal/session/recording.go` with no canonical lifecycle doc.
+
+This ADR codifies the session entity state machine so future work — including ADR-020 pause/resume — has a stable foundation.
+
+## Decision
+
+### Session as Entity
+
+A **session** is one continuous unit of agent activity from `start` to terminal upload or discard. It has a stable identity (`session_name`, derived from timestamp+user+agentID at start), a recording cache directory (`state.SessionPath`), and a final ledger destination.
+
+Sessions are owned by **one** `SAGEOX_AGENT_ID`. Subagents have their own sessions linked via `ParentSessionPath` / `ParentAgentID`.
+
+### State Machine
+
+```
+                  ┌─────────────────┐
+                  │ not-recording   │
+                  └────────┬────────┘
+                           │ start
+                           ▼
+                  ┌─────────────────┐
+                  │   recording     │◄────────┐
+                  └────┬────────┬───┘         │
+              suspend  │        │ /clear      │ resume
+                       ▼        │  (boundary) │
+              ┌─────────────┐   │             │
+              │  suspended  │───┘             │
+              └─────┬───┬───┘ ┌───────────────┘
+                    │   └─────┘
+              stop  │       PID dead + grace
+                    │       (orphan path)
+                    ▼
+                  ┌─────────────────┐
+                  │    stopped      │   (terminal-local)
+                  └────────┬────────┘
+                           │ upload
+                           ▼
+                  ┌─────────────────┐
+                  │    uploaded     │   (terminal-remote)
+                  └─────────────────┘
+
+   Failure / discard branches:
+   recording ──> ghost   (PID dead, no data, ≥ grace)
+   recording ──> orphan  (PID dead, has data, ≥ grace) ──> local ──> uploaded
+   any-recording-state ──> canceled (terminal, data discarded)
+```
+
+| State | `SessionStatus` constant | Meaning |
+|---|---|---|
+| not-recording | (no state file) | No active session for this agent |
+| recording | `StatusRecording` | Tail-watcher/hooks appending entries |
+| suspended | `StatusSuspended` (ADR-020) | User-paused; recording still appends locally, lifecycle marks the range excluded for upload |
+| stopped | `StatusPaused` (legacy name — see "Naming note" below) | User stopped; data preserved locally; awaiting upload |
+| local | `StatusLocal` | On-disk but not uploaded (recovered orphan or stopped) |
+| uploaded | `StatusUploaded` | Committed to ledger |
+| ghost | `StatusGhost` | Parent dead, no data — safe to delete |
+| orphan | `StatusOrphan` | Parent dead, has data — needs recovery |
+| canceled | `StatusCanceled` | User explicitly discarded (terminal — data deleted) |
+
+### Naming note
+
+The existing `StatusPaused` (`internal/session/classify.go:40`) labels a *stopped-but-not-uploaded* session. Despite the name it is **not** an active-pause state. ADR-020 introduces `StatusSuspended` for true active pause. The existing `StatusPaused` constant is **not** renamed — doing so would migrate `.recording.json` files on every user's disk and uploaded ledger metadata, for cosmetic gain.
+
+### Transitions
+
+| From | To | Trigger | Side effect |
+|---|---|---|---|
+| not-recording | recording | `StartRecording`, hook-init, prime auto-start | New `RecordingState` written |
+| recording | suspended | `ox session pause` (ADR-020) | Lifecycle event + `.session_paused.<agentID>` marker |
+| suspended | recording | `ox session resume` (ADR-020) | Lifecycle event + marker cleared |
+| recording / suspended | stopped | `ox session stop`, `SessionEnd` hook | `StoppedAt` set; daemon finalizes |
+| recording / suspended | canceled | `ox session abort` | Marker `.session_canceled`; cache deleted |
+| stopped | local | Daemon detects stopped + has data | Eligible for upload |
+| local | uploaded | Upload pipeline | Committed to ledger; cache pointer-ized per cache-only rule |
+| recording / suspended | ghost | PID dead, no data, ≥ 5min `ghostHeuristicAge` | Cleanup eligible |
+| recording / suspended | orphan | PID dead, has data, ≥ grace | Daemon recovery path |
+| orphan | local | Daemon recovery finalizes | Same as stop |
+
+### `/clear` is a Session Boundary
+
+**Behavior** (already implemented in `cmd/ox/agent_hook.go:262-279,302-338`):
+- `SessionStart` hook with `source = "clear"` triggers `forceReprime`.
+- `stopSessionForClear` sets `StoppedAt` on the prior recording, fires a fire-and-forget daemon finalize IPC, and clears recording state.
+- `runPrimeForHook` then starts a new session in the same `SAGEOX_AGENT_ID` lineage (via `CLAUDE_ENV_FILE` env persistence).
+
+**Why** `/clear` is a boundary:
+- `/clear` wipes the agent's conversation memory. The prior context is gone from the agent's perspective.
+- Continuing a single `raw.jsonl` across `/clear` would conflate unrelated logical units.
+- Agent ID lineage continuity is preserved separately so user identity feels stable.
+
+**User-visible notice** (new in this ADR):
+The post-`/clear` prime invocation emits a `UserNotification` describing the boundary transition. Format:
+
+```
+[ox] /clear → previous session Ox{id} ({status}, {duration}) finalized.
+     New session Ox{id} started. Recording: {on|off}.
+```
+
+When ADR-020 ships, the notice gains an inherited-pause variant.
+
+### `/compact` is NOT a Session Boundary
+
+**Intended behavior**: `/compact` is token-window compression. The agent summarizes prior turns; the session continues. Same `raw.jsonl` keeps growing.
+
+**Current code** (`agent_hook.go:262`) treats `compact` the same as `clear` (`forceReprime = source == "clear" || source == "compact"`). This conflates two different events. **This ADR formally specifies that `/compact` should not finalize the session**; a follow-up issue tracks separating the two paths so `/compact` only re-primes context without stopping recording. Until that fix lands, callers who care about session continuity across compaction should rely on the daemon's incremental drain to keep raw.jsonl up to date.
+
+### Marker File Invariants
+
+| Marker | Owner | Survives `/clear` | Cleared by |
+|---|---|---|---|
+| `.session_stopped.<agentID>` | `MarkExplicitStop` (`recording.go:370`) | No (consumed at prime) | `ConsumeExplicitStop` |
+| `.session_paused.<agentID>` (ADR-020) | `MarkExplicitPause` | **Yes** | resume / stop / abort / expiration |
+| `.session_clear_notice.<agentID>` (this ADR) | `stopSessionForClear` env handoff | N/A — env-scoped, one-shot | prime subprocess read |
+
+Markers are written to the canonical sessions cache directory (`paths.LedgerSessionCacheBase` when endpoint configured, else XDG cache). Reads search alternate XDG cache dirs (`sessionsSearchPaths` in `recording.go:438`) to bridge processes with different `XDG_CACHE_HOME` values (Conductor GUI vs terminal shell).
+
+### PID-Death + Grace
+
+`ghostHeuristicAge` = 5 minutes (`classify.go:50`). After grace:
+- No data → `ghost` → cleanup eligible.
+- Has data → `orphan` → daemon recovery via `session_finalize.go` finalize path.
+
+ADR-020 adds `PauseGhostGrace` = 15 minutes for suspended-then-PID-dead sessions, applied via the existing orphan path.
+
+## Consequences
+
+**Benefits**:
+- Single source of truth for the entity lifecycle (this ADR + the `SessionStatus` constants).
+- ADR-020 has a clean foundation to build pause/resume on.
+- New contributors don't reinvent partial state machines.
+- The `/clear` notice surfaces an existing-but-invisible boundary to users.
+
+**Tradeoffs**:
+- `StatusPaused` legacy name persists. Disambiguated by `StatusSuspended` in ADR-020.
+- The `/compact` separation from `/clear` is intent-only here; the code unification at `agent_hook.go:262` is tracked as a follow-up.
+
+## Cross-References
+
+- ADR-004: hook→phase mapping (the layer below this one).
+- ADR-005: anti-entropy (daemon-side state recovery uses these states).
+- ADR-016: session summarization (consumes uploaded sessions; the state machine guarantees what summarizer sees).
+- ADR-020: session pause/resume (built on this ADR; introduces `StatusSuspended`).
+- `internal/session/classify.go` — `SessionStatus` constants and `ClassifySession`.
+- `internal/session/recording.go` — `RecordingState`, `MarkExplicitStop`, `ClearRecordingStateForAgent`.
+- `cmd/ox/agent_hook.go:262-338` — `/clear` boundary implementation.
+- `internal/daemon/agentwork/session_finalize.go` — orphan finalization path.

--- a/docs/adr/ADR-020-session-pause-resume.md
+++ b/docs/adr/ADR-020-session-pause-resume.md
@@ -1,3 +1,5 @@
+<!-- doc-audience: ai -->
+
 # ADR-020: Session Pause/Resume
 
 **Status**: Accepted
@@ -57,7 +59,7 @@ A project-level "all agents paused" or TTL-bounded variant was rejected for fail
 
 While `state.SuspendedAt != nil`, `handlePrompt` in `cmd/ox/agent_hook.go` emits a `<system-reminder>` on every `UserPromptSubmit`:
 
-```
+```text
 [ox] ⏸ Recording SUSPENDED (3h 14m ago). Resume: /ox-session-resume · Stop: /ox-session-stop
 ```
 
@@ -67,14 +69,14 @@ Scoped to the **current agent's** suspended session only — other repo paused s
 
 `stopSessionForClear` captures finalized-session info (name, status including `was_suspended`, duration) into `OX_CLEAR_PRIOR_SESSION` env. The prime subprocess reads it via `parseClearNoticeEnv` and emits a `UserNotification`:
 
-```
+```text
 [ox] /clear → previous session Ox{id} ({status}, {duration}) finalized.
      New session Ox{id} started. Recording: {on|off}.
 ```
 
 The suspended variant emits:
 
-```
+```text
 [ox] /clear → previous session Ox{id} (suspended, {duration}) finalized.
      Paused range excluded from upload.
      New session Ox{id} started — RECORDING SUSPENDED (carried from previous).

--- a/docs/adr/ADR-020-session-pause-resume.md
+++ b/docs/adr/ADR-020-session-pause-resume.md
@@ -1,0 +1,145 @@
+# ADR-020: Session Pause/Resume
+
+**Status**: Accepted
+**Date**: 2026-05-27
+
+## Context
+
+GH issue #134 asked for `ox session pause` / `ox session resume` so users can temporarily suspend recording during work that should not be part of the session summary — debugging an unrelated issue, system maintenance, side errands. Today the only options are:
+
+- **Stop + Start** → two unrelated sessions; loses logical continuity.
+- **Keep recording** → captures unrelated work that pollutes the eventual summary.
+
+ADR-019 codifies the session entity lifecycle. This ADR builds the pause/resume feature on top of it.
+
+## Decision
+
+### Pause is a temporal redaction scope
+
+A pause does not stop ingestion. The local cache `raw.jsonl` keeps growing through the suspended interval. At upload time (`cmd/ox/session_stop.go:processSession`), a **segment mask** computed from the lifecycle timeline excludes all entries whose 0-indexed position falls in any `[pause_seq, resume_seq)` range. Local cache stays complete (recovery available); ledger upload is scrubbed.
+
+This unifies pause with the existing post-hoc redaction infrastructure (`internal/session/redact_rules.go`). Pause IS redaction — just with temporal scope instead of pattern matching.
+
+### Single active-pause state, no rename
+
+A new `SessionStatus` constant `StatusSuspended` represents active pause. The existing `StatusPaused` (which actually means "user stopped, not uploaded") is **not** renamed — that would migrate `.recording.json` files on every user's disk and uploaded ledger metadata for cosmetic gain. ADR-019 documents the legacy name; `ClassifySession` returns `StatusSuspended` when `Recording && SuspendedAt != nil && agent_pid_alive`.
+
+### Tail-watcher never gates appends
+
+Pause is purely a CLI-side state mutation. The daemon tail-watcher and hook-driven append paths keep writing to local cache throughout the suspended interval. No append-race during the pause boundary. No new IPC. Mask runs only at upload.
+
+This collapses the race-condition surface to zero — there's no point during the suspended window where a write needs to be blocked.
+
+### Marker file survives `/clear`
+
+`internal/session/pause_marker.go` writes `.session_paused.<agentID>` to the canonical sessions cache directory on pause. Unlike `.session_stopped.<agentID>` (consumed at the next prime), the pause marker **survives `/clear`**. New post-`/clear` sessions inherit the suspended state via `PeekExplicitPause` in `cmd/ox/agent_prime.go:startSessionRecording`. The marker is cleared by:
+
+- `ox session resume`
+- `ox session stop`
+- `ox session abort`
+- daemon expiration after PID-death grace
+
+### Per-agent stickiness only
+
+Pause stickiness is keyed by `SAGEOX_AGENT_ID`. New terminal / new agent process = new agent ID = fresh start, no inheritance. This favors over-capture (recoverable) over silent under-capture (irrecoverable).
+
+A project-level "all agents paused" or TTL-bounded variant was rejected for failing toward silent data loss.
+
+### Subagent inheritance
+
+| Scenario | Behavior |
+|---|---|
+| Existing subagent running at pause time | Keeps recording. Finishes + uploads its own session normally. No cascade. |
+| Subagent spawned during pause | `startSessionRecording` detects parent's pause marker (or in-flight `SuspendedAt`) and skips `StartRecording` entirely. Subagent runs without ox tracking. Prime emits a one-line notice. |
+| Subagent outlives parent's pause | Subagent stays unrecorded for its lifetime. No retroactive recording. |
+
+### Per-prompt nudge
+
+While `state.SuspendedAt != nil`, `handlePrompt` in `cmd/ox/agent_hook.go` emits a `<system-reminder>` on every `UserPromptSubmit`:
+
+```
+[ox] ⏸ Recording SUSPENDED (3h 14m ago). Resume: /ox-session-resume · Stop: /ox-session-stop
+```
+
+Scoped to the **current agent's** suspended session only — other repo paused sessions don't bleed into the nudge.
+
+### `/clear` notice
+
+`stopSessionForClear` captures finalized-session info (name, status including `was_suspended`, duration) into `OX_CLEAR_PRIOR_SESSION` env. The prime subprocess reads it via `parseClearNoticeEnv` and emits a `UserNotification`:
+
+```
+[ox] /clear → previous session Ox{id} ({status}, {duration}) finalized.
+     New session Ox{id} started. Recording: {on|off}.
+```
+
+The suspended variant emits:
+
+```
+[ox] /clear → previous session Ox{id} (suspended, {duration}) finalized.
+     Paused range excluded from upload.
+     New session Ox{id} started — RECORDING SUSPENDED (carried from previous).
+     Resume: /ox-session-resume · Stop: /ox-session-stop
+```
+
+### Expiration
+
+A suspended session with a dead parent PID past the existing `session.GhostGracePeriod` (10 min) falls through to the existing orphan finalization path. That path now applies the segment mask via `processSession`, so paused work is excluded from the upload regardless of whether the user explicitly resumed.
+
+No separate `StatusExpired` state. No hard time cap — process lifetime IS the cap, augmented by `ox doctor` as the user-facing escape hatch for stuck pauses.
+
+### Client-side validator
+
+`cmd/ox/session_validate.go:validateMaskInvariant` runs after `ApplySegmentMask` in `processSession`. It computes the expected masked count from the lifecycle timeline and compares against the actual post-mask count. Mismatch aborts upload — paused work cannot leak.
+
+Cloud-side validator is out of scope for this ADR.
+
+### Idempotency
+
+| Command | When | Behavior |
+|---|---|---|
+| `ox session pause` | already suspended | no-op, friendly message, exit 0 |
+| `ox session resume` | not suspended | no-op, friendly message, exit 0 |
+| `ox session pause` | not recording | friendly error, exit 1 |
+| `ox session resume` | not recording | friendly error, exit 1 |
+
+## Implementation
+
+| Component | Location |
+|---|---|
+| `StatusSuspended` constant | `internal/session/classify.go` |
+| `LifecycleEvent` + `LifecycleAction` | `internal/session/recording.go` |
+| `RecordingState.SuspendedAt`, `PauseCount`, `Lifecycle`, `InheritedPause`, `InheritedFromSession` | `internal/session/recording.go` |
+| `MarkExplicitPause` / `PeekExplicitPause` / `ConsumeExplicitPause` / `ClearExplicitPause` | `internal/session/pause_marker.go` |
+| `BuildSegmentRanges` / `ApplySegmentMask` / `CountMaskedEntries` | `internal/session/segment_mask.go` |
+| `ox agent <id> session pause` | `cmd/ox/agent_session_pause.go` |
+| `ox agent <id> session resume` | `cmd/ox/agent_session_resume.go` |
+| `/clear` post-prime notice handoff | `cmd/ox/clear_notice.go`, `cmd/ox/agent_hook.go:stopSessionForClear`, `cmd/ox/agent_prime.go` |
+| `/clear` × pause inheritance | `cmd/ox/agent_prime.go:startSessionRecording` |
+| Subagent inheritance | `cmd/ox/agent_prime.go:startSessionRecording` |
+| Per-prompt nudge | `cmd/ox/agent_hook.go:handlePrompt`, `emitSuspendedNudge` |
+| Upload mask application | `cmd/ox/session_stop.go:processSession` |
+| Mask invariant validator | `cmd/ox/session_validate.go:validateMaskInvariant` |
+| `ox session status` surface | `cmd/ox/session_status.go` |
+| Skills | `.claude/commands/ox-session-pause.md`, `.claude/commands/ox-session-resume.md` |
+
+## Consequences
+
+**Benefits**:
+- One unified mask path at upload — no parallel masking infrastructure.
+- Tail-watcher is unchanged; zero new race surface.
+- Local cache stays complete for forensic recovery.
+- Per-agent stickiness avoids silent data loss across context switches.
+- Adapter-agnostic — every adapter that writes monotonic seq entries to raw.jsonl works.
+
+**Tradeoffs**:
+- Paused work briefly occupies local disk until the next stop/abort. Acceptable — cache cleanup is separate.
+- The legacy `StatusPaused` name persists. Disambiguated in code and ADR.
+- Amp (cloud-first) records the lifecycle timeline but cannot gate cloud-side capture. Documented in agent-support-matrix.md.
+- Server-side mask validator is future work — client-side validator is fail-closed today.
+
+## Cross-references
+
+- ADR-019: session entity lifecycle (foundation).
+- ADR-004: hook → phase mapping (the layer below).
+- `internal/session/segment_mask_test.go`: 200-trial property test.
+- GH issue #134.

--- a/docs/ai/specs/agent-support-matrix.md
+++ b/docs/ai/specs/agent-support-matrix.md
@@ -48,6 +48,11 @@ Agent-specific hooks (`ox integrate install --<agent>`) are *additive* — they 
 | Anti-entropy (daemon recovery) | Yes | Partial (adapter exists, untested E2E) | Yes | No | No |
 | Multi-turn incremental recording | Yes (JSONL append) | Yes (full re-read delta) | Yes (JSONL append) | No | No |
 | E2E integration tests | Yes (real Claude) | No (needs GEMINI_API_KEY CI) | No (needs OPENAI_API_KEY CI) | No | No |
+| **Session pause/resume** (ADR-020) | | | | | |
+| `ox session pause/resume` commands | Yes | Yes | Yes | Yes | Yes |
+| Per-prompt suspended nudge | Yes (UserPromptSubmit) | Yes (BeforeAgent equivalent) | Limited (no push channel) | Limited | Possible (tui.prompt.append) |
+| `/clear` boundary + pause inheritance | Yes | N/A (different lifecycle) | N/A (different lifecycle) | N/A | N/A |
+| Upload mask honoring lifecycle | Yes (adapter-agnostic) | Yes | Yes | Yes (lifecycle-only; cloud-side data not gated) | Yes |
 
 ## Overall Tier Status
 

--- a/internal/codedb/dirty_integration_test.go
+++ b/internal/codedb/dirty_integration_test.go
@@ -28,9 +28,10 @@ func initTestRepo(t *testing.T) string {
 			"GIT_COMMITTER_NAME=test",
 			"GIT_COMMITTER_EMAIL=test@sageox.ai",
 			// scrub host gitconfig so commit.gpgsign / signingkey can't prompt
-			// for ssh/gpg passphrases during the test commit.
-			"GIT_CONFIG_GLOBAL=/dev/null",
-			"GIT_CONFIG_SYSTEM=/dev/null",
+			// for ssh/gpg passphrases during the test commit. os.DevNull keeps
+			// this portable to Windows CI (NUL there, /dev/null elsewhere).
+			"GIT_CONFIG_GLOBAL=" + os.DevNull,
+			"GIT_CONFIG_SYSTEM=" + os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/internal/codedb/dirty_integration_test.go
+++ b/internal/codedb/dirty_integration_test.go
@@ -27,6 +27,10 @@ func initTestRepo(t *testing.T) string {
 			"GIT_AUTHOR_EMAIL=test@sageox.ai",
 			"GIT_COMMITTER_NAME=test",
 			"GIT_COMMITTER_EMAIL=test@sageox.ai",
+			// scrub host gitconfig so commit.gpgsign / signingkey can't prompt
+			// for ssh/gpg passphrases during the test commit.
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/internal/ledger/automerge/automerge_test.go
+++ b/internal/ledger/automerge/automerge_test.go
@@ -24,11 +24,23 @@ func initTestRepo(t *testing.T, dir string) string {
 	return dir
 }
 
+// hermeticGitEnv layers env overrides that scrub host gitconfig so per-user
+// signing (commit.gpgsign + ssh signingkey) can't prompt for passphrases
+// during test commits. Applied to every git subprocess in this package.
+func hermeticGitEnv() []string {
+	return []string{
+		"GIT_EDITOR=true",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	}
+}
+
 func mustGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=true", "GIT_TERMINAL_PROMPT=0") // safe: tempdir git subprocess; layered env disables editor + prompts
+	cmd.Env = append(os.Environ(), hermeticGitEnv()...) // safe: tempdir git subprocess; hermetic env disables editor, prompts, host signing
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(out))
@@ -41,7 +53,7 @@ func mustGit(t *testing.T, dir string, args ...string) string {
 func runGitAllowFail(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=true", "GIT_TERMINAL_PROMPT=0") // safe: same as mustGit; tolerates non-zero exit (rebase conflicts)
+	cmd.Env = append(os.Environ(), hermeticGitEnv()...) // safe: same as mustGit; tolerates non-zero exit (rebase conflicts)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }

--- a/internal/ledger/automerge/automerge_test.go
+++ b/internal/ledger/automerge/automerge_test.go
@@ -27,12 +27,14 @@ func initTestRepo(t *testing.T, dir string) string {
 // hermeticGitEnv layers env overrides that scrub host gitconfig so per-user
 // signing (commit.gpgsign + ssh signingkey) can't prompt for passphrases
 // during test commits. Applied to every git subprocess in this package.
+// os.DevNull keeps the helper portable to Windows CI (NUL there,
+// /dev/null elsewhere).
 func hermeticGitEnv() []string {
 	return []string{
 		"GIT_EDITOR=true",
 		"GIT_TERMINAL_PROMPT=0",
-		"GIT_CONFIG_GLOBAL=/dev/null",
-		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_CONFIG_SYSTEM=" + os.DevNull,
 	}
 }
 

--- a/internal/session/classify.go
+++ b/internal/session/classify.go
@@ -10,34 +10,47 @@ import (
 
 // SessionStatus represents the lifecycle state of a session.
 //
+// See ADR-019 (session entity lifecycle) for the canonical state machine and
+// transition rules. ADR-020 adds StatusSuspended for active pause.
+//
 // Lifecycle:
 //
 //	           ┌──────────┐
-//	           │ recording│
-//	           └────┬─────┘
-//	     ┌──────────┼──────────┐
-//	     ▼          ▼          ▼
-//	┌────────┐ ┌────────┐ ┌────────┐
-//	│ paused │ │ ghost  │ │ orphan │
-//	└───┬────┘ └───┬────┘ └───┬────┘
-//	    │       (cleanup)  (finalize)
-//	    ▼                      │
-//	┌────────┐                 │
-//	│ local  │◄────────────────┘
-//	└───┬────┘
-//	    ▼
-//	┌──────────┐
-//	│ uploaded  │
-//	└──────────┘
+//	           │ recording│◄─────────────┐
+//	           └────┬─────┘  resume      │
+//	  ┌─────┬──────┼──────┬─────────┐    │
+//	  │     │      ▼      ▼         ▼    │ pause
+//	  │     │  ┌────────┐ ┌────────┐     │
+//	  │     │  │ ghost  │ │ orphan │  ┌──┴──────┐
+//	  │     │  └───┬────┘ └───┬────┘  │suspended│
+//	  │     │  (cleanup)  (finalize)  └─────────┘
+//	  │     ▼               │
+//	  │  ┌────────┐         │
+//	  │  │ paused │         │
+//	  │  └───┬────┘         │
+//	  │      ▼              │
+//	  │  ┌────────┐         │
+//	  └─►│ local  │◄────────┘
+//	     └───┬────┘
+//	         ▼
+//	     ┌──────────┐
+//	     │ uploaded │
+//	     └──────────┘
 //
 //	┌──────────┐
-//	│ canceled  │  (terminal — data discarded)
+//	│ canceled │  (terminal — data discarded)
 //	└──────────┘
+//
+// NOTE: StatusPaused is a legacy name meaning "user stopped, data preserved,
+// not yet uploaded" (NOT active pause). StatusSuspended is the active-pause
+// state introduced by ADR-020. The legacy constant is preserved verbatim to
+// avoid migrating .recording.json files and uploaded ledger metadata.
 type SessionStatus string
 
 const (
 	StatusRecording SessionStatus = "recording" // actively being recorded, parent process alive
-	StatusPaused    SessionStatus = "paused"    // user explicitly stopped recording (data preserved, not yet uploaded)
+	StatusSuspended SessionStatus = "suspended" // active pause, recording continues locally, upload will exclude paused range (ADR-020)
+	StatusPaused    SessionStatus = "paused"    // user explicitly stopped recording (data preserved, not yet uploaded) — LEGACY NAME
 	StatusGhost     SessionStatus = "ghost"     // parent dead, no substantive data — safe to delete
 	StatusOrphan    SessionStatus = "orphan"    // parent dead, has data — needs recovery/finalization
 	StatusLocal     SessionStatus = "local"     // exists locally, not uploaded (may have been recovered from orphan)
@@ -81,6 +94,13 @@ func ClassifySession(info SessionInfo, isUploaded bool) SessionStatus {
 			return StatusOrphan
 		}
 		return StatusGhost
+	}
+
+	// ADR-020: active pause has its own status. Reported only while the agent
+	// is alive — if PID is dead past grace, the existing orphan path handles
+	// finalization with the paused range honored at upload.
+	if info.SuspendedAt != nil {
+		return StatusSuspended
 	}
 
 	return StatusRecording

--- a/internal/session/lifecycle_test.go
+++ b/internal/session/lifecycle_test.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClassifySession_Suspended verifies ADR-020 active-pause is reported
+// when the agent is alive and SuspendedAt is set.
+func TestClassifySession_Suspended(t *testing.T) {
+	alivePID := os.Getpid()
+	now := time.Now()
+
+	info := SessionInfo{
+		Recording:   true,
+		ParentPID:   alivePID,
+		CreatedAt:   now.Add(-2 * time.Minute),
+		HasRawData:  true,
+		EntryCount:  10,
+		SuspendedAt: &now,
+	}
+
+	got := ClassifySession(info, false)
+	assert.Equal(t, StatusSuspended, got)
+}
+
+// TestClassifySession_SuspendedDeadAgent verifies that a suspended-then-PID-dead
+// session past grace falls through to the orphan path (not Suspended). The
+// orphan path finalizes the session with the paused range honored at upload.
+func TestClassifySession_SuspendedDeadAgent(t *testing.T) {
+	now := time.Now()
+
+	info := SessionInfo{
+		Recording:   true,
+		ParentPID:   1, // init never matches in practice; isPIDAlive returns true on most systems though
+		CreatedAt:   now.Add(-30 * time.Minute),
+		HasRawData:  true,
+		EntryCount:  10,
+		SuspendedAt: &now,
+	}
+
+	// Use ParentPID=0 to force the no-PID branch (age-based abandonment).
+	info.ParentPID = 0
+	got := ClassifySession(info, false)
+	assert.Equal(t, StatusOrphan, got, "PID-dead past grace must classify as orphan even when SuspendedAt is set")
+}
+
+// TestClassifySession_RecordingUnchanged verifies the non-suspended live path
+// still returns StatusRecording (no SuspendedAt means classic recording).
+func TestClassifySession_RecordingUnchanged(t *testing.T) {
+	info := SessionInfo{
+		Recording:  true,
+		ParentPID:  os.Getpid(),
+		CreatedAt:  time.Now().Add(-1 * time.Minute),
+		HasRawData: true,
+		EntryCount: 5,
+	}
+	got := ClassifySession(info, false)
+	assert.Equal(t, StatusRecording, got)
+}
+
+// TestRecordingState_BackwardCompatibleLoad verifies that .recording.json
+// files written without the new ADR-020 fields (Lifecycle, SuspendedAt,
+// PauseCount, InheritedPause, InheritedFromSession) still load cleanly.
+func TestRecordingState_BackwardCompatibleLoad(t *testing.T) {
+	// minimal pre-ADR-020 .recording.json content
+	legacyJSON := `{
+		"agent_id": "Oxlegacy",
+		"started_at": "2026-05-26T12:00:00Z",
+		"adapter_name": "claude-code",
+		"session_file": "/tmp/source.jsonl",
+		"output_file": "/tmp/out.jsonl",
+		"session_path": "/tmp/sessions/abc",
+		"entry_count": 5,
+		"parent_pid": 12345
+	}`
+
+	var state RecordingState
+	err := json.Unmarshal([]byte(legacyJSON), &state)
+	require.NoError(t, err, "legacy .recording.json must unmarshal without error")
+
+	assert.Equal(t, "Oxlegacy", state.AgentID)
+	assert.Equal(t, "claude-code", state.AdapterName)
+	assert.Equal(t, 5, state.EntryCount)
+	assert.Nil(t, state.SuspendedAt, "SuspendedAt must default to nil")
+	assert.Empty(t, state.Lifecycle, "Lifecycle must default to empty slice")
+	assert.Zero(t, state.PauseCount)
+	assert.False(t, state.InheritedPause)
+	assert.Empty(t, state.InheritedFromSession)
+}
+
+// TestRecordingState_RoundTripWithLifecycle verifies save+load of a state
+// carrying the new ADR-020 fields preserves all values.
+func TestRecordingState_RoundTripWithLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+	sessionPath := filepath.Join(tmp, "sessions", "Oxa7b3-session")
+
+	state := &RecordingState{
+		AgentID:     "Oxa7b3",
+		StartedAt:   now,
+		AdapterName: "claude-code",
+		SessionFile: filepath.Join(tmp, "source.jsonl"),
+		OutputFile:  filepath.Join(sessionPath, "raw.jsonl"),
+		SessionPath: sessionPath,
+		EntryCount:  42,
+		SuspendedAt: &now,
+		PauseCount:  2,
+		Lifecycle: []LifecycleEvent{
+			{Action: LifecycleActionStart, At: now, Seq: 0},
+			{Action: LifecycleActionPause, At: now.Add(5 * time.Minute), Seq: 18},
+			{Action: LifecycleActionResume, At: now.Add(10 * time.Minute), Seq: 18, Reason: "user-resumed"},
+			{Action: LifecycleActionPause, At: now.Add(15 * time.Minute), Seq: 42},
+		},
+		InheritedPause:       true,
+		InheritedFromSession: "2026-05-26T11-00-ryan-Oxa7b3",
+	}
+
+	err := SaveRecordingState(tmp, state)
+	require.NoError(t, err)
+
+	// reload via the canonical loader
+	loaded, err := LoadRecordingState(tmp)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+
+	assert.Equal(t, state.AgentID, loaded.AgentID)
+	assert.Equal(t, state.PauseCount, loaded.PauseCount)
+	require.NotNil(t, loaded.SuspendedAt)
+	assert.True(t, loaded.SuspendedAt.Equal(*state.SuspendedAt))
+	assert.Equal(t, state.InheritedPause, loaded.InheritedPause)
+	assert.Equal(t, state.InheritedFromSession, loaded.InheritedFromSession)
+
+	require.Len(t, loaded.Lifecycle, 4)
+	assert.Equal(t, LifecycleActionStart, loaded.Lifecycle[0].Action)
+	assert.Equal(t, LifecycleActionPause, loaded.Lifecycle[1].Action)
+	assert.Equal(t, 18, loaded.Lifecycle[1].Seq)
+	assert.Equal(t, LifecycleActionResume, loaded.Lifecycle[2].Action)
+	assert.Equal(t, "user-resumed", loaded.Lifecycle[2].Reason)
+}

--- a/internal/session/pause_marker.go
+++ b/internal/session/pause_marker.go
@@ -1,0 +1,122 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// pause_marker.go implements the persistent breadcrumb for an active pause.
+//
+// Why a marker file alongside RecordingState.SuspendedAt:
+//   - .session_paused.<agentID> SURVIVES a /clear boundary (the recording
+//     state is finalized and removed at /clear, but the marker stays).
+//     New post-/clear sessions inherit the paused state via the marker.
+//   - Cross-process discovery: a sibling shell/subagent can detect that
+//     this agent's session is paused without loading RecordingState.
+//   - Resilient against partial state corruption (.recording.json lost or
+//     mid-write); the marker file is small and atomic to write/read.
+//
+// See ADR-019 (session entity lifecycle) and ADR-020 (pause/resume).
+
+const explicitPauseMarker = ".session_paused"
+
+// pauseMarkerPayload is the JSON shape persisted in .session_paused.<agentID>.
+type pauseMarkerPayload struct {
+	Seq int       `json:"seq"`
+	At  time.Time `json:"at"`
+}
+
+// MarkExplicitPause writes a per-agent breadcrumb indicating the user
+// explicitly paused recording. Survives /clear so new post-/clear sessions
+// can inherit the paused state.
+func MarkExplicitPause(projectRoot, agentID string, seq int) error {
+	if projectRoot == "" {
+		return fmt.Errorf("%w: project root", ErrEmptyPath)
+	}
+	if agentID == "" {
+		return fmt.Errorf("agentID must not be empty")
+	}
+
+	dir := resolveSessionsWritePath(projectRoot)
+	if dir == "" {
+		return fmt.Errorf("could not write pause marker for project=%s agent=%s: no sessions directory", projectRoot, agentID)
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create sessions dir for pause marker: %w", err)
+	}
+
+	payload := pauseMarkerPayload{Seq: seq, At: time.Now().UTC()}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal pause marker payload: %w", err)
+	}
+
+	markerPath := filepath.Join(dir, explicitPauseMarker+"."+agentID)
+	if err := os.WriteFile(markerPath, data, 0600); err != nil {
+		return fmt.Errorf("write pause marker: %w", err)
+	}
+	return nil
+}
+
+// PeekExplicitPause reads (without removing) the pause marker for the given
+// agent. Returns the recorded seq, the wall-clock time of the pause, and
+// found=true if the marker exists.
+//
+// Use PeekExplicitPause for status display and post-/clear inheritance
+// detection. Use ConsumeExplicitPause when transitioning out of suspended
+// state.
+func PeekExplicitPause(projectRoot, agentID string) (seq int, at time.Time, found bool) {
+	if projectRoot == "" || agentID == "" {
+		return 0, time.Time{}, false
+	}
+	name := explicitPauseMarker + "." + agentID
+	for _, dir := range sessionsSearchPaths(projectRoot) {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var p pauseMarkerPayload
+		if err := json.Unmarshal(data, &p); err != nil {
+			// legacy marker (or unwritable JSON) — treat as found with seq=0
+			return 0, time.Time{}, true
+		}
+		return p.Seq, p.At, true
+	}
+	return 0, time.Time{}, false
+}
+
+// ConsumeExplicitPause removes the pause marker and returns whether it
+// existed. Use when transitioning out of suspended state (resume, stop,
+// abort, expiration).
+func ConsumeExplicitPause(projectRoot, agentID string) (seq int, found bool) {
+	if projectRoot == "" || agentID == "" {
+		return 0, false
+	}
+	name := explicitPauseMarker + "." + agentID
+	for _, dir := range sessionsSearchPaths(projectRoot) {
+		path := filepath.Join(dir, name)
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			continue
+		}
+		var p pauseMarkerPayload
+		_ = json.Unmarshal(data, &p) // best-effort; preserve seq=0 on parse failure
+		if rmErr := os.Remove(path); rmErr == nil {
+			found = true
+			seq = p.Seq
+		}
+	}
+	return seq, found
+}
+
+// ClearExplicitPause removes the pause marker without returning the
+// recorded seq. Convenience wrapper over ConsumeExplicitPause when the
+// caller doesn't need the previous value.
+func ClearExplicitPause(projectRoot, agentID string) bool {
+	_, found := ConsumeExplicitPause(projectRoot, agentID)
+	return found
+}

--- a/internal/session/pause_marker_test.go
+++ b/internal/session/pause_marker_test.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newPauseMarkerProject reuses the established recording-test helper so the
+// marker helpers find a valid canonical sessions write path.
+func newPauseMarkerProject(t *testing.T) string {
+	t.Helper()
+	cacheDir := t.TempDir()
+	return setupRecordingTest(t, cacheDir)
+}
+
+func TestMarkAndPeekExplicitPause(t *testing.T) {
+	projectRoot := newPauseMarkerProject(t)
+
+	require.NoError(t, MarkExplicitPause(projectRoot, "Oxa7b3", 42))
+
+	seq, at, found := PeekExplicitPause(projectRoot, "Oxa7b3")
+	require.True(t, found)
+	assert.Equal(t, 42, seq)
+	assert.False(t, at.IsZero())
+}
+
+func TestPeekExplicitPause_NotFound(t *testing.T) {
+	projectRoot := newPauseMarkerProject(t)
+
+	_, _, found := PeekExplicitPause(projectRoot, "Oxnope")
+	assert.False(t, found)
+}
+
+func TestPeekExplicitPause_DoesNotConsume(t *testing.T) {
+	projectRoot := newPauseMarkerProject(t)
+
+	require.NoError(t, MarkExplicitPause(projectRoot, "Oxa7b3", 7))
+
+	for i := 0; i < 3; i++ {
+		_, _, found := PeekExplicitPause(projectRoot, "Oxa7b3")
+		assert.Truef(t, found, "peek attempt %d should still find marker", i+1)
+	}
+}
+
+func TestConsumeExplicitPause_RemovesMarker(t *testing.T) {
+	projectRoot := newPauseMarkerProject(t)
+
+	require.NoError(t, MarkExplicitPause(projectRoot, "Oxa7b3", 7))
+	seq, found := ConsumeExplicitPause(projectRoot, "Oxa7b3")
+	assert.True(t, found)
+	assert.Equal(t, 7, seq)
+
+	// second consume returns false
+	_, found = ConsumeExplicitPause(projectRoot, "Oxa7b3")
+	assert.False(t, found)
+}
+
+func TestClearExplicitPause(t *testing.T) {
+	projectRoot := newPauseMarkerProject(t)
+
+	require.NoError(t, MarkExplicitPause(projectRoot, "Oxa7b3", 9))
+	assert.True(t, ClearExplicitPause(projectRoot, "Oxa7b3"))
+	assert.False(t, ClearExplicitPause(projectRoot, "Oxa7b3"), "second clear is a no-op")
+}
+
+func TestMarkExplicitPause_PerAgentIsolation(t *testing.T) {
+	projectRoot := newPauseMarkerProject(t)
+
+	require.NoError(t, MarkExplicitPause(projectRoot, "Oxa", 1))
+	require.NoError(t, MarkExplicitPause(projectRoot, "Oxb", 2))
+
+	_, _, foundA := PeekExplicitPause(projectRoot, "Oxa")
+	_, _, foundB := PeekExplicitPause(projectRoot, "Oxb")
+	assert.True(t, foundA)
+	assert.True(t, foundB)
+
+	// clearing one does not affect the other
+	assert.True(t, ClearExplicitPause(projectRoot, "Oxa"))
+	_, _, foundB2 := PeekExplicitPause(projectRoot, "Oxb")
+	assert.True(t, foundB2, "marker for Oxb must survive Oxa's clear")
+}
+
+func TestMarkExplicitPause_EmptyArgs(t *testing.T) {
+	assert.Error(t, MarkExplicitPause("", "Oxa", 1))
+	assert.Error(t, MarkExplicitPause("/tmp", "", 1))
+}

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -27,6 +27,36 @@ var (
 
 const recordingFile = ".recording.json"
 
+// LifecycleAction is the durable timeline action recorded in RecordingState.Lifecycle.
+// See ADR-019 (session entity lifecycle).
+type LifecycleAction string
+
+const (
+	LifecycleActionStart         LifecycleAction = "start"
+	LifecycleActionPause         LifecycleAction = "pause"
+	LifecycleActionResume        LifecycleAction = "resume"
+	LifecycleActionStop          LifecycleAction = "stop"
+	LifecycleActionClearFinalize LifecycleAction = "clear-finalize"
+	LifecycleActionExpired       LifecycleAction = "expired"
+)
+
+// LifecycleEvent is one entry in the durable session-entity timeline. The
+// timeline is the single source of truth for what regions of raw.jsonl are
+// excluded from upload (see ADR-020). At upload time, paired
+// (pause, resume) ranges become redaction rules.
+//
+// Seq is the raw.jsonl entry sequence number at the moment of the event. It
+// is the universal cursor — every adapter writes entries in monotonic seq
+// order regardless of its native cursor type (byte offset, entry count, ULID).
+// Offset is a diagnostic for native adapter cursors.
+type LifecycleEvent struct {
+	Action LifecycleAction `json:"action"`
+	At     time.Time       `json:"at"`
+	Seq    int             `json:"seq,omitempty"`
+	Offset int64           `json:"offset,omitempty"`
+	Reason string          `json:"reason,omitempty"`
+}
+
 // RecordingState tracks an active recording session.
 // Stored in sessions/<session-name>/.recording.json
 type RecordingState struct {
@@ -61,6 +91,18 @@ type RecordingState struct {
 
 	WatchMode string     `json:"watch_mode,omitempty"` // how entries are captured: "hook" (CLI-driven) or "tail" (daemon-driven)
 	StoppedAt *time.Time `json:"stopped_at,omitempty"` // set by ox session stop to signal daemon to finalize
+
+	// ADR-020 session pause/resume fields. Lifecycle is the durable timeline of
+	// session-entity transitions and is the source of truth for which raw.jsonl
+	// seq ranges are excluded from upload. SuspendedAt is the hot-path "is the
+	// session currently paused" check; cleared on resume/stop/abort. PauseCount
+	// is a monotonic counter for observability. InheritedPause + InheritedFromSession
+	// trace a pause that was carried across a /clear boundary.
+	Lifecycle            []LifecycleEvent `json:"lifecycle,omitempty"`
+	SuspendedAt          *time.Time       `json:"suspended_at,omitempty"`
+	PauseCount           int              `json:"pause_count,omitempty"`
+	InheritedPause       bool             `json:"inherited_pause,omitempty"`
+	InheritedFromSession string           `json:"inherited_from_session,omitempty"`
 
 	// Hook observability: lets `ox session status` show whether hooks are firing
 	// and why they're skipping. Without these, a broken recording path (e.g.

--- a/internal/session/segment_mask.go
+++ b/internal/session/segment_mask.go
@@ -1,5 +1,7 @@
 package session
 
+import "sort"
+
 // segment_mask.go applies pause/resume lifecycle events to a slice of session
 // entries by filtering out entries that fall in any [pause_seq, resume_seq)
 // range. See ADR-019 (session entity lifecycle) and ADR-020 (pause/resume).
@@ -111,15 +113,60 @@ func ApplySegmentMask(entries []SessionEntry, lifecycle []LifecycleEvent) []Sess
 // CountMaskedEntries returns how many entries in `entries` fall inside any
 // exclusion range. Useful for telemetry and the upload-time validator.
 func CountMaskedEntries(entries []SessionEntry, lifecycle []LifecycleEvent) int {
+	return CountMaskedEntriesByTotal(len(entries), lifecycle)
+}
+
+// CountMaskedEntriesByTotal returns how many 0-indexed entry positions in
+// [0, total) fall inside any exclusion range built from `lifecycle`.
+// Identical semantics to CountMaskedEntries (overlaps are unioned, not
+// double-counted) but does not require a slice — callers like the upload-
+// path validator only know the entry count and shouldn't have to allocate
+// len(entries) SessionEntry values just to drive a counting loop.
+func CountMaskedEntriesByTotal(total int, lifecycle []LifecycleEvent) int {
+	if total <= 0 {
+		return 0
+	}
 	ranges := BuildSegmentRanges(lifecycle)
 	if len(ranges) == 0 {
 		return 0
 	}
-	count := 0
-	for i := range entries {
-		if IsSeqExcluded(i, ranges) {
-			count++
+
+	// Project each range onto [0, total) and union overlapping ones so we
+	// don't double-count entries covered by two ranges.
+	type clipped struct{ start, end int }
+	clamped := make([]clipped, 0, len(ranges))
+	for _, r := range ranges {
+		start := r.Start
+		if start < 0 {
+			start = 0
+		}
+		end := r.End
+		if end > total {
+			end = total
+		}
+		if end > start {
+			clamped = append(clamped, clipped{start, end})
 		}
 	}
+	if len(clamped) == 0 {
+		return 0
+	}
+	// Sort by start so we can sweep + union in one pass.
+	sort.Slice(clamped, func(i, j int) bool { return clamped[i].start < clamped[j].start })
+
+	count := 0
+	curStart, curEnd := clamped[0].start, clamped[0].end
+	for _, c := range clamped[1:] {
+		if c.start <= curEnd {
+			// overlap or touch — extend the current union
+			if c.end > curEnd {
+				curEnd = c.end
+			}
+			continue
+		}
+		count += curEnd - curStart
+		curStart, curEnd = c.start, c.end
+	}
+	count += curEnd - curStart
 	return count
 }

--- a/internal/session/segment_mask.go
+++ b/internal/session/segment_mask.go
@@ -1,0 +1,125 @@
+package session
+
+// segment_mask.go applies pause/resume lifecycle events to a slice of session
+// entries by filtering out entries that fall in any [pause_seq, resume_seq)
+// range. See ADR-019 (session entity lifecycle) and ADR-020 (pause/resume).
+//
+// Pause IS redaction with temporal scope. The text-pattern redactor in
+// secrets.go / redact_rules.go scrubs entry CONTENT; the segment mask
+// EXCLUDES entries entirely by sequence range. Both run at upload time
+// (cmd/ox/session_stop.go) and compose without interference: mask drops
+// entries first, then redactor scrubs content of remaining entries.
+//
+// Seq convention (see RecordingState.EntryCount):
+//   - "current EntryCount" = number of entries written so far.
+//   - pause LifecycleEvent records seq = EntryCount at the moment of pause.
+//     Entry (seq+1) is the FIRST excluded entry.
+//   - resume LifecycleEvent records seq = EntryCount at the moment of resume.
+//     Entry (seq+1) is the FIRST included entry.
+//   - In a 0-indexed slice of post-header raw.jsonl entries, the excluded
+//     range is slice indices [pause_seq, resume_seq).
+
+// SegmentRange is a half-open [Start, End) exclusion over 0-indexed entry
+// positions in raw.jsonl (excluding the metadata header line).
+type SegmentRange struct {
+	Start int // inclusive lower bound (== pause seq)
+	End   int // exclusive upper bound (== resume seq; math.MaxInt for open-ended)
+}
+
+const segmentOpenEnded = int(^uint(0) >> 1) // math.MaxInt without importing math
+
+// BuildSegmentRanges walks the lifecycle timeline and returns the set of
+// excluded entry-index ranges. Multiple pause/resume cycles produce multiple
+// ranges; an open-ended pause (no matching resume) produces a range that
+// extends to the end of stream.
+//
+// Malformed timelines are tolerated:
+//   - resume without prior pause: ignored.
+//   - pause directly followed by another pause: the second pause is ignored
+//     (the first pause's range stays open until the next resume).
+//   - overlapping or duplicate ranges: produced as-is; ApplySegmentMask
+//     handles overlaps by unioning during filtering.
+func BuildSegmentRanges(lifecycle []LifecycleEvent) []SegmentRange {
+	var ranges []SegmentRange
+	openStart := -1
+
+	for _, ev := range lifecycle {
+		switch ev.Action {
+		case LifecycleActionPause:
+			if openStart < 0 {
+				openStart = ev.Seq
+			}
+			// nested pause while already paused: keep the outer open
+		case LifecycleActionResume:
+			if openStart < 0 {
+				continue // resume without prior pause: ignore
+			}
+			ranges = append(ranges, SegmentRange{Start: openStart, End: ev.Seq})
+			openStart = -1
+		case LifecycleActionStop, LifecycleActionClearFinalize, LifecycleActionExpired:
+			// terminal events close any open pause at the action's seq.
+			if openStart >= 0 {
+				ranges = append(ranges, SegmentRange{Start: openStart, End: ev.Seq})
+				openStart = -1
+			}
+		}
+	}
+
+	if openStart >= 0 {
+		// open-ended pause (no matching resume, no terminal): exclude to EOS.
+		ranges = append(ranges, SegmentRange{Start: openStart, End: segmentOpenEnded})
+	}
+
+	return ranges
+}
+
+// IsSeqExcluded reports whether the 0-indexed entry position falls in any
+// of the exclusion ranges.
+func IsSeqExcluded(seq int, ranges []SegmentRange) bool {
+	for _, r := range ranges {
+		if seq >= r.Start && seq < r.End {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplySegmentMask returns a new slice containing only entries whose
+// 0-indexed position is NOT in any exclusion range. The input slice is
+// not modified.
+//
+// When lifecycle is empty, the returned slice is a shallow copy of
+// entries (same underlying data, new slice header).
+func ApplySegmentMask(entries []SessionEntry, lifecycle []LifecycleEvent) []SessionEntry {
+	ranges := BuildSegmentRanges(lifecycle)
+	if len(ranges) == 0 {
+		out := make([]SessionEntry, len(entries))
+		copy(out, entries)
+		return out
+	}
+
+	out := make([]SessionEntry, 0, len(entries))
+	for i, e := range entries {
+		if IsSeqExcluded(i, ranges) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// CountMaskedEntries returns how many entries in `entries` fall inside any
+// exclusion range. Useful for telemetry and the upload-time validator.
+func CountMaskedEntries(entries []SessionEntry, lifecycle []LifecycleEvent) int {
+	ranges := BuildSegmentRanges(lifecycle)
+	if len(ranges) == 0 {
+		return 0
+	}
+	count := 0
+	for i := range entries {
+		if IsSeqExcluded(i, ranges) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/session/segment_mask_test.go
+++ b/internal/session/segment_mask_test.go
@@ -271,3 +271,70 @@ func TestApplySegmentMask_Property(t *testing.T) {
 		}
 	}
 }
+
+// TestCountMaskedEntriesByTotal_MatchesCountMaskedEntries — Failure
+// prevented: the allocation-free variant drifts from CountMaskedEntries
+// semantics (over/under-counting overlapping ranges, ignoring open-ended
+// pauses, off-by-one on resume seq). Pin them to identical results across
+// a few representative lifecycles.
+func TestCountMaskedEntriesByTotal_MatchesCountMaskedEntries(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name      string
+		total     int
+		lifecycle []LifecycleEvent
+	}{
+		{
+			name:      "no lifecycle",
+			total:     100,
+			lifecycle: nil,
+		},
+		{
+			name:  "single closed pause [5, 12)",
+			total: 100,
+			lifecycle: []LifecycleEvent{
+				{Action: LifecycleActionPause, Seq: 5, At: now},
+				{Action: LifecycleActionResume, Seq: 12, At: now.Add(1 * time.Minute)},
+			},
+		},
+		{
+			name:  "open-ended pause clipped by total",
+			total: 50,
+			lifecycle: []LifecycleEvent{
+				{Action: LifecycleActionPause, Seq: 20, At: now},
+			},
+		},
+		{
+			name:  "multiple non-overlapping pauses",
+			total: 100,
+			lifecycle: []LifecycleEvent{
+				{Action: LifecycleActionPause, Seq: 5, At: now},
+				{Action: LifecycleActionResume, Seq: 10, At: now.Add(1 * time.Minute)},
+				{Action: LifecycleActionPause, Seq: 40, At: now.Add(2 * time.Minute)},
+				{Action: LifecycleActionResume, Seq: 55, At: now.Add(3 * time.Minute)},
+			},
+		},
+		{
+			name:  "total smaller than highest seq",
+			total: 8,
+			lifecycle: []LifecycleEvent{
+				{Action: LifecycleActionPause, Seq: 5, At: now},
+				{Action: LifecycleActionResume, Seq: 12, At: now.Add(1 * time.Minute)},
+			},
+		},
+		{
+			name:      "zero total",
+			total:     0,
+			lifecycle: []LifecycleEvent{{Action: LifecycleActionPause, Seq: 0, At: now}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			stub := make([]SessionEntry, c.total)
+			want := CountMaskedEntries(stub, c.lifecycle)
+			got := CountMaskedEntriesByTotal(c.total, c.lifecycle)
+			assert.Equalf(t, want, got, "alloc-free variant must match slice variant")
+		})
+	}
+}

--- a/internal/session/segment_mask_test.go
+++ b/internal/session/segment_mask_test.go
@@ -1,0 +1,273 @@
+package session
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeEntries returns n SessionEntries with index-encoded content for assertion.
+func makeEntries(n int) []SessionEntry {
+	out := make([]SessionEntry, n)
+	for i := 0; i < n; i++ {
+		out[i] = SessionEntry{
+			Type:    EntryTypeUser,
+			Content: contentFor(i),
+		}
+	}
+	return out
+}
+
+func contentFor(i int) string {
+	return "entry-" + itoa(i)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+func TestBuildSegmentRanges_Empty(t *testing.T) {
+	ranges := BuildSegmentRanges(nil)
+	assert.Empty(t, ranges)
+}
+
+func TestBuildSegmentRanges_NoPauseEvents(t *testing.T) {
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionStart, Seq: 0},
+		{Action: LifecycleActionStop, Seq: 10},
+	}
+	assert.Empty(t, BuildSegmentRanges(lc))
+}
+
+func TestBuildSegmentRanges_SinglePauseResume(t *testing.T) {
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionStart, Seq: 0},
+		{Action: LifecycleActionPause, Seq: 5},
+		{Action: LifecycleActionResume, Seq: 10},
+		{Action: LifecycleActionStop, Seq: 20},
+	}
+	ranges := BuildSegmentRanges(lc)
+	require.Len(t, ranges, 1)
+	assert.Equal(t, SegmentRange{Start: 5, End: 10}, ranges[0])
+}
+
+func TestBuildSegmentRanges_MultipleCycles(t *testing.T) {
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionPause, Seq: 5},
+		{Action: LifecycleActionResume, Seq: 10},
+		{Action: LifecycleActionPause, Seq: 15},
+		{Action: LifecycleActionResume, Seq: 18},
+		{Action: LifecycleActionPause, Seq: 22},
+		{Action: LifecycleActionResume, Seq: 25},
+	}
+	ranges := BuildSegmentRanges(lc)
+	require.Len(t, ranges, 3)
+	assert.Equal(t, SegmentRange{Start: 5, End: 10}, ranges[0])
+	assert.Equal(t, SegmentRange{Start: 15, End: 18}, ranges[1])
+	assert.Equal(t, SegmentRange{Start: 22, End: 25}, ranges[2])
+}
+
+func TestBuildSegmentRanges_OpenEndedPause(t *testing.T) {
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionPause, Seq: 5},
+	}
+	ranges := BuildSegmentRanges(lc)
+	require.Len(t, ranges, 1)
+	assert.Equal(t, 5, ranges[0].Start)
+	assert.Equal(t, segmentOpenEnded, ranges[0].End)
+}
+
+func TestBuildSegmentRanges_TerminalClosesOpenPause(t *testing.T) {
+	for _, term := range []LifecycleAction{LifecycleActionStop, LifecycleActionClearFinalize, LifecycleActionExpired} {
+		term := term
+		t.Run(string(term), func(t *testing.T) {
+			lc := []LifecycleEvent{
+				{Action: LifecycleActionPause, Seq: 5},
+				{Action: term, Seq: 10},
+			}
+			ranges := BuildSegmentRanges(lc)
+			require.Len(t, ranges, 1)
+			assert.Equal(t, SegmentRange{Start: 5, End: 10}, ranges[0])
+		})
+	}
+}
+
+func TestBuildSegmentRanges_ResumeWithoutPause(t *testing.T) {
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionResume, Seq: 10},
+	}
+	assert.Empty(t, BuildSegmentRanges(lc))
+}
+
+func TestBuildSegmentRanges_DoublePause(t *testing.T) {
+	// Second pause while already paused is ignored — the first pause's
+	// range stays open until the next resume.
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionPause, Seq: 5},
+		{Action: LifecycleActionPause, Seq: 7},
+		{Action: LifecycleActionResume, Seq: 10},
+	}
+	ranges := BuildSegmentRanges(lc)
+	require.Len(t, ranges, 1)
+	assert.Equal(t, SegmentRange{Start: 5, End: 10}, ranges[0])
+}
+
+func TestIsSeqExcluded(t *testing.T) {
+	ranges := []SegmentRange{
+		{Start: 5, End: 10},
+		{Start: 15, End: 20},
+	}
+	cases := map[int]bool{
+		0: false, 4: false, 5: true, 9: true, 10: false,
+		14: false, 15: true, 19: true, 20: false, 100: false,
+	}
+	for seq, want := range cases {
+		assert.Equalf(t, want, IsSeqExcluded(seq, ranges), "seq=%d", seq)
+	}
+}
+
+func TestApplySegmentMask_NoLifecycle(t *testing.T) {
+	entries := makeEntries(10)
+	got := ApplySegmentMask(entries, nil)
+	assert.Len(t, got, 10)
+	for i, e := range got {
+		assert.Equal(t, contentFor(i), e.Content)
+	}
+}
+
+func TestApplySegmentMask_SinglePause(t *testing.T) {
+	entries := makeEntries(10)
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionPause, Seq: 3},
+		{Action: LifecycleActionResume, Seq: 7},
+	}
+	got := ApplySegmentMask(entries, lc)
+	require.Len(t, got, 6, "exclude indexes 3,4,5,6 → 4 entries dropped from 10")
+	assert.Equal(t, contentFor(0), got[0].Content)
+	assert.Equal(t, contentFor(2), got[2].Content)
+	assert.Equal(t, contentFor(7), got[3].Content, "first kept after resume is index 7")
+	assert.Equal(t, contentFor(9), got[5].Content)
+}
+
+func TestApplySegmentMask_OpenEndedPauseExcludesToEOS(t *testing.T) {
+	entries := makeEntries(10)
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionPause, Seq: 6},
+	}
+	got := ApplySegmentMask(entries, lc)
+	require.Len(t, got, 6)
+	for i := 0; i < 6; i++ {
+		assert.Equal(t, contentFor(i), got[i].Content)
+	}
+}
+
+func TestApplySegmentMask_MultipleRanges(t *testing.T) {
+	entries := makeEntries(20)
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionPause, Seq: 3},
+		{Action: LifecycleActionResume, Seq: 5},
+		{Action: LifecycleActionPause, Seq: 12},
+		{Action: LifecycleActionResume, Seq: 15},
+	}
+	got := ApplySegmentMask(entries, lc)
+	// excluded indices: 3,4 (2 dropped) and 12,13,14 (3 dropped) → 15 remain
+	require.Len(t, got, 15)
+	// pick a few representative entries to verify ordering
+	assert.Equal(t, contentFor(0), got[0].Content)
+	assert.Equal(t, contentFor(2), got[2].Content)
+	assert.Equal(t, contentFor(5), got[3].Content) // first kept after first resume
+	assert.Equal(t, contentFor(11), got[9].Content)
+	assert.Equal(t, contentFor(15), got[10].Content) // first kept after second resume
+	assert.Equal(t, contentFor(19), got[14].Content)
+}
+
+func TestApplySegmentMask_DoesNotMutateInput(t *testing.T) {
+	entries := makeEntries(5)
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionPause, Seq: 1},
+		{Action: LifecycleActionResume, Seq: 3},
+	}
+	_ = ApplySegmentMask(entries, lc)
+	assert.Len(t, entries, 5, "input length unchanged")
+	for i, e := range entries {
+		assert.Equal(t, contentFor(i), e.Content, "input content unchanged at %d", i)
+	}
+}
+
+func TestCountMaskedEntries(t *testing.T) {
+	entries := makeEntries(10)
+	lc := []LifecycleEvent{
+		{Action: LifecycleActionPause, Seq: 3},
+		{Action: LifecycleActionResume, Seq: 7},
+	}
+	assert.Equal(t, 4, CountMaskedEntries(entries, lc))
+	assert.Equal(t, 0, CountMaskedEntries(entries, nil))
+}
+
+// TestApplySegmentMask_Property is a randomized property test verifying the
+// invariant: ApplySegmentMask(entries, lc) returns exactly the entries whose
+// 0-indexed position is NOT in any [pause_i, resume_i) range built from lc.
+//
+// We avoid a third-party generator (gopter / rapid) to keep dependencies
+// minimal and run the loop with a fixed seed for determinism.
+func TestApplySegmentMask_Property(t *testing.T) {
+	const trials = 200
+	rng := rand.New(rand.NewSource(1))
+	now := time.Now()
+
+	for trial := 0; trial < trials; trial++ {
+		n := rng.Intn(50) + 1
+		entries := makeEntries(n)
+
+		// build a random lifecycle: 0..6 pause/resume events with seqs in [0,n].
+		var lc []LifecycleEvent
+		paused := false
+		for k := rng.Intn(7); k > 0; k-- {
+			seq := rng.Intn(n + 1)
+			if paused {
+				lc = append(lc, LifecycleEvent{Action: LifecycleActionResume, Seq: seq, At: now})
+				paused = false
+			} else {
+				lc = append(lc, LifecycleEvent{Action: LifecycleActionPause, Seq: seq, At: now})
+				paused = true
+			}
+		}
+
+		ranges := BuildSegmentRanges(lc)
+		got := ApplySegmentMask(entries, lc)
+
+		// Recompute expected by linear scan.
+		expected := make([]SessionEntry, 0, n)
+		for i, e := range entries {
+			if !IsSeqExcluded(i, ranges) {
+				expected = append(expected, e)
+			}
+		}
+
+		require.Len(t, got, len(expected), "trial=%d lc=%v", trial, lc)
+		for i := range got {
+			assert.Equalf(t, expected[i].Content, got[i].Content, "trial=%d i=%d", trial, i)
+		}
+	}
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -416,6 +416,7 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 		var isSubagent bool
 		var parentPID int
 		var origin string
+		var suspendedAt *time.Time
 		recPath := filepath.Join(sessionPath, recordingFile)
 		if recData, recErr := os.ReadFile(recPath); recErr == nil {
 			var recState RecordingState
@@ -427,6 +428,13 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 				isSubagent = recState.IsSubagent()
 				parentPID = recState.ParentPID
 				origin = recState.Origin
+				// ADR-020: ClassifySession branches on SessionInfo.SuspendedAt to
+				// return StatusSuspended; without this propagation, suspended
+				// active sessions get reported as plain "recording".
+				if recState.SuspendedAt != nil {
+					ts := *recState.SuspendedAt
+					suspendedAt = &ts
+				}
 				if !recState.StartedAt.IsZero() && createdAt.IsZero() {
 					createdAt = recState.StartedAt
 				}
@@ -506,6 +514,7 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 			Origin:          origin,
 			HasRawData:      hasRawData,
 			StopReason:      stopReason(meta),
+			SuspendedAt:     suspendedAt,
 		})
 	}
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -323,6 +323,7 @@ type SessionInfo struct {
 	Origin          string              `json:"origin,omitempty"`           // session origin: "human", "subagent", "agent"
 	HasRawData      bool                `json:"has_raw_data,omitempty"`     // true if raw.jsonl exists with content on disk
 	StopReason      string              `json:"stop_reason,omitempty"`      // how session ended: "stopped", "aborted", "recovered"
+	SuspendedAt     *time.Time          `json:"suspended_at,omitempty"`     // ADR-020: non-nil while session is actively paused
 }
 
 // ListSessions returns session files from the last 7 days, sorted by date descending.

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1146,3 +1146,52 @@ func TestReadSessionFromPath_InvalidJSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, sess.Entries, 1)
 }
+
+// TestStore_ListSessions_PropagatesSuspendedAt — Failure prevented:
+// listSessionSessions reads .recording.json but never propagates the
+// SuspendedAt field onto SessionInfo, so ClassifySession (which branches
+// on SessionInfo.SuspendedAt to return StatusSuspended) reports actively
+// paused sessions as plain "recording". The ADR-020 status surface is
+// then broken end-to-end at the listing layer.
+func TestStore_ListSessions_PropagatesSuspendedAt(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, _ := NewStore(tmpDir)
+
+	// Active recording, suspended
+	suspendedDir := filepath.Join(store.basePath, "2026-01-05T12-00-user-Oxsuspd")
+	require.NoError(t, os.MkdirAll(suspendedDir, 0755))
+	pausedAt := time.Now().Add(-2 * time.Minute).UTC()
+	recSuspended := RecordingState{
+		AgentID:     "Oxsuspd",
+		StartedAt:   time.Now().Add(-10 * time.Minute),
+		SuspendedAt: &pausedAt,
+		PauseCount:  1,
+	}
+	data, _ := json.Marshal(recSuspended)
+	require.NoError(t, os.WriteFile(filepath.Join(suspendedDir, recordingFile), data, 0644))
+
+	// Active recording, NOT suspended (control)
+	activeDir := filepath.Join(store.basePath, "2026-01-05T12-30-user-Oxactiv")
+	require.NoError(t, os.MkdirAll(activeDir, 0755))
+	recActive := RecordingState{AgentID: "Oxactiv", StartedAt: time.Now().Add(-5 * time.Minute)}
+	dataA, _ := json.Marshal(recActive)
+	require.NoError(t, os.WriteFile(filepath.Join(activeDir, recordingFile), dataA, 0644))
+
+	sessions, err := store.ListAllSessions()
+	require.NoError(t, err)
+
+	byName := map[string]SessionInfo{}
+	for _, s := range sessions {
+		byName[s.SessionName] = s
+	}
+
+	suspended, ok := byName["2026-01-05T12-00-user-Oxsuspd"]
+	require.True(t, ok, "suspended session missing from results")
+	require.NotNil(t, suspended.SuspendedAt,
+		"SessionInfo.SuspendedAt MUST be populated from .recording.json — ClassifySession depends on it")
+	assert.WithinDuration(t, pausedAt, *suspended.SuspendedAt, time.Second)
+
+	active, ok := byName["2026-01-05T12-30-user-Oxactiv"]
+	require.True(t, ok, "active session missing from results")
+	assert.Nil(t, active.SuspendedAt, "non-suspended recording must NOT report SuspendedAt")
+}


### PR DESCRIPTION
Closes #134.

## Summary

Adds `ox session pause` / `ox session resume` on a new ADR-019 session-entity lifecycle foundation. Pause is a **temporal redaction scope** — local cache keeps growing through the suspended interval, upload mask excludes paused entries via the existing redact pipeline. Single source of truth for "what's excluded": the lifecycle timeline.

10 mergeable phases shipped together to keep the system coherent.

## Mental model

```mermaid
stateDiagram-v2
    [*] --> recording: start
    recording --> suspended: ox session pause
    suspended --> recording: ox session resume
    recording --> stopped: ox session stop
    suspended --> stopped: ox session stop
    stopped --> uploading: daemon finalize
    uploading --> uploaded: LFS push
    recording --> orphan: PID dead, has data
    suspended --> orphan: PID dead past grace
    orphan --> uploaded: orphan recovery + mask
    recording --> canceled: ox session abort
    suspended --> canceled: ox session abort
```

## Architecture

```mermaid
sequenceDiagram
    actor User
    participant Hook as agent_hook
    participant Prime as agent_prime
    participant State as RecordingState
    participant Marker as .session_paused.AGENTID
    participant Stop as session_stop
    participant Ledger

    User->>Hook: ox session pause
    Hook->>State: SuspendedAt=now, append LifecycleEvent{pause, seq=EntryCount}
    Hook->>Marker: write
    Note over State,Marker: tail-watcher keeps appending throughout

    User->>Hook: /clear
    Hook->>State: finalize (StoppedAt, daemon IPC)
    Hook->>Prime: re-prime in same agent ID lineage
    Prime->>Marker: PeekExplicitPause(agentID)
    Marker-->>Prime: found
    Prime->>State: NEW state, SuspendedAt=now, InheritedPause=true

    User->>Hook: ox session resume
    Hook->>State: SuspendedAt=nil, append LifecycleEvent{resume}
    Hook->>Marker: ClearExplicitPause

    User->>Stop: ox session stop
    Stop->>Stop: ApplySegmentMask(entries, Lifecycle)
    Stop->>Stop: validateMaskInvariant -> abort if mismatch
    Stop->>Ledger: upload (paused range excluded)
```

## Key decisions

1. **New `StatusSuspended`, no rename of legacy `StatusPaused`** — zero migration risk for in-flight `.recording.json` and uploaded ledger metadata.
2. **Pause = redaction with temporal scope** — reuses the existing redact pipeline at upload. No parallel masking infrastructure.
3. **Hybrid storage** — local cache complete (recovery available); ledger upload scrubbed.
4. **Tail-watcher never gates appends** — pause is purely CLI-side state. Zero new race surface.
5. **Per-agent stickiness via `.session_paused.<agentID>`** — marker survives `/clear`; new post-`/clear` sessions inherit the suspended state. Marker cleared by resume/stop/abort/expiration.
6. **No subagent cascade** for existing children; subagents spawned during pause skip recording entirely.
7. **Per-prompt `<system-reminder>` nudge** while suspended, scoped to current agent only.
8. **`/clear` post-prime notice** describes state transition (including inherited-pause variant).
9. **No hard time cap** — process lifetime is the effective cap. PID-dead + 10min grace → existing orphan finalize path with mask honored.
10. **`validateMaskInvariant`** fails-closed if post-mask count doesn't match the lifecycle's expected exclusion count. Upload aborts before paused work can leak.

## Test plan

- [x] Unit: `BuildSegmentRanges` + `ApplySegmentMask` + `CountMaskedEntries` with 200-trial property test (`internal/session/segment_mask_test.go`).
- [x] Unit: `ClassifySession` returns `StatusSuspended` only when alive + SuspendedAt; PID-dead falls through to orphan (`internal/session/lifecycle_test.go`).
- [x] Unit: `.recording.json` round-trip with new fields + backward-compat load of legacy JSON (`internal/session/lifecycle_test.go`).
- [x] Unit: `MarkExplicitPause` / `PeekExplicitPause` / `ConsumeExplicitPause` / `ClearExplicitPause` with per-agent isolation (`internal/session/pause_marker_test.go`).
- [x] Unit: `emitSuspendedNudge` fires only when SuspendedAt set, scoped to current agent (`cmd/ox/agent_hook_pause_nudge_test.go`).
- [x] Unit: `validateMaskInvariant` detects matching/leak/open-ended cases (`cmd/ox/session_validate_mask_test.go`).
- [x] Unit: `computeExcludedSinceLastPause` + `formatPausedDuration` (`cmd/ox/agent_session_pause_test.go`).
- [x] Unit: `/clear` notice env round-trip, render variants, build from RecordingState (`cmd/ox/clear_notice_test.go`).
- [x] `make lint` clean.
- [x] Full `go test ./cmd/ox/... ./internal/session/... ./internal/daemon/...` green.
- [ ] Manual E2E in a real Claude Code session: pause → junk work → resume → stop → verify uploaded raw.jsonl excludes the junk range.
- [ ] Manual E2E: pause + /clear → new session inherits suspended state, nudge fires on every prompt, resume in new session works.

## Out of scope

- Cloud-side validator endpoint (tracked as follow-up).
- OpenCode SQLite tail integration (waits on SQLite adapter Bronze→Silver work).
- `--strict` segment-skip-at-ingestion mode (hybrid is the only mode).
- Separation of /clear vs /compact in agent_hook.go forceReprime (filed as ox-wmqe).

## ADRs

- [ADR-019: Session Entity Lifecycle](docs/adr/ADR-019-session-entity-lifecycle.md)
- [ADR-020: Session Pause/Resume](docs/adr/ADR-020-session-pause-resume.md)

## Files changed

26 files, +2178 / -19. New: 14 (2 ADRs, 4 commands/markers, 2 segment-mask, 6 tests). Modified: 12 (lifecycle integration across cmd/ox + internal/session).

🤖 Co-Authored-By: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session pause/resume: idempotent pause, resume reports excluded entries and paused duration; suspended ranges are excluded from uploads, inherited by subagents, and emit per-prompt suspended reminders.

* **Documentation**
  * Added ADRs and CLI docs detailing pause/resume semantics, clear-boundary notices, pause inheritance, and user-facing messages.

* **Tests**
  * Extensive unit and integration tests covering pause/resume, segment masking, status output, clear-notice flow, TOCTOU concurrency, marker persistence, and lifecycle propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->