### PR TITLE
feat(plan): six SVG chart viz patterns + Goose-inspired robustness

### DIFF
--- a/internal/plan/assets/scaffold.css
+++ b/internal/plan/assets/scaffold.css
@@ -309,3 +309,65 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
   .pmapv-row{grid-template-columns:14px 1fr 84px 56px;row-gap:5px}
   .pmapv-off{display:none}
 }
+
+/* --- chart forms: donut / radar / quadrant / treemap / sankey / chord ---
+   Pure computed inline SVG (no Mermaid, no CDN) so they survive the CSP-safe
+   --artifact render. Geometry is computed in the binary; CSS only themes. Every
+   form pairs its color with a non-color channel (legend, value labels, line dash)
+   so it reads in grayscale / under color-vision deficiency. */
+/* shared legend swatch */
+.vsw{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:7px;vertical-align:middle;flex:none}
+/* donut */
+.donut{margin:14px 0}
+.donut figcaption,.radar figcaption,.quad figcaption,.tmap figcaption,.sankey figcaption,.chord figcaption{font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim);margin-bottom:8px}
+.donut-body{display:flex;align-items:center;gap:18px;flex-wrap:wrap}
+.donut-svg{width:140px;height:140px;flex:none}
+.donut-ctr{fill:var(--ink);font-family:"Space Grotesk",sans-serif;font-size:18px;font-weight:600}
+.donut-leg,.radar-leg{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:5px;min-width:150px}
+.donut-leg li{display:flex;align-items:center;font-size:13px}
+.donut-lab{color:var(--ink)}
+.donut-val{margin-left:auto;font-family:"JetBrains Mono",monospace;font-size:11.5px;color:var(--dim);padding-left:14px}
+/* radar */
+.radar{margin:14px 0}
+.radar-body{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+.radar-svg{width:240px;height:232px;flex:none}
+.radar-grid{fill:none;stroke:var(--hair2);stroke-width:1}
+.radar-spoke{stroke:var(--hair2);stroke-width:1}
+.radar-axis{fill:var(--dim);font-family:"JetBrains Mono",monospace;font-size:10px}
+.radar-series{fill-opacity:.12;stroke-width:1.7;stroke-linejoin:round}
+.radar-leg li{display:flex;align-items:center;font-size:13px;color:var(--ink)}
+/* quadrant */
+.quad{margin:14px 0}
+.quad-svg{width:100%;max-width:420px;height:auto}
+.quad-box{fill:var(--panel);stroke:var(--hair2);stroke-width:1}
+.quad-mid{stroke:var(--hair2);stroke-width:1;stroke-dasharray:3 3}
+.quad-pt{stroke:var(--bg);stroke-width:1.5}
+.quad-lab{fill:var(--ink);font-size:11px}
+.quad-axl{fill:var(--dim);font-family:"JetBrains Mono",monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.04em}
+/* treemap */
+.tmap{margin:14px 0}
+.tmap-svg{width:100%;max-width:460px;height:auto;border-radius:8px;overflow:hidden}
+.tmap-cell rect{stroke:var(--bg);stroke-width:1.5;transition:filter .14s}
+.tmap-cell:hover rect{filter:brightness(1.12)}
+.tmap-lab{fill:#0c1112;font-family:"Space Grotesk",sans-serif;font-size:11px;font-weight:600;pointer-events:none}
+.tmap-val{fill:#0c1112;opacity:.78;font-family:"JetBrains Mono",monospace;font-size:9.5px;pointer-events:none}
+.tmap-leg{list-style:none;margin:10px 0 0;padding:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:4px 14px}
+.tmap-leg li{display:flex;align-items:center;font-size:12.5px}
+.tmap-leg-lab{color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.tmap-leg-val{margin-left:auto;font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim);padding-left:8px}
+/* sankey */
+.sankey{margin:14px 0}
+.sankey-svg{width:100%;max-width:520px;height:auto}
+.sankey-link{fill-opacity:.34;transition:fill-opacity .14s}
+.sankey-link:hover{fill-opacity:.6}
+.sankey-lab{fill:var(--ink);font-size:10.5px}
+.sankey-lab.mid{fill:var(--dim);font-size:9.5px}
+/* chord */
+.chord{margin:14px 0}
+.chord-body{display:flex;justify-content:center}
+.chord-svg{width:100%;max-width:300px;height:auto}
+.chord-rib{fill-opacity:.32;transition:fill-opacity .14s}
+.chord-rib:hover{fill-opacity:.62}
+.chord-arc{stroke:var(--bg);stroke-width:1}
+.chord-lab{fill:var(--ink);font-family:"JetBrains Mono",monospace;font-size:9.5px}
+@media(prefers-reduced-motion:reduce){.tmap-cell rect,.sankey-link,.chord-rib{transition:none}}

--- a/internal/plan/assets/scaffold.css
+++ b/internal/plan/assets/scaffold.css
@@ -349,8 +349,8 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .tmap-svg{width:100%;max-width:460px;height:auto;border-radius:8px;overflow:hidden}
 .tmap-cell rect{stroke:var(--bg);stroke-width:1.5;transition:filter .14s}
 .tmap-cell:hover rect{filter:brightness(1.12)}
-.tmap-lab{fill:#0c1112;font-family:"Space Grotesk",sans-serif;font-size:11px;font-weight:600;pointer-events:none}
-.tmap-val{fill:#0c1112;opacity:.78;font-family:"JetBrains Mono",monospace;font-size:9.5px;pointer-events:none}
+.tmap-lab{fill:var(--ink);font-family:"Space Grotesk",sans-serif;font-size:11px;font-weight:600;pointer-events:none}
+.tmap-val{fill:var(--ink);opacity:.78;font-family:"JetBrains Mono",monospace;font-size:9.5px;pointer-events:none}
 .tmap-leg{list-style:none;margin:10px 0 0;padding:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:4px 14px}
 .tmap-leg li{display:flex;align-items:center;font-size:12.5px}
 .tmap-leg-lab{color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}

--- a/internal/plan/assets/viz-catalog.md
+++ b/internal/plan/assets/viz-catalog.md
@@ -319,3 +319,63 @@ why: a branded inline marker + hover beats inventing a circled-`i`/number glyph:
 ```html
 <span class="ox-annot" title="SageOx surfaced: ADR-051 Consent tooling — bundled voiceprint + recording consent; flagged the weaker BIPA position.">ADR-051 <svg class="ox-annot-mark" aria-hidden="true"><use href="#ox-ico-d" class="ico-d"></use><use href="#ox-ico-l" class="ico-l"></use></svg></span>
 ```
+
+## donut
+use: a part-of-whole proportion with a few slices — cost share, test pass/fail, time split. One total, broken down.
+why: a ring reads share pre-attentively and frees the center for the headline total; a paired legend carries exact values + percentages so it survives grayscale. Keep ≤6 slices — beyond that a bar-chart reads cleaner.
+param: {"title":"test outcomes","unit":"","slices":[{"label":"pass","value":182,"color":"sage"},{"label":"fail","value":12,"color":"red"},{"label":"skip","value":24,"color":"slate"}]}
+```html
+<!-- prefer the param renderer: ox plan viz render donut --data donut.json
+     ox computes each slice's arc sweep (value/total·360) + the legend shares. -->
+<figure class="donut"><div class="donut-body"><svg class="donut-svg" viewBox="0 0 140 140"><circle cx="70" cy="70" r="54" fill="none" stroke="var(--sage)" stroke-width="26" stroke-dasharray="254 85" transform="rotate(-90 70 70)"/></svg><ul class="donut-leg"><li><span class="vsw" style="background:var(--sage)"></span><span class="donut-lab">pass</span><span class="donut-val">182 · 83.5%</span></li></ul></div></figure>
+```
+
+## radar
+use: compare a few options across multiple criteria — score each alternative on the same axes to see the shape of its strengths.
+why: overlaid polygons make "which option is strong where" a single shape comparison instead of a table scan; ≤3 series and a per-series line dash keep it legible without relying on color.
+param: {"title":"approach fit","axes":["speed","safety","cost","reuse"],"max":5,"series":[{"label":"native","values":[4,5,2,3],"color":"sage"},{"label":"hybrid","values":[3,4,4,5],"color":"copper"}]}
+```html
+<!-- prefer the param renderer: ox plan viz render radar --data radar.json
+     ox computes each axis spoke angle + the per-series polygon points. -->
+<figure class="radar"><div class="radar-body"><svg class="radar-svg" viewBox="0 0 240 232"><polygon class="radar-series" points="120,40 196,116 120,180 44,116" style="stroke:var(--sage);fill:var(--sage)"/></svg></div></figure>
+```
+
+## quadrant
+use: a two-axis tradeoff scatter — impact vs effort, value vs risk — placing each item in a quadrant so the act-now corner is obvious.
+why: a 2×2 turns "which to do first" into spatial position; the top-corner items pop without reading a single number, and labels keep it readable in grayscale.
+param: {"title":"what to build first","x_label":"effort","y_label":"impact","points":[{"label":"donut","x":2,"y":8,"color":"sage"},{"label":"sankey","x":8,"y":6,"color":"copper"}]}
+```html
+<!-- prefer the param renderer: ox plan viz render quadrant --data quad.json
+     ox normalizes x/y to the plot box and splits the 2×2 at the midlines. -->
+<figure class="quad"><svg class="quad-svg" viewBox="0 0 300 224"><rect class="quad-box" x="50" y="14" width="238" height="182"/><line class="quad-mid" x1="169" y1="14" x2="169" y2="196"/><circle class="quad-pt" cx="98" cy="50" style="fill:var(--sage)"/></svg></figure>
+```
+
+## treemap
+use: a proportional hierarchy where area encodes size — code by package, spend by category, storage by bucket. Size at a glance.
+why: a squarified treemap encodes magnitude as area (the dominant block IS the dominant cost) far denser than a bar list; a legend carries exact sizes so slivers stay readable.
+param: {"title":"repo by package","unit":"KB","items":[{"label":"internal/plan","size":120,"color":"sage"},{"label":"cmd/ox","size":80,"color":"copper"},{"label":"internal/lfs","size":40,"color":"teal"}]}
+```html
+<!-- prefer the param renderer: ox plan viz render treemap --data tmap.json
+     ox runs the squarified layout so each cell's AREA is proportional to size. -->
+<figure class="tmap"><svg class="tmap-svg" viewBox="0 0 320 200" preserveAspectRatio="none"><g class="tmap-cell"><rect x="0" y="0" width="200" height="200" style="fill:var(--sage)"/><text class="tmap-lab" x="6" y="15">internal/plan</text></g></svg></figure>
+```
+
+## sankey
+use: flow magnitude across stages — where tokens, cost, traffic, or users move and split between steps. Conserved quantity, staged.
+why: ribbon width encodes the magnitude flowing along each path, so the dominant route and the leaks read instantly; a node-and-arrow flowchart shows topology but hides the amounts.
+param: {"title":"token budget","unit":"tok","nodes":[{"name":"prompt","color":"sage"},{"name":"tools","color":"copper"},{"name":"output","color":"teal"}],"links":[{"from":"prompt","to":"tools","value":1200},{"from":"prompt","to":"output","value":800},{"from":"tools","to":"output","value":1000}]}
+```html
+<!-- prefer the param renderer: ox plan viz render sankey --data sankey.json
+     ox layers the DAG, sizes nodes by max(in,out), and sets ribbon width ∝ value. -->
+<figure class="sankey"><svg class="sankey-svg" viewBox="0 0 360 240"><path class="sankey-link" d="M67 22 C140 22 140 22 213 22 L213 70 C140 70 140 70 67 70 Z" style="fill:var(--sage)"/><rect class="sankey-node" x="56" y="22" width="11" height="94" style="fill:var(--sage)"/></svg></figure>
+```
+
+## chord
+use: symmetric coupling between entities — which modules, files, or people interact, and how strongly. Who-touches-what.
+why: arcs sized by total coupling and ribbons sized by pairwise strength reveal the tightly-bound cluster a dependency list buries; the circular layout shows mutual relationships a left-to-right graph distorts.
+param: {"title":"module coupling","labels":["api","db","auth","ui"],"matrix":[[0,8,3,2],[8,0,1,0],[3,1,0,4],[2,0,4,0]]}
+```html
+<!-- prefer the param renderer: ox plan viz render chord --data chord.json
+     ox sizes each node arc by its total coupling and each chord by pairwise strength. -->
+<figure class="chord"><div class="chord-body"><svg class="chord-svg" viewBox="0 0 260 260"><path class="chord-arc" d="M130 22 A108 108 0 0 1 226 86 L214 92 A96 96 0 0 0 130 34 Z" style="fill:var(--sage)"/></svg></div></figure>
+```

--- a/internal/plan/diagram_hints.go
+++ b/internal/plan/diagram_hints.go
@@ -307,8 +307,9 @@ func scoreVizSection(heading, body string, cues []string) (int, []string) {
 }
 
 type vizCueSet struct {
-	id   string
-	cues []string
+	id    string
+	param string
+	cues  []string
 }
 
 // computeVizHints returns the strongest few per-section data-viz suggestions.
@@ -322,7 +323,7 @@ func computeVizHints(in Input) []VizHint {
 			continue
 		}
 		if cues := vizUseCues(p.Use); len(cues) > 0 {
-			sets = append(sets, vizCueSet{p.ID, cues})
+			sets = append(sets, vizCueSet{p.ID, p.Param, cues})
 		}
 	}
 	if len(sets) == 0 {
@@ -339,10 +340,10 @@ func computeVizHints(in Input) []VizHint {
 		if strings.TrimSpace(sec.Heading) == "" {
 			continue
 		}
-		bestID, bestScore, bestHits := "", 0, []string(nil)
+		bestID, bestParam, bestScore, bestHits := "", "", 0, []string(nil)
 		for _, s := range sets {
 			if score, hits := scoreVizSection(sec.Heading, sec.Body, s.cues); score > bestScore {
-				bestID, bestScore, bestHits = s.id, score, hits
+				bestID, bestParam, bestScore, bestHits = s.id, s.param, score, hits
 			}
 		}
 		if bestScore < minVizScore || bestID == "" {
@@ -352,6 +353,7 @@ func computeVizHints(in Input) []VizHint {
 			Section:   sec.Heading,
 			PatternID: bestID,
 			Reason:    "section names " + joinAnd(topVizCues(bestHits, 2)),
+			Param:     bestParam,
 		}})
 	}
 	if len(cands) == 0 {

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -122,10 +122,17 @@ type DiagramHint struct {
 // DiagramHint only covers Mermaid/CSS diagram FORMS, leaving the data-viz catalog
 // invisible to content-aware matching. The match signal is DERIVED from each
 // pattern's `use:` line (no separate catalog field) — see computeVizHints.
+//
+// Param carries the matched pattern's `param:` JSON skeleton so the agent goes
+// straight from section→pattern→fill-in-the-blanks, instead of round-tripping
+// `ox plan viz <id>` to recall the shape. This is the most "auto" an autovisualizer
+// can be from INSIDE another coding agent (Claude, Codex, …): ox can't render into a
+// host surface it doesn't own, but it can pre-stage the exact data shape to fill.
 type VizHint struct {
-	Section   string `json:"section"`    // H2 heading the hint applies to
-	PatternID string `json:"pattern_id"` // catalog id, e.g. "risk-matrix" (renderable via `ox plan viz render`)
-	Reason    string `json:"reason"`     // the trigger terms matched, in one clause
+	Section   string `json:"section"`         // H2 heading the hint applies to
+	PatternID string `json:"pattern_id"`      // catalog id, e.g. "risk-matrix" (renderable via `ox plan viz render`)
+	Reason    string `json:"reason"`          // the trigger terms matched, in one clause
+	Param     string `json:"param,omitempty"` // the pattern's `param:` JSON skeleton to fill and render
 }
 
 // Section is one H2-delimited block of a plan, with any file references it cites.

--- a/internal/plan/viz_render.go
+++ b/internal/plan/viz_render.go
@@ -37,17 +37,38 @@ var vizRenderers = map[string]func([]byte) (string, error){
 	"flag-rollout-matrix": renderFlagMatrix,
 	"partition-bar":       renderPartitionBar,
 	"partition-map":       renderPartitionMap,
+	"donut":               renderDonut,
+	"radar":               renderRadar,
+	"quadrant":            renderQuadrant,
+	"treemap":             renderTreemap,
+	"sankey":              renderSankey,
+	"chord":               renderChord,
 }
 
 // RenderViz renders one parameterized pattern from its JSON data into an HTML
 // fragment. Returns an error for an unknown pattern or malformed data so the
 // command layer can show an actionable message.
+//
+// On a render failure (usually a JSON-shape mismatch), the error echoes the
+// pattern's expected `param:` shape from the catalog so the caller — typically an
+// AI coworker driving ox from inside another agent — can self-correct in one shot
+// instead of guessing the schema. (Goose's Auto Visualiser, which has the agent
+// supply the full chart spec, documented exactly this failure mode with no shape
+// hint to recover from; ox supplies data only, and names the shape on a miss.)
 func RenderViz(pattern string, data []byte) (string, error) {
-	r, ok := vizRenderers[strings.ToLower(strings.TrimSpace(pattern))]
+	id := strings.ToLower(strings.TrimSpace(pattern))
+	r, ok := vizRenderers[id]
 	if !ok {
 		return "", fmt.Errorf("pattern %q does not support --data rendering; run `ox plan viz` to see which patterns are parameterized", pattern)
 	}
-	return r(data)
+	out, err := r(data)
+	if err != nil {
+		if p, ok := VizPatternByID(id); ok && p.Param != "" {
+			return "", fmt.Errorf("%w\n  expected shape: %s", err, p.Param)
+		}
+		return "", err
+	}
+	return out, nil
 }
 
 // vizColors is the whitelist of semantic color names a caller may reference;

--- a/internal/plan/viz_render_charts.go
+++ b/internal/plan/viz_render_charts.go
@@ -400,6 +400,12 @@ func layoutStrip(row []float64, s vrect, out *[]vrect) vrect {
 		sum += a
 	}
 	if sum <= 0 {
+		// an all-zero row (zero-size items): emit a zero-area rect PER item so the
+		// result stays one-rect-per-input — callers index rects by item, so a short
+		// slice would index out of bounds. Leave the remaining space unchanged.
+		for range row {
+			*out = append(*out, vrect{s.x, s.y, 0, 0})
+		}
 		return s
 	}
 	if s.w >= s.h {

--- a/internal/plan/viz_render_charts.go
+++ b/internal/plan/viz_render_charts.go
@@ -1,0 +1,872 @@
+package plan
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// viz_render_charts.go holds the SVG chart renderers added to round out the
+// catalog: donut, radar, quadrant, treemap, sankey, chord. Same contract as
+// viz_render.go — the agent supplies DATA, ox computes the GEOMETRY (arc sweeps,
+// polar points, squarified rects, ribbon widths) and emits a self-contained,
+// pure-inline-SVG fragment. Pure SVG (no Mermaid, no CDN) so the fragments survive
+// the CSP-safe `--artifact` render mode, exactly like the sparkline pattern.
+//
+// Every form carries a redundant, non-color channel (a legend, value labels, or
+// shape ordering) so it still reads in grayscale / under color-vision deficiency —
+// the same discipline as the risk-matrix shape glyphs.
+
+// vizPalette is the default categorical color order for charts whose segments are
+// genuinely distinct categories (donut slices, treemap cells, sankey nodes) — used
+// when a datum names no color. Drawn from the same semantic whitelist as colorVar,
+// so it themes with the page and can't inject CSS.
+var vizPalette = []string{"sage", "copper", "teal", "violet", "amber", "slate"}
+
+// paletteColor resolves a datum's color: an explicit (whitelisted) name wins; an
+// empty name cycles the palette by index; an unknown name falls back to sage via
+// colorVar (so a typo can't inject arbitrary CSS — guarded by the whitelist test).
+func paletteColor(name string, i int) string {
+	if strings.TrimSpace(name) == "" {
+		return colorVar(vizPalette[i%len(vizPalette)])
+	}
+	return colorVar(name)
+}
+
+// co formats an SVG coordinate at fixed precision: compact, and deterministic so
+// golden geometry tests assert exact computed points.
+func co(f float64) string { return strconv.FormatFloat(f, 'f', 2, 64) }
+
+// svgPolar maps a center + radius + angle (degrees, 0° = 12 o'clock, increasing
+// clockwise) to an SVG point. SVG y grows downward, so the vertical component is
+// negated to place 0° at the top.
+func svgPolar(cx, cy, r, deg float64) (float64, float64) {
+	rad := deg * math.Pi / 180
+	return cx + r*math.Sin(rad), cy - r*math.Cos(rad)
+}
+
+// --- donut (part-of-whole, few slices) ---
+
+type donutData struct {
+	Title  string `json:"title"`
+	Unit   string `json:"unit"`
+	Center string `json:"center"` // optional center caption; defaults to the total
+	Slices []struct {
+		Label string  `json:"label"`
+		Value float64 `json:"value"`
+		Color string  `json:"color"`
+	} `json:"slices"`
+}
+
+func renderDonut(data []byte) (string, error) {
+	var d donutData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return "", fmt.Errorf("donut data: %w", err)
+	}
+	if len(d.Slices) == 0 {
+		return "", fmt.Errorf("donut: no slices")
+	}
+	total := 0.0
+	for _, s := range d.Slices {
+		if s.Value < 0 {
+			return "", fmt.Errorf("donut: %q has a negative value %s (must be >= 0)", s.Label, fmtNum(s.Value))
+		}
+		total += s.Value
+	}
+	if total <= 0 {
+		return "", fmt.Errorf("donut: total value is zero")
+	}
+	const cx, cy, r, thick = 70.0, 70.0, 54.0, 26.0
+	circ := 2 * math.Pi * r
+
+	var b strings.Builder
+	b.WriteString(`<figure class="donut">`)
+	if d.Title != "" {
+		b.WriteString(`<figcaption>` + esc(d.Title) + `</figcaption>`)
+	}
+	b.WriteString(`<div class="donut-body">`)
+	b.WriteString(`<svg class="donut-svg" viewBox="0 0 140 140" role="img" aria-label="` + esc(d.Title) + `">`)
+	// track ring under the slices
+	fmt.Fprintf(&b, `<circle cx="70" cy="70" r="54" fill="none" stroke="var(--hair2)" stroke-width="%s"/>`, co(thick))
+	acc := 0.0
+	for i, s := range d.Slices {
+		frac := s.Value / total
+		dash := frac * circ
+		gap := 0.0
+		if len(d.Slices) > 1 {
+			gap = math.Min(2.0, dash*0.04) // hairline separator, but never eat a sliver
+		}
+		seg := math.Max(0, dash-gap)
+		rot := acc*360 - 90 // first slice starts at 12 o'clock
+		fmt.Fprintf(&b,
+			`<circle cx="70" cy="70" r="54" fill="none" stroke="%s" stroke-width="%s" stroke-dasharray="%s %s" transform="rotate(%s 70 70)"><title>%s</title></circle>`,
+			paletteColor(s.Color, i), co(thick), co(seg), co(circ-seg), co(rot),
+			esc(s.Label+": "+fmtUnit(d.Unit, s.Value)))
+		acc += frac
+	}
+	center := d.Center
+	if center == "" {
+		center = fmtUnit(d.Unit, total)
+	}
+	b.WriteString(`<text x="70" y="70" class="donut-ctr" text-anchor="middle" dominant-baseline="central">` + esc(center) + `</text>`)
+	b.WriteString(`</svg>`)
+	// legend — redundant, color-independent read (label + value + share)
+	b.WriteString(`<ul class="donut-leg">`)
+	for i, s := range d.Slices {
+		pct := s.Value / total * 100
+		fmt.Fprintf(&b,
+			`<li><span class="vsw" style="background:%s"></span><span class="donut-lab">%s</span><span class="donut-val">%s · %.1f%%</span></li>`,
+			paletteColor(s.Color, i), esc(s.Label), esc(fmtUnit(d.Unit, s.Value)), pct)
+	}
+	b.WriteString(`</ul></div></figure>`)
+	return b.String(), nil
+}
+
+// --- radar (multi-criteria comparison of <= 3 options) ---
+
+type radarData struct {
+	Title  string   `json:"title"`
+	Axes   []string `json:"axes"`
+	Max    float64  `json:"max"` // optional shared scale ceiling; defaults to observed max
+	Series []struct {
+		Label  string    `json:"label"`
+		Values []float64 `json:"values"`
+		Color  string    `json:"color"`
+	} `json:"series"`
+}
+
+func renderRadar(data []byte) (string, error) {
+	var d radarData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return "", fmt.Errorf("radar data: %w", err)
+	}
+	n := len(d.Axes)
+	if n < 3 {
+		return "", fmt.Errorf("radar: need >= 3 axes, got %d", n)
+	}
+	if len(d.Series) == 0 {
+		return "", fmt.Errorf("radar: no series")
+	}
+	if len(d.Series) > 3 {
+		return "", fmt.Errorf("radar: max 3 series for legibility, got %d", len(d.Series))
+	}
+	max := d.Max
+	if max <= 0 {
+		for _, s := range d.Series {
+			for _, v := range s.Values {
+				if v > max {
+					max = v
+				}
+			}
+		}
+	}
+	if max <= 0 {
+		max = 1
+	}
+	for _, s := range d.Series {
+		if len(s.Values) != n {
+			return "", fmt.Errorf("radar: series %q has %d values but there are %d axes", s.Label, len(s.Values), n)
+		}
+		for _, v := range s.Values {
+			if v < 0 {
+				return "", fmt.Errorf("radar: series %q has a negative value", s.Label)
+			}
+		}
+	}
+	const cx, cy, R = 120.0, 116.0, 84.0
+	axisAngle := func(i int) float64 { return float64(i) * 360.0 / float64(n) }
+
+	var b strings.Builder
+	b.WriteString(`<figure class="radar">`)
+	if d.Title != "" {
+		b.WriteString(`<figcaption>` + esc(d.Title) + `</figcaption>`)
+	}
+	b.WriteString(`<div class="radar-body">`)
+	b.WriteString(`<svg class="radar-svg" viewBox="0 0 240 232" role="img" aria-label="` + esc(d.Title) + `">`)
+	// concentric grid rings
+	for _, lvl := range []float64{0.25, 0.5, 0.75, 1.0} {
+		pts := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			x, y := svgPolar(cx, cy, R*lvl, axisAngle(i))
+			pts = append(pts, co(x)+","+co(y))
+		}
+		b.WriteString(`<polygon class="radar-grid" points="` + strings.Join(pts, " ") + `"/>`)
+	}
+	// spokes + axis labels
+	for i := 0; i < n; i++ {
+		x, y := svgPolar(cx, cy, R, axisAngle(i))
+		fmt.Fprintf(&b, `<line class="radar-spoke" x1="%s" y1="%s" x2="%s" y2="%s"/>`, co(cx), co(cy), co(x), co(y))
+		lx, ly := svgPolar(cx, cy, R+12, axisAngle(i))
+		anchor := "middle"
+		if lx > cx+1 {
+			anchor = "start"
+		} else if lx < cx-1 {
+			anchor = "end"
+		}
+		fmt.Fprintf(&b, `<text class="radar-axis" x="%s" y="%s" text-anchor="%s">%s</text>`, co(lx), co(ly+3), anchor, esc(d.Axes[i]))
+	}
+	// series polygons — distinct stroke dash per series (redundant with color so the
+	// options stay distinguishable in grayscale / under CVD)
+	dashes := []string{"", "5 3", "1.5 3"}
+	for si, s := range d.Series {
+		pts := make([]string, 0, n)
+		for i, v := range s.Values {
+			x, y := svgPolar(cx, cy, R*(v/max), axisAngle(i))
+			pts = append(pts, co(x)+","+co(y))
+		}
+		col := paletteColor(s.Color, si)
+		dash := ""
+		if dd := dashes[si%len(dashes)]; dd != "" {
+			dash = ` stroke-dasharray="` + dd + `"`
+		}
+		fmt.Fprintf(&b, `<polygon class="radar-series" points="%s" style="stroke:%s;fill:%s"%s/>`, strings.Join(pts, " "), col, col, dash)
+	}
+	b.WriteString(`</svg>`)
+	// legend
+	b.WriteString(`<ul class="radar-leg">`)
+	for si, s := range d.Series {
+		fmt.Fprintf(&b, `<li><span class="vsw" style="background:%s"></span>%s</li>`, paletteColor(s.Color, si), esc(s.Label))
+	}
+	b.WriteString(`</ul></div></figure>`)
+	return b.String(), nil
+}
+
+// --- quadrant (impact x effort scatter / 2x2) ---
+
+type quadrantData struct {
+	Title  string  `json:"title"`
+	XLabel string  `json:"x_label"`
+	YLabel string  `json:"y_label"`
+	XMax   float64 `json:"x_max"` // optional; defaults to observed max x (min 1)
+	YMax   float64 `json:"y_max"`
+	Points []struct {
+		Label string  `json:"label"`
+		X     float64 `json:"x"`
+		Y     float64 `json:"y"`
+		Color string  `json:"color"`
+	} `json:"points"`
+}
+
+func renderQuadrant(data []byte) (string, error) {
+	var d quadrantData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return "", fmt.Errorf("quadrant data: %w", err)
+	}
+	if len(d.Points) == 0 {
+		return "", fmt.Errorf("quadrant: no points")
+	}
+	xMax, yMax := d.XMax, d.YMax
+	for _, p := range d.Points {
+		if p.X < 0 || p.Y < 0 {
+			return "", fmt.Errorf("quadrant: %q has a negative coordinate (x/y must be >= 0)", p.Label)
+		}
+		if p.X > xMax {
+			xMax = p.X
+		}
+		if p.Y > yMax {
+			yMax = p.Y
+		}
+	}
+	if xMax <= 0 {
+		xMax = 1
+	}
+	if yMax <= 0 {
+		yMax = 1
+	}
+	// plot area inside the viewBox, leaving room for axis labels
+	const x0, y0, pw, ph = 50.0, 14.0, 238.0, 182.0
+	px := func(x float64) float64 { return x0 + (x/xMax)*pw }
+	py := func(y float64) float64 { return y0 + (1-y/yMax)*ph } // invert: up = high
+
+	var b strings.Builder
+	b.WriteString(`<figure class="quad">`)
+	if d.Title != "" {
+		b.WriteString(`<figcaption>` + esc(d.Title) + `</figcaption>`)
+	}
+	b.WriteString(`<svg class="quad-svg" viewBox="0 0 300 224" role="img" aria-label="` + esc(d.Title) + `">`)
+	// plot frame + midlines (the 2x2 split)
+	fmt.Fprintf(&b, `<rect class="quad-box" x="%s" y="%s" width="%s" height="%s"/>`, co(x0), co(y0), co(pw), co(ph))
+	fmt.Fprintf(&b, `<line class="quad-mid" x1="%s" y1="%s" x2="%s" y2="%s"/>`, co(x0+pw/2), co(y0), co(x0+pw/2), co(y0+ph))
+	fmt.Fprintf(&b, `<line class="quad-mid" x1="%s" y1="%s" x2="%s" y2="%s"/>`, co(x0), co(y0+ph/2), co(x0+pw), co(y0+ph/2))
+	// points
+	for i, p := range d.Points {
+		cx, cy := px(p.X), py(p.Y)
+		col := paletteColor(p.Color, i)
+		fmt.Fprintf(&b, `<circle class="quad-pt" cx="%s" cy="%s" r="5" style="fill:%s"><title>%s</title></circle>`,
+			co(cx), co(cy), col, esc(p.Label))
+		anchor := "start"
+		lx := cx + 8
+		if cx > x0+pw*0.7 { // near the right edge, label leftwards so it stays in-frame
+			anchor = "end"
+			lx = cx - 8
+		}
+		fmt.Fprintf(&b, `<text class="quad-lab" x="%s" y="%s" text-anchor="%s">%s</text>`, co(lx), co(cy+3.5), anchor, esc(p.Label))
+	}
+	// axis labels
+	if d.XLabel != "" {
+		fmt.Fprintf(&b, `<text class="quad-axl" x="%s" y="218" text-anchor="middle">%s →</text>`, co(x0+pw/2), esc(d.XLabel))
+	}
+	if d.YLabel != "" {
+		fmt.Fprintf(&b, `<text class="quad-axl" x="14" y="%s" text-anchor="middle" transform="rotate(-90 14 %s)">%s →</text>`, co(y0+ph/2), co(y0+ph/2), esc(d.YLabel))
+	}
+	b.WriteString(`</svg></figure>`)
+	return b.String(), nil
+}
+
+// sortIndexByDesc returns the indices of vals sorted by descending value (stable).
+// Shared by treemap (squarify expects descending) and others.
+func sortIndexByDesc(vals []float64) []int {
+	idx := make([]int, len(vals))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool { return vals[idx[a]] > vals[idx[b]] })
+	return idx
+}
+
+// --- treemap (proportional hierarchy: cell area is proportional to size) ---
+
+type treemapData struct {
+	Title string `json:"title"`
+	Unit  string `json:"unit"`
+	Items []struct {
+		Label string  `json:"label"`
+		Size  float64 `json:"size"`
+		Color string  `json:"color"`
+	} `json:"items"`
+}
+
+// vrect is a geometry rectangle (distinct from the partition segment types).
+type vrect struct{ x, y, w, h float64 }
+
+// squarify lays out scaled `areas` (whose sum equals space.w*space.h) into `space`,
+// returning one vrect per area in input order, using the squarified treemap
+// algorithm (Bruls, Huizing, van Wijk) so cells stay near-square instead of thin
+// slivers. Areas should be descending for the best aspect ratios; the caller sorts
+// and maps the rects back to original items.
+func squarify(areas []float64, space vrect) []vrect {
+	out := make([]vrect, 0, len(areas))
+	s := space
+	i := 0
+	for i < len(areas) {
+		short := math.Min(s.w, s.h)
+		row := []float64{areas[i]}
+		j := i + 1
+		for j < len(areas) {
+			grown := make([]float64, len(row), len(row)+1)
+			copy(grown, row)
+			grown = append(grown, areas[j])
+			if worstAspect(grown, short) <= worstAspect(row, short) {
+				row = grown
+				j++
+			} else {
+				break
+			}
+		}
+		s = layoutStrip(row, s, &out)
+		i = j
+	}
+	return out
+}
+
+// worstAspect returns the worst (largest) aspect ratio among the cells that `row`
+// would form along a strip of length `short` — the quantity squarify minimizes.
+func worstAspect(row []float64, short float64) float64 {
+	sum, mx, mn := 0.0, 0.0, math.MaxFloat64
+	for _, a := range row {
+		sum += a
+		if a > mx {
+			mx = a
+		}
+		if a < mn {
+			mn = a
+		}
+	}
+	if sum <= 0 || short <= 0 {
+		return math.MaxFloat64
+	}
+	s2, sum2 := short*short, sum*sum
+	return math.Max(s2*mx/sum2, sum2/(s2*mn))
+}
+
+// layoutStrip places `row` as one strip along the shorter side of `s`, appends its
+// rects to out, and returns the remaining space.
+func layoutStrip(row []float64, s vrect, out *[]vrect) vrect {
+	sum := 0.0
+	for _, a := range row {
+		sum += a
+	}
+	if sum <= 0 {
+		return s
+	}
+	if s.w >= s.h {
+		thick := sum / s.h // vertical strip on the left
+		y := s.y
+		for _, a := range row {
+			h := a / thick
+			*out = append(*out, vrect{s.x, y, thick, h})
+			y += h
+		}
+		return vrect{s.x + thick, s.y, s.w - thick, s.h}
+	}
+	thick := sum / s.w // horizontal strip on top
+	x := s.x
+	for _, a := range row {
+		w := a / thick
+		*out = append(*out, vrect{x, s.y, w, thick})
+		x += w
+	}
+	return vrect{s.x, s.y + thick, s.w, s.h - thick}
+}
+
+// truncLabel clips a label to roughly the character count a cell of widthPx can
+// hold, so in-cell text never overflows its rectangle.
+func truncLabel(s string, widthPx float64) string {
+	maxCh := int(widthPx / 6.5)
+	r := []rune(s)
+	if len(r) <= maxCh {
+		return s
+	}
+	if maxCh <= 1 {
+		return "…"
+	}
+	return string(r[:maxCh-1]) + "…"
+}
+
+func renderTreemap(data []byte) (string, error) {
+	var d treemapData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return "", fmt.Errorf("treemap data: %w", err)
+	}
+	if len(d.Items) == 0 {
+		return "", fmt.Errorf("treemap: no items")
+	}
+	sizes := make([]float64, len(d.Items))
+	total := 0.0
+	for i, it := range d.Items {
+		if it.Size < 0 {
+			return "", fmt.Errorf("treemap: %q has a negative size %s (must be >= 0)", it.Label, fmtNum(it.Size))
+		}
+		sizes[i] = it.Size
+		total += it.Size
+	}
+	if total <= 0 {
+		return "", fmt.Errorf("treemap: total size is zero")
+	}
+	const W, H = 320.0, 200.0
+	order := sortIndexByDesc(sizes) // descending for squarify; order[k] -> original item
+	areas := make([]float64, len(order))
+	scale := (W * H) / total
+	for k, oi := range order {
+		areas[k] = sizes[oi] * scale
+	}
+	rects := squarify(areas, vrect{0, 0, W, H})
+
+	var b strings.Builder
+	b.WriteString(`<figure class="tmap">`)
+	if d.Title != "" {
+		b.WriteString(`<figcaption>` + esc(d.Title) + `</figcaption>`)
+	}
+	fmt.Fprintf(&b, `<svg class="tmap-svg" viewBox="0 0 %s %s" preserveAspectRatio="none" role="img" aria-label="%s">`, co(W), co(H), esc(d.Title))
+	for k, oi := range order {
+		it := d.Items[oi]
+		rc := rects[k]
+		col := paletteColor(it.Color, k)
+		pct := sizes[oi] / total * 100
+		b.WriteString(`<g class="tmap-cell">`)
+		fmt.Fprintf(&b, `<rect x="%s" y="%s" width="%s" height="%s" style="fill:%s"><title>%s — %s · %.1f%%</title></rect>`,
+			co(rc.x), co(rc.y), co(rc.w), co(rc.h), col, esc(it.Label), esc(fmtUnit(d.Unit, sizes[oi])), pct)
+		if rc.w >= 46 && rc.h >= 24 { // only label cells that can hold text legibly
+			fmt.Fprintf(&b, `<text class="tmap-lab" x="%s" y="%s">%s</text>`, co(rc.x+6), co(rc.y+15), esc(truncLabel(it.Label, rc.w-10)))
+			if rc.h >= 40 {
+				fmt.Fprintf(&b, `<text class="tmap-val" x="%s" y="%s">%s</text>`, co(rc.x+6), co(rc.y+28), esc(fmtUnit(d.Unit, sizes[oi])))
+			}
+		}
+		b.WriteString(`</g>`)
+	}
+	b.WriteString(`</svg>`)
+	// legend — guarantees a color-independent read even for sliver cells (CVD)
+	b.WriteString(`<ul class="tmap-leg">`)
+	for k, oi := range order {
+		it := d.Items[oi]
+		pct := sizes[oi] / total * 100
+		fmt.Fprintf(&b,
+			`<li><span class="vsw" style="background:%s"></span><span class="tmap-leg-lab">%s</span><span class="tmap-leg-val">%s · %.1f%%</span></li>`,
+			paletteColor(it.Color, k), esc(it.Label), esc(fmtUnit(d.Unit, sizes[oi])), pct)
+	}
+	b.WriteString(`</ul></figure>`)
+	return b.String(), nil
+}
+
+// --- sankey (flow magnitude across stages) ---
+
+type sankeyData struct {
+	Title string `json:"title"`
+	Unit  string `json:"unit"`
+	Nodes []struct {
+		Name  string `json:"name"`
+		Color string `json:"color"`
+	} `json:"nodes"`
+	Links []struct {
+		From  string  `json:"from"`
+		To    string  `json:"to"`
+		Value float64 `json:"value"`
+		Color string  `json:"color"`
+	} `json:"links"`
+}
+
+func renderSankey(data []byte) (string, error) {
+	var d sankeyData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return "", fmt.Errorf("sankey data: %w", err)
+	}
+	if len(d.Nodes) == 0 {
+		return "", fmt.Errorf("sankey: no nodes")
+	}
+	if len(d.Links) == 0 {
+		return "", fmt.Errorf("sankey: no links")
+	}
+	idx := make(map[string]int, len(d.Nodes))
+	for i, nd := range d.Nodes {
+		if strings.TrimSpace(nd.Name) == "" {
+			return "", fmt.Errorf("sankey: node %d has no name", i)
+		}
+		if _, dup := idx[nd.Name]; dup {
+			return "", fmt.Errorf("sankey: duplicate node name %q", nd.Name)
+		}
+		idx[nd.Name] = i
+	}
+	type ln struct {
+		s, t  int
+		v     float64
+		color string
+	}
+	links := make([]ln, 0, len(d.Links))
+	for _, l := range d.Links {
+		s, ok1 := idx[l.From]
+		t, ok2 := idx[l.To]
+		if !ok1 {
+			return "", fmt.Errorf("sankey: link references unknown node %q", l.From)
+		}
+		if !ok2 {
+			return "", fmt.Errorf("sankey: link references unknown node %q", l.To)
+		}
+		if l.Value <= 0 {
+			return "", fmt.Errorf("sankey: link %q→%q has value %s (must be > 0)", l.From, l.To, fmtNum(l.Value))
+		}
+		if s == t {
+			return "", fmt.Errorf("sankey: link %q→%q is a self-loop", l.From, l.To)
+		}
+		links = append(links, ln{s, t, l.Value, l.Color})
+	}
+	n := len(d.Nodes)
+	// longest-path layering: layer[t] = max(layer[s]+1). Relax up to n times; still
+	// changing after that means a cycle, which a sankey can't lay out.
+	layer := make([]int, n)
+	for pass := 0; pass < n; pass++ {
+		changed := false
+		for _, l := range links {
+			if layer[l.t] < layer[l.s]+1 {
+				layer[l.t] = layer[l.s] + 1
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+		if pass == n-1 {
+			return "", fmt.Errorf("sankey: links form a cycle (a DAG is required)")
+		}
+	}
+	nLayers := 0
+	for _, lv := range layer {
+		if lv+1 > nLayers {
+			nLayers = lv + 1
+		}
+	}
+	inSum := make([]float64, n)
+	outSum := make([]float64, n)
+	for _, l := range links {
+		outSum[l.s] += l.v
+		inSum[l.t] += l.v
+	}
+	nodeVal := make([]float64, n)
+	for i := range nodeVal {
+		nodeVal[i] = math.Max(inSum[i], outSum[i])
+	}
+	byLayer := make([][]int, nLayers)
+	for i := 0; i < n; i++ {
+		byLayer[layer[i]] = append(byLayer[layer[i]], i)
+	}
+	maxLayerTotal, maxGaps := 0.0, 0
+	for _, mem := range byLayer {
+		t := 0.0
+		for _, i := range mem {
+			t += nodeVal[i]
+		}
+		if t > maxLayerTotal {
+			maxLayerTotal = t
+		}
+		if len(mem)-1 > maxGaps {
+			maxGaps = len(mem) - 1
+		}
+	}
+	if maxLayerTotal <= 0 {
+		maxLayerTotal = 1
+	}
+	const W, plotTop, plotH, nodeW, labelPad = 360.0, 22.0, 196.0, 11.0, 56.0
+	gapPx := 8.0
+	scale := (plotH - float64(maxGaps)*gapPx) / maxLayerTotal
+	if scale <= 0 { // pathological: too many nodes for the gap budget — shrink gaps
+		gapPx = 2.0
+		scale = (plotH - float64(maxGaps)*gapPx) / maxLayerTotal
+	}
+	xOf := func(lyr int) float64 {
+		if nLayers <= 1 {
+			return labelPad
+		}
+		inner := W - 2*labelPad - nodeW
+		return labelPad + float64(lyr)*(inner/float64(nLayers-1))
+	}
+	posInLayer := make([]int, n)
+	ny := make([]float64, n)
+	nh := make([]float64, n)
+	for _, mem := range byLayer {
+		y := plotTop
+		for p, i := range mem {
+			h := nodeVal[i] * scale
+			if h < 1 {
+				h = 1
+			}
+			ny[i], nh[i], posInLayer[i] = y, h, p
+			y += h + gapPx
+		}
+	}
+	// order each node's links so ribbons stack without crossing within a node edge
+	outLinks := make([][]int, n)
+	inLinks := make([][]int, n)
+	for li, l := range links {
+		outLinks[l.s] = append(outLinks[l.s], li)
+		inLinks[l.t] = append(inLinks[l.t], li)
+	}
+	for s := range outLinks {
+		ls := outLinks[s]
+		sort.SliceStable(ls, func(a, b int) bool {
+			la, lb := links[ls[a]], links[ls[b]]
+			if layer[la.t] != layer[lb.t] {
+				return layer[la.t] < layer[lb.t]
+			}
+			return posInLayer[la.t] < posInLayer[lb.t]
+		})
+	}
+	for t := range inLinks {
+		lt := inLinks[t]
+		sort.SliceStable(lt, func(a, b int) bool {
+			la, lb := links[lt[a]], links[lt[b]]
+			if layer[la.s] != layer[lb.s] {
+				return layer[la.s] < layer[lb.s]
+			}
+			return posInLayer[la.s] < posInLayer[lb.s]
+		})
+	}
+	srcY := make([]float64, len(links))
+	tgtY := make([]float64, len(links))
+	for s := range outLinks {
+		oy := ny[s]
+		for _, li := range outLinks[s] {
+			srcY[li] = oy
+			oy += links[li].v * scale
+		}
+	}
+	for t := range inLinks {
+		iy := ny[t]
+		for _, li := range inLinks[t] {
+			tgtY[li] = iy
+			iy += links[li].v * scale
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString(`<figure class="sankey">`)
+	if d.Title != "" {
+		b.WriteString(`<figcaption>` + esc(d.Title) + `</figcaption>`)
+	}
+	fmt.Fprintf(&b, `<svg class="sankey-svg" viewBox="0 0 %s 240" role="img" aria-label="%s">`, co(W), esc(d.Title))
+	for li, l := range links { // ribbons under nodes
+		h := l.v * scale
+		sx := xOf(layer[l.s]) + nodeW
+		tx := xOf(layer[l.t])
+		sy0, ty0 := srcY[li], tgtY[li]
+		mx := (sx + tx) / 2
+		col := paletteColor(l.color, l.s) // default: the source node's palette color
+		fmt.Fprintf(&b,
+			`<path class="sankey-link" d="M%s %s C%s %s %s %s %s %s L%s %s C%s %s %s %s %s %s Z" style="fill:%s"><title>%s → %s: %s</title></path>`,
+			co(sx), co(sy0), co(mx), co(sy0), co(mx), co(ty0), co(tx), co(ty0),
+			co(tx), co(ty0+h), co(mx), co(ty0+h), co(mx), co(sy0+h), co(sx), co(sy0+h),
+			col, esc(d.Nodes[l.s].Name), esc(d.Nodes[l.t].Name), esc(fmtUnit(d.Unit, l.v)))
+	}
+	for i := 0; i < n; i++ { // node bars + labels
+		x := xOf(layer[i])
+		col := paletteColor(d.Nodes[i].Color, i)
+		fmt.Fprintf(&b, `<rect class="sankey-node" x="%s" y="%s" width="%s" height="%s" style="fill:%s"><title>%s: %s</title></rect>`,
+			co(x), co(ny[i]), co(nodeW), co(nh[i]), col, esc(d.Nodes[i].Name), esc(fmtUnit(d.Unit, nodeVal[i])))
+		cy := ny[i] + nh[i]/2 + 3
+		switch layer[i] {
+		case 0: // first stage: label to the left of the node
+			fmt.Fprintf(&b, `<text class="sankey-lab" x="%s" y="%s" text-anchor="end">%s</text>`, co(x-5), co(cy), esc(d.Nodes[i].Name))
+		case nLayers - 1: // last stage: label to the right
+			fmt.Fprintf(&b, `<text class="sankey-lab" x="%s" y="%s" text-anchor="start">%s</text>`, co(x+nodeW+5), co(cy), esc(d.Nodes[i].Name))
+		default: // middle stages: label above to avoid colliding with ribbons
+			fmt.Fprintf(&b, `<text class="sankey-lab mid" x="%s" y="%s" text-anchor="middle">%s</text>`, co(x+nodeW/2), co(ny[i]-4), esc(d.Nodes[i].Name))
+		}
+	}
+	b.WriteString(`</svg></figure>`)
+	return b.String(), nil
+}
+
+// --- chord (symmetric coupling between entities) ---
+
+type chordData struct {
+	Title  string      `json:"title"`
+	Labels []string    `json:"labels"`
+	Matrix [][]float64 `json:"matrix"`
+	Colors []string    `json:"colors"` // optional per-node colors
+}
+
+func colorAt(colors []string, i int) string {
+	if i < len(colors) {
+		return colors[i]
+	}
+	return ""
+}
+
+func renderChord(data []byte) (string, error) {
+	var d chordData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return "", fmt.Errorf("chord data: %w", err)
+	}
+	n := len(d.Labels)
+	if n < 2 {
+		return "", fmt.Errorf("chord: need >= 2 labels, got %d", n)
+	}
+	if len(d.Matrix) != n {
+		return "", fmt.Errorf("chord: matrix has %d rows but there are %d labels", len(d.Matrix), n)
+	}
+	for i, row := range d.Matrix {
+		if len(row) != n {
+			return "", fmt.Errorf("chord: matrix row %d has %d cols, need %d", i, len(row), n)
+		}
+		for _, v := range row {
+			if v < 0 {
+				return "", fmt.Errorf("chord: matrix has a negative value")
+			}
+		}
+	}
+	// coupling is undirected: symmetrize to max(m[i][j], m[j][i]); ignore the diagonal
+	sym := make([][]float64, n)
+	total := make([]float64, n)
+	grand := 0.0
+	for i := 0; i < n; i++ {
+		sym[i] = make([]float64, n)
+		for j := 0; j < n; j++ {
+			if i == j {
+				continue
+			}
+			s := math.Max(d.Matrix[i][j], d.Matrix[j][i])
+			sym[i][j] = s
+			total[i] += s
+		}
+		grand += total[i]
+	}
+	if grand <= 0 {
+		return "", fmt.Errorf("chord: matrix is all zero")
+	}
+	const cx, cy, rInner, rOuter = 130.0, 130.0, 96.0, 108.0
+	gapDeg := 3.0
+	avail := 360.0 - float64(n)*gapDeg
+	if avail < 60 { // very many nodes: shrink the inter-arc gaps to keep arcs visible
+		gapDeg = 1.0
+		avail = 360.0 - float64(n)*gapDeg
+	}
+	arcStart := make([]float64, n)
+	arcW := make([]float64, n)
+	ang := 0.0
+	for i := 0; i < n; i++ {
+		w := total[i] / grand * avail
+		arcStart[i], arcW[i] = ang, w
+		ang += w + gapDeg
+	}
+	cursor := make([]float64, n) // sub-span allocator within each node's arc
+	copy(cursor, arcStart)
+	p := func(a float64) (float64, float64) { return svgPolar(cx, cy, rInner, a) }
+
+	var b strings.Builder
+	b.WriteString(`<figure class="chord">`)
+	if d.Title != "" {
+		b.WriteString(`<figcaption>` + esc(d.Title) + `</figcaption>`)
+	}
+	b.WriteString(`<div class="chord-body">`)
+	b.WriteString(`<svg class="chord-svg" viewBox="0 0 260 260" role="img" aria-label="` + esc(d.Title) + `">`)
+	// chords first (under the arcs); each unordered pair drawn once
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			v := sym[i][j]
+			if v <= 0 {
+				continue
+			}
+			wi := v / total[i] * arcW[i]
+			ai0, ai1 := cursor[i], cursor[i]+wi
+			cursor[i] = ai1
+			wj := v / total[j] * arcW[j]
+			aj0, aj1 := cursor[j], cursor[j]+wj
+			cursor[j] = aj1
+			x1, y1 := p(ai0)
+			x2, y2 := p(ai1)
+			x3, y3 := p(aj0)
+			x4, y4 := p(aj1)
+			col := paletteColor(colorAt(d.Colors, i), i)
+			fmt.Fprintf(&b,
+				`<path class="chord-rib" d="M%s %s A%s %s 0 0 1 %s %s Q%s %s %s %s A%s %s 0 0 1 %s %s Q%s %s %s %s Z" style="fill:%s"><title>%s ↔ %s: %s</title></path>`,
+				co(x1), co(y1), co(rInner), co(rInner), co(x2), co(y2),
+				co(cx), co(cy), co(x3), co(y3),
+				co(rInner), co(rInner), co(x4), co(y4),
+				co(cx), co(cy), co(x1), co(y1),
+				col, esc(d.Labels[i]), esc(d.Labels[j]), fmtNum(v))
+		}
+	}
+	// node arcs (annular band) + radial labels
+	for i := 0; i < n; i++ {
+		if arcW[i] <= 0 {
+			continue
+		}
+		a0, a1 := arcStart[i], arcStart[i]+arcW[i]
+		large := "0"
+		if a1-a0 > 180 {
+			large = "1"
+		}
+		ox0, oy0 := svgPolar(cx, cy, rOuter, a0)
+		ox1, oy1 := svgPolar(cx, cy, rOuter, a1)
+		ix1, iy1 := svgPolar(cx, cy, rInner, a1)
+		ix0, iy0 := svgPolar(cx, cy, rInner, a0)
+		col := paletteColor(colorAt(d.Colors, i), i)
+		fmt.Fprintf(&b,
+			`<path class="chord-arc" d="M%s %s A%s %s 0 %s 1 %s %s L%s %s A%s %s 0 %s 0 %s %s Z" style="fill:%s"><title>%s: %s</title></path>`,
+			co(ox0), co(oy0), co(rOuter), co(rOuter), large, co(ox1), co(oy1),
+			co(ix1), co(iy1), co(rInner), co(rInner), large, co(ix0), co(iy0),
+			col, esc(d.Labels[i]), fmtNum(total[i]))
+		mid := (a0 + a1) / 2
+		lx, ly := svgPolar(cx, cy, rOuter+10, mid)
+		anchor := "middle"
+		if lx > cx+1 {
+			anchor = "start"
+		} else if lx < cx-1 {
+			anchor = "end"
+		}
+		fmt.Fprintf(&b, `<text class="chord-lab" x="%s" y="%s" text-anchor="%s">%s</text>`, co(lx), co(ly+3), anchor, esc(d.Labels[i]))
+	}
+	b.WriteString(`</svg></div></figure>`)
+	return b.String(), nil
+}

--- a/internal/plan/viz_render_charts_test.go
+++ b/internal/plan/viz_render_charts_test.go
@@ -1,0 +1,222 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+)
+
+// viz_render_charts_test.go covers the SVG chart forms (donut, radar, quadrant,
+// treemap, sankey, chord) plus the two robustness wins (shape-echoing errors,
+// hint param skeletons). Each geometry assertion checks a value ox COMPUTES, so a
+// broken layout fails the test rather than passing vacuously.
+
+// TestRenderViz_DonutGeometry verifies slice arc length is computed from the data
+// (a 75% slice's stroke-dasharray ≈ 0.75 of the circumference) and the legend
+// carries the color-independent share read.
+// Failure prevented: an agent-supplied value stops driving the ring.
+func TestRenderViz_DonutGeometry(t *testing.T) {
+	data := `{"unit":"","slices":[{"label":"pass","value":75,"color":"sage"},{"label":"fail","value":25,"color":"teal"}]}`
+	out, err := RenderViz("donut", []byte(data))
+	if err != nil {
+		t.Fatalf("RenderViz: %v", err)
+	}
+	// circumference = 2*pi*54 = 339.292; 75% slice dash = 254.469 minus a 2px gap.
+	if !strings.Contains(out, `stroke-dasharray="252.47`) {
+		t.Errorf("75%% slice dash not computed from value: %s", out)
+	}
+	if !strings.Contains(out, "75.0%") || !strings.Contains(out, "25.0%") {
+		t.Errorf("legend shares missing: %s", out)
+	}
+	if !strings.Contains(out, "var(--sage)") || !strings.Contains(out, "var(--teal)") {
+		t.Errorf("explicit slice colors not applied: %s", out)
+	}
+	if !strings.Contains(out, ">100<") {
+		t.Errorf("center should show the total: %s", out)
+	}
+}
+
+// TestRenderViz_DonutRejectsNegative verifies a negative slice fails loud rather
+// than rendering a broken (negative-length) arc.
+func TestRenderViz_DonutRejectsNegative(t *testing.T) {
+	if _, err := RenderViz("donut", []byte(`{"slices":[{"label":"x","value":-1}]}`)); err == nil {
+		t.Error("expected error for a negative slice value")
+	}
+}
+
+// TestRenderViz_RadarPlotsOnAxis verifies a criterion value maps to the right
+// radius along its axis spoke (computed polar geometry): value 7 of max 10 sits 70%
+// up axis 0, which points straight up from center (120,116) over radius 84.
+func TestRenderViz_RadarPlotsOnAxis(t *testing.T) {
+	out, err := RenderViz("radar", []byte(`{"axes":["a","b","c"],"max":10,"series":[{"label":"x","values":[7,5,5]}]}`))
+	if err != nil {
+		t.Fatalf("RenderViz: %v", err)
+	}
+	// 120, 116 - 84*0.7 = 120, 57.2 — a radius no grid ring sits on, so this proves
+	// the SERIES point, not a coincidental gridline.
+	if !strings.Contains(out, "120.00,57.20") {
+		t.Errorf("criterion not plotted at the computed radius on its axis: %s", out)
+	}
+}
+
+// TestRenderViz_RadarValidates verifies the legibility guards: < 3 axes and a
+// values/axes length mismatch both fail loud.
+func TestRenderViz_RadarValidates(t *testing.T) {
+	if _, err := RenderViz("radar", []byte(`{"axes":["a","b"],"series":[{"label":"x","values":[1,2]}]}`)); err == nil {
+		t.Error("expected error for < 3 axes")
+	}
+	if _, err := RenderViz("radar", []byte(`{"axes":["a","b","c"],"series":[{"label":"x","values":[1,2]}]}`)); err == nil {
+		t.Error("expected error for values/axes length mismatch")
+	}
+}
+
+// TestRenderViz_QuadrantPlacesPoint verifies a point at max x and max y lands in
+// the top-right corner of the plot box (x grows right; y is inverted so high = up).
+func TestRenderViz_QuadrantPlacesPoint(t *testing.T) {
+	out, err := RenderViz("quadrant", []byte(`{"x_label":"effort","y_label":"impact","points":[{"label":"a","x":10,"y":10}]}`))
+	if err != nil {
+		t.Fatalf("RenderViz: %v", err)
+	}
+	if !strings.Contains(out, `cx="288.00" cy="14.00"`) {
+		t.Errorf("max x/y point should sit top-right: %s", out)
+	}
+}
+
+// TestRenderViz_TreemapAreaProportional verifies squarified cell AREA is
+// proportional to size: a size-3 item gets 3x the area of a size-1 item and the
+// two cells tile the whole box.
+// Failure prevented: the treemap stops encoding magnitude as area — its reason to exist.
+func TestRenderViz_TreemapAreaProportional(t *testing.T) {
+	out, err := RenderViz("treemap", []byte(`{"items":[{"label":"big","size":3,"color":"sage"},{"label":"small","size":1,"color":"teal"}]}`))
+	if err != nil {
+		t.Fatalf("RenderViz: %v", err)
+	}
+	// box 320x200 (area 64000); size 3:1 => 48000:16000 => 240x200 and 80x200.
+	if !strings.Contains(out, `width="240.00" height="200.00"`) {
+		t.Errorf("big cell area not proportional: %s", out)
+	}
+	if !strings.Contains(out, `x="240.00"`) || !strings.Contains(out, `width="80.00" height="200.00"`) {
+		t.Errorf("small cell not placed/sized proportionally: %s", out)
+	}
+}
+
+// TestRenderViz_SankeyNodeHeight verifies node heights are computed from flow
+// magnitude (node value = max(in,out), height = value*scale): C carries 4, A
+// carries 3, B carries 1 — heights 188/141/47 at scale 47.
+func TestRenderViz_SankeyNodeHeight(t *testing.T) {
+	data := `{"nodes":[{"name":"A"},{"name":"B"},{"name":"C"}],"links":[{"from":"A","to":"C","value":3},{"from":"B","to":"C","value":1}]}`
+	out, err := RenderViz("sankey", []byte(data))
+	if err != nil {
+		t.Fatalf("RenderViz: %v", err)
+	}
+	if !strings.Contains(out, `height="188.00"`) { // sink node C = max(in 4)
+		t.Errorf("sink node height not computed from flow: %s", out)
+	}
+	if !strings.Contains(out, `height="141.00"`) || !strings.Contains(out, `height="47.00"`) {
+		t.Errorf("source node heights not proportional to flow: %s", out)
+	}
+	if n := strings.Count(out, `class="sankey-link"`); n != 2 {
+		t.Errorf("expected 2 ribbons, got %d", n)
+	}
+	if n := strings.Count(out, `class="sankey-node"`); n != 3 {
+		t.Errorf("expected 3 nodes, got %d", n)
+	}
+}
+
+// TestRenderViz_SankeyRejectsCycle verifies a cyclic link set fails loud — a
+// sankey can't lay out a cycle, and silently dropping links would mislead.
+func TestRenderViz_SankeyRejectsCycle(t *testing.T) {
+	data := `{"nodes":[{"name":"A"},{"name":"B"}],"links":[{"from":"A","to":"B","value":1},{"from":"B","to":"A","value":1}]}`
+	if _, err := RenderViz("sankey", []byte(data)); err == nil {
+		t.Error("expected error for a cyclic flow")
+	}
+}
+
+// TestRenderViz_ChordStructure verifies the matrix becomes one ribbon per
+// unordered pair and one arc per label, and that shape is validated (square matrix,
+// >= 2 labels).
+func TestRenderViz_ChordStructure(t *testing.T) {
+	out, err := RenderViz("chord", []byte(`{"labels":["a","b"],"matrix":[[0,1],[1,0]]}`))
+	if err != nil {
+		t.Fatalf("RenderViz: %v", err)
+	}
+	if n := strings.Count(out, `class="chord-rib"`); n != 1 {
+		t.Errorf("expected 1 ribbon for the single pair, got %d", n)
+	}
+	if n := strings.Count(out, `class="chord-arc"`); n != 2 {
+		t.Errorf("expected 2 node arcs, got %d", n)
+	}
+	if _, err := RenderViz("chord", []byte(`{"labels":["a"],"matrix":[[0]]}`)); err == nil {
+		t.Error("expected error for < 2 labels")
+	}
+	if _, err := RenderViz("chord", []byte(`{"labels":["a","b"],"matrix":[[0,1,2],[1,0,0]]}`)); err == nil {
+		t.Error("expected error for a non-square matrix row")
+	}
+}
+
+// TestRenderViz_ChartsAreArtifactSafe verifies the new SVG forms emit no <script>
+// and no external URL, so they survive the CSP-safe `--artifact` render mode (the
+// same property the sparkline relies on).
+func TestRenderViz_ChartsAreArtifactSafe(t *testing.T) {
+	cases := map[string]string{
+		"donut":    `{"slices":[{"label":"a","value":1}]}`,
+		"radar":    `{"axes":["a","b","c"],"series":[{"label":"x","values":[1,2,3]}]}`,
+		"quadrant": `{"points":[{"label":"a","x":1,"y":2}]}`,
+		"treemap":  `{"items":[{"label":"a","size":1}]}`,
+		"sankey":   `{"nodes":[{"name":"a"},{"name":"b"}],"links":[{"from":"a","to":"b","value":1}]}`,
+		"chord":    `{"labels":["a","b"],"matrix":[[0,1],[1,0]]}`,
+	}
+	for id, data := range cases {
+		out, err := RenderViz(id, []byte(data))
+		if err != nil {
+			t.Fatalf("%s: %v", id, err)
+		}
+		if strings.Contains(out, "<script") {
+			t.Errorf("%s emitted a <script> (breaks CSP --artifact mode)", id)
+		}
+		low := strings.ToLower(out)
+		if strings.Contains(low, "http://") || strings.Contains(low, "https://") {
+			t.Errorf("%s emitted an external URL (breaks CSP --artifact mode)", id)
+		}
+	}
+}
+
+// TestRenderViz_ShapeEchoOnError verifies a JSON-shape mismatch surfaces the
+// pattern's expected `param:` shape (Improvement A) so an agent self-corrects in one
+// shot instead of guessing the schema.
+func TestRenderViz_ShapeEchoOnError(t *testing.T) {
+	_, err := RenderViz("donut", []byte(`{"slices":"not-an-array"}`))
+	if err == nil {
+		t.Fatal("expected an unmarshal error")
+	}
+	if !strings.Contains(err.Error(), "expected shape:") {
+		t.Errorf("error should echo the expected shape: %v", err)
+	}
+	if !strings.Contains(err.Error(), `"slices"`) {
+		t.Errorf("echoed shape should name the data fields: %v", err)
+	}
+}
+
+// TestComputeVizHints_CarriesParamSkeleton verifies a fired viz hint carries the
+// matched pattern's param skeleton (Improvement B) so the agent goes straight to
+// fill-in-the-blanks.
+// Failure prevented: hints name a pattern but force a second `ox plan viz <id>`
+// round-trip to recall the data shape.
+func TestComputeVizHints_CarriesParamSkeleton(t *testing.T) {
+	in := Input{Sections: []Section{{Heading: "Files changed", Body: "new and edited files across the renderer"}}}
+	hints := computeVizHints(in)
+	var fh *VizHint
+	for i := range hints {
+		if hints[i].PatternID == "file-impact-map" {
+			fh = &hints[i]
+		}
+	}
+	if fh == nil {
+		t.Fatalf("expected a file-impact-map hint for a Files-changed section")
+	}
+	if fh.Param == "" {
+		t.Fatal("viz hint should carry the pattern's param skeleton")
+	}
+	if !strings.Contains(fh.Param, "files") {
+		t.Errorf("param skeleton should name the data shape: %s", fh.Param)
+	}
+}

