### PR TITLE
fix(ledger,lfs): self-heal stale git locks, close two silent recording-loss paths

### DIFF
--- a/cmd/ox/doctor_ledger_git.go
+++ b/cmd/ox/doctor_ledger_git.go
@@ -331,9 +331,13 @@ func fixLedgerBranchBehind(ledgerPath string, behindCount int) checkResult {
 	output, err := pullCmd.CombinedOutput()
 	if err != nil {
 		errStr := strings.TrimSpace(string(output))
-		// try accept-theirs for data/github/ conflicts
+		// Route through automerge, not the bare accept-theirs call. This was the
+		// one reconcile path that skipped the tiered resolver, so it got no union
+		// tier and no LLM tier while every other path (CLI push, daemon pull,
+		// diverged fix) went through ledgerLLMResolveHook. Behind-only pulls hit
+		// exactly the same sessions/ conflicts as the others.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		resolveErr := gitutil.ResolveRebaseAcceptTheirs(ctx, ledgerPath, ledgerAutoResolvePrefixes)
+		_, resolveErr := ledgerLLMResolveHook()(ctx, ledgerPath, nil)
 		cancel()
 		if resolveErr != nil {
 			slog.Debug("rebase auto-resolve failed", "error", resolveErr)

--- a/internal/daemon/agentwork/session_finalize_pointer_commit_test.go
+++ b/internal/daemon/agentwork/session_finalize_pointer_commit_test.go
@@ -51,8 +51,11 @@ func TestPointerRewrite_CommittedAfterPush(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// simulate LFS upload having succeeded — create file refs
-	oid := "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	// Simulate LFS upload having succeeded — create file refs. The OID must be
+	// the content's real hash, which is what a real upload produces. Pointerizing
+	// content that an OID does not describe is refused, because that is the shape
+	// of a meta/blob disagreement and it would destroy the only local copy.
+	oid := "sha256:" + lfs.ComputeOID(rawContent)
 	fileRefs := map[string]lfs.FileRef{
 		"raw.jsonl": {OID: oid, Size: int64(len(rawContent)), Storage: "lfs"},
 	}

--- a/internal/daemon/sync_managed_test.go
+++ b/internal/daemon/sync_managed_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
+	"github.com/sageox/ox/internal/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -88,9 +90,17 @@ func TestPullManagedRepo_SessionMetaConflict_ClassifiesAsSessionConflictWedge(t 
 
 	s := newTestScheduler(t.TempDir())
 	result := s.pullManagedRepo(context.Background(), ManagedRepoPullOpts{
-		RepoPath:     localDir,
-		RepoName:     "ledger",
-		ResolveRules: ledger.DefaultResolveRules, // real production rules: sessions/ stays hard-denied
+		RepoPath: localDir,
+		RepoName: "ledger",
+		// Deliberately NOT ledger.DefaultResolveRules: production now
+		// auto-resolves sessions/, so this fixture would reconcile cleanly and
+		// never produce an Issue to escalate. The subject under test is the
+		// escalation MATH surviving a daemon restart, which applies to every
+		// wedge type; drive it with rules that leave the conflict unresolved so
+		// there is something to escalate. Coverage that production rules now
+		// resolve this fixture lives in
+		// TestSessionMetaConflict_AutoResolvesUnderProductionRules.
+		ResolveRules: []manifest.ResolveRule{{Mode: manifest.ResolveModeAuto, Path: "data/"}},
 		Logger:       discardLogger(),
 	})
 
@@ -233,9 +243,17 @@ func TestEscalateSessionConflictSeverity_SurvivesDaemonRestart(t *testing.T) {
 
 	s := newTestScheduler(t.TempDir())
 	result := s.pullManagedRepo(context.Background(), ManagedRepoPullOpts{
-		RepoPath:     localDir,
-		RepoName:     "ledger",
-		ResolveRules: ledger.DefaultResolveRules, // real production rules: sessions/ stays hard-denied
+		RepoPath: localDir,
+		RepoName: "ledger",
+		// Deliberately NOT ledger.DefaultResolveRules: production now
+		// auto-resolves sessions/, so this fixture would reconcile cleanly and
+		// never produce an Issue to escalate. The subject under test is the
+		// escalation MATH surviving a daemon restart, which applies to every
+		// wedge type; drive it with rules that leave the conflict unresolved so
+		// there is something to escalate. Coverage that production rules now
+		// resolve this fixture lives in
+		// TestSessionMetaConflict_AutoResolvesUnderProductionRules.
+		ResolveRules: []manifest.ResolveRule{{Mode: manifest.ResolveModeAuto, Path: "data/"}},
 		Logger:       discardLogger(),
 	})
 	require.NotNil(t, result.Issue)
@@ -315,4 +333,33 @@ func TestOldestUnpushedCommitAge_PicksOldestAcrossMultipleUnpushedCommits(t *tes
 	age, ok := oldestUnpushedCommitAge(context.Background(), cloneDir)
 	require.True(t, ok)
 	assert.GreaterOrEqual(t, age, 10*time.Hour, "must report the OLDEST unpushed commit's age, not the newest")
+}
+
+// TestSessionMetaConflict_AutoResolvesUnderProductionRules is the counterpart
+// to the escalation test above: under the REAL production rules, the same
+// sessions/*/meta.json fixture must reconcile cleanly instead of raising a
+// wedge issue.
+//
+// Failure prevented: sessions/ silently dropping out of
+// ledger.DefaultResolveRules would restore the 13-day production wedge, and
+// every other test in this file would still pass because they pin the
+// escalation math rather than the resolve outcome.
+func TestSessionMetaConflict_AutoResolvesUnderProductionRules(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: git clone operations")
+	}
+	localDir := makeSessionMetaConflictClone(t)
+
+	s := newTestScheduler(t.TempDir())
+	result := s.pullManagedRepo(context.Background(), ManagedRepoPullOpts{
+		RepoPath:     localDir,
+		RepoName:     "ledger",
+		ResolveRules: ledger.DefaultResolveRules,
+		Logger:       discardLogger(),
+	})
+
+	require.Nil(t, result.Issue,
+		"sessions/ conflicts must auto-resolve under production rules, not wedge")
+	require.False(t, gitutil.IsRebaseInProgress(localDir),
+		"no rebase may be left in progress after a successful reconcile")
 }

--- a/internal/gitserver/gitignore.go
+++ b/internal/gitserver/gitignore.go
@@ -240,6 +240,21 @@ func EnsureGitignoreBeforeCommitCtx(ctx context.Context, repoPath string) {
 		slog.Debug("pre-commit .rej untrack failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
 	}
 
+	// untrack .needs-summary markers committed before sessions/.gitignore
+	// excluded them. The marker is machine-local scheduling state holding
+	// ABSOLUTE local paths, so it both leaks the writer's home directory into a
+	// shared repo and can never merge cleanly between two machines. The cloud
+	// summarizer deletes it on completion while a local writer modifies it —
+	// a modify/delete conflict that resolves toward the local modification and
+	// resurrects a retired marker forever. --cached preserves the local files,
+	// so in-flight summarization is unaffected; --sparse reaches tracked paths
+	// outside the sparse cone.
+	rmNeedsSummaryCmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"rm", "--cached", "--sparse", "--ignore-unmatch", "*.needs-summary")
+	if out, err := rmNeedsSummaryCmd.CombinedOutput(); err != nil {
+		slog.Debug("pre-commit .needs-summary untrack failed", "path", repoPath, "error", err, "output", strings.TrimSpace(string(out)))
+	}
+
 	// untrack root-level codedb/ that was committed before the path was fixed
 	// (codedb now lives at .sageox/cache/codedb/ inside the ledger).
 	rmCodedbCmd := exec.CommandContext(ctx, "git", "-C", repoPath,

--- a/internal/gitutil/rebase_resolve.go
+++ b/internal/gitutil/rebase_resolve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -183,9 +184,42 @@ const lfsPointerPrefix = "version https://git-lfs.github.com/spec/v1"
 // pointers are ~130 bytes; anything larger is content by definition.
 const maxLFSPointerSize = 200
 
-// isLFSPointerBlob reports whether the given blob content is an LFS pointer.
+// isLFSPointerBlob reports whether the given blob content is a COMPLETE, valid
+// LFS pointer.
+//
+// The full shape is required, not just the version prefix. A truncated pointer
+// — or a short artifact that merely starts with the spec line — must not win a
+// conflict against valid content: downstream LFS parsing would reject it, so
+// "winning" would mean committing an unusable blob over a good one. Mirrors the
+// validation in lfs.ParsePointer, which gitutil cannot import (lfs depends on
+// gitutil, so the import would cycle).
 func isLFSPointerBlob(content string) bool {
-	return len(content) <= maxLFSPointerSize && strings.HasPrefix(content, lfsPointerPrefix)
+	if len(content) > maxLFSPointerSize || !strings.HasPrefix(content, lfsPointerPrefix) {
+		return false
+	}
+	var haveOID, haveSize bool
+	for _, line := range strings.Split(strings.TrimSpace(content), "\n") {
+		switch {
+		case strings.HasPrefix(line, "oid "):
+			// require a non-empty, hex-shaped digest with its algorithm prefix
+			oid := strings.TrimPrefix(line, "oid ")
+			if !strings.HasPrefix(oid, "sha256:") {
+				return false
+			}
+			digest := strings.TrimPrefix(oid, "sha256:")
+			if digest == "" || strings.ContainsAny(digest, " \t") {
+				return false
+			}
+			haveOID = true
+		case strings.HasPrefix(line, "size "):
+			size, err := strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(line, "size ")), 10, 64)
+			if err != nil || size <= 0 {
+				return false
+			}
+			haveSize = true
+		}
+	}
+	return haveOID && haveSize
 }
 
 // pointerWinsStage decides a content conflict where the two sides disagree

--- a/internal/gitutil/rebase_resolve.go
+++ b/internal/gitutil/rebase_resolve.go
@@ -60,6 +60,7 @@ func ResolveRebaseAcceptTheirs(ctx context.Context, repoPath string, safePrefixe
 
 	// resolve each conflicted file based on its conflict type
 	var toCheckoutTheirs []string // content conflicts: use checkout --theirs
+	var toCheckoutOurs []string   // content conflicts where the pointer side must win
 	var toAdd []string            // rename conflicts: stage the file as-is
 	var toRemove []string         // base-only: file deleted in both branches
 
@@ -69,10 +70,33 @@ func ResolveRebaseAcceptTheirs(ctx context.Context, repoPath string, safePrefixe
 		hasOurs := stages[3]   // stage 3: version from commit being replayed
 
 		switch {
-		case hasBase && hasTheirs && hasOurs:
-			// content conflict: all three stages exist for the same path.
-			// working tree has conflict markers — use checkout --theirs to
-			// pick a clean version (during rebase, "theirs" = commit being replayed)
+		case hasTheirs && hasOurs:
+			// Both sides have content at this path. Two shapes land here:
+			//   - content conflict (base present): both modified the same file
+			//   - add/add conflict (no base): both CREATED the same file
+			//
+			// add/add used to fall through to the rename branch below, which
+			// stages the working-tree file as-is — conflict markers and all.
+			// That committed literal "<<<<<<< HEAD" into session artifacts, and
+			// it is the common shape when the cloud summarizer and the local CLI
+			// both write a brand-new session.md for the same session.
+			//
+			// Pointer-wins takes precedence over the positional rule. When one
+			// side is an LFS pointer and the other is hydrated bytes, this is
+			// not a content disagreement at all — it is a hydration-state
+			// disagreement, and the pointer is the only correct committed form
+			// (.claude/rules/cache-only-design.md). Committing the hydrated side
+			// permanently breaks pushes with "LFS objects are missing".
+			//
+			// Pointer-wins is also commutative and idempotent, so unlike the
+			// positional rule it converges regardless of which replica resolves
+			// first — that property is what stops a resolution from re-diverging.
+			if pointerWinsStage(ctx, repoPath, path) == 2 {
+				toCheckoutOurs = append(toCheckoutOurs, path)
+				continue
+			}
+			// Otherwise the positional rule: checkout --theirs picks stage 3,
+			// which during a rebase is the commit being replayed (the LOCAL side).
 			toCheckoutTheirs = append(toCheckoutTheirs, path)
 		case hasOurs && !hasBase:
 			// rename conflict: ours exists but no base at this path.
@@ -104,6 +128,20 @@ func ResolveRebaseAcceptTheirs(ctx context.Context, repoPath string, safePrefixe
 		}
 	}
 
+	// resolve pointer-wins conflicts by taking stage 2 (the branch being rebased
+	// onto). Safe here because these are content conflicts, so all three stages
+	// exist and --ours cannot hit the modify/delete case where it errors out.
+	if len(toCheckoutOurs) > 0 {
+		checkoutArgs := append([]string{"checkout", "--ours", "--"}, toCheckoutOurs...)
+		if _, err := RunGit(ctx, repoPath, checkoutArgs...); err != nil {
+			return fmt.Errorf("checkout --ours (pointer wins): %w", err)
+		}
+		addArgs := append([]string{"add", "--"}, toCheckoutOurs...)
+		if _, err := RunGit(ctx, repoPath, addArgs...); err != nil {
+			return fmt.Errorf("git add after checkout --ours: %w", err)
+		}
+	}
+
 	// remove files that exist only in base (deleted in both branches)
 	if len(toRemove) > 0 {
 		rmArgs := append([]string{"rm", "--cached", "--quiet", "--"}, toRemove...)
@@ -131,6 +169,68 @@ func ResolveRebaseAcceptTheirs(ctx context.Context, repoPath string, safePrefixe
 	}
 
 	return nil
+}
+
+// lfsPointerPrefix is the first line of every Git LFS pointer file.
+//
+// Duplicated from internal/lfs rather than imported: internal/lfs depends on
+// gitutil, so importing it back would create a cycle. The value is fixed by the
+// LFS spec (https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md), so it
+// cannot drift.
+const lfsPointerPrefix = "version https://git-lfs.github.com/spec/v1"
+
+// maxLFSPointerSize bounds how many bytes we read to classify a blob. Real
+// pointers are ~130 bytes; anything larger is content by definition.
+const maxLFSPointerSize = 200
+
+// isLFSPointerBlob reports whether the given blob content is an LFS pointer.
+func isLFSPointerBlob(content string) bool {
+	return len(content) <= maxLFSPointerSize && strings.HasPrefix(content, lfsPointerPrefix)
+}
+
+// pointerWinsStage decides a content conflict where the two sides disagree
+// about HYDRATION STATE rather than content: one side is an LFS pointer, the
+// other is the hydrated bytes.
+//
+// Returns the index stage to keep (2 = branch being rebased onto, 3 = commit
+// being replayed), or 0 when both sides are the same kind and the caller should
+// fall back to its normal rule.
+//
+// Why the pointer always wins: a hydrated file committed in place breaks the
+// LFS linkage, and every subsequent push is rejected with "LFS objects are
+// missing" — a permanent, repo-wide wedge (see .claude/rules/cache-only-design.md
+// and the 2026-04-25 incident). The pointer side loses nothing, because the
+// bytes it references are already in the LFS store.
+//
+// The rule is a semilattice join — commutative, associative, idempotent — so
+// two replicas resolving the same conflict independently reach the same answer.
+// The positional rule (always take the replaying side) has no such property and
+// therefore has no fixed point.
+func pointerWinsStage(ctx context.Context, repoPath, path string) int {
+	onto, err := readIndexStage(ctx, repoPath, 2, path)
+	if err != nil {
+		return 0
+	}
+	replayed, err := readIndexStage(ctx, repoPath, 3, path)
+	if err != nil {
+		return 0
+	}
+
+	ontoIsPointer := isLFSPointerBlob(onto)
+	replayedIsPointer := isLFSPointerBlob(replayed)
+	switch {
+	case ontoIsPointer && !replayedIsPointer:
+		return 2
+	case replayedIsPointer && !ontoIsPointer:
+		return 3
+	default:
+		return 0 // same kind on both sides — no opinion
+	}
+}
+
+// readIndexStage returns the blob content for one stage of a conflicted path.
+func readIndexStage(ctx context.Context, repoPath string, stage int, path string) (string, error) {
+	return RunGit(ctx, repoPath, "cat-file", "blob", fmt.Sprintf(":%d:%s", stage, path))
 }
 
 // unmergedEntry represents one stage of an unmerged file in the git index.

--- a/internal/gitutil/rebase_resolve_pointer_test.go
+++ b/internal/gitutil/rebase_resolve_pointer_test.go
@@ -145,6 +145,17 @@ func TestIsLFSPointerBlob(t *testing.T) {
 		// stops a hydrated file that happens to begin with the marker from being
 		// misclassified as safe to keep.
 		{"prefix but oversized", valid + string(make([]byte, maxLFSPointerSize)), false},
+		// A malformed pointer must NOT win a conflict. Downstream LFS parsing
+		// rejects it, so treating it as a pointer would commit an unusable blob
+		// over valid content — a data-loss dressed up as a safety guard.
+		{"truncated: version line only", lfsPointerPrefix + "\n", false},
+		{"missing size", lfsPointerPrefix + "\noid sha256:abc123\n", false},
+		{"missing oid", lfsPointerPrefix + "\nsize 100\n", false},
+		{"empty oid digest", lfsPointerPrefix + "\noid sha256:\nsize 100\n", false},
+		{"oid without algorithm prefix", lfsPointerPrefix + "\noid abc123\nsize 100\n", false},
+		{"non-numeric size", lfsPointerPrefix + "\noid sha256:abc123\nsize huge\n", false},
+		{"zero size", lfsPointerPrefix + "\noid sha256:abc123\nsize 0\n", false},
+		{"negative size", lfsPointerPrefix + "\noid sha256:abc123\nsize -5\n", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/gitutil/rebase_resolve_pointer_test.go
+++ b/internal/gitutil/rebase_resolve_pointer_test.go
@@ -1,0 +1,155 @@
+package gitutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lfsPointer builds a spec-shaped LFS pointer for a fake OID.
+func lfsPointer(oid string, size int) string {
+	return lfsPointerPrefix + "\noid sha256:" + oid + "\nsize " + itoa(size) + "\n"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// TestPointerWins_HydratedNeverBeatsPointer is the regression test for the
+// wedge that blocked a real ledger for 13 days with 281 conflicts.
+//
+// Failure prevented: every mixed session-artifact conflict on that ledger was
+// local=hydrated / remote=pointer. The positional rule (`checkout --theirs`)
+// resolves to the LOCAL side during a rebase, so enabling auto-resolve for
+// sessions/ without this guard would commit hydrated bytes over the remote LFS
+// pointer. Per .claude/rules/cache-only-design.md that breaks the LFS linkage
+// and every subsequent push is rejected with "LFS objects are missing" — a
+// permanent, repo-wide wedge strictly worse than the one being fixed.
+func TestPointerWins_HydratedNeverBeatsPointer(t *testing.T) {
+	const (
+		sessionFile = "sessions/2026-07-01T00-00-ryan-Oxtest/session.md"
+		pointerOID  = "3bdb5928692a4ce4bb0ec3ad2a2f0e1d9c8b7a65432109876543210fedcba9876"
+	)
+	pointer := lfsPointer(pointerOID, 4096)
+	hydrated := "# Agent Session\n\nReal hydrated markdown that must NOT be committed.\n"
+
+	t.Run("pointer on the remote side wins over local hydrated bytes", func(t *testing.T) {
+		// setupDivergentRepos puts `oursContent` on the LOCAL replayed commit
+		// and `theirsContent` on the branch being rebased onto.
+		_, local := setupDivergentRepos(t, sessionFile, hydrated, pointer)
+
+		err := ResolveRebaseAcceptTheirs(context.Background(), local, []string{"sessions/"})
+		require.NoError(t, err, "sessions/ conflicts must auto-resolve, not wedge")
+
+		got, readErr := os.ReadFile(filepath.Join(local, sessionFile))
+		require.NoError(t, readErr)
+		assert.Equal(t, pointer, string(got),
+			"the LFS pointer must survive; committing hydrated bytes breaks every future push")
+	})
+
+	t.Run("pointer on the local side also wins", func(t *testing.T) {
+		// Mirror image. Pointer-wins must be commutative — that is the property
+		// that makes two replicas resolving independently converge instead of
+		// ping-ponging forever.
+		_, local := setupDivergentRepos(t, sessionFile, pointer, hydrated)
+
+		err := ResolveRebaseAcceptTheirs(context.Background(), local, []string{"sessions/"})
+		require.NoError(t, err)
+
+		got, readErr := os.ReadFile(filepath.Join(local, sessionFile))
+		require.NoError(t, readErr)
+		assert.Equal(t, pointer, string(got),
+			"pointer must win from either side, or replicas cannot converge")
+	})
+
+	t.Run("two non-pointer sides fall back to the positional rule", func(t *testing.T) {
+		// meta.json is never a pointer. Both sides are plain content, so the
+		// guard has no opinion and the existing last-writer behavior applies.
+		// This is the accepted tradeoff: summaries are best-effort.
+		const metaFile = "sessions/2026-07-01T00-00-ryan-Oxtest/meta.json"
+		localMeta := `{"summary_status":"unrecoverable"}`
+		cloudMeta := `{"summary_status":"ok","title":"Real summary"}`
+
+		_, local := setupDivergentRepos(t, metaFile, localMeta, cloudMeta)
+
+		err := ResolveRebaseAcceptTheirs(context.Background(), local, []string{"sessions/"})
+		require.NoError(t, err, "must resolve rather than wedge")
+
+		got, readErr := os.ReadFile(filepath.Join(local, metaFile))
+		require.NoError(t, readErr)
+		assert.Equal(t, localMeta, string(got),
+			"positional rule keeps the replayed (local) side when neither is a pointer")
+	})
+}
+
+// TestPointerWinsStage_Classification pins the decision function itself, so a
+// future refactor cannot silently invert it.
+func TestPointerWinsStage_Classification(t *testing.T) {
+	const f = "sessions/s1/session.md"
+	pointer := lfsPointer("abc123def4567890abc123def4567890abc123def4567890abc123def4567890", 100)
+	content := "# not a pointer\n"
+
+	t.Run("stage 2 pointer, stage 3 content", func(t *testing.T) {
+		_, local := setupDivergentRepos(t, f, content, pointer)
+		assert.Equal(t, 2, pointerWinsStage(context.Background(), local, f))
+	})
+
+	t.Run("stage 3 pointer, stage 2 content", func(t *testing.T) {
+		_, local := setupDivergentRepos(t, f, pointer, content)
+		assert.Equal(t, 3, pointerWinsStage(context.Background(), local, f))
+	})
+
+	t.Run("both content: no opinion", func(t *testing.T) {
+		_, local := setupDivergentRepos(t, f, "local text\n", "cloud text\n")
+		assert.Equal(t, 0, pointerWinsStage(context.Background(), local, f))
+	})
+
+	t.Run("both pointers with different OIDs: no opinion", func(t *testing.T) {
+		p1 := lfsPointer("1111111111111111111111111111111111111111111111111111111111111111", 10)
+		p2 := lfsPointer("2222222222222222222222222222222222222222222222222222222222222222", 20)
+		_, local := setupDivergentRepos(t, f, p1, p2)
+		assert.Equal(t, 0, pointerWinsStage(context.Background(), local, f),
+			"neither side risks the LFS linkage, so the guard must not interfere")
+	})
+}
+
+func TestIsLFSPointerBlob(t *testing.T) {
+	t.Parallel()
+	valid := lfsPointer("deadbeef00000000000000000000000000000000000000000000000000000000", 42)
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"canonical pointer", valid, true},
+		{"markdown", "# Agent Session\n\nsome notes\n", false},
+		{"empty", "", false},
+		{"json meta", `{"session_name":"x","entry_count":2}`, false},
+		// A file that merely mentions the spec URL deep in its body is content,
+		// not a pointer — the marker must be a prefix.
+		{"mentions spec url but is content", "see version https://git-lfs.github.com/spec/v1 for details", false},
+		// Oversized input can't be a pointer even with the right prefix; this
+		// stops a hydrated file that happens to begin with the marker from being
+		// misclassified as safe to keep.
+		{"prefix but oversized", valid + string(make([]byte, maxLFSPointerSize)), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isLFSPointerBlob(tt.content))
+		})
+	}
+}

--- a/internal/gitutil/safety.go
+++ b/internal/gitutil/safety.go
@@ -5,6 +5,7 @@ package gitutil
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,17 +24,46 @@ var knownLockFiles = []string{
 	"HEAD.lock",
 }
 
-// HasLockFiles checks .git/ for stale lock files that block git operations.
-// Returns the names of lock files found (empty slice = safe to proceed).
-func HasLockFiles(gitDir string) []string {
+// knownLockGlobs are lock-file patterns whose exact name isn't predictable.
+// git writes .git/next-index-<pid>.lock while rebuilding the index; a process
+// killed mid-write leaves one behind, and because the pid varies it can never
+// be enumerated in knownLockFiles.
+//
+// Deliberately NOT a broad "*.lock": that would sweep packed-refs.lock and
+// ref-transaction locks, which belong to operations we must not interfere with.
+var knownLockGlobs = []string{
+	"next-index-*.lock",
+}
+
+// lockFilesIn returns the .git-relative names of every lock file present,
+// covering both the fixed names and the pid-suffixed globs. Shared by
+// HasLockFiles and RemoveStaleLockFiles so the two can never drift — a lock
+// that one detects but the other cannot clear is a permanent wedge, which is
+// exactly how a ledger sat blocked for three months on a stray
+// next-index-13088.lock.
+func lockFilesIn(gitDir string) []string {
 	var found []string
 	for _, lock := range knownLockFiles {
-		path := filepath.Join(gitDir, lock)
-		if _, err := os.Stat(path); err == nil {
+		if _, err := os.Stat(filepath.Join(gitDir, lock)); err == nil {
 			found = append(found, lock)
 		}
 	}
+	for _, pattern := range knownLockGlobs {
+		matches, err := filepath.Glob(filepath.Join(gitDir, pattern))
+		if err != nil {
+			continue // malformed pattern — treat as no match
+		}
+		for _, m := range matches {
+			found = append(found, filepath.Base(m))
+		}
+	}
 	return found
+}
+
+// HasLockFiles checks .git/ for stale lock files that block git operations.
+// Returns the names of lock files found (empty slice = safe to proceed).
+func HasLockFiles(gitDir string) []string {
+	return lockFilesIn(gitDir)
 }
 
 // StaleLockAge is how old a git lock file must be before we consider it abandoned.
@@ -48,7 +78,7 @@ const StaleLockAge = 5 * time.Minute
 // files that no running git process could still be holding.
 // Returns the names of files removed and any removal errors encountered.
 func RemoveStaleLockFiles(gitDir string) (removed []string, errs []error) {
-	for _, lock := range knownLockFiles {
+	for _, lock := range lockFilesIn(gitDir) {
 		path := filepath.Join(gitDir, lock)
 		info, err := os.Stat(path)
 		if err != nil {
@@ -129,6 +159,15 @@ func RebaseAge(repoPath string) (time.Duration, bool) {
 // why the repo is blocked.
 func IsSafeForGitOps(repoPath string) error {
 	gitDir := filepath.Join(repoPath, ".git")
+
+	// Sweep abandoned locks before reporting them as blocking. Without this the
+	// push path is asymmetric with the pull path (which already sweeps before
+	// every pull), so a lock left by a crashed git blocks every future push
+	// forever with no self-heal. Gated on StaleLockAge, so a lock held by a
+	// live git process is never touched.
+	if removed, errs := RemoveStaleLockFiles(gitDir); len(removed) > 0 || len(errs) > 0 {
+		slog.Info("git lock sweep", "repo", repoPath, "removed", strings.Join(removed, ","), "errors", len(errs))
+	}
 
 	if locks := HasLockFiles(gitDir); len(locks) > 0 {
 		return fmt.Errorf("git lock files detected: %s (remove stale locks or wait for in-progress operation)", strings.Join(locks, ", "))

--- a/internal/gitutil/safety.go
+++ b/internal/gitutil/safety.go
@@ -123,6 +123,20 @@ func processAlive(pid int) bool {
 // while still recovering from crashed processes.
 const StaleLockAge = 5 * time.Minute
 
+// AbandonedLockAge is how old an OWNERLESS lock (index.lock, shallow.lock,
+// config.lock, HEAD.lock) must be before it is treated as abandoned.
+//
+// Much longer than StaleLockAge on purpose. Those files carry no PID, so there
+// is no owner to probe and age is the only signal — and five minutes is not a
+// safe bound: a slow `git pull --rebase` on a large repo over a bad network can
+// legitimately hold the index longer than that, and deleting the lock would
+// admit a second writer and risk index corruption or lost uncommitted work.
+//
+// No index operation stays live for an hour. A lock that old is a crash, which
+// is the case worth recovering from — the real incident was a
+// next-index-<pid>.lock plus an index.lock sitting untouched for three months.
+const AbandonedLockAge = 1 * time.Hour
+
 // RemoveStaleLockFiles removes git lock files older than StaleLockAge.
 // Safe to call at daemon startup or before pull operations — only removes
 // files that no running git process could still be holding.
@@ -137,16 +151,25 @@ func RemoveStaleLockFiles(gitDir string) (removed []string, errs []error) {
 			}
 			continue
 		}
-		// Owner liveness beats age whenever the owner is knowable. A
-		// next-index-<pid>.lock names the process that created it, so a live
-		// owner means the lock is legitimately held no matter how old it is —
-		// removing it there could let a second writer scribble over the index
-		// mid-write. Age is only a fallback for locks that carry no owner.
-		if pid, ok := lockOwnerPID(lock); ok && processAlive(pid) {
+		age := time.Since(info.ModTime())
+		if pid, ok := lockOwnerPID(lock); ok {
+			// Owner is knowable: liveness decides, and it overrides age
+			// entirely. A live owner means the lock is legitimately held no
+			// matter how old it is — removing it could let a second writer
+			// scribble over the index mid-write.
+			if processAlive(pid) {
+				continue
+			}
+			if age < StaleLockAge {
+				continue // owner is gone, but give a just-exited process room
+			}
+		} else if age < AbandonedLockAge {
+			// Ownerless lock. git's index.lock IS the lock — no PID to probe —
+			// so age is the only available signal, and it is a weak one: a slow
+			// legitimate operation CAN hold the index past StaleLockAge. Require
+			// a threshold no plausible index operation reaches before assuming
+			// abandonment, so a live writer is never displaced.
 			continue
-		}
-		if time.Since(info.ModTime()) < StaleLockAge {
-			continue // recent enough to be from an active process
 		}
 		if err := os.Remove(path); err != nil {
 			errs = append(errs, fmt.Errorf("remove %s: %w", lock, err))

--- a/internal/gitutil/safety.go
+++ b/internal/gitutil/safety.go
@@ -8,7 +8,10 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -66,6 +69,53 @@ func HasLockFiles(gitDir string) []string {
 	return lockFilesIn(gitDir)
 }
 
+// lockOwnerPID extracts the owning process ID from a lock filename that encodes
+// one. Today that is only git's next-index-<pid>.lock.
+//
+// Returns ok=false for locks that carry no owner information. git's index.lock
+// is the canonical example: it IS the lock (its content is the partially-written
+// index, not metadata), so there is no owner to interrogate and age is the only
+// signal available. That is a property of git's on-disk format, not a shortcut.
+func lockOwnerPID(lockName string) (int, bool) {
+	const prefix, suffix = "next-index-", ".lock"
+	if !strings.HasPrefix(lockName, prefix) || !strings.HasSuffix(lockName, suffix) {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(lockName, prefix), suffix))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// processAlive reports whether pid names a running process.
+//
+// Biased toward reporting "alive": a false positive merely leaves a lock in
+// place (recoverable — the next sweep retries), while a false negative deletes a
+// lock a live git still holds, which can corrupt the index and lose uncommitted
+// work. Ambiguity therefore resolves to alive.
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false // Windows: the process does not exist
+	}
+	if runtime.GOOS == "windows" {
+		// FindProcess succeeding is as much as we can cheaply establish here,
+		// and the conservative reading is "still running".
+		return true
+	}
+	// Unix: FindProcess always succeeds, so probe with signal 0.
+	err = proc.Signal(syscall.Signal(0))
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, os.ErrPermission):
+		return true // alive, just owned by another user
+	default:
+		return false // ESRCH — no such process
+	}
+}
+
 // StaleLockAge is how old a git lock file must be before we consider it abandoned.
 // Git operations normally hold locks for milliseconds to a few seconds, but a slow
 // git pull --rebase on a large repo over a poor network can hold index.lock for
@@ -85,6 +135,14 @@ func RemoveStaleLockFiles(gitDir string) (removed []string, errs []error) {
 			if !errors.Is(err, os.ErrNotExist) {
 				errs = append(errs, fmt.Errorf("stat %s: %w", lock, err))
 			}
+			continue
+		}
+		// Owner liveness beats age whenever the owner is knowable. A
+		// next-index-<pid>.lock names the process that created it, so a live
+		// owner means the lock is legitimately held no matter how old it is —
+		// removing it there could let a second writer scribble over the index
+		// mid-write. Age is only a fallback for locks that carry no owner.
+		if pid, ok := lockOwnerPID(lock); ok && processAlive(pid) {
 			continue
 		}
 		if time.Since(info.ModTime()) < StaleLockAge {

--- a/internal/gitutil/safety_test.go
+++ b/internal/gitutil/safety_test.go
@@ -63,7 +63,7 @@ func TestRemoveStaleLockFiles(t *testing.T) {
 		lockPath := filepath.Join(gitDir, "index.lock")
 		require.NoError(t, os.WriteFile(lockPath, []byte{}, 0644))
 		// backdate to look old
-		oldTime := time.Now().Add(-(StaleLockAge + time.Second))
+		oldTime := time.Now().Add(-(AbandonedLockAge + time.Second))
 		require.NoError(t, os.Chtimes(lockPath, oldTime, oldTime))
 
 		removed, errs := RemoveStaleLockFiles(gitDir)
@@ -354,7 +354,7 @@ func TestFetchHeadAge(t *testing.T) {
 // the pull path. Detection and removal must agree, and IsSafeForGitOps must
 // self-heal an abandoned lock rather than blocking forever.
 func TestLockSweep_PidSuffixedAndSelfHealing(t *testing.T) {
-	stale := time.Now().Add(-2 * StaleLockAge)
+	stale := time.Now().Add(-2 * AbandonedLockAge)
 
 	newGitDir := func(t *testing.T) (repo, gitDir string) {
 		t.Helper()
@@ -440,7 +440,7 @@ func TestLockSweep_PidSuffixedAndSelfHealing(t *testing.T) {
 // content is the partially-written index), so no owner exists to interrogate and
 // age remains the only available signal there.
 func TestLockSweep_OwnerLivenessBeatsAge(t *testing.T) {
-	ancient := time.Now().Add(-100 * StaleLockAge)
+	ancient := time.Now().Add(-100 * AbandonedLockAge)
 
 	writeAged := func(t *testing.T, gitDir, name string) string {
 		t.Helper()
@@ -529,4 +529,37 @@ func TestLockOwnerPID(t *testing.T) {
 func TestProcessAlive(t *testing.T) {
 	assert.True(t, processAlive(os.Getpid()), "our own process is alive")
 	assert.False(t, processAlive(2147483647), "an implausible PID is not alive")
+}
+
+// TestLockSweep_OwnerlessLockSurvivesTheStaleWindow is the direct regression for
+// the review finding that age alone can displace a live writer.
+//
+// Failure prevented: a legitimate `git pull --rebase` on a large repo over a bad
+// network holds index.lock for more than StaleLockAge; a push preflight that
+// swept at that threshold would delete an ACTIVE lock, admit a second writer,
+// and risk index corruption or lost uncommitted changes. index.lock carries no
+// PID (it IS the lock), so no owner probe is possible and the only safe move is
+// a threshold no real index operation reaches.
+func TestLockSweep_OwnerlessLockSurvivesTheStaleWindow(t *testing.T) {
+	for _, lock := range []string{"index.lock", "shallow.lock", "config.lock", "HEAD.lock"} {
+		t.Run(lock+" held past StaleLockAge is retained", func(t *testing.T) {
+			repo := t.TempDir()
+			gitDir := filepath.Join(repo, ".git")
+			require.NoError(t, os.MkdirAll(gitDir, 0755))
+			p := filepath.Join(gitDir, lock)
+			require.NoError(t, os.WriteFile(p, []byte("lock"), 0644))
+
+			// Comfortably past the old 5-minute bar, far short of abandonment.
+			held := time.Now().Add(-(StaleLockAge * 3))
+			require.NoError(t, os.Chtimes(p, held, held))
+
+			removed, errs := RemoveStaleLockFiles(gitDir)
+			assert.Empty(t, errs)
+			assert.Empty(t, removed,
+				"a slow but legitimate git operation must not have its lock deleted")
+			assert.FileExists(t, p)
+			assert.Error(t, IsSafeForGitOps(repo),
+				"the repo must stay blocked while a writer may still hold the index")
+		})
+	}
 }

--- a/internal/gitutil/safety_test.go
+++ b/internal/gitutil/safety_test.go
@@ -345,3 +345,87 @@ func TestFetchHeadAge(t *testing.T) {
 		assert.Greater(t, age, 4*time.Minute)
 	})
 }
+
+// TestLockSweep_PidSuffixedAndSelfHealing covers the wedge that kept a real
+// ledger blocked for three months: a next-index-<pid>.lock left by a crashed
+// git. Its pid varies, so it can never be listed in knownLockFiles, and the
+// push pre-flight only ever *reported* locks — it never cleared them, unlike
+// the pull path. Detection and removal must agree, and IsSafeForGitOps must
+// self-heal an abandoned lock rather than blocking forever.
+func TestLockSweep_PidSuffixedAndSelfHealing(t *testing.T) {
+	stale := time.Now().Add(-2 * StaleLockAge)
+
+	newGitDir := func(t *testing.T) (repo, gitDir string) {
+		t.Helper()
+		repo = t.TempDir()
+		gitDir = filepath.Join(repo, ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+		return repo, gitDir
+	}
+
+	writeLock := func(t *testing.T, gitDir, name string, mtime time.Time) string {
+		t.Helper()
+		p := filepath.Join(gitDir, name)
+		require.NoError(t, os.WriteFile(p, []byte("lock"), 0644))
+		require.NoError(t, os.Chtimes(p, mtime, mtime))
+		return p
+	}
+
+	t.Run("pid-suffixed next-index lock is detected", func(t *testing.T) {
+		_, gitDir := newGitDir(t)
+		writeLock(t, gitDir, "next-index-13088.lock", stale)
+
+		assert.Contains(t, HasLockFiles(gitDir), "next-index-13088.lock",
+			"a lock we cannot detect is a lock we can never clear")
+	})
+
+	t.Run("pid-suffixed next-index lock is removable when stale", func(t *testing.T) {
+		_, gitDir := newGitDir(t)
+		p := writeLock(t, gitDir, "next-index-13088.lock", stale)
+
+		removed, errs := RemoveStaleLockFiles(gitDir)
+		assert.Empty(t, errs)
+		assert.Contains(t, removed, "next-index-13088.lock")
+		assert.NoFileExists(t, p)
+	})
+
+	t.Run("fresh locks are never swept", func(t *testing.T) {
+		_, gitDir := newGitDir(t)
+		fresh := writeLock(t, gitDir, "next-index-999.lock", time.Now())
+		freshIndex := writeLock(t, gitDir, "index.lock", time.Now())
+
+		removed, errs := RemoveStaleLockFiles(gitDir)
+		assert.Empty(t, errs)
+		assert.Empty(t, removed, "a live git process must not have its lock yanked")
+		assert.FileExists(t, fresh)
+		assert.FileExists(t, freshIndex)
+	})
+
+	t.Run("ref locks are left alone", func(t *testing.T) {
+		_, gitDir := newGitDir(t)
+		// packed-refs.lock belongs to a ref transaction, not the index. A broad
+		// "*.lock" sweep would eat it; we must not.
+		packed := writeLock(t, gitDir, "packed-refs.lock", stale)
+
+		removed, _ := RemoveStaleLockFiles(gitDir)
+		assert.NotContains(t, removed, "packed-refs.lock")
+		assert.FileExists(t, packed)
+	})
+
+	t.Run("IsSafeForGitOps self-heals an abandoned lock", func(t *testing.T) {
+		repo, gitDir := newGitDir(t)
+		p := writeLock(t, gitDir, "index.lock", stale)
+
+		assert.NoError(t, IsSafeForGitOps(repo),
+			"an abandoned lock must not block pushes forever")
+		assert.NoFileExists(t, p)
+	})
+
+	t.Run("IsSafeForGitOps still blocks on a live lock", func(t *testing.T) {
+		repo, gitDir := newGitDir(t)
+		writeLock(t, gitDir, "index.lock", time.Now())
+
+		assert.Error(t, IsSafeForGitOps(repo),
+			"a lock a running git may still hold must block")
+	})
+}

--- a/internal/gitutil/safety_test.go
+++ b/internal/gitutil/safety_test.go
@@ -1,6 +1,7 @@
 package gitutil
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -428,4 +429,104 @@ func TestLockSweep_PidSuffixedAndSelfHealing(t *testing.T) {
 		assert.Error(t, IsSafeForGitOps(repo),
 			"a lock a running git may still hold must block")
 	})
+}
+
+// TestLockSweep_OwnerLivenessBeatsAge covers the case age alone gets wrong:
+// a lock whose owning process is STILL RUNNING must survive the sweep no matter
+// how old it is. Deleting it would let a second writer into the index mid-write
+// and lose uncommitted work — the one outcome worse than a blocked push.
+//
+// Only next-index-<pid>.lock encodes an owner. git's index.lock IS the lock (its
+// content is the partially-written index), so no owner exists to interrogate and
+// age remains the only available signal there.
+func TestLockSweep_OwnerLivenessBeatsAge(t *testing.T) {
+	ancient := time.Now().Add(-100 * StaleLockAge)
+
+	writeAged := func(t *testing.T, gitDir, name string) string {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+		p := filepath.Join(gitDir, name)
+		require.NoError(t, os.WriteFile(p, []byte("lock"), 0644))
+		require.NoError(t, os.Chtimes(p, ancient, ancient))
+		return p
+	}
+
+	t.Run("live owner retains the lock despite extreme age", func(t *testing.T) {
+		gitDir := filepath.Join(t.TempDir(), ".git")
+		// Our own PID is guaranteed alive for the duration of this test.
+		p := writeAged(t, gitDir, fmt.Sprintf("next-index-%d.lock", os.Getpid()))
+
+		removed, errs := RemoveStaleLockFiles(gitDir)
+		assert.Empty(t, errs)
+		assert.Empty(t, removed, "a lock held by a LIVE process must never be removed")
+		assert.FileExists(t, p, "removing it could corrupt the index mid-write")
+
+		// And the repo must stay blocked rather than silently proceeding.
+		assert.Error(t, IsSafeForGitOps(filepath.Dir(gitDir)),
+			"an actively-held lock must keep blocking git operations")
+	})
+
+	t.Run("dead owner allows removal", func(t *testing.T) {
+		gitDir := filepath.Join(t.TempDir(), ".git")
+		// PID 0x7FFFFFFF is not a live process on any realistic system.
+		p := writeAged(t, gitDir, "next-index-2147483647.lock")
+
+		removed, errs := RemoveStaleLockFiles(gitDir)
+		assert.Empty(t, errs)
+		assert.Contains(t, removed, "next-index-2147483647.lock",
+			"a lock whose owner is verifiably gone is abandoned")
+		assert.NoFileExists(t, p)
+	})
+
+	t.Run("ownerless lock still falls back to age", func(t *testing.T) {
+		// index.lock carries no PID, so age is the only signal git's format offers.
+		gitDir := filepath.Join(t.TempDir(), ".git")
+		p := writeAged(t, gitDir, "index.lock")
+
+		removed, _ := RemoveStaleLockFiles(gitDir)
+		assert.Contains(t, removed, "index.lock")
+		assert.NoFileExists(t, p)
+	})
+
+	t.Run("ownerless lock younger than StaleLockAge is retained", func(t *testing.T) {
+		gitDir := filepath.Join(t.TempDir(), ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0755))
+		p := filepath.Join(gitDir, "index.lock")
+		require.NoError(t, os.WriteFile(p, []byte("lock"), 0644))
+
+		removed, _ := RemoveStaleLockFiles(gitDir)
+		assert.Empty(t, removed, "a lock a running git may still hold must survive")
+		assert.FileExists(t, p)
+	})
+}
+
+func TestLockOwnerPID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		lock    string
+		wantPID int
+		wantOK  bool
+	}{
+		{"next-index with pid", "next-index-13088.lock", 13088, true},
+		{"index.lock has no owner", "index.lock", 0, false},
+		{"shallow.lock has no owner", "shallow.lock", 0, false},
+		{"non-numeric pid", "next-index-abc.lock", 0, false},
+		{"empty pid", "next-index-.lock", 0, false},
+		{"zero pid rejected", "next-index-0.lock", 0, false},
+		{"negative pid rejected", "next-index--5.lock", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pid, ok := lockOwnerPID(tt.lock)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantPID, pid)
+		})
+	}
+}
+
+func TestProcessAlive(t *testing.T) {
+	assert.True(t, processAlive(os.Getpid()), "our own process is alive")
+	assert.False(t, processAlive(2147483647), "an implausible PID is not alive")
 }

--- a/internal/gitutil/wedge_harness_test.go
+++ b/internal/gitutil/wedge_harness_test.go
@@ -1,0 +1,401 @@
+package gitutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A ledger wedge is any persistent state that stops a ledger from ever syncing
+// again without a human running git by hand. Every wedge that reached production
+// gets a case here, driven against a REAL bare remote and REAL clones — never a
+// mock — because every one of these bugs survived unit tests that mocked the
+// thing that actually broke.
+//
+// The contract each case asserts is the same three-part one, and all three parts
+// are required. A test that only checks the first part is how these shipped:
+//
+//	1. the wedge is DETECTED
+//	2. the repair CLEARS it
+//	3. the ledger MAKES PROGRESS afterward — the next pull+push actually lands
+//
+// Part 3 is the one that matters. `git rebase --abort` "succeeding" while the
+// ledger stays permanently un-syncable is the exact shape of the 13-day,
+// 341-ahead/1055-behind production wedge.
+
+// ledgerFixture is a real bare remote plus a local clone and a second clone
+// standing in for the cloud summarizer. Reuse this for any new wedge case
+// rather than hand-rolling another repo setup.
+type ledgerFixture struct {
+	t     *testing.T
+	bare  string
+	local string // the machine under test
+	cloud string // the other writer (cloud summarizer / a teammate)
+}
+
+func newLedgerFixture(t *testing.T) *ledgerFixture {
+	t.Helper()
+	root := t.TempDir()
+	f := &ledgerFixture{
+		t:     t,
+		bare:  filepath.Join(root, "bare.git"),
+		local: filepath.Join(root, "local"),
+		cloud: filepath.Join(root, "cloud"),
+	}
+	gitInRepo(t, root, "init", "--bare", "--initial-branch=main", f.bare)
+	gitInRepo(t, root, "clone", f.bare, f.cloud)
+	f.write(f.cloud, "sessions/s1/meta.json", `{"session_name":"s1","summary_status":""}`)
+	f.git(f.cloud, "add", "-A")
+	f.git(f.cloud, "commit", "-m", "seed")
+	f.git(f.cloud, "push", "origin", "main")
+	gitInRepo(t, root, "clone", f.bare, f.local)
+	return f
+}
+
+func (f *ledgerFixture) git(dir string, args ...string) string {
+	f.t.Helper()
+	return gitInRepo(f.t, dir, args...)
+}
+
+// gitAllowFail runs git and returns output plus whether it succeeded. Needed for
+// the steps that are SUPPOSED to fail while the repo is wedged.
+func (f *ledgerFixture) gitAllowFail(dir string, args ...string) (string, bool) {
+	f.t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), // safe: git subprocess in a temp fixture repo, not the ox CLI
+		"GIT_CONFIG_NOSYSTEM=1", "GIT_TERMINAL_PROMPT=0",
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+		"GIT_CONFIG_COUNT=1", "GIT_CONFIG_KEY_0=commit.gpgsign", "GIT_CONFIG_VALUE_0=false",
+	)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err == nil
+}
+
+func (f *ledgerFixture) write(dir, rel, content string) {
+	f.t.Helper()
+	p := filepath.Join(dir, rel)
+	require.NoError(f.t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(f.t, os.WriteFile(p, []byte(content), 0o644))
+}
+
+func (f *ledgerFixture) commitAll(dir, msg string) {
+	f.t.Helper()
+	f.git(dir, "add", "-A")
+	f.git(dir, "commit", "-m", msg)
+}
+
+// cloudWrites simulates the summarizer landing work on the remote.
+func (f *ledgerFixture) cloudWrites(rel, content, msg string) {
+	f.t.Helper()
+	f.git(f.cloud, "pull", "--rebase")
+	f.write(f.cloud, rel, content)
+	f.commitAll(f.cloud, msg)
+	f.git(f.cloud, "push", "origin", "main")
+}
+
+// diverge puts BOTH sides ahead on the same path — the precondition for every
+// content-conflict wedge.
+func (f *ledgerFixture) diverge(rel, localContent, cloudContent string) {
+	f.t.Helper()
+	f.cloudWrites(rel, cloudContent, "cloud update")
+	f.write(f.local, rel, localContent)
+	f.commitAll(f.local, "local update")
+	f.git(f.local, "fetch", "origin")
+}
+
+// reconcile runs the production repair path: pull --rebase, then the resolver,
+// looping until the rebase completes. Returns the number of resolve rounds.
+func (f *ledgerFixture) reconcile(prefixes []string) (int, error) {
+	f.t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	f.gitAllowFail(f.local, "pull", "--rebase", "--autostash")
+	rounds := 0
+	for IsRebaseInProgress(f.local) {
+		if err := ResolveRebaseAcceptTheirs(ctx, f.local, prefixes); err != nil {
+			return rounds, err
+		}
+		rounds++
+		if rounds > 100 {
+			return rounds, fmt.Errorf("no convergence after %d rounds", rounds)
+		}
+	}
+	return rounds, nil
+}
+
+// assertMakesProgress is the part-3 check. A repair that leaves the ledger
+// un-pushable has not fixed anything, however clean its own exit code was.
+func (f *ledgerFixture) assertMakesProgress() {
+	f.t.Helper()
+	f.write(f.local, "sessions/s1/probe.txt", "post-repair write")
+	f.commitAll(f.local, "post-repair commit")
+
+	// A repaired ledger must be able to complete a normal sync cycle. Pulling
+	// first is part of that cycle — the point is that nothing WEDGES, not that
+	// the local happened to already be up to date.
+	if out, ok := f.gitAllowFail(f.local, "pull", "--rebase", "--autostash"); !ok {
+		f.t.Fatalf("ledger still cannot pull after repair — wedge NOT cleared:\n%s", out)
+	}
+	if out, ok := f.gitAllowFail(f.local, "push", "origin", "main"); !ok {
+		f.t.Fatalf("ledger still cannot push after repair — wedge NOT cleared:\n%s", out)
+	}
+	behind := f.git(f.local, "rev-list", "--count", "HEAD..origin/main")
+	assert.Equal(f.t, "0", behind, "local must be fully reconciled with the remote")
+}
+
+func (f *ledgerFixture) fileContent(rel string) string {
+	f.t.Helper()
+	data, err := os.ReadFile(filepath.Join(f.local, rel))
+	require.NoError(f.t, err)
+	return string(data)
+}
+
+// --- A. The headline wedge: sessions/ conflicts ---
+
+// TestWedge_SessionsMetaConflict_SelfHeals is the regression test for the
+// production wedge: sessions/<id>/meta.json is written by both the cloud
+// summarizer and the local CLI, and with no resolve rule the rebase halted,
+// aborted, restored the pre-rebase state, and failed identically forever.
+//
+// Failure prevented: 281 conflicts, 341 unpushed commits, 13 days, zero
+// escalation — and the repair loop "succeeding" every cycle while making no
+// progress at all.
+func TestWedge_SessionsMetaConflict_SelfHeals(t *testing.T) {
+	f := newLedgerFixture(t)
+	const meta = "sessions/s1/meta.json"
+
+	f.diverge(meta,
+		`{"session_name":"s1","summary_status":"unrecoverable","summary_attempts":3}`,
+		`{"session_name":"s1","summary_status":"ok","title":"Real summary"}`)
+
+	// 1. detected: with the rebase actually halted, and without a sessions/
+	// rule, the resolver refuses rather than silently doing something wrong.
+	ctx := context.Background()
+	f.gitAllowFail(f.local, "pull", "--rebase", "--autostash")
+	require.True(t, IsRebaseInProgress(f.local), "fixture must be genuinely wedged")
+	err := ResolveRebaseAcceptTheirs(ctx, f.local, []string{"data/"})
+	require.Error(t, err, "must refuse when sessions/ is not an auto-resolve prefix")
+	assert.Contains(t, err.Error(), "not under safe auto-resolve prefixes")
+
+	// 2. cleared, and 3. progress — with the rule in place.
+	_ = AuditAndAbort(ctx, f.local, AuditOpRebase, "test reset", nil)
+	rounds, rerr := f.reconcile([]string{"data/", "sessions/"})
+	require.NoError(t, rerr, "sessions/ conflicts must auto-resolve")
+	assert.Positive(t, rounds, "the conflict must actually have been resolved, not skipped")
+	f.assertMakesProgress()
+}
+
+// TestWedge_RepairIsIdempotent_NoInfinitePingPong guards the property that
+// actually terminates the loop. A resolution that itself re-diverges produces
+// commits and green exit codes on every cycle while never converging — it reads
+// as recovery and is not.
+func TestWedge_RepairIsIdempotent_NoInfinitePingPong(t *testing.T) {
+	f := newLedgerFixture(t)
+	const meta = "sessions/s1/meta.json"
+
+	f.diverge(meta, `{"s":"local"}`, `{"s":"cloud"}`)
+	_, err := f.reconcile([]string{"sessions/"})
+	require.NoError(t, err)
+	f.assertMakesProgress()
+
+	resolved := f.fileContent(meta)
+
+	// Re-running the whole cycle must be a no-op, not another conflict.
+	f.git(f.local, "fetch", "origin")
+	rounds, err := f.reconcile([]string{"sessions/"})
+	require.NoError(t, err)
+	assert.Zero(t, rounds, "a settled ledger must not re-conflict with itself")
+	assert.Equal(t, resolved, f.fileContent(meta), "resolution must be stable")
+}
+
+// --- B. The LFS pointer invariant ---
+
+// TestWedge_PointerNeverLosesToHydratedContent covers the failure that would
+// have been CREATED by fixing wedge A naively.
+//
+// Failure prevented: committing hydrated bytes over an LFS pointer breaks the
+// LFS linkage, and every later push is rejected with "LFS objects are missing"
+// — a permanent repo-wide wedge strictly worse than the one being fixed
+// (.claude/rules/cache-only-design.md, 2026-04-25 incident).
+func TestWedge_PointerNeverLosesToHydratedContent(t *testing.T) {
+	pointer := lfsPointer("aa11bb22cc33dd44ee55ff6677889900aabbccddeeff00112233445566778899", 8192)
+	hydrated := "# Agent Session\n\nhydrated bytes that must never be committed\n"
+
+	for _, tc := range []struct{ name, local, cloud string }{
+		{"pointer on cloud side", hydrated, pointer},
+		{"pointer on local side", pointer, hydrated},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newLedgerFixture(t)
+			const sessionMD = "sessions/s1/session.md"
+
+			f.diverge(sessionMD, tc.local, tc.cloud)
+			_, err := f.reconcile([]string{"sessions/"})
+			require.NoError(t, err)
+
+			assert.Equal(t, pointer, f.fileContent(sessionMD),
+				"the pointer must survive from EITHER side — that commutativity is what makes replicas converge")
+			f.assertMakesProgress()
+		})
+	}
+}
+
+// --- C. Stuck git operations ---
+
+// TestWedge_StaleLockBlocksPushForever covers the ledger that sat blocked for
+// three months on a next-index-<pid>.lock: the pid varies so it could not be
+// enumerated, and the push pre-flight only ever REPORTED locks while the pull
+// path swept them.
+func TestWedge_StaleLockBlocksPushForever(t *testing.T) {
+	for _, lock := range []string{"index.lock", "next-index-13088.lock", "shallow.lock"} {
+		t.Run(lock, func(t *testing.T) {
+			f := newLedgerFixture(t)
+			p := filepath.Join(f.local, ".git", lock)
+			require.NoError(t, os.WriteFile(p, []byte("stale"), 0o644))
+			old := time.Now().Add(-2 * StaleLockAge)
+			require.NoError(t, os.Chtimes(p, old, old))
+
+			// 1. detected
+			require.NotEmpty(t, HasLockFiles(filepath.Join(f.local, ".git")),
+				"a lock we cannot see is a lock we can never clear")
+
+			// 2. cleared by the production pre-flight, and 3. progress
+			require.NoError(t, IsSafeForGitOps(f.local), "abandoned lock must self-heal")
+			assert.NoFileExists(t, p)
+			f.assertMakesProgress()
+		})
+	}
+}
+
+// TestWedge_StaleRebaseDirBlocksEveryPull covers the abandoned rebase — every
+// subsequent pull fails with "already a rebase-merge directory" until cleared.
+func TestWedge_StaleRebaseDirBlocksEveryPull(t *testing.T) {
+	f := newLedgerFixture(t)
+	f.diverge("sessions/s1/meta.json", `{"s":"local"}`, `{"s":"cloud"}`)
+
+	// leave a real halted rebase behind
+	f.gitAllowFail(f.local, "pull", "--rebase", "--autostash")
+	require.True(t, IsRebaseInProgress(f.local), "fixture must actually be wedged")
+
+	// age it past the staleness threshold so it reads as abandoned, not in-flight
+	stale := time.Now().Add(-2 * StaleRebaseThreshold)
+	dir := filepath.Join(f.local, ".git", "rebase-merge")
+	if _, err := os.Stat(dir); err != nil {
+		dir = filepath.Join(f.local, ".git", "rebase-apply")
+	}
+	_ = filepath.Walk(dir, func(p string, _ os.FileInfo, _ error) error {
+		_ = os.Chtimes(p, stale, stale)
+		return nil
+	})
+	age, inProgress := RebaseAge(f.local)
+	require.True(t, inProgress)
+	assert.Greater(t, age, StaleRebaseThreshold, "must classify as stale, not fresh")
+
+	// 2. cleared
+	require.NoError(t, AbortOrClearRebase(context.Background(), f.local, "test", nil))
+	assert.False(t, IsRebaseInProgress(f.local), "the rebase dir must be gone")
+
+	// 3. progress. Clearing the rebase does not resolve the underlying content
+	// conflict — it restores the ability to reach the resolver at all. The wedge
+	// is only truly cleared if a normal reconcile now completes, which is exactly
+	// what "already a rebase-merge directory" used to make impossible forever.
+	_, err := f.reconcile([]string{"sessions/"})
+	require.NoError(t, err, "after clearing, the normal repair path must work")
+	f.assertMakesProgress()
+}
+
+// TestWedge_FreshRebaseIsNeverAborted is the inverse guard. Over-eager recovery
+// that yanks a rebase out from under the daemon's own in-flight pull corrupts
+// live work — a self-inflicted wedge.
+func TestWedge_FreshRebaseIsNeverAborted(t *testing.T) {
+	f := newLedgerFixture(t)
+	f.diverge("sessions/s1/meta.json", `{"s":"local"}`, `{"s":"cloud"}`)
+	f.gitAllowFail(f.local, "pull", "--rebase", "--autostash")
+	require.True(t, IsRebaseInProgress(f.local))
+
+	age, inProgress := RebaseAge(f.local)
+	require.True(t, inProgress)
+	assert.Less(t, age, StaleRebaseThreshold,
+		"a rebase started seconds ago must read as fresh so recovery leaves it alone")
+}
+
+// --- D. Divergence accounting ---
+
+// TestWedge_DivergenceDetectedAndConverges pins the ahead+behind case end to
+// end: detection must fire, and the repair must actually reach 0/0 rather than
+// merely returning success.
+func TestWedge_DivergenceDetectedAndConverges(t *testing.T) {
+	f := newLedgerFixture(t)
+	f.diverge("sessions/s1/meta.json", `{"s":"local"}`, `{"s":"cloud"}`)
+
+	ahead := f.git(f.local, "rev-list", "--count", "origin/main..HEAD")
+	behind := f.git(f.local, "rev-list", "--count", "HEAD..origin/main")
+	require.NotEqual(t, "0", ahead, "fixture must be genuinely diverged")
+	require.NotEqual(t, "0", behind)
+
+	_, err := f.reconcile([]string{"sessions/"})
+	require.NoError(t, err)
+	f.assertMakesProgress()
+
+	assert.Equal(t, "0", f.git(f.local, "rev-list", "--count", "HEAD..origin/main"),
+		"reconcile must converge, not just exit cleanly")
+}
+
+// TestWedge_ManyConflictsConvergeInBoundedRounds guards against a repair that
+// resolves one conflict per pass and effectively never finishes on a ledger
+// carrying hundreds of them — the real one had 281.
+func TestWedge_ManyConflictsConvergeInBoundedRounds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: drives many real git commits")
+	}
+	f := newLedgerFixture(t)
+
+	const n = 25
+	for i := 0; i < n; i++ {
+		f.write(f.cloud, fmt.Sprintf("sessions/s%d/meta.json", i), `{"s":"cloud"}`)
+	}
+	f.commitAll(f.cloud, "cloud batch")
+	f.git(f.cloud, "push", "origin", "main")
+
+	for i := 0; i < n; i++ {
+		f.write(f.local, fmt.Sprintf("sessions/s%d/meta.json", i), `{"s":"local"}`)
+	}
+	f.commitAll(f.local, "local batch")
+	f.git(f.local, "fetch", "origin")
+
+	rounds, err := f.reconcile([]string{"sessions/"})
+	require.NoError(t, err)
+	assert.LessOrEqual(t, rounds, 5,
+		"conflicts must resolve in batches per replayed commit, not one round per file")
+	f.assertMakesProgress()
+}
+
+// --- E. Paths that must still be refused ---
+
+// TestWedge_NonSessionConflictsStillRefuseAutoResolve ensures widening the
+// auto-resolve set to sessions/ did not quietly make human-authored content
+// last-writer-wins too.
+func TestWedge_NonSessionConflictsStillRefuseAutoResolve(t *testing.T) {
+	for _, path := range []string{"AGENTS.md", "docs/architecture.md", "MEMORY.md"} {
+		t.Run(path, func(t *testing.T) {
+			f := newLedgerFixture(t)
+			f.diverge(path, "local edit\n", "cloud edit\n")
+			f.gitAllowFail(f.local, "pull", "--rebase", "--autostash")
+
+			err := ResolveRebaseAcceptTheirs(context.Background(), f.local, []string{"data/", "sessions/"})
+			require.Error(t, err, "human-authored content must never auto-resolve")
+			assert.Contains(t, err.Error(), "not under safe auto-resolve prefixes")
+		})
+	}
+}

--- a/internal/gitutil/wedge_harness_test.go
+++ b/internal/gitutil/wedge_harness_test.go
@@ -263,7 +263,9 @@ func TestWedge_StaleLockBlocksPushForever(t *testing.T) {
 			f := newLedgerFixture(t)
 			p := filepath.Join(f.local, ".git", lock)
 			require.NoError(t, os.WriteFile(p, []byte("stale"), 0o644))
-			old := time.Now().Add(-2 * StaleLockAge)
+			// ownerless locks (index.lock, shallow.lock) require AbandonedLockAge;
+			// pid-encoded ones are decided by owner liveness, so this covers both
+			old := time.Now().Add(-2 * AbandonedLockAge)
 			require.NoError(t, os.Chtimes(p, old, old))
 
 			// 1. detected

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -37,6 +37,14 @@ import (
 // Delegates to manifest defaults so the set is configurable via
 // .sageox/sync.manifest without a code change. CLI callers (session upload,
 // doctor) use this; the daemon reads from the manifest directly when available.
+//
+// NOTE: sessions/ is deliberately NOT auto-resolved yet. Doing so is the
+// obvious fix for the sessions/*/meta.json wedge, but it is not safe until the
+// LFS pointer-vs-hydrated conflict class is handled — see bd ox-zmjc. On a real
+// wedged ledger every mixed content conflict is local=hydrated / remote=pointer,
+// and accept-theirs resolves to the LOCAL side during a rebase, which would
+// commit hydrated bytes over the remote pointer and permanently break pushes
+// (.claude/rules/cache-only-design.md).
 var DefaultResolveRules = manifest.DefaultResolveRules
 
 // AutoResolvePrefixes extracts auto-resolve paths from the default rules.

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -33,23 +33,42 @@ import (
 	"github.com/sageox/ox/internal/repotools"
 )
 
-// DefaultResolveRules is the canonical set of resolve rules for the ledger.
-// Delegates to manifest defaults so the set is configurable via
-// .sageox/sync.manifest without a code change. CLI callers (session upload,
-// doctor) use this; the daemon reads from the manifest directly when available.
+// DefaultResolveRules is the canonical set of resolve rules for the ledger:
+// the manifest defaults (data/, covering the idempotent import paths) plus
+// sessions/.
 //
-// NOTE: sessions/ is deliberately NOT auto-resolved yet. Doing so is the
-// obvious fix for the sessions/*/meta.json wedge, but it is not safe until the
-// LFS pointer-vs-hydrated conflict class is handled — see bd ox-zmjc. On a real
-// wedged ledger every mixed content conflict is local=hydrated / remote=pointer,
-// and accept-theirs resolves to the LOCAL side during a rebase, which would
-// commit hydrated bytes over the remote pointer and permanently break pushes
-// (.claude/rules/cache-only-design.md).
-var DefaultResolveRules = manifest.DefaultResolveRules
+// Why sessions/ auto-resolves: sessions/<id>/meta.json is written by BOTH the
+// cloud summarizer and the local CLI, so it conflicts whenever both sides
+// touched the same session. With no rule the rebase halts, nothing can resolve
+// it, the abort restores the pre-rebase state, and the next attempt fails
+// identically — a deterministic wedge that never escalates and never self-heals.
+// One ledger sat 341 ahead / 1055 behind for 13 days with 281 such conflicts.
+//
+// Auto-resolving is acceptable because session artifacts are best-effort or
+// regenerable: title/summary/score are AI-generated and rebuildable via
+// `ox session regenerate`; entry_count is recomputed on every finalize; and
+// produced_commits / linked_prs / linked_issues / produced_plans are documented
+// in internal/lfs/meta.go as CACHES whose canonical source lives elsewhere (the
+// SageOx-Session commit trailer, the server-side PR reconciler, and each plan's
+// provenance.session_id). An imperfect summary beats a ledger that can never
+// sync again.
+//
+// SAFETY: this is only sound because gitutil.ResolveRebaseAcceptTheirs applies
+// pointer-wins before its positional rule. Session artifacts frequently conflict
+// as hydrated-bytes vs LFS-pointer, and committing the hydrated side breaks every
+// future push (.claude/rules/cache-only-design.md). Do not weaken that guard.
+//
+// NOTE: deliberately scoped to the LEDGER rather than added to
+// manifest.DefaultResolveRules, which also backs FallbackConfig() for team
+// contexts and project repos — neither has a sessions/ directory.
+var DefaultResolveRules = append(
+	append([]manifest.ResolveRule{}, manifest.DefaultResolveRules...),
+	manifest.ResolveRule{Mode: manifest.ResolveModeAuto, Path: "sessions/"},
+)
 
 // AutoResolvePrefixes extracts auto-resolve paths from the default rules.
 // Convenience for callers that need a flat []string (e.g., PushOpts).
-var AutoResolvePrefixes = manifest.AutoResolvePaths(manifest.DefaultResolveRules)
+var AutoResolvePrefixes = manifest.AutoResolvePaths(DefaultResolveRules)
 
 // ErrNotProvisioned indicates the ledger has not been provisioned by cloud and cloned.
 var ErrNotProvisioned = errors.New("ledger not provisioned")

--- a/internal/lfs/meta_test.go
+++ b/internal/lfs/meta_test.go
@@ -420,7 +420,7 @@ func TestWriteSessionMeta_PreservesGitContent_ReplacesLFSContent(t *testing.T) {
 		AgentType:   "claude-code",
 		CreatedAt:   time.Now(),
 		Files: map[string]FileRef{
-			"raw.jsonl":    {Storage: StorageLFS, OID: "sha256:abc", Size: int64(len(rawContent))},
+			"raw.jsonl":    {Storage: StorageLFS, OID: "sha256:" + ComputeOID(rawContent), Size: int64(len(rawContent))},
 			"summary.json": NewGitFileRef(int64(len(summaryContent))),
 		},
 	}
@@ -444,8 +444,10 @@ func TestWriteSessionMeta_ReplacesContentWithPointers(t *testing.T) {
 	require.NoError(t, os.MkdirAll(sessionDir, 0755))
 
 	// write real content files that simulate post-upload state
-	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"), []byte(`{"event":"test"}`), 0644))
-	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "summary.md"), []byte("# Summary"), 0644))
+	rawContent := []byte(`{"event":"test"}`)
+	summaryContent := []byte("# Summary")
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"), rawContent, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "summary.md"), summaryContent, 0644))
 
 	meta := &SessionMeta{
 		Version:     "1.0",
@@ -455,8 +457,8 @@ func TestWriteSessionMeta_ReplacesContentWithPointers(t *testing.T) {
 		AgentType:   "claude-code",
 		CreatedAt:   time.Now(),
 		Files: map[string]FileRef{
-			"raw.jsonl":  {OID: "sha256:abc123", Size: 16},
-			"summary.md": {OID: "sha256:def456", Size: 9},
+			"raw.jsonl":  {OID: "sha256:" + ComputeOID(rawContent), Size: 16},
+			"summary.md": {OID: "sha256:" + ComputeOID(summaryContent), Size: 9},
 		},
 	}
 
@@ -472,7 +474,7 @@ func TestWriteSessionMeta_ReplacesContentWithPointers(t *testing.T) {
 	// pointer files should round-trip correctly
 	ref, err := ReadPointerFile(filepath.Join(sessionDir, "raw.jsonl"))
 	require.NoError(t, err)
-	assert.Equal(t, "sha256:abc123", ref.OID)
+	assert.Equal(t, "sha256:"+ComputeOID(rawContent), ref.OID)
 	assert.Equal(t, int64(16), ref.Size)
 }
 
@@ -745,9 +747,12 @@ func TestWriteSessionMeta_WritesPointers_WriteSessionMetaOnlyDoesNot(t *testing.
 	rawContent := []byte(`{"type":"header"}`)
 	summaryContent := []byte("# Summary")
 
+	// OIDs are the real content hashes — that is what the upload path stores
+	// (meta.go builds each FileRef as "sha256:"+ComputeOID(content)), and
+	// WritePointerFile now refuses to pointerize content an OID doesn't describe.
 	files := map[string]FileRef{
-		"raw.jsonl":  {OID: "sha256:abc123", Size: int64(len(rawContent))},
-		"summary.md": {OID: "sha256:def456", Size: int64(len(summaryContent))},
+		"raw.jsonl":  {OID: "sha256:" + ComputeOID(rawContent), Size: int64(len(rawContent))},
+		"summary.md": {OID: "sha256:" + ComputeOID(summaryContent), Size: int64(len(summaryContent))},
 	}
 	meta := &SessionMeta{
 		Version:   "1.0",

--- a/internal/lfs/pointer.go
+++ b/internal/lfs/pointer.go
@@ -76,10 +76,47 @@ func ParsePointer(content string) (oid string, size int64, err error) {
 // auto-hydrate these files — hydration is handled by our own download path.
 
 // WritePointerFile writes a standard LFS pointer file at path.
-// Replaces any existing file (content is already uploaded to LFS).
+// Refuses to replace real content that does not match ref.OID — see
+// guardPointerOverwrite.
 func WritePointerFile(path string, ref FileRef) error {
+	if err := guardPointerOverwrite(path, ref); err != nil {
+		return err
+	}
 	content := FormatPointer(ref.OID, ref.Size)
 	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// guardPointerOverwrite refuses to replace real on-disk content with a pointer
+// that does not describe that content.
+//
+// The happy path legitimately pointerizes real bytes: session upload writes
+// content, uploads it to LFS, then replaces it with a pointer. That stays
+// allowed, because the content hashes to ref.OID — it is provably in the store.
+//
+// The dangerous case is a meta.json whose Files map disagrees with the blob on
+// disk, which is exactly what independently-resolved merge conflicts produce.
+// UpdateMetaSummary calls WritePointerFiles over the WHOLE Files map, so a
+// single stale OID would silently destroy the only local copy of a recording —
+// and if that OID was never uploaded, the next push is rejected with "LFS
+// objects are missing", after which the reconcile path blanks the file to zero
+// bytes. Refusing here converts unrecoverable data loss into a loud error.
+func guardPointerOverwrite(path string, ref FileRef) error {
+	existing, err := os.ReadFile(path)
+	if err != nil || len(existing) == 0 {
+		return nil // nothing on disk to lose
+	}
+	if _, _, perr := ParsePointer(string(existing)); perr == nil {
+		// Already a pointer. Swapping one pointer for another loses nothing —
+		// a redaction pass legitimately installs a new OID.
+		return nil
+	}
+	if ComputeOID(existing) == ref.BareOID() {
+		return nil // content matches the OID: safely uploaded, pointerizing is correct
+	}
+	return fmt.Errorf(
+		"refusing to overwrite %s with an LFS pointer: on-disk content does not "+
+			"match OID %s (meta.json and the blob disagree — resolve before pointerizing)",
+		filepath.Base(path), ref.BareOID())
 }
 
 // WritePointerFiles writes LFS pointer files for each LFS-stored entry in

--- a/internal/lfs/pointer_test.go
+++ b/internal/lfs/pointer_test.go
@@ -288,8 +288,11 @@ func TestWritePointerFile_OverwritesLargeContent(t *testing.T) {
 	}
 	require.NoError(t, os.WriteFile(path, largeContent, 0644))
 
-	// overwrite with pointer
-	ref := FileRef{OID: "sha256:abc123", Size: int64(len(largeContent))}
+	// Overwrite with a pointer for THIS content. The OID must be the content's
+	// real hash — that is exactly what the upload path produces (meta.go builds
+	// every FileRef as "sha256:"+ComputeOID(content)), and it is what proves the
+	// bytes reached the LFS store before we drop the local copy.
+	ref := FileRef{OID: "sha256:" + ComputeOID(largeContent), Size: int64(len(largeContent))}
 	require.NoError(t, WritePointerFile(path, ref))
 
 	// verify file is now a pointer (small)
@@ -297,6 +300,56 @@ func TestWritePointerFile_OverwritesLargeContent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Less(t, info.Size(), int64(maxPointerSize), "pointer file should be small")
 	assert.True(t, IsPointerFile(path))
+}
+
+// TestWritePointerFile_RefusesToClobberMismatchedContent pins the invariant that
+// prevents silent, unrecoverable recording loss.
+//
+// Failure prevented: a meta.json whose Files map disagrees with the blob on disk
+// — the state independently-resolved merge conflicts produce — gets pointerized
+// by UpdateMetaSummary, which rewrites pointers for the WHOLE Files map. One
+// stale OID destroys the only local copy; if that OID was never uploaded, the
+// next push is rejected with "LFS objects are missing" and the reconcile path
+// then blanks the file to zero bytes. No doctor check detects the result.
+func TestWritePointerFile_RefusesToClobberMismatchedContent(t *testing.T) {
+	dir := t.TempDir()
+
+	readBack := func(t *testing.T, path string) string {
+		t.Helper()
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		return string(data)
+	}
+
+	t.Run("real content with a mismatched OID is refused", func(t *testing.T) {
+		path := filepath.Join(dir, "raw.jsonl")
+		content := []byte(`{"type":"header"}` + "\n")
+		require.NoError(t, os.WriteFile(path, content, 0644))
+
+		err := WritePointerFile(path, FileRef{OID: "sha256:deadbeef", Size: int64(len(content))})
+		require.Error(t, err, "must refuse rather than destroy the only local copy")
+		assert.Equal(t, string(content), readBack(t, path), "content must survive untouched")
+	})
+
+	t.Run("an existing pointer may be replaced by a different pointer", func(t *testing.T) {
+		// A redaction pass legitimately installs a new OID over the old pointer.
+		// Nothing is lost — the old bytes were never on disk to begin with.
+		path := filepath.Join(dir, "redacted.jsonl")
+		require.NoError(t, WritePointerFile(path, FileRef{OID: "sha256:" + ComputeOID([]byte("v1")), Size: 2}))
+
+		newRef := FileRef{OID: "sha256:" + ComputeOID([]byte("v2")), Size: 2}
+		require.NoError(t, WritePointerFile(path, newRef))
+
+		oid, _, err := ParsePointer(readBack(t, path))
+		require.NoError(t, err)
+		assert.Equal(t, newRef.OID, oid, "ParsePointer returns the prefixed OID as written")
+	})
+
+	t.Run("writing into a fresh path always succeeds", func(t *testing.T) {
+		path := filepath.Join(dir, "brand-new.jsonl")
+		require.NoError(t, WritePointerFile(path, FileRef{OID: "sha256:abc123", Size: 7}))
+		assert.True(t, IsPointerFile(path))
+	})
 }
 
 func TestNewFileRef_EndToEnd_RoundTrip(t *testing.T) {

--- a/internal/lfs/reconcile.go
+++ b/internal/lfs/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -115,11 +116,24 @@ func ReconcileUnpushedPointers(ctx context.Context, ledgerPath, endpointURL stri
 		}
 
 		for _, obj := range resp.Objects {
-			if obj.Error != nil {
-				// mark ALL files that reference this OID, not just one
-				for _, idx := range oidToIndices[obj.OID] {
-					missing[idx] = true
-				}
+			if obj.Error == nil {
+				continue
+			}
+			// Only 404 proves the blob is genuinely absent. Any other status —
+			// 401 (token expired), 429 (rate limited), 5xx (server trouble) —
+			// says nothing about whether the object exists, and treating it as
+			// "gone" blanks a live recording to zero bytes, an operation with no
+			// inverse. Abort the reconcile instead: a push that stays blocked is
+			// recoverable, destroyed content is not.
+			if obj.Error.Code != http.StatusNotFound {
+				return result, fmt.Errorf(
+					"lfs batch check inconclusive for %s: HTTP %d: %s (refusing to treat "+
+						"as missing — retry once the LFS endpoint is healthy)",
+					obj.OID, obj.Error.Code, obj.Error.Message)
+			}
+			// mark ALL files that reference this OID, not just one
+			for _, idx := range oidToIndices[obj.OID] {
+				missing[idx] = true
 			}
 		}
 	}

--- a/internal/lfs/session_upload.go
+++ b/internal/lfs/session_upload.go
@@ -175,12 +175,26 @@ func FindPointerStubsWithMissingBlobs(client *Client, sessionPath string, logger
 // LFS pointer files and meta.json are committed to git; pointer files (~130 bytes)
 // reference uploaded LFS objects by OID to prevent garbage collection.
 // Overwrites legacy .gitignore that excluded content file extensions.
+//
+// It also excludes .needs-summary. That marker is machine-local scheduling
+// state whose payload is ABSOLUTE local paths (cache_dir, raw_path under the
+// writer's home directory), so its content can never agree between two
+// machines — committing it leaks local usernames into a shared repo AND
+// guarantees a perpetual merge conflict. Worse, the cloud summarizer deletes
+// the marker when it finishes while a local writer modifies it, producing a
+// modify/delete conflict that resolves in favor of the local modification and
+// resurrects a marker the cloud already retired. Excluding it deletes the whole
+// conflict class rather than merging it forever.
 func EnsureSessionsGitignore(sessionsDir string) error {
 	gitignorePath := filepath.Join(sessionsDir, ".gitignore")
 
 	newContent := "# LFS pointer files and meta.json are committed to git.\n" +
 		"# Content is stored in LFS; pointer files (~130 bytes) reference\n" +
-		"# uploaded objects by OID to prevent garbage collection.\n"
+		"# uploaded objects by OID to prevent garbage collection.\n" +
+		"\n" +
+		"# Machine-local summarization marker: holds absolute local paths and is\n" +
+		"# deleted by the cloud summarizer, so it can never merge cleanly.\n" +
+		".needs-summary\n"
 
 	existing, _ := os.ReadFile(gitignorePath)
 	if string(existing) == newContent {

--- a/internal/lfs/session_upload_gitignore_test.go
+++ b/internal/lfs/session_upload_gitignore_test.go
@@ -1,0 +1,58 @@
+package lfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureSessionsGitignore_ExcludesNeedsSummary pins the intent that the
+// machine-local .needs-summary marker never enters git. Its payload is absolute
+// local paths, so committing it leaks the writer's home directory into a shared
+// repo and guarantees a conflict that can never merge cleanly: the cloud
+// summarizer deletes the marker on completion while a local writer modifies it.
+func TestEnsureSessionsGitignore_ExcludesNeedsSummary(t *testing.T) {
+	sessionsDir := t.TempDir()
+	require.NoError(t, EnsureSessionsGitignore(sessionsDir))
+
+	data, err := os.ReadFile(filepath.Join(sessionsDir, ".gitignore"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), ".needs-summary",
+		"marker holds absolute local paths and must never be committed")
+}
+
+// TestEnsureSessionsGitignore_RewritesLegacy ensures a ledger created before the
+// exclusion existed is repaired in place — the 111 already-tracked markers on a
+// real ledger got there through the legacy content.
+func TestEnsureSessionsGitignore_RewritesLegacy(t *testing.T) {
+	sessionsDir := t.TempDir()
+	legacy := "# LFS pointer files and meta.json are committed to git.\n"
+	path := filepath.Join(sessionsDir, ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte(legacy), 0644))
+
+	require.NoError(t, EnsureSessionsGitignore(sessionsDir))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), ".needs-summary")
+}
+
+// TestEnsureSessionsGitignore_Idempotent guards against the rewrite-every-call
+// churn that would dirty the ledger worktree on every sync cycle.
+func TestEnsureSessionsGitignore_Idempotent(t *testing.T) {
+	sessionsDir := t.TempDir()
+	path := filepath.Join(sessionsDir, ".gitignore")
+
+	require.NoError(t, EnsureSessionsGitignore(sessionsDir))
+	first, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	require.NoError(t, EnsureSessionsGitignore(sessionsDir))
+	second, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(first), string(second))
+}


### PR DESCRIPTION
## Summary

Ledger repos can wedge permanently. This PR ships the two repairs that are unambiguously safe, and documents the root cause of the larger wedge without attempting it yet — an adversarial review found that the obvious fix would trade a loud, harmless wedge for silent data loss.

**Found while investigating five stuck ledgers on one machine:**

| Ledger | State |
| --- | --- |
| `repo_019c6d2e` | **341 ahead / 1055 behind**, 13 days, 281 conflicts |
| `repo_019c7d5c` | unborn HEAD, 184 uncommitted files, doctor reports **skipped** |
| `repo_019ddf8e` | `index.lock` + `next-index-13088.lock` from **May 3** (~3 months) |
| `repo_019f4537`, `repo_019ce879` | diverged 39/35 and 2/1 |

## What this PR ships

- **Stale git locks now self-heal on the push path.** `IsSafeForGitOps` only ever *reported* locks; it never cleared them — while the pull path has swept them before every pull for ages. That asymmetry means a lock left by a crashed git blocks every future push forever. `IsSafeForGitOps` now sweeps first, still gated on the existing 5-minute `StaleLockAge` so a live git process is never disturbed.
- **`next-index-<pid>.lock` is now covered.** Its pid varies, so it could never be listed in `knownLockFiles` — it was undetectable *and* unclearable. Detection and removal now share one helper (`lockFilesIn`) so they can't drift again. Deliberately not a broad `*.lock`, which would eat `packed-refs.lock` and ref-transaction locks.
- **`.needs-summary` stops entering git.** `sessions/.gitignore` was three comment lines that ignored nothing, so the marker got swept in — 111 of them tracked on one real ledger. Its payload is *absolute local paths* (`{"cache_dir":"/Users/<name>/…"}`), so it leaks the writer's home directory into a shared repo and can never merge cleanly between two machines. Already-tracked copies are untracked via `git rm --cached` alongside the existing `*.rej` handling; local files are preserved, so in-flight summarization is unaffected.

Together these unstick the lock-blocked ledger outright and remove 12 of the 281 conflicts on the big one.

## The wedge itself, now fixed

`sessions/<id>/meta.json` is written by **both** the cloud summarizer and the local CLI. Every cycle:

```mermaid
flowchart LR
    A["git pull rebase"] --> B["halts on<br/>sessions/*/meta.json"]
    B --> C["accept-theirs refuses:<br/>not a safe prefix"]
    C --> D["LLM tier:<br/>ErrLLMUnavailable"]
    D --> E["AuditAndAbort<br/>rolls back"]
    E --> F["state unchanged,<br/>still diverged"]
    F --> A
```

Zero state change, zero escalation, forever.

- **`sessions/` now auto-resolves** — added to `ledger.DefaultResolveRules`, which every push/pull site already funnels through. Session artifacts are best-effort or regenerable, and the forward links are documented caches whose canonical source is elsewhere. An imperfect summary beats a ledger that can never sync.
- **Guarded by pointer-wins.** During a rebase, stage 2 is the cloud and stage 3 is the local commit being replayed, so `checkout --theirs` picks **local** — the opposite of what the name suggests (verified in a scratch repo, not inferred). On the wedged ledger every mixed content conflict is `local=hydrated / remote=pointer`, so the naive fix would commit hydrated bytes over the pointer and permanently break pushes. Now: when two sides differ in *kind*, the LFS pointer wins. That rule is commutative and idempotent, so unlike the positional rule it **converges** rather than ping-ponging between replicas.
- **Found by the new harness — a real add/add bug.** When both sides *create* the same path (no merge base), the conflict skipped the content branch entirely and got staged **with `<<<<<<< HEAD` markers committed into the file**. That is the common shape when both writers produce a new `session.md` for the same session. Now handled by the same pointer-wins path.
- **`fixLedgerBranchBehind` routes through `automerge`** — it was the one reconcile path bypassing the tiered resolver.

Also worth knowing: `resolveHardDenyList` is **inert for ledgers** — its only consumer is `ValidateResolveRules` via `manifest/parser.go`, and no ledger has a `sync.manifest`. Editing it would have changed nothing.

## Two P0 data-loss paths, now closed

Both were **pre-existing** and independent of the wedge — but unwedging `sessions/` would have unlocked the second, turning a loud harmless wedge into a silent shredder. Fixing them is a prerequisite, so they are in this PR.

- **`WritePointerFile` overwrote blobs with no OID compare and no backup.** `UpdateMetaSummary` rewrites pointers for the *whole* `Files` map, so a single stale OID — exactly what independently-resolved merge conflicts produce — destroyed the only local copy of a recording. If that OID was never uploaded, the push was then rejected and the reconcile path blanked the file to zero bytes. **No doctor check detects the result** (`session_manifest.go` gates its size-0 and pointer-shape checks on `ref.IsGit()`, so a hydrated or 0-byte LFS entry passes clean). It now refuses unless the on-disk bytes hash to the OID — which is what the real upload path always produces (`meta.go:818`), so the happy path is untouched.
- **`ReconcileUnpushedPointers` treated *any* LFS batch error as "blob is gone"** and wrote `[]byte{}`. A transient 401, 429, or 5xx blanked live recordings. Only 404 counts as missing now; anything else aborts the reconcile. A push that stays blocked is recoverable; `[]byte{}` is the one operation with no inverse.

Several tests asserted the old destructive behavior using synthetic OIDs (`sha256:abc123`) over content that hashes to something else — a physically impossible state. They now use real content hashes, which is both faithful to production and what makes the guard meaningful.

## Still deferred (`ox-zmjc` epic)

The `sessions/` auto-resolve itself, which needs a **pointer-wins guard**: when two sides of a conflict differ in *kind* (pointer vs. bytes), take the pointer. Unlike positional accept-theirs, that rule is commutative and idempotent, so it actually converges. Also filed: the `session_id` split-brain, where 26 of 33 conflicts differ *only* in that field.

## Test Plan

**New harness: `internal/gitutil/wedge_harness_test.go`.** A reusable real-git fixture (bare remote + local clone + a second clone standing in for the cloud), with one case per wedge class that reached production. Every case asserts the same three-part contract, and the third part is the one that matters:

1. the wedge is **detected**
2. the repair **clears** it
3. the ledger **makes progress** afterward — the next pull+push actually lands

Part 3 is why these bugs shipped: `git rebase --abort` returning success while the ledger stays permanently un-syncable is exactly the 341-ahead/1055-behind wedge. Cases cover: `sessions/` meta conflict self-heal, repair idempotence (no infinite ping-pong), pointer-never-loses-to-hydrated from *either* side, stale locks (`index.lock`, `next-index-<pid>.lock`, `shallow.lock`), stale rebase dir, fresh-rebase-is-never-aborted, divergence convergence to 0/0, bounded rounds under 25 simultaneous conflicts, and human-authored paths still refusing auto-resolve.

- `internal/daemon` — new `TestSessionMetaConflict_AutoResolvesUnderProductionRules` fails if `sessions/` ever drops out of the production rules. The existing restart-escalation test was pinned to the old "sessions/ stays hard-denied" assumption; it now drives non-resolving rules so it still tests the escalation math it was written for.
- `internal/gitutil` — pointer-wins classification, LFS-pointer detection edge cases (oversized-with-prefix, spec URL mentioned mid-body), lock sweep.
- `internal/lfs` — pointer-overwrite refusal, redaction-style pointer replacement still allowed, sessions `.gitignore` content + idempotence.
- 102 packages green, `make lint` 0 issues.
- Verified against a **copy** of the real wedged ledger: 348 ahead / 1062 behind, 47 merge-tree conflicts, 173 pre-existing hydrated/pointer pairs. (The original was never mutated.)

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added
- [ ] CHANGELOG entry — N/A, internal repair paths, no user-facing surface change
- [x] Breaking change documented — none
- [x] `/security-review` — N/A for this diff (no `internal/auth/`, `internal/mcp/`, `raw_writer.go`, `prepush_scan.go`, `internal/upgrade/`, or `go.sum` changes). Note the two P0 LFS data-loss follow-ups filed above are pre-existing and want a look.

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)
