### PR TITLE
fix(deps): revert gotreesitter to audited pin v0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-isatty v0.0.23
-	github.com/odvcencio/gotreesitter v0.41.0
+	github.com/odvcencio/gotreesitter v0.13.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/odvcencio/gotreesitter v0.41.0 h1:L1Ig6faEkQ9cF5lYBxnV9vlzFsNk2fpyqSfoVG6Wq8E=
-github.com/odvcencio/gotreesitter v0.41.0/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
+github.com/odvcencio/gotreesitter v0.13.0 h1:y2CuuMjh88r648IQQph4mDbt0i3cA6G6ZKt8hUq5Y4g=
+github.com/odvcencio/gotreesitter v0.13.0/go.mod h1:Sx+iYJBfw5xSWkSttLSuFvguJctlH+ma1BTxZ0MPCqo=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=


### PR DESCRIPTION
## Summary

- **Main is currently broken**: `TestGotreesitterPinned` (`internal/codedb/language/gotreesitter_audit_test.go`) has been failing on every CI run since the dependency-upgrade sweep merged (`chore(deps): upgrade all Go dependencies to latest`, #700).
- Root cause: that sweep bumped `github.com/odvcencio/gotreesitter` — a **personal-fork** tree-sitter dependency (see `ox-abtj`) — from `v0.13.0` to `v0.41.0`. That fork is explicitly audit-gated: the test requires a human to diff the new tag against upstream `tree-sitter`/`tree-sitter-go` and confirm no malicious changes *before* the pin is allowed to move. The upgrade sweep predated this guard test, so nothing caught it at the time.
- Fix: revert to the last audited pin (`v0.13.0`) until someone does that review and deliberately advances it.

## Test Plan

- [x] `go build ./...`
- [x] `make lint`
- [x] `make test-all` (includes `TestGotreesitterPinned` — now passing)
- [x] Reproduced the failure on `origin/main` tip first, confirmed this exact revert fixes it

## Note

If `v0.41.0` (or any newer tag) is actually wanted, that needs the manual audit described in the test's own failure message — diff against upstream, confirm no malicious changes, then update `expectedGotreesitterSum` deliberately. Not something to rubber-stamp from CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal component version to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->