--- a/internal/plan/viz_render_charts_test.go
+++ b/internal/plan/viz_render_charts_test.go
@@ -99,6 +99,29 @@ func TestRenderViz_TreemapAreaProportional(t *testing.T) {
 	}
 }
 
+// TestRenderViz_TreemapZeroSizeItem verifies a zero-size item renders as a
+// zero-area cell instead of panicking, in every position.
+// Failure prevented: squarify dropped the all-zero row, returning fewer rects than
+// items, so rects[k] indexed out of bounds — a runtime panic on any treemap with a 0.
+func TestRenderViz_TreemapZeroSizeItem(t *testing.T) {
+	cases := []string{
+		`{"items":[{"label":"a","size":10},{"label":"z","size":0}]}`,                          // trailing zero
+		`{"items":[{"label":"z","size":0},{"label":"a","size":10}]}`,                          // leading zero
+		`{"items":[{"label":"a","size":10},{"label":"z","size":0},{"label":"b","size":5}]}`,   // middle zero
+		`{"items":[{"label":"a","size":10},{"label":"z1","size":0},{"label":"z2","size":0}]}`, // multiple zeros
+	}
+	for _, data := range cases {
+		out, err := RenderViz("treemap", []byte(data))
+		if err != nil {
+			t.Fatalf("treemap %s: %v", data, err)
+		}
+		// the legend lists every item, so the zero-size label must still appear.
+		if !strings.Contains(out, ">z") && !strings.Contains(out, ">z1") {
+			t.Errorf("zero-size item missing from render: %s", out)
+		}
+	}
+}
+
 // TestRenderViz_SankeyNodeHeight verifies node heights are computed from flow
 // magnitude (node value = max(in,out), height = value*scale): C carries 4, A
 // carries 3, B carries 1 — heights 188/141/47 at scale 47.

