### PR TITLE
docs(release): rewrite release-note guidance to be capability-first

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -84,33 +84,46 @@ git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-merges
 
 ### Step 4: Update CHANGELOG.md
 
-Read the current CHANGELOG.md to understand the format. Then:
+Read `.claude/rules/releases.md`'s **Release Notes Guidelines** section first — it's the
+canonical source for release-note style, this step just applies it. The one question every
+bullet answers: **"As a user, what can I now do that I couldn't do before?"** Target bar:
+Conductor, Wispr Flow, Raycast, Linear, Arc — a reader understands the whole release in
+under a minute.
 
 1. Add a new version section at the top (after the header)
-2. Group changes by: Added, Changed, Fixed, Removed
-3. **Lead with customer value** — open each entry with what a coworker can now do, or the pain that's gone; benefit first, mechanism second (or dropped)
-4. NO commit hashes or PR numbers
-5. NO internal jargon — spell out the user-visible effect, never protocol/impl detail (SSE, CSP, OTLP, askpass, HTTP status codes, struct/field/signal names, file paths). Name the command and any `SAGEOX_*` env var; skip commit prefixes like "feat(scope):"
-6. Keep it crisp — one or two sentences per entry
-7. Use today's date in YYYY-MM-DD format
+2. Group changes by: `New`, `Improved`, `Fixed`, `Security` (security only when relevant)
+3. **Collapse related work into themes.** Ten engineering fixes are often one user-visible
+   improvement — merge aggressively rather than listing each one
+4. **Capability first, mechanism never** (unless it changes something the user can see) —
+   no internal architecture, algorithms, storage, migrations, daemon behavior, internal IDs
+5. NO commit hashes, PR numbers, or commit prefixes like "feat(scope):"
+6. NO internal jargon — spell out the user-visible effect, never protocol/impl detail (SSE,
+   CSP, OTLP, askpass, HTTP status codes, struct/field/signal names, file paths). Name the
+   command and any `SAGEOX_*` env var
+7. Keep it crisp — one or two sentences per entry, usually one, never a paragraph
+8. Use today's date in YYYY-MM-DD format
+9. Target roughly 3–8 New, 2–5 Improved, 3–8 Fixed. More than ~20 bullets total means it
+   hasn't been distilled enough — merge harder
 
 Example format:
 ```markdown
 ## [0.X.0] - YYYY-MM-DD
 
-### Added
-- **Feature Name**: Clear description of what users can now do
+### New
+- **Feature Name** — clear description of what users can now do
 
-### Changed
-- Description of behavior change
+### Improved
+- Description of the user-visible improvement (often merging several fixes/changes)
 
 ### Fixed
-- Bug that was affecting users
+- Bug that was affecting users, described by its user-visible effect
 ```
 
-Benefit-first vs. mechanism-first — the single most important rule:
+Capability-first vs. mechanism-first — the single most important rule:
 - ✅ **Publish a plan as a Claude Code Artifact** — a self-contained page that renders with no network access.
 - ❌ **CSP-safe artifact render** — drops the SSE loop and inlines the Mermaid CDN so the page passes Content-Security-Policy.
+- ✅ **Sync is significantly more reliable, including recovery from interrupted sessions and diverged history.**
+- ❌ "fixed sync / fixed retries / fixed divergence / fixed GPG / fixed daemon startup" (five bullets that are one user-visible theme)
 
 ### Step 5: Bump Version
 

--- a/.claude/rules/releases.md
+++ b/.claude/rules/releases.md
@@ -21,24 +21,73 @@ make bump-version NEW_VERSION=0.10.0
 
 ## Release Process
 
-1. **Agent prepares release notes** — update `CHANGELOG.md`. User experience first. Group by: Added, Changed, Fixed. NO commit hashes. NO auto-generated changelogs. See v0.7.0 for gold standard.
+1. **Agent prepares release notes** — update `CHANGELOG.md`. Follow Release Notes Guidelines below. NO commit hashes. NO auto-generated changelogs.
 2. **Agent asks human for version confirmation** — always ask. Default: bump middle number.
 3. **Human creates draft release** at github.com/sageox/ox/releases/new (tag: `v0.X.0`)
 4. **Human publishes** — automation handles binaries and signing
 
 ## Release Notes Guidelines
 
