### PR TITLE
release: prep v0.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.10.1"
+      "version": "0.11.0"
     }
   ]
 }

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -88,10 +88,11 @@ Read the current CHANGELOG.md to understand the format. Then:
 
 1. Add a new version section at the top (after the header)
 2. Group changes by: Added, Changed, Fixed, Removed
-3. Write **user-focused** descriptions (what users will notice)
-4. NO commit hashes
-5. NO technical jargon like "feat(scope):"
-6. Use today's date in YYYY-MM-DD format
+3. **Lead with customer value** — open each entry with what a coworker can now do, or the pain that's gone; benefit first, mechanism second (or dropped)
+4. NO commit hashes or PR numbers
+5. NO internal jargon — spell out the user-visible effect, never protocol/impl detail (SSE, CSP, OTLP, askpass, HTTP status codes, struct/field/signal names, file paths). Name the command and any `SAGEOX_*` env var; skip commit prefixes like "feat(scope):"
+6. Keep it crisp — one or two sentences per entry
+7. Use today's date in YYYY-MM-DD format
 
 Example format:
 ```markdown
@@ -106,6 +107,10 @@ Example format:
 ### Fixed
 - Bug that was affecting users
 ```
+
+Benefit-first vs. mechanism-first — the single most important rule:
+- ✅ **Publish a plan as a Claude Code Artifact** — a self-contained page that renders with no network access.
+- ❌ **CSP-safe artifact render** — drops the SSE loop and inlines the Mermaid CDN so the page passes Content-Security-Policy.
 
 ### Step 5: Bump Version
 

--- a/.claude/rules/releases.md
+++ b/.claude/rules/releases.md
@@ -28,9 +28,17 @@ make bump-version NEW_VERSION=0.10.0
 
 ## Release Notes Guidelines
 
-**Good:** Clear descriptions of what users can now do. **Bad:** Commit hashes, technical commit messages, internal changes.
+**Lead with customer value — always.** Every entry opens with what a coworker can now *do*, or the pain that's gone. The benefit is the first thing read; the mechanism comes second and stays short, or is dropped. This applies to every release, not just polished ones.
 
-**Agent rules:** DO write human-focused notes, propose version, confirm with human. DO NOT use auto-generated changelogs, include hashes, create tags without approval.
+**Good:** "**Publish a plan as a Claude Code Artifact** — a self-contained page that renders with no network access." Benefit first, plain language.
+
+**Bad:** "**CSP-safe artifact render** — drops the SSE loop and inlines the Mermaid CDN so the page passes Content-Security-Policy." Mechanism first, internal jargon.
+
+**Cut internal jargon.** No protocol/implementation acronyms or symbols in customer-facing notes: SSE, CSP, OTLP, askpass, 401/403, HTTP status codes, struct/field names, signal names, file paths. Name the command and any customer-facing env var (`SAGEOX_*`); translate everything else into the effect the user sees.
+
+**Crisp.** One or two sentences per entry. If a reader can't tell why they'd care by the end of the first line, rewrite it.
+
+**Agent rules:** DO write benefit-first, human-focused notes; propose the version; confirm with human. DO NOT auto-generate changelogs from commits, include hashes/PR numbers, lead with the mechanism, or create tags without approval.
 
 **Release infra changes:** Consult `@oss-release-engineer` subagent first.
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -5,12 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0] - 2026-07-01
 
 ### Added
 
