### PR TITLE
feat(prime): consult-first block — search before reasoning

### DIFF
--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -115,6 +115,23 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 	sb.WriteString("murmurs, and discussions. Do NOT credit them as a teammate — say \"Building on your earlier session...\" instead.\n")
 	sb.WriteString("</instructions>\n")
 
+	// consult-first: the root failure SageOx exists to prevent is an agent
+	// reasoning from first principles when the answer already lives in team
+	// memory — and getting it backwards. This block names the cues that must
+	// trigger a search BEFORE reasoning, and routes each cue to the right
+	// corpus (chronological vs semantic vs code are different retrieval modes).
+	// Static (no per-session/per-team variance) so it's fully cacheable.
+	sb.WriteString("\n<consult-first>\n")
+	sb.WriteString("Before answering from first-principles reasoning, check whether SageOx already has the answer.\n")
+	sb.WriteString("A confident answer that prior work contradicts is worse than a slow one. These cues mean STOP and search first:\n")
+	sb.WriteString("- The user references recent or specific work they did: \"I just pushed...\", \"this request\", \"did X fix Y?\", \"is the alert gone now?\"\n")
+	sb.WriteString("- A prior decision, a prod anomaly, or a metric/cost change — anything with a before/after.\n")
+	sb.WriteString("Route the cue to the right corpus — these are DIFFERENT retrieval modes, not interchangeable:\n")
+	sb.WriteString("- Recency / \"I just did X\" → `ox session list --limit 20 --json` (chronological; the summary is in the list, not in view). A specific recent session is the likeliest source; semantic search can rank it below older fuzzy matches and miss it.\n")
+	sb.WriteString("- Conceptual / \"did we decide or discuss X?\" → `ox query \"<question>\"` (semantic; default `--source=team` covers discussions, docs, and session history). Add `--source=all` to include code.\n")
+	sb.WriteString("- \"Who or what touched this code?\" → `ox code search \"<pattern>\"` / `ox code insights`.\n")
+	sb.WriteString("</consult-first>\n")
+
 	// rule-promotion-guidance: nudge the agent to ask whether a project-local
 	// rule should also become a team rule when one looks generally applicable.
 	// Static (no per-session/per-team variance) so it's fully cacheable.

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -439,6 +439,53 @@ func TestOutputAgentPrimeXML_CacheTierOrdering(t *testing.T) {
 	}
 }
 
