### PR TITLE
feat(schema): publish raw.jsonl JSON Schema at a stable public $id

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -91,6 +91,7 @@ The following components are licensed under the Apache License, Version 2.0:
 - github.com/opencontainers/go-digest - Copyright (c) Open Container Initiative
 - github.com/opencontainers/image-spec - Copyright (c) Open Container Initiative
 - github.com/pjbgf/sha1cd - Copyright (c) Paulo Gomes
+- github.com/santhosh-tekuri/jsonschema - Copyright (c) Santhosh Kumar Tekuri
 - github.com/spf13/cobra - Copyright (c) Steve Francia
 - go.opentelemetry.io/auto/sdk - Copyright (c) OpenTelemetry Authors
 - go.opentelemetry.io/contrib - Copyright (c) OpenTelemetry Authors

--- a/docs/specs/session-raw-jsonl.md
+++ b/docs/specs/session-raw-jsonl.md
@@ -2,6 +2,19 @@
 
 The `raw.jsonl` file is the primary session recording format produced by `ox session start/stop`. Each line is a valid JSON object. The file captures an agent-to-human conversation session with full provenance for replay, summarization, and auditing.
 
+## Machine-Readable Schema
+
+A published JSON Schema for a single `raw.jsonl` line lives at
+[`schema/v1/raw-jsonl.schema.json`](../../schema/v1/raw-jsonl.schema.json)
+(`$id`: `https://sageox.ai/schemas/session/v1/raw-jsonl.schema.json`, MIT).
+It is validated in CI against this repo's session fixtures **and** against live
+`SessionWriter` output, so it describes what ox actually writes rather than what
+this document wishes were true.
+
+This document stays normative for everything a per-line schema cannot express:
+line ordering, completeness, secret redaction, and the PII boundary on
+`username`. Where the two disagree, that is a bug — please file it.
+
 ## Completeness Requirement
 
 **`raw.jsonl` MUST contain the complete, unfiltered output from the coding agent.** Every conversation turn — user messages, assistant responses, tool calls, tool results, and system messages — must be included verbatim. Do not summarize, truncate, or selectively omit entries.
@@ -51,12 +64,14 @@ The header identifies the session and provides provenance metadata.
 | `agent_type` | string | yes | Agent identifier (e.g., `"claude-code"`) |
 | `agent_version` | string | no | Version of the coding agent (e.g., `"1.0.3"`) |
 | `model` | string | no | LLM model used (e.g., `"claude-sonnet-4-20250514"`) |
-| `username` | string | no | Authenticated SageOx username (email) |
+| `username` | string | no | Privacy-safe display name, via `identity.AttributionDisplayName()`. **NOT an email** — `raw.jsonl` is committed to a ledger repo, so writers must never put a contactable address here. Also accepted on read as `ox_username`. |
 | `repo_id` | string | no | SageOx repo ID for provenance |
+| `session_id` | string | no | The `ses_` recording identity minted at session start. The header is its **crash-safe carrier**: `.recording.json` is deleted at stop/abort, so an orphan-finalize can only recover this ID from here. Only `ses_`-prefixed values are accepted into this field — see the caution below. |
+| `ox_version` | string | no | Version of ox that created the session |
 
 Example:
 ```json
-{"type":"header","metadata":{"version":"1.0","created_at":"2026-01-06T14:32:00Z","agent_id":"Ox7f3a","agent_type":"claude-code","agent_version":"1.0.3","model":"claude-sonnet-4-20250514","username":"dev@example.com","repo_id":"repo_01JEYQ9Z8X"}}
+{"type":"header","metadata":{"version":"1.0","created_at":"2026-01-06T14:32:00Z","agent_id":"Ox7f3a","agent_type":"claude-code","agent_version":"1.0.3","model":"claude-sonnet-4-20250514","username":"testdev","repo_id":"repo_01JEYQ9Z8X"}}
 ```
 
 ### Alternative Header Format
