### PR TITLE
fix(session): one permanent session id per recording

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1327,7 +1327,7 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	// constructed so sessionMetaBase always receives the final ID.
 	preservedID, err := lfs.PreservedSessionID(sessionDir)
 	if err != nil {
-		return err
+		return fmt.Errorf("preserve existing SessionID for %s: %w", sessionName, err)
 	}
 	sessionID := session.ResolveOrMintSessionID(preservedID, state.SessionID)
 

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1319,10 +1319,22 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	sessionDir := filepath.Join(sessionsDir, sessionName)
 
+	// durable ID precedence via the shared resolver: a preserved meta.json
+	// ID (prior stop attempt, e.g. LFS upload failed and we're retrying)
+	// beats the start-minted state ID; only mints fresh when neither exists
+	// (recordings started under an older binary). Non-NotExist read errors
+	// are fatal — see PreservedSessionID doc. Resolved before the builder is
+	// constructed so sessionMetaBase always receives the final ID.
+	preservedID, err := lfs.PreservedSessionID(sessionDir)
+	if err != nil {
+		return err
+	}
+	sessionID := session.ResolveOrMintSessionID(preservedID, state.SessionID)
+
 	// write meta.json first (before LFS upload) to preserve session metadata even if LFS fails
 	projectEndpoint := endpoint.GetForProject(projectRoot)
 	displayName := identity.AttributionDisplayName(projectEndpoint, config.GetDisplayName())
-	metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
+	metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot, sessionID).
 		Model(result.Model).
 		Title(state.Title).
 		EntryCount(result.EntryCount).
@@ -1345,19 +1357,6 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 		metaBuilder.SageoxScore(scoreFile.Score, string(scoreFile.Category), scoreFile.Reason)
 	}
 	_ = session.CleanupSageoxScore(state.AgentID)
-
-	// durable ID precedence via the shared resolver: a preserved meta.json
-	// ID (prior stop attempt, e.g. LFS upload failed and we're retrying)
-	// beats the start-minted state ID; empty → the builder's fresh mint
-	// stands (recordings started under an older binary). Non-NotExist read
-	// errors are fatal — see PreservedSessionID doc.
-	preservedID, err := lfs.PreservedSessionID(sessionDir)
-	if err != nil {
-		return err
-	}
-	if resolved := session.ResolveSessionID(preservedID, state.SessionID); resolved != "" {
-		metaBuilder = metaBuilder.SessionID(resolved)
-	}
 
 	meta := metaBuilder.Build()
 	if err := lfs.WriteSessionMeta(sessionDir, meta); err != nil {

--- a/cmd/ox/agent_session_recover.go
+++ b/cmd/ox/agent_session_recover.go
@@ -216,24 +216,26 @@ func recoverFromCache(inst *agentinstance.Instance, projectRoot string, state *s
 					slog.Warn("read existing meta.json failed during recovery; skipping write to avoid SessionID rotation", "error", preserveErr)
 					_ = doctor.SetNeedsDoctorAgent(projectRoot)
 				} else {
+					// durable ID via the shared resolver: preserved meta.json ID
+					// wins; start-minted comes from state, falling back to the
+					// raw-header carrier (state may predate the SessionID field
+					// after a mid-recording binary upgrade). Only mints fresh
+					// when neither source has one. Resolved before the builder
+					// is constructed so sessionMetaBase always receives the
+					// final ID.
+					startMinted := state.SessionID
+					if startMinted == "" {
+						startMinted = session.ReadHeaderSessionID(rawPath)
+					}
+					sessionID := session.ResolveOrMintSessionID(preservedID, startMinted)
+
 					displayName := identity.AttributionDisplayName(endpoint.GetForProject(projectRoot), config.GetDisplayName())
-					metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot).
+					metaBuilder := sessionMetaBase(sessionName, displayName, state.AgentID, state.AdapterName, state.StartedAt, projectRoot, sessionID).
 						EntryCount(entryCount).
 						StopReason(session.StopReasonRecovered).
 						ProducedCommits(state.ProducedCommits).
 						ProducedPlans(state.ProducedPlans).
 						WithFiles(fileRefs)
-					// durable ID via the shared resolver: preserved meta.json ID
-					// wins; start-minted comes from state, falling back to the
-					// raw-header carrier (state may predate the SessionID field
-					// after a mid-recording binary upgrade)
-					startMinted := state.SessionID
-					if startMinted == "" {
-						startMinted = session.ReadHeaderSessionID(rawPath)
-					}
-					if resolved := session.ResolveSessionID(preservedID, startMinted); resolved != "" {
-						metaBuilder = metaBuilder.SessionID(resolved)
-					}
 					meta := metaBuilder.Build()
 					if err := lfs.WriteSessionMeta(ledgerSessionDir, meta); err != nil {
 						slog.Warn("write meta.json failed", "error", err)

--- a/cmd/ox/doctor_session.go
+++ b/cmd/ox/doctor_session.go
@@ -91,6 +91,12 @@ func checkSessionHealth(opts doctorOptions) []checkResult {
 		results = append(results, incompleteResult)
 	}
 
+	// identity integrity: meta.json session_id vs raw.jsonl header
+	// session_id. Detect-only (see checkSessionIDDivergence doc comment
+	// for why); always shown rather than filtered on a boring-pass
+	// message, since a genuine divergence is meant to be rare and loud.
+	results = append(results, checkSessionIDDivergence())
+
 	// linkage soft signals: trailer coverage on recent commits, reachability
 	// of closed-session ProducedCommits SHAs, and PR-body attribution
 	// coverage. None block; all are diagnostic.

--- a/cmd/ox/doctor_session_id_divergence.go
+++ b/cmd/ox/doctor_session_id_divergence.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/sessionid"
 )
 
 // doctor_session_id_divergence.go detects a session whose durable identity
@@ -265,11 +266,32 @@ func readHeaderSessionIDStrict(rawPath string) (string, error) {
 	// precisely the corruption-swallowed-as-fine outcome this check exists
 	// to prevent, so a shape the reader would reject must surface as
 	// unreadable here.
-	_, metadataIsObj := entry["metadata"].(map[string]any)
+	metadataObj, metadataIsObj := entry["metadata"].(map[string]any)
 	_, metaIsObj := entry["_meta"].(map[string]any)
 	isNativeHeader := metadataIsObj && entry["type"] == "header"
 	if !isNativeHeader && !metaIsObj {
 		return "", fmt.Errorf("first line is not a recognizable session header")
+	}
+
+	// A native ox header carries session_id as the ses_ recording identity,
+	// alongside a separate agent_id. ParseStoreMeta only admits ses_-prefixed
+	// values into StoreMeta.SessionID, so a present-but-malformed one reads
+	// back as "" — indistinguishable from a legacy header that never had the
+	// field, and therefore skipped silently. Present-but-invalid is corruption
+	// of the identity carrier itself; say so.
+	//
+	// Deliberately NOT applied to the _meta shape. That format overloads
+	// session_id as an AGENT identifier (store.go's StoreMeta note and
+	// ParseStoreMeta's agent_id fallback), and the documented import format
+	// ships values like "manual". Rejecting non-ses_ values there would report
+	// every imported and adapter-produced session as unreadable.
+	if isNativeHeader {
+		if raw, present := metadataObj["session_id"]; present {
+			id, isString := raw.(string)
+			if !isString || !sessionid.IsValidSessionID(id) {
+				return "", fmt.Errorf("header session_id is present but not a valid ses_ ID")
+			}
+		}
 	}
 
 	return session.ReadHeaderSessionID(rawPath), nil

--- a/cmd/ox/doctor_session_id_divergence.go
+++ b/cmd/ox/doctor_session_id_divergence.go
@@ -253,12 +253,22 @@ func readHeaderSessionIDStrict(rawPath string) (string, error) {
 	if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
 		return "", fmt.Errorf("invalid JSON on header line: %w", err)
 	}
-	// mirror the two header shapes session.ReadHeaderSessionID recognizes
-	// (type=="header"+metadata, or the alternative _meta format used by
-	// imported/manual sessions) — anything else is not a header at all.
-	_, hasMetadata := entry["metadata"]
-	_, hasMeta := entry["_meta"]
-	if !hasMetadata && !hasMeta {
+	// Mirror session.ReadHeaderSessionID's acceptance condition EXACTLY:
+	// (metadata is an object AND type=="header") OR (_meta is an object).
+	//
+	// Bare key-presence is not enough, and the gap is not cosmetic. A first
+	// line that merely HAS a "metadata" key — an ordinary entry, or a header
+	// whose metadata is a string rather than an object — would pass a
+	// presence check, then ReadHeaderSessionID (which does assert the type
+	// and the "header" tag) returns "". The scan reads that empty ID as
+	// "legacy session, predates ID-at-start" and skips it silently. That is
+	// precisely the corruption-swallowed-as-fine outcome this check exists
+	// to prevent, so a shape the reader would reject must surface as
+	// unreadable here.
+	_, metadataIsObj := entry["metadata"].(map[string]any)
+	_, metaIsObj := entry["_meta"].(map[string]any)
+	isNativeHeader := metadataIsObj && entry["type"] == "header"
+	if !isNativeHeader && !metaIsObj {
 		return "", fmt.Errorf("first line is not a recognizable session header")
 	}
 

--- a/cmd/ox/doctor_session_id_divergence.go
+++ b/cmd/ox/doctor_session_id_divergence.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+)
+
+// doctor_session_id_divergence.go detects a session whose durable identity
+// (ses_<UUIDv7>) has desynced between its two on-disk carriers:
+//
+//  1. sessions/<name>/meta.json -> session_id: the ledger's committed record,
+//     written by the 'uploaded' notify path AFTER the session finishes.
+//  2. the first-line _meta/header of that session's raw.jsonl: the
+//     crash-safe carrier, minted at recording START (ID-at-start shipped
+//     2026-07-18, commit 85f59500) so a daemon orphan-finalize can recover
+//     an identity even if .recording.json is already gone.
+//
+// The two are supposed to always agree. On a real wedged ledger they
+// didn't: two writers minted different IDs for one session, and 26 of 33
+// conflicting meta.json files in that ledger differed ONLY in session_id.
+// Because the header ID is what already reaches the outside world during
+// the session (SageOx-Session commit trailers, PR bodies, the server's
+// notifySessionUploaded dedup key — see session_linkage_finalize.go) while
+// meta.json is written after, a divergence silently desyncs the ledger's
+// own record from every URL and trailer that already circulated.
+// filterPRLinkMisses (session_linkage_finalize.go) exact-matches the
+// trailer and discards repair work the moment the two disagree, with
+// nothing anywhere flagging that it happened.
+//
+// This check closes that visibility gap. It does NOT repair anything —
+// see the doc comment on checkSessionIDDivergence for why blind repair
+// is unsafe here.
+
+// CheckSlugSessionIDDivergence is the slug for this check.
+const CheckSlugSessionIDDivergence = "session-id-divergence"
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:     CheckSlugSessionIDDivergence,
+		Name:     "Session ID divergence",
+		Category: "Sessions",
+		FixLevel: FixLevelCheckOnly,
+		Description: "Detects sessions whose meta.json session_id disagrees with the ID minted in " +
+			"raw.jsonl's header — report-only, see doc comment for why auto-repair is unsafe",
+		Run: func(fix bool) checkResult { return checkSessionIDDivergence() },
+	})
+}
+
+// sessionIDDivergence records one session directory where the two identity
+// carriers are both present, both populated, and disagree.
+type sessionIDDivergence struct {
+	Name     string
+	MetaID   string
+	HeaderID string
+}
+
+// sessionIDScanResult is the outcome of scanning a ledger's sessions/
+// directory for meta.json vs raw.jsonl header session_id agreement.
+type sessionIDScanResult struct {
+	checked    int                   // sessions where both IDs were readable and comparable
+	diverged   []sessionIDDivergence // comparable but disagree — the failure mode this check exists for
+	unreadable []string              // "<name>: <reason>" — corrupt/unreadable; NOT silently treated as fine
+}
+
+// checkSessionIDDivergence walks <ledger>/sessions/* and compares the
+// session_id committed to meta.json against the ID carried in that
+// session's raw.jsonl header.
+//
+// # Why report-only, never auto-fix
+//
+// The header ID looks like the obvious "source of truth" to auto-repair
+// meta.json from: it is minted first, it is the crash-safe carrier a
+// daemon orphan-finalize recovers from when .recording.json is already
+// gone, and in the common case it is what already leaked into circulated
+// commit trailers, PR bodies, and the server's dedup key before meta.json
+// is ever written (see notifySessionUploaded, session_linkage_finalize.go).
+// For the wedge this check was built to catch, the header is usually
+// right and meta.json is the stale copy.
+//
+// But "usually" is not "always," and this check has no local way to tell
+// the difference:
+//
+//   - resolveOrphanSessionID (doctor_session_upload_retry.go) deliberately
+//     lets a PRESERVED meta.json ID win over the header ID when a prior
+//     retry already stamped meta.json before crashing on push. In that
+//     shape meta.json is the later, correct value and the header is the
+//     stale one — exactly backwards from "header always wins."
+//   - Telling which of the two IDs already shipped externally (a commit
+//     trailer, a PR body, the server's dedup key) requires an API round
+//     trip this check does not make. Guessing wrong would silently
+//     re-diverge the ledger from whatever already shipped — the same
+//     failure class this check exists to surface, just self-inflicted.
+//   - Rewriting a committed session_id changes the ledger's historical
+//     record of identity. That is a judgment call about which ID is
+//     "real," not a mechanical repair like recreating a .gitignore entry.
+//
+// A wrong auto-repair here is expensive and hard to notice afterward — the
+// incident that motivated this check was exactly this shape (two writers,
+// one ledger, most of the conflicts differing only in session_id). A
+// detect-only check that names both IDs side by side is already a real
+// improvement over the prior silence, and leaves the actual resolution
+// (which ID matches what already circulated) to whoever can check the
+// external record.
+func checkSessionIDDivergence() checkResult {
+	const name = "Session ID divergence"
+
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger found", "")
+	}
+
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	result, err := scanSessionIDDivergence(sessionsDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return SkippedCheck(name, "no sessions directory", "")
+		}
+		return WarningCheck(name, "scan failed", err.Error())
+	}
+
+	if len(result.diverged) == 0 && len(result.unreadable) == 0 {
+		return PassedCheck(name, fmt.Sprintf("%d session(s) checked, all agree", result.checked))
+	}
+
+	return sessionIDDivergenceFailure(name, result)
+}
+
+// scanSessionIDDivergence walks sessionsDir and classifies every session
+// directory. A session is only comparable (counted in `checked`, eligible
+// for `diverged`) when BOTH sides are present, readable, and populated:
+//
+//   - meta.json absent, or present with no session_id (pre-rollout legacy)
+//     -> skipped. Missing/unreadable meta.json is session-upload-retry's
+//     and session-ids' territory, not this check's; an empty SessionID
+//     there is the expected pre-rollout state doctor_session_ids.go's
+//     opt-in backfill already owns.
+//   - raw.jsonl absent, or present only as a dehydrated LFS pointer stub
+//     -> skipped. The header genuinely cannot be read locally; that is
+//     not evidence of anything, let alone a divergence.
+//   - raw.jsonl header well-formed but carries no session_id -> skipped.
+//     Expected for recordings that predate ID-at-start (2026-07-18,
+//     85f59500); reporting these as broken would be false-positive noise
+//     on every pre-rollout session forever.
+//   - either side corrupt/unreadable (invalid JSON, unrecognized shape,
+//     I/O error) -> recorded in `unreadable`, never silently dropped.
+//   - both sides present, populated, and disagree -> recorded in `diverged`.
+func scanSessionIDDivergence(sessionsDir string) (sessionIDScanResult, error) {
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return sessionIDScanResult{}, err
+	}
+
+	var result sessionIDScanResult
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sessionName := e.Name()
+		sessionDir := filepath.Join(sessionsDir, sessionName)
+
+		// PreservedSessionID already distinguishes "absent or no field"
+		// ("", nil) from "present but unreadable" ("", err) — reuse it
+		// rather than re-parsing meta.json here.
+		metaID, metaErr := lfs.PreservedSessionID(sessionDir)
+		if metaErr != nil {
+			result.unreadable = append(result.unreadable, fmt.Sprintf("%s: meta.json: %v", sessionName, metaErr))
+			continue
+		}
+
+		rawPath := filepath.Join(sessionDir, "raw.jsonl")
+		headerID, headerErr := readHeaderSessionIDStrict(rawPath)
+		if headerErr != nil {
+			if errors.Is(headerErr, errRawNotComparable) {
+				continue // absent or dehydrated — nothing to compare, not a failure
+			}
+			result.unreadable = append(result.unreadable, fmt.Sprintf("%s: raw.jsonl: %v", sessionName, headerErr))
+			continue
+		}
+
+		if metaID == "" || headerID == "" {
+			// legacy on at least one side — expected during the rollout
+			// window on either carrier independently, not a divergence.
+			continue
+		}
+
+		result.checked++
+		if metaID != headerID {
+			result.diverged = append(result.diverged, sessionIDDivergence{
+				Name: sessionName, MetaID: metaID, HeaderID: headerID,
+			})
+		}
+	}
+
+	sort.Slice(result.diverged, func(i, j int) bool { return result.diverged[i].Name < result.diverged[j].Name })
+	sort.Strings(result.unreadable)
+	return result, nil
+}
+
+// errRawNotComparable signals that raw.jsonl's header cannot be read
+// locally for a benign reason (absent, or a dehydrated LFS pointer stub)
+// — distinct from a parse/read failure, which callers must surface.
+var errRawNotComparable = errors.New("raw.jsonl not locally comparable")
+
+// readHeaderSessionIDStrict classifies raw.jsonl's header for divergence
+// detection. session.ReadHeaderSessionID deliberately collapses every
+// "can't get an ID" case to "" for its own callers (which only ever want
+// "do I have an ID or should I mint one"); this check needs those cases
+// told apart, because collapsing a corrupt header into "legacy, no ID" is
+// exactly the kind of silent swallow CLAUDE.md's doctor mandate forbids.
+//
+// Once the shape is confirmed to be a parseable, recognizable header, ID
+// extraction itself is delegated to session.ReadHeaderSessionID so the
+// two callers can never disagree about what counts as a valid ses_ ID.
+func readHeaderSessionIDStrict(rawPath string) (string, error) {
+	if lfs.IsPointerFile(rawPath) {
+		return "", errRawNotComparable // dehydrated clone — content not local
+	}
+
+	f, err := os.Open(rawPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", errRawNotComparable
+		}
+		return "", fmt.Errorf("open: %w", err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("not a regular file")
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 256*1024), 256*1024)
+	if !scanner.Scan() {
+		return "", fmt.Errorf("empty file")
+	}
+
+	var entry map[string]any
+	if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+		return "", fmt.Errorf("invalid JSON on header line: %w", err)
+	}
+	// mirror the two header shapes session.ReadHeaderSessionID recognizes
+	// (type=="header"+metadata, or the alternative _meta format used by
+	// imported/manual sessions) — anything else is not a header at all.
+	_, hasMetadata := entry["metadata"]
+	_, hasMeta := entry["_meta"]
+	if !hasMetadata && !hasMeta {
+		return "", fmt.Errorf("first line is not a recognizable session header")
+	}
+
+	return session.ReadHeaderSessionID(rawPath), nil
+}
+
+// sessionIDDivergenceFailure builds the WarningCheck for a non-clean scan.
+// Extracted so the message/detail shape is unit-testable without standing
+// up a real ledger directory.
+//
+// WarningCheck (not CriticalCheck): a divergence here does not block any
+// git/sync operation the way an unmerged-paths or stuck-rebase wedge does
+// (checkLedgerUnmergedPaths, checkLedgerStuckOperation) — it silently
+// breaks a downstream feature (PR-link repair) rather than halting
+// everyone's push. That is the same tier as the "Legacy session IDs"
+// check (doctor_session_ids.go), its closest sibling.
+func sessionIDDivergenceFailure(name string, result sessionIDScanResult) checkResult {
+	const sampleCap = 5
+
+	var parts []string
+	if len(result.diverged) > 0 {
+		parts = append(parts, fmt.Sprintf("%d diverged", len(result.diverged)))
+	}
+	if len(result.unreadable) > 0 {
+		parts = append(parts, fmt.Sprintf("%d unreadable", len(result.unreadable)))
+	}
+	msg := strings.Join(parts, ", ")
+
+	var detail []string
+	if len(result.diverged) > 0 {
+		sample := result.diverged
+		more := ""
+		if len(sample) > sampleCap {
+			more = fmt.Sprintf(" (+%d more)", len(sample)-sampleCap)
+			sample = sample[:sampleCap]
+		}
+		lines := make([]string, len(sample))
+		for i, d := range sample {
+			lines[i] = fmt.Sprintf("%s: meta=%s header=%s", d.Name, d.MetaID, d.HeaderID)
+		}
+		detail = append(detail, fmt.Sprintf("meta.json vs raw.jsonl header disagree%s:\n       %s",
+			more, strings.Join(lines, "\n       ")))
+	}
+	if len(result.unreadable) > 0 {
+		detail = append(detail, fmt.Sprintf("could not compare (unreadable/corrupt):\n       %s",
+			strings.Join(result.unreadable, "\n       ")))
+	}
+	detail = append(detail, "No auto-fix: which ID already shipped externally (commit trailer, PR body, "+
+		"server dedup key) cannot be determined locally — see the doc comment on checkSessionIDDivergence.")
+
+	return WarningCheck(name, msg, strings.Join(detail, "\n"))
+}

