### PR TITLE
feat(recording): name team + learn-more link in status reminder

### DIFF
--- a/internal/constants/agent.go
+++ b/internal/constants/agent.go
@@ -7,6 +7,12 @@ const SageOxGitEmail = "ox@sageox.ai"
 // SageOxGitName is the canonical name for SageOx git identity.
 const SageOxGitName = "SageOx"
 
+// RecordingDocsURL is the short learn-more link shown on the FIRST recording
+// reminder. Redirects to the full /docs/cli/recording page (what's captured,
+// who sees it, how to stop). Kept short on purpose — it is echoed verbatim by
+// the agent into an 80-col terminal, where a long path wraps and truncates.
+const RecordingDocsURL = "sageox.ai/rec"
+
 const (
 	// OxPrimeCommand is the legacy command without AGENT_ENV prefix.
 	// Kept for backwards compatibility detection of existing hooks.

--- a/internal/daemon/whisper_recording_reminder.go
+++ b/internal/daemon/whisper_recording_reminder.go
@@ -3,11 +3,13 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/constants"
 	"github.com/sageox/ox/internal/session"
 	whisperstore "github.com/sageox/ox/internal/whisper/store"
 )
@@ -65,6 +67,20 @@ func (s *RecordingReminderSource) Produce(_ context.Context) []whisperstore.Whis
 		return nil
 	}
 
+	// Resolve the destination the session is shared with, once per tick — a
+	// project-level fact shared by every recording agent in this root. We name
+	// both the team and the repo ("<team>'s <repo> ledger") so the privacy
+	// scope is unmissable. Each part degrades independently when unset.
+	teamName, repoName := "", ""
+	if cfg, err := config.LoadProjectConfig(s.projectRoot); err == nil && cfg != nil {
+		teamName = cfg.TeamName
+		repoName = cfg.Project
+	}
+	if repoName == "" {
+		repoName = repoNameFromPath(s.projectRoot)
+	}
+	dest := recordingDestination(teamName, repoName)
+
 	now := time.Now()
 	var entries []whisperstore.WhisperEntry
 	for _, agent := range summary.Agents {
@@ -81,11 +97,12 @@ func (s *RecordingReminderSource) Produce(_ context.Context) []whisperstore.Whis
 			continue // recording already stopped
 		}
 
