### PR TITLE
feat(kb): surface bubbles in daemon status + ledger-parity doctor checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.10.0"
+      "version": "0.10.1"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -689,4 +689,33 @@ func init() {
 		Description: "Migrates legacy .sageox/config.json projects to the new config.yaml binding format (ADR-017)",
 		Run:         checkKBProjectConfigMigrate,
 	})
+
+	// repo-health parity with ledger/team-context git doctoring — see
+	// doctor_kb_repo_health.go. Repairs kick the daemon (it owns kb git writes).
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugKBMissingClone,
+		Name:        "kb missing clones",
+		Category:    "Knowledge Bubbles",
+		FixLevel:    FixLevelAuto,
+		Description: "Flags bubbles the kb API lists that have no local clone; auto-fix kicks an immediate daemon sync to clone them",
+		Run:         checkKBMissingClone,
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugKBWedged,
+		Name:        "kb wedged repos",
+		Category:    "Knowledge Bubbles",
+		FixLevel:    FixLevelAuto,
+		Description: "Detects bubbles stuck in a merge/rebase (blocks the daemon's sync for every project); auto-fix kicks a daemon sync, then surfaces a manual abort if still wedged",
+		Run:         checkKBWedged,
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugKBSparseCheckout,
+		Name:        "kb sparse checkout",
+		Category:    "Knowledge Bubbles",
+		FixLevel:    FixLevelAuto,
+		Description: "Verifies .sageox stays in each bubble's sparse-checkout cone; auto-fix kicks a daemon sync to reapply sparse from the manifest",
+		Run:         checkKBSparseCheckout,
+	})
 }

--- a/cmd/ox/doctor_kb.go
+++ b/cmd/ox/doctor_kb.go
@@ -526,7 +526,7 @@ func runKBChecks(opts doctorOptions) []checkResult {
 		return nil
 	}
 
