### PR TITLE
fix(ledger): auto-recover zombie rebase wedge that blocks ledger sync

### DIFF
--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -863,6 +863,7 @@ func runDoctorChecks(parent context.Context, opts doctorOptions) []checkCategory
 			opts.shouldFix(CheckSlugLedgerEmbeddedCreds),
 			opts.shouldFix(CheckSlugLedgerURLAPIMatch),
 			opts.shouldFix(CheckSlugLedgerUnmergedPaths),
+			opts.shouldFix(CheckSlugLedgerStuckOperation),
 			opts.shouldFix(CheckSlugGitHubDataMigration),
 		)
 		if len(ledgerGitChecks) > 0 {
@@ -1142,8 +1143,9 @@ func enrichCheckResult(check *checkResult) {
 //   - fixEmbeddedCreds: whether to strip embedded oauth2:TOKEN from origin URL
 //   - fixURLAPIMatch: whether to repoint origin URL to the API-authoritative URL
 //   - fixUnmergedPaths: whether to auto-abort a stuck merge/rebase that left U-state files
+//   - fixStuckOp: whether to auto-clear a stuck merge/rebase/cherry-pick that left NO conflicts (incl. a corrupt rebase dir)
 //   - fixMigration: whether to migrate legacy GitHub data files
-func checkLedgerGitHealth(networkChecks bool, fixGitignore bool, fixBranch bool, fixWorkdir bool, fixEmbeddedCreds bool, fixURLAPIMatch bool, fixUnmergedPaths bool, fixMigration ...bool) []checkResult {
+func checkLedgerGitHealth(networkChecks bool, fixGitignore bool, fixBranch bool, fixWorkdir bool, fixEmbeddedCreds bool, fixURLAPIMatch bool, fixUnmergedPaths bool, fixStuckOp bool, fixMigration ...bool) []checkResult {
 	ledgerPath := getLedgerPath()
 	if ledgerPath == "" {
 		return nil // no ledger found, skip entire category
@@ -1166,6 +1168,12 @@ func checkLedgerGitHealth(networkChecks bool, fixGitignore bool, fixBranch bool,
 		// ledger; the previous order let the wedge hide inside the dirty-workdir
 		// counter ("3 modified") instead of producing an actionable P0.
 		checkLedgerUnmergedPaths(fixUnmergedPaths),
+		// ox-j3cl: the no-conflict twin of the wedge above. A stuck operation
+		// with NO U-state files (worst case: a corrupt rebase dir git rebase
+		// --abort cannot clear) is invisible to unmerged-paths yet blocks every
+		// pull. Runs before branch-status so the reconcile below acts on a
+		// cleared repo instead of pulling on top of the wedge.
+		checkLedgerStuckOperation(fixStuckOp),
 		checkLedgerCleanWorkdir(fixWorkdir),
 		checkLedgerBranchStatus(fixBranch),
 		// ox-eeqi: post-migration the PAT lives in the credential helper,

--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -34,6 +34,14 @@ const (
 	// commit on the ledger (push-summary, doctor auto-commit, session uploads)
 	// until cleared. See bd ox-8zd3 for the original incident.
 	CheckSlugLedgerUnmergedPaths = "ledger-unmerged-paths"
+	// CheckSlugLedgerStuckOperation detects an in-progress merge/rebase/cherry-pick
+	// that has NO unresolved conflicts — the blind spot the unmerged-paths check
+	// misses. Its worst case is a structurally-incomplete "zombie" rebase-merge
+	// dir (only an autostash entry, no head-name/orig-head) left by a process
+	// killed mid-rebase: `git rebase --abort` cannot clear it, so every ledger
+	// pull fails with "already a rebase-merge directory" until it is quit. See
+	// bd ox-j3cl for the original incident.
+	CheckSlugLedgerStuckOperation = "ledger-stuck-operation"
 )
 
 func init() {
@@ -72,6 +80,20 @@ func init() {
 		FixLevel:    FixLevelAuto,
 		Description: "Detects ledger files left in U-state by a stuck merge/rebase/cherry-pick",
 		Run:         func(fix bool) checkResult { return checkLedgerUnmergedPaths(fix) },
+	})
+
+	// Register the stuck-operation check alongside unmerged-paths: together they
+	// cover both wedge shapes — WITH conflicts (unmerged-paths) and WITHOUT
+	// conflicts (stuck-operation, incl. the zombie rebase dir that git rebase
+	// --abort cannot clear). Ordering in the doctor run is set in
+	// checkLedgerGitHealth (doctor.go).
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugLedgerStuckOperation,
+		Name:        "Ledger stuck operation",
+		Category:    "Ledger Git Health",
+		FixLevel:    FixLevelAuto,
+		Description: "Detects a stuck merge/rebase/cherry-pick (incl. a corrupt rebase dir) blocking ledger sync",
+		Run:         func(fix bool) checkResult { return checkLedgerStuckOperation(fix) },
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
@@ -591,6 +613,97 @@ func detectInProgressGitOp(ledgerPath string) (op, hint string) {
 		return "revert", "REVERT_HEAD present"
 	}
 	return "", ""
+}
+
+// checkLedgerStuckOperation detects an in-progress merge / rebase / cherry-pick
+// that has left NO unresolved conflicts — the blind spot checkLedgerUnmergedPaths
+// (gated on U-state files) misses. The worst case is a structurally-incomplete
+// "zombie" rebase-merge directory (only an autostash entry, no head-name /
+// orig-head) left by a process killed mid-rebase: git thinks a rebase is in
+// progress, `git rebase --abort` cannot clear it (nothing to reset to), and
+// every ledger pull fails with "already a rebase-merge directory" — the exact
+// production wedge in bd ox-j3cl.
+//
+// With fix=true, a rebase is cleared via gitutil.AbortOrClearRebase (abort, then
+// `--quit` for a zombie dir); a merge/cherry-pick/revert via the audited abort.
+// A fresh rebase (younger than StaleRebaseThreshold) is left alone — it's almost
+// always a live daemon pull --rebase or a human mid-operation.
+func checkLedgerStuckOperation(fix bool) checkResult {
+	const name = "Ledger stuck operation"
+
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger found", "")
+	}
+	if !isGitRepo(ledgerPath) {
+		return SkippedCheck(name, "ledger not a git repo", "")
+	}
+
+	op, hint := detectInProgressGitOp(ledgerPath)
+	if op == "" {
+		return PassedCheck(name, "no operation in progress")
+	}
+
+	// A fresh rebase is likely in flight (daemon pull --rebase or a human) —
+	// leave it alone. Only a stale one is a wedge. Non-rebase markers
+	// (MERGE_HEAD, CHERRY_PICK_HEAD) never appear during normal ox operation on
+	// the ledger, so treat their presence as a wedge regardless of age.
+	if op == "rebase" {
+		if age, ok := gitutil.RebaseAge(ledgerPath); ok && age < gitutil.StaleRebaseThreshold {
+			return PassedCheck(name, fmt.Sprintf("rebase in progress (%s, fresh)", age.Round(time.Second)))
+		}
+	}
+
+	if !fix {
+		return stuckOperationFailure(name, ledgerPath, op, hint)
+	}
+	return fixLedgerStuckOperation(ledgerPath, op, hint)
+}
+
+// stuckOperationFailure constructs the P0 surfaced when a stuck operation with
+// no unresolved conflicts is blocking ledger sync. Extracted so the message
+// shape is unit-testable without standing up a real git repo (mirrors
+// unmergedPathsFailure).
+func stuckOperationFailure(name, ledgerPath, op, hint string) checkResult {
+	detail := fmt.Sprintf(
+		"a %s is in progress at %s with no unresolved conflicts (%s).\n       "+
+			"This wedge blocks every ledger pull. Run `ox doctor --fix` to clear it.",
+		op, ledgerPath, hint,
+	)
+	// CriticalCheck — a stuck operation silently blocks all ledger sync (pull)
+	// and every future commit; it must be loud.
+	r := CriticalCheck(name, fmt.Sprintf("stuck %s blocking ledger sync", op), detail)
+	r.slug = CheckSlugLedgerStuckOperation
+	r.fixLevel = FixLevelAuto
+	return r
+}
+
+// fixLedgerStuckOperation clears a stuck operation. A rebase goes through
+// gitutil.AbortOrClearRebase (reversible `git rebase --abort`, escalating to
+// `git rebase --quit` for a structurally-incomplete zombie dir that abort
+// cannot clear). A merge/cherry-pick/revert clears via the audited abort — its
+// state is always intact enough to abort. Extracted for direct unit testing.
+func fixLedgerStuckOperation(ledgerPath, op, hint string) checkResult {
+	const name = "Ledger stuck operation"
+
+	var clearErr error
+	if op == "rebase" {
+		clearErr = gitutil.AbortOrClearRebase(context.Background(), ledgerPath, "doctor --fix stuck rebase", slog.Default())
+	} else {
+		abortCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		clearErr = gitutil.AuditAndAbort(abortCtx, ledgerPath, gitutil.AuditableOp(op), "doctor --fix stuck "+op, slog.Default())
+		cancel()
+	}
+	if clearErr != nil {
+		r := FailedCheck(name,
+			fmt.Sprintf("could not clear stuck %s", op),
+			fmt.Sprintf("error: %s\n       %s", clearErr, hint))
+		r.slug = CheckSlugLedgerStuckOperation
+		return r
+	}
+
+	slog.Info("ledger stuck-operation wedge cleared", "op", op, "ledger", ledgerPath)
+	return PassedCheck(name, fmt.Sprintf("cleared stuck %s", op))
 }
 
 // checkLedgerCleanWorkdir checks for uncommitted changes in the ledger repository.

--- a/cmd/ox/doctor_ledger_git_stuckop_test.go
+++ b/cmd/ox/doctor_ledger_git_stuckop_test.go
@@ -1,0 +1,96 @@
+//go:build !short
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildZombieRebaseRepo creates a real git repo wedged by a structurally
+// incomplete .git/rebase-merge dir — only an `autostash` entry, no
+// head-name/orig-head — with HEAD still on `main` and NO unresolved conflicts.
+// This is the exact production wedge (bd ox-j3cl): git thinks a rebase is in
+// progress, `git rebase --abort` cannot clear it, and — because there are no
+// U-state files — the unmerged-paths check reports "no conflicts" and misses it.
+func buildZombieRebaseRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	mustRunGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "session.md"), []byte("base\n"), 0644))
+	mustRunGit(t, repo, "add", "session.md")
+	mustRunGit(t, repo, "commit", "-m", "base")
+
+	// a real autostash object, faithful to production (stashed off a dirty tree,
+	// then the tree restored clean)
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "session.md"), []byte("dirty\n"), 0644))
+	stashOID, err := runIsolatedGit(t, repo, "stash", "create")
+	require.NoError(t, err)
+	mustRunGit(t, repo, "checkout", "--", "session.md")
+
+	stateDir := filepath.Join(repo, ".git", "rebase-merge")
+	require.NoError(t, os.MkdirAll(stateDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "autostash"),
+		[]byte(strings.TrimSpace(stashOID)+"\n"), 0644))
+	return repo
+}
+
+// TestCheckLedgerStuckOperation_UnmergedPathsMissesZombie pins the DETECTION GAP
+// that let the production wedge (bd ox-j3cl) hide: a zombie rebase dir has no
+// U-state files, so parseUnmergedPaths returns nothing and the unmerged-paths
+// check would report "no conflicts" — yet detectInProgressGitOp correctly sees
+// the rebase. The stuck-operation check exists precisely to cover this.
+func TestCheckLedgerStuckOperation_UnmergedPathsMissesZombie(t *testing.T) {
+	skipIntegration(t)
+	repo := buildZombieRebaseRepo(t)
+
+	require.True(t, gitutil.IsRebaseInProgress(repo), "setup should read as a rebase in progress")
+
+	status, err := runIsolatedGit(t, repo, "status", "--porcelain=v1")
+	require.NoError(t, err)
+	require.Empty(t, parseUnmergedPaths(status+"\n"),
+		"a zombie rebase has no U-state files — the exact reason unmerged-paths misses it")
+
+	op, _ := detectInProgressGitOp(repo)
+	require.Equal(t, "rebase", op, "stuck-operation detection must still see the rebase")
+}
+
+// TestFixLedgerStuckOperation_ClearsZombieRebase is the load-bearing fix
+// regression: --fix must clear a zombie rebase dir that `git rebase --abort`
+// cannot, leaving HEAD untouched. Without the AbortOrClearRebase quit escalation
+// this fails and the ledger stays wedged.
+func TestFixLedgerStuckOperation_ClearsZombieRebase(t *testing.T) {
+	skipIntegration(t)
+	repo := buildZombieRebaseRepo(t)
+	headBefore, err := runIsolatedGit(t, repo, "rev-parse", "HEAD")
+	require.NoError(t, err)
+
+	r := fixLedgerStuckOperation(repo, "rebase", "rebase state dir present")
+	assert.True(t, r.passed, "fix must clear a zombie rebase: %+v", r)
+	assert.Contains(t, r.message, "cleared stuck rebase")
+	assert.False(t, gitutil.IsRebaseInProgress(repo), "rebase state must be gone after fix")
+
+	headAfter, err := runIsolatedGit(t, repo, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, headBefore, headAfter, "quit must not move HEAD")
+}
+
+// TestStuckOperationFailure_LoudAndActionable pins the no-fix P0 shape: the
+// wedge must surface as critical (not a warning buried in the summary) and must
+// name the recovery path so a coworker has somewhere to go.
+func TestStuckOperationFailure_LoudAndActionable(t *testing.T) {
+	t.Parallel()
+	r := stuckOperationFailure("Ledger stuck operation", "/tmp/ledger", "rebase", "rebase state dir present")
+	assert.False(t, r.passed, "wedge must surface as a failure, not a warning")
+	assert.Equal(t, "critical", r.priority)
+	assert.Contains(t, r.message, "stuck rebase blocking ledger sync")
+	assert.Contains(t, r.detail, "ox doctor --fix",
+		"detail must point at the recovery action")
+	assert.Equal(t, CheckSlugLedgerStuckOperation, r.slug)
+}

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -433,7 +433,12 @@ func (s *SyncScheduler) recoverPreexistingRebase(ctx context.Context, path, repo
 	}
 	logger.Warn("recovering stale wedged rebase",
 		"op", "stale_rebase_recover", "repo", repoName, "age", age.Round(time.Second))