-**Lead with customer value — always.** Every entry opens with what a coworker can now *do*, or the pain that's gone. The benefit is the first thing read; the mechanism comes second and stays short, or is dropped. This applies to every release, not just polished ones.
+Release notes are not commit history, not engineering documentation, not implementation
+summaries. They answer one question: **"As a user, what can I now do that I couldn't do
+before?"** Assume the reader is an engineer who uses SageOx every day — they care about
+capabilities, not implementation, unless the implementation changes behavior they can see.
 
-**Good:** "**Publish a plan as a Claude Code Artifact** — a self-contained page that renders with no network access." Benefit first, plain language.
+**Target quality bar:** Conductor, Wispr Flow, Raycast, Linear, Arc Browser. Calm, concise,
+confident, product-focused, implementation-light. A reader should understand an entire
+release in under a minute.
 
-**Bad:** "**CSP-safe artifact render** — drops the SSE loop and inlines the Mermaid CDN so the page passes Content-Security-Policy." Mechanism first, internal jargon.
+**The test for every bullet:** would a customer ever describe the feature this way? If not,
+rewrite it. Never expose internal architecture, implementation details, algorithms, storage,
+migrations, daemon behavior, or internal IDs — those belong in the PR body, commit history,
+or architecture docs, not here.
 
-**Cut internal jargon.** No protocol/implementation acronyms or symbols in customer-facing notes: SSE, CSP, OTLP, askpass, 401/403, HTTP status codes, struct/field names, signal names, file paths. Name the command and any customer-facing env var (`SAGEOX_*`); translate everything else into the effect the user sees.
+- ✅ **Every recording now gets a permanent session link from the moment it starts.**
+- ❌ "Recordings now mint their stable session ID at recording start, persisted in the raw
+  header carrier, reused after daemon restart."
+- ✅ **`ox doctor` now catches Decision Record configuration issues before they affect your
+  workflow.**
+- ❌ "`ox doctor` now validates `decision.paths`."
+- ✅ **Search is more resilient under heavy concurrent usage.**
+- ❌ "Retries index corruption before self-heal fallback."
+- ✅ **Publish a plan as a Claude Code Artifact** — a self-contained page that renders with no
+  network access.
+- ❌ "CSP-safe artifact render — drops the SSE loop and inlines the Mermaid CDN so the page
+  passes Content-Security-Policy."
 
-**Crisp.** One or two sentences per entry. If a reader can't tell why they'd care by the end of the first line, rewrite it.
+**Collapse related work into themes — ruthlessly.** Ten engineering fixes are often one
+user-visible improvement. Don't write "fixed sync / fixed retries / fixed divergence / fixed
+GPG / fixed daemon startup." Write **"Sync is significantly more reliable, including recovery
+from interrupted sessions and diverged history."** If three bullets all improve the same
+feature, make one bullet.
 
-**Agent rules:** DO write benefit-first, human-focused notes; propose the version; confirm with human. DO NOT auto-generate changelogs from commits, include hashes/PR numbers, lead with the mechanism, or create tags without approval.
+**Organize around product concepts, not internal subsystems.** Categories: `New`, `Improved`,
+`Fixed`, `Security` (security only when relevant). Users think in workflows, not packages.
+
+**Cut internal jargon.** No protocol/implementation acronyms or symbols: SSE, CSP, OTLP,
+askpass, 401/403, HTTP status codes, struct/field names, signal names, file paths. Name the
+command and any customer-facing env var (`SAGEOX_*`); translate everything else into the
+effect the user sees.
+
+**Crisp.** One or two sentences per entry, usually one. Never a paragraph bullet. If a reader
+can't tell why they'd care by the end of the first line, rewrite it.
+
+**Tone: confident and matter-of-fact, never marketing hype.** No "game changing,"
+"revolutionary," or "best ever."
+
+**Target size:** roughly 3–8 New, 2–5 Improved, 3–8 Fixed (often summarized from many
+commits), Security only when relevant. More than ~20 bullets total means it hasn't been
+distilled enough — go back and merge harder.
+
+**Editing process:** read every change → group into themes → strip implementation detail →
+rewrite each bullet from the user's perspective → merge aggressively → delete anything that
+doesn't materially affect users → read the final release in under a minute → if it still
+reads like a commit log, rewrite it again.
+
+**Agent rules:** DO write capability-first, human-focused notes that pass the "would a
+customer describe it this way" test; propose the version; confirm with human. DO NOT
+auto-generate changelogs from commits, include hashes/PR numbers, narrate mechanism or
+internal architecture, or create tags without approval.
 
 **Release infra changes:** Consult `@oss-release-engineer` subagent first.
 


