### PR TITLE
feat(plan): steer to ox plan render on HTML-plan intent, any mode

### DIFF
--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -503,15 +503,15 @@ func handlePrompt(ctx *HookContext) error {
 	// begins right after the plan was approved.
 	emitPlanNudge(os.Stdout, ctx.ProjectRoot, agentID)
 
-	// While the agent is still IN plan mode (permission_mode == "plan"), steer it
-	// to fold `ox plan enrich --json` team context into the plan BEFORE presenting
-	// — once per plan-mode entry. Complements the plan-EXIT nudge above. Gold-tier
-	// only (gated on the permission mode Claude Code reports); fail-open.
+	// Steer the agent toward `ox plan enrich`/`ox plan render` at the planning
+	// moment — fired when the agent is in plan mode (permission_mode == "plan")
+	// OR the prompt asks to render an HTML plan, once per planning episode.
+	// Complements the plan-EXIT nudge above. Fail-open.
 	var rawPrompt []byte
 	if ctx.Input != nil {
 		rawPrompt = ctx.Input.RawBytes
 	}
-	emitPlanModeHint(os.Stdout, ctx.ProjectRoot, agentID, rawPrompt)
+	emitPlanHint(os.Stdout, ctx.ProjectRoot, agentID, rawPrompt)
 
 	emitWhispers(os.Stdout, agentID)
 

--- a/cmd/ox/agent_hook_plan_mode_nudge.go
+++ b/cmd/ox/agent_hook_plan_mode_nudge.go
@@ -8,31 +8,42 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sageox/ox/internal/config"
 )
 
-// In-plan-mode enrichment hint (Gold tier — Claude Code).
+// Just-in-time plan-rendering steer (Claude Code / Gold tier for the plan-mode
+// trigger; agent-agnostic for the HTML-intent trigger).
 //
 // The plan-exit nudge (agent_hook_plan_nudge.go) fires AFTER the plan is
-// presented. This hint fires WHILE the agent is still drafting, so the
-// deterministic `ox plan enrich --json` team context (collisions, prior art,
-// expert routing) is folded into the plan BEFORE it reaches the human — not
-// bolted on after. Prime carries the same guidance, but in a long context that
-// guidance is diluted; a crisp, just-in-time reminder at the planning moment is
-// what actually changes behavior.
+// presented. This hint fires WHILE the agent is still drafting — or the moment
+// the user asks for an HTML plan — so the deterministic `ox plan enrich --json`
+// team context (collisions, prior art, expert routing) is folded into the plan
+// BEFORE it reaches the human, and the render goes through `ox plan render`
+// instead of a hand-rolled orphan. Prime carries the same guidance, but in a
+// long context that guidance is diluted; a crisp, just-in-time reminder at the
+// planning moment is what actually changes behavior.
+//
+// Two independent triggers, one throttle:
+//   - PLAN MODE: permission_mode == "plan". Claude Code is the only agent that
+//     reports a permission mode, so this trigger is implicitly Gold-only.
+//   - HTML-PLAN INTENT: the user's prompt asks to render a plan as an HTML /
+//     visual page, in ANY permission mode. This is the gap the plan-mode-only
+//     gate missed: most HTML-plan requests ("make me an html plan for X") arrive
+//     outside plan mode, where the plan-mode trigger never fires and the agent
+//     reaches for a generic html-plan skill or hand-rolls a context-blind render.
 //
 // Delivery channel: UserPromptSubmit stdout is the ONLY channel Claude Code
 // injects into model context (see the table in agent_hook.go). Claude Code's
 // UserPromptSubmit payload carries the active permission mode — snake_case
 // `permission_mode` in the hook stdin, camelCase `permissionMode` in the
-// transcript. We decode both defensively. Value "plan" == plan mode.
+// transcript — and the `prompt` text. We decode both defensively.
 //
-// Gold-tier gating is implicit: only Claude Code sends a permission mode, so for
-// every other agent extractPermissionMode returns "" and this is a clean no-op.
-//
-// Throttle: fire exactly once per plan-mode entry. A per-agent stamp file marks
-// "already hinted this entry"; it is cleared the moment a non-plan prompt
-// arrives, so re-entering plan mode re-hints. This avoids hinting on every
-// prompt during a long plan-mode session while still re-firing on each entry.
+// Throttle: fire exactly once per planning episode. A per-agent stamp file marks
+// "already hinted this episode"; it is cleared the moment a prompt arrives that
+// triggers neither path, so a fresh plan-mode entry or a new HTML-plan request
+// re-hints. This avoids hinting on every prompt during a long session while
+// still re-firing on each genuine planning moment.
 //
 // Everything here is best-effort and fail-open: any decode/IO failure leaves the
 // existing hook behavior untouched. The hint is purely additive.
@@ -42,11 +53,32 @@ const (
 	// user is in plan mode.
 	planModeValue = "plan"
 
-	// planModeHintCacheSubdir holds the per-agent "already hinted this entry"
+	// planModeHintCacheSubdir holds the per-agent "already hinted this episode"
 	// stamp under the ledger cache (.sageox/cache/). Local-only derived data,
-	// never committed.
+	// never committed. (Name retained for cache stability; the stamp now covers
+	// both the plan-mode and HTML-intent triggers.)
 	planModeHintCacheSubdir = "plan-mode-hint"
 )
+
+// htmlPlanIntentPhrases are the curated phrases that signal the user wants a plan
+// rendered as an HTML / visual page. Matched case-insensitively as substrings.
+// Each phrase embeds both a plan noun and a render/visual cue so it is
+// self-disambiguating; a false positive costs at most one throttled reminder.
+var htmlPlanIntentPhrases = []string{
+	"html plan",
+	"html-plan", // covers "/html-plan" (the slash command)
+	"plan as html",
+	"plan as a page",
+	"plan as an html",
+	"plan as a visual",
+	"render the plan",
+	"render this plan",
+	"render that plan",
+	"render my plan",
+	"render the implementation plan",
+	"visualize this plan",
+	"visualize the plan",
+}
 
 // planModePromptInput is the minimal subset of Claude Code's UserPromptSubmit
 // stdin needed to detect plan mode. Both spellings are accepted because the hook