-	results := make([]checkResult, 0, 4)
+	results := make([]checkResult, 0, 7)
 	for _, fn := range []struct {
 		name string
 		run  func() checkResult
@@ -534,6 +534,9 @@ func runKBChecks(opts doctorOptions) []checkResult {
 		{"orphans", func() checkResult { return checkKBOrphans(opts.shouldFix(CheckSlugKBOrphans)) }},
 		{"provisioning", func() checkResult { return checkKBFailedProvision(false) }},
 		{"stale-sync", func() checkResult { return checkKBStaleSync(opts.shouldFix(CheckSlugKBStaleSync)) }},
+		{"missing-clone", func() checkResult { return checkKBMissingClone(opts.shouldFix(CheckSlugKBMissingClone)) }},
+		{"wedged", func() checkResult { return checkKBWedged(opts.shouldFix(CheckSlugKBWedged)) }},
+		{"sparse-checkout", func() checkResult { return checkKBSparseCheckout(opts.shouldFix(CheckSlugKBSparseCheckout)) }},
 		{"global-sync-owner", func() checkResult {
 			return checkKBGlobalSyncNoOwner(opts.shouldFix(CheckSlugKBGlobalSyncNoOwner))
 		}},

--- a/cmd/ox/doctor_kb_repo_health.go
+++ b/cmd/ox/doctor_kb_repo_health.go
@@ -1,0 +1,319 @@
+package main
+
+// Knowledge-bubble repo-health doctor checks — parity with the ledger and
+// team-context git-repo doctoring (doctor_ledger_git.go, doctor_ledger_infra.go,
+// doctor_team.go). A knowledge bubble is a daemon-managed git checkout under
+// paths.KBDir(kb_id) with the same .sageox/ layout, sparse-checkout, and
+// merge=union attributes a ledger or team context uses, so it shares their
+// failure modes:
+//
+//   1. Missing clone   — the API lists a bubble that was never cloned locally
+//                        (daemon never ran, or the global-sync owner died
+//                        before reconciling it). AutoFix kicks a daemon sync.
+//
+//   2. Wedged repo     — a stuck merge/rebase leaves U-state files. A wedged
+//                        bubble silently blocks the global-sync owner's
+//                        syncBubbles pass for EVERY daemon on the endpoint, so
+//                        this is Critical. AutoFix kicks a daemon sync (which
+//                        cleans lock files + autostashes); if still wedged the
+//                        check surfaces the exact manual abort command.
+//
+//   3. Sparse cone     — .sageox dropped out of the sparse-checkout cone, which
+//                        would hide kb.yaml / sync.manifest and break the next
+//                        pull's sparse reapply. AutoFix kicks a daemon sync
+//                        (the daemon reapplies sparse from the manifest).
+//
+// DESIGN: detection is read-only and runs CLI-side; repairs go through the
+// daemon (kbHookSync) rather than mutating the tree from the CLI. The daemon
+// owns kb git writes and serializes them with a per-kb_id flock
+// (internal/daemon/kb_lock.go); a CLI write here would race that lock. This is
+// why these checks kick the daemon instead of aborting/committing inline the
+// way the CLI-owned ledger checks do.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/gitutil"
+)
+
+// localKBDirsForHealth returns the kb root and the list of locally-cloned
+// kb_ids, or a SkippedCheck when there's nothing to inspect (no endpoint, no
+// local store, empty store). Shared preamble for the repo-health checks so
+// each one reads as just its specific logic.
+func localKBDirsForHealth(name string) (root string, ids []string, skip *checkResult) {
+	root, err := kbHookRoot()()
+	if err != nil {
+		r := SkippedCheck(name, "endpoint unresolved", "")
+		return "", nil, &r
+	}
+	if _, statErr := os.Stat(root); os.IsNotExist(statErr) {
+		r := SkippedCheck(name, "no local kb store yet", "")
+		return "", nil, &r
+	} else if statErr != nil {
+		r := SkippedCheck(name, "kb root unreadable", statErr.Error())
+		return "", nil, &r
+	}
+	ids, err = listLocalKBIDs(root)
+	if err != nil {
+		r := SkippedCheck(name, "kb root readdir failed", err.Error())
+		return "", nil, &r
+	}
+	return root, ids, nil
+}
+
+// ----------------------------------------------------------------------
+// Check: missing local clone (API has it, disk doesn't)
+// ----------------------------------------------------------------------
+
+// checkKBMissingClone flags bubbles the kb API lists that have no local clone.
+// The inverse of checkKBOrphans (on-disk but not in API). AutoFix kicks an
+// immediate daemon sync so the daemon clones them on its next reconcile.
+//
+// Skips when the kb API is unavailable — without the source of truth we can't
+// know what *should* be on disk.
+func checkKBMissingClone(fix bool) checkResult {
+	const name = "kb missing clones"
+
+	root, err := kbHookRoot()()
+	if err != nil {
+		return SkippedCheck(name, "endpoint unresolved", "")
+	}
+
+	listCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	bubbles, err := kbHookList()(listCtx)
+	if err != nil {
+		if errors.Is(err, api.ErrKBAPIUnavailable) {
+			kbHookLogger().Debug("kb_doctor missing-clone check skipped: kb API unavailable")
+			return SkippedCheck(name, "kb API unavailable", "")
+		}
+		return SkippedCheck(name, "kb API list failed", err.Error())
+	}
+	if len(bubbles) == 0 {
+		return PassedCheck(name, "no bubbles to sync")
+	}
+
+	// a bubble counts as cloned when <root>/<kb_id>/.git exists. A row present
+	// in the dir list but without .git is a partial clone the daemon will heal;
+	// we treat only a fully-absent dir as "missing" to avoid double-flagging
+	// with the wedge/partial paths.
+	var missing []string
+	for _, b := range bubbles {
+		if b.KBID == "" {
+			continue
+		}
+		// provision-failed bubbles have no repo yet — that's the provisioning
+		// check's job, not ours.
+		if b.LifecycleState == kbLifecycleProvisionFailed {
+			continue
+		}
+		gitDir := filepath.Join(root, b.KBID, ".git")
+		if _, statErr := os.Stat(gitDir); os.IsNotExist(statErr) {
+			label := b.Slug
+			if label == "" {
+				label = b.KBID
+			}
+			missing = append(missing, label)
+		}
+	}
+
+	if len(missing) == 0 {
+		return PassedCheck(name, fmt.Sprintf("%d bubble(s) cloned", len(bubbles)))
+	}
+	sort.Strings(missing)
+
+	msg := fmt.Sprintf("%d bubble(s) not yet cloned: %s", len(missing), strings.Join(missing, ", "))
+	detail := "daemon will clone on next sync; run `ox doctor --fix` to trigger it now"
+	if !fix {
+		return WarningCheck(name, msg, detail)
+	}
+
+	if syncErr := kickKBSync(); syncErr != nil {
+		kbHookLogger().Warn("kb_doctor missing-clone autofix failed", "error", syncErr, "missing", len(missing))
+		return WarningCheck(name, msg, fmt.Sprintf("Auto-fix hint: %v", syncErr))
+	}
+	return PassedCheck(name, fmt.Sprintf("kicked sync for %d missing bubble(s)", len(missing)))
+}
+
+// ----------------------------------------------------------------------
+// Check: wedged repo (stuck merge / rebase)
+// ----------------------------------------------------------------------
+
+// checkKBWedged scans each local bubble for a stuck merge/rebase (U-state
+// files or an in-progress rebase). A wedged bubble blocks the global-sync
+// owner's syncBubbles pass, so it's Critical. AutoFix kicks a daemon sync and
+// re-checks; anything still wedged gets the manual abort command.
+func checkKBWedged(fix bool) checkResult {
+	const name = "kb wedged repos"
+
+	root, ids, skip := localKBDirsForHealth(name)
+	if skip != nil {
+		return *skip
+	}
+	if len(ids) == 0 {
+		return PassedCheck(name, "no local bubbles")
+	}
+
+	wedged := make([]string, 0)
+	for _, id := range ids {
+		path := filepath.Join(root, id)
+		if !isGitRepo(path) {
+			continue
+		}
+		if kbRepoWedged(path) {
+			wedged = append(wedged, id)
+		}
+	}
+
+	if len(wedged) == 0 {
+		return PassedCheck(name, "no wedged bubbles")
+	}
+	sort.Strings(wedged)
+
+	msg := fmt.Sprintf("%d wedged bubble(s): %s", len(wedged), strings.Join(wedged, ", "))
+	if !fix {
+		r := CriticalCheck(name, msg, kbWedgedDetail(root, wedged))
+		r.slug = CheckSlugKBWedged
+		r.fixLevel = FixLevelAuto
+		return r
+	}
+
+	if syncErr := kickKBSync(); syncErr != nil {
+		r := CriticalCheck(name, msg, fmt.Sprintf("Auto-fix hint: %v\n%s", syncErr, kbWedgedDetail(root, wedged)))
+		r.slug = CheckSlugKBWedged
+		return r
+	}
+
+	// re-check: the daemon sync cleans lock files + autostashes and move-asides
+	// corrupt repos, but a genuine rebase wedge may persist.
+	var stillWedged []string
+	for _, id := range wedged {
+		if kbRepoWedged(filepath.Join(root, id)) {
+			stillWedged = append(stillWedged, id)
+		}
+	}
+	if len(stillWedged) > 0 {
+		r := CriticalCheck(name,
+			fmt.Sprintf("%d bubble(s) still wedged after sync", len(stillWedged)),
+			kbWedgedDetail(root, stillWedged))
+		r.slug = CheckSlugKBWedged
+		return r
+	}
+	return PassedCheck(name, fmt.Sprintf("cleared %d wedged bubble(s)", len(wedged)))
+}
+
+// kbRepoWedged reports whether a bubble checkout is in a stuck merge/rebase.
+func kbRepoWedged(path string) bool {
+	if gitutil.IsRebaseInProgress(path) {
+		return true
+	}
+	out, err := exec.Command("git", "-C", path, "status", "--porcelain=v1").Output()
+	if err != nil {
+		// can't inspect — don't claim wedged on a read failure.
+		return false
+	}
+	return len(parseUnmergedPaths(string(out))) > 0
+}
+
+// kbWedgedDetail builds the manual-recovery hint listing each wedged bubble's
+// path and the abort command, so a user can clear a wedge the daemon couldn't.
+func kbWedgedDetail(root string, ids []string) string {
+	var b strings.Builder
+	b.WriteString("a stuck merge/rebase blocks the daemon's sync of these bubbles for EVERY project:\n")
+	for _, id := range ids {
+		path := filepath.Join(root, id)
+		fmt.Fprintf(&b, "       %s — `git -C %s rebase --abort` (or `merge --abort`)\n", id, path)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// ----------------------------------------------------------------------
+// Check: sparse-checkout cone integrity
+// ----------------------------------------------------------------------
+
+// checkKBSparseCheckout verifies that each sparse-checkout-enabled bubble keeps
+// .sageox in its cone — without it, kb.yaml / sync.manifest are hidden and the
+// next pull's sparse reapply breaks. Mirrors checkLedgerSparseCheckout and the
+// team sparse-checkout check. AutoFix kicks a daemon sync (the daemon reapplies
+// sparse from the manifest on pull).
+func checkKBSparseCheckout(fix bool) checkResult {
+	const name = "kb sparse checkout"
+
+	root, ids, skip := localKBDirsForHealth(name)
+	if skip != nil {
+		return *skip
+	}
+	if len(ids) == 0 {
+		return PassedCheck(name, "no local bubbles")
+	}
+
+	var broken []string
+	var checked int
+	for _, id := range ids {
+		path := filepath.Join(root, id)
+		if !isGitRepo(path) {
+			continue
+		}
+		sparseFile := filepath.Join(path, ".git", "info", "sparse-checkout")
+		content, err := os.ReadFile(sparseFile)
+		if err != nil {
+			// no sparse-checkout file = full checkout for this bubble; skip it.
+			continue
+		}
+		checked++
+		if !sparseConeIncludesSageox(string(content)) {
+			broken = append(broken, id)
+		}
+	}
+
+	if len(broken) == 0 {
+		if checked == 0 {
+			return SkippedCheck(name, "no sparse-checkout bubbles", "")
+		}
+		return PassedCheck(name, fmt.Sprintf("%d bubble(s) include .sageox in cone", checked))
+	}
+	sort.Strings(broken)
+
+	msg := fmt.Sprintf("%d bubble(s) missing .sageox from sparse cone: %s", len(broken), strings.Join(broken, ", "))
+	detail := "kb.yaml/sync.manifest are hidden; run `ox doctor --fix` to have the daemon reapply sparse from the manifest"
+	if !fix {
+		r := WarningCheck(name, msg, detail)
+		r.slug = CheckSlugKBSparseCheckout
+		r.fixLevel = FixLevelAuto
+		return r
+	}
+
+	if syncErr := kickKBSync(); syncErr != nil {
+		return WarningCheck(name, msg, fmt.Sprintf("Auto-fix hint: %v", syncErr))
+	}
+	return PassedCheck(name, fmt.Sprintf("kicked sync to reapply sparse for %d bubble(s)", len(broken)))
+}
+
+// sparseConeIncludesSageox reports whether a sparse-checkout file lists .sageox
+// in its cone. Matches checkLedgerSparseCheckout's parse.
+func sparseConeIncludesSageox(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == ".sageox" || trimmed == ".sageox/" || trimmed == "/.sageox" || trimmed == "/.sageox/" {
+			return true
+		}
+	}
+	return false
+}
+
+// kickKBSync triggers an immediate daemon sync via the shared kb doctor hook,
+// the same repair primitive checkKBStaleSync uses.
+func kickKBSync() error {
+	syncCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	return kbHookSync()(syncCtx)
+}

--- a/cmd/ox/doctor_kb_repo_health_test.go
+++ b/cmd/ox/doctor_kb_repo_health_test.go
@@ -1,0 +1,179 @@
+package main
+
+// Tests for the knowledge-bubble repo-health doctor checks
+// (doctor_kb_repo_health.go): missing-clone, wedged, sparse-checkout. These
+// give kb parity with the ledger/team-context git-repo doctoring. Each test
+// uses a tmpdir-backed kb root via kbDoctorHooks — no network, no daemon.
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitInitKBDir creates <root>/<kbID> as a real (minimal) git repo so isGitRepo
+// and `git status` work. Returns the repo path.
+func gitInitKBDir(t *testing.T, root, kbID string) string {
+	t.Helper()
+	dir := filepath.Join(root, kbID)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		require.NoError(t, cmd.Run(), "git %v", args)
+	}
+	return dir
+}
+
+// ---- missing-clone ----
+
+// TestCheckKBMissingClone_FlagsUncloned verifies a bubble the API lists with no
+// local .git is reported and the daemon kick fires on --fix.
+// Failure prevented: a subscribed bubble never reaches disk and the user has no
+// signal that sync hasn't happened.
+func TestCheckKBMissingClone_FlagsUncloned(t *testing.T) {
+	root, h := kbTestSetup(t)
+	gitInitKBDir(t, root, "kb_have") // cloned
+	h.List = func(_ context.Context) ([]api.KB, error) {
+		return []api.KB{
+			{KBID: "kb_have", Slug: "have"},
+			{KBID: "kb_missing", Slug: "missing"},
+		}, nil
+	}
+	applyHooks(h)
+
+	res := checkKBMissingClone(false)
+	assert.True(t, res.passed && res.warning, "missing clone must warn; got %+v", res)
+	assert.Contains(t, res.message, "missing")
+	assert.NotContains(t, res.message, "have")
+
+	synced := 0
+	h.Sync = func(_ context.Context) error { synced++; return nil }
+	applyHooks(h)
+	res = checkKBMissingClone(true)
+	assert.Equal(t, 1, synced, "fix must kick exactly one daemon sync")
+	assert.True(t, res.passed && !res.warning, "post-fix kick should pass; got %+v", res)
+}
+
+// TestCheckKBMissingClone_IgnoresProvisionFailed verifies a provision-failed
+// bubble (no repo yet) is not mistaken for a missing clone — that's the
+// provisioning check's job.
+func TestCheckKBMissingClone_IgnoresProvisionFailed(t *testing.T) {
+	root, h := kbTestSetup(t)
+	gitInitKBDir(t, root, "kb_ok")
+	h.List = func(_ context.Context) ([]api.KB, error) {
+		return []api.KB{
+			{KBID: "kb_ok", Slug: "ok"},
+			{KBID: "kb_bad", Slug: "bad", LifecycleState: "provision-failed"},
+		}, nil
+	}
+	applyHooks(h)
+
+	res := checkKBMissingClone(false)
+	assert.True(t, res.passed && !res.warning, "provision-failed must not count as missing; got %+v", res)
+}
+
+// TestCheckKBMissingClone_APIUnavailableSkips verifies the check skips (never
+// flags) when the kb API can't be reached.
+func TestCheckKBMissingClone_APIUnavailableSkips(t *testing.T) {
+	_, h := kbTestSetup(t)
+	h.List = func(_ context.Context) ([]api.KB, error) { return nil, api.ErrKBAPIUnavailable }
+	applyHooks(h)
+
+	res := checkKBMissingClone(false)
+	assert.True(t, res.skipped, "API-unavailable must skip; got %+v", res)
+}
+
+// ---- wedged ----
+
+// TestCheckKBWedged_DetectsRebaseInProgress verifies a bubble stuck mid-rebase
+// is reported Critical with the manual abort hint.
+// Failure prevented: a wedged bubble silently blocks the global-sync owner's
+// syncBubbles pass for every project, with no doctor signal.
+func TestCheckKBWedged_DetectsRebaseInProgress(t *testing.T) {
+	root, h := kbTestSetup(t)
+	dir := gitInitKBDir(t, root, "kb_wedged")
+	gitInitKBDir(t, root, "kb_clean")
+	// simulate an in-progress rebase the way gitutil.IsRebaseInProgress detects.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git", "rebase-merge"), 0o755))
+	applyHooks(h)
+
+	res := checkKBWedged(false)
+	assert.False(t, res.passed, "wedged repo must fail the check; got %+v", res)
+	assert.Equal(t, "critical", res.priority, "wedge must be critical")
+	assert.Contains(t, res.message, "kb_wedged")
+	assert.Contains(t, res.detail, "rebase --abort")
+}
+
+// TestCheckKBWedged_CleanPasses verifies healthy bubbles pass.
+func TestCheckKBWedged_CleanPasses(t *testing.T) {
+	root, h := kbTestSetup(t)
+	gitInitKBDir(t, root, "kb_a")
+	gitInitKBDir(t, root, "kb_b")
+	applyHooks(h)
+
+	res := checkKBWedged(false)
+	assert.True(t, res.passed && !res.warning, "clean repos must pass; got %+v", res)
+}
+
+// TestCheckKBWedged_FixKicksThenRechecks verifies --fix kicks a daemon sync and,
+// when the wedge persists (test never clears it), still reports critical.
+func TestCheckKBWedged_FixKicksThenRechecks(t *testing.T) {
+	root, h := kbTestSetup(t)
+	dir := gitInitKBDir(t, root, "kb_wedged")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git", "rebase-merge"), 0o755))
+	synced := 0
+	h.Sync = func(_ context.Context) error { synced++; return nil }
+	applyHooks(h)
+
+	res := checkKBWedged(true)
+	assert.Equal(t, 1, synced, "fix must attempt a daemon sync")
+	assert.Equal(t, "critical", res.priority, "still-wedged must stay critical; got %+v", res)
+}
+
+// ---- sparse-checkout ----
+
+// TestCheckKBSparseCheckout_FlagsMissingSageox verifies a sparse cone without
+// .sageox is flagged, while a cone with it passes.
+// Failure prevented: .sageox drops from the cone, hiding kb.yaml/sync.manifest
+// and silently breaking the next pull's sparse reapply.
+func TestCheckKBSparseCheckout_FlagsMissingSageox(t *testing.T) {
+	root, h := kbTestSetup(t)
+	bad := gitInitKBDir(t, root, "kb_bad")
+	good := gitInitKBDir(t, root, "kb_good")
+	writeSparse(t, bad, "/*\n!/*/\nsrc\n")           // no .sageox
+	writeSparse(t, good, "/*\n!/*/\n.sageox\nsrc\n") // includes .sageox
+	applyHooks(h)
+
+	res := checkKBSparseCheckout(false)
+	assert.True(t, res.passed && res.warning, "missing .sageox must warn; got %+v", res)
+	assert.Contains(t, res.message, "kb_bad")
+	assert.NotContains(t, res.message, "kb_good")
+}
+
+// TestCheckKBSparseCheckout_NoSparseFileSkips verifies bubbles with full
+// checkout (no sparse-checkout file) don't trigger the check.
+func TestCheckKBSparseCheckout_NoSparseFileSkips(t *testing.T) {
+	root, h := kbTestSetup(t)
+	gitInitKBDir(t, root, "kb_full") // no sparse-checkout file
+	applyHooks(h)
+
+	res := checkKBSparseCheckout(false)
+	assert.True(t, res.skipped, "no sparse bubbles must skip; got %+v", res)
+}
+
+func writeSparse(t *testing.T, repoDir, content string) {
+	t.Helper()
+	infoDir := filepath.Join(repoDir, ".git", "info")
+	require.NoError(t, os.MkdirAll(infoDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(infoDir, "sparse-checkout"), []byte(content), 0o644))
+}

--- a/cmd/ox/doctor_kb_test.go
+++ b/cmd/ox/doctor_kb_test.go
@@ -357,23 +357,29 @@ func TestRunKBChecks_SkipsAPIChecksWhenAPIUnavailable_RunsStaleSync(t *testing.T
 	t.Cleanup(func() { SetKBGlobalSyncReader(nil) })
 
 	results := runKBChecks(doctorOptions{fix: false})
-	// Four checks expected: orphans, provisioning, stale-sync,
-	// global-sync-owner (added in ox-6zme).
-	require.Len(t, results, 4, "all four checks must run")
+	// Seven checks expected, in order: orphans, provisioning, stale-sync,
+	// missing-clone, wedged, sparse-checkout (repo-health parity), then
+	// global-sync-owner (ox-6zme).
+	require.Len(t, results, 7, "all kb checks must run")
 
-	// orphans (idx 0) and provisioning (idx 1) must be skipped
+	// orphans (idx 0), provisioning (idx 1), missing-clone (idx 3) all depend
+	// on the kb API and must skip when it's unavailable.
 	assert.True(t, results[0].skipped, "orphans must skip when API unavailable")
 	assert.True(t, results[1].skipped, "provisioning must skip when API unavailable")
+	assert.True(t, results[3].skipped, "missing-clone must skip when API unavailable")
 
-	// stale-sync (idx 2) must still produce a real signal
+	// stale-sync (idx 2) must still produce a real signal — it's local-only.
 	assert.True(t, results[2].warning, "stale-sync must surface even without API; got %+v", results[2])
 	assert.Contains(t, results[2].message, "kb_stale")
 
-	// global-sync-owner (idx 3) is independent of the kb API; it reads
-	// the daemon registry. In this test the registry is not stubbed and
-	// will skip with "no daemons report endpoint" or "no running
-	// daemons" depending on the host. Just assert it ran (no panic).
-	assert.NotEmpty(t, results[3].name, "global-sync-owner check must run")
+	// wedged (idx 4) and sparse-checkout (idx 5) are local-only repo-health
+	// checks; with only a metadata-seeded (non-git) bubble they run cleanly.
+	assert.True(t, results[4].passed, "wedged must run locally; got %+v", results[4])
+	assert.NotEmpty(t, results[5].name, "sparse-checkout check must run")
+
+	// global-sync-owner (idx 6) is independent of the kb API; it reads the
+	// daemon registry. Just assert it ran (no panic).
+	assert.NotEmpty(t, results[6].name, "global-sync-owner check must run")
 }
 
 // TestRunKBChecks_PanicInOneCheckDoesNotCascade verifies the per-check
@@ -398,9 +404,10 @@ func TestRunKBChecks_PanicInOneCheckDoesNotCascade(t *testing.T) {
 	t.Cleanup(func() { SetKBGlobalSyncReader(nil) })
 
 	results := runKBChecks(doctorOptions{fix: false})
-	// Four checks expected: orphans, provisioning, stale-sync,
-	// global-sync-owner (added in ox-6zme).
-	require.Len(t, results, 4, "every check must run independently")
+	// Seven checks expected: orphans, provisioning, stale-sync, missing-clone,
+	// wedged, sparse-checkout, global-sync-owner. The List panic only takes
+	// down the API-backed checks; the rest run independently.
+	require.Len(t, results, 7, "every check must run independently")
 
 	// orphan check (which calls List) panicked → recovered → reported as failure
 	assert.False(t, results[0].passed, "orphan check should fail after panic")
@@ -409,6 +416,9 @@ func TestRunKBChecks_PanicInOneCheckDoesNotCascade(t *testing.T) {
 	assert.True(t, results[2].warning, "stale-sync must run even after orphan panic")
 	assert.Contains(t, results[2].message, "kb_stale")
 
-	// global-sync-owner (idx 3) is independent of the kb API panic.
-	assert.NotEmpty(t, results[3].name, "global-sync-owner check must run despite orphan panic")
+	// missing-clone (idx 3) also calls List → recovered panic → not passed.
+	assert.False(t, results[3].passed, "missing-clone should fail after List panic")
+
+	// global-sync-owner (idx 6) is independent of the kb API panic.
+	assert.NotEmpty(t, results[6].name, "global-sync-owner check must run despite orphan panic")
 }

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -215,6 +215,15 @@ const (
 	// CheckSlugKBProjectConfigMigrate is co-located with its impl in
 	// doctor_kb_migrate.go to keep the v1 migration check self-contained.
 
+	// Knowledge-bubble repo-health checks — parity with ledger/team-context
+	// git-repo doctoring. A bubble is a daemon-managed git checkout like a
+	// ledger, so the same wedge/sparse/sync failure modes apply. Repairs kick
+	// the daemon (which owns kb git writes) rather than mutating the tree from
+	// the CLI. See doctor_kb_repo_health.go and docs/specs/kb-daemon-sync.md.
+	CheckSlugKBMissingClone   = "kb-missing-clone"
+	CheckSlugKBWedged         = "kb-wedged"
+	CheckSlugKBSparseCheckout = "kb-sparse-checkout"
+
 	// Global-sync leader-election checks (ox-6zme)
 	CheckSlugKBGlobalSyncNoOwner = "kb-global-sync-no-owner"
 )

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-06-15
+
+### Added
+
+- **Knowledge Bubbles now appear in `ox daemon status`** — the daemon reports every bubble it has synced to disk (slug, type, freshness), plus a badge showing whether *this* daemon keeps them fresh or a sibling daemon does. Previously the daemon synced bubbles silently with no way to see what was happening.
+- **`ox doctor` gained knowledge-bubble repo health checks at parity with ledgers and team contexts** — detects bubbles the cloud lists but that were never cloned, bubbles wedged in a stuck merge/rebase (which silently block sync for every project), and bubbles whose sparse-checkout dropped `.sageox`. Repairs route through the daemon so they never collide with an in-flight sync.
+
+### Changed
+
+- **Knowledge Bubbles are now first-class in daemon status output** — the JSON `bubbles[]` array and a human-readable "Knowledge Bubbles" section make it clear which bubbles are local, fresh, and who is responsible for syncing them.
+
 ## [0.10.0] - 2026-06-11
 
 ### Added

--- a/docs/specs/kb-daemon-sync.md
+++ b/docs/specs/kb-daemon-sync.md
@@ -1,0 +1,163 @@
+# Knowledge-Bubble Sync — daemon model, multi-daemon coordination, doctor parity
+
+> How knowledge bubbles (kb) are synced to disk, why N concurrent daemons don't
+> step on each other, what `ox daemon status` / `ox doctor` report, and the one
+> deliberately-deferred question (agents without a git repo).
+
+Knowledge bubbles are the kb-era successor to **ledgers** and **team contexts**
+(ADR-028/030 in `sageox-mono`). A bubble is a single git repo cloned into a
+canonical XDG path and kept fresh by the daemon — the same shape ledgers and
+team contexts already had. This doc records how the CLI side handles them so the
+model isn't re-derived every time someone touches kb sync.
+
+---
+
+## On-disk layout
+
+```
+~/.local/share/sageox/<endpoint>/kb/<kb_id>/      # one clone per bubble (immutable kb_id key)
+  .git/
+  .sageox/
+    meta.json        # daemon-written: {type, slug, owner_user_id, viewer_role, last_sync}
+    kb.yaml          # server-pushed bubble metadata
+    sync.manifest    # sparse-checkout rules
+```
+
+`paths.KBDir(kb_id)` is the canonical path; `paths.KBDir("")` is the per-endpoint
+root. Bubbles are keyed by the **immutable** `kb_id`, never the renameable slug.
+
+---
+
+## Who syncs bubbles — leader-gated, exactly like team context
+
+There is **one daemon per ledger/worktree**, so a user with N projects open runs
+N daemons concurrently. All of them share the *same* on-disk kb store. To avoid N
+daemons each cloning/pulling the same bubbles every 15s, kb sync is gated by the
+**per-(user, endpoint) global-sync flock lease** — the identical mechanism that
+already gates team-context pulls (bead ox-6zme).
+
+```mermaid
+flowchart TD
+    subgraph host["One machine, N per-ledger daemons (same endpoint)"]
+        DA["Daemon A (ledger-1)"]
+        DB["Daemon B (ledger-2)"]
+        DC["Daemon C (ledger-3)"]
+    end
+    Lease["per-endpoint flock lease<br/>global-sync.lease"]
+    DA -->|"LOCK_EX, owner"| Lease
+    DB -->|"ErrNotOwner, skip"| Lease
+    DC -->|"ErrNotOwner, skip"| Lease
+    DA -->|"pullTeamContexts + syncBubbles"| Disk["shared XDG kb store<br/>KBDir(kb_id)"]
+    DB -.->|"reads on-disk state only"| Disk
+    DC -.->|"reads on-disk state only"| Disk
+    DA -->|"per-kb flock before each reconcile"| KBLock["kb-locks/&lt;kb_id&gt;.lock"]
+```
+
+**Two layers, both `flock(2)`, both kernel-released on process death:**
+
+1. **Global-sync lease** (`internal/daemon/global_lease.go`). Acquired once at
+   daemon startup. In the scheduler loop (`internal/daemon/sync.go`, the
+   `teamContextChan` case) only `IsGlobalSyncOwner()` runs `pullTeamContexts`
+   **and** `syncBubbles`. Followers skip both and consume the on-disk state the
+   owner keeps fresh. One API `ListBubbles` call per endpoint, not per daemon.
+
+2. **Per-kb lease** (`internal/daemon/kb_lock.go`). `reconcileBubble` takes a
+   `LOCK_EX|LOCK_NB` on `kb-locks/<kb_id>.lock` before any clone/pull. This is a
+   belt-and-suspenders layer: even if the global lease is bypassed (manual
+   `OX_KB_DISABLE` toggling, lease-file weirdness), two daemons can never clone
+   the same bubble dir simultaneously or have GC rename a clone mid-write.
+
+**Invariant for followers:** a follower daemon never writes a bubble dir. It can
+still *read* and *report* what's on disk — which is exactly what
+`ox daemon status` does (below).
+
+Escape hatch: `OX_KB_DISABLE=1` takes the daemon's kb sync loop offline, mirroring
+the client-side merger short-circuit in `internal/kb/merge.go`.
+
+---
+
+## `ox daemon status` — what's synced + who owns sync
+
+`StatusData.Workspaces["kb"]` carries one row per locally-cloned bubble, scanned
+from disk (`SyncScheduler.kbWorkspaceStatus` in `internal/daemon/status_kb.go`):
+`kb_id`, slug, type, `.git` existence, and `last_sync` from `meta.json`. Because
+it's a pure disk scan, **any** daemon — owner or follower — reports the same
+picture.
+
+`StatusData.GlobalSyncOwner` / `GlobalSyncEndpoint` tell the user whether *this*
+daemon pulls the bubbles or a sibling does. The human view renders a
+"Knowledge Bubbles (N · syncing here)" or "(N · synced by another daemon
+(<endpoint>))" header so a follower never looks idle when the owner is busy.
+
+---
+
+## `ox doctor` — kb checks, at parity with ledger/team-context
+
+A bubble is a daemon-managed git checkout like a ledger, so it shares the same
+failure modes. The kb checks (`cmd/ox/doctor_kb.go`,
+`doctor_kb_repo_health.go`, `doctor_kb_global_sync.go`,
+`doctor_kb_migrate.go`):
+
+| kb check | Mirrors | What it catches | Fix |
+|---|---|---|---|
+| `kb-orphans` | `orphaned-team-dirs` | on-disk kb_id absent from API list | daemon GC move-aside |
+| `kb-missing-clone` | (inverse of orphans) | API bubble with no local clone | kick daemon sync |
+| `kb-wedged` | `ledger-unmerged-paths` | stuck merge/rebase (U-state / rebase dir) — **Critical**, blocks the owner's sync for every project | kick daemon sync, else manual `rebase --abort` |
+| `kb-sparse-checkout` | `ledger-sparse-checkout`, `team-sparse-checkout` | `.sageox` dropped from sparse cone | kick daemon sync (reapply from manifest) |
+| `kb-stale-sync` | (kb-specific) | `meta.json` `last_sync` > 1h | kick daemon sync |
+| `kb-failed-provision` | (kb-specific) | server `lifecycle_state=provision-failed` | requires-agent (server side) |
+| `kb-global-sync-no-owner` | (kb-specific, ox-6zme) | an endpoint with daemons but no lease holder | check-only |
+| `kb-project-config-migrate` | (kb-specific, ADR-017) | legacy `config.json` → `config.yaml` | auto |
+
+**Design rule — repairs go through the daemon, not the CLI.** The daemon owns kb
+git writes and serializes them with the per-kb flock. A kb doctor repair therefore
+*kicks a daemon sync* (`kbHookSync`) rather than committing/aborting inline the way
+the CLI-owned ledger checks do — a CLI write into a daemon-managed tree would race
+the per-kb lock. Detection is read-only and runs CLI-side. See the header comment
+in `doctor_kb_repo_health.go`.
+
+**Intentionally deferred (not yet ported from ledger/team):**
+
+- **Secret scanning** (`ledger-secrets`). Ledger scans its `sessions/` tree for
+  credential patterns. Bubbles have no `sessions/` — they hold imported data,
+  murmurs, and recordings. A kb scan would need a different target set and a
+  policy decision; deferred until kb import flows settle.
+- **Dirty-workdir / cache-tracked auto-commit** (`ledger-clean-workdir`,
+  `ledger-cache-tracked`). These auto-commit from the CLI. For a daemon-managed
+  tree that's the wrong owner; if needed, the repair belongs in the daemon's
+  reconcile pass, not in doctor.
+- **Remote-URL / embedded-creds audit** (`ledger-url-api-match`,
+  `ledger-embedded-creds`). Bubble remotes are set by the daemon at clone time;
+  the daemon is the right place to correct drift, not a CLI doctor check.
+
+---
+
+## Future / open question — agents without a git repo (Cloud Co-Work)
+
+Today the CLI is **repo-bound**: endpoint resolution and credentials flow from a
+project root, and the daemon's `syncBubbles` returns early when `ProjectRoot == ""`.
+Bubbles bind to the current repo via the cwd `.kb-marker` (`internal/kb/resolve.go`).
+
+Cloud Co-Work may run an AI coworker with **no git repo at all**. In the cloud
+model, bubbles are explicitly *not* tied to repos (ADR-028), so the repo-bound
+assumption doesn't carry over cleanly.
+
+**Decision (now): keep the CLI repo-bound.** Breaking the repo binding touches
+endpoint resolution, daemon lifecycle, and selection — too much blast radius for
+a case that doesn't exist in the product yet. When it does, the likely surface is
+a **global/no-repo binding**: resolve a "current bubble" from an env var (`OX_KB`)
+or an XDG-global marker when no git root is found, leaving the repo path unchanged.
+Captured here so the tradeoff isn't re-litigated; no implementation until
+Cloud Co-Work needs it.
+
+---
+
+## Pointers
+
+- Leader election: `internal/daemon/global_lease.go`
+- Per-kb serialization: `internal/daemon/kb_lock.go`
+- Sync loop gate: `internal/daemon/sync.go` (`teamContextChan` case, `IsGlobalSyncOwner`)
+- Reconcile: `internal/daemon/sync_bubbles.go`
+- Status scan: `internal/daemon/status_kb.go`
+- Doctor checks: `cmd/ox/doctor_kb*.go`
+- Domain model (cloud): `sageox-mono` ADR-028, ADR-030, ADR-032

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1581,6 +1581,16 @@ func (s *daemonServiceImpl) Status() *StatusData {
 		}
 	}
 
