### PR TITLE
fix(gitserver): eliminate the repeated keychain access-prompt loop

### DIFF
--- a/internal/gitserver/credentials.go
+++ b/internal/gitserver/credentials.go
@@ -20,7 +20,105 @@ const (
 	keyringService = "sageox-git"
 	// keyringUser is the user identifier for the keychain entry
 	keyringUser = "git-credentials"
+
+	// keyringProbeCacheTTL bounds how long a keyring probe result is
+	// trusted before re-checking live. isKeyringAvailable is called from
+	// the daemon's heartbeat and sync loops (roughly once a minute) as
+	// well as most CLI commands touching git credentials — an uncached
+	// live probe on every call means a Set+Delete round-trip through OS
+	// Keychain Services on every one of those. On macOS, Keychain access
+	// grants are tied to the calling binary's code identity, so a locally
+	// rebuilt dev binary (go build/make install) looks like a new,
+	// unrecognized requester on every rebuild — any previously-granted
+	// "Always Allow" stops applying, and the next probe reprompts. Caching
+	// the result turns "a popup roughly every minute, worse after every
+	// rebuild" into "a popup at most once per TTL window."
+	keyringProbeCacheTTL = 5 * time.Minute
 )
+
+// keyringProbeMu guards the cached keyring-probe result below.
+var keyringProbeMu sync.RWMutex
+
+// keyringProbeAt is when the cached result was captured (zero = never probed).
+var keyringProbeAt time.Time
+
+// keyringProbeOK is the cached probe result.
+var keyringProbeOK bool
+
+// keyringProbeNow and keyringProbeFn are swappable for tests so the cache
+// TTL boundary and call-count behavior can be verified deterministically,
+// without waiting on a real clock or touching a real OS keychain.
+var (
+	keyringProbeNow = time.Now
+	keyringProbeFn  = liveKeyringProbe
+)
+
+// liveKeyringProbe performs the actual Set+Delete round-trip against the OS
+// keychain — the potentially prompt-triggering operation probeKeyringCached
+// exists to avoid repeating on every call.
+func liveKeyringProbe() bool {
+	testKey := "sageox-keyring-probe"
+	testValue := "probe"
+
+	if err := keyring.Set(keyringService, testKey, testValue); err != nil {
+		return false
+	}
+	_ = keyring.Delete(keyringService, testKey)
+	return true
+}
+
+// probeKeyringCached returns whether the OS keychain is functional,
+// reusing a cached result for keyringProbeCacheTTL instead of re-probing
+// live on every call.
+func probeKeyringCached() bool {
+	now := keyringProbeNow()
+
+	keyringProbeMu.RLock()
+	fresh := !keyringProbeAt.IsZero() && now.Sub(keyringProbeAt) < keyringProbeCacheTTL
+	cached := keyringProbeOK
+	keyringProbeMu.RUnlock()
+	if fresh {
+		return cached
+	}
+
+	ok := keyringProbeFn()
+
+	keyringProbeMu.Lock()
+	keyringProbeOK = ok
+	keyringProbeAt = now
+	keyringProbeMu.Unlock()
+
+	return ok
+}
+
+// TestSetKeyringProbeFunc overrides the live probe function for testing.
+// Returns the previous value so it can be restored.
+func TestSetKeyringProbeFunc(fn func() bool) func() bool {
+	keyringProbeMu.Lock()
+	defer keyringProbeMu.Unlock()
+	prev := keyringProbeFn
+	keyringProbeFn = fn
+	return prev
+}
+
+// TestSetKeyringProbeNow overrides the clock used for cache TTL checks.
+// Returns the previous value so it can be restored.
+func TestSetKeyringProbeNow(fn func() time.Time) func() time.Time {
+	keyringProbeMu.Lock()
+	defer keyringProbeMu.Unlock()
+	prev := keyringProbeNow
+	keyringProbeNow = fn
+	return prev
+}
+
+// TestResetKeyringProbeCache clears the cached probe result, forcing the
+// next probeKeyringCached call to re-probe live.
+func TestResetKeyringProbeCache() {
+	keyringProbeMu.Lock()
+	defer keyringProbeMu.Unlock()
+	keyringProbeAt = time.Time{}
+	keyringProbeOK = false
+}
 
 // RepoEntry represents a single git repository from the credentials API.
 // NOTE: GET /api/v1/cli/repos only returns team-context repos, not ledgers.
