### PR TITLE
fix(plan): never leave dangling refs or report a partial backfill as success

### DIFF
--- a/cmd/ox/plan_backfill.go
+++ b/cmd/ox/plan_backfill.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -20,10 +22,10 @@ import (
 // H2 heading instead of the document's H1; see internal/plan/title.go). It
 // re-derives every saved plan's topic/slug from plan.md via plan.Title +
 // plan.Slugify — the compute half lives in internal/plan/backfill.go
-// (ComputeBackfill, ComputeProducedPlansRewrite), so it is fully unit-tested
-// without needing a real git repo; this file owns the CLI porcelain (table
-// output, flags) and the git orchestration (mv/add/commit/push, in
-// plan_commit.go's commitPlanBackfillToLedger).
+// (ComputeBackfill, BackfillRenameMap, ComputeProducedPlansRewrite), so it
+// is fully unit-tested without needing a real git repo; this file owns the
+// CLI porcelain (table output, flags) and the git orchestration (mv/add/
+// commit/push, in plan_commit.go's commitPlanBackfillToLedger).
 //
 // Before any of that, preflightPlanBackfill (plan_backfill_preflight.go)
 // runs two safety guards: the working tree must have at least as many plan
@@ -81,9 +83,19 @@ func init() {
 // resolved ledger path directly (no findGitRoot/config lookup) so tests can
 // point it at a temp fixture. Runs preflightPlanBackfill's two safety guards
 // FIRST — before any scan, before the table is printed, in both dry-run and
-// real mode — then computes the full plan (and, when a slug actually
-// changes, the produced_plans fix-up), prints the table, and — only when
-// dryRun is false — applies every change and lands one batch commit.
+// real mode — then computes the full plan and prints the per-candidate
+// table, and — only when dryRun is false — applies every change and lands
+// one batch commit.
+//
+// The produced_plans rewrite map (plan.BackfillRenameMap) is built from a
+// DIFFERENT candidate set in each branch, and that difference is load-
+// bearing, not cosmetic: dry-run projects it from every non-skipped
+// candidate (nothing is written, so there's nothing else to project from),
+// while the real run derives it ONLY from candidates that ApplyBackfillMeta
+// actually succeeded for. Building the real run's map from the full
+// candidate list (as if every apply were guaranteed to succeed) would let a
+// single failed plan silently redirect a session's produced_plans entry to
+// a slug that plan was never actually renamed to.
 func runPlanBackfillTitlesOnLedger(cmd *cobra.Command, ledgerPath string, dryRun, allowDiverged bool) error {
 	out := cmd.OutOrStdout()
 	ctx := cmd.Context()
@@ -97,33 +109,29 @@ func runPlanBackfillTitlesOnLedger(cmd *cobra.Command, ledgerPath string, dryRun
 	if err != nil {
 		return fmt.Errorf("compute backfill: %w", err)
 	}
-
-	// Only a SLUG change invalidates a sessions/*/meta.json produced_plans
-	// entry (it's resolved by slug — see resolvePlanDir) — a topic-only
-	// correction with no slug change leaves that reference valid.
-	renamed := make(map[string]string, len(candidates))
-	for _, c := range candidates {
-		if c.SkipReason == "" && c.SlugChanged {
-			renamed[c.OldSlug] = c.NewSlug
-		}
-	}
-	sessionRewrites, err := plan.ComputeProducedPlansRewrite(filepath.Join(ledgerPath, "sessions"), renamed)
-	if err != nil {
-		return fmt.Errorf("compute produced_plans rewrite: %w", err)
-	}
-
-	writeBackfillTable(out, candidates, sessionRewrites)
-
+	writeCandidateTable(out, candidates)
 	total, retitled, renamedCount, skipped := backfillCounts(candidates)
+
 	if dryRun {
-		slog.Info("plan_backfill_titles_dry_run", "total", total, "retitled", retitled, "renamed", renamedCount, "skipped", skipped, "sessions_to_fix", len(sessionRewrites))
-		fmt.Fprintf(out, "\nDry run — nothing written. total=%d retitled=%d renamed=%d skipped=%d sessions_to_fix=%d\n",
-			total, retitled, renamedCount, skipped, len(sessionRewrites))
+		// Preview only: project the rewrite map from every non-skipped,
+		// slug-changing candidate as if the whole batch will succeed — the
+		// real run below re-derives this from actual outcomes instead.
+		previewRenamed, ambiguous := plan.BackfillRenameMap(candidates)
+		sessionRewrites, err := plan.ComputeProducedPlansRewrite(filepath.Join(ledgerPath, "sessions"), previewRenamed)
+		if err != nil {
+			return fmt.Errorf("compute produced_plans rewrite: %w", err)
+		}
+		reportAmbiguousSlugs(out, ambiguous)
+		writeSessionRewriteTable(out, sessionRewrites)
+		slog.Info("plan_backfill_titles_dry_run", "total", total, "retitled", retitled, "renamed", renamedCount, "skipped", skipped, "sessions_to_fix", len(sessionRewrites), "ambiguous_slugs", len(ambiguous))
+		fmt.Fprintf(out, "\nDry run — nothing written. total=%d retitled=%d renamed=%d skipped=%d sessions_to_fix=%d ambiguous_slugs=%d\n",
+			total, retitled, renamedCount, skipped, len(sessionRewrites), len(ambiguous))
 		return nil
 	}
 
 	var renames [][2]string      // (old, new) absolute paths for git mv
 	var touchedPlanDirs []string // topic-only correction, no rename: plain git add
+	var applied []plan.BackfillPlan
 	for _, c := range candidates {
 		if !c.Changed() {
 			continue
@@ -131,15 +139,24 @@ func runPlanBackfillTitlesOnLedger(cmd *cobra.Command, ledgerPath string, dryRun
 		if err := plan.ApplyBackfillMeta(ctx, c.OldDir, c.NewTopic, c.NewSlug); err != nil {
 			// A single plan's write failure must never abort the batch — log
 			// and continue, matching ComputeBackfill's own skip-and-continue
-			// contract for a broken source dir.
+			// contract for a broken source dir. Crucially, this candidate is
+			// NOT added to `applied` — see BackfillRenameMap.
 			slog.Warn("plan backfill: apply failed, skipping", "dir", c.OldDir, "error", err)
 			continue
 		}
+		applied = append(applied, c)
 		if c.NewDir != "" {
 			renames = append(renames, [2]string{c.OldDir, c.NewDir})
 		} else {
 			touchedPlanDirs = append(touchedPlanDirs, c.OldDir)
 		}
+	}
+
+	renamed, ambiguous := plan.BackfillRenameMap(applied)
+	reportAmbiguousSlugs(out, ambiguous)
+	sessionRewrites, err := plan.ComputeProducedPlansRewrite(filepath.Join(ledgerPath, "sessions"), renamed)
+	if err != nil {
+		return fmt.Errorf("compute produced_plans rewrite: %w", err)
 	}
 
 	var touchedSessionDirs []string
@@ -150,31 +167,43 @@ func runPlanBackfillTitlesOnLedger(cmd *cobra.Command, ledgerPath string, dryRun
 		}
 		touchedSessionDirs = append(touchedSessionDirs, r.SessionDir)
 	}
+	writeSessionRewriteTable(out, sessionRewrites)
 
 	if len(renames) == 0 && len(touchedPlanDirs) == 0 && len(touchedSessionDirs) == 0 {
 		fmt.Fprintln(out, "Nothing to backfill — every saved plan already matches its post-fix title/slug.")
 		return nil
 	}
 
-	// Best-effort push, same contract as commitPlanToLedger/savePlanArtifacts:
-	// a push failure leaves the local commit for the next push / `ox doctor`
-	// rather than failing the whole command — the mv/edit/commit work already
-	// landed locally and re-running the command would otherwise redo it.
 	if err := commitPlanBackfillToLedger(ledgerPath, renames, touchedPlanDirs, touchedSessionDirs); err != nil {
-		slog.Warn("plan backfill: commit/push failed, deferring to next push/doctor", "error", err)
-		cli.PrintHint("commit/push failed (see log) — the local commit stands; retry with `ox doctor --fix` or a plain push.")
+		if errors.Is(err, errBackfillCommitFailed) {
+			// The mv/edit work above already landed on disk but never made it
+			// into a commit — a materially different, worse state than "committed
+			// but not pushed" below. This MUST fail the command: printing the
+			// success summary here would tell an operator/CI the batch landed
+			// when the ledger working tree is actually left dirty and half-done.
+			slog.Error("plan backfill: commit failed, ledger working tree left partially modified", "ledger", ledgerPath, "error", err)
+			return fmt.Errorf("backfill commit failed before landing locally — ledger working tree at %s has renamed/edited files that were never committed; run `git status` there, finish or discard the partial change by hand, then retry: %w", ledgerPath, err)
+		}
+		// Best-effort push, same contract as commitPlanToLedger/savePlanArtifacts:
+		// the mv/edit/commit work above already landed in ONE local commit; a
+		// push failure leaves that commit for the next push / `ox doctor`
+		// rather than failing the whole command — re-running would otherwise
+		// redo real work that already succeeded.
+		slog.Warn("plan backfill: push failed, local commit stands", "error", err)
+		cli.PrintHint("push failed (see log) — the local commit stands; retry with `ox doctor --fix` or a plain push.")
 	}
 
-	slog.Info("plan_backfill_titles", "total", total, "retitled", retitled, "renamed", renamedCount, "skipped", skipped, "sessions_fixed", len(touchedSessionDirs))
-	fmt.Fprintf(out, "\nBackfilled: total=%d retitled=%d renamed=%d skipped=%d sessions_fixed=%d\n",
-		total, retitled, renamedCount, skipped, len(touchedSessionDirs))
+	slog.Info("plan_backfill_titles", "total", total, "retitled", retitled, "renamed", renamedCount, "skipped", skipped, "sessions_fixed", len(touchedSessionDirs), "ambiguous_slugs", len(ambiguous))
+	fmt.Fprintf(out, "\nBackfilled: total=%d retitled=%d renamed=%d skipped=%d sessions_fixed=%d ambiguous_slugs=%d\n",
+		total, retitled, renamedCount, skipped, len(touchedSessionDirs), len(ambiguous))
 	return nil
 }
 
-// writeBackfillTable prints the full old->new retitle/rename table — the
-// artifact a human reviews before allowing a real run — plus, when any
-// exist, the sessions whose produced_plans need fixing.
-func writeBackfillTable(out io.Writer, candidates []plan.BackfillPlan, sessionRewrites []plan.ProducedPlansRewrite) {
+// writeCandidateTable prints the full old->new retitle/rename table — the
+// artifact a human reviews before allowing a real run. Depends only on
+// candidates, so it's identical whether printed before a dry-run preview or
+// before a real run's apply loop.
+func writeCandidateTable(out io.Writer, candidates []plan.BackfillPlan) {
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
 	fmt.Fprintln(tw, "OLD SLUG\tNEW SLUG\tOLD TOPIC\tNEW TOPIC\tACTION")
 	for _, c := range candidates {
@@ -193,17 +222,52 @@ func writeBackfillTable(out io.Writer, candidates []plan.BackfillPlan, sessionRe
 			c.OldSlug, c.NewSlug, truncate(c.OldTopic, 40), truncate(c.NewTopic, 40), action)
 	}
 	_ = tw.Flush()
+}
 
+// writeSessionRewriteTable prints the sessions whose produced_plans need
+// fixing. In dry-run this is a PROJECTION (computed from every non-skipped
+// candidate, before anything is applied); in a real run it reflects the
+// ACTUAL rewrite map, derived only from candidates that really applied — see
+// runPlanBackfillTitlesOnLedger. No-op when there's nothing to report.
+func writeSessionRewriteTable(out io.Writer, sessionRewrites []plan.ProducedPlansRewrite) {
 	if len(sessionRewrites) == 0 {
 		return
 	}
 	fmt.Fprintln(out, "\nSessions with stale produced_plans to fix:")
-	tw2 := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(tw2, "SESSION\tSTALE SLUGS")
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "SESSION\tSTALE SLUGS")
 	for _, r := range sessionRewrites {
-		fmt.Fprintf(tw2, "%s\t%s\n", filepath.Base(r.SessionDir), strings.Join(r.OldSlugs, ", "))
+		fmt.Fprintf(tw, "%s\t%s\n", filepath.Base(r.SessionDir), strings.Join(r.OldSlugs, ", "))
 	}
-	_ = tw2.Flush()
+	_ = tw.Flush()
+}
+
+// reportAmbiguousSlugs surfaces every old slug plan.BackfillRenameMap
+// excluded because it would derive more than one distinct new slug —
+// produced_plans stores only the bare slug, so there is no automatic way to
+// resolve these; a human has to look at each one. Logs one structured
+// warning per slug (so it shows up in the same pipeline that watches for
+// backfill problems) and prints a table (so a dry-run reviewer sees it
+// without grepping logs). No-op when there's nothing to report.
+func reportAmbiguousSlugs(out io.Writer, ambiguous map[string][]string) {
+	if len(ambiguous) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(ambiguous))
+	for k := range ambiguous {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // deterministic order for the printed table and log sequence
+
+	fmt.Fprintln(out, "\nAmbiguous old slugs — map to multiple new slugs, EXCLUDED from produced_plans rewrite (resolve by hand):")
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "OLD SLUG\tCOMPETING NEW SLUGS")
+	for _, k := range keys {
+		targets := ambiguous[k]
+		slog.Warn("plan backfill: ambiguous old slug excluded from produced_plans rewrite", "old_slug", k, "competing_new_slugs", strings.Join(targets, ","))
+		fmt.Fprintf(tw, "%s\t%s\n", k, strings.Join(targets, ", "))
+	}
+	_ = tw.Flush()
 }
 
 // backfillCounts summarizes a computed batch for the printed/logged totals:

--- a/cmd/ox/plan_backfill_test.go
+++ b/cmd/ox/plan_backfill_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/plan"
 	"github.com/spf13/cobra"
 )
@@ -251,5 +252,136 @@ func TestRunPlanBackfillTitlesOnLedger_RealRunIdempotent(t *testing.T) {
 	after := gitLog()
 	if before != after {
 		t.Errorf("a no-op second run created a new commit:\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+// writeBackfillSessionFixture hand-writes a sessions/<name>/meta.json with
+// the given produced_plans, the on-disk shape ComputeProducedPlansRewrite /
+// ApplyProducedPlansRewrite read and write.
+func writeBackfillSessionFixture(t *testing.T, ledgerPath, name string, producedPlans []string) string {
+	t.Helper()
+	dir := filepath.Join(ledgerPath, "sessions", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := lfs.NewSessionMeta(name, "Person A", "Ox0001", "claude-code", time.Now().UTC()).
+		ProducedPlans(producedPlans).
+		Build()
+	if err := lfs.WriteSessionMetaOnly(dir, meta); err != nil {
+		t.Fatalf("write session meta: %v", err)
+	}
+	return dir
+}
+
+// corruptEventsLog appends a malformed line to dir/events.jsonl so a
+// subsequent LoadEvents call fails to parse it — the trigger
+// appendBackfillRevisedEvent's finding-5 fix reacts to.
+func corruptEventsLog(t *testing.T, dir string) {
+	t.Helper()
+	f, err := os.OpenFile(filepath.Join(dir, "events.jsonl"), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("not valid json\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRunPlanBackfillTitlesOnLedger_FailedApplyExcludesSlugFromSessionRewrite
+// is the finding-1 regression: when ApplyBackfillMeta fails for one
+// candidate in a batch (here: a corrupted events.jsonl makes
+// appendBackfillRevisedEvent fail), that plan is never renamed on disk — and
+// a session's produced_plans entry naming its OLD slug must NOT be rewritten
+// to the NewSlug it was never actually renamed to. A sibling candidate in
+// the same batch that DOES apply cleanly must still get its own session
+// reference fixed, proving the exclusion is targeted, not a batch-wide bail.
+func TestRunPlanBackfillTitlesOnLedger_FailedApplyExcludesSlugFromSessionRewrite(t *testing.T) {
+	ledger := t.TempDir()
+
+	goodDir := writeBackfillPlanFixture(t, ledger, "2026-05-01-1-context-why-now", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	const goodNewSlug = "conversation-model-update-the-execution-plan"
+
+	brokenRaw := "# Add Login Support\n\n## TL;DR\n\nShip it.\n\n## Approach\n\ndo it.\n"
+	brokenDir := writeBackfillPlanFixture(t, ledger, "2026-05-02-tl-dr", brokenRaw, "TL;DR", time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC))
+	corruptEventsLog(t, brokenDir)
+
+	sessionDir := writeBackfillSessionFixture(t, ledger, "2026-05-03-sess-Ox0001", []string{"1-context-why-now", "tl-dr"})
+
+	initGitLedger(t, ledger)
+
+	if _, err := runBackfillForTest(t, ledger, false); err != nil {
+		t.Fatalf("real run: %v", err)
+	}
+
+	// goodDir got renamed; brokenDir's apply failed, so it must be left at
+	// its ORIGINAL path — never renamed, despite ComputeBackfill proposing
+	// a NewDir for it same as any other slug-changing candidate.
+	if _, statErr := os.Stat(goodDir); !os.IsNotExist(statErr) {
+		t.Errorf("goodDir still exists at its old path after a successful apply: stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(brokenDir); statErr != nil {
+		t.Errorf("brokenDir was renamed/removed despite its apply failing: %v", statErr)
+	}
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	if err != nil {
+		t.Fatalf("ReadSessionMeta: %v", err)
+	}
+	if len(got.ProducedPlans) != 2 {
+		t.Fatalf("ProducedPlans = %v, want 2 entries", got.ProducedPlans)
+	}
+	want := map[string]bool{goodNewSlug: false, "tl-dr": false}
+	for _, slug := range got.ProducedPlans {
+		if _, ok := want[slug]; !ok {
+			t.Errorf("unexpected produced_plans entry %q (got %v)", slug, got.ProducedPlans)
+			continue
+		}
+		want[slug] = true
+	}
+	if !want[goodNewSlug] {
+		t.Errorf("produced_plans missing the rewritten slug %q for the successfully applied plan: got %v", goodNewSlug, got.ProducedPlans)
+	}
+	if !want["tl-dr"] {
+		t.Errorf("produced_plans no longer contains the stale slug %q — it must stay untouched since that plan's apply failed: got %v", "tl-dr", got.ProducedPlans)
+	}
+}
+
+// TestRunPlanBackfillTitlesOnLedger_PreCommitFailureFailsCommandAndSkipsSummary
+// is the finding-3/6 regression: a failure at or before `git commit` (here:
+// every git operation is blocked by a stale .git/index.lock, so `git mv` —
+// the FIRST git call the real run makes — fails before anything is
+// committed) must make the command return a non-nil error and must NOT
+// print the "Backfilled: ..." success summary. Contrast with
+// TestRunPlanBackfillTitlesOnLedger_RealRunRenamesAndCommits, where a
+// push-only failure (no remote configured) still returns nil and prints the
+// summary — this is the case that must NOT be treated the same way.
+func TestRunPlanBackfillTitlesOnLedger_PreCommitFailureFailsCommandAndSkipsSummary(t *testing.T) {
+	ledger := t.TempDir()
+	writeBackfillPlanFixture(t, ledger, "2026-05-01-1-context-why-now", backfillTestRaw, "1. Context — Why Now", time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	initGitLedger(t, ledger)
+
+	lockPath := filepath.Join(ledger, ".git", "index.lock")
+	if err := os.WriteFile(lockPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runBackfillForTest(t, ledger, false)
+	if rmErr := os.Remove(lockPath); rmErr != nil && !os.IsNotExist(rmErr) {
+		t.Fatalf("cleanup index.lock: %v", rmErr)
+	}
+
+	if err == nil {
+		t.Fatalf("expected a non-nil error when every git operation is blocked; output:\n%s", out)
+	}
+	if strings.Contains(out, "Backfilled:") {
+		t.Errorf("output printed the success summary despite the commit never landing:\n%s", out)
+	}
+
+	logOut := runGitInDir(t, ledger, "log", "--oneline")
+	if strings.Count(strings.TrimSpace(logOut), "\n") != 0 {
+		t.Errorf("expected only the init commit (nothing landed), got:\n%s", logOut)
 	}
 }

--- a/cmd/ox/plan_commit.go
+++ b/cmd/ox/plan_commit.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,17 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/gitserver"
 )
+
+// errBackfillCommitFailed marks a commitPlanBackfillToLedger failure at or
+// before `git commit` — the ledger working tree is left with renames/edits
+// (ApplyBackfillMeta and any git mv that got that far already ran) that were
+// never captured in a commit. That is a materially worse, inconsistent state
+// than a push-only failure, which leaves a complete, durable local commit for
+// the next push to pick up — so the two must never be handled the same way.
+// runPlanBackfillTitlesOnLedger uses errors.Is against this sentinel to route
+// a pre-commit failure into a hard, non-zero-exit command failure instead of
+// the best-effort warning a push failure gets.
+var errBackfillCommitFailed = errors.New("backfill commit failed before landing locally")
 
 // commitPlanToLedger durably commits a captured plan directory to the ledger
 // and pushes it. This closes a real gap: plan.Save only materializes files into
@@ -62,6 +74,12 @@ func commitPlanToLedger(gitRoot, planDir string) error {
 // commitPlanToLedger's pattern (--sparse, --no-verify, pushLedger with
 // pull-rebase retry) rather than hand-rolling new git plumbing.
 //
+// Only the final push is best-effort. Every git op at or before `git
+// commit` (mv, add, commit itself) returns an error wrapped in
+// errBackfillCommitFailed on failure — unlike a push failure, those leave
+// the working tree in a half-mutated state with nothing to anchor it, so
+// the caller must treat that as a hard failure, not a warning.
+//
 // renames are (oldAbsPath, newAbsPath) pairs applied via `git mv --sparse`.
 // touchedPlanDirs/touchedSessionDirs are absolute paths edited in-place
 // (topic-only correction with no slug change; a session's produced_plans
@@ -91,11 +109,11 @@ func commitPlanBackfillToLedger(ledgerPath string, renames [][2]string, touchedP
 		}
 		mvArgs := []string{"-C", ledgerPath, "mv", "--sparse", oldRel, newRel}
 		if out, err := exec.Command("git", mvArgs...).CombinedOutput(); err != nil {
-			return fmt.Errorf("git mv %s -> %s failed: %s: %w", oldRel, newRel, string(out), err)
+			return fmt.Errorf("%w: git mv %s -> %s failed: %s: %w", errBackfillCommitFailed, oldRel, newRel, string(out), err)
 		}
 		addArgs := []string{"-C", ledgerPath, "add", "--sparse", newRel}
 		if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
-			return fmt.Errorf("git add %s (post-mv content) failed: %s: %w", newRel, string(out), err)
+			return fmt.Errorf("%w: git add %s (post-mv content) failed: %s: %w", errBackfillCommitFailed, newRel, string(out), err)
 		}
 	}
 
@@ -103,7 +121,7 @@ func commitPlanBackfillToLedger(ledgerPath string, renames [][2]string, touchedP
 	if len(addPaths) > 0 {
 		addArgs := append([]string{"-C", ledgerPath, "add", "--sparse"}, addPaths...)
 		if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
-			return fmt.Errorf("git add failed: %s: %w", string(out), err)
+			return fmt.Errorf("%w: git add failed: %s: %w", errBackfillCommitFailed, string(out), err)
 		}
 	}
 
@@ -113,8 +131,11 @@ func commitPlanBackfillToLedger(ledgerPath string, renames [][2]string, touchedP
 		if strings.Contains(string(out), "nothing to commit") {
 			return nil // idempotent: re-run with nothing left to change
 		}
-		return fmt.Errorf("%s: %w", wrapCommitError(string(out), err), err)
+		return fmt.Errorf("%w: %s: %w", errBackfillCommitFailed, wrapCommitError(string(out), err), err)
 	}
 
+	// Everything from here down is push-only: the commit above already
+	// landed locally, so a failure past this point must NOT match
+	// errBackfillCommitFailed — see the caller's best-effort push contract.
 	return pushLedger(context.Background(), ledgerPath)
 }

--- a/cmd/ox/plan_commit_test.go
+++ b/cmd/ox/plan_commit_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// plan_commit_test.go covers commitPlanBackfillToLedger's failure routing:
+// a failure at or before `git commit` must be distinguishable from a
+// push-only failure (see errBackfillCommitFailed in plan_commit.go), since
+// the caller (runPlanBackfillTitlesOnLedger) treats the two very
+// differently — one is a hard command failure, the other a best-effort
+// warning. Reuses initGitLedger from plan_backfill_test.go (same package).
+
+// TestCommitPlanBackfillToLedger_PreCommitGitFailureIsErrBackfillCommitFailed
+// forces `git mv` to fail (source path was never created) — a stand-in for
+// any pre-commit git failure — and verifies the returned error satisfies
+// errors.Is(err, errBackfillCommitFailed).
+func TestCommitPlanBackfillToLedger_PreCommitGitFailureIsErrBackfillCommitFailed(t *testing.T) {
+	ledger := t.TempDir()
+	initGitLedger(t, ledger)
+
+	bogusOld := filepath.Join(ledger, "data", "plans", "2026-01-01-does-not-exist")
+	bogusNew := filepath.Join(ledger, "data", "plans", "2026-01-01-renamed")
+
+	err := commitPlanBackfillToLedger(ledger, [][2]string{{bogusOld, bogusNew}}, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error: git mv on a path that was never created")
+	}
+	if !errors.Is(err, errBackfillCommitFailed) {
+		t.Errorf("error = %v, want errors.Is(err, errBackfillCommitFailed)", err)
+	}
+
+	// Nothing must have been committed — HEAD is still just the init commit.
+	out := runGitInDir(t, ledger, "log", "--oneline")
+	if strings.Count(strings.TrimSpace(out), "\n") != 0 {
+		t.Errorf("expected only the init commit after a pre-commit failure, got:\n%s", out)
+	}
+}
+
+// TestCommitPlanBackfillToLedger_PushOnlyFailureIsNotErrBackfillCommitFailed
+// is the negative case finding 3 explicitly requires: a real, valid commit
+// (mv/add/commit all succeed) followed by a push failure (no remote
+// configured) must return an error that does NOT match
+// errBackfillCommitFailed, and the commit must have actually landed.
+func TestCommitPlanBackfillToLedger_PushOnlyFailureIsNotErrBackfillCommitFailed(t *testing.T) {
+	ledger := t.TempDir()
+	initGitLedger(t, ledger)
+
+	dir := filepath.Join(ledger, "data", "plans", "2026-01-01-real")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(`{"topic":"x"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := commitPlanBackfillToLedger(ledger, nil, []string{dir}, nil)
+	if err == nil {
+		t.Fatal("expected a push failure: no remote is configured for this ledger")
+	}
+	if errors.Is(err, errBackfillCommitFailed) {
+		t.Errorf("push-only failure incorrectly matched errBackfillCommitFailed: %v", err)
+	}
+
+	out := runGitInDir(t, ledger, "log", "--oneline")
+	if !strings.Contains(out, "plan: backfill 1 title") {
+		t.Errorf("commit did not land locally despite this being a push-only failure:\n%s", out)
+	}
+	status := runGitInDir(t, ledger, "status", "--porcelain")
+	if strings.TrimSpace(status) != "" {
+		t.Errorf("working tree not clean after a successful commit (push-only failure): %q", status)
+	}
+}

--- a/internal/plan/backfill.go
+++ b/internal/plan/backfill.go
@@ -3,12 +3,13 @@ package plan
 // backfill.go computes and applies the one-off repair pass for plans saved by
 // the pre-ox-1tjj.8 planTopic (which read the first H2 heading, not the
 // document's H1 — see title.go). It is deliberately split into a read-only
-// COMPUTE half (ComputeBackfill, ComputeProducedPlansRewrite — safe to run
-// any number of times, used directly by `ox plan backfill-titles --dry-run`)
-// and an APPLY half (ApplyBackfillMeta, ApplyProducedPlansRewrite) that
-// mutates one plan/session at a time. The cmd/ox layer owns git (mv/add/
-// commit/push) and orchestrates: compute -> print -> (if not dry-run) apply
-// each -> git mv -> one batch commit.
+// COMPUTE half (ComputeBackfill, BackfillRenameMap, ComputeProducedPlansRewrite
+// — safe to run any number of times, used directly by
+// `ox plan backfill-titles --dry-run`) and an APPLY half (ApplyBackfillMeta,
+// ApplyProducedPlansRewrite) that mutates one plan/session at a time. The
+// cmd/ox layer owns git (mv/add/commit/push) and orchestrates: compute ->
+// print -> (if not dry-run) apply each -> derive BackfillRenameMap from
+// what actually applied -> git mv -> one batch commit.
 
 import (
 	"context"
@@ -18,6 +19,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 
 	"github.com/sageox/ox/internal/fileutil"
@@ -147,6 +149,62 @@ func nextAvailableName(taken map[string]bool, datePrefix, slug string) (finalSlu
 	}
 }
 
+// BackfillRenameMap derives the old-slug -> new-slug rewrite map a
+// sessions/*/meta.json produced_plans fix-up needs, from whatever set of
+// candidates the caller supplies. It is deliberately fed two different
+// inputs by the two callers: `--dry-run` passes every non-skipped candidate
+// (a projection of what WOULD happen, since nothing is written), and a real
+// run passes only the candidates ApplyBackfillMeta + the directory rename
+// actually succeeded for (see runPlanBackfillTitlesOnLedger) — never the
+// full candidate list. That distinction matters: a candidate whose apply
+// failed was never renamed on disk, so redirecting a session's
+// produced_plans entry to its computed-but-never-applied NewSlug would
+// point at a directory that doesn't exist.
+//
+// Only a SLUG change invalidates a produced_plans entry (it's resolved by
+// slug — see resolvePlanDir); a topic-only correction with no slug change
+// leaves that reference valid, so unchanged/topic-only candidates are
+// skipped here same as skipped ones.
+//
+// plan directories are "YYYY-MM-DD-<slug>", so two plans on DIFFERENT dates
+// can legitimately share the same bare OldSlug while deriving different
+// NewSlugs (ComputeBackfill's collision suffixing dedupes on the full
+// dir name including the date prefix, not the bare slug — see
+// nextAvailableName). produced_plans stores only the bare slug, so an old
+// slug that resolves to more than one distinct new slug is genuinely
+// UNRESOLVABLE from this data alone: there is no way to tell which session
+// meant which plan. Rather than guess (and silently corrupt one of the two
+// references), such an old slug is dropped from the returned map entirely
+// and reported back via ambiguous for the caller to warn about and print —
+// those need a human to resolve by hand.
+func BackfillRenameMap(candidates []BackfillPlan) (renamed map[string]string, ambiguous map[string][]string) {
+	renamed = make(map[string]string)
+	ambiguous = make(map[string][]string)
+	for _, c := range candidates {
+		if c.SkipReason != "" || !c.SlugChanged {
+			continue
+		}
+		if targets, isAmbiguous := ambiguous[c.OldSlug]; isAmbiguous {
+			// already-flagged old slug: keep collecting every competing
+			// target for the operator report, but never re-resolve it.
+			if !slices.Contains(targets, c.NewSlug) {
+				ambiguous[c.OldSlug] = append(targets, c.NewSlug)
+			}
+			continue
+		}
+		if existing, ok := renamed[c.OldSlug]; ok {
+			if existing == c.NewSlug {
+				continue // same target from a second candidate — not a conflict
+			}
+			delete(renamed, c.OldSlug)
+			ambiguous[c.OldSlug] = []string{existing, c.NewSlug}
+			continue
+		}
+		renamed[c.OldSlug] = c.NewSlug
+	}
+	return renamed, ambiguous
+}
+
 // ApplyBackfillMeta rewrites one plan's meta.json (topic+slug only — every
 // other field, including provenance and collaboration signals, is left
 // exactly as originally recorded, since this is a title repair, not a
@@ -187,19 +245,30 @@ func ApplyBackfillMeta(ctx context.Context, dir, newTopic, newSlug string) error
 
 // appendBackfillRevisedEvent appends a lifecycle event carrying the corrected
 // topic, under the same events.jsonl flock Save/AppendEvent use. It mints a
-// fresh pln_ id only for a plan dir with NO prior events at all (a legacy
-// plan saved before the event-log foundation shipped) and records that as a
-// `created` event, exactly mirroring Save()'s own firstSave/reuse decision —
-// so a legacy plan ends up in the same state a fresh post-fix Save would have
-// left it in. Returns the resolved (or minted) id for StampHTMLMeta to reuse.
+// fresh pln_ id only for a plan dir with a genuinely EMPTY events.jsonl (a
+// legacy plan saved before the event-log foundation shipped) and records
+// that as a `created` event — the same firstSave/reuse decision Save() makes
+// for a brand-new directory (store.go).
+//
+// A LoadEvents ERROR is deliberately NOT treated the same as "empty",
+// despite Save() doing exactly that on its own read failure: Save is
+// creating a directory that may have no history yet, so "couldn't read
+// events, assume none" is a safe default. This function is REPAIRING a
+// directory that, in the common case, already has real history — treating
+// an unreadable (as opposed to empty) events.jsonl as "no prior events"
+// would mint a second pln_ id for a plan that already has one, forking its
+// identity across two ids in the same log. So a read error is returned
+// as-is: the caller's apply-and-skip contract (runPlanBackfillTitlesOnLedger)
+// logs it and moves on to the next plan, same as any other apply failure,
+// and never invents an identity for history it simply couldn't read.
+// Returns the resolved (or minted) id for StampHTMLMeta to reuse.
 func appendBackfillRevisedEvent(ctx context.Context, dir, newTopic string) (string, error) {
 	eventsPath := filepath.Join(dir, eventsFile)
 	var planID string
 	err := fileutil.WithFileLock(ctx, eventsPath, func() error {
 		existing, lerr := LoadEvents(dir)
 		if lerr != nil {
-			slog.Warn("plan backfill: load existing events failed, minting a fresh id", "error", lerr, "dir", dir)
-			existing = nil
+			return fmt.Errorf("load existing events: %w", lerr)
 		}
 		ev := Event{Kind: EventRevised, Topic: newTopic}
 		if len(existing) == 0 {

--- a/internal/plan/backfill_test.go
+++ b/internal/plan/backfill_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -292,6 +293,92 @@ func TestBackfill_Idempotent(t *testing.T) {
 	}
 }
 
+// TestAppendBackfillRevisedEvent_UnreadableEventsNeverMintsNewID is the
+// finding-5 regression: a plan dir with real prior history whose
+// events.jsonl becomes unreadable (here, a malformed trailing line) must
+// fail the append rather than treat "unreadable" the same as "no prior
+// events" — that used to mint a fresh pln_ id and record a SECOND `created`
+// event on top of the plan's real history, forking its identity.
+func TestAppendBackfillRevisedEvent_UnreadableEventsNeverMintsNewID(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	seedID := "pln_original0000000000001"
+	if err := AppendEvent(ctx, dir, Event{PlanID: seedID, Kind: EventCreated, Status: PlanStatusDraft, Topic: "Old Topic"}); err != nil {
+		t.Fatalf("seed created event: %v", err)
+	}
+	eventsPath := filepath.Join(dir, eventsFile)
+	before, err := os.ReadFile(eventsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeLines := strings.Count(strings.TrimRight(string(before), "\n"), "\n") + 1
+
+	// Corrupt the log with one malformed line — LoadEvents fails to parse
+	// it, exactly the "momentarily unreadable" scenario the fix targets.
+	f, err := os.OpenFile(eventsPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("not valid json\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	gotID, err := appendBackfillRevisedEvent(ctx, dir, "New Topic")
+	if err == nil {
+		t.Fatalf("appendBackfillRevisedEvent succeeded despite unreadable events.jsonl; minted id=%q", gotID)
+	}
+
+	after, err := os.ReadFile(eventsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterLines := strings.Count(strings.TrimRight(string(after), "\n"), "\n") + 1
+	// beforeLines (1 seed line) + 1 injected corrupt line = 2. A buggy
+	// implementation appends a THIRD line (the minted `created` event) here.
+	if afterLines != beforeLines+1 {
+		t.Errorf("events.jsonl grew from %d to %d lines on a failed append (want unchanged at %d): %s",
+			beforeLines, afterLines, beforeLines+1, after)
+	}
+	if strings.Contains(string(after), "New Topic") {
+		t.Errorf("a revised/created event carrying the new topic was appended despite the load failure: %s", after)
+	}
+}
+
+// TestAppendBackfillRevisedEvent_EmptyEventsStillMints is the companion
+// positive case: a plan dir with a genuinely EMPTY (not corrupt, not
+// missing-and-erroring) events.jsonl is the legacy pre-event-log plan the
+// minting path exists for, and must still mint — the finding-5 fix only
+// changes the ERROR case, not this one.
+func TestAppendBackfillRevisedEvent_EmptyEventsStillMints(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	// No events.jsonl at all: LoadEvents returns (nil, nil), matching a
+	// legacy plan saved before the event-log foundation shipped.
+
+	gotID, err := appendBackfillRevisedEvent(ctx, dir, "New Topic")
+	if err != nil {
+		t.Fatalf("appendBackfillRevisedEvent on a legacy (no events.jsonl) plan: %v", err)
+	}
+	if gotID == "" {
+		t.Fatal("no id minted for a legacy plan with no prior events")
+	}
+
+	events, err := LoadEvents(dir)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("LoadEvents after mint: err=%v n=%d", err, len(events))
+	}
+	if events[0].Kind != EventCreated {
+		t.Errorf("Kind = %q, want %q for the minted event", events[0].Kind, EventCreated)
+	}
+	if events[0].PlanID != gotID {
+		t.Errorf("recorded PlanID = %q, want the returned %q", events[0].PlanID, gotID)
+	}
+}
+
 // --- produced_plans rewrite ---
 
 func writeTestSessionMeta(t *testing.T, sessionsDir, name string, producedPlans []string) string {
@@ -324,6 +411,122 @@ func TestComputeProducedPlansRewrite_FindsStaleSlug(t *testing.T) {
 	}
 	if got := rewrites[0].OldSlugs; len(got) != 1 || got[0] != "1-context-why-now" {
 		t.Errorf("OldSlugs = %v, want [1-context-why-now]", got)
+	}
+}
+
+// --- BackfillRenameMap ---
+
+// TestBackfillRenameMap covers the produced_plans rewrite map derivation in
+// isolation from ComputeBackfill/ApplyBackfillMeta: given a hand-built set
+// of candidates, which old slugs make it into the map and which get
+// excluded.
+func TestBackfillRenameMap(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		candidates    []BackfillPlan
+		wantRenamed   map[string]string
+		wantAmbiguous map[string][]string
+	}{
+		{
+			name: "slug change is included",
+			candidates: []BackfillPlan{
+				{OldSlug: "old-a", NewSlug: "new-a", SlugChanged: true},
+			},
+			wantRenamed:   map[string]string{"old-a": "new-a"},
+			wantAmbiguous: map[string][]string{},
+		},
+		{
+			name: "topic-only change (no slug change) is excluded",
+			candidates: []BackfillPlan{
+				{OldSlug: "same-slug", NewSlug: "same-slug", SlugChanged: false, TopicChanged: true},
+			},
+			wantRenamed:   map[string]string{},
+			wantAmbiguous: map[string][]string{},
+		},
+		{
+			name: "a skipped (unreadable) candidate is excluded even if fields look like a slug change",
+			candidates: []BackfillPlan{
+				{OldSlug: "old-a", NewSlug: "new-a", SlugChanged: true, SkipReason: "unreadable meta.json: boom"},
+			},
+			wantRenamed:   map[string]string{},
+			wantAmbiguous: map[string][]string{},
+		},
+		{
+			name: "same old slug, same new slug from two dirs is not ambiguous",
+			candidates: []BackfillPlan{
+				{OldDir: "/plans/2026-05-01-dup", OldSlug: "dup", NewSlug: "target", SlugChanged: true},
+				{OldDir: "/plans/2026-06-01-dup", OldSlug: "dup", NewSlug: "target", SlugChanged: true},
+			},
+			wantRenamed:   map[string]string{"dup": "target"},
+			wantAmbiguous: map[string][]string{},
+		},
+		{
+			// The exact scenario finding 2 describes: two plans on different
+			// dates share a bare old slug (ComputeBackfill's collision
+			// suffixing dedupes on the full dir name INCLUDING the date
+			// prefix, so this is a legitimate, expected input — not
+			// corruption) but derive different new slugs. produced_plans
+			// stores only the bare slug, so there is no way to tell which
+			// session meant which plan: the old slug must be dropped from
+			// the rewrite map entirely rather than guessed.
+			name: "same old slug, different new slugs is ambiguous and excluded",
+			candidates: []BackfillPlan{
+				{OldDir: "/plans/2026-05-01-dup", OldSlug: "dup", NewSlug: "target-a", SlugChanged: true},
+				{OldDir: "/plans/2026-06-01-dup", OldSlug: "dup", NewSlug: "target-b", SlugChanged: true},
+				{OldDir: "/plans/2026-07-01-clean", OldSlug: "clean", NewSlug: "clean-target", SlugChanged: true},
+			},
+			wantRenamed:   map[string]string{"clean": "clean-target"},
+			wantAmbiguous: map[string][]string{"dup": {"target-a", "target-b"}},
+		},
+		{
+			// Three-way collision: the third candidate must still be folded
+			// into the same ambiguous entry, not treated as a fresh conflict.
+			name: "three candidates sharing an old slug all land in one ambiguous entry",
+			candidates: []BackfillPlan{
+				{OldDir: "/plans/2026-05-01-dup", OldSlug: "dup", NewSlug: "target-a", SlugChanged: true},
+				{OldDir: "/plans/2026-06-01-dup", OldSlug: "dup", NewSlug: "target-b", SlugChanged: true},
+				{OldDir: "/plans/2026-07-01-dup", OldSlug: "dup", NewSlug: "target-c", SlugChanged: true},
+			},
+			wantRenamed:   map[string]string{},
+			wantAmbiguous: map[string][]string{"dup": {"target-a", "target-b", "target-c"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotRenamed, gotAmbiguous := BackfillRenameMap(tt.candidates)
+
+			if len(gotRenamed) != len(tt.wantRenamed) {
+				t.Fatalf("renamed = %v, want %v", gotRenamed, tt.wantRenamed)
+			}
+			for k, v := range tt.wantRenamed {
+				if gotRenamed[k] != v {
+					t.Errorf("renamed[%q] = %q, want %q", k, gotRenamed[k], v)
+				}
+			}
+
+			if len(gotAmbiguous) != len(tt.wantAmbiguous) {
+				t.Fatalf("ambiguous = %v, want %v", gotAmbiguous, tt.wantAmbiguous)
+			}
+			for k, want := range tt.wantAmbiguous {
+				got := append([]string(nil), gotAmbiguous[k]...)
+				sort.Strings(got)
+				wantSorted := append([]string(nil), want...)
+				sort.Strings(wantSorted)
+				if len(got) != len(wantSorted) {
+					t.Errorf("ambiguous[%q] = %v, want %v", k, got, wantSorted)
+					continue
+				}
+				for i := range got {
+					if got[i] != wantSorted[i] {
+						t.Errorf("ambiguous[%q] = %v, want %v", k, got, wantSorted)
+						break
+					}
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

`ox plan backfill-titles` is about to be run over ~168 real plans in shared git ledgers. As merged in #722 it could **corrupt provenance and report success while doing it**. This fixes four ways that happens before anyone runs it for real.

Nothing here is user-visible on the happy path. The value is that a repair tool aimed at every plan the team has ever saved now fails honestly instead of quietly leaving the ledger wrong.

**Approach: derive the session-rewrite map from plans that actually got renamed (not from plans we intended to rename), refuse to guess when an old slug is ambiguous, fail the command when the commit never landed, and never mint a second identity for a plan whose history we merely failed to read.**

These were flagged by Greptile on #722 and landed after that PR was squash-merged, so they are a follow-up rather than a fix-up commit.

## The four defects

**1 · A failed plan still redirected its session's provenance.** The old-slug-to-new-slug map was built from every candidate *before* any mutation ran. When `ApplyBackfillMeta` failed, the loop logged and skipped — but the stale entry survived, so the session pass rewrote `produced_plans` to a slug **no directory was ever renamed to**. `reconcileProducedPlansAtStop` could then never resolve it.

**2 · Duplicate old slugs silently collapsed.** The map was keyed on slug alone, but plan directories are `YYYY-MM-DD-<slug>` — two plans on different dates can share a slug and derive different new ones. Last write won, and every session reference to that slug was redirected to a single plan.

`produced_plans` stores only slugs, so an ambiguous one is **genuinely unresolvable** — there is no correct rewrite. It is now excluded from the map entirely and reported: a `slog.Warn` per slug with its competing targets, plus an "Ambiguous old slugs" table in both dry-run and real output. An honest *"these N need manual attention"* beats a confident wrong answer.

**3 · A partial backfill exited 0 claiming success.** A `commitPlanBackfillToLedger` failure was a warning, and the hint read *"the local commit stands."* That is only true when the **push** failed. If `git mv`, `git add`, or `git commit` failed, there is no commit — `meta.json`, `plan.html`, and `events.jsonl` were already mutated on disk and the tree was half-renamed, yet the command printed `Backfilled: …` and returned success.

The two cases are now distinguished by a sentinel (`errBackfillCommitFailed`, matched with `errors.Is` — not string matching). Push-only failure keeps the deliberate best-effort contract it shares with `commitPlanToLedger`. Anything at or before the commit returns non-nil, so the summary line is now structurally unreachable on that path.

**4 · An unreadable event log forked plan identity.** On a `LoadEvents` error, `appendBackfillRevisedEvent` treated the history as absent, minted a fresh `pln_` id, and appended a `created` event — leaving two identities in one log with `plan.html` stamped for the new one.

This mirrored `Save()`, and that is exactly why it was wrong: `Save` is *creating*, this is *repairing*. A read error now returns and the plan is skipped. Minting happens only for a genuinely **empty** log — the legacy pre-event-log case the comment always claimed.

## What changed

| File | Change |
|---|---|
| `internal/plan/backfill.go` | New pure `BackfillRenameMap` (returns the map **and** the ambiguous slugs); `appendBackfillRevisedEvent` propagates read errors. |
| `cmd/ox/plan_backfill.go` | Applies first, then derives the map from an `applied` slice; `errors.Is` routing; ambiguity reporting; table split into candidate + session-rewrite. |
| `cmd/ox/plan_commit.go` | `errBackfillCommitFailed` sentinel wrapped into every pre-commit git failure; the push is deliberately left unwrapped. |
| `internal/plan/backfill_test.go`, `cmd/ox/plan_backfill_test.go`, `cmd/ox/plan_commit_test.go` | Coverage below. |

Dry-run still projects the rewrite map from all candidates — correct, because nothing is written and it is explicitly a preview. The real run derives it from outcomes. That divergence is load-bearing and documented at the call site.

## Test Plan

- [x] `go build ./...`, `go vet ./cmd/ox/ ./internal/plan/`, `gofmt -l` — clean
- [x] `go test ./internal/plan/...` — pass
- [x] `go test ./cmd/ox/ -run 'Plan|Backfill|Slugify|Title'` — pass
- [x] `TestBackfillRenameMap` — 6 cases: failed applies excluded, ambiguous slug dropped and reported, same target from two candidates is **not** a conflict
- [x] `TestAppendBackfillRevisedEvent_UnreadableEventsNeverMintsNewID` + `_EmptyEventsStillMints` — the positive/negative pair for defect 4
- [x] `TestCommitPlanBackfillToLedger_PreCommitGitFailureIsErrBackfillCommitFailed` + `_PushOnlyFailureIsNotErrBackfillCommitFailed`
- [x] End-to-end: `..._FailedApplyExcludesSlugFromSessionRewrite` (two plans, one with a corrupted `events.jsonl`) and `..._PreCommitFailureFailsCommandAndSkipsSummary` (holds `.git/index.lock` to force git failure) — the latter reproduces the original bug exactly: `Backfilled: …` with exit 0 and nothing landed
- [x] **Red-checked** — each fix disabled individually, confirmed its tests fail, restored. I re-ran the defect-4 red-check independently of the authoring agent.
- [ ] N/A: still not run against a real ledger. Dry-run review first.

<details><summary>Why this is a follow-up PR</summary>

#722 was squash-merged while these findings were being worked, so its commits are not ancestors of `main`. This branch is `main` plus one commit rather than a continuation of that branch.

</details>
