### PR TITLE
ox status: dense knowledge-bubble listing + bump to 0.9.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.9.0"
+      "version": "0.9.1"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **`ox status` knowledge bubbles, denser and more useful** — the bubble section used to print a bare count (`9 (8 team, 1 repo)`) and then repeat every team again under "Other Team Contexts" with a full filesystem path on each row. It's now an owner-grouped tree: each owner is a parent node `@slug  (Display Name)` with its knowledge bubbles nested beneath, each carrying a compact, color-coded freshness status (`✓ 2h`, `⚠ 6 uncommitted`). The shared on-disk prefix is printed once instead of per row, owners that need attention sort to the top, and slugs are never truncated. Since nearly every bubble is private, private is the silent default and only **PUBLIC** bubbles are flagged (bold, in the public accent color). Add `--verbose`/`-v` to reveal the opaque IDs and full paths.
-
 ## [0.9.1] - 2026-06-08
 
 ### Added
 
 - **`ox plan` — team-context-enriched implementation plans** — turns a plan an AI coworker drafts into one that knows where the team is going. `ox plan` annotates each part of a plan with deterministic, locally-computed signals (zero model tokens): **collisions** (a file you're about to touch is in a teammate's open PR — or one they murmured about minutes ago, before any commit exists), **prior art** (a teammate already planned or did this — surfaced from the ledger), and **expert routing** (who owns this area, with cited evidence, so you ask the right person). The plan-mode agent then authors the judgment calls — does this align with or conflict with a team decision — reasoning over a context bundle ox assembles. ox makes no model call itself; the inference cost lands in plan mode where you already expect it. Finalized plans are saved to the team ledger (`data/plans/`) as first-class, searchable artifacts, so today's plan becomes tomorrow's prior art. On Claude Code, a renderer skill turns the enriched plan into a beautiful self-contained HTML page for fast human review; other agents get the same enrichment via guidance and the `ox plan` CLI. Configure with `plan.save` and `plan.html` (`off`/`recommend`/`always`), or `SAGEOX_PLAN_HTML` per-run.
+
+### Changed
+
+- **`ox status` knowledge bubbles, denser and more useful** — the bubble section used to print a bare count (`9 (8 team, 1 repo)`) and then repeat every team again under "Other Team Contexts" with a full filesystem path on each row. It's now an owner-grouped tree: each owner is a parent node `@slug  (Display Name)` with its knowledge bubbles nested beneath, each carrying a compact, color-coded freshness status (`✓ 2h`, `⚠ 6 uncommitted`). The shared on-disk prefix is printed once instead of per row, owners that need attention sort to the top, and slugs are never truncated. Since nearly every bubble is private, private is the silent default and only **PUBLIC** bubbles are flagged (bold, in the public accent color). Add `--verbose`/`-v` to reveal the opaque IDs and full paths.
 
 ## [0.9.0] - 2026-05-28
 

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`ox status` knowledge bubbles, denser and more useful** — the bubble section used to print a bare count (`9 (8 team, 1 repo)`) and then repeat every team again under "Other Team Contexts" with a full filesystem path on each row. It's now a single, scannable listing: each owner shown as `@slug` with a compact, color-coded freshness status (`✓ 2h`, `⚠ 6 uncommitted`), the shared on-disk prefix printed once instead of per row, and teams that need attention (uncommitted or wedged) sorted to the top. Add `--verbose`/`-v` to reveal the opaque IDs and full paths when you need them.
+
+## [0.9.1] - 2026-06-08
+
 ### Added
 
 - **`ox plan` — team-context-enriched implementation plans** — turns a plan an AI coworker drafts into one that knows where the team is going. `ox plan` annotates each part of a plan with deterministic, locally-computed signals (zero model tokens): **collisions** (a file you're about to touch is in a teammate's open PR — or one they murmured about minutes ago, before any commit exists), **prior art** (a teammate already planned or did this — surfaced from the ledger), and **expert routing** (who owns this area, with cited evidence, so you ask the right person). The plan-mode agent then authors the judgment calls — does this align with or conflict with a team decision — reasoning over a context bundle ox assembles. ox makes no model call itself; the inference cost lands in plan mode where you already expect it. Finalized plans are saved to the team ledger (`data/plans/`) as first-class, searchable artifacts, so today's plan becomes tomorrow's prior art. On Claude Code, a renderer skill turns the enriched plan into a beautiful self-contained HTML page for fast human review; other agents get the same enrichment via guidance and the `ox plan` CLI. Configure with `plan.save` and `plan.html` (`off`/`recommend`/`always`), or `SAGEOX_PLAN_HTML` per-run.
@@ -156,6 +162,7 @@ New tests pin the scope contract, the auto-redact happy path, the quarantine pat
 **Code search resilience**
 - `codedb` self-heals a corrupt bleve sub-index without forcing a full reindex. On large repos this drops recovery time from "several hours" to "2–5 minutes."
 
+[0.9.1]: https://github.com/sageox/ox/releases/tag/v0.9.1
 [0.9.0]: https://github.com/sageox/ox/releases/tag/v0.9.0
 [0.8.0]: https://github.com/sageox/ox/releases/tag/v0.8.0
 

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`ox status` knowledge bubbles, denser and more useful** — the bubble section used to print a bare count (`9 (8 team, 1 repo)`) and then repeat every team again under "Other Team Contexts" with a full filesystem path on each row. It's now a single, scannable listing: each owner shown as `@slug` with a compact, color-coded freshness status (`✓ 2h`, `⚠ 6 uncommitted`), the shared on-disk prefix printed once instead of per row, and teams that need attention (uncommitted or wedged) sorted to the top. Add `--verbose`/`-v` to reveal the opaque IDs and full paths when you need them.
+- **`ox status` knowledge bubbles, denser and more useful** — the bubble section used to print a bare count (`9 (8 team, 1 repo)`) and then repeat every team again under "Other Team Contexts" with a full filesystem path on each row. It's now an owner-grouped tree: each owner is a parent node `@slug  (Display Name)` with its knowledge bubbles nested beneath, each carrying a compact, color-coded freshness status (`✓ 2h`, `⚠ 6 uncommitted`). The shared on-disk prefix is printed once instead of per row, owners that need attention sort to the top, and slugs are never truncated. Since nearly every bubble is private, private is the silent default and only **PUBLIC** bubbles are flagged (bold, in the public accent color). Add `--verbose`/`-v` to reveal the opaque IDs and full paths.
 
 ## [0.9.1] - 2026-06-08
 

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -44,9 +44,11 @@ type statusTeamContextJSON = status.TeamContextJSON
 type statusDaemonJSON = status.DaemonJSON
 
 var statusJSONFlag bool
+var statusVerboseFlag bool
 
 func init() {
 	statusCmd.Flags().BoolVar(&statusJSONFlag, "json", false, "output in JSON format")
+	statusCmd.Flags().BoolVarP(&statusVerboseFlag, "verbose", "v", false, "show opaque IDs and full on-disk paths")
 }
 
 // status command styles - Tufte-inspired minimal design with brand colors
@@ -401,7 +403,7 @@ func shortenPathViaSymlink(projectRoot, fullPath string, candidates ...string) s
 
 // Shows ledger and team contexts grouped by endpoint
 // Always renders both sections, showing "(none)" if not configured
-func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, daemonStatus *daemon.StatusData, bubblesSummary statusBubblesSummary) string {
+func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, daemonStatus *daemon.StatusData, bubblesSummary statusBubblesSummary, verbose bool) string {
 	var b strings.Builder
 
 	hasLedger := localCfg != nil && localCfg.Ledger != nil && localCfg.Ledger.Path != ""
@@ -890,29 +892,82 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 		b.WriteString("\n")
 	}
 
