### PR TITLE
fix(codedb): retry bleve corruption peek to stop transient lock contention masking self-healable corruption

### DIFF
--- a/internal/codedb/store/store.go
+++ b/internal/codedb/store/store.go
@@ -655,8 +655,11 @@ func removeSQLiteFiles(dbPath string) {
 //
 // True lock contention (another writer holds bbolt's exclusive flock) is
 // preserved as the pre-existing "lock contention" error: the corruption peek
-// uses a read-only open with 100ms timeout, so a live exclusive lock blocks
-// the peek and we stay in the safe wait-and-retry path.
+// retries a read-only open (100ms timeout per attempt) a few times before
+// giving up, so a live exclusive lock blocks the peek and we stay in the safe
+// wait-and-retry path — but a transient hold that clears within the retry
+// budget no longer permanently masks provable corruption (see
+// isBleveIndexCorrupt).
 //
 // path is the bleve sub-index dir (e.g. <root>/bleve/code); root is the
 // codedb dataDir (needed to locate the marker file).
@@ -700,9 +703,11 @@ func openOrCreateBleveIndex(root, path, name string) (bleve.Index, error) {
 	// of JSON input` while the worktree's diff/code shards are healthy). That
 	// state is unrecoverable by waiting — the daemon will spin forever — so we
 	// peek the mapping non-blocking and self-heal when the mapping is provably
-	// empty. The peek uses a read-only open with a 100ms timeout: a real
-	// exclusive lock blocks the read, the peek bails out, and we keep the safe
-	// lock-contention behavior.
+	// empty. The peek retries a read-only open (100ms timeout per attempt,
+	// bleveCorruptionPeekAttempts tries): a real exclusive lock blocks each
+	// read attempt, but a competing writer that releases within the retry
+	// budget no longer strands the peek — only a lock held for the full
+	// budget falls through to the safe lock-contention behavior.
 	boltPath := filepath.Join(path, "store", "root.bolt")
 	if _, statErr := os.Stat(boltPath); statErr == nil {
 		if isBleveIndexCorrupt(boltPath) {
@@ -767,6 +772,20 @@ func WriteNeedsReindexMarker(root, name string) error {
 	return os.WriteFile(NeedsReindexMarkerPath(root, name), []byte(body), 0o600)
 }
 
+// bleveCorruptionPeekAttempts and bleveCorruptionPeekDelay bound how hard
+// isBleveIndexCorrupt retries its read-only peek before conceding the file is
+// genuinely, persistently locked. Overridable in tests (kept as package vars
+// rather than constants) so a test can shrink the delay for speed or use
+// bleveCorruptionPeekRetryHook to synchronize deterministically with a
+// concurrent lock holder instead of racing on wall-clock sleeps (see
+// .claude/rules/testing.md: prefer hooks over time.Sleep for concurrency
+// tests).
+var (
+	bleveCorruptionPeekAttempts  = 3
+	bleveCorruptionPeekDelay     = 150 * time.Millisecond
+	bleveCorruptionPeekRetryHook = func(attempt int) {}
+)
+
 // isBleveIndexCorrupt opens root.bolt read-only with a short timeout and
 // affirmatively checks for three on-disk failure modes that present as the
 // same opaque "error parsing mapping JSON" surface error:
@@ -782,10 +801,14 @@ func WriteNeedsReindexMarker(root, name string) error {
 //     segment is missing on disk.)
 //
 // Returns true only when we successfully read the bolt AND can prove one of
-// the three conditions. On any access error (read-only open timeout, permission,
-// unparseable bolt structure) returns false — we never flag corruption
-// without proof, so a real exclusive write lock stays in the lock-contention
-// path.
+// the three conditions. The read-only open is retried up to
+// bleveCorruptionPeekAttempts times (bleveCorruptionPeekDelay apart) so a
+// transient competing writer doesn't strand a genuinely corrupt mapping in
+// the lock-contention path — a real writer that finishes within the retry
+// budget no longer masks provable corruption. Only once every attempt fails
+// (or the bolt structure itself can't be parsed) do we return false — we
+// never flag corruption without proof, so a write lock held for the full
+// retry budget still stays in the lock-contention path.
 //
 // scorch's bbolt layout in bleve v2.5.7 (empirically verified, see
 // proposals/2026-05-17-bleve-bolt-layout/ if it gets written):
@@ -805,10 +828,21 @@ func WriteNeedsReindexMarker(root, name string) error {
 // is harder to detect reliably and survives as an empty search result rather
 // than a hard open failure.
 func isBleveIndexCorrupt(boltPath string) bool {
-	db, err := bbolt.Open(boltPath, 0600, &bbolt.Options{
-		ReadOnly: true,
-		Timeout:  100 * time.Millisecond,
-	})
+	var db *bbolt.DB
+	var err error
+	for attempt := 0; attempt < bleveCorruptionPeekAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(bleveCorruptionPeekDelay)
+		}
+		bleveCorruptionPeekRetryHook(attempt)
+		db, err = bbolt.Open(boltPath, 0600, &bbolt.Options{
+			ReadOnly: true,
+			Timeout:  100 * time.Millisecond,
+		})
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return false
 	}

--- a/internal/codedb/store/store_test.go
+++ b/internal/codedb/store/store_test.go
@@ -714,6 +714,143 @@ func readDirSize(t *testing.T, dir string) map[string]int64 {
 	return out
 }
 
+// TestIsBleveIndexCorrupt_RecoversWhenLockClearsWithinRetryBudget verifies
+// that a transient competing bbolt lock held across the FIRST corruption-peek
+// attempt no longer permanently masks provable corruption as unrecoverable
+// "lock contention" — the peek retries and self-heal fires once the lock
+// clears within the retry budget.
+//
+// Failure prevented: `ox code search` returning the cryptic "bleve index
+// appears to be in use (lock contention): error parsing mapping JSON:
+// unexpected end of JSON input" whenever a genuinely corrupt mapping happened
+// to coincide with another process briefly holding bbolt's exclusive lock
+// during the single, unretried diagnostic peek.
+func TestIsBleveIndexCorrupt_RecoversWhenLockClearsWithinRetryBudget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+
+	// Restore package-level retry knobs — other tests in this file run in a
+	// concurrent (t.Parallel) wave after all sequential tests complete, and
+	// must see the real defaults.
+	origAttempts, origDelay, origHook := bleveCorruptionPeekAttempts, bleveCorruptionPeekDelay, bleveCorruptionPeekRetryHook
+	t.Cleanup(func() {
+		bleveCorruptionPeekAttempts = origAttempts
+		bleveCorruptionPeekDelay = origDelay
+		bleveCorruptionPeekRetryHook = origHook
+	})
+	bleveCorruptionPeekDelay = time.Millisecond // timing comes from the hook, not the sleep — keep it fast
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err, "create index")
+	require.NoError(t, first.Close())
+
+	boltPath := filepath.Join(indexPath, "store", "root.bolt")
+	// Corrupting the mapping now (lock uncontended) makes the eventual
+	// safeOpenBleve call inside openOrCreateBleveIndex fail FAST rather than
+	// block: bleve's plain Open has no timeout, so if a competing lock were
+	// already held at that point it would hang forever instead of reaching
+	// the corruption-check branch at all. The competing lock below is
+	// introduced only later, from inside isBleveIndexCorrupt's retry loop —
+	// matching the field sequence (open fails fast on real corruption, THEN
+	// the diagnostic peek races a separate concurrent writer).
+	emptyMappingForLatestSnapshot(t, boltPath)
+
+	// Simulate a competing writer appearing during the diagnostic peek: the
+	// hook fires from inside isBleveIndexCorrupt's retry loop. Attempt 0
+	// acquires a real, separate exclusive lock (still uncontended at that
+	// instant, so acquisition is instant) so the loop's own read-only attempt
+	// at attempt 0 genuinely times out against it; attempt 1 releases it
+	// before the next try. No time.Sleep-timing race (see
+	// .claude/rules/testing.md: prefer hooks over sleep for concurrency tests).
+	var lockDB *bbolt.DB
+	var hookCalls int
+	bleveCorruptionPeekRetryHook = func(attempt int) {
+		hookCalls++
+		switch attempt {
+		case 0:
+			var lockErr error
+			lockDB, lockErr = bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: 2 * time.Second})
+			require.NoError(t, lockErr, "acquire competing exclusive lock")
+		case 1:
+			require.NoError(t, lockDB.Close(), "release competing exclusive lock before 2nd peek attempt")
+		}
+	}
+
+	idx, openErr := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, openErr, "self-heal must recover once the competing lock clears within the retry budget")
+	defer func() { _ = idx.Close() }()
+	require.GreaterOrEqual(t, hookCalls, 2, "test setup bug: retry hook did not fire for both attempts")
+
+	require.True(t, HasNeedsReindexMarker(tmp, "test"),
+		"self-heal must write the reindex marker")
+}
+
+// TestOpenOrCreateBleveIndex_SustainedLockStillReturnsContentionError verifies
+// that the corruption-peek retry does NOT turn genuinely sustained lock
+// contention into a false self-heal: a lock held for the entire retry budget
+// must still surface the pre-existing "lock contention" error unchanged, and
+// must NOT nuke the index.
+//
+// Failure prevented: a naive retry-until-success peek turning a real,
+// long-running writer (e.g. the daemon mid full-reindex) into a spurious
+// nuke-and-recreate of an index that was never actually corrupt.
+func TestOpenOrCreateBleveIndex_SustainedLockStillReturnsContentionError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: Bleve + bbolt operations")
+	}
+
+	origAttempts, origDelay, origHook := bleveCorruptionPeekAttempts, bleveCorruptionPeekDelay, bleveCorruptionPeekRetryHook
+	t.Cleanup(func() {
+		bleveCorruptionPeekAttempts = origAttempts
+		bleveCorruptionPeekDelay = origDelay
+		bleveCorruptionPeekRetryHook = origHook
+	})
+	bleveCorruptionPeekAttempts = 2
+	bleveCorruptionPeekDelay = time.Millisecond
+
+	tmp := t.TempDir()
+	indexPath := filepath.Join(tmp, "test-index")
+
+	first, err := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.NoError(t, err, "create index")
+	require.NoError(t, first.Close())
+
+	boltPath := filepath.Join(indexPath, "store", "root.bolt")
+	// See the sibling recovery test for why the lock must NOT be held yet:
+	// bleve's plain Open (inside safeOpenBleve) has no timeout and would
+	// block forever rather than reach the corruption-check branch.
+	emptyMappingForLatestSnapshot(t, boltPath)
+
+	// Acquire a competing exclusive lock at the first peek attempt and hold
+	// it for the entire retry budget (never release it) — simulating a
+	// writer that's still genuinely active throughout, not one that happens
+	// to finish quickly.
+	var lockDB *bbolt.DB
+	bleveCorruptionPeekRetryHook = func(attempt int) {
+		if attempt == 0 {
+			var lockErr error
+			lockDB, lockErr = bbolt.Open(boltPath, 0600, &bbolt.Options{Timeout: 2 * time.Second})
+			require.NoError(t, lockErr, "acquire competing exclusive lock")
+		}
+	}
+	t.Cleanup(func() {
+		if lockDB != nil {
+			_ = lockDB.Close()
+		}
+	})
+
+	_, openErr := openOrCreateBleveIndex(tmp, indexPath, "test")
+	require.Error(t, openErr, "sustained contention must still surface an error")
+	require.Contains(t, openErr.Error(), "lock contention",
+		"sustained contention must not be misread as self-healable corruption")
+	require.False(t, HasNeedsReindexMarker(tmp, "test"),
+		"a genuinely locked (not proven corrupt) index must not trigger self-heal")
+}
+
 // TestRebuildBleveSubIndex_Comment verifies that a targeted rebuild of the
 // comment sub-index recovers Open without affecting code/diff data and
 // resets the SQL flag so ParseComments will repopulate on the next pass.


