### PR TITLE
feat(doctor): detect PR body missing SageOx attribution trailer

### DIFF
--- a/.claude/skills/ox-consult/SKILL.md
+++ b/.claude/skills/ox-consult/SKILL.md
@@ -8,9 +8,9 @@ description: >-
   a metric/cost change. A confident answer that prior work contradicts is worse
   than a slow one — check first, then answer. Routes the cue to the right corpus:
   recency to `ox session list`, conceptual to `ox query`, code-provenance to
-  `ox code search`.
+  `ox code search`, decision-record work to `ox decision enrich`.
 ---
-<!-- ox-hash: 1db18042d6cb ver: 0.11.1 -->
+<!-- ox-hash: 1db18042d6cb ver: 0.12.0 -->
 
 <!-- Thin by design. The authoritative consult-first reflex — the cues, the
      "confident-wrong is worse than slow" reasoning, and the routing rationale —

--- a/.claude/skills/ox-decision/SKILL.md
+++ b/.claude/skills/ox-decision/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ox-decision
+description: >-
+  Consult team context BEFORE creating or editing a Decision Record (ADR, DDR,
+  architecture/design decision doc). Auto-fire when the user asks to "write an
+  ADR", "add a decision record", "amend/update ADR-NNN", cites a DR by number,
+  or edits a file under docs/adr/ or docs/decisions/. Run `ox decision enrich
+  --topic "<subject>"` before drafting a new DR and `ox decision enrich --file
+  <dr.md>` before editing an existing one — related decisions, numbering,
+  conventions, drift, and ready-to-paste citations at zero LLM cost. Follow the
+  returned `guidance`.
+---
+<!-- ox-hash: f62197a45b10 ver: 0.12.0 -->
+
+<!-- Thin by design. The authoritative DR contract — consult-before-drafting,
+     the crediting rules (paste SOURCE refs verbatim, never compose by hand,
+     SageOx credit subtle and capped), amendment semantics, and ref
+     verification — lives in the <decision-record-guidance> block of
+     `ox agent prime` (Layer-1 floor) and in the `guidance` field of
+     `ox decision enrich` JSON, which reach Claude, Codex, and Droid alike.
+     This skill adds ONLY Claude-specific auto-activation ergonomics; it
+     duplicates no behavior. Do not grow this body. -->
+
+## Use when
+
+The task creates, edits, amends, or cites a Decision Record.
+
+## Do
+
+1. New DR: `ox decision enrich --topic "<subject>"` — BEFORE drafting.
+2. Existing DR: `ox decision enrich --file <path>` — BEFORE editing, and again
+   after your edit (it re-verifies every ref).
+3. Follow the `guidance` string in the JSON output — it carries the corpus
+   conventions, crediting contract, and verification rule for this repo.
+
+DR full text is searchable via `ox code search "<terms>"`.

