### PR TITLE
release: prep v0.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.8.1"
+      "version": "0.9.0"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,13 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-28
+
 ### Added
 
+- **Pause and resume sessions** — `ox session pause` and `ox session resume` let you suspend an in-progress recording and pick it back up later without losing context, with a proper session lifecycle (active → paused → resumed → stopped) underneath. Long-running work that spans breaks, meetings, or machine restarts is now captured as one coherent session instead of fragmenting.
+- **Ephemeral mode for throwaway environments** — set `OX_EPHEMERAL=1` to run ox in a capability-based mode tuned for short-lived sandboxes (Codespaces, CI, dev containers): no daemon assumptions, session finalize syncs inline, and Codespaces is now detected reliably. The old per-command `--ephemeral` flag is deprecated (a flag on a single command silently drifted back to non-ephemeral on the next invocation in the same shell) — set the environment variable instead.
+- **Personal access token auth via `SAGEOX_TOKEN`** — non-interactive environments can authenticate by exporting a SageOx PAT in `SAGEOX_TOKEN`, no browser login required. ox warns on stderr as the token nears expiry so automation doesn't fail silently.
+- **Faster clones on large repos** — code-search and ledger clones now support shallow, partial (blobless), and shared-alternates fetching, cutting both wall-clock time and disk for big histories.
+- **Performance metrics in `ox doctor` and the daemon** — `ox doctor` now reports timing for its checks and the daemon exposes per-subsystem performance counters, making slow setups diagnosable instead of mysterious.
+- **`/security-review` pipeline** — a diff-scoped, two-tier (deterministic OSS scanners + AI hunter/validator) security review you can run on demand. Never blocks merge; surfaces input-handling bugs, redaction-bypass risks, daemon IPC authz holes, and supply-chain issues. See `security/README.md`.
+- **Durable session commit + PR/issue linkage** — sessions commit atomically and maintain a reverse index linking each session to the PRs and issues it touched, with stale-URL repair. Past work is now discoverable from the PR/issue side, not just the session list.
+- **Knowledge Bubble as a workspace primitive** (ADR-017) — the resolver, config, and file-locking foundation for treating personal/team/repo knowledge ("bubbles") as first-class workspaces.
 - **Customer-facing env-var namespace convention** — sageox-mono ADR-047 ("Customer-Facing Env Var Namespace") is the canonical home for the rule that customer-facing SageOx env vars use `SAGEOX_*` (product/auth/network identity) and `OX_*` is reserved for CLI-local behavior flags. The legacy customer-facing `OX_TOKEN` / `OX_ENDPOINT` names are removed; `internal/auth/env_naming_test.go` guards against re-introduction. The matching sageox-mono ADR-046 ("Credential Classes and Principal Normalization") is now Accepted with companion sections D7-D10 covering the PAT validation contract, principal `AuthMethod`, customer-facing surface, and cryptographic-separation targets.
-- UserPromptSubmit hook prepends ox query --local recall; local-only by default (ADR-018).
+- **Local recall on every prompt** — the UserPromptSubmit hook prepends `ox query --local` recall, local-only by default (ADR-018).
 - New `hooks.userpromptsubmit.cloud_query` config key (default `off`) opts the UserPromptSubmit hook into a parallel SageOx cloud query. When enabled, prompt content is redacted via the session secrets pipeline before any byte leaves the machine, and the cloud path silently degrades to local-only if `ox login` has not run. `ox doctor` reports the effective value and the privacy/recall tradeoff.
 
 ### Changed
+
+- **AI adapters stop fast on terminal errors** — when a host agent hits an unrecoverable condition (e.g. a rate-limit/quota wall), the adapter detects it and stops promptly instead of retrying into the same wall.
+- **Daemon team discovery relaxed from every 5 minutes to hourly** — less background chatter and CPU for a signal that changes rarely.
 
 **`ox session audit` and `ox session redact` now require an explicit scope**
 