--- a/internal/plan/viz_render_test.go
+++ b/internal/plan/viz_render_test.go
@@ -149,6 +149,12 @@ func TestVizCatalog_ParamPatternsRenderable(t *testing.T) {
 		"flag-rollout-matrix": `{"envs":["dev"],"stages":["merge"],"cells":{"dev":{"merge":"100%"}}}`,
 		"partition-bar":       `{"total":100,"unit":"KB","partitions":[{"label":"a","size":60},{"label":"b","size":40}]}`,
 		"partition-map":       `{"unit":"KB","partitions":[{"label":"a","size":60,"offset":"0x0"},{"label":"b","size":4,"proposed":true}]}`,
+		"donut":               `{"slices":[{"label":"a","value":1}]}`,
+		"radar":               `{"axes":["a","b","c"],"series":[{"label":"x","values":[1,2,3]}]}`,
+		"quadrant":            `{"points":[{"label":"a","x":1,"y":2}]}`,
+		"treemap":             `{"items":[{"label":"a","size":1}]}`,
+		"sankey":              `{"nodes":[{"name":"a"},{"name":"b"}],"links":[{"from":"a","to":"b","value":1}]}`,
+		"chord":               `{"labels":["a","b"],"matrix":[[0,1],[1,0]]}`,
 	}
 	for _, p := range VizCatalog() {
 		if p.Param == "" {


### PR DESCRIPTION
## Summary

Rounds out `ox plan viz` with **six new visualization patterns** Goose's Auto Visualiser has but ox lacked, plus two small robustness wins inspired by studying it. Same contract as the rest of the catalog: **the agent supplies data, ox computes the geometry** and emits a self-contained, pure-inline-SVG fragment.

### Background: the Goose comparison

Block's Goose ships an **Auto Visualiser** that auto-detects data, picks a chart, and renders it inline via MCP-UI. Studying it against ox surfaced two **inverted architectures** — and validated ox's bet:

- **Who computes geometry:** Goose has the agent supply the full chart spec (Vega-Lite); ox supplies data only and computes geometry in Go. Goose's own walkthrough documented "deserialization errors… fell back to Mermaid" — exactly the failure ox's design prevents.
- **What's dropped (doesn't fit ox):** *auto-render* (ox runs **inside** Claude/Codex; it can't render into a host surface it doesn't own) and *MCP-UI* (Claude/Codex aren't MCP-UI clients). ox's real "inline" surface is **Claude Code Artifacts** via the existing `--artifact` mode — which is why the new forms are pure SVG.

```mermaid
flowchart LR
  A["AI coworker<br/>(data only)"] --> R["ox plan viz render"]
  R --> G["deterministic geometry in Go<br/>arcs, squarify, ribbons"]
  G --> S["pure inline SVG<br/>no Mermaid, no CDN"]
  S --> H["plan HTML"]
  S --> ART["CSP-safe artifact"]
  E["ox plan enrich"] -. "viz_hints carry the param skeleton" .-> A
```

### What this ships

**Six parametric chart forms** (`ox plan viz render <id> --data`):

| id | fills the gap | geometry ox computes |
|----|---------------|----------------------|
| `donut` | part-of-whole, few slices | arc sweep = value/total |
| `radar` | compare ≤3 options on shared criteria | polar point per axis |
| `quadrant` | impact×effort tradeoff scatter | normalized x/y, 2×2 split |
| `treemap` | proportional hierarchy (area = size) | squarified rects |
| `sankey` | flow magnitude across stages | DAG layering, ribbon width ∝ value |
| `chord` | symmetric coupling / who-touches-what | arc spans + bezier chords |

**Improvement A — shape-echoing render errors.** On a JSON-shape mismatch, `RenderViz` now appends the pattern's expected `param:` shape, so an agent self-corrects in one shot instead of guessing the schema (the precise gap Goose hit).

**Improvement B — hints carry a data skeleton.** `ox plan enrich` viz hints now include the matched pattern's `param:` JSON, turning *section → pattern* into *section → pattern → fill-in-the-blanks*. This is the most "auto" an autovisualizer can be from inside another agent: pre-stage the shape, let the host fill the values.

**Free win:** because `computeVizHints` derives cues from each pattern's `use:` line, the new forms **auto-enroll** in the enrich autovisualizer — `ox plan enrich` now suggests `sankey` for a "Flow" section and `chord` for a "Coupling" section with no extra wiring.

### Design constraints honored

- **Pure computed inline SVG** (no Mermaid, no CDN) so every form survives the CSP-safe `--artifact` render — asserted by a test.
- **Redundant, non-color channel** on every form (legend / value labels / line dash) so it reads in grayscale and under color-vision deficiency — the same discipline as the risk-matrix shape glyphs.
- **No new theme tokens** — reuses the existing semantic color whitelist via `colorVar`, so the theme-drift test stays green and agent-named colors can't inject CSS.

### Files (all under `internal/plan/`)

- `viz_render_charts.go` (new) — the six renderers + shared SVG/squarify helpers
- `viz_render.go` — registry entries + the `RenderViz` shape-echo wrap (A)
- `types.go` + `diagram_hints.go` — `VizHint.Param` skeleton (B)
- `assets/viz-catalog.md` + `assets/scaffold.css` — catalog entries + themed CSS
- `viz_render_charts_test.go` (new) + `viz_render_test.go` — golden geometry + drift samples

## Test Plan

- `go test ./internal/plan/` — **green**. Golden tests assert *computed* geometry (donut dash ≈ 0.75·circumference; radar point on its axis rim; squarified area ∝ size; sankey node height ∝ flow; chord ribbon/arc counts) so a broken layout fails rather than passing vacuously. Drift tests (`TestVizCatalog_ParamPatternsRenderable`, `TestVizRenderers_AllInCatalog`, `TestVizColors_DefinedInBothThemes`) confirm catalog↔renderer↔CSS can't diverge.
- `golangci-lint -c .config/golangci.yml ./internal/plan/...` — **0 issues**.
- CLI smoke: `ox plan viz` lists all six with `DATA ✓`; `ox plan viz render <id> --data` renders correct SVG; bad JSON echoes the expected shape; `ox plan enrich` emits `sankey`/`chord` hints carrying their `param` skeleton.
- Artifact safety asserted: no `<script>`, no external URL in any form.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (golden geometry per form + drift samples + both improvements)
- [ ] CHANGELOG entry — N/A: agent-facing additions to the hidden `ox plan viz` catalog; folds into the next release notes, not a standalone user-facing CLI change
- [x] No breaking change — purely additive (new catalog ids; new optional `VizHint.param` field)
- [ ] `/security-review` — N/A: no `internal/auth`/`internal/mcp`/secrets/`go.sum`; output is pure string-building with `html.EscapeString` on all text and a semantic color whitelist (covered by `TestRenderViz_ColorWhitelist`)

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added six new chart visualization types: donut, radar, quadrant, treemap, sankey, and chord with integrated styling and legends.
  * Charts now include accessibility features with non-color encodings and motion-respecting design preferences.
  * Improved error messages display expected data schemas when visualization rendering fails.

* **Documentation**
  * Added usage guidance for each new chart type with examples and best-practice recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->