### PR TITLE
fix(session): accept skip-shaped LLM summaries; finalize ledger skips in place

### DIFF
--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -1047,16 +1047,36 @@ func (h *SessionFinalizeHandler) ProcessResult(item *WorkItem, result *RunResult
 	}
 
 	if disposition == session.QualityDiscard {
-		h.logger.Info("session below discard threshold, removing",
-			"session", sessionName,
-			"quality_score", summaryResp.QualityScore,
-			"threshold", h.qualityDiscardThreshold,
-			"reason", summaryResp.ScoreReason,
-		)
-		if err := os.RemoveAll(payload.SessionDir); err != nil {
-			h.logger.Warn("failed to remove low-quality session", "session", sessionName, "err", err)
+		if isGitTrackedLedgerSession(payload.SessionDir, payload.LedgerPath) {
+			// The session already lives in the ledger's git-tracked
+			// sessions/ tree — discard-by-deletion is broken both ways
+			// there: an uncommitted deletion is resurrected by the next
+			// pull/checkout (so anti-entropy re-detects it forever), and
+			// an auto-committed deletion would erase teammates' shared
+			// session history. Finalize it in place instead: keep the
+			// content, write the skip summary and a clean meta.json
+			// (SummaryStatus=ok) so every machine stops re-detecting it.
+			if strings.TrimSpace(summaryResp.Title) == "" {
+				summaryResp.Title = "Brief session" // same default as the prefilter
+			}
+			h.logger.Info("skip-quality session already on ledger, finalizing in place",
+				"session", sessionName,
+				"quality_category", summaryResp.QualityCategory,
+				"reason", summaryResp.ScoreReason,
+			)
+			disposition = session.QualityUpload
+		} else {
+			h.logger.Info("session below discard threshold, removing",
+				"session", sessionName,
+				"quality_score", summaryResp.QualityScore,
+				"threshold", h.qualityDiscardThreshold,
+				"reason", summaryResp.ScoreReason,
+			)
+			if err := os.RemoveAll(payload.SessionDir); err != nil {
+				h.logger.Warn("failed to remove low-quality session", "session", sessionName, "err", err)
+			}
+			return nil
 		}
-		return nil
 	}
 
 	// use cached session from BuildPrompt, fall back to re-reading
@@ -1353,6 +1373,23 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	}
 
 	return fileRefs, nil
+}
+
+// isGitTrackedLedgerSession reports whether sessionDir is a session
+// directory inside the ledger's git-tracked sessions/ tree — as opposed to
+// a recording cache (<ledger>/.sageox/cache/sessions/ or an XDG cache dir),
+// where deletion is a purely local operation. Sessions in the tracked tree
+// are shared team history: removing them from the working tree without a
+// committed deletion just gets reverted by the next pull/checkout.
+func isGitTrackedLedgerSession(sessionDir, ledgerPath string) bool {
+	if ledgerPath == "" {
+		return false
+	}
+	trackedDir := filepath.Join(ledgerPath, "sessions")
+	if filepath.Clean(sessionDir) == filepath.Clean(trackedDir) {
+		return false // the sessions/ root itself is not a session dir
+	}
+	return strings.HasPrefix(filepath.Clean(sessionDir)+string(filepath.Separator), filepath.Clean(trackedDir)+string(filepath.Separator))
 }
 
 // isInLedgerCacheDir reports whether sessionDir is inside the ledger's

