### PR TITLE
fix(ledger): disable commit signing on ox-managed repos so sync can't wedge

### DIFF
--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -930,7 +930,12 @@ func checkLedgerRejTracked(fix bool) checkResult {
 		return SkippedCheck(name, "ledger not a git repo", "")
 	}
 
-	if !gitserver.RejFilesTracked(ledgerPath) {
+	tracked, err := gitserver.RejFilesTracked(ledgerPath)
+	if err != nil {
+		return FailedCheck(name, ".rej detection failed",
+			fmt.Sprintf("could not check tracked .rej files: %v", err))
+	}
+	if !tracked {
 		return PassedCheck(name, "no .rej files tracked")
 	}
 
@@ -976,6 +981,20 @@ func checkLedgerRejTracked(fix bool) checkResult {
 	if err != nil && !strings.Contains(out, "nothing to commit") && !strings.Contains(err.Error(), "nothing to commit") {
 		return FailedCheck(name, "commit failed after untracking",
 			fmt.Sprintf("git commit error: %s", strings.TrimSpace(err.Error())))
+	}
+
+	// re-verify before claiming success: EnsureGitignoreBeforeCommit, the
+	// deletion walk, and the commit all tolerate individual failures, so a
+	// tracked .rej could survive every step. Without this guard `ox doctor
+	// --fix` would report a clean repair while the artifacts remain in history.
+	stillTracked, err := gitserver.RejFilesTracked(ledgerPath)
+	if err != nil {
+		return FailedCheck(name, ".rej verification failed",
+			fmt.Sprintf("could not re-check tracked .rej files after commit: %v", err))
+	}
+	if stillTracked {
+		return FailedCheck(name, "fix incomplete",
+			".rej files are still tracked after untrack and commit")
 	}
 
 	return PassedCheck(name, "untracked .rej files from ledger")

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -810,15 +810,15 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 	// without this, git add -A will commit local-only files like sync-state.json.
 	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
 
-	// Persist commit.gpgsign=false into the ledger's local config so this
-	// commit AND every future CLI/daemon commit succeeds. A ledger that
-	// inherited the user's SSH/GPG signing config commits non-interactively
-	// and dies on the passphrase prompt; this is the root cause of a wedged,
-	// non-syncing ledger. Best-effort: the commit below also forces the flag
-	// inline, so a config-write failure doesn't block recovery.
-	if _, err := gitserver.DisableCommitSigning(ledgerPath); err != nil {
-		_ = err
-	}
+	// Persist commit.gpgsign=false into the ledger's local config so every
+	// FUTURE CLI/daemon commit succeeds too. A ledger that inherited the
+	// user's SSH/GPG signing config commits non-interactively and dies on the
+	// passphrase prompt; this is the root cause of a wedged, non-syncing
+	// ledger. The commit below routes through gitutil.RunGit (which forces the
+	// flag inline regardless), so a persistence failure doesn't block THIS
+	// recovery — but we surface it so `ox doctor --fix` doesn't report a clean
+	// repair while the durable fix silently didn't land.
+	_, signErr := gitserver.DisableCommitSigning(ledgerPath)
 
 	// stage all changes
 	// --sparse: ledger repos use sparse-checkout
@@ -829,20 +829,29 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 			fmt.Sprintf("git add error: %s", strings.TrimSpace(string(output))))
 	}
 
