### PR TITLE
feat(scout): web prior-art research from a meeting transcript

### DIFF
--- a/cmd/ox/doctor_fresh_install_test.go
+++ b/cmd/ox/doctor_fresh_install_test.go
@@ -128,6 +128,12 @@ func isExpectedEmptyRepoIssue(category string, check checkResult) bool {
 	if category == "Updates" {
 		return true
 	}
+	// Session trailer coverage is a soft signal that fires whenever recent
+	// commits lack a SageOx-Session trailer. A fresh test repo's commits are
+	// made without ox running, so coverage is always 0%. Working as designed.
+	if check.name == "session trailer coverage" {
+		return true
+	}
 	// .sageox missing should be skipped, not a warning
 	if check.name == ".sageox" && check.skipped {
 		return true
@@ -408,6 +414,13 @@ func filterTestEnvironmentIssues(issues []string) []string {
 		// warning fires whenever a new release ships. Matches the exemption
 		// already present in doctor_e2e_test.go.
 		if strings.HasPrefix(issue, "Updates:") {
+			continue
+		}
+		// skip session trailer coverage — a soft signal that fires whenever
+		// recent commits lack a SageOx-Session trailer. A fresh test repo's
+		// commits are made without ox running, so coverage is always 0%.
+		// Working as designed; not a state init controls.
+		if strings.Contains(issue, "session trailer coverage") {
 			continue
 		}
 		filtered = append(filtered, issue)

--- a/cmd/ox/doctor_fresh_install_test.go
+++ b/cmd/ox/doctor_fresh_install_test.go
@@ -122,6 +122,11 @@ func isExpectedEmptyRepoIssue(category string, check checkResult) bool {
 	if category == "Authentication" {
 		return true
 	}
+	// Updates check fires whenever upstream releases a new version after
+	// this binary's pinned ldflags version — not a state the test controls.
+	if category == "Updates" {
+		return true
+	}
 	// .sageox missing should be skipped, not a warning
 	if check.name == ".sageox" && check.skipped {
 		return true
@@ -395,6 +400,13 @@ func filterTestEnvironmentIssues(issues []string) []string {
 		}
 		// skip agent worker binary — not installed in test environment
 		if strings.Contains(issue, "agent worker") || strings.Contains(issue, "agent CLI") {
+			continue
+		}
+		// skip update-available warnings — the test binary's version is
+		// pinned by ldflags but upstream releases keep advancing, so this
+		// warning fires whenever a new release ships. Matches the exemption
+		// already present in doctor_e2e_test.go.
+		if strings.HasPrefix(issue, "Updates:") {
 			continue
 		}
 		filtered = append(filtered, issue)

--- a/cmd/ox/root.go
+++ b/cmd/ox/root.go
@@ -154,6 +154,7 @@ func init() {
 	importCmd.GroupID = "knowledge"
 	kbCmd.GroupID = "knowledge"
 	queryCmd.GroupID = "knowledge"
+	scoutCmd.GroupID = "knowledge"
 	distillCmd.GroupID = "knowledge"
 
 	// team coordination — carts, cart analysis, glance, murmurs, teams alias
@@ -180,6 +181,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(queryCmd)
+	rootCmd.AddCommand(scoutCmd)
 	rootCmd.AddCommand(teamsCmd)
 	// agentCmd is registered in agent.go
 

--- a/cmd/ox/scout.go
+++ b/cmd/ox/scout.go
@@ -89,6 +89,9 @@ func init() {
 	scoutCmd.Flags().Bool("json", false, "emit the raw Perplexity Agent API response as JSON")
 }
 
+// runScout is the cobra RunE for `ox scout`. It reads flags, builds a
+// scoutArgs, validates required inputs (filling in the default question when
+// none was given), and hands off to executeScout against real stdin/stdout.
 func runScout(cmd *cobra.Command, args []string) error {
 	question, _ := cmd.Flags().GetString("question")
 	model, _ := cmd.Flags().GetString("model")
@@ -161,6 +164,8 @@ func executeScout(sa *scoutArgs, stdin io.Reader, out io.Writer) error {
 	return renderScoutResponse(out, resp, sa.showCitations)
 }
 
+// readTranscript returns the transcript text for the given path, reading from
+// stdin when path is "-". Read errors are wrapped with the source for context.
 func readTranscript(path string, stdin io.Reader) (string, error) {
 	if path == "-" {
 		b, err := io.ReadAll(stdin)
@@ -220,6 +225,10 @@ type perplexitySearchResult struct {
 	Date    string `json:"date,omitempty"`
 }
 
+// callPerplexity POSTs the request to Perplexity's Agent API and returns the
+// decoded response alongside the raw body (so callers can emit --json without a
+// re-marshal). A non-2xx status yields an error carrying a truncated body
+// excerpt; the raw bytes are still returned for diagnostics.
 func callPerplexity(apiKey string, body perplexityAgentRequest) (*perplexityAgentResponse, []byte, error) {
 	payload, err := json.Marshal(body)
 	if err != nil {
@@ -264,6 +273,9 @@ func callPerplexity(apiKey string, body perplexityAgentRequest) (*perplexityAgen
 	return &resp, raw, nil
 }
 
+// renderScoutResponse writes the agent's message text to out, and — when
+// showCitations is set and the response carried search results — appends the
+// raw "Sources" list. It errors if the response contained no message content.
 func renderScoutResponse(out io.Writer, resp *perplexityAgentResponse, showCitations bool) error {
 	var messageText strings.Builder
 	var searchResults []perplexitySearchResult

--- a/cmd/ox/scout.go
+++ b/cmd/ox/scout.go
@@ -14,49 +14,38 @@ import (
 )
 
 const (
-	perplexityEndpoint  = "https://api.perplexity.ai/chat/completions"
+	perplexityEndpoint  = "https://api.perplexity.ai/v1/agent"
 	perplexityAPIKeyEnv = "PERPLEXITY_API_KEY"
 
-	scoutDefaultModel = "sonar-pro"
+	// scoutDefaultModel routes through Perplexity's Agent API to Anthropic's
+	// Opus 4.7. Any other model ID accepted by /v1/agent works too — see
+	// https://docs.perplexity.ai/docs/agent-api/models.
+	scoutDefaultModel = "anthropic/claude-opus-4-7"
 
-	scoutDefaultQuestion = "What companies, products, or open-source projects are working on the technical topics, decisions, and problems described in the context below?"
+	scoutDefaultQuestion = "Scout the world for prior art, people, and recent developments relevant to the substance of this conversation."
 
-	// Deliberately avoid the words "meeting"/"transcript"/"discussion" in the
-	// search-facing prompt — Sonar uses the user message to generate web search
-	// queries, and any framing noun there will hijack the searches away from
-	// the actual technical substance. Keep this prompt focused on the *kind*
-	// of answer we want; the context itself supplies the search terms.
-	scoutSystemPrompt = `You are a research assistant for a software team. Read the context the user provides, identify the specific technical topics, products, libraries, and decisions in it, and search the web for companies, open-source projects, and prior art working on those exact topics.
+	scoutSystemPrompt = `You are a scout for a working software team. You read a slice of their meeting transcript and surface a few outside findings that would make them stop and say "that's absolutely brilliant."
 
-Focus on accelerators and opportunities — prior art the team could borrow from, patterns to learn from, market signals worth knowing. Cite specifics by name. Be concise: 3 to 5 findings max. Ground every claim in a citation.`
+First, silently identify the 2-4 non-obvious things the team is actually wrestling with: the contested assumptions, the architectural decisions they're debating, the thing they're building by hand, the mental model they're reaching for. Extract rare nouns, unresolved decisions, operational anxieties, named devices/protocols/regulations, and phrases implying "we are about to build this ourselves." Target these — NOT the brand names or generic category nouns in the transcript.
+
+Then search the web based on those things and based on the results, surface the single most important finding. The finding must be something a sharp engineer on this team probably does NOT already know, specific enough to search by name, and additive (it accelerates them — never criticizes work they've done).
+
+Cover recent information specifically: something that changed in roughly the last 6 weeks — a release, launch, paper, talk, deprecation, or acquisition that moves the goalposts. The finding MUST state the month or quarter inline (e.g. "March 2026", "Q1 2026").
+
+If no genuinely strong recent finding exists for this slice, return nothing rather than pad with weak or fabricated results.
+
+The finding must name a concrete, Googleable referent: a repo name, a paper title, a blog-post title, a company + specific feature/doc, or a person + their talk. Do not return a list of well-known SaaS products.
+
+Household-name tools the team obviously already knows are disqualified unless paired with a specific non-obvious technique or a recent change to that tool.
+
+Output rules (hard):
+- the teams time is worth $1 million dollars per minute per member.  Don't waste it.  Make the response short.
+- A single bullet. Nothing else.
+- At most 3 sentences: one opener naming the thing, one specific detail, and 1 EXTREMELY SHORT reason to pay attention.
+- Lead the bullet with the bolded name of the referent.
+- No preamble, no intro line, no restating what the meeting was about, no closing summary, no section headers.
+- Plain markdown bullets only.`
 )
-
-// scoutAllowedModels enumerates the Perplexity sonar models we accept.
-// Keeping the set tight avoids silent typos that yield a 400 from the API
-// with a less obvious error message than a local validation failure.
-var scoutAllowedModels = map[string]bool{
-	"sonar":               true,
-	"sonar-pro":           true,
-	"sonar-reasoning-pro": true,
-	"sonar-deep-research": true,
-}
-
-// scoutDefaultSearchDomains constrains Perplexity's web search to surfaces
-// where software-engineering prior art actually lives. Without this, the
-// search retrieves keyword-matched marketing pages (e.g. searching for
-// "dedicated" returned blockchain node providers) and the model fabricates
-// citation numbers around those unrelated URLs.
-//
-// Tradeoff: vendor docs (temporal.io, aws.amazon.com) and engineering blogs
-// are excluded, so some specific official references are missed. The win is
-// that what *does* come back is verifiable prior art on GitHub or in the
-// open developer commons. Override per-call with --domains.
-var scoutDefaultSearchDomains = []string{
-	"github.com",
-	"news.ycombinator.com",
-	"stackoverflow.com",
-	"arxiv.org",
-}
 
 type scoutArgs struct {
 	transcriptPath string
@@ -70,8 +59,8 @@ type scoutArgs struct {
 var scoutCmd = &cobra.Command{
 	Use:   "scout <transcript-path>",
 	Short: "Search the web for prior art related to a meeting",
-	Long: `Read a meeting transcript, then ask Perplexity for companies, products, and
-projects in the wild that relate to what the team discussed.
+	Long: `Read a meeting transcript, then ask Perplexity's Agent API for prior art,
+people, and recent developments relevant to what the team discussed.
 
 Pass "-" as the path to read the transcript from stdin.
 
@@ -81,7 +70,7 @@ Examples:
   ox scout ./meeting.md
   cat transcript.txt | ox scout -
   ox scout ./meeting.md --question "What open-source libraries solve this?"
-  ox scout ./meeting.md --model sonar-pro
+  ox scout ./meeting.md --model anthropic/claude-sonnet-4-6
   ox scout ./meeting.md --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runScout,
@@ -89,15 +78,15 @@ Examples:
 
 func init() {
 	scoutCmd.Flags().String("question", "", "override the default research question")
-	scoutCmd.Flags().String("model", scoutDefaultModel, "Perplexity model: sonar, sonar-pro, sonar-reasoning-pro, or sonar-deep-research")
-	scoutCmd.Flags().StringSlice("domains", scoutDefaultSearchDomains, "comma-separated search domain whitelist (empty = no filter)")
-	// Citations are hidden by default: Perplexity's web-search retrieval frequently
-	// returns URLs unrelated to the response text (it keyword-matches generic terms
-	// like "dedicated" or "workflow" and lands on marketing pages). The model's
-	// inline references — by exact project/product name — are the real signal.
-	// Enable explicitly with --citations when you trust the search results.
-	scoutCmd.Flags().Bool("citations", false, "show the raw 'Sources' list from Perplexity (often unrelated)")
-	scoutCmd.Flags().Bool("json", false, "emit the raw Perplexity API response as JSON")
+	scoutCmd.Flags().String("model", scoutDefaultModel, "Perplexity Agent API model ID (see https://docs.perplexity.ai/docs/agent-api/models)")
+	scoutCmd.Flags().StringSlice("domains", nil, "comma-separated search domain whitelist (default: no filter, full web)")
+	// Citations are hidden by default: Perplexity's web search returns every
+	// page it visited while researching, not only the ones the model actually
+	// used in its answer. The model's inline named references — by exact
+	// project/product name — are the real signal. Enable --citations to see
+	// the raw list the agent searched.
+	scoutCmd.Flags().Bool("citations", false, "show the raw 'Sources' list returned by Perplexity's web search")
+	scoutCmd.Flags().Bool("json", false, "emit the raw Perplexity Agent API response as JSON")
 }
 
 func runScout(cmd *cobra.Command, args []string) error {
@@ -119,8 +108,8 @@ func runScout(cmd *cobra.Command, args []string) error {
 	if sa.transcriptPath == "" {
 		return fmt.Errorf("transcript path is required (use \"-\" for stdin)")
 	}
-	if !scoutAllowedModels[sa.model] {
-		return fmt.Errorf("invalid --model %q: must be sonar, sonar-pro, sonar-reasoning-pro, or sonar-deep-research", sa.model)
+	if sa.model == "" {
+		return fmt.Errorf("--model is required")
 	}
 	if sa.question == "" {
 		sa.question = scoutDefaultQuestion
@@ -145,16 +134,18 @@ func executeScout(sa *scoutArgs, stdin io.Reader, out io.Writer) error {
 		return fmt.Errorf("transcript is empty")
 	}
 
-	userContent := fmt.Sprintf("%s\n\n--- CONTEXT ---\n%s", sa.question, transcript)
+	userInput := fmt.Sprintf("%s\n\n--- CONTEXT ---\n%s", sa.question, transcript)
 
-	reqBody := perplexityRequest{
-		Model: sa.model,
-		Messages: []perplexityMessage{
-			{Role: "system", Content: scoutSystemPrompt},
-			{Role: "user", Content: userContent},
-		},
-		ReturnCitations:    true,
-		SearchDomainFilter: sa.domains,
+	tool := perplexityTool{Type: "web_search"}
+	if len(sa.domains) > 0 {
+		tool.Filters = &perplexityToolFilters{SearchDomainFilter: sa.domains}
+	}
+
+	reqBody := perplexityAgentRequest{
+		Model:        sa.model,
+		Input:        userInput,
+		Instructions: scoutSystemPrompt,
+		Tools:        []perplexityTool{tool},
 	}
 
 	resp, raw, err := callPerplexity(apiKey, reqBody)
@@ -185,28 +176,51 @@ func readTranscript(path string, stdin io.Reader) (string, error) {
 	return string(b), nil
 }
 
-type perplexityRequest struct {
-	Model              string              `json:"model"`
-	Messages           []perplexityMessage `json:"messages"`
-	ReturnCitations    bool                `json:"return_citations"`
-	SearchDomainFilter []string            `json:"search_domain_filter,omitempty"`
+type perplexityAgentRequest struct {
+	Model        string           `json:"model"`
+	Input        string           `json:"input"`
+	Instructions string           `json:"instructions,omitempty"`
+	Tools        []perplexityTool `json:"tools,omitempty"`
 }
 
-type perplexityMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+type perplexityTool struct {
+	Type    string                 `json:"type"`
+	Filters *perplexityToolFilters `json:"filters,omitempty"`
 }
 
-type perplexityResponse struct {
-	ID      string `json:"id"`
-	Model   string `json:"model"`
-	Choices []struct {
-		Message perplexityMessage `json:"message"`
-	} `json:"choices"`
-	Citations []string `json:"citations"`
+type perplexityToolFilters struct {
+	SearchDomainFilter []string `json:"search_domain_filter,omitempty"`
 }
 
-func callPerplexity(apiKey string, body perplexityRequest) (*perplexityResponse, []byte, error) {
+type perplexityAgentResponse struct {
+	ID     string                 `json:"id"`
+	Model  string                 `json:"model"`
+	Status string                 `json:"status"`
+	Output []perplexityOutputItem `json:"output"`
+}
+
+type perplexityOutputItem struct {
+	Type    string                     `json:"type"`
+	Role    string                     `json:"role,omitempty"`
+	Content []perplexityMessageContent `json:"content,omitempty"`
+	// search_results-only fields
+	Queries []string                 `json:"queries,omitempty"`
+	Results []perplexitySearchResult `json:"results,omitempty"`
+}
+
+type perplexityMessageContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type perplexitySearchResult struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Snippet string `json:"snippet,omitempty"`
+	Date    string `json:"date,omitempty"`
+}
+
+func callPerplexity(apiKey string, body perplexityAgentRequest) (*perplexityAgentResponse, []byte, error) {
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("encode request: %w", err)
@@ -220,9 +234,10 @@ func callPerplexity(apiKey string, body perplexityRequest) (*perplexityResponse,
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	// 60s covers sonar-reasoning's longer search-and-reason cycles; sonar/sonar-pro
-	// typically respond in under 15s.
-	client := &http.Client{Timeout: 60 * time.Second}
+	// 120s budget: the agent endpoint runs one or more web-search tool calls,
+	// then has the chosen model synthesize an answer. Opus + multi-query
+	// search routinely takes 30-60s; sonar-pro alone returns in under 15s.
+	client := &http.Client{Timeout: 120 * time.Second}
 	httpResp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("perplexity request failed: %w", err)
@@ -242,29 +257,45 @@ func callPerplexity(apiKey string, body perplexityRequest) (*perplexityResponse,
 		return nil, raw, fmt.Errorf("perplexity returned %s: %s", httpResp.Status, excerpt)
 	}
 
-	var resp perplexityResponse
+	var resp perplexityAgentResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return nil, raw, fmt.Errorf("decode perplexity response: %w", err)
 	}
 	return &resp, raw, nil
 }
 
-func renderScoutResponse(out io.Writer, resp *perplexityResponse, showCitations bool) error {
-	if len(resp.Choices) == 0 {
-		return fmt.Errorf("perplexity returned no choices")
+func renderScoutResponse(out io.Writer, resp *perplexityAgentResponse, showCitations bool) error {
+	var messageText strings.Builder
+	var searchResults []perplexitySearchResult
+	for _, item := range resp.Output {
+		switch item.Type {
+		case "message":
+			for _, c := range item.Content {
+				// "output_text" is what Opus returns; "text" is a defensive
+				// fallback in case another model surfaces content under that key.
+				if c.Type == "output_text" || c.Type == "text" {
+					messageText.WriteString(c.Text)
+				}
+			}
+		case "search_results":
+			searchResults = append(searchResults, item.Results...)
+		}
 	}
 
-	content := strings.TrimSpace(resp.Choices[0].Message.Content)
-	if _, err := fmt.Fprintln(out, content); err != nil {
+	text := strings.TrimSpace(messageText.String())
+	if text == "" {
+		return fmt.Errorf("perplexity returned no message content")
+	}
+	if _, err := fmt.Fprintln(out, text); err != nil {
 		return err
 	}
 
-	if showCitations && len(resp.Citations) > 0 {
+	if showCitations && len(searchResults) > 0 {
 		if _, err := fmt.Fprintln(out, "\nSources:"); err != nil {
 			return err
 		}
-		for i, url := range resp.Citations {
-			if _, err := fmt.Fprintf(out, "  [%d] %s\n", i+1, url); err != nil {
+		for i, r := range searchResults {
+			if _, err := fmt.Fprintf(out, "  [%d] %s — %s\n", i+1, r.Title, r.URL); err != nil {
 				return err
 			}
 		}

--- a/cmd/ox/scout.go
+++ b/cmd/ox/scout.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	perplexityEndpoint  = "https://api.perplexity.ai/chat/completions"
+	perplexityAPIKeyEnv = "PERPLEXITY_API_KEY"
+
+	scoutDefaultModel = "sonar-pro"
+
+	scoutDefaultQuestion = "What companies, products, or open-source projects are working on the technical topics, decisions, and problems described in the context below?"
+
+	// Deliberately avoid the words "meeting"/"transcript"/"discussion" in the
+	// search-facing prompt — Sonar uses the user message to generate web search
+	// queries, and any framing noun there will hijack the searches away from
+	// the actual technical substance. Keep this prompt focused on the *kind*
+	// of answer we want; the context itself supplies the search terms.
+	scoutSystemPrompt = `You are a research assistant for a software team. Read the context the user provides, identify the specific technical topics, products, libraries, and decisions in it, and search the web for companies, open-source projects, and prior art working on those exact topics.
+
+Focus on accelerators and opportunities — prior art the team could borrow from, patterns to learn from, market signals worth knowing. Cite specifics by name. Be concise: 3 to 5 findings max. Ground every claim in a citation.`
+)
+
+// scoutAllowedModels enumerates the Perplexity sonar models we accept.
+// Keeping the set tight avoids silent typos that yield a 400 from the API
+// with a less obvious error message than a local validation failure.
+var scoutAllowedModels = map[string]bool{
+	"sonar":               true,
+	"sonar-pro":           true,
+	"sonar-reasoning-pro": true,
+	"sonar-deep-research": true,
+}
+
+// scoutDefaultSearchDomains constrains Perplexity's web search to surfaces
+// where software-engineering prior art actually lives. Without this, the
+// search retrieves keyword-matched marketing pages (e.g. searching for
+// "dedicated" returned blockchain node providers) and the model fabricates
+// citation numbers around those unrelated URLs.
+//
+// Tradeoff: vendor docs (temporal.io, aws.amazon.com) and engineering blogs
+// are excluded, so some specific official references are missed. The win is
+// that what *does* come back is verifiable prior art on GitHub or in the
+// open developer commons. Override per-call with --domains.
+var scoutDefaultSearchDomains = []string{
+	"github.com",
+	"news.ycombinator.com",
+	"stackoverflow.com",
+	"arxiv.org",
+}
+
+type scoutArgs struct {
+	transcriptPath string
+	question       string
+	model          string
+	domains        []string
+	showCitations  bool
+	jsonOnly       bool
+}
+
+var scoutCmd = &cobra.Command{
+	Use:   "scout <transcript-path>",
+	Short: "Search the web for prior art related to a meeting",
+	Long: `Read a meeting transcript, then ask Perplexity for companies, products, and
+projects in the wild that relate to what the team discussed.
+
+Pass "-" as the path to read the transcript from stdin.
+
+Requires the PERPLEXITY_API_KEY environment variable.
+
+Examples:
+  ox scout ./meeting.md
+  cat transcript.txt | ox scout -
+  ox scout ./meeting.md --question "What open-source libraries solve this?"
+  ox scout ./meeting.md --model sonar-pro
+  ox scout ./meeting.md --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runScout,
+}
+
+func init() {
+	scoutCmd.Flags().String("question", "", "override the default research question")
+	scoutCmd.Flags().String("model", scoutDefaultModel, "Perplexity model: sonar, sonar-pro, sonar-reasoning-pro, or sonar-deep-research")
+	scoutCmd.Flags().StringSlice("domains", scoutDefaultSearchDomains, "comma-separated search domain whitelist (empty = no filter)")
+	// Citations are hidden by default: Perplexity's web-search retrieval frequently
+	// returns URLs unrelated to the response text (it keyword-matches generic terms
+	// like "dedicated" or "workflow" and lands on marketing pages). The model's
+	// inline references — by exact project/product name — are the real signal.
+	// Enable explicitly with --citations when you trust the search results.
+	scoutCmd.Flags().Bool("citations", false, "show the raw 'Sources' list from Perplexity (often unrelated)")
+	scoutCmd.Flags().Bool("json", false, "emit the raw Perplexity API response as JSON")
+}
+
+func runScout(cmd *cobra.Command, args []string) error {
+	question, _ := cmd.Flags().GetString("question")
+	model, _ := cmd.Flags().GetString("model")
+	domains, _ := cmd.Flags().GetStringSlice("domains")
+	showCitations, _ := cmd.Flags().GetBool("citations")
+	jsonOut, _ := cmd.Flags().GetBool("json")
+
+	sa := &scoutArgs{
+		transcriptPath: strings.TrimSpace(args[0]),
+		question:       strings.TrimSpace(question),
+		model:          strings.TrimSpace(model),
+		domains:        domains,
+		showCitations:  showCitations,
+		jsonOnly:       jsonOut,
+	}
+
+	if sa.transcriptPath == "" {
+		return fmt.Errorf("transcript path is required (use \"-\" for stdin)")
+	}
+	if !scoutAllowedModels[sa.model] {
+		return fmt.Errorf("invalid --model %q: must be sonar, sonar-pro, sonar-reasoning-pro, or sonar-deep-research", sa.model)
+	}
+	if sa.question == "" {
+		sa.question = scoutDefaultQuestion
+	}
+
+	return executeScout(sa, os.Stdin, os.Stdout)
+}
+
+// executeScout reads the transcript, calls Perplexity, and writes results to out.
+// stdin is parameterized so tests can inject content for the "-" path.
+func executeScout(sa *scoutArgs, stdin io.Reader, out io.Writer) error {
+	apiKey := strings.TrimSpace(os.Getenv(perplexityAPIKeyEnv))
+	if apiKey == "" {
+		return fmt.Errorf("missing %s environment variable. Get a key at https://www.perplexity.ai/settings/api", perplexityAPIKeyEnv)
+	}
+
+	transcript, err := readTranscript(sa.transcriptPath, stdin)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(transcript) == "" {
+		return fmt.Errorf("transcript is empty")
+	}
+
+	userContent := fmt.Sprintf("%s\n\n--- CONTEXT ---\n%s", sa.question, transcript)
+
+	reqBody := perplexityRequest{
+		Model: sa.model,
+		Messages: []perplexityMessage{
+			{Role: "system", Content: scoutSystemPrompt},
+			{Role: "user", Content: userContent},
+		},
+		ReturnCitations:    true,
+		SearchDomainFilter: sa.domains,
+	}
+
+	resp, raw, err := callPerplexity(apiKey, reqBody)
+	if err != nil {
+		return err
+	}
+
+	if sa.jsonOnly {
+		_, err := out.Write(raw)
+		return err
+	}
+
+	return renderScoutResponse(out, resp, sa.showCitations)
+}
+
+func readTranscript(path string, stdin io.Reader) (string, error) {
+	if path == "-" {
+		b, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		return string(b), nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read transcript %q: %w", path, err)
+	}
+	return string(b), nil
+}
+
+type perplexityRequest struct {
+	Model              string              `json:"model"`
+	Messages           []perplexityMessage `json:"messages"`
+	ReturnCitations    bool                `json:"return_citations"`
+	SearchDomainFilter []string            `json:"search_domain_filter,omitempty"`
+}
+
+type perplexityMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type perplexityResponse struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Message perplexityMessage `json:"message"`
+	} `json:"choices"`
+	Citations []string `json:"citations"`
+}
+
+func callPerplexity(apiKey string, body perplexityRequest) (*perplexityResponse, []byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, perplexityEndpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	// 60s covers sonar-reasoning's longer search-and-reason cycles; sonar/sonar-pro
+	// typically respond in under 15s.
+	client := &http.Client{Timeout: 60 * time.Second}
+	httpResp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("perplexity request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	raw, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read perplexity response: %w", err)
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		excerpt := string(raw)
+		if len(excerpt) > 500 {
+			excerpt = excerpt[:500] + "..."
+		}
+		return nil, raw, fmt.Errorf("perplexity returned %s: %s", httpResp.Status, excerpt)
+	}
+
+	var resp perplexityResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, raw, fmt.Errorf("decode perplexity response: %w", err)
+	}
+	return &resp, raw, nil
+}
+
+func renderScoutResponse(out io.Writer, resp *perplexityResponse, showCitations bool) error {
+	if len(resp.Choices) == 0 {
+		return fmt.Errorf("perplexity returned no choices")
+	}
+
+	content := strings.TrimSpace(resp.Choices[0].Message.Content)
+	if _, err := fmt.Fprintln(out, content); err != nil {
+		return err
+	}
+
+	if showCitations && len(resp.Citations) > 0 {
+		if _, err := fmt.Fprintln(out, "\nSources:"); err != nil {
+			return err
+		}
+		for i, url := range resp.Citations {
+			if _, err := fmt.Fprintf(out, "  [%d] %s\n", i+1, url); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- New `ox scout <transcript>` subcommand in the `knowledge` group next to `ox query`
- Reads a meeting transcript file (or `-` for stdin), routes it through Perplexity's **Agent API** (`/v1/agent`) with the **`web_search` tool** enabled, prints the model's findings
- Default model: **`anthropic/claude-opus-4-7`** — any Agent API model ID works via `--model` (Claude / GPT / Gemini / Sonar)
- Default search: full web. Optional `--domains` for a per-call whitelist
- Citations hidden by default — Perplexity returns every page the agent visited, not just the ones the model used; the inline named references in the answer are the real signal. Enable with `--citations` to see the raw search-results list
- Hard-coded research prompt designed to surface non-obvious, dated prior art (specific repos / papers / posts / people) rather than household-name SaaS
- Stdlib only — no new module deps

## Motivation
PoC for the SageOx trial-week standup demo: turn captured team context into outward-facing prior-art discovery. Started on Perplexity's `/chat/completions` with Sonar, switched to `/v1/agent` + Opus 4.7 because (a) the synthesis quality jump is large on technical content, (b) the Agent API is the union endpoint — Sonar models still work through it, and (c) it gives us the multi-provider escape hatch for free.

Tradeoff: ~10× cost per call (~\$0.07 vs ~\$0.006) and ~30s wall time including the search-tool roundtrip. Acceptable for a research-on-demand tool; the timeout is bumped to 120s.

Scope deliberately minimal so extensions are mechanical: auto-discover the most recent ledger transcript, styled card output per the v2 design, swap to a team model-council orchestrator when that API exists.

## Test plan
- [x] `make install-ox` clean
- [x] `ox scout --help` renders under the `Knowledge` group
- [x] Error paths return clean messages: missing API key, empty path, missing file, missing model
- [x] Real `/v1/agent` round-trip with `anthropic/claude-opus-4-7` returns dated, named prior art (verified on a synthetic Ledger-LFS transcript: surfaced DVC `scmrepo` smudge-filter, GitLab pure-SSH LFS protocol fix from May 27 2026, git-lfs "do not import as a Go library" notice)
- [ ] **Follow-up commit before marking ready:** table-driven tests for `runScout` arg validation, `readTranscript` (file + stdin), `renderScoutResponse` (message + search-results output items, with / without citations), and a mock `httptest.Server` round-trip for `callPerplexity` against a captured Agent API payload

Draft until the test gap is closed.

## Demo
\`\`\`bash
export PERPLEXITY_API_KEY=pplx-...
ox scout path/to/transcript.vtt
# anthropic/claude-opus-4-7 + web_search, ~30s, dated named prior art

# swap providers freely:
ox scout transcript.vtt --model openai/gpt-5.5
ox scout transcript.vtt --model google/gemini-3-pro
ox scout transcript.vtt --model sonar-pro
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `ox scout` command that processes meeting transcripts and performs web searches via Perplexity Agent API. Supports custom search questions, model selection, domain filtering, raw JSON output, and formatted source citations.

* **Bug Fixes**
  * Improved `ox doctor` command robustness for test environments, particularly in fresh repository scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->