### PR TITLE
docs(adr): ADR-028 — KBs are curated syntheses, not workspaces (supersedes ADR-017)

### DIFF
--- a/docs/adr/ADR-017-kb-as-workspace-primitive.md
+++ b/docs/adr/ADR-017-kb-as-workspace-primitive.md
@@ -7,7 +7,7 @@
 > team context and ledgers are permanent conversation stores, and a KB is a
 > Curator-maintained, read-only synthesis of distilled conversations (ADR-097).
 > The "current KB" workspace binding, KB-targeted session recording, and the
-> `.sageox/config.yaml` `kb_id` marker defined below were removed under epic
+> `.sageox/config.yaml` `kb_id` marker defined below will be removed under epic
 > `ox-6hvs`. This file is retained unmodified below for historical context.
 
 **Status**: ~~Proposed~~ Superseded by [ADR-028](ADR-028-kb-as-curated-synthesis.md)

--- a/docs/adr/ADR-017-kb-as-workspace-primitive.md
+++ b/docs/adr/ADR-017-kb-as-workspace-primitive.md
@@ -1,6 +1,16 @@
 # ADR-017: Knowledge Bubble (KB) as the Unifying Workspace Primitive
 
-**Status**: Proposed
+> ⚠️ **SUPERSEDED in full by [ADR-028: Knowledge Bubbles Are Curated Syntheses,
+> Not Workspaces](ADR-028-kb-as-curated-synthesis.md)** (2026-07-28). The
+> premise this ADR builds on — sageox-mono ADR-030/035's "team contexts and
+> ledgers migrate into KBs" — was reversed by sageox-mono ADR-073 (2026-06-26):
+> team context and ledgers are permanent conversation stores, and a KB is a
+> Curator-maintained, read-only synthesis of distilled conversations (ADR-097).
+> The "current KB" workspace binding, KB-targeted session recording, and the
+> `.sageox/config.yaml` `kb_id` marker defined below were removed under epic
+> `ox-6hvs`. This file is retained unmodified below for historical context.
+
+**Status**: ~~Proposed~~ Superseded by [ADR-028](ADR-028-kb-as-curated-synthesis.md)
 **Date**: 2026-05-18
 
 ## Context

--- a/docs/adr/ADR-028-kb-as-curated-synthesis.md
+++ b/docs/adr/ADR-028-kb-as-curated-synthesis.md
@@ -26,7 +26,7 @@ The platform reversed that premise, and ox was never updated:
 - **ADR-086** gives every user a private per-user team, so "personal" knowledge
   also lives under team machinery; personal bubbles re-scope onto that team.
 - **ADR-097** defines what KBs are *for*: each bubble is owned by a **Curator**
-  agent that folds each newly routed **distillation** (the structured summary a
+  AI coworker that folds each newly routed **distillation** (the structured summary a
   finalized conversation produces, per ADR-057/066) into the bubble's
   current-state knowledge. Humans steer the Curator and read its synopses; they
   never hand-edit synthesized knowledge. Consumers read bubbles two ways —
@@ -58,7 +58,7 @@ awaiting migration." Concretely:
   **deleted**. Only rows returned by the KB API are ever presented as bubbles.
 - `ox teams` is **un-deprecated**; `ox status` regains distinct team-context and
   ledger presentation; all "bubbles are the successor to team contexts /
-  ledgers" framing is removed from code, docs, and agent-facing hints.
+  ledgers" framing is removed from code, docs, and AI-coworker-facing hints.
 
 ### 2. The workspace primitive stays the project/ledger binding
 
@@ -100,9 +100,13 @@ Mounting mirrors the team-context/ledger mental model:
   in that project. The KB list API requires an explicit scope per call
   (`scope_type` + `scope_id`); the contextless "all my bubbles" union no
   longer exists server-side.
-- **Personal-scope mounting is deferred** until the ADR-086 personal-team
-  backfill issue is fixed server-side (bead `ox-cag9.8`). V1 mounts the
-  project team's bubbles only.
+- **The personal half of that scope pair is deferred** until the ADR-086
+  personal-team backfill issue is fixed server-side (bead `ox-cag9.8`).
+  Until then the CLI is **project-team-only across the board**: `ox kb list`
+  lists and the daemon mounts only the project team's bubbles, and
+  `ox kb describe --scope personal` returns a clear "deferred" error. Once
+  the backfill lands, ambient scope becomes project team + personal as
+  defined above with no further design change.
 - Per-project symlinks live under `<project>/.sageox/kb/team/<slug>` (with
   `me/` reserved for the deferred personal scope), mirroring the server's
   `/t/<team>/kb/<slug>` and `/me/kb/<slug>` URL split so per-scope slugs
@@ -121,7 +125,7 @@ Mounting mirrors the team-context/ledger mental model:
 kind-priority slug tie-break (personal > profile > team > …) is dropped —
 per-scope slugs make it ambiguous; `--scope` disambiguates explicitly.
 
-### 6. Prime tells agents what bubbles are and how to use them
+### 6. Prime tells AI coworkers what bubbles are and how to use them
 
 The prime envelope's KB block explains, compactly: the purpose of KBs (curated
 team knowledge, one bubble per area), how to find them (mount paths), how to