-- **`ox plan render --artifact` produces a CSP-safe page you can publish as a Claude Code Artifact** — a strictly self-contained variant built for the artifact's strict Content-Security-Policy (which blocks every cross-origin resource and all fetch/XHR/WebSocket). It drops the Google-Fonts link (falling back to system fonts) and the live SSE review loop, and replaces the Mermaid CDN with the vendored library inlined in place — so diagrams still render at full parity with zero network, and a diagram-free plan pays none of that weight. The SageOx enrichment references stay clickable: outbound `<a href>` navigation isn't CSP-blocked, so a published artifact remains a hub back into the Ledger — collision PRs, prior-art sessions, and expert routes one click away. Artifact mode is a pure export: the ledger's canonical, review-capable render is left untouched.
-- **`ox plan` render now enforces design-craft for every AI coworker, not just Claude** — the binary nudges any agent (Claude, Codex, Gemini) to show the right visual where prose was hiding a diagram or a UI state, and surfaces that expectation in `ox plan enrich` so it lands *before* the plan is authored rather than only at render time. Agent-only provenance (commit SHAs, "12h ago", workspace counts) is curated out of the human-facing badge chips by construction — a reviewer sees the decision, the agent's `--json` keeps the detail — and the missing-diagram nudge no longer mis-fires on a plan that visualized with a chart instead of Mermaid. A `plan_craft` signal records how often a suggested visual actually gets drawn, so the value of enrichment is measurable rather than assumed.
+- **Publish a plan as a Claude Code Artifact** — `ox plan render --artifact` exports a plan as a single self-contained page that renders right inside Claude Code with no network access: diagrams are inlined and nothing loads from a CDN. Its prior-art links still work, so a shared plan stays a jumping-off point back into your team's history.
+- **Live human review on a plan, before any code is written** — `ox plan review` now waits for your reviewers and shows their feedback the moment it lands, so an AI coworker can pause for a real decision instead of guessing. Every note is saved with the plan.
+- **Plans render charts, not just tables** — line, bar, area, and scatter charts now appear inline in a rendered plan, so a plan full of numbers shows the trend at a glance.
+- **Quicker to navigate a plan** — prior-art references (related PRs and past sessions) are clickable links back into your Ledger, and code blocks are syntax-highlighted.
+
+### Changed
+
+- **Sharper plans from every AI coworker, not just Claude** — plan rendering now coaches any agent (Claude, Codex, Gemini) to add a diagram or UI sketch where prose was hiding one, and to fold that in while the plan is being written. It also stops asking for a diagram when a chart already tells the story.
+- **HTML plans open the right way on their own** — ask for an HTML plan and ox opens the polished, team-context-aware view instead of a hand-rolled one-off (set `SAGEOX_PLAN_HTML` to opt out).
+- **Smarter visual suggestions and cleaner layouts** — the renderer points out where a visual would help based on what the plan says, and packs busy sections into tidier layouts.
+- **Full dependency license transparency** — ox now ships a `THIRD_PARTY_NOTICES.md` listing every dependency and its license.
+
+### Fixed
+
+- **Background sync no longer gets stuck on a broken rebase** — if a synced repo's git state wedges (even the rare "zombie" case git can't unwind on its own), the daemon now clears it automatically and `ox doctor` repairs it, so your team's history keeps flowing instead of silently stalling.
+- **`ox sync --team` shows accurate per-team status** — real results and details for each team, instead of one lumped-together summary.
+- **`--title` and `--json` now work when importing documents and media** — set a title on import, and get the new recording's id back in `--json` output.
+- **Clear message when an access token has expired** — token checks no longer hang or retry in silence; ox tells you to sign in again.
+- **No stray telemetry errors after you log out** — ox stops sending background telemetry (and the errors that came with it) once there's no active session.
 
 ## [0.10.1] - 2026-06-15
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.9.1"
+  "version": "0.11.0"
 }

--- a/docs/reference/adapter/install.mdx
+++ b/docs/reference/adapter/install.mdx
@@ -27,7 +27,8 @@ ox adapter install <name|github-url> [flags]
 ### Options
 
 ```
-  -h, --help   help for install
+      --allow-unverified   install without a SageOx-curated checksum (required for arbitrary repos and for curated entries that lack a pinned checksum)
+  -h, --help               help for install
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/code/prs.mdx
+++ b/docs/reference/code/prs.mdx
@@ -1,0 +1,71 @@
+---
+title: "ox code prs"
+description: "CLI reference for ox code prs"
+sidebar_position: 30
+---
+
+## ox code prs
+
+List pull requests with triage signals
+
+### Synopsis
+
+List indexed pull requests ranked for triage.
+
+By default surfaces the most-stalled open PRs first (least-recent activity at
+the top — those most likely to need attention). All ranking signals are
+deterministic and computed from indexed GitHub data (no LLM ranking, no
+external API).
+
+Sort modes:
+  stalled  (default) — most idle PR first, where stalled-days = days since the
+                       most recent of updated_at or last comment.
+  age      — oldest PR by created_at first.
+  activity — most comments first.
+
+Each result row carries: age_days, stalled_days, comments, reviewers (distinct
+authors of review comments), discussants (distinct authors of discussion
+comments), commits, labels, URL.
+
+```
+ox code prs [flags]
+```
+
+### Examples
+
+```
+  # default — most-stalled open PRs first, JSON for agents
+  ox code prs
+
+  # oldest open PRs first, limit 10
+  ox code prs --sort age --limit 10
+
+  # most-discussed closed PRs (e.g., for retrospectives)
+  ox code prs --state closed --sort activity
+```
+
+### Options
+
+```
+  -h, --help           help for prs
+      --limit int      max number of PRs to return (default 20)
+      --pretty         pretty-print JSON output
+      --sort string    ranking: stalled | age | activity (default "stalled")
+      --state string   PR state: open | closed | merged | all (default "open")
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox code](/code)	 - Search code in this repo
+