--- a/cmd/ox/doctor_session_id_divergence_test.go
+++ b/cmd/ox/doctor_session_id_divergence_test.go
@@ -254,6 +254,72 @@ func TestScanSessionIDDivergence_UnrecognizedHeaderShapeReportedUnreadable(t *te
 	assert.Contains(t, result.unreadable[0], "weird-shape")
 }
 
+// TestScanSessionIDDivergence_NativeHeaderInvalidIDIsUnreadable covers the
+// layer below the shape check: the header shape is fine, but the session_id
+// VALUE is corrupt. ParseStoreMeta only admits ses_-prefixed strings into
+// StoreMeta.SessionID, so a malformed value reads back as "" — identical to a
+// legacy header that never carried the field.
+//
+// Failure prevented: a corrupted identity carrier silently classified as
+// "legacy, predates ID-at-start" and omitted from ox doctor entirely, which is
+// the same swallow-corruption-as-fine failure as the shape gap, one level down.
+func TestScanSessionIDDivergence_NativeHeaderInvalidIDIsUnreadable(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		header string
+	}{
+		{"missing ses_ prefix", `{"type":"header","metadata":{"agent_id":"OxAbc1","session_id":"019f9478-022c-7f2a-a5cd-9e7f23679a4e"}}`},
+		{"not a UUID at all", `{"type":"header","metadata":{"agent_id":"OxAbc1","session_id":"ses_garbage"}}`},
+		{"wrong type entirely", `{"type":"header","metadata":{"agent_id":"OxAbc1","session_id":12345}}`},
+		{"empty string", `{"type":"header","metadata":{"agent_id":"OxAbc1","session_id":""}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			sessionsDir := filepath.Join(tmp, "sessions")
+			dir := filepath.Join(sessionsDir, "corrupt-id")
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			writeTestSessionMeta(t, sessionsDir, "corrupt-id", sessionid.GenerateSessionID())
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(tc.header+"\n"), 0o644))
+
+			result, err := scanSessionIDDivergence(sessionsDir)
+			require.NoError(t, err)
+			require.Len(t, result.unreadable, 1,
+				"a corrupt session_id must be reported, not skipped as legacy")
+			assert.Contains(t, result.unreadable[0], "corrupt-id")
+		})
+	}
+}
+
+// TestScanSessionIDDivergence_ImportHeaderNonSesIDStaysQuiet is the
+// false-positive guard for the check above. The alternative _meta format
+// OVERLOADS session_id as an agent identifier — ParseStoreMeta falls it back
+// to StoreMeta.AgentID precisely when it is not ses_-prefixed, and the
+// documented import format in .claude/rules/session-capture.md ships
+// `"session_id":"manual"`.
+//
+// Failure prevented: applying the native-header validity rule to _meta would
+// report every imported and adapter-produced session as unreadable — turning
+// a corruption detector into a wall of noise that gets ignored.
+func TestScanSessionIDDivergence_ImportHeaderNonSesIDStaysQuiet(t *testing.T) {
+	for _, header := range []string{
+		`{"_meta":{"schema_version":"1","agent_type":"claude-code","session_id":"manual"}}`,
+		`{"_meta":{"schema_version":"1","agent_type":"cursor","session_id":"some-agent-uuid"}}`,
+	} {
+		tmp := t.TempDir()
+		sessionsDir := filepath.Join(tmp, "sessions")
+		dir := filepath.Join(sessionsDir, "imported")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		writeTestSessionMeta(t, sessionsDir, "imported", sessionid.GenerateSessionID())
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(header+"\n"), 0o644))
+
+		result, err := scanSessionIDDivergence(sessionsDir)
+		require.NoError(t, err)
+		assert.Empty(t, result.unreadable,
+			"the _meta agent-identifier overload is not corruption: %s", header)
+		assert.Empty(t, result.diverged)
+	}
+}
+
 // TestScanSessionIDDivergence_HeaderShapeMustMatchTheReader covers the gap a
 // bare key-presence check leaves open. Each of these first lines CONTAINS a
 // "metadata" or "_meta" key, so a presence check waves it through — but

--- a/cmd/ox/doctor_session_id_divergence_test.go
+++ b/cmd/ox/doctor_session_id_divergence_test.go
@@ -1,0 +1,399 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/sessionid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTestSessionRaw creates a session directory (if needed) and writes a
+// production-shaped raw.jsonl header via the real session.Store writer, so
+// the fixture matches exactly what recording actually produces. Pass "" for
+// sessionID to reproduce a legacy header that predates ID-at-start
+// (2026-07-18, 85f59500) — the SessionID field is omitempty, so it's simply
+// absent from the header, not present-but-empty.
+func writeTestSessionRaw(t *testing.T, ledgerPath, name, sessionID string) {
+	t.Helper()
+	store, err := session.NewStore(ledgerPath)
+	require.NoError(t, err)
+	w, err := store.CreateRaw(name)
+	require.NoError(t, err)
+	require.NoError(t, w.WriteHeader(&session.StoreMeta{
+		Version:   "1.0",
+		CreatedAt: time.Now(),
+		SessionID: sessionID,
+		AgentType: "claude-code",
+		Username:  "user",
+	}))
+	require.NoError(t, w.Close())
+}
+
+// --- A. scanSessionIDDivergence: the states this check must tell apart ---
+
+// TestScanSessionIDDivergence_AgreeingIDsPass verifies a session whose
+// meta.json and raw.jsonl header carry the SAME session_id is counted as
+// checked and never reported as diverged.
+// Failure prevented: an off-by-something comparison flagging every healthy
+// session as diverged would make the check useless noise from day one.
+func TestScanSessionIDDivergence_AgreeingIDsPass(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	id := sessionid.GenerateSessionID()
+	writeTestSessionMeta(t, sessionsDir, "healthy", id)
+	writeTestSessionRaw(t, tmp, "healthy", id)
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.checked)
+	assert.Empty(t, result.diverged)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_DivergedIDsReported is the core failure mode
+// this check exists for: meta.json and the raw.jsonl header disagree.
+// Failure prevented: silently missing this is exactly the wedge that let a
+// two-writer race mint different IDs for one session and go undetected.
+func TestScanSessionIDDivergence_DivergedIDsReported(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	metaID := sessionid.GenerateSessionID()
+	headerID := sessionid.GenerateSessionID()
+	require.NotEqual(t, metaID, headerID)
+	writeTestSessionMeta(t, sessionsDir, "wedged", metaID)
+	writeTestSessionRaw(t, tmp, "wedged", headerID)
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.checked)
+	require.Len(t, result.diverged, 1)
+	assert.Equal(t, "wedged", result.diverged[0].Name)
+	assert.Equal(t, metaID, result.diverged[0].MetaID)
+	assert.Equal(t, headerID, result.diverged[0].HeaderID)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_MetaJSONAbsentSkipped verifies a session
+// directory with only raw.jsonl (no meta.json yet — still mid-upload) is
+// silently skipped, not reported.
+// Failure prevented: flagging every in-flight upload as "diverged" or
+// "unreadable" would drown the real signal and duplicate
+// session-upload-retry's territory.
+func TestScanSessionIDDivergence_MetaJSONAbsentSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	writeTestSessionRaw(t, tmp, "no-meta-yet", sessionid.GenerateSessionID())
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked)
+	assert.Empty(t, result.diverged)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_RawJSONLAbsentSkipped verifies a committed
+// session directory with meta.json but no raw.jsonl (e.g. content pruned,
+// or a directory doctor's other checks haven't finished populating) is
+// skipped rather than treated as corrupt.
+func TestScanSessionIDDivergence_RawJSONLAbsentSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	writeTestSessionMeta(t, sessionsDir, "no-raw", sessionid.GenerateSessionID())
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked)
+	assert.Empty(t, result.diverged)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_BothAbsentSkipped verifies an empty session
+// directory (neither file present) does not crash the scan and produces no
+// report of any kind.
+func TestScanSessionIDDivergence_BothAbsentSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionsDir, "empty"), 0o755))
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked)
+	assert.Empty(t, result.diverged)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_LegacyHeaderNoIDNotReported is the explicit
+// regression guard for the EXPECTED-not-broken case called out in the
+// task: raw.jsonl headers written before ID-at-start (2026-07-18,
+// 85f59500) carry no session_id at all. meta.json may still have a
+// (later-minted) ID. This must never be reported as a divergence or as
+// corruption.
+func TestScanSessionIDDivergence_LegacyHeaderNoIDNotReported(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	writeTestSessionMeta(t, sessionsDir, "pre-rollout-header", sessionid.GenerateSessionID())
+	writeTestSessionRaw(t, tmp, "pre-rollout-header", "") // legacy: no session_id field
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked, "not comparable — must not count toward checked")
+	assert.Empty(t, result.diverged)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_LegacyMetaNoIDNotReported mirrors the above
+// for the other carrier: meta.json predates the session_id field (owned by
+// doctor_session_ids.go's opt-in backfill), while the header has a valid
+// ID. Must not be reported here either.
+func TestScanSessionIDDivergence_LegacyMetaNoIDNotReported(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	writeTestSessionMeta(t, sessionsDir, "pre-rollout-meta", "") // legacy: no SessionID field
+	writeTestSessionRaw(t, tmp, "pre-rollout-meta", sessionid.GenerateSessionID())
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked)
+	assert.Empty(t, result.diverged)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_CorruptMetaJSONReportedUnreadable verifies a
+// meta.json that fails to parse is surfaced in `unreadable`, never silently
+// treated as "fine" (CLAUDE.md: "missing values are as broken as wrong
+// values").
+func TestScanSessionIDDivergence_CorruptMetaJSONReportedUnreadable(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	dir := filepath.Join(sessionsDir, "corrupt-meta")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte("{not valid json"), 0o644))
+	writeTestSessionRaw(t, tmp, "corrupt-meta", sessionid.GenerateSessionID())
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked)
+	assert.Empty(t, result.diverged)
+	require.Len(t, result.unreadable, 1)
+	assert.Contains(t, result.unreadable[0], "corrupt-meta")
+	assert.Contains(t, result.unreadable[0], "meta.json")
+}
+
+// TestScanSessionIDDivergence_CorruptRawHeaderReportedUnreadable verifies a
+// raw.jsonl whose first line is not valid JSON is surfaced in `unreadable`,
+// not folded into "legacy, no ID."
+func TestScanSessionIDDivergence_CorruptRawHeaderReportedUnreadable(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	dir := filepath.Join(sessionsDir, "corrupt-raw")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	writeTestSessionMeta(t, sessionsDir, "corrupt-raw", sessionid.GenerateSessionID())
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte("not json at all\n"), 0o644))
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked)
+	assert.Empty(t, result.diverged)
+	require.Len(t, result.unreadable, 1)
+	assert.Contains(t, result.unreadable[0], "corrupt-raw")
+	assert.Contains(t, result.unreadable[0], "raw.jsonl")
+}
+
+// TestScanSessionIDDivergence_EmptyRawFileReportedUnreadable verifies a
+// zero-byte raw.jsonl (truncated write, disk full, crash mid-write) is
+// surfaced as unreadable rather than silently treated as legacy.
+func TestScanSessionIDDivergence_EmptyRawFileReportedUnreadable(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	dir := filepath.Join(sessionsDir, "empty-raw")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	writeTestSessionMeta(t, sessionsDir, "empty-raw", sessionid.GenerateSessionID())
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(""), 0o644))
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	require.Len(t, result.unreadable, 1)
+	assert.Contains(t, result.unreadable[0], "empty-raw")
+}
+
+// TestScanSessionIDDivergence_UnrecognizedHeaderShapeReportedUnreadable
+// verifies a raw.jsonl whose first line is valid JSON but neither a
+// type=="header" envelope nor a "_meta" envelope is treated as corrupt,
+// not as an empty/legacy header.
+func TestScanSessionIDDivergence_UnrecognizedHeaderShapeReportedUnreadable(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	dir := filepath.Join(sessionsDir, "weird-shape")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	writeTestSessionMeta(t, sessionsDir, "weird-shape", sessionid.GenerateSessionID())
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(`{"foo":"bar"}`+"\n"), 0o644))
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	require.Len(t, result.unreadable, 1)
+	assert.Contains(t, result.unreadable[0], "weird-shape")
+}
+
+// TestScanSessionIDDivergence_DehydratedRawSkipped verifies a raw.jsonl
+// that is an LFS pointer stub (dehydrated clone — no local content) is
+// skipped, never reported as corrupt or diverged: the header genuinely
+// cannot be read locally, which is not evidence of anything.
+func TestScanSessionIDDivergence_DehydratedRawSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	dir := filepath.Join(sessionsDir, "dehydrated")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	writeTestSessionMeta(t, sessionsDir, "dehydrated", sessionid.GenerateSessionID())
+	require.NoError(t, lfs.WritePointerFile(filepath.Join(dir, "raw.jsonl"), lfs.FileRef{
+		OID: "sha256:" + strings.Repeat("a", 64), Size: 4096,
+	}))
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked)
+	assert.Empty(t, result.diverged)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_IgnoresNonDirEntries verifies stray files
+// directly under sessions/ (e.g. .gitignore) don't crash the scan.
+func TestScanSessionIDDivergence_IgnoresNonDirEntries(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionsDir, ".gitignore"), []byte("cache/\n"), 0o644))
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	assert.Zero(t, result.checked)
+	assert.Empty(t, result.diverged)
+	assert.Empty(t, result.unreadable)
+}
+
+// TestScanSessionIDDivergence_MultipleDivergedSortedByName verifies
+// multiple diverged sessions are returned in a deterministic (sorted)
+// order, so doctor output and tests don't flap on map/readdir ordering.
+func TestScanSessionIDDivergence_MultipleDivergedSortedByName(t *testing.T) {
+	tmp := t.TempDir()
+	sessionsDir := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	for _, name := range []string{"zeta", "alpha", "mu"} {
+		metaID := sessionid.GenerateSessionID()
+		headerID := sessionid.GenerateSessionID()
+		writeTestSessionMeta(t, sessionsDir, name, metaID)
+		writeTestSessionRaw(t, tmp, name, headerID)
+	}
+
+	result, err := scanSessionIDDivergence(sessionsDir)
+	require.NoError(t, err)
+	require.Len(t, result.diverged, 3)
+	assert.Equal(t, []string{"alpha", "mu", "zeta"}, []string{
+		result.diverged[0].Name, result.diverged[1].Name, result.diverged[2].Name,
+	})
+}
+
+// TestScanSessionIDDivergence_NoSessionsDirReturnsNotExist verifies the
+// scan surfaces a wrapped fs.ErrNotExist for a missing sessions/ directory
+// so the caller can turn it into a Skip rather than a scan failure.
+func TestScanSessionIDDivergence_NoSessionsDirReturnsNotExist(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := scanSessionIDDivergence(filepath.Join(tmp, "sessions"))
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+}
+
+// --- B. checkSessionIDDivergence: the doctor-check wrapper ---
+
+// TestCheckSessionIDDivergence_NoLedgerSkips mirrors
+// TestCheckLegacySessionIDs_NoLedgerSkips: running from a directory with no
+// ledger configured must Skip, not Warn — a first-run/no-ledger user
+// should never see this check flagged.
+func TestCheckSessionIDDivergence_NoLedgerSkips(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: requires git root + ledger resolution")
+	}
+	tmp := t.TempDir()
+	old, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmp))
+	t.Cleanup(func() { _ = os.Chdir(old) })
+
+	res := checkSessionIDDivergence()
+	assert.True(t, res.skipped, "expected skipped when no ledger; got %+v", res)
+	assert.Contains(t, strings.ToLower(res.message), "ledger")
+}
+
+// TestCheckSessionIDDivergence_RegisteredCheckOnly locks in the auto-fix
+// decision documented on checkSessionIDDivergence: this check must never
+// silently gain FixLevelAuto (or any fix behavior) without a deliberate,
+// reviewed change, since a wrong auto-repair of a committed session_id is
+// expensive and hard to detect after the fact.
+func TestCheckSessionIDDivergence_RegisteredCheckOnly(t *testing.T) {
+	check := GetDoctorCheck(CheckSlugSessionIDDivergence)
+	require.NotNil(t, check, "doctor check %q must be registered", CheckSlugSessionIDDivergence)
+	assert.Equal(t, FixLevelCheckOnly, check.FixLevel,
+		"session ID divergence must stay report-only — see the doc comment on checkSessionIDDivergence")
+	assert.Equal(t, "Sessions", check.Category)
+}
+
+// --- C. sessionIDDivergenceFailure: message/detail shape ---
+
+// TestSessionIDDivergenceFailure_ReportsBothDivergedAndUnreadable verifies
+// neither bucket silently disappears from the summary when both are
+// non-empty — the "unreadable/corrupt files must not be silently swallowed
+// as fine" requirement.
+func TestSessionIDDivergenceFailure_ReportsBothDivergedAndUnreadable(t *testing.T) {
+	result := sessionIDScanResult{
+		checked:    1,
+		diverged:   []sessionIDDivergence{{Name: "wedged", MetaID: "ses_meta", HeaderID: "ses_header"}},
+		unreadable: []string{"broken: meta.json: parse session meta: unexpected EOF"},
+	}
+
+	got := sessionIDDivergenceFailure("Session ID divergence", result)
+	assert.True(t, got.warning)
+	assert.True(t, got.passed, "WarningCheck sets passed=true — non-blocking, still visible")
+	assert.Contains(t, got.message, "1 diverged")
+	assert.Contains(t, got.message, "1 unreadable")
+	assert.Contains(t, got.detail, "wedged")
+	assert.Contains(t, got.detail, "ses_meta")
+	assert.Contains(t, got.detail, "ses_header")
+	assert.Contains(t, got.detail, "broken: meta.json")
+	assert.Contains(t, got.detail, "No auto-fix")
+}
+
+// TestSessionIDDivergenceFailure_CapsSampleAtFive verifies a long list of
+// diverged sessions is truncated with a "+N more" marker rather than
+// dumping an unbounded list into doctor output.
+func TestSessionIDDivergenceFailure_CapsSampleAtFive(t *testing.T) {
+	var diverged []sessionIDDivergence
+	for i := 0; i < 8; i++ {
+		diverged = append(diverged, sessionIDDivergence{
+			Name: filepath.Join("session", string(rune('a'+i))), MetaID: "ses_a", HeaderID: "ses_b",
+		})
+	}
+	result := sessionIDScanResult{diverged: diverged}
+
+	got := sessionIDDivergenceFailure("Session ID divergence", result)
+	assert.Contains(t, got.message, "8 diverged")
+	assert.Contains(t, got.detail, "+3 more")
+}

--- a/cmd/ox/doctor_session_id_divergence_test.go
+++ b/cmd/ox/doctor_session_id_divergence_test.go
@@ -254,6 +254,44 @@ func TestScanSessionIDDivergence_UnrecognizedHeaderShapeReportedUnreadable(t *te
 	assert.Contains(t, result.unreadable[0], "weird-shape")
 }
 
+// TestScanSessionIDDivergence_HeaderShapeMustMatchTheReader covers the gap a
+// bare key-presence check leaves open. Each of these first lines CONTAINS a
+// "metadata" or "_meta" key, so a presence check waves it through — but
+// session.ReadHeaderSessionID rejects every one of them (it requires an
+// object AND, for the native shape, type=="header"), returning "".
+//
+// Failure prevented: that empty ID reads as "legacy session, predates
+// ID-at-start" and the session is skipped SILENTLY. A corrupt header would
+// then be indistinguishable from a pre-rollout one — the precise
+// corruption-swallowed-as-fine outcome this whole check exists to catch.
+func TestScanSessionIDDivergence_HeaderShapeMustMatchTheReader(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		first string
+	}{
+		{"metadata present but not an object", `{"type":"header","metadata":"not-an-object"}`},
+		{"metadata object without the header tag", `{"metadata":{"session_id":"ses_x"}}`},
+		{"metadata object on an ordinary entry", `{"type":"message","metadata":{"session_id":"ses_x"}}`},
+		{"_meta present but not an object", `{"_meta":"not-an-object"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			sessionsDir := filepath.Join(tmp, "sessions")
+			dir := filepath.Join(sessionsDir, "bad-header")
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			writeTestSessionMeta(t, sessionsDir, "bad-header", sessionid.GenerateSessionID())
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(tc.first+"\n"), 0o644))
+
+			result, err := scanSessionIDDivergence(sessionsDir)
+			require.NoError(t, err)
+			require.Len(t, result.unreadable, 1,
+				"a shape the reader rejects must surface as unreadable, not be skipped as legacy")
+			assert.Contains(t, result.unreadable[0], "bad-header")
+			assert.Empty(t, result.diverged)
+		})
+	}
+}
+
 // TestScanSessionIDDivergence_DehydratedRawSkipped verifies a raw.jsonl
 // that is an LFS pointer stub (dehydrated clone — no local content) is
 // skipped, never reported as corrupt or diverged: the header genuinely

