### PR TITLE
feat(plan): budget-sequence + cost-telemetry-table viz catalog patterns

### DIFF
--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -562,15 +562,19 @@ func writePlanEnrichmentGuidance(sb *strings.Builder, agentType string) {
 	sb.WriteString("Before planning non-trivial work, consult SageOx conversation intelligence so the plan reflects the team's latest decisions: `ox query \"<topic>\"` (discussions + sessions), `ox code search` (code + git history). Plans that ignore recent team context get re-litigated.\n")
 	if prime.ClassifyAgentTier(agentType) == prime.TierBronze {
 		// lighter tier: surface the surface, don't promise real-time nudges.
-		sb.WriteString("When you produce a plan, run `ox plan enrich` for team context (collisions, prior art, expert routing) as JSON. To show the human a rendered page, recommend `ox plan render --open`. Browse prior plans with `ox plan list`.\n")
+		sb.WriteString("When you produce a plan, run `ox plan enrich` for team context (collisions, prior art, expert routing) as JSON. To show the human a rendered page, recommend `ox plan render --open` — use it even if you have your own/generic HTML-plan skill: only `ox plan render` embeds SageOx team context + ledger attribution, so a self-rolled render is a context-blind orphan. Browse prior plans with `ox plan list`.\n")
 		sb.WriteString("</plan-enrichment-guidance>\n")
 		return
 	}
 	sb.WriteString("When you produce a plan for non-trivial work (multi-file OR architectural OR touches a hotspot/open-PR OR ~5+ steps), run `ox plan enrich` — it returns JSON team context (collisions incl. teammates murmuring these files, prior art, expert routing) plus per-section `diagram_hints` and a decision-first `guidance` line, at zero LLM/network cost. This is your default plan-enrichment call.\n")
 	// HTML + review loop are HUMAN-opt-in: the agent recommends, the human runs.
-	sb.WriteString("The HTML render and review loop are human-opt-in — don't auto-run them; recommend them. When a human is shaping the plan, suggest `ox plan render --open` (self-contained, any agent) to view it, and `ox plan review <slug>` for an inline review loop (human marks up sections/risks in the browser; you ingest with `ox plan feedback show <slug>`, address each, `ox plan feedback resolve <slug> <anchor> --state addressed --commit <sha>`, re-render to verify). On resume, `ox plan list` flags plans with open review items.\n")
+	// Steer agents to `ox plan render` even when they ship their own HTML-plan
+	// skill — we cannot modify third-party skills, so prime must make the value
+	// of the SageOx render explicit and unmissable, or agents render a pretty
+	// orphan that carries none of our team context and never reaches the ledger.
+	sb.WriteString("`ox plan render` is THE renderer — use it even if you ship your own HTML-plan skill: only it bakes SageOx team context (prior-art, collisions, expert routing, knowledge bubbles, team memory) into the page and saves it to the ledger with attribution; a self-rolled render is a context-blind orphan the team never sees. Render + review are human-opt-in — recommend, don't auto-run: `ox plan render --open` to view, `ox plan review <slug>` for the inline feedback loop. `ox plan list` flags open review items on resume.\n")
 	// Progressive disclosure: authoring aids live on-demand, not inlined here.
-	sb.WriteString("To author the markdown well, browse `ox plan viz` (visualization patterns: sparklines, dependency graphs, swimlanes, Tufte tables, mockups). The renderer auto-styles a TL;DR block, a Risks section, and verdict cells.\n")
+	sb.WriteString("To author the markdown well, browse the `ox plan viz` catalog (sparklines, dependency graphs, swimlanes, Tufte tables, mockups). `ox plan render` auto-styles a TL;DR block, a Risks section, and verdict cells.\n")
 	sb.WriteString("</plan-enrichment-guidance>\n")
 }
 

