### PR TITLE
release: prep v0.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.11.1"
+      "version": "0.12.0"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox/agent_query.go
+++ b/cmd/ox/agent_query.go
@@ -298,7 +298,7 @@ func queryTeamContext(qa *queryArgs, projectRoot, agentID, agentType string) (*a
 	}
 
 	ep := endpoint.GetForProject(projectRoot)
-	token, err := auth.GetTokenForEndpoint(ep)
+	token, err := auth.EnsureValidTokenForEndpoint(ep, 300)
 	if err != nil || token == nil || token.AccessToken == "" {
 		return nil, fmt.Errorf("not authenticated. Run 'ox login' first")
 	}
@@ -306,6 +306,16 @@ func queryTeamContext(qa *queryArgs, projectRoot, agentID, agentType string) (*a
 	client := api.NewRepoClientWithEndpoint(ep).WithAuthToken(token.AccessToken)
 
 	resp, err := client.Query(req)
+	if err != nil && errors.Is(err, api.ErrUnauthorized) {
+		// proactive refresh above can still miss a token invalidated
+		// server-side (e.g. revoked) after the check; one bounded reactive
+		// retry before giving up, mirroring auth.AuthenticatedRequest.
+		refreshed, refreshErr := auth.Handle401ErrorForEndpoint(token, ep)
+		if refreshErr == nil && refreshed != nil && refreshed.AccessToken != "" {
+			client = client.WithAuthToken(refreshed.AccessToken)
+			resp, err = client.Query(req)
+		}
+	}
 	if err != nil {
 		if errors.Is(err, api.ErrUnauthorized) {
 			return nil, fmt.Errorf("not authenticated. Run 'ox login' first")

--- a/cmd/ox/agent_query_test.go
+++ b/cmd/ox/agent_query_test.go
@@ -1,8 +1,15 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -250,4 +257,190 @@ func TestParseQueryArgs_JSONFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, qa.jsonOnly)
 	assert.Equal(t, "local", qa.source)
+}
+
+// --- queryTeamContext auth: mid-session token refresh (ox-x5h5.4) ---
+// Failure prevented: queryTeamContext used to call the raw, non-refreshing
+// auth.GetTokenForEndpoint and gave up immediately on a 401 — so `ox query`
+// failed with "not authenticated" mid-session even though `ox login`
+// succeeded and the access token had simply aged past its ~1h TTL.
+
+// newQueryTestProject sets up an isolated project + auth store pointed at
+// apiServer, with the given token saved for that endpoint. Mirrors the
+// httptest.NewServer + SAGEOX_ENDPOINT/XDG_CONFIG_HOME harness proven in
+// agent_session_manual_publish_test.go.
+func newQueryTestProject(t *testing.T, apiServer *httptest.Server, token *auth.StoredToken) (projectRoot string, qa *queryArgs) {
+	t.Helper()
+
+	t.Setenv("SAGEOX_ENDPOINT", apiServer.URL)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	projectRoot = createInitializedProjectWithConfig(t, &config.ProjectConfig{
+		RepoID:   "test-repo",
+		Endpoint: apiServer.URL,
+		TeamID:   "test-team",
+	})
+
+	require.NoError(t, auth.SaveTokenForEndpoint(apiServer.URL, token))
+
+	qa = &queryArgs{query: "test query", mode: "hybrid", limit: 5, source: "team"}
+	return projectRoot, qa
+}
+
+// TestQueryTeamContext_NearExpiryTokenRefreshedBeforeQuery proves a token
+// expiring within the 300s buffer is proactively refreshed before the query
+// fires, so the API request carries a live token instead of a stale one.
+func TestQueryTeamContext_NearExpiryTokenRefreshedBeforeQuery(t *testing.T) {
+	var tokenEndpointHit, jwtExchangeHit bool
+	var queryAuthHeader string
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case auth.TokenEndpoint:
+			tokenEndpointHit = true
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "refreshed-opaque",
+				"refresh_token": "refreshed-refresh",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		case "/api/v1/cli/auth/token":
+			jwtExchangeHit = true
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "refreshed-jwt",
+				"token_type":   "Bearer",
+				"expires_in":   900,
+			})
+		case "/api/v1/query":
+			queryAuthHeader = r.Header.Get("Authorization")
+			json.NewEncoder(w).Encode(api.QueryResponse{Results: []api.QueryResult{{Text: "ok"}}})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	// expires in 4 minutes — inside EnsureValidTokenForEndpoint's 300s buffer.
+	projectRoot, qa := newQueryTestProject(t, apiServer, &auth.StoredToken{
+		AccessToken:  "stale-access",
+		RefreshToken: "test-refresh-token",
+		ExpiresAt:    time.Now().Add(4 * time.Minute),
+		TokenType:    "Bearer",
+	})
+
+	resp, err := queryTeamContext(qa, projectRoot, "agent-1", "claude-code")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.True(t, tokenEndpointHit, "expected proactive refresh to hit the token endpoint")
+	assert.True(t, jwtExchangeHit, "expected proactive refresh to complete JWT exchange")
+	assert.Equal(t, "Bearer refreshed-jwt", queryAuthHeader, "query must carry the refreshed token, not the stale one")
+}
+
+// TestQueryTeamContext_RetriesOnceOn401ThenSucceeds proves a token that looks
+// valid locally but is rejected server-side (e.g. revoked) triggers exactly
+// one reactive refresh-and-retry, and the retried query succeeds.
+func TestQueryTeamContext_RetriesOnceOn401ThenSucceeds(t *testing.T) {
+	var queryCallCount int
+	var authHeaders []string
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case auth.TokenEndpoint:
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "refreshed-opaque",
+				"refresh_token": "refreshed-refresh",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		case "/api/v1/cli/auth/token":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "refreshed-jwt",
+				"token_type":   "Bearer",
+				"expires_in":   900,
+			})
+		case "/api/v1/query":
+			queryCallCount++
+			authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+			if queryCallCount == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			json.NewEncoder(w).Encode(api.QueryResponse{Results: []api.QueryResult{{Text: "ok"}}})
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	// far from expiry — proactive refresh must NOT fire; only the reactive
+	// 401 retry path should trigger a refresh.
+	projectRoot, qa := newQueryTestProject(t, apiServer, &auth.StoredToken{
+		AccessToken:  "revoked-access",
+		RefreshToken: "test-refresh-token",
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+		TokenType:    "Bearer",
+	})
+
+	resp, err := queryTeamContext(qa, projectRoot, "agent-1", "claude-code")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Equal(t, 2, queryCallCount, "expected exactly one retry after 401")
+	assert.Equal(t, "Bearer revoked-access", authHeaders[0], "first attempt uses the originally stored token")
+	assert.Equal(t, "Bearer refreshed-jwt", authHeaders[1], "retry uses the freshly refreshed token")
+}
+
+// TestQueryTeamContext_GivesUpIfRetryAlso401s proves a genuinely logged-out
+// user (refresh succeeds but the server still rejects the new token, or the
+// account is truly revoked) gets the unchanged "not authenticated" error
+// after exactly one retry — never a loop.
+func TestQueryTeamContext_GivesUpIfRetryAlso401s(t *testing.T) {
+	var queryCallCount int
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case auth.TokenEndpoint:
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "refreshed-opaque",
+				"refresh_token": "refreshed-refresh",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		case "/api/v1/cli/auth/token":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "refreshed-jwt",
+				"token_type":   "Bearer",
+				"expires_in":   900,
+			})
+		case "/api/v1/query":
+			queryCallCount++
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer apiServer.Close()
+
+	projectRoot, qa := newQueryTestProject(t, apiServer, &auth.StoredToken{
+		AccessToken:  "revoked-access",
+		RefreshToken: "test-refresh-token",
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+		TokenType:    "Bearer",
+	})
+
+	resp, err := queryTeamContext(qa, projectRoot, "agent-1", "claude-code")
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "not authenticated")
+
+	assert.Equal(t, 2, queryCallCount, "expected exactly one retry, not a loop")
 }

--- a/cmd/ox/daemon.go
+++ b/cmd/ox/daemon.go
@@ -452,3 +452,11 @@ func startDaemonBackground(ledgerPath string) error {
 func isTimeoutErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "i/o timeout")
 }
+
+// isUnknownMessageTypeErr returns true if the daemon rejected an IPC
+// message type it doesn't recognize — the signature of an old daemon
+// binary (predating a newly added message type) still running when a
+// newer CLI talks to it.
+func isUnknownMessageTypeErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "unknown message type")
+}

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"sort"
@@ -471,6 +472,14 @@ func runForceSessionUploads(cmd *cobra.Command) error {
 }
 
 // runGC triggers blue/green GC in the daemon, starting it if needed.
