### PR TITLE
fix(release): keep git clean so GoReleaser builds binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,14 @@ jobs:
           # List signed artifacts for logs
           echo "Signed artifacts:"
           go run ./scripts/sign-manifest --list
+
+          # sign-manifest rewrites the tracked .github/release-signatures.json with a
+          # freshly-generated signature on every run. The values it produces are already
+          # captured in $GITHUB_OUTPUT above and handed to GoReleaser via env-var ldflags,
+          # so the on-disk file is only a record. Restore it to keep the working tree clean —
+          # GoReleaser's `release --clean` aborts on a dirty git state (this silently broke
+          # the v0.8.0, v0.8.1, and v0.9.0 artifact builds). See goreleaser.com/errors/dirty.
+          git checkout -- .github/release-signatures.json
         env:
           SAGEOX_CLI_SIGNING_KEY: ${{ secrets.SAGEOX_CLI_SIGNING_KEY }}
 


### PR DESCRIPTION
## What broke

The `release.yml` workflow has published three releases (**v0.8.0, v0.8.1, v0.9.0**) with **zero downloadable binaries**. Every run failed at the same step with the same error:

```
⨯ release failed after 0s
  │ git is in a dirty state
  │ Please check in your pipeline what can be changing the following files:
  │  M .github/release-signatures.json
  │ Learn more at https://goreleaser.com/errors/dirty
```

## Root cause

The **Sign artifacts** step runs `go run ./scripts/sign-manifest`, which rewrites the tracked file `.github/release-signatures.json` with a freshly-generated signature on every run (committed `YmXPZ…` vs CI-generated `QiMest…`). That leaves the working tree dirty.

The very next step runs `goreleaser release ... --clean`, which **aborts on a dirty git state**. So GoReleaser never builds or uploads anything.

The signature values GoReleaser actually needs are **not** read from that file at build time — the Sign step exports them to `$GITHUB_OUTPUT` (`SAGEOX_CLI_PUBLIC_KEY`, `SAGEOX_CLI_SIGNATURES`) and they're injected via env-var ldflags (`.config/goreleaser.yml`). The on-disk file is only a record.

```mermaid
flowchart TD
    A["Sign step: sign-manifest rewrites release-signatures.json"] --> B["Values exported to GITHUB_OUTPUT"]
    B --> C["File left modified, working tree dirty"]
    C --> D["GoReleaser release --clean"]
    D --> E["Abort: git is in a dirty state"]
    E --> F["Release published with no binaries"]
```

## What this PR ships

One line at the end of the Sign step:

```bash
git checkout -- .github/release-signatures.json
```

The signature values are already captured in `$GITHUB_OUTPUT`, so restoring the file is safe — the embedded signature comes from env vars, unaffected. The tree is clean by the time GoReleaser runs.

## Test Plan

- Cannot fully exercise locally (needs `SAGEOX_CLI_SIGNING_KEY` secret + a tag).
- After merge, re-run the build for v0.9.0 via **workflow_dispatch** (the workflow accepts a `tag` input):
  ```bash
  gh workflow run release.yml -f tag=v0.9.0
  ```
  Then confirm `gh release view v0.9.0` lists platform binaries.

## Note

v0.9.0 is already published (tag on main) but currently has no assets. Once this merges and the dispatch re-run succeeds, GoReleaser will attach the binaries to the existing release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow stability by preventing unintended file modifications during the signing process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->