-	if abortErr := gitutil.AuditAndAbort(ctx, path, gitutil.AuditOpRebase, "stale wedged rebase auto-recovery", logger); abortErr != nil {
+	// AbortOrClearRebase first tries the reversible `git rebase --abort`, then
+	// escalates to `git rebase --quit` for a structurally-incomplete "zombie"
+	// state dir (a process killed mid-rebase leaving only an autostash entry, no
+	// head-name/orig-head) that --abort alone cannot clear. See
+	// gitutil.AbortOrClearRebase and bd ox-j3cl.
+	if abortErr := gitutil.AbortOrClearRebase(ctx, path, "stale wedged rebase auto-recovery", logger); abortErr != nil {
 		logger.Error("stale rebase recovery failed",
 			"op", "stale_rebase_recover_failed", "repo", repoName, "error", abortErr)
 		return true, ManagedRepoPullResult{

--- a/internal/daemon/sync_rebase_recovery_test.go
+++ b/internal/daemon/sync_rebase_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -207,6 +208,62 @@ func TestRecoverPreexistingRebase_StaleWedgeRecovered(t *testing.T) {
 	assert.False(t, stop, "stale wedge recovered → caller falls through to a clean pull")
 	assert.Nil(t, res.Issue)
 	assert.False(t, gitutil.IsRebaseInProgress(repo), "stale wedge must be aborted/recovered")
+}
+
+// makeZombieWedge injects the structurally-incomplete rebase-merge dir (only an
+// `autostash` entry, no head-name/orig-head) that a process killed mid-`pull
+// --rebase --autostash` leaves behind — the exact production wedge in bd
+// ox-j3cl. Distinct from makeWedgedRebase, which drives a REAL conflict and thus
+// leaves a COMPLETE, abortable state dir; that fixture never exercised the case
+// where `git rebase --abort` ITSELF fails, so the deadlock survived it.
+func makeZombieWedge(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	mustGit := func(args ...string) {
+		if out, err := runGit(t, repo, args...); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	mustGit("init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("base\n"), 0o644))
+	mustGit("add", "f.txt")
+	mustGit("commit", "-m", "base")
+
+	// a real autostash object, faithful to production (stash created off a
+	// dirty tree, then the tree restored clean)
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("dirty\n"), 0o644))
+	out, err := runGit(t, repo, "stash", "create")
+	require.NoError(t, err, "stash create: %s", out)
+	stashOID := strings.TrimSpace(out)
+	mustGit("checkout", "--", "f.txt")
+
+	stateDir := filepath.Join(repo, ".git", "rebase-merge")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "autostash"), []byte(stashOID+"\n"), 0o644))
+	require.True(t, gitutil.IsRebaseInProgress(repo), "zombie dir should read as rebase-in-progress")
+	return repo
+}
+
+// TestRecoverPreexistingRebase_ZombieDirRecovered is the regression for bd
+// ox-j3cl: the daemon must SELF-HEAL a structurally-incomplete rebase dir that
+// `git rebase --abort` cannot clear, instead of surfacing IssueTypeRebaseStuck
+// and re-looping forever. Pre-fix, recoverPreexistingRebase called AuditAndAbort
+// directly, abort failed on this shape, and the ledger stayed suspended for
+// weeks. This drives the actual decision path so a regression to "abort-only"
+// fails the build.
+func TestRecoverPreexistingRebase_ZombieDirRecovered(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses to build a rebase wedge")
+	}
+	repo := makeZombieWedge(t)
+	backdateRebaseDir(t, repo, time.Hour) // older than staleRebaseThreshold
+	s := &SyncScheduler{}
+
+	stop, res := s.recoverPreexistingRebase(context.Background(), repo, "ledger", discardLogger())
+
+	assert.False(t, stop, "zombie wedge recovered → caller falls through to a clean pull")
+	assert.Nil(t, res.Issue, "must NOT surface IssueTypeRebaseStuck for a recoverable zombie")
+	assert.False(t, gitutil.IsRebaseInProgress(repo), "zombie rebase dir must be cleared")
 }
 
 // TestRecoverPreexistingRebase_StaleWedge_ApplyBackend covers the same CLASS of