@@ -132,20 +230,8 @@ func isKeyringAvailable() bool {
 		}
 	}
 
-	// test if keyring is actually functional by attempting a probe operation
-	// use a unique test key that won't conflict with real data
-	testKey := "sageox-keyring-probe"
-	testValue := "probe"
-
-	// try to set and get a value
-	if err := keyring.Set(keyringService, testKey, testValue); err != nil {
-		return false
-	}
-
-	// clean up probe value
-	_ = keyring.Delete(keyringService, testKey)
-
-	return true
+	// test if keyring is actually functional — cached, see probeKeyringCached
+	return probeKeyringCached()
 }
 
 // RemoveCredentials deletes git server credentials from all storage locations.

--- a/internal/gitserver/credentials.go
+++ b/internal/gitserver/credentials.go
@@ -21,18 +21,13 @@ const (
 	// keyringUser is the user identifier for the keychain entry
 	keyringUser = "git-credentials"
 
-	// keyringProbeCacheTTL bounds how long a keyring probe result is
+	// keyringProbeCacheTTL bounds how long a keyring-availability result is
 	// trusted before re-checking live. isKeyringAvailable is called from
 	// the daemon's heartbeat and sync loops (roughly once a minute) as
-	// well as most CLI commands touching git credentials — an uncached
-	// live probe on every call means a Set+Delete round-trip through OS
-	// Keychain Services on every one of those. On macOS, Keychain access
-	// grants are tied to the calling binary's code identity, so a locally
-	// rebuilt dev binary (go build/make install) looks like a new,
-	// unrecognized requester on every rebuild — any previously-granted
-	// "Always Allow" stops applying, and the next probe reprompts. Caching
-	// the result turns "a popup roughly every minute, worse after every
-	// rebuild" into "a popup at most once per TTL window."
+	// well as most CLI commands touching git credentials, and every CLI
+	// invocation is a fresh process — caching narrows the window further
+	// but can't cover process-to-process reuse on its own; liveKeyringProbe
+	// (below) is what actually removes the repeat-prompt trigger.
 	keyringProbeCacheTTL = 5 * time.Minute
 )
 
@@ -53,18 +48,34 @@ var (
 	keyringProbeFn  = liveKeyringProbe
 )
 
-// liveKeyringProbe performs the actual Set+Delete round-trip against the OS
-// keychain — the potentially prompt-triggering operation probeKeyringCached
-// exists to avoid repeating on every call.
+// liveKeyringProbe checks keychain availability by reading the real,
+// persistent credential slot (keyringService/keyringUser) instead of
+// creating and immediately deleting a throwaway probe entry.
+//
+// The previous approach did keyring.Set("sageox-keyring-probe") followed
+// by keyring.Delete on the same key, every call. On macOS, go-keyring
+// shells out to /usr/bin/security, and Keychain ACL "Always Allow" grants
+// are tied to a SPECIFIC item — an item that gets created and destroyed on
+// every single check never persists long enough for any grant to stick, so
+// every call re-triggered the access prompt. Reading the real credential
+// slot instead means: once the user grants access to that one persistent
+// item (typically the first time ox actually stores or reads real
+// credentials), the same item is reused on every subsequent check and the
+// grant holds. ErrNotFound is a normal, prompt-free outcome — it means the
+// keychain mechanism works, there just aren't credentials stored yet — not
+// a failure.
 func liveKeyringProbe() bool {
-	testKey := "sageox-keyring-probe"
-	testValue := "probe"
+	_, err := keyring.Get(keyringService, keyringUser)
+	return keyringAvailableForErr(err)
+}
 
-	if err := keyring.Set(keyringService, testKey, testValue); err != nil {
-		return false
-	}
-	_ = keyring.Delete(keyringService, testKey)
-	return true
+// keyringAvailableForErr classifies a keyring.Get error: nil (a credential
+// is stored) or ErrNotFound (mechanism works, nothing stored yet) both mean
+// the keychain is available; any other error (locked, denied, no backend)
+// means it isn't. Split out from liveKeyringProbe so this decision is
+// directly testable without a real OS keychain backend.
+func keyringAvailableForErr(err error) bool {
+	return err == nil || errors.Is(err, keyring.ErrNotFound)
 }
 
 // probeKeyringCached returns whether the OS keychain is functional,

