### PR TITLE
fix(clone): supply credential helper to team-context clone, harden git prompts

### DIFF
--- a/cmd/ox/doctor_git_repos_fix.go
+++ b/cmd/ox/doctor_git_repos_fix.go
@@ -591,7 +591,12 @@ func cloneViaDaemon(cloneURL, targetPath, repoType, endpointURL string) error {
 	defer cancel()
 
 	if repoType == "team-context" {
-		// team contexts use shared two-phase partial clone (same code as daemon)
+		// team contexts use shared two-phase partial clone (same code as daemon).
+		// Pre-check credentials exist so we fail with a clear error rather than
+		// a generic git auth failure; but pass the BARE URL to TwoPhaseClone —
+		// it resolves the PAT via the ox credential helper. Embedding the token
+		// in the URL (BuildAuthURL) would persist it into .git/config, which
+		// ox-eeqi explicitly forbids.
 		creds, err := gitserver.LoadCredentialsForEndpoint(endpointURL)
 		if err != nil {
 			return fmt.Errorf("load credentials: %w", err)
@@ -599,11 +604,7 @@ func cloneViaDaemon(cloneURL, targetPath, repoType, endpointURL string) error {
 		if creds == nil {
 			return fmt.Errorf("direct clone failed: %w", gitserver.ErrNoCredentials)
 		}
-		authURL, err := gitserver.BuildAuthURL(cloneURL, creds)
-		if err != nil {
-			return fmt.Errorf("build auth URL: %w", err)
-		}
-		result, err := gitserver.TwoPhaseClone(ctx, authURL, targetPath)
+		result, err := gitserver.TwoPhaseClone(ctx, cloneURL, targetPath)
 		if err != nil {
 			return fmt.Errorf("direct clone failed: %w", err)
 		}
@@ -639,11 +640,14 @@ func cloneRepoForFix(issue repoPathIssue) error {
 	}
 
 	if fetchErr != nil {
-		// Cloud doesn't have the repo - don't delete anything
+		// Cloud doesn't have the repo (or the lookup failed) - don't delete
+		// anything. Surface the underlying reason so the user can distinguish
+		// "provisioning still pending" (status=pending) from an auth/network
+		// failure — the generic "not provisioned" message hides both.
 		if issue.repoType == "ledger" {
-			return fmt.Errorf("cloud has not provisioned ledger yet - no changes made")
+			return fmt.Errorf("ledger not available yet - no changes made: %w", fetchErr)
 		}
-		return fmt.Errorf("cloud has not provisioned team context yet - no changes made")
+		return fmt.Errorf("team context not available yet - no changes made: %w", fetchErr)
 	}
 
 	// Now that we know cloud has the repo, proceed with directory cleanup if needed

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1886,14 +1886,10 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 			_ = progress.WriteStage("cloning", "Cloning repository...")
 		}
 		// Per ox-eeqi: clone with ox-managed credential helper, not embedded
-		// URL credentials. `-c credential.helper=` empty clears inherited
-		// helpers; the second `-c` installs ours for this single invocation.
-		helperCmd := gitserver.DefaultHelperCommand()
-		preArgs := []string{
-			"-c", "credential.helper=",
-			"-c", "credential.helper=" + helperCmd,
-		}
-		cloneArgs := append(preArgs, gitHTTPTimeoutFlags()...)
+		// URL credentials. CredentialHelperArgs clears inherited helpers and
+		// installs ours for this single invocation. Shared with the
+		// team-context two-phase clone so the two paths cannot drift.
+		cloneArgs := append(gitserver.CredentialHelperArgs(), gitHTTPTimeoutFlags()...)
 		// Belt-and-suspenders hardening on the daemon's auto-clone path:
 		//   - protocol.{file,ext}.allow=never disables ext::sh:// transport (CVE-2017-1000117
 		//     class) and file:// fetch from submodules / .gitmodules, even though we already
@@ -1912,7 +1908,10 @@ func (s *SyncScheduler) Checkout(payload CheckoutPayload, progress *ProgressWrit
 			"-c", "protocol.ext.allow=never",
 			"clone", "--quiet", "--", cloneURL, payload.RepoPath,
 		)
-		cloneCmd := exec.CommandContext(ctx, "git", cloneArgs...)
+		// NewNetworkCmd sets GIT_TERMINAL_PROMPT=0 so a credential gap fails
+		// fast instead of EOFing on a username prompt in the daemon's TTY-less
+		// environment.
+		cloneCmd := gitutil.NewNetworkCmd(ctx, cloneArgs...)
 		// set cmd.Dir so git doesn't fail when daemon CWD has been deleted
 		if parentDir := filepath.Dir(payload.RepoPath); parentDir != "" {
 			_ = os.MkdirAll(parentDir, 0755)
@@ -2010,8 +2009,10 @@ func (s *SyncScheduler) remoteRefCheck(ctx context.Context, repoPath string) boo
 		remoteRef = "refs/heads/" + strings.TrimPrefix(upstream, "origin/")
 	}
 
-	// git ls-remote origin <ref> — single HTTP round-trip, no local locks
-	lsCmd := exec.CommandContext(lsCtx, "git", "-C", repoPath, "ls-remote", "origin", remoteRef)
+	// git ls-remote origin <ref> — single HTTP round-trip, no local locks.
+	// NewNetworkCmd disables the credential prompt so a missing/expired PAT
+	// fails fast here instead of hanging, then falls through to the full fetch.
+	lsCmd := gitutil.NewNetworkCmd(lsCtx, "-C", repoPath, "ls-remote", "origin", remoteRef)
 	lsOut, err := lsCmd.Output()
 	if err != nil {
 		s.logger.Debug("ls-remote failed, falling through to fetch", "path", repoPath, "error", err)

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -224,7 +224,9 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 	fetchCtx, fetchSpan := perf.Start(ctx, "git_fetch")
 	fetchArgs := append([]string{"-C", path}, gitHTTPTimeoutFlags()...)
 	fetchArgs = append(fetchArgs, "fetch", "--quiet")
-	fetchCmd := exec.CommandContext(fetchCtx, "git", fetchArgs...)
+	// NewNetworkCmd disables the credential prompt so a lapsed PAT fails fast
+	// instead of hanging the daemon's background sync cycle on a TTY-less prompt.
+	fetchCmd := gitutil.NewNetworkCmd(fetchCtx, fetchArgs...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		perf.RecordError(fetchSpan, err)
 		fetchSpan.End()
@@ -284,7 +286,7 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 	_, pullSpan := perf.Start(ctx, "git_pull_rebase")
 	pullArgs := append([]string{"-C", path}, gitHTTPTimeoutFlags()...)
 	pullArgs = append(pullArgs, "pull", "--rebase", "--autostash", "--quiet")
-	pullCmd := exec.CommandContext(ctx, "git", pullArgs...)
+	pullCmd := gitutil.NewNetworkCmd(ctx, pullArgs...)
 	output, err := pullCmd.CombinedOutput()
 	if err != nil {
 		perf.RecordError(pullSpan, err)

--- a/internal/gitserver/helper_config.go
+++ b/internal/gitserver/helper_config.go
@@ -40,6 +40,24 @@ func DefaultHelperCommand() string {
 	return "!ox git-credential-helper"
 }
 
+// CredentialHelperArgs returns the `-c` flags that install the ox-managed
+// credential helper for a single git invocation, without touching the repo's
+// persisted .git/config. The leading empty `credential.helper=` clears any
+// inherited helpers so ours is authoritative for that one command; the second
+// installs the ox helper.
+//
+// Use this on network git operations that run before the helper has been
+// written into .git/config — notably the initial clone (the repo doesn't
+// exist yet, so InstallCredentialHelper can't be called first). Both the
+// ledger full-clone and the team-context two-phase clone build their clone
+// argv from this so the two paths cannot drift.
+func CredentialHelperArgs() []string {
+	return []string{
+		"-c", "credential.helper=",
+		"-c", "credential.helper=" + DefaultHelperCommand(),
+	}
+}
+
 // HelperConfig holds the parameters needed to install an ox-managed git
 // credential helper into a single repo's .git/config. The shell command
 // the helper invokes is produced by the cmd/ox layer (see HelperCommandString)

--- a/internal/gitserver/helper_config_test.go
+++ b/internal/gitserver/helper_config_test.go
@@ -1,0 +1,24 @@
+package gitserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCredentialHelperArgs verifies the shared credential-helper argv used by
+// both the ledger full-clone and the team-context two-phase clone.
+// Failure prevented: one clone path drifts and stops supplying credentials,
+// reintroducing the non-interactive username prompt.
+func TestCredentialHelperArgs(t *testing.T) {
+	orig := DefaultHelperCommand()
+	t.Cleanup(func() { SetHelperCommand(orig) })
+	SetHelperCommand("!ox git-credential-helper")
+	args := CredentialHelperArgs()
+
+	// exactly: clear inherited helpers, then install the ox helper
+	assert.Equal(t, []string{
+		"-c", "credential.helper=",
+		"-c", "credential.helper=!ox git-credential-helper",
+	}, args)
+}

--- a/internal/gitserver/two_phase_clone.go
+++ b/internal/gitserver/two_phase_clone.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -41,6 +41,12 @@ var TestAllowFileTransport bool
 // This function is used by both the daemon (normal path) and the CLI
 // (doctor fallback when daemon unavailable).
 //
+// cloneURL MUST be bare (no embedded oauth2:TOKEN userinfo). Credentials are
+// resolved via the ox credential helper — installed as argv flags on the
+// phase-1 clone and persisted into .git/config afterward. Passing a
+// token-embedded URL would leak the PAT into .git/config (forbidden by
+// ox-eeqi) without changing behavior.
+//
 // TODO(investigate): go-git v6 has native support for this entire sequence:
 //   - CloneOptions.Filter, Depth, NoCheckout, SingleBranch for phase 1
 //   - CheckoutOptions.SparseCheckoutDirectories for phase 2
@@ -58,33 +64,11 @@ func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string) (*TwoPhaseClo
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
 		return nil, fmt.Errorf("create parent dir %s: %w", parentDir, err)
 	}
-	// Hardening: `-c protocol.{file,ext}.allow=never` disables file:// and
-	// ext::sh:// transports for this invocation, in case a malicious submodule
-	// or redirect tries to coerce git into a CVE-2017-1000117-class fetch.
-	// `--` terminates option parsing so a hostile URL starting with "-" is
-	// treated as a positional, not a flag.
-	//
-	// TestAllowFileTransport is a test-only override (see its godoc); ext://
-	// hardening is always applied — no production or test code legitimately
-	// needs it.
-	cloneArgs := gitutil.GitHTTPTimeoutFlags()
-	if !TestAllowFileTransport {
-		cloneArgs = append(cloneArgs, "-c", "protocol.file.allow=never")
-	}
-	cloneArgs = append(cloneArgs,
-		"-c", "protocol.ext.allow=never",
-		"clone",
-		"--filter=blob:none",
-		"--depth=1",
-		"--sparse",
-		"--no-checkout",
-		"--single-branch",
-		"--branch", "main",
-		"--quiet",
-		"--",
-		cloneURL, repoPath,
-	)
-	cloneCmd := exec.CommandContext(ctx, "git", cloneArgs...)
+	// NewNetworkCmd sets GIT_TERMINAL_PROMPT=0 so a credential gap fails fast
+	// with a clear error instead of EOFing on a username prompt in the
+	// TTY-less daemon (and doctor fallback). Credentials are supplied via the
+	// helper flags in phaseOneCloneArgs.
+	cloneCmd := gitutil.NewNetworkCmd(ctx, phaseOneCloneArgs(cloneURL, repoPath)...)
 	cloneCmd.Dir = parentDir
 	if output, err := cloneCmd.CombinedOutput(); err != nil {
 		sanitized := gitutil.SanitizeOutput(string(output))
@@ -92,6 +76,23 @@ func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string) (*TwoPhaseClo
 			return nil, fmt.Errorf("phase 1 clone failed: %s", sanitized)
 		}
 		return nil, fmt.Errorf("phase 1 clone failed: %w", err)
+	}
+
+	// Install the ox-managed credential helper into the fresh clone's
+	// .git/config so the phase-2 `fetch --unshallow` below and all later
+	// fetch/pull operations resolve credentials via the helper. The phase-1
+	// clone above carries the helper via argv (the repo didn't exist yet);
+	// from here on it lives in .git/config. Host-scoped to the clone host so
+	// it never fires for unrelated remotes. Best-effort — file:// test clones
+	// have no host and unshallow is non-fatal anyway.
+	if host := cloneHost(cloneURL); host != "" {
+		if err := InstallCredentialHelper(repoPath, HelperConfig{
+			Host:    host,
+			Command: DefaultHelperCommand(),
+		}); err != nil {
+			slog.Warn("two-phase clone: failed to install credential helper",
+				"path", repoPath, "host", host, "error", err)
+		}
 	}
 
 	// materialize only .sageox/ to read the manifest.
@@ -161,6 +162,53 @@ func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string) (*TwoPhaseClo
 		ManifestConfig: cfg,
 		SparsePaths:    sparsePaths,
 	}, nil
+}
+
+// phaseOneCloneArgs builds the argv for the phase-1 partial clone.
+//
+// Credential-helper flags come first so git resolves the PAT via the
+// ox-managed helper instead of prompting (the team-context clone is given a
+// bare URL — no embedded userinfo). Then protocol hardening:
+// `-c protocol.{file,ext}.allow=never` disables file:// and ext::sh://
+// transports for this invocation, in case a malicious submodule or redirect
+// tries to coerce git into a CVE-2017-1000117-class fetch. `--` terminates
+// option parsing so a hostile URL starting with "-" is treated as a
+// positional, not a flag.
+//
+// TestAllowFileTransport is a test-only override (see its godoc); ext://
+// hardening is always applied — no production or test code legitimately
+// needs it.
+func phaseOneCloneArgs(cloneURL, repoPath string) []string {
+	args := CredentialHelperArgs()
+	args = append(args, gitutil.GitHTTPTimeoutFlags()...)
+	if !TestAllowFileTransport {
+		args = append(args, "-c", "protocol.file.allow=never")
+	}
+	args = append(args,
+		"-c", "protocol.ext.allow=never",
+		"clone",
+		"--filter=blob:none",
+		"--depth=1",
+		"--sparse",
+		"--no-checkout",
+		"--single-branch",
+		"--branch", "main",
+		"--quiet",
+		"--",
+		cloneURL, repoPath,
+	)
+	return args
+}
+
+// cloneHost extracts the host from a clone URL for credential-helper scoping.
+// Returns "" for URLs without an https host (e.g. file:// test clones), in
+// which case no helper is installed.
+func cloneHost(cloneURL string) string {
+	u, err := url.Parse(cloneURL)
+	if err != nil || u.Scheme != "https" {
+		return ""
+	}
+	return u.Hostname()
 }
 
 // ValidateTeamContextClone checks that a freshly cloned team context has

--- a/internal/gitserver/two_phase_clone_test.go
+++ b/internal/gitserver/two_phase_clone_test.go
@@ -10,6 +10,87 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestPhaseOneCloneArgs_IncludesCredentialHelper locks in the fix for the
+// team-context clone that prompted for a username non-interactively.
+// Failure prevented: the phase-1 clone shells out with a bare URL and no
+// credential helper, so git prompts for a username and EOFs in the daemon.
+func TestPhaseOneCloneArgs_IncludesCredentialHelper(t *testing.T) {
+	orig := DefaultHelperCommand()
+	t.Cleanup(func() { SetHelperCommand(orig) })
+	SetHelperCommand("!ox git-credential-helper")
+	args := phaseOneCloneArgs("https://git.sageox.ai/team/ctx.git", "/tmp/ctx")
+
+	// credential helper must be present: empty reset followed by the ox helper
+	require.Contains(t, args, "credential.helper=")
+	require.Contains(t, args, "credential.helper=!ox git-credential-helper")
+
+	// the credential helper must precede the `clone` verb (config flags only
+	// apply when they come before the subcommand)
+	cloneIdx := indexOf(args, "clone")
+	helperIdx := indexOf(args, "credential.helper=!ox git-credential-helper")
+	require.GreaterOrEqual(t, cloneIdx, 0, "clone verb present")
+	require.GreaterOrEqual(t, helperIdx, 0, "helper present")
+	assert.Less(t, helperIdx, cloneIdx, "credential helper must come before clone verb")
+
+	// partial-clone shape preserved
+	assert.Contains(t, args, "--filter=blob:none")
+	assert.Contains(t, args, "--depth=1")
+	assert.Contains(t, args, "--no-checkout")
+
+	// `--` terminates options; URL and path are the trailing positionals
+	assert.Equal(t, "https://git.sageox.ai/team/ctx.git", args[len(args)-2])
+	assert.Equal(t, "/tmp/ctx", args[len(args)-1])
+	assert.Equal(t, "--", args[len(args)-3])
+
+	// protocol hardening present by default
+	assert.Contains(t, args, "protocol.ext.allow=never")
+	assert.Contains(t, args, "protocol.file.allow=never")
+}
+
+// TestPhaseOneCloneArgs_FileTransportOverride verifies the test-only escape
+// hatch drops the file:// hardening so local bare-repo clones work in tests.
+func TestPhaseOneCloneArgs_FileTransportOverride(t *testing.T) {
+	TestAllowFileTransport = true
+	t.Cleanup(func() { TestAllowFileTransport = false })
+
+	args := phaseOneCloneArgs("file:///tmp/bare.git", "/tmp/ctx")
+	assert.NotContains(t, args, "protocol.file.allow=never",
+		"file transport hardening must be dropped under the test override")
+	// ext hardening always applies
+	assert.Contains(t, args, "protocol.ext.allow=never")
+}
+
+// TestCloneHost verifies credential-helper scoping only targets https hosts.
+// Failure prevented: installing a helper for file:// test clones (no host) or
+// scoping it wrong so it fires for unrelated remotes.
+func TestCloneHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		cloneURL string
+		want     string
+	}{
+		{"https with path", "https://git.sageox.ai/team/ctx.git", "git.sageox.ai"},
+		{"https with port", "https://git.sageox.ai:443/team/ctx.git", "git.sageox.ai"},
+		{"file scheme has no host", "file:///tmp/bare.git", ""},
+		{"ssh scheme ignored", "git@git.sageox.ai:team/ctx.git", ""},
+		{"garbage", "::not-a-url::", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, cloneHost(tt.cloneURL))
+		})
+	}
+}
+
+func indexOf(s []string, target string) int {
+	for i, v := range s {
+		if v == target {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestValidateTeamContextClone_CoreFilesPresent(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "SOUL.md"), []byte("# Soul"), 0644))

--- a/internal/gitutil/cmd.go
+++ b/internal/gitutil/cmd.go
@@ -1,0 +1,31 @@
+package gitutil
+
+import (
+	"context"
+	"os"
+	"os/exec"
+)
+
+// NewNetworkCmd builds an *exec.Cmd for a git operation that talks to a remote
+// (clone, fetch, ls-remote, push). It is the single chokepoint that guarantees
+// every network git invocation runs non-interactively.
+//
+// GIT_TERMINAL_PROMPT=0: ox resolves credentials via the ox-managed credential
+// helper, never an interactive prompt. Without this, a credential gap makes git
+// prompt for a username on a TTY that the daemon (and doctor fallbacks) don't
+// have — the prompt EOFs into a confusing "could not read Username ...
+// Input/output error" instead of a clear auth failure.
+//
+// Use this for every direct exec.Command("git", ...) network call so the env
+// hardening can't be forgotten in one path while present in another — the exact
+// drift that let the team-context clone prompt non-interactively while the
+// ledger clone did not. RunGit applies the same env for calls that route
+// through it; this covers the call sites that build their own *exec.Cmd
+// (because they need to set Env, capture output differently, etc.).
+//
+// The caller still sets Dir and appends any credential/protocol/timeout flags.
+func NewNetworkCmd(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	return cmd
+}

--- a/internal/gitutil/cmd_test.go
+++ b/internal/gitutil/cmd_test.go
@@ -1,0 +1,24 @@
+package gitutil
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewNetworkCmd_DisablesPrompt locks in the single invariant the chokepoint
+// exists for: every network git command runs non-interactively.
+// Failure prevented: a network git exec omits GIT_TERMINAL_PROMPT=0 and a
+// credential gap prompts for a username on a TTY-less daemon, EOFing into a
+// confusing "could not read Username ... Input/output error" (the original
+// team-context clone bug).
+func TestNewNetworkCmd_DisablesPrompt(t *testing.T) {
+	cmd := NewNetworkCmd(context.Background(), "ls-remote", "origin")
+
+	assert.True(t, slices.Contains(cmd.Env, "GIT_TERMINAL_PROMPT=0"),
+		"network git commands must disable the interactive credential prompt")
+	// the args are passed through verbatim after the git binary
+	assert.Equal(t, []string{"git", "ls-remote", "origin"}, cmd.Args)
+}

--- a/internal/gitutil/run.go
+++ b/internal/gitutil/run.go
@@ -3,6 +3,7 @@ package gitutil
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -23,6 +24,13 @@ func RunGit(ctx context.Context, repoPath string, args ...string) (string, error
 	if repoPath != "" {
 		cmd.Dir = repoPath
 	}
+	// GIT_TERMINAL_PROMPT=0: ox runs git non-interactively (daemon, CLI
+	// fallbacks). Without this, a network op missing credentials prompts for
+	// a username on a TTY that isn't there and EOFs into a confusing
+	// "could not read Username ... Input/output error". Disabling the prompt
+	// makes any credential gap fail fast with a clear error. Tests already
+	// set this via internal/testenv, so their behavior is unchanged.
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.CombinedOutput()
 	sanitized := SanitizeOutput(strings.TrimSpace(string(output)))
 


### PR DESCRIPTION
## What broke

A customer (`apurva`, ox 0.9.0) could not sync team context. `ox doctor --fix` and the daemon failed during "Reading manifest and materializing files…":

```
phase 1 clone failed: fatal: could not read Username for 'https://git.sageox.ai': Input/output error
```

The daemon clones **ledgers** and **team-contexts** through different code, and only the ledger path supplied credentials. The team-context clone (`gitserver.TwoPhaseClone`) shelled out `git clone` with a **bare URL, no credential helper, and no `GIT_TERMINAL_PROMPT=0`**. With no credentials and no TTY, git prompted for a username and EOF'd. The PAT (in the OS keychain / `git-credentials-<endpoint>.json`) was never consulted because git failed before any helper ran. The comment at `sync.go` even *claimed* the clone used a helper — only the ledger branch did. The two paths had drifted.

```mermaid
flowchart TD
    A["daemon Checkout"] --> B{"repo type"}
    B -->|ledger| C["clone WITH credential helper, WORKS"]
    B -->|team-context| D["TwoPhaseClone, bare URL, no helper, no prompt guard"]
    D --> E["git prompts for Username, daemon has no TTY"]
    E --> F["could not read Username for git.sageox.ai: Input/output error"]
```

## What this PR ships

- **Team-context clone now authenticates.** `TwoPhaseClone` supplies the ox credential helper on the phase-1 clone (via argv) and installs it into `.git/config` afterward, so `fetch --unshallow` and all later pulls authenticate too. Host-scoped to the clone host.
- **Single chokepoint for non-interactive git** — new `gitutil.NewNetworkCmd` sets `GIT_TERMINAL_PROMPT=0` on every network git exec, so a credential gap **fails fast with a clear error instead of hanging**. This is the structural fix: the prompt guard can no longer be present in one clone path and absent in another. Routed through it: team-context clone, ledger clone, daemon background **fetch / pull**, and `ls-remote`. `gitutil.RunGit` applies the same env for calls that route through it.
- **Shared `CredentialHelperArgs()`** — both the ledger full-clone and the team-context two-phase clone build their credential flags from one function so they cannot drift again.
- **Closed a PAT-leak path** — the doctor fallback previously embedded the token in the clone URL (`BuildAuthURL`), which would persist into `.git/config`. It now passes the bare URL and lets the helper resolve the PAT (per ox-eeqi: no embedded tokens in `.git/config`).
- **Clearer doctor errors** — surfaces the real ledger-status reason (e.g. `status=pending`) instead of a flat "cloud has not provisioned" string, so users can distinguish provisioning-pending from auth/network failure.

## Why testing didn't catch it (structural)

The test harness sets `GIT_TERMINAL_PROMPT=0` **process-wide** (`internal/testenv/gitenv.go`). So every test ran with prompts disabled while production did not — a missing credential fails fast in tests but *hangs/EOFs* in the daemon. Tests passed precisely because they could not reproduce the prod failure mode. The new `NewNetworkCmd` makes the prod behavior the default for network execs; new unit tests assert both the credential-helper flags and the prompt-disable env.

## Customer questions answered

- **"Should ox feed the PAT automatically + set `GIT_TERMINAL_PROMPT=0`?"** — Yes to both, now done. No manual git config needed; on the fixed build `ox doctor --fix` clones the team-context without prompting.
- **Ledger not provisioned** (Issue 2) — server-side only; CLI cannot trigger it (by design). Tracked separately for backend confirmation. The CLI now shows the real status.

## Test Plan

- `make lint` → 0 issues; `go build ./...` clean.
- `go test ./internal/gitutil/ ./internal/gitserver/ ./internal/daemon/ ./cmd/ox/` → pass.
- New unit tests: `phaseOneCloneArgs` includes credential-helper flags before the `clone` verb; `cloneHost` scopes https-only; `CredentialHelperArgs` shape; `NewNetworkCmd` sets `GIT_TERMINAL_PROMPT=0`.
- Manual: with the daemon running, `ox doctor --fix` against a real `git.sageox.ai` team-context clones without a username prompt.

## Follow-ups (filed)

- `ox-hjak` — doctor check: verify team-context credential helper in `.git/config`
- `ox-h1by` — daemon startup self-heal for team-context helper (anti-entropy)
- `ox-z2sq` — hermetic https git-server integration test (exercises the real credential path; the test that would have caught this class)
- `ox-z8g7` — sweep remaining foreground CLI/ledger network git execs through `NewNetworkCmd`
- `[HUMAN]` — confirm/trigger ledger provisioning for `team_bnwyabtkyo`

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed git clone and fetch operations that could hang indefinitely when credentials are unavailable in non-interactive environments.
  * Improved error messages to clearly explain why repository provisioning failed.

* **Improvements**
  * Enhanced credential helper configuration management for more reliable repository operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->