### PR TITLE
feat(perf): performance metrics for for ox doctor + daemon

### DIFF
--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -20,9 +20,11 @@ import (
 	"github.com/sageox/ox/internal/doctor/checks"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/perf"
 	"github.com/sageox/ox/internal/tips"
 	"github.com/sageox/ox/internal/ui"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // checkResult represents a single diagnostic check
@@ -328,7 +330,7 @@ common issues, or --fix-slug to target specific checks.`,
 			renderDoctorHeader(cmd.OutOrStdout(), opts.fix)
 		}
 
-		categories := runDoctorChecks(opts)
+		categories := runDoctorChecks(cmd.Context(), opts)
 		hasFailed := displayDoctorResults(cmd, categories, opts)
 
 		// record doctor run timestamp for staleness tracking
@@ -535,18 +537,27 @@ func detectDoctorState() doctorState {
 
 // doctorProgress shows per-category progress during doctor checks.
 // Displays timing for each category so users can see what's slow.
+//
+// Each show() call also opens a perf span scoped to the category. The
+// span is closed automatically when the next category begins (or when
+// clear() runs in defer). This means `OX_TRACE=1 ox doctor` renders a
+// tree showing exactly which category dominated the run.
 type doctorProgress struct {
 	interactive bool
 	verbose     bool
 	lastStart   time.Time
 	lastName    string
 	lineCount   int
+
+	ctx         context.Context
+	currentSpan trace.Span
 }
 
 func newDoctorProgress(verbose bool) *doctorProgress {
 	return &doctorProgress{
 		interactive: cli.IsInteractive(),
 		verbose:     verbose,
+		ctx:         context.Background(),
 	}
 }
 
@@ -554,6 +565,15 @@ func newDoctorProgress(verbose bool) *doctorProgress {
 // In verbose mode: prints timing for previous category on its own line.
 // In non-verbose mode: overwrites the progress line in-place.
 func (p *doctorProgress) show(category string) {
+	// close the previous category's span (perf tree); always runs even
+	// when the user is non-interactive so the span tree is still built
+	// for OX_TRACE=1 in CI / pipes.
+	if p.currentSpan != nil {
+		p.currentSpan.End()
+		p.currentSpan = nil
+	}
+	_, p.currentSpan = perf.Start(p.ctx, "doctor:"+category)
+
 	if !p.interactive {
 		return
 	}
@@ -573,6 +593,11 @@ func (p *doctorProgress) show(category string) {
 
 // clear removes the ephemeral status line and logs final timing
 func (p *doctorProgress) clear() {
+	if p.currentSpan != nil {
+		p.currentSpan.End()
+		p.currentSpan = nil
+	}
+
 	if !p.interactive {
 		return
 	}
@@ -587,11 +612,21 @@ func (p *doctorProgress) clear() {
 	fmt.Fprint(os.Stderr, "\r\033[K")
 }
 
-func runDoctorChecks(opts doctorOptions) []checkCategory {
+func runDoctorChecks(parent context.Context, opts doctorOptions) []checkCategory {
 	var categories []checkCategory
-	ctx := context.Background()
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	// Open a parent span so per-category spans nest under "doctor".
+	// We inherit from the command's context so this span attaches to
+	// the existing CLI root span — the tree renders once at command
+	// end rather than fragmenting mid-output.
+	ctx, rootSpan := perf.Start(parent, "doctor")
+	defer rootSpan.End()
 
 	progress := newDoctorProgress(opts.verbose)
+	progress.ctx = ctx
 	defer progress.clear()
 
 	// detect environment state early for conditional suppression

--- a/cmd/ox/doctor_display_test.go
+++ b/cmd/ox/doctor_display_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
@@ -468,7 +469,7 @@ func TestRunDoctorChecks_CategoryStructure(t *testing.T) {
 func TestRunDoctorChecks_WithFixFlag(t *testing.T) {
 	t.Parallel()
 	// run with fix=true (can't cache this since it may have side effects)
-	categoriesWithFix := runDoctorChecks(doctorOptions{fix: true})
+	categoriesWithFix := runDoctorChecks(context.Background(), doctorOptions{fix: true})
 	require.NotEmpty(t, categoriesWithFix, "runDoctorChecks(true) returned no categories")
 
 	// use cached fix=false result

--- a/cmd/ox/doctor_fresh_install_test.go
+++ b/cmd/ox/doctor_fresh_install_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,7 +40,7 @@ func TestDoctorFreshInstall_NoWarnings(t *testing.T) {
 		verbose:  true, // see all checks for debugging
 		forceYes: true, // non-interactive
 	}
-	categories := runDoctorChecks(opts)
+	categories := runDoctorChecks(context.Background(), opts)
 
 	// collect all warnings, failures, and fixable issues
 	var warnings []string
@@ -92,7 +93,7 @@ func TestDoctorFreshInstall_EmptyRepo_NoWarnings(t *testing.T) {
 		verbose:  true,
 		forceYes: true,
 	}
-	categories := runDoctorChecks(opts)
+	categories := runDoctorChecks(context.Background(), opts)
 
 	// in an empty repo, we expect .sageox check to be skipped (not a warning)
 	// the user simply hasn't run init yet
@@ -309,7 +310,7 @@ func TestDoctorFreshCheckout_NoSideEffectDirectories(t *testing.T) {
 		verbose:  false,
 		forceYes: true,
 	}
-	_ = runDoctorChecks(opts)
+	_ = runDoctorChecks(context.Background(), opts)
 
 	// verify no new directories were created in the parent
 	afterEntries, err := os.ReadDir(parentDir)

--- a/cmd/ox/doctor_test.go
+++ b/cmd/ox/doctor_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
@@ -29,7 +30,7 @@ func getCachedDoctorChecks(t *testing.T) []checkCategory {
 		t.Skip("short: full doctor pipeline shells out to git/auth — see .claude/rules/testing.md")
 	}
 	cachedCategoriesOnce.Do(func() {
-		cachedCategories = runDoctorChecks(doctorOptions{fix: false})
+		cachedCategories = runDoctorChecks(context.Background(), doctorOptions{fix: false})
 	})
 	return cachedCategories
 }

--- a/cmd/ox/prepush_scan.go
+++ b/cmd/ox/prepush_scan.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sageox/ox/internal/perf"
 	"github.com/sageox/ox/internal/session"
 )
 
@@ -106,6 +107,8 @@ func inPrePushScannerScope(rel string) bool {
 // 2 seconds on a typical dev machine; see BenchmarkPrePushScan in the test
 // file for the budget assertion.
 func scanPrePushForSecrets(ctx context.Context, ledgerPath string) (*PrePushScanResult, error) {
+	ctx, span := perf.Start(ctx, "secret_scan")
+	defer span.End()
 	// Enumerate files in the push range. The triple-dot syntax includes
 	// every file touched by commits on HEAD that aren't on origin/main —
 	// even if a later commit reverts them, the bytes are still in the

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/ledger/automerge"
 	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/perf"
 )
 
 // checkUploadAccess checks if the user has write access to upload sessions.
@@ -331,13 +332,21 @@ var ledgerAutoResolvePrefixes = ledger.AutoResolvePrefixes
 // pushLedger pushes ledger changes to remote with conflict retry.
 // Delegates to gitutil.PushWithRetry with ledger-appropriate options:
 // LFS reconciliation, rebase on conflict, auto-resolve for data/github/.
+//
+// Per-phase timing is captured as nested spans so OX_TRACE=1 / -v shows
+// which segment of the push dominates — the secret scan, credential
+// refresh, the push itself, or LFS reconcile.
 func pushLedger(ctx context.Context, ledgerPath string) error {
+	ctx, span := perf.Start(ctx, "pre-push total")
+	defer span.End()
+
 	// resolve endpoint once, before entering the push loop.
 	// only refresh credentials when we have a real project root —
 	// GetForProject("") falls back to Default, which would inject
 	// production credentials into a local file:// remote URL.
 	// findGitRoot() is CWD-dependent — if the caller isn't in a git repo
 	// (e.g., doctor retry from a different dir), this silently returns "".
+	_, settingsSpan := perf.Start(ctx, "resolve_push_settings")
 	var ep string
 	if root := findGitRoot(); root != "" {
 		ep = endpoint.GetForProject(root)
@@ -354,6 +363,7 @@ func pushLedger(ctx context.Context, ledgerPath string) error {
 	} else if changed {
 		slog.Info("healed kb merge attributes", "ledger", ledgerPath)
 	}
+	settingsSpan.End()
 
 	// Pre-push secret gate (ox-1uss). Scans the commit range that we're about
 	// to push for known credential patterns; refuses the push if any are found
@@ -361,11 +371,17 @@ func pushLedger(ctx context.Context, ledgerPath string) error {
 	// refresh / merge-attribute healing so failures from those don't get
 	// confused with a secret-gate refusal; runs BEFORE PushWithRetry so we
 	// never send bytes containing detected credentials.
-	if err := runPrePushSecretGate(ctx, ledgerPath); err != nil {
+	gateCtx, gateSpan := perf.Start(ctx, "secret_gate")
+	if err := runPrePushSecretGate(gateCtx, ledgerPath); err != nil {
+		perf.RecordError(gateSpan, err)
+		gateSpan.End()
+		perf.RecordError(span, err)
 		return err
 	}
+	gateSpan.End()
 
-	return gitutil.PushWithRetry(ctx, ledgerPath, gitutil.PushOpts{
+	pushCtx, pushSpan := perf.Start(ctx, "git_push")
+	err := gitutil.PushWithRetry(pushCtx, ledgerPath, gitutil.PushOpts{
 		AutoResolvePrefixes: ledgerAutoResolvePrefixes,
 		PrePush: func(repoPath string) error {
 			if ep != "" {
@@ -378,6 +394,12 @@ func pushLedger(ctx context.Context, ledgerPath string) error {
 		ReconcileLFS:          makeLFSReconciler(ep),
 		OnUnresolvedConflicts: ledgerLLMResolveHook(),
 	})
+	if err != nil {
+		perf.RecordError(pushSpan, err)
+		perf.RecordError(span, err)
+	}
+	pushSpan.End()
+	return err
 }
 
 // ledgerLLMResolveHook returns the OnUnresolvedConflicts callback used by

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/logger"
 	"github.com/sageox/ox/internal/observability"
+	"github.com/sageox/ox/internal/perf"
 	"github.com/sageox/ox/internal/signature"
 	"github.com/sageox/ox/internal/telemetry"
 	"github.com/sageox/ox/internal/version"
@@ -136,6 +137,15 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 		}
 		return tok.AccessToken
 	}
+	// Install perf TreeCollectorProcessor BEFORE Init so the next
+	// NewTracerProvider call sees it alongside the OTLP batch exporter.
+	// Spans produced anywhere in the CLI feed both backends — OTLP for
+	// Honeycomb, and the local sink for the per-phase tree rendered to
+	// stderr on slow ops / OX_TRACE=1 / --verbose.
+	observability.AddSpanProcessor(perf.NewTreeProcessor(perf.Options{
+		OnSpan: perf.PerSpanSlog(cliCtx.Logger),
+		OnTree: perf.CLITreeSink(os.Stderr, cfg.Verbose),
+	}))
 	if err := observability.Init(cliCtx.Ctx, "ox-cli", apiEndpoint, tokenFunc, resourceAttrs...); err != nil {
 		slog.Debug("otel init failed, continuing without tracing", "error", err)
 	}
@@ -146,6 +156,12 @@ func NewContext(cmd *cobra.Command, args []string) (*Context, error) {
 		cmdPath = cmd.Parent().Name() + " " + cmdPath
 	}
 	cliCtx.Ctx, _ = observability.StartCommand(cliCtx.Ctx, observability.CommandName(cmdPath))
+	// Propagate the traced context onto the cobra command so
+	// downstream cmd.Context() callers inherit the OTel root span.
+	// Without this, perf.Start(cmd.Context(), ...) creates a NEW
+	// root span and the local tree fragments instead of nesting under
+	// the command.
+	cmd.SetContext(cliCtx.Ctx)
 
 	// Attach universal attributes to the root span: ox.version, host.os,
 	// host.arch, ox.command.args (with values redacted). This is the only

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/observability"
 	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/perf"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/internal/version"
@@ -1089,6 +1090,15 @@ func (d *Daemon) initComponents() time.Duration {
 			}
 			return tok.AccessToken
 		}
+		// Install perf processor BEFORE Init so the daemon's tree sink
+		// receives every span the OTLP exporter does. Per-span slog is
+		// gated by duration (>=100ms) and OX_TRACE; tree rendering to
+		// the daemon log is gated on OX_TRACE only — both are
+		// configured inside the perf sinks themselves.
+		observability.AddSpanProcessor(perf.NewTreeProcessor(perf.Options{
+			OnSpan: perf.PerSpanSlog(d.logger),
+			OnTree: perf.DaemonTreeSink(d.logger),
+		}))
 		if err := observability.Init(d.ctx, "ox-daemon", apiEndpoint, tokenFunc, daemonAttrs...); err != nil {
 			d.logger.Warn("otel tracing init failed", "error", err)
 		}

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/observability"
+	"github.com/sageox/ox/internal/perf"
 	"github.com/sageox/ox/internal/version"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
@@ -1053,6 +1054,12 @@ func (s *SyncScheduler) LastSync() time.Time {
 // Also performs anti-entropy: checks for missing workspaces and triggers clones.
 // Errors from doPull are already logged and recorded; background sync continues.
 func (s *SyncScheduler) pullChanges(ctx context.Context) {
+	// Open a root span for this pull cycle. Child spans (do_pull,
+	// managed_repo, fetch, rebase, ...) nest under it so the daemon
+	// log tree shows each cycle as one self-contained block.
+	ctx, span := s.tracer.StartTask(ctx, "daemon:pull_cycle")
+	defer span.End()
+
 	// anti-entropy: ensure missing workspaces get cloned
 	s.triggerMissingClones()
 
@@ -1207,6 +1214,8 @@ func isValidGitRepo(path string) bool {
 //   - lock file safety: if a git process crashes, its .git/index.lock is released
 //     by the OS; an in-process crash may leave stale locks in the same process
 func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, forceSync bool, refreshSparse bool) error {
+	ctx, span := perf.Start(ctx, "daemon:do_pull")
+	defer span.End()
 	if s.config.LedgerPath == "" {
 		return nil
 	}
@@ -1450,6 +1459,9 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 // Called during the ledger sync cycle for natural batching (~60s).
 // Non-fatal: failures are logged but don't block the sync cycle.
 func (s *SyncScheduler) pushMurmurCommits(ctx context.Context, ledgerPath string) {
+	ctx, span := perf.Start(ctx, "daemon:push_murmurs")
+	defer span.End()
+
 	// check for unpushed murmur commits
 	out, err := s.git.RunGit(ctx, ledgerPath, "log", "--oneline", "origin/main..HEAD", "--", "data/murmurs/")
 	if err != nil || strings.TrimSpace(out) == "" {

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/manifest"
+	"github.com/sageox/ox/internal/perf"
 )
 
 // ManagedRepoPullOpts configures how pullManagedRepo behaves for a given repo.
@@ -137,6 +138,9 @@ type ManagedRepoPullResult struct {
 // Callers wrap this with repo-specific concerns: auto-clone, backoff, mutex,
 // metrics, post-pull signals.
 func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPullOpts) ManagedRepoPullResult {
+	ctx, span := perf.Start(ctx, "daemon:pull_managed_repo")
+	defer span.End()
+
 	logger := opts.Logger
 	if logger == nil {
 		logger = s.logger
@@ -217,10 +221,13 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 	}
 
 	// git fetch
+	fetchCtx, fetchSpan := perf.Start(ctx, "git_fetch")
 	fetchArgs := append([]string{"-C", path}, gitHTTPTimeoutFlags()...)
 	fetchArgs = append(fetchArgs, "fetch", "--quiet")
-	fetchCmd := exec.CommandContext(ctx, "git", fetchArgs...)
+	fetchCmd := exec.CommandContext(fetchCtx, "git", fetchArgs...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
+		perf.RecordError(fetchSpan, err)
+		fetchSpan.End()
 		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
 		errMsg := "fetch failed"
 		if detail != "" {
@@ -228,6 +235,7 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 		}
 		return ManagedRepoPullResult{Err: fmt.Errorf("%s: %w", errMsg, err)}
 	}
+	fetchSpan.End()
 
 	// Track FETCH_HEAD mtime
 	var fetchHeadTime time.Time
@@ -273,10 +281,16 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 
 	// --- Pull ---
 
+	_, pullSpan := perf.Start(ctx, "git_pull_rebase")
 	pullArgs := append([]string{"-C", path}, gitHTTPTimeoutFlags()...)
 	pullArgs = append(pullArgs, "pull", "--rebase", "--autostash", "--quiet")
 	pullCmd := exec.CommandContext(ctx, "git", pullArgs...)
-	if output, err := pullCmd.CombinedOutput(); err != nil {
+	output, err := pullCmd.CombinedOutput()
+	if err != nil {
+		perf.RecordError(pullSpan, err)
+	}
+	pullSpan.End()
+	if err != nil {
 		detail := gitutil.SanitizeOutput(strings.TrimSpace(string(output)))
 		logger.Warn("pull failed", "error", err, "output", detail, "repo", repoName)
 

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/manifest"
 	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/perf"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
 
@@ -26,6 +27,9 @@ import (
 // blocking the sync scheduler event loop.
 // Also performs anti-entropy: checks for missing workspaces and triggers clones.
 func (s *SyncScheduler) pullTeamContexts(ctx context.Context) {
+	ctx, span := s.tracer.StartTask(ctx, "daemon:team_pull_cycle")
+	defer span.End()
+
 	// anti-entropy: ensure missing workspaces get cloned
 	s.triggerMissingClones()
 
@@ -52,6 +56,9 @@ func (s *SyncScheduler) TeamSync(progress *ProgressWriter) error {
 // spawns a background goroutine to clone it. This doesn't block the sync loop.
 // Note: Ledger auto-clone is handled separately in doPull() on the ledger sync ticker.
 func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter, forceSync bool) {
+	ctx, span := perf.Start(ctx, "daemon:do_team_sync")
+	defer span.End()
+
 	// refresh credentials if expired or near expiry
 	s.refreshCredentialsIfNeeded()
 

--- a/internal/observability/otel.go
+++ b/internal/observability/otel.go
@@ -47,12 +47,32 @@ func (rt *bearerRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 }
 
 var (
-	mu       sync.RWMutex
-	rootCtx  context.Context
-	rootSpan trace.Span
-	tracer   trace.Tracer
-	shutFn   func(context.Context) error
+	mu              sync.RWMutex
+	rootCtx         context.Context
+	rootSpan        trace.Span
+	tracer          trace.Tracer
+	shutFn          func(context.Context) error
+	extraProcessors []sdktrace.SpanProcessor
 )
+
+// AddSpanProcessor registers an additional SpanProcessor to be installed
+// alongside the OTLP batch exporter on the next Init() call. Must be
+// called BEFORE Init — processors added after Init are ignored, because
+// the TracerProvider is already built.
+//
+// Used by callers (CLI bootstrap, daemon bootstrap) to wire in
+// internal/perf's TreeCollectorProcessor so per-phase timing renders
+// locally in addition to flowing to the OTLP backend.
+//
+// Safe to call multiple times; each processor is registered once.
+func AddSpanProcessor(p sdktrace.SpanProcessor) {
+	if p == nil {
+		return
+	}
+	mu.Lock()
+	extraProcessors = append(extraProcessors, p)
+	mu.Unlock()
+}
 
 // Init sets up the OTel TracerProvider with OTLP/HTTP export to the SageOx
 // OTLP proxy at {apiEndpoint}/api/v1/otlp/v1/traces.
@@ -104,7 +124,7 @@ func Init(ctx context.Context, serviceName, apiEndpoint string, tokenFunc TokenF
 	resAttrs := []attribute.KeyValue{semconv.ServiceName(serviceName)}
 	resAttrs = append(resAttrs, attrs...)
 
-	tp := sdktrace.NewTracerProvider(
+	tpOpts := []sdktrace.TracerProviderOption{
 		sdktrace.WithBatcher(exporter,
 			sdktrace.WithBatchTimeout(1*time.Second),
 			sdktrace.WithMaxExportBatchSize(16),
@@ -113,7 +133,18 @@ func Init(ctx context.Context, serviceName, apiEndpoint string, tokenFunc TokenF
 			semconv.SchemaURL,
 			resAttrs...,
 		)),
-	)
+	}
+	// Append any processors registered via AddSpanProcessor before Init.
+	// internal/perf uses this hook to install its TreeCollectorProcessor
+	// so the local tree renderer sees the same spans the OTLP exporter
+	// receives, without duplicate instrumentation.
+	mu.RLock()
+	for _, p := range extraProcessors {
+		tpOpts = append(tpOpts, sdktrace.WithSpanProcessor(p))
+	}
+	mu.RUnlock()
+
+	tp := sdktrace.NewTracerProvider(tpOpts...)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 

--- a/internal/observability/otel_test.go
+++ b/internal/observability/otel_test.go
@@ -247,4 +247,5 @@ func resetGlobals() {
 	rootSpan = nil
 	tracer = nil
 	shutFn = nil
+	extraProcessors = nil
 }

--- a/internal/perf/processor.go
+++ b/internal/perf/processor.go
@@ -66,7 +66,7 @@ type TreeCollectorProcessor struct {
 
 	mu      sync.Mutex
 	pending map[trace.TraceID][]sdktrace.ReadOnlySpan
-	emitted map[trace.TraceID]struct{}
+	emitted map[trace.TraceID]time.Time
 }
 
 // NewTreeProcessor returns a processor ready to register with an OTel
@@ -75,9 +75,16 @@ func NewTreeProcessor(opts Options) *TreeCollectorProcessor {
 	return &TreeCollectorProcessor{
 		opts:    opts,
 		pending: make(map[trace.TraceID][]sdktrace.ReadOnlySpan),
-		emitted: make(map[trace.TraceID]struct{}),
+		emitted: make(map[trace.TraceID]time.Time),
 	}
 }
+
+// emittedRetention keeps a short-lived tombstone for completed traces so
+// child spans that end just after the root are dropped instead of creating
+// an un-emittable pending entry. Root traces are pruned opportunistically
+// on the next completed trace so long-lived daemons don't retain one
+// TraceID forever per sync cycle.
+const emittedRetention = 2 * time.Minute
 
 // OnStart is part of the SpanProcessor interface. We don't need it.
 func (p *TreeCollectorProcessor) OnStart(_ context.Context, _ sdktrace.ReadWriteSpan) {}
@@ -98,11 +105,22 @@ func (p *TreeCollectorProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
 
 	tid := s.SpanContext().TraceID()
 	isRoot := !s.Parent().SpanID().IsValid()
+	now := time.Now()
 
 	p.mu.Lock()
-	if _, done := p.emitted[tid]; done {
-		// Late arrival after the root already emitted. Drop quietly —
-		// the tree is already gone. A per-span slog (above) still ran.
+	if isRoot {
+		p.pruneExpiredEmittedLocked(now)
+	}
+	if expiresAt, done := p.emitted[tid]; done {
+		if expiresAt.After(now) {
+			// Late arrival after the root already emitted. Drop quietly —
+			// the tree is already gone. A per-span slog (above) still ran.
+			p.mu.Unlock()
+			return
+		}
+		delete(p.emitted, tid)
+	}
+	if p.pending == nil || p.emitted == nil {
 		p.mu.Unlock()
 		return
 	}
@@ -113,7 +131,7 @@ func (p *TreeCollectorProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
 	}
 	spans := p.pending[tid]
 	delete(p.pending, tid)
-	p.emitted[tid] = struct{}{}
+	p.emitted[tid] = now.Add(emittedRetention)
 	p.mu.Unlock()
 
 	if p.opts.OnTree == nil {
@@ -133,6 +151,14 @@ func (p *TreeCollectorProcessor) Shutdown(_ context.Context) error {
 	p.pending = nil
 	p.emitted = nil
 	return nil
+}
+
+func (p *TreeCollectorProcessor) pruneExpiredEmittedLocked(now time.Time) {
+	for tid, expiresAt := range p.emitted {
+		if !expiresAt.After(now) {
+			delete(p.emitted, tid)
+		}
+	}
 }
 
 // ForceFlush is a no-op. Trees emit synchronously on root OnEnd.

--- a/internal/perf/processor.go
+++ b/internal/perf/processor.go
@@ -1,0 +1,202 @@
+// Package perf collects OpenTelemetry spans into an in-process tree so
+// `ox` commands and the daemon can render per-phase timing to a local sink
+// (stderr, daemon log) without needing the OTLP backend.
+//
+// The package wraps OTel — it does NOT replace it. Spans produced via
+// perf.Start are real OTel spans that still flow to the configured
+// exporter. perf adds a SpanProcessor that buffers each trace's spans
+// in memory and, on root-span end, hands the assembled tree to a sink.
+package perf
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Node is a span captured by the processor with its children attached.
+// Trees are rooted at the trace's root span (no valid parent SpanID).
+type Node struct {
+	Name     string
+	SpanID   trace.SpanID
+	Start    time.Time
+	End      time.Time
+	Duration time.Duration
+	Status   sdktrace.Status
+	Attrs    []attribute.KeyValue
+	Children []*Node
+
+	// Detached is true when the span's parent ended before it did and the
+	// parent's tree was already emitted, or when its parent SpanID was not
+	// present in the trace's pending set. Detached spans render under a
+	// synthetic "<detached>" node so the user sees the timing rather than
+	// silently dropping it.
+	Detached bool
+}
+
+// SpanSink is called for every closed span (one call per OnEnd). Used to
+// emit per-span slog records when OX_TRACE=1 or duration exceeds a
+// threshold. Nil is a no-op.
+type SpanSink func(s sdktrace.ReadOnlySpan)
+
+// TreeSink is called once per closed trace, with the assembled root Node.
+// Used to render the tree to stderr or to the daemon log. Nil is a no-op.
+type TreeSink func(root *Node)
+
+// Options configures a TreeCollectorProcessor.
+type Options struct {
+	OnSpan SpanSink
+	OnTree TreeSink
+}
+
+// TreeCollectorProcessor is an OTel sdktrace.SpanProcessor that buffers
+// spans per trace and, when each trace's root span ends, builds a Node
+// tree and calls Options.OnTree with it.
+//
+// Concurrency: the OTel SDK may call OnEnd from multiple goroutines for
+// spans in the same or different traces. All map mutations are guarded
+// by mu.
+type TreeCollectorProcessor struct {
+	opts Options
+
+	mu      sync.Mutex
+	pending map[trace.TraceID][]sdktrace.ReadOnlySpan
+	emitted map[trace.TraceID]struct{}
+}
+
+// NewTreeProcessor returns a processor ready to register with an OTel
+// TracerProvider via sdktrace.WithSpanProcessor.
+func NewTreeProcessor(opts Options) *TreeCollectorProcessor {
+	return &TreeCollectorProcessor{
+		opts:    opts,
+		pending: make(map[trace.TraceID][]sdktrace.ReadOnlySpan),
+		emitted: make(map[trace.TraceID]struct{}),
+	}
+}
+
+// OnStart is part of the SpanProcessor interface. We don't need it.
+func (p *TreeCollectorProcessor) OnStart(_ context.Context, _ sdktrace.ReadWriteSpan) {}
+
+// OnEnd buffers the span. If the span is the root of its trace, we
+// assemble the tree and hand it to OnTree.
+func (p *TreeCollectorProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
+	if s == nil {
+		return
+	}
+	if !s.SpanContext().IsSampled() {
+		// Honors future sampling without rendering empty trees.
+		return
+	}
+	if p.opts.OnSpan != nil {
+		p.opts.OnSpan(s)
+	}
+
+	tid := s.SpanContext().TraceID()
+	isRoot := !s.Parent().SpanID().IsValid()
+
+	p.mu.Lock()
+	if _, done := p.emitted[tid]; done {
+		// Late arrival after the root already emitted. Drop quietly —
+		// the tree is already gone. A per-span slog (above) still ran.
+		p.mu.Unlock()
+		return
+	}
+	p.pending[tid] = append(p.pending[tid], s)
+	if !isRoot {
+		p.mu.Unlock()
+		return
+	}
+	spans := p.pending[tid]
+	delete(p.pending, tid)
+	p.emitted[tid] = struct{}{}
+	p.mu.Unlock()
+
+	if p.opts.OnTree == nil {
+		return
+	}
+	tree := buildTree(spans, s.SpanContext().SpanID())
+	if tree != nil {
+		p.opts.OnTree(tree)
+	}
+}
+
+// Shutdown drops any pending spans. No-op flush — the underlying
+// exporter handles real flushing.
+func (p *TreeCollectorProcessor) Shutdown(_ context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.pending = nil
+	p.emitted = nil
+	return nil
+}
+
+// ForceFlush is a no-op. Trees emit synchronously on root OnEnd.
+func (p *TreeCollectorProcessor) ForceFlush(_ context.Context) error { return nil }
+
+// buildTree assembles a Node tree from a flat slice of spans, rooted at
+// rootID. Spans whose parent is not in the slice are attached under a
+// synthetic <detached> node so the user sees their timing rather than
+// silently losing it.
+func buildTree(spans []sdktrace.ReadOnlySpan, rootID trace.SpanID) *Node {
+	byID := make(map[trace.SpanID]*Node, len(spans))
+	for _, s := range spans {
+		n := &Node{
+			Name:     s.Name(),
+			SpanID:   s.SpanContext().SpanID(),
+			Start:    s.StartTime(),
+			End:      s.EndTime(),
+			Duration: s.EndTime().Sub(s.StartTime()),
+			Status:   s.Status(),
+			Attrs:    s.Attributes(),
+		}
+		byID[n.SpanID] = n
+	}
+	root, ok := byID[rootID]
+	if !ok {
+		return nil
+	}
+
+	var detached []*Node
+	for _, s := range spans {
+		sid := s.SpanContext().SpanID()
+		if sid == rootID {
+			continue
+		}
+		parent := s.Parent().SpanID()
+		n := byID[sid]
+		if pn, ok := byID[parent]; ok {
+			pn.Children = append(pn.Children, n)
+			continue
+		}
+		n.Detached = true
+		detached = append(detached, n)
+	}
+
+	if len(detached) > 0 {
+		root.Children = append(root.Children, &Node{
+			Name:     "<detached>",
+			Children: detached,
+			Detached: true,
+		})
+	}
+
+	sortByStart(root)
+	return root
+}
+
+func sortByStart(n *Node) {
+	if n == nil {
+		return
+	}
+	sort.SliceStable(n.Children, func(i, j int) bool {
+		return n.Children[i].Start.Before(n.Children[j].Start)
+	})
+	for _, c := range n.Children {
+		sortByStart(c)
+	}
+}

--- a/internal/perf/processor_test.go
+++ b/internal/perf/processor_test.go
@@ -1,0 +1,211 @@
+package perf
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// --- A. Single root span emits one tree ---
+
+// TestProcessor_RootOnlyEmitsTree verifies a tree with just a root span
+// is emitted as a single-node tree.
+// Failure prevented: silently dropping spans with no children.
+func TestProcessor_RootOnlyEmitsTree(t *testing.T) {
+	var got *Node
+	tp := setupTP(t, Options{OnTree: func(n *Node) { got = n }})
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	_, span := tp.Tracer("test").Start(context.Background(), "root")
+	span.End()
+
+	require.NotNil(t, got)
+	assert.Equal(t, "root", got.Name)
+	assert.Empty(t, got.Children)
+}
+
+// --- B. Nested spans nest correctly ---
+
+// TestProcessor_NestedSpansForm Tree verifies parent/child nesting via
+// OTel context inheritance produces the right Children structure.
+// Failure prevented: child spans rendered as orphans or as siblings.
+func TestProcessor_NestedSpansFormTree(t *testing.T) {
+	var got *Node
+	tp := setupTP(t, Options{OnTree: func(n *Node) { got = n }})
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	ctx, root := tr.Start(context.Background(), "root")
+	_, child := tr.Start(ctx, "child")
+	child.End()
+	root.End()
+
+	require.NotNil(t, got)
+	require.Len(t, got.Children, 1)
+	assert.Equal(t, "child", got.Children[0].Name)
+}
+
+// --- C. Parallel siblings nest under parent ---
+
+// TestProcessor_ParallelSiblings verifies concurrent child spans (from a
+// WaitGroup, like daemon team-context syncs) all attach to the parent.
+// Failure prevented: race in pending map; siblings landing on wrong trace.
+func TestProcessor_ParallelSiblings(t *testing.T) {
+	var got *Node
+	tp := setupTP(t, Options{OnTree: func(n *Node) { got = n }})
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	ctx, root := tr.Start(context.Background(), "root")
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, c := tr.Start(ctx, "sibling")
+			time.Sleep(time.Millisecond)
+			c.End()
+		}()
+	}
+	wg.Wait()
+	root.End()
+
+	require.NotNil(t, got)
+	assert.Len(t, got.Children, 5, "all parallel children must nest under root")
+}
+
+// --- D. Detached span renders under <detached> ---
+
+// TestProcessor_OrphanSpanGetsDetached verifies a span whose parent never
+// ran through the processor (e.g. parent in a different sampled state)
+// surfaces under a synthetic <detached> node rather than vanishing.
+// Failure prevented: silent timing loss for spans whose parent missed
+// emission.
+func TestProcessor_OrphanSpanGetsDetached(t *testing.T) {
+	// Construct spans by hand by feeding fake ReadOnlySpans is hard with
+	// the SDK; instead, exercise the same code path by calling buildTree
+	// directly. We use the SDK-backed version via two traces.
+	var got *Node
+	tp := setupTP(t, Options{OnTree: func(n *Node) { got = n }})
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	// Build: root has one real child. We then construct an orphan span
+	// by giving it a parent SpanID that is not in the trace's pending
+	// set — done by ending a span whose parent was a sibling, not the
+	// root.
+	ctx, root := tr.Start(context.Background(), "root")
+	_, mid := tr.Start(ctx, "mid")
+	// Start child of mid, end it AFTER mid has ended — but the SDK
+	// still reports it as child-of-mid via the captured Parent SpanID,
+	// which is present in the slice, so it nests. To make an orphan we
+	// need a parent SpanID that never appears.
+	mid.End()
+	root.End()
+
+	require.NotNil(t, got)
+	// mid is the only direct child; no orphan in this normal case.
+	require.Len(t, got.Children, 1)
+	assert.Equal(t, "mid", got.Children[0].Name)
+}
+
+// --- E. Error status surfaces on Node ---
+
+// TestProcessor_ErrorStatusSurfaces verifies SetStatus(Error) on a span
+// is captured on the corresponding Node so the renderer can flag it.
+// Failure prevented: failed phases looking identical to successful ones.
+func TestProcessor_ErrorStatusSurfaces(t *testing.T) {
+	var got *Node
+	tp := setupTP(t, Options{OnTree: func(n *Node) { got = n }})
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	ctx, root := tr.Start(context.Background(), "root")
+	_, child := tr.Start(ctx, "child")
+	child.SetStatus(codes.Error, "boom")
+	child.End()
+	root.End()
+
+	require.NotNil(t, got)
+	require.Len(t, got.Children, 1)
+	assert.Equal(t, codes.Error, got.Children[0].Status.Code)
+}
+
+// --- F. PerSpan sink called for every span end ---
+
+// TestProcessor_PerSpanSinkCallback verifies OnSpan fires for every
+// closed span, not just the root.
+// Failure prevented: per-span slog emission missing for non-root spans.
+func TestProcessor_PerSpanSinkCallback(t *testing.T) {
+	var spans []string
+	var mu sync.Mutex
+	tp := setupTP(t, Options{
+		OnSpan: func(s sdktrace.ReadOnlySpan) {
+			mu.Lock()
+			spans = append(spans, s.Name())
+			mu.Unlock()
+		},
+	})
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	ctx, root := tr.Start(context.Background(), "root")
+	_, c := tr.Start(ctx, "child")
+	c.End()
+	root.End()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.ElementsMatch(t, []string{"child", "root"}, spans)
+}
+
+// --- G. Independent traces don't cross-contaminate ---
+
+// TestProcessor_IndependentTraces verifies spans from two unrelated
+// traces don't end up in the same tree. Daemon spawns one trace per
+// task; cross-contamination would conflate timing.
+func TestProcessor_IndependentTraces(t *testing.T) {
+	var trees []*Node
+	var mu sync.Mutex
+	tp := setupTP(t, Options{
+		OnTree: func(n *Node) {
+			mu.Lock()
+			trees = append(trees, n)
+			mu.Unlock()
+		},
+	})
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	// Two separate root spans = two independent traces.
+	_, a := tr.Start(context.Background(), "task_a", trace.WithNewRoot())
+	a.End()
+	_, b := tr.Start(context.Background(), "task_b", trace.WithNewRoot())
+	b.End()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, trees, 2)
+}
+
+// setupTP builds a TracerProvider with our processor + an in-memory
+// exporter installed. The exporter is required for span sampling/export
+// semantics to behave like production.
+func setupTP(t *testing.T, opts Options) *sdktrace.TracerProvider {
+	t.Helper()
+	p := NewTreeProcessor(opts)
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(p),
+	)
+	otel.SetTracerProvider(tp)
+	return tp
+}

--- a/internal/perf/processor_test.go
+++ b/internal/perf/processor_test.go
@@ -2,6 +2,7 @@ package perf
 
 import (
 	"context"
+	cryptorand "crypto/rand"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -84,37 +86,81 @@ func TestProcessor_ParallelSiblings(t *testing.T) {
 
 // --- D. Detached span renders under <detached> ---
 
-// TestProcessor_OrphanSpanGetsDetached verifies a span whose parent never
-// ran through the processor (e.g. parent in a different sampled state)
-// surfaces under a synthetic <detached> node rather than vanishing.
+// TestProcessor_OrphanSpanRendersUnderDetached verifies that a span whose
+// parent SpanID is NOT present in the trace's pending set (e.g. because
+// the parent was unsampled, lived in a different process, or arrived
+// after the trace was emitted and got dropped) surfaces under a
+// synthetic "<detached>" node rather than vanishing.
+//
+// We test buildTree directly with synthetic tracetest.SpanStub values so
+// we can construct the exact "parent SpanID has no matching span"
+// scenario, which is hard to provoke through the live SDK because every
+// span created via Tracer.Start has a real parent context.
+//
 // Failure prevented: silent timing loss for spans whose parent missed
 // emission.
-func TestProcessor_OrphanSpanGetsDetached(t *testing.T) {
-	// Construct spans by hand by feeding fake ReadOnlySpans is hard with
-	// the SDK; instead, exercise the same code path by calling buildTree
-	// directly. We use the SDK-backed version via two traces.
-	var got *Node
-	tp := setupTP(t, Options{OnTree: func(n *Node) { got = n }})
-	defer func() { _ = tp.Shutdown(context.Background()) }()
-	tr := tp.Tracer("test")
+func TestProcessor_OrphanSpanRendersUnderDetached(t *testing.T) {
+	traceID := randomTraceID(t)
+	rootID := randomSpanID(t)
+	orphanID := randomSpanID(t)
+	missingParentID := randomSpanID(t)
 
-	// Build: root has one real child. We then construct an orphan span
-	// by giving it a parent SpanID that is not in the trace's pending
-	// set — done by ending a span whose parent was a sibling, not the
-	// root.
-	ctx, root := tr.Start(context.Background(), "root")
-	_, mid := tr.Start(ctx, "mid")
-	// Start child of mid, end it AFTER mid has ended — but the SDK
-	// still reports it as child-of-mid via the captured Parent SpanID,
-	// which is present in the slice, so it nests. To make an orphan we
-	// need a parent SpanID that never appears.
-	mid.End()
-	root.End()
+	start := time.Now().Add(-time.Second)
+	end := start.Add(time.Second)
 
-	require.NotNil(t, got)
-	// mid is the only direct child; no orphan in this normal case.
-	require.Len(t, got.Children, 1)
-	assert.Equal(t, "mid", got.Children[0].Name)
+	rootSpan := tracetest.SpanStub{
+		Name: "root",
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  rootID,
+		}),
+		// Parent left zero → buildTree treats this as root.
+		StartTime: start,
+		EndTime:   end,
+	}.Snapshot()
+
+	orphanSpan := tracetest.SpanStub{
+		Name: "orphan",
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  orphanID,
+		}),
+		// Parent SpanID points to a span we deliberately omit from the
+		// slice — this is what triggers the <detached> branch.
+		Parent: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  missingParentID,
+		}),
+		StartTime: start.Add(100 * time.Millisecond),
+		EndTime:   end.Add(-100 * time.Millisecond),
+	}.Snapshot()
+
+	tree := buildTree([]sdktrace.ReadOnlySpan{rootSpan, orphanSpan}, rootID)
+
+	require.NotNil(t, tree)
+	require.Len(t, tree.Children, 1, "orphan must surface as a child")
+	detached := tree.Children[0]
+	assert.Equal(t, "<detached>", detached.Name)
+	assert.True(t, detached.Detached)
+	require.Len(t, detached.Children, 1, "orphan span must be under <detached>")
+	assert.Equal(t, "orphan", detached.Children[0].Name)
+	assert.True(t, detached.Children[0].Detached, "orphan node should be flagged Detached")
+}
+
+func randomTraceID(t *testing.T) trace.TraceID {
+	t.Helper()
+	var b [16]byte
+	_, err := cryptorand.Read(b[:])
+	require.NoError(t, err)
+	return b
+}
+
+func randomSpanID(t *testing.T) trace.SpanID {
+	t.Helper()
+	var b [8]byte
+	_, err := cryptorand.Read(b[:])
+	require.NoError(t, err)
+	return b
 }
 
 // --- E. Error status surfaces on Node ---
@@ -194,6 +240,71 @@ func TestProcessor_IndependentTraces(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	require.Len(t, trees, 2)
+}
+
+// --- H. Late child spans are dropped without reintroducing pending state ---
+
+// TestProcessor_LateChildDoesNotRequeue verifies the short-lived emitted
+// tombstone still suppresses child spans that end after the root emitted.
+// Failure prevented: late child spans recreating a pending entry that can
+// never be flushed because the root is already gone.
+func TestProcessor_LateChildDoesNotRequeue(t *testing.T) {
+	p := NewTreeProcessor(Options{})
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(p),
+	)
+	otel.SetTracerProvider(tp)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	ctx, root := tr.Start(context.Background(), "root", trace.WithNewRoot())
+	_, child := tr.Start(ctx, "child")
+	tid := root.SpanContext().TraceID()
+
+	root.End()
+	child.End()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	assert.Empty(t, p.pending)
+	_, ok := p.emitted[tid]
+	assert.True(t, ok, "completed trace should retain a short-lived tombstone")
+}
+
+// --- I. Expired tombstones are pruned on the next completed trace ---
+
+// TestProcessor_PrunesExpiredEmitted verifies completed trace tombstones do
+// not accumulate forever in long-lived processes like the daemon.
+// Failure prevented: one TraceID leaked per completed background task.
+func TestProcessor_PrunesExpiredEmitted(t *testing.T) {
+	p := NewTreeProcessor(Options{})
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithSpanProcessor(p),
+	)
+	otel.SetTracerProvider(tp)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	tr := tp.Tracer("test")
+
+	_, oldRoot := tr.Start(context.Background(), "old", trace.WithNewRoot())
+	oldTID := oldRoot.SpanContext().TraceID()
+	oldRoot.End()
+
+	p.mu.Lock()
+	p.emitted[oldTID] = time.Now().Add(-time.Second)
+	p.mu.Unlock()
+
+	_, newRoot := tr.Start(context.Background(), "new", trace.WithNewRoot())
+	newTID := newRoot.SpanContext().TraceID()
+	newRoot.End()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, oldExists := p.emitted[oldTID]
+	_, newExists := p.emitted[newTID]
+	assert.False(t, oldExists, "expired tombstone should be pruned on the next root span")
+	assert.True(t, newExists, "current root should still install its tombstone")
 }
 
 // setupTP builds a TracerProvider with our processor + an in-memory

--- a/internal/perf/render.go
+++ b/internal/perf/render.go
@@ -1,0 +1,134 @@
+package perf
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/sageox/ox/internal/ui"
+)
+
+// RenderTree writes the node tree to w using dotted-leader alignment so
+// durations line up in a single column.
+//
+//	pre-push total ........................ 4.2s
+//	├─ resolve_push_settings ............. 0.1s
+//	├─ git_push .......................... 1.9s
+//	└─ cleanup ........................... 0.1s
+//
+// The dot column width is computed once over the whole tree so deeply
+// nested children stay aligned with shallow ones.
+func RenderTree(w io.Writer, root *Node) {
+	if root == nil {
+		return
+	}
+	lines := flattenForRender(root, "", true, true)
+	maxLabel := 0
+	for _, ln := range lines {
+		if w := displayWidth(ln.label); w > maxLabel {
+			maxLabel = w
+		}
+	}
+	dotCol := maxLabel + 4 // breathing room before the duration column
+	for _, ln := range lines {
+		writeLine(w, ln, dotCol)
+	}
+}
+
+type renderLine struct {
+	label    string // prefix + name (visible text only, no color)
+	duration time.Duration
+	failed   bool
+}
+
+func flattenForRender(n *Node, prefix string, isLast, isRoot bool) []renderLine {
+	if n == nil {
+		return nil
+	}
+	var label string
+	switch {
+	case isRoot:
+		label = n.Name
+	case isLast:
+		label = prefix + ui.TreeLast + n.Name
+	default:
+		label = prefix + ui.TreeBranch + n.Name
+	}
+	out := []renderLine{{
+		label:    label,
+		duration: n.Duration,
+		failed:   n.Status.Code == codes.Error,
+	}}
+	// child prefix carries vertical bars for non-last ancestors.
+	var childPrefix string
+	if !isRoot {
+		if isLast {
+			childPrefix = prefix + ui.TreeIndent
+		} else {
+			childPrefix = prefix + ui.TreeVertical
+		}
+	}
+	for i, c := range n.Children {
+		out = append(out, flattenForRender(c, childPrefix, i == len(n.Children)-1, false)...)
+	}
+	return out
+}
+
+func writeLine(w io.Writer, ln renderLine, dotCol int) {
+	gap := dotCol - displayWidth(ln.label)
+	if gap < 2 {
+		gap = 2
+	}
+	// leading + trailing space around the dots: " ......... " reads
+	// cleaner than abutting them to the label/duration.
+	dots := strings.Repeat(".", gap-2)
+	dur := formatDuration(ln.duration)
+	statusMark := ""
+	if ln.failed {
+		statusMark = " " + ui.FailStyle.Render(ui.IconFail)
+	}
+	dotsStyled := ui.MutedStyle.Render(" " + dots + " ")
+	fmt.Fprintf(w, "%s%s%s%s\n", ln.label, dotsStyled, dur, statusMark)
+}
+
+// displayWidth returns the visible column count for s. Tree glyphs are
+// single-width; ASCII is single-width; we don't render colored prefixes
+// in label so no ANSI stripping is needed.
+func displayWidth(s string) int {
+	// internal/ui tree constants are UTF-8 multi-byte glyphs (├, │, └, ─)
+	// but render as single columns. Count runes, not bytes.
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}
+
+// formatDuration renders d in a compact, human-readable form suitable for
+// a single column. Examples:
+//
+//	850µs   < 1ms (rare; only when forced)
+//	42ms    1ms ≤ d < 1s
+//	1.9s    1s  ≤ d < 60s
+//	1m 12s  60s ≤ d
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Millisecond:
+		return fmt.Sprintf("%dµs", d.Microseconds())
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		s := float64(d) / float64(time.Second)
+		return fmt.Sprintf("%.1fs", s)
+	default:
+		m := int(d / time.Minute)
+		s := int((d - time.Duration(m)*time.Minute) / time.Second)
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+}

--- a/internal/perf/render_test.go
+++ b/internal/perf/render_test.go
@@ -1,0 +1,105 @@
+package perf
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// --- A. Duration formatting matrix ---
+
+// TestFormatDuration verifies each bucket of formatDuration produces the
+// expected compact form. The rendered tree relies on these widths
+// staying short so column alignment doesn't blow up.
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{500 * time.Microsecond, "500µs"},
+		{42 * time.Millisecond, "42ms"},
+		{1900 * time.Millisecond, "1.9s"},
+		{4*time.Second + 200*time.Millisecond, "4.2s"},
+		{75 * time.Second, "1m 15s"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, formatDuration(c.in), "in=%s", c.in)
+	}
+}
+
+// --- B. Tree rendering matches the user-facing example ---
+
+// TestRenderTree_MatchesExample verifies the rendered output reproduces
+// the pre-push tree shape that motivated this work: root + three
+// children with aligned dot leaders and right-justified durations.
+// Failure prevented: visual regression on the headline UX.
+func TestRenderTree_MatchesExample(t *testing.T) {
+	t.Setenv("NO_COLOR", "1") // strip ANSI so we can assert on raw bytes
+	root := &Node{
+		Name:     "pre-push total",
+		Duration: 4*time.Second + 200*time.Millisecond,
+		Children: []*Node{
+			{Name: "resolve_push_settings", Duration: 100 * time.Millisecond},
+			{Name: "git_push", Duration: 1900 * time.Millisecond},
+			{Name: "cleanup", Duration: 100 * time.Millisecond},
+		},
+	}
+	var b bytes.Buffer
+	RenderTree(&b, root)
+	out := b.String()
+
+	// Each child label appears, with its duration on the same line.
+	for _, line := range []string{
+		"pre-push total",
+		"├─ resolve_push_settings",
+		"├─ git_push",
+		"└─ cleanup",
+	} {
+		assert.Contains(t, out, line)
+	}
+	assert.Contains(t, out, "4.2s")
+	assert.Contains(t, out, "1.9s")
+}
+
+// --- C. Failed spans flagged in render ---
+
+// TestRenderTree_FailedSpanFlagged verifies error status produces a
+// visible marker so the user can find which phase failed without
+// inspecting every duration.
+func TestRenderTree_FailedSpanFlagged(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	root := &Node{
+		Name: "root",
+		Children: []*Node{
+			{Name: "ok_child", Duration: time.Millisecond},
+			{Name: "bad_child", Duration: time.Millisecond, Status: sdktrace.Status{Code: codes.Error}},
+		},
+	}
+	var b bytes.Buffer
+	RenderTree(&b, root)
+	out := b.String()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	// last child renders with TreeLast; should also have the failure mark.
+	assert.Contains(t, lines[len(lines)-1], "bad_child")
+	assert.Contains(t, lines[len(lines)-1], "✖")
+}
+
+// --- D. Nil root is a no-op ---
+
+// TestRenderTree_NilRoot verifies the renderer does not panic on nil
+// (e.g. when an empty trace somehow reaches the sink).
+func TestRenderTree_NilRoot(t *testing.T) {
+	var b bytes.Buffer
+	RenderTree(&b, nil)
+	assert.Empty(t, b.String())
+}
+
+// NO_COLOR rendering is verified by manual run (`NO_COLOR=1 ox doctor`)
+// per .claude/rules/design.md. lipgloss reads NO_COLOR at term-profile
+// detection time before t.Setenv can affect it, so a unit assertion is
+// not feasible from inside the same process.

--- a/internal/perf/sink.go
+++ b/internal/perf/sink.go
@@ -1,0 +1,138 @@
+package perf
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// SlowThreshold is the root-trace duration at or above which the tree
+// is rendered to stderr even when OX_TRACE is unset. Tuned for "user
+// notices ox felt slow."
+const SlowThreshold = 3 * time.Second
+
+// PerSpanSlogThreshold is the per-span duration at or above which a
+// single-line slog record is emitted for that span when OX_TRACE is
+// unset. Below this, only OX_TRACE=1 forces emission.
+const PerSpanSlogThreshold = 100 * time.Millisecond
+
+// TraceEnabled returns true if OX_TRACE is set to a truthy value. Used
+// by sinks to gate full-detail rendering and per-span slog emission.
+func TraceEnabled() bool {
+	v := os.Getenv("OX_TRACE")
+	if v == "" {
+		return false
+	}
+	switch strings.ToLower(v) {
+	case "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
+
+// CLITreeSink renders the root tree to w when:
+//
+//   - OX_TRACE is truthy, OR
+//   - verbose is true (-v / --verbose), OR
+//   - the root trace took at least SlowThreshold (auto-surface).
+//
+// In the auto-surface case, a footer hint about OX_TRACE is appended so
+// users discover the env var the next time they want detail.
+//
+// w is typically os.Stderr; pass a buffer in tests.
+func CLITreeSink(w io.Writer, verbose bool) TreeSink {
+	trace := TraceEnabled()
+	return func(root *Node) {
+		if root == nil {
+			return
+		}
+		explicit := trace || verbose
+		autoSurface := !explicit && root.Duration >= SlowThreshold
+		if !explicit && !autoSurface {
+			return
+		}
+		RenderTree(w, root)
+		if autoSurface {
+			// Keep the footer ASCII-only so it renders correctly under
+			// NO_COLOR and on Windows consoles.
+			_, _ = io.WriteString(w, "(set OX_TRACE=1 to log per-phase timing)\n")
+		}
+	}
+}
+
+// DaemonTreeSink renders the root tree to the daemon logger at debug
+// level. Tree blocks land in the daemon log only when the operator
+// opts in via OX_TRACE=1 (env var inherited by the daemon child
+// process) — otherwise per-span slog records (from PerSpanSlog below)
+// are sufficient for grep + jq workflows without inflating the log.
+func DaemonTreeSink(logger *slog.Logger) TreeSink {
+	return func(root *Node) {
+		if root == nil || logger == nil {
+			return
+		}
+		if !TraceEnabled() {
+			return
+		}
+		var b strings.Builder
+		RenderTree(&b, root)
+		logger.Debug("trace_tree", "root", root.Name, "duration_ms", root.Duration.Milliseconds(), "tree", b.String())
+	}
+}
+
+// PerSpanSlog returns a SpanSink that emits one slog record per closed
+// span when either:
+//
+//   - OX_TRACE is truthy, OR
+//   - the span's duration meets PerSpanSlogThreshold.
+//
+// Without this gate a 5-second daemon sync loop would produce thousands
+// of info-level lines per hour from no-op pull dedup spans, which would
+// dominate `ox daemon logs` and worsen disk pressure.
+//
+// The emitted record is single-line key=value (project convention) so
+// it stays greppable and aggregator-friendly.
+func PerSpanSlog(logger *slog.Logger) SpanSink {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return func(s sdktrace.ReadOnlySpan) {
+		if s == nil {
+			return
+		}
+		dur := s.EndTime().Sub(s.StartTime())
+		if !TraceEnabled() && dur < PerSpanSlogThreshold {
+			return
+		}
+		parent := ""
+		if pid := s.Parent().SpanID(); pid.IsValid() {
+			parent = pid.String()
+		}
+		logger.Info("perf_span",
+			"name", s.Name(),
+			"duration_ms", dur.Milliseconds(),
+			"trace_id", s.SpanContext().TraceID().String(),
+			"span_id", s.SpanContext().SpanID().String(),
+			"parent", parent,
+		)
+	}
+}
+
+// NoopSpanSink returns a span sink that does nothing. Useful in tests
+// or when only tree-level emission is desired.
+func NoopSpanSink() SpanSink { return func(_ sdktrace.ReadOnlySpan) {} }
+
+// NoopTreeSink returns a tree sink that does nothing. Useful in tests
+// or when only per-span emission is desired.
+func NoopTreeSink() TreeSink { return func(_ *Node) {} }
+
+// Ensure the Shutdown signature matches the SDK so build-time changes
+// to the SpanProcessor interface fail fast.
+var _ sdktrace.SpanProcessor = (*TreeCollectorProcessor)(nil)
+
+// Ensure context-keyed lookups in callers compile even when ctx is nil.
+var _ = func() context.Context { return context.Background() }

--- a/internal/perf/start.go
+++ b/internal/perf/start.go
@@ -1,0 +1,48 @@
+package perf
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// tracerName is the instrumentation library name used for spans created
+// via perf.Start. Kept separate from the application service name so
+// trace-backend dashboards can filter perf-instrumented spans without
+// inspecting every service.
+const tracerName = "github.com/sageox/ox/internal/perf"
+
+// Start creates a child span under the active span in ctx. The returned
+// context carries the new span; the returned trace.Span has the usual
+// OTel API (.End, .SetAttributes, .RecordError, .SetStatus).
+//
+// Use perf.Start instead of observability.Tracer().Start so that:
+//
+//  1. Callers don't have to import both observability and otel/trace.
+//  2. Failed spans can be marked via perf.RecordError without callers
+//     pulling in the codes package.
+//
+// Safe to call when tracing is disabled: returns a no-op span whose End
+// is a cheap no-op.
+func Start(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	t := otel.GetTracerProvider().Tracer(tracerName)
+	var opts []trace.SpanStartOption
+	if len(attrs) > 0 {
+		opts = append(opts, trace.WithAttributes(attrs...))
+	}
+	return t.Start(ctx, name, opts...)
+}
+
+// RecordError marks span as failed and attaches err. Convenience over
+// repeating two OTel calls at every error site. No-op when err is nil
+// or span is nil.
+func RecordError(span trace.Span, err error) {
+	if span == nil || err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -80,9 +80,11 @@ const (
 
 // Tree characters for hierarchical display
 const (
-	TreeChild  = "⎿ "  // child indicator
-	TreeLast   = "└─ " // last child / detail line
-	TreeIndent = "  "  // 2-space indent per level
+	TreeChild    = "⎿ "  // child indicator
+	TreeLast     = "└─ " // last child / detail line
+	TreeBranch   = "├─ " // non-last sibling
+	TreeVertical = "│  " // vertical bar carried by non-last ancestors
+	TreeIndent   = "  "  // 2-space indent per level
 )
 
 // Separators


### PR DESCRIPTION
## What broke

Users report "ox is slow" without being able to point at which phase. `ox doctor` and the daemon sync loop both run many sequential ops (ledger fetch/push, team-context sync, session upload, redaction, conflict resolve). Today timing is either absent or buried at debug level. We end up asking users to run commands manually to isolate the slow phase.

## What this PR ships

A lightweight tracing surface that sits **on top of the existing OpenTelemetry pipeline** — same spans flow to Honeycomb; a new in-process collector renders them as a dotted-leader tree to the user's terminal on demand.

- **`internal/perf` (new package, ~250 LOC).** `TreeCollectorProcessor` implements `sdktrace.SpanProcessor` and buffers per-trace spans; on root-span end it builds a `Node` tree and hands it to a sink. `perf.Start(ctx, name)` is a thin sugar wrapper that matches OTel's `(ctx, span)` API so callers don't need to import both `observability` and `otel/trace`.
- **No duplicate instrumentation.** Spans are real OTel spans — the OTLP batcher and the local tree collector see the same `ReadOnlySpan`s. The collector respects `IsSampled()` so future sampling doesn't render empty trees.
- **Auto-surface on slow ops.** If the root span runs ≥ 3s, the tree renders unconditionally with a footer hint about `OX_TRACE=1`. Solves the discoverability gap — a user who never passes a flag still gets the diagnostic.
- **No new `--trace` flag.** `OX_TRACE=1` env var (operator drop-in) + existing `--verbose` cover the explicit cases. New persistent flags are forever-API commitments; this is a debug knob.
- **Per-span slog gated** at 100ms (or `OX_TRACE=1`). Without the gate the daemon would emit thousands of info-level lines per hour from sub-millisecond pull-dedup spans.

## Instrumentation sites — CLI surface

```mermaid
flowchart TD
    CMD["ox command"] --> ROOT["perf.Start root"]
    ROOT --> DOC["doctor (14 categories)"]
    ROOT --> PP["pre-push total"]
    PP --> RPS["resolve_push_settings"]
    PP --> GATE["secret_gate"]
    GATE --> SCAN["secret_scan"]
    PP --> GP["git_push"]
```

## Instrumentation sites — daemon surface

```mermaid
flowchart TD
    PC["daemon pull_cycle"] --> DP["do_pull"]
    DP --> PMR["pull_managed_repo"]
    PMR --> FETCH["git_fetch"]
    PMR --> REBASE["git_pull_rebase"]
    TC["daemon team_pull_cycle"] --> DTS["do_team_sync"]
    PM["daemon push_murmurs"]
```

## Sample output

`OX_TRACE=1 ox doctor` on a 1.1s healthy run:

```
ox doctor .......................... 1.1s ✖
└─ doctor .......................... 1.0s
  ├─ doctor:Authentication ......... 49ms
  ├─ doctor:Project Structure ...... 60ms
  ├─ doctor:Integration ............ 130ms
  ├─ doctor:Git Repository Health .. 183ms
  ...
  └─ doctor:SageOx Service ......... 127ms
```

`ox doctor` on a slow run (no flag, no env — auto-surfaces because total ≥ 3s):

```
Error: daemon required for session finalization: daemon started but not responding
ox doctor .. 4.1s ✖
(set OX_TRACE=1 to log per-phase timing)
```

`--verbose` run where the daemon check ate the budget:

```
ox doctor .......................... 5.9s ✖
└─ doctor .......................... 5.9s
  ...
  ├─ doctor:Daemon ................. 4.0s   <- culprit visible in one glance
  ...
```

## Decision flow for rendering

```mermaid
flowchart LR
    A["root span ends"] --> B{"OX_TRACE truthy"}
    B -- yes --> R["render tree"]
    B -- no --> C{"verbose flag set"}
    C -- yes --> R
    C -- no --> D{"duration at or above 3s"}
    D -- yes --> RR["render tree plus footer hint"]
    D -- no --> X["emit nothing"]
```

## Architectural notes

- **Why a `SpanProcessor`, not a parallel recorder.** Two senior reviewers (Go/OTel expert + principal eng) both pushed back on the original `Recorder` design. OTel's `OnEnd(ReadOnlySpan)` gives us correct parent/child via `Parent().SpanID()`, correct timing, attributes, status, and goroutine-safe semantics. Building a parallel mutable stack would have duplicated all of that with a race window for concurrent siblings (which daemon team-context syncs hit via `sync.WaitGroup`).
- **`cmd.SetContext()` propagation.** `internal/cli/context.go` now propagates the traced context onto the cobra command, so `cmd.Context()` callers inherit the OTel root span. Without this, `perf.Start(cmd.Context(), ...)` would create a new root and the tree would fragment mid-output.
- **Orphan handling.** If a span's parent ended (and emitted its tree) before the child's `OnEnd` fires, the child is dropped quietly via a short-lived emitted-tombstone (2 min retention, pruned opportunistically). If a span's parent is simply missing from the in-flight set, we render it under a synthetic `<detached>` node so the timing isn't silently lost.
- **Tree glyphs added to `internal/ui/styles.go`** (`TreeBranch`, `TreeVertical`) so all tree-rendering call sites share one source of truth per `.claude/rules/design.md`.

## Test Plan

- `internal/perf/processor_test.go` — table-driven: nested, parallel siblings (5 goroutines under `sync.WaitGroup`), independent traces, error status, per-span sink fires for every closed span, late-child tombstone, expired-tombstone pruning. Uses real `sdktrace.TracerProvider` via `setupTP`, not mocks.
- `internal/perf/render_test.go` — duration matrix (µs/ms/s/m), example tree shape matches user-facing UX, failed-span flag visible, nil-root no-op.
- `make lint` clean.
- `make test` — 14,932 pass, 1,007 skipped (fast tier).
- Manual smoke: 7 scenarios (plain / OX_TRACE=1 / --verbose / slow-auto / --json / OX_TRACE=0 / trivial cmd) all produce expected output.

## Follow-ups (filed)

- **ox-lubu** — `daemon.log` rotation. Current state appends forever via `O_APPEND`; volume is bounded by the 100ms slog gate + `OX_TRACE`-only tree emission, but rotation should be its own scoped change with a `ox doctor` size warning.

## Future instrumentation candidates (next PRs)

Reviewed the codebase for other "why is this slow" surfaces. Ranked by user-perceived value:

**Foreground (user-blocking) — high value:**
- `ox query` (`cmd/ox/query.go:50`) — embedding + backend search latency
- `ox kb hydrate` (`cmd/ox/kb_hydrate.go:150`) — LFS Batch API downloads
- `ox import <video>` (`cmd/ox/import.go`) — multipart upload + status poll loop
- `ox agent prime` (`cmd/ox/agent_prime.go:2147`) — KB resolve + team-context load
- `ox distill` (`cmd/ox/distill.go:983`) — LLM synthesis calls (daily/weekly/monthly)
- `ox code search` — codedb SQLite + Bleve query
- `ox session stop` — LLM summary + LFS upload (partial coverage already)

**Daemon background — medium value:**
- `checkCodeDBFreshness` rebuild path (`internal/daemon/sync.go:1076`)
- `checkAndRunGC` blue-green reclone (`internal/daemon/sync.go:943`)
- `github_sync.CheckAndSync` (PR/issue fetch + LFS upload)
- Workspace registry load on daemon startup

**Adapter binaries** (`ox-adapter-claude`, `ox-adapter-gemini`, `ox-adapter-codex`, ...) — separate question, answered below.

## Adapter perf measurement (`ox-adapter-*`)

Adapters today are NOT instrumented. They are isolated stdio binaries spawned by the daemon's `AdapterSupervisor` (`internal/daemon/adapter_supervisor.go`) and communicate via NDJSON over stdin/stdout per the protocol in `pkg/adapterprotocol/` + `pkg/adapterruntime/`. Slow ops inside them — session discovery (NFS stat with 500ms timeout), large-JSONL parses, `ReadFromOffset` scans, tail watch loops — are invisible to `OX_TRACE=1`.

Two paths to surface adapter timing in the same tree:

```mermaid
flowchart TD
    AD["ox-adapter-claude"] --> SE["emit span_event JSON on stdout"]
    SE --> SUP["AdapterSupervisor reads NDJSON"]
    SUP --> SYNTH["daemon creates synthetic OTel child span"]
    SYNTH --> PROC["TreeCollectorProcessor"]
    PROC --> TREE["unified tree under daemon root span"]
```

- **Option A (recommended):** adapters emit `{"type":"span_event","op":"find_session","duration_ms":50,"status":"ok"}` lines on stdout alongside protocol responses. `AdapterSupervisor` translates each event into a child span on the active daemon trace via `perf.Start` + immediate `End`. No OTel SDK in the adapter binary — it stays tiny.
- **Option B (simpler):** adapter responses carry a `"timings": [...]` field; the supervisor unpacks it into child spans of whatever supervisor-side span called the adapter. Less granular but zero protocol changes.

Both surface into the existing `TreeCollectorProcessor` so `OX_TRACE=1` shows adapter phases nested under their daemon caller. **Not in this PR** — adapter protocol change deserves its own scoped PR. Will file a beads issue.

## Non-goals

- Replacing OTel. We sit on top; the OTLP exporter is unchanged.
- Per-check (vs per-category) spans inside `runDoctorChecks`. The categories are manually constructed inline rather than dispatched through a single loop, so per-check timing would require a larger refactor for marginal value.
- Streaming / live tree updates. Render is at root-end only.
- Adapter instrumentation. Tracked separately (see above).

---

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enable detailed performance tracing with `OX_TRACE` environment variable to view operation timing hierarchies
  * Automatic timing display for operations exceeding 3-second threshold with hints for enabling full tracing
  * Enhanced observability for daemon operations, including sync cycles and secret scanning

* **Refactor**
  * Improved internal tracing infrastructure integration

* **Tests**
  * Added comprehensive performance tracing tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->