--- a/cmd/ox/doctor_pr_attribution_test.go
+++ b/cmd/ox/doctor_pr_attribution_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- checkPRAttributionCoverage (ox-5r5v) ---
+//
+// Commit-level SageOx attribution is written by a deterministic git hook
+// (hooks_commit_msg.go) — it cannot silently regress without a code change.
+// PR-body attribution has no such backstop: it exists only as guidance an
+// AI coworker is expected to remember and apply on every `gh pr
+// create`/`gh pr edit`. checkPRAttributionCoverage is the only thing that
+// catches a miss before merge, when the PR body becomes the permanent
+// squash-merge record. These tests prove it actually catches that miss,
+// doesn't false-positive on PRs with no SageOx involvement, and doesn't
+// false-positive on branches with no open PR yet (the common case).
+
+func runGitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+}
+
+// --- A. branchHasSageOxCommitTrailer: pure git plumbing, no gh needed ---
+
+// TestBranchHasSageOxCommitTrailer_DetectsPresenceAndAbsence proves the
+// range-based trailer scan correctly distinguishes "no commit ahead of
+// base carries the trailer" from "one does", using a real branch history.
+// Failure prevented: a scan that greps the wrong range (e.g. all of HEAD's
+// history instead of just what's ahead of base) would misreport every
+// branch as attributed, or a scan that never matches would never fire.
+func TestBranchHasSageOxCommitTrailer_DetectsPresenceAndAbsence(t *testing.T) {
+	dir := t.TempDir()
+	runGitCmd(t, dir, "init", "-b", "main")
+	runGitCmd(t, dir, "config", "user.email", "test@test.sageox.ai")
+	runGitCmd(t, dir, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644))
+	runGitCmd(t, dir, "add", "-A")
+	runGitCmd(t, dir, "commit", "-m", "base commit")
+	runGitCmd(t, dir, "checkout", "-b", "feature")
+
+	const trailer = "Co-Authored-By: SageOx <ox@sageox.ai>"
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0o644))
+	runGitCmd(t, dir, "add", "-A")
+	runGitCmd(t, dir, "commit", "-m", "add a, no trailer")
+
+	has, err := branchHasSageOxCommitTrailer(dir, "main", trailer)
+	require.NoError(t, err)
+	assert.False(t, has, "no commit yet carries the trailer")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b"), 0o644))
+	runGitCmd(t, dir, "add", "-A")
+	runGitCmd(t, dir, "commit", "-m", "add b\n\n"+trailer)
+
+	has, err = branchHasSageOxCommitTrailer(dir, "main", trailer)
+	require.NoError(t, err)
+	assert.True(t, has, "a commit ahead of base now carries the trailer")
+}
+
+// --- B. checkPRAttributionCoverage: full dispatch, gh faked ---
+
+// fakeGh installs a fake `gh` executable on PATH that unconditionally
+// prints jsonOutput to stdout regardless of arguments. Tests the
+// parsing/decision logic in checkPRAttributionCoverage without touching
+// the network or a real GitHub repo.
+func fakeGh(t *testing.T, jsonOutput string) {
+	t.Helper()
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "response.json")
+	require.NoError(t, os.WriteFile(jsonPath, []byte(jsonOutput), 0o644))
+	scriptPath := filepath.Join(dir, "gh")
+	script := "#!/bin/sh\ncat " + jsonPath + "\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// setupPRAttributionFixture builds a real initialized project + git repo on
+// a "feature" branch one commit ahead of "main", and fakes `gh pr list` to
+// return a single open PR (#42, base "main") with the given body. When
+// withSageOxCommit is false, the feature commit carries no trailer at all
+// (simulating a PR with no SageOx involvement).
+func setupPRAttributionFixture(t *testing.T, prBody string, withSageOxCommit bool) string {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	dir := createInitializedProjectWithConfig(t, &config.ProjectConfig{
+		ProjectID:   "test_project",
+		WorkspaceID: "test_workspace",
+	})
+
+	runGitCmd(t, dir, "init", "-b", "main")
+	runGitCmd(t, dir, "config", "user.email", "test@test.sageox.ai")
+	runGitCmd(t, dir, "config", "user.name", "Test")
+	runGitCmd(t, dir, "add", "-A")
+	runGitCmd(t, dir, "commit", "-m", "init project")
+
+	runGitCmd(t, dir, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "work.txt"), []byte("work"), 0o644))
+	runGitCmd(t, dir, "add", "-A")
+	msg := "do the work"
+	if withSageOxCommit {
+		msg += "\n\nCo-Authored-By: SageOx <ox@sageox.ai>"
+	}
+	runGitCmd(t, dir, "commit", "-m", msg)
+
+	prJSON := fmt.Sprintf(`[{"number": 42, "baseRefName": "main", "body": %q}]`, prBody)
+	fakeGh(t, prJSON)
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+	require.NoError(t, os.Chdir(dir))
+
+	return dir
+}
+
+// TestCheckPRAttributionCoverage_WarnsWhenBodyMissingTrailer is the actual
+// bug this check exists to catch: a PR with a SageOx-attributed commit
+// whose body has no attribution trailer at all — exactly what happened on
+// PR #703 in production.
+func TestCheckPRAttributionCoverage_WarnsWhenBodyMissingTrailer(t *testing.T) {
+	setupPRAttributionFixture(t, "Just a plain PR description, no attribution anywhere.", true)
+
+	result := checkPRAttributionCoverage()
+
+	assert.True(t, result.warning, "must be flagged as a warning")
+	assert.False(t, result.skipped)
+	assert.Contains(t, result.message, "#42")
+	assert.Contains(t, result.message, "missing the trailer")
+}
+
+// TestCheckPRAttributionCoverage_PassesWhenBodyHasTrailer proves a
+// correctly-attributed PR body doesn't get flagged.
+func TestCheckPRAttributionCoverage_PassesWhenBodyHasTrailer(t *testing.T) {
+	setupPRAttributionFixture(t, "Some PR body.\n\nCo-Authored-By: [SageOx](https://github.com/SageOx)", true)
+
+	result := checkPRAttributionCoverage()
+
+	assert.False(t, result.warning)
+	assert.False(t, result.skipped)
+	assert.Contains(t, result.message, "#42")
+}
+
+// TestCheckPRAttributionCoverage_PassesWhenNoSageOxCommits proves a PR with
+// zero SageOx-attributed commits is never flagged, regardless of its body —
+// there's nothing to attribute.
+func TestCheckPRAttributionCoverage_PassesWhenNoSageOxCommits(t *testing.T) {
+	setupPRAttributionFixture(t, "A PR with no SageOx involvement at all.", false)
+
+	result := checkPRAttributionCoverage()
+
+	assert.False(t, result.warning)
+	assert.False(t, result.skipped)
+	assert.Contains(t, result.message, "no commits")
+}
+
+// TestCheckPRAttributionCoverage_SkipsWhenNoOpenPR proves the common case
+// (a branch with no PR opened yet) is a silent skip, not a false warning.
+func TestCheckPRAttributionCoverage_SkipsWhenNoOpenPR(t *testing.T) {
+	dir := setupPRAttributionFixture(t, "unused", true)
+	fakeGh(t, `[]`) // overwrite: gh reports no open PR for this branch
+	require.NoError(t, os.Chdir(dir))
+
+	result := checkPRAttributionCoverage()
+
+	assert.True(t, result.skipped)
+	assert.False(t, result.warning)
+}

