### PR TITLE
feat(plan): team-context-enriched, beautifully-rendered implementation plans

### DIFF
--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -494,6 +494,12 @@ func handlePrompt(ctx *HookContext) error {
 	// this terminal's nudge.
 	emitSuspendedNudge(os.Stdout, ctx.ProjectRoot, agentID)
 
+	// Deliver a pending plan-exit enrichment nudge (stashed by handleAfterTool
+	// on ExitPlanMode). UserPromptSubmit is the only Claude Code channel whose
+	// stdout reaches the model, so delivery happens here — on the turn that
+	// begins right after the plan was approved.
+	emitPlanNudge(os.Stdout, ctx.ProjectRoot, agentID)
+
 	emitWhispers(os.Stdout, agentID)
 	return nil
 }
@@ -543,6 +549,17 @@ func handleAfterTool(ctx *HookContext) error {
 		slog.Debug("hook: afterTool skipped, no agent ID available")
 		return nil
 	}
+
+	// Plan-exit nudge (Gold tier): the closest plan-exit signal Claude Code
+	// exposes is this PostToolUse firing after ExitPlanMode. Strictly gated on
+	// the tool name so it is a no-op for every other tool — NOT a noisy hook.
+	// Enriches the approved plan and stashes a one-line nudge that the next
+	// UserPromptSubmit (handlePrompt) delivers. Independent of recording state,
+	// so it runs before the recording-state checks below.
+	if ctx.Input != nil && ctx.Input.ToolName == exitPlanModeToolName {
+		handlePlanExit(ctx, agentID)
+	}
+
 	// emit pending whispers (fallback — primary delivery is handlePrompt)
 	emitWhispers(os.Stdout, agentID)
 

--- a/cmd/ox/agent_hook_plan_nudge.go
+++ b/cmd/ox/agent_hook_plan_nudge.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Plan-exit enrichment nudge (Gold tier — Claude Code).
+//
+// The closest plan-exit signal Claude Code exposes is the PostToolUse event
+// firing after the ExitPlanMode tool. We do NOT install a separate, always-on
+// PostToolUse hook for this — that event already has an ox hook installed (see
+// claudeLifecycleEvents), and handleAfterTool runs on every tool. We add a
+// narrow, strictly-gated branch: only when ToolName == "ExitPlanMode" do we do
+// any plan work. Every other tool is untouched, so this is NOT a noisy hook.
+//
+// Delivery channel: PostToolUse stdout is COMPLETELY DISCARDED by Claude Code
+// (empirically confirmed — see the table in agent_hook.go). So we cannot emit
+// the nudge from the PostToolUse handler itself. Instead, the PostToolUse
+// branch stashes a one-line nudge to a per-agent pending file, and the next
+// UserPromptSubmit (handlePrompt — the ONLY proven stdout-injection channel)
+// drains it into model context. After a plan is approved, the agent's next
+// turn is exactly where the nudge belongs, so this timing is correct.
+//
+// Everything here is best-effort and fail-open: any error (no plan text, ox
+// not on PATH, no signals, write failure) leaves the existing hook behavior
+// completely untouched. The nudge is purely additive.
+
+const (
+	// exitPlanModeToolName is Claude Code's plan-mode-exit tool. Its tool_input
+	// carries the approved plan markdown in the "plan" field.
+	exitPlanModeToolName = "ExitPlanMode"
+
+	// planNudgeCacheSubdir holds per-agent pending plan-exit nudges under the
+	// ledger cache (.sageox/cache/). Local-only derived data, never committed.
+	planNudgeCacheSubdir = "plan-nudge"
+
+	// planNudgeMaxAge bounds how long a stashed nudge stays deliverable. If the
+	// user never submits another prompt, a stale nudge should not surface days
+	// later in an unrelated context.
+	planNudgeMaxAge = 30 * time.Minute
+
+	// planSubprocessTimeout caps the `ox plan --json` enrichment call. Enrich is
+	// pure-local (no network/LLM), so this is generous headroom, not a latency
+	// budget the user feels.
+	planSubprocessTimeout = 3 * time.Second
+)
+
+// exitPlanModeInput is the minimal shape of Claude Code's ExitPlanMode
+// tool_input. Only the plan text is needed to enrich.
+type exitPlanModeInput struct {
+	Plan string `json:"plan"`
+}
+
+// planJSONResult is the minimal subset of `ox plan --json` output the nudge
+// needs. The full Result lives in internal/plan; we deliberately decode only
+// the material flag + counts so this stays decoupled from that package.
+type planJSONResult struct {
+	Signals struct {
+		Collisions   int  `json:"collisions"`
+		PriorArt     int  `json:"prior_art"`
+		ExpertRoutes int  `json:"expert_routes"`
+		Material     bool `json:"material"`
+	} `json:"signals"`
+}
+
+// handlePlanExit is invoked from handleAfterTool ONLY when the PostToolUse
+// event reports ToolName == "ExitPlanMode". It enriches the approved plan via
+// `ox plan --json` and, if the signals are material, stashes a one-line nudge
+// for the next UserPromptSubmit to deliver. Fail-open throughout.
+func handlePlanExit(ctx *HookContext, agentID string) {
+	if ctx == nil || ctx.Input == nil || agentID == "" {
+		return
+	}
+
+	planText := extractExitPlanText(ctx.Input.RawBytes)
+	if strings.TrimSpace(planText) == "" {
+		slog.Debug("hook: plan-exit no plan text, skipping nudge")
+		return
+	}
+
+	res, ok := runPlanEnrichment(planText)
+	if !ok {
+		return
+	}
+	if !res.Signals.Material {
+		slog.Debug("hook: plan-exit no material signals",
+			"collisions", res.Signals.Collisions,
+			"prior_art", res.Signals.PriorArt,
+			"expert_routes", res.Signals.ExpertRoutes)
+		return
+	}
+
+	nudge := formatPlanNudgeLine(res)
+	if err := stashPlanNudge(ctx.ProjectRoot, agentID, nudge); err != nil {
+		slog.Debug("hook: plan-exit stash failed", "error", err)
+		return
+	}
+	slog.Info("hook: plan-exit nudge stashed",
+		"agent_id", agentID,
+		"collisions", res.Signals.Collisions,
+		"prior_art", res.Signals.PriorArt,
+		"expert_routes", res.Signals.ExpertRoutes)
+}
+
+// extractExitPlanText pulls the plan markdown out of ExitPlanMode tool_input.
+// Claude Code shapes the hook stdin as {"tool_name":"ExitPlanMode",
+// "tool_input":{"plan":"..."}}. Returns "" on any parse failure (fail-open).
+func extractExitPlanText(rawBytes []byte) string {
+	if len(rawBytes) == 0 {
+		return ""
+	}
+	var envelope struct {
+		ToolInput json.RawMessage `json:"tool_input"`
+	}
+	if err := json.Unmarshal(rawBytes, &envelope); err != nil || len(envelope.ToolInput) == 0 {
+		return ""
+	}
+	var ti exitPlanModeInput
+	if err := json.Unmarshal(envelope.ToolInput, &ti); err != nil {
+		return ""
+	}
+	return ti.Plan
+}
+
+// runPlanEnrichment shells out to `ox plan --json`, feeding the plan markdown
+// on stdin. This is the deterministic, 0-token, no-network plumbing path. We
+// invoke the managed CLI rather than calling internal/plan directly so the
+// nudge stays decoupled from the enrichment internals (another agent owns that
+// package). Returns ok=false on any failure (fail-open).
+func runPlanEnrichment(planText string) (planJSONResult, bool) {
+	var res planJSONResult
+
+	oxPath, err := os.Executable()
+	if err != nil {
+		slog.Debug("hook: plan-exit cannot find ox executable", "error", err)
+		return res, false
+	}
+
+	cmd := exec.Command(oxPath, "plan", "--json")
+	cmd.Stdin = strings.NewReader(planText)
+	cmd.Env = os.Environ()
+
+	// hard timeout so a wedged subprocess never stalls the agent's turn.
+	timer := time.AfterFunc(planSubprocessTimeout, func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	defer timer.Stop()
+
+	out, err := cmd.Output()
+	if err != nil {
+		slog.Debug("hook: plan-exit enrichment subprocess failed", "error", err)
+		return res, false
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		slog.Debug("hook: plan-exit enrichment output not parseable", "error", err)
+		return res, false
+	}
+	return res, true
+}
+
+// formatPlanNudgeLine builds the concise one-line nudge from material signals.
+// Single line, no multi-line noise. Only mentions signal classes that fired.
+func formatPlanNudgeLine(res planJSONResult) string {
+	var parts []string
+	if res.Signals.Collisions > 0 {
+		parts = append(parts, fmt.Sprintf("%s in open PRs/active files", pluralize(res.Signals.Collisions, "collision", "collisions")))
+	}
+	if res.Signals.PriorArt > 0 {
+		parts = append(parts, pluralize(res.Signals.PriorArt, "prior-art match", "prior-art matches"))
+	}
+	if res.Signals.ExpertRoutes > 0 {
+		parts = append(parts, pluralize(res.Signals.ExpertRoutes, "expert route", "expert routes"))
+	}
+	detail := strings.Join(parts, " + ")
+	if detail == "" {
+		detail = "team-context signals"
+	}
+	return fmt.Sprintf("Your plan touches %s. Render an enriched plan for faster human review: run `ox plan`.", detail)
+}
+
+// pluralize renders "<n> <singular|plural>" picking the form by count.
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
+}
+
+// planNudgePath returns the per-agent pending-nudge file path under the ledger
+// cache. Empty projectRoot/agentID yields "" (caller no-ops).
+func planNudgePath(projectRoot, agentID string) string {
+	if projectRoot == "" || agentID == "" {
+		return ""
+	}
+	// agentID is an ox-generated token (no path separators), safe as a filename.
+	return filepath.Join(projectRoot, ".sageox", "cache", planNudgeCacheSubdir, agentID+".txt")
+}
+
+// stashPlanNudge writes a single pending nudge for the agent. Overwrites any
+// existing pending nudge (the latest plan exit wins). Best-effort directory
+// creation; errors bubble up for the caller's debug log.
+func stashPlanNudge(projectRoot, agentID, line string) error {
+	path := planNudgePath(projectRoot, agentID)
+	if path == "" {
+		return fmt.Errorf("plan-nudge: empty project root or agent id")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("plan-nudge mkdir: %w", err)
+	}
+	return os.WriteFile(path, []byte(line), 0o600)
+}
+
+// emitPlanNudge drains and delivers a pending plan-exit nudge to w, then
+// removes the file (deliver-once). Called from handlePrompt — the proven
+// UserPromptSubmit stdout-injection channel. No-op when there is no pending
+// nudge, or when the nudge is older than planNudgeMaxAge (stale → discard).
+func emitPlanNudge(w io.Writer, projectRoot, agentID string) {
+	path := planNudgePath(projectRoot, agentID)
+	if path == "" {
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return // no pending nudge
+	}
+
+	// always remove after observing it — even if stale — so a stale nudge does
+	// not linger and resurface on a later unrelated prompt.
+	defer func() { _ = os.Remove(path) }()
+
+	if time.Since(info.ModTime()) > planNudgeMaxAge {
+		slog.Debug("hook: plan-exit nudge stale, discarding", "age", time.Since(info.ModTime()))
+		return
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	line := strings.TrimSpace(string(data))
+	if line == "" {
+		return
+	}
+
+	// <system-reminder> is the only tag Claude Code treats as trusted system
+	// context (see formatWhispers — <new-context> is rejected as injection).
+	fmt.Fprintf(w, "<system-reminder>[ox] %s</system-reminder>\n", line)
+}

--- a/cmd/ox/agent_hook_plan_nudge_test.go
+++ b/cmd/ox/agent_hook_plan_nudge_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// planNudgeProject builds a minimal initialized project root for the plan-exit
+// nudge tests. Unlike the suspended-nudge tests, the plan nudge is independent
+// of recording state, so no session is started here.
+func planNudgeProject(t *testing.T) string {
+	t.Helper()
+	projectRoot := t.TempDir()
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0o755))
+	cfg := `{"config_version":"2","repo_id":"test-repo-plan-nudge","endpoint":"http://test.sageox.local","session_publishing":"manual"}`
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"), []byte(cfg), 0o644))
+	return projectRoot
+}
+
+// --- A. Plan text extraction from ExitPlanMode tool_input ---
+
+// TestExtractExitPlanText_HappyPath verifies the plan markdown is pulled out of
+// the nested tool_input.plan field of Claude Code's PostToolUse stdin.
+// Failure prevented: nudge silently never fires because the plan text is lost.
+func TestExtractExitPlanText_HappyPath(t *testing.T) {
+	raw := []byte(`{"tool_name":"ExitPlanMode","tool_input":{"plan":"# Refactor auth\n- touch internal/auth/session.go"}}`)
+	got := extractExitPlanText(raw)
+	assert.Contains(t, got, "Refactor auth")
+	assert.Contains(t, got, "internal/auth/session.go")
+}
+
+// TestExtractExitPlanText_Malformed covers every fail-open path: empty input,
+// non-JSON, missing tool_input, missing plan field.
+func TestExtractExitPlanText_Malformed(t *testing.T) {
+	cases := map[string]string{
+		"empty":           ``,
+		"not json":        `not json at all`,
+		"no tool_input":   `{"tool_name":"ExitPlanMode"}`,
+		"no plan field":   `{"tool_input":{"other":"x"}}`,
+		"plan not string": `{"tool_input":{"plan":123}}`,
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Empty(t, extractExitPlanText([]byte(raw)))
+		})
+	}
+}
+
+// --- B. Nudge line formatting ---
+
+// TestFormatPlanNudgeLine_MentionsOnlyFiredSignals verifies the one-line nudge
+// names only the signal classes that actually fired, with correct pluralization.
+// Failure prevented: nudge claims signals (e.g. "0 collisions") that didn't fire.
+func TestFormatPlanNudgeLine_MentionsOnlyFiredSignals(t *testing.T) {
+	var res planJSONResult
+	res.Signals.Collisions = 2
+	res.Signals.PriorArt = 1
+	res.Signals.ExpertRoutes = 0
+	res.Signals.Material = true
+
+	line := formatPlanNudgeLine(res)
+	assert.Contains(t, line, "2 collisions")
+	assert.Contains(t, line, "1 prior-art match")
+	assert.NotContains(t, line, "expert route", "expert routes did not fire — must not be mentioned")
+	assert.Contains(t, line, "ox plan")
+	// single line — grepability invariant
+	assert.NotContains(t, line, "\n")
+}
+
+func TestFormatPlanNudgeLine_SingularCollision(t *testing.T) {
+	var res planJSONResult
+	res.Signals.Collisions = 1
+	line := formatPlanNudgeLine(res)
+	assert.Contains(t, line, "1 collision in")
+	assert.NotContains(t, line, "1 collisions")
+}
+
+// --- C. Stash + emit roundtrip (deliver-once via UserPromptSubmit channel) ---
+
+// TestPlanNudge_StashThenEmit verifies the full deliver path: a stashed nudge is
+// emitted as a <system-reminder> on the next prompt and then removed (deliver-once).
+// Failure prevented: nudge never reaches the model, or reaches it on every prompt.
+func TestPlanNudge_StashThenEmit(t *testing.T) {
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxplan1"
+
+	require.NoError(t, stashPlanNudge(projectRoot, agentID, "Your plan touches 1 collision. Run `ox plan`."))
+
+	var buf bytes.Buffer
+	emitPlanNudge(&buf, projectRoot, agentID)
+	got := buf.String()
+	assert.Contains(t, got, "<system-reminder>")
+	assert.Contains(t, got, "[ox]")
+	assert.Contains(t, got, "ox plan")
+
+	// deliver-once: file is gone, a second prompt emits nothing
+	assert.NoFileExists(t, planNudgePath(projectRoot, agentID))
+	var buf2 bytes.Buffer
+	emitPlanNudge(&buf2, projectRoot, agentID)
+	assert.Empty(t, buf2.String(), "nudge must deliver exactly once")
+}
+
+// TestPlanNudge_NoPendingNudge verifies emit is a clean no-op with nothing stashed.
+func TestPlanNudge_NoPendingNudge(t *testing.T) {
+	projectRoot := planNudgeProject(t)
+	var buf bytes.Buffer
+	emitPlanNudge(&buf, projectRoot, "Oxnone")
+	assert.Empty(t, buf.String())
+}
+
+// TestPlanNudge_StaleDiscarded verifies a nudge older than planNudgeMaxAge is
+// discarded (and removed) rather than surfaced on an unrelated later prompt.
+// Failure prevented: a day-old plan nudge resurfaces mid-unrelated-task.
+func TestPlanNudge_StaleDiscarded(t *testing.T) {
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxstale"
+	require.NoError(t, stashPlanNudge(projectRoot, agentID, "stale nudge"))
+
+	// backdate the file mtime well past the max age
+	path := planNudgePath(projectRoot, agentID)
+	old := time.Now().Add(-2 * planNudgeMaxAge)
+	require.NoError(t, os.Chtimes(path, old, old))
+
+	var buf bytes.Buffer
+	emitPlanNudge(&buf, projectRoot, agentID)
+	assert.Empty(t, buf.String(), "stale nudge must not surface")
+	assert.NoFileExists(t, path, "stale nudge must be removed so it never resurfaces")
+}
+
+// TestPlanNudge_LatestWins verifies a second stash overwrites the first — the
+// most recent plan exit is the one delivered.
+func TestPlanNudge_LatestWins(t *testing.T) {
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxlatest"
+	require.NoError(t, stashPlanNudge(projectRoot, agentID, "first nudge"))
+	require.NoError(t, stashPlanNudge(projectRoot, agentID, "second nudge"))
+
+	var buf bytes.Buffer
+	emitPlanNudge(&buf, projectRoot, agentID)
+	got := buf.String()
+	assert.Contains(t, got, "second nudge")
+	assert.NotContains(t, got, "first nudge")
+}
+
+// TestPlanNudge_EmptyArgs verifies path/emit/stash are safe with empty inputs.
+func TestPlanNudge_EmptyArgs(t *testing.T) {
+	assert.Empty(t, planNudgePath("", "Oxa"))
+	assert.Empty(t, planNudgePath("/tmp", ""))
+
+	var buf bytes.Buffer
+	emitPlanNudge(&buf, "", "Oxa")
+	emitPlanNudge(&buf, "/tmp", "")
+	assert.Empty(t, buf.String())
+
+	assert.Error(t, stashPlanNudge("", "Oxa", "x"))
+}

--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -502,7 +502,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 	}
 
 	// build intent-to-command guidance for agent consumption
-	guidance := buildGuidance(agentID, projectRoot, teamCtx, ledgerStatus)
+	guidance := buildGuidance(agentID, projectRoot, teamCtx, ledgerStatus, agentType)
 	timing["guidance_build"] = time.Since(phaseStart).Milliseconds()
 
 	// register or update agent instance locally (bootstrap completes without cloud API)
@@ -1057,7 +1057,7 @@ func buildCapturePriorGuidance(agentID string) *capturePriorGuidance {
 // buildGuidance constructs state-aware command guidance for agent consumption.
 // Performs I/O (os.Stat, exec.Command) to resolve repo slug and code DB availability,
 // then delegates to pure prime.BuildGuidance.
-func buildGuidance(agentID, projectRoot string, teamCtx *teamContextInfo, ledgerStatus *ledgerInfo) *agentGuidance {
+func buildGuidance(agentID, projectRoot string, teamCtx *teamContextInfo, ledgerStatus *ledgerInfo, agentType string) *agentGuidance {
 	repoSlug := repoSlugFromRemoteOrDir(projectRoot)
 	codeDBDir := resolveCodeDBDir(projectRoot)
 	_, statErr := os.Stat(codeDBDir)
@@ -1070,6 +1070,7 @@ func buildGuidance(agentID, projectRoot string, teamCtx *teamContextInfo, ledger
 		CodeDBExists:     statErr == nil,
 		MemoryEnabled:    auth.IsMemoryEnabled(),
 		MurmuringEnabled: config.MurmuringEnabled(projectRoot),
+		AgentType:        agentType,
 	})
 }
 

--- a/cmd/ox/agent_prime_test.go
+++ b/cmd/ox/agent_prime_test.go
@@ -439,7 +439,7 @@ func TestBuildGuidance_MemoryPut(t *testing.T) {
 			t.Setenv("FEATURE_MEMORY", tt.featureEnv)
 
 			projectRoot := t.TempDir()
-			g := buildGuidance("test-agent", projectRoot, tt.teamCtx, nil)
+			g := buildGuidance("test-agent", projectRoot, tt.teamCtx, nil, "claude-code")
 
 			found := false
 			for _, cmd := range g.Commands {

--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -140,6 +140,13 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 	sb.WriteString("Team rules apply to every supported AI coding agent (Claude, Codex, Amp, etc.) used by teammates running ox — but only for teammates running ox. Project-local .claude/rules/ only reaches Claude users.\n")
 	sb.WriteString("</rule-promotion-guidance>\n")
 
+	// plan-enrichment-guidance: when the agent produces a plan for non-trivial
+	// work, nudge it to enrich the plan with team context via `ox plan` and
+	// recommend an HTML render. Tier-aware (Gold/Silver/Bronze) so we only
+	// promise what the agent can deliver — Bronze agents have no real-time
+	// hook, so they get a lighter note. Parallels <rule-promotion-guidance>.
+	writePlanEnrichmentGuidance(&sb, output.AgentType)
+
 	// code-search: behavioral instruction to prefer ox code search over built-in tools
 	if output.CodeDBAvailable {
 		sb.WriteString("\n<code-search status=\"indexed\">\n")
@@ -534,6 +541,28 @@ var xmlEscaper = strings.NewReplacer(
 
 func escapeXML(s string) string {
 	return xmlEscaper.Replace(s)
+}
+
+// writePlanEnrichmentGuidance emits the <plan-enrichment-guidance> advisory
+// block, scaled to the agent's plan-enrichment tier. Gold (claude-code) and
+// Silver (codex/gemini) and the unknown-agent baseline get the full block;
+// Bronze (amp/opencode/pi) gets a lighter note that only points at `ox plan`
+// and `ox plan list` without promising a real-time nudge the tier can't fire.
+//
+// Token-lean by design: this ships on every prime payload (see
+// docs/ai/specs/agent-ux-principles.md — every token competes with the
+// developer's own context).
+func writePlanEnrichmentGuidance(sb *strings.Builder, agentType string) {
+	sb.WriteString("\n<plan-enrichment-guidance>\n")
+	if prime.ClassifyAgentTier(agentType) == prime.TierBronze {
+		// lighter tier: surface the surface, don't promise nudges.
+		sb.WriteString("When you produce a plan for non-trivial work, `ox plan` enriches it with team context (collisions, prior art, expert routing). Run `ox plan list` to browse prior plans for this repo.\n")
+		sb.WriteString("</plan-enrichment-guidance>\n")
+		return
+	}
+	sb.WriteString("When you produce a plan for non-trivial work (multi-file OR architectural OR touches a hotspot/open-PR OR ~5+ steps), run `ox plan` to enrich it with team context — collisions (incl. teammates actively murmuring on these files), prior art, and expert routing.\n")
+	sb.WriteString("Unless plan.html is off, recommend rendering an enriched HTML plan for the human; render only after they confirm, unless plan.html is always.\n")
+	sb.WriteString("</plan-enrichment-guidance>\n")
 }
 
 // emitTeamRules writes <team-rules> and <team-rules-budget> blocks for the

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -491,6 +491,74 @@ func TestOutputAgentPrimeXML_ConsultFirst(t *testing.T) {
 	}
 }
 
+// TestOutputAgentPrimeXML_PlanEnrichmentGuidance verifies the
+// <plan-enrichment-guidance> advisory renders on every prime payload and
+// scales to the agent tier: full block (with the HTML-render recommendation)
+// for Gold/Silver/unknown-baseline, lighter for Bronze.
+// Failure prevented: the block silently dropping, or a Bronze agent being
+// promised an HTML-render nudge its lifecycle can't fire.
+func TestOutputAgentPrimeXML_PlanEnrichmentGuidance(t *testing.T) {
+	tests := []struct {
+		name        string
+		agentType   string
+		wantFull    bool // full block includes the HTML-render recommendation
+		wantCommand string
+	}{
+		{"gold claude-code", "claude-code", true, "ox plan"},
+		{"silver codex", "codex", true, "ox plan"},
+		{"bronze amp", "amp", false, "ox plan list"},
+		{"unknown baseline", "some-future-agent", true, "ox plan"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&buf)
+
+			out := agentPrimeOutput{AgentID: "a", Status: "fresh", AgentType: tt.agentType}
+			if _, err := outputAgentPrimeXML(cmd, out); err != nil {
+				t.Fatalf("outputAgentPrimeXML() error = %v", err)
+			}
+			xml := buf.String()
+
+			// block always present, on every payload
+			if !strings.Contains(xml, "<plan-enrichment-guidance>") {
+				t.Fatal("prime output missing <plan-enrichment-guidance> block")
+			}
+			if !strings.Contains(xml, "</plan-enrichment-guidance>") {
+				t.Error("plan-enrichment-guidance block not closed")
+			}
+
+			// always routes to `ox plan` as the enrich verb
+			if !strings.Contains(xml, "`ox plan`") {
+				t.Error("plan-enrichment-guidance must mention `ox plan`")
+			}
+
+			// the HTML-render recommendation is the differentiator: full tiers
+			// recommend it; Bronze (lighter) does not.
+			hasHTML := strings.Contains(xml, "HTML plan")
+			if tt.wantFull && !hasHTML {
+				t.Error("full-tier block must recommend rendering an HTML plan")
+			}
+			if !tt.wantFull {
+				if hasHTML {
+					t.Error("bronze block must NOT promise HTML-render nudge")
+				}
+				if !strings.Contains(xml, "ox plan list") {
+					t.Error("bronze block must point at `ox plan list` to browse prior plans")
+				}
+			}
+
+			// must sit in the static (cacheable) tier — above per-session content
+			blockIdx := strings.Index(xml, "<plan-enrichment-guidance>")
+			sessionIdx := strings.Index(xml, "<session-context")
+			if sessionIdx >= 0 && blockIdx > sessionIdx {
+				t.Error("plan-enrichment-guidance must be above the per-session block")
+			}
+		})
+	}
+}
+
 func TestEscapeXML_AllSpecialChars(t *testing.T) {
 	tests := []struct {
 		input string

--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -248,6 +248,38 @@ as whispers in the agent's context.`,
 		Default:     "on",
 		Levels:      []ConfigLevel{ConfigLevelUser, ConfigLevelRepo},
 	},
+	{
+		Key:         "plan.save",
+		Description: "Auto-save approved plans to the ledger",
+		LongDescription: `Controls whether 'ox plan' auto-saves the enriched plan to this repo's
+ledger.
+
+  on  - Persist finalized plans to data/plans/ (default). Plans become
+        first-class ledger artifacts: searchable, attributable, reusable.
+  off - Never auto-save. 'ox plan save' (the explicit persist path used by
+        the ox-plan skill) still saves regardless of this setting.`,
+		Category:    "Plans",
+		ValidValues: []string{"on", "off"},
+		Default:     "on",
+		Levels:      []ConfigLevel{ConfigLevelUser, ConfigLevelRepo},
+	},
+	{
+		Key:         "plan.html",
+		Description: "Enriched-HTML render mode",
+		LongDescription: `Controls when 'ox plan' renders an enriched HTML plan for human review.
+
+  off       - Never render, never nudge.
+  recommend - Prime nudges for a render on complex/material plans; the
+              render happens only after you confirm. (default)
+  always    - Auto-render without a confirm step.
+
+Override per-invocation with the SAGEOX_PLAN_HTML env var (same three
+values).`,
+		Category:    "Plans",
+		ValidValues: []string{config.PlanHTMLOff, config.PlanHTMLRecommend, config.PlanHTMLAlways},
+		Default:     config.DefaultPlanHTML,
+		Levels:      []ConfigLevel{ConfigLevelUser, ConfigLevelRepo},
+	},
 	// NOTE: attribution.plan and attribution.session are intentionally not exposed
 	// in ox config — they are always-on transparency requirements, not user preferences.
 	{
@@ -531,6 +563,22 @@ func ResolveConfigValue(key string, projectRoot string) (*ConfigValue, error) {
 			cv.RepoVal = boolToOnOff(*repoCfg.Hooks.UserPromptSubmit.CloudQuery)
 		}
 
+	case "plan.save":
+		if userCfg != nil && userCfg.Plan.IsSaveSet() {
+			cv.UserVal = boolToOnOff(*userCfg.Plan.Save)
+		}
+		if repoCfg != nil && repoCfg.Plan.IsSaveSet() {
+			cv.RepoVal = boolToOnOff(*repoCfg.Plan.Save)
+		}
+
+	case "plan.html":
+		if userCfg != nil && userCfg.Plan.IsHTMLSet() {
+			cv.UserVal = *userCfg.Plan.HTML
+		}
+		if repoCfg != nil && repoCfg.Plan.IsHTMLSet() {
+			cv.RepoVal = *repoCfg.Plan.HTML
+		}
+
 	}
 
 	// determine effective value and source (User > Repo > Team > Default)
@@ -729,6 +777,19 @@ func setUserConfig(key, value string) error {
 		}
 		cfg.Hooks.SetUserPromptSubmitCloudQuery(value == "on")
 
+	case "plan.save":
+		if cfg.Plan == nil {
+			cfg.Plan = &config.PlanConfig{}
+		}
+		enabled := value == "on"
+		cfg.Plan.Save = &enabled
+
+	case "plan.html":
+		if cfg.Plan == nil {
+			cfg.Plan = &config.PlanConfig{}
+		}
+		cfg.Plan.HTML = config.StringPtr(value)
+
 	default:
 		return fmt.Errorf("unknown user setting: %s", key)
 	}
@@ -791,6 +852,19 @@ func setRepoConfig(key, value, projectRoot string) error {
 			cfg.Hooks = &config.HooksConfig{}
 		}
 		cfg.Hooks.SetUserPromptSubmitCloudQuery(value == "on")
+
+	case "plan.save":
+		if cfg.Plan == nil {
+			cfg.Plan = &config.PlanConfig{}
+		}
+		enabled := value == "on"
+		cfg.Plan.Save = &enabled
+
+	case "plan.html":
+		if cfg.Plan == nil {
+			cfg.Plan = &config.PlanConfig{}
+		}
+		cfg.Plan.HTML = config.StringPtr(value)
 
 	default:
 		return fmt.Errorf("setting %s not supported at repo level", key)
@@ -920,6 +994,22 @@ func unsetUserConfig(key string) error {
 			}
 		}
 
+	case "plan.save":
+		if cfg.Plan != nil {
+			cfg.Plan.Save = nil
+			if cfg.Plan.IsEmpty() {
+				cfg.Plan = nil
+			}
+		}
+
+	case "plan.html":
+		if cfg.Plan != nil {
+			cfg.Plan.HTML = nil
+			if cfg.Plan.IsEmpty() {
+				cfg.Plan = nil
+			}
+		}
+
 	default:
 		return fmt.Errorf("unknown user setting: %s", key)
 	}
@@ -982,6 +1072,22 @@ func unsetRepoConfig(key, projectRoot string) error {
 			}
 			if cfg.Hooks.UserPromptSubmit == nil {
 				cfg.Hooks = nil
+			}
+		}
+
+	case "plan.save":
+		if cfg.Plan != nil {
+			cfg.Plan.Save = nil
+			if cfg.Plan.IsEmpty() {
+				cfg.Plan = nil
+			}
+		}
+
+	case "plan.html":
+		if cfg.Plan != nil {
+			cfg.Plan.HTML = nil
+			if cfg.Plan.IsEmpty() {
+				cfg.Plan = nil
 			}
 		}
 

--- a/cmd/ox/hooks_claude_test.go
+++ b/cmd/ox/hooks_claude_test.go
@@ -787,6 +787,56 @@ func TestInstallProjectClaudeHooks_PreservesExistingPermissions(t *testing.T) {
 	assert.Len(t, allow, 3)
 }
 
