### PR TITLE
docs(agents): README matrix matches shipped adapters; add Goose prime

### DIFF
--- a/.sageox/README.md
+++ b/.sageox/README.md
@@ -66,12 +66,13 @@ ox init
 SageOx integrates with the AI coworkers developers already use:
 
 - **Claude Code, Codex, Gemini CLI, Droid** — Automatic via lifecycle hooks
-- **OpenCode, Amp** — Automatic via a plugin
+- **OpenCode** — Automatic via a plugin
+- **Amp** — Plugin records the session; `AGENTS.md` primes it
 - **Pi, Aider, Goose** — Via the `ox agent prime` marker in their instruction file
 - **Cursor, Windsurf, Cline, Copilot, Kiro** — Via the marker in `.cursorrules`, `.windsurfrules`, and equivalents
 - **Any AI coworker** — Manual `ox agent prime` injection
 
-Sessions are recorded to the Ledger for every agent above that has an ox adapter.
+Sessions are recorded to the Ledger for every AI coworker above that has an ox adapter.
 Run `ox status` to see which ones are wired up in this repo.
 
 ## Key Files

--- a/.sageox/README.md
+++ b/.sageox/README.md
@@ -65,11 +65,14 @@ ox init
 
 SageOx integrates with the AI coworkers developers already use:
 
-- **Claude Code** — Automatic via AGENTS.md hook
-- **Cursor** — Via .cursorrules integration
-- **Windsurf** — Via .windsurfrules integration
-- **OpenCode** — Direct ox CLI integration
+- **Claude Code, Codex, Gemini CLI, Droid** — Automatic via lifecycle hooks
+- **OpenCode, Amp** — Automatic via a plugin
+- **Pi, Aider, Goose** — Via the `ox agent prime` marker in their instruction file
+- **Cursor, Windsurf, Cline, Copilot, Kiro** — Via the marker in `.cursorrules`, `.windsurfrules`, and equivalents
 - **Any AI coworker** — Manual `ox agent prime` injection
+
+Sessions are recorded to the Ledger for every agent above that has an ox adapter.
+Run `ox status` to see which ones are wired up in this repo.
 
 ## Key Files
 

--- a/README.md
+++ b/README.md
@@ -45,17 +45,42 @@ inherits it too. Context compounds instead of evaporating.
 `ox` is agent-agnostic. The same recorded context is primed into, and queryable
 from, whichever agent your team uses.
 
-| Agent | Prime context | Record sessions | Murmur (coordinate) | Query past work |
-|---|:---:|:---:|:---:|:---:|
-| **Claude Code** | ✅ | ✅ | ✅ | ✅ |
-| **Codex CLI** | ✅ | ✅ | ✅ | ✅ |
-| **Cursor** | ✅ | ✅ | ➖ | ✅ |
-| **Windsurf / Cline / Copilot / Aider** | ✅ | ➖ | ➖ | ✅ |
+| Agent | Prime context | Record sessions | What fires it |
+|---|:---:|:---:|---|
+| **Claude Code** | ✅ | ✅ | hooks — session, prompt, tool, and compaction |
+| **Codex CLI** | ✅ | ✅ | hooks — session, prompt, and tool |
+| **Gemini CLI** | ✅ | ✅ | hooks — tool and stop |
+| **Droid** | ✅ | ✅ | hooks — tool and stop |
+| **OpenCode** | ✅ | ✅ | plugin — session start |
+| **Amp** | ✅ | ✅ | plugin records; `AGENTS.md` primes |
+| **Pi** | ✅ | ✅ | `AGENTS.md` |
+| **Aider** | ✅ | ✅ | `CONVENTIONS.md` |
+| **Goose** | ✅ | ➖ | `AGENTS.md` |
+| Cursor · Windsurf · Cline · Copilot · Kiro | ✅ | ➖ | instruction file |
 
-✅ supported · ➖ planned. Claude Code is the primary, most-tested target.
+✅ shipped · ➖ planned. Claude Code is the primary, most-tested target; see
+[agent compatibility](docs/guides/agent-compatibility.md) for the per-agent detail.
 
