### PR TITLE
fix(status): pass project endpoint to paths.KBDir — unbreak main

### DIFF
--- a/cmd/ox/status_bubbles.go
+++ b/cmd/ox/status_bubbles.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/kb"
-	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/status"
 )
 
@@ -57,6 +56,12 @@ type statusBubblesSummary struct {
 	// Unavailable reports that the fetch could not run at all. Renderers
 	// show "(unavailable)" and skip the breakdown.
 	Unavailable bool
+
+	// Endpoint is the API endpoint the rows were fetched from. Carried on
+	// the summary because the canonical KB store is endpoint-scoped
+	// (paths.KBDir) — resolving a bubble's mount path under any other
+	// endpoint would point the card at a different store's directory.
+	Endpoint string
 }
 
 // statusBubblesTypeOrder is the canonical render order for the by-type
@@ -192,12 +197,16 @@ type statusBubbleRow struct {
 	Git    gitRepoStatus
 }
 
-// statusKBDirForBubble resolves a bubble's canonical checkout directory.
+// statusKBDirForBubble resolves a bubble's canonical checkout directory
+// under the endpoint its row was fetched from. The KB store is
+// endpoint-scoped, so ep is load-bearing, not decorative: passing the
+// endpoint.Get() default instead of the project's would point a
+// test.sageox.ai project's cards at the production store.
+//
 // Seam variable so tests can point rows at a temp dir without endpoint
-// plumbing; production is paths.KBDir.
-var statusKBDirForBubble = func(kbID string) string {
-	return paths.KBDir(kbID)
-}
+// plumbing; production is kbDirSafe, which degrades to "" rather than
+// letting paths.KBDir's empty-endpoint panic abort the whole status run.
+var statusKBDirForBubble = kbDirSafe
 
 // collectBubbleRows derives per-bubble local state from a summary. Sync
 // times layer the same way as the team-context cards: daemon (freshest)
