### PR TITLE
fix(plan): prior art you can trust, and renders that don't quietly break

### DIFF
--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -268,7 +268,7 @@ func savePlanArtifacts(gitRoot string, in plan.Input, result plan.Result, html [
 		Slug:           slug,
 		Authors:        planAuthors(gitRoot),
 		CreatedAt:      time.Now().UTC(),
-		SourcePlanPath: in.Path,
+		SourcePlanPath: absSourcePlanPath(in.Path),
 		Primary:        primary,
 		Provenance:     prov,
 		Collaboration:  collab,
@@ -526,6 +526,24 @@ func runPlanLint(cmd *cobra.Command, slug string, strict bool) error {
 // and in.Sections carries only the synthetic pre-draft section — see
 // newTopicInput), so plan.Title would have nothing to derive from.
 func planTopic(in plan.Input) string { return plan.PlanTopic(in) }
+
+// absSourcePlanPath canonicalizes the source document path recorded in a saved
+// plan's meta. It MUST be absolute: a relative spelling is only meaningful next
+// to the working directory it was typed in, which we don't record, so enrich
+// would later re-resolve it against a different directory and stop recognizing
+// the plan's own ledger entry (internal/plan: storedPlanPath). Falls back to the
+// raw value if the path can't be resolved — an unprovable identity is handled
+// conservatively downstream, never guessed at.
+func absSourcePlanPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return filepath.Clean(abs)
+}
 
 // planAuthors returns the capturing coworker's display name (privacy-safe, not
 // an email) when resolvable, else nil.

--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -525,12 +525,7 @@ func runPlanLint(cmd *cobra.Command, slug string, strict bool) error {
 // saved via --persist/--text, where no document exists yet (in.Raw is empty
 // and in.Sections carries only the synthetic pre-draft section — see
 // newTopicInput), so plan.Title would have nothing to derive from.
-func planTopic(in plan.Input) string {
-	if t := strings.TrimSpace(in.Topic); t != "" {
-		return t
-	}
-	return plan.Title(in)
-}
+func planTopic(in plan.Input) string { return plan.PlanTopic(in) }
 
 // planAuthors returns the capturing coworker's display name (privacy-safe, not
 // an email) when resolvable, else nil.

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -23,7 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`ox doctor` now flags a recording whose session link disagrees with the recording itself** — the one state that silently breaks links already written into your commits and pull requests. Reported, never repaired automatically: which link is correct depends on what has already been shared, so doctor names the conflict and leaves the call to you.
 
+- **Four new plan visualizations, so a rendered plan reads like it was designed.** A pull-quote for the one sentence the plan turns on (the natural home for a decider's verbatim words from a team discussion), an honest progress pair that shows shipped beside not-built-yet instead of claiming delivery in prose, a risk register that puts every risk in one scannable row and hides the mechanism behind a click, and the SageOx wordmark lockup. All keyboard-operable and screen-reader-labeled.
+
 ### Fixed
+
+- **The prior art SageOx cites on your plan is now actually about your plan.** Relevance was biased by length: a long transcript that happened to mention each of your search terms somewhere could out-score a short summary genuinely about them, so unrelated sessions surfaced as 95%-confidence prior art and the enrichment looked broken. Scoring now measures how much a document is *about* your terms rather than how many times it happens to contain them — while still surfacing the large, densely on-topic plans that a naive density fix would have made permanently unfindable.
+
+- **Diagram labels no longer clip mid-word in rendered plans.** Diagrams were laid out before the page's webfont finished loading, so every node was sized for the wrong font and its label overflowed once the real one swapped in — a defect invisible until someone screenshotted the page. Plans now re-draw their diagrams when the font settles, and `ox plan lint` flags any render that can still hit the race.
 
 - **Every recording keeps one permanent session link, even when its upload has to be retried.** A retried or recovered upload could assign a second link to a session that already had one, so the references written into commit trailers, pull requests, and plans stopped resolving — and two copies of the same session could disagree about which one it was.
 

--- a/docs/specs/plan-authoring-html.md
+++ b/docs/specs/plan-authoring-html.md
@@ -113,6 +113,23 @@ quick, low-stakes plans only**. The markdown renderer auto-renders:
 
 Good for a small plan; it approximates. A material plan gets an authored page.
 
+## Two Mermaid renderer traps
+
+Both were hit in real renders. They are encoded here so they don't have to be
+rediscovered, and the first one is also caught by the `mermaid.font-race` lint.
+
+- **The webfont race.** Mermaid measures node boxes using whatever font is
+  loaded at render time. When a webfont swaps in later, its wider glyphs
+  overflow the boxes that were sized for the fallback, and every label clips
+  mid-word. The symptom is invisible until someone screenshots the diagram. In
+  an authored page, re-render once the font settles:
+  `document.fonts.ready.then(() => renderMermaid())`. The ox scaffold already
+  does this; a page that hand-rolls its own Mermaid init must do it too.
+- **Parallel groups sprawl horizontally.** Disconnected subgraphs that share a
+  sink lay out side by side and overflow the column. Chain them with invisible
+  links (`A ~~~ B`) to force a vertical stack, and move byte counts and other
+  detail out of node labels into the caption under the diagram.
+
 ## Trust posture
 
 The plan is the developer's **own local content rendered locally for that

--- a/internal/ledgersearch/ledgersearch.go
+++ b/internal/ledgersearch/ledgersearch.go
@@ -51,6 +51,19 @@ const MaxPlanAge = 90 * 24 * time.Hour
 // DefaultLimit is returned when callers pass limit <= 0.
 const DefaultLimit = 5
 
+// maxHitsPerTerm bounds the per-term term-frequency scan so scoring stays cheap
+// on large documents. It also bounds the density bonus: extraHits can never
+// exceed (maxHitsPerTerm-1) * len(terms), which is why tfDensityDivisor has to
+// be tuned against it rather than picked freely.
+const maxHitsPerTerm = 10
+
+// tfDensityDivisor scales the density bonus in scoreContent. Raising it makes
+// scoring stricter about density and therefore biased against large documents;
+// lowering it lets bigger on-topic documents clear callers' thresholds. See the
+// tuning rationale in scoreContent — this is the knob that decides how large an
+// on-topic document may be and still be findable.
+const tfDensityDivisor = 5.0
+
 // Result is a single hit returned to callers. Shape mirrors api.QueryResult
 // loosely so 'ox query --local' output stays compatible with team-context
 // query consumers, but this package stays free of api/ imports to keep the
@@ -450,7 +463,8 @@ func planTimestamp(planPath, dirName string) time.Time {
 }
 
 // scoreContent returns a relevance score and a short snippet for content matching all terms.
-// Score = (matched-term-count / total-terms) + tf-bonus capped at 1.0.
+// AND semantics: every term must appear, or the score is 0. A match scores a flat
+// 0.5 floor plus a density bonus in [0, 0.5], so the range is [0.5, 1.0].
 // Snippet is the first ~160 chars around the first matched term.
 func scoreContent(content string, terms []string) (float64, string) {
 	if content == "" {
@@ -469,10 +483,10 @@ func scoreContent(content string, terms []string) (float64, string) {
 		if firstIdx < 0 || idx < firstIdx {
 			firstIdx = idx
 		}
-		// count tf with a cheap bounded scan (max 10 hits per term)
+		// count tf with a cheap bounded scan (maxHitsPerTerm hits per term)
 		hits := 0
 		start := 0
-		for hits < 10 {
+		for hits < maxHitsPerTerm {
 			next := strings.Index(lower[start:], t)
 			if next < 0 {
 				break
@@ -489,7 +503,32 @@ func scoreContent(content string, terms []string) (float64, string) {
 	if matched < len(terms) {
 		return 0, ""
 	}
-	tfBonus := float64(totalHits) / 100.0
+	// The tf bonus rewards term DENSITY, not raw volume. The previous form
+	// (totalHits/100, capped) was length-biased: any long transcript that
+	// mentioned each term somewhere accumulated enough scattered hits to score
+	// ~0.95, so "long and vaguely related" outranked "short and on-topic" and
+	// sailed past callers' relevance thresholds (plan enrich surfaced unrelated
+	// sessions at 0.95 exactly this way). Normalizing by content size makes the
+	// bonus mean "these terms are what this document is ABOUT": hits beyond the
+	// first per term, per KB of content.
+	//
+	// tfDensityDivisor is what keeps this from over-correcting. The scan above
+	// caps at maxHitsPerTerm, so extraHits <= (maxHitsPerTerm-1)*len(terms) —
+	// which means the divisor sets a hard ceiling on how large a document can
+	// be and still clear a caller's threshold. At 20 (the first cut of this
+	// fix) a 3-term query could not surface anything over ~13.5 KB past plan
+	// enrich's 0.6 gate, silently dropping 14% of this repo's own saved plans
+	// no matter how on-topic they were. At 5 a densely on-topic 20 KB plan
+	// scores ~0.77 while a 96 KB transcript with scattered hits still decays to
+	// ~0.51 — false positives stay gated, true positives survive.
+	extraHits := totalHits - matched
+	kb := float64(len(content)) / 1024.0
+	if kb < 1 {
+		// floor tiny documents at 1 KB so a 200-byte doc with one repeat
+		// cannot out-score everything by density alone.
+		kb = 1
+	}
+	tfBonus := (float64(extraHits) / kb) / tfDensityDivisor
 	if tfBonus > 0.5 {
 		tfBonus = 0.5
 	}

--- a/internal/ledgersearch/ledgersearch_test.go
+++ b/internal/ledgersearch/ledgersearch_test.go
@@ -482,3 +482,79 @@ func TestSnippetAround_Markers(t *testing.T) {
 		t.Errorf("unexpected marker when window covers whole string: %q", full)
 	}
 }
+
+// TestScoreContent_DensityNotLength is the regression for the length bias that
+// made `ox plan enrich` surface unrelated sessions at 0.95: a long document
+// containing every query term scattered incidentally must NOT out-score (or
+// even approach) a short document that is actually about those terms.
+//
+// Failure prevented: restoring the un-normalized totalHits/100 bonus. Both
+// fixtures below saturate the maxHitsPerTerm scan cap, so under the old formula
+// they score identically (0.800) and the threshold assertion goes red — the
+// earlier version of this test used a scattered doc with only 6 total hits,
+// which the old formula scored 0.56 and which therefore passed either way.
+func TestScoreContent_DensityNotLength(t *testing.T) {
+	terms := []string{"mcp", "doctrine", "priming"}
+
+	// short and on-topic: repeats the terms in ~1 KB of content
+	focused := strings.Repeat("mcp doctrine priming shapes the mcp surface. ", 22)
+
+	// long and incidental: each term appears maxHitsPerTerm times, dispersed
+	// through ~100 KB, so the scan cap saturates exactly as it does for focused.
+	filler := strings.Repeat("unrelated transcript chatter about run jobs and browsers. ", 170)
+	scattered := strings.Repeat("mcp doctrine priming "+filler, maxHitsPerTerm)
+
+	fs, fsn := scoreContent(focused, terms)
+	ss, ssn := scoreContent(scattered, terms)
+	if fsn == "" || ssn == "" {
+		t.Fatal("expected snippets for matching content")
+	}
+	// Checked first: this is the assertion the contract above is about, and it
+	// fires on the old formula before the ordering comparison can mask it.
+	if ss >= 0.6 {
+		t.Fatalf("scattered long doc score = %.3f, want < 0.6 (the caller threshold it previously blew through)", ss)
+	}
+	if fs <= ss {
+		t.Fatalf("focused doc must out-score scattered long doc: focused=%.3f scattered=%.3f", fs, ss)
+	}
+	if fs < 0.6 {
+		t.Fatalf("focused doc score = %.3f, want >= 0.6", fs)
+	}
+}
+
+// TestScoreContent_LargeOnTopicDocStillSurfaces guards the other side of the
+// density fix. Normalizing by document size interacts with the maxHitsPerTerm
+// scan cap to impose a hard size ceiling: extraHits is bounded, so past some
+// byte count NO document can clear a caller's threshold however on-topic it is.
+//
+// Failure prevented: raising tfDensityDivisor back toward 20, which put that
+// ceiling at ~13.5 KB for a 3-term query — below the p90 of this repo's own
+// saved plans, so 14% of them became permanently unfindable as prior art.
+func TestScoreContent_LargeOnTopicDocStillSurfaces(t *testing.T) {
+	terms := []string{"mcp", "doctrine", "priming"}
+
+	// ~20 KB and densely on-topic: the terms recur throughout, not just once.
+	unit := "mcp doctrine priming drive the design here. " +
+		strings.Repeat("supporting prose that carries the argument forward. ", 8)
+	dense := strings.Repeat(unit, 40)
+	if len(dense) < 15*1024 {
+		t.Fatalf("fixture too small to exercise the ceiling: %d bytes", len(dense))
+	}
+
+	// same size, but the terms appear once each — genuinely tangential.
+	tangential := "mcp doctrine priming\n" +
+		strings.Repeat("prose with no bearing on the query at all. ", 480)
+
+	ds, _ := scoreContent(dense, terms)
+	ts, _ := scoreContent(tangential, terms)
+
+	if ds < 0.6 {
+		t.Fatalf("dense %d-byte on-topic doc scored %.3f, want >= 0.6 — the density divisor has re-introduced a size ceiling", len(dense), ds)
+	}
+	if ts >= 0.6 {
+		t.Fatalf("tangential %d-byte doc scored %.3f, want < 0.6", len(tangential), ts)
+	}
+	if ds <= ts {
+		t.Fatalf("dense doc must out-score tangential doc of the same size: dense=%.3f tangential=%.3f", ds, ts)
+	}
+}

--- a/internal/plan/assets/plan.html.tmpl
+++ b/internal/plan/assets/plan.html.tmpl
@@ -22,7 +22,7 @@
   <div class="brand">OX · PLAN</div>
   <div class="toc-links">{{range .TOC}}<a href="#{{.ID}}"><span class="n">{{.Num}}</span>{{.Heading}}</a>
   {{end}}</div>
-  {{if .FooterCredit}}<div class="toc-brand" title="Team context enriched by SageOx">
+  {{if .FooterCredit}}<div class="toc-brand" data-ox-wordmark title="Team context enriched by SageOx">
     <span class="wm wm-d">{{.WordmarkDark}}</span><span class="wm wm-l">{{.WordmarkLight}}</span>
     <span class="toc-brand-cap">enriched by SageOx</span>
   </div>{{end}}

--- a/internal/plan/assets/scaffold.js
+++ b/internal/plan/assets/scaffold.js
@@ -52,7 +52,18 @@
     var obs=new IntersectionObserver(function(es){es.forEach(function(e){if(e.isIntersecting){activate(e.target.id,false);}});},{rootMargin:'-12% 0px -75% 0px'});
     document.querySelectorAll('section[id]').forEach(function(s){obs.observe(s);});
   }
-  function start(){renderMer();}
+  // Mermaid measures label text to size nodes. The page loads webfonts async
+  // (display=swap), so a first render that happens before the font arrives
+  // measures the fallback and clips labels mid-word once the wider face swaps
+  // in. Re-render on document.fonts.ready to measure the real font. Guarded:
+  // file:// with no network never resolves fonts, and the first render already
+  // produced a readable diagram, so this is strictly additive.
+  function start(){
+    renderMer();
+    if(document.fonts&&document.fonts.ready&&document.fonts.ready.then){
+      document.fonts.ready.then(function(){renderMer();}).catch(function(){});
+    }
+  }
   if(document.readyState!=='loading')start();else document.addEventListener('DOMContentLoaded',start);
 })();
 // auto-inspector: comparison tables (table.inspect) — click a row, its fields

--- a/internal/plan/assets/viz-catalog.md
+++ b/internal/plan/assets/viz-catalog.md
@@ -12,6 +12,21 @@
      renderers own the widget body; you own the surrounding layout, so the base
      components extend without any renderer change. -->
 
+<!-- CHOOSING BETWEEN PATTERNS — two rules that decide most of it.
+
+     Pair every diagram with the table that carries its exact values. A diagram
+     shows SHAPE; a table beside it carries the NUMBERS (fields, budgets,
+     thresholds, verdict cells). Never make one do the other's job — a diagram
+     crammed with values clips, and a table alone hides structure. The strongest
+     sections put them adjacent: a schema table beside the sequence diagram, a
+     channel table beside the delivery flowchart.
+
+     Vary the form section to section. Good textbooks alternate modes of
+     comprehension on purpose — a diagram for structure, a table for exact
+     values, a pull-quote for the sentence that must not be skimmed, a worked
+     example for feel. A plan is teaching a decision, so pace it the same way.
+     Two consecutive sections in the same form is a smell; three is a bug. -->
+
 ## sequence-diagram
 use: an ordered call/response path that crosses components, services, or async boundaries — when "in what order, how many round-trips" is the question.
 why: shows ordering and latency a flowchart can't; ≤4-5 participants keeps it legible.
@@ -420,4 +435,78 @@ param: {"title":"workflow history growth","x_label":"hours","y_label":"history e
 <!-- prefer the param renderer: ox plan viz render line-chart --data line.json
      ox scales both axes, projects each point to pixels, places the threshold, and draws the legend. -->
 <figure class="linec"><svg class="linec-svg" viewBox="0 0 300 224"><line class="linec-axis" x1="52" y1="14" x2="52" y2="190"/><line class="linec-axis" x1="52" y1="190" x2="288" y2="190"/><line class="linec-thresh" x1="52" y1="119.6" x2="288" y2="119.6" style="stroke:var(--amber)"/><polyline class="linec-series" points="52,190 288,14" style="stroke:var(--red)"/><polyline class="linec-series" points="52,190 126,120 126,181 199,120 199,181 273,120" style="stroke:var(--sage)" stroke-dasharray="5 3"/></svg><ul class="linec-leg"><li><span class="vsw" style="background:var(--red)"></span>before</li><li><span class="vsw" style="background:var(--sage)"></span>after</li></ul></figure>
+```
+
+## pull-quote
+use: a doctrine line, a decider's verbatim words from a Discussion, or the one sentence the whole plan turns on — surfaced as a visual beat between prose blocks.
+why: a load-bearing sentence set in a quote block is read; the same sentence inside a paragraph is skimmed past. Also the natural home for enrichment's Discussion snippets — quote the deciders, cited.
+```html
+<div class="quote">Nothing post-intent can influence the turn where the user didn't think to mention it — and that turn is the entire product.</div>
+<p class="sub">Ryan, 2026-07-30 Discussion with Milkana: <em>"I wanna dance on that edge — I think that's the point."</em></p>
+```
+```css
+.quote{border-left:3px solid var(--accent,#e0a56a);padding:6px 16px;margin:16px 0;font-size:16px;font-style:italic}
+```
+
+## status-pair
+use: work that is genuinely partial — a progress bar plus shipped-vs-not-built cards, side by side. Use whenever declaring anything "in flight"; never claim delivery with prose alone.
+why: an honest 15% bar and a two-column done/not-done grid kill the thin-red-line illusion faster than any caveat sentence; the reviewer sees the gap instead of reading past it.
+```html
+<div class="progress" role="progressbar" aria-label="Tasks completed"
+     aria-valuemin="0" aria-valuemax="20" aria-valuenow="3"><i style="width:15%"></i></div>
+<div class="grid2">
+  <div class="card"><h3>Shipped</h3><ul><li>records + two tools</li></ul></div>
+  <div class="card"><h3>Not built yet</h3><ul><li>the load-bearing mechanism</li></ul></div>
+</div>
+```
+```css
+.progress{height:10px;border-radius:6px;background:var(--panel2,#1b2327);overflow:hidden}
+.progress i{display:block;height:100%;background:var(--good,#7a8f78)}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+```
+
+## wordmark
+use: the SageOx two-color wordmark, fixed bottom-left. The Go renderer injects this as part of the ox chrome; reach for this snippet only on a render that bypasses that path. REQUIRED whenever the plan carried SageOx enrichment (any badge or context item) — and omitted entirely when it did not, since there is nothing to credit.
+why: the lockup ("enriched by" + small mark — never the bare logo) is quiet provenance, and it LINKS: to the enriching team's console URL when known, else https://sageox.ai. Both theme variants inline so it renders from file:// and flips with the page theme.
+```html
+<a class="wm-corner" data-ox-wordmark href="https://sageox.ai" aria-label="enriched by SageOx"><span class="wm-label">enriched by</span><span class="wm wm-d"><svg xmlns="http://www.w3.org/2000/svg" viewBox="8 18 163 51" width="163" height="51"> <title>SageOx Wordmark (Dark, Transparent)</title> <path d="M22.89 55.67Q19.05 55.67 16.10 54.30Q13.15 52.94 11.47 50.34Q9.79 47.75 9.79 44.01V42.76H15.50V44.01Q15.50 47.32 17.51 48.95Q19.53 50.58 22.89 50.58Q26.30 50.58 28.03 49.19Q29.75 47.80 29.75 45.59Q29.75 44.10 28.94 43.17Q28.12 42.23 26.56 41.66Q25.00 41.08 22.79 40.55L21.35 40.26Q18.04 39.50 15.62 38.32Q13.19 37.14 11.90 35.27Q10.60 33.40 10.60 30.38Q10.60 27.35 12.04 25.19Q13.48 23.03 16.12 21.88Q18.76 20.73 22.31 20.73Q25.87 20.73 28.65 21.93Q31.43 23.13 33.04 25.53Q34.65 27.93 34.65 31.53V33.11H28.94V31.53Q28.94 29.46 28.12 28.22Q27.31 26.97 25.82 26.39Q24.33 25.82 22.31 25.82Q19.34 25.82 17.80 26.97Q16.27 28.12 16.27 30.23Q16.27 31.58 16.96 32.51Q17.66 33.45 19.03 34.05Q20.39 34.65 22.46 35.08L23.90 35.42Q27.35 36.18 29.95 37.36Q32.54 38.54 34.00 40.46Q35.47 42.38 35.47 45.45Q35.47 48.47 33.91 50.78Q32.35 53.08 29.54 54.38Q26.73 55.67 22.89 55.67ZM46.00 55.67Q43.50 55.67 41.49 54.78Q39.47 53.90 38.30 52.22Q37.12 50.54 37.12 48.09Q37.12 45.69 38.30 44.06Q39.47 42.42 41.54 41.58Q43.60 40.74 46.24 40.74H53.10V39.30Q53.10 37.43 51.95 36.26Q50.80 35.08 48.35 35.08Q45.95 35.08 44.73 36.21Q43.50 37.34 43.12 39.11L38.03 37.43Q38.61 35.56 39.88 34.02Q41.15 32.49 43.26 31.55Q45.38 30.62 48.45 30.62Q53.10 30.62 55.77 32.94Q58.43 35.27 58.43 39.69V49.00Q58.43 50.44 59.78 50.44H61.79V55.00H57.90Q56.18 55.00 55.07 54.14Q53.97 53.27 53.97 51.78V51.69H53.15Q52.86 52.36 52.14 53.32Q51.42 54.28 49.96 54.98Q48.50 55.67 46.00 55.67ZM46.91 51.16Q49.65 51.16 51.38 49.60Q53.10 48.04 53.10 45.40V44.92H46.58Q44.80 44.92 43.70 45.69Q42.59 46.46 42.59 47.94Q42.59 49.38 43.74 50.27Q44.90 51.16 46.91 51.16ZM62.18 43.24V42.52Q62.18 38.78 63.67 36.11Q65.15 33.45 67.65 32.03Q70.15 30.62 73.12 30.62Q76.48 30.62 78.23 31.82Q79.99 33.02 80.80 34.41H81.62V31.29H86.99V59.51Q86.99 61.86 85.65 63.23Q84.31 64.60 82.00 64.60H66.07V59.80H80.13Q81.52 59.80 81.52 58.36V51.50H80.71Q80.18 52.31 79.27 53.15Q78.35 53.99 76.87 54.57Q75.38 55.14 73.12 55.14Q70.15 55.14 67.65 53.73Q65.15 52.31 63.67 49.65Q62.18 46.98 62.18 43.24ZM74.66 50.30Q77.63 50.30 79.60 48.40Q81.57 46.50 81.57 43.10V42.62Q81.57 39.16 79.63 37.29Q77.68 35.42 74.66 35.42Q71.68 35.42 69.69 37.29Q67.70 39.16 67.70 42.62V43.10Q67.70 46.50 69.69 48.40Q71.68 50.30 74.66 50.30ZM101.78 55.67Q98.23 55.67 95.52 54.16Q92.81 52.65 91.30 49.89Q89.78 47.13 89.78 43.43V42.86Q89.78 39.11 91.27 36.38Q92.76 33.64 95.45 32.13Q98.14 30.62 101.64 30.62Q105.10 30.62 107.69 32.13Q110.28 33.64 111.72 36.38Q113.16 39.11 113.16 42.76V44.73H95.35Q95.45 47.51 97.32 49.19Q99.19 50.87 101.93 50.87Q104.62 50.87 105.91 49.70Q107.21 48.52 107.88 47.03L112.44 49.38Q111.77 50.68 110.50 52.14Q109.22 53.61 107.11 54.64Q105.00 55.67 101.78 55.67ZM95.40 40.55H107.54Q107.35 38.20 105.74 36.81Q104.14 35.42 101.59 35.42Q98.95 35.42 97.37 36.81Q95.78 38.20 95.40 40.55Z" fill="#c4d1c0"/> <path d="M130.62 55.50Q124.38 55.50 120.66 52.05Q116.94 48.60 116.94 42.14V34.26Q116.94 27.80 120.66 24.35Q124.38 20.90 130.62 20.90Q136.91 20.90 140.60 24.35Q144.30 27.80 144.30 34.26V42.14Q144.30 48.60 140.60 52.05Q136.91 55.50 130.62 55.50ZM130.62 50.06Q134.36 50.06 136.45 47.95Q138.54 45.84 138.54 42.24V34.16Q138.54 30.56 136.45 28.45Q134.36 26.34 130.62 26.34Q126.92 26.34 124.84 28.45Q122.75 30.56 122.75 34.16V42.24Q122.75 45.84 124.84 47.95Q126.92 50.06 130.62 50.06Z" fill="#7a8f78"/> <path d="M145.33 55.00L153.81 43.05L145.47 31.29H151.65L157.23 39.50H158.00L163.58 31.29H169.71L161.37 43.05L169.85 55.00H163.63L158.00 46.65H157.23L151.60 55.00Z" fill="#7a8f78"/> </svg></span><span class="wm wm-l"><svg xmlns="http://www.w3.org/2000/svg" viewBox="8 18 163 51" width="163" height="51"> <title>SageOx Wordmark (Light, Transparent)</title> <path d="M22.89 55.67Q19.05 55.67 16.10 54.30Q13.15 52.94 11.47 50.34Q9.79 47.75 9.79 44.01V42.76H15.50V44.01Q15.50 47.32 17.51 48.95Q19.53 50.58 22.89 50.58Q26.30 50.58 28.03 49.19Q29.75 47.80 29.75 45.59Q29.75 44.10 28.94 43.17Q28.12 42.23 26.56 41.66Q25.00 41.08 22.79 40.55L21.35 40.26Q18.04 39.50 15.62 38.32Q13.19 37.14 11.90 35.27Q10.60 33.40 10.60 30.38Q10.60 27.35 12.04 25.19Q13.48 23.03 16.12 21.88Q18.76 20.73 22.31 20.73Q25.87 20.73 28.65 21.93Q31.43 23.13 33.04 25.53Q34.65 27.93 34.65 31.53V33.11H28.94V31.53Q28.94 29.46 28.12 28.22Q27.31 26.97 25.82 26.39Q24.33 25.82 22.31 25.82Q19.34 25.82 17.80 26.97Q16.27 28.12 16.27 30.23Q16.27 31.58 16.96 32.51Q17.66 33.45 19.03 34.05Q20.39 34.65 22.46 35.08L23.90 35.42Q27.35 36.18 29.95 37.36Q32.54 38.54 34.00 40.46Q35.47 42.38 35.47 45.45Q35.47 48.47 33.91 50.78Q32.35 53.08 29.54 54.38Q26.73 55.67 22.89 55.67ZM46.00 55.67Q43.50 55.67 41.49 54.78Q39.47 53.90 38.30 52.22Q37.12 50.54 37.12 48.09Q37.12 45.69 38.30 44.06Q39.47 42.42 41.54 41.58Q43.60 40.74 46.24 40.74H53.10V39.30Q53.10 37.43 51.95 36.26Q50.80 35.08 48.35 35.08Q45.95 35.08 44.73 36.21Q43.50 37.34 43.12 39.11L38.03 37.43Q38.61 35.56 39.88 34.02Q41.15 32.49 43.26 31.55Q45.38 30.62 48.45 30.62Q53.10 30.62 55.77 32.94Q58.43 35.27 58.43 39.69V49.00Q58.43 50.44 59.78 50.44H61.79V55.00H57.90Q56.18 55.00 55.07 54.14Q53.97 53.27 53.97 51.78V51.69H53.15Q52.86 52.36 52.14 53.32Q51.42 54.28 49.96 54.98Q48.50 55.67 46.00 55.67ZM46.91 51.16Q49.65 51.16 51.38 49.60Q53.10 48.04 53.10 45.40V44.92H46.58Q44.80 44.92 43.70 45.69Q42.59 46.46 42.59 47.94Q42.59 49.38 43.74 50.27Q44.90 51.16 46.91 51.16ZM62.18 43.24V42.52Q62.18 38.78 63.67 36.11Q65.15 33.45 67.65 32.03Q70.15 30.62 73.12 30.62Q76.48 30.62 78.23 31.82Q79.99 33.02 80.80 34.41H81.62V31.29H86.99V59.51Q86.99 61.86 85.65 63.23Q84.31 64.60 82.00 64.60H66.07V59.80H80.13Q81.52 59.80 81.52 58.36V51.50H80.71Q80.18 52.31 79.27 53.15Q78.35 53.99 76.87 54.57Q75.38 55.14 73.12 55.14Q70.15 55.14 67.65 53.73Q65.15 52.31 63.67 49.65Q62.18 46.98 62.18 43.24ZM74.66 50.30Q77.63 50.30 79.60 48.40Q81.57 46.50 81.57 43.10V42.62Q81.57 39.16 79.63 37.29Q77.68 35.42 74.66 35.42Q71.68 35.42 69.69 37.29Q67.70 39.16 67.70 42.62V43.10Q67.70 46.50 69.69 48.40Q71.68 50.30 74.66 50.30ZM101.78 55.67Q98.23 55.67 95.52 54.16Q92.81 52.65 91.30 49.89Q89.78 47.13 89.78 43.43V42.86Q89.78 39.11 91.27 36.38Q92.76 33.64 95.45 32.13Q98.14 30.62 101.64 30.62Q105.10 30.62 107.69 32.13Q110.28 33.64 111.72 36.38Q113.16 39.11 113.16 42.76V44.73H95.35Q95.45 47.51 97.32 49.19Q99.19 50.87 101.93 50.87Q104.62 50.87 105.91 49.70Q107.21 48.52 107.88 47.03L112.44 49.38Q111.77 50.68 110.50 52.14Q109.22 53.61 107.11 54.64Q105.00 55.67 101.78 55.67ZM95.40 40.55H107.54Q107.35 38.20 105.74 36.81Q104.14 35.42 101.59 35.42Q98.95 35.42 97.37 36.81Q95.78 38.20 95.40 40.55Z" fill="#aebca7"/> <path d="M130.62 55.50Q124.38 55.50 120.66 52.05Q116.94 48.60 116.94 42.14V34.26Q116.94 27.80 120.66 24.35Q124.38 20.90 130.62 20.90Q136.91 20.90 140.60 24.35Q144.30 27.80 144.30 34.26V42.14Q144.30 48.60 140.60 52.05Q136.91 55.50 130.62 55.50ZM130.62 50.06Q134.36 50.06 136.45 47.95Q138.54 45.84 138.54 42.24V34.16Q138.54 30.56 136.45 28.45Q134.36 26.34 130.62 26.34Q126.92 26.34 124.84 28.45Q122.75 30.56 122.75 34.16V42.24Q122.75 45.84 124.84 47.95Q126.92 50.06 130.62 50.06Z" fill="#546a54"/> <path d="M145.33 55.00L153.81 43.05L145.47 31.29H151.65L157.23 39.50H158.00L163.58 31.29H169.71L161.37 43.05L169.85 55.00H163.63L158.00 46.65H157.23L151.60 55.00Z" fill="#546a54"/> </svg></span></a>
+```
+```css
+.wm-corner{position:fixed;left:14px;bottom:12px;z-index:40;opacity:.75}
+.wm-corner svg{width:96px;height:auto;display:block}
+.wm-l{display:none}
+html[data-theme="light"] .wm-d{display:none}
+html[data-theme="light"] .wm-l{display:inline}
+```
+
+## risk-register
+use: a plan's risk section — every risk scannable in one glance-row (severity dot · risk → one-line resolution · owner), with click-to-expand detail (mechanism · trigger · exit · fallback) per row. Replaces stacked risk cards, which bury the scan under detail.
+why: progressive disclosure for risks: the ten-minute reader scans four rows; the skeptic expands only the row they doubt. Severity is a dot, not a paragraph; triggers are events, never invented dates; owners are visible at the scan layer because an unowned risk is unresolved.
+```html
+<table class="riskreg">
+<tr><th></th><th>Risk → resolution</th><th>Owner</th></tr>
+<tr class="rrow" tabindex="0" role="button" aria-expanded="false" aria-controls="risk-1-det"><td class="sev"><span class="sevdot" style="background:var(--red,#ef4444)"></span><span class="vis-hidden">High severity</span></td>
+  <td><span class="chev" aria-hidden="true">▸</span><b>The risk, named plainly</b><br><span class="sub">One-line resolution — decisive, not a mitigation list.</span></td>
+  <td class="own">Owner</td></tr>
+<tr id="risk-1-det" class="det"><td colspan="3"><div class="detgrid">
+  <b>Mechanism</b><span>how, concretely</span>
+  <b>Trigger</b><span>the event (never an uncommitted date)</span>
+  <b>Exit</b><span>the measurable criterion</span>
+  <b>Fallback</b><span>what happens on failure — designed, not hoped</span>
+</div></td></tr>
+</table>
+```
+```css
+.riskreg tr.rrow{cursor:pointer}
+.riskreg td.sev{width:26px;text-align:center}
+.riskreg .sevdot{display:inline-block;width:9px;height:9px;border-radius:50%}
+.riskreg .chev{color:var(--accent,#e0a56a);margin-right:6px;display:inline-block;transition:transform .12s}
+.riskreg tr.open .chev{transform:rotate(90deg)}
+.riskreg tr.det{display:none}
+.riskreg tr.det.show{display:table-row}
+.detgrid{display:grid;grid-template-columns:88px 1fr;gap:4px 14px;font-size:13px;padding-top:10px}
+.vis-hidden{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap}
+```
+```js
+document.querySelectorAll('.riskreg tr.rrow').forEach(r=>{const t=()=>{const open=!r.classList.contains('open');r.classList.toggle('open',open);r.setAttribute('aria-expanded',String(open));const d=r.nextElementSibling;if(d)d.classList.toggle('show',open);};r.addEventListener('click',t);r.addEventListener('keydown',e=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();t();}});});
 ```

--- a/internal/plan/lint.go
+++ b/internal/plan/lint.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // Finding is one advisory lint result on a rendered plan HTML — attribution
@@ -33,14 +34,113 @@ func countDeterministic(res Result) int {
 	return n
 }
 
+// isEnriched reports whether a plan carried SageOx enrichment: any annotation
+// (deterministic OR judgment) or any context-bundle item. This is THE gate for
+// every "did SageOx earn credit here" rule — LintBranding's footer credit and
+// lintWordmark both use it, so the two can never drift apart on a judgment-only
+// plan (which the renderer does give a wordmark: render.go sets FooterCredit on
+// this same condition). countDeterministic is deliberately narrower and belongs
+// only to the anchored-OX-marker rule.
+func isEnriched(res Result) bool {
+	return len(res.Annotations) > 0 || len(res.Context) > 0
+}
+
 // LintRender runs the full advisory contract over a rendered plan HTML: SageOx
-// attribution (LintBranding) plus diagram validity (LintMermaid). It is the
-// single entrypoint `ox plan lint` / `ox plan save` call. Fail-open: an empty
-// page returns nil.
+// attribution (LintBranding, lintWordmark) plus diagram validity (LintMermaid,
+// lintMermaidFontRace). It is the single entrypoint `ox plan lint` /
+// `ox plan save` call. Fail-open: an empty page returns nil.
 func LintRender(htmlBytes []byte, res Result) []Finding {
 	out := LintBranding(htmlBytes, res)
 	out = append(out, LintMermaid(htmlBytes)...)
+	out = append(out, lintMermaidFontRace(htmlBytes)...)
+	out = append(out, lintWordmark(htmlBytes, res)...)
 	return out
+}
+
+// lintWordmark flags an enriched render missing the SageOx wordmark. The Go
+// renderer injects it bottom-left as part of the ox chrome; this advisory
+// exists for renders that bypass that path, where the mark is part of the spec
+// but the author is fallible. Advisory, and only when the plan actually carried
+// enrichment — the same conditionality as the footer credit.
+func lintWordmark(html []byte, res Result) []Finding {
+	if len(html) == 0 {
+		return nil // nothing rendered; nothing to lint
+	}
+	if !isEnriched(res) {
+		return nil
+	}
+	// Match the emitted marker, not prose. `data-ox-wordmark` is stamped on the
+	// lockup by both the Go template and the `ox plan viz wordmark` snippet;
+	// matching the SVG <title> text instead would let a page that merely
+	// mentions "SageOx Wordmark" satisfy the rule, and would fail a correctly
+	// placed mark whose SVG was minified or title-stripped.
+	if bytes.Contains(html, []byte("data-ox-wordmark")) {
+		return nil
+	}
+	return []Finding{{
+		Rule:    "branding.wordmark-missing",
+		Message: "enriched plan render carries no SageOx wordmark — add the bottom-left mark via `ox plan viz wordmark` (both theme variants, inline SVG)",
+	}}
+}
+
+// mermaidScriptRe extracts <script> bodies so the font-race check reasons about
+// executable code rather than visible prose. A plan that merely quotes
+// "document.fonts.ready" in a code sample must neither trigger nor suppress it.
+var mermaidScriptRe = regexp.MustCompile(`(?is)<script\b[^>]*>(.*?)</script>`)
+
+// mermaidDiagramRe is the diagram-presence signal: an actual Mermaid container,
+// not the word "mermaid" appearing anywhere in CSS, a URL, or body text.
+var mermaidDiagramRe = regexp.MustCompile(`class="[^"]*\bmermaid\b`)
+
+var (
+	// jsBlockCommentRe strips /* ... */ comments from script bodies.
+	jsBlockCommentRe = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	// jsLineCommentRe strips // ... comments. The negative lookbehind for ':' is
+	// spelled as a captured prefix because Go's regexp has no lookbehind — it
+	// keeps "https://…" inside a string literal from being treated as a comment.
+	jsLineCommentRe = regexp.MustCompile(`(^|[^:])//[^\n]*`)
+)
+
+// stripJSComments removes comments from script source so a rule can distinguish
+// code that DOES something from a comment that merely talks about it. Without
+// this, a scaffold comment reading "re-render on document.fonts.ready" silences
+// the very rule that comment describes.
+func stripJSComments(js string) string {
+	js = jsBlockCommentRe.ReplaceAllString(js, " ")
+	return jsLineCommentRe.ReplaceAllString(js, "$1")
+}
+
+// lintMermaidFontRace flags the webfont measurement race: a page that renders
+// Mermaid and loads a webfont but never re-renders on document.fonts.ready will
+// clip node labels mid-word once the wider font swaps in. Advisory — the fix is
+// one line and the symptom is invisible until someone screenshots the diagram.
+func lintMermaidFontRace(html []byte) []Finding {
+	if len(html) == 0 {
+		return nil
+	}
+	h := string(html)
+	// Needs all three: a real diagram, a webfont, and Mermaid actually invoked.
+	if !mermaidDiagramRe.MatchString(h) || !strings.Contains(h, "fonts.googleapis.com") {
+		return nil
+	}
+	var scripts strings.Builder
+	for _, m := range mermaidScriptRe.FindAllStringSubmatch(h, -1) {
+		scripts.WriteString(m[1])
+		scripts.WriteString("\n")
+	}
+	js := stripJSComments(scripts.String())
+	if !strings.Contains(js, "mermaid") {
+		return nil // fonts + a .mermaid block, but nothing renders it
+	}
+	// Require the font-ready path to actually be invoked, not just named: a
+	// comment or a prose snippet describing the fix must not silence the rule.
+	if strings.Contains(js, "fonts.ready") {
+		return nil
+	}
+	return []Finding{{
+		Rule:    "mermaid.font-race",
+		Message: "page renders Mermaid and loads a webfont but never re-renders on document.fonts.ready — node labels will clip mid-word when the font swaps in; add document.fonts.ready.then(()=>renderMermaid())",
+	}}
 }
 
 var (
@@ -127,9 +227,10 @@ func LintBranding(html []byte, res Result) []BrandingFinding {
 
 	var findings []BrandingFinding
 
-	// "carried enrichment" mirrors the skill's own gate: any deterministic
-	// badges OR context-bundle items present.
-	enriched := len(res.Annotations) > 0 || len(res.Context) > 0
+	// "carried enrichment" mirrors the skill's own gate: any annotation OR
+	// context-bundle item present. Shared with lintWordmark via isEnriched so
+	// the credit and the mark can never disagree about what "enriched" means.
+	enriched := isEnriched(res)
 	hasCredit := footerCreditRe.Match(html)
 
 	switch {

--- a/internal/plan/lint_test.go
+++ b/internal/plan/lint_test.go
@@ -131,3 +131,149 @@ func ruleIDs(fs []BrandingFinding) []string {
 	}
 	return ids
 }
+
+// judgmentOnlyResult carries enrichment as a judgment badge and nothing else —
+// the input class where LintBranding and lintWordmark used to disagree.
+func judgmentOnlyResult() Result {
+	return Result{Annotations: []Annotation{{Kind: BadgeJudgment, Type: BadgeCollision, Why: "rigor"}}}
+}
+
+const wordmarkMark = `<div class="toc-brand" data-ox-wordmark><svg></svg></div>`
+
+// TestLintWordmark_EnrichedRendersMustCarryTheMark covers the gate and the
+// marker match together.
+// Failure prevented: the mark silently stops rendering on enriched plans, or
+// the rule nags plans that never earned SageOx credit in the first place.
+func TestLintWordmark_EnrichedRendersMustCarryTheMark(t *testing.T) {
+	tests := []struct {
+		name      string
+		html      string
+		res       Result
+		wantRules []string
+	}{
+		{"enriched render without the mark is flagged", footerCredit, enrichedResult(), []string{"branding.wordmark-missing"}},
+		{"enriched render with the mark is clean", footerCredit + wordmarkMark, enrichedResult(), nil},
+		{"context-only enrichment still requires the mark", footerCredit, contextOnlyResult(), []string{"branding.wordmark-missing"}},
+		// The gate that used to diverge from LintBranding: a judgment-only plan
+		// earns the footer credit, so it must earn the wordmark check too.
+		{"judgment-only enrichment requires the mark", footerCredit, judgmentOnlyResult(), []string{"branding.wordmark-missing"}},
+		{"un-enriched render is never nagged", "<p>plain plan</p>", Result{}, nil},
+		// Prose naming the mark must not satisfy the rule — only the emitted marker.
+		{"prose mentioning the wordmark does not satisfy the rule", footerCredit + `<p>add the SageOx Wordmark here</p>`, enrichedResult(), []string{"branding.wordmark-missing"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertRules(t, lintWordmark([]byte(tt.html), tt.res), tt.wantRules)
+		})
+	}
+}
+
+// TestLintWordmark_EmptyHTMLNoFindings mirrors the guarantee LintBranding
+// already makes. This is live, not hypothetical: `ox plan save` leaves html nil
+// when --html is not passed, so without the guard a markdown-only save is
+// nagged for a missing wordmark on a plan that has no render at all.
+func TestLintWordmark_EmptyHTMLNoFindings(t *testing.T) {
+	if got := lintWordmark(nil, enrichedResult()); got != nil {
+		t.Errorf("expected no findings on empty html, got %+v", got)
+	}
+}
+
+const googleFontLink = `<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet"/>`
+
+// TestLintMermaidFontRace covers the three-way signal and, crucially, both
+// directions of the scoping bug: visible prose must not be able to trigger the
+// finding or to suppress it.
+// Failure prevented: diagrams ship with labels clipped mid-word, or the rule
+// misfires on pages that merely talk about Mermaid and fonts.
+func TestLintMermaidFontRace(t *testing.T) {
+	tests := []struct {
+		name      string
+		html      string
+		wantRules []string
+	}{
+		{
+			"diagram + webfont with no font-ready re-render is flagged",
+			googleFontLink + `<div class="mermaid">graph TD;</div><script>mermaid.run({});</script>`,
+			[]string{"mermaid.font-race"},
+		},
+		{
+			"font-ready re-render clears it",
+			googleFontLink + `<div class="mermaid">graph TD;</div><script>document.fonts.ready.then(function(){mermaid.run({});});</script>`,
+			nil,
+		},
+		{
+			"no webfont means no race",
+			`<div class="mermaid">graph TD;</div><script>mermaid.run({});</script>`,
+			nil,
+		},
+		{
+			"no diagram means no race",
+			googleFontLink + `<script>mermaid.run({});</script>`,
+			nil,
+		},
+		{
+			// the false-positive half of the scoping bug
+			"prose about mermaid and fonts does not trigger it",
+			googleFontLink + `<p>We use mermaid diagrams; the mermaid class renders them.</p>`,
+			nil,
+		},
+		{
+			// the false-negative half: quoting the fix must not suppress the finding
+			"prose quoting document.fonts.ready does not suppress it",
+			googleFontLink + `<div class="mermaid">graph TD;</div><p>add document.fonts.ready.then(render)</p><script>mermaid.run({});</script>`,
+			[]string{"mermaid.font-race"},
+		},
+		{
+			// caught while mutation-testing this very rule: ox's own scaffold
+			// carries a comment naming the fix, which silenced the finding even
+			// with the code removed.
+			"a JS comment naming fonts.ready does not suppress it",
+			googleFontLink + `<div class="mermaid">graph TD;</div><script>// re-render on document.fonts.ready
+mermaid.run({});</script>`,
+			[]string{"mermaid.font-race"},
+		},
+		{
+			"a block comment naming fonts.ready does not suppress it",
+			googleFontLink + `<div class="mermaid">graph TD;</div><script>/* see document.fonts.ready */ mermaid.run({});</script>`,
+			[]string{"mermaid.font-race"},
+		},
+		{
+			// the comment stripper must not eat a URL inside a string literal
+			"a https:// URL in script source is not treated as a comment",
+			googleFontLink + `<div class="mermaid">graph TD;</div><script>var u="https://x/y";document.fonts.ready.then(function(){mermaid.run({});});</script>`,
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertRules(t, lintMermaidFontRace([]byte(tt.html)), tt.wantRules)
+		})
+	}
+}
+
+// TestLintRender_GoRendererOutputIsClean is the guard that would have caught
+// this PR's own regression: ox must never ship a lint rule its OWN renderer
+// fails. Before the scaffold.js font-ready fix, every non-artifact render with
+// a diagram emitted mermaid.font-race against itself, and `ox plan lint
+// --strict` exited non-zero on ox's own output.
+// Failure prevented: a new advisory rule that nags every plan ox produces.
+func TestLintRender_GoRendererOutputIsClean(t *testing.T) {
+	in := Input{
+		Raw: "# Plan\n\n## Approach\nWe build on ADR-051 here.\n\n```mermaid\ngraph TD;\n  A-->B;\n```\n",
+		Sections: []Section{
+			{Heading: "", Body: "# Plan\n"},
+			{Heading: "Approach", Body: "We build on ADR-051 here.\n\n```mermaid\ngraph TD;\n  A-->B;\n```\n"},
+		},
+	}
+	res := Result{Context: adrCtx()}
+	out, err := RenderHTML(in, res)
+	if err != nil {
+		t.Fatalf("RenderHTML: %v", err)
+	}
+	if !strings.Contains(string(out), `class="mermaid"`) {
+		t.Fatal("fixture did not produce a mermaid diagram — the test cannot prove anything")
+	}
+	if findings := LintRender(out, res); len(findings) != 0 {
+		t.Errorf("the Go renderer's own output must lint clean, got %v", ruleIDs(findings))
+	}
+}

--- a/internal/plan/priorart.go
+++ b/internal/plan/priorart.go
@@ -210,15 +210,32 @@ func isPlanRef(ref string) bool {
 	return strings.Contains(ref, "data/plans/") || datedSlugRe.MatchString(ref)
 }
 
-// selfPlanIdentity is the source document a plan was saved from, canonicalized
-// for comparison. Empty means "no identity available" — callers must then leave
-// prior art alone rather than guess.
-func selfPlanIdentity(path string) string {
+// livePlanPath canonicalizes the path of the plan currently being enriched.
+// This one IS relative to the running process's working directory, so resolving
+// it with Abs is correct. Empty means "no identity available".
+func livePlanPath(path string) string {
 	if strings.TrimSpace(path) == "" {
 		return ""
 	}
 	if abs, err := filepath.Abs(path); err == nil {
 		return filepath.Clean(abs)
+	}
+	return filepath.Clean(path)
+}
+
+// storedPlanPath canonicalizes a source path read back from a saved plan's
+// meta.json. Unlike livePlanPath it must NOT call Abs: a stored relative path
+// was spelled relative to the working directory of whoever ran `ox plan save`,
+// which we do not record. Re-resolving it against the CURRENT directory invents
+// a different file — so enriching the same plan from another directory would
+// silently stop recognizing its own ledger entry.
+//
+// Saves write an absolute path (see savePlanArtifacts), so this is about legacy
+// entries written before that. A relative one is unprovable, not wrong: return
+// "" so the caller keeps the hit rather than excluding the wrong plan.
+func storedPlanPath(path string) string {
+	if strings.TrimSpace(path) == "" || !filepath.IsAbs(path) {
+		return ""
 	}
 	return filepath.Clean(path)
 }
@@ -245,7 +262,7 @@ func selfPlanIdentity(path string) string {
 // source path is KEPT, and when the plan being enriched has no path of its own
 // (stdin, or a --topic consult) nothing is excluded at all.
 func excludeSelfPlan(hits []priorArtHit, ledgerPath string, in Input) []priorArtHit {
-	selfPath := selfPlanIdentity(in.Path)
+	selfPath := livePlanPath(in.Path)
 	if selfPath == "" || ledgerPath == "" {
 		return hits
 	}
@@ -277,7 +294,7 @@ func planSourcePath(plansDir, sourceID string) string {
 	if err != nil {
 		return ""
 	}
-	return selfPlanIdentity(meta.SourcePlanPath)
+	return storedPlanPath(meta.SourcePlanPath)
 }
 
 // rankHits filters raw ledger results below the threshold, sorts by score

--- a/internal/plan/priorart.go
+++ b/internal/plan/priorart.go
@@ -2,12 +2,14 @@ package plan
 
 import (
 	"context"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/sageox/ox/internal/ledgersearch"
+	"github.com/sageox/ox/internal/paths"
 )
 
 // init self-registers the prior-art detector with the global registry so the
@@ -72,7 +74,7 @@ func (d *priorArtDetector) Detect(ctx context.Context, in Input, gitRoot string)
 		return nil, nil
 	}
 
-	hits := excludeSelfPlan(rankHits(results), Slugify(PlanTopic(in)))
+	hits := excludeSelfPlan(rankHits(results), ledgerPath, in)
 	if len(hits) == 0 {
 		return nil, nil
 	}
@@ -200,31 +202,82 @@ type priorArtHit struct {
 
 // datedSlugRe matches a ledger plan ref's date prefix, e.g.
 // "2026-07-30-the-mcp-doctrine-plan-context-engineering" — the shape ox plan
-// save writes. Stripping the prefix leaves the bare slug to compare.
+// save writes.
 var datedSlugRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}-`)
+
+// isPlanRef reports whether a ledgersearch SourceID names a saved plan.
+func isPlanRef(ref string) bool {
+	return strings.Contains(ref, "data/plans/") || datedSlugRe.MatchString(ref)
+}
+
+// selfPlanIdentity is the source document a plan was saved from, canonicalized
+// for comparison. Empty means "no identity available" — callers must then leave
+// prior art alone rather than guess.
+func selfPlanIdentity(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(path)
+}
 
 // excludeSelfPlan drops the plan-under-enrichment's OWN ledger entry from prior
 // art. Once a plan is saved and re-enriched, its own save is a guaranteed
 // top-scoring self-match (observed: it was the sole surviving hit after the
-// density-scoring fix). Conservative: only drops entries whose ref is a plan
-// (under data/plans/, or the dated-slug shape) matching THIS plan's slug —
-// never a session that merely mentions the topic, and never a DIFFERENT plan
-// (other plans are legitimate prior art).
-func excludeSelfPlan(hits []priorArtHit, selfSlug string) []priorArtHit {
-	if selfSlug == "" {
+// density-scoring fix).
+//
+// Identity is the SOURCE PLAN PATH recorded in each candidate's meta.json, not
+// the title. Title is not identity: Title falls back to the generic
+// "Implementation Plan" for any document without headings, so matching on the
+// derived slug would make every untitled plan suppress every other untitled
+// plan — and any two genuinely independent plans that happen to share a title
+// would hide each other. Those older dated entries are distinct records and
+// legitimate prior art.
+//
+// Matching on the path (rather than the exact dated directory) still catches
+// the case this exists for: meta.CreatedAt is stamped fresh on every save, so
+// re-enriching tomorrow writes a NEW dated directory while yesterday's copy of
+// the same plan remains — same source path, both correctly excluded.
+//
+// Conservative by construction: a candidate whose meta is missing or records no
+// source path is KEPT, and when the plan being enriched has no path of its own
+// (stdin, or a --topic consult) nothing is excluded at all.
+func excludeSelfPlan(hits []priorArtHit, ledgerPath string, in Input) []priorArtHit {
+	selfPath := selfPlanIdentity(in.Path)
+	if selfPath == "" || ledgerPath == "" {
 		return hits
 	}
+	plansDir := paths.LedgerPlansDir(ledgerPath)
 	out := hits[:0]
 	for _, h := range hits {
-		ref := h.SourceID
-		bare := datedSlugRe.ReplaceAllString(ref, "")
-		isPlanRef := strings.Contains(ref, "data/plans/") || datedSlugRe.MatchString(ref)
-		if isPlanRef && (bare == selfSlug || strings.Contains(ref, "data/plans/"+selfSlug)) {
+		if isPlanRef(h.SourceID) && planSourcePath(plansDir, h.SourceID) == selfPath {
 			continue
 		}
 		out = append(out, h)
 	}
 	return out
+}
+
+// planSourcePath reads a saved plan's recorded source document path. Returns ""
+// when the plan dir or its meta is unreadable, or the field was never set —
+// each of which means "cannot prove this is the same plan", so the caller keeps
+// the hit.
+func planSourcePath(plansDir, sourceID string) string {
+	dirName := sourceID
+	if i := strings.LastIndex(dirName, "data/plans/"); i >= 0 {
+		dirName = dirName[i+len("data/plans/"):]
+	}
+	dirName = strings.Trim(dirName, "/")
+	if dirName == "" || strings.Contains(dirName, "..") {
+		return ""
+	}
+	meta, err := readMeta(filepath.Join(plansDir, dirName))
+	if err != nil {
+		return ""
+	}
+	return selfPlanIdentity(meta.SourcePlanPath)
 }
 
 // rankHits filters raw ledger results below the threshold, sorts by score

--- a/internal/plan/priorart.go
+++ b/internal/plan/priorart.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -71,7 +72,7 @@ func (d *priorArtDetector) Detect(ctx context.Context, in Input, gitRoot string)
 		return nil, nil
 	}
 
-	hits := rankHits(results)
+	hits := excludeSelfPlan(rankHits(results), Slugify(PlanTopic(in)))
 	if len(hits) == 0 {
 		return nil, nil
 	}
@@ -195,6 +196,35 @@ type priorArtHit struct {
 	Author   string
 	Date     string // YYYY-MM-DD if derivable, else ""
 	Text     string // ledgersearch snippet around the matched term (relevance)
+}
+
+// datedSlugRe matches a ledger plan ref's date prefix, e.g.
+// "2026-07-30-the-mcp-doctrine-plan-context-engineering" — the shape ox plan
+// save writes. Stripping the prefix leaves the bare slug to compare.
+var datedSlugRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}-`)
+
+// excludeSelfPlan drops the plan-under-enrichment's OWN ledger entry from prior
+// art. Once a plan is saved and re-enriched, its own save is a guaranteed
+// top-scoring self-match (observed: it was the sole surviving hit after the
+// density-scoring fix). Conservative: only drops entries whose ref is a plan
+// (under data/plans/, or the dated-slug shape) matching THIS plan's slug —
+// never a session that merely mentions the topic, and never a DIFFERENT plan
+// (other plans are legitimate prior art).
+func excludeSelfPlan(hits []priorArtHit, selfSlug string) []priorArtHit {
+	if selfSlug == "" {
+		return hits
+	}
+	out := hits[:0]
+	for _, h := range hits {
+		ref := h.SourceID
+		bare := datedSlugRe.ReplaceAllString(ref, "")
+		isPlanRef := strings.Contains(ref, "data/plans/") || datedSlugRe.MatchString(ref)
+		if isPlanRef && (bare == selfSlug || strings.Contains(ref, "data/plans/"+selfSlug)) {
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
 }
 
 // rankHits filters raw ledger results below the threshold, sorts by score

--- a/internal/plan/priorart_test.go
+++ b/internal/plan/priorart_test.go
@@ -2,6 +2,9 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sageox/ox/internal/ledgersearch"
@@ -401,39 +404,6 @@ func TestDetectorRegistered(t *testing.T) {
 	}
 }
 
-// TestExcludeSelfPlan_DropsOwnLedgerEntry is the regression for the enrich
-// self-match: once a plan is saved and re-enriched, its own ledger entry is a
-// guaranteed top hit and must not surface as "prior art". A different plan's
-// slug and a topical session must both survive.
-//
-// Mutation that turns this red: skip the excludeSelfPlan call in Detect.
-func TestExcludeSelfPlan_DropsOwnLedgerEntry(t *testing.T) {
-	self := "the-mcp-doctrine-plan-context-engineering"
-	hits := []priorArtHit{
-		{Score: 0.9, DocType: "plan", SourceID: "2026-07-30-" + self},                            // own entry — drop
-		{Score: 0.8, DocType: "plan", SourceID: "2026-07-12-some-other-plan"},                    // different plan — keep
-		{Score: 0.85, DocType: "session-transcript", SourceID: "2026-07-05T20-12-galexy-OxduHB"}, // session — keep
-	}
-	got := excludeSelfPlan(hits, self)
-	if len(got) != 2 {
-		t.Fatalf("got %d hits, want 2 (own plan dropped, other plan + session kept)", len(got))
-	}
-	for _, h := range got {
-		if h.SourceID == "2026-07-30-"+self {
-			t.Error("own ledger entry survived — self-match not excluded")
-		}
-	}
-}
-
-// TestExcludeSelfPlan_EmptySlugIsNoOp — a plan with no derivable slug must not
-// accidentally drop everything.
-func TestExcludeSelfPlan_EmptySlugIsNoOp(t *testing.T) {
-	hits := []priorArtHit{{Score: 0.9, DocType: "plan", SourceID: "2026-07-30-anything"}}
-	if got := excludeSelfPlan(hits, ""); len(got) != 1 {
-		t.Fatalf("empty slug dropped hits: got %d, want 1", len(got))
-	}
-}
-
 // TestPlanTopic_MatchesSavePathDerivation pins the invariant that makes
 // self-exclusion work at all: the slug the enricher excludes on must be the
 // slug the save path writes. PlanTopic is shared with the CLI's planTopic for
@@ -481,23 +451,130 @@ func TestPlanTopic_MatchesSavePathDerivation(t *testing.T) {
 	}
 }
 
-// TestExcludeSelfPlan_UsesTheTitleDerivedSlug closes the loop end-to-end: a
-// plan whose H1 is its real title must exclude the ledger entry saved under
-// that H1's slug. Under the Sections-walk derivation this test fails, because
-// the enricher would compute the H2's slug and leave the true self-match in.
-func TestExcludeSelfPlan_UsesTheTitleDerivedSlug(t *testing.T) {
-	in := Parse("# Conversation model update\n\n## 1. Context — Why Now\n\nprose.\n")
-	selfSlug := Slugify(PlanTopic(in))
+// writeLedgerPlan materializes a saved plan dir with the meta.json fields
+// self-exclusion reads. Returns the dated dir name (the ledgersearch SourceID).
+func writeLedgerPlan(t *testing.T, ledger, dirName, sourcePlanPath string) string {
+	t.Helper()
+	dir := filepath.Join(ledger, "data", "plans", dirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	body, err := json.Marshal(Meta{Slug: slugFromDirName(dirName), SourcePlanPath: sourcePlanPath})
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), body, 0o644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+	return dirName
+}
+
+// TestExcludeSelfPlan_DropsOwnLedgerEntry is the regression for the enrich
+// self-match: once a plan is saved and re-enriched, its own ledger entry is a
+// guaranteed top hit and must not surface as "prior art". A different plan and
+// a topical session must both survive.
+//
+// Mutation that turns this red: skip the excludeSelfPlan call in Detect.
+func TestExcludeSelfPlan_DropsOwnLedgerEntry(t *testing.T) {
+	ledger := t.TempDir()
+	selfSrc := filepath.Join(t.TempDir(), "plan.md")
+	own := writeLedgerPlan(t, ledger, "2026-07-30-the-mcp-doctrine", selfSrc)
+	other := writeLedgerPlan(t, ledger, "2026-07-12-some-other-plan", filepath.Join(t.TempDir(), "other.md"))
 
 	hits := []priorArtHit{
-		{Score: 0.9, DocType: "plan", SourceID: "2026-07-30-" + selfSlug},
-		{Score: 0.8, DocType: "plan", SourceID: "2026-07-29-some-other-plan"},
+		{Score: 0.9, DocType: "plan", SourceID: own},
+		{Score: 0.8, DocType: "plan", SourceID: other},
+		{Score: 0.85, DocType: "session-transcript", SourceID: "2026-07-05T20-12-galexy-OxduHB"},
 	}
-	got := excludeSelfPlan(hits, selfSlug)
+	got := excludeSelfPlan(hits, ledger, Input{Path: selfSrc})
+	if len(got) != 2 {
+		t.Fatalf("got %d hits, want 2 (own plan dropped, other plan + session kept)", len(got))
+	}
+	for _, h := range got {
+		if h.SourceID == own {
+			t.Error("own ledger entry survived — self-match not excluded")
+		}
+	}
+}
+
+// TestExcludeSelfPlan_KeepsIndependentPlansSharingATitle is the regression for
+// identifying a plan by its TITLE. Title is not identity: Title falls back to
+// the generic "Implementation Plan" for any document with no headings, so a
+// slug-based match made every untitled plan suppress every other untitled one,
+// and any two independent plans sharing a title hid each other. Those older
+// dated entries are distinct records and legitimate prior art.
+//
+// Mutation that turns this red: comparing Slugify(PlanTopic(in)) against the
+// candidate's date-stripped dir name instead of its recorded source path.
+func TestExcludeSelfPlan_KeepsIndependentPlansSharingATitle(t *testing.T) {
+	ledger := t.TempDir()
+	selfSrc := filepath.Join(t.TempDir(), "plan.md")
+	// identical slug, genuinely different source documents
+	own := writeLedgerPlan(t, ledger, "2026-07-30-implementation-plan", selfSrc)
+	older := writeLedgerPlan(t, ledger, "2026-06-01-implementation-plan", filepath.Join(t.TempDir(), "unrelated.md"))
+
+	hits := []priorArtHit{
+		{Score: 0.9, DocType: "plan", SourceID: own},
+		{Score: 0.8, DocType: "plan", SourceID: older},
+	}
+	got := excludeSelfPlan(hits, ledger, Input{Path: selfSrc})
 	if len(got) != 1 {
-		t.Fatalf("got %d hit(s), want 1 (own entry dropped, other plan kept)", len(got))
+		t.Fatalf("got %d hits, want 1 (only the plan's own entry dropped)", len(got))
 	}
-	if got[0].SourceID != "2026-07-29-some-other-plan" {
-		t.Errorf("wrong hit survived: %q", got[0].SourceID)
+	if got[0].SourceID != older {
+		t.Errorf("wrong hit survived: got %q, want the independent same-title plan %q", got[0].SourceID, older)
+	}
+}
+
+// TestExcludeSelfPlan_DropsEveryDatedSaveOfTheSamePlan covers why identity is
+// the source path rather than the exact dated directory: meta.CreatedAt is
+// stamped fresh on every save, so re-enriching tomorrow writes a NEW dated dir
+// while yesterday's copy of the same plan remains. Both are self-matches.
+func TestExcludeSelfPlan_DropsEveryDatedSaveOfTheSamePlan(t *testing.T) {
+	ledger := t.TempDir()
+	selfSrc := filepath.Join(t.TempDir(), "plan.md")
+	today := writeLedgerPlan(t, ledger, "2026-07-30-the-mcp-doctrine", selfSrc)
+	yesterday := writeLedgerPlan(t, ledger, "2026-07-29-the-mcp-doctrine", selfSrc)
+
+	hits := []priorArtHit{
+		{Score: 0.9, DocType: "plan", SourceID: today},
+		{Score: 0.85, DocType: "plan", SourceID: yesterday},
+	}
+	if got := excludeSelfPlan(hits, ledger, Input{Path: selfSrc}); len(got) != 0 {
+		t.Fatalf("got %d hits, want 0 — every dated save of the same plan is a self-match", len(got))
+	}
+}
+
+// TestExcludeSelfPlan_NoIdentityIsNoOp — stdin and --topic consults carry no
+// source path. With no identity to match on, exclusion must leave prior art
+// alone rather than fall back to guessing from the title.
+func TestExcludeSelfPlan_NoIdentityIsNoOp(t *testing.T) {
+	ledger := t.TempDir()
+	entry := writeLedgerPlan(t, ledger, "2026-07-30-anything", filepath.Join(t.TempDir(), "p.md"))
+	hits := []priorArtHit{{Score: 0.9, DocType: "plan", SourceID: entry}}
+
+	if got := excludeSelfPlan(hits, ledger, Input{}); len(got) != 1 {
+		t.Fatalf("no-path input dropped hits: got %d, want 1", len(got))
+	}
+	if got := excludeSelfPlan(hits, "", Input{Path: "/tmp/x.md"}); len(got) != 1 {
+		t.Fatalf("no-ledger dropped hits: got %d, want 1", len(got))
+	}
+}
+
+// TestExcludeSelfPlan_UnreadableMetaKeepsTheHit — a candidate we cannot prove
+// is the same plan (no meta, or no recorded source path) must survive. Failing
+// open here loses a self-match; failing closed would hide real prior art.
+func TestExcludeSelfPlan_UnreadableMetaKeepsTheHit(t *testing.T) {
+	ledger := t.TempDir()
+	selfSrc := filepath.Join(t.TempDir(), "plan.md")
+	noMeta := "2026-07-30-no-meta-here"
+	noSource := writeLedgerPlan(t, ledger, "2026-07-28-no-source-path", "")
+
+	hits := []priorArtHit{
+		{Score: 0.9, DocType: "plan", SourceID: noMeta},
+		{Score: 0.8, DocType: "plan", SourceID: noSource},
+	}
+	if got := excludeSelfPlan(hits, ledger, Input{Path: selfSrc}); len(got) != 2 {
+		t.Fatalf("got %d hits, want 2 — unprovable candidates must be kept", len(got))
 	}
 }

--- a/internal/plan/priorart_test.go
+++ b/internal/plan/priorart_test.go
@@ -578,3 +578,53 @@ func TestExcludeSelfPlan_UnreadableMetaKeepsTheHit(t *testing.T) {
 		t.Fatalf("got %d hits, want 2 — unprovable candidates must be kept", len(got))
 	}
 }
+
+// TestExcludeSelfPlan_StoredRelativePathIsNotReresolved is the regression for
+// canonicalizing a PERSISTED path against the enrichment working directory. A
+// stored relative path was spelled relative to whatever directory ran
+// `ox plan save`, and that directory is not recorded. Resolving it against the
+// current one names a different file entirely.
+//
+// Failure prevented: calling filepath.Abs on meta.SourcePlanPath. That silently
+// changes identity with the caller's cwd — worse than not matching, because it
+// could resolve onto an unrelated plan and exclude the wrong entry. Saves now
+// persist an absolute path; a legacy relative one is treated as unprovable, so
+// the hit is kept.
+func TestExcludeSelfPlan_StoredRelativePathIsNotReresolved(t *testing.T) {
+	ledger := t.TempDir()
+	legacy := writeLedgerPlan(t, ledger, "2026-07-30-legacy-relative", "docs/plan.md")
+	hits := []priorArtHit{{Score: 0.9, DocType: "plan", SourceID: legacy}}
+
+	// enriching from a directory where "docs/plan.md" happens to resolve to the
+	// live input path must NOT be mistaken for the same plan.
+	workdir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workdir, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	live := filepath.Join(workdir, "docs", "plan.md")
+
+	if got := excludeSelfPlan(hits, ledger, Input{Path: live}); len(got) != 1 {
+		t.Fatalf("a stored relative path was re-resolved against the current dir and matched: got %d hits, want 1", len(got))
+	}
+}
+
+// TestStoredVsLivePlanPath pins the asymmetry directly: the live input path is
+// relative to the running process and so resolves; a stored path must already
+// be absolute to count.
+func TestStoredVsLivePlanPath(t *testing.T) {
+	if got := storedPlanPath("docs/plan.md"); got != "" {
+		t.Errorf("storedPlanPath(relative) = %q, want \"\" (unprovable)", got)
+	}
+	if got := storedPlanPath("/abs/docs/plan.md"); got != "/abs/docs/plan.md" {
+		t.Errorf("storedPlanPath(absolute) = %q, want it kept", got)
+	}
+	if got := storedPlanPath(""); got != "" {
+		t.Errorf("storedPlanPath(empty) = %q, want \"\"", got)
+	}
+	if got := livePlanPath("docs/plan.md"); !filepath.IsAbs(got) {
+		t.Errorf("livePlanPath(relative) = %q, want it resolved against cwd", got)
+	}
+	if got := livePlanPath(""); got != "" {
+		t.Errorf("livePlanPath(empty) = %q, want \"\"", got)
+	}
+}

--- a/internal/plan/priorart_test.go
+++ b/internal/plan/priorart_test.go
@@ -433,3 +433,71 @@ func TestExcludeSelfPlan_EmptySlugIsNoOp(t *testing.T) {
 		t.Fatalf("empty slug dropped hits: got %d, want 1", len(got))
 	}
 }
+
+// TestPlanTopic_MatchesSavePathDerivation pins the invariant that makes
+// self-exclusion work at all: the slug the enricher excludes on must be the
+// slug the save path writes. PlanTopic is shared with the CLI's planTopic for
+// exactly that reason, so it has to keep deriving the topic the same way —
+// explicit --topic wins, otherwise the document TITLE (H1-first).
+//
+// Failure prevented: re-deriving the topic by walking Sections for the first
+// heading. Parse splits on "## " only, so an H1 lives in the Heading==""
+// preamble section and such a walk cannot see it — the ox-1tjj.8 bug. That
+// breaks self-exclusion silently (the enricher computes a different slug than
+// the ledger dir, so the self-match survives) AND regresses plan titles.
+func TestPlanTopic_MatchesSavePathDerivation(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Input
+		want string
+	}{
+		{
+			name: "H1 wins over a numbered context H2",
+			in:   Parse("# Conversation model update\n\n## 1. Context — Why Now\n\nprose.\n"),
+			want: "Conversation model update",
+		},
+		{
+			name: "H1 wins over a TL;DR H2",
+			in:   Parse("# ox plan — enriched plans\n\n## TL;DR\n\nShip it.\n"),
+			want: "ox plan — enriched plans",
+		},
+		{
+			name: "no H1 falls back to the first H2",
+			in:   Parse("preamble\n\n## First Section\n\nbody\n"),
+			want: "First Section",
+		},
+		{
+			name: "explicit topic short-circuits the document title",
+			in:   Input{Topic: "explicit consult topic", Raw: "# A Different Title\n\nbody\n"},
+			want: "explicit consult topic",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := PlanTopic(tc.in); got != tc.want {
+				t.Errorf("PlanTopic(...) = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExcludeSelfPlan_UsesTheTitleDerivedSlug closes the loop end-to-end: a
+// plan whose H1 is its real title must exclude the ledger entry saved under
+// that H1's slug. Under the Sections-walk derivation this test fails, because
+// the enricher would compute the H2's slug and leave the true self-match in.
+func TestExcludeSelfPlan_UsesTheTitleDerivedSlug(t *testing.T) {
+	in := Parse("# Conversation model update\n\n## 1. Context — Why Now\n\nprose.\n")
+	selfSlug := Slugify(PlanTopic(in))
+
+	hits := []priorArtHit{
+		{Score: 0.9, DocType: "plan", SourceID: "2026-07-30-" + selfSlug},
+		{Score: 0.8, DocType: "plan", SourceID: "2026-07-29-some-other-plan"},
+	}
+	got := excludeSelfPlan(hits, selfSlug)
+	if len(got) != 1 {
+		t.Fatalf("got %d hit(s), want 1 (own entry dropped, other plan kept)", len(got))
+	}
+	if got[0].SourceID != "2026-07-29-some-other-plan" {
+		t.Errorf("wrong hit survived: %q", got[0].SourceID)
+	}
+}

--- a/internal/plan/priorart_test.go
+++ b/internal/plan/priorart_test.go
@@ -400,3 +400,36 @@ func TestDetectorRegistered(t *testing.T) {
 		t.Fatal("prior-art detector not registered via init()")
 	}
 }
+
+// TestExcludeSelfPlan_DropsOwnLedgerEntry is the regression for the enrich
+// self-match: once a plan is saved and re-enriched, its own ledger entry is a
+// guaranteed top hit and must not surface as "prior art". A different plan's
+// slug and a topical session must both survive.
+//
+// Mutation that turns this red: skip the excludeSelfPlan call in Detect.
+func TestExcludeSelfPlan_DropsOwnLedgerEntry(t *testing.T) {
+	self := "the-mcp-doctrine-plan-context-engineering"
+	hits := []priorArtHit{
+		{Score: 0.9, DocType: "plan", SourceID: "2026-07-30-" + self},                            // own entry — drop
+		{Score: 0.8, DocType: "plan", SourceID: "2026-07-12-some-other-plan"},                    // different plan — keep
+		{Score: 0.85, DocType: "session-transcript", SourceID: "2026-07-05T20-12-galexy-OxduHB"}, // session — keep
+	}
+	got := excludeSelfPlan(hits, self)
+	if len(got) != 2 {
+		t.Fatalf("got %d hits, want 2 (own plan dropped, other plan + session kept)", len(got))
+	}
+	for _, h := range got {
+		if h.SourceID == "2026-07-30-"+self {
+			t.Error("own ledger entry survived — self-match not excluded")
+		}
+	}
+}
+
+// TestExcludeSelfPlan_EmptySlugIsNoOp — a plan with no derivable slug must not
+// accidentally drop everything.
+func TestExcludeSelfPlan_EmptySlugIsNoOp(t *testing.T) {
+	hits := []priorArtHit{{Score: 0.9, DocType: "plan", SourceID: "2026-07-30-anything"}}
+	if got := excludeSelfPlan(hits, ""); len(got) != 1 {
+		t.Fatalf("empty slug dropped hits: got %d, want 1", len(got))
+	}
+}

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -649,6 +649,24 @@ var slugStopWords = map[string]bool{
 	"and": true, "for": true, "in": true, "on": true, "with": true,
 }
 
+// PlanTopic returns the plan's title — the first non-empty H2 heading, else the
+// first non-empty raw line. Shared with the CLI's planTopic so the slug the
+// enricher self-excludes on (priorart.go) cannot drift from the slug the save
+// path writes to the ledger.
+func PlanTopic(in Input) string {
+	for _, sec := range in.Sections {
+		if h := strings.TrimSpace(sec.Heading); h != "" {
+			return h
+		}
+	}
+	for _, line := range strings.Split(in.Raw, "\n") {
+		if line = strings.TrimSpace(strings.TrimLeft(line, "# ")); line != "" {
+			return line
+		}
+	}
+	return "untitled plan"
+}
+
 // Slugify derives a kebab-case slug from a topic/title. Lowercases, strips
 // punctuation, keeps the first slugWordCap meaningful words, then trims any
 // trailing stopword(s) — interior stopwords are left alone. An empty,

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -649,22 +649,22 @@ var slugStopWords = map[string]bool{
 	"and": true, "for": true, "in": true, "on": true, "with": true,
 }
 
-// PlanTopic returns the plan's title — the first non-empty H2 heading, else the
-// first non-empty raw line. Shared with the CLI's planTopic so the slug the
-// enricher self-excludes on (priorart.go) cannot drift from the slug the save
-// path writes to the ledger.
+// PlanTopic returns the topic a plan is saved under: an explicit --topic wins,
+// otherwise the document's title. Shared with the CLI's planTopic so the slug
+// the enricher self-excludes on (priorart.go) cannot drift from the slug the
+// save path writes to the ledger — which is the whole point of it being one
+// function, so it MUST stay a thin wrapper over the save path's derivation.
+//
+// It delegates to Title rather than re-deriving: Title prefers the document's
+// H1 and only then falls back to the first H2. Walking Sections for the first
+// heading directly is the ox-1tjj.8 bug — Parse splits on "## " only, so an H1
+// lives in the Heading=="" preamble section and is invisible to that walk,
+// which saved "# Real Title" + "## 1. Context" under "1. Context".
 func PlanTopic(in Input) string {
-	for _, sec := range in.Sections {
-		if h := strings.TrimSpace(sec.Heading); h != "" {
-			return h
-		}
+	if t := strings.TrimSpace(in.Topic); t != "" {
+		return t
 	}
-	for _, line := range strings.Split(in.Raw, "\n") {
-		if line = strings.TrimSpace(strings.TrimLeft(line, "# ")); line != "" {
-			return line
-		}
-	}
-	return "untitled plan"
+	return Title(in)
 }
 
 // Slugify derives a kebab-case slug from a topic/title. Lowercases, strips


### PR DESCRIPTION
## What a coworker gets

**Prior art you can trust.** `ox plan enrich` was citing unrelated sessions as
**0.95-confidence prior art**. On a real plan, all three "prior art" hits were
unrelated — RunJob staleness, devtools, device-code auth — and every one blew past
the 0.6 relevance gate. That doesn't just add noise: it makes a human stop
believing the enrichment block, which is the product.

**Plans that look designed, not generated.** Four new `ox plan viz` patterns, so an
AI coworker reaches into a curated catalog instead of hand-rolling a worse
equivalent.

**Renders that don't quietly break.** Diagram labels were clipping mid-word in
rendered plans — a defect invisible until someone screenshots the page.


**Prior art no longer cites the plan you're currently writing.** Once a plan is
saved, re-enriching it matched its own ledger entry — a guaranteed top hit, and the
one that survived the scoring fix above. Enrichment now excludes the
plan-under-enrichment's own entry while keeping other plans, which are legitimate
prior art.

A plan is identified by the **source document path** it recorded, never by its
title. Title is not identity: `Title` falls back to the generic "Implementation
Plan" for any document without headings, so a title-derived match would make every
untitled plan suppress every other untitled plan. The save path stamps
`SourcePlanPath` from the same `Input.Path` the detector reads, so the two agree by
construction. Matching the path rather than the exact dated directory still catches
the case this exists for — `CreatedAt` is stamped fresh on every save, so
re-enriching tomorrow writes a new dated dir while yesterday's copy remains.

Conservative in every unprovable direction: a candidate with no meta or no recorded
source path is kept, and an input with no path of its own excludes nothing.

---

## What broke, and why

### Relevance was measuring the wrong thing

`scoreContent`'s term-frequency bonus was `totalHits/100`, capped at 0.5. That is
length-biased: a 100 KB transcript accumulates scattered hits by sheer volume and
saturates the bonus, with no normalization. "Long and vaguely related" beat "short
and on-topic."

The fix scores **density** — hits beyond the first per term, per KB — so the bonus
means *these terms are what this document is about*.

But density alone over-corrects, and that turned out to matter more than the
original bug:

```mermaid
flowchart TD
  CAP["Scanner caps at 10 hits per term"] --> BOUND["extraHits bounded at 9 x terms"]
  BOUND --> CEIL["Divisor sets a hard document-size ceiling"]
  CEIL --> LOST["3-term query — nothing over 13.5 KB reaches the 0.6 gate"]
  LOST --> REAL["14% of saved plans in this repo, unfindable"]
```

Measured against this repo's real ledger — 27 plans, median 7.4 KB, **p90 17.4 KB**,
max 22.7 KB. A first cut of this fix would have silently made the largest, most
substantial plans permanently invisible as prior art, no matter how on-topic. The
divisor is tuned to 5 and named, with the rationale at the constant:

| document | divisor 20 | divisor 5 |
|---|---|---|
| focused 1 KB, on-topic | 1.000 ✓ | 1.000 ✓ |
| scattered 96 KB — the original bug | 0.502 ✓ gated | 0.506 ✓ gated |
| **dense, on-topic 20 KB plan** | **0.568 ✗ lost** | 0.770 ✓ surfaces |
| tangential 20 KB plan | 0.503 ✓ gated | 0.530 ✓ gated |

### A lint rule that ox's own renderer failed

Mermaid sizes node boxes using whatever font is loaded when it draws. The scaffold
drew before the webfont arrived, so every box was measured against the fallback and
overflowed once the wider face swapped in.

The renderer is fixed first — re-render on `document.fonts.ready` — and only then
does the new `mermaid.font-race` advisory make sense. Shipped the other way around,
it would have fired on **every** non-artifact Go-rendered plan with a diagram, and
`ox plan lint --strict` would have exited non-zero on ox's own output.

`TestLintRender_GoRendererOutputIsClean` now pins that invariant: ox must never ship
a lint rule its own renderer fails.

---

## Review feedback

Reviewed against `origin/main`, which is **83 commits ahead** of where this branch
forked. Four of the branch's commits (`.rej` cleanup, non-interactive git signing)
had **already landed on main via #684** in a better form — including two of the
fixes requested on this PR. Those commits are dropped; that is what resolved all six
merge conflicts.

| Feedback | Resolution |
|---|---|
| `RejFilesTracked` swallows git failures | Already fixed on main (#684) |
| `checkLedgerRejTracked` doesn't re-verify | Already fixed on main (#684) |
| Scattered fixture doesn't reproduce the failure | **Fixed** — confirmed: old formula scored it 0.56, under the 0.6 assertion, so it passed either way |
| `lintWordmark` gate diverges from `LintBranding` | **Fixed** — shared `isEnriched` helper |
| `lintWordmark` on empty HTML | **Fixed** — live bug; `ox plan save` leaves html nil without `--html` |
| `lintWordmark` matches arbitrary page text | **Fixed** — matches a stamped `data-ox-wordmark` marker |
| Font-race check not scoped to scripts | **Fixed** — scoped, comments stripped, requires a real diagram |
| Progress bar lacks value semantics | **Fixed** — `role="progressbar"` + live values |
| Risk rows lack expandable semantics | **Fixed** — `role="button"`, `aria-expanded`, `aria-controls` |
| Wordmark "every rendered plan" vs enrichment-conditional | **Fixed** — scoped to enriched renders |
| Duplicate step 8 in the skill | Moot — main rewrote `SKILL.md` (#717/#719/#720) |
| `extractPATFromRemote` swallows `url.Parse` | Deferred — needs a judgment call, filed |
| Duplicate-title plans hidden from prior art (Greptile P1) | **Fixed** — identity is the source path, not the title |

`SKILL.md` takes main's version wholesale. Main now injects the branding chrome by
construction ("you don't add it"), so the branch's hand-add-the-wordmark guidance was
obsolete — and ~30 of its 36 added lines were thick behavioral guidance that the
thin-relay rule in `CLAUDE.md` puts in the binary, not the skill. Two of them
duplicated rules this same PR encodes as Go lints, which is exactly the drift that
rule exists to prevent. The doctrine worth keeping moved to the viz catalog preamble
and the HTML-authoring spec; the `await` BLOCKS behavior was already in the CLI
guidance, cross-agent.

Filed as follow-ups: `ox-0hu6` (enrich self-match — a re-enriched plan always
matches itself, which makes `Signals.Material` *always* true), `ox-9yo6`, `ox-rjj9`,
`ox-rojt`.

---

## Test plan

- [x] `make test` — 17,129 tests pass, 1,086 skipped
- [x] `make lint` — 0 issues
- [x] **Every regression test verified red under the mutation it names**, not just green:
  - old `totalHits/100` formula → scattered fixture scores 0.800, test fails
  - divisor back to 20 → dense 18 KB on-topic doc scores 0.575, test fails
  - scaffold without `fonts.ready` → `mermaid.font-race` fires on ox's own render
- [x] Comment-stripping in the font-race rule came *out of* that mutation testing — the
      scaffold's own comment naming `fonts.ready` was silencing the finding even with
      the code removed

Co-Authored-By: [SageOx](https://github.com/SageOx)