@@ -65,6 +80,15 @@ The reader also accepts the `_meta` wrapper format (used by capture-prior/import
 ```json
 {"_meta":{"schema_version":"1","agent_type":"claude-code","session_id":"Ox7f3a","started_at":"2026-01-06T14:32:00Z",...}}
 ```
+
+> **Caution — `session_id` means two different things.** In this dialect it is an
+> agent-supplied identifier (`"Ox7f3a"` above). In the native header's `metadata`
+> it is the `ses_` recording identity. `ParseStoreMeta` keeps them apart by
+> accepting only `ses_`-prefixed values into the recording-identity field; a
+> consumer that conflates them attributes a session to the wrong recording.
+>
+> The reader also accepts `started_at` as an alias for `created_at`, and
+> `ox_username` as an alias for `username`.
 
 See [Capture-Prior Format](#capture-prior-format) for details.
 
@@ -80,16 +104,17 @@ Each entry represents a conversation turn or tool invocation. Entries are writte
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | string | yes | Entry type (see below) |
-| `content` | string | yes | Message text or tool output |
-| `timestamp` | ISO8601 | yes | When the entry was recorded (auto-added if missing) |
-| `seq` | integer | yes | Zero-based sequence number (auto-added if missing) |
+| `type` | string | yes | Entry type. **Open vocabulary** — see below |
+| `content` | string | no | Message text or tool output. Absent on some tool entries, which carry everything in `tool_*` |
+| `timestamp` | ISO8601 | yes | When the entry was recorded (auto-added if missing). Import dialect uses **`ts`** |
+| `seq` | integer | yes | Sequence number (auto-added if missing). ox writes **zero-based**; the import dialect is **one-based**. Ordering only, never an identity |
 | `eid` | string | yes | Unique 5-char alphanumeric entry identifier (auto-generated if missing) |
-| `tool_name` | string | no | Tool name (only for `tool` entries) |
-| `tool_input` | string | no | Tool input (only for `tool` entries) |
-| `tool_output` | string | no | Tool output (only for `tool` entries) |
+| `tool_name` | string | no | Tool name (only for `tool` entries). Import dialect uses **`tool`** |
+| `tool_input` | string **or object** | no | Tool input. ox writes a string (often itself JSON); the import dialect writes a decoded object. A reader that checks only for a string silently drops every imported tool call's arguments |
+| `tool_output` | string **or object** | no | Tool output. Same string-or-object split as `tool_input` |
 | `coworker_name` | string | no | Coworker/subagent name if applicable |
 | `coworker_model` | string | no | Coworker model tier (sonnet, opus, haiku) |
+| `data` | object | no | Nested payload written by `WriteEntry()` (as opposed to the flat `WriteRaw()` shape). Typically carries `role` and `content` |
 
 **Entry ID (`eid`):** Each entry gets a unique 5-character identifier from `[0-9A-Za-z]` (62^5 ≈ 916M possibilities). Generated automatically by `WriteRaw()` if not provided by the caller. Provides stable references for deduplication, cross-referencing from derived artifacts, and audit trails. Sessions recorded before this field was added will have entries without `eid` — readers should tolerate missing values.
 
@@ -101,6 +126,29 @@ Each entry represents a conversation turn or tool invocation. Entries are writte
 | `assistant` | AI agent response |
 | `system` | System message (context injection, framework content, coworker load) |
 | `tool` | Tool call or result (bash, read, write, edit, grep, glob) |
+
+**The vocabulary is open, and wider than those four.** `WriteRaw()` takes a
+`map[string]any` and writes whatever `type` the caller supplies, so values
+including `message`, `tool_call`, and `tool_result` also occur in real sessions.
+`header` and `footer` are the only reserved values. **A reader MUST preserve an
+entry whose `type` it does not recognize rather than dropping or rejecting it** —
+that is why the published schema does not enumerate this field.
+
+### Dialects
+
+`raw.jsonl` is not one shape. Three occur in practice, and a reader has to
+handle all three:
+
+| Dialect | Written by | Header | Entries |
+|---|---|---|---|
+| **Flat** (this document's default) | `SessionWriter.WriteRaw()` | `type:"header"` + `metadata` | flat keys, `timestamp`, zero-based `seq`, `eid` |
+| **Nested** | `SessionWriter.WriteEntry()` | same | `{type, timestamp, seq, eid, data:{role, content}}` |
+| **Import** | `ox agent <id> session capture-prior`, importers | `_meta` wrapper | `ts`, one-based `seq`, `tool`, object-valued `tool_input`, no `eid` |
+
+Convergence on one shape is desirable but not scheduled; until then, treat the
+aliases in the field table above as required reading, and validate against the
+[published schema](../../schema/v1/raw-jsonl.schema.json) rather than assuming
+one dialect.
 
 ### Adapter-Layer Entry Classification
 
@@ -169,7 +217,7 @@ The footer provides session summary statistics.
 ## Complete Example
 
 ```jsonl
-{"type":"header","metadata":{"version":"1.0","created_at":"2026-01-06T14:32:00Z","agent_id":"Ox7f3a","agent_type":"claude-code","model":"claude-sonnet-4-20250514","username":"dev@example.com"}}
+{"type":"header","metadata":{"version":"1.0","created_at":"2026-01-06T14:32:00Z","agent_id":"Ox7f3a","agent_type":"claude-code","model":"claude-sonnet-4-20250514","username":"testdev"}}
 {"type":"user","content":"Fix the failing test in auth_test.go","timestamp":"2026-01-06T14:32:01Z","seq":0,"eid":"aB3xZ"}
 {"type":"assistant","content":"I'll look at the test file to understand the failure.","timestamp":"2026-01-06T14:32:03Z","seq":1,"eid":"k9Qm2"}
 {"type":"tool","content":"","tool_name":"read","tool_input":"/path/to/auth_test.go","timestamp":"2026-01-06T14:32:04Z","seq":2,"eid":"Tn4pL"}

--- a/docs/specs/session-raw-jsonl.md
+++ b/docs/specs/session-raw-jsonl.md
@@ -60,8 +60,8 @@ The header identifies the session and provides provenance metadata.
 |-------|------|----------|-------------|
 | `version` | string | yes | Schema version. Currently `"1.0"` |
 | `created_at` | ISO8601 | yes | When the session file was created |
-| `agent_id` | string | yes | Short agent ID (e.g., `"Ox7f3a"`) |
-| `agent_type` | string | yes | Agent identifier (e.g., `"claude-code"`) |
+| `agent_id` | string | no | Short agent ID (e.g., `"Ox7f3a"`). Carries `omitempty` — absent when unset |
+| `agent_type` | string | no | Agent identifier (e.g., `"claude-code"`). Carries `omitempty` — absent when unset |
 | `agent_version` | string | no | Version of the coding agent (e.g., `"1.0.3"`) |
 | `model` | string | no | LLM model used (e.g., `"claude-sonnet-4-20250514"`) |
 | `username` | string | no | Privacy-safe display name, via `identity.AttributionDisplayName()`. **NOT an email** — `raw.jsonl` is committed to a ledger repo, so writers must never put a contactable address here. Also accepted on read as `ox_username`. |
@@ -106,15 +106,20 @@ Each entry represents a conversation turn or tool invocation. Entries are writte
 |-------|------|----------|-------------|
 | `type` | string | yes | Entry type. **Open vocabulary** — see below |
 | `content` | string | no | Message text or tool output. Absent on some tool entries, which carry everything in `tool_*` |
-| `timestamp` | ISO8601 | yes | When the entry was recorded (auto-added if missing). Import dialect uses **`ts`** |
-| `seq` | integer | yes | Sequence number (auto-added if missing). ox writes **zero-based**; the import dialect is **one-based**. Ordering only, never an identity |
-| `eid` | string | yes | Unique 5-char alphanumeric entry identifier (auto-generated if missing) |
+| `timestamp` | ISO8601 | no | When the entry was recorded. Auto-added by `WriteRaw()`/`WriteEntry()` when absent; the import dialect uses **`ts`** instead |
+| `seq` | integer | no | Sequence number. Auto-added when absent. ox writes **zero-based**; the import dialect is **one-based**. Ordering only, never an identity |
+| `eid` | string | no | Unique 5-char alphanumeric entry identifier. Auto-generated when absent; missing entirely on pre-`eid` sessions and on the import dialect |
 | `tool_name` | string | no | Tool name (only for `tool` entries). Import dialect uses **`tool`** |
 | `tool_input` | string **or object** | no | Tool input. ox writes a string (often itself JSON); the import dialect writes a decoded object. A reader that checks only for a string silently drops every imported tool call's arguments |
 | `tool_output` | string **or object** | no | Tool output. Same string-or-object split as `tool_input` |
 | `coworker_name` | string | no | Coworker/subagent name if applicable |
 | `coworker_model` | string | no | Coworker model tier (sonnet, opus, haiku) |
 | `data` | object | no | Nested payload written by `WriteEntry()` (as opposed to the flat `WriteRaw()` shape). Typically carries `role` and `content` |
+
+**`type` is the only field an entry is guaranteed to have.** Everything else is
+optional, aliased, or auto-injected — so a reader must not assume presence. Only
+`version` and `created_at` are guaranteed in a native header's `metadata`; they
+are the two fields on `StoreMeta` without `omitempty`.
 
 **Entry ID (`eid`):** Each entry gets a unique 5-character identifier from `[0-9A-Za-z]` (62^5 ≈ 916M possibilities). Generated automatically by `WriteRaw()` if not provided by the caller. Provides stable references for deduplication, cross-referencing from derived artifacts, and audit trails. Sessions recorded before this field was added will have entries without `eid` — readers should tolerate missing values.
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/sageox/agentx v0.1.11
 	github.com/sageox/frictionax v0.1.2
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dlclark/regexp2/v2 v2.5.1 h1:E5Ug7Dh264W1ymdySmiHNcDG7fmsR307APCE5R07a20=
 github.com/dlclark/regexp2/v2 v2.5.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
@@ -328,6 +330,8 @@ github.com/sageox/agentx v0.1.11 h1:GBmdWTUZGmGcuOlVn6sO08pFXgR8zHI3dDA23YgSurY=
 github.com/sageox/agentx v0.1.11/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
 github.com/sageox/frictionax v0.1.2 h1:iQfssC1g/vVdGXi55smMfY5/4JKcQbJXRzcwrQWiNLo=
 github.com/sageox/frictionax v0.1.2/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shirou/gopsutil/v4 v4.26.2 h1:X8i6sicvUFih4BmYIGT1m2wwgw2VG9YgrDTi7cIRGUI=

--- a/internal/session/rawjsonl_schema_test.go
+++ b/internal/session/rawjsonl_schema_test.go
@@ -1,0 +1,213 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/require"
+)
+
+// schemaPath is the published raw.jsonl line schema, relative to this package.
+const schemaPath = "../../schema/v1/raw-jsonl.schema.json"
+
+// schemaID must match the $id in the schema file. Kept as a literal so a
+// careless $id edit fails a test rather than silently breaking every third
+// party whose validator resolves the old URL.
+const schemaID = "https://sageox.ai/schemas/session/v1/raw-jsonl.schema.json"
+
+func compileRawJSONLSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+
+	f, err := os.Open(schemaPath)
+	require.NoError(t, err, "open published schema")
+	defer f.Close()
+
+	doc, err := jsonschema.UnmarshalJSON(f)
+	require.NoError(t, err, "parse published schema as JSON")
+
+	c := jsonschema.NewCompiler()
+	require.NoError(t, c.AddResource(schemaID, doc), "add schema resource")
+
+	sch, err := c.Compile(schemaID)
+	require.NoError(t, err, "compile published schema")
+	return sch
+}
+
+// validateFileLines validates every non-blank line of a JSONL file against the
+// schema, reporting the line number on failure.
+func validateFileLines(t *testing.T, sch *jsonschema.Schema, path string) int {
+	t.Helper()
+
+	f, err := os.Open(path)
+	require.NoError(t, err, "open %s", path)
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// Session lines carry whole tool outputs and routinely exceed bufio's 64KB default.
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+
+	lineNo, checked := 0, 0
+	for scanner.Scan() {
+		lineNo++
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" {
+			continue
+		}
+
+		var line any
+		require.NoErrorf(t, json.Unmarshal([]byte(raw), &line),
+			"%s:%d is not valid JSON", filepath.Base(path), lineNo)
+
+		require.NoErrorf(t, sch.Validate(line),
+			"%s:%d failed the published schema", filepath.Base(path), lineNo)
+		checked++
+	}
+	require.NoError(t, scanner.Err(), "scan %s", path)
+	return checked
+}
+
+// TestRawJSONLSchema_ValidatesShippedFixtures is the leg that proves the schema
+// agrees with reality rather than merely with the prose spec. These three
+// fixtures deliberately span all three on-disk dialects — native header +
+// nested WriteEntry payloads, and the `_meta` import dialect with `ts` and
+// 1-based seq. A schema that cannot read our own shipped fixtures is worthless.
+//
+// Failure prevented: publishing a schema at a public $id that rejects files ox
+// itself produced.
+func TestRawJSONLSchema_ValidatesShippedFixtures(t *testing.T) {
+	sch := compileRawJSONLSchema(t)
+
+	fixtures := []string{
+		"testdata/standard_session.jsonl",
+		"testdata/sample_session.jsonl",
+		"testdata/imported_session.jsonl",
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(filepath.Base(fixture), func(t *testing.T) {
+			n := validateFileLines(t, sch, fixture)
+			require.Positive(t, n, "fixture had no lines to check")
+		})
+	}
+}
+
+// TestRawJSONLSchema_ValidatesWriterOutput closes the loop the fixtures cannot:
+// fixtures are checked-in snapshots that can drift from the writer, so this
+// drives the real SessionWriter and validates what it actually emits today.
+//
+// Failure prevented: the writer gains a field or changes a shape and the
+// published schema silently stops describing current output.
+func TestRawJSONLSchema_ValidatesWriterOutput(t *testing.T) {
+	sch := compileRawJSONLSchema(t)
+
+	store, err := NewStore(t.TempDir())
+	require.NoError(t, err, "new store")
+
+	writer, err := store.CreateRaw("2026-01-06T14-32-tester-Ox7f3a")
+	require.NoError(t, err, "create raw session")
+
+	require.NoError(t, writer.WriteHeader(&StoreMeta{
+		Version:      "1.0",
+		CreatedAt:    time.Now().UTC(),
+		AgentID:      "Ox7f3a",
+		AgentType:    "claude-code",
+		AgentVersion: "1.0.3",
+		Model:        "claude-sonnet-4",
+		Username:     "tester",
+		RepoID:       "repo_01JEYQ9Z8X",
+		OxVersion:    "0.9.0",
+	}), "write header")
+
+	// One of each documented entry shape, exercising the eid/seq/timestamp
+	// injection path in WriteRaw.
+	for _, entry := range []map[string]any{
+		{"type": "user", "content": "Fix the failing test"},
+		{"type": "assistant", "content": "Reading the test file."},
+		{"type": "tool", "content": "", "tool_name": "bash", "tool_input": "go test ./...", "tool_output": "ok"},
+		{"type": "system", "content": "Loaded coworker: code-reviewer", "coworker_name": "code-reviewer", "coworker_model": "sonnet"},
+	} {
+		require.NoError(t, writer.WriteRaw(entry), "write raw entry type=%v", entry["type"])
+	}
+
+	// Close writes the footer.
+	require.NoError(t, writer.Close(), "close writer")
+
+	n := validateFileLines(t, sch, writer.FilePath())
+	require.Equal(t, 6, n, "expected header + 4 entries + footer")
+}
+
+// TestRawJSONLSchema_DocumentsEveryStoreMetaField is the anti-drift gate. The
+// on-disk entry has no Go struct (WriteRaw takes map[string]any), so the schema
+// is necessarily hand-written and reflection can only guard the one part that
+// IS typed — the header metadata. Every StoreMeta json tag must appear in the
+// schema's storeMeta properties.
+//
+// Failure prevented: a field added to StoreMeta ships to users' ledgers while
+// the published schema still claims it doesn't exist.
+func TestRawJSONLSchema_DocumentsEveryStoreMetaField(t *testing.T) {
+	raw, err := os.ReadFile(schemaPath)
+	require.NoError(t, err, "read published schema")
+
+	var doc struct {
+		Defs struct {
+			StoreMeta struct {
+				Properties map[string]json.RawMessage `json:"properties"`
+			} `json:"storeMeta"`
+		} `json:"$defs"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &doc), "parse published schema")
+	require.NotEmpty(t, doc.Defs.StoreMeta.Properties, "schema has no storeMeta properties")
+
+	typ := reflect.TypeOf(StoreMeta{})
+	for i := range typ.NumField() {
+		name, _, _ := strings.Cut(typ.Field(i).Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		require.Containsf(t, doc.Defs.StoreMeta.Properties, name,
+			"StoreMeta field %q is written to raw.jsonl but missing from %s "+
+				"($defs.storeMeta.properties) — add it there", name, schemaPath)
+	}
+}
+
+// TestRawJSONLSchema_RejectsMalformedLines pins the few things the schema does
+// constrain. Without this, "everything validates" could mean the schema is
+// correct or that it is vacuous; these cases distinguish the two.
+func TestRawJSONLSchema_RejectsMalformedLines(t *testing.T) {
+	sch := compileRawJSONLSchema(t)
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"header without metadata", `{"type":"header"}`},
+		{"entry without type", `{"content":"orphaned","seq":0}`},
+		{"eid wrong length", `{"type":"user","content":"hi","eid":"toolong"}`},
+		{"eid non-alphanumeric", `{"type":"user","content":"hi","eid":"ab-de"}`},
+		{"negative seq", `{"type":"user","content":"hi","seq":-1}`},
+		{"timestamp not RFC3339", `{"type":"user","content":"hi","timestamp":"last tuesday"}`},
+		{"footer entry_count not an integer", `{"type":"footer","entry_count":"42"}`},
+		// The dialect-overload guard: in a NATIVE header, session_id is the
+		// ses_ recording identity. The import dialect overloads the same key
+		// as an agent identifier, and conflating them misattributes a session
+		// to the wrong recording — so the native side pins the prefix.
+		{"native header session_id without ses_ prefix",
+			`{"type":"header","metadata":{"version":"1.0","session_id":"test-session-001"}}`},
+		{"not an object", `"just a string"`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var line any
+			require.NoError(t, json.Unmarshal([]byte(tc.line), &line), "test case is not valid JSON")
+			require.Error(t, sch.Validate(line), "schema accepted a line it should reject")
+		})
+	}
+}

