### PR TITLE
feat(gitutil,codedb,doctor): shallow + partial + alternates clone support

### DIFF
--- a/cmd/ox/agent_doctor.go
+++ b/cmd/ox/agent_doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sageox/ox/internal/agentinstance"
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/doctor"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/session"
 )
 
@@ -282,13 +283,19 @@ func checkLedgerGitStatus(ledgerPath string) (staged int, commitNeeded bool, pus
 		pushNeeded = true
 	}
 
-	// also check if we have local commits not pushed
+	// also check if we have local commits not pushed.
+	// Skip on shallow clones: rev-list --count truncates at the shallow
+	// boundary and may either over- or under-count. We rely on the
+	// "[ahead" porcelain check above, which uses upstream-tracking info
+	// that's accurate even when local history is truncated.
 	if !pushNeeded {
-		revOutput, err := runAgentDoctorGitCommand(ledgerPath, "rev-list", "--count", "@{upstream}..HEAD")
-		if err == nil {
-			count := strings.TrimSpace(revOutput)
-			if count != "0" && count != "" {
-				pushNeeded = true
+		if state, _ := gitutil.InspectRepo(ledgerPath); !state.Shallow {
+			revOutput, err := runAgentDoctorGitCommand(ledgerPath, "rev-list", "--count", "@{upstream}..HEAD")
+			if err == nil {
+				count := strings.TrimSpace(revOutput)
+				if count != "0" && count != "" {
+					pushNeeded = true
+				}
 			}
 		}
 	}

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -220,6 +220,24 @@ func init() {
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugRepoCompleteness,
+		Name:        "Repo completeness",
+		Category:    "Git Repository Health",
+		FixLevel:    FixLevelCheckOnly,
+		Description: "Detects shallow and partial clones; ox subsystems that walk history (divergence, ancestry, codedb blob reads) need full history to be accurate",
+		Run:         checkRepoCompleteness,
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugGitAlternates,
+		Name:        "Git alternates",
+		Category:    "Git Repository Health",
+		FixLevel:    FixLevelCheckOnly,
+		Description: "Detects .git/objects/info/alternates configuration. Native git handles alternates, but codedb's go-git-based indexer does not — see ox-5b5p.",
+		Run:         checkGitAlternates,
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
 		Slug:        CheckSlugGitRepoPaths,
 		Name:        "Git repo paths",
 		Category:    "Git Repository Health",

--- a/cmd/ox/doctor_repo_completeness.go
+++ b/cmd/ox/doctor_repo_completeness.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -102,7 +103,7 @@ func checkGitAlternates(_ bool) checkResult {
 	altsPath := filepath.Join(commonDir, "objects", "info", "alternates")
 	data, err := os.ReadFile(altsPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return PassedCheck("Git alternates", "no alternates configured")
 		}
 		return WarningCheck("Git alternates", "read failed", err.Error())

--- a/cmd/ox/doctor_repo_completeness.go
+++ b/cmd/ox/doctor_repo_completeness.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/gitutil"
+)
+
+// checkRepoCompleteness reports whether the working repo is shallow,
+// partial, or both — clone modes that silently break ox subsystems:
+//
+//   - Shallow clones (CI default for actions/checkout) truncate the
+//     commit graph. rev-list / merge-base produce wrong answers; ox
+//     status displays "—" instead of misleading divergence numbers
+//     after Step 1, but the underlying cause should be surfaced here.
+//   - Partial clones (--filter=blob:none, common on 2026 CI providers
+//     like Buildkite, Depot, Blacksmith, Namespace) keep the commit
+//     graph but fault into the network on blob/tree reads. Codedb's
+//     IndexLocalRepo walks blobs and will trigger lazy fetch.
+//
+// Policy: warn-only in CI / non-TTY (auto-unshallow is bandwidth-hostile
+// and may break the CI checkout); in interactive TTY, surface the same
+// finding so the user can re-clone or `git fetch --unshallow` themselves.
+// We deliberately do NOT auto-fix — both shallow and partial are often
+// intentional and the cost of an unsolicited unshallow is high.
+func checkRepoCompleteness(_ bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Repo completeness", "not in git repo", "")
+	}
+
+	state, err := gitutil.InspectRepo(gitRoot)
+	if err != nil {
+		return WarningCheck("Repo completeness", "detection failed", err.Error())
+	}
+	if !state.Incomplete() {
+		return PassedCheck("Repo completeness", "full history available")
+	}
+
+	var remediation []string
+	if state.Shallow {
+		remediation = append(remediation,
+			"shallow clone — divergence/ancestry checks return undefined",
+			"  remediation (caller's choice): git fetch --unshallow")
+	}
+	if state.Partial {
+		remediation = append(remediation,
+			"partial clone — blob/tree reads may fault into network",
+			"  remediation (caller's choice): git clone without --filter, or",
+			"  `git config --unset-all remote.origin.promisor && git fetch --refetch`")
+	}
+
+	envHint := ""
+	if isCIEnvironment() || !cli.IsInteractive() {
+		envHint = " (CI/non-TTY: informational only)"
+	}
+
+	return WarningCheck("Repo completeness",
+		state.Reason+envHint,
+		strings.Join(remediation, "\n"))
+}
+
+// isCIEnvironment reports whether the process is running under a known CI
+// runner. Used to pick warn-only output instead of an interactive fix.
+// Conservative: only matches signals that are unambiguously CI.
+func isCIEnvironment() bool {
+	for _, k := range []string{"CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "CIRCLECI"} {
+		if v := os.Getenv(k); v == "true" || v == "1" {
+			return true
+		}
+	}
+	return false
+}
+
+// checkGitAlternates verifies that any `.git/objects/info/alternates`
+// entries resolve to readable object stores, and surfaces the situation
+// to the user. Native git CLI handles alternates correctly, but go-git v6
+// — used by codedb's IndexLocalRepo — silently fails on alternates (both
+// relative and absolute paths). See
+// TestPlainOpenTolerant_AlternatesUpstreamLimitation.
+//
+// The check is informational: ox does not auto-rewrite alternates. The
+// remediation surfaces `git repack -a -d --local` (the standard
+// "dissociate" pattern, which copies alternated objects into the local
+// store), or re-clone without --shared/--reference.
+func checkGitAlternates(_ bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck("Git alternates", "not in git repo", "")
+	}
+
+	commonDir, err := commonGitDir(gitRoot)
+	if err != nil {
+		return WarningCheck("Git alternates", "rev-parse failed", err.Error())
+	}
+
+	altsPath := filepath.Join(commonDir, "objects", "info", "alternates")
+	data, err := os.ReadFile(altsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PassedCheck("Git alternates", "no alternates configured")
+		}
+		return WarningCheck("Git alternates", "read failed", err.Error())
+	}
+
+	var entries, unreachable []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entries = append(entries, line)
+
+		resolved := line
+		if !filepath.IsAbs(resolved) {
+			resolved = filepath.Join(commonDir, "objects", line)
+		}
+		if _, statErr := os.Stat(resolved); statErr != nil {
+			unreachable = append(unreachable, fmt.Sprintf("%s → %s (%v)", line, resolved, statErr))
+		}
+	}
+
+	if len(entries) == 0 {
+		return PassedCheck("Git alternates", "alternates file empty")
+	}
+
+	detail := strings.Builder{}
+	fmt.Fprintf(&detail, "%d alternates entry(ies) configured. Native git handles this correctly, but go-git (used by codedb indexing) does NOT honor alternates and will fail object lookups.\n", len(entries))
+	for _, e := range entries {
+		detail.WriteString("  ")
+		detail.WriteString(e)
+		detail.WriteString("\n")
+	}
+	detail.WriteString("\nRemediation options:\n")
+	detail.WriteString("  • Dissociate (copy objects into this repo, keep clone): git repack -a -d --local\n")
+	detail.WriteString("  • Re-clone without --shared / --reference\n")
+	detail.WriteString("  • Affected ox subsystems: codedb indexing (internal/codedb/index/IndexLocalRepo).")
+
+	if len(unreachable) > 0 {
+		return FailedCheck("Git alternates",
+			fmt.Sprintf("%d unreachable alternate(s)", len(unreachable)),
+			detail.String()+"\n\nUnreachable:\n  "+strings.Join(unreachable, "\n  "))
+	}
+	return WarningCheck("Git alternates",
+		fmt.Sprintf("%d alternate(s) configured", len(entries)),
+		detail.String())
+}
+
+// commonGitDir returns the resolved common git dir for repoPath using
+// `git rev-parse --git-common-dir`. Worktree-safe — a linked worktree
+// returns the main repo's git dir, where shallow + alternates live.
+func commonGitDir(repoPath string) (string, error) {
+	out, err := gitutil.RunGit(context.Background(), repoPath, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return "", err
+	}
+	out = strings.TrimSpace(out)
+	if !filepath.IsAbs(out) {
+		return filepath.Join(repoPath, out), nil
+	}
+	return out, nil
+}