-	// commit. -c commit.gpgsign=false guards against a signing config that
-	// DisableCommitSigning couldn't persist (read-only config, etc.).
-	commitCmd := exec.Command("git", "-C", ledgerPath,
-		"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false",
+	// commit via RunGit: it owns the commit.gpgsign=false override plus the
+	// GIT_TERMINAL_PROMPT=0 / cmd.Dir safeguards, so the auto-commit can't
+	// drift from the managed-git execution contract.
+	out, err := gitutil.RunGit(context.Background(), ledgerPath,
 		"commit", "-m", "ox doctor: auto-commit ledger changes")
-	if output, err := commitCmd.CombinedOutput(); err != nil {
-		errStr := strings.TrimSpace(string(output))
-		// "nothing to commit" is fine (race with session auto-stage)
-		if strings.Contains(errStr, "nothing to commit") {
+	if err != nil {
+		// "nothing to commit" is fine (race with session auto-stage). RunGit
+		// folds git's output into the error, so check there.
+		if strings.Contains(out, "nothing to commit") || strings.Contains(err.Error(), "nothing to commit") {
 			return PassedCheck("Ledger clean workdir", "clean (already committed)")
 		}
 		return FailedCheck("Ledger clean workdir",
 			"commit failed",
-			fmt.Sprintf("git commit error: %s", errStr))
+			fmt.Sprintf("git commit error: %s", strings.TrimSpace(err.Error())))
+	}
+
+	// Commit landed, but flag a partial repair: the inline override saved this
+	// commit while the persisted local config didn't take, so future non-ox
+	// commits in this ledger could still wedge.
+	if signErr != nil {
+		return WarningCheck("Ledger clean workdir",
+			fmt.Sprintf("committed %d file(s), but could not persist commit.gpgsign=false", fileCount),
+			fmt.Sprintf("persist signing config: %v — rerun `ox doctor --fix` or set it manually: git -C %s config --local commit.gpgsign false", signErr, ledgerPath))
 	}
 
 	return PassedCheck("Ledger clean workdir",

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"os/exec"
@@ -29,6 +30,7 @@ const (
 	CheckSlugLedgerCleanWorkdir    = "ledger-clean-workdir"
 	CheckSlugLedgerURLAPIMatch     = "ledger-url-api-match"
 	CheckSlugLedgerCacheTracked    = "ledger-cache-tracked"
+	CheckSlugLedgerRejTracked      = "ledger-rej-tracked"
 	// CheckSlugLedgerUnmergedPaths detects an in-progress merge/rebase/cherry-pick
 	// that has left files in U-state. These wedges silently block every future
 	// commit on the ledger (push-summary, doctor auto-commit, session uploads)
@@ -112,6 +114,15 @@ func init() {
 		FixLevel:    FixLevelAuto,
 		Description: "Detects local-only cache files that were accidentally committed to the ledger",
 		Run:         func(fix bool) checkResult { return checkLedgerCacheTracked(fix) },
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugLedgerRejTracked,
+		Name:        "Ledger .rej files untracked",
+		Category:    "Ledger Git Health",
+		FixLevel:    FixLevelAuto,
+		Description: "Detects git apply --reject artifacts (.rej) swept into the ledger",
+		Run:         func(fix bool) checkResult { return checkLedgerRejTracked(fix) },
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
@@ -901,6 +912,73 @@ func checkLedgerCacheTracked(fix bool) checkResult {
 	}
 
 	return PassedCheck(name, "untracked cache files from ledger")
+}
+
+// checkLedgerRejTracked detects *.rej patch-reject artifacts tracked in the
+// ledger. These come from `git apply --reject` during blue-green GC carry and
+// are junk conflict markers, never real ledger content. With fix=true it adds
+// the *.rej ignore, untracks them (git rm --cached, local files preserved),
+// removes the working-tree copies, and commits.
+func checkLedgerRejTracked(fix bool) checkResult {
+	const name = "Ledger .rej files untracked"
+
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger found", "")
+	}
+	if !isGitRepo(ledgerPath) {
+		return SkippedCheck(name, "ledger not a git repo", "")
+	}
+
+	if !gitserver.RejFilesTracked(ledgerPath) {
+		return PassedCheck(name, "no .rej files tracked")
+	}
+
+	if !fix {
+		return WarningCheck(name,
+			".rej patch-reject artifacts are tracked in ledger git history",
+			"run `ox doctor --fix` to untrack and ignore them (local files preserved)")
+	}
+
+	// EnsureGitignoreBeforeCommit now adds the *.rej ignore and untracks any
+	// tracked .rej (git rm --cached). Run it, then delete working-tree copies so
+	// they don't linger as ignored-but-present clutter, then commit the removal.
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
+	// delete the working-tree .rej copies so they don't linger as ignored
+	// clutter (the index removal alone leaves the files on disk).
+	_ = filepath.WalkDir(ledgerPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// regular files only (skip symlinks); ledger tree is ox-managed.
+		if strings.HasSuffix(d.Name(), ".rej") && d.Type().IsRegular() {
+			_ = os.Remove(path) //nolint:gosec // G122: ox-managed ledger tree, symlinks skipped above
+		}
+		return nil
+	})
+
+	// stage the untrack + the updated .gitignore
+	addCmd := exec.Command("git", "-C", ledgerPath, "add", "--sparse", "-A")
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		return FailedCheck(name, "staging failed",
+			fmt.Sprintf("git add error: %s", strings.TrimSpace(string(out))))
+	}
+
+	out, err := gitutil.RunGit(context.Background(), ledgerPath,
+		"commit", "-m", "chore: untrack and ignore .rej patch-reject artifacts")
+	if err != nil && !strings.Contains(out, "nothing to commit") && !strings.Contains(err.Error(), "nothing to commit") {
+		return FailedCheck(name, "commit failed after untracking",
+			fmt.Sprintf("git commit error: %s", strings.TrimSpace(err.Error())))
+	}
+
+	return PassedCheck(name, "untracked .rej files from ledger")
 }
 
 // checkLedgerURLAPIMatch compares the local ledger's git remote URL path against

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -810,6 +810,16 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 	// without this, git add -A will commit local-only files like sync-state.json.
 	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
 
+	// Persist commit.gpgsign=false into the ledger's local config so this
+	// commit AND every future CLI/daemon commit succeeds. A ledger that
+	// inherited the user's SSH/GPG signing config commits non-interactively
+	// and dies on the passphrase prompt; this is the root cause of a wedged,
+	// non-syncing ledger. Best-effort: the commit below also forces the flag
+	// inline, so a config-write failure doesn't block recovery.
+	if _, err := gitserver.DisableCommitSigning(ledgerPath); err != nil {
+		_ = err
+	}
+
 	// stage all changes
 	// --sparse: ledger repos use sparse-checkout
 	addCmd := exec.Command("git", "-C", ledgerPath, "add", "--sparse", "-A")
@@ -819,8 +829,11 @@ func fixLedgerDirtyWorkdir(ledgerPath string, fileCount int) checkResult {
 			fmt.Sprintf("git add error: %s", strings.TrimSpace(string(output))))
 	}
 
-	// commit
-	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "-m", "ox doctor: auto-commit ledger changes")
+	// commit. -c commit.gpgsign=false guards against a signing config that
+	// DisableCommitSigning couldn't persist (read-only config, etc.).
+	commitCmd := exec.Command("git", "-C", ledgerPath,
+		"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false",
+		"commit", "-m", "ox doctor: auto-commit ledger changes")
 	if output, err := commitCmd.CombinedOutput(); err != nil {
 		errStr := strings.TrimSpace(string(output))
 		// "nothing to commit" is fine (race with session auto-stage)

--- a/internal/daemon/sync_gc.go
+++ b/internal/daemon/sync_gc.go
@@ -767,13 +767,47 @@ func (s *SyncScheduler) gcRestoreDiff(ctx context.Context, repoPath, diffFile st
 		return nil
 	}
 
-	// fall back to --reject (applies what it can, creates .rej for conflicts)
+	// fall back to --reject (applies what it can; conflicts go to .rej files)
 	if _, err := gitutil.RunGit(ctx, repoPath, "apply", "--reject", diffFile); err != nil {
 		return fmt.Errorf("git apply failed (diff preserved at %s): %w", diffFile, err)
 	}
 
-	s.logger.Warn("gc: restored uncommitted changes with conflicts (.rej files created)", "path", repoPath)
+	// Delete the .rej artifacts immediately. They are useless conflict markers
+	// that, left in the tree, get swept into ledger history by the broad
+	// `git add -A` commit paths AND keep the checkout permanently "dirty"
+	// (blocking future GC reclone). The complete change is still recoverable
+	// from diffFile, which we surface in the log.
+	removed := removeRejFiles(repoPath)
+	s.logger.Warn("gc: restored uncommitted changes with conflicts; discarded .rej markers",
+		"path", repoPath, "rej_removed", removed, "diff_preserved_at", diffFile)
 	return nil
+}
+
+// removeRejFiles deletes every *.rej file under repoPath (excluding .git) and
+// returns the count removed. Best-effort: individual delete failures are
+// skipped so one unreadable path can't abort the sweep.
+func removeRejFiles(repoPath string) int {
+	removed := 0
+	_ = filepath.WalkDir(repoPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// only regular files (skip symlinks) to avoid following a link out of
+		// the repo; the tree is ox-managed, not adversarial input.
+		if strings.HasSuffix(d.Name(), ".rej") && d.Type().IsRegular() {
+			if os.Remove(path) == nil { //nolint:gosec // G122: ox-managed repo tree, symlinks skipped above
+				removed++
+			}
+		}
+		return nil
+	})
+	return removed
 }
 
 // gcRestoreUntracked copies previously captured untracked files back into the repo.

--- a/internal/daemon/sync_gc_test.go
+++ b/internal/daemon/sync_gc_test.go
@@ -554,3 +554,40 @@ func TestGC_ValidateLedgerGCClone_MissingSessions(t *testing.T) {
 
 	assert.False(t, s.validateLedgerGCClone(dir))
 }