--- a/internal/gitserver/credentials_keyring_probe_test.go
+++ b/internal/gitserver/credentials_keyring_probe_test.go
@@ -1,13 +1,54 @@
 package gitserver
 
 import (
+	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
 )
+
+// --- keyringAvailableForErr: read the real credential slot, not a throwaway ---
+//
+// The old check did keyring.Set("sageox-keyring-probe") followed by
+// keyring.Delete on the same key, every single call. On macOS, Keychain
+// ACL "Always Allow" grants are tied to a specific item — one that's
+// created and destroyed on every check never persists long enough for any
+// grant to stick, so every call re-triggered the OS access prompt.
+// liveKeyringProbe now reads the real, persistent credential slot instead:
+// once access is granted for that one item, it stays granted. ErrNotFound
+// must be treated as "available" (the mechanism works, nothing is stored
+// yet), not as a failure — getting that backwards would make ox report the
+// keychain broken for every user who hasn't logged in yet.
+
+// TestKeyringAvailableForErr_ClassifiesOutcomes proves the classification
+// itself: a stored credential or ErrNotFound both mean the keychain is
+// available; any other error (locked, permission denied, no backend on a
+// headless box) means it isn't. This is the actual bug class from the old
+// code — nothing here touches a real OS keychain, so it runs identically
+// in CI and locally.
+func TestKeyringAvailableForErr_ClassifiesOutcomes(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"credential found", nil, true},
+		{"nothing stored yet", keyring.ErrNotFound, true},
+		{"wrapped not-found", fmt.Errorf("lookup: %w", keyring.ErrNotFound), true},
+		{"keychain locked or access denied", errors.New("User interaction is not allowed."), false},
+		{"no backend available", errors.New("exec: \"security\": executable file not found in $PATH"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, keyringAvailableForErr(tt.err))
+		})
+	}
+}
 
 // --- probeKeyringCached: avoid re-probing the OS keychain on every call ---
 //

