### PR TITLE
fix(import): honor --json and surface recording id on team doc import

### DIFF
--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -125,6 +125,20 @@ type sidecar struct {
 	CreatedAt string `json:"created_at"`
 }
 
+// importResult is the --json payload for a team document import. recording_id is
+// populated only when the server routes the file to transcription and returns an
+// ID (media files); it can be fed to `ox import --status <id> --watch`.
+type importResult struct {
+	Status      string `json:"status"` // "imported" | "already_imported"
+	Title       string `json:"title,omitempty"`
+	Path        string `json:"path,omitempty"`
+	ID          string `json:"id,omitempty"` // existing doc id on already_imported
+	TeamID      string `json:"team_id,omitempty"`
+	SourceOID   string `json:"source_oid,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+	RecordingID string `json:"recording_id,omitempty"`
+}
+
 func runImport(cmd *cobra.Command, args []string) error {
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 
@@ -222,6 +236,9 @@ func runImport(cmd *cobra.Command, args []string) error {
 	// dedup: skip if this exact content was already imported
 	if !importFlags.force {
 		if existing, found := findExistingDocByOID(docsBaseDir, srcRef.OID); found {
+			if jsonOutput {
+				return emitImportJSON(cmd, importResult{Status: "already_imported", ID: existing})
+			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Already imported (id: %s). Use --force to reimport.\n", existing)
 			return nil
 		}
@@ -357,11 +374,37 @@ func runImport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("commit and push: %w", err)
 	}
 
-	// fire-and-forget cloud notification — uses team_id since imports
-	// target team contexts, not project repos
-	notifyImport(tc.TeamID, ep, meta)
+	// cloud notification — uses team_id since imports target team contexts, not
+	// project repos. Returns a recording ID when the server routes the file to
+	// transcription; failures degrade silently and never fail the import.
+	recordingID := notifyImport(tc.TeamID, ep, meta)
+
+	if jsonOutput {
+		return emitImportJSON(cmd, importResult{
+			Status:      "imported",
+			Title:       title,
+			Path:        relDocDir,
+			TeamID:      tc.TeamID,
+			SourceOID:   srcRef.OID,
+			ContentType: meta.ContentType,
+			RecordingID: recordingID,
+		})
+	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Imported: %s\nPath: %s\n", title, relDocDir)
+	if recordingID != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n  Track progress: ox import --status %s --watch%s\n", recordingID, importContextFlagHint())
+	}
+	return nil
+}
+
+// emitImportJSON writes an importResult as indented JSON to stdout.
+func emitImportJSON(cmd *cobra.Command, result importResult) error {
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal import result: %w", err)
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 	return nil
 }
 
@@ -983,23 +1026,26 @@ func runImportList(cmd *cobra.Command, jsonOutput bool) error {
 	return nil
 }
 
-// notifyImport sends a fire-and-forget notification to the cloud about a new import.
-// Uses team_id since imports target team contexts, not project repos.
-// Failures are logged but never block the import.
-func notifyImport(teamID, ep string, meta docMeta) {
+// notifyImport notifies the cloud about a new import and returns the recording
+// ID the server assigns when it routes the file to transcription (empty for
+// non-media docs or older servers). Uses team_id since imports target team
+// contexts, not project repos. Failures are logged but never block the import.
+func notifyImport(teamID, ep string, meta docMeta) string {
 	if teamID == "" {
 		slog.Debug("skipping import notification, no team_id")
-		return
+		return ""
 	}
 
 	storedToken, err := auth.GetTokenForEndpoint(ep)
 	if err != nil || storedToken == nil || storedToken.AccessToken == "" {
 		slog.Debug("skipping import notification, no auth token", "error", err)
-		return
+		return ""
 	}
 
 	client := api.NewRepoClientWithEndpoint(ep).WithAuthToken(storedToken.AccessToken)
-	if err := client.NotifyImport(teamID, &meta); err != nil {
+	recordingID, err := client.NotifyImport(teamID, &meta)
+	if err != nil {
 		slog.Warn("import cloud notification failed", "error", err)
 	}
+	return recordingID
 }

--- a/cmd/ox/import_coverage_test.go
+++ b/cmd/ox/import_coverage_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetectContentType_EmptyContent(t *testing.T) {
@@ -319,4 +321,51 @@ func TestEnsureMetadataGitattributes_ExistingContentPreserved(t *testing.T) {
 	if !strings.Contains(s, "data/**/metadata.json !filter !diff !merge text") {
 		t.Error("metadata rule was not appended")
 	}
+}
+
+// TestEmitImportJSON_Shape verifies the --json import payload includes the
+// recording ID and omits empty optional fields. Failure prevented: agents
+// parsing import output can't find the recording_id to pass to `--status --watch`.
+func TestEmitImportJSON_Shape(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	err := emitImportJSON(cmd, importResult{
+		Status:      "imported",
+		Title:       "Standup",
+		Path:        "data/docs/2026/06/20/standup",
+		TeamID:      "team_abc",
+		SourceOID:   "sha256:deadbeef",
+		ContentType: "video/mp4",
+		RecordingID: "rec_xyz789",
+	})
+	assert.NoError(t, err)
+
+	var got importResult
+	require.NoError(t, json.Unmarshal([]byte(buf.String()), &got))
+	assert.Equal(t, "imported", got.Status)
+	assert.Equal(t, "rec_xyz789", got.RecordingID)
+	assert.Empty(t, got.ID, "id should be omitted on a fresh import")
+}
+
+// TestEmitImportJSON_AlreadyImported verifies the dedup path emits a structured
+// already_imported result instead of plain text when --json is set.
+func TestEmitImportJSON_AlreadyImported(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	err := emitImportJSON(cmd, importResult{Status: "already_imported", ID: "standup"})
+	assert.NoError(t, err)
+
+	var got importResult
+	require.NoError(t, json.Unmarshal([]byte(buf.String()), &got))
+	assert.Equal(t, "already_imported", got.Status)
+	assert.Equal(t, "standup", got.ID)
+	assert.Empty(t, got.RecordingID)
 }

--- a/cmd/ox/import_video_test.go
+++ b/cmd/ox/import_video_test.go
@@ -430,7 +430,7 @@ func TestNotifyImport_VideoContentType(t *testing.T) {
 		Sidecars:       map[string]sidecar{},
 	}
 
-	err := client.NotifyImport("team_vid_001", &meta)
+	_, err := client.NotifyImport("team_vid_001", &meta)
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), notifyCalled.Load())
 	assert.Equal(t, "video/mp4", receivedMeta.ContentType)

--- a/internal/api/mock_repo_service.go
+++ b/internal/api/mock_repo_service.go
@@ -7,7 +7,7 @@ type MockRepoService struct {
 	RegisterRepoFunc    func(req *RepoInitRequest) (*RepoInitResponse, error)
 	GetDoctorIssuesFunc func(repoID string) (*DoctorResponse, error)
 	NotifyUninstallFunc func(repoID, repoSalt string) error
-	NotifyImportFunc    func(teamID string, metadata any) error
+	NotifyImportFunc    func(teamID string, metadata any) (string, error)
 	MergeRepoFunc       func(repoID string, markers map[string]json.RawMessage) (*MergeRepoResponse, *RedirectInfo, error)
 	EndpointFunc        func() string
 	WithAuthTokenFunc   func(token string) *RepoClient
@@ -37,11 +37,11 @@ func (m *MockRepoService) NotifyUninstall(repoID, repoSalt string) error {
 	return nil
 }
 
-func (m *MockRepoService) NotifyImport(teamID string, metadata any) error {
+func (m *MockRepoService) NotifyImport(teamID string, metadata any) (string, error) {
 	if m.NotifyImportFunc != nil {
 		return m.NotifyImportFunc(teamID, metadata)
 	}
-	return nil
+	return "", nil
 }
 
 func (m *MockRepoService) MergeRepo(repoID string, markers map[string]json.RawMessage) (*MergeRepoResponse, *RedirectInfo, error) {

--- a/internal/api/repo.go
+++ b/internal/api/repo.go
@@ -485,11 +485,16 @@ func (c *RepoClient) MergeRepo(repoID string, markers map[string]json.RawMessage
 // NotifyImport sends a fire-and-forget notification about a new document import.
 // Imports target a team context, so teamID identifies where the document lives.
 // The metadata argument should be JSON-marshalable (typically the docMeta struct).
-// Returns nil on network error, 404, or any non-2xx — never fails the caller's operation.
-func (c *RepoClient) NotifyImport(teamID string, metadata any) error {
+//
+// On 2xx the server may return a recording ID for media files it routes to
+// transcription; that ID is returned so callers can poll `ox import --status`.
+// The endpoint is fire-and-forget — a missing/empty body and network errors are
+// not failures: recordingID is "" and err is nil. Only a non-404 4xx/5xx is an
+// error, and even then it never invalidates the already-committed import.
+func (c *RepoClient) NotifyImport(teamID string, metadata any) (recordingID string, err error) {
 	metaBytes, err := json.Marshal(metadata)
 	if err != nil {
-		return fmt.Errorf("marshal metadata: %w", err)
+		return "", fmt.Errorf("marshal metadata: %w", err)
 	}
 
 	reqBody := ImportNotification{
@@ -499,7 +504,7 @@ func (c *RepoClient) NotifyImport(teamID string, metadata any) error {
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
+		return "", fmt.Errorf("marshal request: %w", err)
 	}
 
 	reqURL := strings.TrimSuffix(c.baseURL, "/") + fmt.Sprintf(gitImportPath, teamID)
@@ -509,7 +514,7 @@ func (c *RepoClient) NotifyImport(teamID string, metadata any) error {
 
 	httpReq, err := useragent.NewRequest(context.Background(), "POST", reqURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		return fmt.Errorf("create request: %w", err)
+		return "", fmt.Errorf("create request: %w", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -522,23 +527,33 @@ func (c *RepoClient) NotifyImport(teamID string, metadata any) error {
 
 	if err != nil {
 		logger.LogHTTPError("POST", reqURL, err, duration)
-		return nil // graceful degradation
+		return "", nil // graceful degradation
 	}
 	defer resp.Body.Close()
 
 	logger.LogHTTPResponse("POST", reqURL, resp.StatusCode, duration)
 
-	io.Copy(io.Discard, resp.Body)
-
 	if resp.StatusCode == http.StatusNotFound {
-		return nil // endpoint not yet deployed
+		io.Copy(io.Discard, resp.Body)
+		return "", nil // endpoint not yet deployed
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("import notification failed (%d)", resp.StatusCode)
+		io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("import notification failed (%d)", resp.StatusCode)
 	}
 
-	return nil
+	// 2xx: opportunistically read a recording ID if the server returns one for
+	// media routed to transcription. An empty/non-JSON body is normal (the
+	// endpoint predates this field) and must not be treated as an error.
+	var out struct {
+		RecordingID string `json:"recording_id"`
+	}
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if len(respBody) > 0 {
+		_ = json.Unmarshal(respBody, &out)
+	}
+	return out.RecordingID, nil
 }
 
 // NotifySessionUploaded tells the SageOx server that a session's content

--- a/internal/api/repos_coverage_test.go
+++ b/internal/api/repos_coverage_test.go
@@ -191,8 +191,55 @@ func TestNotifyImport_Success(t *testing.T) {
 		authToken:  "tok",
 	}
 
-	err := client.NotifyImport("team_abc", map[string]string{"file": "doc.md"})
+	recordingID, err := client.NotifyImport("team_abc", map[string]string{"file": "doc.md"})
 	assert.NoError(t, err)
+	assert.Empty(t, recordingID, "no recording_id in body → empty string")
+}
+
+// TestNotifyImport_ReturnsRecordingID verifies the recording ID is surfaced when
+// the server routes a media file to transcription and returns it in the body.
+// Failure prevented: the CLI silently discards the ID, so a team media import
+// can never be watched via `ox import --status <id> --watch`.
+func TestNotifyImport_ReturnsRecordingID(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"recording_id":"rec_xyz789"}`))
+	}))
+	defer srv.Close()
+
+	client := &RepoClient{
+		baseURL:    srv.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		authToken:  "tok",
+	}
+
+	recordingID, err := client.NotifyImport("team_abc", map[string]string{"file": "standup.mp4"})
+	assert.NoError(t, err)
+	assert.Equal(t, "rec_xyz789", recordingID)
+}
+
+// TestNotifyImport_NonJSONBodyTolerated verifies a 2xx with a non-JSON body
+// (older servers that just return "OK") yields no error and an empty ID.
+func TestNotifyImport_NonJSONBodyTolerated(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer srv.Close()
+
+	client := &RepoClient{
+		baseURL:    srv.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+
+	recordingID, err := client.NotifyImport("team_abc", map[string]string{})
+	assert.NoError(t, err)
+	assert.Empty(t, recordingID)
 }
 
 func TestNotifyImport_404_GracefulDegradation(t *testing.T) {
@@ -208,7 +255,7 @@ func TestNotifyImport_404_GracefulDegradation(t *testing.T) {
 		httpClient: &http.Client{Timeout: 10 * time.Second},
 	}
 
-	err := client.NotifyImport("team_abc", map[string]string{})
+	_, err := client.NotifyImport("team_abc", map[string]string{})
 	assert.NoError(t, err, "404 should be swallowed gracefully")
 }
 
@@ -225,7 +272,7 @@ func TestNotifyImport_ServerError(t *testing.T) {
 		httpClient: &http.Client{Timeout: 10 * time.Second},
 	}
 
-	err := client.NotifyImport("team_abc", map[string]string{})
+	_, err := client.NotifyImport("team_abc", map[string]string{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
 }
@@ -239,7 +286,7 @@ func TestNotifyImport_NetworkError(t *testing.T) {
 	}
 
 	// network errors are swallowed (graceful degradation)
-	err := client.NotifyImport("team_abc", map[string]string{})
+	_, err := client.NotifyImport("team_abc", map[string]string{})
 	assert.NoError(t, err)
 }
 

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -7,7 +7,7 @@ type RepoService interface {
 	RegisterRepo(req *RepoInitRequest) (*RepoInitResponse, error)
 	GetDoctorIssues(repoID string) (*DoctorResponse, error)
 	NotifyUninstall(repoID, repoSalt string) error
-	NotifyImport(teamID string, metadata any) error
+	NotifyImport(teamID string, metadata any) (recordingID string, err error)
 	MergeRepo(repoID string, markers map[string]json.RawMessage) (*MergeRepoResponse, *RedirectInfo, error)
 	Endpoint() string
 	WithAuthToken(token string) *RepoClient

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -21,7 +21,8 @@ func TestMockRepoService_NilFuncsReturnZeroValues(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, m.NotifyUninstall("r-123", "salt"))
-	assert.NoError(t, m.NotifyImport("t-123", nil))
+	_, niErr := m.NotifyImport("t-123", nil)
+	assert.NoError(t, niErr)
 
 	mr, ri, err := m.MergeRepo("r-123", nil)
 	assert.Nil(t, mr)
@@ -160,9 +161,9 @@ func TestMockRepoService_MergeWorkflow(t *testing.T) {
 					Repo: &RedirectMapping{From: repoID, To: "repo-winner"},
 				}, nil
 		},
-		NotifyImportFunc: func(teamID string, metadata any) error {
+		NotifyImportFunc: func(teamID string, metadata any) (string, error) {
 			require.Equal(t, "team-1", teamID)
-			return nil
+			return "", nil
 		},
 	}
 
@@ -179,7 +180,7 @@ func TestMockRepoService_MergeWorkflow(t *testing.T) {
 	assert.Equal(t, "repo-winner", redirect.Repo.To)
 
 	// step 2: notify import on the winning repo's team
-	err = svc.NotifyImport("team-1", map[string]string{"source": "merge"})
+	_, err = svc.NotifyImport("team-1", map[string]string{"source": "merge"})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## What was broken

`ox import` advertised `--json` support, but the **team document/file import path** — the default path for `ox import report.pdf`, `ox import ./standup.mp4` (no `--kb`) — ignored the flag entirely and always printed plain text. Only the URL, `--kb` media, `--status`, and `--list` paths honored `--json`.

Separately, `RepoClient.NotifyImport` did `io.Copy(io.Discard, resp.Body)` — so any recording ID the server assigned when it routed a media file to transcription was thrown away. There was no way to take a team media import and watch its processing.

## What this PR ships

- **`--json` on the team document import path.** New `importResult` struct (`status`, `title`, `path`, `team_id`, `source_oid`, `content_type`, `recording_id`, plus `id` for dedup). Both the success branch and the "already imported" dedup branch emit structured JSON when `--json` is set, via a small `emitImportJSON` helper.
- **Recording ID surfaced for `--watch` follow-up.** `NotifyImport` now returns `(recordingID string, err error)` and opportunistically parses an optional `recording_id` from the 2xx response body (size-limited read).
  - Human output: on success with an ID, prints `Track progress: ox import --status <id> --watch`, reusing the existing `importContextFlagHint()` so `--team`/`--kb` carries through.
  - JSON output: the ID lands in `recording_id`.

This makes a pipeline work that previously couldn't:

```
ox import ./standup.mp4 --json | jq -r .recording_id
ox import --status <id> --watch
```

## Compatibility

- `NotifyImport` stays fire-and-forget. Network errors and 404 still degrade to `("", nil)`. A missing or non-JSON 2xx body yields `("", nil)` — older servers that return `OK` are unaffected. The endpoint contract is unchanged on the request side; this only *reads* an optional response field that the server may add.
- URL and `--kb` media paths already returned a recording ID and honored `--json` — untouched.

```mermaid
flowchart TD
    A[ox import file --json] --> B{path?}
    B -->|URL / --kb media| C[already returned recording_id + JSON]
    B -->|team doc/media| D[NEW: honor --json]
    D --> E[NotifyImport]
    E -->|2xx body has recording_id| F[surface id + --watch hint]
    E -->|empty / non-JSON / 404 / net err| G[id = empty, no error]
```

## Server dependency

The `recording_id` only appears if the backend returns it from `POST /api/v1/teams/{team_id}/context/import` for media routed to transcription. This CLI change is forward-compatible: it surfaces the ID the moment the server provides one, with no false promise today. If the backend doesn't yet return it, that's a one-field addition on the `sageox-mono` side.

## Test Plan

- `go build ./...`, `go vet ./internal/api/... ./cmd/ox/...` — clean.
- `go test ./internal/api/... ./cmd/ox/...` — green (full suites).
- New regression tests:
  - `TestNotifyImport_ReturnsRecordingID` — ID parsed from a JSON 2xx body.
  - `TestNotifyImport_NonJSONBodyTolerated` — non-JSON 2xx → `("", nil)`.
  - `TestNotifyImport_Success` — no `recording_id` in body → empty string.
  - `TestEmitImportJSON_Shape` / `TestEmitImportJSON_AlreadyImported` — JSON payload shape for both fresh and dedup imports.
- Updated `RepoService` interface, mock, and all `NotifyImport` call sites for the new signature.

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `ox import --json` output now includes server-assigned recording IDs for transcription tracking.
  * Improved duplicate import handling with structured JSON responses.

* **Tests**
  * Added comprehensive test coverage for JSON output validation and recording ID handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->