### PR DESCRIPTION
## What broke

- `ox code search` (and any other `codedb.Open` caller) intermittently failed with a cryptic, permanent-sounding error:
  ```
  Error: open codedb: open codedb store: open code index: bleve index appears to be in use (lock contention): error parsing mapping JSON: unexpected end of JSON input
  ```
- Reported from the `sageox-mono/verify-recording-delete-anti-entropy` workspace — three consecutive `ox code search` invocations, all failing the same way.
- The codedb bleve self-heal system (`internal/codedb/store/store.go`, PR #617) exists specifically to auto-recover from this exact corrupt-`_mapping` state. Self-heal itself was working correctly — the bug was in how it *decides* whether to trust its own diagnosis.

## Root cause

- `isBleveIndexCorrupt` proves corruption by peeking at `root.bolt` read-only, with a single 100ms-timeout `bbolt.Open` attempt.
- If that one peek loses a race to a genuinely concurrent writer (the daemon, on the same shared `dataDir`), the peek can't get in, and the function conservatively reports "not proven corrupt."
- The caller then falls through to the raw, permanent-sounding "lock contention" error — even when the mapping is provably corrupt and would have self-healed cleanly if the peek had just tried again a moment later.

```mermaid
sequenceDiagram
    participant Search as ox code search
    participant Daemon as daemon writer
    participant Peek as corruption peek

    Note over Daemon: holds bbolt's exclusive lock<br/>(routine indexing pass)
    Search->>Peek: attempt 1 (100ms timeout)
    Peek--xSearch: blocked by live lock, times out
    Note over Search: old behavior: give up here,<br/>report "lock contention" forever
    Daemon-->>Daemon: write finishes, lock released
    Search->>Peek: attempt 2 (100ms timeout, new in this PR)
    Peek-->>Search: read succeeds, mapping is provably corrupt
    Search->>Search: self-heal: nuke + recreate + mark for reindex
```

## What this PR ships

- **Bounded retry with backoff** around the single read-only peek in `isBleveIndexCorrupt` (`internal/codedb/store/store.go`) — up to 3 attempts, 150ms apart by default, both overridable package vars for testability.
- **A deterministic test hook** (`bleveCorruptionPeekRetryHook`) so tests can synchronize a competing lock precisely with a specific retry attempt, instead of racing on `time.Sleep` timing (per this repo's stated concurrency-test convention).
- **No behavior change for genuinely sustained contention** — a lock held for the whole retry budget still returns the exact same "lock contention" error as before.
- Applies uniformly to all three bleve sub-indexes (code/diff/comment) since they share the same decision function — no per-callsite changes needed.

## New tests

| Test | Proves |
|---|---|
| `TestIsBleveIndexCorrupt_RecoversWhenLockClearsWithinRetryBudget` | A competing lock held only across the *first* peek attempt no longer permanently masks provable corruption — self-heal fires once the lock clears within budget. |
| `TestOpenOrCreateBleveIndex_SustainedLockStillReturnsContentionError` | A lock held for the *entire* retry budget still returns the pre-existing "lock contention" error unchanged, and does not falsely self-heal. |

Both verified to fail without the fix (temporarily neutered the retry loop to a single attempt, confirmed red, restored).

## Why existing tests missed this

Every pre-existing test touching this self-heal path is single-actor: one goroutine corrupts the data, then opens it, with nothing else touching the file at the same time. `TestOpenOrCreateBleveIndex_LockedIndexNotNuked` even documents this limitation directly in its own comment — bleve's plain `Open` has no timeout, so real lock contention couldn't be triggered in-process, and the existing tests substitute "corrupt bytes → instant error" as a stand-in. That proves the decision *branch* is wired correctly, but none of them combine "genuinely corrupt" with "a second real actor holding the lock during the diagnostic peek" — exactly the field failure's precondition.

## Follow-up (not in this PR)

A broader adversarial pass over the same self-heal surface surfaced a few more theoretical gaps. None reproduce this bug, and folding them in would go beyond a surgical fix, so they're called out here rather than tracked in beads (our beads/Dolt database is currently panicking on schema migration — `bd doctor` shows a CLI/DB version skew — unrelated to this change, flagging separately):

- **Worth prioritizing next:** a crash between `createBleveSubIndex` recreating the empty index and `WriteNeedsReindexMarker` writing its marker leaves a healthy-looking but permanently-empty sub-index with no rebuild signal.
- **Lower priority (needs a design pass, not just a test):** two concurrent self-heal attempts on the same sub-index from daemon + CLI (no single-flight guard today); the same TOCTOU class exists in the mapping-version upgrade path.
- **No action needed:** ENOSPC vs. EACCES during recreate-after-nuke provably hit the identical code path on inspection — a dedicated ENOSPC test would be redundant.

## Test plan

- [x] `go test ./internal/codedb/store/...` — new tests pass, all 12 existing self-heal/corruption/lock tests pass
- [x] `go test ./internal/codedb/...` — full package, all green
- [x] `make lint` — 0 issues
- [x] `make test` — full suite, 16171 tests, 0 failures
- [x] Regression tests confirmed to fail on the pre-fix code, then pass after restoring the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when search index corruption is detected during temporary database lock contention.
  * Added retry handling so brief exclusive locks no longer cause a false “lock contention” outcome.
  * Preserved the existing contention error behavior when the lock remains in place, preventing incorrect automatic recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->