@@ -209,7 +218,7 @@ func collectBubbleRows(s statusBubblesSummary, daemonStatus *daemon.StatusData) 
 	for _, bub := range s.Bubbles {
 		row := statusBubbleRow{Bubble: bub, Path: bub.LocalPath}
 		if row.Path == "" && bub.KBID != "" {
-			row.Path = statusKBDirForBubble(bub.KBID)
+			row.Path = statusKBDirForBubble(s.Endpoint, bub.KBID)
 		}
 		if row.Path != "" {
 			if _, err := os.Stat(filepath.Join(row.Path, ".git")); err == nil {
@@ -401,13 +410,18 @@ func buildBubblesJSON(s statusBubblesSummary) *status.BubblesJSON {
 // collectBubblesSummary fetches bubbles with a short timeout and returns a
 // summary. Fetch problems never propagate upward — `ox status` must keep
 // rendering the rest of the report.
-func collectBubblesSummary(fetch statusBubblesFetch) statusBubblesSummary {
+//
+// ep is the endpoint the fetch targeted; it rides along on the summary so
+// mount-path resolution uses the same endpoint that produced the rows.
+func collectBubblesSummary(fetch statusBubblesFetch, ep string) statusBubblesSummary {
 	if fetch == nil {
 		return statusBubblesSummary{Unavailable: true}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	return summarizeBubbles(fetch(ctx))
+	s := summarizeBubbles(fetch(ctx))
+	s.Endpoint = ep
+	return s
 }
 
 // statusBubblesFetch is the seam between status rendering and the KB fetch,
@@ -417,12 +431,17 @@ type statusBubblesFetch func(ctx context.Context) kb.ListResult
 // statusBubblesFetchForRoot is the production wiring: same client
 // construction as `ox kb list` so the two surfaces cannot disagree.
 // Tests assign a fake.
-var statusBubblesFetchForRoot = func(projectRoot string) statusBubblesFetch {
+//
+// Returns the resolved project endpoint alongside the fetch. One
+// resolution, two consumers (the API client and the KB store path) — a
+// second independent lookup is how the fetched rows and the rendered
+// mount paths would drift onto different endpoints.
+var statusBubblesFetchForRoot = func(projectRoot string) (statusBubblesFetch, string) {
 	source, ep := newDefaultKBListSource(projectRoot)
 	scopes := ambientKBScopes(projectRoot)
 	return func(ctx context.Context) kb.ListResult {
 		return kb.FetchBubbles(ctx, source, ep, scopes)
-	}
+	}, ep
 }
 
 // commonDir returns the longest shared leading directory of a and b.

--- a/cmd/ox/status_bubbles_test.go
+++ b/cmd/ox/status_bubbles_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/kb"
+	"github.com/sageox/ox/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -333,13 +334,15 @@ func TestCollectBubblesSummary_UsesFetchResult(t *testing.T) {
 			Warnings: []kb.Warning{{Err: "partial"}},
 		}
 	}
-	s := collectBubblesSummary(fetch)
+	s := collectBubblesSummary(fetch, "https://api.test.sageox.ai")
 	assert.False(t, s.Unavailable)
 	assert.Equal(t, 2, s.Total)
 	assert.Equal(t, 1, s.ByType["team"])
 	assert.Equal(t, 1, s.ByType["repo"])
 	require.Len(t, s.Warnings, 1)
 	assert.Equal(t, "partial", s.Warnings[0].Err)
+	assert.Equal(t, "https://api.test.sageox.ai", s.Endpoint,
+		"the fetch endpoint must ride along — mount paths are resolved under it")
 }
 
 // TestCollectBubblesSummary_NilFetchIsUnavailable verifies the defensive
@@ -350,7 +353,7 @@ func TestCollectBubblesSummary_UsesFetchResult(t *testing.T) {
 func TestCollectBubblesSummary_NilFetchIsUnavailable(t *testing.T) {
 	t.Parallel()
 
-	s := collectBubblesSummary(nil)
+	s := collectBubblesSummary(nil, "https://api.sageox.ai")
 	assert.True(t, s.Unavailable)
 }
 
@@ -426,7 +429,7 @@ func fakeKBStore(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	orig := statusKBDirForBubble
-	statusKBDirForBubble = func(kbID string) string {
+	statusKBDirForBubble = func(_, kbID string) string {
 		return filepath.Join(dir, kbID)
 	}
 	t.Cleanup(func() { statusKBDirForBubble = orig })
@@ -471,6 +474,55 @@ func TestCollectBubbleRows_PathAndSortOrder(t *testing.T) {
 	assert.Equal(t, "kb_team", rows[1].Bubble.KBID)
 	assert.True(t, rows[1].Cloned, "a real git checkout must be detected as cloned")
 	assert.Equal(t, clonedPath, rows[1].Path)
+}
+
+// TestCollectBubbleRows_ResolvesPathUnderSummaryEndpoint drives the
+// PRODUCTION path resolver (no fakeKBStore seam — the temp-dir fake ignores
+// the endpoint and would hide exactly this bug) and verifies rows land in
+// the KB store of the endpoint the rows were fetched from.
+//
+// Failure prevented: a test.sageox.ai project's cards pointing at the
+// production store — the class of bug PR #734 fixed. It surfaces only as
+// bubbles resolving to the wrong directory (mounted bubbles reported "not
+// cloned", and vice versa), never as an error.
+func TestCollectBubbleRows_ResolvesPathUnderSummaryEndpoint(t *testing.T) {
+	// not parallel: reads the package-global statusKBDirForBubble seam
+	// other tests in this file swap out.
+	const projectEP = "https://api.test.sageox.ai"
+	const defaultEP = "https://api.sageox.ai"
+
+	s := summarizeBubbles(kb.ListResult{
+		Bubbles: []kb.Bubble{{KBID: "kb_x", Type: api.KBTypeTeam, Slug: "eng", ScopeType: "team"}},
+	})
+	s.Endpoint = projectEP
+
+	rows := collectBubbleRows(s, nil)
+	require.Len(t, rows, 1)
+	assert.Equal(t, paths.KBDir(projectEP, "kb_x"), rows[0].Path)
+	assert.Contains(t, rows[0].Path, filepath.Join("test.sageox.ai", "kb"),
+		"mount path must be scoped by the project endpoint's slug")
+	assert.NotEqual(t, paths.KBDir(defaultEP, "kb_x"), rows[0].Path,
+		"resolving under the endpoint.Get() default reintroduces the #734 bug")
+}
+
+// TestCollectBubbleRows_EmptyEndpointDegrades verifies an unresolved
+// endpoint yields an empty path instead of aborting `ox status`.
+//
+// Failure prevented: paths.KBDir panics on an empty endpoint by contract;
+// a fresh install or unconfigured shell would crash the whole status run
+// instead of rendering the bubble without a mount path.
+func TestCollectBubbleRows_EmptyEndpointDegrades(t *testing.T) {
+	s := summarizeBubbles(kb.ListResult{
+		Bubbles: []kb.Bubble{{KBID: "kb_x", Type: api.KBTypeTeam}},
+	})
+	s.Endpoint = ""
+
+	require.NotPanics(t, func() {
+		rows := collectBubbleRows(s, nil)
+		require.Len(t, rows, 1)
+		assert.Empty(t, rows[0].Path)
+		assert.False(t, rows[0].Cloned)
+	})
 }
 
 // TestRenderBubblesSection_CardsShowPathAndStatus verifies the human

--- a/cmd/ox/status_bubbles_test.go
+++ b/cmd/ox/status_bubbles_test.go
@@ -486,10 +486,22 @@ func TestCollectBubbleRows_PathAndSortOrder(t *testing.T) {
 // bubbles resolving to the wrong directory (mounted bubbles reported "not
 // cloned", and vice versa), never as an error.
 func TestCollectBubbleRows_ResolvesPathUnderSummaryEndpoint(t *testing.T) {
-	// not parallel: reads the package-global statusKBDirForBubble seam
-	// other tests in this file swap out.
+	// not parallel: t.Setenv, plus this reads the package-global
+	// statusKBDirForBubble seam other tests in this file swap out.
 	const projectEP = "https://api.test.sageox.ai"
 	const defaultEP = "https://api.sageox.ai"
+
+	// Pin the XDG data root to a temp dir. Keeping the production resolver
+	// is the point of this test, but letting it resolve into the real
+	// ~/.local/share/sageox is not: test.sageox.ai is the staging slug, so a
+	// SageOx developer plausibly has a genuine kb_x checkout there. That
+	// would make Cloned/Git non-deterministic and run git against a real
+	// repo. OX_XDG_DISABLE is cleared so the root is honored either way.
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("OX_XDG_DISABLE", "")
+	// Decoy ambient endpoint — it must never leak into the explicit-ep
+	// path. Same guard internal/paths/paths_kb_test.go uses.
+	t.Setenv("SAGEOX_ENDPOINT", "https://decoy.example.invalid")
 
 	s := summarizeBubbles(kb.ListResult{
 		Bubbles: []kb.Bubble{{KBID: "kb_x", Type: api.KBTypeTeam, Slug: "eng", ScopeType: "team"}},
@@ -503,6 +515,10 @@ func TestCollectBubbleRows_ResolvesPathUnderSummaryEndpoint(t *testing.T) {
 		"mount path must be scoped by the project endpoint's slug")
 	assert.NotEqual(t, paths.KBDir(defaultEP, "kb_x"), rows[0].Path,
 		"resolving under the endpoint.Get() default reintroduces the #734 bug")
+	assert.NotContains(t, rows[0].Path, "decoy.example.invalid",
+		"the ambient SAGEOX_ENDPOINT must not leak into an explicitly-scoped path")
+	// Deterministic now that the data root is empty: nothing is on disk.
+	assert.False(t, rows[0].Cloned, "temp data root must contain no checkout")
 }
 
 // TestCollectBubbleRows_EmptyEndpointDegrades verifies an unresolved


### PR DESCRIPTION
## Summary

**`main` is currently unbuildable.** `go build ./cmd/ox` fails at `status_bubbles.go:199`. This PR unbreaks it.

- **What broke:** a semantic conflict between two independently-green PRs merged **38 seconds apart** on 2026-07-29.
  - `3df6f4bd` (#733, 23:19:34 UTC) added the call site `paths.KBDir(kbID)`
  - `b9138672` (#734, 23:20:12 UTC) changed the signature to `KBDir(ep, kbID)` and updated its own call sites — but not the one #733 had just landed
- Both PRs branched from the same base (`88db4185`), so neither one's checks ever saw the other's change. Each was green; together they are red.
- **Neither commit is wrong in isolation.** `3df6f4bd` compiles clean; `b9138672` does not.

```mermaid
graph LR
    B["88db4185<br/>shared base"] --> P733["#733 CI ✅<br/>adds KBDir(kbID)"]
    B --> P734["#734 CI ✅<br/>sig → KBDir(ep, kbID)"]
    P733 -->|"23:19:34"| M1["3df6f4bd ✅"]
    P734 -->|"23:20:12<br/>never re-validated"| M2["b9138672 ❌ main red"]
    M1 --> M2
    M2 --> F["this PR ✅"]
```

## What this PR ships

The naive fix is to pass *some* endpoint to satisfy the compiler. That would silently undo #734, whose entire point is that the KB store is **endpoint-scoped** — `paths.KBDir` panics on an empty `ep` by contract, and passing the `endpoint.Get()` default instead of the project's would file a `test.sageox.ai` project's bubbles under the production store. That failure never surfaces as an error, only as KBs resolving to the wrong directory.

So this threads the **same** endpoint the rows were fetched from:

- **`statusBubblesFetchForRoot`** now returns `(fetch, ep)`. It already called `newDefaultKBListSource(projectRoot)` — which resolves `endpoint.GetForProject(...)`, matching #734's other call sites — and was throwing the `ep` away. One resolution, two consumers (API client + store path); a second independent lookup is exactly how the fetched rows and the rendered mount paths would drift onto different endpoints.
- **`statusBubblesSummary.Endpoint`** carries it to `collectBubbleRows` / `buildBubblesJSON`, which only ever receive the summary.
- **`statusKBDirForBubble`** is now the existing `kbDirSafe` helper (added by #734 for `ox agent prime`) rather than a second hand-rolled `recover()`. `ox status` must degrade to a blank path, not crash, when the endpoint is unresolved.
- `cmd/ox/status.go` needed **no** change — Go permits `f(g())` when `g`'s results match `f`'s params exactly.

**Audited the whole class, not just the one line.** #734 changed **two** signatures — `KBDir` *and* `KBCacheDir`. Every call site of both across the module (`cmd/`, `internal/`, `tests/`) now matches the 2-arg form; `KBCacheDir` has no non-test callers, which is why it survived unnoticed.

## Test Plan

| Gate | Result |
|---|---|
| `go build ./...` | pass (whole module, not just `./cmd/ox`) |
| `go vet ./...` | pass — also compiles every test binary |
| `make build` / `make lint` | pass / **0 issues** |
| `gofmt` | clean |
| `./bin/ox status` + `ox status --json` | bubbles section renders, no panic |

**Two regression tests, both verified to fail without the fix** (neutered `s.Endpoint` → hardcoded prod endpoint, watched them go red, restored):

- `TestCollectBubbleRows_ResolvesPathUnderSummaryEndpoint` — drives the **production** resolver, deliberately *not* the `fakeKBStore` temp-dir seam. That seam ignores `ep` entirely and would hide exactly this bug.
- `TestCollectBubbleRows_EmptyEndpointDegrades` — unresolved endpoint yields an empty path instead of aborting the whole status run.

**Pre-existing failures, unrelated to this PR:** `TestRunKBChecks_SkipsAPIChecksWhenAPIUnavailable_RunsStaleSync` and `TestRunKBChecks_PanicInOneCheckDoesNotCascade` fail locally. Confirmed identical at `3df6f4bd` (pre-#734) in a worktree, and they **pass under a clean `HOME`** — they leak the developer's real `~/.local/share/sageox` KB store into the stale-sync assertion. That is why CI is green on them. Everything else passes.

> No test "passed while main was broken." `status_bubbles` and `doctor_kb` are the same package, so the entire `cmd/ox` test binary failed to compile. **The tests weren't weak — the merge wasn't gated.**

## Follow-up: how main went red without anyone noticing

CI is **not** the gap. `.github/workflows/ci.yml` builds `./...` + tests + lint on both `pull_request` and `push: [main]`, and it caught this — run `30499196104`, `test` **and** `lint` both red with the exact compile error, 2 seconds after the merge.

The gap is that nothing gates the merge:

```
gh api repos/sageox/ox/branches/main/protection  →  404
gh api repos/sageox/ox/rulesets                  →  []
```

No branch protection, no rulesets. So (a) nothing requires CI green before merge, and (b) — the load-bearing one — nothing requires a PR branch to be up to date with `main`. #734's checks validated a merge ref computed against pre-#733 `main` and were never re-run.

**Smallest gate that closes it:** a ruleset on `main` with required checks `test` + `lint` **and** strict mode ("require branches to be up to date before merging"). Strict mode is the part that matters — it forces #734 to rebase and re-run. GitHub merge queue is the ergonomic equivalent without per-author rebase churn. Needs repo admin, so it is not in this PR.


---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added — two regression tests, each verified red without the fix
- [x] CHANGELOG entry — **N/A**, not user-facing. #734 is post-`0.12.0` and unreleased, so no shipped version ever had this break; `[Unreleased]` needs no entry for "main compiles again"
- [x] Breaking change — **N/A**, no public surface changed. All edits are to unexported identifiers in `package main`
- [x] `/security-review` — **N/A** documented. Diff touches only `cmd/ox/status_bubbles*.go`; none of `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum`. Endpoint scoping is a correctness/data-isolation concern, and the change strengthens it rather than relaxing it

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status bubble path resolution so bubble mount paths correctly follow the knowledge base’s active endpoint.
  * Added safer handling for missing/empty endpoint information, preventing errors and ensuring bubbles are correctly marked as unavailable or not cloned.  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->