### PR TITLE
fix(plan): drop low-relevance citations + word-boundary snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,8 @@ sessions/
 .claude/settings.local.json
 # Claude worktrees
 .claude/worktrees/
+# Claude scheduled-task runtime lock (ephemeral: session PID + timestamp)
+.claude/scheduled_tasks.lock
 
 .codex/
 

--- a/extensions/claude/commands/ox-plan.md
+++ b/extensions/claude/commands/ox-plan.md
@@ -123,7 +123,37 @@ Put a tiny legend near the alignment strip ("● ox-computed · ○ agent-reason
 
 A judgment badge with no resolvable citation is a bug — degrade it to "consult `<name>`" instead.
 
+**5. SageOx insight overlays — the OX marker (NOT a prose blob).** SageOx insight must NEVER render as a standalone wall of synthesized prose. The anti-pattern, verbatim from a real bad render — **do not produce anything resembling this**:
+
+> ⛒ **SageOx team context (from ox plan)** — expert perspective
+> Foundation owner / prior art: scribe-jbf00 (gate epic), scribe-xfy17 (console-routing trap), scribe-ljzhn (rotted SDL behave sim — do NOT use for BDD). Session 2026-05-15… → informs the twin golden-trace gate. Collisions: platformio.ini + debug_server_scribe.cpp contended (rsnodgrass ryan/flash-dev); the P3-fw firmware edits land there — rebase + re-verify /health fields. Experts: Galex Yen owns twin-sageox-api/admin.go…
+
+That blob fails every respect-the-reader test: lore before action, three distinct signals comma-spliced into one badge, bare IDs that resolve to nothing, no severity, no "so what." Replace it with **anchored OX markers**:
+
+- **The marker.** Each SageOx signal renders as a small, recognizable **OX glyph** sitting in the margin gutter (or inline) right next to the plan element it concerns — a heading, a file ref, a step. It is the visual tell that "SageOx has something to say *here*," the way a code-review comment dot marks a line. Use an **inline SVG mark embedded in the page** (themeable via `currentColor`; the sageox.ai favicon is the north-star look — a rounded-square `ox` monogram in sage/copper). NEVER a remote `<img src>` or `favicon.ico` URL — the page is self-contained and must render from `file://` with no network. The marker is a real `<button aria-label="SageOx insight">` so it is focusable and screen-reader-named.
+- **Rollover reveals the insight.** Hover OR keyboard-focus OR click-to-pin opens the same popover mechanics as 2a. One marker = one signal = one popover. Inside, **action first**:
+  - **Headline (one line, imperative when there's an action):** e.g. *"Rebase before editing `platformio.ini` — contended on PR ryan/flash-dev."* Not *"Collisions: platformio.ini + … contended."*
+  - **Severity color** by signal: collision/active-work → amber; conflict or an explicit "do NOT use" → red; prior-art/session → teal; expert route → copper; alignment → sage.
+  - **Every reference resolves.** A bare `scribe-jbf00` is noise — render it as a link (to the PR/issue/ADR `source_url`) or as the runnable `ox session view <ref>` for a session. An ID with no resolution is degraded to "consult `<name>`", never shown raw.
+  - **Provenance chip + author/when** from 2a.
+  - **Synthesize the "so what," drop the lore.** State what the signal means *for this plan* and what to do; don't recite ownership trivia. Expand or link domain abbreviations (BDD, SDL, `X-Device-ID`) — a busy reviewer should not have to decode jargon.
+- **The only standalone SageOx UI is the alignment strip (item 1) plus an optional collapsed index** ("SageOx flagged: 1 collision · 3 prior-art · 2 experts") whose entries are anchor links that jump/scroll to the corresponding OX marker. No paragraph, ever.
+
+One signal that genuinely spans the whole plan (not a specific element) anchors its OX marker on the plan's H1 / TL;DR — still a marker with a popover, still action-first, still not a blob.
+
 ---
+
+## The reader's ten minutes — audience & time contract (governs everything below)
+
+You are writing for a **senior / principal engineer or engineering manager whose time is worth ~$10,000/hour.** They will spend **no more than ten minutes** on this page, and they must walk away with **everything they need to decide** in those ten minutes. Design every pixel against that budget:
+
+- **Get to the point. Lead with the conclusion**, the decision needed, and the biggest risk — not the backstory. The TL;DR and alignment strip must answer "do I approve, and what do I watch" before any scrolling.
+- **The page stands on its own.** Never reference a symbol, file, ID, or PR without setting enough context to understand *why it matters* — a reader who has not opened the codebase still follows the argument. A bare `scribe-jbf00` or `admin.go` with no framing is wasted ink.
+- **No minutiae.** Do not walk through single lines of code, signatures, or implementation trivia the reader doesn't need to make the call. Describe **how the system behaves and why the change matters**, not how each function is wired. Altitude over detail; zoom in only where a risk lives.
+- **Leverage HTML for compression, not decoration.** A diagram, a colored verdict cell, a severity-coded badge, or an OX-marker popover should *replace* paragraphs — each visual must let the reader understand something faster than prose would. Visuals that don't reduce reading time are noise.
+- **Concise is a feature, verbose is a bug.** Every sentence, badge, and row earns its place or is cut. Density with structure (scannable) beats completeness without it. If it can't be skimmed in ten minutes, it has failed regardless of how correct it is.
+
+This contract outranks any individual rule below: when a "nice to have" visual or a complete-but-long explanation would blow the ten-minute budget, cut it.
 
 ## html-plan quality bar (inherited — all non-negotiable)
 
@@ -189,10 +219,17 @@ Shape rules:
 2. Read the `context[]` bundle; author judgment badges **cited-only**, degrading to "consult `<name>`" when evidence is thin.
 3. Extract from the plan: problem/why, blockers/findings, architecture/flow, concrete steps (with file refs), impact numbers, verification, risks.
 4. Choose the diagrams that compress the most (before/after, sequence, decision gates, state machine, swimlane timeline).
-5. Write one polished self-contained HTML file meeting every html-plan non-negotiable PLUS the alignment strip, per-section badge rail, deterministic-vs-judgment styling, and resolved source links.
-6. Merge your judgment badges into the `ox plan --json` annotations and persist with `ox plan save --plan ... --annotations <merged.json> --html <render.html>`.
-7. Open the HTML and report the path.
+5. Write one polished self-contained HTML file meeting every html-plan non-negotiable PLUS the alignment strip, per-section badge rail, deterministic-vs-judgment styling, OX-marker overlays, and resolved source links.
+6. **Architect review pass (required, before saving).** Spawn an `architect` (or general-purpose) subagent and have it review the rendered HTML *as the $10k/hour principal reader*. It checks, and you then fix, against the audience contract:
+   - Can the reader get **everything they need to decide in ten minutes**? Is the conclusion/decision/biggest-risk up top, before any scroll?
+   - Is it **direct, concise, to the point** — or padded with backstory, minutiae, or single-line code walk-throughs that don't change the decision?
+   - Does it **stand on its own** — is every file/ID/symbol/PR given enough context to matter, with no bare references?
+   - Do the visuals **compress** understanding (replace prose) or just decorate?
+   - Are SageOx insights **anchored OX markers with action-first popovers**, never a prose blob?
+   Revise until the architect signs off that a busy principal would get full value in ten minutes. Cut anything that fails the contract.
+7. Merge your judgment badges into the `ox plan --json` annotations and persist with `ox plan save --plan ... --annotations <merged.json> --html <render.html>`.
+8. Open the HTML and report the path.
 
-The goal: a reviewer skims the alignment strip + TL;DR + hero diagram and already knows whether the plan aligns with team direction and whether to approve — every badge says where its claim comes from, and ox-computed facts are visually separate from agent-reasoned judgment.
+The goal: a $10k/hour principal reader skims the alignment strip + TL;DR + hero diagram and within ten minutes knows whether the plan aligns with team direction and whether to approve — the decision and biggest risk are up top, every badge and OX marker says where its claim comes from and what to do about it, ox-computed facts are visually separate from agent-reasoned judgment, and nothing on the page wastes the reader's time.
 
 $ox plan --json

--- a/extensions/claude/commands/ox-plan.md
+++ b/extensions/claude/commands/ox-plan.md
@@ -46,6 +46,14 @@ flowchart TB
    - When unsure whether a conflict is real, downgrade to "Novel — no prior decision found," not a false `conflicts`.
    - Set `kind:"judgment"` on every badge you author so the renderer can style it distinctly from ox's deterministic ones.
 
+   **NEVER paste the `context[]` bundle verbatim into the HTML.** The bundle is your *reasoning input*, not render output. Dumping the raw items as a flat "session / discussion" card list is the failure mode this spec exists to prevent — it surfaces mid-sentence snippet fragments, low-relevance chatter, and un-cited noise as if it were a finding. The bundle items become HTML *only* after you reason over them into a cited judgment badge attached to a specific plan section. A bundle item you can't turn into a section-anchored, cited badge does not appear in the render at all. Worked example:
+
+   > Bundle item → `{kind:"adr", title:"ADR-018 codedb perf budget", ref:"docs/adr/018...", snippet:"...512MB resident ceiling..."}`
+   > Plan section 3 proposes an in-memory index. →
+   > **Authored badge** → `{section:"3. Index", kind:"judgment", type:"conflicts", why:"In-memory index may breach the 512MB ceiling set in ADR-018", source_url:"docs/adr/018...", ...}`
+   >
+   > If the same ADR were only tangentially related: degrade to `expert-perspective` → "consult `<name>`", NOT a card pasting the raw snippet.
+
 3. **Render ONE self-contained HTML file** meeting the full html-plan quality bar below PLUS the badge-native additions.
 
 4. **Persist the full plan with `ox plan save`.** Bare `ox plan` only auto-saves ox's *deterministic* badges (it cannot see your judgment badges). To persist the complete plan — your merged badges plus the render — call:
@@ -80,7 +88,23 @@ These are what make this an *enriched* plan, not just a pretty one. The human mu
 
 Use the SageOx semantic colors: sage for aligns, red for conflicts, amber for collisions/active-work, copper for expert routes. Each count is a chip; clicking/anchoring it can jump to the first section carrying that badge. This is the "should I even keep reading" glance.
 
-**2. Per-section badge rail.** Every plan section renders its badges in a right-aligned rail (or a row directly under the H2). A badge shows: an icon/dot, the type label, and a **source link** when `source_url`/`ref` is present. Collapse multiple badges of the same type into a count chip that expands.
+**2. Per-section badge rail.** Every plan section renders its badges in a right-aligned rail (or a row directly under the H2). A badge shows: an icon/dot, the type label, a **provenance chip** (see below), and a **source link** when `source_url`/`ref` is present. Collapse multiple badges of the same type into a count chip that expands.
+
+**2a. Per-kind provenance chip + (i) popover.** Every badge carries a small chip naming WHERE its evidence came from, keyed off the bundle item's `kind`, so the reviewer can tell team convention from ledger history from live work at a glance:
+
+| `kind` | Chip label | Semantic color |
+|---|---|---|
+| `adr` | `ADR` | copper |
+| `decision` | `decision` | copper |
+| `discussion` | `team context` | sage |
+| `session` | `ledger · session` | teal |
+| `commit` | `commit` | teal |
+| `murmur` | `active work` | amber |
+
+Each chip has an **(i) affordance** that, on hover OR keyboard focus, opens a small popover showing: the source kind, the author and `when` (if present), the **cleaned** snippet trimmed to one readable clause (never a mid-sentence fragment — if the snippet is clipped, summarize it instead of pasting it), and the resolved link. Requirements:
+- **Pure CSS + a tiny vanilla-JS toggle — no external JS, must work from `file://`.** Hover via `:hover`/`:focus-within`; also support click-to-pin for touch/keyboard. The trigger is a real `<button>` (focusable, `aria-describedby` the popover) — not a bare `<span>` — so it is keyboard- and screen-reader-accessible.
+- The popover inherits the light/dark CSS variables (legible in both themes) and never overflows the viewport (flip/clamp on the right edge).
+- Group/color the chips by the palette above so the alignment strip, rail, and popovers tell one consistent provenance story.
 
 **3. Deterministic vs. judgment — visually distinct.** The human must always know which badges ox *computed* (factual) and which the agent *authored* (cited judgment). Make the treatment unmistakable:
 

--- a/extensions/claude/commands/ox-plan.md
+++ b/extensions/claude/commands/ox-plan.md
@@ -130,7 +130,10 @@ A judgment badge with no resolvable citation is a bug — degrade it to "consult
 
 That blob fails every respect-the-reader test: lore before action, three distinct signals comma-spliced into one badge, bare IDs that resolve to nothing, no severity, no "so what." Replace it with **anchored OX markers**:
 
-- **The marker.** Each SageOx signal renders as a small, recognizable **OX glyph** sitting in the margin gutter (or inline) right next to the plan element it concerns — a heading, a file ref, a step. It is the visual tell that "SageOx has something to say *here*," the way a code-review comment dot marks a line. Use an **inline SVG mark embedded in the page** (themeable via `currentColor`; the sageox.ai favicon is the north-star look — a rounded-square `ox` monogram in sage/copper). NEVER a remote `<img src>` or `favicon.ico` URL — the page is self-contained and must render from `file://` with no network. The marker is a real `<button aria-label="SageOx insight">` so it is focusable and screen-reader-named.
+- **The marker.** Each SageOx signal renders as a small, recognizable **SageOx glyph** sitting in the margin gutter (or inline) right next to the plan element it concerns — a heading, a file ref, a step. It is the visual tell that "SageOx has something to say *here*," the way a code-review comment dot marks a line.
+  - **Canonical mark = the SageOx avatar** (`https://avatars.githubusercontent.com/u/224450799?s=200&v=4`). **Base64-inline it as a `data:image/png;base64,…` URI at render time** (fetch once during rendering, embed the bytes) — the page is self-contained and must render from `file://` with **no runtime network**, so a live remote `<img src>` is banned. Keep it small (a ~28px avatar at `s=64` is plenty; don't inline a giant blob).
+  - **Offline fallback:** if the avatar can't be fetched at render time, draw an **inline-SVG `ox` monogram** (rounded square, sage/copper, themeable via `currentColor`) instead. Never block the render on the network.
+  - The marker is a real `<button aria-label="SageOx insight">` so it is focusable and screen-reader-named, with a faint ring/badge so it reads as interactive.
 - **Rollover reveals the insight.** Hover OR keyboard-focus OR click-to-pin opens the same popover mechanics as 2a. One marker = one signal = one popover. Inside, **action first**:
   - **Headline (one line, imperative when there's an action):** e.g. *"Rebase before editing `platformio.ini` — contended on PR ryan/flash-dev."* Not *"Collisions: platformio.ini + … contended."*
   - **Severity color** by signal: collision/active-work → amber; conflict or an explicit "do NOT use" → red; prior-art/session → teal; expert route → copper; alignment → sage.
@@ -183,6 +186,25 @@ Shape rules:
 | State with time-bounded transitions (timeouts, debounce, retry/backoff) | **`stateDiagram-v2`** with durations on edges | Label transitions with the timeout. |
 
 **Do NOT use Mermaid `gantt` with `dateFormat X` (numeric)** — it renders a meaningless `0 0 1 1 2…` axis. For relative-effort plans, hand-build a CSS swimlane: a per-lane row (`grid-template-columns: 160px 1fr`), a relative track with faint vertical unit gridlines, and absolutely-positioned bars (`left:%` / `width:%`) colored by workstream, with a diamond marker for any gate.
+
+**Pick the diagram by the QUESTION the reader is asking — not by habit.** Reach for the richer diagram types when (and only when) the plan genuinely has that structure. A flat list is a list; do not flowchart it. Never draw two diagrams that show the same thing.
+
+| The reader is asking… | Diagram type | When it earns its place |
+|---|---|---|
+| "In what **order** does this call out — and how many round-trips?" | **`sequenceDiagram`** | A request/call path crosses components, services, or async boundaries. Shows ordering + latency a flowchart can't. ≤ 4–5 participants. |
+| "**What depends on / connects to** what?" (topology, not order) | **interaction / dependency graph** (`flowchart LR`, C4-ish) | Components, actors, modules and their edges — to reveal coupling, blast radius, a contended boundary. |
+| "What are the **steps and branches**?" | **flow diagram** (`flowchart TB` + decision gates) | A pipeline or algorithm with conditionals/gates. The default "shape in one picture" hero. |
+| "What **states** exist and what **transitions** between them?" | **`stateDiagram-v2`** (enriched) | A lifecycle, connection/session model, retry/backoff, or anything with modes. Label edges with the trigger; push the guard/timeout/side-effect to hover. |
+| "**When**, in what sequence, how long?" | **timeline / CSS swimlane** (see table above) | Phases, rollout, parallel work, latency budget. |
+
+One **hero diagram near the top** captures the whole shape. Add a second diagram only where a specific section has structure the hero can't carry. If a diagram needs more than ~7 nodes / ~5 participants to be honest, it's two diagrams.
+
+**Progressive disclosure — rich underneath, calm on top (lean HARD into HTML here).** The single biggest lever for human understanding is putting *little* on the screen while keeping *all* the richness one hover away. The on-screen diagram is the **skeleton**; the detail lives in reveals:
+- **Mermaid node/edge interactions.** Use `click <NodeId> callback "<short tooltip>"` (requires `securityLevel:'loose'` at init) to attach a hover/click handler that opens the **same popover component as the OX markers / 2a chips**. Keep the node label terse ("auth check"); put the payload, the file/symbol it maps to, the cost, and the rationale in the popover — never on the diagram face.
+- **Sequence diagrams:** terse message labels on the line; the contract/payload/error-path detail surfaces on hover of that message (or a `Note` styled collapsed-by-default, expand on click).
+- **State machines:** the edge shows only its trigger; hovering the edge or state reveals guard, side effects, timeout/backoff, and the code path that implements it.
+- **Layered drill-down.** Start at the subsystem altitude; clicking a node expands its internal subgraph (toggle a second `.mermaid` block / swap source + `mermaid.run`), so the reader drills only where they care. One topic, many depths — the ten-minute reader stays at the top layer; the skeptic drills one node.
+- All of it **pure CSS + vanilla JS, keyboard-focusable, `file://`-safe, no network** — same constraints as every other interaction. Tie it back to the time contract: the diagram answers "how does it behave" at a glance; deeper time is spent *only* on the node the reader chooses to interrogate.
 
 **User-facing mockups — show how the feature is exposed.** If the plan changes anything the user sees or hears, include a visual of the resulting UI state honoring the project's design system — don't describe it in prose. For a net-new or multi-state flow, recommend the `/design-mockup` skill rather than hand-rolling many states. Always state which design-system rules the mockup honors. Annotate behavior in user-facing language, never with implementation detail (write "a subtle chime plays", not a source filename).
 

--- a/internal/ledgersearch/ledgersearch.go
+++ b/internal/ledgersearch/ledgersearch.go
@@ -406,9 +406,13 @@ func scoreContent(content string, terms []string) (float64, string) {
 	return score, snippetAround(content, firstIdx, 160)
 }
 
-// snippetAround returns a window of size chars around idx, trimmed at whitespace.
+// snippetAround returns a readable window of about size bytes centered on idx,
+// with both edges snapped to whole-word boundaries so the snippet never begins
+// or ends mid-word. Elided ends are marked with "...". Snapping at ASCII
+// whitespace is also UTF-8 safe: multi-byte runes never contain a byte < 0x80,
+// so a cut at a space can't split a rune.
 func snippetAround(s string, idx, size int) string {
-	if idx < 0 {
+	if idx < 0 || s == "" {
 		return ""
 	}
 	start := idx - size/2
@@ -419,17 +423,74 @@ func snippetAround(s string, idx, size int) string {
 	if end > len(s) {
 		end = len(s)
 	}
-	out := s[start:end]
-	out = strings.TrimSpace(out)
-	// collapse internal whitespace runs for compact display
+
+	elidedLeft := start > 0
+	elidedRight := end < len(s)
+
+	wStart, wEnd := start, end
+	if elidedLeft {
+		// drop the partial leading word, then advance onto the next word start
+		for wStart < wEnd && !isASCIISpace(s[wStart]) {
+			wStart++
+		}
+		for wStart < wEnd && isASCIISpace(s[wStart]) {
+			wStart++
+		}
+	}
+	if elidedRight {
+		// retreat to the end of the last whole word inside the window
+		for wEnd > wStart && !isASCIISpace(s[wEnd-1]) {
+			wEnd--
+		}
+		for wEnd > wStart && isASCIISpace(s[wEnd-1]) {
+			wEnd--
+		}
+	}
+	// degenerate case: a single token longer than the window collapsed it —
+	// fall back to a rune-safe cut so we still show something.
+	if wStart >= wEnd {
+		wStart = alignRuneStart(s, start)
+		wEnd = alignRuneStart(s, end)
+		if wEnd < wStart {
+			wEnd = wStart
+		}
+	}
+
+	out := strings.TrimSpace(s[wStart:wEnd])
 	out = strings.Join(strings.Fields(out), " ")
-	if start > 0 {
+	if out == "" {
+		return ""
+	}
+	if elidedLeft {
 		out = "..." + out
 	}
-	if end < len(s) {
+	if elidedRight {
 		out = out + "..."
 	}
 	return out
+}
+
+// isASCIISpace reports whether b is an ASCII whitespace byte. Used for word-
+// boundary snapping where only single-byte ASCII spaces are valid cut points.
+func isASCIISpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\f', '\v':
+		return true
+	default:
+		return false
+	}
+}
+
+// alignRuneStart moves i back to the start of the UTF-8 rune it lands inside,
+// so a fallback byte-slice never splits a multi-byte rune.
+func alignRuneStart(s string, i int) int {
+	if i >= len(s) {
+		return len(s)
+	}
+	for i > 0 && s[i]&0xC0 == 0x80 {
+		i--
+	}
+	return i
 }
 
 // parseSessionTimestamp pulls the prefix from "YYYY-MM-DDTHH-MM-<user>-<id>".

--- a/internal/ledgersearch/ledgersearch_test.go
+++ b/internal/ledgersearch/ledgersearch_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestSearch_EmptyLedgerPath(t *testing.T) {
@@ -419,5 +421,64 @@ func writeMurmur(t *testing.T, ledgerPath string, ts time.Time, id, topic, conte
 	data, _ := json.Marshal(m)
 	if err := os.WriteFile(filepath.Join(hourDir, id+".json"), data, 0o644); err != nil {
 		t.Fatalf("write murmur: %v", err)
+	}
+}
+
+// --- Snippet word-boundary extraction (A3) ---
+
+// TestSnippetAround_NoMidWordTruncation verifies the snippet window snaps to
+// whole-word boundaries so it never begins or ends mid-word.
+// Failure prevented: the byte-window slicing that produced citations like
+// "...HLS retry semantics" / "...ive intelligence_1" — fragments clipped mid-word
+// at both ends that read as noise in the rendered plan.
+func TestSnippetAround_NoMidWordTruncation(t *testing.T) {
+	// match "retry" mid-sentence; a small window would otherwise clip "...HLS"
+	// on the left and a word on the right.
+	content := "the firmware handles HLS retry semantics carefully before upload begins"
+	idx := strings.Index(content, "retry")
+	got := snippetAround(content, idx, 24)
+
+	trimmed := strings.Trim(got, ".")
+	if trimmed == "" {
+		t.Fatalf("empty snippet for idx=%d", idx)
+	}
+	// every word in the snippet body must be a whole word from the source.
+	srcWords := make(map[string]struct{})
+	for _, w := range strings.Fields(content) {
+		srcWords[w] = struct{}{}
+	}
+	for _, w := range strings.Fields(trimmed) {
+		if _, ok := srcWords[w]; !ok {
+			t.Errorf("snippet word %q is not a whole source word (got %q)", w, got)
+		}
+	}
+}
+
+// TestSnippetAround_UTF8Safe verifies multi-byte runes are never split.
+// Failure prevented: byte slicing through a multi-byte rune yielding a broken
+// "" replacement character in the snippet.
+func TestSnippetAround_UTF8Safe(t *testing.T) {
+	content := "café résumé naïve façade déjà vu coöperate piñata über"
+	for idx := 0; idx < len(content); idx++ {
+		got := snippetAround(content, idx, 16)
+		if !utf8.ValidString(got) {
+			t.Fatalf("invalid UTF-8 snippet at idx=%d: %q", idx, got)
+		}
+	}
+}
+
+// TestSnippetAround_Markers verifies elision markers appear only where text was
+// actually cut.
+func TestSnippetAround_Markers(t *testing.T) {
+	content := "alpha beta gamma delta epsilon zeta eta theta iota"
+	// match at the very start — no left elision.
+	got := snippetAround(content, 0, 16)
+	if strings.HasPrefix(got, "...") {
+		t.Errorf("unexpected left marker when matching at start: %q", got)
+	}
+	// whole string fits — no markers at all.
+	full := snippetAround(content, 0, len(content)+10)
+	if strings.Contains(full, "...") {
+		t.Errorf("unexpected marker when window covers whole string: %q", full)
 	}
 }

--- a/internal/plan/context_bundle.go
+++ b/internal/plan/context_bundle.go
@@ -313,9 +313,18 @@ func topicTerms(query string, headings []string) map[string]struct{} {
 	return terms
 }
 
+// minBundleScore is the relevance floor an item must clear to enter the bundle.
+// Below it an item is weak chatter — a session that merely brushed the query, or
+// a team doc matched on a single token — that spends the client agent's tokens
+// without changing its conclusion. Tuned so a topic-only murmur (0.60), a solid
+// session hit, and a team doc with a few real term hits clear, while a
+// single-token doc match (~0.43) and a barely-matched session (~0.48) do not.
+const minBundleScore = 0.55
+
 // rankAndCap sorts items by score descending (deterministic tiebreak on kind then
-// ref) and truncates to cap. This is the single place the bundle's token budget is
-// enforced — see bundleCap's doc comment for why the cap protects the client agent.
+// ref), drops sub-threshold and duplicate (kind,ref) items, then truncates to cap.
+// This is the single place the bundle's relevance floor and token budget are
+// enforced — see bundleCap and minBundleScore for the rationale.
 func rankAndCap(items []ContextItem, limit int) []ContextItem {
 	sort.SliceStable(items, func(i, j int) bool {
 		if items[i].Score != items[j].Score {
@@ -326,6 +335,22 @@ func rankAndCap(items []ContextItem, limit int) []ContextItem {
 		}
 		return items[i].Ref < items[j].Ref
 	})
+	// filter sub-threshold + dedup by (kind, ref); sorted desc means the first
+	// occurrence of a duplicate is its highest-scoring one.
+	seen := make(map[string]struct{}, len(items))
+	kept := items[:0]
+	for _, it := range items {
+		if it.Score < minBundleScore {
+			continue
+		}
+		key := it.Kind + "\x00" + it.Ref
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		kept = append(kept, it)
+	}
+	items = kept
 	if limit > 0 && len(items) > limit {
 		items = items[:limit]
 	}

--- a/internal/plan/context_bundle_test.go
+++ b/internal/plan/context_bundle_test.go
@@ -252,15 +252,15 @@ func TestTopicTerms(t *testing.T) {
 
 // --- D. Ranking + capping ---
 
-// TestRankAndCap verifies items are ordered by score desc and the bundle is
-// truncated to the cap.
+// TestRankAndCap verifies above-floor items are ordered by score desc and the
+// bundle is truncated to the cap.
 // Failure prevented: an unbounded bundle blowing the client agent's context
 // budget, or low-relevance items crowding out strong ones.
 func TestRankAndCap(t *testing.T) {
 	items := []ContextItem{
-		{Kind: "session", Ref: "low", Score: 0.2},
+		{Kind: "session", Ref: "weak", Score: 0.6},
 		{Kind: "murmur", Ref: "high", Score: 0.9},
-		{Kind: "decision", Ref: "mid", Score: 0.5},
+		{Kind: "decision", Ref: "mid", Score: 0.7},
 	}
 	got := rankAndCap(items, 2)
 	if len(got) != 2 {
@@ -271,15 +271,50 @@ func TestRankAndCap(t *testing.T) {
 	}
 }
 
+// TestRankAndCapScoreFloor verifies items below minBundleScore are dropped.
+// Failure prevented: weak chatter (a single-token doc match, a barely-relevant
+// session) leaking into the bundle as a low-quality citation — the exact
+// "noise" failure mode this fix targets.
+func TestRankAndCapScoreFloor(t *testing.T) {
+	items := []ContextItem{
+		{Kind: "session", Ref: "barely", Score: 0.48},  // below floor
+		{Kind: "discussion", Ref: "weak", Score: 0.43}, // below floor (single-token doc)
+		{Kind: "murmur", Ref: "strong", Score: 0.60},   // clears floor
+	}
+	got := rankAndCap(items, 0)
+	if len(got) != 1 || got[0].Ref != "strong" {
+		t.Fatalf("got %v, want only [strong] after floor", refs(got))
+	}
+}
+
+// TestRankAndCapDedup verifies duplicate (kind,ref) items collapse to the
+// highest-scoring one.
+// Failure prevented: the same session/doc surfacing twice in the bundle,
+// wasting the agent's tokens and double-counting a single source.
+func TestRankAndCapDedup(t *testing.T) {
+	items := []ContextItem{
+		{Kind: "session", Ref: "dup", Score: 0.6},
+		{Kind: "session", Ref: "dup", Score: 0.9}, // higher — should win
+		{Kind: "session", Ref: "other", Score: 0.7},
+	}
+	got := rankAndCap(items, 0)
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2 after dedup (refs: %v)", len(got), refs(got))
+	}
+	if got[0].Ref != "dup" || got[0].Score != 0.9 {
+		t.Fatalf("got[0] = {%s, %.2f}, want {dup, 0.90} (kept highest)", got[0].Ref, got[0].Score)
+	}
+}
+
 // TestRankAndCapDeterministic verifies equal scores break ties deterministically
 // (kind then ref) so JSON output is stable across runs.
 // Failure prevented: non-deterministic bundle ordering that breaks output diffs
 // and flakes tests downstream.
 func TestRankAndCapDeterministic(t *testing.T) {
 	items := []ContextItem{
-		{Kind: "session", Ref: "b", Score: 0.5},
-		{Kind: "adr", Ref: "a", Score: 0.5},
-		{Kind: "adr", Ref: "z", Score: 0.5},
+		{Kind: "session", Ref: "b", Score: 0.6},
+		{Kind: "adr", Ref: "a", Score: 0.6},
+		{Kind: "adr", Ref: "z", Score: 0.6},
 	}
 	got := rankAndCap(items, 0) // 0 = no cap
 	wantRefs := []string{"a", "z", "b"}

--- a/internal/teamdocs/discover.go
+++ b/internal/teamdocs/discover.go
@@ -59,6 +59,15 @@ func DiscoverDocs(teamPath string) ([]TeamDoc, error) {
 		}
 
 		fullPath := filepath.Join(docsDir, name)
+
+		// skip ox-shipped starter scaffolds the team hasn't filled in yet — an
+		// unedited template is noise, not knowledge, and otherwise surfaces as a
+		// bogus citation. Two signals: a `template: true` frontmatter flag, or
+		// known scaffold sentinel text in the body.
+		if isUnfilledScaffold(fullPath) {
+			continue
+		}
+
 		doc := buildDoc(name, fullPath)
 
 		// filter out hidden docs
@@ -74,6 +83,51 @@ func DiscoverDocs(teamPath string) ([]TeamDoc, error) {
 	})
 
 	return docs, nil
+}
+
+// scaffoldSentinels are verbatim fragments found ONLY in ox-shipped starter
+// docs the team has not edited. Matched case-insensitively against the body.
+// Kept deliberately specific — each is placeholder/instruction text a real,
+// filled-in doc would have removed — so a genuine doc is never misclassified.
+var scaffoldSentinels = []string{
+	"define your team's critical domain-specific terms",
+	"replace or extend the examples below",
+}
+
+// isUnfilledScaffold reports whether a team doc is an unedited ox starter
+// scaffold: either flagged `template: true` in frontmatter, or still carrying
+// scaffold sentinel text in its body.
+func isUnfilledScaffold(path string) bool {
+	if parseFrontmatter(path).Template {
+		return true
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+
+	scanner := bufio.NewScanner(file)
+	lineCount := 0
+	for scanner.Scan() {
+		lineCount++
+		line := strings.ToLower(scanner.Text())
+		for _, sentinel := range scaffoldSentinels {
+			if strings.Contains(line, sentinel) {
+				return true
+			}
+		}
+		// sentinels live in the doc's lead-in; don't scan whole files
+		if lineCount > 30 {
+			break
+		}
+	}
+	return false
 }
 
 // buildDoc constructs a TeamDoc from a markdown file, parsing frontmatter

--- a/internal/teamdocs/discover_test.go
+++ b/internal/teamdocs/discover_test.go
@@ -62,6 +62,35 @@ func TestDiscoverDocs(t *testing.T) {
 			files:    map[string]string{},
 			wantDocs: nil,
 		},
+		{
+			// the exact failure this fix targets: an unedited ox starter glossary
+			// surfacing as a bogus "discussion" citation.
+			name: "unfilled scaffold excluded by sentinel text",
+			files: map[string]string{
+				"glossary.md": "# Glossary\n\nDefine your team's critical domain-specific terms, acronyms, jargon here for AI coworkers to reference.\n\n<!-- Replace or extend the examples below with your own terms. -->\n",
+				"real.md":     "# Real Doc\nActual filled-in team knowledge.",
+			},
+			wantDocs: []string{"real.md"},
+			wantNot:  []string{"glossary.md"},
+		},
+		{
+			name: "template frontmatter flag excluded",
+			files: map[string]string{
+				"starter.md": "---\ntitle: Starter\ntemplate: true\n---\n# Starter\nReal-looking body but flagged a template.",
+				"keep.md":    "# Keep\nFilled-in content.",
+			},
+			wantDocs: []string{"keep.md"},
+			wantNot:  []string{"starter.md"},
+		},
+		{
+			// a real, filled-in glossary (sentinel instruction removed) must survive —
+			// guards against the scaffold filter over-matching legitimate docs.
+			name: "filled glossary survives",
+			files: map[string]string{
+				"glossary.md": "# Glossary\n\n| Term | Definition |\n|------|------------|\n| **Ledger** | Per-repo history of work. |",
+			},
+			wantDocs: []string{"glossary.md"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/teamdocs/frontmatter.go
+++ b/internal/teamdocs/frontmatter.go
@@ -12,6 +12,10 @@ type docFrontmatter struct {
 	Description string
 	Visibility  string
 	When        string
+	// Template marks an ox-shipped starter doc the team hasn't filled in yet.
+	// Forward-compatible: when the cloud stamps starters with `template: true`,
+	// discovery skips them so unedited scaffolds never surface as knowledge.
+	Template bool
 }
 
 // parseFrontmatter extracts team doc metadata from YAML frontmatter.
@@ -84,6 +88,8 @@ func parseFrontmatter(path string) docFrontmatter {
 			fm.Description = extractValue(line, "description:")
 		} else if strings.HasPrefix(line, "visibility:") {
 			fm.Visibility = extractValue(line, "visibility:")
+		} else if strings.HasPrefix(line, "template:") {
+			fm.Template = strings.EqualFold(extractValue(line, "template:"), "true")
 		} else if strings.HasPrefix(line, "when:") {
 			val := extractValue(line, "when:")
 			if val == ">-" || val == ">" || val == "|" || val == "|-" {


### PR DESCRIPTION
## What broke

A rendered enriched plan (`/ox-plan`) surfaced low-quality citations: snippets clipped mid-word at both ends (`"...HLS retry semantics"`, `"...ive intelligence_1"`), an unfilled ox starter template (`glossary.md` — `"Define your team's critical domain-specific terms…"`) cited as a DISCUSSION, and the raw `context[]` bundle pasted verbatim as a flat card list with no provenance affordance. Investigation confirmed the "garbage" was **real ledger content, badly retrieved and badly rendered** — not a test fixture (e.g. `scribe-y7r8` is a real beads issue ID), so the fix is relevance + snippet quality + render discipline, not a blocklist.

## What this PR ships

Two independent layers — stop the noise at the source (CLI), and stop dumping it (render spec).

```mermaid
flowchart TB
  JSON["ox plan --json"] --> RET["context bundle retriever"]
  RET -->|"A1 score floor 0.55"| F1["drop weak single-token + barely-matched items"]
  RET -->|"A2 scaffold filter"| F2["drop unfilled ox starter templates"]
  RET -->|"A3 word-boundary snippet"| F3["snap edges to whole words, UTF-8 safe"]
  RET -->|"A4 dedup kind,ref"| F4["collapse duplicate sources"]
  F1 --> BUNDLE["clean bundle"]
  F2 --> BUNDLE
  F3 --> BUNDLE
  F4 --> BUNDLE
  BUNDLE --> AGENT["agent reasons to CITED badges, never pastes raw bundle"]
  AGENT --> HTML["render: per-kind provenance chip + (i) hover popover"]
```

**A — CLI retrieval quality**
- **A1 score floor (`internal/plan/context_bundle.go`):** `minBundleScore = 0.55` applied in `rankAndCap`. Drops single-token team-doc matches (~0.43) and barely-relevant sessions (~0.48); a topic-only murmur (0.60) and solid session/doc hits still clear.
- **A2 scaffold filter (`internal/teamdocs/discover.go`, `frontmatter.go`):** skip unedited ox starter docs via a `template: true` frontmatter flag (forward-compatible) **and** body sentinel detection. Guarded so a filled-in doc survives.
- **A3 word-boundary snippets (`internal/ledgersearch/ledgersearch.go`):** `snippetAround` now snaps both edges to whole-word boundaries; cutting only at ASCII whitespace is inherently UTF-8 safe, with a rune-aligned fallback for over-long single tokens.
- **A4 dedup:** `rankAndCap` collapses duplicate `(kind, ref)` items, keeping the highest score.

**B — render spec (`extensions/claude/commands/ox-plan.md`)**
- **B1:** explicit "**NEVER paste the `context[]` bundle verbatim**" rule + a worked bundle-item to cited-badge example. The bundle is reasoning input, not render output.
- **B2:** per-kind provenance chip table (ADR / decision / team context / ledger·session / commit / active-work, palette-colored) and a keyboard-accessible **(i) hover popover** — pure CSS + tiny vanilla JS, `file://`-safe, theme-aware — showing source kind, author, when, cleaned snippet, and resolved link.

## Test Plan

- New table-driven tests, all green (`internal/plan`, `internal/ledgersearch`, `internal/teamdocs`):
  - A1: sub-floor items dropped; A4: duplicate `(kind,ref)` collapsed to highest score.
  - A2: sentinel scaffold + `template:true` excluded; filled glossary survives.
  - A3: no mid-word truncation; UTF-8 never split; elision markers only where text was cut.
- `make lint` → 0 issues. `make format` clean (unrelated repo-wide gofmt drift reverted to keep this PR focused).

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added
- [x] CHANGELOG entry — N/A (internal retrieval/render quality, no user-facing CLI surface change)
- [x] Breaking change — none
- [x] `/security-review` — N/A (no `internal/auth/`, `internal/mcp/`, `raw_writer.go`, `prepush_scan.go`, `internal/upgrade/`, or `go.sum` touched)

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)