-		if !s.shouldRemind(agentID, agent, now) {
+		remind, isFirst := s.shouldRemind(agentID, agent, now)
+		if !remind {
 			continue
 		}
 
-		content := formatReminderContent(state)
+		content := formatReminderContent(state, dest, isFirst)
 
 		id, err := uuid.NewV7()
 		if err != nil {
@@ -127,36 +144,83 @@ func (s *RecordingReminderSource) Produce(_ context.Context) []whisperstore.Whis
 const claudeCodeMinHeartbeats = 2
 
 // shouldRemind checks the whisper store to decide if an agent needs a reminder.
-// Returns true on first call (no prior reminder) or after the configured interval.
-func (s *RecordingReminderSource) shouldRemind(agentID string, agent ActivityEntry, now time.Time) bool {
+// Returns remind=true on first call (no prior reminder) or after the configured
+// interval. isFirst reports whether this is the startup reminder (no prior
+// reminder in the store), which selects the richer first-fire copy.
+func (s *RecordingReminderSource) shouldRemind(agentID string, agent ActivityEntry, now time.Time) (remind bool, isFirst bool) {
 	// Claude Code's SessionStart hook doesn't deliver whispers — wait
 	// until the first prompt has fired. Other agents whisper immediately.
 	agentType := s.heartbeat.GetAgentType(agentID)
 	if agentType == "claude-code" && agent.Count < claudeCodeMinHeartbeats {
-		return false
+		return false, false
 	}
 
 	lastReminder, err := s.store.LatestWhisperTime(whisperstore.SourceRecordingReminder, "recording-status", agentID)
 	if err != nil {
-		return false // store error — skip this tick
+		return false, false // store error — skip this tick
 	}
 
 	if lastReminder.IsZero() {
-		return true // never reminded — produce immediately (startup reminder)
+		return true, true // never reminded — produce immediately (startup reminder)
 	}
 
-	return now.Sub(lastReminder) >= s.interval
+	return now.Sub(lastReminder) >= s.interval, false
+}
+
+// recordingDestination names where the session is shared, as "<team>'s <repo>
+// ledger". The user's #1 ask was clarity on *which* team — naming the team and
+// the repo together makes the privacy scope unmissable. Each part degrades
+// independently so we never render a dangling possessive or a bare "your team":
+//
+//	team + repo → "Acme Eng's web-app ledger"
+//	team only   → "Acme Eng's ledger"
+//	repo only   → "the web-app ledger"
+//	neither     → "your team's ledger"
+func recordingDestination(teamName, repoName string) string {
+	switch {
+	case teamName != "" && repoName != "":
+		return fmt.Sprintf("%s's %s ledger", teamName, repoName)
+	case teamName != "":
+		return fmt.Sprintf("%s's ledger", teamName)
+	case repoName != "":
+		return fmt.Sprintf("the %s ledger", repoName)
+	default:
+		return "your team's ledger"
+	}
+}
+
+// repoNameFromPath derives a human repo name from the project root when the
+// config has no project slug. Returns "" for degenerate roots ("/", ".", "").
+func repoNameFromPath(projectRoot string) string {
+	base := filepath.Base(projectRoot)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return ""
+	}
+	return base
 }
 
 // formatReminderContent builds the whisper message from recording state.
 // Instructs the agent to surface the recording status to the user in one line.
-func formatReminderContent(state *session.RecordingState) string {
-	duration := state.Duration()
-	turns := state.EntryCount
+//
+// dest is the pre-resolved destination phrase from recordingDestination. The
+// first fire is richer — it establishes consent and offers a stop hint plus a
+// learn-more link — while periodic fires stay terse to avoid alarm-fatigue over
+// a long session. Separators are middots, not periods: periods read as multiple
+// alarming sentences on every hourly repeat.
+func formatReminderContent(state *session.RecordingState, dest string, isFirst bool) string {
+	const tell = "Tell the user in one short line: "
 
-	return fmt.Sprintf(
-		"Tell the user in one short line: \"SageOx recording active: %d turns, %s. Session will be shared with your team.\"",
-		turns, formatDuration(duration))
+	if isFirst {
+		// First fire: counts are ~0 at t=0 (near-zero info), so spend the line
+		// on who-sees-this + how-to-stop + where-to-learn instead.
+		return fmt.Sprintf(
+			tell+"\"Recording to %s · your teammates can read this session · stop: /ox-session-stop · %s\"",
+			dest, constants.RecordingDocsURL)
+	}
+
+	// Periodic fire: reassert destination + elapsed; no link, no stop hint
+	// (repeating them every hour trains the user to filter the whole line out).
+	return fmt.Sprintf(tell+"\"Recording to %s · %d turns, %s\"", dest, state.EntryCount, formatDuration(state.Duration()))
 }
 
 // formatDuration renders a duration as human-readable "Xh Ym" or "Xm".

--- a/internal/daemon/whisper_recording_reminder_test.go
+++ b/internal/daemon/whisper_recording_reminder_test.go
@@ -37,17 +37,62 @@ func TestFormatDuration(t *testing.T) {
 	}
 }
 
+// TestRecordingDestination asserts the destination phrase names team + repo and
+// degrades independently — never a dangling possessive or a bare "your team".
+// Failure prevented: regressing to ambiguous "your team" copy, or emitting a
+// broken phrase like "Acme Eng's  ledger" / "'s web-app ledger" when one part
+// is unset.
+func TestRecordingDestination(t *testing.T) {
+	tests := []struct {
+		name, team, repo, want string
+	}{
+		{"team and repo", "Acme Eng", "web-app", "Acme Eng's web-app ledger"},
+		{"team only", "Acme Eng", "", "Acme Eng's ledger"},
+		{"repo only", "", "web-app", "the web-app ledger"},
+		{"neither", "", "", "your team's ledger"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, recordingDestination(tt.team, tt.repo))
+		})
+	}
+}
+
+func TestRepoNameFromPath(t *testing.T) {
+	assert.Equal(t, "web-app", repoNameFromPath("/Users/dev/code/web-app"))
+	assert.Equal(t, "", repoNameFromPath("/"))
+	assert.Equal(t, "", repoNameFromPath("."))
+	assert.Equal(t, "", repoNameFromPath(""))
+}
+
+// TestFormatReminderContent asserts the first/periodic variants by intent, not
+// byte-for-byte: the destination is unmissable, the learn-more link and stop
+// hint appear ONLY on the first fire, and periodic fires carry the live counts.
+// Failure prevented: leaking the hourly-noise link/stop-hint onto every
+// periodic fire, or dropping the destination from either fire.
 func TestFormatReminderContent(t *testing.T) {
 	state := &session.RecordingState{
 		StartedAt:  time.Now().Add(-1*time.Hour - 23*time.Minute),
 		EntryCount: 45,
 	}
-	content := formatReminderContent(state)
-	assert.Contains(t, content, "Tell the user")
-	assert.Contains(t, content, "SageOx recording active")
-	assert.Contains(t, content, "45 turns")
-	assert.Contains(t, content, "1h 23m")
-	assert.Contains(t, content, "shared with your team")
+	const dest = "Acme Eng's web-app ledger"
+
+	t.Run("first fire", func(t *testing.T) {
+		c := formatReminderContent(state, dest, true)
+		assert.Contains(t, c, "Tell the user")
+		assert.Contains(t, c, dest, "destination (team + repo) must be surfaced")
+		assert.Contains(t, c, "/ox-session-stop", "first fire offers a stop hint")
+		assert.Contains(t, c, "sageox.ai/rec", "first fire offers learn-more link")
+	})
+
+	t.Run("periodic fire", func(t *testing.T) {
+		c := formatReminderContent(state, dest, false)
+		assert.Contains(t, c, dest, "destination reasserted on every fire")
+		assert.Contains(t, c, "45 turns")
+		assert.Contains(t, c, "1h 23m")
+		assert.NotContains(t, c, "sageox.ai/rec", "periodic fire must not repeat the link")
+		assert.NotContains(t, c, "/ox-session-stop", "periodic fire must not repeat the stop hint")
+	})
 }
 
 func TestRecordingReminderSource_Name(t *testing.T) {
@@ -86,6 +131,8 @@ func initRecordingReminderProject(t *testing.T) (projectRoot string, sessionsBas
 		"config_version":     "2",
 		"repo_id":            repoID,
 		"recording_reminder": "on",
+		"team_name":          "Acme Eng",
+		"project":            "web-app",
 	})
 	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), cfgData, 0o644))
 