--- a/cmd/ox/doctor_session_id_divergence_test.go
+++ b/cmd/ox/doctor_session_id_divergence_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -319,7 +320,7 @@ func TestScanSessionIDDivergence_NoSessionsDirReturnsNotExist(t *testing.T) {
 	tmp := t.TempDir()
 	_, err := scanSessionIDDivergence(filepath.Join(tmp, "sessions"))
 	require.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 }
 
 // --- B. checkSessionIDDivergence: the doctor-check wrapper ---

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -250,6 +250,34 @@ func readCacheSessionMeta(rawPath string) (*session.StoreMeta, int, error) {
 	return meta, entryCount, nil
 }
 
+// resolveOrphanSessionID picks the durable ses_ ID for a retried orphan
+// upload. Precedence, via the shared session.ResolveOrMintSessionID
+// resolver: a preserved meta.json ID (a prior retry attempt already wrote
+// meta.json to sessionDir before crashing on push) beats the ID already
+// carried in the orphan's raw.jsonl header (orphan.Meta.SessionID, parsed
+// by findOrphanedSessions); a fresh ID is minted only when neither exists
+// (legacy recordings with no session_id anywhere).
+//
+// This must never be bypassed in favor of an inline mint: doing so is
+// exactly the bug this function fixes (ox-5n8e) — every retry of a still-
+// failing orphan silently rotated to a brand new SessionID because the
+// header-carried one was never consulted, so a later successful push could
+// commit a different ID than a locally stranded prior attempt, producing
+// two meta.json states for the same session.
+//
+// Non-NotExist meta.json read errors are fatal — see PreservedSessionID doc.
+func resolveOrphanSessionID(sessionDir string, orphan orphanedSession) (string, error) {
+	preservedID, err := lfs.PreservedSessionID(sessionDir)
+	if err != nil {
+		return "", fmt.Errorf("preserve existing SessionID: %w", err)
+	}
+	headerID := ""
+	if orphan.Meta != nil {
+		headerID = orphan.Meta.SessionID
+	}
+	return session.ResolveOrMintSessionID(preservedID, headerID), nil
+}
+
 // retrySessionUpload copies session files from cache to ledger, uploads to LFS,
 // writes meta.json, and commits+pushes. This is the recovery path for sessions
 // where phase 2 (ledger upload) failed during session stop. The cache always has
