### PR TITLE
fix(sync): report real per-team status + metadata for ox sync --team

### DIFF
--- a/cmd/ox/distill.go
+++ b/cmd/ox/distill.go
@@ -421,14 +421,53 @@ func syncBeforeDistill() error {
 		return fmt.Errorf("ledger sync failed: %w", err)
 	}
 
-	// sync team contexts
-	if err := cli.WithSpinnerNoResult("Syncing team contexts...", func() error {
+	// sync team contexts. distill only needs THIS repo's team context to be
+	// locally usable. We fail when our own team context isn't usable (failed,
+	// not-found, or still cloning — distilling on missing/stale primary context
+	// would silently hide exactly the failure this change exists to surface), or
+	// on a whole-operation failure. An unrelated secondary team's failure is just
+	// a warning and must not block distillation.
+	primaryTeamID := ""
+	if root := config.FindProjectRoot(); root != "" {
+		if pc, err := config.LoadProjectConfig(root); err == nil && pc != nil {
+			primaryTeamID = pc.TeamID
+		}
+	}
+
+	var teamResults []daemon.TeamSyncResult
+	teamSyncErr := cli.WithSpinnerNoResult("Syncing team contexts...", func() error {
 		client := daemon.NewClientForCurrentRepoWithTimeout(60 * time.Second)
-		return client.TeamSyncWithProgress(func(stage string, percent *int, message string) {
+		var e error
+		teamResults, e = client.TeamSyncWithProgress(func(stage string, percent *int, message string) {
 			// progress handled by spinner
 		})
-	}); err != nil {
-		return fmt.Errorf("team context sync failed: %w", err)
+		return e
+	})
+
+	if primaryTeamID != "" {
+		// reuse the targeted-sync derivation so "usable" means the same thing
+		// everywhere: synced/skipped are usable; cloning/error/not_found are not;
+		// unknown (legacy daemon) is tolerated.
+		pr := resolveTeamSyncResult(primaryTeamID, teamResults, teamSyncErr)
+		switch pr.Status {
+		case "synced", "skipped":
+			if teamSyncErr != nil {
+				cli.PrintWarning(fmt.Sprintf("Team context sync incomplete: %v (unrelated team; continuing)", teamSyncErr))
+			}
+		case "unknown":
+			// legacy daemon: fail closed with the version-aware message rather
+			// than distilling on context we can't confirm is current.
+			return legacyDaemonError()
+		default: // cloning, error, not_found, ambiguous
+			return fmt.Errorf("this repo's team context (%s) is not ready: %s", primaryTeamID, pr.Status)
+		}
+	} else if teamSyncErr != nil {
+		// repo has no primary team configured: only a whole-operation failure
+		// (no per-team data) blocks distillation; otherwise warn and proceed.
+		if len(teamResults) == 0 {
+			return fmt.Errorf("team context sync failed: %w", teamSyncErr)
+		}
+		cli.PrintWarning(fmt.Sprintf("Team context sync incomplete: %v (continuing)", teamSyncErr))
 	}
 
 	// update code index

--- a/cmd/ox/sync.go
+++ b/cmd/ox/sync.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/sageox/ox/internal/cli"
@@ -12,6 +14,7 @@ import (
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/repotools"
+	"github.com/sageox/ox/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -35,9 +38,13 @@ type SyncLedgerResult struct {
 type TeamContextSyncResult struct {
 	TeamID   string `json:"team_id"`
 	TeamName string `json:"team_name"`
+	TeamSlug string `json:"team_slug,omitempty"`
 	Path     string `json:"path"`
-	Status   string `json:"status"` // "synced", "skipped", "error", "not_found"
-	Error    string `json:"error,omitempty"`
+	// "synced", "skipped", "cloning", "error", "not_found", "ambiguous", or
+	// "unknown" ("unknown" = a legacy daemon that didn't report per-team results;
+	// "ambiguous" = a slug/name selector that matched more than one team).
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
 }
 
 var syncCmd = &cobra.Command{
@@ -207,57 +214,215 @@ func syncViaDaemon(_ context.Context, jsonOutput bool, result *SyncResult) error
 }
 
 // syncTeamContext syncs a specific team context by ID via daemon.
-// CLI delegates pull operations to daemon.
+// CLI delegates pull operations to daemon. The daemon syncs all configured
+// teams at once and returns per-team results; we report the status of the
+// requested team specifically (not the bare success of the IPC round-trip).
 func syncTeamContext(_ context.Context, teamID string, jsonOutput bool, result *SyncResult) error {
-	tcResult := TeamContextSyncResult{
-		TeamID: teamID,
+	var results []daemon.TeamSyncResult
+	run := func() error {
+		client := daemon.NewClientForCurrentRepoWithTimeout(60 * time.Second)
+		var e error
+		results, e = client.TeamSyncWithProgress(nil)
+		return e
 	}
 
-	// daemon syncs all teams at once
 	var syncErr error
 	if !jsonOutput {
-		syncErr = cli.WithSpinnerNoResult(fmt.Sprintf("Syncing team %s via daemon...", teamID), func() error {
-			client := daemon.NewClientForCurrentRepoWithTimeout(60 * time.Second)
-			return client.TeamSyncWithProgress(nil)
-		})
+		syncErr = cli.WithSpinnerNoResult(fmt.Sprintf("Syncing team %s via daemon...", teamID), run)
 	} else {
-		client := daemon.NewClientForCurrentRepoWithTimeout(60 * time.Second)
-		syncErr = client.TeamSyncWithProgress(nil)
+		syncErr = run()
 	}
 
-	if syncErr != nil {
-		tcResult.Status = "error"
-		tcResult.Error = syncErr.Error()
-		if !jsonOutput {
-			cli.PrintError(fmt.Sprintf("Team sync failed: %v", syncErr))
-		}
-	} else {
-		tcResult.Status = "synced"
+	tcResult := resolveTeamSyncResult(teamID, results, syncErr)
+	// for the legacy-daemon ("unknown") case, replace the placeholder error with
+	// a version-aware message (queries the daemon's version) before it's reported.
+	if tcResult.Status == "unknown" {
+		tcResult.Error = legacyDaemonError().Error()
+	}
+	result.TeamContexts = append(result.TeamContexts, tcResult)
+
+	// The command succeeds only when the requested team context is locally
+	// usable: "synced" (pulled) or "skipped" (already up to date and present).
+	// Everything else is a non-success that exits non-zero:
+	//   - "cloning": clone in progress, not yet usable — fail so scripts don't
+	//     proceed against missing context (re-run once the clone finishes)
+	//   - "error" / "not_found" / "ambiguous": a real failure, typo/stale selector,
+	//     or a selector matching multiple teams
+	//   - "unknown": a legacy daemon that returned no per-team data. We fail CLOSED:
+	//     its "success" is untrustworthy (old daemons swallowed failures), so we
+	//     surface it with a restart hint instead of implying the team synced.
+	// A whole-op error caused by some *other* team never reaches here as the
+	// requested team's status, so it can't fail this targeted request.
+	switch tcResult.Status {
+	case "synced":
 		if !jsonOutput {
 			cli.PrintSuccess(fmt.Sprintf("Team %s synced via daemon", teamID))
 		}
+		return nil
+	case "skipped":
+		if !jsonOutput {
+			cli.PrintSuccess(fmt.Sprintf("Team %s already up to date", teamID))
+		}
+		return nil
+	case "cloning":
+		if !jsonOutput {
+			cli.PrintError(fmt.Sprintf("Team %s clone in progress (not yet available); re-run shortly", teamID))
+		}
+		return fmt.Errorf("team %s clone in progress (not yet available)", teamID)
+	default: // error, not_found, ambiguous, unknown
+		if !jsonOutput {
+			cli.PrintError(fmt.Sprintf("Team sync failed: %v", tcResult.Error))
+		}
+		return errors.New(tcResult.Error)
+	}
+}
+
+// resolveTeamSyncResult derives the reported result for a targeted --team sync
+// from the daemon's per-team results and the IPC error. It is pure (no I/O) so
+// the status-derivation logic can be unit-tested directly.
+//
+// The selector may be the team ID, its kebab-case slug, or its name (the --help
+// example uses a slug-like value), so it is matched against all three.
+//
+// Selector resolution: an exact team-ID match wins immediately (IDs are unique).
+// Otherwise the selector is matched against slug and name, which are NOT
+// guaranteed unique — if more than one team matches, the result is "ambiguous"
+// rather than silently picking the first (which could report the wrong team).
+//
+// Status outcomes:
+//   - match found      → that team's reported status (synced/skipped/cloning/error)
+//   - slug/name matches >1 team → "ambiguous": caller must disambiguate by ID
+//   - results == nil, no err → "unknown": a legacy pre-change daemon that returned
+//     success without per-team data (current daemons always send an array). The
+//     caller fails CLOSED on this — a legacy daemon also swallowed sync failures,
+//     so its "success" can't be trusted; the user should restart the daemon and
+//     retry rather than proceed on possibly stale/missing context.
+//   - empty results + err → "error": transport/setup failure with nothing to attribute
+//   - results present, no match → "not_found": a genuine miss (typo/stale config)
+func resolveTeamSyncResult(teamID string, results []daemon.TeamSyncResult, syncErr error) TeamContextSyncResult {
+	tcResult := TeamContextSyncResult{TeamID: teamID}
+
+	// exact ID match wins (IDs are unique)
+	var match *daemon.TeamSyncResult
+	for i := range results {
+		if teamID == results[i].TeamID {
+			match = &results[i]
+			break
+		}
+	}
+	// otherwise resolve via slug/name, which may collide across teams
+	if match == nil {
+		var candidates []*daemon.TeamSyncResult
+		for i := range results {
+			r := &results[i]
+			if (r.TeamSlug != "" && teamID == r.TeamSlug) || (r.TeamName != "" && teamID == r.TeamName) {
+				candidates = append(candidates, r)
+			}
+		}
+		switch len(candidates) {
+		case 1:
+			match = candidates[0]
+		case 0:
+			// fall through to not_found / legacy / transport handling below
+		default:
+			ids := make([]string, len(candidates))
+			for i, c := range candidates {
+				ids[i] = c.TeamID
+			}
+			tcResult.Status = "ambiguous"
+			tcResult.Error = fmt.Sprintf("selector %q matches multiple teams (%s); use the team ID", teamID, strings.Join(ids, ", "))
+			return tcResult
+		}
 	}
 
-	result.TeamContexts = append(result.TeamContexts, tcResult)
-	return syncErr
+	switch {
+	case match != nil:
+		tcResult.TeamName = match.TeamName
+		tcResult.TeamSlug = match.TeamSlug
+		tcResult.Path = match.Path
+		tcResult.Status = match.Status
+		tcResult.Error = match.Error
+	case results == nil && syncErr == nil:
+		tcResult.Status = "unknown"
+		tcResult.Error = "daemon did not report per-team results (restart the daemon: ox daemon restart)"
+	case len(results) == 0 && syncErr != nil:
+		tcResult.Status = "error"
+		tcResult.Error = syncErr.Error()
+	default:
+		tcResult.Status = "not_found"
+		tcResult.Error = fmt.Sprintf("team %q not found among synced team contexts", teamID)
+	}
+
+	return tcResult
+}
+
+// legacyDaemonError builds the error surfaced when a TeamSync returned success
+// with no per-team data — i.e. the daemon predates the per-team-results protocol
+// (a new CLI talking to an old, still-running daemon after an upgrade). It reads
+// the daemon's reported version to tell the user it's running an older build. It
+// does NOT restart the daemon: the daemon restarts itself on its next heartbeat
+// (version-mismatch detection), so a re-run resolves it.
+func legacyDaemonError() error {
+	daemonVer := ""
+	client := daemon.NewClientForCurrentRepoWithTimeout(5 * time.Second)
+	if st, err := client.Status(); err == nil && st != nil {
+		daemonVer = st.Version
+	}
+	return legacyDaemonErrorMsg(daemonVer)
+}
+
+// legacyDaemonErrorMsg formats the legacy-daemon error from the daemon's reported
+// version. Split out (pure) so the message logic is unit-testable. daemonVersion
+// may carry a "+builddate" suffix, which is stripped before comparison.
+func legacyDaemonErrorMsg(daemonVersion string) error {
+	const base = "daemon did not report per-team results"
+	if daemonVersion == "" {
+		return fmt.Errorf("%s; restart the daemon and retry (ox daemon restart)", base)
+	}
+	daemonSemver, _, _ := strings.Cut(daemonVersion, "+")
+	if daemonSemver != version.Version {
+		return fmt.Errorf("%s: the daemon is running an older version (%s) than this CLI (%s). "+
+			"The daemon restarts itself on its next heartbeat — re-run shortly, or run 'ox daemon restart'",
+			base, daemonSemver, version.Version)
+	}
+	// versions match but still no per-team data — unexpected; surface for diagnosis.
+	return fmt.Errorf("%s (daemon version %s); restart the daemon and retry (ox daemon restart)", base, daemonSemver)
 }
 
 // syncAllTeamContexts syncs all team contexts via daemon.
-// CLI delegates pull operations to daemon.
-func syncAllTeamContexts(_ context.Context, jsonOutput bool, _ *SyncResult) error {
-	var err error
-	if !jsonOutput {
-		err = cli.WithSpinnerNoResult("Syncing team contexts via daemon...", func() error {
-			client := daemon.NewClientForCurrentRepoWithTimeout(60 * time.Second)
-			return client.TeamSyncWithProgress(func(stage string, percent *int, message string) {
-				// progress updates handled by daemon
-			})
-		})
-	} else {
+// CLI delegates pull operations to daemon and reports the per-team results
+// returned by the daemon in the JSON output.
+func syncAllTeamContexts(_ context.Context, jsonOutput bool, result *SyncResult) error {
+	var results []daemon.TeamSyncResult
+	run := func() error {
 		client := daemon.NewClientForCurrentRepoWithTimeout(60 * time.Second)
-		err = client.TeamSyncWithProgress(nil)
+		var e error
+		results, e = client.TeamSyncWithProgress(nil)
+		return e
 	}
 
+	var err error
+	if !jsonOutput {
+		err = cli.WithSpinnerNoResult("Syncing team contexts via daemon...", run)
+	} else {
+		err = run()
+	}
+
+	for _, r := range results {
+		result.TeamContexts = append(result.TeamContexts, TeamContextSyncResult{
+			TeamID:   r.TeamID,
+			TeamName: r.TeamName,
+			TeamSlug: r.TeamSlug,
+			Path:     r.Path,
+			Status:   r.Status,
+			Error:    r.Error,
+		})
+	}
+
+	// Any error from the daemon must fail the command — never print blanket
+	// success on a non-nil error. This covers setup failures (e.g. unreadable
+	// config) and aggregated per-team failures, regardless of whether the daemon
+	// also sent (possibly empty) per-team data.
 	if err != nil {
 		if !jsonOutput {
 			cli.PrintError(fmt.Sprintf("Team sync failed: %v", err))
@@ -265,11 +430,54 @@ func syncAllTeamContexts(_ context.Context, jsonOutput bool, _ *SyncResult) erro
 		return err
 	}
 
+	// Success with no per-team data at all (results is nil, not an empty array)
+	// means a legacy pre-change daemon — we can't confirm anything synced, so
+	// surface the version skew rather than reporting success. (A current daemon
+	// with zero teams sends `[]`, which is non-nil and falls through to success.)
+	if results == nil {
+		retErr := legacyDaemonError()
+		if !jsonOutput {
+			cli.PrintError(fmt.Sprintf("Team sync failed: %v", retErr))
+		}
+		return retErr
+	}
+
+	// The sync succeeds only if every team context ended up locally usable
+	// (synced or already up to date). Teams that errored or are still cloning are
+	// not usable, so report them as a failure rather than printing blanket success
+	// — otherwise scripts/distill could proceed against missing/stale context.
+	if notReady := notReadyTeams(results); len(notReady) > 0 {
+		msg := fmt.Sprintf("team context(s) not ready: %s", strings.Join(notReady, ", "))
+		if !jsonOutput {
+			cli.PrintError(msg)
+		}
+		return errors.New(msg)
+	}
+
 	if !jsonOutput {
 		cli.PrintSuccess("Team contexts synced via daemon")
 	}
 
 	return nil
+}
+
+// notReadyTeams returns "<name> (<status>)" labels for every team context that
+// did not end up locally usable — i.e. anything other than "synced" or
+// "skipped" (already up to date). Used to fail an all-teams sync when some team
+// is still cloning or errored, instead of reporting blanket success.
+func notReadyTeams(results []daemon.TeamSyncResult) []string {
+	var notReady []string
+	for _, r := range results {
+		if r.Status == "synced" || r.Status == "skipped" {
+			continue
+		}
+		name := r.TeamName
+		if name == "" {
+			name = r.TeamID
+		}
+		notReady = append(notReady, fmt.Sprintf("%s (%s)", name, r.Status))
+	}
+	return notReady
 }
 
 // syncPathExists checks if a path exists.

--- a/cmd/ox/sync_test.go
+++ b/cmd/ox/sync_test.go
@@ -1,8 +1,162 @@
 package main
 
 import (
+	"errors"
+	"strings"
 	"testing"
+
+	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/version"
 )
+
+// TestResolveTeamSyncResult covers the status-derivation logic for a targeted
+// `ox sync --team <selector>`. This is the core of the fix: the reported status
+// must reflect the requested team's real outcome (not a bare IPC success), must
+// carry team_name/team_slug/path, must accept ID/slug/name selectors, and must
+// distinguish a genuine not-found (fatal) from a legacy daemon (non-fatal).
+func TestResolveTeamSyncResult(t *testing.T) {
+	synced := []daemon.TeamSyncResult{
+		{TeamID: "team_acme", TeamSlug: "acme", TeamName: "Acme", Path: "/p/acme", Status: "synced"},
+		{TeamID: "team_beta", TeamSlug: "beta", TeamName: "Beta", Path: "/p/beta", Status: "error", Error: "pull failed"},
+		{TeamID: "team_gamma", TeamSlug: "gamma", TeamName: "Gamma", Path: "/p/gamma", Status: "skipped"},
+		{TeamID: "team_delta", TeamSlug: "delta", TeamName: "Delta", Path: "/p/delta", Status: "cloning"},
+	}
+
+	tests := []struct {
+		name       string
+		selector   string
+		results    []daemon.TeamSyncResult
+		syncErr    error
+		wantStatus string
+		wantName   string
+		wantPath   string
+		wantFatal  bool // status that makes the command exit non-zero
+	}{
+		{
+			name: "match by ID populates metadata", selector: "team_acme", results: synced,
+			wantStatus: "synced", wantName: "Acme", wantPath: "/p/acme", wantFatal: false,
+		},
+		{
+			name: "match by slug", selector: "acme", results: synced,
+			wantStatus: "synced", wantName: "Acme", wantPath: "/p/acme", wantFatal: false,
+		},
+		{
+			name: "match by name", selector: "Acme", results: synced,
+			wantStatus: "synced", wantName: "Acme", wantPath: "/p/acme", wantFatal: false,
+		},
+		{
+			name: "requested team errored is fatal", selector: "beta", results: synced,
+			wantStatus: "error", wantName: "Beta", wantPath: "/p/beta", wantFatal: true,
+		},
+		{
+			name: "recently-synced skipped is usable (non-fatal)", selector: "gamma", results: synced,
+			wantStatus: "skipped", wantName: "Gamma", wantPath: "/p/gamma", wantFatal: false,
+		},
+		{
+			name: "clone-in-progress is not usable (fatal)", selector: "delta", results: synced,
+			wantStatus: "cloning", wantName: "Delta", wantPath: "/p/delta", wantFatal: true,
+		},
+		{
+			name: "unrelated team error does not affect requested team", selector: "acme",
+			results: synced, syncErr: errors.New("team sync failed: Beta: pull failed"),
+			wantStatus: "synced", wantName: "Acme", wantPath: "/p/acme", wantFatal: false,
+		},
+		{
+			name: "genuine not found (current daemon, no match) is fatal", selector: "typo",
+			results: synced, wantStatus: "not_found", wantFatal: true,
+		},
+		{
+			name: "exact ID match wins even when a different team shares the slug as its ID-less selector",
+			// two teams; selector is an exact ID — must pick that one, not scan by slug
+			selector: "team_acme", results: synced,
+			wantStatus: "synced", wantName: "Acme", wantFatal: false,
+		},
+		{
+			name:     "ambiguous slug selector is fatal, not first-match",
+			selector: "dup",
+			results: []daemon.TeamSyncResult{
+				{TeamID: "team_a", TeamSlug: "dup", TeamName: "A", Status: "synced"},
+				{TeamID: "team_b", TeamSlug: "dup", TeamName: "B", Status: "error", Error: "boom"},
+			},
+			wantStatus: "ambiguous", wantFatal: true,
+		},
+		{
+			name: "not found against current daemon with zero teams is fatal", selector: "acme",
+			results: []daemon.TeamSyncResult{}, wantStatus: "not_found", wantFatal: true,
+		},
+		{
+			name: "legacy daemon (nil results, no error) is unknown and fatal (fail closed)", selector: "acme",
+			results: nil, syncErr: nil, wantStatus: "unknown", wantFatal: true,
+		},
+		{
+			name: "transport/setup error with no results is fatal", selector: "acme",
+			results: nil, syncErr: errors.New("daemon unreachable"), wantStatus: "error", wantFatal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveTeamSyncResult(tt.selector, tt.results, tt.syncErr)
+
+			if got.TeamID != tt.selector {
+				t.Errorf("TeamID = %q, want %q", got.TeamID, tt.selector)
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tt.wantStatus)
+			}
+			if tt.wantName != "" && got.TeamName != tt.wantName {
+				t.Errorf("TeamName = %q, want %q", got.TeamName, tt.wantName)
+			}
+			if tt.wantPath != "" && got.Path != tt.wantPath {
+				t.Errorf("Path = %q, want %q", got.Path, tt.wantPath)
+			}
+			// mirror the caller's fatal decision: only "usable" states (synced,
+			// skipped) exit 0; everything else — including "unknown" (legacy daemon,
+			// failed closed) — exits non-zero.
+			fatal := got.Status != "synced" && got.Status != "skipped"
+			if fatal != tt.wantFatal {
+				t.Errorf("fatal = %v (status %q), want %v", fatal, got.Status, tt.wantFatal)
+			}
+		})
+	}
+}
+
+// TestLegacyDaemonErrorMsg verifies the version-skew message shown when a daemon
+// returns success without per-team results: it must name the daemon's older
+// version (vs the CLI) and tell the user it self-restarts on the next heartbeat,
+// strip any "+builddate" suffix, and degrade gracefully when the version is
+// unknown or matches.
+func TestLegacyDaemonErrorMsg(t *testing.T) {
+	t.Run("older daemon names both versions and the self-restart", func(t *testing.T) {
+		err := legacyDaemonErrorMsg("0.0.1-older")
+		msg := err.Error()
+		if !strings.Contains(msg, "0.0.1-older") {
+			t.Errorf("expected daemon version in message, got %q", msg)
+		}
+		if !strings.Contains(msg, version.Version) {
+			t.Errorf("expected CLI version %q in message, got %q", version.Version, msg)
+		}
+		if !strings.Contains(msg, "heartbeat") {
+			t.Errorf("expected self-restart hint in message, got %q", msg)
+		}
+	})
+
+	t.Run("strips +builddate suffix before comparing", func(t *testing.T) {
+		// same semver as the CLI but with a build-date suffix must NOT be reported
+		// as an older version (the daemon uses semver-only comparison too).
+		err := legacyDaemonErrorMsg(version.Version + "+somebuilddate")
+		if strings.Contains(err.Error(), "older version") {
+			t.Errorf("matching semver with build suffix should not be 'older': %q", err.Error())
+		}
+	})
+
+	t.Run("unknown version still produces an actionable error", func(t *testing.T) {
+		err := legacyDaemonErrorMsg("")
+		if !strings.Contains(err.Error(), "ox daemon restart") {
+			t.Errorf("expected restart hint when version unknown, got %q", err.Error())
+		}
+	})
+}
 
 func TestSyncPathExists(t *testing.T) {
 	tests := []struct {
@@ -34,6 +188,35 @@ func TestSyncPathExists(t *testing.T) {
 				t.Errorf("syncPathExists(%q) = %v, want %v", tt.path, result, tt.expected)
 			}
 		})
+	}
+}
+
+// TestNotReadyTeams verifies the all-teams usability gate: only "synced" and
+// "skipped" (already up to date) count as usable; "cloning" and "error" must be
+// reported so `ox sync --all-teams` fails instead of printing blanket success
+// while a team context is missing or still cloning.
+func TestNotReadyTeams(t *testing.T) {
+	results := []daemon.TeamSyncResult{
+		{TeamID: "a", TeamName: "A", Status: "synced"},
+		{TeamID: "b", TeamName: "B", Status: "skipped"},
+		{TeamID: "c", TeamName: "C", Status: "cloning"},
+		{TeamID: "d", TeamName: "D", Status: "error", Error: "pull failed"},
+	}
+
+	got := notReadyTeams(results)
+	want := []string{"C (cloning)", "D (error)"}
+	if len(got) != len(want) {
+		t.Fatalf("notReadyTeams = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("notReadyTeams[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// all usable → empty
+	if r := notReadyTeams([]daemon.TeamSyncResult{{Status: "synced"}, {Status: "skipped"}}); len(r) != 0 {
+		t.Errorf("expected no not-ready teams, got %v", r)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1487,7 +1487,7 @@ func (s *daemonServiceImpl) SyncWithProgress(progress *ProgressWriter) error {
 	return s.d.scheduler.SyncWithProgress(progress)
 }
 
-func (s *daemonServiceImpl) TeamSync(progress *ProgressWriter) error {
+func (s *daemonServiceImpl) TeamSync(progress *ProgressWriter) ([]TeamSyncResult, error) {
 	return s.d.scheduler.TeamSync(progress)
 }
 

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -287,6 +287,19 @@ type CheckoutResult struct {
 	Cloned        bool   `json:"cloned"`         // true if we performed a clone
 }
 
+// TeamSyncResult is the per-team outcome of a team-context sync, returned as the
+// final IPC response payload of a TeamSync request. The CLI uses it to report
+// accurate per-team status (synced/skipped/error) and metadata (team_name, path)
+// instead of inferring "synced" from a bare success/error of the IPC call.
+type TeamSyncResult struct {
+	TeamID   string `json:"team_id"`
+	TeamName string `json:"team_name,omitempty"`
+	TeamSlug string `json:"team_slug,omitempty"` // kebab-case selector users may pass to --team
+	Path     string `json:"path,omitempty"`
+	Status   string `json:"status"` // "synced", "skipped", "cloning", "error"
+	Error    string `json:"error,omitempty"`
+}
+
 // CheckoutProgress is sent during long-running checkout operations.
 type CheckoutProgress struct {
 	Stage   string `json:"stage"`             // "connecting", "cloning", "verifying"
@@ -662,7 +675,7 @@ type DaemonService interface {
 	// sync operations
 	Sync() error
 	SyncWithProgress(progress *ProgressWriter) error
-	TeamSync(progress *ProgressWriter) error
+	TeamSync(progress *ProgressWriter) ([]TeamSyncResult, error)
 	SyncHistory() []SyncEvent
 
 	// status / query operations
@@ -705,7 +718,7 @@ type CallbackService struct {
 
 	onSync              func() error
 	onSyncWithProgress  func(progress *ProgressWriter) error
-	onTeamSync          func(progress *ProgressWriter) error
+	onTeamSync          func(progress *ProgressWriter) ([]TeamSyncResult, error)
 	onStop              func()
 	onStatus            func() *StatusData
 	onActivity          func()
@@ -753,14 +766,14 @@ func (c *CallbackService) SyncWithProgress(progress *ProgressWriter) error {
 	return nil
 }
 
-func (c *CallbackService) TeamSync(progress *ProgressWriter) error {
+func (c *CallbackService) TeamSync(progress *ProgressWriter) ([]TeamSyncResult, error) {
 	c.mu.Lock()
 	fn := c.onTeamSync
 	c.mu.Unlock()
 	if fn != nil {
 		return fn(progress)
 	}
-	return nil
+	return nil, nil
 }
 
 func (c *CallbackService) SyncHistory() []SyncEvent {
@@ -1223,7 +1236,7 @@ func (s *Server) SetSyncHandler(cb func(progress *ProgressWriter) error) {
 }
 
 // SetTeamSyncHandler sets the team context sync handler with progress support.
-func (s *Server) SetTeamSyncHandler(cb func(progress *ProgressWriter) error) {
+func (s *Server) SetTeamSyncHandler(cb func(progress *ProgressWriter) ([]TeamSyncResult, error)) {
 	svc := s.mustCallbackService("SetTeamSyncHandler")
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
@@ -2021,10 +2034,15 @@ func (c *Client) SyncWithProgress(onProgress ProgressCallback) error {
 // The onProgress callback is called for each progress update (may be nil).
 // Uses an idle timeout: the deadline resets on each progress message, so the
 // connection stays alive as long as the daemon is making progress.
-func (c *Client) TeamSyncWithProgress(onProgress ProgressCallback) error {
+//
+// It returns the per-team results carried in the final IPC response so callers
+// can report accurate per-team status and metadata. The results are returned
+// even when err is non-nil (the daemon reports a non-nil error when any team
+// failed to sync), so callers can still surface partial outcomes.
+func (c *Client) TeamSyncWithProgress(onProgress ProgressCallback) ([]TeamSyncResult, error) {
 	conn, err := c.Connect()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer conn.Close()
 
@@ -2044,7 +2062,7 @@ func (c *Client) TeamSyncWithProgress(onProgress ProgressCallback) error {
 	data, _ := json.Marshal(msg)
 	data = append(data, '\n')
 	if _, err := conn.Write(data); err != nil {
-		return fmt.Errorf("write: %w", err)
+		return nil, fmt.Errorf("write: %w", err)
 	}
 
 	// read responses until we get a final one (no progress field)
@@ -2052,12 +2070,12 @@ func (c *Client) TeamSyncWithProgress(onProgress ProgressCallback) error {
 	for {
 		line, err := reader.ReadBytes('\n')
 		if err != nil {
-			return fmt.Errorf("read: %w", err)
+			return nil, fmt.Errorf("read: %w", err)
 		}
 
 		var resp ProgressResponse
 		if err := json.Unmarshal(line, &resp); err != nil {
-			return fmt.Errorf("unmarshal response: %w", err)
+			return nil, fmt.Errorf("unmarshal response: %w", err)
 		}
 
 		// check for progress update
@@ -2069,11 +2087,24 @@ func (c *Client) TeamSyncWithProgress(onProgress ProgressCallback) error {
 			continue // keep reading
 		}
 
-		// final response
-		if !resp.Success {
-			return errors.New(resp.Error)
+		// final response — parse per-team results (present on both success and
+		// partial-failure responses) before deciding the overall error.
+		//
+		// nil-vs-empty contract: a current daemon always sends a `data` array
+		// (possibly `[]`), so results is non-nil here. A legacy pre-change daemon
+		// sends no `data` field, leaving results nil. Callers use that distinction
+		// to tell "team genuinely not found" (non-nil, no match) apart from "old
+		// daemon, status unknown" (nil).
+		var results []TeamSyncResult
+		if len(resp.Data) > 0 {
+			if uErr := json.Unmarshal(resp.Data, &results); uErr != nil {
+				return nil, fmt.Errorf("unmarshal team sync results: %w", uErr)
+			}
 		}
-		return nil
+		if !resp.Success {
+			return results, errors.New(resp.Error)
+		}
+		return results, nil
 	}
 }
 

--- a/internal/daemon/ipc_handlers.go
+++ b/internal/daemon/ipc_handlers.go
@@ -109,11 +109,26 @@ func handleTeamSync(s *Server, _ Message, conn net.Conn) HandlerResult {
 	}
 
 	pw := &ProgressWriter{conn: conn}
-	var resp Response
-	if err := s.service.TeamSync(pw); err != nil {
-		resp = Response{Success: false, Error: err.Error()}
-	} else {
-		resp = Response{Success: true}
+	results, err := s.service.TeamSync(pw)
+
+	// On SUCCESS, carry a non-nil results array so the wire value is `[]`, never
+	// `null` — this lets a new CLI tell a current daemon (sends a `data` array,
+	// possibly empty) apart from a legacy pre-change daemon (sends no usable data),
+	// distinguishing "team genuinely not found" from "old daemon, can't tell".
+	//
+	// On FAILURE we must NOT coerce: a setup failure (e.g. unreadable config)
+	// produces nil results, and coercing to `[]` would let the CLI's
+	// usable-teams check pass and report blanket success despite the error. Leave
+	// results nil so the error is honored.
+	if err == nil && results == nil {
+		results = []TeamSyncResult{}
+	}
+	resp := Response{Success: err == nil}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	if data, mErr := json.Marshal(results); mErr == nil {
+		resp.Data = data
 	}
 	return HandlerResult{Response: &resp}
 }

--- a/internal/daemon/ipc_sync_test.go
+++ b/internal/daemon/ipc_sync_test.go
@@ -3,8 +3,12 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -317,11 +321,11 @@ func TestSyncWithProgress_IdleTimeoutExpiresWithoutProgress(t *testing.T) {
 func TestServer_SetTeamSyncHandler(t *testing.T) {
 	s := NewServer(nil)
 
-	s.SetTeamSyncHandler(func(progress *ProgressWriter) error {
+	s.SetTeamSyncHandler(func(progress *ProgressWriter) ([]TeamSyncResult, error) {
 		if progress != nil {
 			_ = progress.WriteStage("syncing", "Syncing teams...")
 		}
-		return nil
+		return nil, nil
 	})
 
 	s.svc.mu.Lock()
@@ -344,8 +348,13 @@ func TestServerClient_TeamSyncWithProgress_Integration(t *testing.T) {
 		func() *StatusData { return &StatusData{Running: true} },
 	)
 
-	// set team sync handler with progress
-	server.SetTeamSyncHandler(func(progress *ProgressWriter) error {
+	// set team sync handler with progress; it also returns per-team results,
+	// which the client must surface (the fix for "synced" with no metadata).
+	wantResults := []TeamSyncResult{
+		{TeamID: "team-backend", TeamName: "Backend", Path: "/tmp/backend", Status: "synced"},
+		{TeamID: "team-frontend", TeamName: "Frontend", Path: "/tmp/frontend", Status: "synced"},
+	}
+	server.SetTeamSyncHandler(func(progress *ProgressWriter) ([]TeamSyncResult, error) {
 		if progress != nil {
 			_ = progress.WriteStage("starting", "Syncing 2 team context(s)...")
 			_ = progress.WriteStage("syncing", "Syncing team: Backend")
@@ -354,7 +363,7 @@ func TestServerClient_TeamSyncWithProgress_Integration(t *testing.T) {
 			_ = progress.WriteStage("synced", "Team Frontend synced")
 			_ = progress.WriteStage("complete", "Synced 2, skipped 0 team context(s)")
 		}
-		return nil
+		return wantResults, nil
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -372,7 +381,7 @@ func TestServerClient_TeamSyncWithProgress_Integration(t *testing.T) {
 	}
 
 	progressUpdates := []string{}
-	err := client.TeamSyncWithProgress(func(stage string, percent *int, message string) {
+	gotResults, err := client.TeamSyncWithProgress(func(stage string, percent *int, message string) {
 		progressUpdates = append(progressUpdates, stage)
 	})
 
@@ -387,8 +396,171 @@ func TestServerClient_TeamSyncWithProgress_Integration(t *testing.T) {
 	assert.Equal(t, "synced", progressUpdates[4])
 	assert.Equal(t, "complete", progressUpdates[5])
 
+	// verify per-team results round-trip through the final IPC response so the
+	// CLI can report team_name/path/status (regression: these were blank and
+	// status was inferred as "synced" from the bare IPC success).
+	assert.Equal(t, wantResults, gotResults)
+
 	cancel()
 	<-serverDone // wait for server to fully shut down and clean up socket
+}
+
+// TestServerClient_TeamSync_EndToEnd_PopulatesMetadata wires a REAL SyncScheduler
+// (not a stub) into the IPC server and verifies that team_name and path flow all
+// the way from the workspace registry → doTeamSync → IPC → client. This is the
+// full-chain proof for the reported bug ("team_name and path fields not
+// populated") — the earlier tests cover the daemon and the wire separately, this
+// covers them together.
+func TestServerClient_TeamSync_EndToEnd_PopulatesMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_RUNTIME_DIR", "/tmp")
+
+	isolateCredentials(t)
+
+	// a real (syncable) team context repo, configured with a name + path.
+	teamDir := t.TempDir()
+	setupGitRepo(t, teamDir)
+	fetchHead := filepath.Join(teamDir, ".git", "FETCH_HEAD")
+	oldTime := time.Now().Add(-1 * time.Hour)
+	_ = os.Chtimes(fetchHead, oldTime, oldTime)
+
+	projectDir := setupProjectWithConfig(t, fmt.Sprintf(`
+[[team_contexts]]
+team_id = "team_e2e"
+team_name = "E2E Team"
+path = %q
+`, teamDir))
+
+	scheduler := newTestScheduler(projectDir)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	server := NewServer(logger)
+	server.SetHandlers(
+		func() error { return nil },
+		func() {},
+		func() *StatusData { return &StatusData{Running: true} },
+	)
+	// wire the REAL scheduler — this is the production handler path.
+	server.SetTeamSyncHandler(scheduler.TeamSync)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serverDone := make(chan struct{})
+	go func() {
+		server.Start(ctx)
+		close(serverDone)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	client := &Client{socketPath: SocketPath(), timeout: 10 * time.Second}
+
+	results, err := client.TeamSyncWithProgress(nil)
+	require.NoError(t, err)
+
+	var match *TeamSyncResult
+	for i := range results {
+		if results[i].TeamID == "team_e2e" {
+			match = &results[i]
+			break
+		}
+	}
+	require.NotNil(t, match, "requested team must appear in results")
+	assert.Equal(t, "E2E Team", match.TeamName, "team_name must be populated end-to-end")
+	assert.Equal(t, teamDir, match.Path, "path must be populated end-to-end")
+	assert.Equal(t, "synced", match.Status)
+
+	cancel()
+	<-serverDone
+}
+
+// TestServerClient_TeamSyncWithProgress_EmptyResults verifies that a current
+// daemon which synced no teams (e.g. a repo with no team contexts configured)
+// round-trips as a NON-NIL empty slice, not nil. The non-nil/nil distinction is
+// load-bearing: the CLI treats non-nil-empty as "current daemon, team genuinely
+// not found" (fatal) and nil as "legacy daemon, status unknown" (non-fatal). The
+// handler marshals a non-nil slice so the wire value is `[]`, never `null`.
+func TestServerClient_TeamSyncWithProgress_EmptyResults(t *testing.T) {
+	tmpDir := "/tmp"
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	server := NewServer(logger)
+
+	server.SetHandlers(
+		func() error { return nil },
+		func() {},
+		func() *StatusData { return &StatusData{Running: true} },
+	)
+	// handler succeeds but returns no per-team results
+	server.SetTeamSyncHandler(func(progress *ProgressWriter) ([]TeamSyncResult, error) {
+		return nil, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serverDone := make(chan struct{})
+	go func() {
+		server.Start(ctx)
+		close(serverDone)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	client := &Client{socketPath: SocketPath(), timeout: 5 * time.Second}
+
+	results, err := client.TeamSyncWithProgress(nil)
+	require.NoError(t, err, "success with no results must not surface as an error")
+	assert.Empty(t, results, "no per-team results expected")
+	assert.NotNil(t, results, "current daemon must send a non-nil array (`[]`), not nil, so the CLI can tell it apart from a legacy daemon")
+
+	cancel()
+	<-serverDone
+}
+
+// TestServerClient_TeamSyncWithProgress_SetupFailure verifies that a setup
+// failure (TeamSync returns nil results + an error) surfaces to the client as a
+// real error with NIL results — the handler must NOT coerce nil to `[]` on the
+// error path, or the CLI's usable-teams check would pass and report blanket
+// success despite the failure (regression: malformed config hidden behind a
+// successful-looking all-teams sync).
+func TestServerClient_TeamSyncWithProgress_SetupFailure(t *testing.T) {
+	tmpDir := "/tmp"
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	server := NewServer(logger)
+
+	server.SetHandlers(
+		func() error { return nil },
+		func() {},
+		func() *StatusData { return &StatusData{Running: true} },
+	)
+	server.SetTeamSyncHandler(func(progress *ProgressWriter) ([]TeamSyncResult, error) {
+		return nil, errors.New("load workspace registry: malformed config")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serverDone := make(chan struct{})
+	go func() {
+		server.Start(ctx)
+		close(serverDone)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	client := &Client{socketPath: SocketPath(), timeout: 5 * time.Second}
+
+	results, err := client.TeamSyncWithProgress(nil)
+	require.Error(t, err, "setup failure must surface as an error")
+	assert.Contains(t, err.Error(), "malformed config")
+	assert.Nil(t, results, "setup failure must leave results nil (not coerced to []), so the CLI can't mistake it for success")
+
+	cancel()
+	<-serverDone
 }
 
 // Test team sync when handler not set
@@ -421,7 +593,7 @@ func TestServerClient_TeamSyncWithProgress_NoHandler(t *testing.T) {
 		timeout:    5 * time.Second,
 	}
 
-	err := client.TeamSyncWithProgress(nil)
+	_, err := client.TeamSyncWithProgress(nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "team sync handler not set")
 

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -94,6 +94,21 @@ type ManagedRepoPullOpts struct {
 	Logger *slog.Logger
 }
 
+// Skip reasons reported in ManagedRepoPullResult.SkipReason. Defined as
+// constants so consumers can branch on them without fragile string matching.
+const (
+	// skipReasonRebaseInProgress: the working tree is mid-rebase — UNSAFE to
+	// treat as usable (partial/inconsistent state).
+	skipReasonRebaseInProgress = "rebase in progress"
+	// skipReasonLockFilesPresent: a live git process holds lock files (typically
+	// another daemon syncing the same shared context). On-disk files stay
+	// consistent, so the context remains usable.
+	skipReasonLockFilesPresent = "lock files present"
+	// skipReasonRemoteUnchanged / skipReasonRecentlyFetched: already current.
+	skipReasonRemoteUnchanged = "remote unchanged"
+	skipReasonRecentlyFetched = "recently fetched"
+)
+
 // ManagedRepoPullResult describes what happened during pullManagedRepo.
 type ManagedRepoPullResult struct {
 	// Skipped is true if the pull was skipped (repo up-to-date, in rebase, locked, etc).
@@ -158,7 +173,7 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 	// Rebase-in-progress: skip — will resolve on its own or needs manual fix
 	if gitutil.IsRebaseInProgress(path) {
 		logger.Debug("repo in rebase state, skipping pull", "path", path)
-		return ManagedRepoPullResult{Skipped: true, SkipReason: "rebase in progress"}
+		return ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRebaseInProgress}
 	}
 
 	// Lock files: auto-remove stale ones, skip and report if still present
@@ -178,7 +193,7 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 				"path", path, "locks", strings.Join(remaining, ", "))
 			return ManagedRepoPullResult{
 				Skipped:    true,
-				SkipReason: "lock files present",
+				SkipReason: skipReasonLockFilesPresent,
 				Issue: &DaemonIssue{
 					Type:     IssueTypeGitLock,
 					Severity: SeverityWarning,
@@ -196,7 +211,7 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 
 	// ls-remote SHA check: cheapest way to skip when nothing changed
 	if s.remoteRefCheck(ctx, path) {
-		return ManagedRepoPullResult{Skipped: true, SkipReason: "remote unchanged"}
+		return ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRemoteUnchanged}
 	}
 
 	// FETCH_HEAD mtime dedup (secondary: cross-daemon coordination)
@@ -208,7 +223,7 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 		threshold := max(opts.SyncInterval/2, minAge)
 		if age < threshold {
 			logger.Debug("repo recently fetched, skipping", "path", path, "age", age)
-			return ManagedRepoPullResult{Skipped: true, SkipReason: "recently fetched"}
+			return ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRecentlyFetched}
 		}
 	}
 

--- a/internal/daemon/sync_pull_test.go
+++ b/internal/daemon/sync_pull_test.go
@@ -186,9 +186,11 @@ func TestSyncScheduler_PullTeamContext_NotGitRepo(t *testing.T) {
 
 	scheduler := NewSyncScheduler(cfg, logger)
 
-	// pull should handle gracefully: detect invalid repo, move aside for re-clone
+	// pull should handle gracefully: detect invalid repo, move aside for re-clone.
+	// It returns an error so callers report the team context as not-usable (the
+	// path is gone until the next cycle re-clones it) rather than "synced".
 	err := scheduler.pullTeamContext(context.Background(), tcPath)
-	assert.NoError(t, err)
+	assert.Error(t, err, "moving a corrupt repo aside must surface as not-usable, not success")
 	// original path should be gone (moved to .bak)
 	assert.NoDirExists(t, tcPath)
 }

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -37,16 +37,43 @@ func (s *SyncScheduler) pullTeamContexts(ctx context.Context) {
 	// the scheduler for minutes (the caller ctx has no deadline)
 	teamCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
-	s.doTeamSync(teamCtx, nil, false)
+	// background scheduler path: per-team outcomes and setup errors are
+	// recorded on the workspace registry / logged inside doTeamSync, so the
+	// return values aren't needed here.
+	_, _ = s.doTeamSync(teamCtx, nil, false)
 }
 
 // TeamSync performs an on-demand sync of all team contexts with progress updates.
-func (s *SyncScheduler) TeamSync(progress *ProgressWriter) error {
+//
+// It returns the per-team results and a non-nil error if any team failed to
+// sync, so the IPC caller (and ultimately `ox sync`) can report accurate
+// per-team status instead of inferring "synced" from the bare success of the
+// IPC round-trip.
+func (s *SyncScheduler) TeamSync(progress *ProgressWriter) ([]TeamSyncResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	s.doTeamSync(ctx, progress, true)
-	return nil
+	results, err := s.doTeamSync(ctx, progress, true)
+	if err != nil {
+		// setup failure (e.g. config load) — propagate as-is; there are no
+		// per-team results to aggregate.
+		return results, err
+	}
+
+	var failed []string
+	for _, r := range results {
+		if r.Status == "error" {
+			name := r.TeamName
+			if name == "" {
+				name = r.TeamID
+			}
+			failed = append(failed, fmt.Sprintf("%s: %s", name, r.Error))
+		}
+	}
+	if len(failed) > 0 {
+		return results, fmt.Errorf("team sync failed: %s", strings.Join(failed, "; "))
+	}
+	return results, nil
 }
 
 // doTeamSync syncs all team context repos with optional progress updates.
@@ -55,7 +82,13 @@ func (s *SyncScheduler) TeamSync(progress *ProgressWriter) error {
 // Auto-clone behavior: If a team context doesn't exist locally but has a clone URL,
 // spawns a background goroutine to clone it. This doesn't block the sync loop.
 // Note: Ledger auto-clone is handled separately in doPull() on the ledger sync ticker.
-func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter, forceSync bool) {
+// The returned error is reserved for *setup* failures that prevent the sync
+// from running at all (e.g. a config that can't be loaded) — these are real
+// failures that must not be reported as a successful no-op. "No project root"
+// and "no team contexts configured" are legitimate nothing-to-do states and
+// return (nil, nil). Per-team sync failures are NOT returned here; they are
+// carried in the result entries' Status/Error and aggregated by the caller.
+func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter, forceSync bool) ([]TeamSyncResult, error) {
 	ctx, span := perf.Start(ctx, "daemon:do_team_sync")
 	defer span.End()
 
@@ -70,16 +103,19 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 		if progress != nil {
 			_ = progress.WriteStage("skipped", "No project root configured")
 		}
-		return
+		return nil, nil
 	}
 
-	// reload workspace state from config (uses cache if fresh)
+	// reload workspace state from config (uses cache if fresh). A failure here
+	// is a genuine setup error — propagate it so callers don't report a
+	// successful no-op while the real config read/parse/permission error is
+	// silently swallowed.
 	if err := s.workspaceRegistry.LoadFromConfig(); err != nil {
 		s.logger.Warn("failed to load workspace registry for team context sync", "error", err)
 		if progress != nil {
 			_ = progress.WriteMessage(fmt.Sprintf("Failed to load config: %v", err))
 		}
-		return
+		return nil, fmt.Errorf("load workspace registry: %w", err)
 	}
 
 	// get team contexts from registry
@@ -89,7 +125,21 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 		if progress != nil {
 			_ = progress.WriteStage("skipped", "No team contexts configured")
 		}
-		return
+		return nil, nil
+	}
+
+	// per-team outcomes accumulated across the partition + sync phases below,
+	// returned to the IPC caller so the CLI can report accurate status.
+	outcomes := make([]TeamSyncResult, 0, len(teamContexts))
+	addResult := func(ws WorkspaceState, status, errMsg string) {
+		outcomes = append(outcomes, TeamSyncResult{
+			TeamID:   ws.TeamID,
+			TeamName: ws.TeamName,
+			TeamSlug: ws.TeamSlug,
+			Path:     ws.Path,
+			Status:   status,
+			Error:    errMsg,
+		})
 	}
 
 	s.logger.Debug("syncing team contexts", "count", len(teamContexts))
@@ -108,6 +158,7 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 	for _, ws := range teamContexts {
 		if ws.Path == "" {
 			s.workspaceRegistry.SetWorkspaceError(ws.ID, "no path configured")
+			addResult(ws, "error", "no path configured")
 			skippedCount++
 			continue
 		}
@@ -118,6 +169,10 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 					attempts, nextRetry := s.workspaceRegistry.GetCloneRetryInfo(ws.ID)
 					s.logger.Debug("team context clone in backoff, skipping",
 						"team", ws.TeamName, "attempts", attempts, "next_retry", nextRetry)
+					// clone-backoff is a deferred *failure*, not a benign skip: the
+					// repo isn't present and the last clone attempt failed. Report it
+					// as an error so callers don't treat the team as usable.
+					addResult(ws, "error", fmt.Sprintf("clone in backoff after %d failed attempt(s)", attempts))
 					skippedCount++
 					continue
 				}
@@ -131,18 +186,21 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 					go s.cloneInBackground(ws.CloneURL, ws.Path, "team-context", ws.ID) //nolint:gosec // G118 - intentionally uses background context; goroutine outlives request scope
 					cloningCount++
 				}
+				addResult(ws, "cloning", "")
 			} else {
 				s.workspaceRegistry.SetWorkspaceError(ws.ID, "path does not exist and no clone URL available")
 				s.logger.Debug("team context path not found and no clone URL", "team", ws.TeamName, "path", ws.Path)
 				if progress != nil {
 					_ = progress.WriteStage("skipped", fmt.Sprintf("Team %s: not cloned, no URL", ws.TeamName))
 				}
+				addResult(ws, "error", "path does not exist and no clone URL available")
 				skippedCount++
 			}
 			continue
 		}
 
 		if !s.shouldSyncOrBypass(ws.ID, forceSync) {
+			addResult(ws, "skipped", "recently synced")
 			skippedCount++
 			continue
 		}
@@ -192,6 +250,7 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 			if progress != nil {
 				_ = progress.WriteStage("error", fmt.Sprintf("Team %s: %v", r.ws.TeamName, r.err))
 			}
+			addResult(r.ws, "error", r.err.Error())
 			continue
 		}
 
@@ -279,6 +338,7 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 		if progress != nil {
 			_ = progress.WriteStage("synced", fmt.Sprintf("Team %s synced", r.ws.TeamName))
 		}
+		addResult(r.ws, "synced", "")
 	}
 
 	if progress != nil {
@@ -308,6 +368,8 @@ func (s *SyncScheduler) doTeamSync(ctx context.Context, progress *ProgressWriter
 			s.whisperRegistry.CloseTeamStore(openTeamID)
 		}
 	}
+
+	return outcomes, nil
 }
 
 // pullTeamContext performs a git pull on a single team context repo.
@@ -355,7 +417,11 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 		Logger:             s.logger,
 	})
 
-	// corrupt repo: move aside so background clone picks it up next cycle
+	// corrupt repo: move aside so background clone picks it up next cycle.
+	// The local path is now GONE, so this sync did not produce usable context —
+	// return an error (not nil) so callers report it as failed rather than
+	// "synced". The next sync cycle re-clones it (anti-entropy); until then the
+	// team context is genuinely not present.
 	if result.CorruptRepo {
 		backupPath := fmt.Sprintf("%s.bak.%d", path, time.Now().Unix())
 		s.logger.Warn("team context repo corrupt, moving aside for re-clone",
@@ -364,7 +430,7 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 			s.logger.Error("failed to move corrupt team context aside", "error", err)
 			return fmt.Errorf("corrupt team context at %s but rename failed: %w", path, err)
 		}
-		return nil
+		return fmt.Errorf("team context repo was corrupt and moved aside for re-clone; re-run after the daemon re-clones it (path: %s)", path)
 	}
 
 	// handle skip
@@ -373,6 +439,16 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 			s.issues.SetIssue(*result.Issue)
 		} else if s.issues != nil {
 			s.issues.ClearIssue(IssueTypeGitLock, repoName)
+		}
+		// A rebase in progress leaves the working tree in a partial, possibly
+		// inconsistent state — the team context is NOT safely usable, so return an
+		// error rather than letting the caller report it as "synced". The other
+		// skip reasons are benign and the on-disk context is usable: "remote
+		// unchanged"/"recently fetched" mean already current, and "lock files
+		// present" means another live daemon is actively syncing this shared
+		// context (ox's multi-daemon dedup) while the files stay consistent.
+		if result.SkipReason == skipReasonRebaseInProgress {
+			return fmt.Errorf("team context not synced: rebase in progress (resolve the rebase, then re-run)")
 		}
 		return nil
 	}

--- a/internal/daemon/sync_team_discovery_test.go
+++ b/internal/daemon/sync_team_discovery_test.go
@@ -309,6 +309,185 @@ path = %q
 	assert.GreaterOrEqual(t, snap.TeamSyncCount, int64(2), "at least two team syncs should succeed")
 }
 
+// --- Test: on-demand TeamSync returns per-team results and propagates failure ---
+
+// TestTeamSync_ReturnsPerTeamResultsAndPropagatesError is the regression test for
+// the bug where `ox sync --team` reported status "synced" (with blank team_name
+// and path) regardless of the real outcome, because the IPC call only surfaced a
+// bare success/error. TeamSync must now return per-team results carrying
+// team_name/path/status, and a non-nil error when any team failed to sync.
+//
+// Failure prevented: a sync that didn't actually complete is reported as
+// "synced" to the CLI / e2e tests, masking missing team context state.
+func TestTeamSync_ReturnsPerTeamResultsAndPropagatesError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	isolateCredentials(t)
+
+	// one healthy team (real repo with a bare origin) and one that fails:
+	// its path exists but is not a git repo (simulates a wedged/failed clone).
+	goodDir := t.TempDir()
+	setupGitRepo(t, goodDir)
+	badDir := t.TempDir() // exists, but not a git repo
+
+	projectDir := setupProjectWithConfig(t, fmt.Sprintf(`
+[[team_contexts]]
+team_id = "team_good"
+team_name = "Good Team"
+path = %q
+
+[[team_contexts]]
+team_id = "team_bad"
+team_name = "Bad Team"
+path = %q
+`, goodDir, badDir))
+
+	scheduler := newTestScheduler(projectDir)
+
+	// age FETCH_HEAD so the good team's pull isn't deduped/skipped
+	fetchHead := filepath.Join(goodDir, ".git", "FETCH_HEAD")
+	oldTime := time.Now().Add(-1 * time.Hour)
+	_ = os.Chtimes(fetchHead, oldTime, oldTime)
+
+	results, err := scheduler.TeamSync(nil)
+
+	// the bad team failed, so TeamSync must report a non-nil error rather than
+	// swallowing it and implying everything synced.
+	require.Error(t, err, "TeamSync must propagate a failure when any team errors")
+	assert.Contains(t, err.Error(), "Bad Team")
+
+	// results must cover both teams with populated metadata (team_name + path),
+	// not blank fields.
+	byID := make(map[string]TeamSyncResult, len(results))
+	for _, r := range results {
+		byID[r.TeamID] = r
+	}
+	require.Len(t, results, 2, "should report a result for every configured team")
+
+	good := byID["team_good"]
+	assert.Equal(t, "synced", good.Status, "healthy team should be synced")
+	assert.Equal(t, "Good Team", good.TeamName)
+	assert.Equal(t, goodDir, good.Path)
+	assert.Empty(t, good.Error)
+
+	bad := byID["team_bad"]
+	assert.Equal(t, "error", bad.Status, "failing team should be reported as error, not synced")
+	assert.Equal(t, "Bad Team", bad.TeamName)
+	assert.Equal(t, badDir, bad.Path)
+	assert.NotEmpty(t, bad.Error)
+}
+
+// TestTeamSync_PropagatesSetupFailure verifies that a setup failure which
+// prevents the sync from running at all (here: an unparseable config.local.toml
+// that makes LoadFromConfig fail) is propagated as an error, instead of being
+// swallowed and reported as a successful no-op.
+//
+// Failure prevented: a corrupt/unreadable config silently yields IPC success
+// with zero results, so `ox sync --json` reports success with no teams while
+// the real config read/parse/permission error is hidden.
+func TestTeamSync_PropagatesSetupFailure(t *testing.T) {
+	isolateCredentials(t)
+
+	// malformed TOML: unterminated string -> toml.Unmarshal returns an error,
+	// so WorkspaceRegistry.LoadFromConfig fails.
+	projectDir := setupProjectWithConfig(t, "this is = not valid = toml [[[\n")
+
+	scheduler := newTestScheduler(projectDir)
+
+	results, err := scheduler.TeamSync(nil)
+
+	require.Error(t, err, "setup failure must propagate, not be reported as success")
+	assert.Contains(t, err.Error(), "load workspace registry")
+	assert.Empty(t, results, "no per-team results when setup fails before the sync runs")
+}
+
+// TestTeamSync_CorruptRepoReportedAsError verifies that when a team context repo
+// is corrupt and the daemon moves it aside for re-clone, the sync is reported as
+// an error rather than "synced". The local path is gone after the move, so
+// reporting success would let targeted sync / distill proceed against a team
+// context that is no longer present.
+func TestTeamSync_CorruptRepoReportedAsError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+
+	isolateCredentials(t)
+
+	// a dir with a .git/HEAD file (so it reads as "present" and is pulled, not
+	// cloned) but invalid HEAD content (so the pull detects corruption and moves
+	// it aside). This exercises the corrupt-repo move-aside path specifically.
+	corruptDir := t.TempDir()
+	gitDir := filepath.Join(corruptDir, ".git")
+	require.NoError(t, os.MkdirAll(gitDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("not a valid ref\n"), 0644))
+
+	projectDir := setupProjectWithConfig(t, fmt.Sprintf(`
+[[team_contexts]]
+team_id = "team_corrupt"
+team_name = "Corrupt Team"
+path = %q
+`, corruptDir))
+
+	scheduler := newTestScheduler(projectDir)
+
+	results, err := scheduler.TeamSync(nil)
+
+	require.Error(t, err, "a corrupt team context must not be reported as a successful sync")
+	require.Len(t, results, 1)
+	assert.Equal(t, "team_corrupt", results[0].TeamID)
+	assert.Equal(t, "error", results[0].Status, "corrupt/moved-aside team must be error, not synced")
+
+	// prove it went through the corrupt move-aside path (the fix), not some other
+	// error path: the original dir is gone and a .bak backup exists.
+	backups, _ := filepath.Glob(corruptDir + ".bak.*")
+	assert.Len(t, backups, 1, "corrupt repo should have been moved aside for re-clone")
+}
+
+// TestTeamSync_RebaseInProgressReportedAsError verifies that a team context whose
+// repo is mid-rebase is reported as an error, not "synced". A rebase leaves the
+// working tree in a partial/inconsistent state, so the pull is skipped — but the
+// context is not safely usable and must not be claimed as synced.
+func TestTeamSync_RebaseInProgressReportedAsError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+
+	isolateCredentials(t)
+
+	// a valid git repo (so it isn't flagged corrupt) that is mid-rebase: the
+	// presence of .git/rebase-merge makes IsRebaseInProgress() true.
+	teamDir := t.TempDir()
+	setupGitRepo(t, teamDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(teamDir, ".git", "rebase-merge"), 0755))
+
+	projectDir := setupProjectWithConfig(t, fmt.Sprintf(`
+[[team_contexts]]
+team_id = "team_rebasing"
+team_name = "Rebasing Team"
+path = %q
+`, teamDir))
+
+	scheduler := newTestScheduler(projectDir)
+
+	results, err := scheduler.TeamSync(nil)
+
+	require.Error(t, err, "a team context mid-rebase must not be reported as a successful sync")
+	require.Len(t, results, 1)
+	assert.Equal(t, "team_rebasing", results[0].TeamID)
+	assert.Equal(t, "error", results[0].Status, "rebase-in-progress team must be error, not synced")
+}
+
 // --- Test: Credentials with non-team-context repos are ignored ---
 
 func TestTeamContextDiscovery_IgnoresNonTeamContextRepos(t *testing.T) {

--- a/internal/daemon/testutil/ipc_methods_fault_test.go
+++ b/internal/daemon/testutil/ipc_methods_fault_test.go
@@ -314,7 +314,7 @@ func TestTeamSyncWithProgress_Healthy(t *testing.T) {
 	defer d.Stop()
 
 	client := daemon.NewClientForCurrentRepoWithTimeout(1 * time.Second)
-	err := client.TeamSyncWithProgress(nil)
+	_, err := client.TeamSyncWithProgress(nil)
 
 	assert.NoError(t, err)
 }
@@ -333,7 +333,7 @@ func TestTeamSyncWithProgress_AllCriticalFaults(t *testing.T) {
 			defer d.Stop()
 
 			client := daemon.NewClientForCurrentRepoWithTimeout(testTimeout)
-			err := client.TeamSyncWithProgress(nil)
+			_, err := client.TeamSyncWithProgress(nil)
 
 			assert.Error(t, err, "TeamSyncWithProgress() should fail with fault: %s", tt.name)
 		})
@@ -553,7 +553,7 @@ func TestAllIPCMethods_AllCriticalFaults(t *testing.T) {
 		{"Doctor", func(c *daemon.Client) error { _, err := c.Doctor(); return err }},
 		{"RequestSync", func(c *daemon.Client) error { return c.RequestSync() }},
 		{"SyncWithProgress", func(c *daemon.Client) error { return c.SyncWithProgress(nil) }},
-		{"TeamSyncWithProgress", func(c *daemon.Client) error { return c.TeamSyncWithProgress(nil) }},
+		{"TeamSyncWithProgress", func(c *daemon.Client) error { _, err := c.TeamSyncWithProgress(nil); return err }},
 		{"Stop", func(c *daemon.Client) error { return c.Stop() }},
 		{"GetUnviewedErrors", func(c *daemon.Client) error { _, err := c.GetUnviewedErrors(); return err }},
 		{"MarkErrorsViewed", func(c *daemon.Client) error { return c.MarkErrorsViewed([]string{"test"}) }},

--- a/internal/daemon/testutil/mock_service.go
+++ b/internal/daemon/testutil/mock_service.go
@@ -22,7 +22,7 @@ type MockService struct {
 	// sync operations
 	SyncFunc             func() error
 	SyncWithProgressFunc func(progress *daemon.ProgressWriter) error
-	TeamSyncFunc         func(progress *daemon.ProgressWriter) error
+	TeamSyncFunc         func(progress *daemon.ProgressWriter) ([]daemon.TeamSyncResult, error)
 	SyncHistoryFunc      func() []daemon.SyncEvent
 
 	// status / query operations
@@ -79,11 +79,11 @@ func (m *MockService) SyncWithProgress(progress *daemon.ProgressWriter) error {
 	return nil
 }
 
-func (m *MockService) TeamSync(progress *daemon.ProgressWriter) error {
+func (m *MockService) TeamSync(progress *daemon.ProgressWriter) ([]daemon.TeamSyncResult, error) {
 	if m.TeamSyncFunc != nil {
 		return m.TeamSyncFunc(progress)
 	}
-	return nil
+	return nil, nil
 }
 
 func (m *MockService) SyncHistory() []daemon.SyncEvent {

--- a/internal/daemon/testutil/mock_service_test.go
+++ b/internal/daemon/testutil/mock_service_test.go
@@ -45,8 +45,8 @@ func TestMockServiceNilFuncsReturnDefaults(t *testing.T) {
 	if err := m.SyncWithProgress(nil); err != nil {
 		t.Errorf("SyncWithProgress() = %v, want nil", err)
 	}
-	if err := m.TeamSync(nil); err != nil {
-		t.Errorf("TeamSync() = %v, want nil", err)
+	if results, err := m.TeamSync(nil); err != nil || results != nil {
+		t.Errorf("TeamSync() = (%v, %v), want (nil, nil)", results, err)
 	}
 
 	// query operations return nil/empty
@@ -272,9 +272,16 @@ func TestMockServiceOverrides(t *testing.T) {
 
 	t.Run("team sync override", func(t *testing.T) {
 		want := errors.New("team sync failed")
-		m.TeamSyncFunc = func(_ *daemon.ProgressWriter) error { return want }
-		if got := m.TeamSync(nil); !errors.Is(got, want) {
-			t.Errorf("TeamSync() = %v, want %v", got, want)
+		wantResults := []daemon.TeamSyncResult{{TeamID: "t1", Status: "error", Error: "boom"}}
+		m.TeamSyncFunc = func(_ *daemon.ProgressWriter) ([]daemon.TeamSyncResult, error) {
+			return wantResults, want
+		}
+		gotResults, got := m.TeamSync(nil)
+		if !errors.Is(got, want) {
+			t.Errorf("TeamSync() err = %v, want %v", got, want)
+		}
+		if len(gotResults) != 1 || gotResults[0].TeamID != "t1" {
+			t.Errorf("TeamSync() results = %v, want %v", gotResults, wantResults)
 		}
 	})
 


### PR DESCRIPTION
## What broke

`ox sync --json --team <id>` reported `status: "synced"` with blank `team_name` and `path`, even when the team context hadn't actually synced (or wasn't usable). The status was inferred purely from the IPC call succeeding — not from any real per-team outcome.

```mermaid
flowchart LR
    CLI["ox sync --team X"] -->|IPC| H[handleTeamSync]
    H --> TS["SyncScheduler.TeamSync"]
    TS --> DTS["doTeamSync (per-team)"]
    DTS -->|"[]TeamSyncResult"| H
    H -->|"final response Data"| CLI
    CLI --> RES["resolveTeamSyncResult\n(match by id/slug/name)"]
    RES --> OUT["JSON: real status + team_name + path"]
```

## Root causes

- **`TeamSync` was effectively fire-and-forget.** `SyncScheduler.TeamSync` ran `doTeamSync` then `return nil` unconditionally; the IPC layer only carried a bare success/error. Per-team failures were swallowed.
- The CLI then set `status:"synced"` whenever the IPC round-trip didn't error, and never had per-team `team_name`/`path` to report.

## What this PR ships

- **Per-team result payload (option 2).** `TeamSync` now returns `[]TeamSyncResult` (`team_id`, `team_name`, `team_slug`, `path`, `status`, `error`), threaded through the `DaemonService` interface, `CallbackService`, handler, and client. The CLI reports the **requested team's real outcome**, with metadata.
- **Setup failures propagate.** A failed `LoadFromConfig` (e.g. malformed config) is returned as an error instead of a silent successful no-op.
- **Honest usability gate.** Command succeeds only when the requested team is locally usable (`synced` / already-up-to-date `skipped`). `cloning`, `error`, `not_found`, `ambiguous` all exit non-zero — for both `--team` and `--all-teams` — so scripts/distill never proceed against missing/stale context.
- **Selector matching.** `--team` accepts ID, slug, or name; an ambiguous slug/name that matches multiple teams is a fatal `ambiguous` error, not a silent first-match.
- **Corrupt / rebase repos.** A corrupt repo moved aside for re-clone, or a repo mid-rebase, is reported as `error` (not `synced`). A live lock (multi-daemon dedup, files consistent) stays usable by design.
- **Version skew (legacy daemon).** A pre-change daemon that returns success with no per-team data is detected and reported with a version-aware, fail-closed message (names the older daemon version; notes it self-restarts on the next heartbeat). No CLI-driven daemon restart.
- **Distill.** Only fails when *this repo's* team context isn't usable; an unrelated secondary team's failure is a warning.

## Notes for the reviewer

- **Data-location / ergonomics (needs Ryan):** this changes how team-context sync status is reported and how `--team` resolves selectors. The `.sageox/teams/primary` symlink is deliberately **out of scope** — it's still created only by `ox doctor`; this PR makes the *status* honest, which was the bug.
- **Same-version dev caveat:** the daemon's version-mismatch self-restart compares semver, so same-version rebuilds (e.g. local `0.x` → `0.x`) won't auto-restart the daemon — `ox daemon restart` is needed during local testing. Across a real release (version bump) the self-heal is automatic.

## Test Plan

- New pure/unit tests: `resolveTeamSyncResult` (id/slug/name match, ambiguous, not_found, legacy/unknown, error), `notReadyTeams`, `legacyDaemonErrorMsg`.
- New IPC tests: results round-trip, empty-results (non-nil `[]`), setup-failure (nil results + error), and a full **end-to-end** test wiring a real `SyncScheduler` through the IPC server proving `team_name`/`path` populate.
- New daemon tests: per-team error propagation, config-load setup-failure, corrupt-repo move-aside → error, rebase-in-progress → error.
- `go build ./...`, `golangci-lint` (project config) clean on changed packages, full `cmd/ox` and `internal/daemon` suites pass.
- 8 rounds of adversarial review (Codex) → final verdict **approve, no material findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for team synchronization operations with better handling of edge cases (corrupted repos, in-progress rebases).
  * Enhanced error messages for daemon/CLI version compatibility issues.

* **Tests**
  * Added comprehensive test coverage for team synchronization result reporting and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->