### PR TITLE
feat(import): bring Knowledge Bubbles to import parity via --kb

### DIFF
--- a/.claude/commands/ox-plan.md
+++ b/.claude/commands/ox-plan.md
@@ -1,0 +1,259 @@
+<!-- ox-hash: eefb7144a2c4 ver: 0.9.1 -->
+<!-- Keep behavioral "when to render" guidance lean — that belongs in the
+     `ox plan` JSON output (signals.material, guidance) and in the
+     <plan-enrichment-guidance> block from `ox agent prime`, not duplicated here.
+     What legitimately lives in THIS skill is the RENDERING SPEC: how to draw the
+     enriched HTML plan (forked from html-plan) plus the badge-native layout. That
+     is substantive skill content, not command guidance. Skills are agent-specific
+     wrappers; ox serves all agents — keep ox-CLI behavior in the CLI. -->
+Render a SageOx team-enriched implementation plan as a beautiful, self-contained HTML page for human review. Forks the html-plan quality bar (Mermaid diagrams, light/dark toggle, fit-to-column diagrams, CSS swimlane timelines, SageOx palette, scroll-spy nav) and adds badge-native layout: a per-section badge rail, an alignment-summary strip, and source links that resolve to the cited ledger artifact / ADR / open PR.
+
+Use when the user asks to "render the plan", "make an HTML plan", "show the enriched plan", "visualize this plan with team context", runs `/ox-plan`, or when `ox plan` reports material signals and the user confirms a render. **Whether to render at all is decided by the `ox plan` JSON (`signals.material`, `guidance`) + the user's confirmation / `plan.html` config — not by this skill.** Do not nag on trivial plans; honor the command's signal.
+
+---
+
+## Orchestration (what this skill does)
+
+```mermaid
+flowchart TB
+  RUN["Run ox plan --json on the active plan"] --> DET["ox returns DETERMINISTIC badges + context bundle (0 LLM tokens)"]
+  DET --> READ["Agent reads the context bundle: murmurs, sessions, decisions, ADRs, expert artifacts"]
+  READ --> JUDGE["Agent authors JUDGMENT badges, CITED-ONLY (aligns / conflicts / expert-perspective)"]
+  JUDGE --> MERGE["Merge: ox --json annotations + agent judgment badges into one annotations.json"]
+  MERGE --> GATE{"Render confirmed? (user asked OR plan.html recommend + confirm)"}
+  GATE -->|"no"| SAVEMD["ox plan save with merged annotations, no html"]
+  GATE -->|"yes"| HTML["Render ONE self-contained HTML inheriting html-plan quality + badge-native layout"]
+  HTML --> SAVEHTML["ox plan save with merged annotations + html"]
+```
+
+1. **Get the deterministic signals + context bundle.** Run:
+
+   ```bash
+   ox plan --json --file <plan-file>   # or pipe the plan on stdin
+   ```
+
+   This makes **no LLM or network call**. It returns a `Result` JSON:
+   - `annotations[]` — deterministic, ox-computed badges: `collision`, `prior-art`, `expert-routing`. Each carries `{section, kind:"deterministic", type, why, source_url, expert, files}`. These are **factual** — render them as-is, do not second-guess them.
+   - `context[]` — the pre-retrieved bundle the agent reasons over: `{kind: murmur|session|decision|adr|commit|discussion, title, ref, snippet, score, author, when}`.
+   - `signals` — `{collisions, prior_art, expert_routes, material}`. `material` is ox's call on whether a render is worth recommending.
+
+2. **Author the JUDGMENT badges (the agent's job — ox does NO inference).** Read the `context[]` bundle and produce judgment annotations:
+   - `aligns` / `conflicts` — does the plan agree or clash with a cited ADR, decision, or convention?
+   - `expert-perspective` — the synthesized stance of the area expert.
+
+   **CITED-ONLY is non-negotiable.** Every judgment badge MUST point at a real artifact from the bundle (`ref` / `source_url`): a specific ADR, decision doc, session, commit, or discussion. Rules:
+   - Never invent an opinion, a quote, or a conflict. Precision over recall.
+   - When the evidence is **thin or ambiguous, degrade to a routing nudge** — `expert-perspective` becomes "consult `<name>`" (naming the expert from `annotations[].expert`), NOT a fabricated stance. Putting words in a teammate's mouth is the one failure mode that destroys trust.
+   - When unsure whether a conflict is real, downgrade to "Novel — no prior decision found," not a false `conflicts`.
+   - Set `kind:"judgment"` on every badge you author so the renderer can style it distinctly from ox's deterministic ones.
+
+   **NEVER paste the `context[]` bundle verbatim into the HTML.** The bundle is your *reasoning input*, not render output. Dumping the raw items as a flat "session / discussion" card list is the failure mode this spec exists to prevent — it surfaces mid-sentence snippet fragments, low-relevance chatter, and un-cited noise as if it were a finding. The bundle items become HTML *only* after you reason over them into a cited judgment badge attached to a specific plan section. A bundle item you can't turn into a section-anchored, cited badge does not appear in the render at all. Worked example:
+
+   > Bundle item → `{kind:"adr", title:"ADR-018 codedb perf budget", ref:"docs/adr/018...", snippet:"...512MB resident ceiling..."}`
+   > Plan section 3 proposes an in-memory index. →
+   > **Authored badge** → `{section:"3. Index", kind:"judgment", type:"conflicts", why:"In-memory index may breach the 512MB ceiling set in ADR-018", source_url:"docs/adr/018...", ...}`
+   >
+   > If the same ADR were only tangentially related: degrade to `expert-perspective` → "consult `<name>`", NOT a card pasting the raw snippet.
+
+3. **Render ONE self-contained HTML file** meeting the full html-plan quality bar below PLUS the badge-native additions.
+
+4. **Persist the full plan with `ox plan save`.** Bare `ox plan` only auto-saves ox's *deterministic* badges (it cannot see your judgment badges). To persist the complete plan — your merged badges plus the render — call:
+
+   ```bash
+   ox plan save --plan <plan-file> --annotations <merged.json> [--html <render.html>]
+   ```
+
+   - `--annotations <merged.json>` is the **merged** annotations: take the `ox plan --json` Result and **append your judgment badges** to its `annotations[]` array (keep `signals`, `context`, and the deterministic badges intact). That merged file is what gets stored as `annotations.json`.
+   - `--html` is optional: pass it only when you rendered HTML this run. `ox plan save` applies the size-gated plain-git-vs-LFS rule — it never renders.
+   - `ox plan save` always persists (it is an explicit save), reuses the `data/plans/YYYY-MM-DD-<slug>/` path, and prints where it saved.
+
+5. **Honor the storage / UX rules.** Render only when appropriate (the user asked, or confirmed per `plan.html`). **Never render HTML just to populate the ledger.** The `plan.html` you render here is the canonical, committed artifact `ox plan save` stores; it is preserved exactly (it's LLM-authored and non-deterministic — re-rendering yields different output).
+
+---
+
+## Output location
+
+- Inside a repo/workspace: write to `.context/<slug>-plan.html` (create `.context/` if missing — it is the gitignored collaboration dir), then pass it as `--html` to `ox plan save`, which promotes it into the ledger at `data/plans/YYYY-MM-DD-<slug>/plan.html`.
+- No workspace: write to `~/.claude/plans/<slug>-plan.html`.
+- After writing, open the file so the reviewer sees it immediately, then tell the user the exact path.
+
+---
+
+## Badge-native layout (the additions over html-plan)
+
+These are what make this an *enriched* plan, not just a pretty one. The human must instantly see (a) which signals fired, (b) which are factual vs. judged, and (c) where each claim comes from.
+
+**1. Alignment-summary strip (top of page, above the TL;DR).** A compact horizontal strip of counts pulled straight from `signals` + your authored judgment badges:
+
+> **`N aligns` · `M conflicts` · `K collisions` · `E expert routes`**
+
+Use the SageOx semantic colors: sage for aligns, red for conflicts, amber for collisions/active-work, copper for expert routes. Each count is a chip; clicking/anchoring it can jump to the first section carrying that badge. This is the "should I even keep reading" glance.
+
+**2. Per-section badge rail.** Every plan section renders its badges in a right-aligned rail (or a row directly under the H2). A badge shows: an icon/dot, the type label, a **provenance chip** (see below), and a **source link** when `source_url`/`ref` is present. Collapse multiple badges of the same type into a count chip that expands.
+
+**2a. Per-kind provenance chip + (i) popover.** Every badge carries a small chip naming WHERE its evidence came from, keyed off the bundle item's `kind`, so the reviewer can tell team convention from ledger history from live work at a glance:
+
+| `kind` | Chip label | Semantic color |
+|---|---|---|
+| `adr` | `ADR` | copper |
+| `decision` | `decision` | copper |
+| `discussion` | `team context` | sage |
+| `session` | `ledger · session` | teal |
+| `commit` | `commit` | teal |
+| `murmur` | `active work` | amber |
+
+Each chip has an **(i) affordance** that, on hover OR keyboard focus, opens a small popover showing: the source kind, the author and `when` (if present), the **cleaned** snippet trimmed to one readable clause (never a mid-sentence fragment — if the snippet is clipped, summarize it instead of pasting it), and the resolved link. Requirements:
+- **Pure CSS + a tiny vanilla-JS toggle — no external JS, must work from `file://`.** Hover via `:hover`/`:focus-within`; also support click-to-pin for touch/keyboard. The trigger is a real `<button>` (focusable, `aria-describedby` the popover) — not a bare `<span>` — so it is keyboard- and screen-reader-accessible.
+- The popover inherits the light/dark CSS variables (legible in both themes) and never overflows the viewport (flip/clamp on the right edge).
+- Group/color the chips by the palette above so the alignment strip, rail, and popovers tell one consistent provenance story.
+
+**3. Deterministic vs. judgment — visually distinct.** The human must always know which badges ox *computed* (factual) and which the agent *authored* (cited judgment). Make the treatment unmistakable:
+
+| Kind | Treatment | Why |
+|---|---|---|
+| **Deterministic** (`kind:"deterministic"`) | Solid fill, a small "ox" / circuit glyph, no hedging copy | ox computed it locally from git/codedb/murmurs — it is a fact |
+| **Judgment** (`kind:"judgment"`) | Outlined (not filled), a "reasoned" glyph, always shows its citation link, hedged verb ("appears to conflict with…") | the agent inferred it — the human should trust-but-verify via the citation |
+
+Put a tiny legend near the alignment strip ("● ox-computed · ○ agent-reasoned, cited") so the encoding is self-explanatory.
+
+**4. Source links resolve to the cited artifact.** Every badge with a citation links to the real thing:
+- **Open PR / collision** → the PR URL from `source_url`.
+- **Prior art / session** → a session reference. Where there's no web URL, surface the `ox session view <name>` command as the resolution and link the ledger path.
+- **ADR / decision** → the ADR/decision doc path or URL from `ref`/`source_url`.
+- **Expert routing** → the expert's named artifact (their relevant session/commit), and the expert's name from `annotations[].expert`.
+
+A judgment badge with no resolvable citation is a bug — degrade it to "consult `<name>`" instead.
+
+**5. SageOx insight overlays — the OX marker (NOT a prose blob).** SageOx insight must NEVER render as a standalone wall of synthesized prose. The anti-pattern, verbatim from a real bad render — **do not produce anything resembling this**:
+
+> ⛒ **SageOx team context (from ox plan)** — expert perspective
+> Foundation owner / prior art: scribe-jbf00 (gate epic), scribe-xfy17 (console-routing trap), scribe-ljzhn (rotted SDL behave sim — do NOT use for BDD). Session 2026-05-15… → informs the twin golden-trace gate. Collisions: platformio.ini + debug_server_scribe.cpp contended (rsnodgrass ryan/flash-dev); the P3-fw firmware edits land there — rebase + re-verify /health fields. Experts: Galex Yen owns twin-sageox-api/admin.go…
+
+That blob fails every respect-the-reader test: lore before action, three distinct signals comma-spliced into one badge, bare IDs that resolve to nothing, no severity, no "so what." Replace it with **anchored OX markers**:
+
+- **The marker.** Each SageOx signal renders as a small, recognizable **SageOx glyph** sitting in the margin gutter (or inline) right next to the plan element it concerns — a heading, a file ref, a step. It is the visual tell that "SageOx has something to say *here*," the way a code-review comment dot marks a line.
+  - **Canonical mark = the SageOx avatar** (`https://avatars.githubusercontent.com/u/224450799?s=200&v=4`). **Base64-inline it as a `data:image/png;base64,…` URI at render time** (fetch once during rendering, embed the bytes) — the page is self-contained and must render from `file://` with **no runtime network**, so a live remote `<img src>` is banned. Keep it small (a ~28px avatar at `s=64` is plenty; don't inline a giant blob).
+  - **Offline fallback:** if the avatar can't be fetched at render time, draw an **inline-SVG `ox` monogram** (rounded square, sage/copper, themeable via `currentColor`) instead. Never block the render on the network.
+  - The marker is a real `<button aria-label="SageOx insight">` so it is focusable and screen-reader-named, with a faint ring/badge so it reads as interactive.
+- **Rollover reveals the insight.** Hover OR keyboard-focus OR click-to-pin opens the same popover mechanics as 2a. One marker = one signal = one popover. Inside, **action first**:
+  - **Headline (one line, imperative when there's an action):** e.g. *"Rebase before editing `platformio.ini` — contended on PR ryan/flash-dev."* Not *"Collisions: platformio.ini + … contended."*
+  - **Severity color** by signal: collision/active-work → amber; conflict or an explicit "do NOT use" → red; prior-art/session → teal; expert route → copper; alignment → sage.
+  - **Every reference resolves.** A bare `scribe-jbf00` is noise — render it as a link (to the PR/issue/ADR `source_url`) or as the runnable `ox session view <ref>` for a session. An ID with no resolution is degraded to "consult `<name>`", never shown raw.
+  - **Provenance chip + author/when** from 2a.
+  - **Synthesize the "so what," drop the lore.** State what the signal means *for this plan* and what to do; don't recite ownership trivia. Expand or link domain abbreviations (BDD, SDL, `X-Device-ID`) — a busy reviewer should not have to decode jargon.
+- **The only standalone SageOx UI is the alignment strip (item 1) plus an optional collapsed index** ("SageOx flagged: 1 collision · 3 prior-art · 2 experts") whose entries are anchor links that jump/scroll to the corresponding OX marker. No paragraph, ever.
+
+One signal that genuinely spans the whole plan (not a specific element) anchors its OX marker on the plan's H1 / TL;DR — still a marker with a popover, still action-first, still not a blob.
+
+---
+
+## The reader's ten minutes — audience & time contract (governs everything below)
+
+You are writing for a **senior / principal engineer or engineering manager whose time is worth ~$10,000/hour.** They will spend **no more than ten minutes** on this page, and they must walk away with **everything they need to decide** in those ten minutes. Design every pixel against that budget:
+
+- **Get to the point. Lead with the conclusion**, the decision needed, and the biggest risk — not the backstory. The TL;DR and alignment strip must answer "do I approve, and what do I watch" before any scrolling.
+- **The page stands on its own.** Never reference a symbol, file, ID, or PR without setting enough context to understand *why it matters* — a reader who has not opened the codebase still follows the argument. A bare `scribe-jbf00` or `admin.go` with no framing is wasted ink.
+- **No minutiae.** Do not walk through single lines of code, signatures, or implementation trivia the reader doesn't need to make the call. Describe **how the system behaves and why the change matters**, not how each function is wired. Altitude over detail; zoom in only where a risk lives.
+- **Leverage HTML for compression, not decoration.** A diagram, a colored verdict cell, a severity-coded badge, or an OX-marker popover should *replace* paragraphs — each visual must let the reader understand something faster than prose would. Visuals that don't reduce reading time are noise.
+- **Concise is a feature, verbose is a bug.** Every sentence, badge, and row earns its place or is cut. Density with structure (scannable) beats completeness without it. If it can't be skimmed in ten minutes, it has failed regardless of how correct it is.
+
+This contract outranks any individual rule below: when a "nice to have" visual or a complete-but-long explanation would blow the ten-minute budget, cut it.
+
+## html-plan quality bar (inherited — all non-negotiable)
+
+**Self-contained.** One `.html` file. No build step, no local assets. Libraries only via CDN (Mermaid from jsdelivr). Must render from `file://`.
+
+**Diagrams do the heavy lifting.** Prefer a diagram over a paragraph wherever a relationship, flow, state machine, sequence, or before/after exists. Use **Mermaid** (`flowchart`, `sequenceDiagram`, `stateDiagram-v2`, `gantt` as fits). Every plan gets at least one "the shape in one picture" diagram near the top. Apply the **GitHub-strict Mermaid rules from CLAUDE.md**: double-quote every node label containing anything beyond `[A-Za-z0-9 ]`; never use arrow-shaped substrings (`->`, `=>`, `<->`) inside labels even when quoted — substitute `to`, `→`, or a comma; never use reserved-ish IDs (`PR`, `URL`, `IO`, `IS`, `AS`, `END` — rename to `DPR`, `DURL`, etc.); quote path-shaped labels (`/`, `*`); use `<br/>` not `\n` for line breaks. These make diagrams render everywhere, not just locally.
+
+**Size every diagram for the human eye — fit the viewport in BOTH axes.** A diagram that overflows the screen is as useless as one shrunk to a postage stamp. Target: the whole diagram comfortably visible at a readable node size without scrolling. Put in the page CSS:
+- `.mermaid svg { max-width:100% !important; max-height:78vh !important; height:auto !important; width:auto !important }` — fit the content column, cap height. **Do NOT add a fixed-px width cap** (e.g. `min(100%,640px)`) — it crushes legitimately wide diagrams like multi-actor sequence diagrams into unreadable thumbnails.
+- Tighten Mermaid spacing: `flowchart:{ nodeSpacing:34, rankSpacing:34, padding:8, useMaxWidth:true }`, `sequence:{ useMaxWidth:true }`, `state:{ useMaxWidth:true }`, ~13px base `fontSize`.
+- A **sequence diagram** is as wide as its actor count: use **≤ 4–5 participants** and **short actor aliases** (`I as I2S init`, not `i2s_full_duplex_init`). If still too wide, split the flow into two diagrams rather than shrink it illegibly.
+
+Shape rules:
+- Prefer **vertical growth** — `flowchart TB` for long chains so they extend down the page (which scrolls) instead of off the right edge.
+- For a row of **disconnected nodes** (a list, a before/after group), force them into a narrow column by chaining with **invisible links** (`A1 ~~~ A2 ~~~ A3`) inside a `direction TB` subgraph.
+- Keep any single rank to **≤ ~4 nodes**; shorten labels; use `<br/>` to wrap long edge labels.
+- If a diagram can't fit ~72vh at a readable size, it's doing too much — **split into stacked sub-diagrams**, each of which fits.
+
+**Timing & sequencing — make time legible.** Most plans have a temporal spine; surface it. Include at least one timing visual whenever the plan has phases, real-time deadlines, async/concurrent work, a rollout, or a latency budget:
+
+| The plan involves… | Use | Notes |
+|---|---|---|
+| Implementation phases / rollout / relative-effort sequencing | **Hand-built CSS swimlane timeline** | The robust default. Lanes = workstreams; absolutely-positioned bars by percent; a milestone/gate marker. |
+| A *calendar-accurate* schedule (real dates) | **Mermaid `gantt`** with `dateFormat YYYY-MM-DD` + `axisFormat %b %d` | Only when real dates exist. |
+| A latency budget on a request/operation path | **Annotated `sequenceDiagram`** | Put ms budgets in `Note over` blocks. |
+| Parallel work across cores/tasks/agents | **CSS swimlane** (one lane per core/task) | Reveals contention & idle time. |
+| State with time-bounded transitions (timeouts, debounce, retry/backoff) | **`stateDiagram-v2`** with durations on edges | Label transitions with the timeout. |
+
+**Do NOT use Mermaid `gantt` with `dateFormat X` (numeric)** — it renders a meaningless `0 0 1 1 2…` axis. For relative-effort plans, hand-build a CSS swimlane: a per-lane row (`grid-template-columns: 160px 1fr`), a relative track with faint vertical unit gridlines, and absolutely-positioned bars (`left:%` / `width:%`) colored by workstream, with a diamond marker for any gate.
+
+**Pick the diagram by the QUESTION the reader is asking — not by habit.** Reach for the richer diagram types when (and only when) the plan genuinely has that structure. A flat list is a list; do not flowchart it. Never draw two diagrams that show the same thing.
+
+| The reader is asking… | Diagram type | When it earns its place |
+|---|---|---|
+| "In what **order** does this call out — and how many round-trips?" | **`sequenceDiagram`** | A request/call path crosses components, services, or async boundaries. Shows ordering + latency a flowchart can't. ≤ 4–5 participants. |
+| "**What depends on / connects to** what?" (topology, not order) | **interaction / dependency graph** (`flowchart LR`, C4-ish) | Components, actors, modules and their edges — to reveal coupling, blast radius, a contended boundary. |
+| "What are the **steps and branches**?" | **flow diagram** (`flowchart TB` + decision gates) | A pipeline or algorithm with conditionals/gates. The default "shape in one picture" hero. |
+| "What **states** exist and what **transitions** between them?" | **`stateDiagram-v2`** (enriched) | A lifecycle, connection/session model, retry/backoff, or anything with modes. Label edges with the trigger; push the guard/timeout/side-effect to hover. |
+| "**When**, in what sequence, how long?" | **timeline / CSS swimlane** (see table above) | Phases, rollout, parallel work, latency budget. |
+
+One **hero diagram near the top** captures the whole shape. Add a second diagram only where a specific section has structure the hero can't carry. If a diagram needs more than ~7 nodes / ~5 participants to be honest, it's two diagrams.
+
+**Progressive disclosure — rich underneath, calm on top (lean HARD into HTML here).** The single biggest lever for human understanding is putting *little* on the screen while keeping *all* the richness one hover away. The on-screen diagram is the **skeleton**; the detail lives in reveals:
+- **Mermaid node/edge interactions.** Use `click <NodeId> callback "<short tooltip>"` (requires `securityLevel:'loose'` at init) to attach a hover/click handler that opens the **same popover component as the OX markers / 2a chips**. Keep the node label terse ("auth check"); put the payload, the file/symbol it maps to, the cost, and the rationale in the popover — never on the diagram face.
+- **Sequence diagrams:** terse message labels on the line; the contract/payload/error-path detail surfaces on hover of that message (or a `Note` styled collapsed-by-default, expand on click).
+- **State machines:** the edge shows only its trigger; hovering the edge or state reveals guard, side effects, timeout/backoff, and the code path that implements it.
+- **Layered drill-down.** Start at the subsystem altitude; clicking a node expands its internal subgraph (toggle a second `.mermaid` block / swap source + `mermaid.run`), so the reader drills only where they care. One topic, many depths — the ten-minute reader stays at the top layer; the skeptic drills one node.
+- All of it **pure CSS + vanilla JS, keyboard-focusable, `file://`-safe, no network** — same constraints as every other interaction. Tie it back to the time contract: the diagram answers "how does it behave" at a glance; deeper time is spent *only* on the node the reader chooses to interrogate.
+
+**User-facing mockups — show how the feature is exposed.** If the plan changes anything the user sees or hears, include a visual of the resulting UI state honoring the project's design system — don't describe it in prose. For a net-new or multi-state flow, recommend the `/design-mockup` skill rather than hand-rolling many states. Always state which design-system rules the mockup honors. Annotate behavior in user-facing language, never with implementation detail (write "a subtle chime plays", not a source filename).
+
+**Typography & layout.**
+- Font stack (Google Fonts): **Space Grotesk** for display headings (h1/h2), **Inter** for body, **JetBrains Mono** for code, file refs, eyebrows, badges, and small labels. No serif headings.
+- 15–16px body; line-height ~1.6; max content width ~1000–1040px, centered.
+- Confident heading scale: h1 ~42px / 700 / tracking -0.035em; h2 ~24px / 600 / -0.02em with a hairline trailing rule; h3 ~15px uppercase, copper, +0.06em. Mono eyebrow above h1.
+- **SageOx palette** (dark default): bg `#0f1416`, panel `#151b1e`/`#1b2327`, hairline `#2a3439`, ink `#e6edf0`, dim `#9fb0b6`, sage `#7a8f78` (primary/good/aligns), copper `#e0a56a` (one accent / expert routes), amber `#f59e0b` (warning / collisions), red `#ef4444` (blocker / conflicts), teal `#14b8a6` (file refs / capability). Max ~1 copper accent per section. Map badge colors to these semantics so the alignment strip and rail are palette-faithful.
+- Generous whitespace. Cards (`border:1px hairline; radius:10px`) for parallel items. Multi-column grids collapse to one column under ~760px.
+
+**Light & dark mode.** Ship both. Default to `prefers-color-scheme`; add a small fixed sun/moon toggle persisting to `localStorage`. Drive everything off CSS custom properties (a dark `:root` plus an `html[data-theme="light"]` override; route gradient endpoints through `--grad-*` variables). **Mermaid's theme is fixed at init**, so the toggle MUST re-render diagrams: capture each `.mermaid` source on load, and on theme change reset `data-processed`, restore source, `mermaid.initialize` with the matching `themeVariables` (a dark set + a light set), and `mermaid.run({nodes})`. Inline device mockups stay dark in both modes — only the surrounding panel/page flips. **Badges must stay legible in both themes** — define their fills/outlines via the same CSS variables.
+
+**Navigation (when the plan is long).** For plans with **5+ sections**, add a **sticky left-rail TOC** with scroll-spy — top-level sections only, mono small type, muted until hover/active, a 2px left border that turns sage on the active entry. CSS grid shell (`~190px` rail + `minmax(0,1fr)` content); **collapse the rail below ~1000px** (`display:none`). Drive the active state with one `IntersectionObserver` over `h2[id]` (rootMargin roughly `-15% 0 -70% 0`). Number sections and mirror those numbers in the rail. For short plans (≤4 sections) skip the rail.
+
+- Open with a `TL;DR` callout (one tight paragraph: problem, approach, cost, biggest risk) — placed just under the alignment-summary strip.
+- Numbered blocker/finding cards up top.
+- Steps as a clean numbered list with file:line refs styled distinctly (teal, small).
+- Tables for impact/verification matrices. Color verdict cells (good/warn/bad).
+- A `Risks` section with severity-coded left borders (red = load-bearing unknown, amber = watch).
+- Footer: where the canonical plan file lives (`data/plans/<slug>/`) + key invariants.
+
+**SageOx attribution (subtle, earned, conditional).** When the plan actually carries SageOx enrichment — any deterministic badges (collision/prior-art/expert-routing) or context-bundle items were present — give SageOx quiet credit for the team context it infused: a single restrained footer line such as *"Team context enriched by SageOx"*, plus the existing `● ox-computed` marker that already tags deterministic badges as SageOx-sourced. Rules:
+- **Only when it legitimately helped.** If `ox plan --json` returned no badges and an empty `context[]` (an un-enriched plan), add NO SageOx credit — there is nothing to credit.
+- **Never overclaim.** SageOx provided context and signals; the human and the agent wrote the plan. Credit the enrichment, not the authorship. No banners, no marketing copy, no "moat"/"powered by" language — one calm line in the footer.
+- Judgment badges drawn from the SageOx context bundle may carry a small "via SageOx context" provenance note where it reads naturally, but don't repeat it on every badge.
+- **Enforced, not just requested.** `ox plan save` lints the render for this contract (footer credit + an anchored OX marker when the plan carried enrichment; no overclaim on un-enriched plans; no live-remote avatar) and warns on any miss. Re-check anytime with `ox plan lint <slug>` (add `--strict` to fail on findings). A clean lint is part of "done".
+
+**Concise, high-signal prose.** No filler. Every sentence earns its place. Code identifiers in `<code>`. Don't restate what a diagram or badge already shows.
+
+---
+
+## Process
+
+1. Run `ox plan --json` to get deterministic badges + the context bundle (0 tokens, local).
+2. Read the `context[]` bundle; author judgment badges **cited-only**, degrading to "consult `<name>`" when evidence is thin.
+3. Extract from the plan: problem/why, blockers/findings, architecture/flow, concrete steps (with file refs), impact numbers, verification, risks.
+4. Choose the diagrams that compress the most (before/after, sequence, decision gates, state machine, swimlane timeline).
+5. Write one polished self-contained HTML file meeting every html-plan non-negotiable PLUS the alignment strip, per-section badge rail, deterministic-vs-judgment styling, OX-marker overlays, and resolved source links.
+6. **Architect review pass (required, before saving).** Spawn an `architect` (or general-purpose) subagent and have it review the rendered HTML *as the $10k/hour principal reader*. It checks, and you then fix, against the audience contract:
+   - Can the reader get **everything they need to decide in ten minutes**? Is the conclusion/decision/biggest-risk up top, before any scroll?
+   - Is it **direct, concise, to the point** — or padded with backstory, minutiae, or single-line code walk-throughs that don't change the decision?
+   - Does it **stand on its own** — is every file/ID/symbol/PR given enough context to matter, with no bare references?
+   - Do the visuals **compress** understanding (replace prose) or just decorate?
+   - Are SageOx insights **anchored OX markers with action-first popovers**, never a prose blob?
+   Revise until the architect signs off that a busy principal would get full value in ten minutes. Cut anything that fails the contract.
+7. Merge your judgment badges into the `ox plan --json` annotations and persist with `ox plan save --plan ... --annotations <merged.json> --html <render.html>`.
+8. Open the HTML and report the path.
+
+The goal: a $10k/hour principal reader skims the alignment strip + TL;DR + hero diagram and within ten minutes knows whether the plan aligns with team direction and whether to approve — the decision and biggest risk are up top, every badge and OX marker says where its claim comes from and what to do about it, ox-computed facts are visually separate from agent-reasoned judgment, and nothing on the page wastes the reader's time.
+
+$ox plan --json

--- a/.claude/commands/ox-plan.md
+++ b/.claude/commands/ox-plan.md
@@ -161,7 +161,7 @@ This contract outranks any individual rule below: when a "nice to have" visual o
 
 ## html-plan quality bar (inherited — all non-negotiable)
 
-**Self-contained.** One `.html` file. No build step, no local assets. Libraries only via CDN (Mermaid from jsdelivr). Must render from `file://`.
+**Self-contained.** One `.html` file, no build step, no local asset files. The page opens from `file://`, and **all interactivity — popovers, OX markers, the SageOx avatar, theme toggle — is inlined and works fully offline**. The single permitted external dependency is the Mermaid library, loaded from the jsDelivr CDN; diagrams therefore need network to render, while everything else degrades gracefully without it. Do not add any other CDN or remote asset (e.g. a live-remote `<img src>` avatar is banned — inline it).
 
 **Diagrams do the heavy lifting.** Prefer a diagram over a paragraph wherever a relationship, flow, state machine, sequence, or before/after exists. Use **Mermaid** (`flowchart`, `sequenceDiagram`, `stateDiagram-v2`, `gantt` as fits). Every plan gets at least one "the shape in one picture" diagram near the top. Apply the **GitHub-strict Mermaid rules from CLAUDE.md**: double-quote every node label containing anything beyond `[A-Za-z0-9 ]`; never use arrow-shaped substrings (`->`, `=>`, `<->`) inside labels even when quoted — substitute `to`, `→`, or a comma; never use reserved-ish IDs (`PR`, `URL`, `IO`, `IS`, `AS`, `END` — rename to `DPR`, `DURL`, etc.); quote path-shaped labels (`/`, `*`); use `<br/>` not `\n` for line breaks. These make diagrams render everywhere, not just locally.
 
@@ -225,13 +225,13 @@ One **hero diagram near the top** captures the whole shape. Add a second diagram
 - Steps as a clean numbered list with file:line refs styled distinctly (teal, small).
 - Tables for impact/verification matrices. Color verdict cells (good/warn/bad).
 - A `Risks` section with severity-coded left borders (red = load-bearing unknown, amber = watch).
-- Footer: where the canonical plan file lives (`data/plans/<slug>/`) + key invariants.
+- Footer: where the canonical plan file lives (`data/plans/YYYY-MM-DD-<slug>/`) + key invariants.
 
 **SageOx attribution (subtle, earned, conditional).** When the plan actually carries SageOx enrichment — any deterministic badges (collision/prior-art/expert-routing) or context-bundle items were present — give SageOx quiet credit for the team context it infused: a single restrained footer line such as *"Team context enriched by SageOx"*, plus the existing `● ox-computed` marker that already tags deterministic badges as SageOx-sourced. Rules:
 - **Only when it legitimately helped.** If `ox plan --json` returned no badges and an empty `context[]` (an un-enriched plan), add NO SageOx credit — there is nothing to credit.
 - **Never overclaim.** SageOx provided context and signals; the human and the agent wrote the plan. Credit the enrichment, not the authorship. No banners, no marketing copy, no "moat"/"powered by" language — one calm line in the footer.
 - Judgment badges drawn from the SageOx context bundle may carry a small "via SageOx context" provenance note where it reads naturally, but don't repeat it on every badge.
-- **Enforced, not just requested.** `ox plan save` lints the render for this contract (footer credit + an anchored OX marker when the plan carried enrichment; no overclaim on un-enriched plans; no live-remote avatar) and warns on any miss. Re-check anytime with `ox plan lint <slug>` (add `--strict` to fail on findings). A clean lint is part of "done".
+- **Enforced, not just requested.** `ox plan save` lints the render for this contract (footer credit when the plan carried enrichment — any badges or context items; an anchored OX marker only when it carried *deterministic* badges, since markers anchor those signals; no overclaim on un-enriched plans; no live-remote avatar) and warns on any miss. Re-check anytime with `ox plan lint <slug>` (add `--strict` to fail on findings). A clean lint is part of "done".
 
 **Concise, high-signal prose.** No filler. Every sentence earns its place. Code identifiers in `<code>`. Don't restate what a diagram or badge already shows.
 

--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -31,6 +31,7 @@ var importFlags struct {
 	date   string
 	force  bool
 	team   string
+	kb     string
 	title  string
 	status string
 	watch  bool
@@ -39,24 +40,29 @@ var importFlags struct {
 
 var importCmd = &cobra.Command{
 	Use:   "import <file|url>",
-	Short: "Import a document or video URL into team context",
-	Long: `Import a document or video URL into team context for onboarding and knowledge sharing.
+	Short: "Import a document, media file, or video URL into team context or a Knowledge Bubble",
+	Long: `Import a document, media file, or video URL for onboarding and knowledge sharing.
 
-File imports are stored with LFS-backed content and git-tracked metadata.
-URL imports submit a video for cloud processing (transcription, summarization).
+Team imports (default) are stored with LFS-backed content and git-tracked
+metadata in the team context repo — including media files (mp4, mov, webm,
+m4a, mp3, wav, …), which are transcribed and summarized server-side after
+import. With --kb, media files and video URLs are submitted to the cloud
+recording pipeline for the Knowledge Bubble (transcription, summarization).
 Supports Loom, Cap, and direct video URLs.
 
   ox import report.pdf --text extracted.md
   ox import notes.md --date 2026-01-15
+  ox import ./standup.mp4                       # media file into the team (git-tracked, transcribed)
+  ox import ./recording.mp4 --kb my-bubble      # media file into a Knowledge Bubble
   ox import https://www.loom.com/share/abc123 --title "Architecture Review"
   ox import https://cap.link/abc123 --title "Sprint Retro"
-  ox import https://example.com/meeting.mp4 --title "Team Standup"
   ox import --list                              # find import IDs
   ox import --status rec_01234567               # check processing once
   ox import --status rec_01234567 --watch       # wait until complete
 
-The team is auto-discovered from the current repo. Use --team to override
-or when working outside an initialized repo.
+The team is auto-discovered from the current repo. Use --team to override,
+or --kb <slug|kb_id> to target a Knowledge Bubble instead (the two are
+mutually exclusive). Document imports currently support --team only.
 
 For behavioral rules (vs. documents), see 'ox guide team-rules' — rules
 go in agents/rules/, not through ox import.`,
@@ -70,6 +76,8 @@ func init() {
 	importCmd.Flags().StringVar(&importFlags.date, "date", "", "date for filing (YYYY-MM-DD, default: auto-detect from metadata)")
 	importCmd.Flags().BoolVar(&importFlags.force, "force", false, "re-import even if content hash already exists")
 	importCmd.Flags().StringVar(&importFlags.team, "team", "", "team ID (or slug/name when inside a repo)")
+	importCmd.Flags().StringVar(&importFlags.kb, "kb", "", "Knowledge Bubble (slug or kb_id) to import into")
+	importCmd.MarkFlagsMutuallyExclusive("team", "kb")
 	importCmd.Flags().StringVar(&importFlags.title, "title", "", "display title for URL imports")
 	importCmd.Flags().StringVar(&importFlags.status, "status", "", "check processing status of a URL import (use --list to find IDs)")
 	importCmd.Flags().BoolVar(&importFlags.watch, "watch", false, "poll --status until processing completes or fails")
@@ -165,38 +173,29 @@ func runImport(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// dispatch: KB media files → cloud recording-file import. KB-only on
+	// purpose: a Knowledge Bubble has no /context/import route, so the
+	// recordings/import endpoint is its only ingestion path. Team media files
+	// deliberately fall through to the document-LFS path below — the backend's
+	// team-context-doc-import workflow already routes video/*+audio/* to
+	// transcription, and git-LFS keeps the file tracked in the team repo.
+	if importFlags.kb != "" {
+		if isMediaImportFile(srcPath) {
+			return runImportRecordingFile(cmd, srcPath, importDate, jsonOutput)
+		}
+		// KB doc import goes via MCP SaveToBubble (see docs/specs/kb-import-parity.md)
+		return fmt.Errorf("--kb supports media files and video URLs only — document import into a Knowledge Bubble is not yet available (use --team)")
+	}
+
 	// projectRoot is optional — import works outside a repo when --team is given
 	projectRoot, _ := findProjectRoot()
 
 	// resolve endpoint once, used consistently for team resolution, LFS, and push
 	ep := resolveImportEndpoint(projectRoot)
 
-	var tc *config.TeamContext
-	if importFlags.team != "" {
-		if projectRoot != "" {
-			tc = resolveTeamContext(projectRoot, importFlags.team)
-		}
-		if tc == nil {
-			// no project root or team not found via project — scan by endpoint
-			tc = resolveTeamContextByEndpoint(importFlags.team, ep)
-		}
-		if tc == nil {
-			return fmt.Errorf("team context not found: %q (use ox agent prime to see available teams)", importFlags.team)
-		}
-	} else {
-		if projectRoot != "" {
-			tc = config.FindRepoTeamContext(projectRoot)
-		}
-		if tc == nil {
-			// no project or no team in project — try single-team auto-discovery
-			tc = autoDiscoverSingleTeam(ep)
-		}
-		if tc == nil {
-			if projectRoot == "" {
-				return fmt.Errorf("no team found — use --team to specify one, or run from inside a SageOx project")
-			}
-			return fmt.Errorf("no team context configured — use --team to specify one, or run 'ox init' first")
-		}
+	tc, err := resolveImportTeam(projectRoot, ep)
+	if err != nil {
+		return err
 	}
 
 	// data/ is excluded from the team context sparse checkout (deny list in
@@ -650,53 +649,172 @@ func slugify(s string) string {
 	return strings.Trim(result, "-")
 }
 
-// resolveImportTeamAndClient resolves the team context and creates an authenticated API client.
-// Shared by URL import, status, and list operations.
-func resolveImportTeamAndClient() (*config.TeamContext, *api.RepoClient, error) {
-	projectRoot, _ := findProjectRoot()
-	ep := resolveImportEndpoint(projectRoot)
+// mediaImportExts routes a local file to the cloud recording-file import
+// instead of the document-LFS path when targeting a Knowledge Bubble (team
+// media stays on the document-LFS path). Mirrors the audio/video groups in
+// detectContentType so routing and MIME detection can never disagree.
+var mediaImportExts = map[string]bool{
+	".mp4": true, ".mov": true, ".mkv": true, ".avi": true, ".webm": true,
+	".m4a": true, ".mp3": true, ".wav": true, ".ogg": true, ".opus": true,
+	".flac": true, ".aac": true, ".wma": true,
+}
 
+// isMediaImportFile reports whether a local file is audio/video. With --kb it
+// is imported as a recording (cloud processing); for team it still goes
+// through the document path, which transcribes media server-side.
+func isMediaImportFile(path string) bool {
+	return mediaImportExts[strings.ToLower(filepath.Ext(path))]
+}
+
+// resolveImportTeam resolves the team context for an import: explicit --team
+// first (project lookup, then endpoint scan), otherwise repo-bound team or
+// single-team auto-discovery.
+func resolveImportTeam(projectRoot, ep string) (*config.TeamContext, error) {
 	var tc *config.TeamContext
 	if importFlags.team != "" {
 		if projectRoot != "" {
 			tc = resolveTeamContext(projectRoot, importFlags.team)
 		}
 		if tc == nil {
+			// no project root or team not found via project — scan by endpoint
 			tc = resolveTeamContextByEndpoint(importFlags.team, ep)
 		}
 		if tc == nil {
-			return nil, nil, fmt.Errorf("team context not found: %q (use ox agent prime to see available teams)", importFlags.team)
+			return nil, fmt.Errorf("team context not found: %q (use ox agent prime to see available teams)", importFlags.team)
 		}
+		return tc, nil
+	}
+
+	if projectRoot != "" {
+		tc = config.FindRepoTeamContext(projectRoot)
+	}
+	if tc == nil {
+		// no project or no team in project — try single-team auto-discovery
+		tc = autoDiscoverSingleTeam(ep)
+	}
+	if tc == nil {
+		if projectRoot == "" {
+			return nil, fmt.Errorf("no team found — use --team to specify one, or run from inside a SageOx project")
+		}
+		return nil, fmt.Errorf("no team context configured — use --team to specify one, or run 'ox init' first")
+	}
+	return tc, nil
+}
+
+// resolveImportContext resolves the import target (team context or Knowledge
+// Bubble) and creates an authenticated API client. Shared by media-file
+// import, URL import, status, and list operations. Exactly one context is
+// resolved: --kb wins when set, otherwise the existing team resolution runs
+// unchanged.
+func resolveImportContext(ctx context.Context) (contextType, contextID string, client *api.RepoClient, ep string, err error) {
+	// defensive double-check: cobra's MarkFlagsMutuallyExclusive enforces this
+	// for CLI invocations, but this resolver also runs in tests that set the
+	// flag globals directly
+	if importFlags.team != "" && importFlags.kb != "" {
+		return "", "", nil, "", fmt.Errorf("--team and --kb are mutually exclusive — specify exactly one")
+	}
+
+	projectRoot, _ := findProjectRoot()
+	ep = resolveImportEndpoint(projectRoot)
+
+	if importFlags.kb != "" {
+		kbID, kbErr := resolveKBInputForCmd(ctx, importFlags.kb)
+		if kbErr != nil {
+			return "", "", nil, "", fmt.Errorf("resolve --kb %q: %w", importFlags.kb, kbErr)
+		}
+		contextType, contextID = api.ContextTypeKB, kbID
 	} else {
-		if projectRoot != "" {
-			tc = config.FindRepoTeamContext(projectRoot)
+		tc, tcErr := resolveImportTeam(projectRoot, ep)
+		if tcErr != nil {
+			return "", "", nil, "", tcErr
 		}
-		if tc == nil {
-			tc = autoDiscoverSingleTeam(ep)
-		}
-		if tc == nil {
-			if projectRoot == "" {
-				return nil, nil, fmt.Errorf("no team found — use --team to specify one, or run from inside a SageOx project")
-			}
-			return nil, nil, fmt.Errorf("no team context configured — use --team to specify one, or run 'ox init' first")
-		}
+		contextType, contextID = api.ContextTypeTeam, tc.TeamID
 	}
 
 	storedToken, err := auth.GetTokenForEndpoint(ep)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read auth store: %w", err)
+		return "", "", nil, "", fmt.Errorf("failed to read auth store: %w", err)
 	}
 	if storedToken == nil || storedToken.AccessToken == "" {
-		return nil, nil, fmt.Errorf("not authenticated — run 'ox login' first")
+		return "", "", nil, "", fmt.Errorf("not authenticated — run 'ox login' first")
 	}
 
-	client := api.NewRepoClientWithEndpoint(ep).WithAuthToken(storedToken.AccessToken)
-	return tc, client, nil
+	client = api.NewRepoClientWithEndpoint(ep).WithAuthToken(storedToken.AccessToken)
+	return contextType, contextID, client, ep, nil
+}
+
+// runImportRecordingFile imports a local media file as a recording via the
+// 3-step cloud flow (POST import → presigned PUT → POST complete).
+// KB-only: team media imports use the document-LFS path, which the backend
+// already transcribes — see the dispatch in runImport.
+func runImportRecordingFile(cmd *cobra.Command, srcPath string, importDate time.Time, jsonOutput bool) error {
+	// defensive: the runImport dispatch only calls this with --kb set, but a
+	// future caller wiring this up for team would silently change the team
+	// storage model (git-LFS → S3 recording) — fail loudly instead
+	if importFlags.kb == "" {
+		return fmt.Errorf("recording-file import requires --kb — team media imports use the document import path")
+	}
+
+	contextType, contextID, client, _, err := resolveImportContext(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	filename := filepath.Base(srcPath)
+	title := importFlags.title
+	if title == "" {
+		title = inferTitle(srcPath)
+	}
+
+	// recorded_at back-dates the recording to when it actually happened
+	// (--date flag or file mtime) rather than the import time
+	recordedAt := importDate.UTC()
+	req := api.ImportRecordingFileRequest{
+		Filename:    filename,
+		ContentType: detectContentType(filename, nil),
+		Title:       title,
+		RecordedAt:  &recordedAt,
+	}
+
+	resp, err := client.ImportRecordingFile(cmd.Context(), contextType, contextID, srcPath, req)
+	if err != nil {
+		return fmt.Errorf("import failed: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("import endpoint not available (server may not support recording file imports yet)")
+	}
+
+	if jsonOutput {
+		out, _ := json.MarshalIndent(resp, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	}
+
+	cli.PrintSuccess("Import started")
+	fmt.Fprintf(cmd.OutOrStdout(), "  ID:        %s\n", resp.RecordingID)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Status:    %s\n", resp.Status)
+	if title != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "  Title:     %s\n", title)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\n  Track progress: ox import --status %s --watch%s\n", resp.RecordingID, importContextFlagHint())
+	return nil
+}
+
+// importContextFlagHint reproduces the context flag the user passed so copy-
+// pasted follow-up commands resolve the same context.
+func importContextFlagHint() string {
+	if importFlags.kb != "" {
+		return " --kb " + importFlags.kb
+	}
+	if importFlags.team != "" {
+		return " --team " + importFlags.team
+	}
+	return ""
 }
 
 // runImportURL handles importing a video/audio by URL via the cloud API.
 func runImportURL(cmd *cobra.Command, url string, jsonOutput bool) error {
-	tc, client, err := resolveImportTeamAndClient()
+	contextType, contextID, client, _, err := resolveImportContext(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -706,7 +824,7 @@ func runImportURL(cmd *cobra.Command, url string, jsonOutput bool) error {
 		Title: importFlags.title,
 	}
 
-	resp, err := client.ImportVideoURL(tc.TeamID, req)
+	resp, err := client.ImportVideoURL(contextType, contextID, req)
 	if err != nil {
 		return fmt.Errorf("import failed: %w", err)
 	}
@@ -726,13 +844,13 @@ func runImportURL(cmd *cobra.Command, url string, jsonOutput bool) error {
 	if resp.Title != "" {
 		fmt.Fprintf(cmd.OutOrStdout(), "  Title:     %s\n", resp.Title)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "\n  Track progress: ox import --status %s --watch\n", resp.RecordingID)
+	fmt.Fprintf(cmd.OutOrStdout(), "\n  Track progress: ox import --status %s --watch%s\n", resp.RecordingID, importContextFlagHint())
 	return nil
 }
 
 // runImportStatus handles checking the processing status of a recording.
 func runImportStatus(cmd *cobra.Command, jsonOutput bool) error {
-	tc, client, err := resolveImportTeamAndClient()
+	contextType, contextID, client, _, err := resolveImportContext(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -744,7 +862,7 @@ func runImportStatus(cmd *cobra.Command, jsonOutput bool) error {
 	// (CreateVideoRecording activity). Treat 404 as status="starting" rather than
 	// an error, since the ID is known-valid.
 	for {
-		resp, err := client.GetVideoStatus(tc.TeamID, recordingID)
+		resp, err := client.GetVideoStatus(contextType, contextID, recordingID)
 		if err != nil {
 			return fmt.Errorf("status check failed: %w", err)
 		}
@@ -820,14 +938,14 @@ func printVideoStatus(cmd *cobra.Command, resp *api.VideoStatusResponse) {
 	}
 }
 
-// runImportList handles listing team recordings.
+// runImportList handles listing recordings in the resolved context.
 func runImportList(cmd *cobra.Command, jsonOutput bool) error {
-	tc, client, err := resolveImportTeamAndClient()
+	contextType, contextID, client, _, err := resolveImportContext(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.ListVideos(tc.TeamID, 50, 0)
+	resp, err := client.ListVideos(contextType, contextID, 50, 0)
 	if err != nil {
 		return fmt.Errorf("list recordings failed: %w", err)
 	}

--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var importFlags struct {
+type importFlagsT struct {
 	text   string
 	date   string
 	force  bool
@@ -37,6 +37,8 @@ var importFlags struct {
 	watch  bool
 	list   bool
 }
+
+var importFlags importFlagsT
 
 var importCmd = &cobra.Command{
 	Use:   "import <file|url>",

--- a/cmd/ox/import_recording_test.go
+++ b/cmd/ox/import_recording_test.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/testguard"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestMediaFile creates a small mp4 file (valid ftyp header + padding)
+// and returns its path and content length.
+func writeTestMediaFile(t *testing.T) (string, int64) {
+	t.Helper()
+	content := make([]byte, 1024)
+	copy(content, mp4Header)
+	path := filepath.Join(t.TempDir(), "standup.mp4")
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+	return path, int64(len(content))
+}
+
+// TestImportRecordingFile_KB_MockServer exercises the full 3-step bulk
+// recording-file import against a Knowledge Bubble context: POST import →
+// presigned PUT → POST complete. Asserts all three legs fire in order and
+// that every API leg uses the kb/ context path.
+func TestImportRecordingFile_KB_MockServer(t *testing.T) {
+	mediaPath, mediaSize := writeTestMediaFile(t)
+
+	var mu sync.Mutex
+	var legs []string
+
+	recordLeg := func(name string) {
+		mu.Lock()
+		defer mu.Unlock()
+		legs = append(legs, name)
+	}
+
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/api/v1/kb/kb_test123/recordings/import":
+			recordLeg("import")
+
+			var req api.ImportRecordingFileRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, "standup.mp4", req.Filename)
+			assert.Equal(t, "video/mp4", req.ContentType)
+			assert.Equal(t, mediaSize, req.Size, "size must come from the file on disk")
+			assert.Equal(t, "Standup", req.Title)
+			require.NotNil(t, req.RecordedAt)
+
+			// point the presigned PUT back at this same mock server
+			resp := map[string]any{
+				"recording_id": "rec_imp_001",
+				"status":       "pending",
+				"upload": map[string]any{
+					"upload_url": "http://" + r.Host + "/mock-upload/rec_imp_001",
+					"expires_at": time.Now().Add(time.Hour).Format(time.RFC3339),
+				},
+				"created_at": time.Now().Format(time.RFC3339),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(resp)
+
+		case r.Method == "PUT" && r.URL.Path == "/mock-upload/rec_imp_001":
+			recordLeg("upload")
+
+			assert.Equal(t, "video/mp4", r.Header.Get("Content-Type"))
+			assert.Equal(t, mediaSize, r.ContentLength, "PUT must declare the streamed length")
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.Equal(t, mediaSize, int64(len(body)), "full file content must arrive")
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == "POST" && r.URL.Path == "/api/v1/kb/kb_test123/recordings/rec_imp_001/complete":
+			recordLeg("complete")
+
+			var req struct {
+				TotalSize int64 `json:"total_size"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, mediaSize, req.TotalSize)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"recording_id": "rec_imp_001",
+				"status":       "processing",
+			})
+
+		default:
+			http.Error(w, fmt.Sprintf("unexpected request: %s %s", r.Method, r.URL.Path), http.StatusNotFound)
+		}
+	}))
+
+	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
+
+	recordedAt := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	result, err := client.ImportRecordingFile(context.Background(), api.ContextTypeKB, "kb_test123", mediaPath, api.ImportRecordingFileRequest{
+		Filename:    "standup.mp4",
+		ContentType: "video/mp4",
+		Title:       "Standup",
+		RecordedAt:  &recordedAt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "rec_imp_001", result.RecordingID)
+	assert.Equal(t, "processing", result.Status, "status should come from the complete response")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"import", "upload", "complete"}, legs, "the three legs must fire exactly once, in order")
+}
+
+// TestImport_TeamMediaFile_DoesNotUseRecordingImport pins the team routing:
+// a media file WITHOUT --kb must fall through to the document-LFS path (the
+// backend's team-context-doc-import workflow already transcribes media) and
+// must never hit the recordings/import endpoint — that endpoint is KB-only.
+// The test isolates cwd and the XDG data dir so the doc path stops at team
+// resolution, proving routing reached it instead of the recording import.
+func TestImport_TeamMediaFile_DoesNotUseRecordingImport(t *testing.T) {
+	mediaPath, _ := writeTestMediaFile(t)
+	withImportFlags(t, "", "")
+
+	var recordingImportHits atomic.Int32
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/recordings/import") {
+			recordingImportHits.Add(1)
+		}
+		http.Error(w, fmt.Sprintf("unexpected request: %s %s", r.Method, r.URL.Path), http.StatusNotFound)
+	}))
+
+	t.Chdir(t.TempDir())                   // no .sageox/ → no project root
+	t.Setenv("OX_PROJECT_ROOT", "")        // neutralize any ambient override
+	t.Setenv("XDG_DATA_HOME", t.TempDir()) // no synced teams to auto-discover
+	t.Setenv("SAGEOX_ENDPOINT", server.URL)
+	t.Setenv("SAGEOX_TOKEN", "env-test-token")
+
+	cmd := &cobra.Command{}
+	// a bare command has a nil context until Execute(); these tests call the
+	// run funcs directly, so set one explicitly
+	cmd.SetContext(context.Background())
+	cmd.Flags().Bool("json", false, "")
+
+	err := runImport(cmd, []string{mediaPath})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "team", "media without --kb must reach the team document path")
+	assert.Equal(t, int32(0), recordingImportHits.Load(), "team media import must never call recordings/import")
+}
+
+// TestImport_KBMediaFile_UsesRecordingImport pins the KB routing end-to-end
+// through runImport: --kb + media file drives the full 3-leg cloud import
+// against kb/ paths (incl. the KB-only guard in runImportRecordingFile).
+func TestImport_KBMediaFile_UsesRecordingImport(t *testing.T) {
+	mediaPath, _ := writeTestMediaFile(t)
+	withImportFlags(t, "", "kb_route123")
+
+	var mu sync.Mutex
+	var legs []string
+	recordLeg := func(name string) {
+		mu.Lock()
+		defer mu.Unlock()
+		legs = append(legs, name)
+	}
+
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/api/v1/kb/kb_route123/recordings/import":
+			recordLeg("import")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"recording_id": "rec_kb_route_001",
+				"status":       "pending",
+				"upload": map[string]any{
+					"upload_url": "http://" + r.Host + "/mock-upload/rec_kb_route_001",
+					"expires_at": time.Now().Add(time.Hour).Format(time.RFC3339),
+				},
+			})
+		case r.Method == "PUT" && r.URL.Path == "/mock-upload/rec_kb_route_001":
+			recordLeg("upload")
+			io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == "POST" && r.URL.Path == "/api/v1/kb/kb_route123/recordings/rec_kb_route_001/complete":
+			recordLeg("complete")
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"recording_id": "rec_kb_route_001", "status": "processing"})
+		default:
+			http.Error(w, fmt.Sprintf("unexpected request: %s %s", r.Method, r.URL.Path), http.StatusNotFound)
+		}
+	}))
+
+	t.Chdir(t.TempDir())
+	t.Setenv("OX_PROJECT_ROOT", "")
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("SAGEOX_ENDPOINT", server.URL)
+	t.Setenv("SAGEOX_TOKEN", "env-test-token")
+
+	cmd := &cobra.Command{}
+	// a bare command has a nil context until Execute(); these tests call the
+	// run funcs directly, so set one explicitly
+	cmd.SetContext(context.Background())
+	cmd.Flags().Bool("json", false, "")
+	cmd.SetOut(io.Discard) // success output is asserted via the mock legs, not stdout
+
+	err := runImport(cmd, []string{mediaPath})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"import", "upload", "complete"}, legs, "KB media must drive the 3-leg recording import on kb/ paths")
+}
+
+// TestImport_KBDocumentFile_Errors pins the third routing branch: --kb with a
+// non-media file is rejected before any network or git work.
+func TestImport_KBDocumentFile_Errors(t *testing.T) {
+	withImportFlags(t, "", "kb_route123")
+
+	docPath := filepath.Join(t.TempDir(), "notes.md")
+	require.NoError(t, os.WriteFile(docPath, []byte("# notes"), 0o644))
+
+	cmd := &cobra.Command{}
+	// a bare command has a nil context until Execute(); these tests call the
+	// run funcs directly, so set one explicitly
+	cmd.SetContext(context.Background())
+	cmd.Flags().Bool("json", false, "")
+
+	err := runImport(cmd, []string{docPath})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "document import into a Knowledge Bubble is not yet available")
+}
+
+// TestRunImportRecordingFile_RequiresKB pins the defensive KB-only guard: a
+// direct call without --kb must fail before resolving any context, so team
+// media can never silently switch storage models (git-LFS → S3 recording).
+func TestRunImportRecordingFile_RequiresKB(t *testing.T) {
+	mediaPath, _ := writeTestMediaFile(t)
+	withImportFlags(t, "", "")
+
+	cmd := &cobra.Command{}
+	// a bare command has a nil context until Execute(); these tests call the
+	// run funcs directly, so set one explicitly
+	cmd.SetContext(context.Background())
+	cmd.Flags().Bool("json", false, "")
+
+	err := runImportRecordingFile(cmd, mediaPath, time.Now(), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires --kb")
+}
+
+// TestImportRecordingFile_404GracefulDegradation mirrors the URL-import
+// pattern: a 404 on the import-init POST means the endpoint is not deployed
+// yet and must surface as nil, nil — never as an error.
+func TestImportRecordingFile_404GracefulDegradation(t *testing.T) {
+	mediaPath, _ := writeTestMediaFile(t)
+
+	server := testguard.SafeMockServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
+	result, err := client.ImportRecordingFile(context.Background(), api.ContextTypeKB, "kb_test123", mediaPath, api.ImportRecordingFileRequest{
+		Filename: "standup.mp4",
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, result, "should return nil on 404 (endpoint not deployed)")
+}
+
+// TestImportRecordingFile_InvalidContextType asserts the context validation
+// fires before any network traffic.
+func TestImportRecordingFile_InvalidContextType(t *testing.T) {
+	mediaPath, _ := writeTestMediaFile(t)
+
+	client := api.NewRepoClientWithEndpoint("http://localhost:1").WithAuthToken("test-token")
+	result, err := client.ImportRecordingFile(context.Background(), "repo", "repo_x", mediaPath, api.ImportRecordingFileRequest{Filename: "standup.mp4"})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "invalid context type")
+}
+
+// --- --kb flag resolution ---
+
+// withImportFlags saves and restores the package-global importFlags so tests
+// can mutate them safely.
+func withImportFlags(t *testing.T, team, kb string) {
+	t.Helper()
+	savedTeam, savedKB := importFlags.team, importFlags.kb
+	importFlags.team, importFlags.kb = team, kb
+	t.Cleanup(func() {
+		importFlags.team, importFlags.kb = savedTeam, savedKB
+	})
+}
+
+// TestResolveImportContext_KBFlag verifies that --kb with a kb_-prefixed ID
+// resolves fully offline (no kb-API round trip) to a kb context.
+func TestResolveImportContext_KBFlag(t *testing.T) {
+	withImportFlags(t, "", "kb_abc123")
+	// env token keeps the resolver off the on-disk auth store
+	t.Setenv("SAGEOX_ENDPOINT", "https://kb-import-test.invalid")
+	t.Setenv("SAGEOX_TOKEN", "env-test-token")
+
+	contextType, contextID, client, ep, err := resolveImportContext(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, api.ContextTypeKB, contextType)
+	assert.Equal(t, "kb_abc123", contextID)
+	require.NotNil(t, client)
+	assert.Contains(t, ep, "kb-import-test.invalid")
+}
+
+// TestResolveImportContext_BothFlagsError verifies the mutual-exclusion guard
+// (defense in depth behind cobra's MarkFlagsMutuallyExclusive).
+func TestResolveImportContext_BothFlagsError(t *testing.T) {
+	withImportFlags(t, "team_x", "kb_y")
+
+	_, _, _, _, err := resolveImportContext(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestIsMediaImportFile pins the media-vs-document routing boundary.
+func TestIsMediaImportFile(t *testing.T) {
+	media := []string{"a.mp4", "b.MOV", "c.webm", "d.m4a", "e.mp3", "f.wav", "dir/g.mkv"}
+	for _, p := range media {
+		assert.True(t, isMediaImportFile(p), "%s should route to recording import", p)
+	}
+	docs := []string{"report.pdf", "notes.md", "data.json", "img.png", "noext", "archive.tar.gz"}
+	for _, p := range docs {
+		assert.False(t, isMediaImportFile(p), "%s should route to document import", p)
+	}
+}
+
+// TestImportCmd_KBFlagRegistered pins the CLI surface: --kb exists and the
+// help text documents the Knowledge Bubble path.
+func TestImportCmd_KBFlagRegistered(t *testing.T) {
+	flag := importCmd.Flags().Lookup("kb")
+	require.NotNil(t, flag, "--kb flag must be registered on ox import")
+	assert.True(t, strings.Contains(importCmd.Long, "--kb"), "help text should mention --kb")
+}

--- a/cmd/ox/import_recording_test.go
+++ b/cmd/ox/import_recording_test.go
@@ -292,14 +292,17 @@ func TestImportRecordingFile_InvalidContextType(t *testing.T) {
 
 // --- --kb flag resolution ---
 
-// withImportFlags saves and restores the package-global importFlags so tests
-// can mutate them safely.
+// withImportFlags saves and restores the entire package-global importFlags so
+// tests can mutate them safely. It resets to a clean baseline (only team/kb
+// set) rather than snapshotting just those two — runImport also reads status,
+// list, watch, title, date, text, and force, so a prior test that mutated any
+// of those could otherwise leak into routing/assertions here.
 func withImportFlags(t *testing.T, team, kb string) {
 	t.Helper()
-	savedTeam, savedKB := importFlags.team, importFlags.kb
-	importFlags.team, importFlags.kb = team, kb
+	saved := importFlags
+	importFlags = importFlagsT{team: team, kb: kb}
 	t.Cleanup(func() {
-		importFlags.team, importFlags.kb = savedTeam, savedKB
+		importFlags = saved
 	})
 }
 

--- a/cmd/ox/import_video_test.go
+++ b/cmd/ox/import_video_test.go
@@ -218,7 +218,7 @@ func TestImportVideoURL_MockServer(t *testing.T) {
 	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
 
 	// test ImportVideoURL
-	resp, err := client.ImportVideoURL("team_test123", &api.ImportVideoURLRequest{
+	resp, err := client.ImportVideoURL(api.ContextTypeTeam, "team_test123", &api.ImportVideoURLRequest{
 		URL:   "https://localhost/test-video.mp4",
 		Title: "Test Video",
 	})
@@ -229,7 +229,7 @@ func TestImportVideoURL_MockServer(t *testing.T) {
 	assert.Equal(t, int32(1), importCalled.Load())
 
 	// test GetVideoStatus
-	status, err := client.GetVideoStatus("team_test123", "rec_test_001")
+	status, err := client.GetVideoStatus(api.ContextTypeTeam, "team_test123", "rec_test_001")
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	assert.Equal(t, "ready", status.Status)
@@ -255,14 +255,14 @@ func TestImportVideoURL_404GracefulDegradation(t *testing.T) {
 	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
 
 	// ImportVideoURL returns nil, nil on 404
-	resp, err := client.ImportVideoURL("team_test123", &api.ImportVideoURLRequest{
+	resp, err := client.ImportVideoURL(api.ContextTypeTeam, "team_test123", &api.ImportVideoURLRequest{
 		URL: "https://localhost/video.mp4",
 	})
 	assert.NoError(t, err)
 	assert.Nil(t, resp, "should return nil on 404 (endpoint not deployed)")
 
 	// GetVideoStatus returns nil, nil on 404
-	status, err := client.GetVideoStatus("team_test123", "rec_nonexistent")
+	status, err := client.GetVideoStatus(api.ContextTypeTeam, "team_test123", "rec_nonexistent")
 	assert.NoError(t, err)
 	assert.Nil(t, status, "should return nil on 404 (recording not found)")
 }
@@ -316,17 +316,17 @@ func TestImportVideoURL_StatusProgression(t *testing.T) {
 	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
 
 	// first call: pending
-	s1, err := client.GetVideoStatus("team_test123", "rec_progress_001")
+	s1, err := client.GetVideoStatus(api.ContextTypeTeam, "team_test123", "rec_progress_001")
 	require.NoError(t, err)
 	assert.Equal(t, "pending", s1.Status)
 
 	// second call: processing
-	s2, err := client.GetVideoStatus("team_test123", "rec_progress_001")
+	s2, err := client.GetVideoStatus(api.ContextTypeTeam, "team_test123", "rec_progress_001")
 	require.NoError(t, err)
 	assert.Equal(t, "processing", s2.Status)
 
 	// third call: ready
-	s3, err := client.GetVideoStatus("team_test123", "rec_progress_001")
+	s3, err := client.GetVideoStatus(api.ContextTypeTeam, "team_test123", "rec_progress_001")
 	require.NoError(t, err)
 	assert.Equal(t, "ready", s3.Status)
 	assert.Len(t, s3.ProcessingSteps, 4)
@@ -363,7 +363,7 @@ func TestListVideos_MockServer(t *testing.T) {
 	}))
 
 	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
-	resp, err := client.ListVideos("team_test123", 50, 0)
+	resp, err := client.ListVideos(api.ContextTypeTeam, "team_test123", 50, 0)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Len(t, resp.Recordings, 2)
@@ -381,7 +381,7 @@ func TestListVideos_404GracefulDegradation(t *testing.T) {
 	}))
 
 	client := api.NewRepoClientWithEndpoint(server.URL).WithAuthToken("test-token")
-	resp, err := client.ListVideos("team_test123", 50, 0)
+	resp, err := client.ListVideos(api.ContextTypeTeam, "team_test123", 50, 0)
 	assert.NoError(t, err)
 	assert.Nil(t, resp, "should return nil on 404")
 }

--- a/docs/specs/kb-import-parity.md
+++ b/docs/specs/kb-import-parity.md
@@ -1,0 +1,147 @@
+# KB import parity — `ox import --kb`
+
+**Status:** implemented (CLI side; backend bulk-import endpoint lands in parallel in sageox-mono)
+**Audience:** SageOx engineers working on `ox import`, the recordings API client, or Knowledge Bubble ingestion
+
+`ox import` historically targeted team contexts only. This design brings Knowledge Bubbles to
+parity for the import paths that go through the cloud recording pipeline, and documents which
+path is deliberately deferred.
+
+## The three things called "import"
+
+"Import" is overloaded in ox. Three distinct mechanisms share the word:
+
+| Mechanism | What it does | Transport | Team | Knowledge Bubble |
+|---|---|---|---|---|
+| **URL-video import** | Submit a video URL (Loom, Cap, direct) for cloud processing | `POST …/recordings/import/url` | ✅ existing | ✅ **this change** (route already mounted server-side) |
+| **Bulk recording-file import** (new) | Upload a pre-existing local media file as a recording | `POST …/recordings/import` → presigned PUT → `POST …/{rec_id}/complete` | ❌ **not used** — team media stays on document-LFS (below) | ✅ **this change** |
+| **Document-LFS import** | Store a document (PDF, markdown, **and media files**) with LFS-backed content + git-tracked metadata in the team context repo | LFS batch upload + git commit/push + `POST /api/v1/teams/{team_id}/context/import` notify | ✅ existing — **including media transcription** | ❌ **deferred** |
+
+### Team media import already transcribes — team is UNCHANGED
+
+`ox import meeting.mp4` (no flag, or `--team`) was already complete before this change: the
+media file is written as a git-LFS doc into the team-context repo, and the
+`POST /api/v1/teams/{team_id}/context/import` notify kicks off the backend's
+team-context-doc-import workflow, which routes by content type — `video/*` →
+`ImportVideoFileWorkflow`, `audio/*` → `ImportAudioWorkflow` — so team media imports were
+already transcribed server-side AND git-tracked. This change does not touch that path.
+
+The new `…/recordings/import` endpoint is used **only for `--kb`**, because a Knowledge Bubble
+has the genuine gap: there is no `/api/v1/kb/{kb_id}/context/import` route and no KB doc-import
+workflow, so the recording pipeline is a KB's only media-ingestion path.
+
+**Known, intentional asymmetry:** team media lands as a git-LFS doc in the team-context repo
+(history, pointers, repo-visible), while KB media lands as a presigned-S3 recording row
+processed by `RecordingProcessingWorkflow` (no git artifact). Unifying the two storage models
+is out of scope here; if the team path ever moves to the recording pipeline (or KB grows a
+`/context/import` route), the dispatch in `runImport` is the single seam to change.
+
+### Why document-LFS to a Knowledge Bubble is deferred
+
+- **No backend route:** verified against sageox-mono — `/context/import` is registered for
+  teams only; no `/api/v1/kb/{kb_id}/context/import` exists today.
+- **A different path already serves the need:** document content reaches a Knowledge Bubble via
+  the MCP `SaveToBubble` / `kb-import` tools, which write through the bubble's own git repo.
+- **Decision:** `ox import <document> --kb …` returns a clear error pointing at `--team`. If a
+  KB `/context/import` route ships later, the CLI's `NotifyImport` path gets the same context
+  parameterization described below — the seam is already in place.
+
+## UX decision: `--kb` flag, not `ox kb import`
+
+The chosen surface is a `--kb <slug|kb_id>` flag on the existing `ox import` command.
+
+- **Mirrors `--team`:** import already takes an optional context override; `--kb` is the same
+  shape pointed at a different context. One command, one mental model, one set of
+  `--status` / `--list` / `--watch` follow-ups.
+- **No breaking change:** every existing invocation (`--team`, auto-discovered team, `--status`,
+  `--list`) behaves identically when `--kb` is absent.
+- **Mutual exclusion:** `--team` and `--kb` are mutually exclusive (enforced by cobra's
+  `MarkFlagsMutuallyExclusive` plus a defensive check in the resolver). Exactly one context is
+  resolved per invocation.
+- **Why not a subcommand:** `ox kb import` would fork the import surface — two help texts, two
+  flag sets, and a second home for `--status` / `--list`. The `ox kb` namespace is for bubble
+  *management* (config, path, resolution); ingestion stays on `ox import`.
+
+KB resolution reuses `resolveKBInputForCmd` (`cmd/ox/kb_resolve.go`): accepts a bare slug,
+`#slug`, or `kb_…` ID; `kb_…` resolves fully offline, slugs go through the kb API with the
+legacy fallback.
+
+## API-layer context abstraction
+
+The backend mounts identical recording routes under `/api/v1/teams/{team_id}/recordings` and
+`/api/v1/kb/{kb_id}/recordings`. Rather than duplicating each client method per context, the
+path segment is parameterized once:
+
+- **`recordingsBase(contextType, contextID)`** (`internal/api/video.go`) returns the collection
+  path for `"team"` or `"kb"` and rejects anything else. Exported constants
+  `api.ContextTypeTeam` / `api.ContextTypeKB` are the only valid inputs.
+- **`ImportVideoURL`, `GetVideoStatus`, `ListVideos`, `ImportRecordingFile`** all take
+  `(contextType, contextID, …)` and build URLs from `recordingsBase`. The nil-nil-on-404
+  graceful-degradation pattern (endpoint not yet deployed) is preserved unchanged.
+  `ImportRecordingFile` supports both contexts at the client layer but the CLI only ever
+  invokes it for KB (see routing above); `--status` / `--list` / URL import legitimately
+  serve both team and KB recording routes.
+- **`cmd/ox/import.go` resolves context once** via `resolveImportContext()`, which returns
+  `(contextType, contextID, client, endpoint)` for either flag, then threads the pair through
+  URL import, file import, `--status`, and `--list`.
+
+This keeps the team/kb split to exactly two places: one path builder in the API layer, one
+context resolver in the command layer.
+
+## Bulk recording-file import: the 3-step sequence
+
+A local media file (`.mp4 .mov .mkv .avi .webm .m4a .mp3 .wav .ogg .opus .flac .aac .wma`) is
+routed to `ImportRecordingFile` instead of the document-LFS path **only when `--kb` is set**;
+team media files fall through to document-LFS unchanged (see the team-is-UNCHANGED section
+above). `runImportRecordingFile` also carries a defensive KB-only guard so a future caller
+can't silently switch the team storage model. The extension set mirrors the audio/video groups
+in `detectContentType` so routing and MIME detection cannot disagree.
+
+```mermaid
+flowchart LR
+  CLI["ox import recording.mp4 --kb my-bubble"] --> INIT["POST /api/v1/kb/kb_id/recordings/import<br/>filename, content_type, size, title, recorded_at"]
+  INIT --> RESP["201: recording_id + presigned upload_url"]
+  RESP --> UP["PUT file bytes to upload_url<br/>streamed from disk, ContentLength set"]
+  UP --> DONE["POST /recordings/rec_id/complete<br/>total_size"]
+  DONE --> WF["server: RecordingProcessingWorkflow<br/>transcript, summary, status ready"]
+```
+
+Step details:
+
+- **Step 1 — init:** JSON body `{filename, content_type, size, title?, description?, recorded_at?}`.
+  `size` is always taken from `os.Stat` so the presigned request can never disagree with the
+  bytes uploaded. `recorded_at` back-dates historical imports (`--date` flag, else file mtime).
+  A 404 here returns `nil, nil` — the endpoint is not deployed yet, matching `ImportVideoURL`.
+- **Step 2 — presigned PUT:** the open `*os.File` is the request body with `ContentLength`
+  set explicitly — the file is **never** read fully into memory. The PUT uses a dedicated
+  HTTP client without the default 10s timeout (media files routinely take longer); context
+  cancellation still applies. `Content-Type` matches step 1 because presigned URLs may sign it.
+- **Step 3 — complete:** `{total_size}` finalizes the recording and kicks off server-side
+  processing. Imports are a single PUT, never chunked, so `chunk_count` is omitted — the server
+  branches on `metadata.source = "import"`. The response's `status` is surfaced to the user;
+  progress is tracked with `ox import --status rec_… --watch --kb …`.
+
+## Test plan
+
+| Layer | Test | Asserts |
+|---|---|---|
+| API client | `TestImportRecordingFile_KB_MockServer` (`cmd/ox/import_recording_test.go`) | all 3 legs fire exactly once, in order, against `kb/` paths; size from disk; full bytes arrive; final status comes from the complete response |
+| API client | `TestImportRecordingFile_404GracefulDegradation` | 404 on init → `nil, nil`, no error |
+| API client | `TestImportRecordingFile_InvalidContextType` | unknown context rejected before any network traffic |
+| Command | `TestImport_TeamMediaFile_DoesNotUseRecordingImport` | team media (no `--kb`) falls through to the document-LFS path and never hits `recordings/import` |
+| Command | `TestImport_KBMediaFile_UsesRecordingImport` | `--kb` + media drives the 3-leg import on `kb/` paths through `runImport` |
+| Command | `TestImport_KBDocumentFile_Errors` | `--kb` + non-media rejected with the use-`--team` error |
+| Command | `TestRunImportRecordingFile_RequiresKB` | defensive guard: direct call without `--kb` fails before any context resolution |
+| Command | `TestResolveImportContext_KBFlag` | `--kb kb_…` resolves offline to a kb context with an authenticated client |
+| Command | `TestResolveImportContext_BothFlagsError` | `--team` + `--kb` rejected |
+| Command | `TestIsMediaImportFile` | media-vs-document routing boundary pinned |
+| Command | `TestImportCmd_KBFlagRegistered` | `--kb` registered; help text documents it |
+| Regression | existing `TestImportVideoURL_*`, `TestListVideos_*`, `internal/api/video_test.go` suite | team behavior unchanged through the context-parameterized signatures |
+| Manual (post-backend-merge) | `ox import ./sample.mp4 --kb <slug>` against test.sageox.ai | recording appears under the bubble; `--status --watch` reaches `ready` |
+
+## Out of scope
+
+- **Backend implementation** of `POST …/recordings/import` (sageox-mono, shipping in parallel).
+- **Document-LFS import to a Knowledge Bubble** (see deferral rationale above).
+- **Chunked/multipart upload** for very large files — single presigned PUT only; revisit if
+  imports above the server's max file size become a real need.

--- a/internal/api/video.go
+++ b/internal/api/video.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -14,11 +15,32 @@ import (
 	"github.com/sageox/ox/internal/useragent"
 )
 
+// Recording context types. The backend mounts the same recording routes under
+// /api/v1/teams/{team_id}/recordings and /api/v1/kb/{kb_id}/recordings; every
+// recording client method takes one of these plus the matching context ID so
+// team and Knowledge Bubble imports share a single code path.
 const (
-	videoImportURLPath = "/api/v1/teams/%s/recordings/import/url" // POST - %s = team_id
-	videoStatusPath    = "/api/v1/teams/%s/recordings/%s"         // GET - team_id, recording_id
-	videoListPath      = "/api/v1/teams/%s/recordings"            // GET - team_id
+	ContextTypeTeam = "team"
+	ContextTypeKB   = "kb"
 )
+
+// recordingsBase returns the recordings collection path for a context
+// ("/api/v1/teams/{id}/recordings" or "/api/v1/kb/{id}/recordings").
+// Validated here, once, so callers can't accidentally fabricate a path for an
+// unknown context type.
+func recordingsBase(contextType, contextID string) (string, error) {
+	if contextID == "" {
+		return "", fmt.Errorf("context ID is required")
+	}
+	switch contextType {
+	case ContextTypeTeam:
+		return fmt.Sprintf("/api/v1/teams/%s/recordings", contextID), nil
+	case ContextTypeKB:
+		return fmt.Sprintf("/api/v1/kb/%s/recordings", contextID), nil
+	default:
+		return "", fmt.Errorf("invalid context type %q (want %q or %q)", contextType, ContextTypeTeam, ContextTypeKB)
+	}
+}
 
 // ImportVideoURLRequest represents the POST request to import a video by URL
 type ImportVideoURLRequest struct {
@@ -73,10 +95,14 @@ type PaginationResponse struct {
 	HasMore bool `json:"has_more"`
 }
 
-// ImportVideoURL calls POST /api/v1/teams/{team_id}/recordings/import/url
+// ImportVideoURL calls POST /api/v1/{teams|kb}/{id}/recordings/import/url
 // Returns nil, nil if the endpoint returns 404 (graceful degradation)
-func (c *RepoClient) ImportVideoURL(teamID string, req *ImportVideoURLRequest) (*ImportVideoURLResponse, error) {
-	reqURL := strings.TrimSuffix(c.baseURL, "/") + fmt.Sprintf(videoImportURLPath, teamID)
+func (c *RepoClient) ImportVideoURL(contextType, contextID string, req *ImportVideoURLRequest) (*ImportVideoURLResponse, error) {
+	base, err := recordingsBase(contextType, contextID)
+	if err != nil {
+		return nil, err
+	}
+	reqURL := strings.TrimSuffix(c.baseURL, "/") + base + "/import/url"
 
 	bodyBytes, err := json.Marshal(req)
 	if err != nil {
@@ -137,10 +163,14 @@ func (c *RepoClient) ImportVideoURL(teamID string, req *ImportVideoURLRequest) (
 	return &importResp, nil
 }
 
-// GetVideoStatus calls GET /api/v1/teams/{team_id}/recordings/{recording_id}
+// GetVideoStatus calls GET /api/v1/{teams|kb}/{id}/recordings/{recording_id}
 // Returns nil, nil on 404 (graceful degradation); all other errors are returned.
-func (c *RepoClient) GetVideoStatus(teamID, recordingID string) (*VideoStatusResponse, error) {
-	reqURL := strings.TrimSuffix(c.baseURL, "/") + fmt.Sprintf(videoStatusPath, teamID, recordingID)
+func (c *RepoClient) GetVideoStatus(contextType, contextID, recordingID string) (*VideoStatusResponse, error) {
+	base, err := recordingsBase(contextType, contextID)
+	if err != nil {
+		return nil, err
+	}
+	reqURL := strings.TrimSuffix(c.baseURL, "/") + base + "/" + recordingID
 
 	logger.LogHTTPRequest("GET", reqURL)
 	start := time.Now()
@@ -191,10 +221,14 @@ func (c *RepoClient) GetVideoStatus(teamID, recordingID string) (*VideoStatusRes
 	return &statusResp, nil
 }
 
-// ListVideos calls GET /api/v1/teams/{team_id}/recordings with pagination
+// ListVideos calls GET /api/v1/{teams|kb}/{id}/recordings with pagination
 // Returns nil, nil on 404 (graceful degradation)
-func (c *RepoClient) ListVideos(teamID string, limit, offset int) (*ListVideosResponse, error) {
-	reqURL := strings.TrimSuffix(c.baseURL, "/") + fmt.Sprintf(videoListPath, teamID)
+func (c *RepoClient) ListVideos(contextType, contextID string, limit, offset int) (*ListVideosResponse, error) {
+	base, err := recordingsBase(contextType, contextID)
+	if err != nil {
+		return nil, err
+	}
+	reqURL := strings.TrimSuffix(c.baseURL, "/") + base
 	reqURL += fmt.Sprintf("?limit=%d&offset=%d", limit, offset)
 
 	logger.LogHTTPRequest("GET", reqURL)
@@ -244,4 +278,209 @@ func (c *RepoClient) ListVideos(teamID string, limit, offset int) (*ListVideosRe
 	}
 
 	return &listResp, nil
+}
+
+// --- bulk recording-file import (POST …/recordings/import) ---
+
+// ImportRecordingFileRequest is the metadata sent to
+// POST /api/v1/{teams|kb}/{id}/recordings/import. The server validates the
+// format, creates a recording row with source="import", and returns a
+// presigned PUT URL for the file content.
+type ImportRecordingFileRequest struct {
+	Filename    string     `json:"filename"`
+	ContentType string     `json:"content_type,omitempty"`
+	Size        int64      `json:"size"`
+	Title       string     `json:"title,omitempty"`
+	Description string     `json:"description,omitempty"`
+	RecordedAt  *time.Time `json:"recorded_at,omitempty"` // back-dates historical imports
+}
+
+// importRecordingInitResponse is the wire shape returned by the import-init
+// POST. Only the fields the client acts on are decoded; the server may send
+// more (status, created_at, upload.fields, …).
+type importRecordingInitResponse struct {
+	RecordingID string `json:"recording_id"`
+	Upload      struct {
+		UploadURL string    `json:"upload_url"`
+		ExpiresAt time.Time `json:"expires_at"`
+	} `json:"upload"`
+	Status string `json:"status"`
+}
+
+// completeRecordingRequest is the body for POST …/recordings/{rec_id}/complete.
+// Imports are a single presigned PUT, never chunked, so chunk_count is omitted —
+// the server branches on metadata.source="import".
+type completeRecordingRequest struct {
+	TotalSize int64 `json:"total_size"`
+}
+
+// ImportRecordingFileResult is the final state after the 3-step import flow.
+type ImportRecordingFileResult struct {
+	RecordingID string `json:"recording_id"`
+	Status      string `json:"status"`
+}
+
+// ImportRecordingFile imports a pre-existing local media file as a recording
+// using the 3-step flow:
+//
+//  1. POST {base}/import with file metadata → recording_id + presigned PUT URL
+//  2. PUT the file bytes to the presigned URL (streamed from disk)
+//  3. POST {base}/{recording_id}/complete to finalize and kick off processing
+//
+// Returns nil, nil if step 1 returns 404 (endpoint not yet deployed —
+// graceful degradation, matching ImportVideoURL). meta.Size is always taken
+// from the file on disk so the presigned request can never disagree with the
+// bytes actually uploaded.
+func (c *RepoClient) ImportRecordingFile(ctx context.Context, contextType, contextID, filePath string, meta ImportRecordingFileRequest) (*ImportRecordingFileResult, error) {
+	base, err := recordingsBase(contextType, contextID)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("stat media file: %w", err)
+	}
+	meta.Size = info.Size()
+	if meta.Size <= 0 {
+		return nil, fmt.Errorf("media file is empty: %s", filePath)
+	}
+
+	// step 1: initialize the import, get the presigned PUT URL
+	initURL := strings.TrimSuffix(c.baseURL, "/") + base + "/import"
+	status, respBody, err := c.postJSON(ctx, initURL, meta)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusNotFound {
+		return nil, nil
+	}
+	if status < 200 || status >= 300 {
+		return nil, httpStatusError(status, initURL, respBody)
+	}
+
+	var initResp importRecordingInitResponse
+	if err := json.Unmarshal(respBody, &initResp); err != nil {
+		return nil, fmt.Errorf("decode import response: %w", err)
+	}
+	if initResp.RecordingID == "" || initResp.Upload.UploadURL == "" {
+		return nil, fmt.Errorf("import response missing recording_id or upload_url")
+	}
+
+	// step 2: stream the file to the presigned URL
+	if err := c.uploadFilePut(ctx, initResp.Upload.UploadURL, filePath, meta.ContentType, meta.Size); err != nil {
+		return nil, fmt.Errorf("upload media file: %w", err)
+	}
+
+	// step 3: finalize — this flips status and starts server-side processing
+	completeURL := strings.TrimSuffix(c.baseURL, "/") + base + "/" + initResp.RecordingID + "/complete"
+	status, respBody, err = c.postJSON(ctx, completeURL, completeRecordingRequest{TotalSize: meta.Size})
+	if err != nil {
+		return nil, err
+	}
+	if status < 200 || status >= 300 {
+		return nil, httpStatusError(status, completeURL, respBody)
+	}
+
+	result := &ImportRecordingFileResult{RecordingID: initResp.RecordingID, Status: initResp.Status}
+	// the complete response carries the authoritative post-finalize status;
+	// tolerate a missing/empty body since the recording ID is already known
+	var completeResp ImportRecordingFileResult
+	if err := json.Unmarshal(respBody, &completeResp); err == nil && completeResp.Status != "" {
+		result.Status = completeResp.Status
+	}
+	return result, nil
+}
+
+// postJSON sends an authenticated JSON POST and returns the status code and
+// raw response body. Shared by the import-init and complete legs.
+func (c *RepoClient) postJSON(ctx context.Context, reqURL string, body any) (int, []byte, error) {
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	logger.LogHTTPRequest("POST", reqURL)
+	start := time.Now()
+
+	httpReq, err := useragent.NewRequest(ctx, "POST", reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.authToken != "" {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	duration := time.Since(start)
+	if err != nil {
+		logger.LogHTTPError("POST", reqURL, err, duration)
+		return 0, nil, fmt.Errorf("network error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	logger.LogHTTPResponse("POST", reqURL, resp.StatusCode, duration)
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+// uploadFilePut streams a local file to a presigned PUT URL. The file is never
+// read fully into memory — the open handle is the request body and
+// ContentLength is set explicitly (required because net/http cannot infer the
+// length of an *os.File body).
+func (c *RepoClient) uploadFilePut(ctx context.Context, uploadURL, filePath, contentType string, size int64) error {
+	f, err := os.Open(filePath) //nolint:gosec // G304 — path is the user's own import argument
+	if err != nil {
+		return fmt.Errorf("open media file: %w", err)
+	}
+	defer f.Close()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, f)
+	if err != nil {
+		return fmt.Errorf("create upload request: %w", err)
+	}
+	httpReq.ContentLength = size
+	if contentType != "" {
+		// presigned URLs may sign the Content-Type; it must match what the
+		// server was told at import-init time
+		httpReq.Header.Set("Content-Type", contentType)
+	}
+
+	logger.LogHTTPRequest("PUT", uploadURL)
+	start := time.Now()
+
+	// media files routinely exceed the client's default 10s timeout — use a
+	// dedicated transport-default client and rely on ctx for cancellation
+	uploadClient := &http.Client{}
+	resp, err := uploadClient.Do(httpReq)
+	duration := time.Since(start)
+	if err != nil {
+		logger.LogHTTPError("PUT", uploadURL, err, duration)
+		return fmt.Errorf("network error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	logger.LogHTTPResponse("PUT", uploadURL, resp.StatusCode, duration)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return httpStatusError(resp.StatusCode, uploadURL, respBody)
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// httpStatusError formats a non-2xx response into the same error shape the
+// other video methods produce.
+func httpStatusError(status int, reqURL string, body []byte) error {
+	errMsg := strings.TrimSpace(string(body))
+	if errMsg == "" {
+		return fmt.Errorf("HTTP %d from %s", status, reqURL)
+	}
+	return fmt.Errorf("HTTP %d from %s: %s", status, reqURL, errMsg)
 }

--- a/internal/api/video_test.go
+++ b/internal/api/video_test.go
@@ -48,7 +48,7 @@ func TestImportVideoURL_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.ImportVideoURL("team-123", &ImportVideoURLRequest{
+	resp, err := client.ImportVideoURL(ContextTypeTeam, "team-123", &ImportVideoURLRequest{
 		URL:   "https://example.com/meeting.mp4",
 		Title: "Team Standup",
 	})
@@ -68,7 +68,7 @@ func TestImportVideoURL_404_ReturnsNil(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.ImportVideoURL("team-123", &ImportVideoURLRequest{URL: "https://example.com/v.mp4"})
+	resp, err := client.ImportVideoURL(ContextTypeTeam, "team-123", &ImportVideoURLRequest{URL: "https://example.com/v.mp4"})
 
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
@@ -83,7 +83,7 @@ func TestImportVideoURL_500_ReturnsError(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.ImportVideoURL("team-123", &ImportVideoURLRequest{URL: "https://example.com/v.mp4"})
+	resp, err := client.ImportVideoURL(ContextTypeTeam, "team-123", &ImportVideoURLRequest{URL: "https://example.com/v.mp4"})
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
@@ -110,7 +110,7 @@ func TestGetVideoStatus_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.GetVideoStatus("team-123", "rec_abc")
+	resp, err := client.GetVideoStatus(ContextTypeTeam, "team-123", "rec_abc")
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -126,7 +126,7 @@ func TestGetVideoStatus_404_ReturnsNil(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.GetVideoStatus("team-123", "rec_nonexistent")
+	resp, err := client.GetVideoStatus(ContextTypeTeam, "team-123", "rec_nonexistent")
 
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
@@ -139,7 +139,7 @@ func TestGetVideoStatus_NetworkError_ReturnsError(t *testing.T) {
 	server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.GetVideoStatus("team-123", "rec_abc")
+	resp, err := client.GetVideoStatus(ContextTypeTeam, "team-123", "rec_abc")
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
@@ -155,7 +155,7 @@ func TestGetVideoStatus_500_ReturnsError(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.GetVideoStatus("team-123", "rec_abc")
+	resp, err := client.GetVideoStatus(ContextTypeTeam, "team-123", "rec_abc")
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
@@ -186,7 +186,7 @@ func TestListVideos_Success(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.ListVideos("team-123", 50, 0)
+	resp, err := client.ListVideos(ContextTypeTeam, "team-123", 50, 0)
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -204,7 +204,7 @@ func TestListVideos_404_ReturnsNil(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.ListVideos("team-123", 50, 0)
+	resp, err := client.ListVideos(ContextTypeTeam, "team-123", 50, 0)
 
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
@@ -219,7 +219,7 @@ func TestListVideos_500_ReturnsError(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.ListVideos("team-123", 50, 0)
+	resp, err := client.ListVideos(ContextTypeTeam, "team-123", 50, 0)
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
@@ -232,7 +232,7 @@ func TestListVideos_NetworkError_ReturnsError(t *testing.T) {
 	server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.ListVideos("team-123", 50, 0)
+	resp, err := client.ListVideos(ContextTypeTeam, "team-123", 50, 0)
 
 	require.Error(t, err)
 	assert.Nil(t, resp)
@@ -251,7 +251,7 @@ func TestListVideos_EmptyResponse(t *testing.T) {
 	defer server.Close()
 
 	client := newTestClient(server.URL)
-	resp, err := client.ListVideos("team-123", 50, 0)
+	resp, err := client.ListVideos(ContextTypeTeam, "team-123", 50, 0)
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)


### PR DESCRIPTION
## Summary

`ox import` historically targeted **team contexts only**. This PR brings **Knowledge Bubbles** to parity for the import paths that flow through the cloud recording pipeline, via a new `--kb <slug|kb_id>` flag — mutually exclusive with `--team`.

- **New `--kb` flag** on `ox import`: media files and video URLs can now be imported into a Knowledge Bubble. Cobra enforces mutual exclusion with `--team`; the resolver also double-checks defensively for callers that set flag globals directly (tests).
- **Context-typed recordings API client** (`internal/api/video.go`): every recording method now takes a context type (`team` | `kb`) + ID. The backend mounts the same routes under `/api/v1/teams/{id}/recordings` and `/api/v1/kb/{id}/recordings`, so team and KB imports share one code path. `recordingsBase()` validates the context type in one place so callers can't fabricate a path for an unknown type.
- **New recording-file upload flow** for local media into a KB: 3-step `POST …/recordings/import` → presigned `PUT` → `POST …/{rec_id}/complete`. The file is streamed to the presigned URL (open handle as the request body, explicit `ContentLength`) — never read fully into memory — on a dedicated client without the default 10s timeout, since media uploads routinely exceed it.
- **Team behavior is unchanged.** `ox import file.mp4` (no flag / `--team`) still uses the document-LFS path, which the backend already routes to transcription (`video/*` → `ImportVideoFileWorkflow`, `audio/*` → `ImportAudioWorkflow`). The new `…/recordings/import` endpoint is used **only for `--kb`**.
- **KB document import is deferred** with a clear error pointing at `--team`: there is no `/api/v1/kb/{kb_id}/context/import` route today (document content reaches a KB via the MCP `SaveToBubble` path). The dispatch in `runImport` is the single seam to revisit if that route ever ships.

### The three things called "import"

| Mechanism | Transport | Team | Knowledge Bubble |
|---|---|---|---|
| URL-video import | `POST …/recordings/import/url` | existing | **this PR** (route already mounted) |
| Bulk recording-file import (new) | `POST …/recordings/import` to presigned PUT to `…/{rec_id}/complete` | not used (team media stays on doc-LFS) | **this PR** |
| Document-LFS import (incl. media, transcribed) | LFS upload + git commit/push + `…/context/import` notify | existing | **deferred** (no backend route) |

**Intentional asymmetry:** team media lands as a git-LFS doc in the team-context repo (history, pointers, repo-visible); KB media lands as a presigned-S3 recording row processed server-side (no git artifact). Unifying the two storage models is out of scope. Full decision record: `docs/specs/kb-import-parity.md`.

### Dispatch flow

```mermaid
flowchart TD
  A["ox import (file or url)"] --> B{"--kb set?"}
  B -->|"no"| T["team context (unchanged)"]
  T --> TU{"URL?"}
  TU -->|"yes"| TURL["runImportURL via team recordings"]
  TU -->|"no"| TDOC["document-LFS path (media transcribed server-side)"]
  B -->|"yes"| K{"media file?"}
  K -->|"yes (mp4, mov, m4a, mp3, ...)"| KREC["runImportRecordingFile: 3-step presigned upload"]
  K -->|"no, is URL"| KURL["runImportURL via kb recordings"]
  K -->|"no, is document"| KERR["error: use --team for KB document import"]
```

## Test Plan

- `go build ./...` — clean.
- `go test ./cmd/ox/ ./internal/api/` for the import/recording/video suites — all green, including new coverage in `cmd/ox/import_recording_test.go`: KB recording-file happy path (mock 3-step server), team-vs-KB routing, KB document error, `--kb`/`--team` mutual exclusion, `isMediaImportFile`, context-type validation, and 404 graceful degradation.
- Existing team-import and video-URL tests updated to the context-typed signatures and still pass — confirming no behavior change for the team path.

**Pre-existing failures (NOT introduced by this PR):** `make lint` flags `internal/envutil/env_test.go:448` (missing `// safe:` annotation) and `TestMurmurJSONImportanceOverridesDefault` fails — both files are byte-identical to `origin/main` and unrelated to import. Left out of scope to keep this PR coherent; worth a separate fix.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (`cmd/ox/import_recording_test.go` + updated video/import suites)
- [ ] CHANGELOG entry — N/A (feature lands with backend bulk-import endpoint; CHANGELOG to follow at release)
- [x] Breaking change documented — none; `--kb` is additive, all existing invocations behave identically
- [x] Ran `/security-review` — N/A: no changes to `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum`. New file upload reads only the user's own import argument (annotated `//nolint:gosec G304`).

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--kb` flag to `ox import` command for Knowledge Bubble media and video URL ingestion
  * Added specification for rendering `ox plan` as self-contained HTML with visual badges and annotations

* **Documentation**
  * Added KB import parity specification defining import mechanisms and context-based routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->