### PR TITLE
feat: prune local sessions

### DIFF
--- a/cmd/ox/session_prune.go
+++ b/cmd/ox/session_prune.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/session"
@@ -89,7 +90,7 @@ func runSessionPrune(cmd *cobra.Command, _ []string) error {
 
 	fmt.Printf("Sessions to prune (%s):\n", scope)
 	for _, c := range candidates {
-		fmt.Printf("  %s  %s\n", c.name, cli.StyleDim.Render(fmt.Sprintf("(%s · %s)", c.status, c.origin)))
+		fmt.Printf("  %s  %s\n", c.name, cli.StyleDim.Render(fmt.Sprintf("(%s · %s)", c.status, c.originLabel())))
 	}
 	fmt.Println()
 
@@ -105,28 +106,63 @@ func runSessionPrune(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	var removed int
-	for _, c := range candidates {
-		if err := c.store.Delete(c.name); err != nil {
-			fmt.Printf("  Warning: failed to remove %s (%s): %v\n", c.name, c.origin, err)
-			continue
-		}
-		removed++
-	}
+	removed := deletePruneCandidates(candidates)
 
 	cli.PrintSuccess(fmt.Sprintf("Pruned %d session(s)", removed))
 	if skippedRecording > 0 {
 		cli.PrintHint(fmt.Sprintf("Skipped %d active recording(s). Stop them with 'ox session stop' to prune.", skippedRecording))
 	}
-	return nil
+	return prunePartialFailureError(removed, len(candidates))
 }
 
-// pruneCandidate is a session selected for deletion.
+// deletePruneCandidates deletes every physical location of each candidate,
+// printing a warning per failed location but still attempting the rest — a
+// failure on one copy (e.g. a concurrent prune, or a race with another
+// process) must not stop the others from being cleaned up. Returns how many
+// candidates had ALL of their locations deleted successfully.
+func deletePruneCandidates(candidates []pruneCandidate) int {
+	var removed int
+	for _, c := range candidates {
+		ok := true
+		for _, loc := range c.locations {
+			if err := loc.store.Delete(c.name); err != nil {
+				fmt.Printf("  Warning: failed to remove %s (%s): %v\n", c.name, loc.origin, err)
+				ok = false
+			}
+		}
+		if ok {
+			removed++
+		}
+	}
+	return removed
+}
+
+// prunePartialFailureError reports a non-nil error when some sessions failed
+// to delete, so scripts and CI relying on exit code don't see a false success.
+func prunePartialFailureError(removed, total int) error {
+	if removed >= total {
+		return nil
+	}
+	return fmt.Errorf("pruned %d of %d session(s); check the warnings above for what's left", removed, total)
+}
+
+// pruneCandidate is a logical session selected for deletion. It may have more
+// than one physical location — e.g. a not-yet-uploaded session already staged
+// into the ledger cache alongside its per-user copy — all of which get deleted.
 type pruneCandidate struct {
-	name   string
-	status session.SessionStatus
-	store  *session.Store
-	origin string // human-readable: "local" or "ledger-cache"
+	name      string
+	status    session.SessionStatus
+	locations []prunableStore
+}
+
+// originLabel renders where this candidate's copies live, e.g. "local" or
+// "local+ledger-cache" when the session exists in both stores.
+func (c pruneCandidate) originLabel() string {
+	labels := make([]string, len(c.locations))
+	for i, loc := range c.locations {
+		labels[i] = loc.origin
+	}
+	return strings.Join(labels, "+")
 }
 
 // prunableStore pairs a store with a human-readable origin label.
@@ -140,6 +176,13 @@ type prunableStore struct {
 func buildPruneStores(localStore *session.Store, ledgerPath string) []prunableStore {
 	out := []prunableStore{{store: localStore, origin: "local"}}
 
+	// NewStore treats its argument as a repo-context root and appends "sessions"
+	// itself, so passing ledgerPath/.sageox/cache here (not ledgerPath) is
+	// deliberate — the result lands on ledgerPath/.sageox/cache/sessions. Do not
+	// "fix" this to pass ledgerPath directly: that aliases loadUploadedKeys'
+	// ledgerStore (which scans ledgerPath/sessions), making every cache-store
+	// session resolve as already-uploaded and silently no-op the entire
+	// ledger-cache half of prune.
 	cachePath := filepath.Join(ledgerPath, ".sageox", "cache")
 	cacheStore, err := session.NewStore(cachePath)
 	if err != nil {
@@ -152,11 +195,14 @@ func buildPruneStores(localStore *session.Store, ledgerPath string) []prunableSt
 
 // collectPruneCandidates iterates every local store, classifies each session,
 // and returns the ones eligible for deletion. Sessions appearing in multiple
-// stores under the same merge key are deduplicated — local store wins.
+// stores under the same merge key are merged into a single logical candidate
+// (classification from the first store wins — local is scanned first) that
+// carries every physical location, so all copies get deleted together.
 // Active recordings (StatusRecording) are always excluded; the count is
 // returned separately so the caller can report it.
 func collectPruneCandidates(stores []prunableStore, uploaded map[string]bool, pruneAll bool) ([]pruneCandidate, int, error) {
-	seen := make(map[string]bool)
+	const indexRejected = -1
+	index := make(map[string]int) // merge key -> candidates[] index, or indexRejected
 	var (
 		candidates       []pruneCandidate
 		skippedRecording int
@@ -169,20 +215,26 @@ func collectPruneCandidates(stores []prunableStore, uploaded map[string]bool, pr
 		}
 		for _, s := range sessions {
 			key := sessionMergeKey(s)
-			if seen[key] {
+
+			if idx, ok := index[key]; ok {
+				if idx != indexRejected {
+					// same logical session, another physical copy — prune it too.
+					candidates[idx].locations = append(candidates[idx].locations, prunableStore{store: ps.store, origin: ps.origin})
+				}
 				continue
 			}
-			seen[key] = true
 
 			isUploaded := uploaded[key]
 			status := session.ClassifySession(s, isUploaded)
 
 			if status == session.StatusRecording {
 				skippedRecording++
+				index[key] = indexRejected
 				continue
 			}
 
 			if !shouldPrune(status, pruneAll) {
+				index[key] = indexRejected
 				continue
 			}
 
@@ -190,11 +242,11 @@ func collectPruneCandidates(stores []prunableStore, uploaded map[string]bool, pr
 			if name == "" {
 				name = s.Filename
 			}
+			index[key] = len(candidates)
 			candidates = append(candidates, pruneCandidate{
-				name:   name,
-				status: status,
-				store:  ps.store,
-				origin: ps.origin,
+				name:      name,
+				status:    status,
+				locations: []prunableStore{{store: ps.store, origin: ps.origin}},
 			})
 		}
 	}

--- a/cmd/ox/session_prune.go
+++ b/cmd/ox/session_prune.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/session"
+	"github.com/spf13/cobra"
+)
+
+var sessionPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove local-only sessions",
+	Long: `Remove sessions from local stores that have not been uploaded to the ledger.
+
+By default, prune only removes sessions in the "local" status — finalized
+recordings that exist locally but were never pushed to the ledger.
+
+With --all, prune removes every local session that is not present in the
+ledger, including paused, canceled, ghost, and orphan sessions. Active
+recordings are always skipped — stop them with 'ox session stop' first.
+
+Sessions already uploaded to the ledger are never touched. Use
+'ox session remove <name>' to delete those.
+
+Prune covers two local locations:
+  - the per-user session store (where new recordings start)
+  - the ledger cache (<ledger>/.sageox/cache/sessions, the staging area
+    before a recording is committed-as-pointer to the ledger)
+
+Examples:
+  ox session prune              # remove local-only finalized sessions
+  ox session prune --all        # remove anything not uploaded
+  ox session prune --dry-run    # preview what would be removed
+  ox session prune --force      # skip confirmation`,
+	Args: cobra.NoArgs,
+	RunE: runSessionPrune,
+}
+
+func init() {
+	sessionCmd.AddCommand(sessionPruneCmd)
+	sessionPruneCmd.Flags().Bool("all", false, "Remove every local session not uploaded to the ledger (excludes active recordings)")
+	sessionPruneCmd.Flags().Bool("dry-run", false, "Print what would be removed without deleting")
+	sessionPruneCmd.Flags().Bool("force", false, "Skip confirmation prompt")
+}
+
+func runSessionPrune(cmd *cobra.Command, _ []string) error {
+	pruneAll, _ := cmd.Flags().GetBool("all")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	force, _ := cmd.Flags().GetBool("force")
+
+	localStore, _, err := newSessionStore()
+	if err != nil {
+		return err
+	}
+
+	ledgerPath, err := resolveLedgerPath()
+	if err != nil {
+		return fmt.Errorf("ledger is unavailable — refusing to prune without ledger to verify uploaded sessions: %w\nRun 'ox doctor' to fix ledger sync, or use 'ox session remove --all' to remove every local session unconditionally", err)
+	}
+
+	uploaded, err := loadUploadedKeys(ledgerPath)
+	if err != nil {
+		return err
+	}
+
+	// build the list of local stores to scan: per-user store + ledger cache.
+	stores := buildPruneStores(localStore, ledgerPath)
+
+	candidates, skippedRecording, err := collectPruneCandidates(stores, uploaded, pruneAll)
+	if err != nil {
+		return err
+	}
+
+	if len(candidates) == 0 {
+		if skippedRecording > 0 {
+			cli.PrintHint(fmt.Sprintf("Skipped %d active recording(s). Stop them with 'ox session stop' before pruning.", skippedRecording))
+		}
+		fmt.Println("Nothing to prune.")
+		return nil
+	}
+
+	scope := "local-only"
+	if pruneAll {
+		scope = "not-uploaded"
+	}
+
+	fmt.Printf("Sessions to prune (%s):\n", scope)
+	for _, c := range candidates {
+		fmt.Printf("  %s  %s\n", c.name, cli.StyleDim.Render(fmt.Sprintf("(%s · %s)", c.status, c.origin)))
+	}
+	fmt.Println()
+
+	if dryRun {
+		cli.PrintHint(fmt.Sprintf("Dry run: would remove %d session(s).", len(candidates)))
+		return nil
+	}
+
+	if !force {
+		if !cli.ConfirmYesNo(fmt.Sprintf("Remove %d local session(s)?", len(candidates)), false) {
+			fmt.Println("Canceled.")
+			return nil
+		}
+	}
+
+	var removed int
+	for _, c := range candidates {
+		if err := c.store.Delete(c.name); err != nil {
+			fmt.Printf("  Warning: failed to remove %s (%s): %v\n", c.name, c.origin, err)
+			continue
+		}
+		removed++
+	}
+
+	cli.PrintSuccess(fmt.Sprintf("Pruned %d session(s)", removed))
+	if skippedRecording > 0 {
+		cli.PrintHint(fmt.Sprintf("Skipped %d active recording(s). Stop them with 'ox session stop' to prune.", skippedRecording))
+	}
+	return nil
+}
+
+// pruneCandidate is a session selected for deletion.
+type pruneCandidate struct {
+	name   string
+	status session.SessionStatus
+	store  *session.Store
+	origin string // human-readable: "local" or "ledger-cache"
+}
+
+// prunableStore pairs a store with a human-readable origin label.
+type prunableStore struct {
+	store  *session.Store
+	origin string
+}
+
+// buildPruneStores returns the set of local stores prune should scan.
+// Stores that fail to open are skipped with a debug log.
+func buildPruneStores(localStore *session.Store, ledgerPath string) []prunableStore {
+	out := []prunableStore{{store: localStore, origin: "local"}}
+
+	cachePath := filepath.Join(ledgerPath, ".sageox", "cache")
+	cacheStore, err := session.NewStore(cachePath)
+	if err != nil {
+		slog.Debug("prune_open_cache_store", "path", cachePath, "err", err)
+		return out
+	}
+	out = append(out, prunableStore{store: cacheStore, origin: "ledger-cache"})
+	return out
+}
+
+// collectPruneCandidates iterates every local store, classifies each session,
+// and returns the ones eligible for deletion. Sessions appearing in multiple
+// stores under the same merge key are deduplicated — local store wins.
+// Active recordings (StatusRecording) are always excluded; the count is
+// returned separately so the caller can report it.
+func collectPruneCandidates(stores []prunableStore, uploaded map[string]bool, pruneAll bool) ([]pruneCandidate, int, error) {
+	seen := make(map[string]bool)
+	var (
+		candidates       []pruneCandidate
+		skippedRecording int
+	)
+
+	for _, ps := range stores {
+		sessions, err := ps.store.ListAllSessions()
+		if err != nil {
+			return nil, 0, fmt.Errorf("list sessions in %s: %w", ps.origin, err)
+		}
+		for _, s := range sessions {
+			key := sessionMergeKey(s)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			isUploaded := uploaded[key]
+			status := session.ClassifySession(s, isUploaded)
+
+			if status == session.StatusRecording {
+				skippedRecording++
+				continue
+			}
+
+			if !shouldPrune(status, pruneAll) {
+				continue
+			}
+
+			name := s.SessionName
+			if name == "" {
+				name = s.Filename
+			}
+			candidates = append(candidates, pruneCandidate{
+				name:   name,
+				status: status,
+				store:  ps.store,
+				origin: ps.origin,
+			})
+		}
+	}
+
+	return candidates, skippedRecording, nil
+}
+
+// shouldPrune reports whether a session in the given status is a prune target.
+func shouldPrune(status session.SessionStatus, pruneAll bool) bool {
+	if status == session.StatusUploaded {
+		return false
+	}
+	if !pruneAll {
+		return status == session.StatusLocal
+	}
+	switch status {
+	case session.StatusLocal,
+		session.StatusPaused,
+		session.StatusCanceled,
+		session.StatusGhost,
+		session.StatusOrphan:
+		return true
+	}
+	return false
+}
+
+// loadUploadedKeys returns the set of merge keys for sessions present in the
+// ledger. Caller must have a valid ledgerPath — prune refuses to run when the
+// ledger is unavailable, since deleting "local-only" sessions without it could
+// silently drop work that simply hasn't been pulled.
+func loadUploadedKeys(ledgerPath string) (map[string]bool, error) {
+	keys := make(map[string]bool)
+
+	ledgerStore, err := session.NewStore(ledgerPath)
+	if err != nil {
+		return nil, fmt.Errorf("open ledger store: %w", err)
+	}
+
+	ledgerSessions, err := ledgerStore.ListAllSessions()
+	if err != nil {
+		return nil, fmt.Errorf("list ledger sessions: %w", err)
+	}
+
+	for _, ls := range ledgerSessions {
+		keys[sessionMergeKey(ls)] = true
+	}
+	return keys, nil
+}

--- a/cmd/ox/session_prune_test.go
+++ b/cmd/ox/session_prune_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldPrune(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   session.SessionStatus
+		pruneAll bool
+		want     bool
+	}{
+		// default mode — only StatusLocal is pruned
+		{"default_local", session.StatusLocal, false, true},
+		{"default_paused", session.StatusPaused, false, false},
+		{"default_canceled", session.StatusCanceled, false, false},
+		{"default_ghost", session.StatusGhost, false, false},
+		{"default_orphan", session.StatusOrphan, false, false},
+		{"default_uploaded", session.StatusUploaded, false, false},
+		{"default_recording", session.StatusRecording, false, false},
+
+		// --all mode — every non-uploaded, non-recording status is pruned
+		{"all_local", session.StatusLocal, true, true},
+		{"all_paused", session.StatusPaused, true, true},
+		{"all_canceled", session.StatusCanceled, true, true},
+		{"all_ghost", session.StatusGhost, true, true},
+		{"all_orphan", session.StatusOrphan, true, true},
+		{"all_uploaded", session.StatusUploaded, true, false},
+		{"all_recording", session.StatusRecording, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPrune(tt.status, tt.pruneAll)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/ox/session_prune_test.go
+++ b/cmd/ox/session_prune_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/sageox/ox/internal/session"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldPrune(t *testing.T) {
@@ -22,6 +24,7 @@ func TestShouldPrune(t *testing.T) {
 		{"default_orphan", session.StatusOrphan, false, false},
 		{"default_uploaded", session.StatusUploaded, false, false},
 		{"default_recording", session.StatusRecording, false, false},
+		{"default_suspended", session.StatusSuspended, false, false},
 
 		// --all mode — every non-uploaded, non-recording status is pruned
 		{"all_local", session.StatusLocal, true, true},
@@ -31,12 +34,112 @@ func TestShouldPrune(t *testing.T) {
 		{"all_orphan", session.StatusOrphan, true, true},
 		{"all_uploaded", session.StatusUploaded, true, false},
 		{"all_recording", session.StatusRecording, true, false},
+		{"all_suspended", session.StatusSuspended, true, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := shouldPrune(tt.status, tt.pruneAll)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestCollectPruneCandidates_SameSessionAcrossStoresDeletesBothCopies guards
+// against the dedup regression where a not-yet-uploaded session staged in
+// both the per-user store and the ledger cache only had its first-seen copy
+// scheduled for deletion, silently leaving the other behind.
+func TestCollectPruneCandidates_SameSessionAcrossStoresDeletesBothCopies(t *testing.T) {
+	localStore, err := session.NewStore(t.TempDir())
+	require.NoError(t, err)
+	cacheStore, err := session.NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	const name = "2026-01-05T10-30-user1-Oxa7b3"
+	for _, s := range []*session.Store{localStore, cacheStore} {
+		w, err := s.CreateRaw(name)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	}
+
+	stores := []prunableStore{
+		{store: localStore, origin: "local"},
+		{store: cacheStore, origin: "ledger-cache"},
+	}
+
+	candidates, skipped, err := collectPruneCandidates(stores, map[string]bool{}, false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, skipped)
+	require.Len(t, candidates, 1)
+	assert.Len(t, candidates[0].locations, 2)
+	assert.Equal(t, "local+ledger-cache", candidates[0].originLabel())
+}
+
+// TestDeletePruneCandidates_PartialFailureStillDeletesOtherLocations covers
+// the actual delete loop (not just candidate collection): when one location
+// of a multi-location candidate has already vanished — e.g. a race with a
+// concurrent prune or cleanup — the candidate must not count as removed, but
+// its surviving location must still be deleted rather than left behind.
+func TestDeletePruneCandidates_PartialFailureStillDeletesOtherLocations(t *testing.T) {
+	storeA, err := session.NewStore(t.TempDir())
+	require.NoError(t, err)
+	storeB, err := session.NewStore(t.TempDir())
+	require.NoError(t, err)
+	storeC, err := session.NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	mustCreate := func(s *session.Store, name string) {
+		t.Helper()
+		w, err := s.CreateRaw(name)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	}
+
+	const cleanName = "2026-01-05T10-30-user1-Oxaaa1"
+	mustCreate(storeA, cleanName)
+
+	// partial candidate: two locations, one is deleted out from under the
+	// store before the delete loop runs, simulating a race.
+	const partialName = "2026-01-05T10-31-user1-Oxbbb2"
+	mustCreate(storeB, partialName)
+	mustCreate(storeC, partialName)
+	require.NoError(t, os.RemoveAll(storeB.GetSessionPath(partialName)))
+
+	candidates := []pruneCandidate{
+		{name: cleanName, locations: []prunableStore{{store: storeA, origin: "local"}}},
+		{name: partialName, locations: []prunableStore{
+			{store: storeB, origin: "local"},
+			{store: storeC, origin: "ledger-cache"},
+		}},
+	}
+
+	removed := deletePruneCandidates(candidates)
+
+	assert.Equal(t, 1, removed, "only the fully-clean candidate should count as removed")
+	_, statErr := os.Stat(storeA.GetSessionPath(cleanName))
+	assert.True(t, os.IsNotExist(statErr), "clean candidate's location should be deleted")
+	_, statErr = os.Stat(storeC.GetSessionPath(partialName))
+	assert.True(t, os.IsNotExist(statErr), "surviving location must still be deleted even though its sibling location already failed")
+}
+
+func TestPrunePartialFailureError(t *testing.T) {
+	tests := []struct {
+		name           string
+		removed, total int
+		wantErr        bool
+	}{
+		{"all_removed", 3, 3, false},
+		{"nothing_to_remove", 0, 0, false},
+		{"partial_failure", 2, 3, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := prunePartialFailureError(tt.removed, tt.total)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

(As discussed over LinkedIn with Ryan)

> I couldn’t get ox to work quite the way I wanted and as a result was left with hundreds of orphaned local sessions. I like things tidy so this commit adds a ‘ox session prune’ command to clean up all of my failed attempts. Happy to upstream it if you want.

## Test Plan

Added a test and also used the command locally.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented
- [ ] CHANGELOG entry added (if user-facing)
- [ ] Breaking change documented
- [ ] Ran `/security-review` on the diff, **or** N/A documented (PRs touching `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum` get auto-reviewed by the daily batch — see `security/README.md`; this is self-attestation, not a gate)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `ox session prune` to clean up local session records that are no longer present online.
  * Includes `--all` for broader pruning, `--dry-run` to list candidates without changes, and `--force` to skip confirmation.

* **Bug Fixes**
  * Prevents deletion of active recording sessions.
  * If some deletions fail, the command continues other cleanups and reports partial-prune outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->