### PR TITLE
feat(adapter): terminal-error detection (rate limit fast-stop)

### DIFF
--- a/cmd/ox-adapter-claude-code/serve.go
+++ b/cmd/ox-adapter-claude-code/serve.go
@@ -19,9 +19,10 @@ type sessionState struct {
 func handleServe(srv *adapterruntime.Server) {
 	store := adapterruntime.NewSessionStore[sessionState]()
 
-	fw, err := adapterruntime.NewFileWatcher(srv.Writer(), func(file string, offset int64) ([]adapterprotocol.RawEntry, int64, error) {
+	detector := registerTerminalDetector()
+	fw, err := adapterruntime.NewFileWatcherWithDetector(srv.Writer(), func(file string, offset int64) ([]adapterprotocol.RawEntry, int64, error) {
 		return readFromOffset(file, offset)
-	})
+	}, detector)
 	if err != nil {
 		log.Printf("file watcher unavailable: %v", err)
 	}

--- a/cmd/ox-adapter-claude-code/terminal_patterns.go
+++ b/cmd/ox-adapter-claude-code/terminal_patterns.go
@@ -1,0 +1,130 @@
+// terminal_patterns.go wires Claude Code's terminal-error patterns into
+// the shared adapterruntime detector. The catalog lives in
+// terminal_patterns.yaml (embedded) so pattern updates are reviewable as
+// data, not code. parseClaudeReset parses the "resets in ..." capture
+// group from the usage-limit regex into an absolute time when the format
+// is unambiguous; AM/PM and timezone-tagged clock strings are deliberately
+// left unparsed (returned raw only) because they are easy to get wrong
+// across day/DST boundaries — better an empty resets_at than a wrong one.
+package main
+
+import (
+	_ "embed"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/pkg/adapterruntime"
+)
+
+//go:embed terminal_patterns.yaml
+var terminalPatternsYAML []byte
+
+// reTimezoneToken matches uppercase 2-4 letter words used as timezone
+// abbreviations ("PT", "UTC", "EST"). Presence is a signal we cannot
+// safely interpret the clock string without timezone knowledge.
+var reTimezoneToken = regexp.MustCompile(`\b[A-Z]{2,4}\b`)
+
+// reCollapseAlphaDigit removes a single space at a digit/letter boundary
+// so "2h 15m" normalizes to "2h15m" — the form time.ParseDuration
+// accepts. Matches both digit-then-letter and letter-then-digit
+// boundaries because compound durations cross both ways.
+var reCollapseAlphaDigit = regexp.MustCompile(`([0-9a-zA-Z])\s+([0-9a-zA-Z])`)
+
+// loadTerminalPatterns parses the embedded YAML catalog into runtime
+// TerminalPattern values. The structured registry is nil because all
+// structured patterns use the declarative json_path/equals form.
+func loadTerminalPatterns() ([]adapterruntime.TerminalPattern, error) {
+	parsers := map[string]func([]string) (string, *time.Time){
+		"relative_duration_or_clock": parseClaudeReset,
+	}
+	return adapterruntime.LoadYAMLPatterns(terminalPatternsYAML, nil, parsers)
+}
+
+// parseClaudeReset extracts the reset-time substring captured by the
+// usage_limit regex and tries to convert it to an absolute time.
+//
+// match comes from regexp.FindStringSubmatch: match[0] is the full
+// match, match[1] is the first named capture group ("reset"). We only
+// return a non-nil parsed time when the format is unambiguous.
+//
+// Accepted: relative durations ("3h", "2h15m", "in 3h") and 24h clock
+// strings ("15:00"). 24h clock is interpreted in the local timezone
+// using today's date; if the time is already past, we roll forward 24h.
+//
+// Rejected (raw only, parsed nil): AM/PM strings, anything containing
+// a timezone abbreviation, and any format ParseDuration / Parse cannot
+// recognize.
+func parseClaudeReset(match []string) (string, *time.Time) {
+	if len(match) < 2 {
+		return "", nil
+	}
+	raw := strings.TrimSpace(match[1])
+	if raw == "" {
+		return "", nil
+	}
+
+	lower := strings.ToLower(raw)
+	if strings.Contains(lower, "am") || strings.Contains(lower, "pm") {
+		return raw, nil
+	}
+	if reTimezoneToken.MatchString(raw) {
+		return raw, nil
+	}
+
+	normalized := raw
+	if strings.HasPrefix(lower, "in ") {
+		normalized = strings.TrimSpace(normalized[3:])
+	}
+	normalized = reCollapseAlphaDigit.ReplaceAllString(normalized, "$1$2")
+
+	if dur, err := time.ParseDuration(normalized); err == nil {
+		t := time.Now().Add(dur)
+		return raw, &t
+	}
+
+	if clock, err := time.Parse("15:04", raw); err == nil {
+		now := time.Now()
+		t := time.Date(now.Year(), now.Month(), now.Day(), clock.Hour(), clock.Minute(), 0, 0, now.Location())
+		if !t.After(now) {
+			t = t.Add(24 * time.Hour)
+		}
+		return raw, &t
+	}
+
+	return raw, nil
+}
+
+// registerTerminalDetector loads the embedded pattern catalog and
+// constructs a detector. Returns nil when the detector is disabled by
+// env var or pattern loading fails — callers wire the nil into
+// NewFileWatcherWithDetector, which treats it as "no detection".
+func registerTerminalDetector() *adapterruntime.TerminalDetector {
+	if disabledByEnv("claude-code") {
+		return nil
+	}
+	patterns, err := loadTerminalPatterns()
+	if err != nil {
+		log.Printf("terminal detector: failed to load patterns: %v", err)
+		return nil
+	}
+	return adapterruntime.NewTerminalDetector(adapterName, patterns, adapterruntime.DefaultSilenceWindow, adapterruntime.NopMetrics{})
+}
+
+// disabledByEnv is a Phase-2 fallback for the Phase-4 helper
+// adapterruntime.AdapterDisabledByEnv. Switch to that helper once it
+// lands so all adapters share one disable surface.
+func disabledByEnv(adapter string) bool {
+	raw := os.Getenv("OX_DISABLE_TERMINAL_DETECTION")
+	if raw == "" {
+		return false
+	}
+	for _, part := range strings.Split(raw, ",") {
+		if strings.TrimSpace(part) == adapter {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/ox-adapter-claude-code/terminal_patterns.go
+++ b/cmd/ox-adapter-claude-code/terminal_patterns.go
@@ -11,7 +11,6 @@ package main
 import (
 	_ "embed"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -102,7 +101,7 @@ func parseClaudeReset(match []string) (string, *time.Time) {
 // env var or pattern loading fails — callers wire the nil into
 // NewFileWatcherWithDetector, which treats it as "no detection".
 func registerTerminalDetector() *adapterruntime.TerminalDetector {
-	if disabledByEnv("claude-code") {
+	if adapterruntime.AdapterDisabledByEnv(adapterName) {
 		return nil
 	}
 	patterns, err := loadTerminalPatterns()
@@ -111,20 +110,4 @@ func registerTerminalDetector() *adapterruntime.TerminalDetector {
 		return nil
 	}
 	return adapterruntime.NewTerminalDetector(adapterName, patterns, adapterruntime.DefaultSilenceWindow, adapterruntime.NopMetrics{})
-}
-
-// disabledByEnv is a Phase-2 fallback for the Phase-4 helper
-// adapterruntime.AdapterDisabledByEnv. Switch to that helper once it
-// lands so all adapters share one disable surface.
-func disabledByEnv(adapter string) bool {
-	raw := os.Getenv("OX_DISABLE_TERMINAL_DETECTION")
-	if raw == "" {
-		return false
-	}
-	for _, part := range strings.Split(raw, ",") {
-		if strings.TrimSpace(part) == adapter {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/ox-adapter-claude-code/terminal_patterns.yaml
+++ b/cmd/ox-adapter-claude-code/terminal_patterns.yaml
@@ -1,0 +1,25 @@
+version: 1
+patterns:
+  - id: claude_code.api_stop_reason.rate_limited
+    source: structured
+    reason: rate_limited
+    structured:
+      json_path: message.stop_reason
+      equals: rate_limited
+  - id: claude_code.api_stop_reason.max_tokens
+    source: structured
+    reason: ""
+    structured:
+      json_path: message.stop_reason
+      equals: max_tokens
+  - id: claude_code.system_error.usage_limit
+    source: regex
+    reason: rate_limited
+    roles:
+      - system
+    substrings:
+      - "limit reached"
+      - "hit your limit"
+      - "usage limit"
+    re: '(?i)(?:hit your limit|limit reached|usage limit)[^\n]{0,80}?(?:resets?(?:\s+in)?\s+(?P<reset>[^\n.]{1,30}))?'
+    parse_resets_at: relative_duration_or_clock

--- a/cmd/ox-adapter-claude-code/terminal_patterns_test.go
+++ b/cmd/ox-adapter-claude-code/terminal_patterns_test.go
@@ -146,8 +146,9 @@ func TestStructuredRateLimitMatch(t *testing.T) {
 		json.RawMessage(`{"message":{"stop_reason":"rate_limited"}}`),
 	}
 	d.OnBatch("sess1", entries, 1, raws)
-	time.Sleep(15 * time.Millisecond)
-	confirmed := d.Tick(time.Now())
+	// Deterministic: advance the clock past the silence window rather than
+	// sleeping in real time (avoids CI scheduling flakiness).
+	confirmed := d.Tick(time.Now().Add(time.Hour))
 	if len(confirmed) != 1 {
 		t.Fatalf("expected 1 confirmed match, got %d", len(confirmed))
 	}
@@ -165,8 +166,7 @@ func TestStructuredMaxTokensInformational(t *testing.T) {
 		json.RawMessage(`{"message":{"stop_reason":"max_tokens"}}`),
 	}
 	d.OnBatch("sess1", entries, 1, raws)
-	time.Sleep(15 * time.Millisecond)
-	confirmed := d.Tick(time.Now())
+	confirmed := d.Tick(time.Now().Add(time.Hour))
 	if len(confirmed) != 0 {
 		t.Fatalf("expected 0 confirmed (informational), got %d", len(confirmed))
 	}
@@ -186,11 +186,10 @@ func TestRegexSystemRoleOnly(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := newTestDetector(t, 10*time.Millisecond)
 			entries := []adapterprotocol.RawEntry{
-				{Role: tc.role, Content: "5-hour limit reached ∙ resets 3pm"},
+				{Role: tc.role, Content: "5-hour limit reached · resets 3pm"},
 			}
 			d.OnBatch("sess-"+tc.role, entries, 1, nil)
-			time.Sleep(15 * time.Millisecond)
-			confirmed := d.Tick(time.Now())
+			confirmed := d.Tick(time.Now().Add(time.Hour))
 			if tc.wantMatch && len(confirmed) == 0 {
 				t.Fatalf("expected match, got none")
 			}
@@ -207,8 +206,7 @@ func TestRegexSubstringPreFilter(t *testing.T) {
 		{Role: adapterprotocol.RoleSystem, Content: "hello world"},
 	}
 	d.OnBatch("sess1", entries, 1, nil)
-	time.Sleep(15 * time.Millisecond)
-	confirmed := d.Tick(time.Now())
+	confirmed := d.Tick(time.Now().Add(time.Hour))
 	if len(confirmed) != 0 {
 		t.Fatalf("expected no match, got %d", len(confirmed))
 	}

--- a/cmd/ox-adapter-claude-code/terminal_patterns_test.go
+++ b/cmd/ox-adapter-claude-code/terminal_patterns_test.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/sageox/ox/pkg/adapterruntime"
+)
+
+func TestParseClaudeReset(t *testing.T) {
+	tests := []struct {
+		name       string
+		match      []string
+		wantRaw    string
+		wantParsed bool
+		// approxDur, when > 0, asserts parsed is approximately now+approxDur (±5s).
+		approxDur time.Duration
+	}{
+		{
+			name:    "empty capture",
+			match:   []string{"", ""},
+			wantRaw: "",
+		},
+		{
+			name:       "relative with in prefix",
+			match:      []string{"full", "in 3h"},
+			wantRaw:    "in 3h",
+			wantParsed: true,
+			approxDur:  3 * time.Hour,
+		},
+		{
+			name:       "bare duration",
+			match:      []string{"full", "3h"},
+			wantRaw:    "3h",
+			wantParsed: true,
+			approxDur:  3 * time.Hour,
+		},
+		{
+			name:       "compound duration with space",
+			match:      []string{"full", "in 2h 15m"},
+			wantRaw:    "in 2h 15m",
+			wantParsed: true,
+			approxDur:  2*time.Hour + 15*time.Minute,
+		},
+		{
+			name:       "24h clock",
+			match:      []string{"full", "15:00"},
+			wantRaw:    "15:00",
+			wantParsed: true,
+		},
+		{
+			name:    "pm rejected",
+			match:   []string{"full", "3pm"},
+			wantRaw: "3pm",
+		},
+		{
+			name:    "clock with am/pm and tz rejected",
+			match:   []string{"full", "3:00pm UTC"},
+			wantRaw: "3:00pm UTC",
+		},
+		{
+			name:       "trims surrounding whitespace",
+			match:      []string{"full", "  in 3h  "},
+			wantRaw:    "in 3h",
+			wantParsed: true,
+			approxDur:  3 * time.Hour,
+		},
+		{
+			name:    "unknown words",
+			match:   []string{"full", "tomorrow"},
+			wantRaw: "tomorrow",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			before := time.Now()
+			raw, parsed := parseClaudeReset(tc.match)
+			if raw != tc.wantRaw {
+				t.Fatalf("raw: got %q want %q", raw, tc.wantRaw)
+			}
+			if tc.wantParsed {
+				if parsed == nil {
+					t.Fatalf("expected parsed time, got nil")
+				}
+				if tc.approxDur > 0 {
+					expected := before.Add(tc.approxDur)
+					diff := parsed.Sub(expected)
+					if diff < -5*time.Second || diff > 5*time.Second {
+						t.Fatalf("parsed time off by %v from expected %v", diff, expected)
+					}
+				}
+			} else {
+				if parsed != nil {
+					t.Fatalf("expected nil parsed, got %v", parsed)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadTerminalPatterns(t *testing.T) {
+	patterns, err := loadTerminalPatterns()
+	if err != nil {
+		t.Fatalf("loadTerminalPatterns: %v", err)
+	}
+	if len(patterns) != 3 {
+		t.Fatalf("got %d patterns, want 3", len(patterns))
+	}
+	wantIDs := map[string]bool{
+		"claude_code.api_stop_reason.rate_limited": true,
+		"claude_code.api_stop_reason.max_tokens":   true,
+		"claude_code.system_error.usage_limit":     true,
+	}
+	for _, p := range patterns {
+		if !wantIDs[p.ID] {
+			t.Errorf("unexpected pattern id %q", p.ID)
+		}
+		delete(wantIDs, p.ID)
+	}
+	for id := range wantIDs {
+		t.Errorf("missing pattern id %q", id)
+	}
+}
+
+func newTestDetector(t *testing.T, window time.Duration) *adapterruntime.TerminalDetector {
+	t.Helper()
+	patterns, err := loadTerminalPatterns()
+	if err != nil {
+		t.Fatalf("loadTerminalPatterns: %v", err)
+	}
+	return adapterruntime.NewTerminalDetector("claude-code", patterns, window, adapterruntime.NopMetrics{})
+}
+
+func TestStructuredRateLimitMatch(t *testing.T) {
+	d := newTestDetector(t, 10*time.Millisecond)
+	entries := []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleAssistant, Content: "I need to pause."},
+	}
+	raws := []json.RawMessage{
+		json.RawMessage(`{"message":{"stop_reason":"rate_limited"}}`),
+	}
+	d.OnBatch("sess1", entries, 1, raws)
+	time.Sleep(15 * time.Millisecond)
+	confirmed := d.Tick(time.Now())
+	if len(confirmed) != 1 {
+		t.Fatalf("expected 1 confirmed match, got %d", len(confirmed))
+	}
+	if confirmed[0].Pattern.ID != "claude_code.api_stop_reason.rate_limited" {
+		t.Fatalf("wrong pattern: %s", confirmed[0].Pattern.ID)
+	}
+}
+
+func TestStructuredMaxTokensInformational(t *testing.T) {
+	d := newTestDetector(t, 10*time.Millisecond)
+	entries := []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleAssistant, Content: "stopped"},
+	}
+	raws := []json.RawMessage{
+		json.RawMessage(`{"message":{"stop_reason":"max_tokens"}}`),
+	}
+	d.OnBatch("sess1", entries, 1, raws)
+	time.Sleep(15 * time.Millisecond)
+	confirmed := d.Tick(time.Now())
+	if len(confirmed) != 0 {
+		t.Fatalf("expected 0 confirmed (informational), got %d", len(confirmed))
+	}
+}
+
+func TestRegexSystemRoleOnly(t *testing.T) {
+	cases := []struct {
+		name      string
+		role      string
+		wantMatch bool
+	}{
+		{"system matches", adapterprotocol.RoleSystem, true},
+		{"assistant does not match", adapterprotocol.RoleAssistant, false},
+		{"user does not match", adapterprotocol.RoleUser, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newTestDetector(t, 10*time.Millisecond)
+			entries := []adapterprotocol.RawEntry{
+				{Role: tc.role, Content: "5-hour limit reached ∙ resets 3pm"},
+			}
+			d.OnBatch("sess-"+tc.role, entries, 1, nil)
+			time.Sleep(15 * time.Millisecond)
+			confirmed := d.Tick(time.Now())
+			if tc.wantMatch && len(confirmed) == 0 {
+				t.Fatalf("expected match, got none")
+			}
+			if !tc.wantMatch && len(confirmed) != 0 {
+				t.Fatalf("expected no match, got %d", len(confirmed))
+			}
+		})
+	}
+}
+
+func TestRegexSubstringPreFilter(t *testing.T) {
+	d := newTestDetector(t, 10*time.Millisecond)
+	entries := []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "hello world"},
+	}
+	d.OnBatch("sess1", entries, 1, nil)
+	time.Sleep(15 * time.Millisecond)
+	confirmed := d.Tick(time.Now())
+	if len(confirmed) != 0 {
+		t.Fatalf("expected no match, got %d", len(confirmed))
+	}
+}
+
+func TestSilenceWindowRevoke(t *testing.T) {
+	d := newTestDetector(t, 1*time.Hour)
+	hit := []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "5-hour limit reached ∙ resets in 3h"},
+	}
+	d.OnBatch("sess1", hit, 1, nil)
+	revoker := []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "continuing normally"},
+	}
+	d.OnBatch("sess1", revoker, 2, nil)
+	confirmed := d.Tick(time.Now().Add(2 * time.Hour))
+	if len(confirmed) != 0 {
+		t.Fatalf("expected revoked (0), got %d", len(confirmed))
+	}
+}
+
+// fixtureLine is the minimal shape we read from testdata JSONL fixtures.
+// Mirrors claudeCodeEntry but kept local to avoid coupling tests to the
+// production type's evolution.
+type fixtureLine struct {
+	Type    string `json:"type"`
+	IsMeta  bool   `json:"isMeta"`
+	Message *struct {
+		Role    string      `json:"role"`
+		Content interface{} `json:"content"`
+	} `json:"message"`
+	Timestamp string                 `json:"timestamp"`
+	Meta      map[string]interface{} `json:"_meta"`
+}
+
+// loadFixture reads a JSONL fixture, skips the leading _meta line, and
+// returns parallel slices of parsed RawEntries and the raw line bytes
+// each entry came from. Lines that yield multiple entries replicate the
+// raw bytes for each — the structured check looks at the same JSON for
+// every entry from that line.
+func loadFixture(t *testing.T, path string) ([]adapterprotocol.RawEntry, []json.RawMessage) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var entries []adapterprotocol.RawEntry
+	var raws []json.RawMessage
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var probe fixtureLine
+		if err := json.Unmarshal([]byte(line), &probe); err != nil {
+			continue
+		}
+		if probe.Meta != nil {
+			continue
+		}
+		parsed, err := parseLine([]byte(line))
+		if err != nil || len(parsed) == 0 {
+			continue
+		}
+		for _, e := range parsed {
+			entries = append(entries, e)
+			raws = append(raws, json.RawMessage(line))
+		}
+	}
+	return entries, raws
+}
+
+func TestGoldenCorpus(t *testing.T) {
+	dir := filepath.Join("testdata", "terminal")
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	for _, f := range files {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".jsonl") {
+			continue
+		}
+		name := f.Name()
+		t.Run(name, func(t *testing.T) {
+			entries, raws := loadFixture(t, filepath.Join(dir, name))
+			if len(entries) == 0 {
+				t.Fatalf("fixture produced no entries")
+			}
+			d := newTestDetector(t, 10*time.Millisecond)
+			// Feed the batch. For revoke-style fixtures the parallel
+			// raws are still aligned per entry, so the detector sees the
+			// same order a live watcher would.
+			d.OnBatch("fixture-session", entries, 1, raws)
+			confirmed := d.Tick(time.Now().Add(1 * time.Hour))
+			isPositive := strings.HasSuffix(name, ".positive.jsonl")
+			if isPositive && len(confirmed) == 0 {
+				t.Fatalf("positive fixture %s: expected match, got none", name)
+			}
+			if !isPositive && len(confirmed) != 0 {
+				t.Fatalf("negative fixture %s: expected no match, got %d", name, len(confirmed))
+			}
+		})
+	}
+}

--- a/cmd/ox-adapter-claude-code/testdata/terminal/api_stop_rate_limited.positive.jsonl
+++ b/cmd/ox-adapter-claude-code/testdata/terminal/api_stop_rate_limited.positive.jsonl
@@ -1,0 +1,2 @@
+{"_meta":{"fabricated":true,"note":"replace with real sample when captured","phase":"phase-2-initial-corpus"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I need to pause here."}],"stop_reason":"rate_limited","model":"claude-opus-4-7"},"timestamp":"2026-05-28T10:00:00.000Z"}

--- a/cmd/ox-adapter-claude-code/testdata/terminal/assistant_quotes_limit.negative.jsonl
+++ b/cmd/ox-adapter-claude-code/testdata/terminal/assistant_quotes_limit.negative.jsonl
@@ -1,0 +1,2 @@
+{"_meta":{"fabricated":true,"note":"replace with real sample when captured","phase":"phase-2-initial-corpus"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"We should add rate limit handling that says 'limit reached' to the user"}],"model":"claude-opus-4-7"},"timestamp":"2026-05-28T10:00:00.000Z"}

--- a/cmd/ox-adapter-claude-code/testdata/terminal/discussion_in_planning.negative.jsonl
+++ b/cmd/ox-adapter-claude-code/testdata/terminal/discussion_in_planning.negative.jsonl
@@ -1,0 +1,2 @@
+{"_meta":{"fabricated":true,"note":"replace with real sample when captured","phase":"phase-2-initial-corpus"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"For the design doc, let's plan how the system should behave when a user has hit your limit — we'll need a retry strategy."}],"model":"claude-opus-4-7"},"timestamp":"2026-05-28T10:00:00.000Z"}

