### PR TITLE
refactor(daemon): relax teamDiscoveryInterval 5m → 1h

### DIFF
--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -55,8 +55,14 @@ const (
 
 	// teamDiscoveryInterval is how often we re-fetch the team list from the API,
 	// independent of credential token expiry. This ensures new teams are discovered
-	// promptly even when the token is still fresh.
-	teamDiscoveryInterval = 5 * time.Minute
+	// without waiting for the next credential refresh.
+	//
+	// 1h is a deliberate trade-off: team membership changes are rare (admin adds
+	// a member, user joins a new team), so the previous 5min cadence cost ~12x
+	// the API load for no perceptible UX gain. New-team discovery still happens
+	// opportunistically on credential refresh and on explicit user actions
+	// (`ox status`, `ox doctor`).
+	teamDiscoveryInterval = 1 * time.Hour
 
 	// maxConcurrentClones limits background clone operations to prevent resource exhaustion.
 	// 100 team contexts shouldn't spawn 100 concurrent git clones.


### PR DESCRIPTION
## Summary

Relax `teamDiscoveryInterval` from 5 minutes to 1 hour in `internal/daemon/sync.go`. Reduces team-discovery API calls by ~12× with no perceptible UX impact.

## Motivation

`SyncScheduler.discoverTeams()` re-fetches `GET /api/v1/cli/repos` to pick up new team memberships independent of credential token expiry. The previous 5-minute cadence was set without an explicit cost/benefit analysis.

Real-world: team membership changes are rare events (admin adds a member, user joins a new team). Polling 12× per hour for an event that happens at most a few times per week is wasted load on the API.

New-team discovery still happens on:
- Credential refresh (every ~24h, or sooner near expiry)
- Explicit user actions (`ox status`, `ox doctor`)

So worst-case latency for "I was added to a team and want to see it" stays bounded at 1h instead of 5m — acceptable for an admin action that typically precedes the user actually needing access.

## Context

Spun out of triage on issue #577 (closed; premise N/A — no local device state to sync). During investigation, `discoverTeams()` was found to already cover the "team membership changes propagate" half of #577 at 5m. Discussion concluded 1h is the right cadence.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/daemon/ -run TestDiscoverTeams` — `ok 0.598s`
- [ ] Smoke: run `ox` against staging, verify daemon logs `team discovery found updated team list` at ~1h cadence (or remains quiet when no changes)

## Files changed

- `internal/daemon/sync.go` — constant change + expanded comment documenting the trade-off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted team discovery refresh cadence to reduce system overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->