+//
+// TriggerGCAsync is asynchronous: the daemon kicks off the (potentially
+// multi-minute) blue-green reclone in a background goroutine and returns
+// within milliseconds. This mirrors runForceSessionUploads's 5s/30s
+// retry shape rather than blocking on the full reclone. A daemon binary
+// older than this change won't recognize the async message type; that
+// case falls back to the untouched synchronous TriggerGC with a much
+// longer timeout (it's genuinely going to block for the whole reclone).
 func runGC(cmd *cobra.Command) error {
 	w := cmd.OutOrStdout()
 
@@ -478,37 +487,83 @@ func runGC(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to start daemon: %w", err)
 	}
 
-	client := daemon.NewClientForCurrentRepo()
-
+	var usedSyncFallback bool
 	resp, err := cli.WithSpinner("Running garbage collection...", func() (*daemon.TriggerGCResponse, error) {
-		return client.TriggerGC()
+		client := daemon.NewClientForCurrentRepoWithTimeout(5 * time.Second)
+		r, err := client.TriggerGCAsync()
+		if err != nil && isTimeoutErr(err) {
+			client = daemon.NewClientForCurrentRepoWithTimeout(30 * time.Second)
+			r, err = client.TriggerGCAsync()
+		}
+		if err != nil && isUnknownMessageTypeErr(err) {
+			usedSyncFallback = true
+			fallbackClient := daemon.NewClientForCurrentRepoWithTimeout(3 * time.Minute)
+			return fallbackClient.TriggerGC()
+		}
+		return r, err
 	})
 	if err != nil {
-		return fmt.Errorf("gc failed: %w", err)
+		return gcErrorMessage(err)
 	}
 
-	if resp.Triggered == 0 && !resp.LedgerTriggered && resp.Skipped == 0 && len(resp.Errors) == 0 {
-		fmt.Fprintln(w, "No workspaces eligible for GC")
-		return nil
-	}
-
-	if resp.Triggered > 0 {
-		fmt.Fprintf(w, "%s  Recloned %d team context(s)\n",
-			ui.PassStyle.Render(ui.RenderPassIcon()), resp.Triggered)
-	}
-	if resp.LedgerTriggered {
-		fmt.Fprintf(w, "%s  Recloned ledger\n",
-			ui.PassStyle.Render(ui.RenderPassIcon()))
-	}
-	if resp.Skipped > 0 {
-		fmt.Fprintf(w, "%s  Skipped %d (GC already in progress)\n",
-			ui.MutedStyle.Render("○"), resp.Skipped)
-	}
-	for _, e := range resp.Errors {
-		fmt.Fprintf(w, "%s  %s\n", ui.FailStyle.Render("✗"), e)
-	}
-
+	renderGCResponse(w, resp, usedSyncFallback)
 	return nil
+}
+
+// gcErrorMessage maps a runGC failure to a user-facing error, giving a
+// friendly message for the "daemon didn't respond in time" case instead of
+// a raw i/o timeout.
+func gcErrorMessage(err error) error {
+	if isTimeoutErr(err) {
+		return fmt.Errorf("daemon is busy, try again in a moment")
+	}
+	return fmt.Errorf("gc failed: %w", err)
+}
+
+// renderGCResponse writes runGC's user-facing summary for a TriggerGCResponse.
+// Extracted from runGC so the response-branch rendering can be table-tested
+// without a live daemon connection.
+func renderGCResponse(w io.Writer, resp *daemon.TriggerGCResponse, usedSyncFallback bool) {
+	switch {
+	case resp.AlreadyRunning:
+		fmt.Fprintf(w, "%s  GC already in progress; this call was a no-op\n",
+			ui.PassStyle.Render(ui.TimelineDot))
+	case resp.BackgroundStarted:
+		fmt.Fprintf(w, "%s  GC started in background\n",
+			ui.PassStyle.Render(ui.TimelineDot))
+		fmt.Fprintf(w, "%s  Run %s to see results\n",
+			ui.MutedStyle.Render(ui.TimelineBar),
+			ui.MutedStyle.Render("`ox daemon status`"))
+	default:
+		// Legacy synchronous fields: either the version-skew fallback ran
+		// (old daemon, synchronous TriggerGC), or an old daemon answered
+		// trigger_gc_async inline.
+		if resp.Triggered == 0 && !resp.LedgerTriggered && resp.Skipped == 0 && len(resp.Errors) == 0 {
+			fmt.Fprintln(w, "No workspaces eligible for GC")
+			break
+		}
+		if resp.Triggered > 0 {
+			fmt.Fprintf(w, "%s  Recloned %d team context(s)\n",
+				ui.PassStyle.Render(ui.RenderPassIcon()), resp.Triggered)
+		}
+		if resp.LedgerTriggered {
+			fmt.Fprintf(w, "%s  Recloned ledger\n",
+				ui.PassStyle.Render(ui.RenderPassIcon()))
+		}
+		if resp.Skipped > 0 {
+			fmt.Fprintf(w, "%s  Skipped %d (GC already in progress)\n",
+				ui.MutedStyle.Render("○"), resp.Skipped)
+		}
+		for _, e := range resp.Errors {
+			fmt.Fprintf(w, "%s  %s\n", ui.FailStyle.Render("✗"), e)
+		}
+	}
+
+	if usedSyncFallback {
+		fmt.Fprintf(w, "%s  Daemon predates async GC; restart it (%s) for faster background runs\n",
+			ui.MutedStyle.Render(ui.TimelineBar),
+			ui.MutedStyle.Render("`ox daemon restart`"))
+	}
 }
 
 // detectDoctorState detects environment state for conditional check suppression

--- a/cmd/ox/logout.go
+++ b/cmd/ox/logout.go
@@ -131,9 +131,15 @@ var logoutCmd = &cobra.Command{
 			fmt.Println(cli.StyleDim.Render("Note: server-side sessions may still be active — try again when online."))
 		}
 
