### PR TITLE
feat(prime): detect Buzz orchestrator, tailor whisper/murmur guidance

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -777,6 +777,17 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 			"Run your first murmur NOW: describe what the user asked and which code areas you expect to touch."
 	}
 
+	// orchestrator directive — Buzz (block/buzz) spawns the agent through its
+	// buzz-acp ACP harness, which does not fire the lifecycle hooks SageOx uses
+	// to PUSH whispers into a turn. So under Buzz the agent must PULL them, and
+	// publish its own status, by hand. Gated on the detected orchestrator; a
+	// clean no-op for every other environment.
+	if useragent.OrchestratorType() == string(agentx.AgentTypeBuzz) {
+		output.OrchestratorDirective = "Running under Buzz (buzz-acp): SageOx push-whispers rely on agent lifecycle hooks that Buzz does not fire, so teammates' signals will NOT arrive automatically here. Stay in sync by hand:\n" +
+			fmt.Sprintf("  • Pull teammates' murmurs yourself — run `ox agent %s whisper` periodically (e.g. every ~20 tool calls)\n", agentID) +
+			"  • Publish your own WIP so teammates see it — ox murmur --topic=wip \"concise description (≤500 bytes)\""
+	}
+
 	// build pre-assembled notification for JSON-consuming agents.
 	// this duplicates the logic in outputAgentPrimeText so JSON consumers
 	// don't have to assemble the notification from individual fields.

--- a/cmd/ox/agent_prime_orchestrator_test.go
+++ b/cmd/ox/agent_prime_orchestrator_test.go
@@ -13,20 +13,52 @@ import (
 // ORCHESTRATOR_ENV=buzz. This is what lets `ox agent prime` stamp
 // X-Orchestrator: buzz (cmd/ox/agent_prime.go).
 //
-// Uses DetectByType (not OrchestratorType) on purpose: it targets the Buzz
-// agent directly, so the assertion stays deterministic even on a host that also
+// Uses DetectByType (not OrchestratorType) on purpose: it targets a specific
+// agent type, so the assertion stays deterministic even on a host that also
 // sets another orchestrator's env vars (e.g. CONDUCTOR_WORKSPACE_NAME), where
 // the global DetectOrchestrator winner would be registry-iteration-order
-// dependent. DetectByType also returns an error if Buzz was never registered,
-// so this catches a dropped setup.go registration too.
+// dependent. DetectByType also returns an error for an unregistered type, so the
+// unregistered-type row both documents that contract and proves the buzz row's
+// no-error result is a meaningful registration signal (not a vacuous pass).
 func TestBuzzOrchestratorRegistered(t *testing.T) {
-	t.Setenv("ORCHESTRATOR_ENV", "buzz")
-
-	detected, err := agentx.NewDetector().DetectByType(context.Background(), agentx.AgentTypeBuzz)
-	if err != nil {
-		t.Fatalf("DetectByType(buzz) errored — Buzz orchestrator not registered? %v", err)
+	tests := []struct {
+		name         string
+		agentType    agentx.AgentType
+		orchestrator string
+		wantErr      bool
+		wantDetected bool
+	}{
+		{
+			name:         "buzz registered and detects ORCHESTRATOR_ENV=buzz",
+			agentType:    agentx.AgentTypeBuzz,
+			orchestrator: "buzz",
+			wantDetected: true,
+		},
+		{
+			name:         "unregistered type returns not-registered error",
+			agentType:    agentx.AgentType("definitely-not-an-orchestrator"),
+			orchestrator: "buzz",
+			wantErr:      true,
+		},
 	}
-	if !detected {
-		t.Fatal("Buzz orchestrator did not detect ORCHESTRATOR_ENV=buzz after agentx v0.1.11 bump")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ORCHESTRATOR_ENV", tt.orchestrator)
+
+			detected, err := agentx.NewDetector().DetectByType(context.Background(), tt.agentType)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("DetectByType(%q) = nil error, want a not-registered error", tt.agentType)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DetectByType(%q) errored — Buzz orchestrator not registered? %v", tt.agentType, err)
+			}
+			if detected != tt.wantDetected {
+				t.Fatalf("DetectByType(%q) detected = %v, want %v", tt.agentType, detected, tt.wantDetected)
+			}
+		})
 	}
 }

