### PR TITLE
fix(codedb): address #661 review — triage case normalization + rows.Err check

### DIFF
--- a/cmd/ox/code_prs.go
+++ b/cmd/ox/code_prs.go
@@ -92,8 +92,8 @@ func runCodePRs(cmd *cobra.Command, _ []string) error {
 
 	results, err := query.TriagePRs(ctx, db.Store(), query.TriageOpts{
 		Limit: limit,
-		Sort:  sort,
-		State: state,
+		Sort:  strings.ToLower(sort),
+		State: strings.ToLower(state),
 	})
 	if err != nil {
 		return fmt.Errorf("triage PRs: %w", err)

--- a/cmd/ox/code_prs.go
+++ b/cmd/ox/code_prs.go
@@ -85,6 +85,10 @@ func runCodePRs(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("invalid --state %q: must be one of open | closed | merged | all", state)
 	}
 
+	// Normalize once so validation, the query, and the echoed response all agree.
+	sort = strings.ToLower(sort)
+	state = strings.ToLower(state)
+
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -92,8 +96,8 @@ func runCodePRs(cmd *cobra.Command, _ []string) error {
 
 	results, err := query.TriagePRs(ctx, db.Store(), query.TriageOpts{
 		Limit: limit,
-		Sort:  strings.ToLower(sort),
-		State: strings.ToLower(state),
+		Sort:  sort,
+		State: state,
 	})
 	if err != nil {
 		return fmt.Errorf("triage PRs: %w", err)

--- a/internal/codedb/index/backfill_edges.go
+++ b/internal/codedb/index/backfill_edges.go
@@ -53,6 +53,10 @@ func BackfillSymbolEdges(ctx context.Context, s *store.Store, progress ProgressF
 		}
 		blobIDs = append(blobIDs, id)
 	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return stats, fmt.Errorf("iterate blobs for edge backfill: %w", err)
+	}
 	rows.Close()
 
 	if len(blobIDs) == 0 {


### PR DESCRIPTION
## Summary

Addresses the two greptile review findings on #661 (which merged before the review landed).

**P1 — `cmd/ox/code_prs.go` (correctness bug)**
`validTriageSort` / `validTriageState` compare case-insensitively (`strings.ToLower`), so `--sort Age` and `--state Open` pass validation. But the raw value was forwarded to `TriagePRs`:
- `triageOrderBy` doesn't match `"Age"` → silently falls back to default `stalled` sort.
- `--state Open` → `WHERE pr.state = 'Open'` → zero rows (states stored lowercase).

Fix: lowercase `Sort` and `State` before passing to `TriagePRs`, matching validation.

**P2 — `internal/codedb/index/backfill_edges.go` (silent truncation)**
`rows.Err()` was not checked after the blob-ID scan loop. If SQLite errors mid-stream, `rows.Next()` returns false early, `blobIDs` is silently truncated, the partial set is reported as a successful backfill, and the remaining blobs stay at `edge_version = 0`.

Fix: check `rows.Err()` before `rows.Close()`; return a wrapped error on failure.

## Test plan
- `go build ./...` — clean
- `go vet ./cmd/ox/ ./internal/codedb/index/` — clean
- `go test ./internal/codedb/...` — all pass
- `go test ./cmd/ox/ -run 'Triage|PRs'` — pass

Co-Authored-By: [SageOx](https://github.com/SageOx)