### PR TITLE
docs(changelog): refresh v0.10.0 draft release to track latest main

### DIFF
--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.0] - 2026-06-10
+## [0.10.0] - 2026-06-11
 
 ### Added
 
 - **Cross-agent HTML plans with a human review loop** — `ox plan` renders a team-context-enriched plan as a self-contained HTML page for *any* coding agent, not just Claude Code, backed by a catalog of reusable visualizations (timelines, collision maps, sequence diagrams). A new review loop (`ox plan review`) serves the plan for inline human feedback, so a reviewer can shape the approach *before* any code is written — and the feedback is captured back to the ledger.
+- **Just-in-time `ox plan enrich` hint while drafting** — during plan mode (Claude Code), `ox` nudges the agent to fold deterministic team context (collisions, prior art, expert routing) into the plan *while it is being drafted*, so enrichment lands in the first draft a human sees rather than being bolted on after.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Refreshes the in-flight **v0.10.0** release so it reflects the latest `origin/main` before publish.

- **CHANGELOG (`cmd/ox/release_notes.md`, symlinked as `CHANGELOG.md`):**
  - Added an `### Added` bullet for the **just-in-time `ox plan enrich` hint while drafting** shipped in #656 — the only user-facing change that landed after the v0.10.0 release-prep commit (#655).
  - Bumped the `[0.10.0]` heading date `2026-06-10` → `2026-06-11` (publish day).
- **GitHub draft release (out-of-band, via `gh`, no code in this PR):**
  - Regenerated the v0.10.0 draft notes body from the updated `[0.10.0]` section so it includes the #656 bullet.
  - Re-confirmed `target_commitish: main` — the draft has no tag cut yet, so publishing auto-tags the current tip of `main`. The release already tracks latest `origin/main`; no SHA was pinned.

**Excluded by design:** #657 (docs/test refactor — not changelog-worthy) and the README "Tools we love" section from #656 (marketing, not a CLI change).

## Test Plan

- `gh api repos/sageox/ox/releases` → draft v0.10.0 shows `target_commitish: main`, `draft: true`.
- `gh release view v0.10.0` body contains the new "Just-in-time `ox plan enrich` hint" bullet.
- Local `CHANGELOG.md` `[0.10.0]` matches the published draft body.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — N/A, docs-only (release notes text)
- [x] CHANGELOG entry added (if user-facing) — this PR *is* the changelog entry
- [x] Breaking change documented — N/A, no behavior change
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A, touches only `cmd/ox/release_notes.md`; no auth/mcp/session/upgrade/`go.sum` paths

</details>

Co-authored-by: SageOx <ox@sageox.ai>
