### PR TITLE
feat(plan): link saved plans to sessions/agents + collaboration signals

### DIFF
--- a/cmd/ox/agent_hook_plan_nudge.go
+++ b/cmd/ox/agent_hook_plan_nudge.go
@@ -47,10 +47,13 @@ const (
 	// later in an unrelated context.
 	planNudgeMaxAge = 30 * time.Minute
 
-	// planSubprocessTimeout caps the `ox plan --json` enrichment call. Enrich is
-	// pure-local (no network/LLM), so this is generous headroom, not a latency
-	// budget the user feels.
-	planSubprocessTimeout = 3 * time.Second
+	// planSubprocessTimeout caps the `ox plan --json --persist` call. Enrichment
+	// itself is pure-local, but --persist also saves + synchronously commits and
+	// pushes a draft to the ledger (the chosen durability model), so this is
+	// sized to absorb a network push, not just local enrichment. The hard kill
+	// is a safety ceiling: if the push wedges, the local commit still stands and
+	// the next push / `ox doctor` carries it — the agent is never hung.
+	planSubprocessTimeout = 30 * time.Second
 )
 
 // exitPlanModeInput is the minimal shape of Claude Code's ExitPlanMode
@@ -144,7 +147,10 @@ func runPlanEnrichment(planText string) (planJSONResult, bool) {
 		return res, false
 	}
 
-	cmd := exec.Command(oxPath, "plan", "--json")
+	// --persist: durably save + commit the draft now, so a plan exists on the
+	// ledger the moment the agent leaves plan mode (not contingent on a later
+	// `ox plan` / skill save). Enrichment output (stdout JSON) is unchanged.
+	cmd := exec.Command(oxPath, "plan", "--json", "--persist")
 	cmd.Stdin = strings.NewReader(planText)
 	cmd.Env = os.Environ()
 

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/identity"
 	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/plan"
 	"github.com/sageox/ox/internal/proc"
 	"github.com/sageox/ox/internal/repotools"
 	"github.com/sageox/ox/internal/session"
@@ -1316,6 +1317,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		Summary(result.Summary).
 		StopReason(session.StopReasonStopped).
 		ProducedCommits(state.ProducedCommits).
+		ProducedPlans(state.ProducedPlans).
 		LinkedPRs(state.LinkedPRs).
 		LinkedIssues(state.LinkedIssues).
 		// staged: meta.json is being written here, BEFORE the LFS upload +
@@ -1378,6 +1380,12 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		return fmt.Errorf("commit and push: %w", err)
 	}
 
+	// reverse-link reconciliation: the session now has a canonical ses_ id and
+	// is committed, so backfill it + outcome=stopped onto every plan this
+	// session produced (slugs in hand — no directory scan), then commit those
+	// plan dirs. Best-effort; any miss falls to `ox doctor`.
+	reconcileProducedPlansAtStop(projectRoot, state.ProducedPlans, meta.EffectiveSessionID())
+
 	// push succeeded — now safe to replace content files with LFS pointer stubs
 	if len(meta.Files) > 0 {
 		// WritePointerFiles can return both a partial `written` slice AND a
@@ -1412,6 +1420,28 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	finalizeLinkageAfterPush(projectRoot, sessionDir, meta, sessionName)
 
 	return nil
+}
+
+// reconcileProducedPlansAtStop backfills the canonical session id + a
+// "stopped" outcome onto every plan a just-stopped session produced, then
+// commits each updated plan dir (data/plans/ is not covered by the session
+// commit). Slug-driven — no directory scan — and fully best-effort: any miss
+// is reconciled later by `ox doctor`.
+func reconcileProducedPlansAtStop(projectRoot string, slugs []string, sessionID string) {
+	for _, slug := range slugs {
+		if err := plan.ReconcileSessionOutcome(projectRoot, slug, sessionID, plan.SessionOutcomeStopped); err != nil {
+			slog.Debug("plan reconcile at stop failed", "slug", slug, "error", err)
+			continue
+		}
+		_, _, info, err := plan.Load(projectRoot, slug)
+		if err != nil {
+			slog.Debug("plan reconcile load failed", "slug", slug, "error", err)
+			continue
+		}
+		if cerr := commitPlanToLedger(projectRoot, info.Dir); cerr != nil {
+			slog.Debug("plan reconcile commit failed", "slug", slug, "error", cerr)
+		}
+	}
 }
 
 // copySessionCacheToLedger delegates to pipeline.CopySessionToLedger with the real filesystem.

