### PR TITLE
fix(plan): derive plan titles from the H1, keep data/plans in the sparse cone

### DIFF
--- a/cmd/ox/doctor_ledger_infra.go
+++ b/cmd/ox/doctor_ledger_infra.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,9 +13,45 @@ import (
 	"github.com/sageox/ox/internal/ledger"
 )
 
+// requiredSparseCone are the cone entries a ledger cannot function without.
+// Both failures are silent and destructive — the cone doesn't just hide these
+// paths, `git sparse-checkout set` DELETES them from the working tree — so
+// doctor checks them explicitly rather than trusting ConfigureSparseCheckout
+// to have been run by a build that knew about them.
+var requiredSparseCone = []struct{ dir, impact string }{
+	{".sageox", "codedb cache is wiped on every sparse-checkout set"},
+	{"data/plans", "saved plans are deleted from the working tree ~60s after `ox plan save`"},
+}
+
+// normalizeConeEntry strips the surrounding slashes cone mode writes ("/.sageox/")
+// so an entry compares equal to the bare directory name ConfigureSparseCheckout
+// asks for (".sageox"). Without this the comparison never matches a real
+// cone-mode file and every ledger reports a false failure.
+func normalizeConeEntry(line string) string {
+	return strings.Trim(strings.TrimSpace(line), "/")
+}
+
+// missingSparseConeDirs returns the requiredSparseCone entries absent from a
+// sparse-checkout file's contents, preserving requiredSparseCone's order.
+func missingSparseConeDirs(content string) []string {
+	present := make(map[string]bool)
+	for _, line := range strings.Split(content, "\n") {
+		present[normalizeConeEntry(line)] = true
+	}
+
+	var missing []string
+	for _, req := range requiredSparseCone {
+		if !present[req.dir] {
+			missing = append(missing, req.dir)
+		}
+	}
+	return missing
+}
+
 // checkLedgerSparseCheckout verifies that the ledger repo's sparse-checkout
-// cone includes .sageox. Without it, the codedb cache directory gets wiped
-// on every sparse-checkout set operation.
+// cone includes every requiredSparseCone entry. A missing entry means git
+// deletes that path from the working tree on the sync scheduler's next
+// ~60s refresh.
 func checkLedgerSparseCheckout(fix bool) checkResult {
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
@@ -41,6 +78,19 @@ func checkLedgerSparseCheckout(fix bool) checkResult {
 		ledgerPath = defaultPath
 	}
 
+	return checkLedgerSparseCheckoutAtPath(ledgerPath, fix)
+}
+
+// checkLedgerSparseCheckoutAtPath is checkLedgerSparseCheckout with the ledger
+// already resolved. Split out so tests exercise THIS logic rather than a
+// reimplementation of it — the test file previously carried its own copy of
+// the cone matching, which meant a production-side change (like adding
+// data/plans to requiredSparseCone) could not fail a single test.
+func checkLedgerSparseCheckoutAtPath(ledgerPath string, fix bool) checkResult {
+	if ledgerPath == "" {
+		return SkippedCheck("Ledger sparse checkout", "no ledger path", "")
+	}
+
 	if !isGitRepo(ledgerPath) {
 		return SkippedCheck("Ledger sparse checkout", "ledger not a git repo", "")
 	}
@@ -52,29 +102,32 @@ func checkLedgerSparseCheckout(fix bool) checkResult {
 		return SkippedCheck("Ledger sparse checkout", "sparse-checkout not enabled", "")
 	}
 
-	// look for .sageox in the cone entries
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == ".sageox" || trimmed == ".sageox/" {
-			return PassedCheck("Ledger sparse checkout", ".sageox in sparse-checkout cone")
-		}
+	missing := missingSparseConeDirs(string(content))
+	if len(missing) == 0 {
+		return PassedCheck("Ledger sparse checkout", "required dirs in sparse-checkout cone")
 	}
 
-	// .sageox missing from sparse-checkout
+	missingList := strings.Join(missing, ", ")
 	if fix {
 		if repairErr := ledger.ConfigureSparseCheckout(ledgerPath); repairErr != nil {
 			return FailedCheck("Ledger sparse checkout",
-				".sageox missing from cone, repair failed",
+				fmt.Sprintf("%s missing from cone, repair failed", missingList),
 				fmt.Sprintf("error: %v", repairErr))
 		}
-		return PassedCheck("Ledger sparse checkout", "repaired: .sageox added to sparse-checkout cone")
+		return PassedCheck("Ledger sparse checkout",
+			fmt.Sprintf("repaired: %s added to sparse-checkout cone", missingList))
+	}
+
+	var impacts strings.Builder
+	for _, req := range requiredSparseCone {
+		if slices.Contains(missing, req.dir) {
+			fmt.Fprintf(&impacts, "        Without %s: %s.\n", req.dir, req.impact)
+		}
 	}
 
 	return FailedCheck("Ledger sparse checkout",
-		".sageox missing from sparse-checkout cone",
-		"Without .sageox in the cone, codedb cache gets wiped on sparse-checkout set.\n"+
-			"        Run `ox doctor` to auto-fix")
+		fmt.Sprintf("%s missing from sparse-checkout cone", missingList),
+		impacts.String()+"        Run `ox doctor --fix` to auto-fix")
 }
 
 // checkCodeDBConsistency detects when codedb was previously indexed but the

--- a/cmd/ox/doctor_ledger_infra_test.go
+++ b/cmd/ox/doctor_ledger_infra_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,24 +12,89 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// writeSparseCheckout writes a ledger's .git/info/sparse-checkout file.
+func writeSparseCheckout(t *testing.T, ledgerDir, content string) {
+	t.Helper()
+	sparseDir := filepath.Join(ledgerDir, ".git", "info")
+	require.NoError(t, os.MkdirAll(sparseDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sparseDir, "sparse-checkout"), []byte(content), 0o644))
+}
+
 // TestCheckLedgerSparseCheckout_WithSageox verifies that a ledger repo
-// with .sageox in the sparse-checkout file passes the check.
+// carrying every required cone entry passes the check.
 func TestCheckLedgerSparseCheckout_WithSageox(t *testing.T) {
 	t.Parallel()
 
 	ledgerDir := initBareGitRepo(t)
-	sparseDir := filepath.Join(ledgerDir, ".git", "info")
-	require.NoError(t, os.MkdirAll(sparseDir, 0o755))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(sparseDir, "sparse-checkout"),
-		[]byte("/*\n!/*/\n.sageox\nsessions\n"),
-		0o644,
-	))
+	writeSparseCheckout(t, ledgerDir, "/*\n!/*/\n.sageox\nsessions\ndata/plans\n")
 
-	result := checkLedgerSparseCheckoutAtPath(ledgerDir)
+	result := checkLedgerSparseCheckoutAtPath(ledgerDir, false)
 
-	assert.True(t, result.passed, "should pass when .sageox is in sparse-checkout")
+	assert.True(t, result.passed, "should pass when every required dir is in sparse-checkout")
 	assert.False(t, result.skipped)
+}
+
+// TestCheckLedgerSparseCheckout_ConeModeSlashFormat is the regression for the
+// format the check actually meets in the wild. `git sparse-checkout set` in
+// cone mode writes entries as "/.sageox/" — slashes on both sides — so the
+// original exact-string comparison against ".sageox" never matched a single
+// real ledger, and the check reported a false failure on every one of them.
+func TestCheckLedgerSparseCheckout_ConeModeSlashFormat(t *testing.T) {
+	t.Parallel()
+
+	ledgerDir := initBareGitRepo(t)
+	writeSparseCheckout(t, ledgerDir,
+		"/*\n!/*/\n/data/\n!/data/*/\n/data/plans/\n/.sageox/\n/.sync/\n")
+
+	result := checkLedgerSparseCheckoutAtPath(ledgerDir, false)
+
+	assert.True(t, result.passed, "cone-mode entries like /.sageox/ must satisfy the check")
+}
+
+// TestCheckLedgerSparseCheckout_MissingDataPlans covers the cone every existing
+// machine has baked in: correct in every respect except data/plans, which git
+// then deletes from the working tree on the sync scheduler's next refresh.
+func TestCheckLedgerSparseCheckout_MissingDataPlans(t *testing.T) {
+	t.Parallel()
+
+	ledgerDir := initBareGitRepo(t)
+	writeSparseCheckout(t, ledgerDir, "/*\n!/*/\n/.sageox/\n/.sync/\n/sessions/\n")
+
+	result := checkLedgerSparseCheckoutAtPath(ledgerDir, false)
+
+	assert.False(t, result.passed, "should fail when data/plans is missing")
+	assert.Contains(t, result.detail, "data/plans", "detail should name the missing dir and its impact")
+}
+
+// TestMissingSparseConeDirs covers the pure matcher directly — the surrounding
+// check is mostly path resolution.
+func TestMissingSparseConeDirs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{"bare names", ".sageox\ndata/plans\n", nil},
+		{"cone-mode slashes", "/.sageox/\n/data/plans/\n", nil},
+		{"empty file", "", []string{".sageox", "data/plans"}},
+		{"only sageox", "/.sageox/\n", []string{"data/plans"}},
+		{"only plans", "/data/plans/\n", []string{".sageox"}},
+		{
+			// A negation line must not be read as the directory it mentions.
+			"negation lines are not matches",
+			"/*\n!/*/\n/data/\n!/data/*/\n",
+			[]string{".sageox", "data/plans"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, missingSparseConeDirs(tt.content))
+		})
+	}
 }
 
 // TestCheckLedgerSparseCheckout_MissingSageox verifies that a ledger repo
@@ -47,7 +111,7 @@ func TestCheckLedgerSparseCheckout_MissingSageox(t *testing.T) {
 		0o644,
 	))
 
-	result := checkLedgerSparseCheckoutAtPath(ledgerDir)
+	result := checkLedgerSparseCheckoutAtPath(ledgerDir, false)
 
 	assert.False(t, result.passed, "should fail when .sageox missing from sparse-checkout")
 	assert.False(t, result.skipped)
@@ -59,7 +123,7 @@ func TestCheckLedgerSparseCheckout_MissingSageox(t *testing.T) {
 func TestCheckLedgerSparseCheckout_NoLedger(t *testing.T) {
 	t.Parallel()
 
-	result := checkLedgerSparseCheckoutAtPath("")
+	result := checkLedgerSparseCheckoutAtPath("", false)
 
 	assert.True(t, result.skipped, "should skip when no ledger path provided")
 }
@@ -103,37 +167,6 @@ func initBareGitRepo(t *testing.T) string {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git init failed: %s", string(out))
 	return dir
-}
-
-// checkLedgerSparseCheckoutAtPath is a testable helper that checks
-// sparse-checkout at a given ledger path, bypassing config resolution.
-func checkLedgerSparseCheckoutAtPath(ledgerPath string) checkResult {
-	if ledgerPath == "" {
-		return SkippedCheck("Ledger sparse checkout", "no ledger path", "")
-	}
-
-	if !isGitRepo(ledgerPath) {
-		return SkippedCheck("Ledger sparse checkout", "not a git repo", "")
-	}
-
-	sparseFile := filepath.Join(ledgerPath, ".git", "info", "sparse-checkout")
-	content, err := os.ReadFile(sparseFile)
-	if err != nil {
-		return SkippedCheck("Ledger sparse checkout", "sparse-checkout not enabled", "")
-	}
-
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == ".sageox" || trimmed == ".sageox/" {
-			return PassedCheck("Ledger sparse checkout", ".sageox in sparse-checkout cone")
-		}
-	}
-
-	return FailedCheck("Ledger sparse checkout",
-		".sageox missing from sparse-checkout cone",
-		"Without .sageox in the cone, codedb cache gets wiped on sparse-checkout set.\n"+
-			"        Run `ox doctor` to auto-fix")
 }
 
 // checkCodeDBConsistencyAtDir is a testable helper that checks codedb

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -518,28 +518,18 @@ func runPlanLint(cmd *cobra.Command, slug string, strict bool) error {
 	return nil
 }
 
-// planTopic derives a human title for the plan: the --topic consult subject if
-// set, else the first H1/H2 heading, else the first non-empty line, else a
-// fallback. Used for the slug and meta.Topic — checking in.Topic first matters
-// for a topic-only consult saved via --persist/--text (in.Sections carries only
-// the synthetic preamble section, whose Heading is deliberately empty and whose
-// Raw is empty, so both later fallbacks would otherwise miss the real subject).
+// planTopic derives a human title for the plan: the --topic consult subject
+// if set, else plan.Title(in) (the H1, falling back to the first non-empty
+// section heading, falling back to "Implementation Plan"). Used for the slug
+// and meta.Topic — checking in.Topic first matters for a topic-only consult
+// saved via --persist/--text, where no document exists yet (in.Raw is empty
+// and in.Sections carries only the synthetic pre-draft section — see
+// newTopicInput), so plan.Title would have nothing to derive from.
 func planTopic(in plan.Input) string {
 	if t := strings.TrimSpace(in.Topic); t != "" {
 		return t
 	}
-	for _, s := range in.Sections {
-		if h := strings.TrimSpace(s.Heading); h != "" {
-			return h
-		}
-	}
-	for _, line := range strings.Split(in.Raw, "\n") {
-		line = strings.TrimSpace(strings.TrimLeft(line, "# "))
-		if line != "" {
-			return line
-		}
-	}
-	return "untitled plan"
+	return plan.Title(in)
 }
 
 // planAuthors returns the capturing coworker's display name (privacy-safe, not