--- a/docs/reference/code/search.mdx
+++ b/docs/reference/code/search.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox code search"
 description: "CLI reference for ox code search"
-sidebar_position: 30
+sidebar_position: 31
 ---
 
 ## ox code search

--- a/docs/reference/code/status.mdx
+++ b/docs/reference/code/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox code status"
 description: "CLI reference for ox code status"
-sidebar_position: 31
+sidebar_position: 32
 ---
 
 ## ox code status

--- a/docs/reference/distill/history/index.mdx
+++ b/docs/reference/distill/history/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill history"
 description: "CLI reference for ox distill history"
-sidebar_position: 33
+sidebar_position: 34
 ---
 
 ## ox distill history

--- a/docs/reference/distill/history/list.mdx
+++ b/docs/reference/distill/history/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill history list"
 description: "CLI reference for ox distill history list"
-sidebar_position: 34
+sidebar_position: 35
 ---
 
 ## ox distill history list

--- a/docs/reference/distill/history/show.mdx
+++ b/docs/reference/distill/history/show.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill history show"
 description: "CLI reference for ox distill history show"
-sidebar_position: 35
+sidebar_position: 36
 ---
 
 ## ox distill history show

--- a/docs/reference/distill/history/since.mdx
+++ b/docs/reference/distill/history/since.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill history since"
 description: "CLI reference for ox distill history since"
-sidebar_position: 36
+sidebar_position: 37
 ---
 
 ## ox distill history since

--- a/docs/reference/distill/index.mdx
+++ b/docs/reference/distill/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox distill"
 description: "CLI reference for ox distill"
-sidebar_position: 32
+sidebar_position: 33
 ---
 
 ## ox distill

--- a/docs/reference/doctor.mdx
+++ b/docs/reference/doctor.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox doctor"
 description: "CLI reference for ox doctor"
-sidebar_position: 37
+sidebar_position: 38
 ---
 
 ## ox doctor

--- a/docs/reference/glance.mdx
+++ b/docs/reference/glance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox glance"
 description: "CLI reference for ox glance"
-sidebar_position: 38
+sidebar_position: 39
 ---
 
 ## ox glance

--- a/docs/reference/guide.mdx
+++ b/docs/reference/guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox guide"
 description: "CLI reference for ox guide"
-sidebar_position: 39
+sidebar_position: 40
 ---
 
 ## ox guide

--- a/docs/reference/hooks/add.mdx
+++ b/docs/reference/hooks/add.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks add"
 description: "CLI reference for ox hooks add"
-sidebar_position: 41
+sidebar_position: 42
 ---
 
 ## ox hooks add

--- a/docs/reference/hooks/index.mdx
+++ b/docs/reference/hooks/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks"
 description: "CLI reference for ox hooks"
-sidebar_position: 40
+sidebar_position: 41
 ---
 
 ## ox hooks

--- a/docs/reference/hooks/list.mdx
+++ b/docs/reference/hooks/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks list"
 description: "CLI reference for ox hooks list"
-sidebar_position: 42
+sidebar_position: 43
 ---
 
 ## ox hooks list

--- a/docs/reference/hooks/log.mdx
+++ b/docs/reference/hooks/log.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks log"
 description: "CLI reference for ox hooks log"
-sidebar_position: 43
+sidebar_position: 44
 ---
 
 ## ox hooks log

--- a/docs/reference/hooks/test.mdx
+++ b/docs/reference/hooks/test.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks test"
 description: "CLI reference for ox hooks test"
-sidebar_position: 44
+sidebar_position: 45
 ---
 
 ## ox hooks test

--- a/docs/reference/import.mdx
+++ b/docs/reference/import.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox import"
 description: "CLI reference for ox import"
-sidebar_position: 45
+sidebar_position: 46
 ---
 
 ## ox import

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -35,7 +35,7 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
 * [ox glance](/glance)	 - See what your team's AI coworkers are working on
 * [ox guide](/guide)	 - Show a bundled topical guide
 * [ox hooks](/hooks)	 - Manage event hooks for daemon notifications