--- a/internal/doctor/autofix/default_checks.go
+++ b/internal/doctor/autofix/default_checks.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/hooks/claude"
 	"github.com/sageox/ox/internal/lfs"
 )
@@ -52,7 +54,67 @@ func Default() *Registry {
 		BlastRadius: "single ledger; resets summary_attempts on eligible sessions so daemon re-attempts with fixed inline prompt",
 		Run:         checkSessionInlineSummaryRetry,
 	})
+	r.Register(&Check{
+		Slug:        "ledger-rebase-wedge",
+		Description: "Clear a STALE wedged rebase on the ledger — including a structurally-incomplete rebase-merge dir git rebase --abort cannot clear — so background sync resumes unattended",
+		MinInterval: 30 * time.Minute,
+		BlastRadius: "single ledger; git rebase --abort/--quit on a STALE wedge only (fresh in-flight rebases untouched); no history rewrite, HEAD unchanged",
+		Run:         checkLedgerRebaseWedge,
+	})
 	return r
+}
+
+// checkLedgerRebaseWedge is the daemon autofix twin of cmd/ox's
+// ledger-stuck-operation check (bd ox-j3cl). It runs unattended on a slow
+// ticker so a wedged ledger self-heals with no human and no `ox doctor --fix`:
+// the reported production incident sat suspended for six weeks because the only
+// recovery primitive (`git rebase --abort`) could not clear a zombie
+// rebase-merge dir left by a process killed mid-`pull --rebase --autostash`.
+//
+// Complements the daemon's in-line recoverPreexistingRebase (which fires on the
+// pull pipeline): this is an independent trigger with structured telemetry, so
+// a self-heal is visible in the field rather than silent.
+func checkLedgerRebaseWedge(ctx context.Context, repoPath string) CheckResult {
+	if repoPath == "" {
+		return CheckResult{Status: StatusClean}
+	}
+	pctx, err := config.LoadProjectContext(repoPath)
+	if err != nil || pctx == nil {
+		// uninitialized workspace or no ledger configured — nothing to do
+		return CheckResult{Status: StatusClean, Repo: repoPath}
+	}
+	ledgerPath := pctx.DefaultLedgerPath()
+	if ledgerPath == "" {
+		return CheckResult{Status: StatusClean, Repo: repoPath}
+	}
+	return repairLedgerRebaseWedge(ctx, ledgerPath, repoPath)
+}
+
+// repairLedgerRebaseWedge is the side-effect-free-on-healthy core of
+// checkLedgerRebaseWedge, split out so tests can drive it against a real repo
+// without standing up a full ProjectContext. Only a STALE rebase (older than
+// gitutil.StaleRebaseThreshold) is recovered — a fresh one is almost always the
+// daemon's own in-flight pull and must be left alone.
+func repairLedgerRebaseWedge(ctx context.Context, ledgerPath, repoPath string) CheckResult {
+	age, inProgress := gitutil.RebaseAge(ledgerPath)
+	if !inProgress {
+		return CheckResult{Status: StatusClean, Repo: repoPath}
+	}
+	if age < gitutil.StaleRebaseThreshold {
+		return CheckResult{Status: StatusClean, Repo: repoPath}
+	}
+	if err := gitutil.AbortOrClearRebase(ctx, ledgerPath, "autofix stale ledger rebase wedge", slog.Default()); err != nil {
+		return CheckResult{
+			Status:  StatusError,
+			Repo:    repoPath,
+			Summary: fmt.Sprintf("stale rebase wedge recovery failed: %v", err),
+		}
+	}
+	return CheckResult{
+		Status:  StatusFixed,
+		Repo:    repoPath,
+		Summary: fmt.Sprintf("cleared stale wedged rebase on ledger (age %s)", age.Round(time.Second)),
+	}
 }
 
 // checkInitReverted is the daemon-side counterpart of cmd/ox/doctor_init_reverted.go.