-		// strip PATs from git remote URLs for logged-out endpoints
+		// strip PATs from git remote URLs and clear the stored git credential
+		// (keychain + file) for each logged-out endpoint. Revoking the OAuth
+		// token alone leaves the separately-minted git PAT live on disk and
+		// server-side — a decommissioned/shared machine would keep push access.
 		for _, ep := range endpointsToLogout {
 			stripExistingRemotes(ep)
+			if err := gitserver.RemoveCredentialsForEndpoint(ep); err != nil {
+				slog.Debug("logout: failed to remove git credentials", "endpoint", ep, "error", err)
+			}
 		}
 
 		// show contextual tip

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-18
+
+Decision Records get first-class team context, and three real reliability gaps in sync and search are closed for good.
+
 ### Added
 
 - **Universal session links on every PR and commit** — recordings now mint their stable `ses_` ID the moment they start (not at stop), so every artifact carries the durable `https://sageox.ai/c/<session-id>` conversation link from the first minute: commit trailers (`SageOx-Session:`, written by the existing prepare-commit-msg hook), the PR-body last line (a one-line verbatim directive in prime output — squash merges now land the trailer in main's history), and rendered plan footers. Aborting a recording countermands the directive and stops new links immediately; the existing `attribution.session` setting turns the whole surface off. Crashed sessions keep their links stable — the daemon reuses the start-minted ID from the raw-header carrier instead of inventing a new one. Legacy recordings and historical name-based URLs stay valid.
@@ -14,6 +18,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ox decision enrich` — team context for Decision Records** — creating or updating an ADR/DDR now starts from the team's actual history instead of a blank page. Run it with `--topic` before drafting (related decisions, the corpus's numbering and template conventions, prior sessions, ready-to-paste citations) or `--file` before editing (code drift since the decision's date, amendment anchors, and any reference that no longer resolves — the "cited decision #9 that exists in no document" failure class is caught before commit, not after). Zero LLM or network cost; ox never edits the DR — the agent authors every word, and every citation ox emits is one it just verified. DRs are discovered zero-config from conventional dirs (`docs/adr`, `docs/decisions`, …) or the committed `decision.paths` setting.
 - **Plans now tie back to the decisions that shaped them** — `ox plan enrich` surfaces this repo's own Decision Records relevant to a plan, and the rendered plan marks their mentions inline (a subtle marker, context — never a verdict). Running `ox decision enrich` in this repo immediately surfaced nine duplicated ADR numbers our own corpus had accumulated unnoticed.
 - **Every coding agent is primed for decision hygiene** — in repos that keep DRs, `ox agent prime` teaches the consult-and-credit contract: enrich before drafting, credit teammates by name with verifiable refs, amend Accepted decisions with dated markers instead of rewriting history, and keep vendor credit subtle (invisible source refs + the scored commit trailer; at most two visible SageOx credits per DR).
+- **`ox doctor` catches a broken Decision Records setup** — a typo'd or invalid `decision.paths` entry used to fail silently and quietly turn off enrichment; `ox doctor` now flags it before it costs you a wasted `ox decision enrich` run.
+- **Find your team's decisions fast in code search** — `ox code search --decisions` narrows results to just this repo's ADRs/DDRs, and every decision-record hit is now labeled wherever it shows up in search so you can spot it at a glance.
+- **`ox session prune` clears out local-only sessions you no longer need** — removes finalized recordings that were never pushed to the ledger, keeping your local session store tidy. `--all` also clears paused, canceled, ghost, and orphaned sessions; `--dry-run` previews first; `--force` skips the confirmation prompt. Sessions already on the ledger are never touched — use `ox session remove <name>` for those.
+
+### Changed
+
+- **Fresher skills and rules on every `ox init` / `ox doctor --fix`** — includes a new `ox-session-review` skill for auditing session quality, a reorganized `ox-plan` skill, and a new rule that points every agent to where your team's shared conventions actually live.
+
+### Fixed
+
+- **Sync no longer wedges permanently if you have git commit signing turned on** — ox commits non-interactively (session finalize, murmurs, ledger housekeeping) and can't answer a signing passphrase prompt, so a global `commit.gpgsign` setting used to make every one of those commits fail forever with no visible error outside `ox doctor` — sync would just quietly pile up. ox now disables signing on its own commits only (your own repos keep signing normally) and self-heals any ledger or team context already stuck this way.
+- **`ox code search` recovers on its own from a rare false alarm** — under heavy concurrent use it could occasionally report a scary, permanent-looking index corruption error even though ox already knows how to repair it; it now retries briefly first, so the self-heal kicks in instead of the false alarm.
+- **`ox doctor` no longer skips checks because the daemon wasn't running** — it now starts the daemon first, the same way `ox sync` already does, so checks like stuck-session detection actually run instead of being silently skipped.
+
+### Security
+
+- **Dependency security patch** — updated `golang.org/x/crypto`, `x/net`, `x/sys`, `x/term`, `x/text`, and `goldmark` to close reachable CVEs in code paths ox actually exercises.
 
 ## [0.11.1] - 2026-07-01
 

--- a/internal/api/repo.go
+++ b/internal/api/repo.go
@@ -247,7 +247,8 @@ func (c *RepoClient) RegisterRepo(req *RepoInitRequest) (*RepoInitResponse, erro
 	}
 
 	logger.LogHTTPRequest("POST", reqURL)
-	logger.LogHTTPRequestBody(string(bodyBytes))
+	// intentionally skip LogHTTPRequestBody — RepoInitRequest carries repo_salt
+	// and repo_remote_hashes (auth material); matches the RegisterMarkers sibling.
 	start := time.Now()
 
 	// create HTTP request

--- a/internal/auth/authfile_test.go
+++ b/internal/auth/authfile_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -717,10 +718,20 @@ func TestAtomicity_DirectoryPermissions(t *testing.T) {
 func TestAtomicity_OriginalSurvivesWriteError(t *testing.T) {
 	t.Parallel()
 
+	// Permission bits gate this test's injected failure; root and Windows
+	// bypass them, so the write would succeed and the assertion be vacuous.
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission bits do not gate writes on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission bits")
+	}
+
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth.json")
 
-	// write initial data
+	// write initial data (also creates auth.json.lock so the failing write below
+	// still acquires the lock even after the dir is made unwritable)
 	original := &AuthStore{Tokens: map[string]*StoredToken{
 		"https://survive.example.com": {AccessToken: "original"},
 	}}
@@ -732,17 +743,30 @@ func TestAtomicity_OriginalSurvivesWriteError(t *testing.T) {
 	originalData, err := os.ReadFile(authPath)
 	require.NoError(t, err)
 
-	// attempt write that errors in the callback (before writeFile)
-	err = withAuthFileLocked(authPath, func(h *authFileHandle) error {
-		return fmt.Errorf("simulated failure before write")
-	})
-	require.Error(t, err)
+	// Force a REAL mid-write failure: make the config dir read-only so the
+	// atomic temp-file create inside writeFile → AtomicWriteJSON fails *after*
+	// the original already exists. This exercises temp+rename durability rather
+	// than trivially erroring before any write is attempted.
+	require.NoError(t, os.Chmod(dir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) }) // restore so t.TempDir cleanup succeeds
 
-	// original data must be intact
+	mutated := &AuthStore{Tokens: map[string]*StoredToken{
+		"https://survive.example.com": {AccessToken: "mutated"},
+	}}
+	err = withAuthFileLocked(authPath, func(h *authFileHandle) error {
+		return h.writeFile(mutated)
+	})
+	require.Error(t, err, "writing into a read-only dir must fail")
+
+	// original data must be byte-for-byte intact — the failed atomic write must
+	// leave no partial file and must not have clobbered the original
+	require.NoError(t, os.Chmod(dir, 0700)) // regain read access for the assertion
 	afterData, err := os.ReadFile(authPath)
 	require.NoError(t, err)
 	assert.Equal(t, string(originalData), string(afterData),
-		"original file must survive when callback errors before write")
+		"original file must survive a failed atomic write")
+	assert.NotContains(t, string(afterData), "mutated",
+		"failed write must not have partially applied")
 }
 
 // --- F. Legacy migration under lock ---

--- a/internal/auth/env_token.go
+++ b/internal/auth/env_token.go
@@ -59,7 +59,11 @@ func tokenFromEnv(ep string) *StoredToken {
 	if val == "" {
 		return nil
 	}
-	if requested := endpoint.NormalizeEndpoint(ep); requested != "" && requested != envTokenEndpoint() {
+	// Bind the env token to exactly one endpoint. A normalized-empty endpoint
+	// (e.g. malformed input like "api.") has no anchor to match against, so treat
+	// it as a non-match rather than handing out the "*"-scoped token to an
+	// unverifiable target.
+	if requested := endpoint.NormalizeEndpoint(ep); requested == "" || requested != envTokenEndpoint() {
 		return nil
 	}
 	return &StoredToken{

--- a/internal/auth/refresh.go
+++ b/internal/auth/refresh.go
@@ -152,6 +152,14 @@ func Handle401Error(token *StoredToken) (*StoredToken, error) {
 	return refreshToken(token)
 }
 
+// Handle401ErrorForEndpoint is Handle401Error scoped to a specific endpoint.
+// Handle401Error hardcodes endpoint.Get() (the global default), which is wrong
+// for callers bound to a per-project endpoint that can differ from it — e.g.
+// queryTeamContext, which resolves ep via endpoint.GetForProject(projectRoot).
+func Handle401ErrorForEndpoint(token *StoredToken, ep string) (*StoredToken, error) {
+	return refreshTokenForEndpoint(token, ep)
+}
+
 // refreshToken performs token refresh using refresh_token grant.
 //
 // Makes POST to token endpoint with:

--- a/internal/auth/refresh_test.go
+++ b/internal/auth/refresh_test.go
@@ -250,6 +250,19 @@ func TestRefreshToken_RefreshTokenNotRotated(t *testing.T) {
 	assert.Equal(t, oldRefreshToken, newToken.RefreshToken, "preserved from original")
 }
 
+// requireTokenSurvived asserts a failed refresh left the stored credential
+// intact on disk — the #449/#299 credential-wipe regression class. Without this
+// reload the refresh-failure tests assert only the (nil, err) return contract
+// and would stay green even if a failure branch wiped the token from disk.
+func requireTokenSurvived(t *testing.T, client *AuthClient, want *StoredToken) {
+	t.Helper()
+	saved, err := client.GetToken()
+	require.NoError(t, err, "reloading token after failed refresh")
+	require.NotNil(t, saved, "failed refresh must not wipe the stored credential")
+	require.Equal(t, want.AccessToken, saved.AccessToken, "stored access token must be unchanged")
+	require.Equal(t, want.RefreshToken, saved.RefreshToken, "stored refresh token must be unchanged")
+}
+
 func TestRefreshToken_InvalidRefreshToken(t *testing.T) {
 	t.Parallel()
 
@@ -279,6 +292,8 @@ func TestRefreshToken_InvalidRefreshToken(t *testing.T) {
 
 	// verify error message contains server error description
 	assert.Contains(t, err.Error(), "refresh token expired or revoked")
+
+	requireTokenSurvived(t, client, token)
 }
 
 func TestRefreshToken_BadRequest(t *testing.T) {
@@ -305,6 +320,8 @@ func TestRefreshToken_BadRequest(t *testing.T) {
 	require.Error(t, err, "want TokenRefreshError")
 	assert.Nil(t, newToken, "want nil on error")
 	assert.Contains(t, err.Error(), "re-authentication required")
+
+	requireTokenSurvived(t, client, token)
 }
 
 func TestRefreshToken_ServerError(t *testing.T) {
@@ -330,6 +347,8 @@ func TestRefreshToken_ServerError(t *testing.T) {
 	require.Error(t, err, "want TokenRefreshError")
 	assert.Nil(t, newToken, "want nil on error")
 	assert.Contains(t, err.Error(), "HTTP 500")
+
+	requireTokenSurvived(t, client, token)
 }
 
 func TestRefreshToken_NetworkError(t *testing.T) {
@@ -347,6 +366,8 @@ func TestRefreshToken_NetworkError(t *testing.T) {
 
 	// verify error contains network error message
 	assert.Contains(t, err.Error(), "network error")
+
+	requireTokenSurvived(t, client, token)
 }
 
 func TestRefreshToken_MissingAccessToken(t *testing.T) {

--- a/internal/auth/refresh_test.go
+++ b/internal/auth/refresh_test.go
@@ -930,3 +930,93 @@ func TestAuthClient_EnsureValidToken_EnvTokenSkipsRefresh(t *testing.T) {
 	assert.Equal(t, "oxp_env_client_bypass", token.AccessToken)
 	assert.Empty(t, token.RefreshToken)
 }
+
+// --- C. Endpoint-scoped reactive refresh (ox-x5h5.4) ---
+// Failure prevented: Handle401Error hardcodes endpoint.Get() (the global
+// default), which is wrong for a caller bound to a per-project endpoint that
+// differs from it — exactly queryTeamContext's situation
+// (ep := endpoint.GetForProject(projectRoot)). Refreshing against the wrong
+// endpoint produces a token valid nowhere useful, so the retry 401s again
+// and `ox query` fails mid-session even though `ox login` succeeded.
+
+// TestHandle401ErrorForEndpoint_UsesPassedEndpoint proves the refresh POST
+// hits the endpoint passed as an argument, not endpoint.Get()'s global
+// default — the one assertion that proves the bug this function fixes.
+func TestHandle401ErrorForEndpoint_UsesPassedEndpoint(t *testing.T) {
+	// wrongServer stands in for endpoint.Get()'s global default. If
+	// Handle401ErrorForEndpoint ever falls back to it instead of the passed
+	// ep, this handler fires and fails the test — deterministically, instead
+	// of a regression silently reaching the real production endpoint.
+	wrongServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("refresh must use the passed endpoint, not the global default; got %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer wrongServer.Close()
+
+	rightServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case TokenEndpoint:
+			require.NoError(t, r.ParseForm())
+			assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+			assert.Equal(t, "project-refresh-token", r.Form.Get("refresh_token"))
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "project-scoped-access",
+				"refresh_token": "project-scoped-refresh",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+		case "/api/v1/cli/auth/token":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "project-scoped-jwt",
+				"token_type":   "Bearer",
+				"expires_in":   900,
+			})
+		default:
+			t.Errorf("unexpected path on right server: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer rightServer.Close()
+
+	// t.Setenv forbids t.Parallel() in this test.
+	t.Setenv("SAGEOX_ENDPOINT", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// Exactly one endpoint has a valid (non-expired) token, so endpoint.Get()
+	// deterministically resolves to it via the "logged into exactly one
+	// endpoint" branch — this is what makes wrongServer the concrete target
+	// a regression would hit, instead of an untestable real prod default.
+	require.NoError(t, SaveTokenForEndpoint(wrongServer.URL, createTestToken(1*time.Hour)))
+
+	oldToken := createTestToken(-1 * time.Hour)
+	oldToken.RefreshToken = "project-refresh-token"
+
+	newToken, err := Handle401ErrorForEndpoint(oldToken, rightServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, newToken, "want refreshed token")
+	assert.Equal(t, "project-scoped-jwt", newToken.AccessToken)
+
+	// saved under the endpoint refreshed against, not the global default
+	saved, err := GetTokenForEndpoint(rightServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, saved)
+	assert.Equal(t, "project-scoped-jwt", saved.AccessToken)
+}
+
+// TestHandle401ErrorForEndpoint_NoRefreshToken mirrors Handle401Error's
+// existing no-refresh-credential coverage (TestRefreshToken_NoRefreshOrSessionToken)
+// for the endpoint-scoped variant: a token with neither RefreshToken nor
+// SessionToken must fail loudly, not attempt a network call.
+func TestHandle401ErrorForEndpoint_NoRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	token := createTestToken(-1 * time.Hour)
+	token.RefreshToken = ""
+	token.SessionToken = ""
+
+	newToken, err := Handle401ErrorForEndpoint(token, "https://unused.example.com")
+	require.Error(t, err, "want TokenRefreshError")
+	assert.Nil(t, newToken, "want nil on error")
+	assert.Contains(t, err.Error(), "no refresh token available")
+}

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -65,7 +65,7 @@ func ValidateTokenServerSide(ep, accessToken string) error {
 	slog.Debug("server-side token validation rejected",
 		"endpoint", ep,
 		"status", resp.StatusCode,
-		"response", string(body),
+		"response", redactedBody(body, resp.Header.Get("Content-Type")),
 	)
 
 	var errResp struct {

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -682,7 +682,11 @@ func SaveUserConfig(cfg *UserConfig) error {
 		return os.ErrNotExist
 	}
 
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	// 0700 dir / 0600 file: this is the same directory that holds auth.json and
+	// git-credentials.json (see paths.ConfigDir). A 0755/0644 write here would
+	// silently loosen the 0700 invariant auth.authfile relies on, because
+	// MkdirAll never tightens an existing directory.
+	if err := os.MkdirAll(configDir, 0700); err != nil {
 		return fmt.Errorf("creating config dir: %w", err)
 	}
 
@@ -694,7 +698,7 @@ func SaveUserConfig(cfg *UserConfig) error {
 	configPath := filepath.Join(configDir, "config.yaml")
 	tempPath := configPath + ".tmp"
 
-	if err := os.WriteFile(tempPath, data, 0644); err != nil {
+	if err := os.WriteFile(tempPath, data, 0600); err != nil {
 		return fmt.Errorf("writing temp config: %w", err)
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1717,6 +1717,10 @@ func (s *daemonServiceImpl) TriggerGC() *TriggerGCResponse {
 	return s.d.scheduler.TriggerGC(s.d.ctx)
 }
 
+func (s *daemonServiceImpl) TriggerGCAsync() *TriggerGCResponse {
+	return s.d.scheduler.TriggerGCAsync(s.d.ctx)
+}
+
 func (s *daemonServiceImpl) CodeIndex(payload CodeIndexPayload, progress *ProgressWriter) (*CodeIndexResult, error) {
 	if s.d.codedb == nil {
 		return nil, nil

--- a/internal/daemon/ipc.go
+++ b/internal/daemon/ipc.go
@@ -46,7 +46,8 @@ const (
 	MsgTypeSessions          = "sessions"            // get active agent sessions (deprecated: use instances)
 	MsgTypeInstances         = "instances"           // get active agent instances
 	MsgTypeDoctor            = "doctor"              // trigger daemon health checks (anti-entropy, etc.)
-	MsgTypeTriggerGC         = "trigger_gc"          // force GC reclone for team contexts
+	MsgTypeTriggerGC         = "trigger_gc"          // force GC reclone for team contexts (synchronous)
+	MsgTypeTriggerGCAsync    = "trigger_gc_async"    // force GC reclone for team contexts (background, returns immediately)
 	MsgTypeCodeIndex         = "code_index"          // index local code with progress
 	MsgTypeCodeStatus        = "code_status"         // get code index status/stats
 	MsgTypeWhispers          = "whispers"            // query whisper entries for an agent
@@ -564,11 +565,18 @@ type DoctorResponse struct {
 	Errors []string `json:"errors,omitempty"`
 }
 
-// TriggerGCResponse is the response for trigger_gc requests.
+// TriggerGCResponse is the response for trigger_gc / trigger_gc_async requests.
 // Errors include both failures (clone/validation errors) and skips due to
 // uncommitted changes — GC is a disk-space optimization and must never
 // destroy user work.
 type TriggerGCResponse struct {
+	// Async lifecycle indicators (populated by trigger_gc_async only).
+	BackgroundStarted bool `json:"background_started,omitempty"` // a fresh GC sweep was kicked off
+	AlreadyRunning    bool `json:"already_running,omitempty"`    // a prior sweep is still in progress; this call was a no-op
+
+	// Legacy synchronous fields. Populated by trigger_gc always, and by
+	// trigger_gc_async's caller never (results land via IssueTracker
+	// instead — see runTriggerGC's gcFailed wiring).
 	Triggered       int      `json:"triggered"`
 	Skipped         int      `json:"skipped,omitempty"`
 	LedgerTriggered bool     `json:"ledger_triggered,omitempty"`
@@ -693,6 +701,7 @@ type DaemonService interface {
 	Checkout(payload CheckoutPayload, progress *ProgressWriter) (*CheckoutResult, error)
 	MarkErrors(ids []string)
 	TriggerGC() *TriggerGCResponse
+	TriggerGCAsync() *TriggerGCResponse
 	CodeIndex(payload CodeIndexPayload, progress *ProgressWriter) (*CodeIndexResult, error)
 	Doctor() *DoctorResponse
 	SessionFinalize(payload SessionFinalizeIPCPayload)
@@ -739,6 +748,7 @@ type CallbackService struct {
 	onSyncHistory       func() []SyncEvent
 	onDoctor            func() *DoctorResponse
 	onTriggerGC         func() *TriggerGCResponse
+	onTriggerGCAsync    func() *TriggerGCResponse
 	onCodeIndex         func(payload CodeIndexPayload, progress *ProgressWriter) (*CodeIndexResult, error)
 	onCodeStatus        func() *CodeDBStats
 	onWhispers          func(agentID string, attention whisperstore.Attention, topics []string) ([]whisperstore.WhisperEntry, error)
@@ -897,6 +907,16 @@ func (c *CallbackService) MarkErrors(ids []string) {
 func (c *CallbackService) TriggerGC() *TriggerGCResponse {
 	c.mu.Lock()
 	fn := c.onTriggerGC
+	c.mu.Unlock()
+	if fn != nil {
+		return fn()
+	}
+	return nil
+}
+
+func (c *CallbackService) TriggerGCAsync() *TriggerGCResponse {
+	c.mu.Lock()
+	fn := c.onTriggerGCAsync
 	c.mu.Unlock()
 	if fn != nil {
 		return fn()
@@ -1200,6 +1220,7 @@ func (s *Server) buildRouter() *MessageRouter {
 	router.Register(MsgTypeInstances, handleInstances)
 	router.Register(MsgTypeDoctor, handleDoctor)
 	router.Register(MsgTypeTriggerGC, handleTriggerGC)
+	router.Register(MsgTypeTriggerGCAsync, handleTriggerGCAsync)
 	router.Register(MsgTypeCodeIndex, handleCodeIndex)
 	router.Register(MsgTypeCodeStatus, handleCodeStatus)
 	router.Register(MsgTypeWhispers, handleWhispers)
@@ -1389,6 +1410,14 @@ func (s *Server) SetTriggerGCHandler(handler func() *TriggerGCResponse) {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
 	svc.onTriggerGC = handler
+}
+
+// SetTriggerGCAsyncHandler sets the handler for forced background GC reclone.
+func (s *Server) SetTriggerGCAsyncHandler(handler func() *TriggerGCResponse) {
+	svc := s.mustCallbackService("SetTriggerGCAsyncHandler")
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	svc.onTriggerGCAsync = handler
 }
 
 // SetCodeIndexHandler sets the handler for code indexing requests.
@@ -1894,6 +1923,8 @@ func (c *Client) Doctor() (*DoctorResponse, error) {
 }
 
 // TriggerGC requests the daemon to force a GC reclone of team contexts.
+// Blocks until the reclone completes — see TriggerGC's doc comment in
+// sync_gc.go for why this stays synchronous rather than being converted.
 func (c *Client) TriggerGC() (*TriggerGCResponse, error) {
 	resp, err := c.sendMessage(Message{Type: MsgTypeTriggerGC})
 	if err != nil {
@@ -1906,6 +1937,28 @@ func (c *Client) TriggerGC() (*TriggerGCResponse, error) {
 	var gcResp TriggerGCResponse
 	if err := json.Unmarshal(resp.Data, &gcResp); err != nil {
 		return nil, fmt.Errorf("unmarshal trigger_gc response: %w", err)
+	}
+	return &gcResp, nil
+}
+
+// TriggerGCAsync requests the daemon to force a GC reclone of team contexts
+// in the background. Returns immediately (BackgroundStarted or
+// AlreadyRunning) rather than blocking for the full reclone; an old daemon
+// binary that predates this message type returns an "unknown message type"
+// error, which callers should treat as a version-skew signal and fall back
+// to TriggerGC.
+func (c *Client) TriggerGCAsync() (*TriggerGCResponse, error) {
+	resp, err := c.sendMessage(Message{Type: MsgTypeTriggerGCAsync})
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Success {
+		return nil, errors.New(resp.Error)
+	}
+
+	var gcResp TriggerGCResponse
+	if err := json.Unmarshal(resp.Data, &gcResp); err != nil {
+		return nil, fmt.Errorf("unmarshal trigger_gc_async response: %w", err)
 	}
 	return &gcResp, nil
 }

--- a/internal/daemon/ipc_handlers.go
+++ b/internal/daemon/ipc_handlers.go
@@ -299,6 +299,14 @@ func handleTriggerGC(s *Server, _ Message, _ net.Conn) HandlerResult {
 	return HandlerResult{Response: marshalResponse(resp)}
 }
 
+func handleTriggerGCAsync(s *Server, _ Message, _ net.Conn) HandlerResult {
+	resp := s.service.TriggerGCAsync()
+	if resp == nil {
+		resp = &TriggerGCResponse{}
+	}
+	return HandlerResult{Response: marshalResponse(resp)}
+}
+
 func handleCodeIndex(s *Server, msg Message, conn net.Conn) HandlerResult {
 	var payload CodeIndexPayload
 	if len(msg.Payload) > 0 {

--- a/internal/daemon/issues.go
+++ b/internal/daemon/issues.go
@@ -117,6 +117,7 @@ const (
 	IssueTypeCodeDBCacheWiped   = "codedb_cache_wiped"
 	IssueTypeDirtyOverlayFailed = "dirty_overlay_failed"
 	IssueTypeRebaseStuck        = "rebase_stuck"
+	IssueTypeGCFailed           = "gc_failed"
 )
 
 // severityRank returns a numeric rank for sorting (higher = more severe).

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -175,6 +175,7 @@ type SyncScheduler struct {
 	// test hooks (nil in production)
 	onBeforeCloneSem        func()        // called just before acquiring cloneSem; tests use this to observe blocking
 	cloneSemTimeoutOverride time.Duration // override cloneSemTimeout for tests (0 = use default)
+	gcAsyncTestHook         func()        // called at the start of TriggerGCAsync's goroutine, before runTriggerGC; tests use this to hold the goroutine open deterministically
 
 	// callbacks
 	onActivity   func()                                                           // called on any sync activity

--- a/internal/daemon/sync_gc.go
+++ b/internal/daemon/sync_gc.go
@@ -165,12 +165,53 @@ func (s *SyncScheduler) checkAndRunGC(ctx context.Context) {
 
 // TriggerGC forces a GC reclone of all eligible team contexts, bypassing the interval check.
 // Returns immediately if GC is already in progress. Runs synchronously.
+//
+// Do not convert this to run in the background: defaultKBDoctorGC
+// (cmd/ox/doctor_kb.go) calls TriggerGC and immediately rechecks disk
+// state for orphaned kb dirs, which depends on GC having actually
+// finished by the time this call returns. Use TriggerGCAsync for callers
+// (like `ox doctor --gc`) that must not block on a multi-minute reclone.
 func (s *SyncScheduler) TriggerGC(ctx context.Context) *TriggerGCResponse {
 	if !atomic.CompareAndSwapInt32(&s.gcInProgress, 0, 1) {
 		return &TriggerGCResponse{Skipped: 1}
 	}
 	defer atomic.StoreInt32(&s.gcInProgress, 0)
+	return s.runTriggerGC(ctx)
+}
 
+// TriggerGCAsync forces a GC reclone of all eligible team contexts in a
+// background goroutine, mirroring daemonServiceImpl.Doctor()'s async
+// pattern: the caller's IPC read deadline is milliseconds, but a
+// blue-green reclone can take minutes, so the work must not run on the
+// request path. Single-flight via the same gcInProgress guard TriggerGC
+// uses — a concurrent call while GC is running returns AlreadyRunning
+// instead of queuing a second sweep. The goroutine is tracked via the
+// same cloneWg used for background clones so daemon shutdown can bound
+// how long it waits for in-flight GC work (see waitClones).
+func (s *SyncScheduler) TriggerGCAsync(ctx context.Context) *TriggerGCResponse {
+	if !atomic.CompareAndSwapInt32(&s.gcInProgress, 0, 1) {
+		return &TriggerGCResponse{AlreadyRunning: true}
+	}
+	if !s.addClone() {
+		// scheduler is shutting down — don't spawn new background work
+		atomic.StoreInt32(&s.gcInProgress, 0)
+		return &TriggerGCResponse{Skipped: 1}
+	}
+	go func() {
+		defer s.cloneWg.Done()
+		defer atomic.StoreInt32(&s.gcInProgress, 0)
+		if s.gcAsyncTestHook != nil {
+			s.gcAsyncTestHook()
+		}
+		s.runTriggerGC(ctx)
+	}()
+	return &TriggerGCResponse{BackgroundStarted: true}
+}
+
+// runTriggerGC performs the forced-reclone sweep across team contexts and
+// the ledger. Callers must already hold the gcInProgress single-flight
+// guard (both TriggerGC and TriggerGCAsync do).
+func (s *SyncScheduler) runTriggerGC(ctx context.Context) *TriggerGCResponse {
 	if err := s.workspaceRegistry.LoadFromConfig(); err != nil {
 		return &TriggerGCResponse{Errors: []string{fmt.Sprintf("load registry: %v", err)}}
 	}
@@ -198,6 +239,7 @@ func (s *SyncScheduler) TriggerGC(ctx context.Context) *TriggerGCResponse {
 			resp.Triggered++
 			if s.issues != nil {
 				s.issues.ClearIssue(IssueTypeDirtyWorkspace, name)
+				s.issues.ClearIssue(IssueTypeGCFailed, name)
 			}
 		case gcSkippedDirty:
 			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: local changes could not be preserved for GC", name))
@@ -215,6 +257,17 @@ func (s *SyncScheduler) TriggerGC(ctx context.Context) *TriggerGCResponse {
 			resp.Skipped++
 		case gcFailed:
 			resp.Errors = append(resp.Errors, fmt.Sprintf("%s: reclone failed (check daemon logs)", name))
+			// TriggerGCAsync discards this response's return value, so the
+			// IssueTracker is the only way a background GC failure becomes
+			// visible (via `ox daemon status`).
+			if s.issues != nil {
+				s.issues.SetIssue(DaemonIssue{
+					Type:     IssueTypeGCFailed,
+					Severity: SeverityError,
+					Repo:     name,
+					Summary:  "GC reclone failed (check daemon logs)",
+				})
+			}
 		}
 	}
 
@@ -228,6 +281,7 @@ func (s *SyncScheduler) TriggerGC(ctx context.Context) *TriggerGCResponse {
 				resp.LedgerTriggered = true
 				if s.issues != nil {
 					s.issues.ClearIssue(IssueTypeDirtyWorkspace, "ledger")
+					s.issues.ClearIssue(IssueTypeGCFailed, "ledger")
 				}
 				// runBlueGreenGC closes the whisper store before the rename to release
 				// SQLite's mmap; reopen it now so writes don't silently fail until the
@@ -248,6 +302,14 @@ func (s *SyncScheduler) TriggerGC(ctx context.Context) *TriggerGCResponse {
 				resp.Skipped++
 			case gcFailed:
 				resp.Errors = append(resp.Errors, "ledger: reclone failed (check daemon logs)")
+				if s.issues != nil {
+					s.issues.SetIssue(DaemonIssue{
+						Type:     IssueTypeGCFailed,
+						Severity: SeverityError,
+						Repo:     "ledger",
+						Summary:  "GC reclone failed (check daemon logs)",
+					})
+				}
 			}
 		}
 	}

--- a/internal/daemon/sync_gc_async_test.go
+++ b/internal/daemon/sync_gc_async_test.go
@@ -1,0 +1,236 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// primeConfigCacheLocked marks the registry's config cache as freshly
+// loaded so a subsequent LoadFromConfig() call (e.g. inside TriggerGC)
+// hits the cache short-circuit instead of calling rebuildFromConfigLocked,
+// which prunes any workspace not declared in config.local.toml. Tests that
+// inject a WorkspaceState directly into registry.workspaces (bypassing the
+// config file) need this so TriggerGC's internal LoadFromConfig() doesn't
+// wipe the fixture before runTriggerGC iterates it. Caller must hold
+// registry.mu.
+func primeConfigCacheLocked(registry *WorkspaceRegistry) {
+	registry.localConfigCache = &config.LocalConfig{}
+	registry.localConfigLoadedAt = time.Now()
+}
+
+// --- A. TriggerGCAsync single-flight + non-blocking contract ---
+
+// TestTriggerGCAsync_SingleFlight pins the contract that TriggerGCAsync
+// returns immediately (BackgroundStarted=true) without blocking on the
+// reclone, that a concurrent second call while GC is in flight sees
+// AlreadyRunning=true instead of starting a second sweep, and that
+// gcInProgress is released once the background goroutine finishes.
+//
+// Failure prevented: a regression that drops the single-flight guard or
+// blocks on the reclone before returning would reintroduce the exact bug
+// this issue fixes — `ox doctor --gc` hanging on the IPC read deadline.
+func TestTriggerGCAsync_SingleFlight(t *testing.T) {
+	projectDir := setupProjectWithConfig(t, "# empty\n")
+	s := newTestScheduler(projectDir)
+
+	release := make(chan struct{})
+	started := make(chan struct{})
+	var startedOnce sync.Once
+	var hookCalls int32
+	s.gcAsyncTestHook = func() {
+		atomic.AddInt32(&hookCalls, 1)
+		startedOnce.Do(func() { close(started) })
+		<-release
+	}
+
+	ctx := context.Background()
+
+	callStart := time.Now()
+	resp1 := s.TriggerGCAsync(ctx)
+	callElapsed := time.Since(callStart)
+	require.True(t, resp1.BackgroundStarted, "first call must report BackgroundStarted")
+	require.False(t, resp1.AlreadyRunning, "first call must NOT be AlreadyRunning")
+	assert.Less(t, callElapsed, 500*time.Millisecond,
+		"TriggerGCAsync must return essentially immediately, not block on the reclone")
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background goroutine did not reach the test hook in time")
+	}
+
+	// Concurrent calls while the first goroutine is parked in the hook must
+	// all see AlreadyRunning — none may start a second sweep.
+	const concurrent = 10
+	results := make([]*TriggerGCResponse, concurrent)
+	var wg sync.WaitGroup
+	for i := range concurrent {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = s.TriggerGCAsync(ctx)
+		}()
+	}
+	wg.Wait()
+
+	for i, r := range results {
+		assert.True(t, r.AlreadyRunning, "concurrent call %d must see AlreadyRunning while GC is in flight", i)
+		assert.False(t, r.BackgroundStarted, "concurrent call %d must not start a second sweep", i)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hookCalls), "only one goroutine should ever reach the hook")
+
+	// release the parked goroutine and wait (no sleep) for it to drain
+	close(release)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&s.gcInProgress) == 0
+	}, 2*time.Second, 10*time.Millisecond, "gcInProgress must be released after the background goroutine finishes")
+
+	// Cleanup discipline: bound how long we wait for the tracked goroutine.
+	s.waitClones(2 * time.Second)
+}
+
+// --- B. Synchronous TriggerGC unaffected by the async refactor ---
+
+// TestTriggerGC_RemainsSynchronousAfterRefactor proves TriggerGC's external
+// contract is unchanged by the runTriggerGC extraction: it still blocks
+// until the reclone finishes, still returns the same legacy fields, and
+// never sets the new async-only fields. defaultKBDoctorGC
+// (cmd/ox/doctor_kb.go) depends on this: it calls TriggerGC and
+// immediately rechecks disk state, which only works if GC has actually
+// finished by the time the call returns.
+func TestTriggerGC_RemainsSynchronousAfterRefactor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	isolateCredentials(t)
+
+	tmp := t.TempDir()
+	bareDir, cloneDir := gcInitBareAndClone(t, tmp)
+	cloneURL := "file://" + bareDir
+
+	for _, f := range []string{"SOUL.md", ".sageox/config.json"} {
+		fullPath := filepath.Join(cloneDir, f)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte("content"), 0644))
+	}
+	require.NoError(t, exec.Command("git", "-C", cloneDir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", cloneDir, "commit", "-m", "add structure").Run())
+	require.NoError(t, exec.Command("git", "-C", cloneDir, "push", "origin", "HEAD:main").Run())
+
+	projectDir := setupProjectWithConfig(t, "# empty\n")
+	s := newTestScheduler(projectDir)
+	ctx := context.Background()
+
+	ws := &WorkspaceState{
+		ID:       "team-test",
+		Type:     WorkspaceTypeTeamContext,
+		TeamName: "test-team",
+		Path:     cloneDir,
+		CloneURL: cloneURL,
+		Exists:   true,
+	}
+	registry := s.WorkspaceRegistry()
+	registry.mu.Lock()
+	registry.workspaces[ws.ID] = ws
+	primeConfigCacheLocked(registry)
+	registry.mu.Unlock()
+
+	resp := s.TriggerGC(ctx)
+
+	assert.Equal(t, 1, resp.Triggered, "sync TriggerGC must still perform the reclone inline")
+	assert.Empty(t, resp.Errors)
+	assert.False(t, resp.BackgroundStarted, "sync path must never set the async-only field")
+	assert.False(t, resp.AlreadyRunning, "sync path must never set the async-only field")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&s.gcInProgress),
+		"gcInProgress must be released synchronously before TriggerGC returns")
+
+	// the reclone must have actually completed by the time TriggerGC
+	// returns — this is the exact invariant defaultKBDoctorGC depends on.
+	assert.FileExists(t, filepath.Join(cloneDir, "SOUL.md"))
+	assert.NoDirExists(t, cloneDir+".new")
+	assert.NoDirExists(t, cloneDir+".old")
+}
+
+// --- C. IssueTypeGCFailed wiring ---
+
+// TestTriggerGC_IssueTypeGCFailed_SetOnFailureClearedOnSuccess proves a
+// gcFailed reclone result surfaces via the IssueTracker (visible through
+// `ox daemon status`) and is cleared on the next successful reclone for
+// the same repo.
+//
+// Failure prevented: without this wiring, a background GC failure
+// (triggered via TriggerGCAsync) is silently discarded — the goroutine's
+// return value is never read by anyone, so a failing reclone would retry
+// forever with zero user-visible signal.
+func TestTriggerGC_IssueTypeGCFailed_SetOnFailureClearedOnSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	manifest := "version 1\ninclude .sageox/\ninclude SOUL.md\n"
+	bareDir, teamDir, scheduler := setupClonedTeamContext(t, manifest, nil)
+	scheduler.issues = NewIssueTracker()
+	ctx := context.Background()
+
+	// Phase 1: CloneURL is bad, so the reclone itself fails (push/capture
+	// phases succeed against the real origin — only the fresh clone fails).
+	badWS := &WorkspaceState{
+		ID:       "team_test",
+		Type:     WorkspaceTypeTeamContext,
+		TeamName: "test-team",
+		Path:     teamDir,
+		CloneURL: "file:///nonexistent/repo.git",
+		Exists:   true,
+	}
+	registry := scheduler.WorkspaceRegistry()
+	registry.mu.Lock()
+	registry.workspaces[badWS.ID] = badWS
+	// Primed once — the 30s cache window comfortably covers both TriggerGC
+	// calls below, so goodWS's injection doesn't need to re-prime it.
+	primeConfigCacheLocked(registry)
+	registry.mu.Unlock()
+
+	resp1 := scheduler.TriggerGC(ctx)
+	require.Len(t, resp1.Errors, 1)
+	assert.Contains(t, resp1.Errors[0], "reclone failed")
+
+	issues := scheduler.issues.GetIssues()
+	require.Len(t, issues, 1, "gcFailed must surface exactly one issue")
+	assert.Equal(t, IssueTypeGCFailed, issues[0].Type)
+	assert.Equal(t, "test-team", issues[0].Repo)
+	assert.Equal(t, SeverityError, issues[0].Severity)
+
+	// Phase 2: fix the CloneURL and trigger again — success must clear the issue.
+	goodWS := &WorkspaceState{
+		ID:       "team_test",
+		Type:     WorkspaceTypeTeamContext,
+		TeamName: "test-team",
+		Path:     teamDir,
+		CloneURL: "file://" + bareDir,
+		Exists:   true,
+	}
+	registry.mu.Lock()
+	registry.workspaces[goodWS.ID] = goodWS
+	registry.mu.Unlock()
+
+	resp2 := scheduler.TriggerGC(ctx)
+	assert.Equal(t, 1, resp2.Triggered)
+	assert.Empty(t, resp2.Errors)
+	assert.Empty(t, scheduler.issues.GetIssues(), "IssueTypeGCFailed must clear on the next successful reclone")
+}

--- a/internal/daemon/testutil/mock_service.go
+++ b/internal/daemon/testutil/mock_service.go
@@ -38,6 +38,7 @@ type MockService struct {
 	CheckoutFunc          func(payload daemon.CheckoutPayload, progress *daemon.ProgressWriter) (*daemon.CheckoutResult, error)
 	MarkErrorsFunc        func(ids []string)
 	TriggerGCFunc         func() *daemon.TriggerGCResponse
+	TriggerGCAsyncFunc    func() *daemon.TriggerGCResponse
 	CodeIndexFunc         func(payload daemon.CodeIndexPayload, progress *daemon.ProgressWriter) (*daemon.CodeIndexResult, error)
 	DoctorFunc            func() *daemon.DoctorResponse
 	SessionFinalizeFunc   func(payload daemon.SessionFinalizeIPCPayload)
@@ -172,6 +173,13 @@ func (m *MockService) MarkErrors(ids []string) {
 func (m *MockService) TriggerGC() *daemon.TriggerGCResponse {
 	if m.TriggerGCFunc != nil {
 		return m.TriggerGCFunc()
+	}
+	return nil
+}
+
+func (m *MockService) TriggerGCAsync() *daemon.TriggerGCResponse {
+	if m.TriggerGCAsyncFunc != nil {
+		return m.TriggerGCAsyncFunc()
 	}
 	return nil
 }

--- a/internal/gitserver/pat_liveness.go
+++ b/internal/gitserver/pat_liveness.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/paths"
 )
 
 // PATLivenessResult describes the outcome of a PAT liveness check.
@@ -125,11 +126,19 @@ func pickProbeRepoURL(creds *GitCredentials) string {
 	if len(creds.Repos) == 0 {
 		return ""
 	}
-	// pick the first available repo — order doesn't matter for auth validation
+	// Only probe a repo hosted on the same server that issued the PAT. The probe
+	// hands the live PAT to git via GIT_ASKPASS, so a foreign-host repo URL — a
+	// tampered git-credentials file or a compromised repos API response — would
+	// exfiltrate the token. When ServerURL is known we require a host match;
+	// order otherwise doesn't matter for auth validation.
 	for _, repo := range creds.Repos {
-		if repo.URL != "" {
-			return repo.URL
+		if repo.URL == "" {
+			continue
 		}
+		if creds.ServerURL != "" && !endpointHostsEqual(repo.URL, creds.ServerURL) {
+			continue
+		}
+		return repo.URL
 	}
 	return ""
 }
@@ -191,7 +200,15 @@ func ClearCredentialHelperEntry(serverURL string) {
 // Git calls this script with a prompt like "Password for ..." and expects
 // the credential on stdout. Returns the path to the script.
 func writeAskpassScript(token string) (string, error) {
-	f, err := os.CreateTemp("", "ox-askpass-*")
+	// Write under the per-user 0700 temp tree, not world-listable /tmp. The
+	// defer os.Remove in the caller is skipped on SIGKILL/panic, so a crashed
+	// probe can orphan this script — keeping the PAT-bearing filename out of a
+	// world-listable directory contains that residue to the owner.
+	tmpDir := paths.TempDir()
+	if err := os.MkdirAll(tmpDir, 0700); err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp(tmpDir, "ox-askpass-*")
 	if err != nil {
 		return "", err
 	}

--- a/internal/gitserver/pat_liveness_test.go
+++ b/internal/gitserver/pat_liveness_test.go
@@ -87,6 +87,30 @@ func TestPickProbeRepoURL(t *testing.T) {
 			},
 			want: "https://git.sageox.ai/valid/repo.git",
 		},
+		{
+			// Security: never probe (and hand the PAT to) a host other than the
+			// server that issued the PAT. A tampered credentials file or a
+			// compromised repos API response could inject a foreign-host URL.
+			name: "skips foreign host when ServerURL is set",
+			creds: &GitCredentials{
+				ServerURL: "https://git.sageox.ai",
+				Repos: map[string]RepoEntry{
+					"evil": {URL: "https://attacker.example.com/exfil/repo.git"},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "returns same-host repo, skipping a foreign one, when ServerURL is set",
+			creds: &GitCredentials{
+				ServerURL: "https://git.sageox.ai",
+				Repos: map[string]RepoEntry{
+					"evil": {URL: "https://attacker.example.com/exfil/repo.git"},
+					"ours": {URL: "https://git.sageox.ai/team/repo.git"},
+				},
+			},
+			want: "https://git.sageox.ai/team/repo.git",
+		},
 	}
 
 	for _, tt := range tests {
@@ -186,8 +210,12 @@ func TestValidatePATLiveness_CredentialHelperSuppressed(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(fakeGit.Name())
 
+	// Assert the credential helper is ACTUALLY disabled, not merely that some
+	// GIT_CONFIG override exists: the suppression requires KEY_0=credential.helper
+	// with an EMPTY VALUE_0. Checking only GIT_CONFIG_COUNT would stay green even
+	// if a regression pointed KEY_0 elsewhere or set a non-empty helper value.
 	_, err = fakeGit.WriteString(`#!/bin/sh
-if [ -z "$GIT_CONFIG_COUNT" ]; then
+if [ "$GIT_CONFIG_COUNT" != "1" ] || [ "$GIT_CONFIG_KEY_0" != "credential.helper" ] || [ -n "$GIT_CONFIG_VALUE_0" ]; then
   # credential helper was not suppressed — simulate 401 from stale keychain creds
   echo "fatal: unable to access 'https://git.sageox.ai/...': The requested URL returned error: 401" >&2
   exit 128

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -18,7 +18,8 @@ func init() {
 	// initialize with a default logger (warn level, text handler) so log
 	// is never nil even if Init() is not called.
 	log.Store(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelWarn,
+		Level:       slog.LevelWarn,
+		ReplaceAttr: redactAttr,
 	})))
 }
 