--- a/cmd/ox/agent_prime_orchestrator_test.go
+++ b/cmd/ox/agent_prime_orchestrator_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sageox/agentx"
+)
+
+// TestBuzzOrchestratorRegistered guards the agentx v0.1.11 bump: the Buzz
+// orchestrator must be registered in the default registry (populated via the
+// `_ "github.com/sageox/agentx/setup"` blank import in main.go) and must detect
+// ORCHESTRATOR_ENV=buzz. This is what lets `ox agent prime` stamp
+// X-Orchestrator: buzz (cmd/ox/agent_prime.go).
+//
+// Uses DetectByType (not OrchestratorType) on purpose: it targets the Buzz
+// agent directly, so the assertion stays deterministic even on a host that also
+// sets another orchestrator's env vars (e.g. CONDUCTOR_WORKSPACE_NAME), where
+// the global DetectOrchestrator winner would be registry-iteration-order
+// dependent. DetectByType also returns an error if Buzz was never registered,
+// so this catches a dropped setup.go registration too.
+func TestBuzzOrchestratorRegistered(t *testing.T) {
+	t.Setenv("ORCHESTRATOR_ENV", "buzz")
+
+	detected, err := agentx.NewDetector().DetectByType(context.Background(), agentx.AgentTypeBuzz)
+	if err != nil {
+		t.Fatalf("DetectByType(buzz) errored — Buzz orchestrator not registered? %v", err)
+	}
+	if !detected {
+		t.Fatal("Buzz orchestrator did not detect ORCHESTRATOR_ENV=buzz after agentx v0.1.11 bump")
+	}
+}

--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -492,6 +492,11 @@ func outputAgentPrimeXML(cmd *cobra.Command, output agentPrimeOutput) (*prime.Co
 		sb.WriteString(escapeXML(output.MurmurDirective))
 		sb.WriteString("\n")
 	}
+	// orchestrator directive — runtime-specific coordination guidance (e.g. Buzz: pull whispers by hand)
+	if output.OrchestratorDirective != "" {
+		sb.WriteString(escapeXML(output.OrchestratorDirective))
+		sb.WriteString("\n")
+	}
 	sb.WriteString("</session-context>\n")
 
 	// user notices: messages that agents must relay to the user (upgrade, restart, support)

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -272,6 +272,33 @@ func TestOutputAgentPrimeXML_SurfacesOpenPlanFeedback(t *testing.T) {
 	}
 }
 
