### PR TITLE
fix(observability): drop OTLP export client-side when logged out

### DIFF
--- a/internal/observability/otel.go
+++ b/internal/observability/otel.go
@@ -27,9 +27,9 @@ import (
 
 // TokenFunc returns the current bearer token to attach to OTLP requests.
 // Called per-export so long-running processes (daemon) pick up rotated tokens.
-// Returning "" sends the request unauthenticated — the server JWT-gate will
-// then 401 and the batch is dropped, which is the correct behavior when the
-// user is logged out.
+// Returning "" means no bearer is available (logged out / token expired): the
+// batch is dropped client-side (see bearerRoundTripper.RoundTrip) rather than
+// sent, because the JWT-gated proxy would only 401 it anyway.
 type TokenFunc func() string
 
 type bearerRoundTripper struct {
@@ -38,11 +38,29 @@ type bearerRoundTripper struct {
 }
 
 func (rt *bearerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if tok := rt.tokenFunc(); tok != "" {
-		// clone to avoid mutating the caller's request (otlptracehttp may retry)
-		req = req.Clone(req.Context())
-		req.Header.Set("Authorization", "Bearer "+tok)
+	tok := rt.tokenFunc()
+	if tok == "" {
+		// No bearer available (logged out / token expired). The OTLP proxy is
+		// JWT-gated, so actually sending would just 401 and churn the server's
+		// error pipeline (the ox-w9yc5 surge). Drop client-side instead —
+		// mirrors the browser SDK's 204 no-JWT behavior in
+		// apps/web/src/lib/otel-browser.ts. A 2xx with an empty body makes the
+		// batch exporter treat the batch as delivered, so it neither retries
+		// nor logs an export error.
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Proto:      req.Proto,
+			ProtoMajor: req.ProtoMajor,
+			ProtoMinor: req.ProtoMinor,
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
 	}
+	// clone to avoid mutating the caller's request (otlptracehttp may retry)
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+tok)
 	return rt.base.RoundTrip(req)
 }
 
@@ -86,9 +104,10 @@ func AddSpanProcessor(p sdktrace.SpanProcessor) {
 // The daemon uses this to set client.id, client.class, os.type, etc.
 //
 // Safe to call with empty apiEndpoint or nil tokenFunc — tracing is
-// disabled (noop) or sends unauthenticated (server will 401, batch
-// dropped silently). Either is fine for tests and for users who are
-// logged out.
+// disabled (noop). When tokenFunc returns "" at export time (logged-out /
+// expired), the batch is dropped client-side (synthetic 2xx, nothing sent)
+// rather than 401'd by the server. Either is fine for tests and for users
+// who are logged out.
 func Init(ctx context.Context, serviceName, apiEndpoint string, tokenFunc TokenFunc, attrs ...attribute.KeyValue) error {
 	if apiEndpoint == "" {
 		slog.Debug("otel tracing disabled", "reason", "no endpoint")

--- a/internal/observability/otel_test.go
+++ b/internal/observability/otel_test.go
@@ -210,10 +210,14 @@ func TestInit_NilTokenFuncSendsUnauthenticated(t *testing.T) {
 	}
 }
 
-// TestInit_EmptyTokenSkipsHeader verifies that a tokenFunc returning ""
-// (e.g. user logged out) leaves Authorization unset rather than sending
-// "Bearer ", which would be a parse error server-side.
-func TestInit_EmptyTokenSkipsHeader(t *testing.T) {
+// TestInit_EmptyTokenDropsClientSide verifies that a tokenFunc returning ""
+// (e.g. user logged out / token expired) drops the OTLP batch client-side
+// rather than sending it. The JWT-gated proxy would only 401 an
+// unauthenticated batch, so sending it just churns the server's error
+// pipeline (the ox-w9yc5 401 surge). Mirrors the browser SDK's 204 no-JWT
+// drop in apps/web/src/lib/otel-browser.ts.
+// Failure prevented: logged-out CLIs/daemons emitting 401s on every export.
+func TestInit_EmptyTokenDropsClientSide(t *testing.T) {
 	resetGlobals()
 
 	var (
@@ -235,8 +239,64 @@ func TestInit_EmptyTokenSkipsHeader(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
+	assert.Empty(t, seen, "empty token must drop the batch client-side; no request should reach the server")
+}
+
+// TestInit_TokenTransitionDropsThenSends verifies the drop is evaluated
+// per-export: while logged out (token "") nothing is sent, and once a token
+// becomes available (login) the next export reaches the server with the
+// Bearer header — without re-Init. Guards the per-export contract for the
+// long-running daemon (logout → login mid-process).
+func TestInit_TokenTransitionDropsThenSends(t *testing.T) {
+	resetGlobals()
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("Authorization"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	var tokenMu sync.Mutex
+	current := "" // start logged out
+	tokenFunc := func() string {
+		tokenMu.Lock()
+		defer tokenMu.Unlock()
+		return current
+	}
+
+	require.NoError(t, Init(context.Background(), "ox-cli-test", srv.URL, tokenFunc))
+
+	// logged out: export is dropped client-side
+	_, span := StartCommand(context.Background(), "ox test-cmd")
+	span.End()
+	Shutdown(context.Background())
+
+	mu.Lock()
+	require.Empty(t, seen, "logged-out export must not reach the server")
+	mu.Unlock()
+
+	// login: token now available, next export must be sent + authenticated
+	resetGlobals()
+	tokenMu.Lock()
+	current = "tok-after-login"
+	tokenMu.Unlock()
+
+	require.NoError(t, Init(context.Background(), "ox-cli-test", srv.URL, tokenFunc))
+	_, span2 := StartCommand(context.Background(), "ox test-cmd-2")
+	span2.End()
+	Shutdown(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, seen, "post-login export must reach the server")
 	for _, h := range seen {
-		assert.Empty(t, h, "empty tokenFunc value must not inject Authorization")
+		assert.Equal(t, "Bearer tok-after-login", h, "post-login export must carry the bearer")
 	}
 }
 


### PR DESCRIPTION
## Summary

Logged-out `ox` CLIs and the daemon were exporting OTLP trace batches with no bearer to a JWT-gated proxy, which `401`'d every one — churning the server error pipeline (the `ox-w9yc5` 401 surge).

- **Before:** `RoundTrip` sent the batch unauthenticated; the proxy returned `401`; the batch was dropped server-side after generating an error.
- **After:** when the token func returns `""`, `RoundTrip` returns a synthetic `200 OK` empty body and sends nothing. The batch exporter treats it as delivered, so it neither retries nor logs an export error.
- The drop is evaluated **per export**, so a long-running daemon that logs in mid-process starts sending authenticated batches on the next export without re-init.
- Mirrors the browser SDK's `204` no-JWT drop in `apps/web/src/lib/otel-browser.ts`.

```mermaid
flowchart TD
    E["trace batch export"] --> C{"token available?"}
    C -- "no (logged out / expired)" --> D["synthetic 200, send nothing (batch marked delivered)"]
    C -- "yes" --> S["attach Bearer, send to OTLP proxy"]
```

## Test Plan

- `go test ./internal/observability/...` (passing)
- `TestInit_EmptyTokenDropsClientSide` asserts no request reaches the server when logged out.
- `TestInit_TokenTransitionDropsThenSends` asserts logout drops, then post-login export carries `Bearer ...` without re-init.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented
- [ ] CHANGELOG entry added (if user-facing) — N/A (internal observability behavior, no user-facing surface)
- [ ] Breaking change documented — N/A
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: touches `internal/observability/` only, none of the auto-reviewed paths (`internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, `go.sum`)

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry authentication handling to drop batches client-side when authentication tokens are unavailable, preventing failed requests to observability services.
  * Enhanced bearer token management to properly set authentication headers when tokens are available and available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->