### PR TITLE
feat(plan): make rendered plans reviewer-friendly

### DIFF
--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -573,7 +573,16 @@ func runPlanRenderFresh(cmd *cobra.Command, file, outPath string, open, artifact
 	gitRoot := findGitRoot()
 	result := plan.Enrich(context.Background(), in, gitRoot)
 
-	htmlBytes, err := plan.RenderHTMLOpts(in, result, plan.RenderOptions{Slug: plan.Slugify(planTopic(in)), PriorArtURL: priorArtURLResolver(gitRoot), Artifact: artifact, SessionURL: liveSessionConversationURL(gitRoot)})
+	// Companion artifacts: explicit --companion flags plus relative .html links
+	// in the plan markdown (a hand-crafted interactive page linked from the plan
+	// travels WITH it instead of dying as a broken relative href in a temp file).
+	companions := gatherCompanions(cmd, in)
+	var companionNames []string
+	for _, c := range companions {
+		companionNames = append(companionNames, c.Name)
+	}
+
+	htmlBytes, err := plan.RenderHTMLOpts(in, result, plan.RenderOptions{Slug: plan.Slugify(planTopic(in)), PriorArtURL: priorArtURLResolver(gitRoot), Artifact: artifact, SessionURL: liveSessionConversationURL(gitRoot), Companions: plan.CompanionRefs(companionNames)})
 	if err != nil {
 		return fmt.Errorf("render plan: %w", err)
 	}
@@ -591,21 +600,67 @@ func runPlanRenderFresh(cmd *cobra.Command, file, outPath string, open, artifact
 	}
 	// Artifact mode is a pure export target — leave the ledger's canonical
 	// (review-capable) render untouched, and check the page is CSP-clean.
+	// Companions are dropped too: an artifact is one self-contained page.
 	savedDir := ""
 	if artifact {
+		companions = nil
 		for _, f := range plan.LintArtifact(htmlBytes) {
 			cli.PrintHint(fmt.Sprintf("plan-artifact [%s]: %s", f.Rule, f.Message))
 		}
 	} else if gitRoot != "" && config.PlanSave(gitRoot) {
 		// Persist into the ledger when capture is on, so the render is re-openable.
 		savedDir = savePlanWithProvenance(gitRoot, in, result, htmlBytes)
+		// Bundle companions into the saved plan dir + meta so the plan CARRIES
+		// its interactive deep-dives (re-opens, review loop, teammate clones).
+		if savedDir != "" && len(companions) > 0 {
+			if names, cerr := plan.CopyCompanions(companions, savedDir); cerr != nil {
+				cli.PrintHint("could not bundle companion(s): " + cerr.Error())
+			} else if rerr := plan.RecordCompanions(savedDir, names); rerr != nil {
+				cli.PrintHint("could not record companion(s) in plan meta: " + rerr.Error())
+			}
+		}
 	}
 	name := "plan"
 	if in.Path != "" {
 		name = strings.TrimSuffix(filepath.Base(in.Path), filepath.Ext(in.Path))
 	}
-	emitRenderedHTML(cmd, htmlBytes, savedDir, outPath, open, name)
+	emitRenderedHTML(cmd, htmlBytes, savedDir, outPath, open, name, companions)
 	return nil
+}
+
+// gatherCompanions resolves the companion HTML artifacts for a fresh render:
+// explicit --companion flags first, then relative .html links auto-detected in
+// the plan markdown (resolved against the plan file's directory — a stdin plan
+// has no directory, so only explicit flags apply there). Deduped by stored
+// basename, flag order preserved.
+func gatherCompanions(cmd *cobra.Command, in plan.Input) []plan.CompanionFile {
+	explicit, _ := cmd.Flags().GetStringSlice("companion")
+	var srcs []string
+	for _, p := range explicit {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		if info, serr := os.Stat(abs); serr != nil || info.IsDir() {
+			cli.PrintHint("companion not found (skipped): " + p)
+			continue
+		}
+		srcs = append(srcs, abs)
+	}
+	if in.Path != "" {
+		srcs = append(srcs, plan.DetectCompanionLinks(in.Raw, filepath.Dir(in.Path))...)
+	}
+	seen := make(map[string]struct{}, len(srcs))
+	var out []plan.CompanionFile
+	for _, s := range srcs {
+		name := plan.CompanionName(s)
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, plan.CompanionFile{Name: name, SrcPath: s})
+	}
+	return out
 }
 
 // runPlanRenderSaved renders a plan already in the ledger (with its review
@@ -618,34 +673,75 @@ func runPlanRenderSaved(cmd *cobra.Command, slug, outPath string, open, artifact
 	}
 	in := plan.Parse(planMD)
 	review, _ := plan.AssembleReview(info.Dir)
-	htmlBytes, err := plan.RenderHTMLOpts(in, res, plan.RenderOptions{Slug: slug, Review: review, PriorArtURL: priorArtURLResolver(gitRoot), Artifact: artifact})
+	companions := savedCompanionFiles(info.Dir)
+	var companionNames []string
+	for _, c := range companions {
+		companionNames = append(companionNames, c.Name)
+	}
+	htmlBytes, err := plan.RenderHTMLOpts(in, res, plan.RenderOptions{Slug: slug, Review: review, PriorArtURL: priorArtURLResolver(gitRoot), Artifact: artifact, Companions: plan.CompanionRefs(companionNames)})
 	if err != nil {
 		return fmt.Errorf("render plan: %w", err)
 	}
 	// Artifact mode is a pure export of the CSP-safe bytes — never open the
 	// ledger's canonical (non-artifact) plan.html in its place, so pass no
 	// savedDir and let emitRenderedHTML serve the artifact bytes directly.
+	// Companions are dropped too: an artifact is one self-contained page.
 	savedDir := info.Dir
 	if artifact {
 		savedDir = ""
+		companions = nil
 		for _, f := range plan.LintArtifact(htmlBytes) {
 			cli.PrintHint(fmt.Sprintf("plan-artifact [%s]: %s", f.Rule, f.Message))
 		}
 	}
-	emitRenderedHTML(cmd, htmlBytes, savedDir, outPath, open, slug)
+	emitRenderedHTML(cmd, htmlBytes, savedDir, outPath, open, slug, companions)
 	return nil
+}
+
+// savedCompanionFiles lists a saved plan's bundled companions (meta.json
+// Companions ∩ files actually present under companions/) as copyable refs.
+func savedCompanionFiles(planDir string) []plan.CompanionFile {
+	meta, err := plan.LoadMeta(planDir)
+	if err != nil {
+		return nil
+	}
+	var out []plan.CompanionFile
+	for _, n := range meta.Companions {
+		if n == "" || n != filepath.Base(n) {
+			continue
+		}
+		p := filepath.Join(planDir, plan.CompanionsDir, n)
+		if info, serr := os.Stat(p); serr != nil || info.IsDir() {
+			continue
+		}
+		out = append(out, plan.CompanionFile{Name: n, SrcPath: p})
+	}
+	return out
 }
 
 // emitRenderedHTML writes the render to outPath (when set) and opens it (when
 // open). For opening it prefers a plain-file ledger render, else the explicit
 // path, else a temp file backed by htmlBytes — so --open always has real HTML to
 // show even when the saved ledger copy is an LFS pointer. Headless prints the
-// path instead of opening.
-func emitRenderedHTML(cmd *cobra.Command, htmlBytes []byte, savedDir, outPath string, open bool, name string) {
+// path instead of opening. companions are placed in a companions/ subdir next
+// to every emitted copy so the page's relative "companions/<name>" card links
+// resolve wherever the page lands (the card, not the plan's own inline link,
+// is the sanctioned surface — a bare-basename prose link still needs the
+// original file beside the page).
+func emitRenderedHTML(cmd *cobra.Command, htmlBytes []byte, savedDir, outPath string, open bool, name string, companions []plan.CompanionFile) {
+	placeCompanions := func(dir string) {
+		if len(companions) == 0 || dir == "" {
+			return
+		}
+		if _, cerr := plan.CopyCompanions(companions, dir); cerr != nil {
+			cli.PrintHint("could not place companion(s) next to the render: " + cerr.Error())
+		}
+	}
 	if outPath != "" {
 		if werr := os.WriteFile(outPath, htmlBytes, 0o644); werr != nil {
 			cli.PrintHint("Could not write render to " + outPath + ": " + werr.Error())
 		} else {
+			placeCompanions(filepath.Dir(outPath))
 			fmt.Fprintf(cmd.OutOrStdout(), "Rendered HTML: %s\n", outPath)
 		}
 	}
@@ -670,6 +766,7 @@ func emitRenderedHTML(cmd *cobra.Command, htmlBytes []byte, savedDir, outPath st
 			cli.PrintHint("Could not write render: " + werr.Error())
 			return
 		}
+		placeCompanions(filepath.Dir(target))
 	}
 	if cli.IsHeadless() {
 		fmt.Fprintf(cmd.OutOrStdout(), "Rendered HTML: %s\n", target)
@@ -951,6 +1048,7 @@ func init() {
 	planRenderCmd.Flags().Bool("open", false, "open the rendered HTML in your browser")
 	planRenderCmd.Flags().Bool("static", false, "with --open on a saved plan, open a read-only static page instead of launching the live review loop")
 	planRenderCmd.Flags().Bool("artifact", false, "render a strictly self-contained, CSP-safe page for publishing as a Claude Code Artifact (no external fonts/scripts, no review loop; enrichment links preserved)")
+	planRenderCmd.Flags().StringSlice("companion", nil, "bundle a rich self-contained HTML companion with the plan (repeatable; relative .html links in the plan markdown are auto-detected)")
 
 	planListCmd.Flags().Bool("json", false, "emit the plan list as JSON (scripting path)")
 

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -884,7 +884,7 @@ func runPlanRenderSavedHTML(cmd *cobra.Command, gitRoot, slug string, info plan.
 	}))
 	// savedDir stays "" so the emitted bytes (WITH chrome) are what opens — the
 	// stored plan.html is the authored page and has no chrome by design.
-	emitRenderedHTML(cmd, injected, "", outPath, open, slug, nil)
+	emitRenderedHTML(cmd, injected, "", outPath, open, slug, savedCompanionFiles(info.Dir))
 	return nil
 }
 
@@ -1235,7 +1235,7 @@ func init() {
 	planRenderCmd.Flags().StringP("output", "o", "", "write the rendered HTML to this path")
 	planRenderCmd.Flags().Bool("open", false, "open the rendered HTML in your browser")
 	planRenderCmd.Flags().Bool("static", false, "with --open on a saved plan, open a read-only static page instead of launching the live review loop")
-	planRenderCmd.Flags().Bool("artifact", false, "render a strictly self-contained, CSP-safe page for publishing as a Claude Code Artifact (no external fonts/scripts, no review loop; enrichment links preserved)")
+	planRenderCmd.Flags().Bool("artifact", false, "render a self-contained page for publishing as a Claude Code Artifact (no external fonts/scripts, no review loop; enrichment links preserved)")
 	planRenderCmd.Flags().StringSlice("companion", nil, "bundle a rich self-contained HTML companion with the plan (repeatable; relative .html links in the plan markdown are auto-detected)")
 
 	planListCmd.Flags().Bool("json", false, "emit the plan list as JSON (scripting path)")

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -77,6 +77,13 @@ Output is JSON by default (the agent/plumbing path). Use --text for a human summ
 		if err != nil {
 			return err
 		}
+		// An authored HTML plan enriches via its DERIVED markdown — the
+		// detectors are section/file-keyed and must never parse raw HTML.
+		if plan.LooksLikeHTML(in.Raw) {
+			p := plan.Parse(plan.ExtractMarkdown([]byte(in.Raw)))
+			p.Path = in.Path
+			in = p
+		}
 
 		// No plan found anywhere: a clear message beats enriching empty input.
 		if in.Topic == "" && strings.TrimSpace(in.Raw) == "" {
@@ -133,7 +140,15 @@ var planViewCmd = &cobra.Command{
 var planRenderCmd = &cobra.Command{
 	Use:   "render [slug]",
 	Short: "Render a plan to a self-contained HTML page",
-	Long: `Render a plan to a self-contained HTML page.
+	Long: `Render a plan.
+
+PREFERRED input is an authored, self-contained HTML page — the plan of record
+(docs/specs/plan-authoring-html.md): ox derives searchable markdown from it,
+computes team-context enrichment, and serves the page with the ox chrome
+INJECTED (enrichment overlay + review loop appended before </body>; the
+author's markup is never rewritten). --artifact emits the authored page
+VERBATIM. Markdown input remains the quick-plan path and renders through the
+built-in template (tabs, TL;DR hero, auto-visualizations).
 
 No slug renders the plan from --file/stdin; a slug renders a saved plan with its
 review state. With --open on a SAVED plan, ox launches the live review loop
@@ -165,21 +180,27 @@ instead of a dead-end file/clipboard export — pass --static for a read-only pa
 var planSaveCmd = &cobra.Command{
 	Use:    "save",
 	Hidden: true, // agent/skill tier: persist merged badges; taught via prime, not human help
-	Short:  "Persist a fully-enriched plan (merged badges + optional HTML) to the ledger",
-	Long: `Persist a fully-enriched plan to the ledger. Unlike bare 'ox plan' — which
-auto-saves only the deterministic, ox-computed annotations — 'ox plan save' is the
-explicit full-plan persist path used by the html-plan renderer skill after it has
-authored its judgment badges and (optionally) rendered the HTML.
+	Short:  "Persist a plan to the ledger — an authored HTML page (preferred) or markdown",
+	Long: `Persist a plan to the ledger.
 
-  --plan        the plan markdown (source for plan.md + topic/slug derivation)
-  --annotations a MERGED annotations.json: the 'ox plan enrich --json' Result with the
-                agent-authored judgment badges appended (a full plan.Result)
-  --html        optional pre-rendered HTML; size-gated plain-git-vs-LFS per store.Save
+PREFERRED — HTML as the plan of record:
+  --file <plan.html>   an authored, self-contained interactive page. ox stores it
+                       as the canonical artifact (meta primary=html), DERIVES
+                       plan.md from it (regenerated on save — never hand-edit),
+                       and computes deterministic enrichment itself when no
+                       --annotations are passed. Contract + quality bar:
+                       docs/specs/plan-authoring-html.md
 
-This command never renders HTML and never makes an LLM/network call — it only
-materializes the already-produced artifacts into the ledger working tree. It
-always saves (the skill is deliberately persisting), independent of the
-plan.save config.`,
+Quick plans:
+  --file <plan.md>     markdown-primary; annotations optional (self-enriches)
+
+Legacy skill path:
+  --plan        the plan markdown (with --annotations, required together)
+  --annotations a MERGED annotations.json (deterministic + judgment badges)
+  --html        optional pre-rendered HTML; size-gated plain-git-vs-LFS
+
+This command never makes an LLM/network call — enrichment is deterministic and
+local. It always saves, independent of the plan.save config.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runPlanSave(cmd)
 	},
@@ -221,8 +242,23 @@ func maybeSavePlan(gitRoot string, in plan.Input, result plan.Result) string {
 // saved directory, or "" on any failure (capture is best-effort and never
 // aborts the command the agent is waiting on).
 func savePlanWithProvenance(gitRoot string, in plan.Input, result plan.Result, html []byte) string {
+	return savePlanArtifacts(gitRoot, in, result, html, "")
+}
+
+// savePlanArtifacts is savePlanWithProvenance with an explicit primary artifact
+// kind: "" = markdown-primary (html, if any, is a generated render), plan.
+// PrimaryHTML = the html IS the authored plan of record and in.Raw is the
+// DERIVED markdown (ExtractMarkdown). An HTML-primary page may declare its own
+// slug via <meta name="ox-plan-slug"> (the authoring contract), which then
+// wins over the title-derived one.
+func savePlanArtifacts(gitRoot string, in plan.Input, result plan.Result, html []byte, primary string) string {
 	topic := planTopic(in)
 	slug := plan.Slugify(topic)
+	if primary == plan.PrimaryHTML {
+		if s := plan.AuthoredSlug(html); s != "" {
+			slug = s
+		}
+	}
 
 	prov, recState := resolvePlanProvenance(gitRoot)
 	collab := deriveCollabSignals(recState)
@@ -233,6 +269,7 @@ func savePlanWithProvenance(gitRoot string, in plan.Input, result plan.Result, h
 		Authors:        planAuthors(gitRoot),
 		CreatedAt:      time.Now().UTC(),
 		SourcePlanPath: in.Path,
+		Primary:        primary,
 		Provenance:     prov,
 		Collaboration:  collab,
 	}
@@ -313,11 +350,19 @@ func runPlanSave(cmd *cobra.Command) error {
 	annPath, _ := cmd.Flags().GetString("annotations")
 	htmlPath, _ := cmd.Flags().GetString("html")
 
+	// --file: the plan-of-record path. An authored .html page saves as
+	// HTML-primary (markdown derived, annotations optional — ox self-enriches
+	// when none are passed); a .md file is the quick-plan path with the same
+	// optional-annotations relaxation.
+	if filePath, _ := cmd.Flags().GetString("file"); filePath != "" {
+		return runPlanSaveFile(cmd, filePath, annPath)
+	}
+
 	if planPath == "" {
-		return fmt.Errorf("--plan is required: pass the plan markdown file")
+		return fmt.Errorf("pass --file <plan.html|plan.md> (preferred), or the legacy --plan <md> + --annotations pair")
 	}
 	if annPath == "" {
-		return fmt.Errorf("--annotations is required: pass the merged annotations.json")
+		return fmt.Errorf("--annotations is required with --plan: pass the merged annotations.json (or use --file, which self-enriches)")
 	}
 
 	// The plan markdown drives plan.md + topic/slug derivation.
@@ -372,6 +417,60 @@ func runPlanSave(cmd *cobra.Command) error {
 			cli.PrintHint(fmt.Sprintf("plan-lint [%s]: %s", f.Rule, f.Message))
 		}
 	}
+	return nil
+}
+
+// runPlanSaveFile is the plan-of-record save path (`ox plan save --file …`).
+// An authored HTML page becomes the canonical artifact (meta.primary=html,
+// plan.md DERIVED via ExtractMarkdown); a markdown file saves md-primary.
+// annotations.json is OPTIONAL on this path — when absent ox computes the
+// deterministic enrichment itself, so a single command turns an authored page
+// into a saved, enriched, reviewable plan.
+func runPlanSaveFile(cmd *cobra.Command, filePath, annPath string) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("read plan %q: %w", filePath, err)
+	}
+	gitRoot := findGitRoot()
+	out := cmd.OutOrStdout()
+
+	loadResult := func(in plan.Input) plan.Result {
+		if annPath != "" {
+			if b, rerr := os.ReadFile(annPath); rerr == nil {
+				var r plan.Result
+				if json.Unmarshal(b, &r) == nil {
+					return r
+				}
+			}
+			cli.PrintHint("could not read --annotations; computing deterministic enrichment instead")
+		}
+		return plan.Enrich(context.Background(), in, gitRoot)
+	}
+
+	if plan.LooksLikeHTML(string(data)) {
+		derived := plan.ExtractMarkdown(data)
+		mdIn := plan.Parse(derived)
+		mdIn.Path = filePath
+		result := loadResult(mdIn)
+		dir := savePlanArtifacts(gitRoot, mdIn, result, data, plan.PrimaryHTML)
+		if dir == "" {
+			return fmt.Errorf("save plan: no ledger configured for %q or write failed", gitRoot)
+		}
+		slog.Info("plan_saved", "dir", dir, "primary", "html", "annotations", len(result.Annotations))
+		fmt.Fprintf(out, "Saved HTML-primary plan to ledger: %s\n", dir)
+		cli.PrintHint("plan.md was DERIVED from the page (regenerated on save — never hand-edit it). Open the live review loop: `ox plan review " + filepath.Base(dir) + "`.")
+		return nil
+	}
+
+	in := plan.Parse(string(data))
+	in.Path = filePath
+	result := loadResult(in)
+	dir := savePlanArtifacts(gitRoot, in, result, nil, "")
+	if dir == "" {
+		return fmt.Errorf("save plan: no ledger configured for %q or write failed", gitRoot)
+	}
+	slog.Info("plan_saved", "dir", dir, "primary", "md", "annotations", len(result.Annotations))
+	fmt.Fprintf(out, "Saved plan to ledger: %s\n", dir)
 	return nil
 }
 
@@ -567,8 +666,13 @@ func runPlanRenderFresh(cmd *cobra.Command, file, outPath string, open, artifact
 	}
 	if strings.TrimSpace(in.Raw) == "" {
 		fmt.Fprintln(cmd.OutOrStdout(),
-			"No plan found. Pass --file <plan.md>, pipe a plan on stdin, or save a plan-mode file to ~/.claude/plans/ first.")
+			"No plan found. Pass --file <plan.html> (or .md), pipe a plan on stdin, or save a plan-mode file to ~/.claude/plans/ first.")
 		return nil
+	}
+	// HTML-primary: an authored page is the plan of record — derive markdown,
+	// enrich via the derived sections, inject chrome (never wrap/re-render).
+	if plan.LooksLikeHTML(in.Raw) {
+		return runPlanRenderFreshHTML(cmd, in, outPath, open, artifact)
 	}
 	gitRoot := findGitRoot()
 	result := plan.Enrich(context.Background(), in, gitRoot)
@@ -628,6 +732,53 @@ func runPlanRenderFresh(cmd *cobra.Command, file, outPath string, open, artifact
 	return nil
 }
 
+// runPlanRenderFreshHTML is the HTML-primary render path: the authored page IS
+// the plan of record. ox derives markdown from it (terminal view / search /
+// enrichment sections), computes team-context signals over the derived
+// sections, persists the authored page as the canonical artifact
+// (meta.primary=html), and emits the page with the ox chrome INJECTED —
+// enrichment overlay + footer credit + review layer appended before </body>,
+// author markup untouched. --artifact emits the authored bytes VERBATIM.
+func runPlanRenderFreshHTML(cmd *cobra.Command, in plan.Input, outPath string, open, artifact bool) error {
+	authored := []byte(in.Raw)
+	name := "plan"
+	if in.Path != "" {
+		name = strings.TrimSuffix(filepath.Base(in.Path), filepath.Ext(in.Path))
+	}
+	if artifact {
+		// verbatim contract: no injection, no chrome, the author's exact bytes.
+		emitRenderedHTML(cmd, authored, "", outPath, open, name, nil)
+		return nil
+	}
+
+	derived := plan.ExtractMarkdown(authored)
+	mdIn := plan.Parse(derived)
+	mdIn.Path = in.Path
+	gitRoot := findGitRoot()
+	result := plan.Enrich(context.Background(), mdIn, gitRoot)
+
+	slug := plan.Slugify(planTopic(mdIn))
+	if s := plan.AuthoredSlug(authored); s != "" {
+		slug = s
+	}
+	injected := plan.InjectChrome(authored, plan.BuildChromeData(result, plan.RenderOptions{
+		Slug:        slug,
+		PriorArtURL: priorArtURLResolver(gitRoot),
+		SessionURL:  liveSessionConversationURL(gitRoot),
+	}))
+
+	if gitRoot != "" && config.PlanSave(gitRoot) {
+		// The AUTHORED bytes are canonical in the ledger (plan.md is the derived
+		// projection); chrome is injected per render/serve, never stored — that
+		// is what keeps injection idempotent and --artifact verbatim.
+		if dir := savePlanArtifacts(gitRoot, mdIn, result, authored, plan.PrimaryHTML); dir != "" {
+			cli.PrintHint("Saved HTML-primary plan (markdown derived from the page) — live review loop: `ox plan review " + filepath.Base(dir) + "`.")
+		}
+	}
+	emitRenderedHTML(cmd, injected, "", outPath, open, name, nil)
+	return nil
+}
+
 // gatherCompanions resolves the companion HTML artifacts for a fresh render:
 // explicit --companion flags first, then relative .html links auto-detected in
 // the plan markdown (resolved against the plan file's directory — a stdin plan
@@ -635,7 +786,7 @@ func runPlanRenderFresh(cmd *cobra.Command, file, outPath string, open, artifact
 // basename, flag order preserved.
 func gatherCompanions(cmd *cobra.Command, in plan.Input) []plan.CompanionFile {
 	explicit, _ := cmd.Flags().GetStringSlice("companion")
-	var srcs []string
+	var candidates []plan.CompanionFile
 	for _, p := range explicit {
 		abs, err := filepath.Abs(p)
 		if err != nil {
@@ -645,20 +796,22 @@ func gatherCompanions(cmd *cobra.Command, in plan.Input) []plan.CompanionFile {
 			cli.PrintHint("companion not found (skipped): " + p)
 			continue
 		}
-		srcs = append(srcs, abs)
+		candidates = append(candidates, plan.CompanionFile{Name: plan.CompanionName(abs), SrcPath: abs})
 	}
 	if in.Path != "" {
-		srcs = append(srcs, plan.DetectCompanionLinks(in.Raw, filepath.Dir(in.Path))...)
+		candidates = append(candidates, plan.DetectCompanionFiles(in.Raw, filepath.Dir(in.Path))...)
 	}
-	seen := make(map[string]struct{}, len(srcs))
+	seen := make(map[string]struct{}, len(candidates))
 	var out []plan.CompanionFile
-	for _, s := range srcs {
-		name := plan.CompanionName(s)
-		if _, ok := seen[name]; ok {
+	for _, c := range candidates {
+		if c.Name == "" {
+			c.Name = plan.CompanionName(c.SrcPath)
+		}
+		if _, ok := seen[c.Name]; ok {
 			continue
 		}
-		seen[name] = struct{}{}
-		out = append(out, plan.CompanionFile{Name: name, SrcPath: s})
+		seen[c.Name] = struct{}{}
+		out = append(out, c)
 	}
 	return out
 }
@@ -670,6 +823,11 @@ func runPlanRenderSaved(cmd *cobra.Command, slug, outPath string, open, artifact
 	planMD, res, info, err := plan.Load(gitRoot, slug)
 	if err != nil {
 		return fmt.Errorf("load plan %q: %w", slug, err)
+	}
+	// HTML-primary plan: serve the AUTHORED page (chrome injected; verbatim in
+	// artifact mode) — never re-render it through the markdown template.
+	if meta, merr := plan.LoadMeta(info.Dir); merr == nil && meta.Primary == plan.PrimaryHTML {
+		return runPlanRenderSavedHTML(cmd, gitRoot, slug, info, res, outPath, open, artifact)
 	}
 	in := plan.Parse(planMD)
 	review, _ := plan.AssembleReview(info.Dir)
@@ -695,6 +853,38 @@ func runPlanRenderSaved(cmd *cobra.Command, slug, outPath string, open, artifact
 		}
 	}
 	emitRenderedHTML(cmd, htmlBytes, savedDir, outPath, open, slug, companions)
+	return nil
+}
+
+// runPlanRenderSavedHTML serves a saved HTML-primary plan: the authored
+// plan.html bytes with the ox chrome injected fresh (current enrichment +
+// review state), or VERBATIM in artifact mode. It never re-persists.
+func runPlanRenderSavedHTML(cmd *cobra.Command, gitRoot, slug string, info plan.PlanInfo, res plan.Result, outPath string, open, artifact bool) error {
+	path, _, isPointer, exists := plan.PlanHTMLPath(info.Dir)
+	if !exists {
+		return fmt.Errorf("HTML-primary plan %q has no plan.html in %s", slug, info.Dir)
+	}
+	if isPointer {
+		cli.PrintHint("This plan's authored HTML is stored in LFS and not hydrated locally. Hydrate the ledger to view it.")
+		return nil
+	}
+	authored, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read authored plan %q: %w", path, err)
+	}
+	if artifact {
+		emitRenderedHTML(cmd, authored, "", outPath, open, slug, nil)
+		return nil
+	}
+	review, _ := plan.AssembleReview(info.Dir)
+	injected := plan.InjectChrome(authored, plan.BuildChromeData(res, plan.RenderOptions{
+		Slug:        slug,
+		Review:      review,
+		PriorArtURL: priorArtURLResolver(gitRoot),
+	}))
+	// savedDir stays "" so the emitted bytes (WITH chrome) are what opens — the
+	// stored plan.html is the authored page and has no chrome by design.
+	emitRenderedHTML(cmd, injected, "", outPath, open, slug, nil)
 	return nil
 }
 
@@ -724,10 +914,8 @@ func savedCompanionFiles(planDir string) []plan.CompanionFile {
 // path, else a temp file backed by htmlBytes — so --open always has real HTML to
 // show even when the saved ledger copy is an LFS pointer. Headless prints the
 // path instead of opening. companions are placed in a companions/ subdir next
-// to every emitted copy so the page's relative "companions/<name>" card links
-// resolve wherever the page lands (the card, not the plan's own inline link,
-// is the sanctioned surface — a bare-basename prose link still needs the
-// original file beside the page).
+// to every emitted copy for card links, and auto-detected markdown links also
+// preserve their original relative paths beside the render.
 func emitRenderedHTML(cmd *cobra.Command, htmlBytes []byte, savedDir, outPath string, open bool, name string, companions []plan.CompanionFile) {
 	placeCompanions := func(dir string) {
 		if len(companions) == 0 || dir == "" {
@@ -1052,7 +1240,8 @@ func init() {
 
 	planListCmd.Flags().Bool("json", false, "emit the plan list as JSON (scripting path)")
 
-	planSaveCmd.Flags().String("plan", "", "plan markdown file (required; source for plan.md + topic/slug)")
+	planSaveCmd.Flags().String("file", "", "the plan of record: an authored self-contained .html page (preferred; saved as canonical, markdown derived) or a .md quick plan; annotations optional (ox self-enriches)")
+	planSaveCmd.Flags().String("plan", "", "legacy: plan markdown file (with --annotations; prefer --file)")
 	planSaveCmd.Flags().String("annotations", "", "merged annotations.json: enrich badges + agent judgment badges (required)")
 	planSaveCmd.Flags().String("html", "", "optional pre-rendered HTML; size-gated plain-git-vs-LFS on save")
 

--- a/cmd/ox/plan_render_test.go
+++ b/cmd/ox/plan_render_test.go
@@ -11,6 +11,56 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// TestRenderFresh_BundlesCompanionNextToOutput verifies Leg A end-to-end at the
+// command layer: a plan whose markdown links a relative .html companion renders
+// with the companion card AND the companion file is copied into companions/
+// next to the -o output, so both the card link and the plan's own inline
+// relative link resolve. Failure prevented: the hand-crafted interactive page
+// orphaned as a dead href in a temp-file render.
+func TestRenderFresh_BundlesCompanionNextToOutput(t *testing.T) {
+	t.Setenv("SSH_CONNECTION", "test") // headless: never open a browser
+	t.Chdir(t.TempDir())               // outside any git repo: findGitRoot()=="" so no ledger save
+
+	srcDir := t.TempDir()
+	companion := filepath.Join(srcDir, "deep-dive.html")
+	if err := os.WriteFile(companion, []byte("<html>rich</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	planPath := filepath.Join(srcDir, "plan.md")
+	planMD := "# Companion Plan\n\nSee [the deep-dive](deep-dive.html).\n\n## One\n\na\n\n## Two\n\nb\n"
+	if err := os.WriteFile(planPath, []byte(planMD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := t.TempDir()
+	outPath := filepath.Join(outDir, "render.html")
+
+	cmd := planRenderCmd
+	cmd.SetOut(&bytes.Buffer{})
+	if err := cmd.Flags().Set("file", planPath); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cmd.Flags().Set("file", "") })
+	if err := runPlanRenderFresh(cmd, planPath, outPath, false, false); err != nil {
+		t.Fatalf("runPlanRenderFresh: %v", err)
+	}
+
+	html, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !strings.Contains(string(html), `href="companions/deep-dive.html"`) {
+		t.Error("render missing the companion card link")
+	}
+	copied, err := os.ReadFile(filepath.Join(outDir, "companions", "deep-dive.html"))
+	if err != nil {
+		t.Fatalf("companion not copied next to output: %v", err)
+	}
+	if string(copied) != "<html>rich</html>" {
+		t.Errorf("companion content rewritten: %q", copied)
+	}
+}
+
 // TestEmitRenderedHTML_FallsBackFromPointerToFreshBytes verifies `ox plan render
 // --open` still opens real HTML when the saved ledger copy is an LFS pointer.
 // Failure prevented: image-heavy renders save as pointers, then `--open` only
@@ -31,7 +81,7 @@ func TestEmitRenderedHTML_FallsBackFromPointerToFreshBytes(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(&out)
 
-	emitRenderedHTML(cmd, htmlBytes, savedDir, "", true, "large-plan")
+	emitRenderedHTML(cmd, htmlBytes, savedDir, "", true, "large-plan", nil)
 
 	got := strings.TrimSpace(out.String())
 	const prefix = "Rendered HTML: "

--- a/cmd/ox/plan_render_test.go
+++ b/cmd/ox/plan_render_test.go
@@ -8,8 +8,76 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/plan"
 	"github.com/spf13/cobra"
 )
+
+// TestRenderFreshHTML_ArtifactVerbatim pins the --artifact contract for an
+// HTML-primary plan: the authored page is emitted BYTE-FOR-BYTE — no chrome,
+// no meta stamp, no rewriting. Failure prevented: an "export" that silently
+// mutates the author's page.
+func TestRenderFreshHTML_ArtifactVerbatim(t *testing.T) {
+	t.Setenv("SSH_CONNECTION", "test")
+	t.Chdir(t.TempDir())
+
+	srcDir := t.TempDir()
+	authored := "<!doctype html>\n<html><head><title>T</title></head><body><h2>A</h2><script>go()</script></body></html>\n"
+	planPath := filepath.Join(srcDir, "plan.html")
+	if err := os.WriteFile(planPath, []byte(authored), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(t.TempDir(), "out.html")
+
+	cmd := planRenderCmd
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runPlanRenderFresh(cmd, planPath, outPath, false, true); err != nil {
+		t.Fatalf("runPlanRenderFresh: %v", err)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != authored {
+		t.Error("artifact output differs from the authored bytes — verbatim contract broken")
+	}
+}
+
+// TestRenderFreshHTML_InjectsChrome verifies the normal HTML-primary render:
+// the emitted page is the authored one with the ox chrome bundle appended
+// (review layer island + marker region), author markup preserved and NOT
+// wrapped in the generated template.
+func TestRenderFreshHTML_InjectsChrome(t *testing.T) {
+	t.Setenv("SSH_CONNECTION", "test")
+	t.Chdir(t.TempDir())
+
+	srcDir := t.TempDir()
+	authored := "<!doctype html>\n<html><head><title>Chrome T</title></head><body><h2>A</h2><p>body</p></body></html>\n"
+	planPath := filepath.Join(srcDir, "plan.html")
+	if err := os.WriteFile(planPath, []byte(authored), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outPath := filepath.Join(t.TempDir(), "out.html")
+
+	cmd := planRenderCmd
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runPlanRenderFresh(cmd, planPath, outPath, false, false); err != nil {
+		t.Fatalf("runPlanRenderFresh: %v", err)
+	}
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(got)
+	if !strings.Contains(s, plan.ChromeMarkerStart) || !strings.Contains(s, `id="ox-review-state"`) {
+		t.Error("injected render missing the chrome bundle / review island")
+	}
+	if !strings.Contains(s, "<p>body</p>") {
+		t.Error("authored markup lost")
+	}
+	if strings.Contains(s, `<nav class="toc">`) {
+		t.Error("HTML-primary render must not be wrapped in the generated template")
+	}
+}
 
 // TestRenderFresh_BundlesCompanionNextToOutput verifies Leg A end-to-end at the
 // command layer: a plan whose markdown links a relative .html companion renders
@@ -58,6 +126,13 @@ func TestRenderFresh_BundlesCompanionNextToOutput(t *testing.T) {
 	}
 	if string(copied) != "<html>rich</html>" {
 		t.Errorf("companion content rewritten: %q", copied)
+	}
+	inline, err := os.ReadFile(filepath.Join(outDir, "deep-dive.html"))
+	if err != nil {
+		t.Fatalf("companion not copied to preserve inline markdown link: %v", err)
+	}
+	if string(inline) != "<html>rich</html>" {
+		t.Errorf("inline companion content rewritten: %q", inline)
 	}
 }
 

--- a/cmd/ox/plan_review.go
+++ b/cmd/ox/plan_review.go
@@ -107,7 +107,7 @@ func runPlanReview(cmd *cobra.Command, slug string, noServe bool, idleTimeout ti
 	if noServe || cli.IsHeadless() {
 		in := plan.Parse(planMD)
 		review, _ := plan.AssembleReview(info.Dir)
-		return reviewStaticFallback(cmd, gitRoot, slug, in, res, review)
+		return reviewStaticFallback(cmd, gitRoot, slug, info.Dir, in, res, review)
 	}
 
 	// Bind a STABLE address for this plan (persisted last port, then the
@@ -141,7 +141,7 @@ func runPlanReview(cmd *cobra.Command, slug string, noServe bool, idleTimeout ti
 			cli.PrintHint("could not start review server, falling back to file export: " + lerr.Error())
 			in := plan.Parse(planMD)
 			review, _ := plan.AssembleReview(info.Dir)
-			return reviewStaticFallback(cmd, gitRoot, slug, in, res, review)
+			return reviewStaticFallback(cmd, gitRoot, slug, info.Dir, in, res, review)
 		}
 		ln = l
 		cli.PrintHint("Stable review ports are busy — serving on an ephemeral port; a previously open tab won't auto-reconnect to this one.")
@@ -237,6 +237,31 @@ func liveReviewHandler(gitRoot, slug, planDir, base, token string, bc *broadcast
 		// must never mask a dead server with a stale page that still looks live.
 		w.Header().Set("Cache-Control", "no-store")
 		_, _ = w.Write(html)
+	})
+
+	// /companions/<name>: bundled companion HTML artifacts, served from the plan
+	// dir's companions/ subdir so the page's relative links work in the live
+	// loop. Allowlisted against meta.json's Companions (never a raw directory
+	// listing) and basename-only (no traversal).
+	mux.HandleFunc("/companions/", func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimPrefix(r.URL.Path, "/companions/")
+		if name == "" || name != filepath.Base(name) {
+			http.NotFound(w, r)
+			return
+		}
+		meta, err := plan.LoadMeta(planDir)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		for _, n := range meta.Companions {
+			if n == name {
+				w.Header().Set("Cache-Control", "no-store")
+				http.ServeFile(w, r, filepath.Join(planDir, plan.CompanionsDir, name))
+				return
+			}
+		}
+		http.NotFound(w, r)
 	})
 
 	// /healthz: unauthenticated identity probe (loopback only). A second
@@ -420,9 +445,14 @@ func renderLive(gitRoot, slug, base, token string) ([]byte, error) {
 	}
 	in := plan.Parse(planMD)
 	review, _ := plan.AssembleReview(info.Dir)
+	var companionNames []string
+	if meta, merr := plan.LoadMeta(info.Dir); merr == nil {
+		companionNames = meta.Companions
+	}
 	return plan.RenderHTMLOpts(in, res, plan.RenderOptions{
 		Slug: slug, Review: review, ReviewEndpoint: base, ReviewToken: token,
 		PriorArtURL: priorArtURLResolver(gitRoot),
+		Companions:  plan.CompanionRefs(companionNames),
 	})
 }
 
@@ -512,8 +542,13 @@ func (b *broadcaster) broadcast() {
 
 // reviewStaticFallback renders to a file and prints the clipboard-export path for
 // environments with no browser/server.
-func reviewStaticFallback(cmd *cobra.Command, gitRoot, slug string, in plan.Input, res plan.Result, review []plan.MergedItem) error {
-	html, err := plan.RenderHTMLOpts(in, res, plan.RenderOptions{Slug: slug, Review: review, PriorArtURL: priorArtURLResolver(gitRoot)})
+func reviewStaticFallback(cmd *cobra.Command, gitRoot, slug, planDir string, in plan.Input, res plan.Result, review []plan.MergedItem) error {
+	companions := savedCompanionFiles(planDir)
+	var companionNames []string
+	for _, c := range companions {
+		companionNames = append(companionNames, c.Name)
+	}
+	html, err := plan.RenderHTMLOpts(in, res, plan.RenderOptions{Slug: slug, Review: review, PriorArtURL: priorArtURLResolver(gitRoot), Companions: plan.CompanionRefs(companionNames)})
 	if err != nil {
 		return fmt.Errorf("render plan: %w", err)
 	}
@@ -522,6 +557,11 @@ func reviewStaticFallback(cmd *cobra.Command, gitRoot, slug string, in plan.Inpu
 	path := filepath.Join(os.TempDir(), safeSlug+"-review.html")
 	if err := os.WriteFile(path, html, 0o644); err != nil {
 		return fmt.Errorf("write render: %w", err)
+	}
+	if len(companions) > 0 {
+		if _, cerr := plan.CopyCompanions(companions, os.TempDir()); cerr != nil {
+			cli.PrintHint("could not place companion(s) next to the render: " + cerr.Error())
+		}
 	}
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "Rendered review page: %s\n", cli.StyleFile.Render(path))

--- a/cmd/ox/plan_review.go
+++ b/cmd/ox/plan_review.go
@@ -264,7 +264,18 @@ func liveReviewHandler(gitRoot, slug, planDir, base, token string, bc *broadcast
 		for _, n := range meta.Companions {
 			if n == name {
 				w.Header().Set("Cache-Control", "no-store")
-				http.ServeFile(w, r, filepath.Join(planDir, plan.CompanionsDir, name))
+				f, err := os.Open(filepath.Join(planDir, plan.CompanionsDir, n))
+				if err != nil {
+					http.NotFound(w, r)
+					return
+				}
+				defer f.Close()
+				info, err := f.Stat()
+				if err != nil || info.IsDir() {
+					http.NotFound(w, r)
+					return
+				}
+				http.ServeContent(w, r, n, info.ModTime(), f)
 				return
 			}
 		}

--- a/cmd/ox/plan_review.go
+++ b/cmd/ox/plan_review.go
@@ -94,6 +94,13 @@ func reviewSaveDraft(cmd *cobra.Command, file string) (string, error) {
 	if dir == "" {
 		return "", fmt.Errorf("could not save draft to the ledger")
 	}
+	if companions := gatherCompanions(cmd, in); len(companions) > 0 {
+		if names, cerr := plan.CopyCompanions(companions, dir); cerr != nil {
+			cli.PrintHint("could not bundle companion(s): " + cerr.Error())
+		} else if rerr := plan.RecordCompanions(dir, names); rerr != nil {
+			cli.PrintHint("could not record companion(s) in plan meta: " + rerr.Error())
+		}
+	}
 	return plan.Slugify(planTopic(in)), nil
 }
 
@@ -443,10 +450,28 @@ func renderLive(gitRoot, slug, base, token string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	in := plan.Parse(planMD)
 	review, _ := plan.AssembleReview(info.Dir)
+	meta, merr := plan.LoadMeta(info.Dir)
+
+	// HTML-primary plan: serve the AUTHORED page with the ox chrome injected
+	// live (enrichment overlay + review layer wired to this server). Falls
+	// through to the generated render only if the authored page is unreadable
+	// (LFS pointer, missing file) — the review loop must still function.
+	if merr == nil && meta.Primary == plan.PrimaryHTML {
+		if path, _, isPointer, exists := plan.PlanHTMLPath(info.Dir); exists && !isPointer {
+			if authored, rerr := os.ReadFile(path); rerr == nil {
+				return plan.InjectChrome(authored, plan.BuildChromeData(res, plan.RenderOptions{
+					Slug: slug, Review: review, ReviewEndpoint: base, ReviewToken: token,
+					PriorArtURL: priorArtURLResolver(gitRoot),
+				})), nil
+			}
+		}
+		cli.PrintHint("authored plan.html unavailable (LFS pointer or unreadable) — serving the generated render of the derived markdown")
+	}
+
+	in := plan.Parse(planMD)
 	var companionNames []string
-	if meta, merr := plan.LoadMeta(info.Dir); merr == nil {
+	if merr == nil {
 		companionNames = meta.Companions
 	}
 	return plan.RenderHTMLOpts(in, res, plan.RenderOptions{

--- a/cmd/ox/plan_review_test.go
+++ b/cmd/ox/plan_review_test.go
@@ -43,6 +43,53 @@ func reviewPOST(t *testing.T, url, token, body string) int {
 	return resp.StatusCode
 }
 
+// TestReviewLoop_ServesAllowlistedCompanions verifies the /companions/ route:
+// a companion listed in meta.json is served byte-for-byte, while an unlisted
+// file in the same subdir and any non-basename path 404 — the allowlist is
+// meta.Companions, never a directory listing. Failure prevented: the review
+// loop rendering a companion card whose link dead-ends, or the route serving
+// arbitrary plan-dir files.
+func TestReviewLoop_ServesAllowlistedCompanions(t *testing.T) {
+	planDir := t.TempDir()
+	compDir := filepath.Join(planDir, plan.CompanionsDir)
+	if err := os.MkdirAll(compDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(compDir, "deep-dive.html"), []byte("<html>rich</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(compDir, "unlisted.html"), []byte("<html>no</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// meta.json allowlists only deep-dive.html
+	if err := os.WriteFile(filepath.Join(planDir, "meta.json"),
+		[]byte(`{"topic":"t","slug":"p","companions":["deep-dive.html"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, _, _ := newTestReviewServer(t, planDir)
+
+	get := func(path string) (int, string) {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(resp.Body)
+		return resp.StatusCode, buf.String()
+	}
+
+	if code, body := get("/companions/deep-dive.html"); code != http.StatusOK || body != "<html>rich</html>" {
+		t.Errorf("allowlisted companion: code=%d body=%q", code, body)
+	}
+	for _, path := range []string{"/companions/unlisted.html", "/companions/", "/companions/../meta.json"} {
+		if code, _ := get(path); code != http.StatusNotFound {
+			t.Errorf("GET %s = %d, want 404", path, code)
+		}
+	}
+}
+
 // TestReviewLoop_FeedbackEndpointTokenGated verifies a round POST is token-gated,
 // persisted, and signaled. Failure prevented: any local process posting feedback,
 // or a submit lost instead of reaching the agent.

--- a/cmd/ox/plan_save_test.go
+++ b/cmd/ox/plan_save_test.go
@@ -40,8 +40,8 @@ func runPlanSaveWith(t *testing.T, args ...string) (string, error) {
 func TestPlanSave_RequiresPlanAndAnnotations(t *testing.T) {
 	t.Run("missing --plan", func(t *testing.T) {
 		_, err := runPlanSaveWith(t, "--annotations", "ann.json")
-		if err == nil || !strings.Contains(err.Error(), "--plan is required") {
-			t.Fatalf("want --plan required error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "--file <plan.html|plan.md>") {
+			t.Fatalf("want the pass---file guidance error, got %v", err)
 		}
 	})
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.11.1"
+  "version": "0.12.0"
 }

--- a/docs/reference/decision/enrich.mdx
+++ b/docs/reference/decision/enrich.mdx
@@ -50,3 +50,4 @@ ox decision enrich [flags]
 ### SEE ALSO
 
 * [ox decision](/decision)	 - Work with Decision Records (ADRs, DDRs) — enrich with team context
+

--- a/docs/reference/decision/index.mdx
+++ b/docs/reference/decision/index.mdx
@@ -43,3 +43,4 @@ LLM/network cost; every citation it emits resolves.
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
 * [ox decision enrich](/decision/enrich)	 - Enrich a Decision Record (or DR topic) with team context (JSON by default)
+

--- a/docs/reference/plan/abandon.mdx
+++ b/docs/reference/plan/abandon.mdx
@@ -1,28 +1,33 @@
 ---
-title: "ox plan view"
-description: "CLI reference for ox plan view"
-sidebar_position: 81
+title: "ox plan abandon"
+description: "CLI reference for ox plan abandon"
+sidebar_position: 71
 ---
 
-## ox plan view
+## ox plan abandon
 
-Read a saved plan in the terminal
+Mark a saved plan abandoned
+
+### Synopsis
+
+Mark a saved plan abandoned. --reason records why, for the status timeline.
 
 ```
-ox plan view <slug> [flags]
+ox plan abandon <slug> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for view
+  -h, --help            help for abandon
+      --json            emit {"changed":...,"status":...} as JSON
+      --reason string   why the plan was abandoned
 ```
 
 ### Options inherited from parent commands
 
 ```
   -c, --config string    config file path (default: .sageox/config.yaml)
-      --json             output in JSON format (default: false)
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)

--- a/docs/reference/plan/approve.mdx
+++ b/docs/reference/plan/approve.mdx
@@ -1,28 +1,34 @@
 ---
-title: "ox plan view"
-description: "CLI reference for ox plan view"
-sidebar_position: 81
+title: "ox plan approve"
+description: "CLI reference for ox plan approve"
+sidebar_position: 72
 ---
 
-## ox plan view
+## ox plan approve
 
-Read a saved plan in the terminal
+Mark a saved plan approved
+
+### Synopsis
+
+Mark a saved plan approved — the same action a reviewer's Approve button
+in 'ox plan review' takes (both go through the same event-log engine).
+Idempotent: approving an already-approved plan is a no-op (changed:false).
 
 ```
-ox plan view <slug> [flags]
+ox plan approve <slug> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for view
+  -h, --help   help for approve
+      --json   emit {"changed":...,"status":...} as JSON
 ```
 
 ### Options inherited from parent commands
 
 ```
   -c, --config string    config file path (default: .sageox/config.yaml)
-      --json             output in JSON format (default: false)
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)

--- a/docs/reference/plan/enrich.mdx
+++ b/docs/reference/plan/enrich.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan enrich"
 description: "CLI reference for ox plan enrich"
-sidebar_position: 71
+sidebar_position: 73
 ---
 
 ## ox plan enrich
@@ -14,8 +14,13 @@ Enrich an agent-generated implementation plan with deterministic SageOx
 signals (collision, prior-art, expert-routing) and a context bundle the agent
 can reason over. ox computes badges locally — no LLM or network call.
 
-Output is JSON by default (the agent/plumbing path). Use --text for a human
-summary. Reads the plan from --file or stdin, else the newest ~/.claude/plans/*.md.
+Input modes (precedence order):
+  --topic "<subject>" [--files a,b,c]   consult BEFORE drafting a plan
+  --file <plan.md>                      an existing plan document
+  stdin                                 a plan piped from another tool
+  (none of the above)                   auto-discover the newest ~/.claude/plans/*.md
+
+Output is JSON by default (the agent/plumbing path). Use --text for a human summary.
 
 ```
 ox plan enrich [flags]
@@ -24,10 +29,12 @@ ox plan enrich [flags]
 ### Options
 
 ```
-      --file string   plan source file (default: stdin, else newest ~/.claude/plans/*.md)
-  -h, --help          help for enrich
-      --persist       also save + commit a draft to the ledger (used by the ExitPlanMode hook)
-      --text          human-readable summary instead of the default JSON output
+      --file string     plan source file (default: stdin, else newest ~/.claude/plans/*.md)
+      --files strings   comma-separated repo-relative files the topic touches (optional, with --topic)
+  -h, --help            help for enrich
+      --persist         also save + commit a draft to the ledger (used by the ExitPlanMode hook)
+      --text            human-readable summary instead of the default JSON output
+      --topic string    consult mode: the plan subject, before drafting
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -17,8 +17,17 @@ Work with SageOx-enriched implementation plans.
   review   serve a plan and collect human review feedback (the review loop)
   list     browse saved plans
   view     read a saved plan in the terminal
+  status   show a saved plan's lifecycle timeline and current status
 
-Agents: 'ox plan enrich' returns JSON team context (collision / prior-art /
+Lifecycle verbs — approve, work, realize, abandon, supersede — are thin sugar
+over one event-log engine (browser Approve in 'ox plan review' and
+'ox plan approve' are the same mechanism). Each accepts --json for
+{"changed":bool,"status":...} and is idempotent: re-running an
+already-applied verb is a safe no-op.
+
+Agents: run 'ox plan enrich --topic "<subject>" [--files a,b,c]' BEFORE
+drafting a plan, and 'ox plan enrich --file <plan.md>' (or stdin) once
+drafted — both return JSON team context (collision / prior-art /
 expert-routing) at zero LLM/network cost. When a human is shaping a plan,
 recommend 'ox plan render --open' to view it and 'ox plan review <slug>' for an
 inline review loop — those are human-opt-in, never auto-run.
@@ -43,9 +52,15 @@ inline review loop — those are human-opt-in, never auto-run.
 ### SEE ALSO
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+* [ox plan abandon](/plan/abandon)	 - Mark a saved plan abandoned
+* [ox plan approve](/plan/approve)	 - Mark a saved plan approved
 * [ox plan enrich](/plan/enrich)	 - Enrich an implementation plan with SageOx team context (JSON by default)
 * [ox plan list](/plan/list)	 - Browse saved ledger plans
+* [ox plan realize](/plan/realize)	 - Mark a saved plan realized (its intent was carried out)
 * [ox plan render](/plan/render)	 - Render a plan to a self-contained HTML page
 * [ox plan review](/plan/review)	 - Open a live review loop for a saved plan (serve, collect, auto-reload, approve)
+* [ox plan status](/plan/status)	 - Show a saved plan's lifecycle timeline and current status
+* [ox plan supersede](/plan/supersede)	 - Mark a saved plan superseded by a successor plan
 * [ox plan view](/plan/view)	 - Read a saved plan in the terminal
+* [ox plan work](/plan/work)	 - Record that a coding session worked on a saved plan
 

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan list"
 description: "CLI reference for ox plan list"
-sidebar_position: 72
+sidebar_position: 74
 ---
 
 ## ox plan list

--- a/docs/reference/plan/realize.mdx
+++ b/docs/reference/plan/realize.mdx
@@ -1,0 +1,45 @@
+---
+title: "ox plan realize"
+description: "CLI reference for ox plan realize"
+sidebar_position: 75
+---
+
+## ox plan realize
+
+Mark a saved plan realized (its intent was carried out)
+
+### Synopsis
+
+Mark a saved plan realized — the artifact-agnostic terminal status: the
+plan's intent was carried out by some means, not necessarily "implemented"
+(code shipped). One event records both the status change and the session
+edge in a single append. --produced records what shipped (a PR URL, commit,
+etc.); --session overrides the ambient session.
+
+```
+ox plan realize <slug> [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for realize
+      --json              emit {"changed":...,"status":...} as JSON
+      --produced string   what shipped (a PR URL, commit, etc.)
+      --session string    explicit session id (overrides the ambient live-recording session)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
+

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -33,7 +33,7 @@ ox plan render [slug] [flags]
 ### Options
 
 ```
-      --artifact            render a strictly self-contained, CSP-safe page for publishing as a Claude Code Artifact (no external fonts/scripts, no review loop; enrichment links preserved)
+      --artifact            render a self-contained page for publishing as a Claude Code Artifact (no external fonts/scripts, no review loop; enrichment links preserved)
       --companion strings   bundle a rich self-contained HTML companion with the plan (repeatable; relative .html links in the plan markdown are auto-detected)
       --file string         plan source file when no slug is given (default: stdin, else newest ~/.claude/plans/*.md)
   -h, --help                help for render

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan render"
 description: "CLI reference for ox plan render"
-sidebar_position: 73
+sidebar_position: 76
 ---
 
 ## ox plan render
@@ -10,7 +10,15 @@ Render a plan to a self-contained HTML page
 
 ### Synopsis
 
-Render a plan to a self-contained HTML page.
+Render a plan.
+
+PREFERRED input is an authored, self-contained HTML page — the plan of record
+(docs/specs/plan-authoring-html.md): ox derives searchable markdown from it,
+computes team-context enrichment, and serves the page with the ox chrome
+INJECTED (enrichment overlay + review loop appended before </body>; the
+author's markup is never rewritten). --artifact emits the authored page
+VERBATIM. Markdown input remains the quick-plan path and renders through the
+built-in template (tabs, TL;DR hero, auto-visualizations).
 
 No slug renders the plan from --file/stdin; a slug renders a saved plan with its
 review state. With --open on a SAVED plan, ox launches the live review loop
@@ -25,12 +33,13 @@ ox plan render [slug] [flags]
 ### Options
 
 ```
-      --artifact        render a strictly self-contained, CSP-safe page for publishing as a Claude Code Artifact (no external fonts/scripts, no review loop; enrichment links preserved)
-      --file string     plan source file when no slug is given (default: stdin, else newest ~/.claude/plans/*.md)
-  -h, --help            help for render
-      --open            open the rendered HTML in your browser
-  -o, --output string   write the rendered HTML to this path
-      --static          with --open on a saved plan, open a read-only static page instead of launching the live review loop
+      --artifact            render a strictly self-contained, CSP-safe page for publishing as a Claude Code Artifact (no external fonts/scripts, no review loop; enrichment links preserved)
+      --companion strings   bundle a rich self-contained HTML companion with the plan (repeatable; relative .html links in the plan markdown are auto-detected)
+      --file string         plan source file when no slug is given (default: stdin, else newest ~/.claude/plans/*.md)
+  -h, --help                help for render
+      --open                open the rendered HTML in your browser
+  -o, --output string       write the rendered HTML to this path
+      --static              with --open on a saved plan, open a read-only static page instead of launching the live review loop
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/plan/review/await.mdx
+++ b/docs/reference/plan/review/await.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan review await"
 description: "CLI reference for ox plan review await"
-sidebar_position: 75
+sidebar_position: 78
 ---
 
 ## ox plan review await

--- a/docs/reference/plan/review/index.mdx
+++ b/docs/reference/plan/review/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan review"
 description: "CLI reference for ox plan review"
-sidebar_position: 74
+sidebar_position: 77
 ---
 
 ## ox plan review

--- a/docs/reference/plan/status.mdx
+++ b/docs/reference/plan/status.mdx
@@ -1,28 +1,34 @@
 ---
-title: "ox plan view"
-description: "CLI reference for ox plan view"
-sidebar_position: 81
+title: "ox plan status"
+description: "CLI reference for ox plan status"
+sidebar_position: 79
 ---
 
-## ox plan view
+## ox plan status
 
-Read a saved plan in the terminal
+Show a saved plan's lifecycle timeline and current status
+
+### Synopsis
+
+Show a saved plan's lifecycle: the folded current status plus the full
+events.jsonl timeline (created/revised/approved/worked/realized/abandoned/
+superseded), one line per event. Pure reader — never writes.
 
 ```
-ox plan view <slug> [flags]
+ox plan status <slug> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for view
+  -h, --help   help for status
+      --json   emit the current-state projection as JSON
 ```
 
 ### Options inherited from parent commands
 
 ```
   -c, --config string    config file path (default: .sageox/config.yaml)
-      --json             output in JSON format (default: false)
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)

--- a/docs/reference/plan/supersede.mdx
+++ b/docs/reference/plan/supersede.mdx
@@ -1,28 +1,35 @@
 ---
-title: "ox plan view"
-description: "CLI reference for ox plan view"
-sidebar_position: 81
+title: "ox plan supersede"
+description: "CLI reference for ox plan supersede"
+sidebar_position: 80
 ---
 
-## ox plan view
+## ox plan supersede
 
-Read a saved plan in the terminal
+Mark a saved plan superseded by a successor plan
+
+### Synopsis
+
+Mark a saved plan superseded by a successor plan. --by <successor-slug> is
+required and must resolve to another saved plan — validated before anything
+is recorded.
 
 ```
-ox plan view <slug> [flags]
+ox plan supersede <slug> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for view
+      --by string   the successor plan's slug (required)
+  -h, --help        help for supersede
+      --json        emit {"changed":...,"status":...} as JSON
 ```
 
 ### Options inherited from parent commands
 
 ```
   -c, --config string    config file path (default: .sageox/config.yaml)
-      --json             output in JSON format (default: false)
       --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
       --profile          generate CPU profile and execution trace for performance analysis (default: false)
   -q, --quiet            suppress non-error output (default: false)

--- a/docs/reference/plan/work.mdx
+++ b/docs/reference/plan/work.mdx
@@ -1,0 +1,42 @@
+---
+title: "ox plan work"
+description: "CLI reference for ox plan work"
+sidebar_position: 82
+---
+
+## ox plan work
+
+Record that a coding session worked on a saved plan
+
+### Synopsis
+
+Record that a coding session worked on a saved plan. Edge-only: it never
+changes the plan's Status, only its session history. --session overrides the
+ambient session detected from a live recording (explicit beats inferred).
+
+```
+ox plan work <slug> [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for work
+      --json             emit {"changed":...,"status":...} as JSON
+      --session string   explicit session id (overrides the ambient live-recording session)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox plan](/plan)	 - Work with implementation plans (enrich, render, review)
+

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox query"
 description: "CLI reference for ox query"
-sidebar_position: 77
+sidebar_position: 83
 ---
 
 ## ox query

--- a/docs/reference/recap.mdx
+++ b/docs/reference/recap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox recap"
 description: "CLI reference for ox recap"
-sidebar_position: 78
+sidebar_position: 84
 ---
 
 ## ox recap

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox release-notes"
 description: "CLI reference for ox release-notes"
-sidebar_position: 79
+sidebar_position: 85
 ---
 
 ## ox release-notes

--- a/docs/reference/scout.mdx
+++ b/docs/reference/scout.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox scout"
 description: "CLI reference for ox scout"
-sidebar_position: 80
+sidebar_position: 86
 ---
 
 ## ox scout

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session audit"
 description: "CLI reference for ox session audit"
-sidebar_position: 82
+sidebar_position: 88
 ---
 
 ## ox session audit

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session"
 description: "CLI reference for ox session"
-sidebar_position: 81
+sidebar_position: 87
 ---
 
 ## ox session

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session lint"
 description: "CLI reference for ox session lint"
-sidebar_position: 83
+sidebar_position: 89
 ---
 
 ## ox session lint

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session list"
 description: "CLI reference for ox session list"
-sidebar_position: 83
+sidebar_position: 90
 ---
 
 ## ox session list
@@ -18,10 +18,18 @@ Sessions are sorted by date with newest first.
 By default, only shows sessions from the last 7 days for performance.
 Use --all to show all sessions regardless of age.
 
+Use --repo to list another repo's sessions by filesystem path instead of
+the current directory. The path must be the repo root (.sageox/config.json
+must exist directly there — subdirectories are not walked up). Local
+session data reflects the --repo target, but ledger-merged sessions still
+come from the CURRENT directory's configured ledger — this only matters
+if the two repos use different team ledgers.
+
 Examples:
   ox session list              # show last 10 from past 7 days
   ox session list --limit 20   # show last 20 from past 7 days
   ox session list --all        # show all sessions (may be slow)
+  ox session list --repo /path/to/other/repo  # list a different repo's sessions
 
 ```
 ox session list [flags]
@@ -30,9 +38,10 @@ ox session list [flags]
 ### Options
 
 ```
-      --all         show all sessions regardless of age (may be slow)
-  -h, --help        help for list
-      --limit int   maximum sessions to show (0 for no limit) (default 10)
+      --all           show all sessions regardless of age (may be slow)
+  -h, --help          help for list
+      --limit int     maximum sessions to show (0 for no limit) (default 10)
+      --repo string   list sessions for a different repo by filesystem path (must be the repo root; default: current repo)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/session/prune.mdx
+++ b/docs/reference/session/prune.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session prune"
 description: "CLI reference for ox session prune"
-sidebar_position: 84
+sidebar_position: 91
 ---
 
 ## ox session prune
@@ -60,3 +60,4 @@ ox session prune [flags]
 ### SEE ALSO
 
 * [ox session](/session)	 - Manage AI coworker sessions
+

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session redact"
 description: "CLI reference for ox session redact"
-sidebar_position: 86
+sidebar_position: 92
 ---
 
 ## ox session redact

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session regenerate"
 description: "CLI reference for ox session regenerate"
-sidebar_position: 87
+sidebar_position: 93
 ---
 
 ## ox session regenerate

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session repair-meta-summary"
 description: "CLI reference for ox session repair-meta-summary"
-sidebar_position: 88
+sidebar_position: 94
 ---
 
 ## ox session repair-meta-summary

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session score"
 description: "CLI reference for ox session score"
-sidebar_position: 89
+sidebar_position: 95
 ---
 
 ## ox session score

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session status"
 description: "CLI reference for ox session status"
-sidebar_position: 90
+sidebar_position: 96
 ---
 
 ## ox session status

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session stop"
 description: "CLI reference for ox session stop"
-sidebar_position: 90
+sidebar_position: 97
 ---
 
 ## ox session stop
@@ -16,6 +16,7 @@ Use 'ox session status' to see active recordings and their agent IDs.
 
 Examples:
   ox session stop --agent-id OxzAbc    # stop a specific session
+  ox session stop --current             # stop the calling agent's own recording
   ox session stop                       # lists active recordings if no agent ID given
 
 ```
@@ -26,6 +27,7 @@ ox session stop [flags]
 
 ```
       --agent-id string   agent ID of the session to stop
+      --current           stop the calling agent's own recording (uses SAGEOX_AGENT_ID)
   -h, --help              help for stop
 ```
 

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session token-optimize"
 description: "CLI reference for ox session token-optimize"
-sidebar_position: 92
+sidebar_position: 98
 ---
 
 ## ox session token-optimize

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session view"
 description: "CLI reference for ox session view"
-sidebar_position: 93
+sidebar_position: 99
 ---
 
 ## ox session view

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox status"
 description: "CLI reference for ox status"
-sidebar_position: 94
+sidebar_position: 100
 ---
 
 ## ox status

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox sync"
 description: "CLI reference for ox sync"
-sidebar_position: 95
+sidebar_position: 101
 ---
 
 ## ox sync

--- a/docs/reference/teams.mdx
+++ b/docs/reference/teams.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox teams"
 description: "CLI reference for ox teams"
-sidebar_position: 96
+sidebar_position: 102
 ---
 
 ## ox teams

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox uninstall"
 description: "CLI reference for ox uninstall"
-sidebar_position: 97
+sidebar_position: 103
 ---
 
 ## ox uninstall

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox upgrade"
 description: "CLI reference for ox upgrade"
-sidebar_position: 98
+sidebar_position: 104
 ---
 
 ## ox upgrade

--- a/docs/specs/plan-authoring-html.md
+++ b/docs/specs/plan-authoring-html.md
@@ -37,7 +37,7 @@ page that set the standard for what a plan can feel like:
 - **Side-by-side comparison panes** and **verdict cards**.
 - **Design-system dark palette**: canvas `#0b0d0b`, surface `#111411`, accent
   `#99c693`, Inter + Spline Sans Mono.
-- **Self-contained single file** — inline CSS/JS, no external dependencies.
+- **Self-contained local page** — inline CSS/JS, no external dependencies.
 
 A plan page that merely reformats prose has missed the point; the page should do
 work a document cannot.
@@ -68,7 +68,8 @@ and to ungrouped review anchors.
   via `ox plan review <slug>`.
 - Injection is **idempotent and append-only** — re-rendering replaces the marker
   block and never touches authored markup.
-- `--artifact` serves/writes the authored page **verbatim**, zero injection.
+- `--artifact` serves/writes the authored page **verbatim**, zero injection; any
+  inline CSS/JS already present in the authored file remains part of that file.
 
 ## What ox derives — the markdown contract
 
@@ -118,5 +119,6 @@ Good for a small plan; it approximates. A material plan gets an authored page.
 The plan is the developer's **own local content rendered locally for that
 developer**: the review server binds `127.0.0.1` and is token-gated, so author
 scripting is a feature, not a threat — the interactivity is the point.
-`--artifact` is the strict, CSP-safe export for when the page needs to travel
-beyond the local loop.
+`--artifact` is the self-contained export for when the page needs to travel
+beyond the local loop; it does not add external dependencies or ox review
+scripts, and it does not rewrite authored inline assets.

--- a/docs/specs/plan-authoring-html.md
+++ b/docs/specs/plan-authoring-html.md
@@ -1,0 +1,122 @@
+# Plan authoring: the rich HTML page leads
+
+**Status:** active · **Owner:** plan/enrich · **Related:** [plan-render-adoption.md](plan-render-adoption.md) (adoption levers), [ADR-021](../adr/ADR-021-ox-plan-context-not-inference.md) (context, not inference), [ADR-025](../adr/ADR-025-plan-annotation-and-feedback-delivery.md) (annotation + feedback delivery)
+
+## The inversion
+
+The richest artifact leads. An AI coworker (or human) authors a **rich,
+self-contained interactive HTML page first** — that page IS the plan of record.
+Markdown is **extracted from** the HTML by ox: never authored in parallel, never
+required.
+
+This inverts the earlier flow (author markdown → the binary renders HTML). The
+reason is markdown's representational ceiling: a deterministic markdown renderer
+can approximate tabs and timelines, but it cannot reach what a purpose-built page
+delivers — interactive inspectors, animated comparisons, layouts shaped to the
+specific argument. The richest, best visualizations and ability to communicate
+ideas and information are what should be generated first; everything ox needs
+(terminal view, search, enrichment) is derived from that page, not the other way
+around.
+
+| Artifact | Produced by | Role |
+|---|---|---|
+| `plan.html` | Author (AI coworker or human) | **Plan of record.** Stored verbatim in the ledger plan dir |
+| `plan.md` | ox, derived on every save | Terminal view (`ox plan view`), search, enrichment input. **Never hand-edit** — regenerated from the HTML |
+| `meta.json` | ox | Records `"primary": "html"` |
+| ox chrome | ox, injected at render/serve time | Enrichment overlay + footer credit + live review loop |
+
+## The quality bar
+
+The bar is the **SageOx conversation-format comparison page** — the hand-built
+page that set the standard for what a plan can feel like:
+
+- **Tabbed views** behind a sticky nav.
+- **Interactive field inspectors** — hover or click a field, its counterpart
+  lights up, a docked explainer updates.
+- **Animated timelines** with toggles.
+- **Side-by-side comparison panes** and **verdict cards**.
+- **Design-system dark palette**: canvas `#0b0d0b`, surface `#111411`, accent
+  `#99c693`, Inter + Spline Sans Mono.
+- **Self-contained single file** — inline CSS/JS, no external dependencies.
+
+A plan page that merely reformats prose has missed the point; the page should do
+work a document cannot.
+
+## The minimal authoring contract
+
+Everything below is optional and degrades gracefully. **A page with none of these
+hooks still works** — ox falls back to the title / first heading for the topic
+and to ungrouped review anchors.
+
+| Hook | What ox uses it for | Fallback when absent |
+|---|---|---|
+| `<title>` | Plan topic → slug + terminal listings | First heading, else filename |
+| `<meta name="ox-plan-slug" content="...">` | Explicit slug override | Slug derived from title |
+| H2 headings **or** `data-ox-section="Name"` on view containers | Groups enrichment badges and review anchors by section; gives the derived markdown its H2s | Ungrouped anchors; flat derived markdown |
+
+## What ox injects — the chrome contract
+
+`ox plan render --file plan.html` serves the authored page with the ox chrome
+**injected — never wrapped, never rewritten**:
+
+- A script+style bundle **appended before `</body>`**, between
+  `<!-- ox-chrome:start -->` / `<!-- ox-chrome:end -->` markers.
+- The bundle carries: (a) the **SageOx enrichment overlay** — collision /
+  prior-art / expert-routing chips plus surfaced context; (b) the **footer
+  credit**; (c) the full **live review loop** — click any element to attach a
+  mark, content-hash anchored so it works on arbitrary authored markup, served
+  via `ox plan review <slug>`.
+- Injection is **idempotent and append-only** — re-rendering replaces the marker
+  block and never touches authored markup.
+- `--artifact` serves/writes the authored page **verbatim**, zero injection.
+
+## What ox derives — the markdown contract
+
+`ox plan save --file plan.html` stores the authored page as the canonical
+artifact and derives `plan.md` from it automatically:
+
+- Headings, paragraphs, lists, tables, and code carry over directly.
+- Tabs and `[data-ox-section]` view containers become **H2 sections**.
+- Interactive-only content **degrades to its text**.
+- The derived markdown is regenerated on **every** save — never hand-edit it.
+- `ox plan view` and search read the derived markdown; enrichment runs over it.
+
+## Command flow
+
+```mermaid
+flowchart LR
+  AUTH["Author plan.html<br/>(rich, self-contained page)"] --> SAVE["ox plan save --file plan.html"]
+  SAVE --> LEDGER["Ledger plan dir:<br/>plan.html verbatim, primary html"]
+  SAVE --> DERIVE["Derive plan.md,<br/>enrich from it"]
+  AUTH --> SERVE["ox plan render --file plan.html --open"]
+  SERVE --> CHROME["Inject ox chrome<br/>(overlay, credit, review loop)"]
+  CHROME --> LOOP["ox plan review slug<br/>(live marks write back)"]
+  SERVE -->|"with --artifact"| VERBATIM["Authored page verbatim,<br/>zero injection"]
+```
+
+Author `plan.html` → `ox plan save --file plan.html` (or `ox plan render --file
+plan.html --open`) → `ox plan review <slug>` for the live loop.
+
+## The markdown quick path (still supported)
+
+`ox plan render --file plan.md` and `ox plan save --plan ...` remain — **for
+quick, low-stakes plans only**. The markdown renderer auto-renders:
+
+| Markdown input | Auto-rendered as |
+|---|---|
+| More than 3 H2 sections | Tabbed views |
+| Leading summary | TL;DR hero |
+| `:::compare` … `:::` blocks | Side-by-side comparison panes |
+| ` ```html-interactive ` fences | Passthrough interactive blocks |
+| Gated-track tables | Swimlanes |
+| Comparison tables | Click-to-inspect field inspector |
+
+Good for a small plan; it approximates. A material plan gets an authored page.
+
+## Trust posture
+
+The plan is the developer's **own local content rendered locally for that
+developer**: the review server binds `127.0.0.1` and is token-gated, so author
+scripting is a feature, not a threat — the interactivity is the point.
+`--artifact` is the strict, CSP-safe export for when the page needs to travel
+beyond the local loop.

--- a/docs/specs/plan-render-adoption.md
+++ b/docs/specs/plan-render-adoption.md
@@ -4,15 +4,20 @@
 
 ## The problem
 
-`ox plan render` turns an implementation plan into a self-contained HTML page that
+`ox plan render` serves an implementation plan as a self-contained HTML page that
 folds in SageOx team context — open-PR / active-file collisions, prior art, expert
-routing — and saves it to the ledger where teammates find it. None of that is
-reproducible by an agent rendering HTML on its own: the enrichment lives **behind
-the SageOx API**.
+routing — and `ox plan save` persists it to the ledger where teammates find it.
+Since the HTML-first inversion ([plan-authoring-html.md](plan-authoring-html.md)),
+the primary path is an *authored* page (`--file plan.html`) into which ox injects
+its chrome; the binary still renders the page itself on the quick markdown path.
+Either way, none of the enrichment is reproducible by an agent on its own: it
+lives **behind the SageOx API**.
 
-Yet agents often **don't** use it. They emit a plain-markdown plan, or reach for
-their **own** HTML-rendering skill, producing a *context-blind orphan*: a page that
-carries none of the team context and never reaches the ledger.
+Yet agents often **don't** use it. They emit a plain-markdown plan, or author an
+HTML page and stop there — never passing it through `ox plan save` / `ox plan
+render` — producing a *context-blind orphan*: a page that carries none of the
+team context, gets no review loop, and never reaches the ledger. Authoring the
+page is now the sanctioned default; **bypassing ox** is the failure mode.
 
 Three hard constraints shape every fix:
 

--- a/extensions/claude/skills/ox-plan/SKILL.md
+++ b/extensions/claude/skills/ox-plan/SKILL.md
@@ -1,34 +1,37 @@
 ---
 name: ox-plan
 description: >-
-  Enrich an implementation plan with SageOx team context, then render it with
-  `ox plan render` — the binary owns the HTML. This skill does the one thing the
-  binary can't: it reasons the `ox plan enrich` context bundle (open-PR / active-
-  file collisions, prior art, expert routing) into CITED, section-anchored
-  judgment badges, and authors the plan markdown (diagrams, mockups, structure)
-  so the deterministic renderer has something worth drawing. It does NOT hand-
-  author HTML/CSS — `ox plan render` produces the self-contained page (badge rail,
-  Mermaid, light/dark, review loop) for every agent, so Claude and Codex get the
-  same render. Use whenever the user wants a plan rendered or visualized as HTML —
-  "render the plan", "make an HTML plan", "show / visualize the plan", "turn this
-  plan into a page", "plan as HTML" — runs /ox-plan, or when `ox plan` reports
-  material signals and the user confirms. Whether to render at all is decided by
-  the `ox plan` JSON (signals.material, guidance) plus the user's confirmation /
-  plan.html config — not by this skill.
+  Author the plan as a rich, self-contained interactive HTML page FIRST — that
+  page IS the plan of record — then hand it to ox: `ox plan save --file
+  plan.html` stores it in the ledger, derives the markdown from it, and computes
+  the deterministic badges; `ox plan render --file plan.html` serves it with the
+  ox chrome (enrichment overlay + footer credit + live review loop) injected,
+  never rewritten. This skill's authoring energy goes into the page itself —
+  tabs, field inspectors, data-driven visualizations, the dark design register
+  (contract + quality bar: docs/specs/plan-authoring-html.md) — and into
+  reasoning the `ox plan enrich` context bundle into CITED, section-anchored
+  judgment badges (optional, via --annotations). Markdown-first survives only as
+  the quick path for small, low-stakes plans. Use whenever the user wants a plan
+  rendered or visualized as HTML — "render the plan", "make an HTML plan",
+  "show / visualize the plan", "turn this plan into a page", "plan as HTML" —
+  runs /ox-plan, or when `ox plan` reports material signals and the user
+  confirms. Whether to render at all is decided by the `ox plan` JSON
+  (signals.material, guidance) plus the user's confirmation / the `plan.html`
+  config setting — not by this skill.
 ---
 
 <!-- Keep behavioral "when to render" guidance lean — that belongs in the
      `ox plan` JSON output (signals.material, guidance) and in the
      <plan-enrichment-guidance> block from `ox agent prime`, not duplicated here.
-     What legitimately lives in THIS skill is agent-side orchestration the binary
-     CANNOT do: (1) reasoning the context bundle into cited judgment badges, and
-     (2) authoring the plan markdown so the render has substance. The HTML itself
-     is produced by `ox plan render` (internal/plan/render.go + assets) so every
-     agent — Claude, Codex, Amp — gets the identical page. Do NOT hand-roll HTML. -->
+     What legitimately lives in THIS skill is what the binary CANNOT do:
+     (1) authoring the rich interactive page that IS the plan of record, and
+     (2) reasoning the context bundle into cited judgment badges. ox owns the
+     chrome (enrichment overlay, footer credit, review loop — injected between
+     ox-chrome markers) and the derived plan.md — never hand-author those. -->
 
-**Whether to render at all is decided by the `ox plan` JSON (`signals.material`, `guidance`) + the user's confirmation / `plan.html` config — not by this skill.** Do not nag on trivial plans; honor the command's signal.
+**Whether to render at all is decided by the `ox plan` JSON (`signals.material`, `guidance`) + the user's confirmation / the `plan.html` config setting — not by this skill.** Do not nag on trivial plans; honor the command's signal.
 
-**The binary renders. You don't.** `ox plan render <slug>` turns a saved plan (with your merged judgment badges) into the self-contained HTML — badge rail, Mermaid, light/dark toggle, swimlane timelines, device mockups, review loop. Never write raw HTML/CSS to a `.html` file and pass it as `--html`. Your job is the two things the deterministic renderer cannot do for itself: **author cited judgment badges**, and **author plan markdown worth rendering**.
+**You author the page. ox injects the chrome.** For any material plan, author a rich, self-contained interactive HTML page — that page IS the plan of record. `ox plan save --file plan.html` stores it verbatim in the ledger, derives `plan.md` from it, and computes the deterministic badges itself. `ox plan render --file plan.html` serves it with the ox chrome injected (append-only, between `<!-- ox-chrome:start/end -->` markers — never wrapped, never rewritten). Contract + quality bar: **docs/specs/plan-authoring-html.md**. Markdown-first remains only the quick path for small, low-stakes plans.
 
 ---
 
@@ -36,30 +39,31 @@ description: >-
 
 ```mermaid
 flowchart TB
-  RUN["Run ox plan enrich --json on the active plan"] --> DET["ox returns DETERMINISTIC badges + context bundle (0 LLM tokens)"]
+  RUN["Run ox plan enrich --json on the topic or draft"] --> DET["ox returns DETERMINISTIC badges + context bundle (0 LLM tokens)"]
   DET --> READ["Agent reads the context bundle: murmurs, sessions, decisions, ADRs, expert artifacts"]
-  READ --> JUDGE["Agent authors JUDGMENT badges, CITED-ONLY (aligns / conflicts / expert-perspective)"]
-  READ --> MD["Agent authors the plan MARKDOWN: hero diagram, mockups, structure"]
-  JUDGE --> MERGE["Merge: ox --json annotations + agent judgment badges into one annotations.json"]
-  MD --> SAVE
-  MERGE --> SAVE["ox plan save --plan &lt;md&gt; --annotations &lt;merged.json&gt;  (no --html)"]
+  READ --> PAGE["Agent authors plan.html: tabs, inspectors, data-driven viz, dark design register"]
+  READ --> JUDGE["Optional: agent authors JUDGMENT badges, CITED-ONLY (aligns / conflicts / expert-perspective)"]
+  PAGE --> SAVE["ox plan save --file plan.html  (ox derives plan.md + deterministic badges; --annotations optional)"]
+  JUDGE --> SAVE
   SAVE --> GATE{"Render confirmed? (user asked OR plan.html recommend + confirm)"}
   GATE -->|"no"| DONE["Saved to ledger; report slug"]
-  GATE -->|"yes"| RENDER["ox plan render &lt;slug&gt; --open  (binary renders + opens review loop)"]
+  GATE -->|"yes"| RENDER["ox plan render --file plan.html --open  (ox injects chrome, opens review loop)"]
 ```
 
 1. **Get the deterministic signals + context bundle.** Run:
 
    ```bash
-   ox plan enrich --json --file <plan-file>   # or pipe the plan on stdin
+   ox plan enrich --json --file <plan-file>   # or --topic "<subject>" before drafting
    ```
 
    This makes **no LLM or network call**. It returns a `Result` JSON:
-   - `annotations[]` — deterministic, ox-computed badges: `collision`, `prior-art`, `expert-routing`. Each carries `{section, kind:"deterministic", type, why, source_url, expert, files}`. These are **factual** — keep them as-is, do not second-guess them.
+   - `annotations[]` — deterministic, ox-computed badges: `collision`, `prior-art`, `expert-routing`. Each carries `{section, kind:"deterministic", type, why, source_url, expert, files}`. These are **factual** — keep them as-is, do not second-guess them. On save, ox computes these itself; you never re-author them.
    - `context[]` — the pre-retrieved bundle the agent reasons over: `{kind: murmur|session|decision|adr|commit|discussion, title, ref, snippet, score, author, when}`.
    - `signals` — `{collisions, prior_art, expert_routes, material}`. `material` is ox's call on whether a render is worth recommending.
 
-2. **Author the JUDGMENT badges (the agent's job — ox does NO inference).** Read the `context[]` bundle and produce judgment annotations:
+2. **Author the page (the main event — see "Authoring the page" below).** Build the rich, self-contained `plan.html` that carries the plan's whole argument: tabbed views, interactive inspectors, data-driven visualizations, the dark design register.
+
+3. **Optionally author JUDGMENT badges (ox does NO inference).** Read the `context[]` bundle and produce judgment annotations — additive, passed via `--annotations`:
    - `aligns` / `conflicts` — does the plan agree or clash with a cited ADR, decision, or convention?
    - `expert-perspective` — the synthesized stance of the area expert.
 
@@ -67,7 +71,7 @@ flowchart TB
    - Never invent an opinion, a quote, or a conflict. Precision over recall.
    - When the evidence is **thin or ambiguous, degrade to a routing nudge** — `expert-perspective` becomes "consult `<name>`" (naming the expert from `annotations[].expert`), NOT a fabricated stance. Putting words in a teammate's mouth is the one failure mode that destroys trust.
    - When unsure whether a conflict is real, downgrade to "Novel — no prior decision found," not a false `conflicts`.
-   - Set `kind:"judgment"` on every badge you author so the renderer styles it distinctly from ox's deterministic ones (outlined vs. filled — the binary owns that treatment).
+   - Set `kind:"judgment"` on every badge you author so the chrome styles it distinctly from ox's deterministic ones (outlined vs. filled — ox owns that treatment).
 
    **NEVER dump the `context[]` bundle into the plan.** The bundle is your *reasoning input*, not output. A bundle item becomes a badge *only* after you reason over it into a cited judgment attached to a specific plan section. An item you can't turn into a section-anchored, cited badge does not appear at all. Worked example:
 
@@ -77,85 +81,70 @@ flowchart TB
    >
    > If the same ADR were only tangentially related: degrade to `expert-perspective` → "consult `<name>`", NOT a pasted raw snippet.
 
-3. **Author the plan markdown so the render has substance (see "Authoring the plan markdown" below).** Put the hero diagram, any mockups, and the decision/appendix structure INTO the plan markdown file — the renderer draws what the markdown contains. Edit the plan file in place before saving.
-
-4. **Merge annotations and persist with `ox plan save` — no `--html`.**
+4. **Persist with `ox plan save`.**
 
    ```bash
-   ox plan save --plan <plan-file> --annotations <merged.json>
+   ox plan save --file plan.html [--annotations <judgment.json>]
    ```
 
-   - `--annotations <merged.json>` is the **merged** annotations: take the `ox plan enrich --json` Result and **append your judgment badges** to its `annotations[]` array (keep `signals`, `context`, and the deterministic badges intact). That merged file is stored as `annotations.json`.
-   - **Do NOT pass `--html`.** You are not producing HTML — the binary does that in the next step. `ox plan save` persists the markdown + merged annotations to `data/plans/YYYY-MM-DD-<slug>/` and prints the slug.
+   ox stores the authored page verbatim as the canonical artifact (`meta.json` records `"primary":"html"`), derives `plan.md` from it (headings/paragraphs/lists/tables/code; tabs and `[data-ox-section]` views become H2 sections), computes the deterministic badges, and prints the slug. `--annotations` merges in your judgment badges. **Never hand-edit the derived `plan.md`** — it is regenerated on every save.
 
-5. **Render with the binary (only when a render is confirmed).**
+5. **Render with chrome (only when a render is confirmed).**
 
    ```bash
-   ox plan render <slug> --open
+   ox plan render --file plan.html --open
    ```
 
-   `ox plan render <slug>` loads the saved plan — **including your judgment badges** — and produces the self-contained HTML deterministically, then `--open` launches the live review loop (`ox plan review`) so the human's marks write back to the ledger. On a headless shell it prints the path. Nothing you write by hand is involved. **Never render HTML just to populate the ledger** — the markdown + annotations are the canonical artifact; the render is on demand.
+   ox serves your authored page with the chrome injected — the enrichment overlay (collision / prior-art / expert-routing chips, **including your judgment badges**), the footer credit, and the live review loop (click any element to attach a mark; content-hash anchored, so it works on your arbitrary markup). `--open` launches `ox plan review <slug>` so the human's marks write back to the ledger. On a headless shell it prints the path. `--artifact` exports the authored page verbatim, zero injection.
 
 ---
 
-## Authoring the plan markdown (your input to the renderer)
+## Authoring the page (your artifact)
 
-The renderer is only as good as the markdown you hand it. `ox plan render` faithfully renders the plan's markdown and injects the badges — so the diagrams, mockups, and structure that make a plan legible must live **in the plan markdown**, authored by you, before you save. It processes ` ```mermaid ` fences, passes through inline HTML (device mockups, `<details>`), and highlights code fences — so everything below is authored as ordinary markdown/inline-HTML in the plan file.
+**The contract and the quality bar live in `docs/specs/plan-authoring-html.md` — read it before authoring.** The bar is the SageOx conversation-format comparison page: tabbed views behind a sticky nav, interactive field inspectors (hover/click a field, its counterpart lights up, a docked explainer updates), animated timelines with toggles, side-by-side comparison panes, verdict cards, the design-system dark palette (canvas `#0b0d0b`, surface `#111411`, accent `#99c693`, Inter + Spline Sans Mono), all in one self-contained file. A page that merely reformats prose has missed the point.
+
+The minimal hooks (all optional, all degrade gracefully): `<title>` for the topic/slug, `<meta name="ox-plan-slug">` to pin the slug, and H2 headings or `data-ox-section="Name"` on view containers so enrichment badges and review anchors group by section. A page with none of these still works.
 
 ### The reader's ten minutes — audience & time contract
 
-You are writing for a **senior / principal engineer or EM whose time is worth ~$10,000/hour.** They will spend **no more than ten minutes** and must walk away able to decide. Author the markdown against that budget:
+You are writing for a **senior / principal engineer or EM whose time is worth ~$10,000/hour.** They will spend **no more than ten minutes** and must walk away able to decide. Author the page against that budget:
 
-- **Lead with the conclusion**, the decision needed, and the biggest risk — not the backstory. Open with a tight `TL;DR` (problem, approach, cost, biggest risk).
-- **The plan stands on its own.** Never reference a symbol, file, ID, or PR without enough context to understand *why it matters* — a reader who hasn't opened the codebase still follows the argument. A bare `scribe-jbf00` is wasted ink.
-- **No minutiae up top.** Describe how the system behaves and why the change matters, not how each function is wired. **Relocate, don't delete:** push exact `file:line` steps and code trivia into ONE `<details>` **"Implementation notes"** block at the BOTTOM — essential to the implementing agent, invisible to the ten-minute approver. (This two-layer contract also comes from `ox plan enrich`'s `guidance`; author the markdown to that shape.)
-- **Concise is a feature.** Every sentence, row, and section earns its place or is cut. If it can't be skimmed in ten minutes it has failed, however correct.
+- **Lead with the conclusion**, the decision needed, and the biggest risk — not the backstory. The opening view is a tight TL;DR (problem, approach, cost, biggest risk).
+- **The plan stands on its own.** Never reference a symbol, file, ID, or PR without enough context to understand *why it matters* — a reader who hasn't opened the codebase still follows the argument.
+- **No minutiae up top.** Interaction is your relocation tool: exact `file:line` steps and code trivia live in a collapsed "Implementation notes" view — essential to the implementing agent, invisible to the ten-minute approver.
+- **Every element earns its pixels.** Interactivity that compresses understanding (an inspector, a toggleable timeline) is the point; interactivity as decoration is noise.
 
-### Diagrams do the heavy lifting
+### Visualizations do the heavy lifting
 
-Prefer a diagram over a paragraph wherever a relationship, flow, state machine, sequence, or before/after exists. **Every plan gets at least one "the shape in one picture" hero diagram near the top.** Author them as ` ```mermaid ` fences; the binary renders and theme-toggles them. Pick the type by the QUESTION the reader is asking:
-
-| The reader is asking… | Diagram type | Earns its place when |
-|---|---|---|
-| "In what **order**, how many round-trips?" | `sequenceDiagram` (≤ 4–5 participants) | a call path crosses components/services/async boundaries |
-| "**What connects to** what?" (topology) | `flowchart LR` dependency graph | revealing coupling, blast radius, a contended boundary |
-| "What are the **steps and branches**?" | `flowchart TB` + decision gates | a pipeline/algorithm with conditionals — the default hero |
-| "What **states** and **transitions**?" | `stateDiagram-v2` | a lifecycle, session model, retry/backoff |
-| "**When**, in what sequence, how long?" | timeline / swimlane (see below) | phases, rollout, parallel work, latency budget |
-
-Never draw two diagrams that show the same thing. If a diagram needs more than ~7 nodes / ~5 participants to be honest, it is two diagrams — split it.
-
-Apply the **GitHub-strict Mermaid rules from CLAUDE.md**: double-quote every node label containing anything beyond `[A-Za-z0-9 ]`; never use arrow-shaped substrings (`->`, `=>`, `<->`) inside labels (substitute `to`, `→`, or a comma); never use reserved-ish IDs (`PR`, `URL`, `IO`, `IS`, `AS`, `END` — rename to `DPR`, `DURL`, …); quote path-shaped labels; use `<br/>` not `\n`. `ox plan render` runs a Mermaid lint and surfaces broken/non-portable diagrams as `plan-diagram [...]` advisories — treat each as a fix, not a suggestion.
-
-For **timing** (phases, rollout, parallel work, latency budget) include a timing visual. A calendar-accurate schedule → Mermaid `gantt` with `dateFormat YYYY-MM-DD`. A relative-effort sequence → the renderer's CSS **swimlane** primitive (do NOT use `gantt` with numeric `dateFormat X` — it renders a meaningless axis).
-
-### User-facing mockups
-
-If the plan changes anything the user sees or hears, show the resulting UI state — don't describe it in prose. The renderer ships a **device-mockup primitive**: run `ox plan viz device-mockup` for the inline-HTML snippet (`<div class="device ios">` with `.device-statusbar` / `.device-titlebar` / `.device-row` and an iOS action sheet, `.ox` marking the single highlighted destination). Paste it into the plan markdown; the binary styles it. Annotate behavior in user-facing language ("a subtle chime plays"), never with a source filename. For a net-new or multi-state flow, recommend the `/design-mockup` skill.
+Prefer a visualization over a paragraph wherever a relationship, flow, state machine, sequence, comparison, or before/after exists — and in an authored page you are not limited to static diagrams: build the inspector, animate the timeline, wire the hover states. `ox plan viz` remains a useful snippet catalog (swimlanes, risk matrices, device mockups) to adapt into the page. For user-facing changes, show the resulting UI state — don't describe it in prose.
 
 ### What you do NOT author
 
-Typography, palette, light/dark toggle, badge rail, provenance chips, OX markers, scroll-spy nav, self-contained-HTML packaging — **all of that is the renderer's job** (`internal/plan/render.go` + `assets/`). Do not reproduce it in markdown, and do not hand-write a `.html` file. If the render is missing something you expected (a badge treatment, a diagram sizing rule), that is a gap in the binary — file a bd issue against the Go renderer, don't patch it with hand-authored HTML.
+The **ox chrome** — enrichment overlay, footer credit, review loop — is injected by ox between `<!-- ox-chrome:start/end -->` markers; never hand-roll it, never write inside the markers. The **derived `plan.md`** is ox's output; never author or edit it. If the chrome is missing something you expected (a badge treatment, an overlay behavior), that is a gap in the binary — file a bd issue, don't fake it in the page.
+
+---
+
+## The quick path (markdown, low-stakes only)
+
+For a **small, low-stakes plan** where an authored page isn't worth the effort, markdown-first remains: author the plan markdown, then `ox plan save --plan <md> [--annotations ...]` and `ox plan render --file plan.md`. The renderer now auto-renders tabs (>3 H2 sections), a TL;DR hero, `:::compare`/`:::` side-by-side panes, ` ```html-interactive ` passthrough fences, and auto-visualizations (gated-track tables → swimlanes; comparison tables → a click-to-inspect field inspector). It approximates; a material plan gets an authored page. Apply the GitHub-strict Mermaid rules from CLAUDE.md to any ` ```mermaid ` fences, and treat `plan-diagram [...]` advisories as fixes, not suggestions.
 
 ---
 
 ## SageOx attribution
 
-The renderer injects the earned, conditional SageOx credit by construction (a restrained footer line + the `● ox-computed` marker on deterministic badges) — you don't add it, and you must not overclaim. When the plan carried enrichment, `ox plan render` / `ox plan save` lint the output for this contract (footer credit + anchored OX marker; no overclaim on un-enriched plans; no live-remote avatar). Re-check anytime with `ox plan lint <slug>` (`--strict` to fail on findings). A clean lint is part of "done."
+The chrome injects the earned, conditional SageOx credit by construction (a restrained footer line + the `● ox-computed` marker on deterministic badges) — you don't add it, and you must not overclaim. When the plan carried enrichment, `ox plan render` / `ox plan save` lint the output for this contract (footer credit + anchored OX marker; no overclaim on un-enriched plans; no live-remote avatar). Re-check anytime with `ox plan lint <slug>` (`--strict` to fail on findings). A clean lint is part of "done."
 
 ---
 
 ## Process
 
 1. Run `ox plan enrich --json` to get deterministic badges + the context bundle (0 tokens, local).
-2. Read the `context[]` bundle; author judgment badges **cited-only**, degrading to "consult `<name>`" when evidence is thin. Merge them into the enrich `annotations[]`.
-3. Author the plan markdown to the ten-minute contract: TL;DR up top, one hero diagram, mockups for user-facing changes, minutiae in a bottom `<details>` appendix. Edit the plan file in place.
-4. `ox plan save --plan <plan-file> --annotations <merged.json>` — persist markdown + merged badges (no `--html`).
-5. **If no render is confirmed:** stop here — report the saved slug (`ox plan view <slug>` reads it in the terminal). Steps 6–7 apply only once a render exists.
-6. **If a render is confirmed:** `ox plan render <slug> --open` — the binary renders (including your badges) and opens the review loop. Address any `plan-diagram [...]` / `plan-craft [...]` advisories it prints.
-7. **Architect review pass (recommended for material plans, render only).** Spawn an `architect` (or general-purpose) subagent to read the rendered page *as the $10k/hour principal reader*: is the decision + biggest risk up top and graspable in ten minutes? Does every file/ID/PR carry enough context to matter? Do the diagrams compress understanding? Revise the plan markdown / badges and re-render until it signs off.
-8. Report the slug — and, when you rendered, the rendered path.
+2. Author `plan.html` to the contract + quality bar in `docs/specs/plan-authoring-html.md`: TL;DR view up top, interactive views that compress understanding, minutiae in a collapsed implementation-notes view.
+3. Optionally: read the `context[]` bundle and author judgment badges **cited-only**, degrading to "consult `<name>`" when evidence is thin.
+4. `ox plan save --file plan.html [--annotations <judgment.json>]` — ox stores the page, derives the markdown, computes deterministic badges, prints the slug.
+5. **If no render is confirmed:** stop here — report the saved slug (`ox plan view <slug>` reads the derived markdown in the terminal). Steps 6–7 apply only once a render exists.
+6. **If a render is confirmed:** `ox plan render --file plan.html --open` — ox injects the chrome and opens the review loop (`ox plan review <slug>`).
+7. **Architect review pass (recommended for material plans, render only).** Spawn an `architect` (or general-purpose) subagent to read the served page *as the $10k/hour principal reader*: is the decision + biggest risk up top and graspable in ten minutes? Does every file/ID/PR carry enough context to matter? Do the views compress understanding? Revise the page / badges and re-render until it signs off.
+8. Report the slug — and, when you rendered, the served/exported path.
 
-The goal: a $10k/hour principal reader skims the render's alignment strip + TL;DR + hero diagram and within ten minutes knows whether the plan aligns with team direction and whether to approve — with ox-computed facts visually separate from your cited judgment, and every badge saying where its claim comes from. You supply the reasoning and the markdown; `ox plan render` supplies the page.
-
-$ox plan enrich --json
+The goal: a $10k/hour principal reader opens the page, skims the TL;DR view + the enrichment overlay, and within ten minutes knows whether the plan aligns with team direction and whether to approve — with ox-computed facts visually separate from your cited judgment, and every badge saying where its claim comes from. You supply the page and the reasoning; ox supplies the chrome, the derived markdown, and the ledger.

--- a/internal/plan/assets/chrome.css
+++ b/internal/plan/assets/chrome.css
@@ -26,10 +26,10 @@
 .ox-chrome-chip a:hover{text-decoration:underline}
 .ox-chrome-chip[data-type="collision"]{border-left-color:var(--amber, #f59e0b)}
 .ox-chrome-chip[data-type="prior-art"]{border-left-color:var(--teal, #14b8a6)}
-.ox-chrome-chip[data-type="expert-routing"]{border-left-color:var(--copper, #e0a56a)}
+.ox-chrome-chip[data-type="expert-routing"]{border-left-color:var(--violet, #a78bfa)}
 .ox-chrome-chip[data-type="aligns"]{border-left-color:var(--sage, #99c693)}
 .ox-chrome-chip[data-type="conflicts"]{border-left-color:var(--red, #ef4444)}
-.ox-chrome-chip[data-type="expert-perspective"]{border-left-color:var(--copper, #e0a56a)}
+.ox-chrome-chip[data-type="expert-perspective"]{border-left-color:var(--violet, #a78bfa)}
 .ox-chrome-context-h{font:600 10.5px/1 "Spline Sans Mono","JetBrains Mono",monospace;text-transform:uppercase;letter-spacing:.06em;color:var(--faint, #6f7a6d);margin:12px 0 6px}
 .ox-chrome-context-item{font-size:12px;color:var(--dim, #a8b3a5);padding:5px 0;border-top:1px solid var(--hair, #252c24)}
 .ox-chrome-context-item:first-child{border-top:none}

--- a/internal/plan/assets/chrome.css
+++ b/internal/plan/assets/chrome.css
@@ -1,0 +1,138 @@
+/* ox plan — injected chrome for an AUTHORED HTML plan (developer-hand-built,
+   no scaffold.css). Two parts:
+   1. .ox-chrome-* — the SageOx enrichment overlay + footer credit (new here).
+   2. .rev-* — a self-contained copy of the review-loop styles review.js needs
+      (scaffold.css owns the canonical copy for ox-generated renders; an
+      authored page never loads that file, so review.js would otherwise run
+      unstyled).
+   Every color is var(--x, fallback): a page that already defines --sage/--panel/
+   etc. (e.g. one that reused the SageOx token names) themes the chrome for
+   free; everything else gets the SageOx green-black palette as a fallback.
+   z-index is pinned near the top of the 32-bit range (2147483xxx, not
+   scaffold.css's 55-80): an authored page's own stacking context is unknown
+   and often deliberately tall (modals, sticky tab bars), so ox-owned chrome
+   must out-rank anything the author wrote to stay clickable. */
+
+/* --- enrichment overlay (collision / prior-art / expert-routing chips) --- */
+.ox-chrome-btn{position:fixed;left:16px;bottom:64px;z-index:2147483000;width:38px;height:38px;border-radius:50%;background:var(--panel, #111411);border:1px solid var(--hair, #252c24);color:var(--sage, #99c693);font:600 11px/1 "Spline Sans Mono","JetBrains Mono",monospace;letter-spacing:.02em;cursor:pointer;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35));display:flex;align-items:center;justify-content:center;transition:transform .15s,border-color .15s}
+.ox-chrome-btn:hover{border-color:var(--sage, #99c693);transform:translateY(-1px)}
+.ox-chrome-panel{position:fixed;left:16px;bottom:110px;z-index:2147482999;width:340px;max-width:calc(100vw - 32px);max-height:70vh;overflow-y:auto;background:var(--panel, #111411);border:1px solid var(--hair, #252c24);border-radius:10px;padding:12px;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35));display:none}
+.ox-chrome-panel.open{display:block}
+.ox-chrome-panel-h{font:600 11px/1 "Spline Sans Mono","JetBrains Mono",monospace;text-transform:uppercase;letter-spacing:.08em;color:var(--faint, #6f7a6d);margin-bottom:10px}
+.ox-chrome-chip{padding:8px 10px;margin-bottom:6px;background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);border-left:3px solid var(--hair, #252c24);border-radius:7px;font:13px/1.45 Inter,system-ui,sans-serif;color:var(--ink, #e8ede7)}
+.ox-chrome-chip b{display:block;font-size:12.5px;margin-bottom:2px}
+.ox-chrome-chip span{color:var(--dim, #a8b3a5)}
+.ox-chrome-chip a{color:var(--sage, #99c693);text-decoration:none;font-size:11.5px;margin-left:4px;white-space:nowrap}
+.ox-chrome-chip a:hover{text-decoration:underline}
+.ox-chrome-chip[data-type="collision"]{border-left-color:var(--amber, #f59e0b)}
+.ox-chrome-chip[data-type="prior-art"]{border-left-color:var(--teal, #14b8a6)}
+.ox-chrome-chip[data-type="expert-routing"]{border-left-color:var(--copper, #e0a56a)}
+.ox-chrome-chip[data-type="aligns"]{border-left-color:var(--sage, #99c693)}
+.ox-chrome-chip[data-type="conflicts"]{border-left-color:var(--red, #ef4444)}
+.ox-chrome-chip[data-type="expert-perspective"]{border-left-color:var(--copper, #e0a56a)}
+.ox-chrome-context-h{font:600 10.5px/1 "Spline Sans Mono","JetBrains Mono",monospace;text-transform:uppercase;letter-spacing:.06em;color:var(--faint, #6f7a6d);margin:12px 0 6px}
+.ox-chrome-context-item{font-size:12px;color:var(--dim, #a8b3a5);padding:5px 0;border-top:1px solid var(--hair, #252c24)}
+.ox-chrome-context-item:first-child{border-top:none}
+.ox-chrome-context-item b{color:var(--faint, #6f7a6d);font-weight:600;text-transform:uppercase;font-size:10px;letter-spacing:.04em;margin-right:6px}
+
+/* --- footer credit strip --- */
+.ox-chrome-foot{position:static;padding:16px 20px 28px;font:11.5px/1.5 "Spline Sans Mono","JetBrains Mono",monospace;color:var(--faint, #6f7a6d);text-align:center;border-top:1px solid var(--hair, #252c24);margin-top:24px}
+.ox-chrome-foot a{color:var(--sage, #99c693);text-decoration:none}
+.ox-chrome-foot a:hover{text-decoration:underline}
+
+/* --- in-document review layer (ox plan review / feedback) ---
+   copied from assets/scaffold.css; keep the two in sync by hand when the
+   review-loop markup changes (review.js is the shared source of truth for
+   which classes exist; this file only supplies their paint). */
+.rev-status{background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);border-left:3px solid var(--copper, #e0a56a);border-radius:9px;padding:10px 14px;margin:12px 0 6px;font-size:13.5px;color:var(--dim, #a8b3a5)}
+.rev-status-tag{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--copper, #e0a56a);margin-right:8px}
+.rev-status strong{color:var(--ink, #e8ede7)}
+.rev-bar{position:fixed;left:16px;bottom:16px;z-index:2147483000;display:flex;align-items:center;gap:8px;background:var(--panel, #111411);border:1px solid var(--hair, #252c24);border-radius:9px;padding:6px 8px;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35))}
+.rev-bar button{background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);color:var(--dim, #a8b3a5);border-radius:6px;padding:4px 9px;font-size:12px;cursor:pointer;font-family:"Spline Sans Mono","JetBrains Mono",monospace}
+.rev-bar button:hover{color:var(--ink, #e8ede7)}
+.rev-bar .rev-toggle.on{background:var(--sage, #99c693);border-color:var(--sage, #99c693);color:#0c1112}
+.rev-bar .rev-submit{border-color:var(--copper, #e0a56a);color:var(--copper, #e0a56a)}
+.rev-bar .rev-count{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--faint, #6f7a6d)}
+.rev-bar .rev-who{max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--faint, #6f7a6d)}
+.rev-bar .rev-who:hover{color:var(--sage, #99c693);border-color:var(--sage, #99c693)}
+body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.rev-on tr:hover,body.rev-on .ox-chip:hover,body.rev-on .stat:hover,body.rev-on .bar-row:hover,body.rev-on [data-ox-section]:hover{outline:1px dashed var(--sage, #99c693);outline-offset:2px;cursor:crosshair}
+/* inline mark glyph — redundant encoding: distinct GLYPH per status, color reinforces (never color alone) */
+.rev-marked,.rev-committed{position:relative;box-shadow:inset 3px 0 0 var(--hair, #252c24)}
+.rev-glyph{position:absolute;left:-1.25em;top:0;font-size:12px;line-height:1.5;color:var(--dim, #a8b3a5)}
+.rev-marked[data-rev="approve"]{box-shadow:inset 3px 0 0 var(--sage, #99c693)} .rev-marked[data-rev="approve"] .rev-glyph{color:var(--sage, #99c693)}
+.rev-marked[data-rev="request-change"]{box-shadow:inset 3px 0 0 var(--amber, #f59e0b)} .rev-marked[data-rev="request-change"] .rev-glyph{color:var(--amber, #f59e0b)}
+.rev-marked[data-rev="flag"]{box-shadow:inset 3px 0 0 var(--red, #ef4444)} .rev-marked[data-rev="flag"] .rev-glyph{color:var(--red, #ef4444)}
+.rev-marked[data-rev="comment"]{box-shadow:inset 3px 0 0 var(--copper, #e0a56a)} .rev-marked[data-rev="comment"] .rev-glyph{color:var(--copper, #e0a56a)}
+/* committed states: addressed/verified struck + green-check; open keeps status; wontfix muted */
+.rev-committed[data-revstate="addressed"],.rev-committed[data-revstate="verified"]{box-shadow:inset 3px 0 0 var(--sage, #99c693)}
+.rev-committed[data-revstate="addressed"] .rev-glyph,.rev-committed[data-revstate="verified"] .rev-glyph{color:var(--sage, #99c693)}
+.rev-committed[data-revstate="open"]{box-shadow:inset 3px 0 0 var(--amber, #f59e0b)} .rev-committed[data-revstate="open"] .rev-glyph{color:var(--amber, #f59e0b)}
+.rev-committed[data-revstate="wontfix"] .rev-glyph{color:var(--faint, #6f7a6d)}
+.rev-pop{position:absolute;z-index:2147483001;width:280px;background:var(--panel, #111411);border:1px solid var(--hair, #252c24);border-radius:9px;padding:10px;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35))}
+.rev-pop .rev-row{display:flex;flex-wrap:wrap;gap:5px;margin:4px 0}
+.rev-pop .rev-s{flex:1 1 auto;background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);color:var(--dim, #a8b3a5);border-radius:5px;padding:3px 6px;font-size:10.5px;cursor:pointer;font-family:"Spline Sans Mono","JetBrains Mono",monospace}
+/* control color PREDICTS the resulting mark color */
+.rev-pop .rev-s[data-s="approve"].on{background:var(--sage, #99c693);border-color:var(--sage, #99c693);color:#0c1112}
+.rev-pop .rev-s[data-s="request-change"].on{background:var(--amber, #f59e0b);border-color:var(--amber, #f59e0b);color:#0c1112}
+.rev-pop .rev-s[data-s="flag"].on{background:var(--red, #ef4444);border-color:var(--red, #ef4444);color:#fff}
+.rev-pop .rev-s[data-s="comment"].on{background:var(--copper, #e0a56a);border-color:var(--copper, #e0a56a);color:#0c1112}
+.rev-pop .rev-note{width:100%;min-height:54px;background:var(--bg, #0b0d0b);border:1px solid var(--hair, #252c24);border-radius:5px;color:var(--ink, #e8ede7);font-family:Inter,system-ui,sans-serif;font-size:12.5px;padding:6px;resize:vertical}
+.rev-pop .rev-save{flex:1;background:var(--sage, #99c693);border:1px solid var(--sage, #99c693);color:#0c1112;border-radius:5px;padding:4px;font-size:11px;cursor:pointer}
+.rev-pop .rev-del{background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);color:var(--dim, #a8b3a5);border-radius:5px;padding:4px 8px;font-size:11px;cursor:pointer}
+.rev-pop .rev-cap{font-size:11.5px;color:var(--dim, #a8b3a5);margin-bottom:6px}
+.rev-pop .rev-accept{flex:1;background:var(--sage, #99c693);border:1px solid var(--sage, #99c693);color:#0c1112;border-radius:5px;padding:4px;font-size:11px;cursor:pointer}
+.rev-pop .rev-reopen{background:var(--panel2, #171b17);border:1px solid var(--amber, #f59e0b);color:var(--amber, #f59e0b);border-radius:5px;padding:4px 8px;font-size:11px;cursor:pointer}
+/* top-level Approve (closes the loop) */
+.rev-bar .rev-approve{border-color:var(--sage, #99c693);color:var(--sage, #99c693)}
+.rev-bar .rev-approve:hover{background:var(--sage, #99c693);color:#0c1112}
+/* orphaned-note banner — feedback whose anchored text changed */
+.rev-orphans{position:fixed;left:50%;top:14px;transform:translateX(-50%);z-index:2147482998;max-width:680px;background:var(--panel, #111411);border:1px solid var(--amber, #f59e0b);border-left:3px solid var(--amber, #f59e0b);border-radius:9px;padding:10px 14px;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35));font-size:13px;color:var(--dim, #a8b3a5)}
+.rev-orphans-h{color:var(--amber, #f59e0b);font-weight:600;margin-bottom:4px}
+.rev-orphans ul{margin:.3em 0;padding-left:1.1em}
+.rev-orphans .rev-orphans-x{margin-top:6px;background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);color:var(--dim, #a8b3a5);border-radius:5px;padding:3px 9px;font-size:11px;cursor:pointer;font-family:"Spline Sans Mono","JetBrains Mono",monospace}
+/* first-visit discoverability bubble near the Review toggle */
+.rev-hint{position:fixed;left:96px;bottom:20px;z-index:2147482997;background:var(--copper, #e0a56a);color:#0c1112;border-radius:7px;padding:6px 10px;font-size:12px;font-weight:600;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35));animation:rev-bob 1.4s ease-in-out infinite}
+@keyframes rev-bob{0%,100%{transform:translateX(0)}50%{transform:translateX(-4px)}}
+/* review comments rail — surfaces the note TEXT (not just a margin glyph) in the
+   right gutter; each row scroll-jumps to its anchored element. */
+.rev-rail{position:fixed;top:64px;right:18px;z-index:2147482996;width:266px;max-height:calc(100vh - 100px);overflow-y:auto;background:var(--panel, #111411);border:1px solid var(--hair, #252c24);border-radius:10px;padding:10px 12px;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35))}
+.rev-rail-h{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--dim, #a8b3a5);margin-bottom:8px;display:flex;align-items:center;gap:6px}
+.rev-rail-n{background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);border-radius:8px;padding:0 6px;font-size:10.5px;color:var(--faint, #6f7a6d)}
+.rev-rail-empty{color:var(--faint, #6f7a6d);font-size:12px;line-height:1.5}
+.rev-rail-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
+.rev-rail-item{display:flex;gap:8px;padding:7px 8px;background:var(--bg, #0b0d0b);border:1px solid var(--hair, #252c24);border-left:3px solid var(--hair, #252c24);border-radius:7px;cursor:pointer}
+.rev-rail-item:hover{border-color:var(--hair, #252c24);background:var(--panel2, #171b17)}
+.rev-rail-item[data-status="approve"]{border-left-color:var(--sage, #99c693)} .rev-rail-item[data-status="approve"] .rev-rail-glyph{color:var(--sage, #99c693)}
+.rev-rail-item[data-status="request-change"]{border-left-color:var(--amber, #f59e0b)} .rev-rail-item[data-status="request-change"] .rev-rail-glyph{color:var(--amber, #f59e0b)}
+.rev-rail-item[data-status="flag"]{border-left-color:var(--red, #ef4444)} .rev-rail-item[data-status="flag"] .rev-rail-glyph{color:var(--red, #ef4444)}
+.rev-rail-item[data-status="comment"]{border-left-color:var(--copper, #e0a56a)} .rev-rail-item[data-status="comment"] .rev-rail-glyph{color:var(--copper, #e0a56a)}
+.rev-rail-glyph{flex:none;font-size:12px;line-height:1.4;color:var(--dim, #a8b3a5)}
+.rev-rail-body{min-width:0;flex:1}
+.rev-rail-sec{display:flex;align-items:center;gap:6px;margin-bottom:3px}
+.rev-rail-sec-t{flex:1;min-width:0;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px;color:var(--faint, #6f7a6d);text-transform:uppercase;letter-spacing:.03em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.rev-rail-who{flex:none;font-size:9px;border-radius:6px;padding:0 5px;border:1px solid var(--hair, #252c24);color:var(--sage, #99c693);text-transform:none;letter-spacing:0;max-width:90px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.rev-rail-note{font-size:12.5px;color:var(--ink, #e8ede7);line-height:1.45;overflow-wrap:anywhere}
+.rev-rail-note.muted{color:var(--dim, #a8b3a5)}
+.rev-rail-tag{flex:none;font-size:9px;border-radius:6px;padding:0 5px;border:1px solid var(--hair, #252c24);color:var(--dim, #a8b3a5);text-transform:uppercase;letter-spacing:.02em}
+.rev-rail-tag.unsent{color:var(--copper, #e0a56a);border-color:var(--copper, #e0a56a)}
+.rev-rail-tag.addressed,.rev-rail-tag.verified{color:var(--sage, #99c693);border-color:var(--sage, #99c693)}
+.rev-rail-tag.wontfix{color:var(--faint, #6f7a6d)}
+.rev-flash{animation:rev-flash 1.2s ease-out}
+@keyframes rev-flash{0%{background:var(--amber, #f59e0b)}100%{background:transparent}}
+/* narrow viewports: the fixed rail would cover the prose, so drop it into flow */
+@media(max-width:1400px){.rev-rail{position:static;width:auto;max-height:none;margin:24px 16px 0;right:auto;top:auto}}
+@media print{.rev-bar,.toggle,.rev-orphans,.rev-hint,.rev-rail,.ox-chrome-btn,.ox-chrome-panel{display:none}}
+/* review connection state — the page must never look live when the server is gone */
+.rev-conn{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px}
+.rev-conn.ok{color:var(--sage, #99c693)}
+.rev-conn.off{color:var(--red, #ef4444);animation:rev-conn-pulse 1.6s ease-in-out infinite}
+@keyframes rev-conn-pulse{50%{opacity:.45}}
+.rev-offline-bar{position:fixed;top:0;left:0;right:0;z-index:2147483002;background:var(--panel, #111411);border-bottom:2px solid var(--red, #ef4444);color:var(--ink, #e8ede7);padding:9px 14px;font-size:13px;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35))}
+.rev-offline-bar code{background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);border-radius:5px;padding:2px 7px;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:12px;user-select:all}
+.rev-offline-bar .rev-offline-copy{margin-left:6px;background:var(--panel2, #171b17);border:1px solid var(--hair, #252c24);color:var(--dim, #a8b3a5);border-radius:5px;padding:2px 8px;font-size:11px;cursor:pointer}
+.rev-offline-bar .rev-offline-copy:hover{color:var(--ink, #e8ede7)}
+body.rev-offline .rev-bar .rev-submit,body.rev-offline .rev-bar .rev-approve{opacity:.45;cursor:not-allowed}
+.rev-toast{position:fixed;left:16px;bottom:64px;z-index:2147483000;background:var(--panel, #111411);border:1px solid var(--sage, #99c693);color:var(--ink, #e8ede7);border-radius:9px;padding:8px 12px;font-size:12.5px;box-shadow:var(--shadow, 0 1px 0 rgba(255,255,255,.02), 0 8px 30px rgba(0,0,0,.35))}
+
+/* print: the chrome is a review surface, never part of the printed plan */
+@media print{.ox-chrome-btn,.ox-chrome-panel,.rev-bar,.rev-rail,.rev-orphans,.rev-hint,.rev-pop,.rev-offline-bar,.rev-toast,.ox-chrome-foot{display:none!important}}

--- a/internal/plan/assets/chrome.js
+++ b/internal/plan/assets/chrome.js
@@ -1,0 +1,106 @@
+// ox plan — injected chrome boot script for an AUTHORED HTML plan (a
+// developer-hand-built page ox did not generate). Runs BEFORE assets/review.js
+// in the injected bundle — script tags execute in document order, and that
+// ordering is load-bearing: review.js reads its config off document.body's
+// data-slug / data-review-endpoint / data-review-token attributes, which this
+// script must set FIRST. Vanilla, zero deps, file://-safe: an authored page
+// carries no bundler, so this has to run standalone in any browser.
+(function () {
+  var body = document.body;
+  if (!body) return;
+
+  var data = {};
+  try {
+    var island = document.getElementById('ox-chrome-data');
+    if (island) data = JSON.parse(island.textContent || '{}') || {};
+  } catch (e) {
+    data = {}; // malformed island — degrade to "no enrichment", never throw
+  }
+
+  // materialize body[data-*] BEFORE review.js's IIFE runs, so it picks up the
+  // live-server wiring (or stays in static/offline mode when unset).
+  try {
+    if (data.slug) body.setAttribute('data-slug', data.slug);
+    if (data.endpoint) body.setAttribute('data-review-endpoint', data.endpoint);
+    if (data.token) body.setAttribute('data-review-token', data.token);
+  } catch (e) {}
+
+  // an authored page has no [section id]/.ox-chip/.stat/.bar-row convention of
+  // its own — this is the Agentation-style "click any element" granularity
+  // review.js falls back to (SELECTOR = window.OX_REVIEW_SELECTOR || …).
+  try {
+    window.OX_REVIEW_SELECTOR = 'h1,h2,h3,h4,p,li,tr,pre,blockquote,figure,[data-ox-section]';
+  } catch (e) {}
+
+  var TYPE_LABEL = {
+    'collision': 'Collision', 'prior-art': 'Prior art', 'expert-routing': 'Expert',
+    'aligns': 'Aligns', 'conflicts': 'Conflicts', 'expert-perspective': 'Expert view'
+  };
+
+  function esc(s) { return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;'); }
+
+  // floating "OX" toggle + panel: collision / prior-art / expert-routing /
+  // aligns / conflicts / expert-perspective chips, plus the surfaced context
+  // items. Omitted entirely when there's nothing to show — an empty button is
+  // chrome without information (Linear register: no UI element without
+  // information value).
+  function buildOverlay() {
+    var signals = Array.isArray(data.signals) ? data.signals : [];
+    var context = Array.isArray(data.context) ? data.context : [];
+    if (!signals.length && !context.length) return;
+
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'ox-chrome-btn';
+    btn.textContent = 'OX';
+    btn.setAttribute('aria-label', 'SageOx team-context enrichment');
+    body.appendChild(btn);
+
+    var panel = document.createElement('div');
+    panel.className = 'ox-chrome-panel';
+    var html = '<div class="ox-chrome-panel-h">Team context</div>';
+    signals.forEach(function (s) {
+      var type = s && s.type ? String(s.type) : '';
+      var label = esc((s && s.label) || TYPE_LABEL[type] || type);
+      var why = esc(s && s.why);
+      var link = s && s.url ? ' <a href="' + esc(s.url) + '" target="_blank" rel="noopener noreferrer">view ↗</a>' : '';
+      html += '<div class="ox-chrome-chip" data-type="' + esc(type) + '"><b>' + label + '</b><span>' + why + '</span>' + link + '</div>';
+    });
+    if (context.length) {
+      html += '<div class="ox-chrome-context-h">Context surfaced</div>';
+      context.forEach(function (c) {
+        html += '<div class="ox-chrome-context-item"><b>' + esc(c && c.kind) + '</b>' + esc(c && c.title) + '</div>';
+      });
+    }
+    panel.innerHTML = html;
+    body.appendChild(panel);
+
+    btn.onclick = function (ev) {
+      ev.stopPropagation();
+      panel.classList.toggle('open');
+    };
+    document.addEventListener('click', function (ev) {
+      if (panel.classList.contains('open') && ev.target !== btn && !panel.contains(ev.target)) {
+        panel.classList.remove('open');
+      }
+    });
+  }
+
+  // slim credit strip, always last in the body — "earned" wording
+  // (footer_credit) only appears when enrichment actually fired; the
+  // always-on "Rendered by ox plan" nod matches the ox-generated render's
+  // same subtle brand mark so an authored plan reads as recognizably ox too.
+  function buildFooter() {
+    var parts = [];
+    if (data.footer_credit) parts.push('Team context enriched by SageOx');
+    if (data.session_url) parts.push('<a href="' + esc(data.session_url) + '" target="_blank" rel="noopener noreferrer">View session</a>');
+    parts.push('Rendered by <code>ox plan</code> · SageOx');
+    var foot = document.createElement('div');
+    foot.className = 'ox-chrome-foot';
+    foot.innerHTML = parts.join(' · ');
+    body.appendChild(foot);
+  }
+
+  try { buildOverlay(); } catch (e) {}
+  try { buildFooter(); } catch (e) {}
+})();

--- a/internal/plan/assets/chrome.js
+++ b/internal/plan/assets/chrome.js
@@ -37,7 +37,18 @@
     'aligns': 'Aligns', 'conflicts': 'Conflicts', 'expert-perspective': 'Expert view'
   };
 
-  function esc(s) { return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;'); }
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+  function safeURL(u) {
+    var raw = String(u || '').trim();
+    return /^https?:\/\//i.test(raw) ? esc(raw) : '';
+  }
 
   // floating "OX" toggle + panel: collision / prior-art / expert-routing /
   // aligns / conflicts / expert-perspective chips, plus the surfaced context
@@ -63,7 +74,8 @@
       var type = s && s.type ? String(s.type) : '';
       var label = esc((s && s.label) || TYPE_LABEL[type] || type);
       var why = esc(s && s.why);
-      var link = s && s.url ? ' <a href="' + esc(s.url) + '" target="_blank" rel="noopener noreferrer">view ↗</a>' : '';
+      var href = s ? safeURL(s.url) : '';
+      var link = href ? ' <a href="' + href + '" target="_blank" rel="noopener noreferrer">view ↗</a>' : '';
       html += '<div class="ox-chrome-chip" data-type="' + esc(type) + '"><b>' + label + '</b><span>' + why + '</span>' + link + '</div>';
     });
     if (context.length) {
@@ -93,7 +105,8 @@
   function buildFooter() {
     var parts = [];
     if (data.footer_credit) parts.push('Team context enriched by SageOx');
-    if (data.session_url) parts.push('<a href="' + esc(data.session_url) + '" target="_blank" rel="noopener noreferrer">View session</a>');
+    var sessionHref = safeURL(data.session_url);
+    if (sessionHref) parts.push('<a href="' + sessionHref + '" target="_blank" rel="noopener noreferrer">View session</a>');
     parts.push('Rendered by <code>ox plan</code> · SageOx');
     var foot = document.createElement('div');
     foot.className = 'ox-chrome-foot';

--- a/internal/plan/assets/plan.html.tmpl
+++ b/internal/plan/assets/plan.html.tmpl
@@ -6,7 +6,7 @@
 <title>{{.Title}}</title>
 {{if not .Artifact}}<link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
-<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=Spline+Sans+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
 {{end}}<style>{{.CSS}}</style>
 </head>
 <body data-slug="{{.Slug}}" data-review-endpoint="{{.ReviewEndpoint}}" data-review-token="{{.ReviewToken}}">
@@ -30,7 +30,12 @@
 <main>
   <div class="eyebrow">SageOx · enriched plan</div>
   <h1>{{.Title}}</h1>
-  {{if .HasSignals}}<div class="ox-enrich">
+  {{if .Companions}}<div class="companions">{{range .Companions}}<a class="companion-card" href="{{.Href}}" target="_blank" rel="noopener noreferrer">
+    <span class="companion-tag">Companion · interactive deep-dive</span>
+    <span class="companion-name">{{.Name}}</span>
+    <span class="companion-cap">Rich self-contained page bundled with this plan — opens in a new tab</span>
+  </a>{{end}}</div>
+  {{end}}{{if .HasSignals}}<div class="ox-enrich">
     <button class="ox-marker" aria-label="SageOx insight" title="SageOx team-context signals"><svg class="ox-ico" aria-hidden="true"><use href="#ox-ico-d" class="ico-d"></use><use href="#ox-ico-l" class="ico-l"></use></svg></button>
     <div>
       <strong>Team context enriched by SageOx</strong> — {{.SignalCount}} deterministic signal{{.Plural}} on this plan{{if .Sections}}, anchored to the sections they affect{{end}}.
@@ -41,7 +46,8 @@
   {{if .Review.HasReview}}<div class="rev-status"><span class="rev-status-tag">Review</span> <strong>{{.Review.Open}}</strong> open · {{.Review.Addressed}} addressed · {{.Review.Verified}} verified{{if .Review.Wontfix}} · {{.Review.Wontfix}} won't-fix{{end}}</div>{{end}}
   {{if .TLDR}}<div class="tldr"><span class="tldr-tag">TL;DR</span>{{.TLDR}}</div>{{end}}
   {{if .Preamble}}<section id="preamble">{{.Preamble}}</section>{{end}}
-  {{range .Sections}}<section id="{{.ID}}"{{if .IsRisk}} class="risk"{{end}}>
+  {{if .Tabbed}}<div class="tabbar" role="tablist">{{range .TOC}}<button role="tab" aria-selected="false" data-tab="{{.ID}}"><span class="n">{{.Num}}</span>{{.Heading}}</button>{{end}}</div>
+  {{end}}{{range .Sections}}<section id="{{.ID}}"{{if .IsRisk}} class="risk"{{end}}>
     <h2>{{.Heading}}</h2>
     {{if .Signals}}<div class="ox-rail">{{range .Signals}}<span class="ox-chip ox-sig-{{.Type}}"><button class="ox-marker sm" aria-label="SageOx insight" title="SageOx signal"><svg class="ox-ico" aria-hidden="true"><use href="#ox-ico-d" class="ico-d"></use><use href="#ox-ico-l" class="ico-l"></use></svg></button> <strong>{{.Label}}</strong> — {{if .URL}}<a class="src-link" href="{{.URL}}" target="_blank" rel="noopener noreferrer">{{.Why}}</a> <a class="src-go" href="{{.URL}}" target="_blank" rel="noopener noreferrer" title="Open on SageOx">view ↗</a>{{else}}{{.Why}}{{if .Source}} <span class="src">{{.Source}}</span>{{end}}{{end}}</span>{{end}}</div>{{end}}
     {{.HTML}}

--- a/internal/plan/assets/plan.html.tmpl
+++ b/internal/plan/assets/plan.html.tmpl
@@ -35,25 +35,27 @@
     <span class="companion-name">{{.Name}}</span>
     <span class="companion-cap">Rich self-contained page bundled with this plan — opens in a new tab</span>
   </a>{{end}}</div>
-  {{end}}{{if .HasSignals}}<div class="ox-enrich">
+  {{end}}{{if or .HasSignals .ContextItems}}<div class="ox-enrich">
     <button class="ox-marker" aria-label="SageOx insight" title="SageOx team-context signals"><svg class="ox-ico" aria-hidden="true"><use href="#ox-ico-d" class="ico-d"></use><use href="#ox-ico-l" class="ico-l"></use></svg></button>
     <div>
-      <strong>Team context enriched by SageOx</strong> — {{.SignalCount}} deterministic signal{{.Plural}} on this plan{{if .Sections}}, anchored to the sections they affect{{end}}.
+      <strong>Team context enriched by SageOx</strong>{{if .HasSignals}} — {{.SignalCount}} team-context signal{{.Plural}} on this plan{{if .Sections}}, anchored to the sections they affect{{end}}.{{else}} — surfaced context on this plan.{{end}}
       {{if .Signals}}<ul>{{range .Signals}}<li><span class="ox-sig-{{.Type}}">{{.Label}}</span> — {{if .URL}}<a class="src-link" href="{{.URL}}" target="_blank" rel="noopener noreferrer">{{.Why}}</a> <a class="src-go" href="{{.URL}}" target="_blank" rel="noopener noreferrer" title="Open on SageOx">view ↗</a>{{else}}{{.Why}}{{if .Source}} <span class="src">{{.Source}}</span>{{end}}{{end}}</li>
       {{end}}</ul>{{end}}
+      {{if .ContextItems}}<div class="ox-ctx"><span class="ox-ctx-cap">Context surfaced</span>{{range .ContextItems}}<span class="ox-ctx-item"><span class="ox-ctx-kind">{{.Kind}}</span> {{.Title}}</span>{{end}}</div>{{end}}
     </div>
   </div>{{end}}
   {{if .Review.HasReview}}<div class="rev-status"><span class="rev-status-tag">Review</span> <strong>{{.Review.Open}}</strong> open · {{.Review.Addressed}} addressed · {{.Review.Verified}} verified{{if .Review.Wontfix}} · {{.Review.Wontfix}} won't-fix{{end}}</div>{{end}}
   {{if .TLDR}}<div class="tldr"><span class="tldr-tag">TL;DR</span>{{.TLDR}}</div>{{end}}
+  {{if .Stats}}<div class="hero-stats">{{range .Stats}}<span class="hstat hstat-{{.Class}}"><span class="hstat-v">{{.Value}}</span><span class="hstat-l">{{.Label}}</span></span>{{end}}</div>{{end}}
   {{if .Preamble}}<section id="preamble">{{.Preamble}}</section>{{end}}
-  {{if .Tabbed}}<div class="tabbar" role="tablist">{{range .TOC}}<button role="tab" aria-selected="false" data-tab="{{.ID}}"><span class="n">{{.Num}}</span>{{.Heading}}</button>{{end}}</div>
+  {{if .Tabbed}}<div class="tabbar" aria-label="Plan sections">{{range .TOC}}<button type="button" aria-current="false" data-tab="{{.ID}}"><span class="n">{{.Num}}</span>{{.Heading}}</button>{{end}}</div>
   {{end}}{{range .Sections}}<section id="{{.ID}}"{{if .IsRisk}} class="risk"{{end}}>
     <h2>{{.Heading}}</h2>
     {{if .Signals}}<div class="ox-rail">{{range .Signals}}<span class="ox-chip ox-sig-{{.Type}}"><button class="ox-marker sm" aria-label="SageOx insight" title="SageOx signal"><svg class="ox-ico" aria-hidden="true"><use href="#ox-ico-d" class="ico-d"></use><use href="#ox-ico-l" class="ico-l"></use></svg></button> <strong>{{.Label}}</strong> — {{if .URL}}<a class="src-link" href="{{.URL}}" target="_blank" rel="noopener noreferrer">{{.Why}}</a> <a class="src-go" href="{{.URL}}" target="_blank" rel="noopener noreferrer" title="Open on SageOx">view ↗</a>{{else}}{{.Why}}{{if .Source}} <span class="src">{{.Source}}</span>{{end}}{{end}}</span>{{end}}</div>{{end}}
     {{.HTML}}
   </section>
   {{end}}
-  <div class="foot">{{if .ReviewEndpoint}}<span class="foot-live">Live review loop · powered by SageOx</span> · {{end}}{{if .FooterCredit}}Team context enriched by SageOx · {{end}}{{if .SessionURL}}<a href="{{.SessionURL}}" target="_blank" rel="noopener noreferrer">Session recording</a> · {{end}}Rendered by <code>ox plan</code> · SageOx — self-contained, agent-agnostic.</div>
+  <div class="foot">{{if .ReviewEndpoint}}<span class="foot-live">Live review loop · powered by SageOx</span> · {{end}}{{if .FooterCredit}}Team context enriched by SageOx · {{end}}{{if not .HasSignals}}<span class="foot-quiet">enrichment ran — no collisions or prior art surfaced</span> · {{end}}{{if .SessionURL}}<a href="{{.SessionURL}}" target="_blank" rel="noopener noreferrer">Session recording</a> · {{end}}Rendered by <code>ox plan</code> · SageOx — self-contained, agent-agnostic.</div>
 </main>
 </div>
 {{if not .Artifact}}<script type="application/json" id="ox-review-state">{{.ReviewJSON}}</script>

--- a/internal/plan/assets/plan.html.tmpl
+++ b/internal/plan/assets/plan.html.tmpl
@@ -55,7 +55,7 @@
     {{.HTML}}
   </section>
   {{end}}
-  <div class="foot">{{if .ReviewEndpoint}}<span class="foot-live">Live review loop · powered by SageOx</span> · {{end}}{{if .FooterCredit}}Team context enriched by SageOx · {{end}}{{if not .HasSignals}}<span class="foot-quiet">enrichment ran — no collisions or prior art surfaced</span> · {{end}}{{if .SessionURL}}<a href="{{.SessionURL}}" target="_blank" rel="noopener noreferrer">Session recording</a> · {{end}}Rendered by <code>ox plan</code> · SageOx — self-contained, agent-agnostic.</div>
+  <div class="foot">{{if .ReviewEndpoint}}<span class="foot-live">Live review loop · powered by SageOx</span> · {{end}}{{if .FooterCredit}}Team context enriched by SageOx · {{end}}{{if and .FooterCredit (not .HasSignals)}}<span class="foot-quiet">enrichment ran — no collisions or prior art surfaced</span> · {{end}}{{if .SessionURL}}<a href="{{.SessionURL}}" target="_blank" rel="noopener noreferrer">Session recording</a> · {{end}}Rendered by <code>ox plan</code> · SageOx — self-contained, agent-agnostic.</div>
 </main>
 </div>
 {{if not .Artifact}}<script type="application/json" id="ox-review-state">{{.ReviewJSON}}</script>

--- a/internal/plan/assets/review.js
+++ b/internal/plan/assets/review.js
@@ -21,7 +21,7 @@
     { id: 'flag', glyph: '⚑' },
     { id: 'comment', glyph: '◌' }
   ];
-  var SELECTOR = 'section[id], li, tr, .ox-chip, .stat, .bar-row';
+  var SELECTOR = window.OX_REVIEW_SELECTOR || 'section[id], li, tr, .ox-chip, .stat, .bar-row';
 
   var marks = load();
   var committed = parseCommitted();
@@ -65,7 +65,7 @@
 
   function fnv1a(s) { var h = 0x811c9dc5; for (var i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = (h * 0x01000193) >>> 0; } return ('0000000' + h.toString(16)).slice(-8); }
   function norm(s) { return (s || '').replace(/\s+/g, ' ').trim().toLowerCase(); }
-  function headingOf(el) { var sec = el.closest('section[id]'); if (!sec) return ''; var h = sec.querySelector('h2'); return h ? h.textContent : sec.id; }
+  function headingOf(el) { var sec = el.closest('section[id], [data-ox-section]'); if (!sec) return ''; var ds = sec.getAttribute && sec.getAttribute('data-ox-section'); if (ds) return ds; var h = sec.querySelector('h2, h3'); return h ? h.textContent : (sec.id || ''); }
   function anchorText(el) {
     var clone = el.cloneNode(true);
     clone.querySelectorAll('.rev-glyph').forEach(function (g) { g.remove(); });

--- a/internal/plan/assets/scaffold.css
+++ b/internal/plan/assets/scaffold.css
@@ -1,17 +1,18 @@
 /* ox plan — portable HTML scaffold. Generic, agent-agnostic, self-contained.
-   Palette + layout mirror the SageOx design register (Apple x Linear x Tufte).
+   Palette + layout mirror the SageOx design register (Apple x Linear x Tufte):
+   dark-first green-black (#0b0d0b canvas / #111411 surface / #99c693 accent).
    Inline plan-authored HTML (device mockups, etc.) passes through unchanged. */
 :root{
-  --bg:#0f1416; --panel:#151b1e; --panel2:#1b2327; --hair:#2a3439; --hair2:#222c30;
-  --ink:#e6edf0; --dim:#9fb0b6; --faint:#71868d;
-  --sage:#7a8f78; --sage-bright:#aebca7; --copper:#e0a56a; --amber:#f59e0b; --red:#ef4444; --teal:#14b8a6;
+  --bg:#0b0d0b; --panel:#111411; --panel2:#171b17; --hair:#252c24; --hair2:#1b211a;
+  --ink:#e8ede7; --dim:#a8b3a5; --faint:#6f7a6d;
+  --sage:#99c693; --sage-bright:#b7d4b2; --sage-deep:#4e7d4c; --copper:#e0a56a; --amber:#f59e0b; --red:#ef4444; --teal:#14b8a6;
   --slate:#64748b; --violet:#a78bfa;
-  --grad-a:#17211f; --grad-b:#141a1d; --shadow:0 1px 0 rgba(255,255,255,.02),0 8px 30px rgba(0,0,0,.35);
+  --grad-a:#131813; --grad-b:#101410; --shadow:0 1px 0 rgba(255,255,255,.02),0 8px 30px rgba(0,0,0,.35);
 }
 html[data-theme="light"]{
   --bg:#eef2ee; --panel:#fff; --panel2:#f5f8f4; --hair:#d8e0d8; --hair2:#e4ebe3;
   --ink:#16201c; --dim:#3f4d46; --faint:#566159;
-  --sage:#56745a; --sage-bright:#3f5a43; --copper:#a8613b; --amber:#b4730c; --red:#c1352f; --teal:#0c6b62;
+  --sage:#56745a; --sage-bright:#3f5a43; --sage-deep:#3f5a43; --copper:#a8613b; --amber:#b4730c; --red:#c1352f; --teal:#0c6b62;
   --slate:#5a6675; --violet:#7c5fd6;
   --grad-a:#e7efe7; --grad-b:#f3f7f2; --shadow:0 1px 0 rgba(0,0,0,.02),0 8px 26px rgba(40,60,45,.10);
 }
@@ -22,39 +23,39 @@ body{margin:0;background:var(--bg);color:var(--ink);font-family:Inter,system-ui,
 /* bottom padding reserves the bottom-left corner for the fixed .rev-bar action
    bar so it never masks the SageOx credit (.toc-brand) tucked above it */
 nav.toc{position:sticky;top:0;height:100vh;padding:26px 14px 62px 22px;border-right:1px solid var(--hair2);display:flex;flex-direction:column}
-nav.toc .brand{font-family:"JetBrains Mono",monospace;font-size:11px;letter-spacing:.14em;color:var(--faint);text-transform:uppercase;margin-bottom:16px;flex:0 0 auto}
+nav.toc .brand{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;letter-spacing:.14em;color:var(--faint);text-transform:uppercase;margin-bottom:16px;flex:0 0 auto}
 nav.toc .toc-links{flex:1 1 auto;overflow-y:auto;min-height:0}
 /* subtle SageOx wordmark badge, tucked into the bottom-left corner of the nav */
 .toc-brand{flex:0 0 auto;margin-top:14px;padding:10px 8px 2px;display:flex;flex-direction:column;gap:3px;opacity:.4;transition:opacity .15s}
 .toc-brand:hover{opacity:.75}
 .toc-brand .wm{display:block;line-height:0}
 .toc-brand svg{width:44px;height:auto;display:block}
-.toc-brand-cap{font-family:"JetBrains Mono",monospace;font-size:7.5px;letter-spacing:.05em;color:var(--faint)}
+.toc-brand-cap{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:7.5px;letter-spacing:.05em;color:var(--faint)}
 .toc-brand .wm-l{display:none}
 html[data-theme="light"] .toc-brand .wm-d{display:none}
 html[data-theme="light"] .toc-brand .wm-l{display:block}
-nav.toc a{display:block;font-family:"JetBrains Mono",monospace;font-size:11.5px;color:var(--dim);text-decoration:none;padding:5px 8px;border-left:2px solid transparent;line-height:1.4}
+nav.toc a{display:block;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11.5px;color:var(--dim);text-decoration:none;padding:5px 8px;border-left:2px solid transparent;line-height:1.4}
 nav.toc a .n{color:var(--faint);margin-right:7px}
 nav.toc a:hover{color:var(--ink)}
 nav.toc a.active{color:var(--ink);border-left-color:var(--sage)}
 main{padding:40px 46px 120px;min-width:0}
 /* hold prose to a readable measure (~72-80ch); let wide visuals opt out */
 main>section,main>.tldr,main>.ox-enrich,main>.rev-status,main>.eyebrow,main>h1,main>.foot{max-width:780px}
-main>section .mermaid,main>section .swim,main>section .statrow,main>section .barc,main>section table.heat,main>section .multiples,main>section .pbar-fig,main>section .pmapv,main>section .linec,main>section .device-row-wrap{max-width:none}
-.eyebrow{font-family:"JetBrains Mono",monospace;font-size:11.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--copper)}
+main>section .mermaid,main>section .swim,main>section .statrow,main>section .barc,main>section table.heat,main>section .multiples,main>section .pbar-fig,main>section .pmapv,main>section .linec,main>section .device-row-wrap,main>section .compare,main>section .interactive-block{max-width:none}
+.eyebrow{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--copper)}
 h1{font-family:"Space Grotesk",sans-serif;font-weight:700;font-size:40px;line-height:1.1;letter-spacing:-.035em;margin:.2em 0 .35em}
 h2{font-family:"Space Grotesk",sans-serif;font-weight:600;font-size:23px;letter-spacing:-.02em;margin:2.2em 0 .2em;padding-bottom:.3em;border-bottom:1px solid var(--hair)}
-h3{font-family:"JetBrains Mono",monospace;font-weight:500;font-size:12.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--copper);margin:1.7em 0 .5em}
+h3{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-weight:500;font-size:12.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--copper);margin:1.7em 0 .5em}
 p{margin:.7em 0}
 a{color:var(--teal)}
 strong{color:var(--ink);font-weight:600}
-code{font-family:"JetBrains Mono",monospace;font-size:.86em;background:var(--panel2);border:1px solid var(--hair2);border-radius:4px;padding:.06em .36em;color:var(--sage-bright)}
+code{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:.86em;background:var(--panel2);border:1px solid var(--hair2);border-radius:4px;padding:.06em .36em;color:var(--sage-bright)}
 pre{background:var(--panel);border:1px solid var(--hair);border-radius:8px;padding:12px 14px;overflow-x:auto}
 pre code{background:none;border:none;padding:0;color:var(--ink)}
 blockquote{border-left:3px solid var(--hair);margin:1em 0;padding:.2em 0 .2em 14px;color:var(--dim)}
 table{width:100%;border-collapse:collapse;margin:.9em 0;font-size:13.5px}
 th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--hair2);vertical-align:top}
-th{font-family:"JetBrains Mono",monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);font-weight:500}
+th{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);font-weight:500}
 ul,ol{margin:.5em 0;padding-left:1.2em}li{margin:.25em 0}
 .mermaid{margin:14px 0;background:var(--panel);border:1px solid var(--hair);border-radius:10px;padding:14px;overflow-x:auto}
 .mermaid svg{max-width:100%!important;max-height:78vh!important;height:auto!important;width:auto!important}
@@ -73,12 +74,12 @@ html[data-theme="light"] .ico-l{display:inline}
 .ox-annot-mark{width:.86em;height:.86em;vertical-align:-.13em;margin-left:1px;opacity:.85}
 .ox-enrich ul{margin:.4em 0 0;padding-left:1.1em;font-size:14px}
 .ox-enrich li{margin:.28em 0}
-.ox-enrich .src{color:var(--teal);font-family:"JetBrains Mono",monospace;font-size:.82em}
+.ox-enrich .src{color:var(--teal);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:.82em}
 /* prior-art links: the crisp "person · date · summary" label is a subtle link
    (underline only on hover); the trailing "view ↗" is the explicit click-through */
 .src-link{color:inherit;text-decoration:none;border-bottom:1px dotted var(--faint)}
 .src-link:hover{color:var(--teal);border-bottom-color:var(--teal)}
-.src-go{color:var(--faint);text-decoration:none;font-family:"JetBrains Mono",monospace;font-size:.78em;white-space:nowrap}
+.src-go{color:var(--faint);text-decoration:none;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:.78em;white-space:nowrap}
 .src-go:hover{color:var(--teal)}
 /* Fixed semantic color map (one meaning per hue; never color alone — pair with a
    text label or shape glyph): sage=good/aligns · copper=expert · amber=collision/
@@ -89,7 +90,7 @@ html[data-theme="light"] .ico-l{display:inline}
 .ox-sig-expert-routing{color:var(--copper)}
 /* TL;DR hero callout — the decision-first lede */
 .tldr{position:relative;background:linear-gradient(135deg,var(--grad-a),var(--grad-b));border:1px solid var(--hair);border-left:3px solid var(--copper);border-radius:10px;padding:16px 18px 16px 20px;margin:14px 0 8px;box-shadow:var(--shadow)}
-.tldr-tag{display:inline-block;font-family:"JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.14em;color:var(--copper);text-transform:uppercase;margin-bottom:6px}
+.tldr-tag{display:inline-block;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.14em;color:var(--copper);text-transform:uppercase;margin-bottom:6px}
 .tldr>p:first-of-type,.tldr blockquote{margin-top:0}
 .tldr blockquote{border:none;padding:0;color:var(--ink)}
 /* Per-section anchored signal rail */
@@ -99,11 +100,41 @@ html[data-theme="light"] .ico-l{display:inline}
 .ox-chip.ox-sig-prior-art{border-left-color:var(--teal)}
 .ox-chip.ox-sig-expert-routing{border-left-color:var(--copper)}
 .ox-chip strong{color:var(--ink)}
-.ox-chip .src{color:var(--teal);font-family:"JetBrains Mono",monospace;font-size:.8em}
+.ox-chip .src{color:var(--teal);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:.8em}
 .ox-marker.sm{width:22px;height:22px;padding:3px;border-radius:5px;flex:0 0 auto;align-self:center}
 /* Risk section — severity accent */
 section.risk{border-left:3px solid var(--amber);padding-left:16px;margin-left:-19px}
 section.risk h2{border-bottom-color:var(--amber)}
+/* Companion cards — a bundled interactive deep-dive is a first-class artifact,
+   surfaced right under the title (never a footnote). */
+.companions{display:flex;flex-wrap:wrap;gap:12px;margin:14px 0 6px;max-width:780px}
+.companion-card{flex:1 1 280px;display:flex;flex-direction:column;gap:3px;background:linear-gradient(135deg,var(--grad-a),var(--grad-b));border:1px solid var(--hair);border-left:3px solid var(--sage);border-radius:10px;padding:13px 16px;text-decoration:none;color:var(--ink);box-shadow:var(--shadow);transition:border-color .15s}
+.companion-card:hover{border-color:var(--sage)}
+.companion-tag{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--sage)}
+.companion-name{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-weight:600;font-size:14px;overflow-wrap:anywhere}
+.companion-cap{font-size:12px;color:var(--dim)}
+/* Tabbed section views (>3 H2s) — sticky top tab bar, one view at a time.
+   Hiding is gated on body.tabs-on (added by scaffold.js) so a no-JS open
+   degrades to the full single scroll. */
+.tabbar{position:sticky;top:0;z-index:40;display:flex;gap:2px;flex-wrap:wrap;margin:18px 0 6px;padding:6px 0 0;max-width:780px;background:rgba(11,13,11,.88);backdrop-filter:blur(14px);border-bottom:1px solid var(--hair2)}
+html[data-theme="light"] .tabbar{background:rgba(238,242,238,.88)}
+.tabbar button{font:inherit;font-size:12.5px;font-weight:500;color:var(--faint);background:none;border:none;border-bottom:2px solid transparent;padding:9px 13px;cursor:pointer;transition:color .13s,border-color .13s;letter-spacing:.005em}
+.tabbar button:hover{color:var(--dim)}
+.tabbar button[aria-selected="true"]{color:var(--ink);border-bottom-color:var(--sage)}
+.tabbar button .n{color:var(--faint);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;margin-right:6px}
+body.tabs-on main>section[id^="sec-"]{display:none}
+body.tabs-on main>section[id^="sec-"].on{display:block;animation:view-fade .22s ease}
+body.tabs-on main>section.on h2{margin-top:.6em}
+@keyframes view-fade{from{opacity:0;transform:translateY(3px)}to{opacity:1;transform:none}}
+@media(prefers-reduced-motion:reduce){body.tabs-on main>section[id^="sec-"].on{animation:none}}
+/* Comparison panes — the compare marker renders adjacent blocks side by side */
+.compare{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px;margin:14px 0}
+.compare-pane{background:var(--panel);border:1px solid var(--hair2);border-top:2px solid var(--sage-deep);border-radius:10px;padding:4px 14px 10px;min-width:0;overflow-x:auto}
+.compare-pane>h3:first-child{margin-top:.8em}
+.compare-pane table{margin:.5em 0}
+/* Plan-authored interactivity (```html-interactive fences) */
+.interactive-block{margin:14px 0}
+.interactive-omitted{background:var(--panel2);border:1px dashed var(--hair);border-radius:8px;padding:10px 14px;margin:14px 0;font-size:13px;color:var(--faint);font-style:italic}
 /* Verdict table cells */
 td.v-good{color:var(--sage-bright);font-weight:600}
 td.v-warn{color:var(--amber);font-weight:600}
@@ -112,7 +143,7 @@ td.v-bad{color:var(--red);font-weight:600}
 /* swimlane timeline */
 .swim{display:flex;flex-direction:column;gap:6px;margin:14px 0}
 .swim .lane{display:grid;grid-template-columns:120px 1fr;align-items:center;gap:10px}
-.swim .lane-name{font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim);text-align:right}
+.swim .lane-name{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--dim);text-align:right}
 .swim .track{position:relative;height:26px;background:var(--panel);border:1px solid var(--hair2);border-radius:6px;background-image:repeating-linear-gradient(90deg,transparent 0,transparent 9.9%,var(--hair2) 10%,var(--hair2) 10.1%)}
 .swim .lane:hover .track{border-color:var(--hair)}
 .swim .bar{position:absolute;top:3px;height:20px;border-radius:4px;font-size:10.5px;font-weight:600;color:#0c1112;display:flex;align-items:center;padding:0 7px;white-space:nowrap;overflow:hidden;transition:filter .14s}
@@ -121,17 +152,17 @@ td.v-bad{color:var(--red);font-weight:600}
 .swim .mark{position:absolute;top:0;line-height:24px;font-size:13px;transform:translateX(-50%);white-space:nowrap}
 .swim .anno{position:absolute;top:3px;line-height:18px;font-size:10px;color:var(--dim);white-space:nowrap}
 .swim .axis .track{height:auto;background:none;border:none;background-image:none}
-.swim .axis .tick{position:absolute;top:0;transform:translateX(-50%);font-family:"JetBrains Mono",monospace;font-size:10px;color:var(--dim);white-space:nowrap}
+.swim .axis .tick{position:absolute;top:0;transform:translateX(-50%);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px;color:var(--dim);white-space:nowrap}
 /* sparkline + small multiples */
 .spark{display:inline-block;width:80px;height:18px;vertical-align:middle}
 .multiples{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:12px;margin:14px 0}
 .multiples figure{margin:0;background:var(--panel);border:1px solid var(--hair2);border-radius:8px;padding:8px 10px}
-.multiples figcaption{font-family:"JetBrains Mono",monospace;font-size:10.5px;color:var(--dim);margin-bottom:4px}
+.multiples figcaption{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;color:var(--dim);margin-bottom:4px}
 .multiples .spark{width:100%}
 /* before / after */
 .ba{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin:14px 0}
 .ba-col{background:var(--panel);border:1px solid var(--hair2);border-radius:8px;padding:10px 12px}
-.ba-col h4{margin:.1em 0 .5em;font-family:"JetBrains Mono",monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint)}
+.ba-col h4{margin:.1em 0 .5em;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint)}
 /* heatmap table — shading encodes magnitude */
 table.heat td.h1{background:rgba(122,143,120,.14)}
 table.heat td.h2{background:rgba(224,165,106,.18)}
@@ -162,7 +193,7 @@ html[data-theme="light"] ul.ftree .chg{border:1px solid var(--hair)}
 .device.ios .device-screen::before{content:"";position:absolute;top:13px;left:50%;transform:translateX(-50%);width:92px;height:26px;background:#05080a;border-radius:14px}
 .device.ios .device-screen::after{content:"";position:absolute;bottom:9px;left:50%;transform:translateX(-50%);width:118px;height:4px;background:#3a464c;border-radius:3px}
 /* status bar (time left · signal/battery right) */
-.device-statusbar{display:flex;justify-content:space-between;align-items:center;font-family:"JetBrains Mono",monospace;font-size:11px;color:#cfd9dd;margin:-6px 0 12px}
+.device-statusbar{display:flex;justify-content:space-between;align-items:center;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:#cfd9dd;margin:-6px 0 12px}
 .device-statusbar .sb-r{letter-spacing:.06em}
 /* app title bar (back chevron / title / trailing action) */
 .device-titlebar{display:flex;align-items:center;gap:8px;font-family:"Space Grotesk",sans-serif;font-weight:600;font-size:15px;color:#e6edf0;padding-bottom:10px;margin-bottom:10px;border-bottom:1px solid #222c30}
@@ -180,21 +211,21 @@ html[data-theme="light"] ul.ftree .chg{border:1px solid var(--hair)}
 /* generic list row inside a screen */
 .device-row{display:flex;align-items:center;gap:10px;padding:9px 0;border-bottom:1px solid #222c30;font-size:13px}
 .device-row .dr-ic{width:30px;height:30px;border-radius:8px;background:#263035;display:flex;align-items:center;justify-content:center;font-size:15px;flex:none}
-.device-row .dr-sub{display:block;color:#9fb0b6;font-size:11px;font-family:"JetBrains Mono",monospace}
+.device-row .dr-sub{display:block;color:#9fb0b6;font-size:11px;font-family:"Spline Sans Mono","JetBrains Mono",monospace}
 /* bar chart / cost waterfall */
 .barc{margin:14px 0}
-.barc figcaption{font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim);margin-bottom:8px}
+.barc figcaption{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--dim);margin-bottom:8px}
 .bar-row{display:grid;grid-template-columns:140px 1fr 72px;align-items:center;gap:10px;margin:5px 0}
 .bar-row .bl{font-size:12.5px;color:var(--dim);text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .bar-row .bt{background:var(--panel);border:1px solid var(--hair2);border-radius:5px;height:18px;overflow:hidden}
 .bar-row .bf{display:block;height:100%;border-radius:5px 0 0 5px}
-.bar-row .bv{font-family:"JetBrains Mono",monospace;font-size:12px;color:var(--ink)}
+.bar-row .bv{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:12px;color:var(--ink)}
 /* stat cards */
 .statrow{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin:14px 0}
 .stat{background:var(--panel);border:1px solid var(--hair2);border-left:3px solid var(--hair);border-radius:9px;padding:12px 14px}
 .stat .sv{font-family:"Space Grotesk",sans-serif;font-size:26px;font-weight:600;line-height:1}
 .stat .sl{font-size:12px;color:var(--dim);margin-top:4px}
-.stat .sd{font-family:"JetBrains Mono",monospace;font-size:11.5px;margin-top:6px}
+.stat .sd{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11.5px;margin-top:6px}
 .stat.good{border-left-color:var(--sage)}.stat.good .sd{color:var(--sage-bright)}
 .stat.bad{border-left-color:var(--red)}.stat.bad .sd{color:var(--red)}
 .stat.warn{border-left-color:var(--amber)}.stat.warn .sd{color:var(--amber)}
@@ -202,14 +233,14 @@ html[data-theme="light"] ul.ftree .chg{border:1px solid var(--hair)}
 /* file-impact tree */
 ul.ftree,ul.ftree ul{list-style:none;margin:.3em 0;padding-left:14px}
 ul.ftree{margin:14px 0;padding-left:0}
-ul.ftree .grp{font-family:"JetBrains Mono",monospace;font-size:12px;color:var(--faint)}
+ul.ftree .grp{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:12px;color:var(--faint)}
 ul.ftree li{margin:3px 0;font-size:13.5px}
-ul.ftree .chg{font-family:"JetBrains Mono",monospace;font-size:10px;text-transform:uppercase;padding:1px 5px;border-radius:4px;margin-right:6px}
+ul.ftree .chg{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px;text-transform:uppercase;padding:1px 5px;border-radius:4px;margin-right:6px}
 ul.ftree .chg.new{background:rgba(122,143,120,.18);color:var(--sage-bright)}
 ul.ftree .chg.edit{background:rgba(224,165,106,.18);color:var(--copper)}
 ul.ftree .chg.del{background:rgba(239,68,68,.18);color:var(--red)}
 ul.ftree .chg.read{background:var(--panel2);color:var(--dim)}
-ul.ftree .sc{font-family:"JetBrains Mono",monospace;font-size:9.5px;color:var(--faint);border:1px solid var(--hair2);border-radius:3px;padding:0 4px;margin-left:4px}
+ul.ftree .sc{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9.5px;color:var(--faint);border:1px solid var(--hair2);border-radius:3px;padding:0 4px;margin-left:4px}
 ul.ftree .fnote{color:var(--dim);font-size:12px}
 /* risk matrix */
 table.riskm td:first-child{font-weight:500;color:var(--ink)}
@@ -219,7 +250,7 @@ table.riskm tr.sev-medium td:nth-child(2){color:var(--copper)}
 table.riskm tr.sev-low td:nth-child(2){color:var(--dim)}
 table.riskm tr.sev-blocker{background:rgba(239,68,68,.06)}
 /* flag rollout matrix */
-table.flagm td:first-child{font-family:"JetBrains Mono",monospace;font-size:12px;color:var(--dim)}
+table.flagm td:first-child{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:12px;color:var(--dim)}
 .foot{margin-top:48px;padding-top:18px;border-top:1px solid var(--hair);font-size:12.5px;color:var(--dim)}
 /* live-review-loop credit: a slightly stronger nod — the loop is a unique SageOx capability */
 .foot-live{color:var(--sage);font-weight:600}
@@ -228,14 +259,14 @@ table.flagm td:first-child{font-family:"JetBrains Mono",monospace;font-size:12px
 /* --- in-document review layer (ox plan review / feedback) --- */
 /* committed review-state strip (server-rendered, JS-independent) */
 .rev-status{background:var(--panel2);border:1px solid var(--hair2);border-left:3px solid var(--copper);border-radius:9px;padding:10px 14px;margin:12px 0 6px;font-size:13.5px;color:var(--dim)}
-.rev-status-tag{font-family:"JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--copper);margin-right:8px}
+.rev-status-tag{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--copper);margin-right:8px}
 .rev-status strong{color:var(--ink)}
 .rev-bar{position:fixed;left:16px;bottom:16px;z-index:60;display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--hair);border-radius:9px;padding:6px 8px;box-shadow:var(--shadow)}
-.rev-bar button{background:var(--panel2);border:1px solid var(--hair2);color:var(--dim);border-radius:6px;padding:4px 9px;font-size:12px;cursor:pointer;font-family:"JetBrains Mono",monospace}
+.rev-bar button{background:var(--panel2);border:1px solid var(--hair2);color:var(--dim);border-radius:6px;padding:4px 9px;font-size:12px;cursor:pointer;font-family:"Spline Sans Mono","JetBrains Mono",monospace}
 .rev-bar button:hover{color:var(--ink)}
 .rev-bar .rev-toggle.on{background:var(--sage);border-color:var(--sage);color:#0c1112}
 .rev-bar .rev-submit{border-color:var(--copper);color:var(--copper)}
-.rev-bar .rev-count{font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--faint)}
+.rev-bar .rev-count{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--faint)}
 .rev-bar .rev-who{max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--faint)}
 .rev-bar .rev-who:hover{color:var(--sage);border-color:var(--sage)}
 body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.rev-on tr:hover,body.rev-on .ox-chip:hover,body.rev-on .stat:hover,body.rev-on .bar-row:hover{outline:1px dashed var(--sage);outline-offset:2px;cursor:crosshair}
@@ -253,7 +284,7 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .rev-committed[data-revstate="wontfix"] .rev-glyph{color:var(--faint)}
 .rev-pop{position:absolute;z-index:70;width:280px;background:var(--panel);border:1px solid var(--hair);border-radius:9px;padding:10px;box-shadow:var(--shadow)}
 .rev-pop .rev-row{display:flex;flex-wrap:wrap;gap:5px;margin:4px 0}
-.rev-pop .rev-s{flex:1 1 auto;background:var(--panel2);border:1px solid var(--hair2);color:var(--dim);border-radius:5px;padding:3px 6px;font-size:10.5px;cursor:pointer;font-family:"JetBrains Mono",monospace}
+.rev-pop .rev-s{flex:1 1 auto;background:var(--panel2);border:1px solid var(--hair2);color:var(--dim);border-radius:5px;padding:3px 6px;font-size:10.5px;cursor:pointer;font-family:"Spline Sans Mono","JetBrains Mono",monospace}
 /* control color PREDICTS the resulting mark color */
 .rev-pop .rev-s[data-s="approve"].on{background:var(--sage);border-color:var(--sage);color:#0c1112}
 .rev-pop .rev-s[data-s="request-change"].on{background:var(--amber);border-color:var(--amber);color:#0c1112}
@@ -272,14 +303,14 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .rev-orphans{position:fixed;left:50%;top:14px;transform:translateX(-50%);z-index:65;max-width:680px;background:var(--panel);border:1px solid var(--amber);border-left:3px solid var(--amber);border-radius:9px;padding:10px 14px;box-shadow:var(--shadow);font-size:13px;color:var(--dim)}
 .rev-orphans-h{color:var(--amber);font-weight:600;margin-bottom:4px}
 .rev-orphans ul{margin:.3em 0;padding-left:1.1em}
-.rev-orphans .rev-orphans-x{margin-top:6px;background:var(--panel2);border:1px solid var(--hair2);color:var(--dim);border-radius:5px;padding:3px 9px;font-size:11px;cursor:pointer;font-family:"JetBrains Mono",monospace}
+.rev-orphans .rev-orphans-x{margin-top:6px;background:var(--panel2);border:1px solid var(--hair2);color:var(--dim);border-radius:5px;padding:3px 9px;font-size:11px;cursor:pointer;font-family:"Spline Sans Mono","JetBrains Mono",monospace}
 /* first-visit discoverability bubble near the Review toggle */
 .rev-hint{position:fixed;left:96px;bottom:20px;z-index:61;background:var(--copper);color:#0c1112;border-radius:7px;padding:6px 10px;font-size:12px;font-weight:600;box-shadow:var(--shadow);animation:rev-bob 1.4s ease-in-out infinite}
 @keyframes rev-bob{0%,100%{transform:translateX(0)}50%{transform:translateX(-4px)}}
 /* review comments rail — surfaces the note TEXT (not just a margin glyph) in the
    right gutter; each row scroll-jumps to its anchored element. */
 .rev-rail{position:fixed;top:64px;right:18px;z-index:55;width:266px;max-height:calc(100vh - 100px);overflow-y:auto;background:var(--panel);border:1px solid var(--hair);border-radius:10px;padding:10px 12px;box-shadow:var(--shadow)}
-.rev-rail-h{font-family:"JetBrains Mono",monospace;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--dim);margin-bottom:8px;display:flex;align-items:center;gap:6px}
+.rev-rail-h{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--dim);margin-bottom:8px;display:flex;align-items:center;gap:6px}
 .rev-rail-n{background:var(--panel2);border:1px solid var(--hair2);border-radius:8px;padding:0 6px;font-size:10.5px;color:var(--faint)}
 .rev-rail-empty{color:var(--faint);font-size:12px;line-height:1.5}
 .rev-rail-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
@@ -292,7 +323,7 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .rev-rail-glyph{flex:none;font-size:12px;line-height:1.4;color:var(--dim)}
 .rev-rail-body{min-width:0;flex:1}
 .rev-rail-sec{display:flex;align-items:center;gap:6px;margin-bottom:3px}
-.rev-rail-sec-t{flex:1;min-width:0;font-family:"JetBrains Mono",monospace;font-size:10px;color:var(--faint);text-transform:uppercase;letter-spacing:.03em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.rev-rail-sec-t{flex:1;min-width:0;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px;color:var(--faint);text-transform:uppercase;letter-spacing:.03em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .rev-rail-who{flex:none;font-size:9px;border-radius:6px;padding:0 5px;border:1px solid var(--hair2);color:var(--sage);text-transform:none;letter-spacing:0;max-width:90px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .rev-rail-note{font-size:12.5px;color:var(--ink);line-height:1.45;overflow-wrap:anywhere}
 .rev-rail-note.muted{color:var(--dim)}
@@ -310,19 +341,19 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
    Pure-CSS: staggered grow-in entrance, hover lift/brighten, and a hover tooltip
    carrying the detail the compact view can't fit. prefers-reduced-motion honored. */
 .pm-dot{display:inline-block;width:9px;height:9px;border-radius:3px;margin-right:8px;vertical-align:middle;flex:none}
-.pm-flag{font-family:"JetBrains Mono",monospace;font-size:9px;font-weight:600;letter-spacing:.04em;color:var(--dim);border:1px solid var(--hair2);border-radius:4px;padding:1px 5px;margin-left:7px;vertical-align:middle}
-.pm-mono{font-family:"JetBrains Mono",monospace;font-size:12px}
+.pm-flag{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9px;font-weight:600;letter-spacing:.04em;color:var(--dim);border:1px solid var(--hair2);border-radius:4px;padding:1px 5px;margin-left:7px;vertical-align:middle}
+.pm-mono{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:12px}
 /* shared hover tooltip */
 .pm-tip{position:absolute;z-index:30;left:50%;bottom:calc(100% + 9px);transform:translate(-50%,4px);min-width:128px;max-width:240px;background:var(--panel2);border:1px solid var(--hair);border-radius:9px;padding:8px 10px;box-shadow:var(--shadow);opacity:0;visibility:hidden;pointer-events:none;transition:opacity .16s ease,transform .16s ease,visibility .16s;display:flex;flex-direction:column;gap:3px;text-align:left}
 .pm-tip::after{content:"";position:absolute;top:100%;left:50%;transform:translateX(-50%);border:5px solid transparent;border-top-color:var(--hair)}
 .pm-tip b{font-size:12.5px;color:var(--ink);font-weight:600}
-.pm-tip-k{font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim)}
-.pm-tip-flag{align-self:flex-start;font-family:"JetBrains Mono",monospace;font-size:9px;font-weight:600;letter-spacing:.04em;color:var(--copper);border:1px solid var(--hair2);border-radius:4px;padding:1px 5px}
+.pm-tip-k{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--dim)}
+.pm-tip-flag{align-self:flex-start;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9px;font-weight:600;letter-spacing:.04em;color:var(--copper);border:1px solid var(--hair2);border-radius:4px;padding:1px 5px}
 .pm-tip-flag.prop{border-style:dashed}
 .pm-tip-note{font-size:11.5px;color:var(--dim);line-height:1.4}
 /* proportional bar */
 .pbar-fig{margin:14px 0}
-.pbar-fig figcaption{font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim);margin-bottom:8px}
+.pbar-fig figcaption{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--dim);margin-bottom:8px}
 .pbar{display:flex;height:50px;border-radius:8px}
 .pbar .pseg{position:relative;display:flex;align-items:center;justify-content:center;min-width:2px;transform-origin:left center;animation:pm-grow .55s cubic-bezier(.22,.61,.36,1) backwards;animation-delay:calc(var(--i,0)*45ms);transition:filter .15s ease,transform .15s ease}
 .pbar .pseg:first-child{border-radius:8px 0 0 8px} .pbar .pseg:last-child{border-radius:0 8px 8px 0}
@@ -338,7 +369,7 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .pbar .pseg:last-child:hover .pm-tip{transform:translate(0,0)}
 .pbar .pseg:last-child .pm-tip::after{left:auto;right:20px}
 .pbar-tab{width:100%;border-collapse:collapse;margin-top:12px;font-size:13px}
-.pbar-tab th{text-align:left;font-family:"JetBrains Mono",monospace;font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:var(--dim);font-weight:500;padding:6px 10px;border-bottom:1px solid var(--hair2)}
+.pbar-tab th{text-align:left;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:var(--dim);font-weight:500;padding:6px 10px;border-bottom:1px solid var(--hair2)}
 .pbar-tab td{padding:7px 10px;border-bottom:1px solid var(--hair2)}
 .pbar-tab td.pm-mono{text-align:right;color:var(--dim)}
 .pbar-tab td:first-child{color:var(--ink)}
@@ -346,10 +377,10 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .pbar-tab tr:hover{background:var(--panel)}
 /* vertical ordered map with log rail */
 .pmapv{margin:14px 0;border:1px solid var(--hair2);border-radius:10px}
-.pmapv figcaption{display:flex;justify-content:space-between;font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim);padding:9px 14px;background:var(--panel2);border-bottom:1px solid var(--hair2);border-radius:10px 10px 0 0}
+.pmapv figcaption{display:flex;justify-content:space-between;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--dim);padding:9px 14px;background:var(--panel2);border-bottom:1px solid var(--hair2);border-radius:10px 10px 0 0}
 .pmapv-rk{color:var(--faint);text-transform:uppercase;letter-spacing:.05em;font-size:9.5px}
 /* interleaved section divider (e.g. "PROPOSED SECURE ADDITIONS") between row groups */
-.pmapv-group{font-family:"JetBrains Mono",monospace;font-size:9.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--copper);padding:11px 14px 5px;border-bottom:1px solid var(--hair2);background:var(--panel2)}
+.pmapv-group{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--copper);padding:11px 14px 5px;border-bottom:1px solid var(--hair2);background:var(--panel2)}
 .pmapv-row{position:relative;display:grid;grid-template-columns:14px 78px 1fr 130px 70px;align-items:center;gap:11px;padding:8px 14px;border-bottom:1px solid var(--hair2);animation:pm-fade .5s ease backwards;animation-delay:calc(var(--i,0)*35ms);transition:background .14s ease}
 .pmapv-row:last-child{border-bottom:none;border-radius:0 0 10px 10px}
 .pmapv-row:hover{background:var(--panel)}
@@ -386,21 +417,21 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .vsw{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:7px;vertical-align:middle;flex:none}
 /* donut */
 .donut{margin:14px 0}
-.donut figcaption,.radar figcaption,.quad figcaption,.tmap figcaption,.sankey figcaption,.chord figcaption,.linec figcaption{font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim);margin-bottom:8px}
+.donut figcaption,.radar figcaption,.quad figcaption,.tmap figcaption,.sankey figcaption,.chord figcaption,.linec figcaption{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--dim);margin-bottom:8px}
 .donut-body{display:flex;align-items:center;gap:18px;flex-wrap:wrap}
 .donut-svg{width:140px;height:140px;flex:none}
 .donut-ctr{fill:var(--ink);font-family:"Space Grotesk",sans-serif;font-size:18px;font-weight:600}
 .donut-leg,.radar-leg{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:5px;min-width:150px}
 .donut-leg li{display:flex;align-items:center;font-size:13px}
 .donut-lab{color:var(--ink)}
-.donut-val{margin-left:auto;font-family:"JetBrains Mono",monospace;font-size:11.5px;color:var(--dim);padding-left:14px}
+.donut-val{margin-left:auto;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11.5px;color:var(--dim);padding-left:14px}
 /* radar */
 .radar{margin:14px 0}
 .radar-body{display:flex;align-items:center;gap:16px;flex-wrap:wrap}
 .radar-svg{width:240px;height:232px;flex:none}
 .radar-grid{fill:none;stroke:var(--hair2);stroke-width:1}
 .radar-spoke{stroke:var(--hair2);stroke-width:1}
-.radar-axis{fill:var(--dim);font-family:"JetBrains Mono",monospace;font-size:10px}
+.radar-axis{fill:var(--dim);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px}
 .radar-series{fill-opacity:.12;stroke-width:1.7;stroke-linejoin:round}
 .radar-leg li{display:flex;align-items:center;font-size:13px;color:var(--ink)}
 /* quadrant */
@@ -410,19 +441,19 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .quad-mid{stroke:var(--hair2);stroke-width:1;stroke-dasharray:3 3}
 .quad-pt{stroke:var(--bg);stroke-width:1.5}
 .quad-lab{fill:var(--ink);font-size:11px}
-.quad-axl{fill:var(--dim);font-family:"JetBrains Mono",monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.04em}
+.quad-axl{fill:var(--dim);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.04em}
 /* line chart */
 .linec{margin:14px 0}
 .linec-svg{width:100%;max-width:560px;height:auto;display:block}
 .linec-axis{stroke:var(--hair2);stroke-width:1}
 .linec-tick{stroke:var(--hair2);stroke-width:1}
-.linec-tlab{fill:var(--dim);font-family:"JetBrains Mono",monospace;font-size:9.5px}
-.linec-axl{fill:var(--dim);font-family:"JetBrains Mono",monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.04em}
+.linec-tlab{fill:var(--dim);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9.5px}
+.linec-axl{fill:var(--dim);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.04em}
 .linec-thresh{stroke-width:1;stroke-dasharray:3 4;opacity:.85}
-.linec-thlab{font-family:"JetBrains Mono",monospace;font-size:9.5px;opacity:.9}
+.linec-thlab{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9.5px;opacity:.9}
 .linec-series{fill:none;stroke-width:1.8;stroke-linejoin:round;stroke-linecap:round}
 .linec-dot{stroke:var(--bg);stroke-width:1}
-.linec-note{font-family:"JetBrains Mono",monospace;font-size:9.5px}
+.linec-note{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9.5px}
 .linec-leg{list-style:none;margin:8px 0 0;padding:0;display:flex;flex-wrap:wrap;gap:6px 16px}
 .linec-leg li{display:flex;align-items:center;font-size:12.5px;color:var(--ink)}
 /* treemap */
@@ -431,11 +462,11 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .tmap-cell rect{stroke:var(--bg);stroke-width:1.5;transition:filter .14s}
 .tmap-cell:hover rect{filter:brightness(1.12)}
 .tmap-lab{fill:var(--ink);font-family:"Space Grotesk",sans-serif;font-size:11px;font-weight:600;pointer-events:none}
-.tmap-val{fill:var(--ink);opacity:.78;font-family:"JetBrains Mono",monospace;font-size:9.5px;pointer-events:none}
+.tmap-val{fill:var(--ink);opacity:.78;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9.5px;pointer-events:none}
 .tmap-leg{list-style:none;margin:10px 0 0;padding:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:4px 14px}
 .tmap-leg li{display:flex;align-items:center;font-size:12.5px}
 .tmap-leg-lab{color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.tmap-leg-val{margin-left:auto;font-family:"JetBrains Mono",monospace;font-size:11px;color:var(--dim);padding-left:8px}
+.tmap-leg-val{margin-left:auto;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--dim);padding-left:8px}
 /* sankey */
 .sankey{margin:14px 0}
 .sankey-svg{width:100%;max-width:520px;height:auto}
@@ -450,16 +481,16 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .chord-rib{fill-opacity:.32;transition:fill-opacity .14s}
 .chord-rib:hover{fill-opacity:.62}
 .chord-arc{stroke:var(--bg);stroke-width:1}
-.chord-lab{fill:var(--ink);font-family:"JetBrains Mono",monospace;font-size:9.5px}
+.chord-lab{fill:var(--ink);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9.5px}
 @media(prefers-reduced-motion:reduce){.tmap-cell rect,.sankey-link,.chord-rib{transition:none}}
 
 /* review connection state — the page must never look live when the server is gone */
-.rev-conn{font-family:"JetBrains Mono",monospace;font-size:11px}
+.rev-conn{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px}
 .rev-conn.ok{color:var(--sage)}
 .rev-conn.off{color:var(--red);animation:rev-conn-pulse 1.6s ease-in-out infinite}
 @keyframes rev-conn-pulse{50%{opacity:.45}}
 .rev-offline-bar{position:fixed;top:0;left:0;right:0;z-index:80;background:var(--panel);border-bottom:2px solid var(--red);color:var(--ink);padding:9px 14px;font-size:13px;box-shadow:var(--shadow)}
-.rev-offline-bar code{background:var(--panel2);border:1px solid var(--hair2);border-radius:5px;padding:2px 7px;font-family:"JetBrains Mono",monospace;font-size:12px;user-select:all}
+.rev-offline-bar code{background:var(--panel2);border:1px solid var(--hair2);border-radius:5px;padding:2px 7px;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:12px;user-select:all}
 .rev-offline-bar .rev-offline-copy{margin-left:6px;background:var(--panel2);border:1px solid var(--hair2);color:var(--dim);border-radius:5px;padding:2px 8px;font-size:11px;cursor:pointer}
 .rev-offline-bar .rev-offline-copy:hover{color:var(--ink)}
 body.rev-offline .rev-bar .rev-submit,body.rev-offline .rev-bar .rev-approve{opacity:.45;cursor:not-allowed}

--- a/internal/plan/assets/scaffold.css
+++ b/internal/plan/assets/scaffold.css
@@ -4,7 +4,7 @@
    Inline plan-authored HTML (device mockups, etc.) passes through unchanged. */
 :root{
   --bg:#0b0d0b; --panel:#111411; --panel2:#171b17; --hair:#252c24; --hair2:#1b211a;
-  --ink:#e8ede7; --dim:#a8b3a5; --faint:#6f7a6d;
+  --ink:#e8ede7; --dim:#a8b3a5; --faint:#7b857a;
   --sage:#99c693; --sage-bright:#b7d4b2; --sage-deep:#4e7d4c; --copper:#e0a56a; --amber:#f59e0b; --red:#ef4444; --teal:#14b8a6;
   --slate:#64748b; --violet:#a78bfa;
   --grad-a:#131813; --grad-b:#101410; --shadow:0 1px 0 rgba(255,255,255,.02),0 8px 30px rgba(0,0,0,.35);
@@ -12,8 +12,8 @@
 html[data-theme="light"]{
   --bg:#eef2ee; --panel:#fff; --panel2:#f5f8f4; --hair:#d8e0d8; --hair2:#e4ebe3;
   --ink:#16201c; --dim:#3f4d46; --faint:#566159;
-  --sage:#56745a; --sage-bright:#3f5a43; --sage-deep:#3f5a43; --copper:#a8613b; --amber:#b4730c; --red:#c1352f; --teal:#0c6b62;
-  --slate:#5a6675; --violet:#7c5fd6;
+  --sage:#56745a; --sage-bright:#3f5a43; --sage-deep:#3f5a43; --copper:#9f5c38; --amber:#9a620a; --red:#c1352f; --teal:#0c6b62;
+  --slate:#5a6675; --violet:#755acb;
   --grad-a:#e7efe7; --grad-b:#f3f7f2; --shadow:0 1px 0 rgba(0,0,0,.02),0 8px 26px rgba(40,60,45,.10);
 }
 *{box-sizing:border-box}
@@ -37,15 +37,15 @@ html[data-theme="light"] .toc-brand .wm-l{display:block}
 nav.toc a{display:block;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11.5px;color:var(--dim);text-decoration:none;padding:5px 8px;border-left:2px solid transparent;line-height:1.4}
 nav.toc a .n{color:var(--faint);margin-right:7px}
 nav.toc a:hover{color:var(--ink)}
-nav.toc a.active{color:var(--ink);border-left-color:var(--sage)}
+nav.toc a.active{color:var(--ink);border-left-color:var(--ink)}
 main{padding:40px 46px 120px;min-width:0}
 /* hold prose to a readable measure (~72-80ch); let wide visuals opt out */
 main>section,main>.tldr,main>.ox-enrich,main>.rev-status,main>.eyebrow,main>h1,main>.foot{max-width:780px}
 main>section .mermaid,main>section .swim,main>section .statrow,main>section .barc,main>section table.heat,main>section .multiples,main>section .pbar-fig,main>section .pmapv,main>section .linec,main>section .device-row-wrap,main>section .compare,main>section .interactive-block{max-width:none}
-.eyebrow{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--copper)}
+.eyebrow{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--faint)}
 h1{font-family:"Space Grotesk",sans-serif;font-weight:700;font-size:40px;line-height:1.1;letter-spacing:-.035em;margin:.2em 0 .35em}
 h2{font-family:"Space Grotesk",sans-serif;font-weight:600;font-size:23px;letter-spacing:-.02em;margin:2.2em 0 .2em;padding-bottom:.3em;border-bottom:1px solid var(--hair)}
-h3{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-weight:500;font-size:12.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--copper);margin:1.7em 0 .5em}
+h3{font-family:Inter,system-ui,sans-serif;font-weight:600;font-size:14px;text-transform:uppercase;letter-spacing:.03em;color:var(--faint);margin:1.7em 0 .5em}
 p{margin:.7em 0}
 a{color:var(--teal)}
 strong{color:var(--ink);font-weight:600}
@@ -87,10 +87,10 @@ html[data-theme="light"] .ico-l{display:inline}
    the positive verdict cell so it doesn't double as "expert". */
 .ox-sig-collision{color:var(--amber)}
 .ox-sig-prior-art{color:var(--teal)}
-.ox-sig-expert-routing{color:var(--copper)}
+.ox-sig-expert-routing{color:var(--violet)}
 /* TL;DR hero callout — the decision-first lede */
-.tldr{position:relative;background:linear-gradient(135deg,var(--grad-a),var(--grad-b));border:1px solid var(--hair);border-left:3px solid var(--copper);border-radius:10px;padding:16px 18px 16px 20px;margin:14px 0 8px;box-shadow:var(--shadow)}
-.tldr-tag{display:inline-block;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.14em;color:var(--copper);text-transform:uppercase;margin-bottom:6px}
+.tldr{position:relative;background:linear-gradient(135deg,var(--grad-a),var(--grad-b));border:1px solid var(--hair);border-left:3px solid #5b605a;border-radius:10px;padding:16px 18px 16px 20px;margin:14px 0 8px;box-shadow:var(--shadow)}
+.tldr-tag{display:inline-block;font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;letter-spacing:.14em;color:var(--dim);text-transform:uppercase;margin-bottom:6px}
 .tldr>p:first-of-type,.tldr blockquote{margin-top:0}
 .tldr blockquote{border:none;padding:0;color:var(--ink)}
 /* Per-section anchored signal rail */
@@ -98,7 +98,7 @@ html[data-theme="light"] .ico-l{display:inline}
 .ox-chip{display:flex;align-items:baseline;gap:8px;font-size:13px;color:var(--dim);background:var(--panel2);border:1px solid var(--hair2);border-left:2px solid var(--hair);border-radius:7px;padding:7px 11px}
 .ox-chip.ox-sig-collision{border-left-color:var(--amber)}
 .ox-chip.ox-sig-prior-art{border-left-color:var(--teal)}
-.ox-chip.ox-sig-expert-routing{border-left-color:var(--copper)}
+.ox-chip.ox-sig-expert-routing{border-left-color:var(--violet)}
 .ox-chip strong{color:var(--ink)}
 .ox-chip .src{color:var(--teal);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:.8em}
 .ox-marker.sm{width:22px;height:22px;padding:3px;border-radius:5px;flex:0 0 auto;align-self:center}
@@ -113,20 +113,16 @@ section.risk h2{border-bottom-color:var(--amber)}
 .companion-tag{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--sage)}
 .companion-name{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-weight:600;font-size:14px;overflow-wrap:anywhere}
 .companion-cap{font-size:12px;color:var(--dim)}
-/* Tabbed section views (>3 H2s) — sticky top tab bar, one view at a time.
-   Hiding is gated on body.tabs-on (added by scaffold.js) so a no-JS open
-   degrades to the full single scroll. */
-.tabbar{position:sticky;top:0;z-index:40;display:flex;gap:2px;flex-wrap:wrap;margin:18px 0 6px;padding:6px 0 0;max-width:780px;background:rgba(11,13,11,.88);backdrop-filter:blur(14px);border-bottom:1px solid var(--hair2)}
+/* Long-plan section jumps (>3 H2s) — sticky top row, continuous scroll.
+   The whole plan stays visible so reviewers keep context and comment anchors
+   from the review rail always have a visible target. */
+.tabbar{position:sticky;top:0;z-index:40;display:flex;gap:2px;flex-wrap:nowrap;overflow-x:auto;margin:18px 0 12px;padding:6px 0 0;max-width:780px;background:rgba(11,13,11,.88);backdrop-filter:blur(14px);border-bottom:1px solid var(--hair2);scrollbar-width:thin}
 html[data-theme="light"] .tabbar{background:rgba(238,242,238,.88)}
-.tabbar button{font:inherit;font-size:12.5px;font-weight:500;color:var(--faint);background:none;border:none;border-bottom:2px solid transparent;padding:9px 13px;cursor:pointer;transition:color .13s,border-color .13s;letter-spacing:.005em}
+.tabbar button{font:inherit;font-size:12.5px;font-weight:500;color:var(--faint);background:none;border:none;border-bottom:2px solid transparent;padding:9px 13px;cursor:pointer;transition:color .13s,border-color .13s;letter-spacing:.005em;white-space:nowrap;flex:0 0 auto}
 .tabbar button:hover{color:var(--dim)}
-.tabbar button[aria-selected="true"]{color:var(--ink);border-bottom-color:var(--sage)}
+.tabbar button[aria-current="true"]{color:var(--ink);border-bottom-color:var(--ink)}
 .tabbar button .n{color:var(--faint);font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;margin-right:6px}
-body.tabs-on main>section[id^="sec-"]{display:none}
-body.tabs-on main>section[id^="sec-"].on{display:block;animation:view-fade .22s ease}
-body.tabs-on main>section.on h2{margin-top:.6em}
-@keyframes view-fade{from{opacity:0;transform:translateY(3px)}to{opacity:1;transform:none}}
-@media(prefers-reduced-motion:reduce){body.tabs-on main>section[id^="sec-"].on{animation:none}}
+main>section[id^="sec-"]{scroll-margin-top:72px}
 /* Comparison panes — the compare marker renders adjacent blocks side by side */
 .compare{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px;margin:14px 0}
 .compare-pane{background:var(--panel);border:1px solid var(--hair2);border-top:2px solid var(--sage-deep);border-radius:10px;padding:4px 14px 10px;min-width:0;overflow-x:auto}
@@ -148,7 +144,7 @@ td.v-bad{color:var(--red);font-weight:600}
 .swim .lane:hover .track{border-color:var(--hair)}
 .swim .bar{position:absolute;top:3px;height:20px;border-radius:4px;font-size:10.5px;font-weight:600;color:#0c1112;display:flex;align-items:center;padding:0 7px;white-space:nowrap;overflow:hidden;transition:filter .14s}
 .swim .bar:hover{filter:brightness(1.13)}
-.swim .gate{position:absolute;top:0;color:var(--copper);font-size:16px;transform:translateX(-50%)}
+.swim .gate{position:absolute;top:0;color:var(--ink);font-size:16px;transform:translateX(-50%)}
 .swim .mark{position:absolute;top:0;line-height:24px;font-size:13px;transform:translateX(-50%);white-space:nowrap}
 .swim .anno{position:absolute;top:3px;line-height:18px;font-size:10px;color:var(--dim);white-space:nowrap}
 .swim .axis .track{height:auto;background:none;border:none;background-image:none}
@@ -495,3 +491,48 @@ body.rev-on [data-rev],body.rev-on section[id]:hover,body.rev-on li:hover,body.r
 .rev-offline-bar .rev-offline-copy:hover{color:var(--ink)}
 body.rev-offline .rev-bar .rev-submit,body.rev-offline .rev-bar .rev-approve{opacity:.45;cursor:not-allowed}
 .rev-toast{position:fixed;left:16px;bottom:64px;z-index:60;background:var(--panel);border:1px solid var(--sage);color:var(--ink);border-radius:9px;padding:8px 12px;font-size:12.5px;box-shadow:var(--shadow)}
+
+/* Judgment signal colors (agent-authored, cited): aligns=positive, conflicts=
+   blocker, expert view=copper — same one-meaning-per-hue map as above. */
+.ox-sig-aligns{color:var(--sage)}
+.ox-sig-conflicts{color:var(--red)}
+.ox-sig-expert-perspective{color:var(--violet)}
+.ox-chip.ox-sig-aligns{border-left-color:var(--sage)}
+.ox-chip.ox-sig-conflicts{border-left-color:var(--red)}
+.ox-chip.ox-sig-expert-perspective{border-left-color:var(--violet)}
+/* Alignment strip — surfaced context bundle inside the enrichment panel */
+.ox-ctx{display:flex;flex-wrap:wrap;align-items:baseline;gap:6px 12px;margin-top:9px;font-size:12.5px;color:var(--dim)}
+.ox-ctx-cap{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:9.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint)}
+.ox-ctx-kind{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10px;border:1px solid var(--hair2);border-radius:4px;padding:0 4px;color:var(--teal);margin-right:2px}
+/* Auto-inspector — comparison tables become click-to-inspect: the clicked row
+   lights and its fields project into a docked explainer (scaffold.js). */
+table.inspect tbody tr{cursor:pointer;transition:background .12s}
+table.inspect tbody tr:hover{background:var(--panel)}
+table.inspect tbody tr.lit{background:rgba(153,198,147,.13);box-shadow:inset 2px 0 0 var(--sage)}
+.inspect-dock{position:sticky;bottom:12px;z-index:20;background:var(--panel2);border:1px solid var(--hair);border-left:3px solid var(--sage);border-radius:10px;padding:12px 16px;margin:10px 0;box-shadow:var(--shadow)}
+.inspect-dock-hint{font-size:12px;color:var(--faint);font-style:italic}
+.inspect-f{margin:4px 0;font-size:13.5px;color:var(--ink)}
+.inspect-k{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);margin-right:8px}
+.auto-swim{margin:14px 0}
+.auto-swim figcaption{font-family:"Spline Sans Mono","JetBrains Mono",monospace;font-size:11px;color:var(--dim);margin-bottom:8px}
+/* Hero stat chips — first-30-seconds numbers derived from plan structure */
+.hero-stats{display:flex;flex-wrap:wrap;gap:8px;margin:10px 0 4px;max-width:780px}
+.hstat{display:inline-flex;align-items:baseline;gap:7px;background:var(--panel);border:1px solid var(--hair2);border-radius:8px;padding:8px 13px;min-height:44px;box-sizing:border-box}
+.hstat-v{font-size:20px;font-weight:600;color:var(--ink);line-height:1}
+.hstat-l{font-size:11px;color:var(--dim)}
+.hstat-teal{border-left:3px solid var(--teal)}
+.hstat-amber{border-left:3px solid var(--amber)}
+.hstat-copper{border-left:3px solid var(--copper)}
+.hstat-red{border-left:3px solid var(--red)}
+/* quiet zero-signal footer note — silence must be distinguishable from never-ran */
+.foot-quiet{color:var(--faint);font-style:italic}
+/* Long-plan mode: the sticky jump bar is the ONE nav — the left TOC would
+   duplicate it (scaffold.js adds has-tabbar when the bar exists) */
+body.has-tabbar .shell{grid-template-columns:1fr}
+body.has-tabbar nav.toc{display:none}
+/* type scale per design review: compact Inter title, calmer H2 */
+h1{font-family:Inter,system-ui,sans-serif;font-weight:700;font-size:30px;letter-spacing:-.015em;line-height:1.15}
+h2{font-family:Inter,system-ui,sans-serif;font-weight:600;font-size:22px;letter-spacing:-.01em;line-height:1.25}
+body{font-size:16px;line-height:1.6}
+/* prose measure: ~66ch ideal (Butterick); tables/visuals keep the wide column */
+main>section p,main>section ul,main>section ol,main>section blockquote{max-width:66ch}

--- a/internal/plan/assets/scaffold.js
+++ b/internal/plan/assets/scaffold.js
@@ -67,11 +67,17 @@
       tr.addEventListener('click',function(){
         [].slice.call(t.querySelectorAll('tr.lit')).forEach(function(r){r.classList.remove('lit');});
         tr.classList.add('lit');
-        var html='';
-        [].slice.call(tr.children).forEach(function(c,i){
-          html+='<div class="inspect-f"><span class="inspect-k">'+(heads[i]||('field '+(i+1)))+'</span><span class="inspect-v">'+c.innerHTML+'</span></div>';
-        });
-        if(body)body.innerHTML=html;
+        if(body){
+          body.textContent='';
+          [].slice.call(tr.children).forEach(function(c,i){
+            var row=document.createElement('div');row.className='inspect-f';
+            var k=document.createElement('span');k.className='inspect-k';
+            k.textContent=heads[i]||('field '+(i+1));
+            var v=document.createElement('span');v.className='inspect-v';
+            v.innerHTML=c.innerHTML; // first-party rendered cell markup
+            row.appendChild(k);row.appendChild(v);body.appendChild(row);
+          });
+        }
         var hint=dock.querySelector('.inspect-dock-hint');
         if(hint)hint.remove();
         dock.hidden=false;

--- a/internal/plan/assets/scaffold.js
+++ b/internal/plan/assets/scaffold.js
@@ -1,8 +1,9 @@
 // ox plan — portable scaffold runtime. No build step, runs from file://.
 // Mermaid is the only external dep (CDN, at view time). Handles dark/light
-// re-render, OS-preference default + persistence, and scroll-spy TOC.
+// re-render, OS-preference default + persistence, tabbed section views
+// (plans with >3 sections), and scroll-spy TOC (single-scroll mode).
 (function(){
-  var darkVars={background:'#151b1e',primaryColor:'#1a2226',primaryTextColor:'#e6edf0',primaryBorderColor:'#2a3439',lineColor:'#5f7178',secondaryColor:'#16201f',tertiaryColor:'#141d20',fontFamily:'Inter, sans-serif',fontSize:'13px',actorBkg:'#1a2226',actorBorder:'#2a3439',actorTextColor:'#e6edf0',noteBkgColor:'#241803',noteTextColor:'#f7d8a0',noteBorderColor:'#f59e0b'};
+  var darkVars={background:'#111411',primaryColor:'#171b17',primaryTextColor:'#e8ede7',primaryBorderColor:'#252c24',lineColor:'#6f7a6d',secondaryColor:'#141814',tertiaryColor:'#121612',fontFamily:'Inter, sans-serif',fontSize:'13px',actorBkg:'#171b17',actorBorder:'#252c24',actorTextColor:'#e8ede7',noteBkgColor:'#241803',noteTextColor:'#f7d8a0',noteBorderColor:'#f59e0b'};
   var lightVars={background:'#ffffff',primaryColor:'#f5f8f4',primaryTextColor:'#16201c',primaryBorderColor:'#d8e0d8',lineColor:'#6c7a72',secondaryColor:'#eef4ee',tertiaryColor:'#eef7f5',fontFamily:'Inter, sans-serif',fontSize:'13px',actorBkg:'#f5f8f4',actorBorder:'#d8e0d8',actorTextColor:'#16201c',noteBkgColor:'#fdf2dc',noteTextColor:'#6b4a0c',noteBorderColor:'#b4730c'};
   var nodes=[].slice.call(document.querySelectorAll('.mermaid'));
   var srcs=nodes.map(function(n){return n.textContent;});
@@ -18,10 +19,34 @@
   if(saved)root.setAttribute('data-theme',saved);
   else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches)root.setAttribute('data-theme','light');
   if(btn)btn.onclick=function(){var next=root.getAttribute('data-theme')==='light'?'dark':'light';root.setAttribute('data-theme',next);try{localStorage.setItem('ox-plan-theme',next);}catch(e){}renderMer();};
-  // scroll-spy over section headings
   var links=[].slice.call(document.querySelectorAll('nav.toc a'));
-  var map={};links.forEach(function(a){map[a.getAttribute('href').slice(1)]=a;});
-  if(window.IntersectionObserver){
+  // tabbed views (>3 sections): the server renders a .tabbar; JS switches the
+  // visible section. Hiding is gated on body.tabs-on so a no-JS open still
+  // shows every section as one scroll (graceful degradation).
+  var tabbar=document.querySelector('.tabbar');
+  if(tabbar){
+    document.body.classList.add('tabs-on');
+    var views=[].slice.call(document.querySelectorAll('main > section[id^="sec-"]'));
+    var tabs=[].slice.call(tabbar.querySelectorAll('button[data-tab]'));
+    var activate=function(id,remember){
+      views.forEach(function(v){v.classList.toggle('on',v.id===id);});
+      tabs.forEach(function(b){b.setAttribute('aria-selected',String(b.getAttribute('data-tab')===id));});
+      links.forEach(function(l){l.classList.toggle('active',l.getAttribute('href')==='#'+id);});
+      if(remember&&history.replaceState)history.replaceState(null,'','#'+id);
+      // a diagram laid out inside a hidden tab has zero width — re-render on reveal
+      renderMer();
+    };
+    tabs.forEach(function(b){b.addEventListener('click',function(){activate(b.getAttribute('data-tab'),true);});});
+    // TOC entries drive tabs too: one nav model, two affordances.
+    links.forEach(function(l){var id=l.getAttribute('href').slice(1);if(id.indexOf('sec-')!==0)return;l.addEventListener('click',function(e){e.preventDefault();activate(id,true);});});
+    var initial=(location.hash||'').slice(1);
+    if(!views.some(function(v){return v.id===initial;}))initial=views.length?views[0].id:'';
+    if(initial)activate(initial,false);
+  }
+  // scroll-spy over section headings (single-scroll mode; in tabbed mode the
+  // active TOC entry mirrors the active tab instead)
+  if(!tabbar&&window.IntersectionObserver){
+    var map={};links.forEach(function(a){map[a.getAttribute('href').slice(1)]=a;});
     var obs=new IntersectionObserver(function(es){es.forEach(function(e){if(e.isIntersecting){links.forEach(function(l){l.classList.remove('active');});var a=map[e.target.id];if(a)a.classList.add('active');}});},{rootMargin:'-12% 0px -75% 0px'});
     document.querySelectorAll('section[id]').forEach(function(s){obs.observe(s);});
   }

--- a/internal/plan/assets/scaffold.js
+++ b/internal/plan/assets/scaffold.js
@@ -1,7 +1,7 @@
 // ox plan — portable scaffold runtime. No build step, runs from file://.
 // Mermaid is the only external dep (CDN, at view time). Handles dark/light
-// re-render, OS-preference default + persistence, tabbed section views
-// (plans with >3 sections), and scroll-spy TOC (single-scroll mode).
+// re-render, OS-preference default + persistence, sticky section jumps
+// (plans with >3 sections), and scroll-spy TOC.
 (function(){
   var darkVars={background:'#111411',primaryColor:'#171b17',primaryTextColor:'#e8ede7',primaryBorderColor:'#252c24',lineColor:'#6f7a6d',secondaryColor:'#141814',tertiaryColor:'#121612',fontFamily:'Inter, sans-serif',fontSize:'13px',actorBkg:'#171b17',actorBorder:'#252c24',actorTextColor:'#e8ede7',noteBkgColor:'#241803',noteTextColor:'#f7d8a0',noteBorderColor:'#f59e0b'};
   var lightVars={background:'#ffffff',primaryColor:'#f5f8f4',primaryTextColor:'#16201c',primaryBorderColor:'#d8e0d8',lineColor:'#6c7a72',secondaryColor:'#eef4ee',tertiaryColor:'#eef7f5',fontFamily:'Inter, sans-serif',fontSize:'13px',actorBkg:'#f5f8f4',actorBorder:'#d8e0d8',actorTextColor:'#16201c',noteBkgColor:'#fdf2dc',noteTextColor:'#6b4a0c',noteBorderColor:'#b4730c'};
@@ -20,36 +20,78 @@
   else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches)root.setAttribute('data-theme','light');
   if(btn)btn.onclick=function(){var next=root.getAttribute('data-theme')==='light'?'dark':'light';root.setAttribute('data-theme',next);try{localStorage.setItem('ox-plan-theme',next);}catch(e){}renderMer();};
   var links=[].slice.call(document.querySelectorAll('nav.toc a'));
-  // tabbed views (>3 sections): the server renders a .tabbar; JS switches the
-  // visible section. Hiding is gated on body.tabs-on so a no-JS open still
-  // shows every section as one scroll (graceful degradation).
+  // Sticky section jumps (>3 sections): every section stays in the document
+  // flow so reviewers keep context and review-rail jumps can always land on
+  // visible content. The bar is a compact duplicate of the side TOC for long
+  // plans, not an alternate one-section app state.
   var tabbar=document.querySelector('.tabbar');
+  var activate=function(id,remember){
+    if(!id)return;
+    if(tabbar){
+      var tabs=[].slice.call(tabbar.querySelectorAll('button[data-tab]'));
+      tabs.forEach(function(b){b.setAttribute('aria-current',String(b.getAttribute('data-tab')===id));});
+    }
+    links.forEach(function(l){l.classList.toggle('active',l.getAttribute('href')==='#'+id);});
+    if(remember&&history.replaceState)history.replaceState(null,'','#'+id);
+  };
   if(tabbar){
-    document.body.classList.add('tabs-on');
-    var views=[].slice.call(document.querySelectorAll('main > section[id^="sec-"]'));
-    var tabs=[].slice.call(tabbar.querySelectorAll('button[data-tab]'));
-    var activate=function(id,remember){
-      views.forEach(function(v){v.classList.toggle('on',v.id===id);});
-      tabs.forEach(function(b){b.setAttribute('aria-selected',String(b.getAttribute('data-tab')===id));});
-      links.forEach(function(l){l.classList.toggle('active',l.getAttribute('href')==='#'+id);});
-      if(remember&&history.replaceState)history.replaceState(null,'','#'+id);
-      // a diagram laid out inside a hidden tab has zero width — re-render on reveal
-      renderMer();
-    };
-    tabs.forEach(function(b){b.addEventListener('click',function(){activate(b.getAttribute('data-tab'),true);});});
-    // TOC entries drive tabs too: one nav model, two affordances.
-    links.forEach(function(l){var id=l.getAttribute('href').slice(1);if(id.indexOf('sec-')!==0)return;l.addEventListener('click',function(e){e.preventDefault();activate(id,true);});});
+    document.body.classList.add('has-tabbar'); // the jump bar is the one nav — CSS hides the duplicate TOC
+    [].slice.call(tabbar.querySelectorAll('button[data-tab]')).forEach(function(b){
+      b.addEventListener('click',function(){
+        var id=b.getAttribute('data-tab'),el=document.getElementById(id);
+        activate(id,true);
+        if(el)el.scrollIntoView({behavior:'smooth',block:'start'});
+      });
+    });
     var initial=(location.hash||'').slice(1);
-    if(!views.some(function(v){return v.id===initial;}))initial=views.length?views[0].id:'';
-    if(initial)activate(initial,false);
+    if(initial&&document.getElementById(initial))activate(initial,false);
   }
-  // scroll-spy over section headings (single-scroll mode; in tabbed mode the
-  // active TOC entry mirrors the active tab instead)
-  if(!tabbar&&window.IntersectionObserver){
-    var map={};links.forEach(function(a){map[a.getAttribute('href').slice(1)]=a;});
-    var obs=new IntersectionObserver(function(es){es.forEach(function(e){if(e.isIntersecting){links.forEach(function(l){l.classList.remove('active');});var a=map[e.target.id];if(a)a.classList.add('active');}});},{rootMargin:'-12% 0px -75% 0px'});
+  // scroll-spy over section headings. In long-plan mode it drives both the
+  // side TOC and the sticky jump bar.
+  if(window.IntersectionObserver){
+    var obs=new IntersectionObserver(function(es){es.forEach(function(e){if(e.isIntersecting){activate(e.target.id,false);}});},{rootMargin:'-12% 0px -75% 0px'});
     document.querySelectorAll('section[id]').forEach(function(s){obs.observe(s);});
   }
   function start(){renderMer();}
   if(document.readyState!=='loading')start();else document.addEventListener('DOMContentLoaded',start);
+})();
+// auto-inspector: comparison tables (table.inspect) — click a row, its fields
+// project into the docked explainer with header-labeled values.
+(function(){
+  [].slice.call(document.querySelectorAll('table.inspect')).forEach(function(t){
+    var dock=t.nextElementSibling;
+    if(!dock||(dock.className||'').indexOf('inspect-dock')<0)return;
+    var body=dock.querySelector('.inspect-dock-body');
+    var heads=[].slice.call(t.querySelectorAll('thead th')).map(function(h){return h.textContent.trim();});
+    [].slice.call(t.querySelectorAll('tbody tr')).forEach(function(tr){
+      tr.addEventListener('click',function(){
+        [].slice.call(t.querySelectorAll('tr.lit')).forEach(function(r){r.classList.remove('lit');});
+        tr.classList.add('lit');
+        var html='';
+        [].slice.call(tr.children).forEach(function(c,i){
+          html+='<div class="inspect-f"><span class="inspect-k">'+(heads[i]||('field '+(i+1)))+'</span><span class="inspect-v">'+c.innerHTML+'</span></div>';
+        });
+        if(body)body.innerHTML=html;
+        var hint=dock.querySelector('.inspect-dock-hint');
+        if(hint)hint.remove();
+        dock.hidden=false;
+      });
+    });
+  });
+})();
+// keyboard map: 1-9 jump to tab, [ / ] prev-next tab, t theme, r review toggle.
+// Skipped while typing in an input/textarea (review notes).
+(function(){
+  function typing(e){var t=e.target;return t&&(t.tagName==='TEXTAREA'||t.tagName==='INPUT'||t.isContentEditable);}
+  document.addEventListener('keydown',function(e){
+    if(typing(e)||e.metaKey||e.ctrlKey||e.altKey)return;
+    var tabs=[].slice.call(document.querySelectorAll('.tabbar button[data-tab]'));
+    if(e.key==='t'){var b=document.getElementById('themeBtn');if(b){b.click();e.preventDefault();}return;}
+    if(e.key==='r'){var r=document.querySelector('.rev-bar .rev-toggle');if(r){r.click();e.preventDefault();}return;}
+    if(!tabs.length)return;
+    var cur=tabs.findIndex(function(b){return b.getAttribute('aria-current')==='true';});
+    if(e.key>='1'&&e.key<='9'){var i=+e.key-1;if(tabs[i]){tabs[i].click();e.preventDefault();}return;}
+    if(e.key==='['&&cur>0){tabs[cur-1].click();e.preventDefault();return;}
+    if(e.key===']'&&cur>=0&&cur<tabs.length-1){tabs[cur+1].click();e.preventDefault();return;}
+  });
 })();

--- a/internal/plan/autoviz.go
+++ b/internal/plan/autoviz.go
@@ -1,0 +1,150 @@
+package plan
+
+// autoviz.go — structure-driven auto-visualization for the markdown-path
+// render. The scaffold ships swimlanes, stat cards and interactive primitives
+// that a markdown author has no way to reach; these passes detect the plan
+// STRUCTURES those primitives were built for and emit them deterministically,
+// so a quick markdown plan still lands closer to the hand-built quality bar:
+//   - a gated-track table (Track/Phase column + Gate column) gains a .swim
+//     swimlane figure above it — the table stays as the detail record;
+//   - a comparison/correspondence table (>=3 columns under a comparison
+//     heading) becomes click-to-inspect: rows light up and a docked explainer
+//     shows the row's fields (scaffold.js drives it; no external deps).
+// Both passes are additive: the source table is never removed, and a plan
+// with neither structure renders byte-identically.
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	tableBlockRe = regexp.MustCompile(`(?s)<table>.*?</table>`)
+	headerCellRe = regexp.MustCompile(`(?s)<th[^>]*>(.*?)</th>`)
+	rowRe        = regexp.MustCompile(`(?s)<tr>.*?</tr>`)
+	cellRe       = regexp.MustCompile(`(?s)<td[^>]*>(.*?)</td>`)
+	tagStripRe   = regexp.MustCompile(`<[^>]*>`)
+
+	trackHeaderRe = regexp.MustCompile(`(?i)\b(track|phase|wave|workstream|stage)\b`)
+	gateHeaderRe  = regexp.MustCompile(`(?i)\b(gate|gated|blocked|blocks|depends|after)\b`)
+	compareHeadRe = regexp.MustCompile(`(?i)compar|correspond|\bvs\b|versus`)
+)
+
+// swimPalette cycles bar fills for auto-swimlanes. Dark label text (#0c1112,
+// per the scaffold's .swim .bar) needs light fills — these are the catalog's
+// own accent hexes.
+var swimPalette = []string{"#99c693", "#e0a56a", "#14b8a6", "#a78bfa", "#64748b", "#f59e0b"}
+
+// autoVisualize runs the structure-driven passes over one rendered section.
+// heading is the section's H2 text (comparison detection keys off it).
+func autoVisualize(sectionHTML, heading string) string {
+	out := autoSwimlane(sectionHTML)
+	if compareHeadRe.MatchString(heading) {
+		out = autoInspector(out)
+	}
+	return out
+}
+
+// stripTags flattens a table-cell fragment to text.
+func stripTags(s string) string {
+	return strings.TrimSpace(tagStripRe.ReplaceAllString(s, ""))
+}
+
+// autoSwimlane finds the first table whose header carries BOTH a track-ish and
+// a gate-ish column and prepends a .swim swimlane figure: one lane per row,
+// bars staggered in row order (the table's order IS the sequence), a ◆ gate
+// marker at each gated bar's end carrying the gate text as its tooltip. Only
+// the first matching table converts — one hero visual per section, the rest
+// stay tables.
+func autoSwimlane(sectionHTML string) string {
+	converted := false
+	return tableBlockRe.ReplaceAllStringFunc(sectionHTML, func(table string) string {
+		if converted {
+			return table
+		}
+		headers := headerCellRe.FindAllStringSubmatch(table, -1)
+		trackCol, gateCol := -1, -1
+		for i, h := range headers {
+			txt := stripTags(h[1])
+			if trackCol < 0 && trackHeaderRe.MatchString(txt) {
+				trackCol = i
+			}
+			if gateCol < 0 && gateHeaderRe.MatchString(txt) {
+				gateCol = i
+			}
+		}
+		if trackCol < 0 || gateCol < 0 || trackCol == gateCol {
+			return table
+		}
+		var lanes [][2]string // [name, gate] per data row
+		for _, row := range rowRe.FindAllString(table, -1) {
+			cells := cellRe.FindAllStringSubmatch(row, -1)
+			if len(cells) <= trackCol || len(cells) <= gateCol {
+				continue // header row (th) or ragged row
+			}
+			lanes = append(lanes, [2]string{stripTags(cells[trackCol][1]), stripTags(cells[gateCol][1])})
+		}
+		if len(lanes) < 2 {
+			return table // a single lane is not a timeline
+		}
+		converted = true
+		return buildSwimlane(lanes) + table
+	})
+}
+
+// buildSwimlane emits the scaffold's .swim markup: sequential bars (row order
+// = execution order — the only ordering a gated-track table asserts), each
+// gated lane carrying a ◆ marker at its bar end with the gate as tooltip.
+func buildSwimlane(lanes [][2]string) string {
+	n := len(lanes)
+	// bars share a 2%..98% band; each occupies its sequential slot with a 1%
+	// gutter so adjacent lanes read as ordered, not stacked.
+	slot := 96.0 / float64(n)
+	var b strings.Builder
+	b.WriteString(`<figure class="swim auto-swim"><figcaption>Sequenced tracks (gates marked ◆ — hover for the gate)</figcaption>`)
+	for i, l := range lanes {
+		left := 2 + slot*float64(i)
+		width := slot - 1
+		color := swimPalette[i%len(swimPalette)]
+		name := htmlEscape(l[0])
+		b.WriteString(`<div class="lane"><div class="lane-name">` + name + `</div><div class="track">`)
+		fmt.Fprintf(&b, `<span class="bar" style="left:%.1f%%;width:%.1f%%;background:%s">%s</span>`, left, width, color, name)
+		if l[1] != "" {
+			fmt.Fprintf(&b, `<span class="gate" style="left:%.1f%%" title="gate: %s">◆</span>`, left+width, htmlEscape(l[1]))
+		}
+		b.WriteString(`</div></div>`)
+	}
+	b.WriteString(`</figure>`)
+	return b.String()
+}
+
+func htmlEscape(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&#34;")
+	return r.Replace(s)
+}
+
+// autoInspector upgrades comparison tables (>=3 columns, >=3 data rows) to the
+// click-to-inspect register: the table gains class "inspect" and a docked
+// explainer follows it; scaffold.js lights the clicked row and projects its
+// cells (labeled by the header row) into the dock — the generatable core of
+// the hand-built field-inspector experience.
+func autoInspector(sectionHTML string) string {
+	return tableBlockRe.ReplaceAllStringFunc(sectionHTML, func(table string) string {
+		headers := headerCellRe.FindAllStringSubmatch(table, -1)
+		if len(headers) < 3 {
+			return table
+		}
+		dataRows := 0
+		for _, row := range rowRe.FindAllString(table, -1) {
+			if len(cellRe.FindAllStringSubmatch(row, -1)) >= 3 {
+				dataRows++
+			}
+		}
+		if dataRows < 3 {
+			return table
+		}
+		out := strings.Replace(table, "<table>", `<table class="inspect">`, 1)
+		return out + `<div class="inspect-dock" hidden><span class="inspect-dock-hint">Click a row to inspect the correspondence.</span><div class="inspect-dock-body"></div></div>`
+	})
+}

--- a/internal/plan/autoviz_test.go
+++ b/internal/plan/autoviz_test.go
@@ -1,0 +1,221 @@
+package plan
+
+import (
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestAutoSwimlane_GatedTracks verifies the structure-keyed emission: a table
+// with a Track column and a Gate column renders a .swim swimlane above the
+// table (lanes in row order, ◆ gate markers carrying the gate text), and the
+// table itself survives as the detail record. Failure prevented: a
+// five-gated-track plan rendering as prose while ~700 lines of viz CSS ship
+// unused.
+func TestAutoSwimlane_GatedTracks(t *testing.T) {
+	raw := strings.Join([]string{
+		"# P", "",
+		"## Sequencing", "",
+		"| Track | Work | Gate |", "|---|---|---|",
+		"| A. Turn provenance | schema | none |", // "none" still text — marker rendered with title
+		"| B. Folder layout | readers | A ships |",
+		"| C. Access seam | commit plan | B green |", "",
+	}, "\n")
+	out, err := RenderHTML(Parse(raw), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `class="swim auto-swim"`) {
+		t.Fatal("gated-track table did not emit a swimlane")
+	}
+	if got := strings.Count(s, `class="lane-name"`); got != 3 {
+		t.Errorf("expected 3 swimlane lanes, got %d", got)
+	}
+	if !strings.Contains(s, `title="gate: B green"`) {
+		t.Error("gate marker missing its gate-condition tooltip")
+	}
+	if !strings.Contains(s, "<table>") {
+		t.Error("the source table must survive below the swimlane")
+	}
+}
+
+// TestAutoSwimlane_RequiresGateColumn pins the precision gate: a plain
+// tracks table (no gate-ish header) must NOT sprout a swimlane.
+func TestAutoSwimlane_RequiresGateColumn(t *testing.T) {
+	raw := "# P\n\n## Sequencing\n\n| Track | Work |\n|---|---|\n| A | x |\n| B | y |\n"
+	out, err := RenderHTML(Parse(raw), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	if strings.Contains(string(out), `class="swim auto-swim"`) {
+		t.Error("swimlane emitted without a gate column")
+	}
+}
+
+// TestAutoInspector_ComparisonTable verifies the click-to-inspect upgrade: a
+// >=3-column table under a comparison heading gains class "inspect" and a
+// docked explainer; the same table under a neutral heading stays plain.
+func TestAutoInspector_ComparisonTable(t *testing.T) {
+	table := "| Field | Ours | Theirs |\n|---|---|---|\n| id | source_ref | sha256 |\n| author | author_id | pubkey |\n| time | start_utc | created_at |\n"
+	comparing := "# P\n\n## Format comparison\n\n" + table
+	out, err := RenderHTML(Parse(comparing), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `<table class="inspect">`) {
+		t.Error("comparison table did not gain the inspect class")
+	}
+	if !strings.Contains(s, `class="inspect-dock"`) {
+		t.Error("comparison table missing its docked explainer")
+	}
+
+	neutral := "# P\n\n## Storage\n\n" + table
+	out2, err := RenderHTML(Parse(neutral), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	if strings.Contains(string(out2), `class="inspect"`) {
+		t.Error("non-comparison section table wrongly upgraded to inspector")
+	}
+}
+
+// TestRenderHTML_TLDRAlwaysLede pins the mandatory hero: a plan with NO
+// explicit TL;DR marker still opens on a plain-language lede — the preamble's
+// first paragraph LIFTED (moved, not copied) into the .tldr hero.
+func TestRenderHTML_TLDRAlwaysLede(t *testing.T) {
+	lede := "Ship the conversation model this week so multi-mic capture lands."
+	raw := "# P\n\n" + lede + "\n\nSecond paragraph stays put.\n\n## One\n\na\n"
+	out, err := RenderHTML(Parse(raw), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `class="tldr"`) {
+		t.Fatal("hero missing on a plan without an explicit TL;DR")
+	}
+	if got := strings.Count(s, lede); got != 1 {
+		t.Errorf("lede must appear exactly once (lifted, not copied): %d", got)
+	}
+	tldrIdx := strings.Index(s, `class="tldr"`)
+	if strings.Index(s, lede) < tldrIdx {
+		t.Error("lede text appears before the hero — not lifted into it")
+	}
+	if !strings.Contains(s, "Second paragraph stays put.") {
+		t.Error("non-lede preamble content lost")
+	}
+}
+
+// TestRenderHTML_TLDRSkipsBannerLiftsSection pins the guard: a preamble that
+// OPENS with a blockquote (a status banner) is not a lede — the hero lifts the
+// first section's opening paragraph instead, and the banner stays intact.
+func TestRenderHTML_TLDRSkipsBannerLiftsSection(t *testing.T) {
+	raw := "# P\n\n> **Status.** shipped on branch X.\n\n## Context\n\nThe model must serve every capture surface.\n\nMore detail.\n"
+	out, err := RenderHTML(Parse(raw), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `class="tldr"`) {
+		t.Fatal("hero missing")
+	}
+	if strings.Count(s, "The model must serve every capture surface.") != 1 {
+		t.Error("section lede not lifted exactly once")
+	}
+	if !strings.Contains(s, "shipped on branch X.") {
+		t.Error("status banner blockquote must survive untouched")
+	}
+}
+
+// TestRenderHTML_ContextStripAndJudgment verifies the enrichment plumbing the
+// judge flagged as unshipped: retrieved context items surface as the
+// alignment strip, and agent-authored judgment badges (aligns/conflicts)
+// render as chips — while rigor stays excluded.
+func TestRenderHTML_ContextStripAndJudgment(t *testing.T) {
+	in := sampleInput()
+	res := Result{
+		Annotations: []Annotation{
+			{Kind: BadgeJudgment, Type: BadgeAligns, Why: "matches ADR-016 retention rule", SourceURL: "docs/adr/016.md", Files: []string{"store.go"}},
+			{Kind: BadgeJudgment, Type: BadgeConflicts, Why: "clashes with ADR-024 tiering", SourceURL: "docs/adr/024.md"},
+			{Kind: BadgeJudgment, Type: BadgeRigor, Why: "thoughtful-collab"},
+		},
+		Context: []ContextItem{
+			{Kind: "adr", Title: "ADR-016 flags", Score: 0.9},
+			{Kind: "session", Title: "2026-05-12 render rework", Score: 0.8},
+		},
+	}
+	out, err := RenderHTML(in, res)
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		`class="ox-ctx"`, "ADR-016 flags", "2026-05-12 render rework",
+		"ox-sig-aligns", "matches ADR-016 retention rule",
+		"ox-sig-conflicts", "clashes with ADR-024 tiering",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("enrichment layer missing %q", want)
+		}
+	}
+	if strings.Contains(s, "thoughtful-collab") {
+		t.Error("rigor judgment leaked into the render")
+	}
+}
+
+// TestRenderHTML_QuietZeroSignalLine pins the silence-vs-never-ran rule: a
+// zero-signal render carries an explicit quiet line, so an empty rail is
+// readable as "checked, clean" rather than "enrichment never ran".
+func TestRenderHTML_QuietZeroSignalLine(t *testing.T) {
+	out, err := RenderHTML(sampleInput(), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	if !strings.Contains(string(out), "no collisions or prior art surfaced") {
+		t.Error("zero-signal render missing the quiet footer line")
+	}
+}
+
+// --- WCAG contrast gate over the corrected tokens (perceptual-ux spec) ---
+
+func relLum(hex string) float64 {
+	c := func(i int) float64 {
+		v, _ := strconv.ParseInt(hex[i:i+2], 16, 32)
+		f := float64(v) / 255
+		if f <= 0.03928 {
+			return f / 12.92
+		}
+		return math.Pow((f+0.055)/1.055, 2.4)
+	}
+	return 0.2126*c(1) + 0.7152*c(3) + 0.0722*c(5)
+}
+
+func contrast(a, b string) float64 {
+	la, lb := relLum(a), relLum(b)
+	if la < lb {
+		la, lb = lb, la
+	}
+	return (la + 0.05) / (lb + 0.05)
+}
+
+// TestContrastTokens is the acceptance gate from the perceptual-ux review:
+// corrected text tokens clear WCAG AA (4.5:1) on the surfaces they sit on —
+// including the chrome's own near-opaque surfaces on white AND #0b0d0b hosts.
+func TestContrastTokens(t *testing.T) {
+	cases := []struct{ name, fg, bg string }{
+		{"dark faint on panel2 (BUG1 fix)", "#7b857a", "#171b17"},
+		{"dark faint on canvas", "#7b857a", "#0b0d0b"},
+		{"light amber on canvas (BUG2 fix)", "#9a620a", "#eef2ee"},
+		{"light copper on canvas (BUG3 fix)", "#9f5c38", "#eef2ee"},
+		{"light violet on canvas", "#755acb", "#eef2ee"},
+		{"chrome ink on chrome dark surface", "#e8ede7", "#111411"},
+		{"chrome light ink on chrome light surface", "#16201c", "#ffffff"},
+	}
+	for _, tc := range cases {
+		if got := contrast(tc.fg, tc.bg); got < 4.5 {
+			t.Errorf("%s: contrast %.2f < 4.5", tc.name, got)
+		}
+	}
+}

--- a/internal/plan/autoviz_test.go
+++ b/internal/plan/autoviz_test.go
@@ -165,16 +165,16 @@ func TestRenderHTML_ContextStripAndJudgment(t *testing.T) {
 	}
 }
 
-// TestRenderHTML_QuietZeroSignalLine pins the silence-vs-never-ran rule: a
-// zero-signal render carries an explicit quiet line, so an empty rail is
-// readable as "checked, clean" rather than "enrichment never ran".
+// TestRenderHTML_QuietZeroSignalLine pins the silence-vs-never-ran rule: an
+// un-enriched render does not claim enrichment ran, so a missing rail stays
+// readable as "no enrichment input" rather than "checked, clean".
 func TestRenderHTML_QuietZeroSignalLine(t *testing.T) {
 	out, err := RenderHTML(sampleInput(), Result{})
 	if err != nil {
 		t.Fatalf("RenderHTML: %v", err)
 	}
-	if !strings.Contains(string(out), "no collisions or prior art surfaced") {
-		t.Error("zero-signal render missing the quiet footer line")
+	if strings.Contains(string(out), "no collisions or prior art surfaced") {
+		t.Error("zero-signal un-enriched render claimed enrichment ran")
 	}
 }
 

--- a/internal/plan/companion.go
+++ b/internal/plan/companion.go
@@ -1,0 +1,158 @@
+package plan
+
+// companion.go — rich HTML companion artifacts carried WITH a plan.
+//
+// A markdown plan has a hard richness ceiling: interactivity (tabbed views,
+// field inspectors, animated timelines) cannot be expressed in prose. When a
+// coworker hand-crafts a self-contained interactive HTML page alongside a
+// plan, that page must travel WITH the plan — copied into the saved plan's
+// ledger dir, listed in meta.json, linked prominently from the rendered page,
+// and served by the live review loop — instead of becoming an orphan the
+// render competes with.
+//
+// Companions are stored under a companions/ subdir of the plan dir (and of
+// any -o/temp output dir), so the rendered page can link them with one
+// uniform relative href ("companions/<name>") that works from file://, from
+// a saved ledger render, and from the `ox plan review` server alike.
+//
+// TRUST BOUNDARY: a companion is the developer's own local file, copied
+// byte-for-byte (never rewritten or sanitized) and rendered locally for that
+// same developer — the same posture as the plan markdown itself (see
+// newMarkdown). Artifact mode omits companion links: an artifact is a single
+// self-contained page and a relative link would dangle.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// CompanionsDir is the subdirectory (of a plan dir or a render output dir)
+// where companion HTML files live.
+const CompanionsDir = "companions"
+
+// Companion is the render-time view of one companion artifact: the display
+// name and the href the rendered page links to.
+type Companion struct {
+	Name string
+	Href string
+}
+
+// CompanionFile pairs a companion's sanitized basename with the source path
+// it is copied from — the command layer's carrying shape between detection,
+// ledger save, and output emission.
+type CompanionFile struct {
+	Name    string // sanitized basename, e.g. "deep-dive.html"
+	SrcPath string // absolute path of the file to copy
+}
+
+// mdLinkRe matches inline markdown links [text](target). Targets are then
+// filtered to bare relative .html paths — a URL (scheme or leading slash) or
+// an anchor is never a companion candidate.
+var mdLinkRe = regexp.MustCompile(`\[[^\]]*\]\(([^()\s]+\.html?)\)`)
+
+// DetectCompanionLinks scans plan markdown for relative links to local .html
+// files and resolves them against baseDir (the plan file's directory). Only
+// links whose target actually exists on disk are returned — a dangling link
+// is prose, not a companion. Returns absolute paths, deduped, in document
+// order. baseDir == "" (stdin plans have no directory) yields nil.
+func DetectCompanionLinks(raw, baseDir string) []string {
+	if baseDir == "" {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, m := range mdLinkRe.FindAllStringSubmatch(raw, -1) {
+		target := m[1]
+		if strings.Contains(target, "://") || strings.HasPrefix(target, "/") || strings.HasPrefix(target, "#") {
+			continue
+		}
+		abs := filepath.Join(baseDir, filepath.FromSlash(target))
+		if info, err := os.Stat(abs); err != nil || info.IsDir() {
+			continue
+		}
+		if _, ok := seen[abs]; ok {
+			continue
+		}
+		seen[abs] = struct{}{}
+		out = append(out, abs)
+	}
+	return out
+}
+
+// CompanionName sanitizes a companion source path to the basename it is
+// stored and linked under. Path separators can never survive (basename), and
+// a name that could collide with the plan's own artifacts inside the
+// companions/ subdir cannot arise — the subdir is the namespace.
+func CompanionName(srcPath string) string {
+	return filepath.Base(filepath.Clean(srcPath))
+}
+
+// CopyCompanions copies companion files into destDir/companions/, creating
+// the subdir on first use. Returns the stored basenames in input order.
+// Copies are byte-for-byte — a companion's HTML is never rewritten.
+func CopyCompanions(files []CompanionFile, destDir string) ([]string, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+	dir := filepath.Join(destDir, CompanionsDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create companions dir: %w", err)
+	}
+	var names []string
+	for _, f := range files {
+		data, err := os.ReadFile(f.SrcPath)
+		if err != nil {
+			return names, fmt.Errorf("read companion %q: %w", f.SrcPath, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, f.Name), data, 0o644); err != nil {
+			return names, fmt.Errorf("write companion %q: %w", f.Name, err)
+		}
+		names = append(names, f.Name)
+	}
+	return names, nil
+}
+
+// RecordCompanions merges companion basenames into a saved plan's meta.json
+// (deduped, order-preserving) under the meta flock. No-op when the plan has
+// no meta.json yet or names is empty.
+func RecordCompanions(planDir string, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	return MutatePlanMeta(context.Background(), planDir, func(m *Meta) (*Meta, error) {
+		if m == nil {
+			return nil, nil
+		}
+		seen := make(map[string]struct{}, len(m.Companions))
+		for _, n := range m.Companions {
+			seen[n] = struct{}{}
+		}
+		for _, n := range names {
+			if _, ok := seen[n]; ok {
+				continue
+			}
+			seen[n] = struct{}{}
+			m.Companions = append(m.Companions, n)
+		}
+		return m, nil
+	})
+}
+
+// CompanionRefs projects stored companion basenames into the render-time
+// Companion list. The href is the uniform relative "companions/<name>" that
+// resolves next to plan.html in the ledger dir, next to an -o/temp output,
+// and against the review server's /companions/ route.
+func CompanionRefs(names []string) []Companion {
+	var out []Companion
+	for _, n := range names {
+		if n == "" || n != filepath.Base(n) {
+			continue // defensive: a stored name must be a bare basename
+		}
+		out = append(out, Companion{Name: n, Href: CompanionsDir + "/" + n})
+	}
+	return out
+}

--- a/internal/plan/companion.go
+++ b/internal/plan/companion.go
@@ -47,6 +47,7 @@ type Companion struct {
 type CompanionFile struct {
 	Name    string // sanitized basename, e.g. "deep-dive.html"
 	SrcPath string // absolute path of the file to copy
+	RelPath string // optional sanitized markdown href path to preserve beside renders
 }
 
 // mdLinkRe matches inline markdown links [text](target). Targets are then
@@ -60,17 +61,32 @@ var mdLinkRe = regexp.MustCompile(`\[[^\]]*\]\(([^()\s]+\.html?)\)`)
 // is prose, not a companion. Returns absolute paths, deduped, in document
 // order. baseDir == "" (stdin plans have no directory) yields nil.
 func DetectCompanionLinks(raw, baseDir string) []string {
+	var out []string
+	for _, f := range DetectCompanionFiles(raw, baseDir) {
+		out = append(out, f.SrcPath)
+	}
+	return out
+}
+
+// DetectCompanionFiles is DetectCompanionLinks with the original markdown href
+// path retained, so emitted renders can preserve both the companion card link
+// and the author's inline relative link.
+func DetectCompanionFiles(raw, baseDir string) []CompanionFile {
 	if baseDir == "" {
 		return nil
 	}
 	seen := make(map[string]struct{})
-	var out []string
+	var out []CompanionFile
 	for _, m := range mdLinkRe.FindAllStringSubmatch(raw, -1) {
 		target := m[1]
 		if strings.Contains(target, "://") || strings.HasPrefix(target, "/") || strings.HasPrefix(target, "#") {
 			continue
 		}
-		abs := filepath.Join(baseDir, filepath.FromSlash(target))
+		rel := filepath.Clean(filepath.FromSlash(target))
+		if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+			continue
+		}
+		abs := filepath.Join(baseDir, rel)
 		if info, err := os.Stat(abs); err != nil || info.IsDir() {
 			continue
 		}
@@ -78,7 +94,7 @@ func DetectCompanionLinks(raw, baseDir string) []string {
 			continue
 		}
 		seen[abs] = struct{}{}
-		out = append(out, abs)
+		out = append(out, CompanionFile{Name: CompanionName(abs), SrcPath: abs, RelPath: filepath.ToSlash(rel)})
 	}
 	return out
 }
@@ -110,6 +126,24 @@ func CopyCompanions(files []CompanionFile, destDir string) ([]string, error) {
 		}
 		if err := os.WriteFile(filepath.Join(dir, f.Name), data, 0o644); err != nil {
 			return names, fmt.Errorf("write companion %q: %w", f.Name, err)
+		}
+		if f.RelPath != "" && f.RelPath != CompanionsDir+"/"+f.Name {
+			rel := filepath.Clean(filepath.FromSlash(f.RelPath))
+			if rel != "." && !filepath.IsAbs(rel) && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				dst := filepath.Join(destDir, rel)
+				if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+					return names, fmt.Errorf("create companion link dir %q: %w", f.RelPath, err)
+				}
+				if _, err := os.Stat(dst); err == nil {
+					names = append(names, f.Name)
+					continue
+				} else if !os.IsNotExist(err) {
+					return names, fmt.Errorf("stat companion link %q: %w", f.RelPath, err)
+				}
+				if err := os.WriteFile(dst, data, 0o644); err != nil {
+					return names, fmt.Errorf("write companion link %q: %w", f.RelPath, err)
+				}
+			}
 		}
 		names = append(names, f.Name)
 	}

--- a/internal/plan/companion.go
+++ b/internal/plan/companion.go
@@ -23,6 +23,7 @@ package plan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -137,7 +138,7 @@ func CopyCompanions(files []CompanionFile, destDir string) ([]string, error) {
 				if _, err := os.Stat(dst); err == nil {
 					names = append(names, f.Name)
 					continue
-				} else if !os.IsNotExist(err) {
+				} else if !errors.Is(err, os.ErrNotExist) {
 					return names, fmt.Errorf("stat companion link %q: %w", f.RelPath, err)
 				}
 				if err := os.WriteFile(dst, data, 0o644); err != nil {

--- a/internal/plan/companion_test.go
+++ b/internal/plan/companion_test.go
@@ -38,6 +38,16 @@ Also [the same again](deep-dive.html), [a URL](https://example.com/x.html),
 			t.Errorf("link[%d] = %q, want %q", i, got[i], want[i])
 		}
 	}
+	files := DetectCompanionFiles(raw, dir)
+	wantRel := []string{"deep-dive.html", "viz/timeline.html"}
+	if len(files) != len(wantRel) {
+		t.Fatalf("DetectCompanionFiles = %+v, want %d files", files, len(wantRel))
+	}
+	for i := range wantRel {
+		if files[i].RelPath != wantRel[i] {
+			t.Errorf("file[%d].RelPath = %q, want %q", i, files[i].RelPath, wantRel[i])
+		}
+	}
 
 	if got := DetectCompanionLinks(raw, ""); got != nil {
 		t.Errorf("empty baseDir (stdin plan) must detect nothing, got %v", got)
@@ -52,7 +62,7 @@ func TestCopyCompanions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	names, err := CopyCompanions([]CompanionFile{{Name: "a.html", SrcPath: a}}, dst)
+	names, err := CopyCompanions([]CompanionFile{{Name: "a.html", SrcPath: a, RelPath: "docs/a.html"}}, dst)
 	if err != nil {
 		t.Fatalf("CopyCompanions: %v", err)
 	}
@@ -65,6 +75,13 @@ func TestCopyCompanions(t *testing.T) {
 	}
 	if string(b) != "<html>A</html>" {
 		t.Errorf("companion content rewritten: %q", b)
+	}
+	inline, err := os.ReadFile(filepath.Join(dst, "docs", "a.html"))
+	if err != nil {
+		t.Fatalf("inline companion link copy unreadable: %v", err)
+	}
+	if string(inline) != "<html>A</html>" {
+		t.Errorf("inline companion content rewritten: %q", inline)
 	}
 }
 

--- a/internal/plan/companion_test.go
+++ b/internal/plan/companion_test.go
@@ -1,0 +1,120 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDetectCompanionLinks(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "deep-dive.html")
+	if err := os.WriteFile(present, []byte("<html></html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(dir, "viz")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(sub, "timeline.html")
+	if err := os.WriteFile(nested, []byte("<html></html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	raw := `# Plan
+
+See [the interactive companion](deep-dive.html) and [timeline](viz/timeline.html).
+Also [the same again](deep-dive.html), [a URL](https://example.com/x.html),
+[an absolute path](/etc/x.html), and [a dangling link](missing.html).
+`
+	got := DetectCompanionLinks(raw, dir)
+	want := []string{present, nested}
+	if len(got) != len(want) {
+		t.Fatalf("DetectCompanionLinks = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("link[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	if got := DetectCompanionLinks(raw, ""); got != nil {
+		t.Errorf("empty baseDir (stdin plan) must detect nothing, got %v", got)
+	}
+}
+
+func TestCopyCompanions(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	a := filepath.Join(src, "a.html")
+	if err := os.WriteFile(a, []byte("<html>A</html>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	names, err := CopyCompanions([]CompanionFile{{Name: "a.html", SrcPath: a}}, dst)
+	if err != nil {
+		t.Fatalf("CopyCompanions: %v", err)
+	}
+	if len(names) != 1 || names[0] != "a.html" {
+		t.Fatalf("names = %v", names)
+	}
+	b, err := os.ReadFile(filepath.Join(dst, CompanionsDir, "a.html"))
+	if err != nil {
+		t.Fatalf("copied companion unreadable: %v", err)
+	}
+	if string(b) != "<html>A</html>" {
+		t.Errorf("companion content rewritten: %q", b)
+	}
+}
+
+func TestCompanionRefs(t *testing.T) {
+	refs := CompanionRefs([]string{"a.html", "", "../evil.html", "b.html"})
+	if len(refs) != 2 {
+		t.Fatalf("refs = %+v, want 2 sane entries", refs)
+	}
+	if refs[0].Href != "companions/a.html" || refs[1].Href != "companions/b.html" {
+		t.Errorf("hrefs = %q, %q", refs[0].Href, refs[1].Href)
+	}
+}
+
+// TestSavePreservesCompanionsOnResave pins the read-merge rule: a re-save that
+// carries no companions (the hook draft, a later `ox plan` run) must not wipe
+// the list RecordCompanions already stored.
+func TestSavePreservesCompanionsOnResave(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	created := time.Date(2026, 7, 25, 10, 0, 0, 0, time.UTC)
+	in := Input{Raw: "# Companion plan\n\nBody."}
+	meta := Meta{Topic: "Companion plan", CreatedAt: created}
+
+	dir, err := Save("/fake/git/root", in, Result{}, nil, meta)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := RecordCompanions(dir, []string{"deep-dive.html"}); err != nil {
+		t.Fatalf("RecordCompanions: %v", err)
+	}
+	// duplicate record must not double up
+	if err := RecordCompanions(dir, []string{"deep-dive.html", "extra.html"}); err != nil {
+		t.Fatalf("RecordCompanions (2nd): %v", err)
+	}
+
+	if _, err := Save("/fake/git/root", in, Result{}, nil, meta); err != nil {
+		t.Fatalf("re-Save: %v", err)
+	}
+	got, err := LoadMeta(dir)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	want := []string{"deep-dive.html", "extra.html"}
+	if len(got.Companions) != len(want) {
+		t.Fatalf("Companions after re-save = %v, want %v", got.Companions, want)
+	}
+	for i := range want {
+		if got.Companions[i] != want[i] {
+			t.Errorf("Companions[%d] = %q, want %q", i, got.Companions[i], want[i])
+		}
+	}
+}

--- a/internal/plan/extract.go
+++ b/internal/plan/extract.go
@@ -399,7 +399,7 @@ func flattenInline(n *html.Node) string {
 				if text == "" {
 					continue
 				}
-				if href != "" && !strings.HasPrefix(href, "#") && !strings.HasPrefix(strings.ToLower(href), "javascript:") {
+				if href != "" && !strings.HasPrefix(href, "#") && !unsafeLinkScheme(href) {
 					b.WriteString("[" + text + "](" + href + ")")
 				} else {
 					b.WriteString(text)
@@ -410,6 +410,18 @@ func flattenInline(n *html.Node) string {
 		}
 	}
 	return b.String()
+}
+
+// unsafeLinkScheme reports whether href uses a scheme that must never survive
+// into derived markdown as a clickable link.
+func unsafeLinkScheme(href string) bool {
+	h := strings.ToLower(strings.TrimSpace(href))
+	for _, scheme := range []string{"javascript:", "data:", "vbscript:"} {
+		if strings.HasPrefix(h, scheme) {
+			return true
+		}
+	}
+	return false
 }
 
 // inlineWrap trims/collapses s and wraps it in pre/suf, or returns "" for

--- a/internal/plan/extract.go
+++ b/internal/plan/extract.go
@@ -1,0 +1,431 @@
+package plan
+
+// extract.go derives searchable markdown from an authored HTML plan page —
+// the inverse of render.go's markdown→HTML path. Once an HTML page is a
+// plan's PRIMARY artifact (Meta.Primary == "html", see store.go), plan.md
+// becomes a DERIVED convenience view: `ox plan view` terminal rendering,
+// grep/search, and enrich.go's section parsing (which still splits markdown
+// on "## " H2 headings — see input.go Parse()) all read the derived
+// projection rather than the HTML.
+//
+// The projection is intentionally lossy and one-directional: interactive-only
+// markup (spans wired up by page JS, tab chrome, decorative containers)
+// degrades to its visible text rather than being reconstructed as structured
+// markdown. That is a feature, not a gap — the authored HTML stays the plan
+// of record, and this output only needs to be good enough to search and skim.
+
+import (
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// headingLevel maps the heading atoms to their markdown "#" depth. A lookup
+// table rather than atom arithmetic — x/net/html/atom values are hash-table
+// offsets, not a contiguous H1..H6 enum, so atom.H2-atom.H1 is not safe.
+var headingLevel = map[atom.Atom]int{
+	atom.H1: 1, atom.H2: 2, atom.H3: 3, atom.H4: 4, atom.H5: 5, atom.H6: 6,
+}
+
+// ExtractMarkdown derives searchable markdown from an authored HTML plan
+// document. It is a lossy, deterministic projection: headings, paragraphs,
+// lists, tables, code blocks and links survive; interactive-only content
+// degrades to its visible text. Never returns an error — a malformed
+// document yields best-effort text (the derived md is a convenience view,
+// the authored HTML stays the plan of record).
+func ExtractMarkdown(htmlBytes []byte) string {
+	doc, err := html.Parse(strings.NewReader(string(htmlBytes)))
+	if err != nil {
+		// x/net/html.Parse only errors on a Reader I/O failure, never on
+		// malformed markup (that's the point of an HTML5 error-recovery
+		// parser) — strings.Reader can't fail, but stay defensive since this
+		// function's contract is "never panics, never errors".
+		return ""
+	}
+
+	e := &extractor{}
+	if body := firstDescendant(doc, atom.Body); body != nil {
+		e.walkBlock(body)
+	}
+	e.flush() // catch any trailing bare text that never hit a block boundary
+
+	if !e.sawH1 {
+		if title := extractTitle(doc); title != "" {
+			e.blocks = append([]string{"# " + title}, e.blocks...)
+		}
+	}
+
+	if len(e.blocks) == 0 {
+		return ""
+	}
+	return strings.Join(e.blocks, "\n\n") + "\n"
+}
+
+// extractTitle returns the flattened <head><title> text, or "" if absent.
+func extractTitle(doc *html.Node) string {
+	head := firstDescendant(doc, atom.Head)
+	if head == nil {
+		return ""
+	}
+	t := firstDescendant(head, atom.Title)
+	if t == nil {
+		return ""
+	}
+	return collapseSpace(textContent(t))
+}
+
+// extractor accumulates markdown blocks (headings, paragraphs, lists,
+// tables, code fences) in document order. run is a SINGLE buffer shared
+// across the entire walk — not one per container — because "transparent"
+// elements (div/section/span/...) must let adjacent bare text merge across
+// nesting levels (e.g. two sibling <span>s inside a wrapper <div> collapse
+// into one paragraph). It is flushed immediately before any true block-level
+// element and once more at the very end of the walk.
+type extractor struct {
+	blocks []string
+	run    strings.Builder
+	sawH1  bool
+}
+
+// flush closes out the current bare-text run as a paragraph block, if it has
+// any non-whitespace content.
+func (e *extractor) flush() {
+	if text := collapseSpace(e.run.String()); text != "" {
+		e.blocks = append(e.blocks, text)
+	}
+	e.run.Reset()
+}
+
+// isSkipped elements are dropped entirely — no text, no recursion. nav is
+// here (not just button/select/...) because tab bars are label noise: their
+// button text ("Overview", "Table", ...) has no informational value once the
+// page's own headings already say the same thing.
+func isSkipped(a atom.Atom) bool {
+	switch a {
+	case atom.Script, atom.Style, atom.Noscript, atom.Template, atom.Svg,
+		atom.Iframe, atom.Canvas, atom.Button, atom.Select, atom.Input,
+		atom.Textarea, atom.Nav:
+		return true
+	}
+	return false
+}
+
+// walkBlock processes n's children in block context: text nodes and
+// transparent containers feed the shared run buffer, true block-level
+// elements flush the buffer and emit their own block.
+func (e *extractor) walkBlock(n *html.Node) {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		switch c.Type {
+		case html.TextNode:
+			e.run.WriteString(c.Data)
+
+		case html.ElementNode:
+			if isSkipped(c.DataAtom) {
+				continue
+			}
+
+			// data-ox-section is the authoring contract for pages whose
+			// tabs/views are divs rather than headings (see render_tabbed
+			// fixtures) — it always marks a section boundary regardless of
+			// the element's tag.
+			if name := attrVal(c, "data-ox-section"); name != "" {
+				e.flush()
+				e.emitSectionMarker(c, name)
+				e.walkBlock(c)
+				continue
+			}
+
+			switch c.DataAtom {
+			case atom.H1, atom.H2, atom.H3, atom.H4, atom.H5, atom.H6:
+				e.flush()
+				e.emitHeading(c)
+			case atom.P:
+				e.flush()
+				e.emitParagraph(c)
+			case atom.Ul, atom.Ol:
+				e.flush()
+				e.emitList(c)
+			case atom.Table:
+				e.flush()
+				e.emitTable(c)
+			case atom.Pre:
+				e.flush()
+				e.emitPre(c)
+			case atom.Blockquote:
+				e.flush()
+				e.emitBlockquote(c)
+			case atom.Hr:
+				e.flush()
+				e.blocks = append(e.blocks, "---")
+			default:
+				// div/section/span/article/header/footer/aside/anything else:
+				// transparent. Recurse in the SAME block scope (no new run
+				// buffer, no flush) so bare text flows into the current block.
+				e.walkBlock(c)
+			}
+		}
+	}
+}
+
+// emitSectionMarker emits "## <name>" for a data-ox-section boundary, unless
+// the section's own first h1-h3 already carries identical text — avoids
+// double-emitting the heading when authors also (redundantly) put a matching
+// <h2> inside the marked div.
+func (e *extractor) emitSectionMarker(n *html.Node, name string) {
+	label := collapseSpace(name)
+	if label == "" {
+		return
+	}
+	if heading, ok := firstHeadingText(n); ok && heading == label {
+		return
+	}
+	e.blocks = append(e.blocks, "## "+label)
+}
+
+// firstHeadingText returns the flattened text of the first h1/h2/h3
+// descendant of n in document order, skipping subtrees that are themselves
+// skipped (script/nav/...).
+func firstHeadingText(n *html.Node) (string, bool) {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type != html.ElementNode {
+			continue
+		}
+		switch c.DataAtom {
+		case atom.H1, atom.H2, atom.H3:
+			return collapseSpace(flattenInline(c)), true
+		}
+		if isSkipped(c.DataAtom) {
+			continue
+		}
+		if text, ok := firstHeadingText(c); ok {
+			return text, true
+		}
+	}
+	return "", false
+}
+
+func (e *extractor) emitHeading(n *html.Node) {
+	level, ok := headingLevel[n.DataAtom]
+	if !ok {
+		return
+	}
+	if n.DataAtom == atom.H1 {
+		// Recorded even if the h1 turns out to be empty-text: an h1 ELEMENT
+		// being present is what suppresses the <title> fallback, regardless
+		// of whether it renders any visible content.
+		e.sawH1 = true
+	}
+	text := collapseSpace(flattenInline(n))
+	if text == "" {
+		return
+	}
+	e.blocks = append(e.blocks, strings.Repeat("#", level)+" "+text)
+}
+
+func (e *extractor) emitParagraph(n *html.Node) {
+	if text := collapseSpace(flattenInline(n)); text != "" {
+		e.blocks = append(e.blocks, text)
+	}
+}
+
+func (e *extractor) emitList(n *html.Node) {
+	if lines := renderListLines(n, 0); len(lines) > 0 {
+		e.blocks = append(e.blocks, strings.Join(lines, "\n"))
+	}
+}
+
+// renderListLines renders one ul/ol's <li> children, indenting nested
+// ul/ol two spaces per depth. A li's "own text" excludes any nested list
+// (flattenInline already skips ul/ol) so the item line doesn't duplicate its
+// children's text.
+func renderListLines(n *html.Node, depth int) []string {
+	ordered := n.DataAtom == atom.Ol
+	indent := strings.Repeat("  ", depth)
+	var lines []string
+	idx := 0
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type != html.ElementNode || c.DataAtom != atom.Li {
+			continue
+		}
+		idx++
+		marker := "- "
+		if ordered {
+			marker = strconv.Itoa(idx) + ". "
+		}
+		lines = append(lines, indent+marker+collapseSpace(flattenInline(c)))
+
+		for cc := c.FirstChild; cc != nil; cc = cc.NextSibling {
+			if cc.Type == html.ElementNode && (cc.DataAtom == atom.Ul || cc.DataAtom == atom.Ol) {
+				lines = append(lines, renderListLines(cc, depth+1)...)
+			}
+		}
+	}
+	return lines
+}
+
+// emitTable renders a GFM table. The header row is the FIRST <tr> found
+// anywhere in the table (thead or not), using th or td cells — some authored
+// tables sloppily mark header cells as td. Every subsequent <tr> is a body
+// row, on the same th-or-td acceptance.
+func (e *extractor) emitTable(n *html.Node) {
+	rows := collectTableRows(n)
+	if len(rows) == 0 {
+		return
+	}
+	header := tableCells(rows[0])
+	if len(header) == 0 {
+		return
+	}
+	lines := []string{tableRow(header), tableRow(dashRow(len(header)))}
+	for _, r := range rows[1:] {
+		lines = append(lines, tableRow(tableCells(r)))
+	}
+	e.blocks = append(e.blocks, strings.Join(lines, "\n"))
+}
+
+// collectTableRows gathers <tr> descendants in document order, not
+// descending into a nested table's own rows.
+func collectTableRows(n *html.Node) []*html.Node {
+	var rows []*html.Node
+	var walk func(*html.Node)
+	walk = func(m *html.Node) {
+		for c := m.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type != html.ElementNode {
+				continue
+			}
+			switch c.DataAtom {
+			case atom.Tr:
+				rows = append(rows, c)
+			case atom.Table:
+				// a nested table's rows belong to it, not this one
+			default:
+				walk(c)
+			}
+		}
+	}
+	walk(n)
+	return rows
+}
+
+// tableCells flattens a row's th/td cells, escaping "|" so it can't be
+// mistaken for a column delimiter. Newline collapsing is a side effect of
+// collapseSpace (all whitespace, including embedded newlines, becomes one
+// space).
+func tableCells(tr *html.Node) []string {
+	var cells []string
+	for c := tr.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type != html.ElementNode {
+			continue
+		}
+		if c.DataAtom == atom.Th || c.DataAtom == atom.Td {
+			text := collapseSpace(flattenInline(c))
+			cells = append(cells, strings.ReplaceAll(text, "|", "\\|"))
+		}
+	}
+	return cells
+}
+
+func tableRow(cells []string) string {
+	return "| " + strings.Join(cells, " | ") + " |"
+}
+
+func dashRow(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = "---"
+	}
+	return out
+}
+
+// emitPre fences the pre's raw text content verbatim — no whitespace
+// collapsing — trimming only trailing newlines so the closing fence doesn't
+// float behind a stray blank line.
+func (e *extractor) emitPre(n *html.Node) {
+	code := strings.TrimRight(textContent(n), "\n")
+	e.blocks = append(e.blocks, "```\n"+code+"\n```")
+}
+
+// emitBlockquote runs an isolated sub-extractor over the blockquote's
+// content (reusing the full block machinery — nested lists/tables/etc. all
+// work for free) and prefixes every resulting line with "> ".
+func (e *extractor) emitBlockquote(n *html.Node) {
+	inner := &extractor{}
+	inner.walkBlock(n)
+	inner.flush()
+	if inner.sawH1 {
+		e.sawH1 = true
+	}
+	for _, block := range inner.blocks {
+		lines := strings.Split(block, "\n")
+		for i, line := range lines {
+			lines[i] = "> " + line
+		}
+		e.blocks = append(e.blocks, strings.Join(lines, "\n"))
+	}
+}
+
+// flattenInline flattens n's children into inline markdown text: <code>,
+// <strong>/<b>, <em>/<i>, <a href>, and <br> get their markdown form;
+// everything else (span, nested div, ...) contributes bare text. Block-level
+// ul/ol content never leaks into a heading/paragraph/cell/li's flattened
+// text — lists render as their own block via emitList.
+func flattenInline(n *html.Node) string {
+	var b strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		switch c.Type {
+		case html.TextNode:
+			b.WriteString(c.Data)
+
+		case html.ElementNode:
+			if isSkipped(c.DataAtom) {
+				continue
+			}
+			switch c.DataAtom {
+			case atom.Ul, atom.Ol:
+				continue
+			case atom.Br:
+				b.WriteString(" ")
+			case atom.Code:
+				b.WriteString(inlineWrap("`", flattenInline(c), "`"))
+			case atom.Strong, atom.B:
+				b.WriteString(inlineWrap("**", flattenInline(c), "**"))
+			case atom.Em, atom.I:
+				b.WriteString(inlineWrap("*", flattenInline(c), "*"))
+			case atom.A:
+				href := attrVal(c, "href")
+				text := collapseSpace(flattenInline(c))
+				if text == "" {
+					continue
+				}
+				if href != "" && !strings.HasPrefix(href, "#") && !strings.HasPrefix(strings.ToLower(href), "javascript:") {
+					b.WriteString("[" + text + "](" + href + ")")
+				} else {
+					b.WriteString(text)
+				}
+			default:
+				b.WriteString(flattenInline(c))
+			}
+		}
+	}
+	return b.String()
+}
+
+// inlineWrap trims/collapses s and wraps it in pre/suf, or returns "" for
+// whitespace-only content — an empty **strong** or `code` span would just be
+// visual noise in the derived markdown.
+func inlineWrap(pre, s, suf string) string {
+	t := collapseSpace(s)
+	if t == "" {
+		return ""
+	}
+	return pre + t + suf
+}
+
+// collapseSpace collapses any run of whitespace (including newlines) to a
+// single space and trims the ends — the single whitespace rule applied
+// everywhere except inside a <pre>.
+func collapseSpace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/plan/extract_test.go
+++ b/internal/plan/extract_test.go
@@ -1,0 +1,205 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+)
+
+// tabbedFixtureHTML models a real hand-built tabbed plan page: a <head> with
+// <title> + a <style> that must never leak, an <h1>, a <nav> tab bar whose
+// button labels must never leak, and one <section class="view"> per tab
+// exercising a table (with a "|" in a cell), a list, a fenced <pre>, and an
+// interactive-only <div><span> pair. A trailing <script> must never leak.
+const tabbedFixtureHTML = `<!DOCTYPE html>
+<html>
+<head>
+<title>Turn vs Event</title>
+<style>body{color:red}</style>
+</head>
+<body>
+<header><h1>Turn vs Event: A Field Guide</h1></header>
+<nav>
+<button>TabOne</button>
+<button>TabTwo</button>
+<button>TabThree</button>
+<button>TabFour</button>
+<button>TabFive</button>
+</nav>
+<section class="view" id="overview">
+<h2>Overview</h2>
+<p>Some context about the difference.</p>
+</section>
+<section class="view" id="table">
+<h2>Comparison Table</h2>
+<table>
+<tr><th>Concept</th><th>Scope</th></tr>
+<tr><td>Turn</td><td>Single message | reply</td></tr>
+<tr><td>Event</td><td>Anchor span</td></tr>
+</table>
+</section>
+<section class="view" id="list">
+<h2>Key Properties</h2>
+<ul>
+<li>Deterministic ordering</li>
+<li>Stable identity</li>
+</ul>
+</section>
+<section class="view" id="code">
+<h2>Example</h2>
+<pre>  step one
+    step two</pre>
+</section>
+<section class="view" id="interactive">
+<h2>Interactive Demo</h2>
+<div class="code"><span>raw</span> <span>text</span></div>
+</section>
+<script>const MAP={a:1,b:2};</script>
+</body>
+</html>`
+
+// TestExtractMarkdown_TabbedPage pins the full tabbed-page shape: h1 wins
+// over <title>, every h2 survives, a table/list/code-block/interactive-div
+// each degrade correctly, and script/style/nav content never leaks. Failure
+// prevented: a plan-of-record HTML page whose derived markdown either loses
+// searchable content or leaks chrome noise (tab labels, CSS, JS) into the
+// grep/search-facing projection.
+func TestExtractMarkdown_TabbedPage(t *testing.T) {
+	md := ExtractMarkdown([]byte(tabbedFixtureHTML))
+
+	if !strings.HasPrefix(md, "# Turn vs Event: A Field Guide") {
+		t.Fatalf("expected md to start with the h1 (title dropped), got prefix %q", firstLine(md))
+	}
+
+	mustContain := []string{
+		"## Overview",
+		"## Comparison Table",
+		"## Key Properties",
+		"## Example",
+		"## Interactive Demo",
+		"| Concept | Scope |",
+		"| --- | --- |",
+		`Single message \| reply`, // "|" in cell text escaped
+		"- Deterministic ordering",
+		"- Stable identity",
+		"```\n  step one\n    step two\n```", // verbatim pre content
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(md, want) {
+			t.Errorf("ExtractMarkdown output missing %q\n--- output ---\n%s", want, md)
+		}
+	}
+
+	// The interactive-only <div><span> pair must degrade to its own single
+	// paragraph, not two, and not bleed into a neighboring block.
+	if !hasBlock(md, "raw text") {
+		t.Errorf("expected %q to appear as its own paragraph\n--- output ---\n%s", "raw text", md)
+	}
+
+	mustNotContain := []string{
+		"const MAP",                                          // <script> body
+		"color:red",                                          // <style> body
+		"TabOne", "TabTwo", "TabThree", "TabFour", "TabFive", // nav button labels
+	}
+	for _, bad := range mustNotContain {
+		if strings.Contains(md, bad) {
+			t.Errorf("ExtractMarkdown output leaked skipped content %q\n--- output ---\n%s", bad, md)
+		}
+	}
+}
+
+// TestExtractMarkdown_DataOxSection covers the data-ox-section authoring
+// contract for pages whose tabs/views are plain divs, not headings. Failure
+// prevented: a heading-less view rendering as unlabelled prose with no
+// searchable section boundary, or a view whose div AND its own <h2> both
+// producing the same heading twice.
+func TestExtractMarkdown_DataOxSection(t *testing.T) {
+	const html = `<html><body>
+<div data-ox-section="Verdict"><p>The verdict is clear.</p></div>
+<div data-ox-section="Anatomy"><h2>Anatomy</h2><p>Breakdown follows.</p></div>
+</body></html>`
+
+	md := ExtractMarkdown([]byte(html))
+
+	if !strings.Contains(md, "## Verdict") {
+		t.Errorf("expected synthesized %q marker for a heading-less section\n--- output ---\n%s", "## Verdict", md)
+	}
+	if got := strings.Count(md, "## Anatomy"); got != 1 {
+		t.Errorf("expected exactly one %q (marker suppressed in favor of the section's own h2), got %d\n--- output ---\n%s", "## Anatomy", got, md)
+	}
+}
+
+// TestExtractMarkdown_NoH1FallsBackToTitle covers the fallback path: when the
+// body never produces an h1, <title> becomes the first line so a plan
+// missing a body heading still has a searchable top-level label. Failure
+// prevented: a plan with no h1 losing its identifying title entirely from the
+// derived markdown.
+func TestExtractMarkdown_NoH1FallsBackToTitle(t *testing.T) {
+	const html = `<html><head><title>Fallback Title</title></head><body><p>First paragraph.</p><p>Second paragraph.</p></body></html>`
+
+	md := ExtractMarkdown([]byte(html))
+	if !strings.HasPrefix(md, "# Fallback Title") {
+		t.Fatalf("expected md to start with %q, got %q", "# Fallback Title", firstLine(md))
+	}
+}
+
+// TestExtractMarkdown_MalformedInputNeverPanics is the hard contract:
+// ExtractMarkdown must never error or panic, only degrade. Failure
+// prevented: a malformed authored page (or a nil/empty read) crashing
+// whatever background job is deriving plan.md from plan.html.
+func TestExtractMarkdown_MalformedInputNeverPanics(t *testing.T) {
+	tests := []struct {
+		name         string
+		in           []byte
+		wantContains string
+	}{
+		{"nil input", nil, ""},
+		{"unclosed tag", []byte("<div>unclosed"), "unclosed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("ExtractMarkdown(%q) panicked: %v", tt.in, r)
+				}
+			}()
+			got := ExtractMarkdown(tt.in)
+			if tt.wantContains != "" && !strings.Contains(got, tt.wantContains) {
+				t.Errorf("ExtractMarkdown(%q) = %q, want contains %q", tt.in, got, tt.wantContains)
+			}
+		})
+	}
+}
+
+// TestExtractMarkdown_Deterministic pins document-order-only output: no map
+// iteration or other nondeterminism sneaking into the walk. Failure
+// prevented: a flaky derived plan.md that rewrites itself differently on
+// every save/regenerate cycle, producing noisy diffs and unstable search.
+func TestExtractMarkdown_Deterministic(t *testing.T) {
+	t.Parallel()
+	a := ExtractMarkdown([]byte(tabbedFixtureHTML))
+	b := ExtractMarkdown([]byte(tabbedFixtureHTML))
+	if a != b {
+		t.Fatalf("ExtractMarkdown is non-deterministic:\n--- run 1 ---\n%s\n--- run 2 ---\n%s", a, b)
+	}
+}
+
+// hasBlock reports whether md contains a block (a "\n\n"-delimited unit)
+// whose trimmed content equals want exactly — stronger than strings.Contains
+// alone, which would also pass if want only ever showed up as a substring of
+// some larger, incorrectly-merged block.
+func hasBlock(md, want string) bool {
+	for _, block := range strings.Split(strings.TrimSuffix(md, "\n"), "\n\n") {
+		if block == want {
+			return true
+		}
+	}
+	return false
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/plan/extract_test.go
+++ b/internal/plan/extract_test.go
@@ -184,6 +184,33 @@ func TestExtractMarkdown_Deterministic(t *testing.T) {
 	}
 }
 
+// TestExtractMarkdown_DropsUnsafeLinkSchemes pins the markdown projection's
+// link safety floor: schemes browsers can execute as active content degrade to
+// plain text instead of becoming live anchors when plan.md is rendered later.
+func TestExtractMarkdown_DropsUnsafeLinkSchemes(t *testing.T) {
+	const html = `<html><body><p>
+		<a href=" javascript:alert(1)">js</a>
+		<a href="DATA:text/html,evil">data</a>
+		<a href="vbscript:evil">vb</a>
+		<a href="https://example.com/ok">ok</a>
+	</p></body></html>`
+
+	md := ExtractMarkdown([]byte(html))
+	for _, bad := range []string{"javascript:", "DATA:", "vbscript:"} {
+		if strings.Contains(md, bad) {
+			t.Fatalf("unsafe href survived into markdown: %q\n--- output ---\n%s", bad, md)
+		}
+	}
+	if !strings.Contains(md, "[ok](https://example.com/ok)") {
+		t.Fatalf("safe http link missing from markdown\n--- output ---\n%s", md)
+	}
+	for _, want := range []string{"js", "data", "vb"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("rejected link text %q should remain as plain text\n--- output ---\n%s", want, md)
+		}
+	}
+}
+
 // hasBlock reports whether md contains a block (a "\n\n"-delimited unit)
 // whose trimmed content equals want exactly — stronger than strings.Contains
 // alone, which would also pass if want only ever showed up as a substring of

--- a/internal/plan/html_primary_test.go
+++ b/internal/plan/html_primary_test.go
@@ -1,0 +1,111 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// authoredFixture is a miniature authored HTML plan in the comparison-page
+// register: title, tabbed sections with h2s, a table, a script (interactive).
+const authoredFixture = `<!doctype html>
+<html><head><title>Turn model rollout</title>
+<meta name="ox-plan-slug" content="turn model rollout">
+</head><body>
+<header><h1>Turn model rollout</h1><nav><button>00 Anatomy</button></nav></header>
+<section class="view" data-ox-section="Anatomy"><h2>Anatomy</h2><p>One atom table, never two.</p>
+<table><tr><th>Field</th><th>Ours</th></tr><tr><td>id</td><td>source_ref</td></tr></table></section>
+<section class="view"><h2>Sequencing</h2><ul><li>provenance first</li></ul></section>
+<script>const MAP={secret:1};</script>
+</body></html>`
+
+// TestSave_HTMLPrimaryRoundTrip is the html-primary save round-trip: the
+// authored page is stored canonical (meta primary=html, slug from the
+// authoring-contract meta tag), plan.md is the DERIVED markdown that Load —
+// and therefore `ox plan view` / search — reads, and a re-save keeps Primary.
+func TestSave_HTMLPrimaryRoundTrip(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	authored := []byte(authoredFixture)
+	derived := ExtractMarkdown(authored)
+	in := Parse(derived)
+	meta := Meta{
+		Topic:     "Turn model rollout",
+		Slug:      AuthoredSlug(authored),
+		Primary:   PrimaryHTML,
+		CreatedAt: time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC),
+	}
+
+	dir, err := Save("/fake/git/root", in, Result{}, authored, meta)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if base := filepath.Base(dir); base != "2026-07-25-turn-model-rollout" {
+		t.Errorf("dir = %q — slug should come from the ox-plan-slug meta tag", base)
+	}
+
+	got, merr := LoadMeta(dir)
+	if merr != nil {
+		t.Fatalf("LoadMeta: %v", merr)
+	}
+	if got.Primary != PrimaryHTML {
+		t.Errorf("meta.Primary = %q, want %q", got.Primary, PrimaryHTML)
+	}
+
+	// the terminal/search surface reads the DERIVED markdown
+	md, _, _, lerr := Load("/fake/git/root", "turn-model-rollout")
+	if lerr != nil {
+		t.Fatalf("Load: %v", lerr)
+	}
+	for _, want := range []string{"# Turn model rollout", "## Anatomy", "## Sequencing", "- provenance first", "| Field | Ours |"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("derived plan.md missing %q", want)
+		}
+	}
+	if strings.Contains(md, "const MAP") {
+		t.Error("script content leaked into the derived markdown")
+	}
+
+	// the canonical artifact is the authored page (plus the sanctioned <head>
+	// identity stamp), not a generated render
+	htmlBytes, rerr := os.ReadFile(filepath.Join(dir, "plan.html"))
+	if rerr != nil {
+		t.Fatalf("read stored plan.html: %v", rerr)
+	}
+	if !strings.Contains(string(htmlBytes), "const MAP={secret:1};") {
+		t.Error("authored interactivity lost from the stored canonical page")
+	}
+	if !strings.Contains(string(htmlBytes), `name="sageox:plan"`) {
+		t.Error("stored page missing the self-identifying head stamp")
+	}
+
+	// a markdown-shaped re-save (hook draft) must not demote Primary
+	if _, err := Save("/fake/git/root", in, Result{}, nil, Meta{Topic: "Turn model rollout", Slug: "turn-model-rollout", CreatedAt: meta.CreatedAt}); err != nil {
+		t.Fatalf("re-Save: %v", err)
+	}
+	got2, _ := LoadMeta(dir)
+	if got2.Primary != PrimaryHTML {
+		t.Errorf("re-save demoted Primary to %q", got2.Primary)
+	}
+}
+
+// TestInjectChrome_OnAuthoredFixture ties injection to the authored register:
+// the chrome bundle lands before </body>, the authored markup is untouched,
+// and the review layer + enrichment data ride along.
+func TestInjectChrome_OnAuthoredFixture(t *testing.T) {
+	res := Result{Annotations: []Annotation{{Kind: BadgeDeterministic, Type: BadgeCollision, Why: "teammate editing store.go"}}}
+	out := InjectChrome([]byte(authoredFixture), BuildChromeData(res, RenderOptions{Slug: "turn-model-rollout"}))
+	s := string(out)
+	if !strings.HasPrefix(s, authoredFixture[:strings.Index(authoredFixture, "</body>")]) {
+		t.Error("authored bytes before </body> were modified by injection")
+	}
+	if !strings.Contains(s, ChromeMarkerStart) || !strings.Contains(s, "teammate editing store.go") {
+		t.Error("chrome bundle or enrichment signal missing")
+	}
+	if strings.Index(s, ChromeMarkerEnd) > strings.LastIndex(s, "</body>") {
+		t.Error("chrome bundle not placed before </body>")
+	}
+}

--- a/internal/plan/inject.go
+++ b/internal/plan/inject.go
@@ -1,0 +1,322 @@
+package plan
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// inject.go is the HTML-primary path: a developer hand-authors a rich,
+// self-contained HTML plan (tabs, inspectors, animations — whatever the
+// author's own agent built) and ox injects its enrichment chrome INTO that
+// page rather than wrapping it. RenderHTML/RenderHTMLOpts stay the ox-owned
+// generator for plans authored as markdown; InjectChrome is the seam for a
+// plan authored directly as HTML, where ox contributes only the SageOx
+// enrichment overlay, the footer credit, and the review loop — never the
+// author's markup, layout, or scripting.
+
+//go:embed assets/chrome.css assets/chrome.js
+var chromeAssets embed.FS
+
+// ChromeMarkerStart / ChromeMarkerEnd delimit the injected ox chrome bundle
+// inside an authored HTML plan. Everything between them is ox-owned and
+// replaced wholesale on re-injection; the author's markup is never touched.
+const (
+	ChromeMarkerStart = "<!-- ox-chrome:start -->"
+	ChromeMarkerEnd   = "<!-- ox-chrome:end -->"
+)
+
+// ChromeData is everything the injected bundle needs, pre-projected so the
+// JS stays dumb.
+type ChromeData struct {
+	Slug    string
+	Signals []ChromeSignal  // enrichment chips (deterministic + judgment)
+	Context []ChromeContext // surfaced context items (alignment strip)
+	// ReviewJSON is the merged review-state JSON array ("[]" when none) — the
+	// same shape render.go's buildReviewState produces, so review.js's
+	// #ox-review-state island reads identically on an authored page.
+	ReviewJSON     string
+	ReviewEndpoint string // live review server base URL ("" = static)
+	ReviewToken    string
+	SessionURL     string // /c/ conversation link ("" = omit)
+	FooterCredit   bool   // true when any enrichment exists (earned credit)
+}
+
+// ChromeSignal is one enrichment chip: a deterministic badge (collision /
+// prior-art / expert-routing) or a judgment badge (aligns / conflicts /
+// expert-perspective) the client agent authored from the context bundle.
+type ChromeSignal struct {
+	Type    string `json:"type"` // collision | prior-art | expert-routing | aligns | conflicts | expert-perspective
+	Label   string `json:"label"`
+	Why     string `json:"why"`
+	URL     string `json:"url,omitempty"`
+	Section string `json:"section,omitempty"`
+}
+
+// ChromeContext is one surfaced context item shown in the "Context surfaced"
+// strip — a slimmed-down ContextItem (no Score/Snippet/Author/When; those are
+// ranking/reasoning inputs for the agent, not something a human reader needs).
+type ChromeContext struct {
+	Kind  string `json:"kind"`
+	Title string `json:"title"`
+	Ref   string `json:"ref,omitempty"`
+}
+
+// chromePayload is the wire shape of the #ox-chrome-data island — the JSON
+// snake_case keys are the chrome.js contract, independent of ChromeData's Go
+// field names.
+type chromePayload struct {
+	Slug         string          `json:"slug"`
+	Signals      []ChromeSignal  `json:"signals"`
+	Context      []ChromeContext `json:"context"`
+	Endpoint     string          `json:"endpoint"`
+	Token        string          `json:"token"`
+	SessionURL   string          `json:"session_url"`
+	FooterCredit bool            `json:"footer_credit"`
+}
+
+// chromeSignalLabels maps a badge type to its chip label. Only types present
+// here are ever surfaced as a ChromeSignal — this is what excludes BadgeRigor
+// (a collaboration-rigor stance the panel never shows) without a separate
+// type check.
+var chromeSignalLabels = map[BadgeType]string{
+	BadgeCollision:   "Collision",
+	BadgePriorArt:    "Prior art",
+	BadgeExpertRoute: "Expert",
+	BadgeAligns:      "Aligns",
+	BadgeConflicts:   "Conflicts",
+	BadgeExpertPersp: "Expert view",
+}
+
+// chromeContextCap bounds the "Context surfaced" strip to the highest-scoring
+// items — the alignment strip is a glance-able list, not the full bundle the
+// agent reasoned over.
+const chromeContextCap = 5
+
+// BuildChromeData projects an enrichment Result into ChromeData. Deterministic
+// badge Whys go through humanize() (same provenance-strip floor as the
+// generated render — no SHAs / "12h ago" / workspace counts may leak);
+// HumanWhy overrides when set; a "commit:<sha>" SourceURL is suppressed;
+// prior-art URLs resolve through opts.PriorArtURL when non-nil. Judgment
+// badges (aligns/conflicts/expert-perspective) ARE included here — they're
+// agent-authored, cited claims the human should see. rigor is excluded.
+// Context items are capped at 5 by Score descending (stable tie-break by
+// document order).
+func BuildChromeData(res Result, opts RenderOptions) ChromeData {
+	reviewJSON, _ := buildReviewState(opts.Review)
+	return ChromeData{
+		Slug:           opts.Slug,
+		Signals:        buildChromeSignals(res, opts.PriorArtURL),
+		Context:        buildChromeContext(res.Context),
+		ReviewJSON:     string(reviewJSON),
+		ReviewEndpoint: opts.ReviewEndpoint,
+		ReviewToken:    opts.ReviewToken,
+		SessionURL:     opts.SessionURL,
+		// Mirrors RenderHTMLOpts's FooterCredit: earned only when ox actually
+		// found something to say, not on a greenfield plan with zero signals.
+		FooterCredit: len(res.Annotations) > 0 || len(res.Context) > 0,
+	}
+}
+
+// buildChromeSignals projects every non-rigor annotation into a ChromeSignal.
+// Deterministic badges get the humanize()/HumanWhy/commit-URL treatment
+// render.go's deterministicSignalsWithFiles applies; judgment badges keep
+// their raw SourceURL as the citation link (they carry no agent-only
+// provenance to strip).
+func buildChromeSignals(res Result, priorArtURL func(refKind, ref string) string) []ChromeSignal {
+	var out []ChromeSignal
+	for _, a := range res.Annotations {
+		label, ok := chromeSignalLabels[a.Type]
+		if !ok {
+			continue // rigor, or a future badge type the chrome doesn't know yet
+		}
+		why := humanize(a.Why)
+		if a.HumanWhy != "" {
+			why = a.HumanWhy
+		}
+		sig := ChromeSignal{
+			Type:    string(a.Type),
+			Label:   label,
+			Why:     why,
+			Section: a.Section,
+		}
+		switch {
+		case a.Type == BadgePriorArt && priorArtURL != nil:
+			sig.URL = priorArtURL(a.RefKind, a.SourceURL)
+		case a.Kind == BadgeDeterministic && strings.HasPrefix(a.SourceURL, "commit:"):
+			// agent-only provenance (a raw commit SHA) — never surface to a human.
+		default:
+			sig.URL = a.SourceURL
+		}
+		out = append(out, sig)
+	}
+	return out
+}
+
+// buildChromeContext slims + caps the context bundle for the alignment strip:
+// the top chromeContextCap items by Score descending, ties broken by document
+// order (sort.SliceStable over an index slice preserves it).
+func buildChromeContext(items []ContextItem) []ChromeContext {
+	if len(items) == 0 {
+		return nil
+	}
+	order := make([]int, len(items))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		return items[order[i]].Score > items[order[j]].Score
+	})
+	n := len(order)
+	if n > chromeContextCap {
+		n = chromeContextCap
+	}
+	out := make([]ChromeContext, 0, n)
+	for _, i := range order[:n] {
+		it := items[i]
+		out = append(out, ChromeContext{Kind: it.Kind, Title: it.Title, Ref: it.Ref})
+	}
+	return out
+}
+
+// chromeMarkerRegion matches a complete ox-chrome bundle, including one
+// leading and one trailing newline if present, so repeated injection never
+// accumulates blank lines where the previous bundle was removed.
+var chromeMarkerRegion = regexp.MustCompile(`(?s)\n?` + regexp.QuoteMeta(ChromeMarkerStart) + `.*?` + regexp.QuoteMeta(ChromeMarkerEnd) + `\n?`)
+
+// bodyCloseTag finds </body> case-insensitively — an authored page is not
+// guaranteed to use lowercase HTML.
+var bodyCloseTag = regexp.MustCompile(`(?i)</body>`)
+
+// InjectChrome appends the ox chrome bundle to an authored HTML page,
+// immediately before the last </body> (case-insensitive); a page with no
+// </body> gets it appended at the end. NON-DESTRUCTIVE: the author's bytes
+// are byte-for-byte preserved outside the marker region. IDEMPOTENT: any
+// existing marker region is removed first, so re-injection never doubles.
+func InjectChrome(authored []byte, data ChromeData) []byte {
+	stripped := chromeMarkerRegion.ReplaceAll(authored, nil)
+	bundle := buildChromeBundle(data)
+
+	loc := bodyCloseTag.FindAllIndex(stripped, -1)
+	insertAt := len(stripped)
+	if len(loc) > 0 {
+		insertAt = loc[len(loc)-1][0]
+	}
+
+	out := make([]byte, 0, len(stripped)+len(bundle))
+	out = append(out, stripped[:insertAt]...)
+	out = append(out, bundle...)
+	out = append(out, stripped[insertAt:]...)
+	return out
+}
+
+// buildChromeBundle assembles the marker-delimited island+style+script bundle
+// in the fixed order the API contract specifies: review-state island,
+// chrome-data island, style, boot script, review script. Boot-before-review is
+// load-bearing (chrome.js primes document.body's dataset before review.js's
+// IIFE reads it); the rest is order-independent.
+func buildChromeBundle(data ChromeData) []byte {
+	reviewJSON := data.ReviewJSON
+	if strings.TrimSpace(reviewJSON) == "" {
+		reviewJSON = "[]"
+	}
+	payload := chromePayload{
+		Slug:         data.Slug,
+		Signals:      data.Signals,
+		Context:      data.Context,
+		Endpoint:     data.ReviewEndpoint,
+		Token:        data.ReviewToken,
+		SessionURL:   data.SessionURL,
+		FooterCredit: data.FooterCredit,
+	}
+	if payload.Signals == nil {
+		payload.Signals = []ChromeSignal{}
+	}
+	if payload.Context == nil {
+		payload.Context = []ChromeContext{}
+	}
+	chromeJSON, err := json.Marshal(payload)
+	if err != nil {
+		// payload is plain strings/bools/slices of plain structs; Marshal only
+		// fails on unsupported types (chan/func) or cyclic maps, neither of which
+		// this shape contains — unreachable in practice, but fail closed rather
+		// than panic on an untrusted-shaped Result feeding BuildChromeData.
+		chromeJSON = []byte(`{}`)
+	}
+
+	var b bytes.Buffer
+	b.WriteString("\n")
+	b.WriteString(ChromeMarkerStart)
+	b.WriteString("\n")
+
+	b.WriteString(`<script type="application/json" id="ox-review-state">`)
+	b.WriteString(escapeScriptIsland(reviewJSON))
+	b.WriteString("</script>\n")
+
+	b.WriteString(`<script type="application/json" id="ox-chrome-data">`)
+	b.WriteString(escapeScriptIsland(string(chromeJSON)))
+	b.WriteString("</script>\n")
+
+	b.WriteString(`<style id="ox-chrome-style">`)
+	b.Write(mustChromeAsset("assets/chrome.css"))
+	b.WriteString("</style>\n")
+
+	b.WriteString(`<script id="ox-chrome-boot">`)
+	b.Write(mustChromeAsset("assets/chrome.js"))
+	b.WriteString("</script>\n")
+
+	b.WriteString(`<script id="ox-chrome-review">`)
+	b.Write(mustReviewScript())
+	b.WriteString("</script>\n")
+
+	b.WriteString(ChromeMarkerEnd)
+	b.WriteString("\n")
+	return b.Bytes()
+}
+
+// jsonLessThanEscape is the six-character JSON unicode-escape sequence for
+// "<" (backslash, u, 0, 0, 3, c) — written as a rune slice so gofmt/vet never
+// see (and no future edit can accidentally collapse) a literal backslash-u
+// escape sitting in Go source. encoding/json performs this exact substitution
+// by default (HTMLEscape); escapeScriptIsland applies it to content that
+// didn't go through json.Marshal (the caller-supplied ReviewJSON string).
+var jsonLessThanEscape = string([]rune{'\\', 'u', '0', '0', '3', 'c'})
+
+// escapeScriptIsland keeps JSON content safe to embed inside a <script>
+// island by replacing "<" with jsonLessThanEscape. This is distinct from
+// HTML-entity escaping ("&lt;"): script-tag content is a raw text element
+// (entities are never decoded inside it), so "&lt;" would corrupt the JSON,
+// while the unicode escape round-trips through JSON.parse back to the
+// original "<" and makes a "</script" sequence unrecognizable to the HTML
+// parser — the payload can never terminate the island early.
+func escapeScriptIsland(jsonStr string) string {
+	return strings.ReplaceAll(jsonStr, "<", jsonLessThanEscape)
+}
+
+// mustChromeAsset reads an embedded chrome.css/chrome.js asset. Both are
+// embedded above; a read failure means the embed directive itself is
+// broken (a compile-time condition), not a runtime one — panicking here
+// mirrors template.Must's contract for a compiled-in asset that cannot
+// legitimately be missing.
+func mustChromeAsset(path string) []byte {
+	b, err := chromeAssets.ReadFile(path)
+	if err != nil {
+		panic("plan: embedded chrome asset missing: " + path + ": " + err.Error())
+	}
+	return b
+}
+
+// mustReviewScript reads assets/review.js through the render package's
+// existing renderAssets embed (declared in render.go) — inject.go embeds only
+// its own new assets (chrome.css/chrome.js) and reuses that embed rather than
+// duplicating the directive.
+func mustReviewScript() []byte {
+	b, err := renderAssets.ReadFile("assets/review.js")
+	if err != nil {
+		panic("plan: embedded assets/review.js missing: " + err.Error())
+	}
+	return b
+}

--- a/internal/plan/inject.go
+++ b/internal/plan/inject.go
@@ -206,7 +206,7 @@ func InjectChrome(authored []byte, data ChromeData) []byte {
 		insertAt = loc[len(loc)-1][0]
 	}
 
-	out := make([]byte, 0, len(stripped)+len(bundle))
+	out := make([]byte, 0, len(stripped))
 	out = append(out, stripped[:insertAt]...)
 	out = append(out, bundle...)
 	out = append(out, stripped[insertAt:]...)

--- a/internal/plan/inject_test.go
+++ b/internal/plan/inject_test.go
@@ -255,3 +255,22 @@ func TestInjectChrome_ZeroEnrichmentStillInjectsReview(t *testing.T) {
 		t.Errorf("signals/context should default to empty arrays, not null: %s", chromeIsland)
 	}
 }
+
+// TestChromeJS_EscapesAttributesAndFiltersLinks guards the standalone injected
+// script's XSS boundary. The script builds small HTML strings at runtime, so it
+// must escape attribute delimiters and only emit clickable http(s) links.
+func TestChromeJS_EscapesAttributesAndFiltersLinks(t *testing.T) {
+	js := string(mustChromeAsset("assets/chrome.js"))
+	for _, want := range []string{
+		`.replace(/"/g, '&quot;')`,
+		`.replace(/'/g, '&#39;')`,
+		`function safeURL`,
+		`/^https?:\/\//i.test(raw)`,
+		`var href = s ? safeURL(s.url) : '';`,
+		`var sessionHref = safeURL(data.session_url);`,
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("chrome.js missing safety guard %q", want)
+		}
+	}
+}

--- a/internal/plan/inject_test.go
+++ b/internal/plan/inject_test.go
@@ -1,0 +1,257 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+)
+
+// islandBody returns the text strictly between startTag (an opening-tag
+// delimiter such as `id="foo">`) and the next "</script>". Unlike the
+// package's between() helper (render_test.go), which returns a span that
+// STARTS AT startTag (inclusive — see its use anchoring on a whole opening
+// tag like `<section id="sec-1"`), islandBody strips startTag itself so
+// callers can assert on exact island content.
+func islandBody(s, startTag string) string {
+	return strings.TrimPrefix(between(s, startTag, "</script>"), startTag)
+}
+
+// TestInjectChrome_AppendOnlyPlacement verifies the non-destructive contract:
+// the author's bytes survive byte-for-byte up to the injection point, and the
+// chrome bundle lands immediately before the last </body>. Failure prevented:
+// InjectChrome re-serializing the page through an HTML parser (reordering
+// attributes, closing unclosed tags, mangling author markup) instead of a
+// pure byte-level splice.
+func TestInjectChrome_AppendOnlyPlacement(t *testing.T) {
+	authored := `<html><head><title>T</title></head><body><main id="m"><h2>A</h2></main></body></html>`
+	out := InjectChrome([]byte(authored), ChromeData{Slug: "demo"})
+	s := string(out)
+
+	prefixEnd := strings.Index(authored, "</body>")
+	wantPrefix := authored[:prefixEnd]
+	if !strings.HasSuffix(wantPrefix, "</main>") {
+		t.Fatalf("test setup broken: authored prefix does not end with </main>: %q", wantPrefix)
+	}
+	if !strings.HasPrefix(s, wantPrefix) {
+		t.Fatalf("authored bytes not preserved byte-for-byte up to the injection point\n got prefix:  %q\n want prefix: %q", s[:min(len(s), len(wantPrefix)+40)], wantPrefix)
+	}
+
+	markerAt := strings.Index(s, ChromeMarkerStart)
+	bodyAt := strings.Index(s, "</body>")
+	if markerAt < 0 {
+		t.Fatalf("ChromeMarkerStart not found in output")
+	}
+	if bodyAt < 0 || markerAt >= bodyAt {
+		t.Errorf("chrome bundle not placed before </body>: markerAt=%d bodyAt=%d", markerAt, bodyAt)
+	}
+	if got := strings.Count(s, ChromeMarkerStart); got != 1 {
+		t.Errorf("expected exactly one ChromeMarkerStart, got %d", got)
+	}
+}
+
+// TestInjectChrome_Idempotent verifies re-injection replaces the previous
+// bundle wholesale instead of stacking a second one. Failure prevented: every
+// `ox plan review` re-render (or every re-run of the injector as a plan is
+// iterated on) accumulating one more copy of the chrome bundle — duplicate
+// review bars, duplicate review.js instances double-registering listeners.
+func TestInjectChrome_Idempotent(t *testing.T) {
+	authored := []byte(`<html><body><main><h2>A</h2></main></body></html>`)
+	once := InjectChrome(authored, ChromeData{Slug: "first-slug"})
+	twice := InjectChrome(once, ChromeData{Slug: "second-slug"})
+	s := string(twice)
+
+	if got := strings.Count(s, ChromeMarkerStart); got != 1 {
+		t.Fatalf("re-injection left %d start markers, want exactly 1", got)
+	}
+	if got := strings.Count(s, ChromeMarkerEnd); got != 1 {
+		t.Fatalf("re-injection left %d end markers, want exactly 1", got)
+	}
+	chromeIsland := islandBody(s, `id="ox-chrome-data">`)
+	if !strings.Contains(chromeIsland, `"slug":"second-slug"`) {
+		t.Errorf("re-injected bundle missing the new slug: %s", chromeIsland)
+	}
+	if strings.Contains(chromeIsland, "first-slug") {
+		t.Errorf("re-injected bundle still carries the old slug — old bundle not fully replaced: %s", chromeIsland)
+	}
+}
+
+// TestInjectChrome_NoBodyTagAppendsAtEnd verifies a body-less HTML fragment
+// (no </body> at all) still gets the bundle, appended at the end with the
+// authored bytes untouched. Failure prevented: InjectChrome panicking or
+// silently dropping the bundle on a fragment/partial-document input, which is
+// a realistic authored-plan shape (a snippet meant to be pasted into a larger
+// page, or a page an agent generated without a full <html> skeleton).
+func TestInjectChrome_NoBodyTagAppendsAtEnd(t *testing.T) {
+	authored := []byte(`<div>fragment</div>`)
+	out := InjectChrome(authored, ChromeData{Slug: "frag"})
+	s := string(out)
+
+	if !strings.HasPrefix(s, string(authored)) {
+		t.Fatalf("authored prefix not preserved for a body-less fragment: %q", s[:min(len(s), 60)])
+	}
+	if !strings.Contains(s, ChromeMarkerStart) || !strings.Contains(s, ChromeMarkerEnd) {
+		t.Fatalf("chrome bundle not appended to a body-less fragment")
+	}
+}
+
+// TestInjectChrome_ReviewIslandAndEscaping verifies the review-state and
+// chrome-data islands carry their content, and that a malicious note field
+// containing a literal "</script>" cannot terminate the #ox-review-state
+// island early. Failure prevented: a reviewer's own note text — free-form,
+// attacker-controlled if the review server is ever exposed beyond
+// localhost — breaking out of the JSON island and injecting a live <script>
+// into every teammate's authored plan page.
+func TestInjectChrome_ReviewIslandAndEscaping(t *testing.T) {
+	malicious := `[{"anchor":"h1234","state":"open","note":"</script><script>alert(1)</script>"}]`
+	data := ChromeData{
+		Slug:           "demo",
+		ReviewJSON:     malicious,
+		ReviewEndpoint: "http://127.0.0.1:54321",
+		ReviewToken:    "tok-abc",
+	}
+	out := InjectChrome([]byte(`<html><body></body></html>`), data)
+	s := string(out)
+
+	reviewIsland := islandBody(s, `id="ox-review-state">`)
+	if !strings.Contains(reviewIsland, `"anchor":"h1234"`) || !strings.Contains(reviewIsland, `"state":"open"`) {
+		t.Fatalf("review-state island missing expected content: %q", reviewIsland)
+	}
+	if strings.Contains(reviewIsland, "</script") {
+		t.Errorf("review-state island contains an unescaped </script — early island termination: %q", reviewIsland)
+	}
+	// the whole document must still parse as exactly the 5 ox-owned script/style
+	// tags plus zero attacker-injected ones: an early-terminated island would
+	// leave a stray "<script>alert(1)</script>" as its own top-level element.
+	if strings.Contains(s, "<script>alert(1)</script>") {
+		t.Errorf("attacker script escaped the review-state island and landed as live markup")
+	}
+
+	chromeIsland := islandBody(s, `id="ox-chrome-data">`)
+	if !strings.Contains(chromeIsland, `"endpoint":"http://127.0.0.1:54321"`) {
+		t.Errorf("chrome-data island missing the review endpoint: %q", chromeIsland)
+	}
+	if !strings.Contains(chromeIsland, `"token":"tok-abc"`) {
+		t.Errorf("chrome-data island missing the review token: %q", chromeIsland)
+	}
+}
+
+// TestBuildChromeData_SignalsAndContext verifies the enrichment-Result
+// projection: deterministic Why noise is stripped, a "commit:" SourceURL never
+// surfaces as a link, judgment badges (aligns) ARE surfaced with their citing
+// URL, rigor is excluded, and Context is capped at 5 ordered by Score
+// descending. Failure prevented: agent-only provenance (commit SHAs, raw
+// "N commits" counts) leaking into the human-facing overlay, or the panel
+// silently dropping the cited judgment badges the client agent authored.
+func TestBuildChromeData_SignalsAndContext(t *testing.T) {
+	res := Result{
+		Annotations: []Annotation{
+			{
+				Kind:      BadgeDeterministic,
+				Type:      BadgeCollision,
+				Why:       "teammate editing foo.go (3 commits, last touched Jan 2026)",
+				SourceURL: "commit:abc123",
+			},
+			{
+				Kind:      BadgeJudgment,
+				Type:      BadgeAligns,
+				Why:       "matches ADR-016",
+				SourceURL: "docs/adr/016.md",
+			},
+			{
+				Kind: BadgeJudgment,
+				Type: BadgeRigor,
+				Why:  "thoughtful human<->agent back-and-forth", // must NOT surface
+			},
+		},
+		Context: []ContextItem{
+			{Kind: "adr", Title: "one", Score: 0.90},
+			{Kind: "adr", Title: "two", Score: 0.95},
+			{Kind: "adr", Title: "three", Score: 0.10},
+			{Kind: "adr", Title: "four", Score: 0.50},
+			{Kind: "adr", Title: "five", Score: 0.70},
+			{Kind: "adr", Title: "six", Score: 0.60},
+			{Kind: "adr", Title: "seven", Score: 0.80},
+		},
+	}
+
+	data := BuildChromeData(res, RenderOptions{})
+
+	if len(data.Signals) != 2 {
+		t.Fatalf("want 2 signals (rigor excluded), got %d: %+v", len(data.Signals), data.Signals)
+	}
+	var collision, aligns *ChromeSignal
+	for i := range data.Signals {
+		switch data.Signals[i].Type {
+		case string(BadgeCollision):
+			collision = &data.Signals[i]
+		case string(BadgeAligns):
+			aligns = &data.Signals[i]
+		}
+	}
+	if collision == nil {
+		t.Fatal("collision signal missing")
+	}
+	if strings.Contains(collision.Why, "commits") || strings.Contains(collision.Why, "Jan 2026") {
+		t.Errorf("collision Why not stripped of the provenance parenthetical: %q", collision.Why)
+	}
+	if collision.URL != "" {
+		t.Errorf("commit: SourceURL leaked as a signal URL: %q", collision.URL)
+	}
+	if aligns == nil {
+		t.Fatal("aligns (judgment) signal missing — judgment badges must surface")
+	}
+	if aligns.Label != "Aligns" {
+		t.Errorf("aligns label = %q, want %q", aligns.Label, "Aligns")
+	}
+	if aligns.Why != "matches ADR-016" {
+		t.Errorf("aligns why = %q, want unmodified %q", aligns.Why, "matches ADR-016")
+	}
+	for _, sig := range data.Signals {
+		if sig.Type == string(BadgeRigor) {
+			t.Errorf("rigor badge leaked into chrome signals: %+v", sig)
+		}
+	}
+
+	if len(data.Context) != 5 {
+		t.Fatalf("context not capped at 5, got %d: %+v", len(data.Context), data.Context)
+	}
+	wantOrder := []string{"two", "one", "seven", "five", "six"} // scores 0.95,0.90,0.80,0.70,0.60 desc
+	for i, want := range wantOrder {
+		if data.Context[i].Title != want {
+			t.Errorf("context[%d].Title = %q, want %q (full: %+v)", i, data.Context[i].Title, want, data.Context)
+		}
+	}
+}
+
+// TestInjectChrome_ZeroEnrichmentStillInjectsReview verifies the review loop
+// works on a plan with no enrichment at all — the two layers are independent.
+// Failure prevented: BuildChromeData/InjectChrome conflating "nothing to show
+// in the overlay" with "skip the review layer too," which would silently
+// disable review on every greenfield plan (the majority case: most plans
+// carry no collision/prior-art/expert signal).
+func TestInjectChrome_ZeroEnrichmentStillInjectsReview(t *testing.T) {
+	data := ChromeData{Slug: "greenfield"} // no signals, no context, FooterCredit false
+	out := InjectChrome([]byte(`<html><body></body></html>`), data)
+	s := string(out)
+
+	reviewIsland := islandBody(s, `id="ox-review-state">`)
+	if strings.TrimSpace(reviewIsland) != "[]" {
+		t.Errorf("review-state island should default to an empty array, got %q", reviewIsland)
+	}
+	if !strings.Contains(s, `id="ox-chrome-review">`) {
+		t.Fatalf("review.js not embedded on an un-enriched plan")
+	}
+	reviewScript := islandBody(s, `id="ox-chrome-review">`)
+	if !strings.Contains(reviewScript, "OX_REVIEW_SELECTOR") {
+		t.Errorf("embedded review script missing the authored-page SELECTOR override")
+	}
+	if !strings.Contains(s, `id="ox-chrome-boot">`) {
+		t.Errorf("chrome.js boot script not embedded on an un-enriched plan")
+	}
+	chromeIsland := islandBody(s, `id="ox-chrome-data">`)
+	if !strings.Contains(chromeIsland, `"footer_credit":false`) {
+		t.Errorf("footer_credit should be false with zero enrichment: %s", chromeIsland)
+	}
+	if !strings.Contains(chromeIsland, `"signals":[]`) || !strings.Contains(chromeIsland, `"context":[]`) {
+		t.Errorf("signals/context should default to empty arrays, not null: %s", chromeIsland)
+	}
+}

--- a/internal/plan/input.go
+++ b/internal/plan/input.go
@@ -185,6 +185,38 @@ func discoverActivePlanFile(dir string) string {
 	return newest
 }
 
+// PrimaryHTML is the Meta.Primary value for a plan whose authored HTML page is
+// the plan of record (markdown derived; see store.go Meta.Primary).
+const PrimaryHTML = "html"
+
+// LooksLikeHTML reports whether a resolved plan source is an authored HTML
+// document rather than markdown — the switch that routes --file plan.html into
+// the HTML-primary pipeline (extract → enrich → inject) instead of the
+// markdown template. Sniffs the document head only: a markdown plan that
+// merely EMBEDS html (an ```html-interactive fence, an inline <div>) never
+// STARTS with a doctype/<html> tag, so it is not misrouted.
+func LooksLikeHTML(raw string) bool {
+	head := strings.ToLower(strings.TrimSpace(raw))
+	if len(head) > 256 {
+		head = head[:256]
+	}
+	return strings.HasPrefix(head, "<!doctype html") || strings.HasPrefix(head, "<html")
+}
+
+// oxSlugMetaRe matches the authoring contract's explicit slug override,
+// <meta name="ox-plan-slug" content="…"> (docs/specs/plan-authoring-html.md).
+var oxSlugMetaRe = regexp.MustCompile(`(?i)<meta\s+name=["']ox-plan-slug["']\s+content=["']([^"']+)["']`)
+
+// AuthoredSlug returns the slug an authored HTML plan declares via the
+// optional <meta name="ox-plan-slug"> tag, slugified, or "" when the page
+// doesn't carry one (the title-derived slug is used instead).
+func AuthoredSlug(htmlBytes []byte) string {
+	if m := oxSlugMetaRe.FindSubmatch(htmlBytes); m != nil {
+		return Slugify(string(m[1]))
+	}
+	return ""
+}
+
 // Parse splits markdown into Sections on "## " H2 headings and extracts the file
 // references cited in each section. Content before the first H2 becomes a
 // preamble Section with an empty Heading (only emitted when it has content).

--- a/internal/plan/render.go
+++ b/internal/plan/render.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"log/slog"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -153,6 +154,25 @@ type reviewSummary struct {
 	HasReview bool
 }
 
+// statChip is one hero stat (value + label), emitted from plan structure so
+// the first 30 seconds carry numbers, not prose. Class picks the accent.
+type statChip struct {
+	Value string
+	Label string
+	Class string // neutral | copper | amber | red | teal
+	Href  string // scroll-jump target ("" = inert)
+}
+
+// renderContext is one surfaced context-bundle item shown in the enrichment
+// panel's alignment strip. Retrieved context used to reach the page ONLY when
+// the prose happened to name it (inline markers); the strip closes that
+// plumbing gap — retrieved ADRs/sessions/decisions are visible enrichment
+// even when no marker anchors.
+type renderContext struct {
+	Kind  string
+	Title string
+}
+
 type renderData struct {
 	Title string
 	Slug  string
@@ -175,7 +195,9 @@ type renderData struct {
 	HasSignals     bool
 	SignalCount    int
 	Plural         string
-	Signals        []renderSignal // unanchored signals (no matching section)
+	Signals        []renderSignal  // unanchored signals (no matching section)
+	ContextItems   []renderContext // surfaced context bundle (alignment strip)
+	Stats          []statChip      // hero stat chips (structure-derived numbers)
 	FooterCredit   bool
 	SessionURL     string // /c/ conversation link of the producing recording ("" = omit)
 	// Artifact toggles the CSP-safe variant: the template drops the Google-Fonts
@@ -290,6 +312,9 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 		}
 		var secHTML string
 		secHTML, markers = injectMarkers(string(body), markers)
+		// structure-driven auto-visualization: gated-track tables gain a
+		// swimlane, comparison tables become click-to-inspect (autoviz.go).
+		secHTML = autoVisualize(secHTML, s.Heading)
 		num++
 		id := fmt.Sprintf("sec-%d", num)
 		data.TOC = append(data.TOC, tocEntry{ID: id, Num: fmt.Sprintf("%02d", num), Heading: s.Heading})
@@ -308,11 +333,38 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 	// entries is chrome without information.
 	data.Tabbed = len(data.Sections) > 3
 
-	// Anchor each deterministic signal to the section(s) whose files it concerns;
-	// signals that match no section stay in the global enrichment panel. This is
-	// the data join that replaces a single prose blob with section-anchored
+	// TL;DR hero, ALWAYS: a page must open on a plain-language lede, never on
+	// status blocks or insider jargon. When the plan carries no explicit TL;DR
+	// marker, the first plain paragraph (preamble first, else the first
+	// section) is LIFTED into the hero — moved, not copied, so it never reads
+	// twice.
+	if strings.TrimSpace(string(data.TLDR)) == "" {
+		if para, rest, ok := liftLede(string(data.Preamble)); ok {
+			data.TLDR = template.HTML("<p>" + para + "</p>") //nolint:gosec // first-party rendered fragment
+			data.Preamble = template.HTML(rest)              //nolint:gosec // first-party rendered fragment
+		} else if len(data.Sections) > 0 {
+			if para, rest, ok := liftLede(string(data.Sections[0].HTML)); ok {
+				data.TLDR = template.HTML("<p>" + para + "</p>") //nolint:gosec // first-party rendered fragment
+				data.Sections[0].HTML = template.HTML(rest)      //nolint:gosec // first-party rendered fragment
+			}
+		}
+	}
+
+	// Alignment strip: surface the retrieved context bundle (top items by
+	// score) so enrichment is visible even when no inline marker anchors and
+	// no badge fired — the retrieved ADR/session IS team context on the plan.
+	data.ContextItems = topContextItems(res.Context, 5)
+
+	// Hero stat chips: the first-30-seconds numbers (sections, files, team
+	// signals, open review items), each only when non-zero. Two chips minimum
+	// or none — a single lonely chip is noise, not a dashboard.
+	data.Stats = heroStats(res, len(data.Sections), data.Review)
+
+	// Anchor each signal to the section(s) whose files it concerns; signals
+	// that match no section stay in the global enrichment panel. This is the
+	// data join that replaces a single prose blob with section-anchored
 	// markers — the spec's per-section badge rail.
-	all := deterministicSignalsWithFiles(res, opts.PriorArtURL)
+	all := signalsWithFiles(res, opts.PriorArtURL)
 	data.HasSignals = len(all) > 0
 	data.SignalCount = len(all)
 	if data.SignalCount != 1 {
@@ -613,19 +665,29 @@ type signalWithFiles struct {
 	files []string
 }
 
-// deterministicSignalsWithFiles projects the ox-computed badges (collision /
-// prior-art / expert-routing) into anchorable signals. Judgment badges are
-// agent-authored and not surfaced here. The presence of any signal is what makes
-// the render emit the anchored OX marker the lint contract requires.
-func deterministicSignalsWithFiles(res Result, priorArtURL func(refKind, ref string) string) []signalWithFiles {
+// signalsWithFiles projects badges into anchorable signals: the ox-computed
+// deterministic ones (collision / prior-art / expert-routing) AND the
+// agent-authored, cited judgment ones (aligns / conflicts / expert
+// perspective) — a saved plan's merged annotations.json carries both, and
+// dropping judgment badges left the alignment layer invisible in real output.
+// rigor stays excluded: it is a collaboration meta-signal, not plan content.
+// The presence of any signal is what makes the render emit the anchored OX
+// marker the lint contract requires.
+func signalsWithFiles(res Result, priorArtURL func(refKind, ref string) string) []signalWithFiles {
 	labels := map[string]string{
-		"collision":      "Collision",
-		"prior-art":      "Prior art",
-		"expert-routing": "Expert",
+		"collision":          "Collision",
+		"prior-art":          "Prior art",
+		"expert-routing":     "Expert",
+		"aligns":             "Aligns",
+		"conflicts":          "Conflicts",
+		"expert-perspective": "Expert view",
 	}
 	var out []signalWithFiles
 	for _, a := range res.Annotations {
-		if a.Kind != BadgeDeterministic {
+		if a.Kind != BadgeDeterministic && a.Kind != BadgeJudgment {
+			continue
+		}
+		if a.Type == BadgeRigor {
 			continue
 		}
 		label, ok := labels[string(a.Type)]
@@ -660,6 +722,89 @@ func deterministicSignalsWithFiles(res Result, priorArtURL func(refKind, ref str
 			sig.URL = priorArtURL(a.RefKind, a.SourceURL)
 		}
 		out = append(out, signalWithFiles{renderSignal: sig, files: a.Files})
+	}
+	return out
+}
+
+// firstParaRe matches the first <p> block of a rendered fragment; leadingJunk
+// guards liftLede against reaching INTO a wrapper (a compare pane, a figure,
+// a list) to steal a nested paragraph — lifting is only safe when the
+// paragraph is the fragment's actual opening block.
+var (
+	firstParaRe = regexp.MustCompile(`(?s)<p>(.*?)</p>`)
+	// only a fragment that OPENS with a bare paragraph lifts — an opening
+	// blockquote (a status banner) or table is not a lede, and lifting the
+	// <p> nested inside it would gut its wrapper.
+	leadingTags = regexp.MustCompile(`^\s*<p>`)
+)
+
+// liftLede lifts the opening paragraph out of a rendered HTML fragment,
+// returning (paragraph inner HTML, remaining fragment, ok). ok is false when
+// the fragment doesn't OPEN with plain prose (a table, figure, or heading
+// first) — synthesizing a hero from mid-document content would misrepresent
+// the plan, so the hero is skipped instead.
+func liftLede(html string) (string, string, bool) {
+	if !leadingTags.MatchString(html) {
+		return "", html, false
+	}
+	m := firstParaRe.FindStringSubmatchIndex(html)
+	if m == nil {
+		return "", html, false
+	}
+	para := strings.TrimSpace(html[m[2]:m[3]])
+	if para == "" {
+		return "", html, false
+	}
+	rest := strings.TrimSpace(html[:m[0]] + html[m[1]:])
+	return para, rest, true
+}
+
+// heroStats derives the hero chip row from plan structure + enrichment: each
+// chip only when its number is non-zero, and fewer than two chips yields none
+// (one lonely number is noise). Signals chip is teal (source-colored), open
+// review amber (needs attention), the rest neutral.
+func heroStats(res Result, sections int, review reviewSummary) []statChip {
+	var out []statChip
+	if sections > 0 {
+		out = append(out, statChip{Value: fmt.Sprintf("%d", sections), Label: "sections", Class: "neutral"})
+	}
+	if res.Signals.Files > 0 {
+		out = append(out, statChip{Value: fmt.Sprintf("%d", res.Signals.Files), Label: "files touched", Class: "neutral"})
+	}
+	if n := res.Signals.Collisions + res.Signals.PriorArt + res.Signals.ExpertRoutes; n > 0 {
+		out = append(out, statChip{Value: fmt.Sprintf("%d", n), Label: "team signals", Class: "teal"})
+	}
+	if review.Open > 0 {
+		out = append(out, statChip{Value: fmt.Sprintf("%d", review.Open), Label: "open review", Class: "amber"})
+	}
+	if len(out) < 2 {
+		return nil
+	}
+	return out
+}
+
+// topContextItems projects the retrieved context bundle into the alignment
+// strip: highest-scored first (stable on ties), capped so the strip stays a
+// glance, not a dump.
+func topContextItems(items []ContextItem, limit int) []renderContext {
+	idx := make([]int, len(items))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool { return items[idx[a]].Score > items[idx[b]].Score })
+	var out []renderContext
+	for _, i := range idx {
+		if len(out) == limit {
+			break
+		}
+		title := strings.TrimSpace(items[i].Title)
+		if title == "" {
+			title = items[i].Ref
+		}
+		if title == "" {
+			continue
+		}
+		out = append(out, renderContext{Kind: items[i].Kind, Title: title})
 	}
 	return out
 }

--- a/internal/plan/render.go
+++ b/internal/plan/render.go
@@ -80,8 +80,15 @@ type RenderOptions struct {
 	// place (only when the plan carries a diagram), so diagrams render at full
 	// parity with zero network. The SageOx enrichment reference links are
 	// preserved — top-level <a href> navigation is not CSP-blocked, so a published
-	// artifact stays a hub back into the Ledger.
+	// artifact stays a hub back into the Ledger. Companion cards and
+	// ```html-interactive blocks are omitted/stripped in this mode: an artifact
+	// is one self-contained page with no sibling files and no author scripting.
 	Artifact bool
+	// Companions are rich self-contained HTML artifacts bundled with the plan
+	// (see companion.go), linked prominently near the top of the rendered page.
+	// The Href is context-resolved by the caller (relative companions/<name>
+	// for file renders; the same path against the review server's route).
+	Companions []Companion
 }
 
 // reviewStateItem is the slim per-item shape injected into the page for the
@@ -174,6 +181,14 @@ type renderData struct {
 	// Artifact toggles the CSP-safe variant: the template drops the Google-Fonts
 	// link, the Mermaid CDN script, and the SSE review layer when set.
 	Artifact bool
+	// Companions render as a prominent card row under the title (never in
+	// artifact mode — a self-contained page must not carry sibling-file links).
+	Companions []Companion
+	// Tabbed switches the section layout from one long scroll to tabbed views
+	// with a sticky top tab bar (the comparison-page register). Enabled when
+	// the plan has more than 3 H2 sections; smaller plans keep the single
+	// scroll, which reads better at that size.
+	Tabbed bool
 	// WordmarkDark/Light are the inline SageOx wordmark SVGs for the subtle
 	// side-nav corner badge; CSS shows the variant matching the active theme.
 	WordmarkDark  template.HTML
@@ -235,6 +250,9 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 		WordmarkDark:   template.HTML(wordmarkDark),  //nolint:gosec // first-party embedded asset
 		WordmarkLight:  template.HTML(wordmarkLight), //nolint:gosec // first-party embedded asset
 	}
+	if !opts.Artifact {
+		data.Companions = opts.Companions
+	}
 	data.ReviewJSON, data.Review = buildReviewState(opts.Review)
 
 	// Inline reference markers ox can stand behind: where a section's prose names
@@ -251,13 +269,13 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 			// template renders the title) and lift any TL;DR into its own callout.
 			tldr, rest := splitTLDR(s.Body)
 			if strings.TrimSpace(tldr) != "" {
-				tldrHTML, err := mdToHTML(md, tldr)
+				tldrHTML, err := mdToHTML(md, tldr, opts.Artifact)
 				if err != nil {
 					return nil, err
 				}
 				data.TLDR = template.HTML(stripLeadingTLDRLabel(string(tldrHTML)))
 			}
-			body, err := mdToHTML(md, rest)
+			body, err := mdToHTML(md, rest, opts.Artifact)
 			if err != nil {
 				return nil, err
 			}
@@ -266,7 +284,7 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 			data.Preamble = template.HTML(pre)
 			continue
 		}
-		body, err := mdToHTML(md, s.Body)
+		body, err := mdToHTML(md, s.Body, opts.Artifact)
 		if err != nil {
 			return nil, err
 		}
@@ -283,6 +301,12 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 			files:   s.Files,
 		})
 	}
+
+	// Tabbed layout: with more than 3 H2 sections the single scroll buries the
+	// later sections; tabs (sticky top bar, one view at a time) keep every
+	// section one click away. Smaller plans keep the scroll — a tab bar with 2
+	// entries is chrome without information.
+	data.Tabbed = len(data.Sections) > 3
 
 	// Anchor each deterministic signal to the section(s) whose files it concerns;
 	// signals that match no section stay in the global enrichment panel. This is
@@ -377,19 +401,115 @@ func newMarkdown() goldmark.Markdown {
 	)
 }
 
-func mdToHTML(md goldmark.Markdown, src string) (template.HTML, error) {
+func mdToHTML(md goldmark.Markdown, src string, artifact bool) (template.HTML, error) {
 	var buf bytes.Buffer
 	if err := md.Convert([]byte(src), &buf); err != nil {
 		return "", fmt.Errorf("markdown convert: %w", err)
 	}
 	// Ordering is load-bearing: mermaid fences are rewritten to <pre class="mermaid">
-	// FIRST, so highlightFences (which scans for <pre><code class="language-X">)
-	// never sees — and never chroma-tokenizes — a mermaid block. colorVerdictCells
-	// touches table cells only, so its position is independent.
+	// FIRST, then ```html-interactive fences pass through raw — both BEFORE
+	// highlightFences (which scans for <pre><code class="language-X">) so neither
+	// is ever chroma-tokenized. colorVerdictCells touches table cells only, so its
+	// position is independent; compareContainers rewrites paragraph markers only.
 	rendered := mermaidFence.ReplaceAllString(buf.String(), `<pre class="mermaid">$1</pre>`)
+	rendered = interactiveFences(rendered, artifact)
 	rendered = highlightFences(rendered)
 	rendered = colorVerdictCells(rendered)
+	rendered = compareContainers(rendered)
 	return template.HTML(rendered), nil //nolint:gosec // first-party plan markdown; see newMarkdown trust note
+}
+
+// interactiveFence matches a goldmark-rendered ```html-interactive fenced block.
+// The fence is the SANCTIONED channel for plan-authored interactivity (tab
+// logic, field inspectors, animated figures): unlike a raw markdown HTML block
+// — which goldmark splits at the first blank line for non-script tags — a
+// fence's content survives verbatim to the closing fence, so multi-element
+// interactive fragments arrive intact.
+var interactiveFence = regexp.MustCompile(`(?s)<pre><code class="language-html-interactive">(.*?)</code></pre>`)
+
+// interactiveFences rewrites ```html-interactive fences into raw HTML
+// (entities un-escaped back to the authored markup) wrapped in a neutral
+// container. TRUST BOUNDARY: same as newMarkdown's WithUnsafe — the plan is
+// the developer's own local content rendered locally for that developer, so
+// author scripting is a feature, not an injection surface. In artifact mode
+// the block is REPLACED by a static placeholder: the artifact CSP posture is
+// "no author scripting", and stripping here keeps that contract strict.
+func interactiveFences(s string, artifact bool) string {
+	return interactiveFence.ReplaceAllStringFunc(s, func(block string) string {
+		if artifact {
+			return `<div class="interactive-omitted">Interactive block omitted from the self-contained artifact export — open the full render for the live version.</div>`
+		}
+		m := interactiveFence.FindStringSubmatch(block)
+		if m == nil {
+			return block
+		}
+		return `<div class="interactive-block">` + html.UnescapeString(m[1]) + `</div>`
+	})
+}
+
+// comparePair matches a `:::compare` opener paragraph, its content, and the
+// closing `:::` paragraph. Rewritten pairwise; an unbalanced marker is left
+// visible in the output (author feedback beats silent structural damage).
+var comparePair = regexp.MustCompile(`(?s)<p>:::compare</p>\s*(.*?)\s*<p>:::</p>`)
+
+// compareContainers turns `:::compare … :::` blocks into side-by-side panes —
+// the comparison-pane register the hand-built pages use, expressible from
+// plain markdown: two tables, or two blocks each under its own H3.
+func compareContainers(s string) string {
+	return comparePair.ReplaceAllStringFunc(s, func(block string) string {
+		m := comparePair.FindStringSubmatch(block)
+		if m == nil {
+			return block
+		}
+		var b strings.Builder
+		b.WriteString(`<div class="compare">`)
+		for _, pane := range splitComparePanes(m[1]) {
+			b.WriteString(`<div class="compare-pane">`)
+			b.WriteString(pane)
+			b.WriteString(`</div>`)
+		}
+		b.WriteString(`</div>`)
+		return b.String()
+	})
+}
+
+// splitComparePanes divides a compare block's inner HTML into panes: at each
+// <h3> when the block carries two or more (heading-titled panes), else at
+// each <table> (the bare two-tables case), else the whole block as a single
+// pane (degrades to one full-width panel rather than breaking layout).
+func splitComparePanes(inner string) []string {
+	for _, marker := range []string{"<h3", "<table"} {
+		if strings.Count(inner, marker) >= 2 {
+			return splitAtMarker(inner, marker)
+		}
+	}
+	return []string{inner}
+}
+
+// splitAtMarker splits s at each occurrence of marker; content before the
+// first occurrence (a lede paragraph) becomes its own leading pane.
+func splitAtMarker(s, marker string) []string {
+	var out []string
+	rest := s
+	for {
+		i := strings.Index(rest, marker)
+		if i < 0 {
+			if trimmed := strings.TrimSpace(rest); trimmed != "" {
+				out = append(out, trimmed)
+			}
+			return out
+		}
+		if lead := strings.TrimSpace(rest[:i]); lead != "" {
+			out = append(out, lead)
+		}
+		j := strings.Index(rest[i+len(marker):], marker)
+		if j < 0 {
+			out = append(out, strings.TrimSpace(rest[i:]))
+			return out
+		}
+		out = append(out, strings.TrimSpace(rest[i:i+len(marker)+j]))
+		rest = rest[i+len(marker)+j:]
+	}
 }
 
 // codeFence matches a goldmark-rendered fenced code block carrying a language

--- a/internal/plan/render_tabbed_test.go
+++ b/internal/plan/render_tabbed_test.go
@@ -1,0 +1,185 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+)
+
+// manySectionInput builds a plan with n H2 sections (plus a preamble).
+func manySectionInput(n int) Input {
+	var b strings.Builder
+	b.WriteString("# Big Plan\n\nPreamble.\n\n")
+	headings := []string{"Context", "Approach", "Sequencing", "Verification", "Risks", "Rollout"}
+	for i := 0; i < n; i++ {
+		b.WriteString("## " + headings[i%len(headings)] + "\n\nBody " + headings[i%len(headings)] + ".\n\n")
+	}
+	return Parse(b.String())
+}
+
+// TestRenderHTML_TabbedOverThreeSections verifies the raised ceiling: a plan
+// with more than 3 H2 sections renders the sticky tab bar (one button per
+// section, comparison-page register), while sections keep their ids so hash
+// deep links still resolve. Failure prevented: a long plan rendering as one
+// undifferentiated scroll — the "much worse customer experience" complaint.
+func TestRenderHTML_TabbedOverThreeSections(t *testing.T) {
+	out, err := RenderHTML(manySectionInput(6), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		`class="tabbar" role="tablist"`,
+		`data-tab="sec-1"`,
+		`data-tab="sec-6"`,
+		`<section id="sec-6"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("tabbed render missing %q", want)
+		}
+	}
+	if got := strings.Count(s, `role="tab"`); got != 6 {
+		t.Errorf("expected 6 tab buttons, got %d", got)
+	}
+}
+
+// TestRenderHTML_SingleScrollAtThreeOrFewer pins the fallback: small plans
+// keep the single scroll — a tab bar with 2-3 entries is chrome without
+// information — and existing plans render byte-compatible (no tabbar).
+func TestRenderHTML_SingleScrollAtThreeOrFewer(t *testing.T) {
+	for _, n := range []int{1, 2, 3} {
+		out, err := RenderHTML(manySectionInput(n), Result{})
+		if err != nil {
+			t.Fatalf("RenderHTML(%d sections): %v", n, err)
+		}
+		if strings.Contains(string(out), `class="tabbar"`) {
+			t.Errorf("%d-section plan unexpectedly rendered tabs", n)
+		}
+	}
+}
+
+// TestRenderHTML_InteractivePassthrough verifies the sanctioned interactivity
+// channel: a ```html-interactive fence passes through as raw, executable HTML
+// (entities un-escaped, script intact) in the normal render. Failure
+// prevented: plan-authored interactivity (inspectors, animated figures)
+// arriving as an escaped, dead code listing.
+func TestRenderHTML_InteractivePassthrough(t *testing.T) {
+	raw := "# P\n\n## One\n\na\n\n## Two\n\n```html-interactive\n<div id=\"insp\">x &amp; y</div>\n\n<script>document.getElementById('insp').textContent='live';</script>\n```\n"
+	out, err := RenderHTML(Parse(raw), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		`<div class="interactive-block">`,
+		`<div id="insp">x &amp; y</div>`, // entity in CONTENT survives one unescape
+		`<script>document.getElementById('insp').textContent='live';</script>`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("interactive render missing %q", want)
+		}
+	}
+	if strings.Contains(s, "language-html-interactive") {
+		t.Error("interactive fence leaked as an escaped code listing")
+	}
+}
+
+// TestRenderHTML_InteractiveStrippedInArtifact pins the artifact contract:
+// --artifact stays strict — the author-scripting block is REPLACED by a static
+// placeholder, keeping the CSP-safe export free of plan-authored scripts.
+func TestRenderHTML_InteractiveStrippedInArtifact(t *testing.T) {
+	raw := "# P\n\n## One\n\na\n\n## Two\n\n```html-interactive\n<script>alert(1)</script>\n```\n"
+	out, err := RenderHTMLOpts(Parse(raw), Result{}, RenderOptions{Artifact: true})
+	if err != nil {
+		t.Fatalf("RenderHTMLOpts: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, "alert(1)") {
+		t.Error("artifact render carried the plan-authored script")
+	}
+	if !strings.Contains(s, `class="interactive-omitted"`) {
+		t.Error("artifact render missing the interactive-omitted placeholder")
+	}
+	if findings := LintArtifact(out); len(findings) != 0 {
+		t.Errorf("artifact render with stripped interactivity failed LintArtifact: %+v", findings)
+	}
+}
+
+// TestRenderHTML_CompareContainer verifies the comparison-pane marker: a
+// `:::compare … :::` block wraps its two tables into adjacent panes.
+func TestRenderHTML_CompareContainer(t *testing.T) {
+	raw := strings.Join([]string{
+		"# P", "",
+		"## Formats", "",
+		":::compare", "",
+		"| ours | |", "|---|---|", "| a | 1 |", "",
+		"| theirs | |", "|---|---|", "| b | 2 |", "",
+		":::", "",
+	}, "\n")
+	out, err := RenderHTML(Parse(raw), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `<div class="compare">`) {
+		t.Fatal("compare container not rendered")
+	}
+	if got := strings.Count(s, `<div class="compare-pane">`); got != 2 {
+		t.Errorf("expected 2 compare panes, got %d", got)
+	}
+	if strings.Contains(s, ":::compare") {
+		t.Error("compare marker paragraph leaked into the output")
+	}
+}
+
+// TestRenderHTML_CompareUnbalancedMarkerVisible pins the fail-visible rule:
+// an opener with no close is left as-is (author feedback beats silent damage).
+func TestRenderHTML_CompareUnbalancedMarkerVisible(t *testing.T) {
+	raw := "# P\n\n## S\n\n:::compare\n\nprose only, no close\n"
+	out, err := RenderHTML(Parse(raw), Result{})
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, `class="compare"`) {
+		t.Error("unbalanced compare marker was wrapped anyway")
+	}
+	if !strings.Contains(s, ":::compare") {
+		t.Error("unbalanced marker should remain visible in the output")
+	}
+}
+
+// TestRenderHTML_CompanionCard verifies Leg A's render surface: a bundled
+// companion renders as a prominent card near the top with the uniform
+// companions/<name> href — and artifact mode omits it (a self-contained page
+// must not carry sibling-file links).
+func TestRenderHTML_CompanionCard(t *testing.T) {
+	in := manySectionInput(2)
+	comps := CompanionRefs([]string{"deep-dive.html"})
+
+	out, err := RenderHTMLOpts(in, Result{}, RenderOptions{Companions: comps})
+	if err != nil {
+		t.Fatalf("RenderHTMLOpts: %v", err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		`class="companion-card"`,
+		`href="companions/deep-dive.html"`,
+		"Companion · interactive deep-dive",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("companion render missing %q", want)
+		}
+	}
+	// prominence: the card must appear before the first section, not below it.
+	if strings.Index(s, `class="companion-card"`) > strings.Index(s, `<section id="sec-1"`) {
+		t.Error("companion card rendered below the sections — must lead")
+	}
+
+	art, err := RenderHTMLOpts(in, Result{}, RenderOptions{Companions: comps, Artifact: true})
+	if err != nil {
+		t.Fatalf("RenderHTMLOpts artifact: %v", err)
+	}
+	if strings.Contains(string(art), `class="companion-card"`) {
+		t.Error("artifact render must omit companion cards")
+	}
+}

--- a/internal/plan/render_tabbed_test.go
+++ b/internal/plan/render_tabbed_test.go
@@ -16,19 +16,20 @@ func manySectionInput(n int) Input {
 	return Parse(b.String())
 }
 
-// TestRenderHTML_TabbedOverThreeSections verifies the raised ceiling: a plan
-// with more than 3 H2 sections renders the sticky tab bar (one button per
-// section, comparison-page register), while sections keep their ids so hash
-// deep links still resolve. Failure prevented: a long plan rendering as one
-// undifferentiated scroll — the "much worse customer experience" complaint.
-func TestRenderHTML_TabbedOverThreeSections(t *testing.T) {
+// TestRenderHTML_SectionJumpsOverThreeSections verifies the raised ceiling: a
+// plan with more than 3 H2 sections renders the sticky jump bar (one button per
+// section, comparison-page register), while sections stay in the document flow
+// with ids so hash/review deep links still resolve. Failure prevented: a long
+// plan either rendering as one undifferentiated scroll or hiding most sections
+// behind a tab state the reviewer/comment rail can miss.
+func TestRenderHTML_SectionJumpsOverThreeSections(t *testing.T) {
 	out, err := RenderHTML(manySectionInput(6), Result{})
 	if err != nil {
 		t.Fatalf("RenderHTML: %v", err)
 	}
 	s := string(out)
 	for _, want := range []string{
-		`class="tabbar" role="tablist"`,
+		`class="tabbar" aria-label="Plan sections"`,
 		`data-tab="sec-1"`,
 		`data-tab="sec-6"`,
 		`<section id="sec-6"`,
@@ -37,8 +38,11 @@ func TestRenderHTML_TabbedOverThreeSections(t *testing.T) {
 			t.Errorf("tabbed render missing %q", want)
 		}
 	}
-	if got := strings.Count(s, `role="tab"`); got != 6 {
-		t.Errorf("expected 6 tab buttons, got %d", got)
+	if got := strings.Count(s, `data-tab="sec-`); got != 6 {
+		t.Errorf("expected 6 section jump buttons, got %d", got)
+	}
+	if strings.Contains(s, `role="tab"`) || strings.Contains(s, `role="tablist"`) {
+		t.Error("section jumps must not advertise hidden tab semantics")
 	}
 }
 

--- a/internal/plan/render_test.go
+++ b/internal/plan/render_test.go
@@ -76,8 +76,31 @@ func TestRenderHTML_NoSignalsNoMarker(t *testing.T) {
 	if strings.Contains(strings.ToLower(s), "enriched by sageox") {
 		t.Error("un-enriched render claims enrichment credit (overclaim)")
 	}
+	if strings.Contains(s, "enrichment ran") {
+		t.Error("un-enriched render claims enrichment ran")
+	}
 	if findings := LintBranding(out, res); len(findings) != 0 {
 		t.Fatalf("no-signal render failed lint: %+v", findings)
+	}
+}
+
+// TestRenderHTML_QuietFooterRequiresEnrichment distinguishes two otherwise
+// similar outcomes: no deterministic signals because enrichment found only
+// context, versus no signals because enrichment never ran / found nothing.
+func TestRenderHTML_QuietFooterRequiresEnrichment(t *testing.T) {
+	in := sampleInput()
+	res := Result{Context: []ContextItem{{Kind: "adr", Title: "ADR-001", Score: 1}}}
+
+	out, err := RenderHTML(in, res)
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "Team context enriched by SageOx") {
+		t.Fatal("context-only enrichment should earn footer credit")
+	}
+	if !strings.Contains(s, "enrichment ran") {
+		t.Fatal("context-only enrichment with no signals should show the quiet no-signal note")
 	}
 }
 

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -135,6 +135,14 @@ type Meta struct {
 
 	// Status is the plan's lifecycle. Missing == "draft" for legacy plans.
 	Status PlanStatus `json:"status,omitempty"`
+	// Primary records which stored artifact is the plan of record: "html"
+	// (PrimaryHTML) when an authored HTML page is canonical — plan.md is then
+	// DERIVED via ExtractMarkdown, regenerated on save, never hand-edited —
+	// or "" when the markdown is primary (legacy + quick plans; plan.html is a
+	// generated render). Render/review branch on this: an HTML-primary plan is
+	// served as the authored page with ox chrome INJECTED (inject.go), never
+	// re-rendered through the markdown template.
+	Primary string `json:"primary,omitempty"`
 	// Companions lists the basenames of rich HTML companion artifacts stored
 	// under the plan dir's companions/ subdir (see companion.go). Rendered as
 	// prominent links on the plan page and served by `ox plan review`.
@@ -277,6 +285,12 @@ func Save(gitRoot string, in Input, res Result, html []byte, meta Meta) (string,
 				// wipe the already-bundled list.
 				if len(merged.Companions) == 0 {
 					merged.Companions = existing.Companions
+				}
+				// Primary sticks: a later markdown-shaped re-save (the hook
+				// draft, a lifecycle write) must not demote an HTML-primary
+				// plan back to markdown-primary.
+				if merged.Primary == "" {
+					merged.Primary = existing.Primary
 				}
 				// SessionID and SessionOutcome are system-managed (backfilled /
 				// reconciled at stop), never set by a save-time caller — preserve

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -135,6 +135,10 @@ type Meta struct {
 
 	// Status is the plan's lifecycle. Missing == "draft" for legacy plans.
 	Status PlanStatus `json:"status,omitempty"`
+	// Companions lists the basenames of rich HTML companion artifacts stored
+	// under the plan dir's companions/ subdir (see companion.go). Rendered as
+	// prominent links on the plan page and served by `ox plan review`.
+	Companions []string `json:"companions,omitempty"`
 	// Provenance links the plan to its producing session/agent/repo (forward).
 	Provenance *Provenance `json:"provenance,omitempty"`
 	// Collaboration holds the deterministic collaboration-effort counts.
@@ -267,6 +271,12 @@ func Save(gitRoot string, in Input, res Result, html []byte, meta Meta) (string,
 				}
 				if !existing.CreatedAt.IsZero() {
 					merged.CreatedAt = existing.CreatedAt
+				}
+				// Companions are recorded by the render path after Save (see
+				// RecordCompanions); a re-save that doesn't carry them must not
+				// wipe the already-bundled list.
+				if len(merged.Companions) == 0 {
+					merged.Companions = existing.Companions
 				}
 				// SessionID and SessionOutcome are system-managed (backfilled /
 				// reconciled at stop), never set by a save-time caller — preserve


### PR DESCRIPTION
## Summary

- **Plan of record:** Makes authored HTML the primary plan artifact, derives markdown from the rendered page, and injects reusable ox review chrome instead of treating generated markdown as the only durable output.
- **Reviewer UX:** Keeps rendered plans readable as one continuous document, adds a sticky section jump bar for orientation, and avoids hiding large portions of the plan behind tabs.
- **Companion artifacts:** Detects linked local HTML companions, copies them beside rendered output, preserves original inline links, and exposes companion cards for reviewer inspection.
- **Command surface:** Extends plan rendering/review flows and regenerates CLI reference docs for the new plan lifecycle commands and render flags.

## What Broke

- **Hidden context:** The first rendered-tab pass made human review harder because only the active section was visible, so reviewers could miss plan scope, failure modes, and later sections.
- **Broken companion paths:** Generated companion cards could point to copied artifacts while original inline markdown links still targeted files that were not copied next to the output.
- **Review-file gap:** `ox plan review --file` did not bundle companions the same way direct render paths did.

## What This PR Ships

- **HTML-first plan pipeline:** Adds extraction/injection helpers and tests so plans can be authored as rich HTML while ox still produces derived markdown and review metadata.
- **Continuous review layout:** Converts the tab UI into section-jump navigation, preserves scroll-based active state, hides duplicate side navigation when the jump bar is present, and keeps all plan sections visible.
- **Companion durability:** Tracks companion source path plus original relative link path, rejects unsafe paths, and copies both canonical `companions/<file>` artifacts and non-clobbering sibling paths when needed.
- **Auto-visualization hints:** Adds content-aware plan visualization support and tests for extracting charts, tables, timelines, comparisons, and flow hints.
- **Docs and skill updates:** Updates plan authoring/rendering docs, generated CLI reference pages, and the `ox-plan` skill wrapper for the new renderer behavior.

## Flow

```mermaid
flowchart TD
    A[Author plan HTML or markdown] --> B[ox plan render/review]
    B --> C[Extract readable markdown + metadata]
    B --> D[Inject ox chrome]
    D --> E[Rendered reviewer page]
    E --> F[Continuous sections + jump bar]
    E --> G[Companion cards]
    G --> H[companions/file.html]
    G --> I[original relative link preserved]
```

## Test Plan

- **Passed:** `make lint`
- **Passed:** `make test` (`DONE 16953 tests, 1080 skipped in 116.355s`)
- **Passed:** Focused plan renderer/companion tests during development, including `go test ./internal/plan` and `go test ./cmd/ox` plan-render cases.
- **Passed:** Rendered a real plan fixture and visually inspected screenshot/metrics confirming all sections remain visible, `tabs-on` hiding is absent, footer stays below content, and duplicate side navigation is hidden when the jump bar is present.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented
- [x] CHANGELOG entry N/A: unreleased plan-rendering work on a feature branch
- [x] Breaking change documented: `docs/specs/plan-authoring-html.md` and `docs/specs/plan-render-adoption.md`
- [x] Security review N/A: does not touch `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum`

</details>

Co-authored-by: SageOx <ox@sageox.ai>
SageOx-Session: https://sageox.ai/c/ses_019f9c38-39b0-7cc9-bffb-7ab292fb751e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Author and save plans as interactive HTML, with Markdown automatically derived for search and terminal viewing.
  * Render and review authored HTML while preserving original content and injecting current enrichment and review tools.
  * Add companion HTML files to rendered plans and live reviews.
  * Improve plan visuals with section navigation, comparison inspectors, swimlanes, context indicators, and responsive review controls.
  * Add plan lifecycle commands: abandon, approve, realize, status, supersede, and work.
  * Add session listing by repository and support stopping the current session.

* **Documentation**
  * Expanded plan command references and documented the HTML-first authoring workflow.
  * Updated documentation navigation and version to 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->