--- a/internal/session/rawjsonl_schema_test.go
+++ b/internal/session/rawjsonl_schema_test.go
@@ -194,6 +194,11 @@ func TestRawJSONLSchema_RejectsMalformedLines(t *testing.T) {
 		{"negative seq", `{"type":"user","content":"hi","seq":-1}`},
 		{"timestamp not RFC3339", `{"type":"user","content":"hi","timestamp":"last tuesday"}`},
 		{"footer entry_count not an integer", `{"type":"footer","entry_count":"42"}`},
+		// version and created_at are the only StoreMeta fields without
+		// omitempty, so the native writer always emits them; a header missing
+		// them is truncated or hand-rolled, not merely sparse.
+		{"native header with empty metadata", `{"type":"header","metadata":{}}`},
+		{"native header missing created_at", `{"type":"header","metadata":{"version":"1.0"}}`},
 		// The dialect-overload guard: in a NATIVE header, session_id is the
 		// ses_ recording identity. The import dialect overloads the same key
 		// as an agent identifier, and conflating them misattributes a session

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,101 @@
+# Published schemas
+
+Machine-readable descriptions of the file formats ox writes. They exist so
+anything — another agent, another vendor's tooling, a future us — can read a
+SageOx session without importing our Go code.
+
+| Schema | `$id` | Describes |
+|---|---|---|
+| [`v1/raw-jsonl.schema.json`](v1/raw-jsonl.schema.json) | `https://sageox.ai/schemas/session/v1/raw-jsonl.schema.json` | One line of a session `raw.jsonl` |
+
+**License: MIT**, same as the rest of this repo. Copy these into your own
+validator, vendor them, generate types from them — no attribution dance needed
+for an interface description.
+
+## How to use one
+
+A `raw.jsonl` file is [JSON Lines](https://jsonlines.org/): validate each line
+independently against the schema. There is no schema for the file as a whole,
+because JSON Lines has no whole-file JSON document to validate.
+
+```bash
+# every line of a session must validate
+while read -r line; do
+  printf '%s' "$line" | check-jsonschema --schemafile schema/v1/raw-jsonl.schema.json -
+done < sessions/<name>/raw.jsonl
+```
+
+## The rules these schemas deliberately do not express
+
+JSON Schema validates one line. It cannot express file-level or semantic rules,
+so those stay normative in
+[`docs/specs/session-raw-jsonl.md`](../docs/specs/session-raw-jsonl.md) and are
+enforced in Go:
+
+- **Line ordering** — header first, footer last. Not universal in practice
+  (imported and in-progress sessions have no footer), which is exactly why it
+  isn't a schema constraint.
+- **Completeness** — `raw.jsonl` must be the full, unfiltered agent output. A
+  truncated file is perfectly valid JSON and completely wrong.
+- **Secret redaction** — the only transformation applied before writing.
+- **The PII boundary** — `username` is a privacy-safe display name, never an
+  email. The schema says so in its `description`; nothing can make a validator
+  enforce it.
+
+## Open by construction
+
+Every object in these schemas omits `additionalProperties`, i.e. unknown
+properties are allowed. That is deliberate and it is the whole compatibility
+promise:
+
+> A consumer holding a v1 copy of the schema must keep validating files written
+> by a newer ox.
+
+`additionalProperties: false` would turn every additive field into a validation
+break for every deployed validator. Strictness belongs on the **writer** side,
+where we control both ends — see `internal/session` and the corpus test — not on
+the schema other people run.
+
+Closed vocabularies live in `enum`s instead, and there are deliberately very few.
+Entry `type` is **not** enumerated: the shipped vocabulary is wider than the spec
+ever documented (`user`, `assistant`, `system`, `tool`, `message`, `tool_call`,
+`tool_result`), and a reader that rejects an unfamiliar type would be wrong.
+Preserve what you don't recognize.
+
+## Traps the schema documents
+
+Writing this schema against real fixtures surfaced several things the prose spec
+had wrong or silent about. They are now in the schema's `description` fields,
+where a consumer will actually meet them:
+
+- **`session_id` means two different things.** In a native header it is the
+  `ses_` recording identity; in the import dialect it is an agent-supplied
+  identifier. Conflating them attributes a session to the wrong recording.
+- **`tool_input` / `tool_output` are string *or* object.** ox writes a string;
+  the import dialect writes a decoded object. Checking only for a string
+  silently drops every imported tool call's arguments.
+- **`username` is not an email**, and must never become one — `raw.jsonl` is
+  committed to a ledger repo.
+- **Aliases**: `ts`→`timestamp`, `tool`→`tool_name`, `ox_username`→`username`,
+  `started_at`→`created_at`.
+- **`seq` is zero-based from ox, one-based from importers.** It is an ordering
+  hint, never an identity.
+
+## Versioning
+
+The directory is the version. Within `v1/`, changes are **append-only**: no
+property removed, no `required` entry added or removed, no `enum` value removed,
+no type narrowed. Anything else mints `v2/` and freezes `v1/` forever, because
+the `$id` is a URL that other people's validators fetch — it can never change
+meaning under them.
+
+## Not published here
+
+- **The adapter protocol wire types** (`pkg/adapterprotocol`, incl. `RawEntry`)
+  — a different contract with its own version constant and its own reference at
+  [`docs/specs/adapter-protocol.md`](../docs/specs/adapter-protocol.md).
+  `adapterprotocol.RawEntry` is what an *adapter hands to ox*; the schema here is
+  what *ox writes to disk*. They are related but not the same shape, and giving
+  one format two homes is how drift starts.
+- **Derived session artifacts** (`summary.json`, `session.html`, `meta.json`) —
+  no external reader today.

--- a/schema/v1/raw-jsonl.schema.json
+++ b/schema/v1/raw-jsonl.schema.json
@@ -59,6 +59,8 @@
       "title": "Session header metadata",
       "description": "Mirrors session.StoreMeta. Field set is open: readers MUST preserve unknown keys.",
       "type": "object",
+      "required": ["version", "created_at"],
+      "$comment": "Only these two are required, because only these two lack `omitempty` on the Go struct and are therefore always serialized by the native writer. agent_id and agent_type carry omitempty and are genuinely optional, notwithstanding what the prose spec claimed before this schema existed.",
       "properties": {
         "version": {
           "type": "string",

--- a/schema/v1/raw-jsonl.schema.json
+++ b/schema/v1/raw-jsonl.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sageox.ai/schemas/session/v1/raw-jsonl.schema.json",
+  "title": "SageOx session raw.jsonl line",
+  "description": "One line of a SageOx `raw.jsonl` session recording. A raw.jsonl file is JSON Lines: every line is an independent JSON object validating against this schema. Conventionally the first line is a header and the last is a footer, but neither is guaranteed for imported or in-progress sessions, so file-level ordering is NOT expressed here (see $comment for the prose spec). Licensed MIT, same as the ox CLI — copy it into your own validator freely.",
+  "$comment": "Prose spec: https://github.com/sageox/ox/blob/main/docs/specs/session-raw-jsonl.md — it is normative for the rules JSON Schema cannot express (line ordering, redaction, completeness).",
+
+  "oneOf": [
+    { "$ref": "#/$defs/header" },
+    { "$ref": "#/$defs/importHeader" },
+    { "$ref": "#/$defs/footer" },
+    { "$ref": "#/$defs/entry" }
+  ],
+
+  "$defs": {
+    "rfc3339": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}[Tt ][0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?([Zz]|[+-][0-9]{2}:[0-9]{2})$",
+      "description": "RFC3339 timestamp. Either Z or a numeric offset — ox writes header times in UTC but stamps entries with the machine's local offset.",
+      "$comment": "The pattern is deliberately redundant with `format`. Most validators treat `format` as an annotation rather than an assertion by default, so a published schema that relies on `format` alone enforces nothing for the third parties it exists to serve."
+    },
+
+    "header": {
+      "title": "Header line (native)",
+      "description": "Written by ox at session start via SessionWriter.WriteHeader.",
+      "type": "object",
+      "required": ["type", "metadata"],
+      "properties": {
+        "type": { "const": "header" },
+        "metadata": { "$ref": "#/$defs/storeMeta" }
+      }
+    },
+
+    "importHeader": {
+      "title": "Header line (import dialect)",
+      "description": "Emitted by `ox agent <id> session capture-prior` and other importers. Carries `_meta` instead of `type`+`metadata`. Accepted by the reader; not written by ox itself.",
+      "type": "object",
+      "required": ["_meta"],
+      "not": { "required": ["type"] },
+      "properties": {
+        "_meta": {
+          "type": "object",
+          "properties": {
+            "schema_version": { "type": "string" },
+            "agent_type": { "type": "string" },
+            "session_id": {
+              "type": "string",
+              "description": "CAUTION — in THIS dialect `session_id` is an agent-supplied identifier, NOT the ses_ recording identity that the native header's metadata.session_id carries. One key, two meanings, split by dialect. ox's reader keeps them apart by only accepting ses_-prefixed values into the recording-identity field; a consumer that conflates them will attribute a session to the wrong recording."
+            },
+            "started_at": { "$ref": "#/$defs/rfc3339" },
+            "username": { "$ref": "#/$defs/username" }
+          }
+        }
+      }
+    },
+
+    "storeMeta": {
+      "title": "Session header metadata",
+      "description": "Mirrors session.StoreMeta. Field set is open: readers MUST preserve unknown keys.",
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Header metadata format version. Currently \"1.0\". Distinct from this schema's version and from adapterprotocol.EntrySchemaVersion."
+        },
+        "created_at": { "$ref": "#/$defs/rfc3339" },
+        "started_at": {
+          "$ref": "#/$defs/rfc3339",
+          "description": "Accepted as an alias for created_at by the reader; prefer created_at when writing."
+        },
+        "agent_id": { "type": "string", "description": "Short agent id, e.g. \"Ox7f3a\"." },
+        "session_id": {
+          "type": "string",
+          "pattern": "^ses_",
+          "description": "The ses_ recording identity minted at session start. The header is its crash-safe carrier: the on-disk recording-state file is deleted at stop/abort, so an orphan-finalize can only recover this id from here. See the import dialect's _meta.session_id, which overloads the same key with a DIFFERENT meaning."
+        },
+        "agent_type": { "type": "string", "description": "Coding agent identifier, e.g. \"claude-code\"." },
+        "agent_version": { "type": "string", "description": "Version of the coding agent." },
+        "model": { "type": "string", "description": "LLM model identifier." },
+        "username": { "$ref": "#/$defs/username" },
+        "ox_username": {
+          "$ref": "#/$defs/username",
+          "description": "Accepted as an alias for username by the reader; prefer username when writing."
+        },
+        "repo_id": { "type": "string", "description": "SageOx repo id, for provenance." },
+        "ox_version": { "type": "string", "description": "Version of ox that created the session." }
+      }
+    },
+
+    "username": {
+      "type": "string",
+      "description": "Privacy-safe display name, resolved via identity.AttributionDisplayName. NOT an email address and NOT a contactable identifier — do not treat it as one.",
+      "$comment": "PII boundary: raw.jsonl is committed to a ledger repo. Writers MUST NOT put an email address here."
+    },
+
+    "footer": {
+      "title": "Footer line",
+      "description": "Written at session close. Absent from imported and in-progress sessions.",
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "footer" },
+        "closed_at": { "$ref": "#/$defs/rfc3339" },
+        "entry_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Entries written, excluding header and footer. Not emitted by every writer; readers MUST tolerate its absence."
+        }
+      }
+    },
+
+    "entry": {
+      "title": "Entry line",
+      "description": "One conversation turn or tool invocation. `type` carries an OPEN vocabulary — values observed in the wild include user, assistant, system, tool, message, tool_call, tool_result. Readers MUST tolerate an unrecognized type by preserving the line rather than failing.",
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "minLength": 1,
+          "not": { "enum": ["header", "footer"] },
+          "description": "Entry kind. Open vocabulary; see this subschema's description for observed values."
+        },
+        "content": { "type": "string", "description": "Message text or tool output." },
+        "timestamp": {
+          "$ref": "#/$defs/rfc3339",
+          "description": "When the entry was recorded. Injected by WriteRaw if the caller omits it."
+        },
+        "ts": {
+          "$ref": "#/$defs/rfc3339",
+          "description": "Import-dialect alias for timestamp. Prefer timestamp when writing."
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Ordering hint within the file. ox writes zero-based; the import dialect is one-based. Ordering only — never an identity."
+        },
+        "eid": {
+          "type": "string",
+          "pattern": "^[0-9A-Za-z]{5}$",
+          "description": "Entry identifier, 5 chars from [0-9A-Za-z]. Injected by WriteRaw. Absent on sessions recorded before eid existed and on the import dialect."
+        },
+        "tool_name": { "type": "string", "description": "Tool invoked. The import dialect uses `tool` for the same thing." },
+        "tool": { "type": "string", "description": "Import-dialect alias for tool_name. Prefer tool_name when writing." },
+        "tool_input": {
+          "type": ["string", "object"],
+          "description": "Tool arguments. ox writes a string (often itself JSON); the import dialect writes a decoded object. Readers MUST handle both — checking only for a string silently drops every imported tool call's arguments."
+        },
+        "tool_output": {
+          "type": ["string", "object"],
+          "description": "Tool result. Same string-or-object split as tool_input."
+        },
+        "coworker_name": { "type": "string", "description": "Coworker/subagent name, when the entry is attributable to one." },
+        "coworker_model": { "type": "string", "description": "Coworker model tier." },
+        "data": {
+          "type": "object",
+          "description": "Nested payload written by SessionWriter.WriteEntry (as opposed to the flat WriteRaw shape). Typically carries role and content."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Anyone can now read a SageOx session recording without importing our Go code — or asking us what a field means. `raw.jsonl` gets a published JSON Schema at a stable public `$id`, MIT-licensed, so other agents and other vendors' tooling can validate, parse, and generate types against our session format directly.

Writing it against real fixtures turned up **seven documented-vs-actual drifts in our own format**, including one PII bug that was about to be published as fact: the spec described `username` as an email and used `dev@example.com` in two examples, while the code has said *"privacy-safe display name — NOT an email"* since it was written. `raw.jsonl` is committed to a ledger repo.

**Approach:** hand-write the line schema (entries have no Go struct — `WriteRaw` takes `map[string]any`), then make it trustworthy with three test legs: it must validate our shipped fixtures, validate live `SessionWriter` output, and reflect `StoreMeta`'s fields so a new Go field can't ship without appearing in the schema.

## What the fixtures taught us

`raw.jsonl` is not one shape. Three dialects occur in practice, and a reader has to handle all of them:

| Dialect | Written by | Header | Entries |
|---|---|---|---|
| Flat | `SessionWriter.WriteRaw()` | `type:"header"` + `metadata` | flat keys, `timestamp`, zero-based `seq`, `eid` |
| Nested | `SessionWriter.WriteEntry()` | same | `{type, timestamp, seq, eid, data:{role, content}}` |
| Import | `capture-prior`, importers | `_meta` wrapper | `ts`, one-based `seq`, `tool`, object-valued `tool_input`, no `eid` |

Seven drifts found, all now documented in the schema's `description` fields where a consumer actually meets them:

| # | Drift | Consequence if unnoticed |
|---|---|---|
| 1 | `username` documented as an email, with two `dev@example.com` examples | PII in a committed ledger repo — **the reason this is worth catching before publishing** |
| 2 | `session_id` means the `ses_` recording identity natively, but an *agent identifier* in the import dialect | a session attributed to the wrong recording |
| 3 | `tool_input`/`tool_output` are string **or** object | a string-only reader silently drops every imported tool call's arguments |
| 4 | `type` vocabulary is 7 values in the wild, 4 in the spec | a reader that enumerates rejects real sessions |
| 5 | `StoreMeta` has `session_id` + `ox_version`; spec documented neither | invisible fields |
| 6 | Aliases: `ts`→`timestamp`, `tool`→`tool_name`, `ox_username`→`username`, `started_at`→`created_at` | half the corpus unparsed |
| 7 | Spec marks `agent_id`/`agent_type`/`timestamp`/`seq`/`eid` required; all are optional in Go or absent in the import dialect | a reader that trusts the table rejects valid sessions |

Nos. 2, 3 and 5 were caught by the tests failing on first run, not by reading — which is the argument for the test legs. No. 7 came from CodeRabbit on this PR; the fix tightens `storeMeta` to require `version`/`created_at` (the only two `StoreMeta` fields without `omitempty`) and corrects the docs table, done now because adding a `required` entry after v1 ships would force a v2 under this schema's own rule.

## Two decisions worth a reviewer's attention

**Open, not closed.** Every object omits `additionalProperties`, and entry `type` is deliberately not an `enum`. A consumer holding a v1 copy of the schema must keep validating files written by a newer ox; `additionalProperties: false` would turn every additive field into a validation break for everyone downstream. Strictness stays on the writer side where we control both ends.

**`pattern` alongside `format`.** Most validators treat `format` as an annotation rather than an assertion by default, so a published schema relying on `format` alone enforces nothing for the third parties it exists to serve. The first test run proved it — `"last tuesday"` validated as a timestamp.

## What changed

| File | Change |
|---|---|
| `schema/v1/raw-jsonl.schema.json` | **new** — the published line schema (`$id`: `https://sageox.ai/schemas/session/v1/raw-jsonl.schema.json`) |
| `schema/README.md` | **new** — usage, the traps above, the open-by-construction rationale, append-only versioning rule |
| `internal/session/rawjsonl_schema_test.go` | **new** — 4 tests / 16 cases |
| `docs/specs/session-raw-jsonl.md` | PII fix, `session_id` dialect caution, missing fields, dialect table, schema pointer |
| `go.mod` / `go.sum` | `santhosh-tekuri/jsonschema/v6` — **test-only**, confirmed absent from `go list -deps` on the production package |
| `THIRD_PARTY_NOTICES.md` | Apache-2.0 entry for the above |

## Test Plan

- [x] `go test ./internal/session/ ./pkg/adapterprotocol/` — both packages pass
- [x] 4 new tests, 18 sub-cases: 3 fixture dialects, live writer round-trip (6 lines: header + 4 entries + footer), `StoreMeta` reflection over 11 fields, 10 rejection cases
- [x] `golangci-lint run ./internal/session/` — **0 findings in the new file** (40 pre-existing errcheck findings in `store_test.go`, untouched)
- [x] `go build ./...` and `go vet ./internal/session/` clean
- [x] Rejection cases prove the schema isn't vacuous: bad `eid` length/charset, negative `seq`, non-RFC3339 timestamp, header without metadata, entry without type, non-`ses_` native `session_id`, `entry_count` as string, empty `metadata`, header missing `created_at`, non-object line

<details><summary>Why hand-written rather than generated</summary>

The monorepo's conversation-schema design generates from Go types, and that's right there — many types, high churn. Here the on-disk entry has **no Go struct at all** (`WriteRaw(data map[string]any)`), so there is nothing to generate from; the prose spec was the only contract. Reflection still guards the one part that *is* typed — `StoreMeta` — which is where a silent field addition would otherwise slip through.

</details>

<details><summary>Deliberately not in this PR</summary>

- **`pkg/adapterprotocol.RawEntry`** — a different contract (what an *adapter hands to ox*, vs what *ox writes to disk*), with its own version constant and its own reference doc. Giving one format two homes is how drift starts.
- **Tool-call pairing and a `reasoning` role on `RawEntry`** — approved separately. Adding `reasoning` is enum growth, so it mints `v2/` under the rule in `schema/README.md`. Publishing v1 first is deliberate: the bump exercises the compat rule before anything depends on it.
- **Converging the three dialects** — the schema documents the split honestly rather than pretending it away. Convergence is real work and wants its own change.
- **Serving the `$id` URL** — the schema is valid and useful as a repo file today; JSON Schema `$id`s are identifiers and need not dereference.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a machine-readable JSON Schema for validating `raw.jsonl` session recordings.
  * Added support for validating headers, entries, footers, timestamps, ordering, tool payloads, and multiple session dialects.
  * Added documentation covering schema usage, compatibility rules, dialect differences, and versioning.

* **Documentation**
  * Clarified privacy-safe username requirements and session metadata semantics.
  * Documented open-ended entry types and string-or-object tool fields.
  * Added a third-party license notice.

* **Bug Fixes**
  * Added automated validation to detect malformed or non-conforming session records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