-<sub>Agent names are trademarks of their respective owners; `ox` is compatible
-with, not affiliated with, them.</sub>
+`ox query`, `ox murmur`, and `ox status` are plain CLI commands. They work from
+any agent — including ones with no adapter — as long as `ox` is on `PATH`.
+
+### Orchestrators
+
+`ox` also detects the harness running your agents, and adapts what it tells them:
+
+- [**Block Buzz**](https://github.com/block/buzz) — spawns agents through its
+  `buzz-acp` ACP harness
+- [**Conductor**](https://conductor.build) · [**Gas City**](https://github.com/gastownhall/gascity)
+  · [**OpenClaw**](https://github.com/openclaw/openclaw)
+
+Detection is config-independent — `ox` walks the process ancestry rather than
+trusting an environment variable, so it works even when the harness sets nothing.
+Under Buzz, `ox agent prime` emits an extra directive: `buzz-acp` does not fire
+the agent lifecycle hooks that push whispers into a turn, so the agent is told to
+pull teammates' signals by hand instead of silently missing them.
+
+<sub>Agent and orchestrator names are trademarks of their respective owners; `ox`
+is compatible with, not affiliated with, them.</sub>
 
 ## Install
 

--- a/cmd/ox/guides/agents-md.md
+++ b/cmd/ox/guides/agents-md.md
@@ -6,7 +6,7 @@ audience: both
 
 # AGENTS.md and CLAUDE.md
 
-AI coding agents read instruction files at session start to learn project conventions. Different tools historically named these files differently — `CLAUDE.md` (Claude Code), `.cursorrules` (Cursor), `.windsurfrules` (Windsurf), `AGENTS.md` (Codex CLI, Aider, OpenAI Agents SDK). The cross-tool convention has converged on **AGENTS.md at the repo root**.
+AI coding agents read instruction files at session start to learn project conventions. Different tools historically named these files differently — `CLAUDE.md` (Claude Code), `.cursorrules` (Cursor), `.windsurfrules` (Windsurf), `GEMINI.md` (Gemini CLI), `CONVENTIONS.md` (Aider). The cross-tool convention has converged on **AGENTS.md at the repo root**, which Codex, OpenCode, Amp, Pi, Goose, and the OpenAI Agents SDK all read.
 
 SageOx supports both `AGENTS.md` and `CLAUDE.md` and follows the convention of treating them as siblings — typically `CLAUDE.md` is a symlink to `AGENTS.md` so both work without duplication.
 

--- a/cmd/ox/guides/getting-started.md
+++ b/cmd/ox/guides/getting-started.md
@@ -6,7 +6,7 @@ audience: both
 
 # Getting Started
 
-SageOx makes your team's architectural decisions, conventions, and prior session history automatically available to every AI coworker on the team — Claude, Codex, Amp, and any other supported coding agent. Every coding session starts with the full picture, not from zero.
+SageOx makes your team's architectural decisions, conventions, and prior session history automatically available to every AI coworker on the team — Claude Code, Codex, Gemini, Droid, OpenCode, Amp, Pi, Aider, Goose, and any other supported coding agent. Every coding session starts with the full picture, not from zero.
 
 ## Setup (one-time)
 

--- a/cmd/ox/guides/murmur-vs-rule.md
+++ b/cmd/ox/guides/murmur-vs-rule.md
@@ -37,7 +37,7 @@ Murmurs are great for "don't pick up this code right now" or "I'm changing a con
 
 ## Team rules
 
-A team rule is a markdown file in `<team-context>/agents/rules/<topic>.md` that loads (or is cataloged) into every teammate's AI coworker session via `ox agent prime`. It persists indefinitely and applies to every supported coding agent (Claude, Codex, Amp, etc.) that any teammate uses.
+A team rule is a markdown file in `<team-context>/agents/rules/<topic>.md` that loads (or is cataloged) into every teammate's AI coworker session via `ox agent prime`. It persists indefinitely and applies to every supported coding agent (Claude Code, Codex, Gemini, Droid, OpenCode, Amp, etc.) that any teammate uses.
 
 ```bash
 # clone or update your team-context repo

--- a/cmd/ox/guides/team-rules.md
+++ b/cmd/ox/guides/team-rules.md
@@ -6,14 +6,14 @@ audience: both
 
 # Team Rules
 
-Team rules are conventions, policies, and decisions that apply to **every AI coworker** working on your team's repos — Claude, Codex, Amp, Cursor, and any other supported coding agent. They live in your team's SageOx team context, not in any single repo.
+Team rules are conventions, policies, and decisions that apply to **every AI coworker** working on your team's repos — Claude Code, Codex, Gemini, Droid, OpenCode, Amp, Cursor, Goose, and any other supported coding agent. They live in your team's SageOx team context, not in any single repo.
 
 ## Scope: who they reach
 
 A SageOx team rule applies to:
 
 - **All teammates who run `ox`** in a repo associated with the team. Teammates who don't use `ox` will not see it (same as `.claude/rules/` only reaching Claude users).
-- **All coding agents those teammates use** — Claude, Codex, Amp, etc. SageOx is agent-agnostic; the rule loads via `ox agent prime` regardless of which coding tool is connected.
+- **All coding agents those teammates use** — Claude Code, Codex, Gemini, Droid, OpenCode, Amp, etc. SageOx is agent-agnostic; the rule loads via `ox agent prime` regardless of which coding tool is connected.
 
 ## When to use a team rule vs. a project-local rule
 

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -1340,12 +1340,13 @@ ox init
 SageOx integrates with the AI coworkers developers already use:
 
 - **Claude Code, Codex, Gemini CLI, Droid** — Automatic via lifecycle hooks
-- **OpenCode, Amp** — Automatic via a plugin
+- **OpenCode** — Automatic via a plugin
+- **Amp** — Plugin records the session; ` + "`AGENTS.md`" + ` primes it
 - **Pi, Aider, Goose** — Via the ` + "`ox agent prime`" + ` marker in their instruction file
 - **Cursor, Windsurf, Cline, Copilot, Kiro** — Via the marker in ` + "`.cursorrules`" + `, ` + "`.windsurfrules`" + `, and equivalents
 - **Any AI coworker** — Manual ` + "`ox agent prime`" + ` injection
 
-Sessions are recorded to the Ledger for every agent above that has an ox adapter.
+Sessions are recorded to the Ledger for every AI coworker above that has an ox adapter.
 Run ` + "`ox status`" + ` to see which ones are wired up in this repo.
 
 ## Key Files

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -1339,11 +1339,14 @@ ox init
 
 SageOx integrates with the AI coworkers developers already use:
 
-- **Claude Code** — Automatic via AGENTS.md hook
-- **Cursor** — Via .cursorrules integration
-- **Windsurf** — Via .windsurfrules integration
-- **OpenCode** — Direct ox CLI integration
+- **Claude Code, Codex, Gemini CLI, Droid** — Automatic via lifecycle hooks
+- **OpenCode, Amp** — Automatic via a plugin
+- **Pi, Aider, Goose** — Via the ` + "`ox agent prime`" + ` marker in their instruction file
+- **Cursor, Windsurf, Cline, Copilot, Kiro** — Via the marker in ` + "`.cursorrules`" + `, ` + "`.windsurfrules`" + `, and equivalents
 - **Any AI coworker** — Manual ` + "`ox agent prime`" + ` injection
+
+Sessions are recorded to the Ledger for every agent above that has an ox adapter.
+Run ` + "`ox status`" + ` to see which ones are wired up in this repo.
 
 ## Key Files
 

--- a/cmd/ox/instruction_files.go
+++ b/cmd/ox/instruction_files.go
@@ -22,6 +22,7 @@ const (
 	agentOpenCode   = "opencode"
 	agentAmp        = "amp"
 	agentAider      = "aider"
+	agentGoose      = "goose"
 )
 
 // Marker format constants.
@@ -162,6 +163,16 @@ var InstructionFileRegistry = []InstructionFileSpec{
 	{
 		AgentType:    agentAider,
 		DisplayName:  "Aider",
+		ProjectFiles: []string{"AGENTS.md"},
+		MarkerFormat: markerFormatMarkdown,
+		DetectFn:     nil, // shares AGENTS.md
+	},
+	{
+		AgentType:   agentGoose,
+		DisplayName: "Goose",
+		// Goose loads AGENTS.md before .goosehints, hierarchically from the
+		// working directory up to the repo root. Marking AGENTS.md is enough;
+		// .goosehints would be a second copy of the same instruction.
 		ProjectFiles: []string{"AGENTS.md"},
 		MarkerFormat: markerFormatMarkdown,
 		DetectFn:     nil, // shares AGENTS.md

--- a/cmd/ox/instruction_files_test.go
+++ b/cmd/ox/instruction_files_test.go
@@ -593,6 +593,28 @@ func TestInstructionFileRegistry_AllSpecsHaveRequiredFields(t *testing.T) {
 	}
 }
 
+// TestInstructionFileRegistry_GooseSharesAgentsMd pins where the Goose marker
+// goes. Goose loads AGENTS.md BEFORE .goosehints, so marking AGENTS.md reaches
+// it first and a second .goosehints copy would only duplicate the instruction.
+// Goose must also carry no DetectFn — an AGENTS.md-sharing agent that gated on
+// detection would suppress the marker in repos where no Goose-specific file
+// exists, which is every repo, since Goose creates none.
+func TestInstructionFileRegistry_GooseSharesAgentsMd(t *testing.T) {
+	var goose *InstructionFileSpec
+	for i := range InstructionFileRegistry {
+		if InstructionFileRegistry[i].AgentType == agentGoose {
+			goose = &InstructionFileRegistry[i]
+			break
+		}
+	}
+
+	require.NotNil(t, goose, "Goose must be registered — it reads AGENTS.md natively")
+	assert.Equal(t, []string{"AGENTS.md"}, goose.ProjectFiles)
+	assert.Equal(t, markerFormatMarkdown, goose.MarkerFormat)
+	assert.Nil(t, goose.DetectFn, "Goose shares AGENTS.md; gating on detection would suppress the marker")
+	assert.False(t, goose.Creatable, "AGENTS.md is a primary file; Creatable would be redundant")
+}
+
 func TestInstructionFileRegistry_PrimaryFilesAreMarkdown(t *testing.T) {
 	// AGENTS.md and CLAUDE.md must use markdown format -- they support HTML comments
 	for _, spec := range InstructionFileRegistry {

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -76,8 +76,9 @@ var integrateCmd = &cobra.Command{
 Supported agents:
   Claude Code (default)    JSON hooks in ~/.claude/settings.json
 
-Other agents (Codex, Gemini) can be installed with their respective flags.
-Run 'ox init' to set up the project with appropriate guidance files.
+Other agents (Codex, Gemini, Amp, OpenCode, Pi) can be installed with their
+respective flags. Run 'ox init' to set up the project with appropriate
+guidance files.
 
 The integration ensures that 'ox agent prime' runs when an AI coding session starts.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -98,7 +99,8 @@ Other agents can be installed with their respective flags:
   --gemini    Gemini CLI hooks
   --codex     Codex CLI hooks
   --amp       Amp CLI integration (AGENTS.md marker)
-  --opencode  OpenCode plugin`,
+  --opencode  OpenCode plugin
+  --pi        Pi coding agent integration (AGENTS.md marker)`,
 	RunE: runIntegrateInstall,
 }
 

--- a/docs/guides/agent-compatibility.md
+++ b/docs/guides/agent-compatibility.md
@@ -6,20 +6,44 @@ ox works with multiple AI coding agents. Support depth varies by agent — here'
 
 | Tier | What It Means |
 |------|---------------|
-| **Gold** | Full feature parity. Real-time session recording, hooks, whispers, anti-entropy recovery. Tested in CI. |
-| **Silver** | Core features work. Hooks fire, context primes correctly, basic session recording. Tested weekly. |
-| **Bronze** | Context injection via AGENTS.md works. Session recording via manual start/stop. Limited or no hooks. |
+| **Gold** | Full feature parity. Real-time session recording, hooks on every lifecycle phase, whisper push, anti-entropy recovery. Tested in CI. |
+| **Silver** | Core features work. Hooks fire, context primes correctly, sessions record. Tested weekly. |
+| **Bronze** | Context injection works and sessions record. Limited or no lifecycle hooks. |
+| **Marker only** | ox writes an `ox agent prime` marker into the agent's instruction file. No adapter, so no session recording. |
 
 ## Feature Availability
 
-| Feature | Claude Code | Codex | Gemini | Amp | Pi | OpenCode |
-|---------|:-:|:-:|:-:|:-:|:-:|:-:|
-| Context Prime | Gold | Silver | Silver | Bronze | Bronze | Bronze |
-| Session Recording | Gold | Silver | Silver | — | — | — |
-| Whispers | Gold | — | Silver | — | — | — |
-| Hooks | Gold | Silver | Silver | — | — | — |
-| MCP | Gold | — | — | — | Bronze | — |
-| Anti-Entropy | Gold | — | — | — | — | — |
+| Feature | Claude Code | Codex | Gemini | Droid | OpenCode | Amp | Pi | Aider | Goose |
+|---------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| Tier | Gold | Silver | Silver | Silver | Bronze | Bronze | Bronze | Bronze | Marker only |
+| Context prime | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Session recording | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Auto-prime at session start | ✅ | ✅ | — | — | ✅ | — | — | — | — |
+| Lifecycle hooks | ✅ | ✅ | ✅ | ✅ | plugin | plugin | — | — | — |
+| Whisper push | ✅ | ✅ | fallback | fallback | — | — | — | — | — |
+| Team rules install | ✅ | — | — | ✅ | — | — | — | — | — |
+| Skills / commands install | ✅ | — | — | — | — | — | — | — | — |
+| Anti-entropy recovery | ✅ | — | — | — | — | — | — | — | — |
+
+**Auto-prime** means a hook or plugin runs `ox agent prime` for you. Where it's absent,
+priming relies on the agent obeying the blocking marker in its instruction file.
+
+**Whisper push** is delivered on the `UserPromptSubmit` hook. Agents marked *fallback*
+only install tool and stop hooks, so whispers arrive on the next tool call rather than
+the next prompt. Every agent can pull explicitly with `ox agent <id> whisper`.
+
+## Where each agent's sessions come from
+
+| Agent | Session store |
+|---|---|
+| Claude Code | `~/.claude/projects/<hash>/<uuid>.jsonl` |
+| Codex | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` |
+| Gemini | `~/.gemini/tmp/<hash>/session-*.json` |
+| Droid | `~/.factory/projects/<slug>/<uuid>.jsonl` |
+| OpenCode | `~/.local/share/opencode/opencode.db` (SQLite) |
+| Amp | `~/.cache/amp/ox-sessions/<thread>.jsonl` (written by the ox plugin) |
+| Pi | `~/.pi/agent/sessions/<dir>/*.jsonl` |
+| Aider | `.aider.chat.history.md` |
 
 ## Quick Start by Agent
 
@@ -43,42 +67,76 @@ ox init
 ox integrate install --gemini
 ```
 
-### Amp
+### Droid (Factory)
 ```bash
 ox init
-ox integrate install --amp
+ox adapter install droid
 ```
-Amp support is context-injection only (AGENTS.md marker). No native hooks yet.
-
-### Pi
-```bash
-ox init
-ox integrate install --pi
-```
-Pi reads AGENTS.md, CLAUDE.md, and SYSTEM.md natively. MCP server support available.
+Installs hooks into `.factory/settings.json` and team rules into `.factory/rules/`.
 
 ### OpenCode
 ```bash
 ox init
 ox integrate install --opencode
 ```
-OpenCode has 27+ plugin events but ox currently uses only `session.created`.
+Installs a TypeScript plugin that runs `ox agent prime` on `session.created`.
+OpenCode exposes 27+ plugin events; ox uses only that one today.
+
+### Amp
+```bash
+ox init
+ox integrate install --amp
+```
+Installs a user-scope plugin at `~/.config/amp/plugins/ox-bridge.ts` that records
+the session, and an `AGENTS.md` marker that primes it. Amp does not persist
+transcripts itself, so the plugin is what makes recording possible.
+
+### Pi
+```bash
+ox init
+ox integrate install --pi
+```
+Pi reads `AGENTS.md`, `CLAUDE.md`, and `SYSTEM.md` natively.
+
+### Aider
+```bash
+ox init
+ox adapter install aider
+```
+Aider loads `CONVENTIONS.md` via the `--read` flag in `.aider.conf.yml`, so the
+marker goes there rather than in `AGENTS.md`.
+
+### Goose
+```bash
+ox init
+```
+Goose loads `AGENTS.md` before `.goosehints`, hierarchically from the working
+directory up to the repo root, so `ox init` alone is enough to prime it. There is
+no Goose adapter yet, so sessions are not recorded — see below.
 
 ## Known Limitations
 
-- **Amp**: No native hook events for session lifecycle. Context works via AGENTS.md marker only.
-- **OpenCode**: Sessions stored in SQLite, not files. Real-time tail watching requires SQLite adapter (not yet implemented).
-- **Pi**: Extension-based architecture, not shell hooks. MCP works but hook lifecycle events aren't available.
+- **Goose**: no adapter, so no session recording. Goose does have a full hooks
+  system (`SessionStart`, `SessionEnd`, `Stop`, `UserPromptSubmit`, tool events)
+  and a SQLite session store, so an adapter is tractable. It has **no compaction
+  event**, which means team context primed at session start is lost when Goose
+  compacts — a limitation ox cannot work around.
+- **Gemini, Droid**: no `SessionStart` hook, so priming depends on the instruction
+  file marker rather than firing automatically.
+- **Codex**: no `SessionEnd` hook, so sessions do not auto-finalize; they close on
+  the next `ox agent <id> session stop` or daemon sweep.
+- **Pi, Aider**: instruction-file marker only. No lifecycle hooks.
+- **Cursor, Windsurf, Cline, Copilot, Kiro**: marker only. ox writes the prime
+  marker into `.cursorrules`, `.windsurfrules`, `.clinerules`,
+  `.github/copilot-instructions.md`, and `.kiro/steering/ox.md` respectively.
 
 ## Version Requirements
 
-All agents should be at their latest version for best compatibility. Run `ox doctor` to check for version issues.
+All agents should be at their latest version for best compatibility. Run `ox doctor`
+to check for version issues.
 
 ## Detailed Matrix
 
-For test-level compatibility data including version history, generate the full matrix:
-
-```bash
-make compat-matrix   # produces docs/compatibility.html
-open docs/compatibility.html
-```
+Per-capability data, including which surfaces resolve on which agent, lives in
+[docs/specs/agent-support-matrix.md](../specs/agent-support-matrix.md). Test-level
+compatibility runs live in the private `sageox/ox-test-harness` repo.

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/sageox/agentx v0.1.11
+	github.com/sageox/agentx v0.1.12
 	github.com/sageox/frictionax v0.1.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sageox/agentx v0.1.11 h1:GBmdWTUZGmGcuOlVn6sO08pFXgR8zHI3dDA23YgSurY=
-github.com/sageox/agentx v0.1.11/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
+github.com/sageox/agentx v0.1.12 h1:CP1E/BPpKYE+UEGiCdtKEBqhLfwCqluz3PH/ZDykGKU=
+github.com/sageox/agentx v0.1.12/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
 github.com/sageox/frictionax v0.1.2 h1:iQfssC1g/vVdGXi55smMfY5/4JKcQbJXRzcwrQWiNLo=
 github.com/sageox/frictionax v0.1.2/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=


### PR DESCRIPTION
## What broke

The README's "Works with your coding agent" table advertised aspiration and hid shipped work.

- It claimed **Cursor records sessions ✅**. There is no Cursor adapter — Cursor gets an instruction-file marker and nothing else.
- It omitted **Gemini, Amp, OpenCode, Droid, Pi, and Aider** entirely — six adapters that build from `Makefile:34` and ship in every release tarball.

The same drift ran downstream. `cmd/ox/init.go` writes a `.sageox/README.md` into **every customer repo** advertising `.cursorrules` and `.windsurfrules` "integrations" we don't have. `docs/guides/agent-compatibility.md` said OpenCode has no SQLite session adapter — it has had one for months — and pointed at a `make compat-matrix` target that doesn't exist.

## The Goose finding

While auditing the agent list, `agentx`'s model of Goose turned out to be stale in every field. Verified against a live Goose install and the upstream repo:

| Surface | What we believed | Reality |
|---|---|---|
| Hooks | `Hooks: false` — "CLI-based" | Full lifecycle hooks since v1.38 (Open Plugins spec) |
| Context files | `.goose/config.yaml`, `.goosehints` | **`AGENTS.md` first**, then `.goosehints`, hierarchically to repo root |
| Sessions | `SupportsSession() == false` | `session_id` on every hook payload; SQLite store |

The context-file finding is the useful one: **Goose already reads the file ox already marks.** Priming Goose costs one registry entry, not an adapter.

Fixed upstream in [sageox/agentx#13](https://github.com/sageox/agentx/pull/13), released as [v0.1.12](https://github.com/sageox/agentx/releases/tag/v0.1.12), bumped here.

## What this PR ships

- **`README.md`** — table rewritten to ship-reality: one row per bundled adapter, plus a marker-only row. The always-✅ "Query past work" column is gone (a column where every cell is identical carries no information), replaced by a line noting `ox query` / `ox murmur` / `ox status` work from any agent on `PATH`. New **"What fires it"** column distinguishes hooks from plugins from instruction-file markers.
- **Orchestrators section** — ox has detected [Block Buzz](https://github.com/block/buzz), Conductor, Gas City, and OpenClaw for a while, and emits a Buzz-specific prime directive, but the README never said so. Now linked and explained.
- **Goose prime** — `cmd/ox/instruction_files.go` registers Goose against `AGENTS.md`, sharing the file with Codex/OpenCode/Amp/Aider. `DetectFn` is deliberately `nil`: Goose creates no marker file of its own, so gating on detection would suppress the marker in every repo.
- **`cmd/ox/init.go`** — customer-repo template regrouped by *how* integration happens, and no longer claims integrations that don't exist. `.sageox/README.md` (the checked-in copy) updated to match.
- **`docs/guides/agent-compatibility.md`** — rewritten against the code. Adds Droid, Aider, and Goose; adds a session-store table; replaces the dead `make compat-matrix` pointer. New rows for **auto-prime** and **whisper push**, which is where the real per-agent difference lives.
- **`cmd/ox/integrate.go`** — `--pi` was a live flag missing from help.
- **`cmd/ox/guides/*.md`** — four prose agent lists refreshed; `agents-md.md` no longer files Aider under `AGENTS.md` (ox marks its `CONVENTIONS.md`).

## The honest cells

Two rows in the compatibility guide are new because they're where agents actually differ:

```mermaid
flowchart LR
    START["Session starts"] --> HOOK{"Hook or plugin<br/>installed"}
    HOOK -->|"yes"| AUTO["ox agent prime runs<br/>Claude Code, Codex, OpenCode"]
    HOOK -->|"no"| MARK["Agent must obey the<br/>instruction-file marker"]
    MARK --> REST["Gemini, Droid, Amp, Pi, Aider, Goose"]
```

Gemini and Droid install only tool and stop hooks — no `SessionStart` — so they prime off the marker, not the hook. Codex installs no `SessionEnd`, so its sessions don't auto-finalize. Those are now stated rather than averaged into a ✅.

## Repo topics

Added `buzz`. GitHub caps topics at 20, so this traded the generic `cli` (already covered by `developer-tools` and `coding-agent`). `goose`, `opencode`, and `amp` are still missing and need two more slots — say the word on which to trade.

## Test Plan

- `make lint` — **0 issues**
- `make test` — **17109 tests pass, 1086 skipped, 0 failures**
- New `TestInstructionFileRegistry_GooseSharesAgentsMd` pins the Goose target file, marker format, and the `DetectFn: nil` decision with the reasoning inline
- `ox docs --output docs/reference` regenerated — no diff (`ox integrate` has no generated `.mdx` today)

## Follow-ups filed

Auditing the fleet surfaced four things worth fixing before a seventh adapter lands:

| Issue | |
|---|---|
| `ox-8arr` | **P1 bug** — `ox-adapter-opencode` declares `CapIncrementalReader` but never wires `ReadFromOffset` into `adapterruntime.Config`. Hook-driven OpenCode recording silently captures nothing past prime. One-line fix. |
| `ox-h064` | The adapter compliance suite has no `TestXxx` entry point — it has never executed. `docs/guides/adapter-authoring.md` points at a package path and API that don't exist, so an adapter written by following it won't compile. |
| `ox-vhyn` | `scripts/install.sh` ships 5 of 8 adapters; `upgrade.go` and `registry.yaml` each miss `droid`. |
| `ox-osm5` | `gemini`, `pi`, and `aider` each ship a complete `rules.go` that is never registered — dead code that reads as a feature. |

`ox-wldv` tracks the Goose adapter itself (session reader + plugin-directory hook installer), with the verified SQLite schema, hook events, and payload shape captured so it doesn't need re-research. That work is in progress on a follow-up branch.

Co-Authored-By: [SageOx](https://github.com/SageOx)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Goose support, including shared instruction-file integration.
  * Expanded AI coworker integrations across Claude Code, Codex, Gemini, Droid, OpenCode, Amp, Pi, Aider, and Goose.
  * Added integration guidance for orchestrators such as Block Buzz, Conductor, Gas City, and OpenClaw.
  * Improved integration details for session recording, context priming, triggering, and installation.

* **Documentation**
  * Expanded compatibility matrices, setup guidance, command help, and instruction-file documentation.
  * Clarified lifecycle, recovery, session storage, and limitations for supported AI coworkers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->