--- a/internal/doctor/autofix/ledger_rebase_wedge_test.go
+++ b/internal/doctor/autofix/ledger_rebase_wedge_test.go
@@ -1,0 +1,109 @@
+package autofix
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// afGit runs git in dir with a fixed identity. Git isolation (no global/system
+// config, no gpgsign prompt) comes from gitenv_test.go's testenv blank-import.
+func afGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...) // git in a temp dir, not the ox CLI
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), // safe: hermetic env for git (not ox) subprocess in a temp dir; ox is never spawned here
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v: %s", args, out)
+	return strings.TrimSpace(string(out))
+}
+
+// makeZombieLedger builds a real repo wedged by a structurally-incomplete
+// .git/rebase-merge dir — only an `autostash` entry, no head-name/orig-head —
+// the exact shape `git rebase --abort` cannot clear (bd ox-j3cl). When stale is
+// true the state dir is backdated past gitutil.StaleRebaseThreshold.
+func makeZombieLedger(t *testing.T, stale bool) string {
+	t.Helper()
+	repo := t.TempDir()
+	afGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("base\n"), 0o644))
+	afGit(t, repo, "add", "f.txt")
+	afGit(t, repo, "commit", "-m", "base")
+
+	// a real autostash object, faithful to production
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("dirty\n"), 0o644))
+	stashOID := afGit(t, repo, "stash", "create")
+	afGit(t, repo, "checkout", "--", "f.txt")
+
+	stateDir := filepath.Join(repo, ".git", "rebase-merge")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "autostash"), []byte(stashOID+"\n"), 0o644))
+	require.True(t, gitutil.IsRebaseInProgress(repo))
+
+	if stale {
+		old := time.Now().Add(-time.Hour)
+		require.NoError(t, os.Chtimes(filepath.Join(stateDir, "autostash"), old, old))
+		require.NoError(t, os.Chtimes(stateDir, old, old))
+	}
+	return repo
+}
+
+// TestRepairLedgerRebaseWedge_ClearsStaleZombie is the autofix regression for bd
+// ox-j3cl: UNATTENDED — no human, no `ox doctor --fix` — the daemon must clear a
+// stale zombie rebase dir so background sync resumes. The reported incident sat
+// suspended six weeks because the only recovery primitive (git rebase --abort)
+// could not clear this shape.
+func TestRepairLedgerRebaseWedge_ClearsStaleZombie(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses")
+	}
+	repo := makeZombieLedger(t, true)
+
+	res := repairLedgerRebaseWedge(context.Background(), repo, repo)
+
+	assert.Equal(t, StatusFixed, res.Status, "stale zombie must be auto-cleared: %+v", res)
+	assert.False(t, gitutil.IsRebaseInProgress(repo), "rebase state must be gone after autofix")
+}
+
+// TestRepairLedgerRebaseWedge_LeavesFreshRebase: a fresh rebase is almost always
+// the daemon's own in-flight pull. Autofix must NOT abort it out from under the
+// pull. Failure prevented: the unattended ticker racing the sync loop and
+// corrupting a live rebase.
+func TestRepairLedgerRebaseWedge_LeavesFreshRebase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses")
+	}
+	repo := makeZombieLedger(t, false) // mtime = now → fresh
+
+	res := repairLedgerRebaseWedge(context.Background(), repo, repo)
+
+	assert.Equal(t, StatusClean, res.Status, "a fresh rebase must be left alone")
+	assert.True(t, gitutil.IsRebaseInProgress(repo), "fresh rebase must NOT be cleared")
+}
+
+// TestRepairLedgerRebaseWedge_CleanRepo: no rebase in progress → StatusClean,
+// no side effects. Guards the idempotent no-op path the ticker hits every cycle.
+func TestRepairLedgerRebaseWedge_CleanRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses")
+	}
+	repo := t.TempDir()
+	afGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("x\n"), 0o644))
+	afGit(t, repo, "add", "f.txt")
+	afGit(t, repo, "commit", "-m", "base")
+
+	res := repairLedgerRebaseWedge(context.Background(), repo, repo)
+	assert.Equal(t, StatusClean, res.Status)
+}

