### PR TITLE
fix(daemon): persist GC timestamps + correct "gc in Nd" wording

### DIFF
--- a/internal/config/local_config.go
+++ b/internal/config/local_config.go
@@ -53,6 +53,10 @@ type LocalConfig struct {
 type LedgerConfig struct {
 	Path     string    `toml:"path"`
 	LastSync time.Time `toml:"last_sync"`
+	// LastGC records when the daemon last completed a blue-green GC reclone.
+	// Persisted so the gc_interval_days cadence survives daemon restarts.
+	// omitempty intentionally omitted (see LastSync note above).
+	LastGC time.Time `toml:"last_gc"`
 }
 
 // HasLastSync returns true if LastSync has been set (is non-zero).
@@ -69,6 +73,10 @@ type TeamContext struct {
 	Slug     string    `toml:"slug,omitempty"`
 	Path     string    `toml:"path"`
 	LastSync time.Time `toml:"last_sync"`
+	// LastGC records when the daemon last completed a blue-green GC reclone.
+	// Persisted so the gc_interval_days cadence survives daemon restarts.
+	// omitempty intentionally omitted (see LastSync note above).
+	LastGC time.Time `toml:"last_gc"`
 }
 
 // HasLastSync returns true if LastSync has been set (is non-zero).
@@ -419,6 +427,15 @@ func (c *LocalConfig) UpdateLedgerLastSync() {
 	c.Ledger.LastSync = time.Now().UTC()
 }
 
+// UpdateLedgerLastGC records when the daemon last GC-recloned the ledger.
+// No-ops if Ledger is nil (consistent with UpdateLedgerLastSync behavior).
+func (c *LocalConfig) UpdateLedgerLastGC() {
+	if c.Ledger == nil {
+		return
+	}
+	c.Ledger.LastGC = time.Now().UTC()
+}
+
 // GetTeamContext returns the team context config for the given team ID, or nil if not found.
 func (c *LocalConfig) GetTeamContext(teamID string) *TeamContext {
 	if c == nil {
@@ -462,6 +479,16 @@ func (c *LocalConfig) UpdateTeamContextLastSync(teamID string) {
 	for i := range c.TeamContexts {
 		if c.TeamContexts[i].TeamID == teamID {
 			c.TeamContexts[i].LastSync = time.Now().UTC()
+			return
+		}
+	}
+}
+
+// UpdateTeamContextLastGC records when the daemon last GC-recloned a team context.
+func (c *LocalConfig) UpdateTeamContextLastGC(teamID string) {
+	for i := range c.TeamContexts {
+		if c.TeamContexts[i].TeamID == teamID {
+			c.TeamContexts[i].LastGC = time.Now().UTC()
 			return
 		}
 	}

--- a/internal/daemon/status_display.go
+++ b/internal/daemon/status_display.go
@@ -801,11 +801,11 @@ func formatGCStatus(ws WorkspaceSyncStatus, verbose bool) string {
 	if remaining <= 0 {
 		s = styleMuted.Render(" · gc due")
 	} else {
-		s = styleMuted.Render(" · gc in " + formatRelativeTime(remaining))
+		s = styleMuted.Render(" · gc in " + formatDurationShort(remaining))
 	}
 
 	if verbose {
-		s += styleMuted.Render(" (last " + formatRelativeTime(age) + " ago)")
+		s += styleMuted.Render(" (last " + formatDurationShort(age) + " ago)")
 	}
 
 	return s
@@ -999,6 +999,25 @@ func formatDurationCompact(d time.Duration) string {
 }
 
 // formatRelativeTime formats a duration as relative time (e.g., "5m ago").
+// formatDurationShort formats a duration as a bare single-unit magnitude
+// (e.g. "6d", "4h", "3m", "5s") with NO "ago" suffix. Use for countdowns
+// ("gc in 6d") and where the caller supplies its own suffix ("last 1h ago").
+// For elapsed timestamps that should read "... ago", use formatRelativeTime.
+func formatDurationShort(d time.Duration) string {
+	d = d.Round(time.Second)
+
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
 func formatRelativeTime(d time.Duration) string {
 	d = d.Round(time.Second)
 

--- a/internal/daemon/status_display_test.go
+++ b/internal/daemon/status_display_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -69,6 +70,73 @@ func TestFormatRelativeTime(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestFormatDurationShort verifies the bare-magnitude formatter has NO "ago"
+// suffix. Failure prevented: reusing formatRelativeTime for countdowns produced
+// "gc in 6d ago" — a duration that reads like an elapsed timestamp.
+func TestFormatDurationShort(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"seconds", 5 * time.Second, "5s"},
+		{"minutes", 3 * time.Minute, "3m"},
+		{"hours", 2 * time.Hour, "2h"},
+		{"days", 6*24*time.Hour + 23*time.Hour, "6d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, formatDurationShort(tt.d))
+		})
+	}
+}
+
+// TestFormatGCStatus verifies the GC suffix reads correctly across states.
+// Failure prevented: "gc in 6d ago" (countdown with a stray "ago") and the
+// verbose double-"ago" "(last 1h ago ago)".
+func TestFormatGCStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("never run shows gc due", func(t *testing.T) {
+		t.Parallel()
+		ws := WorkspaceSyncStatus{GCIntervalDays: 7} // LastGCTime zero
+		assert.Equal(t, "· gc due", strings.TrimSpace(stripANSI(formatGCStatus(ws, false))))
+	})
+
+	t.Run("recent gc shows countdown without ago", func(t *testing.T) {
+		t.Parallel()
+		ws := WorkspaceSyncStatus{
+			GCIntervalDays: 7,
+			LastGCTime:     time.Now().Add(-1 * time.Hour),
+		}
+		got := strings.TrimSpace(stripANSI(formatGCStatus(ws, false)))
+		assert.Equal(t, "· gc in 6d", got)
+		assert.NotContains(t, got, "ago")
+	})
+
+	t.Run("verbose appends single ago for elapsed", func(t *testing.T) {
+		t.Parallel()
+		ws := WorkspaceSyncStatus{
+			GCIntervalDays: 7,
+			LastGCTime:     time.Now().Add(-1 * time.Hour),
+		}
+		got := strings.TrimSpace(stripANSI(formatGCStatus(ws, true)))
+		assert.Equal(t, "· gc in 6d (last 1h ago)", got)
+		assert.NotContains(t, got, "ago ago")
+	})
+
+	t.Run("overdue shows gc due", func(t *testing.T) {
+		t.Parallel()
+		ws := WorkspaceSyncStatus{
+			GCIntervalDays: 7,
+			LastGCTime:     time.Now().Add(-8 * 24 * time.Hour),
+		}
+		assert.Equal(t, "· gc due", strings.TrimSpace(stripANSI(formatGCStatus(ws, false))))
+	})
 }
 
 func TestShortenPath_StatusDisplay(t *testing.T) {

--- a/internal/daemon/workspace_registry.go
+++ b/internal/daemon/workspace_registry.go
@@ -223,6 +223,7 @@ func (r *WorkspaceRegistry) rebuildFromConfigLocked(cfg *config.LocalConfig) {
 		existing.Path = cfg.Ledger.Path
 		existing.Endpoint = r.endpoint
 		existing.ConfigLastSync = cfg.Ledger.LastSync
+		existing.LastGCTime = cfg.Ledger.LastGC
 		existing.Exists = gitutil.IsGitRepo(cfg.Ledger.Path)
 
 		// backfill: if repo exists but was never marked as synced, set it now
@@ -279,6 +280,7 @@ func (r *WorkspaceRegistry) rebuildFromConfigLocked(cfg *config.LocalConfig) {
 		existing.Path = tc.Path
 		existing.Endpoint = r.endpoint
 		existing.ConfigLastSync = tc.LastSync
+		existing.LastGCTime = tc.LastGC
 		existing.Exists = tc.Path != "" && gitutil.IsGitRepo(tc.Path)
 
 		// populate clone URL from credentials (match by team ID or name)
@@ -552,13 +554,35 @@ func (r *WorkspaceRegistry) GetGCInterval(path string) int {
 	return 7
 }
 
-// UpdateLastGC records that GC completed for a workspace.
+// UpdateLastGC records that GC completed for a workspace, in both the registry
+// and config.local.toml. Persisting to disk lets the gc_interval_days cadence
+// survive daemon restarts — otherwise every restart zeroes LastGCTime and
+// re-reclones every workspace. Persistence is best-effort (mirrors the GC path's
+// other non-fatal steps); the in-memory update always happens.
 func (r *WorkspaceRegistry) UpdateLastGC(id string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if ws := r.workspaces[id]; ws != nil {
-		ws.LastGCTime = time.Now()
+	ws := r.workspaces[id]
+	if ws == nil {
+		return
+	}
+	ws.LastGCTime = time.Now()
+
+	// also persist to the config file
+	if r.localConfigCache == nil {
+		return // in-memory only; nothing to persist
+	}
+
+	switch ws.Type {
+	case WorkspaceTypeLedger:
+		r.localConfigCache.UpdateLedgerLastGC()
+	case WorkspaceTypeTeamContext:
+		r.localConfigCache.UpdateTeamContextLastGC(ws.TeamID)
+	}
+
+	if err := config.SaveLocalConfig(r.projectRoot, r.localConfigCache); err != nil {
+		slog.Warn("failed to persist last_gc to config.local.toml", "id", id, "error", err)
 	}
 }
 

--- a/internal/daemon/workspace_registry_test.go
+++ b/internal/daemon/workspace_registry_test.go
@@ -526,6 +526,55 @@ func TestUpdateConfigLastSync_PreservesLedgerPath(t *testing.T) {
 		"last_sync should be set after UpdateConfigLastSync")
 }
 
+// TestUpdateLastGC_PersistsAcrossReload verifies GC timestamps survive a daemon
+// restart. Failure prevented: LastGCTime lived only in memory, so every restart
+// zeroed it, made every workspace look "gc due", and re-recloned all repos —
+// defeating the gc_interval_days cadence.
+func TestUpdateLastGC_PersistsAcrossReload(t *testing.T) {
+	projectDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, ".sageox"), 0755))
+
+	ledgerPath := filepath.Join(t.TempDir(), "ledger")
+	require.NoError(t, os.MkdirAll(filepath.Join(ledgerPath, ".git"), 0755))
+	teamPath := filepath.Join(t.TempDir(), "team")
+	require.NoError(t, os.MkdirAll(filepath.Join(teamPath, ".git"), 0755))
+
+	// seed config with a ledger + one team context, no GC recorded yet
+	localCfg := &config.LocalConfig{
+		Ledger: &config.LedgerConfig{Path: ledgerPath},
+		TeamContexts: []config.TeamContext{
+			{TeamID: "team-1", TeamName: "Team One", Path: teamPath},
+		},
+	}
+	require.NoError(t, config.SaveLocalConfig(projectDir, localCfg))
+
+	reg := NewWorkspaceRegistry(projectDir, "test-repo")
+	reg.configCacheDuration = 1 * time.Hour // keep cache warm
+	require.NoError(t, reg.LoadFromConfig())
+
+	// record GC for both workspaces
+	reg.UpdateLastGC("ledger")
+	reg.UpdateLastGC("team-1")
+
+	// it must be written to disk, not just the in-memory map
+	reloaded, err := config.LoadLocalConfig(projectDir)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.Ledger)
+	assert.False(t, reloaded.Ledger.LastGC.IsZero(), "ledger last_gc should persist to disk")
+	require.Len(t, reloaded.TeamContexts, 1)
+	assert.False(t, reloaded.TeamContexts[0].LastGC.IsZero(), "team context last_gc should persist to disk")
+
+	// a fresh registry (simulating a daemon restart) must backfill LastGCTime
+	// from disk so the workspaces are no longer treated as overdue
+	fresh := NewWorkspaceRegistry(projectDir, "test-repo")
+	fresh.configCacheDuration = 1 * time.Hour
+	require.NoError(t, fresh.LoadFromConfig())
+	assert.False(t, fresh.GetLastGCTime("ledger").IsZero(),
+		"restart must backfill ledger LastGCTime from config")
+	assert.False(t, fresh.GetLastGCTime("team-1").IsZero(),
+		"restart must backfill team context LastGCTime from config")
+}
+
 func TestExponentialBackoff_Cap(t *testing.T) {
 	t.Parallel()
 	base := time.Minute


### PR DESCRIPTION
## What broke

`ox daemon status` showed nearly every team context as `· gc due` and the active one as `· gc in 6d ago` — which reads as broken even though GC is actually working. Two real defects were behind it:

- **GC timestamps never persisted to disk.** `WorkspaceRegistry.UpdateLastGC` only mutated the in-memory map. Nothing wrote `last_gc` to `config.local.toml`. On every daemon restart, all `LastGCTime` reset to zero, so `LastGCTime.IsZero()` was true for every workspace, so all repos showed `gc due` **and got fully recloned again** (one per hourly cycle). The 7-day `gc_interval_days` cadence was effectively meaningless across restarts — pure disk + bandwidth churn in an actively-restarting dev environment.
- **`gc in Nd ago` wording bug.** `formatGCStatus` built the *remaining-time* countdown with `formatRelativeTime`, which unconditionally appends `" ago"` (it was written for *elapsed* time). Verbose mode was worse: `(last 3d ago ago)` — a double "ago".

```mermaid
flowchart TD
    A["daemon restart"] --> B["LastGCTime resets to zero in memory"]
    B --> C["every workspace reads as gc due"]
    C --> D["full blue-green reclone, one per hourly cycle"]
    D --> E["UpdateLastGC sets time in memory only"]
    E --> A

    F["this PR: persist last_gc to config.local.toml"] -.-> G["restart backfills LastGCTime from disk"]
    G -.-> H["7-day cadence honored, no needless reclone"]
```

## What this PR ships

Persistence mirrors the existing `last_sync` field exactly — same struct, same registry-owned `SaveLocalConfig` path, same backfill-on-rebuild. No new storage location or file format.

- **`internal/config/local_config.go`** — `LastGC time.Time` (toml `last_gc`) on `LedgerConfig` and `TeamContext`; new `UpdateLedgerLastGC()` / `UpdateTeamContextLastGC()` mutators.
- **`internal/daemon/workspace_registry.go`** — `UpdateLastGC` now persists through the config cache (best-effort, like the GC path's other steps); `rebuildFromConfigLocked` backfills `LastGCTime` from config so a restarted daemon remembers when GC last ran. Self-healing for existing installs: one reclone records the timestamp, then it sticks.
- **`internal/daemon/status_display.go`** — new `formatDurationShort` helper (bare `6d` / `4h`, no "ago") used by `formatGCStatus`. `formatRelativeTime` and its 5 elapsed-timestamp callers are untouched.

## Out of scope (intentionally unchanged)

- The one-GC-per-hour drain (`break` in `sync_gc.go`) is correct — with persistence in place, each repo now GCs once per 7 days and remembers it.
- The `ledger: local changes could not be preserved for GC reclone` warning is the **dirty-skip safety net working as designed** (`gcSkippedDirty`), not a regression. Remediation is `ox doctor`.

## Test Plan

- New unit tests (all green):
  - `TestFormatDurationShort` — bare magnitude, no "ago".
  - `TestFormatGCStatus` — never-run / countdown / verbose / overdue states; asserts no stray or double "ago".
  - `TestUpdateLastGC_PersistsAcrossReload` — `last_gc` written to disk for ledger + team context, and a fresh registry backfills `LastGCTime` (simulated daemon restart).
- `go build ./...`, `go vet`, `gofmt` clean. `internal/config` + GC/format/registry daemon tests pass.
- Pre-existing, unrelated: `TestGlobalLease*` fail locally only because a live daemon holds the global-sync lease; the repo's 50 `errcheck` lint findings are all in untouched files.

## Manual verification

```
go build -o ox-tmp ./cmd/ox
# restart daemon, then:
ox daemon status   # recloned context shows "gc in <N>d" (no "ago"); stays put across a restart instead of reverting to "gc due"
```