@@ -296,6 +324,14 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 		}
 	}
 
+	// durable ID via the shared resolver, resolved before the network round
+	// trip so a corrupt pre-existing meta.json aborts fast rather than after
+	// a wasted LFS upload. See resolveOrphanSessionID doc.
+	sessionID, err := resolveOrphanSessionID(sessionDir, orphan)
+	if err != nil {
+		return err
+	}
+
 	// upload to LFS
 	fileRefs, err := uploadSessionLFS(projectRoot, sessionDir)
 	if err != nil {
@@ -304,22 +340,11 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 
 	// build and write meta.json; use WriteSessionMetaOnly so content files
 	// remain intact until after the push (pointer stubs + no remote = unrecoverable)
-	//
-	// preserve any pre-existing ses_<UUIDv7> on retry: a prior orphan
-	// publish attempt may have written meta.json before crashing on push.
-	// Non-NotExist read errors are fatal — see PreservedSessionID doc.
-	preservedID, err := lfs.PreservedSessionID(sessionDir)
-	if err != nil {
-		return fmt.Errorf("preserve existing SessionID: %w", err)
-	}
-	metaBuilder := sessionMetaBase(orphan.SessionName, orphan.Meta.Username, orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt, projectRoot).
+	metaBuilder := sessionMetaBase(orphan.SessionName, orphan.Meta.Username, orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt, projectRoot, sessionID).
 		Model(orphan.Meta.Model).
 		EntryCount(orphan.EntryCount).
 		StopReason(session.StopReasonRecovered).
 		WithFiles(fileRefs)
-	if preservedID != "" {
-		metaBuilder = metaBuilder.SessionID(preservedID)
-	}
 	meta := metaBuilder.Build()
 	if err := lfs.WriteSessionMetaOnly(sessionDir, meta); err != nil {
 		return fmt.Errorf("write meta.json: %w", err)

--- a/cmd/ox/doctor_session_upload_retry_test.go
+++ b/cmd/ox/doctor_session_upload_retry_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/sessionid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -779,4 +780,132 @@ func TestRetrySessionUpload_ContentFilesNotPointers_OnLFSFailure(t *testing.T) {
 		assert.False(t, lfs.IsPointerFile(fPath),
 			"%s must remain real content after a failed upload (bug #291 regression)", f)
 	}
+}
+
+// --- resolveOrphanSessionID: ox-5n8e regression coverage ---
+//
+// Production evidence: the same session (identical session_name, username,
+// agent_id, created_at, entry_count, and per-file LFS OIDs) ended up with
+// two different session_id values in meta.json on two replicas of the same
+// ledger. Root cause: retrySessionUpload only ever consulted a preserved
+// meta.json ID and, when none was present yet (true for every orphan by
+// construction — findOrphanedSessions already filters out sessions with an
+// existing ledger meta.json), silently minted a brand new ID instead of
+// falling back to the ID already carried in the orphan's raw.jsonl header
+// (orphan.Meta.SessionID). Any session retried more than once before its
+// first successful push — a stale/reset local ledger clone, a second
+// developer machine, a repeated `ox doctor` run — got a different random ID
+// each time.
+
+// TestResolveOrphanSessionID_HeaderIDPreservedWhenNoLedgerMetaYet is the
+// direct regression test for the bug: this is the exact state every orphan
+// is in on its first (and any subsequent, still-failing) retry attempt —
+// no meta.json in the ledger session dir — which is precisely where the
+// header-carried ID must NOT be discarded.
+func TestResolveOrphanSessionID_HeaderIDPreservedWhenNoLedgerMetaYet(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "sessions", "2026-05-08T19-25-ajit-OxF9dp")
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	// no meta.json written — mirrors every orphan retrySessionUpload sees
+
+	const headerID = "ses_019f633e-29f3-7566-9ab4-a3da5b666fe5"
+	orphan := orphanedSession{
+		SessionName: "2026-05-08T19-25-ajit-OxF9dp",
+		Meta:        &session.StoreMeta{AgentID: "OxF9dp", SessionID: headerID},
+	}
+
+	got, err := resolveOrphanSessionID(sessionDir, orphan)
+	require.NoError(t, err)
+	assert.Equal(t, headerID, got, "must preserve the header-carried SessionID, not mint a new one")
+}
+
+// TestResolveOrphanSessionID_PreservedMetaWinsOverHeader verifies the
+// documented precedence: a meta.json already written to the ledger session
+// dir (an earlier retry that got as far as the write before the push
+// failed) outranks the header ID.
+func TestResolveOrphanSessionID_PreservedMetaWinsOverHeader(t *testing.T) {
+	sessionDir := t.TempDir()
+	const preservedID = "ses_019f63cb-97ff-761e-ab36-e7a967b4438f"
+	require.NoError(t, lfs.WriteSessionMeta(sessionDir, &lfs.SessionMeta{
+		Version:     "1.0",
+		SessionName: "2026-05-08T19-25-ajit-OxF9dp",
+		SessionID:   preservedID,
+		CreatedAt:   time.Now(),
+	}))
+
+	orphan := orphanedSession{
+		SessionName: "2026-05-08T19-25-ajit-OxF9dp",
+		Meta:        &session.StoreMeta{AgentID: "OxF9dp", SessionID: "ses_019f633e-29f3-7566-9ab4-a3da5b666fe5"},
+	}
+
+	got, err := resolveOrphanSessionID(sessionDir, orphan)
+	require.NoError(t, err)
+	assert.Equal(t, preservedID, got, "preserved meta.json ID must win over the header-carried ID")
+}
+
+// TestResolveOrphanSessionID_CorruptMetaRefusesToMint mirrors the
+// unreadable-events-never-mints-new-id shape from the plan backfill
+// hardening (PR #723): a meta.json that exists but cannot be parsed must
+// abort with an error, never silently fall through to minting a fresh
+// SessionID that would rotate away from an ID we simply failed to read.
+func TestResolveOrphanSessionID_CorruptMetaRefusesToMint(t *testing.T) {
+	sessionDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "meta.json"), []byte("{not valid json"), 0644))
+
+	orphan := orphanedSession{
+		SessionName: "corrupt-meta-session",
+		Meta:        &session.StoreMeta{AgentID: "OxBAD1", SessionID: "ses_019f633e-29f3-7566-9ab4-a3da5b666fe5"},
+	}
+
+	got, err := resolveOrphanSessionID(sessionDir, orphan)
+	require.Error(t, err, "corrupt meta.json must refuse to resolve, not mint a fresh ID")
+	assert.Empty(t, got)
+}
+
+// TestResolveOrphanSessionID_NoIDAnywhereMintsExactlyOne covers the
+// genuinely-legacy case: no ledger meta.json and no header SessionID (a
+// recording from before SessionID-at-birth minting). Minting is the only
+// correct behavior here, and it must produce a valid, well-formed ID.
+func TestResolveOrphanSessionID_NoIDAnywhereMintsExactlyOne(t *testing.T) {
+	sessionDir := t.TempDir()
+	orphan := orphanedSession{
+		SessionName: "legacy-session",
+		Meta:        &session.StoreMeta{AgentID: "OxLEG1"}, // no SessionID
+	}
+
+	got, err := resolveOrphanSessionID(sessionDir, orphan)
+	require.NoError(t, err)
+	assert.True(t, sessionid.IsValidSessionID(got), "must mint a valid ses_<UUIDv7> when no ID exists anywhere, got %q", got)
+}
+
+// TestResolveOrphanSessionID_RegisteredTwiceYieldsOneID reproduces the
+// exact production shape: the same session_name/created_at is retried
+// twice (e.g. the first retry wrote meta.json locally but the push failed,
+// and a later `ox doctor` run retries again). Both calls must resolve to
+// the SAME session_id.
+func TestResolveOrphanSessionID_RegisteredTwiceYieldsOneID(t *testing.T) {
+	sessionDir := t.TempDir()
+	orphan := orphanedSession{
+		SessionName: "2026-05-08T19-25-ajit-OxF9dp",
+		Meta:        &session.StoreMeta{AgentID: "OxF9dp"}, // legacy: no header ID either
+	}
+
+	// first registration: nothing anywhere yet — mints ID_A and (as
+	// retrySessionUpload does in production) writes it to meta.json before
+	// attempting the push.
+	first, err := resolveOrphanSessionID(sessionDir, orphan)
+	require.NoError(t, err)
+	require.True(t, sessionid.IsValidSessionID(first))
+	require.NoError(t, lfs.WriteSessionMeta(sessionDir, &lfs.SessionMeta{
+		Version:     "1.0",
+		SessionName: orphan.SessionName,
+		SessionID:   first,
+		CreatedAt:   time.Now(),
+	}))
+
+	// second registration: same session, same cache content, retried again
+	// (push failed the first time). Must return the SAME id, not mint a
+	// second one.
+	second, err := resolveOrphanSessionID(sessionDir, orphan)
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "retrying the same session must yield one durable session_id, not two")
 }

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -172,6 +172,9 @@ const (
 	CheckSlugSessionUncommitted = "session-uncommitted"
 	CheckSlugSessionOrphaned    = "session-orphaned"
 	CheckSlugSessionManifest    = "session-manifest"
+	// CheckSlugSessionIDDivergence is co-located with its impl in
+	// doctor_session_id_divergence.go to keep the check + its detect-only
+	// rationale self-contained (mirrors CheckSlugSessionIDsBackfilled).
 
 	// Authentication checks (credential health)
 	CheckSlugGitHubAuth          = "github-auth"

--- a/cmd/ox/prime_session_marker_test.go
+++ b/cmd/ox/prime_session_marker_test.go
@@ -441,9 +441,14 @@ func TestWriteToAgentEnvFile_NeverLoosensPermissions(t *testing.T) {
 // the test non-parallel, which is required here anyway. Any future test
 // that queries markers by PID should call this rather than hope it wins the
 // ordering race.
+// t.Name() alone is NOT enough: two concurrent `go test` processes run the
+// same test name, would derive the same directory, and the Cleanup below
+// would delete the other process's markers — reintroducing the shared-key
+// collision at process scope instead of test scope. t.TempDir()'s basename
+// is unique per test AND per process, so it closes that last gap.
 func isolateSessionMarkerDir(t *testing.T) {
 	t.Helper()
-	unique := "oxtest-" + strings.ReplaceAll(t.Name(), "/", "_")
+	unique := "oxtest-" + filepath.Base(t.TempDir()) + "-" + strings.ReplaceAll(t.Name(), "/", "_")
 	t.Setenv("USER", unique)
 	t.Setenv("USERNAME", unique)
 	require.NoError(t, os.MkdirAll(SessionMarkerDir(), 0700))

--- a/cmd/ox/prime_session_marker_test.go
+++ b/cmd/ox/prime_session_marker_test.go
@@ -419,6 +419,37 @@ func TestWriteToAgentEnvFile_NeverLoosensPermissions(t *testing.T) {
 	})
 }
 
+// isolateSessionMarkerDir gives the calling test a private SessionMarkerDir.
+//
+// SessionMarkerDir() is paths.TempDir()/sessions — ONE global directory
+// shared by the whole package (and with the developer's real ox install).
+// FindSessionMarkerByPID scans it and returns the FIRST marker matching the
+// queried PID, in os.ReadDir order. Every test that writes a marker with
+// ParentPID: os.Getpid() therefore competes for the same key, and which one
+// a PID query resolves to comes down to filename ordering — several test
+// files do exactly that (agent_hook_test.go, session_force_stop_test.go,
+// agent_prime_id_reuse_test.go).
+//
+// Failure prevented: a PID-query test intermittently asserting against
+// another test's marker. Reproduced deterministically by planting a
+// same-PID marker whose session ID sorts earlier — the query then returns
+// the competitor rather than the marker under test.
+//
+// paths.TempDir() derives the directory from $USER (then $USERNAME on
+// Windows), so overriding those per test isolates the namespace without
+// touching production code. t.Setenv restores them automatically and marks
+// the test non-parallel, which is required here anyway. Any future test
+// that queries markers by PID should call this rather than hope it wins the
+// ordering race.
+func isolateSessionMarkerDir(t *testing.T) {
+	t.Helper()
+	unique := "oxtest-" + strings.ReplaceAll(t.Name(), "/", "_")
+	t.Setenv("USER", unique)
+	t.Setenv("USERNAME", unique)
+	require.NoError(t, os.MkdirAll(SessionMarkerDir(), 0700))
+	t.Cleanup(func() { _ = os.RemoveAll(SessionMarkerDir()) })
+}
+
 // TestFindSessionMarkerByPID_MatchesParentPID is the #527/#529 regression
 // guard for PID-based marker fallback: a second prime call that lacks a
 // native agent_session_id (e.g. invoked from a CLAUDE.md BLOCKING
@@ -429,7 +460,10 @@ func TestWriteToAgentEnvFile_NeverLoosensPermissions(t *testing.T) {
 //
 // Uses the current test process PID so the proc.IsAlive liveness gate
 // passes — a recycled/dead PID is specifically what the gate filters out.
+// That PID is shared with every other test in the package, so the marker
+// namespace is isolated first; see isolateSessionMarkerDir.
 func TestFindSessionMarkerByPID_MatchesParentPID(t *testing.T) {
+	isolateSessionMarkerDir(t)
 	agentPID := os.Getpid()
 	sessionID := "findbyPIDtest_" + time.Now().Format("20060102150405.000")
 
@@ -466,6 +500,7 @@ func TestFindSessionMarkerByPID_IgnoresDeadParentPID(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test requires POSIX `true` to spawn-and-reap a guaranteed-dead PID")
 	}
+	isolateSessionMarkerDir(t)
 
 	cmd := exec.Command("true")
 	require.NoError(t, cmd.Start())
@@ -490,6 +525,7 @@ func TestFindSessionMarkerByPID_IgnoresDeadParentPID(t *testing.T) {
 // strict: unrelated markers on the system must not be returned for a PID
 // they don't reference.
 func TestFindSessionMarkerByPID_IgnoresNonMatchingPID(t *testing.T) {
+	isolateSessionMarkerDir(t)
 	sessionID := "findbyPIDnomatch_" + time.Now().Format("20060102150405.000")
 	marker := &SessionMarker{
 		AgentID:        "OxOther",
@@ -509,6 +545,53 @@ func TestFindSessionMarkerByPID_IgnoresNonMatchingPID(t *testing.T) {
 // placeholder / unset PID values (0, negative) against a stored marker
 // that happens to record PID 0 from an earlier buggy write.
 func TestFindSessionMarkerByPID_RejectsInvalidPID(t *testing.T) {
+	isolateSessionMarkerDir(t)
 	assert.Nil(t, FindSessionMarkerByPID(0))
 	assert.Nil(t, FindSessionMarkerByPID(-1))
+}
+
+// TestFindSessionMarkerByPID_IgnoresMarkerFromAnotherTestsDir is the
+// regression guard for isolateSessionMarkerDir itself. It reconstructs the
+// exact conditions that made this suite flaky: a marker sitting in the
+// SHARED global dir carrying the same ParentPID (os.Getpid(), which every
+// test in the package shares) under a session ID that sorts EARLIER, so an
+// un-isolated os.ReadDir scan reaches it first.
+//
+// Failure prevented: the flake returning. Remove the isolateSessionMarkerDir
+// call below and this fails deterministically with AgentID "OxForeign" —
+// which is how the original intermittent failure was diagnosed. Note that a
+// test which merely writes one marker and reads it back would keep passing
+// throughout, which is why the flake survived this long.
+func TestFindSessionMarkerByPID_IgnoresMarkerFromAnotherTestsDir(t *testing.T) {
+	agentPID := os.Getpid()
+
+	// Plant BEFORE isolating, so it lands in the shared dir that other tests
+	// in this package really do write to. "aaa" sorts ahead of "own".
+	foreignID := "aaa_foreign_marker_from_another_test"
+	require.NoError(t, WriteSessionMarker(&SessionMarker{
+		AgentID:        "OxForeign",
+		AgentSessionID: foreignID,
+		PrimedAt:       time.Now().Truncate(time.Second),
+		ParentPID:      agentPID,
+	}))
+	// capture the absolute path now: once USER is overridden below,
+	// markerPath resolves somewhere else entirely and could not clean this up
+	foreignPath := markerPath(foreignID)
+	t.Cleanup(func() { _ = os.Remove(foreignPath) })
+
+	isolateSessionMarkerDir(t)
+
+	ownID := "own_marker_under_test"
+	require.NoError(t, WriteSessionMarker(&SessionMarker{
+		AgentID:        "OxOwn",
+		AgentSessionID: ownID,
+		PrimedAt:       time.Now().Truncate(time.Second),
+		ParentPID:      agentPID,
+	}))
+	t.Cleanup(func() { DeleteSessionMarker(ownID) })
+
+	found := FindSessionMarkerByPID(agentPID)
+	require.NotNil(t, found, "the isolated dir's own marker must still be found")
+	assert.Equal(t, "OxOwn", found.AgentID,
+		"a same-PID marker in the shared global dir must not leak into an isolated test")
 }

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Plans are written for the reader who approves them.** Every AI coworker now drafts a plan with the decision up top — the shape, the tradeoffs, and the risk you need to approve it in ten minutes — and moves the exact files, edits, and gotchas into an "Implementation notes" section at the end, for the coworker that builds it. The rendered plan collapses that detail into an appendix you never have to open, so a ten-minute review actually takes ten minutes.
 
+- **`ox doctor` now flags a recording whose session link disagrees with the recording itself** — the one state that silently breaks links already written into your commits and pull requests. Reported, never repaired automatically: which link is correct depends on what has already been shared, so doctor names the conflict and leaves the call to you.
+
+### Fixed
+
+- **Every recording keeps one permanent session link, even when its upload has to be retried.** A retried or recovered upload could assign a second link to a session that already had one, so the references written into commit trailers, pull requests, and plans stopped resolving — and two copies of the same session could disagree about which one it was.
+
+- **Ledger sync no longer stalls on machines that sign git commits.** If your git config requires a passphrase to sign, sync could stop partway with no terminal available to answer the prompt, leaving work stranded locally.
+
 ## [0.12.0] - 2026-07-18
 
 Decision Records get first-class team context, and three real reliability gaps in sync and search are closed for good.

--- a/cmd/ox/session_meta_helper.go
+++ b/cmd/ox/session_meta_helper.go
@@ -6,23 +6,26 @@ import (
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/lfs"
-	"github.com/sageox/ox/internal/sessionid"
 )
 
 // sessionMetaBase creates a SessionMetaBuilder pre-populated with identity
 // fields (UserID, RepoID, SessionID) resolved from the project root.
 // Callers chain additional optional setters before calling Build().
 //
-// The SessionID stamped here is a fresh ses_<UUIDv7> FALLBACK for paths
-// with no recording state (imports, manual uploads, legacy recordings).
-// Recording-backed callers override it with the ID minted at
-// StartRecording, and a preserved meta.json ID overrides both (last
-// write wins on the builder). Never regenerated on later mutates:
-// MutateSessionMeta paths preserve the value via JSON round-trip.
-func sessionMetaBase(sessionName, username, agentID, agentType string, createdAt time.Time, projectRoot string) *lfs.SessionMetaBuilder {
+// sessionID is REQUIRED and must already be fully resolved by the caller via
+// session.ResolveOrMintSessionID(preserved, startMinted) — preferring a
+// preserved meta.json ID, then a start-minted/header-carried ID, and only
+// minting fresh as a last resort. This constructor deliberately does not
+// mint on its own: a prior version defaulted to a fresh mint here and relied
+// on every caller remembering to override it, which one call site (doctor's
+// orphan retry-upload) silently failed to do, rotating SessionIDs on every
+// retry. Requiring the value up front makes that class of bug impossible.
+// Never regenerated on later mutates: MutateSessionMeta paths preserve the
+// value via JSON round-trip.
+func sessionMetaBase(sessionName, username, agentID, agentType string, createdAt time.Time, projectRoot, sessionID string) *lfs.SessionMetaBuilder {
 	ep := endpoint.GetForProject(projectRoot)
 	return lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
 		UserID(auth.GetUserID(ep)).
 		RepoID(getRepoIDOrDefault(projectRoot)).
-		SessionID(sessionid.GenerateSessionID())
+		SessionID(sessionID)
 }

--- a/cmd/ox/session_meta_helper_test.go
+++ b/cmd/ox/session_meta_helper_test.go
@@ -6,19 +6,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/sessionid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestSessionMetaBase_StampsValidSessionID asserts that every meta.json
-// constructed via the canonical CLI builder carries a fresh ses_<UUIDv7>.
+// TestSessionMetaBase_StampsGivenSessionID asserts that the builder stamps
+// exactly the SessionID the caller resolved and passed in — it must never
+// mint its own.
 //
-// Failure prevented: a refactor that drops the `.SessionID(...)` chain
-// (e.g., during a builder reorganization) would silently emit legacy-
-// shaped meta.json on every newly recorded session, undoing the rollout
-// and forcing every consumer back onto the synthetic fallback.
-func TestSessionMetaBase_StampsValidSessionID(t *testing.T) {
+// Failure prevented: a regression reintroducing an internal fallback mint
+// (the pre-fix shape) would let a call site that forgets to resolve a
+// durable ID silently get a fresh one instead of a compile error, exactly
+// the bug that let doctor's orphan retry-upload rotate SessionIDs on every
+// retry (ox-5n8e).
+func TestSessionMetaBase_StampsGivenSessionID(t *testing.T) {
 	tmp := t.TempDir()
 	// sessionMetaBase calls getRepoIDOrDefault, which probes the project
 	// root. Pass an empty/temp path; the helper tolerates the default
@@ -26,28 +29,25 @@ func TestSessionMetaBase_StampsValidSessionID(t *testing.T) {
 	projectRoot := filepath.Join(tmp, "project")
 	require.NoError(t, os.MkdirAll(projectRoot, 0o755))
 
-	for i := 0; i < 5; i++ {
-		meta := sessionMetaBase("session-name", "user", "Ox1234", "claude-code", time.Now(), projectRoot).Build()
-		require.NotNil(t, meta)
-		assert.True(t, sessionid.IsValidSessionID(meta.SessionID),
-			"sessionMetaBase must stamp a valid ses_<UUIDv7> on every call, got: %q", meta.SessionID)
-	}
+	given := "ses_01890a5d-ac96-774b-bcce-b302099a8057"
+	meta := sessionMetaBase("session-name", "user", "Ox1234", "claude-code", time.Now(), projectRoot, given).Build()
+	require.NotNil(t, meta)
+	assert.Equal(t, given, meta.SessionID,
+		"sessionMetaBase must stamp exactly the SessionID it was given, never substitute its own")
 }
 
-// TestSessionMetaBase_SessionIDsAreUnique guards against a refactor that
-// computes a single static ID and reuses it (e.g., a global var captured
-// at package init).
-func TestSessionMetaBase_SessionIDsAreUnique(t *testing.T) {
-	tmp := t.TempDir()
-	projectRoot := filepath.Join(tmp, "project")
-	require.NoError(t, os.MkdirAll(projectRoot, 0o755))
-
+// TestResolveOrMintSessionID_MintsUniqueValidIDs guards the single mint
+// chokepoint (session.ResolveOrMintSessionID) against a refactor that
+// computes a single static ID and reuses it (e.g., a global var captured at
+// package init), or emits a malformed ID.
+func TestResolveOrMintSessionID_MintsUniqueValidIDs(t *testing.T) {
 	seen := make(map[string]bool)
 	const n = 50
 	for i := 0; i < n; i++ {
-		meta := sessionMetaBase("session-name", "user", "Ox1234", "claude-code", time.Now(), projectRoot).Build()
-		assert.False(t, seen[meta.SessionID], "duplicate SessionID generated: %q", meta.SessionID)
-		seen[meta.SessionID] = true
+		id := session.ResolveOrMintSessionID("", "")
+		assert.True(t, sessionid.IsValidSessionID(id), "must mint a valid ses_<UUIDv7>, got %q", id)
+		assert.False(t, seen[id], "duplicate SessionID generated: %q", id)
+		seen[id] = true
 	}
 	assert.Len(t, seen, n)
 }

--- a/cmd/ox/session_upload_cmd.go
+++ b/cmd/ox/session_upload_cmd.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -153,12 +154,21 @@ func buildSessionMeta(sessionPath, sessionName, projectRoot string, fileRefs map
 		}
 		return meta, nil
 	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		// meta.json exists but couldn't be read/parsed — refuse to proceed.
+		// Silently falling through to "construct from directory name" here
+		// would mint a fresh SessionID and rotate away from whatever
+		// identity the unreadable file held. See PreservedSessionID doc.
+		return nil, fmt.Errorf("read existing meta.json (refusing to silently rotate SessionID): %w", err)
+	}
 
 	// no existing meta.json — construct from directory name
 	ts, username, agentID := parseSessionDirName(sessionName)
 
+	rawPath := filepath.Join(sessionPath, ledgerFileRaw)
+
 	// count entries in raw.jsonl if present
-	entryCount := countJSONLLines(filepath.Join(sessionPath, ledgerFileRaw))
+	entryCount := countJSONLLines(rawPath)
 
 	// read summary if present
 	summary := readFileString(filepath.Join(sessionPath, ledgerFileSummaryMD))
@@ -168,8 +178,13 @@ func buildSessionMeta(sessionPath, sessionName, projectRoot string, fileRefs map
 		fileRefs = make(map[string]lfs.FileRef)
 	}
 
+	// durable ID via the shared resolver: no preserved meta.json exists (the
+	// read above returned NotExist), so the raw-header carrier is the only
+	// possible source before minting fresh.
+	sessionID := session.ResolveOrMintSessionID("", session.ReadHeaderSessionID(rawPath))
+
 	ep := endpoint.GetForProject(projectRoot)
-	return sessionMetaBase(sessionName, firstNonEmpty(username, identity.AttributionDisplayName(ep, config.GetDisplayName()), "unknown"), agentID, "unknown", ts, projectRoot).
+	return sessionMetaBase(sessionName, firstNonEmpty(username, identity.AttributionDisplayName(ep, config.GetDisplayName()), "unknown"), agentID, "unknown", ts, projectRoot, sessionID).
 		EntryCount(entryCount).
 		Summary(summary).
 		WithFiles(fileRefs).

--- a/cmd/ox/session_upload_cmd_test.go
+++ b/cmd/ox/session_upload_cmd_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/sessionid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -102,4 +104,66 @@ func TestFirstNonEmpty(t *testing.T) {
 	assert.Equal(t, "a", firstNonEmpty("a", "b"))
 	assert.Equal(t, "b", firstNonEmpty("", "b", "c"))
 	assert.Equal(t, "", firstNonEmpty("", ""))
+}
+
+// writeUploadTestRawHeader writes a minimal raw.jsonl carrying the ox
+// header format, optionally with a session_id, for buildSessionMeta tests.
+func writeUploadTestRawHeader(t *testing.T, rawPath, agentID, sessionID string) {
+	t.Helper()
+	metadata := map[string]any{
+		"version":    "1.0",
+		"agent_id":   agentID,
+		"agent_type": "claude-code",
+	}
+	if sessionID != "" {
+		metadata["session_id"] = sessionID
+	}
+	header := map[string]any{"type": "header", "metadata": metadata}
+	data, err := json.Marshal(header)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(rawPath, append(data, '\n'), 0644))
+}
+
+// TestBuildSessionMeta_HeaderIDPreservedWhenNoMetaJSON is the manual-upload
+// counterpart of the ox-5n8e fix: when meta.json is genuinely absent (a
+// session dir with only raw.jsonl, e.g. copied in by hand or left behind by
+// a partial upload), the SessionID already carried in the raw.jsonl header
+// must be reused, not discarded in favor of a fresh mint.
+func TestBuildSessionMeta_HeaderIDPreservedWhenNoMetaJSON(t *testing.T) {
+	sessionPath := t.TempDir()
+	const headerID = "ses_019f633e-29f3-7566-9ab4-a3da5b666fe5"
+	writeUploadTestRawHeader(t, filepath.Join(sessionPath, ledgerFileRaw), "OxUP01", headerID)
+
+	meta, err := buildSessionMeta(sessionPath, "2026-05-08T19-25-ajit-OxUP01", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, headerID, meta.SessionID, "must preserve the header-carried SessionID, not mint a new one")
+}
+
+// TestBuildSessionMeta_CorruptMetaJSONRefusesToMint mirrors the
+// unreadable-events-never-mints-new-id shape from the plan backfill
+// hardening (PR #723): an existing-but-corrupt meta.json must abort with an
+// error rather than silently falling through to "construct from directory
+// name", which would mint a fresh SessionID and rotate away from whatever
+// identity the unreadable file held.
+func TestBuildSessionMeta_CorruptMetaJSONRefusesToMint(t *testing.T) {
+	sessionPath := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, "meta.json"), []byte("{not valid json"), 0644))
+	writeUploadTestRawHeader(t, filepath.Join(sessionPath, ledgerFileRaw), "OxBAD2", "ses_019f633e-29f3-7566-9ab4-a3da5b666fe5")
+
+	meta, err := buildSessionMeta(sessionPath, "corrupt-meta-session", "", nil)
+	require.Error(t, err, "corrupt meta.json must refuse to build a fresh one")
+	assert.Nil(t, meta)
+}
+
+// TestBuildSessionMeta_NoIDAnywhereMintsExactlyOne covers the genuinely
+// first-publish case: no meta.json and no header SessionID (legacy
+// recording). Minting is the only correct behavior, and it must produce a
+// valid ID.
+func TestBuildSessionMeta_NoIDAnywhereMintsExactlyOne(t *testing.T) {
+	sessionPath := t.TempDir()
+	writeUploadTestRawHeader(t, filepath.Join(sessionPath, ledgerFileRaw), "OxLEG2", "")
+
+	meta, err := buildSessionMeta(sessionPath, "legacy-manual-session", "", nil)
+	require.NoError(t, err)
+	assert.True(t, sessionid.IsValidSessionID(meta.SessionID), "must mint a valid ses_<UUIDv7> when no ID exists anywhere, got %q", meta.SessionID)
 }

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/adapters"
-	"github.com/sageox/ox/internal/sessionid"
 	"github.com/sageox/ox/pkg/sessionsummary"
 	"github.com/sageox/ox/pkg/summaryeval"
 )
@@ -1248,10 +1247,7 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	if stored.Meta != nil {
 		headerID = stored.Meta.SessionID
 	}
-	sessionIDForMeta := session.ResolveSessionID(preservedSessionID, headerID)
-	if sessionIDForMeta == "" {
-		sessionIDForMeta = sessionid.GenerateSessionID()
-	}
+	sessionIDForMeta := session.ResolveOrMintSessionID(preservedSessionID, headerID)
 
 	// Failure-stub retry cap. Pre-fix, the daemon would re-finalize a
 	// session on every anti-entropy cycle whenever its title was empty,
@@ -2019,15 +2015,25 @@ func recoverRawFromSessionFile(logger *slog.Logger, recPath, sessionDir, rawPath
 
 	enc := json.NewEncoder(f)
 
-	// write header
+	// write header. state.SessionID (when present — post rollout, minted at
+	// StartRecording) MUST be carried into the reconstructed header: this
+	// raw.jsonl is the crash-safe carrier every later finalize path reads
+	// via ReadHeaderSessionID/ParseStoreMeta. Dropping it here would make
+	// writeMetaAndUploadLFS treat the session as having no durable ID and
+	// mint a fresh one, rotating away from an identity that may already be
+	// circulated (commit trailers, PR bodies) or cached server-side.
+	metaFields := map[string]any{
+		"schema_version": "1",
+		"agent_id":       state.AgentID,
+		"agent_type":     state.AdapterName,
+		"started_at":     state.StartedAt,
+		"recovered":      true,
+	}
+	if state.SessionID != "" {
+		metaFields["session_id"] = state.SessionID
+	}
 	header := map[string]any{
-		"_meta": map[string]any{
-			"schema_version": "1",
-			"agent_id":       state.AgentID,
-			"agent_type":     state.AdapterName,
-			"started_at":     state.StartedAt,
-			"recovered":      true,
-		},
+		"_meta": metaFields,
 	}
 	if err := enc.Encode(header); err != nil {
 		logger.Warn("recovery: failed to write header", "err", err)

--- a/internal/daemon/agentwork/session_finalize_misc_test.go
+++ b/internal/daemon/agentwork/session_finalize_misc_test.go
@@ -295,6 +295,77 @@ func TestRecoverRawFromSessionFile(t *testing.T) {
 		}
 	})
 
+	// TestRecoverRawFromSessionFile carries_forward_session_id_from_state
+	// guards the ox-5n8e root cause: .recording.json's SessionID (minted at
+	// StartRecording, post rollout) is the crash-safe carrier every later
+	// finalize path reads back out of the raw.jsonl header via
+	// ReadHeaderSessionID/ParseStoreMeta. If the reconstructed header drops
+	// it, writeMetaAndUploadLFS sees an empty headerID and — when no
+	// meta.json exists yet either — mints a brand new SessionID, rotating
+	// away from an identity that may already be circulated (commit
+	// trailers, PR bodies) or cached server-side. Two independent
+	// finalize attempts for the SAME session (e.g. two developer clones
+	// that both pull the orphaned raw.jsonl before either pushes a
+	// meta.json) would then each mint a different ID for identical content
+	// — exactly the two-session_id-values-for-one-session bug observed in
+	// production.
+	t.Run("carries_forward_session_id_from_state", func(t *testing.T) {
+		sessionDir := t.TempDir()
+		recPath := filepath.Join(sessionDir, recordingMarker)
+		rawPath := filepath.Join(sessionDir, artifactRaw)
+
+		sourceFile := filepath.Join(t.TempDir(), "session.jsonl")
+		startedAt := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+		writeSimpleJSONL(t, sourceFile, []time.Time{startedAt.Add(1 * time.Minute)})
+
+		const durableID = "ses_01890a5d-ac96-774b-bcce-b302099a8057"
+		writeRecordingState(t, recPath, session.RecordingState{
+			AgentID:     "OxSID1",
+			AdapterName: "test-mock",
+			SessionFile: sourceFile,
+			StartedAt:   startedAt,
+			SessionID:   durableID,
+		})
+
+		if !recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+			t.Fatal("expected recovery to succeed")
+		}
+
+		got := session.ReadHeaderSessionID(rawPath)
+		if got != durableID {
+			t.Errorf("reconstructed header lost the durable SessionID: want %q, got %q", durableID, got)
+		}
+	})
+
+	t.Run("no_session_id_in_state_yields_no_header_id", func(t *testing.T) {
+		// legacy recording (predates SessionID-at-birth minting): state has
+		// no SessionID, so the reconstructed header correctly carries none
+		// — nothing to preserve, and this must not error or invent one.
+		sessionDir := t.TempDir()
+		recPath := filepath.Join(sessionDir, recordingMarker)
+		rawPath := filepath.Join(sessionDir, artifactRaw)
+
+		sourceFile := filepath.Join(t.TempDir(), "session.jsonl")
+		startedAt := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+		writeSimpleJSONL(t, sourceFile, []time.Time{startedAt.Add(1 * time.Minute)})
+
+		writeRecordingState(t, recPath, session.RecordingState{
+			AgentID:     "OxSID0",
+			AdapterName: "test-mock",
+			SessionFile: sourceFile,
+			StartedAt:   startedAt,
+			// SessionID intentionally empty
+		})
+
+		if !recoverRawFromSessionFile(logger, recPath, sessionDir, rawPath) {
+			t.Fatal("expected recovery to succeed")
+		}
+
+		if got := session.ReadHeaderSessionID(rawPath); got != "" {
+			t.Errorf("expected no header SessionID for a legacy state with none, got %q", got)
+		}
+	})
+
 	t.Run("no_entries_after_start_time", func(t *testing.T) {
 		sessionDir := t.TempDir()
 		recPath := filepath.Join(sessionDir, recordingMarker)

--- a/internal/gitutil/cmd.go
+++ b/internal/gitutil/cmd.go
@@ -29,8 +29,19 @@ import (
 // git's output to classify failures (non-fast-forward, LFS, auth), which
 // breaks silently on a host whose locale renders git's messages translated.
 // See RunGit's comment in run.go for the full rationale.
+//
+// commit.gpgsign=false / tag.gpgsign=false: also matches RunGit (run.go).
+// Most network commands never commit, so this reads like a no-op — but
+// `git pull --rebase` does (internal/daemon/sync_managed.go), and a signing
+// prompt on the daemon's TTY-less environment kills that commit. The rebase
+// then sits halted with a CLEAN, conflict-free index: byte-identical to the
+// upstream-equivalent-commit halt that ResolveRebaseAcceptTheirs skips.
+// Skipping it would silently discard content that was resolved but never
+// recorded. Applied here rather than at the one committing call site so a
+// future network command that commits inherits the hardening by default.
 func NewNetworkCmd(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	gitArgs := append([]string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}, args...)
+	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C", "LANG=C")
 	return cmd
 }

--- a/internal/gitutil/cmd_test.go
+++ b/internal/gitutil/cmd_test.go
@@ -19,6 +19,34 @@ func TestNewNetworkCmd_DisablesPrompt(t *testing.T) {
 
 	assert.True(t, slices.Contains(cmd.Env, "GIT_TERMINAL_PROMPT=0"),
 		"network git commands must disable the interactive credential prompt")
-	// the args are passed through verbatim after the git binary
-	assert.Equal(t, []string{"git", "ls-remote", "origin"}, cmd.Args)
+	// caller args are passed through verbatim, after ox's own -c hardening
+	assert.Equal(t, []string{"ls-remote", "origin"}, cmd.Args[len(cmd.Args)-2:])
+}
+
+// TestNewNetworkCmd_DisablesCommitSigning covers the OTHER half of running
+// non-interactively: a git command that COMMITS must not stop for a signing
+// passphrase. `git pull --rebase` (internal/daemon/sync_managed.go) is the
+// network command that commits.
+//
+// Failure prevented: on a host whose git config enables passphrase-protected
+// commit signing, the daemon's pull-rebase commit dies for want of a TTY and
+// leaves the rebase halted with a CLEAN, conflict-free index — which is
+// byte-identical to the upstream-equivalent-commit halt that
+// ResolveRebaseAcceptTheirs skips. Skipping it would silently discard content
+// that was resolved but never recorded.
+func TestNewNetworkCmd_DisablesCommitSigning(t *testing.T) {
+	// asserted across the whole surface, not just the pull path: the point of
+	// the chokepoint is that a future network command that commits inherits
+	// the hardening rather than having to remember it.
+	for _, args := range [][]string{
+		{"pull", "--rebase", "--autostash"},
+		{"-C", "/tmp/example", "fetch", "--quiet"},
+		{"ls-remote", "origin"},
+	} {
+		cmd := NewNetworkCmd(context.Background(), args...)
+		assert.True(t, slices.Contains(cmd.Args, "commit.gpgsign=false"),
+			"commit signing must be disabled for %v", args)
+		assert.True(t, slices.Contains(cmd.Args, "tag.gpgsign=false"),
+			"tag signing must be disabled for %v", args)
+	}
 }

--- a/internal/gitutil/cmd_test.go
+++ b/internal/gitutil/cmd_test.go
@@ -38,15 +38,28 @@ func TestNewNetworkCmd_DisablesCommitSigning(t *testing.T) {
 	// asserted across the whole surface, not just the pull path: the point of
 	// the chokepoint is that a future network command that commits inherits
 	// the hardening rather than having to remember it.
-	for _, args := range [][]string{
-		{"pull", "--rebase", "--autostash"},
-		{"-C", "/tmp/example", "fetch", "--quiet"},
-		{"ls-remote", "origin"},
+	// Asserts the COMPLETE argv, not just membership: `-c` is positional and
+	// must immediately precede its key=value, so a slices.Contains check would
+	// still pass on an unpaired or misordered flag that git silently rejects.
+	for _, tc := range []struct {
+		args []string
+		want []string
+	}{
+		{
+			args: []string{"pull", "--rebase", "--autostash"},
+			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "pull", "--rebase", "--autostash"},
+		},
+		{
+			args: []string{"-C", "/tmp/example", "fetch", "--quiet"},
+			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "-C", "/tmp/example", "fetch", "--quiet"},
+		},
+		{
+			args: []string{"ls-remote", "origin"},
+			want: []string{"git", "-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "ls-remote", "origin"},
+		},
 	} {
-		cmd := NewNetworkCmd(context.Background(), args...)
-		assert.True(t, slices.Contains(cmd.Args, "commit.gpgsign=false"),
-			"commit signing must be disabled for %v", args)
-		assert.True(t, slices.Contains(cmd.Args, "tag.gpgsign=false"),
-			"tag signing must be disabled for %v", args)
+		cmd := NewNetworkCmd(context.Background(), tc.args...)
+		assert.Equal(t, tc.want, cmd.Args,
+			"signing must be disabled ahead of the caller's verbatim args for %v", tc.args)
 	}
 }

--- a/internal/gitutil/rebase_resolve.go
+++ b/internal/gitutil/rebase_resolve.go
@@ -290,8 +290,17 @@ func rebaseStepIsEmpty(ctx context.Context, repoPath string) bool {
 // runRebaseStep runs a `git rebase <arg>` with the editor disabled so git never
 // blocks waiting for a commit message, and with the C locale pinned so any
 // diagnostic we do read is stable regardless of the user's language settings.
+//
+// commit.gpgsign=false / tag.gpgsign=false mirror RunGit's hardening (run.go).
+// `--continue` COMMITS, so a repo whose config enables passphrase-protected
+// signing makes it hang or die on a TTY-less daemon. The rebase is then left
+// halted with a clean, conflict-free index — indistinguishable from the
+// upstream-equivalent-commit halt that advanceNonConflictRebaseStep skips, and
+// skipping it would discard a resolution that was staged but never recorded.
+// Matters more now that this runs in a loop that can fire hundreds of times.
 func runRebaseStep(ctx context.Context, repoPath, arg string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rebase", arg)
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", "rebase", arg)
 	cmd.Dir = repoPath
 	cmd.Env = append(cmd.Environ(), "GIT_EDITOR=true", "LC_ALL=C", "LANG=C")
 	out, err := cmd.CombinedOutput()

--- a/internal/session/session_id_birth_test.go
+++ b/internal/session/session_id_birth_test.go
@@ -44,6 +44,54 @@ func TestStartRecording_MintsSessionIDAtBirth(t *testing.T) {
 	assert.Equal(t, state.SessionID, reloaded.SessionID)
 }
 
+// TestStartRecording_EveryRecordingGetsItsOwnID verifies the other half of
+// the birth contract: the ID is minted PER RECORDING, never shared or carried
+// over. TestStartRecording_MintsSessionIDAtBirth only proves one recording
+// gets a valid ID — a StartRecording that returned a package-level constant,
+// or reused whatever the previous recording left on disk, would still pass it.
+//
+// Failure prevented: two distinct recordings resolving to one /c/<ses_id>
+// conversation. Every consumer treats the ID as a unique key — the server-side
+// dedup key, the SageOx-Session commit trailer, plan provenance — so a
+// collision silently merges two unrelated sessions rather than erroring.
+func TestStartRecording_EveryRecordingGetsItsOwnID(t *testing.T) {
+	cacheDir := t.TempDir()
+	projectRoot := setupRecordingTest(t, cacheDir)
+
+	sessionFile := filepath.Join(t.TempDir(), "session.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte("{}\n"), 0644))
+
+	// The repeated OxSaMe entries are the case that matters: a single agent
+	// recording, stopping, and recording again. Session directory names are
+	// minute-granular and include the agent ID, so consecutive starts by one
+	// agent can land on the SAME directory name — the shape most likely to
+	// carry an identity forward. (Two concurrent recordings for one agent are
+	// already impossible; StartRecording rejects that outright.)
+	seen := make(map[string]string)
+	for _, agentID := range []string{"OxSaMe", "OxOthr", "OxSaMe", "OxSaMe"} {
+		state, err := StartRecording(projectRoot, StartRecordingOptions{
+			AgentID:     agentID,
+			AdapterName: "claude-code",
+			SessionFile: sessionFile,
+			Username:    "testuser",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		require.True(t, sessionid.IsValidSessionID(state.SessionID),
+			"every recording must mint a valid ses_ ID, got %q", state.SessionID)
+
+		prior, dup := seen[state.SessionID]
+		require.False(t, dup,
+			"recording for agent %s reused the ID minted for agent %s: %s",
+			agentID, prior, state.SessionID)
+		seen[state.SessionID] = agentID
+
+		_, err = StopRecording(projectRoot, agentID)
+		require.NoError(t, err)
+	}
+	assert.Len(t, seen, 4, "each StartRecording must contribute a distinct ID")
+}
+
 // TestRecordingState_LegacyJSONWithoutSessionID verifies recordings started
 // under an older binary (no session_id field) load with an empty ID so every
 // emitter falls back to the name-based URL instead of crashing or inventing

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -954,6 +954,22 @@ func ResolveSessionID(preserved, startMinted string) string {
 	return startMinted
 }
 
+// ResolveOrMintSessionID applies ResolveSessionID precedence and mints a
+// fresh ses_<UUIDv7> only when neither a preserved nor a start-minted ID
+// exists (a legacy recording with no durable identity anywhere). This is
+// the single chokepoint for "mint as last resort" — every meta.json writer
+// (CLI stop, CLI recover, doctor retry-upload, manual upload, daemon
+// finalize) must resolve its SessionID through this function rather than
+// minting inline, so a call site can never accidentally skip past a
+// preserved or header-carried ID and rotate an identity that already
+// exists.
+func ResolveOrMintSessionID(preserved, startMinted string) string {
+	if resolved := ResolveSessionID(preserved, startMinted); resolved != "" {
+		return resolved
+	}
+	return sessionid.GenerateSessionID()
+}
+
 // ReadHeaderSessionID returns the ses_ ID carried in the first-line header
 // of the raw.jsonl at path, or "" for legacy/foreign/absent headers. This is
 // the crash-safe-carrier read for paths where .recording.json is already


### PR DESCRIPTION
## What broke

A recorded session's `ses_` id is its permanent identity. It is written into `sessions/<name>/meta.json`, and copies of it are minted **during** the session and leak into places that can never be edited afterward: `SageOx-Session` commit trailers, PR bodies, plan `provenance.session_id`, and the server-side dedup key.

Three code paths could assign a **second, different** id to a session that already had one. Once that happens, every already-circulated reference points at an identity `meta.json` no longer agrees with — and `filterPRLinkMisses` exact-matches the trailer, so it silently discards repair work rather than reporting a mismatch.

Found on a real ledger: **26 of 33 conflicting `meta.json` files differed in `session_id` and nothing else.** Because that field is a genuine content divergence no merge can reconcile, `pull --rebase` halted on them and the ledger could not sync at all.

```mermaid
flowchart TD
    A["session records"] --> B["ses_ id minted at start<br/>written to raw.jsonl header"]
    B --> C["id copied into commit trailer,<br/>PR body, plan provenance"]
    B --> D["upload to ledger"]
    D -->|"push fails"| E["orphan, retried later"]
    E --> F["retry never reads the header id"]
    F --> G["mints a SECOND id into meta.json"]
    G --> H["meta.json disagrees with<br/>every circulated copy"]
    C --> H
```

## Root causes

- **`retrySessionUpload`** checked only `PreservedSessionID` (the ledger's `meta.json`) and never `orphan.Meta.SessionID` (the raw.jsonl header). `findOrphanedSessions` filters out anything already uploaded, so `meta.json` is **always** absent for an orphan by construction — meaning every retry minted fresh. This path is also the one that stamps `stop_reason: "recovered"`, matching the production evidence.
- **`recoverRawFromSessionFile`** rebuilt the raw.jsonl header from `state` but dropped `state.SessionID`, though the field was right there in the same struct. Downstream then saw no durable id and minted.
- **`buildSessionMeta`** treated a corrupt/unreadable `meta.json` the same as an absent one, rotating an id it had merely failed to parse.

## What this PR ships

- **The invariant is now structural, not a per-call-site guard.** `session.ResolveOrMintSessionID` is the single chokepoint (preserved → start-minted/header → mint only as a last resort), and `sessionMetaBase` now **requires** a resolved id as a parameter. A caller can no longer silently skip resolution — the old signature defaulted to a fresh mint and relied on every caller remembering to override it, which is exactly how this bug happened.
- **`ox doctor` gained a detection check** comparing each session's `meta.json` id against its raw.jsonl header. **Report-only, deliberately.** The header looks authoritative — it is minted first and is what leaked externally — but `resolveOrphanSessionID` shows `meta.json` legitimately wins when a prior retry stamped it before crashing on push, and which id already shipped cannot be determined locally without an API round trip. A wrong auto-repair would re-diverge the ledger from what already circulated: the same failure the check exists to catch. A test fails if `FixLevel` ever drifts to `Auto`.
- **Commit signing is disabled for git commands that commit unattended** — `NewNetworkCmd` (used by the daemon's `pull --rebase`) and `runRebaseStep` (`--continue`/`--skip`), matching `RunGit`'s existing hardening. A signing passphrase prompt on a TTY-less daemon leaves a rebase halted with a *clean, conflict-free index*, which is byte-identical to the upstream-equivalent-commit halt that `advanceNonConflictRebaseStep` skips. Skipping that would discard a resolution that was staged but never recorded.
- **Session-marker PID tests get an isolated directory.** `SessionMarkerDir()` is one global dir shared by the whole package *and* the developer's real ox install; `FindSessionMarkerByPID` returns the first `os.ReadDir` match. Several test files write markers keyed on `os.Getpid()`, so the winner was filename ordering.

## Test Plan

- [x] `make lint` — 0 issues
- [x] `make test-all` — pass
- [x] Every fix red-checked: neutered individually, confirmed the test goes red, restored
  - ignoring the header id in `resolveOrphanSessionID` → `TestResolveOrphanSessionID_HeaderIDPreservedWhenNoLedgerMetaYet` fails with a freshly-minted id, reproducing the production symptom exactly
  - re-enabling auto-fix on the doctor check → `TestCheckSessionIDDivergence_RegisteredCheckOnly` fails
  - removing the marker isolation → the new test fails with the competing marker's `AgentID`, which is how the flake was originally diagnosed
- [x] Negative pairs included: a corrupt `meta.json` must **refuse** rather than mint; a genuinely empty one still mints exactly one
- [x] Legacy sessions predating id-at-start carry no header id — verified they are skipped, not reported as broken

### Known-red on main (not introduced here)

`make test-slow` has 5 failures: `TestDistillGitHubFacts_DeterministicNamesConflict`, `TestDistillGitHubFacts_UUID7PreventsConflict`, `TestDistillHistoryRead_JR10_SinceJsonFormat_ParallelBodies`, `TestIncrementalE2E_SingleAgent`, `TestIncrementalE2E_CtrlC_AntiEntropy`.

All five fail identically on a clean `origin/main` worktree — verified before opening this PR. Pre-existing, unrelated to this diff, and worth its own issue.

## Notes for the reviewer

The cloud half of this bug lives in `sageox-monorepo` and is **not** fixed here — the cloud derives a different id (UUIDv5 from repo + session name) and, because of a struct-tag typo, was structurally unable to read the CLI's id at all. That is tracked separately; unifying the two identities is a real migration against `share_links` and `conversations`, not a bug fix.

Co-Authored-By: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `ox doctor` adds a detect-only *session-id-divergence* warning when a session’s `meta.json` and `raw.jsonl` IDs don’t match.
- **Bug Fixes**
  - Session IDs are now consistently preserved across uploads, retries, and recovery (reducing session-id rotation).
  - Upload fails fast if `meta.json` is corrupt.
  - Network Git operations and rebase steps disable commit/tag GPG signing to prevent hangs.
  - Ledger sync no longer stalls on systems requiring a signing passphrase.
- **Tests**
  - Expanded session-id divergence, orphan-session resolution, recovery preservation, and test isolation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->