--- a/internal/gitutil/rebase_recover.go
+++ b/internal/gitutil/rebase_recover.go
@@ -1,0 +1,166 @@
+package gitutil
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// StaleRebaseThreshold is how long a rebase must have been in progress before
+// automated recovery treats it as a wedge rather than an in-flight operation.
+// A fresh rebase (younger than this) is almost always a live `pull --rebase`
+// or a human mid-operation and must be left alone. Matches the daemon's own
+// staleness gate so the CLI (doctor) and daemon agree on what "stuck" means.
+const StaleRebaseThreshold = 5 * time.Minute
+
+// AbortOrClearRebase clears an in-progress rebase state that is blocking sync.
+//
+// It first tries the reversible, audited `git rebase --abort` (via
+// AuditAndAbort), which is correct whenever the rebase state directory is
+// intact. When abort FAILS because the state directory is structurally
+// incomplete — a "zombie" left by a process killed mid-rebase, e.g. a
+// .git/rebase-merge containing only an `autostash` entry with no
+// head-name/orig-head — abort cannot determine where to reset HEAD, so it
+// escalates to `git rebase --quit`, which removes the state directory WITHOUT
+// moving HEAD.
+//
+// The quit escalation is gated on two conditions that together make it safe:
+//
+//  1. The state directory is missing the metadata `--abort` needs (head-name /
+//     orig-head). A complete directory that still failed to abort is a
+//     different, unknown problem — surface it, don't guess.
+//  2. HEAD is on a real branch (not detached). A detached HEAD means the
+//     rebase had already rewound and was mid-replay, where --quit would strand
+//     HEAD at a partial-replay commit. A zombie killed during rebase init never
+//     rewound HEAD, so the branch still holds every original commit and --quit
+//     is a pure no-op on history.
+//
+// Any parked working tree recorded in the state's `autostash` entry is logged
+// (object id) before the directory is dropped so it stays recoverable as a
+// dangling object — never silently discarded (.claude/rules/daemon-git.md).
+//
+// Returns nil when no rebase remains in progress afterward; otherwise the error
+// from the last recovery attempt. Logger MUST be non-nil in normal use; a nil
+// logger falls back to a discard handler rather than panicking.
+func AbortOrClearRebase(ctx context.Context, repoPath, reason string, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discardWriter{}, nil))
+	}
+
+	// Rung 1: the reversible, audited abort. Clears any intact rebase state.
+	abortErr := AuditAndAbort(ctx, repoPath, AuditOpRebase, reason, logger)
+	if abortErr == nil {
+		return nil
+	}
+
+	// Abort failed. Decide whether the crash-mid-init signature holds, where
+	// `git rebase --quit` is the safe escalation.
+	stateDir, ok := rebaseStateDir(repoPath)
+	if !ok {
+		// No state dir yet abort failed. If nothing is in progress the
+		// post-condition is already satisfied; otherwise surface the abort error.
+		if !IsRebaseInProgress(repoPath) {
+			return nil
+		}
+		return abortErr
+	}
+	if rebaseStateAbortable(stateDir) {
+		// The directory carries the metadata abort needs, yet abort still
+		// failed — an unknown fault. Don't quit blindly; surface it.
+		return abortErr
+	}
+	if headDetached(ctx, repoPath) {
+		// Rebase had rewound HEAD; quitting would strand a partial replay.
+		return abortErr
+	}
+
+	// Record any parked autostash before dropping the state directory.
+	autostash := readAutostashOID(stateDir)
+
+	quitCtx, cancel := context.WithTimeout(context.Background(), abortTimeout)
+	defer cancel()
+	quitCmd := exec.CommandContext(quitCtx, "git", "-C", repoPath, "rebase", "--quit")
+	out, quitErr := quitCmd.CombinedOutput()
+	if quitErr != nil {
+		// `git rebase --quit` can exit non-zero while STILL removing the state
+		// directory (e.g. a stale autostash object failed to re-apply). The
+		// wedge is what we care about — only treat it as a failure if a rebase
+		// genuinely persists.
+		if IsRebaseInProgress(repoPath) {
+			logger.Error("git_rebase_quit_failed",
+				"op", "rebase_quit_failed", "repo", repoPath,
+				"error", quitErr,
+				"output", SanitizeOutput(strings.TrimSpace(string(out))))
+			return fmt.Errorf("git rebase --quit after failed abort: %w", quitErr)
+		}
+		logger.Warn("git_rebase_quit_nonzero_but_cleared",
+			"op", "rebase_quit_nonzero_but_cleared", "repo", repoPath,
+			"output", SanitizeOutput(strings.TrimSpace(string(out))))
+	}
+
+	if IsRebaseInProgress(repoPath) {
+		return fmt.Errorf("rebase state persists after git rebase --quit at %s", repoPath)
+	}
+
+	logger.Warn("git_rebase_quit_recovered",
+		"op", "rebase_quit_recovered", "repo", repoPath,
+		"reason", reason,
+		"head_sha", captureHeadSHA(ctx, repoPath),
+		"autostash_oid", autostash,
+		"abort_error", SanitizeOutput(abortErr.Error()))
+	return nil
+}
+
+// rebaseStateDir returns the active rebase state directory (.git/rebase-merge
+// or .git/rebase-apply) and whether one exists.
+func rebaseStateDir(repoPath string) (string, bool) {
+	gitDir := filepath.Join(repoPath, ".git")
+	for _, d := range []string{"rebase-merge", "rebase-apply"} {
+		p := filepath.Join(gitDir, d)
+		if _, err := os.Stat(p); err == nil {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// rebaseStateAbortable reports whether a rebase state directory carries the
+// metadata `git rebase --abort` needs to reset HEAD: a non-empty head-name AND
+// orig-head. A directory missing either is a zombie abort cannot clear.
+func rebaseStateAbortable(stateDir string) bool {
+	return nonEmptyFile(filepath.Join(stateDir, "head-name")) &&
+		nonEmptyFile(filepath.Join(stateDir, "orig-head"))
+}
+
+// nonEmptyFile reports whether path exists and has a non-zero size.
+func nonEmptyFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Size() > 0
+}
+
+// readAutostashOID returns the object id recorded in the rebase state's
+// autostash file, or "" if none. git writes the stashed working tree's commit
+// id here; logging it keeps the parked changes recoverable after --quit.
+func readAutostashOID(stateDir string) string {
+	data, err := os.ReadFile(filepath.Join(stateDir, "autostash"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// headDetached reports whether HEAD is NOT on a branch. `git symbolic-ref -q
+// HEAD` exits 0 when on a branch and non-zero when detached. Best-effort: on
+// any error it returns false (treat as on-branch) so a transient git hiccup
+// doesn't over-eagerly refuse the quit path.
+func headDetached(ctx context.Context, repoPath string) bool {
+	subCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(subCtx, "git", "-C", repoPath, "symbolic-ref", "-q", "HEAD")
+	return cmd.Run() != nil
+}

--- a/internal/gitutil/rebase_recover_test.go
+++ b/internal/gitutil/rebase_recover_test.go
@@ -1,0 +1,123 @@
+package gitutil
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func quietLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// makeZombieRebase builds a real repo on `main` and injects a structurally
+// incomplete .git/rebase-merge directory — only an `autostash` entry, no
+// head-name/orig-head — exactly the wedge a process killed mid-`pull --rebase
+// --autostash` leaves behind (bd ox-j3cl). `git rebase --abort` CANNOT clear
+// this: there is nothing to reset HEAD to. HEAD stays on `main`, so the branch
+// still holds every original commit.
+func makeZombieRebase(t *testing.T) (repo, headBefore string) {
+	t.Helper()
+	repo = t.TempDir()
+	runGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("base\n"), 0o644))
+	runGit(t, repo, "add", "f.txt")
+	runGit(t, repo, "commit", "-m", "base")
+
+	// A real stash object stands in for the autostash git parks at rebase
+	// start, so `git rebase --quit`'s autostash handling has a valid OID —
+	// faithful to production and avoids an invalid-autostash test artifact.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("dirty\n"), 0o644))
+	stashOID := strings.TrimSpace(captureGit(t, repo, "stash", "create"))
+	runGit(t, repo, "checkout", "--", "f.txt") // restore a clean tree
+
+	headBefore = strings.TrimSpace(captureGit(t, repo, "rev-parse", "HEAD"))
+
+	stateDir := filepath.Join(repo, ".git", "rebase-merge")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "autostash"), []byte(stashOID+"\n"), 0o644))
+
+	require.True(t, IsRebaseInProgress(repo), "setup should look like a rebase in progress")
+	return repo, headBefore
+}
+
+// TestAbortOrClearRebase_ZombieDirCleared is the core regression for bd ox-j3cl:
+// a structurally-incomplete rebase-merge dir (autostash only) wedges every pull.
+// `git rebase --abort` cannot clear it; AbortOrClearRebase escalates to
+// `git rebase --quit` and clears it WITHOUT moving HEAD.
+// Failure prevented: a corrupt rebase dir permanently suspends ledger sync.
+func TestAbortOrClearRebase_ZombieDirCleared(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses")
+	}
+	repo, headBefore := makeZombieRebase(t)
+
+	// Prove the OLD recovery path can't clear this shape: plain abort fails and
+	// leaves the wedge. This is what the pre-fix daemon/doctor did — and why the
+	// ledger stayed stuck. Without the quit escalation below, this repo is dead.
+	abortErr := AuditAndAbort(context.Background(), repo, AuditOpRebase, "regression: abort alone", quietLogger())
+	require.Error(t, abortErr, "git rebase --abort must fail on a zombie dir (no head-name/orig-head)")
+	require.True(t, IsRebaseInProgress(repo), "abort failure must leave the wedge in place")
+
+	// The fix: abort→quit escalation clears it.
+	err := AbortOrClearRebase(context.Background(), repo, "regression: clear zombie", quietLogger())
+	require.NoError(t, err, "AbortOrClearRebase must clear a zombie rebase dir")
+	assert.False(t, IsRebaseInProgress(repo), "rebase state must be gone after recovery")
+
+	headAfter := strings.TrimSpace(captureGit(t, repo, "rev-parse", "HEAD"))
+	assert.Equal(t, headBefore, headAfter, "quit must NOT move HEAD")
+	branch := strings.TrimSpace(captureGit(t, repo, "rev-parse", "--abbrev-ref", "HEAD"))
+	assert.Equal(t, "main", branch, "HEAD must remain on the original branch")
+}
+
+// TestAbortOrClearRebase_IntactStateUsesAbort proves the escalation does not
+// change behavior for a NORMAL wedge: a real conflict-halted rebase has a
+// complete, abortable state dir, so rung 1 (`git rebase --abort`) clears it and
+// we never reach --quit. Failure prevented: over-eager --quit that skips the
+// reversible abort on an intact rebase.
+func TestAbortOrClearRebase_IntactStateUsesAbort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git rebase operations")
+	}
+	_, repo := setupDivergentRepos(t, "conflict.txt", "local-side", "remote-side")
+	require.True(t, IsRebaseInProgress(repo), "precondition: an intact conflict rebase")
+
+	err := AbortOrClearRebase(context.Background(), repo, "intact abort", quietLogger())
+	require.NoError(t, err)
+	assert.False(t, IsRebaseInProgress(repo), "intact rebase must clear via --abort")
+}
+
+// TestAbortOrClearRebase_DetachedHeadRefusesQuit guards the one shape where
+// --quit is UNSAFE: a detached HEAD means the rebase had already rewound and
+// was mid-replay, where dropping the state dir would strand a partial replay.
+// The recovery must refuse and surface the error for a human.
+// Failure prevented: silent data loss by quitting a genuinely in-flight rebase.
+func TestAbortOrClearRebase_DetachedHeadRefusesQuit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: spawns git subprocesses")
+	}
+	repo := t.TempDir()
+	runGit(t, repo, "init", "--initial-branch=main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("base\n"), 0o644))
+	runGit(t, repo, "add", "f.txt")
+	runGit(t, repo, "commit", "-m", "base")
+	head := strings.TrimSpace(captureGit(t, repo, "rev-parse", "HEAD"))
+	// Detach BEFORE injecting the state dir — git refuses checkout mid-rebase.
+	runGit(t, repo, "checkout", "--detach", head)
+
+	stateDir := filepath.Join(repo, ".git", "rebase-merge")
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	// autostash content is irrelevant here — we must bail before the quit.
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "autostash"),
+		[]byte("0000000000000000000000000000000000000000\n"), 0o644))
+	require.True(t, IsRebaseInProgress(repo))
+
+	err := AbortOrClearRebase(context.Background(), repo, "detached guard", quietLogger())
+	require.Error(t, err, "must refuse to quit when HEAD is detached (mid-replay risk)")
+	assert.True(t, IsRebaseInProgress(repo), "the state dir must be left intact for a human")
+}


