### PR TITLE
security: adapter integrity, redaction chokepoint, env + clone hardening (ADR-022)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ check-raw-writer-chokepoint: ## Ensure raw.jsonl is only opened via session.RawW
 	@# Any os.OpenFile/Create/WriteFile of a raw.jsonl path outside the
 	@# canonical chokepoint (internal/session/raw_writer.go) is a redaction
 	@# bypass risk. Test files and the chokepoint itself are allowed.
+	@# Pass 1: literal raw.jsonl path passed straight to a writer call.
 	@violations=$$(grep -rnE '(os\.OpenFile|os\.Create|os\.WriteFile)\([^)]*raw[._]?jsonl' \
 		--include='*.go' . 2>/dev/null \
 		| grep -v '_test\.go:' \
@@ -184,8 +185,24 @@ check-raw-writer-chokepoint: ## Ensure raw.jsonl is only opened via session.RawW
 		| grep -vE ':[0-9]+:[[:space:]]*//') ; \
 	if [ -n "$$violations" ] ; then \
 		echo "ERROR: raw.jsonl must be written via session.RawWriter (see internal/session/raw_writer.go)"; \
-		echo "Violations:"; \
+		echo "Violations (literal path):"; \
 		echo "$$violations"; \
+		exit 1; \
+	fi
+	@# Pass 2: variable-indirection. The raw.jsonl path is usually held in
+	@# a `rawPath` var or the `ledgerFileRaw` constant, so the literal
+	@# "raw.jsonl" string never appears at the open site. Scoped to the two
+	@# packages that record sessions (cmd/ox, internal/session) since those
+	@# are where the bypass lived; the chokepoint and tests are exempt.
+	@indirect=$$(grep -rnE '(os\.OpenFile|os\.Create|os\.WriteFile)\([^)]*(rawPath|ledgerFileRaw)' \
+		--include='*.go' cmd/ox internal/session 2>/dev/null \
+		| grep -v '_test\.go:' \
+		| grep -v 'internal/session/raw_writer\.go:' \
+		| grep -vE ':[0-9]+:[[:space:]]*//') ; \
+	if [ -n "$$indirect" ] ; then \
+		echo "ERROR: raw.jsonl path (rawPath / ledgerFileRaw) must be written via session.RawWriter"; \
+		echo "Violations (variable indirection):"; \
+		echo "$$indirect"; \
 		exit 1; \
 	fi
 

--- a/cmd/ox/adapter.go
+++ b/cmd/ox/adapter.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,10 +17,21 @@ import (
 
 	adapter "github.com/sageox/ox/internal/adapter"
 	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/spf13/cobra"
 )
