### PR TITLE
fix(import): honor --title on team document/media imports

### DIFF
--- a/cmd/ox/import.go
+++ b/cmd/ox/import.go
@@ -53,6 +53,7 @@ recording pipeline for the Knowledge Bubble (transcription, summarization).
 Supports Loom, Cap, and direct video URLs.
 
   ox import report.pdf --text extracted.md
+  ox import report.pdf --title "Q2 Review"        # override the filename-derived title
   ox import notes.md --date 2026-01-15
   ox import ./standup.mp4                       # media file into the team (git-tracked, transcribed)
   ox import ./recording.mp4 --kb my-bubble      # media file into a Knowledge Bubble
@@ -80,7 +81,7 @@ func init() {
 	importCmd.Flags().StringVar(&importFlags.team, "team", "", "team ID (or slug/name when inside a repo)")
 	importCmd.Flags().StringVar(&importFlags.kb, "kb", "", "Knowledge Bubble (slug or kb_id) to import into")
 	importCmd.MarkFlagsMutuallyExclusive("team", "kb")
-	importCmd.Flags().StringVar(&importFlags.title, "title", "", "display title for URL imports")
+	importCmd.Flags().StringVar(&importFlags.title, "title", "", "display title (defaults to filename for file imports)")
 	importCmd.Flags().StringVar(&importFlags.status, "status", "", "check processing status of a URL import (use --list to find IDs)")
 	importCmd.Flags().BoolVar(&importFlags.watch, "watch", false, "poll --status until processing completes or fails")
 	importCmd.Flags().BoolVar(&importFlags.list, "list", false, "list imports and their processing status")
@@ -244,9 +245,9 @@ func runImport(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// derive directory name from filename stem
-	dirName := inferTitle(srcPath)
-	dirSlug := slugify(dirName)
+	// derive the per-document storage slug from --title, falling back to the
+	// filename stem (see resolveImportSlug for the empty-slug guard)
+	dirSlug := resolveImportSlug(srcPath)
 
 	docDir := filepath.Join(docsBaseDir,
 		importDate.Format("2006"),
@@ -324,7 +325,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("write pointer files: %w", err)
 	}
 
-	title := inferTitle(srcPath)
+	title := resolveImportTitle(srcPath)
 
 	// build and write metadata.json (plain git, not LFS — stays readable without
 	// hydration). like pointer files, the local copy is ephemeral and cleaned up
@@ -406,6 +407,31 @@ func emitImportJSON(cmd *cobra.Command, result importResult) error {
 	}
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 	return nil
+}
+
+// resolveImportTitle returns the explicit --title when set, otherwise the
+// title inferred from the filename. It backs both the metadata.json/server
+// display title and (via resolveImportSlug) the per-document storage slug.
+func resolveImportTitle(srcPath string) string {
+	if t := strings.TrimSpace(importFlags.title); t != "" {
+		return t
+	}
+	return inferTitle(srcPath)
+}
+
+// resolveImportSlug derives the per-document storage slug for the team import
+// path. It prefers the slugified --title, but a punctuation-only title (e.g.
+// "!!!") slugifies to "" — which would collapse docDir onto the date directory
+// and silently scatter metadata.json and pointer files there. In that case it
+// falls back to the filename-derived slug so storage identity always lives
+// under a per-document directory. (A pathological filename like "!!!.pdf" can
+// still produce an empty slug; that edge predates the --title feature and is
+// out of scope here.)
+func resolveImportSlug(srcPath string) string {
+	if s := slugify(resolveImportTitle(srcPath)); s != "" {
+		return s
+	}
+	return slugify(inferTitle(srcPath))
 }
 
 // inferTitle derives a human-readable title from a filename.

--- a/cmd/ox/import_test.go
+++ b/cmd/ox/import_test.go
@@ -170,6 +170,65 @@ func TestInferTitle(t *testing.T) {
 	}
 }
 
