### PR TITLE
docs: dependency licensing policy + third-party notices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,18 @@ if HasOxPrimeMarker(gitRoot) { ... }
 
 ---
 
+## Dependency Licensing Policy
+
+**NEVER add copyleft-licensed dependencies to this codebase.** This is a hard rule with no exceptions.
+
+- **Banned licenses:** GPL, LGPL, AGPL, SSPL, EUPL, OSL, CPL, EPL, CC-BY-SA
+- **Allowed licenses:** MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Unlicense, CC0, MPL-2.0, Zlib
+- **MPL-2.0 note:** Allowed because it is file-level copyleft (not project-level), but prefer MIT/Apache/BSD when alternatives exist
+
+Before adding any new `go get` dependency, verify its license. If a dependency transitively pulls in a GPL/LGPL package, find an alternative. When in doubt, check the module's LICENSE file in the Go module cache or on the project's repository.
+
+---
+
 ## Key Policies (Details in `.claude/rules/`)
 
 - **LFS independence:** ox NEVER shells out to `git-lfs` and never commits `.gitattributes` with `filter=lfs`. All LFS operations — pointer detection, parsing, upload, download, hydration — are pure Go in `internal/lfs/`. Talking to GitLab's LFS Batch API goes through `internal/lfs/client.go`, not a subprocess. If a push fails with `LFS objects are missing`, the fix is NEVER `git lfs push --all` — see `.claude/rules/lfs-no-git-lfs-binary.md`

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,233 @@
+# Third-Party Software Notices
+
+This product includes software developed by third parties. The following
+notices are provided in compliance with the license terms of each project.
+
+---
+
+## MIT License
+
+The following components are licensed under the MIT License:
+
+- charm.land/bubbles - Copyright (c) Charmbracelet, Inc.
+- charm.land/bubbletea - Copyright (c) Charmbracelet, Inc.
+- charm.land/glamour - Copyright (c) Charmbracelet, Inc.
+- charm.land/lipgloss - Copyright (c) Charmbracelet, Inc.
+- github.com/AlexanderGrooff/mermaid-ascii - Copyright (c) Alexander Grooff
+- github.com/Microsoft/go-winio - Copyright (c) Microsoft Corporation
+- github.com/alecthomas/chroma - Copyright (c) Alec Thomas
+- github.com/cenkalti/backoff - Copyright (c) Cenk Alti
+- github.com/charmbracelet/colorprofile - Copyright (c) Charmbracelet, Inc.
+- github.com/charmbracelet/ultraviolet - Copyright (c) Charmbracelet, Inc.
+- github.com/charmbracelet/x/ansi - Copyright (c) Charmbracelet, Inc.
+- github.com/charmbracelet/x/term - Copyright (c) Charmbracelet, Inc.
+- github.com/cpuguy83/go-md2man - Copyright (c) Brian Goff
+- github.com/fatih/color - Copyright (c) Fatih Arslan
+- github.com/gin-gonic/gin - Copyright (c) Manu Martinez-Almeida
+- github.com/goccy/go-json - Copyright (c) Masaaki Goshima
+- github.com/joho/godotenv - Copyright (c) John Barton
+- github.com/json-iterator/go - Copyright (c) json-iterator
+- github.com/mattn/go-colorable - Copyright (c) Yasuhiro Matsumoto
+- github.com/mattn/go-isatty - Copyright (c) Yasuhiro Matsumoto
+- github.com/mattn/go-runewidth - Copyright (c) Yasuhiro Matsumoto
+- github.com/muesli/cancelreader - Copyright (c) Christian Muehlhaeuser
+- github.com/odvcencio/gotreesitter - Copyright (c) Contributors
+- github.com/pelletier/go-toml - Copyright (c) Thomas Pelletier
+- github.com/sirupsen/logrus - Copyright (c) Simon Eskildsen
+- github.com/stretchr/testify - Copyright (c) Stretchr, Inc.
+- github.com/testcontainers/testcontainers-go - Copyright (c) Testcontainers
+- github.com/yuin/goldmark - Copyright (c) Yusuke Inuzuka
+- github.com/zalando/go-keyring - Copyright (c) Zalando SE
+- go.etcd.io/bbolt - Copyright (c) Ben Johnson, etcd Authors
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+---
+
+## Apache License 2.0
+
+The following components are licensed under the Apache License, Version 2.0:
+
+- github.com/blevesearch/bleve - Copyright (c) Couchbase, Inc.
+- github.com/bytedance/sonic - Copyright (c) ByteDance, Inc.
+- github.com/containerd/errdefs - Copyright (c) The containerd Authors
+- github.com/containerd/log - Copyright (c) The containerd Authors
+- github.com/containerd/platforms - Copyright (c) The containerd Authors
+- github.com/distribution/reference - Copyright (c) Docker, Inc.
+- github.com/docker/docker - Copyright (c) Docker, Inc.
+- github.com/docker/go-connections - Copyright (c) Docker, Inc.
+- github.com/docker/go-units - Copyright (c) Docker, Inc.
+- github.com/go-git/go-billy - Copyright (c) go-git Authors
+- github.com/go-git/go-git - Copyright (c) go-git Authors
+- github.com/go-logr/logr - Copyright (c) go-logr Authors
+- github.com/golang/groupcache - Copyright (c) Google Inc.
+- github.com/google/pprof - Copyright (c) Google Inc.
+- github.com/inconshreveable/mousetrap - Copyright (c) Alan Shreve
+- github.com/klauspost/compress - Copyright (c) Klaus Post
+- github.com/moby/docker-image-spec - Copyright (c) Moby Project
+- github.com/moby/go-archive - Copyright (c) Moby Project
+- github.com/moby/patternmatcher - Copyright (c) Moby Project
+- github.com/moby/term - Copyright (c) Moby Project
+- github.com/modern-go/concurrent - Copyright (c) Contributors
+- github.com/modern-go/reflect2 - Copyright (c) Contributors
+- github.com/mschoch/smat - Copyright (c) Marty Schoch
+- github.com/oklog/ulid - Copyright (c) OK Log
+- github.com/opencontainers/go-digest - Copyright (c) Open Container Initiative
+- github.com/opencontainers/image-spec - Copyright (c) Open Container Initiative
+- github.com/pjbgf/sha1cd - Copyright (c) Paulo Gomes
+- github.com/spf13/cobra - Copyright (c) Steve Francia
+- go.opentelemetry.io/auto/sdk - Copyright (c) OpenTelemetry Authors
+- go.opentelemetry.io/contrib - Copyright (c) OpenTelemetry Authors
+- go.opentelemetry.io/otel - Copyright (c) OpenTelemetry Authors
+- go.opentelemetry.io/proto/otlp - Copyright (c) OpenTelemetry Authors
+- google.golang.org/genproto - Copyright (c) Google LLC
+- google.golang.org/grpc - Copyright (c) gRPC Authors
+- gopkg.in/ini.v1 - Copyright (c) Unknwon
+- gopkg.in/yaml.v3 - Copyright (c) Canonical Ltd.
+
+> Licensed under the Apache License, Version 2.0 (the "License");
+> you may not use this file except in compliance with the License.
+> You may obtain a copy of the License at
+>
+>     http://www.apache.org/licenses/LICENSE-2.0
+>
+> Unless required by applicable law or agreed to in writing, software
+> distributed under the License is distributed on an "AS IS" BASIS,
+> WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+> See the License for the specific language governing permissions and
+> limitations under the License.
+
+---
+
+## BSD 2-Clause License
+
+The following components are licensed under the BSD 2-Clause License:
+
+- github.com/emirpasic/gods - Copyright (c) Emir Pasic
+- github.com/godbus/dbus - Copyright (c) Georg Reinke
+- github.com/magiconair/properties - Copyright (c) Michael Magiconair
+- github.com/pkg/browser - Copyright (c) Evan Shaw
+- github.com/pkg/errors - Copyright (c) Dave Cheney
+- github.com/russross/blackfriday - Copyright (c) Russ Ross
+
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are met:
+>
+> 1. Redistributions of source code must retain the above copyright notice,
+>    this list of conditions and the following disclaimer.
+> 2. Redistributions in binary form must reproduce the above copyright notice,
+>    this list of conditions and the following disclaimer in the documentation
+>    and/or other materials provided with the distribution.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+> AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+> IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+> ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+> LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+> CONSEQUENTIAL DAMAGES ARISING FROM THE USE OF THIS SOFTWARE.
+
+---
+
+## BSD 3-Clause License
+
+The following components are licensed under the BSD 3-Clause License:
+
+- dario.cat/mergo - Copyright (c) Dario Castane
+- filippo.io/edwards25519 - Copyright (c) Filippo Valsorda
+- github.com/ProtonMail/go-crypto - Copyright (c) ProtonMail AG
+- github.com/bits-and-blooms/bitset - Copyright (c) Will Fitzgerald
+- github.com/cloudflare/circl - Copyright (c) Cloudflare, Inc.
+- github.com/fsnotify/fsnotify - Copyright (c) fsnotify Authors
+- github.com/go-git/gcfg - Copyright (c) go-git Authors
+- github.com/gofrs/flock - Copyright (c) Jason Fiedler
+- github.com/golang/protobuf - Copyright (c) Google Inc.
+- github.com/golang/snappy - Copyright (c) Google Inc.
+- github.com/google/go-cmp - Copyright (c) Google Inc.
+- github.com/google/uuid - Copyright (c) Google Inc.
+- github.com/gorilla/css - Copyright (c) Gorilla Web Toolkit
+- github.com/grpc-ecosystem/grpc-gateway - Copyright (c) gRPC-Gateway Authors
+- github.com/microcosm-cc/bluemonday - Copyright (c) David Kitchen
+- github.com/shirou/gopsutil - Copyright (c) Shirou Wakayama
+- github.com/spf13/pflag - Copyright (c) Alex Ogier, Steve Francia
+- github.com/tklauser/go-sysconf - Copyright (c) Tobias Klauser
+- golang.org/x/arch - Copyright (c) The Go Authors
+- golang.org/x/crypto - Copyright (c) The Go Authors
+- golang.org/x/net - Copyright (c) The Go Authors
+- golang.org/x/sync - Copyright (c) The Go Authors
+- golang.org/x/sys - Copyright (c) The Go Authors
+- golang.org/x/term - Copyright (c) The Go Authors
+- golang.org/x/text - Copyright (c) The Go Authors
+- gonum.org/v1/gonum - Copyright (c) Gonum Authors
+- google.golang.org/protobuf - Copyright (c) Google Inc.
+- modernc.org/sqlite - Copyright (c) Jan Mercl
+- modernc.org/libc - Copyright (c) Jan Mercl
+- modernc.org/mathutil - Copyright (c) Jan Mercl
+- modernc.org/memory - Copyright (c) Jan Mercl
+
+> Redistribution and use in source and binary forms, with or without
+> modification, are permitted provided that the following conditions are met:
+>
+> 1. Redistributions of source code must retain the above copyright notice,
+>    this list of conditions and the following disclaimer.
+> 2. Redistributions in binary form must reproduce the above copyright notice,
+>    this list of conditions and the following disclaimer in the documentation
+>    and/or other materials provided with the distribution.
+> 3. Neither the name of the copyright holder nor the names of its contributors
+>    may be used to endorse or promote products derived from this software
+>    without specific prior written permission.
+>
+> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+> AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+> IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+> ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+> LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+> CONSEQUENTIAL DAMAGES ARISING FROM THE USE OF THIS SOFTWARE.
+
+---
+
+## ISC License
+
+The following components are licensed under the ISC License:
+
+- github.com/davecgh/go-spew - Copyright (c) Dave Collins
+
+> Permission to use, copy, modify, and/or distribute this software for any
+> purpose with or without fee is hereby granted, provided that the above
+> copyright notice and this permission notice appear in all copies.
+>
+> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+> WITH REGARD TO THIS SOFTWARE.
+
+---
+
+## Mozilla Public License 2.0
+
+The following components are licensed under the Mozilla Public License 2.0:
+
+- github.com/go-sql-driver/mysql - Copyright (c) Go-MySQL-Driver Authors
+- github.com/cyphar/filepath-securejoin - Copyright (c) SUSE LLC
+- github.com/hashicorp/golang-lru - Copyright (c) HashiCorp, Inc.
+
+> This Source Code Form is subject to the terms of the Mozilla Public License,
+> v. 2.0. If a copy of the MPL was not distributed with this file, You can
+> obtain one at https://mozilla.org/MPL/2.0/.
+>
+> MPL-2.0 is a file-level copyleft license. If you modify any file originally
+> licensed under MPL-2.0, you must make the modified file available under MPL-2.0.
+> Files you add or your own code that merely uses these libraries are not affected.