@@ -32,11 +33,13 @@ func Init(verbose bool) {
 	var handler slog.Handler
 	if os.Getenv("OX_ENV") == "production" {
 		handler = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
-			Level: level,
+			Level:       level,
+			ReplaceAttr: redactAttr,
 		})
 	} else {
 		handler = slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			Level: level,
+			Level:       level,
+			ReplaceAttr: redactAttr,
 		})
 	}
 

--- a/internal/logger/redact.go
+++ b/internal/logger/redact.go
@@ -1,0 +1,57 @@
+package logger
+
+import (
+	"log/slog"
+	"regexp"
+)
+
+// redactSecrets scrubs credential material from a string before it reaches a
+// log sink. It is the last-line backstop wired into every handler through
+// ReplaceAttr (see Init), so no call site can leak a raw secret by logging an
+// arbitrary string value — most importantly the full HTTP response bodies that
+// carry the git PAT (ReposResponse.token / TeamInfo git_token) and repo_salt.
+//
+// It deliberately overlaps a little with internal/auth.redactedBody (auth JSON
+// error-body allowlist) and internal/gitutil.SanitizeOutput (git subprocess
+// output). Those redact at their own layers; this guards the slog sink itself.
+// logger imports only the stdlib, so it can sit under every other package
+// without an import cycle — which is exactly why the backstop lives here.
+//
+// Matched shapes:
+//   - JSON string field with a sensitive key: "token":"…", "git_token":"…"
+//   - Authorization: Bearer <token> and a bare "Bearer <token>"
+//   - credentials in a URL userinfo: https://user:secret@host
+//   - well-known PAT prefixes (SageOx oxp_, GitLab glpat-, GitHub gh*_)
+func redactSecrets(s string) string {
+	if s == "" {
+		return s
+	}
+	s = jsonSecretRe.ReplaceAllString(s, `${1}[REDACTED]${2}`)
+	s = bearerRe.ReplaceAllString(s, `${1}[REDACTED]`)
+	s = urlCredRe.ReplaceAllString(s, `${1}:[REDACTED]@`)
+	s = patRe.ReplaceAllString(s, `[REDACTED]`)
+	return s
+}
+
+var (
+	// "sensitive_key": "value" — case-insensitive key, string values only.
+	// Longer keys precede their substrings so the alternation matches the
+	// specific field (refresh_token) rather than the generic one (token).
+	jsonSecretRe = regexp.MustCompile(`(?i)("(?:access_token|refresh_token|session_token|git_token|token|password|passwd|authorization|repo_salt|client_secret|secret|api[_-]?key)"\s*:\s*")[^"]*(")`)
+	// Authorization: Bearer xxxxx  /  "Bearer xxxxx"
+	bearerRe = regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+`)
+	// scheme://user:secret@host — keep the username, redact the secret.
+	urlCredRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://[^:/?#\s@]+):[^@/?#\s]+@`)
+	// well-known personal-access-token prefixes (bare token strings).
+	patRe = regexp.MustCompile(`(?:oxp_|glpat-|ghp_|gho_|ghu_|ghs_|github_pat_)[A-Za-z0-9_-]{8,}`)
+)
+
+// redactAttr is the slog ReplaceAttr hook: scrub every string-valued attribute
+// (body, response, url, error, …) through redactSecrets. Non-string attrs are
+// passed through untouched.
+func redactAttr(_ []string, a slog.Attr) slog.Attr {
+	if a.Value.Kind() == slog.KindString {
+		a.Value = slog.StringValue(redactSecrets(a.Value.String()))
+	}
+	return a
+}