--- a/internal/daemon/agentwork/session_finalize_summary_test.go
+++ b/internal/daemon/agentwork/session_finalize_summary_test.go
@@ -511,8 +511,19 @@ func TestParseSummaryJSON(t *testing.T) {
 }
 
 func TestProcessResult_QualityScoreDiscard(t *testing.T) {
+	// Discard-by-deletion only applies to sessions in a recording cache —
+	// git-tracked ledger sessions are finalized in place instead (see
+	// TestProcessResult_SkipOnLedger_FinalizesInPlace). Stage the session
+	// in the ledger's gitignored cache dir.
 	ledgerPath := createTestSession(t, "test-discard", nil)
-	sessionDir := filepath.Join(ledgerPath, "sessions", "test-discard")
+	trackedDir := filepath.Join(ledgerPath, "sessions", "test-discard")
+	sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "test-discard")
+	if err := os.MkdirAll(filepath.Dir(sessionDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(trackedDir, sessionDir); err != nil {
+		t.Fatal(err)
+	}
 
 	handler := NewSessionFinalizeHandlerForTest(slog.Default())
 	handler.SetQualityThresholds(0.3, 0.1)
@@ -546,6 +557,109 @@ func TestProcessResult_QualityScoreDiscard(t *testing.T) {
 	if _, statErr := os.Stat(sessionDir); !os.IsNotExist(statErr) {
 		t.Error("expected session directory to be removed for quality below discard threshold")
 	}
+}
+
+// TestProcessResult_SkipOnLedger_FinalizesInPlace is the regression test for
+// the 2026-07 ledger anti-entropy incident. A session that already lives in
+// the git-tracked ledger sessions/ tree gets a skip verdict from the LLM
+// (fenced JSON, no key_actions — the exact shape the parser used to reject).
+// The daemon must NOT delete the directory (an uncommitted deletion is
+// resurrected by the next pull, so detection loops forever; a committed one
+// erases shared history). Instead it finalizes in place: skip summary
+// written, meta.json marked ok, .needs-summary marker cleared.
+func TestProcessResult_SkipOnLedger_FinalizesInPlace(t *testing.T) {
+	ledgerPath := createTestSession(t, "2026-05-12T05-59-ajit-OxSKIP", nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", "2026-05-12T05-59-ajit-OxSKIP")
+
+	// git-tracked marker, as committed by doctor auto-commit in the incident
+	markerPath := filepath.Join(sessionDir, ".needs-summary")
+	require.NoError(t, os.WriteFile(markerPath, []byte(`{"cache_dir":"`+sessionDir+`"}`), 0644))
+
+	handler := NewSessionFinalizeHandlerForTest(slog.Default())
+	handler.SetQualityThresholds(0.3, 0.1)
+
+	item := &WorkItem{
+		ID:       "test-skip-ledger",
+		Type:     sessionFinalizeType,
+		DedupKey: "session-finalize:2026-05-12T05-59-ajit-OxSKIP",
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+
+	// verbatim incident shape: fenced skip JSON, no key_actions
+	result := &RunResult{
+		Output: "```json\n" +
+			`{"quality_category":"skip","score_reason":"Routine maintenance task with no broader insight or decision-making.","title":"Remove worktree and local branch"}` +
+			"\n```",
+	}
+
+	require.NoError(t, handler.ProcessResult(item, result))
+
+	// the session dir must survive — it is shared team history
+	require.DirExists(t, sessionDir, "git-tracked ledger session must not be deleted on skip")
+
+	// skip summary written with the LLM's title
+	summaryData, err := os.ReadFile(filepath.Join(sessionDir, "summary.json"))
+	require.NoError(t, err, "summary.json must be written for in-place skip finalize")
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(summaryData, &summary))
+	assert.Equal(t, "Remove worktree and local branch", summary["title"])
+	assert.Equal(t, "skip", summary["quality_category"])
+
+	// meta.json must be terminal-clean so detection and the daily
+	// inline-summary-retry autofix stop re-arming this session
+	metaData, err := os.ReadFile(filepath.Join(sessionDir, "meta.json"))
+	require.NoError(t, err, "meta.json must be written for in-place skip finalize")
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(metaData, &meta))
+	assert.Equal(t, "ok", meta["summary_status"], "meta must be marked ok, not failed_validation")
+	if ve, ok := meta["validation_error"].(string); ok {
+		assert.NotContains(t, ve, "title too short")
+	}
+
+	// marker cleared → the uncapped HasNeedsSummaryMarker branch goes quiet
+	_, statErr := os.Stat(markerPath)
+	assert.True(t, os.IsNotExist(statErr), ".needs-summary marker must be cleared")
+}
+
+// TestProcessResult_SkipTitleDefault verifies a title-less skip verdict on a
+// ledger-resident session gets the prefilter's "Brief session" default —
+// an empty title in summary.json would re-trigger shouldRetryEmptySummary
+// detection and restart the loop the in-place finalize exists to end.
+func TestProcessResult_SkipTitleDefault(t *testing.T) {
+	ledgerPath := createTestSession(t, "2026-05-12T06-00-ajit-OxSKP2", nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", "2026-05-12T06-00-ajit-OxSKP2")
+
+	handler := NewSessionFinalizeHandlerForTest(slog.Default())
+	handler.SetQualityThresholds(0.3, 0.1)
+
+	item := &WorkItem{
+		ID:       "test-skip-title",
+		Type:     sessionFinalizeType,
+		DedupKey: "session-finalize:2026-05-12T06-00-ajit-OxSKP2",
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+	result := &RunResult{
+		Output: `{"quality_category":"skip","score_reason":"No substantive work."}`,
+	}
+
+	require.NoError(t, handler.ProcessResult(item, result))
+	require.DirExists(t, sessionDir)
+
+	summaryData, err := os.ReadFile(filepath.Join(sessionDir, "summary.json"))
+	require.NoError(t, err)
+	var summary map[string]any
+	require.NoError(t, json.Unmarshal(summaryData, &summary))
+	assert.Equal(t, "Brief session", summary["title"], "title-less skip must default to the prefilter title")
 }
 
 // TestProcessResult_ValidationFailure_UploadsFallbackStub pins down the
@@ -597,8 +711,19 @@ func TestProcessResult_ValidationFailure_UploadsFallbackStub(t *testing.T) {
 // as QualityUpload, causing empty "No Activity Recorded" sessions to reach the
 // team ledger.
 func TestProcessResult_EmptySessionLLMScoreZero_Discarded(t *testing.T) {
+	// The leak this guards (#525) happens on the cache→ledger upload path —
+	// discard-by-deletion applies to recording-cache sessions. Git-tracked
+	// ledger sessions are finalized in place instead (see
+	// TestProcessResult_SkipOnLedger_FinalizesInPlace).
 	ledgerPath := createTestSession(t, "test-empty-zero", nil)
-	sessionDir := filepath.Join(ledgerPath, "sessions", "test-empty-zero")
+	trackedDir := filepath.Join(ledgerPath, "sessions", "test-empty-zero")
+	sessionDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", "test-empty-zero")
+	if err := os.MkdirAll(filepath.Dir(sessionDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(trackedDir, sessionDir); err != nil {
+		t.Fatal(err)
+	}
 
 	handler := NewSessionFinalizeHandlerForTest(slog.Default())
 	handler.SetQualityThresholds(0.3, 0.1)

--- a/pkg/sessionsummary/parse.go
+++ b/pkg/sessionsummary/parse.go
@@ -65,7 +65,22 @@ func ParseSummaryJSON(output string) (*SummarizeResponse, error) {
 // least one entry — both fields are explicitly requested by
 // BuildSummaryPrompt, so their absence indicates the LLM did not
 // actually summarize.
+//
+// Skip-shape exception (mirrors ValidateSummaryContent's skip contract):
+// when the LLM judges a session quality_category "skip", it legitimately
+// has no key_actions — nothing was accomplished — and may carry only a
+// title and score_reason. Rejecting that shape here funneled every skip
+// verdict into the unparsable-output branch, which fabricated a blank
+// stub that then failed validation with "title too short (0 chars)" —
+// a permanent, daily-retried failure-stub state for trivial sessions
+// (the 2026-07 ledger anti-entropy incident). A skip response is
+// accepted when it carries a non-empty score_reason or title, so
+// incidental fenced text that merely round-trips the struct still
+// fails the gate.
 func summaryHasContent(r *SummarizeResponse) bool {
+	if r.QualityCategory == QualityCategorySkip {
+		return strings.TrimSpace(r.ScoreReason) != "" || strings.TrimSpace(r.Title) != ""
+	}
 	if strings.TrimSpace(r.Title) == "" {
 		return false
 	}

--- a/pkg/sessionsummary/parse_test.go
+++ b/pkg/sessionsummary/parse_test.go
@@ -97,6 +97,48 @@ func TestParseSummaryJSON_MissingKeyActionsRejected(t *testing.T) {
 	}
 }
 
+// TestParseSummaryJSON_SkipShapeAccepted pins the skip-shape contract at the
+// parse layer: a quality_category="skip" response legitimately carries no
+// key_actions (nothing was accomplished), and must parse so it can flow to
+// EvaluateQualityCategory instead of the unparsable-output fallback. The
+// pre-fix behavior — rejecting skip shapes for missing key_actions — put
+// every skip-worthy session into a permanent "title too short" failure-stub
+// loop (2026-07 ledger anti-entropy incident).
+func TestParseSummaryJSON_SkipShapeAccepted(t *testing.T) {
+	cases := map[string]string{
+		"raw skip, title + reason": `{"quality_category":"skip","score_reason":"Routine maintenance, no insight.","title":"Remove worktree"}`,
+		"raw skip, reason only":    `{"quality_category":"skip","score_reason":"Single Q&A, no work performed."}`,
+		"fenced skip (incident shape)": "```json\n" +
+			`{"quality_category":"skip","score_reason":"Task assignment only; no review work performed.","title":"Security Review Task Assignment"}` +
+			"\n```",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			resp, err := ParseSummaryJSON(input)
+			require.NoError(t, err, "skip-shaped response must parse without key_actions")
+			require.Equal(t, QualityCategorySkip, resp.QualityCategory)
+		})
+	}
+}
+
+// TestParseSummaryJSON_SkipShapeStillGated verifies the skip exception does
+// not reopen the incidental-fenced-text hole the gate exists for: a skip
+// category with neither title nor score_reason is still rejected, and
+// non-skip responses still require key_actions.
+func TestParseSummaryJSON_SkipShapeStillGated(t *testing.T) {
+	cases := map[string]string{
+		"skip with no title or reason":      `{"quality_category":"skip"}`,
+		"skip with whitespace-only fields":  `{"quality_category":"skip","score_reason":"  ","title":"\n"}`,
+		"non-skip category, no key_actions": `{"quality_category":"share","title":"Real Title","summary":"x","outcome":"success"}`,
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseSummaryJSON(input)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestEntriesFromRaw(t *testing.T) {
 	ts := "2026-03-24T10:00:00.000Z"
 	raw := []map[string]any{


### PR DESCRIPTION
## What broke

The root cause of the 2026-07 sageox-monorepo ledger anti-entropy incident (711/297 divergence, 1,970 futile re-finalizations on one machine, ~136 sessions stuck in a daily retry loop fleet-wide):

- **`ParseSummaryJSON` rejects the LLM's own skip verdict.** Its acceptance gate requires `key_actions` — but a `quality_category: "skip"` response legitimately has none (nothing was accomplished). The parser discards valid JSON as "no valid summary JSON found".
- The daemon then fabricates a **blank stub**, which its validator rejects with the red-herring `title too short (0 chars)` — grading the daemon's own placeholder, not the LLM output. The stub is committed to the ledger.
- The `failed_validation` + "title too short" meta makes the session **eligible for the daily `session-inline-summary-retry` autofix**, which resets `summary_attempts` to 0 and re-arms the session — every 24h, on every machine, forever. Summarization is deterministically impossible, so the loop never converges.
- The irony: `ValidateSummaryContent` has an explicit skip-shape bypass that never runs, because the parser kills skip responses first — and the parser gate's comment says it exists to *prevent* "a permanent failure-stub state".

```mermaid
flowchart LR
    A[LLM: quality_category=skip<br/>no key_actions] -->|rejected by<br/>parse gate| B[blank stub<br/>title '']
    B -->|validator grades stub| C[failed_validation:<br/>'title too short']
    C -->|committed to ledger| D[daily autofix resets<br/>attempts, rewrites marker]
    D -->|uncapped marker<br/>detection| A
```

## What this PR ships

- **`pkg/sessionsummary/parse.go`** — `summaryHasContent` accepts skip-shaped responses (`quality_category == "skip"`) without `key_actions`, gated on a non-empty `score_reason` or `title` so incidental fenced text still fails. Non-skip responses are gated exactly as before. This aligns the parser with the validator's existing skip contract.
- **`internal/daemon/agentwork/session_finalize.go`** — a skip/discard verdict on a session in the **git-tracked ledger `sessions/` tree** no longer deletes the directory. Deletion there is broken both ways: uncommitted deletions are resurrected by the next pull (detection loops forever), committed ones erase teammates' shared history. Instead the session is **finalized in place**: skip summary written (title defaults to `"Brief session"`, matching the prefilter), `summary_status: ok` in meta.json, `.needs-summary` marker cleared, committed once. That terminal state syncs fleet-wide and retires the session from every machine's loop. Cache-resident sessions still discard-by-delete as designed. New helper: `isGitTrackedLedgerSession`.

## Test Plan

- [x] New: `TestParseSummaryJSON_SkipShapeAccepted` (raw, reason-only, and the verbatim fenced incident shape) and `TestParseSummaryJSON_SkipShapeStillGated` (empty skips and non-skip-without-key_actions still rejected)
- [x] New: `TestProcessResult_SkipOnLedger_FinalizesInPlace` — ledger session survives, summary carries the LLM title, meta is `ok`, marker cleared
- [x] New: `TestProcessResult_SkipTitleDefault` — title-less skip gets "Brief session" (an empty title would re-trigger `shouldRetryEmptySummary`)
- [x] Verified red-without-fix: stashing the source changes fails the new parser suite + both finalize tests
- [x] Two pre-existing discard tests (`QualityScoreDiscard`, the #525 empty-session regression) moved their fixtures to the ledger *cache* dir — the leak they guard happens on the cache→upload path, and discard-by-delete now only applies there
- [x] `go test ./pkg/sessionsummary/ ./internal/daemon/agentwork/` green; `make lint` 0 issues

## Field validation

Deployed locally (0.12.0 + this patch) during incident recovery: the previously-stuck sessions finalize in place on first attempt (skip summary, `ok` meta, marker cleared, push fast-forwards). Follow-up hardening still worth separate issues: bound the daily autofix reset, stop writing markers into the git-tracked dir (`meta_repair.go`), exclude `.needs-summary` from doctor auto-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Skip-reviewed sessions stored in the ledger are now preserved and finalized instead of being deleted.
  * Finalized sessions receive a default title, “Brief session,” when no title is provided.
  * Skip results are now accepted even when they do not include key actions, provided supporting details are present.
  * Invalid or incomplete skip results continue to be rejected.
* **Reliability**
  * Session metadata and summaries are consistently written and finalized for supported skip outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->