-* [ox import](/import)	 - Import a document or video URL into team context
+* [ox import](/import)	 - Import a document, media file, or video URL into team context or a Knowledge Bubble
 * [ox index](/index)	 - Index code and project data for search
 * [ox init](/init)	 - Initialize SageOx for this repository
 * [ox kb](/kb)	 - Work with knowledge bubbles

--- a/docs/reference/index/code.mdx
+++ b/docs/reference/index/code.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index code"
 description: "CLI reference for ox index code"
-sidebar_position: 47
+sidebar_position: 48
 ---
 
 ## ox index code

--- a/docs/reference/index/github.mdx
+++ b/docs/reference/index/github.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index github"
 description: "CLI reference for ox index github"
-sidebar_position: 48
+sidebar_position: 49
 ---
 
 ## ox index github

--- a/docs/reference/index/index.mdx
+++ b/docs/reference/index/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index"
 description: "CLI reference for ox index"
-sidebar_position: 46
+sidebar_position: 47
 ---
 
 ## ox index

--- a/docs/reference/index/status.mdx
+++ b/docs/reference/index/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index status"
 description: "CLI reference for ox index status"
-sidebar_position: 49
+sidebar_position: 50
 ---
 
 ## ox index status

--- a/docs/reference/init.mdx
+++ b/docs/reference/init.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox init"
 description: "CLI reference for ox init"
-sidebar_position: 50
+sidebar_position: 51
 ---
 
 ## ox init

--- a/docs/reference/kb/config/get.mdx
+++ b/docs/reference/kb/config/get.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb config get"
 description: "CLI reference for ox kb config get"
-sidebar_position: 53
+sidebar_position: 54
 ---
 
 ## ox kb config get

--- a/docs/reference/kb/config/index.mdx
+++ b/docs/reference/kb/config/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb config"
 description: "CLI reference for ox kb config"
-sidebar_position: 52
+sidebar_position: 53
 ---
 
 ## ox kb config

--- a/docs/reference/kb/config/list.mdx
+++ b/docs/reference/kb/config/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb config list"
 description: "CLI reference for ox kb config list"
-sidebar_position: 54
+sidebar_position: 55
 ---
 
 ## ox kb config list

--- a/docs/reference/kb/hydrate.mdx
+++ b/docs/reference/kb/hydrate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb hydrate"
 description: "CLI reference for ox kb hydrate"
-sidebar_position: 55
+sidebar_position: 56
 ---
 
 ## ox kb hydrate

--- a/docs/reference/kb/index.mdx
+++ b/docs/reference/kb/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb"
 description: "CLI reference for ox kb"
-sidebar_position: 51
+sidebar_position: 52
 ---
 
 ## ox kb

--- a/docs/reference/kb/list.mdx
+++ b/docs/reference/kb/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb list"
 description: "CLI reference for ox kb list"
-sidebar_position: 56
+sidebar_position: 57
 ---
 
 ## ox kb list

--- a/docs/reference/kb/path.mdx
+++ b/docs/reference/kb/path.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb path"
 description: "CLI reference for ox kb path"
-sidebar_position: 57
+sidebar_position: 58
 ---
 
 ## ox kb path

--- a/docs/reference/kb/show.mdx
+++ b/docs/reference/kb/show.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb show"
 description: "CLI reference for ox kb show"
-sidebar_position: 58
+sidebar_position: 59
 ---
 
 ## ox kb show

--- a/docs/reference/login.mdx
+++ b/docs/reference/login.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox login"
 description: "CLI reference for ox login"
-sidebar_position: 59
+sidebar_position: 60
 ---
 
 ## ox login

--- a/docs/reference/logout.mdx
+++ b/docs/reference/logout.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox logout"
 description: "CLI reference for ox logout"
-sidebar_position: 60
+sidebar_position: 61
 ---
 
 ## ox logout

--- a/docs/reference/murmur/delete.mdx
+++ b/docs/reference/murmur/delete.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur delete"
 description: "CLI reference for ox murmur delete"
-sidebar_position: 62
+sidebar_position: 63
 ---
 
 ## ox murmur delete

--- a/docs/reference/murmur/index.mdx
+++ b/docs/reference/murmur/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur"
 description: "CLI reference for ox murmur"
-sidebar_position: 61
+sidebar_position: 62
 ---
 
 ## ox murmur

--- a/docs/reference/murmur/list.mdx
+++ b/docs/reference/murmur/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur list"
 description: "CLI reference for ox murmur list"