### PR DESCRIPTION
## What this PR ships

Salvages two durable artifacts from long-lived local stashes (the only non-superseded content out of 19 audited) into `main`.

- **`AGENTS.md` — Dependency Licensing Policy** (new section): hard rule against copyleft deps for AI coworkers.
  - **Banned:** GPL, LGPL, AGPL, SSPL, EUPL, OSL, CPL, EPL, CC-BY-SA
  - **Allowed:** MIT, Apache-2.0, BSD-2/3-Clause, ISC, Unlicense, CC0, MPL-2.0, Zlib
  - Guidance to verify license before any `go get`, including transitive pulls.
- **`THIRD_PARTY_NOTICES.md`** (new): attribution/notices for bundled third-party dependencies.

## Motivation

A 19-stash audit found almost everything either already merged into `main` or pure beads/config state noise. These two were the only items with real, unmerged value — both licensing-hygiene related, so they ship together as one coherent change. The remaining 17 stashes are being dropped.

## Test Plan

Docs-only; no code paths touched. Nothing to build or test. Render-check `AGENTS.md` section and `THIRD_PARTY_NOTICES.md` on GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added dependency licensing policy guidelines detailing acceptable licenses and verification requirements for new dependencies.
  * Added consolidated third-party software license notices and component attributions across multiple license types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->