--- a/internal/logger/redact_test.go
+++ b/internal/logger/redact_test.go
@@ -1,0 +1,113 @@
+package logger
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestRedactSecrets_Shapes verifies every credential shape the sink must scrub.
+// Failure prevented: a raw token/PAT/URL-credential reaching a log line.
+func TestRedactSecrets_Shapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		secret  string // must NOT appear in output
+		mustCon string // must still appear (non-secret context preserved)
+	}{
+		{
+			name:    "repos response git PAT (the HIGH finding)",
+			in:      `{"token":"glpat-AABBCCDDEEFFGGHHIIJJ","server_url":"https://git.sageox.ai","username":"oauth2"}`,
+			secret:  "glpat-AABBCCDDEEFFGGHHIIJJ",
+			mustCon: "server_url",
+		},
+		{
+			name:    "team info git_token",
+			in:      `{"git_token":"oxp_1234567890abcdefghij","name":"team-x"}`,
+			secret:  "oxp_1234567890abcdefghij",
+			mustCon: "team-x",
+		},
+		{
+			name:    "oauth access + refresh token",
+			in:      `{"access_token":"eyJhbGciOi.secretpart.sig","refresh_token":"rt_supersecretvalue"}`,
+			secret:  "rt_supersecretvalue",
+			mustCon: "refresh_token",
+		},
+		{
+			name:    "repo_salt auth material",
+			in:      `{"repo_salt":"c2FsdHNhbHRzYWx0","repo":"acme"}`,
+			secret:  "c2FsdHNhbHRzYWx0",
+			mustCon: "acme",
+		},
+		{
+			name:    "authorization bearer header",
+			in:      "Authorization: Bearer eyJ0eXAiOiJKV1QifQ.payload.signature",
+			secret:  "eyJ0eXAiOiJKV1QifQ.payload.signature",
+			mustCon: "Authorization",
+		},
+		{
+			name:    "credentials embedded in url",
+			in:      "cloning https://oauth2:glpat-ZZZZZZZZZZ@git.sageox.ai/team/ledger.git",
+			secret:  "glpat-ZZZZZZZZZZ",
+			mustCon: "git.sageox.ai",
+		},
+		{
+			name:    "bare sageox PAT prefix",
+			in:      "probe used token oxp_deadbeefdeadbeefdead for ls-remote",
+			secret:  "oxp_deadbeefdeadbeefdead",
+			mustCon: "ls-remote",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactSecrets(tc.in)
+			if strings.Contains(got, tc.secret) {
+				t.Fatalf("secret leaked through redaction:\n in:  %s\n out: %s", tc.in, got)
+			}
+			if !strings.Contains(got, "[REDACTED]") {
+				t.Fatalf("expected [REDACTED] marker in output, got: %s", got)
+			}
+			if tc.mustCon != "" && !strings.Contains(got, tc.mustCon) {
+				t.Fatalf("non-secret context %q was destroyed: %s", tc.mustCon, got)
+			}
+		})
+	}
+}
+
+// TestRedactSecrets_NoFalsePositives keeps the scrubber from mangling ordinary
+// log lines — over-redaction hides real debugging signal.
+func TestRedactSecrets_NoFalsePositives(t *testing.T) {
+	clean := []string{
+		`{"status":"ok","count":3,"endpoint":"sageox.ai"}`,
+		"http response body (empty body)",
+		"POST https://api.sageox.ai/api/v1/repo/init 200 in 42ms",
+	}
+	for _, s := range clean {
+		if got := redactSecrets(s); got != s {
+			t.Errorf("clean string altered:\n in:  %s\n out: %s", s, got)
+		}
+	}
+}
+
+// TestReplaceAttr_Backstop proves the sink itself scrubs — the durable fix.
+// Failure prevented: any slog call site logging a token-bearing string leaks it.
+func TestReplaceAttr_Backstop(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level:       slog.LevelDebug,
+		ReplaceAttr: redactAttr,
+	})
+	l := slog.New(h)
+
+	// Simulate LogHTTPResponseBody on the GetRepos success path.
+	l.Debug("http response body", "body", `{"token":"glpat-LIVEPATVALUE123456","username":"oauth2"}`)
+
+	out := buf.String()
+	if strings.Contains(out, "glpat-LIVEPATVALUE123456") {
+		t.Fatalf("PAT reached the log sink despite ReplaceAttr backstop:\n%s", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Fatalf("expected redaction marker in sink output:\n%s", out)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.11.1"
+	Version   = "0.12.0"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )


### PR DESCRIPTION
## Summary

- Release prep for **v0.12.0** — Y-bump. 17 days since `v0.11.1` (2026-07-01), 27 commits accumulated, `[Unreleased]` only covered about half of them.
- All version files verified in sync (`make verify-version`).

## What's in this release

### Added
- **`ox decision enrich`** — team context for Decision Records: related decisions, corpus conventions, prior sessions, and citation verification before you draft or edit an ADR/DDR.
- **Plans tie back to the decisions that shaped them** — `ox plan enrich` surfaces relevant DRs; rendered plans mark their mentions inline.
- **Every coding agent primed for decision hygiene** — enrich-before-drafting, credit-by-name, amend-don't-rewrite conventions taught via `ox agent prime`.
- **`ox doctor` catches a broken Decision Records setup** — flags a typo'd/invalid `decision.paths` before it silently disables enrichment.
- **`ox code search --decisions`** — filter results to just this repo's ADRs/DDRs; decision-record hits are labeled everywhere they surface.
- **`ox session prune`** — clears local-only sessions never pushed to the ledger (`--all`/`--dry-run`/`--force`); ledger-uploaded sessions are never touched.

### Changed
- **Fresher skills and rules on `ox init` / `ox doctor --fix`** — new `ox-session-review` skill, reorganized `ox-plan` skill, new team-context pointer rule.

### Fixed
- **Sync no longer wedges permanently with git commit signing on** — a global `commit.gpgsign` setting used to silently fail every ox-managed commit forever; ox now disables signing on its own commits only and self-heals repos already stuck.
- **`ox code search` recovers from a rare false-alarm corruption error** — retries briefly before surfacing it, so the existing self-heal actually kicks in.
- **`ox doctor` no longer skips daemon-dependent checks when the daemon isn't running** — auto-starts it first, matching `ox sync`.

### Security
- **Dependency patch** — `x/crypto`, `x/net`, `x/sys`, `x/term`, `x/text`, `goldmark` bumped to close reachable CVEs.

## Test Plan

- [x] `make lint`
- [x] `make test-all`
- [x] `make test-slow`
- [x] `make test-digital-twin`
- [ ] `make test-integration` — requires `ANTHROPIC_API_KEY`, run separately (hard release gate per `.claude/rules/releases.md`)
- [ ] `make smoke-test` — requires `SAGEOX_CI_PASSWORD`, run separately
- [ ] Run Walks — human-driven, coordinate in Slack per `.claude/commands/release.md`

## Post-merge steps

1. `git tag v0.12.0 && git push --tags`
2. `gh release create v0.12.0 --draft --notes-file -` (piping the CHANGELOG section for this version)
3. Human publishes the draft release → GoReleaser handles binaries/signing/Homebrew tap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated product version to **0.12.0**.
  * Added detailed changelog entries for **Added**, **Changed**, **Fixed**, and **Security** updates.

* **Bug Fixes**
  * Improved reliability for session link minting, initialization/diagnostics fixes, sync/signing, and `code search` auto-recovery.
  * Enhanced `doctor` daemon startup checks and IPC handling for compatibility.

* **Security**
  * Applied dependency security updates and hardened sensitive-data handling and logging redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->