--- a/cmd/ox/plan_backfill.go
+++ b/cmd/ox/plan_backfill.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/plan"
+	"github.com/spf13/cobra"
+)
+
+// plan_backfill.go implements `ox plan backfill-titles` — the one-off repair
+// pass for plans saved by the pre-ox-1tjj.8 planTopic (which read the first
+// H2 heading instead of the document's H1; see internal/plan/title.go). It
+// re-derives every saved plan's topic/slug from plan.md via plan.Title +
+// plan.Slugify — the compute half lives in internal/plan/backfill.go
+// (ComputeBackfill, ComputeProducedPlansRewrite), so it is fully unit-tested
+// without needing a real git repo; this file owns the CLI porcelain (table
+// output, flags) and the git orchestration (mv/add/commit/push, in
+// plan_commit.go's commitPlanBackfillToLedger).
+//
+// Before any of that, preflightPlanBackfill (plan_backfill_preflight.go)
+// runs two safety guards: the working tree must have at least as many plan
+// dirs as origin/main (an incomplete sparse-checkout cone would otherwise
+// make this scan a fraction of the real corpus and report a false-clean
+// summary), and the ledger must not be diverged from origin/main unless
+// --allow-diverged says that's expected. Both guards run before the table
+// is printed, in dry-run and real mode alike.
+var planBackfillTitlesCmd = &cobra.Command{
+	Use:    "backfill-titles",
+	Hidden: true, // maintenance/CI tier — a one-off repair pass, taught via docs/prime, not human help
+	Short:  "Re-derive title/slug for every saved plan from its plan.md H1 (repair pass)",
+	Long: `Repairs plans saved by the pre-fix planTopic, which read the first H2
+heading rather than the document's H1 (ox-1tjj.8: Parse splits markdown on H2
+only, so an H1 followed by a "1. Context — Why Now" or "TL;DR" H2 saved to the
+ledger under the H2's text). For every saved plan this re-derives topic/slug
+via plan.Title/plan.Slugify, rewrites meta.json + re-stamps plan.html + appends
+a 'revised' event, and renames the plan directory to the corrected slug WHILE
+KEEPING ITS ORIGINAL DATE PREFIX — the plan's identity, not today's date. Any
+sessions/*/meta.json produced_plans entry pointing at an old slug is rewritten
+too, so 'ox agent stop' reconciliation keeps resolving it.
+
+Always run --dry-run first: it prints the full retitle/rename table and
+touches nothing — that table is the reviewable artifact before a real run.
+Idempotent: a plan already matching its correct title/slug is a no-op (no
+event, no rename, no commit). A single broken/unreadable plan dir is skipped
+with a logged reason; it never aborts the batch.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		allowDiverged, _ := cmd.Flags().GetBool("allow-diverged")
+		gitRoot := findGitRoot()
+		ctx, err := config.LoadProjectContext(gitRoot)
+		if err != nil || ctx == nil {
+			return fmt.Errorf("no project context for %q: cannot backfill plans", gitRoot)
+		}
+		ledgerPath := ctx.DefaultLedgerPath()
+		if ledgerPath == "" {
+			return fmt.Errorf("no ledger configured for %q: cannot backfill plans", gitRoot)
+		}
+		return runPlanBackfillTitlesOnLedger(cmd, ledgerPath, dryRun, allowDiverged)
+	},
+}
+
+func init() {
+	planBackfillTitlesCmd.Flags().Bool("dry-run", false, "print the retitle/rename table; touch nothing")
+	// --allow-diverged: escape hatch for Guard 2 (preflightPlanBackfill). Only
+	// pass this when the ahead/behind state vs origin/main is already known and
+	// expected — the guard exists because a mass directory rename landed on top
+	// of an UNEXPECTED divergence turns a routine repair into a manual rebase.
+	planBackfillTitlesCmd.Flags().Bool("allow-diverged", false, "skip the divergence preflight guard; only use when the ledger's divergence from origin/main is known and intentional")
+	planCmd.AddCommand(planBackfillTitlesCmd)
+}
+
+// runPlanBackfillTitlesOnLedger is the testable core: it takes an already-
+// resolved ledger path directly (no findGitRoot/config lookup) so tests can
+// point it at a temp fixture. Runs preflightPlanBackfill's two safety guards
+// FIRST — before any scan, before the table is printed, in both dry-run and
+// real mode — then computes the full plan (and, when a slug actually
+// changes, the produced_plans fix-up), prints the table, and — only when
+// dryRun is false — applies every change and lands one batch commit.
+func runPlanBackfillTitlesOnLedger(cmd *cobra.Command, ledgerPath string, dryRun, allowDiverged bool) error {
+	out := cmd.OutOrStdout()
+	ctx := cmd.Context()
+	plansDir := paths.LedgerPlansDir(ledgerPath)
+
+	if err := preflightPlanBackfill(ctx, out, ledgerPath, allowDiverged); err != nil {
+		return err
+	}
+
+	candidates, err := plan.ComputeBackfill(plansDir)
+	if err != nil {
+		return fmt.Errorf("compute backfill: %w", err)
+	}
+
+	// Only a SLUG change invalidates a sessions/*/meta.json produced_plans
+	// entry (it's resolved by slug — see resolvePlanDir) — a topic-only
+	// correction with no slug change leaves that reference valid.
+	renamed := make(map[string]string, len(candidates))
+	for _, c := range candidates {
+		if c.SkipReason == "" && c.SlugChanged {
+			renamed[c.OldSlug] = c.NewSlug
+		}
+	}
+	sessionRewrites, err := plan.ComputeProducedPlansRewrite(filepath.Join(ledgerPath, "sessions"), renamed)
+	if err != nil {
+		return fmt.Errorf("compute produced_plans rewrite: %w", err)
+	}
+
+	writeBackfillTable(out, candidates, sessionRewrites)
+
+	total, retitled, renamedCount, skipped := backfillCounts(candidates)
+	if dryRun {
+		slog.Info("plan_backfill_titles_dry_run", "total", total, "retitled", retitled, "renamed", renamedCount, "skipped", skipped, "sessions_to_fix", len(sessionRewrites))
+		fmt.Fprintf(out, "\nDry run — nothing written. total=%d retitled=%d renamed=%d skipped=%d sessions_to_fix=%d\n",
+			total, retitled, renamedCount, skipped, len(sessionRewrites))
+		return nil
+	}
+
+	var renames [][2]string      // (old, new) absolute paths for git mv
+	var touchedPlanDirs []string // topic-only correction, no rename: plain git add
+	for _, c := range candidates {
+		if !c.Changed() {
+			continue
+		}
+		if err := plan.ApplyBackfillMeta(ctx, c.OldDir, c.NewTopic, c.NewSlug); err != nil {
+			// A single plan's write failure must never abort the batch — log
+			// and continue, matching ComputeBackfill's own skip-and-continue
+			// contract for a broken source dir.
+			slog.Warn("plan backfill: apply failed, skipping", "dir", c.OldDir, "error", err)
+			continue
+		}
+		if c.NewDir != "" {
+			renames = append(renames, [2]string{c.OldDir, c.NewDir})
+		} else {
+			touchedPlanDirs = append(touchedPlanDirs, c.OldDir)
+		}
+	}
+
+	var touchedSessionDirs []string
+	for _, r := range sessionRewrites {
+		if err := plan.ApplyProducedPlansRewrite(ctx, r.SessionDir, renamed); err != nil {
+			slog.Warn("plan backfill: produced_plans rewrite failed, skipping", "dir", r.SessionDir, "error", err)
+			continue
+		}
+		touchedSessionDirs = append(touchedSessionDirs, r.SessionDir)
+	}
+
+	if len(renames) == 0 && len(touchedPlanDirs) == 0 && len(touchedSessionDirs) == 0 {
+		fmt.Fprintln(out, "Nothing to backfill — every saved plan already matches its post-fix title/slug.")
+		return nil
+	}
+
+	// Best-effort push, same contract as commitPlanToLedger/savePlanArtifacts:
+	// a push failure leaves the local commit for the next push / `ox doctor`
+	// rather than failing the whole command — the mv/edit/commit work already
+	// landed locally and re-running the command would otherwise redo it.
+	if err := commitPlanBackfillToLedger(ledgerPath, renames, touchedPlanDirs, touchedSessionDirs); err != nil {
+		slog.Warn("plan backfill: commit/push failed, deferring to next push/doctor", "error", err)
+		cli.PrintHint("commit/push failed (see log) — the local commit stands; retry with `ox doctor --fix` or a plain push.")
+	}
+
+	slog.Info("plan_backfill_titles", "total", total, "retitled", retitled, "renamed", renamedCount, "skipped", skipped, "sessions_fixed", len(touchedSessionDirs))
+	fmt.Fprintf(out, "\nBackfilled: total=%d retitled=%d renamed=%d skipped=%d sessions_fixed=%d\n",
+		total, retitled, renamedCount, skipped, len(touchedSessionDirs))
+	return nil
+}
+
+// writeBackfillTable prints the full old->new retitle/rename table — the
+// artifact a human reviews before allowing a real run — plus, when any
+// exist, the sessions whose produced_plans need fixing.
+func writeBackfillTable(out io.Writer, candidates []plan.BackfillPlan, sessionRewrites []plan.ProducedPlansRewrite) {
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "OLD SLUG\tNEW SLUG\tOLD TOPIC\tNEW TOPIC\tACTION")
+	for _, c := range candidates {
+		if c.SkipReason != "" {
+			fmt.Fprintf(tw, "%s\t—\t—\t—\tSKIPPED: %s\n", filepath.Base(c.OldDir), c.SkipReason)
+			continue
+		}
+		action := "unchanged"
+		switch {
+		case c.Changed() && c.NewDir != "":
+			action = "retitled + renamed"
+		case c.Changed():
+			action = "retitled"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			c.OldSlug, c.NewSlug, truncate(c.OldTopic, 40), truncate(c.NewTopic, 40), action)
+	}
+	_ = tw.Flush()
+
+	if len(sessionRewrites) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "\nSessions with stale produced_plans to fix:")
+	tw2 := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw2, "SESSION\tSTALE SLUGS")
+	for _, r := range sessionRewrites {
+		fmt.Fprintf(tw2, "%s\t%s\n", filepath.Base(r.SessionDir), strings.Join(r.OldSlugs, ", "))
+	}
+	_ = tw2.Flush()
+}
+
+// backfillCounts summarizes a computed batch for the printed/logged totals:
+// total scanned, how many need a topic/slug correction, how many of those
+// also need a directory rename, and how many were unreadable and skipped.
+func backfillCounts(candidates []plan.BackfillPlan) (total, retitled, renamed, skipped int) {
+	for _, c := range candidates {
+		total++
+		if c.SkipReason != "" {
+			skipped++
+			continue
+		}
+		if c.Changed() {
+			retitled++
+		}
+		if c.NewDir != "" {
+			renamed++
+		}
+	}
+	return total, retitled, renamed, skipped
+}

--- a/cmd/ox/plan_backfill_preflight.go
+++ b/cmd/ox/plan_backfill_preflight.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/plan"
+)
+
+// plan_backfill_preflight.go owns the git plumbing for the two safety
+// guards `ox plan backfill-titles` runs before it scans a single plan
+// directory — the pure abort/proceed verdicts live in
+// internal/plan/backfill_preflight.go (VerifyCorpusComplete,
+// VerifyNotDiverged), following the same compute-vs-orchestrate split as
+// ComputeBackfill/ApplyBackfillMeta. Neither guard fetches: like
+// checkLedgerBranchStatus (doctor_ledger_git.go), they trust the daemon's
+// own sync loop to keep origin/main current and only read cached refs —
+// this must stay fast and side-effect-free since it runs on every
+// invocation, dry-run included.
+
+// preflightPlanBackfill runs both guards against ledgerPath before
+// runPlanBackfillTitlesOnLedger computes or prints anything. Returning an
+// error here aborts the command outright — in both dry-run and real mode,
+// since a dry-run's retitle/rename table is only a trustworthy reviewable
+// artifact if the corpus it scanned was actually complete.
+func preflightPlanBackfill(ctx context.Context, out io.Writer, ledgerPath string, allowDiverged bool) error {
+	localCount, err := plan.CountPlanDirs(paths.LedgerPlansDir(ledgerPath))
+	if err != nil {
+		return fmt.Errorf("count local plan dirs: %w", err)
+	}
+	remoteCount, remoteKnown := remotePlanDirCount(ctx, ledgerPath)
+
+	note, err := plan.VerifyCorpusComplete(localCount, remoteCount, remoteKnown)
+	if err != nil {
+		slog.Error("plan_backfill_preflight_abort", "guard", "corpus_completeness", "local_count", localCount, "remote_count", remoteCount, "remote_known", remoteKnown, "error", err)
+		return err
+	}
+	if note != "" {
+		slog.Info("plan_backfill_preflight", "guard", "corpus_completeness", "local_count", localCount, "remote_count", remoteCount, "remote_known", remoteKnown, "note", note)
+		fmt.Fprintln(out, note)
+	}
+
+	ahead, behind, divergenceRemoteKnown := aheadBehindCounts(ctx, ledgerPath)
+	note, err = plan.VerifyNotDiverged(ahead, behind, divergenceRemoteKnown, allowDiverged)
+	if err != nil {
+		slog.Error("plan_backfill_preflight_abort", "guard", "divergence", "ahead", ahead, "behind", behind, "remote_known", divergenceRemoteKnown, "allow_diverged", allowDiverged, "error", err)
+		return err
+	}
+	if note != "" {
+		slog.Info("plan_backfill_preflight", "guard", "divergence", "ahead", ahead, "behind", behind, "remote_known", divergenceRemoteKnown, "note", note)
+		fmt.Fprintln(out, note)
+	}
+	return nil
+}
+
+// remotePlanDirCount counts plan directories under data/plans on
+// origin/main — the read-only remote-side count Guard 1 compares the
+// working tree against. `git ls-tree` on a path that resolves to a subtree
+// lists that subtree's immediate children non-recursively, exactly the
+// per-directory count CountPlanDirs computes locally.
+//
+// remoteKnown=false whenever origin/main can't be resolved at all (no
+// remote configured, a repo that's never been fetched, or — in tests — not
+// a git repository yet). That is NOT the same as origin/main resolving to a
+// tree with zero plans (an empty ledger): `git ls-tree` exits 0 with empty
+// output when the path is simply absent from an otherwise-valid tree, so
+// only a genuine git error (non-nil err) marks the remote unknown.
+func remotePlanDirCount(ctx context.Context, ledgerPath string) (count int, remoteKnown bool) {
+	out, err := gitutil.RunGit(ctx, ledgerPath, "ls-tree", "-d", "--name-only", "origin/main", "data/plans/")
+	if err != nil {
+		return 0, false
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return 0, true
+	}
+	return len(strings.Split(trimmed, "\n")), true
+}
+
+// aheadBehindCounts returns the ledger's commit divergence from
+// origin/main, mirroring fixLedgerBranchDiverged's git rev-list
+// --left-right pattern (doctor_ledger_git.go) rather than inventing new
+// plumbing. remoteKnown=false whenever origin/main can't be resolved.
+func aheadBehindCounts(ctx context.Context, ledgerPath string) (ahead, behind int, remoteKnown bool) {
+	out, err := gitutil.RunGit(ctx, ledgerPath, "rev-list", "--left-right", "--count", "origin/main...HEAD")
+	if err != nil {
+		return 0, 0, false
+	}
+	// "git rev-list --left-right --count L...R" prints "<only-in-L> <only-in-R>":
+	// commits only reachable from origin/main (behind) first, then commits only
+	// reachable from HEAD (ahead) — same order fixLedgerBranchDiverged parses.
+	parts := strings.Fields(out)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	behindN, errBehind := strconv.Atoi(parts[0])
+	aheadN, errAhead := strconv.Atoi(parts[1])
+	if errBehind != nil || errAhead != nil {
+		return 0, 0, false
+	}
+	return aheadN, behindN, true
+}

--- a/cmd/ox/plan_backfill_preflight_test.go
+++ b/cmd/ox/plan_backfill_preflight_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/plan"
+)
+
+// plan_backfill_preflight_test.go covers the two safety guards
+// preflightPlanBackfill (plan_backfill_preflight.go) runs before
+// runPlanBackfillTitlesOnLedger scans a single plan directory. The pure
+// abort/proceed verdicts (VerifyCorpusComplete, VerifyNotDiverged) are
+// proven directly in internal/plan/backfill_preflight_test.go; this file
+// proves the git-backed counting wires into that verdict correctly, and
+// that an abort here actually stops the command before it does anything —
+// including in dry-run mode, which is the whole point of Guard 1.
+
+// runGitInDir runs a git command in dir, failing the test on error.
+func runGitInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v (in %s): %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+// initGitLedgerWithOrigin builds a local git repo AND a bare "origin" remote
+// pre-loaded with its current content, then fetches it — so origin/main
+// resolves locally, which is what both guards compare against. Deliberately
+// separate from plan_backfill_test.go's initGitLedger (which configures no
+// remote at all): that absence is itself a fixture, exercising the
+// "unresolvable origin/main" skip path every guard must degrade to safely.
+//
+// Forces the branch name to "main" via "git init -b main" regardless of the
+// host's init.defaultBranch — both guards hardcode "origin/main" (matching
+// production: ledgers are always on main), so a test host defaulting to
+// "master" would silently make every case here exercise the skip path
+// instead of the divergence/completeness path under test.
+func initGitLedgerWithOrigin(t *testing.T, ledgerPath string) (originPath string) {
+	t.Helper()
+	runGitInDir(t, ledgerPath, "init", "-q", "-b", "main")
+	runGitInDir(t, ledgerPath, "config", "user.email", "test@example.com")
+	runGitInDir(t, ledgerPath, "config", "user.name", "Test")
+	runGitInDir(t, ledgerPath, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(ledgerPath, ".gitignore"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitInDir(t, ledgerPath, "add", "-A")
+	runGitInDir(t, ledgerPath, "commit", "-q", "-m", "init")
+
+	originPath = t.TempDir()
+	runGitInDir(t, originPath, "init", "-q", "--bare")
+	runGitInDir(t, ledgerPath, "remote", "add", "origin", originPath)
+	runGitInDir(t, ledgerPath, "push", "-q", "-u", "origin", "main")
+	return originPath
+}
+
+// TestRunPlanBackfillTitlesOnLedger_NoRemoteSkipsBothGuards proves a ledger
+// with no remote at all (the common case for a brand-new/local-only ledger)
+// is NOT blocked by either guard — both degrade to a printed skip note and
+// the command proceeds exactly as it did before these guards existed.
+func TestRunPlanBackfillTitlesOnLedger_NoRemoteSkipsBothGuards(t *testing.T) {
+	ledger := t.TempDir()
+	writeBackfillPlanFixture(t, ledger, "2026-05-01-1-context-why-now", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	initGitLedger(t, ledger) // no remote configured
+
+	out, err := runBackfillForTest(t, ledger, true)
+	if err != nil {
+		t.Fatalf("runPlanBackfillTitlesOnLedger with no remote configured: %v", err)
+	}
+	if !strings.Contains(out, "corpus completeness check skipped") {
+		t.Errorf("output missing the corpus-completeness skip note:\n%s", out)
+	}
+	if !strings.Contains(out, "divergence check skipped") {
+		t.Errorf("output missing the divergence skip note:\n%s", out)
+	}
+	if !strings.Contains(out, "Dry run — nothing written.") {
+		t.Errorf("preflight skip notes must not block the rest of the command:\n%s", out)
+	}
+}
+
+// TestRunPlanBackfillTitlesOnLedger_DivergedLedgerAborts proves Guard 2 stops
+// a run when the ledger has a local commit origin/main doesn't have yet —
+// landing a batch rename on top of that divergence is exactly what turns a
+// routine repair into a manual rebase.
+func TestRunPlanBackfillTitlesOnLedger_DivergedLedgerAborts(t *testing.T) {
+	ledger := t.TempDir()
+	writeBackfillPlanFixture(t, ledger, "2026-05-01-1-context-why-now", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	initGitLedgerWithOrigin(t, ledger)
+
+	if err := os.WriteFile(filepath.Join(ledger, "unpushed.txt"), []byte("local only\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitInDir(t, ledger, "add", "-A")
+	runGitInDir(t, ledger, "commit", "-q", "-m", "local-only commit")
+
+	out, err := runBackfillForTest(t, ledger, true)
+	if err == nil {
+		t.Fatalf("expected the divergence guard to abort, got output:\n%s", out)
+	}
+	var derr *plan.DivergenceError
+	if !errors.As(err, &derr) {
+		t.Fatalf("error = %v (%T), want *plan.DivergenceError", err, err)
+	}
+	if derr.Ahead != 1 || derr.Behind != 0 {
+		t.Errorf("DivergenceError = {ahead:%d behind:%d}, want {ahead:1 behind:0}", derr.Ahead, derr.Behind)
+	}
+	if !strings.Contains(err.Error(), "--allow-diverged") {
+		t.Errorf("abort message missing the --allow-diverged remedy: %v", err)
+	}
+}
+
+// TestRunPlanBackfillTitlesOnLedger_AllowDivergedOverridesAbort proves the
+// --allow-diverged escape hatch lets an operator who already knows their
+// ledger is intentionally ahead/behind proceed anyway.
+func TestRunPlanBackfillTitlesOnLedger_AllowDivergedOverridesAbort(t *testing.T) {
+	ledger := t.TempDir()
+	writeBackfillPlanFixture(t, ledger, "2026-05-01-1-context-why-now", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	initGitLedgerWithOrigin(t, ledger)
+
+	if err := os.WriteFile(filepath.Join(ledger, "unpushed.txt"), []byte("local only\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitInDir(t, ledger, "add", "-A")
+	runGitInDir(t, ledger, "commit", "-q", "-m", "local-only commit")
+
+	out, err := runBackfillForTestWithFlags(t, ledger, true, true)
+	if err != nil {
+		t.Fatalf("runPlanBackfillTitlesOnLedger with --allow-diverged: %v", err)
+	}
+	if !strings.Contains(out, "--allow-diverged was passed") {
+		t.Errorf("output missing the allow-diverged proceeding note:\n%s", out)
+	}
+	if !strings.Contains(out, "Dry run — nothing written.") {
+		t.Errorf("the divergence override must not block the rest of the command:\n%s", out)
+	}
+}
+
+// TestRunPlanBackfillTitlesOnLedger_IncompleteCorpusAbortsInDryRun reproduces
+// the exact production incident: a plan directory present in git history
+// (and on origin/main) but missing from the working tree, e.g. because
+// git sparse-checkout set evicted it. Guard 1 must abort even for --dry-run
+// — a dry run's table is only trustworthy if the corpus it scanned was
+// complete, and this is the case where it silently wasn't.
+func TestRunPlanBackfillTitlesOnLedger_IncompleteCorpusAbortsInDryRun(t *testing.T) {
+	ledger := t.TempDir()
+	dirA := writeBackfillPlanFixture(t, ledger, "2026-05-01-plan-a", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	writeBackfillPlanFixture(t, ledger, "2026-05-02-plan-b", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC))
+	initGitLedgerWithOrigin(t, ledger) // both dirs committed + pushed: local == remote == 2
+
+	// Delete ONLY the working-tree copy — content stays in HEAD and on
+	// origin/main, matching what a sparse-checkout eviction does (it touches
+	// disk, never history).
+	if err := os.RemoveAll(dirA); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runBackfillForTest(t, ledger, true) // dry-run
+	if err == nil {
+		t.Fatalf("expected the corpus-completeness guard to abort a dry run, got output:\n%s", out)
+	}
+	var cerr *plan.CorpusCompletenessError
+	if !errors.As(err, &cerr) {
+		t.Fatalf("error = %v (%T), want *plan.CorpusCompletenessError", err, err)
+	}
+	if cerr.LocalCount != 1 || cerr.RemoteCount != 2 {
+		t.Errorf("CorpusCompletenessError = {local:%d remote:%d}, want {local:1 remote:2}", cerr.LocalCount, cerr.RemoteCount)
+	}
+	if strings.Contains(out, "Dry run — nothing written.") {
+		t.Errorf("an aborted preflight must never reach the dry-run summary line:\n%s", out)
+	}
+}

--- a/cmd/ox/plan_backfill_test.go
+++ b/cmd/ox/plan_backfill_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/plan"
+	"github.com/spf13/cobra"
+)
+
+// plan_backfill_test.go covers the cmd/ox layer of `ox plan backfill-titles`:
+// dry-run output/no-op contract and the real-run apply+rename+commit
+// orchestration. The retitle/rename/collision/idempotency computation itself
+// is proven directly against internal/plan.ComputeBackfill/ApplyBackfillMeta
+// in internal/plan/backfill_test.go — this file only proves the CLI plumbing
+// wires those primitives together correctly, per the test pyramid split
+// plan_lifecycle_test.go already documents for this command family.
+
+// writeBackfillPlanFixture hand-writes a plan directory (plan.md, meta.json,
+// events.jsonl) directly under ledgerPath/data/plans — the on-disk shape
+// runPlanBackfillTitlesOnLedger reads — without going through plan.Save,
+// since Save's ledger resolution goes through a package-private resolver
+// tests outside internal/plan cannot override. buggyTopic simulates exactly
+// what the pre-ox-1tjj.8 planTopic wrote: the first H2's text, not the H1's.
+func writeBackfillPlanFixture(t *testing.T, ledgerPath, dirName, raw, buggyTopic string, createdAt time.Time) string {
+	t.Helper()
+	dir := filepath.Join(ledgerPath, "data", "plans", dirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "plan.md"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := plan.Meta{Topic: buggyTopic, Slug: plan.Slugify(buggyTopic), CreatedAt: createdAt}
+	metaBytes, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), metaBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ev := plan.Event{PlanID: "pln_backfilltest00000001", Kind: plan.EventCreated, Status: plan.PlanStatusDraft, Topic: buggyTopic}
+	if err := plan.AppendEvent(context.Background(), dir, ev); err != nil {
+		t.Fatalf("seed created event: %v", err)
+	}
+	return dir
+}
+
+// runBackfillForTest wires an isolated cobra.Command (own buffer, own
+// context) and calls runPlanBackfillTitlesOnLedger directly against
+// ledgerPath — the testable core, bypassing findGitRoot/config resolution.
+func runBackfillForTest(t *testing.T, ledgerPath string, dryRun bool) (string, error) {
+	t.Helper()
+	return runBackfillForTestWithFlags(t, ledgerPath, dryRun, false)
+}
+
+// runBackfillForTestWithFlags is runBackfillForTest plus the --allow-diverged
+// escape hatch, for the preflight-guard tests that need to exercise it.
+func runBackfillForTestWithFlags(t *testing.T, ledgerPath string, dryRun, allowDiverged bool) (string, error) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err := runPlanBackfillTitlesOnLedger(cmd, ledgerPath, dryRun, allowDiverged)
+	return out.String(), err
+}
+
+const backfillTestRaw = "# Conversation model update — the execution plan\n\n" +
+	"## 1. Context — Why Now\n\nframing prose.\n\n## Approach\n\ndo the thing.\n"
+
+func TestRunPlanBackfillTitlesOnLedger_DryRunTouchesNothing(t *testing.T) {
+	ledger := t.TempDir()
+	dir := writeBackfillPlanFixture(t, ledger, "2026-05-01-1-context-why-now", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+
+	metaBefore, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runBackfillForTest(t, ledger, true)
+	if err != nil {
+		t.Fatalf("runPlanBackfillTitlesOnLedger dry-run: %v", err)
+	}
+
+	if !strings.Contains(out, "Dry run — nothing written.") {
+		t.Errorf("output missing dry-run banner:\n%s", out)
+	}
+	if !strings.Contains(out, "total=1 retitled=1 renamed=1 skipped=0") {
+		t.Errorf("output missing expected counts:\n%s", out)
+	}
+	if !strings.Contains(out, "Conversation model update") {
+		t.Errorf("output missing the corrected title:\n%s", out)
+	}
+	if !strings.Contains(out, "retitled + renamed") {
+		t.Errorf("output missing the retitled+renamed action:\n%s", out)
+	}
+
+	// Nothing on disk changed: same dir, same meta.json bytes, no new dir.
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("original plan dir was removed/renamed during a dry-run: %v", err)
+	}
+	metaAfter, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(metaBefore) != string(metaAfter) {
+		t.Errorf("meta.json changed during a dry-run")
+	}
+	entries, err := os.ReadDir(filepath.Join(ledger, "data", "plans"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("plans dir has %d entries after dry-run, want 1 (no rename applied)", len(entries))
+	}
+}
+
+func TestRunPlanBackfillTitlesOnLedger_DryRunNoPlansIsCleanNoOp(t *testing.T) {
+	ledger := t.TempDir()
+	out, err := runBackfillForTest(t, ledger, true)
+	if err != nil {
+		t.Fatalf("runPlanBackfillTitlesOnLedger on an empty ledger: %v", err)
+	}
+	if !strings.Contains(out, "total=0") {
+		t.Errorf("output = %q, want total=0", out)
+	}
+}
+
+// initGitLedger turns ledgerPath into a minimal git repo with one commit —
+// the real-run path's git mv/add/commit needs a working git repository.
+// Pushing is best-effort (see runPlanBackfillTitlesOnLedger's contract
+// mirroring commitPlanToLedger/savePlanArtifacts) and is expected to fail
+// here (no remote configured) without failing the command.
+func initGitLedger(t *testing.T, ledgerPath string) {
+	t.Helper()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = ledgerPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+	run("config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(ledgerPath, ".gitignore"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-q", "-m", "init")
+}
+
+// TestRunPlanBackfillTitlesOnLedger_RealRunRenamesAndCommits exercises the
+// real (non-dry-run) path end to end against an actual git repo: the plan
+// directory is renamed on disk, its meta.json is corrected, and a batch
+// commit lands — all without a network push succeeding (best-effort, must
+// not fail the command).
+func TestRunPlanBackfillTitlesOnLedger_RealRunRenamesAndCommits(t *testing.T) {
+	ledger := t.TempDir()
+	oldDir := writeBackfillPlanFixture(t, ledger, "2026-05-01-1-context-why-now", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	initGitLedger(t, ledger)
+
+	out, err := runBackfillForTest(t, ledger, false)
+	if err != nil {
+		t.Fatalf("runPlanBackfillTitlesOnLedger real run: %v", err)
+	}
+	if !strings.Contains(out, "Backfilled: total=1 retitled=1 renamed=1 skipped=0") {
+		t.Errorf("output missing expected summary:\n%s", out)
+	}
+
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Errorf("old plan dir still exists after a real run: stat err=%v", err)
+	}
+	newDir := filepath.Join(ledger, "data", "plans", "2026-05-01-conversation-model-update-the-execution-plan")
+	metaBytes, err := os.ReadFile(filepath.Join(newDir, "meta.json"))
+	if err != nil {
+		t.Fatalf("renamed plan dir missing meta.json: %v", err)
+	}
+	var meta plan.Meta
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.Topic != "Conversation model update — the execution plan" {
+		t.Errorf("meta.Topic = %q, want the corrected H1 title", meta.Topic)
+	}
+
+	// The rename + edit landed in a real git commit (whether or not the
+	// best-effort push to a nonexistent remote succeeded).
+	logCmd := exec.Command("git", "log", "--oneline")
+	logCmd.Dir = ledger
+	logOut, err := logCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log: %v\n%s", err, logOut)
+	}
+	if !strings.Contains(string(logOut), "plan: backfill 1 title") {
+		t.Errorf("git log missing the batch commit:\n%s", logOut)
+	}
+	statusCmd := exec.Command("git", "status", "--porcelain")
+	statusCmd.Dir = ledger
+	statusOut, err := statusCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git status: %v\n%s", err, statusOut)
+	}
+	if strings.TrimSpace(string(statusOut)) != "" {
+		t.Errorf("working tree not clean after the batch commit:\n%s", statusOut)
+	}
+}
+
+// TestRunPlanBackfillTitlesOnLedger_RealRunIdempotent proves a second real
+// run on an already-backfilled ledger is a clean no-op: no further rename,
+// no new commit.
+func TestRunPlanBackfillTitlesOnLedger_RealRunIdempotent(t *testing.T) {
+	ledger := t.TempDir()
+	writeBackfillPlanFixture(t, ledger, "2026-05-01-1-context-why-now", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	initGitLedger(t, ledger)
+
+	if _, err := runBackfillForTest(t, ledger, false); err != nil {
+		t.Fatalf("first real run: %v", err)
+	}
+	// exec.Cmd runs exactly once — a fresh Command is needed for each git log
+	// call, not a reused one.
+	gitLog := func() string {
+		t.Helper()
+		cmd := exec.Command("git", "log", "--oneline")
+		cmd.Dir = ledger
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git log: %v\n%s", err, out)
+		}
+		return string(out)
+	}
+	before := gitLog()
+
+	out, err := runBackfillForTest(t, ledger, false)
+	if err != nil {
+		t.Fatalf("second real run: %v", err)
+	}
+	if !strings.Contains(out, "Nothing to backfill") {
+		t.Errorf("second run output = %q, want the no-op message", out)
+	}
+
+	after := gitLog()
+	if before != after {
+		t.Errorf("a no-op second run created a new commit:\nbefore: %s\nafter:  %s", before, after)
+	}
+}

--- a/cmd/ox/plan_commit.go
+++ b/cmd/ox/plan_commit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/sageox/ox/internal/config"
@@ -98,9 +99,7 @@ func commitPlanBackfillToLedger(ledgerPath string, renames [][2]string, touchedP
 		}
 	}
 
-	addPaths := make([]string, 0, len(touchedPlanDirs)+len(touchedSessionDirs))
-	addPaths = append(addPaths, touchedPlanDirs...)
-	addPaths = append(addPaths, touchedSessionDirs...)
+	addPaths := slices.Concat(touchedPlanDirs, touchedSessionDirs)
 	if len(addPaths) > 0 {
 		addArgs := append([]string{"-C", ledgerPath, "add", "--sparse"}, addPaths...)
 		if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {

--- a/cmd/ox/plan_commit.go
+++ b/cmd/ox/plan_commit.go
@@ -52,3 +52,70 @@ func commitPlanToLedger(gitRoot, planDir string) error {
 
 	return pushLedger(context.Background(), ledgerPath)
 }
+
+// commitPlanBackfillToLedger stages every backfilled plan rename, in-place
+// plan edit, and session produced_plans fix into ONE commit and pushes it —
+// the batch counterpart to commitPlanToLedger (which commits a single saved
+// plan). A repair run can touch hundreds of plans; landing that as one
+// reviewable commit beats one commit per directory. Mirrors
+// commitPlanToLedger's pattern (--sparse, --no-verify, pushLedger with
+// pull-rebase retry) rather than hand-rolling new git plumbing.
+//
+// renames are (oldAbsPath, newAbsPath) pairs applied via `git mv --sparse`.
+// touchedPlanDirs/touchedSessionDirs are absolute paths edited in-place
+// (topic-only correction with no slug change; a session's produced_plans
+// fix) that need a plain `git add`.
+//
+// Each rename is `git mv` followed by an explicit `git add` of the NEW path.
+// `git mv` alone is NOT enough here: it only restages the move of whatever
+// content is already in the index (HEAD) — a file mutated on disk but never
+// `git add`'d before the mv (exactly ApplyBackfillMeta's write, which happens
+// before this function is ever called) rides along as a rename of the OLD
+// content, leaving the just-mutated bytes as an uncommitted diff on the NEW
+// path immediately after the commit. Confirmed against git 2.55 directly —
+// `git status --porcelain` shows "RM" (rename + pending modify), not a clean
+// rename, when the source was dirty. The follow-up `git add` stages the
+// current working-tree content at the new path in the same pass.
+func commitPlanBackfillToLedger(ledgerPath string, renames [][2]string, touchedPlanDirs, touchedSessionDirs []string) error {
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
+	for _, pair := range renames {
+		oldRel, err := filepath.Rel(ledgerPath, pair[0])
+		if err != nil {
+			return fmt.Errorf("relativize %q: %w", pair[0], err)
+		}
+		newRel, err := filepath.Rel(ledgerPath, pair[1])
+		if err != nil {
+			return fmt.Errorf("relativize %q: %w", pair[1], err)
+		}
+		mvArgs := []string{"-C", ledgerPath, "mv", "--sparse", oldRel, newRel}
+		if out, err := exec.Command("git", mvArgs...).CombinedOutput(); err != nil {
+			return fmt.Errorf("git mv %s -> %s failed: %s: %w", oldRel, newRel, string(out), err)
+		}
+		addArgs := []string{"-C", ledgerPath, "add", "--sparse", newRel}
+		if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
+			return fmt.Errorf("git add %s (post-mv content) failed: %s: %w", newRel, string(out), err)
+		}
+	}
+
+	addPaths := make([]string, 0, len(touchedPlanDirs)+len(touchedSessionDirs))
+	addPaths = append(addPaths, touchedPlanDirs...)
+	addPaths = append(addPaths, touchedSessionDirs...)
+	if len(addPaths) > 0 {
+		addArgs := append([]string{"-C", ledgerPath, "add", "--sparse"}, addPaths...)
+		if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
+			return fmt.Errorf("git add failed: %s: %w", string(out), err)
+		}
+	}
+
+	commitMsg := fmt.Sprintf("plan: backfill %d title(s)", len(renames)+len(touchedPlanDirs))
+	commitCmd := exec.Command("git", "-C", ledgerPath, "commit", "--no-verify", "-m", commitMsg)
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		if strings.Contains(string(out), "nothing to commit") {
+			return nil // idempotent: re-run with nothing left to change
+		}
+		return fmt.Errorf("%s: %w", wrapCommitError(string(out), err), err)
+	}
+
+	return pushLedger(context.Background(), ledgerPath)
+}

--- a/cmd/ox/plan_topic_test.go
+++ b/cmd/ox/plan_topic_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/internal/plan"
+)
+
+// plan_topic_test.go covers planTopic directly — ox-1tjj.8's coverage hole
+// (`git grep -n planTopic -- '*_test.go'` returned nothing before this file
+// existed). planTopic used to independently walk in.Sections for the first
+// non-empty Heading, which — because plan.Parse splits markdown on H2 ("## ")
+// only — could never see a document's H1 (it lives in the Heading=="" preamble
+// section): a plan whose H1 was a real title followed by a numbered-context or
+// TL;DR H2 saved to the ledger under the H2's text instead. These cases pin
+// the fix: planTopic now delegates to plan.Title (already covered in depth by
+// internal/plan/title_test.go) for everything except the --topic short-circuit.
+func TestPlanTopic(t *testing.T) {
+	tests := []struct {
+		name string
+		in   plan.Input
+		want string
+	}{
+		{
+			name: "the ox-1tjj.8 regression: H1 followed by a numbered context H2",
+			in: plan.Parse("# Conversation model update — the execution plan\n\n" +
+				"## 1. Context — Why Now\n\nSome framing prose.\n\n" +
+				"## Approach\n\nDo the thing.\n"),
+			want: "Conversation model update — the execution plan",
+		},
+		{
+			name: "the ox-1tjj.8 regression: H1 followed by a TL;DR H2",
+			in: plan.Parse("# ox plan — Team-Context-Enriched Plans\n\n" +
+				"## TL;DR\n\nShip it.\n\n" +
+				"## Design\n\nDetails.\n"),
+			want: "ox plan — Team-Context-Enriched Plans",
+		},
+		{
+			name: "no H1 — falls back to the first H2 heading",
+			in:   plan.Parse("preamble prose\n\n## First Section\n\nbody\n"),
+			want: "First Section",
+		},
+		{
+			name: "no headings at all falls back to the generic default",
+			in:   plan.Parse("just a paragraph\n"),
+			want: "Implementation Plan",
+		},
+		{
+			name: "in.Topic short-circuits even when in.Raw carries a different heading",
+			in: plan.Input{
+				Topic: "explicit consult topic",
+				Raw:   "# A Different Document Title\n\nbody\n",
+			},
+			want: "explicit consult topic",
+		},
+		{
+			name: "--topic consult mode: no document exists yet",
+			in:   plan.Input{Topic: "pre-draft subject", Sections: []plan.Section{{Body: "pre-draft subject"}}},
+			want: "pre-draft subject",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := planTopic(tc.in); got != tc.want {
+				t.Errorf("planTopic(...) = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -461,8 +461,29 @@ func CloneWithSparseCheckout(path, remoteURL string) error {
 	return nil
 }
 
+// baseSparseDirs are the ledger directories checked out in full, always —
+// as opposed to the data/github and data/murmurs siblings, which are added as
+// rolling windows.
+//
+// data/plans is deliberately unwindowed. Plans are durable artifacts every
+// local read path needs (`ox plan list/view/render/backfill-titles`), and they
+// are tiny: plan.md + annotations.json + events.jsonl, with the only large
+// member (plan.html) LFS-gated above 256 KB. Omitting it made plans
+// effectively WRITE-ONLY — `ox plan save` wrote and pushed a plan directory,
+// then the sync scheduler's ~60s ConfigureSparseCheckout refresh deleted it
+// from the working tree again, leaving ledgers with dozens of plans on
+// origin/main and none on disk. Only dirtyDirsOutsideCone kept a save alive
+// long enough to commit at all.
+var baseSparseDirs = []string{
+	".sageox",
+	".sync",
+	"sessions",
+	"audit",
+	"data/plans",
+}
+
 // ConfigureSparseCheckout sets up sparse checkout for the ledger.
-// Includes: .sync/, sessions/, audit/, a sliding window of recent GitHub data,
+// Includes: baseSparseDirs, a sliding window of recent GitHub data,
 // and a rolling window of recent murmur data (hourly granularity).
 // Excludes: assets/ (large files), older data outside the windows.
 //
@@ -490,12 +511,7 @@ func ConfigureSparseCheckout(path string) error {
 	}
 
 	// base directories always included
-	dirs := []string{
-		".sageox",
-		".sync",
-		"sessions",
-		"audit",
-	}
+	dirs := append([]string{}, baseSparseDirs...)
 
 	// add sliding window of recent GitHub data (last N days, default 30)
 	// keeps local disk usage small; older data lives in git history

--- a/internal/ledger/murmur_sparse_test.go
+++ b/internal/ledger/murmur_sparse_test.go
@@ -117,11 +117,13 @@ func TestConfigureSparseCheckout_MurmurDoesNotBreakExisting(t *testing.T) {
 		t.Errorf("expected %d GitHub data paths, got %d (murmur integration may have broken GitHub paths)", DefaultGitHubDataWindowDays, githubCount)
 	}
 
-	// total should be base dirs (.sageox, .sync, sessions, audit) + GitHub + murmur
-	expectedTotal := 4 + DefaultGitHubDataWindowDays + DefaultMurmurWindowHours
+	// total should be base dirs + GitHub + murmur. Derived from baseSparseDirs
+	// rather than hardcoded: adding a base dir is a legitimate change, and what
+	// this assertion actually guards is the windows not clobbering the bases.
+	expectedTotal := len(baseSparseDirs) + DefaultGitHubDataWindowDays + DefaultMurmurWindowHours
 	if len(lines) != expectedTotal {
-		t.Errorf("expected %d total sparse checkout entries (4 base + %d GitHub + %d murmur), got %d",
-			expectedTotal, DefaultGitHubDataWindowDays, DefaultMurmurWindowHours, len(lines))
+		t.Errorf("expected %d total sparse checkout entries (%d base + %d GitHub + %d murmur), got %d",
+			expectedTotal, len(baseSparseDirs), DefaultGitHubDataWindowDays, DefaultMurmurWindowHours, len(lines))
 	}
 }
 

--- a/internal/ledger/plans_sparse_test.go
+++ b/internal/ledger/plans_sparse_test.go
@@ -1,0 +1,68 @@
+package ledger
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestConfigureSparseCheckout_IncludesDataPlans pins data/plans into the cone.
+//
+// Its absence made plans write-only on disk: `ox plan save` wrote and pushed a
+// plan directory, then the sync scheduler's ~60s ConfigureSparseCheckout
+// refresh deleted it from the working tree, leaving ledgers with dozens of
+// plans on origin/main and none locally. Every local plan read path
+// (`ox plan list/view/render/backfill-titles`) depends on this entry.
+func TestConfigureSparseCheckout_IncludesDataPlans(t *testing.T) {
+	tempDir := t.TempDir()
+
+	if err := exec.Command("git", "init", tempDir).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	if err := ConfigureSparseCheckout(tempDir); err != nil {
+		t.Fatalf("ConfigureSparseCheckout: %v", err)
+	}
+
+	output, err := exec.Command("git", "-C", tempDir, "sparse-checkout", "list").Output()
+	if err != nil {
+		t.Fatalf("sparse-checkout list: %v", err)
+	}
+
+	if !strings.Contains(string(output), "data/plans") {
+		t.Errorf("sparse checkout missing data/plans in output:\n%s", output)
+	}
+}
+
+// TestConfigureSparseCheckout_DataPlansIsNotWindowed guards the one way
+// data/plans differs from its data/ siblings: github and murmur paths are
+// rolling windows (data/github/YYYY/MM/DD, data/murmurs/YYYY-MM-DD-HH), so a
+// plan saved outside the window would vanish if plans were ever given the same
+// treatment. The cone must carry the bare parent directory, not a dated child.
+func TestConfigureSparseCheckout_DataPlansIsNotWindowed(t *testing.T) {
+	tempDir := t.TempDir()
+
+	if err := exec.Command("git", "init", tempDir).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	if err := ConfigureSparseCheckout(tempDir); err != nil {
+		t.Fatalf("ConfigureSparseCheckout: %v", err)
+	}
+
+	output, err := exec.Command("git", "-C", tempDir, "sparse-checkout", "list").Output()
+	if err != nil {
+		t.Fatalf("sparse-checkout list: %v", err)
+	}
+
+	for _, line := range strings.Split(string(output), "\n") {
+		entry := strings.Trim(strings.TrimSpace(line), "/")
+		if entry == "data/plans" {
+			return
+		}
+		if strings.HasPrefix(entry, "data/plans/") {
+			t.Fatalf("data/plans is windowed as %q; a plan outside the window would be deleted from the working tree", entry)
+		}
+	}
+	t.Fatalf("no data/plans entry in sparse-checkout list:\n%s", output)
+}

--- a/internal/plan/backfill.go
+++ b/internal/plan/backfill.go
@@ -1,0 +1,299 @@
+package plan
+
+// backfill.go computes and applies the one-off repair pass for plans saved by
+// the pre-ox-1tjj.8 planTopic (which read the first H2 heading, not the
+// document's H1 — see title.go). It is deliberately split into a read-only
+// COMPUTE half (ComputeBackfill, ComputeProducedPlansRewrite — safe to run
+// any number of times, used directly by `ox plan backfill-titles --dry-run`)
+// and an APPLY half (ApplyBackfillMeta, ApplyProducedPlansRewrite) that
+// mutates one plan/session at a time. The cmd/ox layer owns git (mv/add/
+// commit/push) and orchestrates: compute -> print -> (if not dry-run) apply
+// each -> git mv -> one batch commit.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/sageox/ox/internal/fileutil"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/planid"
+)
+
+// BackfillPlan is one plan directory's before/after retitle+rename, computed
+// by ComputeBackfill. It is the reviewable unit `ox plan backfill-titles
+// --dry-run` prints and the real run applies unchanged (the dry-run table IS
+// the plan, not a preview of a separately-computed one).
+type BackfillPlan struct {
+	OldDir   string // absolute path, current
+	NewDir   string // absolute path after rename; "" when no rename is needed
+	OldSlug  string
+	NewSlug  string
+	OldTopic string
+	NewTopic string
+	// TopicChanged/SlugChanged are independent: a title can change without its
+	// slug changing (rare — two different titles can collide on Slugify), and
+	// in that case the plan's content (meta.json/plan.html/events.jsonl) is
+	// still corrected even though the directory keeps its name.
+	TopicChanged bool
+	SlugChanged  bool
+	// SkipReason is non-empty when this plan dir could not be read at all
+	// (corrupt/missing meta.json or plan.md) — every other field is
+	// meaningless in that case. A skip never aborts ComputeBackfill's scan.
+	SkipReason string
+}
+
+// Changed reports whether this plan needs any write at all.
+func (p BackfillPlan) Changed() bool {
+	return p.SkipReason == "" && (p.TopicChanged || p.SlugChanged)
+}
+
+// ComputeBackfill scans plansDir (a resolved <ledger>/data/plans) and, for
+// every plan directory, re-derives its topic/slug from plan.md via Title +
+// Slugify — exactly what a fresh post-fix Save would compute — and reports
+// whether that differs from what's currently on disk. Read-only: it never
+// writes. A single unreadable/malformed plan dir is recorded with SkipReason
+// and the scan continues rather than aborting the batch.
+func ComputeBackfill(plansDir string) ([]BackfillPlan, error) {
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read plans dir=%s: %w", plansDir, err)
+	}
+
+	var dirNames []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirNames = append(dirNames, e.Name())
+		}
+	}
+	// Sorted, deterministic order: collision-suffix assignment (nextAvailableName
+	// below) depends on processing order, and a stable sort keeps repeated runs
+	// (and dry-run vs the real run) computing the identical table.
+	sort.Strings(dirNames)
+
+	// taken seeds with every CURRENTLY-occupied name so a computed target never
+	// collides with a plan that isn't being renamed; a plan's own current name
+	// is freed the instant we decide to rename it (see below), so a later plan
+	// in this same pass may legitimately claim it.
+	taken := make(map[string]bool, len(dirNames))
+	for _, n := range dirNames {
+		taken[n] = true
+	}
+
+	out := make([]BackfillPlan, 0, len(dirNames))
+	for _, name := range dirNames {
+		dir := filepath.Join(plansDir, name)
+		meta, merr := readMeta(dir)
+		if merr != nil {
+			slog.Warn("plan backfill: unreadable meta.json, skipping", "dir", dir, "error", merr)
+			out = append(out, BackfillPlan{OldDir: dir, SkipReason: fmt.Sprintf("unreadable meta.json: %v", merr)})
+			continue
+		}
+		mdBytes, rerr := os.ReadFile(filepath.Join(dir, planMDFile))
+		if rerr != nil {
+			slog.Warn("plan backfill: unreadable plan.md, skipping", "dir", dir, "error", rerr)
+			out = append(out, BackfillPlan{OldDir: dir, SkipReason: fmt.Sprintf("unreadable plan.md: %v", rerr)})
+			continue
+		}
+
+		newTopic := Title(Parse(string(mdBytes)))
+		newSlug := Slugify(newTopic)
+		oldSlug := slugFromDirName(name)
+		datePrefix := datedDirRe.FindString(name) // "" for a dir name with no YYYY-MM-DD- prefix (tolerated, not expected)
+
+		bp := BackfillPlan{
+			OldDir:       dir,
+			OldSlug:      oldSlug,
+			NewSlug:      newSlug,
+			OldTopic:     meta.Topic,
+			NewTopic:     newTopic,
+			TopicChanged: newTopic != meta.Topic,
+			SlugChanged:  newSlug != oldSlug,
+		}
+
+		if bp.SlugChanged {
+			delete(taken, name) // this dir is moving; its old name is up for grabs
+			finalSlug, finalName := nextAvailableName(taken, datePrefix, newSlug)
+			taken[finalName] = true
+			bp.NewSlug = finalSlug
+			bp.NewDir = filepath.Join(plansDir, finalName)
+		}
+
+		out = append(out, bp)
+	}
+	return out, nil
+}
+
+// nextAvailableName finds the first unclaimed "<datePrefix><slug>[-N]" name,
+// suffixing -2, -3, ... on collision. Two distinctly-worded plans saved the
+// same day CAN legitimately derive the same slug (Slugify truncates at
+// slugWordCap), so a collision is a normal, expected case, not corruption.
+func nextAvailableName(taken map[string]bool, datePrefix, slug string) (finalSlug, dirName string) {
+	candidate := slug
+	for n := 2; ; n++ {
+		name := datePrefix + candidate
+		if !taken[name] {
+			return candidate, name
+		}
+		candidate = fmt.Sprintf("%s-%d", slug, n)
+	}
+}
+
+// ApplyBackfillMeta rewrites one plan's meta.json (topic+slug only — every
+// other field, including provenance and collaboration signals, is left
+// exactly as originally recorded, since this is a title repair, not a
+// re-save), re-stamps its plan.html <head> tags when a render exists and
+// isn't an LFS pointer, and appends a lifecycle event carrying the corrected
+// topic. Operates on dir's CURRENT path; the caller renames the directory
+// (git mv) afterward so the rename captures this mutated content in the same
+// git operation.
+func ApplyBackfillMeta(ctx context.Context, dir, newTopic, newSlug string) error {
+	if err := MutatePlanMeta(ctx, dir, func(m *Meta) (*Meta, error) {
+		if m == nil {
+			return nil, fmt.Errorf("no meta.json in %s", dir)
+		}
+		m.Topic = newTopic
+		m.Slug = newSlug
+		return m, nil
+	}); err != nil {
+		return fmt.Errorf("update meta: %w", err)
+	}
+
+	planID, err := appendBackfillRevisedEvent(ctx, dir, newTopic)
+	if err != nil {
+		return fmt.Errorf("append revised event: %w", err)
+	}
+
+	htmlPath, _, isPointer, exists := PlanHTMLPath(dir)
+	if exists && !isPointer {
+		html, rerr := os.ReadFile(htmlPath)
+		if rerr != nil {
+			return fmt.Errorf("read plan.html: %w", rerr)
+		}
+		if err := os.WriteFile(htmlPath, StampHTMLMeta(html, planID, newSlug, newTopic), 0o644); err != nil {
+			return fmt.Errorf("write plan.html: %w", err)
+		}
+	}
+	return nil
+}
+
+// appendBackfillRevisedEvent appends a lifecycle event carrying the corrected
+// topic, under the same events.jsonl flock Save/AppendEvent use. It mints a
+// fresh pln_ id only for a plan dir with NO prior events at all (a legacy
+// plan saved before the event-log foundation shipped) and records that as a
+// `created` event, exactly mirroring Save()'s own firstSave/reuse decision —
+// so a legacy plan ends up in the same state a fresh post-fix Save would have
+// left it in. Returns the resolved (or minted) id for StampHTMLMeta to reuse.
+func appendBackfillRevisedEvent(ctx context.Context, dir, newTopic string) (string, error) {
+	eventsPath := filepath.Join(dir, eventsFile)
+	var planID string
+	err := fileutil.WithFileLock(ctx, eventsPath, func() error {
+		existing, lerr := LoadEvents(dir)
+		if lerr != nil {
+			slog.Warn("plan backfill: load existing events failed, minting a fresh id", "error", lerr, "dir", dir)
+			existing = nil
+		}
+		ev := Event{Kind: EventRevised, Topic: newTopic}
+		if len(existing) == 0 {
+			planID = planid.GeneratePlanID()
+			ev.Kind = EventCreated
+			ev.Status = PlanStatusDraft
+		} else {
+			planID = existing[0].PlanID
+		}
+		ev.PlanID = planID
+		return appendEventLocked(eventsPath, ev)
+	})
+	return planID, err
+}
+
+// ProducedPlansRewrite is one sessions/*/meta.json whose produced_plans list
+// names at least one old slug being renamed — the stale-reference repair
+// reconcileProducedPlansAtStop (cmd/ox/agent_session.go) would otherwise
+// silently fail on, since it resolves plans by slug.
+type ProducedPlansRewrite struct {
+	SessionDir string
+	// OldSlugs are the entries in this session's produced_plans that will
+	// change — a subset (a session can produce several plans; only the
+	// renamed ones are listed here).
+	OldSlugs []string
+}
+
+// ComputeProducedPlansRewrite scans sessionsDir (<ledger>/sessions) for every
+// session whose produced_plans names an old slug present in renamed
+// (old slug -> new slug). Read-only. A single unreadable session meta.json is
+// logged and skipped, never aborts the scan.
+func ComputeProducedPlansRewrite(sessionsDir string, renamed map[string]string) ([]ProducedPlansRewrite, error) {
+	if len(renamed) == 0 {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read sessions dir=%s: %w", sessionsDir, err)
+	}
+
+	var out []ProducedPlansRewrite
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(sessionsDir, e.Name())
+		meta, merr := lfs.ReadSessionMeta(dir)
+		if merr != nil {
+			// ReadSessionMeta wraps os.ReadFile's *PathError with %w, so the
+			// not-exist check must unwrap via errors.Is — os.IsNotExist does NOT
+			// see through a wrapped error (verified: it only inspects the
+			// error's own concrete type, never calls Unwrap).
+			if errors.Is(merr, fs.ErrNotExist) {
+				continue // no meta.json (e.g. a stray dir) — nothing to rewrite
+			}
+			slog.Warn("plan backfill: unreadable session meta.json, skipping", "dir", dir, "error", merr)
+			continue
+		}
+		var stale []string
+		for _, slug := range meta.ProducedPlans {
+			if _, ok := renamed[slug]; ok {
+				stale = append(stale, slug)
+			}
+		}
+		if len(stale) > 0 {
+			out = append(out, ProducedPlansRewrite{SessionDir: dir, OldSlugs: stale})
+		}
+	}
+	return out, nil
+}
+
+// ApplyProducedPlansRewrite rewrites one session's produced_plans entries
+// in place (old slug -> new slug per renamed), under MutateSessionMeta's
+// flock so the write serializes against a concurrent session-stop
+// reconciliation. No-op (no write) if nothing in this session actually
+// matches renamed.
+func ApplyProducedPlansRewrite(ctx context.Context, sessionDir string, renamed map[string]string) error {
+	return lfs.MutateSessionMeta(ctx, sessionDir, func(m *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+		if m == nil {
+			return nil, nil
+		}
+		changed := false
+		for i, slug := range m.ProducedPlans {
+			if newSlug, ok := renamed[slug]; ok {
+				m.ProducedPlans[i] = newSlug
+				changed = true
+			}
+		}
+		if !changed {
+			return nil, nil
+		}
+		return m, nil
+	})
+}