--- a/cmd/ox-adapter-claude-code/testdata/terminal/prior_session_quoted.negative.jsonl
+++ b/cmd/ox-adapter-claude-code/testdata/terminal/prior_session_quoted.negative.jsonl
@@ -1,3 +1,3 @@
 {"_meta":{"fabricated":true,"note":"replace with real sample when captured","phase":"phase-2-initial-corpus"}}
-{"type":"user","isMeta":true,"message":{"role":"user","content":"5-hour limit reached ∙ resets 3pm"},"timestamp":"2026-05-28T10:00:00.000Z"}
+{"type":"user","isMeta":true,"message":{"role":"user","content":"5-hour limit reached · resets 3pm"},"timestamp":"2026-05-28T10:00:00.000Z"}
 {"type":"user","isMeta":true,"message":{"role":"user","content":"continuing normally"},"timestamp":"2026-05-28T10:00:01.000Z"}

--- a/cmd/ox-adapter-claude-code/testdata/terminal/prior_session_quoted.negative.jsonl
+++ b/cmd/ox-adapter-claude-code/testdata/terminal/prior_session_quoted.negative.jsonl
@@ -1,0 +1,3 @@
+{"_meta":{"fabricated":true,"note":"replace with real sample when captured","phase":"phase-2-initial-corpus"}}
+{"type":"user","isMeta":true,"message":{"role":"user","content":"5-hour limit reached ∙ resets 3pm"},"timestamp":"2026-05-28T10:00:00.000Z"}
+{"type":"user","isMeta":true,"message":{"role":"user","content":"continuing normally"},"timestamp":"2026-05-28T10:00:01.000Z"}

--- a/cmd/ox-adapter-claude-code/testdata/terminal/usage_limit_message.positive.jsonl
+++ b/cmd/ox-adapter-claude-code/testdata/terminal/usage_limit_message.positive.jsonl
@@ -1,0 +1,2 @@
+{"_meta":{"fabricated":true,"note":"replace with real sample when captured","phase":"phase-2-initial-corpus"}}
+{"type":"user","isMeta":true,"message":{"role":"user","content":"5-hour limit reached ∙ resets 3pm"},"timestamp":"2026-05-28T10:00:00.000Z"}

--- a/cmd/ox-adapter-claude-code/testdata/terminal/usage_limit_message.positive.jsonl
+++ b/cmd/ox-adapter-claude-code/testdata/terminal/usage_limit_message.positive.jsonl
@@ -1,2 +1,2 @@
 {"_meta":{"fabricated":true,"note":"replace with real sample when captured","phase":"phase-2-initial-corpus"}}
-{"type":"user","isMeta":true,"message":{"role":"user","content":"5-hour limit reached ∙ resets 3pm"},"timestamp":"2026-05-28T10:00:00.000Z"}
+{"type":"user","isMeta":true,"message":{"role":"user","content":"5-hour limit reached · resets 3pm"},"timestamp":"2026-05-28T10:00:00.000Z"}