+// TestPostToolUseHook_ManagedForPlanExitNudge documents and locks in the
+// dependency the plan-exit enrichment nudge relies on: the PostToolUse event
+// MUST be part of the managed ox hook install (that is the event Claude Code
+// fires after ExitPlanMode), MUST be idempotent (re-install adds no duplicate),
+// and MUST be removable via the managed uninstall path.
+// Failure prevented: someone drops PostToolUse from claudeLifecycleEvents and
+// the plan-exit nudge silently stops firing, or a non-removable hook leaks.
+func TestPostToolUseHook_ManagedForPlanExitNudge(t *testing.T) {
+	gitRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(gitRoot, ".claude"), 0o755))
+
+	// install — PostToolUse must be present (carrier of the plan-exit signal)
+	require.NoError(t, InstallProjectClaudeHooks(gitRoot))
+	assert.True(t, listProjectClaudeHooks(gitRoot)["PostToolUse"],
+		"PostToolUse hook must be installed — it carries the ExitPlanMode plan-exit nudge")
+
+	// idempotent — re-install adds no duplicate ox hook on the event
+	require.NoError(t, InstallProjectClaudeHooks(gitRoot))
+	settings, err := readProjectClaudeSettings(gitRoot)
+	require.NoError(t, err)
+	oxCount := 0
+	for _, entry := range settings.Hooks["PostToolUse"] {
+		for _, h := range entry.Hooks {
+			if isAnyOxCommand(h.Command) {
+				oxCount++
+			}
+		}
+	}
+	assert.Equal(t, 1, oxCount, "re-install must not duplicate the PostToolUse ox hook")
+
+	// the installed hook routes to `ox agent hook PostToolUse`, where the
+	// plan-exit branch lives
+	assert.Contains(t, settings.Hooks["PostToolUse"][0].Hooks[0].Command, "hook PostToolUse")
+
+	// removable — the managed remove primitive strips the PostToolUse ox hook,
+	// leaving the event clean. This is the same primitive doctor cleanup uses.
+	for i := range settings.Hooks["PostToolUse"] {
+		removeAnyOxHook(&settings.Hooks["PostToolUse"][i])
+	}
+	remaining := 0
+	for _, entry := range settings.Hooks["PostToolUse"] {
+		for _, h := range entry.Hooks {
+			if isAnyOxCommand(h.Command) {
+				remaining++
+			}
+		}
+	}
+	assert.Equal(t, 0, remaining, "PostToolUse ox hook must be removable via the managed remove primitive")
+}
+
 // --- getSharedClaudeSettingsPath / getLocalClaudeSettingsPath ---
 
 func TestSettingsPathHelpers(t *testing.T) {

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -1,0 +1,433 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/identity"
+	"github.com/sageox/ox/internal/plan"
+	"github.com/spf13/cobra"
+)
+
+var planCmd = &cobra.Command{
+	Use:   "plan",
+	Short: "Enrich an implementation plan with SageOx team context",
+	Long: `Enrich an agent-generated implementation plan with deterministic SageOx
+signals (collision, prior-art, expert-routing) and a context bundle the agent
+can reason over. ox computes badges locally — it never makes an LLM or network
+call in this path.
+
+Reads the active plan from --file or stdin. Use --json for the plumbing path
+(hook/agent), which emits the full Result as JSON and nothing else.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		file, _ := cmd.Flags().GetString("file")
+		jsonOut, _ := cmd.Flags().GetBool("json")
+
+		in, err := plan.Resolve(file, cmd.InOrStdin())
+		if err != nil {
+			return err
+		}
+
+		// No --file, no piped stdin, and nothing auto-discovered: there is no
+		// plan to enrich. Tell the human clearly instead of silently enriching
+		// an empty input (which yields a confusing all-zero summary).
+		if strings.TrimSpace(in.Raw) == "" {
+			fmt.Fprintln(cmd.OutOrStdout(),
+				"No plan found. Pass --file <plan.md>, pipe a plan on stdin, or save a plan-mode file to ~/.claude/plans/ first.")
+			return nil
+		}
+
+		// gitRoot is best-effort: detectors are fail-open, so an empty root
+		// simply yields fewer signals rather than an error.
+		gitRoot := findGitRoot()
+
+		result := plan.Enrich(context.Background(), in, gitRoot)
+
+		// --json is the plumbing path: no save, no metrics side effects that
+		// could perturb stdout. Emit the Result and nothing else.
+		if jsonOut {
+			return writePlanJSON(cmd, result)
+		}
+
+		// Porcelain path: optionally capture the plan to the ledger, then
+		// record a local metric (including whether it was saved), then print
+		// a concise human summary.
+		savedDir := maybeSavePlan(gitRoot, in, result)
+		plan.RecordPlanGenerated(result, savedDir != "")
+		return writePlanHuman(cmd, result, savedDir)
+	},
+}
+
+var planListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Browse saved ledger plans",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runPlanList(cmd)
+	},
+}
+
+var planViewCmd = &cobra.Command{
+	Use:   "view <slug>",
+	Short: "Open a saved plan",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		open, _ := cmd.Flags().GetBool("open")
+		return runPlanView(cmd, args[0], open)
+	},
+}
+
+var planSaveCmd = &cobra.Command{
+	Use:   "save",
+	Short: "Persist a fully-enriched plan (merged badges + optional HTML) to the ledger",
+	Long: `Persist a fully-enriched plan to the ledger. Unlike bare 'ox plan' — which
+auto-saves only the deterministic, ox-computed annotations — 'ox plan save' is the
+explicit full-plan persist path used by the ox-plan renderer skill after it has
+authored its judgment badges and (optionally) rendered the HTML.
+
+  --plan        the plan markdown (source for plan.md + topic/slug derivation)
+  --annotations a MERGED annotations.json: the 'ox plan --json' Result with the
+                agent-authored judgment badges appended (a full plan.Result)
+  --html        optional pre-rendered HTML; size-gated plain-git-vs-LFS per store.Save
+
+This command never renders HTML and never makes an LLM/network call — it only
+materializes the already-produced artifacts into the ledger working tree. It
+always saves (the skill is deliberately persisting), independent of the
+plan.save config.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runPlanSave(cmd)
+	},
+}
+
+// maybeSavePlan captures the enriched plan to the ledger when auto-save is
+// enabled and a ledger is configured. html is nil for now — the porcelain path
+// never renders HTML just to save it (that's a skill-side, opt-in action).
+// Returns the saved directory, or "" when nothing was saved (disabled, no
+// ledger, or a write error — capture is best-effort and never aborts the
+// command).
+func maybeSavePlan(gitRoot string, in plan.Input, result plan.Result) string {
+	if gitRoot == "" || !config.PlanSave(gitRoot) {
+		return ""
+	}
+
+	topic := planTopic(in)
+	meta := plan.Meta{
+		Topic:          topic,
+		Slug:           plan.Slugify(topic),
+		Authors:        planAuthors(gitRoot),
+		CreatedAt:      time.Now().UTC(),
+		SourcePlanPath: in.Path,
+	}
+
+	dir, err := plan.Save(gitRoot, in, result, nil, meta)
+	if err != nil {
+		// best-effort: a missing ledger or write failure must not break the
+		// enrichment output the agent is waiting on.
+		return ""
+	}
+	return dir
+}
+
+// runPlanSave persists a fully-enriched plan to the ledger from a plan markdown
+// file, a MERGED annotations.json (deterministic + judgment badges), and an
+// optional pre-rendered HTML file. This is the explicit full-plan persist path
+// the ox-plan skill calls — it always saves (no auto-save config gate) and never
+// renders HTML here (the skill already produced it).
+func runPlanSave(cmd *cobra.Command) error {
+	planPath, _ := cmd.Flags().GetString("plan")
+	annPath, _ := cmd.Flags().GetString("annotations")
+	htmlPath, _ := cmd.Flags().GetString("html")
+
+	if planPath == "" {
+		return fmt.Errorf("--plan is required: pass the plan markdown file")
+	}
+	if annPath == "" {
+		return fmt.Errorf("--annotations is required: pass the merged annotations.json")
+	}
+
+	// The plan markdown drives plan.md + topic/slug derivation.
+	in, err := plan.Resolve(planPath, nil)
+	if err != nil {
+		return err
+	}
+
+	// The merged annotations.json is a full plan.Result: ox's deterministic
+	// badges plus the agent-authored judgment badges the skill appended.
+	annBytes, err := os.ReadFile(annPath)
+	if err != nil {
+		return fmt.Errorf("read annotations %q: %w", annPath, err)
+	}
+	var result plan.Result
+	if err := json.Unmarshal(annBytes, &result); err != nil {
+		return fmt.Errorf("parse annotations %q: %w", annPath, err)
+	}
+
+	// Optional pre-rendered HTML. store.Save applies the size-gated
+	// plain-git-vs-LFS rule; we never render here.
+	var html []byte
+	if htmlPath != "" {
+		html, err = os.ReadFile(htmlPath)
+		if err != nil {
+			return fmt.Errorf("read html %q: %w", htmlPath, err)
+		}
+	}
+
+	gitRoot := findGitRoot()
+	topic := planTopic(in)
+	meta := plan.Meta{
+		Topic:          topic,
+		Slug:           plan.Slugify(topic),
+		Authors:        planAuthors(gitRoot),
+		CreatedAt:      time.Now().UTC(),
+		SourcePlanPath: planPath,
+	}
+
+	dir, err := plan.Save(gitRoot, in, result, html, meta)
+	if err != nil {
+		return fmt.Errorf("save plan: %w", err)
+	}
+
+	slog.Info("plan_saved", "dir", dir, "slug", meta.Slug, "html", htmlPath != "", "annotations", len(result.Annotations))
+	fmt.Fprintf(cmd.OutOrStdout(), "Saved plan to ledger: %s\n", dir)
+	return nil
+}
+
+// planTopic derives a human title for the plan: the first H1/H2 heading, else
+// the first non-empty line, else a fallback. Used for the slug and meta.Topic.
+func planTopic(in plan.Input) string {
+	for _, s := range in.Sections {
+		if h := strings.TrimSpace(s.Heading); h != "" {
+			return h
+		}
+	}
+	for _, line := range strings.Split(in.Raw, "\n") {
+		line = strings.TrimSpace(strings.TrimLeft(line, "# "))
+		if line != "" {
+			return line
+		}
+	}
+	return "untitled plan"
+}
+
+// planAuthors returns the capturing coworker's display name (privacy-safe, not
+// an email) when resolvable, else nil.
+func planAuthors(gitRoot string) []string {
+	ep := ""
+	if ctx, err := config.LoadProjectContext(gitRoot); err == nil && ctx != nil {
+		ep = ctx.Endpoint()
+	}
+	if name := identity.AttributionDisplayName(ep, ""); name != "" {
+		return []string{name}
+	}
+	return nil
+}
+
+// writePlanJSON emits the Result as indented JSON and nothing else. This is the
+// plumbing path the plan-exit hook and the agent call. It makes NO network/LLM
+// call (Enrich is pure-local).
+func writePlanJSON(cmd *cobra.Command, result plan.Result) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(result); err != nil {
+		return fmt.Errorf("encode plan result: %w", err)
+	}
+	_, err := buf.WriteTo(cmd.OutOrStdout())
+	return err
+}
+
+// writePlanHuman prints a concise summary: signal counts plus one line per
+// material annotation, where the plan was saved (if captured), and a hint that
+// an enriched HTML render is available via the ox-plan skill.
+func writePlanHuman(cmd *cobra.Command, result plan.Result, savedDir string) error {
+	out := cmd.OutOrStdout()
+	s := result.Signals
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Plan signals: %d collision(s), %d prior-art, %d expert route(s)\n",
+		s.Collisions, s.PriorArt, s.ExpertRoutes)
+
+	if len(result.Annotations) == 0 {
+		b.WriteString("No team-context signals fired for this plan.\n")
+	} else {
+		for _, a := range result.Annotations {
+			section := a.Section
+			if section == "" {
+				section = "(plan)"
+			}
+			fmt.Fprintf(&b, "  [%s] %s — %s\n", a.Type, section, a.Why)
+		}
+	}
+
+	if savedDir != "" {
+		fmt.Fprintf(&b, "\nSaved to ledger: %s\n", savedDir)
+	}
+
+	if s.Material {
+		b.WriteString("\nMaterial signals found. Render an enriched HTML plan via the ox-plan skill for faster human review.\n")
+	}
+
+	fmt.Fprint(out, b.String())
+	return nil
+}
+
+// runPlanList renders the saved plans as a table. Fail-open: outside a project
+// or with no plans, it prints a friendly empty-state instead of erroring.
+func runPlanList(cmd *cobra.Command) error {
+	out := cmd.OutOrStdout()
+	gitRoot := findGitRoot()
+
+	plans, err := plan.List(gitRoot)
+	if err != nil {
+		return fmt.Errorf("list plans: %w", err)
+	}
+	if len(plans) == 0 {
+		fmt.Fprintln(out, "No saved plans yet. Run 'ox plan' on an implementation plan to capture one.")
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, cli.StyleDim.Render("SLUG\tDATE\tHTML\tAUTHORS\tTOPIC"))
+	for _, p := range plans {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			p.Slug,
+			planDate(p.CreatedAt),
+			htmlMark(p.HasHTML),
+			authorsLabel(p.Authors),
+			truncate(p.Topic, 60),
+		)
+	}
+	return tw.Flush()
+}
+
+// runPlanView prints a saved plan's markdown plus a badge summary. When a
+// plan.html exists, it mentions the file; with --open (and a non-headless
+// terminal) it opens it in the browser, hydrating an LFS pointer first.
+func runPlanView(cmd *cobra.Command, slug string, open bool) error {
+	out := cmd.OutOrStdout()
+	gitRoot := findGitRoot()
+
+	planMD, res, info, err := plan.Load(gitRoot, slug)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, cli.StyleBrand.Render(info.Topic))
+	fmt.Fprintf(out, "%s  %s\n", cli.StyleDim.Render("slug:"+info.Slug), cli.StyleDim.Render(planDate(info.CreatedAt)))
+	if len(info.Authors) > 0 {
+		fmt.Fprintln(out, cli.StyleDim.Render("authors: "+strings.Join(info.Authors, ", ")))
+	}
+	fmt.Fprintln(out)
+
+	fmt.Fprintln(out, planMD)
+
+	writeBadgeSummary(out, res)
+
+	htmlPath, _, _, hasHTML := plan.PlanHTMLPath(info.Dir)
+	if !hasHTML {
+		return nil
+	}
+
+	fmt.Fprintf(out, "\nRendered HTML: %s\n", cli.StyleFile.Render(htmlPath))
+	if !open {
+		cli.PrintHint("Re-run with --open to view the rendered plan in your browser.")
+		return nil
+	}
+	if cli.IsHeadless() {
+		cli.PrintHint("Headless environment: open the HTML file above manually.")
+		return nil
+	}
+	return openPlanHTML(info.Dir)
+}
+
+// openPlanHTML opens a captured plan's plan.html in the browser. When the
+// in-place file is an LFS pointer (large render stored out-of-band), it is
+// hydrated to a temp file first so the browser opens real content, never a
+// 130-byte pointer. Hydration uses pure-Go LFS — never the git-lfs binary.
+func openPlanHTML(dir string) error {
+	path, _, isPointer, exists := plan.PlanHTMLPath(dir)
+	if !exists {
+		return fmt.Errorf("plan.html not found in %s", dir)
+	}
+	if !isPointer {
+		return cli.OpenInBrowser(path)
+	}
+	// Large render stored as an LFS pointer. Hydration via the Batch API is a
+	// follow-up (mirrors session hydrate); for now surface a clear message
+	// rather than opening a pointer stub.
+	cli.PrintHint("This plan's HTML is stored in LFS and not yet hydrated locally. Hydrate the ledger to view it.")
+	return nil
+}
+
+// writeBadgeSummary prints the stored Result's signal rollup and annotations.
+func writeBadgeSummary(out io.Writer, res plan.Result) {
+	s := res.Signals
+	fmt.Fprintf(out, "%s %d collision(s), %d prior-art, %d expert route(s)\n",
+		cli.StyleBold.Render("Signals:"), s.Collisions, s.PriorArt, s.ExpertRoutes)
+	for _, a := range res.Annotations {
+		section := a.Section
+		if section == "" {
+			section = "(plan)"
+		}
+		fmt.Fprintf(out, "  [%s] %s — %s\n", a.Type, section, a.Why)
+	}
+}
+
+func planDate(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	return t.Format("2006-01-02")
+}
+
+func htmlMark(has bool) string {
+	if has {
+		return "yes"
+	}
+	return "—"
+}
+
+func authorsLabel(authors []string) string {
+	if len(authors) == 0 {
+		return "—"
+	}
+	return strings.Join(authors, ", ")
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func init() {
+	planCmd.Flags().Bool("json", false, "emit the enrichment Result as JSON (plumbing path; no network/LLM call)")
+	planCmd.Flags().String("file", "", "plan source file (default: stdin, else newest ~/.claude/plans/*.md)")
+
+	planViewCmd.Flags().Bool("open", false, "open the rendered plan.html in your browser (if one was saved)")
+
+	planSaveCmd.Flags().String("plan", "", "plan markdown file (required; source for plan.md + topic/slug)")
+	planSaveCmd.Flags().String("annotations", "", "merged annotations.json: ox --json badges + agent judgment badges (required)")
+	planSaveCmd.Flags().String("html", "", "optional pre-rendered HTML; size-gated plain-git-vs-LFS on save")
+
+	planCmd.AddCommand(planListCmd)
+	planCmd.AddCommand(planViewCmd)
+	planCmd.AddCommand(planSaveCmd)
+
+	planCmd.GroupID = "dev"
+	rootCmd.AddCommand(planCmd)
+}

--- a/cmd/ox/plan_save_test.go
+++ b/cmd/ox/plan_save_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newPlanSaveTestCmd builds an isolated cobra command wired to runPlanSave with
+// the same flags the real `ox plan save` registers. Isolated (not the global
+// planSaveCmd) so flag state never leaks across tests.
+func newPlanSaveTestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		RunE: func(c *cobra.Command, _ []string) error { return runPlanSave(c) },
+	}
+	cmd.Flags().String("plan", "", "")
+	cmd.Flags().String("annotations", "", "")
+	cmd.Flags().String("html", "", "")
+	return cmd
+}
+
+func runPlanSaveWith(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newPlanSaveTestCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestPlanSave_RequiresPlanAndAnnotations verifies the cmd-level guards fire
+// before any filesystem work. Failure prevented: a malformed skill invocation
+// silently no-ops or panics instead of reporting the missing required input.
+func TestPlanSave_RequiresPlanAndAnnotations(t *testing.T) {
+	t.Run("missing --plan", func(t *testing.T) {
+		_, err := runPlanSaveWith(t, "--annotations", "ann.json")
+		if err == nil || !strings.Contains(err.Error(), "--plan is required") {
+			t.Fatalf("want --plan required error, got %v", err)
+		}
+	})
+
+	t.Run("missing --annotations", func(t *testing.T) {
+		_, err := runPlanSaveWith(t, "--plan", "plan.md")
+		if err == nil || !strings.Contains(err.Error(), "--annotations is required") {
+			t.Fatalf("want --annotations required error, got %v", err)
+		}
+	})
+}
+
+// TestPlanSave_BadAnnotationsJSONErrors verifies a corrupt merged
+// annotations.json surfaces a clear parse error rather than persisting a
+// half-baked Result. The merged file is agent-authored, so malformed input is a
+// realistic failure mode worth a precise message.
+func TestPlanSave_BadAnnotationsJSONErrors(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "plan.md")
+	annPath := filepath.Join(dir, "ann.json")
+	if err := os.WriteFile(planPath, []byte("## Plan\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(annPath, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runPlanSaveWith(t, "--plan", planPath, "--annotations", annPath)
+	if err == nil || !strings.Contains(err.Error(), "parse annotations") {
+		t.Fatalf("want parse-annotations error, got %v", err)
+	}
+}
+
+// TestPlanSave_MissingFilesError verifies missing input files are reported per
+// flag, not swallowed. A skill passing a stale path must learn which file is
+// absent.
+func TestPlanSave_MissingFilesError(t *testing.T) {
+	dir := t.TempDir()
+	annPath := filepath.Join(dir, "ann.json")
+	if err := os.WriteFile(annPath, []byte(`{"annotations":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runPlanSaveWith(t, "--plan", filepath.Join(dir, "nope.md"), "--annotations", annPath)
+	if err == nil {
+		t.Fatal("want error for missing --plan file, got nil")
+	}
+}

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ox plan` — team-context-enriched implementation plans** — turns a plan an AI coworker drafts into one that knows where the team is going. `ox plan` annotates each part of a plan with deterministic, locally-computed signals (zero model tokens): **collisions** (a file you're about to touch is in a teammate's open PR — or one they murmured about minutes ago, before any commit exists), **prior art** (a teammate already planned or did this — surfaced from the ledger), and **expert routing** (who owns this area, with cited evidence, so you ask the right person). The plan-mode agent then authors the judgment calls — does this align with or conflict with a team decision — reasoning over a context bundle ox assembles. ox makes no model call itself; the inference cost lands in plan mode where you already expect it. Finalized plans are saved to the team ledger (`data/plans/`) as first-class, searchable artifacts, so today's plan becomes tomorrow's prior art. On Claude Code, a renderer skill turns the enriched plan into a beautiful self-contained HTML page for fast human review; other agents get the same enrichment via guidance and the `ox plan` CLI. Configure with `plan.save` and `plan.html` (`off`/`recommend`/`always`), or `SAGEOX_PLAN_HTML` per-run.
+
 ## [0.9.0] - 2026-05-28
 
 ### Added

--- a/docs/adr/ADR-021-ox-plan-context-not-inference.md
+++ b/docs/adr/ADR-021-ox-plan-context-not-inference.md
@@ -1,0 +1,148 @@
+# ADR-021: `ox plan` — ox Provides Context, the Client Does Inference
+
+**Status**: Draft (Proposed) — **awaiting Ryan's review** on the storage path (§3) and config/env namespace (§4), both of which are Required-Review per `CLAUDE.md`.
+**Date**: 2026-06-03
+**Deciders**: SageOx Engineering (path + env-var decisions owned by Ryan)
+
+> **DRAFT.** This ADR records the intended decisions for the `ox plan` feature so Ryan can review the two Required-Review items before any code lands. Nothing here is built yet. The companion design write-up lives at `~/.claude/plans/system-instruction-you-are-working-enchanted-pearl.md`.
+
+## Context
+
+Plans today are generated **blind to team direction**. An agent in plan mode reasons from code plus the user's prompt. It cannot see whether the team already decided against the approach, whether it violates a convention, whether a teammate shipped it last week, whether a file in the plan sits in someone's open PR *right now*, or **who the expert** in that area is. SageOx holds every one of those signals in the Ledger and Team Context. No other planning tool does.
+
+The temptation is to make this a cloud feature: ship the plan to a hosted LLM "judge" that scores it against team context and returns verdicts. We are rejecting that. The agent is *already in plan mode*, already spending tokens to produce a good plan, and the user already expects to pay for inference there. ox's durable advantage is not another inference call — it is **privileged access to the team's data**. So the architecture splits cleanly: ox is the best *context provider* for planning; the client agent does the reasoning.
+
+This decision is the load-bearing one. Everything else (command surface, storage, config, agent support) follows from it.
+
+## Decision
+
+**ox provides context; the client does inference. ox never makes an LLM or network-judge call in the plan path.**
+
+### 1. The deterministic / judgment split
+
+Every plan signal is a **badge** attached to a plan section. Badges come in two kinds, and the kind determines who computes it.
+
+```mermaid
+flowchart TB
+  PLAN["Plan section"] --> DET["Deterministic badges: ox computes locally, zero model tokens"]
+  PLAN --> JUD["Judgment badges: client agent authors in plan mode"]
+
+  DET --> COL["Collision and active work: open PR, hotspot, or recent murmur on these files"]
+  DET --> PA["Prior art: a teammate already did or planned this"]
+  DET --> EX["Expert routing: who owns this area plus their relevant work"]
+
+  CTX["ox context bundle: recent murmurs, ranked sessions, decisions, ADRs, expert artifacts"] --> JUD
+  JUD --> AL["Aligns or conflicts: versus ADRs, decisions, conventions"]
+  JUD --> EXP["Expert perspective: synthesized stance, every claim cites a real artifact"]
+```
+
+| Badge | Kind | Produced by | Source data (all exists today) |
+|-------|------|-------------|--------------------------------|
+| **Collision / active work** | Deterministic | ox (local) | `codedb` open-PR / contention plus recent murmur scan (`metadata["files"]` / topic match, recency-weighted). Murmurs catch contention *before* any commit or PR exists. |
+| **Prior art** | Deterministic | ox (local) | Local-first: `codedb` FTS plus `ledgersearch` over sessions and captured plans; cloud `ox query` only as fallback. |
+| **Expert routing** | Deterministic | ox (local) | `codedb.commits` to `file_revs` author-per-path, murmur `principal_id` / topic, `glance.GroupByAuthor()`. |
+| **Aligns / conflicts** | Judgment | **client agent** | ox hands it Team Context, rules, and ADRs via the context bundle; the agent reasons. |
+| **Expert perspective** | Judgment | **client agent** | ox hands it the expert's sessions and discussions; the agent synthesizes a *grounded, cited* stance. |
+
+Deterministic badges are pure local SQL and keyword retrieval. They are free, always-on, and safe to fire ambiently on every plan from a hook. Judgment badges are authored by the plan-mode agent reasoning over ox's retrieved bundle, in the agent's own context window, where the user already expects token spend.
+
+**Expert fabrication is the one failure mode that kills trust.** Routing is deterministic and cited ("Ajit owns `internal/auth/`, N commits, last touched May; his session *token-refresh-race* is relevant"). Perspective is judgment, and *every claim must cite a real artifact* — a commit, a session, a discussion. When evidence is thin, the agent degrades to "consult [name]," never a fabricated quote.
+
+### 2. Command surface — porcelain versus plumbing
+
+Git-style split. `enrich` is plumbing humans never type; enrichment is simply what `ox plan` *is*.
+
+| Command | Audience | What it does | ox-side model tokens |
+|---------|----------|--------------|----------------------|
+| `ox plan` | human (skill-orchestrated) | active plan → pull signals + context bundle → *agent* authors judgment badges → render → auto-save | **0** (inference is the client's) |
+| `ox plan --json` | hook / agent | emit deterministic badges + retrieved context bundle as JSON | **0** — pure local SQL / keyword + retrieval |
+| `ox plan list` | human | browse saved Ledger plans (parallels `ox session list`) | 0 |
+| `ox plan view <slug>` | human | open a saved plan (parallels `ox session view`) | 0 |
+
+The `--json` primitive returns both the deterministic badges *and* a `context[]` array (ranked refs plus loaded snippets), so the agent gets everything in one local call. The plan-exit hook consumes just the badges; the skill additionally feeds the context to the agent for judgment badges.
+
+### 3. Plan storage in the Ledger — **Required-Review (Ryan owns this)**
+
+Grounded in the current layout: sessions live at `<ledger>/sessions/<name>/`, and **murmurs already use `<ledger>/data/murmurs/YYYY-MM-DD/HH/`**. The dated `data/` pattern is precedented, so finalized plans mirror it:
+
+```
+<ledger>/data/plans/YYYY-MM-DD-<2-4-word-slug>/
+  ├── plan.md           # enriched markdown source (badges inline / frontmatter)
+  ├── annotations.json  # structured badges {section, badge, why, source_url, expert} — searchable
+  ├── meta.json         # {topic, authors[], created_at, reviewed_by, approved}
+  └── plan.html         # rendered beauty — COMMITTED, but ONLY if already rendered
+```
+
+- **Auto-save is default-on** (`plan.save=true`). Plans are sanitized *output*, far less sensitive than session recordings (which expose raw human thinking), so always-save is an easy default. This makes plans first-class Ledger artifacts: searchable, attributable, reusable — the flywheel where team #2's plans are better because of team #1's recorded work.
+- **Commit the rendered HTML when it exists.** The Mermaid diagrams, device mockups, and swimlane timelines are **LLM-authored and non-deterministic** — regenerating means re-running a model and getting *different* output, at real cost. So `plan.html` is canonical alongside `plan.md`, preserving the exact artifact the human approved. (Contrast `session.md`'s web view, which is a deterministic render and need not be committed.)
+- **Never render HTML solely to populate the Ledger.** Auto-save persists *what the user actually produced*: always `plan.md` + `annotations.json` + `meta.json`; add `plan.html` **only if one was already rendered**. Burning client tokens on a render the human never asked to see, just to fill the Ledger, is the wrong trade.
+- **LFS for large inline imagery.** If a `plan.html` embeds large base64 imagery, it stores via LFS (like `raw.jsonl`) through `internal/lfs/` — never the `git-lfs` binary, per `.claude/rules/lfs-no-git-lfs-binary.md`. Otherwise git-track directly.
+
+Path construction goes through a new `paths.LedgerPlansDir()` helper, not hand-joined strings.
+
+### 4. Config and env namespace — **Required-Review (Ryan owns this)**
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `plan.save` | `true` | Persist finalized plans to `data/plans/`. |
+| `plan.html` | `recommend` | Enriched-HTML render mode, tri-state: `off` (never render, never nudge), `recommend` (prime nudges, render on confirm), `always` (auto-render). |
+| `SAGEOX_PLAN_HTML` | unset | Direct env override for `plan.html` — must be `off`, `recommend`, or `always`. |
+
+**`SAGEOX_*` is canonical for customer-facing identity; a customer-facing `OX_*` env var is an anti-pattern** (sageox-mono ADR-047, `docs/human/adr/047-customer-facing-env-var-namespace.md`). The env var is therefore `SAGEOX_PLAN_HTML`, not `OX_PLAN_HTML`.
+
+### 5. Agent-agnostic support, graduated by tier
+
+The CLI/JSON contract is the baseline and works for **every** coding agent: any agent can call `ox plan --json`, read the badges and context, and act on them. Polish is layered on top, not gated all-or-nothing.
+
+| Tier | Mechanism | Agents |
+|------|-----------|--------|
+| Baseline | `ox plan` / `ox plan --json` CLI contract | all coding agents |
+| Polished | Claude Code skill + plan-exit hook (shipped by `ox init`); Codex plugin | first-class targets |
+| Adapter | `ox-adapter-*` capability bridges the contract to other agents | everyone else |
+
+This follows ADR-009 (`ox-adapter-*` naming) and ADR-008 (external adapter binaries): the secret sauce stays in ox's data access, and the adapter layer exposes it to agents we do not ship a native integration for. Support is graduated, not binary.
+
+### 6. Prime integration
+
+Most users never type a plan command — they use the agent's built-in plan mode, which silently writes a markdown plan file. ox gets in the loop three ways, all mirroring mechanisms ox already uses:
+
+1. **`<plan-enrichment-guidance>` block in `ox agent prime`** (parallel to the existing `<rule-promotion-guidance>`): when the agent produces a plan for non-trivial work (multi-file, architectural, touches a hotspot or open PR, or roughly ≥5 steps), it recommends an enriched render. Silenceable via `plan.html=off`; kept from nagging on one-line plans by the heuristic.
+2. **A new `IntentCommand`** mapping intent "render / enrich a plan" to `ox plan`.
+3. **A plan-exit hook** (shipped by `ox init`, like the prime hook): on plan-file write it runs `ox plan --json` locally (0 tokens); if badges are material, the agent surfaces a one-line nudge ("Plan touches 2 files in open PRs and conflicts with 1 ADR — render enriched plan?").
+
+The HTML render is **opt-in / confirm by default**: fast badges compute silently; the *recommendation* appears only when the plan is complex or badges are material; the render waits for confirm unless the user opted in via `plan.html=always` or `SAGEOX_PLAN_HTML=always`.
+
+## Consequences
+
+### Positive
+
+- **The moat is data access, not an inference call.** A competitor can buy the same model; they cannot buy the team's Ledger. Keeping inference client-side is consistent with "keep our secret sauce in the SageOx cloud / behind APIs."
+- **ox spends zero LLM tokens in the plan path.** Every `ox plan` operation is deterministic local work, so the plan-exit hook can fire ambiently on every plan and the deterministic badges can always be on.
+- **No cloud judge service to build, run, secure, or scale.** Simpler architecture, fewer trust boundaries, no per-plan cloud round-trip on a latency-sensitive path.
+- **Plans become first-class Ledger artifacts** — searchable, attributable, reusable across teams.
+- **Inference cost lands where the user already expects it** — in plan mode, in the agent's own context window.
+- **Works on day one for cold-start teams** via collision + expert-routing (pure local SQL over git/`codedb`), with no recorded discussions required.
+
+### Negative / risks
+
+- **Cold start for judgment badges.** Empty teams get no aligns/prior-art until they have recorded work. Mitigation: lead with collision + expert-routing, which work from git/`codedb` immediately.
+- **Expert fabrication.** A synthesized stance that invents an opinion would destroy trust. Mitigation: cite-or-degrade — every perspective claim cites a real artifact, or downgrades to "consult [name]."
+- **False conflicts.** A judgment badge that flags a non-existent conflict erodes confidence. Mitigation: precision over recall; downgrade to "Novel" when unsure.
+- **Latency on plan exit.** The fast tier must be local and sub-second; it must never block plan-exit on a cloud call. Enforced by the zero-network rule.
+- **Renderer drift.** The ox renderer forks `html-plan` and will diverge over time. Accept, or periodically reconcile.
+- **Retrieval ceiling.** v1 rides keyword retrieval (`ledgersearch` whole-document TF, `codedb` Bleve FTS) — there is no semantic/vector index or sub-document chunking yet. Good enough for prior-art recall; a chunked/semantic plan index is a fast-follow refreshed by the daemon's existing `BuildLedgerIndex()` path.
+
+## Alternatives considered
+
+- **Cloud LLM judge (rejected).** Ship the plan to a hosted model that scores it against team context and returns verdicts. Rejected because it puts the moat in the wrong place (inference is a commodity; data access is not), adds a cloud service to build/run/secure, introduces a per-plan network round-trip on a latency-sensitive path, and bills the user for inference twice (once in plan mode, again in the cloud). `ox plan deep` and any cloud-judge variant are dropped.
+- **`enrich` as a user-facing verb (rejected).** An `ox plan enrich` command that humans type. Rejected because enrichment is not a separate step — it is what `ox plan` *is*. `enrich` is plumbing; exposing it as porcelain adds a verb with no distinct user intent. The plumbing surface is `ox plan --json`.
+- **HTML render on every save (rejected).** Always render `plan.html` so the Ledger is uniformly rich. Rejected as token-wasteful: rendering an artifact the human never asked to see, purely to populate the Ledger, burns client tokens for no human benefit. HTML is committed-when-it-exists, not generated-on-save.
+
+## References
+
+- `~/.claude/plans/system-instruction-you-are-working-enchanted-pearl.md` — full `ox plan` design write-up this ADR distills.
+- ADR-008: External Adapter Binaries — the adapter model §5 builds on.
+- ADR-009: Naming Convention `ox-adapter-*` — the `ox-adapter-*` exposure tier in §5.
+- ADR-016: Session Summarization Delegation — prior art for "calling agent does the LLM work, ox does not," the same client-side-inference principle applied to summaries.
+- sageox-mono ADR-047 (`docs/human/adr/047-customer-facing-env-var-namespace.md`) — the `SAGEOX_*` canonical / customer-facing `OX_*` anti-pattern rule that fixes §4's env var name.
+- `.claude/rules/lfs-no-git-lfs-binary.md` — why large `plan.html` imagery goes through `internal/lfs/`, never the `git-lfs` binary.

--- a/docs/adr/ADR-021-ox-plan-context-not-inference.md
+++ b/docs/adr/ADR-021-ox-plan-context-not-inference.md
@@ -100,7 +100,7 @@ The CLI/JSON contract is the baseline and works for **every** coding agent: any 
 | Polished | Claude Code skill + plan-exit hook (shipped by `ox init`); Codex plugin | first-class targets |
 | Adapter | `ox-adapter-*` capability bridges the contract to other agents | everyone else |
 
-This follows ADR-009 (`ox-adapter-*` naming) and ADR-008 (external adapter binaries): the secret sauce stays in ox's data access, and the adapter layer exposes it to agents we do not ship a native integration for. Support is graduated, not binary.
+This follows ADR-009 (`ox-adapter-*` naming) and ADR-008 (external adapter binaries): the durable value stays in ox's data access, and the adapter layer exposes it to agents we do not ship a native integration for. Support is graduated, not binary.
 
 ### 6. Prime integration
 
@@ -116,7 +116,7 @@ The HTML render is **opt-in / confirm by default**: fast badges compute silently
 
 ### Positive
 
-- **The moat is data access, not an inference call.** A competitor can buy the same model; they cannot buy the team's Ledger. Keeping inference client-side is consistent with "keep our secret sauce in the SageOx cloud / behind APIs."
+- **The durable value is data access, not an inference call.** Any model can score a plan; the team's Ledger is what ox uniquely brings. Keeping inference client-side keeps ox's value in the data and context it provides.
 - **ox spends zero LLM tokens in the plan path.** Every `ox plan` operation is deterministic local work, so the plan-exit hook can fire ambiently on every plan and the deterministic badges can always be on.
 - **No cloud judge service to build, run, secure, or scale.** Simpler architecture, fewer trust boundaries, no per-plan cloud round-trip on a latency-sensitive path.
 - **Plans become first-class Ledger artifacts** — searchable, attributable, reusable across teams.
@@ -134,7 +134,7 @@ The HTML render is **opt-in / confirm by default**: fast badges compute silently
 
 ## Alternatives considered
 
-- **Cloud LLM judge (rejected).** Ship the plan to a hosted model that scores it against team context and returns verdicts. Rejected because it puts the moat in the wrong place (inference is a commodity; data access is not), adds a cloud service to build/run/secure, introduces a per-plan network round-trip on a latency-sensitive path, and bills the user for inference twice (once in plan mode, again in the cloud). `ox plan deep` and any cloud-judge variant are dropped.
+- **Cloud LLM judge (rejected).** Ship the plan to a hosted model that scores it against team context and returns verdicts. Rejected because it puts ox's value in the wrong place (inference is a commodity; data access is not), adds a cloud service to build/run/secure, introduces a per-plan network round-trip on a latency-sensitive path, and bills the user for inference twice (once in plan mode, again in the cloud). `ox plan deep` and any cloud-judge variant are dropped.
 - **`enrich` as a user-facing verb (rejected).** An `ox plan enrich` command that humans type. Rejected because enrichment is not a separate step — it is what `ox plan` *is*. `enrich` is plumbing; exposing it as porcelain adds a verb with no distinct user intent. The plumbing surface is `ox plan --json`.
 - **HTML render on every save (rejected).** Always render `plan.html` so the Ledger is uniformly rich. Rejected as token-wasteful: rendering an artifact the human never asked to see, purely to populate the Ledger, burns client tokens for no human benefit. HTML is committed-when-it-exists, not generated-on-save.
 

--- a/docs/ai/specs/agent-support-matrix.md
+++ b/docs/ai/specs/agent-support-matrix.md
@@ -53,6 +53,72 @@ Agent-specific hooks (`ox integrate install --<agent>`) are *additive* — they 
 | Per-prompt suspended nudge | Yes (UserPromptSubmit) | Yes (BeforeAgent equivalent) | Limited (no push channel) | Limited | Possible (tui.prompt.append) |
 | `/clear` boundary + pause inheritance | Yes | N/A (different lifecycle) | N/A (different lifecycle) | N/A | N/A |
 | Upload mask honoring lifecycle | Yes (adapter-agnostic) | Yes | Yes | Yes (lifecycle-only; cloud-side data not gated) | Yes |
+| **Plan enrichment** (`ox plan`) | | | | | |
+| `ox plan --json` baseline (0-token, no network) | Yes (any agent can run it) | Yes | Yes | Yes | Yes |
+| Real-time plan-exit nudge | Yes (PostToolUse on ExitPlanMode → UserPromptSubmit) | Guidance-only | Guidance-only | Guidance-only | Guidance-only |
+| Tiered prime guidance for `ox plan` | Gold block + IntentCommand | Silver block + IntentCommand | Silver block + IntentCommand | Bronze note | Bronze note |
+
+## Plan Enrichment (`ox plan`)
+
+`ox plan` enriches an agent-generated implementation plan with deterministic
+SageOx signals (collision / prior-art / expert-route). `ox plan --json` is the
+plumbing path: 0 tokens, no LLM, no network — it computes badges locally. There
+are three graduated levels of exposure:
+
+| Level | Who | Mechanism |
+|-------|-----|-----------|
+| **Baseline (all agents)** | Every agent | `ox plan --json` is a plain CLI command. Any agent that can run a shell command can invoke it. Nothing to install. |
+| **Guidance fallback (Silver/Bronze)** | codex, gemini (Silver); amp, opencode, pi (Bronze) | No real-time hook. The tiered prime guidance (`internal/prime`, agent-tier-aware) tells the agent that `ox plan` exists. Silver gets the full advisory block + IntentCommand; Bronze gets the lighter note. The agent decides when to run it. |
+| **Real nudge (Gold — Claude Code only)** | claude-code | A PostToolUse hook fires after the `ExitPlanMode` tool. ox enriches the approved plan via `ox plan --json`; if `signals.material` is true, it stashes a one-line nudge that the next `UserPromptSubmit` delivers into model context. |
+
+### Why the Gold nudge uses PostToolUse → UserPromptSubmit (not PostToolUse stdout)
+
+Claude Code's closest plan-exit signal is the **PostToolUse** event firing after
+`ExitPlanMode`. But Claude Code **discards PostToolUse stdout** (empirically
+confirmed — see the channel table in `cmd/ox/agent_hook.go`), so a nudge emitted
+directly from the PostToolUse handler never reaches the model.
+
+The wiring therefore splits across two events:
+
+1. **Detect (PostToolUse):** `handleAfterTool` already runs on every tool. A
+   narrow branch — strictly gated on `ToolName == "ExitPlanMode"` — runs
+   `ox plan --json` against the approved plan text and, if material, writes a
+   single one-line nudge to `.sageox/cache/plan-nudge/<agentID>.txt`. Every
+   other tool is untouched, so this is **not** a noisy always-on hook; it reuses
+   the PostToolUse hook that `ox init` / `ox doctor` already manage.
+2. **Deliver (UserPromptSubmit):** `handlePrompt` — the only Claude Code channel
+   whose stdout is injected into model context — drains the pending nudge as a
+   `<system-reminder>` on the user's next turn (which is exactly when execution
+   begins after plan approval), then removes the file (deliver-once).
+
+The nudge is fail-open and stale-bounded (30 min): any error or a never-followed
+plan exit leaves existing hook behavior completely untouched.
+
+```mermaid
+flowchart LR
+    EPM["ExitPlanMode tool"] --> PTU["PostToolUse hook<br/>(handleAfterTool)"]
+    PTU -->|"ToolName == ExitPlanMode"| ENR["ox plan --json"]
+    ENR -->|"signals.material"| STASH["stash one-line nudge<br/>.sageox/cache/plan-nudge"]
+    UPS["next UserPromptSubmit<br/>(handlePrompt)"] --> DRAIN["drain + deliver as<br/>system-reminder, then remove"]
+    STASH -.->|"deliver-once on next turn"| DRAIN
+```
+
+### Silver / Bronze degradation
+
+Silver (codex, gemini) and Bronze (amp, opencode, pi) get **no real-time hook**
+— they rely on the already-shipped tiered prime guidance plus the baseline
+`ox plan --json` command. Nothing in the plan-exit wiring breaks them: the
+PostToolUse branch is gated on `ToolName == "ExitPlanMode"` (a Claude-Code tool
+name), so for other agents it is simply never taken. No per-agent install is
+required for plan enrichment beyond what each tier already has.
+
+### No new adapter capability
+
+The Gold nudge rides entirely on the existing `PostToolUse` lifecycle hook
+(already in `claudeLifecycleEvents`) and the `ox agent hook PostToolUse` routing.
+It is managed by the same `ox init` / `ox doctor` install path and the existing
+`CapHookInstaller` adapter capability — no new `pkg/adapterprotocol` capability
+was added.
 
 ## Overall Tier Status
 

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -1,0 +1,49 @@
+---
+title: "ox plan"
+description: "CLI reference for ox plan"
+sidebar_position: 67
+---
+
+## ox plan
+
+Enrich an implementation plan with SageOx team context
+
+### Synopsis
+
+Enrich an agent-generated implementation plan with deterministic SageOx
+signals (collision, prior-art, expert-routing) and a context bundle the agent
+can reason over. ox computes badges locally — it never makes an LLM or network
+call in this path.
+
+Reads the active plan from --file or stdin. Use --json for the plumbing path
+(hook/agent), which emits the full Result as JSON and nothing else.
+
+```
+ox plan [flags]
+```
+
+### Options
+
+```
+      --file string   plan source file (default: stdin, else newest ~/.claude/plans/*.md)
+  -h, --help          help for plan
+      --json          emit the enrichment Result as JSON (plumbing path; no network/LLM call)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+* [ox plan list](/plan/list)	 - Browse saved ledger plans
+* [ox plan save](/plan/save)	 - Persist a fully-enriched plan (merged badges + optional HTML) to the ledger
+* [ox plan view](/plan/view)	 - Open a saved plan
+

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -1,0 +1,35 @@
+---
+title: "ox plan list"
+description: "CLI reference for ox plan list"
+sidebar_position: 68
+---
+
+## ox plan list
+
+Browse saved ledger plans
+
+```
+ox plan list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox plan](/plan)	 - Enrich an implementation plan with SageOx team context
+

--- a/docs/reference/plan/save.mdx
+++ b/docs/reference/plan/save.mdx
@@ -1,0 +1,55 @@
+---
+title: "ox plan save"
+description: "CLI reference for ox plan save"
+sidebar_position: 69
+---
+
+## ox plan save
+
+Persist a fully-enriched plan (merged badges + optional HTML) to the ledger
+
+### Synopsis
+
+Persist a fully-enriched plan to the ledger. Unlike bare 'ox plan' — which
+auto-saves only the deterministic, ox-computed annotations — 'ox plan save' is the
+explicit full-plan persist path used by the ox-plan renderer skill after it has
+authored its judgment badges and (optionally) rendered the HTML.
+
+  --plan        the plan markdown (source for plan.md + topic/slug derivation)
+  --annotations a MERGED annotations.json: the 'ox plan --json' Result with the
+                agent-authored judgment badges appended (a full plan.Result)
+  --html        optional pre-rendered HTML; size-gated plain-git-vs-LFS per store.Save
+
+This command never renders HTML and never makes an LLM/network call — it only
+materializes the already-produced artifacts into the ledger working tree. It
+always saves (the skill is deliberately persisting), independent of the
+plan.save config.
+
+```
+ox plan save [flags]
+```
+
+### Options
+
+```
+      --annotations string   merged annotations.json: ox --json badges + agent judgment badges (required)
+  -h, --help                 help for save
+      --html string          optional pre-rendered HTML; size-gated plain-git-vs-LFS on save
+      --plan string          plan markdown file (required; source for plan.md + topic/slug)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox plan](/plan)	 - Enrich an implementation plan with SageOx team context
+

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -1,0 +1,36 @@
+---
+title: "ox plan view"
+description: "CLI reference for ox plan view"
+sidebar_position: 70
+---
+
+## ox plan view
+
+Open a saved plan
+
+```
+ox plan view <slug> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for view
+      --open   open the rendered plan.html in your browser (if one was saved)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox plan](/plan)	 - Enrich an implementation plan with SageOx team context
+

--- a/extensions/claude/commands/ox-plan.md
+++ b/extensions/claude/commands/ox-plan.md
@@ -1,0 +1,169 @@
+<!-- Keep behavioral "when to render" guidance lean — that belongs in the
+     `ox plan` JSON output (signals.material, guidance) and in the
+     <plan-enrichment-guidance> block from `ox agent prime`, not duplicated here.
+     What legitimately lives in THIS skill is the RENDERING SPEC: how to draw the
+     enriched HTML plan (forked from html-plan) plus the badge-native layout. That
+     is substantive skill content, not command guidance. Skills are agent-specific
+     wrappers; ox serves all agents — keep ox-CLI behavior in the CLI. -->
+Render a SageOx team-enriched implementation plan as a beautiful, self-contained HTML page for human review. Forks the html-plan quality bar (Mermaid diagrams, light/dark toggle, fit-to-column diagrams, CSS swimlane timelines, SageOx palette, scroll-spy nav) and adds badge-native layout: a per-section badge rail, an alignment-summary strip, and source links that resolve to the cited ledger artifact / ADR / open PR.
+
+Use when the user asks to "render the plan", "make an HTML plan", "show the enriched plan", "visualize this plan with team context", runs `/ox-plan`, or when `ox plan` reports material signals and the user confirms a render. **Whether to render at all is decided by the `ox plan` JSON (`signals.material`, `guidance`) + the user's confirmation / `plan.html` config — not by this skill.** Do not nag on trivial plans; honor the command's signal.
+
+---
+
+## Orchestration (what this skill does)
+
+```mermaid
+flowchart TB
+  RUN["Run ox plan --json on the active plan"] --> DET["ox returns DETERMINISTIC badges + context bundle (0 LLM tokens)"]
+  DET --> READ["Agent reads the context bundle: murmurs, sessions, decisions, ADRs, expert artifacts"]
+  READ --> JUDGE["Agent authors JUDGMENT badges, CITED-ONLY (aligns / conflicts / expert-perspective)"]
+  JUDGE --> MERGE["Merge: ox --json annotations + agent judgment badges into one annotations.json"]
+  MERGE --> GATE{"Render confirmed? (user asked OR plan.html recommend + confirm)"}
+  GATE -->|"no"| SAVEMD["ox plan save with merged annotations, no html"]
+  GATE -->|"yes"| HTML["Render ONE self-contained HTML inheriting html-plan quality + badge-native layout"]
+  HTML --> SAVEHTML["ox plan save with merged annotations + html"]
+```
+
+1. **Get the deterministic signals + context bundle.** Run:
+
+   ```bash
+   ox plan --json --file <plan-file>   # or pipe the plan on stdin
+   ```
+
+   This makes **no LLM or network call**. It returns a `Result` JSON:
+   - `annotations[]` — deterministic, ox-computed badges: `collision`, `prior-art`, `expert-routing`. Each carries `{section, kind:"deterministic", type, why, source_url, expert, files}`. These are **factual** — render them as-is, do not second-guess them.
+   - `context[]` — the pre-retrieved bundle the agent reasons over: `{kind: murmur|session|decision|adr|commit|discussion, title, ref, snippet, score, author, when}`.
+   - `signals` — `{collisions, prior_art, expert_routes, material}`. `material` is ox's call on whether a render is worth recommending.
+
+2. **Author the JUDGMENT badges (the agent's job — ox does NO inference).** Read the `context[]` bundle and produce judgment annotations:
+   - `aligns` / `conflicts` — does the plan agree or clash with a cited ADR, decision, or convention?
+   - `expert-perspective` — the synthesized stance of the area expert.
+
+   **CITED-ONLY is non-negotiable.** Every judgment badge MUST point at a real artifact from the bundle (`ref` / `source_url`): a specific ADR, decision doc, session, commit, or discussion. Rules:
+   - Never invent an opinion, a quote, or a conflict. Precision over recall.
+   - When the evidence is **thin or ambiguous, degrade to a routing nudge** — `expert-perspective` becomes "consult `<name>`" (naming the expert from `annotations[].expert`), NOT a fabricated stance. Putting words in a teammate's mouth is the one failure mode that destroys trust.
+   - When unsure whether a conflict is real, downgrade to "Novel — no prior decision found," not a false `conflicts`.
+   - Set `kind:"judgment"` on every badge you author so the renderer can style it distinctly from ox's deterministic ones.
+
+3. **Render ONE self-contained HTML file** meeting the full html-plan quality bar below PLUS the badge-native additions.
+
+4. **Persist the full plan with `ox plan save`.** Bare `ox plan` only auto-saves ox's *deterministic* badges (it cannot see your judgment badges). To persist the complete plan — your merged badges plus the render — call:
+
+   ```bash
+   ox plan save --plan <plan-file> --annotations <merged.json> [--html <render.html>]
+   ```
+
+   - `--annotations <merged.json>` is the **merged** annotations: take the `ox plan --json` Result and **append your judgment badges** to its `annotations[]` array (keep `signals`, `context`, and the deterministic badges intact). That merged file is what gets stored as `annotations.json`.
+   - `--html` is optional: pass it only when you rendered HTML this run. `ox plan save` applies the size-gated plain-git-vs-LFS rule — it never renders.
+   - `ox plan save` always persists (it is an explicit save), reuses the `data/plans/YYYY-MM-DD-<slug>/` path, and prints where it saved.
+
+5. **Honor the storage / UX rules.** Render only when appropriate (the user asked, or confirmed per `plan.html`). **Never render HTML just to populate the ledger.** The `plan.html` you render here is the canonical, committed artifact `ox plan save` stores; it is preserved exactly (it's LLM-authored and non-deterministic — re-rendering yields different output).
+
+---
+
+## Output location
+
+- Inside a repo/workspace: write to `.context/<slug>-plan.html` (create `.context/` if missing — it is the gitignored collaboration dir), then pass it as `--html` to `ox plan save`, which promotes it into the ledger at `data/plans/YYYY-MM-DD-<slug>/plan.html`.
+- No workspace: write to `~/.claude/plans/<slug>-plan.html`.
+- After writing, open the file so the reviewer sees it immediately, then tell the user the exact path.
+
+---
+
+## Badge-native layout (the additions over html-plan)
+
+These are what make this an *enriched* plan, not just a pretty one. The human must instantly see (a) which signals fired, (b) which are factual vs. judged, and (c) where each claim comes from.
+
+**1. Alignment-summary strip (top of page, above the TL;DR).** A compact horizontal strip of counts pulled straight from `signals` + your authored judgment badges:
+
+> **`N aligns` · `M conflicts` · `K collisions` · `E expert routes`**
+
+Use the SageOx semantic colors: sage for aligns, red for conflicts, amber for collisions/active-work, copper for expert routes. Each count is a chip; clicking/anchoring it can jump to the first section carrying that badge. This is the "should I even keep reading" glance.
+
+**2. Per-section badge rail.** Every plan section renders its badges in a right-aligned rail (or a row directly under the H2). A badge shows: an icon/dot, the type label, and a **source link** when `source_url`/`ref` is present. Collapse multiple badges of the same type into a count chip that expands.
+
+**3. Deterministic vs. judgment — visually distinct.** The human must always know which badges ox *computed* (factual) and which the agent *authored* (cited judgment). Make the treatment unmistakable:
+
+| Kind | Treatment | Why |
+|---|---|---|
+| **Deterministic** (`kind:"deterministic"`) | Solid fill, a small "ox" / circuit glyph, no hedging copy | ox computed it locally from git/codedb/murmurs — it is a fact |
+| **Judgment** (`kind:"judgment"`) | Outlined (not filled), a "reasoned" glyph, always shows its citation link, hedged verb ("appears to conflict with…") | the agent inferred it — the human should trust-but-verify via the citation |
+
+Put a tiny legend near the alignment strip ("● ox-computed · ○ agent-reasoned, cited") so the encoding is self-explanatory.
+
+**4. Source links resolve to the cited artifact.** Every badge with a citation links to the real thing:
+- **Open PR / collision** → the PR URL from `source_url`.
+- **Prior art / session** → a session reference. Where there's no web URL, surface the `ox session view <name>` command as the resolution and link the ledger path.
+- **ADR / decision** → the ADR/decision doc path or URL from `ref`/`source_url`.
+- **Expert routing** → the expert's named artifact (their relevant session/commit), and the expert's name from `annotations[].expert`.
+
+A judgment badge with no resolvable citation is a bug — degrade it to "consult `<name>`" instead.
+
+---
+
+## html-plan quality bar (inherited — all non-negotiable)
+
+**Self-contained.** One `.html` file. No build step, no local assets. Libraries only via CDN (Mermaid from jsdelivr). Must render from `file://`.
+
+**Diagrams do the heavy lifting.** Prefer a diagram over a paragraph wherever a relationship, flow, state machine, sequence, or before/after exists. Use **Mermaid** (`flowchart`, `sequenceDiagram`, `stateDiagram-v2`, `gantt` as fits). Every plan gets at least one "the shape in one picture" diagram near the top. Apply the **GitHub-strict Mermaid rules from CLAUDE.md**: double-quote every node label containing anything beyond `[A-Za-z0-9 ]`; never use arrow-shaped substrings (`->`, `=>`, `<->`) inside labels even when quoted — substitute `to`, `→`, or a comma; never use reserved-ish IDs (`PR`, `URL`, `IO`, `IS`, `AS`, `END` — rename to `DPR`, `DURL`, etc.); quote path-shaped labels (`/`, `*`); use `<br/>` not `\n` for line breaks. These make diagrams render everywhere, not just locally.
+
+**Size every diagram for the human eye — fit the viewport in BOTH axes.** A diagram that overflows the screen is as useless as one shrunk to a postage stamp. Target: the whole diagram comfortably visible at a readable node size without scrolling. Put in the page CSS:
+- `.mermaid svg { max-width:100% !important; max-height:78vh !important; height:auto !important; width:auto !important }` — fit the content column, cap height. **Do NOT add a fixed-px width cap** (e.g. `min(100%,640px)`) — it crushes legitimately wide diagrams like multi-actor sequence diagrams into unreadable thumbnails.
+- Tighten Mermaid spacing: `flowchart:{ nodeSpacing:34, rankSpacing:34, padding:8, useMaxWidth:true }`, `sequence:{ useMaxWidth:true }`, `state:{ useMaxWidth:true }`, ~13px base `fontSize`.
+- A **sequence diagram** is as wide as its actor count: use **≤ 4–5 participants** and **short actor aliases** (`I as I2S init`, not `i2s_full_duplex_init`). If still too wide, split the flow into two diagrams rather than shrink it illegibly.
+
+Shape rules:
+- Prefer **vertical growth** — `flowchart TB` for long chains so they extend down the page (which scrolls) instead of off the right edge.
+- For a row of **disconnected nodes** (a list, a before/after group), force them into a narrow column by chaining with **invisible links** (`A1 ~~~ A2 ~~~ A3`) inside a `direction TB` subgraph.
+- Keep any single rank to **≤ ~4 nodes**; shorten labels; use `<br/>` to wrap long edge labels.
+- If a diagram can't fit ~72vh at a readable size, it's doing too much — **split into stacked sub-diagrams**, each of which fits.
+
+**Timing & sequencing — make time legible.** Most plans have a temporal spine; surface it. Include at least one timing visual whenever the plan has phases, real-time deadlines, async/concurrent work, a rollout, or a latency budget:
+
+| The plan involves… | Use | Notes |
+|---|---|---|
+| Implementation phases / rollout / relative-effort sequencing | **Hand-built CSS swimlane timeline** | The robust default. Lanes = workstreams; absolutely-positioned bars by percent; a milestone/gate marker. |
+| A *calendar-accurate* schedule (real dates) | **Mermaid `gantt`** with `dateFormat YYYY-MM-DD` + `axisFormat %b %d` | Only when real dates exist. |
+| A latency budget on a request/operation path | **Annotated `sequenceDiagram`** | Put ms budgets in `Note over` blocks. |
+| Parallel work across cores/tasks/agents | **CSS swimlane** (one lane per core/task) | Reveals contention & idle time. |
+| State with time-bounded transitions (timeouts, debounce, retry/backoff) | **`stateDiagram-v2`** with durations on edges | Label transitions with the timeout. |
+
+**Do NOT use Mermaid `gantt` with `dateFormat X` (numeric)** — it renders a meaningless `0 0 1 1 2…` axis. For relative-effort plans, hand-build a CSS swimlane: a per-lane row (`grid-template-columns: 160px 1fr`), a relative track with faint vertical unit gridlines, and absolutely-positioned bars (`left:%` / `width:%`) colored by workstream, with a diamond marker for any gate.
+
+**User-facing mockups — show how the feature is exposed.** If the plan changes anything the user sees or hears, include a visual of the resulting UI state honoring the project's design system — don't describe it in prose. For a net-new or multi-state flow, recommend the `/design-mockup` skill rather than hand-rolling many states. Always state which design-system rules the mockup honors. Annotate behavior in user-facing language, never with implementation detail (write "a subtle chime plays", not a source filename).
+
+**Typography & layout.**
+- Font stack (Google Fonts): **Space Grotesk** for display headings (h1/h2), **Inter** for body, **JetBrains Mono** for code, file refs, eyebrows, badges, and small labels. No serif headings.
+- 15–16px body; line-height ~1.6; max content width ~1000–1040px, centered.
+- Confident heading scale: h1 ~42px / 700 / tracking -0.035em; h2 ~24px / 600 / -0.02em with a hairline trailing rule; h3 ~15px uppercase, copper, +0.06em. Mono eyebrow above h1.
+- **SageOx palette** (dark default): bg `#0f1416`, panel `#151b1e`/`#1b2327`, hairline `#2a3439`, ink `#e6edf0`, dim `#9fb0b6`, sage `#7a8f78` (primary/good/aligns), copper `#e0a56a` (one accent / expert routes), amber `#f59e0b` (warning / collisions), red `#ef4444` (blocker / conflicts), teal `#14b8a6` (file refs / capability). Max ~1 copper accent per section. Map badge colors to these semantics so the alignment strip and rail are palette-faithful.
+- Generous whitespace. Cards (`border:1px hairline; radius:10px`) for parallel items. Multi-column grids collapse to one column under ~760px.
+
+**Light & dark mode.** Ship both. Default to `prefers-color-scheme`; add a small fixed sun/moon toggle persisting to `localStorage`. Drive everything off CSS custom properties (a dark `:root` plus an `html[data-theme="light"]` override; route gradient endpoints through `--grad-*` variables). **Mermaid's theme is fixed at init**, so the toggle MUST re-render diagrams: capture each `.mermaid` source on load, and on theme change reset `data-processed`, restore source, `mermaid.initialize` with the matching `themeVariables` (a dark set + a light set), and `mermaid.run({nodes})`. Inline device mockups stay dark in both modes — only the surrounding panel/page flips. **Badges must stay legible in both themes** — define their fills/outlines via the same CSS variables.
+
+**Navigation (when the plan is long).** For plans with **5+ sections**, add a **sticky left-rail TOC** with scroll-spy — top-level sections only, mono small type, muted until hover/active, a 2px left border that turns sage on the active entry. CSS grid shell (`~190px` rail + `minmax(0,1fr)` content); **collapse the rail below ~1000px** (`display:none`). Drive the active state with one `IntersectionObserver` over `h2[id]` (rootMargin roughly `-15% 0 -70% 0`). Number sections and mirror those numbers in the rail. For short plans (≤4 sections) skip the rail.
+
+- Open with a `TL;DR` callout (one tight paragraph: problem, approach, cost, biggest risk) — placed just under the alignment-summary strip.
+- Numbered blocker/finding cards up top.
+- Steps as a clean numbered list with file:line refs styled distinctly (teal, small).
+- Tables for impact/verification matrices. Color verdict cells (good/warn/bad).
+- A `Risks` section with severity-coded left borders (red = load-bearing unknown, amber = watch).
+- Footer: where the canonical plan file lives (`data/plans/<slug>/`) + key invariants.
+
+**Concise, high-signal prose.** No filler. Every sentence earns its place. Code identifiers in `<code>`. Don't restate what a diagram or badge already shows.
+
+---
+
+## Process
+
+1. Run `ox plan --json` to get deterministic badges + the context bundle (0 tokens, local).
+2. Read the `context[]` bundle; author judgment badges **cited-only**, degrading to "consult `<name>`" when evidence is thin.
+3. Extract from the plan: problem/why, blockers/findings, architecture/flow, concrete steps (with file refs), impact numbers, verification, risks.
+4. Choose the diagrams that compress the most (before/after, sequence, decision gates, state machine, swimlane timeline).
+5. Write one polished self-contained HTML file meeting every html-plan non-negotiable PLUS the alignment strip, per-section badge rail, deterministic-vs-judgment styling, and resolved source links.
+6. Merge your judgment badges into the `ox plan --json` annotations and persist with `ox plan save --plan ... --annotations <merged.json> --html <render.html>`.
+7. Open the HTML and report the path.
+
+The goal: a reviewer skims the alignment strip + TL;DR + hero diagram and already knows whether the plan aligns with team direction and whether to approve — every badge says where its claim comes from, and ox-computed facts are visually separate from agent-reasoned judgment.
+
+$ox plan --json

--- a/extensions/claude/commands/ox-plan.md
+++ b/extensions/claude/commands/ox-plan.md
@@ -150,6 +150,11 @@ Shape rules:
 - A `Risks` section with severity-coded left borders (red = load-bearing unknown, amber = watch).
 - Footer: where the canonical plan file lives (`data/plans/<slug>/`) + key invariants.
 
+**SageOx attribution (subtle, earned, conditional).** When the plan actually carries SageOx enrichment — any deterministic badges (collision/prior-art/expert-routing) or context-bundle items were present — give SageOx quiet credit for the team context it infused: a single restrained footer line such as *"Team context enriched by SageOx"*, plus the existing `● ox-computed` marker that already tags deterministic badges as SageOx-sourced. Rules:
+- **Only when it legitimately helped.** If `ox plan --json` returned no badges and an empty `context[]` (an un-enriched plan), add NO SageOx credit — there is nothing to credit.
+- **Never overclaim.** SageOx provided context and signals; the human and the agent wrote the plan. Credit the enrichment, not the authorship. No banners, no marketing copy, no "moat"/"powered by" language — one calm line in the footer.
+- Judgment badges drawn from the SageOx context bundle may carry a small "via SageOx context" provenance note where it reads naturally, but don't repeat it on every badge.
+
 **Concise, high-signal prose.** No filler. Every sentence earns its place. Code identifiers in `<code>`. Don't restate what a diagram or badge already shows.
 
 ---

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -26,4 +26,11 @@ const (
 	// EnvGitHubSyncIssues overrides the issue sync mode.
 	// Consumed by: ResolveGitHubSyncIssues()
 	EnvGitHubSyncIssues = "OX_GITHUB_SYNC_ISSUES"
+
+	// EnvPlanHTML directly overrides the plan.html render mode. It must be one
+	// of the enum values off | recommend | always; any other value falls
+	// through to config/default. Customer-facing, so it uses the canonical
+	// SAGEOX_* namespace (ADR-047).
+	// Consumed by: PlanHTML()
+	EnvPlanHTML = "SAGEOX_PLAN_HTML"
 )

--- a/internal/config/plan.go
+++ b/internal/config/plan.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// PlanConfig holds the `plan.*` settings namespace for the `ox plan` feature.
+// Pointer fields distinguish "unset" (nil, fall through to the next precedence
+// level / documented default) from an explicit value. This is what keeps a
+// missing value resolving to the *documented* default rather than the Go
+// zero-value, which would be a surprise for the true-by-default Save key.
+type PlanConfig struct {
+	// Save auto-saves approved plans to the repo's ledger.
+	// Default: true.
+	Save *bool `yaml:"save,omitempty" json:"save,omitempty"`
+
+	// HTML controls the enriched-HTML render behavior as a tri-state:
+	//   off       — never render, never nudge.
+	//   recommend — prime nudges; render only on user confirm. (default)
+	//   always    — auto-render without a confirm step.
+	// Collapsing the prior pair of recommend/auto-render bools into one enum
+	// removes the nonsensical "don't recommend but auto-render" combination.
+	HTML *string `yaml:"html,omitempty" json:"html,omitempty"`
+}
+
+// Plan setting defaults and the html enum. Centralized so the resolvers, the
+// config-settings registry, and tests all agree on one source of truth.
+const (
+	DefaultPlanSave = true
+
+	PlanHTMLOff       = "off"
+	PlanHTMLRecommend = "recommend"
+	PlanHTMLAlways    = "always"
+
+	DefaultPlanHTML = PlanHTMLRecommend
+)
+
+// isPlanHTMLValue reports whether v is one of the three known plan.html enum
+// values. Used to validate the env override before it can win precedence.
+func isPlanHTMLValue(v string) bool {
+	switch v {
+	case PlanHTMLOff, PlanHTMLRecommend, PlanHTMLAlways:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsSaveSet reports whether plan.save was explicitly set.
+func (c *PlanConfig) IsSaveSet() bool {
+	return c != nil && c.Save != nil
+}
+
+// IsHTMLSet reports whether plan.html was explicitly set.
+func (c *PlanConfig) IsHTMLSet() bool {
+	return c != nil && c.HTML != nil
+}
+
+// IsEmpty reports whether no plan setting is explicitly set. Used by unset
+// paths to nil out the struct once its last field is cleared.
+func (c *PlanConfig) IsEmpty() bool {
+	return c == nil || (c.Save == nil && c.HTML == nil)
+}
+
+// PlanSave resolves whether approved plans auto-save to the ledger.
+// Precedence: user config > project config > default (true).
+func PlanSave(projectRoot string) bool {
+	userCfg, _ := LoadUserConfig()
+	if userCfg != nil && userCfg.Plan.IsSaveSet() {
+		return *userCfg.Plan.Save
+	}
+	if projectRoot != "" {
+		if cfg, _ := LoadProjectConfig(projectRoot); cfg != nil && cfg.Plan.IsSaveSet() {
+			return *cfg.Plan.Save
+		}
+	}
+	return DefaultPlanSave
+}
+
+// PlanHTML resolves the enriched-HTML render mode, returning one of
+// PlanHTMLOff / PlanHTMLRecommend / PlanHTMLAlways.
+// Precedence: env SAGEOX_PLAN_HTML > user config > project config > default.
+// The env var is a DIRECT override (it must itself be a valid enum value);
+// an unknown or empty env value falls through rather than forcing anything.
+func PlanHTML(projectRoot string) string {
+	if env := strings.TrimSpace(strings.ToLower(os.Getenv(EnvPlanHTML))); env != "" {
+		if isPlanHTMLValue(env) {
+			return env
+		}
+		slog.Debug("plan: ignoring unrecognized env override", "env", EnvPlanHTML, "value", env)
+	}
+	userCfg, _ := LoadUserConfig()
+	if userCfg != nil && userCfg.Plan.IsHTMLSet() && isPlanHTMLValue(*userCfg.Plan.HTML) {
+		return *userCfg.Plan.HTML
+	}
+	if projectRoot != "" {
+		if cfg, _ := LoadProjectConfig(projectRoot); cfg != nil && cfg.Plan.IsHTMLSet() && isPlanHTMLValue(*cfg.Plan.HTML) {
+			return *cfg.Plan.HTML
+		}
+	}
+	return DefaultPlanHTML
+}

--- a/internal/config/plan_test.go
+++ b/internal/config/plan_test.go
@@ -1,0 +1,248 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateUserConfig points OX_USER_CONFIG at a nonexistent file so the
+// real user config on the test machine can't leak plan settings into a
+// resolver under test. Tests that want explicit user config write their own
+// YAML and re-point OX_USER_CONFIG at it.
+func isolateUserConfig(t *testing.T) {
+	t.Helper()
+	t.Setenv("OX_USER_CONFIG", filepath.Join(t.TempDir(), "config.yaml"))
+}
+
+// clearPlanHTMLEnv ensures SAGEOX_PLAN_HTML is not inherited from the ambient
+// environment for tests that assert config/default resolution.
+func clearPlanHTMLEnv(t *testing.T) {
+	t.Helper()
+	require.NoError(t, os.Unsetenv(EnvPlanHTML))
+}
+
+// --- A. Documented defaults hold when nothing is configured ---
+// Failure prevented: a defaulted key silently returning the Go zero value
+// (false / "") because the resolver forgot the pointer-vs-default distinction.
+
+func TestPlanSave_DefaultsTrue(t *testing.T) {
+	isolateUserConfig(t)
+	// empty project root and a fresh temp project must both resolve to the
+	// documented default (true).
+	assert.Equal(t, DefaultPlanSave, PlanSave(""), "empty project root")
+	assert.Equal(t, DefaultPlanSave, PlanSave(t.TempDir()), "uninitialized temp project")
+	assert.True(t, DefaultPlanSave, "guard: plan.save default must be true")
+}
+
+func TestPlanHTML_DefaultsRecommend(t *testing.T) {
+	isolateUserConfig(t)
+	clearPlanHTMLEnv(t)
+	assert.Equal(t, PlanHTMLRecommend, PlanHTML(""), "empty project root")
+	assert.Equal(t, PlanHTMLRecommend, PlanHTML(t.TempDir()), "uninitialized temp project")
+	assert.Equal(t, PlanHTMLRecommend, DefaultPlanHTML, "guard: default enum is recommend")
+}
+
+// --- B. Explicit project config overrides the default ---
+// Failure prevented: explicit-false on the true-by-default save key being
+// ignored (the entire reason PlanConfig.Save is *bool, not bool); and an
+// explicit html enum value not taking effect.
+
+func TestPlanSave_ProjectOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		save *bool
+		want bool
+	}{
+		{"explicit false sticks against true default", boolPtr(false), false},
+		{"explicit true", boolPtr(true), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateUserConfig(t)
+			dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+				ProjectID:   "test_project",
+				WorkspaceID: "test_workspace",
+				Plan:        &PlanConfig{Save: tt.save},
+			})
+			assert.Equal(t, tt.want, PlanSave(dir))
+		})
+	}
+}
+
+func TestPlanHTML_ProjectOverride(t *testing.T) {
+	for _, val := range []string{PlanHTMLOff, PlanHTMLRecommend, PlanHTMLAlways} {
+		t.Run(val, func(t *testing.T) {
+			isolateUserConfig(t)
+			clearPlanHTMLEnv(t)
+			dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+				ProjectID:   "test_project",
+				WorkspaceID: "test_workspace",
+				Plan:        &PlanConfig{HTML: StringPtr(val)},
+			})
+			assert.Equal(t, val, PlanHTML(dir))
+		})
+	}
+}
+
+// off must truly silence — proves the off value round-trips through config and
+// is returned verbatim (the renderer/prime guidance keys off this exact value).
+func TestPlanHTML_OffSilences(t *testing.T) {
+	isolateUserConfig(t)
+	clearPlanHTMLEnv(t)
+	dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+		ProjectID:   "test_project",
+		WorkspaceID: "test_workspace",
+		Plan:        &PlanConfig{HTML: StringPtr(PlanHTMLOff)},
+	})
+	assert.Equal(t, PlanHTMLOff, PlanHTML(dir), "plan.html=off must resolve to off, not the recommend default")
+}
+
+// --- C. Precedence: user config > project config > default ---
+// Failure prevented: a project-level value masking a user-level preference,
+// or the precedence chain short-circuiting at the wrong rung.
+
+func TestPlanSave_UserBeatsProject(t *testing.T) {
+	// user=false, project=true → user wins (false). Proves the user rung is
+	// consulted first AND that explicit-false on the user side is honored.
+	userDir := t.TempDir()
+	userCfgPath := filepath.Join(userDir, "config.yaml")
+	require.NoError(t, os.WriteFile(userCfgPath, []byte("plan:\n  save: false\n"), 0644))
+	t.Setenv("OX_USER_CONFIG", userCfgPath)
+
+	dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+		ProjectID:   "test_project",
+		WorkspaceID: "test_workspace",
+		Plan:        &PlanConfig{Save: boolPtr(true)},
+	})
+
+	assert.False(t, PlanSave(dir), "user explicit-false must override project explicit-true")
+}
+
+func TestPlanSave_ProjectUsedWhenUserUnset(t *testing.T) {
+	// user unset, project=false → project value (false) is used, not default.
+	isolateUserConfig(t)
+	dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+		ProjectID:   "test_project",
+		WorkspaceID: "test_workspace",
+		Plan:        &PlanConfig{Save: boolPtr(false)},
+	})
+	assert.False(t, PlanSave(dir), "project explicit-false used when user is unset")
+}
+
+func TestPlanHTML_UserBeatsProject(t *testing.T) {
+	// user=always, project=off → user wins (always).
+	userDir := t.TempDir()
+	userCfgPath := filepath.Join(userDir, "config.yaml")
+	require.NoError(t, os.WriteFile(userCfgPath, []byte("plan:\n  html: always\n"), 0644))
+	t.Setenv("OX_USER_CONFIG", userCfgPath)
+	clearPlanHTMLEnv(t)
+
+	dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+		ProjectID:   "test_project",
+		WorkspaceID: "test_workspace",
+		Plan:        &PlanConfig{HTML: StringPtr(PlanHTMLOff)},
+	})
+
+	assert.Equal(t, PlanHTMLAlways, PlanHTML(dir), "user plan.html must override project plan.html")
+}
+
+func TestPlanHTML_ProjectUsedWhenUserUnset(t *testing.T) {
+	isolateUserConfig(t)
+	clearPlanHTMLEnv(t)
+	dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+		ProjectID:   "test_project",
+		WorkspaceID: "test_workspace",
+		Plan:        &PlanConfig{HTML: StringPtr(PlanHTMLOff)},
+	})
+	assert.Equal(t, PlanHTMLOff, PlanHTML(dir), "project plan.html used when user is unset")
+}
+
+// --- D. Env override SAGEOX_PLAN_HTML is a direct enum override ---
+// Failure prevented: the env not winning over config; or the env being treated
+// as a magic-string special case instead of a plain enum value.
+
+func TestPlanHTML_EnvDirectOverride(t *testing.T) {
+	// Each valid enum value, set via env, wins over a contradicting config.
+	for _, envVal := range []string{PlanHTMLOff, PlanHTMLRecommend, PlanHTMLAlways} {
+		t.Run("env="+envVal+" beats project", func(t *testing.T) {
+			isolateUserConfig(t)
+			t.Setenv(EnvPlanHTML, envVal)
+			// project says off; env should win regardless of what it says.
+			dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+				ProjectID:   "test_project",
+				WorkspaceID: "test_workspace",
+				Plan:        &PlanConfig{HTML: StringPtr(PlanHTMLOff)},
+			})
+			assert.Equal(t, envVal, PlanHTML(dir), "env enum value must win over project config")
+		})
+	}
+}
+
+func TestPlanHTML_EnvBeatsUser(t *testing.T) {
+	userDir := t.TempDir()
+	userCfgPath := filepath.Join(userDir, "config.yaml")
+	require.NoError(t, os.WriteFile(userCfgPath, []byte("plan:\n  html: off\n"), 0644))
+	t.Setenv("OX_USER_CONFIG", userCfgPath)
+	t.Setenv(EnvPlanHTML, PlanHTMLAlways)
+	assert.Equal(t, PlanHTMLAlways, PlanHTML(""), "env must override user config")
+}
+
+func TestPlanHTML_EnvCaseInsensitive(t *testing.T) {
+	isolateUserConfig(t)
+	t.Setenv(EnvPlanHTML, "ALWAYS")
+	assert.Equal(t, PlanHTMLAlways, PlanHTML(""), "env override should normalize case")
+}
+
+func TestPlanHTML_EnvUnknownFallsThrough(t *testing.T) {
+	// An unknown or empty env value must NOT force anything — it falls through
+	// to the configured value, then the default. Proves env is validated, not
+	// blindly trusted.
+	tests := []struct {
+		name   string
+		envVal string
+		setEnv bool
+		// project config html (empty = leave Plan nil → default applies)
+		projectHTML string
+		want        string
+	}{
+		{"unset env → default", "", false, "", PlanHTMLRecommend},
+		{"empty env → default", "", true, "", PlanHTMLRecommend},
+		{"junk env → default", "yes-please", true, "", PlanHTMLRecommend},
+		{"junk env respects config", "yes-please", true, PlanHTMLAlways, PlanHTMLAlways},
+		{"junk env does not suppress off config", "true", true, PlanHTMLOff, PlanHTMLOff},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateUserConfig(t)
+			if tt.setEnv {
+				t.Setenv(EnvPlanHTML, tt.envVal)
+			} else {
+				require.NoError(t, os.Unsetenv(EnvPlanHTML))
+			}
+			var plan *PlanConfig
+			if tt.projectHTML != "" {
+				plan = &PlanConfig{HTML: StringPtr(tt.projectHTML)}
+			}
+			dir := CreateInitializedProjectWithConfig(t, &ProjectConfig{
+				ProjectID:   "test_project",
+				WorkspaceID: "test_workspace",
+				Plan:        plan,
+			})
+			assert.Equal(t, tt.want, PlanHTML(dir),
+				"unknown env value must fall through, never force a value")
+		})
+	}
+}
+
+// --- E. PlanConfig helpers ---
+
+func TestPlanConfig_IsEmpty(t *testing.T) {
+	assert.True(t, (*PlanConfig)(nil).IsEmpty(), "nil config is empty")
+	assert.True(t, (&PlanConfig{}).IsEmpty(), "zero-value config is empty")
+	assert.False(t, (&PlanConfig{Save: boolPtr(false)}).IsEmpty(), "save set → not empty")
+	assert.False(t, (&PlanConfig{HTML: StringPtr(PlanHTMLOff)}).IsEmpty(), "html set → not empty")
+}

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -147,6 +147,10 @@ type ProjectConfig struct {
 	// the user hasn't personally configured). See HooksConfig.
 	Hooks *HooksConfig `json:"hooks,omitempty" yaml:"hooks,omitempty"`
 
+	// Plan holds the `plan.*` settings namespace for the `ox plan` feature.
+	// Pointer so an absent block is distinguishable from explicit zero-values.
+	Plan *PlanConfig `json:"plan,omitempty" yaml:"plan,omitempty"`
+
 	// KBID is the immutable knowledge-bubble identifier this project is bound
 	// to (ADR-017). Populated when the project has been migrated to the new
 	// .sageox/config.yaml format. Empty for legacy JSON-only projects that

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -344,6 +344,10 @@ type UserConfig struct {
 	// UserPromptSubmit cloud_query opt-in; see HooksConfig for rationale.
 	Hooks *HooksConfig `yaml:"hooks,omitempty"`
 
+	// Plan holds the user-level `plan.*` settings for the `ox plan` feature.
+	// Pointer so an absent block is distinguishable from explicit zero-values.
+	Plan *PlanConfig `yaml:"plan,omitempty"`
+
 	// Ephemeral is the persisted user preference for ephemeral mode (no
 	// daemon, no local ledger clone, HTTP-only reads). Pointer so we can
 	// distinguish unset (nil) from explicit false. When non-nil, the value

--- a/internal/ledgersearch/ledgersearch.go
+++ b/internal/ledgersearch/ledgersearch.go
@@ -1,5 +1,7 @@
 // Package ledgersearch provides zero-network, local-only full-text search over
-// the cached ledger contents: session summaries/markdown and recent murmurs.
+// the cached ledger contents: session summaries/markdown, recent murmurs, and
+// captured plans (data/plans/<dated-slug>/plan.md). Including plans closes the
+// prior-art flywheel — a plan saved by `ox plan` resurfaces in future plans.
 //
 // Design choice (see ox-m01h): this is an in-memory grep over a bounded window
 // of recent files rather than a persistent bleve index. Rationale:
@@ -40,6 +42,12 @@ const MaxSessionAge = 90 * 24 * time.Hour
 // the last 12 hours hydrated; we scan a slightly wider window to be safe.
 const MaxMurmurAge = 7 * 24 * time.Hour
 
+// MaxPlanAge bounds how far back we scan captured plans. Plans are the prior-art
+// flywheel's highest-signal corpus (a saved plan should resurface in future
+// plans), so we keep the same generous window as sessions rather than the
+// tighter murmur window.
+const MaxPlanAge = 90 * 24 * time.Hour
+
 // DefaultLimit is returned when callers pass limit <= 0.
 const DefaultLimit = 5
 
@@ -52,13 +60,14 @@ type Result struct {
 	Score float64 `json:"score"`
 	// Text is a short snippet around the matched term.
 	Text string `json:"text"`
-	// DocType is "session" or "murmur".
+	// DocType is "session", "murmur", or "plan".
 	DocType string `json:"doc_type"`
 	// FilePath is the absolute on-disk path of the source file.
 	FilePath string `json:"file_path"`
 	// SourceType is "ledger" — distinguishes from team-context results when merged.
 	SourceType string `json:"source_type"`
-	// SourceID is the session folder name or murmur ID.
+	// SourceID is the session folder name, murmur ID, or plan folder name
+	// (the dated slug, e.g. "2026-06-03-add-cache" — usable to locate the plan).
 	SourceID string `json:"source_id"`
 	// CreatedAt is the source's timestamp (ISO 8601). Empty if unknown.
 	CreatedAt string `json:"created_at,omitempty"`
@@ -113,6 +122,7 @@ func Search(opts Options) ([]Result, error) {
 	var results []Result
 	results = append(results, scanSessions(opts.LedgerPath, terms, now)...)
 	results = append(results, scanMurmurs(opts.LedgerPath, terms, now)...)
+	results = append(results, scanPlans(opts.LedgerPath, terms, now)...)
 
 	// sort by score desc, ties broken by recency desc
 	sort.SliceStable(results, func(i, j int) bool {
@@ -268,6 +278,84 @@ func scanMurmurs(ledgerPath string, terms []string, now time.Time) []Result {
 		}
 	}
 	return results
+}
+
+// scanPlans walks data/plans/<YYYY-MM-DD-slug>/ and scores plan.md hits. This
+// closes the prior-art flywheel: a plan saved by `ox plan` must resurface as
+// prior art in future plans. Mirrors scanSessions — same TF scoring, same age
+// filter, same Result shape — but reads the canonical plan.md (always plain
+// git, never an LFS pointer) and pulls created_at from meta.json when present.
+// Fail-open: a missing data/plans/ dir yields no results, never an error.
+func scanPlans(ledgerPath string, terms []string, now time.Time) []Result {
+	plansDir := filepath.Join(ledgerPath, "data", "plans")
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		// missing dir (no plans saved yet) or unreadable — fail open.
+		return nil
+	}
+
+	cutoff := now.Add(-MaxPlanAge)
+	var results []Result
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		planPath := filepath.Join(plansDir, name)
+
+		// created_at comes from meta.json (authoritative); fall back to the
+		// dated dir-name prefix when meta is missing/partial so age filtering
+		// and recency tiebreaks still work on a partial plan dir.
+		ts := planTimestamp(planPath, name)
+		if !ts.IsZero() && ts.Before(cutoff) {
+			continue
+		}
+
+		// plan.md is the canonical plan text — always plain git, the same role
+		// summary.md plays for sessions.
+		path := filepath.Join(planPath, "plan.md")
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			continue
+		}
+		score, snippet := scoreContent(string(data), terms)
+		if score <= 0 {
+			continue
+		}
+		results = append(results, Result{
+			Score:      score,
+			Text:       snippet,
+			DocType:    "plan",
+			FilePath:   path,
+			SourceType: "ledger",
+			SourceID:   name, // dated slug — locates the plan via `ox plan view`
+			CreatedAt:  ts.Format(time.RFC3339),
+		})
+	}
+	return results
+}
+
+// planTimestamp resolves a plan's created_at, preferring meta.json's explicit
+// timestamp and falling back to the YYYY-MM-DD prefix of the dir name. Returns
+// zero time when neither is available — callers treat that as "include".
+func planTimestamp(planPath, dirName string) time.Time {
+	metaPath := filepath.Join(planPath, "meta.json")
+	if data, err := os.ReadFile(metaPath); err == nil {
+		var m struct {
+			CreatedAt time.Time `json:"created_at"`
+		}
+		if json.Unmarshal(data, &m) == nil && !m.CreatedAt.IsZero() {
+			return m.CreatedAt
+		}
+	}
+	// fall back to the dated dir-name prefix "YYYY-MM-DD-<slug>".
+	if len(dirName) >= 10 {
+		if t, err := time.Parse("2006-01-02", dirName[:10]); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }
 
 // scoreContent returns a relevance score and a short snippet for content matching all terms.

--- a/internal/ledgersearch/ledgersearch_test.go
+++ b/internal/ledgersearch/ledgersearch_test.go
@@ -178,6 +178,138 @@ func TestSearch_MultiTermANDSemantics(t *testing.T) {
 	}
 }
 
+// --- Plans: the prior-art flywheel ---
+// A plan saved by `ox plan` MUST resurface as prior art in future plans.
+// Failure prevented: plans saved to data/plans/ are invisible to the prior-art
+// detector, so the flywheel never closes and every plan looks novel.
+
+func TestSearch_PlanMatch(t *testing.T) {
+	t.Parallel()
+	dir := makeLedger(t)
+	now := time.Now().UTC()
+	writePlan(t, dir, "2026-05-21-cache-layer", now.Add(-24*time.Hour),
+		"Add cache layer", "ryan",
+		"# Add cache layer\n\nWe will add an in-memory cache to the query path.")
+
+	results, err := Search(Options{LedgerPath: dir, Query: "cache", Now: now})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 plan result, got %d", len(results))
+	}
+	r := results[0]
+	if r.DocType != "plan" {
+		t.Errorf("doc_type = %q, want plan", r.DocType)
+	}
+	if r.SourceType != "ledger" {
+		t.Errorf("source_type = %q, want ledger", r.SourceType)
+	}
+	// SourceID must be the dated-slug dir so a reader can `ox plan view` it.
+	if r.SourceID != "2026-05-21-cache-layer" {
+		t.Errorf("source_id = %q, want dated slug", r.SourceID)
+	}
+	if r.Score <= 0 {
+		t.Errorf("expected positive score, got %f", r.Score)
+	}
+	// created_at must come from meta.json (the day before now), not zero.
+	if r.CreatedAt == "" {
+		t.Errorf("expected created_at from meta.json, got empty")
+	}
+}
+
+func TestSearch_PlanFailOpenNoPlansDir(t *testing.T) {
+	t.Parallel()
+	// ledger with sessions/ but no data/plans/ — scanning plans must not error.
+	dir := makeLedger(t)
+	now := time.Now().UTC()
+	writeSession(t, dir, "2026-05-20T10-15-ryan-OxABCD", "a session about widgets")
+
+	results, err := Search(Options{LedgerPath: dir, Query: "widgets", Now: now})
+	if err != nil {
+		t.Fatalf("expected fail-open with no plans dir, got err %v", err)
+	}
+	// the session still matches; the absence of data/plans/ must not break it.
+	if len(results) != 1 || results[0].DocType != "session" {
+		t.Fatalf("expected the session result to survive, got %+v", results)
+	}
+}
+
+func TestSearch_PlanVsSessionDistinguishable(t *testing.T) {
+	t.Parallel()
+	dir := makeLedger(t)
+	now := time.Now().UTC()
+	// same term in both a session and a plan: results must be tagged distinctly
+	// so the prior-art detector can phrase "planned" vs "worked on".
+	writeSession(t, dir, "2026-05-20T10-15-ryan-OxSESS", "deployment pipeline notes")
+	writePlan(t, dir, "2026-05-22-deployment-rework", now.Add(-2*time.Hour),
+		"Deployment rework", "ajit",
+		"# Deployment rework\n\nRebuild the deployment pipeline end to end.")
+
+	results, err := Search(Options{LedgerPath: dir, Query: "deployment", Now: now, Limit: 10})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	byType := map[string]Result{}
+	for _, r := range results {
+		byType[r.DocType] = r
+	}
+	if _, ok := byType["session"]; !ok {
+		t.Errorf("expected a session result, got types %v", keys(byType))
+	}
+	plan, ok := byType["plan"]
+	if !ok {
+		t.Fatalf("expected a plan result, got types %v", keys(byType))
+	}
+	if plan.SourceID != "2026-05-22-deployment-rework" {
+		t.Errorf("plan source_id = %q, want dated slug", plan.SourceID)
+	}
+}
+
+func TestSearch_PlanAgeCutoff(t *testing.T) {
+	t.Parallel()
+	dir := makeLedger(t)
+	now := time.Now().UTC()
+	// meta.json created_at far in the past — must be excluded by MaxPlanAge.
+	writePlan(t, dir, "2020-01-01-ancient-plan", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		"Ancient plan", "ryan", "# Ancient plan\n\nwidget overhaul")
+
+	results, err := Search(Options{LedgerPath: dir, Query: "widget", Now: now})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected age-cutoff to exclude old plan, got %d", len(results))
+	}
+}
+
+func TestSearch_PlanDateFallsBackToDirName(t *testing.T) {
+	t.Parallel()
+	// plan dir with no meta.json: age filter + created_at fall back to the
+	// YYYY-MM-DD dir prefix so a partial plan dir is still searchable/datable.
+	dir := makeLedger(t)
+	now := time.Now().UTC()
+	planDir := filepath.Join(dir, "data", "plans", "2026-05-23-no-meta-plan")
+	if err := os.MkdirAll(planDir, 0o755); err != nil {
+		t.Fatalf("mkdir plan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(planDir, "plan.md"),
+		[]byte("# No meta\n\ntelemetry rollout"), 0o644); err != nil {
+		t.Fatalf("write plan.md: %v", err)
+	}
+
+	results, err := Search(Options{LedgerPath: dir, Query: "telemetry", Now: now})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result from meta-less plan, got %d", len(results))
+	}
+	if results[0].CreatedAt == "" {
+		t.Errorf("expected created_at derived from dir name, got empty")
+	}
+}
+
 func TestParseSessionTimestamp(t *testing.T) {
 	t.Parallel()
 	cases := map[string]bool{
@@ -232,6 +364,39 @@ func writeSession(t *testing.T, ledgerPath, sessionName, summaryMD string) {
 	if err := os.WriteFile(filepath.Join(sessionDir, "summary.md"), []byte(summaryMD), 0o644); err != nil {
 		t.Fatalf("write summary: %v", err)
 	}
+}
+
+// writePlan materializes a captured-plan dir mirroring internal/plan/store.go's
+// layout: data/plans/<dated-slug>/{plan.md,meta.json}. plan.md is the canonical
+// searchable text; meta.json carries the authoritative created_at.
+func writePlan(t *testing.T, ledgerPath, dirName string, createdAt time.Time, topic, author, planMD string) {
+	t.Helper()
+	planDir := filepath.Join(ledgerPath, "data", "plans", dirName)
+	if err := os.MkdirAll(planDir, 0o755); err != nil {
+		t.Fatalf("mkdir plan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(planDir, "plan.md"), []byte(planMD), 0o644); err != nil {
+		t.Fatalf("write plan.md: %v", err)
+	}
+	meta := map[string]any{
+		"topic":      topic,
+		"slug":       dirName,
+		"authors":    []string{author},
+		"created_at": createdAt,
+	}
+	data, _ := json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(planDir, "meta.json"), data, 0o644); err != nil {
+		t.Fatalf("write meta.json: %v", err)
+	}
+}
+
+// keys returns the map keys for a clearer test failure message.
+func keys(m map[string]Result) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 func writeMurmur(t *testing.T, ledgerPath string, ts time.Time, id, topic, content string) {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -163,6 +163,21 @@ func TeamWhisperDBDir(teamID, endpointURL string) string {
 	return filepath.Join(TeamContextDir(teamID, endpointURL), ".sageox", "cache", "whisper")
 }
 
+// LedgerPlansDir returns the directory holding captured plans inside a ledger
+// checkout. Plans are git-tracked plain text (plan.md, annotations.json,
+// meta.json) so a dehydrated clone can list and read them with zero LFS
+// hydration. Format: <ledgerPath>/data/plans/
+//
+// Unlike the endpoint/repo-keyed helpers above, this takes the already-resolved
+// ledger root (e.g. from ProjectContext.DefaultLedgerPath) so callers don't
+// re-derive the endpoint. Returns "" when ledgerPath is empty.
+func LedgerPlansDir(ledgerPath string) string {
+	if ledgerPath == "" {
+		return ""
+	}
+	return filepath.Join(ledgerPath, "data", "plans")
+}
+
 // LedgerSessionCacheBase returns the base cache directory inside a repo's ledger.
 // Session recording states are stored under <base>/sessions/<session-name>/.
 // This is the canonical, environment-independent cache location — unlike XDG cache dirs

--- a/internal/plan/collision.go
+++ b/internal/plan/collision.go
@@ -1,0 +1,515 @@
+package plan
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/codedb"
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ledger"
+	"github.com/sageox/ox/internal/paths"
+)
+
+func init() {
+	RegisterDetector(&collisionDetector{})
+}
+
+// murmurWindowHours bounds how far back a murmur is treated as an active-work
+// signal. Capped at ledger.MaxMurmurWindowHours (24h) inside ReadMurmursInWindow,
+// so this asks for the widest meaningful window. A teammate murmuring "editing
+// internal/auth/" is the earliest collision signal — it predates any commit or PR.
+const murmurWindowHours = ledger.MaxMurmurWindowHours
+
+// collisionDetector reports active-work contention on a plan's referenced files
+// from three local, zero-token sources: open PRs touching the file, multi-
+// workspace contention, and recent teammate murmurs. It is fail-open: any
+// missing/unreadable data path returns no annotations rather than an error.
+type collisionDetector struct{}
+
+// Name identifies the detector in logs and registry diagnostics.
+func (d *collisionDetector) Name() string { return "collision" }
+
+// Detect unions the plan's section files, then asks codedb (open PRs +
+// contention) and the ledger murmur cache which of those files a teammate is
+// already active in. Returns one annotation per (file, signal). FAIL-OPEN
+// everywhere: no codedb, no ledger, no murmurs -> (nil, nil).
+func (d *collisionDetector) Detect(ctx context.Context, in Input, gitRoot string) ([]Annotation, error) {
+	files := planFiles(in)
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	var annotations []Annotation
+	annotations = append(annotations, d.detectCodeDB(ctx, gitRoot, files)...)
+	annotations = append(annotations, d.detectMurmurs(gitRoot, in, files)...)
+
+	if len(annotations) == 0 {
+		return nil, nil
+	}
+	return annotations, nil
+}
+
+// detectCodeDB opens the shared codedb in SQL-only mode (mirroring
+// `ox code insights`) and maps plan files to open PRs and contention. Returns
+// nil on any failure so enrichment is never blocked by a missing/locked index.
+func (d *collisionDetector) detectCodeDB(ctx context.Context, gitRoot string, files []string) []Annotation {
+	dataDir := resolveCodeDBDir(gitRoot)
+	if dataDir == "" {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, store.MetadataDBFile)); err != nil {
+		// no built index — fail open
+		return nil
+	}
+
+	db, err := codedb.OpenSQLOnly(dataDir)
+	if err != nil {
+		slog.Debug("collision codedb open failed", "dir", dataDir, "error", err)
+		return nil
+	}
+	defer func() { _ = db.Close() }()
+
+	s := db.Store()
+	want := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		want[f] = struct{}{}
+	}
+
+	var annotations []Annotation
+	annotations = append(annotations, prCollisions(s, want)...)
+	annotations = append(annotations, contentionCollisions(s, want)...)
+	return annotations
+}
+
+// prCollisions finds open PRs whose changed files intersect the plan's files.
+// A PR's files are the union of its commits' diffs (via pr_commits.sha and the
+// merge_commit), joined commits.hash -> diffs.path. Files reviewed in
+// pr_comments.path are also treated as touched, since a review comment on a path
+// is a strong signal the PR is editing it.
+func prCollisions(s *store.Store, want map[string]struct{}) []Annotation {
+	rows, err := s.Query(`
+		SELECT DISTINCT pr.number, COALESCE(pr.author, ''), COALESCE(pr.url, ''), d.path
+		FROM pull_requests pr
+		JOIN pr_commits pc ON pc.pr_id = pr.id
+		JOIN commits c ON c.hash = pc.sha
+		JOIN diffs d ON d.commit_id = c.id
+		WHERE pr.state = 'open'
+		UNION
+		SELECT DISTINCT pr.number, COALESCE(pr.author, ''), COALESCE(pr.url, ''), d.path
+		FROM pull_requests pr
+		JOIN commits c ON c.hash = pr.merge_commit
+		JOIN diffs d ON d.commit_id = c.id
+		WHERE pr.state = 'open'
+		UNION
+		SELECT DISTINCT pr.number, COALESCE(pr.author, ''), COALESCE(pr.url, ''), prc.path
+		FROM pull_requests pr
+		JOIN pr_comments prc ON prc.pr_id = pr.id
+		WHERE pr.state = 'open' AND prc.path IS NOT NULL AND prc.path != ''`)
+	if err != nil {
+		slog.Debug("collision PR query failed", "error", err)
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	// group by file: a file may be touched by multiple open PRs.
+	type prRef struct {
+		number int
+		author string
+		url    string
+	}
+	byFile := make(map[string][]prRef)
+	for rows.Next() {
+		var (
+			number      int
+			author, url string
+			path        string
+		)
+		if err := rows.Scan(&number, &author, &url, &path); err != nil {
+			continue
+		}
+		if _, ok := want[path]; !ok {
+			continue
+		}
+		byFile[path] = append(byFile[path], prRef{number: number, author: author, url: url})
+	}
+
+	var annotations []Annotation
+	for _, file := range sortedKeys(byFile) {
+		refs := byFile[file]
+		// deterministic order: ascending PR number
+		sort.Slice(refs, func(i, j int) bool { return refs[i].number < refs[j].number })
+		// emit one annotation per (file, PR) so each carries its own URL/author.
+		for _, r := range refs {
+			who := r.author
+			if who == "" {
+				who = "a teammate"
+			}
+			annotations = append(annotations, Annotation{
+				Kind:      BadgeDeterministic,
+				Type:      BadgeCollision,
+				Why:       fmt.Sprintf("%s is in open PR #%d (%s)", file, r.number, who),
+				SourceURL: r.url,
+				Expert:    r.author,
+				Files:     []string{file},
+			})
+		}
+	}
+	return annotations
+}
+
+// contentionCollisions reports plan files touched by more than one workspace in
+// the recent commit window — a sign two efforts are converging on the same file.
+func contentionCollisions(s *store.Store, want map[string]struct{}) []Annotation {
+	rows, err := s.Query(`
+		SELECT d.path, COUNT(DISTINCT r.name) AS workspace_count
+		FROM diffs d
+		JOIN commits c ON c.id = d.commit_id
+		JOIN repos r ON r.id = c.repo_id
+		WHERE c.timestamp > unixepoch('now', '-14 days')
+		GROUP BY d.path HAVING workspace_count > 1`)
+	if err != nil {
+		slog.Debug("collision contention query failed", "error", err)
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	type hit struct {
+		path  string
+		count int
+	}
+	var hits []hit
+	for rows.Next() {
+		var h hit
+		if err := rows.Scan(&h.path, &h.count); err != nil {
+			continue
+		}
+		if _, ok := want[h.path]; !ok {
+			continue
+		}
+		hits = append(hits, h)
+	}
+
+	sort.Slice(hits, func(i, j int) bool { return hits[i].path < hits[j].path })
+
+	var annotations []Annotation
+	for _, h := range hits {
+		annotations = append(annotations, Annotation{
+			Kind:  BadgeDeterministic,
+			Type:  BadgeCollision,
+			Why:   fmt.Sprintf("%s is contended — touched by %d workspaces recently", h.path, h.count),
+			Files: []string{h.path},
+		})
+	}
+	return annotations
+}
+
+// detectMurmurs reads recent murmurs from the ledger cache and matches their
+// metadata["files"] (and topic against section headings) to the plan's files.
+// Murmurs are the EARLIEST collision signal — they exist before any commit/PR.
+func (d *collisionDetector) detectMurmurs(gitRoot string, in Input, files []string) []Annotation {
+	ledgerPath := resolveLedgerPath(gitRoot)
+	if ledgerPath == "" {
+		return nil
+	}
+
+	murmurs, err := ledger.ReadMurmursInWindow(ledgerPath, murmurWindowHours)
+	if err != nil || len(murmurs) == 0 {
+		return nil
+	}
+
+	return matchMurmurs(murmurs, files, sectionHeadings(in), time.Now().UTC())
+}
+
+// matchMurmurs is the pure, testable core of murmur collision detection: given a
+// set of murmurs, the plan's files, and section headings, it returns one
+// annotation per (file, murmur) where the murmur references that file in its
+// metadata["files"] list. Topic-vs-heading matches are reported when a murmur's
+// topic overlaps a section heading even without an explicit file list.
+//
+// now is injected so recency phrasing is deterministic under test.
+func matchMurmurs(murmurs []ledger.MurmurFile, files []string, headings []string, now time.Time) []Annotation {
+	want := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		want[f] = struct{}{}
+	}
+
+	var annotations []Annotation
+	seen := make(map[string]struct{})
+
+	for _, m := range murmurs {
+		who := murmurAuthor(m)
+		ago := humanizeAgo(now.Sub(m.Timestamp.UTC()))
+
+		// explicit file references in murmur metadata.
+		for _, mf := range murmurFiles(m) {
+			matched, ok := matchPlanFile(mf, want)
+			if !ok {
+				continue
+			}
+			key := matched + "\x00" + m.ID
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			annotations = append(annotations, Annotation{
+				Kind:   BadgeDeterministic,
+				Type:   BadgeCollision,
+				Why:    fmt.Sprintf("%s murmured editing %s %s", who, matched, ago),
+				Expert: who,
+				Files:  []string{matched},
+			})
+		}
+	}
+
+	// topic-vs-heading overlap is a softer signal; only emit when no explicit
+	// file match already fired for the same murmur, to avoid double-reporting.
+	matchedMurmur := make(map[string]struct{})
+	for k := range seen {
+		if i := strings.IndexByte(k, 0); i >= 0 {
+			matchedMurmur[k[i+1:]] = struct{}{}
+		}
+	}
+	for _, m := range murmurs {
+		if _, done := matchedMurmur[m.ID]; done {
+			continue
+		}
+		if m.Topic == "" || len(headings) == 0 {
+			continue
+		}
+		if !topicMatchesHeading(m.Topic, headings) {
+			continue
+		}
+		who := murmurAuthor(m)
+		ago := humanizeAgo(now.Sub(m.Timestamp.UTC()))
+		annotations = append(annotations, Annotation{
+			Kind:   BadgeDeterministic,
+			Type:   BadgeCollision,
+			Why:    fmt.Sprintf("%s murmured on topic %q %s", who, m.Topic, ago),
+			Expert: who,
+		})
+	}
+
+	sort.SliceStable(annotations, func(i, j int) bool { return annotations[i].Why < annotations[j].Why })
+	return annotations
+}
+
+// matchPlanFile reports whether a murmur-referenced path corresponds to one of
+// the plan's files. Matching tolerates directory references ("internal/auth/")
+// and exact-or-suffix file matches, returning the canonical plan-file path.
+func matchPlanFile(murmurRef string, want map[string]struct{}) (string, bool) {
+	murmurRef = strings.TrimSpace(murmurRef)
+	if murmurRef == "" {
+		return "", false
+	}
+	clean := normalizePath(murmurRef)
+
+	// exact match against a plan file.
+	if _, ok := want[clean]; ok {
+		return clean, true
+	}
+
+	// directory-style murmur ("internal/auth/" or "internal/auth"): match any
+	// plan file under that directory prefix.
+	dirPrefix := clean
+	if !strings.HasSuffix(dirPrefix, "/") {
+		dirPrefix += "/"
+	}
+	for planFile := range want {
+		if strings.HasPrefix(planFile, dirPrefix) {
+			return planFile, true
+		}
+		// suffix match: the murmur cites a fuller path (e.g. an absolute or
+		// repo-prefixed path) ending in the plan's relative file ref.
+		if strings.HasSuffix(clean, "/"+normalizePath(planFile)) {
+			return planFile, true
+		}
+	}
+	return "", false
+}
+
+// topicMatchesHeading reports whether a murmur topic shares a meaningful token
+// with any section heading. Tokens shorter than 4 chars are ignored to avoid
+// matching on stopwords like "the" or "api".
+func topicMatchesHeading(topic string, headings []string) bool {
+	topicTokens := tokenize(topic)
+	if len(topicTokens) == 0 {
+		return false
+	}
+	for _, h := range headings {
+		hTokens := make(map[string]struct{})
+		for _, t := range tokenize(h) {
+			hTokens[t] = struct{}{}
+		}
+		for _, t := range topicTokens {
+			if len(t) < 4 {
+				continue
+			}
+			if _, ok := hTokens[t]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// tokenize lowercases and splits text into alphanumeric word tokens.
+func tokenize(s string) []string {
+	return strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	})
+}
+
+// murmurFiles extracts the file list a murmur references from its metadata. The
+// convention is a comma- or newline-separated metadata["files"] value.
+func murmurFiles(m ledger.MurmurFile) []string {
+	raw, ok := m.Metadata["files"]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == '\n' || r == ';' || r == ' '
+	})
+	var out []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// murmurAuthor returns a human-friendly attribution for a murmur, preferring the
+// principal (the coworker the agent works for) over the agent instance.
+func murmurAuthor(m ledger.MurmurFile) string {
+	if m.PrincipalID != "" {
+		return m.PrincipalID
+	}
+	if m.AgentID != "" {
+		return m.AgentID
+	}
+	return "a teammate"
+}
+
+// humanizeAgo renders a duration as a short recency phrase ("3h ago", "2d ago").
+func humanizeAgo(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+// planFiles returns the deduped, normalized union of every section's file refs.
+// The :line suffix produced by the input parser is stripped for matching.
+func planFiles(in Input) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, sec := range in.Sections {
+		for _, f := range sec.Files {
+			clean := normalizePath(f)
+			if clean == "" {
+				continue
+			}
+			if _, ok := seen[clean]; ok {
+				continue
+			}
+			seen[clean] = struct{}{}
+			out = append(out, clean)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sectionHeadings returns the non-empty H2 headings of the plan.
+func sectionHeadings(in Input) []string {
+	var out []string
+	for _, sec := range in.Sections {
+		if h := strings.TrimSpace(sec.Heading); h != "" {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// normalizePath strips a trailing :line suffix and surrounding whitespace so a
+// plan ref like "internal/auth/token.go:42" matches the codedb/murmur path.
+func normalizePath(p string) string {
+	p = strings.TrimSpace(p)
+	if i := strings.LastIndexByte(p, ':'); i > 0 {
+		// only treat as :line if the suffix is all digits.
+		if allDigits(p[i+1:]) {
+			p = p[:i]
+		}
+	}
+	return strings.TrimPrefix(p, "./")
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// sortedKeys returns the map keys in ascending order for deterministic output.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// resolveCodeDBDir mirrors cmd/ox's resolution: prefer the shared codedb keyed
+// by repo_id+endpoint, falling back to the per-project cache dir. cmd/ox is
+// package main and can't be imported, so the canonical paths helpers are reused
+// directly here.
+func resolveCodeDBDir(gitRoot string) string {
+	if ctx, err := config.LoadProjectContext(gitRoot); err == nil {
+		if dir := paths.CodeDBSharedDir(ctx.RepoID(), ctx.Endpoint()); dir != "" {
+			return dir
+		}
+	}
+	return paths.CodeDBDataDir(gitRoot)
+}
+
+// resolveLedgerPath returns the ledger checkout root for the repo, which hosts
+// the murmur cache under data/murmurs/. Uses the canonical ProjectContext helper
+// so path construction is never duplicated. Returns "" when uninitialized.
+func resolveLedgerPath(gitRoot string) string {
+	ctx, err := config.LoadProjectContext(gitRoot)
+	if err != nil {
+		return ""
+	}
+	p := ctx.DefaultLedgerPath()
+	if p == "" {
+		return ""
+	}
+	if _, err := os.Stat(p); err != nil {
+		return ""
+	}
+	return p
+}

--- a/internal/plan/collision_test.go
+++ b/internal/plan/collision_test.go
@@ -1,0 +1,386 @@
+package plan
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/codedb"
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/sageox/ox/internal/ledger"
+)
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "internal/auth/token.go", "internal/auth/token.go"},
+		{"line suffix", "internal/auth/token.go:42", "internal/auth/token.go"},
+		{"dot-slash prefix", "./cmd/ox/plan.go", "cmd/ox/plan.go"},
+		{"whitespace", "  internal/x.go  ", "internal/x.go"},
+		{"colon non-numeric kept", "pkg:thing.go", "pkg:thing.go"},
+		{"dir trailing slash kept", "internal/auth/", "internal/auth/"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizePath(tc.in); got != tc.want {
+				t.Errorf("normalizePath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlanFiles_DedupeNormalizeSort(t *testing.T) {
+	in := Input{Sections: []Section{
+		{Heading: "A", Files: []string{"internal/b.go:10", "internal/a.go"}},
+		{Heading: "B", Files: []string{"internal/a.go", "./internal/c.go"}},
+	}}
+	got := planFiles(in)
+	want := []string{"internal/a.go", "internal/b.go", "internal/c.go"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("planFiles = %v, want %v", got, want)
+	}
+}
+
+func TestMatchPlanFile(t *testing.T) {
+	want := map[string]struct{}{
+		"internal/auth/token.go": {},
+		"cmd/ox/plan.go":         {},
+	}
+	tests := []struct {
+		name      string
+		murmurRef string
+		wantFile  string
+		wantOK    bool
+	}{
+		{"exact", "internal/auth/token.go", "internal/auth/token.go", true},
+		{"dir with slash", "internal/auth/", "internal/auth/token.go", true},
+		{"dir without slash", "internal/auth", "internal/auth/token.go", true},
+		{"line suffix", "internal/auth/token.go:7", "internal/auth/token.go", true},
+		{"suffix path", "src/cmd/ox/plan.go", "cmd/ox/plan.go", true},
+		{"no match", "internal/other/x.go", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file, ok := matchPlanFile(tc.murmurRef, want)
+			if ok != tc.wantOK || file != tc.wantFile {
+				t.Errorf("matchPlanFile(%q) = (%q,%v), want (%q,%v)",
+					tc.murmurRef, file, ok, tc.wantFile, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestTopicMatchesHeading(t *testing.T) {
+	headings := []string{"Refactor authentication flow", "Add caching layer"}
+	tests := []struct {
+		name  string
+		topic string
+		want  bool
+	}{
+		{"shared long token", "authentication-tokens", true},
+		{"shared caching", "caching", true},
+		{"only short tokens", "the api io", false},
+		{"unrelated", "unrelated stuff here today", false},
+		{"empty", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := topicMatchesHeading(tc.topic, headings); got != tc.want {
+				t.Errorf("topicMatchesHeading(%q) = %v, want %v", tc.topic, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHumanizeAgo(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"just now", 10 * time.Second, "just now"},
+		{"minutes", 5 * time.Minute, "5m ago"},
+		{"hours", 3 * time.Hour, "3h ago"},
+		{"days", 50 * time.Hour, "2d ago"},
+		{"negative clamps", -time.Hour, "just now"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := humanizeAgo(tc.d); got != tc.want {
+				t.Errorf("humanizeAgo(%v) = %q, want %q", tc.d, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMurmurFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]string
+		want []string
+	}{
+		{"comma separated", map[string]string{"files": "a.go, b.go"}, []string{"a.go", "b.go"}},
+		{"newline separated", map[string]string{"files": "a.go\nb.go"}, []string{"a.go", "b.go"}},
+		{"missing key", map[string]string{}, nil},
+		{"empty value", map[string]string{"files": "  "}, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := murmurFiles(ledger.MurmurFile{Metadata: tc.meta})
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("murmurFiles = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchMurmurs(t *testing.T) {
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	files := []string{"internal/auth/token.go", "cmd/ox/plan.go"}
+	headings := []string{"Refactor authentication flow"}
+
+	tests := []struct {
+		name        string
+		murmurs     []ledger.MurmurFile
+		wantCount   int
+		wantSubstr  string
+		wantExperts []string
+	}{
+		{
+			name: "explicit file match",
+			murmurs: []ledger.MurmurFile{{
+				ID:          "m1",
+				PrincipalID: "bob",
+				Timestamp:   now.Add(-3 * time.Hour),
+				Metadata:    map[string]string{"files": "internal/auth/token.go"},
+			}},
+			wantCount:   1,
+			wantSubstr:  "bob murmured editing internal/auth/token.go 3h ago",
+			wantExperts: []string{"bob"},
+		},
+		{
+			name: "directory murmur matches file under it",
+			murmurs: []ledger.MurmurFile{{
+				ID:          "m2",
+				PrincipalID: "alice",
+				Timestamp:   now.Add(-30 * time.Minute),
+				Metadata:    map[string]string{"files": "internal/auth/"},
+			}},
+			wantCount:  1,
+			wantSubstr: "alice murmured editing internal/auth/token.go 30m ago",
+		},
+		{
+			name: "topic-heading overlap with no file list",
+			murmurs: []ledger.MurmurFile{{
+				ID:          "m3",
+				PrincipalID: "carol",
+				Timestamp:   now.Add(-1 * time.Hour),
+				Topic:       "authentication-rewrite",
+			}},
+			wantCount:  1,
+			wantSubstr: "carol murmured on topic",
+		},
+		{
+			name: "no match — unrelated file and topic",
+			murmurs: []ledger.MurmurFile{{
+				ID:          "m4",
+				PrincipalID: "dave",
+				Timestamp:   now.Add(-1 * time.Hour),
+				Topic:       "unrelated work",
+				Metadata:    map[string]string{"files": "internal/other/x.go"},
+			}},
+			wantCount: 0,
+		},
+		{
+			name: "explicit match suppresses topic double-report",
+			murmurs: []ledger.MurmurFile{{
+				ID:          "m5",
+				PrincipalID: "erin",
+				Timestamp:   now.Add(-2 * time.Hour),
+				Topic:       "authentication-rewrite",
+				Metadata:    map[string]string{"files": "internal/auth/token.go"},
+			}},
+			wantCount:  1,
+			wantSubstr: "erin murmured editing internal/auth/token.go 2h ago",
+		},
+		{
+			name: "agent_id fallback when no principal",
+			murmurs: []ledger.MurmurFile{{
+				ID:        "m6",
+				AgentID:   "agent-xyz",
+				Timestamp: now.Add(-5 * time.Hour),
+				Metadata:  map[string]string{"files": "cmd/ox/plan.go"},
+			}},
+			wantCount:   1,
+			wantSubstr:  "agent-xyz murmured editing cmd/ox/plan.go 5h ago",
+			wantExperts: []string{"agent-xyz"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchMurmurs(tc.murmurs, files, headings, now)
+			if len(got) != tc.wantCount {
+				t.Fatalf("matchMurmurs returned %d annotations, want %d: %+v", len(got), tc.wantCount, got)
+			}
+			for _, a := range got {
+				if a.Kind != BadgeDeterministic || a.Type != BadgeCollision {
+					t.Errorf("wrong badge kind/type: %+v", a)
+				}
+			}
+			if tc.wantSubstr != "" {
+				found := false
+				for _, a := range got {
+					if strings.Contains(a.Why, tc.wantSubstr) {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("no annotation Why contained %q; got %+v", tc.wantSubstr, got)
+				}
+			}
+			for _, exp := range tc.wantExperts {
+				found := false
+				for _, a := range got {
+					if a.Expert == exp {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected expert %q in annotations; got %+v", exp, got)
+				}
+			}
+		})
+	}
+}
+
+// --- codedb integration: tiny in-place SQLite fixture ---
+
+func TestPRAndContentionCollisions(t *testing.T) {
+	dir := t.TempDir()
+	db, err := codedb.OpenSQLOnly(dir)
+	if err != nil {
+		t.Fatalf("OpenSQLOnly: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	s := db.Store()
+
+	seedCodeDBFixture(t, s)
+
+	want := map[string]struct{}{
+		"internal/auth/token.go": {},
+		"cmd/ox/plan.go":         {}, // contended file
+		"internal/unrelated.go":  {}, // present in plan but not in any signal
+	}
+
+	prAnns := prCollisions(s, want)
+	if len(prAnns) != 1 {
+		t.Fatalf("prCollisions returned %d, want 1: %+v", len(prAnns), prAnns)
+	}
+	pr := prAnns[0]
+	if pr.Type != BadgeCollision || pr.Kind != BadgeDeterministic {
+		t.Errorf("wrong badge: %+v", pr)
+	}
+	if !strings.Contains(pr.Why, "open PR #412") || !strings.Contains(pr.Why, "alice") {
+		t.Errorf("unexpected PR Why: %q", pr.Why)
+	}
+	if pr.SourceURL != "https://example.test/pr/412" {
+		t.Errorf("expected PR URL, got %q", pr.SourceURL)
+	}
+	if pr.Expert != "alice" {
+		t.Errorf("expected expert alice, got %q", pr.Expert)
+	}
+	if len(pr.Files) != 1 || pr.Files[0] != "internal/auth/token.go" {
+		t.Errorf("unexpected Files: %v", pr.Files)
+	}
+
+	contAnns := contentionCollisions(s, want)
+	if len(contAnns) != 1 {
+		t.Fatalf("contentionCollisions returned %d, want 1: %+v", len(contAnns), contAnns)
+	}
+	c := contAnns[0]
+	if !strings.Contains(c.Why, "cmd/ox/plan.go") || !strings.Contains(c.Why, "contended") {
+		t.Errorf("unexpected contention Why: %q", c.Why)
+	}
+}
+
+func TestPRCollisions_NoMatchReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	db, err := codedb.OpenSQLOnly(dir)
+	if err != nil {
+		t.Fatalf("OpenSQLOnly: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	s := db.Store()
+	seedCodeDBFixture(t, s)
+
+	// plan references a file no open PR touches
+	want := map[string]struct{}{"docs/readme.md": {}}
+	if got := prCollisions(s, want); got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+// TestDetect_FailOpenNoIndex verifies Detect returns (nil,nil) when there is no
+// codedb index and no ledger — the fail-open contract.
+func TestDetect_FailOpenNoIndex(t *testing.T) {
+	d := &collisionDetector{}
+	in := Input{Sections: []Section{{Heading: "X", Files: []string{"internal/a.go"}}}}
+	// a temp dir with no .sageox config resolves to an empty/absent codedb +
+	// ledger, so both legs fail open.
+	anns, err := d.Detect(context.Background(), in, t.TempDir())
+	if err != nil {
+		t.Fatalf("Detect returned error (must fail-open): %v", err)
+	}
+	if anns != nil {
+		t.Errorf("expected nil annotations with no data, got %+v", anns)
+	}
+}
+
+func TestDetect_NoFilesReturnsNil(t *testing.T) {
+	d := &collisionDetector{}
+	anns, err := d.Detect(context.Background(), Input{}, t.TempDir())
+	if err != nil || anns != nil {
+		t.Fatalf("expected (nil,nil), got (%+v,%v)", anns, err)
+	}
+}
+
+// seedCodeDBFixture inserts a minimal but realistic graph:
+//   - repo "ws-a" with a commit touching internal/auth/token.go, on open PR #412
+//   - two repos (workspaces) both touching cmd/ox/plan.go recently -> contention
+func seedCodeDBFixture(t *testing.T, s *store.Store) {
+	t.Helper()
+	now := time.Now().Unix()
+
+	exec := func(q string, args ...any) {
+		if _, err := s.Exec(q, args...); err != nil {
+			t.Fatalf("seed exec failed: %v\nquery: %s", err, q)
+		}
+	}
+
+	// repos / workspaces
+	exec(`INSERT INTO repos(id, name, path) VALUES (1,'ws-a','/tmp/ws-a'),(2,'ws-b','/tmp/ws-b')`)
+
+	// commits
+	exec(`INSERT INTO commits(id, repo_id, hash, author, message, timestamp)
+	      VALUES (1,1,'aaa111','alice','auth work', ?)`, now)
+	exec(`INSERT INTO commits(id, repo_id, hash, author, message, timestamp)
+	      VALUES (2,1,'bbb222','alice','plan in ws-a', ?)`, now)
+	exec(`INSERT INTO commits(id, repo_id, hash, author, message, timestamp)
+	      VALUES (3,2,'ccc333','bob','plan in ws-b', ?)`, now)
+
+	// diffs: auth file (PR), plan.go touched by both workspaces (contention)
+	exec(`INSERT INTO diffs(id, commit_id, path) VALUES (1,1,'internal/auth/token.go')`)
+	exec(`INSERT INTO diffs(id, commit_id, path) VALUES (2,2,'cmd/ox/plan.go')`)
+	exec(`INSERT INTO diffs(id, commit_id, path) VALUES (3,3,'cmd/ox/plan.go')`)
+
+	// open PR #412 by alice, links to commit aaa111 via pr_commits
+	exec(`INSERT INTO pull_requests(id, number, title, author, state, url)
+	      VALUES (1,412,'auth refactor','alice','open','https://example.test/pr/412')`)
+	exec(`INSERT INTO pr_commits(id, pr_id, sha) VALUES (1,1,'aaa111')`)
+}

--- a/internal/plan/context_bundle.go
+++ b/internal/plan/context_bundle.go
@@ -1,0 +1,353 @@
+package plan
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/ledger"
+	"github.com/sageox/ox/internal/ledgersearch"
+	"github.com/sageox/ox/internal/teamdocs"
+)
+
+// init self-registers the context-bundle retriever with the global registry so
+// the orchestrator (enrich.go) picks it up without being touched. RegisterRetriever
+// ignores nil and is concurrency-safe.
+func init() {
+	RegisterRetriever(&contextBundleRetriever{})
+}
+
+// bundleCap caps the TOTAL number of items in the assembled context bundle
+// across all kinds. The bundle is what the CLIENT agent reasons over to author
+// the judgment badges (aligns/conflicts, expert-perspective); every item costs
+// tokens in that agent's context window. Past the top handful, additional items
+// add noise without changing the agent's conclusion. Capping here protects the
+// client's context budget — local retrieval is cheap, but the agent's attention
+// is not.
+const bundleCap = 12
+
+// murmurBundleWindowHours bounds murmur recency for the bundle. The murmur cache
+// is sparsely checked out (~12h hydrated by default), and ReadMurmursInWindow
+// hard-caps at ledger.MaxMurmurWindowHours (24h) regardless, so this asks for the
+// widest meaningful window. Recent murmurs are the freshest "what's a teammate
+// actively thinking about" signal feeding the bundle.
+const murmurBundleWindowHours = ledger.MaxMurmurWindowHours
+
+// sessionBundleLimit caps prior sessions pulled from ledgersearch before the
+// global bundleCap merge. A few strong session summaries give the client agent
+// enough prior-work grounding; more just dilutes.
+const sessionBundleLimit = 8
+
+// Relative weights per kind. Murmurs are the freshest (active work), sessions are
+// concrete prior work, team decisions/ADRs/docs are durable conventions the
+// judgment badges cite. These tune cross-kind ordering after each item's own
+// match strength is folded in; they are deliberately close so a strong hit in a
+// lower-weighted kind can still outrank a weak hit in a higher one.
+const (
+	weightMurmur   = 1.00
+	weightSession  = 0.95
+	weightDecision = 0.90
+	weightDoc      = 0.85
+)
+
+// contextBundleRetriever assembles the ranked, capped context bundle the client
+// agent reasons over. It is RETRIEVAL + RANKING ONLY — ox makes no inference and,
+// in the default path, no LLM or network call: every source is local (the ledger
+// murmur/session cache and the on-disk team context). FAIL-OPEN: any missing or
+// unreadable source contributes nothing rather than erroring.
+type contextBundleRetriever struct{}
+
+// Name identifies the retriever in logs and the registry.
+func (r *contextBundleRetriever) Name() string { return "context-bundle" }
+
+// Retrieve gathers murmurs, prior sessions, and team decisions/ADRs/docs that
+// match the plan, scores and merges them, and returns the top bundleCap items.
+// Fail-open everywhere: an empty plan or any source failure yields the items that
+// could be gathered (possibly none), never an error.
+func (r *contextBundleRetriever) Retrieve(ctx context.Context, in Input, gitRoot string) ([]ContextItem, error) {
+	files := planFiles(in)
+	headings := sectionHeadings(in)
+	query := deriveQuery(in)
+
+	var items []ContextItem
+	items = append(items, r.gatherMurmurs(gitRoot, files, headings)...)
+	items = append(items, r.gatherSessions(gitRoot, query)...)
+	items = append(items, r.gatherTeamContext(gitRoot, query, headings)...)
+
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	items = rankAndCap(items, bundleCap)
+	slog.Debug("plan context-bundle: assembled", "items", len(items), "files", len(files))
+	return items, nil
+}
+
+// gatherMurmurs surfaces recent teammate murmurs whose referenced files or topic
+// overlap the plan. Reuses resolveLedgerPath + ReadMurmursInWindow + the murmur
+// accessor helpers from collision.go rather than reimplementing ledger access.
+func (r *contextBundleRetriever) gatherMurmurs(gitRoot string, files, headings []string) []ContextItem {
+	ledgerPath := resolveLedgerPath(gitRoot)
+	if ledgerPath == "" {
+		return nil
+	}
+	murmurs, err := ledger.ReadMurmursInWindow(ledgerPath, murmurBundleWindowHours)
+	if err != nil || len(murmurs) == 0 {
+		return nil
+	}
+	return murmurContextItems(murmurs, files, headings, time.Now().UTC())
+}
+
+// gatherSessions pulls the most relevant prior-session summaries from the local
+// ledger via ledgersearch, reusing deriveQuery (priorart.go) for the query and
+// parseSessionAuthorDate (priorart.go) for attribution. The Ref is the session
+// folder name, usable directly by `ox session view <ref>`.
+func (r *contextBundleRetriever) gatherSessions(gitRoot, query string) []ContextItem {
+	if query == "" {
+		return nil
+	}
+	ledgerPath := resolveLedgerPath(gitRoot)
+	if ledgerPath == "" {
+		return nil
+	}
+	results, err := ledgersearch.Search(ledgersearch.Options{
+		LedgerPath: ledgerPath,
+		Query:      query,
+		Limit:      sessionBundleLimit,
+	})
+	if err != nil || len(results) == 0 {
+		return nil
+	}
+	return sessionContextItems(results)
+}
+
+// gatherTeamContext surfaces team decisions, ADRs, and docs that match the plan's
+// topic, LOCAL-FIRST from the on-disk team context checkout (the same source
+// `ox agent team-ctx` reads). No network in the default path.
+func (r *contextBundleRetriever) gatherTeamContext(gitRoot, query string, headings []string) []ContextItem {
+	if gitRoot == "" {
+		return nil
+	}
+	tc := config.FindRepoTeamContext(gitRoot)
+	if tc == nil || tc.Path == "" {
+		return nil
+	}
+
+	terms := topicTerms(query, headings)
+	if len(terms) == 0 {
+		return nil
+	}
+
+	docs, err := teamdocs.DiscoverDocs(tc.Path)
+	if err != nil {
+		slog.Debug("plan context-bundle: discover team docs failed", "error", err)
+		docs = nil
+	}
+	return teamDocContextItems(docs, terms)
+
+	// TODO(cloud-augment): when the local team-context checkout is sparse or the
+	// topic match is weak, optionally fan out to the cloud `ox query` / team-ctx
+	// API for un-cached decisions and cross-team discussions. That path makes a
+	// NETWORK call, so it must stay behind an explicit opt-in and never run in
+	// this default, local-first retrieval.
+}
+
+// murmurContextItems is the pure core of murmur bundling: given murmurs, the plan
+// files, and section headings, it returns one ContextItem per relevant murmur,
+// scored by match strength. now is injected so recency phrasing is deterministic
+// under test.
+func murmurContextItems(murmurs []ledger.MurmurFile, files, headings []string, now time.Time) []ContextItem {
+	want := make(map[string]struct{}, len(files))
+	for _, f := range files {
+		want[f] = struct{}{}
+	}
+
+	var items []ContextItem
+	for _, m := range murmurs {
+		matched, score := scoreMurmur(m, want, headings)
+		if !matched {
+			continue
+		}
+		who := murmurAuthor(m)
+		ts := m.Timestamp.UTC()
+		title := m.Topic
+		if title == "" {
+			title = "murmur from " + who
+		}
+		items = append(items, ContextItem{
+			Kind:    "murmur",
+			Title:   title,
+			Ref:     m.ID,
+			Snippet: snippet(m.Content, 200),
+			Score:   weightMurmur * score,
+			Author:  who,
+			When:    formatWhen(ts),
+		})
+	}
+	return items
+}
+
+// scoreMurmur reports whether a murmur is relevant to the plan and how strongly.
+// An explicit file reference (metadata["files"] overlapping a plan file) is the
+// strongest signal; a topic-vs-heading token overlap is a softer one. Returns
+// (false, 0) when neither fires.
+func scoreMurmur(m ledger.MurmurFile, want map[string]struct{}, headings []string) (bool, float64) {
+	for _, mf := range murmurFiles(m) {
+		if _, ok := matchPlanFile(mf, want); ok {
+			return true, 1.0
+		}
+	}
+	if m.Topic != "" && len(headings) > 0 && topicMatchesHeading(m.Topic, headings) {
+		return true, 0.6
+	}
+	return false, 0
+}
+
+// sessionContextItems converts ranked ledgersearch results into session/murmur
+// ContextItems. ledgersearch returns both doc types; murmurs already covered by
+// the dedicated murmur pass are skipped here to avoid double-surfacing — the
+// murmur pass carries richer file-match scoring. Sessions become Kind="session"
+// with a Ref usable by `ox session view`.
+func sessionContextItems(results []ledgersearch.Result) []ContextItem {
+	var items []ContextItem
+	for _, res := range results {
+		if res.DocType != "session" {
+			continue
+		}
+		author, date := parseSessionAuthorDate(res.SourceID, res.CreatedAt)
+		title := res.SourceID
+		if author != "" {
+			title = author + " — " + res.SourceID
+		}
+		items = append(items, ContextItem{
+			Kind:    "session",
+			Title:   title,
+			Ref:     res.SourceID,
+			Snippet: snippet(res.Text, 200),
+			Score:   weightSession * res.Score,
+			Author:  author,
+			When:    date,
+		})
+	}
+	return items
+}
+
+// teamDocContextItems matches discovered team docs against the plan's topic terms
+// and classifies each by kind (adr / decision / discussion) from its filename and
+// title. Score is the fraction of the doc's title+description+name tokens that the
+// plan's terms hit — a cheap, deterministic relevance proxy that needs no index.
+func teamDocContextItems(docs []teamdocs.TeamDoc, terms map[string]struct{}) []ContextItem {
+	var items []ContextItem
+	for _, d := range docs {
+		haystack := tokenizeWords(strings.ToLower(d.Name + " " + d.Title + " " + d.Description))
+		if len(haystack) == 0 {
+			continue
+		}
+		hits := 0
+		for _, tok := range haystack {
+			if _, ok := terms[tok]; ok {
+				hits++
+			}
+		}
+		if hits == 0 {
+			continue
+		}
+		score := float64(hits) / float64(len(haystack))
+		title := d.Title
+		if title == "" {
+			title = d.Name
+		}
+		items = append(items, ContextItem{
+			Kind:    classifyDocKind(d.Name, d.Title),
+			Title:   title,
+			Ref:     d.Path,
+			Snippet: snippet(d.Description, 200),
+			Score:   weightDoc * (0.5 + score), // floor so any real match clears weak murmurs
+			When:    d.When,
+		})
+	}
+	return items
+}
+
+// classifyDocKind maps a team doc to one of the bundle's allowed kinds. An ADR
+// (name/title mentioning "adr" or "architecture decision") is an "adr"; a doc
+// about a decision is a "decision"; everything else surfaced from team context is
+// a "discussion" (the team's shared written knowledge).
+func classifyDocKind(name, title string) string {
+	hay := strings.ToLower(name + " " + title)
+	switch {
+	case strings.Contains(hay, "adr") ||
+		strings.Contains(hay, "architecture decision") ||
+		strings.Contains(hay, "architecture-decision"):
+		return "adr"
+	case strings.Contains(hay, "decision"):
+		return "decision"
+	default:
+		return "discussion"
+	}
+}
+
+// topicTerms builds the set of salient lowercase tokens describing the plan's
+// topic, drawn from the derived query (priorart.go's keyword extraction) plus the
+// section headings. Short tokens are dropped to avoid matching on stopwords.
+func topicTerms(query string, headings []string) map[string]struct{} {
+	terms := make(map[string]struct{})
+	add := func(text string) {
+		for _, tok := range tokenizeWords(strings.ToLower(text)) {
+			if len(tok) < minKeyword {
+				continue
+			}
+			if _, skip := stopwords[tok]; skip {
+				continue
+			}
+			terms[tok] = struct{}{}
+		}
+	}
+	add(query)
+	for _, h := range headings {
+		add(h)
+	}
+	return terms
+}
+
+// rankAndCap sorts items by score descending (deterministic tiebreak on kind then
+// ref) and truncates to cap. This is the single place the bundle's token budget is
+// enforced — see bundleCap's doc comment for why the cap protects the client agent.
+func rankAndCap(items []ContextItem, limit int) []ContextItem {
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].Score != items[j].Score {
+			return items[i].Score > items[j].Score
+		}
+		if items[i].Kind != items[j].Kind {
+			return items[i].Kind < items[j].Kind
+		}
+		return items[i].Ref < items[j].Ref
+	})
+	if limit > 0 && len(items) > limit {
+		items = items[:limit]
+	}
+	return items
+}
+
+// snippet trims and collapses whitespace in text, truncating to max runes so a
+// long murmur/summary body doesn't blow the bundle's per-item footprint.
+func snippet(text string, max int) string {
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if len(runes) > max {
+		return strings.TrimSpace(string(runes[:max-1])) + "…"
+	}
+	return text
+}
+
+// formatWhen renders a timestamp as YYYY-MM-DD for the bundle's When field,
+// returning "" for a zero time so the field is omitted.
+func formatWhen(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}

--- a/internal/plan/context_bundle_test.go
+++ b/internal/plan/context_bundle_test.go
@@ -1,0 +1,364 @@
+package plan
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/ledger"
+	"github.com/sageox/ox/internal/ledgersearch"
+	"github.com/sageox/ox/internal/teamdocs"
+)
+
+// --- A. Murmur match + scoring ---
+
+// TestScoreMurmur verifies a murmur is bundled only when its files or topic
+// overlap the plan, with file matches outranking topic matches.
+// Failure prevented: an unrelated murmur leaking into the client's context
+// budget, or a relevant one (explicit file ref) being dropped.
+func TestScoreMurmur(t *testing.T) {
+	want := map[string]struct{}{"internal/auth/token.go": {}}
+	headings := []string{"Refactor OAuth refresh"}
+
+	tests := []struct {
+		name      string
+		murmur    ledger.MurmurFile
+		wantMatch bool
+		wantScore float64
+	}{
+		{
+			name: "explicit file reference scores highest",
+			murmur: ledger.MurmurFile{
+				Metadata: map[string]string{"files": "internal/auth/token.go"},
+			},
+			wantMatch: true,
+			wantScore: 1.0,
+		},
+		{
+			name: "directory-style file reference matches",
+			murmur: ledger.MurmurFile{
+				Metadata: map[string]string{"files": "internal/auth/"},
+			},
+			wantMatch: true,
+			wantScore: 1.0,
+		},
+		{
+			name: "topic overlap is a softer match",
+			murmur: ledger.MurmurFile{
+				Topic: "oauth provider wiring",
+			},
+			wantMatch: true,
+			wantScore: 0.6,
+		},
+		{
+			name: "no file and unrelated topic does not match",
+			murmur: ledger.MurmurFile{
+				Topic:    "unrelated billing work",
+				Metadata: map[string]string{"files": "internal/billing/charge.go"},
+			},
+			wantMatch: false,
+			wantScore: 0,
+		},
+		{
+			name:      "empty murmur does not match",
+			murmur:    ledger.MurmurFile{},
+			wantMatch: false,
+			wantScore: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMatch, gotScore := scoreMurmur(tt.murmur, want, headings)
+			if gotMatch != tt.wantMatch {
+				t.Fatalf("scoreMurmur() match = %v, want %v", gotMatch, tt.wantMatch)
+			}
+			if gotScore != tt.wantScore {
+				t.Fatalf("scoreMurmur() score = %v, want %v", gotScore, tt.wantScore)
+			}
+		})
+	}
+}
+
+// TestMurmurContextItems verifies relevant murmurs become well-formed bundle
+// items and irrelevant ones are excluded.
+// Failure prevented: malformed ContextItem (missing kind/ref/author) reaching
+// the client agent, or noise murmurs inflating the bundle.
+func TestMurmurContextItems(t *testing.T) {
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	files := []string{"internal/auth/token.go"}
+	headings := []string{"OAuth refresh"}
+
+	murmurs := []ledger.MurmurFile{
+		{
+			ID:          "m-relevant",
+			PrincipalID: "alice",
+			Topic:       "auth token cleanup",
+			Content:     "editing the token refresh path",
+			Timestamp:   now.Add(-2 * time.Hour),
+			Metadata:    map[string]string{"files": "internal/auth/token.go"},
+		},
+		{
+			ID:        "m-unrelated",
+			Topic:     "billing invoices",
+			Content:   "nothing to do with the plan",
+			Timestamp: now.Add(-1 * time.Hour),
+			Metadata:  map[string]string{"files": "internal/billing/charge.go"},
+		},
+	}
+
+	items := murmurContextItems(murmurs, files, headings, now)
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	got := items[0]
+	if got.Kind != "murmur" {
+		t.Errorf("kind = %q, want murmur", got.Kind)
+	}
+	if got.Ref != "m-relevant" {
+		t.Errorf("ref = %q, want m-relevant", got.Ref)
+	}
+	if got.Author != "alice" {
+		t.Errorf("author = %q, want alice", got.Author)
+	}
+	if got.When != "2026-06-03" {
+		t.Errorf("when = %q, want 2026-06-03", got.When)
+	}
+	if got.Score != weightMurmur*1.0 {
+		t.Errorf("score = %v, want %v", got.Score, weightMurmur*1.0)
+	}
+}
+
+// --- B. Session items from ledgersearch ---
+
+// TestSessionContextItems verifies session results become session items with a
+// `ox session view`-usable ref, and that murmur-typed results are skipped (the
+// dedicated murmur pass owns those with richer scoring).
+// Failure prevented: double-surfacing a murmur as both murmur and session, or a
+// session ref the client can't pass to `ox session view`.
+func TestSessionContextItems(t *testing.T) {
+	results := []ledgersearch.Result{
+		{
+			DocType:   "session",
+			SourceID:  "2026-05-01T09-30-bob-agent7",
+			Text:      "implemented oauth token refresh and caching",
+			Score:     0.9,
+			CreatedAt: "2026-05-01T09:30:00Z",
+		},
+		{
+			DocType:  "murmur",
+			SourceID: "m-skip",
+			Text:     "should not appear as a session",
+			Score:    0.8,
+		},
+	}
+
+	items := sessionContextItems(results)
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1 (murmur must be skipped)", len(items))
+	}
+	got := items[0]
+	if got.Kind != "session" {
+		t.Errorf("kind = %q, want session", got.Kind)
+	}
+	if got.Ref != "2026-05-01T09-30-bob-agent7" {
+		t.Errorf("ref = %q, want the session folder name", got.Ref)
+	}
+	if got.Author != "bob" {
+		t.Errorf("author = %q, want bob", got.Author)
+	}
+	if got.Score != weightSession*0.9 {
+		t.Errorf("score = %v, want %v", got.Score, weightSession*0.9)
+	}
+}
+
+// --- C. Team docs: matching + kind classification ---
+
+// TestClassifyDocKind verifies team docs are mapped to allowed bundle kinds.
+// Failure prevented: an ADR surfacing under the wrong kind, breaking the client
+// agent's aligns/conflicts reasoning which keys off adr/decision.
+func TestClassifyDocKind(t *testing.T) {
+	tests := []struct {
+		name, title, want string
+	}{
+		{"adr-018-perf.md", "ADR 018: Performance", "adr"},
+		{"architecture-decision-log.md", "", "adr"},
+		{"endpoint-decision.md", "Endpoint Decision", "decision"},
+		{"api-conventions.md", "API Conventions", "discussion"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyDocKind(tt.name, tt.title); got != tt.want {
+				t.Fatalf("classifyDocKind(%q, %q) = %q, want %q", tt.name, tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTeamDocContextItems verifies only topic-matching docs become items and that
+// non-matching docs are excluded.
+// Failure prevented: every team doc flooding the bundle regardless of relevance.
+func TestTeamDocContextItems(t *testing.T) {
+	terms := map[string]struct{}{"oauth": {}, "token": {}, "refresh": {}}
+	docs := []teamdocs.TeamDoc{
+		{
+			Name:        "adr-009-oauth.md",
+			Title:       "ADR 009: OAuth token strategy",
+			Description: "how we refresh tokens",
+			Path:        "/team/docs/adr-009-oauth.md",
+		},
+		{
+			Name:        "deploy-runbook.md",
+			Title:       "Deploy Runbook",
+			Description: "kubernetes rollout steps",
+			Path:        "/team/docs/deploy-runbook.md",
+		},
+	}
+
+	items := teamDocContextItems(docs, terms)
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1 (only the matching doc)", len(items))
+	}
+	got := items[0]
+	if got.Kind != "adr" {
+		t.Errorf("kind = %q, want adr", got.Kind)
+	}
+	if got.Ref != "/team/docs/adr-009-oauth.md" {
+		t.Errorf("ref = %q, want the doc path", got.Ref)
+	}
+	if got.Score <= 0 {
+		t.Errorf("score = %v, want > 0", got.Score)
+	}
+}
+
+// TestTopicTerms verifies salient terms are drawn from query+headings with
+// stopwords and short tokens dropped.
+// Failure prevented: stopwords matching every doc, or an empty topic silently
+// matching nothing meaningful.
+func TestTopicTerms(t *testing.T) {
+	terms := topicTerms("oauth token", []string{"Add the refresh flow"})
+	for _, want := range []string{"oauth", "token", "refresh", "flow"} {
+		if _, ok := terms[want]; !ok {
+			t.Errorf("missing term %q", want)
+		}
+	}
+	// "the" is a stopword, "add" is a stopword — must be absent.
+	for _, banned := range []string{"the", "add"} {
+		if _, ok := terms[banned]; ok {
+			t.Errorf("stopword %q leaked into terms", banned)
+		}
+	}
+}
+
+// --- D. Ranking + capping ---
+
+// TestRankAndCap verifies items are ordered by score desc and the bundle is
+// truncated to the cap.
+// Failure prevented: an unbounded bundle blowing the client agent's context
+// budget, or low-relevance items crowding out strong ones.
+func TestRankAndCap(t *testing.T) {
+	items := []ContextItem{
+		{Kind: "session", Ref: "low", Score: 0.2},
+		{Kind: "murmur", Ref: "high", Score: 0.9},
+		{Kind: "decision", Ref: "mid", Score: 0.5},
+	}
+	got := rankAndCap(items, 2)
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2 after cap", len(got))
+	}
+	if got[0].Ref != "high" || got[1].Ref != "mid" {
+		t.Fatalf("order = [%s,%s], want [high,mid]", got[0].Ref, got[1].Ref)
+	}
+}
+
+// TestRankAndCapDeterministic verifies equal scores break ties deterministically
+// (kind then ref) so JSON output is stable across runs.
+// Failure prevented: non-deterministic bundle ordering that breaks output diffs
+// and flakes tests downstream.
+func TestRankAndCapDeterministic(t *testing.T) {
+	items := []ContextItem{
+		{Kind: "session", Ref: "b", Score: 0.5},
+		{Kind: "adr", Ref: "a", Score: 0.5},
+		{Kind: "adr", Ref: "z", Score: 0.5},
+	}
+	got := rankAndCap(items, 0) // 0 = no cap
+	wantRefs := []string{"a", "z", "b"}
+	for i, w := range wantRefs {
+		if got[i].Ref != w {
+			t.Fatalf("got[%d].Ref = %q, want %q (order: %v)", i, got[i].Ref, w, refs(got))
+		}
+	}
+}
+
+func refs(items []ContextItem) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.Ref
+	}
+	return out
+}
+
+// --- E. Snippet truncation ---
+
+// TestSnippet verifies whitespace collapse and rune-safe truncation.
+// Failure prevented: a giant murmur body bloating one item, or truncation
+// splitting a multi-byte rune.
+func TestSnippet(t *testing.T) {
+	if got := snippet("  hello   world\n\tagain  ", 200); got != "hello world again" {
+		t.Errorf("whitespace collapse = %q", got)
+	}
+	long := snippet("aaaaaaaaaa", 5)
+	if []rune(long)[len([]rune(long))-1] != '…' {
+		t.Errorf("expected ellipsis on truncation, got %q", long)
+	}
+	// multi-byte runes must not be split mid-byte.
+	multi := snippet("日本語のテキストが長い場合", 5)
+	if len([]rune(multi)) > 5 {
+		t.Errorf("truncated length = %d runes, want <= 5", len([]rune(multi)))
+	}
+}
+
+// --- F. Fail-open behavior ---
+
+// TestRetrieveFailOpen verifies the retriever returns (nil, nil) — never an
+// error — when there is no project/ledger to read from.
+// Failure prevented: a missing ledger aborting plan enrichment instead of
+// degrading gracefully.
+func TestRetrieveFailOpen(t *testing.T) {
+	r := &contextBundleRetriever{}
+
+	// empty git root: nothing resolvable.
+	items, err := r.Retrieve(context.Background(), Input{}, "")
+	if err != nil {
+		t.Fatalf("err = %v, want nil (fail-open)", err)
+	}
+	if items != nil {
+		t.Fatalf("items = %v, want nil for empty input", items)
+	}
+
+	// non-existent git root with a populated-looking plan: still fail-open.
+	in := Input{Sections: []Section{
+		{Heading: "OAuth token refresh", Files: []string{"internal/auth/token.go"}},
+	}}
+	items, err = r.Retrieve(context.Background(), in, "/nonexistent/git/root")
+	if err != nil {
+		t.Fatalf("err = %v, want nil (fail-open)", err)
+	}
+	if items != nil {
+		t.Fatalf("items = %v, want nil when sources are unreadable", items)
+	}
+}
+
+// TestRetrieverRegistered verifies the retriever self-registers via init() so the
+// orchestrator picks it up.
+// Failure prevented: the bundle silently never being produced because the
+// retriever wasn't registered.
+func TestRetrieverRegistered(t *testing.T) {
+	_, rs := snapshotRegistry()
+	for _, r := range rs {
+		if r.Name() == "context-bundle" {
+			return
+		}
+	}
+	t.Fatal("context-bundle retriever not registered")
+}

--- a/internal/plan/enrich.go
+++ b/internal/plan/enrich.go
@@ -1,0 +1,172 @@
+package plan
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"sync"
+)
+
+// registry holds the detectors and retrievers contributed by Round 2 packages.
+// Registration happens via init() in collision.go / expert.go / priorart.go
+// (detectors) and the context-bundle assembler (retrievers). The registry is
+// intentionally global so feature files self-register without touching the
+// orchestrator. Enrich works correctly with zero registered detectors/retrievers
+// (it returns an empty, non-material Result).
+var (
+	registryMu sync.RWMutex
+	detectors  []Detector
+	retrievers []Retriever
+)
+
+// RegisterDetector adds a deterministic detector to the global registry.
+// Call from an init() in the detector's file. Nil detectors are ignored.
+func RegisterDetector(d Detector) {
+	if d == nil {
+		return
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	detectors = append(detectors, d)
+}
+
+// RegisterRetriever adds a context-bundle retriever to the global registry.
+// Call from an init() in the retriever's file. Nil retrievers are ignored.
+func RegisterRetriever(r Retriever) {
+	if r == nil {
+		return
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	retrievers = append(retrievers, r)
+}
+
+// snapshotRegistry returns copies of the registered detectors and retrievers
+// under the read lock, so Enrich can run without holding the lock across the
+// (potentially slow) detector calls.
+func snapshotRegistry() ([]Detector, []Retriever) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	ds := make([]Detector, len(detectors))
+	copy(ds, detectors)
+	rs := make([]Retriever, len(retrievers))
+	copy(rs, retrievers)
+	return ds, rs
+}
+
+// Enrich runs every registered detector and retriever against the plan, FAIL-OPEN:
+// a panic or error in any one detector/retriever is logged and skipped, never
+// aborting the others. It aggregates the annotations and context items, computes
+// a deterministic SignalSummary, and returns a sorted, deduped Result.
+//
+// ox makes NO network or LLM call here — detectors and retrievers read only
+// local data. Round 2 owns their implementations.
+func Enrich(ctx context.Context, in Input, gitRoot string) Result {
+	ds, rs := snapshotRegistry()
+
+	var annotations []Annotation
+	for _, d := range ds {
+		annotations = append(annotations, runDetector(ctx, d, in, gitRoot)...)
+	}
+
+	var items []ContextItem
+	for _, r := range rs {
+		items = append(items, runRetriever(ctx, r, in, gitRoot)...)
+	}
+
+	annotations = sortDedupeAnnotations(annotations)
+
+	return Result{
+		Annotations: annotations,
+		Context:     items,
+		Signals:     summarize(annotations),
+	}
+}
+
+// runDetector invokes a single detector with panic recovery so a misbehaving
+// detector can never abort enrichment.
+func runDetector(ctx context.Context, d Detector, in Input, gitRoot string) (out []Annotation) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Warn("plan detector panicked", "detector", d.Name(), "recover", r)
+			out = nil
+		}
+	}()
+	anns, err := d.Detect(ctx, in, gitRoot)
+	if err != nil {
+		slog.Warn("plan detector failed", "detector", d.Name(), "error", err)
+		return nil
+	}
+	return anns
+}
+
+// runRetriever invokes a single retriever with panic recovery (fail-open).
+func runRetriever(ctx context.Context, r Retriever, in Input, gitRoot string) (out []ContextItem) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Warn("plan retriever panicked", "retriever", r.Name(), "recover", rec)
+			out = nil
+		}
+	}()
+	items, err := r.Retrieve(ctx, in, gitRoot)
+	if err != nil {
+		slog.Warn("plan retriever failed", "retriever", r.Name(), "error", err)
+		return nil
+	}
+	return items
+}
+
+// summarize counts annotations by type and decides materiality. A plan is
+// material when any collision OR expert-route fired, or when there is at least
+// one prior-art hit (the "strong prior-art" gate is refined in Round 2 once
+// prior-art scoring exists).
+func summarize(annotations []Annotation) SignalSummary {
+	var s SignalSummary
+	for _, a := range annotations {
+		switch a.Type {
+		case BadgeCollision:
+			s.Collisions++
+		case BadgePriorArt:
+			s.PriorArt++
+		case BadgeExpertRoute:
+			s.ExpertRoutes++
+		}
+	}
+	s.Material = s.Collisions > 0 || s.ExpertRoutes > 0 || s.PriorArt >= 1
+	return s
+}
+
+// sortDedupeAnnotations produces a deterministic, duplicate-free ordering so the
+// JSON output is stable across runs (hooks diff it; tests assert on it).
+func sortDedupeAnnotations(annotations []Annotation) []Annotation {
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(annotations))
+	deduped := make([]Annotation, 0, len(annotations))
+	for _, a := range annotations {
+		key := a.Section + "\x00" + string(a.Type) + "\x00" + a.Why + "\x00" + a.SourceURL + "\x00" + a.Expert
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, a)
+	}
+
+	sort.SliceStable(deduped, func(i, j int) bool {
+		a, b := deduped[i], deduped[j]
+		if a.Section != b.Section {
+			return a.Section < b.Section
+		}
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		if a.Expert != b.Expert {
+			return a.Expert < b.Expert
+		}
+		return a.Why < b.Why
+	})
+
+	return deduped
+}

--- a/internal/plan/enrich_test.go
+++ b/internal/plan/enrich_test.go
@@ -1,0 +1,38 @@
+package plan
+
+import (
+	"context"
+	"testing"
+)
+
+// TestEnrichEmptyRegistry verifies the orchestrator works with zero registered
+// detectors/retrievers: empty annotations, empty context, non-material signals.
+func TestEnrichEmptyRegistry(t *testing.T) {
+	// Snapshot/restore the global registry so this test doesn't see (or leak)
+	// detectors registered by Round 2 packages.
+	registryMu.Lock()
+	savedDetectors, savedRetrievers := detectors, retrievers
+	detectors, retrievers = nil, nil
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		detectors, retrievers = savedDetectors, savedRetrievers
+		registryMu.Unlock()
+	})
+
+	in := Parse("## Section\nbody")
+	result := Enrich(context.Background(), in, "")
+
+	if len(result.Annotations) != 0 {
+		t.Errorf("expected no annotations, got %d", len(result.Annotations))
+	}
+	if len(result.Context) != 0 {
+		t.Errorf("expected no context items, got %d", len(result.Context))
+	}
+	if result.Signals.Material {
+		t.Errorf("expected non-material signals for empty registry")
+	}
+	if result.Signals.Collisions != 0 || result.Signals.PriorArt != 0 || result.Signals.ExpertRoutes != 0 {
+		t.Errorf("expected zero signal counts, got %+v", result.Signals)
+	}
+}

--- a/internal/plan/expert.go
+++ b/internal/plan/expert.go
@@ -1,0 +1,382 @@
+package plan
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/codedb"
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/paths"
+)
+
+// expertDetector routes each plan area/file to the team expert with CITED
+// evidence drawn from local data only. It computes author ownership per path
+// from codedb (commits joined to diffs) and emits one BadgeExpertRoute
+// annotation per dominant author, citing that author's most relevant real
+// artifact (a commit hash, or a PR url when one is on record).
+//
+// CITED-ONLY GUARANTEE: this detector never synthesizes an opinion and never
+// fabricates a link. SourceURL is only set from a value that came out of the
+// database (pull_requests.url or a real commit hash). If neither exists, the
+// expert is still routed by name but SourceURL is omitted.
+//
+// FAIL-OPEN: a missing index, an unreadable DB, an empty plan, or any query
+// error yields (nil, nil). Enrich recovers from panics; we also guard the DB
+// open path so a corrupt index can never abort enrichment.
+type expertDetector struct{}
+
+func init() {
+	RegisterDetector(&expertDetector{})
+}
+
+// Name identifies the detector in logs and the registry.
+func (e *expertDetector) Name() string { return "expert-routing" }
+
+// minCommitsToRoute is the floor for claiming someone "owns" a path. A single
+// drive-by commit is not ownership; we want a dominant, recurring author.
+const minCommitsToRoute = 2
+
+// authorStat is the per-path, per-author rollup pulled from codedb. It is the
+// pure input to ranking — no DB handle, so the ranking logic is unit-testable.
+type authorStat struct {
+	Author      string
+	Path        string
+	Commits     int
+	LastTouched time.Time
+	// CiteHash is a real commit hash for this author+path (most recent),
+	// usable as a citation ref. Empty when unknown.
+	CiteHash string
+	// CitePRURL is a real PR url touching this path (most recent merged/open),
+	// preferred over a bare commit ref when present. Empty when unknown.
+	CitePRURL string
+}
+
+// Detect resolves the codedb index, gathers author ownership for each cited
+// plan file, and emits expert-routing annotations. Fail-open throughout.
+func (e *expertDetector) Detect(ctx context.Context, in Input, gitRoot string) ([]Annotation, error) {
+	files := expertPlanFiles(in)
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	dataDir := resolveExpertCodeDBDir(gitRoot)
+	if dataDir == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(dataDir); err != nil {
+		// no index on disk — fail open, nothing to route from
+		return nil, nil
+	}
+
+	db, err := codedb.OpenSQLOnly(dataDir)
+	if err != nil {
+		slog.Debug("plan expert: open codedb failed", "error", err)
+		return nil, nil
+	}
+	defer func() { _ = db.Close() }()
+
+	stats := gatherAuthorStats(ctx, db.Store(), files)
+	if len(stats) == 0 {
+		return nil, nil
+	}
+
+	anns := rankExperts(stats)
+	if len(anns) == 0 {
+		return nil, nil
+	}
+	slog.Debug("plan expert: routed areas", "files", len(files), "experts", len(anns))
+	return anns, nil
+}
+
+// expertPlanFiles returns the deduped, sorted set of file references cited
+// anywhere in the plan. Sections already carry extracted Files; we union them.
+// Named distinctly from the package-shared planFiles helper so this file builds
+// independently of peers' in-flight files.
+func expertPlanFiles(in Input) []string {
+	seen := make(map[string]struct{})
+	var files []string
+	for _, s := range in.Sections {
+		for _, f := range s.Files {
+			f = strings.TrimSpace(f)
+			if f == "" {
+				continue
+			}
+			// strip any :line suffix so path ownership matches the file
+			if idx := strings.LastIndexByte(f, ':'); idx > 0 {
+				if _, err := fmt.Sscanf(f[idx+1:], "%d", new(int)); err == nil {
+					f = f[:idx]
+				}
+			}
+			if _, ok := seen[f]; ok {
+				continue
+			}
+			seen[f] = struct{}{}
+			files = append(files, f)
+		}
+	}
+	sort.Strings(files)
+	return files
+}
+
+// gatherAuthorStats queries codedb for per-path author commit counts, last-touch
+// time, and a citable artifact (commit hash, PR url). Each query is best-effort:
+// a failure on one path skips that path, never the whole detector.
+func gatherAuthorStats(ctx context.Context, s *store.Store, files []string) []authorStat {
+	var out []authorStat
+	for _, path := range files {
+		if ctx.Err() != nil {
+			break
+		}
+		out = append(out, authorStatsForPath(s, path)...)
+	}
+	return out
+}
+
+// authorStatsForPath returns one authorStat per author who has touched path,
+// each carrying a real, citable commit hash and (when available) a PR url.
+func authorStatsForPath(s *store.Store, path string) []authorStat {
+	rows, err := s.Query(`
+		SELECT c.author, COUNT(*) AS commits, MAX(c.timestamp) AS last_ts
+		FROM diffs d
+		JOIN commits c ON c.id = d.commit_id
+		WHERE d.path = ? AND c.author IS NOT NULL AND c.author != ''
+		GROUP BY c.author
+		ORDER BY commits DESC, last_ts DESC`, path)
+	if err != nil {
+		slog.Debug("plan expert: author query failed", "path", path, "error", err)
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var stats []authorStat
+	for rows.Next() {
+		var st authorStat
+		var lastTS int64
+		if err := rows.Scan(&st.Author, &st.Commits, &lastTS); err != nil {
+			continue
+		}
+		st.Path = path
+		st.LastTouched = time.Unix(lastTS, 0).UTC()
+		st.CiteHash = mostRecentCommitHash(s, path, st.Author)
+		st.CitePRURL = mostRecentPRURL(s, path, st.Author)
+		stats = append(stats, st)
+	}
+	return stats
+}
+
+// mostRecentCommitHash returns the newest real commit hash by author on path,
+// for use as a citation ref. Empty string when none — never fabricated.
+func mostRecentCommitHash(s *store.Store, path, author string) string {
+	row := s.QueryRow(`
+		SELECT c.hash
+		FROM diffs d
+		JOIN commits c ON c.id = d.commit_id
+		WHERE d.path = ? AND c.author = ?
+		ORDER BY c.timestamp DESC
+		LIMIT 1`, path, author)
+	var hash string
+	if err := row.Scan(&hash); err != nil {
+		return ""
+	}
+	return hash
+}
+
+// mostRecentPRURL returns the url of the newest PR whose commits touched path
+// and were authored by author. Empty when none — a PR url, when present, is a
+// stronger citation than a bare commit hash. Never fabricated.
+func mostRecentPRURL(s *store.Store, path, author string) string {
+	row := s.QueryRow(`
+		SELECT p.url
+		FROM pull_requests p
+		JOIN pr_commits pc ON pc.pr_id = p.id
+		JOIN commits c ON c.hash = pc.sha
+		JOIN diffs d ON d.commit_id = c.id
+		WHERE d.path = ? AND c.author = ? AND p.url IS NOT NULL AND p.url != ''
+		ORDER BY COALESCE(p.merged_at, p.updated_at, p.created_at) DESC
+		LIMIT 1`, path, author)
+	var url string
+	if err := row.Scan(&url); err != nil {
+		return ""
+	}
+	return url
+}
+
+// rankExperts is the pure routing core: given per-file author stats, it picks
+// the dominant author for each file, groups files under their dominant author,
+// and produces one annotation per expert citing the strongest real artifact.
+//
+// Deterministic: ties broken by recency then author name; outputs sorted by
+// expert name. No DB handle, no network — unit-testable in isolation.
+func rankExperts(stats []authorStat) []Annotation {
+	// dominant author per path
+	type winner struct {
+		author      string
+		commits     int
+		lastTouched time.Time
+		citeHash    string
+		citePRURL   string
+	}
+	byPath := make(map[string]winner)
+	for _, st := range stats {
+		if st.Author == "" || st.Path == "" {
+			continue
+		}
+		w, ok := byPath[st.Path]
+		if !ok || betterOwner(st, w.commits, w.lastTouched, w.author) {
+			byPath[st.Path] = winner{
+				author:      st.Author,
+				commits:     st.Commits,
+				lastTouched: st.LastTouched,
+				citeHash:    st.CiteHash,
+				citePRURL:   st.CitePRURL,
+			}
+		}
+	}
+
+	// group paths under their dominant author
+	type areaOwnership struct {
+		files       []string
+		commits     int
+		lastTouched time.Time
+		citeHash    string
+		citePRURL   string
+	}
+	byExpert := make(map[string]*areaOwnership)
+	for path, w := range byPath {
+		if w.commits < minCommitsToRoute {
+			continue // a single drive-by commit is not ownership
+		}
+		ao, ok := byExpert[w.author]
+		if !ok {
+			ao = &areaOwnership{}
+			byExpert[w.author] = ao
+		}
+		ao.files = append(ao.files, path)
+		ao.commits += w.commits
+		if w.lastTouched.After(ao.lastTouched) {
+			ao.lastTouched = w.lastTouched
+			// cite the artifact from the author's most recent owned path
+			ao.citeHash = w.citeHash
+			ao.citePRURL = w.citePRURL
+		}
+	}
+
+	experts := make([]string, 0, len(byExpert))
+	for name := range byExpert {
+		experts = append(experts, name)
+	}
+	sort.Strings(experts)
+
+	var anns []Annotation
+	for _, name := range experts {
+		ao := byExpert[name]
+		sort.Strings(ao.files)
+		anns = append(anns, Annotation{
+			Kind:      BadgeDeterministic,
+			Type:      BadgeExpertRoute,
+			Expert:    name,
+			Files:     ao.files,
+			Why:       whyOwns(name, ao.files, ao.commits, ao.lastTouched),
+			SourceURL: citation(ao.citePRURL, ao.citeHash),
+		})
+	}
+	return anns
+}
+
+// betterOwner reports whether candidate stat beats the current per-path winner.
+// Primary key: commit count. Tie-break: recency, then author name (stable).
+func betterOwner(cand authorStat, curCommits int, curLast time.Time, curAuthor string) bool {
+	if cand.Commits != curCommits {
+		return cand.Commits > curCommits
+	}
+	if !cand.LastTouched.Equal(curLast) {
+		return cand.LastTouched.After(curLast)
+	}
+	return cand.Author < curAuthor
+}
+
+// whyOwns builds the human-readable routing rationale. It names the area
+// (a shared directory prefix when the files share one, else "these files").
+func whyOwns(name string, files []string, commits int, lastTouched time.Time) string {
+	area := commonArea(files)
+	when := "unknown"
+	if !lastTouched.IsZero() {
+		when = lastTouched.Format("Jan 2006")
+	}
+	return fmt.Sprintf("%s owns %s (%d commits, last touched %s)", name, area, commits, when)
+}
+
+// citation returns the cited artifact ref. A PR url wins over a commit hash.
+// Returns "" when neither is real — the caller then omits SourceURL rather than
+// inventing one.
+func citation(prURL, commitHash string) string {
+	if prURL != "" {
+		return prURL
+	}
+	if commitHash != "" {
+		return "commit:" + commitHash
+	}
+	return ""
+}
+
+// commonArea returns the longest shared directory prefix across files, or
+// "these files" when they don't share a directory. Used only for the Why string.
+func commonArea(files []string) string {
+	if len(files) == 0 {
+		return "these files"
+	}
+	if len(files) == 1 {
+		return files[0]
+	}
+	parts := strings.Split(dirOf(files[0]), "/")
+	for _, f := range files[1:] {
+		fp := strings.Split(dirOf(f), "/")
+		n := len(parts)
+		if len(fp) < n {
+			n = len(fp)
+		}
+		i := 0
+		for i < n && parts[i] == fp[i] {
+			i++
+		}
+		parts = parts[:i]
+		if len(parts) == 0 {
+			break
+		}
+	}
+	if len(parts) == 0 || (len(parts) == 1 && parts[0] == "") {
+		return "these files"
+	}
+	return strings.Join(parts, "/") + "/"
+}
+
+// dirOf returns the directory portion of a repo-relative path ("" for a
+// top-level file).
+func dirOf(path string) string {
+	if idx := strings.LastIndexByte(path, '/'); idx >= 0 {
+		return path[:idx]
+	}
+	return ""
+}
+
+// resolveExpertCodeDBDir resolves the codedb index directory the same way the
+// `ox code` commands do: prefer the shared ledger cache (repo-scoped), fall back
+// to the project-local cache. Returns "" when nothing can be resolved so the
+// caller fails open. No hardcoded paths.
+func resolveExpertCodeDBDir(gitRoot string) string {
+	if gitRoot == "" {
+		return ""
+	}
+	if ctx, err := config.LoadProjectContext(gitRoot); err == nil {
+		if dir := paths.CodeDBSharedDir(ctx.RepoID(), ctx.Endpoint()); dir != "" {
+			return dir
+		}
+	}
+	return paths.CodeDBDataDir(gitRoot)
+}

--- a/internal/plan/expert_test.go
+++ b/internal/plan/expert_test.go
@@ -1,0 +1,334 @@
+package plan
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", s, err)
+	}
+	return tm.UTC()
+}
+
+func TestRankExperts(t *testing.T) {
+	may := mustTime(t, "2026-05-10")
+	apr := mustTime(t, "2026-04-01")
+	jun := mustTime(t, "2026-06-01")
+
+	tests := []struct {
+		name  string
+		stats []authorStat
+		// expectations keyed by expert name
+		wantExperts map[string]struct {
+			files     []string
+			source    string
+			whyHas    []string // substrings required in Why
+			whyMisses []string
+		}
+		wantCount int
+	}{
+		{
+			name:        "empty input routes nobody",
+			stats:       nil,
+			wantExperts: nil,
+			wantCount:   0,
+		},
+		{
+			name: "single dominant author routes with PR citation",
+			stats: []authorStat{
+				{Author: "ajit", Path: "internal/auth/token.go", Commits: 9, LastTouched: may, CiteHash: "abc123", CitePRURL: "https://git/pr/42"},
+				{Author: "dana", Path: "internal/auth/token.go", Commits: 2, LastTouched: apr, CiteHash: "def456"},
+			},
+			wantExperts: map[string]struct {
+				files     []string
+				source    string
+				whyHas    []string
+				whyMisses []string
+			}{
+				"ajit": {
+					files:  []string{"internal/auth/token.go"},
+					source: "https://git/pr/42",
+					whyHas: []string{"ajit owns", "9 commits", "May 2026"},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "commit-hash citation when no PR url",
+			stats: []authorStat{
+				{Author: "rupak", Path: "internal/codedb/store.go", Commits: 5, LastTouched: jun, CiteHash: "deadbeef"},
+			},
+			wantExperts: map[string]struct {
+				files     []string
+				source    string
+				whyHas    []string
+				whyMisses []string
+			}{
+				"rupak": {
+					files:  []string{"internal/codedb/store.go"},
+					source: "commit:deadbeef",
+					whyHas: []string{"rupak owns", "5 commits"},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "no citable artifact omits SourceURL but still routes",
+			stats: []authorStat{
+				{Author: "sam", Path: "internal/x/y.go", Commits: 4, LastTouched: may},
+			},
+			wantExperts: map[string]struct {
+				files     []string
+				source    string
+				whyHas    []string
+				whyMisses []string
+			}{
+				"sam": {
+					files:  []string{"internal/x/y.go"},
+					source: "",
+					whyHas: []string{"sam owns"},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "below-threshold ownership is dropped",
+			stats: []authorStat{
+				{Author: "drive-by", Path: "internal/z/q.go", Commits: 1, LastTouched: may, CiteHash: "h"},
+			},
+			wantExperts: nil,
+			wantCount:   0,
+		},
+		{
+			name: "multiple files under one expert share a common area",
+			stats: []authorStat{
+				{Author: "ajit", Path: "internal/auth/token.go", Commits: 9, LastTouched: may, CiteHash: "a1"},
+				{Author: "ajit", Path: "internal/auth/refresh.go", Commits: 6, LastTouched: jun, CiteHash: "a2", CitePRURL: "https://git/pr/77"},
+			},
+			wantExperts: map[string]struct {
+				files     []string
+				source    string
+				whyHas    []string
+				whyMisses []string
+			}{
+				"ajit": {
+					files:  []string{"internal/auth/refresh.go", "internal/auth/token.go"},
+					source: "https://git/pr/77", // from the most-recently-touched owned path (jun)
+					whyHas: []string{"internal/auth/", "15 commits", "Jun 2026"},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "two experts each route their own area, sorted by name",
+			stats: []authorStat{
+				{Author: "rupak", Path: "internal/codedb/store.go", Commits: 8, LastTouched: jun, CiteHash: "r1"},
+				{Author: "ajit", Path: "internal/auth/token.go", Commits: 5, LastTouched: may, CiteHash: "a1"},
+			},
+			wantExperts: map[string]struct {
+				files     []string
+				source    string
+				whyHas    []string
+				whyMisses []string
+			}{
+				"ajit":  {files: []string{"internal/auth/token.go"}, source: "commit:a1", whyHas: []string{"ajit owns"}},
+				"rupak": {files: []string{"internal/codedb/store.go"}, source: "commit:r1", whyHas: []string{"rupak owns"}},
+			},
+			wantCount: 2,
+		},
+		{
+			name: "dominant author wins on commit count, not recency",
+			stats: []authorStat{
+				{Author: "veteran", Path: "internal/core/engine.go", Commits: 20, LastTouched: apr, CiteHash: "v1"},
+				{Author: "newcomer", Path: "internal/core/engine.go", Commits: 3, LastTouched: jun, CiteHash: "n1"},
+			},
+			wantExperts: map[string]struct {
+				files     []string
+				source    string
+				whyHas    []string
+				whyMisses []string
+			}{
+				"veteran": {files: []string{"internal/core/engine.go"}, source: "commit:v1", whyHas: []string{"veteran owns", "20 commits"}},
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rankExperts(tc.stats)
+			if len(got) != tc.wantCount {
+				t.Fatalf("rankExperts returned %d annotations, want %d: %+v", len(got), tc.wantCount, got)
+			}
+			gotByExpert := make(map[string]Annotation, len(got))
+			for _, a := range got {
+				if a.Kind != BadgeDeterministic {
+					t.Errorf("expert %q: Kind=%q, want %q", a.Expert, a.Kind, BadgeDeterministic)
+				}
+				if a.Type != BadgeExpertRoute {
+					t.Errorf("expert %q: Type=%q, want %q", a.Expert, a.Type, BadgeExpertRoute)
+				}
+				gotByExpert[a.Expert] = a
+			}
+
+			// outputs are sorted by expert name
+			for i := 1; i < len(got); i++ {
+				if got[i-1].Expert > got[i].Expert {
+					t.Errorf("annotations not sorted by expert: %q before %q", got[i-1].Expert, got[i].Expert)
+				}
+			}
+
+			for name, want := range tc.wantExperts {
+				a, ok := gotByExpert[name]
+				if !ok {
+					t.Fatalf("expected expert %q routed, missing", name)
+				}
+				if !equalStrings(a.Files, want.files) {
+					t.Errorf("expert %q: Files=%v, want %v", name, a.Files, want.files)
+				}
+				if a.SourceURL != want.source {
+					t.Errorf("expert %q: SourceURL=%q, want %q", name, a.SourceURL, want.source)
+				}
+				for _, sub := range want.whyHas {
+					if !strings.Contains(a.Why, sub) {
+						t.Errorf("expert %q: Why=%q missing %q", name, a.Why, sub)
+					}
+				}
+				for _, sub := range want.whyMisses {
+					if strings.Contains(a.Why, sub) {
+						t.Errorf("expert %q: Why=%q must not contain %q", name, a.Why, sub)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCitationNeverFabricates(t *testing.T) {
+	// no real artifact -> empty, caller omits SourceURL
+	if got := citation("", ""); got != "" {
+		t.Errorf("citation with no artifact = %q, want empty", got)
+	}
+	// PR url wins over commit hash
+	if got := citation("https://git/pr/1", "abc"); got != "https://git/pr/1" {
+		t.Errorf("citation = %q, want PR url", got)
+	}
+	if got := citation("", "abc"); got != "commit:abc" {
+		t.Errorf("citation = %q, want commit:abc", got)
+	}
+}
+
+func TestCommonArea(t *testing.T) {
+	tests := []struct {
+		files []string
+		want  string
+	}{
+		{nil, "these files"},
+		{[]string{"internal/auth/token.go"}, "internal/auth/token.go"},
+		{[]string{"internal/auth/a.go", "internal/auth/b.go"}, "internal/auth/"},
+		{[]string{"internal/auth/a.go", "internal/codedb/b.go"}, "internal/"},
+		{[]string{"cmd/ox/a.go", "internal/auth/b.go"}, "these files"},
+		{[]string{"README.md", "CHANGELOG.md"}, "these files"},
+	}
+	for _, tc := range tests {
+		if got := commonArea(tc.files); got != tc.want {
+			t.Errorf("commonArea(%v) = %q, want %q", tc.files, got, tc.want)
+		}
+	}
+}
+
+func TestBetterOwner(t *testing.T) {
+	may := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	jun := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// higher commit count wins
+	if !betterOwner(authorStat{Author: "a", Commits: 5, LastTouched: may}, 3, jun, "b") {
+		t.Error("higher commit count should win")
+	}
+	// lower commit count loses even if more recent
+	if betterOwner(authorStat{Author: "a", Commits: 2, LastTouched: jun}, 5, may, "b") {
+		t.Error("lower commit count should lose")
+	}
+	// tie on commits -> recency wins
+	if !betterOwner(authorStat{Author: "a", Commits: 5, LastTouched: jun}, 5, may, "b") {
+		t.Error("on tie, more recent should win")
+	}
+	// tie on commits and recency -> lexicographically smaller author wins (stable)
+	if !betterOwner(authorStat{Author: "aaa", Commits: 5, LastTouched: may}, 5, may, "bbb") {
+		t.Error("on full tie, smaller author name should win")
+	}
+}
+
+func TestPlanFiles(t *testing.T) {
+	in := Input{
+		Sections: []Section{
+			{Files: []string{"internal/auth/token.go", "internal/auth/token.go:42"}},
+			{Files: []string{"cmd/ox/plan.go", "  "}},
+			{Files: nil},
+		},
+	}
+	got := expertPlanFiles(in)
+	want := []string{"cmd/ox/plan.go", "internal/auth/token.go"}
+	if !equalStrings(got, want) {
+		t.Errorf("expertPlanFiles = %v, want %v", got, want)
+	}
+}
+
+func TestDetectFailsOpenOnEmptyPlan(t *testing.T) {
+	d := &expertDetector{}
+	// empty plan, no files -> (nil, nil), never an error
+	anns, err := d.Detect(context.Background(), Input{}, "/nonexistent/root")
+	if err != nil {
+		t.Fatalf("Detect returned error on empty plan: %v", err)
+	}
+	if anns != nil {
+		t.Errorf("Detect returned annotations on empty plan: %v", anns)
+	}
+}
+
+func TestDetectFailsOpenOnMissingIndex(t *testing.T) {
+	d := &expertDetector{}
+	in := Input{
+		Sections: []Section{{Files: []string{"internal/auth/token.go"}}},
+	}
+	// gitRoot that resolves to no codedb index -> fail open, no error
+	anns, err := d.Detect(context.Background(), in, t.TempDir())
+	if err != nil {
+		t.Fatalf("Detect returned error on missing index: %v", err)
+	}
+	if anns != nil {
+		t.Errorf("Detect returned annotations with no index: %v", anns)
+	}
+}
+
+func TestExpertDetectorRegistered(t *testing.T) {
+	ds, _ := snapshotRegistry()
+	found := false
+	for _, d := range ds {
+		if d.Name() == "expert-routing" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expertDetector not registered via init()")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/plan/input.go
+++ b/internal/plan/input.go
@@ -1,0 +1,203 @@
+package plan
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// h2Pattern matches a markdown H2 heading at the start of a line ("## Heading").
+// Content before the first H2 forms a preamble section with an empty Heading.
+var h2Pattern = regexp.MustCompile(`(?m)^##\s+(.+?)\s*$`)
+
+// fileRefPattern extracts file references from a plan section. Two shapes:
+//   - backtick-quoted paths: `internal/plan/input.go`, `cmd/ox/plan.go`
+//   - path:line refs: internal/plan/input.go:42
+//
+// Kept deliberately conservative — a reference must look path-like (contain a
+// slash or a known source extension) to avoid matching prose in backticks.
+var fileRefPattern = regexp.MustCompile(
+	"`([^`\\n]+)`" + // group 1: backtick-quoted span
+		"|" +
+		`\b([\w./-]+\.[A-Za-z0-9]+(?::\d+)?)\b`, // group 2: path.ext or path.ext:line
+)
+
+// pathLike reports whether a candidate extracted reference looks like a file
+// path rather than incidental prose. Requires either a directory separator or a
+// recognizable source-file extension.
+var pathLikePattern = regexp.MustCompile(`(/|\.[A-Za-z0-9]{1,6}(?::\d+)?$)`)
+
+// Resolve reads a plan from --file if set, otherwise from a piped stdin, and
+// parses it into an Input. When neither is provided it best-effort auto-discovers
+// the active plan-mode file: the newest *.md under ~/.claude/plans/ (the dir
+// Claude Code plan-mode writes to). Precedence is --file > piped stdin >
+// auto-discovery. An empty/unfound source yields an Input with empty Raw and no
+// sections (the enrich path must stay fail-open on empty input); the caller is
+// expected to surface a clear "no plan found" message rather than enrich nothing.
+func Resolve(file string, stdin io.Reader) (Input, error) {
+	if file != "" {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return Input{}, fmt.Errorf("read plan file %q: %w", file, err)
+		}
+		in := Parse(string(data))
+		in.Path = file
+		return in, nil
+	}
+
+	// A piped stdin takes precedence over auto-discovery: agents pipe the plan
+	// explicitly. A nil reader (no pipe) means the human porcelain path, where
+	// we fall through to auto-discovery.
+	if stdin != nil {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return Input{}, fmt.Errorf("read plan from stdin: %w", err)
+		}
+		// Only treat stdin as the source when it actually carried content; an
+		// empty pipe (e.g. a TTY reported as a non-nil but empty reader) should
+		// still fall through to auto-discovery.
+		if strings.TrimSpace(string(data)) != "" {
+			return Parse(string(data)), nil
+		}
+	}
+
+	// Auto-discovery: newest plan-mode markdown file, if any. Best-effort —
+	// a missing dir / no files yields an empty Input (unchanged behavior).
+	if path := discoverActivePlanFile(planModeDir()); path != "" {
+		if data, err := os.ReadFile(path); err == nil {
+			in := Parse(string(data))
+			in.Path = path
+			return in, nil
+		}
+	}
+
+	return Parse(""), nil
+}
+
+// planModeDirOverride lets tests point auto-discovery at a temp directory
+// without touching the real ~/.claude/plans. Empty means "use the default".
+var planModeDirOverride string
+
+// planModeDir returns the Claude Code plan-mode directory (~/.claude/plans),
+// or the test override when set. Returns "" when the home dir is unresolvable
+// so discovery degrades to a no-op.
+func planModeDir() string {
+	if planModeDirOverride != "" {
+		return planModeDirOverride
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".claude", "plans")
+}
+
+// discoverActivePlanFile returns the absolute path of the newest *.md file in
+// dir (by modification time), or "" when dir is empty, missing, or holds no
+// markdown. Best-effort: any read error degrades to "" rather than aborting.
+func discoverActivePlanFile(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+
+	var newest string
+	var newestMod int64 = -1
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if mod := info.ModTime().UnixNano(); mod > newestMod {
+			newestMod = mod
+			newest = filepath.Join(dir, entry.Name())
+		}
+	}
+	return newest
+}
+
+// Parse splits markdown into Sections on "## " H2 headings and extracts the file
+// references cited in each section. Content before the first H2 becomes a
+// preamble Section with an empty Heading (only emitted when it has content).
+func Parse(raw string) Input {
+	in := Input{Raw: raw}
+	if strings.TrimSpace(raw) == "" {
+		return in
+	}
+
+	locs := h2Pattern.FindAllStringSubmatchIndex(raw, -1)
+
+	// preamble: everything before the first H2 heading.
+	firstHeadingStart := len(raw)
+	if len(locs) > 0 {
+		firstHeadingStart = locs[0][0]
+	}
+	if preamble := strings.TrimSpace(raw[:firstHeadingStart]); preamble != "" {
+		in.Sections = append(in.Sections, newSection("", preamble))
+	}
+
+	for i, loc := range locs {
+		heading := strings.TrimSpace(raw[loc[2]:loc[3]])
+		bodyStart := loc[1]
+		bodyEnd := len(raw)
+		if i+1 < len(locs) {
+			bodyEnd = locs[i+1][0]
+		}
+		body := strings.TrimSpace(raw[bodyStart:bodyEnd])
+		in.Sections = append(in.Sections, newSection(heading, body))
+	}
+
+	return in
+}
+
+// newSection builds a Section, extracting file references from heading+body.
+func newSection(heading, body string) Section {
+	return Section{
+		Heading: heading,
+		Body:    body,
+		Files:   extractFileRefs(heading + "\n" + body),
+	}
+}
+
+// extractFileRefs pulls path-like file references out of text, deduped and
+// sorted for deterministic output.
+func extractFileRefs(text string) []string {
+	matches := fileRefPattern.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(matches))
+	var refs []string
+	for _, m := range matches {
+		candidate := m[1]
+		if candidate == "" {
+			candidate = m[2]
+		}
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if !pathLikePattern.MatchString(candidate) {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		refs = append(refs, candidate)
+	}
+
+	sort.Strings(refs)
+	return refs
+}

--- a/internal/plan/input_test.go
+++ b/internal/plan/input_test.go
@@ -1,0 +1,279 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		wantHeadings []string
+		// wantFiles maps a section heading to the file refs expected in it.
+		wantFiles map[string][]string
+	}{
+		{
+			name:         "empty input yields no sections",
+			raw:          "",
+			wantHeadings: nil,
+		},
+		{
+			name:         "whitespace-only input yields no sections",
+			raw:          "   \n\t\n  ",
+			wantHeadings: nil,
+		},
+		{
+			name:         "single H2 section",
+			raw:          "## Overview\nSome body text here.",
+			wantHeadings: []string{"Overview"},
+			wantFiles:    map[string][]string{"Overview": nil},
+		},
+		{
+			name:         "multiple H2 sections split correctly",
+			raw:          "## First\nbody one\n\n## Second\nbody two\n\n## Third\nbody three",
+			wantHeadings: []string{"First", "Second", "Third"},
+		},
+		{
+			name:         "preamble before first H2 becomes empty-heading section",
+			raw:          "Intro paragraph before any heading.\n\n## Real Section\nbody",
+			wantHeadings: []string{"", "Real Section"},
+		},
+		{
+			name:         "backtick-quoted file paths extracted",
+			raw:          "## Changes\nEdit `internal/plan/input.go` and `cmd/ox/plan.go`.",
+			wantHeadings: []string{"Changes"},
+			wantFiles: map[string][]string{
+				"Changes": {"cmd/ox/plan.go", "internal/plan/input.go"},
+			},
+		},
+		{
+			name:         "path:line refs extracted",
+			raw:          "## Bug\nThe issue is at internal/plan/enrich.go:42 in the loop.",
+			wantHeadings: []string{"Bug"},
+			wantFiles: map[string][]string{
+				"Bug": {"internal/plan/enrich.go:42"},
+			},
+		},
+		{
+			name:         "non-path backticks are ignored",
+			raw:          "## Notes\nRun `make build` and check `the result`.",
+			wantHeadings: []string{"Notes"},
+			wantFiles:    map[string][]string{"Notes": nil},
+		},
+		{
+			name:         "duplicate file refs deduped and sorted",
+			raw:          "## Dup\nTouch `a/b.go`, then `a/b.go` again, plus `a/a.go`.",
+			wantHeadings: []string{"Dup"},
+			wantFiles: map[string][]string{
+				"Dup": {"a/a.go", "a/b.go"},
+			},
+		},
+		{
+			name:         "bare extension file without directory extracted",
+			raw:          "## Top\nUpdate `Makefile.go` here.",
+			wantHeadings: []string{"Top"},
+			wantFiles: map[string][]string{
+				"Top": {"Makefile.go"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := Parse(tt.raw)
+
+			if in.Raw != tt.raw {
+				t.Errorf("Raw mismatch: got %q want %q", in.Raw, tt.raw)
+			}
+
+			var gotHeadings []string
+			for _, s := range in.Sections {
+				gotHeadings = append(gotHeadings, s.Heading)
+			}
+			if !reflect.DeepEqual(gotHeadings, tt.wantHeadings) {
+				t.Errorf("headings: got %v want %v", gotHeadings, tt.wantHeadings)
+			}
+
+			for heading, wantFiles := range tt.wantFiles {
+				sec := findSection(in.Sections, heading)
+				if sec == nil {
+					t.Fatalf("section %q not found", heading)
+				}
+				if !reflect.DeepEqual(sec.Files, wantFiles) {
+					t.Errorf("section %q files: got %v want %v", heading, sec.Files, wantFiles)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveEmptyStdin(t *testing.T) {
+	// point auto-discovery at an empty dir so the test never reads the real
+	// ~/.claude/plans and an empty stdin yields an empty Input.
+	withPlanModeDir(t, t.TempDir())
+	in, err := Resolve("", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("Resolve empty stdin: unexpected error %v", err)
+	}
+	if len(in.Sections) != 0 {
+		t.Errorf("expected no sections for empty input, got %d", len(in.Sections))
+	}
+}
+
+func TestResolveNilStdin(t *testing.T) {
+	withPlanModeDir(t, t.TempDir())
+	in, err := Resolve("", nil)
+	if err != nil {
+		t.Fatalf("Resolve nil stdin: unexpected error %v", err)
+	}
+	if len(in.Sections) != 0 {
+		t.Errorf("expected no sections for nil input, got %d", len(in.Sections))
+	}
+}
+
+// withPlanModeDir points auto-discovery at a temp dir for the duration of a
+// test, restoring the default afterward. NEVER touches the real ~/.claude/plans.
+func withPlanModeDir(t *testing.T, dir string) {
+	t.Helper()
+	prev := planModeDirOverride
+	planModeDirOverride = dir
+	t.Cleanup(func() { planModeDirOverride = prev })
+}
+
+// writePlanFile writes a markdown plan with a controlled mod time so the
+// newest-file selection is deterministic regardless of filesystem timestamp
+// granularity.
+func writePlanFile(t *testing.T, dir, name, body string, mod time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestResolve_AutoDiscoversNewestPlanFile verifies that with no --file and no
+// piped stdin, Resolve picks the NEWEST *.md under the plan-mode dir.
+// Failure prevented: the human 'ox plan' path silently enriching nothing (or
+// an arbitrary/oldest file) when plan-mode already wrote the active plan.
+func TestResolve_AutoDiscoversNewestPlanFile(t *testing.T) {
+	dir := t.TempDir()
+	withPlanModeDir(t, dir)
+
+	base := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	writePlanFile(t, dir, "old-plan.md", "## Old\nstale plan", base.Add(-2*time.Hour))
+	newest := writePlanFile(t, dir, "active-plan.md", "## Active\nthe current plan", base)
+	// a non-markdown file in the dir must be ignored.
+	writePlanFile(t, dir, "notes.txt", "not a plan", base.Add(time.Hour))
+
+	in, err := Resolve("", nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if in.Path != newest {
+		t.Errorf("auto-discovered path = %q, want %q (newest .md)", in.Path, newest)
+	}
+	if !strings.Contains(in.Raw, "the current plan") {
+		t.Errorf("expected newest plan content, got %q", in.Raw)
+	}
+}
+
+// TestResolve_FilePrecedenceOverDiscovery verifies --file wins over a present
+// auto-discoverable plan-mode file. Agents/explicit callers must not be
+// overridden by whatever happens to sit in ~/.claude/plans.
+func TestResolve_FilePrecedenceOverDiscovery(t *testing.T) {
+	planModeDir := t.TempDir()
+	withPlanModeDir(t, planModeDir)
+	writePlanFile(t, planModeDir, "discovered.md", "## Discovered\nshould be ignored", time.Now())
+
+	explicitDir := t.TempDir()
+	explicit := writePlanFile(t, explicitDir, "explicit.md", "## Explicit\nuse me", time.Now())
+
+	in, err := Resolve(explicit, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if in.Path != explicit {
+		t.Errorf("path = %q, want %q (--file precedence)", in.Path, explicit)
+	}
+	if !strings.Contains(in.Raw, "use me") {
+		t.Errorf("expected --file content, got %q", in.Raw)
+	}
+}
+
+// TestResolve_StdinPrecedenceOverDiscovery verifies a piped stdin wins over
+// auto-discovery — agents pipe the plan explicitly and must not be shadowed.
+func TestResolve_StdinPrecedenceOverDiscovery(t *testing.T) {
+	planModeDir := t.TempDir()
+	withPlanModeDir(t, planModeDir)
+	writePlanFile(t, planModeDir, "discovered.md", "## Discovered\nignore me", time.Now())
+
+	in, err := Resolve("", strings.NewReader("## Piped\nfrom stdin"))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if in.Path != "" {
+		t.Errorf("stdin source should have empty Path, got %q", in.Path)
+	}
+	if !strings.Contains(in.Raw, "from stdin") {
+		t.Errorf("expected stdin content, got %q", in.Raw)
+	}
+}
+
+// TestResolve_EmptyWhenNoDiscoverablePlan verifies discovery degrades to an
+// empty Input when the plan-mode dir is empty or missing — the fail-open
+// contract the caller relies on to print a clear "no plan found" message.
+func TestResolve_EmptyWhenNoDiscoverablePlan(t *testing.T) {
+	t.Run("empty dir", func(t *testing.T) {
+		withPlanModeDir(t, t.TempDir())
+		in, err := Resolve("", nil)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if strings.TrimSpace(in.Raw) != "" {
+			t.Errorf("expected empty Raw, got %q", in.Raw)
+		}
+	})
+
+	t.Run("missing dir", func(t *testing.T) {
+		withPlanModeDir(t, filepath.Join(t.TempDir(), "does-not-exist"))
+		in, err := Resolve("", nil)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if strings.TrimSpace(in.Raw) != "" {
+			t.Errorf("expected empty Raw, got %q", in.Raw)
+		}
+	})
+
+	t.Run("empty piped stdin falls through to discovery", func(t *testing.T) {
+		dir := t.TempDir()
+		withPlanModeDir(t, dir)
+		discovered := writePlanFile(t, dir, "p.md", "## Found\nvia discovery", time.Now())
+		// an empty (but non-nil) pipe must not suppress auto-discovery.
+		in, err := Resolve("", strings.NewReader("   \n"))
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if in.Path != discovered {
+			t.Errorf("path = %q, want %q (empty stdin should fall through)", in.Path, discovered)
+		}
+	})
+}
+
+func findSection(sections []Section, heading string) *Section {
+	for i := range sections {
+		if sections[i].Heading == heading {
+			return &sections[i]
+		}
+	}
+	return nil
+}

--- a/internal/plan/metrics.go
+++ b/internal/plan/metrics.go
@@ -1,0 +1,25 @@
+package plan
+
+import "log/slog"
+
+// RecordPlanGenerated emits a single-line, key=value structured metric for a
+// completed `ox plan` enrichment. It is purely local observability — there is
+// no server LLM in this path, so there is nothing to meter server-side. The
+// counts let us see, in aggregate, how often plans fire collision / prior-art /
+// expert signals and how much context the bundle carried, without recording any
+// plan content.
+//
+// saved reports whether the enriched plan was captured to the ledger. It is a
+// separate boolean (not derived from res) because auto-save is gated on config
+// and on a configured ledger, independent of the signal summary.
+func RecordPlanGenerated(res Result, saved bool) {
+	slog.Info("plan_generated",
+		"collisions", res.Signals.Collisions,
+		"prior_art", res.Signals.PriorArt,
+		"expert_routes", res.Signals.ExpertRoutes,
+		"material", res.Signals.Material,
+		"annotations", len(res.Annotations),
+		"context_items", len(res.Context),
+		"saved", saved,
+	)
+}

--- a/internal/plan/priorart.go
+++ b/internal/plan/priorart.go
@@ -1,0 +1,313 @@
+package plan
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/ledgersearch"
+)
+
+// init self-registers the prior-art detector with the global registry so the
+// orchestrator picks it up without touching Enrich (see enrich.go).
+func init() {
+	RegisterDetector(&priorArtDetector{})
+}
+
+// priorArtScoreThreshold gates weak ledger matches out of the emitted set.
+// ledgersearch scores are 0.5 (all terms matched, no tf bonus) .. 1.0. A bare
+// 0.5 match means the query terms appeared once each — too weak to claim a
+// teammate "already did this". Require some term-frequency lift so we only
+// surface sessions that are substantively about the plan's subject. This keeps
+// prior-art precise: enrich's materiality gate counts PriorArt>=1 as material,
+// so a noisy hit would falsely flag every plan.
+const priorArtScoreThreshold = 0.6
+
+// maxPriorArtHits caps how many prior-art annotations we emit per plan. Past
+// the top few, additional sessions add noise without changing the agent's
+// decision ("someone has worked near here — go read it").
+const maxPriorArtHits = 3
+
+// minKeyword is the shortest token we treat as a meaningful search keyword.
+// Anything shorter is almost always a stopword or noise ("to", "a", "of").
+const minKeyword = 3
+
+// priorArtDetector finds prior sessions/murmurs where a teammate already did or
+// planned similar work, using LOCAL-FIRST keyword retrieval over the cached
+// ledger (zero LLM tokens, zero network). The cloud `ox query` augment is a
+// fallback, NOT the deterministic path — see the TODO at the bottom.
+type priorArtDetector struct{}
+
+// Name identifies the detector in logs and registry snapshots.
+func (d *priorArtDetector) Name() string { return "prior-art" }
+
+// Detect runs the local-first retrieval and emits one Annotation per strong
+// prior-art hit. FAIL-OPEN: missing config, no ledger, empty plan, or any read
+// error yields (nil, nil) — never an aborting error.
+func (d *priorArtDetector) Detect(ctx context.Context, in Input, gitRoot string) ([]Annotation, error) {
+	query := deriveQuery(in)
+	if query == "" {
+		return nil, nil
+	}
+
+	// resolveLedgerPath is a package-level helper shared with the collision
+	// detector (collision.go) — it returns the canonical ledger checkout root
+	// via ProjectContext and "" when uninitialized. Reuse, never duplicate.
+	ledgerPath := resolveLedgerPath(gitRoot)
+	if ledgerPath == "" {
+		return nil, nil
+	}
+
+	results, err := ledgersearch.Search(ledgersearch.Options{
+		LedgerPath: ledgerPath,
+		Query:      query,
+		// ask for a few extra so thresholding+ranking still has headroom to
+		// fill maxPriorArtHits after weak matches are dropped.
+		Limit: maxPriorArtHits * 3,
+	})
+	if err != nil {
+		// ledgersearch is already fail-open, but stay defensive.
+		return nil, nil
+	}
+
+	hits := rankHits(results)
+	if len(hits) == 0 {
+		return nil, nil
+	}
+
+	annotations := make([]Annotation, 0, len(hits))
+	for _, h := range hits {
+		annotations = append(annotations, annotationFromHit(h))
+	}
+
+	// TODO(cloud-augment): when local retrieval is sparse (e.g. fewer than
+	// maxPriorArtHits strong hits) optionally fan out to the cloud `ox query`
+	// API for cross-repo / un-cached prior art. This MUST stay out of the
+	// deterministic local path: it makes a network call, so it belongs behind
+	// an explicit opt-in flag and a retriever, never here in Detect.
+
+	return annotations, nil
+}
+
+// deriveQuery builds a keyword search query from the plan. Salient terms come
+// from section HEADINGS plus the preamble/title (the "what we're building"
+// signal), not full bodies — bodies are full of generic implementation prose
+// ("add a function", "write a test") that dilutes the query and pulls in
+// unrelated sessions. Keeping the query tight keeps prior-art precise.
+func deriveQuery(in Input) string {
+	var b strings.Builder
+	for _, s := range in.Sections {
+		if s.Heading != "" {
+			b.WriteString(s.Heading)
+			b.WriteByte(' ')
+		} else {
+			// the preamble (empty heading) typically holds the plan title /
+			// one-line topic — high signal, include it.
+			b.WriteString(s.Body)
+			b.WriteByte(' ')
+		}
+	}
+
+	keywords := extractKeywords(b.String())
+	return strings.Join(keywords, " ")
+}
+
+// stopwords are common English + plan-boilerplate tokens that carry no topical
+// signal. Filtering them keeps the AND-matched ledgersearch query from being
+// over-constrained by noise words that appear in every session.
+var stopwords = map[string]struct{}{
+	"the": {}, "and": {}, "for": {}, "with": {}, "this": {}, "that": {},
+	"from": {}, "into": {}, "are": {}, "was": {}, "will": {}, "should": {},
+	"add": {}, "use": {}, "new": {}, "via": {}, "per": {}, "any": {},
+	"all": {}, "not": {}, "but": {}, "our": {}, "its": {}, "out": {},
+	"plan": {}, "task": {}, "step": {}, "code": {}, "file": {}, "test": {},
+	"todo": {}, "section": {}, "implement": {}, "implementation": {},
+	"function": {}, "method": {}, "support": {}, "feature": {},
+}
+
+// extractKeywords lowercases, tokenizes, drops stopwords/short tokens, dedupes,
+// and ranks by frequency so the most-repeated salient terms lead the query.
+// Returned slice is bounded so the AND-matched query stays satisfiable —
+// requiring 20 terms to co-occur in one session would match nothing.
+func extractKeywords(text string) []string {
+	const maxKeywords = 8
+
+	counts := make(map[string]int)
+	var order []string
+	for _, tok := range tokenizeWords(text) {
+		if len(tok) < minKeyword {
+			continue
+		}
+		if _, skip := stopwords[tok]; skip {
+			continue
+		}
+		if _, seen := counts[tok]; !seen {
+			order = append(order, tok)
+		}
+		counts[tok]++
+	}
+	if len(order) == 0 {
+		return nil
+	}
+
+	// stable sort by frequency desc, then original appearance order (already
+	// the order slice's order) for ties — deterministic output.
+	sort.SliceStable(order, func(i, j int) bool {
+		return counts[order[i]] > counts[order[j]]
+	})
+
+	if len(order) > maxKeywords {
+		order = order[:maxKeywords]
+	}
+	return order
+}
+
+// tokenizeWords splits text into lowercase alphanumeric tokens. Mirrors
+// ledgersearch tokenization semantics so the query terms line up with how the
+// index scores them.
+func tokenizeWords(text string) []string {
+	var out []string
+	var cur strings.Builder
+	for _, r := range strings.ToLower(text) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			cur.WriteRune(r)
+			continue
+		}
+		if cur.Len() > 0 {
+			out = append(out, cur.String())
+			cur.Reset()
+		}
+	}
+	if cur.Len() > 0 {
+		out = append(out, cur.String())
+	}
+	return out
+}
+
+// priorArtHit is a thresholded, ranked ledger result ready to become an
+// Annotation. Kept separate from ledgersearch.Result so ranking/threshold logic
+// is pure and testable without constructing on-disk fixtures.
+type priorArtHit struct {
+	Score    float64
+	DocType  string
+	SourceID string
+	Author   string
+	Date     string // YYYY-MM-DD if derivable, else ""
+}
+
+// rankHits filters raw ledger results below the threshold, sorts by score
+// (recency as tiebreak), and caps to maxPriorArtHits. Pure function — the unit
+// tests exercise threshold + cap + ordering directly.
+func rankHits(results []ledgersearch.Result) []priorArtHit {
+	hits := make([]priorArtHit, 0, len(results))
+	for _, r := range results {
+		if r.Score < priorArtScoreThreshold {
+			continue
+		}
+		author, date := parseSessionAuthorDate(r.SourceID, r.CreatedAt)
+		hits = append(hits, priorArtHit{
+			Score:    r.Score,
+			DocType:  r.DocType,
+			SourceID: r.SourceID,
+			Author:   author,
+			Date:     date,
+		})
+	}
+
+	sort.SliceStable(hits, func(i, j int) bool {
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		return hits[i].Date > hits[j].Date
+	})
+
+	if len(hits) > maxPriorArtHits {
+		hits = hits[:maxPriorArtHits]
+	}
+	return hits
+}
+
+// parseSessionAuthorDate extracts the author username and a YYYY-MM-DD date from
+// a session folder name of the form "YYYY-MM-DDTHH-MM-<username>-<agentID>".
+// Murmurs (and any non-conforming name) yield empty author; date falls back to
+// the parsed CreatedAt timestamp when the name doesn't carry one.
+func parseSessionAuthorDate(sourceID, createdAt string) (author, date string) {
+	date = dateOnly(createdAt)
+
+	// session name prefix is exactly 16 chars: "YYYY-MM-DDTHH-MM".
+	if len(sourceID) >= 18 && sourceID[10] == 'T' && sourceID[13] == '-' {
+		if date == "" {
+			date = sourceID[:10]
+		}
+		rest := sourceID[16:] // "-<username>-<agentID>"
+		rest = strings.TrimPrefix(rest, "-")
+		// username is everything up to the last hyphen (agentID has no hyphen).
+		if i := strings.LastIndex(rest, "-"); i > 0 {
+			author = rest[:i]
+		} else {
+			author = rest
+		}
+		return author, date
+	}
+
+	// plan dir names are "YYYY-MM-DD-<slug>" (no author embedded); recover the
+	// date from the prefix so a plan hit still carries a recency tiebreak and a
+	// dated annotation. Author stays empty — meta.json authors aren't in the ref.
+	if date == "" && len(sourceID) >= 10 && sourceID[4] == '-' && sourceID[7] == '-' {
+		if _, err := time.Parse("2006-01-02", sourceID[:10]); err == nil {
+			date = sourceID[:10]
+		}
+	}
+	return author, date
+}
+
+// dateOnly reduces an ISO-8601 timestamp to its YYYY-MM-DD prefix. Returns ""
+// when the input isn't a recognizable timestamp.
+func dateOnly(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t.Format("2006-01-02")
+	}
+	if len(ts) >= 10 {
+		return ts[:10]
+	}
+	return ""
+}
+
+// annotationFromHit renders a prior-art Annotation. The SourceURL carries the
+// session ref (folder name) so a human/agent can `ox session view <ref>`.
+func annotationFromHit(h priorArtHit) Annotation {
+	who := h.Author
+	if who == "" {
+		who = "a teammate"
+	}
+
+	verb := "worked on"
+	subject := "session"
+	switch h.DocType {
+	case "murmur":
+		verb = "mentioned"
+		subject = "murmur"
+	case "plan":
+		// a saved plan is the strongest prior-art signal — someone already
+		// scoped this exact work. Phrase it as "planned this in plan <slug>".
+		verb = "planned"
+		subject = "plan"
+	}
+
+	why := who + " " + verb + " this in " + subject + " " + h.SourceID
+	if h.Date != "" {
+		why += " (" + h.Date + ")"
+	}
+
+	return Annotation{
+		Kind:      BadgeDeterministic,
+		Type:      BadgePriorArt,
+		Why:       why,
+		SourceURL: h.SourceID,
+		Expert:    h.Author,
+	}
+}

--- a/internal/plan/priorart_test.go
+++ b/internal/plan/priorart_test.go
@@ -1,0 +1,364 @@
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sageox/ox/internal/ledgersearch"
+)
+
+func TestDeriveQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Input
+		// want is a set of keywords that MUST appear; order-independent since
+		// frequency ranking is exercised separately.
+		wantContains []string
+		wantEmpty    bool
+	}{
+		{
+			name:      "empty plan yields empty query",
+			in:        Input{},
+			wantEmpty: true,
+		},
+		{
+			name: "only stopwords yields empty query",
+			in: Input{Sections: []Section{
+				{Heading: "Add the new feature"},
+			}},
+			wantEmpty: true,
+		},
+		{
+			name: "headings drive the query, stopwords dropped",
+			in: Input{Sections: []Section{
+				{Heading: "Implement OAuth token refresh"},
+				{Heading: "Cache the refreshed credentials"},
+			}},
+			wantContains: []string{"oauth", "token", "refresh", "cache", "credentials"},
+		},
+		{
+			name: "preamble title is included",
+			in: Input{Sections: []Section{
+				{Heading: "", Body: "Redesign the ledger sparse checkout"},
+			}},
+			wantContains: []string{"redesign", "ledger", "sparse", "checkout"},
+		},
+		{
+			name: "short tokens filtered",
+			in: Input{Sections: []Section{
+				{Heading: "io db ui pipeline migration"},
+			}},
+			wantContains: []string{"pipeline", "migration"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveQuery(tt.in)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Fatalf("deriveQuery() = %q, want empty", got)
+				}
+				return
+			}
+			for _, kw := range tt.wantContains {
+				if !containsToken(got, kw) {
+					t.Errorf("deriveQuery() = %q, missing keyword %q", got, kw)
+				}
+			}
+			// short tokens must never leak through
+			for _, tok := range tokenizeWords(got) {
+				if len(tok) < minKeyword {
+					t.Errorf("deriveQuery() leaked short token %q in %q", tok, got)
+				}
+			}
+		})
+	}
+}
+
+func containsToken(query, tok string) bool {
+	for _, t := range tokenizeWords(query) {
+		if t == tok {
+			return true
+		}
+	}
+	return false
+}
+
+func TestExtractKeywordsFrequencyRanking(t *testing.T) {
+	// "ledger" appears 3x, "session" 2x, "murmur" 1x — frequency ordering.
+	text := "ledger session ledger murmur ledger session"
+	got := extractKeywords(text)
+	if len(got) == 0 {
+		t.Fatal("extractKeywords returned nothing")
+	}
+	if got[0] != "ledger" {
+		t.Errorf("most frequent term should lead: got[0]=%q, want ledger (full=%v)", got[0], got)
+	}
+}
+
+func TestExtractKeywordsBoundsCount(t *testing.T) {
+	// 12 distinct salient tokens; query must be capped so AND-match stays satisfiable.
+	text := "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima"
+	got := extractKeywords(text)
+	if len(got) > 8 {
+		t.Errorf("extractKeywords returned %d terms, want <= 8 (%v)", len(got), got)
+	}
+}
+
+func TestRankHitsThresholdAndCap(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []ledgersearch.Result
+		wantIDs []string
+	}{
+		{
+			name:    "no results",
+			results: nil,
+			wantIDs: nil,
+		},
+		{
+			name: "weak matches thresholded out",
+			results: []ledgersearch.Result{
+				{Score: 0.5, SourceID: "weak-1", DocType: "session"},
+				{Score: 0.55, SourceID: "weak-2", DocType: "session"},
+			},
+			wantIDs: nil,
+		},
+		{
+			name: "strong match passes threshold",
+			results: []ledgersearch.Result{
+				{Score: 0.5, SourceID: "weak", DocType: "session"},
+				{Score: 0.8, SourceID: "strong", DocType: "session"},
+			},
+			wantIDs: []string{"strong"},
+		},
+		{
+			name: "sorted by score desc",
+			results: []ledgersearch.Result{
+				{Score: 0.7, SourceID: "mid", DocType: "session", CreatedAt: "2026-01-01T00:00:00Z"},
+				{Score: 0.95, SourceID: "top", DocType: "session", CreatedAt: "2026-01-01T00:00:00Z"},
+				{Score: 0.65, SourceID: "low", DocType: "session", CreatedAt: "2026-01-01T00:00:00Z"},
+			},
+			wantIDs: []string{"top", "mid", "low"},
+		},
+		{
+			name: "capped at maxPriorArtHits",
+			results: []ledgersearch.Result{
+				{Score: 0.91, SourceID: "a", DocType: "session"},
+				{Score: 0.92, SourceID: "b", DocType: "session"},
+				{Score: 0.93, SourceID: "c", DocType: "session"},
+				{Score: 0.94, SourceID: "d", DocType: "session"},
+			},
+			wantIDs: []string{"d", "c", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rankHits(tt.results)
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("rankHits returned %d hits, want %d (%+v)", len(got), len(tt.wantIDs), got)
+			}
+			for i, id := range tt.wantIDs {
+				if got[i].SourceID != id {
+					t.Errorf("hit[%d].SourceID = %q, want %q", i, got[i].SourceID, id)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSessionAuthorDate(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceID   string
+		createdAt  string
+		wantAuthor string
+		wantDate   string
+	}{
+		{
+			name:       "well-formed session name",
+			sourceID:   "2026-02-13T14-56-alice-OxAb12",
+			createdAt:  "2026-02-13T14:56:00Z",
+			wantAuthor: "alice",
+			wantDate:   "2026-02-13",
+		},
+		{
+			name:       "multi-segment username",
+			sourceID:   "2026-03-01T09-00-bob-smith-OxCd34",
+			createdAt:  "",
+			wantAuthor: "bob-smith",
+			wantDate:   "2026-03-01",
+		},
+		{
+			name:       "murmur id yields no author, date from createdAt",
+			sourceID:   "01HXYZmurmurid",
+			createdAt:  "2026-04-10T12:00:00Z",
+			wantAuthor: "",
+			wantDate:   "2026-04-10",
+		},
+		{
+			name:       "non-conforming name, no timestamp",
+			sourceID:   "random",
+			createdAt:  "",
+			wantAuthor: "",
+			wantDate:   "",
+		},
+		{
+			// plan dir name "YYYY-MM-DD-<slug>": no author, date from prefix.
+			name:       "plan dir name yields date from prefix, no author",
+			sourceID:   "2026-05-21-cache-layer",
+			createdAt:  "",
+			wantAuthor: "",
+			wantDate:   "2026-05-21",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			author, date := parseSessionAuthorDate(tt.sourceID, tt.createdAt)
+			if author != tt.wantAuthor {
+				t.Errorf("author = %q, want %q", author, tt.wantAuthor)
+			}
+			if date != tt.wantDate {
+				t.Errorf("date = %q, want %q", date, tt.wantDate)
+			}
+		})
+	}
+}
+
+func TestAnnotationFromHit(t *testing.T) {
+	tests := []struct {
+		name        string
+		hit         priorArtHit
+		wantType    BadgeType
+		wantKind    BadgeKind
+		wantExpert  string
+		wantSource  string
+		whyContains []string
+	}{
+		{
+			name: "session hit with author and date",
+			hit: priorArtHit{
+				Score: 0.9, DocType: "session",
+				SourceID: "2026-02-13T14-56-alice-OxAb12",
+				Author:   "alice", Date: "2026-02-13",
+			},
+			wantType:    BadgePriorArt,
+			wantKind:    BadgeDeterministic,
+			wantExpert:  "alice",
+			wantSource:  "2026-02-13T14-56-alice-OxAb12",
+			whyContains: []string{"alice", "worked on", "2026-02-13"},
+		},
+		{
+			name: "murmur hit without author",
+			hit: priorArtHit{
+				Score: 0.7, DocType: "murmur", SourceID: "mid", Author: "", Date: "",
+			},
+			wantType:    BadgePriorArt,
+			wantKind:    BadgeDeterministic,
+			wantExpert:  "",
+			wantSource:  "mid",
+			whyContains: []string{"a teammate", "mentioned", "murmur"},
+		},
+		{
+			// a saved plan is the strongest prior-art signal: "planned this in plan".
+			name: "plan hit phrases as planned",
+			hit: priorArtHit{
+				Score: 0.85, DocType: "plan",
+				SourceID: "2026-05-21-cache-layer", Author: "", Date: "2026-05-21",
+			},
+			wantType:    BadgePriorArt,
+			wantKind:    BadgeDeterministic,
+			wantExpert:  "",
+			wantSource:  "2026-05-21-cache-layer",
+			whyContains: []string{"a teammate", "planned", "plan", "2026-05-21"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := annotationFromHit(tt.hit)
+			if a.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", a.Type, tt.wantType)
+			}
+			if a.Kind != tt.wantKind {
+				t.Errorf("Kind = %q, want %q", a.Kind, tt.wantKind)
+			}
+			if a.Expert != tt.wantExpert {
+				t.Errorf("Expert = %q, want %q", a.Expert, tt.wantExpert)
+			}
+			if a.SourceURL != tt.wantSource {
+				t.Errorf("SourceURL = %q, want %q", a.SourceURL, tt.wantSource)
+			}
+			for _, frag := range tt.whyContains {
+				if !contains(a.Why, frag) {
+					t.Errorf("Why = %q, missing %q", a.Why, frag)
+				}
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestDetectFailOpen verifies the detector returns (nil, nil) when there is no
+// ledger to search — the core fail-open contract.
+func TestDetectFailOpen(t *testing.T) {
+	d := &priorArtDetector{}
+
+	// empty plan: deriveQuery returns "", short-circuits before any path resolution.
+	anns, err := d.Detect(context.Background(), Input{}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Detect on empty plan returned error: %v", err)
+	}
+	if anns != nil {
+		t.Errorf("Detect on empty plan returned %d annotations, want nil", len(anns))
+	}
+
+	// real query but uninitialized gitRoot: ledger path resolution fails open.
+	in := Input{Sections: []Section{{Heading: "Implement OAuth token refresh"}}}
+	anns, err = d.Detect(context.Background(), in, t.TempDir())
+	if err != nil {
+		t.Fatalf("Detect with no ledger returned error: %v", err)
+	}
+	if anns != nil {
+		t.Errorf("Detect with no ledger returned %d annotations, want nil", len(anns))
+	}
+
+	// empty gitRoot also fails open.
+	anns, err = d.Detect(context.Background(), in, "")
+	if err != nil {
+		t.Fatalf("Detect with empty gitRoot returned error: %v", err)
+	}
+	if anns != nil {
+		t.Errorf("Detect with empty gitRoot returned %d annotations, want nil", len(anns))
+	}
+}
+
+// TestDetectorRegistered confirms init() registered the detector exactly once
+// under its canonical name.
+func TestDetectorRegistered(t *testing.T) {
+	ds, _ := snapshotRegistry()
+	found := 0
+	for _, d := range ds {
+		if d.Name() == "prior-art" {
+			found++
+		}
+	}
+	if found == 0 {
+		t.Fatal("prior-art detector not registered via init()")
+	}
+}

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -1,0 +1,367 @@
+package plan
+
+// Plan capture-to-ledger. Mirrors the session storage model (internal/session)
+// but optimized for the plan artifact's read pattern: small canonical text
+// (plan.md, annotations.json, meta.json) stays PLAIN git so a teammate's
+// DEHYDRATED clone can list / read / search plans with zero LFS hydration.
+// Only a heavy pre-rendered plan.html is size-gated into an LFS pointer
+// (hydrate-on-demand), exactly how sessions keep summary.md plain but
+// raw.jsonl in LFS.
+//
+// Layout: <ledger>/data/plans/YYYY-MM-DD-<2-4-word-slug>/
+//
+//	plan.md          # always plain git (Input.Raw)
+//	annotations.json # always plain git (the Result — searchable badge data)
+//	meta.json        # always plain git (topic, slug, authors, timestamps, …)
+//	plan.html        # only if a render was passed in; plain git if small,
+//	                 # LFS pointer (internal/lfs.WritePointerFile) if large.
+//
+// CLI WRITES files into the ledger working tree (daemon-git split): we never
+// commit inline and never discard uncommitted changes — same as session
+// capture, which writes meta.json + content and lets a later push carry it.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/paths"
+)
+
+const (
+	planMDFile      = "plan.md"
+	annotationsFile = "annotations.json"
+	planMetaFile    = "meta.json"
+	planHTMLFile    = "plan.html"
+
+	// htmlLFSThreshold is the size above which a passed-in plan.html is stored
+	// as an LFS pointer rather than committed plain. ~256KB: base64 imagery and
+	// large rendered plans cross this; a normal text-only render stays well
+	// under it and is kept plain so a dehydrated clone reads it directly.
+	htmlLFSThreshold = 256 * 1024
+)
+
+// Meta is the git-tracked descriptor written as meta.json alongside a captured
+// plan. It carries the searchable, hydration-free facts about the plan: who
+// authored it, when, and where it came from.
+type Meta struct {
+	// SchemaVersion stamps the meta.json shape (set to SchemaVersion on write)
+	// so a future reader can detect and migrate an older layout.
+	SchemaVersion  string    `json:"schema_version,omitempty"`
+	Topic          string    `json:"topic"`
+	Slug           string    `json:"slug"`
+	Authors        []string  `json:"authors,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	SourcePlanPath string    `json:"source_plan_path,omitempty"`
+}
+
+// PlanInfo is the listing-level view of a captured plan, assembled from
+// meta.json. Dir is the absolute path to the plan folder.
+type PlanInfo struct {
+	Slug      string
+	Topic     string
+	Dir       string
+	CreatedAt time.Time
+	Authors   []string
+	HasHTML   bool
+}
+
+// Save writes a captured plan into the ledger under data/plans/<dated-slug>/.
+// It writes plan.md (from in.Raw), annotations.json (res), and meta.json as
+// plain git-tracked text. plan.html is written ONLY when html != nil: plain
+// when small, as an LFS pointer when it exceeds htmlLFSThreshold. Save never
+// renders HTML and never commits — it only materializes files in the working
+// tree. Returns the absolute plan directory.
+//
+// gitRoot is the producing project's git root; the ledger path is resolved
+// from it via ProjectContext. Returns an error if no ledger is configured
+// (the caller decides whether that is fatal — the porcelain path treats it as
+// "nothing to save").
+func Save(gitRoot string, in Input, res Result, html []byte, meta Meta) (string, error) {
+	ledger := ledgerPathFor(gitRoot)
+	if ledger == "" {
+		return "", fmt.Errorf("no ledger configured for %q: cannot save plan", gitRoot)
+	}
+
+	if meta.CreatedAt.IsZero() {
+		meta.CreatedAt = time.Now().UTC()
+	}
+	if meta.Slug == "" {
+		meta.Slug = Slugify(meta.Topic)
+	}
+
+	// Stamp the current schema version onto both long-lived artifacts so a
+	// future reader can detect and migrate an older on-disk layout.
+	meta.SchemaVersion = SchemaVersion
+	res.SchemaVersion = SchemaVersion
+
+	dirName := fmt.Sprintf("%s-%s", meta.CreatedAt.UTC().Format("2006-01-02"), meta.Slug)
+	dir := filepath.Join(paths.LedgerPlansDir(ledger), dirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create plan dir=%s: %w", dir, err)
+	}
+
+	// plan.md — plain git, diffable, hydrated-by-default.
+	if err := os.WriteFile(filepath.Join(dir, planMDFile), []byte(in.Raw), 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", planMDFile, err)
+	}
+
+	// annotations.json — the searchable badge data (Result).
+	annotations, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal annotations: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, annotationsFile), annotations, 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", annotationsFile, err)
+	}
+
+	// meta.json — plain git descriptor.
+	metaBytes, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal plan meta: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, planMetaFile), metaBytes, 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", planMetaFile, err)
+	}
+
+	// plan.html — only when a render was already produced. Size-gated: small
+	// renders stay plain so dehydrated clones read them directly; large ones
+	// become LFS pointers (pure-Go pointer write, never the git-lfs binary).
+	if html != nil {
+		htmlPath := filepath.Join(dir, planHTMLFile)
+		if int64(len(html)) > htmlLFSThreshold {
+			ref := lfs.NewFileRef(html)
+			if err := lfs.WritePointerFile(htmlPath, ref); err != nil {
+				return "", fmt.Errorf("write plan.html LFS pointer: %w", err)
+			}
+		} else if err := os.WriteFile(htmlPath, html, 0o644); err != nil {
+			return "", fmt.Errorf("write %s: %w", planHTMLFile, err)
+		}
+	}
+
+	return dir, nil
+}
+
+// List enumerates captured plans under <ledger>/data/plans/, parsing each
+// meta.json. Fail-open: an unconfigured or missing ledger yields an empty
+// slice (not an error), matching the detectors' fail-open contract. Results
+// are sorted newest-first by CreatedAt.
+func List(gitRoot string) ([]PlanInfo, error) {
+	ledger := ledgerPathFor(gitRoot)
+	plansDir := paths.LedgerPlansDir(ledger)
+	if plansDir == "" {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read plans dir=%s: %w", plansDir, err)
+	}
+
+	var infos []PlanInfo
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(plansDir, entry.Name())
+		meta, err := readMeta(dir)
+		if err != nil {
+			continue // skip malformed/partial plan dirs (fail-open)
+		}
+		infos = append(infos, planInfoFrom(dir, entry.Name(), meta))
+	}
+
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].CreatedAt.After(infos[j].CreatedAt)
+	})
+	return infos, nil
+}
+
+// Load reads a captured plan by slug. The slug matches either the meta.json
+// slug or the directory's trailing slug segment (the YYYY-MM-DD- prefix is
+// optional in the lookup). Returns the raw plan markdown, the stored Result,
+// and the listing info.
+func Load(gitRoot, slug string) (string, Result, PlanInfo, error) {
+	var res Result
+	ledger := ledgerPathFor(gitRoot)
+	plansDir := paths.LedgerPlansDir(ledger)
+	if plansDir == "" {
+		return "", res, PlanInfo{}, fmt.Errorf("no ledger configured for %q", gitRoot)
+	}
+
+	dir, name, err := resolvePlanDir(plansDir, slug)
+	if err != nil {
+		return "", res, PlanInfo{}, err
+	}
+
+	meta, err := readMeta(dir)
+	if err != nil {
+		return "", res, PlanInfo{}, fmt.Errorf("read plan meta for %q: %w", slug, err)
+	}
+
+	mdBytes, err := os.ReadFile(filepath.Join(dir, planMDFile))
+	if err != nil {
+		return "", res, PlanInfo{}, fmt.Errorf("read %s for %q: %w", planMDFile, slug, err)
+	}
+
+	// annotations.json is the canonical Result; a missing/partial file is
+	// non-fatal — the markdown is the primary artifact.
+	if annBytes, readErr := os.ReadFile(filepath.Join(dir, annotationsFile)); readErr == nil {
+		_ = json.Unmarshal(annBytes, &res)
+	}
+
+	return string(mdBytes), res, planInfoFrom(dir, name, meta), nil
+}
+
+// PlanHTMLPath returns the absolute path to a captured plan's plan.html, the
+// referenced FileRef when it is an LFS pointer, and whether the file exists.
+// The view path uses this to decide between opening a plain HTML file and
+// hydrating a pointer first.
+func PlanHTMLPath(dir string) (path string, ref lfs.FileRef, isPointer, exists bool) {
+	path = filepath.Join(dir, planHTMLFile)
+	if _, err := os.Stat(path); err != nil {
+		return path, lfs.FileRef{}, false, false
+	}
+	if lfs.IsPointerFile(path) {
+		if r, err := lfs.ReadPointerFile(path); err == nil {
+			return path, r, true, true
+		}
+		return path, lfs.FileRef{}, true, true
+	}
+	return path, lfs.FileRef{}, false, true
+}
+
+// --- helpers ---
+
+// slugWordRe splits on any run of non-alphanumeric characters.
+var slugWordRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// Slugify derives a 2-4 word kebab-case slug from a topic/title. Lowercases,
+// strips punctuation, and keeps the first 2-4 meaningful words. An empty or
+// punctuation-only input yields "untitled-plan" so a directory name is always
+// well-formed.
+func Slugify(topic string) string {
+	words := slugWordRe.Split(strings.ToLower(strings.TrimSpace(topic)), -1)
+
+	var kept []string
+	for _, w := range words {
+		if w == "" {
+			continue
+		}
+		kept = append(kept, w)
+		if len(kept) == 4 {
+			break
+		}
+	}
+
+	if len(kept) == 0 {
+		return "untitled-plan"
+	}
+	return strings.Join(kept, "-")
+}
+
+// ledgerResolver maps a producing-repo git root to its ledger checkout root.
+// It is a package var so tests can point Save/List/Load at a temp ledger
+// without standing up a full ProjectContext. Production code uses the default
+// (canonical ProjectContext) resolver.
+var ledgerResolver = defaultLedgerResolver
+
+// defaultLedgerResolver resolves the ledger checkout root for the producing
+// repo via the canonical ProjectContext helper. Returns "" when uninitialized
+// so callers can fail-open. Unlike collision.go's resolveLedgerPath, this does
+// NOT require the directory to already exist — Save must be able to create the
+// plans dir on first capture.
+func defaultLedgerResolver(gitRoot string) string {
+	if gitRoot == "" {
+		return ""
+	}
+	ctx, err := config.LoadProjectContext(gitRoot)
+	if err != nil || ctx == nil {
+		return ""
+	}
+	return ctx.DefaultLedgerPath()
+}
+
+func ledgerPathFor(gitRoot string) string {
+	return ledgerResolver(gitRoot)
+}
+
+func readMeta(dir string) (Meta, error) {
+	var meta Meta
+	data, err := os.ReadFile(filepath.Join(dir, planMetaFile))
+	if err != nil {
+		return meta, err
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return meta, fmt.Errorf("parse plan meta=%s: %w", dir, err)
+	}
+	return meta, nil
+}
+
+func planInfoFrom(dir, dirName string, meta Meta) PlanInfo {
+	slug := meta.Slug
+	if slug == "" {
+		slug = slugFromDirName(dirName)
+	}
+	_, _, _, hasHTML := PlanHTMLPath(dir)
+	return PlanInfo{
+		Slug:      slug,
+		Topic:     meta.Topic,
+		Dir:       dir,
+		CreatedAt: meta.CreatedAt,
+		Authors:   meta.Authors,
+		HasHTML:   hasHTML,
+	}
+}
+
+// resolvePlanDir finds the plan directory matching slug. It accepts an exact
+// directory name, a meta.json slug, or the trailing slug segment of a dated
+// directory name. Returns the absolute dir and its base name.
+func resolvePlanDir(plansDir, slug string) (string, string, error) {
+	// exact directory match (e.g. "2026-06-03-my-plan")
+	exact := filepath.Join(plansDir, slug)
+	if info, err := os.Stat(exact); err == nil && info.IsDir() {
+		return exact, slug, nil
+	}
+
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", "", fmt.Errorf("plan %q not found: no plans saved", slug)
+		}
+		return "", "", fmt.Errorf("read plans dir=%s: %w", plansDir, err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		dir := filepath.Join(plansDir, name)
+		if slugFromDirName(name) == slug {
+			return dir, name, nil
+		}
+		if meta, err := readMeta(dir); err == nil && meta.Slug == slug {
+			return dir, name, nil
+		}
+	}
+	return "", "", fmt.Errorf("plan %q not found", slug)
+}
+
+// datedDirRe matches the YYYY-MM-DD- prefix of a plan directory name.
+var datedDirRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}-`)
+
+// slugFromDirName strips the optional YYYY-MM-DD- prefix from a directory name.
+func slugFromDirName(name string) string {
+	return datedDirRe.ReplaceAllString(name, "")
+}

--- a/internal/plan/store_test.go
+++ b/internal/plan/store_test.go
@@ -1,0 +1,312 @@
+package plan
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// withLedger points the package ledger resolver at a temp ledger for the
+// duration of a test, restoring the production resolver afterward.
+func withLedger(t *testing.T, ledger string) {
+	t.Helper()
+	prev := ledgerResolver
+	ledgerResolver = func(string) string { return ledger }
+	t.Cleanup(func() { ledgerResolver = prev })
+}
+
+func sampleResult() Result {
+	return Result{
+		Annotations: []Annotation{
+			{Section: "Storage", Kind: BadgeDeterministic, Type: BadgeCollision, Why: "touches open PR #42", Files: []string{"store.go"}},
+		},
+		Context: []ContextItem{
+			{Kind: "adr", Title: "ADR-016", Ref: "docs/adr/016.md", Score: 0.9},
+		},
+		Signals: SignalSummary{Collisions: 1, PriorArt: 0, ExpertRoutes: 1, Material: true},
+	}
+}
+
+func TestSaveListLoad_RoundTrip(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	created := time.Date(2026, 6, 3, 10, 0, 0, 0, time.UTC)
+	in := Input{Path: "PLAN.md", Raw: "# Plan capture to ledger\n\nDo the thing."}
+	res := sampleResult()
+	meta := Meta{
+		Topic:     "Plan capture to ledger",
+		Authors:   []string{"Person A"},
+		CreatedAt: created,
+	}
+
+	dir, err := Save("/fake/git/root", in, res, nil, meta)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// dir is the dated-slug folder under data/plans
+	wantDir := filepath.Join(ledger, "data", "plans", "2026-06-03-plan-capture-to-ledger")
+	if dir != wantDir {
+		t.Fatalf("Save dir = %q, want %q", dir, wantDir)
+	}
+
+	// plan.md, annotations.json, meta.json are PLAIN git (not LFS pointers).
+	for _, f := range []string{"plan.md", "annotations.json", "meta.json"} {
+		p := filepath.Join(dir, f)
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected %s to exist: %v", f, err)
+		}
+		if lfs.IsPointerFile(p) {
+			t.Errorf("%s must be plain git, got an LFS pointer", f)
+		}
+	}
+
+	// no plan.html when html == nil
+	if _, err := os.Stat(filepath.Join(dir, "plan.html")); !os.IsNotExist(err) {
+		t.Errorf("plan.html should not exist when html is nil, stat err=%v", err)
+	}
+
+	// List sees exactly one plan with the expected fields.
+	plans, err := List("/fake/git/root")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("List returned %d plans, want 1", len(plans))
+	}
+	got := plans[0]
+	if got.Slug != "plan-capture-to-ledger" {
+		t.Errorf("slug = %q, want plan-capture-to-ledger", got.Slug)
+	}
+	if got.Topic != "Plan capture to ledger" {
+		t.Errorf("topic = %q", got.Topic)
+	}
+	if got.HasHTML {
+		t.Errorf("HasHTML = true, want false")
+	}
+	if !got.CreatedAt.Equal(created) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, created)
+	}
+
+	// Load round-trips the markdown and the Result.
+	planMD, loadedRes, info, err := Load("/fake/git/root", "plan-capture-to-ledger")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if planMD != in.Raw {
+		t.Errorf("Load markdown = %q, want %q", planMD, in.Raw)
+	}
+	if loadedRes.Signals != res.Signals {
+		t.Errorf("Load signals = %+v, want %+v", loadedRes.Signals, res.Signals)
+	}
+	if len(loadedRes.Annotations) != 1 || loadedRes.Annotations[0].Type != BadgeCollision {
+		t.Errorf("Load annotations = %+v", loadedRes.Annotations)
+	}
+	if info.Slug != "plan-capture-to-ledger" {
+		t.Errorf("Load info slug = %q", info.Slug)
+	}
+
+	// SchemaVersion is stamped on both artifacts on write so a future reader
+	// can detect/migrate an older layout. Without this, version-bumping the
+	// on-disk shape later would be a silent guess.
+	if loadedRes.SchemaVersion != SchemaVersion {
+		t.Errorf("annotations.json schema_version = %q, want %q", loadedRes.SchemaVersion, SchemaVersion)
+	}
+	metaBytes, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotMeta Meta
+	if err := json.Unmarshal(metaBytes, &gotMeta); err != nil {
+		t.Fatal(err)
+	}
+	if gotMeta.SchemaVersion != SchemaVersion {
+		t.Errorf("meta.json schema_version = %q, want %q", gotMeta.SchemaVersion, SchemaVersion)
+	}
+
+	// The dropped approval fields must not reappear in the serialized meta.
+	// Their presence would imply an approval flow that does not exist.
+	if strings.Contains(string(metaBytes), "approved") || strings.Contains(string(metaBytes), "reviewed_by") {
+		t.Errorf("meta.json must not carry approval fields: %s", metaBytes)
+	}
+}
+
+func TestSave_HTMLSizeGating(t *testing.T) {
+	tests := []struct {
+		name        string
+		size        int
+		wantPointer bool
+	}{
+		{"small html stays plain git", 1024, false},
+		{"large html becomes LFS pointer", htmlLFSThreshold + 1, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ledger := t.TempDir()
+			withLedger(t, ledger)
+
+			html := bytes.Repeat([]byte("a"), tc.size)
+			in := Input{Raw: "# H\n"}
+			meta := Meta{Topic: "Size gate", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+
+			dir, err := Save("/g", in, sampleResult(), html, meta)
+			if err != nil {
+				t.Fatalf("Save: %v", err)
+			}
+
+			htmlPath := filepath.Join(dir, "plan.html")
+			isPointer := lfs.IsPointerFile(htmlPath)
+			if isPointer != tc.wantPointer {
+				t.Fatalf("plan.html IsPointer = %v, want %v (size=%d)", isPointer, tc.wantPointer, tc.size)
+			}
+
+			if tc.wantPointer {
+				// pointer references the correct OID/size
+				ref, err := lfs.ReadPointerFile(htmlPath)
+				if err != nil {
+					t.Fatalf("ReadPointerFile: %v", err)
+				}
+				if ref.Size != int64(len(html)) {
+					t.Errorf("pointer size = %d, want %d", ref.Size, len(html))
+				}
+				if ref.OID != "sha256:"+lfs.ComputeOID(html) {
+					t.Errorf("pointer OID = %q, want sha256:%s", ref.OID, lfs.ComputeOID(html))
+				}
+			} else {
+				// plain bytes survive verbatim
+				got, err := os.ReadFile(htmlPath)
+				if err != nil {
+					t.Fatalf("read plain html: %v", err)
+				}
+				if !bytes.Equal(got, html) {
+					t.Errorf("plain html bytes differ from input")
+				}
+			}
+
+			// List reflects HasHTML in both cases.
+			plans, err := List("/g")
+			if err != nil || len(plans) != 1 {
+				t.Fatalf("List: %v (n=%d)", err, len(plans))
+			}
+			if !plans[0].HasHTML {
+				t.Errorf("HasHTML = false, want true")
+			}
+		})
+	}
+}
+
+func TestList_FailOpen(t *testing.T) {
+	t.Run("no ledger configured", func(t *testing.T) {
+		withLedger(t, "")
+		plans, err := List("/g")
+		if err != nil {
+			t.Fatalf("List err = %v, want nil (fail-open)", err)
+		}
+		if plans != nil {
+			t.Errorf("List = %v, want nil", plans)
+		}
+	})
+
+	t.Run("ledger exists but no plans dir", func(t *testing.T) {
+		withLedger(t, t.TempDir())
+		plans, err := List("/g")
+		if err != nil {
+			t.Fatalf("List err = %v, want nil", err)
+		}
+		if len(plans) != 0 {
+			t.Errorf("List = %v, want empty", plans)
+		}
+	})
+
+	t.Run("skips malformed plan dir", func(t *testing.T) {
+		ledger := t.TempDir()
+		withLedger(t, ledger)
+		// a dir with no meta.json must be skipped, not error.
+		bad := filepath.Join(ledger, "data", "plans", "2026-01-01-broken")
+		if err := os.MkdirAll(bad, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		plans, err := List("/g")
+		if err != nil {
+			t.Fatalf("List err = %v", err)
+		}
+		if len(plans) != 0 {
+			t.Errorf("List = %v, want empty (malformed skipped)", plans)
+		}
+	})
+}
+
+func TestSave_NoLedgerErrors(t *testing.T) {
+	withLedger(t, "")
+	_, err := Save("/g", Input{Raw: "# x"}, sampleResult(), nil, Meta{Topic: "x"})
+	if err == nil {
+		t.Fatal("Save with no ledger should error so the porcelain path can treat it as 'nothing to save'")
+	}
+}
+
+func TestLoad_NotFound(t *testing.T) {
+	withLedger(t, t.TempDir())
+	_, _, _, err := Load("/g", "does-not-exist")
+	if err == nil {
+		t.Fatal("Load of missing slug should error")
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"Plan capture to ledger", "plan-capture-to-ledger"},
+		{"One Two", "one-two"},
+		{"  Trim   Me  ", "trim-me"},
+		{"A/B: C.d, E!", "a-b-c-d"},
+		{"Five Six Seven Eight Nine", "five-six-seven-eight"},
+		{"Single", "single"},
+		{"", "untitled-plan"},
+		{"!!!", "untitled-plan"},
+		{"CamelCase Words", "camelcase-words"},
+	}
+	for _, tc := range tests {
+		if got := Slugify(tc.in); got != tc.want {
+			t.Errorf("Slugify(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSave_DefaultsSlugAndTimestamp(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	// empty Slug and zero CreatedAt should be derived/defaulted.
+	dir, err := Save("/g", Input{Raw: "# x"}, sampleResult(), nil, Meta{Topic: "Derive My Slug"})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if base := filepath.Base(dir); !strings.HasSuffix(base, "-derive-my-slug") {
+		t.Errorf("dir base = %q, want suffix -derive-my-slug", base)
+	}
+
+	// meta.json carries a non-zero created_at and the derived slug.
+	data, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta Meta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.Slug != "derive-my-slug" {
+		t.Errorf("meta.Slug = %q", meta.Slug)
+	}
+	if meta.CreatedAt.IsZero() {
+		t.Errorf("meta.CreatedAt is zero, want defaulted")
+	}
+}

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -1,0 +1,129 @@
+// Package plan enriches agent-generated implementation plans with SageOx team
+// context. ox computes DETERMINISTIC badges locally (zero LLM tokens) and
+// assembles a context bundle; the client agent does any inference. ox NEVER
+// makes an LLM or network call in this path.
+//
+// Architecture:
+//   - Detectors produce deterministic Annotations from local data (collision,
+//     prior-art, expert-routing). They are fail-open: missing/unreadable data
+//     returns (nil, nil), never an aborting error.
+//   - Retrievers assemble a context bundle ([]ContextItem) the client agent
+//     reasons over to author judgment badges (aligns/conflicts, expert
+//     perspective). Also fail-open.
+//   - Enrich() orchestrates registered detectors and retrievers, aggregating
+//     results into a Result with a deterministic SignalSummary.
+//
+// Round 2 agents implement detectors/retrievers in collision.go, expert.go,
+// priorart.go (and a context-bundle assembler) and register them via init().
+package plan
+
+import "context"
+
+// SchemaVersion is the on-disk schema version stamped into both annotations.json
+// (Result.SchemaVersion) and meta.json (Meta.SchemaVersion) on write. These are
+// long-lived ledger artifacts a future ox may need to migrate; an explicit
+// version lets a reader detect and adapt to an older layout instead of guessing.
+// Bump this when the serialized shape of Result or Meta changes incompatibly.
+const SchemaVersion = "v1"
+
+// BadgeKind distinguishes who produces an annotation: ox locally (deterministic,
+// zero tokens) versus the client agent (judgment, reasoned from the bundle).
+type BadgeKind string
+
+const (
+	// BadgeDeterministic: ox computes the badge locally with zero LLM tokens.
+	BadgeDeterministic BadgeKind = "deterministic"
+	// BadgeJudgment: the client agent authors the badge from the context bundle.
+	BadgeJudgment BadgeKind = "judgment"
+)
+
+// BadgeType is the specific signal an annotation carries.
+type BadgeType string
+
+const (
+	// BadgeCollision: plan touches files in an open PR, hotspot, or recent murmur.
+	BadgeCollision BadgeType = "collision"
+	// BadgePriorArt: a teammate already did or planned this.
+	BadgePriorArt BadgeType = "prior-art"
+	// BadgeExpertRoute: who owns this area + their relevant work (deterministic).
+	BadgeExpertRoute BadgeType = "expert-routing"
+	// BadgeAligns: plan aligns with ADRs, decisions, conventions (judgment).
+	BadgeAligns BadgeType = "aligns"
+	// BadgeConflicts: plan conflicts with ADRs, decisions, conventions (judgment).
+	BadgeConflicts BadgeType = "conflicts"
+	// BadgeExpertPersp: synthesized expert stance, cited (judgment).
+	BadgeExpertPersp BadgeType = "expert-perspective"
+)
+
+// Annotation is a single badge attached to a plan section.
+type Annotation struct {
+	Section   string    `json:"section,omitempty"`
+	Kind      BadgeKind `json:"kind"`
+	Type      BadgeType `json:"type"`
+	Why       string    `json:"why"`
+	SourceURL string    `json:"source_url,omitempty"`
+	Expert    string    `json:"expert,omitempty"`
+	Files     []string  `json:"files,omitempty"`
+}
+
+// ContextItem is one ranked, pre-retrieved slice of ledger / team context / code
+// the client agent reasons over to author judgment badges.
+type ContextItem struct {
+	Kind    string  `json:"kind"` // murmur|session|decision|adr|commit|discussion
+	Title   string  `json:"title"`
+	Ref     string  `json:"ref"`
+	Snippet string  `json:"snippet,omitempty"`
+	Score   float64 `json:"score"`
+	Author  string  `json:"author,omitempty"`
+	When    string  `json:"when,omitempty"`
+}
+
+// Section is one H2-delimited block of a plan, with any file references it cites.
+type Section struct {
+	Heading string
+	Body    string
+	Files   []string
+}
+
+// Input is a resolved plan: its source path (if any), raw markdown, and parsed
+// sections.
+type Input struct {
+	Path     string
+	Raw      string
+	Sections []Section
+}
+
+// SignalSummary is the deterministic rollup of which signals fired. Material is
+// true when the plan warrants surfacing a nudge (any collision OR expert-route
+// OR at least one strong prior-art hit).
+type SignalSummary struct {
+	Collisions   int  `json:"collisions"`
+	PriorArt     int  `json:"prior_art"`
+	ExpertRoutes int  `json:"expert_routes"`
+	Material     bool `json:"material"`
+}
+
+// Result is the full output of Enrich: deterministic annotations, the context
+// bundle, and the signal summary.
+type Result struct {
+	// SchemaVersion stamps the serialized annotations.json shape (set to
+	// SchemaVersion on write) so a future reader can detect an older layout.
+	SchemaVersion string        `json:"schema_version,omitempty"`
+	Annotations   []Annotation  `json:"annotations"`
+	Context       []ContextItem `json:"context"`
+	Signals       SignalSummary `json:"signals"`
+}
+
+// Detector produces deterministic annotations from local data.
+// MUST be fail-open: on missing/unreadable data return (nil, nil), never an
+// error that aborts enrichment.
+type Detector interface {
+	Name() string
+	Detect(ctx context.Context, in Input, gitRoot string) ([]Annotation, error)
+}
+
+// Retriever produces context-bundle items. Also fail-open.
+type Retriever interface {
+	Name() string
+	Retrieve(ctx context.Context, in Input, gitRoot string) ([]ContextItem, error)
+}

--- a/internal/prime/agent_type.go
+++ b/internal/prime/agent_type.go
@@ -45,6 +45,43 @@ func CanonicalAgentType(agentType string) string {
 	return slug
 }
 
+// AgentTier classifies an agent by the richness of plan-enrichment guidance
+// it can act on. Higher tiers get the full advisory block + IntentCommand;
+// lower tiers get a lighter note that only promises what the tier can deliver.
+type AgentTier int
+
+const (
+	// TierUnknown is the safe baseline for unrecognized/empty agent types:
+	// full block + the active `ox plan` command. We assume capability rather
+	// than under-serve an agent we simply haven't classified yet.
+	TierUnknown AgentTier = iota
+	// TierBronze covers known agents with no real-time lifecycle hooks
+	// (amp, opencode, pi). Lighter note: `ox plan` exists + `ox plan list` to
+	// browse prior plans — no promise of a nudge the tier can't deliver.
+	TierBronze
+	// TierSilver covers guidance-driven agents (codex, gemini): full block +
+	// IntentCommand, but no real-time hook firing the nudge for them.
+	TierSilver
+	// TierGold covers claude-code, which has PostToolUse/Stop hooks that can
+	// drive the enrichment nudge in real time. Full block + IntentCommand.
+	TierGold
+)
+
+// ClassifyAgentTier maps an agent type to its plan-enrichment tier. Unknown or
+// empty agent types fall back to TierUnknown (safe baseline = block + command).
+func ClassifyAgentTier(agentType string) AgentTier {
+	switch CanonicalAgentType(agentType) {
+	case string(agentx.AgentTypeClaudeCode):
+		return TierGold
+	case string(agentx.AgentTypeCodex), string(agentx.AgentTypeGemini):
+		return TierSilver
+	case string(agentx.AgentTypeAmp), string(agentx.AgentTypeOpenCode), string(agentx.AgentTypePi):
+		return TierBronze
+	default:
+		return TierUnknown
+	}
+}
+
 // IsAgentSupported returns true if the agent is officially supported.
 func IsAgentSupported(agentType string) bool {
 	normalized := CanonicalAgentType(agentType)

--- a/internal/prime/agent_type_test.go
+++ b/internal/prime/agent_type_test.go
@@ -6,6 +6,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestClassifyAgentTier verifies plan-enrichment tier classification, including
+// canonicalization of display names/aliases and the unknown-agent baseline.
+// Failure prevented: an agent landing in the wrong tier and being shown
+// guidance its lifecycle can't honor (or losing the baseline command entirely).
+func TestClassifyAgentTier(t *testing.T) {
+	tests := []struct {
+		agentType string
+		want      AgentTier
+	}{
+		{"claude-code", TierGold},
+		{"Claude Code", TierGold},
+		{"claudecode", TierGold},
+		{"codex", TierSilver},
+		{"gemini", TierSilver},
+		{"gemini-cli", TierSilver},
+		{"amp", TierBronze},
+		{"opencode", TierBronze},
+		{"pi", TierBronze},
+		{"", TierUnknown},
+		{"some-future-agent", TierUnknown},
+		{"cursor", TierUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.agentType, func(t *testing.T) {
+			assert.Equal(t, tt.want, ClassifyAgentTier(tt.agentType),
+				"ClassifyAgentTier(%q)", tt.agentType)
+		})
+	}
+}
+
 func TestCanonicalAgentType(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/prime/guidance.go
+++ b/internal/prime/guidance.go
@@ -15,6 +15,7 @@ type GuidanceParams struct {
 	CodeDBExists     bool             // true if code search index exists on disk
 	MemoryEnabled    bool             // true if memory feature is enabled
 	MurmuringEnabled bool             // true if murmuring: "auto" is set for this project
+	AgentType        string           // detected/claimed agent type; drives plan-enrichment tiering
 }
 
 // BuildGuidance constructs state-aware command guidance for agent consumption.
@@ -83,6 +84,26 @@ func BuildGuidance(p GuidanceParams) *Guidance {
 		cmds = append(cmds, IntentCommand{
 			Intent:  fmt.Sprintf("code search %s (not indexed yet): index first, then search code, symbols, and diffs", p.RepoSlug),
 			Command: "ox code index",
+		})
+	}
+
+	// plan enrichment — guide the agent toward `ox plan` when it produces a
+	// plan for non-trivial work. Tier-aware: Gold/Silver get the active
+	// enrich command; Bronze gets the browse-prior-plans command so we don't
+	// promise a nudge the tier can't deliver. (The matching behavioral block
+	// is the <plan-enrichment-guidance> advisory in agent_prime_xml.go.)
+	switch ClassifyAgentTier(p.AgentType) {
+	case TierBronze:
+		// lighter: surface that plans can be enriched + browsed, without
+		// promising a real-time nudge this tier can't fire.
+		cmds = append(cmds, IntentCommand{
+			Intent:  "enrich an implementation plan with team context ('ox plan'), or browse prior plans for this repo",
+			Command: "ox plan list",
+		})
+	default: // TierGold, TierSilver, TierUnknown (baseline) — active enrich command
+		cmds = append(cmds, IntentCommand{
+			Intent:  "enrich/render your implementation plan with team context: collisions, prior art, expert routing — run when a plan touches multiple files, architecture, a hotspot/open-PR, or ~5+ steps",
+			Command: "ox plan",
 		})
 	}
 

--- a/internal/prime/guidance_test.go
+++ b/internal/prime/guidance_test.go
@@ -152,6 +152,48 @@ func TestBuildGuidance(t *testing.T) {
 	}
 }
 
+// planCommandFor returns the Command string of the plan-enrichment
+// IntentCommand BuildGuidance emits for a given agent type, or "" if absent.
+func planCommandFor(t *testing.T, agentType string) string {
+	t.Helper()
+	g := BuildGuidance(GuidanceParams{AgentID: "p", RepoSlug: "org/repo", AgentType: agentType})
+	require.NotNil(t, g)
+	for _, c := range g.Commands {
+		if c.Command == "ox plan" || c.Command == "ox plan list" {
+			return c.Command
+		}
+	}
+	return ""
+}
+
+// TestBuildGuidance_PlanEnrichmentTiering verifies the plan IntentCommand is
+// tier-aware: Gold/Silver and the unknown baseline route to the active
+// `ox plan`; Bronze routes to the lighter `ox plan list`.
+// Failure prevented: a Bronze agent being promised a real-time enrichment
+// nudge its lifecycle can't deliver, or an unknown agent losing the command.
+func TestBuildGuidance_PlanEnrichmentTiering(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentType string
+		want      string
+	}{
+		{"gold claude-code", "claude-code", "ox plan"},
+		{"silver codex", "codex", "ox plan"},
+		{"silver gemini", "gemini", "ox plan"},
+		{"bronze amp", "amp", "ox plan list"},
+		{"bronze opencode", "opencode", "ox plan list"},
+		{"bronze pi", "pi", "ox plan list"},
+		{"unknown baseline", "some-future-agent", "ox plan"},
+		{"empty baseline", "", "ox plan"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, planCommandFor(t, tt.agentType),
+				"agentType %q should route to %q", tt.agentType, tt.want)
+		})
+	}
+}
+
 func containsStr(haystack, needle string) bool {
 	return len(haystack) >= len(needle) && (haystack == needle ||
 		len(haystack) > len(needle) && (haystack[:len(needle)] == needle ||


### PR DESCRIPTION
## Summary

Adds **`ox plan`** — a command family that enriches an AI coworker's implementation plan with SageOx team context, so a plan starts with the full picture of where the team is going instead of from zero.

The core idea: **ox provides context; the client does inference.** ox never makes an LLM or network call in this path. It computes **deterministic badges** locally (zero model tokens) and assembles a **context bundle**; the plan-mode agent — already spending tokens to produce a good plan — authors the **judgment badges** by reasoning over that bundle. SageOx's value is the data access (ledger, codedb, murmurs), not the inference.

```mermaid
flowchart TB
  P["Plan section"] --> DET["Deterministic: ox computes locally, 0 model tokens"]
  P --> JUD["Judgment: client agent authors from the context bundle"]
  DET --> C["Collision: file in a teammate's open PR, hotspot, or recent murmur"]
  DET --> PA["Prior art: a teammate already planned or did this"]
  DET --> EX["Expert routing: who owns this area, with cited evidence"]
  CTX["ox context bundle: recent murmurs, prior sessions, decisions, ADRs"] --> JUD
  JUD --> AL["Aligns or Conflicts: versus ADRs, decisions, conventions"]
  JUD --> EXD["Expert perspective: synthesized stance, cited only"]
```

## What this PR ships

- **`ox plan`** (porcelain) — discover the active plan, enrich it, auto-save to the ledger.
- **`ox plan --json`** (plumbing, 0 tokens, no network) — deterministic badges + context bundle for the plan-exit hook and the renderer skill.
- **`ox plan save`** — explicit full-plan persist (merged deterministic + agent-authored judgment badges + optional rendered HTML).
- **`ox plan list` / `view`** — browse saved plans (parallels `ox session list` / `view`).
- **Three deterministic detectors** (`internal/plan/`): collision/active-work (codedb open PRs + contention **+ recent murmurs** — the earliest signal, before any commit exists), expert routing (codedb author frequency, cited only — never fabricated), prior art (local-first ledgersearch).
- **Context-bundle retriever** — murmurs + prior sessions + team decisions/ADRs, capped for the client's token budget.
- **Prior-art flywheel closed** — `ledgersearch.scanPlans()` indexes saved plans so today's plan becomes tomorrow's prior art.
- **Capture to the ledger** — `data/plans/YYYY-MM-DD-<slug>/` with `plan.md` + `annotations.json` + `meta.json` as **plain git** (a dehydrated clone lists/reads/searches with zero LFS hydration), and `plan.html` only when already rendered (size-gated LFS, pure-Go).
- **Agent-tiered prime guidance** + **plan-exit nudge** (Claude Code: PostToolUse on `ExitPlanMode` detects, UserPromptSubmit delivers — because Claude Code discards PostToolUse stdout). Graduated support: Claude Code gets the renderer skill; other agents get guidance + the CLI. See `docs/ai/specs/agent-support-matrix.md`.
- **Renderer skill** (`extensions/claude/commands/ox-plan.md`) — forks the html-plan quality bar (light/dark, fit-to-column diagrams, swimlanes) and adds a per-section badge rail + alignment-summary strip.
- **Config** — `plan.save` (bool) + `plan.html` (`off` / `recommend` / `always`) + `SAGEOX_PLAN_HTML` env override. One tri-state instead of contradictory bools.
- **ADR-021** records the architecture + the two Required-Review decisions (ledger path, env namespace), both approved.

## Test Plan

- `go build ./...` clean; `internal/plan`, `internal/ledgersearch`, `internal/config` lint **0 issues**.
- Table-driven unit tests green across `internal/plan/` (detector matching, ranking, capping, Save→List→Load round-trip, schema_version, slugify, fail-open), `internal/ledgersearch/` (plans surface as prior art, distinguishable from sessions, age cutoff), `internal/config/` (tri-state precedence env > user > project > default, `off` silences), `internal/prime/` (agent-tier guidance), and `cmd/ox/` (plan-exit nudge idempotency + deliver-once, `ox plan save` guards).
- Smoke: `ox plan --json` emits valid JSON and makes no network/LLM call; `ox plan list` / `ox plan save --help` behave.
- E2E in `sageox/ox-test-harness` is a tracked follow-up (additive + advisory — `ox plan` never blocks merge).

## Follow-ups (filed, all P3/P4, none blocking)

- Chunked/semantic plan index (richer prior-art recall).
- LFS hydration of `plan.html` in `ox plan view`.
- Optional cloud `ox query` augment for sparse local retrieval.
- `ox doctor` plan-setup check.
- Real-session E2E in `ox-test-harness`.

---
<details>
<summary>Checklist</summary>

- [x] Tests added (unit + table-driven across all new packages; E2E filed as follow-up)
- [x] CHANGELOG entry added (user-facing — under `[Unreleased]`)
- [ ] Breaking change — N/A (new command, additive)
- [x] `/security-review` — N/A documented: no changes to `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum`. New `SAGEOX_PLAN_HTML` env is read-only config; the LLM trust boundary is unchanged (ox makes no model call).

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)