--- a/internal/gitserver/credentials_keyring_probe_test.go
+++ b/internal/gitserver/credentials_keyring_probe_test.go
@@ -1,0 +1,128 @@
+package gitserver
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- probeKeyringCached: avoid re-probing the OS keychain on every call ---
+//
+// isKeyringAvailable is called from the daemon's heartbeat and sync loops
+// (roughly once a minute) plus most CLI commands touching git credentials.
+// An uncached live probe on every call means a Set+Delete round-trip
+// through OS Keychain Services every time — on macOS this can reprompt the
+// user for access on every call, and always reprompts after a locally
+// rebuilt dev binary changes identity. Failure prevented: a popup roughly
+// every minute (worse after every rebuild) instead of at most once per TTL
+// window.
+
+// resetKeyringProbeState restores the probe function, clock, and cache to
+// clean defaults after a test, so later tests never observe a stubbed
+// probe or a stale cached result.
+func resetKeyringProbeState(t *testing.T) {
+	t.Helper()
+	prevFn := TestSetKeyringProbeFunc(liveKeyringProbe)
+	prevNow := TestSetKeyringProbeNow(time.Now)
+	TestResetKeyringProbeCache()
+	t.Cleanup(func() {
+		TestSetKeyringProbeFunc(prevFn)
+		TestSetKeyringProbeNow(prevNow)
+		TestResetKeyringProbeCache()
+	})
+}
+
+// TestProbeKeyringCached_SecondCallWithinTTLDoesNotReprobe proves back-to-
+// back calls reuse the cached result instead of hitting the OS keychain
+// again. Failure prevented: a probe on every isKeyringAvailable call —
+// exactly the bug that produced a keychain popup roughly once a minute.
+func TestProbeKeyringCached_SecondCallWithinTTLDoesNotReprobe(t *testing.T) {
+	resetKeyringProbeState(t)
+
+	var calls int32
+	TestSetKeyringProbeFunc(func() bool {
+		atomic.AddInt32(&calls, 1)
+		return true
+	})
+
+	first := probeKeyringCached()
+	second := probeKeyringCached()
+
+	assert.True(t, first)
+	assert.True(t, second)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"the live probe must fire once, not once per call")
+}
+
+// TestProbeKeyringCached_ReprobesAfterTTLExpires proves the cache isn't
+// permanent — once the TTL window has passed, the next call re-probes
+// live instead of trusting a result from before the keychain state (e.g.
+// locked/unlocked, or a rebuilt binary's identity) may have changed.
+// Uses an injectable clock, not time.Sleep, so this is deterministic and
+// fast per this repo's testing discipline.
+func TestProbeKeyringCached_ReprobesAfterTTLExpires(t *testing.T) {
+	resetKeyringProbeState(t)
+
+	var calls int32
+	TestSetKeyringProbeFunc(func() bool {
+		atomic.AddInt32(&calls, 1)
+		return true
+	})
+
+	now := time.Now()
+	TestSetKeyringProbeNow(func() time.Time { return now })
+	probeKeyringCached()
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	// still within TTL: no re-probe
+	TestSetKeyringProbeNow(func() time.Time { return now.Add(keyringProbeCacheTTL - time.Second) })
+	probeKeyringCached()
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "must not reprobe before the TTL elapses")
+
+	// past TTL: must re-probe
+	TestSetKeyringProbeNow(func() time.Time { return now.Add(keyringProbeCacheTTL + time.Second) })
+	probeKeyringCached()
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "must reprobe once the TTL has elapsed")
+}
+
+// TestProbeKeyringCached_CachesFailureNotJustSuccess proves a failed probe
+// (keychain locked, unavailable, etc.) is cached too — not just successes.
+// Failure prevented: a broken keychain still gets hammered with a live
+// probe on every call because only the success path was memoized.
+func TestProbeKeyringCached_CachesFailureNotJustSuccess(t *testing.T) {
+	resetKeyringProbeState(t)
+
+	var calls int32
+	TestSetKeyringProbeFunc(func() bool {
+		atomic.AddInt32(&calls, 1)
+		return false
+	})
+
+	first := probeKeyringCached()
+	second := probeKeyringCached()
+
+	assert.False(t, first)
+	assert.False(t, second)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls),
+		"a failed probe must also be cached, not retried on every call")
+}
+
+// TestIsKeyringAvailable_ForceFileStorageNeverProbes proves the
+// forceFileStorage override still short-circuits before touching the
+// probe cache at all — the caching change must not alter this existing,
+// test-relied-upon contract (setupTestDir forces file storage in nearly
+// every other test in this package).
+func TestIsKeyringAvailable_ForceFileStorageNeverProbes(t *testing.T) {
+	resetKeyringProbeState(t)
+	setupTestDir(t) // sets forceFileStorage = true, restores on cleanup
+
+	TestSetKeyringProbeFunc(func() bool {
+		t.Fatal("live probe must never run when forceFileStorage is set")
+		return false
+	})
+
+	assert.False(t, isKeyringAvailable())
+}


### PR DESCRIPTION
## What broke

Users repeatedly saw macOS keychain access prompts for `sageox-keyring-probe` — described as "really annoying."

## Root cause (the real one, not just call frequency)

`isKeyringAvailable()` checked whether the OS keychain works by creating a throwaway probe entry, then immediately deleting it — on every single call:

```go
keyring.Set(keyringService, "sageox-keyring-probe", "probe")
keyring.Delete(keyringService, "sageox-keyring-probe")
```

That function is called (via `LoadCredentialsForEndpoint`) from the daemon's heartbeat and sync loops (roughly once a minute) and from most CLI commands touching git credentials — and every CLI invocation is a fresh process.

The deeper issue: `zalando/go-keyring`'s macOS backend shells out to `/usr/bin/security`. macOS Keychain ties an "Always Allow" access grant to a **specific item**. An item that gets created and destroyed on every check never persists long enough for any grant to stick — so every call re-triggered the access prompt, no matter how many times the user clicked "Always Allow." This wasn't primarily a call-frequency problem; the probe pattern itself was structurally incapable of ever being granted permanently.

