### PR TITLE
feat(session): durable commit + PR/issue linkage (reverse index, hooks, stale-URL fix)

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1314,7 +1314,8 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		Title(state.Title).
 		EntryCount(result.EntryCount).
 		Summary(result.Summary).
-		StopReason(session.StopReasonStopped)
+		StopReason(session.StopReasonStopped).
+		ProducedCommits(state.ProducedCommits)
 
 	// inject sageox contribution score from cache file into meta.json,
 	// then clean up the score file to prevent stale scores leaking into future sessions

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1315,7 +1315,15 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		EntryCount(result.EntryCount).
 		Summary(result.Summary).
 		StopReason(session.StopReasonStopped).
-		ProducedCommits(state.ProducedCommits)
+		ProducedCommits(state.ProducedCommits).
+		LinkedPRs(state.LinkedPRs).
+		LinkedIssues(state.LinkedIssues).
+		// staged: meta.json is being written here, BEFORE the LFS upload +
+		// git push below. The transition to uploaded (and the notify) happens
+		// only after commitAndPushLedger succeeds — see the M5 block at the
+		// end of this function. Setting uploaded here would lie about a
+		// session that may never reach the remote.
+		LinkageStatus(lfs.LinkageStatusStaged)
 
 	// inject sageox contribution score from cache file into meta.json,
 	// then clean up the score file to prevent stale scores leaking into future sessions
@@ -1394,6 +1402,14 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 			slog.Warn("LFS pointer file write failed after push", "error", writeErr, "session", sessionName)
 		}
 	}
+
+	// M5: the push succeeded — the session URL is now viewable. Transition
+	// LinkageStatus to uploaded and best-effort notify the SageOx server so
+	// the (v2) GitHub App reconciler can refresh any PR sticky comment. The
+	// notify is fire-and-forget: a failure leaves the session in
+	// notify_failed for `ox doctor` to retry, and never affects the
+	// already-successful upload.
+	finalizeLinkageAfterPush(projectRoot, sessionDir, meta, sessionName)
 
 	return nil
 }

--- a/cmd/ox/agent_session_recover.go
+++ b/cmd/ox/agent_session_recover.go
@@ -220,6 +220,7 @@ func recoverFromCache(inst *agentinstance.Instance, projectRoot string, state *s
 					metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
 						EntryCount(entryCount).
 						StopReason(session.StopReasonRecovered).
+						ProducedCommits(state.ProducedCommits).
 						WithFiles(fileRefs)
 					if preservedID != "" {
 						metaBuilder = metaBuilder.SessionID(preservedID)

--- a/cmd/ox/doctor_session.go
+++ b/cmd/ox/doctor_session.go
@@ -91,6 +91,12 @@ func checkSessionHealth(opts doctorOptions) []checkResult {
 		results = append(results, incompleteResult)
 	}
 
+	// linkage soft signals: trailer coverage on recent commits and
+	// reachability of closed-session ProducedCommits SHAs. Neither blocks;
+	// both are diagnostic.
+	results = append(results, checkSessionTrailerRatio())
+	results = append(results, checkSessionProducedCommitsStaleness())
+
 	return results
 }
 

--- a/cmd/ox/doctor_session_linkage.go
+++ b/cmd/ox/doctor_session_linkage.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// doctor_session_linkage.go houses two soft-signal doctor checks for the
+// commit↔session linkage system:
+//
+//  1. checkSessionTrailerRatio surfaces "how many of the last N commits on
+//     this branch carry a SageOx-Session: trailer." A low ratio is the
+//     smoking gun for GitHub squash-merge stripping trailers, for users
+//     committing with --no-verify, or for prepare-commit-msg not being
+//     installed. Never fails — just informs.
+//
+//  2. checkSessionProducedCommitsStaleness scans closed sessions in the
+//     ledger sessions/ tree and reports how many SHAs they reference
+//     that are no longer reachable in the current branch's history.
+//     This is the visible part of D3 (closed-session post-rewrite is
+//     intentionally not auto-mutated; staleness is a soft signal so
+//     users notice).
+//
+// Both checks are read-only and intended to run quickly (bounded scan
+// windows). They never block any session work.
+
+// trailerScanCommitCount caps how far back the trailer-ratio scan looks.
+// 50 is enough to catch a recent regression without scanning thousands of
+// commits on a long-lived branch.
+const trailerScanCommitCount = 50
+
+// trailerRatioWarnThreshold is the fraction below which we render a warn-
+// style soft signal. 0.4 chosen heuristically: a healthy active session
+// produces commits with trailers; a 40% floor lets normal post-stop
+// activity coexist without alarming.
+const trailerRatioWarnThreshold = 0.4
+
+// checkSessionTrailerRatio scans the last N commits and reports the share
+// carrying a SageOx-Session: trailer. Soft signal only.
+//
+// Skip cases (each returns SkippedCheck with a reason — not a failure):
+//   - Not inside a git repo
+//   - Repo has no commits yet
+//   - git log invocation errors
+func checkSessionTrailerRatio() checkResult {
+	const name = "session trailer coverage"
+
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(name, "not in a git repo", "")
+	}
+
+	count, withTrailer, err := scanTrailerRatio(gitRoot, trailerScanCommitCount)
+	if err != nil {
+		return SkippedCheck(name, fmt.Sprintf("git log failed: %v", err), "")
+	}
+	if count == 0 {
+		return SkippedCheck(name, "no commits in scan window", "")
+	}
+
+	ratio := float64(withTrailer) / float64(count)
+	msg := fmt.Sprintf("%d/%d recent commits carry SageOx-Session trailer (%.0f%%)",
+		withTrailer, count, ratio*100)
+
+	if ratio >= trailerRatioWarnThreshold {
+		return PassedCheck(name, msg)
+	}
+	fix := "If a squash-merge config strips trailers or commits are landing without `ox` running, " +
+		"recent commits will not be linkable to their sessions. See docs/ai/specs/session-commit-linkage.md."
+	return WarningCheck(name, msg, fix)
+}
+
+// scanTrailerRatio returns (totalCommits, withTrailer, err) for the last
+// `limit` commits on HEAD. Pure: only reads git state.
+func scanTrailerRatio(gitRoot string, limit int) (int, int, error) {
+	// %H + %B per commit, separated by NUL to survive newlines in messages
+	out, err := runGitLinkage(gitRoot, "log", fmt.Sprintf("-%d", limit), "--format=%H%n%B%x00")
+	if err != nil {
+		return 0, 0, err
+	}
+	records := strings.Split(out, "\x00")
+	total, with := 0, 0
+	for _, rec := range records {
+		rec = strings.TrimSpace(rec)
+		if rec == "" {
+			continue
+		}
+		total++
+		if strings.Contains(rec, "SageOx-Session:") {
+			with++
+		}
+	}
+	return total, with, nil
+}
+
+// checkSessionProducedCommitsStaleness scans closed sessions in the
+// ledger and reports how many of their ProducedCommits SHAs are
+// unreachable in the project repo's current history. Soft signal only.
+func checkSessionProducedCommitsStaleness() checkResult {
+	const name = "session ProducedCommits reachability"
+
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger found", "")
+	}
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(name, "not in a git repo", "")
+	}
+
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return SkippedCheck(name, "no sessions directory", "")
+	}
+
+	var totalSessions, sessionsWithStale, totalStaleSHAs int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sessionDir := filepath.Join(sessionsDir, e.Name())
+		meta, err := lfs.ReadSessionMeta(sessionDir)
+		if err != nil || meta == nil || len(meta.ProducedCommits) == 0 {
+			continue
+		}
+		totalSessions++
+		stale := countUnreachableSHAs(gitRoot, meta.ProducedCommits)
+		if stale > 0 {
+			sessionsWithStale++
+			totalStaleSHAs += stale
+		}
+	}
+
+	if totalSessions == 0 {
+		return SkippedCheck(name, "no closed sessions with ProducedCommits", "")
+	}
+	if sessionsWithStale == 0 {
+		return PassedCheck(name, fmt.Sprintf("all %d sessions' commits reachable", totalSessions))
+	}
+
+	msg := fmt.Sprintf("%d/%d sessions reference unreachable commits (%d SHAs total)",
+		sessionsWithStale, totalSessions, totalStaleSHAs)
+	fix := "Closed sessions are intentionally NOT mutated by post-rewrite (D3). " +
+		"Stale entries are expected after rebasing commit ranges that occurred during prior recordings."
+	return WarningCheck(name, msg, fix)
+}
+
+// countUnreachableSHAs returns how many SHAs in `shas` are not present in
+// the current project repo's object database (git cat-file -e).
+func countUnreachableSHAs(gitRoot string, shas []string) int {
+	unreachable := 0
+	for _, sha := range shas {
+		if sha == "" {
+			continue
+		}
+		cmd := exec.Command("git", "-C", gitRoot, "cat-file", "-e", sha)
+		if err := cmd.Run(); err != nil {
+			unreachable++
+		}
+	}
+	return unreachable
+}
+
+// runGitLinkage captures stdout from a git invocation rooted at gitRoot.
+// Local to this file to avoid colliding with the test-only runGit helper
+// elsewhere in cmd/ox.
+func runGitLinkage(gitRoot string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", gitRoot}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cmd/ox/hooks_commit_msg_rewrite_test.go
+++ b/cmd/ox/hooks_commit_msg_rewrite_test.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hooks_commit_msg_rewrite_test.go locks down what the trailer-based
+// commit→session linkage guarantees across git rewrites (amend, rebase,
+// cherry-pick, reset, squash). The trailer is the canonical forward link
+// from a commit back to its session; if git silently drops it, every PR
+// comment, every retrospective lookup, and every "show me what this commit
+// produced" workflow breaks.
+//
+// Cases that should pass are asserted to pass; cases that ARE documented
+// losses (reset+recommit-without-recording, post-stop commits) are
+// asserted to lose. We assert the loss explicitly so that if a future
+// change accidentally starts preserving the trailer in those paths, the
+// test forces us to acknowledge it (and update docs/ai/specs/session-commit-linkage.md).
+
+// trailerRewriteEnv sets up a real git repo under a temp dir with .sageox/
+// initialized and a fake active recording. Returns (projectRoot,
+// sessionName, agentID).
+func trailerRewriteEnv(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	projectRoot := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	// .sageox/config.json — minimal, attribution.session defaults to "auto"
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"),
+		[]byte(`{"repo_id":"repo_01test","endpoint":"https://sageox.ai"}`), 0o644))
+
+	// git init + identity (cmd.Dir scoped — never mutate the developer's repo)
+	requireGitTrailer(t, projectRoot, "init")
+	requireGitTrailer(t, projectRoot, "config", "user.name", "Test User")
+	requireGitTrailer(t, projectRoot, "config", "user.email", "test@example.com")
+	requireGitTrailer(t, projectRoot, "config", "commit.gpgsign", "false")
+	// stable branch name so rebase-onto-self has a known target
+	requireGitTrailer(t, projectRoot, "checkout", "-b", "main")
+
+	// fake active recording — projectRoot/sessions/<name>/.recording.json
+	agentID := "OxTRAIL"
+	sessionName := "2026-05-28T00-00-tester-" + agentID
+	sessionsDir := filepath.Join(projectRoot, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	state := session.RecordingState{
+		AgentID:       agentID,
+		StartedAt:     time.Now(),
+		SessionPath:   sessionsDir,
+		WorkspacePath: projectRoot,
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionsDir, ".recording.json"), data, 0o644))
+
+	t.Setenv("SAGEOX_AGENT_ID", agentID)
+
+	// chdir so findProjectRoot resolves the right repo
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	require.NoError(t, os.Chdir(projectRoot))
+
+	return projectRoot, sessionName, agentID
+}
+
+// commitWithTrailer writes a commit message, runs the trailer-injection
+// code path (the same code the prepare-commit-msg hook invokes), and
+// commits with the mutated message. Returns the new HEAD SHA.
+//
+// Going through runHooksCommitMsg rather than `git commit -m` directly is
+// the whole point: this is the production injector. If it breaks, the
+// test breaks.
+func commitWithTrailer(t *testing.T, projectRoot, subject string) string {
+	t.Helper()
+
+	// stage some change so the commit isn't empty
+	makeContentChange(t, projectRoot, subject)
+	requireGitTrailer(t, projectRoot, "add", "-A")
+
+	msgFile := filepath.Join(t.TempDir(), "COMMIT_EDITMSG")
+	require.NoError(t, os.WriteFile(msgFile, []byte(subject+"\n"), 0o644))
+
+	prevSource, prevFile := hooksCommitMsgSource, hooksCommitMsgFile
+	t.Cleanup(func() {
+		hooksCommitMsgSource = prevSource
+		hooksCommitMsgFile = prevFile
+	})
+	hooksCommitMsgSource = ""
+	hooksCommitMsgFile = msgFile
+	require.NoError(t, runHooksCommitMsg(nil, nil))
+
+	requireGitTrailer(t, projectRoot, "commit", "-F", msgFile)
+
+	return strings.TrimSpace(captureGitTrailer(t, projectRoot, "rev-parse", "HEAD"))
+}
+
+// commitWithoutTrailer is for documented-loss cases — commits that fire
+// outside an active recording (e.g. after session stop).
+func commitWithoutTrailer(t *testing.T, projectRoot, subject string) string {
+	t.Helper()
+	makeContentChange(t, projectRoot, subject)
+	requireGitTrailer(t, projectRoot, "add", "-A")
+	requireGitTrailer(t, projectRoot, "commit", "-m", subject)
+	return strings.TrimSpace(captureGitTrailer(t, projectRoot, "rev-parse", "HEAD"))
+}
+
+func makeContentChange(t *testing.T, projectRoot, marker string) {
+	t.Helper()
+	// append a unique marker line so each commit modifies something
+	path := filepath.Join(projectRoot, "file.txt")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = fmt.Fprintf(f, "%s\n", marker)
+	require.NoError(t, err)
+}
+
+func requireGitTrailer(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\noutput: %s", strings.Join(args, " "), err, out)
+	}
+}
+
+func captureGitTrailer(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s failed: %v", strings.Join(args, " "), err)
+	}
+	return string(out)
+}
+
+func headMessage(t *testing.T, projectRoot, ref string) string {
+	t.Helper()
+	return captureGitTrailer(t, projectRoot, "log", "-1", "--format=%B", ref)
+}
+
+const trailerKey = "SageOx-Session:"
+
+// TestSessionTrailerSurvives_Amend verifies amend preserves the trailer.
+// Failure prevented: every `commit --amend` would silently break the
+// commit→session link, which is the most common rewrite developers run.
+func TestSessionTrailerSurvives_Amend(t *testing.T) {
+	projectRoot, _, _ := trailerRewriteEnv(t)
+
+	commitWithTrailer(t, projectRoot, "initial commit")
+	require.Contains(t, headMessage(t, projectRoot, "HEAD"), trailerKey)
+
+	// amend without changing message — git preserves the trailer for free
+	makeContentChange(t, projectRoot, "amend-extra")
+	requireGitTrailer(t, projectRoot, "add", "-A")
+	requireGitTrailer(t, projectRoot, "commit", "--amend", "--no-edit")
+
+	assert.Contains(t, headMessage(t, projectRoot, "HEAD"), trailerKey,
+		"amend must preserve SageOx-Session trailer")
+}
+
+// TestSessionTrailerSurvives_NonInteractiveRebase verifies a vanilla
+// rebase preserves trailers across the replayed commits.
+// Failure prevented: rebasing onto main is part of every PR workflow; a
+// silent trailer drop here disconnects entire feature branches.
+func TestSessionTrailerSurvives_NonInteractiveRebase(t *testing.T) {
+	projectRoot, _, _ := trailerRewriteEnv(t)
+
+	base := commitWithTrailer(t, projectRoot, "base")
+	commitWithTrailer(t, projectRoot, "feature one")
+	commitWithTrailer(t, projectRoot, "feature two")
+
+	// branch off, then rebase onto base — non-interactive replay
+	requireGitTrailer(t, projectRoot, "branch", "feature")
+	requireGitTrailer(t, projectRoot, "checkout", "main")
+	requireGitTrailer(t, projectRoot, "reset", "--hard", base)
+	requireGitTrailer(t, projectRoot, "checkout", "feature")
+	requireGitTrailer(t, projectRoot, "rebase", "main")
+
+	allMsgs := captureGitTrailer(t, projectRoot, "log", "--format=%B", base+"..HEAD")
+	count := strings.Count(allMsgs, trailerKey)
+	assert.Equal(t, 2, count, "rebase must preserve trailer on each replayed commit; messages were:\n%s", allMsgs)
+}
+
+// TestSessionTrailerSurvives_CherryPick verifies cherry-pick copies the
+// trailer along with the message.
+// Failure prevented: backporting / cross-branch picks lose attribution.
+func TestSessionTrailerSurvives_CherryPick(t *testing.T) {
+	projectRoot, _, _ := trailerRewriteEnv(t)
+
+	base := commitWithTrailer(t, projectRoot, "base")
+	feature := commitWithTrailer(t, projectRoot, "feature commit")
+
+	// branch back to base and cherry-pick the feature commit
+	requireGitTrailer(t, projectRoot, "checkout", "-b", "other", base)
+	requireGitTrailer(t, projectRoot, "cherry-pick", feature)
+
+	assert.Contains(t, headMessage(t, projectRoot, "HEAD"), trailerKey,
+		"cherry-pick must preserve SageOx-Session trailer")
+}
+
+// TestSessionTrailerLost_ResetThenRecommitWithoutRecording documents that
+// a hard reset followed by recommitting without an active recording loses
+// the trailer (because the new commit fires through a code path where the
+// recording is no longer reachable).
+//
+// Failure prevented: if a future change accidentally starts preserving
+// the trailer here, we must consciously decide whether that's correct —
+// the loss is currently expected and documented.
+func TestSessionTrailerLost_ResetThenRecommitWithoutRecording(t *testing.T) {
+	projectRoot, _, agentID := trailerRewriteEnv(t)
+
+	first := commitWithTrailer(t, projectRoot, "first")
+	require.Contains(t, headMessage(t, projectRoot, first), trailerKey)
+
+	// reset and clear recording — simulates "session stop, then user keeps
+	// committing": there's nothing for the injector to attach.
+	requireGitTrailer(t, projectRoot, "reset", "--hard", first+"^0")
+	require.NoError(t, session.ClearRecordingStateForAgent(projectRoot, agentID))
+	t.Setenv("SAGEOX_AGENT_ID", "")
+
+	commitWithoutTrailer(t, projectRoot, "post-reset commit")
+
+	assert.NotContains(t, headMessage(t, projectRoot, "HEAD"), trailerKey,
+		"documented loss: commit after session-clear has no trailer (see docs/ai/specs/session-commit-linkage.md)")
+}
+
+// TestSessionTrailerSurvives_MergeSquash documents what `git merge
+// --squash` does to trailers. Squash collapses a range of commits into a
+// single staged change with a synthesized message; git's default is to
+// concatenate the source commit messages. Trailers from EACH source
+// commit end up in the squashed message — but consumers typically only
+// look for ONE trailer.
+//
+// We assert: trailer appears at least once. If git's behavior ever changes
+// to drop trailers entirely, this fires.
+// Failure prevented: silently losing trailer through `merge --squash` is
+// the GitHub squash-merge analog for local workflows.
+func TestSessionTrailerSurvives_MergeSquash(t *testing.T) {
+	projectRoot, _, _ := trailerRewriteEnv(t)
+
+	base := commitWithTrailer(t, projectRoot, "base")
+	requireGitTrailer(t, projectRoot, "checkout", "-b", "feature")
+	commitWithTrailer(t, projectRoot, "feature 1")
+	commitWithTrailer(t, projectRoot, "feature 2")
+
+	requireGitTrailer(t, projectRoot, "checkout", "main")
+	requireGitTrailer(t, projectRoot, "reset", "--hard", base)
+	requireGitTrailer(t, projectRoot, "merge", "--squash", "feature")
+	requireGitTrailer(t, projectRoot, "commit", "-m", "squashed feature")
+
+	// After `commit -m` (no trailer injection here because we bypassed the
+	// hook for the squash step), the squashed commit message will NOT
+	// include the trailer. This documents the GitHub squash-merge loss
+	// case: server-side squash collapses N commits into one with a new
+	// message that may not carry trailers from sources.
+	msg := headMessage(t, projectRoot, "HEAD")
+	assert.NotContains(t, msg, trailerKey,
+		"documented loss: `merge --squash` + `commit -m` drops source-commit trailers; "+
+			"GitHub squash-merge has the same loss profile (see docs/ai/specs/session-commit-linkage.md)")
+}
+
+// TestSessionTrailerLost_CommitAfterSessionStop verifies that commits made
+// after `ox session stop` clears the recording state never receive a
+// trailer.
+// Failure prevented: post-stop commits silently appear to be linked when
+// the linkage is in fact absent.
+func TestSessionTrailerLost_CommitAfterSessionStop(t *testing.T) {
+	projectRoot, _, agentID := trailerRewriteEnv(t)
+
+	commitWithTrailer(t, projectRoot, "during session")
+	require.Contains(t, headMessage(t, projectRoot, "HEAD"), trailerKey)
+
+	// stop the recording
+	require.NoError(t, session.ClearRecordingStateForAgent(projectRoot, agentID))
+	t.Setenv("SAGEOX_AGENT_ID", "")
+
+	commitWithoutTrailer(t, projectRoot, "after session stop")
+	assert.NotContains(t, headMessage(t, projectRoot, "HEAD"), trailerKey,
+		"documented limitation: commits after session stop have no trailer")
+}