### PR DESCRIPTION
## Summary

A ledger clone got stuck **sync-suspended for six weeks** because its `.git/rebase-merge/` was a **zombie**: a `git pull --rebase --autostash` was killed right after git wrote the `autostash` entry but **before** `head-name`/`orig-head`. Git then reports "currently rebasing" forever, every background `pull --rebase` fails with `fatal: already a rebase-merge directory`, and the daemon's only recovery — `git rebase --abort` — **also fails** (it needs `orig-head` to reset), so it surfaced a dead-end "run `ox doctor --fix`" that itself couldn't clear the state either.

Root gap: **`git rebase --abort` was the only recovery primitive in the codebase — nothing fell back to `git rebase --quit`**, the correct tool for an un-abortable state dir when HEAD never rewound.

```mermaid
flowchart TD
    K["process killed mid rebase pull, autostash written"] --> Z["zombie rebase-merge dir: autostash only, no head-name"]
    Z --> F["every rebase pull to fatal 'already a rebase-merge directory'"]
    F --> S["sync backoff to suspended, 6 weeks"]
    Z --> A["git rebase abort cannot reset: no head-name or orig-head"]
    A --> DE["old code: dead-end, tells user to run doctor which also cannot clear it"]
    Z --> N["NEW AbortOrClearRebase: escalate to git rebase quit, HEAD unchanged"]
    N --> R["pull resumes, daemon auto-push uploads the backlog"]
```