--- a/cmd/ox/doctor_session.go
+++ b/cmd/ox/doctor_session.go
@@ -91,11 +91,12 @@ func checkSessionHealth(opts doctorOptions) []checkResult {
 		results = append(results, incompleteResult)
 	}
 
-	// linkage soft signals: trailer coverage on recent commits and
-	// reachability of closed-session ProducedCommits SHAs. Neither blocks;
-	// both are diagnostic.
+	// linkage soft signals: trailer coverage on recent commits, reachability
+	// of closed-session ProducedCommits SHAs, and PR-body attribution
+	// coverage. None block; all are diagnostic.
 	results = append(results, checkSessionTrailerRatio())
 	results = append(results, checkSessionProducedCommitsStaleness())
+	results = append(results, checkPRAttributionCoverage())
 
 	return results
 }

--- a/cmd/ox/doctor_session_linkage.go
+++ b/cmd/ox/doctor_session_linkage.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/lfs"
 )
 
-// doctor_session_linkage.go houses two soft-signal doctor checks for the
-// commit↔session linkage system:
+// doctor_session_linkage.go houses soft-signal doctor checks for the
+// commit↔session↔PR linkage system:
 //
 //  1. checkSessionTrailerRatio surfaces "how many of the last N commits on
 //     this branch carry a SageOx-Session: trailer." A low ratio is the
