### PR TITLE
fix(carts): verify a recorded server before signalling its PID

### DIFF
--- a/internal/carts/server.go
+++ b/internal/carts/server.go
@@ -241,7 +241,16 @@ func waitForServer(host string, port int, timeout time.Duration) error {
 	return fmt.Errorf("timeout waiting for dolt server on port %d", port)
 }
 
-// StopServer stops a running dolt server for the given carts directory.
+// StopServer stops the dolt server recorded for the given carts directory.
+//
+// A recorded PID is NOT sufficient authority to signal it. runningServerPort
+// already refuses to REUSE a record without probing the endpoint, because a
+// crash can leave a stale record while the OS reassigns that PID to an unrelated
+// process. Stopping needs the same proof for a stronger reason: reusing a wrong
+// record fails a carts command, whereas signalling a wrong PID kills a process
+// that has nothing to do with ox.
+//
+// Stale records are still cleared, so a bad record cannot wedge future starts.
 func StopServer(cartsDir string) error {
 	pidData, err := os.ReadFile(filepath.Join(cartsDir, pidFileName))
 	if err != nil {
@@ -249,15 +258,38 @@ func StopServer(cartsDir string) error {
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
 	if err != nil {
+		clearServerState(cartsDir)
 		return nil
 	}
-	proc, err := os.FindProcess(pid)
+
+	portData, err := os.ReadFile(filepath.Join(cartsDir, portFileName))
 	if err != nil {
+		clearServerState(cartsDir)
 		return nil
 	}
-	_ = proc.Signal(os.Interrupt)
-	// Clean up state files
-	os.Remove(filepath.Join(cartsDir, pidFileName))
-	os.Remove(filepath.Join(cartsDir, portFileName))
+	port, err := strconv.Atoi(strings.TrimSpace(string(portData)))
+	if err != nil {
+		clearServerState(cartsDir)
+		return nil
+	}
+
+	// Bind the PID to a live dolt server on the recorded port before signalling.
+	if !proc.IsAlive(pid) || pingEndpoint(serverHost, port, endpointCheckTimeout) != nil {
+		clearServerState(cartsDir)
+		return nil
+	}
+
+	if err := proc.Terminate(pid); err != nil {
+		// Leave the record: the server is still running and still discoverable,
+		// which beats orphaning it behind deleted state.
+		return fmt.Errorf("stop carts dolt server %d: %w", pid, err)
+	}
+	clearServerState(cartsDir)
 	return nil
+}
+
+// clearServerState removes the recorded pid/port pair.
+func clearServerState(cartsDir string) {
+	_ = os.Remove(filepath.Join(cartsDir, pidFileName))
+	_ = os.Remove(filepath.Join(cartsDir, portFileName))
 }

--- a/internal/carts/server.go
+++ b/internal/carts/server.go
@@ -247,7 +247,7 @@ func waitForServer(host string, port int, timeout time.Duration) error {
 // already refuses to REUSE a record without probing the endpoint, because a
 // crash can leave a stale record while the OS reassigns that PID to an unrelated
 // process. Stopping needs the same proof for a stronger reason: reusing a wrong
-// record fails a carts command, whereas signalling a wrong PID kills a process
+// record fails a carts command, whereas signaling a wrong PID kills a process
 // that has nothing to do with ox.
 //
 // Stale records are still cleared, so a bad record cannot wedge future starts.
@@ -273,7 +273,7 @@ func StopServer(cartsDir string) error {
 		return nil
 	}
 
-	// Bind the PID to a live dolt server on the recorded port before signalling.
+	// Bind the PID to a live dolt server on the recorded port before signaling.
 	if !proc.IsAlive(pid) || pingEndpoint(serverHost, port, endpointCheckTimeout) != nil {
 		clearServerState(cartsDir)
 		return nil

--- a/internal/carts/server_test.go
+++ b/internal/carts/server_test.go
@@ -81,14 +81,14 @@ func TestRunningServerPort(t *testing.T) {
 // TestStopServer covers the decision to SIGNAL a recorded PID, which needs the
 // same proof reuse does — for a stronger reason.
 //
-// Failure prevented: StopServer signalled whatever PID the state file named. A
+// Failure prevented: StopServer signaled whatever PID the state file named. A
 // crash leaves a stale record behind while the OS is free to reassign that PID,
 // so `ox carts` stopping its server could interrupt an unrelated process. Reuse
-// of a bad record merely fails a command; signalling one kills a stranger.
+// of a bad record merely fails a command; signaling one kills a stranger.
 func TestStopServer(t *testing.T) {
 	// livingHelper starts a child that stays up until the test ends. It returns
 	// the PID and a channel closed once the child has exited AND been reaped:
-	// proc.IsAlive alone would report a signalled-but-unreaped child as alive,
+	// proc.IsAlive alone would report a signaled-but-unreaped child as alive,
 	// because a zombie still answers.
 	livingHelper := func(t *testing.T) (int, <-chan struct{}) {
 		t.Helper()
@@ -125,7 +125,7 @@ func TestStopServer(t *testing.T) {
 		}
 		select {
 		case <-exited:
-			t.Fatal("signalled an unrelated process on the strength of a stale record")
+			t.Fatal("signaled an unrelated process on the strength of a stale record")
 		case <-time.After(500 * time.Millisecond):
 		}
 		assertStateCleared(t, dir)

--- a/internal/carts/server_test.go
+++ b/internal/carts/server_test.go
@@ -78,6 +78,125 @@ func TestRunningServerPort(t *testing.T) {
 	}
 }
 
+// TestStopServer covers the decision to SIGNAL a recorded PID, which needs the
+// same proof reuse does — for a stronger reason.
+//
+// Failure prevented: StopServer signalled whatever PID the state file named. A
+// crash leaves a stale record behind while the OS is free to reassign that PID,
+// so `ox carts` stopping its server could interrupt an unrelated process. Reuse
+// of a bad record merely fails a command; signalling one kills a stranger.
+func TestStopServer(t *testing.T) {
+	// livingHelper starts a child that stays up until the test ends. It returns
+	// the PID and a channel closed once the child has exited AND been reaped:
+	// proc.IsAlive alone would report a signalled-but-unreaped child as alive,
+	// because a zombie still answers.
+	livingHelper := func(t *testing.T) (int, <-chan struct{}) {
+		t.Helper()
+		cmd := exec.Command(os.Args[0], "-test.run=TestSleepHelper")
+		cmd.Env = append(os.Environ(), "OX_CARTS_SLEEP_HELPER=1")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("spawn sleep helper: %v", err)
+		}
+		exited := make(chan struct{})
+		go func() {
+			_, _ = cmd.Process.Wait()
+			close(exited)
+		}()
+		t.Cleanup(func() { _ = cmd.Process.Kill() })
+		return cmd.Process.Pid, exited
+	}
+
+	stubPing := func(t *testing.T, result error) {
+		t.Helper()
+		orig := pingEndpoint
+		pingEndpoint = func(string, int, time.Duration) error { return result }
+		t.Cleanup(func() { pingEndpoint = orig })
+	}
+
+	t.Run("leaves an unrelated live process alone when the endpoint is stale", func(t *testing.T) {
+		dir := t.TempDir()
+		pid, exited := livingHelper(t)
+		writeStateFile(t, dir, pidFileName, strconv.Itoa(pid))
+		writeStateFile(t, dir, portFileName, "50422")
+		stubPing(t, errStubUnreachable)
+
+		if err := StopServer(dir); err != nil {
+			t.Fatalf("StopServer: %v", err)
+		}
+		select {
+		case <-exited:
+			t.Fatal("signalled an unrelated process on the strength of a stale record")
+		case <-time.After(500 * time.Millisecond):
+		}
+		assertStateCleared(t, dir)
+	})
+
+	t.Run("stops the server when the recorded endpoint answers", func(t *testing.T) {
+		dir := t.TempDir()
+		pid, exited := livingHelper(t)
+		writeStateFile(t, dir, pidFileName, strconv.Itoa(pid))
+		writeStateFile(t, dir, portFileName, "50422")
+		stubPing(t, nil)
+
+		if err := StopServer(dir); err != nil {
+			t.Fatalf("StopServer: %v", err)
+		}
+		select {
+		case <-exited:
+		case <-time.After(5 * time.Second):
+			t.Fatal("expected the verified server process to be terminated")
+		}
+		assertStateCleared(t, dir)
+	})
+
+	t.Run("clears a record naming a dead process", func(t *testing.T) {
+		dir := t.TempDir()
+		writeStateFile(t, dir, pidFileName, strconv.Itoa(deadPID(t)))
+		writeStateFile(t, dir, portFileName, "50422")
+		stubPing(t, nil)
+
+		if err := StopServer(dir); err != nil {
+			t.Fatalf("StopServer: %v", err)
+		}
+		assertStateCleared(t, dir)
+	})
+
+	t.Run("clears a record missing its port file", func(t *testing.T) {
+		dir := t.TempDir()
+		writeStateFile(t, dir, pidFileName, strconv.Itoa(os.Getpid()))
+		stubPing(t, nil)
+
+		if err := StopServer(dir); err != nil {
+			t.Fatalf("StopServer: %v", err)
+		}
+		assertStateCleared(t, dir)
+	})
+
+	t.Run("no record is a no-op", func(t *testing.T) {
+		if err := StopServer(t.TempDir()); err != nil {
+			t.Fatalf("StopServer on an empty dir: %v", err)
+		}
+	})
+}
+
+// TestSleepHelper is not a test: it is the body of the long-lived child process
+// spawned by TestStopServer, and exits immediately unless that env var is set.
+func TestSleepHelper(t *testing.T) {
+	if os.Getenv("OX_CARTS_SLEEP_HELPER") != "1" {
+		t.Skip("helper process entry point; not a standalone test")
+	}
+	time.Sleep(60 * time.Second)
+}
+
+func assertStateCleared(t *testing.T, dir string) {
+	t.Helper()
+	for _, name := range []string{pidFileName, portFileName} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Errorf("%s should be cleared; a stale record wedges future starts", name)
+		}
+	}
+}
+
 // deadPID returns a PID that has certainly exited: it runs the test binary as a
 // no-op child (`-test.run=^$` matches no test) and reaps it. Portable across
 // platforms, unlike shelling out to `true`, and it fails rather than skips when

--- a/internal/proc/proc.go
+++ b/internal/proc/proc.go
@@ -7,6 +7,7 @@
 package proc
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -102,4 +103,23 @@ func IsAlive(pid int) bool {
 		return false
 	}
 	return isAliveProc(proc)
+}
+
+// Terminate asks the process with the given PID to shut down.
+//
+// On Unix this is SIGINT, giving the target a chance to close resources and
+// release locks. Windows has no deliverable equivalent — os.Process.Signal
+// supports only os.Kill there and returns syscall.EWINDOWS for os.Interrupt, so
+// a caller that "sent an interrupt" on Windows silently did nothing — so the
+// process is terminated outright. Callers that need a clean shutdown on Windows
+// must arrange it another way (e.g. an RPC the target listens for).
+func Terminate(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("terminate: invalid pid %d", pid)
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("terminate: find process %d: %w", pid, err)
+	}
+	return terminateProc(proc)
 }

--- a/internal/proc/proc_test.go
+++ b/internal/proc/proc_test.go
@@ -2,7 +2,9 @@ package proc
 
 import (
 	"os"
+	"os/exec"
 	"testing"
+	"time"
 )
 
 func TestFindAgentAncestorPID_ReturnsLiveProcess(t *testing.T) {
@@ -65,5 +67,59 @@ func TestMatchesAgent(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("matchesAgent(%q, %q, ...) = %v, want %v", tc.name, tc.hint, got, tc.want)
 		}
+	}
+}
+
+// IsAlive must distinguish live from dead. On Windows isAliveProc returned
+// `proc != nil`, and os.FindProcess never fails there, so IsAlive was always
+// true — a caller using it to decide whether to restart something would trust a
+// dead record forever. These assertions hold on every platform.
+func TestIsAlive(t *testing.T) {
+	if !IsAlive(os.Getpid()) {
+		t.Error("the running test process should report as alive")
+	}
+	for _, pid := range []int{0, -1} {
+		if IsAlive(pid) {
+			t.Errorf("IsAlive(%d) should be false", pid)
+		}
+	}
+
+	// A reaped child: the PID is valid but names nothing running.
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawn no-op helper: %v", err)
+	}
+	if IsAlive(cmd.Process.Pid) {
+		t.Errorf("reaped pid %d should report as dead", cmd.Process.Pid)
+	}
+}
+
+func TestTerminateRejectsInvalidPID(t *testing.T) {
+	for _, pid := range []int{0, -1} {
+		if err := Terminate(pid); err == nil {
+			t.Errorf("Terminate(%d) should error rather than signal something arbitrary", pid)
+		}
+	}
+}
+
+func TestTerminateStopsAProcess(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^$", "-test.timeout=60s")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn helper: %v", err)
+	}
+	exited := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	if err := Terminate(cmd.Process.Pid); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Error("expected the process to exit after Terminate")
 	}
 }