**What this ships** — recovery is **automatic and hands-free** (no human, no `ox doctor --fix`), defense-in-depth across three layers that all call one new primitive:

- **`internal/gitutil/rebase_recover.go` — `AbortOrClearRebase`:** try the reversible `git rebase --abort`, then escalate to `git rebase --quit` for a structurally-incomplete zombie dir. Gated on **HEAD-on-a-branch** (never quit a detached mid-replay) and logs the parked `autostash` OID before dropping it, so nothing is silently discarded.
- **Layer 1 — daemon sync loop** (`internal/daemon/sync_managed.go`): `recoverPreexistingRebase` now uses the primitive, so it self-heals on the next pull attempt instead of emitting `IssueTypeRebaseStuck`.
- **Layer 2 — daemon autofix scheduler** (`internal/doctor/autofix/default_checks.go`): new `ledger-rebase-wedge` check on the 30-min unattended ticker (twin of `checkInitReverted`), independent of the pull path and emitting `autofix_*` telemetry so a self-heal is **visible**, not silent.
- **Layer 3 — manual backstop** (`cmd/ox/doctor_ledger_git.go` + `doctor.go`): new `ledger-stuck-operation` `FixLevelAuto` check that detects an in-progress op **regardless of unmerged-path count** — closing the blind spot where `ledger-unmerged-paths` (gated on U-state files) reported "no conflicts" and missed the zombie entirely.