### PR DESCRIPTION
## What broke

Release notes had gradually drifted toward engineering changelogs — benefit-first in the opening clause, but often followed by implementation detail (daemon behavior, storage mechanics, internal IDs), and rarely merged: related fixes shipped as separate bullets instead of one theme.

## What this PR ships

Rewrites the release-note guidance in both places it lives, so they can't drift out of sync with each other:

- **`.claude/rules/releases.md`** — the canonical **Release Notes Guidelines** section, now built around one question: *"As a user, what can I now do that I couldn't do before?"*
- **`.claude/commands/release.md`** — the `/release` slash command's Step 4, now points at the rules file as the source of truth and applies the same principles inline.

### The core shift

| Before | Now |
|---|---|
| Categories: `Added`, `Changed`, `Fixed` | Categories: `New`, `Improved`, `Fixed`, `Security` |
| Benefit-first opening, mechanism often followed | Mechanism excluded entirely unless it's user-visible behavior |
| One bullet per fix | Related fixes collapsed into one thematic bullet |
| No size target | ~3–8 New, 2–5 Improved, 3–8 Fixed; >20 bullets total means "merge harder" |
| Target bar: unspecified | Target bar: Conductor, Wispr Flow, Raycast, Linear, Arc — read the whole release in under a minute |

### Concrete example — what already-published v0.12.0 would look like under the new rules

Not changing the published `[0.12.0]` entry (out of scope — it's already live), but here's the delta to make it concrete. Today's `### Fixed` section has 7 separate bullets for sync/distill/doctor/auth work. Under the new guidance, that becomes:

```markdown
### Improved
- Sync recovers automatically from far more failure scenarios — diverged history,
  an interrupted background cleanup, and commit-signing conflicts all self-heal
  instead of getting stuck, with any recovered work left for you to review.
- ox distill preserves partial progress instead of discarding a whole run over
  one bad day.
- ox doctor and ox query no longer silently skip checks or drop you mid-session.
```

7 bullets → 3. Each one describes a capability or a resolved pain point, not a subsystem.

## Test plan

Documentation-only change (`.claude/rules/releases.md`, `.claude/commands/release.md`) — no code paths affected. Verified:
- No stray references to the old category names (`Added`/`Changed`/`Removed`) remain in either file
- No stray references to the removed "see v0.7.0 for gold standard" pointer (v0.7.0 predates this bar and isn't a reliable example of it)
- Grepped the repo for other release-note conventions (skills, templates, docs, GitHub workflows, GoReleaser config) — confirmed these two files are the only two that define release-note *writing* style; everything else (GoReleaser, GitHub Actions) is mechanical publishing and explicitly preserves human/agent-written notes untouched (`goreleaser.yml`: `changelog: disable: true`, `release: mode: keep`)

## Judgment calls made

- **Renamed categories** (`Added`/`Changed` → `New`/`Improved`) per the new guidance's explicit "organize around product concepts" example set. Did **not** retroactively rewrite the 19 existing historical `CHANGELOG.md` version sections — those stay as published; the new categories apply going forward.
- **Removed the "See v0.7.0 for gold standard" pointer** rather than replacing it with a new example release, since no existing published release fully reflects the new bar yet (ruthless thematic merging is new). The good/bad examples are now embedded directly in the guidance instead.