+
+// TestRemoveRejFiles_SweepsTreebutSkipsGit verifies the gc .rej cleanup that
+// runs after `git apply --reject`: every .rej under the repo is deleted (so it
+// can't be committed or block GC), while anything under .git is left untouched.
+// Failure prevented: partial-apply conflict markers polluting ledger history.
+func TestRemoveRejFiles_SweepsTreeButSkipsGit(t *testing.T) {
+	dir := t.TempDir()
+	// .rej files at various depths
+	rejPaths := []string{
+		filepath.Join(dir, "a.rej"),
+		filepath.Join(dir, "sessions", "s1", "meta.json.rej"),
+		filepath.Join(dir, "sessions", "s2", "session.md.rej"),
+	}
+	for _, p := range rejPaths {
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0755))
+		require.NoError(t, os.WriteFile(p, []byte("reject"), 0644))
+	}
+	// a .rej inside .git must NOT be touched
+	gitRej := filepath.Join(dir, ".git", "keep.rej")
+	require.NoError(t, os.MkdirAll(filepath.Dir(gitRej), 0755))
+	require.NoError(t, os.WriteFile(gitRej, []byte("internal"), 0644))
+	// a non-.rej file must survive
+	keep := filepath.Join(dir, "sessions", "s1", "meta.json")
+	require.NoError(t, os.WriteFile(keep, []byte("real"), 0644))
+
+	n := removeRejFiles(dir)
+
+	assert.Equal(t, 3, n, "should remove exactly the 3 tree .rej files")
+	for _, p := range rejPaths {
+		_, err := os.Stat(p)
+		assert.True(t, os.IsNotExist(err), "%s should be deleted", p)
+	}
+	_, err := os.Stat(gitRej)
+	assert.NoError(t, err, ".git/*.rej must be preserved")
+	_, err = os.Stat(keep)
+	assert.NoError(t, err, "non-.rej files must survive")
+}

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -200,6 +200,21 @@ func EnsureGitignoreBeforeCommitCtx(ctx context.Context, repoPath string) {
 	// broad `git add -A`/per-session `add` paths sweep them into ledger history.
 	if err := ensureRootGitignoreEntry(repoPath, rejGitignoreEntry); err != nil {
 		slog.Debug("pre-commit .rej ignore guard failed", "path", repoPath, "error", err)
+	} else {
+		// stage the root .gitignore we just wrote so the caller's commit tracks
+		// it. Symmetric with the *.rej untrack below: both the ignore file and
+		// its untracking must land in the caller's next commit. Callers that
+		// stage narrowly (an explicit pathspec, not `git add -A` — e.g.
+		// commitAndPushLedger / commitPointerRewriteAndPush) would otherwise
+		// leave this newly-written root .gitignore untracked, so the post-commit
+		// worktree stays dirty and trips the pointer-commit clean-worktree
+		// (autostash-race) invariant. --sparse mirrors the untrack ops below
+		// (harmless when no sparse cone is set).
+		addIgnoreCmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+			"add", "--sparse", ".gitignore")
+		if out, err := addIgnoreCmd.CombinedOutput(); err != nil {
+			slog.Debug("pre-commit root .gitignore stage failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
+		}
 	}
 
 	// untrack cache files that were committed before .gitignore existed.

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -59,15 +59,18 @@ func ensureRootGitignoreEntry(repoPath, entry string) error {
 	return os.WriteFile(gitignorePath, []byte(content), 0644)
 }
 
-// RejFilesTracked returns true if any *.rej patch-reject files are tracked by
-// git. Used by doctor to detect .rej artifacts swept into ledger history.
-func RejFilesTracked(repoPath string) bool {
+// RejFilesTracked reports whether any *.rej patch-reject files are tracked by
+// git. Used by doctor to detect .rej artifacts swept into ledger history. A
+// non-nil error means detection itself failed (e.g. git unavailable, not a
+// repo) — callers MUST NOT treat that as "no .rej tracked", or doctor could
+// report a clean ledger when the check never ran.
+func RejFilesTracked(repoPath string) (bool, error) {
 	cmd := exec.Command("git", "-C", repoPath, "ls-files", "*.rej")
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("git ls-files *.rej: %s: %w", strings.TrimSpace(string(out)), err)
 	}
-	return len(strings.TrimSpace(string(out))) > 0
+	return len(strings.TrimSpace(string(out))) > 0, nil
 }
 
 // EnsureCheckoutGitignore ensures .sageox/.gitignore exists in the given repo

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -29,6 +29,47 @@ var checkoutRequiredEntries = []string{
 	"!sync.manifest",
 }
 
+// rejGitignoreEntry is the root-.gitignore pattern that keeps `git apply
+// --reject` patch-reject artifacts out of ledger/team history at any depth.
+const rejGitignoreEntry = "*.rej"
+
+// ensureRootGitignoreEntry appends a single pattern to the repo's ROOT
+// .gitignore if absent. Unlike the .sageox/.gitignore (which only governs
+// files under .sageox/), the root file governs the whole repo — needed for
+// session-dir artifacts like sessions/<id>/meta.json.rej. Idempotent.
+func ensureRootGitignoreEntry(repoPath, entry string) error {
+	if repoPath == "" {
+		return nil
+	}
+	gitignorePath := filepath.Join(repoPath, ".gitignore")
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return nil // already present
+		}
+	}
+	content := string(data)
+	if content != "" && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += entry + "\n"
+	return os.WriteFile(gitignorePath, []byte(content), 0644)
+}
+
+// RejFilesTracked returns true if any *.rej patch-reject files are tracked by
+// git. Used by doctor to detect .rej artifacts swept into ledger history.
+func RejFilesTracked(repoPath string) bool {
+	cmd := exec.Command("git", "-C", repoPath, "ls-files", "*.rej")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return len(strings.TrimSpace(string(out))) > 0
+}
+
 // EnsureCheckoutGitignore ensures .sageox/.gitignore exists in the given repo
 // with required entries to prevent daemon-written files from appearing as untracked.
 // Without this, isCheckoutClean() in the GC path sees these files as dirty and
@@ -154,6 +195,13 @@ func EnsureGitignoreBeforeCommitCtx(ctx context.Context, repoPath string) {
 		slog.Debug("pre-commit gitignore guard failed", "path", repoPath, "error", err)
 	}
 
+	// ensure *.rej is ignored repo-wide. .rej patch-reject files are junk left
+	// by `git apply --reject` (blue-green GC carry); without a root ignore, the
+	// broad `git add -A`/per-session `add` paths sweep them into ledger history.
+	if err := ensureRootGitignoreEntry(repoPath, rejGitignoreEntry); err != nil {
+		slog.Debug("pre-commit .rej ignore guard failed", "path", repoPath, "error", err)
+	}
+
 	// untrack cache files that were committed before .gitignore existed.
 	// --cached removes from git index only, local files are preserved.
 	// --ignore-unmatch avoids errors when nothing is tracked.