--- a/cmd/ox/doctor_repo_completeness_test.go
+++ b/cmd/ox/doctor_repo_completeness_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scaffoldRepoForDoctor creates a temp git repo and chdir's into it so
+// findGitRoot() resolves. Returns the root path.
+func scaffoldRepoForDoctor(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	root = resolved
+
+	gi := exec.Command("git", "init", "-q", "-b", "main")
+	gi.Dir = root
+	require.NoError(t, gi.Run())
+	// Identity for commits.
+	for _, kv := range [][]string{{"user.name", "test"}, {"user.email", "test@sageox.ai"}} {
+		c := exec.Command("git", "config", kv[0], kv[1])
+		c.Dir = root
+		require.NoError(t, c.Run())
+	}
+
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(root))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	return root
+}
+
+func commitFileRepoCompleteness(t *testing.T, dir, name, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	c1 := exec.Command("git", "add", name)
+	c1.Dir = dir
+	require.NoError(t, c1.Run())
+	c2 := exec.Command("git", "commit", "-q", "-m", "add "+name)
+	c2.Dir = dir
+	c2.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+	out, err := c2.CombinedOutput()
+	require.NoError(t, err, "git commit: %s", out)
+}
+
+func TestCheckRepoCompleteness_NormalRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	root := scaffoldRepoForDoctor(t)
+	commitFileRepoCompleteness(t, root, "f1.txt", "v1")
+
+	res := checkRepoCompleteness(false)
+	assert.True(t, res.passed, "normal repo: %+v", res)
+}
+
+func TestCheckRepoCompleteness_Shallow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	// Build a source with multiple commits, then clone shallow.
+	src := t.TempDir()
+	gi := exec.Command("git", "init", "-q", "-b", "main")
+	gi.Dir = src
+	require.NoError(t, gi.Run())
+	for i := 0; i < 3; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(src, "f"+string(rune('a'+i))+".txt"), []byte("v"), 0o644))
+		add := exec.Command("git", "add", ".")
+		add.Dir = src
+		require.NoError(t, add.Run())
+		ci := exec.Command("git", "commit", "-q", "-m", "c")
+		ci.Dir = src
+		ci.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		require.NoError(t, ci.Run())
+	}
+
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "shallow")
+	clone := exec.Command("git", "clone", "-q", "--depth", "1", "--no-local", "file://"+src, dst)
+	out, err := clone.CombinedOutput()
+	require.NoError(t, err, "%s", out)
+
+	resolved, err := filepath.EvalSymlinks(dst)
+	require.NoError(t, err)
+	prev, _ := os.Getwd()
+	require.NoError(t, os.Chdir(resolved))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	res := checkRepoCompleteness(false)
+	assert.True(t, res.warning, "shallow clone should warn, got %+v", res)
+	assert.Contains(t, res.message, "shallow")
+}
+
+func TestCheckRepoCompleteness_NotARepo(t *testing.T) {
+	dir := t.TempDir()
+	prev, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	res := checkRepoCompleteness(false)
+	assert.True(t, res.skipped, "non-repo should skip, got %+v", res)
+}
+
+func TestCheckGitAlternates_NoAlternates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	root := scaffoldRepoForDoctor(t)
+	commitFileRepoCompleteness(t, root, "f1.txt", "v1")
+
+	res := checkGitAlternates(false)
+	assert.True(t, res.passed, "%+v", res)
+}
+
+func TestCheckGitAlternates_WithSharedClone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	src := t.TempDir()
+	gi := exec.Command("git", "init", "-q", "-b", "main")
+	gi.Dir = src
+	require.NoError(t, gi.Run())
+	require.NoError(t, os.WriteFile(filepath.Join(src, "f.txt"), []byte("v"), 0o644))
+	add := exec.Command("git", "add", ".")
+	add.Dir = src
+	require.NoError(t, add.Run())
+	ci := exec.Command("git", "commit", "-q", "-m", "c")
+	ci.Dir = src
+	ci.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	require.NoError(t, ci.Run())
+
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "shared")
+	clone := exec.Command("git", "clone", "-q", "--shared", "--no-checkout", src, dst)
+	out, err := clone.CombinedOutput()
+	require.NoError(t, err, "%s", out)
+
+	resolved, err := filepath.EvalSymlinks(dst)
+	require.NoError(t, err)
+	prev, _ := os.Getwd()
+	require.NoError(t, os.Chdir(resolved))
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	res := checkGitAlternates(false)
+	assert.True(t, res.warning || !res.passed, "shared clone should not pass cleanly: %+v", res)
+	assert.True(t, strings.Contains(res.detail, "go-git") || strings.Contains(res.message, "alternate"),
+		"detail should mention codedb/go-git impact: %q / %q", res.message, res.detail)
+}

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -108,6 +108,8 @@ const (
 	CheckSlugGitignoreMissing   = "gitignore-missing" // .sageox/.gitignore in ledger/team checkouts
 	CheckSlugGitFsck            = "git-fsck"
 	CheckSlugGitLock            = "git-lock"
+	CheckSlugRepoCompleteness   = "repo-completeness"
+	CheckSlugGitAlternates      = "git-alternates"
 
 	// Authentication checks
 	CheckSlugAuthStatus      = "auth-status"

--- a/cmd/ox/index.go
+++ b/cmd/ox/index.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -110,6 +111,13 @@ func indexCodeInProcess(cmd *cobra.Command, args []string, full bool) error {
 		}
 	} else {
 		if err := db.IndexLocalRepo(ctx, gitRoot, opts); err != nil {
+			if errors.Is(err, index.ErrAlternatesUnsupported) {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"codedb: skipping local index — repo uses git alternates (go-git v6 limitation).\n"+
+						"  Remediation: `git repack -a -d --local` to copy objects locally, or\n"+
+						"  re-clone without --shared / --reference. See `ox doctor` (git-alternates check).\n")
+				return nil
+			}
 			return fmt.Errorf("index local: %w", err)
 		}
 	}

