### PR TITLE
Nudge HTML plan render on substantial plans, not just team signals

### DIFF
--- a/cmd/ox/agent_hook_plan_nudge.go
+++ b/cmd/ox/agent_hook_plan_nudge.go
@@ -50,10 +50,11 @@ const (
 	planNudgeMaxAge = 30 * time.Minute
 
 	// nonTrivialMinFilesHook / nonTrivialMinStepsHook mirror internal/plan's
-	// unexported nonTrivialMinFiles / nonTrivialMinSteps. The hook stays
-	// deliberately decoupled from the plan package (another agent owns it), so it
-	// can't import those consts — it only reads the computed signals over JSON.
-	// These local copies are used solely for wording the NonTrivial-only nudge.
+	// exported NonTrivialMinFiles / NonTrivialMinSteps. The hook stays
+	// deliberately decoupled from the plan package (it reads the computed signals
+	// over JSON, never recomputes), so these stay local copies used solely for
+	// wording the NonTrivial-only nudge. TestPlanNudgeThresholds_MatchPlanPackage
+	// asserts the copies never silently diverge from the authoritative values.
 	nonTrivialMinFilesHook = 2
 	nonTrivialMinStepsHook = 5
 

--- a/cmd/ox/agent_hook_plan_nudge.go
+++ b/cmd/ox/agent_hook_plan_nudge.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/sageox/ox/internal/config"
 )
 
 // Plan-exit enrichment nudge (Gold tier — Claude Code).
@@ -47,6 +49,14 @@ const (
 	// later in an unrelated context.
 	planNudgeMaxAge = 30 * time.Minute
 
+	// nonTrivialMinFilesHook / nonTrivialMinStepsHook mirror internal/plan's
+	// unexported nonTrivialMinFiles / nonTrivialMinSteps. The hook stays
+	// deliberately decoupled from the plan package (another agent owns it), so it
+	// can't import those consts — it only reads the computed signals over JSON.
+	// These local copies are used solely for wording the NonTrivial-only nudge.
+	nonTrivialMinFilesHook = 2
+	nonTrivialMinStepsHook = 5
+
 	// planSubprocessTimeout caps the `ox plan --json --persist` call. Enrichment
 	// itself is pure-local, but --persist also saves + synchronously commits and
 	// pushes a draft to the ledger (the chosen durability model), so this is
@@ -71,13 +81,18 @@ type planJSONResult struct {
 		PriorArt     int  `json:"prior_art"`
 		ExpertRoutes int  `json:"expert_routes"`
 		Material     bool `json:"material"`
+		Files        int  `json:"files"`
+		Steps        int  `json:"steps"`
+		NonTrivial   bool `json:"non_trivial"`
 	} `json:"signals"`
 }
 
 // handlePlanExit is invoked from handleAfterTool ONLY when the PostToolUse
 // event reports ToolName == "ExitPlanMode". It enriches the approved plan via