@@ -26,8 +29,18 @@ import (
 //     intentionally not auto-mutated; staleness is a soft signal so
 //     users notice).
 //
-// Both checks are read-only and intended to run quickly (bounded scan
-// windows). They never block any session work.
+//  3. checkPRAttributionCoverage catches a miss on the one linkage hop that
+//     has no automated enforcement at all: commit-level SageOx attribution
+//     is written by a deterministic git hook (hooks_commit_msg.go), but
+//     PR-body attribution exists only as guidance an AI coworker is
+//     expected to remember and apply on every `gh pr create`/`gh pr edit`
+//     (internal/prime/attribution.go). A long session with context
+//     compaction can lose track of that instruction; this check is the
+//     backstop that catches it before merge, when the PR body becomes the
+//     permanent squash-merge record. See ox-5r5v.
+//
+// All three checks are read-only and intended to run quickly (bounded scan
+// windows / single gh call). None ever block any session work.
 
 // trailerScanCommitCount caps how far back the trailer-ratio scan looks.
 // 50 is enough to catch a recent regression without scanning thousands of
@@ -177,4 +190,113 @@ func runGitLinkage(gitRoot string, args ...string) (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+// checkPRAttributionCoverage reports whether the open PR for the current
+// branch (if any) is missing the SageOx PR-body attribution trailer despite
+// having commits that carry SageOx commit attribution. Soft signal only —
+// see the package doc comment above for why this is the sole backstop for
+// the PR-body attribution hop.
+//
+// Skip cases (each returns SkippedCheck — not a failure): not in a git
+// repo, project not initialized, attribution not configured, gh
+// unavailable, no current branch, or no open PR for it.
+func checkPRAttributionCoverage() checkResult {
+	const name = "PR SageOx attribution coverage"
+
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(name, "not in a git repo", "")
+	}
+	if !config.IsInitialized(gitRoot) {
+		return SkippedCheck(name, "project not initialized", "")
+	}
+	cfg, err := config.LoadProjectConfig(gitRoot)
+	if err != nil {
+		return SkippedCheck(name, "could not load project config", "")
+	}
+	attr := resolveProjectAttribution(cfg)
+	if attr.Commit == "" || attr.PR == "" {
+		return SkippedCheck(name, "SageOx attribution not configured for this project", "")
+	}
+	if _, err := exec.LookPath("gh"); err != nil {
+		return SkippedCheck(name, "gh CLI not available", "")
+	}
+
+	branch, err := runGitLinkage(gitRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return SkippedCheck(name, "could not determine current branch", "")
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" || branch == "HEAD" {
+		return SkippedCheck(name, "detached HEAD", "")
+	}
+
+	pr, err := lookupOpenPRForBranch(gitRoot, branch)
+	if err != nil || pr == nil {
+		return SkippedCheck(name, "no open PR for current branch", "")
+	}
+
+	hasSageOxCommit, err := branchHasSageOxCommitTrailer(gitRoot, pr.BaseRefName, attr.Commit)
+	if err != nil {
+		return SkippedCheck(name, fmt.Sprintf("git log failed: %v", err), "")
+	}
+	if !hasSageOxCommit {
+		return PassedCheck(name, "no commits on this branch carry SageOx attribution")
+	}
+
+	if strings.Contains(pr.Body, attr.PR) || strings.Contains(pr.Body, "SageOx-Session:") {
+		return PassedCheck(name, fmt.Sprintf("PR #%d body carries SageOx attribution", pr.Number))
+	}
+
+	msg := fmt.Sprintf("PR #%d has SageOx-attributed commits but its body is missing the trailer", pr.Number)
+	fix := fmt.Sprintf("Add %q to the end of the PR body before merge — it becomes the permanent record on squash-merge: gh pr edit %d --body-file <file>",
+		attr.PR, pr.Number)
+	return WarningCheck(name, msg, fix)
+}
+
+// prAttributionInfo is the subset of `gh pr view`/`gh pr list` fields
+// needed by checkPRAttributionCoverage.
+type prAttributionInfo struct {
+	Number      int    `json:"number"`
+	Body        string `json:"body"`
+	BaseRefName string `json:"baseRefName"`
+}
+
+// lookupOpenPRForBranch shells out to gh to find the open PR (if any) whose
+// head is branch. Mirrors prURLForBranch's (hooks_pre_push.go) invocation
+// style. Bounded by ghTimeout. Returns nil on any failure or no match.
+func lookupOpenPRForBranch(gitRoot, branch string) (*prAttributionInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+		"--head", branch, "--state", "open", "--json", "number,body,baseRefName")
+	cmd.Dir = gitRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var prs []prAttributionInfo
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, err
+	}
+	if len(prs) == 0 {
+		return nil, nil
+	}
+	return &prs[0], nil
+}
+
+// branchHasSageOxCommitTrailer reports whether any commit ahead of the PR's
+// base branch carries commitTrailer (the project's resolved SageOx commit
+// attribution string). Falls back to a local base-ref range when the
+// remote-tracking ref isn't available (e.g. base branch never fetched).
+func branchHasSageOxCommitTrailer(gitRoot, baseRef, commitTrailer string) (bool, error) {
+	out, err := runGitLinkage(gitRoot, "log", "origin/"+baseRef+"..HEAD", "--format=%B")
+	if err != nil {
+		out, err = runGitLinkage(gitRoot, "log", baseRef+"..HEAD", "--format=%B")
+		if err != nil {
+			return false, err
+		}
+	}
+	return strings.Contains(out, commitTrailer), nil
 }


