### PR TITLE
fix(daemon): auto-recover stale wedged ledger rebase instead of skipping forever

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -81,7 +81,21 @@ Target: 85%+ for internal packages. Check: `go test ./internal/... -coverprofile
 
 ## Bug Fix Regression Tests
 
-Every bug fix MUST include a regression test. Reproduce exact conditions; test must fail without fix, pass with it. Integration-level regressions go in `sageox/ox-test-harness`.
+Every bug fix MUST include a regression test that **fails without the fix and passes with it** — verify this explicitly (neuter the fix, watch the test go red, restore it). A test that passes both ways guards nothing.
+
+**Test the CLASS of failure, not the specific patch.** A bug is one instance of a broader failure mode. The patch fixes the instance; the test suite must cover the class. Before writing the test, ask: *what is the general failure here, and where else can it occur?* Then test those too.
+
+- Generalize the trigger: the reported wedge was a stale `rebase-merge`, but the class is "the repo is stuck in a persistent git state that blocks sync." So also cover `rebase-apply`, an aborted merge/cherry-pick, leftover lock files — same recovery contract, different entry point.
+- Generalize the input axis: if a bug hit one path/encoding/timing, test the target in *each* possible location/state, not only the one that broke.
+- Name the test after the class it prevents, not the ticket number.
+
+**Simulate the ENVIRONMENT the failure occurred in, not a stripped-down stub.** Reproduce the conditions that produced the bug — real subprocesses, real divergent history, real concurrent writers, real multi-cycle loops — so the test exercises the actual interaction, not a mock that can't reproduce it. Build up reusable harnesses (a real wedged-repo factory, a bare-remote-plus-clone fixture) that future tests in the same domain reuse; this makes the suite progressively more cross-cutting instead of a pile of isolated unit checks.
+
+- A unit test on a helper (e.g. "does `RebaseAge` read the mtime") does NOT prove the daemon recovers — it would pass even if recovery were never wired in. Drive the actual decision path.
+- Prove the system *makes progress after recovery* (un-wedged AND the next pull reconciles), not merely that one function returned the right value.
+- Where a true end-to-end belongs above the unit layer, put the integration regression in `sageox/ox-test-harness`.
+
+**The intent is what's under test — the durable behavior the user relies on — across the whole class of bugs, not a snapshot of one code path.** Optimize each regression test to catch the *next* variant of the same mistake, not just a re-run of the exact one already fixed.
 
 ## Handling Test Failures
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v8
         with:
           version: v2.11.4
           args: -c .config/golangci.yml

--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -36,6 +36,6 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1.6

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -170,10 +170,10 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 		return ManagedRepoPullResult{CorruptRepo: true}
 	}
 
-	// Rebase-in-progress: skip — will resolve on its own or needs manual fix
-	if gitutil.IsRebaseInProgress(path) {
-		logger.Debug("repo in rebase state, skipping pull", "path", path)
-		return ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRebaseInProgress}
+	// Rebase-in-progress handling: leave a fresh rebase alone, auto-recover
+	// a stale wedge, or surface an unrecoverable one. See recoverPreexistingRebase.
+	if stop, res := s.recoverPreexistingRebase(ctx, path, repoName, logger); stop {
+		return res
 	}
 
 	// Lock files: auto-remove stale ones, skip and report if still present
@@ -393,6 +393,63 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 	}
 
 	return result
+}
+
+// staleRebaseThreshold separates a fresh, in-flight rebase from an abandoned
+// wedge. The daemon's own `git pull --rebase` completes in seconds, so 5
+// minutes cleanly distinguishes "someone is actively rebasing" from "a rebase
+// has been stuck here for a while" and guarantees we never abort a rebase out
+// from under an in-progress operation.
+const staleRebaseThreshold = 5 * time.Minute
+
+// recoverPreexistingRebase handles a rebase that is ALREADY in progress when a
+// sync cycle starts (as opposed to one this call's own pull --rebase just
+// triggered, which the post-pull recovery ladder handles).
+//
+//   - No rebase, or a FRESH one (younger than staleRebaseThreshold): a fresh
+//     rebase is almost always the daemon's own concurrent pull or a human/CLI
+//     mid-operation — leave it alone. Returns stop=false for "no rebase" so the
+//     caller proceeds to pull; stop=true with a Skipped result for a fresh one.
+//   - A STALE rebase: a genuine wedge (abandoned by a crash, or stopped at an
+//     "edit"/conflict and never continued). Bare-skipping it forever was a
+//     deadlock — the post-pull ladder only fires for a rebase THIS call
+//     started, so a pre-existing wedge never got recovered, stranding every
+//     new session behind it and churning the sync loop. Auto-recover via
+//     AuditAndAbort (logs everything discarded before resetting; session data
+//     is the store's to re-publish, per .claude/rules/daemon-git.md), then
+//     return stop=false so the caller falls through to a clean pull and
+//     re-syncs this same cycle.
+//   - If the abort itself fails the repo is genuinely stuck: return stop=true
+//     with a confirm-required IssueTypeRebaseStuck so doctor / the scheduled
+//     doctor agent task picks it up instead of silently re-looping.
+func (s *SyncScheduler) recoverPreexistingRebase(ctx context.Context, path, repoName string, logger *slog.Logger) (stop bool, result ManagedRepoPullResult) {
+	age, inProgress := gitutil.RebaseAge(path)
+	if !inProgress {
+		return false, ManagedRepoPullResult{}
+	}
+	if age < staleRebaseThreshold {
+		logger.Debug("repo in fresh rebase, skipping pull this cycle", "path", path, "age", age)
+		return true, ManagedRepoPullResult{Skipped: true, SkipReason: skipReasonRebaseInProgress}
+	}
+	logger.Warn("recovering stale wedged rebase",
+		"op", "stale_rebase_recover", "repo", repoName, "age", age.Round(time.Second))
+	if abortErr := gitutil.AuditAndAbort(ctx, path, gitutil.AuditOpRebase, "stale wedged rebase auto-recovery", logger); abortErr != nil {
+		logger.Error("stale rebase recovery failed",
+			"op", "stale_rebase_recover_failed", "repo", repoName, "error", abortErr)
+		return true, ManagedRepoPullResult{
+			Skipped:    true,
+			SkipReason: "stale rebase recovery failed",
+			Issue: &DaemonIssue{
+				Type:            IssueTypeRebaseStuck,
+				Severity:        SeverityError,
+				Repo:            repoName,
+				Summary:         fmt.Sprintf("%s is stuck in a wedged rebase and auto-recovery failed. Run 'ox doctor --fix' to recover.", repoName),
+				RequiresConfirm: true,
+			},
+		}
+	}
+	logger.Info("recovered stale wedged rebase", "op", "stale_rebase_recovered", "repo", repoName)
+	return false, ManagedRepoPullResult{}
 }
 
 // detectDivergedBranchesAt checks if local and remote branches have both

--- a/internal/daemon/sync_rebase_recovery_test.go
+++ b/internal/daemon/sync_rebase_recovery_test.go
@@ -1,0 +1,286 @@
+package daemon
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Pre-existing rebase recovery ---
+//
+// These pin the behavior of recoverPreexistingRebase, the fix for the wedge
+// where the daemon skipped a pre-existing rebase forever (sync_managed.go:159
+// pre-fix). The original bug stranded every new session behind the wedge and
+// spun the sync loop. A unit test on RebaseAge alone would pass even if the
+// recovery were never wired in — these call the recovery decision directly so
+// a regression to "bare skip" fails the build.
+
+// makeWedgedRebase creates a real git repo stuck mid-rebase with a conflict,
+// so .git/rebase-merge exists and IsRebaseInProgress reports true. No remote
+// needed — the abort path operates purely locally.
+func makeWedgedRebase(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+
+	git := func(args ...string) {
+		out, err := runGit(t, repo, args...)
+		// Only the intentional conflicting rebase may exit non-zero; surface
+		// any other setup failure (e.g. unsupported --initial-branch) so a
+		// broken fixture fails loudly instead of masquerading as a wedge.
+		if err != nil && args[0] != "rebase" {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	write := func(content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(repo, "file.txt"), []byte(content), 0o644))
+	}
+
+	git("init", "--initial-branch=main")
+	write("base\n")
+	git("add", "file.txt")
+	git("commit", "-m", "base")
+	git("checkout", "-b", "feature")
+	write("feature change\n")
+	git("add", "file.txt")
+	git("commit", "-m", "feature")
+	git("checkout", "main")
+	write("main change\n")
+	git("add", "file.txt")
+	git("commit", "-m", "main")
+	git("checkout", "feature")
+	git("rebase", "main") // conflicts on file.txt → leaves the repo wedged
+
+	require.True(t, gitutil.IsRebaseInProgress(repo), "setup should leave a wedged rebase")
+	return repo
+}
+
+// backdateRebaseDir ages the in-progress rebase so RebaseAge reports it stale.
+func backdateRebaseDir(t *testing.T, repo string, age time.Duration) {
+	t.Helper()
+	old := time.Now().Add(-age)
+	touched := false
+	for _, d := range []string{"rebase-merge", "rebase-apply"} {
+		p := filepath.Join(repo, ".git", d)
+		if _, err := os.Stat(p); err == nil {
+			require.NoError(t, os.Chtimes(p, old, old))
+			touched = true
+		}
+	}
+	require.True(t, touched, "expected a rebase dir to backdate")
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// gitEnv is the hermetic env every git subprocess in these tests runs under:
+// no system/global config, fixed identity, signing off.
+func gitEnv() []string {
+	return append(os.Environ(),
+		"GIT_CONFIG_NOSYSTEM=1", "HOME="+os.TempDir(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=commit.gpgsign", "GIT_CONFIG_VALUE_0=false",
+	)
+}
+
+// runGit runs git in dir, returning combined output and error so callers can
+// assert on either the result or the failure.
+func runGit(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("git", args...) // safe: git in a temp dir, not the ox CLI
+	cmd.Dir = dir
+	cmd.Env = gitEnv()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// setupRemoteWithStuckRebase reproduces the production ENVIRONMENT: a clone
+// with a local-ahead commit, a remote that advanced with a non-conflicting
+// commit, and a rebase that stopped partway and was never continued (here via
+// a failing `-x` exec, the no-conflict analog of the real "stopped at edit"
+// wedge). Returns the clone path. After recovery, a normal pull must reconcile
+// cleanly — proving the daemon makes PROGRESS, not just that it un-wedges.
+func setupRemoteWithStuckRebase(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	bare := filepath.Join(root, "remote.git")
+	seed := filepath.Join(root, "seed")
+	clone := filepath.Join(root, "clone")
+
+	mustGit := func(dir string, args ...string) {
+		if out, err := runGit(t, dir, args...); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	write := func(dir, name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+	}
+
+	mustGit(root, "init", "--bare", "--initial-branch=main", bare)
+
+	// seed the remote with a base commit
+	mustGit(root, "clone", bare, seed)
+	write(seed, "base.txt", "base\n")
+	mustGit(seed, "add", "base.txt")
+	mustGit(seed, "commit", "-m", "base")
+	mustGit(seed, "push", "origin", "main")
+
+	// the clone the daemon manages: add a local-ahead commit (not pushed)
+	mustGit(root, "clone", bare, clone)
+	write(clone, "local.txt", "local work\n")
+	mustGit(clone, "add", "local.txt")
+	mustGit(clone, "commit", "-m", "local change")
+
+	// remote advances with a NON-conflicting commit (different file)
+	write(seed, "remote.txt", "remote work\n")
+	mustGit(seed, "add", "remote.txt")
+	mustGit(seed, "commit", "-m", "remote change")
+	mustGit(seed, "push", "origin", "main")
+
+	// leave the clone wedged in a rebase that stopped and was never continued
+	// (a failing -x exec halts the rebase with a clean tree, no conflict).
+	_, err := runGit(t, clone, "rebase", "-x", "exit 1", "HEAD~1")
+	require.Error(t, err, "the failing -x exec should halt the rebase")
+	require.True(t, gitutil.IsRebaseInProgress(clone), "clone should be wedged")
+	return clone
+}
+
+// TestRecoverPreexistingRebase_NoRebase: a clean repo must not be treated as
+// wedged — the caller proceeds to a normal pull.
+func TestRecoverPreexistingRebase_NoRebase(t *testing.T) {
+	repo := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	s := &SyncScheduler{}
+
+	stop, res := s.recoverPreexistingRebase(context.Background(), repo, "ledger", discardLogger())
+
+	assert.False(t, stop, "no rebase → caller should fall through to pull")
+	assert.False(t, res.Skipped)
+	assert.Nil(t, res.Issue)
+}
+
+// TestRecoverPreexistingRebase_FreshRebaseLeftAlone: a rebase that is only
+// seconds old is almost always the daemon's own in-flight pull --rebase or a
+// human mid-operation. It must be skipped, NOT aborted out from under them.
+// Failure prevented: aborting an active rebase and corrupting concurrent work.
+func TestRecoverPreexistingRebase_FreshRebaseLeftAlone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses to build a real rebase")
+	}
+	repo := makeWedgedRebase(t) // just-created → fresh
+	s := &SyncScheduler{}
+
+	stop, res := s.recoverPreexistingRebase(context.Background(), repo, "ledger", discardLogger())
+
+	assert.True(t, stop, "fresh rebase → stop this cycle")
+	assert.True(t, res.Skipped)
+	assert.Equal(t, skipReasonRebaseInProgress, res.SkipReason)
+	assert.True(t, gitutil.IsRebaseInProgress(repo), "fresh rebase must NOT be aborted")
+}
+
+// TestRecoverPreexistingRebase_StaleWedgeRecovered is the core regression for
+// the reported bug: a rebase wedged long ago must be auto-aborted so the repo
+// can sync again, instead of being skipped forever.
+// Failure prevented: a pre-existing wedge deadlocks the daemon and strands
+// every new session behind it (the exact production incident).
+func TestRecoverPreexistingRebase_StaleWedgeRecovered(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses to build a real rebase")
+	}
+	repo := makeWedgedRebase(t)
+	backdateRebaseDir(t, repo, time.Hour) // older than staleRebaseThreshold
+	s := &SyncScheduler{}
+
+	stop, res := s.recoverPreexistingRebase(context.Background(), repo, "ledger", discardLogger())
+
+	assert.False(t, stop, "stale wedge recovered → caller falls through to a clean pull")
+	assert.Nil(t, res.Issue)
+	assert.False(t, gitutil.IsRebaseInProgress(repo), "stale wedge must be aborted/recovered")
+}
+
+// TestRecoverPreexistingRebase_StaleWedge_ApplyBackend covers the same CLASS of
+// failure via git's other rebase backend. A wedge can leave `.git/rebase-apply`
+// instead of `.git/rebase-merge` (older git, `--apply`, `git am`); recovery
+// must handle both, since the production deadlock is "stuck in a persistent
+// git state", not "stuck in one specific directory layout".
+func TestRecoverPreexistingRebase_StaleWedge_ApplyBackend(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses to build a real rebase")
+	}
+	repo := t.TempDir()
+	mustGit := func(args ...string) {
+		if out, err := runGit(t, repo, args...); err != nil && args[0] != "rebase" {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(c string) { require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte(c), 0o644)) }
+
+	mustGit("init", "--initial-branch=main")
+	write("base\n")
+	mustGit("add", "f.txt")
+	mustGit("commit", "-m", "base")
+	mustGit("checkout", "-b", "feature")
+	write("feature\n")
+	mustGit("add", "f.txt")
+	mustGit("commit", "-m", "feature")
+	mustGit("checkout", "main")
+	write("main\n")
+	mustGit("add", "f.txt")
+	mustGit("commit", "-m", "main")
+	mustGit("checkout", "feature")
+	// --apply forces the am-based backend → .git/rebase-apply on conflict
+	mustGit("rebase", "--apply", "main")
+	require.True(t, gitutil.IsRebaseInProgress(repo), "expected an apply-backend wedge")
+	require.DirExists(t, filepath.Join(repo, ".git", "rebase-apply"))
+
+	backdateRebaseDir(t, repo, time.Hour)
+	stop, res := (&SyncScheduler{}).recoverPreexistingRebase(context.Background(), repo, "ledger", discardLogger())
+
+	assert.False(t, stop)
+	assert.Nil(t, res.Issue)
+	assert.False(t, gitutil.IsRebaseInProgress(repo), "apply-backend wedge must also be recovered")
+}
+
+// TestRecoverPreexistingRebase_RecoveryRestoresSyncProgress is the ENVIRONMENT
+// test: a real remote, a local-ahead commit, a non-conflicting remote advance,
+// and a rebase that stopped and was abandoned — the shape of the production
+// incident. It asserts the daemon doesn't merely un-wedge but actually CATCHES
+// UP: after recovery, a normal pull reconciles and the remote's commit lands.
+// Failure prevented: "recovery" that aborts the wedge but leaves the repo
+// unable to make forward progress (still stranded, just not mid-rebase).
+func TestRecoverPreexistingRebase_RecoveryRestoresSyncProgress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real bare remote + clone + rebase via git subprocesses")
+	}
+	clone := setupRemoteWithStuckRebase(t)
+	backdateRebaseDir(t, clone, time.Hour)
+
+	// 1. recovery un-wedges the abandoned rebase
+	stop, res := (&SyncScheduler{}).recoverPreexistingRebase(context.Background(), clone, "ledger", discardLogger())
+	require.False(t, stop, "stale wedge should be recovered, not skipped")
+	require.Nil(t, res.Issue)
+	require.False(t, gitutil.IsRebaseInProgress(clone))
+
+	// 2. the daemon's normal pull (what pullManagedRepo runs after recovery)
+	//    now reconciles cleanly with the advanced remote.
+	if out, err := runGit(t, clone, "pull", "--rebase", "--autostash", "origin", "main"); err != nil {
+		t.Fatalf("post-recovery pull should reconcile, got: %v\n%s", err, out)
+	}
+
+	// 3. progress proven: the remote's commit is present AND local work survived,
+	//    with no leftover wedge.
+	assert.False(t, gitutil.IsRebaseInProgress(clone))
+	assert.FileExists(t, filepath.Join(clone, "remote.txt"), "remote commit must have landed")
+	assert.FileExists(t, filepath.Join(clone, "local.txt"), "local-ahead work must survive")
+}

--- a/internal/gitutil/safety.go
+++ b/internal/gitutil/safety.go
@@ -81,6 +81,49 @@ func IsRebaseInProgress(repoPath string) bool {
 	return false
 }
 
+// RebaseAge returns how long a rebase has been in progress, based on the
+// mtime of the .git/rebase-merge or .git/rebase-apply directory. The bool is
+// false if no rebase is in progress (age is then meaningless).
+//
+// Used to distinguish a transient, in-flight rebase (seconds old — leave it
+// alone) from a genuinely wedged one abandoned by a prior crash or a rebase
+// that stopped at an "edit"/conflict and was never continued (minutes/days
+// old — safe to auto-recover). A fresh rebase that the daemon's own pull just
+// started must NOT be aborted out from under itself.
+func RebaseAge(repoPath string) (time.Duration, bool) {
+	gitDir := filepath.Join(repoPath, ".git")
+	for _, dir := range []string{"rebase-merge", "rebase-apply"} {
+		p := filepath.Join(gitDir, dir)
+		info, err := os.Stat(p)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue // this backend's dir is absent; check the other
+			}
+			// A genuine stat failure (permission, I/O) is NOT proof the repo is
+			// clean. Treat it conservatively as an in-progress rebase so the
+			// caller skips rather than pulling on a possibly-wedged repo, and
+			// report it as fresh (age 0) so we never auto-abort on a guess.
+			return 0, true
+		}
+		// Use the OLDEST mtime among the dir and its entries. The rebase
+		// metadata files are written once at rebase start and not rewritten
+		// while it sits stuck, but a partial/failed `rebase --abort` can bump
+		// the directory's own mtime to "now". Keying off the oldest entry keeps
+		// a wedge stuck after a failed abort reading as stale on the next cycle,
+		// instead of masking it as "fresh" for another staleRebaseThreshold.
+		oldest := info.ModTime()
+		if entries, derr := os.ReadDir(p); derr == nil {
+			for _, e := range entries {
+				if fi, ferr := e.Info(); ferr == nil && fi.ModTime().Before(oldest) {
+					oldest = fi.ModTime()
+				}
+			}
+		}
+		return time.Since(oldest), true
+	}
+	return 0, false
+}
+
 // IsSafeForGitOps combines lock file and rebase state checks into a single
 // pre-flight check. Returns nil if safe to proceed, or an error describing
 // why the repo is blocked.

--- a/internal/gitutil/safety_test.go
+++ b/internal/gitutil/safety_test.go
@@ -131,6 +131,92 @@ func TestIsRebaseInProgress(t *testing.T) {
 	})
 }
 
+// TestRebaseAge pins the fresh-vs-stale distinction the daemon relies on to
+// decide whether to auto-recover a wedged rebase.
+// Failure prevented: without an age signal the daemon either skips a
+// pre-existing wedge forever (stranding every new session — the original bug)
+// or aborts a rebase its own pull just started seconds ago.
+func TestRebaseAge(t *testing.T) {
+	t.Run("no rebase in progress", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0755))
+
+		_, inProgress := RebaseAge(repo)
+		assert.False(t, inProgress)
+	})
+
+	// A non-ENOENT stat error (here ENOTDIR: .git is a file, not a dir) is NOT
+	// proof the repo is clean. RebaseAge must conservatively report in-progress
+	// so the caller skips rather than pulling on a possibly-wedged repo, and
+	// fresh (age 0) so it never auto-aborts on a guess.
+	t.Run("non-not-exist stat error treated as in-progress fresh", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(repo, ".git"), []byte("not a dir"), 0644))
+
+		age, inProgress := RebaseAge(repo)
+		assert.True(t, inProgress)
+		assert.Equal(t, time.Duration(0), age)
+	})
+
+	t.Run("fresh rebase reports small age", func(t *testing.T) {
+		repo := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git", "rebase-merge"), 0755))
+
+		age, inProgress := RebaseAge(repo)
+		assert.True(t, inProgress)
+		// just-created dir → well under any sane stale threshold
+		assert.Less(t, age, time.Minute)
+	})
+
+	t.Run("stale rebase reports large age via backdated mtime", func(t *testing.T) {
+		repo := t.TempDir()
+		dir := filepath.Join(repo, ".git", "rebase-merge")
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		// backdate the dir mtime to simulate a wedge abandoned an hour ago
+		old := time.Now().Add(-time.Hour)
+		require.NoError(t, os.Chtimes(dir, old, old))
+
+		age, inProgress := RebaseAge(repo)
+		assert.True(t, inProgress)
+		assert.Greater(t, age, 30*time.Minute)
+	})
+
+	// rebase-apply (git am-style / older interactive rebases) hits the same
+	// loop; a typo skipping it would silently bypass stale recovery for that
+	// backend, so pin its stale path independently.
+	t.Run("stale rebase-apply backend reports large age", func(t *testing.T) {
+		repo := t.TempDir()
+		dir := filepath.Join(repo, ".git", "rebase-apply")
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		old := time.Now().Add(-time.Hour)
+		require.NoError(t, os.Chtimes(dir, old, old))
+
+		age, inProgress := RebaseAge(repo)
+		assert.True(t, inProgress)
+		assert.Greater(t, age, 30*time.Minute)
+	})
+
+	// Blind-spot guard: a partial/failed `rebase --abort` can bump the dir's
+	// own mtime to "now" while the rebase metadata files keep their original
+	// (old) mtime. Age must follow the OLDEST entry so a genuinely stuck wedge
+	// still reads as stale instead of looking fresh for another threshold.
+	t.Run("fresh dir mtime but old entry still reads stale", func(t *testing.T) {
+		repo := t.TempDir()
+		dir := filepath.Join(repo, ".git", "rebase-merge")
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		oldFile := filepath.Join(dir, "onto")
+		require.NoError(t, os.WriteFile(oldFile, []byte("deadbeef\n"), 0644))
+		old := time.Now().Add(-time.Hour)
+		require.NoError(t, os.Chtimes(oldFile, old, old)) // metadata file is old
+		now := time.Now()
+		require.NoError(t, os.Chtimes(dir, now, now)) // dir mtime bumped to "now"
+
+		age, inProgress := RebaseAge(repo)
+		assert.True(t, inProgress)
+		assert.Greater(t, age, 30*time.Minute, "age must follow the oldest entry, not the bumped dir mtime")
+	})
+}
+
 func TestIsSafeForGitOps(t *testing.T) {
 	t.Run("clean repo", func(t *testing.T) {
 		repo := t.TempDir()


### PR DESCRIPTION
## What broke

A ledger clone's local git repo can get stuck mid-rebase — a rebase abandoned by a crashed process, or one that stopped at an `edit`/conflict and was never continued. Once that happens, the daemon **never recovers it**:

- `pullManagedRepo` short-circuited at the pre-flight check: *"rebase in progress, skip and return."*
- The recovery ladder (auto-resolve, LLM, `AuditAndAbort`) only runs for a rebase **this same call** just started via `git pull --rebase`. A *pre-existing* wedge never reached it.

Result: a permanent deadlock. Every new session committed locally but could never be pushed, the ledger fell arbitrarily far behind origin, and the sync loop churned on a repo it could never make progress on (the CPU-waste this branch is named for).

This is not hypothetical — it stranded **~6 weeks of sessions** across two real ledgers on a maintainer's machine (one wedged since May 3, one since May 26). The sessions were recorded fine; they just never reached the ledger teammates read.

## Why the old code couldn't recover

```mermaid
flowchart TD
    A["sync cycle starts"] --> B{"rebase in progress?"}
    B -- no --> C["fetch, pull rebase, normal sync"]
    B -- yes --> D["log debug, return Skipped"]
    D --> E["next cycle"]
    E --> A
    C -. "only THIS path reaches" .-> F["recovery ladder:<br/>auto-resolve, LLM, AuditAndAbort"]
    D -. "pre-existing wedge never reaches recovery" .-> G["permanent deadlock<br/>sessions strand, loop churns"]