-	// Knowledge bubbles summary — rendered as the last line of the
-	// project-status block, immediately above "Other Team Contexts" so the
-	// kb noun is adjacent to the team contexts it (eventually) supersedes
-	// without dominating the project-state header.
-	b.WriteString(renderBubblesLine(bubblesSummary))
-
-	// Other team contexts
-	hasOtherTCs := len(otherCloudTCs) > 0 || len(otherDetailTCs) > 0
-	if hasOtherTCs {
-		b.WriteString("\n")
-		b.WriteString(statusHeaderStyle.Render("Other Team Contexts"))
-		b.WriteString("\n")
-		b.WriteString(statusMutedStyle.Render("───────────────────"))
-		b.WriteString("\n")
-
-		for _, entry := range otherCloudTCs {
-			hasAnyTeams = true
-			renderCloudTC(entry.info)
+	// Knowledge bubbles — dense, owner-grouped listing of the team contexts
+	// available beyond this repo. Replaces the old count-only line plus the
+	// "Other Team Contexts" section, which duplicated these teams and printed
+	// a full on-disk path per row. Each owner shows as @slug with a compact,
+	// color-coded status; the shared path prefix is printed once. This-repo's
+	// ledger and primary team stay in Project Status above.
+	buildOtherRow := func(name, slug, teamID, visibility, access string) otherTeamRow {
+		if slug == "" {
+			slug = api.DeriveSlug(name)
 		}
-		for _, entry := range otherDetailTCs {
-			hasAnyTeams = true
-			renderDetailTC(entry.info)
+		expectedPath := paths.TeamContextDir(teamID, projectEndpoint)
+		row := otherTeamRow{name: name, slug: slug, visibility: visibility, access: access, path: expectedPath}
+		if _, err := os.Stat(filepath.Join(expectedPath, ".git")); err == nil {
+			row.cloned = true
+			var lastSync time.Time
+			hasSync := false
+			if ds, ok := daemonStatus.LastSyncForPath(expectedPath); ok {
+				lastSync, hasSync = ds, true
+			} else if localCfg != nil {
+				if tc := localCfg.GetTeamContext(teamID); tc != nil && tc.HasLastSync() {
+					lastSync, hasSync = tc.LastSync, true
+				}
+			}
+			row.st = getGitRepoStatus(expectedPath, lastSync, hasSync)
 		}
+		row.attention = !row.cloned || row.st.Error != "" || row.st.UncommittedCount > 0 || row.st.IsWedged()
+		return row
+	}
+
+	var otherRows []otherTeamRow
+	seenBubblePath := make(map[string]bool)
+	for _, entry := range otherCloudTCs {
+		visibility, access := "private", "member"
+		if d, ok := teamDetail[entry.info.StableID()]; ok {
+			if d.Visibility != "" {
+				visibility = d.Visibility
+			}
+			if d.AccessLevel != "" {
+				access = d.AccessLevel
+			}
+		}
+		row := buildOtherRow(entry.info.Name, entry.info.Slug, entry.info.StableID(), visibility, access)
+		if seenBubblePath[row.path] {
+			continue
+		}
+		seenBubblePath[row.path] = true
+		otherRows = append(otherRows, row)
+	}
+	for _, entry := range otherDetailTCs {
+		visibility := entry.info.Visibility
+		if visibility == "" {
+			visibility = "private"
+		}
+		row := buildOtherRow(entry.info.Name, entry.info.Slug, entry.info.StableID(), visibility, entry.info.AccessLevel)
+		if seenBubblePath[row.path] {
+			continue
+		}
+		seenBubblePath[row.path] = true
+		otherRows = append(otherRows, row)
+	}
+
+	sortOtherBubbleRows(otherRows)
+
+	if len(otherRows) > 0 {
+		hasAnyTeams = true
+	}
+
+	if bubblesSummary.Total > 0 || len(otherRows) > 0 {
+		b.WriteString("\n")
+		b.WriteString(statusHeaderStyle.Render("Knowledge bubbles"))
+		b.WriteString("  ")
+		b.WriteString(statusMutedStyle.Render(bubblesCountSummary(bubblesSummary, len(otherRows))))
+		b.WriteString("\n")
+		b.WriteString(statusMutedStyle.Render("─────────────────"))
+		b.WriteString("\n")
+		b.WriteString(renderOtherBubbleRows(otherRows, daemonStatus.IsBootstrapping(), verbose))
 	}
 
 	if !hasAnyTeams && repoTeamID == "" {
@@ -1578,7 +1633,7 @@ daemon health, and a tree view of all SageOx directory locations.`,
 			// Knowledge-bubbles summary is rendered inside renderGitReposSection
 			// (just above "Other Team Contexts") so the kb line is the
 			// last line of the project-state block, not sandwiched mid-header.
-			fmt.Print(renderGitReposSection(localCfg, gitRoot, daemonStatus, bubblesSummary))
+			fmt.Print(renderGitReposSection(localCfg, gitRoot, daemonStatus, bubblesSummary, statusVerboseFlag))
 
 			// show daemon sync section
 			fmt.Print(renderDaemonSyncSection(daemonStatus, syncHistory, localCfg, false, projectInitialized))

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -967,7 +967,16 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 		b.WriteString("\n")
 		b.WriteString(statusMutedStyle.Render("─────────────────"))
 		b.WriteString("\n")
-		b.WriteString(renderOtherBubbleRows(otherRows, daemonStatus.IsBootstrapping(), verbose))
+		if len(otherRows) > 0 {
+			b.WriteString(renderOtherBubbleRows(otherRows, daemonStatus.IsBootstrapping(), verbose))
+		} else {
+			// bubbles exist (e.g. personal/profile) but none are team contexts
+			// cloned locally — point at the full list rather than leave an
+			// empty block under the header.
+			b.WriteString(statusLabelStyle.Render(""))
+			b.WriteString(statusMutedStyle.Render("no team contexts cloned locally — run 'ox kb list' to see all bubbles"))
+			b.WriteString("\n")
+		}
 	}
 
 	if !hasAnyTeams && repoTeamID == "" {

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -903,7 +903,7 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 			slug = api.DeriveSlug(name)
 		}
 		expectedPath := paths.TeamContextDir(teamID, projectEndpoint)
-		row := otherTeamRow{name: name, slug: slug, visibility: visibility, access: access, path: expectedPath}
+		row := otherTeamRow{name: name, slug: slug, bubbleType: "team", visibility: visibility, access: access, path: expectedPath}
 		if _, err := os.Stat(filepath.Join(expectedPath, ".git")); err == nil {
 			row.cloned = true
 			var lastSync time.Time

--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -323,8 +323,11 @@ func renderOtherBubbleRows(rows []otherTeamRow, bootstrapping, verbose bool) str
 	}
 	var b strings.Builder
 
-	// shared on-disk prefix, printed once instead of per row
-	base := filepath.Dir(rows[0].path)
+	// shared on-disk prefix, printed once instead of per row. Derived from the
+	// directory common to ALL rows (not just rows[0], which attention-sort may
+	// reorder), so the header stays accurate if bubbles ever span different
+	// parents (e.g. teams/ and kb/).
+	base := commonBubbleBase(rows)
 	b.WriteString(statusLabelStyle.Render("  on disk"))
 	b.WriteString(statusMutedStyle.Render(shortenHome(base) + string(os.PathSeparator)))
 	b.WriteString("\n\n")
@@ -363,6 +366,38 @@ func renderOtherBubbleRows(rows []otherTeamRow, bootstrapping, verbose bool) str
 // every bubble is private, flagging only the exception is what makes it pop.
 func renderPublicFlag() string {
 	return statusPublicStyle.Bold(true).Render("PUBLIC")
+}
+
+// commonBubbleBase returns the deepest directory shared by every row's parent,
+// so the "on disk" header is truthful even when rows live under different
+// parents. With the usual single-parent case it just returns that parent.
+func commonBubbleBase(rows []otherTeamRow) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	base := filepath.Dir(rows[0].path)
+	for _, r := range rows[1:] {
+		base = commonDir(base, filepath.Dir(r.path))
+	}
+	return base
+}
+
+// commonDir returns the longest shared leading directory of a and b.
+func commonDir(a, b string) string {
+	if a == b {
+		return a
+	}
+	sep := string(os.PathSeparator)
+	as, bs := strings.Split(a, sep), strings.Split(b, sep)
+	n := len(as)
+	if len(bs) < n {
+		n = len(bs)
+	}
+	i := 0
+	for i < n && as[i] == bs[i] {
+		i++
+	}
+	return strings.Join(as[:i], sep)
 }
 
 // renderSlugRef styles a slug reference: the sigil (@ for an owner, # for a

--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -19,9 +19,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	lipgloss "charm.land/lipgloss/v2"
 
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/auth"
@@ -255,4 +259,145 @@ func newDefaultStatusBubblesMerger(projectRoot string) statusBubblesMerger {
 // Production calls newDefaultStatusBubblesMerger; tests assign a fake.
 var statusBubblesMergerForRoot = func(projectRoot string) statusBubblesMerger {
 	return newDefaultStatusBubblesMerger(projectRoot)
+}
+
+// otherTeamRow is one line in the dense Knowledge-bubbles listing: a team
+// context available beyond this repo, with its locally-computed git status.
+type otherTeamRow struct {
+	name       string
+	slug       string
+	visibility string
+	access     string
+	path       string
+	st         gitRepoStatus
+	cloned     bool
+	attention  bool // uncommitted / wedged / not-cloned — sorts to the top
+}
+
+// sortOtherBubbleRows orders the listing needs-attention first (uncommitted /
+// wedged / not-cloned float to the top so problems are seen), then
+// alphabetically by name. Stable so equal rows keep discovery order.
+func sortOtherBubbleRows(rows []otherTeamRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].attention != rows[j].attention {
+			return rows[i].attention
+		}
+		return strings.ToLower(rows[i].name) < strings.ToLower(rows[j].name)
+	})
+}
+
+// column widths for the bubble listing — sized so the widest row fits 80
+// columns: 2 indent + 20 slug + 2 + 26 name + 2 + 7 vis + 2 + status(≤16) = 77.
+const (
+	bubbleSlugColW = 20
+	bubbleNameColW = 26
+	bubbleVisColW  = 7
+)
+
+// bubblesCountSummary describes the bubble totals for the section header,
+// e.g. "13 total · 7 listed". The merger total counts every bubble you can
+// reach (including kb-API and personal bubbles not shown in this team-context
+// list), so we report it as "total" and the rendered count as "listed" rather
+// than claiming a precise in-repo split the two sources can't guarantee.
+// Falls back to the rendered count alone when the merger total is unavailable.
+func bubblesCountSummary(s statusBubblesSummary, others int) string {
+	if s.Unavailable || s.Total == 0 {
+		if others == 1 {
+			return "1 team context listed"
+		}
+		return fmt.Sprintf("%d team contexts listed", others)
+	}
+	return fmt.Sprintf("%d total · %d listed", s.Total, others)
+}
+
+// renderOtherBubbleRows renders the shared on-disk prefix (once) followed by
+// one aligned, color-coded line per team. Returns "" when there are none.
+func renderOtherBubbleRows(rows []otherTeamRow, bootstrapping, verbose bool) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	var b strings.Builder
+
+	// shared on-disk prefix, printed once instead of per row
+	base := filepath.Dir(rows[0].path)
+	b.WriteString(statusLabelStyle.Render("  on disk"))
+	b.WriteString(statusMutedStyle.Render(shortenHome(base) + string(os.PathSeparator)))
+	b.WriteString("\n\n")
+
+	for _, row := range rows {
+		slug := truncateForColumn("@"+row.slug, bubbleSlugColW)
+		name := truncateForColumn(row.name, bubbleNameColW)
+		b.WriteString("  ")
+		b.WriteString(padCell(renderSlugRef(slug[:1], slug[1:]), bubbleSlugColW))
+		b.WriteString("  ")
+		b.WriteString(padCell(statusValueStyle.Render(name), bubbleNameColW))
+		b.WriteString("  ")
+		b.WriteString(padCell(renderVisibility(row.visibility), bubbleVisColW))
+		b.WriteString("  ")
+		b.WriteString(renderBubbleStatus(row.st, row.cloned, bootstrapping))
+		b.WriteString("\n")
+		if verbose {
+			b.WriteString(statusLabelStyle.Render(""))
+			b.WriteString(statusMutedStyle.Render("    " + row.path))
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// renderSlugRef styles a slug reference: the sigil (@ for an owner, # for a
+// bubble) is muted so the slug itself stands out — e.g. dim("@") + bright("sageox").
+func renderSlugRef(sigil, slug string) string {
+	return statusMutedStyle.Render(sigil) + statusValueStyle.Render(slug)
+}
+
+// padCell right-pads a (possibly ANSI-styled) cell to width w using its
+// visible width, so color codes don't break column alignment.
+func padCell(cell string, w int) string {
+	if gap := w - lipgloss.Width(cell); gap > 0 {
+		return cell + strings.Repeat(" ", gap)
+	}
+	return cell
+}
+
+// renderBubbleStatus renders the dense status cell for a bubble's local
+// checkout: a crisp freshness age when clean ("✓ 2h"), the actionable count
+// when dirty ("⚠ 6 uncommitted"), a red ⚠ when wedged, or a clone hint.
+func renderBubbleStatus(st gitRepoStatus, cloned, bootstrapping bool) string {
+	switch {
+	case !cloned:
+		if bootstrapping {
+			return statusMutedStyle.Render("⟳ setting up")
+		}
+		return statusWarningStyle.Render("⚠ not cloned")
+	case st.Error != "":
+		return statusErrorStyle.Render("✗ " + st.Error)
+	case st.IsWedged():
+		// ⚠ glyph in error color — wedged needs eyes like uncommitted, but is worse
+		if st.RebaseInProgress {
+			return statusErrorStyle.Render("⚠ rebase wedged")
+		}
+		return statusErrorStyle.Render("⚠ diverged")
+	case st.UncommittedCount > 0:
+		return statusWarningStyle.Render(fmt.Sprintf("⚠ %d uncommitted", st.UncommittedCount))
+	case st.HasLastSync:
+		return statusSuccessStyle.Render("✓ " + status.CompactAge(st.LastSync))
+	default:
+		return statusSuccessStyle.Render("✓ synced")
+	}
+}
+
+// shortenHome replaces the user's home directory prefix with ~ for display.
+func shortenHome(path string) string {
+	if path == "" {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	if strings.HasPrefix(path, home) {
+		return "~" + strings.TrimPrefix(path, home)
+	}
+	return path
 }

--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/status"
+	"github.com/sageox/ox/internal/ui"
 )
 
 // statusBubblesMerger is the seam between status rendering and the F3
@@ -261,11 +262,14 @@ var statusBubblesMergerForRoot = func(projectRoot string) statusBubblesMerger {
 	return newDefaultStatusBubblesMerger(projectRoot)
 }
 
-// otherTeamRow is one line in the dense Knowledge-bubbles listing: a team
-// context available beyond this repo, with its locally-computed git status.
+// otherTeamRow is one entry in the dense Knowledge-bubbles listing: a bubble
+// available beyond this repo, with its locally-computed git status. Rendered
+// as a 2-line card so the full slug, type, name, visibility, and status all
+// fit without truncating the slug.
 type otherTeamRow struct {
 	name       string
 	slug       string
+	bubbleType string // kb type: "team", "personal", etc. — surfaced so the kind is obvious
 	visibility string
 	access     string
 	path       string
@@ -286,13 +290,10 @@ func sortOtherBubbleRows(rows []otherTeamRow) {
 	})
 }
 
-// column widths for the bubble listing — sized so the widest row fits 80
-// columns: 2 indent + 20 slug + 2 + 26 name + 2 + 7 vis + 2 + status(≤16) = 77.
-const (
-	bubbleSlugColW = 20
-	bubbleNameColW = 26
-	bubbleVisColW  = 7
-)
+// bubbleLabelColW is the width of the nested bubble label column ("(team)",
+// "#slug  (repo)", …) before the status column. Labels never truncate; a
+// wider label just pushes the status right.
+const bubbleLabelColW = 22
 
 // bubblesCountSummary describes the bubble totals for the section header,
 // e.g. "13 total · 7 listed". The merger total counts every bubble you can
@@ -303,15 +304,19 @@ const (
 func bubblesCountSummary(s statusBubblesSummary, others int) string {
 	if s.Unavailable || s.Total == 0 {
 		if others == 1 {
-			return "1 team context listed"
+			return "1 owner listed"
 		}
-		return fmt.Sprintf("%d team contexts listed", others)
+		return fmt.Sprintf("%d owners listed", others)
 	}
-	return fmt.Sprintf("%d total · %d listed", s.Total, others)
+	return fmt.Sprintf("%d total · %d owners", s.Total, others)
 }
 
-// renderOtherBubbleRows renders the shared on-disk prefix (once) followed by
-// one aligned, color-coded line per team. Returns "" when there are none.
+// renderOtherBubbleRows renders the shared on-disk prefix (once) followed by an
+// owner-grouped tree: each owner is a parent node `@slug  (Display Name)` with
+// its knowledge bubbles nested beneath under solid tree glyphs. The owner's own
+// context shows as `(team)`; other bubbles would read `#slug  (type)`. Today
+// every owner has exactly one context bubble, so each renders as a 2-line card —
+// the layout absorbs additional bubbles unchanged. Returns "" when empty.
 func renderOtherBubbleRows(rows []otherTeamRow, bootstrapping, verbose bool) string {
 	if len(rows) == 0 {
 		return ""
@@ -325,24 +330,39 @@ func renderOtherBubbleRows(rows []otherTeamRow, bootstrapping, verbose bool) str
 	b.WriteString("\n\n")
 
 	for _, row := range rows {
-		slug := truncateForColumn("@"+row.slug, bubbleSlugColW)
-		name := truncateForColumn(row.name, bubbleNameColW)
-		b.WriteString("  ")
-		b.WriteString(padCell(renderSlugRef(slug[:1], slug[1:]), bubbleSlugColW))
-		b.WriteString("  ")
-		b.WriteString(padCell(statusValueStyle.Render(name), bubbleNameColW))
-		b.WriteString("  ")
-		b.WriteString(padCell(renderVisibility(row.visibility), bubbleVisColW))
-		b.WriteString("  ")
-		b.WriteString(renderBubbleStatus(row.st, row.cloned, bootstrapping))
+		typeLabel := row.bubbleType
+		if typeLabel == "" {
+			typeLabel = "team"
+		}
+		// owner parent node: @slug (never truncated) + display name
+		b.WriteString(renderSlugRef("@", row.slug))
+		b.WriteString(statusMutedStyle.Render("  (" + row.name + ")"))
 		b.WriteString("\n")
+
+		// nested bubble: the owner's context. └─ because it's the only/last child.
+		b.WriteString(statusMutedStyle.Render(ui.TreeLast))
+		b.WriteString(padCell(statusMutedStyle.Render("("+typeLabel+")"), bubbleLabelColW))
+		b.WriteString(renderBubbleStatus(row.st, row.cloned, bootstrapping))
+		// visibility: private is the silent default; only PUBLIC is flagged.
+		if strings.EqualFold(row.visibility, "public") {
+			b.WriteString("  ")
+			b.WriteString(renderPublicFlag())
+		}
+		b.WriteString("\n")
+
 		if verbose {
-			b.WriteString(statusLabelStyle.Render(""))
-			b.WriteString(statusMutedStyle.Render("    " + row.path))
+			b.WriteString(statusMutedStyle.Render("   " + row.path))
 			b.WriteString("\n")
 		}
 	}
 	return b.String()
+}
+
+// renderPublicFlag renders the PUBLIC visibility marker in bold caps using the
+// public semantic token. Private bubbles render no marker at all — since nearly
+// every bubble is private, flagging only the exception is what makes it pop.
+func renderPublicFlag() string {
+	return statusPublicStyle.Bold(true).Render("PUBLIC")
 }
 
 // renderSlugRef styles a slug reference: the sigil (@ for an owner, # for a

--- a/cmd/ox/status_bubbles_test.go
+++ b/cmd/ox/status_bubbles_test.go
@@ -516,6 +516,10 @@ func TestRenderBubbleStatus(t *testing.T) {
 	wedged := stripANSIBubbles(renderBubbleStatus(gitRepoStatus{Exists: true, RebaseInProgress: true}, true, false))
 	assert.Equal(t, "⚠ rebase wedged", wedged)
 
+	// the other IsWedged() branch: diverged (both ahead and behind)
+	diverged := stripANSIBubbles(renderBubbleStatus(gitRepoStatus{Exists: true, AheadCount: 2, BehindCount: 1}, true, false))
+	assert.Equal(t, "⚠ diverged", diverged)
+
 	notCloned := stripANSIBubbles(renderBubbleStatus(gitRepoStatus{}, false, false))
 	assert.Equal(t, "⚠ not cloned", notCloned)
 }
@@ -529,4 +533,26 @@ func TestRenderSlugRef(t *testing.T) {
 	assert.Equal(t, "@sageox", out)
 	out = stripANSIBubbles(renderSlugRef("#", "marketing"))
 	assert.Equal(t, "#marketing", out)
+}
+
+// TestCommonBubbleBase verifies the "on disk" prefix is the directory shared by
+// ALL rows, so it stays accurate if bubbles ever live under different parents
+// (e.g. teams/ and kb/) — not just the first attention-sorted row's parent.
+func TestCommonBubbleBase(t *testing.T) {
+	t.Parallel()
+
+	d := "/home/u/.local/share/sageox/sageox.ai"
+	// all under teams/ → that shared parent
+	same := []otherTeamRow{
+		{path: d + "/teams/team_a"},
+		{path: d + "/teams/team_b"},
+	}
+	assert.Equal(t, d+"/teams", commonBubbleBase(same))
+
+	// mixed teams/ and kb/ → the endpoint dir they share, not teams/
+	mixed := []otherTeamRow{
+		{path: d + "/teams/team_a"},
+		{path: d + "/kb/kb_x"},
+	}
+	assert.Equal(t, d, commonBubbleBase(mixed))
 }

--- a/cmd/ox/status_bubbles_test.go
+++ b/cmd/ox/status_bubbles_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/config"
@@ -396,4 +397,119 @@ func stripANSIBubbles(s string) string {
 		}
 		s = s[:i] + s[i+j+1:]
 	}
+}
+
+// --- Dense knowledge-bubble listing (owner-grouped @slug tree) ---
+
+// TestBubblesCountSummary verifies the section header reports the merger
+// total and the rendered count truthfully, without claiming a precise
+// in-repo split the two data sources can't guarantee.
+//
+// Failure prevented: a "N in this repo" claim drifts from reality because
+// the merger total counts kb-API/personal bubbles the team-context list omits.
+func TestBubblesCountSummary(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "13 total · 7 listed",
+		bubblesCountSummary(statusBubblesSummary{Total: 13}, 7))
+
+	// merger total unavailable → fall back to the rendered count alone
+	assert.Equal(t, "7 team contexts listed",
+		bubblesCountSummary(statusBubblesSummary{Unavailable: true}, 7))
+	assert.Equal(t, "1 team context listed",
+		bubblesCountSummary(statusBubblesSummary{Total: 0}, 1))
+}
+
+// TestSortOtherBubbleRows_NeedsAttentionFirst verifies dirty/wedged/not-cloned
+// rows float to the top, then alphabetical by name.
+//
+// Failure prevented: a team with uncommitted work is buried mid-list where
+// the user scrolls past it.
+func TestSortOtherBubbleRows_NeedsAttentionFirst(t *testing.T) {
+	t.Parallel()
+
+	rows := []otherTeamRow{
+		{name: "Zulu", cloned: true},                      // clean
+		{name: "Alpha", cloned: true},                     // clean
+		{name: "Bravo", cloned: true, attention: true},    // dirty
+		{name: "Charlie", cloned: false, attention: true}, // not cloned
+	}
+	sortOtherBubbleRows(rows)
+
+	order := []string{rows[0].name, rows[1].name, rows[2].name, rows[3].name}
+	// attention rows first (Bravo, Charlie alphabetical), then clean (Alpha, Zulu)
+	assert.Equal(t, []string{"Bravo", "Charlie", "Alpha", "Zulu"}, order)
+}
+
+// TestRenderOtherBubbleRows verifies the dense listing: @slug identifiers, the
+// shared on-disk prefix printed exactly once, crisp freshness age for clean
+// repos, the uncommitted count for dirty ones, and full paths only under verbose.
+//
+// Failure prevented: the section regresses to repeating a full path per row
+// (the original density complaint) or hides per-bubble status.
+func TestRenderOtherBubbleRows(t *testing.T) {
+	t.Parallel()
+
+	base := "/home/u/.local/share/sageox/sageox.ai/teams"
+	rows := []otherTeamRow{
+		{
+			name: "SageOx Internal", slug: "sageox-internal", visibility: "private",
+			path: base + "/team_aaa", cloned: true, attention: true,
+			st: gitRepoStatus{Exists: true, UncommittedCount: 6},
+		},
+		{
+			name: "Ryan's Test", slug: "ryan-s-test", visibility: "private",
+			path: base + "/team_bbb", cloned: true,
+			st: gitRepoStatus{Exists: true, HasLastSync: true, LastSync: time.Now().Add(-2 * time.Hour)},
+		},
+	}
+
+	out := stripANSIBubbles(renderOtherBubbleRows(rows, false, false))
+
+	// @slug identifiers, not opaque team_ ids, in the default view
+	assert.Contains(t, out, "@sageox-internal")
+	assert.Contains(t, out, "@ryan-s-test")
+	assert.NotContains(t, out, "team_aaa", "opaque ids hidden unless --verbose")
+
+	// shared prefix printed once as a header, never per row
+	assert.Equal(t, 1, strings.Count(out, "on disk"))
+	assert.Contains(t, out, "teams/")
+
+	// per-bubble status: crisp age for clean, count for dirty
+	assert.Contains(t, out, "✓ 2h", "clean repo shows freshness age, not the word synced")
+	assert.Contains(t, out, "⚠ 6 uncommitted")
+
+	// verbose reveals the full on-disk path
+	verbose := stripANSIBubbles(renderOtherBubbleRows(rows, false, true))
+	assert.Contains(t, verbose, base+"/team_aaa")
+}
+
+// TestRenderBubbleStatus covers each status cell variant and that the freshness
+// age (not the word "synced") is the clean-repo signal.
+func TestRenderBubbleStatus(t *testing.T) {
+	t.Parallel()
+
+	clean := stripANSIBubbles(renderBubbleStatus(
+		gitRepoStatus{Exists: true, HasLastSync: true, LastSync: time.Now().Add(-3 * 24 * time.Hour)}, true, false))
+	assert.Equal(t, "✓ 3d", clean)
+
+	dirty := stripANSIBubbles(renderBubbleStatus(gitRepoStatus{Exists: true, UncommittedCount: 18}, true, false))
+	assert.Equal(t, "⚠ 18 uncommitted", dirty)
+
+	wedged := stripANSIBubbles(renderBubbleStatus(gitRepoStatus{Exists: true, RebaseInProgress: true}, true, false))
+	assert.Equal(t, "⚠ rebase wedged", wedged)
+
+	notCloned := stripANSIBubbles(renderBubbleStatus(gitRepoStatus{}, false, false))
+	assert.Equal(t, "⚠ not cloned", notCloned)
+}
+
+// TestRenderSlugRef verifies the sigil and slug are rendered as distinct
+// segments so the muted sigil + bright slug styling can apply per the design.
+func TestRenderSlugRef(t *testing.T) {
+	t.Parallel()
+
+	out := stripANSIBubbles(renderSlugRef("@", "sageox"))
+	assert.Equal(t, "@sageox", out)
+	out = stripANSIBubbles(renderSlugRef("#", "marketing"))
+	assert.Equal(t, "#marketing", out)
 }

--- a/cmd/ox/status_bubbles_test.go
+++ b/cmd/ox/status_bubbles_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/kb"
+	"github.com/sageox/ox/internal/ui"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -410,13 +411,13 @@ func stripANSIBubbles(s string) string {
 func TestBubblesCountSummary(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "13 total · 7 listed",
+	assert.Equal(t, "13 total · 7 owners",
 		bubblesCountSummary(statusBubblesSummary{Total: 13}, 7))
 
 	// merger total unavailable → fall back to the rendered count alone
-	assert.Equal(t, "7 team contexts listed",
+	assert.Equal(t, "7 owners listed",
 		bubblesCountSummary(statusBubblesSummary{Unavailable: true}, 7))
-	assert.Equal(t, "1 team context listed",
+	assert.Equal(t, "1 owner listed",
 		bubblesCountSummary(statusBubblesSummary{Total: 0}, 1))
 }
 
@@ -441,43 +442,59 @@ func TestSortOtherBubbleRows_NeedsAttentionFirst(t *testing.T) {
 	assert.Equal(t, []string{"Bravo", "Charlie", "Alpha", "Zulu"}, order)
 }
 
-// TestRenderOtherBubbleRows verifies the dense listing: @slug identifiers, the
-// shared on-disk prefix printed exactly once, crisp freshness age for clean
-// repos, the uncommitted count for dirty ones, and full paths only under verbose.
+// TestRenderOtherBubbleRows verifies the owner-grouped tree: each owner is a
+// parent node `@slug  (Display Name)` with its bubble nested under a tree glyph
+// as `(team)` + status. Slugs are never truncated, the shared on-disk prefix
+// prints once, private is the silent default while PUBLIC is flagged, and full
+// paths appear only under verbose.
 //
-// Failure prevented: the section regresses to repeating a full path per row
-// (the original density complaint) or hides per-bubble status.
+// Failure prevented: the section regresses to repeating a full path per row,
+// hides per-bubble status, truncates a slug with "…", buries the owner↔bubble
+// relationship, or clutters every row with a redundant "private" marker.
 func TestRenderOtherBubbleRows(t *testing.T) {
 	t.Parallel()
 
 	base := "/home/u/.local/share/sageox/sageox.ai/teams"
+	longSlug := "dry-run-ice-cream-2026-05-01" // would be truncated under a 1-line layout
 	rows := []otherTeamRow{
 		{
-			name: "SageOx Internal", slug: "sageox-internal", visibility: "private",
+			name: "SageOx Internal", slug: "sageox-internal", bubbleType: "team", visibility: "private",
 			path: base + "/team_aaa", cloned: true, attention: true,
 			st: gitRepoStatus{Exists: true, UncommittedCount: 6},
 		},
 		{
-			name: "Ryan's Test", slug: "ryan-s-test", visibility: "private",
+			name: "Dry Run - Ice Cream 2026-05-01", slug: longSlug, bubbleType: "team", visibility: "private",
 			path: base + "/team_bbb", cloned: true,
 			st: gitRepoStatus{Exists: true, HasLastSync: true, LastSync: time.Now().Add(-2 * time.Hour)},
+		},
+		{
+			name: "Open Docs", slug: "open-docs", bubbleType: "team", visibility: "public",
+			path: base + "/team_ccc", cloned: true,
+			st: gitRepoStatus{Exists: true, HasLastSync: true, LastSync: time.Now().Add(-5 * time.Minute)},
 		},
 	}
 
 	out := stripANSIBubbles(renderOtherBubbleRows(rows, false, false))
 
-	// @slug identifiers, not opaque team_ ids, in the default view
-	assert.Contains(t, out, "@sageox-internal")
-	assert.Contains(t, out, "@ryan-s-test")
+	// owner parent node: full @slug (never truncated) + display name in parens
+	assert.Contains(t, out, "@sageox-internal  (SageOx Internal)")
+	assert.Contains(t, out, "@"+longSlug+"  (Dry Run - Ice Cream 2026-05-01)", "slug must render in full — no ellipsis")
+	assert.NotContains(t, out, "…", "slugs are never shortened with an ellipsis")
 	assert.NotContains(t, out, "team_aaa", "opaque ids hidden unless --verbose")
+
+	// the bubble nests under the owner as (team) with a tree glyph
+	assert.Contains(t, out, ui.TreeLast+"(team)")
 
 	// shared prefix printed once as a header, never per row
 	assert.Equal(t, 1, strings.Count(out, "on disk"))
-	assert.Contains(t, out, "teams/")
 
 	// per-bubble status: crisp age for clean, count for dirty
-	assert.Contains(t, out, "✓ 2h", "clean repo shows freshness age, not the word synced")
+	assert.Contains(t, out, "✓ 5m", "clean repo shows freshness age, not the word synced")
 	assert.Contains(t, out, "⚠ 6 uncommitted")
+
+	// visibility: private is silent, only PUBLIC is flagged
+	assert.NotContains(t, out, "private", "private is the silent default — no marker")
+	assert.Contains(t, out, "PUBLIC", "public bubbles are flagged")
 
 	// verbose reveals the full on-disk path
 	verbose := stripANSIBubbles(renderOtherBubbleRows(rows, false, true))

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.8.1"
+  "version": "0.9.1"
 }

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -42,8 +42,10 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
 * [ox login](/login)	 - Authenticate with sageox.ai
 * [ox logout](/logout)	 - Log out of SageOx
 * [ox murmur](/murmur)	 - Publish a coordination signal to other AI coworkers
+* [ox plan](/plan)	 - Enrich an implementation plan with SageOx team context
 * [ox query](/query)	 - Search team knowledge
 * [ox release-notes](/release-notes)	 - Display release notes for the current version
+* [ox scout](/scout)	 - Search the web for prior art related to a meeting
 * [ox session](/session)	 - Manage AI coworker sessions
 * [ox status](/status)	 - Display SageOx status and directory locations
 * [ox sync](/sync)	 - Manually sync ledger/team contexts (rarely needed)

--- a/docs/reference/kb/config/get.mdx
+++ b/docs/reference/kb/config/get.mdx
@@ -1,0 +1,38 @@
+---
+title: "ox kb config get"
+description: "CLI reference for ox kb config get"
+sidebar_position: 53
+---
+
+## ox kb config get
+
+Print the effective value of a KB config key
+
+```
+ox kb config get <key> [flags]
+```
+
+### Options
+
+```
+      --at string     Print only the value at this scope (env|kb|user|default)
+  -h, --help          help for get
+      --json          Emit JSON output
+      --kb string     Target KB by slug, #slug, or kb_id (default: resolve from cwd)
+      --show-origin   Print each layer's value with origin
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox kb config](/kb/config)	 - Inspect KB configuration values (read-only)
+

--- a/docs/reference/kb/config/index.mdx
+++ b/docs/reference/kb/config/index.mdx
@@ -1,0 +1,47 @@
+---
+title: "ox kb config"
+description: "CLI reference for ox kb config"
+sidebar_position: 52
+---
+
+## ox kb config
+
+Inspect KB configuration values (read-only)
+
+### Synopsis
+
+Inspect the effective value of a KB configuration key across precedence layers.
+
+Layers (highest precedence first):
+  env      OX_SESSION_RECORDING (session_recording.mode only)
+  kb       .sageox/config.yaml inside the KB checkout
+  user     ~/.config/sageox/config.yaml (or ~/.sageox/config/config.yaml)
+  default  per-KB-type fallback
+
+session_recording.mode has a safety inversion: a "disabled" on either kb OR
+user layer wins regardless of precedence. `--show-origin` marks the layer
+that triggered the inversion.
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox kb](/kb)	 - Work with knowledge bubbles
+* [ox kb config get](/kb/config/get)	 - Print the effective value of a KB config key
+* [ox kb config list](/kb/config/list)	 - List effective values for all known KB config keys
+

--- a/docs/reference/kb/config/list.mdx
+++ b/docs/reference/kb/config/list.mdx
@@ -1,33 +1,30 @@
 ---
-title: "ox login"
-description: "CLI reference for ox login"
-sidebar_position: 59
+title: "ox kb config list"
+description: "CLI reference for ox kb config list"
+sidebar_position: 54
 ---
 
-## ox login
+## ox kb config list
 
-Authenticate with sageox.ai
-
-### Synopsis
-
-Authenticate with sageox.ai to access premium features and sync your configuration.
+List effective values for all known KB config keys
 
 ```
-ox login [flags]
+ox kb config list [flags]
 ```
 
 ### Options
 
 ```
-      --endpoint string   SageOx endpoint URL (overrides SAGEOX_ENDPOINT)
-  -h, --help              help for login
+  -h, --help          help for list
+      --json          Emit JSON output
+      --kb string     Target KB by slug, #slug, or kb_id (default: resolve from cwd)
+      --show-origin   Print each layer's value with origin
 ```
 
 ### Options inherited from parent commands
 
 ```
   -c, --config string    config file path (default: .sageox/config.yaml)
-      --json             output in JSON format (default: false)
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
@@ -36,5 +33,5 @@ ox login [flags]
 
 ### SEE ALSO
 
-* [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+* [ox kb config](/kb/config)	 - Inspect KB configuration values (read-only)
 

--- a/docs/reference/kb/hydrate.mdx
+++ b/docs/reference/kb/hydrate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb hydrate"
 description: "CLI reference for ox kb hydrate"
-sidebar_position: 52
+sidebar_position: 55
 ---
 
 ## ox kb hydrate

--- a/docs/reference/kb/index.mdx
+++ b/docs/reference/kb/index.mdx
@@ -37,6 +37,7 @@ see what you have access to, `ox kb show <slug>` for details, and
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+* [ox kb config](/kb/config)	 - Inspect KB configuration values (read-only)
 * [ox kb hydrate](/kb/hydrate)	 - Materialize LFS pointer files in a knowledge bubble
 * [ox kb list](/kb/list)	 - List knowledge bubbles you can access
 * [ox kb path](/kb/path)	 - Print the local path of a knowledge bubble (scriptable)

--- a/docs/reference/kb/list.mdx
+++ b/docs/reference/kb/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb list"
 description: "CLI reference for ox kb list"
-sidebar_position: 53
+sidebar_position: 56
 ---
 
 ## ox kb list

--- a/docs/reference/kb/path.mdx
+++ b/docs/reference/kb/path.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb path"
 description: "CLI reference for ox kb path"
-sidebar_position: 54
+sidebar_position: 57
 ---
 
 ## ox kb path

--- a/docs/reference/kb/show.mdx
+++ b/docs/reference/kb/show.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb show"
 description: "CLI reference for ox kb show"
-sidebar_position: 55
+sidebar_position: 58
 ---
 
 ## ox kb show

--- a/docs/reference/logout.mdx
+++ b/docs/reference/logout.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox logout"
 description: "CLI reference for ox logout"
-sidebar_position: 57
+sidebar_position: 60
 ---
 
 ## ox logout

--- a/docs/reference/murmur/delete.mdx
+++ b/docs/reference/murmur/delete.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur delete"
 description: "CLI reference for ox murmur delete"
-sidebar_position: 59
+sidebar_position: 62
 ---
 
 ## ox murmur delete

--- a/docs/reference/murmur/index.mdx
+++ b/docs/reference/murmur/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur"
 description: "CLI reference for ox murmur"
-sidebar_position: 58
+sidebar_position: 61
 ---
 
 ## ox murmur

--- a/docs/reference/murmur/list.mdx
+++ b/docs/reference/murmur/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur list"
 description: "CLI reference for ox murmur list"
-sidebar_position: 60
+sidebar_position: 63
 ---
 
 ## ox murmur list

--- a/docs/reference/murmur/pause.mdx
+++ b/docs/reference/murmur/pause.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur pause"
 description: "CLI reference for ox murmur pause"
-sidebar_position: 61
+sidebar_position: 64
 ---
 
 ## ox murmur pause

--- a/docs/reference/murmur/resume.mdx
+++ b/docs/reference/murmur/resume.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur resume"
 description: "CLI reference for ox murmur resume"
-sidebar_position: 62
+sidebar_position: 65
 ---
 
 ## ox murmur resume

--- a/docs/reference/murmur/status.mdx
+++ b/docs/reference/murmur/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur status"
 description: "CLI reference for ox murmur status"
-sidebar_position: 63
+sidebar_position: 66
 ---
 
 ## ox murmur status

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -28,6 +28,8 @@ ox plan [flags]
       --file string   plan source file (default: stdin, else newest ~/.claude/plans/*.md)
   -h, --help          help for plan
       --json          emit the enrichment Result as JSON (plumbing path; no network/LLM call)
+      --open          after enrich, open this plan's rendered HTML if one is saved
+      --persist       with --json, also save + commit a draft to the ledger (used by the ExitPlanMode hook)
 ```
 
 ### Options inherited from parent commands
@@ -43,6 +45,7 @@ ox plan [flags]
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+* [ox plan lint](/plan/lint)	 - Check a saved plan's HTML render for SageOx attribution + self-contained invariants
 * [ox plan list](/plan/list)	 - Browse saved ledger plans
 * [ox plan save](/plan/save)	 - Persist a fully-enriched plan (merged badges + optional HTML) to the ledger
 * [ox plan view](/plan/view)	 - Open a saved plan

--- a/docs/reference/plan/lint.mdx
+++ b/docs/reference/plan/lint.mdx
@@ -1,0 +1,44 @@
+---
+title: "ox plan lint"
+description: "CLI reference for ox plan lint"
+sidebar_position: 68
+---
+
+## ox plan lint
+
+Check a saved plan's HTML render for SageOx attribution + self-contained invariants
+
+### Synopsis
+
+Lint a saved plan's rendered HTML against the html-plan attribution contract:
+when the plan carried SageOx enrichment the render must credit it (footer line +
+an anchored OX marker), an un-enriched plan must not overclaim, and the SageOx
+mark must be self-contained (no live remote avatar). Advisory by default; pass
+--strict to exit non-zero on findings (for CI / golden checks).
+
+```
+ox plan lint <slug> [flags]
+```
+
+### Options
+
+```
+  -h, --help     help for lint
+      --strict   exit non-zero when the render has attribution findings (for CI / golden checks)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox plan](/plan)	 - Enrich an implementation plan with SageOx team context
+

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan list"
 description: "CLI reference for ox plan list"
-sidebar_position: 68
+sidebar_position: 69
 ---
 
 ## ox plan list

--- a/docs/reference/plan/save.mdx
+++ b/docs/reference/plan/save.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan save"
 description: "CLI reference for ox plan save"
-sidebar_position: 69
+sidebar_position: 70
 ---
 
 ## ox plan save
@@ -12,7 +12,7 @@ Persist a fully-enriched plan (merged badges + optional HTML) to the ledger
 
 Persist a fully-enriched plan to the ledger. Unlike bare 'ox plan' — which
 auto-saves only the deterministic, ox-computed annotations — 'ox plan save' is the
-explicit full-plan persist path used by the ox-plan renderer skill after it has
+explicit full-plan persist path used by the html-plan renderer skill after it has
 authored its judgment badges and (optionally) rendered the HTML.
 
   --plan        the plan markdown (source for plan.md + topic/slug derivation)

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan view"
 description: "CLI reference for ox plan view"
-sidebar_position: 70
+sidebar_position: 71
 ---
 
 ## ox plan view

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox query"
 description: "CLI reference for ox query"
-sidebar_position: 64
+sidebar_position: 72
 ---
 
 ## ox query
@@ -15,6 +15,7 @@ Search across team discussions, docs, session history, and local code.
 Sources:
   team      Search team discussions, docs, and session history (default)
   code      Search local code index only (queries)
+  local     Search locally-cached ledger ONLY (zero network, fast hook path)
   all       Search both team context and local code index
 
 Examples:
@@ -23,6 +24,8 @@ Examples:
   ox query "deployment process" --team team_abc123
   ox query "error handling" --source=code
   ox query "auth flow" --source=all
+  ox query "cache invalidation" --local
+  ox query "auth flow" --local --json
 
 ```
 ox query [flags]
@@ -32,10 +35,12 @@ ox query [flags]
 
 ```
   -h, --help            help for query
+      --json            emit machine-readable JSON (default in agent context)
   -k, --limit int       max results to return (default 5)
+      --local           search the locally-cached ledger only (zero network)
       --mode string     search mode: hybrid, knn, or bm25 (default "hybrid")
       --repo string     repo ID to search (default: from project config)
-      --source string   search source: team (default), code, all (default "team")
+      --source string   search source: team (default), code, local, all (default "team")
       --team string     team ID to search (default: from project config)
 ```
 
@@ -43,7 +48,6 @@ ox query [flags]
 
 ```
   -c, --config string    config file path (default: .sageox/config.yaml)
-      --json             output in JSON format (default: false)
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox release-notes"
 description: "CLI reference for ox release-notes"
-sidebar_position: 65
+sidebar_position: 73
 ---
 
 ## ox release-notes

--- a/docs/reference/scout.mdx
+++ b/docs/reference/scout.mdx
@@ -1,0 +1,55 @@
+---
+title: "ox scout"
+description: "CLI reference for ox scout"
+sidebar_position: 74
+---
+
+## ox scout
+
+Search the web for prior art related to a meeting
+
+### Synopsis
+
+Read a meeting transcript, then ask Perplexity's Agent API for prior art,
+people, and recent developments relevant to what the team discussed.
+
+Pass "-" as the path to read the transcript from stdin.
+
+Requires the PERPLEXITY_API_KEY environment variable.
+
+Examples:
+  ox scout ./meeting.md
+  cat transcript.txt | ox scout -
+  ox scout ./meeting.md --question "What open-source libraries solve this?"
+  ox scout ./meeting.md --model anthropic/claude-sonnet-4-6
+  ox scout ./meeting.md --json
+
+```
+ox scout <transcript-path> [flags]
+```
+
+### Options
+
+```
+      --citations         show the raw 'Sources' list returned by Perplexity's web search
+      --domains strings   comma-separated search domain whitelist (default: no filter, full web)
+  -h, --help              help for scout
+      --json              emit the raw Perplexity Agent API response as JSON
+      --model string      Perplexity Agent API model ID (see https://docs.perplexity.ai/docs/agent-api/models) (default "anthropic/claude-opus-4-7")
+      --question string   override the default research question
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session audit"
 description: "CLI reference for ox session audit"
-sidebar_position: 67
+sidebar_position: 76
 ---
 
 ## ox session audit

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session"
 description: "CLI reference for ox session"
-sidebar_position: 66
+sidebar_position: 75
 ---
 
 ## ox session

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session lint"
 description: "CLI reference for ox session lint"
-sidebar_position: 68
+sidebar_position: 77
 ---
 
 ## ox session lint

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session list"
 description: "CLI reference for ox session list"
-sidebar_position: 69
+sidebar_position: 78
 ---
 
 ## ox session list

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session redact"
 description: "CLI reference for ox session redact"
-sidebar_position: 70
+sidebar_position: 79
 ---
 
 ## ox session redact

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session regenerate"
 description: "CLI reference for ox session regenerate"
-sidebar_position: 71
+sidebar_position: 80
 ---
 
 ## ox session regenerate

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session repair-meta-summary"
 description: "CLI reference for ox session repair-meta-summary"
-sidebar_position: 72
+sidebar_position: 81
 ---
 
 ## ox session repair-meta-summary

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session score"
 description: "CLI reference for ox session score"
-sidebar_position: 73
+sidebar_position: 82
 ---
 
 ## ox session score

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session status"
 description: "CLI reference for ox session status"
-sidebar_position: 74
+sidebar_position: 83
 ---
 
 ## ox session status

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session stop"
 description: "CLI reference for ox session stop"
-sidebar_position: 75
+sidebar_position: 84
 ---
 
 ## ox session stop

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session token-optimize"
 description: "CLI reference for ox session token-optimize"
-sidebar_position: 76
+sidebar_position: 85
 ---
 
 ## ox session token-optimize

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session view"
 description: "CLI reference for ox session view"
-sidebar_position: 77
+sidebar_position: 86
 ---
 
 ## ox session view

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox status"
 description: "CLI reference for ox status"
-sidebar_position: 78
+sidebar_position: 87
 ---
 
 ## ox status
@@ -22,8 +22,9 @@ ox status [flags]
 ### Options
 
 ```
-  -h, --help   help for status
-      --json   output in JSON format
+  -h, --help      help for status
+      --json      output in JSON format
+  -v, --verbose   show opaque IDs and full on-disk paths
 ```
 
 ### Options inherited from parent commands
@@ -33,7 +34,6 @@ ox status [flags]
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)
-  -v, --verbose          enable verbose output (default: false)
 ```
 
 ### SEE ALSO

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox sync"
 description: "CLI reference for ox sync"
-sidebar_position: 79
+sidebar_position: 88
 ---
 
 ## ox sync

--- a/docs/reference/teams.mdx
+++ b/docs/reference/teams.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox teams"
 description: "CLI reference for ox teams"
-sidebar_position: 80
+sidebar_position: 89
 ---
 
 ## ox teams

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox uninstall"
 description: "CLI reference for ox uninstall"
-sidebar_position: 81
+sidebar_position: 90
 ---
 
 ## ox uninstall

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox upgrade"
 description: "CLI reference for ox upgrade"
-sidebar_position: 82
+sidebar_position: 91
 ---
 
 ## ox upgrade

--- a/internal/status/format.go
+++ b/internal/status/format.go
@@ -78,6 +78,29 @@ func FormatTimeAgo(t time.Time) string {
 	}
 }
 
+// CompactAge formats elapsed time since t in the shortest useful form:
+// "now", "5m", "2h", "3d", "2w". Used in dense status views (e.g. the
+// knowledge-bubble tree) where FormatTimeAgo ("2 hours ago") is too wide.
+// A zero time renders as "—".
+func CompactAge(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	diff := time.Since(t)
+	switch {
+	case diff < time.Minute:
+		return "now"
+	case diff < time.Hour:
+		return fmt.Sprintf("%dm", int(diff.Minutes()))
+	case diff < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(diff.Hours()))
+	case diff < 7*24*time.Hour:
+		return fmt.Sprintf("%dd", int(diff.Hours()/24))
+	default:
+		return fmt.Sprintf("%dw", int(diff.Hours()/24/7))
+	}
+}
+
 // FormatEndpointDisplay returns a shorter display name for an endpoint URL.
 // e.g., "https://api.test.sageox.ai" -> "api.test.sageox.ai"
 func FormatEndpointDisplay(endpointURL string) string {

--- a/internal/status/format_test.go
+++ b/internal/status/format_test.go
@@ -248,3 +248,31 @@ func TestEstimateTokens(t *testing.T) {
 	assert.Equal(t, 250, EstimateTokens(1000))
 	assert.Equal(t, 1, EstimateTokens(4))
 }
+
+// TestCompactAge verifies the dense freshness formatter used by the
+// knowledge-bubble listing: shortest useful unit, "now" under a minute,
+// "—" for a zero time.
+//
+// Failure prevented: the bubble status column widens (e.g. "2 hours ago")
+// and overflows the 80-column budget, or a never-synced repo renders a
+// misleading "0m" instead of an explicit unknown marker.
+func TestCompactAge(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{"zero", time.Time{}, "—"},
+		{"under a minute", now.Add(-30 * time.Second), "now"},
+		{"minutes", now.Add(-5 * time.Minute), "5m"},
+		{"hours", now.Add(-2 * time.Hour), "2h"},
+		{"days", now.Add(-3 * 24 * time.Hour), "3d"},
+		{"weeks", now.Add(-2 * 7 * 24 * time.Hour), "2w"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, CompactAge(tc.t))
+		})
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.9.0"
+	Version   = "0.9.1"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## What this PR ships

Two related pieces of work on the `ox status` surface, plus a version bump.

- **Version → 0.9.1** across the canonical source and all mirrors (`internal/version/version.go`, plugin manifests, `docs/package.json`, `CHANGELOG`). `make verify-version` passes.
- **`ox status` knowledge-bubble redesign** — replaces the count-only line + duplicated "Other Team Contexts" section with one owner-grouped tree.
- **CLI reference regeneration** — picks up accumulated drift (missing `scout`, `plan lint`, `kb config` pages; sidebar ordering) plus the new `status --verbose` flag.

## The problem (status before)

The knowledge-bubble section showed a bare count, then listed every team **again** under a separate header with a full filesystem path on each row:

```
Knowledge bubbles   9 (8 team, 1 repo)

Other Team Contexts
───────────────────
Team                SageOx Internal
  Visibility        private (✓ member)
  Path              /Users/ryan/.local/share/sageox/sageox.ai/teams/team_xlcr6yzpec
  Status            ⚠ 6 uncommitted
... (4 lines per team, full path every time, teams duplicated with the count)
```

- No real per-bubble status in the "Knowledge bubbles" line — just a tally.
- Same teams duplicated between the count and the list.
- The long data-dir prefix repeated on every row. Does not scale to dozens of bubbles.

## What this PR ships (status after)

An owner-grouped tree. Each owner is a parent node `@slug  (Display Name)`; its knowledge bubbles nest beneath under solid tree glyphs, each with a compact, color-coded status:

```
Knowledge bubbles  13 total · 7 owners
─────────────────
  on disk  ~/.local/share/sageox/sageox.ai/teams/

@sageox-internal  (SageOx Internal)
└─ (team)                ⚠ 6 uncommitted
@dry-run-ice-cream-2026-05-01  (Dry Run - Ice Cream 2026-05-01)
└─ (team)                ✓ 3d
@open-docs  (Open Docs)
└─ (team)                ✓ 5m   PUBLIC
…
```

- **Owner parent node** — `@slug  (Display Name)`. The owner's own context nests as `(team)`; a future multi-bubble owner reads `├─ #sageox-mono (repo)`, `└─ #marketing (custom)` with **no layout change**.
- **Slugs never truncated** — the full identifier always shows.
- **Status with the bubble** — `✓ <age>` when clean (crisp `now`/`5m`/`2h`/`3d`/`2w`), `⚠ N uncommitted` when dirty, red `⚠ rebase wedged` when stuck. Needs-attention owners sort to the top.
- **PUBLIC-only visibility** — nearly every bubble is private, so private is the silent default (no marker); only `PUBLIC` is flagged, in bold + the public accent token, so it pops.
- **Shared on-disk prefix printed once**, never per row. `--verbose`/`-v` reveals opaque IDs and full paths.
- Fits 80 columns, semantic theme styles only (no raw colors), `NO_COLOR`-safe.

## Data flow

```mermaid
flowchart LR
  CLI["ox status"] --> CTC["cloud team contexts (name, slug, visibility)"]
  CLI --> MRG["kb merger (headline total)"]
  CTC --> ROWS["build otherTeamRow + git status per checkout"]
  ROWS --> SORT["sort: needs-attention first, then name"]
  SORT --> REND["render owner tree, prefix once, PUBLIC-only"]
  MRG --> REND
```

## Design notes / deliberate scope

- The listing is driven by existing **cloud team-context** data (already carries `slug`/visibility/status via `RepoInfo.Slug`); the kb merger supplies only the headline total. No new data plumbing.
- The **multi-bubble-per-owner** nesting is forward-looking — no source exposes more than one bubble per owner today, so each owner renders one `(team)` child. The tree layout absorbs additional bubbles unchanged when the API grows them.
- The ledger + primary-team blocks in **Project Status** are left untouched — they carry many fragile edge-case branches (not-cloned, bootstrapping, wedged, viewer) and are not the density problem.

## Test Plan

- `make verify-version` to "All versions match: 0.9.1"
- `go build ./... && go vet ./cmd/ox/ ./internal/status/` clean
- `make lint` to 0 issues
- `go test ./cmd/ox/ ./internal/status/` green, incl. new tests:
  - `bubblesCountSummary`, `sortOtherBubbleRows` (attention-first), `renderOtherBubbleRows` (owner node + nested `(team)`, full slug / no ellipsis, prefix-once, PUBLIC flagged + private silent, `--verbose` reveals paths), `renderBubbleStatus` variants, `renderSlugRef`, `CompactAge`
- Manual: `ox status`, `ox status --verbose`, `COLUMNS=80 NO_COLOR=1 ox status` (max line 63 cols)

Co-Authored-By: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Denser "Knowledge bubbles" in ox status with owner-grouped rows, attention-first sorting, compact color-coded freshness/status, and a -v/--verbose mode to reveal opaque IDs and full on-disk paths.
  * Added ox plan lint, ox scout, and ox kb config commands; ox query gains a --local offline search option.
* **Documentation**
  * Many CLI reference pages added/updated and sidebar ordering refreshed.
* **Tests**
  * New tests covering bubbles rendering and compact age formatting.
* **Chores**
  * Version bumped to 0.9.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->