@@ -72,15 +104,35 @@ func extractPermissionMode(rawBytes []byte) string {
 	return in.PermissionModeCamel
 }
 
-// emitPlanModeHint writes the in-plan-mode enrichment hint to w when the agent is
-// in plan mode and has not yet been hinted for the current plan-mode entry.
+// promptRequestsHTMLPlan reports whether the user's prompt is asking to render a
+// plan as an HTML / visual page. Reuses extractPromptText (the same envelope the
+// recall preamble parses) so the two paths can't drift on field names.
+// Conservative substring match on a curated phrase set; returns false on any
+// extraction failure (fail-open).
+func promptRequestsHTMLPlan(rawBytes []byte) bool {
+	text := extractPromptText(rawBytes)
+	if text == "" {
+		return false
+	}
+	text = strings.ToLower(text)
+	for _, phrase := range htmlPlanIntentPhrases {
+		if strings.Contains(text, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// emitPlanHint writes the just-in-time plan-rendering steer to w when the agent
+// is in plan mode OR the prompt asks to render an HTML plan, and it has not yet
+// been hinted for the current planning episode.
 //
 // Called from handlePrompt (the proven UserPromptSubmit stdout-injection channel)
 // on every prompt. State machine, keyed on a per-agent stamp:
-//   - mode == "plan", no stamp  -> emit hint, write stamp (hinted this entry)
-//   - mode == "plan", stamp set -> suppress (already hinted this entry)
-//   - mode != "plan"            -> clear stamp (next plan-mode entry re-hints)
-func emitPlanModeHint(w io.Writer, projectRoot, agentID string, rawBytes []byte) {
+//   - triggered, no stamp  -> emit hint, write stamp (hinted this episode)
+//   - triggered, stamp set -> suppress (already hinted this episode)
+//   - not triggered        -> clear stamp (next trigger re-hints)
+func emitPlanHint(w io.Writer, projectRoot, agentID string, rawBytes []byte) {
 	if projectRoot == "" || agentID == "" {
 		return
 	}
@@ -89,41 +141,73 @@ func emitPlanModeHint(w io.Writer, projectRoot, agentID string, rawBytes []byte)
 		return
 	}
 
-	if extractPermissionMode(rawBytes) != planModeValue {
-		// not in plan mode — reset so the next entry re-hints. Best-effort.
+	inPlanMode := extractPermissionMode(rawBytes) == planModeValue
+	htmlIntent := promptRequestsHTMLPlan(rawBytes)
+	// Honor the user's opt-out: plan.html=off (env SAGEOX_PLAN_HTML / config)
+	// silences the HTML-intent steer for users who don't want render nudges. The
+	// plan-mode steer leads with `ox plan enrich` (render-independent team
+	// context) and keeps its own permission-mode gate, so it's left untouched.
+	if htmlIntent && config.PlanHTML(projectRoot) == config.PlanHTMLOff {
+		htmlIntent = false
+	}
+	if !inPlanMode && !htmlIntent {
+		// neither trigger — reset so the next planning moment re-hints. Best-effort.
 		_ = os.Remove(stamp)
 		return
 	}
 
-	// in plan mode: hint once per entry.
+	// triggered: hint once per episode.
 	if _, err := os.Stat(stamp); err == nil {
-		return // already hinted for this plan-mode entry
+		return // already hinted for this episode
 	}
 	if err := os.MkdirAll(filepath.Dir(stamp), 0o755); err != nil {
-		slog.Debug("hook: plan-mode hint mkdir failed", "error", err)
+		slog.Debug("hook: plan hint mkdir failed", "error", err)
 		return
 	}
+
+	// Plan-mode lead wins when both triggers fire — it's the in-draft superset
+	// message ("enrich WHILE you draft, then render"). The HTML-intent lead is
+	// for the no-plan-mode case where the user is already asking to render.
 	// <system-reminder> is the only tag Claude Code treats as trusted system
 	// context. Single line — grepability invariant.
-	fmt.Fprintf(w, "<system-reminder>[ox] %s</system-reminder>\n", planModeHintLine())
+	line := htmlPlanHintLine()
+	trigger := "html-intent"
+	if inPlanMode {
+		line = planModeHintLine()
+		trigger = "plan-mode"
+	}
+	fmt.Fprintf(w, "<system-reminder>[ox] %s</system-reminder>\n", line)
 
 	// Write the stamp only after a successful emit so that a failed write
-	// doesn't permanently suppress the hint for this plan-mode entry.
+	// doesn't permanently suppress the hint for this episode.
 	if err := os.WriteFile(stamp, []byte("1"), 0o600); err != nil {
-		slog.Debug("hook: plan-mode hint stamp write failed", "error", err)
+		slog.Debug("hook: plan hint stamp write failed", "error", err)
 		return
 	}
-	slog.Info("hook: plan-mode hint emitted", "agent_id", agentID)
+	slog.Info("hook: plan hint emitted", "agent_id", agentID, "trigger", trigger)
 }
 
-// planModeHintLine is the crisp two-beat steer: enrich (JSON) WHILE drafting,
-// render (the SageOx team-context-optimized plan) when presenting.
+// planModeHintLine is the in-draft steer for plan mode: enrich (JSON) WHILE
+// drafting, render (the SageOx team-context-optimized plan) when presenting.
 func planModeHintLine() string {
 	return strings.Join([]string{
 		"Plan mode — run `ox plan enrich --json` WHILE you draft so the plan reflects team context",
 		"(collisions, prior art, expert routing) BEFORE you present it; then offer it as a",
 		"SageOx team-context-optimized plan via `ox plan render --open`. The render owns the SageOx",
 		"footer credit and OX-icon markers — don't hand-author your own.",
+	}, " ")
+}
+
+// htmlPlanHintLine is the steer for when the user asks to render an HTML plan
+// outside plan mode: lead with the renderer, push rich cognition-first visuals
+// via the viz catalog, warn off the orphan render.
+func htmlPlanHintLine() string {
+	return strings.Join([]string{
+		"Rendering an HTML plan? Use `ox plan render --open` (run `ox plan enrich --json` first) — only it folds in",
+		"SageOx team context (collisions, prior art, expert routing) and saves to the ledger. Lean into the",
+		"`ox plan viz` catalog: rich, interactive HTML+JS visuals — dependency explorers, charts, swimlane timelines,",
+		"Tufte tables — that surface the critical decisions and tradeoffs and cut the reviewer's cognitive load,",
+		"rather than burying them in prose. A hand-rolled render is a context-blind orphan; don't author the SageOx credit — the render owns it.",
 	}, " ")
 }
 

--- a/cmd/ox/agent_hook_plan_mode_nudge.go
+++ b/cmd/ox/agent_hook_plan_mode_nudge.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -40,10 +41,14 @@ import (
 // transcript — and the `prompt` text. We decode both defensively.
 //
 // Throttle: fire exactly once per planning episode. A per-agent stamp file marks
-// "already hinted this episode"; it is cleared the moment a prompt arrives that
-// triggers neither path, so a fresh plan-mode entry or a new HTML-plan request
-// re-hints. This avoids hinting on every prompt during a long session while
-// still re-firing on each genuine planning moment.
+// "already hinted this episode" and records WHICH trigger hinted; it is cleared
+// the moment a prompt arrives that triggers neither path, so a fresh plan-mode
+// entry or a new HTML-plan request re-hints. Plan mode is the higher-value
+// trigger (its lead steers enrich WHILE drafting), so it upgrades over an
+// earlier HTML-intent stamp in the same episode — the html-intent → plan-mode
+// transition with no neutral prompt between must not swallow the draft-first
+// steer. This avoids hinting on every prompt during a long session while still
+// re-firing on each genuine planning moment.
 //
 // Everything here is best-effort and fail-open: any decode/IO failure leaves the
 // existing hook behavior untouched. The hint is purely additive.
@@ -58,12 +63,19 @@ const (
 	// never committed. (Name retained for cache stability; the stamp now covers
 	// both the plan-mode and HTML-intent triggers.)
 	planModeHintCacheSubdir = "plan-mode-hint"
+
+	// Stamp payloads recording which trigger last hinted this episode. Plan mode
+	// outranks HTML intent, so a plan-mode hint may overwrite an html-intent
+	// stamp (an upgrade), but not vice-versa.
+	triggerPlanMode   = "plan-mode"
+	triggerHTMLIntent = "html-intent"
 )
 
 // htmlPlanIntentPhrases are the curated phrases that signal the user wants a plan
-// rendered as an HTML / visual page. Matched case-insensitively as substrings.
-// Each phrase embeds both a plan noun and a render/visual cue so it is
-// self-disambiguating; a false positive costs at most one throttled reminder.
+// rendered as an HTML / visual page. Matched case-insensitively on WORD
+// boundaries (see containsWord) so "render the plan" does not fire on "render the
+// planned route" / "visualize the planning timeline". Each phrase embeds both a
+// plan noun and a render/visual cue so it is self-disambiguating.
 var htmlPlanIntentPhrases = []string{
 	"html plan",
 	"html-plan", // covers "/html-plan" (the slash command)
@@ -107,20 +119,45 @@ func extractPermissionMode(rawBytes []byte) string {
 // promptRequestsHTMLPlan reports whether the user's prompt is asking to render a
 // plan as an HTML / visual page. Reuses extractPromptText (the same envelope the
 // recall preamble parses) so the two paths can't drift on field names.
-// Conservative substring match on a curated phrase set; returns false on any
-// extraction failure (fail-open).
+// Word-boundary match on a curated phrase set; returns false on any extraction
+// failure (fail-open).
 func promptRequestsHTMLPlan(rawBytes []byte) bool {
-	text := extractPromptText(rawBytes)
+	text := strings.ToLower(extractPromptText(rawBytes))
 	if text == "" {
 		return false
 	}
-	text = strings.ToLower(text)
 	for _, phrase := range htmlPlanIntentPhrases {
-		if strings.Contains(text, phrase) {
+		if containsWord(text, phrase) {
 			return true
 		}
 	}
 	return false
+}
+
+// containsWord reports whether phrase occurs in text bounded by a
+// non-alphanumeric character (or the string edge) on both sides — a
+// word-boundary-aware strings.Contains. Both args are assumed already
+// lowercased. ASCII-only: a multibyte rune adjacent to a match counts as a
+// boundary, which is fine for these ASCII phrases.
+func containsWord(text, phrase string) bool {
+	for from := 0; ; {
+		i := strings.Index(text[from:], phrase)
+		if i < 0 {
+			return false
+		}
+		start := from + i
+		end := start + len(phrase)
+		leftOK := start == 0 || !isASCIIAlphaNum(text[start-1])
+		rightOK := end == len(text) || !isASCIIAlphaNum(text[end])
+		if leftOK && rightOK {
+			return true
+		}
+		from = start + 1
+	}
+}
+
+func isASCIIAlphaNum(b byte) bool {
+	return b >= 'a' && b <= 'z' || b >= '0' && b <= '9'
 }
 
 // emitPlanHint writes the just-in-time plan-rendering steer to w when the agent
@@ -128,10 +165,12 @@ func promptRequestsHTMLPlan(rawBytes []byte) bool {
 // been hinted for the current planning episode.
 //
 // Called from handlePrompt (the proven UserPromptSubmit stdout-injection channel)
-// on every prompt. State machine, keyed on a per-agent stamp:
-//   - triggered, no stamp  -> emit hint, write stamp (hinted this episode)
-//   - triggered, stamp set -> suppress (already hinted this episode)
-//   - not triggered        -> clear stamp (next trigger re-hints)
+// on every prompt. State machine, keyed on a per-agent stamp that records the
+// triggering source:
+//   - triggered, no stamp          -> emit, stamp the trigger
+//   - plan-mode, stamp=html-intent -> emit (upgrade), restamp plan-mode
+//   - triggered, stamp >= trigger  -> suppress (already hinted this episode)
+//   - not triggered                -> clear stamp (next trigger re-hints)
 func emitPlanHint(w io.Writer, projectRoot, agentID string, rawBytes []byte) {
 	if projectRoot == "" || agentID == "" {
 		return
@@ -156,31 +195,45 @@ func emitPlanHint(w io.Writer, projectRoot, agentID string, rawBytes []byte) {
 		return
 	}
 
-	// triggered: hint once per episode.
-	if _, err := os.Stat(stamp); err == nil {
-		return // already hinted for this episode
+	// Pick the trigger + message. Plan mode is the higher-value lead (it steers
+	// enrich WHILE drafting); the HTML-intent lead is render-first, for the
+	// no-plan-mode case where the user is already asking to render.
+	trigger := triggerHTMLIntent
+	line := htmlPlanHintLine()
+	if inPlanMode {
+		trigger = triggerPlanMode
+		line = planModeHintLine()
 	}
+
+	// Throttle: once per episode, but a plan-mode hint may UPGRADE over an
+	// earlier html-intent stamp (the html-intent → plan-mode transition with no
+	// neutral prompt between, where the draft-first steer would otherwise be
+	// swallowed). Reading the stamp also distinguishes "absent" (proceed) from a
+	// real read error (leave state untouched rather than risk a double-hint).
+	if prev, err := os.ReadFile(stamp); err == nil {
+		if trigger != triggerPlanMode || strings.TrimSpace(string(prev)) == triggerPlanMode {
+			return // already hinted this episode for an equal-or-higher trigger
+		}
+		// stamp is html-intent and we're now in plan mode — fall through to upgrade.
+	} else if !errors.Is(err, os.ErrNotExist) {
+		slog.Debug("hook: plan hint stamp read failed", "error", err)
+		return
+	}
+
 	if err := os.MkdirAll(filepath.Dir(stamp), 0o755); err != nil {
 		slog.Debug("hook: plan hint mkdir failed", "error", err)
 		return
 	}
 
-	// Plan-mode lead wins when both triggers fire — it's the in-draft superset
-	// message ("enrich WHILE you draft, then render"). The HTML-intent lead is
-	// for the no-plan-mode case where the user is already asking to render.
 	// <system-reminder> is the only tag Claude Code treats as trusted system
-	// context. Single line — grepability invariant.
-	line := htmlPlanHintLine()
-	trigger := "html-intent"
-	if inPlanMode {
-		line = planModeHintLine()
-		trigger = "plan-mode"
+	// context. Single line — grepability invariant. Persist the stamp ONLY after
+	// a successful emit, so a broken stdout doesn't suppress a hint the model
+	// never saw.
+	if _, err := fmt.Fprintf(w, "<system-reminder>[ox] %s</system-reminder>\n", line); err != nil {
+		slog.Debug("hook: plan hint emit failed", "error", err)
+		return
 	}
-	fmt.Fprintf(w, "<system-reminder>[ox] %s</system-reminder>\n", line)
-
-	// Write the stamp only after a successful emit so that a failed write
-	// doesn't permanently suppress the hint for this episode.
-	if err := os.WriteFile(stamp, []byte("1"), 0o600); err != nil {
+	if err := os.WriteFile(stamp, []byte(trigger), 0o600); err != nil {
 		slog.Debug("hook: plan hint stamp write failed", "error", err)
 		return
 	}

--- a/cmd/ox/agent_hook_plan_mode_nudge_test.go
+++ b/cmd/ox/agent_hook_plan_mode_nudge_test.go
@@ -243,6 +243,54 @@ func TestEmitPlanHint_NoTriggerResetsAfterHTMLIntent(t *testing.T) {
 	assert.Contains(t, buf3.String(), "ox plan render --open", "a later HTML-plan request must re-hint")
 }
 
+// TestEmitPlanHint_PlanModeUpgradesAfterHTMLIntent verifies the higher-value
+// plan-mode (draft-first) steer still fires when the user gets an HTML-intent
+// hint and THEN enters plan mode with no neutral prompt between — the shared
+// stamp must not swallow it. Failure prevented: the render-first html-intent
+// hint suppresses the "enrich WHILE you draft" steer for the whole episode.
+func TestEmitPlanHint_PlanModeUpgradesAfterHTMLIntent(t *testing.T) {
+	t.Setenv(config.EnvPlanHTML, config.PlanHTMLRecommend)
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxupgrade"
+	htmlPrompt := []byte(`{"permission_mode":"default","prompt":"make me an html plan"}`)
+	planPrompt := []byte(`{"permission_mode":"plan","prompt":"plan it"}`)
+
+	var buf1 bytes.Buffer
+	emitPlanHint(&buf1, projectRoot, agentID, htmlPrompt)
+	require.Contains(t, buf1.String(), "Rendering an HTML plan", "html-intent hint fires first")
+
+	// enter plan mode directly, no neutral prompt between: draft-first steer upgrades
+	var buf2 bytes.Buffer
+	emitPlanHint(&buf2, projectRoot, agentID, planPrompt)
+	assert.Contains(t, buf2.String(), "Plan mode —", "plan-mode steer upgrades over an html-intent stamp")
+
+	// once upgraded, a second plan-mode prompt in the same entry is suppressed
+	var buf3 bytes.Buffer
+	emitPlanHint(&buf3, projectRoot, agentID, planPrompt)
+	assert.Empty(t, buf3.String(), "plan-mode hint fires once after the upgrade")
+}
+
+// TestEmitPlanHint_HTMLIntentDoesNotUpgradePlanMode verifies the reverse is NOT
+// an upgrade: after a plan-mode hint, an html-intent prompt in the same episode
+// stays suppressed (the plan-mode lead already covers rendering). Failure
+// prevented: an episode double-hints when the user toggles plan mode off then
+// asks to render.
+func TestEmitPlanHint_HTMLIntentDoesNotUpgradePlanMode(t *testing.T) {
+	t.Setenv(config.EnvPlanHTML, config.PlanHTMLRecommend)
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxnoupgrade"
+	planPrompt := []byte(`{"permission_mode":"plan","prompt":"plan it"}`)
+	htmlPrompt := []byte(`{"permission_mode":"acceptEdits","prompt":"now render this plan as html"}`)
+
+	var buf1 bytes.Buffer
+	emitPlanHint(&buf1, projectRoot, agentID, planPrompt)
+	require.Contains(t, buf1.String(), "Plan mode —", "plan-mode hint fires first")
+
+	var buf2 bytes.Buffer
+	emitPlanHint(&buf2, projectRoot, agentID, htmlPrompt)
+	assert.Empty(t, buf2.String(), "html-intent must not re-hint after a plan-mode hint in the same episode")
+}
+
 // --- D. HTML-plan intent detection ---
 
 // TestPromptRequestsHTMLPlan covers the phrase detector that drives the any-mode
@@ -266,9 +314,11 @@ func TestPromptRequestsHTMLPlan(t *testing.T) {
 		``,
 		`not json`,
 		`{"prompt":"fix the failing test"}`,
-		`{"prompt":"plan the sprint"}`,        // plan, but no render/html cue
-		`{"prompt":"render the login page"}`,  // render, but not a plan
-		`{"prompt":"what does this html do"}`, // html, but not a plan
+		`{"prompt":"plan the sprint"}`,                 // plan, but no render/html cue
+		`{"prompt":"render the login page"}`,           // render, but not a plan
+		`{"prompt":"what does this html do"}`,          // html, but not a plan
+		`{"prompt":"render the planned route"}`,        // word boundary: "plan" != "planned"
+		`{"prompt":"visualize the planning timeline"}`, // word boundary: "plan" != "planning"
 	}
 	for _, raw := range negatives {
 		assert.False(t, promptRequestsHTMLPlan([]byte(raw)), "should NOT detect: %s", raw)

--- a/cmd/ox/agent_hook_plan_mode_nudge_test.go
+++ b/cmd/ox/agent_hook_plan_mode_nudge_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/sageox/ox/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,13 +49,13 @@ func TestExtractPermissionMode_FailOpen(t *testing.T) {
 	}
 }
 
-// --- B. Hint lifecycle: once per plan-mode entry ---
+// --- B. Plan-mode trigger: hint once per plan-mode entry ---
 
-// TestEmitPlanModeHint_FiresOncePerEntry verifies the core throttle: the hint
+// TestEmitPlanHint_FiresOncePerEntry verifies the core throttle: the hint
 // fires on the first plan-mode prompt, suppresses on subsequent plan-mode
 // prompts (same entry), then re-fires after the agent leaves and re-enters plan
 // mode. Failure prevented: the hint spams every prompt, or never re-fires.
-func TestEmitPlanModeHint_FiresOncePerEntry(t *testing.T) {
+func TestEmitPlanHint_FiresOncePerEntry(t *testing.T) {
 	projectRoot := planNudgeProject(t)
 	agentID := "Oxmode1"
 	planPrompt := []byte(`{"permission_mode":"plan","prompt":"plan it"}`)
@@ -62,7 +63,7 @@ func TestEmitPlanModeHint_FiresOncePerEntry(t *testing.T) {
 
 	// 1. first plan-mode prompt: hint fires
 	var buf bytes.Buffer
-	emitPlanModeHint(&buf, projectRoot, agentID, planPrompt)
+	emitPlanHint(&buf, projectRoot, agentID, planPrompt)
 	got := buf.String()
 	assert.Contains(t, got, "<system-reminder>")
 	assert.Contains(t, got, "[ox]")
@@ -73,59 +74,203 @@ func TestEmitPlanModeHint_FiresOncePerEntry(t *testing.T) {
 
 	// 2. second plan-mode prompt, same entry: suppressed
 	var buf2 bytes.Buffer
-	emitPlanModeHint(&buf2, projectRoot, agentID, planPrompt)
+	emitPlanHint(&buf2, projectRoot, agentID, planPrompt)
 	assert.Empty(t, buf2.String(), "must not re-hint within the same plan-mode entry")
 
 	// 3. agent leaves plan mode: stamp cleared, nothing emitted
 	var buf3 bytes.Buffer
-	emitPlanModeHint(&buf3, projectRoot, agentID, normalPrompt)
+	emitPlanHint(&buf3, projectRoot, agentID, normalPrompt)
 	assert.Empty(t, buf3.String(), "non-plan prompt emits nothing")
 	assert.NoFileExists(t, planModeHintPath(projectRoot, agentID), "leaving plan mode clears the stamp")
 
 	// 4. re-enters plan mode: hint fires again
 	var buf4 bytes.Buffer
-	emitPlanModeHint(&buf4, projectRoot, agentID, planPrompt)
+	emitPlanHint(&buf4, projectRoot, agentID, planPrompt)
 	assert.Contains(t, buf4.String(), "ox plan enrich --json", "re-entering plan mode must re-hint")
 }
 
-// TestEmitPlanModeHint_NonClaudeNoOp verifies that a payload with no
-// permission-mode field (every non-Claude agent) produces no hint and writes no
-// stamp. Failure prevented: the Gold-only feature leaks to agents that can't
-// deliver it.
-func TestEmitPlanModeHint_NonClaudeNoOp(t *testing.T) {
+// TestEmitPlanHint_NonClaudeNoOpOnNeutralPrompt verifies that a payload with no
+// permission-mode field and no HTML-plan intent (the common non-Claude case)
+// produces no hint and writes no stamp. Failure prevented: the plan-mode steer
+// leaks to agents/prompts that didn't trigger it.
+func TestEmitPlanHint_NonClaudeNoOpOnNeutralPrompt(t *testing.T) {
 	projectRoot := planNudgeProject(t)
 	agentID := "Oxsilver"
 	var buf bytes.Buffer
-	emitPlanModeHint(&buf, projectRoot, agentID, []byte(`{"prompt":"do work"}`))
+	emitPlanHint(&buf, projectRoot, agentID, []byte(`{"prompt":"do work"}`))
 	assert.Empty(t, buf.String())
 	assert.NoFileExists(t, planModeHintPath(projectRoot, agentID))
 }
 
-// TestEmitPlanModeHint_EmptyArgs verifies path/emit are safe with empty inputs.
-func TestEmitPlanModeHint_EmptyArgs(t *testing.T) {
+// TestEmitPlanHint_EmptyArgs verifies path/emit are safe with empty inputs.
+func TestEmitPlanHint_EmptyArgs(t *testing.T) {
 	assert.Empty(t, planModeHintPath("", "Oxa"))
 	assert.Empty(t, planModeHintPath("/tmp", ""))
 
 	var buf bytes.Buffer
-	emitPlanModeHint(&buf, "", "Oxa", []byte(`{"permission_mode":"plan"}`))
-	emitPlanModeHint(&buf, "/tmp", "", []byte(`{"permission_mode":"plan"}`))
+	emitPlanHint(&buf, "", "Oxa", []byte(`{"permission_mode":"plan"}`))
+	emitPlanHint(&buf, "/tmp", "", []byte(`{"permission_mode":"plan"}`))
 	assert.Empty(t, buf.String())
 }
 
-// TestEmitPlanModeHint_StampPersistsAcrossEntry verifies the stamp file exists
+// TestEmitPlanHint_StampPersistsAcrossEntry verifies the stamp file exists
 // while in plan mode (so repeat prompts stay suppressed) and is keyed per agent.
-func TestEmitPlanModeHint_StampPersistsAcrossEntry(t *testing.T) {
+func TestEmitPlanHint_StampPersistsAcrossEntry(t *testing.T) {
 	projectRoot := planNudgeProject(t)
 	agentA := "OxA"
 	agentB := "OxB"
 	planPrompt := []byte(`{"permission_mode":"plan"}`)
 
 	var buf bytes.Buffer
-	emitPlanModeHint(&buf, projectRoot, agentA, planPrompt)
+	emitPlanHint(&buf, projectRoot, agentA, planPrompt)
 	require.FileExists(t, planModeHintPath(projectRoot, agentA))
 
 	// agent B is independent — its first plan-mode prompt still hints
 	var bufB bytes.Buffer
-	emitPlanModeHint(&bufB, projectRoot, agentB, planPrompt)
+	emitPlanHint(&bufB, projectRoot, agentB, planPrompt)
 	assert.Contains(t, bufB.String(), "ox plan enrich --json", "per-agent stamp must not bleed across agents")
+}
+
+// --- C. HTML-plan intent trigger (any permission mode) ---
+
+// TestEmitPlanHint_FiresOnHTMLIntentOutsidePlanMode verifies the gap fix: a user
+// asking to render an HTML plan OUTSIDE plan mode still gets the just-in-time
+// steer toward `ox plan render` + the viz catalog. Failure prevented: agents in
+// default/acceptEdits mode hand-roll context-blind orphan renders because the
+// only just-in-time steer was gated on plan mode.
+func TestEmitPlanHint_FiresOnHTMLIntentOutsidePlanMode(t *testing.T) {
+	t.Setenv(config.EnvPlanHTML, config.PlanHTMLRecommend) // deterministic: not opted out
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxhtml1"
+	prompt := []byte(`{"permission_mode":"default","prompt":"make me an html plan for the auth refactor"}`)
+
+	var buf bytes.Buffer
+	emitPlanHint(&buf, projectRoot, agentID, prompt)
+	got := buf.String()
+	assert.Contains(t, got, "<system-reminder>")
+	assert.Contains(t, got, "[ox]")
+	assert.Contains(t, got, "ox plan render --open")
+	assert.Contains(t, got, "ox plan viz", "must point at the visualization catalog")
+	assert.NotContains(t, got, "Plan mode —", "outside plan mode uses the render lead, not the plan-mode lead")
+	assert.NotContains(t, got, "\n<", "hint must be a single system-reminder line")
+}
+
+// TestEmitPlanHint_HTMLIntentThrottled verifies the once-per-episode throttle on
+// the HTML-intent path. Failure prevented: the steer spams every prompt while
+// the user keeps discussing the plan.
+func TestEmitPlanHint_HTMLIntentThrottled(t *testing.T) {
+	t.Setenv(config.EnvPlanHTML, config.PlanHTMLRecommend)
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxhtml2"
+	prompt := []byte(`{"permission_mode":"default","prompt":"render this plan as an html page"}`)
+
+	var buf1, buf2 bytes.Buffer
+	emitPlanHint(&buf1, projectRoot, agentID, prompt)
+	emitPlanHint(&buf2, projectRoot, agentID, prompt)
+	assert.Contains(t, buf1.String(), "ox plan render --open")
+	assert.Empty(t, buf2.String(), "must not re-hint within the same episode")
+}
+
+// TestEmitPlanHint_PlanModeLeadWinsWhenBoth verifies that when the agent is in
+// plan mode AND the prompt names an html plan, the in-draft plan-mode lead
+// (enrich WHILE drafting) wins — it's the superset message. Failure prevented:
+// the render-first lead overrides the more useful in-draft enrich steer.
+func TestEmitPlanHint_PlanModeLeadWinsWhenBoth(t *testing.T) {
+	t.Setenv(config.EnvPlanHTML, config.PlanHTMLRecommend)
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxboth"
+	prompt := []byte(`{"permission_mode":"plan","prompt":"draft and render an html plan"}`)
+
+	var buf bytes.Buffer
+	emitPlanHint(&buf, projectRoot, agentID, prompt)
+	got := buf.String()
+	assert.Contains(t, got, "Plan mode —")
+	assert.Contains(t, got, "ox plan enrich --json")
+}
+
+// TestEmitPlanHint_RespectsPlanHTMLOff verifies the opt-out: a user who set
+// plan.html=off does NOT get the HTML-intent steer. Failure prevented: the steer
+// nags users who explicitly disabled HTML plan rendering.
+func TestEmitPlanHint_RespectsPlanHTMLOff(t *testing.T) {
+	t.Setenv(config.EnvPlanHTML, config.PlanHTMLOff)
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxoff"
+	prompt := []byte(`{"permission_mode":"default","prompt":"make me an html plan"}`)
+
+	var buf bytes.Buffer
+	emitPlanHint(&buf, projectRoot, agentID, prompt)
+	assert.Empty(t, buf.String(), "plan.html=off must silence the HTML-intent steer")
+	assert.NoFileExists(t, planModeHintPath(projectRoot, agentID))
+}
+
+// TestEmitPlanHint_PlanModeUnaffectedByPlanHTMLOff documents the deliberate
+// asymmetry: plan.html=off silences the render-first HTML-intent steer but NOT
+// the plan-mode in-draft steer, which leads with `ox plan enrich` (team context
+// valuable regardless of whether the human renders HTML).
+func TestEmitPlanHint_PlanModeUnaffectedByPlanHTMLOff(t *testing.T) {
+	t.Setenv(config.EnvPlanHTML, config.PlanHTMLOff)
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxoffplan"
+	prompt := []byte(`{"permission_mode":"plan","prompt":"plan it"}`)
+
+	var buf bytes.Buffer
+	emitPlanHint(&buf, projectRoot, agentID, prompt)
+	assert.Contains(t, buf.String(), "ox plan enrich --json", "plan-mode steer fires regardless of plan.html=off")
+}
+
+// TestEmitPlanHint_NoTriggerResetsAfterHTMLIntent verifies the stamp resets when
+// a neutral prompt follows an HTML-intent hint, so a later HTML-plan request
+// re-hints. Failure prevented: the throttle permanently suppresses after one
+// episode.
+func TestEmitPlanHint_NoTriggerResetsAfterHTMLIntent(t *testing.T) {
+	t.Setenv(config.EnvPlanHTML, config.PlanHTMLRecommend)
+	projectRoot := planNudgeProject(t)
+	agentID := "Oxreset"
+	htmlPrompt := []byte(`{"permission_mode":"default","prompt":"render this plan as html"}`)
+	neutralPrompt := []byte(`{"permission_mode":"default","prompt":"fix the failing test"}`)
+
+	var buf1 bytes.Buffer
+	emitPlanHint(&buf1, projectRoot, agentID, htmlPrompt)
+	require.Contains(t, buf1.String(), "ox plan render --open")
+
+	var buf2 bytes.Buffer
+	emitPlanHint(&buf2, projectRoot, agentID, neutralPrompt)
+	assert.Empty(t, buf2.String())
+	assert.NoFileExists(t, planModeHintPath(projectRoot, agentID), "neutral prompt clears the stamp")
+
+	var buf3 bytes.Buffer
+	emitPlanHint(&buf3, projectRoot, agentID, htmlPrompt)
+	assert.Contains(t, buf3.String(), "ox plan render --open", "a later HTML-plan request must re-hint")
+}
+
+// --- D. HTML-plan intent detection ---
+
+// TestPromptRequestsHTMLPlan covers the phrase detector that drives the any-mode
+// trigger. Failure prevented: real HTML-plan requests slip through (no steer) or
+// unrelated prompts false-fire (nagging).
+func TestPromptRequestsHTMLPlan(t *testing.T) {
+	positives := []string{
+		`{"prompt":"make me an html plan for X"}`,
+		`{"prompt":"use the /html-plan skill"}`,
+		`{"prompt":"render the plan as a page"}`,
+		`{"prompt":"render this plan please"}`,
+		`{"prompt":"can you visualize the plan"}`,
+		`{"prompt":"visualize this plan as html"}`,
+		`{"prompt":"show the PLAN AS HTML"}`, // case-insensitive
+	}
+	for _, raw := range positives {
+		assert.True(t, promptRequestsHTMLPlan([]byte(raw)), "should detect: %s", raw)
+	}
+
+	negatives := []string{
+		``,
+		`not json`,
+		`{"prompt":"fix the failing test"}`,
+		`{"prompt":"plan the sprint"}`,        // plan, but no render/html cue
+		`{"prompt":"render the login page"}`,  // render, but not a plan
+		`{"prompt":"what does this html do"}`, // html, but not a plan
+	}
+	for _, raw := range negatives {
+		assert.False(t, promptRequestsHTMLPlan([]byte(raw)), "should NOT detect: %s", raw)
+	}
 }

--- a/internal/auth/env_naming_test.go
+++ b/internal/auth/env_naming_test.go
@@ -26,11 +26,11 @@ func TestNoCustomerFacingOxTokenReintroduction(t *testing.T) {
 	// (CHANGELOG.md is a symlink to cmd/ox/release_notes.md — filepath.Walk
 	// visits the real file, so allowlist the real path).
 	allowlist := map[string]bool{
-		"internal/auth/env_token_test.go":   true,
-		"internal/auth/env_naming_test.go":  true,
-		"docs/adr/adr-ephemeral-mode.md": true,
-		"cmd/ox/release_notes.md":           true,
-		"CHANGELOG.md":                      true,
+		"internal/auth/env_token_test.go":  true,
+		"internal/auth/env_naming_test.go": true,
+		"docs/adr/adr-ephemeral-mode.md":   true,
+		"cmd/ox/release_notes.md":          true,
+		"CHANGELOG.md":                     true,
 	}
 
 	bannedPatterns := []string{`"OX_TOKEN"`, `"OX_ENDPOINT"`, "`OX_TOKEN`", "`OX_ENDPOINT`"}


### PR DESCRIPTION
## What's broken

Downstream coding agents in ox-initialized repos generate HTML plans ad-hoc and **don't route to `ox plan render`** (the team-context-enriched renderer) or the `ox plan viz` catalog. The result is a "context-blind orphan" render: pretty HTML that carries no SageOx badges (collisions / prior-art / expert routing), never reaches the ledger, and has no attribution.

The root cause is **timing, not wording**. `ox` already injects strong steering toward `ox plan render` — but only through channels that fire once at session start (`ox agent prime`) and dilute as context grows. The one channel that actually changes behavior is the just-in-time `UserPromptSubmit` nudge (`emitPlanModeHint`); its own header comment states the thesis:

> prime carries the same guidance, but in a long context that guidance is diluted; a crisp, just-in-time reminder at the planning moment is what actually changes behavior.

**That just-in-time nudge was gated on `permission_mode == "plan"`.** A large share of HTML-plan requests arrive *outside* plan mode — a user in default/acceptEdits mode simply says "make me an html plan for X". On that path the nudge no-ops, prime guidance is stale, and the agent reaches for a generic `html-plan` skill or hand-rolls HTML.

```mermaid
flowchart TB
  U["User: 'make me an HTML plan for X'"] --> M{"permission_mode is plan ?"}
  M -- yes --> H["just-in-time steer fires: ox plan enrich plus render"]
  M -- "no (before this PR)" --> G["no just-in-time steer"]
  G --> O["agent uses generic html-plan skill or hand-rolls HTML"]
  O --> ORPH["context-blind orphan: no badges, no ledger, no viz catalog"]
  M -- "no (after this PR)" --> I{"prompt asks for an HTML plan ?"}
  I -- yes --> H2["render-lead steer fires: ox plan render plus ox plan viz"]
  I -- no --> Q["stay quiet"]
  H --> GOOD["ox plan render: enriched, saved to ledger, attributed"]
  H2 --> GOOD
```

## What this PR ships

- **Second trigger on the existing just-in-time nudge.** `emitPlanModeHint` → `emitPlanHint` now fires when the agent is in plan mode **OR** the prompt asks to render an HTML plan, in any permission mode. Same per-agent stamp, same once-per-episode throttle, same `<system-reminder>` stdout channel — no new hook.
- **Mode-appropriate message.** Plan mode keeps the in-draft lead ("enrich WHILE you draft, then render"). The new HTML-intent lead leads with the renderer and names the catalog:
  > Rendering an HTML plan? Use `ox plan render --open` (run `ox plan enrich --json` first) — only it folds in SageOx team context (collisions, prior art, expert routing) and saves to the ledger. Lean into the `ox plan viz` catalog: rich, interactive HTML+JS visuals — dependency explorers, charts, swimlane timelines, Tufte tables — that surface the critical decisions and tradeoffs and cut the reviewer's cognitive load, rather than burying them in prose. A hand-rolled render is a context-blind orphan; don't author the SageOx credit — the render owns it.
- **Conservative intent detector.** `promptRequestsHTMLPlan` reuses the existing `extractPromptText` and matches a curated phrase set (`html plan`, `/html-plan`, `render the plan`, `plan as html`, `visualize the plan`, …). Each phrase embeds both a plan noun and a render cue, so it self-disambiguates; a false positive costs at most one throttled reminder.

## Opt-out (respects existing config)

The HTML-intent steer honors the existing **`plan.html`** setting — `SAGEOX_PLAN_HTML=off`, or `plan.html: off` in user/project config — so users who've disabled HTML plan rendering aren't nagged. Resolved via the existing `config.PlanHTML()`.

| `plan.html` | HTML-intent steer | Plan-mode steer |
|-------------|-------------------|-----------------|
| `recommend` (default) | fires | fires |
| `always` | fires | fires |
| `off` | **silent** | fires (leads with `ox plan enrich`, render-independent) |

The asymmetry is deliberate: the plan-mode steer leads with `ox plan enrich` (team context that's valuable whether or not the human renders HTML), so it keeps its own permission-mode gate.

## Scope / non-goals

- **Claude Code only**, same as the pre-existing nudge — `UserPromptSubmit` stdout is the only channel Claude Code injects into model context. Cross-agent steering already lives in prime's tier-aware `<plan-enrichment-guidance>`. No speculative cross-agent plumbing.
- **No prime copy rewrite / no token-budget change.** Prime guidance is already strong; the gap was timing. (An earlier draft added cognitive-load framing to the always-on prime block but tripped the SageOx-overhead budget regression test — reverted; that framing lives in the just-in-time nudge instead.)
- **Richer interactive viz patterns** (true HTML+JS explorers in the catalog, a cognitive-load-first layout spec) are a larger follow-up, tracked separately — this PR steers agents toward the capability and names it; it does not expand the catalog.

## Test Plan

- `make lint` → 0 issues. `go test ./cmd/ox/ -count=1 -short` → ok (full package, ~80s).
- New table-driven coverage in `agent_hook_plan_mode_nudge_test.go`:
  - HTML intent outside plan mode fires; message names `ox plan render --open` + `ox plan viz`, single line.
  - Once-per-episode throttle on the HTML path; stamp resets after a neutral prompt and re-hints.
  - Plan-mode lead wins when both triggers fire.
  - `plan.html=off` silences the HTML-intent steer; plan-mode steer still fires.
  - `promptRequestsHTMLPlan` positives/negatives, incl. `/html-plan`, case-insensitivity, and precision negatives ("render the login page", "plan the sprint").
- Existing plan-mode lifecycle tests retained (renamed call sites), confirming no regression.

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smarter plan guidance that can trigger when planning mode is active or when a prompt requests an HTML/visual plan.
  * Added an HTML-plan-specific opt-out to suppress only the HTML-style steering while keeping standard planning guidance.

* **Bug Fixes**
  * Improved throttling to be episode-scoped, reset after neutral prompts, and to “upgrade” appropriately when both triggers occur.
  * More reliably detects HTML-plan intent using phrase matching with safer word boundaries.

* **Tests**
  * Expanded and refactored the hint-emission test suite to cover HTML-intent, throttling, opt-out, and upgrade ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->