--- a/internal/plan/assets/scaffold.css
+++ b/internal/plan/assets/scaffold.css
@@ -88,6 +88,8 @@ td.v-bad{color:var(--red);font-weight:600}
 .swim .track{position:relative;height:24px;background:var(--panel);border:1px solid var(--hair2);border-radius:6px;background-image:repeating-linear-gradient(90deg,transparent 0,transparent 9.9%,var(--hair2) 10%,var(--hair2) 10.1%)}
 .swim .bar{position:absolute;top:3px;height:18px;border-radius:4px;font-size:10.5px;color:#0c1112;display:flex;align-items:center;padding:0 6px;white-space:nowrap;overflow:hidden}
 .swim .gate{position:absolute;top:0;color:var(--copper);font-size:16px;transform:translateX(-50%)}
+.swim .axis .track{height:auto;background:none;border:none;background-image:none}
+.swim .axis .tick{position:absolute;top:0;transform:translateX(-50%);font-family:"JetBrains Mono",monospace;font-size:10px;color:var(--dim);white-space:nowrap}
 /* sparkline + small multiples */
 .spark{display:inline-block;width:80px;height:18px;vertical-align:middle}
 .multiples{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:12px;margin:14px 0}

--- a/internal/plan/assets/viz-catalog.md
+++ b/internal/plan/assets/viz-catalog.md
@@ -22,6 +22,34 @@ sequenceDiagram
   A-->>C: response
 ```
 
+## budget-sequence
+use: a latency or cost budget across an ordered call path — show where each slice of the budget goes and the lever that buys it ("warm claim under 1s p99").
+why: a bare sequence diagram shows order; budget bands (`Note over`) plus a paired stage/budget/lever table show WHERE the time goes and WHAT to pull — the reviewer approves the budget, not just the topology. Pair the diagram (the path) with the table (the levers); neither alone makes the budget reviewable.
+```mermaid
+sequenceDiagram
+  participant C as Caller
+  participant W as Workflow
+  participant R as Renderer
+  participant S as S3 plus CDN
+  C->>W: start stream
+  W->>R: claim warm slot (HRW wfid to pod)
+  Note over W,R: deterministic route, ~0ms
+  R->>R: navigate to brand-new URL (shared shell cached)
+  Note over R: route delta only, SSR paint-instant, under 600ms
+  R->>S: write first partial segment + manifest
+  Note over R,S: LL-HLS partial, under 300ms
+  S-->>C: manifest ready
+  Note over C,S: total budget under 1s p99
+```
+```text
+| stage                          | budget  | lever                                |
+|--------------------------------|---------|--------------------------------------|
+| route to warm pod              | ~0ms    | consistent-hash (ADR-040 #1)         |
+| navigate to new URL (route Δ)  | <400ms  | generic warm pool + warm shell cache |
+| first painted frame            | <300ms  | paint-instant pages                  |
+| first partial segment+manifest | <300ms  | LL-HLS partials                      |
+```
+
 ## dependency-graph
 use: topology, not order — "what depends on / connects to what", to reveal coupling, a contended boundary, or blast radius.
 why: a graph makes coupling visible at a glance; a list buries it.
@@ -46,14 +74,16 @@ stateDiagram-v2
 ```
 
 ## swimlane-timeline
-use: phases, rollout, or relative-effort sequencing across workstreams (NOT calendar dates).
-why: lanes + bars show what runs when and in parallel; the robust default for "when, in what order, how long".
+use: phases, rollout, or relative-effort sequencing across workstreams (NOT calendar dates) — a "build sequence" showing what's foundational, what unblocks the goal, and what's deferred to scale.
+why: lanes + bars show what runs when and in parallel; the robust default for "when, in what order, how long". Add a labeled gate (◆) for the milestone that matters, a bottom axis of phase columns, and a one-line caption stating the unit — that's what turns a bar chart into an at-a-glance build plan.
 ```html
 <div class="swim">
-  <div class="lane"><span class="lane-name">Backend</span><div class="track"><span class="bar" style="left:0;width:40%;background:var(--sage)">schema</span><span class="bar" style="left:42%;width:30%;background:var(--teal)">API</span></div></div>
-  <div class="lane"><span class="lane-name">Frontend</span><div class="track"><span class="bar" style="left:44%;width:46%;background:var(--copper)">UI</span></div></div>
-  <div class="lane"><span class="lane-name">Gate</span><div class="track"><span class="gate" style="left:90%" title="ship">◆</span></div></div>
+  <div class="lane"><span class="lane-name">Foundation</span><div class="track"><span class="bar" style="left:0;width:18%;background:var(--copper)">measure</span><span class="bar" style="left:20%;width:14%;background:var(--sage)">fix pool</span></div></div>
+  <div class="lane"><span class="lane-name">Claim &lt;1s</span><div class="track"><span class="bar" style="left:38%;width:18%;background:var(--teal)">pre-warm</span><span class="bar" style="left:58%;width:16%;background:var(--teal)">paint</span><span class="bar" style="left:76%;width:18%;background:var(--teal)">partials</span></div></div>
+  <div class="lane"><span class="lane-name">Scale</span><div class="track"><span class="bar" style="left:38%;width:18%;background:var(--copper)">cost dials</span><span class="bar" style="left:58%;width:16%;background:var(--copper)">deep pool</span><span class="bar" style="left:76%;width:18%;background:var(--copper)">multi-replica</span></div></div>
+  <div class="lane axis"><span class="lane-name"></span><div class="track"><span class="tick" style="left:9%">measure</span><span class="tick" style="left:27%">pool fixed</span><span class="tick" style="left:47%">claim &lt;1s ◆</span><span class="tick" style="left:66%">deep pool</span><span class="tick" style="left:85%">100k scale</span></div></div>
 </div>
+<p class="dim">Relative effort, not calendar. ◆ = the gate where the goal becomes meetable.</p>
 ```
 
 ## gantt
@@ -117,6 +147,21 @@ why: shading encodes magnitude so the hot cell pops without the reader parsing e
   <tr><td>/plan</td><td class="h1">12</td><td class="h2">40</td></tr>
   <tr><td>/render</td><td class="h2">38</td><td class="h4">210</td></tr>
 </table>
+```
+
+## cost-telemetry-table
+use: per-stage cost/telemetry where some stages are reducible — name the cost, the telemetry field it's measured by, and whether it can be cut, then pair the table with ONE callout stating the conclusion.
+why: the table establishes the numbers (and where they come from, so the reviewer can verify against prod); a leading or trailing `TL;DR` callout states the load-bearing decision ("every reducible row is reduced by not doing it on the request path") so the reviewer gets the conclusion before parsing cells. Pair the table with the callout — the table is evidence, the callout is the read.
+```html
+<table class="heat">
+  <tr><th>cold-spawn stage</th><th>~cost</th><th>telemetry field</th><th>reducible?</th></tr>
+  <tr><td>new Chromium context</td><td>500-800ms</td><td>worker-pool</td><td>yes — pre-create</td></tr>
+  <tr><td>load heavy cast page</td><td>800-1500ms</td><td>navigate_ms</td><td>yes — pre-warm + SSR</td></tr>
+  <tr><td>paint handshake</td><td>300-600ms</td><td>paint_ms</td><td>yes — paint-instant</td></tr>
+  <tr><td>ffmpeg init + first segment</td><td>300-500ms</td><td>first_frame_ms</td><td>yes — partials</td></tr>
+  <tr><td><strong>cold total</strong></td><td class="h4"><strong>2.0-3.6s</strong></td><td></td><td></td></tr>
+</table>
+<div class="tldr"><span class="tldr-tag">TL;DR</span><p>Every reducible row is reduced by <em>not doing it on the request path</em> — i.e. pre-warming. Pre-warming is the mechanism, not an optimization.</p></div>
 ```
 
 ## device-mockup

--- a/internal/plan/diagram_hints.go
+++ b/internal/plan/diagram_hints.go
@@ -211,7 +211,7 @@ func buildGuidance(in Input, hints []DiagramHint) string {
 	b.WriteString("Render with `ox plan render --open` (self-contained, cross-agent). Author for a reviewer who has ~10 minutes: ")
 	b.WriteString("lead with the conclusion and the biggest risk; keep every file/ID/PR framed enough to stand on its own; ")
 	b.WriteString("let one hero diagram and a few tables replace prose rather than decorate it; cut anything that does not change the decision. ")
-	b.WriteString("Explore visualization patterns with `ox plan viz` (sparklines, dependency graphs, swimlane timelines, Tufte tables, device mockups) and weave in the ones that compress understanding.")
+	b.WriteString("Explore visualization patterns with `ox plan viz` (sparklines, dependency graphs, swimlane timelines, budget sequences, Tufte tables, device mockups) and weave in the ones that compress understanding.")
 	if len(hints) > 0 {
 		b.WriteString(" Diagrams that fit this plan: ")
 		parts := make([]string, 0, len(hints))

--- a/internal/plan/viz_catalog_test.go
+++ b/internal/plan/viz_catalog_test.go
@@ -42,6 +42,37 @@ func TestVizCatalog_HasCorePatterns(t *testing.T) {
 	}
 }
 
+// TestVizCatalog_PairedPatternsKeepBothHalves verifies the two patterns whose
+// readability comes from PAIRING two halves ship both halves. A budget-sequence
+// is only reviewable when the diagram (the path) sits beside the stage/budget/lever
+// table (the levers); a cost-telemetry-table only delivers its read when the data
+// table sits beside the conclusion callout.
+// Failure prevented: a future edit drops one half and the pattern silently
+// regresses to "just another diagram" / "just another table".
+func TestVizCatalog_PairedPatternsKeepBothHalves(t *testing.T) {
+	bs, ok := VizPatternByID("budget-sequence")
+	if !ok {
+		t.Fatal("catalog missing budget-sequence")
+	}
+	if !strings.Contains(bs.Body, "```mermaid") {
+		t.Error("budget-sequence missing the mermaid diagram half")
+	}
+	if !strings.Contains(bs.Body, "| stage") || !strings.Contains(bs.Body, "lever") {
+		t.Error("budget-sequence missing the paired stage/budget/lever table half")
+	}
+
+	ct, ok := VizPatternByID("cost-telemetry-table")
+	if !ok {
+		t.Fatal("catalog missing cost-telemetry-table")
+	}
+	if !strings.Contains(ct.Body, `class="heat"`) {
+		t.Error("cost-telemetry-table missing the data table half")
+	}
+	if !strings.Contains(ct.Body, `class="tldr"`) {
+		t.Error("cost-telemetry-table missing the paired conclusion callout half")
+	}
+}
+
 // TestVizPatternByID_CaseInsensitiveAndMiss verifies lookup is case-insensitive
 // and a miss is handled (not a panic / false hit).
 func TestVizPatternByID_CaseInsensitiveAndMiss(t *testing.T) {


### PR DESCRIPTION
## What this PR ships

Adds two new `ox plan` visualization-catalog patterns and enriches one existing pattern, so any coding agent authoring an HTML plan can produce the kind of self-explanatory visuals a reviewer grasps in seconds. Driven by three real renders a reviewer called out as "very easy to understand" — the catalog only partially taught how to make them.

The catalog (`internal/plan/assets/viz-catalog.md`) is the single cross-agent source surfaced progressively via `ox plan viz [id]` — agents list it cheaply, then pull only the snippet they need. Closing these gaps there (not in a Claude-only skill) keeps the guidance in the binary for every agent.

## The gap

| Reviewer's render | Catalog before | Action |
|---|---|---|
| Sequence diagram with per-stage latency budgets + a `stage · budget · lever` table | `sequence-diagram` taught order only — no budget bands, no paired lever table | **new** `budget-sequence` |
| "Build sequence" lane chart (Foundation / Claim / Scale) with a labeled gate + phase axis | `swimlane-timeline` existed but the example was barer than the render | **enriched** `swimlane-timeline` |
| Cost/telemetry table (`stage · cost · field · reducible?`) with a conclusion callout | `heatmap-table` and `callout` existed only **separately** | **new** `cost-telemetry-table` |

## What's new

- **`budget-sequence`** — a Mermaid `sequenceDiagram` using `Note over` budget bands, **paired with** a `stage · budget · lever` table. The diagram shows the path; the table assigns each slice of the budget and the lever that buys it. The reviewer approves the *budget*, not just the topology.
- **`cost-telemetry-table`** — a `.heat` table (cold-total row flagged red) **paired with** a `.tldr` conclusion callout. The table is the evidence; the callout is the load-bearing read ("every reducible row is reduced by not doing it on the request path").
- **`swimlane-timeline`** (enriched) — three phase lanes, a labeled `◆` gate, a phase-axis tick row, and a caption stating the unit ("relative effort, not calendar"). One additive CSS rule (`.swim .axis` / `.tick`) in `scaffold.css`.

Both new patterns deliberately teach the **pairing** — the half that makes the render land. Neither half alone is reviewable.

```mermaid
flowchart LR
  A["ox plan viz"] --> B["pull pattern snippet"]
  B --> C["budget-sequence: diagram half + lever-table half"]
  B --> D["cost-telemetry-table: heat-table half + callout half"]
  C --> E["ox plan render to open"]
  D --> E
```

## Also in this branch

Commit `a8203f4d` (prior) steers agents to `ox plan render` over generic HTML-plan skills — only `ox plan render` bakes SageOx team context + ledger attribution into the page, so a self-rolled render is a context-blind orphan.

## Test Plan

- **New intent test** `TestVizCatalog_PairedPatternsKeepBothHalves` — asserts each paired pattern keeps **both** halves (`budget-sequence` has a ```mermaid block **and** a lever table; `cost-telemetry-table` has `class="heat"` **and** `class="tldr"`). Failure prevented: a future edit drops one half and the pattern silently regresses to "just a diagram" / "just a table".
- `./ox plan viz` lists both new IDs; `ox plan viz <id>` emits the paired snippets.
- `go test ./internal/plan/` ✅ (parser, mermaid lint, new test)
- `make lint` → **0 issues**

Manual: paste the snippets into a scratch plan, `ox plan render --open`, confirm budget bands, lever table, labeled swimlane axis, and table+callout pairing render in light + dark.

Co-Authored-By: [SageOx](https://github.com/SageOx)