--- a/cmd/ox/agent_session_recover.go
+++ b/cmd/ox/agent_session_recover.go
@@ -221,6 +221,7 @@ func recoverFromCache(inst *agentinstance.Instance, projectRoot string, state *s
 						EntryCount(entryCount).
 						StopReason(session.StopReasonRecovered).
 						ProducedCommits(state.ProducedCommits).
+						ProducedPlans(state.ProducedPlans).
 						WithFiles(fileRefs)
 					if preservedID != "" {
 						metaBuilder = metaBuilder.SessionID(preservedID)

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -32,6 +32,7 @@ Reads the active plan from --file or stdin. Use --json for the plumbing path
 	RunE: func(cmd *cobra.Command, args []string) error {
 		file, _ := cmd.Flags().GetString("file")
 		jsonOut, _ := cmd.Flags().GetBool("json")
+		persist, _ := cmd.Flags().GetBool("persist")
 
 		in, err := plan.Resolve(file, cmd.InOrStdin())
 		if err != nil {
@@ -53,9 +54,16 @@ Reads the active plan from --file or stdin. Use --json for the plumbing path
 
 		result := plan.Enrich(context.Background(), in, gitRoot)
 
-		// --json is the plumbing path: no save, no metrics side effects that
-		// could perturb stdout. Emit the Result and nothing else.
+		// --json is the plumbing path: by default no save, no metrics side
+		// effects that could perturb stdout — emit the Result and nothing else.
+		// With --persist (the ExitPlanMode hook passes it) the path ALSO saves +
+		// commits a draft, so a plan is durable the moment the agent exits plan
+		// mode. The save writes only to logs/ledger, never to stdout, so the
+		// JSON the hook parses stays clean.
 		if jsonOut {
+			if persist && gitRoot != "" && config.PlanSave(gitRoot) {
+				savePlanWithProvenance(gitRoot, in, result, nil)
+			}
 			return writePlanJSON(cmd, result)
 		}
 
@@ -118,23 +126,96 @@ func maybeSavePlan(gitRoot string, in plan.Input, result plan.Result) string {
 	if gitRoot == "" || !config.PlanSave(gitRoot) {
 		return ""
 	}
+	return savePlanWithProvenance(gitRoot, in, result, nil)
+}
 
+// savePlanWithProvenance is the shared capture path: it stamps the plan with
+// provenance (session/agent/repo) + deterministic collaboration signals, writes
+// it to the ledger (read-merge preserving lifecycle), records the reverse link
+// on the live recording, and durably commits + pushes the plan dir. Returns the
+// saved directory, or "" on any failure (capture is best-effort and never
+// aborts the command the agent is waiting on).
+func savePlanWithProvenance(gitRoot string, in plan.Input, result plan.Result, html []byte) string {
 	topic := planTopic(in)
+	slug := plan.Slugify(topic)
+
+	prov, recState := resolvePlanProvenance(gitRoot)
+	collab := deriveCollabSignals(recState)
+
 	meta := plan.Meta{
 		Topic:          topic,
-		Slug:           plan.Slugify(topic),
+		Slug:           slug,
 		Authors:        planAuthors(gitRoot),
 		CreatedAt:      time.Now().UTC(),
 		SourcePlanPath: in.Path,
+		Provenance:     prov,
+		Collaboration:  collab,
 	}
 
-	dir, err := plan.Save(gitRoot, in, result, nil, meta)
+	dir, err := plan.Save(gitRoot, in, result, html, meta)
 	if err != nil {
-		// best-effort: a missing ledger or write failure must not break the
-		// enrichment output the agent is waiting on.
 		return ""
 	}
+
+	// reverse link: record the slug on the live recording so it folds into the
+	// session's meta.json at stop (no-op if there's no live recording).
+	if prov != nil && prov.SessionName != "" {
+		_ = appendProducedPlan(gitRoot, prov.AgentID, slug)
+	}
+
+	// durability: commit + push the plan dir now (sync). Best-effort — a push
+	// failure leaves the local commit for the next push / `ox doctor`.
+	if err := commitPlanToLedger(gitRoot, dir); err != nil {
+		slog.Warn("plan: commit/push failed, deferring to next push/doctor", "error", err, "dir", dir)
+	}
+
+	slog.Info("plan_saved_provenance",
+		"slug", slug,
+		"session", provSessionLabel(prov),
+		"agent_id", provAgentLabel(prov),
+		"user_prompts", collabCount(collab, "user_prompts"),
+		"agent_questions", collabCount(collab, "agent_questions"),
+		"tool_calls", collabCount(collab, "tool_calls"),
+		"duration_s", collabCount(collab, "duration_seconds"))
+
 	return dir
+}
+
+// provSessionLabel / provAgentLabel render provenance fields for structured
+// logs without panicking on a nil provenance.
+func provSessionLabel(p *plan.Provenance) string {
+	if p == nil {
+		return ""
+	}
+	if p.SessionID != "" {
+		return p.SessionID
+	}
+	return p.SessionName
+}
+
+func provAgentLabel(p *plan.Provenance) string {
+	if p == nil {
+		return ""
+	}
+	return p.AgentID
+}
+
+// collabCount reads a single collaboration count for logging; 0 when absent.
+func collabCount(c *plan.CollabSignals, field string) int {
+	if c == nil {
+		return 0
+	}
+	switch field {
+	case "user_prompts":
+		return c.UserPrompts
+	case "agent_questions":
+		return c.AgentQuestions
+	case "tool_calls":
+		return c.ToolCalls
+	case "duration_seconds":
+		return c.DurationSeconds
+	}
+	return 0
 }
 
 // runPlanSave persists a fully-enriched plan to the ledger from a plan markdown
@@ -181,22 +262,16 @@ func runPlanSave(cmd *cobra.Command) error {
 		}
 	}
 
+	// The skill path always persists (no plan.save gate) and reuses the shared
+	// provenance/collaboration + read-merge + commit path so the hook's draft
+	// and the skill's full save converge on the same dated-slug dir.
 	gitRoot := findGitRoot()
-	topic := planTopic(in)
-	meta := plan.Meta{
-		Topic:          topic,
-		Slug:           plan.Slugify(topic),
-		Authors:        planAuthors(gitRoot),
-		CreatedAt:      time.Now().UTC(),
-		SourcePlanPath: planPath,
+	dir := savePlanWithProvenance(gitRoot, in, result, html)
+	if dir == "" {
+		return fmt.Errorf("save plan: no ledger configured for %q or write failed", gitRoot)
 	}
 
-	dir, err := plan.Save(gitRoot, in, result, html, meta)
-	if err != nil {
-		return fmt.Errorf("save plan: %w", err)
-	}
-
-	slog.Info("plan_saved", "dir", dir, "slug", meta.Slug, "html", htmlPath != "", "annotations", len(result.Annotations))
+	slog.Info("plan_saved", "dir", dir, "html", htmlPath != "", "annotations", len(result.Annotations))
 	fmt.Fprintf(cmd.OutOrStdout(), "Saved plan to ledger: %s\n", dir)
 	return nil
 }
@@ -326,6 +401,14 @@ func runPlanView(cmd *cobra.Command, slug string, open bool) error {
 	if len(info.Authors) > 0 {
 		fmt.Fprintln(out, cli.StyleDim.Render("authors: "+strings.Join(info.Authors, ", ")))
 	}
+	if meta, err := plan.ReadPlanMeta(gitRoot, info.Slug); err == nil {
+		if line := planProvenanceLine(meta); line != "" {
+			fmt.Fprintln(out, cli.StyleDim.Render(line))
+		}
+		if line := planCollabLine(meta); line != "" {
+			fmt.Fprintln(out, cli.StyleDim.Render(line))
+		}
+	}
 	fmt.Fprintln(out)
 
 	fmt.Fprintln(out, planMD)
@@ -382,6 +465,58 @@ func writeBadgeSummary(out io.Writer, res plan.Result) {
 	}
 }
 
+// planProvenanceLine renders the one-line forward link (session · agent · model
+// · outcome) for a saved plan, or "" when the plan carries no provenance.
+func planProvenanceLine(meta plan.Meta) string {
+	p := meta.Provenance
+	if p == nil {
+		return ""
+	}
+	var parts []string
+	switch {
+	case p.SessionID != "":
+		parts = append(parts, "session: "+p.SessionID)
+	case p.SessionName != "":
+		parts = append(parts, "session: "+p.SessionName)
+	}
+	if p.AgentID != "" {
+		parts = append(parts, "agent: "+p.AgentID)
+	}
+	if p.Model != "" {
+		parts = append(parts, "model: "+p.Model)
+	}
+	if p.SessionOutcome != "" && p.SessionOutcome != plan.SessionOutcomeActive {
+		parts = append(parts, "session "+p.SessionOutcome)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " · ")
+}
+
+// planCollabLine renders the one-line collaboration fingerprint (status +
+// effort proxies) for a saved plan, or "" when there are no collaboration
+// signals.
+func planCollabLine(meta plan.Meta) string {
+	c := meta.Collaboration
+	if c == nil {
+		return ""
+	}
+	parts := []string{
+		fmt.Sprintf("%d prompts", c.UserPrompts),
+		fmt.Sprintf("%d questions", c.AgentQuestions),
+		fmt.Sprintf("%d tool calls", c.ToolCalls),
+	}
+	if c.DurationSeconds > 0 {
+		parts = append(parts, fmt.Sprintf("%ds", c.DurationSeconds))
+	}
+	prefix := ""
+	if meta.Status != "" {
+		prefix = string(meta.Status) + " · "
+	}
+	return "collaboration: " + prefix + strings.Join(parts, " · ")
+}
+
 func planDate(t time.Time) string {
 	if t.IsZero() {
 		return "—"
@@ -416,6 +551,7 @@ func truncate(s string, n int) string {
 
 func init() {
 	planCmd.Flags().Bool("json", false, "emit the enrichment Result as JSON (plumbing path; no network/LLM call)")
+	planCmd.Flags().Bool("persist", false, "with --json, also save + commit a draft to the ledger (used by the ExitPlanMode hook)")
 	planCmd.Flags().String("file", "", "plan source file (default: stdin, else newest ~/.claude/plans/*.md)")
 
 	planViewCmd.Flags().Bool("open", false, "open the rendered plan.html in your browser (if one was saved)")

--- a/cmd/ox/plan_collaboration.go
+++ b/cmd/ox/plan_collaboration.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/identity"
+	"github.com/sageox/ox/internal/plan"
+	"github.com/sageox/ox/internal/session"
+)
+
+// Plan provenance + collaboration signals (cmd/ox side).
+//
+// internal/plan is a pure data layer with no session/agent-instance deps, so
+// the bits that touch the recording state and raw.jsonl transcript live here
+// and hand internal/plan plain structs. Everything is best-effort and
+// fail-open: a plan saved outside a primed/recording session simply carries no
+// provenance and no collaboration block, never an error.
+
+// resolvePlanProvenance builds the forward link for a plan being saved in
+// gitRoot. Returns the provenance to stamp and the live recording state (so the
+// caller can derive collaboration signals from the same load). Returns
+// (nil, nil) when no agent context is detected — the plan is then unlinked,
+// which renders fine.
+func resolvePlanProvenance(gitRoot string) (*plan.Provenance, *session.RecordingState) {
+	agentID, agentType := detectAgentContext()
+	if agentID == "" {
+		return nil, nil
+	}
+
+	prov := &plan.Provenance{AgentID: agentID, AgentType: agentType}
+
+	// instance store: authoritative agent type + model snapshot.
+	if inst, err := resolveInstance(agentID); err == nil && inst != nil {
+		if inst.AgentType != "" {
+			prov.AgentType = inst.AgentType
+		}
+		prov.Model = inst.Model
+	}
+
+	// repo id + author snapshot (denormalized so the plan renders standalone).
+	ep := ""
+	if ctx, err := config.LoadProjectContext(gitRoot); err == nil && ctx != nil {
+		ep = ctx.Endpoint()
+	}
+	if cfg, err := config.LoadProjectConfig(gitRoot); err == nil && cfg != nil {
+		prov.RepoID = cfg.RepoID
+	}
+	prov.AuthorName = identity.AttributionDisplayName(ep, "")
+
+	// live recording → session name (available now) + active outcome. The
+	// canonical ses_ SessionID is minted at stop and backfilled there.
+	var st *session.RecordingState
+	if rs, err := session.LoadRecordingStateForAgent(gitRoot, agentID); err == nil && rs != nil {
+		st = rs
+		prov.SessionName = session.GetSessionName(rs.SessionPath)
+		prov.SessionOutcome = plan.SessionOutcomeActive
+	}
+
+	return prov, st
+}
+
+// deriveCollabSignals counts deterministic collaboration-effort proxies from the
+// live recording's raw.jsonl (local cache full content — no LFS hydration).
+// Returns nil when there is no live recording or no countable entries, so the
+// plan's collaboration block is omitted rather than written all-zero.
+func deriveCollabSignals(st *session.RecordingState) *plan.CollabSignals {
+	if st == nil || st.SessionPath == "" {
+		return nil
+	}
+	rawPath := filepath.Join(st.SessionPath, "raw.jsonl")
+	if _, err := os.Stat(rawPath); err != nil {
+		return nil
+	}
+	stored, err := session.ReadSessionFromPath(rawPath)
+	if err != nil || stored == nil || len(stored.Entries) == 0 {
+		return nil
+	}
+
+	sig := &plan.CollabSignals{}
+	var firstUserTS, lastTS time.Time
+	for _, e := range stored.Entries {
+		switch entryString(e, "type") {
+		case "user":
+			sig.UserPrompts++
+			if ts := entryTime(e); !ts.IsZero() && firstUserTS.IsZero() {
+				firstUserTS = ts
+			}
+		case "tool":
+			sig.ToolCalls++
+			if strings.Contains(entryString(e, "tool_name"), "AskUserQuestion") {
+				sig.AgentQuestions++
+			}
+		}
+		if ts := entryTime(e); !ts.IsZero() {
+			lastTS = ts
+		}
+	}
+
+	if !firstUserTS.IsZero() && lastTS.After(firstUserTS) {
+		sig.DurationSeconds = int(lastTS.Sub(firstUserTS).Seconds())
+	}
+
+	// all-zero counts carry no signal — omit the block entirely.
+	if sig.UserPrompts == 0 && sig.ToolCalls == 0 && sig.AgentQuestions == 0 && sig.DurationSeconds == 0 {
+		return nil
+	}
+	return sig
+}
+
+// appendProducedPlan records the plan slug on the agent's live recording state
+// (the reverse-link accumulator folded into session meta at stop). Dedups by
+// slug. Best-effort: no live recording → no-op.
+func appendProducedPlan(projectRoot, agentID, slug string) error {
+	if agentID == "" || slug == "" {
+		return nil
+	}
+	st, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	if err != nil || st == nil {
+		return nil
+	}
+	for _, existing := range st.ProducedPlans {
+		if existing == slug {
+			return nil // already recorded
+		}
+	}
+	st.ProducedPlans = append(st.ProducedPlans, slug)
+	return session.SaveRecordingState(projectRoot, st)
+}
+
+// entryString reads a string field from a raw.jsonl entry map, tolerating
+// absent/typed-otherwise values.
+func entryString(e map[string]any, key string) string {
+	if v, ok := e[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// entryTime parses an entry's timestamp, accepting both the recording format
+// ("ts") and the import format ("timestamp"). Returns zero time on any miss.
+func entryTime(e map[string]any) time.Time {
+	for _, key := range []string{"ts", "timestamp"} {
+		if s := entryString(e, key); s != "" {
+			if t, err := time.Parse(time.RFC3339, s); err == nil {
+				return t
+			}
+		}
+	}
+	return time.Time{}
+}

--- a/cmd/ox/plan_collaboration_test.go
+++ b/cmd/ox/plan_collaboration_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/session"
+)
+
+// writeRawJSONL writes a synthetic recording raw.jsonl into dir and returns the
+// recording state pointing at it.
+func writeRawJSONL(t *testing.T, lines string) *session.RecordingState {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return &session.RecordingState{SessionPath: dir}
+}
+
+// TestDeriveCollabSignals_Counts verifies the deterministic effort counts from a
+// transcript: user prompts, tool calls, AskUserQuestion clarifications, and the
+// span from first user turn to last entry.
+// Failure prevented: collaboration-rigor signals are wrong, so any later
+// judgment of plan thoughtfulness is built on bad counts.
+func TestDeriveCollabSignals_Counts(t *testing.T) {
+	raw := `{"type":"header","metadata":{"version":"1.0"}}
+{"type":"user","ts":"2026-06-04T10:00:00Z","content":"do X"}
+{"type":"assistant","ts":"2026-06-04T10:00:05Z","content":"thinking"}
+{"type":"tool","ts":"2026-06-04T10:00:10Z","tool_name":"Grep"}
+{"type":"tool","ts":"2026-06-04T10:01:00Z","tool_name":"mcp__conductor__AskUserQuestion"}
+{"type":"user","ts":"2026-06-04T10:02:00Z","content":"answer"}
+{"type":"user","ts":"2026-06-04T10:05:00Z","content":"go"}
+{"type":"footer","closed_at":"2026-06-04T10:05:00Z"}
+`
+	got := deriveCollabSignals(writeRawJSONL(t, raw))
+	if got == nil {
+		t.Fatal("expected signals, got nil")
+	}
+	if got.UserPrompts != 3 {
+		t.Errorf("UserPrompts = %d, want 3", got.UserPrompts)
+	}
+	if got.ToolCalls != 2 {
+		t.Errorf("ToolCalls = %d, want 2", got.ToolCalls)
+	}
+	if got.AgentQuestions != 1 {
+		t.Errorf("AgentQuestions = %d, want 1 (AskUserQuestion)", got.AgentQuestions)
+	}
+	// first user 10:00:00 → last entry 10:05:00 == 300s.
+	if got.DurationSeconds != 300 {
+		t.Errorf("DurationSeconds = %d, want 300", got.DurationSeconds)
+	}
+}
+
+// TestDeriveCollabSignals_NoSignalSources verifies the all-empty cases return
+// nil so the plan omits the collaboration block rather than writing all-zero.
+func TestDeriveCollabSignals_NoSignalSources(t *testing.T) {
+	// nil state
+	if got := deriveCollabSignals(nil); got != nil {
+		t.Errorf("nil state: want nil, got %+v", got)
+	}
+	// state with no raw.jsonl
+	if got := deriveCollabSignals(&session.RecordingState{SessionPath: t.TempDir()}); got != nil {
+		t.Errorf("missing raw.jsonl: want nil, got %+v", got)
+	}
+	// transcript with only assistant turns (nothing countable)
+	raw := `{"type":"assistant","ts":"2026-06-04T10:00:00Z","content":"hi"}
+{"type":"assistant","ts":"2026-06-04T10:00:05Z","content":"bye"}
+`
+	if got := deriveCollabSignals(writeRawJSONL(t, raw)); got != nil {
+		t.Errorf("only-assistant transcript: want nil, got %+v", got)
+	}
+}
+
+// TestAppendProducedPlan_NoRecordingNoOp verifies the reverse-link append is a
+// safe no-op when there is no live recording for the agent.
+// Failure prevented: a plan saved outside a recording errors instead of just
+// skipping the reverse link.
+func TestAppendProducedPlan_NoRecordingNoOp(t *testing.T) {
+	if err := appendProducedPlan(t.TempDir(), "Oxnope", "some-slug"); err != nil {
+		t.Errorf("expected no-op nil, got %v", err)
+	}
+	// empty agent / slug are also no-ops.
+	if err := appendProducedPlan(t.TempDir(), "", "s"); err != nil {
+		t.Errorf("empty agent: %v", err)
+	}
+}

--- a/cmd/ox/plan_commit.go
+++ b/cmd/ox/plan_commit.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/gitserver"
+)
+
+// commitPlanToLedger durably commits a captured plan directory to the ledger
+// and pushes it. This closes a real gap: plan.Save only materializes files into
+// the ledger working tree, and commitAndPushLedger stages only sessions/<name>/
+// — so without this, saved plans sit dirty-but-uncommitted indefinitely.
+//
+// Mirrors commitAndPushLedger's pattern (explicit-path `git add --sparse`,
+// --no-verify commit, pushLedger with pull-rebase retry), scoped to the plan
+// dir. Commit AND push are synchronous (the chosen durability model: the plan
+// is on the remote before the caller returns). Best-effort on the caller's
+// side: a push failure returns an error to log, but the local commit stands and
+// the next push / `ox doctor` carries it.
+func commitPlanToLedger(gitRoot, planDir string) error {
+	ctx, err := config.LoadProjectContext(gitRoot)
+	if err != nil || ctx == nil {
+		return fmt.Errorf("no project context for %q: cannot commit plan", gitRoot)
+	}
+	ledgerPath := ctx.DefaultLedgerPath()
+	if ledgerPath == "" {
+		return fmt.Errorf("no ledger configured for %q: cannot commit plan", gitRoot)
+	}
+
+	// ensure .gitignore is in place before any commit to prevent cache leakage
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
+	// --sparse: ledger repos use sparse-checkout (cone mode).
+	addArgs := []string{"-C", ledgerPath, "add", "--sparse", planDir}
+	if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("git add failed: %s: %w", string(out), err)
+	}
+
+	commitMsg := fmt.Sprintf("plan: %s", filepath.Base(planDir))
+	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "--no-verify", "-m", commitMsg)
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		if strings.Contains(string(out), "nothing to commit") {
+			return nil // idempotent: re-save with no change
+		}
+		return fmt.Errorf("%s: %w", wrapCommitError(string(out), err), err)
+	}
+
+	return pushLedger(context.Background(), ledgerPath)
+}

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -70,22 +70,22 @@ type SessionMeta struct {
 	//     and silently break dedup/lookup.
 	SessionID string `json:"session_id,omitempty"`
 
-	AgentType           string    `json:"agent_type"` // "claude-code", "cursor", etc.
-	Model               string    `json:"model,omitempty"`
-	Title               string    `json:"title,omitempty"`
-	CreatedAt           time.Time `json:"created_at"`
-	EntryCount          int       `json:"entry_count,omitempty"`
-	Summary             string    `json:"summary,omitempty"`
-	StopReason          string    `json:"stop_reason,omitempty"`             // how session ended (session.StopReason* constants)
-	StopDetail          string    `json:"stop_detail,omitempty"`             // human-readable detail (matched message, capped 512B)
-	StopSource          string    `json:"stop_source,omitempty"`             // adapterprotocol.TerminalSource* (structured / regex / exit_code)
-	StopPatternID       string    `json:"stop_pattern_id,omitempty"`         // which adapter pattern fired
-	StopResetsAtRaw     string    `json:"stop_resets_at_raw,omitempty"`      // raw reset-time substring as matched
-	StopResetsAt        *time.Time `json:"stop_resets_at,omitempty"`         // parsed absolute reset time, may be nil even when raw populated
-	RepoID              string    `json:"repo_id,omitempty"`
-	SageoxScore         *float64  `json:"sageox_score,omitempty"`          // agent's self-reported contribution score (0.0-1.0)
-	SageoxScoreCategory string    `json:"sageox_score_category,omitempty"` // named category: none, minor, moderate, significant, critical
-	SageoxScoreReason   string    `json:"sageox_score_reason,omitempty"`   // detailed explanation of SageOx influence
+	AgentType           string     `json:"agent_type"` // "claude-code", "cursor", etc.
+	Model               string     `json:"model,omitempty"`
+	Title               string     `json:"title,omitempty"`
+	CreatedAt           time.Time  `json:"created_at"`
+	EntryCount          int        `json:"entry_count,omitempty"`
+	Summary             string     `json:"summary,omitempty"`
+	StopReason          string     `json:"stop_reason,omitempty"`        // how session ended (session.StopReason* constants)
+	StopDetail          string     `json:"stop_detail,omitempty"`        // human-readable detail (matched message, capped 512B)
+	StopSource          string     `json:"stop_source,omitempty"`        // adapterprotocol.TerminalSource* (structured / regex / exit_code)
+	StopPatternID       string     `json:"stop_pattern_id,omitempty"`    // which adapter pattern fired
+	StopResetsAtRaw     string     `json:"stop_resets_at_raw,omitempty"` // raw reset-time substring as matched
+	StopResetsAt        *time.Time `json:"stop_resets_at,omitempty"`     // parsed absolute reset time, may be nil even when raw populated
+	RepoID              string     `json:"repo_id,omitempty"`
+	SageoxScore         *float64   `json:"sageox_score,omitempty"`          // agent's self-reported contribution score (0.0-1.0)
+	SageoxScoreCategory string     `json:"sageox_score_category,omitempty"` // named category: none, minor, moderate, significant, critical
+	SageoxScoreReason   string     `json:"sageox_score_reason,omitempty"`   // detailed explanation of SageOx influence
 
 	// SummaryStatus and ValidationError mirror the same-named fields on
 	// pkg/sessionsummary.SummarizeResponse. SummaryStatus is the
@@ -184,6 +184,15 @@ type SessionMeta struct {
 	// (Fixes #N / Closes #N / Resolves #N / GH-N) on the pushed range and
 	// from any LinkedPR body. omitempty for legacy round-trip.
 	LinkedIssues []string `json:"linked_issues,omitempty"`
+
+	// ProducedPlans is the reverse-direction index of plan slugs captured
+	// during this recording (the forward link lives on each plan's meta.json
+	// as provenance.session_id). Accumulated in RecordingState.ProducedPlans
+	// while the recording is active and folded into meta.json at session-stop
+	// — exactly mirroring ProducedCommits. An aborted session never reaches
+	// this fold, so the plan's forward link is the sole record in that case.
+	// omitempty so older meta.json files round-trip unchanged.
+	ProducedPlans []string `json:"produced_plans,omitempty"`
 
 	// LinkageStatus is the upload/notify lifecycle state for PR/issue
 	// linkage. See docs/ai/specs/session-pr-issue-linkage.md (v1.5) for the
@@ -439,6 +448,15 @@ func (b *SessionMetaBuilder) RepoID(id string) *SessionMetaBuilder {
 // order; duplicates are not deduplicated (callers do that if needed).
 func (b *SessionMetaBuilder) ProducedCommits(shas []string) *SessionMetaBuilder {
 	b.meta.ProducedCommits = shas
+	return b
+}
+
+// ProducedPlans sets the reverse-direction plan-slug index for this session.
+// Caller passes the slugs accumulated in RecordingState.ProducedPlans during
+// the active recording. Order preserves capture order; duplicates are not
+// deduplicated here (the append site dedups).
+func (b *SessionMetaBuilder) ProducedPlans(slugs []string) *SessionMetaBuilder {
+	b.meta.ProducedPlans = slugs
 	return b
 }
 

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -21,6 +21,7 @@ package plan
 // capture, which writes meta.json + content and lets a later push carry it.
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -31,6 +32,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/paths"
 )
@@ -48,9 +50,76 @@ const (
 	htmlLFSThreshold = 256 * 1024
 )
 
+// PlanStatus is the plan's own lifecycle, independent of the producing
+// session. A plan is worth keeping even if never built — it is a decision
+// record and prior-art seed — so status lets UI/search weight rather than
+// discard. v1: a plain writable field; no CLI auto-detection of "implemented"
+// (that correlation is inference and belongs in the cloud judge per ADR-021).
+type PlanStatus string
+
+const (
+	PlanStatusDraft       PlanStatus = "draft"
+	PlanStatusImplemented PlanStatus = "implemented"
+	PlanStatusAbandoned   PlanStatus = "abandoned"
+	PlanStatusSuperseded  PlanStatus = "superseded"
+)
+
+// Session-outcome values for Provenance.SessionOutcome. "" == unknown.
+const (
+	SessionOutcomeActive  = "active"
+	SessionOutcomeStopped = "stopped"
+	SessionOutcomeAborted = "aborted"
+)
+
+// Provenance ties a saved plan back to the session/agent/repo that produced
+// it. It is DENORMALIZED on purpose: the join keys (SessionID/AgentID/RepoID)
+// are the precise link, but a session can be aborted, never uploaded, or GC'd,
+// so the snapshot fields (AgentType/Model/AuthorName) let a plan render fully
+// without the session present. Duplication is the feature, not a smell.
+type Provenance struct {
+	// Join keys (may dangle if the session was aborted / never uploaded).
+	//
+	// Two-phase population, because the canonical ses_ SessionID is minted
+	// fresh at session-STOP and is NOT knowable mid-recording:
+	//   - SessionName is the durable identifier available at plan-save time
+	//     (the recording's folder name, what `ox session view <name>` resolves).
+	//     It is the primary join key and is always set when a recording is live.
+	//   - SessionID (ses_<UUIDv7>) is BACKFILLED at session-stop, in the same
+	//     reconciliation that sets SessionOutcome=stopped — we have the real id
+	//     and the produced-plan slugs in hand there. Empty for aborted sessions
+	//     (no stop) and for plans saved outside a recording.
+	SessionName string `json:"session_name,omitempty"`
+	SessionID   string `json:"session_id,omitempty"` // ses_<UUIDv7>, backfilled at stop
+	AgentID     string `json:"agent_id,omitempty"`   // Ox#### stable agent instance
+	RepoID      string `json:"repo_id,omitempty"`
+
+	// Denormalized snapshot — renders without the session present.
+	AgentType  string `json:"agent_type,omitempty"` // claude-code, codex, ...
+	Model      string `json:"model,omitempty"`
+	AuthorName string `json:"author_name,omitempty"` // privacy-safe display name at save time
+
+	// SessionOutcome is RECONCILED SYSTEM STATE, not authored provenance:
+	// "" (unknown) | "active" | "stopped" | "aborted". Written only by
+	// session-stop / `ox doctor` through MutatePlanMeta, never by Save.
+	SessionOutcome string `json:"session_outcome,omitempty"`
+}
+
+// CollabSignals are deterministic, locally-counted facts about the human↔agent
+// collaboration that produced the plan — effort proxies, NOT a score. Scoring
+// (a rigor judgment) is authored by the agent now / a cloud judge later, per
+// ADR-021. Signal COUNTS (collisions/prior-art/expert-routes) deliberately
+// live in annotations.json (Result.Signals), not here, to avoid duplication.
+type CollabSignals struct {
+	UserPrompts     int `json:"user_prompts"`     // distinct human turns before the plan
+	AgentQuestions  int `json:"agent_questions"`  // AskUserQuestion / clarifying tool calls
+	ToolCalls       int `json:"tool_calls"`       // exploration-depth proxy
+	DurationSeconds int `json:"duration_seconds"` // first user prompt → plan finalized
+}
+
 // Meta is the git-tracked descriptor written as meta.json alongside a captured
 // plan. It carries the searchable, hydration-free facts about the plan: who
-// authored it, when, and where it came from.
+// authored it, when, where it came from, which session/agent produced it, and
+// how thoughtful the collaboration was.
 type Meta struct {
 	// SchemaVersion stamps the meta.json shape (set to SchemaVersion on write)
 	// so a future reader can detect and migrate an older layout.
@@ -60,6 +129,13 @@ type Meta struct {
 	Authors        []string  `json:"authors,omitempty"`
 	CreatedAt      time.Time `json:"created_at"`
 	SourcePlanPath string    `json:"source_plan_path,omitempty"`
+
+	// Status is the plan's lifecycle. Missing == "draft" for legacy plans.
+	Status PlanStatus `json:"status,omitempty"`
+	// Provenance links the plan to its producing session/agent/repo (forward).
+	Provenance *Provenance `json:"provenance,omitempty"`
+	// Collaboration holds the deterministic collaboration-effort counts.
+	Collaboration *CollabSignals `json:"collaboration,omitempty"`
 }
 
 // PlanInfo is the listing-level view of a captured plan, assembled from
@@ -122,12 +198,46 @@ func Save(gitRoot string, in Input, res Result, html []byte, meta Meta) (string,
 		return "", fmt.Errorf("write %s: %w", annotationsFile, err)
 	}
 
-	// meta.json — plain git descriptor.
-	metaBytes, err := json.MarshalIndent(meta, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshal plan meta: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, planMetaFile), metaBytes, 0o644); err != nil {
+	// meta.json — plain git descriptor, written under the flock with a
+	// READ-MERGE so a re-save never resets lifecycle. Re-running `ox plan` on
+	// the same dated-slug dir (e.g. the hook draft, then the skill's full save)
+	// must preserve a manually-set Status, the system-reconciled SessionOutcome,
+	// and the original CreatedAt, while refreshing the rest. Routing through
+	// MutatePlanMeta also serializes against a concurrent session-stop/doctor
+	// outcome write to the same file.
+	if err := MutatePlanMeta(context.Background(), dir, func(existing *Meta) (*Meta, error) {
+		merged := meta
+		if existing != nil {
+			if existing.Status != "" {
+				merged.Status = existing.Status
+			}
+			if !existing.CreatedAt.IsZero() {
+				merged.CreatedAt = existing.CreatedAt
+			}
+			// SessionID and SessionOutcome are system-managed (backfilled /
+			// reconciled at stop), never set by a save-time caller — preserve
+			// them across a re-save even when the caller supplies fresh
+			// provenance for the other (snapshot) fields.
+			if existing.Provenance != nil {
+				if existing.Provenance.SessionID != "" || existing.Provenance.SessionOutcome != "" {
+					if merged.Provenance == nil {
+						merged.Provenance = &Provenance{}
+					}
+					if existing.Provenance.SessionID != "" {
+						merged.Provenance.SessionID = existing.Provenance.SessionID
+					}
+					if existing.Provenance.SessionOutcome != "" {
+						merged.Provenance.SessionOutcome = existing.Provenance.SessionOutcome
+					}
+				}
+			}
+		}
+		if merged.Status == "" {
+			merged.Status = PlanStatusDraft
+		}
+		merged.SchemaVersion = SchemaVersion
+		return &merged, nil
+	}); err != nil {
 		return "", fmt.Errorf("write %s: %w", planMetaFile, err)
 	}
 
@@ -239,6 +349,127 @@ func PlanHTMLPath(dir string) (path string, ref lfs.FileRef, isPointer, exists b
 		return path, lfs.FileRef{}, true, true
 	}
 	return path, lfs.FileRef{}, false, true
+}
+
+// MutatePlanMeta runs an exclusive read-modify-write under an advisory flock on
+// a plan's meta.json — the direct mirror of lfs.MutateSessionMeta. Every write
+// to meta.json AFTER the initial Save (status changes, session-outcome
+// reconciliation) MUST go through this so a re-save and a concurrent
+// session-stop/doctor write serialize at the filesystem level instead of
+// clobbering each other.
+//
+// The mutator receives the on-disk Meta (nil if the file is missing) and
+// returns the Meta to write, or nil to leave the file untouched (an "only if
+// exists" guard). Returning an error aborts the write.
+func MutatePlanMeta(ctx context.Context, planDir string, mutate func(*Meta) (*Meta, error)) error {
+	metaPath := filepath.Join(planDir, planMetaFile)
+	return fileutil.WithFileLock(ctx, metaPath, func() error {
+		var arg *Meta
+		if data, err := os.ReadFile(metaPath); err == nil {
+			var m Meta
+			if jerr := json.Unmarshal(data, &m); jerr != nil {
+				return fmt.Errorf("parse plan meta=%s: %w", planDir, jerr)
+			}
+			arg = &m
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("read plan meta=%s: %w", planDir, err)
+		}
+
+		out, mErr := mutate(arg)
+		if mErr != nil {
+			return mErr
+		}
+		if out == nil {
+			return nil // mutator chose not to write
+		}
+
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal plan meta: %w", err)
+		}
+		return fileutil.AtomicWriteBytes(metaPath, data, 0o644)
+	})
+}
+
+// SetStatus updates a saved plan's lifecycle status (by slug) under the meta
+// flock. No-op if the plan dir has no meta.json. Use the PlanStatus* constants.
+func SetStatus(gitRoot, slug string, status PlanStatus) error {
+	dir, err := resolvePlanDirForSlug(gitRoot, slug)
+	if err != nil {
+		return err
+	}
+	return MutatePlanMeta(context.Background(), dir, func(m *Meta) (*Meta, error) {
+		if m == nil {
+			return nil, nil
+		}
+		m.Status = status
+		return m, nil
+	})
+}
+
+// SetSessionOutcome reconciles the producing session's lifecycle onto the plan
+// (by slug) under the meta flock — written only by session-stop / `ox doctor`,
+// never by Save. Use the SessionOutcome* constants. No-op if no meta.json.
+func SetSessionOutcome(gitRoot, slug, outcome string) error {
+	dir, err := resolvePlanDirForSlug(gitRoot, slug)
+	if err != nil {
+		return err
+	}
+	return MutatePlanMeta(context.Background(), dir, func(m *Meta) (*Meta, error) {
+		if m == nil {
+			return nil, nil
+		}
+		if m.Provenance == nil {
+			m.Provenance = &Provenance{}
+		}
+		m.Provenance.SessionOutcome = outcome
+		return m, nil
+	})
+}
+
+// ReconcileSessionOutcome backfills the producing session's canonical id and
+// final outcome onto a plan (by slug) at session-stop, where both are known.
+// sessionID is the ses_<UUIDv7> minted at stop (skipped when ""); outcome is a
+// SessionOutcome* constant. Single flocked write so it can't race a re-save.
+func ReconcileSessionOutcome(gitRoot, slug, sessionID, outcome string) error {
+	dir, err := resolvePlanDirForSlug(gitRoot, slug)
+	if err != nil {
+		return err
+	}
+	return MutatePlanMeta(context.Background(), dir, func(m *Meta) (*Meta, error) {
+		if m == nil {
+			return nil, nil
+		}
+		if m.Provenance == nil {
+			m.Provenance = &Provenance{}
+		}
+		if sessionID != "" {
+			m.Provenance.SessionID = sessionID
+		}
+		m.Provenance.SessionOutcome = outcome
+		return m, nil
+	})
+}
+
+// ReadPlanMeta returns the stored Meta for a saved plan (by slug), including
+// provenance, collaboration signals, and status. Used by the view path to
+// surface the link without re-deriving it.
+func ReadPlanMeta(gitRoot, slug string) (Meta, error) {
+	dir, err := resolvePlanDirForSlug(gitRoot, slug)
+	if err != nil {
+		return Meta{}, err
+	}
+	return readMeta(dir)
+}
+
+// resolvePlanDirForSlug resolves a slug to its plan directory under the ledger.
+func resolvePlanDirForSlug(gitRoot, slug string) (string, error) {
+	plansDir := paths.LedgerPlansDir(ledgerPathFor(gitRoot))
+	if plansDir == "" {
+		return "", fmt.Errorf("no ledger configured for %q", gitRoot)
+	}
+	dir, _, err := resolvePlanDir(plansDir, slug)
+	return dir, err
 }
 
 // --- helpers ---

--- a/internal/plan/store_test.go
+++ b/internal/plan/store_test.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -308,5 +309,163 @@ func TestSave_DefaultsSlugAndTimestamp(t *testing.T) {
 	}
 	if meta.CreatedAt.IsZero() {
 		t.Errorf("meta.CreatedAt is zero, want defaulted")
+	}
+}
+
+// --- Provenance, status, collaboration, and read-merge lifecycle ---
+
+// TestSave_StampsProvenanceStatusAndCollab verifies a saved plan persists its
+// forward link (provenance), collaboration signals, and defaults Status=draft.
+// Failure prevented: plans saved with no committed link back to the producing
+// session/agent, defeating the whole feature.
+func TestSave_StampsProvenanceStatusAndCollab(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	in := Input{Path: "PLAN.md", Raw: "# Link plans to sessions\n\nbody"}
+	meta := Meta{
+		Topic:     "Link plans to sessions",
+		CreatedAt: time.Date(2026, 6, 4, 9, 0, 0, 0, time.UTC),
+		Provenance: &Provenance{
+			SessionName: "2026-06-04-ryan-Oxab12", AgentID: "Oxab12",
+			RepoID: "repo-1", AgentType: "claude-code", Model: "opus",
+			AuthorName: "Person A", SessionOutcome: SessionOutcomeActive,
+		},
+		Collaboration: &CollabSignals{UserPrompts: 5, AgentQuestions: 3, ToolCalls: 12, DurationSeconds: 600},
+	}
+
+	if _, err := Save("/g", in, sampleResult(), nil, meta); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := ReadPlanMeta("/g", "link-plans-to-sessions")
+	if err != nil {
+		t.Fatalf("ReadPlanMeta: %v", err)
+	}
+	if got.Status != PlanStatusDraft {
+		t.Errorf("Status = %q, want draft", got.Status)
+	}
+	if got.Provenance == nil || got.Provenance.AgentID != "Oxab12" || got.Provenance.SessionName != "2026-06-04-ryan-Oxab12" {
+		t.Errorf("provenance not persisted: %+v", got.Provenance)
+	}
+	if got.Collaboration == nil || got.Collaboration.UserPrompts != 5 || got.Collaboration.DurationSeconds != 600 {
+		t.Errorf("collaboration not persisted: %+v", got.Collaboration)
+	}
+}
+
+// TestSave_ReadMergePreservesLifecycle verifies a re-save preserves a
+// manually-set Status, the system-reconciled SessionOutcome, and the original
+// CreatedAt while refreshing the rest.
+// Failure prevented: the skill's full save (or any re-enrich) silently resets a
+// plan marked "implemented" back to "draft", or loses the session outcome.
+func TestSave_ReadMergePreservesLifecycle(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	orig := time.Date(2026, 6, 4, 8, 0, 0, 0, time.UTC)
+	in := Input{Path: "P.md", Raw: "# My plan\n\nv1"}
+	if _, err := Save("/g", in, sampleResult(), nil, Meta{Topic: "My plan", CreatedAt: orig}); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+
+	// human marks implemented; stop reconciles the session outcome.
+	if err := SetStatus("/g", "my-plan", PlanStatusImplemented); err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
+	if err := ReconcileSessionOutcome("/g", "my-plan", "ses_abc", SessionOutcomeStopped); err != nil {
+		t.Fatalf("ReconcileSessionOutcome: %v", err)
+	}
+
+	// re-save (e.g. skill's full save) with a later CreatedAt and fresh result.
+	if _, err := Save("/g", Input{Path: "P.md", Raw: "# My plan\n\nv2"}, sampleResult(), nil,
+		Meta{Topic: "My plan", CreatedAt: orig.Add(2 * time.Hour)}); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+
+	got, err := ReadPlanMeta("/g", "my-plan")
+	if err != nil {
+		t.Fatalf("ReadPlanMeta: %v", err)
+	}
+	if got.Status != PlanStatusImplemented {
+		t.Errorf("Status = %q, want implemented preserved across re-save", got.Status)
+	}
+	if got.Provenance == nil || got.Provenance.SessionOutcome != SessionOutcomeStopped {
+		t.Errorf("SessionOutcome not preserved: %+v", got.Provenance)
+	}
+	if got.Provenance.SessionID != "ses_abc" {
+		t.Errorf("SessionID backfill lost on re-save: %+v", got.Provenance)
+	}
+	if !got.CreatedAt.Equal(orig) {
+		t.Errorf("CreatedAt = %v, want original %v preserved", got.CreatedAt, orig)
+	}
+	// markdown still refreshed to v2.
+	md, _, _, _ := Load("/g", "my-plan")
+	if !strings.Contains(md, "v2") {
+		t.Errorf("plan.md not refreshed on re-save: %q", md)
+	}
+}
+
+// TestReconcileSessionOutcome_BackfillsSessionID verifies stop-time backfill of
+// the canonical ses_ id alongside the outcome.
+// Failure prevented: the forward link never gets its ses_ id (only the
+// save-time session name), so a UI keyed on ses_ can't join.
+func TestReconcileSessionOutcome_BackfillsSessionID(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+	if _, err := Save("/g", Input{Raw: "# Topic A\n"}, sampleResult(), nil, Meta{Topic: "Topic A", CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := ReconcileSessionOutcome("/g", "topic-a", "ses_7", SessionOutcomeAborted); err != nil {
+		t.Fatalf("ReconcileSessionOutcome: %v", err)
+	}
+	got, _ := ReadPlanMeta("/g", "topic-a")
+	if got.Provenance == nil || got.Provenance.SessionID != "ses_7" || got.Provenance.SessionOutcome != SessionOutcomeAborted {
+		t.Errorf("backfill failed: %+v", got.Provenance)
+	}
+}
+
+// TestMutatePlanMeta_MissingFileNoOp verifies the mutator gets nil for a
+// missing meta.json and a nil return writes nothing.
+func TestMutatePlanMeta_MissingFileNoOp(t *testing.T) {
+	dir := t.TempDir()
+	called := false
+	err := MutatePlanMeta(context.Background(), dir, func(m *Meta) (*Meta, error) {
+		called = true
+		if m != nil {
+			t.Errorf("expected nil meta for missing file, got %+v", m)
+		}
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("MutatePlanMeta: %v", err)
+	}
+	if !called {
+		t.Error("mutator not called")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "meta.json")); !os.IsNotExist(err) {
+		t.Error("meta.json should not be created on nil return")
+	}
+}
+
+// TestReadPlanMeta_LegacyNoProvenance verifies a v1 plan dir (no provenance /
+// status) loads cleanly with empty status — readers treat it as draft.
+// Failure prevented: the new fields break reading plans saved before them.
+func TestReadPlanMeta_LegacyNoProvenance(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+	dir := filepath.Join(ledger, "data", "plans", "2026-01-01-legacy-plan")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{"topic":"Legacy plan","slug":"legacy-plan","created_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPlanMeta("/g", "legacy-plan")
+	if err != nil {
+		t.Fatalf("ReadPlanMeta legacy: %v", err)
+	}
+	if got.Status != "" || got.Provenance != nil || got.Collaboration != nil {
+		t.Errorf("legacy meta should have empty new fields, got %+v", got)
 	}
 }

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -53,6 +53,10 @@ const (
 	BadgeConflicts BadgeType = "conflicts"
 	// BadgeExpertPersp: synthesized expert stance, cited (judgment).
 	BadgeExpertPersp BadgeType = "expert-perspective"
+	// BadgeRigor: collaboration-rigor stance synthesized from CollabSignals —
+	// how thoughtful the human↔agent path to this plan was (judgment). ox emits
+	// the raw counts (CollabSignals); the agent/cloud authors this badge.
+	BadgeRigor BadgeType = "rigor"
 )
 
 // Annotation is a single badge attached to a plan section.

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -111,6 +111,13 @@ type RecordingState struct {
 	// older .recording.json files round-trip unchanged.
 	ProducedCommits []string `json:"produced_commits,omitempty"`
 
+	// ProducedPlans is the reverse-direction index of plan slugs captured
+	// during this recording (e.g. by `ox plan` auto-save). Appended at
+	// plan-save time, folded into SessionMeta.ProducedPlans at session stop /
+	// finalize — mirrors ProducedCommits. omitempty so older .recording.json
+	// files round-trip unchanged.
+	ProducedPlans []string `json:"produced_plans,omitempty"`
+
 	// LinkedPRs / LinkedIssues are the GitHub PR and issue references this
 	// recording is associated with. Appended by the pre-push hook from the
 	// pushed commit range, folded into SessionMeta at stop. omitempty for


### PR DESCRIPTION
## Summary

Saved plans (`<ledger>/data/plans/`) had **no committed link** back to the session, agent, or repo that produced them, and nothing captured how the human↔AI collaboration reached the plan. This PR adds a **bidirectional, committed link** plus deterministic **collaboration-rigor signals** — laying groundwork for UI that shows "every prompt that went into a plan" and lets teams gauge how thoughtful a plan's authoring was. ox computes only raw facts locally; scoring stays a judgment (agent now, cloud later) per ADR-021.

### What it does
- **Forward link (denormalized):** plan `meta.json` gains `provenance` — join keys (`session_name` now, canonical `ses_` `session_id` backfilled at stop, `agent_id`, `repo_id`) plus a snapshot (`agent_type`, `model`, `author_name`) so a plan renders even if its session was aborted or never uploaded.
- **Reverse link:** `SessionMeta.ProducedPlans` (mirrors `ProducedCommits`) — accumulated on the live `RecordingState` at save, folded into session `meta.json` at stop.
- **Collaboration signals:** deterministic counts from the recording transcript — `user_prompts`, `agent_questions` (AskUserQuestion), `tool_calls`, `duration_seconds`. Omitted entirely when no live recording.
- **Plan status lifecycle:** `draft | implemented | abandoned | superseded` (plain writable field; no CLI auto-detection).
- **Durability fix:** nothing committed `data/plans/` before — `commitPlanToLedger` (sync add+commit+push) closes that gap. The `ExitPlanMode` hook now auto-persists a draft via a new opt-in `--persist` flag on `ox plan --json` (the pure plumbing path stays pure without it).
- **Concurrency-safe:** all post-save writes route through a new `MutatePlanMeta` flock RMW (mirror of `MutateSessionMeta`); re-save is read-merge, preserving `status` / `session_id` / `session_outcome` / original `created_at`.

### Two-phase session link (the `ses_` id is minted at stop, not mid-recording)

```mermaid
flowchart TD
  Exit["ExitPlanMode hook → ox plan --json --persist"] --> Save["plan.Save (read-merge) + commitPlanToLedger (durable now)"]
  Save --> Draft["status=draft · session_name set · ses_ id empty · outcome=active"]
  Draft --> Stop{"session ends how?"}
  Stop -->|stop| Recon["backfill ses_ id + outcome=stopped on the in-hand slugs, no scan"]
  Stop -->|abort| Keep["plan kept; outcome=aborted reconciled by ox doctor (no hot-path scan)"]
```

### Notes
- `SchemaVersion` stays `v1` — every new field is additive + `omitempty`; legacy plans read cleanly (status treated as `draft`).
- Deferred to a follow-up: `ox doctor` backstop (abort to `aborted` reconciliation + committing any dirty plan dir).

## Test Plan

- `go build ./...`, `go vet`, `make lint` (0 issues).
- New unit tests, all green:
  - `internal/plan/store_test.go` — provenance/status/collab round-trip, read-merge preserves lifecycle across re-save, `ses_` backfill, `MutatePlanMeta` no-op on missing file, legacy v1 read.
  - `cmd/ox/plan_collaboration_test.go` — transcript counts, all-empty cases return nil, reverse-link append no-ops without a recording.
- Full `cmd/ox` + `internal/session` suites pass (short mode).
- End-to-end (prime → plan → stop → abort against a real ledger) belongs in `ox-test-harness`; the deterministic logic is unit-covered here.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added
- [ ] CHANGELOG entry — N/A (adds an opt-in `--persist` flag + metadata; no headline behavior change for end users)
- [ ] Breaking change — N/A (additive, `omitempty`, schema unchanged)
- [x] `/security-review` — N/A: touches none of `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, `go.sum`. Reverse-link reads the recording cache (full content), never the ledger LFS pointer (cache-only rule respected).

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)