+// TestResolveImportTitle verifies that --title overrides the filename-derived
+// title for team document/media imports, and that the filename is used as the
+// fallback when --title is empty or whitespace-only.
+// Failure prevented: --title silently ignored on the default import path, so
+// the metadata.json/server title always tracks the filename (the original bug).
+func TestResolveImportTitle(t *testing.T) {
+	orig := importFlags.title
+	t.Cleanup(func() { importFlags.title = orig })
+
+	tests := []struct {
+		name  string
+		title string
+		path  string
+		want  string
+	}{
+		{"explicit title overrides filename", "Q2 Review", "report.pdf", "Q2 Review"},
+		{"empty title falls back to filename", "", "my-doc.pdf", "my doc"},
+		{"whitespace-only title falls back to filename", "   ", "my-doc.pdf", "my doc"},
+		{"title is trimmed", "  Trimmed Title  ", "report.pdf", "Trimmed Title"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			importFlags.title = tt.title
+			assert.Equal(t, tt.want, resolveImportTitle(tt.path))
+		})
+	}
+}
+
+// TestResolveImportSlug verifies that the storage slug follows --title for
+// normal input but falls back to the filename slug when the title slugifies to
+// empty (e.g. a punctuation-only title).
+// Failure prevented: --title "!!!" yields an empty slug, collapsing docDir onto
+// the date directory and scattering metadata.json/pointer files there instead
+// of under a per-document slug.
+func TestResolveImportSlug(t *testing.T) {
+	orig := importFlags.title
+	t.Cleanup(func() { importFlags.title = orig })
+
+	tests := []struct {
+		name  string
+		title string
+		path  string
+		want  string
+	}{
+		{"title drives slug", "Q2 Review", "report.pdf", "q2-review"},
+		{"empty title uses filename", "", "my-doc.pdf", "my-doc"},
+		{"punctuation-only title falls back to filename", "!!!", "my-doc.pdf", "my-doc"},
+		{"whitespace-only title falls back to filename", "   ", "my-doc.pdf", "my-doc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			importFlags.title = tt.title
+			assert.Equal(t, tt.want, resolveImportSlug(tt.path))
+		})
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	tests := []struct {
 		input string

--- a/docs/reference/import.mdx
+++ b/docs/reference/import.mdx
@@ -6,27 +6,33 @@ sidebar_position: 45
 
 ## ox import
 
-Import a document or video URL into team context
+Import a document, media file, or video URL into team context or a Knowledge Bubble
 
 ### Synopsis
 
-Import a document or video URL into team context for onboarding and knowledge sharing.
+Import a document, media file, or video URL for onboarding and knowledge sharing.
 
-File imports are stored with LFS-backed content and git-tracked metadata.
-URL imports submit a video for cloud processing (transcription, summarization).
+Team imports (default) are stored with LFS-backed content and git-tracked
+metadata in the team context repo — including media files (mp4, mov, webm,
+m4a, mp3, wav, …), which are transcribed and summarized server-side after
+import. With --kb, media files and video URLs are submitted to the cloud
+recording pipeline for the Knowledge Bubble (transcription, summarization).
 Supports Loom, Cap, and direct video URLs.
 
   ox import report.pdf --text extracted.md
+  ox import report.pdf --title "Q2 Review"        # override the filename-derived title
   ox import notes.md --date 2026-01-15
+  ox import ./standup.mp4                       # media file into the team (git-tracked, transcribed)
+  ox import ./recording.mp4 --kb my-bubble      # media file into a Knowledge Bubble
   ox import https://www.loom.com/share/abc123 --title "Architecture Review"
   ox import https://cap.link/abc123 --title "Sprint Retro"
-  ox import https://example.com/meeting.mp4 --title "Team Standup"
   ox import --list                              # find import IDs
   ox import --status rec_01234567               # check processing once
   ox import --status rec_01234567 --watch       # wait until complete
 
-The team is auto-discovered from the current repo. Use --team to override
-or when working outside an initialized repo.
+The team is auto-discovered from the current repo. Use --team to override,
+or --kb <slug|kb_id> to target a Knowledge Bubble instead (the two are
+mutually exclusive). Document imports currently support --team only.
 
 For behavioral rules (vs. documents), see 'ox guide team-rules' — rules
 go in agents/rules/, not through ox import.
@@ -41,11 +47,12 @@ ox import <file|url> [flags]
       --date string     date for filing (YYYY-MM-DD, default: auto-detect from metadata)
       --force           re-import even if content hash already exists
   -h, --help            help for import
+      --kb string       Knowledge Bubble (slug or kb_id) to import into
       --list            list imports and their processing status
       --status string   check processing status of a URL import (use --list to find IDs)
       --team string     team ID (or slug/name when inside a repo)
       --text string     path to pre-extracted text/markdown for indexing (optional)
-      --title string    display title for URL imports
+      --title string    display title (defaults to filename for file imports)
       --watch           poll --status until processing completes or fails
 ```
 


### PR DESCRIPTION
## What broke

`ox import --title "…"` silently ignored the flag on the **default team document/media import** path.

- `--title` was only wired into the **URL import** (`runImportURL`) and **KB media-file import** (`runImportRecordingFile`) paths.
- The default team path (`runImport`) derived everything from the filename via `inferTitle(srcPath)` — for **both** the directory slug *and* the title written into `metadata.json` and sent to the server.
- Result: `ox import report.pdf --title "Q2 Review"` parsed the flag and dropped it. The CLI was *ignoring* it, not failing to transmit it. The flag's own help even read `"display title for URL imports"`.

## What this PR ships

- **`--title` now applies to team document/media imports.** New `resolveImportTitle(srcPath)` returns the trimmed `--title` when set, else falls back to `inferTitle(srcPath)`. It backs the `metadata.json`/server display title.
- **Storage slug follows `--title` too, with an empty-slug guard.** New `resolveImportSlug(srcPath)` prefers the slugified title but falls back to the filename slug when the title slugifies to empty.
- **Help text broadened** from `"display title for URL imports"` → `"display title (defaults to filename for file imports)"`, plus a file-import `--title` example in the long help.
- **Reference docs** (`docs/reference/import.mdx`) regenerated from the cobra definitions.

## Why the empty-slug guard

A punctuation-only title makes the slug collapse, scattering files onto the date directory:

```mermaid
flowchart TD
    A["ox import doc.pdf --title '!!!'"] --> B["slugify('!!!') = ''"]
    B --> C{"guard?"}
    C -->|"without guard"| D["docDir = data/docs/2026/06/20/<br/>metadata.json + pointers land in the date dir"]
    C -->|"with guard (this PR)"| E["fall back to filename slug 'doc'<br/>docDir = data/docs/2026/06/20/doc/"]
```

This was the one genuinely new edge `--title` introduced (free text is far more likely than a filename to slugify to empty). Same-title collisions on the same day were intentionally **not** hardened: that risk is pre-existing, already detected by the `os.Stat` guard, escape-hatched by `--force`, and narrowed by date-bucketing — the existing design handles it.

## Scope notes

- URL and KB media paths already honored `--title` correctly and are unchanged.
- A pathological filename like `!!!.pdf` can still produce an empty slug; that edge predates `--title` and is left out of scope.

## Test Plan

- `TestResolveImportTitle` — override, empty/whitespace fallback, trimming.
- `TestResolveImportSlug` — title-driven slug, filename fallback, punctuation-only and whitespace-only titles fall back to the filename slug.
- `go test ./cmd/ox/` import suite green; `golangci-lint` clean on changed files; `gofmt` clean.

Co-Authored-By: SageOx <ox@sageox.ai>
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--title` flag now serves as the authoritative source for both document titles and storage directory naming in `ox import`.

* **Documentation**
  * Updated `ox import` reference to clarify support for Loom, Cap, and direct video URLs via `--kb` option; clarified `--title` defaults to filename for file imports.

* **Tests**
  * Added test coverage for title and slug resolution in import functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->