+// TestOutputAgentPrimeXML_OrchestratorDirective verifies the buzz-conditional
+// coordination guidance is emitted into prime output when set, and is a clean
+// no-op when empty.
+// Failure prevented: OrchestratorDirective is populated for a Buzz session but
+// the XML writer silently drops it, so the agent never learns push-whispers are
+// off and must be pulled with `ox agent <id> whisper`.
+func TestOutputAgentPrimeXML_OrchestratorDirective(t *testing.T) {
+	render := func(directive string) string {
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetOut(&buf)
+		if _, err := outputAgentPrimeXML(cmd, agentPrimeOutput{
+			AgentID: "a", Status: "fresh", OrchestratorDirective: directive,
+		}); err != nil {
+			t.Fatalf("outputAgentPrimeXML: %v", err)
+		}
+		return buf.String()
+	}
+	xml := render("Running under Buzz (buzz-acp): push-whispers do not fire; pull with ox agent a whisper")
+	if !strings.Contains(xml, "Running under Buzz") || !strings.Contains(xml, "ox agent a whisper") {
+		t.Errorf("orchestrator directive must be emitted verbatim, got:\n%s", xml)
+	}
+	if strings.Contains(render(""), "Running under Buzz") {
+		t.Error("an empty orchestrator directive must emit nothing")
+	}
+}
+
 func TestOutputAgentPrimeXML_PRAttribution_DifferentValues(t *testing.T) {
 	// ensures PR line renders output.Attribution.PR, not output.Attribution.Commit
 	var buf bytes.Buffer

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/sageox/agentx v0.1.10
+	github.com/sageox/agentx v0.1.11
 	github.com/sageox/frictionax v0.1.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sageox/agentx v0.1.10 h1:uLDo3p5YdKThMIHqcq+vPApI8n484UODNu/RVZzG92g=
-github.com/sageox/agentx v0.1.10/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
+github.com/sageox/agentx v0.1.11 h1:GBmdWTUZGmGcuOlVn6sO08pFXgR8zHI3dDA23YgSurY=
+github.com/sageox/agentx v0.1.11/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
 github.com/sageox/frictionax v0.1.2 h1:iQfssC1g/vVdGXi55smMfY5/4JKcQbJXRzcwrQWiNLo=
 github.com/sageox/frictionax v0.1.2/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/internal/prime/types.go
+++ b/internal/prime/types.go
@@ -397,6 +397,10 @@ type Output struct {
 	ObservationDirective string `json:"observation_directive,omitempty"` // proactive instruction to record observations via ox memory put
 	// Murmur directive (behavioral — set when murmuring: "auto")
 	MurmurDirective string `json:"murmur_directive,omitempty"` // proactive instruction to publish WIP status via ox murmur
+	// Orchestrator directive (behavioral — set when the session runs under an
+	// orchestrator whose runtime changes how ox coordination reaches the agent,
+	// e.g. Buzz, where lifecycle hooks don't fire so push-whispers must be pulled)
+	OrchestratorDirective string `json:"orchestrator_directive,omitempty"`
 	// Current user identity (so agents can distinguish self vs teammate)
 	// Multiple aliases because sessions, murmurs, and discussions each use different name forms.
 	// This is local-only context (not persisted to ledger), so full name is safe here.


### PR DESCRIPTION
## Summary

Makes `ox` recognize when it's running under Block's **Buzz** ([block/buzz](https://github.com/block/buzz)) — whose `buzz-acp` ACP harness spawns Claude Code / Codex as sub-agents — and adapt its coordination guidance, since Buzz does not fire the lifecycle hooks SageOx normally relies on.

Two parts:

- **Detection** — bumps `github.com/sageox/agentx` `v0.1.10 → v0.1.11` (merged as [sageox/agentx#12](https://github.com/sageox/agentx/pull/12)), which adds `AgentTypeBuzz` + a new `Environment.ProcessAncestry()` probe. Buzz sets **no marker env var** on the child, so the reliable signal is that `buzz-acp` is always a **process ancestor** of the agent. `ox agent prime` already stamps `agentx.OrchestratorType()` as the `X-Orchestrator` header, so once the dep resolves Buzz, detection flows with no change to that call site.
- **Guidance** (the ox code here) — when the detected orchestrator is `buzz`, prime emits a new `OrchestratorDirective`: under Buzz, real-time **push-whispers don't arrive** (they ride hooks Buzz doesn't fire), so the agent is told to **pull** teammates' signals with `ox agent <id> whisper` and publish its own with `ox murmur`. A clean no-op for every other environment.

```mermaid
flowchart LR
    Buzz["buzz-acp"] -->|"spawns via ACP"| Agent["Claude / Codex"]
    Agent -->|"runs ox agent prime"| DET{"orchestrator is buzz?"}
    DET -->|"yes"| G["emit directive: pull whispers<br/>via ox agent id whisper"]
    DET -->|"no"| N["normal prime output"]
    G --> HDR["X-Orchestrator: buzz on API calls"]
```

**Change surface (ox):**

| File | Change |
|------|--------|
| `go.mod` / `go.sum` | agentx `v0.1.10 → v0.1.11` (Buzz detection) |
| `internal/prime/types.go` | new `OrchestratorDirective` field on prime `Output` |
| `cmd/ox/agent_prime.go` | populate it when `OrchestratorType() == buzz` |
| `cmd/ox/agent_prime_xml.go` | emit it in the XML session-context (mirrors `MurmurDirective`) |
| `cmd/ox/*_test.go` | registration/detection guard + directive-emission test |

**Scope note:** this is the interim, hook-independent shell path (agent runs `ox murmur` / `ox agent whisper`). The durable MCP-based path (an `ox_murmur` tool forwarded over ACP `session/new`) is deferred and tracked separately — it needs `ox mcp serve`, which doesn't exist yet.

## Test Plan

- **agentx (v0.1.11):** table-driven `Detect` (env hatch, `BUZZ_ACP_AGENT_COMMAND`, ancestry hit deep/prefixed, plus negative guards that `BUZZ_RELAY_URL`/`BUZZ_PRIVATE_KEY` alone do **not** detect) + a pure `walkAncestry` parser test (malformed rows, comm-with-spaces, self-parent loop, 20-level cap, PID-1 exclusion). `make test` + `golangci-lint` green; ancestry probe validated on a live host (returned `[go zsh claude conductor-runtime conductor]` — correctly surfaced the real orchestrator).
- **ox (this PR):** `TestBuzzOrchestratorRegistered` (Buzz registered in the default registry **and** detects `ORCHESTRATOR_ENV=buzz` — deterministic via `DetectByType`, so it doesn't flake when the host also sets Conductor env vars) and `TestOutputAgentPrimeXML_OrchestratorDirective` (directive emitted when set, no-op when empty). `make lint` → 0 issues; `make test` → 16,879 passed, 0 failed.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added
- [x] CHANGELOG entry added — agentx side ships the `v0.1.11` entry; the ox side is additive guidance (no user-facing CLI/behavior change beyond a prime directive), so no ox CHANGELOG entry
- [x] Breaking change — none. The agentx `Environment` interface gained a method, verified non-breaking for ox (no ox-side implementers; full build + tests pass)
- [x] Ran `/security-review` — N/A. No auth/MCP/session-writer/redaction/upgrade code touched; the only `go.sum` change is the agentx version bump (a SageOx-owned module reviewed in sageox/agentx#12)

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for sessions running under Buzz when automatic teammate updates are unavailable.
  * Buzz sessions now receive instructions to manually retrieve teammate murmurs and publish work-in-progress updates.
  * The guidance is included in session startup output when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->