+	// knowledge bubbles: scanned from disk so any daemon (owner or follower)
+	// reports what's synced. Only the global-sync owner actually writes these
+	// dirs (see sync.go:920-928), but the on-disk state is the shared truth.
+	if kbRows := s.d.scheduler.kbWorkspaceStatus(); len(kbRows) > 0 {
+		workspaces["kb"] = kbRows
+	}
+
+	globalSyncOwner := s.d.scheduler.IsGlobalSyncOwner()
+	globalSyncEndpoint := endpoint.NormalizeEndpoint(endpoint.GetForProject(s.d.config.ProjectRoot))
+
 	return &StatusData{
 		Running:            true,
 		Pid:                os.Getpid(),
@@ -1598,6 +1608,8 @@ func (s *daemonServiceImpl) Status() *StatusData {
 		AvgSyncTime:        stats.AvgDuration,
 		Workspaces:         workspaces,
 		ProjectTeamID:      projectTeamID,
+		GlobalSyncOwner:    globalSyncOwner,
+		GlobalSyncEndpoint: globalSyncEndpoint,
 		TeamContexts:       s.d.scheduler.TeamContextStatus(),
 		InactivityTimeout:  s.d.config.InactivityTimeout,
 		TimeSinceActivity:  s.d.timeSinceLastActivity(),

--- a/internal/daemon/global_lease_test.go
+++ b/internal/daemon/global_lease_test.go
@@ -6,9 +6,13 @@ package daemon
 // kb_lock_test.go: in-process contention, cross-endpoint independence,
 // and a subprocess-based owner-death failover.
 //
-// All tests redirect the lease directory via t.Setenv on XDG_STATE_HOME
-// (paths.DaemonStateDir resolves under StateDir → XDG_STATE_HOME) so the
-// developer's real ~/.local/state/ox state is never touched.
+// All tests redirect the lease directory to a per-test temp dir so the
+// developer's real daemon state — and the lease their running daemons
+// actually hold — is never touched. In the default XDG mode
+// paths.DaemonStateDir resolves under StateDir → xdgRuntimeDir →
+// XDG_RUNTIME_DIR (NOT XDG_STATE_HOME), so the isolation MUST set
+// XDG_RUNTIME_DIR; setting only XDG_STATE_HOME silently no-ops and the
+// tests then contend with live daemons for the real lease.
 
 import (
 	"errors"
@@ -23,13 +27,17 @@ import (
 	"time"
 )
 
-// withIsolatedLeaseDir redirects paths.DaemonStateDir → tmp dir via
-// XDG_STATE_HOME for the duration of the test. Also resets the
-// package-level globalLeaseDirOnce so a fresh per-test directory is
-// created instead of reusing a cached one from a previous test.
+// withIsolatedLeaseDir redirects paths.DaemonStateDir → tmp dir for the
+// duration of the test. In XDG mode StateDir derives from XDG_RUNTIME_DIR,
+// so that is the env var that actually moves the lease path; XDG_STATE_HOME
+// is set too (it carries the marker-file dir in the subprocess test and
+// covers the non-XDG fallback). Also resets the package-level
+// globalLeaseDirOnce so a fresh per-test directory is created instead of
+// reusing a cached one from a previous test.
 func withIsolatedLeaseDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", dir)
 	t.Setenv("XDG_STATE_HOME", dir)
 	// reset memoized state so this test sees the redirected XDG path.
 	globalLeaseDirOnce = sync.Once{}
@@ -244,6 +252,9 @@ func TestGlobalLeaseSubprocessFailover(t *testing.T) {
 	cmd.Env = append(os.Environ(), // safe: re-execs test binary, not ox CLI
 		"OX_TEST_HOLD_LEASE=1",
 		"OX_TEST_HOLD_ENDPOINT=sageox.ai",
+		// XDG_RUNTIME_DIR moves the lease path (StateDir reads it in XDG
+		// mode); XDG_STATE_HOME carries the marker-file dir the helper writes.
+		"XDG_RUNTIME_DIR="+dir,
 		"XDG_STATE_HOME="+dir,
 	)
 	if err := cmd.Start(); err != nil {

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -117,10 +117,22 @@ type StatusData struct {
 	SyncsLastHour int           `json:"syncs_last_hour,omitempty"`
 	AvgSyncTime   time.Duration `json:"avg_sync_time,omitempty"`
 
-	// workspaces being synced, keyed by type ("ledger", "team-context")
-	// each type maps to a list of workspaces of that type (ledger has 1, team-context may have many)
+	// workspaces being synced, keyed by type ("ledger", "team-context", "kb")
+	// each type maps to a list of workspaces of that type (ledger has 1,
+	// team-context and kb may have many)
 	Workspaces    map[string][]WorkspaceSyncStatus `json:"workspaces,omitempty"`
 	ProjectTeamID string                           `json:"project_team_id,omitempty"` // primary team for this project
+
+	// GlobalSyncOwner reports whether THIS daemon holds the per-endpoint
+	// flock lease that gates team-context pulls and knowledge-bubble sync.
+	// Followers (false) consume the on-disk state the owner keeps fresh — so
+	// kb rows can still be listed by any daemon, but only the owner writes them.
+	// See internal/daemon/global_lease.go (bead ox-6zme).
+	GlobalSyncOwner bool `json:"global_sync_owner,omitempty"`
+	// GlobalSyncEndpoint is the normalized endpoint this daemon's global-sync
+	// ownership applies to. Surfaced so a follower can say "synced by another
+	// daemon at <endpoint>" rather than implying nothing is syncing.
+	GlobalSyncEndpoint string `json:"global_sync_endpoint,omitempty"`
 
 	// team context sync (deprecated: use Workspaces["team-context"] instead)
 	TeamContexts []TeamContextSyncStatus `json:"team_contexts,omitempty"`
@@ -227,14 +239,16 @@ func GetExtendedStatus(s *StatusData) (ExtendedStatus, bool) {
 // WorkspaceSyncStatus represents the sync status of a workspace (ledger or team context).
 // Provides a unified view of all repos the daemon is syncing.
 type WorkspaceSyncStatus struct {
-	ID             string    `json:"id"`                         // workspace ID (e.g., "ledger", team_id)
-	Type           string    `json:"type"`                       // "ledger" or "team_context"
+	ID             string    `json:"id"`                         // workspace ID (e.g., "ledger", team_id, kb_id)
+	Type           string    `json:"type"`                       // "ledger", "team-context", or "kb"
 	Path           string    `json:"path"`                       // local filesystem path
 	CloneURL       string    `json:"clone_url,omitempty"`        // git remote URL
 	Exists         bool      `json:"exists"`                     // whether path exists locally
 	TeamID         string    `json:"team_id,omitempty"`          // team ID (for team contexts)
 	TeamName       string    `json:"team_name,omitempty"`        // team name (for team contexts)
 	TeamSlug       string    `json:"team_slug,omitempty"`        // kebab-case team slug
+	KBType         string    `json:"kb_type,omitempty"`          // bubble type (for kb: personal, team, repo, custom)
+	Slug           string    `json:"slug,omitempty"`             // bubble slug (for kb)
 	LastSync       time.Time `json:"last_sync,omitempty"`        // last successful sync
 	LastErr        string    `json:"last_error,omitempty"`       // last error message
 	Syncing        bool      `json:"syncing,omitempty"`          // currently syncing

--- a/internal/daemon/status_display.go
+++ b/internal/daemon/status_display.go
@@ -31,8 +31,15 @@ type StatusJSON struct {
 
 	Project    statusProjectGroupJSON  `json:"project"`
 	OtherTeams []statusTeamContextJSON `json:"other_teams,omitempty"`
+	Bubbles    []statusBubbleJSON      `json:"bubbles,omitempty"`
 	Issues     []statusIssueJSON       `json:"issues,omitempty"`
 	AutoExitIn string                  `json:"auto_exit_in,omitempty"`
+
+	// global-sync ownership: whether THIS daemon pulls team contexts + bubbles
+	// for its endpoint, or a sibling daemon does. Surfaced so tooling can tell
+	// an idle follower apart from a daemon that genuinely syncs nothing.
+	GlobalSyncOwner    bool   `json:"global_sync_owner"`
+	GlobalSyncEndpoint string `json:"global_sync_endpoint,omitempty"`
 }
 
 type statusSyncJSON struct {
@@ -63,6 +70,15 @@ type statusTeamContextJSON struct {
 	Path     string     `json:"path"`
 	LastSync *time.Time `json:"last_sync,omitempty"`
 	GCStatus string     `json:"gc_status,omitempty"`
+}
+
+type statusBubbleJSON struct {
+	KBID     string     `json:"kb_id"`
+	Slug     string     `json:"slug,omitempty"`
+	KBType   string     `json:"kb_type,omitempty"`
+	Status   string     `json:"status"`
+	Path     string     `json:"path"`
+	LastSync *time.Time `json:"last_sync,omitempty"`
 }
 
 type statusCodeIndexJSON struct {
@@ -159,6 +175,24 @@ func BuildStatusJSON(status *StatusData, cliVersion string) *StatusJSON {
 			continue
 		}
 		out.OtherTeams = append(out.OtherTeams, *buildTeamContextJSON(tc))
+	}
+
+	// knowledge bubbles synced to disk + which daemon owns global sync
+	out.GlobalSyncOwner = status.GlobalSyncOwner
+	out.GlobalSyncEndpoint = status.GlobalSyncEndpoint
+	for _, b := range status.Workspaces["kb"] {
+		bj := statusBubbleJSON{
+			KBID:   b.ID,
+			Slug:   b.Slug,
+			KBType: b.KBType,
+			Status: wsStatusString(b),
+			Path:   b.Path,
+		}
+		if !b.LastSync.IsZero() {
+			ls := b.LastSync
+			bj.LastSync = &ls
+		}
+		out.Bubbles = append(out.Bubbles, bj)
 	}
 
 	// issues
@@ -693,6 +727,74 @@ func formatWorkspaceGroups(status *StatusData, verbose bool) string {
 			padding := strings.Repeat(" ", alignWidth-len(name))
 			out.WriteString(styleMuted.Render("    "+branch) + name + padding + formatWSStatus(tc) + formatGCStatus(tc, verbose) + "\n")
 		}
+	}
+
+	out.WriteString(formatKBGroup(status, verbose))
+
+	return out.String()
+}
+
+// formatKBGroup renders the Knowledge Bubbles section of `ox daemon status`:
+// a header with an owner badge (this daemon syncs them vs another daemon does)
+// and one tree row per locally-synced bubble. Returns "" when no bubbles are
+// on disk. Mirrors the Other Team Contexts block — bubbles ARE the kb-era
+// successor to team contexts (see docs/specs/kb-daemon-sync.md).
+func formatKBGroup(status *StatusData, verbose bool) string {
+	bubbles := status.Workspaces["kb"]
+	if len(bubbles) == 0 {
+		return ""
+	}
+
+	var out strings.Builder
+	out.WriteString("\n")
+	out.WriteString(styleBold.Render("Knowledge Bubbles"))
+	out.WriteString(styleMuted.Render(fmt.Sprintf(" (%d)", len(bubbles))))
+	// owner badge: only the global-sync owner actually pulls these; followers
+	// read the on-disk state the owner keeps fresh.
+	if status.GlobalSyncOwner {
+		out.WriteString(styleMuted.Render(" · syncing here"))
+	} else {
+		badge := " · synced by another daemon"
+		if status.GlobalSyncEndpoint != "" {
+			badge = " · synced by another daemon (" + status.GlobalSyncEndpoint + ")"
+		}
+		out.WriteString(styleMuted.Render(badge))
+	}
+	out.WriteString("\n")
+
+	// label each bubble by slug (falling back to kb_id), tagged with its type.
+	label := func(b WorkspaceSyncStatus) string {
+		name := b.Slug
+		if name == "" {
+			name = b.ID
+		}
+		if b.KBType != "" {
+			return name + styleMuted.Render(" ("+b.KBType+")")
+		}
+		return name
+	}
+
+	alignWidth := 0
+	for _, b := range bubbles {
+		rawLen := len(stripANSI(label(b)))
+		if rawLen > alignWidth {
+			alignWidth = rawLen
+		}
+	}
+	alignWidth += 2
+
+	for i, b := range bubbles {
+		branch := "├── "
+		if i == len(bubbles)-1 {
+			branch = "└── "
+		}
+		lbl := label(b)
+		padding := strings.Repeat(" ", alignWidth-len(stripANSI(lbl)))
+		row := styleMuted.Render("    "+branch) + lbl + padding + formatWSStatus(b)
+		if verbose {
+			row += styleMuted.Render("  " + b.Path)
+		}
+		out.WriteString(row + "\n")
 	}
 
 	return out.String()

--- a/internal/daemon/status_kb.go
+++ b/internal/daemon/status_kb.go
@@ -1,0 +1,106 @@
+package daemon
+
+// status_kb.go — enumerate locally-synced knowledge bubbles for `ox daemon
+// status`. Purely local: it scans the canonical XDG kb root
+// (paths.KBDir("")) and reads each bubble's .sageox/meta.json. This works in
+// ANY daemon, owner or follower — followers report the on-disk truth the
+// global-sync owner keeps fresh (see global_lease.go / sync.go:920-928), so
+// `ox daemon status` always shows what's on disk regardless of which daemon
+// holds the lease.
+//
+// The daemon owns git reads (clone/pull); this is a read-only status view, so
+// it never touches git state beyond a .git existence stat.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/sageox/ox/internal/paths"
+)
+
+// kbWorkspaceStatus returns one WorkspaceSyncStatus per locally-cloned
+// knowledge bubble, sourced entirely from disk. Returns nil (not an error)
+// when the kb store doesn't exist yet or the endpoint is unresolved — a
+// daemon with no bubbles on disk simply has no kb rows to report.
+func (s *SyncScheduler) kbWorkspaceStatus() []WorkspaceSyncStatus {
+	root := kbRootSafe()
+	if root == "" {
+		return nil
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		// no kb store yet (fresh install / not logged in) is the common case;
+		// anything else is logged at debug since status must never fail hard.
+		if !os.IsNotExist(err) {
+			s.logger.Debug("kb_status readdir failed", "root", root, "error", err)
+		}
+		return nil
+	}
+
+	rows := make([]WorkspaceSyncStatus, 0, len(entries))
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		name := ent.Name()
+		if len(name) > 0 && name[0] == '.' {
+			// skip .trash/ and any other dotfile siblings
+			continue
+		}
+
+		kbPath := filepath.Join(root, name)
+		row := WorkspaceSyncStatus{
+			ID:     name, // kb_id is the directory name
+			Type:   "kb",
+			Path:   kbPath,
+			Exists: kbHasGitDir(kbPath),
+		}
+
+		// meta.json is the daemon's own per-bubble record (written every
+		// reconcile in writeKBMeta). Reuse the in-package kbMeta shape.
+		if meta, ok := readKBMetaForStatus(kbPath); ok {
+			row.KBType = string(meta.Type)
+			row.Slug = meta.Slug
+			row.LastSync = meta.LastSync
+		}
+
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// kbRootSafe returns paths.KBDir(""), recovering the panic KBDir raises when
+// no endpoint is configured (tests with no SAGEOX_ENDPOINT, fresh installs)
+// so a status query degrades to "no bubbles" instead of crashing the daemon.
+func kbRootSafe() (root string) {
+	defer func() {
+		if recover() != nil {
+			root = ""
+		}
+	}()
+	return paths.KBDir("")
+}
+
+// kbHasGitDir reports whether <kbPath>/.git exists — the same "is this a real
+// clone" signal reconcileBubble uses to decide clone-vs-pull.
+func kbHasGitDir(kbPath string) bool {
+	_, err := os.Stat(filepath.Join(kbPath, ".git"))
+	return err == nil
+}
+
+// readKBMetaForStatus loads <kbPath>/.sageox/meta.json into the in-package
+// kbMeta shape. Returns ok=false when the file is absent (initial-clone
+// pending) or unparseable, so the caller leaves those fields zero.
+func readKBMetaForStatus(kbPath string) (kbMeta, bool) {
+	data, err := os.ReadFile(filepath.Join(kbPath, ".sageox", "meta.json"))
+	if err != nil {
+		return kbMeta{}, false
+	}
+	var meta kbMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return kbMeta{}, false
+	}
+	return meta, true
+}

--- a/internal/daemon/status_kb_test.go
+++ b/internal/daemon/status_kb_test.go
@@ -1,0 +1,150 @@
+package daemon
+
+// Tests for kbWorkspaceStatus — the on-disk scanner that feeds the Knowledge
+// Bubbles section of `ox daemon status`. The scanner must work in ANY daemon
+// (owner or follower), so these tests exercise it without a global-sync lease
+// and assert only on what's physically on disk.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/stretchr/testify/require"
+)
+
+// writeBubbleOnDisk materializes a bubble dir under the canonical kb root with
+// an optional .git marker and meta.json, matching what reconcileBubble writes.
+func writeBubbleOnDisk(t *testing.T, kbID string, hasGit bool, meta *kbMeta) {
+	t.Helper()
+	dir := paths.KBDir(kbID)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sageox"), 0o755))
+	if hasGit {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	}
+	if meta != nil {
+		data, err := json.MarshalIndent(meta, "", "  ")
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".sageox", "meta.json"), data, 0o644))
+	}
+}
+
+// TestKBWorkspaceStatus_ReportsClonedBubbles verifies synced bubbles surface
+// with their slug/type/last-sync read from meta.json.
+// Failure prevented: `ox daemon status` shows no knowledge bubbles even though
+// the daemon is actively syncing them to disk.
+func TestKBWorkspaceStatus_ReportsClonedBubbles(t *testing.T) {
+	kbTestEnv(t)
+	s, _ := kbTestScheduler(t)
+
+	synced := time.Now().UTC().Truncate(time.Second)
+	writeBubbleOnDisk(t, "kb_personal_1", true, &kbMeta{
+		Type:     api.KBTypePersonal,
+		Slug:     "my-notes",
+		LastSync: synced,
+	})
+	writeBubbleOnDisk(t, "kb_team_2", true, &kbMeta{
+		Type:     api.KBTypeTeam,
+		Slug:     "frontend",
+		LastSync: synced,
+	})
+
+	rows := s.kbWorkspaceStatus()
+	require.Len(t, rows, 2)
+
+	byID := map[string]WorkspaceSyncStatus{}
+	for _, r := range rows {
+		require.Equal(t, "kb", r.Type)
+		byID[r.ID] = r
+	}
+
+	personal := byID["kb_personal_1"]
+	require.True(t, personal.Exists)
+	require.Equal(t, "my-notes", personal.Slug)
+	require.Equal(t, string(api.KBTypePersonal), personal.KBType)
+	require.Equal(t, synced, personal.LastSync.UTC())
+
+	team := byID["kb_team_2"]
+	require.Equal(t, "frontend", team.Slug)
+	require.Equal(t, string(api.KBTypeTeam), team.KBType)
+}
+
+// TestKBWorkspaceStatus_MissingMetaStillListed verifies a clone whose meta.json
+// hasn't been written yet (initial-clone pending) still appears, with a zero
+// LastSync rather than being dropped.
+// Failure prevented: a freshly-cloned bubble silently vanishes from status
+// during the window before the daemon writes its first meta.json.
+func TestKBWorkspaceStatus_MissingMetaStillListed(t *testing.T) {
+	kbTestEnv(t)
+	s, _ := kbTestScheduler(t)
+
+	writeBubbleOnDisk(t, "kb_pending_1", true, nil) // .git but no meta.json
+
+	rows := s.kbWorkspaceStatus()
+	require.Len(t, rows, 1)
+	require.Equal(t, "kb_pending_1", rows[0].ID)
+	require.True(t, rows[0].Exists)
+	require.True(t, rows[0].LastSync.IsZero())
+	require.Empty(t, rows[0].Slug)
+}
+
+// TestKBWorkspaceStatus_SkipsDotDirsAndNonClones verifies the scanner ignores
+// the .trash/ sibling and reports a partial clone (no .git) as Exists=false.
+// Failure prevented: GC's .trash/ holding area is mistaken for a real bubble,
+// or a half-cloned dir is reported as a healthy checkout.
+func TestKBWorkspaceStatus_SkipsDotDirsAndNonClones(t *testing.T) {
+	kbTestEnv(t)
+	s, _ := kbTestScheduler(t)
+
+	// .trash/ must be skipped
+	require.NoError(t, os.MkdirAll(filepath.Join(paths.KBDir(""), ".trash", "kb_old"), 0o755))
+	// a dir with no .git is a partial clone — listed but Exists=false
+	writeBubbleOnDisk(t, "kb_partial_1", false, &kbMeta{Type: api.KBTypeRepo, Slug: "half"})
+
+	rows := s.kbWorkspaceStatus()
+	require.Len(t, rows, 1)
+	require.Equal(t, "kb_partial_1", rows[0].ID)
+	require.False(t, rows[0].Exists)
+}
+
+// TestKBWorkspaceStatus_EmptyStoreReturnsNil verifies a daemon with no kb store
+// yet (fresh install) returns no rows rather than erroring.
+// Failure prevented: status crashes or logs noise on machines that never
+// synced a bubble.
+func TestKBWorkspaceStatus_EmptyStoreReturnsNil(t *testing.T) {
+	kbTestEnv(t)
+	s, _ := kbTestScheduler(t)
+
+	require.Empty(t, s.kbWorkspaceStatus())
+}
+
+// TestFormatKBGroup_OwnerVsFollowerBadge verifies the section header tells the
+// user whether THIS daemon syncs bubbles or a sibling does.
+// Failure prevented: a follower daemon's status implies nothing is syncing the
+// bubbles, when in fact the global-sync owner is keeping them fresh.
+func TestFormatKBGroup_OwnerVsFollowerBadge(t *testing.T) {
+	base := &StatusData{
+		Workspaces: map[string][]WorkspaceSyncStatus{
+			"kb": {{ID: "kb_1", Type: "kb", Slug: "notes", KBType: "personal", Exists: true, LastSync: time.Now()}},
+		},
+		GlobalSyncEndpoint: "staging.sageox.ai",
+	}
+
+	owner := *base
+	owner.GlobalSyncOwner = true
+	require.Contains(t, stripANSI(formatKBGroup(&owner, false)), "syncing here")
+
+	follower := *base
+	follower.GlobalSyncOwner = false
+	out := stripANSI(formatKBGroup(&follower, false))
+	require.Contains(t, out, "synced by another daemon")
+	require.Contains(t, out, "staging.sageox.ai")
+	require.Contains(t, out, "notes")
+
+	// no bubbles -> empty section
+	require.Empty(t, formatKBGroup(&StatusData{}, false))
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.10.0"
+	Version   = "0.10.1"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## What this PR ships

Knowledge bubbles (kb) are the kb-era successor to ledgers and team contexts. The sync, prime, and selection plumbing already existed and is mature — this PR closes the remaining observability/repair gaps and writes down the model.

- **`ox daemon status` now surfaces knowledge bubbles.** The daemon reports every bubble it has synced to disk (slug, type, freshness) plus a badge showing whether *this* daemon keeps them fresh or a sibling does. Previously the daemon synced bubbles silently with no way to see it.
- **`ox doctor` reaches parity with ledger/team-context git-repo doctoring.** Three new kb checks: missing local clone, wedged repo (stuck merge/rebase — **Critical**, it blocks the global-sync owner's pass for every project), and sparse-checkout cone integrity.
- **Docs:** `docs/specs/kb-daemon-sync.md` records the multi-daemon coordination model, the doctor parity matrix (incl. what's intentionally deferred and why), and the Cloud Co-Work / no-git-repo open question.
- **Version:** patch bump `0.10.0` → `0.10.1` (`make verify-version` green).

## Why the multi-daemon model is already safe

There is one daemon per ledger, so N projects → N daemons sharing the same on-disk kb store. kb sync is gated by the **same per-endpoint flock lease** that already gates team-context pulls — only the lease owner runs `syncBubbles`; followers read the on-disk state. A second per-`kb_id` flock serializes any reconcile. The new status scan is read-only, so any daemon (owner or follower) reports the same on-disk truth.

```mermaid
flowchart TD
    subgraph host["One machine, N per-ledger daemons (same endpoint)"]
        DA["Daemon A (ledger-1)"]
        DB["Daemon B (ledger-2)"]
    end
    Lease["per-endpoint flock lease"]
    DA -->|"LOCK_EX, owner"| Lease
    DB -->|"ErrNotOwner, skip"| Lease
    DA -->|"pullTeamContexts + syncBubbles"| Disk["shared XDG kb store"]
    DB -.->|"reads on-disk state only"| Disk
    DA -->|"per-kb flock before each reconcile"| KBLock["kb-locks lockfile"]
```

## Bug fixed along the way

Running the **full** daemon test suite surfaced 6 failing global-sync lease tests reporting "another daemon owns the lease." Root cause: the tests isolate via `XDG_STATE_HOME`, but in the default XDG mode `paths.StateDir()` derives the lease path from `XDG_RUNTIME_DIR`, which it never reads `XDG_STATE_HOME` for — so the isolation silently no-ops and the tests **contend with the developer's actually-running daemons** for the real lease file. CI never caught it (no live daemon there). Fix: isolate via `XDG_RUNTIME_DIR` (the env `StateDir` actually reads), threaded through the subprocess-failover child too.

## Design notes

- **Repairs route through the daemon, not the CLI.** The daemon owns kb git writes and serializes them with a per-`kb_id` flock; a CLI write would race that lock. So kb doctor repairs *kick a daemon sync* rather than committing/aborting inline the way the CLI-owned ledger checks do. Detection stays read-only and CLI-side.
- **Deferred-with-rationale (documented):** secret scanning (bubbles have no `sessions/` tree), dirty-workdir auto-commit, and remote-URL audit — all belong to the daemon's reconcile pass, not a CLI doctor check.

## Test Plan

- `go build ./...` · `make lint` (0 issues) · `make verify-version` (all match 0.10.1)
- New: `internal/daemon/status_kb_test.go` (scanner + owner/follower badge), `cmd/ox/doctor_kb_repo_health_test.go` (9 cases). Updated 2 existing kb-check count assertions (4 → 7).
- Full `internal/daemon` and `cmd/ox` kb/doctor/status suites pass. Global-sync lease tests pass (were failing before the isolation fix).
- Manual: `ox daemon status --json | jq '.workspaces.kb, .global_sync_owner'`; second daemon on the same endpoint shows the "synced by another daemon" follower badge; deleting a synced bubble dir → `ox doctor --fix` re-clones it.

Note: `TestCodeDBMaintainerNilManager` is a pre-existing flake (passes alone / on rerun, unrelated to this change) — left untouched rather than papered over.