```mermaid
flowchart TD
    A["isKeyringAvailable called"] --> B["Set 'sageox-keyring-probe'"]
    B --> C["macOS: new item,<br/>no existing grant"]
    C --> D["prompt: Allow / Always Allow / Deny"]
    D --> E["Delete the item immediately"]
    E --> F["grant discarded with the item"]
    F -->|"next call"| A
```

## What this PR ships

Two changes, in `internal/gitserver/credentials.go`:

1. **Stop creating a throwaway item.** `liveKeyringProbe` now reads the real, persistent credential slot (`keyringService`/`keyringUser` — the same one `ox login` actually stores into) via `keyring.Get`, instead of `Set`+`Delete` on a fake key. `ErrNotFound` is treated as "available" (the mechanism works, nothing stored yet) — not as a failure. Once the user grants access to that one persistent item (typically the first time ox stores or reads real credentials), the grant holds, because the item itself never gets destroyed by the availability check.
2. **Cache the result** (5 minute TTL) so the daemon's heartbeat/sync loops don't even re-check that often. Doesn't fix the root cause on its own — kept as defense in depth on top of (1).

```mermaid
flowchart TD
    A["isKeyringAvailable called"] --> B{"cached result<br/>within 5 min?"}
    B -->|"yes"| C["return cached result,<br/>no OS call at all"]
    B -->|"no"| D["Get the real credential slot<br/>(keyringService/keyringUser)"]
    D --> E{"err?"}
    E -->|"nil or ErrNotFound"| F["available — first access<br/>ever prompts once, then holds"]
    E -->|"anything else"| G["not available"]
```

## Your "Reset to Defaults" question

Don't use it — it's much more destructive than this needs. macOS's "Reset My Default Keychain" wipes **every** saved password for **every** app using your default keychain (Wi-Fi passwords, other apps' saved logins, everything), not just ox's.

If you ever do want to clear just ox's stored git credential and force a fresh `ox login`, the safe, targeted equivalent is:

```bash
security delete-generic-password -s sageox-git
```

That removes only the one item ox owns. Nothing else is touched. With this fix, you shouldn't need to reach for it just to stop the prompts, though — the prompt-loop was the bug, not something that needed a keychain reset to clear.

## Test plan

- `TestKeyringAvailableForErr_ClassifiesOutcomes` — the actual bug class: proves `ErrNotFound` is treated as "available," not "broken" (getting this backwards would make ox report a healthy keychain as broken for every user who hasn't logged in yet). Pure function, no real OS keychain touched, runs identically in CI and locally.
- `TestProbeKeyringCached_SecondCallWithinTTLDoesNotReprobe` / `_ReprobesAfterTTLExpires` / `_CachesFailureNotJustSuccess` — the caching layer, using an injectable clock (no `time.Sleep`) and an injectable probe function (no real keychain).
- `TestIsKeyringAvailable_ForceFileStorageNeverProbes` — proves the existing `forceFileStorage` test override (used by nearly every other test in this package) still short-circuits before ever touching the probe/cache, so this change can't break any of that pre-existing test suite.

All red-first verified (neutered the fix, confirmed the test failed for the intended reason, restored, confirmed green).

Verified clean: `go build ./...`, `go vet ./...`, `make lint` (0 issues), `go test ./internal/gitserver/...` (full suite).

## Note on `make test-slow`

Ran the full slow tier twice as part of the parallel v0.12.0 release-gate work. 5 failures both times, but a **different set** of tests each run, and the 2 that repeated (`TestIncrementalE2E_CtrlC_AntiEntropy`, `TestDistillHistoryRead_JR10_SinceJsonFormat_ParallelBodies`) are pre-existing E2E tests (`incremental_e2e_test.go` last touched by an unrelated 2026 commit, `#545`) with timing/count-based assertions against real subprocess hooks — unrelated to this change or anything else in this PR (`internal/gitserver` only). Confirmed via isolated single-test reruns. Not something this PR introduces or should block on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keychain availability detection by avoiding temporary credential writes.
  - Added short-term caching for keychain checks, reducing repeated access attempts.
  - Correctly handles unavailable, locked, or missing keychain scenarios.
  - Ensures file-based credential storage bypasses keychain checks when enabled.

- **Tests**
  - Added coverage for cached checks, expiration, failure handling, and keychain error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->