### PR TITLE
feat(plan): multi-user plan-review feedback loop + real-time await

### DIFF
--- a/cmd/ox/agent_hook_plan_nudge.go
+++ b/cmd/ox/agent_hook_plan_nudge.go
@@ -224,12 +224,12 @@ func formatPlanNudgeLine(res planJSONResult) string {
 	}
 	if detail := strings.Join(parts, " + "); detail != "" {
 		// Material path: lead with the team-context signals.
-		return fmt.Sprintf("Your plan touches %s. Render it as a SageOx team-context-optimized plan (HTML) with `ox plan render --open`, then offer to start the live review loop (`ox plan review <slug>`) so the human can mark it up in-browser — ask first.", detail)
+		return fmt.Sprintf("Your plan touches %s. Render it as a SageOx team-context-optimized plan (HTML) with `ox plan render --open`, then offer the live review loop (`ox plan review <slug>`) so the human marks it up in-browser (ask first); receive their feedback in-turn with `ox plan review await <slug>` — it BLOCKS for feedback, so confirm with the user before entering it.", detail)
 	}
 
 	// NonTrivial-only path: no team-context signals fired, but the plan is
 	// structurally substantial. Lead with the render benefit and the scope.
-	return fmt.Sprintf("Your plan spans %s. Render it as a SageOx team-context-optimized plan (HTML) with `ox plan render --open`, then offer to start the live review loop (`ox plan review <slug>`) so the human can mark it up in-browser — ask first.", planScopePhrase(res.Signals.Files, res.Signals.Steps))
+	return fmt.Sprintf("Your plan spans %s. Render it as a SageOx team-context-optimized plan (HTML) with `ox plan render --open`, then offer the live review loop (`ox plan review <slug>`) so the human marks it up in-browser (ask first); receive their feedback in-turn with `ox plan review await <slug>` — it BLOCKS for feedback, so confirm with the user before entering it.", planScopePhrase(res.Signals.Files, res.Signals.Steps))
 }
 
 // planScopePhrase describes plan scale from the structural counts, naming only

--- a/cmd/ox/agent_hook_plan_nudge_test.go
+++ b/cmd/ox/agent_hook_plan_nudge_test.go
@@ -73,6 +73,8 @@ func TestFormatPlanNudgeLine_MentionsOnlyFiredSignals(t *testing.T) {
 	assert.Contains(t, line, "ox plan render --open")
 	assert.Contains(t, line, "SageOx team-context-optimized plan")
 	assert.Contains(t, line, "ox plan review", "exit nudge must offer the live review loop")
+	assert.Contains(t, line, "ox plan review await", "nudge must point to the agent-side await loop")
+	assert.Contains(t, line, "confirm", "nudge must carry the ask-before-blocking guardrail")
 	assert.NotContains(t, line, "ox plan --open")
 	// single line — grepability invariant
 	assert.NotContains(t, line, "\n")
@@ -102,6 +104,8 @@ func TestFormatPlanNudgeLine_NonTrivialOnly(t *testing.T) {
 		assert.Contains(t, line, "6 steps")
 		assert.Contains(t, line, "SageOx team-context-optimized plan")
 		assert.Contains(t, line, "ox plan render --open")
+		assert.Contains(t, line, "ox plan review await", "non-trivial nudge must also point to await")
+		assert.Contains(t, line, "confirm", "ask-before-blocking guardrail on the non-trivial path too")
 		assert.NotContains(t, line, "collision", "no team-context signal fired — must not be mentioned")
 		assert.NotContains(t, line, "\n", "single line — grepability invariant")
 	})

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -472,7 +472,7 @@ func writePlanHuman(cmd *cobra.Command, result plan.Result, savedDir string) err
 		if s.Material {
 			lead = "Material signals found."
 		}
-		fmt.Fprintf(&b, "\n%s Render a SageOx team-context-optimized plan with `ox plan render --open`, then start a live review loop with `ox plan review <slug>` — mark it up in the browser and your AI coworker addresses each item live.\n", lead)
+		fmt.Fprintf(&b, "\n%s Render a SageOx team-context-optimized plan with `ox plan render --open`, then start a live review loop with `ox plan review <slug>` — the human marks it up in the browser and the AI coworker receives it in-turn via `ox plan review await <slug>`, addressing each item live. `await` BLOCKS for feedback, so the coworker should confirm with the user before entering that loop (or use a short --timeout and poll).\n", lead)
 	}
 
 	fmt.Fprint(out, b.String())