-sidebar_position: 63
+sidebar_position: 64
 ---
 
 ## ox murmur list

--- a/docs/reference/murmur/pause.mdx
+++ b/docs/reference/murmur/pause.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur pause"
 description: "CLI reference for ox murmur pause"
-sidebar_position: 64
+sidebar_position: 65
 ---
 
 ## ox murmur pause

--- a/docs/reference/murmur/resume.mdx
+++ b/docs/reference/murmur/resume.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur resume"
 description: "CLI reference for ox murmur resume"
-sidebar_position: 65
+sidebar_position: 66
 ---
 
 ## ox murmur resume

--- a/docs/reference/murmur/status.mdx
+++ b/docs/reference/murmur/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur status"
 description: "CLI reference for ox murmur status"
-sidebar_position: 66
+sidebar_position: 67
 ---
 
 ## ox murmur status

--- a/docs/reference/plan/enrich.mdx
+++ b/docs/reference/plan/enrich.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan enrich"
 description: "CLI reference for ox plan enrich"
-sidebar_position: 68
+sidebar_position: 69
 ---
 
 ## ox plan enrich

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan"
 description: "CLI reference for ox plan"
-sidebar_position: 67
+sidebar_position: 68
 ---
 
 ## ox plan

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan list"
 description: "CLI reference for ox plan list"
-sidebar_position: 69
+sidebar_position: 70
 ---
 
 ## ox plan list

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -1,12 +1,22 @@
 ---
 title: "ox plan render"
 description: "CLI reference for ox plan render"
-sidebar_position: 70
+sidebar_position: 71
 ---
 
 ## ox plan render
 
 Render a plan to a self-contained HTML page
+
+### Synopsis
+
+Render a plan to a self-contained HTML page.
+
+No slug renders the plan from --file/stdin; a slug renders a saved plan with its
+review state. With --open on a SAVED plan, ox launches the live review loop
+(`ox plan review`) so your marks write straight back to the ledger
+instead of a dead-end file/clipboard export — pass --static for a read-only page.
+-o/--output and --artifact always write a static file.
 
 ```
 ox plan render [slug] [flags]
@@ -20,6 +30,7 @@ ox plan render [slug] [flags]
   -h, --help            help for render
       --open            open the rendered HTML in your browser
   -o, --output string   write the rendered HTML to this path
+      --static          with --open on a saved plan, open a read-only static page instead of launching the live review loop
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/plan/review/await.mdx
+++ b/docs/reference/plan/review/await.mdx
@@ -1,0 +1,59 @@
+---
+title: "ox plan review await"
+description: "CLI reference for ox plan review await"
+sidebar_position: 73
+---
+
+## ox plan review await
+
+Block until reviewers submit feedback, then print open items as JSON (agent loop)
+
+### Synopsis
+
+Block until human reviewers submit review feedback, then emit the open items as JSON.
+
+This is the agent side of the review loop. Instead of parking the authoring agent in
+a serve loop (where it cannot act), the agent runs:
+
+    ox plan review await <slug>
+
+which blocks until there is open, unaddressed feedback from ANY reviewer (multi-user),
+prints it as JSON on stdout, and exits. The agent then addresses each item, runs
+`ox plan feedback resolve <slug> <anchor> --state addressed --commit <sha>`, re-renders
+with `ox plan render` (the reviewers' page auto-reloads over SSE), and calls await
+again — a real turn-based loop that keeps the authoring agent in context.
+
+Because this command BLOCKS (up to --timeout), CONFIRM WITH THE USER before entering
+the loop — do not silently park an autonomous ("auto") agent run waiting on a human.
+Ask first, or pass a short --timeout and poll between other work.
+
+Emits immediately if feedback is already waiting (never strands a race). Exits with
+status "timeout" if nothing arrives within --timeout, or "approved" once a reviewer
+approves the plan (the loop is done).
+
+```
+ox plan review await <slug> [flags]
+```
+
+### Options
+
+```
+  -h, --help               help for await
+      --timeout duration   block at most this long before exiting with status "timeout" (default 30m0s)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox plan review](/plan/review)	 - Open a live review loop for a saved plan (serve, collect, auto-reload, approve)
+

--- a/docs/reference/plan/review/index.mdx
+++ b/docs/reference/plan/review/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan review"
 description: "CLI reference for ox plan review"
-sidebar_position: 71
+sidebar_position: 72
 ---
 
 ## ox plan review
