### PR TITLE
fix(agent-tasks): guard args slice when 'tasks' called with no subcommand

### DIFF
--- a/cmd/ox/agent_tasks.go
+++ b/cmd/ox/agent_tasks.go
@@ -104,10 +104,11 @@ func runAgentTasks(w io.Writer, inst *agentinstance.Instance, args []string) err
 	defer store.Close()
 
 	sub := "list"
+	var rest []string
 	if len(args) > 0 {
 		sub = args[0]
+		rest = args[1:]
 	}
-	rest := args[1:]
 
 	switch sub {
 	case "list":

--- a/cmd/ox/agent_tasks_test.go
+++ b/cmd/ox/agent_tasks_test.go
@@ -52,6 +52,20 @@ func TestRunAgentTasks_ListEmpty(t *testing.T) {
 	}
 }
 
+// TestRunAgentTasks_NoSubcommandDefaultsToList verifies that an empty subargs
+// slice defaults to "list" without panicking on args[1:].
+// Failure prevented: `ox agent <id> tasks` (no subcommand) crashes the CLI.
+func TestRunAgentTasks_NoSubcommandDefaultsToList(t *testing.T) {
+	setupTaskProject(t)
+	var buf bytes.Buffer
+	if err := runAgentTasks(&buf, testInst(), nil); err != nil {
+		t.Fatalf("no subcommand: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"type": "agent_tasks"`) {
+		t.Fatalf("expected list output, got: %s", buf.String())
+	}
+}
+
 func TestRunAgentTasks_ClaimAndComplete(t *testing.T) {
 	root := setupTaskProject(t)
 

--- a/cmd/ox/strip_ansi_test.go
+++ b/cmd/ox/strip_ansi_test.go
@@ -74,7 +74,7 @@ func TestStripANSIEscapes(t *testing.T) {
 			// 8-bit C1 introducers: 0x9b is CSI, 0x9d is OSC. A terminal acts on
 			// these without a leading ESC, so they must be dropped too.
 			name: "C1 control bytes stripped (8-bit CSI/OSC/ST)",
-			in:   "abcd",
+			in:   "a\u009bb\u009dc\u0080d",
 			want: "abcd",
 		},
 		{


### PR DESCRIPTION
## What broke

`ox agent <id> tasks` invoked with **no subcommand** panicked:

```
panic: runtime error: slice bounds out of range [1:0]
```

`runAgentTasks` set `sub` behind a `len(args) > 0` guard but then sliced
`rest := args[1:]` **unconditionally**. With empty `args`, `args[1:]` is out of
range and crashes before the `switch` can default to `list`.

The agent-task scheduler itself shipped via #647 (SQLite-backed). This is the one
review-feedback fix from the original JSONL branch that was still live against
`main` — the other three (ID-slice guard, doctor ID-slice guard, doc fences) were
already absorbed into #647.

## What this PR ships

- **Fix:** guard `rest` behind the same `len(args) > 0` check, so a bare
  `ox agent <id> tasks` cleanly defaults to `list`.
- **Regression test:** `TestRunAgentTasks_NoSubcommandDefaultsToList` — calls
  `runAgentTasks` with `nil` args and asserts it lists instead of panicking.

```mermaid
flowchart LR
  A["ox agent id tasks (no subcommand)"] --> B{"len(args) > 0 ?"}
  B -- no --> C["sub = list, rest = nil"]
  B -- yes --> D["sub = args[0], rest = args[1:]"]
  C --> E[dispatch list]
  D --> E
```

## Test Plan

- `go build ./cmd/ox/` + `go vet ./cmd/ox/` clean.
- `go test ./cmd/ox/ -run TestRunAgentTasks` passes (incl. new regression test).
- `gofmt` clean.

Co-Authored-By: SageOx <ox@sageox.ai>