+
+// adapterDownloadHosts are the GitHub release-asset hosts permitted as a
+// defense-in-depth transport guard (ADR-022 decision 4). This is NOT the primary
+// integrity control — the checksum gate is. GitHub rotates CDN hosts, so this
+// list errs toward the known asset hosts and never substitutes for the checksum.
+var adapterDownloadHosts = map[string]bool{
+	"github.com":                           true,
+	"objects.githubusercontent.com":        true,
+	"release-assets.githubusercontent.com": true,
+}
 
 var adapterCmd = &cobra.Command{
 	Use:   "adapter",
@@ -42,6 +56,8 @@ func init() {
 	// flags
 	adapterListCmd.Flags().Bool("json", false, "output in JSON format")
 	adapterInfoCmd.Flags().Bool("json", false, "output in JSON format")
+	adapterInstallCmd.Flags().Bool("allow-unverified", false,
+		"install without a SageOx-curated checksum (required for arbitrary repos and for curated entries that lack a pinned checksum)")
 }
 
 // userLocalAdaptersDir returns the platform-specific user adapter install directory.
@@ -284,6 +300,34 @@ it to ~/.local/share/ox/adapters/.`,
 	RunE: runAdapterInstall,
 }
 
+// installPlan is the resolved intent for an adapter install: where to fetch it,
+// which release to pin, and whether SageOx vouches for the bytes via a checksum.
+type installPlan struct {
+	owner     string
+	repo      string
+	tag       string            // pinned release tag (required; never releases/latest)
+	checksum  string            // expected sha256 hex for this platform ("" => unverifiable)
+	curated   bool              // true => resolved from registry (SageOx is trust anchor)
+	platform  string            // e.g. "darwin_arm64"
+	checksums map[string]string // full per-platform map (curated only; for diagnostics)
+}
+
+// installConfig parameterizes installAdapter so it can be driven by tests against
+// an httptest server. Production fills apiBaseURL with the GitHub API root and
+// allowedHosts with adapterDownloadHosts.
+type installConfig struct {
+	plan         installPlan
+	apiBaseURL   string          // GitHub API root, e.g. https://api.github.com
+	allowedHosts map[string]bool // download-host transport guard (defense-in-depth)
+	installDir   string
+	// verify is the protocol-conformance check run AFTER the checksum gate. It is
+	// indirected so tests can assert it is never reached when the gate fails.
+	verify func(binaryPath string) error
+	// httpClient performs the API + asset GETs. nil => http.DefaultClient. Tests
+	// inject a TLS test server's client so the https transport guard still applies.
+	httpClient *http.Client
+}
+
 // runAdapterInstall acquires and installs an adapter binary.
 //
 // SECURITY POSTURE (see docs/adr/ADR-022-adapter-security-posture.md):
@@ -292,18 +336,54 @@ it to ~/.local/share/ox/adapters/.`,
 // trust anchor. Two paths with different anchors:
 //   - curated short-name ("cursor"): SageOx vouches -> integrity check required
 //     (pin tag + sha256, verify-before-exec). Tracked in ox-5ihl.
-//   - arbitrary github.com/<owner>/<repo>: the user vouches -> stays frictionless.
+//   - arbitrary github.com/<owner>/<repo>@<tag>: the user vouches -> stays
+//     frictionless, but is unverifiable by SageOx and so requires an explicit
+//     --allow-unverified opt-in (and an explicit @<tag> pin in the source).
+//
+// Install ordering is an invariant (ADR-022 decision 5): resolve -> pin tag ->
+// GET releases/tags/<tag> (asserting tag_name matches) -> select asset ->
+// validate download host -> download while hashing -> constant-time checksum
+// compare -> ONLY THEN chmod -> verifyAdapterProtocol -> atomic rename. No
+// untrusted byte is made executable or run before the checksum gate.
 //
 // Once installed, an adapter runs every session as the user; installation IS the
 // trust decision. We do not sandbox an installed adapter from the user's own
 // session — that is outside the documented threat model (security/SECURITY.md).
-func runAdapterInstall(_ *cobra.Command, args []string) error {
+func runAdapterInstall(cmd *cobra.Command, args []string) error {
 	source := args[0]
+	allowUnverified, _ := cmd.Flags().GetBool("allow-unverified")
 
-	// try registry lookup first (short name like "cursor")
-	owner, repo, err := resolveAdapterSource(source)
+	platform := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+	plan, err := resolveAdapterSource(source, platform)
 	if err != nil {
 		return err
+	}
+
+	// A curated entry with no pinned tag has no release to fetch at all (we refuse
+	// to fall back to releases/latest — that is the gap ox-5ihl closes), so even
+	// --allow-unverified cannot satisfy it. NOTE (ox-5ihl): the external entries
+	// (cursor, windsurf, copilot, cline) currently ship WITHOUT a tag/checksum, so
+	// they land here until a maintainer pins one — the intended, documented
+	// transition.
+	if plan.curated && plan.tag == "" {
+		return fmt.Errorf("adapter %q has no pinned release tag in the registry yet; "+
+			"a maintainer must pin a tag + per-platform checksum before it can be installed (ADR-022/ox-5ihl)",
+			plan.repo)
+	}
+
+	// Fail-closed gate (ADR-022 decisions 2-3): an install SageOx cannot vouch for
+	// — an arbitrary repo, or a curated entry whose registry lacks a checksum for
+	// this platform — must not silently chmod+exec untrusted bytes. Require an
+	// explicit opt-in.
+	if plan.checksum == "" && !allowUnverified {
+		if plan.curated {
+			return fmt.Errorf("adapter %q has no pinned checksum for platform %s yet; "+
+				"either wait for a checksum to be pinned in the registry, or re-run with --allow-unverified to install unverified",
+				plan.repo, platform)
+		}
+		return fmt.Errorf("installing from an arbitrary repo (%s/%s) cannot be verified by SageOx; "+
+			"re-run with --allow-unverified to install unverified",
+			plan.owner, plan.repo)
 	}
 
 	installDir, err := userLocalAdaptersDir()
@@ -314,26 +394,58 @@ func runAdapterInstall(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("create adapter directory: %w", err)
 	}
 
-	platform := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
-	slog.Info("fetching latest release", "owner", owner, "repo", repo, "platform", platform)
+	if plan.checksum == "" {
+		// allow-unverified path: keep protocol conformance, drop the provenance gate.
+		cli.PrintWarning(fmt.Sprintf(
+			"installing %s/%s@%s WITHOUT integrity verification (--allow-unverified): "+
+				"SageOx cannot vouch for these bytes; you are the trust anchor",
+			plan.owner, plan.repo, plan.tag))
+	}
 
-	// fetch latest release from GitHub API
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
-	// NOTE: resolves releases/latest with no version pin. On the curated path this
-	// is the authenticity gap (ox-5ihl, ADR-022): the GitHub API response is
-	// network input and is not yet trusted to name the exact binary SageOx curated.
-	resp, err := http.Get(apiURL) //nolint:gosec // URL constructed from trusted adapter registry
+	cfg := installConfig{
+		plan:         plan,
+		apiBaseURL:   "https://api.github.com",
+		allowedHosts: adapterDownloadHosts,
+		installDir:   installDir,
+		verify:       verifyAdapterProtocol,
+	}
+	return installAdapter(cfg)
+}
+
+// installAdapter performs the integrity-gated acquisition described on
+// runAdapterInstall. It is split out so tests can drive every step (tag
+// assertion, host guard, checksum gate, verify ordering) against an httptest
+// server. The ordering here is a security invariant — do not reorder.
+func installAdapter(cfg installConfig) error {
+	plan := cfg.plan
+	if plan.tag == "" {
+		// defense in depth: resolveAdapterSource must always pin a tag.
+		return fmt.Errorf("internal: install plan has no pinned tag")
+	}
+
+	client := cfg.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	slog.Info("fetching pinned release", "owner", plan.owner, "repo", plan.repo, "tag", plan.tag, "platform", plan.platform)
+
+	// Fetch the PINNED release (releases/tags/<tag>), never releases/latest, so a
+	// retagged/swapped "latest" cannot redirect a pinned install (ADR-022).
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", cfg.apiBaseURL, plan.owner, plan.repo, plan.tag)
+	resp, err := client.Get(apiURL) //nolint:gosec // URL built from registry-resolved owner/repo/tag
 	if err != nil {
 		return fmt.Errorf("fetch release info: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("GitHub API returned %d for %s/%s (check repo exists and has releases)", resp.StatusCode, owner, repo)
+		return fmt.Errorf("GitHub API returned %d for %s/%s tag %s (check the tag exists)", resp.StatusCode, plan.owner, plan.repo, plan.tag)
 	}
 
 	var release struct {
-		Assets []struct {
+		TagName string `json:"tag_name"`
+		Assets  []struct {
 			Name               string `json:"name"`
 			BrowserDownloadURL string `json:"browser_download_url"`
 		} `json:"assets"`
@@ -342,28 +454,35 @@ func runAdapterInstall(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("decode release response: %w", err)
 	}
 
+	// Assert the response describes the tag we asked for; a mismatch means the API
+	// returned a different release than the pin and must be rejected.
+	if release.TagName != plan.tag {
+		return fmt.Errorf("release tag mismatch: requested %q but GitHub returned %q", plan.tag, release.TagName)
+	}
+
 	// find matching asset for current platform
 	var downloadURL, assetName string
 	for _, asset := range release.Assets {
-		if strings.Contains(asset.Name, platform) {
+		if strings.Contains(asset.Name, plan.platform) {
 			downloadURL = asset.BrowserDownloadURL
 			assetName = asset.Name
 			break
 		}
 	}
 	if downloadURL == "" {
-		return fmt.Errorf("no release asset found for platform %s in %s/%s", platform, owner, repo)
+		return fmt.Errorf("no release asset found for platform %s in %s/%s@%s", plan.platform, plan.owner, plan.repo, plan.tag)
 	}
 
-	slog.Info("downloading adapter", "asset", assetName)
+	// Transport guard (ADR-022 decision 4): defense-in-depth only — the checksum
+	// gate below is the real control. Reject a download URL pointing off the known
+	// asset hosts (e.g. an attacker-influenced browser_download_url).
+	if err := gitutil.ValidateHTTPSHost(downloadURL, cfg.allowedHosts); err != nil {
+		return fmt.Errorf("refusing download: %w", err)
+	}
 
-	// download binary
-	// NOTE: bytes fetched here are network input and currently unverified. The
-	// integrity gate (sha256 constant-time compare against the registry pin, BEFORE
-	// chmod/exec) belongs immediately after the download completes — see ADR-022
-	// decisions 2 and 5, ox-5ihl. A download-host allowlist is deliberately NOT the
-	// control (GitHub rotates CDN hosts; checksum subsumes it — ADR-022 decision 4).
-	dlResp, err := http.Get(downloadURL) //nolint:gosec // URL from GitHub API release response
+	slog.Info("downloading adapter", "asset", assetName, "tag", plan.tag)
+
+	dlResp, err := client.Get(downloadURL) //nolint:gosec // host validated above; bytes checksum-gated below
 	if err != nil {
 		return fmt.Errorf("download binary: %w", err)
 	}
@@ -373,30 +492,44 @@ func runAdapterInstall(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("download returned %d", dlResp.StatusCode)
 	}
 
-	// derive binary name from asset name (strip platform suffix for the installed name)
-	binaryName := deriveAdapterBinaryName(assetName, platform)
-	destPath := filepath.Join(installDir, binaryName)
+	binaryName := deriveAdapterBinaryName(assetName, plan.platform)
+	destPath := filepath.Join(cfg.installDir, binaryName)
 
 	// write to temp file then rename (atomic install)
-	tmpFile, err := os.CreateTemp(installDir, ".ox-adapter-install-*")
+	tmpFile, err := os.CreateTemp(cfg.installDir, ".ox-adapter-install-*")
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
 	}
 	tmpPath := tmpFile.Name()
 	defer os.Remove(tmpPath) // clean up on failure
 
-	if _, err := io.Copy(tmpFile, dlResp.Body); err != nil {
+	// Hash WHILE copying so the bytes we write are exactly the bytes we hash.
+	hasher := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmpFile, hasher), dlResp.Body); err != nil {
 		tmpFile.Close()
 		return fmt.Errorf("write binary: %w", err)
 	}
 	tmpFile.Close()
 
+	// CHECKSUM GATE (ADR-022 invariant): the file is still 0600 and never executed.
+	// On the verified path, a mismatch aborts BEFORE chmod/exec. Constant-time
+	// compare avoids leaking where the digests diverge.
+	if plan.checksum != "" {
+		got := hex.EncodeToString(hasher.Sum(nil))
+		want := strings.ToLower(plan.checksum)
+		if subtle.ConstantTimeCompare([]byte(got), []byte(want)) != 1 {
+			return fmt.Errorf("checksum mismatch for %s: expected %s, got %s (refusing to install)", assetName, want, got)
+		}
+		slog.Info("adapter checksum verified", "asset", assetName, "sha256", got)
+	}
+
+	// Only past the gate do we make the bytes executable.
 	if err := os.Chmod(tmpPath, 0755); err != nil {
 		return fmt.Errorf("set executable permission: %w", err)
 	}
 
-	// verify the binary runs info successfully
-	if err := verifyAdapterBinary(tmpPath); err != nil {
+	// Protocol conformance (NOT provenance — provenance was the checksum gate).
+	if err := cfg.verify(tmpPath); err != nil {
 		return fmt.Errorf("installed binary failed verification: %w", err)
 	}
 
@@ -408,60 +541,98 @@ func runAdapterInstall(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-// resolveAdapterSource resolves an adapter source string to owner/repo.
-// Accepts either a short name (looked up in the embedded registry) or a
-// full github.com/<owner>/<repo> URL.
+// resolveAdapterSource resolves an adapter source string to an installPlan.
+// Accepts either a short name (looked up in the embedded registry) or a full
+// github.com/<owner>/<repo>[@<tag>] URL.
 //
 // This split is the adapter trust boundary (ADR-022): a short name means
 // "install what SageOx curated under this name" (SageOx is the trust anchor, so
-// the curated path must verify authenticity), while a github.com/<owner>/<repo>
-// URL means "install this repo I explicitly named" (the user is the trust anchor,
-// so that path stays frictionless). Keep the two paths distinguishable here — do
-// not collapse them into one install flow with one trust policy.
-func resolveAdapterSource(source string) (owner, repo string, err error) {
+// the curated path carries a registry tag pin + per-platform checksum), while a
+// github.com/<owner>/<repo>@<tag> URL means "install this repo I explicitly
+// named at this tag" (the user is the trust anchor; SageOx has no checksum, so
+// the caller must pass --allow-unverified). Keep the two paths distinguishable —
+// do not collapse them into one install flow with one trust policy.
+func resolveAdapterSource(source, platform string) (installPlan, error) {
 	// if it looks like a GitHub URL, parse directly (user-as-trust-anchor path)
 	if strings.Contains(source, "/") {
-		return parseGitHubRepo(source)
+		owner, repo, tag, err := parseGitHubRepo(source)
+		if err != nil {
+			return installPlan{}, err
+		}
+		// The arbitrary path requires an explicit @<tag>: without a pin there is
+		// nothing reproducible to install and nothing for the user to vouch for.
+		if tag == "" {
+			return installPlan{}, fmt.Errorf("installing from an arbitrary repo requires an explicit tag: use github.com/%s/%s@<tag>", owner, repo)
+		}
+		return installPlan{owner: owner, repo: repo, tag: tag, curated: false, platform: platform}, nil
 	}
 
-	// short name -- look up in registry
+	// short name -- look up in registry (curated, SageOx-as-trust-anchor path)
 	reg, loadErr := adapter.LoadEmbeddedRegistry()
 	if loadErr != nil {
-		return "", "", fmt.Errorf("registry unavailable: %w", loadErr)
+		return installPlan{}, fmt.Errorf("registry unavailable: %w", loadErr)
 	}
 
 	entry := reg.Lookup(source)
 	if entry == nil {
-		return "", "", fmt.Errorf("adapter %q not found in registry (use github.com/<owner>/<repo> for unlisted adapters)", source)
+		return installPlan{}, fmt.Errorf("adapter %q not found in registry (use github.com/<owner>/<repo>@<tag> for unlisted adapters)", source)
 	}
 
 	if entry.Bundled {
-		return "", "", fmt.Errorf("adapter %q is bundled with ox and does not need to be installed separately", source)
+		return installPlan{}, fmt.Errorf("adapter %q is bundled with ox and does not need to be installed separately", source)
 	}
 
 	parts := strings.SplitN(entry.Repo, "/", 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid repo %q in registry for adapter %q", entry.Repo, source)
+		return installPlan{}, fmt.Errorf("invalid repo %q in registry for adapter %q", entry.Repo, source)
 	}
-	return parts[0], parts[1], nil
+
+	plan := installPlan{
+		owner:     parts[0],
+		repo:      parts[1],
+		tag:       entry.Tag,
+		curated:   true,
+		platform:  platform,
+		checksums: entry.Checksums,
+		checksum:  entry.Checksums[platform], // "" when unpinned -> fail-closed upstream
+	}
+	// A curated entry with no tag pin cannot fetch releases/tags/<tag>; treat it as
+	// unverifiable (fail-closed unless --allow-unverified). We cannot fall back to
+	// releases/latest — that is precisely the gap ADR-022/ox-5ihl closes. When the
+	// tag is missing we leave plan.tag empty AND blank the checksum so the caller's
+	// fail-closed branch fires with a clear message rather than a tag assertion.
+	if plan.tag == "" {
+		plan.checksum = ""
+	}
+	return plan, nil
 }
 
-// parseGitHubRepo extracts owner/repo from a GitHub URL or shorthand.
-func parseGitHubRepo(source string) (owner, repo string, err error) {
+// parseGitHubRepo extracts owner, repo, and an optional @<tag> from a GitHub URL
+// or shorthand: github.com/<owner>/<repo>[@<tag>]. tag is "" when absent; the
+// caller decides whether a missing tag is acceptable (the arbitrary path requires
+// one — ADR-022).
+func parseGitHubRepo(source string) (owner, repo, tag string, err error) {
 	source = strings.TrimPrefix(source, "https://")
 	source = strings.TrimPrefix(source, "http://")
 	source = strings.TrimSuffix(source, "/")
 
 	if !strings.HasPrefix(source, "github.com/") {
-		return "", "", fmt.Errorf("must start with github.com/")
+		return "", "", "", fmt.Errorf("must start with github.com/")
 	}
 
-	parts := strings.SplitN(strings.TrimPrefix(source, "github.com/"), "/", 2)
+	rest := strings.TrimPrefix(source, "github.com/")
+	// split off an optional @<tag> suffix (on the repo segment)
+	if at := strings.LastIndex(rest, "@"); at != -1 {
+		tag = rest[at+1:]
+		rest = rest[:at]
+	}
+
+	parts := strings.SplitN(rest, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("expected github.com/<owner>/<repo>")
+		return "", "", "", fmt.Errorf("expected github.com/<owner>/<repo>[@<tag>]")
 	}
 
-	return parts[0], parts[1], nil
+	return parts[0], parts[1], tag, nil
 }
 
 // deriveAdapterBinaryName strips platform suffix from the asset name.
@@ -476,14 +647,15 @@ func deriveAdapterBinaryName(assetName, platform string) string {
 	return name
 }
 
-// verifyAdapterBinary runs the info subcommand to verify a binary is a valid adapter.
+// verifyAdapterProtocol runs the info subcommand to verify a binary is a valid adapter.
 //
 // IMPORTANT: this is PROTOCOL-CONFORMANCE verification, NOT provenance. It answers
 // "is this a runnable ox adapter?", never "is this the binary SageOx curated?".
-// The name has misled reviewers into reading it as an integrity check — it is not,
-// and was never intended to be (ADR-022). Provenance is the checksum gate in
-// runAdapterInstall (ox-5ihl). When that lands, rename this verifyAdapterProtocol.
-func verifyAdapterBinary(binaryPath string) error {
+// The old name (verifyAdapterBinary) misled reviewers into reading it as an
+// integrity check — it is not, and was never intended to be (ADR-022 decision 5).
+// Provenance is the checksum gate in installAdapter (ox-5ihl), which runs BEFORE
+// this is ever reached on the verified path.
+func verifyAdapterProtocol(binaryPath string) error {
 	cmd := exec.Command(binaryPath, "info")
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("OX_PROTOCOL_VERSION=%d", adapterprotocol.ProtocolVersion),
@@ -580,8 +752,8 @@ func runAdapterLink(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("binary name must start with 'ox-adapter-' (got %q)", binaryName)
 	}
 
-	// verify it is a valid adapter
-	if err := verifyAdapterBinary(sourcePath); err != nil {
+	// verify it is a valid adapter (protocol conformance; dev link, not acquisition)
+	if err := verifyAdapterProtocol(sourcePath); err != nil {
 		return fmt.Errorf("binary validation failed: %w", err)
 	}
 

--- a/cmd/ox/adapter.go
+++ b/cmd/ox/adapter.go
@@ -284,6 +284,19 @@ it to ~/.local/share/ox/adapters/.`,
 	RunE: runAdapterInstall,
 }
 
+// runAdapterInstall acquires and installs an adapter binary.
+//
+// SECURITY POSTURE (see docs/adr/ADR-022-adapter-security-posture.md):
+// Executing adapter code is the intended extension mechanism, not a vulnerability.
+// What we harden is the *moment of acquisition*, and only where SageOx is the
+// trust anchor. Two paths with different anchors:
+//   - curated short-name ("cursor"): SageOx vouches -> integrity check required
+//     (pin tag + sha256, verify-before-exec). Tracked in ox-5ihl.
+//   - arbitrary github.com/<owner>/<repo>: the user vouches -> stays frictionless.
+//
+// Once installed, an adapter runs every session as the user; installation IS the
+// trust decision. We do not sandbox an installed adapter from the user's own
+// session — that is outside the documented threat model (security/SECURITY.md).
 func runAdapterInstall(_ *cobra.Command, args []string) error {
 	source := args[0]
 
@@ -306,6 +319,9 @@ func runAdapterInstall(_ *cobra.Command, args []string) error {
 
 	// fetch latest release from GitHub API
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
+	// NOTE: resolves releases/latest with no version pin. On the curated path this
+	// is the authenticity gap (ox-5ihl, ADR-022): the GitHub API response is
+	// network input and is not yet trusted to name the exact binary SageOx curated.
 	resp, err := http.Get(apiURL) //nolint:gosec // URL constructed from trusted adapter registry
 	if err != nil {
 		return fmt.Errorf("fetch release info: %w", err)
@@ -342,6 +358,11 @@ func runAdapterInstall(_ *cobra.Command, args []string) error {
 	slog.Info("downloading adapter", "asset", assetName)
 
 	// download binary
+	// NOTE: bytes fetched here are network input and currently unverified. The
+	// integrity gate (sha256 constant-time compare against the registry pin, BEFORE
+	// chmod/exec) belongs immediately after the download completes — see ADR-022
+	// decisions 2 and 5, ox-5ihl. A download-host allowlist is deliberately NOT the
+	// control (GitHub rotates CDN hosts; checksum subsumes it — ADR-022 decision 4).
 	dlResp, err := http.Get(downloadURL) //nolint:gosec // URL from GitHub API release response
 	if err != nil {
 		return fmt.Errorf("download binary: %w", err)
@@ -390,8 +411,15 @@ func runAdapterInstall(_ *cobra.Command, args []string) error {
 // resolveAdapterSource resolves an adapter source string to owner/repo.
 // Accepts either a short name (looked up in the embedded registry) or a
 // full github.com/<owner>/<repo> URL.
+//
+// This split is the adapter trust boundary (ADR-022): a short name means
+// "install what SageOx curated under this name" (SageOx is the trust anchor, so
+// the curated path must verify authenticity), while a github.com/<owner>/<repo>
+// URL means "install this repo I explicitly named" (the user is the trust anchor,
+// so that path stays frictionless). Keep the two paths distinguishable here — do
+// not collapse them into one install flow with one trust policy.
 func resolveAdapterSource(source string) (owner, repo string, err error) {
-	// if it looks like a GitHub URL, parse directly
+	// if it looks like a GitHub URL, parse directly (user-as-trust-anchor path)
 	if strings.Contains(source, "/") {
 		return parseGitHubRepo(source)
 	}
@@ -449,6 +477,12 @@ func deriveAdapterBinaryName(assetName, platform string) string {
 }
 
 // verifyAdapterBinary runs the info subcommand to verify a binary is a valid adapter.
+//
+// IMPORTANT: this is PROTOCOL-CONFORMANCE verification, NOT provenance. It answers
+// "is this a runnable ox adapter?", never "is this the binary SageOx curated?".
+// The name has misled reviewers into reading it as an integrity check — it is not,
+// and was never intended to be (ADR-022). Provenance is the checksum gate in
+// runAdapterInstall (ox-5ihl). When that lands, rename this verifyAdapterProtocol.
 func verifyAdapterBinary(binaryPath string) error {
 	cmd := exec.Command(binaryPath, "info")
 	cmd.Env = append(os.Environ(),

--- a/cmd/ox/adapter.go
+++ b/cmd/ox/adapter.go
@@ -433,7 +433,7 @@ func installAdapter(cfg installConfig) error {
 	// Fetch the PINNED release (releases/tags/<tag>), never releases/latest, so a
 	// retagged/swapped "latest" cannot redirect a pinned install (ADR-022).
 	apiURL := fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", cfg.apiBaseURL, plan.owner, plan.repo, plan.tag)
-	resp, err := client.Get(apiURL) //nolint:gosec // URL built from registry-resolved owner/repo/tag
+	resp, err := client.Get(apiURL) //nolint:gosec // fixed api.github.com endpoint; owner/repo/tag from registry (curated) or validated user input (arbitrary-repo path)
 	if err != nil {
 		return fmt.Errorf("fetch release info: %w", err)
 	}

--- a/cmd/ox/adapter_fix_argv_test.go
+++ b/cmd/ox/adapter_fix_argv_test.go
@@ -81,3 +81,47 @@ func TestRunAdapterFix_StringsFieldsLossiness(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "FixArgv") || strings.Contains(err.Error(), "display-only"))
 }
+
+// TestRunAdapterFix_RefusesGlobalConfigPersistence is the load-bearing test for
+// ADR-022 §8: a malicious adapter returning `git config --global ...` with
+// FixSafe=true must NOT silently auto-run. argv[0]="git" passes the allowlist, so
+// without the scope-escalation gate this would grant machine-wide persistence
+// (core.hooksPath / credential.helper / init.templateDir) on `ox doctor --fix`.
+// In a non-interactive test environment the gate must refuse outright — FixSafe
+// and --yes cannot elevate a global/system mutation to auto-run.
+// Failure prevented: adapter-driven machine-wide RCE persistence via doctor --fix.
+func TestRunAdapterFix_RefusesGlobalConfigPersistence(t *testing.T) {
+	for _, argv := range [][]string{
+		{"git", "config", "--global", "core.hooksPath", "/tmp/evil"},
+		{"git", "config", "--system", "credential.helper", "/tmp/steal"},
+		{"git", "-c", "core.fsmonitor=/tmp/evil", "status"},
+	} {
+		issue := adapterprotocol.DiagnoseIssue{Slug: "persist", FixArgv: argv, FixSafe: true}
+		err := runAdapterFix(issue, true /* forceYes can't elevate */)
+		require.Error(t, err, "argv %v must be refused", argv)
+		assert.Contains(t, err.Error(), "global/system")
+	}
+}
+
+// TestArgvHasScopeEscalation locks the detector: scope flags (including the
+// --flag=value joined form) are caught; a repo-local fix is not.
+func TestArgvHasScopeEscalation(t *testing.T) {
+	escalating := [][]string{
+		{"git", "config", "--global", "x", "y"},
+		{"git", "config", "--system", "x", "y"},
+		{"git", "config", "--worktree", "x", "y"},
+		{"git", "-c", "k=v", "status"},
+		{"git", "config", "--global=true", "x"},
+	}
+	for _, a := range escalating {
+		assert.True(t, argvHasScopeEscalation(a), "expected escalation for %v", a)
+	}
+	safe := [][]string{
+		{"git", "config", "--local", "core.hooksPath", ".husky"},
+		{"git", "--version"},
+		{"ox", "doctor"},
+	}
+	for _, a := range safe {
+		assert.False(t, argvHasScopeEscalation(a), "expected no escalation for %v", a)
+	}
+}

--- a/cmd/ox/adapter_install_test.go
+++ b/cmd/ox/adapter_install_test.go
@@ -1,0 +1,399 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// These tests cover the curated-path install integrity invariant from ADR-022 /
+// ox-5ihl: download -> checksum gate -> chmod -> verifyAdapterProtocol -> rename.
+// The security claim is that no untrusted byte is made executable or run before
+// the checksum gate passes, and that unverifiable installs fail closed.
+
+// fakeReleaseServer stands in for the GitHub API + asset CDN. It serves a tagged
+// release whose single asset for the current platform returns assetBody. The
+// asset URL is rooted at the same httptest host so ValidateHTTPSHost can be
+// driven by passing that host (or omitting it) in allowedHosts.
+type fakeReleaseServer struct {
+	srv       *httptest.Server
+	tagName   string // value returned in tag_name (may differ from requested to test mismatch)
+	assetBody []byte // bytes served for the platform asset
+	assetHost string // override host in browser_download_url (for host-guard tests); "" => same server
+	hits      map[string]int
+}
+
+func newFakeReleaseServer(t *testing.T, tagName string, assetBody []byte) *fakeReleaseServer {
+	t.Helper()
+	f := &fakeReleaseServer{tagName: tagName, assetBody: assetBody, hits: map[string]int{}}
+	mux := http.NewServeMux()
+	platform := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+	assetName := "ox-adapter-fake_" + platform
+
+	mux.HandleFunc("/asset", func(w http.ResponseWriter, _ *http.Request) {
+		f.hits["asset"]++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(f.assetBody)
+	})
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// expect /repos/<owner>/<repo>/releases/tags/<tag>
+		f.hits["api"]++
+		if !strings.Contains(r.URL.Path, "/releases/tags/") {
+			http.Error(w, "only releases/tags/<tag> is served", http.StatusNotFound)
+			return
+		}
+		host := f.srv.URL
+		if f.assetHost != "" {
+			host = f.assetHost
+		}
+		resp := map[string]any{
+			"tag_name": f.tagName,
+			"assets": []map[string]string{
+				{"name": assetName, "browser_download_url": host + "/asset"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	// TLS server so the https transport guard (ValidateHTTPSHost) applies; tests
+	// inject f.srv.Client() which trusts the test cert.
+	f.srv = httptest.NewTLSServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// allowAllHosts returns nil so ValidateHTTPSHost skips the allowlist check, which
+// is what we want for httptest (the server is on an ephemeral 127.0.0.1 host).
+func allowAllHosts() map[string]bool { return nil }
+
+// TestInstallAdapter_ChecksumMatch_Verifies the happy path: matching checksum
+// passes the gate, the binary is chmod'd and the verify hook runs, then rename.
+func TestInstallAdapter_ChecksumMatch(t *testing.T) {
+	body := []byte("trusted adapter bytes")
+	f := newFakeReleaseServer(t, "v1.0.0", body)
+
+	installDir := t.TempDir()
+	verifyCalled := false
+	cfg := installConfig{
+		plan: installPlan{
+			owner: "sageox", repo: "ox-adapters", tag: "v1.0.0",
+			checksum: sha256Hex(body), curated: true,
+			platform: fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH),
+		},
+		apiBaseURL:   f.srv.URL,
+		httpClient:   f.srv.Client(),
+		allowedHosts: allowAllHosts(),
+		installDir:   installDir,
+		verify: func(path string) error {
+			verifyCalled = true
+			// by the time verify runs, bytes are on disk and executable
+			fi, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+			if fi.Mode().Perm()&0o100 == 0 {
+				t.Errorf("verify reached but binary not executable (perm=%o)", fi.Mode().Perm())
+			}
+			return nil
+		},
+	}
+
+	if err := installAdapter(cfg); err != nil {
+		t.Fatalf("install with matching checksum should succeed: %v", err)
+	}
+	if !verifyCalled {
+		t.Error("verifyAdapterProtocol should run after the checksum gate passes")
+	}
+	// installed file should exist with the trusted bytes
+	got, err := os.ReadFile(filepath.Join(installDir, "ox-adapter-fake"))
+	if err != nil {
+		t.Fatalf("installed binary missing: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Errorf("installed bytes = %q, want %q", got, body)
+	}
+}
+
+// TestInstallAdapter_ChecksumMismatch_FailsBeforeChmodAndExec is the core security
+// test: a swapped/compromised asset (wrong bytes) must abort BEFORE the binary is
+// made executable or handed to verifyAdapterProtocol, and nothing is installed.
+func TestInstallAdapter_ChecksumMismatch_FailsBeforeChmodAndExec(t *testing.T) {
+	wrongBody := []byte("malicious swapped bytes")
+	f := newFakeReleaseServer(t, "v1.0.0", wrongBody)
+
+	installDir := t.TempDir()
+	cfg := installConfig{
+		plan: installPlan{
+			owner: "sageox", repo: "ox-adapters", tag: "v1.0.0",
+			// pin the checksum of DIFFERENT (legitimate) bytes
+			checksum: sha256Hex([]byte("the bytes SageOx actually curated")),
+			curated:  true,
+			platform: fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH),
+		},
+		apiBaseURL:   f.srv.URL,
+		httpClient:   f.srv.Client(),
+		allowedHosts: allowAllHosts(),
+		installDir:   installDir,
+		verify: func(string) error {
+			t.Fatal("verifyAdapterProtocol must NOT be reached on checksum mismatch (sentinel)")
+			return nil
+		},
+	}
+
+	err := installAdapter(cfg)
+	if err == nil {
+		t.Fatal("install must fail on checksum mismatch")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("error should mention checksum mismatch, got: %v", err)
+	}
+	// nothing installed
+	if entries, _ := os.ReadDir(installDir); len(entries) != 0 {
+		t.Errorf("no file should remain in install dir on mismatch, found %d", len(entries))
+	}
+}
+
+// TestInstallAdapter_AllowUnverified_SkipsChecksumKeepsVerify mirrors the
+// --allow-unverified path: with an empty checksum the gate is skipped (no compare)
+// but verifyAdapterProtocol STILL runs and the install proceeds.
+func TestInstallAdapter_AllowUnverified_SkipsChecksumKeepsVerify(t *testing.T) {
+	body := []byte("user-vouched-for bytes")
+	f := newFakeReleaseServer(t, "v0.1.0", body)
+
+	installDir := t.TempDir()
+	verifyCalled := false
+	cfg := installConfig{
+		plan: installPlan{
+			owner: "me", repo: "ox-adapter-x", tag: "v0.1.0",
+			checksum: "", curated: false, // unverifiable, allow-unverified
+			platform: fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH),
+		},
+		apiBaseURL:   f.srv.URL,
+		httpClient:   f.srv.Client(),
+		allowedHosts: allowAllHosts(),
+		installDir:   installDir,
+		verify:       func(string) error { verifyCalled = true; return nil },
+	}
+
+	if err := installAdapter(cfg); err != nil {
+		t.Fatalf("allow-unverified install should proceed: %v", err)
+	}
+	if !verifyCalled {
+		t.Error("protocol verification must still run on the allow-unverified path")
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "ox-adapter-fake")); err != nil {
+		t.Errorf("binary should be installed on allow-unverified path: %v", err)
+	}
+}
+
+// TestInstallAdapter_RejectsAttackerDownloadHost verifies the defense-in-depth
+// transport guard: a browser_download_url pointing at a host outside the
+// allowlist is refused before any download.
+func TestInstallAdapter_RejectsAttackerDownloadHost(t *testing.T) {
+	body := []byte("bytes")
+	f := newFakeReleaseServer(t, "v1.0.0", body)
+	f.assetHost = "https://attacker.example.com" // asset URL points off-allowlist
+
+	cfg := installConfig{
+		plan: installPlan{
+			owner: "sageox", repo: "ox-adapters", tag: "v1.0.0",
+			checksum: sha256Hex(body), curated: true,
+			platform: fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH),
+		},
+		apiBaseURL:   f.srv.URL,
+		httpClient:   f.srv.Client(),
+		allowedHosts: adapterDownloadHosts, // real allowlist, attacker host not in it
+		installDir:   t.TempDir(),
+		verify:       func(string) error { return nil },
+	}
+
+	err := installAdapter(cfg)
+	if err == nil {
+		t.Fatal("install must refuse an off-allowlist download host")
+	}
+	if !strings.Contains(err.Error(), "allowlist") {
+		t.Errorf("error should mention host allowlist, got: %v", err)
+	}
+}
+
+// TestInstallAdapter_TagNameMismatchRejected verifies that a release whose
+// tag_name differs from the pinned tag is rejected (a retag/substitution attempt).
+func TestInstallAdapter_TagNameMismatchRejected(t *testing.T) {
+	body := []byte("bytes")
+	f := newFakeReleaseServer(t, "v9.9.9", body) // API returns a different tag
+
+	cfg := installConfig{
+		plan: installPlan{
+			owner: "sageox", repo: "ox-adapters", tag: "v1.0.0", // we asked for v1.0.0
+			checksum: sha256Hex(body), curated: true,
+			platform: fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH),
+		},
+		apiBaseURL:   f.srv.URL,
+		httpClient:   f.srv.Client(),
+		allowedHosts: allowAllHosts(),
+		installDir:   t.TempDir(),
+		verify:       func(string) error { return nil },
+	}
+
+	err := installAdapter(cfg)
+	if err == nil {
+		t.Fatal("install must reject a tag_name that does not match the pin")
+	}
+	if !strings.Contains(err.Error(), "tag mismatch") {
+		t.Errorf("error should mention tag mismatch, got: %v", err)
+	}
+}
+
+// TestInstallAdapter_UsesTagsEndpointNotLatest verifies the install hits
+// releases/tags/<tag>, never releases/latest (the gap ox-5ihl closes).
+func TestInstallAdapter_UsesTagsEndpointNotLatest(t *testing.T) {
+	body := []byte("bytes")
+	var requestedPath string
+	mux := http.NewServeMux()
+	platform := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	mux.HandleFunc("/asset", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		resp := map[string]any{
+			"tag_name": "v2.0.0",
+			"assets": []map[string]string{
+				{"name": "ox-adapter-fake_" + platform, "browser_download_url": srv.URL + "/asset"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	cfg := installConfig{
+		plan: installPlan{
+			owner: "sageox", repo: "ox-adapters", tag: "v2.0.0",
+			checksum: sha256Hex(body), curated: true, platform: platform,
+		},
+		apiBaseURL:   srv.URL,
+		httpClient:   srv.Client(),
+		allowedHosts: allowAllHosts(),
+		installDir:   t.TempDir(),
+		verify:       func(string) error { return nil },
+	}
+	if err := installAdapter(cfg); err != nil {
+		t.Fatalf("install should succeed: %v", err)
+	}
+	if !strings.Contains(requestedPath, "/releases/tags/v2.0.0") {
+		t.Errorf("expected releases/tags/v2.0.0 endpoint, got %q", requestedPath)
+	}
+	if strings.Contains(requestedPath, "releases/latest") {
+		t.Errorf("install must not use releases/latest, got %q", requestedPath)
+	}
+}
+
+// TestInstallAdapter_NoTag_FailsClosed verifies the internal invariant that a
+// plan without a pinned tag cannot install (defense in depth behind the cobra layer).
+func TestInstallAdapter_NoTag_FailsClosed(t *testing.T) {
+	cfg := installConfig{
+		plan:       installPlan{owner: "me", repo: "x", curated: false, platform: "linux_amd64"},
+		apiBaseURL: "https://api.github.com",
+		installDir: t.TempDir(),
+		verify:     func(string) error { return nil },
+	}
+	if err := installAdapter(cfg); err == nil {
+		t.Fatal("install with no pinned tag must fail closed")
+	}
+}
+
+// --- resolveAdapterSource trust-anchor behavior ---
+
+// TestResolveAdapterSource_ArbitraryRepoRequiresTag verifies that an arbitrary
+// github.com/<owner>/<repo> source without an explicit @<tag> is rejected.
+func TestResolveAdapterSource_ArbitraryRepoRequiresTag(t *testing.T) {
+	_, err := resolveAdapterSource("github.com/me/ox-adapter-x", "linux_amd64")
+	if err == nil {
+		t.Fatal("arbitrary repo without @tag must be rejected")
+	}
+	if !strings.Contains(err.Error(), "@<tag>") {
+		t.Errorf("error should instruct to pin a tag, got: %v", err)
+	}
+}
+
+// TestResolveAdapterSource_ArbitraryRepoWithTag verifies a tagged arbitrary repo
+// resolves to an uncurated, checksum-less plan (so the caller fails closed
+// without --allow-unverified).
+func TestResolveAdapterSource_ArbitraryRepoWithTag(t *testing.T) {
+	plan, err := resolveAdapterSource("github.com/me/ox-adapter-x@v0.1.0", "linux_amd64")
+	if err != nil {
+		t.Fatalf("tagged arbitrary repo should resolve: %v", err)
+	}
+	if plan.curated {
+		t.Error("arbitrary repo must not be marked curated")
+	}
+	if plan.tag != "v0.1.0" {
+		t.Errorf("tag = %q, want v0.1.0", plan.tag)
+	}
+	if plan.checksum != "" {
+		t.Error("arbitrary repo must have no SageOx checksum")
+	}
+}
+
+// TestResolveAdapterSource_CuratedUnpinned verifies a curated entry that lacks a
+// tag/checksum (the current external entries) resolves to a checksum-less plan,
+// driving fail-closed behavior until a maintainer pins one.
+func TestResolveAdapterSource_CuratedUnpinned(t *testing.T) {
+	// "cursor" is a real external registry entry shipped without a pin.
+	plan, err := resolveAdapterSource("cursor", "darwin_arm64")
+	if err != nil {
+		t.Fatalf("curated lookup should resolve: %v", err)
+	}
+	if !plan.curated {
+		t.Error("registry short-name must be marked curated")
+	}
+	if plan.checksum != "" {
+		t.Error("unpinned curated entry must have empty checksum (fail-closed)")
+	}
+}
+
+// --- runAdapterInstall fail-closed / allow-unverified at the cobra layer ---
+
+// TestRunAdapterInstall_UnverifiableFailsClosed verifies that installing an
+// arbitrary tagged repo WITHOUT --allow-unverified fails closed (no network needed
+// — the gate fires before any fetch).
+func TestRunAdapterInstall_UnverifiableFailsClosed(t *testing.T) {
+	cmd := adapterInstallCmd
+	// ensure the flag defaults to false for this invocation
+	_ = cmd.Flags().Set("allow-unverified", "false")
+	err := cmd.RunE(cmd, []string{"github.com/me/ox-adapter-x@v0.1.0"})
+	if err == nil {
+		t.Fatal("unverifiable install without --allow-unverified must fail closed")
+	}
+	if !strings.Contains(err.Error(), "allow-unverified") {
+		t.Errorf("error should point to --allow-unverified, got: %v", err)
+	}
+}
+
+// TestRunAdapterInstall_CuratedUnpinnedFailsClosed verifies the documented
+// transition: `ox adapter install cursor` (no pin yet) fails closed without
+// --allow-unverified.
+func TestRunAdapterInstall_CuratedUnpinnedFailsClosed(t *testing.T) {
+	cmd := adapterInstallCmd
+	_ = cmd.Flags().Set("allow-unverified", "false")
+	err := cmd.RunE(cmd, []string{"cursor"})
+	if err == nil {
+		t.Fatal("curated entry with no pinned tag must fail closed")
+	}
+}

--- a/cmd/ox/adapter_test.go
+++ b/cmd/ox/adapter_test.go
@@ -174,12 +174,15 @@ func TestParseGitHubRepo(t *testing.T) {
 		input     string
 		wantOwner string
 		wantRepo  string
+		wantTag   string
 		wantErr   bool
 	}{
 		{input: "github.com/sageox/ox-adapters", wantOwner: "sageox", wantRepo: "ox-adapters"},
 		{input: "https://github.com/sageox/ox-adapters", wantOwner: "sageox", wantRepo: "ox-adapters"},
 		{input: "https://github.com/sageox/ox-adapters/", wantOwner: "sageox", wantRepo: "ox-adapters"},
 		{input: "http://github.com/sageox/ox-adapters", wantOwner: "sageox", wantRepo: "ox-adapters"},
+		{input: "github.com/sageox/ox-adapters@v1.2.3", wantOwner: "sageox", wantRepo: "ox-adapters", wantTag: "v1.2.3"},
+		{input: "https://github.com/me/x@v0.1.0", wantOwner: "me", wantRepo: "x", wantTag: "v0.1.0"},
 		{input: "gitlab.com/foo/bar", wantErr: true},
 		{input: "github.com/", wantErr: true},
 		{input: "github.com/owner-only", wantErr: true},
@@ -188,7 +191,7 @@ func TestParseGitHubRepo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			owner, repo, err := parseGitHubRepo(tt.input)
+			owner, repo, tag, err := parseGitHubRepo(tt.input)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error for %q", tt.input)
@@ -203,6 +206,9 @@ func TestParseGitHubRepo(t *testing.T) {
 			}
 			if repo != tt.wantRepo {
 				t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+			}
+			if tag != tt.wantTag {
+				t.Errorf("tag = %q, want %q", tag, tt.wantTag)
 			}
 		})
 	}
@@ -245,7 +251,7 @@ func TestVerifyAdapterBinary_InvalidBinary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := verifyAdapterBinary(badBinary)
+	err := verifyAdapterProtocol(badBinary)
 	if err == nil {
 		t.Fatal("should reject binary with invalid info response")
 	}
@@ -257,7 +263,7 @@ func TestVerifyAdapterBinary_ValidBinary(t *testing.T) {
 	dir := t.TempDir()
 	createFakeAdapter(t, dir, "valid", "1.0.0", "session")
 
-	err := verifyAdapterBinary(filepath.Join(dir, "ox-adapter-valid"))
+	err := verifyAdapterProtocol(filepath.Join(dir, "ox-adapter-valid"))
 	if err != nil {
 		t.Fatalf("should accept valid adapter: %v", err)
 	}
@@ -274,7 +280,7 @@ echo '{"protocol_version":0,"name":"old","display_name":"Old","version":"1.0.0",
 		t.Fatal(err)
 	}
 
-	err := verifyAdapterBinary(binaryPath)
+	err := verifyAdapterProtocol(binaryPath)
 	if err == nil {
 		t.Fatal("should reject adapter with old protocol version")
 	}

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1810,7 +1810,7 @@ func runAgentSessionRecord(inst *agentinstance.Instance, args []string) error {
 	}
 
 	// record entries to session file
-	recorded, err := recordEntriesToSession(state, entries)
+	recorded, err := recordEntriesToSession(projectRoot, state, entries)
 	if err != nil {
 		return fmt.Errorf("failed to record entries: %w", err)
 	}
@@ -2089,22 +2089,30 @@ func parseRecordEntries(args []string) ([]sessionRecordInput, error) {
 }
 
 // recordEntriesToSession appends entries to the raw session file.
-func recordEntriesToSession(state *session.RecordingState, entries []sessionRecordInput) (int, error) {
+//
+// All writes go through session.RawWriter — the single chokepoint that
+// gates every byte landing in raw.jsonl through the three-layer redaction
+// stack (command-allowlist, built-in regex Redactor, gitleaks extras).
+// Writing content/tool_input/tool_output verbatim here would let secrets
+// reach the team-visible LFS ledger unredacted. state.SessionPath is the
+// LOCAL recording cache (not the ledger), so routing through RawWriter is
+// consistent with cache-only design.
+//
+// WriteRaw (not WriteEntry) is used because SessionEntry carries no seq
+// field; the seq numbering (state.EntryCount + i) must survive into the
+// JSON, so we hand RawWriter the same map the legacy encoder wrote.
+func recordEntriesToSession(projectRoot string, state *session.RecordingState, entries []sessionRecordInput) (int, error) {
 	if state == nil || state.SessionPath == "" {
 		return 0, fmt.Errorf("invalid recording state")
 	}
 
-	// open raw session file for append
 	rawPath := filepath.Join(state.SessionPath, ledgerFileRaw)
-	f, err := os.OpenFile(rawPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	w, err := session.NewRawWriter(rawPath, projectRoot)
 	if err != nil {
 		return 0, fmt.Errorf("open raw session: %w", err)
 	}
-	defer f.Close()
 
-	encoder := json.NewEncoder(f)
 	recorded := 0
-
 	for i, entry := range entries {
 		// parse timestamp or use current time
 		ts := time.Now()
@@ -2132,14 +2140,15 @@ func recordEntriesToSession(state *session.RecordingState, entries []sessionReco
 			data["tool_output"] = entry.ToolOutput
 		}
 
-		if err := encoder.Encode(data); err != nil {
+		if err := w.WriteRaw(data); err != nil {
+			_ = w.Close()
 			return recorded, fmt.Errorf("write entry %d: %w", i, err)
 		}
 		recorded++
 	}
 
-	// sync to disk
-	if err := f.Sync(); err != nil {
+	// CloseAndSync flushes and fsyncs in one shot (RawWriter owns durability).
+	if err := w.CloseAndSync(); err != nil {
 		return recorded, fmt.Errorf("sync session: %w", err)
 	}
 

--- a/cmd/ox/agent_session_incremental.go
+++ b/cmd/ox/agent_session_incremental.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -65,18 +64,24 @@ func writeRawHeader(projectRoot string, state *session.RecordingState) error {
 		"metadata": meta,
 	}
 
-	data, err := json.Marshal(header)
-	if err != nil {
-		return fmt.Errorf("marshal header: %w", err)
-	}
-	data = append(data, '\n')
-
 	if err := os.MkdirAll(filepath.Dir(rawPath), 0755); err != nil {
 		return fmt.Errorf("create raw.jsonl dir: %w", err)
 	}
 
-	if err := os.WriteFile(rawPath, data, 0644); err != nil {
+	// route the header through the RawWriter chokepoint so every byte in
+	// raw.jsonl — including this metadata line — passes the redaction
+	// stack. Truncate because the header is always the first line written
+	// at session start.
+	w, err := session.NewRawWriterTruncate(rawPath, projectRoot)
+	if err != nil {
+		return fmt.Errorf("open raw.jsonl: %w", err)
+	}
+	if err := w.WriteRaw(header); err != nil {
+		_ = w.Close()
 		return fmt.Errorf("write raw.jsonl header: %w", err)
+	}
+	if err := w.CloseAndSync(); err != nil {
+		return fmt.Errorf("sync raw.jsonl header: %w", err)
 	}
 
 	return nil

--- a/cmd/ox/agent_session_record_redaction_test.go
+++ b/cmd/ox/agent_session_record_redaction_test.go
@@ -1,0 +1,132 @@
+//go:build !short
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecordEntriesToSession_RedactsSecrets is the load-bearing security
+// test for ox-hxyq: recordEntriesToSession must route every byte through
+// the session.RawWriter redaction chokepoint. Before the fix this path
+// opened raw.jsonl directly and encoded tool_output verbatim, landing
+// secrets unredacted in the team-visible LFS ledger.
+//
+// Failure prevented: a secret in tool_output (or content/tool_input)
+// reaches raw.jsonl unredacted because the recording path bypassed
+// RawWriter.
+func TestRecordEntriesToSession_RedactsSecrets(t *testing.T) {
+	projectRoot := setupIncrementalTest(t)
+	state := startTestRecording(t, projectRoot, "OxRedact", "claude-code")
+
+	// canaries spanning the three redaction layers and all three string
+	// fields (content, tool_input, tool_output).
+	awsKey := "AKIAIOSFODNN7EXAMPLE"
+	// split-string OpenAI-shaped key so GitHub's secret scanner doesn't
+	// block the push; the redactor sees the concatenated whole.
+	openaiKey := "sk-" + "abcdefghijklmnopqrst" + "T3Blbk" + "FJ" + "abcdefghijklmnopqrst"
+
+	entries := []sessionRecordInput{
+		{
+			Type:       "tool",
+			Content:    "ran a command",
+			ToolName:   "Bash",
+			ToolInput:  "echo $OPENAI_API_KEY",
+			ToolOutput: "AWS_SECRET_ACCESS_KEY=" + awsKey + "\nkey=" + openaiKey,
+		},
+	}
+
+	recorded, err := recordEntriesToSession(projectRoot, state, entries)
+	require.NoError(t, err)
+	assert.Equal(t, 1, recorded)
+
+	rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+	data, err := os.ReadFile(rawPath)
+	require.NoError(t, err)
+	out := string(data)
+
+	// raw secrets must NOT survive the chokepoint.
+	assert.NotContains(t, out, awsKey, "AWS key leaked through recording path")
+	assert.NotContains(t, out, openaiKey, "OpenAI key leaked through recording path")
+
+	// the redaction marker proves the chokepoint actually fired.
+	assert.Contains(t, out, "[REDACTED", "expected redaction marker in raw.jsonl")
+
+	// seq numbering and the entry payload must still round-trip.
+	lines := readJSONLLines(t, rawPath)
+	require.Len(t, lines, 1)
+	assert.Equal(t, "tool", lines[0]["type"])
+	assert.Equal(t, "Bash", lines[0]["tool_name"])
+	// seq starts at state.EntryCount (0 for a fresh recording).
+	assert.EqualValues(t, 0, lines[0]["seq"])
+}
+
+// TestRecordEntriesToSession_FileModeIsOwnerOnly verifies the recording
+// path creates raw.jsonl as 0600 (owner-only), not world-readable.
+// raw.jsonl holds full conversation content; 0644 would leak it to every
+// local user.
+func TestRecordEntriesToSession_FileModeIsOwnerOnly(t *testing.T) {
+	projectRoot := setupIncrementalTest(t)
+	state := startTestRecording(t, projectRoot, "OxMode", "claude-code")
+
+	_, err := recordEntriesToSession(projectRoot, state, []sessionRecordInput{
+		{Type: "user", Content: "hello"},
+	})
+	require.NoError(t, err)
+
+	rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+	fi, err := os.Stat(rawPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), fi.Mode().Perm(),
+		"raw.jsonl must be owner-only (0600), got %o", fi.Mode().Perm())
+}
+
+// TestRecordEntriesToSession_PreservesSeqNumbering verifies multi-entry
+// seq numbering continues from state.EntryCount. The legacy direct-encoder
+// path numbered entries state.EntryCount+i; RawWriter must preserve that.
+func TestRecordEntriesToSession_PreservesSeqNumbering(t *testing.T) {
+	projectRoot := setupIncrementalTest(t)
+	state := startTestRecording(t, projectRoot, "OxSeq", "claude-code")
+	state.EntryCount = 5 // simulate prior entries already recorded
+
+	_, err := recordEntriesToSession(projectRoot, state, []sessionRecordInput{
+		{Type: "user", Content: "a"},
+		{Type: "assistant", Content: "b"},
+	})
+	require.NoError(t, err)
+
+	rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+	lines := readJSONLLines(t, rawPath)
+	require.Len(t, lines, 2)
+	assert.EqualValues(t, 5, lines[0]["seq"])
+	assert.EqualValues(t, 6, lines[1]["seq"])
+}
+
+// TestWriteRawHeader_FileModeIsOwnerOnly verifies the header write also
+// produces a 0600 raw.jsonl. writeRawHeader truncates at session start, so
+// it owns the initial file mode.
+func TestWriteRawHeader_FileModeIsOwnerOnly(t *testing.T) {
+	projectRoot := setupIncrementalTest(t)
+	state := startTestRecording(t, projectRoot, "OxHdrMode", "claude-code")
+
+	require.NoError(t, writeRawHeader(projectRoot, state))
+
+	rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
+	fi, err := os.Stat(rawPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), fi.Mode().Perm(),
+		"raw.jsonl header write must be owner-only (0600), got %o", fi.Mode().Perm())
+
+	// header contents must be unchanged.
+	lines := readJSONLLines(t, rawPath)
+	require.Len(t, lines, 1)
+	assert.Equal(t, "header", lines[0]["type"])
+	meta, ok := lines[0]["metadata"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "OxHdrMode", meta["agent_id"])
+}

--- a/cmd/ox/agent_session_subagent.go
+++ b/cmd/ox/agent_session_subagent.go
@@ -116,7 +116,9 @@ func runAgentSessionSubagentComplete(inst *agentinstance.Instance, args []string
 		fmt.Printf("  Parent session: %s\n", parentPath)
 		fmt.Printf("  Total subagents: %d\n", subagentCount)
 		if summary != "" {
-			fmt.Printf("  Summary: %s\n", summary)
+			// summary is LLM-generated/untrusted — strip terminal escapes to
+			// prevent escape-sequence injection (security finding #11)
+			fmt.Printf("  Summary: %s\n", stripANSIEscapes(summary))
 		}
 		fmt.Println()
 		fmt.Println("--- Machine Output ---")
@@ -199,7 +201,8 @@ func runAgentSessionSubagentList(inst *agentinstance.Instance) error {
 			for i, sub := range subagents {
 				fmt.Printf("    %d. %s", i+1, sub.SubagentID)
 				if sub.Summary != "" {
-					fmt.Printf(" - %s", sub.Summary)
+					// untrusted LLM-generated summary — strip terminal escapes (finding #11)
+					fmt.Printf(" - %s", stripANSIEscapes(sub.Summary))
 				}
 				fmt.Println()
 			}
@@ -217,7 +220,8 @@ func runAgentSessionSubagentList(inst *agentinstance.Instance) error {
 		for i, sub := range subagents {
 			fmt.Printf("  %d. %s", i+1, sub.SubagentID)
 			if sub.Summary != "" {
-				fmt.Printf(" - %s", sub.Summary)
+				// untrusted LLM-generated summary — strip terminal escapes (finding #11)
+				fmt.Printf(" - %s", stripANSIEscapes(sub.Summary))
 			}
 			fmt.Println()
 		}

--- a/cmd/ox/code.go
+++ b/cmd/ox/code.go
@@ -267,9 +267,13 @@ func compactSnippet(s string, maxLen int) string {
 //   - DCS (ESC P), SOS (ESC X), PM (ESC ^), APC (ESC _): … terminated by ST
 //   - other two-byte ESC sequences (ESC followed by a single byte)
 //   - bare C0 control bytes 0x00-0x1f except tab (0x09) and newline (0x0a)
+//   - bare C1 control bytes 0x80-0x9f, which include the 8-bit forms of CSI
+//     (0x9b) and OSC (0x9d) that terminals interpret as escape introducers —
+//     stripping ESC-prefixed sequences alone would miss them. Matches
+//     sanitizeSessionText (session_list.go).
 //
-// Runes are processed as bytes-safe: only ASCII control bytes are inspected; any
-// multibyte UTF-8 rune (all bytes >= 0x80) passes through unchanged.
+// Normal text is unaffected: printable Unicode starts at U+00A0, so only the
+// control ranges (never real runes in user content) are dropped.
 func stripANSIEscapes(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
@@ -287,8 +291,9 @@ func stripANSIEscapes(s string) string {
 		if r < 0x20 && r != '\t' && r != '\n' {
 			continue
 		}
-		// drop DEL
-		if r == 0x7f {
+		// drop DEL and the C1 control range (0x80-0x9f): 0x9b/0x9d are 8-bit
+		// CSI/OSC introducers, so leaving them would reopen the injection hole.
+		if r == 0x7f || (r >= 0x80 && r <= 0x9f) {
 			continue
 		}
 

--- a/cmd/ox/code.go
+++ b/cmd/ox/code.go
@@ -256,24 +256,85 @@ func compactSnippet(s string, maxLen int) string {
 	return result
 }
 
-// stripANSIEscapes removes ANSI escape sequences from a string.
+// stripANSIEscapes removes terminal escape sequences and bare control bytes from
+// a string so untrusted text (e.g. LLM-generated summaries) can be printed to a
+// terminal without injecting cursor moves, clipboard writes, or title changes.
+//
+// It strips:
+//   - CSI sequences: ESC [ … <final byte 0x40-0x7e>
+//   - OSC sequences: ESC ] … terminated by BEL (0x07) or ST (ESC \). The OSC 52
+//     clipboard-write payload is the motivating attack (security finding #11).
+//   - DCS (ESC P), SOS (ESC X), PM (ESC ^), APC (ESC _): … terminated by ST
+//   - other two-byte ESC sequences (ESC followed by a single byte)
+//   - bare C0 control bytes 0x00-0x1f except tab (0x09) and newline (0x0a)
+//
+// Runes are processed as bytes-safe: only ASCII control bytes are inspected; any
+// multibyte UTF-8 rune (all bytes >= 0x80) passes through unchanged.
 func stripANSIEscapes(s string) string {
 	var b strings.Builder
-	inEscape := false
-	for _, r := range s {
-		if r == '\033' {
-			inEscape = true
+	b.Grow(len(s))
+
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+
+		if r == '\033' { // ESC
+			i = skipEscapeSequence(runes, i)
 			continue
 		}
-		if inEscape {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
-				inEscape = false
-			}
+
+		// drop bare C0 control bytes except tab and newline
+		if r < 0x20 && r != '\t' && r != '\n' {
 			continue
 		}
+		// drop DEL
+		if r == 0x7f {
+			continue
+		}
+
 		b.WriteRune(r)
 	}
 	return b.String()
+}
+
+// skipEscapeSequence consumes the escape sequence starting at runes[i] (which is
+// ESC) and returns the index of its final consumed rune, so the caller's loop
+// advances past the whole sequence. Unterminated sequences consume to end.
+func skipEscapeSequence(runes []rune, i int) int {
+	// i points at ESC; look at the byte after it
+	if i+1 >= len(runes) {
+		return i // lone trailing ESC — drop it
+	}
+	next := runes[i+1]
+
+	switch next {
+	case '[': // CSI: ESC [ … <final 0x40-0x7e>
+		j := i + 2
+		for j < len(runes) {
+			c := runes[j]
+			if c >= 0x40 && c <= 0x7e {
+				return j // final byte
+			}
+			j++
+		}
+		return len(runes) - 1
+	case ']', 'P', 'X', '^', '_': // OSC, DCS, SOS, PM, APC — string terminated by BEL or ST (ESC \)
+		j := i + 2
+		for j < len(runes) {
+			c := runes[j]
+			if c == '\a' { // BEL terminator
+				return j
+			}
+			if c == '\033' && j+1 < len(runes) && runes[j+1] == '\\' { // ST: ESC \
+				return j + 1
+			}
+			j++
+		}
+		return len(runes) - 1
+	default:
+		// other two-byte escapes (e.g. ESC c, ESC =): drop ESC + the next byte
+		return i + 1
+	}
 }
 
 // codeQueryCmd is a hidden alias for codeSearchCmd — agents try "query" as a search verb

--- a/cmd/ox/doctor_adapters.go
+++ b/cmd/ox/doctor_adapters.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
@@ -277,6 +278,33 @@ var adapterFixArgvAllowlist = map[string]bool{
 	"ox":  true,
 }
 
+// gitScopeEscalationFlags are argv tokens that escalate a fix beyond the current
+// repo into machine-wide / persistent state. `git config --global|--system|
+// --worktree` and git's inline `-c` are the persistence vectors; the same flags
+// are treated as escalating for `ox` argv too (ADR-022 §8).
+var gitScopeEscalationFlags = map[string]bool{
+	"--global":   true,
+	"--system":   true,
+	"--worktree": true,
+	"-c":         true,
+}
+
+// argvHasScopeEscalation reports whether any argument (after argv[0]) is a
+// scope-escalating flag, including the `--global=...` joined form.
+func argvHasScopeEscalation(argv []string) bool {
+	for _, a := range argv[1:] {
+		if gitScopeEscalationFlags[a] {
+			return true
+		}
+		for flag := range gitScopeEscalationFlags {
+			if strings.HasPrefix(a, flag+"=") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // runAdapterFix executes a fix produced by an adapter.
 //
 // Hardening contract (ox-saoy):
@@ -303,6 +331,29 @@ func runAdapterFix(issue adapterprotocol.DiagnoseIssue, forceYes bool) error {
 			argv0, issue.Fix)
 	}
 
+	// A scope-escalating flag (e.g. `git config --global core.hooksPath=/tmp/evil`)
+	// grants machine-wide persistence — every future git command in every repo
+	// would run attacker code. FixSafe means "idempotent and non-destructive", NOT
+	// "run a persistence-granting command without showing the user". Per ADR-022 §8
+	// we surface the exact command and require explicit confirmation regardless of
+	// FixSafe/--yes, and refuse outright when we can't prompt. A key denylist
+	// (core.hooksPath, credential.helper, init.templateDir, …) is a losing game;
+	// gating on the scope flag is the durable control.
+	if argvHasScopeEscalation(issue.FixArgv) {
+		cli.PrintWarning(fmt.Sprintf("adapter-requested fix modifies global/system state:\n  %s",
+			strings.Join(issue.FixArgv, " ")))
+		if !cli.IsInteractive() {
+			return fmt.Errorf("auto-fix refused: %q modifies global/system state and cannot be confirmed non-interactively; apply manually: %s",
+				strings.Join(issue.FixArgv, " "), issue.Fix)
+		}
+		if !cli.ConfirmYesNo("Run this adapter-requested command?", false) {
+			return fmt.Errorf("auto-fix declined")
+		}
+	}
+
+	// Surface the exact command to the user (stdout, not only slog) so an
+	// adapter can never silently mutate state under `ox doctor --fix`.
+	fmt.Printf("  running: %s\n", strings.Join(issue.FixArgv, " "))
 	slog.Info("running adapter fix", "argv", issue.FixArgv)
 	cmd := exec.Command(issue.FixArgv[0], issue.FixArgv[1:]...)
 	output, err := cmd.CombinedOutput()

--- a/cmd/ox/strip_ansi_test.go
+++ b/cmd/ox/strip_ansi_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStripANSIEscapes verifies that terminal escape sequences and bare control
+// bytes are removed from untrusted (LLM-generated) text while normal printable
+// content, tabs, and newlines survive.
+//
+// Failure prevented: an adversarial subagent summary containing an OSC 52
+// clipboard-write payload (\x1b]52;c;...\x07), a DCS sequence, or bare control
+// bytes reaches the terminal and is interpreted, allowing escape-sequence
+// injection (security finding #11).
+func TestStripANSIEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text untouched",
+			in:   "hello world",
+			want: "hello world",
+		},
+		{
+			name: "tab and newline survive",
+			in:   "line1\n\tindented\n",
+			want: "line1\n\tindented\n",
+		},
+		{
+			name: "CSI color codes stripped",
+			in:   "\x1b[31mred\x1b[0m text",
+			want: "red text",
+		},
+		{
+			name: "CSI cursor move stripped",
+			in:   "a\x1b[2Jb",
+			want: "ab",
+		},
+		{
+			// the motivating attack: OSC 52 clipboard write terminated by BEL
+			name: "OSC 52 clipboard payload terminated by BEL stripped",
+			in:   "before\x1b]52;c;ZWNobyBwd25lZAo=\x07after",
+			want: "beforeafter",
+		},
+		{
+			// OSC terminated by ST (ESC backslash) instead of BEL
+			name: "OSC payload terminated by ST stripped",
+			in:   "x\x1b]0;malicious title\x1b\\y",
+			want: "xy",
+		},
+		{
+			name: "DCS sequence stripped",
+			in:   "a\x1bP1;2;3mpayload\x1b\\b",
+			want: "ab",
+		},
+		{
+			name: "APC sequence stripped",
+			in:   "a\x1b_some apc data\x1b\\b",
+			want: "ab",
+		},
+		{
+			name: "bare control bytes stripped, tab/newline kept",
+			in:   "a\x00b\x07c\x1bd\te\nf\x7fg",
+			// \x00 dropped, \x07 (BEL) dropped, ESC+'d' is a two-byte escape so
+			// both drop, \t and \n kept, \x7f (DEL) dropped
+			want: "abc\te\nfg",
+		},
+		{
+			name: "unicode passes through",
+			in:   "café → résumé",
+			want: "café → résumé",
+		},
+		{
+			name: "lone trailing ESC dropped",
+			in:   "text\x1b",
+			want: "text",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stripANSIEscapes(c.in)
+			assert.Equal(t, c.want, got)
+			// defense-in-depth: no ESC byte may survive in any output
+			assert.False(t, strings.ContainsRune(got, '\x1b'), "ESC leaked into output: %q", got)
+		})
+	}
+}

--- a/cmd/ox/strip_ansi_test.go
+++ b/cmd/ox/strip_ansi_test.go
@@ -71,7 +71,14 @@ func TestStripANSIEscapes(t *testing.T) {
 			want: "abc\te\nfg",
 		},
 		{
-			name: "unicode passes through",
+			// 8-bit C1 introducers: 0x9b is CSI, 0x9d is OSC. A terminal acts on
+			// these without a leading ESC, so they must be dropped too.
+			name: "C1 control bytes stripped (8-bit CSI/OSC/ST)",
+			in:   "abcd",
+			want: "abcd",
+		},
+		{
+			name: "unicode passes through (U+00A0 and up survive)",
 			in:   "café → résumé",
 			want: "café → résumé",
 		},

--- a/docs/adr/ADR-013-adapter-distribution.md
+++ b/docs/adr/ADR-013-adapter-distribution.md
@@ -154,3 +154,13 @@ Items deferred from initial design reviews, to revisit when the adapter ecosyste
 - **Community adapter index**: A curated index file in `sageox/ox-adapters` listing community adapters by name, repo URL, and last-verified-compliance date. Community authors submit PRs to get listed. Low ops overhead, no infrastructure.
 - **License and trademark clarity**: `CONTRIBUTING.md` in `sageox/ox-adapters` clarifying expected licenses (MIT, Apache 2.0, or commercial) and whether the `ox-adapter-*` naming convention implies any trademark grant.
 - **Release pipeline specification**: Document what triggers adapter releases, minimum protocol version policy, breaking-change freeze windows before ox major releases, and whether `registry.yaml` updates are automated or manual.
+
+## See also
+
+**ADR-022 (Adapter Security Posture)** governs the trust model for the install
+flow described here. It refines the "GitHub release integrity is sufficient while
+all adapters are first-party" assumption above: the curated short-name path (where
+SageOx is the trust anchor) requires a pinned `tag` + per-platform `sha256` in
+`registry.yaml`, verified before exec, because a compromised maintainer release can
+otherwise install a substituted binary under a trusted name. The arbitrary-repo
+path (user as trust anchor) stays frictionless. See ADR-022 for the full posture.

--- a/docs/adr/ADR-022-adapter-security-posture.md
+++ b/docs/adr/ADR-022-adapter-security-posture.md
@@ -53,21 +53,24 @@ flowchart TB
     B3["user IS the trust anchor"]
     B1 ~~~ B2 ~~~ B3
   end
-  A3 --> NEED["integrity check REQUIRED:<br/>does the binary match what SageOx curated?"]
-  B3 --> OPEN["frictionless by design:<br/>do not gate the engineer's own code"]
+  A3 --> NEED["SageOx-checksum gate REQUIRED:<br/>does the binary match what SageOx curated?"]
+  B3 --> OPEN["no SageOx checksum gate:<br/>one-time --allow-unverified opt-in, user vouches"]
 ```
 
 - **Curated short-name path** (`ox adapter install cursor`): the user trusts that
-  SageOx vetted what sits behind the name. Today the code resolves
-  `releases/latest` and runs whatever `browser_download_url` the GitHub API returns
+  SageOx vetted what sits behind the name. The original code resolved
+  `releases/latest` and ran whatever `browser_download_url` the GitHub API returned
   — no version pin, no checksum. A compromised maintainer release, a swapped asset,
-  or a CDN/MITM substitution can deliver a *different* binary **under a name the
+  or a CDN/MITM substitution could deliver a *different* binary **under a name the
   user was taught to trust**, with no signal. This authenticity gap is the
-  legitimate finding (`ox-5ihl`).
+  legitimate finding (`ox-5ihl`), closed by decision 3.
 - **Arbitrary-repo path** (`ox adapter install github.com/<owner>/<repo>`): the user
-  explicitly names a repo they already trust. The user is the trust anchor; a
-  SageOx-side checksum gate here would break the "anyone can build and install an
-  adapter" contract for zero security gain.
+  explicitly names a repo they already trust — the user, not SageOx, is the trust
+  anchor. "Frictionless" here means **no SageOx-side checksum gate** (we never demand
+  a hash the user cannot produce for their own code), not zero ceremony: the user
+  pins `@<tag>` and acknowledges the trust decision once with `--allow-unverified`
+  (decision 3). That one-time opt-in is deliberate friction proportional to "you are
+  vouching for this," not a curation gate.
 
 ### 3. Integrity is enforced only where SageOx is the trust anchor
 
@@ -79,14 +82,28 @@ missing pin as fail-closed. A code-reviewed tag/checksum bump becomes the contro
 
 The arbitrary-repo path requires an explicit `@<tag>` plus an explicit
 `--allow-unverified` opt-in, after which ox installs without a SageOx-side checksum.
-We do not add a checksum gate the user cannot satisfy for their own code.
+We do not add a checksum gate the user cannot satisfy for their own code. A curated
+entry that has no pinned checksum yet also fails closed until `--allow-unverified`
+is passed (the documented transition while `registry.yaml` is populated).
+Implemented in `runAdapterInstall` / `resolveAdapterSource` (`ox-5ihl`).
 
-### 4. No standalone download-host allowlist
+### 4. The download-host allowlist is defense-in-depth, never the primary control
 
-GitHub rotates release-asset CDN hosts, so a hardcoded allowlist is a maintenance
-landmine that breaks real installs, and it does not stop malicious bytes served at
-a legitimate URL. Checksum verification (decision 3) subsumes it. We do not ship a
-separate host allowlist as a control.
+Checksum verification (decision 3) is **the** integrity control: it stops malicious
+bytes regardless of which host served them. A host allowlist cannot do that (bad
+bytes at a legitimate URL pass it) and is a maintenance liability — GitHub rotates
+release-asset CDN hosts (`objects.githubusercontent.com`,
+`release-assets.githubusercontent.com`, …), so the list must be widened when a new
+one appears or curated installs break with a "host not in allowlist" error.
+
+Given that, the install path keeps only a **thin defense-in-depth transport guard**
+(`gitutil.ValidateHTTPSHost` with `adapterDownloadHosts` in `cmd/ox/adapter.go`):
+it enforces `https` and the known GitHub asset hosts so an obviously-wrong
+`browser_download_url` is rejected before bytes are fetched. It is explicitly **not**
+relied on for integrity and **must be widened or removed** the moment it causes a
+real install failure — the checksum gate is the security boundary. If the
+maintenance cost outweighs the marginal value, drop the host set and keep only the
+`https` check; nothing else depends on it.
 
 ### 5. `verifyAdapterBinary` checks conformance, not provenance
 

--- a/docs/adr/ADR-022-adapter-security-posture.md
+++ b/docs/adr/ADR-022-adapter-security-posture.md
@@ -131,9 +131,13 @@ capability checks.
 `FixSafe=false` issues are never auto-run — but a malicious adapter can still
 return `git config --global …` to gain persistence. Because this is downstream of
 an already-installed (already-trusted, decision 6) adapter, the residual control is
-to **surface the full command to the terminal and confirm `--global`/`--system`
-mutations**, rather than maintain a losing denylist of dangerous git-config keys
-(tracked in the review as a MEDIUM, downstream of `ox-5ihl`).
+to **surface the full command to the terminal and confirm scope-escalating
+mutations** (`--global`/`--system`/`--worktree`/`-c`), rather than maintain a
+losing denylist of dangerous git-config keys. Implemented in `runAdapterFix`
+(`argvHasScopeEscalation`): any such fix is printed and requires explicit
+confirmation regardless of `FixSafe`/`--yes`, and is refused outright when ox
+cannot prompt (non-interactive). Every adapter fix is now echoed to stdout before
+it runs, so nothing executes silently.
 
 ## Consequences
 

--- a/docs/adr/ADR-022-adapter-security-posture.md
+++ b/docs/adr/ADR-022-adapter-security-posture.md
@@ -1,0 +1,162 @@
+# ADR-022: Adapter Security Posture
+
+**Status**: Accepted
+**Date**: 2026-06-10
+
+## Context
+
+Adapters (ADR-008) let any engineer extend ox to drive a new AI coworker backend
+by shipping a standalone `ox-adapter-<name>` binary that speaks the adapter
+protocol (ADR-010). ox discovers it (ADR-009), installs it (ADR-013), and the
+daemon runs it — one-shot or long-lived in `--serve` mode (ADR-012). **Executing
+adapter code is the entire point of the mechanism.** It is how the platform stays
+open to backends we did not write and cannot anticipate.
+
+The adapter ADR family (008–015) documents the architecture but never states the
+*security posture* — what we trust, where, and why. A 2026-06-10 security review
+exposed the cost of that omission: it flagged the install path as a CRITICAL
+"executes a binary with no integrity check," a framing that reads the extension
+mechanism itself as a vulnerability. That is wrong, but a real, narrower gap hides
+inside it. This ADR records the posture so reviewers — human and AI — do not
+re-litigate the extensibility decision, and so the genuine gaps are fixed without
+breaking the open mechanism.
+
+This ADR sits inside the trust boundary defined in `security/SECURITY.md`. It does
+not restate that boundary; it applies it to adapters.
+
+## Decision
+
+### 1. Running third-party adapter code is intended design, not a vulnerability
+
+Reviews must not flag "adapters execute code" as a finding. The mechanism's value
+is precisely that ox runs binaries it did not compile. What we secure is the
+*moment of acquisition* and the *blast radius of an already-trusted adapter* — not
+the fact of execution.
+
+### 2. Two install paths, two trust anchors
+
+`resolveAdapterSource` (`cmd/ox/adapter.go`) deliberately keeps these distinct:
+
+```mermaid
+flowchart TB
+  subgraph CURATED["Curated short-name install"]
+    direction TB
+    A1["ox adapter install cursor"]
+    A2["SageOx registry vouches for the binary"]
+    A3["user trusts SageOx curation"]
+    A1 ~~~ A2 ~~~ A3
+  end
+  subgraph ARBITRARY["Arbitrary-repo install"]
+    direction TB
+    B1["ox adapter install github.com/me/x"]
+    B2["the user named this repo explicitly"]
+    B3["user IS the trust anchor"]
+    B1 ~~~ B2 ~~~ B3
+  end
+  A3 --> NEED["integrity check REQUIRED:<br/>does the binary match what SageOx curated?"]
+  B3 --> OPEN["frictionless by design:<br/>do not gate the engineer's own code"]
+```
+
+- **Curated short-name path** (`ox adapter install cursor`): the user trusts that
+  SageOx vetted what sits behind the name. Today the code resolves
+  `releases/latest` and runs whatever `browser_download_url` the GitHub API returns
+  — no version pin, no checksum. A compromised maintainer release, a swapped asset,
+  or a CDN/MITM substitution can deliver a *different* binary **under a name the
+  user was taught to trust**, with no signal. This authenticity gap is the
+  legitimate finding (`ox-5ihl`).
+- **Arbitrary-repo path** (`ox adapter install github.com/<owner>/<repo>`): the user
+  explicitly names a repo they already trust. The user is the trust anchor; a
+  SageOx-side checksum gate here would break the "anyone can build and install an
+  adapter" contract for zero security gain.
+
+### 3. Integrity is enforced only where SageOx is the trust anchor
+
+For curated entries, pin a release `tag` and a per-platform `sha256` in the
+embedded `registry.yaml` (ADR-013). Verify downloaded bytes against the pin with a
+constant-time compare **before** the binary is made executable or run; treat a
+missing pin as fail-closed. A code-reviewed tag/checksum bump becomes the control
+— the review *is* the trust decision. (Implementation: `ox-5ihl`.)
+
+The arbitrary-repo path requires an explicit `@<tag>` plus an explicit
+`--allow-unverified` opt-in, after which ox installs without a SageOx-side checksum.
+We do not add a checksum gate the user cannot satisfy for their own code.
+
+### 4. No standalone download-host allowlist
+
+GitHub rotates release-asset CDN hosts, so a hardcoded allowlist is a maintenance
+landmine that breaks real installs, and it does not stop malicious bytes served at
+a legitimate URL. Checksum verification (decision 3) subsumes it. We do not ship a
+separate host allowlist as a control.
+
+### 5. `verifyAdapterBinary` checks conformance, not provenance
+
+`verifyAdapterBinary` runs the binary's `info` subcommand and validates the
+response. **This is protocol-conformance verification, not provenance.** It answers
+"is this a runnable ox adapter?", never "is this the binary SageOx curated?". The
+name has misled reviewers into reading it as an integrity check; it is not, and was
+never intended to be. It will be renamed `verifyAdapterProtocol`, and the
+install-path ordering becomes an invariant: **download → checksum gate → chmod →
+exec** (provenance is established before any execution).
+
+### 6. An installed adapter is inside the user's trust unit
+
+Per `security/SECURITY.md`, ox does not defend against a process already running as
+the user's own UID — such a process can edit the ledger, read the 0600 daemon
+token, and invoke `ox` directly. Applied to adapters: **once installed, an adapter
+runs every session as the user; installation IS the trust decision.** We harden
+acquisition (decisions 3–5); we do not pretend to sandbox an installed adapter from
+the user's own session. That would contradict the documented threat model and the
+purpose of the mechanism.
+
+This is also why the daemon spawning a *first-party* `ox distill` subprocess with
+the daemon's own environment is not a leak (ox trusting itself), whereas spawning a
+*third-party* adapter in `--serve` mode with the full daemon environment **is** a
+real boundary crossing — that env must be sanitized to the adapter's declared
+`RequiredEnv` (see `internal/session/adapters/external.go`; tracked in `ox-gkqu`).
+
+### 7. Self-declared capabilities are convenience metadata, not a security boundary
+
+An adapter's `Capabilities` (ADR-010 `InfoResponse`) are self-reported. ox uses
+them to *gate features it offers* (e.g. only request subagent control from an
+adapter that declares `subagent_controller`), not to *contain* the adapter. A
+malicious adapter can declare any capability set; capabilities therefore protect
+ox from accidentally driving an incomplete adapter, not from a hostile one. The
+defense against a hostile adapter is acquisition integrity (decisions 2–5), not
+capability checks.
+
+### 8. Adapter-reported fixes are constrained input
+
+`ox doctor --fix` executes `FixArgv` from an adapter's `diagnose` output
+(`cmd/ox/doctor_adapters.go`). `FixArgv[0]` is allowlisted to `{git, ox}` and
+`FixSafe=false` issues are never auto-run — but a malicious adapter can still
+return `git config --global …` to gain persistence. Because this is downstream of
+an already-installed (already-trusted, decision 6) adapter, the residual control is
+to **surface the full command to the terminal and confirm `--global`/`--system`
+mutations**, rather than maintain a losing denylist of dangerous git-config keys
+(tracked in the review as a MEDIUM, downstream of `ox-5ihl`).
+
+## Consequences
+
+- Engineers can still build and install any adapter from any repo — the
+  extensibility promise (ADR-008) is intact.
+- The curated path gains real authenticity guarantees; a compromised upstream
+  release no longer silently installs under a trusted name.
+- Adding a curated adapter now requires recording its tag + checksum in
+  `registry.yaml` — a reviewed change, by design.
+- Severity of the curated-path gap is **positioning-dependent**: CRITICAL *only
+  because* SageOx markets the short-name registry as the safe, curated default. If
+  that positioning changes, it drops to HIGH. The arbitrary-repo path is, and
+  remains, accepted risk.
+- A future move to signed releases (sigstore/cosign, verified in pure Go to honor
+  ADR-001 / ADR-007's no-external-binary rule) can replace manual checksum rotation
+  without changing this posture.
+
+## See also
+
+- ADR-008 (external adapter binaries), ADR-010 (IPC mechanism), ADR-012 (daemon as
+  adapter supervisor), ADR-013 (distribution & registry) — the architecture this
+  posture secures.
+- `security/SECURITY.md` — the trust boundary this ADR sits inside.
+- `security/.output/FINDINGS.md`, `security/.output/FIX-DESIGN.md` — the review and
+  remediation design.
+- `ox-5ihl` (curated-path integrity), `ox-gkqu` (serve-mode env sanitization).

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -34,6 +34,10 @@ type AdapterEntry struct {
 	Repo         string   `yaml:"repo" json:"repo"`
 	Capabilities []string `yaml:"capabilities" json:"capabilities"`
 	DetectCmds   []string `yaml:"detect_commands,omitempty" json:"detect_commands,omitempty"`
+	// Curated-path integrity fields (Tag, Checksums) are planned here per
+	// ADR-022 (adapter security posture): for the short-name install path SageOx
+	// is the trust anchor, so a code-reviewed tag pin + per-platform sha256 in
+	// this registry becomes the authenticity control. Tracked in ox-5ihl.
 }
 
 // CommunityEntry describes a community-contributed adapter.

--- a/internal/adapter/registry.go
+++ b/internal/adapter/registry.go
@@ -34,10 +34,40 @@ type AdapterEntry struct {
 	Repo         string   `yaml:"repo" json:"repo"`
 	Capabilities []string `yaml:"capabilities" json:"capabilities"`
 	DetectCmds   []string `yaml:"detect_commands,omitempty" json:"detect_commands,omitempty"`
-	// Curated-path integrity fields (Tag, Checksums) are planned here per
-	// ADR-022 (adapter security posture): for the short-name install path SageOx
-	// is the trust anchor, so a code-reviewed tag pin + per-platform sha256 in
-	// this registry becomes the authenticity control. Tracked in ox-5ihl.
+
+	// Curated-path integrity fields (ADR-022, ox-5ihl). For the short-name
+	// install path SageOx is the trust anchor, so a code-reviewed release tag
+	// pin plus per-platform sha256 in this registry IS the authenticity control.
+	// The download is verified against these BEFORE the binary is made
+	// executable or run (see runAdapterInstall). A missing pin fails closed
+	// unless the user opts into --allow-unverified.
+	//
+	// Tag pins the exact GitHub release (e.g. "v1.2.3"); installs fetch
+	// releases/tags/<Tag>, never releases/latest. Checksums maps a platform key
+	// ("darwin_arm64") to the lowercase sha256 hex of that platform's asset.
+	Tag       string            `yaml:"tag,omitempty" json:"tag,omitempty"`
+	Checksums map[string]string `yaml:"checksums,omitempty" json:"checksums,omitempty"`
+}
+
+// RequireInstallable returns an error if a non-bundled entry lacks the curated
+// integrity pins (Tag + Checksums) that ADR-022 requires before SageOx can
+// vouch for a short-name install. Bundled adapters ship with ox and are exempt.
+//
+// Callers use this to drive fail-closed behavior on the curated install path:
+// an entry that is not installable can only be installed with an explicit
+// --allow-unverified opt-in. It is NOT called automatically at registry load,
+// so `ox adapter list`/`info` still surface entries that lack a pin.
+func (e *AdapterEntry) RequireInstallable() error {
+	if e.Bundled {
+		return nil
+	}
+	if e.Tag == "" {
+		return fmt.Errorf("adapter %q has no pinned release tag in the registry", e.Name)
+	}
+	if len(e.Checksums) == 0 {
+		return fmt.Errorf("adapter %q has no per-platform checksums in the registry", e.Name)
+	}
+	return nil
 }
 
 // CommunityEntry describes a community-contributed adapter.

--- a/internal/adapter/registry.yaml
+++ b/internal/adapter/registry.yaml
@@ -71,6 +71,24 @@ adapters:
     capabilities: [session_reader, hook_installer, incremental_reader, file_watcher, serve_mode]
     detect_commands: [aider]
 
+  # --- External (non-bundled) adapters ---
+  #
+  # SECURITY (ADR-022, ox-5ihl): the short-name install path treats SageOx as the
+  # trust anchor, so each external entry MUST pin a release `tag` and per-platform
+  # `checksums` before `ox adapter install <name>` will run without friction.
+  # Example:
+  #     tag: v1.2.3
+  #     checksums:
+  #       darwin_arm64:  <sha256-hex>
+  #       darwin_amd64:  <sha256-hex>
+  #       linux_amd64:   <sha256-hex>
+  # The sha256 is computed over the exact release asset for that platform.
+  #
+  # The entries below ship WITHOUT pins: no real binaries exist yet to checksum,
+  # and fake checksums are worse than none. Until a maintainer adds real pins,
+  # `ox adapter install <name>` for these FAILS CLOSED and requires
+  # --allow-unverified. This is the intended, documented transition — populating
+  # tag + checksums here restores frictionless install.
   - name: cursor
     display_name: Cursor
     description: Reads Cursor sessions

--- a/internal/adapter/registry_test.go
+++ b/internal/adapter/registry_test.go
@@ -179,6 +179,67 @@ func TestGitHubRepo_Format(t *testing.T) {
 	}
 }
 
+// --- F2. RequireInstallable (curated-path integrity gate, ADR-022/ox-5ihl) ---
+
+// TestRequireInstallable_BundledExempt verifies bundled adapters need no pin.
+// Failure prevented: gating bundled adapters (which ship with ox) on a registry
+// checksum they will never have.
+func TestRequireInstallable_BundledExempt(t *testing.T) {
+	e := &AdapterEntry{Name: "claude-code", Bundled: true}
+	if err := e.RequireInstallable(); err != nil {
+		t.Errorf("bundled adapter should be installable without a pin, got: %v", err)
+	}
+}
+
+// TestRequireInstallable_MissingTag verifies a non-bundled entry without a tag
+// is not installable. Failure prevented: a tagless curated entry installing from
+// releases/latest with no provenance (the gap ox-5ihl closes).
+func TestRequireInstallable_MissingTag(t *testing.T) {
+	e := &AdapterEntry{Name: "cursor", Bundled: false, Checksums: map[string]string{"darwin_arm64": "abc"}}
+	if err := e.RequireInstallable(); err == nil {
+		t.Fatal("entry without a tag must not be installable")
+	}
+}
+
+// TestRequireInstallable_MissingChecksums verifies a non-bundled entry without
+// checksums is not installable. Failure prevented: installing unverified bytes
+// under a SageOx-curated name.
+func TestRequireInstallable_MissingChecksums(t *testing.T) {
+	e := &AdapterEntry{Name: "cursor", Bundled: false, Tag: "v1.0.0"}
+	if err := e.RequireInstallable(); err == nil {
+		t.Fatal("entry without checksums must not be installable")
+	}
+}
+
+// TestRequireInstallable_FullyPinned verifies a non-bundled entry with both a tag
+// and checksums is installable.
+func TestRequireInstallable_FullyPinned(t *testing.T) {
+	e := &AdapterEntry{
+		Name: "cursor", Bundled: false, Tag: "v1.0.0",
+		Checksums: map[string]string{"darwin_arm64": "deadbeef"},
+	}
+	if err := e.RequireInstallable(); err != nil {
+		t.Errorf("fully pinned entry should be installable, got: %v", err)
+	}
+}
+
+// TestExternalEntries_CurrentlyUnpinned documents the intended transition state:
+// the shipped external entries have no real checksum yet, so RequireInstallable
+// fails (install requires --allow-unverified until a maintainer pins them). If
+// this test starts failing, real pins were added — update it then.
+func TestExternalEntries_CurrentlyUnpinned(t *testing.T) {
+	reg, err := LoadEmbeddedRegistry()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedRegistry() error: %v", err)
+	}
+	for _, a := range reg.ExternalAdapters() {
+		a := a
+		if err := a.RequireInstallable(); err == nil {
+			t.Errorf("external adapter %q now has a pin; update the registry-transition test", a.Name)
+		}
+	}
+}
+
 // --- G. Uniqueness constraints ---
 
 // TestAdapterNames_Unique verifies no duplicate adapter names exist.

--- a/internal/daemon/adapter_supervisor.go
+++ b/internal/daemon/adapter_supervisor.go
@@ -505,11 +505,9 @@ func (s *AdapterSupervisor) spawnAdapterLocked(adapterType string) (*AdapterProc
 	// currently only knows adapterType + capabilities at spawn time, not the
 	// adapter's RequiredEnv (which lives in the ADR-010 InfoResponse and is not
 	// plumbed through findBinary). Wiring that through is follow-up work.
-	// OX_PROTOCOL_VERSION is appended last so the daemon's compiled version wins
-	// over any inherited value.
-	cmd.Env = append(envutil.SanitizedEnv(os.Environ(), nil),
-		fmt.Sprintf("OX_PROTOCOL_VERSION=%d", adapterprotocol.ProtocolVersion),
-	)
+	// SanitizedEnv already injects the compiled OX_PROTOCOL_VERSION as the sole,
+	// authoritative copy (it drops any inherited value), so no manual append.
+	cmd.Env = envutil.SanitizedEnv(os.Environ(), nil)
 
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/daemon/adapter_supervisor.go
+++ b/internal/daemon/adapter_supervisor.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/sageox/ox/internal/envutil"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/sageox/ox/pkg/ndjson"
 )
@@ -496,7 +497,17 @@ func (s *AdapterSupervisor) spawnAdapterLocked(adapterType string) (*AdapterProc
 	}
 
 	cmd := exec.Command(binaryPath, "--serve")
-	cmd.Env = append(os.Environ(),
+	// A serve-mode adapter is a long-lived THIRD-PARTY binary; the full daemon
+	// environment (SAGEOX_TOKEN, GITHUB_TOKEN, AWS_*, …) crossing into it is a
+	// real trust-boundary leak (ADR-022 §6). Sanitize to the default allowlist.
+	// TODO(ox-gkqu): pass the adapter's declared info.RequiredEnv here instead of
+	// nil so adapters can receive their own non-secret config. The supervisor
+	// currently only knows adapterType + capabilities at spawn time, not the
+	// adapter's RequiredEnv (which lives in the ADR-010 InfoResponse and is not
+	// plumbed through findBinary). Wiring that through is follow-up work.
+	// OX_PROTOCOL_VERSION is appended last so the daemon's compiled version wins
+	// over any inherited value.
+	cmd.Env = append(envutil.SanitizedEnv(os.Environ(), nil),
 		fmt.Sprintf("OX_PROTOCOL_VERSION=%d", adapterprotocol.ProtocolVersion),
 	)
 

--- a/internal/daemon/agentwork/claude_runner.go
+++ b/internal/daemon/agentwork/claude_runner.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -92,9 +93,15 @@ func (r *ClaudeRunner) Run(ctx context.Context, req RunRequest) (*RunResult, err
 	if req.Model != "" {
 		args = append(args, "--model", req.Model)
 	}
-	args = append(args, "-p", req.Prompt)
+	// `-p`/`--print` enables non-interactive (print) mode. The prompt itself is
+	// NOT passed as the flag value — claude reads it from stdin when -p has no
+	// argument. Keeping the (potentially sensitive) session transcript out of
+	// argv prevents same-UID processes from reading it via ps / /proc/<pid>/cmdline
+	// / sysctl kern.procargs2 (security finding #10).
+	args = append(args, "-p")
 
 	cmd := exec.CommandContext(ctx, r.binaryPath, args...)
+	cmd.Stdin = strings.NewReader(req.Prompt)
 	if req.WorkDir != "" {
 		cmd.Dir = req.WorkDir
 	}

--- a/internal/daemon/agentwork/claude_runner_test.go
+++ b/internal/daemon/agentwork/claude_runner_test.go
@@ -273,6 +273,46 @@ sleep 0.1
 	}
 }
 
+// TestClaudeRunner_Run_PromptViaStdin verifies the summarization prompt is
+// delivered to the claude subprocess via stdin and NEVER appears as an argv
+// element. argv is world-readable to same-UID processes (ps,
+// /proc/<pid>/cmdline, sysctl kern.procargs2); leaking the session transcript
+// there is security finding #10.
+func TestClaudeRunner_Run_PromptViaStdin(t *testing.T) {
+	tmp := t.TempDir()
+	argsFile := filepath.Join(tmp, "args.txt")
+	stdinFile := filepath.Join(tmp, "stdin.txt")
+	script := filepath.Join(tmp, "claude")
+	// Fake claude: dump argv (one per line) and stdin to files, then emit a
+	// minimal valid stream-json result. The trailing sleep defuses the same
+	// pipe-close race documented in TestClaudeRunner_Run_ModelFlag.
+	body := `#!/bin/sh
+for a in "$@"; do printf '%s\n' "$a" >> "` + argsFile + `"; done
+cat > "` + stdinFile + `"
+printf '%s\n' '{"type":"result","result":"ok","usage":{"input_tokens":1,"output_tokens":1}}'
+sleep 0.1
+`
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	r := &ClaudeRunner{binaryPath: script, logger: slog.Default()}
+
+	const secret = "SENSITIVE-TRANSCRIPT-CONTENT-do-not-leak"
+	_, err := r.Run(context.Background(), RunRequest{
+		Prompt: secret, TimeoutOverride: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	argv, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	stdin, err := os.ReadFile(stdinFile)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(argv), secret, "prompt leaked into argv")
+	assert.Equal(t, secret, string(stdin), "prompt not delivered via stdin")
+	// -p (print mode) flag must remain
+	assert.Contains(t, strings.Split(strings.TrimSpace(string(argv)), "\n"), "-p")
+}
+
 func TestClaudeRunner_Run_ContextCancellation(t *testing.T) {
 	tmp := t.TempDir()
 	script := filepath.Join(tmp, "claude")

--- a/internal/daemon/agentwork/codex_runner.go
+++ b/internal/daemon/agentwork/codex_runner.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -57,9 +58,14 @@ func (r *CodexRunner) Run(ctx context.Context, req RunRequest) (*RunResult, erro
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	args := []string{"--full-auto", "--quiet", "-p", req.Prompt}
+	// The prompt is fed via stdin rather than as an argv element so the
+	// (potentially sensitive) session transcript does not appear in
+	// ps / /proc/<pid>/cmdline / sysctl kern.procargs2 (security finding #10).
+	// `-` as the positional prompt tells codex to read the prompt from stdin.
+	args := []string{"--full-auto", "--quiet", "-"}
 
 	cmd := exec.CommandContext(ctx, r.binaryPath, args...)
+	cmd.Stdin = strings.NewReader(req.Prompt)
 	if req.WorkDir != "" {
 		cmd.Dir = req.WorkDir
 	}

--- a/internal/daemon/agentwork/codex_runner_test.go
+++ b/internal/daemon/agentwork/codex_runner_test.go
@@ -1,0 +1,48 @@
+package agentwork
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCodexRunner_Run_PromptViaStdin verifies the prompt is delivered to the
+// codex subprocess via stdin and never appears as an argv element (security
+// finding #10 — argv is world-readable to same-UID processes).
+func TestCodexRunner_Run_PromptViaStdin(t *testing.T) {
+	tmp := t.TempDir()
+	argsFile := filepath.Join(tmp, "args.txt")
+	stdinFile := filepath.Join(tmp, "stdin.txt")
+	script := filepath.Join(tmp, "codex")
+	body := `#!/bin/sh
+for a in "$@"; do printf '%s\n' "$a" >> "` + argsFile + `"; done
+cat > "` + stdinFile + `"
+sleep 0.1
+`
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	r := &CodexRunner{binaryPath: script, logger: slog.Default()}
+
+	const secret = "SENSITIVE-TRANSCRIPT-CONTENT-do-not-leak"
+	_, err := r.Run(context.Background(), RunRequest{
+		Prompt: secret, TimeoutOverride: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	argv, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	stdin, err := os.ReadFile(stdinFile)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(argv), secret, "prompt leaked into argv")
+	assert.Equal(t, secret, string(stdin), "prompt not delivered via stdin")
+	// `-` positional must remain so codex reads the prompt from stdin
+	assert.Contains(t, strings.Split(strings.TrimSpace(string(argv)), "\n"), "-")
+}

--- a/internal/daemon/agentwork/gemini_runner.go
+++ b/internal/daemon/agentwork/gemini_runner.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// GeminiRunner implements Runner using `gemini -p`.
+// GeminiRunner implements Runner using `gemini` with the prompt delivered via stdin.
 // It spawns Gemini CLI in non-interactive (headless) mode.
 // GeminiRunner is safe for concurrent use — each Run() call is independent.
 type GeminiRunner struct {

--- a/internal/daemon/agentwork/gemini_runner.go
+++ b/internal/daemon/agentwork/gemini_runner.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -57,9 +58,13 @@ func (r *GeminiRunner) Run(ctx context.Context, req RunRequest) (*RunResult, err
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	args := []string{"-p", req.Prompt}
-
-	cmd := exec.CommandContext(ctx, r.binaryPath, args...)
+	// Gemini runs non-interactively (headless) when its stdin is not a TTY and
+	// reads the prompt from stdin. The prompt is fed via stdin rather than the
+	// `-p` argv value so the (potentially sensitive) session transcript does not
+	// appear in ps / /proc/<pid>/cmdline / sysctl kern.procargs2 (security
+	// finding #10).
+	cmd := exec.CommandContext(ctx, r.binaryPath)
+	cmd.Stdin = strings.NewReader(req.Prompt)
 	if req.WorkDir != "" {
 		cmd.Dir = req.WorkDir
 	}

--- a/internal/daemon/agentwork/gemini_runner_test.go
+++ b/internal/daemon/agentwork/gemini_runner_test.go
@@ -1,0 +1,50 @@
+package agentwork
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeminiRunner_Run_PromptViaStdin verifies the prompt is delivered to the
+// gemini subprocess via stdin and never appears as an argv element (security
+// finding #10 — argv is world-readable to same-UID processes). gemini runs
+// headless and reads its prompt from stdin when stdin is not a TTY.
+func TestGeminiRunner_Run_PromptViaStdin(t *testing.T) {
+	tmp := t.TempDir()
+	argsFile := filepath.Join(tmp, "args.txt")
+	stdinFile := filepath.Join(tmp, "stdin.txt")
+	script := filepath.Join(tmp, "gemini")
+	// touch argsFile first so it exists even when gemini receives zero argv
+	body := `#!/bin/sh
+: > "` + argsFile + `"
+for a in "$@"; do printf '%s\n' "$a" >> "` + argsFile + `"; done
+cat > "` + stdinFile + `"
+sleep 0.1
+`
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	r := &GeminiRunner{binaryPath: script, logger: slog.Default()}
+
+	const secret = "SENSITIVE-TRANSCRIPT-CONTENT-do-not-leak"
+	_, err := r.Run(context.Background(), RunRequest{
+		Prompt: secret, TimeoutOverride: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	argv, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	stdin, err := os.ReadFile(stdinFile)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(argv), secret, "prompt leaked into argv")
+	// no prompt-bearing argv at all — the prompt rides on stdin
+	assert.Empty(t, string(argv), "expected no argv; prompt should ride stdin")
+	assert.Equal(t, secret, string(stdin), "prompt not delivered via stdin")
+}

--- a/internal/daemon/hooks/runner.go
+++ b/internal/daemon/hooks/runner.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/sageox/ox/internal/envutil"
 )
 
 const (
@@ -88,7 +90,11 @@ func (r *HookRunner) run(ctx context.Context, event Event, hook HookConfig) {
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Env = append(os.Environ(),
+	// Hooks run arbitrary user-defined commands (e.g. from a prompt-injected
+	// CLAUDE.md `env > /tmp/x`). They must NOT inherit daemon secrets — sanitize
+	// to the default allowlist before adding the hook-specific OX_EVENT vars.
+	// See ADR-022 §6.
+	cmd.Env = append(envutil.SanitizedEnv(os.Environ(), nil),
 		"OX_EVENT="+event.Name,
 		"OX_EVENT_TIMESTAMP="+event.Timestamp.UTC().Format(time.RFC3339),
 	)

--- a/internal/daemon/hooks/runner_test.go
+++ b/internal/daemon/hooks/runner_test.go
@@ -446,6 +446,47 @@ func TestRunnerEnvironmentVariables(t *testing.T) {
 	}
 }
 
+// TestRunnerDoesNotLeakDaemonSecrets verifies hook subprocesses do NOT inherit
+// daemon secrets from the daemon's environment.
+// Failure prevented: a prompt-injected CLAUDE.md hook (e.g. `env > /tmp/x`)
+// exfiltrates SAGEOX_TOKEN / GITHUB_TOKEN / AWS_* from the daemon. See ADR-022 §6.
+func TestRunnerDoesNotLeakDaemonSecrets(t *testing.T) {
+	// not parallel: mutates process environment via t.Setenv
+	t.Setenv("SAGEOX_TOKEN", "tok-must-not-leak")
+	t.Setenv("GITHUB_TOKEN", "ghp-must-not-leak")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "aws-must-not-leak")
+
+	envFile := filepath.Join(t.TempDir(), "leaked.txt")
+
+	runner := hooks.NewHookRunner([]hooks.HookConfig{
+		// dump the secrets a malicious hook would target; empty if sanitized
+		{Event: "daemon.started", Command: fmt.Sprintf(
+			`printf "%%s|%%s|%%s|%%s" "$SAGEOX_TOKEN" "$GITHUB_TOKEN" "$AWS_SECRET_ACCESS_KEY" "$OX_EVENT" > %s`, envFile)},
+	}, testLogger())
+
+	runner.Dispatch(context.Background(), hooks.Event{
+		Name:      hooks.EventDaemonStarted,
+		Timestamp: time.Now(),
+	})
+	runner.Wait()
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("failed to read env output: %v", err)
+	}
+
+	got := string(data)
+	for _, secret := range []string{"tok-must-not-leak", "ghp-must-not-leak", "aws-must-not-leak"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("daemon secret leaked to hook env: %q present in %q", secret, got)
+		}
+	}
+	// the hook-specific OX_EVENT var must still be delivered
+	if !strings.Contains(got, "daemon.started") {
+		t.Errorf("OX_EVENT should still be set for hooks, got %q", got)
+	}
+}
+
 // --- Concurrent Dispatch calls ---
 
 // TestRunnerConcurrentDispatch verifies multiple goroutines can call Dispatch

--- a/internal/envutil/env.go
+++ b/internal/envutil/env.go
@@ -1,0 +1,136 @@
+// Package envutil sanitizes subprocess environments so the daemon and CLI never
+// leak secrets (SAGEOX_TOKEN, GITHUB_TOKEN, AWS_*, …) into untrusted or
+// long-lived child processes (third-party adapters, user-defined hooks).
+//
+// It is a leaf package: it imports only the standard library plus
+// pkg/adapterprotocol (for the OX_PROTOCOL_VERSION default), so it can be safely
+// imported by internal/session/adapters, internal/daemon, and internal/daemon/hooks
+// without creating an import cycle.
+//
+// See ADR-022 §6 (docs/adr/ADR-022-adapter-security-posture.md) for the
+// first-party-vs-third-party trust distinction that motivates default-deny
+// sanitization.
+package envutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+// allowlistedEnvVars are exact-match variable names always passed to child processes.
+var allowlistedEnvVars = map[string]bool{
+	"HOME":   true,
+	"PATH":   true,
+	"TMPDIR": true,
+}
+
+// allowlistedEnvPrefixes are prefix patterns; any variable starting with these is passed through.
+var allowlistedEnvPrefixes = []string{
+	"XDG_",
+}
+
+// denylistedEnvPatterns are substrings that block child-declared required env vars.
+// Prevents callers from requesting sensitive credentials via self-declared required_env.
+var denylistedEnvPatterns = []string{
+	"SECRET",
+	"TOKEN",
+	"KEY",
+	"PASSWORD",
+	"CREDENTIAL",
+	"PRIVATE",
+}
+
+// SanitizedEnv builds a sanitized environment for subprocess execution.
+// It filters environ (typically os.Environ()) to only include:
+//   - Exact-match allowlisted vars: HOME, PATH, TMPDIR
+//   - Prefix-match allowlisted vars: XDG_*
+//   - OX_* protocol vars (OX_PROTOCOL_VERSION, OX_REPO_ROOT, OX_REPO_ID, OX_TEAM_ID)
+//   - Any additional vars declared in requiredEnv (e.g. an adapter's required_env list)
+//
+// All other variables (API keys, tokens, secrets) are stripped. The denylist
+// always wins: a requiredEnv name matching a denylisted pattern is never passed
+// through, so a malicious adapter cannot exfiltrate credentials by declaring them.
+func SanitizedEnv(environ []string, requiredEnv []string) []string {
+	// build a set of caller-declared required env var names, filtering out
+	// names that match sensitive patterns to prevent credential exfiltration
+	required := make(map[string]bool, len(requiredEnv))
+	for _, name := range requiredEnv {
+		if isDenylisted(name) {
+			continue
+		}
+		required[name] = true
+	}
+
+	env := make([]string, 0, len(allowlistedEnvVars)+len(requiredEnv)+4)
+
+	// track which OX_ vars we found so we can inject defaults for missing ones
+	foundOX := make(map[string]bool)
+
+	for _, entry := range environ {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+
+		if isAllowlisted(name) || required[name] {
+			env = append(env, entry)
+		}
+
+		// track OX_ vars we see (they pass through isAllowlisted via the OX_ prefix check)
+		if strings.HasPrefix(name, "OX_") {
+			foundOX[name] = true
+		}
+	}
+
+	// always inject OX_PROTOCOL_VERSION if not already present
+	if !foundOX["OX_PROTOCOL_VERSION"] {
+		env = append(env, fmt.Sprintf("OX_PROTOCOL_VERSION=%d", adapterprotocol.ProtocolVersion))
+	}
+
+	return env
+}
+
+// SafeCommand returns an exec.Cmd whose environment is pre-sanitized via
+// SanitizedEnv(os.Environ(), nil) — a default-deny convenience for spawning
+// untrusted children. Callers needing to pass through a declared required_env
+// allowlist should build the command manually and set cmd.Env = SanitizedEnv(...).
+func SafeCommand(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	cmd.Env = SanitizedEnv(os.Environ(), nil)
+	return cmd
+}
+
+// isDenylisted returns true if the variable name contains a sensitive pattern.
+// Used to prevent caller-declared required env from requesting credentials.
+func isDenylisted(name string) bool {
+	upper := strings.ToUpper(name)
+	for _, pattern := range denylistedEnvPatterns {
+		if strings.Contains(upper, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAllowlisted returns true if the variable name matches the allowlist.
+func isAllowlisted(name string) bool {
+	if allowlistedEnvVars[name] {
+		return true
+	}
+	// OX_* protocol vars are always passed through — EXCEPT names matching
+	// the credential denylist, which must never leak to child subprocesses
+	// regardless of prefix.
+	if strings.HasPrefix(name, "OX_") {
+		return !isDenylisted(name)
+	}
+	for _, prefix := range allowlistedEnvPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/envutil/env.go
+++ b/internal/envutil/env.go
@@ -67,29 +67,30 @@ func SanitizedEnv(environ []string, requiredEnv []string) []string {
 
 	env := make([]string, 0, len(allowlistedEnvVars)+len(requiredEnv)+4)
 
-	// track which OX_ vars we found so we can inject defaults for missing ones
-	foundOX := make(map[string]bool)
-
 	for _, entry := range environ {
 		name, _, ok := strings.Cut(entry, "=")
 		if !ok {
 			continue
 		}
 
+		// OX_PROTOCOL_VERSION is owned by ox, not inherited. A stale value in the
+		// daemon's own environment (e.g. exported by the parent shell) must never
+		// reach a child: drop any inherited copy so the compiled value injected
+		// below is the single, authoritative entry. On Linux/glibc getenv returns
+		// the FIRST matching envp entry, so a passed-through stale copy would
+		// shadow a later-appended fresh one — the subtle bug this guards against.
+		if name == "OX_PROTOCOL_VERSION" {
+			continue
+		}
+
 		if isAllowlisted(name) || required[name] {
 			env = append(env, entry)
 		}
-
-		// track OX_ vars we see (they pass through isAllowlisted via the OX_ prefix check)
-		if strings.HasPrefix(name, "OX_") {
-			foundOX[name] = true
-		}
 	}
 
-	// always inject OX_PROTOCOL_VERSION if not already present
-	if !foundOX["OX_PROTOCOL_VERSION"] {
-		env = append(env, fmt.Sprintf("OX_PROTOCOL_VERSION=%d", adapterprotocol.ProtocolVersion))
-	}
+	// Inject the compiled OX_PROTOCOL_VERSION unconditionally (inherited copies
+	// were dropped above, so this is always the authoritative value).
+	env = append(env, fmt.Sprintf("OX_PROTOCOL_VERSION=%d", adapterprotocol.ProtocolVersion))
 
 	return env
 }

--- a/internal/envutil/env_test.go
+++ b/internal/envutil/env_test.go
@@ -1,4 +1,4 @@
-package adapters
+package envutil
 
 import (
 	"fmt"
@@ -388,5 +388,78 @@ func TestIsAllowlisted(t *testing.T) {
 				t.Errorf("isAllowlisted(%q) = %v, want %v", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSanitizedEnv_NamedDaemonSecretsStripped(t *testing.T) {
+	// Failure prevented: the specific high-value daemon secrets called out in
+	// ADR-022 (SAGEOX_TOKEN, GITHUB_TOKEN, AWS_*) leak into untrusted children.
+	environ := []string{
+		"HOME=/home/dev",
+		"PATH=/usr/bin",
+		"XDG_CONFIG_HOME=/home/dev/.config",
+		"OX_REPO_ID=repo-abc",
+		"SAGEOX_TOKEN=tok-abc123",
+		"GITHUB_TOKEN=ghp_abc123",
+		"AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
+		"AWS_ACCESS_KEY_ID=AKIA...",     // matches KEY denylist substring
+		"AWS_SESSION_TOKEN=FwoGZXIv...", // matches TOKEN denylist substring
+	}
+
+	m := envMap(SanitizedEnv(environ, nil))
+
+	for _, key := range []string{"SAGEOX_TOKEN", "GITHUB_TOKEN", "AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "AWS_SESSION_TOKEN"} {
+		if _, ok := m[key]; ok {
+			t.Errorf("daemon secret %s must be stripped from sanitized env", key)
+		}
+	}
+
+	for _, key := range []string{"HOME", "PATH", "XDG_CONFIG_HOME", "OX_REPO_ID"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("expected non-secret %s to survive sanitization", key)
+		}
+	}
+}
+
+func TestSanitizedEnv_DenylistWinsOverRequiredEnv(t *testing.T) {
+	// Failure prevented: a malicious adapter exfiltrates a secret by naming it in
+	// required_env. The denylist must override any requiredEnv allowlist entry.
+	environ := []string{
+		"HOME=/home/dev",
+		"GITHUB_TOKEN=ghp_abc123",
+		"MODEL_NAME=gemini-pro",
+	}
+	requiredEnv := []string{"GITHUB_TOKEN", "MODEL_NAME"}
+
+	m := envMap(SanitizedEnv(environ, requiredEnv))
+
+	if _, ok := m["GITHUB_TOKEN"]; ok {
+		t.Error("GITHUB_TOKEN must be blocked by denylist even when declared in required_env")
+	}
+	if _, ok := m["MODEL_NAME"]; !ok {
+		t.Error("non-secret MODEL_NAME declared in required_env should pass through")
+	}
+}
+
+func TestSafeCommand_PresetsSanitizedEnv(t *testing.T) {
+	// Failure prevented: SafeCommand spawns a child with the full os.Environ(),
+	// leaking whatever secrets the parent process holds.
+	t.Setenv("SAGEOX_TOKEN", "tok-leak-me")
+	t.Setenv("HOME", "/home/dev")
+
+	cmd := SafeCommand("true")
+	if cmd.Env == nil {
+		t.Fatal("SafeCommand must preset a sanitized Env, got nil")
+	}
+
+	m := envMap(cmd.Env)
+	if _, ok := m["SAGEOX_TOKEN"]; ok {
+		t.Error("SafeCommand env must not contain SAGEOX_TOKEN")
+	}
+	if _, ok := m["HOME"]; !ok {
+		t.Error("SafeCommand env should retain HOME")
+	}
+	if _, ok := m["OX_PROTOCOL_VERSION"]; !ok {
+		t.Error("SafeCommand env should inject OX_PROTOCOL_VERSION")
 	}
 }

--- a/internal/envutil/env_test.go
+++ b/internal/envutil/env_test.go
@@ -85,13 +85,16 @@ func TestSanitizedEnv_XDGPrefixMatching(t *testing.T) {
 }
 
 func TestSanitizedEnv_OXProtocolVarsAlwaysIncluded(t *testing.T) {
-	// Failure prevented: adapter doesn't receive protocol version or repo context.
+	// Failure prevented: adapter doesn't receive repo context, OR (regression for
+	// the Greptile-flagged Linux bug) inherits a STALE OX_PROTOCOL_VERSION that
+	// shadows the compiled value. OX_PROTOCOL_VERSION is owned by ox and must
+	// always be the compiled version, never whatever the parent shell exported.
 	environ := []string{
 		"HOME=/home/dev",
 		"OX_REPO_ROOT=/src/project",
 		"OX_REPO_ID=repo-abc",
 		"OX_TEAM_ID=team-xyz",
-		"OX_PROTOCOL_VERSION=1",
+		"OX_PROTOCOL_VERSION=99", // stale inherited value — must be overridden
 	}
 
 	result := SanitizedEnv(environ, nil)
@@ -101,7 +104,7 @@ func TestSanitizedEnv_OXProtocolVarsAlwaysIncluded(t *testing.T) {
 		"OX_REPO_ROOT":        "/src/project",
 		"OX_REPO_ID":          "repo-abc",
 		"OX_TEAM_ID":          "team-xyz",
-		"OX_PROTOCOL_VERSION": "1",
+		"OX_PROTOCOL_VERSION": fmt.Sprintf("%d", adapterprotocol.ProtocolVersion),
 	}
 
 	for k, v := range expected {
@@ -110,6 +113,18 @@ func TestSanitizedEnv_OXProtocolVarsAlwaysIncluded(t *testing.T) {
 		} else if got != v {
 			t.Errorf("%s = %q, want %q", k, got, v)
 		}
+	}
+
+	// Exactly one OX_PROTOCOL_VERSION entry — the stale one must be dropped, not
+	// duplicated (a second entry would shadow the fresh one via getenv on Linux).
+	count := 0
+	for _, e := range result {
+		if strings.HasPrefix(e, "OX_PROTOCOL_VERSION=") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 OX_PROTOCOL_VERSION entry, got %d", count)
 	}
 }
 

--- a/internal/gitutil/clone.go
+++ b/internal/gitutil/clone.go
@@ -31,7 +31,14 @@ import (
 // caller is relying on scheme validation + HardenedCloneArgs alone — appropriate
 // for user-owned ledger repos that may live on github.com, gitlab.com, or a
 // self-hosted forge).
-func ValidateCloneURL(cloneURL string, trustedHosts []string) error {
+//
+// allowLocal permits `file://` URLs and scheme-less local filesystem paths. In
+// production this is false (a ledger/team-context clone is always a remote https
+// repo, never a local path). Tests that clone from a local bare repo wire this to
+// the test-only override (gitserver.TestAllowFileTransport) — the same flag that
+// gates HardenedCloneArgs — so both guards relax together. The `ext::` transport
+// is rejected regardless of allowLocal: it forks a shell and is never legitimate.
+func ValidateCloneURL(cloneURL string, trustedHosts []string, allowLocal bool) error {
 	if cloneURL == "" {
 		return fmt.Errorf("clone URL is empty")
 	}
@@ -45,6 +52,15 @@ func ValidateCloneURL(cloneURL string, trustedHosts []string) error {
 	parsed, err := url.Parse(cloneURL)
 	if err != nil {
 		return fmt.Errorf("invalid clone URL %q: %w", cloneURL, err)
+	}
+
+	// Local filesystem paths (no scheme) and file:// URLs: only when explicitly
+	// allowed. ext::/git:// etc. fall through to the scheme switch and are rejected.
+	if parsed.Scheme == "" || parsed.Scheme == "file" {
+		if allowLocal {
+			return nil
+		}
+		return fmt.Errorf("local/file clone URLs are not permitted: %s", cloneURL)
 	}
 
 	host := strings.ToLower(parsed.Hostname())

--- a/internal/gitutil/clone.go
+++ b/internal/gitutil/clone.go
@@ -1,0 +1,94 @@
+package gitutil
+
+// Clone-safety helpers. Leaf utilities (no imports from internal/daemon,
+// internal/ledger, or internal/gitserver) so every caller — CLI, daemon, ledger
+// — applies the same clone invariants without import cycles. See ADR-022 and
+// security/SECURITY.md for the trust model these enforce.
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ValidateCloneURL rejects clone URLs that can turn `git clone` into arbitrary
+// command execution or local-file access.
+//
+// git's `ext::` transport forks a shell command, and `file://` reaches the local
+// filesystem; either is RCE/SSRF when the URL is sourced from an attacker-
+// influenced channel (a tampered on-disk credentials file, a compromised API
+// response). This validator is the first of two independent defenses; the second
+// is HardenedCloneArgs, which disables those transports at the git level even if
+// a URL slips through.
+//
+// Scheme policy:
+//   - https://         always allowed
+//   - http://          allowed ONLY for localhost / 127.0.0.1 (local dev)
+//   - everything else  rejected (ext://, git://, ssh://, file://, …)
+//
+// Host policy: if trustedHosts is non-empty, the URL host must equal one of them
+// or be a subdomain of one. If trustedHosts is empty, any host is accepted (the
+// caller is relying on scheme validation + HardenedCloneArgs alone — appropriate
+// for user-owned ledger repos that may live on github.com, gitlab.com, or a
+// self-hosted forge).
+func ValidateCloneURL(cloneURL string, trustedHosts []string) error {
+	if cloneURL == "" {
+		return fmt.Errorf("clone URL is empty")
+	}
+	// A leading dash would be parsed by git as a flag, not a positional. Callers
+	// must also pass "--" before the URL (HardenedCloneArgs callers do), but
+	// reject it here too so validation alone is sufficient.
+	if strings.HasPrefix(cloneURL, "-") {
+		return fmt.Errorf("clone URL may not start with '-': %q", cloneURL)
+	}
+
+	parsed, err := url.Parse(cloneURL)
+	if err != nil {
+		return fmt.Errorf("invalid clone URL %q: %w", cloneURL, err)
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return fmt.Errorf("clone URL has no host: %s", cloneURL)
+	}
+
+	isLocalHost := host == "localhost" || host == "127.0.0.1"
+
+	switch parsed.Scheme {
+	case "https":
+		// ok
+	case "http":
+		if !isLocalHost {
+			return fmt.Errorf("only https:// is supported for remote hosts, got: %s", cloneURL)
+		}
+		return nil // local dev over http needs no host allowlist
+	default:
+		return fmt.Errorf("unsupported clone URL scheme %q (only https is allowed): %s", parsed.Scheme, cloneURL)
+	}
+
+	if len(trustedHosts) == 0 {
+		return nil
+	}
+	for _, trusted := range trustedHosts {
+		if host == trusted || strings.HasSuffix(host, "."+trusted) {
+			return nil
+		}
+	}
+	return fmt.Errorf("untrusted git host: %s (allowed: %v)", parsed.Host, trustedHosts)
+}
+
+// HardenedCloneArgs returns the `-c` flags that disable git's dangerous
+// transports for a clone. Prepend these to the git argument list, before the
+// "clone" subcommand. Always pass "--" before the positional <url> <path> too,
+// so a hostile URL can never be parsed as a flag.
+//
+// allowFileTransport must be wired to a test-only override (e.g.
+// gitserver.TestAllowFileTransport) so the suite can clone from file:// bare
+// repos while production stays locked. In production it is always false.
+func HardenedCloneArgs(allowFileTransport bool) []string {
+	args := []string{"-c", "protocol.ext.allow=never"}
+	if !allowFileTransport {
+		args = append(args, "-c", "protocol.file.allow=never")
+	}
+	return args
+}

--- a/internal/gitutil/clone_test.go
+++ b/internal/gitutil/clone_test.go
@@ -1,0 +1,55 @@
+package gitutil
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestValidateCloneURL(t *testing.T) {
+	hosts := []string{"sageox.ai", "sageox.io"}
+	tests := []struct {
+		name    string
+		url     string
+		hosts   []string
+		wantErr bool
+	}{
+		{"https trusted host", "https://git.sageox.ai/team/ctx.git", hosts, false},
+		{"https subdomain", "https://x.y.sageox.io/r.git", hosts, false},
+		{"https any host when no allowlist", "https://github.com/o/r.git", nil, false},
+		{"https untrusted host with allowlist", "https://github.com/o/r.git", hosts, true},
+		{"ext transport RCE", "ext::sh -c 'touch /tmp/pwned'", nil, true},
+		{"git scheme", "git://evil/r.git", nil, true},
+		{"ssh scheme", "ssh://git@host/r.git", nil, true},
+		{"file scheme remote", "file:///etc/passwd", nil, true},
+		{"http remote rejected", "http://github.com/o/r.git", nil, true},
+		{"http localhost allowed", "http://localhost/r.git", nil, false},
+		{"http 127.0.0.1 allowed", "http://127.0.0.1:8080/r.git", nil, false},
+		{"leading dash flag injection", "--upload-pack=touch /tmp/x", nil, true},
+		{"empty", "", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCloneURL(tt.url, tt.hosts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCloneURL(%q) err=%v, wantErr=%v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHardenedCloneArgs(t *testing.T) {
+	prod := HardenedCloneArgs(false)
+	if !slices.Contains(prod, "protocol.ext.allow=never") {
+		t.Error("production args must disable ext transport")
+	}
+	if !slices.Contains(prod, "protocol.file.allow=never") {
+		t.Error("production args must disable file transport")
+	}
+	test := HardenedCloneArgs(true)
+	if slices.Contains(test, "protocol.file.allow=never") {
+		t.Error("test override must allow file transport")
+	}
+	if !slices.Contains(test, "protocol.ext.allow=never") {
+		t.Error("ext transport must stay disabled even under file-transport test override")
+	}
+}

--- a/internal/gitutil/clone_test.go
+++ b/internal/gitutil/clone_test.go
@@ -8,30 +8,34 @@ import (
 func TestValidateCloneURL(t *testing.T) {
 	hosts := []string{"sageox.ai", "sageox.io"}
 	tests := []struct {
-		name    string
-		url     string
-		hosts   []string
-		wantErr bool
+		name       string
+		url        string
+		hosts      []string
+		allowLocal bool
+		wantErr    bool
 	}{
-		{"https trusted host", "https://git.sageox.ai/team/ctx.git", hosts, false},
-		{"https subdomain", "https://x.y.sageox.io/r.git", hosts, false},
-		{"https any host when no allowlist", "https://github.com/o/r.git", nil, false},
-		{"https untrusted host with allowlist", "https://github.com/o/r.git", hosts, true},
-		{"ext transport RCE", "ext::sh -c 'touch /tmp/pwned'", nil, true},
-		{"git scheme", "git://evil/r.git", nil, true},
-		{"ssh scheme", "ssh://git@host/r.git", nil, true},
-		{"file scheme remote", "file:///etc/passwd", nil, true},
-		{"http remote rejected", "http://github.com/o/r.git", nil, true},
-		{"http localhost allowed", "http://localhost/r.git", nil, false},
-		{"http 127.0.0.1 allowed", "http://127.0.0.1:8080/r.git", nil, false},
-		{"leading dash flag injection", "--upload-pack=touch /tmp/x", nil, true},
-		{"empty", "", nil, true},
+		{"https trusted host", "https://git.sageox.ai/team/ctx.git", hosts, false, false},
+		{"https subdomain", "https://x.y.sageox.io/r.git", hosts, false, false},
+		{"https any host when no allowlist", "https://github.com/o/r.git", nil, false, false},
+		{"https untrusted host with allowlist", "https://github.com/o/r.git", hosts, false, true},
+		{"ext transport RCE rejected even with allowLocal", "ext::sh -c 'touch /tmp/pwned'", nil, true, true},
+		{"git scheme", "git://evil/r.git", nil, false, true},
+		{"ssh scheme", "ssh://git@host/r.git", nil, false, true},
+		{"file scheme rejected in production", "file:///etc/passwd", nil, false, true},
+		{"file scheme allowed for local tests", "file:///tmp/x.bare", nil, true, false},
+		{"bare local path rejected in production", "/tmp/x", nil, false, true},
+		{"bare local path allowed for local tests", "/tmp/x", nil, true, false},
+		{"http remote rejected", "http://github.com/o/r.git", nil, false, true},
+		{"http localhost allowed", "http://localhost/r.git", nil, false, false},
+		{"http 127.0.0.1 allowed", "http://127.0.0.1:8080/r.git", nil, false, false},
+		{"leading dash flag injection", "--upload-pack=touch /tmp/x", nil, true, true},
+		{"empty", "", nil, false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateCloneURL(tt.url, tt.hosts)
+			err := ValidateCloneURL(tt.url, tt.hosts, tt.allowLocal)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateCloneURL(%q) err=%v, wantErr=%v", tt.url, err, tt.wantErr)
+				t.Errorf("ValidateCloneURL(%q, allowLocal=%v) err=%v, wantErr=%v", tt.url, tt.allowLocal, err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/gitutil/httphost.go
+++ b/internal/gitutil/httphost.go
@@ -1,0 +1,40 @@
+package gitutil
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ValidateHTTPSHost rejects a URL whose scheme is not https or whose host is not
+// in the allowlist. It is used before fetching attacker-influenced URLs (e.g. an
+// adapter asset's browser_download_url taken from a GitHub API response).
+//
+// Per ADR-022 (decision 4) this is a transport guard, NOT the primary integrity
+// control: a host allowlist cannot stop malicious bytes served at a legitimate
+// URL, and over-tight host lists break when a CDN rotates hosts. The primary
+// control for downloaded binaries is checksum verification. Use this only as
+// defense-in-depth alongside a checksum gate, never as a substitute.
+func ValidateHTTPSHost(rawURL string, allowedHosts map[string]bool) error {
+	if rawURL == "" {
+		return fmt.Errorf("URL is empty")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("URL must use https, got %q in: %s", parsed.Scheme, rawURL)
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return fmt.Errorf("URL has no host: %s", rawURL)
+	}
+	if len(allowedHosts) == 0 {
+		return nil
+	}
+	if allowedHosts[host] {
+		return nil
+	}
+	return fmt.Errorf("URL host %q not in allowlist: %s", host, rawURL)
+}

--- a/internal/gitutil/httphost_test.go
+++ b/internal/gitutil/httphost_test.go
@@ -1,0 +1,28 @@
+package gitutil
+
+import "testing"
+
+func TestValidateHTTPSHost(t *testing.T) {
+	allow := map[string]bool{"github.com": true, "objects.githubusercontent.com": true}
+	tests := []struct {
+		name    string
+		url     string
+		allow   map[string]bool
+		wantErr bool
+	}{
+		{"allowed host", "https://github.com/o/r/releases/x", allow, false},
+		{"allowed cdn host", "https://objects.githubusercontent.com/a/b", allow, false},
+		{"disallowed host", "https://attacker.example.com/evil.tar.gz", allow, true},
+		{"http rejected", "http://github.com/o/r", allow, true},
+		{"any host when no allowlist", "https://anywhere.test/x", nil, false},
+		{"empty", "", allow, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateHTTPSHost(tt.url, tt.allow)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateHTTPSHost(%q) err=%v, wantErr=%v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -401,6 +401,17 @@ func CloneWithSparseCheckout(path, remoteURL string) error {
 		return fmt.Errorf("git clone: remote URL is empty")
 	}
 
+	// Validate the URL before it reaches git. remoteURL is sourced from the
+	// workspace registry / credentials file, which is attacker-influenceable;
+	// without this, an `ext::sh -c '...'` URL would make git fork a shell as the
+	// daemon user (RCE). Host allowlist is intentionally empty: ledgers legitimately
+	// live on github.com / gitlab.com / self-hosted forges, so we rely on scheme
+	// validation here plus HardenedCloneArgs below (two independent defenses).
+	// See ADR-022 / security/SECURITY.md (#hunter-cli-input).
+	if err := gitutil.ValidateCloneURL(remoteURL, nil); err != nil {
+		return fmt.Errorf("git clone: unsafe remote URL: %w", err)
+	}
+
 	// remove existing directory if empty
 	entries, _ := os.ReadDir(path)
 	if len(entries) == 0 {
@@ -414,15 +425,23 @@ func CloneWithSparseCheckout(path, remoteURL string) error {
 	// cloned origin URL stays bare and credentials live in the OS
 	// keychain or 0600 file store.
 	helperCmd := gitserver.DefaultHelperCommand()
-	cloneCmd := exec.Command("git",
+	gitArgs := []string{
 		"-c", "credential.helper=",
-		"-c", "credential.helper="+helperCmd,
+		"-c", "credential.helper=" + helperCmd,
+	}
+	// Disable git's ext:: / file:: transports so a hostile URL can't reach a
+	// shell or the local filesystem even if it passed validation.
+	gitArgs = append(gitArgs, gitutil.HardenedCloneArgs(gitserver.TestAllowFileTransport)...)
+	// "--" guarantees remoteURL is treated as a positional, never a flag.
+	gitArgs = append(gitArgs,
 		"clone",
 		"--filter=blob:none",
 		"--sparse",
+		"--",
 		remoteURL,
 		path,
 	)
+	cloneCmd := exec.Command("git", gitArgs...)
 	if output, err := cloneCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git clone: %w: %s", err, output)
 	}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -408,7 +408,7 @@ func CloneWithSparseCheckout(path, remoteURL string) error {
 	// live on github.com / gitlab.com / self-hosted forges, so we rely on scheme
 	// validation here plus HardenedCloneArgs below (two independent defenses).
 	// See ADR-022 / security/SECURITY.md (#hunter-cli-input).
-	if err := gitutil.ValidateCloneURL(remoteURL, nil); err != nil {
+	if err := gitutil.ValidateCloneURL(remoteURL, nil, gitserver.TestAllowFileTransport); err != nil {
 		return fmt.Errorf("git clone: unsafe remote URL: %w", err)
 	}
 

--- a/internal/ledger/main_test.go
+++ b/internal/ledger/main_test.go
@@ -1,0 +1,20 @@
+package ledger
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sageox/ox/internal/gitserver"
+)
+
+// TestMain opts the ledger test binary into git's file/local transport. These
+// tests clone from local bare repos (file:// and bare /tmp paths) to simulate a
+// remote. Production hardens against that transport — CloneWithSparseCheckout
+// passes `-c protocol.file.allow=never` (HardenedCloneArgs) and rejects
+// local/file URLs in gitutil.ValidateCloneURL — both gated on
+// gitserver.TestAllowFileTransport. Tests must opt back in, mirroring the daemon
+// suite's isolateCredentials helper.
+func TestMain(m *testing.M) {
+	gitserver.TestAllowFileTransport = true
+	os.Exit(m.Run())
+}

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -9,11 +9,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/sageox/ox/internal/envutil"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/sageox/ox/pkg/adapterruntime"
 	"github.com/sageox/ox/pkg/ndjson"
@@ -32,29 +32,6 @@ var (
 	// ErrProtocolMismatch is returned when an adapter's protocol version is incompatible.
 	ErrProtocolMismatch = errors.New("adapter protocol version mismatch")
 )
-
-// allowlistedEnvVars are exact-match variable names always passed to adapter processes.
-var allowlistedEnvVars = map[string]bool{
-	"HOME":   true,
-	"PATH":   true,
-	"TMPDIR": true,
-}
-
-// allowlistedEnvPrefixes are prefix patterns; any variable starting with these is passed through.
-var allowlistedEnvPrefixes = []string{
-	"XDG_",
-}
-
-// denylistedEnvPatterns are substrings that block adapter-declared required_env vars.
-// Prevents adapters from requesting sensitive credentials via self-declared required_env.
-var denylistedEnvPatterns = []string{
-	"SECRET",
-	"TOKEN",
-	"KEY",
-	"PASSWORD",
-	"CREDENTIAL",
-	"PRIVATE",
-}
 
 // ExternalAdapter implements Adapter and IncrementalReader by calling an
 // external adapter binary via subprocess (one-shot) or serve-mode pipe.
@@ -586,86 +563,7 @@ func (ea *ExternalAdapter) buildEnv() []string {
 	if ea.info != nil {
 		requiredEnv = ea.info.RequiredEnv
 	}
-	return SanitizedEnv(os.Environ(), requiredEnv)
-}
-
-// SanitizedEnv builds a sanitized environment for adapter subprocess execution.
-// It filters environ (typically os.Environ()) to only include:
-//   - Exact-match allowlisted vars: HOME, PATH, TMPDIR
-//   - Prefix-match allowlisted vars: XDG_*
-//   - OX_* protocol vars (OX_PROTOCOL_VERSION, OX_REPO_ROOT, OX_REPO_ID, OX_TEAM_ID)
-//   - Any additional vars declared in the adapter's required_env list
-//
-// All other variables (API keys, tokens, secrets) are stripped.
-func SanitizedEnv(environ []string, requiredEnv []string) []string {
-	// build a set of adapter-declared required env var names, filtering out
-	// names that match sensitive patterns to prevent credential exfiltration
-	required := make(map[string]bool, len(requiredEnv))
-	for _, name := range requiredEnv {
-		if isDenylisted(name) {
-			continue
-		}
-		required[name] = true
-	}
-
-	env := make([]string, 0, len(allowlistedEnvVars)+len(requiredEnv)+4)
-
-	// track which OX_ vars we found so we can inject defaults for missing ones
-	foundOX := make(map[string]bool)
-
-	for _, entry := range environ {
-		name, _, ok := strings.Cut(entry, "=")
-		if !ok {
-			continue
-		}
-
-		if isAllowlisted(name) || required[name] {
-			env = append(env, entry)
-		}
-
-		// track OX_ vars we see (they pass through isAllowlisted via the OX_ prefix check)
-		if strings.HasPrefix(name, "OX_") {
-			foundOX[name] = true
-		}
-	}
-
-	// always inject OX_PROTOCOL_VERSION if not already present
-	if !foundOX["OX_PROTOCOL_VERSION"] {
-		env = append(env, fmt.Sprintf("OX_PROTOCOL_VERSION=%d", adapterprotocol.ProtocolVersion))
-	}
-
-	return env
-}
-
-// isDenylisted returns true if the variable name contains a sensitive pattern.
-// Used to prevent adapter-declared required_env from requesting credentials.
-func isDenylisted(name string) bool {
-	upper := strings.ToUpper(name)
-	for _, pattern := range denylistedEnvPatterns {
-		if strings.Contains(upper, pattern) {
-			return true
-		}
-	}
-	return false
-}
-
-// isAllowlisted returns true if the variable name matches the allowlist.
-func isAllowlisted(name string) bool {
-	if allowlistedEnvVars[name] {
-		return true
-	}
-	// OX_* protocol vars are always passed through — EXCEPT names matching
-	// the credential denylist, which must never leak to
-	// adapter subprocesses regardless of prefix.
-	if strings.HasPrefix(name, "OX_") {
-		return !isDenylisted(name)
-	}
-	for _, prefix := range allowlistedEnvPrefixes {
-		if strings.HasPrefix(name, prefix) {
-			return true
-		}
-	}
-	return false
+	return envutil.SanitizedEnv(os.Environ(), requiredEnv)
 }
 
 // protocolToInternal converts protocol RawEntry slice to internal RawEntry slice.

--- a/internal/session/raw_writer.go
+++ b/internal/session/raw_writer.go
@@ -56,7 +56,10 @@ type RawWriter struct {
 // (e.g. daemon writing to a ledger session whose project isn't known
 // at write time); built-in patterns still apply.
 func NewRawWriter(path, projectRoot string) (*RawWriter, error) {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	// 0600: raw.jsonl holds full conversation content (and, until the
+	// redaction stack scrubs them, any secrets in transit). Keep it
+	// owner-only — never world-readable.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("raw writer: open: %w", err)
 	}
@@ -68,7 +71,8 @@ func NewRawWriter(path, projectRoot string) (*RawWriter, error) {
 // that produce a fresh raw.jsonl rather than appending. The redaction
 // stack is identical — every byte still passes through.
 func NewRawWriterTruncate(path, projectRoot string) (*RawWriter, error) {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	// 0600: owner-only, same rationale as NewRawWriter.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("raw writer: open: %w", err)
 	}

--- a/internal/session/raw_writer_test.go
+++ b/internal/session/raw_writer_test.go
@@ -438,6 +438,34 @@ func TestGeneratedAirtableRule_KeywordIsTokenAnchor(t *testing.T) {
 	require.True(t, found, "airtable_personnal_access_token rule not found in generated detectors")
 }
 
+// TestRawWriter_FileModeIsOwnerOnly verifies raw.jsonl is created 0600,
+// not world-readable. raw.jsonl holds full conversation content (and any
+// secrets in transit before the redaction stack scrubs them); a 0644 file
+// would leak it to every local user. Covers both constructors.
+// Failure prevented: companion "raw.jsonl world-readable" finding.
+func TestRawWriter_FileModeIsOwnerOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		open func(path string) (*RawWriter, error)
+	}{
+		{"append", func(p string) (*RawWriter, error) { return NewRawWriter(p, "") }},
+		{"truncate", func(p string) (*RawWriter, error) { return NewRawWriterTruncate(p, "") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "raw.jsonl")
+			w, err := tc.open(path)
+			require.NoError(t, err)
+			require.NoError(t, w.WriteEntry(&SessionEntry{Type: EntryTypeUser, Content: "hi"}))
+			require.NoError(t, w.Close())
+
+			fi, err := os.Stat(path)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0600), fi.Mode().Perm(),
+				"raw.jsonl must be owner-only (0600), got %o", fi.Mode().Perm())
+		})
+	}
+}
+
 // TestRawWriter_JSONLOutputIsValid verifies every line in the output is
 // parseable JSON. A redactor that introduces unescaped quotes or breaks
 // the wire format would create downstream parse failures.

--- a/security/SECURITY.md
+++ b/security/SECURITY.md
@@ -283,6 +283,7 @@ flowchart LR
 - [`internal/daemon/ipc_peercred_linux.go`](../internal/daemon/ipc_peercred_linux.go) — peer-credential check
 - [`internal/daemon/ipc.go`](../internal/daemon/ipc.go) — size + connection caps, message dispatch
 - [`cmd/ox/adapter.go`](../cmd/ox/adapter.go) — adapter download + install
+- [`docs/adr/ADR-022-adapter-security-posture.md`](../docs/adr/ADR-022-adapter-security-posture.md) — adapter trust model: curated-path integrity (tag + sha256, verify-before-exec) vs frictionless arbitrary-repo install; what `verifyAdapterBinary` does and does not check
 - [`internal/gitserver/credentials.go`](../internal/gitserver/credentials.go) — keyring-backed git credentials
 - [`internal/auth/authfile.go`](../internal/auth/authfile.go) — OAuth token storage (file, NOT keyring — see open risk in [`#hunter-secrets-redaction`](#hunter-secrets-redaction))
 


### PR DESCRIPTION
## What this PR ships

Implements the confirmed CRITICAL/HIGH findings from the 2026-06-10 full-repo security review **plus** the adapter security-posture ADR — all in one PR (the team opted not to split). Each fix is built as an **invariant in a shared leaf package** so the bug class can't silently drift back.

```mermaid
flowchart TB
  subgraph IN["Untrusted inputs"]
    direction TB
    U1["adapter release JSON + asset bytes"]
    U2["session entries via --entries / stdin"]
    U3["daemon env to hooks + serve-mode adapters"]
    U4["clone URL from credentials file"]
    U1 ~~~ U2 ~~~ U3 ~~~ U4
  end
  subgraph CHOKE["Now unavoidable chokepoint"]
    direction TB
    C1["sha256 gate + tag pin (verify before exec)"]
    C2["session.RawWriter redaction"]
    C3["envutil.SanitizedEnv (default deny)"]
    C4["gitutil.ValidateCloneURL + hardened args"]
    C1 ~~~ C2 ~~~ C3 ~~~ C4
  end
  subgraph SINK["Dangerous sinks"]
    direction TB
    S1["exec downloaded binary"]
    S2["raw.jsonl in team ledger"]
    S3["child process env"]
    S4["git clone as daemon user"]
    S1 ~~~ S2 ~~~ S3 ~~~ S4
  end
  U1 --> C1 --> S1
  U2 --> C2 --> S2
  U3 --> C3 --> S3
  U4 --> C4 --> S4
```

## Fixes

- **PR0 / shared primitives (`ox-045x`)** — new `internal/gitutil` helpers: `ValidateCloneURL`, `HardenedCloneArgs`, `ValidateHTTPSHost`. Dependency-free leaf, reused below.
- **Clone RCE (`ox-o8qu`, HIGH)** — `CloneWithSparseCheckout` (`internal/ledger/ledger.go`) now validates the registry/credential-sourced URL, disables git `ext::`/`file::` transports, and inserts `--` before the URL. Kills `ext::sh -c '…'` RCE as the daemon user. Two independent defenses (scheme validation + transport flags).
- **Redaction bypass (`ox-hxyq`, HIGH→arguably CRIT)** — `recordEntriesToSession` + `writeRawHeader` route through `session.RawWriter`'s three-layer redaction instead of raw `os.OpenFile`; `raw.jsonl` is now `0600` not `0644`; the Makefile chokepoint check catches `rawPath`/`ledgerFileRaw` variable indirection that the literal-string grep missed.
- **Env leak (`ox-gkqu`, HIGH)** — new `internal/envutil.SanitizedEnv` (relocated from adapters) is the default-deny spawn env for **hook scripts** and **serve-mode adapter binaries**, so `SAGEOX_TOKEN`/`GITHUB_TOKEN`/`AWS_*` no longer leak to untrusted children. First-party `ox distill` intentionally keeps inheriting (ADR-022 §6).
- **Adapter curated-path integrity (`ox-5ihl`, CRIT→HIGH, reframed)** — `AdapterEntry` gains `Tag` + per-platform `Checksums`; install reorders to **download → sha256 constant-time gate → chmod → exec**, fetches `releases/tags/<tag>` (asserts `tag_name`), renames `verifyAdapterBinary`→`verifyAdapterProtocol`. Curated entries lacking a checksum and arbitrary `github.com/<owner>/<repo>` installs **fail closed** unless `--allow-unverified`; arbitrary repos require `@<tag>`. No standalone host allowlist as primary control (ADR-022 §4) — checksum subsumes it. **Executing adapter code stays intended extensibility; only the curated trust path gains authenticity.**
- **LLM-trust hygiene** — summarization prompt delivered via subprocess **stdin** (off argv → no `ps`/`/proc` leak); stored subagent summaries are **ANSI/control-stripped** before terminal print, and `stripANSIEscapes` now covers OSC/DCS/APC/BEL + bare control bytes (terminal-escape injection).

## Posture record

- **`docs/adr/ADR-022-adapter-security-posture.md`** (new) + inline trust-boundary comments in `cmd/ox/adapter.go`; cross-linked from `ADR-013` and `security/SECURITY.md`. Documents the two-trust-anchor model and the same-UID threat-model boundary.

## Out of threat model (documented, not "fixed")

Per `security/SECURITY.md`, ox accepts the same-UID actor (they can edit the ledger / read the 0600 token directly). The MEDIUM/LOW daemon findings (Windows pipe squatting, `handleStop` drain, `handleTriggerGC` rate-limit) describe an attacker already inside the trust unit; not addressed here by design. Windows IPC is explicitly unaudited.

## Severity note (your call)

Adapter curated-path gap is CRITICAL only if `ox adapter install <name>` is marketed as curated-safe; otherwise HIGH (ADR-022). Reframed accordingly.

## Test Plan

- `go build ./...` clean; `go vet` clean on all touched packages.
- New tests pass: `gitutil` (clone/host validation), `envutil` (secret stripping), adapter install (checksum-mismatch fails before exec, host rejection, fail-closed, tag pinning), session redaction (`tool_output` secret → `[REDACTED`), `raw.jsonl` 0600, ANSI stripping (OSC 52 clipboard payload), runner prompt-via-stdin.
- Guard checks pass: `make check-raw-writer-chokepoint`, `make check-no-git-lfs-shell`.
- Note: 6 `TestGlobalLease*` failures are environmental (a real `ox daemon` holds the global-sync lease on the dev box); they touch `global_lease.go`, untouched by this PR.

## Required review (per CLAUDE.md)

- Adapter trust model + checksum source-of-truth (`registry.yaml`).
- Clone data-access boundary.
- Distill env opt-in. No new customer-facing `SAGEOX_*`/`OX_*` env vars.

## Follow-up (data/wiring, not blocking)

- Populate real `tag` + per-platform `checksums` in `registry.yaml` for cursor/windsurf/copilot/cline to restore frictionless curated install (until then those require `--allow-unverified`).
- Wire adapter `RequiredEnv` into the daemon supervisor spawn (TODO `ox-gkqu`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADRs and security docs clarifying adapter trust model, registry pin/checksum expectations, and related guidance.
* **Security**
  * Enforced download → checksum/conformance → chmod → exec ordering; curated installs require pinned release + per-platform checksum; explicit repos require opt-in to skip verification.
* **New Features**
  * Installer adds --allow-unverified and stricter curated vs explicit source flows; adapter fixes detect scope-escalation and require confirmation.
* **Bug Fixes**
  * Sanitize daemon/hook environments, feed sensitive prompts via stdin, strip ANSI from summaries, and make session raw files owner-only.
* **Tests**
  * Expanded coverage for installs, env sanitization, ANSI stripping, cloning/hosts, raw-writer, and adapter-fix safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->