### PR DESCRIPTION
## What broke

PR #703 merged with commits carrying `Co-Authored-By: SageOx <ox@sageox.ai>` (added automatically by the `prepare-commit-msg` hook) but a PR body with no SageOx attribution trailer at all — the reviewer had to add it manually after merge.

## Root cause

Commit-level and PR-body-level attribution are two different systems:

- **Commits**: fully automated. A deterministic git hook (`cmd/ox/hooks_commit_msg.go`) runs on every commit and appends the trailer based on the reporting agent's contribution score. Cannot silently regress without a code change.
- **PR bodies**: no automated mechanism at all. It exists only as instructional guidance emitted once by `ox agent prime` (`internal/prime/attribution.go` + `Session.PRDirective`) — the AI coworker is expected to notice it, remember it, and manually check + append it on every `gh pr create`/`gh pr edit`.

Confirmed via full-repo search: no GitHub Action, `gh` wrapper, or hook touches PR bodies anywhere in this codebase. In a long session with several context compactions, that one-time instruction fell out of context and was never re-applied — especially on a later `gh pr edit` that overwrote the whole body.

```mermaid
flowchart TD
    A["git commit"] --> B["prepare-commit-msg hook<br/>(deterministic, cmd/ox/hooks_commit_msg.go)"]
    B --> C["Co-Authored-By: SageOx<br/>added automatically"]
    D["gh pr create / gh pr edit"] --> E{"AI coworker remembers<br/>the prime-time instruction?"}
    E -->|"yes"| F["PR body gets<br/>the attribution trailer"]
    E -->|"no — lost to context<br/>compaction, as happened here"| G["PR body silently<br/>missing attribution"]
```

## What this PR ships

A new soft-signal `ox doctor` check, `checkPRAttributionCoverage` (`cmd/ox/doctor_session_linkage.go`), alongside the existing commit↔session linkage checks in the same file:

- Resolves the current branch's open PR (if any) via `gh pr list --head <branch> --state open`
- Skips silently (not a failure) when: not in a git repo, project not initialized, attribution not configured, `gh` unavailable, no current branch, or no open PR for it — the common case
- If the PR's commits (ahead of its base branch) carry the project's configured SageOx commit trailer but the PR body doesn't contain the configured PR trailer, emits a `WarningCheck` naming the PR number and pointing at the fix (`gh pr edit <n> --body-file <file>`)
- Never blocks — matches the existing `checkSessionTrailerRatio`/`checkSessionProducedCommitsStaleness` pattern in the same file exactly

This doesn't make PR-body attribution deterministic (that would need a real automated injection point, which doesn't exist for `gh pr create`/`edit` today), but it closes the detection gap: a miss now surfaces the next time anyone runs `ox doctor` on that branch, instead of silently reaching a squash-merge.

## Test plan

All red-first verified (neutered the check, confirmed the test failed for the intended reason, restored, confirmed green).

- `TestBranchHasSageOxCommitTrailer_DetectsPresenceAndAbsence` — pure git plumbing (real repo, no `gh` needed): proves the range-based trailer scan distinguishes "no commit ahead of base has it" from "one does"
- `TestCheckPRAttributionCoverage_WarnsWhenBodyMissingTrailer` — the actual bug: SageOx-attributed commit + body with no attribution → warning naming the PR
- `TestCheckPRAttributionCoverage_PassesWhenBodyHasTrailer` — correctly-attributed PR body isn't flagged
- `TestCheckPRAttributionCoverage_PassesWhenNoSageOxCommits` — a PR with zero SageOx involvement is never flagged, regardless of body content
- `TestCheckPRAttributionCoverage_SkipsWhenNoOpenPR` — the common case (branch with no PR yet) is a silent skip, not a false warning

`gh` is faked via a PATH-injected shell script that echoes canned JSON (`fakeGh` helper) — tests the parsing/decision logic without touching the network or a real GitHub repo, following the existing `prURLForBranch` (`hooks_pre_push.go`) convention for shelling out to `gh`.

Verified: `go build ./...`, `go vet ./...`, `make lint` (0 issues), `go test ./cmd/ox/...` (full suite, clean).

## Tracking

Closes ox-5r5v.