+// TestOutputAgentPrimeXML_ConsultFirst verifies the consult-first block ships
+// in every prime output, names the recency/anomaly cues, and routes each to a
+// distinct corpus.
+// Failure prevented: an agent reasons from priors instead of searching prior
+// sessions/ledger — the exact regression that produced a confidently-wrong
+// answer to a question already answered in a session from the day before.
+func TestOutputAgentPrimeXML_ConsultFirst(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	// minimal output — consult-first is static, must appear with no team/ledger
+	if _, err := outputAgentPrimeXML(cmd, agentPrimeOutput{AgentID: "a", Status: "fresh"}); err != nil {
+		t.Fatalf("outputAgentPrimeXML() error = %v", err)
+	}
+	xml := buf.String()
+
+	if !strings.Contains(xml, "<consult-first>") {
+		t.Fatal("prime output missing <consult-first> block")
+	}
+
+	// the trigger: a confident wrong answer is worse than a slow one
+	if !strings.Contains(xml, "first-principles") {
+		t.Error("consult-first must warn against reasoning from first principles")
+	}
+
+	// recency cue routes to chronological session list, not semantic query
+	if !strings.Contains(xml, "ox session list --limit 20 --json") {
+		t.Error("consult-first must route recency cues to `ox session list`")
+	}
+	// conceptual cue routes to semantic query
+	if !strings.Contains(xml, `ox query "<question>"`) {
+		t.Error("consult-first must route conceptual cues to `ox query`")
+	}
+	// code-provenance cue routes to code search
+	if !strings.Contains(xml, `ox code search "<pattern>"`) {
+		t.Error("consult-first must route code-provenance cues to `ox code search`")
+	}
+
+	// must sit in the static (cacheable) tier — before the cache boundary
+	consultIdx := strings.Index(xml, "<consult-first>")
+	boundaryIdx := strings.Index(xml, "CACHE BOUNDARY")
+	if boundaryIdx >= 0 && consultIdx > boundaryIdx {
+		t.Error("consult-first must be above the cache boundary (static tier)")
+	}
+}
+
 func TestEscapeXML_AllSpecialChars(t *testing.T) {
 	tests := []struct {
 		input string

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -478,11 +478,16 @@ func TestOutputAgentPrimeXML_ConsultFirst(t *testing.T) {
 		t.Error("consult-first must route code-provenance cues to `ox code search`")
 	}
 
-	// must sit in the static (cacheable) tier — before the cache boundary
+	// must sit in the static (cacheable) tier — above all per-session content.
+	// The cache boundary itself is a source comment (not emitted), so anchor on
+	// <session-context>, the first per-session block in the output.
 	consultIdx := strings.Index(xml, "<consult-first>")
-	boundaryIdx := strings.Index(xml, "CACHE BOUNDARY")
-	if boundaryIdx >= 0 && consultIdx > boundaryIdx {
-		t.Error("consult-first must be above the cache boundary (static tier)")
+	sessionIdx := strings.Index(xml, "<session-context")
+	if sessionIdx < 0 {
+		t.Fatal("missing <session-context> block")
+	}
+	if consultIdx > sessionIdx {
+		t.Error("consult-first must be above the per-session block (static tier)")
 	}
 }
 


### PR DESCRIPTION
## What this PR ships

A static `<consult-first>` block in `ox agent prime` output that steers AI coworkers to **search team memory before reasoning from first principles** — and routes each kind of question to the corpus that actually holds the answer.

## Why

A recurring failure mode: an agent leads with confident first-principles reasoning on a question already answered in a prior session, and gets it backwards. The trigger phrasing was all there ("I just pushed a couple PRs… did that fix the cost anomaly alert?") — that's "I did X, did it fix the thing we track," not a generic how-does-billing-work question. The correct first move was to search sessions/ledger; the answer was sitting in a session from the day before.

The root cause isn't a missing skill — it's **not thinking to invoke ox at all**. A skill the agent must choose to invoke can't fix that. Priming is the always-loaded channel, so the trigger belongs here.

## The block

```mermaid
flowchart TD
    Q[User message] --> C{Recency / specific recent work,<br/>prior decision, or prod anomaly?}
    C -->|No| R[Reason normally]
    C -->|Yes| STOP[STOP — search before reasoning]
    STOP --> M{Which retrieval mode?}
    M -->|"I just did X" recency| S[ox session list --limit 20 --json<br/>chronological]
    M -->|"did we decide/discuss X?"| QY[ox query — semantic<br/>--source=team default]
    M -->|"who/what touched this code?"| CS[ox code search / ox code insights]
```

- **The trigger:** names the cues that must force a search first — *"I just pushed..."*, *"this request"*, *"did X fix Y?"*, *"is the alert gone now?"*, any prod anomaly or before/after metric change. Framed as: a confident answer that prior work contradicts is worse than a slow one.
- **Corpus routing:** the teachable gap. Chronological (`ox session list`), semantic (`ox query`), and code (`ox code search`) are **different retrieval modes** — a specific recent session is best found chronologically, where semantic ranking can bury it below older fuzzy matches.

## Design notes

- **Cache tier:** sits above the CACHE BOUNDARY (static, fully cacheable — costs prefix-cache tokens once, not per session) and is charged to the `sageox` budget bucket.
- **Flags verified against `--help`**, not recollection: `ox query --source=team|code|local|all`, `ox session list --limit/--json`.
- **Unrelated gofmt churn excluded** — `make format` reformatted 11 pre-existing files I never touched; reverted them so this PR is just the two relevant files.

## Test Plan

- `TestOutputAgentPrimeXML_ConsultFirst` — asserts the block ships in minimal output, warns against first-principles reasoning, routes each cue to its distinct command, and sits in the static (cacheable) tier.
- `go test ./cmd/ox/ -run Prime` — green.
- Verified rendered output of `ox agent prime`.

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a static "consult-first" instruction block to agent output that directs the agent to consult the corpus first for recent/specific work, decision points, anomalies, or contradictions and routes cues to the appropriate retrieval mode.

* **Tests**
  * Added automated test coverage confirming the "consult-first" block is emitted, contains expected trigger text and routing cues, and appears in the correct output order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sageox/ox/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->