### PR TITLE
chore(agents): refresh ox-installed skills/rules to agentx 0.11.1

### DIFF
--- a/.claude/rules/sageox/use-team-context.md
+++ b/.claude/rules/sageox/use-team-context.md
@@ -1,0 +1,75 @@
+---
+description: How to discover and use team-context rules and knowledge from the SageOx ox CLI
+---
+<!-- agentx-hash: 689754a46103 ver: 0.11.1 -->
+# Team Context — More Rules Live Outside This Repo
+
+This repo uses SageOx. Behavioral rules and conventions that apply to your
+WHOLE TEAM (not just this repo) live in your team's SageOx team-context
+repo, NOT in `.claude/rules/`. SageOx will not auto-sync them here —
+that would create stale-mirror and naming-conflict problems. Instead,
+read them on demand from the canonical location.
+
+## Where team rules live
+
+Team-context repo path: see `ox status` (look for "team_context").
+Typical layout:
+
+    <team-context>/
+      AGENTS.md                  # team-wide preamble
+      MEMORY.md                  # team memory (already inlined into prime)
+      agents/
+        rules/
+          <topic>.md             # one concern per file
+          backend/postgres.md    # subdirectories supported
+          frontend/react.md
+        commands/                # team slash commands
+        profiles/                # AI coworker profiles
+      discussions/               # archived team meetings
+      memory/                    # daily/weekly/monthly summaries
+      documents/                 # imported docs
+
+## How to discover and read them
+
+`ox agent prime` already inlines:
+- Team AGENTS.md / CLAUDE.md
+- `visibility: always` team rules (full body)
+- Team MEMORY.md
+
+`ox agent prime` also catalogs (name + description + path only):
+- `visibility: indexed` team rules — read on demand via the path
+
+To read an indexed team rule: use the Read tool with the absolute path
+shown in the prime output's `<team-rules>` block.
+
+To search team-wide knowledge (discussions, sessions, docs):
+- `ox query "<question>"` — semantic search across the team's
+  recorded discussions and prior coding sessions
+- `ox agent team-ctx` — distilled team knowledge for AI agents
+
+To learn the team-rule format (when authoring or promoting a rule):
+- `ox guide team-rules`
+
+## When you write a project-local rule
+
+If a user adds or edits a rule in `.claude/rules/` (this repo's
+local rules) that looks generally applicable — not specific to this
+repo's paths/services/schemas — ASK them whether to also publish it as
+a team rule under `<team-context>/agents/rules/`. Default to
+asking; do not silently publish. Repo-specific rules stay project-local.
+
+Team rules apply to every supported AI coding agent (Claude, Codex, Amp,
+Cursor, etc.) used by teammates running ox — but only for teammates
+running ox. Project-local `.claude/rules/` only reaches Claude
+users. That asymmetry is the reason to promote durable conventions
+team-wide.
+
+## Why this rule exists (instead of syncing team rules here)
+
+Syncing team rules from team-context into `.claude/rules/` would
+require: continuous mirror semantics (write on change, remove on
+disappearance), namespace management to avoid project-local conflicts,
+and per-adapter coverage (Claude has rules; Codex / Amp don't yet).
+Pointing here instead keeps the team-context repo as the single source
+of truth and works uniformly across every coding agent that supports
+rules.

--- a/.claude/skills/ox-consult/SKILL.md
+++ b/.claude/skills/ox-consult/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ox-consult
+description: >-
+  Search SageOx team memory BEFORE answering from first-principles reasoning.
+  Auto-fire when the user references recent or specific work or asks a
+  before/after question: "I just pushed...", "did X fix Y?", "is the alert gone
+  now?", "this request", or anything tied to a prior decision, a prod anomaly, or
+  a metric/cost change. A confident answer that prior work contradicts is worse
+  than a slow one — check first, then answer. Routes the cue to the right corpus:
+  recency to `ox session list`, conceptual to `ox query`, code-provenance to
+  `ox code search`.
+---
+<!-- ox-hash: f3c7f0844eef ver: 0.11.1 -->
+
+<!-- Thin by design. The authoritative consult-first reflex — the cues, the
+     "confident-wrong is worse than slow" reasoning, and the routing rationale —
+     lives in the <consult-first> block of `ox agent prime` (Layer-1 floor), which
+     reaches Claude, Codex, and Droid alike. This skill adds ONLY Claude-specific
+     auto-activation ergonomics; it duplicates no reasoning. Every command it
+     names is already reachable from the floor, so removing this skill loses
+     ergonomics but never the floor. Do not grow this body. -->
+
+## Use when
+
+The user's message carries a consult cue — STOP and search before reasoning:
+
+- References recent or specific work: "I just pushed...", "this request", "did X fix Y?", "is the alert gone now?"
+- Touches a prior decision, a prod anomaly, or a metric/cost change — anything with a before/after.
+
+## Route the cue (different retrieval modes — not interchangeable)
+
+- Recency / "I just did X" → `ox session list --limit 20 --json` (chronological; the summary is in the list).
+- Conceptual / "did we decide or discuss X?" → `ox query "<question>"` (semantic; add `--source=all` to include code).
+- "Who or what touched this code?" → `ox code search "<pattern>"`.

--- a/.claude/skills/ox-plan/SKILL.md
+++ b/.claude/skills/ox-plan/SKILL.md
@@ -1,4 +1,25 @@
-<!-- ox-hash: eefb7144a2c4 ver: 0.9.1 -->
+---
+name: ox-plan
+description: >-
+  THE renderer for an implementation plan: turn it into a beautiful,
+  self-contained HTML page that folds in SageOx team context a self-authored or
+  generic HTML-plan render structurally CANNOT — open-PR / active-file
+  collisions, prior art, and expert routing — saves it to the ledger so
+  teammates find it, and opens an in-browser review loop (`ox plan review`).
+  Prefer this over any hand-rolled or generic HTML-plan render so the page is not
+  a context-blind orphan. Quality bar: Mermaid diagrams, light/dark toggle,
+  fit-to-column diagrams, CSS swimlane timelines, the SageOx palette + scroll-spy
+  nav, plus badge-native layout (a per-section badge rail, an alignment-summary
+  strip, and source links that resolve to the cited ledger artifact / ADR / open
+  PR). Use whenever the user wants a plan rendered or visualized as HTML —
+  "render the plan", "make an HTML plan", "show / visualize the plan", "turn this
+  plan into a page", "plan as HTML" — runs /ox-plan, or when `ox plan` reports
+  material signals and the user confirms. Whether to render at all is decided by
+  the `ox plan` JSON (signals.material, guidance) plus the user's confirmation /
+  plan.html config — not by this skill.
+---
+<!-- ox-hash: d5e9af46f21a ver: 0.11.1 -->
+
 <!-- Keep behavioral "when to render" guidance lean — that belongs in the
      `ox plan` JSON output (signals.material, guidance) and in the
      <plan-enrichment-guidance> block from `ox agent prime`, not duplicated here.
@@ -6,9 +27,8 @@
      enriched HTML plan (forked from html-plan) plus the badge-native layout. That
      is substantive skill content, not command guidance. Skills are agent-specific
      wrappers; ox serves all agents — keep ox-CLI behavior in the CLI. -->
-Render a SageOx team-enriched implementation plan as a beautiful, self-contained HTML page for human review. Forks the html-plan quality bar (Mermaid diagrams, light/dark toggle, fit-to-column diagrams, CSS swimlane timelines, SageOx palette, scroll-spy nav) and adds badge-native layout: a per-section badge rail, an alignment-summary strip, and source links that resolve to the cited ledger artifact / ADR / open PR.
 
-Use when the user asks to "render the plan", "make an HTML plan", "show the enriched plan", "visualize this plan with team context", runs `/ox-plan`, or when `ox plan` reports material signals and the user confirms a render. **Whether to render at all is decided by the `ox plan` JSON (`signals.material`, `guidance`) + the user's confirmation / `plan.html` config — not by this skill.** Do not nag on trivial plans; honor the command's signal.
+**Whether to render at all is decided by the `ox plan` JSON (`signals.material`, `guidance`) + the user's confirmation / `plan.html` config — not by this skill.** Do not nag on trivial plans; honor the command's signal.
 
 ---
 
@@ -16,7 +36,7 @@ Use when the user asks to "render the plan", "make an HTML plan", "show the enri
 
 ```mermaid
 flowchart TB
-  RUN["Run ox plan --json on the active plan"] --> DET["ox returns DETERMINISTIC badges + context bundle (0 LLM tokens)"]
+  RUN["Run ox plan enrich --json on the active plan"] --> DET["ox returns DETERMINISTIC badges + context bundle (0 LLM tokens)"]
   DET --> READ["Agent reads the context bundle: murmurs, sessions, decisions, ADRs, expert artifacts"]
   READ --> JUDGE["Agent authors JUDGMENT badges, CITED-ONLY (aligns / conflicts / expert-perspective)"]
   JUDGE --> MERGE["Merge: ox --json annotations + agent judgment badges into one annotations.json"]
@@ -29,7 +49,7 @@ flowchart TB
 1. **Get the deterministic signals + context bundle.** Run:
 
    ```bash
-   ox plan --json --file <plan-file>   # or pipe the plan on stdin
+   ox plan enrich --json --file <plan-file>   # or pipe the plan on stdin
    ```
 
    This makes **no LLM or network call**. It returns a `Result` JSON:
@@ -57,13 +77,13 @@ flowchart TB
 
 3. **Render ONE self-contained HTML file** meeting the full html-plan quality bar below PLUS the badge-native additions.
 
-4. **Persist the full plan with `ox plan save`.** Bare `ox plan` only auto-saves ox's *deterministic* badges (it cannot see your judgment badges). To persist the complete plan — your merged badges plus the render — call:
+4. **Persist the full plan with `ox plan save`.** Bare `ox plan enrich` only auto-saves ox's *deterministic* badges (it cannot see your judgment badges). To persist the complete plan — your merged badges plus the render — call:
 
    ```bash
    ox plan save --plan <plan-file> --annotations <merged.json> [--html <render.html>]
    ```
 
-   - `--annotations <merged.json>` is the **merged** annotations: take the `ox plan --json` Result and **append your judgment badges** to its `annotations[]` array (keep `signals`, `context`, and the deterministic badges intact). That merged file is what gets stored as `annotations.json`.
+   - `--annotations <merged.json>` is the **merged** annotations: take the `ox plan enrich --json` Result and **append your judgment badges** to its `annotations[]` array (keep `signals`, `context`, and the deterministic badges intact). That merged file is what gets stored as `annotations.json`.
    - `--html` is optional: pass it only when you rendered HTML this run. `ox plan save` applies the size-gated plain-git-vs-LFS rule — it never renders.
    - `ox plan save` always persists (it is an explicit save), reuses the `data/plans/YYYY-MM-DD-<slug>/` path, and prints where it saved.
 
@@ -161,7 +181,7 @@ This contract outranks any individual rule below: when a "nice to have" visual o
 
 ## html-plan quality bar (inherited — all non-negotiable)
 
-**Self-contained.** One `.html` file, no build step, no local asset files. The page opens from `file://`, and **all interactivity — popovers, OX markers, the SageOx avatar, theme toggle — is inlined and works fully offline**. The single permitted external dependency is the Mermaid library, loaded from the jsDelivr CDN; diagrams therefore need network to render, while everything else degrades gracefully without it. Do not add any other CDN or remote asset (e.g. a live-remote `<img src>` avatar is banned — inline it).
+**Self-contained.** One `.html` file. No build step, no local assets. Libraries only via CDN (Mermaid from jsdelivr). Must render from `file://`.
 
 **Diagrams do the heavy lifting.** Prefer a diagram over a paragraph wherever a relationship, flow, state machine, sequence, or before/after exists. Use **Mermaid** (`flowchart`, `sequenceDiagram`, `stateDiagram-v2`, `gantt` as fits). Every plan gets at least one "the shape in one picture" diagram near the top. Apply the **GitHub-strict Mermaid rules from CLAUDE.md**: double-quote every node label containing anything beyond `[A-Za-z0-9 ]`; never use arrow-shaped substrings (`->`, `=>`, `<->`) inside labels even when quoted — substitute `to`, `→`, or a comma; never use reserved-ish IDs (`PR`, `URL`, `IO`, `IS`, `AS`, `END` — rename to `DPR`, `DURL`, etc.); quote path-shaped labels (`/`, `*`); use `<br/>` not `\n` for line breaks. These make diagrams render everywhere, not just locally.
 
@@ -207,7 +227,7 @@ One **hero diagram near the top** captures the whole shape. Add a second diagram
 - **Layered drill-down.** Start at the subsystem altitude; clicking a node expands its internal subgraph (toggle a second `.mermaid` block / swap source + `mermaid.run`), so the reader drills only where they care. One topic, many depths — the ten-minute reader stays at the top layer; the skeptic drills one node.
 - All of it **pure CSS + vanilla JS, keyboard-focusable, `file://`-safe, no network** — same constraints as every other interaction. Tie it back to the time contract: the diagram answers "how does it behave" at a glance; deeper time is spent *only* on the node the reader chooses to interrogate.
 
-**User-facing mockups — show how the feature is exposed.** If the plan changes anything the user sees or hears, include a visual of the resulting UI state honoring the project's design system — don't describe it in prose. For a net-new or multi-state flow, recommend the `/design-mockup` skill rather than hand-rolling many states. Always state which design-system rules the mockup honors. Annotate behavior in user-facing language, never with implementation detail (write "a subtle chime plays", not a source filename).
+**User-facing mockups — show how the feature is exposed.** If the plan changes anything the user sees or hears, include a visual of the resulting UI state honoring the project's design system — don't describe it in prose. The renderer ships a **device-mockup primitive**: `<div class="device ios">` (iPhone-class frame — notch + home indicator) composed from `.device-statusbar`, `.device-titlebar`, `.device-row`, and an iOS share/action sheet (`.device-sheet` + `.device-actions` + `.device-action`, with `.ox` marking the single highlighted destination — one accent per view); run `ox plan viz device-mockup` for the snippet. The screen stays dark in both themes. For a net-new or multi-state flow, recommend the `/design-mockup` skill rather than hand-rolling many states. Always state which design-system rules the mockup honors. Annotate behavior in user-facing language, never with implementation detail (write "a subtle chime plays", not a source filename).
 
 **Typography & layout.**
 - Font stack (Google Fonts): **Space Grotesk** for display headings (h1/h2), **Inter** for body, **JetBrains Mono** for code, file refs, eyebrows, badges, and small labels. No serif headings.
@@ -225,13 +245,13 @@ One **hero diagram near the top** captures the whole shape. Add a second diagram
 - Steps as a clean numbered list with file:line refs styled distinctly (teal, small).
 - Tables for impact/verification matrices. Color verdict cells (good/warn/bad).
 - A `Risks` section with severity-coded left borders (red = load-bearing unknown, amber = watch).
-- Footer: where the canonical plan file lives (`data/plans/YYYY-MM-DD-<slug>/`) + key invariants.
+- Footer: where the canonical plan file lives (`data/plans/<slug>/`) + key invariants.
 
 **SageOx attribution (subtle, earned, conditional).** When the plan actually carries SageOx enrichment — any deterministic badges (collision/prior-art/expert-routing) or context-bundle items were present — give SageOx quiet credit for the team context it infused: a single restrained footer line such as *"Team context enriched by SageOx"*, plus the existing `● ox-computed` marker that already tags deterministic badges as SageOx-sourced. Rules:
 - **Only when it legitimately helped.** If `ox plan --json` returned no badges and an empty `context[]` (an un-enriched plan), add NO SageOx credit — there is nothing to credit.
 - **Never overclaim.** SageOx provided context and signals; the human and the agent wrote the plan. Credit the enrichment, not the authorship. No banners, no marketing copy, no "moat"/"powered by" language — one calm line in the footer.
 - Judgment badges drawn from the SageOx context bundle may carry a small "via SageOx context" provenance note where it reads naturally, but don't repeat it on every badge.
-- **Enforced, not just requested.** `ox plan save` lints the render for this contract (footer credit when the plan carried enrichment — any badges or context items; an anchored OX marker only when it carried *deterministic* badges, since markers anchor those signals; no overclaim on un-enriched plans; no live-remote avatar) and warns on any miss. Re-check anytime with `ox plan lint <slug>` (add `--strict` to fail on findings). A clean lint is part of "done".
+- **Enforced, not just requested.** `ox plan save` lints the render for this contract (footer credit + an anchored OX marker when the plan carried enrichment; no overclaim on un-enriched plans; no live-remote avatar) and warns on any miss. Re-check anytime with `ox plan lint <slug>` (add `--strict` to fail on findings). A clean lint is part of "done".
 
 **Concise, high-signal prose.** No filler. Every sentence earns its place. Code identifiers in `<code>`. Don't restate what a diagram or badge already shows.
 
@@ -239,7 +259,7 @@ One **hero diagram near the top** captures the whole shape. Add a second diagram
 
 ## Process
 
-1. Run `ox plan --json` to get deterministic badges + the context bundle (0 tokens, local).
+1. Run `ox plan enrich --json` to get deterministic badges + the context bundle (0 tokens, local).
 2. Read the `context[]` bundle; author judgment badges **cited-only**, degrading to "consult `<name>`" when evidence is thin.
 3. Extract from the plan: problem/why, blockers/findings, architecture/flow, concrete steps (with file refs), impact numbers, verification, risks.
 4. Choose the diagrams that compress the most (before/after, sequence, decision gates, state machine, swimlane timeline).
@@ -250,10 +270,11 @@ One **hero diagram near the top** captures the whole shape. Add a second diagram
    - Does it **stand on its own** — is every file/ID/symbol/PR given enough context to matter, with no bare references?
    - Do the visuals **compress** understanding (replace prose) or just decorate?
    - Are SageOx insights **anchored OX markers with action-first popovers**, never a prose blob?
+   - **Craft:** does a user-facing change show a **mockup** (the `.device.ios` primitive / `ox plan viz device-mockup`), and is every diagram ox suggested actually **drawn**? `ox plan render` surfaces these as `plan-craft [...]` advisories for any agent (Claude, Codex, …) — treat each as a review item, not a suggestion to skip.
    Revise until the architect signs off that a busy principal would get full value in ten minutes. Cut anything that fails the contract.
-7. Merge your judgment badges into the `ox plan --json` annotations and persist with `ox plan save --plan ... --annotations <merged.json> --html <render.html>`.
+7. Merge your judgment badges into the `ox plan enrich --json` annotations and persist with `ox plan save --plan ... --annotations <merged.json> --html <render.html>`.
 8. Open the HTML and report the path.
 
 The goal: a $10k/hour principal reader skims the alignment strip + TL;DR + hero diagram and within ten minutes knows whether the plan aligns with team direction and whether to approve — the decision and biggest risk are up top, every badge and OX marker says where its claim comes from and what to do about it, ox-computed facts are visually separate from agent-reasoned judgment, and nothing on the page wastes the reader's time.
 
-$ox plan --json
+$ox plan enrich --json

--- a/.claude/skills/ox-session-review/SKILL.md
+++ b/.claude/skills/ox-session-review/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: ox-session-review
+description: >-
+  Audit every session in the project ledger for quality, then offer cleanup and
+  regeneration. Carries the operational knowledge from the 2026-04-25 cleanup
+  (the cache-only invariant and a failure-mode watch-list) that no single ox
+  subcommand backs. Use when the user asks to "review the ledger sessions",
+  "audit session quality", "clean up bad session summaries", "regenerate session
+  summaries", runs /ox-session-review, or wants to find and fix sessions with
+  missing/poor titles, empty summaries, or broken metadata.
+---
+<!-- ox-hash: 65414ac11ddf ver: 0.11.1 -->
+
+<!-- Keep this file thin on behavioral guidance that belongs in `ox` CLI JSON
+     output (guidance field). Skills are agent-specific wrappers; ox serves all
+     agents (Codex, etc.). This skill is intentionally richer than most because
+     the audit + regeneration flow is not backed by a single ox subcommand. -->
+
+This skill carries the operational knowledge from the 2026-04-25 cleanup
+(see PRs #559–#564 and bd ox-b917, ox-9o29, ox-4ncz, ox-1i3k). Read the
+**Failure-mode watch-list** before acting — it is the difference between
+a routine audit and re-causing the same incident.
+
+## Failure-mode watch-list (READ FIRST)
+
+When operating on the ledger, watch for and handle each of these
+explicitly. Silent skipping is not allowed — surface them in the report.
+
+| Mode | Symptom | Right action |
+|---|---|---|
+| **Cache-only invariant break** | After hydration, the in-place `<ledger>/sessions/<name>/raw.jsonl` is real content (not a ~140B LFS pointer). | Stop. Do not run any ox command that may `git add` the session dir. Investigate which code path wrote in-place — likely a regression of `.claude/rules/cache-only-design.md`. |
+| **Phantom LFS OID** | `ox session download` returns HTTP 404 from the LFS Batch API for an OID referenced in `meta.json`. | Unrecoverable from client. `ox session remove <name> --force` and report the lost session in the final summary. |
+| **0-byte in-place stub** | `meta.json` references a real OID, but in-place file is 0 bytes (and not a pointer). | Treat as needing download. Confirm `cmd/ox/session_hydrate.go` has the `info.Size() > 0` guard (PR #564). Without it, the resolver will silently return "" forever. |
+| **Daemon anti-entropy clobber** | A freshly-pushed good summary gets overwritten with a failure-marker stub minutes later. | The daemon scheduled finalize before our regen landed. Look at `internal/daemon/agentwork/session_finalize.go` `workNoLongerNeeded` re-verify guard (PR #561). If running a long batch regen, prefer a quiet daemon window. |
+| **Validation banner on the website** | Site shows "Summary failed content validation: title too short" but the ledger has good content. | Likely browser-side React Query cache (staleTime 5m, gcTime 30m). Verify origin/main HEAD has the right summary; advise hard refresh. Do not "fix" by re-pushing. |
+| **LLM regenerate hangs / asks for permission** | Regenerate spawns Claude Code and times out without writing. | Pass `--permission-mode bypassPermissions` to the headless invocation (PR #560 / regenerate flow). |
+
+## The cache-only invariant (assert this before and after every batch)
+
+Per `.claude/rules/cache-only-design.md`:
+
+- For any session synced from the ledger, `<ledger>/sessions/<name>/raw.jsonl`
+  MUST stay an LFS pointer (size ~140B, `lfs.IsPointerFile == true`).
+- Hydrated full content lives only at
+  `<ledger>/.sageox/cache/sessions/<name>/raw.jsonl` (gitignored).
+- All readers route through `cmd/ox/session_content.go:openSessionContent`.
+
+**Assertion to run before declaring a batch complete:**
+
+```bash
+# From the ledger root. Should print 0.
+find sessions -name 'raw.jsonl' -size +1k -not -path '*/.*' | wc -l
+```
+
+Any non-zero count means hydrated bytes leaked to the in-place path —
+the next `commitAndPushLedger` will glob them into a regular blob and
+break LFS linkage. Stop and investigate before pushing.
+
+## Phase 1 — Scan & Score (read-only)
+
+1. Run `ox session list --all`.
+2. Resolve the ledger sessions directory:
+   - Read `.sageox/config.json` for `repo_id` and `endpoint`.
+   - Sessions live at
+     `~/.local/share/sageox/<endpoint-slug>/ledgers/<repo_id>/sessions/`.
+3. For each session directory:
+   1. Read `meta.json` — capture `entry_count`, `title`, `summary`,
+      `files`, `created_at`.
+   2. Read `summary.json` if present — capture `title`, `summary`,
+      `key_actions`, `outcome`, `diagrams`, `aha_moments`,
+      `sageox_insights`.
+   3. Do NOT hydrate `raw.jsonl` during scan — hydration only happens in
+      Phase 4 for sessions the user explicitly approves for
+      regeneration. (For 100+ session ledgers, eager hydration is
+      prohibitively slow and risks the failure modes above.)
+   4. Score into the first-matching bucket below.
+
+## Quality Buckets (first match wins)
+
+### Removal Candidates
+- `entry_count` is `0` or missing AND `files` manifest is empty/missing.
+- Session outcome is `"failed"` AND `entry_count < 5`.
+- Only skill-wrapper activity with nothing between (`/ox-session-start`
+  → `/ox-session-stop`).
+- Phantom-OID sessions surfaced during a previous Phase 4 run (track
+  these — they cannot be regenerated).
+
+### Meta Repair
+- `files` manifest empty/missing BUT `entry_count > 0` — meta needs
+  repair after hydrating + re-scanning raw.jsonl for actual file writes.
+
+### Missing/Poor Summary
+- No `summary.json`.
+- `summary.json` has empty `title`, `summary`, or `key_actions`.
+- Summary matches the stats-only fallback pattern (e.g., "N user
+  messages, N assistant responses"; any summary where the body is < 80
+  chars and contains only digits + "messages"/"responses").
+- Title fails the website's content-validation gate (e.g., < 4 words or
+  matches "Summary failed content validation: title too short").
+- `diagrams` or `aha_moments` empty on a session with `entry_count > 50`.
+
+### Poor Title
+- Empty, or matches generic patterns: `"Session recording"`, date-only,
+  fewer than 4 words, or doesn't reflect content.
+
+### OK
+- Passes all checks.
+
+## Phase 2 — Report
+
+Present grouped tables (Removal, Meta Repair, Missing/Poor Summary, Poor
+Title) plus a one-line `OK: N healthy` tally. Surface systemic patterns
+(e.g., "91/153 sessions have empty titles — likely a distiller bug") so
+the user can file upstream bugs rather than just masking symptoms.
+
+Always include in the report:
+- A count of sessions where in-place raw.jsonl is NOT a pointer (should
+  be 0; non-zero is an invariant break — surface loudly).
+- Daemon liveness check: `ox doctor` daemon section. If a long batch is
+  planned, mention whether the daemon will be racing.
+
+## Phase 3 — User Confirms Actions
+
+ASK the user what to act on. Never auto-delete or auto-regenerate. Offer
+per-bucket choices plus a "top-N by entry_count" option to target
+highest-value sessions first when buckets are large.
+
+## Phase 4 — Execute Approved Actions
+
+### Removals
+```bash
+ox session remove <session_name> --force
+```
+
+### Meta Repair
+1. Hydrate: `ox session download <session_name>` (writes to cache, not
+   in-place — verify after).
+2. Re-scan hydrated `raw.jsonl` for Write/Edit tool calls; collect
+   unique file paths.
+3. Regenerate summary (see below) — the summary pipeline will also
+   repopulate `files`.
+
+### Summary Regeneration — Full-Session Processing
+
+**Step 4a — Hydrate.** `ox session download <session_name>`. After,
+verify the in-place file is still a pointer: `ls -la
+<ledger>/sessions/<name>/raw.jsonl` should show ~140B. Real bytes go to
+`<ledger>/.sageox/cache/sessions/<name>/raw.jsonl`.
+
+**Step 4b — Token-Optimize (pre-summarize stage).**
+
+Before feeding raw.jsonl into the summarization LLM, run a token-
+optimize pass. For now this is a **no-op pass-through** — copy
+raw.jsonl unchanged — but the long-term intent is documented so future
+implementers (or a future `ox session token-optimize` subcommand) know
+the contract:
+
+```text
+# token_optimize(raw_jsonl) -> optimized_jsonl
+#
+# Goal: reduce token footprint 5-10x while preserving all signal needed
+#       for title/summary/key_actions/aha_moments/diagrams/insights.
+#
+# Intended removals / compressions:
+#   - Duplicate tool_result blocks that repeat file contents already shown.
+#   - Large Read tool_result bodies (keep first/last ~40 lines + elision).
+#   - Base64 image payloads (keep MIME + dimensions only).
+#   - Binary blobs, minified JS/CSS, compiled output in tool_results.
+#   - Repeated system-reminder boilerplate (keep first occurrence).
+#   - Verbose stack traces (keep top frame + ellipsis).
+#   - Bash outputs with progress bars / spinners / ANSI — strip to final state.
+#   - Redundant tool_use inputs that mirror the prior assistant message verbatim.
+#
+# Must preserve verbatim:
+#   - All user turns (intent signal).
+#   - Assistant turns with reasoning / decisions / explanations.
+#   - Every Write/Edit tool_use input (path + diff — drives `files` manifest).
+#   - First + last 3 entries (chapter boundaries).
+#   - Error messages and their immediate resolution turns.
+#
+# Long-term: pipe raw.jsonl through a cheap model (haiku-class) for this
+# compression pass, THEN pipe into a reasoning model for the actual summary.
+# For now: no-op copy.
+```
+
+Implement inline: copy `raw.jsonl` from cache → `/tmp/ox-optimized-
+<session>.jsonl` unchanged. Log: "token_optimize: no-op pass-through (N
+bytes in / N bytes out)".
+
+**Step 4c — Chunked Full-Session Analysis.**
+
+Split the optimized jsonl into ordered chunks sized to fit a single LLM
+context window (target ~60k tokens; roughly 1500-2000 lines depending on
+turn size). Per chunk produce:
+
+```json
+{
+  "chunk_index": N,
+  "local_actions": [...],
+  "local_aha_moments": [...],
+  "local_topics": [...],
+  "local_files_touched": [...],
+  "local_errors_or_decisions": [...]
+}
+```
+
+**Step 4d — Synthesize Final Summary.**
+
+Feed the ordered partials (plus first 50 and last 50 lines of raw.jsonl
+for opening/closing context) into a final synthesis pass producing the
+canonical summary JSON:
+
+```json
+{
+  "title": "Short descriptive title reflecting actual work (5-10 words)",
+  "summary": "One paragraph executive summary covering motivation, approach, and outcome",
+  "key_actions": ["Concrete action 1", "Concrete action 2"],
+  "outcome": "success|partial|failed",
+  "topics_found": ["topic1", "topic2"],
+  "chapter_titles": ["Phase 1: ...", "Phase 2: ..."],
+  "aha_moments": [
+    {
+      "seq": 7,
+      "role": "user|assistant",
+      "type": "question|insight|decision|breakthrough|synthesis",
+      "highlight": "Key text from this moment",
+      "why": "Why this mattered for the session's trajectory"
+    }
+  ],
+  "diagrams": [
+    {
+      "title": "Data flow / architecture / state machine title",
+      "type": "flowchart|sequence|state|architecture",
+      "mermaid": "graph TD\n  A[Start] --> B[End]",
+      "why": "What this diagram clarifies about the session"
+    }
+  ],
+  "sageox_insights": [
+    {
+      "kind": "decision|convention|gotcha|followup",
+      "insight": "Concrete reusable insight other coworkers would benefit from",
+      "evidence_seq": 42
+    }
+  ]
+}
+```
+
+**`diagrams` and `sageox_insights` MUST NOT be hardcoded empty.**
+Generate them when the session has material worth capturing:
+- **Diagrams**: any architectural change, data flow, state machine,
+  pipeline, or non-trivial refactor. Mermaid syntax compatible with
+  GitHub. Skip only if genuinely trivial (e.g., typo fix).
+- **sageox_insights**: decisions, conventions discovered, gotchas that
+  tripped the session, and followups other coworkers should inherit.
+  Skip only if no reusable knowledge.
+
+If invoking a headless LLM (Claude Code in `-p` mode), pass
+`--permission-mode bypassPermissions`. Without it the LLM hangs waiting
+for a tool-permission prompt that no one will answer.
+
+**Step 4e — Push.**
+1. Pipe the synthesized JSON to push-summary via stdin. Do NOT write to `/tmp/` or any shared path — multiple agents may run concurrently on the same machine and race on shared filenames; macOS tmpfs GC can also reap the file between write and read.
+   ```bash
+   echo "$summary_json" | ox session push-summary --file - --session-dir <full_ledger_path>
+   ```
+2. Verify `"success": true`.
+
+**Step 4f — Post-batch invariant check.**
+After a batch run, before any `git push`, confirm:
+- `find <ledger>/sessions -name 'raw.jsonl' -size +1k -not -path '*/.*' | wc -l` is `0`.
+- `git status` in the ledger shows only `summary.json` / `summary.md` /
+  `meta.json` modifications, never `raw.jsonl`.
+
+If either check fails, do not push. Diagnose which step wrote in-place.
+
+## Edge Cases
+
+- **Empty ledger**: report and exit.
+- **All sessions OK**: report and exit.
+- **Hydration failure (404)**: phantom OID. Surface for removal, do not
+  retry endlessly.
+- **Hydration failure (network)**: log, skip, continue; list at end.
+- **Very large session (raw.jsonl > 20k lines)**: still process fully
+  via chunking — never fall back to edge-only sampling. If resource-
+  constrained, warn and offer to defer rather than produce a low-
+  quality summary.
+- **Systemic distiller bugs**: if scan reveals patterns ("all sessions
+  from user X have stats-only summaries", ">50% empty titles"), surface
+  as likely upstream bug and suggest `bd create` for a root-cause fix
+  instead of only per-session regeneration.
+
+## Reusable prompt for ledger reviews in other repos
+
+When asked to review a different ledger, lead with:
+
+> Audit every session in this project's ledger for quality.
+> Read `.claude/rules/cache-only-design.md` and
+> `.claude/rules/lfs-no-git-lfs-binary.md` first — both invariants
+> apply during this audit. Run the `/ox-session-review` skill flow:
+> scan read-only, report by bucket, confirm with me before any
+> removals or regenerations, and run the post-batch invariant check
+> before pushing.

--- a/.factory/rules/ox.md
+++ b/.factory/rules/ox.md
@@ -1,7 +1,7 @@
 ---
 description: SageOx behavioral guidance for AI coworkers
 ---
-<!-- agentx-hash: 898b8cbf7f9c ver: 0.7.2 -->
+<!-- agentx-hash: 28b4db70eda3 ver: 0.11.1 -->
 # SageOx Rules
 
 This project uses [SageOx](https://sageox.ai) for team context and session recording.

--- a/.factory/rules/sageox/use-team-context.md
+++ b/.factory/rules/sageox/use-team-context.md
@@ -1,0 +1,71 @@
+---
+description: How to discover and use team-context rules and knowledge from the SageOx ox CLI
+---
+<!-- agentx-hash: 95b1d1892cc5 ver: 0.11.1 -->
+# Team Context — More Rules Live Outside This Repo
+
+This repo uses SageOx. Behavioral rules and conventions that apply to your
+WHOLE TEAM (not just this repo) live in your team's SageOx team-context
+repo, NOT in `.factory/rules/`. SageOx will not auto-sync them here —
+that would create stale-mirror and naming-conflict problems. Instead,
+read them on demand from the canonical location.
+
+## Where team rules live
+
+Team-context repo path: see `ox status` (look for "team_context").
+Typical layout:
+
+    <team-context>/
+      AGENTS.md                  # team-wide preamble
+      MEMORY.md                  # team memory (already inlined into prime)
+      agents/
+        rules/
+          <topic>.md             # one concern per file
+          backend/postgres.md    # subdirectories supported
+          frontend/react.md
+        commands/                # team slash commands
+        profiles/                # AI coworker profiles
+      discussions/               # archived team meetings
+      memory/                    # daily/weekly/monthly summaries
+      documents/                 # imported docs
+
+## How to discover and read them
+
+`ox agent prime` already inlines:
+- Team AGENTS.md / CLAUDE.md
+- `visibility: always` team rules (full body)
+- Team MEMORY.md
+
+`ox agent prime` also catalogs (name + description + path only):
+- `visibility: indexed` team rules — read on demand via the path
+
+To read an indexed team rule: use the file-read tool with the absolute
+path shown in the prime output's `<team-rules>` block.
+
+To search team-wide knowledge (discussions, sessions, docs):
+- `ox query "<question>"` — semantic search across the team's
+  recorded discussions and prior coding sessions
+- `ox agent team-ctx` — distilled team knowledge for AI agents
+
+To learn the team-rule format (when authoring or promoting a rule):
+- `ox guide team-rules`
+
+## When you write a project-local rule
+
+If a user adds or edits a rule in `.factory/rules/` (this repo's
+local rules) that looks generally applicable — not specific to this
+repo's paths/services/schemas — ASK them whether to also publish it as
+a team rule under `<team-context>/agents/rules/`. Default to
+asking; do not silently publish. Repo-specific rules stay project-local.
+
+Team rules apply to every supported AI coding agent (Claude, Codex, Amp,
+Cursor, Droid, etc.) used by teammates running ox — but only for
+teammates running ox.
+
+## Why this rule exists (instead of syncing team rules here)
+
+Syncing team rules from team-context into `.factory/rules/` would
+require continuous mirror semantics, namespace management to avoid
+project-local conflicts, and per-adapter coverage. Pointing here keeps
+the team-context repo as the single source of truth and works uniformly
+across every coding agent that supports rules.

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -163,7 +163,11 @@ common issues, or --fix-slug to target specific checks.`,
 
 		gitRoot := findGitRoot()
 
-		// trigger daemon health checks (anti-entropy, etc.) if daemon is running
+		// ensure daemon is running so anti-entropy detection can execute.
+		// like ox sync, we rely on the daemon for background health checks.
+		_ = autoStartDaemon()
+
+		// trigger daemon health checks (anti-entropy, etc.)
 		// runs in background goroutine to not block CLI
 		if daemon.IsRunning() {
 			go func() {


### PR DESCRIPTION
## Summary

Agents working in this repo pick up the current ox skill set — the same artifacts `ox init`/`ox doctor` ship to customers, refreshed by the binary itself (agentx 0.7.2 → 0.11.1). No hand edits; this is the ox doctor reconciliation output, committed so every workspace and coworker sees the same agent setup.

- **`/ox-plan` slash command → `ox-plan` skill** — the 259-line command body moves to `.claude/skills/ox-plan/` per the thin-relay rule (the HTML rendering spec is legitimate skill content; command guidance stays in the CLI's JSON output)
- **New skills installed:** `ox-consult` (search SageOx team memory before answering from first principles) and `ox-session-review`
- **New shared rules:** `.claude/rules/sageox/use-team-context.md`, plus `.factory/rules/sageox/` so Factory/Droid agents get the same guidance (cross-agent parity)
- **`.factory/rules/ox.md`:** agentx-hash stamp bump `898b8cbf7f9c` (0.7.2) → `28b4db70eda3` (0.11.1)

## Test Plan

- Files are generated output of the installed ox binary (doctor reconciliation), not hand-authored
- `ox doctor` in this workspace after refresh: 84 checks passed, 0 failures, 5 non-blocking warnings

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — N/A: generated agent-setup files only, no product code
- [x] CHANGELOG entry added (if user-facing) — N/A: repo-local agent setup, not user-facing
- [x] Breaking change documented — N/A
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: no sensitive paths touched (no `internal/auth/`, `internal/mcp/`, `raw_writer.go`, `prepush_scan.go`, `internal/upgrade/`, `go.sum`)

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for accessing shared team context, rules, and knowledge across supported coding agents.
  * Added workflows for consulting team memory, reviewing sessions, and producing enriched plans with diagrams and device mockups.

* **Bug Fixes**
  * `ox doctor` now attempts to start the daemon before running daemon health checks, improving diagnostics when the daemon is stopped.

* **Documentation**
  * Clarified local-versus-team rule usage and session review safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->