-// `ox plan --json` and, if the signals are material, stashes a one-line nudge
-// for the next UserPromptSubmit to deliver. Fail-open throughout.
+// `ox plan --json` and, if the signals are material OR the plan is structurally
+// non-trivial, stashes a one-line nudge for the next UserPromptSubmit to
+// deliver. The HTML-render recommendation is gated by plan.html (off ==> never
+// render, never nudge). Fail-open throughout.
 func handlePlanExit(ctx *HookContext, agentID string) {
 	if ctx == nil || ctx.Input == nil || agentID == "" {
 		return
@@ -93,11 +108,26 @@ func handlePlanExit(ctx *HookContext, agentID string) {
 	if !ok {
 		return
 	}
-	if !res.Signals.Material {
-		slog.Debug("hook: plan-exit no material signals",
+
+	// The render nudge fires on either axis: team-context signals (Material) or
+	// structural substance (NonTrivial). The HTML render is worth recommending on
+	// a large greenfield plan even when team context is silent.
+	if !res.Signals.Material && !res.Signals.NonTrivial {
+		slog.Debug("hook: plan-exit not material and trivial, skipping nudge",
 			"collisions", res.Signals.Collisions,
 			"prior_art", res.Signals.PriorArt,
-			"expert_routes", res.Signals.ExpertRoutes)
+			"expert_routes", res.Signals.ExpertRoutes,
+			"files", res.Signals.Files,
+			"steps", res.Signals.Steps)
+		return
+	}
+
+	// plan.html=off means "never render, never nudge" (the config enum's own
+	// definition). Suppress the recommendation. Enrichment + --persist already
+	// ran above: the draft save is durability (gated separately on plan.save) and
+	// is independent of the render recommendation, so it stands either way.
+	if config.PlanHTML(ctx.ProjectRoot) == config.PlanHTMLOff {
+		slog.Debug("hook: plan-exit plan.html=off, skipping nudge", "agent_id", agentID)
 		return
 	}
 
@@ -110,7 +140,9 @@ func handlePlanExit(ctx *HookContext, agentID string) {
 		"agent_id", agentID,
 		"collisions", res.Signals.Collisions,
 		"prior_art", res.Signals.PriorArt,
-		"expert_routes", res.Signals.ExpertRoutes)
+		"expert_routes", res.Signals.ExpertRoutes,
+		"files", res.Signals.Files,
+		"steps", res.Signals.Steps)
 }
 
 // extractExitPlanText pulls the plan markdown out of ExitPlanMode tool_input.
@@ -174,8 +206,10 @@ func runPlanEnrichment(planText string) (planJSONResult, bool) {
 	return res, true
 }
 
-// formatPlanNudgeLine builds the concise one-line nudge from material signals.
-// Single line, no multi-line noise. Only mentions signal classes that fired.
+// formatPlanNudgeLine builds the concise one-line nudge. Single line, no
+// multi-line noise (grepability invariant). When team-context signals fired it
+// leads with them (the rich line); when the plan fired only on structural
+// non-triviality it leads with the render benefit and the plan's scope.
 func formatPlanNudgeLine(res planJSONResult) string {
 	var parts []string
 	if res.Signals.Collisions > 0 {
@@ -187,11 +221,41 @@ func formatPlanNudgeLine(res planJSONResult) string {
 	if res.Signals.ExpertRoutes > 0 {
 		parts = append(parts, pluralize(res.Signals.ExpertRoutes, "expert route", "expert routes"))
 	}
-	detail := strings.Join(parts, " + ")
-	if detail == "" {
-		detail = "team-context signals"
+	if detail := strings.Join(parts, " + "); detail != "" {
+		// Material path: lead with the team-context signals.
+		return fmt.Sprintf("Your plan touches %s. Render a human-review HTML page with the `html-plan` skill (open it with `ox plan --open`).", detail)
 	}
-	return fmt.Sprintf("Your plan touches %s. Render an enriched plan for faster human review: run `ox plan`.", detail)
+
+	// NonTrivial-only path: no team-context signals fired, but the plan is
+	// structurally substantial. Lead with the render benefit and the scope.
+	return fmt.Sprintf("Your plan spans %s. Render a human-review HTML page with the `html-plan` skill (open it with `ox plan --open`).", planScopePhrase(res.Signals.Files, res.Signals.Steps))
+}
+
+// planScopePhrase describes plan scale from the structural counts, naming only
+// the dimension(s) that crossed the non-trivial threshold, with correct
+// pluralization. At least one dimension is non-zero when this is reached; the
+// fallback keeps it safe if the thresholds are ever loosened relative to the
+// firing gate.
+func planScopePhrase(files, steps int) string {
+	var parts []string
+	if files >= nonTrivialMinFilesHook {
+		parts = append(parts, pluralize(files, "file", "files"))
+	}
+	if steps >= nonTrivialMinStepsHook {
+		parts = append(parts, pluralize(steps, "step", "steps"))
+	}
+	if len(parts) == 0 {
+		if files > 0 {
+			parts = append(parts, pluralize(files, "file", "files"))
+		}
+		if steps > 0 {
+			parts = append(parts, pluralize(steps, "step", "steps"))
+		}
+	}
+	if len(parts) == 0 {
+		return "multiple files"
+	}
+	return strings.Join(parts, " / ")
 }
 
 // pluralize renders "<n> <singular|plural>" picking the form by count.

--- a/cmd/ox/agent_hook_plan_nudge_test.go
+++ b/cmd/ox/agent_hook_plan_nudge_test.go
@@ -82,6 +82,40 @@ func TestFormatPlanNudgeLine_SingularCollision(t *testing.T) {
 	assert.NotContains(t, line, "1 collisions")
 }
 
+// TestFormatPlanNudgeLine_NonTrivialOnly verifies the render-focused line used
+// when no team-context signals fired but the plan is structurally non-trivial.
+// Failure prevented: a large greenfield plan gets a line claiming team-context
+// signals that didn't fire, or no HTML-render framing at all.
+func TestFormatPlanNudgeLine_NonTrivialOnly(t *testing.T) {
+	t.Run("files and steps", func(t *testing.T) {
+		var res planJSONResult
+		res.Signals.NonTrivial = true
+		res.Signals.Files = 7
+		res.Signals.Steps = 6
+
+		line := formatPlanNudgeLine(res)
+		assert.Contains(t, line, "7 files")
+		assert.Contains(t, line, "6 steps")
+		assert.Contains(t, line, "HTML page")
+		assert.Contains(t, line, "ox plan")
+		assert.NotContains(t, line, "collision", "no team-context signal fired — must not be mentioned")
+		assert.NotContains(t, line, "\n", "single line — grepability invariant")
+	})
+
+	t.Run("files only (steps below threshold)", func(t *testing.T) {
+		var res planJSONResult
+		res.Signals.NonTrivial = true
+		res.Signals.Files = 4
+		res.Signals.Steps = 2 // below nonTrivialMinStepsHook — must not be named
+
+		line := formatPlanNudgeLine(res)
+		assert.Contains(t, line, "4 files")
+		assert.NotContains(t, line, "step", "steps below threshold must not be named")
+		assert.Contains(t, line, "HTML page")
+		assert.NotContains(t, line, "\n")
+	})
+}
+
 // --- C. Stash + emit roundtrip (deliver-once via UserPromptSubmit channel) ---
 
 // TestPlanNudge_StashThenEmit verifies the full deliver path: a stashed nudge is

--- a/cmd/ox/agent_hook_plan_nudge_test.go
+++ b/cmd/ox/agent_hook_plan_nudge_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,6 +115,30 @@ func TestFormatPlanNudgeLine_NonTrivialOnly(t *testing.T) {
 		assert.Contains(t, line, "HTML page")
 		assert.NotContains(t, line, "\n")
 	})
+
+	t.Run("steps only (files below threshold)", func(t *testing.T) {
+		var res planJSONResult
+		res.Signals.NonTrivial = true
+		res.Signals.Files = 1 // below nonTrivialMinFilesHook — must not be named
+		res.Signals.Steps = 7
+
+		line := formatPlanNudgeLine(res)
+		assert.Contains(t, line, "7 steps")
+		assert.NotContains(t, line, "file", "files below threshold must not be named")
+		assert.Contains(t, line, "HTML page")
+		assert.NotContains(t, line, "\n")
+	})
+}
+
+// TestPlanNudgeThresholds_MatchPlanPackage guards the deliberately-duplicated
+// non-triviality thresholds: the hook keeps local copies for wording, but they
+// must never silently diverge from internal/plan's authoritative values (a
+// divergence would make planScopePhrase mis-word the nudge with no other signal).
+// Failure prevented: the plan package changes a threshold and the hook's wording
+// gate drifts out of sync unnoticed.
+func TestPlanNudgeThresholds_MatchPlanPackage(t *testing.T) {
+	assert.Equal(t, plan.NonTrivialMinFiles, nonTrivialMinFilesHook, "hook file-threshold mirror drifted from plan package")
+	assert.Equal(t, plan.NonTrivialMinSteps, nonTrivialMinStepsHook, "hook step-threshold mirror drifted from plan package")
 }
 
 // --- C. Stash + emit roundtrip (deliver-once via UserPromptSubmit channel) ---

--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -564,7 +564,7 @@ func writePlanEnrichmentGuidance(sb *strings.Builder, agentType string) {
 		return
 	}
 	sb.WriteString("When you produce a plan for non-trivial work (multi-file OR architectural OR touches a hotspot/open-PR OR ~5+ steps), run `ox plan` to enrich it with team context — collisions (incl. teammates actively murmuring on these files), prior art, and expert routing.\n")
-	sb.WriteString("Unless plan.html is off, recommend rendering an enriched HTML plan for the human; render only after they confirm, unless plan.html is always.\n")
+	sb.WriteString("For non-trivial plans, render a human-review HTML page with the `html-plan` skill (it writes a self-contained file and opens it); re-open any saved render with `ox plan --open` or `ox plan view <slug> --open`. Render only after the human confirms, unless plan.html is always; skip if plan.html is off.\n")
 	sb.WriteString("</plan-enrichment-guidance>\n")
 }
 

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -539,9 +539,9 @@ func TestOutputAgentPrimeXML_PlanEnrichmentGuidance(t *testing.T) {
 
 			// the HTML-render recommendation is the differentiator: full tiers
 			// recommend it; Bronze (lighter) does not.
-			hasHTML := strings.Contains(xml, "HTML plan")
+			hasHTML := strings.Contains(xml, "HTML page")
 			if tt.wantFull && !hasHTML {
-				t.Error("full-tier block must recommend rendering an HTML plan")
+				t.Error("full-tier block must recommend rendering an HTML page")
 			}
 			if !tt.wantFull {
 				if hasHTML {

--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -257,7 +257,7 @@ ledger.
   on  - Persist finalized plans to data/plans/ (default). Plans become
         first-class ledger artifacts: searchable, attributable, reusable.
   off - Never auto-save. 'ox plan save' (the explicit persist path used by
-        the ox-plan skill) still saves regardless of this setting.`,
+        the html-plan skill) still saves regardless of this setting.`,
 		Category:    "Plans",
 		ValidValues: []string{"on", "off"},
 		Default:     "on",

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -122,6 +122,21 @@ plan.save config.`,
 	},
 }
 
+var planLintCmd = &cobra.Command{
+	Use:   "lint <slug>",
+	Short: "Check a saved plan's HTML render for SageOx attribution + self-contained invariants",
+	Long: `Lint a saved plan's rendered HTML against the html-plan attribution contract:
+when the plan carried SageOx enrichment the render must credit it (footer line +
+an anchored OX marker), an un-enriched plan must not overclaim, and the SageOx
+mark must be self-contained (no live remote avatar). Advisory by default; pass
+--strict to exit non-zero on findings (for CI / golden checks).`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		strict, _ := cmd.Flags().GetBool("strict")
+		return runPlanLint(cmd, args[0], strict)
+	},
+}
+
 // maybeSavePlan captures the enriched plan to the ledger when auto-save is
 // enabled and a ledger is configured. html is nil for now — the porcelain path
 // never renders HTML just to save it (that's a skill-side, opt-in action).
@@ -279,6 +294,54 @@ func runPlanSave(cmd *cobra.Command) error {
 
 	slog.Info("plan_saved", "dir", dir, "html", htmlPath != "", "annotations", len(result.Annotations))
 	fmt.Fprintf(cmd.OutOrStdout(), "Saved plan to ledger: %s\n", dir)
+
+	// Branding guarantee: every render the skill saves is checked for the
+	// earned-and-conditional SageOx attribution. Warn-only — a missing credit
+	// must never block the save (fail-open). Run `ox plan lint <slug>` to recheck.
+	for _, f := range plan.LintBranding(html, result) {
+		cli.PrintHint(fmt.Sprintf("plan-lint [%s]: %s", f.Rule, f.Message))
+	}
+	return nil
+}
+
+// runPlanLint loads a saved plan's HTML render and reports SageOx-attribution
+// findings. Advisory by default; --strict makes it exit non-zero on findings so
+// a golden check or CI step can enforce the contract. Fail-open on a missing or
+// LFS-dehydrated render (nothing local to lint).
+func runPlanLint(cmd *cobra.Command, slug string, strict bool) error {
+	out := cmd.OutOrStdout()
+	gitRoot := findGitRoot()
+
+	_, res, info, err := plan.Load(gitRoot, slug)
+	if err != nil {
+		return err
+	}
+
+	path, _, isPointer, exists := plan.PlanHTMLPath(info.Dir)
+	if !exists {
+		fmt.Fprintln(out, "No HTML render for this plan — nothing to lint.")
+		return nil
+	}
+	if isPointer {
+		cli.PrintHint("This plan's HTML is stored in LFS and not hydrated locally; cannot lint its content.")
+		return nil
+	}
+	html, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read plan html %q: %w", path, err)
+	}
+
+	findings := plan.LintBranding(html, res)
+	if len(findings) == 0 {
+		fmt.Fprintln(out, cli.StyleSuccess.Render("✓")+" SageOx attribution OK")
+		return nil
+	}
+	for _, f := range findings {
+		fmt.Fprintf(out, "%s [%s] %s\n", cli.StyleWarning.Render("!"), f.Rule, f.Message)
+	}
+	if strict {
+		return fmt.Errorf("%d branding lint finding(s)", len(findings))
+	}
 	return nil
 }
 
@@ -597,9 +660,12 @@ func init() {
 	planSaveCmd.Flags().String("annotations", "", "merged annotations.json: ox --json badges + agent judgment badges (required)")
 	planSaveCmd.Flags().String("html", "", "optional pre-rendered HTML; size-gated plain-git-vs-LFS on save")
 
+	planLintCmd.Flags().Bool("strict", false, "exit non-zero when the render has attribution findings (for CI / golden checks)")
+
 	planCmd.AddCommand(planListCmd)
 	planCmd.AddCommand(planViewCmd)
 	planCmd.AddCommand(planSaveCmd)
+	planCmd.AddCommand(planLintCmd)
 
 	planCmd.GroupID = "dev"
 	rootCmd.AddCommand(planCmd)

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -72,7 +72,13 @@ Reads the active plan from --file or stdin. Use --json for the plumbing path
 		// a concise human summary.
 		savedDir := maybeSavePlan(gitRoot, in, result)
 		plan.RecordPlanGenerated(result, savedDir != "")
-		return writePlanHuman(cmd, result, savedDir)
+		if err := writePlanHuman(cmd, result, savedDir); err != nil {
+			return err
+		}
+		if open, _ := cmd.Flags().GetBool("open"); open {
+			openSavedPlanHTML(cmd, savedDir)
+		}
+		return nil
 	},
 }
 
@@ -99,7 +105,7 @@ var planSaveCmd = &cobra.Command{
 	Short: "Persist a fully-enriched plan (merged badges + optional HTML) to the ledger",
 	Long: `Persist a fully-enriched plan to the ledger. Unlike bare 'ox plan' — which
 auto-saves only the deterministic, ox-computed annotations — 'ox plan save' is the
-explicit full-plan persist path used by the ox-plan renderer skill after it has
+explicit full-plan persist path used by the html-plan renderer skill after it has
 authored its judgment badges and (optionally) rendered the HTML.
 
   --plan        the plan markdown (source for plan.md + topic/slug derivation)
@@ -221,7 +227,7 @@ func collabCount(c *plan.CollabSignals, field string) int {
 // runPlanSave persists a fully-enriched plan to the ledger from a plan markdown
 // file, a MERGED annotations.json (deterministic + judgment badges), and an
 // optional pre-rendered HTML file. This is the explicit full-plan persist path
-// the ox-plan skill calls — it always saves (no auto-save config gate) and never
+// the html-plan skill calls — it always saves (no auto-save config gate) and never
 // renders HTML here (the skill already produced it).
 func runPlanSave(cmd *cobra.Command) error {
 	planPath, _ := cmd.Flags().GetString("plan")
@@ -322,7 +328,10 @@ func writePlanJSON(cmd *cobra.Command, result plan.Result) error {
 
 // writePlanHuman prints a concise summary: signal counts plus one line per
 // material annotation, where the plan was saved (if captured), and a hint that
-// an enriched HTML render is available via the ox-plan skill.
+// an enriched HTML render is available via the html-plan skill. The render
+// recommendation fires when EITHER team-context signals (Material) OR structural
+// substance (NonTrivial) warrant a human-review render — the same two axes the
+// ExitPlanMode nudge uses, so porcelain and hook stay consistent.
 func writePlanHuman(cmd *cobra.Command, result plan.Result, savedDir string) error {
 	out := cmd.OutOrStdout()
 	s := result.Signals
@@ -347,12 +356,39 @@ func writePlanHuman(cmd *cobra.Command, result plan.Result, savedDir string) err
 		fmt.Fprintf(&b, "\nSaved to ledger: %s\n", savedDir)
 	}
 
-	if s.Material {
-		b.WriteString("\nMaterial signals found. Render an enriched HTML plan via the ox-plan skill for faster human review.\n")
+	if s.Material || s.NonTrivial {
+		lead := "Substantial plan."
+		if s.Material {
+			lead = "Material signals found."
+		}
+		fmt.Fprintf(&b, "\n%s Render an enriched HTML plan via the html-plan skill for faster human review (open it with `ox plan --open`).\n", lead)
 	}
 
 	fmt.Fprint(out, b.String())
 	return nil
+}
+
+// openSavedPlanHTML backs `ox plan --open`: it opens the render of the plan the
+// porcelain path just saved, mirroring `ox plan view --open` but off the saved
+// directory. Best-effort — enrichment already succeeded, so a missing render or
+// a headless shell prints a hint instead of erroring.
+func openSavedPlanHTML(cmd *cobra.Command, savedDir string) {
+	if savedDir == "" {
+		cli.PrintHint("No saved plan to open (plan capture is off or no ledger is configured).")
+		return
+	}
+	path, _, _, exists := plan.PlanHTMLPath(savedDir)
+	if !exists {
+		cli.PrintHint("No HTML render yet — run the `html-plan` skill to produce one, then re-run with --open.")
+		return
+	}
+	if cli.IsHeadless() {
+		fmt.Fprintf(cmd.OutOrStdout(), "Rendered HTML: %s\n", path)
+		return
+	}
+	if err := openPlanHTML(savedDir); err != nil {
+		cli.PrintHint("Could not open the rendered plan: " + err.Error())
+	}
 }
 
 // runPlanList renders the saved plans as a table. Fail-open: outside a project
@@ -553,6 +589,7 @@ func init() {
 	planCmd.Flags().Bool("json", false, "emit the enrichment Result as JSON (plumbing path; no network/LLM call)")
 	planCmd.Flags().Bool("persist", false, "with --json, also save + commit a draft to the ledger (used by the ExitPlanMode hook)")
 	planCmd.Flags().String("file", "", "plan source file (default: stdin, else newest ~/.claude/plans/*.md)")
+	planCmd.Flags().Bool("open", false, "after enrich, open this plan's rendered HTML if one is saved")
 
 	planViewCmd.Flags().Bool("open", false, "open the rendered plan.html in your browser (if one was saved)")
 

--- a/extensions/claude/commands/ox-plan.md
+++ b/extensions/claude/commands/ox-plan.md
@@ -230,6 +230,7 @@ One **hero diagram near the top** captures the whole shape. Add a second diagram
 - **Only when it legitimately helped.** If `ox plan --json` returned no badges and an empty `context[]` (an un-enriched plan), add NO SageOx credit — there is nothing to credit.
 - **Never overclaim.** SageOx provided context and signals; the human and the agent wrote the plan. Credit the enrichment, not the authorship. No banners, no marketing copy, no "moat"/"powered by" language — one calm line in the footer.
 - Judgment badges drawn from the SageOx context bundle may carry a small "via SageOx context" provenance note where it reads naturally, but don't repeat it on every badge.
+- **Enforced, not just requested.** `ox plan save` lints the render for this contract (footer credit + an anchored OX marker when the plan carried enrichment; no overclaim on un-enriched plans; no live-remote avatar) and warns on any miss. Re-check anytime with `ox plan lint <slug>` (add `--strict` to fail on findings). A clean lint is part of "done".
 
 **Concise, high-signal prose.** No filler. Every sentence earns its place. Code identifiers in `<code>`. Don't restate what a diagram or badge already shows.
 

--- a/internal/codedb/dirty_integration_test.go
+++ b/internal/codedb/dirty_integration_test.go
@@ -30,8 +30,8 @@ func initTestRepo(t *testing.T) string {
 			// scrub host gitconfig so commit.gpgsign / signingkey can't prompt
 			// for ssh/gpg passphrases during the test commit. os.DevNull keeps
 			// this portable to Windows CI (NUL there, /dev/null elsewhere).
-			"GIT_CONFIG_GLOBAL=" + os.DevNull,
-			"GIT_CONFIG_SYSTEM=" + os.DevNull,
+			"GIT_CONFIG_GLOBAL="+os.DevNull,
+			"GIT_CONFIG_SYSTEM="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		require.NoError(t, err, "git %v: %s", args, out)

--- a/internal/codedb/index/alternates_test.go
+++ b/internal/codedb/index/alternates_test.go
@@ -110,4 +110,3 @@ func TestHasAlternates(t *testing.T) {
 			"worktree must inherit main repo's alternates via rev-parse --git-common-dir")
 	})
 }
-

--- a/internal/codedb/index/gogit_test.go
+++ b/internal/codedb/index/gogit_test.go
@@ -171,7 +171,7 @@ func TestPlainOpenTolerant_AlternatesUpstreamLimitation(t *testing.T) {
 	}
 
 	cases := []struct {
-		name       string
+		name         string
 		makeRelative bool
 	}{
 		{name: "absolute_path", makeRelative: false},

--- a/internal/daemon/terminal_handler_test.go
+++ b/internal/daemon/terminal_handler_test.go
@@ -245,11 +245,11 @@ func TestProcessTerminalEvent_AuditLog(t *testing.T) {
 
 	h := newTestHandler(t, root)
 	data := adapterprotocol.TerminalErrorData{
-		Reason:     "rate_limited",
-		Source:     "regex",
-		PatternID:  "claude_code.system_error.usage_limit",
-		RawMessage: "5-hour limit reached resets 3pm",
-		DetectedAt: time.Now().UTC(),
+		Reason:      "rate_limited",
+		Source:      "regex",
+		PatternID:   "claude_code.system_error.usage_limit",
+		RawMessage:  "5-hour limit reached resets 3pm",
+		DetectedAt:  time.Now().UTC(),
 		ConfirmedAt: time.Now().UTC(),
 	}
 	if err := h.processTerminalEvent(context.Background(), "claude-code", "Ox1234", sessionPath, data, true); err != nil {

--- a/internal/gitutil/incomplete_test.go
+++ b/internal/gitutil/incomplete_test.go
@@ -65,10 +65,10 @@ func TestInspectRepo(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		setup     func(t *testing.T) string
-		wantShall bool
-		wantPart  bool
+		name       string
+		setup      func(t *testing.T) string
+		wantShall  bool
+		wantPart   bool
 		wantReason string
 	}{
 		{

--- a/internal/observability/terminal_metrics.go
+++ b/internal/observability/terminal_metrics.go
@@ -141,8 +141,8 @@ type MetricsSnapshot struct {
 type HistogramSummary struct {
 	Count   uint64    `json:"count"`
 	SumMs   float64   `json:"sum_ms"`
-	Buckets []uint64  `json:"buckets"`           // parallel to Boundaries + overflow
-	Bounds  []float64 `json:"boundaries"`        // canonical bucket boundaries (ms)
+	Buckets []uint64  `json:"buckets"`    // parallel to Boundaries + overflow
+	Bounds  []float64 `json:"boundaries"` // canonical bucket boundaries (ms)
 }
 
 // Snapshot returns a deep copy of the metrics state. Safe to call from

--- a/internal/plan/enrich.go
+++ b/internal/plan/enrich.go
@@ -9,11 +9,13 @@ import (
 )
 
 const (
-	// nonTrivialMinFiles: a multi-file plan (>= 2 distinct files) is non-trivial.
-	nonTrivialMinFiles = 2
-	// nonTrivialMinSteps: a ~5+ step plan is non-trivial, matching the prime
+	// NonTrivialMinFiles: a multi-file plan (>= 2 distinct files) is non-trivial.
+	// Exported as the single source of truth: the plan-exit hook mirrors these
+	// for wording and a drift test asserts the copies stay equal.
+	NonTrivialMinFiles = 2
+	// NonTrivialMinSteps: a ~5+ step plan is non-trivial, matching the prime
 	// "~5+ steps" criterion. H2 sections are the step proxy.
-	nonTrivialMinSteps = 5
+	NonTrivialMinSteps = 5
 )
 
 // registry holds the detectors and retrievers contributed by Round 2 packages.
@@ -146,7 +148,7 @@ func summarize(annotations []Annotation, in Input) SignalSummary {
 
 	s.Files = countDistinctFiles(in.Sections)
 	s.Steps = countSteps(in.Sections)
-	s.NonTrivial = s.Files >= nonTrivialMinFiles || s.Steps >= nonTrivialMinSteps
+	s.NonTrivial = s.Files >= NonTrivialMinFiles || s.Steps >= NonTrivialMinSteps
 	return s
 }
 

--- a/internal/plan/enrich.go
+++ b/internal/plan/enrich.go
@@ -4,7 +4,16 @@ import (
 	"context"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
+)
+
+const (
+	// nonTrivialMinFiles: a multi-file plan (>= 2 distinct files) is non-trivial.
+	nonTrivialMinFiles = 2
+	// nonTrivialMinSteps: a ~5+ step plan is non-trivial, matching the prime
+	// "~5+ steps" criterion. H2 sections are the step proxy.
+	nonTrivialMinSteps = 5
 )
 
 // registry holds the detectors and retrievers contributed by Round 2 packages.
@@ -79,7 +88,7 @@ func Enrich(ctx context.Context, in Input, gitRoot string) Result {
 	return Result{
 		Annotations: annotations,
 		Context:     items,
-		Signals:     summarize(annotations),
+		Signals:     summarize(annotations, in),
 	}
 }
 
@@ -116,11 +125,12 @@ func runRetriever(ctx context.Context, r Retriever, in Input, gitRoot string) (o
 	return items
 }
 
-// summarize counts annotations by type and decides materiality. A plan is
-// material when any collision OR expert-route fired, or when there is at least
-// one prior-art hit (the "strong prior-art" gate is refined in Round 2 once
-// prior-art scoring exists).
-func summarize(annotations []Annotation) SignalSummary {
+// summarize rolls up the two independent signal axes. Material (team-context):
+// any collision OR expert-route fired, or there is at least one prior-art hit
+// (the "strong prior-art" gate is refined in Round 2 once prior-art scoring
+// exists). NonTrivial (structural): the plan is multi-file or many-step, so an
+// enriched HTML render is worth recommending even when team context is silent.
+func summarize(annotations []Annotation, in Input) SignalSummary {
 	var s SignalSummary
 	for _, a := range annotations {
 		switch a.Type {
@@ -133,7 +143,40 @@ func summarize(annotations []Annotation) SignalSummary {
 		}
 	}
 	s.Material = s.Collisions > 0 || s.ExpertRoutes > 0 || s.PriorArt >= 1
+
+	s.Files = countDistinctFiles(in.Sections)
+	s.Steps = countSteps(in.Sections)
+	s.NonTrivial = s.Files >= nonTrivialMinFiles || s.Steps >= nonTrivialMinSteps
 	return s
+}
+
+// countDistinctFiles unions Section.Files across all sections, deduped. Each
+// section's Files is already path-validated + per-section deduped by Parse; this
+// only collapses the cross-section union so a single file cited in three
+// sections counts once, not three times.
+func countDistinctFiles(sections []Section) int {
+	seen := make(map[string]struct{})
+	for _, sec := range sections {
+		for _, f := range sec.Files {
+			seen[f] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+// countSteps counts H2-delimited sections (the plan's structural steps),
+// EXCLUDING the empty-heading preamble Parse emits for content before the first
+// H2 (it is framing, not a step). Counting it would inflate by one and push a
+// 4-section plan over the non-trivial step threshold.
+func countSteps(sections []Section) int {
+	n := 0
+	for _, sec := range sections {
+		if strings.TrimSpace(sec.Heading) == "" {
+			continue // preamble, not a step
+		}
+		n++
+	}
+	return n
 }
 
 // sortDedupeAnnotations produces a deterministic, duplicate-free ordering so the

--- a/internal/plan/enrich_test.go
+++ b/internal/plan/enrich_test.go
@@ -35,4 +35,76 @@ func TestEnrichEmptyRegistry(t *testing.T) {
 	if result.Signals.Collisions != 0 || result.Signals.PriorArt != 0 || result.Signals.ExpertRoutes != 0 {
 		t.Errorf("expected zero signal counts, got %+v", result.Signals)
 	}
+	// a single section with no file refs is trivial: Files=0, Steps=1.
+	if result.Signals.Files != 0 || result.Signals.Steps != 1 {
+		t.Errorf("expected Files=0 Steps=1, got Files=%d Steps=%d", result.Signals.Files, result.Signals.Steps)
+	}
+	if result.Signals.NonTrivial {
+		t.Errorf("expected single-section no-file plan to be trivial")
+	}
+}
+
+// TestSummarizeNonTrivialDecoupledFromMaterial verifies the core decoupling:
+// a structurally substantial plan is NonTrivial even with zero team-context
+// signals (no registered detectors => Material is false). Without this, a large
+// greenfield plan would never trigger the HTML-render nudge.
+// Failure prevented: the render nudge stays coupled to team-context signals.
+func TestSummarizeNonTrivialDecoupledFromMaterial(t *testing.T) {
+	registryMu.Lock()
+	savedDetectors, savedRetrievers := detectors, retrievers
+	detectors, retrievers = nil, nil
+	registryMu.Unlock()
+	t.Cleanup(func() {
+		registryMu.Lock()
+		detectors, retrievers = savedDetectors, savedRetrievers
+		registryMu.Unlock()
+	})
+
+	t.Run("multi-file triggers NonTrivial without Material", func(t *testing.T) {
+		in := Parse("## Plan\ntouch `internal/auth/session.go` and `cmd/ox/login.go`")
+		res := Enrich(context.Background(), in, "")
+		if res.Signals.Material {
+			t.Fatalf("expected non-material (no detectors), got material")
+		}
+		if res.Signals.Files != 2 {
+			t.Errorf("expected Files=2, got %d", res.Signals.Files)
+		}
+		if !res.Signals.NonTrivial {
+			t.Errorf("expected multi-file plan to be NonTrivial")
+		}
+	})
+
+	t.Run("same file across sections counts once", func(t *testing.T) {
+		raw := "## A\nedit `internal/auth/session.go`\n\n## B\nalso `internal/auth/session.go`"
+		res := Enrich(context.Background(), Parse(raw), "")
+		if res.Signals.Files != 1 {
+			t.Errorf("expected distinct Files=1 (cross-section dedup), got %d", res.Signals.Files)
+		}
+		if res.Signals.NonTrivial {
+			t.Errorf("single distinct file across two sections is not multi-file; expected trivial on files")
+		}
+	})
+
+	t.Run("five steps triggers NonTrivial, preamble excluded", func(t *testing.T) {
+		// leading preamble before the first H2 must NOT count as a step.
+		raw := "intro preamble\n\n## One\n## Two\n## Three\n## Four\n## Five"
+		res := Enrich(context.Background(), Parse(raw), "")
+		if res.Signals.Steps != 5 {
+			t.Errorf("expected Steps=5 (preamble excluded), got %d", res.Signals.Steps)
+		}
+		if !res.Signals.NonTrivial {
+			t.Errorf("expected 5-step plan to be NonTrivial")
+		}
+	})
+
+	t.Run("four steps with preamble stays trivial", func(t *testing.T) {
+		raw := "intro preamble\n\n## One\n## Two\n## Three\n## Four"
+		res := Enrich(context.Background(), Parse(raw), "")
+		if res.Signals.Steps != 4 {
+			t.Errorf("expected Steps=4 (preamble excluded), got %d", res.Signals.Steps)
+		}
+		if res.Signals.NonTrivial {
+			t.Errorf("4-step no-multi-file plan must stay trivial (preamble off-by-one guard)")
+		}
+	})
 }

--- a/internal/plan/lint.go
+++ b/internal/plan/lint.go
@@ -1,0 +1,92 @@
+package plan
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// BrandingFinding is one SageOx-attribution lint result on a rendered plan
+// HTML. All findings are advisory (warn-level): linting NEVER blocks a render
+// or a save (fail-open agent UX). A non-empty slice means the render did not
+// honor the html-plan skill's attribution contract.
+type BrandingFinding struct {
+	Rule    string // stable id, e.g. "branding.footer-credit"
+	Message string // human-readable, actionable
+}
+
+var (
+	// the canonical OX marker is a focusable button named for screen readers
+	// (extensions/claude/commands/ox-plan.md: `<button aria-label="SageOx insight">`).
+	oxMarkerRe = regexp.MustCompile(`(?i)aria-label\s*=\s*["']SageOx insight["']`)
+
+	// footer credit, e.g. "Team context enriched by SageOx" — substring match,
+	// case-insensitive, wording-tolerant.
+	footerCreditRe = regexp.MustCompile(`(?i)enriched by SageOx`)
+
+	// banned: a LIVE remote avatar image. The mark must be data:-inlined or
+	// inline-SVG so the page renders from file:// with no runtime network.
+	remoteAvatarRe = regexp.MustCompile(`(?i)<img[^>]+src\s*=\s*["']https?://[^"']*avatars\.githubusercontent\.com`)
+)
+
+// LintBranding verifies a rendered plan HTML carries the conditional SageOx
+// attribution the html-plan skill is spec'd to produce. The contract
+// (extensions/claude/commands/ox-plan.md, "SageOx attribution — subtle, earned,
+// conditional"):
+//
+//   - EARNED: when the plan carried enrichment — any deterministic badges OR
+//     context-bundle items were present — the render MUST credit it: a footer
+//     line ("…enriched by SageOx") and, when there are deterministic badges, at
+//     least one anchored OX marker.
+//   - NO OVERCLAIM: an un-enriched plan (no badges, empty context) must NOT
+//     carry SageOx credit — there is nothing to credit.
+//   - SELF-CONTAINED: the OX marker's avatar must never be a live remote
+//     <img src>; it is data:-inlined or an inline-SVG monogram. Always checked.
+//
+// Returns nil when the page satisfies the contract. Fail-open: callers warn,
+// never block.
+func LintBranding(html []byte, res Result) []BrandingFinding {
+	if len(html) == 0 {
+		return nil // nothing rendered; nothing to lint
+	}
+	h := string(html)
+
+	var findings []BrandingFinding
+
+	// "carried enrichment" mirrors the skill's own gate: any deterministic
+	// badges OR context-bundle items present.
+	enriched := len(res.Annotations) > 0 || len(res.Context) > 0
+	hasCredit := footerCreditRe.Match(html)
+
+	switch {
+	case enriched && !hasCredit:
+		findings = append(findings, BrandingFinding{
+			Rule:    "branding.footer-credit",
+			Message: `plan carries SageOx enrichment but the render has no footer credit (expected a calm line like "Team context enriched by SageOx")`,
+		})
+	case !enriched && hasCredit:
+		findings = append(findings, BrandingFinding{
+			Rule:    "branding.overclaim",
+			Message: "render credits SageOx but the plan carried no enrichment (no badges, empty context) — drop the credit; there is nothing to credit",
+		})
+	}
+
+	// OX markers anchor deterministic signals; require at least one only when
+	// such badges exist. Context-only enrichment earns the footer credit but
+	// not necessarily a per-element marker.
+	if len(res.Annotations) > 0 && !oxMarkerRe.MatchString(h) {
+		findings = append(findings, BrandingFinding{
+			Rule:    "branding.ox-marker",
+			Message: fmt.Sprintf(`render has %d deterministic SageOx badge(s) but no anchored OX marker (expected a focusable <button aria-label="SageOx insight">)`, len(res.Annotations)),
+		})
+	}
+
+	// Always enforced: the mark must be self-contained, never a live remote img.
+	if remoteAvatarRe.MatchString(h) {
+		findings = append(findings, BrandingFinding{
+			Rule:    "branding.remote-avatar",
+			Message: `OX marker uses a live remote avatar <img src="https://avatars.githubusercontent.com…"> — inline it as a data: URI or an inline SVG so the page renders from file:// with no network`,
+		})
+	}
+
+	return findings
+}

--- a/internal/plan/lint_test.go
+++ b/internal/plan/lint_test.go
@@ -1,0 +1,131 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+)
+
+// enrichedResult is a Result that carries SageOx enrichment (one deterministic
+// badge). un-enriched plans use the zero Result.
+func enrichedResult() Result {
+	return Result{Annotations: []Annotation{{Type: BadgeCollision, Why: "contended"}}}
+}
+
+// contextOnlyResult carries enrichment via the context bundle but no badges.
+func contextOnlyResult() Result {
+	return Result{Context: []ContextItem{{Kind: "session", Title: "prior work"}}}
+}
+
+// the canonical attribution fragments the html-plan skill is spec'd to emit.
+const (
+	footerCredit = `<footer>Team context enriched by SageOx</footer>`
+	oxMarker     = `<button aria-label="SageOx insight">…</button>`
+	inlineAvatar = `<img src="data:image/png;base64,AAAA">`
+	remoteAvatar = `<img src="https://avatars.githubusercontent.com/u/224450799?s=64">`
+)
+
+// TestLintBranding_EarnedCreditRequired verifies the core guarantee: an
+// enriched plan whose render omits the footer credit is flagged, and a fully
+// attributed render is clean.
+// Failure prevented: SageOx silently loses credit on a team-context-aware plan.
+func TestLintBranding_EarnedCreditRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		html      string
+		res       Result
+		wantRules []string
+	}{
+		{
+			name: "enriched + credit + marker is clean",
+			html: footerCredit + oxMarker + inlineAvatar,
+			res:  enrichedResult(),
+		},
+		{
+			name:      "enriched but no credit is flagged",
+			html:      oxMarker + inlineAvatar,
+			res:       enrichedResult(),
+			wantRules: []string{"branding.footer-credit"},
+		},
+		{
+			name:      "enriched with badges but no OX marker is flagged",
+			html:      footerCredit,
+			res:       enrichedResult(),
+			wantRules: []string{"branding.ox-marker"},
+		},
+		{
+			name: "context-only enrichment needs credit, not a marker",
+			html: footerCredit,
+			res:  contextOnlyResult(),
+		},
+		{
+			name:      "context-only enrichment without credit is flagged",
+			html:      "<p>plan</p>",
+			res:       contextOnlyResult(),
+			wantRules: []string{"branding.footer-credit"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertRules(t, LintBranding([]byte(tt.html), tt.res), tt.wantRules)
+		})
+	}
+}
+
+// TestLintBranding_NoOverclaim verifies an un-enriched plan must NOT credit
+// SageOx — there is nothing to credit.
+// Failure prevented: marketing-y credit appears on plans ox did not enrich.
+func TestLintBranding_NoOverclaim(t *testing.T) {
+	t.Run("un-enriched + no credit is clean", func(t *testing.T) {
+		assertRules(t, LintBranding([]byte("<p>greenfield plan</p>"), Result{}), nil)
+	})
+	t.Run("un-enriched + credit is overclaim", func(t *testing.T) {
+		assertRules(t, LintBranding([]byte(footerCredit), Result{}), []string{"branding.overclaim"})
+	})
+}
+
+// TestLintBranding_RemoteAvatarBanned verifies the self-contained invariant: a
+// live remote avatar is always flagged, even on an otherwise-correct render.
+// Failure prevented: the page needs network to show the SageOx mark, breaking
+// file:// rendering for the reviewer.
+func TestLintBranding_RemoteAvatarBanned(t *testing.T) {
+	html := footerCredit + `<button aria-label="SageOx insight">` + remoteAvatar + `</button>`
+	got := LintBranding([]byte(html), enrichedResult())
+	assertRules(t, got, []string{"branding.remote-avatar"})
+}
+
+// TestLintBranding_EmptyHTMLNoFindings verifies linting is a no-op when there is
+// no render to check (fail-open: a save without --html must not be flagged).
+func TestLintBranding_EmptyHTMLNoFindings(t *testing.T) {
+	if got := LintBranding(nil, enrichedResult()); got != nil {
+		t.Errorf("expected no findings on empty html, got %+v", got)
+	}
+}
+
+// assertRules checks the finding rule-ids match exactly (order-independent).
+func assertRules(t *testing.T, got []BrandingFinding, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d finding(s) %v, want %d %v", len(got), ruleIDs(got), len(want), want)
+	}
+	have := make(map[string]bool, len(got))
+	for _, f := range got {
+		have[f.Rule] = true
+		// every message must be non-empty and name something actionable.
+		if strings.TrimSpace(f.Message) == "" {
+			t.Errorf("finding %s has empty message", f.Rule)
+		}
+	}
+	for _, r := range want {
+		if !have[r] {
+			t.Errorf("missing expected finding %q; got %v", r, ruleIDs(got))
+		}
+	}
+}
+
+func ruleIDs(fs []BrandingFinding) []string {
+	ids := make([]string, len(fs))
+	for i, f := range fs {
+		ids[i] = f.Rule
+	}
+	return ids
+}

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -97,14 +97,27 @@ type Input struct {
 	Sections []Section
 }
 
-// SignalSummary is the deterministic rollup of which signals fired. Material is
-// true when the plan warrants surfacing a nudge (any collision OR expert-route
-// OR at least one strong prior-art hit).
+// SignalSummary is the deterministic rollup of which signals fired.
+//
+// Material is the TEAM-CONTEXT axis: true when the plan warrants surfacing a
+// nudge because team context had something to say (any collision OR
+// expert-route OR at least one strong prior-art hit).
+//
+// NonTrivial is the STRUCTURAL axis, independent of team context: true when the
+// plan is substantial enough to warrant an enriched HTML render for human
+// review even on greenfield work where zero team-context signals fire —
+// multi-file (Files >= 2) OR many-step (Steps >= 5). Files counts distinct file
+// references cited across all sections; Steps counts H2 sections (excluding the
+// preamble). These mirror the prime non-triviality criteria; hotspot/open-PR is
+// already covered by Material, and "architectural" is left to agent judgment.
 type SignalSummary struct {
 	Collisions   int  `json:"collisions"`
 	PriorArt     int  `json:"prior_art"`
 	ExpertRoutes int  `json:"expert_routes"`
 	Material     bool `json:"material"`
+	Files        int  `json:"files"`
+	Steps        int  `json:"steps"`
+	NonTrivial   bool `json:"non_trivial"`
 }
 
 // Result is the full output of Enrich: deterministic annotations, the context

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -311,17 +311,17 @@ type SessionInfo struct {
 	Size            int64               `json:"size"`
 	CreatedAt       time.Time           `json:"created_at"`
 	ModTime         time.Time           `json:"mod_time"`
-	HydrationStatus lfs.HydrationStatus `json:"hydration_status,omitempty"` // hydrated/dehydrated/partial
-	Username        string              `json:"username,omitempty"`         // from meta.json
-	Title           string              `json:"title,omitempty"`            // from meta.json
-	Summary         string              `json:"summary,omitempty"`          // from meta.json
-	Recording       bool                `json:"recording,omitempty"`        // true if session is actively being recorded
-	AgentID         string              `json:"agent_id,omitempty"`         // from .recording.json when recording
-	EntryCount      int                 `json:"entry_count,omitempty"`      // from .recording.json or meta.json
-	IsSubagent      bool                `json:"is_subagent,omitempty"`      // true if spawned by a parent session
-	ParentPID       int                 `json:"parent_pid,omitempty"`       // from .recording.json for liveness detection
-	Origin          string              `json:"origin,omitempty"`           // session origin: "human", "subagent", "agent"
-	HasRawData      bool                `json:"has_raw_data,omitempty"`     // true if raw.jsonl exists with content on disk
+	HydrationStatus lfs.HydrationStatus `json:"hydration_status,omitempty"`   // hydrated/dehydrated/partial
+	Username        string              `json:"username,omitempty"`           // from meta.json
+	Title           string              `json:"title,omitempty"`              // from meta.json
+	Summary         string              `json:"summary,omitempty"`            // from meta.json
+	Recording       bool                `json:"recording,omitempty"`          // true if session is actively being recorded
+	AgentID         string              `json:"agent_id,omitempty"`           // from .recording.json when recording
+	EntryCount      int                 `json:"entry_count,omitempty"`        // from .recording.json or meta.json
+	IsSubagent      bool                `json:"is_subagent,omitempty"`        // true if spawned by a parent session
+	ParentPID       int                 `json:"parent_pid,omitempty"`         // from .recording.json for liveness detection
+	Origin          string              `json:"origin,omitempty"`             // session origin: "human", "subagent", "agent"
+	HasRawData      bool                `json:"has_raw_data,omitempty"`       // true if raw.jsonl exists with content on disk
 	StopReason      string              `json:"stop_reason,omitempty"`        // how session ended (StopReason* constants)
 	SuspendedAt     *time.Time          `json:"suspended_at,omitempty"`       // ADR-020: non-nil while session is actively paused
 	StopDetail      string              `json:"stop_detail,omitempty"`        // human-readable detail (matched message, capped 512B)

--- a/pkg/adapterprotocol/types.go
+++ b/pkg/adapterprotocol/types.go
@@ -304,8 +304,8 @@ type EntriesEventData struct {
 
 // Event names emitted by adapters.
 const (
-	EventEntries        = "entries"
-	EventTerminalError  = "terminal_error"
+	EventEntries       = "entries"
+	EventTerminalError = "terminal_error"
 )
 
 // TerminalErrorSource identifies how a terminal condition was detected.
@@ -335,15 +335,15 @@ const (
 // time — the UI falls back to ResetsAtRaw verbatim. Both may be empty
 // when no reset hint was present in the matched text.
 type TerminalErrorData struct {
-	Reason       string     `json:"reason"`
-	Source       string     `json:"source"` // see TerminalSource* constants
-	PatternID    string     `json:"pattern_id,omitempty"`
-	RawMessage   string     `json:"raw_message"` // capped at 512 bytes
-	ResetsAtRaw  string     `json:"resets_at_raw,omitempty"`
-	ResetsAt     *time.Time `json:"resets_at,omitempty"`
-	EntrySeq     int64      `json:"entry_seq,omitempty"`
-	DetectedAt   time.Time  `json:"detected_at"`
-	ConfirmedAt  time.Time  `json:"confirmed_at"`
+	Reason      string     `json:"reason"`
+	Source      string     `json:"source"` // see TerminalSource* constants
+	PatternID   string     `json:"pattern_id,omitempty"`
+	RawMessage  string     `json:"raw_message"` // capped at 512 bytes
+	ResetsAtRaw string     `json:"resets_at_raw,omitempty"`
+	ResetsAt    *time.Time `json:"resets_at,omitempty"`
+	EntrySeq    int64      `json:"entry_seq,omitempty"`
+	DetectedAt  time.Time  `json:"detected_at"`
+	ConfirmedAt time.Time  `json:"confirmed_at"`
 }
 
 // --- Serve mode method names ---


### PR DESCRIPTION
## Summary

**Customer-facing change:** when an AI coworker finishes planning a piece of work, ox now recommends rendering a polished, self-contained **HTML plan page** for the human reviewer whenever the plan is *substantial* — multi-file or many-step — **not only** when ox happened to find team-context signals (collisions with open PRs, prior art, expert routes). It also **guarantees** that the team-context-aware render actually carries proper SageOx attribution.

- **The gap this closes:** previously the render recommendation fired *only* on team-context signals. On greenfield / sparse-ledger work — brand-new features with no prior art to collide with — the agent got **no** prompt to produce a review page, even for a sprawling multi-file plan. Those are exactly the plans a human most wants to skim before approving.
- **Now:** the nudge fires on **either** axis — team-context signals **or** structural substance (`>= 2 distinct files` OR `>= 5 steps`). The render's value (a scannable artifact for the reviewer) is independent of whether team context had anything to say.
- **Respects the setting:** suppressed entirely when `plan.html` is `off`; the draft plan is still saved to the ledger (durability is separate from the render recommendation).
- **Easier to reach the render:** `ox plan --open` opens the saved HTML; prime guidance and CLI copy point at the `html-plan` skill (renamed from the internal `ox-plan` label) with a headless-safe fallback that prints the path.
- **Branding is now enforced, not just requested:** a deterministic linter checks every saved render for the spec'd SageOx attribution.

```mermaid
flowchart TD
  A["Plan approved (ExitPlanMode)"] --> B["ox plan: enrich and save draft"]
  B --> C{"plan.html is off?"}
  C -->|yes| Z["no render nudge (draft still saved)"]
  C -->|no| D{"team signals OR multi-file or many-step?"}
  D -->|no| Z2["no nudge (trivial plan, stays quiet)"]
  D -->|yes| E["recommend an HTML plan render to the human"]
  E --> F["ox plan save: lint SageOx attribution"]
```

## What changed

- **`internal/plan` — new structural axis.** `SignalSummary` gains `Files`, `Steps`, `NonTrivial` (additive JSON, no schema bump). `Files` = distinct file refs unioned across sections (same file cited twice counts once); `Steps` = H2 sections excluding the preamble. `NonTrivial = Files >= 2 OR Steps >= 5`, mirroring the prime non-triviality criteria.
- **`cmd/ox/agent_hook_plan_nudge.go` — decoupled trigger.** The just-in-time plan-exit nudge fires on `Material OR NonTrivial`, gated by `plan.html=off`. Wording degrades gracefully: team-context line when signals fired, render-focused scope line (`N files / M steps`) when only structural.
- **`cmd/ox/plan.go` — discoverability + lint.** New `ox plan --open` flag + `openSavedPlanHTML` (headless-safe). `writePlanHuman` recommends a render on `Material OR NonTrivial`. New **`ox plan lint <slug>`** subcommand (`--strict` exits non-zero); `ox plan save` runs the lint and warns inline.
- **`internal/plan/lint.go` — branding guarantee.** `LintBranding(html, res)` enforces the html-plan attribution contract, deterministically (no LLM): when the plan carried enrichment → require footer credit (+ an anchored OX marker when deterministic badges exist); un-enriched plan → no overclaim; **always** ban a live-remote avatar `<img src>` (self-contained / `file://` render). Fail-open — warns, never blocks.
- **Copy / guidance + spec.** Prime block, config help, and `extensions/claude/commands/ox-plan.md` reference the `html-plan` skill, `ox plan --open`, and the lint guarantee.
- **`chore` commit:** 8 unrelated test/util files carry pure `gofmt` alignment (no behavior), in their own commit.

## Test Plan

- `make lint` → 0 issues. `make test` → green (one pre-existing codedb flake, `TestCheckpointFlush_DataAccessibleAfterRun`, passes on isolated re-run).
- `internal/plan/enrich_test.go`: proves `NonTrivial && !Material` on multi-file/5-step plans, cross-section file dedup, preamble off-by-one guard.
- `internal/plan/lint_test.go`: earned-credit required (footer + marker), context-only enrichment needs credit not marker, no-overclaim on greenfield, remote-avatar always banned, empty-html no-op.
- `cmd/ox/agent_hook_plan_nudge_test.go`: NonTrivial-only nudge wording.
- **Known gaps (follow-up):** `ox plan --open`/`openSavedPlanHTML` and the `plan.html=off` hook gate are not yet unit-tested (the latter needs the real `ox` binary → slow tier).

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented
- [ ] CHANGELOG entry added (if user-facing) — N/A: agent-facing behavioral nudge + lint, no version bump in this PR
- [x] Breaking change documented — none (additive `SignalSummary` fields, backward-compatible)
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: diff touches none of `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, `go.sum`

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--open` flag to browse saved plan HTML pages directly in your browser
  * Introduced `ox plan lint <slug>` subcommand to verify plan attribution and format compliance

* **Improvements**
  * Plan review recommendations now trigger for both material signals and structurally complex plans
  * Enhanced guidance for when and how to render plan HTML pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->