### PR TITLE
feat(status): per-KB cards with path and sync status in ox status

### DIFF
--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -871,10 +871,11 @@ func renderGitReposSection(localCfg *config.LocalConfig, projectRoot string, dae
 		b.WriteString("\n")
 	}
 
-	// Knowledge bubbles — count-only summary of real KB-API rows. Team
-	// contexts are conversation stores, not bubbles (ox ADR-028), and render
-	// in their own section below.
-	b.WriteString(renderBubblesLine(bubblesSummary))
+	// Knowledge bubbles — summary line plus one card per KB-API row with
+	// its mount path and sync status. Team contexts are conversation
+	// stores, not bubbles (ox ADR-028), and render in their own section
+	// below.
+	b.WriteString(renderBubblesSection(bubblesSummary, daemonStatus))
 
 	// Other team contexts — restored under ox ADR-028 (epic ox-gmkd) after
 	// the bubble-listing detour. Cards reuse renderCloudTC/renderDetailTC

--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -371,7 +371,9 @@ func buildBubblesJSON(s statusBubblesSummary) *status.BubblesJSON {
 			case r.Bubble.LifecycleState == kbLifecycleProvisioning:
 				syncStatus = "provisioning"
 			case r.Bubble.LifecycleState == kbLifecycleProvisionFailed:
-				syncStatus = "provision failed"
+				// same wording as the human card ("✗ provisioning failed")
+				// minus the glyph — one status vocabulary across formats.
+				syncStatus = "provisioning failed"
 			default:
 				syncStatus = "not cloned"
 			}

--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -1,24 +1,27 @@
 package main
 
-// status_bubbles.go — `ox status` knowledge-bubbles summary line.
+// status_bubbles.go — `ox status` knowledge-bubbles section.
 //
-// One scannable line sourced from the KB API (the only source of bubble
-// rows under ox ADR-028). Team contexts and ledgers are conversation
-// stores with their own status sections — they are not bubbles and do
-// not appear in this count.
+// Sourced from the KB API (the only source of bubble rows under ox
+// ADR-028). Team contexts and ledgers are conversation stores with their
+// own status sections — they are not bubbles and do not appear here.
 //
-// Format:
+// The section opens with a scannable summary line:
 //
 //	Knowledge bubbles: <total> (<n> personal, <n> profile, <n> team, <n> repo[, <n> custom][, <n> unknown])
 //
-// Zero buckets are omitted. Total=0 collapses to `Knowledge bubbles: 0`
-// (no parens). Fetch errors degrade gracefully to `(unavailable)` so the
-// rest of `ox status` still renders.
+// followed by one card per bubble (personal-scope rows first, then the
+// project team's) showing the local mount path (paths.KBDir) and its sync
+// status, mirroring the Ledger / Team Context cards. Zero buckets are
+// omitted from the summary. Total=0 collapses to `Knowledge bubbles: 0`
+// (no parens, no cards). Fetch errors degrade gracefully to
+// `(unavailable)` so the rest of `ox status` still renders.
 
 import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -26,7 +29,9 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/kb"
+	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/status"
 )
 
