### PR TITLE
fix(observability): attach JWT Bearer to OTLP exports per-request

### DIFF
--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -126,7 +126,17 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 	if env := os.Getenv("AGENT_ENV"); env != "" {
 		resourceAttrs = append(resourceAttrs, attribute.String(observability.AttrAgentEnv, env))
 	}
-	if err := observability.Init(cliCtx.Ctx, "ox-cli", apiEndpoint, resourceAttrs...); err != nil {
+	// The OTLP proxy is JWT-gated; closure resolves the token at export
+	// time so the per-command exporter always uses the latest value on disk
+	// (refreshed by other code paths).
+	tokenFunc := func() string {
+		tok, err := auth.GetTokenForEndpoint(apiEndpoint)
+		if err != nil || tok == nil {
+			return ""
+		}
+		return tok.AccessToken
+	}
+	if err := observability.Init(cliCtx.Ctx, "ox-cli", apiEndpoint, tokenFunc, resourceAttrs...); err != nil {
 		slog.Debug("otel init failed, continuing without tracing", "error", err)
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1079,7 +1079,17 @@ func (d *Daemon) initComponents() time.Duration {
 		if env := os.Getenv("AGENT_ENV"); env != "" {
 			daemonAttrs = append(daemonAttrs, attribute.String(observability.AttrAgentEnv, env))
 		}
-		if err := observability.Init(d.ctx, "ox-daemon", apiEndpoint, daemonAttrs...); err != nil {
+		// The OTLP proxy is JWT-gated. The daemon is long-running and the
+		// stored token rotates on refresh, so resolve per-export via this
+		// closure rather than baking a static header at Init time.
+		tokenFunc := func() string {
+			tok, err := auth.GetTokenForEndpoint(apiEndpoint)
+			if err != nil || tok == nil {
+				return ""
+			}
+			return tok.AccessToken
+		}
+		if err := observability.Init(d.ctx, "ox-daemon", apiEndpoint, tokenFunc, daemonAttrs...); err != nil {
 			d.logger.Warn("otel tracing init failed", "error", err)
 		}
 		d.tracer = observability.NewDaemonTracer()

--- a/internal/observability/daemon_tracer_test.go
+++ b/internal/observability/daemon_tracer_test.go
@@ -48,7 +48,7 @@ func TestNewDaemonTracer_NoInit(t *testing.T) {
 // TestNewDaemonTracer_WithInit returns a usable tracer after Init.
 func TestNewDaemonTracer_WithInit(t *testing.T) {
 	resetGlobals()
-	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318")
+	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318", nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { Shutdown(context.Background()); resetGlobals() })
 
@@ -63,7 +63,7 @@ func TestNewDaemonTracer_WithInit(t *testing.T) {
 // Failure prevented: all daemon tasks sharing one trace, defeating per-task visibility.
 func TestDaemonTracer_StartTask_IndependentTraces(t *testing.T) {
 	resetGlobals()
-	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318")
+	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318", nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { Shutdown(context.Background()); resetGlobals() })
 
@@ -89,7 +89,7 @@ func TestDaemonTracer_StartTask_IndependentTraces(t *testing.T) {
 // Failure prevented: subtask spans disconnected from parent task trace.
 func TestDaemonTracer_StartSubtask_ChildOfTask(t *testing.T) {
 	resetGlobals()
-	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318")
+	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318", nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { Shutdown(context.Background()); resetGlobals() })
 
@@ -115,7 +115,7 @@ func TestDaemonTracer_StartSubtask_ChildOfTask(t *testing.T) {
 // Failure prevented: panic or ignored attributes on task spans.
 func TestDaemonTracer_StartTask_WithAttrs(t *testing.T) {
 	resetGlobals()
-	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318")
+	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318", nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { Shutdown(context.Background()); resetGlobals() })
 
@@ -137,7 +137,7 @@ func TestDaemonTracer_StartTask_WithAttrs(t *testing.T) {
 // Failure prevented: daemon can't set client.id, client.class, etc.
 func TestInit_ExtraAttrs(t *testing.T) {
 	resetGlobals()
-	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318",
+	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318", nil,
 		attribute.String("client.id", "test-id"),
 		attribute.String("client.class", "daemon"),
 	)

--- a/internal/observability/otel.go
+++ b/internal/observability/otel.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -24,6 +25,27 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// TokenFunc returns the current bearer token to attach to OTLP requests.
+// Called per-export so long-running processes (daemon) pick up rotated tokens.
+// Returning "" sends the request unauthenticated — the server JWT-gate will
+// then 401 and the batch is dropped, which is the correct behavior when the
+// user is logged out.
+type TokenFunc func() string
+
+type bearerRoundTripper struct {
+	base      http.RoundTripper
+	tokenFunc TokenFunc
+}
+
+func (rt *bearerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if tok := rt.tokenFunc(); tok != "" {
+		// clone to avoid mutating the caller's request (otlptracehttp may retry)
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	return rt.base.RoundTrip(req)
+}
+
 var (
 	mu       sync.RWMutex
 	rootCtx  context.Context
@@ -35,11 +57,19 @@ var (
 // Init sets up the OTel TracerProvider with OTLP/HTTP export to the SageOx
 // OTLP proxy at {apiEndpoint}/api/v1/otlp/v1/traces.
 //
+// The proxy is JWT-gated (see apps/api-go/internal/handlers/otlp_proxy.go),
+// so tokenFunc is required for exports to succeed. tokenFunc is invoked
+// per-request rather than baked into a static header so long-running
+// processes (the daemon) pick up rotated tokens without restart.
+//
 // Extra attrs are merged into the OTel resource alongside service.name.
 // The daemon uses this to set client.id, client.class, os.type, etc.
 //
-// Safe to call with empty apiEndpoint — tracing is disabled (noop).
-func Init(ctx context.Context, serviceName, apiEndpoint string, attrs ...attribute.KeyValue) error {
+// Safe to call with empty apiEndpoint or nil tokenFunc — tracing is
+// disabled (noop) or sends unauthenticated (server will 401, batch
+// dropped silently). Either is fine for tests and for users who are
+// logged out.
+func Init(ctx context.Context, serviceName, apiEndpoint string, tokenFunc TokenFunc, attrs ...attribute.KeyValue) error {
 	if apiEndpoint == "" {
 		slog.Debug("otel tracing disabled", "reason", "no endpoint")
 		return nil
@@ -58,6 +88,12 @@ func Init(ctx context.Context, serviceName, apiEndpoint string, attrs ...attribu
 	}
 	if parsed.Scheme == "http" {
 		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+	if tokenFunc != nil {
+		opts = append(opts, otlptracehttp.WithHTTPClient(&http.Client{
+			Timeout:   2 * time.Second,
+			Transport: &bearerRoundTripper{base: http.DefaultTransport, tokenFunc: tokenFunc},
+		}))
 	}
 
 	exporter, err := otlptracehttp.New(ctx, opts...)

--- a/internal/observability/otel_test.go
+++ b/internal/observability/otel_test.go
@@ -186,9 +186,14 @@ func TestInit_BearerAttachedPerRequest(t *testing.T) {
 func TestInit_NilTokenFuncSendsUnauthenticated(t *testing.T) {
 	resetGlobals()
 
-	var seen []string
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
@@ -198,6 +203,8 @@ func TestInit_NilTokenFuncSendsUnauthenticated(t *testing.T) {
 	span.End()
 	Shutdown(context.Background())
 
+	mu.Lock()
+	defer mu.Unlock()
 	for _, h := range seen {
 		assert.Empty(t, h, "nil tokenFunc must not inject Authorization")
 	}
@@ -209,9 +216,14 @@ func TestInit_NilTokenFuncSendsUnauthenticated(t *testing.T) {
 func TestInit_EmptyTokenSkipsHeader(t *testing.T) {
 	resetGlobals()
 
-	var seen []string
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
@@ -221,6 +233,8 @@ func TestInit_EmptyTokenSkipsHeader(t *testing.T) {
 	span.End()
 	Shutdown(context.Background())
 
+	mu.Lock()
+	defer mu.Unlock()
 	for _, h := range seen {
 		assert.Empty(t, h, "empty tokenFunc value must not inject Authorization")
 	}

--- a/internal/observability/otel_test.go
+++ b/internal/observability/otel_test.go
@@ -2,7 +2,11 @@ package observability
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,7 +60,7 @@ func TestShutdown_NoInit(t *testing.T) {
 // TestInit_EmptyEndpoint disables tracing gracefully.
 func TestInit_EmptyEndpoint(t *testing.T) {
 	resetGlobals()
-	err := Init(context.Background(), "test", "")
+	err := Init(context.Background(), "test", "", nil)
 	require.NoError(t, err)
 	assert.False(t, Enabled())
 }
@@ -64,7 +68,7 @@ func TestInit_EmptyEndpoint(t *testing.T) {
 // TestInit_InvalidEndpoint disables tracing gracefully.
 func TestInit_InvalidEndpoint(t *testing.T) {
 	resetGlobals()
-	err := Init(context.Background(), "test", "://bad")
+	err := Init(context.Background(), "test", "://bad", nil)
 	require.NoError(t, err)
 	assert.False(t, Enabled())
 }
@@ -85,7 +89,7 @@ func TestInit_ValidEndpoint(t *testing.T) {
 	resetGlobals()
 
 	// Use a non-routable IP so export silently fails (no real Collector needed)
-	err := Init(context.Background(), "ox-cli-test", "http://192.0.2.1:4318")
+	err := Init(context.Background(), "ox-cli-test", "http://192.0.2.1:4318", nil)
 	require.NoError(t, err)
 	assert.True(t, Enabled())
 
@@ -115,6 +119,111 @@ func TestSetCommandStatus_NoSpan(t *testing.T) {
 		SetCommandStatus(nil)
 		SetCommandStatus(assert.AnError)
 	})
+}
+
+// --- I. JWT bearer attachment (regression for OTLP 401 dropouts) ---
+
+// TestInit_BearerAttachedPerRequest verifies the exporter attaches the
+// current token from tokenFunc on every export, and picks up rotated
+// values without restart.
+// Failure prevented: PR #1217 server-side JWT-gating silently dropping
+// CLI/daemon trace batches because the exporter sent no Authorization
+// header (174k 401s/30d in prod).
+func TestInit_BearerAttachedPerRequest(t *testing.T) {
+	resetGlobals()
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	var tokenMu sync.Mutex
+	current := "tok-A"
+	tokenFunc := func() string {
+		tokenMu.Lock()
+		defer tokenMu.Unlock()
+		return current
+	}
+
+	require.NoError(t, Init(context.Background(), "ox-cli-test", srv.URL, tokenFunc))
+	require.True(t, Enabled())
+
+	_, span := StartCommand(context.Background(), "ox test-cmd")
+	span.End()
+	Shutdown(context.Background())
+
+	resetGlobals()
+	tokenMu.Lock()
+	current = "tok-B"
+	tokenMu.Unlock()
+
+	require.NoError(t, Init(context.Background(), "ox-cli-test", srv.URL, tokenFunc))
+	_, span2 := StartCommand(context.Background(), "ox test-cmd-2")
+	span2.End()
+	Shutdown(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, seen, "exporter should have made at least one request")
+	for _, h := range seen {
+		assert.True(t, strings.HasPrefix(h, "Bearer "), "every export must carry Bearer header, got %q", h)
+	}
+	// At least one batch from each phase should reflect its rotated token.
+	assert.Contains(t, seen, "Bearer tok-A")
+	assert.Contains(t, seen, "Bearer tok-B")
+}
+
+// TestInit_NilTokenFuncSendsUnauthenticated verifies that passing nil
+// tokenFunc is a no-op for header injection (the server will then 401,
+// which matches "logged out" behavior). Documents the contract.
+func TestInit_NilTokenFuncSendsUnauthenticated(t *testing.T) {
+	resetGlobals()
+
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	require.NoError(t, Init(context.Background(), "ox-cli-test", srv.URL, nil))
+	_, span := StartCommand(context.Background(), "ox test-cmd")
+	span.End()
+	Shutdown(context.Background())
+
+	for _, h := range seen {
+		assert.Empty(t, h, "nil tokenFunc must not inject Authorization")
+	}
+}
+
+// TestInit_EmptyTokenSkipsHeader verifies that a tokenFunc returning ""
+// (e.g. user logged out) leaves Authorization unset rather than sending
+// "Bearer ", which would be a parse error server-side.
+func TestInit_EmptyTokenSkipsHeader(t *testing.T) {
+	resetGlobals()
+
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	require.NoError(t, Init(context.Background(), "ox-cli-test", srv.URL, func() string { return "" }))
+	_, span := StartCommand(context.Background(), "ox test-cmd")
+	span.End()
+	Shutdown(context.Background())
+
+	for _, h := range seen {
+		assert.Empty(t, h, "empty tokenFunc value must not inject Authorization")
+	}
 }
 
 func resetGlobals() {


### PR DESCRIPTION
## Summary

- `ox-cli` and `ox-daemon` OTLP trace batches have been silently 401'ing in prod since 2026-05-14, when sageox-monorepo PR #1217 (commit `4bc7356c3`) JWT-gated `/api/v1/otlp/*` in `apps/api-go/internal/handlers/otlp_proxy.go`.
- Honeycomb confirms the symptom: **174,744 × 401** on `POST /api/v1/otlp/*` over the last 30d, vs 792,014 × 200 from browsers (which got an interceptor in the same PR but the CLI/daemon were missed).
- `internal/observability/otel.go` constructed the `otlptracehttp` exporter with no `Authorization` header, so every batch was rejected and dropped into the 2s exporter timeout with only a `Debug` log to show for it.

## Fix shape

- Add `TokenFunc func() string` and `bearerRoundTripper` to `internal/observability/otel.go`.
- Wire via `otlptracehttp.WithHTTPClient(&http.Client{Transport: &bearerRoundTripper{...}})`, **not** `otlptracehttp.WithHeaders(...)` — the latter would bake the token at construction time and go stale for the long-running daemon.
- `RoundTrip` clones the request before setting the header so the otel SDK's retry layer can't see a mutated request.
- `Init` gains a `tokenFunc TokenFunc` parameter. Nil tokenFunc or empty return → no header attached (graceful logged-out path; server returns 401 and the batch is dropped, which matches intent).
- CLI (`internal/cli/context.go`) and daemon (`internal/daemon/daemon.go`) pass closures that call `auth.GetTokenForEndpoint(apiEndpoint)` per export. Daemon picks up token rotation without restart.

```mermaid
sequenceDiagram
    participant CLI as ox-cli / ox-daemon
    participant RT as bearerRoundTripper
    participant Store as auth token store (disk)
    participant Proxy as api-go OTLP proxy
    participant HC as Honeycomb

    CLI->>RT: BatchSpans → POST /api/v1/otlp/v1/traces
    RT->>Store: tokenFunc() (per-request, no cache)
    Store-->>RT: current Bearer JWT (or "")
    alt token present
        RT->>Proxy: + Authorization: Bearer ...
        Proxy-->>HC: forwarded
        Proxy-->>RT: 200
    else token empty (logged out)
        RT->>Proxy: no Authorization
        Proxy-->>RT: 401 (batch dropped silently)
    end
```

Server-side JWT-gating is intentional (audit ox-w9yc5 — per-user accountability for Honeycomb ingest cost). This PR does not touch it.

## Test plan

- [x] `go test ./internal/observability/... -count=1` — passes incl. 3 new regression tests:
  - `TestInit_BearerAttachedPerRequest` — rotates token between two Init/Shutdown cycles against `httptest.Server`; asserts every captured request has `Bearer <current>` and that both rotated values land. This is the actual regression for the 401 dropout.
  - `TestInit_NilTokenFuncSendsUnauthenticated` — documents nil-tokenFunc contract.
  - `TestInit_EmptyTokenSkipsHeader` — empty string must NOT produce `"Bearer "` (server parse error).
- [x] `make lint` — `0 issues`.
- [x] `go build ./...` — clean.
- [ ] Manual verify after merge: tail Honeycomb `api-go` 401 series on `POST /api/v1/otlp/*` — should drop sharply once the new build is in CLI/daemon hands.

Refs: ox-cso

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OTLP tracing exports now support dynamic JWT bearer tokens so the system can fetch and rotate tokens at export time; when no token is available the exporter sends no Authorization header.

* **Tests**
  * Expanded test coverage verifying per-request token injection, token rotation behavior, and cases where the token function is nil or returns an empty token.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->