@@ -138,8 +185,11 @@ func TestRecordingReminderSource_Produce_FirstReminder(t *testing.T) {
 	assert.Equal(t, "recording-reminder", entries[0].Source)
 	assert.Equal(t, "recording-status", entries[0].Topic)
 	assert.Equal(t, agentID, entries[0].AgentID)
-	assert.Contains(t, entries[0].Content, "12 turns")
-	assert.Contains(t, entries[0].Content, "SageOx recording active")
+	// first fire: names team + repo destination, offers stop + learn-more;
+	// counts are omitted (near-zero info at session start)
+	assert.Contains(t, entries[0].Content, "Acme Eng's web-app ledger")
+	assert.Contains(t, entries[0].Content, "/ox-session-stop")
+	assert.Contains(t, entries[0].Content, "sageox.ai/rec")
 }
 
 func TestRecordingReminderSource_Produce_SuppressedUntilHeartbeatThreshold(t *testing.T) {
@@ -182,7 +232,8 @@ func TestRecordingReminderSource_Produce_NonClaudeAgent_ImmediateReminder(t *tes
 	entries := src.Produce(context.Background())
 
 	require.Len(t, entries, 1, "non-claude agent should get immediate reminder")
-	assert.Contains(t, entries[0].Content, "3 turns")
+	// first fire names the destination rather than leaking startup counts
+	assert.Contains(t, entries[0].Content, "Acme Eng's web-app ledger")
 }
 
 func TestRecordingReminderSource_Produce_IntervalGating(t *testing.T) {

--- a/scripts/smoketest/smoke-test-recording-reminder.sh
+++ b/scripts/smoketest/smoke-test-recording-reminder.sh
@@ -79,7 +79,7 @@ for attempt in $(seq 1 18); do
     whisper_output=$(AGENT_ENV=claude-code $OX agent "$agent_id" whisper 2>&1)
     set -e
 
-    if echo "$whisper_output" | grep -qi "SageOx recording active"; then
+    if echo "$whisper_output" | grep -qiE "Recording (to|this session)"; then
         reminder_found=true
         echo "  reminder found on attempt $attempt"
         break
@@ -90,7 +90,7 @@ for attempt in $(seq 1 18); do
     history_output=$(AGENT_ENV=claude-code $OX agent "$agent_id" whisper history 2>&1)
     set -e
 
-    if echo "$history_output" | grep -qi "SageOx recording active"; then
+    if echo "$history_output" | grep -qiE "Recording (to|this session)"; then
         reminder_found=true
         echo "  reminder found in history on attempt $attempt"
         break
@@ -108,9 +108,9 @@ fi
 
 echo "Step 4: Validate whisper content..."
 
-# the content should mention turns and duration
+# first-fire content names the destination ledger and offers a learn-more link
 combined_output="${whisper_output}${history_output}"
-if ! echo "$combined_output" | grep -qE "turns.*shared|SageOx recording active"; then
+if ! echo "$combined_output" | grep -qiE "Recording to .* ledger|teammates can read|sageox.ai/rec"; then
     echo "error: whisper content missing expected fields"
     echo "$combined_output"
     exit 1


### PR DESCRIPTION
## Summary

The recurring "recording active" status line said **"shared with your team"** — ambiguous when a coworker belongs to several teams, with no way to learn more or stop. This redesigns the line so the **destination ledger is named unmissably** (`<team>'s <repo> ledger`), the first fire carries a stop hint + short learn-more link, and periodic fires stay terse to avoid alarm-fatigue over a long session.

**Before**

`SageOx recording active: 3 turns, 1m. Session shared with your team.`

**After**

| Fire | Line the agent echoes |
|------|------------------------|
| First | `Recording to Acme Eng's web-app ledger · your teammates can read this session · stop: /ox-session-stop · sageox.ai/rec` |
| Periodic | `Recording to Acme Eng's web-app ledger · 47 turns, 1h 2m` |

The destination degrades independently — never a dangling possessive or a bare "your team":

| Team | Repo | Destination phrase |
|------|------|--------------------|
| known | known | `Acme Eng's web-app ledger` |
| known | unknown | `Acme Eng's ledger` |
| unknown | known | `the web-app ledger` |
| unknown | unknown | `your team's ledger` |

## Why these choices

- **Name team + repo** — the user's #1 ask was *which* team; pairing it with the repo and the canonical term **ledger** makes the privacy scope concrete (this session lands in that repo's shared history).
- **Link + stop hint on the FIRST fire only** — they answer a one-time onboarding question ("what's captured / who sees it / how to stop"). Repeating a URL hourly trains banner-blindness and defeats the privacy goal.
- **First fire omits turn/duration counts** — at session start they're always ~`0 turns, <1m`, near-zero info; the line is better spent on consent + escape + learn-more.
- **Middot `·` separators, no trailing period** — periods read as multiple alarming sentences on every hourly repeat.

## Resolution + selection logic

```mermaid
flowchart TD
    A["recording reminder fires"] --> R["resolve destination: team name plus repo slug, fallback repo dir basename"]
    R --> B{"first fire this session"}
    B -->|yes| C["Recording to DEST, teammates can read this session, stop hint, sageox.ai/rec"]
    B -->|no| D["Recording to DEST, N turns, duration"]
```

## Implementation

- `internal/daemon/whisper_recording_reminder.go` — new `recordingDestination(team, repo)` + `repoNameFromPath` helpers; `formatReminderContent(state, dest, isFirst)` emits the first/periodic variants; `Produce` resolves team (`cfg.TeamName`) and repo (`cfg.Project`, falling back to the project-root basename) once per tick; `shouldRemind` now returns `(remind, isFirst)`.
- `internal/constants/agent.go` — new `RecordingDocsURL = "sageox.ai/rec"` (kept short; echoed verbatim into 80-col terminals).
- Tests + smoketest assert by **intent** (destination present; link/stop-hint first-fire-only) rather than exact byte strings.

## Dependency (tracked, non-blocking)

`sageox.ai/rec` does not exist yet — it 404s until web stands up the redirect to `/docs/cli/recording`. Tracked separately. The constant is the single switch: if a dead privacy link is undesirable before the page lands, drop `RecordingDocsURL` from the first-fire string.

## Test Plan

- `go build`, `go vet`, daemon reminder tests (`RecordingReminder|FormatReminderContent|RecordingDestination|RepoNameFromPath|FormatDuration`) — green.
- `golangci-lint` on the changed packages — clean (repo-wide pre-existing findings in unrelated daemon files are untouched).
- Unit cases cover the four destination combos + first/periodic content; integration cases assert the first fire names `Acme Eng's web-app ledger` and omits counts.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (destination combos + first/periodic content + updated integration/smoketest assertions)
- [ ] CHANGELOG entry — follow-up if desired; copy-only change to an existing line
- [x] Breaking change — none (whisper copy only)
- [x] `/security-review` — N/A (no auth/mcp/raw_writer/prepush/upgrade/go.sum touched)

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recording reminders now display team and project context for where recordings are shared, include a learn-more documentation link and stop instructions on the first reminder notification, and reduce subsequent reminder messages to minimize notification clutter.

* **Tests**
  * Updated test coverage for reminder content formatting, destination resolution, and detection pattern validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->