@@ -40,6 +45,11 @@ type statusBubblesSummary struct {
 	// non-zero buckets appear so order-of-iteration callers can skip the
 	// is-zero check.
 	ByType map[string]int
+
+	// Bubbles are the raw fetched rows, kept so the section renderer and
+	// JSON emitter can show per-bubble cards (path + sync status), not
+	// just counts.
+	Bubbles []kb.Bubble
 
 	// Warnings are non-fatal errors from the KB fetch.
 	Warnings []kb.Warning
@@ -84,6 +94,7 @@ func summarizeBubbles(res kb.ListResult) statusBubblesSummary {
 	return statusBubblesSummary{
 		Total:    len(res.Bubbles),
 		ByType:   by,
+		Bubbles:  res.Bubbles,
 		Warnings: res.Warnings,
 	}
 }
@@ -171,6 +182,133 @@ func renderBubblesLine(s statusBubblesSummary) string {
 	return b.String()
 }
 
+// statusBubbleRow is one bubble plus its derived local state: where the
+// checkout lives (canonical paths.KBDir keyed by kb_id) and what git says
+// about it. Computed once so the human renderer and JSON emitter agree.
+type statusBubbleRow struct {
+	Bubble kb.Bubble
+	Path   string
+	Cloned bool
+	Git    gitRepoStatus
+}
+
+// statusKBDirForBubble resolves a bubble's canonical checkout directory.
+// Seam variable so tests can point rows at a temp dir without endpoint
+// plumbing; production is paths.KBDir.
+var statusKBDirForBubble = func(kbID string) string {
+	return paths.KBDir(kbID)
+}
+
+// collectBubbleRows derives per-bubble local state from a summary. Sync
+// times layer the same way as the team-context cards: daemon (freshest)
+// via LastSyncForPath, else none. Rows sort personal-scope first, then by
+// type priority, then slug, so a user's own bubbles lead the section.
+// Safe with a nil daemonStatus (JSON path).
+func collectBubbleRows(s statusBubblesSummary, daemonStatus *daemon.StatusData) []statusBubbleRow {
+	rows := make([]statusBubbleRow, 0, len(s.Bubbles))
+	for _, bub := range s.Bubbles {
+		row := statusBubbleRow{Bubble: bub, Path: bub.LocalPath}
+		if row.Path == "" && bub.KBID != "" {
+			row.Path = statusKBDirForBubble(bub.KBID)
+		}
+		if row.Path != "" {
+			if _, err := os.Stat(filepath.Join(row.Path, ".git")); err == nil {
+				row.Cloned = true
+				lastSync, hasSync := daemonStatus.LastSyncForPath(row.Path)
+				row.Git = getGitRepoStatus(row.Path, lastSync, hasSync)
+			}
+		}
+		rows = append(rows, row)
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		bi, bj := rows[i].Bubble, rows[j].Bubble
+		if ri, rj := bubbleScopeRank(bi.ScopeType), bubbleScopeRank(bj.ScopeType); ri != rj {
+			return ri < rj
+		}
+		if pi, pj := kbTypePriority(bi.Type), kbTypePriority(bj.Type); pi != pj {
+			return pi < pj
+		}
+		return bi.Slug < bj.Slug
+	})
+	return rows
+}
+
+// bubbleScopeRank orders personal-scope ("user") bubbles ahead of
+// team-scope ones. Unknown scope types trail with team.
+func bubbleScopeRank(scopeType string) int {
+	if scopeType == "user" {
+		return 0
+	}
+	return 1
+}
+
+// renderBubblesSection renders the full knowledge-bubbles block: the
+// summary line, then one card per bubble in the Ledger / Team Context
+// card style — name, type + slug, mount path, and sync status, with the
+// same staleness warning and not-cloned repair hint the team-context
+// cards show.
+func renderBubblesSection(s statusBubblesSummary, daemonStatus *daemon.StatusData) string {
+	var b strings.Builder
+	b.WriteString(renderBubblesLine(s))
+	if s.Unavailable || len(s.Bubbles) == 0 {
+		return b.String()
+	}
+
+	bootstrapping := daemonStatus.IsBootstrapping()
+	for _, r := range collectBubbleRows(s, daemonStatus) {
+		bub := r.Bubble
+		name := bub.Name
+		if name == "" {
+			name = bub.Slug
+		}
+		if name == "" {
+			name = bub.KBID
+		}
+		b.WriteString("\n")
+		b.WriteString(statusLabelStyle.Render("KB"))
+		b.WriteString(statusValueStyle.Render(name))
+		b.WriteString("\n")
+
+		b.WriteString(statusLabelStyle.Render("  Type"))
+		b.WriteString(statusValueStyle.Render(formatKBType(bub.Type)))
+		if bub.Slug != "" {
+			b.WriteString(" ")
+			b.WriteString(renderSlugRef("#", bub.Slug))
+		}
+		b.WriteString("\n")
+
+		if r.Path != "" {
+			b.WriteString(statusLabelStyle.Render("  Path"))
+			b.WriteString(statusMutedStyle.Render(shortenHome(r.Path)))
+			b.WriteString("\n")
+		}
+
+		b.WriteString(statusLabelStyle.Render("  Status"))
+		b.WriteString(renderBubbleStatus(r.Git, r.Cloned, bootstrapping))
+		b.WriteString("\n")
+
+		if r.Cloned {
+			// staleness warning, same threshold as the team-context cards
+			syncState := daemon.LoadSyncState(r.Path)
+			if syncState.IsStale(daemon.DefaultStalenessThreshold) && !syncState.LastSync.IsZero() {
+				b.WriteString(statusLabelStyle.Render(""))
+				b.WriteString(statusWarningStyle.Render(fmt.Sprintf("⚠ stale (last sync %s)", status.FormatTimeAgo(syncState.LastSync))))
+				b.WriteString("\n")
+			}
+		} else if !bootstrapping {
+			if bub.RepoURL != "" {
+				b.WriteString(statusLabelStyle.Render("  Remote"))
+				b.WriteString(statusMutedStyle.Render(bub.RepoURL))
+				b.WriteString("\n")
+			}
+			b.WriteString(statusLabelStyle.Render(""))
+			b.WriteString(statusMutedStyle.Render("Run 'ox doctor --fix' to clone"))
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
 // buildBubblesJSON converts a summary into the BubblesJSON payload. Uses
 // status.BubblesJSON directly so the shape stays in sync with the type
 // declared in internal/status/types.go.
@@ -193,6 +331,28 @@ func buildBubblesJSON(s statusBubblesSummary) *status.BubblesJSON {
 		out.ByType = make(map[string]int, len(s.ByType))
 		for k, v := range s.ByType {
 			out.ByType[k] = v
+		}
+	}
+	if len(s.Bubbles) > 0 {
+		// nil daemonStatus: JSON reports git-derived state; the freshest
+		// daemon sync time only refines the human status cell.
+		rows := collectBubbleRows(s, nil)
+		out.Bubbles = make([]status.BubbleJSON, 0, len(rows))
+		for _, r := range rows {
+			syncStatus := "not cloned"
+			if r.Cloned {
+				syncStatus, _ = status.FormatGitRepoStatus(r.Git)
+			}
+			out.Bubbles = append(out.Bubbles, status.BubbleJSON{
+				KBID:       r.Bubble.KBID,
+				Type:       jsonTypeForBubble(r.Bubble.Type),
+				Slug:       r.Bubble.Slug,
+				Name:       r.Bubble.Name,
+				ScopeType:  r.Bubble.ScopeType,
+				Path:       r.Path,
+				Cloned:     r.Cloned,
+				SyncStatus: syncStatus,
+			})
 		}
 	}
 	if len(s.Warnings) > 0 {

--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -242,6 +242,21 @@ func bubbleScopeRank(scopeType string) int {
 	return 1
 }
 
+// kbLifecycleProvisioning is the lifecycle_state for a bubble whose
+// server-side repo is still being created. The failed counterpart
+// (kbLifecycleProvisionFailed) is declared in doctor_kb.go; "active" and
+// unknown/empty values are treated as cloneable.
+const kbLifecycleProvisioning = "provisioning"
+
+// bubbleCloneable reports whether an unmounted bubble can actually be
+// cloned — i.e. the server has (or should have) a repo for it. While
+// provisioning is in flight or has failed there is nothing for
+// `ox doctor --fix` to clone, so the repair hint must not appear.
+func bubbleCloneable(b kb.Bubble) bool {
+	return b.LifecycleState != kbLifecycleProvisioning &&
+		b.LifecycleState != kbLifecycleProvisionFailed
+}
+
 // renderBubblesSection renders the full knowledge-bubbles block: the
 // summary line, then one card per bubble in the Ledger / Team Context
 // card style — name, type + slug, mount path, and sync status, with the
@@ -284,7 +299,17 @@ func renderBubblesSection(s statusBubblesSummary, daemonStatus *daemon.StatusDat
 		}
 
 		b.WriteString(statusLabelStyle.Render("  Status"))
-		b.WriteString(renderBubbleStatus(r.Git, r.Cloned, bootstrapping))
+		switch {
+		case !r.Cloned && bub.LifecycleState == kbLifecycleProvisioning:
+			// no checkout AND the server hasn't finished provisioning the
+			// repo — a clone hint would send doctor after a repo that does
+			// not exist yet.
+			b.WriteString(statusMutedStyle.Render("⟳ provisioning"))
+		case !r.Cloned && bub.LifecycleState == kbLifecycleProvisionFailed:
+			b.WriteString(statusErrorStyle.Render("✗ provisioning failed"))
+		default:
+			b.WriteString(renderBubbleStatus(r.Git, r.Cloned, bootstrapping))
+		}
 		b.WriteString("\n")
 
 		if r.Cloned {
@@ -295,7 +320,7 @@ func renderBubblesSection(s statusBubblesSummary, daemonStatus *daemon.StatusDat
 				b.WriteString(statusWarningStyle.Render(fmt.Sprintf("⚠ stale (last sync %s)", status.FormatTimeAgo(syncState.LastSync))))
 				b.WriteString("\n")
 			}
-		} else if !bootstrapping {
+		} else if !bootstrapping && bubbleCloneable(bub) {
 			if bub.RepoURL != "" {
 				b.WriteString(statusLabelStyle.Render("  Remote"))
 				b.WriteString(statusMutedStyle.Render(bub.RepoURL))
@@ -339,9 +364,16 @@ func buildBubblesJSON(s statusBubblesSummary) *status.BubblesJSON {
 		rows := collectBubbleRows(s, nil)
 		out.Bubbles = make([]status.BubbleJSON, 0, len(rows))
 		for _, r := range rows {
-			syncStatus := "not cloned"
-			if r.Cloned {
+			var syncStatus string
+			switch {
+			case r.Cloned:
 				syncStatus, _ = status.FormatGitRepoStatus(r.Git)
+			case r.Bubble.LifecycleState == kbLifecycleProvisioning:
+				syncStatus = "provisioning"
+			case r.Bubble.LifecycleState == kbLifecycleProvisionFailed:
+				syncStatus = "provision failed"
+			default:
+				syncStatus = "not cloned"
 			}
 			out.Bubbles = append(out.Bubbles, status.BubbleJSON{
 				KBID:       r.Bubble.KBID,

--- a/cmd/ox/status_bubbles_test.go
+++ b/cmd/ox/status_bubbles_test.go
@@ -509,6 +509,63 @@ func TestRenderBubblesSection_CardsShowPathAndStatus(t *testing.T) {
 	assert.Less(t, meIdx, engIdx, "personal-scope card must render before the team-scope card")
 }
 
+// TestRenderBubblesSection_ProvisioningSuppressesCloneHint verifies that
+// unmounted bubbles still being provisioned (or whose provisioning
+// failed) do NOT show the "Run 'ox doctor --fix' to clone" hint — there
+// is no repo to clone yet, so the hint would send the user (and doctor)
+// after a repo that does not exist.
+//
+// Failure prevented: a provisioning bubble renders the misleading clone
+// hint; the user runs doctor, the clone fails, and the failure looks
+// like an ox bug instead of an in-flight server operation.
+func TestRenderBubblesSection_ProvisioningSuppressesCloneHint(t *testing.T) {
+	fakeKBStore(t)
+
+	s := summarizeBubbles(kb.ListResult{
+		Bubbles: []kb.Bubble{
+			{KBID: "kb_prov", Type: api.KBTypeTeam, Slug: "prov", Name: "Provisioning Bubble",
+				ScopeType: "team", LifecycleState: "provisioning"},
+			{KBID: "kb_dead", Type: api.KBTypeTeam, Slug: "dead", Name: "Failed Bubble",
+				ScopeType: "team", LifecycleState: "provision-failed"},
+		},
+	})
+	clean := stripANSIBubbles(renderBubblesSection(s, nil))
+
+	assert.Contains(t, clean, "⟳ provisioning")
+	assert.Contains(t, clean, "✗ provisioning failed")
+	assert.NotContains(t, clean, "Run 'ox doctor --fix' to clone",
+		"clone hint must be suppressed while there is no repo to clone")
+	assert.NotContains(t, clean, "not cloned")
+}
+
+// TestBuildBubblesJSON_LifecycleSyncStatus verifies the JSON sync_status
+// distinguishes provisioning states from a plain missing clone.
+//
+// Failure prevented: scriptable consumers treat an in-flight provisioning
+// bubble as a broken mount and trigger spurious repair automation.
+func TestBuildBubblesJSON_LifecycleSyncStatus(t *testing.T) {
+	fakeKBStore(t)
+
+	s := summarizeBubbles(kb.ListResult{
+		Bubbles: []kb.Bubble{
+			{KBID: "kb_prov", Type: api.KBTypeTeam, Slug: "prov", ScopeType: "team", LifecycleState: "provisioning"},
+			{KBID: "kb_dead", Type: api.KBTypeTeam, Slug: "dead", ScopeType: "team", LifecycleState: "provision-failed"},
+			{KBID: "kb_gone", Type: api.KBTypeTeam, Slug: "gone", ScopeType: "team", LifecycleState: "active"},
+		},
+	})
+	js := buildBubblesJSON(s)
+	require.NotNil(t, js)
+	require.Len(t, js.Bubbles, 3)
+
+	byID := map[string]string{}
+	for _, b := range js.Bubbles {
+		byID[b.KBID] = b.SyncStatus
+	}
+	assert.Equal(t, "provisioning", byID["kb_prov"])
+	assert.Equal(t, "provision failed", byID["kb_dead"])
+	assert.Equal(t, "not cloned", byID["kb_gone"])
+}
+
 // TestRenderBubblesSection_NoCardsWhenEmptyOrUnavailable verifies the
 // degraded cases stay a single line — no stray card scaffolding.
 //

--- a/cmd/ox/status_bubbles_test.go
+++ b/cmd/ox/status_bubbles_test.go
@@ -9,6 +9,8 @@ package main
 
 import (
 	"context"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -415,6 +417,147 @@ func TestRenderBubbleStatus(t *testing.T) {
 
 	notCloned := stripANSIBubbles(renderBubbleStatus(gitRepoStatus{}, false, false))
 	assert.Equal(t, "⚠ not cloned", notCloned)
+}
+
+// fakeKBStore redirects statusKBDirForBubble at a temp dir for the duration
+// of the test and returns it. Tests using it must NOT be parallel — the seam
+// is a package global.
+func fakeKBStore(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := statusKBDirForBubble
+	statusKBDirForBubble = func(kbID string) string {
+		return filepath.Join(dir, kbID)
+	}
+	t.Cleanup(func() { statusKBDirForBubble = orig })
+	return dir
+}
+
+// gitInitKB creates a real (empty) git repo at dir/kbID so getGitRepoStatus
+// exercises the actual clone-detection path, not a stubbed .git marker.
+func gitInitKB(t *testing.T, dir, kbID string) string {
+	t.Helper()
+	path := filepath.Join(dir, kbID)
+	cmd := exec.Command("git", "init", "-q", path)
+	cmd.Dir = dir
+	require.NoError(t, cmd.Run())
+	return path
+}
+
+// TestCollectBubbleRows_PathAndSortOrder verifies each row resolves its
+// canonical checkout path from the kb_id, detects clone state from a real
+// git repo, and that personal-scope rows sort ahead of team-scope ones.
+//
+// Failure prevented: the section lists a team bubble first (burying the
+// user's own bubbles), points Path at the wrong directory, or reports a
+// cloned bubble as missing after a path-resolution refactor.
+func TestCollectBubbleRows_PathAndSortOrder(t *testing.T) {
+	store := fakeKBStore(t)
+	clonedPath := gitInitKB(t, store, "kb_team")
+
+	s := summarizeBubbles(kb.ListResult{
+		Bubbles: []kb.Bubble{
+			{KBID: "kb_team", Type: api.KBTypeTeam, Slug: "eng", ScopeType: "team"},
+			{KBID: "kb_me", Type: api.KBTypePersonal, Slug: "me", ScopeType: "user"},
+		},
+	})
+	rows := collectBubbleRows(s, nil)
+	require.Len(t, rows, 2)
+
+	assert.Equal(t, "kb_me", rows[0].Bubble.KBID, "personal-scope bubble must sort first")
+	assert.False(t, rows[0].Cloned)
+	assert.Equal(t, filepath.Join(store, "kb_me"), rows[0].Path)
+
+	assert.Equal(t, "kb_team", rows[1].Bubble.KBID)
+	assert.True(t, rows[1].Cloned, "a real git checkout must be detected as cloned")
+	assert.Equal(t, clonedPath, rows[1].Path)
+}
+
+// TestRenderBubblesSection_CardsShowPathAndStatus verifies the human
+// output: the summary line stays, and each bubble gets a card with name,
+// type + slug, mount path, and a sync-status cell — with the doctor hint
+// and remote URL on not-cloned rows.
+//
+// Failure prevented: the section regresses to the count-only line, or a
+// not-cloned bubble renders without the repair path users need.
+func TestRenderBubblesSection_CardsShowPathAndStatus(t *testing.T) {
+	store := fakeKBStore(t)
+	gitInitKB(t, store, "kb_team")
+
+	s := summarizeBubbles(kb.ListResult{
+		Bubbles: []kb.Bubble{
+			{KBID: "kb_team", Type: api.KBTypeTeam, Slug: "eng", Name: "Engineering Bubble", ScopeType: "team"},
+			{KBID: "kb_me", Type: api.KBTypePersonal, Slug: "me", Name: "My Bubble", ScopeType: "user",
+				RepoURL: "https://git.sageox.ai/kb/kb_me.git"},
+		},
+	})
+	clean := stripANSIBubbles(renderBubblesSection(s, nil))
+
+	assert.Contains(t, clean, "Knowledge bubbles", "summary line must survive the section expansion")
+	assert.Contains(t, clean, "Engineering Bubble")
+	assert.Contains(t, clean, "#eng")
+	assert.Contains(t, clean, filepath.Join(store, "kb_team"))
+	assert.Contains(t, clean, "✓", "cloned clean bubble must show a success cell")
+
+	assert.Contains(t, clean, "My Bubble")
+	assert.Contains(t, clean, "⚠ not cloned")
+	assert.Contains(t, clean, "https://git.sageox.ai/kb/kb_me.git")
+	assert.Contains(t, clean, "Run 'ox doctor --fix' to clone")
+
+	meIdx := strings.Index(clean, "My Bubble")
+	engIdx := strings.Index(clean, "Engineering Bubble")
+	assert.Less(t, meIdx, engIdx, "personal-scope card must render before the team-scope card")
+}
+
+// TestRenderBubblesSection_NoCardsWhenEmptyOrUnavailable verifies the
+// degraded cases stay a single line — no stray card scaffolding.
+//
+// Failure prevented: an unavailable fetch or empty list renders orphaned
+// "KB"/"Status" labels under the summary line.
+func TestRenderBubblesSection_NoCardsWhenEmptyOrUnavailable(t *testing.T) {
+	t.Parallel()
+
+	empty := stripANSIBubbles(renderBubblesSection(statusBubblesSummary{}, nil))
+	assert.NotContains(t, empty, "Type")
+	assert.NotContains(t, empty, "Status")
+
+	unavail := stripANSIBubbles(renderBubblesSection(statusBubblesSummary{Unavailable: true}, nil))
+	assert.Contains(t, unavail, "(unavailable)")
+	assert.NotContains(t, unavail, "Status")
+}
+
+// TestBuildBubblesJSON_PopulatesRows verifies the JSON envelope carries
+// per-bubble rows mirroring the human cards: identity, path, cloned flag,
+// and a sync-status string ("not cloned" when there is no checkout).
+//
+// Failure prevented: scriptable consumers only ever see counts and cannot
+// locate a bubble's checkout or detect an unmounted one.
+func TestBuildBubblesJSON_PopulatesRows(t *testing.T) {
+	store := fakeKBStore(t)
+	gitInitKB(t, store, "kb_team")
+
+	s := summarizeBubbles(kb.ListResult{
+		Bubbles: []kb.Bubble{
+			{KBID: "kb_team", Type: api.KBTypeTeam, Slug: "eng", ScopeType: "team"},
+			{KBID: "kb_me", Type: api.KBTypePersonal, Slug: "me", ScopeType: "user"},
+		},
+	})
+	js := buildBubblesJSON(s)
+	require.NotNil(t, js)
+	require.Len(t, js.Bubbles, 2)
+
+	me := js.Bubbles[0]
+	assert.Equal(t, "kb_me", me.KBID)
+	assert.Equal(t, "personal", me.Type)
+	assert.False(t, me.Cloned)
+	assert.Equal(t, "not cloned", me.SyncStatus)
+	assert.Equal(t, filepath.Join(store, "kb_me"), me.Path)
+
+	team := js.Bubbles[1]
+	assert.Equal(t, "kb_team", team.KBID)
+	assert.True(t, team.Cloned)
+	assert.NotEmpty(t, team.SyncStatus)
+	assert.NotEqual(t, "not cloned", team.SyncStatus)
 }
 
 // TestRenderSlugRef verifies the sigil and slug are rendered as distinct

--- a/cmd/ox/status_bubbles_test.go
+++ b/cmd/ox/status_bubbles_test.go
@@ -562,7 +562,8 @@ func TestBuildBubblesJSON_LifecycleSyncStatus(t *testing.T) {
 		byID[b.KBID] = b.SyncStatus
 	}
 	assert.Equal(t, "provisioning", byID["kb_prov"])
-	assert.Equal(t, "provision failed", byID["kb_dead"])
+	assert.Equal(t, "provisioning failed", byID["kb_dead"],
+		"JSON must use the same status vocabulary as the human card")
 	assert.Equal(t, "not cloned", byID["kb_gone"])
 }
 

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -38,7 +38,23 @@ type AgentTasksJSON struct {
 type BubblesJSON struct {
 	Total    int                 `json:"total"`
 	ByType   map[string]int      `json:"by_type,omitempty"`
+	Bubbles  []BubbleJSON        `json:"bubbles,omitempty"`
 	Warnings []BubbleWarningJSON `json:"warnings,omitempty"`
+}
+
+// BubbleJSON is one knowledge-bubble row in `ox status --json`, mirroring
+// the per-bubble cards in the human output: identity plus the local mount
+// path and its sync state. Defined in internal/status (not internal/kb)
+// for the same dependency reason as BubbleWarningJSON.
+type BubbleJSON struct {
+	KBID       string `json:"kb_id,omitempty"`
+	Type       string `json:"type"`
+	Slug       string `json:"slug,omitempty"`
+	Name       string `json:"name,omitempty"`
+	ScopeType  string `json:"scope_type,omitempty"`
+	Path       string `json:"path,omitempty"`
+	Cloned     bool   `json:"cloned"`
+	SyncStatus string `json:"sync_status,omitempty"`
 }
 
 // BubbleWarningJSON mirrors kb.Warning for JSON output. Defined


### PR DESCRIPTION
## What this ships

`ox status` previously showed knowledge bubbles as a count-only line. It now renders a full section styled like the Ledger / Team Context cards — one card per KB with its local mount path and sync status.

```
Knowledge bubbles   2 (1 team, 1 custom)

KB                  Magic Wonderland Bubble
  Type              team #team
  Path              ~/.local/share/sageox/sageox.ai/kb/kb_019f1377-79e2-7a7b-a038-58b725ca6556
  Status            ✓ now

KB                  Product
  Type              custom #product
  Path              ~/.local/share/sageox/sageox.ai/kb/kb_019f18ee-2eb0-7386-a1d6-d5176d40222c
  Status            ✓ now
```

- **Card contents:** name, type + `#slug`, canonical mount path (`paths.KBDir(kb_id)`, home-shortened), and a dense status cell.
- **Status cell variants:** `✓ <age>` (clean, daemon last-sync layered in), `⚠ n uncommitted`, `⚠ diverged` / `⚠ rebase wedged`, `⟳ setting up` while the daemon bootstraps, and `⚠ not cloned` with the remote URL plus a `Run 'ox doctor --fix' to clone` hint (doctor's existing `kb missing clones` check auto-fixes by kicking a daemon sync).
- **Staleness:** same `daemon.LoadSyncState` threshold and `⚠ stale (last sync …)` row as the team-context cards.
- **Ordering:** personal-scope (`user`) bubbles first, then team-scope, then by type priority and slug — matching `ox kb list`'s sort.
- **JSON parity:** `--json` gains `bubbles.bubbles[]` rows (`kb_id`, `type`, `slug`, `name`, `scope_type`, `path`, `cloned`, `sync_status`) alongside the existing counts.
- **Degradation unchanged:** `Knowledge bubbles: 0` and `(unavailable)` stay single lines — no orphaned card scaffolding.
- This finally gives `renderBubbleStatus` (previously dead code in `status_bubbles.go`) a caller.

## Status resolution flow

```mermaid
flowchart LR
    A[KB API rows<br/>kb.FetchBubbles] --> B[collectBubbleRows]
    B --> C{".git exists at<br/>paths.KBDir(kb_id)?"}
    C -- no --> D["⚠ not cloned<br/>+ Remote + doctor hint"]
    C -- yes --> E[getGitRepoStatus]
    F[daemon LastSyncForPath] --> E
    E --> G["✓ age / ⚠ uncommitted /<br/>⚠ wedged"]
    H[daemon.LoadSyncState] --> I["⚠ stale row"]
```

## Scope notes

- **Personal KBs:** cards sort personal-scope first and render them as soon as the fetch returns them, but `kb.AmbientScopes` is still project-team-only — personal-scope listing stays blocked on the server-side personal-team backfill (bead `ox-cag9.8`). No rendering change needed when that unblocks.
- **Pre-existing quirk (not touched):** `paths.KBDir` keys the store by the global endpoint (`endpoint.Get()`), so a test-endpoint project mounts KBs under the prod endpoint's directory. Daemon sync uses the same helper, so display and reality agree; changing it is path-location territory (Ryan review) and out of scope here.

Tracked as bead `ox-e8uv`.

## Test Plan

- [x] New table/behavior tests in `cmd/ox/status_bubbles_test.go` using real `git init` checkouts (no stubbed `.git` markers): path resolution + personal-first sort, card rendering incl. not-cloned repair hint, empty/unavailable single-line degradation, JSON rows.
- [x] `go test -short ./cmd/ox ./internal/status` green; `make lint` 0 issues.
- [x] Verified live against a real project with 2 mounted KBs (output above) and against a 0-bubble project (line stays `Knowledge bubbles 0`), human + `--json`.

SageOx-Session: https://sageox.ai/c/ses_019fafde-2cbd-7bd3-a161-4f90dedac108


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded knowledge-bubble output to show a summary plus one card per bubble, including mount path and sync status.
  * Enhanced `ox status --json` to return per-bubble details, including path, cloned flag, and `sync_status`, alongside existing warnings.
* **Bug Fixes**
  * Aligned the human/JSON vocabulary for “provisioning failed” to ensure consistent status wording.
* **Tests**
  * Added integration-style coverage for real checkout detection, card expansion/hint behavior, and JSON bubble row population across cloned, not-cloned, provisioning, and empty/unavailable cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->