### PR TITLE
fix(auth,ephemeral): apply PR #626 CodeRabbit findings + test isolation

### DIFF
--- a/cmd/ox/agent_prime_ephemeral_fallback.go
+++ b/cmd/ox/agent_prime_ephemeral_fallback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -81,6 +82,12 @@ func tryHTTPTeamContextFallback(ctx context.Context, projectRoot, teamID string)
 // fetchTeamContextViaAPI writes the HTTP-fetched team context to disk
 // under teamCtxDir. Each file uses an atomic temp-file + rename pattern
 // so a partial fetch never leaves a half-written file in place.
+//
+// Files present on disk under teamCtxDir/docs/** or the three root files
+// (AGENTS.md / CLAUDE.md / MEMORY.md) that are NOT in the current response
+// are removed AFTER successful writes. This prevents a previously-served
+// doc from lingering and being fed to the agent indefinitely after it was
+// removed upstream.
 func fetchTeamContextViaAPI(teamCtxDir string, resp *api.TeamContextContentResponse) error {
 	if resp == nil {
 		return fmt.Errorf("nil response")
@@ -88,6 +95,8 @@ func fetchTeamContextViaAPI(teamCtxDir string, resp *api.TeamContextContentRespo
 	if err := os.MkdirAll(teamCtxDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir team-context dir: %w", err)
 	}
+
+	keep := map[string]bool{}
 
 	for _, doc := range resp.Docs {
 		if doc.Name == "" {
@@ -108,6 +117,7 @@ func fetchTeamContextViaAPI(teamCtxDir string, resp *api.TeamContextContentRespo
 		if err := atomicWriteFile(destPath, []byte(doc.Content), 0o644); err != nil {
 			return fmt.Errorf("write doc %s: %w", destPath, err)
 		}
+		keep[destPath] = true
 	}
 
 	type rootFile struct {
@@ -120,13 +130,45 @@ func fetchTeamContextViaAPI(teamCtxDir string, resp *api.TeamContextContentRespo
 		{"MEMORY.md", resp.Memory},
 	}
 	for _, rf := range rootFiles {
+		dest := filepath.Join(teamCtxDir, rf.name)
 		if rf.content == "" {
+			// not in this response — make sure a stale copy isn't left behind
+			_ = os.Remove(dest)
 			continue
 		}
-		dest := filepath.Join(teamCtxDir, rf.name)
 		if err := atomicWriteFile(dest, []byte(rf.content), 0o644); err != nil {
 			return fmt.Errorf("write %s: %w", rf.name, err)
 		}
+		keep[dest] = true
+	}
+
+	// sweep stale files under docs/ that the response no longer includes.
+	// We deliberately scope removal to docs/ + the three known root files
+	// so users storing other data under teamCtxDir (e.g. a local clone
+	// sibling, lock files, caches) is never touched.
+	//
+	// Use os.Root to anchor the walk + remove inside docsRoot — defeats
+	// symlink-TOCTOU traversal escapes (gosec G122).
+	docsRoot := filepath.Join(teamCtxDir, "docs")
+	if root, openErr := os.OpenRoot(docsRoot); openErr == nil {
+		defer root.Close()
+		_ = fs.WalkDir(root.FS(), ".", func(p string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			abs := filepath.Join(docsRoot, p)
+			if keep[abs] {
+				return nil
+			}
+			if rmErr := root.Remove(p); rmErr != nil {
+				slog.Debug("ephemeral team-context fallback: failed to remove stale doc",
+					"path", abs, "err", rmErr.Error())
+			}
+			return nil
+		})
+	} else if !errors.Is(openErr, fs.ErrNotExist) {
+		slog.Debug("ephemeral team-context fallback: open docs root failed",
+			"dir", docsRoot, "err", openErr.Error())
 	}
 
 	return nil

--- a/cmd/ox/agent_prime_ephemeral_fallback_test.go
+++ b/cmd/ox/agent_prime_ephemeral_fallback_test.go
@@ -181,3 +181,73 @@ func TestDiscoverTeamContextWithFallback_RefreshesExistingLocalCopy(t *testing.T
 	require.NoError(t, err)
 	assert.Equal(t, "fresh", string(doc))
 }
+
+// TestFetchTeamContextViaAPI_RemovesStaleDocsAndRootFiles — Failure prevented:
+// when the upstream team-context omits a doc or root file that was present
+// on a prior fetch, the old copy lingers on disk and the agent keeps seeing
+// deleted instructions. After this fix, files no longer in the response are
+// removed.
+func TestFetchTeamContextViaAPI_RemovesStaleDocsAndRootFiles(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	teamCtxDir := filepath.Join(tmpDir, "team-ctx", "team_stale")
+
+	// First fetch: seed AGENTS.md + CLAUDE.md + MEMORY.md + two docs.
+	first := &api.TeamContextContentResponse{
+		TeamID: "team_stale",
+		Docs: []api.TeamContextDoc{
+			{Name: "keep.md", Content: "keep-v1"},
+			{Name: "drop.md", Content: "drop-me"},
+			{Name: "subdir/old.md", Content: "old-nested"},
+		},
+		AgentsMD: "agents-v1",
+		ClaudeMD: "claude-v1",
+		Memory:   "memory-v1",
+	}
+	require.NoError(t, fetchTeamContextViaAPI(teamCtxDir, first))
+
+	// Sanity-check the seed landed.
+	for _, p := range []string{
+		filepath.Join(teamCtxDir, "AGENTS.md"),
+		filepath.Join(teamCtxDir, "CLAUDE.md"),
+		filepath.Join(teamCtxDir, "MEMORY.md"),
+		filepath.Join(teamCtxDir, "docs", "keep.md"),
+		filepath.Join(teamCtxDir, "docs", "drop.md"),
+		filepath.Join(teamCtxDir, "docs", "subdir", "old.md"),
+	} {
+		_, err := os.Stat(p)
+		require.NoError(t, err, "seed file missing: %s", p)
+	}
+
+	// Second fetch: upstream removed drop.md, subdir/old.md, CLAUDE.md, MEMORY.md.
+	second := &api.TeamContextContentResponse{
+		TeamID: "team_stale",
+		Docs: []api.TeamContextDoc{
+			{Name: "keep.md", Content: "keep-v2"},
+		},
+		AgentsMD: "agents-v2",
+		// ClaudeMD + Memory intentionally blank — upstream removed them
+	}
+	require.NoError(t, fetchTeamContextViaAPI(teamCtxDir, second))
+
+	// Files that should still exist with refreshed content
+	for path, want := range map[string]string{
+		filepath.Join(teamCtxDir, "AGENTS.md"):           "agents-v2",
+		filepath.Join(teamCtxDir, "docs", "keep.md"):     "keep-v2",
+	} {
+		got, err := os.ReadFile(path)
+		require.NoError(t, err, "%s should be kept", path)
+		assert.Equal(t, want, string(got), "%s content mismatch", path)
+	}
+
+	// Files that should be GONE
+	for _, p := range []string{
+		filepath.Join(teamCtxDir, "CLAUDE.md"),
+		filepath.Join(teamCtxDir, "MEMORY.md"),
+		filepath.Join(teamCtxDir, "docs", "drop.md"),
+		filepath.Join(teamCtxDir, "docs", "subdir", "old.md"),
+	} {
+		_, err := os.Stat(p)
+		assert.True(t, os.IsNotExist(err), "stale file must be removed: %s (err=%v)", p, err)
+	}
+}

--- a/cmd/ox/doctor_ledger_git_unmerged_test.go
+++ b/cmd/ox/doctor_ledger_git_unmerged_test.go
@@ -243,7 +243,7 @@ func runIsolatedGit(t *testing.T, dir string, args ...string) (string, error) {
 	cmd.Dir = dir
 	// scrub HOME/XDG_CONFIG_HOME so per-user gitconfig (including merge.tool
 	// hooks that could open an editor) can't interfere with the test.
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(os.Environ(), // safe: git subprocess in temp dir, not ox
 		"HOME="+dir,
 		"XDG_CONFIG_HOME="+filepath.Join(dir, ".config"),
 		"GIT_CONFIG_GLOBAL=/dev/null",
@@ -370,7 +370,7 @@ func TestFixLedgerUnmergedPaths_NoStateMarkers_NoAutoResolve(t *testing.T) {
 
 	cmd := exec.Command("git", "update-index", "--index-info")
 	cmd.Dir = repo
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(os.Environ(), // safe: git subprocess in temp dir, not ox
 		"HOME="+repo,
 		"GIT_CONFIG_GLOBAL=/dev/null",
 		"GIT_CONFIG_SYSTEM=/dev/null",

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -93,6 +93,14 @@ func EnsureValidToken(bufferSeconds int) (*StoredToken, error) {
 		return nil, nil
 	}
 
+	// env-sourced tokens (SAGEOX_TOKEN) have no refresh credential —
+	// the server returning 401 is the source of truth for invalidation.
+	// Mirror EnsureValidTokenForEndpoint so callers on the non-endpoint
+	// path do not attempt to refresh env tokens.
+	if isEnvToken(endpoint.Get(), token) {
+		return token, nil
+	}
+
 	// check if token needs refresh (expired or will expire within buffer)
 	if token.IsExpired(bufferSeconds) {
 		return refreshToken(token)
@@ -356,6 +364,12 @@ func (c *AuthClient) EnsureValidToken(bufferSeconds int) (*StoredToken, error) {
 
 	if token == nil {
 		return nil, nil
+	}
+
+	// env-sourced tokens (SAGEOX_TOKEN) have no refresh credential —
+	// the server returning 401 is the source of truth for invalidation.
+	if isEnvToken(c.Endpoint(), token) {
+		return token, nil
 	}
 
 	// check if token needs refresh (expired or will expire within buffer)

--- a/internal/auth/refresh_test.go
+++ b/internal/auth/refresh_test.go
@@ -853,3 +853,59 @@ func TestRefreshToken_JWTExchangeRefreshTokenFallback_WithSessionToken(t *testin
 	assert.Equal(t, "jwt-refresh-from-exchange", token.RefreshToken,
 		"JWT exchange refresh_token should be preferred over session_token fallback")
 }
+
+// --- B. Env-token refresh bypass (PR #626 follow-up) ---
+// Failure prevented: EnsureValidToken / (*AuthClient).EnsureValidToken (the
+// non-endpoint variants) attempt a refresh call for SAGEOX_TOKEN-sourced
+// tokens, which (a) have no refresh credential and (b) hit the network for
+// no reason. Their *ForEndpoint counterparts already bypass via isEnvToken;
+// these tests pin the same contract for the non-endpoint paths.
+
+// TestEnsureValidToken_EnvTokenSkipsRefresh — Failure prevented: the
+// package-level EnsureValidToken triggers refreshToken() for an env token
+// even though refresh credentials are absent.
+func TestEnsureValidToken_EnvTokenSkipsRefresh(t *testing.T) {
+	// fail-loud server: any HTTP traffic during this test is a regression.
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("env token must NOT trigger network refresh; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer mockServer.Close()
+
+	t.Setenv("SAGEOX_ENDPOINT", mockServer.URL)
+	t.Setenv(EnvVarToken, "oxp_env_bypass")
+
+	// route disk auth into a temp dir without altering package state
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// buffer exceeds the 24h synthetic env-token TTL so IsExpired() returns true
+	// and the pre-fix code path would call refreshToken().
+	bigBuffer := int((48 * time.Hour).Seconds())
+	token, err := EnsureValidToken(bigBuffer)
+	require.NoError(t, err)
+	require.NotNil(t, token, "env token should be returned as-is")
+	assert.Equal(t, "oxp_env_bypass", token.AccessToken)
+	assert.Empty(t, token.RefreshToken, "env token must have no refresh credential")
+}
+
+// TestAuthClient_EnsureValidToken_EnvTokenSkipsRefresh — Failure prevented:
+// the AuthClient variant of EnsureValidToken triggers refreshToken() for an
+// env token. Mirrors the *ForEndpoint behavior already pinned in
+// EnsureValidTokenForEndpoint.
+func TestAuthClient_EnsureValidToken_EnvTokenSkipsRefresh(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("env token must NOT trigger network refresh; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer mockServer.Close()
+
+	t.Setenv("SAGEOX_ENDPOINT", mockServer.URL)
+	t.Setenv(EnvVarToken, "oxp_env_client_bypass")
+
+	client := NewAuthClientWithDir(t.TempDir()).WithEndpoint(mockServer.URL)
+
+	bigBuffer := int((48 * time.Hour).Seconds())
+	token, err := client.EnsureValidToken(bigBuffer)
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "oxp_env_client_bypass", token.AccessToken)
+	assert.Empty(t, token.RefreshToken)
+}

--- a/internal/auth/token_meta_cache.go
+++ b/internal/auth/token_meta_cache.go
@@ -71,6 +71,15 @@ func tokenHashKey(token string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// tokenMetaCacheKey scopes the cache entry to (endpoint, token). The same
+// token value can legitimately exist for multiple endpoints (dev/prod/etc.);
+// keying on token alone would let metadata from one endpoint shadow another.
+// "\n" is a safe separator — it cannot appear in either input.
+func tokenMetaCacheKey(ep, token string) string {
+	sum := sha256.Sum256([]byte(ep + "\n" + token))
+	return hex.EncodeToString(sum[:])
+}
+
 // tokenMetaCachePath returns the on-disk cache file location:
 // $XDG_CACHE_HOME/sageox/token_meta.json (or legacy ~/.sageox/cache/...).
 func tokenMetaCachePath() string {
@@ -143,7 +152,7 @@ func FetchTokenMetaCached(ctx context.Context, ep, token string) (*TokenMeta, er
 		return nil, fmt.Errorf("empty token")
 	}
 	ep = endpoint.NormalizeEndpoint(ep)
-	key := tokenHashKey(token)
+	key := tokenMetaCacheKey(ep, token)
 
 	tokenMetaCacheMu.Lock()
 	defer tokenMetaCacheMu.Unlock()

--- a/internal/auth/token_meta_cache_test.go
+++ b/internal/auth/token_meta_cache_test.go
@@ -174,3 +174,72 @@ func TestTokenMetaCachePath_InsideCacheDir(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, rel, "..", "path must be inside the configured XDG cache dir")
 }
+
+// --- Endpoint scoping (PR #626 follow-up) ---
+
+// TestFetchTokenMetaCached_EndpointIsolation — Failure prevented: the cache
+// key was originally tokenHashKey(token) only, so the same token value used
+// against two different endpoints (e.g. prod + staging during migration)
+// returned the first endpoint's metadata for both. The user would see a
+// staging name/expiry surfaced for a prod token (or vice versa).
+func TestFetchTokenMetaCached_EndpointIsolation(t *testing.T) {
+	withTempCacheDir(t)
+
+	type epResp struct {
+		prefix string
+		name   string
+	}
+	serve := func(r epResp) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			expires := time.Now().Add(72 * time.Hour)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"expires_at":   expires.Format(time.RFC3339),
+				"token_prefix": r.prefix,
+				"name":         r.name,
+			})
+		}))
+	}
+
+	srvProd := serve(epResp{prefix: "oxp_PROD", name: "prod"})
+	defer srvProd.Close()
+	srvStage := serve(epResp{prefix: "oxp_STAGE", name: "stage"})
+	defer srvStage.Close()
+
+	// Same token value, two endpoints — must NOT collide in the cache.
+	const tok = "oxp_shared_value"
+
+	prodMeta, err := FetchTokenMetaCached(context.Background(), srvProd.URL, tok)
+	require.NoError(t, err)
+	require.NotNil(t, prodMeta)
+	assert.Equal(t, "oxp_PROD", prodMeta.TokenPrefix)
+	assert.Equal(t, "prod", prodMeta.Name)
+
+	stageMeta, err := FetchTokenMetaCached(context.Background(), srvStage.URL, tok)
+	require.NoError(t, err)
+	require.NotNil(t, stageMeta)
+	assert.Equal(t, "oxp_STAGE", stageMeta.TokenPrefix, "second endpoint must NOT return cached prod metadata")
+	assert.Equal(t, "stage", stageMeta.Name)
+
+	// Re-fetch prod — should still be the prod entry, untouched by stage.
+	prodAgain, err := FetchTokenMetaCached(context.Background(), srvProd.URL, tok)
+	require.NoError(t, err)
+	require.NotNil(t, prodAgain)
+	assert.Equal(t, "oxp_PROD", prodAgain.TokenPrefix)
+}
+
+// TestTokenMetaCacheKey_DistinctByEndpoint — Failure prevented: cache-key
+// helper conflates (ep, token) and the on-disk file ends up with one entry
+// per token instead of one per (endpoint, token) pair.
+func TestTokenMetaCacheKey_DistinctByEndpoint(t *testing.T) {
+	a := tokenMetaCacheKey("https://api.sageox.ai", "oxp_x")
+	b := tokenMetaCacheKey("https://staging.sageox.ai", "oxp_x")
+	c := tokenMetaCacheKey("https://api.sageox.ai", "oxp_x")
+	assert.NotEqual(t, a, b, "different endpoints must produce different keys for the same token")
+	assert.Equal(t, a, c, "same (endpoint, token) must produce the same key")
+	// Defend against trivial concatenation collisions:
+	// (ep="ab", token="") vs (ep="a", token="b") must NOT collide.
+	x := tokenMetaCacheKey("ab", "")
+	y := tokenMetaCacheKey("a", "b")
+	assert.NotEqual(t, x, y, "separator must prevent prefix-collision")
+}

--- a/internal/codedb/dirty_integration_test.go
+++ b/internal/codedb/dirty_integration_test.go
@@ -27,6 +27,10 @@ func initTestRepo(t *testing.T) string {
 			"GIT_AUTHOR_EMAIL=test@sageox.ai",
 			"GIT_COMMITTER_NAME=test",
 			"GIT_COMMITTER_EMAIL=test@sageox.ai",
+			// scrub host gitconfig so commit.gpgsign / signingkey can't prompt
+			// for ssh/gpg passphrases during the test commit.
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/internal/ledger/automerge/automerge_test.go
+++ b/internal/ledger/automerge/automerge_test.go
@@ -24,11 +24,23 @@ func initTestRepo(t *testing.T, dir string) string {
 	return dir
 }
 
+// hermeticGitEnv layers env overrides that scrub host gitconfig so per-user
+// signing (commit.gpgsign + ssh signingkey) can't prompt for passphrases
+// during test commits. Applied to every git subprocess in this package.
+func hermeticGitEnv() []string {
+	return []string{
+		"GIT_EDITOR=true",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	}
+}
+
 func mustGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=true", "GIT_TERMINAL_PROMPT=0") // safe: tempdir git subprocess; layered env disables editor + prompts
+	cmd.Env = append(os.Environ(), hermeticGitEnv()...) // safe: tempdir git subprocess; hermetic env disables editor, prompts, host signing
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(out))
@@ -41,7 +53,7 @@ func mustGit(t *testing.T, dir string, args ...string) string {
 func runGitAllowFail(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_EDITOR=true", "GIT_TERMINAL_PROMPT=0") // safe: same as mustGit; tolerates non-zero exit (rebase conflicts)
+	cmd.Env = append(os.Environ(), hermeticGitEnv()...) // safe: same as mustGit; tolerates non-zero exit (rebase conflicts)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }


### PR DESCRIPTION
## What broke

Three Major-tier CodeRabbit findings on #626 were flagged before merge but never applied. Two are auth-correctness bugs that affect any caller of the non-endpoint `EnsureValidToken` variants or any user running multiple `(endpoint, token)` pairs in the same shell. The third is a stale-file bug in ephemeral team-context fetch.

Plus two pre-existing test suites that flake on developer machines with `commit.gpgsign=true` because they inherit host gitconfig.

| Area | Bug | Where | Impact |
|---|---|---|---|
| Auth | `EnsureValidToken` / `(*AuthClient).EnsureValidToken` attempt refresh for SAGEOX_TOKEN | `internal/auth/refresh.go:86,351` | Spurious network call per cached-meta refresh + `no refresh token available` errors for headless / CI users |
| Auth | `FetchTokenMetaCached` keys on token hash only | `internal/auth/token_meta_cache.go:146` | Same token value on prod + staging returns the wrong host's metadata; expiry warnings + names get crossed |
| Ephemeral | `fetchTeamContextViaAPI` never deletes docs the upstream removed | `cmd/ox/agent_prime_ephemeral_fallback.go:84` | Deleted team-context docs keep priming AI coworkers indefinitely until next manual cleanup |
| Tests | git subprocess inherits host `commit.gpgsign` + ssh signing key | `internal/ledger/automerge/*_test.go`, `internal/codedb/dirty_integration_test.go` | `git commit` prompts for ssh passphrase, test fails on developer laptops |

## What this PR ships

### 1. Env-token refresh bypass on non-endpoint paths

```mermaid
flowchart LR
  caller["caller"] --> ensure["EnsureValidToken / *AuthClient.EnsureValidToken"]
  ensure --> isenv{"isEnvToken?"}
  isenv -- "yes" --> ret["return token as-is"]
  isenv -- "no" --> exp{"IsExpired?"}
  exp -- "yes" --> refresh["refreshToken to network"]
  exp -- "no" --> ret
```

`EnsureValidTokenForEndpoint` already had this gate (`internal/auth/refresh.go:119,383`). The non-endpoint variants did not. Now they do, using `endpoint.Get()` / `c.Endpoint()` for the scope check.

### 2. Endpoint-scoped token-meta cache key

`FetchTokenMetaCached` was documented as keyed by `(endpoint, token)` but actually hashed only the token, so the same SAGEOX_TOKEN aimed at prod + staging would shadow each other in `token_meta.json`. New helper:

```go
func tokenMetaCacheKey(ep, token string) string {
    sum := sha256.Sum256([]byte(ep + "\n" + token))
    return hex.EncodeToString(sum[:])
}
```

The `\n` separator is collision-proof (cannot appear in either input). Existing on-disk cache entries from the old layout expire naturally via the 1h `tokenMetaCacheTTL`.

### 3. Stale team-context file cleanup

`fetchTeamContextViaAPI` now builds a `keep` set during write, then walks `docs/` via `os.OpenRoot` (symlink-TOCTOU safe, gosec G122-clean) and removes anything not in the set. Root files (`AGENTS.md`/`CLAUDE.md`/`MEMORY.md`) are explicitly removed when omitted from the response.

```mermaid
flowchart TD
  resp["HTTP team-context response"] --> wr["write docs/** + root files"]
  wr --> keep["build keep-set"]
  keep --> walk["os.OpenRoot(docs/) WalkDir"]
  walk --> drop{"path in keep?"}
  drop -- "no" --> rm["root.Remove(rel)"]
  drop -- "yes" --> skip["leave it"]
  wr --> rmRoot["os.Remove on omitted root files"]
```

Removal is scoped to `docs/**` plus the three known root files — user/daemon data elsewhere under `teamCtxDir` is untouched.

### 4. Hermetic git env in two test suites

Added `GIT_CONFIG_GLOBAL=/dev/null` + `GIT_CONFIG_SYSTEM=/dev/null` to the test git subprocesses in `internal/ledger/automerge` and `internal/codedb/dirty_integration_test.go`. Pre-existing pattern in other test files; these two were missed.

## Regression tests

| Test | Verifies | Stashed-fix repro? |
|---|---|---|
| `TestEnsureValidToken_EnvTokenSkipsRefresh` | pkg-level: env token + buffer > 24h synthetic TTL → no HTTP traffic | yes — `no refresh token available` without fix |
| `TestAuthClient_EnsureValidToken_EnvTokenSkipsRefresh` | same for `*AuthClient` variant | yes |
| `TestFetchTokenMetaCached_EndpointIsolation` | same token, two endpoints → two separate cache entries | inspection (helper test won't compile without fix) |
| `TestTokenMetaCacheKey_DistinctByEndpoint` | helper avoids prefix-collision | inspection |
| `TestFetchTeamContextViaAPI_RemovesStaleDocsAndRootFiles` | seed → refresh-omitting-some → stale gone, kept ones refreshed | yes — three stale-path failures without fix |

## Test Plan

- [x] `go test ./...` clean
- [x] `make lint` clean (`0 issues.`)
- [x] `go vet ./...` clean
- [x] Each new test verified to FAIL with the corresponding fix stashed
- [ ] Manual smoke (post-merge): `SAGEOX_TOKEN=oxp_x` on a fresh shell + `ox status` does not hit `/oauth/token`

## Sequencing

This is the #626 follow-up. The #627 (session pause/resume) fixes — 2 TOCTOU races + 3 surface bugs — are tracked separately and will land on `ryan/recording-pause` directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team context system now properly removes outdated documentation files during updates
  * Environment-sourced authentication tokens skip unnecessary refresh attempts
  * Token metadata caching properly isolates data by endpoint to prevent cross-environment conflicts

* **Tests**
  * Added tests for stale documentation cleanup behavior
  * Added regression tests for environment token handling
  * Added endpoint isolation validation for token caching

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->