@@ -49,4 +49,5 @@ ox plan review <slug> [flags]
 ### SEE ALSO
 
 * [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
+* [ox plan review await](/plan/review/await)	 - Block until reviewers submit feedback, then print open items as JSON (agent loop)
 

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan view"
 description: "CLI reference for ox plan view"
-sidebar_position: 72
+sidebar_position: 74
 ---
 
 ## ox plan view

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox query"
 description: "CLI reference for ox query"
-sidebar_position: 73
+sidebar_position: 75
 ---
 
 ## ox query

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox release-notes"
 description: "CLI reference for ox release-notes"
-sidebar_position: 74
+sidebar_position: 76
 ---
 
 ## ox release-notes

--- a/docs/reference/scout.mdx
+++ b/docs/reference/scout.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox scout"
 description: "CLI reference for ox scout"
-sidebar_position: 75
+sidebar_position: 77
 ---
 
 ## ox scout

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session audit"
 description: "CLI reference for ox session audit"
-sidebar_position: 77
+sidebar_position: 79
 ---
 
 ## ox session audit

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session"
 description: "CLI reference for ox session"
-sidebar_position: 76
+sidebar_position: 78
 ---
 
 ## ox session

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session lint"
 description: "CLI reference for ox session lint"
-sidebar_position: 78
+sidebar_position: 80
 ---
 
 ## ox session lint

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session list"
 description: "CLI reference for ox session list"
-sidebar_position: 79
+sidebar_position: 81
 ---
 
 ## ox session list

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session redact"
 description: "CLI reference for ox session redact"
-sidebar_position: 80
+sidebar_position: 82
 ---
 
 ## ox session redact

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session regenerate"
 description: "CLI reference for ox session regenerate"
-sidebar_position: 81
+sidebar_position: 83
 ---
 
 ## ox session regenerate

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session repair-meta-summary"
 description: "CLI reference for ox session repair-meta-summary"
-sidebar_position: 82
+sidebar_position: 84
 ---
 
 ## ox session repair-meta-summary

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session score"
 description: "CLI reference for ox session score"
-sidebar_position: 83
+sidebar_position: 85
 ---
 
 ## ox session score

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session status"
 description: "CLI reference for ox session status"
-sidebar_position: 84
+sidebar_position: 86
 ---
 
 ## ox session status

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session stop"
 description: "CLI reference for ox session stop"
-sidebar_position: 85
+sidebar_position: 87
 ---
 
 ## ox session stop

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session token-optimize"
 description: "CLI reference for ox session token-optimize"
-sidebar_position: 86
+sidebar_position: 88
 ---
 
 ## ox session token-optimize

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session view"
 description: "CLI reference for ox session view"
-sidebar_position: 87
+sidebar_position: 89
 ---
 
 ## ox session view

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox status"
 description: "CLI reference for ox status"
-sidebar_position: 88
+sidebar_position: 90
 ---
 
 ## ox status

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox sync"
 description: "CLI reference for ox sync"
-sidebar_position: 89
+sidebar_position: 91
 ---
 
 ## ox sync

--- a/docs/reference/teams.mdx
+++ b/docs/reference/teams.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox teams"
 description: "CLI reference for ox teams"
-sidebar_position: 90
+sidebar_position: 92
 ---
 
 ## ox teams

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox uninstall"
 description: "CLI reference for ox uninstall"
-sidebar_position: 91
+sidebar_position: 93
 ---
 
 ## ox uninstall

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox upgrade"
 description: "CLI reference for ox upgrade"
-sidebar_position: 92
+sidebar_position: 94
 ---
 
 ## ox upgrade

--- a/internal/daemon/sync_rebase_recovery_test.go
+++ b/internal/daemon/sync_rebase_recovery_test.go
@@ -33,7 +33,7 @@ func makeWedgedRebase(t *testing.T) string {
 	repo := t.TempDir()
 
 	git := func(args ...string) {
-		out, err := runGit(t, repo, args...)
+		out, err := runGitOut(t, repo, args...)
 		// Only the intentional conflicting rebase may exit non-zero; surface
 		// any other setup failure (e.g. unsupported --initial-branch) so a
 		// broken fixture fails loudly instead of masquerading as a wedge.
@@ -95,9 +95,9 @@ func gitEnv() []string {
 	)
 }
 
-// runGit runs git in dir, returning combined output and error so callers can
+// runGitOut runs git in dir, returning combined output and error so callers can
 // assert on either the result or the failure.
-func runGit(t *testing.T, dir string, args ...string) (string, error) {
+func runGitOut(t *testing.T, dir string, args ...string) (string, error) {
 	t.Helper()
 	cmd := exec.Command("git", args...) // safe: git in a temp dir, not the ox CLI
 	cmd.Dir = dir
@@ -120,7 +120,7 @@ func setupRemoteWithStuckRebase(t *testing.T) string {
 	clone := filepath.Join(root, "clone")
 
 	mustGit := func(dir string, args ...string) {
-		if out, err := runGit(t, dir, args...); err != nil {
+		if out, err := runGitOut(t, dir, args...); err != nil {
 			t.Fatalf("git %v failed: %v\n%s", args, err, out)
 		}
 	}
@@ -151,7 +151,7 @@ func setupRemoteWithStuckRebase(t *testing.T) string {
 
 	// leave the clone wedged in a rebase that stopped and was never continued
 	// (a failing -x exec halts the rebase with a clean tree, no conflict).
-	_, err := runGit(t, clone, "rebase", "-x", "exit 1", "HEAD~1")
+	_, err := runGitOut(t, clone, "rebase", "-x", "exit 1", "HEAD~1")
 	require.Error(t, err, "the failing -x exec should halt the rebase")
 	require.True(t, gitutil.IsRebaseInProgress(clone), "clone should be wedged")
 	return clone
@@ -220,7 +220,7 @@ func makeZombieWedge(t *testing.T) string {
 	t.Helper()
 	repo := t.TempDir()
 	mustGit := func(args ...string) {
-		if out, err := runGit(t, repo, args...); err != nil {
+		if out, err := runGitOut(t, repo, args...); err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, out)
 		}
 	}
@@ -232,7 +232,7 @@ func makeZombieWedge(t *testing.T) string {
 	// a real autostash object, faithful to production (stash created off a
 	// dirty tree, then the tree restored clean)
 	require.NoError(t, os.WriteFile(filepath.Join(repo, "f.txt"), []byte("dirty\n"), 0o644))
-	out, err := runGit(t, repo, "stash", "create")
+	out, err := runGitOut(t, repo, "stash", "create")
 	require.NoError(t, err, "stash create: %s", out)
 	stashOID := strings.TrimSpace(out)
 	mustGit("checkout", "--", "f.txt")
@@ -277,7 +277,7 @@ func TestRecoverPreexistingRebase_StaleWedge_ApplyBackend(t *testing.T) {
 	}
 	repo := t.TempDir()
 	mustGit := func(args ...string) {
-		if out, err := runGit(t, repo, args...); err != nil && args[0] != "rebase" {
+		if out, err := runGitOut(t, repo, args...); err != nil && args[0] != "rebase" {
 			t.Fatalf("git %v: %v\n%s", args, err, out)
 		}
 	}
@@ -331,7 +331,7 @@ func TestRecoverPreexistingRebase_RecoveryRestoresSyncProgress(t *testing.T) {
 
 	// 2. the daemon's normal pull (what pullManagedRepo runs after recovery)
 	//    now reconciles cleanly with the advanced remote.
-	if out, err := runGit(t, clone, "pull", "--rebase", "--autostash", "origin", "main"); err != nil {
+	if out, err := runGitOut(t, clone, "pull", "--rebase", "--autostash", "origin", "main"); err != nil {
 		t.Fatalf("post-recovery pull should reconcile, got: %v\n%s", err, out)
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.10.1"
+	Version   = "0.11.0"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## What this ships

- **Version bump: `0.10.1` → `0.11.0`** — Beads-style middle-number increment; a medium release (8 plan features + 6 fixes + 2 docs since v0.10.1), no breaking changes. All four version sources agree (`make verify-version` passes).
- **`CHANGELOG.md` `[0.11.0]` section** — the pre-drafted `[Unreleased]` entries were promoted and the rest of the window filled in. User-focused, no commit hashes (per release rules). Edited at the real target `cmd/ox/release_notes.md` (the `CHANGELOG.md` symlink).
- **CLI reference docs regenerated to 0.11.0** (`make docs`) — version footers plus the `plan/review/` restructure (from `plan review await`) and the new `code/prs.mdx`.

### Changelog highlights

- **Added:** `ox plan review` real-time multi-user feedback (SSE); inline SVG charts in rendered plans; clickable prior-art links + highlighted code.
- **Changed:** design-craft enforced for every AI coworker; steer to `ox plan render --open` on HTML-plan intent; content-aware viz hints; dependency licensing policy + third-party notices.
- **Fixed:** daemon + `ox doctor` auto-recover a wedged *or zombie* ledger rebase; `ox sync --team` per-team status; team imports honor `--title`/`--json`; PAT liveness hardening; OTLP dropped when logged out.

## Release-blocker fixed (bundled, commit 1)

`make test-slow` was **red on `main` itself** — a compile error, not a logic bug:

- `runGit` was declared twice in package `daemon`: `sync_rebase_recovery_test.go` (no build tag, added in #678) and `twin_adversarial_sync_test.go` (`//go:build slow`).
- Normal builds exclude the slow-tagged file, so `test-all` stayed green and the collision only surfaced under `-tags slow`.
- Fix: renamed the newer helper `runGit` → `runGitOut` (returns `(string, error)`); test-only, contained to one file. `go vet -tags slow ./...` is now clean and the rebase-recovery tests pass.
- **Rebased onto latest `main`**, which picked up #688 (`fix(ledger): auto-recover zombie rebase wedge`). #688 added two more `runGit` call sites to the same file, so the rename now covers those too; its new `TestRecoverPreexistingRebase_ZombieDirRecovered` passes and its user-facing effect (daemon + `ox doctor` handling zombie wedges) is folded into the changelog.

## Gate results

| Gate | Result |
|---|---|
| `make lint` | ✅ |
| `make test-all` | ✅ |
| `make test-digital-twin` | ✅ |
| `go vet -tags slow ./...` | ✅ (0 errors) |
| `make test-slow` | ⚠️ environmental only (see below) — **must be re-run in CI** |

`test-slow` reports 232 failures in this sandbox, **all environmental, none in changed code**:

- **225** — `panic: rootless Docker not found` in the Gitea digital-twin fixture crashes the `internal/daemon` test binary, so every daemon test is marked "unknown" (includes trivial pure-function tests like `TestStripANSI`).
- **2** — `TestIncrementalE2E_*` launch real `claude-code` agents.
- **3** — `TestDistillGitHubFacts_*` / `TestDistillHistoryRead_*`: `src refspec main does not match any` (git `init.defaultBranch` ≠ `main`).
- **2** — `TestDoctorSuppression_*`: logged-out assertions (the sandbox session is primed/logged-in).

## Provenance (source → changelog entry)

| CHANGELOG entry | PR |
|---|---|
| `--artifact` export | #674 |
| `plan review` await + feedback loop | #687, #682 |
| SVG chart patterns | #682, #679 |
| clickable prior-art + highlighted code | #672 |
| design-craft for every AI coworker | #686 |
| steer to `plan render` | #685 |
| content-aware hints + partition widgets | #669 |
| licensing policy + third-party notices | #680 |
| daemon + doctor wedged/zombie-rebase recovery | #678, #688 |
| `sync --team` per-team status | #675 |
| import `--title` / `--json` | #677, #676 |
| PAT liveness hardening | #683 |
| OTLP drop when logged out | #671 |

Excluded: ADR-024 doc (#670) — internal, not user-facing.

## Also in this PR

- **Release notes rewritten to lead with customer value** — crisper, benefit-first, internal jargon (CSP/SSE/OTLP/askpass/etc.) removed.
- **New convention codified** (`.claude/rules/releases.md` + the `/release` command): every future release's notes must be benefit-first, so this isn't re-litigated each release.

## Remaining steps (human-/secret-gated)

```mermaid
flowchart TD
  A["CHANGELOG 0.11.0, version bump, docs regen"] --> B["Automated gates: lint, test-all, digital-twin, vet-slow"]
  B --> C["This draft PR"]
  C --> D["Human gates: test-integration, smoke-test, run-walks"]
  D --> E["Merge to main"]
  E --> F["Tag v0.11.0 and push"]
  F --> G["Draft GitHub release"]
  G --> H["Publish, which triggers GoReleaser"]
```

- `make test-integration` — hard gate; needs `ANTHROPIC_API_KEY` + `claude` CLI.
- `make smoke-test` — needs `SAGEOX_CI_PASSWORD` (runs against test.sageox.ai).
- **Run-walks** — install the RC, walk the 7 core flows, report in Slack.
- After merge: `git tag v0.11.0 && git push --tags`, then `gh release create v0.11.0 --draft` with the `[0.11.0]` changelog block; a human publishes (triggers GoReleaser signing/build/Homebrew).