--- a/cmd/ox/session_redact_history.go
+++ b/cmd/ox/session_redact_history.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
@@ -775,8 +776,25 @@ func fileLastCommitIsPushed(ledgerPath, path string) (bool, error) {
 		// file isn't tracked yet — pure working-tree change. Safe to redact.
 		return false, nil
 	}
-	// Is that commit reachable from origin/main? merge-base --is-ancestor
-	// exits 0 if yes, 1 if no.
+	// Is that commit reachable from origin/main?
+	//
+	// On a shallow ledger clone, the commit may live above the shallow
+	// horizon — merge-base would fail with "unknown revision" or report
+	// "not an ancestor" purely because the upstream history isn't
+	// fetched yet. Redaction safety MUST NOT depend on that ambiguity:
+	// claiming "not pushed" when the commit truly is upstream means we
+	// rewrite history that someone else may already have. Deepen up to
+	// 4 × 50 commits (matching `git rebase --autosquash` since 2.39)
+	// to get a definitive answer before deciding.
+	//
+	// If DeepenUntilAncestor errors (e.g. fresh ledger with no origin/main),
+	// fall through to the legacy single-shot check below — same behavior
+	// as before, safe for the fresh-ledger case.
+	ctx := context.Background()
+	if ok, err := gitutil.DeepenUntilAncestor(ctx, ledgerPath, sha, "origin/main", 50, 4); err == nil {
+		return ok, nil
+	}
+
 	cmd := exec.Command("git", "-C", ledgerPath, "merge-base", "--is-ancestor", sha, "origin/main")
 	if err := cmd.Run(); err == nil {
 		return true, nil

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -219,13 +219,24 @@ func getGitRepoStatus(repoPath string, lastSync time.Time, hasLastSync bool) git
 	// .git/rebase-apply. Cheap (two stat calls); always run.
 	status.RebaseInProgress = gitutil.IsRebaseInProgress(repoPath)
 
-	// ahead/behind count vs upstream. Silent if no upstream is
-	// configured (offline-only repo) — that's not a wedge, just a fact
-	// of the workspace. Failures here are non-fatal; status UI would
-	// rather under-report than refuse to render.
-	if ahead, behind, ok := gitAheadBehind(repoPath); ok {
-		status.AheadCount = ahead
-		status.BehindCount = behind
+	// Shallow detection. rev-list --left-right needs the commit graph;
+	// when truncated by `--depth N`, divergence counts are wrong (they
+	// silently truncate at the shallow boundary). Partial clones
+	// (--filter=blob:none) keep the commit graph intact — divergence
+	// still works there, so we don't suppress for Partial here.
+	repoState, _ := gitutil.InspectRepo(repoPath)
+	if repoState.Shallow {
+		status.IncompleteHistory = true
+		status.IncompleteReason = repoState.Reason
+	} else {
+		// ahead/behind count vs upstream. Silent if no upstream is
+		// configured (offline-only repo) — that's not a wedge, just a fact
+		// of the workspace. Failures here are non-fatal; status UI would
+		// rather under-report than refuse to render.
+		if ahead, behind, ok := gitAheadBehind(repoPath); ok {
+			status.AheadCount = ahead
+			status.BehindCount = behind
+		}
 	}
 
 	// check if synced with remote (only if uncommitted count is 0

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -224,11 +224,19 @@ func getGitRepoStatus(repoPath string, lastSync time.Time, hasLastSync bool) git
 	// silently truncate at the shallow boundary). Partial clones
 	// (--filter=blob:none) keep the commit graph intact — divergence
 	// still works there, so we don't suppress for Partial here.
-	repoState, _ := gitutil.InspectRepo(repoPath)
-	if repoState.Shallow {
+	//
+	// If InspectRepo itself fails (e.g. transient rev-parse error on a
+	// half-initialized repo), skip the divergence query rather than
+	// risk computing counts against an unknown clone state.
+	repoState, inspectErr := gitutil.InspectRepo(repoPath)
+	switch {
+	case inspectErr != nil:
+		status.IncompleteHistory = true
+		status.IncompleteReason = "history detection failed"
+	case repoState.Shallow:
 		status.IncompleteHistory = true
 		status.IncompleteReason = repoState.Reason
-	} else {
+	default:
 		// ahead/behind count vs upstream. Silent if no upstream is
 		// configured (offline-only repo) — that's not a wedge, just a fact
 		// of the workspace. Failures here are non-fatal; status UI would

--- a/cmd/ox/status_incomplete_history_test.go
+++ b/cmd/ox/status_incomplete_history_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetGitRepoStatus_ShallowSetsIncompleteHistory verifies the end-to-end
+// flow from a shallow user repo through getGitRepoStatus to the GitRepoStatus
+// struct: IncompleteHistory must be set, IncompleteReason populated, and
+// ahead/behind counts left at zero (not falsely computed).
+//
+// Failure prevented: ox status quietly displaying "0 ahead, 0 behind" or
+// inflated divergence numbers in CI environments where the user repo was
+// shallow-cloned by actions/checkout. The plumbing through status.go must
+// route shallow detection into the struct, not just internal helpers.
+func TestGetGitRepoStatus_ShallowSetsIncompleteHistory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+
+	src := t.TempDir()
+	runGitOrFail(t, src, "init", "-q", "-b", "main")
+	runGitOrFail(t, src, "config", "user.name", "test")
+	runGitOrFail(t, src, "config", "user.email", "test@sageox.ai")
+	for i := 0; i < 4; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(src, "f"+string(rune('a'+i))+".txt"), []byte("v"), 0o644))
+		runGitOrFail(t, src, "add", ".")
+		runGitOrFail(t, src, "commit", "-q", "-m", "c")
+	}
+
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "shallow")
+	clone := exec.Command("git", "clone", "-q", "--depth", "1", "--no-local", "file://"+src, dst)
+	out, err := clone.CombinedOutput()
+	require.NoError(t, err, "%s", out)
+
+	status := getGitRepoStatus(dst, time.Time{}, false)
+	assert.True(t, status.IncompleteHistory,
+		"shallow user repo must set IncompleteHistory; got %+v", status)
+	assert.Equal(t, "shallow clone", status.IncompleteReason)
+	assert.Equal(t, 0, status.AheadCount, "shallow repo must not report a confident AheadCount")
+	assert.Equal(t, 0, status.BehindCount, "shallow repo must not report a confident BehindCount")
+	// Not wedged: divergence-based wedge needs both counts > 0; rebase
+	// detection still works independently.
+	assert.False(t, status.IsWedged(), "shallow alone is not a wedge")
+}
+
+// TestGetGitRepoStatus_PartialClonePreservesDivergence verifies that
+// `--filter=blob:none` partial clones — which keep the commit graph intact
+// — still compute ahead/behind correctly. The Partial flag is informational
+// only; suppressing divergence on Partial would be a regression.
+func TestGetGitRepoStatus_PartialClonePreservesDivergence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+
+	src := t.TempDir()
+	runGitOrFail(t, src, "init", "-q", "-b", "main")
+	runGitOrFail(t, src, "config", "user.name", "test")
+	runGitOrFail(t, src, "config", "user.email", "test@sageox.ai")
+	require.NoError(t, os.WriteFile(filepath.Join(src, "f.txt"), []byte("v"), 0o644))
+	runGitOrFail(t, src, "add", ".")
+	runGitOrFail(t, src, "commit", "-q", "-m", "c")
+
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "partial")
+	clone := exec.Command("git", "clone", "-q", "--filter=blob:none", "--no-local", "file://"+src, dst)
+	out, err := clone.CombinedOutput()
+	require.NoError(t, err, "%s", out)
+
+	status := getGitRepoStatus(dst, time.Time{}, false)
+	assert.False(t, status.IncompleteHistory,
+		"partial clone keeps commit graph; divergence is still computable")
+}
+
+func runGitOrFail(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+}

