### PR TITLE
feat(codedb): ADR-019 resolved symbol_edges (phase 1) + graphify PR triage (re-land #624 to main)

### DIFF
--- a/cmd/ox/code_prs.go
+++ b/cmd/ox/code_prs.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/codedb"
+	"github.com/sageox/ox/internal/codedb/query"
+	"github.com/sageox/ox/internal/repotools"
+	"github.com/spf13/cobra"
+)
+
+var codePRsCmd = &cobra.Command{
+	Use:   "prs",
+	Short: "List pull requests with triage signals",
+	Long: `List indexed pull requests ranked for triage.
+
+By default surfaces the most-stalled open PRs first (least-recent activity at
+the top — those most likely to need attention). All ranking signals are
+deterministic and computed from indexed GitHub data (no LLM ranking, no
+external API).
+
+Sort modes:
+  stalled  (default) — most idle PR first, where stalled-days = days since the
+                       most recent of updated_at or last comment.
+  age      — oldest PR by created_at first.
+  activity — most comments first.
+
+Each result row carries: age_days, stalled_days, comments, reviewers (distinct
+authors of review comments), discussants (distinct authors of discussion
+comments), commits, labels, URL.`,
+	Example: `  # default — most-stalled open PRs first, JSON for agents
+  ox code prs
+
+  # oldest open PRs first, limit 10
+  ox code prs --sort age --limit 10
+
+  # most-discussed closed PRs (e.g., for retrospectives)
+  ox code prs --state closed --sort activity`,
+	RunE: runCodePRs,
+}
+
+func init() {
+	codePRsCmd.Flags().Int("limit", 20, "max number of PRs to return")
+	codePRsCmd.Flags().String("sort", "stalled", "ranking: stalled | age | activity")
+	codePRsCmd.Flags().String("state", "open", "PR state: open | closed | merged | all")
+	codePRsCmd.Flags().Bool("pretty", false, "pretty-print JSON output")
+	codeCmd.AddCommand(codePRsCmd)
+}
+
+func runCodePRs(cmd *cobra.Command, _ []string) error {
+	root, err := repotools.FindRepoRoot(repotools.VCSGit)
+	if err != nil {
+		return fmt.Errorf("not in a git repository")
+	}
+
+	dataDir := resolveCodeDBDir(root)
+	if _, err := os.Stat(dataDir); os.IsNotExist(err) {
+		return fmt.Errorf("%s\n%s",
+			cli.StyleError.Render("No code index found"),
+			"Run "+cli.StyleCommand.Render("ox code index")+" to create one")
+	}
+
+	// SQL-only: triage reads from pull_requests + pr_comments + pr_commits, no
+	// bleve. Matches the `code activity` rationale — avoids being blocked by a
+	// corrupt/locked bleve sub-index.
+	db, err := codedb.OpenSQLOnly(dataDir)
+	if err != nil {
+		return fmt.Errorf("open codedb: %w", err)
+	}
+	defer db.Close()
+
+	limit, _ := cmd.Flags().GetInt("limit")
+	sort, _ := cmd.Flags().GetString("sort")
+	state, _ := cmd.Flags().GetString("state")
+
+	if !validTriageSort(sort) {
+		return fmt.Errorf("invalid --sort %q: must be one of stalled | age | activity", sort)
+	}
+	if !validTriageState(state) {
+		return fmt.Errorf("invalid --state %q: must be one of open | closed | merged | all", state)
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	results, err := query.TriagePRs(ctx, db.Store(), query.TriageOpts{
+		Limit: limit,
+		Sort:  sort,
+		State: state,
+	})
+	if err != nil {
+		return fmt.Errorf("triage PRs: %w", err)
+	}
+
+	resp := triagePRResponse{
+		Results: results,
+		Total:   len(results),
+		Sort:    sort,
+		State:   state,
+	}
+	if len(results) == 0 {
+		resp.Guidance = "No PRs matched. Indexed PR data? Try `ox index github` if this repo has GitHub data."
+	}
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal results: %w", err)
+	}
+	if pretty, _ := cmd.Flags().GetBool("pretty"); pretty {
+		var any json.RawMessage
+		if err := json.Unmarshal(out, &any); err == nil {
+			if indented, err := json.MarshalIndent(any, "", "  "); err == nil {
+				out = indented
+			}
+		}
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(out))
+	return nil
+}
+
+type triagePRResponse struct {
+	Results  []query.TriagedPR `json:"results"`
+	Total    int               `json:"total"`
+	Sort     string            `json:"sort"`
+	State    string            `json:"state"`
+	Guidance string            `json:"guidance,omitempty"`
+}
+
+func validTriageSort(s string) bool {
+	switch strings.ToLower(s) {
+	case "stalled", "age", "activity":
+		return true
+	}
+	return false
+}
+
+func validTriageState(s string) bool {
+	switch strings.ToLower(s) {
+	case "open", "closed", "merged", "all":
+		return true
+	}
+	return false
+}