@@ -161,6 +209,15 @@ func EnsureGitignoreBeforeCommitCtx(ctx context.Context, repoPath string) {
 		"rm", "--cached", "-r", "--ignore-unmatch", ".sageox/cache/")
 	if out, err := rmCmd.CombinedOutput(); err != nil {
 		slog.Debug("pre-commit cache untrack failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
+	}
+
+	// untrack any .rej files committed before the ignore was in place. Pathspec
+	// '*.rej' matches at any depth; --cached preserves the local files (then
+	// gitignore keeps them out of future commits).
+	rmRejCmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"rm", "--cached", "--ignore-unmatch", "*.rej")
+	if out, err := rmRejCmd.CombinedOutput(); err != nil {
+		slog.Debug("pre-commit .rej untrack failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
 	}
 
 	// untrack root-level codedb/ that was committed before the path was fixed

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -213,9 +213,11 @@ func EnsureGitignoreBeforeCommitCtx(ctx context.Context, repoPath string) {
 
 	// untrack any .rej files committed before the ignore was in place. Pathspec
 	// '*.rej' matches at any depth; --cached preserves the local files (then
-	// gitignore keeps them out of future commits).
+	// gitignore keeps them out of future commits). --sparse is required so the
+	// removal also reaches tracked paths OUTSIDE the sparse-checkout cone
+	// (e.g. data/github/**/*.rej), which git otherwise silently skips.
 	rmRejCmd := exec.CommandContext(ctx, "git", "-C", repoPath,
-		"rm", "--cached", "--ignore-unmatch", "*.rej")
+		"rm", "--cached", "--sparse", "--ignore-unmatch", "*.rej")
 	if out, err := rmRejCmd.CombinedOutput(); err != nil {
 		slog.Debug("pre-commit .rej untrack failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
 	}

--- a/internal/gitserver/gitignore_test.go
+++ b/internal/gitserver/gitignore_test.go
@@ -392,3 +392,59 @@ func TestEnsureRootGitignoreEntry_Idempotent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, strings.Count(string(content), "*.rej"), "entry must be written exactly once")
 }
+
+// TestEnsureGitignoreBeforeCommit_StagesRootGitignore is the regression for the
+// class: the guard WRITES a root .gitignore (the repo-wide *.rej ignore) that a
+// caller staging NARROWLY — an explicit pathspec, not `git add -A` — never
+// commits, so the file lingers untracked and the post-commit worktree is dirty.
+// A dirty worktree here trips the pointer-commit clean-worktree (autostash-race)
+// invariant that guards ledger sync. The guard must therefore stage what it
+// writes, symmetric with its `git rm --cached *.rej` untrack, so the caller's
+// commit tracks it regardless of how narrowly that caller stages.
+//
+// Adversarial design: this commits with a NARROW pathspec (an unrelated file),
+// deliberately NOT `git add -A`. A `-A` commit would sweep up the untracked
+// .gitignore and pass even with the fix reverted — that is exactly the theater
+// this test avoids. Neutering the fix (dropping the guard's `git add .gitignore`)
+// must turn this red at both the staged-index and clean-worktree assertions.
+func TestEnsureGitignoreBeforeCommit_StagesRootGitignore(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--initial-branch=main")
+	runGit(t, dir, "config", "user.name", "test")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	// commit directly here (not via gitutil.RunGit), so neutralize any global
+	// signing config that would hang a non-interactive commit in this test.
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+
+	// the caller's own artifact — staged with an explicit pathspec, mirroring
+	// commitAndPushLedger (meta.json + specific files), NOT a broad `git add -A`.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "payload.txt"), []byte("x"), 0644))
+
+	EnsureGitignoreBeforeCommit(dir)
+
+	// 1. the guard must have STAGED the root .gitignore it wrote — present in the
+	//    index, not merely sitting untracked on disk.
+	staged, err := exec.Command("git", "-C", dir, "diff", "--cached", "--name-only").Output()
+	require.NoError(t, err)
+	assert.Contains(t, strings.Split(strings.TrimSpace(string(staged)), "\n"), ".gitignore",
+		"guard must stage the root .gitignore it writes")
+
+	// 2. the caller stages ONLY its own file, then commits the index. This is the
+	//    narrow-staging path the bug lives on.
+	runGit(t, dir, "add", "--sparse", "payload.txt")
+	runGit(t, dir, "commit", "--no-verify", "-m", "narrow commit")
+
+	// 3. worktree must be clean — no `?? .gitignore` left behind.
+	out, err := exec.Command("git", "-C", dir, "status", "--porcelain").Output()
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(string(out)),
+		"worktree must be clean after a narrow-pathspec commit; an untracked root .gitignore here trips the pointer-commit clean-worktree invariant, got: %s", out)
+
+	// 4. and the root .gitignore is genuinely tracked now (belt to the status check).
+	ls, err := exec.Command("git", "-C", dir, "ls-files", ".gitignore").Output()
+	require.NoError(t, err)
+	assert.NotEmpty(t, strings.TrimSpace(string(ls)), "root .gitignore must be tracked after the commit")
+}