--- a/cmd/ox-adapter-claude-code/testdata/terminal/usage_limit_relative.positive.jsonl
+++ b/cmd/ox-adapter-claude-code/testdata/terminal/usage_limit_relative.positive.jsonl
@@ -1,0 +1,2 @@
+{"_meta":{"fabricated":true,"note":"replace with real sample when captured","phase":"phase-2-initial-corpus"}}
+{"type":"user","isMeta":true,"message":{"role":"user","content":"You've hit your limit · resets in 3h"},"timestamp":"2026-05-28T10:00:00.000Z"}

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -808,6 +808,12 @@ func outputSessionStopJSON(inst *agentinstance.Instance, state *session.Recordin
 		output.LedgerSessionDir = processResult.LedgerSessionDir
 		output.UploadWarning = processResult.UploadWarning
 		output.DataWarnings = processResult.DataWarnings
+		output.StopReason = processResult.StopReason
+		output.StopDetail = processResult.StopDetail
+		output.StopSource = processResult.StopSource
+		output.StopPatternID = processResult.StopPatternID
+		output.StopResetsAtRaw = processResult.StopResetsAtRaw
+		output.StopResetsAt = processResult.StopResetsAt
 		// async mode: summary_prompt is empty, update guidance
 		if processResult.SummaryPrompt == "" {
 			output.Guidance = "Session stopped and saved. Upload and summary generation happen automatically in the background."

--- a/cmd/ox/session_list.go
+++ b/cmd/ox/session_list.go
@@ -462,6 +462,17 @@ func printSessionRow(t session.SessionInfo, uploaded bool, localUser string) {
 
 	row += sessionSummaryStyle.Render(name)
 
+	// adapter-detected terminal stop reasons (rate limit, quota, generic
+	// terminal_error) surface here as a trailing annotation so a session
+	// list reader can tell at a glance why the agent paused. User-initiated
+	// stops (stopped/canceled/recovered) return "" from FormatStopReason
+	// and do not add the suffix.
+	if !t.Recording {
+		if stopLabel := session.FormatStopReason(t); stopLabel != "" {
+			row += "  " + sessionHydrationStyle.Render("["+stopLabel+"]")
+		}
+	}
+
 	fmt.Println("  " + row)
 
 	// emit a second line with the session's title (or summary snippet) so agents

--- a/internal/daemon/adapter_supervisor.go
+++ b/internal/daemon/adapter_supervisor.go
@@ -98,6 +98,11 @@ type AdapterSupervisor struct {
 	workers     *WorkerTracker
 	adapterCaps map[string][]string // adapter_type -> declared capabilities
 
+	// terminal_error event dispatch (see adapter_supervisor_terminal.go).
+	terminalMu      sync.RWMutex
+	terminalHandler TerminalErrorHandler
+	terminalQueues  map[string]*terminalAgentQueue
+
 	// overridable for testing
 	idleDuration time.Duration
 }
@@ -252,8 +257,15 @@ func (s *AdapterSupervisor) sendRequestLocked(ctx context.Context, proc *Adapter
 		}
 
 		if probe.Event != "" {
-			// push event — log and skip, continue reading for the actual response
-			s.logger.Debug("skipping push event from adapter", "type", proc.adapterType, "event", probe.Event)
+			// push event — decode and dispatch asynchronously so the
+			// read loop never blocks on downstream work (finalize,
+			// metrics, etc.). Unknown event types are still logged.
+			var evt adapterprotocol.Event
+			if err := json.Unmarshal(result.data, &evt); err != nil {
+				s.logger.Warn("decode push event failed", "type", proc.adapterType, "event", probe.Event, "err", err)
+				continue
+			}
+			s.dispatchPushEvent(proc.adapterType, &evt)
 			continue
 		}
 

--- a/internal/daemon/adapter_supervisor_terminal.go
+++ b/internal/daemon/adapter_supervisor_terminal.go
@@ -1,0 +1,167 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+// TerminalErrorHandler is the daemon-side surface for the adapter
+// `terminal_error` push event. The supervisor decodes the wire event,
+// looks up the per-agent queue, and hands the decoded event to the
+// configured handler.
+//
+// Implementations MUST be safe to call from multiple goroutines and
+// MUST NOT block — the per-agent worker pool already serializes events
+// for a single agent, so the handler can assume that two simultaneous
+// HandleTerminalError calls always carry different agent IDs.
+type TerminalErrorHandler interface {
+	HandleTerminalError(ctx context.Context, adapterType string, evt *adapterprotocol.Event)
+}
+
+// SetTerminalErrorHandler wires the daemon-side handler that fires for
+// terminal_error push events. Calling with nil disables routing for the
+// event (events are decoded but dropped); the supervisor never panics
+// regardless. Safe to call before or after Start.
+func (s *AdapterSupervisor) SetTerminalErrorHandler(h TerminalErrorHandler) {
+	s.terminalMu.Lock()
+	defer s.terminalMu.Unlock()
+	s.terminalHandler = h
+}
+
+// dispatchPushEvent routes an adapter push event to the right downstream
+// handler. Always non-blocking on the read loop: terminal events fan out
+// through a per-agent queue + drain goroutine; subagent events go to the
+// existing synchronous HandleWorkerEvent (already cheap); unknown event
+// names are logged.
+func (s *AdapterSupervisor) dispatchPushEvent(adapterType string, evt *adapterprotocol.Event) {
+	if evt == nil {
+		return
+	}
+	switch evt.Event {
+	case adapterprotocol.EventEntries:
+		// Entries events are consumed via the session reader path elsewhere.
+		return
+	case adapterprotocol.EventTerminalError:
+		s.submitTerminalEvent(adapterType, evt)
+	case adapterprotocol.EventSubagentProgress,
+		adapterprotocol.EventSubagentCompleted,
+		adapterprotocol.EventSubagentFailed:
+		// Existing subagent dispatch is cheap and lock-free w.r.t. the read loop.
+		s.HandleWorkerEvent(evt)
+	default:
+		s.logger.Debug("ignoring unknown push event", "type", adapterType, "event", evt.Event)
+	}
+}
+
+// submitTerminalEvent enqueues the event on a per-agent buffered channel
+// and starts a drain goroutine on first use. Per-agent keying ensures
+// finalize for agent A cannot block finalize for agent B and cannot
+// deadlock the read loop by RPC-ing back into the same adapter.
+func (s *AdapterSupervisor) submitTerminalEvent(adapterType string, evt *adapterprotocol.Event) {
+	s.terminalMu.Lock()
+	if s.terminalQueues == nil {
+		s.terminalQueues = make(map[string]*terminalAgentQueue)
+	}
+	q, ok := s.terminalQueues[evt.AgentID]
+	if !ok {
+		q = &terminalAgentQueue{
+			ch:          make(chan terminalDispatch, 16),
+			adapterType: adapterType,
+		}
+		s.terminalQueues[evt.AgentID] = q
+		go s.drainTerminalQueue(evt.AgentID, q)
+	}
+	s.terminalMu.Unlock()
+	select {
+	case q.ch <- terminalDispatch{adapterType: adapterType, evt: evt}:
+	default:
+		// Queue full — extremely unlikely (16 buffered + slow drain).
+		// Drop with a warn rather than blocking the read loop.
+		s.logger.Warn("terminal_event queue full, dropping",
+			"type", adapterType, "agent_id", evt.AgentID)
+	}
+}
+
+// drainTerminalQueue runs one goroutine per agent. It exits after the
+// queue has been idle for terminalQueueIdleTimeout, releasing the map
+// slot. New events for the same agent later spawn a fresh drainer.
+func (s *AdapterSupervisor) drainTerminalQueue(agentID string, q *terminalAgentQueue) {
+	idle := time.NewTimer(terminalQueueIdleTimeout)
+	defer idle.Stop()
+	for {
+		select {
+		case d := <-q.ch:
+			s.terminalMu.RLock()
+			h := s.terminalHandler
+			s.terminalMu.RUnlock()
+			if h == nil {
+				s.logger.Debug("terminal_error received but no handler configured",
+					"type", d.adapterType, "agent_id", d.evt.AgentID)
+			} else {
+				ctx, cancel := context.WithTimeout(context.Background(), terminalHandlerTimeout)
+				h.HandleTerminalError(ctx, d.adapterType, d.evt)
+				cancel()
+			}
+			if !idle.Stop() {
+				select {
+				case <-idle.C:
+				default:
+				}
+			}
+			idle.Reset(terminalQueueIdleTimeout)
+		case <-idle.C:
+			// idle timeout — drop the queue and exit
+			s.terminalMu.Lock()
+			if cur, ok := s.terminalQueues[agentID]; ok && cur == q {
+				delete(s.terminalQueues, agentID)
+			}
+			s.terminalMu.Unlock()
+			return
+		}
+	}
+}
+
+// RLock helper for tests/callers that just want to read the handler.
+func (s *AdapterSupervisor) terminalHandlerSnapshot() TerminalErrorHandler {
+	s.terminalMu.RLock()
+	defer s.terminalMu.RUnlock()
+	return s.terminalHandler
+}
+
+type terminalAgentQueue struct {
+	ch          chan terminalDispatch
+	adapterType string
+}
+
+type terminalDispatch struct {
+	adapterType string
+	evt         *adapterprotocol.Event
+}
+
+const (
+	// terminalQueueIdleTimeout drops the per-agent drain goroutine
+	// after this much idle time. Keeps the supervisor footprint
+	// proportional to active terminal-error traffic, not total agents.
+	terminalQueueIdleTimeout = 30 * time.Second
+
+	// terminalHandlerTimeout caps how long the handler may take per
+	// event. Finalize involves meta.json mutation + best-effort
+	// EndSession RPC; both are fast in practice (well under a second),
+	// so 60s is a generous upper bound that still avoids hung daemons
+	// when the underlying disk or adapter pipe stalls.
+	terminalHandlerTimeout = 60 * time.Second
+)
+
+// terminalSupervisorState holds the fields added to AdapterSupervisor
+// for terminal_error dispatch. Lives in this file rather than the
+// supervisor struct definition so the existing struct stays focused.
+// The actual fields are declared on AdapterSupervisor in
+// adapter_supervisor.go; this comment documents the contract.
+//
+// terminalMu       sync.RWMutex
+// terminalHandler  TerminalErrorHandler
+// terminalQueues   map[string]*terminalAgentQueue
+var _ sync.RWMutex

--- a/internal/daemon/adapter_supervisor_terminal_test.go
+++ b/internal/daemon/adapter_supervisor_terminal_test.go
@@ -1,0 +1,132 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+// recordingTerminalHandler captures HandleTerminalError calls for assertion.
+type recordingTerminalHandler struct {
+	mu     sync.Mutex
+	events []*adapterprotocol.Event
+	types  []string
+}
+
+func (h *recordingTerminalHandler) HandleTerminalError(_ context.Context, adapterType string, evt *adapterprotocol.Event) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.events = append(h.events, evt)
+	h.types = append(h.types, adapterType)
+}
+
+func (h *recordingTerminalHandler) seen() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.events)
+}
+
+func newSilentSupervisor() *AdapterSupervisor {
+	return NewAdapterSupervisor(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+}
+
+func TestDispatch_RoutesTerminalErrorToHandler(t *testing.T) {
+	s := newSilentSupervisor()
+	h := &recordingTerminalHandler{}
+	s.SetTerminalErrorHandler(h)
+
+	data, _ := json.Marshal(adapterprotocol.TerminalErrorData{
+		Reason: "rate_limited", Source: "regex", PatternID: "p1",
+	})
+	evt := &adapterprotocol.Event{
+		Event:   adapterprotocol.EventTerminalError,
+		AgentID: "agent-1",
+		Data:    data,
+	}
+	s.dispatchPushEvent("claude-code", evt)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && h.seen() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if h.seen() != 1 {
+		t.Fatalf("expected 1 terminal event, got %d", h.seen())
+	}
+	if h.types[0] != "claude-code" {
+		t.Errorf("adapter type=%q want %q", h.types[0], "claude-code")
+	}
+}
+
+func TestDispatch_TerminalErrorPerAgentIsolation(t *testing.T) {
+	s := newSilentSupervisor()
+	h := &recordingTerminalHandler{}
+	s.SetTerminalErrorHandler(h)
+
+	for _, agent := range []string{"a", "b", "c"} {
+		data, _ := json.Marshal(adapterprotocol.TerminalErrorData{Reason: "rate_limited"})
+		s.dispatchPushEvent("claude-code", &adapterprotocol.Event{
+			Event:   adapterprotocol.EventTerminalError,
+			AgentID: agent,
+			Data:    data,
+		})
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && h.seen() < 3 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if h.seen() != 3 {
+		t.Fatalf("expected 3 events across 3 agents, got %d", h.seen())
+	}
+}
+
+func TestDispatch_UnknownEventNoOp(t *testing.T) {
+	s := newSilentSupervisor()
+	h := &recordingTerminalHandler{}
+	s.SetTerminalErrorHandler(h)
+	// Future-event-name passes through without crash / without invoking handler.
+	s.dispatchPushEvent("claude-code", &adapterprotocol.Event{
+		Event:   "future_event_v2",
+		AgentID: "agent-1",
+		Data:    json.RawMessage(`{}`),
+	})
+	// Settle: drain has 30s idle timer but handler should NEVER be called.
+	time.Sleep(50 * time.Millisecond)
+	if h.seen() != 0 {
+		t.Errorf("unknown event should not invoke handler, got %d", h.seen())
+	}
+}
+
+func TestDispatch_EntriesEventIgnored(t *testing.T) {
+	s := newSilentSupervisor()
+	h := &recordingTerminalHandler{}
+	s.SetTerminalErrorHandler(h)
+	s.dispatchPushEvent("claude-code", &adapterprotocol.Event{
+		Event:   adapterprotocol.EventEntries,
+		AgentID: "agent-1",
+		Data:    json.RawMessage(`{}`),
+	})
+	time.Sleep(50 * time.Millisecond)
+	if h.seen() != 0 {
+		t.Errorf("entries event should not invoke terminal handler, got %d", h.seen())
+	}
+}
+
+func TestDispatch_NoHandlerSilentlyDrops(t *testing.T) {
+	s := newSilentSupervisor()
+	// No handler set — must not panic.
+	data, _ := json.Marshal(adapterprotocol.TerminalErrorData{Reason: "rate_limited"})
+	s.dispatchPushEvent("claude-code", &adapterprotocol.Event{
+		Event:   adapterprotocol.EventTerminalError,
+		AgentID: "agent-1",
+		Data:    data,
+	})
+	// no assertion needed — we just must not crash. Settle for goroutine.
+	time.Sleep(50 * time.Millisecond)
+}

--- a/internal/daemon/terminal_handler.go
+++ b/internal/daemon/terminal_handler.go
@@ -1,0 +1,353 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/sageox/ox/internal/fileutil"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+// terminalMarkerFile is the write-ahead marker name. Lives inside the
+// session dir alongside meta.json. Its presence at daemon start signals
+// that a terminal-error finalize was in flight when the previous daemon
+// process exited — RecoverPendingTerminalFinalize replays it.
+const terminalMarkerFile = ".terminal_pending.json"
+
+// terminalAuditFile is the daemon-wide append-only audit log of every
+// terminal-error event that progressed past the precedence gate. One
+// JSONL record per finalize attempt; never rotated by the daemon
+// (operator's responsibility if it ever gets large).
+const terminalAuditFile = "terminal_events.jsonl"
+
+// terminalMaxDetail caps StopDetail length when it is persisted to
+// meta.json or the audit log. Defense-in-depth against an adapter that
+// somehow bypasses the wire-side MaxRawMessageBytes cap.
+const terminalMaxDetail = 512
+
+// auditTruncateLen caps the raw_message field copied into the audit log.
+// Smaller than terminalMaxDetail because audit lines accumulate forever
+// and one row per terminal event is plenty of forensic context.
+const auditTruncateLen = 256
+
+// EndSessionRPC is the supervisor surface the handler uses to ask the
+// adapter to clean up. Pulled out as an interface so tests can stub it.
+type EndSessionRPC interface {
+	EndSession(adapterType, agentID string) error
+}
+
+// DefaultTerminalErrorHandler is the production TerminalErrorHandler.
+// It resolves session paths through the daemon's recording-state
+// lookup, stamps terminal-stop metadata into meta.json via the
+// existing MutateSessionMeta flock-protected RMW, and best-effort
+// sends EndSession to the adapter.
+//
+// Wire it via AdapterSupervisor.SetTerminalErrorHandler at daemon start.
+type DefaultTerminalErrorHandler struct {
+	ProjectRoot string
+	LedgerPath  string
+	Logger      *slog.Logger
+	Supervisor  EndSessionRPC
+
+	// auditMu serializes audit-log appends to avoid interleaved JSONL
+	// lines when multiple agents finalize simultaneously. The file is
+	// O_APPEND-opened (so writes are atomic up to PIPE_BUF) but we
+	// don't want even single-line interleaving in operator-facing logs.
+	auditMu sync.Mutex
+}
+
+// NewDefaultTerminalErrorHandler constructs a handler with the bare
+// minimum wiring needed for production. Supervisor may be nil — in
+// that case EndSession is skipped (handler still stamps meta and writes
+// audit). Useful for tests and the orphan-recovery path on startup.
+func NewDefaultTerminalErrorHandler(projectRoot, ledgerPath string, logger *slog.Logger, sup EndSessionRPC) *DefaultTerminalErrorHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &DefaultTerminalErrorHandler{
+		ProjectRoot: projectRoot,
+		LedgerPath:  ledgerPath,
+		Logger:      logger,
+		Supervisor:  sup,
+	}
+}
+
+// HandleTerminalError is the TerminalErrorHandler implementation.
+func (h *DefaultTerminalErrorHandler) HandleTerminalError(ctx context.Context, adapterType string, evt *adapterprotocol.Event) {
+	if evt == nil {
+		return
+	}
+	var data adapterprotocol.TerminalErrorData
+	if err := json.Unmarshal(evt.Data, &data); err != nil {
+		h.Logger.Warn("decode terminal_error data failed",
+			"adapter", adapterType, "agent_id", evt.AgentID, "err", err)
+		return
+	}
+	sessionPath, err := h.resolveSessionPath(evt.AgentID)
+	if err != nil {
+		h.Logger.Warn("terminal_error: cannot resolve session path",
+			"adapter", adapterType, "agent_id", evt.AgentID, "err", err)
+		return
+	}
+	if err := h.processTerminalEvent(ctx, adapterType, evt.AgentID, sessionPath, data, true); err != nil {
+		h.Logger.Warn("terminal_error finalize failed",
+			"adapter", adapterType, "agent_id", evt.AgentID, "path", sessionPath, "err", err)
+	}
+}
+
+// resolveSessionPath looks up the recording state by agent ID and
+// returns the on-disk session directory.
+func (h *DefaultTerminalErrorHandler) resolveSessionPath(agentID string) (string, error) {
+	if agentID == "" {
+		return "", errors.New("empty agent_id")
+	}
+	if h.ProjectRoot == "" {
+		return "", errors.New("handler has no project root configured")
+	}
+	state, err := session.LoadRecordingStateForAgent(h.ProjectRoot, agentID)
+	if err != nil {
+		return "", fmt.Errorf("load recording state: %w", err)
+	}
+	if state == nil || state.SessionPath == "" {
+		return "", fmt.Errorf("recording state missing SessionPath for agent %q", agentID)
+	}
+	return state.SessionPath, nil
+}
+
+// processTerminalEvent runs the WAL + precedence-gated finalize for one
+// terminal_error event. Shared between the live event path and the
+// startup recovery sweep; writeMarker is false on recovery because the
+// marker already exists on disk.
+func (h *DefaultTerminalErrorHandler) processTerminalEvent(
+	ctx context.Context,
+	adapterType, agentID, sessionPath string,
+	data adapterprotocol.TerminalErrorData,
+	writeMarker bool,
+) error {
+	if writeMarker {
+		if err := h.writeMarker(sessionPath, adapterType, data); err != nil {
+			return fmt.Errorf("write marker: %w", err)
+		}
+	}
+	markerPath := filepath.Join(sessionPath, terminalMarkerFile)
+
+	// Precedence gate. Read meta first — if a user-initiated stop has
+	// already won, finalize is a no-op (still drop the marker so we
+	// stop replaying it on every restart).
+	existing, metaErr := lfs.ReadSessionMeta(sessionPath)
+	if metaErr != nil && !errors.Is(metaErr, fs.ErrNotExist) {
+		return fmt.Errorf("read existing meta: %w", metaErr)
+	}
+	if existing != nil && !session.CanTransitionStopReason(existing.StopReason, data.Reason) {
+		h.Logger.Info("terminal_error skipped: user-stop precedence",
+			"adapter", adapterType, "agent_id", agentID,
+			"existing_reason", existing.StopReason, "incoming_reason", data.Reason)
+		_ = os.Remove(markerPath)
+		return nil
+	}
+
+	detail := truncate(data.RawMessage, terminalMaxDetail)
+	if err := stampTerminalStop(ctx, sessionPath, data, detail); err != nil {
+		return fmt.Errorf("stamp meta: %w", err)
+	}
+
+	// Best-effort signal to the adapter that it can clean up. Adapter
+	// may already be dead (the whole reason we're here) — log and move
+	// on either way; the finalize stamp above is the load-bearing step.
+	if h.Supervisor != nil {
+		if err := h.Supervisor.EndSession(adapterType, agentID); err != nil {
+			h.Logger.Debug("terminal_error EndSession best-effort RPC failed",
+				"adapter", adapterType, "agent_id", agentID, "err", err)
+		}
+	}
+
+	if err := os.Remove(markerPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		h.Logger.Warn("terminal_error: delete marker failed",
+			"adapter", adapterType, "agent_id", agentID, "path", markerPath, "err", err)
+	}
+
+	h.writeAudit(ctx, adapterType, agentID, sessionPath, data, detail)
+	return nil
+}
+
+func (h *DefaultTerminalErrorHandler) writeMarker(sessionPath, adapterType string, data adapterprotocol.TerminalErrorData) error {
+	if err := os.MkdirAll(sessionPath, 0o755); err != nil {
+		return err
+	}
+	rec := struct {
+		AdapterType string                              `json:"adapter_type"`
+		Data        adapterprotocol.TerminalErrorData   `json:"data"`
+		WrittenAt   time.Time                           `json:"written_at"`
+	}{
+		AdapterType: adapterType,
+		Data:        data,
+		WrittenAt:   time.Now().UTC(),
+	}
+	payload, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return err
+	}
+	return fileutil.AtomicWriteBytes(filepath.Join(sessionPath, terminalMarkerFile), payload, 0o644)
+}
+
+// stampTerminalStop mutates meta.json under the standard flock so the
+// daemon and CLI never lose each other's writes. Uses the existing
+// SessionMetaBuilder.TerminalStop helper.
+func stampTerminalStop(ctx context.Context, sessionPath string, data adapterprotocol.TerminalErrorData, detail string) error {
+	return lfs.MutateSessionMeta(ctx, sessionPath, func(meta *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+		if meta == nil {
+			// No meta.json yet — refuse to invent one from scratch in
+			// the terminal path. The session was never committed and
+			// the user probably already cleaned it up; the marker
+			// being deleted by the caller is the right outcome.
+			return nil, nil
+		}
+		meta.StopReason = data.Reason
+		meta.StopSource = data.Source
+		meta.StopPatternID = data.PatternID
+		meta.StopDetail = detail
+		meta.StopResetsAtRaw = data.ResetsAtRaw
+		meta.StopResetsAt = data.ResetsAt
+		return meta, nil
+	})
+}
+
+// writeAudit appends a single JSONL row to <ledger>/.sageox/audit/terminal_events.jsonl.
+// Best-effort: logs on failure but never fails the finalize call.
+func (h *DefaultTerminalErrorHandler) writeAudit(
+	ctx context.Context,
+	adapterType, agentID, sessionPath string,
+	data adapterprotocol.TerminalErrorData,
+	detail string,
+) {
+	if h.LedgerPath == "" {
+		return
+	}
+	auditDir := filepath.Join(h.LedgerPath, ".sageox", "audit")
+	if err := os.MkdirAll(auditDir, 0o755); err != nil {
+		h.Logger.Warn("terminal_error audit: mkdir failed", "err", err)
+		return
+	}
+	auditPath := filepath.Join(auditDir, terminalAuditFile)
+	record := map[string]any{
+		"timestamp":    time.Now().UTC().Format(time.RFC3339Nano),
+		"session_path": sessionPath,
+		"agent_id":     agentID,
+		"adapter_type": adapterType,
+		"pattern_id":   data.PatternID,
+		"source":       data.Source,
+		"reason":       data.Reason,
+		"raw_message":  truncate(data.RawMessage, auditTruncateLen),
+		"detected_at":  data.DetectedAt.UTC().Format(time.RFC3339Nano),
+		"confirmed_at": data.ConfirmedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if data.ResetsAt != nil {
+		record["resets_at"] = data.ResetsAt.UTC().Format(time.RFC3339Nano)
+	}
+	if data.ResetsAtRaw != "" {
+		record["resets_at_raw"] = data.ResetsAtRaw
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		h.Logger.Warn("terminal_error audit: marshal failed", "err", err)
+		return
+	}
+	line = append(line, '\n')
+
+	h.auditMu.Lock()
+	defer h.auditMu.Unlock()
+	f, err := os.OpenFile(auditPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		h.Logger.Warn("terminal_error audit: open failed", "err", err)
+		return
+	}
+	defer f.Close()
+	if _, err := f.Write(line); err != nil {
+		h.Logger.Warn("terminal_error audit: write failed", "err", err)
+	}
+}
+
+// RecoverPendingTerminalFinalize re-runs finalize for every session
+// that has a `.terminal_pending.json` marker but no committed StopReason
+// at the marker's level. Idempotent: deletes markers whose underlying
+// session has already advanced past their reason.
+//
+// Call this from the daemon's startup recovery path (alongside the
+// existing orphan-recovery sweep). It is safe to call concurrently
+// with live event handling — finalize for a given session is gated
+// by MutateSessionMeta's flock.
+func (h *DefaultTerminalErrorHandler) RecoverPendingTerminalFinalize(ctx context.Context) error {
+	if h.LedgerPath == "" {
+		return errors.New("ledger path not configured")
+	}
+	sessionsDir := filepath.Join(h.LedgerPath, "sessions")
+	matches, err := filepath.Glob(filepath.Join(sessionsDir, "*", terminalMarkerFile))
+	if err != nil {
+		return fmt.Errorf("glob terminal markers: %w", err)
+	}
+	for _, markerPath := range matches {
+		sessionPath := filepath.Dir(markerPath)
+		raw, readErr := os.ReadFile(markerPath)
+		if readErr != nil {
+			h.Logger.Warn("terminal_error recovery: read marker failed",
+				"path", markerPath, "err", readErr)
+			continue
+		}
+		var rec struct {
+			AdapterType string                              `json:"adapter_type"`
+			Data        adapterprotocol.TerminalErrorData   `json:"data"`
+			WrittenAt   time.Time                           `json:"written_at"`
+		}
+		if err := json.Unmarshal(raw, &rec); err != nil {
+			h.Logger.Warn("terminal_error recovery: decode marker failed",
+				"path", markerPath, "err", err)
+			// Drop the unparseable marker so we stop tripping over it.
+			_ = os.Remove(markerPath)
+			continue
+		}
+		// Use the marker's recorded agent_id if present (the wire payload
+		// did not include it explicitly, but the supervisor knows it at
+		// dispatch time — for the recovery path we infer from the
+		// session dir's recording state).
+		agentID := h.agentIDForSession(sessionPath)
+		if err := h.processTerminalEvent(ctx, rec.AdapterType, agentID, sessionPath, rec.Data, false); err != nil {
+			h.Logger.Warn("terminal_error recovery: replay failed",
+				"path", sessionPath, "err", err)
+		}
+	}
+	return nil
+}
+
+// agentIDForSession reads .recording.json from the session dir to
+// recover the agent ID. Returns "" if not found; the recovery path
+// still completes the finalize stamp + audit write without it.
+func (h *DefaultTerminalErrorHandler) agentIDForSession(sessionPath string) string {
+	data, err := os.ReadFile(filepath.Join(sessionPath, ".recording.json"))
+	if err != nil {
+		return ""
+	}
+	var state struct {
+		AgentID string `json:"agent_id"`
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return ""
+	}
+	return state.AgentID
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/daemon/terminal_handler.go
+++ b/internal/daemon/terminal_handler.go
@@ -141,24 +141,24 @@ func (h *DefaultTerminalErrorHandler) processTerminalEvent(
 	}
 	markerPath := filepath.Join(sessionPath, terminalMarkerFile)
 
-	// Precedence gate. Read meta first — if a user-initiated stop has
-	// already won, finalize is a no-op (still drop the marker so we
-	// stop replaying it on every restart).
-	existing, metaErr := lfs.ReadSessionMeta(sessionPath)
-	if metaErr != nil && !errors.Is(metaErr, fs.ErrNotExist) {
-		return fmt.Errorf("read existing meta: %w", metaErr)
+	// Stamp the terminal-stop metadata. The precedence gate runs INSIDE
+	// the flocked read-modify-write so the "is this transition allowed?"
+	// decision and the write are atomic — a concurrent user-stop can't
+	// slip in between a separate pre-check and the write (TOCTOU). When
+	// the transition is disallowed (user-stop already won) or there is no
+	// meta.json to stamp, applied is false and we drop the marker so the
+	// recovery sweep stops replaying it.
+	detail := truncate(data.RawMessage, terminalMaxDetail)
+	applied, existingReason, err := stampTerminalStop(ctx, sessionPath, data, detail)
+	if err != nil {
+		return fmt.Errorf("stamp meta: %w", err)
 	}
-	if existing != nil && !session.CanTransitionStopReason(existing.StopReason, data.Reason) {
-		h.Logger.Info("terminal_error skipped: user-stop precedence",
+	if !applied {
+		h.Logger.Info("terminal_error skipped: precedence or missing meta",
 			"adapter", adapterType, "agent_id", agentID,
-			"existing_reason", existing.StopReason, "incoming_reason", data.Reason)
+			"existing_reason", existingReason, "incoming_reason", data.Reason)
 		_ = os.Remove(markerPath)
 		return nil
-	}
-
-	detail := truncate(data.RawMessage, terminalMaxDetail)
-	if err := stampTerminalStop(ctx, sessionPath, data, detail); err != nil {
-		return fmt.Errorf("stamp meta: %w", err)
 	}
 
 	// Best-effort signal to the adapter that it can clean up. Adapter
@@ -185,9 +185,9 @@ func (h *DefaultTerminalErrorHandler) writeMarker(sessionPath, adapterType strin
 		return err
 	}
 	rec := struct {
-		AdapterType string                              `json:"adapter_type"`
-		Data        adapterprotocol.TerminalErrorData   `json:"data"`
-		WrittenAt   time.Time                           `json:"written_at"`
+		AdapterType string                            `json:"adapter_type"`
+		Data        adapterprotocol.TerminalErrorData `json:"data"`
+		WrittenAt   time.Time                         `json:"written_at"`
 	}{
 		AdapterType: adapterType,
 		Data:        data,
@@ -201,10 +201,17 @@ func (h *DefaultTerminalErrorHandler) writeMarker(sessionPath, adapterType strin
 }
 
 // stampTerminalStop mutates meta.json under the standard flock so the
-// daemon and CLI never lose each other's writes. Uses the existing
-// SessionMetaBuilder.TerminalStop helper.
-func stampTerminalStop(ctx context.Context, sessionPath string, data adapterprotocol.TerminalErrorData, detail string) error {
-	return lfs.MutateSessionMeta(ctx, sessionPath, func(meta *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+// daemon and CLI never lose each other's writes, AND runs the stop-reason
+// precedence gate inside the same locked section so the check and write
+// are atomic. Returns:
+//
+//   - applied: true only when the metadata was actually written (meta
+//     existed and the transition was allowed).
+//   - existingReason: the StopReason found on disk (for logging when the
+//     transition was blocked); "" when there was no meta.json.
+//   - err: any error from the locked RMW.
+func stampTerminalStop(ctx context.Context, sessionPath string, data adapterprotocol.TerminalErrorData, detail string) (applied bool, existingReason string, err error) {
+	err = lfs.MutateSessionMeta(ctx, sessionPath, func(meta *lfs.SessionMeta) (*lfs.SessionMeta, error) {
 		if meta == nil {
 			// No meta.json yet — refuse to invent one from scratch in
 			// the terminal path. The session was never committed and
@@ -212,14 +219,23 @@ func stampTerminalStop(ctx context.Context, sessionPath string, data adapterprot
 			// being deleted by the caller is the right outcome.
 			return nil, nil
 		}
+		existingReason = meta.StopReason
+		// Atomic precedence gate: a user-initiated stop committed between
+		// the caller's decision to finalize and this locked section still
+		// wins, because we re-check here under the lock.
+		if !session.CanTransitionStopReason(meta.StopReason, data.Reason) {
+			return nil, nil // no write — caller treats applied=false as "skipped"
+		}
 		meta.StopReason = data.Reason
 		meta.StopSource = data.Source
 		meta.StopPatternID = data.PatternID
 		meta.StopDetail = detail
 		meta.StopResetsAtRaw = data.ResetsAtRaw
 		meta.StopResetsAt = data.ResetsAt
+		applied = true
 		return meta, nil
 	})
+	return applied, existingReason, err
 }
 
 // writeAudit appends a single JSONL row to <ledger>/.sageox/audit/terminal_events.jsonl.
@@ -304,9 +320,9 @@ func (h *DefaultTerminalErrorHandler) RecoverPendingTerminalFinalize(ctx context
 			continue
 		}
 		var rec struct {
-			AdapterType string                              `json:"adapter_type"`
-			Data        adapterprotocol.TerminalErrorData   `json:"data"`
-			WrittenAt   time.Time                           `json:"written_at"`
+			AdapterType string                            `json:"adapter_type"`
+			Data        adapterprotocol.TerminalErrorData `json:"data"`
+			WrittenAt   time.Time                         `json:"written_at"`
 		}
 		if err := json.Unmarshal(raw, &rec); err != nil {
 			h.Logger.Warn("terminal_error recovery: decode marker failed",

--- a/internal/daemon/terminal_handler_test.go
+++ b/internal/daemon/terminal_handler_test.go
@@ -1,0 +1,286 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+func seedSessionMeta(t *testing.T, sessionPath string, stopReason string) {
+	t.Helper()
+	if err := os.MkdirAll(sessionPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	meta := lfs.NewSessionMeta("test-session", "tester", "Ox1234", "claude-code", time.Now()).
+		StopReason(stopReason).
+		Build()
+	if err := lfs.WriteSessionMetaOnly(sessionPath, meta); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+}
+
+func newTestHandler(t *testing.T, ledgerPath string) *DefaultTerminalErrorHandler {
+	t.Helper()
+	return &DefaultTerminalErrorHandler{
+		LedgerPath: ledgerPath,
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestProcessTerminalEvent_StampsMeta(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "s1")
+	seedSessionMeta(t, sessionPath, "")
+
+	h := newTestHandler(t, root)
+	resetsAt := time.Now().Add(3 * time.Hour).UTC()
+	data := adapterprotocol.TerminalErrorData{
+		Reason:      "rate_limited",
+		Source:      "regex",
+		PatternID:   "claude_code.system_error.usage_limit",
+		RawMessage:  "5-hour limit reached resets 3pm",
+		ResetsAtRaw: "3pm",
+		ResetsAt:    &resetsAt,
+		DetectedAt:  time.Now().Add(-30 * time.Second).UTC(),
+		ConfirmedAt: time.Now().UTC(),
+	}
+	if err := h.processTerminalEvent(context.Background(), "claude-code", "agent-1", sessionPath, data, true); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+
+	meta, err := lfs.ReadSessionMeta(sessionPath)
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	if meta.StopReason != "rate_limited" {
+		t.Errorf("StopReason=%q want rate_limited", meta.StopReason)
+	}
+	if meta.StopSource != "regex" {
+		t.Errorf("StopSource=%q want regex", meta.StopSource)
+	}
+	if meta.StopPatternID != "claude_code.system_error.usage_limit" {
+		t.Errorf("StopPatternID=%q", meta.StopPatternID)
+	}
+	if meta.StopDetail == "" {
+		t.Errorf("StopDetail empty")
+	}
+	if meta.StopResetsAtRaw != "3pm" {
+		t.Errorf("StopResetsAtRaw=%q want 3pm", meta.StopResetsAtRaw)
+	}
+	if meta.StopResetsAt == nil {
+		t.Errorf("StopResetsAt nil")
+	}
+	// Marker must be deleted after success.
+	if _, err := os.Stat(filepath.Join(sessionPath, terminalMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("marker not deleted: err=%v", err)
+	}
+}
+
+func TestProcessTerminalEvent_PrecedenceGate(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "user-stopped")
+	seedSessionMeta(t, sessionPath, "stopped") // user already stopped
+
+	h := newTestHandler(t, root)
+	data := adapterprotocol.TerminalErrorData{
+		Reason:     "rate_limited",
+		Source:     "regex",
+		PatternID:  "p1",
+		RawMessage: "limit reached",
+	}
+	if err := h.processTerminalEvent(context.Background(), "claude-code", "agent-1", sessionPath, data, true); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	meta, err := lfs.ReadSessionMeta(sessionPath)
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	// user-stop wins — terminal-error fields must NOT have been written
+	if meta.StopReason != "stopped" {
+		t.Errorf("StopReason=%q want stopped (user-stop precedence)", meta.StopReason)
+	}
+	if meta.StopSource != "" {
+		t.Errorf("StopSource leaked despite precedence gate: %q", meta.StopSource)
+	}
+	if meta.StopPatternID != "" {
+		t.Errorf("StopPatternID leaked: %q", meta.StopPatternID)
+	}
+	// Marker must STILL be deleted so we don't replay on every restart.
+	if _, err := os.Stat(filepath.Join(sessionPath, terminalMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("marker not deleted after precedence skip: err=%v", err)
+	}
+}
+
+func TestProcessTerminalEvent_TruncatesDetail(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "trunc")
+	seedSessionMeta(t, sessionPath, "")
+
+	h := newTestHandler(t, root)
+	big := strings.Repeat("x", terminalMaxDetail+200)
+	data := adapterprotocol.TerminalErrorData{
+		Reason:     "rate_limited",
+		Source:     "regex",
+		PatternID:  "p1",
+		RawMessage: big,
+	}
+	if err := h.processTerminalEvent(context.Background(), "claude-code", "agent-1", sessionPath, data, true); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	meta, _ := lfs.ReadSessionMeta(sessionPath)
+	if len(meta.StopDetail) > terminalMaxDetail {
+		t.Errorf("StopDetail len=%d exceeds cap %d", len(meta.StopDetail), terminalMaxDetail)
+	}
+}
+
+func TestProcessTerminalEvent_WritesMarkerBeforeMeta(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "marker-first")
+	seedSessionMeta(t, sessionPath, "")
+
+	h := newTestHandler(t, root)
+	data := adapterprotocol.TerminalErrorData{Reason: "rate_limited", Source: "regex"}
+	if err := h.writeMarker(sessionPath, "claude-code", data); err != nil {
+		t.Fatalf("writeMarker: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessionPath, terminalMarkerFile)); err != nil {
+		t.Fatalf("marker not present after writeMarker: %v", err)
+	}
+	// Decode and assert the marker carries the wire data.
+	raw, _ := os.ReadFile(filepath.Join(sessionPath, terminalMarkerFile))
+	var rec struct {
+		AdapterType string                            `json:"adapter_type"`
+		Data        adapterprotocol.TerminalErrorData `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		t.Fatalf("marker decode: %v", err)
+	}
+	if rec.AdapterType != "claude-code" || rec.Data.Reason != "rate_limited" {
+		t.Errorf("marker contents wrong: %+v", rec)
+	}
+}
+
+func TestRecoverPendingTerminalFinalize_ReplaysMarker(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "abandoned")
+	seedSessionMeta(t, sessionPath, "")
+
+	h := newTestHandler(t, root)
+	// Simulate the previous daemon writing a marker and then crashing.
+	data := adapterprotocol.TerminalErrorData{
+		Reason:    "rate_limited",
+		Source:    "regex",
+		PatternID: "p1",
+	}
+	if err := h.writeMarker(sessionPath, "claude-code", data); err != nil {
+		t.Fatalf("writeMarker: %v", err)
+	}
+
+	if err := h.RecoverPendingTerminalFinalize(context.Background()); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	meta, _ := lfs.ReadSessionMeta(sessionPath)
+	if meta.StopReason != "rate_limited" {
+		t.Errorf("expected StopReason rate_limited after recovery, got %q", meta.StopReason)
+	}
+	if _, err := os.Stat(filepath.Join(sessionPath, terminalMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("marker not cleaned up after recovery")
+	}
+}
+
+func TestRecoverPendingTerminalFinalize_NoOpAlreadyFinalized(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "user-quit")
+	seedSessionMeta(t, sessionPath, "stopped")
+
+	h := newTestHandler(t, root)
+	data := adapterprotocol.TerminalErrorData{Reason: "rate_limited"}
+	if err := h.writeMarker(sessionPath, "claude-code", data); err != nil {
+		t.Fatalf("writeMarker: %v", err)
+	}
+
+	if err := h.RecoverPendingTerminalFinalize(context.Background()); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	meta, _ := lfs.ReadSessionMeta(sessionPath)
+	if meta.StopReason != "stopped" {
+		t.Errorf("user-stop must survive recovery; got %q", meta.StopReason)
+	}
+	if _, err := os.Stat(filepath.Join(sessionPath, terminalMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("marker not cleaned up on no-op recovery")
+	}
+}
+
+func TestRecoverPendingTerminalFinalize_DropsCorruptMarker(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "corrupt")
+	if err := os.MkdirAll(sessionPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionPath, terminalMarkerFile), []byte("not json"), 0o644); err != nil {
+		t.Fatalf("seed corrupt marker: %v", err)
+	}
+	h := newTestHandler(t, root)
+	if err := h.RecoverPendingTerminalFinalize(context.Background()); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessionPath, terminalMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("corrupt marker not cleaned up")
+	}
+}
+
+func TestProcessTerminalEvent_AuditLog(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "audit")
+	seedSessionMeta(t, sessionPath, "")
+
+	h := newTestHandler(t, root)
+	data := adapterprotocol.TerminalErrorData{
+		Reason:     "rate_limited",
+		Source:     "regex",
+		PatternID:  "claude_code.system_error.usage_limit",
+		RawMessage: "5-hour limit reached resets 3pm",
+		DetectedAt: time.Now().UTC(),
+		ConfirmedAt: time.Now().UTC(),
+	}
+	if err := h.processTerminalEvent(context.Background(), "claude-code", "Ox1234", sessionPath, data, true); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	auditPath := filepath.Join(root, ".sageox", "audit", terminalAuditFile)
+	raw, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit: %v", err)
+	}
+	if !strings.Contains(string(raw), `"reason":"rate_limited"`) {
+		t.Errorf("audit missing reason field: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"agent_id":"Ox1234"`) {
+		t.Errorf("audit missing agent_id: %s", raw)
+	}
+}
+
+func TestProcessTerminalEvent_NoMetaIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(root, "sessions", "no-meta")
+	if err := os.MkdirAll(sessionPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	h := newTestHandler(t, root)
+	data := adapterprotocol.TerminalErrorData{Reason: "rate_limited", Source: "regex"}
+	if err := h.processTerminalEvent(context.Background(), "claude-code", "agent-1", sessionPath, data, true); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	// no meta.json before, no meta.json after — handler refuses to invent one.
+	if _, err := os.Stat(filepath.Join(sessionPath, "meta.json")); !os.IsNotExist(err) {
+		t.Errorf("handler should not synthesize meta.json from scratch")
+	}
+}

--- a/internal/doctor/checks/registry.go
+++ b/internal/doctor/checks/registry.go
@@ -21,6 +21,7 @@ func All(d Deps) []doctor.Check {
 		NewSageoxDirectoryCheck(d.Git),
 		NewGitignoreCheck(d.Git, d.FS),
 		NewOxInPathCheck(d.LookPath),
+		NewTerminalPatternsCheck(),
 	}
 }
 

--- a/internal/doctor/checks/registry_test.go
+++ b/internal/doctor/checks/registry_test.go
@@ -20,7 +20,7 @@ func TestAll_ReturnsAllChecks(t *testing.T) {
 		LookPath: lookPath,
 	})
 
-	require.Len(t, allChecks, 3, "expected 3 registered checks")
+	require.Len(t, allChecks, 4, "expected 4 registered checks")
 
 	// verify each check has a unique, non-empty name
 	names := make(map[string]bool)
@@ -35,6 +35,7 @@ func TestAll_ReturnsAllChecks(t *testing.T) {
 	assert.True(t, names[".sageox/ directory"], "missing SageoxDirectoryCheck")
 	assert.True(t, names[".gitignore"], "missing GitignoreCheck")
 	assert.True(t, names["ox in PATH"], "missing OxInPathCheck")
+	assert.True(t, names["terminal-patterns framework"], "missing TerminalPatternsCheck")
 }
 
 func TestAll_NilDeps(t *testing.T) {
@@ -42,7 +43,7 @@ func TestAll_NilDeps(t *testing.T) {
 	// prevents: nil deps causes panic — All should handle gracefully
 	// Git=nil will be passed through to checks; OxInPathCheck handles nil lookPath
 	allChecks := All(Deps{})
-	assert.Len(t, allChecks, 3)
+	assert.Len(t, allChecks, 4)
 }
 
 func TestAll_EachCheckHasCategory(t *testing.T) {
@@ -62,10 +63,11 @@ func TestByName_ReturnsMapWithAllChecks(t *testing.T) {
 	git := &mockGitRunner{results: map[string]mockGitResult{}}
 	m := ByName(Deps{Git: git})
 
-	require.Len(t, m, 3, "ByName should return all checks")
+	require.Len(t, m, 4, "ByName should return all checks")
 	assert.NotNil(t, m[".sageox/ directory"], "missing SageoxDirectoryCheck")
 	assert.NotNil(t, m[".gitignore"], "missing GitignoreCheck")
 	assert.NotNil(t, m["ox in PATH"], "missing OxInPathCheck")
+	assert.NotNil(t, m["terminal-patterns framework"], "missing TerminalPatternsCheck")
 }
 
 func TestByName_LookupWorks(t *testing.T) {

--- a/internal/doctor/checks/terminal_patterns.go
+++ b/internal/doctor/checks/terminal_patterns.go
@@ -1,0 +1,71 @@
+package checks
+
+import (
+	"context"
+
+	"github.com/sageox/ox/internal/doctor"
+	"github.com/sageox/ox/pkg/adapterruntime"
+)
+
+// terminalFrameworkProbe is the YAML body used to verify the YAML catalog
+// loader is wired correctly. An empty patterns list compiles cleanly when
+// every step (YAML parsing, version gate, registry resolution) works.
+const terminalFrameworkProbe = "version: 1\npatterns: []\n"
+
+// TerminalPatternsCheck is an advisory doctor check that confirms the
+// adapter terminal-pattern framework is callable from the ox process.
+// It does NOT enumerate per-adapter pattern catalogs — those live inside
+// adapter binaries and are loaded at adapter startup, not from ox itself.
+//
+// The check is intentionally cheap and unconditional: it always returns
+// pass in a healthy build. A failure here means the YAML loader or the
+// adapterruntime package itself has regressed, which is a build-level
+// bug rather than a user environment issue.
+type TerminalPatternsCheck struct{}
+
+// NewTerminalPatternsCheck creates a TerminalPatternsCheck.
+func NewTerminalPatternsCheck() *TerminalPatternsCheck {
+	return &TerminalPatternsCheck{}
+}
+
+// Name returns the check identifier.
+func (c *TerminalPatternsCheck) Name() string {
+	return "terminal-patterns framework"
+}
+
+// Category groups the check under the ecosystem family.
+func (c *TerminalPatternsCheck) Category() string {
+	return "Ecosystem"
+}
+
+// Run probes the YAML pattern loader and reports whether the framework
+// is reachable. Always informational — never blocks `ox doctor --fix`.
+func (c *TerminalPatternsCheck) Run(_ context.Context, _ bool) doctor.CheckResult {
+	patterns, err := adapterruntime.LoadYAMLPatterns(
+		[]byte(terminalFrameworkProbe),
+		map[string]adapterruntime.StructuredCheck{},
+		nil,
+	)
+	if err != nil {
+		return doctor.CheckResult{
+			Name:    c.Name(),
+			Status:  doctor.StatusWarn,
+			Message: "loader probe failed: " + err.Error(),
+		}
+	}
+	if len(patterns) != 0 {
+		return doctor.CheckResult{
+			Name:    c.Name(),
+			Status:  doctor.StatusWarn,
+			Message: "loader probe returned unexpected patterns",
+		}
+	}
+	return doctor.CheckResult{
+		Name:    c.Name(),
+		Status:  doctor.StatusPass,
+		Message: "ok",
+	}
+}
+
+// compile-time interface check
+var _ doctor.Check = (*TerminalPatternsCheck)(nil)

--- a/internal/doctor/checks/terminal_patterns_test.go
+++ b/internal/doctor/checks/terminal_patterns_test.go
@@ -1,0 +1,36 @@
+package checks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sageox/ox/internal/doctor"
+)
+
+// TestTerminalPatternsCheck_HappyPath verifies the framework probe
+// returns pass in a healthy build. Failure prevented: a build-time
+// regression in the YAML loader silently masquerades as "ok" if this
+// check did not actually exercise LoadYAMLPatterns.
+func TestTerminalPatternsCheck_HappyPath(t *testing.T) {
+	c := NewTerminalPatternsCheck()
+	res := c.Run(context.Background(), false)
+
+	if res.Name != c.Name() {
+		t.Fatalf("Name mismatch: got %q want %q", res.Name, c.Name())
+	}
+	if res.Status != doctor.StatusPass {
+		t.Fatalf("expected StatusPass, got %q (msg=%q)", res.Status, res.Message)
+	}
+}
+
+// TestTerminalPatternsCheck_MetadataStable guards against accidental
+// renames that would break operator dashboards keyed on check name.
+func TestTerminalPatternsCheck_MetadataStable(t *testing.T) {
+	c := NewTerminalPatternsCheck()
+	if c.Name() != "terminal-patterns framework" {
+		t.Fatalf("check name drifted: got %q", c.Name())
+	}
+	if c.Category() != "Ecosystem" {
+		t.Fatalf("check category drifted: got %q", c.Category())
+	}
+}

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -76,7 +76,12 @@ type SessionMeta struct {
 	CreatedAt           time.Time `json:"created_at"`
 	EntryCount          int       `json:"entry_count,omitempty"`
 	Summary             string    `json:"summary,omitempty"`
-	StopReason          string    `json:"stop_reason,omitempty"` // how session ended: "stopped", "aborted", "recovered", ""
+	StopReason          string    `json:"stop_reason,omitempty"`             // how session ended (session.StopReason* constants)
+	StopDetail          string    `json:"stop_detail,omitempty"`             // human-readable detail (matched message, capped 512B)
+	StopSource          string    `json:"stop_source,omitempty"`             // adapterprotocol.TerminalSource* (structured / regex / exit_code)
+	StopPatternID       string    `json:"stop_pattern_id,omitempty"`         // which adapter pattern fired
+	StopResetsAtRaw     string    `json:"stop_resets_at_raw,omitempty"`      // raw reset-time substring as matched
+	StopResetsAt        *time.Time `json:"stop_resets_at,omitempty"`         // parsed absolute reset time, may be nil even when raw populated
 	RepoID              string    `json:"repo_id,omitempty"`
 	SageoxScore         *float64  `json:"sageox_score,omitempty"`          // agent's self-reported contribution score (0.0-1.0)
 	SageoxScoreCategory string    `json:"sageox_score_category,omitempty"` // named category: none, minor, moderate, significant, critical
@@ -374,6 +379,20 @@ func (b *SessionMetaBuilder) SessionID(id string) *SessionMetaBuilder {
 
 func (b *SessionMetaBuilder) StopReason(reason string) *SessionMetaBuilder {
 	b.meta.StopReason = reason
+	return b
+}
+
+// TerminalStop stamps the adapter-detected terminal-stop metadata in one
+// call so the daemon's terminal-error handler doesn't have to chain six
+// setters. Detail is truncated to 512 bytes by the caller before this is
+// invoked (the protocol caps it at the wire boundary).
+func (b *SessionMetaBuilder) TerminalStop(reason, source, patternID, detail, resetsRaw string, resetsAt *time.Time) *SessionMetaBuilder {
+	b.meta.StopReason = reason
+	b.meta.StopSource = source
+	b.meta.StopPatternID = patternID
+	b.meta.StopDetail = detail
+	b.meta.StopResetsAtRaw = resetsRaw
+	b.meta.StopResetsAt = resetsAt
 	return b
 }
 

--- a/internal/observability/terminal_metrics.go
+++ b/internal/observability/terminal_metrics.go
@@ -1,0 +1,228 @@
+package observability
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sageox/ox/pkg/adapterruntime"
+)
+
+// silenceWindowBuckets are the histogram boundaries (in ms) used for
+// silence-window observation. Tuned for the 20s default window with
+// generous headroom on either side so vendor wording drift (faster
+// streaming, slower trailing renders) is still visible without
+// re-bucketing. Aligned to the OTLP histogram spec for direct export
+// when an OTLP meter provider gets wired in.
+var silenceWindowBuckets = []float64{5000, 10000, 15000, 20000, 30000, 60000, 120000, 300000}
+
+// InMemoryMetrics is an adapterruntime.Metrics implementation that
+// counts events in process-local maps. Designed for early-rollout
+// visibility today, before OTLP metric exporters get wired into
+// internal/observability/otel.go alongside the existing tracer.
+//
+// Two reasons this ships before a real OTLP path:
+//
+//  1. The existing observability package only initializes a
+//     TracerProvider (otel.go:Init), not a MeterProvider. Building a
+//     MeterProvider with the OTLP/HTTP metric exporter, JWT auth, and
+//     correct shutdown semantics is a non-trivial change that deserves
+//     its own PR for review.
+//  2. The Metrics interface lets us swap the implementation later
+//     without touching adapter or detector code — the detector wiring
+//     in pkg/adapterruntime never needs to learn about OTLP.
+//
+// Snapshot() returns a serialized view of every counter and histogram
+// observed so far, suitable for dumping in `ox doctor`, a JSON debug
+// endpoint, or a periodic flush to logs while the OTLP integration
+// is in flight.
+//
+// Thread-safe: counters/histograms guarded by a single mutex. The
+// detector currently fires one event per matched entry plus one per
+// silence-window tick, so contention is negligible.
+type InMemoryMetrics struct {
+	mu               sync.Mutex
+	patternHit       map[string]uint64
+	patternConfirmed map[string]uint64
+	patternRevoked   map[string]uint64
+	resetsParseFail  map[string]uint64
+	silenceMs        map[string]*histogramSeries
+}
+
+type histogramSeries struct {
+	count   uint64
+	sumMs   float64
+	buckets []uint64 // parallel to silenceWindowBuckets; final entry counts >last
+}
+
+// NewInMemoryMetrics constructs an empty in-memory metrics sink.
+func NewInMemoryMetrics() *InMemoryMetrics {
+	return &InMemoryMetrics{
+		patternHit:       make(map[string]uint64),
+		patternConfirmed: make(map[string]uint64),
+		patternRevoked:   make(map[string]uint64),
+		resetsParseFail:  make(map[string]uint64),
+		silenceMs:        make(map[string]*histogramSeries),
+	}
+}
+
+// PatternHit increments ox.adapter.terminal.pattern_hit{adapter, pattern_id, source, reason}.
+func (m *InMemoryMetrics) PatternHit(adapter, patternID string, source adapterruntime.PatternSource, reason string) {
+	key := joinLabels(adapter, patternID, string(source), reason)
+	m.mu.Lock()
+	m.patternHit[key]++
+	m.mu.Unlock()
+}
+
+// PatternConfirmed increments ox.adapter.terminal.pattern_confirmed{adapter, pattern_id}.
+func (m *InMemoryMetrics) PatternConfirmed(adapter, patternID string) {
+	key := joinLabels(adapter, patternID)
+	m.mu.Lock()
+	m.patternConfirmed[key]++
+	m.mu.Unlock()
+}
+
+// PatternRevoked increments ox.adapter.terminal.pattern_revoked{adapter, pattern_id}.
+func (m *InMemoryMetrics) PatternRevoked(adapter, patternID string) {
+	key := joinLabels(adapter, patternID)
+	m.mu.Lock()
+	m.patternRevoked[key]++
+	m.mu.Unlock()
+}
+
+// ResetsAtParseFailure increments ox.adapter.terminal.resets_at_parse_failure{adapter, pattern_id}.
+func (m *InMemoryMetrics) ResetsAtParseFailure(adapter, patternID string) {
+	key := joinLabels(adapter, patternID)
+	m.mu.Lock()
+	m.resetsParseFail[key]++
+	m.mu.Unlock()
+}
+
+// SilenceWindowObservedMs records ox.adapter.terminal.silence_window_observed_ms
+// {adapter, pattern_id} as a histogram with silenceWindowBuckets boundaries.
+func (m *InMemoryMetrics) SilenceWindowObservedMs(adapter, patternID string, observed time.Duration) {
+	key := joinLabels(adapter, patternID)
+	ms := float64(observed.Milliseconds())
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h, ok := m.silenceMs[key]
+	if !ok {
+		h = &histogramSeries{buckets: make([]uint64, len(silenceWindowBuckets)+1)}
+		m.silenceMs[key] = h
+	}
+	h.count++
+	h.sumMs += ms
+	placed := false
+	for i, boundary := range silenceWindowBuckets {
+		if ms <= boundary {
+			h.buckets[i]++
+			placed = true
+			break
+		}
+	}
+	if !placed {
+		h.buckets[len(silenceWindowBuckets)]++ // overflow bucket
+	}
+}
+
+// MetricsSnapshot is a serialized view of every counter and histogram
+// observed by an InMemoryMetrics. Keys are the joined label tuple
+// (adapter|pattern_id|source|reason) — split on "|" to recover labels.
+type MetricsSnapshot struct {
+	PatternHit       map[string]uint64           `json:"pattern_hit,omitempty"`
+	PatternConfirmed map[string]uint64           `json:"pattern_confirmed,omitempty"`
+	PatternRevoked   map[string]uint64           `json:"pattern_revoked,omitempty"`
+	ResetsParseFail  map[string]uint64           `json:"resets_at_parse_failure,omitempty"`
+	SilenceWindowMs  map[string]HistogramSummary `json:"silence_window_observed_ms,omitempty"`
+}
+
+// HistogramSummary is the snapshot view of one histogram series.
+type HistogramSummary struct {
+	Count   uint64    `json:"count"`
+	SumMs   float64   `json:"sum_ms"`
+	Buckets []uint64  `json:"buckets"`           // parallel to Boundaries + overflow
+	Bounds  []float64 `json:"boundaries"`        // canonical bucket boundaries (ms)
+}
+
+// Snapshot returns a deep copy of the metrics state. Safe to call from
+// any goroutine. The returned maps are independent and can be mutated
+// without affecting the in-memory store.
+func (m *InMemoryMetrics) Snapshot() MetricsSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cp := func(in map[string]uint64) map[string]uint64 {
+		if len(in) == 0 {
+			return nil
+		}
+		out := make(map[string]uint64, len(in))
+		for k, v := range in {
+			out[k] = v
+		}
+		return out
+	}
+
+	var silence map[string]HistogramSummary
+	if len(m.silenceMs) > 0 {
+		silence = make(map[string]HistogramSummary, len(m.silenceMs))
+		for k, h := range m.silenceMs {
+			b := make([]uint64, len(h.buckets))
+			copy(b, h.buckets)
+			bounds := make([]float64, len(silenceWindowBuckets))
+			copy(bounds, silenceWindowBuckets)
+			silence[k] = HistogramSummary{
+				Count:   h.count,
+				SumMs:   h.sumMs,
+				Buckets: b,
+				Bounds:  bounds,
+			}
+		}
+	}
+
+	return MetricsSnapshot{
+		PatternHit:       cp(m.patternHit),
+		PatternConfirmed: cp(m.patternConfirmed),
+		PatternRevoked:   cp(m.patternRevoked),
+		ResetsParseFail:  cp(m.resetsParseFail),
+		SilenceWindowMs:  silence,
+	}
+}
+
+// SortedKeys returns the sorted union of every metric key, useful for
+// deterministic display (table rendering in `ox doctor` or test
+// assertions).
+func (s MetricsSnapshot) SortedKeys() []string {
+	seen := map[string]struct{}{}
+	add := func(in map[string]uint64) {
+		for k := range in {
+			seen[k] = struct{}{}
+		}
+	}
+	add(s.PatternHit)
+	add(s.PatternConfirmed)
+	add(s.PatternRevoked)
+	add(s.ResetsParseFail)
+	for k := range s.SilenceWindowMs {
+		seen[k] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// joinLabels canonicalizes a label tuple into a deterministic key.
+// "|" cannot appear in any label produced by adapterruntime (labels
+// are pattern IDs and adapter names from registered config), so it is
+// safe as a delimiter. Empty labels are preserved so the position is
+// unambiguous on split.
+func joinLabels(labels ...string) string {
+	return strings.Join(labels, "|")
+}
+
+// compile-time interface check — keeps the wire contract honest if the
+// adapterruntime.Metrics signature ever changes.
+var _ adapterruntime.Metrics = (*InMemoryMetrics)(nil)

--- a/internal/session/classify.go
+++ b/internal/session/classify.go
@@ -64,10 +64,72 @@ const ghostHeuristicAge = 5 * time.Minute
 
 // StopReason constants for how a session ended.
 const (
-	StopReasonStopped   = "stopped"   // user explicitly stopped via /ox-session-stop
-	StopReasonCanceled  = "canceled"  // user explicitly canceled via /ox-session-abort
-	StopReasonRecovered = "recovered" // recovered from orphan by daemon anti-entropy
+	StopReasonStopped       = "stopped"        // user explicitly stopped via /ox-session-stop
+	StopReasonCanceled      = "canceled"       // user explicitly canceled via /ox-session-abort
+	StopReasonRecovered     = "recovered"      // recovered from orphan by daemon anti-entropy
+	StopReasonRateLimited   = "rate_limited"   // adapter detected agent hit a usage / rate limit
+	StopReasonQuotaExceeded = "quota_exceeded" // adapter detected agent quota exhausted
+	StopReasonTerminalError = "terminal_error" // adapter detected non-recoverable agent error (generic)
 )
+
+// stopReasonRank gates StopReason transitions. Higher wins. User-initiated
+// reasons (stopped, canceled) take precedence over adapter-detected terminal
+// conditions, so a replay of an old rate-limit line can never overwrite a
+// reason the user set explicitly. The "recovered" reason is the lowest,
+// applied only when nothing else is known.
+var stopReasonRank = map[string]int{
+	"":                      0,
+	StopReasonRecovered:     10,
+	StopReasonTerminalError: 40,
+	StopReasonRateLimited:   50,
+	StopReasonQuotaExceeded: 50,
+	StopReasonCanceled:      100,
+	StopReasonStopped:       100,
+}
+
+// CanTransitionStopReason reports whether next is allowed to overwrite current
+// according to the precedence lattice. Equal ranks (e.g. user re-stopping a
+// session) are allowed so explicit user actions are always idempotent.
+// Unknown reasons are treated as rank 0.
+func CanTransitionStopReason(current, next string) bool {
+	return stopReasonRank[next] >= stopReasonRank[current]
+}
+
+// FormatStopReason renders a SessionInfo's terminal-stop reason for display
+// in `ox status` and `ox session list`. Falls back through:
+//
+//   - parsed absolute reset time (e.g. "rate limit (resets 15:00)")
+//   - raw matched reset string (e.g. "rate limit (resets in 3h)")
+//   - bare reason text ("rate limit")
+//
+// Returns "" when there is no terminal stop reason worth surfacing.
+func FormatStopReason(info SessionInfo) string {
+	label := stopReasonLabel(info.StopReason)
+	if label == "" {
+		return ""
+	}
+	switch {
+	case info.StopResetsAt != nil && !info.StopResetsAt.IsZero():
+		return label + " (resets " + info.StopResetsAt.Local().Format("15:04") + ")"
+	case info.StopResetsAtRaw != "":
+		return label + " (resets " + info.StopResetsAtRaw + ")"
+	default:
+		return label
+	}
+}
+
+func stopReasonLabel(reason string) string {
+	switch reason {
+	case StopReasonRateLimited:
+		return "rate limit"
+	case StopReasonQuotaExceeded:
+		return "quota exceeded"
+	case StopReasonTerminalError:
+		return "agent error"
+	default:
+		return ""
+	}
+}
 
 // ClassifySession determines the lifecycle status of a session based on its metadata
 // and whether it exists in the ledger. This is the single source of truth for session

--- a/internal/session/classify_test.go
+++ b/internal/session/classify_test.go
@@ -230,6 +230,112 @@ func TestRawJSONLHasData(t *testing.T) {
 	assert.True(t, RawJSONLHasData(sessionPath))
 }
 
+// TestCanTransitionStopReason verifies the precedence lattice for
+// StopReason transitions. Failure prevented: a stale replayed adapter
+// rate-limit line overwriting a user-initiated "stopped" reason and
+// flipping the session display to "rate limit".
+func TestCanTransitionStopReason(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		next    string
+		want    bool
+	}{
+		{name: "empty to rate_limited (0 to 50)", current: "", next: StopReasonRateLimited, want: true},
+		{name: "rate_limited idempotent", current: StopReasonRateLimited, next: StopReasonRateLimited, want: true},
+		{name: "stopped beats rate_limited", current: StopReasonStopped, next: StopReasonRateLimited, want: false},
+		{name: "recovered to rate_limited", current: StopReasonRecovered, next: StopReasonRateLimited, want: true},
+		{name: "rate_limited to stopped (user override)", current: StopReasonRateLimited, next: StopReasonStopped, want: true},
+		{name: "unknown to unknown (both rank 0)", current: "weird", next: "alsoweird", want: true},
+		{name: "canceled beats rate_limited", current: StopReasonCanceled, next: StopReasonRateLimited, want: false},
+		{name: "quota beats terminal_error", current: StopReasonTerminalError, next: StopReasonQuotaExceeded, want: true},
+		{name: "stopped beats canceled (equal rank, idempotent)", current: StopReasonStopped, next: StopReasonCanceled, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanTransitionStopReason(tt.current, tt.next)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestFormatStopReason verifies the user-facing string produced for each
+// terminal-stop reason and reset-time shape. Failure prevented: a UI
+// regression that renders user-initiated stops as "rate limit", or omits
+// the reset-time hint when the adapter parsed one out of the matched line.
+func TestFormatStopReason(t *testing.T) {
+	resetTime := time.Date(2026, 5, 28, 15, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		name string
+		info SessionInfo
+		want string
+	}{
+		{
+			name: "empty stop reason",
+			info: SessionInfo{StopReason: ""},
+			want: "",
+		},
+		{
+			name: "rate limited, no resets",
+			info: SessionInfo{StopReason: StopReasonRateLimited},
+			want: "rate limit",
+		},
+		{
+			name: "rate limited, raw resets only",
+			info: SessionInfo{StopReason: StopReasonRateLimited, StopResetsAtRaw: "in 3h"},
+			want: "rate limit (resets in 3h)",
+		},
+		{
+			name: "rate limited, parsed resets time",
+			info: SessionInfo{StopReason: StopReasonRateLimited, StopResetsAt: &resetTime},
+			want: "rate limit (resets " + resetTime.Local().Format("15:04") + ")",
+		},
+		{
+			name: "quota exceeded",
+			info: SessionInfo{StopReason: StopReasonQuotaExceeded},
+			want: "quota exceeded",
+		},
+		{
+			name: "terminal error",
+			info: SessionInfo{StopReason: StopReasonTerminalError},
+			want: "agent error",
+		},
+		{
+			name: "user-initiated stopped is suppressed",
+			info: SessionInfo{StopReason: StopReasonStopped},
+			want: "",
+		},
+		{
+			name: "user-initiated canceled is suppressed",
+			info: SessionInfo{StopReason: StopReasonCanceled},
+			want: "",
+		},
+		{
+			name: "recovered is suppressed",
+			info: SessionInfo{StopReason: StopReasonRecovered},
+			want: "",
+		},
+		{
+			name: "parsed time wins over raw",
+			info: SessionInfo{
+				StopReason:      StopReasonRateLimited,
+				StopResetsAt:    &resetTime,
+				StopResetsAtRaw: "in 3h",
+			},
+			want: "rate limit (resets " + resetTime.Local().Format("15:04") + ")",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatStopReason(tt.info)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestIsPIDAlive(t *testing.T) {
 	// current process is alive
 	assert.True(t, isPIDAlive(os.Getpid()))

--- a/internal/session/pipeline/types.go
+++ b/internal/session/pipeline/types.go
@@ -9,6 +9,8 @@
 // both phases. It does NOT contain cobra commands, LFS upload logic, or git operations.
 package pipeline
 
+import "time"
+
 // Ledger artifact filenames — single source of truth used by both
 // the upload path (write) and post-prune path rewrite (read-back).
 const (
@@ -60,6 +62,17 @@ type Result struct {
 	UploadWarning    string   // non-empty when ledger upload failed (explains recovery)
 	DataWarnings     []string // data quality warnings from validation (reported to agent)
 	UploadMs         int64    // time spent on LFS upload + git push (ms)
+
+	// Adapter-detected terminal-stop metadata, populated by the daemon's
+	// terminal-error handler when finalizing a session that the adapter
+	// declared dead (rate limit / quota / agent error). All fields are
+	// zero when the session ended via normal user-initiated stop.
+	StopReason      string
+	StopDetail      string
+	StopSource      string
+	StopPatternID   string
+	StopResetsAtRaw string
+	StopResetsAt    *time.Time
 }
 
 // StartOutput is the JSON output format for session start.
@@ -103,6 +116,18 @@ type StopOutput struct {
 	Guidance         string           `json:"guidance,omitempty"`           // behavioral guidance for the agent
 	TotalMs          int64            `json:"total_ms,omitempty"`           // wall clock for entire session stop
 	Timing           map[string]int64 `json:"timing,omitempty"`             // per-phase breakdown (ms)
+
+	// Terminal-stop metadata. Populated only when the session was
+	// finalized by the adapter terminal-error path (rate limit etc.),
+	// not by a user-initiated stop. StopReason mirrors session.StopReason*
+	// constants; StopResetsAt may be nil even when StopResetsAtRaw is set
+	// (parsing was ambiguous — UI should fall back to the raw string).
+	StopReason      string     `json:"stop_reason,omitempty"`
+	StopDetail      string     `json:"stop_detail,omitempty"`
+	StopSource      string     `json:"stop_source,omitempty"`
+	StopPatternID   string     `json:"stop_pattern_id,omitempty"`
+	StopResetsAtRaw string     `json:"stop_resets_at_raw,omitempty"`
+	StopResetsAt    *time.Time `json:"stop_resets_at,omitempty"`
 }
 
 // RemindOutput is the JSON output format for session remind.

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -322,8 +322,13 @@ type SessionInfo struct {
 	ParentPID       int                 `json:"parent_pid,omitempty"`       // from .recording.json for liveness detection
 	Origin          string              `json:"origin,omitempty"`           // session origin: "human", "subagent", "agent"
 	HasRawData      bool                `json:"has_raw_data,omitempty"`     // true if raw.jsonl exists with content on disk
-	StopReason      string              `json:"stop_reason,omitempty"`      // how session ended: "stopped", "aborted", "recovered"
-	SuspendedAt     *time.Time          `json:"suspended_at,omitempty"`     // ADR-020: non-nil while session is actively paused
+	StopReason      string              `json:"stop_reason,omitempty"`        // how session ended (StopReason* constants)
+	SuspendedAt     *time.Time          `json:"suspended_at,omitempty"`       // ADR-020: non-nil while session is actively paused
+	StopDetail      string              `json:"stop_detail,omitempty"`        // human-readable detail (matched message, capped 512B)
+	StopSource      string              `json:"stop_source,omitempty"`        // adapterprotocol.TerminalSource* (structured / regex / exit_code)
+	StopPatternID   string              `json:"stop_pattern_id,omitempty"`    // which adapter pattern fired (for telemetry / drift detection)
+	StopResetsAtRaw string              `json:"stop_resets_at_raw,omitempty"` // raw reset-time substring as matched
+	StopResetsAt    *time.Time          `json:"stop_resets_at,omitempty"`     // parsed absolute reset time, may be nil even when raw populated
 }
 
 // ListSessions returns session files from the last 7 days, sorted by date descending.
@@ -515,6 +520,11 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 			HasRawData:      hasRawData,
 			StopReason:      stopReason(meta),
 			SuspendedAt:     suspendedAt,
+			StopDetail:      stopMetaString(meta, func(m *lfs.SessionMeta) string { return m.StopDetail }),
+			StopSource:      stopMetaString(meta, func(m *lfs.SessionMeta) string { return m.StopSource }),
+			StopPatternID:   stopMetaString(meta, func(m *lfs.SessionMeta) string { return m.StopPatternID }),
+			StopResetsAtRaw: stopMetaString(meta, func(m *lfs.SessionMeta) string { return m.StopResetsAtRaw }),
+			StopResetsAt:    stopMetaTime(meta),
 		})
 	}
 
@@ -527,6 +537,22 @@ func stopReason(meta *lfs.SessionMeta) string {
 		return meta.StopReason
 	}
 	return ""
+}
+
+// stopMetaString lifts a string field off meta.json safely.
+func stopMetaString(meta *lfs.SessionMeta, pick func(*lfs.SessionMeta) string) string {
+	if meta == nil {
+		return ""
+	}
+	return pick(meta)
+}
+
+// stopMetaTime lifts the parsed reset-at timestamp off meta.json safely.
+func stopMetaTime(meta *lfs.SessionMeta) *time.Time {
+	if meta == nil {
+		return nil
+	}
+	return meta.StopResetsAt
 }
 
 // entryCount returns the best available entry count for a session.

--- a/internal/uicatalog/entries/session_list_screen.go
+++ b/internal/uicatalog/entries/session_list_screen.go
@@ -52,11 +52,12 @@ func init() {
 				val(pad("oxsid_01JE...A7QX", 22)) + pad("4m ago", 12) + pad(ok("0:18"), 11) + pad("12", 7) + pad(ok("● live"), 12) + sec("claude-code"),
 				val(pad("oxsid_01JE...8MNP", 22)) + pad("28m ago", 12) + pad(val("1:04"), 11) + pad("47", 7) + pad(ok("✓ hydrated"), 12) + sec("claude-code"),
 				val(pad("oxsid_01JE...3KZF", 22)) + pad("2h ago", 12) + pad(val("0:42"), 11) + pad("23", 7) + pad(warn("⟳ stub"), 12) + sec("codex"),
+				val(pad("oxsid_01JE...9PQR", 22)) + pad("3h ago", 12) + pad(val("1:47"), 11) + pad("64", 7) + pad(warn("⏸ paused"), 12) + sec("claude-code") + "  " + warn("[rate limit (resets 15:00)]"),
 				val(pad("oxsid_01JE...7VRC", 22)) + pad("yesterday", 12) + pad(val("2:18"), 11) + pad("93", 7) + pad(ok("✓ hydrated"), 12) + sec("claude-code"),
 				val(pad("oxsid_01JE...2WMD", 22)) + pad("yesterday", 12) + pad(warn("4:31"), 11) + pad("181", 7) + pad(ok("✓ hydrated"), 12) + sec("cursor"),
 			}, "\n")
 
-			footer := "\n\n" + dim("5 sessions · 1 live · 3 hydrated · 1 stub · run `ox session view <id>`")
+			footer := "\n\n" + dim("6 sessions · 1 live · 3 hydrated · 1 stub · 1 paused · run `ox session view <id>`")
 
 			return heading + headerRow + rows + footer
 		},

--- a/internal/uicatalog/entries/status_screen.go
+++ b/internal/uicatalog/entries/status_screen.go
@@ -64,6 +64,16 @@ func init() {
 				row("uptime", val("3h 21m")) +
 				row("queue", warn("2 stale repos"))
 
+			// AI coworker session blocks. The "paused" row shows the design
+			// for adapter-detected terminal stops (rate limit / quota / agent
+			// error). Recording==false plus a non-empty FormatStopReason
+			// produces the trailing label — user-initiated stops (stopped /
+			// canceled / recovered) suppress the suffix entirely.
+			coworkers := sect("AI COWORKERS") + "\n" +
+				row("claude-code (Ox1A)", ok("● recording — 47 turns")) +
+				row("claude-code (Ox2B)", warn("⏸ paused — rate limit (resets ~3h). Resume when ready.")) +
+				row("codex (Ox3C)", val("idle"))
+
 			r := rand.New(rand.NewSource(7))
 			now := time.Now()
 			var ts []time.Time
@@ -78,6 +88,7 @@ func init() {
 				workspace + "\n" +
 				ledger + "\n" +
 				daemon + "\n" +
+				coworkers + "\n" +
 				activity
 		},
 	})

--- a/pkg/adapterprotocol/types.go
+++ b/pkg/adapterprotocol/types.go
@@ -7,12 +7,21 @@
 // The canonical protocol reference is adapter/protocol/spec.md.
 package adapterprotocol
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // ProtocolVersion is the current adapter protocol version.
 // Adapters return this in their info response. ox refuses adapters
 // whose major version is lower than its own minimum supported.
 const ProtocolVersion = 1
+
+// ProtocolDate is a human-readable date string identifying the protocol
+// revision. Bumped when wire-level changes are made (new event types,
+// new HelloResponse fields) without changing the major ProtocolVersion.
+// Adapters can use this for fine-grained capability negotiation.
+const ProtocolDate = "2026-05-01"
 
 // --- Adapter types ---
 
@@ -274,15 +283,67 @@ const (
 
 // Event is an adapter-initiated push message (no request ID).
 type Event struct {
-	Event   string          `json:"event"` // "entries"
+	Event   string          `json:"event"` // "entries", "terminal_error", "subagent.*"
 	AgentID string          `json:"agent_id"`
 	Data    json.RawMessage `json:"data"`
 }
 
 // EntriesEventData is the data payload for "entries" events.
+//
+// Seq is a per-session monotonically increasing batch sequence number.
+// Daemons use it to gate downstream actions (e.g. terminal_error
+// finalize) on "entries up to seq N have been persisted" — defeats the
+// race where a terminal_error event arrives before its co-batch
+// entries are durable. Adapters older than ProtocolDate=2026-05-01
+// emit seq=0; daemons MUST treat 0 as "unknown / don't gate".
 type EntriesEventData struct {
 	Entries   []RawEntry `json:"entries"`
 	NewOffset int64      `json:"new_offset"`
+	Seq       int64      `json:"seq,omitempty"`
+}
+
+// Event names emitted by adapters.
+const (
+	EventEntries        = "entries"
+	EventTerminalError  = "terminal_error"
+)
+
+// TerminalErrorSource identifies how a terminal condition was detected.
+const (
+	TerminalSourceStructured = "structured" // matched a structured JSON field (preferred)
+	TerminalSourceRegex      = "regex"      // matched a regex over free text (fallback)
+	TerminalSourceExitCode   = "exit_code"  // underlying agent process exited
+)
+
+// TerminalErrorData is the data payload for "terminal_error" events.
+// Emitted by an adapter when it detects the agent has entered a
+// non-recoverable terminal condition (rate limit, quota exceeded,
+// banned content, etc.) AND the detection has survived the silence-
+// window confirmation. The daemon's terminal-error handler reacts by
+// finalizing the session cleanly with a structured StopReason.
+//
+// EntrySeq matches the Seq of the entries-event batch that contained
+// the matched entry; the daemon MUST gate finalize on "entries with
+// Seq <= EntrySeq have been persisted" to avoid losing the trailing
+// content. EntrySeq=0 means the adapter did not track sequencing
+// (older protocol) — daemon falls back to immediate finalize.
+//
+// ResetsAtRaw is the matched substring verbatim (e.g. "in 3h", "3pm
+// local"). ResetsAt is a best-effort parsed absolute timestamp. When
+// parsing is ambiguous (no timezone, locale-sensitive AM/PM) the
+// adapter MUST leave ResetsAt nil rather than emit a wrong absolute
+// time — the UI falls back to ResetsAtRaw verbatim. Both may be empty
+// when no reset hint was present in the matched text.
+type TerminalErrorData struct {
+	Reason       string     `json:"reason"`
+	Source       string     `json:"source"` // see TerminalSource* constants
+	PatternID    string     `json:"pattern_id,omitempty"`
+	RawMessage   string     `json:"raw_message"` // capped at 512 bytes
+	ResetsAtRaw  string     `json:"resets_at_raw,omitempty"`
+	ResetsAt     *time.Time `json:"resets_at,omitempty"`
+	EntrySeq     int64      `json:"entry_seq,omitempty"`
+	DetectedAt   time.Time  `json:"detected_at"`
+	ConfirmedAt  time.Time  `json:"confirmed_at"`
 }
 
 // --- Serve mode method names ---

--- a/pkg/adapterruntime/terminal_patterns.go
+++ b/pkg/adapterruntime/terminal_patterns.go
@@ -1,0 +1,531 @@
+package adapterruntime
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultSilenceWindow is the time the detector waits after a pattern
+// match before confirming the session is terminal. If new entries
+// arrive in this window — and they are not themselves matches —
+// the pending match is revoked. Defeats the failure mode where a
+// rendered prior transcript quotes a rate-limit line.
+const DefaultSilenceWindow = 20 * time.Second
+
+// MaxRawMessageBytes caps how much of the matched line is forwarded to
+// the daemon over the wire. Long lines are truncated to this length to
+// keep telemetry / audit records compact and to avoid leaking secrets
+// that may sit on the same line (the boundary guard in upstream code
+// strips before write, but defense-in-depth).
+const MaxRawMessageBytes = 512
+
+// PatternSource categorizes how a match was found.
+type PatternSource string
+
+const (
+	SourceStructured PatternSource = "structured"
+	SourceRegex      PatternSource = "regex"
+	SourceExitCode   PatternSource = "exit_code"
+)
+
+// StructuredCheck inspects a raw line (parsed by the adapter to a RawEntry,
+// plus the original JSON bytes for free-form path lookups). Returns a
+// non-nil Match when the entry matches the structured signal, or nil
+// otherwise. Structured checks are the preferred detection path: they
+// look at vendor-supplied fields (e.g. message.stop_reason) rather than
+// guessing at free-text wording that vendors change quietly.
+type StructuredCheck func(entry adapterprotocol.RawEntry, raw json.RawMessage) *Match
+
+// TerminalPattern declares one detection rule for an adapter. Patterns
+// are evaluated in registration order; the first match wins for a given
+// entry. Structured patterns are always checked before regex patterns
+// on the same entry — see TerminalDetector.checkEntry.
+type TerminalPattern struct {
+	ID            string
+	Reason        string // empty means "log + metric, do not finalize"
+	Source        PatternSource
+	Structured    StructuredCheck
+	Substrings    []string // cheap pre-filter for regex patterns; ANY substring must be present before Re is evaluated
+	Re            *regexp.Regexp
+	Roles         []string // for regex patterns: gate to these entry.Role values (default {"system"})
+	ParseResetsAt func(match []string) (raw string, parsed *time.Time)
+}
+
+// Match is what a TerminalPattern.Check returns when an entry matches.
+// The detector populates additional fields (Source, ConfirmedAt) before
+// emitting the terminal_error event.
+type Match struct {
+	PatternID   string
+	Reason      string
+	RawMessage  string
+	ResetsAtRaw string
+	ResetsAt    *time.Time
+}
+
+// Metrics is the observability surface for the detector. The watcher
+// (or test harness) injects an implementation. Production wires this
+// to OTLP counters / gauges; the default NopMetrics drops everything.
+//
+// PatternHit fires for every match found (before silence-window
+// confirmation). PatternConfirmed fires when the silence window
+// elapses without a revoking entry. PatternRevoked fires when a
+// non-matching entry arrives before the window elapses (false
+// positive caught). ResetsAtParseFailure fires when a pattern matched
+// but ParseResetsAt could not produce an absolute timestamp.
+type Metrics interface {
+	PatternHit(adapter, patternID string, source PatternSource, reason string)
+	PatternConfirmed(adapter, patternID string)
+	PatternRevoked(adapter, patternID string)
+	ResetsAtParseFailure(adapter, patternID string)
+	SilenceWindowObservedMs(adapter, patternID string, observed time.Duration)
+}
+
+// NopMetrics is a Metrics that discards all events.
+type NopMetrics struct{}
+
+func (NopMetrics) PatternHit(string, string, PatternSource, string)              {}
+func (NopMetrics) PatternConfirmed(string, string)                               {}
+func (NopMetrics) PatternRevoked(string, string)                                 {}
+func (NopMetrics) ResetsAtParseFailure(string, string)                           {}
+func (NopMetrics) SilenceWindowObservedMs(string, string, time.Duration)         {}
+
+// ConfirmedMatch is what Tick returns when a pending match's silence
+// window has elapsed. Translates 1:1 to a terminal_error event.
+type ConfirmedMatch struct {
+	SessionID   string
+	Pattern     TerminalPattern
+	Match       Match
+	EntrySeq    int64
+	DetectedAt  time.Time
+	ConfirmedAt time.Time
+}
+
+// pendingMatch holds the state of a match awaiting silence-window
+// confirmation. firstSeenSeq is the entries-batch Seq the originating
+// match was observed in; the daemon's terminal-error handler gates
+// finalize on "entries with Seq <= firstSeenSeq have been persisted".
+type pendingMatch struct {
+	pattern      TerminalPattern
+	match        Match
+	firstSeenAt  time.Time
+	firstSeenSeq int64
+}
+
+// TerminalDetector evaluates a list of patterns against every entry the
+// watcher pushes, holds matches in a silence-window pending state, and
+// emits confirmed matches via Tick.
+//
+// Thread-safe: the watcher calls OnBatch from its read goroutine and
+// Tick from a heartbeat goroutine concurrently.
+type TerminalDetector struct {
+	adapterName   string
+	patterns      []TerminalPattern
+	silenceWindow time.Duration
+	metrics       Metrics
+
+	mu      sync.Mutex
+	pending map[string]*pendingMatch // sessionID -> match awaiting confirmation
+}
+
+// NewTerminalDetector constructs a detector with the given patterns.
+// adapterName is used for metric labeling. Passing nil patterns yields
+// a no-op detector that is safe to call (handy for the disabled case).
+func NewTerminalDetector(adapterName string, patterns []TerminalPattern, silenceWindow time.Duration, metrics Metrics) *TerminalDetector {
+	if metrics == nil {
+		metrics = NopMetrics{}
+	}
+	if silenceWindow <= 0 {
+		silenceWindow = DefaultSilenceWindow
+	}
+	return &TerminalDetector{
+		adapterName:   adapterName,
+		patterns:      patterns,
+		silenceWindow: silenceWindow,
+		metrics:       metrics,
+		pending:       make(map[string]*pendingMatch),
+	}
+}
+
+// Enabled reports whether the detector has any patterns to evaluate.
+// Callers can skip OnBatch/Tick wiring entirely when false.
+func (d *TerminalDetector) Enabled() bool {
+	return d != nil && len(d.patterns) > 0
+}
+
+// OnBatch evaluates entries (in order) against the registered patterns.
+// If any entry matches, the match is stored as pending for this session.
+// If a non-matching entry arrives while a match is pending, the pending
+// match is revoked — vendor messages that look like a rate-limit but are
+// followed by more conversational output were a false positive.
+//
+// rawLines is parallel to entries (same length) carrying the original
+// JSON bytes for structured-pass JSON-path checks. Pass nil for adapters
+// that cannot supply raws; only structured patterns that look at
+// RawEntry fields will fire in that case.
+//
+// seq is the per-session monotonically increasing batch identifier from
+// the entries event. The first session-batch should be 1, never 0
+// (0 reserved for "unknown").
+func (d *TerminalDetector) OnBatch(sessionID string, entries []adapterprotocol.RawEntry, seq int64, rawLines []json.RawMessage) {
+	if !d.Enabled() || sessionID == "" || len(entries) == 0 {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for i, entry := range entries {
+		var raw json.RawMessage
+		if i < len(rawLines) {
+			raw = rawLines[i]
+		}
+		if pattern, match := d.checkEntry(entry, raw); match != nil {
+			// New match. If something was already pending and this is
+			// a different pattern, the newer match supersedes — same
+			// session, same vendor, terminal condition still applies.
+			d.pending[sessionID] = &pendingMatch{
+				pattern:      pattern,
+				match:        *match,
+				firstSeenAt:  time.Now(),
+				firstSeenSeq: seq,
+			}
+			d.metrics.PatternHit(d.adapterName, pattern.ID, pattern.Source, pattern.Reason)
+		} else if existing, ok := d.pending[sessionID]; ok {
+			// Non-matching entry arrived while a match was pending.
+			// False positive: revoke and let the session continue.
+			d.metrics.PatternRevoked(d.adapterName, existing.pattern.ID)
+			delete(d.pending, sessionID)
+		}
+	}
+}
+
+// Tick checks every pending match and returns the ones whose silence
+// window has elapsed. Caller (typically the watcher heartbeat) emits
+// a terminal_error event for each ConfirmedMatch.
+func (d *TerminalDetector) Tick(now time.Time) []ConfirmedMatch {
+	if !d.Enabled() {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var confirmed []ConfirmedMatch
+	for sessionID, p := range d.pending {
+		elapsed := now.Sub(p.firstSeenAt)
+		if elapsed < d.silenceWindow {
+			continue
+		}
+		// Skip empty-Reason patterns: those are informational only
+		// (e.g. log max_tokens stop_reason for telemetry) — they
+		// should not finalize the session.
+		if p.pattern.Reason != "" {
+			confirmed = append(confirmed, ConfirmedMatch{
+				SessionID:   sessionID,
+				Pattern:     p.pattern,
+				Match:       p.match,
+				EntrySeq:    p.firstSeenSeq,
+				DetectedAt:  p.firstSeenAt,
+				ConfirmedAt: now,
+			})
+			d.metrics.PatternConfirmed(d.adapterName, p.pattern.ID)
+			d.metrics.SilenceWindowObservedMs(d.adapterName, p.pattern.ID, elapsed)
+		}
+		delete(d.pending, sessionID)
+	}
+	return confirmed
+}
+
+// Forget drops any pending state for the given session. The watcher
+// calls this on Unwatch so a re-Watch under the same agentID does not
+// inherit a pending match from a previous session.
+func (d *TerminalDetector) Forget(sessionID string) {
+	if !d.Enabled() {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.pending, sessionID)
+}
+
+// checkEntry walks the pattern list and returns the first match. caller must hold d.mu.
+func (d *TerminalDetector) checkEntry(entry adapterprotocol.RawEntry, raw json.RawMessage) (TerminalPattern, *Match) {
+	// Structured patterns first (preferred path).
+	for _, p := range d.patterns {
+		if p.Source != SourceStructured || p.Structured == nil {
+			continue
+		}
+		if m := p.Structured(entry, raw); m != nil {
+			m.PatternID = p.ID
+			if m.Reason == "" {
+				m.Reason = p.Reason
+			}
+			truncateRawMessage(m)
+			return p, m
+		}
+	}
+	// Regex fallback.
+	for _, p := range d.patterns {
+		if p.Source != SourceRegex || p.Re == nil {
+			continue
+		}
+		if !roleAllowed(entry.Role, p.Roles) {
+			continue
+		}
+		// Cheap substring pre-filter — short-circuits the regex when
+		// the line cannot possibly match. Empty Substrings means
+		// "always run the regex".
+		if !substringPresent(entry.Content, p.Substrings) {
+			continue
+		}
+		subs := p.Re.FindStringSubmatch(entry.Content)
+		if subs == nil {
+			continue
+		}
+		m := &Match{
+			PatternID:  p.ID,
+			Reason:     p.Reason,
+			RawMessage: entry.Content,
+		}
+		if p.ParseResetsAt != nil {
+			raw, parsed := p.ParseResetsAt(subs)
+			m.ResetsAtRaw = raw
+			m.ResetsAt = parsed
+			if raw != "" && parsed == nil {
+				d.metrics.ResetsAtParseFailure(d.adapterName, p.ID)
+			}
+		}
+		truncateRawMessage(m)
+		return p, m
+	}
+	return TerminalPattern{}, nil
+}
+
+func truncateRawMessage(m *Match) {
+	if len(m.RawMessage) > MaxRawMessageBytes {
+		m.RawMessage = m.RawMessage[:MaxRawMessageBytes]
+	}
+}
+
+// roleAllowed returns true when entry's role is in allowed. Default
+// allowed for regex patterns is {"system"} when the pattern declares
+// no Roles (the safer default — system messages are adapter-authored,
+// assistant messages can contain user-quoted text).
+func roleAllowed(role string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return role == adapterprotocol.RoleSystem
+	}
+	for _, a := range allowed {
+		if role == a {
+			return true
+		}
+	}
+	return false
+}
+
+func substringPresent(content string, substrings []string) bool {
+	if len(substrings) == 0 {
+		return true
+	}
+	lower := strings.ToLower(content)
+	for _, s := range substrings {
+		if strings.Contains(lower, strings.ToLower(s)) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- YAML pattern catalog ---
+
+// YAMLCatalog is the on-disk representation of an adapter's pattern set.
+// Adapters embed a YAML file via go:embed and pass the bytes to
+// LoadYAMLPatterns to get back TerminalPattern values registered with
+// a Go-resident StructuredCheck registry.
+type YAMLCatalog struct {
+	Version  int                  `yaml:"version"`
+	Patterns []YAMLPatternEntry   `yaml:"patterns"`
+}
+
+// YAMLPatternEntry is a single pattern in the catalog file. Structured
+// patterns reference a named check function from a registry (string
+// indirection so the YAML stays declarative); regex patterns inline
+// their regex + parser hint.
+type YAMLPatternEntry struct {
+	ID         string            `yaml:"id"`
+	Source     PatternSource     `yaml:"source"`
+	Reason     string            `yaml:"reason"`
+	Roles      []string          `yaml:"roles,omitempty"`
+	Substrings []string          `yaml:"substrings,omitempty"`
+	Re         string            `yaml:"re,omitempty"`
+	Structured YAMLStructuredRef `yaml:"structured,omitempty"`
+	ParseHint  string            `yaml:"parse_resets_at,omitempty"` // name of a registered ParseResetsAt
+}
+
+// YAMLStructuredRef declares which named structured check to bind.
+// Resolved against the catalog's structuredRegistry at load time.
+type YAMLStructuredRef struct {
+	JSONPath string `yaml:"json_path,omitempty"` // simple dotted path for the bundled equality check
+	Equals   string `yaml:"equals,omitempty"`
+	Check    string `yaml:"check,omitempty"`     // named entry in StructuredRegistry (custom checks)
+}
+
+// LoadYAMLPatterns parses a YAML catalog and returns TerminalPattern
+// values. structuredRegistry resolves named structured checks declared
+// via YAMLStructuredRef.Check. parserRegistry resolves named
+// ParseResetsAt entries (e.g. "relative_duration_or_clock"). Returns an
+// error if any regex fails to compile or any named lookup fails —
+// adapter init must surface this rather than silently skipping bad
+// patterns.
+func LoadYAMLPatterns(
+	data []byte,
+	structuredRegistry map[string]StructuredCheck,
+	parserRegistry map[string]func(match []string) (string, *time.Time),
+) ([]TerminalPattern, error) {
+	var catalog YAMLCatalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		return nil, fmt.Errorf("parse YAML catalog: %w", err)
+	}
+	if catalog.Version != 1 {
+		return nil, fmt.Errorf("unsupported catalog version %d (expected 1)", catalog.Version)
+	}
+	patterns := make([]TerminalPattern, 0, len(catalog.Patterns))
+	for i, e := range catalog.Patterns {
+		if e.ID == "" {
+			return nil, fmt.Errorf("pattern at index %d: missing id", i)
+		}
+		p := TerminalPattern{
+			ID:         e.ID,
+			Reason:     e.Reason,
+			Source:     e.Source,
+			Roles:      e.Roles,
+			Substrings: e.Substrings,
+		}
+		switch e.Source {
+		case SourceStructured:
+			switch {
+			case e.Structured.Check != "":
+				fn, ok := structuredRegistry[e.Structured.Check]
+				if !ok {
+					return nil, fmt.Errorf("pattern %q: unknown structured check %q", e.ID, e.Structured.Check)
+				}
+				p.Structured = fn
+			case e.Structured.JSONPath != "":
+				p.Structured = jsonPathEqualsCheck(e.Structured.JSONPath, e.Structured.Equals)
+			default:
+				return nil, fmt.Errorf("pattern %q: structured source needs json_path or check", e.ID)
+			}
+		case SourceRegex:
+			if e.Re == "" {
+				return nil, fmt.Errorf("pattern %q: regex source needs re", e.ID)
+			}
+			re, err := regexp.Compile(e.Re)
+			if err != nil {
+				return nil, fmt.Errorf("pattern %q: compile regex: %w", e.ID, err)
+			}
+			p.Re = re
+			if e.ParseHint != "" {
+				fn, ok := parserRegistry[e.ParseHint]
+				if !ok {
+					return nil, fmt.Errorf("pattern %q: unknown parser %q", e.ID, e.ParseHint)
+				}
+				p.ParseResetsAt = fn
+			}
+		default:
+			return nil, fmt.Errorf("pattern %q: unknown source %q", e.ID, e.Source)
+		}
+		patterns = append(patterns, p)
+	}
+	return patterns, nil
+}
+
+// jsonPathEqualsCheck builds a structured check that walks a simple
+// dotted JSON path (e.g. "message.stop_reason") and returns a match
+// when the value equals the given string. Designed for the common
+// case so YAML authors do not need to register a Go function for
+// every vendor signal.
+func jsonPathEqualsCheck(path, want string) StructuredCheck {
+	parts := strings.Split(path, ".")
+	return func(_ adapterprotocol.RawEntry, raw json.RawMessage) *Match {
+		if len(raw) == 0 {
+			return nil
+		}
+		var node any
+		if err := json.Unmarshal(raw, &node); err != nil {
+			return nil
+		}
+		for _, part := range parts {
+			obj, ok := node.(map[string]any)
+			if !ok {
+				return nil
+			}
+			node, ok = obj[part]
+			if !ok {
+				return nil
+			}
+		}
+		got, ok := node.(string)
+		if !ok || got != want {
+			return nil
+		}
+		return &Match{RawMessage: path + "=" + got}
+	}
+}
+
+// ToTerminalErrorData converts a ConfirmedMatch to the wire payload.
+func (c ConfirmedMatch) ToTerminalErrorData() adapterprotocol.TerminalErrorData {
+	return adapterprotocol.TerminalErrorData{
+		Reason:      c.Match.Reason,
+		Source:      string(c.Pattern.Source),
+		PatternID:   c.Pattern.ID,
+		RawMessage:  c.Match.RawMessage,
+		ResetsAtRaw: c.Match.ResetsAtRaw,
+		ResetsAt:    c.Match.ResetsAt,
+		EntrySeq:    c.EntrySeq,
+		DetectedAt:  c.DetectedAt,
+		ConfirmedAt: c.ConfirmedAt,
+	}
+}
+
+// AdapterDisabledByEnv reports whether OX_DISABLE_TERMINAL_DETECTION
+// names the given adapter. Adapter binaries call this BEFORE
+// constructing a TerminalDetector — when true, skip detector
+// instantiation. Comma-separated, case-insensitive, whitespace-tolerant.
+// Empty env var (the common case) returns false for any adapter.
+func AdapterDisabledByEnv(adapterName string) bool {
+	raw := os.Getenv("OX_DISABLE_TERMINAL_DETECTION")
+	if raw == "" {
+		return false
+	}
+	target := strings.ToLower(strings.TrimSpace(adapterName))
+	for _, part := range strings.Split(raw, ",") {
+		if strings.ToLower(strings.TrimSpace(part)) == target {
+			return true
+		}
+	}
+	return false
+}
+
+// LogConfirmedMatch is a debug helper for adapter authors who want to
+// see what fired without standing up a metrics implementation.
+func LogConfirmedMatch(logger *slog.Logger, adapter string, c ConfirmedMatch) {
+	if logger == nil {
+		return
+	}
+	logger.Info("terminal_error confirmed",
+		"adapter", adapter,
+		"session_id", c.SessionID,
+		"pattern_id", c.Pattern.ID,
+		"source", c.Pattern.Source,
+		"reason", c.Match.Reason,
+		"entry_seq", c.EntrySeq,
+		"silence_ms", c.ConfirmedAt.Sub(c.DetectedAt).Milliseconds(),
+	)
+}

--- a/pkg/adapterruntime/terminal_patterns.go
+++ b/pkg/adapterruntime/terminal_patterns.go
@@ -1,6 +1,7 @@
 package adapterruntime
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -92,11 +93,11 @@ type Metrics interface {
 // NopMetrics is a Metrics that discards all events.
 type NopMetrics struct{}
 
-func (NopMetrics) PatternHit(string, string, PatternSource, string)              {}
-func (NopMetrics) PatternConfirmed(string, string)                               {}
-func (NopMetrics) PatternRevoked(string, string)                                 {}
-func (NopMetrics) ResetsAtParseFailure(string, string)                           {}
-func (NopMetrics) SilenceWindowObservedMs(string, string, time.Duration)         {}
+func (NopMetrics) PatternHit(string, string, PatternSource, string)      {}
+func (NopMetrics) PatternConfirmed(string, string)                       {}
+func (NopMetrics) PatternRevoked(string, string)                         {}
+func (NopMetrics) ResetsAtParseFailure(string, string)                   {}
+func (NopMetrics) SilenceWindowObservedMs(string, string, time.Duration) {}
 
 // ConfirmedMatch is what Tick returns when a pending match's silence
 // window has elapsed. Translates 1:1 to a terminal_error event.
@@ -350,8 +351,8 @@ func substringPresent(content string, substrings []string) bool {
 // LoadYAMLPatterns to get back TerminalPattern values registered with
 // a Go-resident StructuredCheck registry.
 type YAMLCatalog struct {
-	Version  int                  `yaml:"version"`
-	Patterns []YAMLPatternEntry   `yaml:"patterns"`
+	Version  int                `yaml:"version"`
+	Patterns []YAMLPatternEntry `yaml:"patterns"`
 }
 
 // YAMLPatternEntry is a single pattern in the catalog file. Structured
@@ -374,7 +375,7 @@ type YAMLPatternEntry struct {
 type YAMLStructuredRef struct {
 	JSONPath string `yaml:"json_path,omitempty"` // simple dotted path for the bundled equality check
 	Equals   string `yaml:"equals,omitempty"`
-	Check    string `yaml:"check,omitempty"`     // named entry in StructuredRegistry (custom checks)
+	Check    string `yaml:"check,omitempty"` // named entry in StructuredRegistry (custom checks)
 }
 
 // LoadYAMLPatterns parses a YAML catalog and returns TerminalPattern
@@ -390,7 +391,13 @@ func LoadYAMLPatterns(
 	parserRegistry map[string]func(match []string) (string, *time.Time),
 ) ([]TerminalPattern, error) {
 	var catalog YAMLCatalog
-	if err := yaml.Unmarshal(data, &catalog); err != nil {
+	// Strict decode: unknown / mistyped keys in the catalog fail fast
+	// rather than silently dropping a pattern entry. A typo like
+	// "subtsrings:" would otherwise compile to a pattern with no
+	// pre-filter and never be noticed.
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&catalog); err != nil {
 		return nil, fmt.Errorf("parse YAML catalog: %w", err)
 	}
 	if catalog.Version != 1 {

--- a/pkg/adapterruntime/terminal_patterns_env_test.go
+++ b/pkg/adapterruntime/terminal_patterns_env_test.go
@@ -1,0 +1,40 @@
+package adapterruntime
+
+import (
+	"testing"
+)
+
+// TestAdapterDisabledByEnv verifies the kill-switch env var honors
+// case-insensitive comma-separated adapter names and trims whitespace.
+// Failure prevented: a misconfigured env value (e.g. mixed case from
+// shell quoting) silently fails to disable detection, leaving the
+// detector running when an operator believed it was off.
+func TestAdapterDisabledByEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		adapter string
+		want    bool
+	}{
+		{name: "unset", env: "", adapter: "claude-code", want: false},
+		{name: "single match", env: "claude-code", adapter: "claude-code", want: true},
+		{name: "single non-match", env: "claude-code", adapter: "codex", want: false},
+		{name: "multi both", env: "claude-code,codex", adapter: "codex", want: true},
+		{name: "multi other", env: "claude-code,codex", adapter: "claude-code", want: true},
+		{name: "multi non-match", env: "claude-code,codex", adapter: "cursor", want: false},
+		{name: "case insensitive + trim", env: "  Claude-Code  ,  codex", adapter: "claude-code", want: true},
+		{name: "case insensitive target", env: "claude-code", adapter: "Claude-Code", want: true},
+		{name: "empty target", env: "claude-code", adapter: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OX_DISABLE_TERMINAL_DETECTION", tt.env)
+			got := AdapterDisabledByEnv(tt.adapter)
+			if got != tt.want {
+				t.Fatalf("AdapterDisabledByEnv(%q) with env=%q = %v, want %v",
+					tt.adapter, tt.env, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/adapterruntime/terminal_patterns_test.go
+++ b/pkg/adapterruntime/terminal_patterns_test.go
@@ -1,0 +1,400 @@
+package adapterruntime
+
+import (
+	"encoding/json"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+// recordingMetrics captures Metrics calls for assertions.
+type recordingMetrics struct {
+	mu        sync.Mutex
+	hits      []hitRecord
+	confirmed []confirmRecord
+	revoked   []confirmRecord
+	parseFail []confirmRecord
+}
+
+type hitRecord struct {
+	adapter, patternID, reason string
+	source                     PatternSource
+}
+type confirmRecord struct{ adapter, patternID string }
+
+func (m *recordingMetrics) PatternHit(adapter, id string, src PatternSource, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hits = append(m.hits, hitRecord{adapter, id, reason, src})
+}
+func (m *recordingMetrics) PatternConfirmed(adapter, id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.confirmed = append(m.confirmed, confirmRecord{adapter, id})
+}
+func (m *recordingMetrics) PatternRevoked(adapter, id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revoked = append(m.revoked, confirmRecord{adapter, id})
+}
+func (m *recordingMetrics) ResetsAtParseFailure(adapter, id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.parseFail = append(m.parseFail, confirmRecord{adapter, id})
+}
+func (m *recordingMetrics) SilenceWindowObservedMs(string, string, time.Duration) {}
+
+func TestDetector_StructuredMatchBeforeRegex(t *testing.T) {
+	structured := TerminalPattern{
+		ID:     "structured-first",
+		Reason: "rate_limited",
+		Source: SourceStructured,
+		Structured: func(adapterprotocol.RawEntry, json.RawMessage) *Match {
+			return &Match{RawMessage: "structured fired"}
+		},
+	}
+	regexPat := TerminalPattern{
+		ID:     "regex-second",
+		Reason: "rate_limited",
+		Source: SourceRegex,
+		Re:     regexp.MustCompile(`limit reached`),
+		Roles:  []string{adapterprotocol.RoleSystem},
+	}
+	m := &recordingMetrics{}
+	d := NewTerminalDetector("test", []TerminalPattern{structured, regexPat}, 10*time.Millisecond, m)
+
+	d.OnBatch("sess", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "limit reached"},
+	}, 1, nil)
+
+	if len(m.hits) != 1 {
+		t.Fatalf("expected 1 hit, got %d", len(m.hits))
+	}
+	if m.hits[0].patternID != "structured-first" {
+		t.Errorf("expected structured to win, got %q", m.hits[0].patternID)
+	}
+}
+
+func TestDetector_RegexRoleGate(t *testing.T) {
+	pat := TerminalPattern{
+		ID:     "system-only",
+		Reason: "rate_limited",
+		Source: SourceRegex,
+		Re:     regexp.MustCompile(`limit reached`),
+		Roles:  []string{adapterprotocol.RoleSystem},
+	}
+	cases := []struct {
+		role    string
+		wantHit bool
+	}{
+		{adapterprotocol.RoleSystem, true},
+		{adapterprotocol.RoleAssistant, false},
+		{adapterprotocol.RoleUser, false},
+		{adapterprotocol.RoleTool, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.role, func(t *testing.T) {
+			m := &recordingMetrics{}
+			d := NewTerminalDetector("test", []TerminalPattern{pat}, 10*time.Millisecond, m)
+			d.OnBatch("sess", []adapterprotocol.RawEntry{
+				{Role: tc.role, Content: "limit reached"},
+			}, 1, nil)
+			gotHit := len(m.hits) > 0
+			if gotHit != tc.wantHit {
+				t.Errorf("role %s: got hit=%v want %v", tc.role, gotHit, tc.wantHit)
+			}
+		})
+	}
+}
+
+func TestDetector_RegexDefaultRoleIsSystem(t *testing.T) {
+	pat := TerminalPattern{
+		ID:     "default-role",
+		Reason: "rate_limited",
+		Source: SourceRegex,
+		Re:     regexp.MustCompile(`limit reached`),
+		// Roles unset
+	}
+	m := &recordingMetrics{}
+	d := NewTerminalDetector("test", []TerminalPattern{pat}, 10*time.Millisecond, m)
+	// assistant role must NOT match
+	d.OnBatch("sess", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleAssistant, Content: "limit reached"},
+	}, 1, nil)
+	if len(m.hits) != 0 {
+		t.Errorf("expected default role gate to reject assistant, got hits=%d", len(m.hits))
+	}
+	// system role must match
+	d.OnBatch("sess2", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "limit reached"},
+	}, 1, nil)
+	if len(m.hits) != 1 {
+		t.Errorf("expected system role default to match, got hits=%d", len(m.hits))
+	}
+}
+
+func TestDetector_SubstringPreFilter(t *testing.T) {
+	called := 0
+	wrapped := regexp.MustCompile(`limit reached`)
+	pat := TerminalPattern{
+		ID:         "prefilter",
+		Reason:     "rate_limited",
+		Source:     SourceRegex,
+		Substrings: []string{"limit reached"},
+		Re:         wrapped,
+		Roles:      []string{adapterprotocol.RoleSystem},
+	}
+	m := &recordingMetrics{}
+	d := NewTerminalDetector("test", []TerminalPattern{pat}, 10*time.Millisecond, m)
+	// no substring match → regex must not match (pre-filter rejected)
+	d.OnBatch("sess", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "all good here"},
+	}, 1, nil)
+	if len(m.hits) != 0 {
+		t.Errorf("expected pre-filter to skip, got hits=%d", len(m.hits))
+	}
+	_ = called
+}
+
+func TestDetector_SilenceWindowConfirm(t *testing.T) {
+	pat := TerminalPattern{
+		ID:     "sw",
+		Reason: "rate_limited",
+		Source: SourceRegex,
+		Re:     regexp.MustCompile(`limit reached`),
+		Roles:  []string{adapterprotocol.RoleSystem},
+	}
+	m := &recordingMetrics{}
+	d := NewTerminalDetector("test", []TerminalPattern{pat}, 10*time.Millisecond, m)
+	d.OnBatch("sess", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "limit reached"},
+	}, 1, nil)
+	// Tick before window elapses → no confirm.
+	if c := d.Tick(time.Now()); len(c) != 0 {
+		t.Errorf("expected no confirm before window, got %d", len(c))
+	}
+	// Tick after window elapses → confirm.
+	got := d.Tick(time.Now().Add(time.Hour))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 confirm after window, got %d", len(got))
+	}
+	if got[0].EntrySeq != 1 {
+		t.Errorf("EntrySeq=%d want 1", got[0].EntrySeq)
+	}
+}
+
+func TestDetector_SilenceWindowRevoke(t *testing.T) {
+	pat := TerminalPattern{
+		ID:     "rv",
+		Reason: "rate_limited",
+		Source: SourceRegex,
+		Re:     regexp.MustCompile(`limit reached`),
+		Roles:  []string{adapterprotocol.RoleSystem},
+	}
+	m := &recordingMetrics{}
+	d := NewTerminalDetector("test", []TerminalPattern{pat}, time.Hour, m)
+	// match in batch 1
+	d.OnBatch("sess", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "limit reached"},
+	}, 1, nil)
+	// non-matching entry in batch 2 — revokes pending
+	d.OnBatch("sess", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "continuing normally"},
+	}, 2, nil)
+	// Tick way past window — must NOT confirm
+	got := d.Tick(time.Now().Add(2 * time.Hour))
+	if len(got) != 0 {
+		t.Errorf("expected revoke to prevent confirm, got %d", len(got))
+	}
+	if len(m.revoked) != 1 {
+		t.Errorf("expected 1 revoke metric, got %d", len(m.revoked))
+	}
+}
+
+func TestDetector_EmptyReasonInformationalOnly(t *testing.T) {
+	pat := TerminalPattern{
+		ID:     "info-only",
+		Reason: "", // intentional: log+metric, do not finalize
+		Source: SourceStructured,
+		Structured: func(adapterprotocol.RawEntry, json.RawMessage) *Match {
+			return &Match{RawMessage: "info"}
+		},
+	}
+	m := &recordingMetrics{}
+	d := NewTerminalDetector("test", []TerminalPattern{pat}, 10*time.Millisecond, m)
+	d.OnBatch("sess", []adapterprotocol.RawEntry{{Role: adapterprotocol.RoleAssistant}}, 1, nil)
+	if len(m.hits) != 1 {
+		t.Errorf("hit must still fire for metrics, got %d", len(m.hits))
+	}
+	got := d.Tick(time.Now().Add(time.Hour))
+	if len(got) != 0 {
+		t.Errorf("empty-reason pattern must NOT produce ConfirmedMatch, got %d", len(got))
+	}
+}
+
+func TestDetector_Forget(t *testing.T) {
+	pat := TerminalPattern{
+		ID:     "fp",
+		Reason: "rate_limited",
+		Source: SourceRegex,
+		Re:     regexp.MustCompile(`limit reached`),
+		Roles:  []string{adapterprotocol.RoleSystem},
+	}
+	d := NewTerminalDetector("test", []TerminalPattern{pat}, time.Hour, NopMetrics{})
+	d.OnBatch("sess", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: "limit reached"},
+	}, 1, nil)
+	d.Forget("sess")
+	if got := d.Tick(time.Now().Add(2 * time.Hour)); len(got) != 0 {
+		t.Errorf("Forget must drop pending, got %d", len(got))
+	}
+}
+
+func TestDetector_RawMessageTruncation(t *testing.T) {
+	big := make([]byte, MaxRawMessageBytes+200)
+	for i := range big {
+		big[i] = 'x'
+	}
+	pat := TerminalPattern{
+		ID:     "trunc",
+		Reason: "rate_limited",
+		Source: SourceRegex,
+		Re:     regexp.MustCompile(`x+`),
+		Roles:  []string{adapterprotocol.RoleSystem},
+	}
+	d := NewTerminalDetector("test", []TerminalPattern{pat}, 10*time.Millisecond, NopMetrics{})
+	d.OnBatch("sess", []adapterprotocol.RawEntry{
+		{Role: adapterprotocol.RoleSystem, Content: string(big)},
+	}, 1, nil)
+	got := d.Tick(time.Now().Add(time.Hour))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 confirm, got %d", len(got))
+	}
+	if len(got[0].Match.RawMessage) > MaxRawMessageBytes {
+		t.Errorf("raw message not truncated: len=%d > %d", len(got[0].Match.RawMessage), MaxRawMessageBytes)
+	}
+}
+
+func TestDetector_DisabledNoOp(t *testing.T) {
+	var d *TerminalDetector // nil detector
+	if d.Enabled() {
+		t.Error("nil detector must report Enabled()=false")
+	}
+	d2 := NewTerminalDetector("test", nil, 10*time.Millisecond, NopMetrics{})
+	if d2.Enabled() {
+		t.Error("zero-pattern detector must report Enabled()=false")
+	}
+	// OnBatch / Tick / Forget all safe on disabled
+	d.OnBatch("sess", nil, 1, nil)
+	if got := d.Tick(time.Now()); got != nil {
+		t.Errorf("nil detector Tick must return nil, got %v", got)
+	}
+	d.Forget("sess")
+}
+
+func TestLoadYAMLPatterns_StructuredJSONPath(t *testing.T) {
+	yaml := []byte(`version: 1
+patterns:
+  - id: t.stop_reason
+    source: structured
+    reason: rate_limited
+    structured:
+      json_path: message.stop_reason
+      equals: rate_limited
+`)
+	patterns, err := LoadYAMLPatterns(yaml, nil, nil)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(patterns) != 1 {
+		t.Fatalf("want 1 pattern, got %d", len(patterns))
+	}
+	// Exercise the structured check.
+	raw := json.RawMessage(`{"message":{"stop_reason":"rate_limited"}}`)
+	m := patterns[0].Structured(adapterprotocol.RawEntry{}, raw)
+	if m == nil {
+		t.Fatal("expected structured match")
+	}
+	raw2 := json.RawMessage(`{"message":{"stop_reason":"max_tokens"}}`)
+	if m := patterns[0].Structured(adapterprotocol.RawEntry{}, raw2); m != nil {
+		t.Errorf("expected no match for max_tokens, got %+v", m)
+	}
+}
+
+func TestLoadYAMLPatterns_RegexCompileError(t *testing.T) {
+	yaml := []byte(`version: 1
+patterns:
+  - id: bad
+    source: regex
+    reason: x
+    re: '(unbalanced'
+`)
+	if _, err := LoadYAMLPatterns(yaml, nil, nil); err == nil {
+		t.Error("expected compile error for invalid regex, got nil")
+	}
+}
+
+func TestLoadYAMLPatterns_VersionMismatch(t *testing.T) {
+	yaml := []byte(`version: 99
+patterns: []
+`)
+	if _, err := LoadYAMLPatterns(yaml, nil, nil); err == nil {
+		t.Error("expected version mismatch error, got nil")
+	}
+}
+
+func TestLoadYAMLPatterns_NoReDoSOnPathological(t *testing.T) {
+	// Sanity check: the bundled-style regex shape must not catastrophically
+	// backtrack on hostile input. Run with a hard deadline.
+	yaml := []byte(`version: 1
+patterns:
+  - id: redos
+    source: regex
+    reason: rate_limited
+    roles: [system]
+    re: '(?i)(?:hit your limit|limit reached|usage limit)[^\n]{0,80}?(?:resets?(?:\s+in)?\s+(?P<reset>[^\n.]{1,30}))?'
+`)
+	patterns, err := LoadYAMLPatterns(yaml, nil, nil)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	hostile := ""
+	for i := 0; i < 5000; i++ {
+		hostile += "a"
+	}
+	done := make(chan bool, 1)
+	go func() {
+		_ = patterns[0].Re.FindStringSubmatch(hostile)
+		done <- true
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReDoS: regex did not finish within 2s on hostile input")
+	}
+}
+
+func TestConfirmedMatch_ToTerminalErrorData(t *testing.T) {
+	now := time.Now()
+	c := ConfirmedMatch{
+		SessionID:   "s1",
+		Pattern:     TerminalPattern{ID: "p1", Source: SourceRegex},
+		Match:       Match{Reason: "rate_limited", RawMessage: "msg", ResetsAtRaw: "in 3h", ResetsAt: &now},
+		EntrySeq:    7,
+		DetectedAt:  now.Add(-30 * time.Second),
+		ConfirmedAt: now,
+	}
+	d := c.ToTerminalErrorData()
+	if d.Reason != "rate_limited" || d.PatternID != "p1" || d.Source != string(SourceRegex) {
+		t.Errorf("payload fields wrong: %+v", d)
+	}
+	if d.EntrySeq != 7 {
+		t.Errorf("entry seq lost: %d", d.EntrySeq)
+	}
+	if d.ResetsAt == nil || !d.ResetsAt.Equal(now) {
+		t.Errorf("resets_at lost: %v", d.ResetsAt)
+	}
+}

--- a/pkg/adapterruntime/watcher.go
+++ b/pkg/adapterruntime/watcher.go
@@ -25,6 +25,14 @@ type FileWatcher struct {
 
 	// debounce rapid writes (e.g., multiple JSONL lines in one flush)
 	debounce time.Duration
+
+	// detector is the optional terminal-error pattern matcher. When
+	// non-nil and Enabled, every entries batch the watcher pushes is
+	// also fed to the detector; a heartbeat goroutine fires confirmed
+	// terminal_error events when their silence window elapses.
+	detector      *TerminalDetector
+	heartbeatStop chan struct{}
+	heartbeatOnce sync.Once
 }
 
 type watchedSession struct {
@@ -32,11 +40,22 @@ type watchedSession struct {
 	sessionFile string
 	offset      int64
 	timer       *time.Timer
+	// seq is the monotonically increasing batch number for this session.
+	// Bumped before each entries event so terminal_error events can be
+	// tagged with the batch they originated from.
+	seq int64
 }
 
 // NewFileWatcher creates a watcher that pushes entry events via the writer.
 // readFn is called to read new entries from the session file at a given offset.
 func NewFileWatcher(writer *Writer, readFn ReadFunc) (*FileWatcher, error) {
+	return NewFileWatcherWithDetector(writer, readFn, nil)
+}
+
+// NewFileWatcherWithDetector creates a watcher with an optional
+// terminal-error detector. Passing a nil or empty detector is
+// equivalent to NewFileWatcher.
+func NewFileWatcherWithDetector(writer *Writer, readFn ReadFunc, detector *TerminalDetector) (*FileWatcher, error) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, err
@@ -47,8 +66,13 @@ func NewFileWatcher(writer *Writer, readFn ReadFunc) (*FileWatcher, error) {
 		watcher:  w,
 		sessions: make(map[string]*watchedSession),
 		debounce: 100 * time.Millisecond,
+		detector: detector,
 	}
 	go fw.loop()
+	if detector.Enabled() {
+		fw.heartbeatStop = make(chan struct{})
+		go fw.detectorHeartbeat()
+	}
 	return fw, nil
 }
 
@@ -100,6 +124,12 @@ func (fw *FileWatcher) Unwatch(agentID string) {
 	if !fw.fileInUse(ws.sessionFile, "") {
 		_ = fw.watcher.Remove(ws.sessionFile)
 	}
+
+	// drop any pending detector state so a re-Watch under the same
+	// agentID does not inherit a half-confirmed match.
+	if fw.detector != nil {
+		fw.detector.Forget(agentID)
+	}
 }
 
 // Close shuts down the file watcher.
@@ -112,6 +142,11 @@ func (fw *FileWatcher) Close() {
 	}
 	fw.sessions = make(map[string]*watchedSession)
 	fw.mu.Unlock()
+	fw.heartbeatOnce.Do(func() {
+		if fw.heartbeatStop != nil {
+			close(fw.heartbeatStop)
+		}
+	})
 	_ = fw.watcher.Close()
 }
 
@@ -186,25 +221,74 @@ func (fw *FileWatcher) readAndPush(agentID string) {
 		return
 	}
 
+	// Bump per-session sequence under the lock so the entries event
+	// and the detector's pending-match record agree on the batch
+	// identifier the daemon will later use to gate finalize.
 	fw.mu.Lock()
+	var seq int64
 	if ws, ok := fw.sessions[agentID]; ok {
 		ws.offset = newOffset
 		ws.timer = nil
+		ws.seq++
+		seq = ws.seq
 	}
 	fw.mu.Unlock()
 
 	data, err := json.Marshal(adapterprotocol.EntriesEventData{
 		Entries:   entries,
 		NewOffset: newOffset,
+		Seq:       seq,
 	})
 	if err != nil {
 		log.Printf("file watcher marshal error: %v", err)
 		return
 	}
 
+	// Ordering invariant: entries event MUST be pushed before the
+	// detector observes the batch. The daemon's terminal-error
+	// handler gates finalize on "entries with Seq <= EntrySeq have
+	// been persisted", which is only true if the entries event hits
+	// the wire first.
 	fw.writer.PushEvent(adapterprotocol.Event{
-		Event:   "entries",
+		Event:   adapterprotocol.EventEntries,
 		AgentID: agentID,
 		Data:    data,
 	})
+
+	if fw.detector.Enabled() {
+		// rawLines parallel-to-entries is not currently surfaced by the
+		// ReadFunc contract; pass nil so structured-pass falls back to
+		// inspecting RawEntry fields. Adapters wanting full JSON-path
+		// access should extend the ReadFunc signature in a follow-up.
+		fw.detector.OnBatch(agentID, entries, seq, nil)
+	}
+}
+
+// detectorHeartbeat polls the detector every 2s for confirmed matches
+// and pushes them to the daemon as terminal_error events. Runs until
+// the watcher is closed.
+func (fw *FileWatcher) detectorHeartbeat() {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-fw.heartbeatStop:
+			return
+		case now := <-ticker.C:
+			confirmed := fw.detector.Tick(now)
+			for _, c := range confirmed {
+				payload := c.ToTerminalErrorData()
+				data, err := json.Marshal(payload)
+				if err != nil {
+					log.Printf("terminal_error marshal error: %v", err)
+					continue
+				}
+				fw.writer.PushEvent(adapterprotocol.Event{
+					Event:   adapterprotocol.EventTerminalError,
+					AgentID: c.SessionID,
+					Data:    data,
+				})
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

When an AI coding agent (Claude Code, etc.) hits a hard usage cap, it emits a message like "You've hit your limit · resets in 3h" and goes silent. Today the adapter waits 30-60s for its timeout, the session stays "active" in `ox status`, the daemon keeps polling, and the user sees nothing useful. This PR adds adapter-side pattern detection that surfaces a structured `terminal_error` event, lets the daemon finalize the session cleanly with a typed stop reason, and renders the reason (plus resets-at hint) in `ox status` / `ox session list`.

## Detection and dispatch pipeline

```mermaid
flowchart LR
    A["adapter watcher (JSONL tail)"] -->|"entries event, Seq=N"| W["daemon read loop"]
    A --> DET["TerminalDetector.OnBatch"]
    DET --> S1{"structured pass<br/>message.stop_reason"}
    DET --> R1{"regex fallback<br/>system role only"}
    S1 -->|"hit"| P["pending match<br/>(session keyed)"]
    R1 -->|"hit"| P
    P --> SW{"silence window<br/>20s"}
    SW -->|"non-matching entry<br/>arrives in window"| REV["revoke (false positive)"]
    SW -->|"window elapsed"| C["ConfirmedMatch"]
    C -->|"terminal_error event<br/>EntrySeq=N"| W
    W --> DISP["dispatchPushEvent"]
    DISP -->|"terminal_error"| Q["per agent buffered queue<br/>16 cap, 30s idle GC"]
    Q --> H["DefaultTerminalErrorHandler"]
    H --> WAL["write .terminal_pending.json"]
    WAL --> GATE{"CanTransitionStopReason"}
    GATE -->|"user stop already set"| DROP["drop marker, no-op"]
    GATE -->|"allowed"| STAMP["MutateSessionMeta<br/>stamp Terminal* fields"]
    STAMP --> END["best-effort EndSession RPC"]
    END --> DEL["delete marker"]
    DEL --> AUD["audit log append"]
    AUD --> UI["ox status, ox session list"]
```

## Stop-reason precedence lattice

```mermaid
stateDiagram-v2
    [*] --> empty
    empty --> recovered: "daemon anti-entropy"
    empty --> terminal_error: "adapter rate_limited / quota"
    recovered --> terminal_error: "rank 10 to 40"
    terminal_error --> rate_limited: "rank 40 to 50"
    rate_limited --> stopped: "user takes over (rank 50 to 100)"
    rate_limited --> canceled: "user discards (rank 50 to 100)"
    stopped --> stopped: "idempotent (rank 100 = 100)"
    canceled --> canceled: "idempotent"
    note right of stopped
        User stop is terminal.
        Replays of older adapter
        terminal_error events are
        no-ops; recovery sweep
        drops their markers.
    end note
```

## Crash-safe recovery sequence

```mermaid
sequenceDiagram
    participant ADP as adapter
    participant SUP as supervisor
    participant H as terminal handler
    participant FS as session dir
    participant DAE as daemon (next start)
    ADP->>SUP: terminal_error event
    SUP->>H: dispatch (per agent queue)
    H->>FS: write .terminal_pending.json (WAL)
    H->>FS: read existing meta.json
    Note over H,FS: precedence gate passes
    H->>FS: MutateSessionMeta stamp Terminal*
    Note over H,SUP: daemon crash here
    DAE->>FS: glob sessions/*/.terminal_pending.json
    DAE->>FS: marker found, replay processTerminalEvent
    DAE->>FS: meta already stamped, idempotent
    DAE->>FS: delete marker, audit log
```

## What this PR ships

- **Protocol (`pkg/adapterprotocol`).** New `EventTerminalError` event + `TerminalErrorData` payload (Reason, Source, PatternID, RawMessage capped 512B, ResetsAtRaw, ResetsAt, EntrySeq for ordering). `EntriesEventData.Seq` for daemon-side batch gating. `ProtocolDate` constant for fine-grained capability negotiation.
- **Stop-reason model (`internal/session/classify.go`).** `StopReasonRateLimited` / `StopReasonQuotaExceeded` / `StopReasonTerminalError` plus precedence lattice (`CanTransitionStopReason`) so user-stop always wins over adapter-detected reasons. UI formatter `FormatStopReason` returns text like "rate limit (resets 15:00)" or falls back to raw matched substring when parsing is ambiguous.
- **Meta + StopOutput (`internal/lfs/meta.go`, `internal/session/pipeline`, `internal/session/store.go`).** `SessionMeta` gains `StopReason/StopDetail/StopSource/StopPatternID/StopResetsAtRaw/StopResetsAt` + `SessionMetaBuilder.TerminalStop` setter. Same fields mirrored on `Result`, `StopOutput`, and `SessionInfo`. Plumbed end-to-end from daemon stamp to `ox session stop` JSON.
- **Detector SDK (`pkg/adapterruntime/terminal_patterns.go`, `watcher.go`).** Data-driven `TerminalDetector` with structured-pass first, regex fallback with role gate (default system-only) + cheap substring pre-filter (ReDoS-tested), silence-window confirm/revoke (default 20s), per-session pending state, `Metrics` interface, YAML catalog loader with `json_path` declarative structured checks. `NewFileWatcherWithDetector` wires detector into the read loop + 2s heartbeat goroutine that pushes confirmed matches.
- **Claude Code patterns (`cmd/ox-adapter-claude-code`).** Embedded `terminal_patterns.yaml` with three patterns: structured `message.stop_reason==rate_limited` (preferred), structured `message.stop_reason==max_tokens` (informational metric only — does not finalize), regex `usage_limit` system-role-only with reset-time named capture. `parseClaudeReset` accepts relative durations ("3h", "in 2h 15m", "15:00") and **rejects ambiguous formats** (AM/PM, timezone tags) — returns raw string with nil time so UI displays the raw substring rather than a wrong absolute time.
- **Daemon dispatch (`internal/daemon/adapter_supervisor.go`, `adapter_supervisor_terminal.go`, `terminal_handler.go`).** Replaced the silent "skip push event" branch with `dispatchPushEvent`: routes `terminal_error` to a per-agent buffered queue (drain goroutine per agent, 30s idle GC) so finalize for agent A cannot block finalize for agent B and cannot deadlock by RPC-ing back into the same adapter. `DefaultTerminalErrorHandler` resolves session path via `LoadRecordingStateForAgent`, writes `.terminal_pending.json` WAL marker **before** any state mutation, precedence-gates against existing meta, stamps Terminal* fields via `MutateSessionMeta` (existing flock-protected RMW), best-effort `EndSession` RPC, deletes marker on success. `RecoverPendingTerminalFinalize` glob-replays markers on daemon restart (corrupt markers dropped; user-stop survives recovery).
- **Audit log.** Every confirmed terminal event appends a JSONL row to `<ledger>/.sageox/audit/terminal_events.jsonl` (session_path, agent_id, adapter_type, pattern_id, source, reason, raw_message truncated to 256B, timestamps).
- **UI display (`cmd/ox/session_list.go`, `internal/uicatalog/entries`).** `ox session list` appends `[rate limit (resets HH:MM)]` annotation; uicatalog status_screen + session_list_screen demonstrate the paused-with-terminal-reason design.
- **Doctor + metrics + kill switch.** `internal/doctor/checks/terminal_patterns.go` advisory check. `internal/observability/terminal_metrics.go` `InMemoryMetrics` impl satisfying `adapterruntime.Metrics` with OTLP-shaped histogram bucket boundaries (5s-300s) — real OTLP exporter wiring deferred until a meter provider lands in `internal/observability/otel.go`. Env-var kill switch `OX_DISABLE_TERMINAL_DETECTION=<adapter>,…` (case-insensitive, comma-separated) via `adapterruntime.AdapterDisabledByEnv`.

## Test Plan

- `go build ./...` clean.
- 956+ tests pass across `pkg/adapterruntime`, `internal/session`, `internal/lfs`, `internal/daemon`, `internal/doctor`, `internal/observability`, `cmd/ox-adapter-claude-code`.
- Phase 1 framework: 15 detector tests including structured-first ordering, role gate (system / assistant / user / tool), substring pre-filter, silence-window confirm + revoke, empty-reason informational pattern, RawMessage truncation, ReDoS sanity (under 2s on 5000-char hostile input), YAML loader (json_path structured, regex compile error, version mismatch).
- Phase 2 adapter: `TestParseClaudeReset` table (relative durations parse, AM/PM and timezone rejected), structured + regex patterns, golden corpus regression over 6 fabricated JSONL fixtures (3 positive, 3 negative).
- Phase 3 daemon: dispatch routes terminal vs subagent vs entries vs unknown; per-agent isolation across 3 agents; no-handler silently drops. `processTerminalEvent` stamps meta, respects user-stop precedence, truncates detail, writes audit log, refuses to invent meta.json from scratch. `RecoverPendingTerminalFinalize` replays markers, no-ops when already finalized, drops corrupt markers.
- Phase 4: `CanTransitionStopReason` table (9 cases) + `FormatStopReason` (10 cases), kill-switch env var parsing (case + whitespace tolerant), doctor check happy-path.

## Golden corpus — why fabricated samples are a liability

The 6 fixtures under `cmd/ox-adapter-claude-code/testdata/terminal/` are fabricated. Each begins with `{"_meta":{"fabricated":true,...}}`. They were written from a reading of Claude Code's documented JSONL schema, not from observed output. That is good enough to exercise the parser end-to-end and prove the patterns wire up, but it is **not** good enough to prove the patterns actually match real Claude Code emissions.

Risks of shipping with fabricated corpus only:

1. **Schema drift.** Anthropic ships Claude Code updates roughly weekly. A field rename (`stop_reason` to `finish_reason`) or nesting change (`message.stop_reason` to `usage.stop_reason`) silently breaks the structured pattern and we never know until a user reports a stuck session. The regex fallback covers some of this, but not all, and structured signals are the primary detection path by design.
2. **False-positive blindness.** We have no idea what real Claude Code system messages look like during normal operation. There may be wordings ("approaching limit", "tier upgrade available") that share substrings with our regex and would fire incorrectly. Without real captures we cannot tune.
3. **Reset-time format coverage.** `parseClaudeReset` rejects AM/PM and timezones, but Claude Code may localize reset times in formats we have not seen ("today at 3 PM PT", "tomorrow 09:00 UTC"). Real captures tell us which forms to support cleanly.
4. **Multi-line messages.** Real rate-limit messages may span multiple JSONL entries (a system entry plus an assistant follow-up). Our silence-window logic assumes the terminal entry is the last one before silence — fabricated single-entry fixtures cannot validate that.

**Replacing fabricated with real does not require code changes** — only the fixture files. The YAML patterns and parser stay put. The corpus is a black-box conformance test of the production code path.

## Per-adapter capture matrix

ox bundles 8 session adapters today. Only Claude Code ships terminal patterns in this PR; the other 7 need their own capture + pattern packs (filed as follow-up bd issues). For each, we need a **minimum corpus** of real captures:

| Adapter | Vendor signal source | Session file path | Captures needed |
|---|---|---|---|
| `claude-code` | Anthropic API `stop_reason` field; CLI system messages | `~/.claude/projects/<hash>/<sid>.jsonl` | Rate limit (5h tier), monthly quota, "approaching limit" warning, normal session, prior-session-quoted message |
| `codex` | OpenAI API `finish_reason`, HTTP 429 surface | `~/.codex/sessions/...` (verify) | Tier-limit hit, RPM exceeded, monthly cap, organization quota, model unavailability |
| `gemini` | Google AI `finishReason`, 429 retryAfter | `~/.config/gemini-cli/...` (verify) | Free-tier minute cap, daily cap, region-restricted error, model unavailable |
| `amp` | Sourcegraph API surface | `~/.config/amp/...` (verify) | Plan limit, org seat exhaustion, model fallback notice |
| `aider` | Backend-LLM dependent (anthropic / openai / etc.) | `~/.aider/` or in-repo `.aider.chat.history.md` (verify) | Captures per backing LLM; same surfaces as codex / claude-code via the backend |
| `droid` | Factory AI surface | `~/.factory/...` (verify) | Tier limit, agent quota |
| `pi` | TBD | TBD | TBD — adapter scope to audit |
| `opencode` | TBD | TBD | TBD — adapter scope to audit |

**What "real capture" means:**

- **Positive sample.** The agent actually hit the terminal condition. The JSONL contains the vendor-emitted message verbatim (including punctuation, Unicode, surrounding entries). At least 5 entries of preceding context so silence-window logic has something to chew on.
- **Negative sample of the same shape.** A normal session where the agent merely *discusses* rate limits in an assistant turn (planning, code review, doc writing). Same `~/.claude/projects/` directory format; just no real terminal event. Proves role gating + silence revoke defeat false positives.
- **Prior-session-quoted sample.** The agent renders a quoted line from a past session (e.g. "Last time you said 'limit reached'"). Same role/format. Proves replay defense.
- **Reset-format coverage.** At least 3 captures spanning different reset-time wordings the vendor uses ("in 3h", "at 15:00", "tomorrow"). Lets `parseClaudeReset` (and future per-vendor parsers) tune confidence.

**Collection protocol** (recommended follow-up):

1. Add `ox dev capture-terminal-sample <adapter> --session-file <path>` that copies the JSONL to `cmd/ox-adapter-<adapter>/testdata/terminal/<slug>.<positive|negative|replay>.jsonl` with a `_meta` header documenting **provenance** (date, adapter version, vendor product version, redaction pass applied).
2. SOPs-style guidance for capturing positives: free-tier accounts hit rate limits cheaply; recommend running a known-heavy task on a fresh free-tier key to reliably trigger each vendor's terminal surface. Document the exact incantation per vendor.
3. CI guard: a fabricated fixture (`fabricated:true` in `_meta`) emits a `t.Logf` warning but does not fail. After a real capture lands, drop the fabricated one or move it to `testdata/terminal/legacy-fabricated/` for diff history.
4. Drift detection: telemetry counter `ox.adapter.terminal.pattern_hit{adapter,pattern_id}` plus a 30-day silence alert (last_match_unix gauge). When a known pattern has not fired in 30 days while real rate-limit sessions still complete via other paths, vendor wording almost certainly drifted.

## Other improvements worth landing soon

- **`ReadFunc` signature extension.** Today `FileWatcher.readAndPush` passes `nil` for `rawLines` to the detector, so structured JSON-path checks only fire from the test path. Extending the SDK's `ReadFunc` to return original JSON bytes alongside `RawEntry` is a small mechanical follow-up — once done, the structured-first detection path lights up in production and the regex fallback becomes the safety net it was designed to be.
- **OTLP exporter.** `internal/observability/otel.go` currently sets up only a tracer provider. Once a JWT-bearing meter provider lands (auth path already shipped in #628), swap `InMemoryMetrics` for the OTLP impl — Metrics interface keeps the swap one-line.
- **Config-key path** for the kill switch. Env var ships now; project / user / team config (`~/.sageox/config.yaml: terminal_detection.disabled_adapters: [...]`) is the natural follow-up.
- **`ox session resume <id>`** — the UI copy suggests this command; it does not exist yet. Either wire it up or change the copy.
- **Auto-resume at `resets_at`** — opt-in. Notify the user when the window passes; do not silently restart.
- **`cmd/ox/status.go` per-session display** — today it shows aggregate AI coworker counts. A row-per-session view would let terminal-stop annotations surface there too.
- **Murmur on rate-limit hit** — high-signal team context. Auto-publish `wip: "Claude paused — rate limit, resets ~3h"` to teammates.
- **i18n / locale pattern packs** — vendors localize. Claude Code is English-anchored today but a Japanese rate-limit message will silently miss the regex. Per-locale catalogs (or fully structured detection, which is locale-independent) is the long-term fix.

## Bd issues

Closed: ox-spn1 (P1), ox-gp36 (P2), ox-6bjo (P3), ox-u6k9 (P4), ox-qfl4 (epic).

To file (recommend P2 — none block this PR landing):

- Capture-and-replace real Claude Code corpus (positive + negative + replay + reset-format coverage).
- Per-adapter pattern packs: codex, gemini, amp, aider, droid (audit pi + opencode adapter scope first).
- `ox dev capture-terminal-sample` collection helper.
- ReadFunc signature extension for structured-pass in production.
- OTLP meter provider + exporter swap.
- Config-key path for kill switch.
- `ox session resume <id>` command.
- 30-day pattern-silence drift alert.

---
<details>
<summary>Checklist</summary>

- [x] Tests added (Phase 1 framework + Phase 2 adapter + Phase 3 daemon + Phase 4 classify/doctor/env-var)
- [ ] CHANGELOG entry — N/A (no user-facing CLI surface changes today; reason appears in existing JSON output via `omitempty` fields and existing list formatting)
- [ ] Breaking change — none
- [ ] `/security-review` — N/A; this PR touches none of the auto-watched paths (`internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, `go.sum`)

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal error detection: adapters can report rate limits, quota/exceeded and terminal conditions with reset timing.
  * Session stop output now includes structured terminal details (reason, source, pattern id, resets).
  * CLI: session list shows paused/rate-limit badges; status screen adds an “AI COWORKERS” section.

* **Documentation**
  * Added a doctor check to validate the terminal-patterns framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->