--- a/docs/adr/ADR-019-codedb-resolved-symbol-edges.md
+++ b/docs/adr/ADR-019-codedb-resolved-symbol-edges.md
@@ -1,0 +1,205 @@
+# ADR-019: Resolved Symbol Edges for CodeDB
+
+**Status**: Proposed (needs Ryan — new data structure + changes call-graph search semantics)
+**Date**: 2026-05-27
+
+## Context
+
+CodeDB's "call graph" today is a **name-string match**, not a resolved edge
+set. `symbol_refs(symbol_id, ref_name, kind, blob_id, line, col)` records the
+*containing* symbol (where a call appears) and the *name* being called as a
+string. The `calls:` / `calledby:` query DSL joins via `LIKE '%name%'` or
+`ref_name = name` against `symbols.name` (`internal/codedb/search/translate.go`).
+
+There is no resolved `src → dst` edge. Two consequences:
+
+1. **Cross-file ambiguity.** Any name shared by multiple definitions
+   conflates them. Measured on the biggest live codedb (`repo_019c6d2e`,
+   40,250 symbols / 185,912 refs):
+
+   ```
+   top function-name collisions (defs per name):
+     string  640   bool    371   error   248   int     72   main   71
+     new      69   encode   60   decode   59   from    53   Register 33
+
+   ambiguous call refs (name shared by >1 function): 18.7% of 185,912
+   ```
+
+   Nearly one in five call references resolves to >1 candidate. `calls:Register`
+   returns hits from 33 unrelated definitions of `Register`.
+
+2. **No graph algorithms possible.** Without resolved edges there is no
+   well-formed directed graph to run centrality on, no shortest-path queries,
+   no community detection. Every graphify-style feature we want next
+   (`ox code path`, "god nodes" insights, architectural digest, module
+   communities) is blocked on this.
+
+[graphify](https://github.com/safishamsi/graphify) builds resolved, typed
+edges with confidence scoring and runs Leiden community detection + centrality
++ shortest path on the result. It uses tree-sitter for code (same library
+codedb uses via `gotreesitter`) plus LLM extraction for docs (out-of-scope per
+the project's "deterministic only" call from the earlier session). Resolved
+edges is the deterministic core that's portable.
+
+## Decision
+
+Add a **resolved-edge table** populated at index time by per-language
+resolvers. Replace the call-graph queries' name-match joins with index lookups
+on this table. Phase the rollout: same-file Go first (validates the model),
+then cross-file Go, then other languages.
+
+### Schema (`symbol_edges`)
+
+```sql
+CREATE TABLE symbol_edges (
+    id              INTEGER PRIMARY KEY,
+    src_blob_id     INTEGER NOT NULL REFERENCES blobs(id),
+    src_symbol_id   INTEGER NOT NULL REFERENCES symbols(id),  -- containing symbol
+    dst_blob_id     INTEGER          REFERENCES blobs(id),    -- nullable: external/stdlib
+    dst_symbol_id   INTEGER          REFERENCES symbols(id),  -- nullable: external/unresolved
+    dst_name        TEXT    NOT NULL,                         -- always known (the referenced name)
+    kind            TEXT    NOT NULL,                         -- call | reference | implements | inherits | imports
+    confidence      TEXT    NOT NULL,                         -- extracted | inferred | ambiguous
+    line            INTEGER NOT NULL,
+    col             INTEGER NOT NULL
+);
+
+CREATE INDEX idx_symbol_edges_src ON symbol_edges(src_symbol_id, kind);
+CREATE INDEX idx_symbol_edges_dst ON symbol_edges(dst_symbol_id, kind);
+CREATE INDEX idx_symbol_edges_dst_name ON symbol_edges(dst_name, kind);
+```
+
+Edges are **populated alongside `symbol_refs`** (which we keep for the
+unresolved-name path used by other queries; resolved edges are an additional
+layer, not a replacement). When a `symbol_refs` row can be resolved, an edge
+is inserted with the appropriate confidence; when it can't, the `symbol_refs`
+row alone records the unresolved name as today.
+
+### Confidence model
+
+| Level | Meaning |
+|---|---|
+| `extracted` | Tree-sitter + scope rules give a single definitive target (e.g., same-file private function called by an enclosing method) |
+| `inferred` | Best-guess via import graph + package symbol table; unique target after scope resolution |
+| `ambiguous` | Multiple plausible targets after resolution; we emit one edge per candidate with `ambiguous` so agents can see the spread |
+
+Edges with `confidence=ambiguous` cap fan-out at a small constant (e.g., 8
+candidates) to bound storage on pathological names.
+
+### Per-language resolver phases
+
+Resolver shape: given a blob's symbols + refs (output of `symbols.Extract`),
+produce a list of `(src_symbol_id, dst_blob_id?, dst_symbol_id?, kind, confidence)`.
+
+**Phase 1 — same-file scope (all 8 supported languages).** For each ref, walk
+up the containing-symbol tree; if a same-file symbol with matching name is in
+scope, emit an `extracted` edge. Otherwise leave unresolved. Cheap, language-
+agnostic, doesn't need import graphs. Catches private helpers, local methods.
+
+**Phase 2 — Go cross-file resolver.** Build a per-package symbol table from
+the indexed blobs (Go is uniform: package directory = package, exported = uppercase,
+qualified vs unqualified call distinguishable). For unresolved refs, look up
+the referenced name in the same package's symbol table (`inferred`). Qualified
+calls (`pkg.Func`) join to the package symbol table via the import path.
+
+**Phase 3 — Other languages.** Python (per-file imports), TypeScript/JavaScript
+(module imports), Rust (use statements + mod tree), C/C++ (per-file scope +
+includes, deferred — preprocessor is hard).
+
+Resolvers are pluggable per language (interface satisfied per-language) — Go
+ships first; others added incrementally without touching the storage layer.
+
+### Search read-path change
+
+`calls:Name` and `calledby:Name` switch from name-match to edge lookup:
+
+```sql
+-- calls:Name (callers of Name) — today: LIKE '%Name%' join
+-- proposed: index lookup on dst_name + dst_symbol_id resolution
+SELECT DISTINCT s_src.name, s_src.kind, fr.path
+FROM symbol_edges e
+JOIN symbols s_src ON s_src.id = e.src_symbol_id
+JOIN blobs b ON b.id = e.src_blob_id
+JOIN file_revs fr ON fr.blob_id = b.id
+WHERE e.dst_name = ? AND e.kind = 'call'
+```
+
+Multi-hop (`depth:N`) becomes a clean recursive CTE on `src_symbol_id ↔
+dst_symbol_id` instead of the current `LIKE`-bounded recursion.
+
+A query-time filter `confidence:extracted` (or `confidence:>=inferred`) lets
+agents constrain by certainty when precision matters.
+
+### Reindex / versioning
+
+Add `.needs_reindex_symbols` marker semantics analogous to ADR-018's bleve
+marker. When this ADR ships, existing codedbs need symbols re-parsed to
+populate `symbol_edges`. The `blobs.parsed` flag already exists — bump its
+meaning to "parsed at edge-resolver version N" via a small `blobs.edge_version`
+column, defaulting 0; resolver only processes rows where
+`edge_version < current_version`.
+
+## Consequences
+
+**Positive**
+- **Precision**: `calls:Foo` returns just the callers of *this* `Foo`, not the
+  18.7% spread we have today. Agents get correct call graphs.
+- **Unlocks the graphify port**: centrality (#2), shortest-path (#3),
+  architectural digest (#4), communities (#7) all depend on having a real
+  edge set.
+- **Fixes a slow query**: `LIKE '%name%'` in the call-graph CTE can't use an
+  index; the new lookup uses `idx_symbol_edges_dst_name`.
+
+**Negative / risk**
+- **New write-path cost**: per-blob resolver runs after symbol extraction.
+  Same-file phase is cheap (in-memory scope walk). Cross-file phase requires
+  a per-package symbol-table build at index time.
+- **Storage**: edges roughly proportional to `symbol_refs` (≤ same count;
+  fewer when unresolved refs dropped). On the 186k-ref repo, expect ~150k
+  edges → ~10–15 MB SQLite (with the three indexes).
+- **Data-access ergonomics change**: search results for `calls:` and
+  `calledby:` change semantics (correctly, but visibly). New `confidence`
+  filter is additive.
+- **Reindex required** on existing codedbs to populate edges.
+
+## Alternatives considered
+
+1. **Query-time resolution** (compute edges in the search planner from
+   `symbol_refs` + scope tables on every query). Avoids storage, but per-query
+   cost is high and rules out graph algorithms (need persistent edges for
+   centrality/communities). Rejected.
+2. **LLM-based resolution** (graphify's approach for non-tree-sitter content).
+   Conflicts with the deterministic-only call from earlier session. Rejected.
+3. **Keep status quo + add confidence as a hint** (don't resolve, just flag
+   names that have >1 definition). Improves agent awareness but doesn't fix
+   precision and doesn't unlock graph algorithms. Rejected.
+
+## Phasing
+
+| Phase | Scope | Why first / why later |
+|---|---|---|
+| **1** | Schema + same-file resolver (all 8 langs) + new search SQL + tests | Validates the model end-to-end on a cheap resolver; all 8 langs trivially because containment scope is language-agnostic at tree-sitter level |
+| **2** | Go cross-file resolver (package symbol tables) | Go is uniform/strict (good first non-trivial case); also our own codebase, easy to validate qualitatively |
+| **3** | Centrality / `god nodes` (graphify #2), `ox code path` (graphify #3), digest (graphify #4) | Built on the now-real edge set |
+| **4** | Per-language resolvers for Python / TS / Rust / Java | Each is a focused, isolated addition once the framework is proven |
+| **5** | Leiden community detection (graphify #7) | Defer until centrality/path prove the edge set is useful |
+
+## Open questions for review
+
+1. **Edges as a table vs. denormalized into `symbol_refs`?** Adding columns
+   to `symbol_refs` (e.g., `dst_symbol_id`, `confidence`) would avoid a join
+   but couples the resolved-edge concept to the existing schema. Proposed: a
+   separate `symbol_edges` table — clearer model, easier rollback.
+2. **Should `kind` distinguish `call` vs `reference` more finely** (e.g.,
+   include `read` vs `write` vs `call`)? Today's `symbol_refs.kind` has
+   `call`/`reference`/`definition`; proposed: edges carry the same vocabulary
+   plus `implements` / `inherits` / `imports` over time.
+3. **Ambiguity cap.** 8 candidates per ambiguous ref seems right for the
+   biggest collisions (`string`→640 defs would otherwise blow up the table).
+   Confirm or pick a different cap.
+4. **Edge-version bump strategy.** Same `.needs_reindex_<name>` pattern from
+   ADR-018, OR a separate per-blob version column? Proposed: per-blob column
+   (`blobs.edge_version`) — fine-grained, incremental.
+5. **Search-result schema.** Should `calls:`/`calledby:` results carry the
+   `confidence` field (so agents can filter or weight)? Proposed: yes,
+   plumbed through.

--- a/docs/adr/ADR-019-codedb-resolved-symbol-edges.md
+++ b/docs/adr/ADR-019-codedb-resolved-symbol-edges.md
@@ -1,3 +1,4 @@
+<!-- doc-audience: ai -->
 # ADR-019: Resolved Symbol Edges for CodeDB
 
 **Status**: Proposed (needs Ryan — new data structure + changes call-graph search semantics)

--- a/internal/codedb/codedb.go
+++ b/internal/codedb/codedb.go
@@ -127,6 +127,14 @@ func (db *DB) ParseComments(ctx context.Context, progress func(string)) (index.C
 	return index.ParseComments(ctx, db.store, index.ProgressFunc(progress))
 }
 
+// BackfillSymbolEdges populates ADR-019 symbol_edges for blobs that were
+// parsed before the resolver landed (or before a resolver version bump).
+// Idempotent and cheap (pure SQL, no tree-sitter); daemons call it after
+// every index pass so codedbs upgrade without operator action.
+func (db *DB) BackfillSymbolEdges(ctx context.Context, progress func(string)) (index.BackfillStats, error) {
+	return index.BackfillSymbolEdges(ctx, db.store, index.ProgressFunc(progress))
+}
+
 // IndexGitHubData reads PR/issue JSON files from the ledger and indexes them into CodeDB.
 func (db *DB) IndexGitHubData(ctx context.Context, ledgerPath string, progress func(string)) (*index.GitHubIndexStats, error) {
 	return index.IndexGitHubData(ctx, db.store, ledgerPath, index.ProgressFunc(progress))

--- a/internal/codedb/index/backfill_edges.go
+++ b/internal/codedb/index/backfill_edges.go
@@ -1,0 +1,219 @@
+package index
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/sageox/ox/internal/codedb/symbols"
+)
+
+// BackfillStats holds counts from a BackfillSymbolEdges pass.
+type BackfillStats struct {
+	BlobsProcessed uint64
+	EdgesInserted  uint64
+}
+
+// backfillChunkSize bounds how many blobs are loaded and resolved per
+// transaction. Backfill reads symbols + symbol_refs from SQL (no tree-sitter
+// re-parsing) so the per-blob cost is small; the chunk size still caps peak
+// memory and tx duration on huge repos.
+const backfillChunkSize = 256
+
+// BackfillSymbolEdges resolves and inserts symbol_edges for parsed blobs that
+// don't yet have edges at the current resolver version (ADR-019 phase 1).
+//
+// Idempotent: blobs with edge_version >= ResolverVersion are skipped. Runs
+// pure-SQL (load symbols + symbol_refs, in-memory resolve, batched insert);
+// no tree-sitter, no blob reads. Safe and cheap to run after every index
+// pass — the daemon does so as part of doIndex so codedbs upgrade
+// automatically without operator intervention.
+func BackfillSymbolEdges(ctx context.Context, s *store.Store, progress ProgressFunc) (BackfillStats, error) {
+	report := func(msg string) {
+		if progress != nil {
+			progress(msg)
+		}
+	}
+
+	var stats BackfillStats
+
+	rows, err := s.QueryContext(ctx,
+		"SELECT id FROM blobs WHERE parsed = 1 AND edge_version < ?",
+		symbols.ResolverVersion)
+	if err != nil {
+		return stats, fmt.Errorf("query blobs needing edge backfill: %w", err)
+	}
+	var blobIDs []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return stats, fmt.Errorf("scan blob id: %w", err)
+		}
+		blobIDs = append(blobIDs, id)
+	}
+	rows.Close()
+
+	if len(blobIDs) == 0 {
+		report("Edge backfill: nothing to do (all parsed blobs at current resolver version).")
+		return stats, nil
+	}
+	report(fmt.Sprintf("Edge backfill: %d blobs to process", len(blobIDs)))
+
+	for start := 0; start < len(blobIDs); start += backfillChunkSize {
+		end := min(start+backfillChunkSize, len(blobIDs))
+		bp, ei, err := backfillEdgeChunk(ctx, s, blobIDs[start:end])
+		stats.BlobsProcessed += bp
+		stats.EdgesInserted += ei
+		if err != nil {
+			return stats, err
+		}
+		report(fmt.Sprintf("Edge backfill: %d/%d blobs", end, len(blobIDs)))
+	}
+
+	report(fmt.Sprintf("Edge backfill complete: %d blobs, %d edges inserted",
+		stats.BlobsProcessed, stats.EdgesInserted))
+	return stats, nil
+}
+
+// backfillEdgeChunk processes one chunk's worth of blobs in a single tx.
+// Returns counts only on a successful commit; on any error the tx rolls back
+// and (0, 0, err) is returned so accumulated stats stay consistent.
+func backfillEdgeChunk(ctx context.Context, s *store.Store, blobIDs []int64) (blobsProcessed, edgesInserted uint64, err error) {
+	tx, err := s.Begin()
+	if err != nil {
+		return 0, 0, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	for _, blobID := range blobIDs {
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
+
+		syms, symDBIDs, err := loadBlobSymbols(ctx, tx, blobID)
+		if err != nil {
+			return 0, 0, err
+		}
+		refs, err := loadBlobRefs(ctx, tx, blobID, symDBIDs)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		edgesBefore, err := countBlobEdges(ctx, tx, blobID)
+		if err != nil {
+			return 0, 0, err
+		}
+		if err := insertSymbolEdges(tx, blobID, syms, refs, symDBIDs); err != nil {
+			return 0, 0, fmt.Errorf("backfill edges for blob %d: %w", blobID, err)
+		}
+		edgesAfter, err := countBlobEdges(ctx, tx, blobID)
+		if err != nil {
+			return 0, 0, err
+		}
+		edgesInserted += uint64(edgesAfter - edgesBefore)
+
+		if _, err := tx.ExecContext(ctx,
+			"UPDATE blobs SET edge_version = ? WHERE id = ?",
+			symbols.ResolverVersion, blobID,
+		); err != nil {
+			return 0, 0, fmt.Errorf("update edge_version for blob %d: %w", blobID, err)
+		}
+		blobsProcessed++
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, 0, fmt.Errorf("commit backfill chunk: %w", err)
+	}
+	return blobsProcessed, edgesInserted, nil
+}
+
+// loadBlobSymbols reads all symbols for a blob in their insertion order and
+// returns the reconstructed symbols.Symbol slice + the parallel slice of DB
+// ids needed for edge insertion. ParentIdx is left at -1 because the
+// resolver doesn't consult it for same-file scope today.
+func loadBlobSymbols(ctx context.Context, tx *sql.Tx, blobID int64) ([]symbols.Symbol, []int64, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT id, name, kind, line, col, COALESCE(end_line, 0), COALESCE(end_col, 0),
+		        COALESCE(signature, ''), COALESCE(return_type, ''), COALESCE(params, '')
+		 FROM symbols WHERE blob_id = ? ORDER BY id`,
+		blobID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load symbols for blob %d: %w", blobID, err)
+	}
+	defer rows.Close()
+
+	var syms []symbols.Symbol
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		var name, kind, sig, retType, params string
+		var line, col, endLine, endCol int
+		if err := rows.Scan(&id, &name, &kind, &line, &col, &endLine, &endCol, &sig, &retType, &params); err != nil {
+			return nil, nil, fmt.Errorf("scan symbol row for blob %d: %w", blobID, err)
+		}
+		ids = append(ids, id)
+		syms = append(syms, symbols.Symbol{
+			Name: name, Kind: kind, Line: line, Col: col,
+			EndLine: endLine, EndCol: endCol,
+			Signature: sig, ReturnType: retType, Params: params,
+			ParentIdx: -1,
+		})
+	}
+	return syms, ids, rows.Err()
+}
+
+// loadBlobRefs reads symbol_refs for a blob and recovers ContainingSymIdx by
+// mapping each row's stored symbol_id back to its index in symDBIDs (which is
+// the order loadBlobSymbols returned). Refs whose stored symbol_id is NULL or
+// not in the map get ContainingSymIdx = -1 (file-scope; resolver drops them).
+func loadBlobRefs(ctx context.Context, tx *sql.Tx, blobID int64, symDBIDs []int64) ([]symbols.Ref, error) {
+	idToIdx := make(map[int64]int, len(symDBIDs))
+	for i, id := range symDBIDs {
+		idToIdx[id] = i
+	}
+
+	rows, err := tx.QueryContext(ctx,
+		"SELECT ref_name, kind, line, col, symbol_id FROM symbol_refs WHERE blob_id = ?",
+		blobID)
+	if err != nil {
+		return nil, fmt.Errorf("load refs for blob %d: %w", blobID, err)
+	}
+	defer rows.Close()
+
+	var refs []symbols.Ref
+	for rows.Next() {
+		var refName, kind string
+		var line, col int
+		var containingSymID sql.NullInt64
+		if err := rows.Scan(&refName, &kind, &line, &col, &containingSymID); err != nil {
+			return nil, fmt.Errorf("scan ref row for blob %d: %w", blobID, err)
+		}
+		containingIdx := -1
+		if containingSymID.Valid {
+			if idx, ok := idToIdx[containingSymID.Int64]; ok {
+				containingIdx = idx
+			}
+		}
+		refs = append(refs, symbols.Ref{
+			RefName: refName, Kind: kind, Line: line, Col: col,
+			ContainingSymIdx: containingIdx,
+		})
+	}
+	return refs, rows.Err()
+}
+
+// countBlobEdges returns the number of symbol_edges rows currently in the
+// transaction for the given blob. Used by backfill to attribute the
+// per-blob edge insertion count (insertSymbolEdges is shared with the
+// inline ParseSymbols path and doesn't return a count).
+func countBlobEdges(ctx context.Context, tx *sql.Tx, blobID int64) (int, error) {
+	var n int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM symbol_edges WHERE src_blob_id = ?", blobID,
+	).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}

--- a/internal/codedb/index/backfill_edges_test.go
+++ b/internal/codedb/index/backfill_edges_test.go
@@ -1,0 +1,116 @@
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/codedb/store"
+	"github.com/sageox/ox/internal/codedb/symbols"
+)
+
+// TestBackfillSymbolEdges_PopulatesEdgesAndBumpsVersion seeds the SQLite half
+// of a store with a parsed blob (edge_version=0) plus its symbols+refs, runs
+// BackfillSymbolEdges, and verifies: (a) an edge was inserted with the
+// expected src/dst/confidence, (b) edge_version was bumped to current, (c) a
+// second backfill is a no-op (idempotent).
+func TestBackfillSymbolEdges_PopulatesEdgesAndBumpsVersion(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Seed one repo + one commit + one blob (parsed=1, edge_version=0).
+	_, err = s.Exec("INSERT INTO repos (id, name, path) VALUES (1, 'test', '/tmp/test')")
+	require.NoError(t, err)
+	_, err = s.Exec("INSERT INTO commits (id, repo_id, hash) VALUES (1, 1, 'abc')")
+	require.NoError(t, err)
+	_, err = s.Exec("INSERT INTO blobs (id, content_hash, language, parsed, edge_version) VALUES (1, 'h1', 'go', 1, 0)")
+	require.NoError(t, err)
+	_, err = s.Exec("INSERT INTO file_revs (id, commit_id, path, blob_id) VALUES (1, 1, 'main.go', 1)")
+	require.NoError(t, err)
+
+	// Two symbols: helper (callee, id=10) and caller (id=11).
+	_, err = s.Exec("INSERT INTO symbols (id, blob_id, name, kind, line, col) VALUES (10, 1, 'helper', 'function', 1, 1)")
+	require.NoError(t, err)
+	_, err = s.Exec("INSERT INTO symbols (id, blob_id, name, kind, line, col) VALUES (11, 1, 'caller', 'function', 5, 1)")
+	require.NoError(t, err)
+
+	// A call ref from caller (containing symbol_id=11) to "helper".
+	_, err = s.Exec("INSERT INTO symbol_refs (blob_id, symbol_id, ref_name, kind, line, col) VALUES (1, 11, 'helper', 'call', 6, 5)")
+	require.NoError(t, err)
+
+	// Sanity: edge_version starts at 0, no edges yet.
+	var ver int
+	require.NoError(t, s.QueryRow("SELECT edge_version FROM blobs WHERE id=1").Scan(&ver))
+	require.Equal(t, 0, ver)
+	var edges int
+	require.NoError(t, s.QueryRow("SELECT COUNT(*) FROM symbol_edges WHERE src_blob_id=1").Scan(&edges))
+	require.Equal(t, 0, edges)
+
+	// Run backfill.
+	stats, err := BackfillSymbolEdges(context.Background(), s, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), stats.BlobsProcessed)
+	require.Equal(t, uint64(1), stats.EdgesInserted)
+
+	// Verify the edge: src=11 (caller), dst=10 (helper), inferred (single same-file match).
+	var srcID, dstID int64
+	var dstName, kind, confidence string
+	require.NoError(t, s.QueryRow(
+		`SELECT src_symbol_id, dst_symbol_id, dst_name, kind, confidence
+		 FROM symbol_edges WHERE src_blob_id=1`,
+	).Scan(&srcID, &dstID, &dstName, &kind, &confidence))
+	require.Equal(t, int64(11), srcID)
+	require.Equal(t, int64(10), dstID)
+	require.Equal(t, "helper", dstName)
+	require.Equal(t, "call", kind)
+	require.Equal(t, "inferred", confidence)
+
+	// edge_version bumped to current.
+	require.NoError(t, s.QueryRow("SELECT edge_version FROM blobs WHERE id=1").Scan(&ver))
+	require.Equal(t, symbols.ResolverVersion, ver)
+
+	// Idempotent: re-run is a no-op.
+	stats2, err := BackfillSymbolEdges(context.Background(), s, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), stats2.BlobsProcessed,
+		"second backfill must skip blobs already at current resolver version")
+}
+
+// TestBackfillSymbolEdges_AmbiguousFansOut verifies the resolver's ambiguity
+// policy survives the SQL round-trip: a name shared by multiple same-file
+// symbols produces one "ambiguous" edge per candidate.
+func TestBackfillSymbolEdges_AmbiguousFansOut(t *testing.T) {
+	s, err := store.Open(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	_, err = s.Exec("INSERT INTO repos (id, name, path) VALUES (1, 't', '/tmp')")
+	require.NoError(t, err)
+	_, err = s.Exec("INSERT INTO commits (id, repo_id, hash) VALUES (1, 1, 'abc')")
+	require.NoError(t, err)
+	_, err = s.Exec("INSERT INTO blobs (id, content_hash, language, parsed, edge_version) VALUES (1, 'h', 'go', 1, 0)")
+	require.NoError(t, err)
+	_, err = s.Exec("INSERT INTO file_revs (id, commit_id, path, blob_id) VALUES (1, 1, 'm.go', 1)")
+	require.NoError(t, err)
+	// Three same-name targets + one caller.
+	for i, id := range []int{1, 2, 3} {
+		_, err = s.Exec("INSERT INTO symbols (id, blob_id, name, kind, line, col) VALUES (?, 1, 'Process', 'function', ?, 1)", id, i+1)
+		require.NoError(t, err)
+	}
+	_, err = s.Exec("INSERT INTO symbols (id, blob_id, name, kind, line, col) VALUES (100, 1, 'caller', 'function', 10, 1)")
+	require.NoError(t, err)
+	_, err = s.Exec("INSERT INTO symbol_refs (blob_id, symbol_id, ref_name, kind, line, col) VALUES (1, 100, 'Process', 'call', 11, 5)")
+	require.NoError(t, err)
+
+	stats, err := BackfillSymbolEdges(context.Background(), s, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), stats.EdgesInserted, "one edge per same-name candidate")
+
+	var n int
+	require.NoError(t, s.QueryRow(
+		"SELECT COUNT(*) FROM symbol_edges WHERE src_blob_id=1 AND confidence='ambiguous'",
+	).Scan(&n))
+	require.Equal(t, 3, n)
+}

--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -1796,6 +1796,14 @@ func ParseSymbols(ctx context.Context, s *store.Store, progress ProgressFunc) (P
 		if err := insertSymbolEdges(tx, blob.id, syms, refs, symDBIDs); err != nil {
 			return stats, fmt.Errorf("insert symbol edges: %w", err)
 		}
+		// Stamp the resolver version on the blob so BackfillSymbolEdges can
+		// distinguish "already at current resolver" from "needs backfill".
+		if _, err := tx.ExecContext(ctx,
+			"UPDATE blobs SET edge_version = ? WHERE id = ?",
+			symbols.ResolverVersion, blob.id,
+		); err != nil {
+			return stats, fmt.Errorf("update blob edge_version: %w", err)
+		}
 
 		if err := txq.MarkBlobParsed(ctx, blob.id); err != nil {
 			return stats, fmt.Errorf("mark blob parsed: %w", err)

--- a/internal/codedb/index/indexer.go
+++ b/internal/codedb/index/indexer.go
@@ -1790,6 +1790,13 @@ func ParseSymbols(ctx context.Context, s *store.Store, progress ProgressFunc) (P
 			}
 		}
 
+		// ADR-019 phase 1: resolve same-file edges (caller → callee) using
+		// the in-memory syms/refs we already extracted. Phase 1 is intra-blob
+		// only — cross-file resolution comes in later phases.
+		if err := insertSymbolEdges(tx, blob.id, syms, refs, symDBIDs); err != nil {
+			return stats, fmt.Errorf("insert symbol edges: %w", err)
+		}
+
 		if err := txq.MarkBlobParsed(ctx, blob.id); err != nil {
 			return stats, fmt.Errorf("mark blob parsed: %w", err)
 		}
@@ -1805,6 +1812,42 @@ func ParseSymbols(ctx context.Context, s *store.Store, progress ProgressFunc) (P
 		stats.BlobsParsed, stats.SymbolsExtracted))
 
 	return stats, nil
+}
+
+// insertSymbolEdges resolves same-file edges via symbols.Resolve and inserts
+// them in batches. ADR-019 phase 1 only emits intra-blob edges; cross-file
+// resolution comes later. No-op when the resolver returns nothing
+// (refs without same-file matches stay in symbol_refs for the name-fallback path).
+func insertSymbolEdges(tx *sql.Tx, blobID int64, syms []symbols.Symbol, refs []symbols.Ref, symDBIDs []int64) error {
+	edges := symbols.Resolve(syms, refs)
+	if len(edges) == 0 {
+		return nil
+	}
+	const edgeBatchSize = 50
+	for batchStart := 0; batchStart < len(edges); batchStart += edgeBatchSize {
+		batchEnd := min(batchStart+edgeBatchSize, len(edges))
+		batch := edges[batchStart:batchEnd]
+
+		var sb strings.Builder
+		sb.WriteString("INSERT INTO symbol_edges (src_blob_id, src_symbol_id, dst_blob_id, dst_symbol_id, dst_name, kind, confidence, line, col) VALUES ")
+		sqlArgs := make([]interface{}, 0, len(batch)*9)
+		for k, e := range batch {
+			if k > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString("(?,?,?,?,?,?,?,?,?)")
+			// Phase 1: src and dst are both in the same blob.
+			sqlArgs = append(sqlArgs,
+				blobID, symDBIDs[e.SrcIdx],
+				blobID, symDBIDs[e.DstIdx],
+				e.DstName, e.Kind, e.Confidence, e.Line, e.Col,
+			)
+		}
+		if _, err := tx.Exec(sb.String(), sqlArgs...); err != nil {
+			return fmt.Errorf("batch insert symbol edges: %w", err)
+		}
+	}
+	return nil
 }
 
 // parseBlobRow is a tip blob queued for comment extraction.

--- a/internal/codedb/query/triage.go
+++ b/internal/codedb/query/triage.go
@@ -1,0 +1,165 @@
+package query
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/codedb/store"
+)
+
+// TriagedPR is the agent-facing summary of a pull request with deterministic
+// ranking signals attached. All signals are computed from indexed GitHub data
+// (pull_requests, pr_comments, pr_commits) — no LLM ranking, no external API.
+type TriagedPR struct {
+	Number      int      `json:"number"`
+	Title       string   `json:"title"`
+	Author      string   `json:"author,omitempty"`
+	URL         string   `json:"url,omitempty"`
+	Labels      []string `json:"labels,omitempty"`
+	State       string   `json:"state"`
+	AgeDays     int      `json:"age_days"`     // days since created_at
+	StalledDays int      `json:"stalled_days"` // days since max(updated_at, last comment created_at)
+	Comments    int      `json:"comments"`     // total pr_comments rows
+	Reviewers   int      `json:"reviewers"`    // distinct comment authors with path != NULL (code reviews)
+	Discussants int      `json:"discussants"`  // distinct comment authors with path = NULL (discussion)
+	Commits     int      `json:"commits"`      // pr_commits rows
+}
+
+// TriageOpts configures PR triage queries.
+type TriageOpts struct {
+	Limit int    // default 20
+	Sort  string // "stalled" (default — most-idle first), "age" (oldest first), "activity" (most comments first)
+	State string // "open" (default), "closed", "merged", "all"
+}
+
+const (
+	defaultTriageLimit = 20
+	defaultTriageSort  = "stalled"
+	defaultTriageState = "open"
+)
+
+// TriagePRs returns ranked pull-request summaries for triage. Deterministic:
+// the same inputs always produce the same ranking; no LLM scoring. Default
+// behavior surfaces the most-stalled open PRs (those an agent or human should
+// look at first because they've been idle longest).
+func TriagePRs(ctx context.Context, s *store.Store, opts TriageOpts) ([]TriagedPR, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultTriageLimit
+	}
+	sort := opts.Sort
+	if sort == "" {
+		sort = defaultTriageSort
+	}
+	state := opts.State
+	if state == "" {
+		state = defaultTriageState
+	}
+
+	// "last activity" is the most-recent of pr.updated_at and any comment's
+	// created_at. Computed in the SELECT so it's available for ORDER BY and
+	// for the stalled_days return value without an extra round-trip.
+	q := `
+		SELECT
+		  pr.number, pr.title, COALESCE(pr.author, ''), COALESCE(pr.url, ''),
+		  COALESCE(pr.labels, ''), pr.state,
+		  COALESCE(pr.created_at, 0) AS created_at,
+		  COALESCE(
+		    MAX(
+		      COALESCE(pr.updated_at, 0),
+		      COALESCE((SELECT MAX(created_at) FROM pr_comments WHERE pr_id = pr.id), 0)
+		    ),
+		    0
+		  ) AS last_activity,
+		  COALESCE((SELECT COUNT(*) FROM pr_comments WHERE pr_id = pr.id), 0) AS comments,
+		  COALESCE((SELECT COUNT(DISTINCT author) FROM pr_comments WHERE pr_id = pr.id AND path IS NOT NULL), 0) AS reviewers,
+		  COALESCE((SELECT COUNT(DISTINCT author) FROM pr_comments WHERE pr_id = pr.id AND path IS NULL), 0) AS discussants,
+		  COALESCE((SELECT COUNT(*) FROM pr_commits WHERE pr_id = pr.id), 0) AS commits
+		FROM pull_requests pr`
+
+	var args []interface{}
+	if state != "all" {
+		q += " WHERE pr.state = ?"
+		args = append(args, state)
+	}
+	q += " ORDER BY " + triageOrderBy(sort) + " LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := s.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query triage PRs: %w", err)
+	}
+	defer rows.Close()
+
+	now := time.Now().Unix()
+	var out []TriagedPR
+	for rows.Next() {
+		var p TriagedPR
+		var labels string
+		var createdAt, lastActivity int64
+		if err := rows.Scan(
+			&p.Number, &p.Title, &p.Author, &p.URL,
+			&labels, &p.State,
+			&createdAt, &lastActivity,
+			&p.Comments, &p.Reviewers, &p.Discussants, &p.Commits,
+		); err != nil {
+			return nil, fmt.Errorf("scan triage row: %w", err)
+		}
+		if labels != "" {
+			p.Labels = splitAndTrim(labels, ",")
+		}
+		p.AgeDays = daysBetween(now, createdAt)
+		p.StalledDays = daysBetween(now, lastActivity)
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate triage rows: %w", err)
+	}
+	return out, nil
+}
+
+// triageOrderBy maps a sort key to the ORDER BY clause. Unknown keys fall
+// back to the default ("stalled").
+func triageOrderBy(sort string) string {
+	switch sort {
+	case "age":
+		// oldest first; tie-break by number for stability
+		return "created_at ASC, pr.number ASC"
+	case "activity":
+		// most-discussed first
+		return "comments DESC, last_activity DESC, pr.number ASC"
+	default:
+		// stalled: most-idle first (least-recent activity at top)
+		return "last_activity ASC, pr.number ASC"
+	}
+}
+
+// daysBetween returns whole days between two Unix timestamps (both seconds).
+// Returns 0 when either is zero (missing data) to avoid garbage age values
+// like "55 years stale" for unindexed/null timestamps.
+func daysBetween(nowUnix, thenUnix int64) int {
+	if nowUnix == 0 || thenUnix == 0 {
+		return 0
+	}
+	d := nowUnix - thenUnix
+	if d < 0 {
+		return 0
+	}
+	return int(d / 86400)
+}
+
+// splitAndTrim splits s on sep and trims whitespace from each piece, dropping
+// empties. Used for the labels CSV column.
+func splitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/codedb/query/triage_test.go
+++ b/internal/codedb/query/triage_test.go
@@ -1,0 +1,183 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sageox/ox/internal/codedb/store"
+)
+
+// seedTriageDB inserts four pull_requests with controlled created_at /
+// updated_at and a varied comment+commit distribution so each sort key has a
+// distinct expected ordering. Returns the store; the caller controls cleanup.
+func seedTriageDB(t *testing.T) *store.Store {
+	t.Helper()
+	s, err := store.Open(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	now := time.Now().Unix()
+	day := int64(86400)
+
+	// PRs: (number, created_days_ago, updated_days_ago, state)
+	// #1 — created 30d ago, updated 1d ago     → newest activity (least stalled)
+	// #2 — created 60d ago, updated 30d ago    → most stalled
+	// #3 — created 10d ago, updated 5d ago     → newest PR, middle stalled
+	// #4 — created 90d ago, updated 20d ago    → oldest PR
+	prs := []struct {
+		id      int
+		num     int
+		created int64
+		updated int64
+		state   string
+		title   string
+	}{
+		{1, 101, now - 30*day, now - 1*day, "open", "small fix"},
+		{2, 102, now - 60*day, now - 30*day, "open", "big refactor"},
+		{3, 103, now - 10*day, now - 5*day, "open", "in flight"},
+		{4, 104, now - 90*day, now - 20*day, "open", "ancient"},
+	}
+	for _, p := range prs {
+		_, err := s.Exec(`INSERT INTO pull_requests (id, number, title, author, state, labels, created_at, updated_at, url)
+		                  VALUES (?, ?, ?, 'alice', ?, '', ?, ?, ?)`,
+			p.id, p.num, p.title, p.state, p.created, p.updated,
+			"https://example/pr/"+itoa(p.num))
+		require.NoError(t, err)
+	}
+
+	// Comments: PR #3 gets the most chatter (3 comments, 2 reviewers, 1 discussant).
+	// PR #1 gets 1 review comment. Others none.
+	comments := []struct {
+		id     int
+		prID   int
+		author string
+		path   *string
+	}{
+		{1, 1, "bob", strPtr("a.go")},   // review (path set)
+		{2, 3, "bob", strPtr("b.go")},   // review
+		{3, 3, "carol", strPtr("c.go")}, // review (distinct reviewer)
+		{4, 3, "dave", nil},             // discussion (path NULL)
+	}
+	for _, c := range comments {
+		_, err := s.Exec(`INSERT INTO pr_comments (id, pr_id, author, body, path, created_at)
+		                  VALUES (?, ?, ?, 'msg', ?, ?)`,
+			c.id, c.prID, c.author, c.path, now-2*day)
+		require.NoError(t, err)
+	}
+
+	// Commits: PR #2 has 5, PR #1 has 2.
+	commitID := 1
+	for prID, n := range map[int]int{2: 5, 1: 2} {
+		for i := 0; i < n; i++ {
+			_, err := s.Exec("INSERT INTO pr_commits (id, pr_id, sha) VALUES (?, ?, ?)", commitID, prID, "sha"+itoa(commitID))
+			require.NoError(t, err)
+			commitID++
+		}
+	}
+	return s
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+// TestTriagePRs_DefaultStalledOrder verifies the default sort surfaces the
+// most-idle PR first. Failure prevented: triage that doesn't actually surface
+// stalled PRs is useless to agents.
+func TestTriagePRs_DefaultStalledOrder(t *testing.T) {
+	s := seedTriageDB(t)
+	got, err := TriagePRs(context.Background(), s, TriageOpts{})
+	require.NoError(t, err)
+	require.Len(t, got, 4)
+
+	// Expected stalled-first order: PR #2 (30d) → #4 (20d) → #3 (2d via last
+	// comment, beating its older updated_at) → #1 (1d, most recent activity).
+	// This validates that MAX(updated_at, last_comment_at) drives the ranking,
+	// not raw updated_at alone.
+	require.Equal(t, []int{102, 104, 103, 101}, prNumbers(got),
+		"stalled-first: most-idle PR at the top, freshest activity at the bottom")
+}
+
+// TestTriagePRs_AgeSort orders by created_at ascending — oldest PR first.
+func TestTriagePRs_AgeSort(t *testing.T) {
+	s := seedTriageDB(t)
+	got, err := TriagePRs(context.Background(), s, TriageOpts{Sort: "age"})
+	require.NoError(t, err)
+	require.Equal(t, []int{104, 102, 101, 103}, prNumbers(got))
+}
+
+// TestTriagePRs_ActivitySort surfaces most-commented PRs first (PR #3 has 3
+// comments; PR #1 has 1; others have 0).
+func TestTriagePRs_ActivitySort(t *testing.T) {
+	s := seedTriageDB(t)
+	got, err := TriagePRs(context.Background(), s, TriageOpts{Sort: "activity"})
+	require.NoError(t, err)
+	require.Equal(t, 103, got[0].Number, "most comments first")
+	require.Equal(t, 3, got[0].Comments)
+	require.Equal(t, 2, got[0].Reviewers, "review comments have path set")
+	require.Equal(t, 1, got[0].Discussants, "discussion comments have path NULL")
+}
+
+// TestTriagePRs_SignalsPopulated verifies the per-PR signal fields land
+// correctly for downstream agents.
+func TestTriagePRs_SignalsPopulated(t *testing.T) {
+	s := seedTriageDB(t)
+	got, err := TriagePRs(context.Background(), s, TriageOpts{Sort: "activity"})
+	require.NoError(t, err)
+
+	byNum := make(map[int]TriagedPR, len(got))
+	for _, p := range got {
+		byNum[p.Number] = p
+	}
+
+	require.Equal(t, 5, byNum[102].Commits, "PR #2 has 5 commits")
+	require.Equal(t, 2, byNum[101].Commits, "PR #1 has 2 commits")
+	require.GreaterOrEqual(t, byNum[104].AgeDays, 89, "PR #4 is ~90 days old")
+}
+
+// TestTriagePRs_StateFilter — "closed" includes only closed/merged.
+func TestTriagePRs_StateFilter(t *testing.T) {
+	s := seedTriageDB(t)
+	// Flip PR #4 to closed.
+	_, err := s.Exec("UPDATE pull_requests SET state = 'closed' WHERE number = 104")
+	require.NoError(t, err)
+
+	got, err := TriagePRs(context.Background(), s, TriageOpts{State: "closed"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, 104, got[0].Number)
+}
+
+// TestTriagePRs_LimitRespected — caller-supplied limit caps the result set.
+func TestTriagePRs_LimitRespected(t *testing.T) {
+	s := seedTriageDB(t)
+	got, err := TriagePRs(context.Background(), s, TriageOpts{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+}
+
+func prNumbers(prs []TriagedPR) []int {
+	out := make([]int, len(prs))
+	for i, p := range prs {
+		out[i] = p.Number
+	}
+	return out
+}

--- a/internal/codedb/search/ast.go
+++ b/internal/codedb/search/ast.go
@@ -70,6 +70,12 @@ type Filters struct {
 	Depth       int // for multi-hop calls:/calledby: (default 1, max 10)
 	CommentKind string
 	State       string
+	// Confidence is the minimum confidence threshold for ADR-019 symbol_edges
+	// queries. Values: "extracted" | "inferred" | "ambiguous". When set,
+	// calls:/calledby: query the resolved symbol_edges table instead of the
+	// LIKE-name-match path on symbol_refs. Empty (default) keeps the existing
+	// name-match behavior so older codedbs (no edges yet) still work.
+	Confidence string
 }
 
 // ParsedQuery is the result of parsing a query string.

--- a/internal/codedb/search/query.go
+++ b/internal/codedb/search/query.go
@@ -190,6 +190,13 @@ func ParseQuery(input string) (*ParsedQuery, error) {
 				filters.CommentKind = value
 			case !negated && key == "state":
 				filters.State = value
+			case !negated && key == "confidence":
+				switch value {
+				case "extracted", "inferred", "ambiguous":
+					filters.Confidence = value
+				default:
+					return nil, fmt.Errorf("confidence: must be extracted|inferred|ambiguous, got '%s'", value)
+				}
 			case negated:
 				return nil, fmt.Errorf("negation not supported for '%s:'", key)
 			default:

--- a/internal/codedb/search/testdata/golden/parse/author_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/author_filter.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/bare_keyword.golden
+++ b/internal/codedb/search/testdata/golden/parse/bare_keyword.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/before_after.golden
+++ b/internal/codedb/search/testdata/golden/parse/before_after.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/calledby_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/calledby_filter.golden
@@ -25,6 +25,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/calls_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/calls_filter.golden
@@ -25,6 +25,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/case_no.golden
+++ b/internal/codedb/search/testdata/golden/parse/case_no.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/case_yes.golden
+++ b/internal/codedb/search/testdata/golden/parse/case_yes.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/combined_all_filters.golden
+++ b/internal/codedb/search/testdata/golden/parse/combined_all_filters.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/combined_repo_rev.golden
+++ b/internal/codedb/search/testdata/golden/parse/combined_repo_rev.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/comment_kind.golden
+++ b/internal/codedb/search/testdata/golden/parse/comment_kind.golden
@@ -25,6 +25,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "doc",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/count_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/count_filter.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/empty.golden
+++ b/internal/codedb/search/testdata/golden/parse/empty.golden
@@ -25,6 +25,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/file_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/file_filter.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/file_glob.golden
+++ b/internal/codedb/search/testdata/golden/parse/file_glob.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/lang_alias_l.golden
+++ b/internal/codedb/search/testdata/golden/parse/lang_alias_l.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/lang_alias_language.golden
+++ b/internal/codedb/search/testdata/golden/parse/lang_alias_language.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/lang_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/lang_filter.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/message_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/message_filter.golden
@@ -25,6 +25,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/message_quoted.golden
+++ b/internal/codedb/search/testdata/golden/parse/message_quoted.golden
@@ -25,6 +25,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/multi_keyword.golden
+++ b/internal/codedb/search/testdata/golden/parse/multi_keyword.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/neg_author.golden
+++ b/internal/codedb/search/testdata/golden/parse/neg_author.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/neg_file.golden
+++ b/internal/codedb/search/testdata/golden/parse/neg_file.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/neg_lang.golden
+++ b/internal/codedb/search/testdata/golden/parse/neg_lang.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/neg_message.golden
+++ b/internal/codedb/search/testdata/golden/parse/neg_message.golden
@@ -25,6 +25,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/neg_repo.golden
+++ b/internal/codedb/search/testdata/golden/parse/neg_repo.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/or_multiword.golden
+++ b/internal/codedb/search/testdata/golden/parse/or_multiword.golden
@@ -28,6 +28,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/or_three_terms.golden
+++ b/internal/codedb/search/testdata/golden/parse/or_three_terms.golden
@@ -29,6 +29,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/or_two_terms.golden
+++ b/internal/codedb/search/testdata/golden/parse/or_two_terms.golden
@@ -28,6 +28,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/patterntype_regexp.golden
+++ b/internal/codedb/search/testdata/golden/parse/patterntype_regexp.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/quoted_phrase.golden
+++ b/internal/codedb/search/testdata/golden/parse/quoted_phrase.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/regex_basic.golden
+++ b/internal/codedb/search/testdata/golden/parse/regex_basic.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/regex_with_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/regex_with_filter.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/repo_at_rev.golden
+++ b/internal/codedb/search/testdata/golden/parse/repo_at_rev.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/repo_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/repo_filter.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/returns_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/returns_filter.golden
@@ -25,6 +25,7 @@
     "Returns": "BatchIterator",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/rev_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/rev_filter.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/select_file.golden
+++ b/internal/codedb/search/testdata/golden/parse/select_file.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/select_repo.golden
+++ b/internal/codedb/search/testdata/golden/parse/select_repo.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/select_symbol.golden
+++ b/internal/codedb/search/testdata/golden/parse/select_symbol.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/select_symbol_kind.golden
+++ b/internal/codedb/search/testdata/golden/parse/select_symbol_kind.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/state_filter.golden
+++ b/internal/codedb/search/testdata/golden/parse/state_filter.golden
@@ -25,6 +25,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": "open"
+    "State": "open",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/type_code_explicit.golden
+++ b/internal/codedb/search/testdata/golden/parse/type_code_explicit.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/type_comment.golden
+++ b/internal/codedb/search/testdata/golden/parse/type_comment.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/type_commit.golden
+++ b/internal/codedb/search/testdata/golden/parse/type_commit.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/type_diff.golden
+++ b/internal/codedb/search/testdata/golden/parse/type_diff.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/type_issue.golden
+++ b/internal/codedb/search/testdata/golden/parse/type_issue.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/type_pr.golden
+++ b/internal/codedb/search/testdata/golden/parse/type_pr.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/type_symbol.golden
+++ b/internal/codedb/search/testdata/golden/parse/type_symbol.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/testdata/golden/parse/unknown_filter_as_term.golden
+++ b/internal/codedb/search/testdata/golden/parse/unknown_filter_as_term.golden
@@ -27,6 +27,7 @@
     "Returns": "",
     "Depth": 0,
     "CommentKind": "",
-    "State": ""
+    "State": "",
+    "Confidence": ""
   }
 }

--- a/internal/codedb/search/translate.go
+++ b/internal/codedb/search/translate.go
@@ -487,6 +487,14 @@ func translateComment(query *ParsedQuery) (*TranslatedQuery, error) {
 }
 
 func translateCallers(query *ParsedQuery) (*TranslatedQuery, error) {
+	// ADR-019 phase 1 read path: when the caller asked for a confidence
+	// threshold, route to the resolved symbol_edges path. Without it we keep
+	// the historical symbol_refs name-match (preserves behavior on codedbs
+	// without any edges yet).
+	if query.Filters.Confidence != "" {
+		return translateCallersEdges(query)
+	}
+
 	f := query.Filters
 	p := newParamCollector(f.Case)
 
@@ -571,6 +579,12 @@ LIMIT %d`, targetParam, depthParam, revSQL, limit)
 }
 
 func translateCallees(query *ParsedQuery) (*TranslatedQuery, error) {
+	// ADR-019 phase 1 read path: confidence: filter routes to the resolved
+	// symbol_edges variant. See translateCallers for the same dispatch.
+	if query.Filters.Confidence != "" {
+		return translateCalleesEdges(query)
+	}
+
 	f := query.Filters
 	p := newParamCollector(f.Case)
 

--- a/internal/codedb/search/translate_edges.go
+++ b/internal/codedb/search/translate_edges.go
@@ -1,0 +1,218 @@
+package search
+
+import (
+	"fmt"
+	"strings"
+)
+
+// confidenceClause returns "AND e.confidence IN (?, ?, ...)" expanded for the
+// minimum-threshold semantics: "extracted" → just extracted; "inferred" →
+// extracted+inferred; "ambiguous" → all three. Empty string for invalid input
+// (treated as no extra filter).
+func confidenceClause(p *paramCollector, minLevel string) string {
+	var levels []string
+	switch minLevel {
+	case "extracted":
+		levels = []string{"extracted"}
+	case "inferred":
+		levels = []string{"extracted", "inferred"}
+	case "ambiguous":
+		levels = []string{"extracted", "inferred", "ambiguous"}
+	default:
+		return ""
+	}
+	placeholders := make([]string, len(levels))
+	for i, l := range levels {
+		placeholders[i] = p.add(l)
+	}
+	return "AND e.confidence IN (" + strings.Join(placeholders, ", ") + ")"
+}
+
+// translateCallersEdges resolves `calls:Name` via the symbol_edges table when
+// the user requested a confidence threshold (ADR-019 phase 1 read path).
+// Edges carry the resolved src_symbol_id, so the caller list is precise even
+// when many same-name targets exist; dst_name supports the same pattern/regex
+// syntax as the legacy symbol_refs path for backward compatibility.
+func translateCallersEdges(query *ParsedQuery) (*TranslatedQuery, error) {
+	f := query.Filters
+	p := newParamCollector(f.Case)
+
+	if f.Depth > 1 {
+		return translateCallersEdgesRecursive(query, p)
+	}
+
+	joins := []string{
+		"JOIN symbols s ON s.id = e.src_symbol_id",
+		"JOIN blobs b ON b.id = e.src_blob_id",
+		"JOIN file_revs fr ON fr.blob_id = b.id",
+		"JOIN refs r ON r.commit_id = fr.commit_id",
+	}
+	var conditions []string
+
+	var clause string
+	if query.IsRegex {
+		clause = regexMatchClause("e.dst_name", f.Calls, p)
+	} else {
+		clause = patternMatchClause("e.dst_name", f.Calls, p)
+	}
+	conditions = append(conditions, "AND "+clause)
+	conditions = append(conditions, "AND e.kind = 'call'")
+	conditions = append(conditions, "AND s.kind = 'function'")
+	conditions = append(conditions, confidenceClause(p, f.Confidence))
+
+	addRepoFilter(p, &joins, &conditions, f.Repo, f.NegRepo, "r.repo_id")
+	addFileFilter(p, &conditions, f.File, f.NegFile, "fr.path")
+	addLangFilter(p, &conditions, f.Lang, f.NegLang)
+	addRevFilter(p, &conditions, f.Rev)
+
+	limit := resolveLimit(f.Count)
+
+	sql := fmt.Sprintf(
+		"SELECT DISTINCT fr.path, s.name, s.kind, s.line\nFROM symbol_edges e\n%s\nWHERE 1=1%s\nORDER BY fr.path, s.line\nLIMIT %d",
+		strings.Join(joins, "\n"), conditionsSQL(conditions), limit)
+
+	return &TranslatedQuery{
+		SQL:        sql,
+		Params:     p.params,
+		SearchType: SearchTypeSymbol,
+	}, nil
+}
+
+// translateCallersEdgesRecursive walks the caller chain via dst_symbol_id ↔
+// src_symbol_id (RESOLVED ids — no name-collision conflation, unlike the
+// legacy symbol_refs recursive variant which joins by ref_name string).
+func translateCallersEdgesRecursive(query *ParsedQuery, p *paramCollector) (*TranslatedQuery, error) {
+	f := query.Filters
+	targetParam := p.add(f.Calls)
+	depthParam := p.add(fmt.Sprintf("%d", f.Depth))
+	confSeedClause := confidenceClause(p, f.Confidence)
+	confRecurseClause := confidenceClause(p, f.Confidence) // separate params for the recursive arm
+
+	var revConditions []string
+	addRevFilter(p, &revConditions, f.Rev)
+	revSQL := conditionsSQL(revConditions)
+
+	limit := resolveLimit(f.Count)
+
+	sql := fmt.Sprintf(`WITH RECURSIVE call_chain(symbol_id, depth) AS (
+  SELECT e.src_symbol_id, 1
+  FROM symbol_edges e
+  JOIN symbols s ON s.id = e.src_symbol_id
+  WHERE e.dst_name LIKE '%%' || %s || '%%' AND e.kind = 'call' AND s.kind = 'function'
+        %s
+  UNION
+  SELECT e2.src_symbol_id, cc.depth + 1
+  FROM call_chain cc
+  JOIN symbol_edges e2 ON e2.dst_symbol_id = cc.symbol_id AND e2.kind = 'call'
+  WHERE cc.depth < %s %s
+)
+SELECT DISTINCT fr.path, s.name, s.kind, cc.depth
+FROM call_chain cc
+JOIN symbols s ON s.id = cc.symbol_id
+JOIN blobs b ON b.id = s.blob_id
+JOIN file_revs fr ON fr.blob_id = b.id
+JOIN refs r ON r.commit_id = fr.commit_id
+WHERE 1=1%s
+ORDER BY cc.depth, fr.path
+LIMIT %d`, targetParam, confSeedClause, depthParam, confRecurseClause, revSQL, limit)
+
+	return &TranslatedQuery{
+		SQL:        sql,
+		Params:     p.params,
+		SearchType: SearchTypeSymbol,
+	}, nil
+}
+
+// translateCalleesEdges resolves `calledby:Name` via symbol_edges when the
+// caller requested a confidence threshold. dst_symbol_id is resolved so the
+// callee list is precise.
+func translateCalleesEdges(query *ParsedQuery) (*TranslatedQuery, error) {
+	f := query.Filters
+	p := newParamCollector(f.Case)
+
+	if f.Depth > 1 {
+		return translateCalleesEdgesRecursive(query, p)
+	}
+
+	joins := []string{
+		"JOIN symbol_edges e ON e.src_symbol_id = s.id",
+		"JOIN symbols s_dst ON s_dst.id = e.dst_symbol_id",
+		"JOIN blobs b ON b.id = s_dst.blob_id",
+		"JOIN file_revs fr ON fr.blob_id = b.id",
+		"JOIN refs r ON r.commit_id = fr.commit_id",
+	}
+	var conditions []string
+
+	var clause string
+	if query.IsRegex {
+		clause = regexMatchClause("s.name", f.CalledBy, p)
+	} else {
+		clause = patternMatchClause("s.name", f.CalledBy, p)
+	}
+	conditions = append(conditions, "AND "+clause)
+	conditions = append(conditions, "AND e.kind = 'call'")
+	conditions = append(conditions, "AND s.kind = 'function'")
+	conditions = append(conditions, confidenceClause(p, f.Confidence))
+
+	addRepoFilter(p, &joins, &conditions, f.Repo, f.NegRepo, "r.repo_id")
+	addFileFilter(p, &conditions, f.File, f.NegFile, "fr.path")
+	addLangFilter(p, &conditions, f.Lang, f.NegLang)
+	addRevFilter(p, &conditions, f.Rev)
+
+	limit := resolveLimit(f.Count)
+
+	sql := fmt.Sprintf(
+		"SELECT DISTINCT fr.path, s_dst.name, s_dst.kind, s_dst.line\nFROM symbols s\n%s\nWHERE 1=1%s\nORDER BY fr.path, s_dst.line\nLIMIT %d",
+		strings.Join(joins, "\n"), conditionsSQL(conditions), limit)
+
+	return &TranslatedQuery{
+		SQL:        sql,
+		Params:     p.params,
+		SearchType: SearchTypeSymbol,
+	}, nil
+}
+
+// translateCalleesEdgesRecursive walks the callee chain via resolved
+// dst_symbol_id → src_symbol_id, freed from the name-equality conflation of
+// the legacy symbol_refs recursion.
+func translateCalleesEdgesRecursive(query *ParsedQuery, p *paramCollector) (*TranslatedQuery, error) {
+	f := query.Filters
+	targetParam := p.add(f.CalledBy)
+	depthParam := p.add(fmt.Sprintf("%d", f.Depth))
+	confSeedClause := confidenceClause(p, f.Confidence)
+	confRecurseClause := confidenceClause(p, f.Confidence)
+
+	var revConditions []string
+	addRevFilter(p, &revConditions, f.Rev)
+	revSQL := conditionsSQL(revConditions)
+
+	limit := resolveLimit(f.Count)
+
+	sql := fmt.Sprintf(`WITH RECURSIVE call_chain(symbol_id, depth) AS (
+  SELECT e.dst_symbol_id, 1
+  FROM symbols s
+  JOIN symbol_edges e ON e.src_symbol_id = s.id AND e.kind = 'call'
+  WHERE s.name LIKE '%%' || %s || '%%' AND s.kind = 'function'
+        %s
+  UNION
+  SELECT e2.dst_symbol_id, cc.depth + 1
+  FROM call_chain cc
+  JOIN symbol_edges e2 ON e2.src_symbol_id = cc.symbol_id AND e2.kind = 'call'
+  WHERE cc.depth < %s %s
+)
+SELECT DISTINCT fr.path, s.name, s.kind, cc.depth
+FROM call_chain cc
+JOIN symbols s ON s.id = cc.symbol_id
+JOIN blobs b ON b.id = s.blob_id
+JOIN file_revs fr ON fr.blob_id = b.id
+JOIN refs r ON r.commit_id = fr.commit_id
+WHERE 1=1%s
+ORDER BY cc.depth, fr.path
+LIMIT %d`, targetParam, confSeedClause, depthParam, confRecurseClause, revSQL, limit)
+
+	return &TranslatedQuery{
+		SQL:        sql,
+		Params:     p.params,
+		SearchType: SearchTypeSymbol,
+	}, nil
+}

--- a/internal/codedb/search/translate_edges_test.go
+++ b/internal/codedb/search/translate_edges_test.go
@@ -1,0 +1,117 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfidenceParse covers the `confidence:` DSL token added for ADR-019.
+// Valid values land in Filters.Confidence; invalid values error.
+func TestConfidenceParse(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantVal string
+		wantErr bool
+	}{
+		{"calls:Foo confidence:extracted", "extracted", false},
+		{"calls:Foo confidence:inferred", "inferred", false},
+		{"calls:Foo confidence:ambiguous", "ambiguous", false},
+		{"calls:Foo confidence:bogus", "", true},
+		{"calls:Foo", "", false}, // omitted — empty (legacy path)
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			q, err := ParseQuery(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantVal, q.Filters.Confidence)
+		})
+	}
+}
+
+// TestTranslateCallers_RoutesByConfidence proves that `confidence:` flips the
+// translator from the symbol_refs name-match path (legacy) to the resolved
+// symbol_edges path (ADR-019). Failure here means the read swap regressed.
+func TestTranslateCallers_RoutesByConfidence(t *testing.T) {
+	t.Run("no confidence -> symbol_refs", func(t *testing.T) {
+		q, err := ParseQuery("calls:Foo")
+		require.NoError(t, err)
+		tr, err := Translate(q)
+		require.NoError(t, err)
+		require.Contains(t, tr.SQL, "FROM symbol_refs sr",
+			"legacy path must use symbol_refs when no confidence: filter")
+		require.NotContains(t, tr.SQL, "symbol_edges")
+	})
+	t.Run("confidence set -> symbol_edges", func(t *testing.T) {
+		q, err := ParseQuery("calls:Foo confidence:inferred")
+		require.NoError(t, err)
+		tr, err := Translate(q)
+		require.NoError(t, err)
+		require.Contains(t, tr.SQL, "FROM symbol_edges e",
+			"confidence: filter must route to the resolved symbol_edges path")
+		require.Contains(t, tr.SQL, "e.kind = 'call'")
+		require.Contains(t, tr.SQL, "e.confidence IN",
+			"confidence threshold must constrain the edge set")
+	})
+}
+
+// TestTranslateCalledBy_RoutesByConfidence — same dispatch for `calledby:`.
+func TestTranslateCalledBy_RoutesByConfidence(t *testing.T) {
+	q, err := ParseQuery("calledby:Foo confidence:extracted")
+	require.NoError(t, err)
+	tr, err := Translate(q)
+	require.NoError(t, err)
+	require.Contains(t, tr.SQL, "symbol_edges")
+	require.Contains(t, tr.SQL, "s_dst")
+}
+
+// TestConfidenceClause_ThresholdSemantics verifies the minimum-threshold
+// expansion: "inferred" → extracted+inferred (excludes ambiguous);
+// "ambiguous" → all three; "extracted" → only extracted; invalid → empty.
+func TestConfidenceClause_ThresholdSemantics(t *testing.T) {
+	tests := []struct {
+		level     string
+		wantCount int // number of confidence values in the IN clause
+	}{
+		{"extracted", 1},
+		{"inferred", 2},
+		{"ambiguous", 3},
+		{"", 0},
+		{"bogus", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			p := newParamCollector(false)
+			clause := confidenceClause(p, tt.level)
+			if tt.wantCount == 0 {
+				require.Equal(t, "", clause)
+				return
+			}
+			require.True(t, strings.HasPrefix(clause, "AND e.confidence IN ("),
+				"clause shape: %q", clause)
+			// param count == confidence values in IN clause
+			require.Len(t, p.params, tt.wantCount)
+		})
+	}
+}
+
+// TestTranslateCallers_RecursiveUsesEdgesWithConfidence — depth>1 with
+// confidence must use the resolved-edges recursive CTE (joins on
+// dst_symbol_id ↔ src_symbol_id, NOT on ref_name strings).
+func TestTranslateCallers_RecursiveUsesEdgesWithConfidence(t *testing.T) {
+	q, err := ParseQuery("calls:Foo confidence:inferred depth:3")
+	require.NoError(t, err)
+	tr, err := Translate(q)
+	require.NoError(t, err)
+	require.Contains(t, tr.SQL, "WITH RECURSIVE call_chain")
+	require.Contains(t, tr.SQL, "symbol_edges")
+	require.Contains(t, tr.SQL, "e2.dst_symbol_id = cc.symbol_id",
+		"recursion must join on resolved ids, not on names")
+	require.NotContains(t, tr.SQL, "sr2.ref_name = cc.name",
+		"recursive symbol_refs name-equality must NOT be in the edges path")
+}

--- a/internal/codedb/store/schema.go
+++ b/internal/codedb/store/schema.go
@@ -219,7 +219,31 @@ func CreateSchema(db *sql.DB) error {
 	if err := migrateAddPRCommits(db); err != nil {
 		return err
 	}
+	if err := migrateAddEdgeVersion(db); err != nil {
+		return err
+	}
 	return migrateInvalidateGitHubMtimesForIssue474(db)
+}
+
+// migrateAddEdgeVersion adds the blobs.edge_version column used by the ADR-019
+// resolver. Existing rows default to 0; the backfill routine bumps them to the
+// current resolver version after edges are populated, and ParseSymbols stamps
+// new blobs at the current version inline.
+func migrateAddEdgeVersion(db *sql.DB) error {
+	var exists bool
+	err := db.QueryRow(`SELECT COUNT(*) > 0 FROM pragma_table_info('blobs') WHERE name='edge_version'`).Scan(&exists)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	if _, err := db.Exec(`ALTER TABLE blobs ADD COLUMN edge_version INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
+	// Index supports the backfill scan: find blobs needing edges fast.
+	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_blobs_edge_version ON blobs(edge_version)`)
+	return err
 }
 
 // migrateAddTypeInfo adds signature, return_type, and params columns to the

--- a/internal/codedb/store/schema.go
+++ b/internal/codedb/store/schema.go
@@ -81,6 +81,29 @@ CREATE TABLE IF NOT EXISTS symbol_refs (
     col       INTEGER NOT NULL
 );
 
+-- ADR-019: resolved symbol edges. Populated alongside symbol_refs at index
+-- time by per-language resolvers. src_symbol_id is the *containing* symbol
+-- (caller); dst_symbol_id is the *resolved target* (callee) when known.
+-- dst_blob_id/dst_symbol_id are NULL for unresolved/external targets (the
+-- dst_name column always carries the referenced name so name-fallback queries
+-- still work). confidence: extracted (direct binding), inferred (heuristic
+-- match), ambiguous (one row per candidate, capped).
+CREATE TABLE IF NOT EXISTS symbol_edges (
+    id            INTEGER PRIMARY KEY,
+    src_blob_id   INTEGER NOT NULL REFERENCES blobs(id),
+    src_symbol_id INTEGER NOT NULL REFERENCES symbols(id),
+    dst_blob_id   INTEGER          REFERENCES blobs(id),
+    dst_symbol_id INTEGER          REFERENCES symbols(id),
+    dst_name      TEXT    NOT NULL,
+    kind          TEXT    NOT NULL,
+    confidence    TEXT    NOT NULL,
+    line          INTEGER NOT NULL,
+    col           INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_symbol_edges_src      ON symbol_edges(src_symbol_id, kind);
+CREATE INDEX IF NOT EXISTS idx_symbol_edges_dst      ON symbol_edges(dst_symbol_id, kind);
+CREATE INDEX IF NOT EXISTS idx_symbol_edges_dst_name ON symbol_edges(dst_name, kind);
+
 CREATE TABLE IF NOT EXISTS pull_requests (
     id          INTEGER PRIMARY KEY,
     number      INTEGER NOT NULL UNIQUE,

--- a/internal/codedb/symbols/resolver.go
+++ b/internal/codedb/symbols/resolver.go
@@ -19,6 +19,13 @@ type Edge struct {
 // hundreds of definitions) don't blow up the edges table.
 const ambiguousEdgeCap = 8
 
+// ResolverVersion is the structural version of Resolve's output. Bump when
+// changing the resolver semantics (new edge kinds, scope rules, confidence
+// policy). ParseSymbols stamps `blobs.edge_version` at this version after
+// inserting edges; BackfillSymbolEdges processes blobs whose stored version
+// is below this one.
+const ResolverVersion = 1
+
 // Resolve produces same-file edges from refs to in-scope symbols (ADR-019
 // phase 1). Drops refs that aren't inside any containing symbol (file-scope
 // refs have no meaningful "caller"); drops refs whose name doesn't match any

--- a/internal/codedb/symbols/resolver.go
+++ b/internal/codedb/symbols/resolver.go
@@ -1,0 +1,68 @@
+package symbols
+
+// Edge is a resolved reference from a containing source symbol to a target
+// symbol identified by its index in the syms slice. ADR-019 phase 1 resolves
+// only within the same file (the syms slice is one blob's worth); cross-file
+// resolution comes in later phases with per-language import/scope handling.
+type Edge struct {
+	SrcIdx     int    // index in syms — the containing symbol (caller)
+	DstIdx     int    // index in syms — the resolved target (callee)
+	DstName    string // the referenced name, always populated
+	Kind       string // "call" | "reference" (from the underlying Ref.Kind)
+	Confidence string // "inferred" | "ambiguous" — see ADR-019 confidence model
+	Line       int
+	Col        int
+}
+
+// ambiguousEdgeCap bounds how many candidate edges we emit for a single
+// ambiguous reference, so pathological collisions (e.g. a name shared by
+// hundreds of definitions) don't blow up the edges table.
+const ambiguousEdgeCap = 8
+
+// Resolve produces same-file edges from refs to in-scope symbols (ADR-019
+// phase 1). Drops refs that aren't inside any containing symbol (file-scope
+// refs have no meaningful "caller"); drops refs whose name doesn't match any
+// same-file symbol (they remain in symbol_refs for the name-fallback path).
+//
+// Confidence policy: one same-file match → "inferred" (heuristic but high
+// signal in most languages); multiple matches → "ambiguous", emitted as one
+// edge per candidate up to ambiguousEdgeCap. Reserve "extracted" for later
+// phases that consult the language's actual scope/import rules.
+func Resolve(syms []Symbol, refs []Ref) []Edge {
+	if len(syms) == 0 || len(refs) == 0 {
+		return nil
+	}
+	byName := make(map[string][]int, len(syms))
+	for i := range syms {
+		byName[syms[i].Name] = append(byName[syms[i].Name], i)
+	}
+
+	var edges []Edge
+	for i := range refs {
+		ref := &refs[i]
+		if ref.ContainingSymIdx < 0 {
+			continue
+		}
+		candidates, ok := byName[ref.RefName]
+		if !ok {
+			continue
+		}
+		confidence := "inferred"
+		if len(candidates) > 1 {
+			confidence = "ambiguous"
+		}
+		n := min(len(candidates), ambiguousEdgeCap)
+		for k := range n {
+			edges = append(edges, Edge{
+				SrcIdx:     ref.ContainingSymIdx,
+				DstIdx:     candidates[k],
+				DstName:    ref.RefName,
+				Kind:       ref.Kind,
+				Confidence: confidence,
+				Line:       ref.Line,
+				Col:        ref.Col,
+			})
+		}
+	}
+	return edges
+}

--- a/internal/codedb/symbols/resolver_test.go
+++ b/internal/codedb/symbols/resolver_test.go
@@ -1,0 +1,95 @@
+package symbols
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolve_BasicSameFile covers ADR-019 phase 1: a unique same-file
+// definition produces one "inferred" edge from the containing symbol.
+func TestResolve_BasicSameFile(t *testing.T) {
+	syms := []Symbol{
+		{Name: "helper", Kind: "function"},    // idx 0
+		{Name: "caller", Kind: "function"},    // idx 1
+		{Name: "unrelated", Kind: "function"}, // idx 2
+	}
+	refs := []Ref{
+		{RefName: "helper", Kind: "call", Line: 10, Col: 5, ContainingSymIdx: 1}, // caller → helper
+	}
+
+	edges := Resolve(syms, refs)
+	require.Len(t, edges, 1)
+	require.Equal(t, 1, edges[0].SrcIdx)
+	require.Equal(t, 0, edges[0].DstIdx)
+	require.Equal(t, "helper", edges[0].DstName)
+	require.Equal(t, "call", edges[0].Kind)
+	require.Equal(t, "inferred", edges[0].Confidence)
+	require.Equal(t, 10, edges[0].Line)
+}
+
+// TestResolve_AmbiguousFansOut covers the ambiguity policy: multiple same-file
+// matches produce one edge per candidate, marked "ambiguous", capped.
+func TestResolve_AmbiguousFansOut(t *testing.T) {
+	syms := []Symbol{
+		{Name: "Process", Kind: "function"}, // idx 0
+		{Name: "Process", Kind: "method"},   // idx 1
+		{Name: "Process", Kind: "function"}, // idx 2
+		{Name: "caller", Kind: "function"},  // idx 3
+	}
+	refs := []Ref{
+		{RefName: "Process", Kind: "call", Line: 7, ContainingSymIdx: 3},
+	}
+
+	edges := Resolve(syms, refs)
+	require.Len(t, edges, 3, "one edge per same-name candidate")
+	for _, e := range edges {
+		require.Equal(t, "ambiguous", e.Confidence)
+		require.Equal(t, 3, e.SrcIdx)
+	}
+}
+
+// TestResolve_AmbiguityCapped guards the ambiguousEdgeCap so a pathological
+// collision (e.g. 600+ defs of "string" in the wild) can't blow up the table.
+func TestResolve_AmbiguityCapped(t *testing.T) {
+	syms := make([]Symbol, 0, 20)
+	for i := 0; i < 20; i++ {
+		syms = append(syms, Symbol{Name: "string", Kind: "function"})
+	}
+	syms = append(syms, Symbol{Name: "caller", Kind: "function"})
+	refs := []Ref{
+		{RefName: "string", Kind: "reference", ContainingSymIdx: len(syms) - 1},
+	}
+
+	edges := Resolve(syms, refs)
+	require.Len(t, edges, ambiguousEdgeCap,
+		"ambiguous edge fan-out must be capped at ambiguousEdgeCap")
+}
+
+// TestResolve_FileScopeRefsDropped covers the "no containing symbol" case —
+// file-scope refs have no caller to attribute the edge to. They stay in
+// symbol_refs for the name-fallback path; they don't produce edges.
+func TestResolve_FileScopeRefsDropped(t *testing.T) {
+	syms := []Symbol{{Name: "Init", Kind: "function"}}
+	refs := []Ref{
+		{RefName: "Init", Kind: "call", ContainingSymIdx: -1}, // file scope
+	}
+	require.Nil(t, Resolve(syms, refs))
+}
+
+// TestResolve_UnknownNameProducesNoEdge — refs whose name doesn't match any
+// same-file symbol leave no edge (they fall through to the name-match path).
+func TestResolve_UnknownNameProducesNoEdge(t *testing.T) {
+	syms := []Symbol{{Name: "helper", Kind: "function"}, {Name: "caller", Kind: "function"}}
+	refs := []Ref{
+		{RefName: "externalFunc", Kind: "call", ContainingSymIdx: 1},
+	}
+	require.Empty(t, Resolve(syms, refs))
+}
+
+// TestResolve_EmptyInputs — defensive zero-value behavior.
+func TestResolve_EmptyInputs(t *testing.T) {
+	require.Nil(t, Resolve(nil, nil))
+	require.Nil(t, Resolve([]Symbol{{Name: "x"}}, nil))
+	require.Nil(t, Resolve(nil, []Ref{{RefName: "x", ContainingSymIdx: 0}}))
+}

--- a/internal/daemon/codedb.go
+++ b/internal/daemon/codedb.go
@@ -311,6 +311,11 @@ func (m *CodeDBManager) BuildLedgerIndex(ctx context.Context, ledgerPath string)
 		// non-fatal
 	}
 
+	// ADR-019 edge backfill for ledger codedb (non-fatal, idempotent).
+	if _, err := db.BackfillSymbolEdges(indexCtx, nil); err != nil {
+		m.logger.Warn("codedb ledger: edge backfill failed", "error", err)
+	}
+
 	cached := queryStatsFromDB(db, ledgerDir)
 	m.mu.Lock()
 	m.ledgerStats = cached
@@ -533,6 +538,22 @@ func (m *CodeDBManager) doIndex(ctx context.Context, payload CodeIndexPayload, p
 	}
 	commentDuration := time.Since(commentStart)
 	m.logger.Info("codedb stage complete", "stage", "comments", "duration", commentDuration.Round(time.Millisecond), "extracted", cStats.CommentsExtracted)
+
+	// stage 3.5: backfill resolved symbol edges (ADR-019). Cheap, pure-SQL
+	// pass over blobs that were parsed before the resolver version landed;
+	// no-op on freshly-indexed codedbs (ParseSymbols stamps the version
+	// inline). Best-effort: a failure here logs a warning but doesn't fail
+	// the indexing run — search still works on symbol_refs without edges.
+	if backfillStats, bfErr := db.BackfillSymbolEdges(ctx, func(msg string) {
+		if pw != nil {
+			_ = pw.WriteMessage(msg)
+		}
+	}); bfErr != nil {
+		m.logger.Warn("codedb symbol-edge backfill failed (non-fatal)", "error", bfErr)
+	} else if backfillStats.BlobsProcessed > 0 {
+		m.logger.Info("codedb stage complete", "stage", "edge-backfill",
+			"blobs", backfillStats.BlobsProcessed, "edges", backfillStats.EdgesInserted)
+	}
 
 	// stage 4: build dirty overlay index for uncommitted worktree files
 	// Skip when fsnotify already rebuilt the dirty overlay recently — BuildDirtyIndex


### PR DESCRIPTION
## Summary

Re-lands PR #624 to `main`. #624 was stacked on #623 and merged into the #623 branch *after* #623 had already merged to `main`, so its commits were stranded and never reached `main`.

Commits:
- docs(adr): ADR-019 resolved symbol edges for CodeDB (proposal)
- feat(codedb): ADR-019 phase 1 — symbol_edges table + same-file resolver (write path)
- feat(codedb): ADR-019 phase 1 — confidence: filter routes calls/calledby to symbol_edges
- feat(codedb): ADR-019 backfill — populate symbol_edges for existing parsed blobs
- feat(codedb): graphify-style PR triage — `ox code prs` with deterministic ranking
- docs(adr): ADR-019 add doc-audience marker

## Test plan
- Same as #624 (already reviewed/merged on the stacked branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ox code prs` subcommand to list and rank indexed GitHub pull requests for triage, with sorting by stalled/age/activity and state filtering.
  * Added PR triage query capability with age, staleness, and activity signals.
  * Implemented resolved symbol edge model for improved call graph accuracy with confidence levels.
  * Added confidence-based filtering for code search queries.

* **Documentation**
  * Added architectural decision record documenting symbol edge resolution design.

* **Tests**
  * Added comprehensive test coverage for PR triage queries and symbol edge resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->