--- a/internal/gitserver/gitignore_test.go
+++ b/internal/gitserver/gitignore_test.go
@@ -353,12 +353,16 @@ func TestEnsureGitignoreBeforeCommit_IgnoresAndUntracksRej(t *testing.T) {
 	runGit(t, dir, "add", relRej)
 	runGit(t, dir, "commit", "-m", "oops: committed a .rej")
 
-	require.True(t, RejFilesTracked(dir), "fixture should leave a tracked .rej")
+	tracked, err := RejFilesTracked(dir)
+	require.NoError(t, err)
+	require.True(t, tracked, "fixture should leave a tracked .rej")
 
 	EnsureGitignoreBeforeCommit(dir)
 
 	// untracked from the index (local file may remain; doctor deletes it)
-	assert.False(t, RejFilesTracked(dir), "EnsureGitignoreBeforeCommit must untrack .rej")
+	tracked, err = RejFilesTracked(dir)
+	require.NoError(t, err)
+	assert.False(t, tracked, "EnsureGitignoreBeforeCommit must untrack .rej")
 
 	// *.rej now ignored repo-wide, so future adds skip it
 	out, err := exec.Command("git", "-C", dir, "check-ignore", relRej).CombinedOutput()
@@ -378,7 +382,9 @@ func TestEnsureGitignoreBeforeCommit_IgnoresAndUntracksRej(t *testing.T) {
 	staged, err := exec.Command("git", "-C", dir, "diff", "--cached", "--name-only").Output()
 	require.NoError(t, err)
 	assert.NotContains(t, string(staged), ".rej", "a broad add must not stage ignored .rej")
-	assert.False(t, RejFilesTracked(dir), "no .rej should be tracked after the sweep")
+	tracked, err = RejFilesTracked(dir)
+	require.NoError(t, err)
+	assert.False(t, tracked, "no .rej should be tracked after the sweep")
 }
 
 // TestEnsureRootGitignoreEntry_Idempotent verifies the root-.gitignore writer

--- a/internal/gitserver/gitignore_test.go
+++ b/internal/gitserver/gitignore_test.go
@@ -330,3 +330,65 @@ func TestEnsureCheckoutGitignore_WithSparseCheckout(t *testing.T) {
 	assert.Empty(t, strings.TrimSpace(string(output)),
 		"gitignore should be committed, not untracked")
 }
+
+// TestEnsureGitignoreBeforeCommit_IgnoresAndUntracksRej is the regression for
+// .rej patch-reject artifacts polluting ledger history. The class: any junk a
+// broad `git add -A` can sweep in must be ignored repo-wide and untracked once
+// detected. Failure prevented: blue-green GC `git apply --reject` artifacts
+// committed into the ledger forever.
+func TestEnsureGitignoreBeforeCommit_IgnoresAndUntracksRej(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init", "--initial-branch=main")
+	runGit(t, dir, "config", "user.name", "test")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+
+	// commit a .rej deep in a session dir, mirroring the real pollution path
+	relRej := filepath.Join("sessions", "2026-01-01T00-00-x", "meta.json.rej")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, filepath.Dir(relRej)), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, relRej), []byte("<<<<<<< reject"), 0644))
+	runGit(t, dir, "add", relRej)
+	runGit(t, dir, "commit", "-m", "oops: committed a .rej")
+
+	require.True(t, RejFilesTracked(dir), "fixture should leave a tracked .rej")
+
+	EnsureGitignoreBeforeCommit(dir)
+
+	// untracked from the index (local file may remain; doctor deletes it)
+	assert.False(t, RejFilesTracked(dir), "EnsureGitignoreBeforeCommit must untrack .rej")
+
+	// *.rej now ignored repo-wide, so future adds skip it
+	out, err := exec.Command("git", "-C", dir, "check-ignore", relRej).CombinedOutput()
+	require.NoError(t, err, "check-ignore should match: %s", out)
+	assert.Equal(t, relRej, strings.TrimSpace(string(out)))
+
+	// commit the untrack (clears the staged deletion), then drop a FRESH .rej
+	// and prove a broad `git add -A` won't sweep it back into the index.
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-m", "untrack .rej")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, relRej), []byte("new reject"), 0644))
+	fresh := filepath.Join("sessions", "2026-02-02T00-00-y", "session.md.rej")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, filepath.Dir(fresh)), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fresh), []byte("another"), 0644))
+
+	runGit(t, dir, "add", "-A")
+	staged, err := exec.Command("git", "-C", dir, "diff", "--cached", "--name-only").Output()
+	require.NoError(t, err)
+	assert.NotContains(t, string(staged), ".rej", "a broad add must not stage ignored .rej")
+	assert.False(t, RejFilesTracked(dir), "no .rej should be tracked after the sweep")
+}
+
+// TestEnsureRootGitignoreEntry_Idempotent verifies the root-.gitignore writer
+// appends once and is a no-op on repeat — so repeated daemon/doctor passes
+// don't grow the file.
+func TestEnsureRootGitignoreEntry_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, ensureRootGitignoreEntry(dir, "*.rej"))
+	require.NoError(t, ensureRootGitignoreEntry(dir, "*.rej"))
+	content, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(string(content), "*.rej"), "entry must be written exactly once")
+}