--- a/internal/plan/backfill_preflight.go
+++ b/internal/plan/backfill_preflight.go
@@ -1,0 +1,119 @@
+package plan
+
+// backfill_preflight.go holds the two GIT-FREE verdict functions
+// `ox plan backfill-titles` checks before it scans or touches a single plan
+// directory. Both guards close the same failure mode: a ledger whose
+// working tree silently disagrees with origin/main (an incomplete
+// sparse-checkout cone, or an unpushed/unpulled branch) would otherwise let
+// ComputeBackfill run against a fraction of the real corpus and print a
+// CLEAN summary — "nothing to backfill" looks identical whether nothing
+// needed fixing or the run barely saw anything. The git plumbing that
+// gathers the counts these functions consume (git ls-tree, git rev-list)
+// lives in cmd/ox/plan_backfill_preflight.go, mirroring the compute/apply
+// split ComputeBackfill/ApplyBackfillMeta already establish in this file.
+
+import (
+	"fmt"
+	"os"
+)
+
+// CountPlanDirs counts plan directories actually present in the working
+// tree at plansDir — Guard 1's local half. A plansDir that doesn't exist yet
+// (a fresh ledger that has never saved a plan) is 0 dirs, not an error,
+// mirroring ComputeBackfill's own os.IsNotExist handling.
+func CountPlanDirs(plansDir string) (int, error) {
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read plans dir=%s: %w", plansDir, err)
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// CorpusCompletenessError means the working tree has fewer plan directories
+// than origin/main does. The real incident this guards against: until the
+// ledger's sparse-checkout cone included data/plans, git sparse-checkout set
+// deleted plan directories from disk roughly 60s after every save (see
+// baseSparseDirs' doc comment in internal/ledger/ledger.go), leaving ledgers
+// with dozens of plans on origin/main and none on disk. A backfill run
+// against that tree scans almost nothing, reworks nothing, and reports
+// success — indistinguishable from "everything was already correct".
+type CorpusCompletenessError struct {
+	LocalCount  int
+	RemoteCount int
+}
+
+func (e *CorpusCompletenessError) Error() string {
+	return fmt.Sprintf(
+		"plan backfill aborted: working tree has %d plan dir(s) under data/plans but origin/main has %d — the sparse-checkout cone is likely missing data/plans; run `ox doctor --fix`, then `git pull`, then retry",
+		e.LocalCount, e.RemoteCount)
+}
+
+// VerifyCorpusComplete is Guard 1's pure verdict, computed from counts the
+// cmd/ox layer gathers (local dir count, remote tree count via git ls-tree).
+// local < remote is a hard abort (CorpusCompletenessError) — proceeding
+// would silently rework a subset of the real corpus. local > remote is
+// legitimate (plans saved locally that haven't been pushed yet) and is
+// reported via note rather than blocked. local == remote is silent.
+//
+// remoteKnown=false means origin/main could not be resolved at all — no
+// remote configured, a repo that's never been fetched, or (in tests) not a
+// git repository yet. That must never hard-fail an otherwise-valid local
+// run: a freshly cloned or intentionally offline ledger doing a purely
+// local repair is a normal, supported case, not a reason to block backfill
+// entirely just because there's nothing to compare against.
+func VerifyCorpusComplete(localCount, remoteCount int, remoteKnown bool) (note string, err error) {
+	if !remoteKnown {
+		return "corpus completeness check skipped: origin/main unresolvable (no remote configured, or never fetched)", nil
+	}
+	switch {
+	case localCount < remoteCount:
+		return "", &CorpusCompletenessError{LocalCount: localCount, RemoteCount: remoteCount}
+	case localCount > remoteCount:
+		return fmt.Sprintf("working tree has %d plan dir(s) not yet on origin/main (%d there) — proceeding (unpushed local saves)", localCount, remoteCount), nil
+	default:
+		return "", nil
+	}
+}
+
+// DivergenceError means the ledger has local commits origin/main doesn't
+// have (ahead), commits from origin/main it hasn't pulled (behind), or
+// both. Landing a mass directory rename on top of that divergence turns a
+// routine repair into a manual rebase — worth stopping for, unless the
+// operator explicitly says the divergence is expected (--allow-diverged).
+type DivergenceError struct {
+	Ahead  int
+	Behind int
+}
+
+func (e *DivergenceError) Error() string {
+	return fmt.Sprintf(
+		"plan backfill aborted: ledger diverged from origin/main (ahead %d, behind %d) — reconcile first (`ox doctor --fix`, or pull/push), or pass --allow-diverged if this divergence is expected",
+		e.Ahead, e.Behind)
+}
+
+// VerifyNotDiverged is Guard 2's pure verdict. allowDiverged is the
+// --allow-diverged escape hatch for an operator who already knows their
+// ledger is intentionally ahead/behind. remoteKnown mirrors
+// VerifyCorpusComplete: an unresolvable origin/main skips the guard rather
+// than failing a valid local-only run.
+func VerifyNotDiverged(ahead, behind int, remoteKnown, allowDiverged bool) (note string, err error) {
+	if !remoteKnown {
+		return "divergence check skipped: origin/main unresolvable (no remote configured, or never fetched)", nil
+	}
+	if ahead == 0 && behind == 0 {
+		return "", nil
+	}
+	if !allowDiverged {
+		return "", &DivergenceError{Ahead: ahead, Behind: behind}
+	}
+	return fmt.Sprintf("ledger diverged from origin/main (ahead %d, behind %d) — proceeding: --allow-diverged was passed", ahead, behind), nil
+}

--- a/internal/plan/backfill_preflight_test.go
+++ b/internal/plan/backfill_preflight_test.go
@@ -1,0 +1,138 @@
+package plan
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVerifyCorpusComplete(t *testing.T) {
+	tests := []struct {
+		name        string
+		localCount  int
+		remoteCount int
+		remoteKnown bool
+		wantAbort   bool
+		wantNote    bool
+	}{
+		{name: "complete corpus: local equals remote", localCount: 5, remoteCount: 5, remoteKnown: true, wantAbort: false, wantNote: false},
+		{name: "incomplete corpus: local behind remote aborts", localCount: 1, remoteCount: 25, remoteKnown: true, wantAbort: true},
+		{name: "local ahead of remote proceeds with a note", localCount: 3, remoteCount: 2, remoteKnown: true, wantAbort: false, wantNote: true},
+		{name: "unknown remote skips the guard entirely", localCount: 0, remoteCount: 0, remoteKnown: false, wantAbort: false, wantNote: true},
+		{name: "unknown remote skips even when counts would otherwise abort", localCount: 0, remoteCount: 99, remoteKnown: false, wantAbort: false, wantNote: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			note, err := VerifyCorpusComplete(tt.localCount, tt.remoteCount, tt.remoteKnown)
+
+			if tt.wantAbort {
+				if err == nil {
+					t.Fatalf("VerifyCorpusComplete(%d, %d, %v) = nil error, want abort", tt.localCount, tt.remoteCount, tt.remoteKnown)
+				}
+				var cerr *CorpusCompletenessError
+				if !errors.As(err, &cerr) {
+					t.Fatalf("error = %v (%T), want *CorpusCompletenessError", err, err)
+				}
+				if cerr.LocalCount != tt.localCount || cerr.RemoteCount != tt.remoteCount {
+					t.Errorf("CorpusCompletenessError = {%d, %d}, want {%d, %d}", cerr.LocalCount, cerr.RemoteCount, tt.localCount, tt.remoteCount)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("VerifyCorpusComplete(%d, %d, %v) unexpected error: %v", tt.localCount, tt.remoteCount, tt.remoteKnown, err)
+			}
+			if tt.wantNote && note == "" {
+				t.Errorf("expected a non-empty note, got none")
+			}
+			if !tt.wantNote && note != "" {
+				t.Errorf("expected no note, got %q", note)
+			}
+		})
+	}
+}
+
+func TestVerifyNotDiverged(t *testing.T) {
+	tests := []struct {
+		name          string
+		ahead, behind int
+		remoteKnown   bool
+		allowDiverged bool
+		wantAbort     bool
+		wantNote      bool
+	}{
+		{name: "in sync: no note, no abort", ahead: 0, behind: 0, remoteKnown: true, wantAbort: false, wantNote: false},
+		{name: "ahead only aborts without the flag", ahead: 3, behind: 0, remoteKnown: true, wantAbort: true},
+		{name: "behind only aborts without the flag", ahead: 0, behind: 5, remoteKnown: true, wantAbort: true},
+		{name: "diverged both directions aborts without the flag", ahead: 343, behind: 1056, remoteKnown: true, wantAbort: true},
+		{name: "allow-diverged overrides the abort and notes it", ahead: 343, behind: 1056, remoteKnown: true, allowDiverged: true, wantAbort: false, wantNote: true},
+		{name: "unknown remote skips the guard entirely", ahead: 0, behind: 0, remoteKnown: false, wantAbort: false, wantNote: true},
+		{name: "unknown remote skips even when counts would otherwise abort", ahead: 10, behind: 10, remoteKnown: false, wantAbort: false, wantNote: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			note, err := VerifyNotDiverged(tt.ahead, tt.behind, tt.remoteKnown, tt.allowDiverged)
+
+			if tt.wantAbort {
+				if err == nil {
+					t.Fatalf("VerifyNotDiverged(%d, %d, %v, %v) = nil error, want abort", tt.ahead, tt.behind, tt.remoteKnown, tt.allowDiverged)
+				}
+				var derr *DivergenceError
+				if !errors.As(err, &derr) {
+					t.Fatalf("error = %v (%T), want *DivergenceError", err, err)
+				}
+				if derr.Ahead != tt.ahead || derr.Behind != tt.behind {
+					t.Errorf("DivergenceError = {%d, %d}, want {%d, %d}", derr.Ahead, derr.Behind, tt.ahead, tt.behind)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("VerifyNotDiverged(%d, %d, %v, %v) unexpected error: %v", tt.ahead, tt.behind, tt.remoteKnown, tt.allowDiverged, err)
+			}
+			if tt.wantNote && note == "" {
+				t.Errorf("expected a non-empty note, got none")
+			}
+			if !tt.wantNote && note != "" {
+				t.Errorf("expected no note, got %q", note)
+			}
+		})
+	}
+}
+
+func TestCountPlanDirs(t *testing.T) {
+	t.Run("nonexistent plansDir counts as zero, not an error", func(t *testing.T) {
+		t.Parallel()
+		count, err := CountPlanDirs(filepath.Join(t.TempDir(), "does-not-exist"))
+		if err != nil {
+			t.Fatalf("CountPlanDirs: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("count = %d, want 0", count)
+		}
+	})
+
+	t.Run("counts only directories, ignores files", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		for _, name := range []string{"2026-05-01-plan-a", "2026-05-02-plan-b"} {
+			if err := os.MkdirAll(filepath.Join(dir, name), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(dir, "stray-file.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		count, err := CountPlanDirs(dir)
+		if err != nil {
+			t.Fatalf("CountPlanDirs: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("count = %d, want 2 (files must not be counted)", count)
+		}
+	})
+}

--- a/internal/plan/backfill_test.go
+++ b/internal/plan/backfill_test.go
@@ -1,0 +1,382 @@
+package plan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// savePlanWithBuggyTopic writes a plan via Save, but stamps meta.Topic/Slug
+// with an explicit (wrong) value rather than letting Save derive it — this is
+// how every real corpus plan ended up mistitled: the pre-ox-1tjj.8 cmd/ox
+// planTopic computed the first H2's text (Parse only splits on H2, so it
+// could never see raw's H1) and handed THAT to Save as meta.Topic. Save
+// itself never derives a topic; it only persists what the caller supplies.
+func savePlanWithBuggyTopic(t *testing.T, ledger, raw, buggyTopic string, createdAt time.Time) string {
+	t.Helper()
+	withLedger(t, ledger)
+	meta := Meta{Topic: buggyTopic, Slug: Slugify(buggyTopic), CreatedAt: createdAt}
+	dir, err := Save("/g", Input{Raw: raw}, sampleResult(), nil, meta)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	return dir
+}
+
+// h1FollowedByContextH2 is the exact real-world shape ox-1tjj.8 shipped:
+// an H1 real title followed by a "1. Context — Why Now" H2, whose text the
+// buggy planTopic grabbed instead.
+const h1FollowedByContextH2 = "# Conversation model update — the execution plan\n\n" +
+	"## 1. Context — Why Now\n\nframing prose.\n\n## Approach\n\ndo the thing.\n"
+
+func TestComputeBackfill_RenameCorrectsTopicAndPreservesOriginalDatePrefix(t *testing.T) {
+	ledger := t.TempDir()
+	// deliberately NOT today — proves the rename keeps the plan's ORIGINAL
+	// save date, not the date the backfill happens to run on.
+	created := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	dir := savePlanWithBuggyTopic(t, ledger, h1FollowedByContextH2, "1. Context — Why Now", created)
+	plansDir := filepath.Dir(dir)
+
+	candidates, err := ComputeBackfill(plansDir)
+	if err != nil {
+		t.Fatalf("ComputeBackfill: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("got %d candidates, want 1: %+v", len(candidates), candidates)
+	}
+	c := candidates[0]
+
+	if !c.Changed() || !c.TopicChanged || !c.SlugChanged {
+		t.Fatalf("candidate not flagged as changed: %+v", c)
+	}
+	wantTopic := "Conversation model update — the execution plan"
+	if c.NewTopic != wantTopic {
+		t.Errorf("NewTopic = %q, want %q", c.NewTopic, wantTopic)
+	}
+	if c.OldTopic != "1. Context — Why Now" {
+		t.Errorf("OldTopic = %q, want the original buggy topic", c.OldTopic)
+	}
+	wantSlug := Slugify(wantTopic)
+	if c.NewSlug != wantSlug {
+		t.Errorf("NewSlug = %q, want %q", c.NewSlug, wantSlug)
+	}
+	if c.NewDir == "" {
+		t.Fatal("NewDir is empty, want a rename")
+	}
+	wantDirName := "2026-05-01-" + wantSlug
+	if got := filepath.Base(c.NewDir); got != wantDirName {
+		t.Errorf("NewDir basename = %q, want %q (original date prefix preserved, not today's date)", got, wantDirName)
+	}
+}
+
+func TestComputeBackfill_TLDRRegression(t *testing.T) {
+	ledger := t.TempDir()
+	raw := "# ox plan — Team-Context-Enriched Plans\n\n## TL;DR\n\nShip it.\n\n## Design\n\ndetails.\n"
+	dir := savePlanWithBuggyTopic(t, ledger, raw, "TL;DR", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	plansDir := filepath.Dir(dir)
+
+	candidates, err := ComputeBackfill(plansDir)
+	if err != nil {
+		t.Fatalf("ComputeBackfill: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].NewTopic != "ox plan — Team-Context-Enriched Plans" {
+		t.Fatalf("candidates = %+v, want the corrected H1 topic", candidates)
+	}
+}
+
+func TestComputeBackfill_AlreadyCorrectPlanIsUnchanged(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+	// A plan saved by the FIXED code: meta.Topic already matches the H1.
+	raw := "# Already Correct Plan\n\n## Approach\n\ndo it.\n"
+	meta := Meta{Topic: "Already Correct Plan", Slug: Slugify("Already Correct Plan"), CreatedAt: time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)}
+	dir, err := Save("/g", Input{Raw: raw}, sampleResult(), nil, meta)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	plansDir := filepath.Dir(dir)
+
+	candidates, err := ComputeBackfill(plansDir)
+	if err != nil {
+		t.Fatalf("ComputeBackfill: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Changed() {
+		t.Fatalf("candidates = %+v, want exactly 1 unchanged candidate", candidates)
+	}
+}
+
+// TestComputeBackfill_CollisionSuffixing verifies two plans whose H1s
+// collide on the same slug (Slugify truncates/normalizes, so distinct real
+// titles CAN legitimately produce the same slug) get -2, -3, ... suffixes
+// rather than one silently overwriting the other.
+func TestComputeBackfill_CollisionSuffixing(t *testing.T) {
+	ledger := t.TempDir()
+	created := time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
+	// Both correct to the exact same H1 text (and therefore the exact same
+	// slug) but start from different buggy topics so Save gives them distinct
+	// starting directories.
+	raw := "# Add Login Support\n\n## 1. Context — Why Now\n\nframing.\n\n## Approach\n\ndo it.\n"
+	dirA := savePlanWithBuggyTopic(t, ledger, raw, "1. Context — Why Now", created)
+	raw2 := "# Add Login Support\n\n## TL;DR\n\nShip it.\n\n## Approach\n\ndo it.\n"
+	dirB := savePlanWithBuggyTopic(t, ledger, raw2, "TL;DR", created)
+	plansDir := filepath.Dir(dirA)
+	if filepath.Dir(dirB) != plansDir {
+		t.Fatalf("test setup: dirA/dirB not siblings: %q vs %q", dirA, dirB)
+	}
+
+	candidates, err := ComputeBackfill(plansDir)
+	if err != nil {
+		t.Fatalf("ComputeBackfill: %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("got %d candidates, want 2: %+v", len(candidates), candidates)
+	}
+
+	// ComputeBackfill processes directory names in sorted order — dirA's
+	// buggy slug ("1-context-why-now") sorts before dirB's ("tl-dr"), so dirA
+	// claims the clean slug and dirB gets suffixed.
+	byOldDir := map[string]BackfillPlan{}
+	for _, c := range candidates {
+		byOldDir[c.OldDir] = c
+	}
+	first, second := byOldDir[dirA], byOldDir[dirB]
+
+	wantSlug := Slugify("Add Login Support")
+	if first.NewSlug != wantSlug {
+		t.Errorf("first candidate NewSlug = %q, want the clean %q", first.NewSlug, wantSlug)
+	}
+	if second.NewSlug != wantSlug+"-2" {
+		t.Errorf("second candidate NewSlug = %q, want the suffixed %q", second.NewSlug, wantSlug+"-2")
+	}
+	if first.NewDir == second.NewDir {
+		t.Fatalf("both candidates resolved to the same NewDir: %q", first.NewDir)
+	}
+}
+
+// TestComputeBackfill_SkipsUnreadableDirButContinues verifies a single
+// corrupt plan dir never aborts the batch: it's reported via SkipReason and
+// scanning continues to the next dir.
+func TestComputeBackfill_SkipsUnreadableDirButContinues(t *testing.T) {
+	ledger := t.TempDir()
+	created := time.Date(2026, 6, 4, 0, 0, 0, 0, time.UTC)
+	good := savePlanWithBuggyTopic(t, ledger, h1FollowedByContextH2, "1. Context — Why Now", created)
+	plansDir := filepath.Dir(good)
+
+	broken := filepath.Join(plansDir, "2026-06-04-broken")
+	if err := os.MkdirAll(broken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "meta.json"), []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := ComputeBackfill(plansDir)
+	if err != nil {
+		t.Fatalf("ComputeBackfill must not error on one broken dir: %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("got %d candidates, want 2 (1 good + 1 skipped): %+v", len(candidates), candidates)
+	}
+	var sawSkip, sawGood bool
+	for _, c := range candidates {
+		switch c.OldDir {
+		case broken:
+			sawSkip = c.SkipReason != ""
+		case good:
+			sawGood = c.Changed()
+		}
+	}
+	if !sawSkip {
+		t.Error("broken dir was not reported with a SkipReason")
+	}
+	if !sawGood {
+		t.Error("good dir alongside the broken one was not processed")
+	}
+}
+
+// TestComputeBackfill_DryRunTouchesNothing proves the compute half is
+// read-only: file contents and mtimes are byte-identical before and after.
+func TestComputeBackfill_DryRunTouchesNothing(t *testing.T) {
+	ledger := t.TempDir()
+	dir := savePlanWithBuggyTopic(t, ledger, h1FollowedByContextH2, "1. Context — Why Now", time.Date(2026, 6, 5, 0, 0, 0, 0, time.UTC))
+	plansDir := filepath.Dir(dir)
+
+	metaPath := filepath.Join(dir, planMetaFile)
+	before, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeInfo, err := os.Stat(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ComputeBackfill(plansDir); err != nil {
+		t.Fatalf("ComputeBackfill: %v", err)
+	}
+
+	after, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterInfo, err := os.Stat(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("meta.json content changed after ComputeBackfill (dry-run must never write)")
+	}
+	if !beforeInfo.ModTime().Equal(afterInfo.ModTime()) {
+		t.Errorf("meta.json mtime changed after ComputeBackfill (dry-run must never write)")
+	}
+	if _, err := os.Stat(filepath.Join(dir, eventsFile)); err == nil {
+		data, _ := os.ReadFile(filepath.Join(dir, eventsFile))
+		if strings.Count(string(data), "\n") != 1 {
+			t.Errorf("events.jsonl grew during a dry-run compute: %s", data)
+		}
+	}
+}
+
+// TestBackfill_Idempotent applies a full backfill pass (ApplyBackfillMeta +
+// the directory rename the cmd layer would perform via git mv, simulated
+// here with os.Rename since this test lives at the internal/plan layer) and
+// then re-runs ComputeBackfill: the second pass must report every plan
+// unchanged, append no new event, and propose no further rename.
+func TestBackfill_Idempotent(t *testing.T) {
+	ledger := t.TempDir()
+	dir := savePlanWithBuggyTopic(t, ledger, h1FollowedByContextH2, "1. Context — Why Now", time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC))
+	plansDir := filepath.Dir(dir)
+	ctx := context.Background()
+
+	candidates, err := ComputeBackfill(plansDir)
+	if err != nil || len(candidates) != 1 {
+		t.Fatalf("ComputeBackfill first pass: %v, %+v", err, candidates)
+	}
+	c := candidates[0]
+	if err := ApplyBackfillMeta(ctx, c.OldDir, c.NewTopic, c.NewSlug); err != nil {
+		t.Fatalf("ApplyBackfillMeta: %v", err)
+	}
+	if c.NewDir != "" {
+		if err := os.Rename(c.OldDir, c.NewDir); err != nil {
+			t.Fatalf("simulated git mv (os.Rename): %v", err)
+		}
+	}
+
+	eventsBefore, err := LoadEvents(c.NewDir)
+	if err != nil || len(eventsBefore) != 2 { // created (Save) + revised (ApplyBackfillMeta)
+		t.Fatalf("LoadEvents after first pass: err=%v n=%d", err, len(eventsBefore))
+	}
+
+	second, err := ComputeBackfill(plansDir)
+	if err != nil {
+		t.Fatalf("ComputeBackfill second pass: %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("second pass found %d plans, want 1: %+v", len(second), second)
+	}
+	if second[0].Changed() {
+		t.Fatalf("second pass reports a change on an already-backfilled plan: %+v", second[0])
+	}
+	if second[0].NewDir != "" {
+		t.Errorf("second pass proposes a further rename: %+v", second[0])
+	}
+
+	eventsAfter, err := LoadEvents(c.NewDir)
+	if err != nil || len(eventsAfter) != len(eventsBefore) {
+		t.Fatalf("a no-op second pass must append no event: before=%d after=%d (err=%v)", len(eventsBefore), len(eventsAfter), err)
+	}
+}
+
+// --- produced_plans rewrite ---
+
+func writeTestSessionMeta(t *testing.T, sessionsDir, name string, producedPlans []string) string {
+	t.Helper()
+	dir := filepath.Join(sessionsDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := lfs.NewSessionMeta(name, "Person A", "Ox0001", "claude-code", time.Now().UTC()).
+		ProducedPlans(producedPlans).
+		Build()
+	if err := lfs.WriteSessionMetaOnly(dir, meta); err != nil {
+		t.Fatalf("write session meta: %v", err)
+	}
+	return dir
+}
+
+func TestComputeProducedPlansRewrite_FindsStaleSlug(t *testing.T) {
+	sessionsDir := t.TempDir()
+	writeTestSessionMeta(t, sessionsDir, "2026-06-01-a-Ox0001", []string{"1-context-why-now", "unrelated-plan"})
+	writeTestSessionMeta(t, sessionsDir, "2026-06-02-b-Ox0002", []string{"unrelated-plan"})
+
+	renamed := map[string]string{"1-context-why-now": "conversation-model-update-execution-plan"}
+	rewrites, err := ComputeProducedPlansRewrite(sessionsDir, renamed)
+	if err != nil {
+		t.Fatalf("ComputeProducedPlansRewrite: %v", err)
+	}
+	if len(rewrites) != 1 {
+		t.Fatalf("got %d rewrites, want 1 (only the session naming the stale slug): %+v", len(rewrites), rewrites)
+	}
+	if got := rewrites[0].OldSlugs; len(got) != 1 || got[0] != "1-context-why-now" {
+		t.Errorf("OldSlugs = %v, want [1-context-why-now]", got)
+	}
+}
+
+func TestComputeProducedPlansRewrite_EmptyRenamedIsNoOp(t *testing.T) {
+	sessionsDir := t.TempDir()
+	writeTestSessionMeta(t, sessionsDir, "2026-06-01-a-Ox0001", []string{"some-slug"})
+	rewrites, err := ComputeProducedPlansRewrite(sessionsDir, nil)
+	if err != nil {
+		t.Fatalf("ComputeProducedPlansRewrite: %v", err)
+	}
+	if len(rewrites) != 0 {
+		t.Errorf("rewrites = %+v, want none when renamed is empty", rewrites)
+	}
+}
+
+func TestApplyProducedPlansRewrite_RewritesInPlace(t *testing.T) {
+	sessionsDir := t.TempDir()
+	dir := writeTestSessionMeta(t, sessionsDir, "2026-06-01-a-Ox0001", []string{"1-context-why-now", "unrelated-plan"})
+
+	renamed := map[string]string{"1-context-why-now": "conversation-model-update-execution-plan"}
+	if err := ApplyProducedPlansRewrite(context.Background(), dir, renamed); err != nil {
+		t.Fatalf("ApplyProducedPlansRewrite: %v", err)
+	}
+
+	got, err := lfs.ReadSessionMeta(dir)
+	if err != nil {
+		t.Fatalf("ReadSessionMeta: %v", err)
+	}
+	want := []string{"conversation-model-update-execution-plan", "unrelated-plan"}
+	if len(got.ProducedPlans) != len(want) || got.ProducedPlans[0] != want[0] || got.ProducedPlans[1] != want[1] {
+		t.Errorf("ProducedPlans = %v, want %v", got.ProducedPlans, want)
+	}
+}
+
+func TestApplyProducedPlansRewrite_NoMatchIsNoOp(t *testing.T) {
+	sessionsDir := t.TempDir()
+	dir := writeTestSessionMeta(t, sessionsDir, "2026-06-01-a-Ox0001", []string{"unrelated-plan"})
+	metaPath := filepath.Join(dir, "meta.json")
+	before, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renamed := map[string]string{"1-context-why-now": "conversation-model-update-execution-plan"}
+	if err := ApplyProducedPlansRewrite(context.Background(), dir, renamed); err != nil {
+		t.Fatalf("ApplyProducedPlansRewrite: %v", err)
+	}
+
+	after, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("meta.json rewritten despite no matching produced_plans entry")
+	}
+}

--- a/internal/plan/render.go
+++ b/internal/plan/render.go
@@ -110,8 +110,6 @@ type reviewStateItem struct {
 // reads — so no un-escaping is needed here.
 var mermaidFence = regexp.MustCompile(`(?s)<pre><code class="language-mermaid">(.*?)</code></pre>`)
 
-var h1Line = regexp.MustCompile(`(?m)^#\s+(.+?)\s*$`)
-
 // riskHeading flags a section whose heading is about risks, so it can carry
 // severity styling.
 var riskHeading = regexp.MustCompile(`(?i)\brisks?\b`)
@@ -259,7 +257,7 @@ func RenderHTMLOpts(in Input, res Result, opts RenderOptions) ([]byte, error) {
 	md := newMarkdown()
 
 	data := renderData{
-		Title:          planTitle(in),
+		Title:          Title(in),
 		Slug:           opts.Slug,
 		CSS:            template.CSS(string(css) + highlightCSS()),
 		JS:             template.JS(js),
@@ -875,18 +873,6 @@ var lineSuffix = regexp.MustCompile(`:\d+$`)
 
 func normalizeRef(s string) string {
 	return lineSuffix.ReplaceAllString(strings.TrimSpace(s), "")
-}
-
-func planTitle(in Input) string {
-	if m := h1Line.FindStringSubmatch(in.Raw); m != nil {
-		return strings.TrimSpace(m[1])
-	}
-	for _, s := range in.Sections {
-		if strings.TrimSpace(s.Heading) != "" {
-			return s.Heading
-		}
-	}
-	return "Implementation Plan"
 }
 
 var leadingH1 = regexp.MustCompile(`(?s)^\s*<h1[^>]*>.*?</h1>`)

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -358,10 +358,16 @@ func Save(gitRoot string, in Input, res Result, html []byte, meta Meta) (string,
 		// meta.json may end up with above (which can preserve an earlier session's
 		// SessionID/SessionOutcome on a re-save): each event records the specific
 		// session that performed that save, and Fold aggregates across all of them
-		// — see events.go's multi-session model. Topic is deliberately left unset:
-		// the title's source of truth is plan.html's <head> (see html_meta.go),
-		// not the event log.
-		ev := Event{PlanID: planID, Kind: EventRevised}
+		// — see events.go's multi-session model. Topic IS carried here (denormalized
+		// from meta.Topic, the same value just written to meta.json above):
+		// plan.html's <head> (sageox:plan-title, see html_meta.go) remains the
+		// source of truth for a STANDALONE copy of the render — a page downloaded,
+		// emailed, or pasted into a chat thread with no ledger context at hand — but
+		// a reader with only events.jsonl (the cloud fold, `ox plan status`) needs a
+		// title without fetching/parsing the render. This mirrors the AgentType/
+		// Model/AuthorName snapshot fields on Provenance above: duplication is the
+		// feature, not a smell.
+		ev := Event{PlanID: planID, Kind: EventRevised, Topic: meta.Topic}
 		if firstSave {
 			ev.Kind = EventCreated
 			ev.Status = PlanStatusDraft
@@ -624,10 +630,30 @@ func resolvePlanDirForSlug(gitRoot, slug string) (string, error) {
 // slugWordRe splits on any run of non-alphanumeric characters.
 var slugWordRe = regexp.MustCompile(`[^a-z0-9]+`)
 
-// Slugify derives a 2-4 word kebab-case slug from a topic/title. Lowercases,
-// strips punctuation, and keeps the first 2-4 meaningful words. An empty or
-// punctuation-only input yields "untitled-plan" so a directory name is always
-// well-formed.
+// slugWordCap bounds how many words Slugify keeps. 6, not 4 (ox-1tjj.8): a
+// 4-word cap collided distinct plans onto the same generic slug often enough
+// to be a real problem (two plans both starting "Add support for the..."),
+// and — separately — a cap landing exactly on a stopword read as a
+// truncation bug ("...update-the"), not a title. 6 gives enough words to stay
+// distinctive without producing an unwieldy directory name.
+const slugWordCap = 6
+
+// slugStopWords are common English function words trimmed from the END of a
+// derived slug only — never from the interior (see Slugify's doc comment). A
+// trailing article/preposition ("...update-the") reads as a cut-off
+// mid-sentence, not a title; the same word in the middle of a slug still
+// carries grammatical information a reader would otherwise have to infer, so
+// stripping it there would cost more readability than the terseness is worth.
+var slugStopWords = map[string]bool{
+	"a": true, "an": true, "the": true, "of": true, "to": true,
+	"and": true, "for": true, "in": true, "on": true, "with": true,
+}
+
+// Slugify derives a kebab-case slug from a topic/title. Lowercases, strips
+// punctuation, keeps the first slugWordCap meaningful words, then trims any
+// trailing stopword(s) — interior stopwords are left alone. An empty,
+// punctuation-only, or all-stopword input yields "untitled-plan" so a
+// directory name is always well-formed.
 func Slugify(topic string) string {
 	words := slugWordRe.Split(strings.ToLower(strings.TrimSpace(topic)), -1)
 
@@ -637,9 +663,13 @@ func Slugify(topic string) string {
 			continue
 		}
 		kept = append(kept, w)
-		if len(kept) == 4 {
+		if len(kept) == slugWordCap {
 			break
 		}
+	}
+
+	for len(kept) > 0 && slugStopWords[kept[len(kept)-1]] {
+		kept = kept[:len(kept)-1]
 	}
 
 	if len(kept) == 0 {

--- a/internal/plan/store_events_test.go
+++ b/internal/plan/store_events_test.go
@@ -35,10 +35,10 @@ func sampleProvenance() *Provenance {
 }
 
 // TestSave_FirstSaveWritesCreatedEvent verifies the first save of a fresh plan
-// directory mints a pln_ id, writes a single `created` event carrying the
-// resolved provenance and a draft status, and leaves Topic unset — the
-// title's source of truth is plan.html's <head> (see html_meta.go), not the
-// event log.
+// directory mints a pln_ id and writes a single `created` event carrying the
+// resolved provenance, a draft status, and the plan's topic — denormalized
+// from meta.Topic so a reader of events.jsonl alone (the cloud fold,
+// `ox plan status`) has a title without fetching plan.html.
 func TestSave_FirstSaveWritesCreatedEvent(t *testing.T) {
 	ledger := t.TempDir()
 	withLedger(t, ledger)
@@ -73,8 +73,8 @@ func TestSave_FirstSaveWritesCreatedEvent(t *testing.T) {
 	if ev.Status != PlanStatusDraft {
 		t.Errorf("Status = %q, want %q", ev.Status, PlanStatusDraft)
 	}
-	if ev.Topic != "" {
-		t.Errorf("Topic = %q, want empty (title lives in plan.html, not the event log)", ev.Topic)
+	if ev.Topic != meta.Topic {
+		t.Errorf("Topic = %q, want %q (denormalized from meta.Topic for the cloud-side title fold)", ev.Topic, meta.Topic)
 	}
 	if ev.SessionID != "ses_test0001" || ev.SessionName != "2026-07-01-person-a-Oxab12" {
 		t.Errorf("session fields = (%q,%q), want provenance's", ev.SessionID, ev.SessionName)
@@ -201,6 +201,9 @@ func TestSave_SecondSaveAppendsRevisedEventSamePlanID(t *testing.T) {
 	}
 	if events[1].PlanID != events[0].PlanID {
 		t.Errorf("PlanID drifted across saves: %q != %q, want stable", events[1].PlanID, events[0].PlanID)
+	}
+	if events[0].Topic != "Stable plan id" || events[1].Topic != "Stable plan id" {
+		t.Errorf("Topic = (%q, %q), want %q on both created and revised events", events[0].Topic, events[1].Topic, "Stable plan id")
 	}
 }
 

--- a/internal/plan/store_test.go
+++ b/internal/plan/store_test.go
@@ -262,23 +262,42 @@ func TestLoad_NotFound(t *testing.T) {
 
 func TestSlugify(t *testing.T) {
 	tests := []struct {
+		name string
 		in   string
 		want string
 	}{
-		{"Plan capture to ledger", "plan-capture-to-ledger"},
-		{"One Two", "one-two"},
-		{"  Trim   Me  ", "trim-me"},
-		{"A/B: C.d, E!", "a-b-c-d"},
-		{"Five Six Seven Eight Nine", "five-six-seven-eight"},
-		{"Single", "single"},
-		{"", "untitled-plan"},
-		{"!!!", "untitled-plan"},
-		{"CamelCase Words", "camelcase-words"},
+		{"basic phrase", "Plan capture to ledger", "plan-capture-to-ledger"},
+		{"two words", "One Two", "one-two"},
+		{"trims whitespace", "  Trim   Me  ", "trim-me"},
+		{"strips punctuation", "A/B: C.d, E!", "a-b-c-d-e"},
+		{"single word", "Single", "single"},
+		{"empty input", "", "untitled-plan"},
+		{"punctuation only", "!!!", "untitled-plan"},
+		{"preserves case-folded compounds", "CamelCase Words", "camelcase-words"},
+		// slugWordCap raised 4 -> 6 (ox-1tjj.8): a title with 5-6 words no
+		// longer gets silently truncated.
+		{"six-word cap keeps all six", "One Two Three Four Five Six", "one-two-three-four-five-six"},
+		{"five words, under the new cap", "Five Six Seven Eight Nine", "five-six-seven-eight-nine"},
+		{"seven words still caps at six", "One Two Three Four Five Six Seven", "one-two-three-four-five-six"},
+		// trailing-stopword trim: a cap (or a title that just ends on a
+		// function word) landing on "the"/"for"/etc. reads as a cut-off
+		// mid-sentence, not a title.
+		{"trims a single trailing stopword", "My Cool Plan For", "my-cool-plan"},
+		{"trims a run of trailing stopwords", "Fix The Bug In The", "fix-the-bug"},
+		{"cap truncation landing on a stopword gets trimmed", "One Two Three Four Five The Six", "one-two-three-four-five"},
+		{"cap truncation NOT landing on a stopword keeps all six", "Add support for the new thing", "add-support-for-the-new-thing"},
+		{"all-stopword input falls back", "The Of For", "untitled-plan"},
+		// interior stopwords are NEVER stripped — only a trailing run.
+		{"preserves interior stopwords", "Fix the bug in the parser", "fix-the-bug-in-the-parser"},
+		{"conversation model update em-dash the execution plan", "Conversation model update — the execution plan", "conversation-model-update-the-execution-plan"},
 	}
 	for _, tc := range tests {
-		if got := Slugify(tc.in); got != tc.want {
-			t.Errorf("Slugify(%q) = %q, want %q", tc.in, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Slugify(tc.in); got != tc.want {
+				t.Errorf("Slugify(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -412,13 +431,16 @@ func TestSave_ReadMergePreservesLifecycle(t *testing.T) {
 func TestReconcileSessionOutcome_BackfillsSessionID(t *testing.T) {
 	ledger := t.TempDir()
 	withLedger(t, ledger)
-	if _, err := Save("/g", Input{Raw: "# Topic A\n"}, sampleResult(), nil, Meta{Topic: "Topic A", CreatedAt: time.Now().UTC()}); err != nil {
+	// "Topic Alpha", not "Topic A" — a trailing single-letter "A" would be
+	// trimmed as the stopword "a" (Slugify's trailing-stopword trim), which is
+	// incidental to what this test actually exercises (SessionID backfill).
+	if _, err := Save("/g", Input{Raw: "# Topic Alpha\n"}, sampleResult(), nil, Meta{Topic: "Topic Alpha", CreatedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if err := ReconcileSessionOutcome("/g", "topic-a", "ses_7", SessionOutcomeAborted); err != nil {
+	if err := ReconcileSessionOutcome("/g", "topic-alpha", "ses_7", SessionOutcomeAborted); err != nil {
 		t.Fatalf("ReconcileSessionOutcome: %v", err)
 	}
-	got, _ := ReadPlanMeta("/g", "topic-a")
+	got, _ := ReadPlanMeta("/g", "topic-alpha")
 	if got.Provenance == nil || got.Provenance.SessionID != "ses_7" || got.Provenance.SessionOutcome != SessionOutcomeAborted {
 		t.Errorf("backfill failed: %+v", got.Provenance)
 	}

--- a/internal/plan/title.go
+++ b/internal/plan/title.go
@@ -1,0 +1,37 @@
+package plan
+
+import (
+	"regexp"
+	"strings"
+)
+
+// h1Line matches a markdown H1 heading at the start of a line ("# Heading").
+var h1Line = regexp.MustCompile(`(?m)^#\s+(.+?)\s*$`)
+
+// Title derives a plan's human title, checked in this order: the document's
+// H1, the first non-empty H2 section heading (a plan with no H1 at all — rare
+// but not invalid markdown), or a fallback for a plan with no headings.
+//
+// This is the ONE title derivation for the whole package. Before ox-1tjj.8,
+// RenderHTMLOpts used this exact H1-first logic (as the unexported planTitle)
+// while cmd/ox's planTopic independently walked Input.Sections looking for
+// the first non-empty Heading — and because Parse splits only on H2 ("## "),
+// that section loop could never see the H1 at all: Parse puts everything
+// before the first H2 into a preamble Section whose Heading is deliberately
+// "". So a plan whose H1 was a real title followed by "## 1. Context — Why
+// Now" or "## TL;DR" rendered correctly (H1-aware) but saved to the ledger
+// under the WRONG topic/slug (the first H2's text) — the rendered page and
+// the saved plan card silently disagreed. Exporting this one function and
+// routing both callers through it makes that divergence structurally
+// impossible.
+func Title(in Input) string {
+	if m := h1Line.FindStringSubmatch(in.Raw); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	for _, s := range in.Sections {
+		if strings.TrimSpace(s.Heading) != "" {
+			return s.Heading
+		}
+	}
+	return "Implementation Plan"
+}

--- a/internal/plan/title_test.go
+++ b/internal/plan/title_test.go
@@ -1,0 +1,73 @@
+package plan
+
+import "testing"
+
+// TestTitle covers the H1-first derivation ox-1tjj.8 fixed: Parse splits
+// markdown on H2 ("## ") only, so a naive walk of Input.Sections looking for
+// the first non-empty Heading returns the first H2 — never the H1, which
+// lives in the (Heading=="") preamble section. These cases are the two
+// real-world regressions that shipped: a plan whose H1 is a genuine title
+// followed by a "1. Context — Why Now" or "TL;DR" H2 rendered correctly
+// (RenderHTMLOpts already used this H1-first logic) but saved to the ledger
+// under the H2's text instead.
+func TestTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "H1 followed by a numbered context H2 — the ox-1tjj.8 regression",
+			raw: "# Conversation model update — the execution plan\n\n" +
+				"## 1. Context — Why Now\n\nSome framing prose.\n\n" +
+				"## Approach\n\nDo the thing.\n",
+			want: "Conversation model update — the execution plan",
+		},
+		{
+			name: "H1 followed by a TL;DR H2 — the second ox-1tjj.8 regression",
+			raw: "# ox plan — Team-Context-Enriched Plans\n\n" +
+				"## TL;DR\n\nShip it.\n\n" +
+				"## Design\n\nDetails.\n",
+			want: "ox plan — Team-Context-Enriched Plans",
+		},
+		{
+			name: "H1 with no H2 sections at all",
+			raw:  "# Just A Title\n\nNo sections here, just prose.\n",
+			want: "Just A Title",
+		},
+		{
+			name: "H1 with surrounding whitespace is trimmed",
+			raw:  "#    Padded Title   \n\nbody\n",
+			want: "Padded Title",
+		},
+		{
+			name: "no H1 — first H2 heading wins",
+			raw:  "Some preamble with no heading.\n\n## First Section\n\nbody\n",
+			want: "First Section",
+		},
+		{
+			name: "no headings at all falls back",
+			raw:  "Just a paragraph, no heading anywhere.\n",
+			want: "Implementation Plan",
+		},
+		{
+			name: "empty input falls back",
+			raw:  "",
+			want: "Implementation Plan",
+		},
+		{
+			name: "H2 before the H1 in raw text is still not chosen (H1 always wins)",
+			raw:  "## Not The Title\n\nprose\n\n# The Real Title\n\nmore prose\n",
+			want: "The Real Title",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := Parse(tc.raw)
+			if got := Title(in); got != tc.want {
+				t.Errorf("Title(Parse(%q)) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Plans you save now carry **their real title** into the ledger and the web gallery, instead of a fragment of whatever section heading happened to come first. Today a plan whose page reads *"Conversation model update — the execution plan"* is filed as `1-context-why-now`, and the team's Plans gallery is a wall of cards reading "1 Context Why Now", "1 Tl Dr", "Context", "Tl Dr".

It also fixes a second, quieter defect found while testing this one: **`data/plans` was never in the ledger's sparse-checkout cone**, so saved plans were deleted from your working tree about 60 seconds after every save. Two ledgers on one laptop had 25 and 66 plans on `origin/main` and **zero on disk** — `ox plan list`, `view`, and `render` simply could not see most of the team's work.

**Approach: one H1-first `plan.Title` shared by the render and save paths (there were two derivations and only the render one was correct), the title carried on the lifecycle event the cloud already reads, and `data/plans` pinned into the sparse cone.**

```mermaid
flowchart TD
    MD["plan.md with a real H1"] --> RENDER["render path: planTitle"]
    MD --> SAVE["save path: planTopic"]
    RENDER --> GOOD["page title is correct"]
    SAVE --> BAD["walked H2 sections only, so it never saw the H1"]
    BAD --> SLUG["slug and meta.Topic take the first H2"]
    SLUG --> CARD["gallery card reads 1 Context Why Now"]
```

Because `Parse` splits markdown on `##` only, everything above the first H2 lands in a preamble section whose heading is empty — so the save path's section walk could never reach the H1. The render path matched the H1 directly and was right all along.

A third link made it worse: `Save` deliberately left the event's `Topic` blank, reasoning that "the title's source of truth is `plan.html`'s `<head>`." Nothing in the cloud ever reads that meta tag, and it was stamped with the same wrong string anyway — so every ox-saved plan reached the gallery with an empty title, and the web fell back to title-casing the slug.

## What changed

| File | Change |
|---|---|
| `internal/plan/title.go` | **New.** Exported `Title(in)` — the one H1-first derivation, moved out of `render.go`'s private `planTitle`. |
| `internal/plan/render.go` | Deleted the duplicate; calls `Title(in)`. |
| `cmd/ox/plan.go` | `planTopic` keeps its `--topic` short-circuit, then delegates to `plan.Title`. Deleted the H2-only section walk. |
| `internal/plan/store.go` | `Slugify`: cap 4 to 6, trailing stopwords trimmed. `Save`: events now carry `Topic`. |
| `internal/ledger/ledger.go` | `data/plans` added to a new `baseSparseDirs` (deliberately unwindowed, unlike its `data/` siblings). |
| `cmd/ox/doctor_ledger_infra.go` | Cone check generalized to `requiredSparseCone`, **and fixed** — see below. |
| `internal/plan/backfill.go`, `backfill_preflight.go` | **New.** Pure, git-free repair + preflight verdict logic. |
| `cmd/ox/plan_backfill.go`, `plan_backfill_preflight.go`, `plan_commit.go` | **New/extended.** `ox plan backfill-titles` and its git orchestration. |

### Two bugs found while testing this one

**The doctor check that should have caught the cone problem never worked.** It compared entries against `.sageox`, but `git sparse-checkout set` in cone mode writes `/.sageox/` — slashes both sides. The comparison never matched a single real ledger. Fixed with a normalizer, and pinned by a regression test.

**The tests for that check were exercising a copy of it.** `checkLedgerSparseCheckoutAtPath` was a full reimplementation living in the test file, so no production-side change could fail a test. Deleted; the production function is now what the tests call.

### `ox plan backfill-titles`

A one-off repair pass for the ~168 already-saved plans. Re-derives each plan's title/slug from its `plan.md` H1, rewrites `meta.json`, re-stamps `plan.html`, appends a `revised` event, and renames the directory **keeping its original date prefix**. Stale `produced_plans` references in `sessions/*/meta.json` are rewritten so stop-time reconciliation keeps resolving.

Two preflight guards, both active in `--dry-run`:

- **Corpus completeness** — aborts if the working tree holds fewer plan dirs than `origin/main`, naming both counts. Without this, a run against a narrow cone would rework almost nothing and report success.
- **Divergence** — aborts on an out-of-sync ledger unless `--allow-diverged`.

`--dry-run` prints the full old-to-new table and is the intended review artifact before any real run.

## Test Plan

- [x] `go build ./...`, `go vet ./cmd/ox/ ./internal/plan/ ./internal/ledger/`, `gofmt -l` — all clean
- [x] `go test ./internal/plan/... ./internal/ledger/` — pass
- [x] `go test ./cmd/ox/ -run 'Plan|Backfill|Slugify|Title|SparseCone|LedgerSparse'` — pass
- [x] `TestPlanTopic` — 6 cases, including both real-world regressions (H1 followed by `## 1. Context — Why Now`, and by `## TL;DR`). Closes a hole where **no test referenced `planTopic` at all**.
- [x] `TestTitle` 8 cases, `TestSlugify` expanded to 18
- [x] Backfill: rename correctness, original-date-prefix preservation, collision suffixing, skip-and-continue, dry-run-writes-nothing, idempotent second run — verified against a real `git init` fixture
- [x] Preflight: complete/incomplete corpus, local-ahead, unknown remote, diverged aborts, `--allow-diverged` overrides, incomplete corpus aborts **in dry-run**
- [x] Cone: `data/plans` present and unwindowed; cone-mode `/dir/` format accepted; missing-dir detail names the impact
- [x] **Red-checked** — every new fix was reverted individually to confirm its tests fail, then restored
- [ ] N/A: the backfill has not been run against any real ledger. Dry-run review comes first.

<details><summary>Consequences and follow-ups</summary>

**Slug changes are limited to new plans** until the backfill runs. Existing directories keep their names, so existing URLs keep working until you choose to run it.

**The backfill renames directories, so existing plan URLs will 404.** The `pln_` id in `events.jsonl` is untouched — plan identity survives; only the path changes.

**Interior stopwords are deliberately preserved.** `"Conversation model update — the execution plan"` yields `conversation-model-update-the-execution-plan`: `the` is the 4th of 6 words, so it is interior, not trailing. Stripping it would require removing stopwords everywhere, which costs more readability than the terseness buys.

**On existing machines the narrow cone is already baked into `.git/info/sparse-checkout`** and will not self-heal from the code change alone — `ox doctor --fix` now repairs it, which is also the remedy the backfill's abort message points at.

</details>