@@ -35,6 +48,13 @@ The 0.8.1 `ledger-redaction-debt` doctor check told the user to run `ox session 
 2. `ox session redact --session <name>` now also walks `.sageox/cache/quarantine/<name>/` for the targeted sessions. For JSONL quarantine, it redacts at the quarantine path via the canonical chokepoint, moves the file back to `sessions/<name>/`, appends a `RedactionPass` to `meta.json`, and removes the debt marker on success. Non-JSONL quarantine is listed as "manual scrub required" — the chokepoint applies the raw-writer redaction stack and expects JSONL.
 
 Before this PR, the doctor warning pointed at a command that couldn't help: the forward path (`prepush_autoredact.quarantineUnredactableFindings`) had moved the bytes OUT of `sessions/<name>/`, and the backward path only walked `sessions/`. Recovery required manually inspecting, scrubbing, and moving files back. Now `ox doctor` → copy-paste → done.
+
+**Daemon and sync reliability**
+
+- The daemon no longer deletes its IPC socket file when a superseded instance shuts down, so a freshly-started daemon stays reachable instead of leaving the CLI unable to connect.
+- Code-search self-heals a corrupt bleve `_mapping` automatically and falls back to SQL-only insights, instead of failing the query outright.
+- Observability exports now attach a fresh JWT Bearer token per OTLP request, fixing dropped telemetry once the initial token expired on long-running daemons.
+- Ledger pushes that wedged in a "U" (unmerged) state are now surfaced and audited rather than silently stalling, and the summary push no longer writes to a `/tmp` scratch path.
 
 ### Security
 
@@ -132,6 +152,7 @@ New tests pin the scope contract, the auto-redact happy path, the quarantine pat
 **Code search resilience**
 - `codedb` self-heals a corrupt bleve sub-index without forcing a full reindex. On large repos this drops recovery time from "several hours" to "2–5 minutes."
 
+[0.9.0]: https://github.com/sageox/ox/releases/tag/v0.9.0
 [0.8.0]: https://github.com/sageox/ox/releases/tag/v0.8.0
 
 ## [0.7.2] - 2026-05-04

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.8.1"
+	Version   = "0.9.0"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## Summary

Release prep for **v0.9.0** (bump from 0.8.1). Version bumped across all canonical files and the changelog/release-notes rewritten to cover the ~23 commits shipped since v0.8.1. Draft GitHub release created separately; **publish is a human step** (publishing triggers GoReleaser).

## What this PR ships

- **Version bump 0.8.1 → 0.9.0** across `internal/version/version.go`, `.claude-plugin/marketplace.json`, `claude-plugin/.claude-plugin/plugin.json` (via `make bump-version`). `make verify-version` reports all match.
- **Changelog / release notes** (`cmd/ox/release_notes.md`, the `//go:embed` source that `CHANGELOG.md` symlinks to): `[Unreleased]` promoted to `[0.9.0] - 2026-05-28`, fresh empty `[Unreleased]` added, and the section augmented with the feature/fix work that wasn't yet documented.

## Changelog highlights (0.9.0)

### Added
- **Pause / resume sessions** — suspend an in-progress recording and resume later (active to paused to resumed to stopped lifecycle).
- **Ephemeral mode** via `OX_EPHEMERAL=1` — capability-based runtime for Codespaces / CI / dev containers; inline finalize sync; reliable Codespaces detection. `--ephemeral` flag deprecated.
- **PAT auth** via `SAGEOX_TOKEN` for non-interactive environments, with expiry warnings.
- **Faster clones** — shallow / partial / shared-alternates support for code-search and ledger clones.
- **Performance metrics** in `ox doctor` and the daemon.
- **`/security-review` pipeline** (deterministic OSS tier + AI tier), never blocks merge.
- **Durable session commit + PR/issue linkage** (reverse index, stale-URL repair).
- **Knowledge Bubble as a workspace primitive** (ADR-017).

### Changed
- Adapters stop fast on terminal errors (rate-limit/quota walls).
- Daemon team discovery relaxed 5m to hourly.

### Fixed
- Daemon keeps its IPC socket on superseded shutdown; codedb self-heals corrupt bleve mapping; per-request JWT on OTLP exports; ledger "U"-state wedge surfaced + audited.

### Security
- Redaction-debt markers validated against path-traversal (Closes #608).
- `.claude/settings.json` no longer rewritten on every session.

## Test Plan

| Gate | Result |
|------|--------|
| `make lint` | ✅ pass |
| `make test-all` | ✅ pass |
| `make test-slow` | ✅ pass |
| `make test-digital-twin` | ✅ pass |
| `make verify-version` | ✅ all files 0.9.0 |
| `make test-integration` | ⏳ **human-gated** — needs `ANTHROPIC_API_KEY` |
| `make smoke-test` | ⏳ **human-gated** — needs `SAGEOX_CI_PASSWORD` |
| Run Walks | ⏳ **human-gated** — manual fresh-setup / prime / session / clone walkthrough |

## Release flow

```mermaid
flowchart TD
    A["Bump version plus changelog"] --> B["Quality gates: lint, test-all, test-slow, digital-twin"]
    B --> C["Commit: release prep v0.9.0"]
    C --> D["Push branch ryan/release-v0.9.0"]
    D --> E["Draft PR to main (this PR)"]
    D --> F["Draft GitHub release v0.9.0 (no publish)"]
    E --> G["Human: run integration plus smoke plus Run Walks"]
    G --> H["Human: merge PR"]
    F --> I["Human: publish draft release"]
    I --> J["GoReleaser builds and publishes artifacts"]
```

## Post-merge steps (human)

1. Run the human-gated gates (integration, smoke, Run Walks).
2. Merge this PR.
3. Review the draft release at https://github.com/sageox/ox/releases
4. **Publish** the draft release to trigger GoReleaser.

> Note: the existing remote `ryan/release-version-bump` branch is a stale 0.8.0-era branch (missing 0.8.1 and all newer commits); this release uses `ryan/release-v0.9.0` instead. The stale branch can be deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.9.0 in manifests and build configuration

* **Documentation**
  * Release notes for 0.9.0 now document session management enhancements, new authentication options, repository cloning performance improvements, security review pipelines, daemon reliability improvements, and expanded observability metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->