Once the wedge clears, the existing `pull --rebase` + daemon auto-push (`pushMurmurCommits` / session-finalize) reconcile and upload the backlog with no further action.

## Test Plan

- **10 new tests**, all green; `make lint` 0 issues; `go build ./...` clean.
- Regression fixtures hand-craft the exact production shape (`mkdir .git/rebase-merge && touch autostash`) — the prior stuck-rebase fixtures all drove *real conflicts*, producing **complete, abortable** state dirs, so they only ever tested the path where `--abort` succeeds and never reproduced the crash-mid-init wedge.
- The gitutil test asserts `require.Error` on the old `git rebase --abort` path (proving it's the shape that was invisible) then that `AbortOrClearRebase` clears it with HEAD unchanged; the autofix test log prints the real signature: `git_abort_failed … could not read '.git/rebase-merge/head-name'` to `git_rebase_quit_recovered … autostash_oid=…`.
- Coverage across all three layers: `internal/gitutil` (abort→quit escalation, intact-state still uses abort, detached-HEAD refuses quit), `internal/daemon` (self-heal vs `IssueTypeRebaseStuck`), `internal/doctor/autofix` (stale clears / fresh left alone / clean no-op), `cmd/ox` (detection blind-spot + fix + loud P0).

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — 10 new regression tests across all four packages
- [ ] CHANGELOG entry added (if user-facing) — daemon/doctor self-heal; no CLI surface change, entry can be added if desired
- [x] Breaking change documented — none; additive recovery only, HEAD never moved on the safe path
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: touches none of `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, `go.sum`

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and recovery for stuck Git operations that can block ledger sync.
  * Improved handling of stale rebase states, including safe cleanup of incomplete repository metadata.
  * Added a new background check to surface and fix blocked ledger operations earlier.

* **Bug Fixes**
  * Recovered from “zombie” rebase states without changing `HEAD`.
  * Prevented stale rebase wedges from causing repeated sync failures.
  * Added broader regression coverage for cleanup and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->