--- a/internal/codedb/index/alternates.go
+++ b/internal/codedb/index/alternates.go
@@ -1,0 +1,65 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ErrAlternatesUnsupported reports that a repo uses
+// `.git/objects/info/alternates`, a layout go-git v6 does not honor. ox's
+// codedb indexing path (plainOpenTolerant + Log walk) silently fails on
+// such repos with bare "object not found" errors. The right caller
+// behavior is to soft-skip: log + suggest `git repack -a -d --local` or
+// re-clone without --shared/--reference, but do not treat as fatal.
+//
+// Pinned by TestPlainOpenTolerant_AlternatesUpstreamLimitation. When
+// upstream go-git adds alternates support and that test starts failing,
+// remove this gate.
+var ErrAlternatesUnsupported = errors.New("git alternates not supported by go-git v6 (codedb indexing skipped)")
+
+// hasAlternates reports whether repoPath has a non-empty
+// `.git/objects/info/alternates`. Resolves via `git rev-parse
+// --git-common-dir` so linked worktrees inherit the main repo's state.
+func hasAlternates(repoPath string) bool {
+	commonDir, err := resolveCommonDir(repoPath)
+	if err != nil {
+		// Fall back to the conservative direct check. If rev-parse fails
+		// we'd rather miss the alternate (codedb fails with the usual
+		// "object not found" message later) than block indexing on a
+		// transient git error.
+		alts := filepath.Join(repoPath, ".git", "objects", "info", "alternates")
+		return nonEmptyFile(alts)
+	}
+	alts := filepath.Join(commonDir, "objects", "info", "alternates")
+	return nonEmptyFile(alts)
+}
+
+func nonEmptyFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Size() > 0
+}
+
+func resolveCommonDir(repoPath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--git-common-dir")
+	cmd.Dir = repoPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	dir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(repoPath, dir)
+	}
+	return dir, nil
+}