@@ -622,7 +622,7 @@ func emitRenderedHTML(cmd *cobra.Command, htmlBytes []byte, savedDir, outPath st
 	// Encourage the live review loop once the page is in front of a human — the
 	// slug is real only when the plan is in the ledger (capture on).
 	if savedDir != "" && !cli.IsHeadless() {
-		cli.PrintHint("Start a live review loop: `ox plan review " + filepath.Base(savedDir) + "` — mark it up in the browser, your AI coworker addresses each item live.")
+		cli.PrintHint("Start a live review loop: `ox plan review " + filepath.Base(savedDir) + "` — mark it up in the browser; your AI coworker receives it via `ox plan review await " + filepath.Base(savedDir) + "` and addresses each item live (it blocks for feedback — the coworker should confirm before entering that wait).")
 	}
 	if savedDir != "" {
 		if _, _, isPointer, exists := plan.PlanHTMLPath(savedDir); exists && !isPointer {

--- a/cmd/ox/plan_review_await.go
+++ b/cmd/ox/plan_review_await.go
@@ -38,6 +38,10 @@ prints it as JSON on stdout, and exits. The agent then addresses each item, runs
 with ` + "`ox plan render`" + ` (the reviewers' page auto-reloads over SSE), and calls await
 again — a real turn-based loop that keeps the authoring agent in context.
 
+Because this command BLOCKS (up to --timeout), CONFIRM WITH THE USER before entering
+the loop — do not silently park an autonomous ("auto") agent run waiting on a human.
+Ask first, or pass a short --timeout and poll between other work.
+
 Emits immediately if feedback is already waiting (never strands a race). Exits with
 status "timeout" if nothing arrives within --timeout, or "approved" once a reviewer
 approves the plan (the loop is done).`,
@@ -86,6 +90,14 @@ func runPlanReviewAwait(cmd *cobra.Command, slug string, timeout time.Duration) 
 	_ = os.MkdirAll(filepath.Join(planDir, "feedback"), 0o755)
 	_ = w.Add(planDir)
 	_ = w.Add(filepath.Join(planDir, "feedback"))
+
+	// Re-snapshot AFTER registering the watcher: feedback written in the gap between
+	// the first snapshot and watch registration would otherwise be seen by neither
+	// (the watcher didn't exist yet) and strand the agent until --timeout. This
+	// closes that race.
+	if res, done := awaitSnapshot(planDir); done {
+		return emitAwait(cmd, slug, res)
+	}
 
 	fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for reviewer feedback on %q … (Ctrl-C to stop)\n", slug)
 

--- a/cmd/ox/plan_review_await.go
+++ b/cmd/ox/plan_review_await.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/sageox/ox/internal/plan"
+	"github.com/spf13/cobra"
+)
+
+// plan_review_await.go implements `ox plan review await <slug>` — the AGENT side of
+// the real-time review loop. Rather than parking the authoring coworker in a serve
+// loop (where it has no turn to act), the agent runs this and BLOCKS until reviewers
+// submit; it then prints every reviewer's open items as JSON and exits, so the agent
+// acts in-context, resolves, re-renders (the reviewers' page auto-reloads), and calls
+// await again. It reads the ledger directly (no socket), so it is multi-user by
+// construction — feedback from any number of reviewers is merged — and cross-harness:
+// any coding agent can run a blocking command and read its stdout.
+var planReviewAwaitCmd = &cobra.Command{
+	Use:   "await <slug>",
+	Short: "Block until reviewers submit feedback, then print open items as JSON (agent loop)",
+	Long: `Block until human reviewers submit review feedback, then emit the open items as JSON.
+
+This is the agent side of the review loop. Instead of parking the authoring agent in
+a serve loop (where it cannot act), the agent runs:
+
+    ox plan review await <slug>
+
+which blocks until there is open, unaddressed feedback from ANY reviewer (multi-user),
+prints it as JSON on stdout, and exits. The agent then addresses each item, runs
+` + "`ox plan feedback resolve <slug> <anchor> --state addressed --commit <sha>`" + `, re-renders
+with ` + "`ox plan render`" + ` (the reviewers' page auto-reloads over SSE), and calls await
+again — a real turn-based loop that keeps the authoring agent in context.
+
+Emits immediately if feedback is already waiting (never strands a race). Exits with
+status "timeout" if nothing arrives within --timeout, or "approved" once a reviewer
+approves the plan (the loop is done).`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		timeout, _ := cmd.Flags().GetDuration("timeout")
+		return runPlanReviewAwait(cmd, args[0], timeout)
+	},
+}
+
+// awaitResult is the JSON contract the agent consumes from stdout.
+type awaitResult struct {
+	Slug      string            `json:"slug"`
+	Status    string            `json:"status"` // feedback | approved | timeout
+	Open      []plan.MergedItem `json:"open"`
+	Contested []string          `json:"contested,omitempty"`
+	Counts    awaitCounts       `json:"counts"`
+}
+
+type awaitCounts struct {
+	Open      int `json:"open"`
+	Reviewers int `json:"reviewers"`
+}
+
+func runPlanReviewAwait(cmd *cobra.Command, slug string, timeout time.Duration) error {
+	gitRoot := findGitRoot()
+	_, _, info, err := plan.Load(gitRoot, slug)
+	if err != nil {
+		return fmt.Errorf("load plan %q: %w", slug, err)
+	}
+	planDir := info.Dir
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt)
+	defer stop()
+
+	// emit immediately if feedback is already waiting or the plan is already approved
+	if res, done := awaitSnapshot(planDir); done {
+		return emitAwait(cmd, slug, res)
+	}
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("watch feedback: %w", err)
+	}
+	defer w.Close()
+	_ = os.MkdirAll(filepath.Join(planDir, "feedback"), 0o755)
+	_ = w.Add(planDir)
+	_ = w.Add(filepath.Join(planDir, "feedback"))
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for reviewer feedback on %q … (Ctrl-C to stop)\n", slug)
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	recheck := make(chan struct{}, 1)
+	trigger := func() {
+		select {
+		case recheck <- struct{}{}:
+		default:
+		}
+	}
+	var debounce *time.Timer
+	for {
+		select {
+		case <-ctx.Done():
+			return emitAwait(cmd, slug, awaitResult{Status: "timeout"})
+		case <-timer.C:
+			return emitAwait(cmd, slug, awaitResult{Status: "timeout"})
+		case _, ok := <-w.Events:
+			if !ok {
+				return emitAwait(cmd, slug, awaitResult{Status: "timeout"})
+			}
+			// coalesce write bursts (a round write, a resolve, a re-render) into one recheck
+			if debounce != nil {
+				debounce.Stop()
+			}
+			debounce = time.AfterFunc(200*time.Millisecond, trigger)
+		case <-recheck:
+			if res, done := awaitSnapshot(planDir); done {
+				return emitAwait(cmd, slug, res)
+			}
+		case _, ok := <-w.Errors:
+			if !ok {
+				return emitAwait(cmd, slug, awaitResult{Status: "timeout"})
+			}
+		}
+	}
+}
+
+// awaitSnapshot reads current review state; done is true when there is open feedback
+// (from any reviewer) or the plan has been approved — the two conditions that end a
+// wait and hand the agent something to do.
+func awaitSnapshot(planDir string) (awaitResult, bool) {
+	if meta, err := plan.LoadMeta(planDir); err == nil && meta.Status == plan.PlanStatusApproved {
+		return awaitResult{Status: "approved"}, true
+	}
+	items, err := plan.AssembleReview(planDir)
+	if err != nil {
+		return awaitResult{}, false
+	}
+	var open []plan.MergedItem
+	reviewers := map[string]bool{}
+	for _, it := range items {
+		if it.Open && it.Status != plan.FeedbackApprove {
+			open = append(open, it)
+			if it.Reviewer != "" {
+				reviewers[it.Reviewer] = true
+			}
+		}
+	}
+	if len(open) == 0 {
+		return awaitResult{}, false
+	}
+	var contested []string
+	for a := range plan.ContestedAnchors(items) {
+		contested = append(contested, a)
+	}
+	sort.Strings(contested)
+	return awaitResult{
+		Status:    "feedback",
+		Open:      open,
+		Contested: contested,
+		Counts:    awaitCounts{Open: len(open), Reviewers: len(reviewers)},
+	}, true
+}
+
+func emitAwait(cmd *cobra.Command, slug string, res awaitResult) error {
+	res.Slug = slug
+	if res.Open == nil {
+		res.Open = []plan.MergedItem{}
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(res)
+}
+
+func init() {
+	planReviewAwaitCmd.Flags().Duration("timeout", 30*time.Minute, "block at most this long before exiting with status \"timeout\"")
+	planReviewCmd.AddCommand(planReviewAwaitCmd)
+}

--- a/docs/adr/ADR-025-plan-annotation-and-feedback-delivery.md
+++ b/docs/adr/ADR-025-plan-annotation-and-feedback-delivery.md
@@ -1,0 +1,197 @@
+# ADR-025: Plan Review — Annotation Model, Anchors, and Feedback-Delivery Classes
+
+**Status**: Draft (Proposed) — **awaiting Ryan's review**. Two items are Required-Review per `CLAUDE.md`: the **delivery-class terminology** (§2, customer-facing vocabulary) and the **anchor scheme + delivery defaults** (§3–§4, data-access ergonomics).
+**Date**: 2026-06-30
+**Deciders**: SageOx Engineering (terminology + ergonomics owned by Ryan)
+**Relates to**: [ADR-021 `ox plan` context-not-inference](ADR-021-ox-plan-context-not-inference.md), [ADR Whisper & Murmur Architecture](adr-whisper-murmur-architecture.md), [ADR-018 UserPromptSubmit JIT discovery](ADR-018-userpromptsubmit-jit-discovery.md), [ADR-026 Collaborative review & execution gating](ADR-026-collaborative-review-and-execution-gating.md), `docs/specs/plan-render-adoption.md`
+
+> **DRAFT.** Records the intended vocabulary and data model for the HTML-plan **review feedback loop** — how a human's marks on a rendered plan flow back to a coding agent — so the terms are fixed before they spread through code, skills, and docs. The current loop (typed note at a content-hash anchor → async task) is built; the generalizations (richer annotation kinds, real-time delivery, durable anchors) are proposed. Companion strategy write-up: `~/.claude/plans/system-instruction-you-are-working-partitioned-lecun.md`; visual explainer: `.context/plan-feedback-sota.html`.
+
+## Context
+
+`ox plan render` / `ox plan review` turns a plan into a live HTML page a human marks up. Those marks must reach a coding agent — ideally the one that authored the plan, ideally fast. The mechanism already exists in one narrow form (a typed note pinned to a content-hash anchor, delivered as an async agent-task) and is about to grow along three independent dimensions:
+
+1. **More delivery paths.** Different agent harnesses (Claude Code, Codex, Gemini, …) expose different injection mechanisms; some can take feedback *in real time*, others only on their next turn, others only via a freshly-spawned instance. We need names for these latency classes that are precise and consistent across the product, or every surface will invent its own.
+2. **Richer annotation.** Typed-note-at-anchor is the easy model. Humans also want to circle, arrow, strike, suggest an edit, or scribble free-form. All of that must funnel into something an agent can act on.
+3. **Stable addressing.** Every mark hangs off an **anchor**. The anchor scheme is currently implicit in the page JS. It is load-bearing and undocumented, and it must be defined before richer marks (ranges, regions, gestures) can attach to it.
+
+There is **no existing ADR** for this. ADR-021 fixes the *enrichment* story (`ox plan` provides context, the client does inference; `annotations.json` holds **enrichment badges**). This ADR is the *review-feedback* story and is deliberately disjoint from it.
+
+> **Terminology hazard — read first.** The word "annotation" is overloaded. This ADR uses:
+> - **Enrichment badge** — an ox/agent-authored signal *about* the plan (collision, prior-art, aligns/conflicts). Lives in `annotations.json`. Owned by ADR-021. **Not** this ADR.
+> - **Review annotation** (a.k.a. **mark**) — a *human reviewer's* feedback pinned to part of the plan. Lives in `feedback/round-*.json`. **This ADR.**
+
+### Problem statement
+
+Fix a vocabulary and a data model such that: (a) any feedback **modality** (typed note, suggested edit, free-form drawing, approval) normalizes to one envelope an agent can act on; (b) any envelope can ride any **delivery class** (the two are orthogonal); (c) every mark addresses the plan through a **defined, stable anchor**; and (d) feedback content is treated as untrusted **data**, never as commands.
+
+## Decision
+
+### 1. Two orthogonal axes
+
+The model separates **what the human expressed** (the annotation) from **how/when it reaches the agent** (the delivery class). These compose freely: a free-form circle can be delivered real-time *or* delegated; a typed note can be delivered any of three ways.
+
+```mermaid
+flowchart LR
+  subgraph WHAT["Annotation model — what the human expressed"]
+    direction TB
+    A1["typed note at anchor"]
+    A2["suggested edit"]
+    A3["gesture: circle, arrow, strike"]
+    A4["approval or verdict"]
+  end
+  subgraph NORM["Normalize"]
+    N["envelope: targets, kind, payload, attachments, provenance"]
+  end
+  subgraph HOW["Delivery class — how and when it reaches the agent"]
+    direction TB
+    D1["real-time: in-turn await"]
+    D2["next-turn: whisper on next prompt"]
+    D3["delegated: task queue or fresh agent"]
+  end
+  A1 --> N
+  A2 --> N
+  A3 --> N
+  A4 --> N
+  N --> D1
+  N --> D2
+  N --> D3
+```
+
+### 2. Delivery-class terminology — **Required-Review (Ryan owns this)**
+
+Three classes name *when* the agent acts on a page mark and *which* agent. The discriminators are **WHO** (the same in-context authoring agent vs. a different/fresh one) and **WHEN** (this turn / next turn / out-of-band).
+
+| Class | WHO acts | WHEN | Human waits? | Mechanisms (this repo) |
+|-------|----------|------|--------------|------------------------|
+| **real-time** | same authoring agent, in context | within the turn the submit triggers | yes (synchronous) | blocking `ox plan review await` tool; stdin/PTY |
+| **next-turn** | same agent | at its next turn boundary | no | plan-feedback as a **whisper** source (UserPromptSubmit `additionalContext`); SDK stream-input |
+| **delegated** | a different / fresh / any-available agent | out-of-band, whenever | no | async agent-task queue (`KindPlanFeedback`, exists); headless responder (`codex exec resume`, `claude -p`) |
+
+**Naming rationale (the part Ryan flagged):**
+
+- **`real-time`** — kept. Names the UX promise. Precise synonym: *in-turn / synchronous*. (Engineering prose may use "in-turn"; product/user copy uses "real-time".)
+- **`next-turn`** — replaces **`turn-aligned`**. Keeps the "turn" framing Ryan liked; drops "aligned" (vague). Chosen over **`future-turn`** because "future" is unbounded (any later turn) while the signal lands at the **next** turn boundary specifically — "next" is the accurate word.
+- **`delegated`** — replaces **`batch`**. "Batch" implies accumulation/grouping, which is not the defining trait. The defining trait is that the work is **handed to a different agent** (fresh / headless / any-available of the type), out of band. "Delegated" names exactly that. (Considered: `deferred` — describes timing, not the hand-off; `async` — same; `delegated` is the right discriminator because WHO, not WHEN, is what separates it from `next-turn`.)
+
+This vocabulary is the canonical set; code, skills, CLI help, and docs use these three words and no synonyms.
+
+### 3. Anchors — **Required-Review (data-access ergonomics)**
+
+An **anchor** is the stable identity of an addressable plan element, the thing a review annotation pins to and the id `ox plan feedback resolve <slug> <anchor>` keys on.
+
+**Current scheme (built — `internal/plan/assets/review.js`):**
+
+- **Addressable set** (the `SELECTOR`): `section[id]`, `li`, `tr`, `.ox-chip`, `.stat`, `.bar-row` — i.e. sections, list items, table rows, badge chips, stat cells, viz bar-rows. Granularity is block/row level.
+- **Id**: `anchor = "h" + fnv1a32( norm(heading) + "\x00" + norm(text) )`, eight lowercase hex chars. `heading` = the nearest enclosing `section[id]`'s `h2` (else the section id); `text` = the element's text minus review glyphs; `norm` = collapse-whitespace, trim, lowercase.
+- **Contract**: *content-addressed.* Stable across re-renders **iff** (heading + text) is unchanged. It **intentionally breaks** when the agent rewrites that text — the break is the natural "this was addressed" signal (the mark falls off resolved content). Marks whose text changed *without* a matching resolution are surfaced as **orphans** in the page, never silently dropped.
+- **Safety**: anchors are validated to contain no `/`, `\`, or `..` (`validateAnchor`) because they key filesystem-adjacent operations.
+
+**Known limits**: 32-bit collision ceiling; fragile to *incidental* edits in the same block (a typo fix re-anchors the mark); single-element only (no ranges/regions); identity == content, so a block cannot be tracked through a rewrite the author did *not* intend as a resolution.
+
+**Proposed evolution (decision point — see §6):** add a renderer-assigned **durable block id** — the markdown→HTML pass stamps a stable `data-anchor` on each addressable block, persisted in the render and the merged review state, with the content-hash kept as a re-association fallback. This decouples identity from exact text and is a **prerequisite** for ranges, suggested-edits, and gestures (all of which need identity independent of the text). **Recommendation:** keep content-hash for v1 (it is sufficient for typed-note-at-anchor and self-heals the resolved-signal for free); introduce durable ids in the same change that adds the first richer modality.
+
+### 4. The annotation envelope
+
+**Current shape (built — `internal/plan/feedback.go`).** A review round (`FeedbackSet`) is one page submit; each item is one anchored mark; the agent's disposition is an append-logged `Resolution`. All of it lives under the plan's ledger dir, version-controlled with the plan.
+
+```jsonc
+// feedback/round-<ts>.json  — one review round (immutable)
+{ "slug": "2026-06-30-auth-plan", "reviewer": "ryan", "created_at": "…Z",
+  "items": [ { "anchor": "h3f9a1c2", "section": "Authentication", "label": "token bucket",
+               "status": "request-change", "note": "rate-limit per-IP too" } ] }
+// feedback/resolutions.json  — agent dispositions (append log)
+[ { "anchor": "h3f9a1c2", "state": "addressed", "commit": "abc123", "note": "added per-IP bucket", "at": "…Z" } ]
+```
+
+`status ∈ {approve, request-change, flag, comment}`; `state ∈ {addressed, wontfix, verified}`. `AssembleReview` joins latest-mark-per-anchor with latest-resolution and computes `open` (no resolution, or re-raised after the last one). This is the single source the digest and the render read. (Latest-per-anchor is the **single-reviewer** case; multiplayer generalizes the unit to a per-target **thread** that keeps every principal's voice — §7, ADR-026.)
+
+**Generalized envelope (proposed).** Today's `FeedbackItem` is one *profile* of a general **review annotation**: a `(targets, kind, payload, attachments, provenance)` tuple. Generalizing unlocks ranges, suggested edits, and free-form gestures without a second pipeline.
+
+```jsonc
+{
+  "id": "<uuidv7>",                 // identity of the annotation itself, independent of its target
+  "targets": [                      // was a single "anchor"
+    { "type": "anchor",  "anchor": "h3f9a1c2" },                       // one element (today)
+    { "type": "range",   "from": "h3f9a1c2", "to": "h9b1" },           // a span (new)
+    { "type": "region",  "anchor": "h3f9a1c2", "rect": [x,y,w,h] },    // geometric, relative to a block (new)
+    { "type": "document" }                                            // whole plan (e.g. top-level approve)
+  ],
+  "kind": "request-change",         // approve | request-change | flag | comment | question | suggestion | gesture
+  "payload": {                      // exactly one
+    "note":       { "text": "…" },                                    // typed note (today)
+    "suggestion": { "text": "…", "replacement": "…" },                // suggested edit / diff (new)
+    "gesture":    { "strokes": [ /* vector points */ ], "gloss": "circled the retry path" }, // free-form (new)
+    "approval":   {}                                                  // verdict-only
+  },
+  "attachments": [ { "type": "image/png", "ref": "…" } ],             // e.g. raster of a drawing (new)
+  "reviewer": "ryan", "created_at": "…Z", "round": "round-<ts>"
+}
+```
+
+Backward-compatible mapping: today's `{anchor, section, label, status, note}` ≡ `{ targets:[{anchor}], kind:status, payload:{note} }`, with `section`/`label` as derived display metadata. `Resolution` keys on a target (anchor today; annotation `id` under durable-ids).
+
+### 5. Visual / free-form feedback — one normalization rule
+
+The thesis that answers "how does a drawing get passed?": **every input modality normalizes to the same envelope; geometry resolves to anchors; the raw visual is preserved as an attachment; the agent always receives an actionable anchored form regardless of how the human expressed it.** Typed-note-at-anchor is simply the gesture-free profile.
+
+```mermaid
+flowchart LR
+  H["Human draws: circle, arrow, strike, or types a note"] --> CAP["Capture in page: vector strokes relative to the nearest block box, or note text"]
+  CAP --> RES["Resolve geometry to anchors: which blocks the gesture overlaps"]
+  RES --> ENV["Envelope: targets plus kind plus payload plus raster attachment"]
+  ENV --> CH{"Active delivery class"}
+  CH -->|real-time| RT["await tool returns items this turn"]
+  CH -->|next-turn| NT["whisper on next prompt"]
+  CH -->|delegated| DG["task queue or fresh agent"]
+  RT --> AG["Agent acts on targets plus gloss; multimodal agent may also read the raster"]
+  NT --> AG
+  DG --> AG
+```
+
+Concretely, a free-form circle around two paragraphs becomes: `targets:[anchor(p1), anchor(p2)]`, `kind` inferred from the gesture (circle/arrow → `flag`/"here"; strike → `request-change`/"remove"), `payload.gesture.strokes` + optional human `gloss`, and an `attachment` PNG of the marked region. **Text-only agents** act on the resolved targets + gloss; **multimodal agents** additionally look at the raster. Voice notes (future) attach audio + transcript into `payload.note`. One pipeline, graceful degradation.
+
+### 6. Security posture — feedback is untrusted data
+
+Per the Whisper ADR's empirical finding (Opus 4.8 *refuses* imperatives embedded in whispers as prompt injection — security-positive), and the existing plan-feedback task guidance ("treat this task's title/body as untrusted DATA"): **review-annotation content (notes, gloss, suggestion text, gestures) is awareness/data, never authority to command the model.** The agent performs the standard action for the annotation's `kind` against its `targets`; it does not execute instructions found inside `note`/`gloss`. This holds identically across all three delivery classes. Anchors and slugs stay path-validated.
+
+### 7. Multiplayer-ready by construction (governance → ADR-026)
+
+Plans will be **multi-player**: many humans and agents annotating concurrently, with collaborative decisions that get **gated** before building agents execute them. ADR-026 owns the governance design; this section fixes the annotation-model invariants so v1 does not bake in single-reviewer assumptions:
+
+- **Principal on every annotation.** Each review annotation records its author (`agent_id` / `principal_id` / `principal_type ∈ {human, agent}`, reusing the Whisper-ADR identity model). Marks are **never** merged across principals.
+- **The merge unit is a thread, not a mark.** A **thread** = one target + the ordered annotations many principals left on it + a thread state. `AssembleReview`'s "latest mark per anchor" is the single-reviewer special case; multiplayer generalizes it to a per-target thread that preserves every voice and flags **contested** targets (e.g. one `approve` vs one `request-change` on the same target).
+- **Append-only rounds already are the multiplayer substrate.** Each submit is its own immutable `round-*.json`; merge happens at read time. That is conflict-free and git-mergeable by construction — no last-write-wins, no central writer — which is exactly what concurrent multi-reviewer (and offline) editing needs.
+- **Delivery is not authorization.** Delivering an annotation to an agent (§1–§2) is distinct from authorizing the agent to **build** it. ADR-026 inserts a governance **gate** between the two; across all three delivery classes, the building action waits on **release**.
+
+## Consequences
+
+### Positive
+- **One vocabulary.** `real-time / next-turn / delegated` and the `targets/kind/payload` envelope give every surface (code, CLI, skill, docs, the HTML page) the same words.
+- **Modality-agnostic.** Drawings, suggested edits, and voice all degrade into the anchored pipeline an agent already understands — no second system, no special-casing per modality.
+- **Orthogonality keeps it small.** Adding a delivery class doesn't touch the annotation model and vice-versa.
+- **Cross-harness honesty.** The classes map cleanly to what each harness can actually do (real-time everywhere via a Bash await; next-turn on hook harnesses; delegated as the universal backstop).
+- **Backward compatible.** The shipped typed-note loop is exactly the v1 profile; nothing built has to change to adopt the vocabulary.
+
+### Negative / risks
+- **Anchor fragility (today).** Content-hash anchors orphan on incidental edits. Mitigated now by surfacing orphans; resolved later by durable ids (§3) — but that adds a renderer responsibility and a migration of existing marks.
+- **Gesture resolution is lossy.** Geometry→anchor mapping can mis-attribute a sloppy circle. Mitigation: attach the raster so a human (and a multimodal agent) can disambiguate; keep the inferred targets editable in the page before submit.
+- **Multimodal dependence.** Full fidelity of drawings needs a multimodal agent; text-only agents get targets + gloss only. Acceptable — the gloss + targets are themselves actionable.
+- **Vocabulary churn cost.** Renaming `turn-aligned`/`batch` in any place they've already leaked (the strategy doc, the explainer) is a one-time sweep.
+
+## Alternatives considered
+
+- **Keep `turn-aligned` / `batch` (rejected).** "Aligned" is vague and "batch" mis-describes the mechanism (it's a hand-off, not a grouping). `next-turn` / `delegated` are more precise.
+- **`future-turn` for the middle class (rejected in favor of `next-turn`).** "Future" is unbounded; the signal lands at the *next* boundary. "Next" is the accurate word and equally short.
+- **A separate pipeline for drawings (rejected).** Treating visual feedback as its own channel doubles the surface and strands text-only agents. Normalizing every modality to one envelope (§5) is simpler and degrades better.
+- **Anchor by DOM/XPath position (rejected).** Positional anchors break on reorder and don't self-signal resolution. Content-hash self-heals the resolved case; durable ids (when needed) beat XPath on rewrite-survival.
+- **Live socket as the source of truth (rejected, per `feedback.go`).** A machine runs many ox daemons, so a persistent localhost endpoint is ambiguous about which plan it targets. The server stays ephemeral and agent-owned; the ledger files are the source of truth.
+
+## References
+- `internal/plan/feedback.go` — `FeedbackItem` / `FeedbackSet` / `Resolution` / `AssembleReview` (the built v1 profile).
+- `internal/plan/assets/review.js` — the anchor function (`anchorFor`, `fnv1a`) and the mark/orphan UX.
+- `cmd/ox/plan_review.go`, `cmd/ox/plan_feedback.go` — the live server, `/feedback|/accept|/reopen|/approve`, and the `KindPlanFeedback` delegated path.
+- [ADR-021](ADR-021-ox-plan-context-not-inference.md) — enrichment badges (`annotations.json`); the *other* meaning of "annotation," kept disjoint here.
+- [Whisper & Murmur ADR](adr-whisper-murmur-architecture.md) — the next-turn delivery substrate and the untrusted-data / prompt-injection posture (§6).
+- [ADR-026](ADR-026-collaborative-review-and-execution-gating.md) — multiplayer review semantics + execution gating (the governance layer §7 reserves space for).
+- `~/.claude/plans/system-instruction-you-are-working-partitioned-lecun.md` — feedback-channel strategy; `.context/plan-feedback-sota.html` — visual explainer.

--- a/docs/adr/ADR-026-collaborative-review-and-execution-gating.md
+++ b/docs/adr/ADR-026-collaborative-review-and-execution-gating.md
@@ -1,0 +1,150 @@
+# ADR-026: Collaborative Plan Review & Execution Gating
+
+**Status**: Draft (Proposed) — **awaiting Ryan's review**. The whole ADR is Required-Review: it defines a **trust boundary** (who may authorize an agent to build) and **data-access ergonomics** (how multi-principal feedback is stored, merged, and surfaced).
+**Date**: 2026-06-30
+**Deciders**: SageOx Engineering (governance + authorization policy owned by Ryan)
+**Relates to**: [ADR-025 Annotation Model, Anchors, Delivery Classes](ADR-025-plan-annotation-and-feedback-delivery.md), [ADR Whisper & Murmur Architecture](adr-whisper-murmur-architecture.md), [ADR-021 `ox plan` context-not-inference](ADR-021-ox-plan-context-not-inference.md)
+
+> **DRAFT.** ADR-025 fixed the *single-author* feedback loop (annotation model, anchors, delivery classes) and reserved space (§7) for this one. This ADR adds the two things multi-player plans need: **(1) multiplayer review semantics** — many humans and agents annotating the same plan concurrently, with every voice preserved — and **(2) execution gating** — a governance step that decides *whether and when* a collaboratively-agreed decision is released to building agents. None of this is built yet.
+
+## Context
+
+Plans are becoming **multi-player**. Several humans review the same rendered plan; agent contributors annotate it too; and an orchestrator (human, or an overarching agent) wants to **gate** when the agreed decisions actually get executed by the agents doing the building. Two gaps in the current single-author loop:
+
+1. **Concurrency loses voices.** `AssembleReview` keeps the *latest mark per anchor* (ADR-025 §4). With two reviewers marking the same element, one is silently overwritten. Multi-player needs every principal's mark preserved and disagreement made visible, not resolved by write-order.
+2. **Feedback is treated as immediately actionable.** Today a mark flows straight to an agent as work. But a collaborative decision should not be built until the group has **agreed** and an **authorizer has released it**. There is no gate between "feedback exists" and "agent builds."
+
+The design must add both without abandoning ADR-025's foundations: append-only immutable rounds, ephemeral agent-owned server, ledger-as-source-of-truth, and feedback-as-untrusted-data.
+
+### Problem statement
+
+Define (a) **multiplayer review semantics** — identity, threads, concurrency, contested decisions, attribution — and (b) an **execution-gating model** — a state machine, an authorization policy (who may release), gate scope, veto, and audit — such that building agents act only on **released** work, and an agent may *contribute* to review but may *authorize* execution only when explicitly and auditably designated.
+
+## Decision
+
+### 1. A third concern, orthogonal to ADR-025's two axes
+
+ADR-025 separated **WHAT** the human expressed (annotation model) from **HOW/WHEN** it reaches the agent (delivery class). This ADR adds **WHETHER + WHO authorizes execution** (governance). It is orthogonal to both: a real-time-delivered annotation can still be gated; the building action waits on **release** regardless of delivery class.
+
+```mermaid
+flowchart LR
+  subgraph PRIN["Many principals: humans and agents"]
+    R1["reviewer A (human)"]
+    R2["reviewer B (human)"]
+    R3["agent contributor"]
+  end
+  R1 --> THR["Threads per target: every voice kept, attributed"]
+  R2 --> THR
+  R3 --> THR
+  THR --> DEC["Decision: agreed or contested"]
+  DEC --> GATE{"Gate: authorized to execute?"}
+  GATE -->|"released by authorizer"| BUILD["Building agents act on released work only"]
+  GATE -->|"held, contested, or vetoed"| HOLD["Not executed; returns to discussion"]
+```
+
+### 2. Identity and roles (reuse the Whisper principal model)
+
+Every review annotation already carries an author (ADR-025 §7). This ADR fixes the identity + role vocabulary, reusing the Whisper ADR's `agent_id` / `principal_id` / `principal_type` rather than inventing a parallel one.
+
+| Concept | Definition |
+|---------|-----------|
+| **principal** | the actor behind an annotation or a gate event: `{ principal_id, principal_type ∈ {human, agent} }` |
+| **contributor** | any principal who annotates (humans **and** agent contributors) |
+| **reviewer** | a contributor whose verdict (`approve` / `request-change`) counts toward a decision |
+| **authorizer** | a principal permitted to **release** a gate (a.k.a. orchestrator). May be human or a designated agent |
+| **owner** | the plan author; the default authorizer when no policy is configured |
+
+An agent can hold any role. Critically, **an agent authorizer is a designated, audited exception**, not the default (see §8).
+
+### 3. Multiplayer review semantics
+
+- **The merge unit is a thread.** A **thread** = one *target* (ADR-025 anchor/range/region/document) + the ordered annotations many principals left on it + a thread state. It replaces "latest mark per anchor." Every principal's mark is retained and attributed.
+- **Append-only rounds already are the multiplayer substrate.** Each submit is its own immutable `round-*.json`; the merge happens at read time. That is **conflict-free and git-mergeable by construction** — no central writer, no last-write-wins — which is exactly what concurrent (and offline) multi-reviewer editing needs. The change is to the *merge view*, not the storage.
+- **Contested threads are first-class.** When verdicts on one target conflict (e.g. one `approve`, one `request-change`), the thread state is **contested** and surfaced as such. A contested target cannot reach `released` until resolved — by discussion converging, or by an authorizer deciding.
+- **Attribution + audit come free.** Who said what, when, in which round — read straight from the append log. Gate events (below) append to the same log.
+
+### 4. Execution gating — the state machine
+
+Gating attaches to a **decision** — a thread, or a plan **section** grouping several threads. States:
+
+```mermaid
+flowchart LR
+  PRO["proposed"] --> DIS["discussed"]
+  DIS --> AGR["agreed"]
+  AGR --> AUT["authorized"]
+  AUT --> REL["released"]
+  REL --> EXE["executing"]
+  EXE --> DON["done"]
+  DIS -.-> BLK["blocked or vetoed"]
+  AGR -.-> BLK
+  BLK -.-> DIS
+  PRO -.-> WDR["withdrawn"]
+```
+
+- **The building agent's precondition is `released`.** A decision in any earlier state is visible to agents as *context*, never as a build directive.
+- `agreed` (the group converged) is distinct from `authorized` (an authorizer signed off) and from `released` (cleared to build). Separating them lets policy require an explicit human/orchestrator gate even after consensus.
+- `blocked / vetoed` halts progress until cleared; `withdrawn` retires a decision.
+
+### 5. Authorization policy — who may release — **Required-Review**
+
+Configurable per plan, overridable per section. The gate's release condition is one of:
+
+| Policy | Release condition | Notes |
+|--------|-------------------|-------|
+| **owner** (default) | the plan owner releases | simplest; always available so a plan can never deadlock for lack of an authorizer |
+| **quorum** | N-of-M reviewer approvals, no open `request-change` | group consensus without a single gatekeeper |
+| **required-reviewers** | named reviewers per area approve (CODEOWNERS-style) | **reuse ADR-021 expert-routing** to *suggest* the required reviewers per section |
+| **orchestrator** | a designated principal (human or agent) releases on the group's behalf | the "overarching orchestrator" case; agent orchestrators are constrained by §8 |
+
+Any **required reviewer may veto** (block); an authorizer must clear the block before release. **Recommendation:** ship `owner` for v1; add `quorum` / `required-reviewers` (wired to expert-routing) as a fast-follow; treat `orchestrator` (esp. agent) as the most security-sensitive and last.
+
+### 6. Gate scope
+
+A gate covers a **whole plan**, a **section**, or a **single decision**. **Section-scoped is the recommended default unit:** agreed sections release and build while contested sections hold — partial progress without all-or-nothing. Whole-plan gating is a convenience wrapper; single-decision gating is for fine-grained control.
+
+### 7. How building agents respect the gate (across delivery classes)
+
+Gating sits in front of *execution*, not in front of *awareness*. The discussion always flows so agents can inform themselves; only the **build directive** is gated.
+
+| Delivery class (ADR-025 §2) | Gated behavior |
+|------------------------------|----------------|
+| **delegated** | the build task is **enqueued only for `released` work** — the gate is the precondition for creating the `KindPlanFeedback` / build task (and, where relevant, a beads issue) |
+| **real-time** (`await`) | returns `released` items as **actionable directives**; un-released items as **advisory only** ("discussed, not yet authorized — do not build") |
+| **next-turn** (whisper) | surfaces a status line: "N decisions released, M awaiting authorization, K contested" |
+
+A new read surface, `ox plan gate status <slug>`, returns per-section/decision release state for any agent or orchestrator to consult.
+
+### 8. Security and trust
+
+- **Feedback stays untrusted data** (ADR-025 §6). The agent performs the standard action for an annotation's `kind` against its `targets`; it never executes instructions embedded in notes/gloss — and now, never *before release*.
+- **Release is a trust boundary.** A gate event is authenticated to a principal and appended to the audit log. **An agent may not release unless it is the explicitly designated `orchestrator` authorizer** for that plan/section, and even then it is audited like any principal.
+- **No self-deal.** The agent (or agent-author) that produced a plan or a decision **cannot authorize its own build** unless policy explicitly grants it — the authorizer and the author must be distinguishable, mirroring "no self-approval" in code review.
+- **No deadlock.** `owner` is always a valid authorizer of last resort, so a misconfigured quorum/required-reviewers policy can never strand a plan.
+
+## Consequences
+
+### Positive
+- **Multiplayer-correct from the start.** Threads + append-only rounds preserve every principal's voice; contested decisions are visible, not silently resolved by write-order.
+- **Human (and orchestrator) control over execution.** Nothing builds until agreed *and* released; partial release lets agreed work proceed while contested work waits.
+- **Reuse, not reinvention.** Identity from the Whisper ADR; required-reviewer suggestions from ADR-021 expert-routing; storage + delivery from ADR-025; build-task/beads as the delegated execution hook.
+- **Auditability.** Every annotation and gate event is attributable from the append log.
+
+### Negative / risks
+- **Governance complexity + config surface.** Mitigation: `owner` default, section scope, ship policies incrementally.
+- **Agent-orchestrator trust.** An agent that can release execution is powerful. Mitigation: designation is explicit + audited; no self-deal; least-privilege; default off.
+- **Contested-thread UX.** Surfacing and resolving disagreement well is hard. Mitigation: make `contested` first-class in the render and digest; require explicit resolution.
+- **Latency to build.** A gate slows "feedback → build." That is the point for collaborative decisions; advisory comments still flow without gating.
+
+## Alternatives considered
+
+- **Immediate execution (today's behavior) — rejected** for multi-player: it has no consensus or authorization step and overwrites concurrent reviewers.
+- **Last-write-wins per anchor — rejected:** loses voices and mis-models disagreement; threads + contested state are correct.
+- **A central live collaboration server as source of truth — rejected** (consistent with ADR-025): a machine runs many ox daemons, so a persistent endpoint is ambiguous; append-only ledger rounds are already conflict-free and git-mergeable.
+- **A bespoke gating system parallel to beads — rejected in favor of integration:** the delegated build path already routes through agent-tasks; the gate should be the precondition for enqueuing there (and for any beads issue it creates), not a second tracker.
+- **Pure consensus with no explicit authorizer — rejected as the only option:** some teams want a named gatekeeper/orchestrator; `quorum` remains available for teams that prefer consensus-only.
+
+## References
+- [ADR-025](ADR-025-plan-annotation-and-feedback-delivery.md) — annotation envelope, anchors, the three delivery classes, and §7 which reserves this governance layer.
+- [Whisper & Murmur ADR](adr-whisper-murmur-architecture.md) — the `principal_id` / `principal_type` identity model reused in §2, and the untrusted-data posture.
+- [ADR-021](ADR-021-ox-plan-context-not-inference.md) — expert-routing (reused to suggest required reviewers) and plan storage in the ledger.
+- Prior art: GitHub required reviews + CODEOWNERS + merge queue (gating before merge); Google Docs suggestions/comments/resolve and Figma multiplayer (concurrent attributed annotation); the append-only/CRDT lineage behind conflict-free multi-writer editing.

--- a/internal/plan/assets/review.js
+++ b/internal/plan/assets/review.js
@@ -38,9 +38,16 @@
     try { var a = JSON.parse(el.textContent || '[]'); var m = {}; a.forEach(function (x) { (m[x.anchor] = m[x.anchor] || []).push(x); }); return m; }
     catch (e) { return {}; }
   }
-  // repOf picks the representative mark for an anchor's inline glyph: an
-  // addressed/verified mark wins (show ✓), else the first.
-  function repOf(arr) { for (var i = 0; i < arr.length; i++) { if (arr[i].state === 'addressed' || arr[i].state === 'verified') return arr[i]; } return arr[0]; }
+  // repOf picks the representative mark for an anchor's inline glyph. Prefer a
+  // still-OPEN blocking mark (request-change/flag) so one reviewer's unresolved
+  // feedback is never painted as resolved just because another reviewer's mark on
+  // the same anchor was addressed; then any open mark; then addressed/verified.
+  function repOf(arr) {
+    for (var i = 0; i < arr.length; i++) { if (arr[i].state === 'open' && (arr[i].status === 'request-change' || arr[i].status === 'flag')) return arr[i]; }
+    for (var j = 0; j < arr.length; j++) { if (arr[j].state === 'open') return arr[j]; }
+    for (var k = 0; k < arr.length; k++) { if (arr[k].state === 'addressed' || arr[k].state === 'verified') return arr[k]; }
+    return arr[0];
+  }
   function post(path, payload, ok) {
     fetch(base + path, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Review-Token': token }, body: JSON.stringify(payload) })
       .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); if (ok) ok(); })
@@ -243,6 +250,7 @@
     var items = Object.keys(marks).map(function (k) { return marks[k]; });
     if (!items.length) { alert('No marks yet. Toggle Review, click a section, leave a note.'); return; }
     var who = ensureReviewer();
+    if (!who) { alert('Set your name first (the "Set name" button in the bar) — feedback is attributed per reviewer.'); return; }
     var p = { slug: slug, reviewer: who, items: items };
     if (live) {
       post('/feedback', p, function () { marks = {}; save(); /* SSE reload will repaint */ });

--- a/internal/plan/assets/review.js
+++ b/internal/plan/assets/review.js
@@ -25,17 +25,22 @@
 
   var marks = load();
   var committed = parseCommitted();
+  var reviewer = (localStorage.getItem('ox-plan-reviewer') || '').trim(); // multi-user: who you are
   var on = false;
   var pendingReload = false;
 
   function load() { try { return JSON.parse(localStorage.getItem(KEY)) || {}; } catch (e) { return {}; } }
   function save() { try { localStorage.setItem(KEY, JSON.stringify(marks)); } catch (e) {} }
   function parseCommitted() {
+    // anchor -> [mark, …]: multi-user, so several reviewers on one anchor all show.
     var el = document.getElementById('ox-review-state');
     if (!el) return {};
-    try { var a = JSON.parse(el.textContent || '[]'); var m = {}; a.forEach(function (x) { m[x.anchor] = x; }); return m; }
+    try { var a = JSON.parse(el.textContent || '[]'); var m = {}; a.forEach(function (x) { (m[x.anchor] = m[x.anchor] || []).push(x); }); return m; }
     catch (e) { return {}; }
   }
+  // repOf picks the representative mark for an anchor's inline glyph: an
+  // addressed/verified mark wins (show ✓), else the first.
+  function repOf(arr) { for (var i = 0; i < arr.length; i++) { if (arr[i].state === 'addressed' || arr[i].state === 'verified') return arr[i]; } return arr[0]; }
   function post(path, payload, ok) {
     fetch(base + path, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Review-Token': token }, body: JSON.stringify(payload) })
       .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); if (ok) ok(); })
@@ -53,7 +58,7 @@
   function anchorFor(el) { return 'h' + fnv1a(norm(headingOf(el)) + '\u0000' + norm(anchorText(el))); }
   function glyphFor(id) { for (var i = 0; i < STATUS.length; i++) if (STATUS[i].id === id) return STATUS[i].glyph; return '◌'; }
   function labelFor(el) { var t = (el.textContent || '').replace(/\s+/g, ' ').trim(); return t.length > 70 ? t.slice(0, 69) + '…' : t; }
-  function committedState(el) { var c = committed[anchorFor(el)]; return c ? c.state : ''; }
+  function committedState(el) { var arr = committed[anchorFor(el)] || []; return arr.length ? repOf(arr).state : ''; }
 
   function paint() {
     document.querySelectorAll('.rev-marked,.rev-committed').forEach(function (el) {
@@ -63,7 +68,8 @@
     var seen = {};
     document.querySelectorAll(SELECTOR).forEach(function (el) {
       var a = anchorFor(el);
-      var c = committed[a], m = marks[a];
+      var carr = committed[a] || [];
+      var c = carr.length ? repOf(carr) : null, m = marks[a];
       if (!c && !m) return;
       if (c) seen[a] = true;
       var status = m ? m.status : c.status;
@@ -72,7 +78,8 @@
       if (c && !m) {
         el.classList.add('rev-committed'); el.setAttribute('data-revstate', c.state);
         glyph.textContent = (c.state === 'addressed' || c.state === 'verified') ? '✓' : (c.state === 'wontfix' ? '—' : glyphFor(status));
-        glyph.title = c.state + (c.note ? (' — ' + c.note) : '');
+        var who = carr.map(function (x) { return x.reviewer || 'someone'; }).join(', ');
+        glyph.title = who + ' · ' + c.state + (carr.length > 1 ? ' (' + carr.length + ' reviewers)' : '') + (c.note ? (' — ' + c.note) : '');
       } else {
         el.classList.add('rev-marked'); el.setAttribute('data-rev', status);
         glyph.textContent = glyphFor(status);
@@ -80,7 +87,8 @@
       el.appendChild(glyph);
     });
     // orphaned committed notes: their anchored text changed, so nothing matched.
-    var orphans = Object.keys(committed).filter(function (a) { return !seen[a]; }).map(function (a) { return committed[a]; });
+    var orphans = [];
+    Object.keys(committed).forEach(function (a) { if (!seen[a]) committed[a].forEach(function (x) { orphans.push(x); }); });
     renderOrphans(orphans);
     var n = Object.keys(marks).length;
     countEl.textContent = n ? (n + ' unsent') : '';
@@ -111,21 +119,25 @@
     setTimeout(function () { el.classList.remove('rev-flash'); }, 1200);
   }
   function railRows() {
-    // document order, so the rail reads top-to-bottom with the plan; each row
-    // carries its live element for scroll-to.
+    // document order; each row carries its live element for scroll-to. Multi-user:
+    // one row per reviewer's committed mark on an element, plus your unsent local mark.
     var rows = [];
     document.querySelectorAll(SELECTOR).forEach(function (el) {
-      var a = anchorFor(el), m = marks[a], c = committed[a];
-      if (!m && !c) return;
-      rows.push({
-        el: el,
-        status: m ? m.status : c.status,
-        note: m ? m.note : (c ? c.note : ''),
-        section: (m && m.section) || (c && c.section) || headingOf(el),
-        label: (m && m.label) || (c && c.label) || labelFor(el),
-        state: c ? c.state : '',
-        unsent: !!m
+      var a = anchorFor(el), m = marks[a], carr = committed[a] || [];
+      carr.forEach(function (c) {
+        rows.push({
+          el: el, status: c.status, note: c.note,
+          section: c.section || headingOf(el), label: c.label || labelFor(el),
+          state: c.state, reviewer: c.reviewer || '', unsent: false
+        });
       });
+      if (m) {
+        rows.push({
+          el: el, status: m.status, note: m.note,
+          section: m.section || headingOf(el), label: m.label || labelFor(el),
+          state: '', reviewer: reviewer || '(you)', unsent: true
+        });
+      }
     });
     return rows;
   }
@@ -146,9 +158,10 @@
       else if (r.state && r.state !== 'open') tag = '<span class="rev-rail-tag ' + esc(r.state) + '">' + esc(r.state) + '</span>';
       var body = r.note ? '<div class="rev-rail-note">' + esc(r.note) + '</div>'
         : '<div class="rev-rail-note muted">' + esc(r.label) + '</div>';
+      var whoTag = r.reviewer ? '<span class="rev-rail-who">' + esc(r.reviewer) + '</span>' : '';
       html += '<li class="rev-rail-item" data-i="' + i + '" data-status="' + esc(r.status) + '">' +
         '<span class="rev-rail-glyph">' + glyphFor(r.status) + '</span>' +
-        '<div class="rev-rail-body"><div class="rev-rail-sec"><span class="rev-rail-sec-t">' + esc(r.section || '(plan)') + '</span>' + tag + '</div>' + body + '</div></li>';
+        '<div class="rev-rail-body"><div class="rev-rail-sec"><span class="rev-rail-sec-t">' + esc(r.section || '(plan)') + '</span>' + whoTag + tag + '</div>' + body + '</div></li>';
     });
     html += '</ul>';
     rail.innerHTML = html;
@@ -219,10 +232,18 @@
     openPop(el, ev);
   }
 
+  function ensureReviewer() {
+    if (!reviewer) {
+      var n = (prompt('Your name (shown to teammates reviewing this plan):', '') || '').trim();
+      if (n) { reviewer = n; try { localStorage.setItem('ox-plan-reviewer', reviewer); } catch (e) {} if (typeof updateWho === 'function') updateWho(); }
+    }
+    return reviewer;
+  }
   function submit() {
     var items = Object.keys(marks).map(function (k) { return marks[k]; });
     if (!items.length) { alert('No marks yet. Toggle Review, click a section, leave a note.'); return; }
-    var p = { slug: slug, items: items };
+    var who = ensureReviewer();
+    var p = { slug: slug, reviewer: who, items: items };
     if (live) {
       post('/feedback', p, function () { marks = {}; save(); /* SSE reload will repaint */ });
       return;
@@ -249,10 +270,15 @@
   var bar = document.createElement('div');
   bar.className = 'rev-bar';
   bar.innerHTML = '<button class="rev-toggle" title="Toggle review mode">Review</button><span class="rev-count"></span>' +
+    (live ? '<button class="rev-who" title="Set the name teammates see on your comments"></button>' : '') +
     '<button class="rev-submit" title="Send feedback to the agent">' + (live ? 'Submit' : 'Export') + '</button>' +
     (live ? '<button class="rev-approve" title="Approve and close the loop">Approve</button>' : '');
   document.body.appendChild(bar);
   var countEl = bar.querySelector('.rev-count');
+  var whoEl = bar.querySelector('.rev-who');
+  function updateWho() { if (whoEl) whoEl.textContent = reviewer ? ('You: ' + reviewer) : 'Set name'; }
+  updateWho();
+  if (whoEl) whoEl.onclick = function () { var n = (prompt('Your name (shown to teammates on this plan):', reviewer) || '').trim(); if (n) { reviewer = n; try { localStorage.setItem('ox-plan-reviewer', reviewer); } catch (e) {} updateWho(); paint(); } };
   bar.querySelector('.rev-toggle').onclick = function () {
     on = !on; body.classList.toggle('rev-on', on); this.classList.toggle('on', on);
     if (!on) closePop();

--- a/internal/plan/assets/scaffold.css
+++ b/internal/plan/assets/scaffold.css
@@ -236,6 +236,8 @@ table.flagm td:first-child{font-family:"JetBrains Mono",monospace;font-size:12px
 .rev-bar .rev-toggle.on{background:var(--sage);border-color:var(--sage);color:#0c1112}
 .rev-bar .rev-submit{border-color:var(--copper);color:var(--copper)}
 .rev-bar .rev-count{font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--faint)}
+.rev-bar .rev-who{max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--faint)}
+.rev-bar .rev-who:hover{color:var(--sage);border-color:var(--sage)}
 body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.rev-on tr:hover,body.rev-on .ox-chip:hover,body.rev-on .stat:hover,body.rev-on .bar-row:hover{outline:1px dashed var(--sage);outline-offset:2px;cursor:crosshair}
 /* inline mark glyph — redundant encoding: distinct GLYPH per status, color reinforces (never color alone) */
 .rev-marked,.rev-committed{position:relative;box-shadow:inset 3px 0 0 var(--hair)}
@@ -291,6 +293,7 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .rev-rail-body{min-width:0;flex:1}
 .rev-rail-sec{display:flex;align-items:center;gap:6px;margin-bottom:3px}
 .rev-rail-sec-t{flex:1;min-width:0;font-family:"JetBrains Mono",monospace;font-size:10px;color:var(--faint);text-transform:uppercase;letter-spacing:.03em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.rev-rail-who{flex:none;font-size:9px;border-radius:6px;padding:0 5px;border:1px solid var(--hair2);color:var(--sage);text-transform:none;letter-spacing:0;max-width:90px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .rev-rail-note{font-size:12.5px;color:var(--ink);line-height:1.45;overflow-wrap:anywhere}
 .rev-rail-note.muted{color:var(--dim)}
 .rev-rail-tag{flex:none;font-size:9px;border-radius:6px;padding:0 5px;border:1px solid var(--hair2);color:var(--dim);text-transform:uppercase;letter-spacing:.02em}

--- a/internal/plan/feedback.go
+++ b/internal/plan/feedback.go
@@ -1,6 +1,8 @@
 package plan
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +12,18 @@ import (
 	"strings"
 	"time"
 )
+
+// randSuffix returns a short random hex tag for a round filename, so two reviewers
+// submitting in the same nanosecond never clobber each other's round. Falls back to
+// a fixed tag only if the OS entropy source fails (the timestamp still disambiguates
+// the common case); uniqueness degrades gracefully, it never errors the save.
+func randSuffix() string {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		return "00000000"
+	}
+	return hex.EncodeToString(b)
+}
 
 // feedback.go is the ledger side of the agent-driven plan review loop. The agent
 // renders the plan, a reviewer marks up sections / risks / decisions in the
@@ -71,11 +85,12 @@ func validResolutionState(s ResolutionState) bool {
 // itself the signal the item was addressed. Anchor doubles as the item id used
 // by `ox plan feedback resolve`.
 type FeedbackItem struct {
-	Anchor  string         `json:"anchor"`            // stable content-hash id, e.g. "h3f9a1c2"
-	Section string         `json:"section,omitempty"` // section heading the element sits under
-	Label   string         `json:"label"`             // short text of the element
-	Status  FeedbackStatus `json:"status"`            // approve | request-change | flag | comment
-	Note    string         `json:"note,omitempty"`    // the reviewer's comment
+	Anchor   string         `json:"anchor"`             // stable content-hash id, e.g. "h3f9a1c2"
+	Section  string         `json:"section,omitempty"`  // section heading the element sits under
+	Label    string         `json:"label"`              // short text of the element
+	Status   FeedbackStatus `json:"status"`             // approve | request-change | flag | comment
+	Note     string         `json:"note,omitempty"`     // the reviewer's comment
+	Reviewer string         `json:"reviewer,omitempty"` // who left this mark (multi-user); stamped from the round on save
 }
 
 // FeedbackSet is one review round (one submit from the page).
@@ -153,11 +168,21 @@ func SaveFeedback(planDir string, set FeedbackSet, now time.Time) (string, error
 	if set.CreatedAt.IsZero() {
 		set.CreatedAt = now.UTC()
 	}
+	// stamp the round's reviewer onto each item so the merge can attribute marks
+	// per-author (multi-user): two reviewers marking the same anchor are both kept.
+	for i := range set.Items {
+		if set.Items[i].Reviewer == "" {
+			set.Items[i].Reviewer = set.Reviewer
+		}
+	}
 	dir := filepath.Join(planDir, feedbackSubdir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("create feedback dir: %w", err)
 	}
-	name := "round-" + now.UTC().Format("20060102-150405.000000000") + ".json"
+	// timestamp prefix keeps rounds chronologically sortable by filename; a random
+	// suffix makes concurrent multi-user submits collision-proof (two reviewers can
+	// submit in the same nanosecond).
+	name := "round-" + now.UTC().Format("20060102-150405.000000000") + "-" + randSuffix() + ".json"
 	path := filepath.Join(dir, name)
 	b, err := json.MarshalIndent(set, "", "  ")
 	if err != nil {
@@ -274,21 +299,30 @@ func AssembleReview(planDir string) ([]MergedItem, error) {
 		return nil, err
 	}
 
-	// latest mark per anchor (rounds are chronological)
-	latestItem := map[string]FeedbackItem{}
-	raisedAt := map[string]time.Time{}
-	var order []string
+	// latest mark per (anchor, reviewer): multi-user — two reviewers marking the
+	// same anchor are BOTH preserved (keying by anchor alone silently dropped one).
+	// With a single/anonymous reviewer the key collapses to per-anchor, so existing
+	// single-user behavior is unchanged.
+	type markKey struct{ anchor, reviewer string }
+	latestItem := map[markKey]FeedbackItem{}
+	raisedAt := map[markKey]time.Time{}
+	var order []markKey
 	for _, set := range sets {
 		for _, it := range set.Items {
-			if _, seen := latestItem[it.Anchor]; !seen {
-				order = append(order, it.Anchor)
+			if it.Reviewer == "" {
+				it.Reviewer = set.Reviewer // rounds saved before per-item stamping carried it on the set
 			}
-			latestItem[it.Anchor] = it
-			raisedAt[it.Anchor] = set.CreatedAt
+			k := markKey{it.Anchor, it.Reviewer}
+			if _, seen := latestItem[k]; !seen {
+				order = append(order, k)
+			}
+			latestItem[k] = it
+			raisedAt[k] = set.CreatedAt
 		}
 	}
 
-	// latest resolution per anchor
+	// latest resolution per anchor: the agent resolves the underlying element, which
+	// closes every reviewer's mark on that anchor unless a later round re-raises it.
 	latestRes := map[string]Resolution{}
 	for _, r := range resolutions {
 		if cur, ok := latestRes[r.Anchor]; !ok || r.At.After(cur.At) {
@@ -297,9 +331,9 @@ func AssembleReview(planDir string) ([]MergedItem, error) {
 	}
 
 	out := make([]MergedItem, 0, len(order))
-	for _, anchor := range order {
-		mi := MergedItem{FeedbackItem: latestItem[anchor], RaisedAt: raisedAt[anchor], Open: true}
-		if r, ok := latestRes[anchor]; ok {
+	for _, k := range order {
+		mi := MergedItem{FeedbackItem: latestItem[k], RaisedAt: raisedAt[k], Open: true}
+		if r, ok := latestRes[k.anchor]; ok {
 			rc := r
 			mi.Resolution = &rc
 			// re-raised after resolution → open again
@@ -308,6 +342,32 @@ func AssembleReview(planDir string) ([]MergedItem, error) {
 		out = append(out, mi)
 	}
 	return out, nil
+}
+
+// ContestedAnchors returns the set of anchors where OPEN reviewer verdicts conflict
+// — e.g. one reviewer approves while another requests a change. These are the marks
+// a human authorizer must reconcile before the plan is safe to execute (ADR-026).
+// Comment-only marks never contest; an approve alongside any change/flag does.
+func ContestedAnchors(items []MergedItem) map[string]bool {
+	byAnchor := map[string]map[FeedbackStatus]bool{}
+	for _, it := range items {
+		if !it.Open || it.Status == FeedbackComment {
+			continue
+		}
+		if byAnchor[it.Anchor] == nil {
+			byAnchor[it.Anchor] = map[FeedbackStatus]bool{}
+		}
+		byAnchor[it.Anchor][it.Status] = true
+	}
+	contested := map[string]bool{}
+	for anchor, verdicts := range byAnchor {
+		approve := verdicts[FeedbackApprove]
+		change := verdicts[FeedbackRequestChange] || verdicts[FeedbackFlag]
+		if approve && change {
+			contested[anchor] = true
+		}
+	}
+	return contested
 }
 
 // FeedbackDigest renders a compact, agent-readable summary from the merged view:
@@ -339,15 +399,25 @@ func FeedbackDigest(items []MergedItem) string {
 			wontfix++
 		}
 	}
+	contested := ContestedAnchors(items)
 	var b strings.Builder
 	fmt.Fprintf(&b, "Review: %d open · %d addressed · %d verified · %d wontfix · %d approvals\n",
 		open, addressed, verified, wontfix, approvals)
+	if len(contested) > 0 {
+		fmt.Fprintf(&b, "⚠ %d contested anchor(s) — reviewers disagree; reconcile before executing.\n", len(contested))
+	}
 	for _, it := range openItems {
 		label := it.Label
 		if label == "" {
 			label = it.Anchor
 		}
 		fmt.Fprintf(&b, "  [%s] (%s) %s", it.Status, it.Anchor, label)
+		if it.Reviewer != "" {
+			fmt.Fprintf(&b, " @%s", it.Reviewer)
+		}
+		if contested[it.Anchor] {
+			b.WriteString(" ⚠contested")
+		}
 		if it.Section != "" {
 			fmt.Fprintf(&b, " · §%s", it.Section)
 		}

--- a/internal/plan/feedback_multiuser_test.go
+++ b/internal/plan/feedback_multiuser_test.go
@@ -6,81 +6,146 @@ import (
 	"time"
 )
 
-// These cover the multi-user review model: distinct reviewers on the same anchor
-// are both preserved (not last-write-wins), conflicting verdicts are flagged
-// contested, and concurrent same-instant submits never clobber each other.
+// Multi-user review model: distinct reviewers on the same anchor are both
+// preserved (not last-write-wins), conflicting verdicts are flagged contested,
+// concurrent same-instant submits never clobber each other, and the ingest path
+// rejects malformed rounds before they reach the merge.
 
-func TestAssembleReview_MultiReviewerSameAnchorBothKept(t *testing.T) {
-	dir := t.TempDir()
+func openItem(anchor string, s FeedbackStatus, reviewer string) MergedItem {
+	return MergedItem{FeedbackItem: FeedbackItem{Anchor: anchor, Status: s, Reviewer: reviewer}, Open: true}
+}
+
+func closedItem(anchor string, s FeedbackStatus) MergedItem {
+	return MergedItem{FeedbackItem: FeedbackItem{Anchor: anchor, Status: s}, Open: false}
+}
+
+func TestAssembleReview_Multiuser(t *testing.T) {
 	t0 := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
-	if _, err := SaveFeedback(dir, FeedbackSet{Reviewer: "ryan", Items: []FeedbackItem{
-		{Anchor: "h1", Section: "Auth", Label: "token bucket", Status: FeedbackRequestChange, Note: "per-IP too"},
-	}}, t0); err != nil {
-		t.Fatal(err)
+	type round struct {
+		reviewer string
+		at       time.Time
+		items    []FeedbackItem
 	}
-	if _, err := SaveFeedback(dir, FeedbackSet{Reviewer: "sam", Items: []FeedbackItem{
-		{Anchor: "h1", Section: "Auth", Label: "token bucket", Status: FeedbackApprove, Note: "fine as-is"},
-	}}, t0.Add(time.Second)); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name      string
+		rounds    []round
+		wantItems int
+		wantByRev map[string]FeedbackStatus // reviewer -> expected latest status
+	}{
+		{
+			name: "two reviewers on the same anchor are both kept",
+			rounds: []round{
+				{"ryan", t0, []FeedbackItem{{Anchor: "h1", Status: FeedbackRequestChange, Note: "per-IP too"}}},
+				{"sam", t0.Add(time.Second), []FeedbackItem{{Anchor: "h1", Status: FeedbackApprove, Note: "fine"}}},
+			},
+			wantItems: 2,
+			wantByRev: map[string]FeedbackStatus{"ryan": FeedbackRequestChange, "sam": FeedbackApprove},
+		},
+		{
+			name: "single anonymous reviewer still collapses per-anchor (backward compatible)",
+			rounds: []round{
+				{"", t0, []FeedbackItem{{Anchor: "h1", Status: FeedbackFlag, Note: "first"}}},
+				{"", t0.Add(time.Second), []FeedbackItem{{Anchor: "h1", Status: FeedbackRequestChange, Note: "second"}}},
+			},
+			wantItems: 1,
+			wantByRev: map[string]FeedbackStatus{"": FeedbackRequestChange},
+		},
+		{
+			name: "same reviewer re-marking an anchor keeps only their latest",
+			rounds: []round{
+				{"ryan", t0, []FeedbackItem{{Anchor: "h1", Status: FeedbackComment}}},
+				{"ryan", t0.Add(time.Second), []FeedbackItem{{Anchor: "h1", Status: FeedbackRequestChange}}},
+			},
+			wantItems: 1,
+			wantByRev: map[string]FeedbackStatus{"ryan": FeedbackRequestChange},
+		},
+		{
+			name: "distinct anchors from distinct reviewers all survive",
+			rounds: []round{
+				{"ryan", t0, []FeedbackItem{{Anchor: "h1", Status: FeedbackRequestChange}}},
+				{"sam", t0.Add(time.Second), []FeedbackItem{{Anchor: "h2", Status: FeedbackFlag}}},
+			},
+			wantItems: 2,
+			wantByRev: map[string]FeedbackStatus{"ryan": FeedbackRequestChange, "sam": FeedbackFlag},
+		},
 	}
-	items, err := AssembleReview(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(items) != 2 {
-		t.Fatalf("want 2 items (one per reviewer on the same anchor), got %d", len(items))
-	}
-	got := map[string]FeedbackStatus{}
-	for _, it := range items {
-		if it.Reviewer == "" {
-			t.Errorf("item missing reviewer attribution: %+v", it)
-		}
-		got[it.Reviewer] = it.Status
-	}
-	if got["ryan"] != FeedbackRequestChange || got["sam"] != FeedbackApprove {
-		t.Errorf("reviewer marks not preserved distinctly: %+v", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, r := range tt.rounds {
+				if _, err := SaveFeedback(dir, FeedbackSet{Reviewer: r.reviewer, Items: r.items}, r.at); err != nil {
+					t.Fatalf("SaveFeedback: %v", err)
+				}
+			}
+			items, err := AssembleReview(dir)
+			if err != nil {
+				t.Fatalf("AssembleReview: %v", err)
+			}
+			if len(items) != tt.wantItems {
+				t.Fatalf("item count = %d, want %d (%+v)", len(items), tt.wantItems, items)
+			}
+			got := map[string]FeedbackStatus{}
+			for _, it := range items {
+				if it.Reviewer == "" && len(tt.wantByRev) > 1 {
+					t.Errorf("item missing reviewer attribution: %+v", it)
+				}
+				got[it.Reviewer] = it.Status
+			}
+			for rev, want := range tt.wantByRev {
+				if got[rev] != want {
+					t.Errorf("reviewer %q status = %q, want %q", rev, got[rev], want)
+				}
+			}
+		})
 	}
 }
 
-func TestAssembleReview_SingleReviewerStillCollapsesPerAnchor(t *testing.T) {
-	// backward compatibility: with no reviewer set, a later mark on an anchor still
-	// supersedes the earlier one (per-anchor), exactly as before multi-user.
-	dir := t.TempDir()
-	t0 := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
-	_, _ = SaveFeedback(dir, FeedbackSet{Items: []FeedbackItem{{Anchor: "h1", Status: FeedbackFlag, Note: "first"}}}, t0)
-	_, _ = SaveFeedback(dir, FeedbackSet{Items: []FeedbackItem{{Anchor: "h1", Status: FeedbackRequestChange, Note: "second"}}}, t0.Add(time.Second))
-	items, err := AssembleReview(dir)
-	if err != nil {
-		t.Fatal(err)
+func TestContestedAnchors_Table(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []MergedItem
+		want  []string
+	}{
+		{"approve vs request-change is contested", []MergedItem{
+			openItem("h1", FeedbackApprove, "sam"), openItem("h1", FeedbackRequestChange, "ryan"),
+		}, []string{"h1"}},
+		{"approve vs flag is contested", []MergedItem{
+			openItem("h3", FeedbackApprove, "a"), openItem("h3", FeedbackFlag, "b"),
+		}, []string{"h3"}},
+		{"two approvals agree", []MergedItem{
+			openItem("h2", FeedbackApprove, "sam"), openItem("h2", FeedbackApprove, "ryan"),
+		}, nil},
+		{"comment never contests an approval", []MergedItem{
+			openItem("h4", FeedbackApprove, "a"), openItem("h4", FeedbackComment, "b"),
+		}, nil},
+		{"closed items never contest", []MergedItem{
+			closedItem("h5", FeedbackApprove), closedItem("h5", FeedbackRequestChange),
+		}, nil},
 	}
-	if len(items) != 1 || items[0].Status != FeedbackRequestChange || items[0].Note != "second" {
-		t.Fatalf("single-reviewer collapse broke: %+v", items)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ContestedAnchors(tt.items)
+			if len(got) != len(tt.want) {
+				t.Fatalf("contested count = %d %v, want %d %v", len(got), got, len(tt.want), tt.want)
+			}
+			for _, a := range tt.want {
+				if !got[a] {
+					t.Errorf("anchor %q should be contested", a)
+				}
+			}
+		})
 	}
 }
 
-func TestContestedAnchors_ConflictingVerdicts(t *testing.T) {
-	items := []MergedItem{
-		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackApprove, Reviewer: "sam"}, Open: true},
-		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackRequestChange, Reviewer: "ryan"}, Open: true},
-		{FeedbackItem: FeedbackItem{Anchor: "h2", Status: FeedbackApprove, Reviewer: "sam"}, Open: true},
-		{FeedbackItem: FeedbackItem{Anchor: "h2", Status: FeedbackApprove, Reviewer: "ryan"}, Open: true},
+// error path: the ingest guard rejects a malformed round before it can reach
+// SaveFeedback / the merge, so a crafted export can't inject an unknown status.
+func TestParseFeedback_RejectsUnknownStatus(t *testing.T) {
+	_, err := ParseFeedback([]byte(`{"slug":"p","items":[{"anchor":"h1","status":"bogus"}]}`))
+	if err == nil {
+		t.Fatal("expected an error for an unknown status, got nil")
 	}
-	c := ContestedAnchors(items)
-	if !c["h1"] {
-		t.Error("h1 (approve vs request-change) should be contested")
-	}
-	if c["h2"] {
-		t.Error("h2 (two approvals) should NOT be contested")
-	}
-}
-
-func TestContestedAnchors_ClosedItemsNeverContested(t *testing.T) {
-	items := []MergedItem{
-		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackApprove}, Open: false},
-		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackRequestChange}, Open: false},
-	}
-	if len(ContestedAnchors(items)) != 0 {
-		t.Error("closed items must not be contested")
+	if !strings.Contains(err.Error(), "unknown status") {
+		t.Errorf("error = %v, want it to mention the unknown status", err)
 	}
 }
 
@@ -120,7 +185,7 @@ func TestSaveFeedback_StampsReviewerOntoItems(t *testing.T) {
 
 func TestFeedbackDigest_ShowsReviewerAndContested(t *testing.T) {
 	items := []MergedItem{
-		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackApprove, Reviewer: "sam", Label: "x"}, Open: true},
+		openItem("h1", FeedbackApprove, "sam"),
 		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackRequestChange, Reviewer: "ryan", Label: "x", Note: "fix"}, Open: true},
 	}
 	d := FeedbackDigest(items)

--- a/internal/plan/feedback_multiuser_test.go
+++ b/internal/plan/feedback_multiuser_test.go
@@ -1,0 +1,133 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// These cover the multi-user review model: distinct reviewers on the same anchor
+// are both preserved (not last-write-wins), conflicting verdicts are flagged
+// contested, and concurrent same-instant submits never clobber each other.
+
+func TestAssembleReview_MultiReviewerSameAnchorBothKept(t *testing.T) {
+	dir := t.TempDir()
+	t0 := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	if _, err := SaveFeedback(dir, FeedbackSet{Reviewer: "ryan", Items: []FeedbackItem{
+		{Anchor: "h1", Section: "Auth", Label: "token bucket", Status: FeedbackRequestChange, Note: "per-IP too"},
+	}}, t0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SaveFeedback(dir, FeedbackSet{Reviewer: "sam", Items: []FeedbackItem{
+		{Anchor: "h1", Section: "Auth", Label: "token bucket", Status: FeedbackApprove, Note: "fine as-is"},
+	}}, t0.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	items, err := AssembleReview(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want 2 items (one per reviewer on the same anchor), got %d", len(items))
+	}
+	got := map[string]FeedbackStatus{}
+	for _, it := range items {
+		if it.Reviewer == "" {
+			t.Errorf("item missing reviewer attribution: %+v", it)
+		}
+		got[it.Reviewer] = it.Status
+	}
+	if got["ryan"] != FeedbackRequestChange || got["sam"] != FeedbackApprove {
+		t.Errorf("reviewer marks not preserved distinctly: %+v", got)
+	}
+}
+
+func TestAssembleReview_SingleReviewerStillCollapsesPerAnchor(t *testing.T) {
+	// backward compatibility: with no reviewer set, a later mark on an anchor still
+	// supersedes the earlier one (per-anchor), exactly as before multi-user.
+	dir := t.TempDir()
+	t0 := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	_, _ = SaveFeedback(dir, FeedbackSet{Items: []FeedbackItem{{Anchor: "h1", Status: FeedbackFlag, Note: "first"}}}, t0)
+	_, _ = SaveFeedback(dir, FeedbackSet{Items: []FeedbackItem{{Anchor: "h1", Status: FeedbackRequestChange, Note: "second"}}}, t0.Add(time.Second))
+	items, err := AssembleReview(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Status != FeedbackRequestChange || items[0].Note != "second" {
+		t.Fatalf("single-reviewer collapse broke: %+v", items)
+	}
+}
+
+func TestContestedAnchors_ConflictingVerdicts(t *testing.T) {
+	items := []MergedItem{
+		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackApprove, Reviewer: "sam"}, Open: true},
+		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackRequestChange, Reviewer: "ryan"}, Open: true},
+		{FeedbackItem: FeedbackItem{Anchor: "h2", Status: FeedbackApprove, Reviewer: "sam"}, Open: true},
+		{FeedbackItem: FeedbackItem{Anchor: "h2", Status: FeedbackApprove, Reviewer: "ryan"}, Open: true},
+	}
+	c := ContestedAnchors(items)
+	if !c["h1"] {
+		t.Error("h1 (approve vs request-change) should be contested")
+	}
+	if c["h2"] {
+		t.Error("h2 (two approvals) should NOT be contested")
+	}
+}
+
+func TestContestedAnchors_ClosedItemsNeverContested(t *testing.T) {
+	items := []MergedItem{
+		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackApprove}, Open: false},
+		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackRequestChange}, Open: false},
+	}
+	if len(ContestedAnchors(items)) != 0 {
+		t.Error("closed items must not be contested")
+	}
+}
+
+func TestSaveFeedback_ConcurrentSameInstantUniqueFiles(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	p1, err := SaveFeedback(dir, FeedbackSet{Reviewer: "a", Items: []FeedbackItem{{Anchor: "h1", Status: FeedbackFlag}}}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := SaveFeedback(dir, FeedbackSet{Reviewer: "b", Items: []FeedbackItem{{Anchor: "h1", Status: FeedbackFlag}}}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 == p2 {
+		t.Fatalf("same-instant submits collided on filename: %s", p1)
+	}
+	sets, err := LoadAllFeedback(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sets) != 2 {
+		t.Fatalf("want 2 rounds preserved, got %d", len(sets))
+	}
+}
+
+func TestSaveFeedback_StampsReviewerOntoItems(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := SaveFeedback(dir, FeedbackSet{Reviewer: "ryan", Items: []FeedbackItem{{Anchor: "h1", Status: FeedbackComment}}}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	sets, _ := LoadAllFeedback(dir)
+	if len(sets) != 1 || len(sets[0].Items) != 1 || sets[0].Items[0].Reviewer != "ryan" {
+		t.Fatalf("reviewer not stamped onto item: %+v", sets)
+	}
+}
+
+func TestFeedbackDigest_ShowsReviewerAndContested(t *testing.T) {
+	items := []MergedItem{
+		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackApprove, Reviewer: "sam", Label: "x"}, Open: true},
+		{FeedbackItem: FeedbackItem{Anchor: "h1", Status: FeedbackRequestChange, Reviewer: "ryan", Label: "x", Note: "fix"}, Open: true},
+	}
+	d := FeedbackDigest(items)
+	if !strings.Contains(d, "@ryan") {
+		t.Errorf("digest should attribute the open item to its reviewer: %q", d)
+	}
+	if !strings.Contains(d, "contested") {
+		t.Errorf("digest should flag the contested anchor: %q", d)
+	}
+}

--- a/internal/plan/render.go
+++ b/internal/plan/render.go
@@ -74,12 +74,13 @@ type RenderOptions struct {
 // reviewStateItem is the slim per-item shape injected into the page for the
 // review layer to paint inline. state is open|addressed|verified|wontfix.
 type reviewStateItem struct {
-	Anchor  string `json:"anchor"`
-	Section string `json:"section,omitempty"`
-	Label   string `json:"label"`
-	Status  string `json:"status"`
-	State   string `json:"state"`
-	Note    string `json:"note,omitempty"`
+	Anchor   string `json:"anchor"`
+	Section  string `json:"section,omitempty"`
+	Label    string `json:"label"`
+	Status   string `json:"status"`
+	State    string `json:"state"`
+	Note     string `json:"note,omitempty"`
+	Reviewer string `json:"reviewer,omitempty"`
 }
 
 // mermaid fences come out of goldmark as <pre><code class="language-mermaid">…;

--- a/internal/plan/render_review.go
+++ b/internal/plan/render_review.go
@@ -42,7 +42,7 @@ func buildReviewState(items []MergedItem) (template.JS, reviewSummary) {
 		}
 		slim = append(slim, reviewStateItem{
 			Anchor: it.Anchor, Section: it.Section, Label: it.Label,
-			Status: string(it.Status), State: state, Note: it.Note,
+			Status: string(it.Status), State: state, Note: it.Note, Reviewer: it.Reviewer,
 		})
 	}
 	b, err := json.Marshal(slim)


### PR DESCRIPTION
## Summary

Ships a **multi-user, real-time plan-review feedback loop**: humans mark up an
`ox plan render` HTML page in the browser, and the authoring coding agent receives
that feedback **in-turn** via a new blocking primitive — `ox plan review await` —
addresses it, and the reviewers' pages update live. Plus two ADRs codifying the
model, and multi-user correctness so concurrent reviewers are never lost.

```mermaid
flowchart LR
  RA["Reviewer A"]
  RB["Reviewer B"]
  PG["HTML plan page"]
  LG["Ledger rounds, append-only"]
  AG["Coding agent"]
  RA --> PG
  RB --> PG
  PG -->|"POST feedback"| LG
  AG -->|"await returns open items"| LG
  AG -->|"resolve then render"| LG
  LG -.->|"SSE live-reload"| PG
```

## What ships

- **`ox plan review await <slug>`** (`cmd/ox/plan_review_await.go`, new) — blocks until any
  reviewer submits, prints every reviewer's open items as JSON, exits; the agent acts
  in-turn, resolves, re-renders, loops. A plain stdout-JSON command, so it is
  **cross-harness by design** (no MCP, no Claude-only hook). Emits immediately if
  feedback is already waiting; exits `approved` on sign-off or `timeout` otherwise.
- **Multi-user merge** (`internal/plan/feedback.go`) — the review merge now keys by
  **(anchor, reviewer)**, so two people marking the same element are both preserved
  (single/anonymous reviewer still collapses per-anchor — unchanged). Adds
  `ContestedAnchors` (conflicting verdicts on one anchor), collision-proof round
  filenames (`round-<ts>-<rand>.json`), reviewer stamped onto each item, and reviewer
  attribution in the digest.
- **Review page** (`internal/plan/assets/review.js`, `scaffold.css`) — reviewer identity
  ("You: <name>", stored in `localStorage`), per-reviewer attribution in the comments
  rail, and multiple reviewers' marks shown on the same element.
- **Render** (`internal/plan/render.go`, `render_review.go`) — the review-state island
  carries the reviewer, so the page can attribute committed marks.
- **ADR-025** — annotation model, anchor scheme, and the delivery-class vocabulary
  **real-time / next-turn / delegated**. **ADR-026** — multiplayer review semantics
  (threads, contested) and execution gating.

## Test Plan

- **7 new table tests** (`internal/plan/feedback_multiuser_test.go`): multi-reviewer
  merge keeps both marks, single-reviewer still collapses, contested detection,
  closed-items-never-contested, collision-proof filenames, reviewer stamping, digest
  attribution. Full `internal/plan` + `cmd/ox` suites green; `gofmt`/`go vet` clean;
  zero new lint in changed files.
- **Live end-to-end**: two reviewers in isolated browser contexts submitted concurrently
  → `await` returned all open items from both, attributed, with the conflicting Decision
  anchor flagged `contested` → agent resolved the clear items → reviewers' page
  live-updated to ✓ over SSE → a real human reviewer then approved, closing the loop.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (`feedback_multiuser_test.go`, 7 cases)
- [ ] CHANGELOG entry — pending (new `ox plan review await` subcommand is user-facing)
- [x] Breaking change — none (multi-user merge is backward-compatible for single/anon reviewer)
- [x] `/security-review` — N/A: touches only plan-review (`internal/plan`, `cmd/ox/plan_*`); none of `internal/auth/`, `internal/mcp/`, `raw_writer.go`, `prepush_scan.go`, `internal/upgrade/`, or `go.sum`

</details>

Co-Authored-By: SageOx <ox@sageox.ai>
Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ox plan review await <slug>` to block until approval or open unapproved feedback, returning an indented JSON status (with `--timeout`).
  * Enabled multi-user committed review marks per anchor, showing reviewer “who” in the UI and including reviewer attribution in review payloads/digests.
  * Highlight contested open decisions in digest output.
* **Bug Fixes**
  * Improved review monitoring to avoid missed updates/race windows and to debounce event bursts.
  * Prevented feedback filename collisions during concurrent saves.
* **Documentation**
  * Published ADR-025 (plan annotation/feedback vocabulary) and ADR-026 (collaborative review + execution gating).
* **Tests**
  * Added coverage for multi-user merging, contested-anchor detection, digest attribution, parsing validation, and concurrent save behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->