--- a/internal/gitserver/helper_config.go
+++ b/internal/gitserver/helper_config.go
@@ -134,31 +134,70 @@ func readGitConfig(repoPath, key string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// MigrateLedgerCredentials performs the one-shot migration for a single
-// ledger: strip any embedded oauth2:TOKEN from the origin URL, then install
-// the ox credential helper for the resulting bare host. Idempotent — safe
-// to invoke on every daemon startup.
+// DisableCommitSigning forces commit and tag signing OFF in a single repo's
+// .git/config. ox-managed repos (ledgers, team contexts) are committed
+// non-interactively by the daemon and CLI; if they inherit a user's global
+// commit.gpgsign=true with an SSH/GPG signing key, every commit blocks on a
+// passphrase prompt that has no TTY to answer it and dies with
+// "fatal: failed to write commit object". The result is silent: sessions
+// stage but never commit, never push, never sync.
 //
-// Returns ok=true if the migration ran (either stripped or installed or
-// both); ok=false if there was nothing to do. The error result is reserved
-// for genuine failures (git command errors, malformed origin URLs).
+// Writing the override into the repo's LOCAL config (not --global) keeps the
+// user's own repos free to sign while guaranteeing ox-managed repos never do.
+// Idempotent: skips the write when both keys already read "false".
+func DisableCommitSigning(repoPath string) (changed bool, err error) {
+	for _, key := range []string{"commit.gpgsign", "tag.gpgsign"} {
+		// readGitConfig walks all config levels, so an inherited global
+		// "true" is what we compare against — a local "false" already in
+		// place reads back as "false" and we skip.
+		if current, rerr := readGitConfig(repoPath, key); rerr == nil && current == "false" {
+			continue
+		}
+		cmd := exec.Command("git", "-C", repoPath, "config", "--local", key, "false")
+		if output, cerr := cmd.CombinedOutput(); cerr != nil {
+			return changed, fmt.Errorf("git config --local %s false: %s: %w",
+				key, strings.TrimSpace(string(output)), cerr)
+		}
+		changed = true
+	}
+	return changed, nil
+}
+
+// MigrateLedgerCredentials performs the one-shot migration for a single
+// ledger: disable commit signing, strip any embedded oauth2:TOKEN from the
+// origin URL, then install the ox credential helper for the resulting bare
+// host. Idempotent — safe to invoke on every daemon startup.
+//
+// Returns ok=true if the migration ran (signing disabled, stripped, or
+// installed); ok=false if there was nothing to do. The error result is
+// reserved for genuine failures (git command errors, malformed origin URLs).
 func MigrateLedgerCredentials(repoPath string, helperCmd string) (changed bool, err error) {
+	// 0. Disable commit/tag signing FIRST, unconditionally. This must run
+	// even for repos with no/SSH/file origin (which return early below),
+	// because a wedged signing config blocks local commits regardless of
+	// the remote. Self-heals existing repos on the next daemon sweep.
+	if signChanged, serr := DisableCommitSigning(repoPath); serr != nil {
+		return false, fmt.Errorf("disable commit signing: %w", serr)
+	} else if signChanged {
+		changed = true
+	}
+
 	// 1. Read origin URL; bail cleanly for SSH / file:// / missing remotes.
 	pat, remoteURL, err := extractPATFromRemote(repoPath)
 	if err != nil {
 		// No origin or unreadable config — nothing to migrate, but not a
 		// hard error. Callers (daemon startup) shouldn't fail because of one
-		// weird ledger.
-		return false, nil
+		// weird ledger. Preserve any signing change made above.
+		return changed, nil
 	}
 	if remoteURL == "" {
-		return false, nil
+		return changed, nil
 	}
 
 	// Only migrate https:// remotes with the ox-managed oauth2 prefix.
 	parsed, err := url.Parse(remoteURL)
 	if err != nil || parsed.Scheme != "https" {
-		return false, nil
+		return changed, nil
 	}
 
 	// 2. Strip embedded PAT if present (no-op if origin is already bare).

--- a/internal/gitserver/helper_config.go
+++ b/internal/gitserver/helper_config.go
@@ -116,6 +116,25 @@ func InstallCredentialHelper(repoPath string, cfg HelperConfig) error {
 	return nil
 }
 
+// readGitConfigLocal reads a single config value from the repo's LOCAL
+// .git/config only (ignoring global/system scopes); returns ("", nil) when the
+// key has no local override. Use this when the persistence of a repo-local
+// override matters and an inherited value must NOT count as "already set".
+func readGitConfigLocal(repoPath, key string) (string, error) {
+	cmd := exec.Command("git", "-C", repoPath, "config", "--local", "--get", key)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		// exit 1 = key absent locally (or no local config file yet); treat as
+		// a clean "no local value" so callers persist the override.
+		if asErr(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // readGitConfig reads a single config value; returns ("", nil) when the
 // key is absent (git exits 1 with empty output in that case).
 func readGitConfig(repoPath, key string) (string, error) {
@@ -144,13 +163,16 @@ func readGitConfig(repoPath, key string) (string, error) {
 //
 // Writing the override into the repo's LOCAL config (not --global) keeps the
 // user's own repos free to sign while guaranteeing ox-managed repos never do.
-// Idempotent: skips the write when both keys already read "false".
+// Idempotent: skips the write when the key is already "false" in the repo's
+// LOCAL config specifically.
 func DisableCommitSigning(repoPath string) (changed bool, err error) {
 	for _, key := range []string{"commit.gpgsign", "tag.gpgsign"} {
-		// readGitConfig walks all config levels, so an inherited global
-		// "true" is what we compare against — a local "false" already in
-		// place reads back as "false" and we skip.
-		if current, rerr := readGitConfig(repoPath, key); rerr == nil && current == "false" {
+		// Read the repo-LOCAL value only, not the merged config. A merged
+		// "false" can come from a global/system scope while the repo has no
+		// local override at all — skipping on that would leave the managed
+		// repo unprotected, so a later global flip to "true" re-wedges it.
+		// Only a persisted local "false" means the repair is already in place.
+		if current, rerr := readGitConfigLocal(repoPath, key); rerr == nil && current == "false" {
 			continue
 		}
 		cmd := exec.Command("git", "-C", repoPath, "config", "--local", key, "false")
@@ -194,9 +216,15 @@ func MigrateLedgerCredentials(repoPath string, helperCmd string) (changed bool, 
 		return changed, nil
 	}
 
-	// Only migrate https:// remotes with the ox-managed oauth2 prefix.
+	// Only migrate https:// remotes with the ox-managed oauth2 prefix. A
+	// malformed origin URL is genuine misconfig worth surfacing (per the
+	// "genuine failures" contract above) — don't fold it into the non-HTTPS
+	// no-op, or callers like doctor never learn the remote is broken.
 	parsed, err := url.Parse(remoteURL)
-	if err != nil || parsed.Scheme != "https" {
+	if err != nil {
+		return changed, fmt.Errorf("parse origin URL %q: %w", remoteURL, err)
+	}
+	if parsed.Scheme != "https" {
 		return changed, nil
 	}
 

--- a/internal/gitserver/helper_config_test.go
+++ b/internal/gitserver/helper_config_test.go
@@ -1,9 +1,13 @@
 package gitserver
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCredentialHelperArgs verifies the shared credential-helper argv used by
@@ -21,4 +25,86 @@ func TestCredentialHelperArgs(t *testing.T) {
 		"-c", "credential.helper=",
 		"-c", "credential.helper=!ox git-credential-helper",
 	}, args)
+}
+
+// gitRepoWithBrokenSigning builds a real git repo whose local config enables
+// SSH commit signing with a signing key that can't be used non-interactively
+// — the exact state that wedges a ledger: commit dies with "failed to write
+// commit object" because the signing key passphrase prompt has no TTY.
+func gitRepoWithBrokenSigning(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir // never mutate the real repo's identity/config
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	run("init")
+	run("config", "--local", "user.name", "Test")
+	run("config", "--local", "user.email", "test@example.com")
+	// point at a signing key that forces a passphrase/agent interaction that
+	// fails in this headless test — reproduces the production wedge.
+	bogusKey := filepath.Join(dir, "nonexistent_signing_key")
+	run("config", "--local", "gpg.format", "ssh")
+	run("config", "--local", "user.signingkey", bogusKey)
+	run("config", "--local", "commit.gpgsign", "true")
+	return dir
+}
+
+func tryCommit(t *testing.T, dir string, extraArgs ...string) error {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644))
+	add := exec.Command("git", "add", "-A")
+	add.Dir = dir
+	require.NoError(t, add.Run())
+	args := append(append([]string{}, extraArgs...), "commit", "-m", "probe")
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	return cmd.Run()
+}
+
+// TestDisableCommitSigning_UnwedgesSignedRepo proves the recovery contract for
+// the whole class of "ox-managed repo inherited the user's commit signing and
+// can't commit non-interactively". Failure prevented: ledger/team commits die
+// with "failed to write commit object", sessions stage but never sync.
+func TestDisableCommitSigning_UnwedgesSignedRepo(t *testing.T) {
+	dir := gitRepoWithBrokenSigning(t)
+
+	// Sanity: with signing on, the commit genuinely fails. If this ever
+	// starts passing, the fixture no longer reproduces the bug.
+	require.Error(t, tryCommit(t, dir), "expected signed commit to fail in headless env")
+
+	changed, err := DisableCommitSigning(dir)
+	require.NoError(t, err)
+	assert.True(t, changed, "first disable should mutate config")
+
+	// Now the same commit succeeds — the wedge is cleared persistently.
+	require.NoError(t, tryCommit(t, dir), "commit should succeed after signing disabled")
+
+	got, err := readGitConfig(dir, "commit.gpgsign")
+	require.NoError(t, err)
+	assert.Equal(t, "false", got)
+
+	// Idempotent: a second call is a no-op (no further mutation).
+	changed, err = DisableCommitSigning(dir)
+	require.NoError(t, err)
+	assert.False(t, changed, "second disable should be a no-op")
+}
+
+// TestMigrateLedgerCredentials_DisablesSigningWithoutRemote proves the
+// self-heal fires for repos that have no migratable https origin (the early
+// return paths) — signing must still be disabled so a freshly-set-up or
+// SSH-origin ledger isn't left wedged.
+func TestMigrateLedgerCredentials_DisablesSigningWithoutRemote(t *testing.T) {
+	dir := gitRepoWithBrokenSigning(t) // no origin remote configured
+
+	changed, err := MigrateLedgerCredentials(dir, "!ox git-credential-helper")
+	require.NoError(t, err)
+	assert.True(t, changed, "signing change should be reported even with no remote")
+
+	got, err := readGitConfig(dir, "commit.gpgsign")
+	require.NoError(t, err)
+	assert.Equal(t, "false", got)
+	require.NoError(t, tryCommit(t, dir), "commit should succeed post-migrate")
 }

--- a/internal/gitserver/helper_config_test.go
+++ b/internal/gitserver/helper_config_test.go
@@ -92,6 +92,70 @@ func TestDisableCommitSigning_UnwedgesSignedRepo(t *testing.T) {
 	assert.False(t, changed, "second disable should be a no-op")
 }
 
+// gitRepoWithInheritedSigning builds a repo with NO local signing config whose
+// signing is enabled purely through an inherited global config (GIT_CONFIG_GLOBAL
+// pointed at a temp file) — the actual production wedge, where the user's
+// ~/.config/git/config sets commit.gpgsign=true and managed repos inherit it.
+// Returns the repo path; the caller's git subprocesses inherit the temp global
+// via t.Setenv, so DisableCommitSigning sees the inherited "true".
+func gitRepoWithInheritedSigning(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	globalCfg := filepath.Join(home, "global.gitconfig")
+	// isolate from the real machine config for every git subprocess in this test
+	t.Setenv("GIT_CONFIG_GLOBAL", globalCfg)
+	t.Setenv("GIT_CONFIG_SYSTEM", filepath.Join(home, "no-system"))
+
+	setGlobal := func(k, v string) {
+		cmd := exec.Command("git", "config", "--file", globalCfg, k, v)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git config --file: %s", out)
+	}
+	setGlobal("gpg.format", "ssh")
+	setGlobal("user.signingkey", filepath.Join(home, "nope"))
+	setGlobal("commit.gpgsign", "true")
+
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"-C", dir, "init"},
+		{"-C", dir, "config", "--local", "user.name", "Test"},
+		{"-C", dir, "config", "--local", "user.email", "test@example.com"},
+	} {
+		require.NoError(t, exec.Command("git", args...).Run())
+	}
+	return dir
+}
+
+// TestDisableCommitSigning_PersistsLocalDespiteInheritedConfig is the core
+// regression for the CodeRabbit major finding: the skip check must read the
+// repo-LOCAL value, not the merged value. With signing enabled via inherited
+// global config, DisableCommitSigning must still write a local "false" so the
+// repair is durable against a later global change. Failure prevented: a managed
+// repo left unprotected because the merged read saw an inherited value.
+func TestDisableCommitSigning_PersistsLocalDespiteInheritedConfig(t *testing.T) {
+	dir := gitRepoWithInheritedSigning(t)
+
+	// merged read sees the inherited "true"; local read sees no override yet.
+	merged, err := readGitConfig(dir, "commit.gpgsign")
+	require.NoError(t, err)
+	assert.Equal(t, "true", merged, "inherited global signing should be visible via merged read")
+	local, err := readGitConfigLocal(dir, "commit.gpgsign")
+	require.NoError(t, err)
+	assert.Empty(t, local, "repo must start with no local override")
+
+	// sanity: a raw commit fails because it inherits the (unusable) signing key
+	require.Error(t, tryCommit(t, dir), "inherited signing should fail the commit")
+
+	changed, err := DisableCommitSigning(dir)
+	require.NoError(t, err)
+	assert.True(t, changed, "must persist a local override even when merged config already reads true")
+
+	local, err = readGitConfigLocal(dir, "commit.gpgsign")
+	require.NoError(t, err)
+	assert.Equal(t, "false", local, "local override must be written so the repair survives global changes")
+	require.NoError(t, tryCommit(t, dir), "commit should succeed after local signing disabled")
+}
+
 // TestMigrateLedgerCredentials_DisablesSigningWithoutRemote proves the
 // self-heal fires for repos that have no migratable https origin (the early
 // return paths) — signing must still be disabled so a freshly-set-up or

--- a/internal/gitutil/run.go
+++ b/internal/gitutil/run.go
@@ -16,6 +16,15 @@ func RunGit(ctx context.Context, repoPath string, args ...string) (string, error
 	if repoPath != "" {
 		cmdArgs = append(cmdArgs, "-C", repoPath)
 	}
+	// commit.gpgsign=false / tag.gpgsign=false: ox only ever commits its own
+	// machine-managed repos (ledgers, team contexts, murmurs) and always does
+	// so non-interactively. If the user's git config enables SSH/GPG commit
+	// signing with a passphrase-protected key, signing prompts on a TTY that
+	// the daemon and CLI fallbacks don't have, and the commit dies with
+	// "fatal: failed to write commit object" — silently wedging ledger sync.
+	// Overriding per-invocation makes ox's commits immune regardless of the
+	// repo's persisted config. Harmless no-op for non-commit subcommands.
+	cmdArgs = append(cmdArgs, "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false")
 	cmdArgs = append(cmdArgs, args...)
 
 	cmd := exec.CommandContext(ctx, "git", cmdArgs...)

--- a/internal/gitutil/run_test.go
+++ b/internal/gitutil/run_test.go
@@ -64,6 +64,34 @@ func TestRunGit(t *testing.T) {
 		assert.Contains(t, output, "git version")
 	})
 
+	t.Run("commit succeeds despite inherited signing config", func(t *testing.T) {
+		// Reproduces the ledger-wedge class: a repo whose config enables SSH
+		// commit signing with an unusable key. A bare `git commit` dies with
+		// "failed to write commit object"; RunGit must override it inline so
+		// ox's machine-managed commits never depend on a TTY passphrase prompt.
+		repo := t.TempDir()
+		setup := [][]string{
+			{"-C", repo, "init", "--quiet"},
+			{"-C", repo, "config", "--local", "user.name", "Test"},
+			{"-C", repo, "config", "--local", "user.email", "test@example.com"},
+			{"-C", repo, "config", "--local", "gpg.format", "ssh"},
+			{"-C", repo, "config", "--local", "user.signingkey", filepath.Join(repo, "nope")},
+			{"-C", repo, "config", "--local", "commit.gpgsign", "true"},
+		}
+		for _, a := range setup {
+			require.NoError(t, exec.Command("git", a...).Run())
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("x"), 0o644))
+		require.NoError(t, exec.Command("git", "-C", repo, "add", "-A").Run())
+
+		// sanity: a raw signed commit fails in this headless env
+		require.Error(t, exec.Command("git", "-C", repo, "commit", "-m", "raw").Run())
+
+		// RunGit's injected -c commit.gpgsign=false clears the wedge
+		_, err := RunGit(context.Background(), repo, "commit", "-m", "via RunGit")
+		assert.NoError(t, err)
+	})
+
 	t.Run("output is auto-sanitized", func(t *testing.T) {
 		// create a repo with a remote that has credentials embedded
 		repo := t.TempDir()


### PR DESCRIPTION
## What broke

Every ox-managed git commit — session finalization, murmurs, LFS pointers — silently failed, so sessions recorded to disk but never reached the remote. `ox status` showed mounting `uncommitted` counts (sageox-mono **200**, speaker **204**, ox **140 staged + 38 pending**); the daemon logged `Sync suspended after N consecutive failures`.

Root cause: a user's `~/.config/git/config` (XDG) set `commit.gpgsign=true` with an SSH/GPG signing key. Ledger and team-context repos **inherit** that config. ox commits them **non-interactively** (daemon + CLI), so git's signing-key passphrase prompt has no TTY to answer and the commit dies with:

```
error: Load key "/Users/.../.ssh/git": incorrect passphrase ...
fatal: failed to write commit object
```

Commit fails → changes stay staged → never pushed → never sync. Silent, because nothing surfaces the signing failure except `ox doctor`.

```mermaid
flowchart TD
  A["user XDG git config<br/>commit.gpgsign=true"] --> B{"ox-managed commit<br/>(daemon / CLI, no TTY)"}
  B --> C["git tries to SSH-sign"]
  C --> D["passphrase prompt, no TTY"]
  D --> E["fatal: failed to write commit object"]
  E --> F["changes staged, never committed"]
  F --> G["never pushed to remote"]
  G --> H["sync suspended, sessions stranded on disk"]
```

## Why signing is wrong here, not just inconvenient

Ledger commits are **machine-authored** (`finalize session`, `murmur:`, `lfs: pointerize`). There is no human to attest to, no verifier of ledger signatures, and the remote is already access-controlled by PAT/OAuth. Signing them with the user's **personal** key is semantically incorrect and can only ever break a non-interactive commit. Uniform-off on ox-managed repos is the correct posture; the user's own repos are untouched and still sign normally.

## What this PR ships

Three layers, defense in depth — signing can't wedge sync regardless of config state:

- **`internal/gitutil/run.go`** — `RunGit` injects `-c commit.gpgsign=false -c tag.gpgsign=false` on every invocation. Stateless per-command immunity for ox's own commits; harmless no-op for non-commit subcommands.
- **`internal/gitserver/helper_config.go`** — new `DisableCommitSigning(repoPath)`, called first in `MigrateLedgerCredentials` (which already runs per-repo on daemon startup, ledger clone, and doctor). Persists `commit.gpgsign=false` into each managed repo's **local** config. This **self-heals existing wedged repos** on the next daemon sweep and fixes the ~22 direct `exec.Command` commit sites without touching them (they inherit the local override). Runs even on the no-remote / SSH-origin early-return paths.
- **`cmd/ox/doctor_ledger_git.go`** — `ox doctor --fix` persists the signing repair and forces the flag inline while flushing the backlog (last-line-of-defense recovery).

Scope is limited to ox-managed repos (ledgers, team contexts, murmurs). The user's source repos are never modified, so personal commit signing keeps working where it carries meaning.

## Test Plan

- `TestDisableCommitSigning_UnwedgesSignedRepo` — builds a real repo with SSH signing + an unusable key; a bare `git commit` genuinely fails, the fix makes it pass; asserts persisted `false` and idempotency.
- `TestMigrateLedgerCredentials_DisablesSigningWithoutRemote` — proves the self-heal fires on the no-https-origin early-return path.
- `TestRunGit/commit_succeeds_despite_inherited_signing_config` — proves the exec-layer injection un-wedges a signed repo via `RunGit`.
- Each fixture reproduces the real wedge (signed commit fails without the fix) so the tests guard the failure **class**, not one patch.
- Full suites green: `internal/daemon`, `internal/gitserver`, `internal/gitutil`, `cmd/ox`. `make lint` → 0 issues.

**Verified live:** flushed the local backlog — ox / sageox-mono / speaker ledgers all now `✓ synced` and pushed; signing disabled on all 14 team-context repos.

Co-Authored-By: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented git operations from getting stuck on signing/passphrase prompts by ensuring signing is disabled during git commands and persistently disabling it for future ledger commits when needed.
  * Ledger doctor now detects and fixes `git apply --reject` artifacts (`*.rej`) by cleaning them up and ensuring they won’t be reintroduced.
  * Improved conflict-reject handling by sweeping and removing generated `*.rej` files after fixes.
* **New Features**
  * Added an additional ledger doctor check to handle tracked `*.rej` files.
* **Tests**
  * Added coverage for commit-signing disabling, idempotency, and `*.rej` untracking/sweeping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update: also fixes `.rej` patch-reject pollution (ox-vxi2)

While verifying the flush, found ledgers carried **tracked `.rej` files** (ox=5, sageox-mono=49, speaker=35) — `git apply --reject` artifacts from blue-green GC carry, swept into history by the broad `git add -A` commit paths and also keeping the checkout permanently "dirty" (blocking future GC).

```mermaid
flowchart TD
  A["blue-green GC reclone"] --> B["gcRestoreDiff: git apply --3way"]
  B -->|conflict| C["fallback git apply --reject"]
  C --> D["leaves *.rej in tree"]
  D --> E["git add -A sweeps .rej into ledger"]
  D --> F["tree stays dirty, blocks next GC"]
```

Fix, three layers:
- **Source** — `gcRestoreDiff` deletes the `.rej` markers right after the `--reject` apply (the full change is still recoverable from the preserved diff file, surfaced in the log).
- **Prevention** — `*.rej` added to the ledger **root** `.gitignore` (the existing `.sageox/.gitignore` only governs `.sageox/`), so every staging path — `git add -A` and per-session `git add <dir>/` — skips them.
- **Cleanup** — `EnsureGitignoreBeforeCommit` untracks tracked `.rej` via `git rm --cached --sparse` (the `--sparse` reaches cone-excluded paths like `data/github/**`), and a new `ledger-rej-tracked` doctor check (auto-fix) untracks + deletes + commits.

**Verified live:** ox / sageox-mono / speaker now `tracked_rej=0`.

Tests: `TestEnsureGitignoreBeforeCommit_IgnoresAndUntracksRej` (untrack + ignore + a fresh `.rej` won't re-stage), `TestEnsureRootGitignoreEntry_Idempotent`, `TestRemoveRejFiles_SweepsTreeButSkipsGit` (deletes tree `.rej`, preserves `.git/`).

Closes ox-vxi2. (Separate: the daemon's `session meta re-summarization errored=8` is unrelated to `.rej` and left for its own investigation.)