### PR TITLE
fix(kb): scope KB store paths by project endpoint, not the endpoint.Get() default

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -2356,7 +2356,7 @@ func buildPrimeKBEnvelope(ctx context.Context, projectRoot string) ([]prime.KBIn
 		if infos[i].KBID == "" {
 			continue
 		}
-		dir := kbDirSafe(infos[i].KBID)
+		dir := kbDirSafe(ep, infos[i].KBID)
 		if dir == "" {
 			continue
 		}
@@ -2369,15 +2369,15 @@ func buildPrimeKBEnvelope(ctx context.Context, projectRoot string) ([]prime.KBIn
 	return infos, reachable
 }
 
-// kbDirSafe wraps paths.KBDir, which panics when no endpoint is
-// configured — prime must degrade, not crash, in that state.
-func kbDirSafe(kbID string) (dir string) {
+// kbDirSafe wraps paths.KBDir, which panics when the endpoint is
+// empty — prime must degrade, not crash, in that state.
+func kbDirSafe(ep, kbID string) (dir string) {
 	defer func() {
 		if r := recover(); r != nil {
 			dir = ""
 		}
 	}()
-	return paths.KBDir(kbID)
+	return paths.KBDir(ep, kbID)
 }
 
 // enrichKBTokensFromInstance fills KBInfo.Tokens for kbInfos using the

--- a/cmd/ox/doctor_kb.go
+++ b/cmd/ox/doctor_kb.go
@@ -148,7 +148,9 @@ func kbHookLogger() *slog.Logger {
 	return slog.Default()
 }
 
-// defaultKBDoctorRoot resolves the canonical kb root for the active endpoint,
+// defaultKBDoctorRoot resolves the canonical kb root for the project's
+// endpoint (same resolution as defaultKBDoctorList, so the orphan check
+// compares the API list against the store that list actually populates),
 // recovering paths.KBDir's panic so an unconfigured endpoint becomes a
 // returned error rather than an aborted doctor run.
 func defaultKBDoctorRoot() (root string, err error) {
@@ -158,7 +160,11 @@ func defaultKBDoctorRoot() (root string, err error) {
 			err = fmt.Errorf("kb root resolution panicked: %v", r)
 		}
 	}()
-	root = paths.KBDir("")
+	ep := endpoint.GetForProject(findGitRoot())
+	if ep == "" {
+		ep = endpoint.Get()
+	}
+	root = paths.KBDir(ep, "")
 	if root == "" {
 		return "", errors.New("kb root unresolved")
 	}

--- a/cmd/ox/kb_describe.go
+++ b/cmd/ox/kb_describe.go
@@ -101,7 +101,7 @@ func runKBDescribe(cmd *cobra.Command, args []string) error {
 		return handleKBDescribeError(cmd.OutOrStdout(), err, input, jsonOutput)
 	}
 
-	localPath := paths.KBDir(bubble.KBID)
+	localPath := paths.KBDir(ep, bubble.KBID)
 
 	if jsonOutput {
 		return outputJSON(cmd.OutOrStdout(), kbDescribeOutput{KB: bubble, LocalPath: localPath})

--- a/internal/daemon/status_kb.go
+++ b/internal/daemon/status_kb.go
@@ -24,7 +24,7 @@ import (
 // when the kb store doesn't exist yet or the endpoint is unresolved — a
 // daemon with no bubbles on disk simply has no kb rows to report.
 func (s *SyncScheduler) kbWorkspaceStatus() []WorkspaceSyncStatus {
-	root := kbRootSafe()
+	root := kbRootSafe(s.kbEndpoint())
 	if root == "" {
 		return nil
 	}
@@ -71,16 +71,16 @@ func (s *SyncScheduler) kbWorkspaceStatus() []WorkspaceSyncStatus {
 	return rows
 }
 
-// kbRootSafe returns paths.KBDir(""), recovering the panic KBDir raises when
-// no endpoint is configured (tests with no SAGEOX_ENDPOINT, fresh installs)
+// kbRootSafe returns paths.KBDir(ep, ""), recovering the panic KBDir raises
+// when the endpoint is empty (tests with no SAGEOX_ENDPOINT, fresh installs)
 // so a status query degrades to "no bubbles" instead of crashing the daemon.
-func kbRootSafe() (root string) {
+func kbRootSafe(ep string) (root string) {
 	defer func() {
 		if recover() != nil {
 			root = ""
 		}
 	}()
-	return paths.KBDir("")
+	return paths.KBDir(ep, "")
 }
 
 // kbHasGitDir reports whether <kbPath>/.git exists — the same "is this a real

--- a/internal/daemon/status_kb_test.go
+++ b/internal/daemon/status_kb_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +22,7 @@ import (
 // an optional .git marker and meta.json, matching what reconcileBubble writes.
 func writeBubbleOnDisk(t *testing.T, kbID string, hasGit bool, meta *kbMeta) {
 	t.Helper()
-	dir := paths.KBDir(kbID)
+	dir := paths.KBDir(endpoint.Get(), kbID)
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".sageox"), 0o755))
 	if hasGit {
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
@@ -101,7 +102,7 @@ func TestKBWorkspaceStatus_SkipsDotDirsAndNonClones(t *testing.T) {
 	s, _ := kbTestScheduler(t)
 
 	// .trash/ must be skipped
-	require.NoError(t, os.MkdirAll(filepath.Join(paths.KBDir(""), ".trash", "kb_old"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(paths.KBDir(endpoint.Get(), ""), ".trash", "kb_old"), 0o755))
 	// a dir with no .git is a partial clone — listed but Exists=false
 	writeBubbleOnDisk(t, "kb_partial_1", false, &kbMeta{Type: api.KBTypeRepo, Slug: "half"})
 

--- a/internal/daemon/sync_bubbles.go
+++ b/internal/daemon/sync_bubbles.go
@@ -233,6 +233,14 @@ func (s *SyncScheduler) projectTeamIDForKB() string {
 	return s.workspaceRegistry.ProjectTeamID()
 }
 
+// kbEndpoint resolves the endpoint that scopes this daemon's KB store
+// paths (paths.KBDir / trash / symlink targets). Project-bound: a
+// test.sageox.ai project's bubbles must land under the test.sageox.ai
+// slug, never the production default (see bead ox-651l).
+func (s *SyncScheduler) kbEndpoint() string {
+	return endpoint.GetForProject(s.config.ProjectRoot)
+}
+
 // buildKBLister resolves a KBBubbleLister using the test factory if set,
 // otherwise constructs a real api.KBClient bound to the project's
 // endpoint and the heartbeat-cached auth token.
@@ -271,7 +279,7 @@ func (s *SyncScheduler) reconcileBubble(ctx context.Context, b api.KB) {
 		return
 	}
 
-	target := paths.KBDir(b.KBID)
+	target := paths.KBDir(s.kbEndpoint(), b.KBID)
 	if target == "" {
 		s.logger.Warn("kb_sync target path empty, skipping", "kb_id", b.KBID, "type", string(b.KBType))
 		return

--- a/internal/daemon/sync_bubbles_backoff_test.go
+++ b/internal/daemon/sync_bubbles_backoff_test.go
@@ -34,6 +34,7 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,7 +72,7 @@ func TestSyncBubbles_Backoff_NoStickyState(t *testing.T) {
 	})
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	if _, err := os.Stat(filepath.Join(target, ".git")); err == nil {
 		t.Fatalf("bubble was unexpectedly cloned despite list error")
 	}
@@ -151,7 +152,7 @@ func TestSyncBubbles_Backoff_RateLimitedThenRecovers(t *testing.T) {
 			s.syncBubbles(context.Background())
 		})
 	}
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	if _, err := os.Stat(filepath.Join(target, ".git")); err == nil {
 		t.Fatal("bubble cloned despite back-to-back rate-limit responses")
 	}
@@ -201,7 +202,7 @@ func TestSyncBubbles_Backoff_FailedBubbleSucceedsOnLaterPass(t *testing.T) {
 
 	// pass 1: clone fails.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	if _, err := os.Stat(filepath.Join(target, ".git")); err == nil {
 		t.Fatal("expected clone to fail when the bare repo does not exist")
 	}
@@ -254,7 +255,7 @@ func TestSyncBubbles_Backoff_UnauthorizedSurfacedDistinctly(t *testing.T) {
 
 	// no kb dirs should have been created — the list call failed
 	// before the per-bubble loop ran.
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	if entries, err := os.ReadDir(root); err == nil {
 		assert.Empty(t, entries, "401 must not produce any on-disk side effects")
 	}

--- a/internal/daemon/sync_bubbles_clone_test.go
+++ b/internal/daemon/sync_bubbles_clone_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
@@ -73,7 +74,7 @@ func TestSyncBubbles_Clone_AllKinds(t *testing.T) {
 
 			s.syncBubbles(context.Background())
 
-			target := paths.KBDir(bubble.KBID)
+			target := paths.KBDir(endpoint.Get(), bubble.KBID)
 			require.DirExists(t, filepath.Join(target, ".git"), "%s: .git must exist after clone", tc.name)
 			seeded := filepath.Join(target, tc.seedFile)
 			body, err := os.ReadFile(seeded)
@@ -131,7 +132,7 @@ func TestSyncBubbles_Clone_EndpointScoping(t *testing.T) {
 		})
 		s.syncBubbles(context.Background())
 
-		stagingTarget = paths.KBDir(bubble.KBID)
+		stagingTarget = paths.KBDir(endpoint.Get(), bubble.KBID)
 		body, err := os.ReadFile(filepath.Join(stagingTarget, "f.md"))
 		require.NoError(t, err)
 		assert.Equal(t, "A\n", string(body), "staging endpoint must clone A's content")
@@ -157,7 +158,7 @@ func TestSyncBubbles_Clone_EndpointScoping(t *testing.T) {
 		})
 		s.syncBubbles(context.Background())
 
-		target := paths.KBDir(bubble.KBID)
+		target := paths.KBDir(endpoint.Get(), bubble.KBID)
 		require.NotEmpty(t, target)
 		body, err := os.ReadFile(filepath.Join(target, "f.md"))
 		require.NoError(t, err)
@@ -205,14 +206,14 @@ func TestSyncBubbles_Clone_EmptyRepoURL_NoClone(t *testing.T) {
 	s.syncBubbles(context.Background())
 
 	// unprovisioned bubble has no checkout.
-	assert.NoDirExists(t, filepath.Join(paths.KBDir(unprovisioned.KBID), ".git"))
+	assert.NoDirExists(t, filepath.Join(paths.KBDir(endpoint.Get(), unprovisioned.KBID), ".git"))
 	// the bubble after must still be cloned.
-	assert.DirExists(t, filepath.Join(paths.KBDir(good.KBID), ".git"))
+	assert.DirExists(t, filepath.Join(paths.KBDir(endpoint.Get(), good.KBID), ".git"))
 }
 
 // TestSyncBubbles_Clone_EmptyKBID_Skipped is the kb-side equivalent of
 // the team-context "skip when team_id is missing" guard. An empty kb_id
-// must never produce a checkout — paths.KBDir("") would otherwise resolve
+// must never produce a checkout — paths.KBDir(ep, "") would otherwise resolve
 // to the kb base dir itself, which is a destructive write target.
 //
 // Failure prevented: an API regression returning blank kb_id rows
@@ -235,7 +236,7 @@ func TestSyncBubbles_Clone_EmptyKBID_Skipped(t *testing.T) {
 		s.syncBubbles(context.Background())
 	})
 	// no top-level git dir should appear at the kb root.
-	if entries, err := os.ReadDir(paths.KBDir("")); err == nil {
+	if entries, err := os.ReadDir(paths.KBDir(endpoint.Get(), "")); err == nil {
 		for _, e := range entries {
 			assert.NotEqual(t, ".git", e.Name(), "kb root must not become a git repo")
 		}
@@ -271,7 +272,7 @@ func TestSyncBubbles_Clone_BadURL_LeavesNoPartialCheckout(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bad.KBID)
+	target := paths.KBDir(endpoint.Get(), bad.KBID)
 	// either the dir is absent OR present but with no .git — never both.
 	if _, err := os.Stat(filepath.Join(target, ".git")); err == nil {
 		t.Fatalf(".git dir created from a failing clone — partial state left behind at %s", target)
@@ -309,7 +310,7 @@ func TestSyncBubbles_Clone_PostCloneMergeAttrsInstalled(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	attrs, err := os.ReadFile(filepath.Join(target, ".git", "info", "attributes"))
 	require.NoError(t, err, "info/attributes must exist after clone")
 	got := string(attrs)
@@ -351,7 +352,7 @@ func TestSyncBubbles_Clone_Idempotent(t *testing.T) {
 
 	// first pass: clone.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// drop a local untracked marker file. If the next pass re-clones
@@ -397,7 +398,7 @@ func TestSyncBubbles_Clone_RestoresAfterManualGitDirRemoval(t *testing.T) {
 
 	// initial clone.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// manually remove .git as if a user did `rm -rf .git`.
@@ -447,7 +448,7 @@ func TestSyncBubbles_Clone_ShallowAndPartialFilter(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// blob:none filter must be recorded on the remote config so subsequent
@@ -515,7 +516,7 @@ func TestSyncBubbles_Clone_HasGitignoreEntries(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	gitignoreBytes, err := os.ReadFile(filepath.Join(target, ".sageox", ".gitignore"))
 	require.NoError(t, err, ".sageox/.gitignore must exist after clone")
 	contents := string(gitignoreBytes)
@@ -594,7 +595,7 @@ resolve auto data/
 
 	// first pass: clone — manifest should ship into the local checkout.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 	require.FileExists(t, filepath.Join(target, ".sageox", "sync.manifest"))
 

--- a/internal/daemon/sync_bubbles_clone_test.go
+++ b/internal/daemon/sync_bubbles_clone_test.go
@@ -235,11 +235,16 @@ func TestSyncBubbles_Clone_EmptyKBID_Skipped(t *testing.T) {
 	assert.NotPanics(t, func() {
 		s.syncBubbles(context.Background())
 	})
-	// no top-level git dir should appear at the kb root.
-	if entries, err := os.ReadDir(paths.KBDir(endpoint.Get(), "")); err == nil {
-		for _, e := range entries {
-			assert.NotEqual(t, ".git", e.Name(), "kb root must not become a git repo")
-		}
+	// no top-level git dir should appear at the kb root. An absent root is
+	// fine (nothing was cloned); any other ReadDir error must fail loudly
+	// rather than skip the assertions below.
+	entries, err := os.ReadDir(paths.KBDir(endpoint.Get(), ""))
+	if err != nil {
+		require.ErrorIs(t, err, os.ErrNotExist, "kb root must be readable or absent")
+		return
+	}
+	for _, e := range entries {
+		assert.NotEqual(t, ".git", e.Name(), "kb root must not become a git repo")
 	}
 }
 

--- a/internal/daemon/sync_bubbles_discovery_test.go
+++ b/internal/daemon/sync_bubbles_discovery_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,7 @@ func TestSyncBubbles_NewlyAppearing_ClonedOnNextPass(t *testing.T) {
 
 	// pass 1: empty list. No clones expected.
 	s.syncBubbles(context.Background())
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	if entries, err := os.ReadDir(root); err == nil {
 		assert.Empty(t, entries, "no bubbles should exist before the API surfaces any")
 	}
@@ -86,7 +87,7 @@ func TestSyncBubbles_NewlyAppearing_ClonedOnNextPass(t *testing.T) {
 	// pass 2: must clone the new bubble.
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(newBubble.KBID)
+	target := paths.KBDir(endpoint.Get(), newBubble.KBID)
 	assert.DirExists(t, filepath.Join(target, ".git"),
 		"newly-listed bubble must be cloned on the next pass")
 	assert.FileExists(t, filepath.Join(target, "AGENTS.md"))
@@ -135,7 +136,7 @@ func TestSyncBubbles_DisappearingBubble_NotTouchedBySync(t *testing.T) {
 
 	// pass 1: clone.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// API drops the bubble.
@@ -187,7 +188,7 @@ func TestSyncBubbles_Discovery_Flapping(t *testing.T) {
 
 	// pass 1: present → clone.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// pass 2: gone → no-op.
@@ -241,7 +242,7 @@ func TestSyncBubbles_NewBubbleAlongsideExisting(t *testing.T) {
 
 	// pass 1: clone bubbleA.
 	s.syncBubbles(context.Background())
-	targetA := paths.KBDir(bubbleA.KBID)
+	targetA := paths.KBDir(endpoint.Get(), bubbleA.KBID)
 	require.DirExists(t, filepath.Join(targetA, ".git"))
 	metaPathA := filepath.Join(targetA, ".sageox", "meta.json")
 	preStat, err := os.Stat(metaPathA)
@@ -260,7 +261,7 @@ func TestSyncBubbles_NewBubbleAlongsideExisting(t *testing.T) {
 	// pass 2: bubbleB clones, bubbleA must remain intact.
 	s.syncBubbles(context.Background())
 
-	targetB := paths.KBDir(bubbleB.KBID)
+	targetB := paths.KBDir(endpoint.Get(), bubbleB.KBID)
 	assert.DirExists(t, filepath.Join(targetB, ".git"), "newcomer must clone")
 	assert.FileExists(t, filepath.Join(targetB, "b.md"))
 

--- a/internal/daemon/sync_bubbles_diverge_test.go
+++ b/internal/daemon/sync_bubbles_diverge_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,7 +63,7 @@ func TestSyncBubbles_LocalCommitsRebaseOnPull(t *testing.T) {
 
 	// first pass: clone the bubble.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// add a local commit inside the kb checkout (simulates the daemon
@@ -135,7 +136,7 @@ func TestSyncBubbles_ForcePushedRemote_DivergenceDetected(t *testing.T) {
 
 	// initial clone — local is now at the original commit.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// force-push a rewritten history. The bare repo's main branch
@@ -206,7 +207,7 @@ func TestSyncBubbles_ListErrorPreservesExistingClones(t *testing.T) {
 	})
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"), "precondition: bubble cloned")
 
 	// pass 2: list errors with a transient non-sentinel error. The

--- a/internal/daemon/sync_bubbles_integration_test.go
+++ b/internal/daemon/sync_bubbles_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
@@ -97,16 +98,16 @@ func TestSyncBubblesIntegration_FullFlow_MultipleBubbles(t *testing.T) {
 
 	// both bubbles materialize.
 	for _, kb := range []api.KB{a, b} {
-		target := paths.KBDir(kb.KBID)
+		target := paths.KBDir(endpoint.Get(), kb.KBID)
 		assert.DirExists(t, filepath.Join(target, ".git"), "%s: .git", kb.Slug)
 		assert.FileExists(t, filepath.Join(target, ".sageox", "meta.json"), "%s: meta.json", kb.Slug)
 	}
-	assert.FileExists(t, filepath.Join(paths.KBDir(a.KBID), "AGENTS.md"))
-	assert.FileExists(t, filepath.Join(paths.KBDir(b.KBID), "notes.md"))
+	assert.FileExists(t, filepath.Join(paths.KBDir(endpoint.Get(), a.KBID), "AGENTS.md"))
+	assert.FileExists(t, filepath.Join(paths.KBDir(endpoint.Get(), b.KBID), "notes.md"))
 
 	// CLI read-back via the same KB type used by `ox kb list`.
 	for _, kb := range []api.KB{a, b} {
-		raw, err := os.ReadFile(filepath.Join(paths.KBDir(kb.KBID), ".sageox", "meta.json"))
+		raw, err := os.ReadFile(filepath.Join(paths.KBDir(endpoint.Get(), kb.KBID), ".sageox", "meta.json"))
 		require.NoError(t, err)
 		var meta kbMeta
 		require.NoError(t, json.Unmarshal(raw, &meta))
@@ -151,7 +152,7 @@ func TestSyncBubblesIntegration_APIMockToOnDisk(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(row.KBID)
+	target := paths.KBDir(endpoint.Get(), row.KBID)
 	body, err := os.ReadFile(filepath.Join(target, "AGENTS.md"))
 	require.NoError(t, err)
 	assert.Equal(t, "from-mock\n", string(body))
@@ -202,7 +203,7 @@ func TestSyncBubblesIntegration_EndpointSwitchMidFlight(t *testing.T) {
 		return &fakeKBLister{bubbles: []api.KB{bubble1}}
 	})
 	s1.syncBubbles(context.Background())
-	stagingTarget := paths.KBDir(bubble1.KBID)
+	stagingTarget := paths.KBDir(endpoint.Get(), bubble1.KBID)
 	stagingBody, err := os.ReadFile(filepath.Join(stagingTarget, "f.md"))
 	require.NoError(t, err)
 	assert.Equal(t, "from-staging\n", string(stagingBody))
@@ -226,7 +227,7 @@ func TestSyncBubblesIntegration_EndpointSwitchMidFlight(t *testing.T) {
 		return &fakeKBLister{bubbles: []api.KB{bubble2}}
 	})
 	s2.syncBubbles(context.Background())
-	prodTarget := paths.KBDir(bubble2.KBID)
+	prodTarget := paths.KBDir(endpoint.Get(), bubble2.KBID)
 	prodBody, err := os.ReadFile(filepath.Join(prodTarget, "f.md"))
 	require.NoError(t, err)
 	assert.Equal(t, "from-prod\n", string(prodBody))
@@ -276,7 +277,7 @@ func TestSyncBubblesIntegration_RepeatedSyncIsIdempotent(t *testing.T) {
 		s.syncBubbles(context.Background())
 	}
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// exactly one meta.json. No tmp leftovers.
@@ -340,10 +341,10 @@ func TestSyncBubblesIntegration_BubbleAddedSecondPass(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	assert.DirExists(t, filepath.Join(paths.KBDir(a.KBID), ".git"))
-	assert.NoDirExists(t, filepath.Join(paths.KBDir(b.KBID), ".git"))
+	assert.DirExists(t, filepath.Join(paths.KBDir(endpoint.Get(), a.KBID), ".git"))
+	assert.NoDirExists(t, filepath.Join(paths.KBDir(endpoint.Get(), b.KBID), ".git"))
 
 	s.syncBubbles(context.Background())
-	assert.DirExists(t, filepath.Join(paths.KBDir(a.KBID), ".git"))
-	assert.DirExists(t, filepath.Join(paths.KBDir(b.KBID), ".git"), "newly-added bubble must clone on the next pass")
+	assert.DirExists(t, filepath.Join(paths.KBDir(endpoint.Get(), a.KBID), ".git"))
+	assert.DirExists(t, filepath.Join(paths.KBDir(endpoint.Get(), b.KBID), ".git"), "newly-added bubble must clone on the next pass")
 }

--- a/internal/daemon/sync_bubbles_mergeattrs_test.go
+++ b/internal/daemon/sync_bubbles_mergeattrs_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/kb"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
@@ -70,7 +71,7 @@ func TestSyncBubbles_MergeAttrs_AppliedAtCloneTime(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	got := readKBAttrs(t, target)
 	for _, want := range kb.MergeUnionPaths {
 		assert.Contains(t, got, want, "expected merge rule for %s", want)
@@ -112,7 +113,7 @@ func TestSyncBubbles_MergeAttrs_NotInWorkingTree(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	if _, err := os.Stat(filepath.Join(target, ".gitattributes")); !os.IsNotExist(err) {
 		t.Fatalf("kb sync must NOT create a tracked .gitattributes; got err=%v", err)
 	}
@@ -150,7 +151,7 @@ func TestSyncBubbles_MergeAttrs_IdempotentAcrossPasses(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	first := readKBAttrs(t, target)
 
 	// trigger a real pull on the second pass — push upstream + age FETCH_HEAD.
@@ -197,7 +198,7 @@ func TestSyncBubbles_MergeAttrs_PreservesUserAuthoredLines(t *testing.T) {
 
 	// initial clone — installs the managed block.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 
 	// user appends a custom rule outside the managed markers.
 	attrsPath := filepath.Join(target, ".git", "info", "attributes")
@@ -246,7 +247,7 @@ func TestSyncBubbles_MergeAttrs_RecoversTruncatedManagedBlock(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	attrsPath := filepath.Join(target, ".git", "info", "attributes")
 
 	// corrupt to a truncated block: header but no footer.
@@ -298,7 +299,7 @@ func TestSyncBubbles_MergeAttrs_ThreeWayUnionConcatenates(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	gitConfig(t, target)
 
 	// remote writes a divergent line.

--- a/internal/daemon/sync_bubbles_network_test.go
+++ b/internal/daemon/sync_bubbles_network_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,9 +77,9 @@ func TestSyncBubbles_Network_UnreachableRemoteIsContained(t *testing.T) {
 	}
 
 	// the unreachable bubble is not cloned.
-	assert.NoDirExists(t, filepath.Join(paths.KBDir(bad.KBID), ".git"))
+	assert.NoDirExists(t, filepath.Join(paths.KBDir(endpoint.Get(), bad.KBID), ".git"))
 	// the good bubble must still land.
-	assert.DirExists(t, filepath.Join(paths.KBDir(good.KBID), ".git"))
+	assert.DirExists(t, filepath.Join(paths.KBDir(endpoint.Get(), good.KBID), ".git"))
 }
 
 // TestSyncBubbles_Network_APIListTimeout verifies the kb API list call
@@ -306,7 +307,7 @@ func TestSyncBubbles_Network_RepeatedPassesIdempotentUnderFlapping(t *testing.T)
 
 	// the bubble should be cloned exactly once — not duplicated, not
 	// repeatedly torn down.
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	assert.DirExists(t, filepath.Join(target, ".git"))
 	parent := filepath.Dir(target)
 	entries, err := os.ReadDir(parent)

--- a/internal/daemon/sync_bubbles_pull_test.go
+++ b/internal/daemon/sync_bubbles_pull_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,7 +63,7 @@ func TestSyncBubbles_Pull_FastForward(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	pushExtraCommit(t, bareDir, "AGENTS.md", "v2\n")
@@ -109,7 +110,7 @@ func TestSyncBubbles_Pull_DedupSkipsWhenFetchRecent(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	fetchHead := filepath.Join(target, ".git", "FETCH_HEAD")
 
 	// `git clone` doesn't create FETCH_HEAD — only `git fetch` does. To
@@ -170,7 +171,7 @@ func TestSyncBubbles_Pull_CorruptRepoMovedAside(t *testing.T) {
 
 	// initial clone.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// corrupt the repo: leave .git as an empty dir so isValidGitRepo fails.
@@ -227,7 +228,7 @@ func TestSyncBubbles_Pull_NotGitRepoBecomesClonedOnNextPass(t *testing.T) {
 	})
 
 	// stage the pre-existing directory: present, contains a file, no .git.
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.NoError(t, os.MkdirAll(target, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(target, "stale.txt"), []byte("leftover"), 0o644))
 
@@ -275,7 +276,7 @@ func TestSyncBubbles_Pull_PreservesUntrackedFiles(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	notes := filepath.Join(target, "scratch.md")
 	require.NoError(t, os.WriteFile(notes, []byte("WIP\n"), 0o644))
 
@@ -322,7 +323,7 @@ func TestSyncBubbles_Pull_PreservesUncommittedTrackedChanges(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 
 	// uncommitted local edit to a tracked file (NOT colliding with
 	// the upstream change we'll push next).
@@ -376,7 +377,7 @@ func TestSyncBubbles_Pull_RebaseInProgressIsSkipped(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 
 	// fake rebase-merge state.
 	rebaseDir := filepath.Join(target, ".git", "rebase-merge")
@@ -426,7 +427,7 @@ func TestSyncBubbles_Pull_LockFilesSkipPull(t *testing.T) {
 	})
 
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 
 	// plant a "fresh" lock so the auto-cleaner won't reap it.
 	lockPath := filepath.Join(target, ".git", "index.lock")

--- a/internal/daemon/sync_bubbles_race_test.go
+++ b/internal/daemon/sync_bubbles_race_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,7 +90,7 @@ func TestSyncBubbles_ConcurrentPasses_NoPanic(t *testing.T) {
 		"every goroutine must complete its pass")
 
 	// after all goroutines, the bubble must be in a usable state.
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	assert.DirExists(t, filepath.Join(target, ".git"))
 
 	// meta.json must be valid JSON (not torn by a half-finished write).
@@ -138,7 +139,7 @@ func TestSyncBubbles_RapidSequentialPasses(t *testing.T) {
 		})
 	}
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// no .bak.* siblings should accumulate from rapid passes — the
@@ -200,7 +201,7 @@ func TestSyncBubbles_TwoSchedulers_SameEndpoint_NoCorruption(t *testing.T) {
 		t.Fatal("two schedulers on the same kb dir deadlocked")
 	}
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	assert.DirExists(t, filepath.Join(target, ".git"))
 
 	// no leftover index.lock from a torn concurrent fetch.

--- a/internal/daemon/sync_bubbles_scheduler_test.go
+++ b/internal/daemon/sync_bubbles_scheduler_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -188,7 +189,7 @@ func TestSyncBubbles_Checkout_MainBranch(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	body, err := os.ReadFile(filepath.Join(target, "MAIN.md"))

--- a/internal/daemon/sync_bubbles_sparse_test.go
+++ b/internal/daemon/sync_bubbles_sparse_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +66,7 @@ func TestSyncBubbles_Pull_ReappliesSparseFromManifest(t *testing.T) {
 
 	// --- Stage 2: first sync — clone. allowed/ materializes, also/ does not. ---
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"), "first sync must clone the bubble")
 	require.FileExists(t, filepath.Join(target, "allowed", "foo.md"),
 		"allowed/ is in the manifest's include set, must materialize on clone")

--- a/internal/daemon/sync_bubbles_state_test.go
+++ b/internal/daemon/sync_bubbles_state_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,7 @@ func TestSyncBubbles_State_PersistsAcrossSchedulerRestart(t *testing.T) {
 	})
 	s1.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	metaPath := filepath.Join(target, ".sageox", "meta.json")
 	require.FileExists(t, metaPath)
 	beforeRaw, err := os.ReadFile(metaPath)
@@ -149,7 +150,7 @@ func TestSyncBubbles_State_UpdatesAfterPull(t *testing.T) {
 
 	// pass 1: clone + write meta (last_sync = T1).
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	metaPath := filepath.Join(target, ".sageox", "meta.json")
 	raw, err := os.ReadFile(metaPath)
 	require.NoError(t, err)
@@ -211,7 +212,7 @@ func TestSyncBubbles_State_ManualMetaDeletion_Recovered(t *testing.T) {
 
 	// pass 1: clone + meta.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	metaPath := filepath.Join(target, ".sageox", "meta.json")
 	require.FileExists(t, metaPath)
 
@@ -263,7 +264,7 @@ func TestSyncBubbles_State_MetaSurvivesScheduler_Without_Project(t *testing.T) {
 	})
 	s1.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	metaPath := filepath.Join(target, ".sageox", "meta.json")
 	require.FileExists(t, metaPath)
 	beforeRaw, err := os.ReadFile(metaPath)

--- a/internal/daemon/sync_bubbles_test.go
+++ b/internal/daemon/sync_bubbles_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
@@ -149,7 +150,7 @@ func TestSyncBubbles_InitialClone(t *testing.T) {
 		return &fakeKBLister{bubbles: []api.KB{bubble}}
 	})
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.NoDirExists(t, target, "precondition: target shouldn't exist yet")
 
 	s.syncBubbles(context.Background())
@@ -198,7 +199,7 @@ func TestSyncBubbles_IncrementalPull(t *testing.T) {
 
 	// first pass: clone
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// push a new commit and run another pass
@@ -236,7 +237,7 @@ func TestSyncBubbles_KBAPIUnavailable_NoOp(t *testing.T) {
 	s.syncBubbles(context.Background())
 	assert.Equal(t, 1, called, "lister factory still invoked")
 
-	base := paths.KBDir("")
+	base := paths.KBDir(endpoint.Get(), "")
 	if entries, err := os.ReadDir(base); err == nil {
 		assert.Empty(t, entries, "kb dir must remain empty when API unavailable")
 	}
@@ -280,13 +281,13 @@ func TestSyncBubbles_PerBubbleFailureIsolation(t *testing.T) {
 	s.syncBubbles(context.Background())
 
 	// the bad bubble should not have a populated checkout
-	badTarget := paths.KBDir(bad.KBID)
+	badTarget := paths.KBDir(endpoint.Get(), bad.KBID)
 	if _, err := os.Stat(filepath.Join(badTarget, ".git")); err == nil {
 		t.Fatalf("bad bubble unexpectedly succeeded at %s", badTarget)
 	}
 
 	// the good bubble must still be cloned despite the earlier failure
-	goodTarget := paths.KBDir(good.KBID)
+	goodTarget := paths.KBDir(endpoint.Get(), good.KBID)
 	assert.DirExists(t, filepath.Join(goodTarget, ".git"), "good bubble must clone even when an earlier one failed")
 	assert.FileExists(t, filepath.Join(goodTarget, ".sageox", "meta.json"))
 }
@@ -327,7 +328,7 @@ func TestSyncBubbles_MetaJSONFields(t *testing.T) {
 	before := time.Now().Add(-time.Second)
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	raw, err := os.ReadFile(filepath.Join(target, ".sageox", "meta.json"))
 	require.NoError(t, err)
 

--- a/internal/daemon/sync_bubbles_validate_test.go
+++ b/internal/daemon/sync_bubbles_validate_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,7 +64,7 @@ func TestSyncBubbles_Validate_UnknownKBType_StillSyncs(t *testing.T) {
 
 	s.syncBubbles(context.Background())
 
-	target := paths.KBDir(unk.KBID)
+	target := paths.KBDir(endpoint.Get(), unk.KBID)
 	assert.DirExists(t, filepath.Join(target, ".git"),
 		"KBTypeUnknown must still clone — forward-compat per ADR-036")
 
@@ -117,7 +118,7 @@ func TestSyncBubbles_Validate_MetaJSONIsAtomicWrite(t *testing.T) {
 		s.syncBubbles(context.Background())
 	}
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	metaDir := filepath.Join(target, ".sageox")
 	entries, err := os.ReadDir(metaDir)
 	require.NoError(t, err)
@@ -168,7 +169,7 @@ func TestSyncBubbles_Validate_PreExistingCorruptMeta_Recovered(t *testing.T) {
 
 	// pass 1: clone + write meta.json.
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	metaPath := filepath.Join(target, ".sageox", "meta.json")
 	require.FileExists(t, metaPath)
 
@@ -219,7 +220,7 @@ func TestSyncBubbles_Validate_ListErrorLeavesDiskUntouched(t *testing.T) {
 		return &fakeKBLister{bubbles: []api.KB{bubble}}
 	})
 	s.syncBubbles(context.Background())
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	require.DirExists(t, filepath.Join(target, ".git"))
 
 	// snapshot meta.json bytes.

--- a/internal/daemon/sync_gc_kb.go
+++ b/internal/daemon/sync_gc_kb.go
@@ -114,7 +114,7 @@ func (s *SyncScheduler) kbGCRoot() (root string, err error) {
 			root = ""
 		}
 	}()
-	root = paths.KBDir("")
+	root = paths.KBDir(s.kbEndpoint(), "")
 	if root == "" {
 		return "", errors.New("kb root unresolved")
 	}

--- a/internal/daemon/sync_gc_kb_basic_test.go
+++ b/internal/daemon/sync_gc_kb_basic_test.go
@@ -60,6 +60,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,7 +87,7 @@ func TestKBGC_FullCycle_MixedAuthorizedAndOrphans(t *testing.T) {
 	keep2 := makeKBDir(t, "kb_keep_2", "beta")
 	orphan1 := makeKBDir(t, "kb_orphan_1", "gone")
 	orphan2 := makeKBDir(t, "kb_orphan_2", "also-gone")
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	s.runKBGC(ctx, stubListFn("kb_keep_1", "kb_keep_2"))
 
@@ -119,7 +120,7 @@ func TestKBGC_FullCycle_TriageThenReap_SamePass(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	// pre-seed an expired trash entry from a prior pass
 	trashDir := filepath.Join(root, kbTrashDirName)
@@ -160,9 +161,9 @@ func TestKBGC_KBRootMissing_NoPanic(t *testing.T) {
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
 
-	// kb root has not been created — paths.KBDir("") resolves but the
+	// kb root has not been created — paths.KBDir(ep, "") resolves but the
 	// directory itself is absent.
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	_, err := os.Stat(root)
 	require.True(t, os.IsNotExist(err), "precondition: root must not exist")
 
@@ -210,7 +211,7 @@ func TestKBGC_PreExistingTrash_NewOrphansAddedAlongside(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	trashDir := filepath.Join(root, kbTrashDirName)
 
 	// pre-existing recent trash entry (within grace, must survive)
@@ -270,7 +271,7 @@ func TestKBGC_TriageMovesEntireDir_IncludingUntrackedFiles(t *testing.T) {
 	assert.NoDirExists(t, dir)
 
 	// all four file paths survive intact under .trash/
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	trashEntries, err := os.ReadDir(filepath.Join(root, kbTrashDirName))
 	require.NoError(t, err)
 	require.Len(t, trashEntries, 1)
@@ -305,7 +306,7 @@ func TestKBGC_NonDirEntriesIgnored(t *testing.T) {
 
 	// seed both a kb dir (orphan) and a stray top-level file
 	makeKBDir(t, "kb_orphan", "x")
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	stray := filepath.Join(root, "stray-file")
 	require.NoError(t, os.WriteFile(stray, []byte("not-a-bubble"), 0o644))
 
@@ -329,7 +330,7 @@ func TestKBGC_DotPrefixedDirsIgnored(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	require.NoError(t, os.MkdirAll(root, 0o755))
 	dotDir := filepath.Join(root, ".future-state")

--- a/internal/daemon/sync_gc_kb_bluegreen_test.go
+++ b/internal/daemon/sync_gc_kb_bluegreen_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,7 @@ func TestKBGC_StaleBakDir_FromCorruptRecovery_Triaged(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	// authorized current bubble
 	keep := makeKBDir(t, "kb_keep", "live")
@@ -98,7 +99,7 @@ func TestKBGC_MultipleStaleBakDirs_AllTriaged(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	keep := makeKBDir(t, "kb_keep", "live")
 	for i, ts := range []int64{1700000000, 1700000100, 1700000200} {
@@ -135,10 +136,10 @@ func TestKBGC_PartiallyClonedDir_NotInAPI_StillTriaged(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	// directory exists but is empty — simulates an interrupted clone
-	partial := paths.KBDir("kb_dead_clone")
+	partial := paths.KBDir(endpoint.Get(), "kb_dead_clone")
 	require.NoError(t, os.MkdirAll(partial, 0o755))
 
 	// API doesn't know about it — confirmed dead
@@ -166,7 +167,7 @@ func TestKBGC_RespectsCloneInFlight_DoesNotTriageActiveClone(t *testing.T) {
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
 
-	active := paths.KBDir("kb_being_cloned")
+	active := paths.KBDir(endpoint.Get(), "kb_being_cloned")
 	require.NoError(t, os.MkdirAll(active, 0o755))
 	// Mark clone as in-flight via the kb-specific sync.Map maintained by
 	// cloneBubble. The deferred clear ensures other tests don't see the
@@ -200,7 +201,7 @@ func TestKBGC_CrashMidTriage_LeavesNoHalfState(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	// orphan A: will fail to move (parent path made read-only)
 	orphanA := makeKBDir(t, "kb_will_fail", "a")
@@ -251,7 +252,7 @@ func TestKBGC_TriageFailure_DoesNotBlockReaper(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	// healthy trash with one expired entry
 	trashDir := filepath.Join(root, kbTrashDirName)

--- a/internal/daemon/sync_gc_kb_reopen_test.go
+++ b/internal/daemon/sync_gc_kb_reopen_test.go
@@ -59,6 +59,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,7 +81,7 @@ func TestKBGC_ReListedAfterTriage_TrashLeftAlone(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	// pre-existing recent trash entry for kb_returning
 	trashDir := filepath.Join(root, kbTrashDirName)
@@ -101,7 +102,7 @@ func TestKBGC_ReListedAfterTriage_TrashLeftAlone(t *testing.T) {
 	assert.Equal(t, "from-grace", string(data), "trash entry contents must remain bit-identical")
 
 	// canonical dir: NOT created by GC (clone is sync's job, not GC's)
-	canonical := paths.KBDir("kb_returning")
+	canonical := paths.KBDir(endpoint.Get(), "kb_returning")
 	_, err = os.Stat(canonical)
 	assert.True(t, os.IsNotExist(err),
 		"GC must not auto-restore from trash — canonical dir creation is the sync loop's job")
@@ -124,7 +125,7 @@ func TestKBGC_ReListedAfterTriage_FreshCloneCoexists(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	// stale trash entry from a prior pass
 	trashDir := filepath.Join(root, kbTrashDirName)
@@ -166,7 +167,7 @@ func TestKBGC_ReListedAfterGracePeriod_FreshCloneClean(t *testing.T) {
 	kbGCEnv(t)
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	// trash entry beyond grace (reapable)
 	trashDir := filepath.Join(root, kbTrashDirName)
@@ -242,7 +243,7 @@ func TestKBGC_ConcurrentReList_DuringReap_SafeUnderRace(t *testing.T) {
 	ctx := context.Background()
 
 	makeKBDir(t, "kb_flapping", "x")
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -261,7 +262,7 @@ func TestKBGC_ConcurrentReList_DuringReap_SafeUnderRace(t *testing.T) {
 	// the kb_flapping dir is in EXACTLY ONE place: canonical or trash,
 	// never both, never neither.
 	canonicalExists := false
-	if _, err := os.Stat(paths.KBDir("kb_flapping")); err == nil {
+	if _, err := os.Stat(paths.KBDir(endpoint.Get(), "kb_flapping")); err == nil {
 		canonicalExists = true
 	}
 

--- a/internal/daemon/sync_gc_kb_reopen_test.go
+++ b/internal/daemon/sync_gc_kb_reopen_test.go
@@ -264,6 +264,8 @@ func TestKBGC_ConcurrentReList_DuringReap_SafeUnderRace(t *testing.T) {
 	canonicalExists := false
 	if _, err := os.Stat(paths.KBDir(endpoint.Get(), "kb_flapping")); err == nil {
 		canonicalExists = true
+	} else {
+		require.ErrorIs(t, err, os.ErrNotExist, "canonical kb dir must be statable or absent")
 	}
 
 	trashCount := 0

--- a/internal/daemon/sync_gc_kb_test.go
+++ b/internal/daemon/sync_gc_kb_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ func kbGCEnv(t *testing.T) string {
 // place).
 func makeKBDir(t *testing.T, kbID, marker string) string {
 	t.Helper()
-	dir := paths.KBDir(kbID)
+	dir := paths.KBDir(endpoint.Get(), kbID)
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "marker.txt"), []byte(marker), 0o644))
 	return dir
@@ -161,7 +162,7 @@ func TestKBGC_Reap_ExpiredEntryRemoved(t *testing.T) {
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
 
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	trashDir := filepath.Join(root, kbTrashDirName)
 	require.NoError(t, os.MkdirAll(trashDir, 0o755))
 
@@ -188,7 +189,7 @@ func TestKBGC_Reap_RecentEntryKept(t *testing.T) {
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
 
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	trashDir := filepath.Join(root, kbTrashDirName)
 	require.NoError(t, os.MkdirAll(trashDir, 0o755))
 
@@ -212,7 +213,7 @@ func TestKBGC_Reap_BadTimestampNeverDeletes(t *testing.T) {
 	s, _ := kbTestScheduler(t)
 	ctx := context.Background()
 
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	trashDir := filepath.Join(root, kbTrashDirName)
 	require.NoError(t, os.MkdirAll(trashDir, 0o755))
 
@@ -363,7 +364,7 @@ func TestKBGC_ConcurrentPasses_SafeUnderRename(t *testing.T) {
 	}
 	wg.Wait()
 
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	// every orphan should be in .trash/, none in the root
 	entries, err := os.ReadDir(root)
 	require.NoError(t, err)

--- a/internal/daemon/sync_kb_endpoint_test.go
+++ b/internal/daemon/sync_kb_endpoint_test.go
@@ -1,0 +1,83 @@
+package daemon
+
+// sync_kb_endpoint_test.go — regression tests for bead ox-651l: the daemon
+// resolved KB store paths through endpoint.Get() (env → single-login →
+// production default), ignoring the project's configured endpoint. A
+// test.sageox.ai project's bubbles were filed under the production
+// sageox.ai slug, defeating KBDir's staging/production isolation invariant.
+//
+// The class under test: every KB path the daemon derives (clone target,
+// symlink target, GC root, status root) must be scoped by the PROJECT's
+// endpoint, with the SAGEOX_ENDPOINT env var as the only override.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kbEndpointTestProject creates an initialized project whose config.json
+// pins an endpoint the machine is NOT otherwise using, so any fallback to
+// endpoint.Get()'s default is observable as a wrong path slug.
+func kbEndpointTestProject(t *testing.T, ep string) string {
+	t.Helper()
+	root := setupProjectWithConfig(t, "")
+	body := `{"endpoint":"` + ep + `","repo_id":"repo_kb_ep"}`
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".sageox", "config.json"), []byte(body), 0o644))
+	return root
+}
+
+// TestKBEndpoint_ProjectConfigWinsOverDefault verifies the scheduler
+// resolves KB paths from the project's configured endpoint when no env
+// override is set.
+//
+// Failure prevented: a test/staging project's bubbles silently landing in
+// the production sageox.ai store, where a production daemon's GC (which
+// trusts the production API list) would treat them as orphans — and where
+// kb_ids from different endpoints share one namespace with no collision
+// guarantee.
+func TestKBEndpoint_ProjectConfigWinsOverDefault(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("OX_XDG_DISABLE", "")
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "cache"))
+	t.Setenv("SAGEOX_ENDPOINT", "") // empty = unset: project config must win
+
+	projectRoot := kbEndpointTestProject(t, "https://test.sageox.ai")
+	s := newSymlinkTestScheduler(t, projectRoot)
+
+	assert.Equal(t, "https://test.sageox.ai", s.kbEndpoint(),
+		"kbEndpoint must resolve the project's endpoint, not the machine default")
+
+	// Drive the real symlink reconciler: the per-project mount must point
+	// into the project-endpoint slug's store, not the production default.
+	s.reconcileProjectSymlinks(context.Background(), projectRoot, []api.KB{
+		{KBID: "kb_team", KBType: api.KBTypeTeam, Slug: "platform"},
+	})
+
+	target, err := os.Readlink(filepath.Join(projectRoot, ".sageox", "kb", "team", "platform"))
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tmp, "sageox", "test.sageox.ai", "kb", "kb_team"), target,
+		"symlink must target the test.sageox.ai store, not the sageox.ai default")
+}
+
+// TestKBEndpoint_EnvOverrideStillWins verifies SAGEOX_ENDPOINT (the
+// explicit operator override) beats the project config, preserving the
+// documented precedence of endpoint.GetForProject.
+//
+// Failure prevented: fixing the default-fallback bug by accidentally
+// inverting precedence, which would break every workflow that pins an
+// endpoint via env (twin tests, staging smoke runs).
+func TestKBEndpoint_EnvOverrideStillWins(t *testing.T) {
+	t.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
+
+	projectRoot := kbEndpointTestProject(t, "https://test.sageox.ai")
+	s := newSymlinkTestScheduler(t, projectRoot)
+
+	assert.Equal(t, "https://staging.sageox.ai", s.kbEndpoint())
+}

--- a/internal/daemon/sync_symlinks.go
+++ b/internal/daemon/sync_symlinks.go
@@ -159,7 +159,7 @@ func (s *SyncScheduler) reconcileProjectSymlinksWithOps(ctx context.Context, pro
 
 		// 1. create/replace links present in desired.
 		for rel, kbID := range desired {
-			target := paths.KBDir(kbID)
+			target := paths.KBDir(s.kbEndpoint(), kbID)
 			if target == "" {
 				continue
 			}

--- a/internal/daemon/sync_symlinks_test.go
+++ b/internal/daemon/sync_symlinks_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -99,7 +100,7 @@ func TestReconcileProjectSymlinks_InitialCreate(t *testing.T) {
 	// targets resolve to canonical KBDir paths
 	target, err := os.Readlink(filepath.Join(kbDir, "team", "platform"))
 	require.NoError(t, err)
-	assert.Equal(t, paths.KBDir("kb_team"), target)
+	assert.Equal(t, paths.KBDir(endpoint.Get(), "kb_team"), target)
 }
 
 // TestReconcileProjectSymlinks_Idempotent verifies running the
@@ -174,7 +175,7 @@ func TestReconcileProjectSymlinks_KBRevoked_PrunesLinkButNotTarget(t *testing.T)
 	s := newSymlinkTestScheduler(t, projectRoot)
 
 	// pre-create the canonical target so the symlink resolves.
-	target := paths.KBDir("kb_p")
+	target := paths.KBDir(endpoint.Get(), "kb_p")
 	require.NoError(t, os.MkdirAll(target, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(target, "marker.txt"), []byte("present"), 0o644))
 
@@ -210,7 +211,7 @@ func TestReconcileProjectSymlinks_FlatLayoutMigration(t *testing.T) {
 
 	// simulate the old flat layout: a symlink directly under .sageox/kb/
 	// pointing at the bubble's canonical dir.
-	target := paths.KBDir("kb_team")
+	target := paths.KBDir(endpoint.Get(), "kb_team")
 	require.NoError(t, os.MkdirAll(target, 0o755))
 	flatLink := filepath.Join(kbDir, "platform")
 	require.NoError(t, os.Symlink(target, flatLink))
@@ -526,7 +527,7 @@ func TestReconcileProjectSymlinks_TargetRelocated(t *testing.T) {
 	s := newSymlinkTestScheduler(t, projectRoot)
 
 	bubbles := []api.KB{{KBID: "kb_p", KBType: api.KBTypePersonal, Slug: "personal-abc"}}
-	target := paths.KBDir("kb_p")
+	target := paths.KBDir(endpoint.Get(), "kb_p")
 	require.NoError(t, os.MkdirAll(target, 0o755))
 
 	// first pass — link points at the canonical target

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -543,16 +543,17 @@ func LedgersDataDir(repoID, ep string) string {
 // Endpoint-scoped (mandatory) so staging and production bubbles never collide.
 // Keyed by kb_id (immutable per ADR-036), not slug (renameable).
 //
+// IMPORTANT: ep is REQUIRED. Use endpoint.GetForProject(projectRoot) to get
+// the correct endpoint for a project context. Only use endpoint.Get() during
+// login or other flows with no project context. Passing the wrong endpoint
+// files a bubble under the wrong slug — a test.sageox.ai project's bubbles
+// must never land in the production sageox.ai store.
+//
 // Empty kb_id returns the base kb directory for that endpoint (matches the
 // LedgersDataDir(...) convention so callers can list all bubbles).
-func KBDir(kbID string) string {
-	// endpoint.Get() (not GetForProject) is correct here: KBDir is keyed by the
-	// immutable kb_id and is not project-bound. The KB store is per-machine,
-	// per-endpoint; a kb_id collides only if the user logs into multiple
-	// endpoints, in which case the endpoint subdir disambiguates.
-	ep := endpoint.Get()
+func KBDir(ep, kbID string) string {
 	if ep == "" {
-		panic("KBDir: endpoint is required - endpoint.Get() returned empty")
+		panic("KBDir: endpoint is required - use endpoint.GetForProject(projectRoot) not empty string")
 	}
 
 	slug := endpoint.NormalizeSlug(ep)
@@ -575,12 +576,12 @@ func KBDir(kbID string) string {
 // Endpoint-scoped, kb_id-keyed — same invariants as KBDir but rooted under
 // the XDG cache home rather than the data home.
 //
+// IMPORTANT: ep is REQUIRED — same contract as KBDir.
+//
 // Empty kb_id returns the base kb cache directory for that endpoint.
-func KBCacheDir(kbID string) string {
-	// see KBDir for the endpoint.Get() rationale.
-	ep := endpoint.Get()
+func KBCacheDir(ep, kbID string) string {
 	if ep == "" {
-		panic("KBCacheDir: endpoint is required - endpoint.Get() returned empty")
+		panic("KBCacheDir: endpoint is required - use endpoint.GetForProject(projectRoot) not empty string")
 	}
 
 	slug := endpoint.NormalizeSlug(ep)

--- a/internal/paths/paths_kb_test.go
+++ b/internal/paths/paths_kb_test.go
@@ -20,7 +20,7 @@ func TestKBDir_EndpointScopedUnderDataHome(t *testing.T) {
 	clearXDGEnv()
 	tmp := t.TempDir()
 	os.Setenv("XDG_DATA_HOME", tmp)
-	os.Setenv("SAGEOX_ENDPOINT", "https://api.sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 
 	dir := KBDir("https://api.sageox.ai", "kb_abc123")
 	want := filepath.Join(tmp, "sageox", "sageox.ai", "kb", "kb_abc123")
@@ -41,10 +41,9 @@ func TestKBDir_EndpointIsolation(t *testing.T) {
 	clearXDGEnv()
 	os.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	os.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 	staging := KBDir("https://staging.sageox.ai", "kb_xyz")
 
-	os.Setenv("SAGEOX_ENDPOINT", "https://api.sageox.ai")
 	prod := KBDir("https://api.sageox.ai", "kb_xyz")
 
 	if staging == prod {
@@ -71,7 +70,7 @@ func TestKBDir_EmptyKBIDReturnsBase(t *testing.T) {
 	defer restoreEnv(saved)
 	clearXDGEnv()
 	os.Setenv("XDG_DATA_HOME", t.TempDir())
-	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 
 	dir := KBDir("https://sageox.ai", "")
 	if !strings.HasSuffix(dir, filepath.Join("sageox.ai", "kb")) {
@@ -93,7 +92,7 @@ func TestKBDir_KBIDSanitization(t *testing.T) {
 	defer restoreEnv(saved)
 	clearXDGEnv()
 	os.Setenv("XDG_DATA_HOME", t.TempDir())
-	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 
 	dir := KBDir("https://sageox.ai", "../../etc/passwd")
 	if strings.Contains(dir, "..") {
@@ -115,7 +114,7 @@ func TestKBCacheDir_UsesCacheNotDataDir(t *testing.T) {
 	dataRoot := t.TempDir()
 	os.Setenv("XDG_CACHE_HOME", cacheRoot)
 	os.Setenv("XDG_DATA_HOME", dataRoot)
-	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 
 	cache := KBCacheDir("https://sageox.ai", "kb_abc")
 	data := KBDir("https://sageox.ai", "kb_abc")
@@ -144,10 +143,9 @@ func TestKBCacheDir_EndpointIsolation(t *testing.T) {
 	clearXDGEnv()
 	os.Setenv("XDG_CACHE_HOME", t.TempDir())
 
-	os.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 	staging := KBCacheDir("https://staging.sageox.ai", "kb_xyz")
 
-	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
 	prod := KBCacheDir("https://sageox.ai", "kb_xyz")
 
 	if staging == prod {
@@ -226,7 +224,7 @@ func TestKBDir_XDGDataHomeOverride(t *testing.T) {
 
 	custom := t.TempDir()
 	os.Setenv("XDG_DATA_HOME", custom)
-	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 
 	dir := KBDir("https://sageox.ai", "kb_abc")
 	if !strings.HasPrefix(dir, custom) {
@@ -244,7 +242,7 @@ func TestKBCacheDir_XDGCacheHomeOverride(t *testing.T) {
 
 	custom := t.TempDir()
 	os.Setenv("XDG_CACHE_HOME", custom)
-	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 
 	dir := KBCacheDir("https://sageox.ai", "kb_abc")
 	if !strings.HasPrefix(dir, custom) {
@@ -263,7 +261,7 @@ func TestKBDir_LegacyXDGDisable(t *testing.T) {
 	clearXDGEnv()
 
 	os.Setenv("OX_XDG_DISABLE", "1")
-	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
+	os.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid") // must not leak into the explicit-ep path
 
 	dir := KBDir("https://sageox.ai", "kb_abc")
 	// legacy mode: ~/.sageox/data/<endpoint>/kb/<kb_id>

--- a/internal/paths/paths_kb_test.go
+++ b/internal/paths/paths_kb_test.go
@@ -22,7 +22,7 @@ func TestKBDir_EndpointScopedUnderDataHome(t *testing.T) {
 	os.Setenv("XDG_DATA_HOME", tmp)
 	os.Setenv("SAGEOX_ENDPOINT", "https://api.sageox.ai")
 
-	dir := KBDir("kb_abc123")
+	dir := KBDir("https://api.sageox.ai", "kb_abc123")
 	want := filepath.Join(tmp, "sageox", "sageox.ai", "kb", "kb_abc123")
 	if dir != want {
 		t.Errorf("KBDir(kb_abc123) = %q, want %q", dir, want)
@@ -42,10 +42,10 @@ func TestKBDir_EndpointIsolation(t *testing.T) {
 	os.Setenv("XDG_DATA_HOME", t.TempDir())
 
 	os.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
-	staging := KBDir("kb_xyz")
+	staging := KBDir("https://staging.sageox.ai", "kb_xyz")
 
 	os.Setenv("SAGEOX_ENDPOINT", "https://api.sageox.ai")
-	prod := KBDir("kb_xyz")
+	prod := KBDir("https://api.sageox.ai", "kb_xyz")
 
 	if staging == prod {
 		t.Fatalf("KBDir for staging and prod must differ; both = %q", staging)
@@ -73,7 +73,7 @@ func TestKBDir_EmptyKBIDReturnsBase(t *testing.T) {
 	os.Setenv("XDG_DATA_HOME", t.TempDir())
 	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
 
-	dir := KBDir("")
+	dir := KBDir("https://sageox.ai", "")
 	if !strings.HasSuffix(dir, filepath.Join("sageox.ai", "kb")) {
 		t.Errorf("KBDir('') = %q, want suffix sageox.ai/kb", dir)
 	}
@@ -95,7 +95,7 @@ func TestKBDir_KBIDSanitization(t *testing.T) {
 	os.Setenv("XDG_DATA_HOME", t.TempDir())
 	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
 
-	dir := KBDir("../../etc/passwd")
+	dir := KBDir("https://sageox.ai", "../../etc/passwd")
 	if strings.Contains(dir, "..") {
 		t.Errorf("KBDir traversal not sanitized: %q", dir)
 	}
@@ -117,8 +117,8 @@ func TestKBCacheDir_UsesCacheNotDataDir(t *testing.T) {
 	os.Setenv("XDG_DATA_HOME", dataRoot)
 	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
 
-	cache := KBCacheDir("kb_abc")
-	data := KBDir("kb_abc")
+	cache := KBCacheDir("https://sageox.ai", "kb_abc")
+	data := KBDir("https://sageox.ai", "kb_abc")
 
 	wantCache := filepath.Join(cacheRoot, "sageox", "sageox.ai", "kb", "kb_abc")
 	if cache != wantCache {
@@ -145,10 +145,10 @@ func TestKBCacheDir_EndpointIsolation(t *testing.T) {
 	os.Setenv("XDG_CACHE_HOME", t.TempDir())
 
 	os.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
-	staging := KBCacheDir("kb_xyz")
+	staging := KBCacheDir("https://staging.sageox.ai", "kb_xyz")
 
 	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
-	prod := KBCacheDir("kb_xyz")
+	prod := KBCacheDir("https://sageox.ai", "kb_xyz")
 
 	if staging == prod {
 		t.Fatalf("KBCacheDir for staging and prod must differ; both = %q", staging)
@@ -228,7 +228,7 @@ func TestKBDir_XDGDataHomeOverride(t *testing.T) {
 	os.Setenv("XDG_DATA_HOME", custom)
 	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
 
-	dir := KBDir("kb_abc")
+	dir := KBDir("https://sageox.ai", "kb_abc")
 	if !strings.HasPrefix(dir, custom) {
 		t.Errorf("KBDir = %q, want prefix %q (XDG_DATA_HOME override)", dir, custom)
 	}
@@ -246,7 +246,7 @@ func TestKBCacheDir_XDGCacheHomeOverride(t *testing.T) {
 	os.Setenv("XDG_CACHE_HOME", custom)
 	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
 
-	dir := KBCacheDir("kb_abc")
+	dir := KBCacheDir("https://sageox.ai", "kb_abc")
 	if !strings.HasPrefix(dir, custom) {
 		t.Errorf("KBCacheDir = %q, want prefix %q (XDG_CACHE_HOME override)", dir, custom)
 	}
@@ -265,7 +265,7 @@ func TestKBDir_LegacyXDGDisable(t *testing.T) {
 	os.Setenv("OX_XDG_DISABLE", "1")
 	os.Setenv("SAGEOX_ENDPOINT", "https://sageox.ai")
 
-	dir := KBDir("kb_abc")
+	dir := KBDir("https://sageox.ai", "kb_abc")
 	// legacy mode: ~/.sageox/data/<endpoint>/kb/<kb_id>
 	if !strings.Contains(dir, filepath.Join(".sageox", "data", "sageox.ai", "kb", "kb_abc")) {
 		t.Errorf("KBDir under OX_XDG_DISABLE = %q, want path under .sageox/data/sageox.ai/kb/kb_abc", dir)

--- a/tests/kb_twin/compare_test.go
+++ b/tests/kb_twin/compare_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,7 +61,7 @@ func assertExpectedState(t *testing.T, dctx kbDiagContext, expected ExpectedStat
 // assertExpectedKB checks a single bubble's on-disk state.
 func assertExpectedKB(t *testing.T, dctx kbDiagContext, kbID string, ek ExpectedKB) {
 	t.Helper()
-	target := paths.KBDir(kbID)
+	target := paths.KBDir(endpoint.Get(), kbID)
 	gitDir := filepath.Join(target, ".git")
 
 	_, gitErr := os.Stat(gitDir)
@@ -173,7 +174,7 @@ func assertExpectedSymlink(t *testing.T, dctx kbDiagContext, sl ExpectedSymlink,
 		t.Errorf("%sreadlink %s: %v", dctx.prefix(), link, err)
 		return
 	}
-	want := paths.KBDir(sl.TargetKBID)
+	want := paths.KBDir(endpoint.Get(), sl.TargetKBID)
 	if got != want {
 		t.Errorf("%ssymlink %s -> %s, want %s",
 			dctx.prefix(), link, got, want)
@@ -185,7 +186,7 @@ func assertExpectedSymlink(t *testing.T, dctx kbDiagContext, sl ExpectedSymlink,
 // presence so changes to the suffix format don't ripple here.
 func assertExpectedTrash(t *testing.T, dctx kbDiagContext, tr ExpectedTrash) {
 	t.Helper()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	trashDir := filepath.Join(root, ".trash")
 	entries, err := os.ReadDir(trashDir)
 	if err != nil && !os.IsNotExist(err) {
@@ -227,7 +228,7 @@ func sortedKeys(m map[string]string) []string {
 // but this guard is cheap and intent-revealing.)
 func requireFreshKBRoot(t *testing.T) {
 	t.Helper()
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	if root == "" {
 		require.Fail(t, "paths.KBDir resolution failed — endpoint not set?")
 		return

--- a/tests/kb_twin/twin_test.go
+++ b/tests/kb_twin/twin_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/daemon"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/paths"
 )
@@ -282,7 +283,7 @@ func pokePastFetchHead(bubbles []api.KB) {
 		if b.KBID == "" {
 			continue
 		}
-		fetchHead := filepath.Join(paths.KBDir(b.KBID), ".git", "FETCH_HEAD")
+		fetchHead := filepath.Join(paths.KBDir(endpoint.Get(), b.KBID), ".git", "FETCH_HEAD")
 		info, err := os.Stat(fetchHead)
 		if err != nil {
 			continue // no FETCH_HEAD yet, nothing to backdate
@@ -363,7 +364,7 @@ func TestKBTwin_MultiEndpoint(t *testing.T) {
 			sched.SyncBubblesForTest(ctx)
 
 			// resolve KBDir under THIS endpoint and confirm the clone landed.
-			target := paths.KBDir("kb_shared_id")
+			target := paths.KBDir(endpoint.Get(), "kb_shared_id")
 			if _, err := os.Stat(filepath.Join(target, ".git")); err != nil {
 				t.Fatalf("expected clone at %s for endpoint %s: %v", target, ep, err)
 			}
@@ -401,7 +402,7 @@ func TestKBTwin_APIUnavailable_NoSideEffects(t *testing.T) {
 		return nil, api.ErrKBAPIUnavailable
 	})
 
-	root := paths.KBDir("")
+	root := paths.KBDir(endpoint.Get(), "")
 	entries, err := os.ReadDir(root)
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatalf("read kb root %s: %v", root, err)
@@ -454,7 +455,7 @@ func TestKBTwin_MetaJSONShape(t *testing.T) {
 	defer cancel()
 	sched.SyncBubblesForTest(ctx)
 
-	target := paths.KBDir(bubble.KBID)
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
 	raw, err := os.ReadFile(filepath.Join(target, ".sageox", "meta.json"))
 	if err != nil {
 		t.Fatalf("read meta: %v", err)


### PR DESCRIPTION
## What broke

A daemon syncing a **test.sageox.ai** project wrote its knowledge bubbles into the **production** store at `~/.local/share/sageox/sageox.ai/kb/` — the `test.sageox.ai/kb/` directory never existed, even though `ox daemon status` showed the KBs syncing green (observed live on a test-recordings project; bead **ox-651l**).

- **Root cause:** `paths.KBDir`/`KBCacheDir` resolved their endpoint via `endpoint.Get()` (env var → single-login → production default), ignoring the project's configured endpoint. With one login on `sageox.ai` and no `SAGEOX_ENDPOINT` set, every project on the machine filed KBs under the production slug.
- **Why it matters:** it defeats KBDir's own documented invariant ("endpoint-scoped so staging and production bubbles never collide"). kb_ids from different endpoints share one namespace with no collision guarantee, and one endpoint's GC (which trusts *its* API list) would triage the other endpoint's clones as orphans.
- The in-function comment even asserted `endpoint.Get()` was "correct here" — while `endpoint.Get()`'s own doc warns it "will cause bugs where operations target production" when a project context exists.

```mermaid
flowchart LR
    subgraph before [Before]
        A[daemon for test.sageox.ai project] -->|"paths.KBDir(kb_id)"| B["endpoint.Get() → https://sageox.ai (default)"]
        B --> C["~/.local/share/sageox/sageox.ai/kb/ ❌ wrong slug"]
    end
    subgraph after [After]
        D[daemon for test.sageox.ai project] -->|"paths.KBDir(ep, kb_id)"| E["endpoint.GetForProject(projectRoot) → https://test.sageox.ai"]
        E --> F["~/.local/share/sageox/test.sageox.ai/kb/ ✅"]
    end
```

## What this PR ships

- **`internal/paths`:** `KBDir` and `KBCacheDir` now take a required `ep` parameter — the exact contract of their siblings `LedgersDataDir`/`TeamsDataDir`/`HeartbeatCacheDir` ("use `endpoint.GetForProject(projectRoot)`"). The misleading rationale comment is gone.
- **`internal/daemon`:** new `SyncScheduler.kbEndpoint()` (= `endpoint.GetForProject(s.config.ProjectRoot)`, the same resolution the KB API lister and clone-URL builder already used) now scopes all four KB path consumers: bubble reconciler (clone/pull target), project symlink targets, GC root, and daemon-status rows. Path scope and API scope can no longer disagree.
- **`cmd/ox`:** prime, `ox doctor` (kb root now resolves identically to the API list the orphan check compares against), and `ox kb describe` pass the project endpoint they already had in scope.
- **Regression tests** (`internal/daemon/sync_kb_endpoint_test.go`), verified red-without-fix / green-with-fix:

| Test | Failure prevented |
|------|-------------------|
| `TestKBEndpoint_ProjectConfigWinsOverDefault` | project KBs filed under the production default slug (drives the real symlink reconciler; red run reproduces the exact reported paths) |
| `TestKBEndpoint_EnvOverrideStillWins` | fixing the fallback by accidentally inverting precedence, breaking `SAGEOX_ENDPOINT`-pinned workflows |

- ~115 existing test call sites updated mechanically (`paths.KBDir(...)` → `paths.KBDir(endpoint.Get(), ...)` — behavior-preserving since those tests pin `SAGEOX_ENDPOINT`, which both resolvers honor first).

## Migration / existing machines

KB clones are read-only daemon mirrors, so recloning is lossless: the fixed daemon clones into the correct endpoint slug and repoints the project symlinks on its next pass. Pre-fix orphan dirs under the wrong slug are inert; **ox-2um4** (P3) tracks a doctor check to detect and clean them.

## Test Plan

- [x] `make lint` — 0 issues
- [x] `make test` — 17,100 tests, 0 failures
- [x] `go test -tags kb_twin ./tests/kb_twin/`
- [x] Regression tests verified to fail with the fix neutered (reproducing the reported `sageox.ai`-instead-of-`test.sageox.ai` path) and pass with it restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)
SageOx-Session: https://sageox.ai/c/ses_019fafe6-73ac-74a7-aeb3-c63b2be13b7d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Knowledge Bubble data, cache, and workspace paths are now correctly isolated per endpoint.
  * Project-specific endpoint settings are consistently respected for Knowledge Bubble storage and checkout locations.
  * Improved resilience when endpoint configuration is missing/empty, avoiding crashes and ensuring safe “no bubbles”/empty outcomes.
  * `kb describe` now reports accurate endpoint-scoped `local_path` values.
  * Symlink reconciliation, bubble synchronization, garbage collection, and status reporting now target the correct endpoint-scoped storage locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->