### PR TITLE
feat(plan): clickable prior-art session links + syntax-highlighted code blocks in render

### DIFF
--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -489,6 +489,27 @@ func openSavedPlanHTML(cmd *cobra.Command, savedDir string) {
 // first), persists it to the ledger when capture is on, and writes/opens per the
 // flags. This is the cross-agent path: any agent gets the rich render here. The
 // render injects SageOx attribution by construction (passes the lint contract).
+// priorArtURLResolver builds the closure RenderOptions.PriorArtURL uses to turn a
+// prior-art source into a SageOx web link (opened in a new tab from the enrichment
+// panel). Sessions resolve to the canonical session view; murmurs have no
+// individual web view, so they render unlinked; plans will get a web route soon
+// (see TODO). Project config is loaded once; when it's unavailable the resolver
+// yields "" and the render degrades to crisp text rather than failing.
+func priorArtURLResolver(gitRoot string) func(refKind, ref string) string {
+	cfg, _ := config.LoadProjectConfig(gitRoot)
+	return func(refKind, ref string) string {
+		switch refKind {
+		case "session":
+			return buildSessionURL(cfg, ref)
+		// TODO(plan-web-route): when SageOx ships a per-plan web view, add
+		// buildPlanURL(cfg, ref) here keyed on "plan" (bd: follow-up issue). The
+		// resolver already branches on refKind, so it's a drop-in.
+		default:
+			return ""
+		}
+	}
+}
+
 func runPlanRenderFresh(cmd *cobra.Command, file, outPath string, open bool) error {
 	in, err := plan.Resolve(file, cmd.InOrStdin())
 	if err != nil {
@@ -502,7 +523,7 @@ func runPlanRenderFresh(cmd *cobra.Command, file, outPath string, open bool) err
 	gitRoot := findGitRoot()
 	result := plan.Enrich(context.Background(), in, gitRoot)
 
-	htmlBytes, err := plan.RenderHTMLOpts(in, result, plan.RenderOptions{Slug: plan.Slugify(planTopic(in))})
+	htmlBytes, err := plan.RenderHTMLOpts(in, result, plan.RenderOptions{Slug: plan.Slugify(planTopic(in)), PriorArtURL: priorArtURLResolver(gitRoot)})
 	if err != nil {
 		return fmt.Errorf("render plan: %w", err)
 	}
@@ -533,7 +554,7 @@ func runPlanRenderSaved(cmd *cobra.Command, slug, outPath string, open bool) err
 	}
 	in := plan.Parse(planMD)
 	review, _ := plan.AssembleReview(info.Dir)
-	htmlBytes, err := plan.RenderHTMLOpts(in, res, plan.RenderOptions{Slug: slug, Review: review})
+	htmlBytes, err := plan.RenderHTMLOpts(in, res, plan.RenderOptions{Slug: slug, Review: review, PriorArtURL: priorArtURLResolver(gitRoot)})
 	if err != nil {
 		return fmt.Errorf("render plan: %w", err)
 	}

--- a/cmd/ox/plan_review.go
+++ b/cmd/ox/plan_review.go
@@ -103,7 +103,7 @@ func runPlanReview(cmd *cobra.Command, slug string, noServe bool, idleTimeout ti
 	if noServe || cli.IsHeadless() {
 		in := plan.Parse(planMD)
 		review, _ := plan.AssembleReview(info.Dir)
-		return reviewStaticFallback(cmd, slug, in, res, review)
+		return reviewStaticFallback(cmd, gitRoot, slug, in, res, review)
 	}
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -111,7 +111,7 @@ func runPlanReview(cmd *cobra.Command, slug string, noServe bool, idleTimeout ti
 		cli.PrintHint("could not start review server, falling back to file export: " + err.Error())
 		in := plan.Parse(planMD)
 		review, _ := plan.AssembleReview(info.Dir)
-		return reviewStaticFallback(cmd, slug, in, res, review)
+		return reviewStaticFallback(cmd, gitRoot, slug, in, res, review)
 	}
 	addr := ln.Addr().String()
 	token, err := randomToken()
@@ -326,6 +326,7 @@ func renderLive(gitRoot, slug, base, token string) ([]byte, error) {
 	review, _ := plan.AssembleReview(info.Dir)
 	return plan.RenderHTMLOpts(in, res, plan.RenderOptions{
 		Slug: slug, Review: review, ReviewEndpoint: base, ReviewToken: token,
+		PriorArtURL: priorArtURLResolver(gitRoot),
 	})
 }
 
@@ -415,8 +416,8 @@ func (b *broadcaster) broadcast() {
 
 // reviewStaticFallback renders to a file and prints the clipboard-export path for
 // environments with no browser/server.
-func reviewStaticFallback(cmd *cobra.Command, slug string, in plan.Input, res plan.Result, review []plan.MergedItem) error {
-	html, err := plan.RenderHTMLOpts(in, res, plan.RenderOptions{Slug: slug, Review: review})
+func reviewStaticFallback(cmd *cobra.Command, gitRoot, slug string, in plan.Input, res plan.Result, review []plan.MergedItem) error {
+	html, err := plan.RenderHTMLOpts(in, res, plan.RenderOptions{Slug: slug, Review: review, PriorArtURL: priorArtURLResolver(gitRoot)})
 	if err != nil {
 		return fmt.Errorf("render plan: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/AlexanderGrooff/mermaid-ascii v0.0.0-20251230110936-0ccc8d6547f7
 	github.com/Microsoft/go-winio v0.6.2
+	github.com/alecthomas/chroma/v2 v2.14.0
 	github.com/bbalet/stopwords v1.0.0
 	github.com/blevesearch/bleve/v2 v2.5.7
 	github.com/charmbracelet/x/ansi v0.11.6
@@ -56,7 +57,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.4.5 // indirect
-	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/blevesearch/bleve_index_api v1.2.11 // indirect

--- a/internal/plan/assets/plan.html.tmpl
+++ b/internal/plan/assets/plan.html.tmpl
@@ -34,7 +34,7 @@
     <button class="ox-marker" aria-label="SageOx insight" title="SageOx team-context signals"><svg class="ox-ico" aria-hidden="true"><use href="#ox-ico-d" class="ico-d"></use><use href="#ox-ico-l" class="ico-l"></use></svg></button>
     <div>
       <strong>Team context enriched by SageOx</strong> — {{.SignalCount}} deterministic signal{{.Plural}} on this plan{{if .Sections}}, anchored to the sections they affect{{end}}.
-      {{if .Signals}}<ul>{{range .Signals}}<li><span class="ox-sig-{{.Type}}">{{.Label}}</span> — {{.Why}}{{if .Source}} <span class="src">{{.Source}}</span>{{end}}</li>
+      {{if .Signals}}<ul>{{range .Signals}}<li><span class="ox-sig-{{.Type}}">{{.Label}}</span> — {{if .URL}}<a class="src-link" href="{{.URL}}" target="_blank" rel="noopener noreferrer">{{.Why}}</a> <a class="src-go" href="{{.URL}}" target="_blank" rel="noopener noreferrer" title="Open on SageOx">view ↗</a>{{else}}{{.Why}}{{if .Source}} <span class="src">{{.Source}}</span>{{end}}{{end}}</li>
       {{end}}</ul>{{end}}
     </div>
   </div>{{end}}
@@ -43,7 +43,7 @@
   {{if .Preamble}}<section id="preamble">{{.Preamble}}</section>{{end}}
   {{range .Sections}}<section id="{{.ID}}"{{if .IsRisk}} class="risk"{{end}}>
     <h2>{{.Heading}}</h2>
-    {{if .Signals}}<div class="ox-rail">{{range .Signals}}<span class="ox-chip ox-sig-{{.Type}}"><button class="ox-marker sm" aria-label="SageOx insight" title="SageOx signal"><svg class="ox-ico" aria-hidden="true"><use href="#ox-ico-d" class="ico-d"></use><use href="#ox-ico-l" class="ico-l"></use></svg></button> <strong>{{.Label}}</strong> — {{.Why}}{{if .Source}} <span class="src">{{.Source}}</span>{{end}}</span>{{end}}</div>{{end}}
+    {{if .Signals}}<div class="ox-rail">{{range .Signals}}<span class="ox-chip ox-sig-{{.Type}}"><button class="ox-marker sm" aria-label="SageOx insight" title="SageOx signal"><svg class="ox-ico" aria-hidden="true"><use href="#ox-ico-d" class="ico-d"></use><use href="#ox-ico-l" class="ico-l"></use></svg></button> <strong>{{.Label}}</strong> — {{if .URL}}<a class="src-link" href="{{.URL}}" target="_blank" rel="noopener noreferrer">{{.Why}}</a> <a class="src-go" href="{{.URL}}" target="_blank" rel="noopener noreferrer" title="Open on SageOx">view ↗</a>{{else}}{{.Why}}{{if .Source}} <span class="src">{{.Source}}</span>{{end}}{{end}}</span>{{end}}</div>{{end}}
     {{.HTML}}
   </section>
   {{end}}

--- a/internal/plan/assets/scaffold.css
+++ b/internal/plan/assets/scaffold.css
@@ -74,6 +74,12 @@ html[data-theme="light"] .ico-l{display:inline}
 .ox-enrich ul{margin:.4em 0 0;padding-left:1.1em;font-size:14px}
 .ox-enrich li{margin:.28em 0}
 .ox-enrich .src{color:var(--teal);font-family:"JetBrains Mono",monospace;font-size:.82em}
+/* prior-art links: the crisp "person · date · summary" label is a subtle link
+   (underline only on hover); the trailing "view ↗" is the explicit click-through */
+.src-link{color:inherit;text-decoration:none;border-bottom:1px dotted var(--faint)}
+.src-link:hover{color:var(--teal);border-bottom-color:var(--teal)}
+.src-go{color:var(--faint);text-decoration:none;font-family:"JetBrains Mono",monospace;font-size:.78em;white-space:nowrap}
+.src-go:hover{color:var(--teal)}
 /* Fixed semantic color map (one meaning per hue; never color alone — pair with a
    text label or shape glyph): sage=good/aligns · copper=expert · amber=collision/
    warn · red=blocker/conflict · teal=prior-art/file. sage-bright is reserved for

--- a/internal/plan/priorart.go
+++ b/internal/plan/priorart.go
@@ -194,6 +194,7 @@ type priorArtHit struct {
 	SourceID string
 	Author   string
 	Date     string // YYYY-MM-DD if derivable, else ""
+	Text     string // ledgersearch snippet around the matched term (relevance)
 }
 
 // rankHits filters raw ledger results below the threshold, sorts by score
@@ -212,6 +213,7 @@ func rankHits(results []ledgersearch.Result) []priorArtHit {
 			SourceID: r.SourceID,
 			Author:   author,
 			Date:     date,
+			Text:     r.Text,
 		})
 	}
 
@@ -277,37 +279,62 @@ func dateOnly(ts string) string {
 	return ""
 }
 
-// annotationFromHit renders a prior-art Annotation. The SourceURL carries the
-// session ref (folder name) so a human/agent can `ox session view <ref>`.
+// maxSummaryWords caps the relevance summary. The summary is the snippet from
+// the prior work where this plan's keywords matched — enough to recognize "oh,
+// that thing", not a full sentence.
+const maxSummaryWords = 10
+
+// minSummaryWords drops a summary too short to read as a phrase (a stray
+// fragment), falling the bullet back to "person · date".
+const minSummaryWords = 3
+
+// relevanceSummary cleans a ledgersearch snippet (raw session/markdown text — a
+// ~160-char window around the matched term) into a short, human-readable phrase:
+// collapse whitespace/newlines, cap to maxSummaryWords on a word boundary, and
+// trim leading/trailing markdown noise. Returns "" when too little survives.
+func relevanceSummary(text string) string {
+	fields := strings.Fields(text) // collapses every run of whitespace/newlines
+	if len(fields) > maxSummaryWords {
+		fields = fields[:maxSummaryWords]
+	}
+	// strip edge noise: markdown markers (#, >, *, backtick, list dashes, table
+	// pipes, quotes) plus the snippet's leading/trailing ellipsis and stray
+	// sentence punctuation — these land at the window boundaries, not mid-phrase.
+	cleaned := strings.Trim(strings.Join(fields, " "), "#>*`-|\"'.,;:… \t")
+	if len(strings.Fields(cleaned)) < minSummaryWords {
+		return ""
+	}
+	return cleaned
+}
+
+// annotationFromHit renders a prior-art Annotation as a crisp
+// "<person> · <date> · <relevance summary>" label. The slug is NOT shown in the
+// label — it's carried in SourceURL as the locator (so a human/agent can
+// `ox session view <ref>`, and the renderer can turn it into a SageOx link).
+// RefKind lets the renderer pick the right web-URL shape per source type.
 func annotationFromHit(h priorArtHit) Annotation {
 	who := h.Author
 	if who == "" {
 		who = "a teammate"
 	}
 
-	verb := "worked on"
-	subject := "session"
-	switch h.DocType {
-	case "murmur":
-		verb = "mentioned"
-		subject = "murmur"
-	case "plan":
-		// a saved plan is the strongest prior-art signal — someone already
-		// scoped this exact work. Phrase it as "planned this in plan <slug>".
-		verb = "planned"
-		subject = "plan"
-	}
-
-	why := who + " " + verb + " this in " + subject + " " + h.SourceID
+	summary := relevanceSummary(h.Text)
+	parts := []string{who}
 	if h.Date != "" {
-		why += " (" + h.Date + ")"
+		parts = append(parts, h.Date)
+	}
+	if summary != "" {
+		parts = append(parts, summary)
 	}
 
 	return Annotation{
 		Kind:      BadgeDeterministic,
 		Type:      BadgePriorArt,
-		Why:       why,
+		Why:       strings.Join(parts, " · "),
 		SourceURL: h.SourceID,
 		Expert:    h.Author,
+		Date:      h.Date,
+		Summary:   summary,
+		RefKind:   h.DocType,
 	}
 }

--- a/internal/plan/priorart_test.go
+++ b/internal/plan/priorart_test.go
@@ -229,14 +229,19 @@ func TestParseSessionAuthorDate(t *testing.T) {
 }
 
 func TestAnnotationFromHit(t *testing.T) {
+	// The crisp label is "person · date · summary" — the slug must NOT appear in
+	// Why (it's the locator in SourceURL and becomes the link). RefKind/Date/
+	// Summary are the structured fields the renderer composes + links.
 	tests := []struct {
-		name        string
-		hit         priorArtHit
-		wantType    BadgeType
-		wantKind    BadgeKind
-		wantExpert  string
-		wantSource  string
-		whyContains []string
+		name           string
+		hit            priorArtHit
+		wantExpert     string
+		wantSource     string
+		wantRefKind    string
+		wantDate       string
+		wantSummaryNon bool // expect a non-empty Summary
+		whyContains    []string
+		whyOmits       []string
 	}{
 		{
 			name: "session hit with author and date",
@@ -245,46 +250,65 @@ func TestAnnotationFromHit(t *testing.T) {
 				SourceID: "2026-02-13T14-56-alice-OxAb12",
 				Author:   "alice", Date: "2026-02-13",
 			},
-			wantType:    BadgePriorArt,
-			wantKind:    BadgeDeterministic,
 			wantExpert:  "alice",
 			wantSource:  "2026-02-13T14-56-alice-OxAb12",
-			whyContains: []string{"alice", "worked on", "2026-02-13"},
+			wantRefKind: "session",
+			wantDate:    "2026-02-13",
+			whyContains: []string{"alice", "2026-02-13"},
+			// the slug must not be duplicated into the label
+			whyOmits: []string{"OxAb12", "worked on"},
+		},
+		{
+			name: "session hit with relevance summary",
+			hit: priorArtHit{
+				Score: 0.9, DocType: "session",
+				SourceID: "2026-02-13T14-56-alice-OxAb12",
+				Author:   "alice", Date: "2026-02-13",
+				Text: "## the cache warming path for cold starts was added here later",
+			},
+			wantExpert:     "alice",
+			wantSource:     "2026-02-13T14-56-alice-OxAb12",
+			wantRefKind:    "session",
+			wantDate:       "2026-02-13",
+			wantSummaryNon: true,
+			whyContains:    []string{"alice", "2026-02-13", "cache warming path"},
+			// markdown header marker stripped; slug not present
+			whyOmits: []string{"##", "OxAb12"},
 		},
 		{
 			name: "murmur hit without author",
 			hit: priorArtHit{
 				Score: 0.7, DocType: "murmur", SourceID: "mid", Author: "", Date: "",
 			},
-			wantType:    BadgePriorArt,
-			wantKind:    BadgeDeterministic,
 			wantExpert:  "",
 			wantSource:  "mid",
-			whyContains: []string{"a teammate", "mentioned", "murmur"},
+			wantRefKind: "murmur",
+			whyContains: []string{"a teammate"},
+			whyOmits:    []string{"mid", "mentioned"},
 		},
 		{
-			// a saved plan is the strongest prior-art signal: "planned this in plan".
-			name: "plan hit phrases as planned",
+			name: "plan hit crisp label",
 			hit: priorArtHit{
 				Score: 0.85, DocType: "plan",
 				SourceID: "2026-05-21-cache-layer", Author: "", Date: "2026-05-21",
 			},
-			wantType:    BadgePriorArt,
-			wantKind:    BadgeDeterministic,
 			wantExpert:  "",
 			wantSource:  "2026-05-21-cache-layer",
-			whyContains: []string{"a teammate", "planned", "plan", "2026-05-21"},
+			wantRefKind: "plan",
+			wantDate:    "2026-05-21",
+			whyContains: []string{"a teammate", "2026-05-21"},
+			whyOmits:    []string{"cache-layer", "planned"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := annotationFromHit(tt.hit)
-			if a.Type != tt.wantType {
-				t.Errorf("Type = %q, want %q", a.Type, tt.wantType)
+			if a.Type != BadgePriorArt {
+				t.Errorf("Type = %q, want %q", a.Type, BadgePriorArt)
 			}
-			if a.Kind != tt.wantKind {
-				t.Errorf("Kind = %q, want %q", a.Kind, tt.wantKind)
+			if a.Kind != BadgeDeterministic {
+				t.Errorf("Kind = %q, want %q", a.Kind, BadgeDeterministic)
 			}
 			if a.Expert != tt.wantExpert {
 				t.Errorf("Expert = %q, want %q", a.Expert, tt.wantExpert)
@@ -292,9 +316,23 @@ func TestAnnotationFromHit(t *testing.T) {
 			if a.SourceURL != tt.wantSource {
 				t.Errorf("SourceURL = %q, want %q", a.SourceURL, tt.wantSource)
 			}
+			if a.RefKind != tt.wantRefKind {
+				t.Errorf("RefKind = %q, want %q", a.RefKind, tt.wantRefKind)
+			}
+			if a.Date != tt.wantDate {
+				t.Errorf("Date = %q, want %q", a.Date, tt.wantDate)
+			}
+			if (a.Summary != "") != tt.wantSummaryNon {
+				t.Errorf("Summary = %q, wantNonEmpty=%v", a.Summary, tt.wantSummaryNon)
+			}
 			for _, frag := range tt.whyContains {
 				if !contains(a.Why, frag) {
 					t.Errorf("Why = %q, missing %q", a.Why, frag)
+				}
+			}
+			for _, frag := range tt.whyOmits {
+				if contains(a.Why, frag) {
+					t.Errorf("Why = %q, should omit %q", a.Why, frag)
 				}
 			}
 		})

--- a/internal/plan/render.go
+++ b/internal/plan/render.go
@@ -4,12 +4,17 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
+	"html"
 	"html/template"
 	"log/slog"
 	"path"
 	"regexp"
 	"strings"
+	"sync"
 
+	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	ghtml "github.com/yuin/goldmark/renderer/html"
@@ -47,6 +52,13 @@ type RenderOptions struct {
 	// with the token. Empty for a static file:// render (clipboard fallback).
 	ReviewEndpoint string
 	ReviewToken    string
+	// PriorArtURL resolves a prior-art source (its kind + ref/slug) to a SageOx
+	// web URL, opened in a new tab from the enrichment panel. Nil-safe: when nil
+	// or when it returns "", the prior-art entry renders as crisp text with no
+	// link. This is the seam that keeps internal/plan config-agnostic — the
+	// command layer builds the closure from the local project config, and
+	// `ox plan enrich --json` (no config) never embeds an environment URL.
+	PriorArtURL func(refKind, ref string) string
 }
 
 // reviewStateItem is the slim per-item shape injected into the page for the
@@ -99,6 +111,7 @@ type renderSignal struct {
 	Label  string
 	Why    string
 	Source string
+	URL    string // SageOx web URL for prior-art; empty = render as plain text
 }
 
 type reviewSummary struct {
@@ -178,7 +191,7 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 	data := renderData{
 		Title:          planTitle(in),
 		Slug:           opts.Slug,
-		CSS:            template.CSS(css),
+		CSS:            template.CSS(string(css) + highlightCSS()),
 		JS:             template.JS(js),
 		ReviewJS:       template.JS(reviewJS),
 		ReviewEndpoint: opts.ReviewEndpoint,
@@ -240,7 +253,7 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 	// signals that match no section stay in the global enrichment panel. This is
 	// the data join that replaces a single prose blob with section-anchored
 	// markers — the spec's per-section badge rail.
-	all := deterministicSignalsWithFiles(res)
+	all := deterministicSignalsWithFiles(res, opts.PriorArtURL)
 	data.HasSignals = len(all) > 0
 	data.SignalCount = len(all)
 	if data.SignalCount != 1 {
@@ -295,9 +308,108 @@ func mdToHTML(md goldmark.Markdown, src string) (template.HTML, error) {
 	if err := md.Convert([]byte(src), &buf); err != nil {
 		return "", fmt.Errorf("markdown convert: %w", err)
 	}
-	html := mermaidFence.ReplaceAllString(buf.String(), `<pre class="mermaid">$1</pre>`)
-	html = colorVerdictCells(html)
-	return template.HTML(html), nil
+	// Ordering is load-bearing: mermaid fences are rewritten to <pre class="mermaid">
+	// FIRST, so highlightFences (which scans for <pre><code class="language-X">)
+	// never sees — and never chroma-tokenizes — a mermaid block. colorVerdictCells
+	// touches table cells only, so its position is independent.
+	rendered := mermaidFence.ReplaceAllString(buf.String(), `<pre class="mermaid">$1</pre>`)
+	rendered = highlightFences(rendered)
+	rendered = colorVerdictCells(rendered)
+	return template.HTML(rendered), nil //nolint:gosec // first-party plan markdown; see newMarkdown trust note
+}
+
+// codeFence matches a goldmark-rendered fenced code block carrying a language
+// class. Non-greedy body capture mirrors mermaidFence. By the time highlightFences
+// runs, mermaid blocks are already <pre class="mermaid">, so they never match
+// here. goldmark HTML-escapes code content, so a literal "</code></pre>" inside a
+// block becomes "&lt;/code&gt;&lt;/pre&gt;" and cannot prematurely close the match.
+var codeFence = regexp.MustCompile(`(?s)<pre><code class="language-([\w+#.-]+)">(.*?)</code></pre>`)
+
+// Code highlighting renders class-based markup once (the markup is style-
+// independent), while highlightCSS() emits two theme-scoped stylesheets so the
+// colors flip with the page's [data-theme] toggle — no client JS, no CDN. The
+// palette mirrors sageox-mono's web highlighter (Shiki github-dark / github-light)
+// for cross-surface parity.
+var (
+	highlightFormatter = chromahtml.New(chromahtml.WithClasses(true), chromahtml.ClassPrefix("ox-hl-"))
+	highlightCSSOnce   sync.Once
+	highlightCSSCache  string
+	chromaBackground   = regexp.MustCompile(`background(-color)?:[^;}]*;?`)
+)
+
+// highlightFences colorizes fenced code blocks server-side with chroma. Blocks
+// with no language class don't match the regex (left monochrome); blocks with an
+// unknown language, the mermaid language, or any chroma error are returned
+// verbatim — an unknown lexer must NOT fall back to prose-tokenizing.
+func highlightFences(s string) string {
+	return codeFence.ReplaceAllStringFunc(s, func(block string) string {
+		m := codeFence.FindStringSubmatch(block)
+		if m == nil {
+			return block
+		}
+		lang := m[1]
+		if lang == "mermaid" {
+			return block // belt-and-suspenders; mermaid is handled upstream
+		}
+		lexer := lexers.Get(lang)
+		if lexer == nil {
+			return block // unknown language → leave monochrome, never panic
+		}
+		iterator, err := lexer.Tokenise(nil, html.UnescapeString(m[2])) // chroma re-escapes on output
+		if err != nil {
+			return block
+		}
+		var out bytes.Buffer
+		if err := highlightFormatter.Format(&out, styles.Get("github-dark"), iterator); err != nil {
+			return block
+		}
+		return out.String()
+	})
+}
+
+// highlightCSS builds the combined, theme-scoped chroma stylesheet (generated
+// once). github-dark applies under html[data-theme="dark"], github (light) under
+// html[data-theme="light"], so toggling the theme recolors code with zero JS.
+// chroma's baked panel background is stripped so the scaffold's var(--panel)
+// shows through.
+func highlightCSS() string {
+	highlightCSSOnce.Do(func() {
+		highlightCSSCache = "\n/* code syntax highlighting (chroma, theme-scoped) */\n" +
+			themeScopedChromaCSS(`html[data-theme="dark"]`, "github-dark") +
+			themeScopedChromaCSS(`html[data-theme="light"]`, "github")
+	})
+	return highlightCSSCache
+}
+
+// themeScopedChromaCSS emits chroma's class CSS for one style, with every rule
+// prefixed by scope (a [data-theme] selector) and all background declarations
+// stripped. WriteCSS uses the formatter's class prefix, so classes line up with
+// the markup highlightFences produces.
+func themeScopedChromaCSS(scope, styleName string) string {
+	var raw bytes.Buffer
+	if err := highlightFormatter.WriteCSS(&raw, styles.Get(styleName)); err != nil {
+		return ""
+	}
+	css := chromaBackground.ReplaceAllString(raw.String(), "")
+	var b strings.Builder
+	for _, line := range strings.Split(css, "\n") {
+		line = strings.TrimSpace(line)
+		// chroma prefixes each rule with a "/* TokenName */" comment; drop it so
+		// the scope sits flush against the selector (cleaner, and unambiguous).
+		if strings.HasPrefix(line, "/*") {
+			if end := strings.Index(line, "*/"); end >= 0 {
+				line = strings.TrimSpace(line[end+2:])
+			}
+		}
+		if line == "" || !strings.Contains(line, "{") {
+			continue
+		}
+		b.WriteString(scope)
+		b.WriteByte(' ')
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 // signalWithFiles couples a projected renderSignal with the annotation's file
@@ -311,7 +423,7 @@ type signalWithFiles struct {
 // prior-art / expert-routing) into anchorable signals. Judgment badges are
 // agent-authored and not surfaced here. The presence of any signal is what makes
 // the render emit the anchored OX marker the lint contract requires.
-func deterministicSignalsWithFiles(res Result) []signalWithFiles {
+func deterministicSignalsWithFiles(res Result, priorArtURL func(refKind, ref string) string) []signalWithFiles {
 	labels := map[string]string{
 		"collision":      "Collision",
 		"prior-art":      "Prior art",
@@ -326,15 +438,19 @@ func deterministicSignalsWithFiles(res Result) []signalWithFiles {
 		if !ok {
 			continue
 		}
-		out = append(out, signalWithFiles{
-			renderSignal: renderSignal{
-				Type:   string(a.Type),
-				Label:  label,
-				Why:    a.Why,
-				Source: a.SourceURL,
-			},
-			files: a.Files,
-		})
+		sig := renderSignal{
+			Type:   string(a.Type),
+			Label:  label,
+			Why:    a.Why,
+			Source: a.SourceURL,
+		}
+		// Prior-art entries link to the SageOx web view when the command layer
+		// supplied a resolver and it can build a URL for this source kind
+		// (sessions today; plans/murmurs fall back to plain text).
+		if a.Type == BadgePriorArt && priorArtURL != nil {
+			sig.URL = priorArtURL(a.RefKind, a.SourceURL)
+		}
+		out = append(out, signalWithFiles{renderSignal: sig, files: a.Files})
 	}
 	return out
 }

--- a/internal/plan/render_highlight_test.go
+++ b/internal/plan/render_highlight_test.go
@@ -1,0 +1,223 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+)
+
+// renderMarkdown is a small helper: parse raw plan markdown and render it with
+// the given options, failing the test on error.
+func renderMarkdown(t *testing.T, raw string, opts RenderOptions) string {
+	t.Helper()
+	out, err := RenderHTMLOpts(Parse(raw), Result{}, opts)
+	if err != nil {
+		t.Fatalf("RenderHTMLOpts: %v", err)
+	}
+	return string(out)
+}
+
+// --- A. Code-block syntax highlighting ---
+
+// TestHighlight_KnownLanguageColorized verifies a fenced block with a known
+// language is chroma-tokenized into class-based spans.
+// Failure prevented: code blocks render flat monochrome (the original complaint).
+func TestHighlight_KnownLanguageColorized(t *testing.T) {
+	raw := "# P\n\n## Code\n\n```json\n{\n  \"version\": 1\n}\n```\n"
+	s := renderMarkdown(t, raw, RenderOptions{})
+
+	if !strings.Contains(s, `<pre class="ox-hl-chroma">`) {
+		t.Error("known-language block was not chroma-highlighted")
+	}
+	if !strings.Contains(s, "ox-hl-") {
+		t.Error("expected prefixed chroma token classes in output")
+	}
+	if !strings.Contains(s, "version") {
+		t.Error("code content lost during highlighting")
+	}
+}
+
+// TestHighlight_MermaidUntouched verifies mermaid fences are NOT chroma-tokenized
+// — they must stay <pre class="mermaid"> for mermaid.run() to pick up.
+// Failure prevented: highlighting breaks every Mermaid diagram (the #1 risk).
+func TestHighlight_MermaidUntouched(t *testing.T) {
+	raw := "# P\n\n## Flow\n\n```mermaid\nflowchart LR\n  A[\"x\"] --> B[\"y\"]\n```\n"
+	s := renderMarkdown(t, raw, RenderOptions{})
+
+	if !strings.Contains(s, `<pre class="mermaid">`) {
+		t.Error("mermaid fence was not preserved")
+	}
+	// No code block should have been chroma-wrapped (only mermaid present).
+	if strings.Contains(s, `<pre class="ox-hl-chroma">`) {
+		t.Error("mermaid block was incorrectly chroma-tokenized")
+	}
+	if !strings.Contains(s, "flowchart LR") {
+		t.Error("mermaid source lost")
+	}
+}
+
+// TestHighlight_UnknownLanguageVerbatim verifies an unknown language is left as
+// goldmark rendered it — never falling back to prose-tokenizing or panicking.
+func TestHighlight_UnknownLanguageVerbatim(t *testing.T) {
+	raw := "# P\n\n## Code\n\n```zzznotalang\nhello world\n```\n"
+	s := renderMarkdown(t, raw, RenderOptions{})
+
+	if strings.Contains(s, `<pre class="ox-hl-chroma">`) {
+		t.Error("unknown language should not be chroma-wrapped")
+	}
+	if !strings.Contains(s, `class="language-zzznotalang"`) {
+		t.Error("unknown-language block should be left verbatim")
+	}
+}
+
+// TestHighlight_BareFenceUntouched verifies a fence with no language stays plain.
+func TestHighlight_BareFenceUntouched(t *testing.T) {
+	raw := "# P\n\n## Code\n\n```\nplain text\n```\n"
+	s := renderMarkdown(t, raw, RenderOptions{})
+
+	if strings.Contains(s, `<pre class="ox-hl-chroma">`) {
+		t.Error("bare fence should not be highlighted")
+	}
+	if !strings.Contains(s, "plain text") {
+		t.Error("bare fence content lost")
+	}
+}
+
+// TestHighlight_EmbeddedCloseTagSafe verifies a code block whose content contains
+// the literal string "</code></pre>" is not truncated — goldmark escapes the
+// angle brackets, so the close-tag regex cannot match inside the block.
+func TestHighlight_EmbeddedCloseTagSafe(t *testing.T) {
+	raw := "# P\n\n## Code\n\n```html\n<div></code></pre>after</div>\n```\n"
+	s := renderMarkdown(t, raw, RenderOptions{})
+
+	if !strings.Contains(s, "after") {
+		t.Error("content after an embedded close-tag was truncated")
+	}
+}
+
+// TestHighlightCSS_ThemeScopedAndStable verifies both theme palettes are emitted,
+// scoped under [data-theme], with chroma's panel background stripped so the
+// scaffold's var(--panel) shows through; and that generation is stable.
+// Failure prevented: highlight colors don't flip with the theme toggle, or chroma
+// paints its own background over the design-token panel.
+func TestHighlightCSS_ThemeScopedAndStable(t *testing.T) {
+	css := highlightCSS()
+
+	if !strings.Contains(css, `html[data-theme="dark"]`) {
+		t.Error("missing dark-theme-scoped highlight CSS")
+	}
+	if !strings.Contains(css, `html[data-theme="light"]`) {
+		t.Error("missing light-theme-scoped highlight CSS")
+	}
+	if strings.Contains(css, "background-color:") || strings.Contains(css, "background:") {
+		t.Error("chroma background leaked; scaffold var(--panel) would be overpainted")
+	}
+	if highlightCSS() != css {
+		t.Error("highlightCSS must be deterministic across calls")
+	}
+}
+
+// --- B. Prior-art crisp clickable links ---
+
+func priorArtResult() Result {
+	return Result{Annotations: []Annotation{{
+		Kind: BadgeDeterministic, Type: BadgePriorArt,
+		Why:       "alice · 2026-02-13 · cache warming path",
+		SourceURL: "2026-02-13T14-56-alice-OxAb12",
+		Expert:    "alice", Date: "2026-02-13", RefKind: "session",
+	}}}
+}
+
+// TestPriorArt_SessionLinks verifies a session prior-art entry becomes a crisp
+// linked label plus a "view" affordance, opening in a new tab.
+// Failure prevented: prior art stays dead, repetitive text (the complaint).
+func TestPriorArt_SessionLinks(t *testing.T) {
+	in := Parse("# P\n\n## Approach\n\nDo it.\n")
+	resolver := func(refKind, ref string) string {
+		if refKind == "session" {
+			return "https://ex.test/repo/r1/sessions/" + ref + "/view"
+		}
+		return ""
+	}
+	out, err := RenderHTMLOpts(in, priorArtResult(), RenderOptions{PriorArtURL: resolver})
+	if err != nil {
+		t.Fatalf("RenderHTMLOpts: %v", err)
+	}
+	s := string(out)
+
+	for _, want := range []string{
+		`class="src-link"`,
+		`href="https://ex.test/repo/r1/sessions/2026-02-13T14-56-alice-OxAb12/view"`,
+		`target="_blank"`,
+		`rel="noopener noreferrer"`,
+		"view ↗",
+		"alice · 2026-02-13 · cache warming path",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("linked prior-art missing %q", want)
+		}
+	}
+	// the slug must NOT be printed as a trailing plain-text .src span — that
+	// visible double-print (slug in prose AND in the span) was the original bug.
+	// It legitimately appears inside the two anchor hrefs only.
+	if strings.Contains(s, `<span class="src">`) {
+		t.Error("linked prior-art must not also print the slug as a plain .src span")
+	}
+}
+
+// TestPriorArt_NoLinkWhenResolverEmpty verifies plans/murmurs (resolver returns
+// "") render as crisp text with no anchor and no empty href.
+func TestPriorArt_NoLinkWhenResolverEmpty(t *testing.T) {
+	in := Parse("# P\n\n## Approach\n\nDo it.\n")
+	resolver := func(refKind, ref string) string { return "" } // e.g. plan/murmur
+	out, err := RenderHTMLOpts(in, priorArtResult(), RenderOptions{PriorArtURL: resolver})
+	if err != nil {
+		t.Fatalf("RenderHTMLOpts: %v", err)
+	}
+	s := string(out)
+
+	if strings.Contains(s, `class="src-link"`) {
+		t.Error("entry should not be linked when resolver yields no URL")
+	}
+	if !strings.Contains(s, "alice · 2026-02-13 · cache warming path") {
+		t.Error("crisp label missing in the no-link fallback")
+	}
+}
+
+// TestPriorArt_NilResolverNoPanic verifies a nil PriorArtURL (the zero
+// RenderOptions, e.g. enrich --json paths) renders crisp text without linking.
+func TestPriorArt_NilResolverNoPanic(t *testing.T) {
+	in := Parse("# P\n\n## Approach\n\nDo it.\n")
+	out, err := RenderHTMLOpts(in, priorArtResult(), RenderOptions{}) // nil resolver
+	if err != nil {
+		t.Fatalf("RenderHTMLOpts: %v", err)
+	}
+	if strings.Contains(string(out), `class="src-link"`) {
+		t.Error("nil resolver must not produce links")
+	}
+}
+
+// --- C. relevanceSummary cleaning ---
+
+// TestRelevanceSummary verifies snippet cleaning: whitespace collapse, edge
+// markdown stripping, word-boundary cap, and the too-short → "" fallback.
+func TestRelevanceSummary(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"collapses whitespace", "the   cache\n\nwarming  path", "the cache warming path"},
+		{"strips edge markdown", "## the cache warming path ##", "the cache warming path"},
+		{"strips quote and list markers", ">- the cache warming path -", "the cache warming path"},
+		{"caps at ten words", "one two three four five six seven eight nine ten eleven twelve", "one two three four five six seven eight nine ten"},
+		{"too short -> empty", "ok", ""},
+		{"empty -> empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := relevanceSummary(tt.in); got != tt.want {
+				t.Errorf("relevanceSummary(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -68,6 +68,13 @@ type Annotation struct {
 	SourceURL string    `json:"source_url,omitempty"`
 	Expert    string    `json:"expert,omitempty"`
 	Files     []string  `json:"files,omitempty"`
+	// Date, Summary, RefKind carry the structured prior-art fields the renderer
+	// composes into a crisp "person · date · summary" link. Environment-
+	// independent (no URL), so they're safe to emit in `ox plan enrich --json`;
+	// the web URL is built only at render time from the local project config.
+	Date    string `json:"date,omitempty"`
+	Summary string `json:"summary,omitempty"`
+	RefKind string `json:"ref_kind,omitempty"` // session | plan | murmur
 }
 
 // ContextItem is one ranked, pre-retrieved slice of ledger / team context / code


### PR DESCRIPTION
## Summary

Two presentation upgrades to the `ox plan render` HTML page (`ox plan render --open`), both long-standing rough edges a user flagged:

- **Prior-art entries are now crisp, clickable links.** They were dead, repetitive text — the session/plan slug was printed twice (once in the prose, once as a trailing span) and nothing was a link. Each bullet now reads **`person · date · short relevance summary`** and links to the SageOx session view, opening in a new tab.
- **Fenced code blocks are now syntax-highlighted.** JSON, Go, bash, etc. rendered as flat monochrome ink. They're now colorized server-side, theme-aware, with zero client JS.

## What changed

**Prior-art links**
- New crisp label `person · date · summary`; the slug is no longer duplicated. Summary is a cleaned, ~10-word, best-effort phrase from the match snippet.
- The label is a subtle link **plus** a `view ↗` affordance, both `target="_blank" rel="noopener noreferrer"`.
- URL construction stays in the command layer (reuses `buildSessionURL`) via a nil-safe `RenderOptions.PriorArtURL` resolver, so `internal/plan` stays config-agnostic and `ox plan enrich --json` never embeds an environment-specific URL (it gains `date` / `summary` / `ref_kind` instead).
- **Sessions link today.** Murmurs intentionally stay unlinked; **plans are deferred** (no per-plan web route yet) with an inline `TODO(plan-web-route)` and a tracked follow-up — the resolver already branches on `ref_kind`, so it's a drop-in.

**Syntax highlighting**
- Rendered with **chroma** (pure Go, no CDN, no JS) so the page stays self-contained. Palette is `github-dark` / `github` — intentionally identical to sageox-mono's web Shiki themes for cross-surface parity (no invented colors).
- Two `[data-theme]`-scoped stylesheets mean code colors **flip with the existing dark/light toggle** with zero JS. chroma's baked background is stripped so the design-token panel shows through.

```mermaid
flowchart LR
  MD["plan markdown"] --> GM["goldmark"]
  GM --> MM["rewrite mermaid fences to pre.mermaid"]
  MM --> HL["highlightFences via chroma"]
  HL --> VC["colorVerdictCells"]
  VC --> OUT["self-contained HTML"]
```

Ordering is load-bearing: mermaid fences are rewritten **before** highlighting, so a diagram is never chroma-tokenized. Unknown languages and bare fences are left verbatim (no prose-tokenizing, no panic).

```mermaid
flowchart TD
  PA["prior-art hit"] --> K{"ref_kind?"}
  K -->|session| DURL["build session web URL"]
  K -->|plan| TXT["crisp text, link deferred"]
  K -->|murmur| TXT
  DURL --> LINK["linked label plus view affordance"]
```

## Test Plan

- New table-driven tests (`internal/plan/render_highlight_test.go`): mermaid-not-tokenized, unknown/bare-fence verbatim, embedded `</pre>` safety, both theme stylesheets present with no background leak, session-link / no-link-fallback / nil-resolver, and summary cleaning. Updated the stale `TestAnnotationFromHit`.
- `make test` green (**15,959 tests**), `make lint` clean.
- Live end-to-end render verified: 3 colorized blocks (Go/JSON/bash), Mermaid intact, theme toggle flips code colors, prior-art session link resolves to `…/sessions/<name>/view`, and `enrich --json` carries the new fields with no URL.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented
- [ ] CHANGELOG entry added (if user-facing) — follow-up before release
- [x] Breaking change documented — none (additive `Annotation` JSON fields, all `omitempty`)
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: no auth/mcp/raw_writer/upgrade/go.sum changes; `go.mod` only promotes existing transitive `chroma` to direct

</details>

Co-Authored-By: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prior-art references in plans now render as clickable links with visual affordances ("view ↗").
  * Signal items display as interactive links when URLs are available.
  * Code blocks in plan content now include syntax highlighting.
  * Prior-art badges now include relevance summaries and metadata.

* **Style**
  * Added styling for prior-art link elements with hover states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->