### PR TITLE
fix(release): wire HOMEBREW_TAP_GITHUB_TOKEN into goreleaser

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,1 +1,0 @@
-README.md

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,1 +1,0 @@
-NEVER ADD OR ENABLE NEW GITHUB WORKFLOWS with a physical discussion with Ryan or Ajit.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SAGEOX_CLI_PUBLIC_KEY: ${{ steps.sign.outputs.SAGEOX_CLI_PUBLIC_KEY }}
           SAGEOX_CLI_SIGNATURES: ${{ steps.sign.outputs.SAGEOX_CLI_SIGNATURES }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       - name: Release summary
         run: |


### PR DESCRIPTION
## Summary

- **Root cause:** `sageox/homebrew-tap` was pinned to v0.6.0 — 100 days stale, 15 releases behind the current v0.11.1 — because `.github/workflows/release.yml` never forwarded the `HOMEBREW_TAP_GITHUB_TOKEN` secret into the goreleaser step's `env:` block. The secret has existed in repo secrets since 2026-04-02; it was just never wired in. Confirmed directly from CI logs (`gh run view <run-id> --log-failed`) on every release since v0.6.1:
  ```
  homebrew formula: template: tmpl:1:7: executing "tmpl" at <.Env.HOMEBREW_TAP_GITHUB_TOKEN>: map has no entry for key "HOMEBREW_TAP_GITHUB_TOKEN"
  ```
  Binaries, checksums, and the GitHub release itself published fine every time — only the final Homebrew publish step silently died, so it went unnoticed for 3+ months.
- **Fix:** add the missing `HOMEBREW_TAP_GITHUB_TOKEN` line to goreleaser-action's `env:` block (1 line). No new secret to provision.
- **Also removes** `.github/workflows/CLAUDE.md` (a symlink) and its target `.github/workflows/README.md` — both contained only a single stale guardrail line ("never add/enable new workflows without discussing with Ryan/Ajit"), which Ryan asked to remove in this session. Note this PR only *edits* an already-enabled workflow — it doesn't add or enable a new one.
- **Companion action, already pushed directly to `sageox/homebrew-tap`** (can't be a GoReleaser fix retroactively, so this isn't part of this diff): manually caught the tap's `ox.rb` up to v0.11.1 — correct URLs/sha256 for all 4 Homebrew-supported platforms, and added the 8 bundled adapter binaries to the `install` block, which the stale formula was missing entirely. Also fixed a stale `ox-cli` link in that repo's README. Noting here for the record since it's the other half of this fix.

```mermaid
flowchart TD
    A["release published on GitHub"] --> B["CI: release.yml triggers"]
    B --> C["sign artifacts"]
    C --> D["goreleaser: build binaries"]
    D --> E["goreleaser: create GitHub release + upload assets"]
    E --> F{"goreleaser: publish homebrew formula"}
    F -->|"before fix: token missing"| G["step fails<br/>sageox/homebrew-tap never updated"]
    F -->|"after fix: token forwarded"| H["ox.rb pushed to sageox/homebrew-tap"]
```

## Test Plan

- Reproduced root cause from real CI history: `gh run list --repo sageox/ox --workflow=release.yml` showed 15 straight failures (v0.6.1 → v0.11.1); `gh run view --log-failed` on the v0.11.1 run pinpointed the exact `HOMEBREW_TAP_GITHUB_TOKEN` template error above.
- Confirmed via `gh secret list --repo sageox/ox` that the secret already exists — this is a wiring-only fix, not a new-credential change.
- Can't trigger a real `release: published` event from a PR, so full end-to-end proof lands on the next real release — flagging that here so it isn't forgotten.
- Validated the workflow YAML change is syntactically correct and scoped only to the affected step.
- For the companion `homebrew-tap` push: refetched `checksums.txt` from the v0.11.1 release assets and diffed against the pushed formula's sha256 values (exact match), ran `ruby -c ox.rb` for syntax, and confirmed live content via `gh api repos/sageox/homebrew-tap/contents/ox.rb`.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — N/A: CI/release-infra fix with no unit-testable code path; verified against real failing CI run logs and a live formula content diff instead (see Test Plan).
- [x] CHANGELOG entry added (if user-facing) — N/A: internal release-pipeline fix, not a CLI/product behavior change.
- [x] Breaking change documented — N/A: no breaking change.
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: touches only an existing secret reference in workflow env config and deletes two doc-only files; not in the auto-reviewed path list (`internal/auth/`, `internal/mcp/`, etc.) and not security-sensitive beyond making an already-provisioned token actually get used as originally intended.

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)