--- a/internal/proc/proc_unix.go
+++ b/internal/proc/proc_unix.go
@@ -43,3 +43,9 @@ func isAliveProc(proc *os.Process) bool {
 	err := proc.Signal(syscall.Signal(0))
 	return err == nil
 }
+
+// terminateProc sends SIGINT, letting the target close resources and release any
+// locks it holds before exiting.
+func terminateProc(proc *os.Process) error {
+	return proc.Signal(os.Interrupt)
+}

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -2,7 +2,17 @@
 
 package proc
 
-import "os"
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// stillActive is the exit code GetExitCodeProcess reports for a process that has
+// not exited (STILL_ACTIVE in the Win32 headers, 259). x/sys/windows exposes the
+// same value as STATUS_PENDING but not under the STILL_ACTIVE name, so spell it
+// out rather than borrowing a constant that means something else.
+const stillActive = 259
 
 // parentPID is not implemented on Windows; returns unsupported.
 func parentPID(_ int) (int, error) {
@@ -14,9 +24,39 @@ func processName(_ int) string {
 	return ""
 }
 
-// isAliveProc checks if a process is alive by sending signal 0.
-// On Windows, os.FindProcess always succeeds; use process.Wait as a proxy.
+// isAliveProc reports whether a process is still running.
+//
+// This used to return `proc != nil`, which is ALWAYS true: os.FindProcess never
+// fails on Windows, so IsAlive reported every PID — including long-dead ones —
+// as alive. Callers that use liveness to decide whether to restart something
+// (carts' dolt server) would therefore trust a dead record forever.
+//
+// Signal(0) is not an option either: Go's Windows os.Process.Signal supports only
+// os.Kill and returns syscall.EWINDOWS for anything else. Open the process and
+// ask for its exit code instead.
 func isAliveProc(proc *os.Process) bool {
-	// On Windows, Signal(0) is not supported. Best-effort: assume alive if findProcess succeeded.
-	return proc != nil
+	if proc == nil {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(proc.Pid))
+	if err != nil {
+		// Most often ERROR_INVALID_PARAMETER: the PID names nothing. A permission
+		// failure also lands here; reporting "not alive" is the safe answer, since
+		// a process we cannot query is one we cannot manage either.
+		return false
+	}
+	defer windows.CloseHandle(h)
+
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}
+
+// terminateProc kills the process. os.Interrupt is not deliverable on Windows —
+// os.Process.Signal returns syscall.EWINDOWS for it — so attempting a graceful
+// signal here would fail while reporting nothing useful to the caller.
+func terminateProc(proc *os.Process) error {
+	return proc.Kill()
 }


### PR DESCRIPTION
## Summary

`ox carts stop` can no longer kill a process that has nothing to do with ox, and it actually stops the server on Windows instead of silently pretending to.

`StopServer` signalled whatever PID the state file named. After a crash the file outlives the server, and the OS is free to hand that PID to something else — so stopping carts could interrupt an unrelated process. Greptile reproduced it: a stale record naming a live `/bin/sleep` got it interrupted. Separately, `os.Process.Signal(os.Interrupt)` is **not implemented on Windows**; it returns an error, so `StopServer` deleted the state record while the dolt server kept running and holding the write lock — leaving it orphaned and undiscoverable, which is worse than failing outright.

**Approach: signalling a PID now requires the same proof that reusing one does — the process is alive AND the recorded endpoint answers as a dolt server — and termination goes through a platform-correct helper in the shared `proc` package.**

While fixing the Windows half, `internal/proc.IsAlive` turned out to be broken in the same direction: `isAliveProc` returned `proc != nil`, and `os.FindProcess` never fails on Windows, so **`IsAlive` was unconditionally true there**. Every dead PID read as alive.

## Scope note

This branch previously carried a larger set of carts fixes. #780, #781 and #782 landed the same fixes on `main` independently and better (notably `fileutil.WithFileLock` for concurrent startup, which is stronger than what this branch had). It has been rebased onto `main` and reduced to only what is still missing — from 848 lines to 284. The prior tip is preserved at tag `backup/carts-pre-reduce-7299f84f`.

## What changed

| File | Change |
|---|---|
| `internal/proc/proc_windows.go` | `isAliveProc` uses `OpenProcess` + `GetExitCodeProcess` (`STILL_ACTIVE`) instead of always returning true; adds `terminateProc` = `Kill` |
| `internal/proc/proc_unix.go` | Adds `terminateProc` = `SIGINT`, so dolt can close storage and release its lock |
| `internal/proc/proc.go` | New `Terminate(pid)` wrapper with invalid-PID guard |
| `internal/carts/server.go` | `StopServer` verifies liveness + endpoint before signalling; clears stale records either way; propagates termination errors |
| `internal/proc/proc_test.go` | `IsAlive` live/dead/invalid, `Terminate` invalid-PID and stops-a-process |
| `internal/carts/server_test.go` | `TestStopServer` — 5 cases incl. the reported unrelated-process scenario |

## Blast radius (positive)

`IsAlive` has four other callers — `prime_session_marker.go`, `agent_hook.go`, `agenttask/store.go`, and carts reuse. On Windows all four previously saw every dead PID as alive, so stale session markers and agent-task claims were never reclaimed. They now get correct answers. `./internal/daemon/...` passes.

## Test Plan

- [x] `go test ./internal/carts/ ./internal/proc/ -count=2` — passes; 8 new cases
- [x] `go test ./internal/carts/ ./internal/proc/ -race` — clean
- [x] `go test ./internal/daemon/...` — passes (dependents of the changed `IsAlive`)
- [x] `go vet` + `gofmt -l` — clean
- [x] `GOOS=windows` test-compile for both packages; `GOOS=linux` + host `go build ./...`
- [x] Reproduced the reported bug: live unrelated process + stale record + unreachable endpoint ⇒ process survives, record cleared
- [x] End-to-end against a real dolt DB: cold start, reuse, and stop

<details>
<summary>Why signalling needs a stricter check than reuse</summary>

`runningServerPort` already probes the endpoint before reusing a record, because a live PID alone proves nothing after PID recycling. `StopServer` needed the same probe for a stronger reason: reusing a wrong record just fails an `ox carts` command, while signalling a wrong PID affects a process outside ox entirely. Stale records are still cleared on every rejection path, so a bad record can't wedge future starts.

On termination failure the record is deliberately **left in place** — a running server that remains discoverable is better than one orphaned behind deleted state.

</details>

<details>
<summary>Not addressed here: pid/port are still two files</summary>

A crash between the two `os.WriteFile` calls leaves a live server with a PID recorded and no port, which `runningServerPort` rejects — so subsequent calls start duplicates against the locked dolt dir. `main` mitigates this (both files are removed if either write fails, and startup is lock-serialized), but a crash bypasses that cleanup.

Fixing it properly means publishing one record via atomic rename, which interacts with `EnsureServer`'s use of the pid file as its lock path. Deliberately left out to keep this PR small; worth a follow-up issue.

</details>