--- a/internal/codedb/index/alternates_test.go
+++ b/internal/codedb/index/alternates_test.go
@@ -1,0 +1,113 @@
+package index
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIndexLocalRepo_AlternatesReturnsSentinel verifies that IndexLocalRepo
+// detects `.git/objects/info/alternates` and returns ErrAlternatesUnsupported
+// rather than attempting to walk the repo (which would fail with bare
+// "object not found" mid-walk because go-git v6 doesn't honor alternates).
+//
+// Failure prevented: codedb silently producing a partial or empty index for
+// any repo using `git clone --shared` or `--reference`. The sentinel lets
+// callers (cmd/ox/index.go, internal/daemon/codedb.go) surface a clear
+// "indexing skipped, here's why" message instead of a cryptic error.
+func TestIndexLocalRepo_AlternatesReturnsSentinel(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+
+	srcDir, _ := initGitRepo(t, 3)
+	runGitIn(t, srcDir, "gc", "--quiet")
+
+	parent := t.TempDir()
+	dstDir := filepath.Join(parent, "shared-clone")
+	cmd := exec.Command("git", "clone", "--shared", "--no-checkout", srcDir, dstDir)
+	cmd.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git clone --shared: %s", out)
+
+	// Confirm fixture truly has alternates configured.
+	altsPath := filepath.Join(dstDir, ".git", "objects", "info", "alternates")
+	info, err := os.Stat(altsPath)
+	require.NoError(t, err)
+	require.Positive(t, info.Size(), "alternates file must be non-empty")
+
+	dbDir := t.TempDir()
+	s, err := store.Open(dbDir)
+	require.NoError(t, err)
+	defer s.Close()
+
+	err = IndexLocalRepo(context.Background(), s, dstDir, IndexOptions{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAlternatesUnsupported,
+		"IndexLocalRepo must return ErrAlternatesUnsupported sentinel for alternates repos")
+}
+
+// TestHasAlternates verifies the helper's detection logic in isolation,
+// including the worktree case (where alternates lives on the common dir).
+func TestHasAlternates(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+
+	t.Run("no_alternates", func(t *testing.T) {
+		t.Parallel()
+		dir, _ := initGitRepo(t, 1)
+		assert.False(t, hasAlternates(dir))
+	})
+
+	t.Run("shared_clone_has_alternates", func(t *testing.T) {
+		t.Parallel()
+		srcDir, _ := initGitRepo(t, 1)
+		parent := t.TempDir()
+		dstDir := filepath.Join(parent, "shared")
+		cmd := exec.Command("git", "clone", "--shared", "--no-checkout", srcDir, dstDir)
+		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s", out)
+
+		assert.True(t, hasAlternates(dstDir))
+	})
+
+	t.Run("worktree_inherits_alternates", func(t *testing.T) {
+		t.Parallel()
+		srcDir, _ := initGitRepo(t, 2)
+		parent := t.TempDir()
+		mainDir := filepath.Join(parent, "main")
+		cmd := exec.Command("git", "clone", "--shared", srcDir, mainDir)
+		cmd.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s", out)
+
+		wtDir := filepath.Join(parent, "wt")
+		wtCmd := exec.Command("git", "worktree", "add", "-b", "feat", wtDir)
+		wtCmd.Dir = mainDir
+		out, err = wtCmd.CombinedOutput()
+		require.NoError(t, err, "%s", out)
+
+		// resolveGitDir resolves the worktree's .git file to the main
+		// repo's git dir, which is where alternates lives.
+		openPath, _ := resolveGitDir(wtDir)
+		assert.True(t, hasAlternates(openPath),
+			"worktree must inherit main repo's alternates via rev-parse --git-common-dir")
+	})
+}
+

--- a/internal/codedb/index/gogit_test.go
+++ b/internal/codedb/index/gogit_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -141,4 +142,115 @@ func TestPlainOpenTolerant_WorktreeWithExtensions(t *testing.T) {
 	repo, err := plainOpenTolerant(repoOpenPath)
 	require.NoError(t, err)
 	assert.NotNil(t, repo)
+}
+
+// TestPlainOpenTolerant_AlternatesUpstreamLimitation pins the current
+// go-git v6 behavior with .git/objects/info/alternates: object lookups fail
+// because v6's storage layer (both via plainOpenTolerant's custom
+// KeepDescriptors path AND vanilla git.PlainOpen) does NOT read the
+// alternates file. Native git CLI handles this correctly; go-git does not.
+//
+// Subtests cover both alternates-path shapes — relative (common in --reference
+// setups and manual configurations) and absolute (default for
+// `git clone --shared`). Both fail today.
+//
+// Failure prevented: codedb's IndexLocalRepo (internal/codedb/index/indexer.go:310)
+// opens user-controlled paths via plainOpenTolerant. If a user's repo uses
+// shared/reference clones, codedb would silently fail or index incomplete
+// history. Step 3 (ox-5b5p) of the shallow+shared epic gates IndexLocalRepo
+// on alternates absence and surfaces a clear "alternates unsupported" error
+// instead of producing wrong output.
+//
+// When this test starts FAILING — i.e., go-git v6 (or a successor) adds
+// alternates support — remove the IndexLocalRepo gate and flip the assertions
+// here to `require.NoError`. The test then becomes a positive regression test.
+func TestPlainOpenTolerant_AlternatesUpstreamLimitation(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+
+	cases := []struct {
+		name       string
+		makeRelative bool
+	}{
+		{name: "absolute_path", makeRelative: false},
+		{name: "relative_path", makeRelative: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Build source repo with 3 commits (forces packfile creation under gc).
+			srcDir, _ := initGitRepo(t, 3)
+			runGitIn(t, srcDir, "gc", "--quiet")
+
+			// Clone with --shared so destination's alternates references source.
+			// --no-checkout keeps working tree empty; we exercise the object store.
+			parent := t.TempDir()
+			dstDir := filepath.Join(parent, "shared-clone")
+			cloneCmd := exec.Command("git", "clone", "--shared", "--no-checkout", srcDir, dstDir)
+			cloneCmd.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+				"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+				"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+			out, err := cloneCmd.CombinedOutput()
+			require.NoError(t, err, "git clone --shared: %s", out)
+
+			altsPath := filepath.Join(dstDir, ".git", "objects", "info", "alternates")
+			contents, err := os.ReadFile(altsPath)
+			require.NoError(t, err)
+			require.True(t, filepath.IsAbs(strings.TrimSpace(string(contents))),
+				"git clone --shared should write absolute alternates path by default")
+
+			if tc.makeRelative {
+				srcObjects := filepath.Join(srcDir, ".git", "objects")
+				rel, relErr := filepath.Rel(filepath.Dir(altsPath), srcObjects)
+				require.NoError(t, relErr)
+				require.Contains(t, rel, "..", "rewrite must be relative (contain ../)")
+				require.NoError(t, os.WriteFile(altsPath, []byte(rel+"\n"), 0o644))
+			}
+
+			// Sanity: destination has no own objects — all reads must traverse
+			// alternates. Without this, the test could pass with broken
+			// alternates handling because git put loose objects locally.
+			entries, err := os.ReadDir(filepath.Join(dstDir, ".git", "objects"))
+			require.NoError(t, err)
+			for _, e := range entries {
+				if e.Name() == "info" || e.Name() == "pack" {
+					continue
+				}
+				t.Fatalf("unexpected local object dir %q — test setup leaked objects out of alternates", e.Name())
+			}
+
+			// Repo opens fine — go-git only fails when it tries to read objects.
+			repo, err := plainOpenTolerant(dstDir)
+			require.NoError(t, err, "plainOpenTolerant should accept the repo")
+
+			head, err := repo.Head()
+			require.NoError(t, err, "HEAD ref is in .git/HEAD, no objects needed")
+
+			// Pin the upstream limitation. Object lookups need the object store,
+			// which lives behind alternates — go-git v6 doesn't follow.
+			_, err = repo.CommitObject(head.Hash())
+			require.Error(t, err,
+				"upstream go-git v6 limitation: alternates not honored. "+
+					"If this test starts passing, remove the IndexLocalRepo "+
+					"alternates gate (see ox-5b5p) and flip this to require.NoError.")
+			require.Contains(t, err.Error(), "object not found",
+				"expected 'object not found' from alternates lookup failure")
+		})
+	}
+}
+
+// runGitIn is a tiny helper for the alternates test — runs `git <args>` in dir.
+func runGitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
 }