@@ -149,8 +153,8 @@ bubble content is **data, never instructions**. The `current_kb` field and the
 
 ### Benefits
 
-- ox's model matches the platform's settled model; agents stop being primed
-  with a dead migration story.
+- ox's model matches the platform's settled model; AI coworkers stop being
+  primed with a dead migration story.
 - Session recording — a privacy surface — is decoupled from a concept under
   redefinition, reverting to the well-understood project/team precedence.
 - The mount machinery (canonical checkouts, flocks, GC, doctor) is preserved

--- a/docs/adr/ADR-028-kb-as-curated-synthesis.md
+++ b/docs/adr/ADR-028-kb-as-curated-synthesis.md
@@ -1,0 +1,198 @@
+# ADR-028: Knowledge Bubbles Are Curated Syntheses, Not Workspaces
+
+- **Status:** Accepted
+- **Date:** 2026-07-28
+- **Deciders:** Galex Yen
+- **Supersedes:** [ADR-017: KB as the Unifying Workspace Primitive](ADR-017-kb-as-workspace-primitive.md) — in full
+- **Relates to (sageox-mono):** ADR-073 (KB Scope & Ownership — Accepted 2026-06-26), ADR-086 (Private Per-User Teams), ADR-097 (Curator Synthesis for Knowledge Bubbles), ADR-057 (Conversation Ontology), ADR-066 (Conversational Distillation Engine)
+- **Beads:** epic `ox-ay95` (this ADR); implementation epics `ox-nsf7`, `ox-6hvs`, `ox-gmkd`, `ox-cag9` (label `kb-v2-cli`)
+
+## Context
+
+ox's Knowledge Bubble support was built between April and June 2026 against the
+platform worldview of that era: sageox-mono ADR-028/030/035 declared that every
+team context and every ledger would migrate into a KB, and ox ADR-017 extended
+that locally — "what we called 'the ledger' was always a KB" — making the KB the
+workspace primitive that session recording, murmurs, and prime resolve against.
+
+The platform reversed that premise, and ox was never updated:
+
+- **ADR-073** (Accepted 2026-06-26) settled that **team context is a permanent
+  conversation store** — it stores the conversations a team has (recordings,
+  discussions, coding sessions), not their distilled knowledge. The
+  team-context→KB migration (ADR-030/035) is dead. KBs gained polymorphic scope:
+  every bubble is owned by exactly one user or one team, immutable after
+  creation, with access via materialized `kb_members` rows.
+- **ADR-086** gives every user a private per-user team, so "personal" knowledge
+  also lives under team machinery; personal bubbles re-scope onto that team.
+- **ADR-097** defines what KBs are *for*: each bubble is owned by a **Curator**
+  agent that folds each newly routed **distillation** (the structured summary a
+  finalized conversation produces, per ADR-057/066) into the bubble's
+  current-state knowledge. Humans steer the Curator and read its synopses; they
+  never hand-edit synthesized knowledge. Consumers read bubbles two ways —
+  **query** (`ox kb query`, one verb, server-owned intent; not yet implemented
+  server-side) and **mount** (the bubble as a navigable filesystem).
+
+The definitional sentence this ADR adopts:
+
+> A Knowledge Bubble is a team-scoped, Curator-maintained, provenance-carrying
+> **synthesis** of the team's distilled conversations for one area of work
+> (#engineering, #marketing, …), consumed read-only via query and mount. It is
+> not a workspace, not a conversation store, and not a migration target for
+> team context or ledgers.
+
+Everything in ox that contradicts that sentence is wrong and comes out. The
+full inventory of what was built and where it diverges was researched on
+2026-07-27 (kb-v2-cli research report + design interview); the decision log
+below records the rulings from that interview.
+
+## Decision
+
+### 1. Team context and ledgers are restored as first-class, permanent stores
+
+They are conversation stores — the inputs to distillation — not "legacy KBs
+awaiting migration." Concretely:
+
+- The three-source merger (`internal/kb/merge.go`), which synthesizes team
+  contexts as `team`-type bubbles and ledgers as `repo`-type bubbles, is
+  **deleted**. Only rows returned by the KB API are ever presented as bubbles.
+- `ox teams` is **un-deprecated**; `ox status` regains distinct team-context and
+  ledger presentation; all "bubbles are the successor to team contexts /
+  ledgers" framing is removed from code, docs, and agent-facing hints.
+
+### 2. The workspace primitive stays the project/ledger binding
+
+ADR-017's "current KB" concept — the `.sageox/config.yaml` `kb_id` binding,
+`kb.ResolveCurrentKB`, prime's `current_kb` — is **removed**. "Which KB am I
+in?" stops being a question: a KB is something you consult, not something you
+work inside.
+
+- **Session recording never targets KBs.** Recording precedence reverts to
+  `env > project config > team config`. The KB-config branch of
+  `ResolveSessionRecording` (and the vendored `internal/api/kbconfig` schema
+  that exists to serve it) is deleted.
+- The `kb-project-config-migrate` doctor check is deleted. It waited for a
+  server-provisioned `kb_type=repo` bubble per repo — provisioning that will
+  never happen under ADR-073 — and mislabeled every repo an "orphan repo."
+
+### 3. KBs are read-only to the CLI
+
+The CLI is a consumer. No ox command writes into a bubble's content:
+
+- `ox import --kb` is **removed**. It uploaded raw recordings — exactly the
+  conversation content KBs exclude — via `POST /kb/{id}/recordings`.
+  Recordings import into team context (`--team`), a conversation store.
+- `ox kb config` is **removed** (its flagship key answered "does this KB record
+  sessions?", a dead question). A future settings/steering viewer will be
+  designed against the server's actual config + steering contract (ADR-097 C9).
+
+### 4. Consumption model: auto-mount, scoped to the working directory
+
+Mounting mirrors the team-context/ledger mental model:
+
+- The daemon **auto-mounts every accessible bubble** for the ambient scopes
+  into the canonical XDG path (`paths.KBDir(kb_id)`), pull-only, at a uniform
+  60s cadence. The existing machinery — per-`kb_id` flocks, sparse + blob-less
+  clones, GC with trash grace, doctor repo-health checks — is retained and
+  re-pointed.
+- **Ambient scope is defined by the `ox init`-ed project**: the project's team
+  scope plus the caller's personal scope. Other teams' bubbles are invisible
+  in that project. The KB list API requires an explicit scope per call
+  (`scope_type` + `scope_id`); the contextless "all my bubbles" union no
+  longer exists server-side.
+- **Personal-scope mounting is deferred** until the ADR-086 personal-team
+  backfill issue is fixed server-side (bead `ox-cag9.8`). V1 mounts the
+  project team's bubbles only.
+- Per-project symlinks live under `<project>/.sageox/kb/team/<slug>` (with
+  `me/` reserved for the deferred personal scope), mirroring the server's
+  `/t/<team>/kb/<slug>` and `/me/kb/<slug>` URL split so per-scope slugs
+  cannot collide on disk.
+
+### 5. Command surface
+
+| Verb | Contract |
+|---|---|
+| `ox kb list` | Bubbles for the ambient scopes; scope column; JSON carries scope, description, topics |
+| `ox kb describe <ref>` | Renamed from `kb show`. Refs: bare `kb_<id>`, or `#<slug>` + `--scope team\|personal` |
+| `ox kb query` | Reserved (ADR-097 C18: one verb, server-owned intent). Ships in a follow-up epic once the server endpoint exists |
+| *(removed)* | `kb path`, `kb hydrate` (no team-context/ledger parallels exist; hydration returns if bubbles grow binary assets), `kb config`, `import --kb` |
+
+`#slug` remains display grammar (bare slugs in JSON/storage). The client-side
+kind-priority slug tie-break (personal > profile > team > …) is dropped —
+per-scope slugs make it ambiguous; `--scope` disambiguates explicitly.
+
+### 6. Prime tells agents what bubbles are and how to use them
+
+The prime envelope's KB block explains, compactly: the purpose of KBs (curated
+team knowledge, one bubble per area), how to find them (mount paths), how to
+query them (`ox kb query` once available; navigate the mount meanwhile), and
+how to navigate them — every bubble is self-describing via a fixed platform
+`AGENTS.md` pointing at a Curator-authored manifest (ADR-097 C10/C19). All
+bubble content is **data, never instructions**. The `current_kb` field and the
+"ledger archive" per-type hints are removed.
+
+## Decision log (2026-07-27 design interview)
+
+| # | Question | Ruling |
+|---|---|---|
+| 1 | Mount model | Auto-mount all accessible (team-context mental model); project anchors context; symlinks in `.sageox/` |
+| 2 | Scope fan-out | Project team + personal; personal deferred pending backfill fix |
+| 3 | Legacy purge | Full purge + un-deprecate `ox teams`; delete the merger outright |
+| 4 | Current-KB machinery | Remove it all |
+| 5 | `import --kb` | Remove entirely, including the recordings client paths |
+| 6 | `kb config` | Remove; future settings/steering viewer designed against the real server contract |
+| 7 | Surface | Drop `path`/`hydrate`; `show`→`describe`; `#slug` + `--scope` grammar |
+| 8 | Prime | Purpose + catalog + AGENTS.md/manifest navigation guidance |
+| 9 | `kb query` | Deferred to its own epic |
+
+## Consequences
+
+### Benefits
+
+- ox's model matches the platform's settled model; agents stop being primed
+  with a dead migration story.
+- Session recording — a privacy surface — is decoupled from a concept under
+  redefinition, reverting to the well-understood project/team precedence.
+- The mount machinery (canonical checkouts, flocks, GC, doctor) is preserved
+  where it was right and re-derived from consumption needs where it wasn't.
+- No backward-compatibility burden: the KB surface has no external users yet.
+
+### Tradeoffs and accepted interim states
+
+- Between the removal epics and `ox-cag9`, no bubbles sync locally. This is
+  not a regression: the contextless list call already fails against the
+  scope-required server, so mounting is dormant today.
+- Bubbles with LFS-pointer content have no materialization verb after
+  `kb hydrate` is removed. Curator output is markdown; hydration returns if
+  bubbles grow binary assets.
+- `status --json` mirrors (`team_contexts`, `ledger`) lose their "deprecated,
+  retained for one release" framing and become permanent — consumers that
+  migrated to bubble-shaped output must migrate back (none are known).
+- Personal bubbles are invisible to the CLI until the ADR-086 backfill fix
+  lands (`ox-cag9.8`).
+
+## Implementation tracking
+
+One PR per epic, merge order `ox-ay95 → ox-nsf7 → ox-6hvs`, `ox-ay95 →
+ox-gmkd`, `{ox-6hvs, ox-gmkd} → ox-cag9`:
+
+| Epic | PR |
+|---|---|
+| `ox-ay95` | This ADR + spec reframing (docs-only) |
+| `ox-nsf7` | Remove `kb path`/`kb hydrate`/`kb config`/`import --kb` |
+| `ox-6hvs` | Detach session recording; delete the current-KB binding |
+| `ox-gmkd` | Delete the merger; restore team context & ledgers as first-class |
+| `ox-cag9` | Scoped client, `list`/`describe`, daemon mounting, prime guidance |
+
+## References
+
+- sageox-mono `docs/adr/073-knowledge-bubble-scope-and-ownership.md` — scope,
+  ownership, materialized membership; supersedes the migration ADRs
+- sageox-mono `docs/adr/097-curator-synthesis-for-knowledge-bubbles.md` — the
+  Curator, self-description (C10), query (C18), mount (C19)
+- sageox-mono `docs/adr/086-private-per-user-teams.md` — personal teams; no
+  `#team` bubble for them; personal-KB re-scope
+- [ADR-017](ADR-017-kb-as-workspace-primitive.md) — the superseded worldview,
+  kept in place with a supersession banner
+- `docs/specs/kb-daemon-sync.md` — daemon mount mechanics (reframed by this ADR)
+- `docs/specs/kb-import-parity.md` — superseded alongside `import --kb`

--- a/docs/specs/kb-daemon-sync.md
+++ b/docs/specs/kb-daemon-sync.md
@@ -116,7 +116,7 @@ failure modes. The kb checks (`cmd/ox/doctor_kb.go`,
 | `kb-stale-sync` | (kb-specific) | `meta.json` `last_sync` > 1h | kick daemon sync |
 | `kb-failed-provision` | (kb-specific) | server `lifecycle_state=provision-failed` | requires-agent (server side) |
 | `kb-global-sync-no-owner` | (kb-specific, ox-6zme) | an endpoint with daemons but no lease holder | check-only |
-| `kb-project-config-migrate` | (kb-specific, ADR-017) | legacy `config.json` → `config.yaml` | auto — **slated for removal under ox ADR-028 / epic `ox-6hvs`** (waits on repo→KB provisioning that never happens) |
+| `kb-project-config-migrate` | (kb-specific, ADR-017) | legacy `config.json` → `config.yaml` | **DEPRECATED, non-operative** (ox ADR-028): its repo→KB provisioning premise no longer holds, so it cannot complete and misreports repos as "orphans." Do not rely on it; still present in the binary until epic `ox-6hvs` deletes it |
 
 **Design rule — repairs go through the daemon, not the CLI.** The daemon owns kb
 git writes and serializes them with the per-kb flock. A kb doctor repair therefore

--- a/docs/specs/kb-daemon-sync.md
+++ b/docs/specs/kb-daemon-sync.md
@@ -9,9 +9,9 @@ distilled conversations for one area of work (ox ADR-028; sageox-mono
 ADR-073/097). Bubbles do **not** replace ledgers or team contexts — those are
 permanent conversation stores and sync via their own pipelines. What bubbles
 *share* with them is the transport shape: a single git repo cloned into a
-canonical XDG path and kept fresh by the daemon, mounted so agents can navigate
-the published knowledge locally. This doc records how the CLI side handles that
-sync so the model isn't re-derived every time someone touches it.
+canonical XDG path and kept fresh by the daemon, mounted so AI coworkers can
+navigate the published knowledge locally. This doc records how the CLI side
+handles that sync so the model isn't re-derived every time someone touches it.
 
 > **Note (2026-07-28):** the mechanics below predate ox ADR-028 / epic
 > `ox-cag9` (scoped list API, project-team ambient scope, `team/`-prefixed
@@ -116,7 +116,7 @@ failure modes. The kb checks (`cmd/ox/doctor_kb.go`,
 | `kb-stale-sync` | (kb-specific) | `meta.json` `last_sync` > 1h | kick daemon sync |
 | `kb-failed-provision` | (kb-specific) | server `lifecycle_state=provision-failed` | requires-agent (server side) |
 | `kb-global-sync-no-owner` | (kb-specific, ox-6zme) | an endpoint with daemons but no lease holder | check-only |
-| `kb-project-config-migrate` | (kb-specific, ADR-017) | legacy `config.json` → `config.yaml` | auto — **removed under ox ADR-028 / epic `ox-6hvs`** (waited on repo→KB provisioning that never happens) |
+| `kb-project-config-migrate` | (kb-specific, ADR-017) | legacy `config.json` → `config.yaml` | auto — **slated for removal under ox ADR-028 / epic `ox-6hvs`** (waits on repo→KB provisioning that never happens) |
 
 **Design rule — repairs go through the daemon, not the CLI.** The daemon owns kb
 git writes and serializes them with the per-kb flock. A kb doctor repair therefore
@@ -128,9 +128,11 @@ in `doctor_kb_repo_health.go`.
 **Intentionally deferred (not yet ported from ledger/team):**
 
 - **Secret scanning** (`ledger-secrets`). Ledger scans its `sessions/` tree for
-  credential patterns. Bubbles have no `sessions/` — they hold imported data,
-  murmurs, and recordings. A kb scan would need a different target set and a
-  policy decision; deferred until kb import flows settle.
+  credential patterns. Bubbles have no `sessions/` — under ox ADR-028 they hold
+  Curator-published synthesis, not raw conversation content (sessions, murmurs,
+  recordings all live in conversation stores). Whether Curator output warrants
+  a scan of its own is a server-side question (the Curator publishes, not the
+  CLI); no kb-side check is planned.
 - **Dirty-workdir / cache-tracked auto-commit** (`ledger-clean-workdir`,
   `ledger-cache-tracked`). These auto-commit from the CLI. For a daemon-managed
   tree that's the wrong owner; if needed, the repair belongs in the daemon's
@@ -145,19 +147,26 @@ in `doctor_kb_repo_health.go`.
 
 Today the CLI is **repo-bound**: endpoint resolution and credentials flow from a
 project root, and the daemon's `syncBubbles` returns early when `ProjectRoot == ""`.
-Bubbles bind to the current repo via the cwd `.kb-marker` (`internal/kb/resolve.go`).
 
-Cloud Co-Work may run an AI coworker with **no git repo at all**. In the cloud
-model, bubbles are explicitly *not* tied to repos (ADR-028), so the repo-bound
-assumption doesn't carry over cleanly.
+> **Superseded contract (2026-07-28):** an earlier revision of this section
+> described bubbles binding to the current repo via a cwd marker
+> (`internal/kb/resolve.go`) and sketched resolving a "current bubble" from an
+> `OX_KB` env var or XDG-global marker. That current-KB binding model is
+> removed by [ox ADR-028](../adr/ADR-028-kb-as-curated-synthesis.md) — there
+> is no "current bubble"; the project's **ambient scope** (its team, plus the
+> caller's personal scope once `ox-cag9.8` lands) determines which bubbles are
+> listed and mounted. Do not implement the marker/env-var contract.
+
+Cloud Co-Work may run an AI coworker with **no git repo at all**. Bubbles are
+not tied to repos, so the repo-bound assumption doesn't carry over cleanly.
 
 **Decision (now): keep the CLI repo-bound.** Breaking the repo binding touches
 endpoint resolution, daemon lifecycle, and selection — too much blast radius for
-a case that doesn't exist in the product yet. When it does, the likely surface is
-a **global/no-repo binding**: resolve a "current bubble" from an env var (`OX_KB`)
-or an XDG-global marker when no git root is found, leaving the repo path unchanged.
-Captured here so the tradeoff isn't re-litigated; no implementation until
-Cloud Co-Work needs it.
+a case that doesn't exist in the product yet. When it does, the likely surface
+is **no-repo scope resolution**: derive the ambient scopes (a chosen team, the
+caller's personal scope) from an explicit flag or environment instead of a
+project root, leaving the repo path unchanged. Captured here so the tradeoff
+isn't re-litigated; no implementation until Cloud Co-Work needs it.
 
 ---
 

--- a/docs/specs/kb-daemon-sync.md
+++ b/docs/specs/kb-daemon-sync.md
@@ -4,11 +4,20 @@
 > step on each other, what `ox daemon status` / `ox doctor` report, and the one
 > deliberately-deferred question (agents without a git repo).
 
-Knowledge bubbles are the kb-era successor to **ledgers** and **team contexts**
-(ADR-028/030 in `sageox-mono`). A bubble is a single git repo cloned into a
-canonical XDG path and kept fresh by the daemon — the same shape ledgers and
-team contexts already had. This doc records how the CLI side handles them so the
-model isn't re-derived every time someone touches kb sync.
+A knowledge bubble is a Curator-maintained, read-only synthesis of a team's
+distilled conversations for one area of work (ox ADR-028; sageox-mono
+ADR-073/097). Bubbles do **not** replace ledgers or team contexts — those are
+permanent conversation stores and sync via their own pipelines. What bubbles
+*share* with them is the transport shape: a single git repo cloned into a
+canonical XDG path and kept fresh by the daemon, mounted so agents can navigate
+the published knowledge locally. This doc records how the CLI side handles that
+sync so the model isn't re-derived every time someone touches it.
+
+> **Note (2026-07-28):** the mechanics below predate ox ADR-028 / epic
+> `ox-cag9` (scoped list API, project-team ambient scope, `team/`-prefixed
+> project symlinks, uniform 60s cadence). Locking, GC, sparse-checkout, and
+> doctor-parity sections remain accurate; per-type sync policy and symlink
+> layout are being revised under that epic.
 
 ---
 
@@ -107,7 +116,7 @@ failure modes. The kb checks (`cmd/ox/doctor_kb.go`,
 | `kb-stale-sync` | (kb-specific) | `meta.json` `last_sync` > 1h | kick daemon sync |
 | `kb-failed-provision` | (kb-specific) | server `lifecycle_state=provision-failed` | requires-agent (server side) |
 | `kb-global-sync-no-owner` | (kb-specific, ox-6zme) | an endpoint with daemons but no lease holder | check-only |
-| `kb-project-config-migrate` | (kb-specific, ADR-017) | legacy `config.json` → `config.yaml` | auto |
+| `kb-project-config-migrate` | (kb-specific, ADR-017) | legacy `config.json` → `config.yaml` | auto — **removed under ox ADR-028 / epic `ox-6hvs`** (waited on repo→KB provisioning that never happens) |
 
 **Design rule — repairs go through the daemon, not the CLI.** The daemon owns kb
 git writes and serializes them with the per-kb flock. A kb doctor repair therefore

--- a/docs/specs/kb-import-parity.md
+++ b/docs/specs/kb-import-parity.md
@@ -1,6 +1,15 @@
 # KB import parity — `ox import --kb`
 
-**Status:** implemented (CLI side; backend bulk-import endpoint lands in parallel in sageox-mono)
+> ⚠️ **SUPERSEDED by [ox ADR-028](../adr/ADR-028-kb-as-curated-synthesis.md)**
+> (2026-07-28). Knowledge bubbles are read-only syntheses of distilled
+> conversations — raw recordings are conversation content and belong in team
+> context (a conversation store), never in a bubble. `ox import --kb` and the
+> `/kb/{id}/recordings` client paths are removed under epic `ox-nsf7`. Retained
+> below for historical context on the import mechanisms and their storage
+> asymmetry; the `--team` document-LFS path described here is unaffected and
+> remains current.
+
+**Status:** ~~implemented~~ superseded — CLI surface removed (epic `ox-nsf7`)
 **Audience:** SageOx engineers working on `ox import`, the recordings API client, or Knowledge Bubble ingestion
 
 `ox import` historically targeted team contexts only. This design brings Knowledge Bubbles to

--- a/docs/specs/kb-import-parity.md
+++ b/docs/specs/kb-import-parity.md
@@ -4,12 +4,12 @@
 > (2026-07-28). Knowledge bubbles are read-only syntheses of distilled
 > conversations — raw recordings are conversation content and belong in team
 > context (a conversation store), never in a bubble. `ox import --kb` and the
-> `/kb/{id}/recordings` client paths are removed under epic `ox-nsf7`. Retained
-> below for historical context on the import mechanisms and their storage
-> asymmetry; the `--team` document-LFS path described here is unaffected and
-> remains current.
+> `/kb/{id}/recordings` client paths will be removed under epic `ox-nsf7`.
+> Retained below for historical context on the import mechanisms and their
+> storage asymmetry; the `--team` document-LFS path described here is
+> unaffected and remains current.
 
-**Status:** ~~implemented~~ superseded — CLI surface removed (epic `ox-nsf7`)
+**Status:** ~~implemented~~ superseded — CLI surface slated for removal (epic `ox-nsf7`)
 **Audience:** SageOx engineers working on `ox import`, the recordings API client, or Knowledge Bubble ingestion
 
 `ox import` historically targeted team contexts only. This design brings Knowledge Bubbles to


### PR DESCRIPTION
## Why

ox's Knowledge Bubble support was built (Apr–Jun 2026) on a platform premise that has since been reversed: sageox-mono ADR-030/035 said team contexts and ledgers would migrate into KBs, and ox ADR-017 made the KB the workspace primitive that session recording and prime resolve against. sageox-mono **ADR-073** (Accepted 2026-06-26) killed the migration — team context and ledgers are **permanent conversation stores** — and **ADR-097** redefined KBs as Curator-maintained, read-only **syntheses** of distilled conversations, consumed via query and mount. ox was never updated.

This is the docs-only foundation PR for the `kb-v2-cli` epic series: it puts the reversal on paper before any code changes, so every later PR cites it.

## What this PR ships

- **`docs/adr/ADR-028-kb-as-curated-synthesis.md`** (new) — the reversal ADR:
  - **Definitional:** a KB is a team-scoped, Curator-maintained, provenance-carrying synthesis of the team's distilled conversations for one area of work — not a workspace, not a conversation store, not a migration target.
  - **Decisions:** team context/ledgers restored as first-class (merger + legacy synthesis deleted, `ox teams` un-deprecated); the ADR-017 "current KB" binding removed and session recording reverted to `env > project > team`; CLI is read-only toward bubbles (`import --kb` and `kb config` removed); auto-mount with project-team ambient scope (personal deferred pending the ADR-086 backfill fix); surface = `kb list` + `kb describe` with `#slug`/`--scope` grammar; prime gains a purpose/navigation guidance block.
  - Full decision log from the 2026-07-27 design interview, accepted interim states, and the 5-epic implementation tracker.
- **`docs/adr/ADR-017-kb-as-workspace-primitive.md`** — in-place supersession banner; body retained for history.
- **`docs/specs/kb-daemon-sync.md`** — opening reframed (bubbles do **not** replace ledgers/team contexts); scoping note for what `ox-cag9` revises; migrate-check row marked removed.
- **`docs/specs/kb-import-parity.md`** — superseded banner (recordings are conversation content and never belong in a bubble; the `--team` path is unaffected).

## The model shift

```mermaid
flowchart LR
  subgraph STORES["Conversation stores (permanent)"]
    TC["Team context"]
    LG["Ledgers"]
  end
  TC --> FIN["Conversation finalized"]
  LG --> FIN
  FIN --> DIST["Distillation (mono ADR-066)"]
  DIST --> CUR["Curator run (mono ADR-097)"]
  CUR --> KB["Knowledge Bubble (published synthesis)"]
  KB --> Q["ox kb query (later)"]
  KB --> M["mount (ox kb list / describe)"]
```

## Epic tracker (one PR per epic)

| Epic | PR | Depends on |
|---|---|---|
| `ox-ay95` | **this PR** | — |
| `ox-nsf7` | remove `kb path`/`kb hydrate`/`kb config`/`import --kb` | ay95 |
| `ox-6hvs` | detach session recording; delete current-KB binding | nsf7 |
| `ox-gmkd` | delete merger; restore team context & ledgers | ay95 |
| `ox-cag9` | scoped client, `list`/`describe`, daemon mounting, prime | 6hvs, gmkd |

## Test Plan

- Docs-only; no code paths touched. Cross-links verified (`ADR-017 ↔ ADR-028`, spec → ADR relative paths).
- Terminology sweep: CLAUDE.md and `.claude/rules/` clean; the one remaining stale claim (generated `docs/reference/kb/index.mdx` from `kbCmd.Long`) is deliberately deferred to `ox-gmkd.4` per the "fix cobra strings, not generated .mdx" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvdj8XSiiwRDsKw4CzooQM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Knowledge Bubbles are curated, read-only syntheses, not workspace or conversation stores.
  * Updated the Knowledge Bubble consumption model: read-only query/mount behavior and revised per-project layout.
  * Removed or marked superseded legacy concepts (workspace binding, current KB/binding mechanics) and deprecated related CLI commands (including prior import/config flows).
  * Refined related KB daemon sync and doctor-check guidance, including clarified parity/repair expectations and updated “no current bubble” semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->