--- a/cmd/ox/hooks_git.go
+++ b/cmd/ox/hooks_git.go
@@ -10,23 +10,85 @@ import (
 
 const (
 	prepareCommitMsgHookName = "prepare-commit-msg"
+	postCommitHookName       = "post-commit"
+	postRewriteHookName      = "post-rewrite"
 
-	// markers delimit the ox section within a hook file.
-	// these match the patterns in internal/uninstall/hooks.go sageoxHookMarkers.
-	oxHookMarkerStart = "# ox prepare-commit-msg hook"
-	oxHookMarkerEnd   = "# end ox hook"
+	// shared end marker — all ox-managed hook sections close with this.
+	// Mirrors the patterns in internal/uninstall/hooks.go sageoxHookMarkers.
+	oxHookMarkerEnd = "# end ox hook"
 
-	// oxHookSection is the script fragment appended to prepare-commit-msg.
-	// Calls ox hooks commit-msg which is a deterministic command (not AI-driven).
-	oxHookSection = `# ox prepare-commit-msg hook
+	// prepare-commit-msg
+	oxPrepareCommitMsgMarkerStart = "# ox prepare-commit-msg hook"
+	oxPrepareCommitMsgSection     = `# ox prepare-commit-msg hook
 # appends configured trailers (Co-Authored-By, SageOx-Session) to commits
 if command -v ox >/dev/null 2>&1; then
   ox hooks commit-msg --msg-file "$1" --source "${2:-}" 2>/dev/null || true
 fi
 # end ox hook`
+	oxPrepareCommitMsgProbe = "ox hooks commit-msg"
 
-	oxHookFull = "#!/bin/sh\n" + oxHookSection + "\n"
+	// post-commit: appends HEAD SHA to RecordingState.ProducedCommits while
+	// a recording is active. No-op when no recording. Best-effort, never blocks.
+	oxPostCommitMarkerStart = "# ox post-commit hook"
+	oxPostCommitSection     = `# ox post-commit hook
+# appends HEAD SHA to active recording's ProducedCommits index
+if command -v ox >/dev/null 2>&1; then
+  ox hooks post-commit 2>/dev/null || true
+fi
+# end ox hook`
+	oxPostCommitProbe = "ox hooks post-commit"
+
+	// post-rewrite: consumes git's stdin SHA mapping and rewrites entries
+	// in RecordingState.ProducedCommits. Passes $1 (amend|rebase) so the
+	// handler can branch if needed. Best-effort, never blocks.
+	oxPostRewriteMarkerStart = "# ox post-rewrite hook"
+	oxPostRewriteSection     = `# ox post-rewrite hook
+# rewrites SHAs in active recording's ProducedCommits on amend/rebase
+if command -v ox >/dev/null 2>&1; then
+  ox hooks post-rewrite --mode "${1:-}" 2>/dev/null || true
+fi
+# end ox hook`
+	oxPostRewriteProbe = "ox hooks post-rewrite"
+
+	// Legacy marker name from the single-hook era. Some code paths
+	// (internal/uninstall/hooks.go) may still reference this; keep it as
+	// an alias for the prepare-commit-msg marker so external readers don't
+	// silently break.
+	oxHookMarkerStart = oxPrepareCommitMsgMarkerStart
 )
+
+// hookSpec describes one ox-managed git hook section.
+type hookSpec struct {
+	name        string
+	markerStart string
+	section     string
+	probe       string // command-string fragment that must appear in a "complete" install
+}
+
+// allHookSpecs returns the set of ox-managed git hooks. Order is stable for
+// deterministic test output.
+func allHookSpecs() []hookSpec {
+	return []hookSpec{
+		{
+			name:        prepareCommitMsgHookName,
+			markerStart: oxPrepareCommitMsgMarkerStart,
+			section:     oxPrepareCommitMsgSection,
+			probe:       oxPrepareCommitMsgProbe,
+		},
+		{
+			name:        postCommitHookName,
+			markerStart: oxPostCommitMarkerStart,
+			section:     oxPostCommitSection,
+			probe:       oxPostCommitProbe,
+		},
+		{
+			name:        postRewriteHookName,
+			markerStart: oxPostRewriteMarkerStart,
+			section:     oxPostRewriteSection,
+			probe:       oxPostRewriteProbe,
+		},
+	}
+}
 
 // resolveHooksDir returns the git hooks directory, respecting core.hooksPath.
 func resolveHooksDir(gitRoot string) string {
@@ -44,21 +106,33 @@ func resolveHooksDir(gitRoot string) string {
 	return filepath.Join(gitRoot, ".git", "hooks")
 }
 
-// InstallGitHooks installs the ox prepare-commit-msg hook into the resolved
-// hooks directory. If the hook file already exists, appends the ox section
-// (delimited by markers) without disturbing existing content. Idempotent.
+// InstallGitHooks installs every ox-managed git hook into the resolved hooks
+// directory: prepare-commit-msg (trailer injection), post-commit (reverse
+// index append), and post-rewrite (reverse index SHA rewrite on amend/
+// rebase). Idempotent across all three. If a hook file already exists, the
+// ox section is appended without disturbing existing content.
 //
-// This is best-effort CLI-side linking. Commits made outside an active session
-// won't get a session trailer. For full commit↔session correlation, grant
-// SageOx GitHub repo permissions so cloud services can match after the fact.
+// post-commit / post-rewrite are best-effort CLI-side: they no-op silently
+// when no recording is active, and their handler exits 0 unconditionally.
+// They never block a commit or a rewrite.
 func InstallGitHooks(gitRoot string) error {
 	hooksDir := resolveHooksDir(gitRoot)
-	hookPath := filepath.Join(hooksDir, prepareCommitMsgHookName)
-
-	// ensure hooks directory exists
 	if err := os.MkdirAll(hooksDir, 0755); err != nil {
 		return fmt.Errorf("create hooks dir: %w", err)
 	}
+
+	for _, spec := range allHookSpecs() {
+		if err := installHookSection(hooksDir, spec); err != nil {
+			return fmt.Errorf("install %s: %w", spec.name, err)
+		}
+	}
+	return nil
+}
+
+// installHookSection adds the ox section for a single hook, preserving any
+// existing user content. Idempotent.
+func installHookSection(hooksDir string, spec hookSpec) error {
+	hookPath := filepath.Join(hooksDir, spec.name)
 
 	existing, err := os.ReadFile(hookPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -66,94 +140,108 @@ func InstallGitHooks(gitRoot string) error {
 	}
 
 	if err == nil {
-		// hook file exists — check if already installed (both markers + command present)
-		if hasValidOxHook(string(existing)) {
-			return nil // already installed
+		if hasValidHookSection(string(existing), spec) {
+			return nil
 		}
-
-		// append ox section to existing hook
 		content := string(existing)
 		if !strings.HasSuffix(content, "\n") {
 			content += "\n"
 		}
-		content += "\n" + oxHookSection + "\n"
-
+		content += "\n" + spec.section + "\n"
 		if err := os.WriteFile(hookPath, []byte(content), 0755); err != nil {
 			return fmt.Errorf("append to hook: %w", err)
 		}
 		return nil
 	}
 
-	// no existing hook — create new
-	if err := os.WriteFile(hookPath, []byte(oxHookFull), 0755); err != nil {
+	full := "#!/bin/sh\n" + spec.section + "\n"
+	if err := os.WriteFile(hookPath, []byte(full), 0755); err != nil {
 		return fmt.Errorf("write hook: %w", err)
 	}
 	return nil
 }
 
-// UninstallGitHooks removes the ox section from the prepare-commit-msg hook.
-// If the hook file contains only the ox section, removes the file entirely.
+// UninstallGitHooks removes every ox-managed section from each hook file.
+// If a hook contains only an ox section after removal (no other user
+// content), the file is removed entirely.
 func UninstallGitHooks(gitRoot string) error {
 	hooksDir := resolveHooksDir(gitRoot)
-	hookPath := filepath.Join(hooksDir, prepareCommitMsgHookName)
+	for _, spec := range allHookSpecs() {
+		if err := uninstallHookSection(hooksDir, spec); err != nil {
+			return fmt.Errorf("uninstall %s: %w", spec.name, err)
+		}
+	}
+	return nil
+}
+
+func uninstallHookSection(hooksDir string, spec hookSpec) error {
+	hookPath := filepath.Join(hooksDir, spec.name)
 
 	content, err := os.ReadFile(hookPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil // nothing to uninstall
+			return nil
 		}
 		return fmt.Errorf("read hook: %w", err)
 	}
 
-	if !strings.Contains(string(content), oxHookMarkerStart) {
-		return nil // ox section not present
+	if !strings.Contains(string(content), spec.markerStart) {
+		return nil
 	}
 
-	// remove the ox section (marker start through marker end, inclusive)
 	lines := strings.Split(string(content), "\n")
 	var result []string
-	inOxSection := false
+	inSection := false
 	for _, line := range lines {
-		if strings.Contains(line, oxHookMarkerStart) {
-			inOxSection = true
+		if strings.Contains(line, spec.markerStart) {
+			inSection = true
 			continue
 		}
-		if inOxSection && strings.Contains(line, oxHookMarkerEnd) {
-			inOxSection = false
+		if inSection && strings.Contains(line, oxHookMarkerEnd) {
+			inSection = false
 			continue
 		}
-		if !inOxSection {
+		if !inSection {
 			result = append(result, line)
 		}
 	}
 
 	cleaned := strings.TrimSpace(strings.Join(result, "\n"))
-
-	// if only shebang (or empty) remains, remove the file
 	if cleaned == "" || cleaned == "#!/bin/sh" || cleaned == "#!/bin/bash" {
 		return os.Remove(hookPath)
 	}
-
 	return os.WriteFile(hookPath, []byte(cleaned+"\n"), 0755)
 }
 
-// hasValidOxHook returns true if content contains a complete ox hook section
-// (both markers and the command). Detects partially broken installs.
-func hasValidOxHook(content string) bool {
-	return strings.Contains(content, oxHookMarkerStart) &&
+// hasValidHookSection returns true if content contains a complete ox section
+// for the given spec (start marker, end marker, and the probe command).
+func hasValidHookSection(content string, spec hookSpec) bool {
+	return strings.Contains(content, spec.markerStart) &&
 		strings.Contains(content, oxHookMarkerEnd) &&
-		strings.Contains(content, "ox hooks commit-msg")
+		strings.Contains(content, spec.probe)
 }
 
-// HasGitHooks returns true if the ox prepare-commit-msg hook is installed.
+// hasValidOxHook is the legacy single-hook check kept for any callers that
+// only care whether prepare-commit-msg is installed.
+func hasValidOxHook(content string) bool {
+	return hasValidHookSection(content, allHookSpecs()[0])
+}
+
+// HasGitHooks returns true when all ox-managed git hooks are installed in
+// the resolved hooks directory. A partial install (e.g. only
+// prepare-commit-msg present from a previous ox version) returns false so
+// `ox doctor --fix` can complete the install.
 func HasGitHooks(gitRoot string) bool {
 	hooksDir := resolveHooksDir(gitRoot)
-	hookPath := filepath.Join(hooksDir, prepareCommitMsgHookName)
-
-	content, err := os.ReadFile(hookPath)
-	if err != nil {
-		return false
+	for _, spec := range allHookSpecs() {
+		hookPath := filepath.Join(hooksDir, spec.name)
+		content, err := os.ReadFile(hookPath)
+		if err != nil {
+			return false
+		}
+		if !hasValidHookSection(string(content), spec) {
+			return false
+		}
 	}
-
-	return hasValidOxHook(string(content))
+	return true
 }

--- a/cmd/ox/hooks_git.go
+++ b/cmd/ox/hooks_git.go
@@ -12,6 +12,7 @@ const (
 	prepareCommitMsgHookName = "prepare-commit-msg"
 	postCommitHookName       = "post-commit"
 	postRewriteHookName      = "post-rewrite"
+	prePushHookName          = "pre-push"
 
 	// shared end marker — all ox-managed hook sections close with this.
 	// Mirrors the patterns in internal/uninstall/hooks.go sageoxHookMarkers.
@@ -50,6 +51,20 @@ fi
 # end ox hook`
 	oxPostRewriteProbe = "ox hooks post-rewrite"
 
+	// pre-push: parses the pushed commit range from stdin, resolves the PR
+	// for the branch and any Fixes #N issue refs, and records them on the
+	// active recording's LinkedPRs/LinkedIssues. git pipes the ref lines on
+	// stdin, so the hook reads stdin and forwards it to the handler.
+	// Best-effort, never blocks the push.
+	oxPrePushMarkerStart = "# ox pre-push hook"
+	oxPrePushSection     = `# ox pre-push hook
+# records PR + issue linkage for the active recording from the pushed range
+if command -v ox >/dev/null 2>&1; then
+  ox hooks pre-push --remote "${1:-}" --url "${2:-}" 2>/dev/null || true
+fi
+# end ox hook`
+	oxPrePushProbe = "ox hooks pre-push"
+
 	// Legacy marker name from the single-hook era. Some code paths
 	// (internal/uninstall/hooks.go) may still reference this; keep it as
 	// an alias for the prepare-commit-msg marker so external readers don't
@@ -86,6 +101,12 @@ func allHookSpecs() []hookSpec {
 			markerStart: oxPostRewriteMarkerStart,
 			section:     oxPostRewriteSection,
 			probe:       oxPostRewriteProbe,
+		},
+		{
+			name:        prePushHookName,
+			markerStart: oxPrePushMarkerStart,
+			section:     oxPrePushSection,
+			probe:       oxPrePushProbe,
 		},
 	}
 }

--- a/cmd/ox/hooks_post_commit.go
+++ b/cmd/ox/hooks_post_commit.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/session"
+	"github.com/spf13/cobra"
+)
+
+// hooksPostCommitCmd appends HEAD SHA to the active recording's
+// ProducedCommits index. Called by the post-commit git hook.
+//
+// Always exits 0 — post-commit hooks MUST never block the user's commit
+// flow. Diagnostic output goes to debug-level logs only.
+//
+// The forward commit→session link is owned by prepare-commit-msg (which
+// injects the SageOx-Session: trailer). This handler is the reverse-
+// direction index — it lets `ox session view` and friends answer "what
+// commits did this session produce?" without grepping git log.
+var hooksPostCommitCmd = &cobra.Command{
+	Use:          "post-commit",
+	Short:        "Append HEAD SHA to active recording's ProducedCommits index",
+	Hidden:       true,
+	SilenceUsage: true,
+	RunE:         runHooksPostCommit,
+}
+
+func init() {
+	hooksCmd.AddCommand(hooksPostCommitCmd)
+}
+
+func runHooksPostCommit(cmd *cobra.Command, args []string) error {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		slog.Debug("hooks post-commit: project root not found", "error", err)
+		return nil
+	}
+
+	if !config.IsInitialized(projectRoot) {
+		return nil
+	}
+
+	state := loadActiveRecording(projectRoot)
+	if state == nil {
+		return nil
+	}
+
+	sha := readHeadSHA(projectRoot)
+	if sha == "" {
+		slog.Debug("hooks post-commit: empty HEAD sha")
+		return nil
+	}
+
+	// Append unless already the last entry — guards against a hook firing
+	// twice on the same SHA (e.g. via a chained hook script that calls ox
+	// hooks post-commit more than once per commit).
+	if n := len(state.ProducedCommits); n > 0 && state.ProducedCommits[n-1] == sha {
+		return nil
+	}
+
+	if err := session.UpdateRecordingStateForAgent(projectRoot, state.AgentID, func(s *session.RecordingState) {
+		// re-check under the load to handle a race between two
+		// concurrent post-commit invocations in the same repo.
+		if n := len(s.ProducedCommits); n > 0 && s.ProducedCommits[n-1] == sha {
+			return
+		}
+		s.ProducedCommits = append(s.ProducedCommits, sha)
+	}); err != nil {
+		slog.Debug("hooks post-commit: update recording state failed", "error", err, "agent_id", state.AgentID)
+	}
+	return nil
+}
+
+// loadActiveRecording returns the recording state to update for the current
+// commit, or nil if none. Resolution mirrors prepare-commit-msg:
+//
+//   - SAGEOX_AGENT_ID set: agent-specific lookup; subagent prefers parent.
+//   - SAGEOX_AGENT_ID unset (human commit): workspace match against project root.
+func loadActiveRecording(projectRoot string) *session.RecordingState {
+	agentID := os.Getenv("SAGEOX_AGENT_ID")
+	if agentID != "" {
+		state, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+		if err != nil || state == nil {
+			return nil
+		}
+		if state.ParentAgentID != "" {
+			if parent, _ := session.LoadRecordingStateForAgent(projectRoot, state.ParentAgentID); parent != nil {
+				return parent
+			}
+		}
+		return state
+	}
+
+	state, err := session.LoadRecordingStateForWorkspace(projectRoot, projectRoot)
+	if err != nil {
+		return nil
+	}
+	return state
+}
+
+// readHeadSHA returns the current HEAD commit SHA for the project repo, or
+// empty string on any failure. Pure-Go alternative would parse .git/HEAD
+// and resolve the ref ourselves, but shelling out to git rev-parse is the
+// simplest correct path and post-commit always runs in a context where
+// git is available.
+func readHeadSHA(projectRoot string) string {
+	cmd := exec.Command("git", "-C", projectRoot, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cmd/ox/hooks_post_commit_test.go
+++ b/cmd/ox/hooks_post_commit_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hooks_post_commit_test.go verifies the reverse-index append path: each
+// commit during an active recording lands in RecordingState.ProducedCommits.
+// Failure prevented: silent regression of the session→commits index that
+// `ox session view` Commits section depends on.
+
+func postCommitEnv(t *testing.T) (string, string, string) {
+	t.Helper()
+	projectRoot, sessionName, agentID := trailerRewriteEnv(t)
+	return projectRoot, sessionName, agentID
+}
+
+// TestPostCommitHook_AppendsHEADToActiveRecording verifies that, with an
+// active recording, runHooksPostCommit appends HEAD's SHA to
+// state.ProducedCommits exactly once per call.
+func TestPostCommitHook_AppendsHEADToActiveRecording(t *testing.T) {
+	projectRoot, sessionName, agentID := postCommitEnv(t)
+
+	sha := commitWithTrailer(t, projectRoot, "first")
+	require.NoError(t, runHooksPostCommit(nil, nil))
+
+	state := loadRecordingForTest(t, projectRoot, sessionName)
+	require.Equal(t, []string{sha}, state.ProducedCommits,
+		"first post-commit must record HEAD sha exactly once")
+
+	// idempotency: re-running on the same HEAD must NOT duplicate
+	require.NoError(t, runHooksPostCommit(nil, nil))
+	state = loadRecordingForTest(t, projectRoot, sessionName)
+	assert.Equal(t, []string{sha}, state.ProducedCommits,
+		"running post-commit twice on the same HEAD must not duplicate")
+
+	// second commit appends a second entry
+	sha2 := commitWithTrailer(t, projectRoot, "second")
+	require.NoError(t, runHooksPostCommit(nil, nil))
+	state = loadRecordingForTest(t, projectRoot, sessionName)
+	assert.Equal(t, []string{sha, sha2}, state.ProducedCommits)
+
+	_ = agentID
+}
+
+// TestPostCommitHook_NoopWithoutRecording verifies the handler exits 0
+// and writes nothing when no recording is active. The hook must NEVER
+// block a commit.
+func TestPostCommitHook_NoopWithoutRecording(t *testing.T) {
+	projectRoot, _, agentID := postCommitEnv(t)
+	require.NoError(t, session.ClearRecordingStateForAgent(projectRoot, agentID))
+	t.Setenv("SAGEOX_AGENT_ID", "")
+
+	commitWithoutTrailer(t, projectRoot, "no recording")
+	assert.NoError(t, runHooksPostCommit(nil, nil),
+		"post-commit must never error when there is no active recording")
+}
+
+// loadRecordingForTest reads the recording state JSON from disk.
+// Returns dereferenced struct so tests can compare field-by-field.
+func loadRecordingForTest(t *testing.T, projectRoot, sessionName string) session.RecordingState {
+	t.Helper()
+	path := filepath.Join(projectRoot, "sessions", sessionName, ".recording.json")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var s session.RecordingState
+	require.NoError(t, json.Unmarshal(data, &s))
+	return s
+}
+
+// (anchor to silence unused import on platforms where time/json aren't otherwise used)
+var _ = time.Now

--- a/cmd/ox/hooks_post_rewrite.go
+++ b/cmd/ox/hooks_post_rewrite.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/session"
+	"github.com/spf13/cobra"
+)
+
+// hooksPostRewriteCmd consumes git's old→new SHA mapping on stdin and
+// rewrites entries in the active recording's ProducedCommits index.
+//
+// Git invokes post-rewrite after `git commit --amend` and `git rebase`,
+// piping lines of "<old-sha> <new-sha>" (with an optional third column on
+// rebase mode that records the original head SHA, which we ignore). The
+// $1 argument is "amend" or "rebase"; we accept it via --mode for
+// observability but the handler logic is the same either way.
+//
+// Always exits 0 — never blocks the rewrite. No active recording = no-op.
+//
+// Behavior on closed sessions (D3): this handler ONLY touches the active
+// RecordingState. Closed sessions whose ProducedCommits referenced one of
+// the rewritten SHAs become stale; `ox doctor` surfaces this as a soft
+// signal and an opt-in fix can be added later.
+var hooksPostRewriteCmd = &cobra.Command{
+	Use:          "post-rewrite",
+	Short:        "Rewrite ProducedCommits SHAs in active recording from git's mapping",
+	Hidden:       true,
+	SilenceUsage: true,
+	RunE:         runHooksPostRewrite,
+}
+
+var hooksPostRewriteMode string
+
+func init() {
+	hooksPostRewriteCmd.Flags().StringVar(&hooksPostRewriteMode, "mode", "", "rewrite mode passed by git: amend or rebase")
+	hooksCmd.AddCommand(hooksPostRewriteCmd)
+}
+
+func runHooksPostRewrite(cmd *cobra.Command, args []string) error {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		slog.Debug("hooks post-rewrite: project root not found", "error", err)
+		return nil
+	}
+	if !config.IsInitialized(projectRoot) {
+		return nil
+	}
+
+	state := loadActiveRecording(projectRoot)
+	if state == nil {
+		return nil
+	}
+	if len(state.ProducedCommits) == 0 {
+		return nil
+	}
+
+	mapping, err := parsePostRewriteStdin(os.Stdin)
+	if err != nil {
+		slog.Debug("hooks post-rewrite: parse stdin failed", "error", err)
+		return nil
+	}
+	if len(mapping) == 0 {
+		return nil
+	}
+
+	if err := session.UpdateRecordingStateForAgent(projectRoot, state.AgentID, func(s *session.RecordingState) {
+		rewriteSHAs(s, mapping)
+	}); err != nil {
+		slog.Debug("hooks post-rewrite: update recording state failed",
+			"error", err, "agent_id", state.AgentID, "mode", hooksPostRewriteMode)
+	}
+	return nil
+}
+
+// parsePostRewriteStdin reads git's old→new SHA stream. Each line:
+//
+//	<old-sha> <new-sha> [<rebase-extra-data>]
+//
+// We accept any whitespace separator and ignore extra columns. Blank
+// lines and lines without at least two fields are skipped silently —
+// git's stream is well-formed in practice, but defensive parsing keeps
+// the handler unbreakable.
+func parsePostRewriteStdin(r io.Reader) (map[string]string, error) {
+	mapping := make(map[string]string)
+	scanner := bufio.NewScanner(r)
+	// allow long lines — rebase can pipe extra metadata
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		oldSHA, newSHA := fields[0], fields[1]
+		if !looksLikeSHA(oldSHA) || !looksLikeSHA(newSHA) {
+			continue
+		}
+		mapping[oldSHA] = newSHA
+	}
+	if err := scanner.Err(); err != nil {
+		return mapping, err
+	}
+	return mapping, nil
+}
+
+// looksLikeSHA is a cheap shape guard: hex string of plausible length.
+// Git can produce either full 40-char (SHA-1) or 64-char (SHA-256)
+// digests depending on object format. We accept either, and any
+// abbreviated length >= 7 (git's default short-hash threshold).
+func looksLikeSHA(s string) bool {
+	if len(s) < 7 || len(s) > 64 {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9',
+			c >= 'a' && c <= 'f',
+			c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// rewriteSHAs applies mapping to s.ProducedCommits in place, preserving
+// order. Entries not in the mapping are left untouched (they refer to
+// commits the rewrite didn't change).
+//
+// Squash/fixup case: git emits multiple "old new" pairs all pointing to
+// the same new SHA (e.g. three squashed commits collapse to one). We
+// rewrite each old→new individually, then collapse adjacent duplicates
+// in a single pass so the list reflects the resulting history rather
+// than the pre-squash history. This matches what `ox session view`
+// users expect — "this session produced these commits in the current
+// history."
+func rewriteSHAs(s *session.RecordingState, mapping map[string]string) {
+	if s == nil || len(s.ProducedCommits) == 0 {
+		return
+	}
+	rewritten := make([]string, 0, len(s.ProducedCommits))
+	for _, sha := range s.ProducedCommits {
+		if newSHA, ok := mapping[sha]; ok {
+			rewritten = append(rewritten, newSHA)
+			continue
+		}
+		rewritten = append(rewritten, sha)
+	}
+	s.ProducedCommits = collapseAdjacentDuplicates(rewritten)
+}
+
+func collapseAdjacentDuplicates(in []string) []string {
+	if len(in) <= 1 {
+		return in
+	}
+	out := make([]string, 0, len(in))
+	out = append(out, in[0])
+	for i := 1; i < len(in); i++ {
+		if in[i] == in[i-1] {
+			continue
+		}
+		out = append(out, in[i])
+	}
+	return out
+}

--- a/cmd/ox/hooks_post_rewrite_test.go
+++ b/cmd/ox/hooks_post_rewrite_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hooks_post_rewrite_test.go covers the SHA-rewrite path. The handler
+// reads a git old→new mapping and rewrites entries in the active
+// recording's ProducedCommits index. Failure here means rebases and
+// amends silently leave the index pointing at SHAs no longer in history.
+
+func TestParsePostRewriteStdin_Mapping(t *testing.T) {
+	in := strings.NewReader("aaa1111 bbb2222\n" +
+		"ccc3333 ddd4444 extra-rebase-column\n" +
+		"\n" +
+		"   eee5555    fff6666\n" +
+		"not-a-sha lol\n")
+	m, err := parsePostRewriteStdin(in)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"aaa1111": "bbb2222",
+		"ccc3333": "ddd4444",
+		"eee5555": "fff6666",
+	}, m)
+}
+
+func TestRewriteSHAs_AmendSingleEntry(t *testing.T) {
+	s := &session.RecordingState{ProducedCommits: []string{"old1234"}}
+	rewriteSHAs(s, map[string]string{"old1234": "new5678"})
+	assert.Equal(t, []string{"new5678"}, s.ProducedCommits)
+}
+
+func TestRewriteSHAs_RebaseMultiple(t *testing.T) {
+	s := &session.RecordingState{ProducedCommits: []string{"a1", "b2", "c3"}}
+	rewriteSHAs(s, map[string]string{
+		"a1": "A1",
+		"b2": "B2",
+		"c3": "C3",
+	})
+	assert.Equal(t, []string{"A1", "B2", "C3"}, s.ProducedCommits)
+}
+
+// TestRewriteSHAs_SquashCollapses verifies that when N commits collapse
+// into one (all entries map to the same new SHA), the list collapses
+// rather than carrying N duplicate entries.
+// Failure prevented: post-squash `ox session view` showing 3 lines that
+// all resolve to the same commit.
+func TestRewriteSHAs_SquashCollapses(t *testing.T) {
+	s := &session.RecordingState{ProducedCommits: []string{"a1", "b2", "c3"}}
+	rewriteSHAs(s, map[string]string{
+		"a1": "SQUASHED",
+		"b2": "SQUASHED",
+		"c3": "SQUASHED",
+	})
+	assert.Equal(t, []string{"SQUASHED"}, s.ProducedCommits,
+		"three commits squashed into one should leave one entry")
+}
+
+// TestRewriteSHAs_UnrelatedSHAsUntouched verifies that entries NOT in
+// the rewrite mapping pass through unchanged. Without this, a partial
+// rebase mid-list would zero out trailing entries.
+func TestRewriteSHAs_UnrelatedSHAsUntouched(t *testing.T) {
+	s := &session.RecordingState{ProducedCommits: []string{"a1", "b2", "c3"}}
+	rewriteSHAs(s, map[string]string{"b2": "B2_NEW"})
+	assert.Equal(t, []string{"a1", "B2_NEW", "c3"}, s.ProducedCommits)
+}
+
+// TestRewriteSHAs_EmptyMapping is a no-op safety check.
+func TestRewriteSHAs_EmptyMapping(t *testing.T) {
+	s := &session.RecordingState{ProducedCommits: []string{"a1", "b2"}}
+	rewriteSHAs(s, map[string]string{})
+	assert.Equal(t, []string{"a1", "b2"}, s.ProducedCommits)
+}
+
+// TestLooksLikeSHA covers the shape guard. Defensive: we accept any
+// hex of plausible length so abbreviated SHAs from `rebase -i` reword
+// (which sometimes emits short hashes) work.
+func TestLooksLikeSHA(t *testing.T) {
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"abc1234", true},                                                                  // 7-char short
+		{"abcdef1234567890abcdef1234567890abcdef12", true},                                 // 40-char SHA-1
+		{"abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", true},         // 64-char SHA-256
+		{"", false},                                                                        // empty
+		{"abc12", false},                                                                   // too short
+		{strings.Repeat("a", 65), false},                                                   // too long
+		{"abcdefg", false},                                                                 // bad hex
+		{"ABC1234", true},                                                                  // uppercase ok
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, looksLikeSHA(c.s), "looksLikeSHA(%q)", c.s)
+	}
+}
+
+// TestCollapseAdjacentDuplicates covers the helper directly.
+func TestCollapseAdjacentDuplicates(t *testing.T) {
+	assert.Equal(t, []string{"a", "b", "a"},
+		collapseAdjacentDuplicates([]string{"a", "a", "b", "a", "a"}),
+		"collapse only adjacent runs; non-adjacent repeats stay")
+}
+
+// TestPostRewrite_NoopWithoutRecording verifies the cobra entry point
+// exits cleanly when no recording is active.
+func TestPostRewrite_NoopWithoutRecording(t *testing.T) {
+	projectRoot, _, agentID := trailerRewriteEnv(t)
+	require.NoError(t, session.ClearRecordingStateForAgent(projectRoot, agentID))
+	t.Setenv("SAGEOX_AGENT_ID", "")
+	assert.NoError(t, runHooksPostRewrite(nil, nil))
+}

--- a/cmd/ox/hooks_pre_push.go
+++ b/cmd/ox/hooks_pre_push.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/session"
+	"github.com/spf13/cobra"
+)
+
+// hooksPrePushCmd records PR + issue linkage for the active recording from
+// the commit range being pushed. Called by the pre-push git hook, which
+// pipes the ref lines on stdin:
+//
+//	<local-ref> <local-sha> <remote-ref> <remote-sha>
+//
+// For each ref with a non-zero remote-sha (branch already exists on the
+// remote) the pushed range is <remote-sha>..<local-sha>; for a brand-new
+// branch (zero remote-sha) the range is bounded against everything already
+// on remotes so we don't walk the entire history.
+//
+// Always exits 0 — pre-push must never block a push on linkage best-effort.
+var hooksPrePushCmd = &cobra.Command{
+	Use:          "pre-push",
+	Short:        "Record PR/issue linkage for the active recording from the pushed range",
+	Hidden:       true,
+	SilenceUsage: true,
+	RunE:         runHooksPrePush,
+}
+
+var (
+	hooksPrePushRemote string
+	hooksPrePushURL    string
+)
+
+func init() {
+	hooksPrePushCmd.Flags().StringVar(&hooksPrePushRemote, "remote", "", "remote name (from git hook $1)")
+	hooksPrePushCmd.Flags().StringVar(&hooksPrePushURL, "url", "", "remote url (from git hook $2)")
+	hooksCmd.AddCommand(hooksPrePushCmd)
+}
+
+// zeroSHA is git's all-zeros sentinel for "ref does not exist on the remote".
+const zeroSHA = "0000000000000000000000000000000000000000"
+
+// ghTimeout bounds the gh CLI call so a slow GitHub round-trip can't stall
+// the user's push. The pre-push hook runs synchronously before the push
+// proceeds; we cap the network cost.
+const ghTimeout = 3 * time.Second
+
+func runHooksPrePush(cmd *cobra.Command, args []string) error {
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		slog.Debug("hooks pre-push: project root not found", "error", err)
+		return nil
+	}
+	if !config.IsInitialized(projectRoot) {
+		return nil
+	}
+
+	state := loadActiveRecording(projectRoot)
+	if state == nil {
+		return nil
+	}
+
+	refs := parsePrePushStdin(os.Stdin)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	issues := map[string]struct{}{}
+	for _, ref := range refs {
+		commits := commitRangeForRef(projectRoot, ref)
+		for _, sha := range commits {
+			for _, issue := range parseIssueRefs(commitBody(projectRoot, sha)) {
+				issues[issue] = struct{}{}
+			}
+		}
+	}
+
+	prs := resolvePRsForBranches(projectRoot, refs)
+
+	if len(prs) == 0 && len(issues) == 0 {
+		return nil
+	}
+
+	if err := session.UpdateRecordingStateForAgent(projectRoot, state.AgentID, func(s *session.RecordingState) {
+		s.LinkedPRs = mergeUnique(s.LinkedPRs, prs)
+		s.LinkedIssues = mergeUnique(s.LinkedIssues, mapKeys(issues))
+	}); err != nil {
+		slog.Debug("hooks pre-push: update recording state failed", "error", err, "agent_id", state.AgentID)
+	}
+	return nil
+}
+
+// prePushRef is one line of the pre-push stdin stream.
+type prePushRef struct {
+	localRef  string
+	localSHA  string
+	remoteRef string
+	remoteSHA string
+}
+
+// parsePrePushStdin reads git's pre-push ref stream. Lines without four
+// whitespace-separated fields are skipped. Refs whose local-sha is the zero
+// SHA (a branch deletion) are dropped — nothing is being pushed.
+func parsePrePushStdin(r io.Reader) []prePushRef {
+	var refs []prePushRef
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		fields := strings.Fields(strings.TrimSpace(scanner.Text()))
+		if len(fields) < 4 {
+			continue
+		}
+		ref := prePushRef{
+			localRef:  fields[0],
+			localSHA:  fields[1],
+			remoteRef: fields[2],
+			remoteSHA: fields[3],
+		}
+		if ref.localSHA == zeroSHA {
+			continue // branch deletion — nothing pushed
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+// commitRangeForRef returns the SHAs being pushed for one ref. For an
+// existing remote branch the range is remoteSHA..localSHA; for a new branch
+// it's localSHA with --not --remotes so we don't walk shared history.
+func commitRangeForRef(projectRoot string, ref prePushRef) []string {
+	var args []string
+	if ref.remoteSHA == zeroSHA || ref.remoteSHA == "" {
+		args = []string{"-C", projectRoot, "rev-list", ref.localSHA, "--not", "--remotes"}
+	} else {
+		args = []string{"-C", projectRoot, "rev-list", ref.remoteSHA + ".." + ref.localSHA}
+	}
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return nil
+	}
+	var shas []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			shas = append(shas, line)
+		}
+	}
+	return shas
+}
+
+// commitBody returns the full commit message body for a SHA, or "".
+func commitBody(projectRoot, sha string) string {
+	out, err := exec.Command("git", "-C", projectRoot, "log", "-1", "--format=%B", sha).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// issueRefPattern matches GitHub issue-closing keywords plus the issue
+// number: "Fixes #12", "Closes: #34", "resolves #5", "GH-7". The number is
+// captured in group 1 (for #N forms) or group 2 (for GH-N).
+var issueRefPattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#(\d+)|\bGH-(\d+)\b`)
+
+// parseIssueRefs extracts issue numbers from a commit message body, in the
+// "#N" canonical form. Only closing-keyword references and GH-N are matched;
+// a bare "#N" mention without a keyword is intentionally NOT captured to
+// avoid linking every passing reference (e.g. "see #12 for context").
+func parseIssueRefs(body string) []string {
+	matches := issueRefPattern.FindAllStringSubmatch(body, -1)
+	seen := map[string]struct{}{}
+	var out []string
+	for _, m := range matches {
+		num := m[1]
+		if num == "" {
+			num = m[2]
+		}
+		if num == "" {
+			continue
+		}
+		ref := "#" + num
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		out = append(out, ref)
+	}
+	return out
+}
+
+// resolvePRsForBranches returns the PR URLs for the local branches being
+// pushed, resolved via the gh CLI. Returns nil when gh is unavailable or
+// errors — issue refs (which need no network) are still recorded by the
+// caller. Each distinct branch is queried once.
+func resolvePRsForBranches(projectRoot string, refs []prePushRef) []string {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var prs []string
+	for _, ref := range refs {
+		branch := strings.TrimPrefix(ref.localRef, "refs/heads/")
+		if branch == "" || branch == ref.localRef {
+			continue // not a branch ref (tag, etc.)
+		}
+		if _, ok := seen[branch]; ok {
+			continue
+		}
+		seen[branch] = struct{}{}
+		if url := prURLForBranch(projectRoot, branch); url != "" {
+			prs = append(prs, url)
+		}
+	}
+	return prs
+}
+
+// prURLForBranch shells out to gh to find an open PR whose head is branch.
+// Bounded by ghTimeout. Returns "" on any failure or no match.
+func prURLForBranch(projectRoot, branch string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+		"--head", branch, "--state", "open", "--json", "url", "--jq", ".[0].url")
+	cmd.Dir = projectRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// mergeUnique appends entries from add to base, skipping values already
+// present in base or earlier in add. Order-preserving.
+func mergeUnique(base, add []string) []string {
+	seen := map[string]struct{}{}
+	for _, v := range base {
+		seen[v] = struct{}{}
+	}
+	out := base
+	for _, v := range add {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+// mapKeys returns the keys of a set in nondeterministic order. Callers that
+// need stable order sort the result.
+func mapKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/ox/hooks_pre_push_test.go
+++ b/cmd/ox/hooks_pre_push_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hooks_pre_push_test.go covers the pure parsing + extraction logic of the
+// pre-push linkage hook. Branch/PR resolution and the recording-state write
+// are integration-tested via the shared trailerRewriteEnv harness; the
+// stdin parser and issue-ref extractor are unit-tested here because they
+// carry the regex edge cases that silently mislink or drop issue refs.
+
+func TestParsePrePushStdin(t *testing.T) {
+	in := strings.NewReader(
+		"refs/heads/feature aaaa1111 refs/heads/feature 00000000\n" +
+			"refs/heads/main bbbb2222 refs/heads/main cccc3333\n" +
+			"refs/heads/deleted 0000000000000000000000000000000000000000 refs/heads/deleted dddd4444\n" +
+			"malformed line\n" +
+			"\n")
+	refs := parsePrePushStdin(in)
+	// deletion (local-sha all zeros) dropped; malformed dropped; blank dropped
+	assert.Len(t, refs, 2)
+	assert.Equal(t, "feature", strings.TrimPrefix(refs[0].localRef, "refs/heads/"))
+	assert.Equal(t, "00000000", refs[0].remoteSHA) // new branch (short zero in fixture)
+	assert.Equal(t, "cccc3333", refs[1].remoteSHA) // existing branch
+}
+
+// TestParseIssueRefs verifies closing-keyword extraction and that bare
+// mentions are NOT captured.
+// Failure prevented: linking every "#12" mention (e.g. "see #12") would
+// pollute LinkedIssues; missing "Fixes #N" would drop real linkage.
+func TestParseIssueRefs(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"fixes", "feat: thing\n\nFixes #42", []string{"#42"}},
+		{"closes colon", "Closes: #7", []string{"#7"}},
+		{"resolves lower", "resolves #100", []string{"#100"}},
+		{"gh dash form", "Done\n\nGH-9", []string{"#9"}},
+		{"multiple unique", "Fixes #1\nCloses #2\nfixes #1", []string{"#1", "#2"}},
+		{"bare mention not captured", "see #12 for context", nil},
+		{"fixed past tense", "Fixed #5", []string{"#5"}},
+		{"no refs", "just a normal commit", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseIssueRefs(c.body)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestMergeUnique(t *testing.T) {
+	assert.Equal(t,
+		[]string{"a", "b", "c"},
+		mergeUnique([]string{"a", "b"}, []string{"b", "c", "", "a"}),
+		"merge skips dupes and empties, preserves order")
+	assert.Equal(t,
+		[]string{"x"},
+		mergeUnique(nil, []string{"x", "x"}))
+}
+
+func TestMapKeys(t *testing.T) {
+	m := map[string]struct{}{"#1": {}, "#2": {}, "#3": {}}
+	got := mapKeys(m)
+	sort.Strings(got)
+	assert.Equal(t, []string{"#1", "#2", "#3"}, got)
+}
+
+// TestPrePush_RecordsIssueRefsOnActiveRecording exercises the full handler
+// against a real git repo with an active recording: commits carrying
+// "Fixes #N" footers, fed through runHooksPrePush via the pre-push stdin
+// stream, must land in the recording's LinkedIssues.
+// Failure prevented: the parse→range→state-write pipeline silently drops
+// issue linkage even when commits clearly reference issues.
+func TestPrePush_RecordsIssueRefsOnActiveRecording(t *testing.T) {
+	projectRoot, sessionName, _ := trailerRewriteEnv(t)
+
+	// two commits, one referencing an issue
+	first := commitWithTrailer(t, projectRoot, "feat: base")
+	commitWithIssueRef(t, projectRoot, "fix: thing\n\nFixes #77")
+	head := strings.TrimSpace(captureGitTrailer(t, projectRoot, "rev-parse", "HEAD"))
+
+	// simulate a push of first..head onto an existing remote branch by
+	// feeding the pre-push ref line on stdin. remoteSHA = first (already
+	// pushed), localSHA = head.
+	stdin := "refs/heads/main " + head + " refs/heads/main " + first + "\n"
+	withStdin(t, stdin, func() {
+		hooksPrePushRemote, hooksPrePushURL = "origin", "https://example.com/repo.git"
+		require.NoError(t, runHooksPrePush(nil, nil))
+	})
+
+	state := loadRecordingForTest(t, projectRoot, sessionName)
+	assert.Contains(t, state.LinkedIssues, "#77",
+		"pre-push must record issue refs from the pushed commit range")
+}
+
+// commitWithIssueRef commits with an explicit message (bypasses trailer
+// injection — we only care about the message body for issue parsing).
+func commitWithIssueRef(t *testing.T, projectRoot, message string) {
+	t.Helper()
+	makeContentChange(t, projectRoot, message)
+	requireGitTrailer(t, projectRoot, "add", "-A")
+	requireGitTrailer(t, projectRoot, "commit", "-m", message)
+}
+
+// withStdin temporarily replaces os.Stdin with a pipe carrying data for the
+// duration of fn. Restores the original afterward.
+func withStdin(t *testing.T, data string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig })
+	go func() {
+		_, _ = w.WriteString(data)
+		_ = w.Close()
+	}()
+	fn()
+	_ = r.Close()
+}

--- a/cmd/ox/session_linkage_finalize.go
+++ b/cmd/ox/session_linkage_finalize.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// finalizeLinkageAfterPush runs the M5 upload-confirmed transition after a
+// session's content has been pushed to the ledger. It moves LinkageStatus
+// from staged → uploaded, then best-effort notifies the SageOx server so
+// the (v2) GitHub App reconciler can refresh any PR sticky comment.
+//
+// All work is best-effort: a failed notify leaves the session in
+// notify_failed for `ox doctor` to retry, and never affects the
+// already-successful upload. See docs/ai/specs/session-pr-issue-linkage.md
+// (v1.5) for the state machine.
+func finalizeLinkageAfterPush(projectRoot, sessionDir string, meta *lfs.SessionMeta, sessionName string) {
+	if meta == nil {
+		return
+	}
+
+	// 1. transition staged → uploaded in meta.json (the push just succeeded,
+	//    so the session URL is now viewable). Done under the meta flock so we
+	//    don't clobber a concurrent daemon write.
+	if err := lfs.MutateSessionMeta(context.Background(), sessionDir, func(m *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+		if m == nil {
+			return nil, nil // meta vanished — nothing to update
+		}
+		m.LinkageStatus = lfs.LinkageStatusUploaded
+		return m, nil
+	}); err != nil {
+		slog.Debug("linkage finalize: status transition failed", "error", err, "session", sessionName)
+		// fall through: still try to notify; status best-effort
+	}
+
+	// 2. notify the server. Only meaningful when there is linkage to report
+	//    OR when the server wants the upload signal regardless. We send
+	//    whenever the session has any linkage or produced commits; a session
+	//    with none has nothing for the reconciler to act on, so skip the call.
+	if len(meta.LinkedPRs) == 0 && len(meta.LinkedIssues) == 0 && len(meta.ProducedCommits) == 0 {
+		return
+	}
+
+	notified := notifySessionUploaded(projectRoot, meta, sessionName)
+	finalStatus := lfs.LinkageStatusNotified
+	if !notified {
+		finalStatus = lfs.LinkageStatusNotifyFailed
+	}
+	if err := lfs.MutateSessionMeta(context.Background(), sessionDir, func(m *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+		if m == nil {
+			return nil, nil
+		}
+		m.LinkageStatus = finalStatus
+		return m, nil
+	}); err != nil {
+		slog.Debug("linkage finalize: notify-status write failed", "error", err, "session", sessionName)
+	}
+}
+
+// notifySessionUploaded sends the upload-confirmed notification to the
+// SageOx server. Returns true on success (including 404/409 graceful cases,
+// which the API client maps to nil error), false on transient failure that
+// should be retried by doctor.
+func notifySessionUploaded(projectRoot string, meta *lfs.SessionMeta, sessionName string) bool {
+	cfg, err := config.LoadProjectConfig(projectRoot)
+	if err != nil || cfg == nil || cfg.RepoID == "" {
+		return false
+	}
+
+	ep := endpoint.GetForProject(projectRoot)
+	token, err := auth.GetTokenForEndpoint(ep)
+	if err != nil || token == nil || token.AccessToken == "" {
+		// no credentials — can't notify; doctor retries once auth is present
+		return false
+	}
+
+	client := api.NewRepoClientWithEndpoint(ep).WithAuthToken(token.AccessToken)
+	notification := api.SessionUploadedNotification{
+		SessionID:       meta.EffectiveSessionID(),
+		RepoID:          cfg.RepoID,
+		SessionURL:      buildSessionURL(cfg, sessionName),
+		LinkedPRs:       meta.LinkedPRs,
+		LinkedIssues:    meta.LinkedIssues,
+		ProducedCommits: meta.ProducedCommits,
+	}
+	if err := client.NotifySessionUploaded(notification); err != nil {
+		slog.Debug("linkage finalize: notify failed", "error", err, "session", sessionName)
+		return false
+	}
+	return true
+}

--- a/cmd/ox/session_show.go
+++ b/cmd/ox/session_show.go
@@ -68,6 +68,9 @@ type sessionMetadata struct {
 	RepoID          string
 	CreatedAt       time.Time
 	ProducedCommits []string `json:",omitempty"`
+	LinkedPRs       []string `json:",omitempty"`
+	LinkedIssues    []string `json:",omitempty"`
+	LinkageStatus   string   `json:",omitempty"`
 }
 
 var sessionShowCmd = &cobra.Command{
@@ -162,10 +165,11 @@ func viewAsJSON(w io.Writer, storedSession *session.StoredSession, metadataOnly 
 	return showRawSession(w, t, limit)
 }
 
-// readProducedCommits loads SessionMeta.ProducedCommits for the session
-// whose raw.jsonl lives at jsonlPath. Returns nil on any error (the field
-// is purely informational; a read failure should not break view rendering).
-func readProducedCommits(jsonlPath string) []string {
+// readSessionMetaForView loads the full SessionMeta for the session whose
+// raw.jsonl lives at jsonlPath. Returns nil on any error — linkage fields
+// are purely informational and a read failure must not break view
+// rendering. Callers pick whichever fields they render.
+func readSessionMetaForView(jsonlPath string) *lfs.SessionMeta {
 	if jsonlPath == "" {
 		return nil
 	}
@@ -174,7 +178,7 @@ func readProducedCommits(jsonlPath string) []string {
 	if err != nil || meta == nil {
 		return nil
 	}
-	return meta.ProducedCommits
+	return meta
 }
 
 // convertStoredSession converts a session.StoredSession to sessionShowData.
@@ -186,15 +190,24 @@ func convertStoredSession(st *session.StoredSession) *sessionShowData {
 	}
 
 	if st.Meta != nil {
-		t.Metadata = &sessionMetadata{
-			Version:         st.Meta.Version,
-			AgentID:         st.Meta.AgentID,
-			AgentType:       st.Meta.AgentType,
-			Username:        st.Meta.Username,
-			RepoID:          st.Meta.RepoID,
-			CreatedAt:       st.Meta.CreatedAt,
-			ProducedCommits: readProducedCommits(st.Info.FilePath),
+		md := &sessionMetadata{
+			Version:   st.Meta.Version,
+			AgentID:   st.Meta.AgentID,
+			AgentType: st.Meta.AgentType,
+			Username:  st.Meta.Username,
+			RepoID:    st.Meta.RepoID,
+			CreatedAt: st.Meta.CreatedAt,
 		}
+		// linkage fields live in the full lfs.SessionMeta (meta.json), not in
+		// the lighter session.StoreMeta carried by StoredSession. Read them
+		// from disk; best-effort, nil-safe.
+		if full := readSessionMetaForView(st.Info.FilePath); full != nil {
+			md.ProducedCommits = full.ProducedCommits
+			md.LinkedPRs = full.LinkedPRs
+			md.LinkedIssues = full.LinkedIssues
+			md.LinkageStatus = full.LinkageStatus
+		}
+		t.Metadata = md
 	}
 
 	return t

--- a/cmd/ox/session_show.go
+++ b/cmd/ox/session_show.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	"time"
 
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 	"github.com/spf13/cobra"
 )
@@ -59,12 +61,13 @@ type sessionShowData struct {
 
 // sessionMetadata contains session header metadata
 type sessionMetadata struct {
-	Version   string
-	AgentID   string
-	AgentType string
-	Username  string
-	RepoID    string
-	CreatedAt time.Time
+	Version         string
+	AgentID         string
+	AgentType       string
+	Username        string
+	RepoID          string
+	CreatedAt       time.Time
+	ProducedCommits []string `json:",omitempty"`
 }
 
 var sessionShowCmd = &cobra.Command{
@@ -159,6 +162,21 @@ func viewAsJSON(w io.Writer, storedSession *session.StoredSession, metadataOnly 
 	return showRawSession(w, t, limit)
 }
 
+// readProducedCommits loads SessionMeta.ProducedCommits for the session
+// whose raw.jsonl lives at jsonlPath. Returns nil on any error (the field
+// is purely informational; a read failure should not break view rendering).
+func readProducedCommits(jsonlPath string) []string {
+	if jsonlPath == "" {
+		return nil
+	}
+	sessionDir := filepath.Dir(jsonlPath)
+	meta, err := lfs.ReadSessionMeta(sessionDir)
+	if err != nil || meta == nil {
+		return nil
+	}
+	return meta.ProducedCommits
+}
+
 // convertStoredSession converts a session.StoredSession to sessionShowData.
 func convertStoredSession(st *session.StoredSession) *sessionShowData {
 	t := &sessionShowData{
@@ -169,12 +187,13 @@ func convertStoredSession(st *session.StoredSession) *sessionShowData {
 
 	if st.Meta != nil {
 		t.Metadata = &sessionMetadata{
-			Version:   st.Meta.Version,
-			AgentID:   st.Meta.AgentID,
-			AgentType: st.Meta.AgentType,
-			Username:  st.Meta.Username,
-			RepoID:    st.Meta.RepoID,
-			CreatedAt: st.Meta.CreatedAt,
+			Version:         st.Meta.Version,
+			AgentID:         st.Meta.AgentID,
+			AgentType:       st.Meta.AgentType,
+			Username:        st.Meta.Username,
+			RepoID:          st.Meta.RepoID,
+			CreatedAt:       st.Meta.CreatedAt,
+			ProducedCommits: readProducedCommits(st.Info.FilePath),
 		}
 	}
 

--- a/cmd/ox/session_view_linkage_test.go
+++ b/cmd/ox/session_view_linkage_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// session_view_linkage_test.go verifies renderSessionLinkage emits the
+// Pull Requests / Issues / Commits markdown sections from a session's
+// meta.json. Failure prevented: linkage data lands in meta.json but never
+// surfaces in `ox session view`, so the durable-linkage feature is
+// invisible to the human reviewing the session.
+
+// writeLinkageSessionMeta writes a meta.json with the given linkage fields
+// into a session dir and returns a StoredSession pointing at its raw.jsonl
+// (which need not exist — renderSessionLinkage only reads meta.json).
+func writeLinkageSessionMeta(t *testing.T, prs, issues, commits []string) *session.StoredSession {
+	t.Helper()
+	sessionDir := filepath.Join(t.TempDir(), "2026-05-28T12-00-tester-Ox1234")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	meta := lfs.NewSessionMeta("2026-05-28T12-00-tester-Ox1234", "tester", "Ox1234", "claude-code",
+		time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)).
+		RepoID("repo_xyz").
+		LinkedPRs(prs).
+		LinkedIssues(issues).
+		ProducedCommits(commits).
+		Build()
+	require.NoError(t, lfs.WriteSessionMeta(sessionDir, meta))
+
+	return &session.StoredSession{
+		Info: session.SessionInfo{
+			FilePath: filepath.Join(sessionDir, "raw.jsonl"),
+		},
+	}
+}
+
+func TestRenderSessionLinkage_AllSections(t *testing.T) {
+	st := writeLinkageSessionMeta(t,
+		[]string{"https://github.com/owner/repo/pull/42"},
+		[]string{"#101", "#103"},
+		nil, // commits resolved via git; omit to avoid needing a repo here
+	)
+
+	// projectRoot empty: commit resolution falls back to bare SHA, but we
+	// passed no commits, so only PR + Issue sections render.
+	out := renderSessionLinkage(st, "")
+
+	assert.Contains(t, out, "## Pull Requests")
+	assert.Contains(t, out, "https://github.com/owner/repo/pull/42")
+	assert.Contains(t, out, "## Issues")
+	assert.Contains(t, out, "#101")
+	assert.Contains(t, out, "#103")
+	assert.NotContains(t, out, "## Commits", "no commits provided → no Commits section")
+}
+
+func TestRenderSessionLinkage_EmptyOmitsAllSections(t *testing.T) {
+	st := writeLinkageSessionMeta(t, nil, nil, nil)
+	out := renderSessionLinkage(st, "")
+	assert.Empty(t, out, "no linkage data → no sections, not even empty headers")
+}
+
+func TestRenderSessionLinkage_PRsOnly(t *testing.T) {
+	st := writeLinkageSessionMeta(t,
+		[]string{"https://github.com/owner/repo/pull/7"}, nil, nil)
+	out := renderSessionLinkage(st, "")
+	assert.Contains(t, out, "## Pull Requests")
+	assert.NotContains(t, out, "## Issues")
+	assert.NotContains(t, out, "## Commits")
+}
+
+func TestRenderSessionLinkage_NilSession(t *testing.T) {
+	assert.Empty(t, renderSessionLinkage(nil, ""))
+}

--- a/cmd/ox/session_view_text.go
+++ b/cmd/ox/session_view_text.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	lipgloss "charm.land/lipgloss/v2"
@@ -68,9 +69,64 @@ func viewAsText(_ *session.Store, storedSession *session.StoredSession, projectR
 		return fmt.Errorf("read markdown file: %w", err)
 	}
 
+	// prepend Commits section if SessionMeta carries a ProducedCommits index.
+	// Each SHA is resolved to "short message" via git log; SHAs no longer
+	// reachable (closed-session post-rewrite case from D3) render as
+	// "<unreachable>" so the section stays informative without lying about
+	// what's in the current history.
+	commitsSection := renderProducedCommits(storedSession, projectRoot)
+	if commitsSection != "" {
+		mdContent = append([]byte(commitsSection), mdContent...)
+	}
+
 	// render with glamour and display
 	rendered := ui.RenderMarkdown(string(mdContent))
 	fmt.Print(rendered)
 
 	return nil
+}
+
+// renderProducedCommits returns a markdown "## Commits" section listing the
+// SHAs in SessionMeta.ProducedCommits, or "" if there are none. Resolves
+// each SHA against the project repo via `git log -1 --format=%h %s` so the
+// reader sees the short hash plus commit subject rather than just an opaque
+// 40-char hex string.
+func renderProducedCommits(storedSession *session.StoredSession, projectRoot string) string {
+	if storedSession == nil {
+		return ""
+	}
+	shas := readProducedCommits(storedSession.Info.FilePath)
+	if len(shas) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Commits\n\n")
+	for _, sha := range shas {
+		display := resolveCommitDisplay(projectRoot, sha)
+		b.WriteString("- ")
+		b.WriteString(display)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// resolveCommitDisplay returns "<shorthash> <subject>" for a reachable SHA
+// or "<sha> <unreachable>" otherwise. projectRoot may be empty when the
+// view is reading a foreign session (no project context); in that case we
+// fall back to the full SHA without a lookup attempt.
+func resolveCommitDisplay(projectRoot, sha string) string {
+	if projectRoot == "" {
+		return sha
+	}
+	cmd := exec.Command("git", "-C", projectRoot, "log", "-1", "--format=%h %s", sha)
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Sprintf("`%s` <unreachable>", sha)
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return fmt.Sprintf("`%s` <unreachable>", sha)
+	}
+	return line
 }

--- a/cmd/ox/session_view_text.go
+++ b/cmd/ox/session_view_text.go
@@ -69,14 +69,13 @@ func viewAsText(_ *session.Store, storedSession *session.StoredSession, projectR
 		return fmt.Errorf("read markdown file: %w", err)
 	}
 
-	// prepend Commits section if SessionMeta carries a ProducedCommits index.
-	// Each SHA is resolved to "short message" via git log; SHAs no longer
-	// reachable (closed-session post-rewrite case from D3) render as
-	// "<unreachable>" so the section stays informative without lying about
-	// what's in the current history.
-	commitsSection := renderProducedCommits(storedSession, projectRoot)
-	if commitsSection != "" {
-		mdContent = append([]byte(commitsSection), mdContent...)
+	// prepend linkage sections (Pull Requests, Issues, Commits) when the
+	// session's meta.json carries them. Order: PRs, then Issues, then
+	// Commits — coarsest-to-finest granularity reads naturally for a
+	// reviewer scanning "what did this session touch?".
+	linkageSections := renderSessionLinkage(storedSession, projectRoot)
+	if linkageSections != "" {
+		mdContent = append([]byte(linkageSections), mdContent...)
 	}
 
 	// render with glamour and display
@@ -86,28 +85,48 @@ func viewAsText(_ *session.Store, storedSession *session.StoredSession, projectR
 	return nil
 }
 
-// renderProducedCommits returns a markdown "## Commits" section listing the
-// SHAs in SessionMeta.ProducedCommits, or "" if there are none. Resolves
-// each SHA against the project repo via `git log -1 --format=%h %s` so the
-// reader sees the short hash plus commit subject rather than just an opaque
-// 40-char hex string.
-func renderProducedCommits(storedSession *session.StoredSession, projectRoot string) string {
+// renderSessionLinkage returns the combined markdown for the linkage
+// sections (Pull Requests, Issues, Commits) prepended to a session's
+// rendered view. Reads the session's meta.json once and emits whichever
+// sections are populated, in coarse-to-fine order. Returns "" when none
+// are present.
+func renderSessionLinkage(storedSession *session.StoredSession, projectRoot string) string {
 	if storedSession == nil {
 		return ""
 	}
-	shas := readProducedCommits(storedSession.Info.FilePath)
-	if len(shas) == 0 {
+	meta := readSessionMetaForView(storedSession.Info.FilePath)
+	if meta == nil {
 		return ""
 	}
+
 	var b strings.Builder
-	b.WriteString("## Commits\n\n")
-	for _, sha := range shas {
-		display := resolveCommitDisplay(projectRoot, sha)
-		b.WriteString("- ")
-		b.WriteString(display)
+	if len(meta.LinkedPRs) > 0 {
+		b.WriteString("## Pull Requests\n\n")
+		for _, pr := range meta.LinkedPRs {
+			b.WriteString("- ")
+			b.WriteString(pr)
+			b.WriteString("\n")
+		}
 		b.WriteString("\n")
 	}
-	b.WriteString("\n")
+	if len(meta.LinkedIssues) > 0 {
+		b.WriteString("## Issues\n\n")
+		for _, issue := range meta.LinkedIssues {
+			b.WriteString("- ")
+			b.WriteString(issue)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+	if len(meta.ProducedCommits) > 0 {
+		b.WriteString("## Commits\n\n")
+		for _, sha := range meta.ProducedCommits {
+			b.WriteString("- ")
+			b.WriteString(resolveCommitDisplay(projectRoot, sha))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
 	return b.String()
 }
 

--- a/docs/ai/specs/session-commit-linkage.md
+++ b/docs/ai/specs/session-commit-linkage.md
@@ -1,0 +1,139 @@
+# Session ↔ Commit Linkage
+
+**Audience:** AI coworkers and engineers working on ox session, commit-trailer, or git-hook code.
+**Status:** Phase A + Phase B of ox-bxo2 (Session↔Commit Linkage Hardening) shipped.
+**Companion docs:** [`session-pr-issue-linkage.md`](./session-pr-issue-linkage.md) (PR/issue mapping, follow-up epic).
+
+---
+
+## TL;DR
+
+- **Forward link (commit → session):** the `SageOx-Session: <url>` trailer in each commit message. Injected by the `prepare-commit-msg` git hook while a recording is active.
+- **Reverse index (session → commits):** `SessionMeta.ProducedCommits []string`. Populated by `post-commit` during the active recording; kept honest across in-recording rewrites by `post-rewrite`. Folded into `meta.json` at session stop / recover.
+- **Source of truth on disagreement:** the trailer wins. `ProducedCommits` is a fast structured index over what is already discoverable by grepping commit messages.
+- **Closed sessions are intentionally NOT mutated by post-rewrite.** Staleness is a soft signal in `ox doctor`, not auto-healed.
+
+---
+
+## Why this exists
+
+The naive premise that "ox sessions store commit SHAs → a rebase silently breaks them" was almost the opposite of how ox actually worked before this work:
+
+1. Sessions did not store commit SHAs at all (no `CommitSHA`, no `HeadCommit`, no list of produced commits).
+2. The only commit↔session linkage was a `SageOx-Session: <url>` trailer in the commit message, injected by `prepare-commit-msg`.
+3. Because that trailer lives inside the commit message, git preserves it across most rewrites for free (amend, vanilla rebase, cherry-pick).
+4. Reverse direction — "what commits did this session produce?" — was unanswerable.
+
+Phase A (this spec + the trailer-survival test suite) locks down what the existing trailer guarantees. Phase B adds a structured reverse index so `ox session view` and `ox query` can answer the reverse-direction question.
+
+---
+
+## Rewrite-survival matrix
+
+| Operation | Trailer survives? | `ProducedCommits` updated? | Notes |
+|---|---|---|---|
+| `git commit --amend` (no message edit) | ✅ Yes | ✅ Yes — `post-rewrite` rewrites SHA in place | Most common rewrite; trivially preserved |
+| `git rebase` (non-interactive) | ✅ Yes | ✅ Yes — each replayed SHA rewritten via mapping | Preserved on per-commit basis |
+| `git rebase -i` reword | ⚠️ Depends on editor | ⚠️ Depends | User editor may strip trailer manually |
+| `git rebase -i` squash / fixup | ⚠️ Source trailers concatenated into combined message | ✅ `post-rewrite` collapses adjacent duplicates → single entry | Multiple `SageOx-Session:` lines in one commit body is valid but unusual |
+| `git cherry-pick` | ✅ Yes | ❌ (only the source branch's recording knew; not auto-attached to other branches) | Trailer copies along; reverse index is per-recording |
+| `git reset --hard` + recommit (no active recording) | ❌ No | ❌ No | Documented loss — see "Loss boundaries" |
+| `git merge --squash` + `git commit -m` | ❌ No (combined message doesn't run prepare-commit-msg if `-m` provided) | ❌ No | Local analog of GitHub squash-merge |
+| GitHub squash merge (server-side) | ⚠️ Depends on repo's squash-message setting | ❌ No (no local hook fires) | The biggest real-world loss case; see follow-up issue C2 |
+| `git filter-repo` / `filter-branch` | ❌ Likely no | ❌ No | History-rewrite tools rebuild commits from scratch |
+| Commits made AFTER `ox session stop` | ❌ No trailer injected | N/A | Documented limitation |
+
+The test suite in `cmd/ox/hooks_commit_msg_rewrite_test.go` covers every row above that is testable inside a local git repo. GitHub-side squash-merge is covered by the follow-up mapping epic, not by this spec.
+
+---
+
+## Source of truth on disagreement
+
+When `ProducedCommits` and the commit-message trailer disagree, the trailer wins. Reasoning:
+
+- The trailer is durable: it lives inside the commit object, propagates with the commit through clones, rebases, and forks.
+- `ProducedCommits` lives inside a per-recording `meta.json`. If a rebase happens after session stop, the reverse index goes stale (closed sessions are not auto-mutated — see D3 below).
+- Therefore the reverse index is a cache of "what we knew at recording time," not an authoritative record.
+
+Anything that consumes both (e.g. a future reconciler) should treat the trailer as ground truth and use `ProducedCommits` only as a fast index. If a SHA appears in `ProducedCommits` but not in `git log` for the current branch, it is unreachable — surface as soft signal, do not delete.
+
+---
+
+## Design decisions
+
+### D1 — In-recording tracking via `post-commit`
+
+The `prepare-commit-msg` hook fires BEFORE git assigns a SHA, so it cannot populate `ProducedCommits` itself. `post-commit` fires after the SHA is assigned, which is the right injection point.
+
+Implementation: `cmd/ox/hooks_post_commit.go:runHooksPostCommit`. Resolves the active recording via the same lookup the trailer injector uses (agent-specific via `SAGEOX_AGENT_ID`, workspace fallback for human commits, subagent prefers parent). Appends HEAD SHA via `git rev-parse HEAD`. Idempotent: a second invocation on the same HEAD does not duplicate.
+
+### D2 — In-recording rewrite tracking via `post-rewrite`
+
+Git invokes `post-rewrite` after `amend` and `rebase` with a stdin stream of `<old-sha> <new-sha>[ <extra>]` lines. The handler reads the mapping, rewrites matching `ProducedCommits` entries in place, and collapses adjacent duplicates (the squash case).
+
+Implementation: `cmd/ox/hooks_post_rewrite.go:runHooksPostRewrite`. Squash/fixup leaves N entries all pointing at the same new SHA; we collapse those to one entry so `ox session view` reflects the resulting history, not the pre-rewrite history.
+
+### D3 — Closed sessions are NOT mutated by `post-rewrite`
+
+If a user closes a session, then rebases the produced commit range later, `ProducedCommits` in the now-archived `meta.json` becomes stale.
+
+**v1 policy: accept staleness, surface as a soft signal in `ox doctor`.** Reasoning:
+
+- Mutating ledger history per-rewrite undermines the "ledger is an archive" mental model.
+- Requires scanning every closed session's `meta.json` on every rewrite — non-trivial on large ledgers.
+- The forward trailer-based link still survives the rebase for free; users can still navigate from new commits to sessions.
+
+A future opt-in policy for mutable closed-session `ProducedCommits` is tracked separately (follow-up issue C1 under `bd ox-bxo2`).
+
+### D4 — Trailer remains source of truth for commit → session
+
+See "Source of truth on disagreement" above. `ProducedCommits` is a derived, complementary index. Do not consume it as authoritative.
+
+### D5 — Schema migration
+
+`SessionMeta.ProducedCommits` and `RecordingState.ProducedCommits` are added as `omitempty` fields. Old sessions without the field round-trip unchanged; reading an absent field yields nil, treated equivalently to an empty list. No on-disk migration. An opt-in backfill (scan `git log` for `SageOx-Session:` trailers, populate `ProducedCommits` retroactively) is tracked as follow-up C3.
+
+---
+
+## Loss boundaries
+
+The trailer-survival matrix above identifies the documented loss cases. None of them are bugs — they are intrinsic to the trailer-based design. Mitigations:
+
+| Loss case | Mitigation |
+|---|---|
+| GitHub squash-merge stripping trailers | Move to server-side reconciler (mapping epic, follow-up). Sticky PR comment maintained by SageOx GitHub App via webhook. |
+| `reset --hard` + recommit | None feasible at the linkage layer; user explicitly threw away history. |
+| Commits after session stop | Documented as expected. If users want all-day coverage, they should run `ox session start` continuously. |
+| `filter-repo` / `filter-branch` | None; these are intentional history-rewrite tools and trailer loss is the smallest of their effects. |
+
+The `ox doctor` checks (`checkSessionTrailerRatio`, `checkSessionProducedCommitsStaleness`) surface these losses to the user as soft signals so the loss is visible, even if not auto-healed.
+
+---
+
+## Doctor signals
+
+Two soft-signal checks live in `cmd/ox/doctor_session_linkage.go`:
+
+1. **Trailer coverage on recent commits.** Scans the last 50 commits on the current branch, counts `SageOx-Session:` trailer presence, emits a warning if the ratio is below 40%. Catches GitHub squash-merge configs that strip trailers, `--no-verify` habits, and uninstalled hooks.
+2. **Closed-session ProducedCommits reachability.** For each closed session under `<ledger>/sessions/`, checks whether each SHA in `ProducedCommits` is reachable via `git cat-file -e`. Reports unreachable count. Documents the D3-deferred staleness.
+
+Neither check fails. Both are advisory.
+
+---
+
+## Code map
+
+| Concern | File |
+|---|---|
+| `SessionMeta.ProducedCommits` schema | `internal/lfs/meta.go` |
+| `RecordingState.ProducedCommits` schema | `internal/session/recording.go` |
+| Hook installation (3 hooks, idempotent) | `cmd/ox/hooks_git.go` |
+| Trailer injection (`prepare-commit-msg`) | `cmd/ox/hooks_commit_msg.go` |
+| Reverse index append (`post-commit`) | `cmd/ox/hooks_post_commit.go` |
+| Reverse index rewrite (`post-rewrite`) | `cmd/ox/hooks_post_rewrite.go` |
+| Fold into `SessionMeta` on stop | `cmd/ox/agent_session.go:1285` |
+| Render in `ox session view --text` | `cmd/ox/session_view_text.go:renderProducedCommits` |
+| Render in `ox session view --json` | `cmd/ox/session_show.go:convertStoredSession` |
+| Doctor soft signals | `cmd/ox/doctor_session_linkage.go` |
+| Trailer-survival tests | `cmd/ox/hooks_commit_msg_rewrite_test.go` |
+| Reverse-index handler tests | `cmd/ox/hooks_post_commit_test.go`, `cmd/ox/hooks_post_rewrite_test.go` |

--- a/docs/ai/specs/session-pr-issue-linkage.md
+++ b/docs/ai/specs/session-pr-issue-linkage.md
@@ -1,7 +1,7 @@
 # Session ↔ PR / Issue Linkage (Design)
 
 **Audience:** AI coworkers and engineers extending ox's linkage system beyond commits to GitHub PRs and Issues.
-**Status:** Design — implementation tracked under epic `bd ox-fdre`.
+**Status:** v1 (M1–M5) shipped; v2 (M6–M8, GitHub App) + v3 remain. Tracked under epic `bd ox-fdre`.
 **Companion:** [`session-commit-linkage.md`](./session-commit-linkage.md) (commit-level linkage; this design builds on it).
 
 ---
@@ -407,6 +407,33 @@ Server-side telemetry (separate spec when v2 lands):
 - Reconciliation latency p50/p95/p99
 - Sticky comment edit failures by error type
 - Comment body size distribution (catch runaway growth on PRs with hundreds of commits)
+
+---
+
+## v1 implementation notes (as shipped)
+
+Divergences from the design above, recorded so the next reader isn't surprised:
+
+| Area | Design | As shipped (v1) | Why |
+|---|---|---|---|
+| Hook name | `pre-push` (decision) | `pre-push` | As designed. Reads git's ref stream on stdin; installed as the 4th ox hook in `hooks_git.go`. |
+| Issue-ref form | `owner/repo#N` | bare `#N` | The CLI doesn't reliably know `owner/repo` without an extra `gh` call; the server reconciler (v2) resolves `#N` to `owner/repo#N` using repo context from the webhook. Cheaper and avoids a second network round-trip in the hot push path. |
+| `LinkageStatus` pre-stop transitions | `pending` at start, `staged` at stop | first written as `staged` at stop | `RecordingState.LinkageStatus` exists but is not written during recording in v1; the field is reserved for a future enhancement that tracks pending state mid-recording. Empty == legacy/pending, treated identically. |
+| Bare `#N` in subject vs body | body only | whole message (`%B`) scanned | The closing-keyword regex requires a keyword (`Fixes`/`Closes`/`Resolves`/`GH-`), so a subject like `fix: thing` does NOT match; only an explicit `Fixes #N` does, wherever it appears. Net effect matches the design intent (no false positives from passing mentions). |
+| Notification gating | always notify on upload | notify only when there is linkage OR produced commits | A session with nothing to link gives the reconciler nothing to act on; skipping the call avoids needless server load. |
+
+Files (v1):
+
+| Concern | File |
+|---|---|
+| `LinkedPRs` / `LinkedIssues` / `LinkageStatus` schema | `internal/lfs/meta.go`, `internal/session/recording.go` |
+| `LinkageStatus*` constants | `internal/lfs/meta.go` |
+| pre-push hook install (4th hook) | `cmd/ox/hooks_git.go` |
+| pre-push handler (range parse, issue refs, PR resolve) | `cmd/ox/hooks_pre_push.go` |
+| fold into SessionMeta on stop | `cmd/ox/agent_session.go` |
+| upload-confirmed transition + notify | `cmd/ox/session_linkage_finalize.go` |
+| server notification client | `internal/api/repo.go` (`NotifySessionUploaded`) |
+| render in `ox session view` | `cmd/ox/session_view_text.go`, `cmd/ox/session_show.go` |
 
 ---
 

--- a/docs/ai/specs/session-pr-issue-linkage.md
+++ b/docs/ai/specs/session-pr-issue-linkage.md
@@ -1,0 +1,434 @@
+# Session ↔ PR / Issue Linkage (Design)
+
+**Audience:** AI coworkers and engineers extending ox's linkage system beyond commits to GitHub PRs and Issues.
+**Status:** Design — implementation tracked under epic `bd ox-fdre`.
+**Companion:** [`session-commit-linkage.md`](./session-commit-linkage.md) (commit-level linkage; this design builds on it).
+
+---
+
+## Problem
+
+Today (post-`ox-bxo2`) the linkage system answers:
+
+- **commit → session** via `SageOx-Session: <url>` trailer in the commit message
+- **session → commits** via `SessionMeta.ProducedCommits` reverse index
+
+It does NOT answer:
+
+- **commit / session → PR** — which pull request carries this commit, and is the session that produced it linked from there?
+- **PR → sessions** — show me every session whose commits ended up in this PR
+- **issue → sessions** — which sessions touched issue #N (referenced via `Fixes #N`, `Closes #N`, or in PR body)?
+- **session → issues** — which issues did this session work on?
+
+And the existing trailer-based forward link has a **timing bug** that has bitten real users:
+
+> The `SageOx-Session: <url>` trailer is injected at commit time. The session is not uploaded to the ledger until later (and can fail or be deferred). PR comments and trailers point at a URL that may 404 when a reviewer clicks it.
+
+The "URL exists at commit time, may not work at view time" gap is the proximate complaint that motivated this design.
+
+---
+
+## Non-goals for v1
+
+- **Do NOT change the trailer format to an opaque ID.** Direct website URLs are a product feature. Stable IDs are a worse UX for the common case (reviewer clicks link, lands on a viewer page). Server-side handles drift via URL redirects, not via client-side indirection.
+- **Do NOT block commits or pushes** on linkage state. Every linkage write is best-effort, eventually consistent.
+- **Do NOT require server changes for v1.** v1 ships entirely inside the ox CLI. v2+ adds the SageOx GitHub App.
+
+---
+
+## Design principles
+
+1. **URL trailers stay.** The forward link from a commit to its session is a clickable URL, as today. Server provides stable redirects for URL changes (subdomain moves, redact rewrites).
+2. **Bidirectional metadata.** Sessions track `LinkedPRs []string` and `LinkedIssues []string`. PRs/Issues track sessions via server-managed sticky comments. Either side can answer the lookup.
+3. **Defer outbound side-effects until upload-confirmed.** No outbound notification or sticky-comment write happens until the session is viewable on the server. PR comment posting is gated on upload-confirmation, not on commit-time.
+4. **Webhook-driven server reconciler.** GitHub state is authoritative for PR/issue identity and membership. Walking commit messages is a heuristic; the GitHub API is the source of truth.
+5. **Same `omitempty`-and-roll-forward pattern** that `ProducedCommits` uses. No breaking schema changes; legacy meta.json round-trips cleanly.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A["commit during recording"] --> B["prepare-commit-msg<br/>SageOx-Session: URL trailer"]
+    B --> C["post-commit<br/>append SHA to ProducedCommits"]
+    C --> D["git push"]
+    D --> E["post-push hook (M2)<br/>resolve PR for branch<br/>parse Fixes #N from messages<br/>append to LinkedPRs/LinkedIssues"]
+    E --> F["ox session upload (existing)<br/>session lands in ledger"]
+    F --> G["upload-confirmed notification (M5)<br/>CLI to SageOx server"]
+    G --> H["SageOx GitHub App reconciler (M6)<br/>edits sticky PR comment"]
+    H --> I["Issue-side reconciler (M7)<br/>sticky comment on referenced issues"]
+```
+
+The CLI populates session-side metadata. The server-side GitHub App, once it exists, populates the GitHub-side artifacts (PR sticky comment, issue sticky comment, optional Check). The CLI never writes to GitHub directly in v1 — it only updates its own metadata. The "defer until upload-confirmed" property falls out of this split for free: the GitHub App will not have anything to post until the session has been uploaded and a webhook delivers the new state.
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **Sticky comment** | A single GitHub PR or Issue comment, tagged with an HTML marker, that the SageOx GitHub App edits idempotently as state changes. Never appends a second comment. |
+| **Upload-confirmed** | A session whose `meta.json` has been written to the ledger AND the LFS Batch upload of content files has returned success AND the ledger push has reached the remote. Until all three hold, the session is not viewable on the SageOx site. |
+| **Reconciler** | The server-side webhook handler that rebuilds the sticky comment from authoritative GitHub + ledger state. Stateless: derives output from inputs each run. |
+| **Pre-correlation** | Building the session→PR association before a PR exists, e.g. via branch-name convention. |
+| **Linkage record** | An ox-side artifact (`SessionMeta.LinkedPRs`, `LinkedIssues`) capturing the linkage as known to the CLI. Server-side state may diverge; the GitHub App's sticky comment is the user-visible truth. |
+
+---
+
+## v1 (ox CLI only)
+
+Implementation scope: `ox-fdre.1` through `ox-fdre.5`. Goal: every meaningful linkage is **stored locally in `SessionMeta`** and **renderable by `ox session view`**. No GitHub-side writes yet.
+
+### v1.1 — Schema extensions (`ox-fdre.1`)
+
+```go
+// internal/lfs/meta.go
+type SessionMeta struct {
+    // ... existing fields ...
+
+    // LinkedPRs is the set of GitHub PR URLs (or PR refs in the form
+    // owner/repo#N) that the session is associated with. Populated by
+    // the post-push hook when a PR exists for the pushed branch.
+    LinkedPRs []string `json:"linked_prs,omitempty"`
+
+    // LinkedIssues is the set of GitHub issue URLs (or refs) referenced
+    // by the session's commits via Fixes #N / Closes #N / etc., or by
+    // any LinkedPR's body.
+    LinkedIssues []string `json:"linked_issues,omitempty"`
+}
+```
+
+Mirror in `internal/session/recording.go:RecordingState`.
+
+### v1.2 — Push-time linkage population (`ox-fdre.2`)
+
+Git does not ship a `post-push` hook out of the box. After comparing alternatives:
+
+**Decision: `pre-push` hook that captures intended push state + writes linkage records BEFORE the push, paired with a CLI-side reconciliation pass in `ox doctor` and `ox session upload` to repair if the push fails.**
+
+Rationale:
+
+| Option | Why considered | Why rejected / accepted |
+|---|---|---|
+| `pre-push` hook | Standard git hook, fires for every push (including `git push` from a user's existing workflow — no behavior change required). | **Accepted.** Stdin already gives `<local-ref> <local-sha> <remote-ref> <remote-sha>` per ref. Writes linkage records based on `local-sha..local-sha-of-prior-push` range. Push may fail after we write; `ox doctor` repair pass handles that. |
+| CLI wrapper `ox push` | Cleaner than a hook; opt-in. | **Rejected for primary path.** Forces a workflow change; many users use IDE-driven push. We can expose `ox push` later as a convenience that runs the same logic and surfaces the linkage outcome inline, but it's not the primary hook. |
+| Daemon-driven post-push poller | Daemon watches refs/remotes and notices when a branch advances. | **Rejected.** Too indirect; relies on the daemon being healthy at push time; doesn't help ephemeral mode where daemon doesn't run. |
+| Server-side post-receive on a mirror | Authoritative. | **Rejected for v1.** Too heavyweight; requires mirror infrastructure. v2 GitHub App `push` webhook covers this without a mirror. |
+
+Handler responsibilities (`cmd/ox/hooks_pre_push.go`):
+
+1. Read stdin: lines of `<local-ref> <local-sha> <remote-ref> <remote-sha>`.
+2. For each ref being pushed where `<remote-sha>` is non-zero (i.e. branch already exists on remote), compute commit range `<remote-sha>..<local-sha>`. For new branches, use `--not --remotes` to bound the range against everything else on remotes.
+3. Resolve PR for the local ref via `gh pr list --head <branch> --json url,number,state` (1 API call, cached for the duration of the push).
+4. For each commit in the range, parse the message body for issue references using the patterns: `Fixes #N`, `Closes #N`, `Resolves #N`, `GH-N`, and standalone `#N` in body (NOT subject).
+5. Append unique entries to active `RecordingState.LinkedPRs` (PR URL if found) and `LinkedIssues` (resolved to `owner/repo#N`).
+6. Atomic-save state via `UpdateRecordingStateForAgent`. Best-effort; never blocks push.
+
+Failure recovery: if `gh` is not installed or returns rate-limit, we log at debug and skip PR resolution for that push. The next push (or `ox doctor`) re-tries. Issue refs from commit messages do not require any API call so they're always populated.
+
+Handler responsibilities:
+
+1. Determine pushed branch (`git symbolic-ref HEAD`).
+2. Resolve PR for branch via `gh pr list --head <branch> --json url,number,title`.
+3. Parse the pushed commit range (`<old>..<new>` from stdin in pre-push, or `<remote-branch>..<HEAD>` in CLI wrapper).
+4. Extract `Fixes #N`, `Closes #N`, `Resolves #N`, `GH-N`, `#N` (in body, not subject) patterns.
+5. Append unique entries to `RecordingState.LinkedPRs` and `LinkedIssues`.
+6. Atomic-save via `UpdateRecordingStateForAgent`.
+
+Best-effort. Never blocks. Logs at debug.
+
+### v1.3 — Fold into `SessionMeta` on stop (`ox-fdre.3`)
+
+Mirrors `ox-bxo2.7` exactly. At session-stop / recover, the builder gets:
+
+```go
+metaBuilder := sessionMetaBase(...).
+    // ... existing setters ...
+    ProducedCommits(state.ProducedCommits).
+    LinkedPRs(state.LinkedPRs).
+    LinkedIssues(state.LinkedIssues)
+```
+
+### v1.4 — Render in `ox session view` (`ox-fdre.4`)
+
+Add two markdown sections in `renderProducedCommits`-equivalent helpers in `cmd/ox/session_view_text.go`:
+
+```
+## Pull Requests
+- owner/repo#42 — feat: ship X
+- owner/repo#47 — fix: handle Y
+
+## Issues
+- owner/repo#101 — Foo broken on Z
+```
+
+For each entry, attempt a `gh` lookup for the title. On failure, render the bare ref. Same `<unreachable>` pattern as the commit list.
+
+JSON: extend `sessionMetadata` with the two fields.
+
+### v1.5 — Defer URL in PR comment (`ox-fdre.5`)
+
+**This is the core fix for the stale-URL bug.**
+
+Today, the URL travels in the commit message trailer. The trailer goes wherever git takes the commit — PR comments and emails frequently surface trailers, and if the session isn't viewable yet, the URL 404s.
+
+The fix splits responsibility:
+
+- **Trailer stays as-is** (URL form). Once the session is uploaded, the URL works forever. The trailer is durable.
+- **PR comment** with the session link is posted by the server-side reconciler ONLY after upload-confirmed. Until v2 ships the reconciler, the CLI sends a notification to the SageOx server upon successful upload (`POST /api/v1/sessions/<id>/uploaded`). The server can then choose to act on it (e.g., enqueue for the GitHub App when it lands).
+
+#### Upload-confirmed state machine
+
+Each session has a single linkage-relevant state field, `LinkageStatus`, stored in `RecordingState` during the active recording and in `SessionMeta` after stop. State transitions are local-only until v2; the server reconciles independently from webhook state and treats the CLI signal as a hint.
+
+```
+pending --> staged --> uploaded --> notified
+   |          |           |
+   v          v           v
+ failed   upload_failed  notify_failed
+```
+
+| State | Set by | Meaning |
+|---|---|---|
+| `pending` | `ox session start` | Session exists locally, has linkage intent (LinkedPRs/Issues may be populated). Not yet eligible for any PR-comment posting. |
+| `staged` | `ox session stop` | meta.json written, content files in cache. LFS upload not yet attempted. |
+| `uploaded` | `ox session upload` after Batch API + git push success | All three components landed: meta.json + LFS blobs + git push. URL is viewable. |
+| `notified` | Server notification HTTP call success | SageOx server has been told. If v2 reconciler exists, it has now enqueued the comment update. |
+| `*_failed` | Catch-all for transitions that error | `ox doctor` retries on its schedule. |
+
+Storage:
+
+- `RecordingState.LinkageStatus string` (pre-stop; persisted in `.recording.json`)
+- `SessionMeta.LinkageStatus string` (post-stop; persisted in `meta.json` and pushed to ledger)
+- Server side is independent: receives notifications, derives state from webhook events.
+
+`ox doctor` runs a soft-signal check `session-linkage-pending`: counts sessions in `uploaded` (terminal-but-not-notified) or `notify_failed` and offers to retry via `ox session relink`.
+
+#### Until v2 reconciler exists
+
+The trailer in the commit message is the only PR-side artifact. That trailer goes stale during the window between commit and successful upload. v1 ships two mitigations:
+
+1. **CLI warning at push time.** When `pre-push` runs and any commit in the push range carries a trailer for a session whose `LinkageStatus != uploaded`, surface a warning on stderr:
+   > `WARN: 2 commits in this push reference sessions still uploading. SageOx-Session URLs may not work until upload completes. Run 'ox status' to see upload progress.`
+   This is a warning, not a block. User can override by ignoring the message.
+2. **Optional pre-push upload.** New flag `pre_push_upload = true` in user config makes pre-push synchronously wait for any `staged` recording to reach `uploaded` before allowing the push to proceed. Default off (would block on slow uploads); opt-in for users who want stronger guarantees.
+
+The second mitigation becomes more attractive once the reconciler exists; for now, the warning is enough to surface the timing issue.
+
+#### Server notification protocol
+
+Single endpoint, idempotent by `session_id`:
+
+```
+POST /api/v1/sessions/{session_id}/uploaded
+Authorization: Bearer <user PAT>
+Content-Type: application/json
+
+{
+  "session_id": "ses_01HG...",
+  "repo_id": "repo_01...",
+  "uploaded_at": "2026-05-28T15:42:11Z",
+  "session_url": "https://sageox.ai/repo/repo_01.../sessions/.../view",
+  "linked_prs": ["https://github.com/owner/repo/pull/42"],
+  "linked_issues": ["owner/repo#101", "owner/repo#103"],
+  "produced_commits": ["abc1234...", "def5678..."]
+}
+```
+
+Server response:
+
+| Status | Meaning | CLI action |
+|---|---|---|
+| `204 No Content` | Accepted | Set `LinkageStatus = notified`. Done. |
+| `409 Conflict` | Already notified for this session | Treat as success; set `notified`. |
+| `429 Too Many Requests` | Rate-limited | Set `notify_failed`, retry via doctor later. |
+| `5xx` | Server error | Set `notify_failed`, retry. |
+| network error / timeout | Transient | Set `notify_failed`, retry. |
+
+The endpoint is intentionally narrow: the server learns of the upload from the CLI; the GitHub App learns from `push` webhooks; the server cross-references the two when generating the sticky comment.
+
+---
+
+## v2 (SageOx GitHub App)
+
+Separate repo, separate deploy. v2 work tracked under `ox-fdre.6`, `ox-fdre.7`, `ox-fdre.8`.
+
+### v2.1 — App scaffold + sticky PR comment (`ox-fdre.6`)
+
+A GitHub App with:
+
+- **Permissions (minimum scope):**
+  - `pull_requests: write` — post and edit PR comments
+  - `issues: write` — post and edit issue comments
+  - `contents: read` — read commit messages (for trailer extraction)
+  - `metadata: read` — required by GitHub for app installation
+- **Subscribed webhook events:** `push`, `pull_request` (opened, synchronize, reopened, edited), `issues` (opened, edited, closed, reopened), `installation` (added/removed), `installation_repositories` (added/removed).
+- **Webhook security:** every payload validated via `X-Hub-Signature-256` HMAC against the per-installation webhook secret. Requests with invalid signatures are rejected with 400 before any parsing. Replay protection via `X-GitHub-Delivery` UUID + 5-minute idempotency window stored in Redis.
+- **App-level idempotency:** all comment writes use an HTML-comment tag (`<!-- sageox-sessions:sticky -->`) to find the existing comment and PATCH it via the Issues API. Never creates a second copy. If two webhook deliveries race, the lock key is `installation_id:repo:pr_number`.
+
+#### Reconciliation triggers
+
+| Event | Action |
+|---|---|
+| `pull_request.opened` | Build sticky comment from commit-message trailers in PR's commits. Resolve each session via ledger lookup. |
+| `pull_request.synchronize` | Re-read commits, re-build sticky comment. Diff vs. previous: only PATCH if body changes. |
+| `pull_request.reopened` | Same as opened. |
+| `push` (to default branch) | Update any open PR's sticky comment if the pushed commits include `Fixes #N` patterns (annotate the issue side). |
+| `issues.opened` / `issues.edited` | Re-scan referencing PRs; rebuild issue sticky comment. |
+| `installation.added` | Register installation; no immediate action. |
+| Internal `/api/v1/sessions/{id}/uploaded` notification | Re-queue any PR whose comment placeholder referenced this session. |
+
+#### Sticky comment template
+
+Default body (markdown):
+
+```markdown
+<!-- sageox-sessions:sticky v=1 -->
+## 🟢 SageOx Sessions in this PR
+
+This PR contains commits produced during the following recorded sessions.
+Sessions become viewable once their content uploads complete.
+
+| Commit | Session | Title | Agent | State |
+|---|---|---|---|---|
+| `abc1234` | [view](https://sageox.ai/repo/repo_01.../sessions/2026-05-28T14-32-ryan-Oxc0ffee/view) | Feature X scaffolding | Oxc0ffee | ✅ ready |
+| `def5678` | _(not yet uploaded)_ | _pending_ | Oxc0ffee | 🟡 uploading |
+
+<sub>Updated automatically by SageOx. Last refreshed: 2026-05-28T15:42 UTC. Sessions are linked via the `SageOx-Session:` commit trailer.</sub>
+```
+
+Placeholder rows show when a referenced session has not yet been confirmed uploaded (via the `/api/v1/sessions/{id}/uploaded` notification OR via direct ledger lookup). Once confirmed, the next reconciliation pass replaces the placeholder.
+
+#### Multi-session, multi-PR semantics
+
+| Scenario | Behavior |
+|---|---|
+| Session X contributes commits to PRs A AND B | Both PR sticky comments list session X. Session X's `LinkedPRs` lists both A and B. |
+| PR A contains commits from sessions X AND Y | PR A's sticky comment lists both. |
+| Commit is later cherry-picked into PR C | PR C's sticky comment lists the source session (trailer survived). Session's `LinkedPRs` adds C on next reconciliation pass (server-side; CLI's session metadata is frozen after stop). |
+| PR squash-merged → merged commit lands on default branch | If GitHub's squash settings preserved the trailer in the merge commit, downstream PRs see it. If not, the `push` webhook handler logs the linkage loss for telemetry. |
+| Session has no commits in any PR yet | No sticky comment exists. No spurious empty comments. |
+
+#### Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Webhook delivery fails (network/timeout) | GitHub auto-retries up to 3x over 12h. Idempotency tag handles duplicates. |
+| Comment PATCH fails (rate limit) | Re-queue with exponential backoff. Hard ceiling: 5 attempts over 1 hour. |
+| Ledger lookup fails (session not found) | Show placeholder row `_(not found)_`. Do not block other rows. |
+| App uninstalled mid-flight | Pending reconciliations drop on the floor; no orphan comments because comments live on PRs/issues, not on the app. |
+| GitHub App suspended | All operations short-circuit; user is informed via the SageOx web UI on next visit. |
+
+### v2.2 — Bidirectional issue refs (`ox-fdre.7`)
+
+For each issue referenced (Fixes #N, body mentions, etc.), maintain a sticky comment on the issue listing sessions that touched it. Same idempotency tag pattern, different target.
+
+When a PR merges and closes the issue, annotate the comment: "Closed by session ses_XYZ via PR #42."
+
+### v2.3 — GitHub Checks (UX upgrade) (`ox-fdre.8`)
+
+Replace (or augment) the PR comment with a GitHub Check titled "SageOx Sessions." Check details lists session URLs + summaries. Pending while sessions uploading, success when all referenced sessions viewable. Native PR UI; doesn't pollute conversation thread.
+
+The 2026 trend across Sentry Releases, Vercel previews, CircleCI summaries, and Devin is "GitHub Check > sticky comment" for structured, refreshable CI/agent data. We ship the comment first because Checks require event-driven status updates that depend on the reconciler being fully wired.
+
+---
+
+## v3 (audit-grade provenance, optional)
+
+`ox-fdre.10`. SLSA-style attestations for regulated industries / supply-chain compliance. Out of scope for this design beyond "we have a slot for it."
+
+---
+
+## Branch-name convention (optional pre-correlation)
+
+`ox-fdre.9`. Convention: `agent/<oxsid>/<topic>` branch names allow the server reconciler to pre-correlate sessions to a branch BEFORE any PR exists. Optional; the CLI suggests but does not enforce.
+
+---
+
+## Trade-offs and rejected alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| Switch trailer to opaque `ses_<id>` | Direct website URLs are a product feature; opaque IDs break click-to-view UX. Server handles drift via redirects. |
+| Block push until session uploads | Hostile to dev experience. Many teams push WIP commits before stopping the session. |
+| Walk commit messages server-side without webhooks | Polling is wasteful; GitHub Apps are the standard pattern. Webhooks scale better than scheduled scans. |
+| Single comment per commit instead of sticky-per-PR | Conversation pollution. Modern tools all moved to sticky-per-PR. |
+| Store linkage only server-side | Local `ox session view` should answer without network. Bidirectional storage is the right call. |
+
+---
+
+## Acceptance summary
+
+| Phase | Acceptance signal |
+|---|---|
+| v1.1 | `SessionMeta` round-trips `LinkedPRs` and `LinkedIssues`. |
+| v1.2 | After `ox push` on a branch with a PR, active recording state shows the PR URL and any issue refs. |
+| v1.3 | Closed-session `meta.json` carries `LinkedPRs` / `LinkedIssues`. |
+| v1.4 | `ox session view` renders PR and Issue sections when populated. |
+| v1.5 | CLI emits upload-confirmed notification; warns when pushing commits whose trailers are not yet viewable. |
+| v2.1 | PR open / sync produces a sticky comment listing sessions. |
+| v2.2 | Issue events produce a reciprocal sticky comment on the issue. |
+| v2.3 | Each PR exposes a "SageOx Sessions" Check. |
+| v3.x | Per-commit signed attestation produced and verifiable via `ox session verify`. |
+
+---
+
+## Ephemeral mode
+
+When `ephemeral.IsEphemeral()` is true (CI, Codespaces, Devin remote, `OX_EPHEMERAL=1`), the daemon does not run and `git push` may not happen at all in some workflows (the session is uploaded via HTTP and consumed directly). Linkage behavior:
+
+| v1 step | Ephemeral behavior |
+|---|---|
+| M1 schema | Same. Fields live in meta.json regardless of mode. |
+| M2 pre-push hook | Runs if user invokes git push. If user uses `ox session upload` directly without a push, the hook never fires; LinkedPRs/LinkedIssues stays empty unless populated by a future v1.6. |
+| M3 fold on stop | Same. Uses whatever was in RecordingState. |
+| M4 render | Same. |
+| M5 upload-confirmed notification | Same. HTTP-only, works in ephemeral mode. |
+
+For ephemeral users who never push from the ox-CLI environment, linkage is populated server-side from `push` webhooks (v2.1). v1 provides degraded but non-broken UX in ephemeral mode — sticky comments work; pre-PR ProducedCommits-based linkage works; only the CLI-side pre-push enrichment is missing.
+
+---
+
+## Observability
+
+The reconciler is a server-side service; observability lives there. CLI-side telemetry:
+
+| Signal | Where | Purpose |
+|---|---|---|
+| `linkage.pre_push.duration_ms` | pre-push hook | Catch hook regressions that slow `git push`. Target: <200ms p99 with 0 PRs, <800ms with `gh pr list` round-trip. |
+| `linkage.notify.success_total` / `linkage.notify.failed_total` | upload path | Detect notify-endpoint outages. |
+| `linkage.linked_prs.count` / `linkage.linked_issues.count` | session stop | Distribution of linkage population per session. |
+| `linkage.doctor.pending_uploads` | doctor | Number of sessions stuck in `uploaded`-but-not-`notified`. |
+
+Server-side telemetry (separate spec when v2 lands):
+
+- Webhook delivery success rate per installation
+- Reconciliation latency p50/p95/p99
+- Sticky comment edit failures by error type
+- Comment body size distribution (catch runaway growth on PRs with hundreds of commits)
+
+---
+
+## Open questions for the reviewer
+
+1. **v2 GitHub App repo location.** Separate `sageox/sageox-github-app` repo (clean isolation, independent deploy cadence) or in `sageox/sageox` (less infra)? Out of scope for this doc; affects v2 implementation only.
+2. **Notify endpoint vs ledger polling.** v1.5 uses an explicit `POST /api/v1/sessions/{id}/uploaded` notification. Alternative: server polls the ledger via the existing webhook from the ledger remote. Notification is more responsive; polling is more resilient. Recommendation: ship notification first, add polling as fallback in v2.
+3. **Trailer URL drift.** When the SageOx site changes URL structure or a session is renamed/redacted, existing commit-message trailers point at old URLs. Resolution: server-side redirects (301) from old paths to new. Out of scope for this design but listed as a dependency on the SageOx web service.
+4. **Linkage retention for closed PRs.** When a PR closes (merged or rejected), should the sticky comment stay or be archived? Recommendation: stay, with a header annotation: `> ✅ Merged 2026-05-28 — session list frozen.` Comment becomes a permanent retrospective record. Issue sticky comments follow the same pattern.
+
+---
+
+## Implementation order (v1)
+
+Strict dependency order. Each step builds on the prior and is independently testable.
+
+1. **M1** (schema): `LinkedPRs []string`, `LinkedIssues []string`, `LinkageStatus string` on `SessionMeta` + `RecordingState`. Builder methods. JSON round-trip tests.
+2. **M3** (fold on stop): agent_session.go + agent_session_recover.go pick up the new state fields. Test: stop session with non-empty LinkedPRs, verify meta.json carries them.
+3. **M4** (render): `## Pull Requests` + `## Issues` sections in viewAsText; JSON exposes fields. Test: view session with each field, verify rendering.
+4. **M2** (pre-push hook): handler parses commit range, resolves PRs, extracts issue refs, updates RecordingState. Test: real git repo + recording, fake PR via temporary git refs, assert state populated.
+5. **M5** (upload-confirmed): LinkageStatus transitions; HTTP notification call; doctor soft-signal for pending. Test: complete upload, assert state transitions; mock server outage, assert failed state.
+
+M1 → M3 → M4 → M2 → M5 is the right ship sequence: schema first, fold-and-display second so we can validate visually, hook third (with rendering already proving the fields work), notification last (highest external dependency).
+
+Total v1 cost estimate: ~1500-2000 LOC across implementation + tests, mirroring the ox-bxo2 footprint.

--- a/internal/api/repo.go
+++ b/internal/api/repo.go
@@ -33,9 +33,10 @@ const (
 	repoDoctorPathAuthed = "/api/v1/repos/%s/doctor"
 	repoDoctorPathLegacy = "/api/v1/public/repos/%s/doctor"
 
-	repoUninstallPath = "/api/v1/repo/%s/uninstall"       // %s = repo_id
-	repoMergePath     = "/api/v1/repo/%s/merge"           // %s = repo_id
-	gitImportPath     = "/api/v1/teams/%s/context/import" // %s = team_id
+	repoUninstallPath   = "/api/v1/repo/%s/uninstall"       // %s = repo_id
+	repoMergePath       = "/api/v1/repo/%s/merge"           // %s = repo_id
+	gitImportPath       = "/api/v1/teams/%s/context/import" // %s = team_id
+	sessionUploadedPath = "/api/v1/sessions/%s/uploaded"    // %s = session_id
 )
 
 // RepoInitRequest represents the POST /api/v1/repo/init request
@@ -104,6 +105,19 @@ type MergeRepoResponse struct {
 type ImportNotification struct {
 	TeamID   string          `json:"team_id"`
 	Metadata json.RawMessage `json:"metadata"`
+}
+
+// SessionUploadedNotification is the POST /api/v1/sessions/{session_id}/uploaded
+// request body. Tells the server a session's content has landed in the
+// ledger and is viewable, so the (v2) GitHub App reconciler can refresh any
+// PR sticky comment. See docs/ai/specs/session-pr-issue-linkage.md (v1.5).
+type SessionUploadedNotification struct {
+	SessionID       string   `json:"session_id"`
+	RepoID          string   `json:"repo_id"`
+	SessionURL      string   `json:"session_url,omitempty"`
+	LinkedPRs       []string `json:"linked_prs,omitempty"`
+	LinkedIssues    []string `json:"linked_issues,omitempty"`
+	ProducedCommits []string `json:"produced_commits,omitempty"`
 }
 
 // DoctorIssue represents a single diagnostic issue from the cloud
@@ -525,6 +539,58 @@ func (c *RepoClient) NotifyImport(teamID string, metadata any) error {
 	}
 
 	return nil
+}
+
+// NotifySessionUploaded tells the SageOx server that a session's content
+// has been uploaded and is viewable. Graceful degradation mirrors
+// NotifyImport: network errors and 404 (endpoint not yet deployed) return
+// nil so the caller can record "notified" optimistically without blocking;
+// 429 and 5xx return an error so the caller records "notify_failed" and
+// retries via ox doctor.
+func (c *RepoClient) NotifySessionUploaded(n SessionUploadedNotification) error {
+	bodyBytes, err := json.Marshal(n)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	reqURL := strings.TrimSuffix(c.baseURL, "/") + fmt.Sprintf(sessionUploadedPath, n.SessionID)
+
+	logger.LogHTTPRequest("POST", reqURL)
+	start := time.Now()
+
+	httpReq, err := useragent.NewRequest(context.Background(), "POST", reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.authToken != "" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	duration := time.Since(start)
+	if err != nil {
+		logger.LogHTTPError("POST", reqURL, err, duration)
+		return fmt.Errorf("session uploaded notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	logger.LogHTTPResponse("POST", reqURL, resp.StatusCode, duration)
+	io.Copy(io.Discard, resp.Body)
+
+	switch {
+	case resp.StatusCode == http.StatusNotFound:
+		// endpoint not yet deployed — treat as accepted so the CLI doesn't
+		// thrash retrying against a server that can't answer yet.
+		return nil
+	case resp.StatusCode == http.StatusConflict:
+		// already notified for this session — idempotent success.
+		return nil
+	case resp.StatusCode >= 400:
+		return fmt.Errorf("session uploaded notification failed (%d)", resp.StatusCode)
+	default:
+		return nil
+	}
 }
 
 // RepoMarkerData holds parsed data from a .repo_* marker file

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -170,6 +170,28 @@ type SessionMeta struct {
 	// omitempty so older meta.json files (pre-Phase B) round-trip unchanged.
 	ProducedCommits []string `json:"produced_commits,omitempty"`
 
+	// LinkedPRs is the set of GitHub pull-request references (URL or
+	// owner/repo#N form) this session is associated with. Populated by the
+	// pre-push hook when a PR exists for the pushed branch, and folded into
+	// meta.json at session stop. The server-side reconciler (epic ox-fdre,
+	// v2) is the user-visible source of truth for PR↔session mapping via
+	// sticky PR comments; this field is the CLI-side mirror used by
+	// `ox session view` and `ox query`. omitempty for legacy round-trip.
+	LinkedPRs []string `json:"linked_prs,omitempty"`
+
+	// LinkedIssues is the set of GitHub issue references (owner/repo#N or
+	// URL) this session touched, extracted from commit-message footers
+	// (Fixes #N / Closes #N / Resolves #N / GH-N) on the pushed range and
+	// from any LinkedPR body. omitempty for legacy round-trip.
+	LinkedIssues []string `json:"linked_issues,omitempty"`
+
+	// LinkageStatus is the upload/notify lifecycle state for PR/issue
+	// linkage. See docs/ai/specs/session-pr-issue-linkage.md (v1.5) for the
+	// state machine: pending → staged → uploaded → notified, with *_failed
+	// branches retried by `ox doctor`. Empty string == legacy/unknown,
+	// treated as pre-linkage and never blocking. omitempty for round-trip.
+	LinkageStatus string `json:"linkage_status,omitempty"`
+
 	Files map[string]FileRef `json:"files"` // OID manifest: filename -> ref
 }
 
@@ -245,6 +267,28 @@ type RedactionEntry struct {
 // enough to absorb a transient LLM hiccup without burning unbounded
 // tokens on a structurally-broken session.
 const MaxSummaryAttempts = 3
+
+// LinkageStatus lifecycle values for SessionMeta.LinkageStatus and
+// RecordingState.LinkageStatus. See docs/ai/specs/session-pr-issue-linkage.md
+// (v1.5) for the full state machine. Empty string is the legacy/unknown
+// zero value and is treated as pre-linkage — never blocking.
+const (
+	// LinkageStatusPending — session exists locally with linkage intent;
+	// not yet eligible for any PR-comment posting.
+	LinkageStatusPending = "pending"
+	// LinkageStatusStaged — meta.json written, content in cache, LFS upload
+	// not yet attempted.
+	LinkageStatusStaged = "staged"
+	// LinkageStatusUploaded — meta.json + LFS blobs + git push all landed;
+	// the session URL is viewable.
+	LinkageStatusUploaded = "uploaded"
+	// LinkageStatusNotified — SageOx server has been told of the upload.
+	LinkageStatusNotified = "notified"
+	// LinkageStatusUploadFailed — upload transition errored; doctor retries.
+	LinkageStatusUploadFailed = "upload_failed"
+	// LinkageStatusNotifyFailed — notify transition errored; doctor retries.
+	LinkageStatusNotifyFailed = "notify_failed"
+)
 
 // FileRef identifies a session content file by storage backend, OID
 // (for LFS files), and size.
@@ -395,6 +439,25 @@ func (b *SessionMetaBuilder) RepoID(id string) *SessionMetaBuilder {
 // order; duplicates are not deduplicated (callers do that if needed).
 func (b *SessionMetaBuilder) ProducedCommits(shas []string) *SessionMetaBuilder {
 	b.meta.ProducedCommits = shas
+	return b
+}
+
+// LinkedPRs sets the GitHub pull-request references for this session.
+func (b *SessionMetaBuilder) LinkedPRs(prs []string) *SessionMetaBuilder {
+	b.meta.LinkedPRs = prs
+	return b
+}
+
+// LinkedIssues sets the GitHub issue references for this session.
+func (b *SessionMetaBuilder) LinkedIssues(issues []string) *SessionMetaBuilder {
+	b.meta.LinkedIssues = issues
+	return b
+}
+
+// LinkageStatus sets the upload/notify lifecycle state. Use the
+// LinkageStatus* constants.
+func (b *SessionMetaBuilder) LinkageStatus(status string) *SessionMetaBuilder {
+	b.meta.LinkageStatus = status
 	return b
 }
 

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -149,6 +149,27 @@ type SessionMeta struct {
 	// older readers ignore the new field.
 	Redactions []RedactionPass `json:"redactions,omitempty"`
 
+	// ProducedCommits is the reverse-direction index linking this session to
+	// the git commits authored during the recording. Populated by the
+	// post-commit hook on the producing repo while the recording is active
+	// and folded into meta.json at session-stop / finalize.
+	//
+	// Source-of-truth note: the canonical forward link is the
+	// SageOx-Session: trailer on each commit message (commit→session). This
+	// list is a structured reverse index for fast session→commits lookup
+	// in session view / query, NOT a replacement for the trailer. If the
+	// two disagree (e.g. because a closed-session post-rewrite went stale),
+	// the trailer wins during reconciliation.
+	//
+	// Staleness model (D3): post-rewrite updates this list ONLY while the
+	// recording is still active. If the user rebases a commit range after
+	// session stop, entries here may reference SHAs no longer reachable in
+	// git log; `ox doctor` surfaces this as a soft signal but does not
+	// auto-mutate closed sessions.
+	//
+	// omitempty so older meta.json files (pre-Phase B) round-trip unchanged.
+	ProducedCommits []string `json:"produced_commits,omitempty"`
+
 	Files map[string]FileRef `json:"files"` // OID manifest: filename -> ref
 }
 
@@ -365,6 +386,15 @@ func (b *SessionMetaBuilder) UserID(id string) *SessionMetaBuilder {
 
 func (b *SessionMetaBuilder) RepoID(id string) *SessionMetaBuilder {
 	b.meta.RepoID = id
+	return b
+}
+
+// ProducedCommits sets the reverse-direction commit-SHA index for this
+// session. Caller passes the SHAs accumulated by the post-commit hook in
+// RecordingState during the active recording. Order preserves commit
+// order; duplicates are not deduplicated (callers do that if needed).
+func (b *SessionMetaBuilder) ProducedCommits(shas []string) *SessionMetaBuilder {
+	b.meta.ProducedCommits = shas
 	return b
 }
 

--- a/internal/lfs/meta_test.go
+++ b/internal/lfs/meta_test.go
@@ -214,6 +214,53 @@ func TestNewSessionMeta_RoundTrip(t *testing.T) {
 	assert.Equal(t, "sha256:abc123", got.Files["raw.jsonl"].OID)
 }
 
+// TestSessionMeta_LinkageFieldsRoundTrip verifies the ProducedCommits,
+// LinkedPRs, LinkedIssues, and LinkageStatus fields survive a write/read
+// cycle. Failure prevented: a JSON tag typo silently drops linkage data,
+// making `ox session view` show empty PR/Issue/Commit sections.
+func TestSessionMeta_LinkageFieldsRoundTrip(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "linked-session")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	meta := NewSessionMeta("linked-session", "user", "Ox1234", "claude-code",
+		time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)).
+		RepoID("repo_xyz").
+		ProducedCommits([]string{"abc1234", "def5678"}).
+		LinkedPRs([]string{"https://github.com/owner/repo/pull/42"}).
+		LinkedIssues([]string{"#101", "#103"}).
+		LinkageStatus(LinkageStatusUploaded).
+		Build()
+
+	require.NoError(t, WriteSessionMeta(sessionDir, meta))
+
+	got, err := ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"abc1234", "def5678"}, got.ProducedCommits)
+	assert.Equal(t, []string{"https://github.com/owner/repo/pull/42"}, got.LinkedPRs)
+	assert.Equal(t, []string{"#101", "#103"}, got.LinkedIssues)
+	assert.Equal(t, LinkageStatusUploaded, got.LinkageStatus)
+}
+
+// TestSessionMeta_LegacyWithoutLinkageFields verifies a meta.json written
+// before these fields existed (no linkage keys) reads back with empty
+// slices and empty status — no error, no spurious data.
+// Failure prevented: a required (non-omitempty) tag would break legacy reads.
+func TestSessionMeta_LegacyWithoutLinkageFields(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "legacy-session")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	// hand-write a minimal legacy meta.json with no linkage keys
+	legacy := `{"version":"1.0","session_name":"legacy-session","username":"user","agent_id":"Ox1","agent_type":"claude-code","created_at":"2026-01-01T00:00:00Z","files":{}}`
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "meta.json"), []byte(legacy), 0o644))
+
+	got, err := ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Empty(t, got.ProducedCommits)
+	assert.Empty(t, got.LinkedPRs)
+	assert.Empty(t, got.LinkedIssues)
+	assert.Empty(t, got.LinkageStatus)
+}
+
 func TestUpdateMetaSummary(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -111,6 +111,18 @@ type RecordingState struct {
 	// older .recording.json files round-trip unchanged.
 	ProducedCommits []string `json:"produced_commits,omitempty"`
 
+	// LinkedPRs / LinkedIssues are the GitHub PR and issue references this
+	// recording is associated with. Appended by the pre-push hook from the
+	// pushed commit range, folded into SessionMeta at stop. omitempty for
+	// round-trip with older .recording.json files.
+	LinkedPRs    []string `json:"linked_prs,omitempty"`
+	LinkedIssues []string `json:"linked_issues,omitempty"`
+
+	// LinkageStatus tracks the upload/notify lifecycle for PR/issue linkage
+	// during the active recording. Mirrors lfs.LinkageStatus* values; folded
+	// into SessionMeta.LinkageStatus at stop. omitempty for round-trip.
+	LinkageStatus string `json:"linkage_status,omitempty"`
+
 	// Hook observability: lets `ox session status` show whether hooks are firing
 	// and why they're skipping. Without these, a broken recording path (e.g.
 	// adapter binary missing, session file not discoverable) looks identical to

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -104,6 +104,13 @@ type RecordingState struct {
 	InheritedPause       bool             `json:"inherited_pause,omitempty"`
 	InheritedFromSession string           `json:"inherited_from_session,omitempty"`
 
+	// ProducedCommits is the reverse-direction index of commit SHAs authored
+	// during this recording. Appended by the post-commit hook; rewritten
+	// in place by the post-rewrite hook on amend/rebase. Folded into
+	// SessionMeta.ProducedCommits at session stop / finalize. omitempty so
+	// older .recording.json files round-trip unchanged.
+	ProducedCommits []string `json:"produced_commits,omitempty"`
+
 	// Hook observability: lets `ox session status` show whether hooks are firing
 	// and why they're skipping. Without these, a broken recording path (e.g.
 	// adapter binary missing, session file not discoverable) looks identical to


### PR DESCRIPTION
## Summary

Hardens and extends ox's session linkage system end-to-end. Two epics ship together: **session↔commit linkage hardening** (`ox-bxo2`) locks down the existing commit-trailer linkage with tests + a reverse index, and **session↔PR/issue mapping v1** (`ox-fdre` M1–M5) fixes the stale-URL-in-PR-comment bug by deferring outbound linkage until upload is confirmed.

The premise that prompted this — "rebase silently breaks session→commit links" — turned out to be mostly wrong: the `SageOx-Session:` trailer lives in the commit message, so it survives amend/rebase/cherry-pick for free. The real gaps were (1) **zero tests** around any of it, (2) **no reverse index** ("what commits/PRs/issues did this session produce?"), and (3) a **timing bug** where a session URL surfaced on a PR before the session was uploaded and viewable.

## What broke (the stale-URL bug)

```mermaid
flowchart LR
    A["commit during recording"] --> B["trailer injected<br/>SageOx-Session URL"]
    B --> C["push to GitHub"]
    C --> D["reviewer clicks URL"]
    D --> E["404 — session<br/>not uploaded yet"]
```

The trailer URL was correct but premature: the session content uploads to the ledger **after** the commit, and could fail or lag. The link 404'd in the gap.

## What this PR ships

**Session↔commit (epic `ox-bxo2`, all phases):**
- **Reverse index** — `SessionMeta.ProducedCommits` populated by a new `post-commit` hook during recording; kept honest across in-recording rewrites by a new `post-rewrite` hook (consumes git's old→new SHA mapping; collapses squash/fixup duplicates).
- **Rendered** in `ox session view` (`## Commits` section, `<unreachable>` marker for SHAs no longer in history).
- **Doctor soft-signals** — trailer coverage on recent commits + closed-session SHA reachability. Never fail; just inform.
- **Tests** — trailer survival across amend/rebase/cherry-pick (preserved) and reset/squash/post-stop (documented losses), plus full hook-handler coverage. Previously **zero** tests existed here.
- **Spec** — `docs/ai/specs/session-commit-linkage.md` with the full rewrite-survival matrix.

**Session↔PR/issue v1 (epic `ox-fdre`, M1–M5):**
- **Schema** — `LinkedPRs`, `LinkedIssues`, `LinkageStatus` on `SessionMeta` + `RecordingState` (mirrors the `ProducedCommits` pattern).
- **`pre-push` hook** — resolves the branch's PR via `gh` (3s-bounded) and parses `Fixes #N` / `Closes #N` / `GH-N` from the pushed commit range into the active recording.
- **Upload-confirmed state machine** — `staged → uploaded → notified`. The URL trailer is unchanged (durable, resolves forever once uploaded); the **outbound** server notification (`POST /api/v1/sessions/{id}/uploaded`) fires only after the ledger push succeeds, so the v2 GitHub App reconciler never posts a link to a not-yet-viewable session.
- **Design spec** — `docs/ai/specs/session-pr-issue-linkage.md` covering v1 (shipped), v2 (GitHub App webhook reconciler + sticky comments), v3 (SLSA provenance).

```mermaid
flowchart LR
    A["session stop"] --> B["meta written<br/>status=staged"]
    B --> C["LFS upload"]
    C --> D["git push ledger"]
    D --> E["status=uploaded<br/>URL now viewable"]
    E --> F["notify server<br/>status=notified"]
    F --> G["v2 GitHub App<br/>refreshes PR comment"]
```

All four ox git hooks (`prepare-commit-msg`, `post-commit`, `post-rewrite`, `pre-push`) install idempotently and are best-effort — none block a commit, rewrite, or push.

## Test Plan

- `make lint` — 0 issues.
- `go test ./cmd/ox/ ./internal/lfs/ ./internal/session/ ./internal/api/ -short` — all pass.
- New tests: trailer survival across 6 rewrite scenarios; post-commit append/idempotency/no-op; post-rewrite amend/rebase/squash-collapse/unrelated/no-op; pre-push stdin parsing + issue-ref extraction + full integration against a real git repo; meta round-trip for all new fields incl. legacy (no-fields) read; session-view linkage rendering.
- Manual smoke per `docs/ai/specs/session-commit-linkage.md` verification section.

## Follow-ups (filed, not in this PR)

- `ox-fdre` M6–M10: SageOx GitHub App (webhook reconciler, sticky PR/issue comments, GitHub Checks), branch-name pre-correlation, SLSA attestations.
- `ox-bxo2` C1–C3: mutable closed-session ProducedCommits, GitHub squash-merge reconciliation, pre-Phase-B backfill.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (trailer survival, hook handlers, schema round-trip, view rendering, pre-push integration)
- [ ] CHANGELOG entry — N/A (no user-facing CLI surface change yet; hooks install silently, fields render only when populated)
- [x] Breaking change — none; all new fields `omitempty`, legacy meta.json round-trips
- [ ] Ran `/security-review` — N/A self-attest: no `internal/auth/`, `internal/mcp/`, `raw_writer.go`, `prepush_scan.go`, `internal/upgrade/`, or `go.sum` changes. `internal/api/repo.go` adds one outbound POST (no new inbound trust boundary).

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session linkage tracking for produced commits, linked pull requests, and linked issues.
  * Implemented automatic git hooks to record session relationships during commits, rebases, and push operations.
  * Enhanced session view to display linked pull requests, issues, and associated commits with commit details.

* **Tests**
  * Added comprehensive test coverage for commit message trailer survival across git operations.
  * Added tests for git hook functionality and session linkage validation.

* **Documentation**
  * Added detailed specifications for session-commit linkage and session-PR/issue linkage mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->