--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -307,6 +307,13 @@ func IndexRepo(ctx context.Context, s *store.Store, url string, opts IndexOption
 // IndexLocalRepo indexes a local git repository in-place (no clone).
 // It indexes all committed history AND the current working tree, including
 // uncommitted (dirty) files.
+//
+// Returns ErrAlternatesUnsupported when the repo has
+// `.git/objects/info/alternates` configured. go-git v6 does not honor
+// alternates (see TestPlainOpenTolerant_AlternatesUpstreamLimitation), so
+// blob and commit reads would silently fail mid-walk. Callers should
+// treat this as a soft-skip (codedb indexing unavailable for this repo)
+// rather than a fatal error.
 func IndexLocalRepo(ctx context.Context, s *store.Store, localPath string, opts IndexOptions) error {
 	report := func(msg string) {
 		if opts.Progress != nil {
@@ -320,6 +327,14 @@ func IndexLocalRepo(ctx context.Context, s *store.Store, localPath string, opts 
 	// go-git can access the shared object store (packfiles, loose objects).
 	report("Opening local repository...")
 	repoOpenPath, isWorktree := resolveGitDir(localPath)
+
+	// Gate on alternates BEFORE plainOpenTolerant: go-git v6 silently
+	// returns "object not found" later in the walk, which surfaces as
+	// confusing partial-index failures rather than the actual root cause.
+	if hasAlternates(repoOpenPath) {
+		return fmt.Errorf("codedb cannot index %s: %w", localPath, ErrAlternatesUnsupported)
+	}
+
 	repo, err := plainOpenTolerant(repoOpenPath)
 	if err != nil {
 		return fmt.Errorf("open local repo %s: %w", localPath, err)

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -293,6 +293,10 @@ func (m *CodeDBManager) BuildLedgerIndex(ctx context.Context, ledgerPath string)
 	opts := index.IndexOptions{}
 
 	if err := db.IndexLocalRepo(indexCtx, ledgerPath, opts); err != nil {
+		if errors.Is(err, index.ErrAlternatesUnsupported) {
+			m.logger.Info("codedb ledger: skipped (alternates configured)", "path", ledgerPath)
+			return
+		}
 		m.logger.Warn("codedb ledger: index failed", "error", err)
 		return
 	}
@@ -485,6 +489,13 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 			_ = pw.WriteStage("indexing", fmt.Sprintf("Indexing local repo %s...", projectRoot))
 		}
 		if err := db.IndexLocalRepo(ctx, projectRoot, opts); err != nil {
+			if errors.Is(err, index.ErrAlternatesUnsupported) {
+				m.logger.Info("codedb local: skipped (alternates configured)", "path", projectRoot)
+				if pw != nil {
+					_ = pw.WriteStage("indexing", "codedb: skipped (git alternates not supported)")
+				}
+				return nil, nil
+			}
 			m.setError(err)
 			return nil, fmt.Errorf("index local: %w", err)
 		}

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -365,8 +365,17 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 }
 
 // detectDivergedBranchesAt checks if local and remote branches have both
-// progressed independently at the given repo path.
+// progressed independently at the given repo path. Returns false when the
+// repo is shallow — rev-list counts truncate at the shallow boundary and
+// would falsely report "diverged" for branches that share ancestry past
+// the shallow horizon. False is safe: it just means we don't auto-trigger
+// a rebase based on divergence detection; the next sync will retry.
 func detectDivergedBranchesAt(ctx context.Context, repoPath string) bool {
+	if state, _ := gitutil.InspectRepo(repoPath); state.Shallow {
+		slog.Debug("divergence check skipped: shallow clone",
+			"repo", repoPath, "reason", state.Reason)
+		return false
+	}
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath,
 		"rev-list", "--left-right", "--count", "origin/main...HEAD")
 	output, err := cmd.Output()

--- a/internal/gitutil/incomplete.go
+++ b/internal/gitutil/incomplete.go
@@ -1,0 +1,211 @@
+package gitutil
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RepoState describes whether a repository has the complete commit graph
+// needed for reachability queries (ahead/behind, merge-base, ancestry).
+//
+// A repo can be "incomplete" in two distinct ways:
+//
+//  1. Shallow — `git clone --depth N` creates `.git/shallow` listing the
+//     commits whose parents have been truncated. Walking past them fails.
+//     CI defaults (GitHub Actions actions/checkout@v5) still use this.
+//
+//  2. Partial — `git clone --filter=blob:none` (or tree:0) creates a
+//     promisor remote that fetches objects lazily. The commit graph is
+//     complete, but blob/tree reads may fault into the network mid-walk.
+//     2026 CI providers (Buildkite, Depot, Blacksmith, Namespace) lean
+//     toward this over shallow because it breaks fewer tools.
+//
+// Callers running history walks (rev-list --left-right --count,
+// merge-base --is-ancestor, log --since) must treat `Incomplete()==true`
+// results as opaque — render a sentinel ("—" / null), not zero counts.
+// Zero would be a confident lie; the truth is "unknowable from this clone."
+type RepoState struct {
+	// Shallow reports whether the repo has a `.git/shallow` file
+	// (resolved via `git rev-parse --git-common-dir`, so linked worktrees
+	// inherit the main repo's shallow state).
+	Shallow bool
+
+	// Partial reports whether the repo has a promisor remote or
+	// `extensions.partialClone` set. Object reads may require network.
+	Partial bool
+
+	// Reason is a short human-readable description suitable for UI/log
+	// output, e.g. "shallow clone" or "partial clone (blob:none)".
+	// Empty when neither Shallow nor Partial is true.
+	Reason string
+}
+
+// Incomplete reports whether the repo lacks full history for reachability
+// queries. Callers should branch on this before invoking divergence /
+// ancestry git commands.
+func (s RepoState) Incomplete() bool {
+	return s.Shallow || s.Partial
+}
+
+// inspectTimeout caps the cost of detection. InspectRepo runs up to four
+// fast git commands (rev-parse, three configs). On a healthy machine each
+// returns in <50ms; the cap exists to bound pathological cases (NFS, FUSE).
+const inspectTimeout = 5 * time.Second
+
+// InspectRepo detects shallow and partial-clone state for repoPath.
+//
+// Worktree correctness: uses `git rev-parse --git-common-dir` so a linked
+// worktree inherits its main repo's shallow status (`.git/shallow` lives
+// on the common dir, not the worktree's gitdir). Conductor — ox's primary
+// consumer — runs in linked worktrees, so this matters.
+//
+// Returns a zero RepoState (no error) when repoPath is not a git repo;
+// callers can use IsGitRepo first if they need to distinguish.
+func InspectRepo(repoPath string) (RepoState, error) {
+	if repoPath == "" {
+		return RepoState{}, errors.New("inspect repo: empty path")
+	}
+	if !IsGitRepo(repoPath) {
+		return RepoState{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), inspectTimeout)
+	defer cancel()
+
+	commonDir, err := runQuietGit(ctx, repoPath, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return RepoState{}, err
+	}
+	// rev-parse may return a relative path; resolve against repoPath.
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(repoPath, commonDir)
+	}
+
+	state := RepoState{}
+
+	if _, err := os.Stat(filepath.Join(commonDir, "shallow")); err == nil {
+		state.Shallow = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return state, err
+	}
+
+	// Partial detection: prefer the promisor-remote signal because it
+	// captures the runtime contract (network fetch may be needed). Fall
+	// back to extensions.partialClone for repos that disabled the remote
+	// but still have the extension recorded.
+	if v, err := runQuietGit(ctx, repoPath, "config", "--get-regexp", `^remote\..*\.promisor$`); err == nil && v != "" {
+		state.Partial = true
+	} else if v, err := runQuietGit(ctx, repoPath, "config", "--get", "extensions.partialClone"); err == nil && v != "" {
+		state.Partial = true
+	}
+
+	switch {
+	case state.Shallow && state.Partial:
+		state.Reason = "shallow + partial clone"
+	case state.Shallow:
+		state.Reason = "shallow clone"
+	case state.Partial:
+		state.Reason = "partial clone"
+	}
+
+	return state, nil
+}
+
+// runQuietGit is InspectRepo's helper — like RunGit but discards stderr
+// from non-zero exits (`git config --get` returns exit 1 on missing keys,
+// which is not an error condition for detection).
+func runQuietGit(ctx context.Context, repoPath string, args ...string) (string, error) {
+	cmdArgs := append([]string{"-C", repoPath}, args...)
+	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+	cmd.Dir = repoPath
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = nil // discard
+	err := cmd.Run()
+	out := strings.TrimSpace(stdout.String())
+	if err != nil {
+		// `git config --get` exits 1 when the key is missing.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && len(args) >= 1 && args[0] == "config" {
+			return "", nil
+		}
+		return out, err
+	}
+	return out, nil
+}
+
+// DeepenUntilAncestor attempts `git fetch --deepen <step>` in a loop until
+// `git merge-base --is-ancestor <commit> <ref>` succeeds, or the cap is
+// exhausted. Used by destructive ops (e.g. session redaction) that need a
+// definitive ancestry answer in a shallow repo.
+//
+// Returns:
+//   - (true, nil)  — ancestry confirmed (commit is reachable from ref).
+//   - (false, nil) — ancestry definitively absent after full deepen, OR
+//     not shallow and not an ancestor. Caller should treat as "no".
+//   - (false, err) — fetch or merge-base error other than non-ancestor.
+//
+// Matches the pattern `git rebase --autosquash` has used since 2.39.
+func DeepenUntilAncestor(ctx context.Context, repoPath, commit, ref string, step, maxIterations int) (bool, error) {
+	if step <= 0 {
+		step = 50
+	}
+	if maxIterations <= 0 {
+		maxIterations = 4
+	}
+
+	check := func() (bool, error) {
+		cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "merge-base", "--is-ancestor", commit, ref)
+		err := cmd.Run()
+		if err == nil {
+			return true, nil
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// 1  = definitively not an ancestor (commits exist, no path)
+			// 128 = unknown revision in current shallow view; treat as
+			//       "not provably an ancestor here" so the deepen loop
+			//       proceeds. If still 128 after full deepen, the commit
+			//       truly doesn't exist upstream.
+			code := exitErr.ExitCode()
+			if code == 1 || code == 128 {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+
+	if ok, err := check(); ok || err != nil {
+		return ok, err
+	}
+
+	state, err := InspectRepo(repoPath)
+	if err != nil || !state.Shallow {
+		return false, err
+	}
+
+	for i := 0; i < maxIterations; i++ {
+		if _, err := RunGit(ctx, repoPath, "fetch", "--deepen", strconv.Itoa(step)); err != nil {
+			return false, err
+		}
+		ok, err := check()
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+		// Stop early if the deepen revealed full history.
+		if state, _ := InspectRepo(repoPath); !state.Shallow {
+			return false, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/gitutil/incomplete_test.go
+++ b/internal/gitutil/incomplete_test.go
@@ -1,0 +1,185 @@
+package gitutil
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initRepoWithCommits sets up a temp git repo with N commits and returns
+// (path, tipSHA). Uses the same env-isolated pattern as other ox tests so
+// it's safe under -p N parallel runs.
+func initRepoWithCommits(t *testing.T, n int) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.name", "test")
+	runGit(t, dir, "config", "user.email", "test@sageox.ai")
+	for i := 1; i <= n; i++ {
+		name := filepath.Join(dir, "f"+itoaTest(i)+".txt")
+		require.NoError(t, os.WriteFile(name, []byte("v"+itoaTest(i)), 0o644))
+		runGit(t, dir, "add", ".")
+		runGit(t, dir, "commit", "-m", "c"+itoaTest(i))
+	}
+	out := captureGit(t, dir, "rev-parse", "HEAD")
+	return dir, strings.TrimSpace(out)
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), // safe: git CLI in temp dir, not ox subprocess
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@sageox.ai",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@sageox.ai")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+}
+
+func captureGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+	return string(out)
+}
+
+func itoaTest(n int) string {
+	if n < 10 {
+		return string(rune('0' + n))
+	}
+	return itoaTest(n/10) + itoaTest(n%10)
+}
+
+func TestInspectRepo(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) string
+		wantShall bool
+		wantPart  bool
+		wantReason string
+	}{
+		{
+			name: "normal_repo",
+			setup: func(t *testing.T) string {
+				dir, _ := initRepoWithCommits(t, 2)
+				return dir
+			},
+		},
+		{
+			name: "shallow_clone",
+			setup: func(t *testing.T) string {
+				src, _ := initRepoWithCommits(t, 5)
+				dst := filepath.Join(t.TempDir(), "shallow")
+				// file:// + --no-local forces the dumb-protocol path that
+				// honors --depth. A plain path clone hardlinks instead.
+				runGit(t, t.TempDir(), "clone", "--depth", "1", "--no-local", "file://"+src, dst)
+				return dst
+			},
+			wantShall:  true,
+			wantReason: "shallow clone",
+		},
+		{
+			name: "partial_blob_none",
+			setup: func(t *testing.T) string {
+				src, _ := initRepoWithCommits(t, 3)
+				dst := filepath.Join(t.TempDir(), "partial")
+				runGit(t, t.TempDir(), "clone", "--filter=blob:none", "--no-local", "file://"+src, dst)
+				return dst
+			},
+			wantPart:   true,
+			wantReason: "partial clone",
+		},
+		{
+			name: "shallow_and_partial",
+			setup: func(t *testing.T) string {
+				src, _ := initRepoWithCommits(t, 5)
+				dst := filepath.Join(t.TempDir(), "both")
+				runGit(t, t.TempDir(), "clone", "--depth", "1", "--filter=blob:none", "--no-local", "file://"+src, dst)
+				return dst
+			},
+			wantShall:  true,
+			wantPart:   true,
+			wantReason: "shallow + partial clone",
+		},
+		{
+			name: "worktree_inherits_shallow",
+			setup: func(t *testing.T) string {
+				src, _ := initRepoWithCommits(t, 5)
+				main := filepath.Join(t.TempDir(), "main")
+				runGit(t, t.TempDir(), "clone", "--depth", "1", "--no-local", "file://"+src, main)
+				wt := filepath.Join(t.TempDir(), "wt")
+				runGit(t, main, "worktree", "add", "-b", "feat", wt)
+				return wt
+			},
+			wantShall:  true,
+			wantReason: "shallow clone",
+		},
+		{
+			name: "not_a_repo",
+			setup: func(t *testing.T) string {
+				return t.TempDir()
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := tc.setup(t)
+			state, err := InspectRepo(path)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantShall, state.Shallow, "Shallow")
+			assert.Equal(t, tc.wantPart, state.Partial, "Partial")
+			assert.Equal(t, tc.wantReason, state.Reason, "Reason")
+			assert.Equal(t, tc.wantShall || tc.wantPart, state.Incomplete(), "Incomplete()")
+		})
+	}
+}
+
+func TestInspectRepo_EmptyPath(t *testing.T) {
+	t.Parallel()
+	_, err := InspectRepo("")
+	assert.Error(t, err)
+}
+
+// TestDeepenUntilAncestor verifies the deepen-loop succeeds when the
+// commit exists in upstream history but isn't reachable at the initial
+// shallow depth.
+func TestDeepenUntilAncestor(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+
+	src, _ := initRepoWithCommits(t, 5)
+	// We want to test that DeepenUntilAncestor can prove the OLD commit is
+	// an ancestor of HEAD after deepening, starting from a shallow clone.
+	// Capture an old commit SHA from src BEFORE cloning.
+	oldSHA := strings.TrimSpace(captureGit(t, src, "rev-parse", "HEAD~3"))
+	require.NotEmpty(t, oldSHA)
+
+	dst := filepath.Join(t.TempDir(), "shallow")
+	runGit(t, t.TempDir(), "clone", "--depth", "1", "--no-local", "file://"+src, dst)
+
+	state, err := InspectRepo(dst)
+	require.NoError(t, err)
+	require.True(t, state.Shallow, "expected shallow clone setup")
+
+	ctx := context.Background()
+	ok, err := DeepenUntilAncestor(ctx, dst, oldSHA, "HEAD", 2, 4)
+	require.NoError(t, err)
+	assert.True(t, ok, "deepen loop should reveal old commit is ancestor of HEAD")
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -180,6 +180,17 @@ type GitRepoStatus struct {
 	// directory present). The most direct signal of a wedge.
 	RebaseInProgress bool
 
+	// IncompleteHistory reports whether the repo is shallow or partial
+	// (lazy-fetch promisor). When true, AheadCount/BehindCount are not
+	// computable; both are zero and UI should render a sentinel ("—" /
+	// null) rather than treat the zeros as a confident answer.
+	IncompleteHistory bool
+
+	// IncompleteReason is a short human-readable description of why
+	// history is incomplete (e.g. "shallow clone", "partial clone").
+	// Empty when IncompleteHistory is false.
+	IncompleteReason string
+
 	Error string
 }
 


### PR DESCRIPTION
Part of the ongoing series of ephemeral ox CLI improvements.

## What this PR ships

Hardens ox subsystems that walk git history against clone modes that silently truncate or redirect the object graph:

- **Shallow** (`git clone --depth N`) — CI default for `actions/checkout`
- **Partial** (`--filter=blob:none`, promisor remotes) — increasingly the 2026 default on Buildkite, Depot, Blacksmith, Namespace
- **Shared / reference** (`.git/objects/info/alternates`) — common in monorepo dev setups

Built bottom-up across 5 steps, each with its own beads issue.

## Step-by-step

### Step 0 — verify upstream (ox-dm7f)

`TestPlainOpenTolerant_AlternatesUpstreamLimitation` empirically pins go-git v6's behavior with `.git/objects/info/alternates`: object lookups fail (\`object not found\`) for **both** absolute and relative paths, via both \`git.PlainOpen\` and the custom KeepDescriptors storage path. Pinning regression flips to \`require.NoError\` when upstream adds support.

### Step 1 — \`internal/gitutil/incomplete.go\` (ox-2f6o)

\`\`\`go
type RepoState struct { Shallow, Partial bool; Reason string }
func InspectRepo(repoPath string) (RepoState, error)
func DeepenUntilAncestor(ctx, repoPath, commit, ref string, step, maxIter int) (bool, error)
\`\`\`

- Uses \`git rev-parse --git-common-dir\` (not \`--git-dir\`) — \`.git/shallow\` lives on the **common dir**, so linked worktrees (Conductor's case) inherit correctly.
- Partial detection: \`remote.*.promisor\` regex first, \`extensions.partialClone\` fallback.
- \`DeepenUntilAncestor\` matches the \`git rebase --autosquash\` deepen-loop pattern (since 2.39).

Adopted at 4 sites:

| Site | Behavior |
|---|---|
| \`cmd/ox/status.go:gitAheadBehind\` | Gates ahead/behind on \`Shallow\` only. Partial keeps commit graph, so divergence remains valid. |
| \`internal/daemon/sync_managed.go:detectDivergedBranchesAt\` | Returns false on shallow — don't auto-rebase based on truncated counts. |
| \`cmd/ox/agent_doctor.go\` | Skips \`rev-list --count\` on shallow; relies on porcelain \`[ahead\` from \`git status -b\`. |
| \`cmd/ox/session_redact_history.go:fileLastCommitIsPushed\` | Destructive op — calls \`DeepenUntilAncestor\` before refusing. Gets a definitive ancestry answer up to depth 200. |

\`GitRepoStatus\` gains \`IncompleteHistory\` + \`IncompleteReason\` so UI can render a sentinel ("—" / null) instead of confident-but-wrong zeros.

### Step 2 — \`ox doctor\` checks (ox-8bbz)

Two new checks registered via \`doctor_check_registry.go\`:

- \`checkRepoCompleteness\` — sub-findings for shallow / partial. Env-driven policy: in CI / non-TTY, append "informational only"; in interactive TTY, surface remediation. Never auto-fixes (re-clone is bandwidth-hostile and intent-laden).
- \`checkGitAlternates\` — reads alternates via common-dir, stats each target. Surfaces codedb impact directly in the detail string.

### Step 3 — codedb gate (ox-5b5p, became required after Step 0)

\`internal/codedb/index/alternates.go\`:

\`\`\`go
var ErrAlternatesUnsupported = errors.New("git alternates not supported by go-git v6 (codedb indexing skipped)")
func hasAlternates(repoPath string) bool  // uses rev-parse --git-common-dir
\`\`\`

\`IndexLocalRepo\` short-circuits **before** \`plainOpenTolerant\`. Callers (\`cmd/ox/index.go\`, \`internal/daemon/codedb.go\`) check \`errors.Is\` and emit a clear soft-skip message instead of mid-walk \`object not found\` chaos.

### Step 4 — integration tests (ox-pv1u)

End-to-end through \`getGitRepoStatus\`:

- \`TestGetGitRepoStatus_ShallowSetsIncompleteHistory\` — shallow user repo → \`IncompleteHistory=true\`, counts stay 0, not wedged.
- \`TestGetGitRepoStatus_PartialClonePreservesDivergence\` — guards against the regression of suppressing divergence on partial (commit graph is intact for blob-filter).

Cut from original plan: \`tests/e2e/ci_incomplete_e2e_test.go\` (binary-level) — function-level integration coverage already validates user-facing behavior.

## Failure-mode flow

\`\`\`mermaid
flowchart TD
  A[User repo state] --> B{InspectRepo}
  B -->|Shallow| C[status: render sentinel<br/>daemon: skip auto-rebase<br/>agent_doctor: skip rev-list count<br/>redact: deepen-loop until ancestor]
  B -->|Partial only| D[Divergence still valid<br/>codedb may lazy-fetch blobs<br/>doctor warns informationally]
  B -->|Alternates| E[codedb: ErrAlternatesUnsupported<br/>doctor: surface dissociate remediation]
  B -->|Full history| F[Normal path]
\`\`\`

## What is NOT in scope

- Auto \`fetch --unshallow\` on user repos (bandwidth-hostile in CI).
- Migrating ledger/daemon ops from git CLI to go-git (works today *because* of CLI).
- Submodule recursion in divergence checks (follow-up).
- sha256 repos (defer).

## Test Plan

- [x] \`make lint\` — 0 issues
- [x] \`go test -short ./...\` — all packages pass
- [x] Unit tests for \`InspectRepo\` (5 fixture cases), \`DeepenUntilAncestor\`, \`hasAlternates\` (3 cases), doctor checks (5 cases), upstream pinning test (2 subtests), integration tests
- [ ] Manual: \`ox status\` inside \`git clone --depth 1 --no-local file:// …\`
- [ ] Manual: \`ox doctor\` inside \`git clone --shared\` — expect alternates warning with remediation
- [ ] Manual: Conductor worktree of a shallow main repo — confirm \`--git-common-dir\` resolves shallow state

## Beads

- ox-rva0 (epic)
- ox-dm7f, ox-2f6o, ox-8bbz, ox-5b5p, ox-pv1u (steps 0–4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New doctor checks flag shallow/partial clones and configured git alternates; repo status exposes an "incomplete history" indicator and reason.
  * History-deepening attempts added to better determine whether commits are pushed.

* **Bug Fixes**
  * Avoids false divergence/ahead-behind results for shallow clones.
  * Indexing and daemon flows now treat repos using git alternates as non-fatal (skipped) with targeted guidance.

* **Tests**
  * Extensive integration tests covering shallow clones, partial clones, alternates, and deepening behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->