```

## What this PR ships

A pre-flight that tells a *fresh* in-flight rebase apart from an *abandoned* one and recovers the latter:

```mermaid
flowchart TD
    A2["sync cycle starts"] --> B2{"rebase in progress?"}
    B2 -- no --> C2["normal sync"]
    B2 -- yes --> H2{"older than 5 min?"}
    H2 -- fresh --> D2["skip this cycle and retry later"]
    H2 -- stale --> I2["AuditAndAbort logs what it discards"]
    I2 -- "abort ok" --> K2["clean pull and resync now"]
    I2 -- "abort failed" --> J2["surface IssueTypeRebaseStuck for escalation"]
```

- **`gitutil.RebaseAge(repoPath)`** (new) — returns how long a rebase has been in progress, from the `.git/rebase-merge` / `rebase-apply` dir mtime.
- **`pullManagedRepo`** — a rebase younger than 5 min (almost always the daemon's own concurrent `pull --rebase`) is left alone; a stale wedge is `AuditAndAbort`'d and the cycle falls through to a clean pull, re-syncing immediately. If the abort itself fails, it surfaces `IssueTypeRebaseStuck` so doctor / the scheduled doctor agent task picks it up instead of silently looping.
- **`AuditAndAbort`** is the existing primitive — it logs `head_sha`, unmerged files, and stash count before resetting, so recovery leaves an audit trail (per `.claude/rules/daemon-git.md`). Session data is the store's to re-publish, so the abort is non-destructive in practice.

## Design choices

- **5-minute staleness threshold:** the daemon's own `pull --rebase` completes in seconds, so 5 min cleanly separates "in-flight" from "wedged" and guarantees we never abort a rebase out from under an active operation.
- **Layered, not all-or-nothing:** this fixes the deadlock + CPU spin and auto-recovers the common case. A genuinely *diverged* ledger (local-ahead session commits that conflict with origin — the layout-migration case) is now un-wedged and **surfaced** rather than silently looping; full hands-off resolution (reset-to-origin + republish-from-store) is tracked as a follow-up.

## Test Plan

Recovery is now exercised directly (not just the `RebaseAge` helper), so a regression to "bare skip on rebase in progress" fails the build:

- `TestRecoverPreexistingRebase_StaleWedgeRecovered` — builds a **real** wedged rebase, backdates it past the threshold, asserts it gets aborted/recovered. **Verified it fails without the fix** (neuter the threshold and the wedge is left stuck).
- `TestRecoverPreexistingRebase_FreshRebaseLeftAlone` — a seconds-old rebase (the daemon's own in-flight pull, or a human mid-operation) is skipped, **not** aborted.
- `TestRecoverPreexistingRebase_NoRebase` — clean repo falls through to a normal pull.
- `TestRebaseAge` — none / fresh / stale (backdated mtime) for the helper.
- `go vet` + `gofmt` — clean.
- Note: `TestSyncScheduler_ReacquiresGlobalLeaseAfterOwnerExit` fails in this environment, but it is **pre-existing and environmental** (a live local daemon holds the real per-endpoint global-sync lease); it fails identically on the unmodified base and has zero relation to rebase handling.

## Follow-up

- `ox-eoy3` — escalate an unrecoverable wedge as a rich doctor agent-task (with repo + wedge context), and codify the reset-to-origin + republish-from-store strategy so diverged ledgers also self-heal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stuck in-progress rebases by detecting how long the rebase has been running and distinguishing fresh vs stale (“wedged”) states.
  * Fresh in-progress rebases are skipped; stale wedged rebases are automatically audited and recovered so syncing can continue.
  * If recovery fails, the operation is paused and requires confirmation.

* **Tests**
  * Added coverage for rebase-age detection and recovery across both merge and apply rebase backends, plus integration-style validation that sync resumes correctly after recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->