### PR TITLE
fix(init): stop polluting root .gitignore; stage what init writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,5 +119,4 @@ issues.jsonl
 
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
-.sageox/kb/
 security/.output/

--- a/.sageox/.gitignore
+++ b/.sageox/.gitignore
@@ -22,5 +22,6 @@ config.local.toml
 !offline/
 
 # SageOx required entries
+kb/
 ledger
 teams/

--- a/cmd/ox-adapter-claude-code/rules.go
+++ b/cmd/ox-adapter-claude-code/rules.go
@@ -60,9 +60,13 @@ func handleInstallRules(p adapterprotocol.RulesParams) (*adapterprotocol.Install
 		return nil, err
 	}
 
+	// agentx returns names relative to the rules dir (ox.md,
+	// sageox/use-team-context.md). The FilesWritten contract is
+	// repo-relative — see GH #731, where handing ox `ox.md` made it stage
+	// nothing at all.
 	return &adapterprotocol.InstallRulesResponse{
 		Installed:    true,
-		FilesWritten: written,
+		FilesWritten: adapterprotocol.RepoRelativePaths(p.RepoRoot, rulesDir, written),
 	}, nil
 }
 

--- a/cmd/ox-adapter-claude-code/rules_test.go
+++ b/cmd/ox-adapter-claude-code/rules_test.go
@@ -25,7 +25,8 @@ func TestHandleInstallRules_CreatesFile(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, resp.Installed)
-	assert.Contains(t, resp.FilesWritten, "ox.md")
+	// repo-relative per the adapterprotocol FilesWritten contract — see GH #731.
+	assert.Contains(t, resp.FilesWritten, filepath.Join(".claude", "rules", "ox.md"))
 
 	ruleFile := filepath.Join(dir, ".claude", "rules", "ox.md")
 	data, err := os.ReadFile(ruleFile)
@@ -238,18 +239,22 @@ func TestHandleInstallRules_InstallsNamespacedRules(t *testing.T) {
 	_, err = os.Stat(top)
 	require.NoError(t, err, ".claude/rules/ox.md should still be installed at top level")
 
-	// FilesWritten should reference both
-	var sawTop, sawNS bool
-	for _, name := range resp.FilesWritten {
-		if name == "ox.md" {
-			sawTop = true
-		}
-		if name == "sageox/use-team-context.md" {
-			sawNS = true
-		}
+	// FilesWritten must reference both, REPO-relative — not relative to the
+	// rules dir. agentx returns rules-dir-relative names; reporting those
+	// verbatim made ox resolve `ox.md` to <root>/ox.md, which does not
+	// exist, and one bad pathspec failed the whole `git add` so nothing at
+	// all was staged (GH #731).
+	assert.Contains(t, resp.FilesWritten, filepath.Join(".claude", "rules", "ox.md"),
+		"got %v", resp.FilesWritten)
+	assert.Contains(t, resp.FilesWritten, filepath.Join(".claude", "rules", "sageox", "use-team-context.md"),
+		"got %v", resp.FilesWritten)
+
+	// and every entry must actually resolve inside the repo, or ox drops it.
+	for _, rel := range resp.FilesWritten {
+		assert.False(t, filepath.IsAbs(rel), "%s should be repo-relative", rel)
+		_, statErr := os.Stat(filepath.Join(dir, rel))
+		assert.NoError(t, statErr, "%s must resolve to a real file under RepoRoot", rel)
 	}
-	assert.True(t, sawTop, "FilesWritten should include ox.md, got %v", resp.FilesWritten)
-	assert.True(t, sawNS, "FilesWritten should include sageox/use-team-context.md, got %v", resp.FilesWritten)
 }
 
 // TestHandleCheckRules_NamespacedRulesMissing verifies that check reports

--- a/cmd/ox-adapter-claude-code/skills.go
+++ b/cmd/ox-adapter-claude-code/skills.go
@@ -196,8 +196,12 @@ func handleInstallSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.Insta
 		if err := os.WriteFile(dstPath, stamped, 0o644); err != nil {
 			return nil, fmt.Errorf("write skill file %s: %w", sk.Name, err)
 		}
-		// report the SKILL.md path relative to the skills dir (e.g. ox-plan/SKILL.md).
-		written = append(written, filepath.Join(sk.Name, skillFileName))
+		// report repo-relative (e.g. .claude/skills/ox-plan/SKILL.md) per the
+		// FilesWritten contract. Reporting it relative to the skills dir —
+		// as this did until GH #731 — made ox resolve it to <root>/ox-plan/
+		// SKILL.md, which does not exist, and one bad pathspec fails the
+		// whole `git add`, so nothing at all got staged.
+		written = append(written, dstPath)
 	}
 
 	// Command→skill migration cleanup: when a surface moves from a slash command
@@ -210,7 +214,7 @@ func handleInstallSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.Insta
 
 	return &adapterprotocol.InstallSkillsResponse{
 		Installed:    true,
-		FilesWritten: written,
+		FilesWritten: adapterprotocol.RepoRelativePaths(p.RepoRoot, dir, written),
 	}, nil
 }
 

--- a/cmd/ox-adapter-claude-code/skills_test.go
+++ b/cmd/ox-adapter-claude-code/skills_test.go
@@ -41,8 +41,8 @@ func TestHandleInstallSkills_StampPlacement(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, resp.Installed)
-	assert.Contains(t, resp.FilesWritten, filepath.Join(name, skillFileName),
-		"FilesWritten must reference <name>/SKILL.md")
+	assert.Contains(t, resp.FilesWritten, filepath.Join(".claude", "skills", name, skillFileName),
+		"FilesWritten must be repo-relative per the adapterprotocol contract")
 
 	data, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", name, skillFileName))
 	require.NoError(t, err, "SKILL.md must exist on disk after install")
@@ -218,7 +218,7 @@ func TestHandleCheckSkills_FrontmatterEdited_ReportsStale(t *testing.T) {
 	// reinstall (the --fix path) must rewrite the file and clear staleness.
 	resp, err := handleInstallSkills(params)
 	require.NoError(t, err)
-	assert.Contains(t, resp.FilesWritten, filepath.Join(name, skillFileName),
+	assert.Contains(t, resp.FilesWritten, filepath.Join(".claude", "skills", name, skillFileName),
 		"--fix must rewrite a skill whose frontmatter was edited")
 
 	fixed, err := handleCheckSkills(params)

--- a/cmd/ox-adapter-droid/rules.go
+++ b/cmd/ox-adapter-droid/rules.go
@@ -45,9 +45,11 @@ func handleInstallRules(p adapterprotocol.RulesParams) (*adapterprotocol.Install
 		return nil, err
 	}
 
+	// agentx returns names relative to the rules dir; the FilesWritten
+	// contract is repo-relative. See GH #731.
 	return &adapterprotocol.InstallRulesResponse{
 		Installed:    true,
-		FilesWritten: written,
+		FilesWritten: adapterprotocol.RepoRelativePaths(p.RepoRoot, rulesDir, written),
 	}, nil
 }
 

--- a/cmd/ox-adapter-droid/rules_test.go
+++ b/cmd/ox-adapter-droid/rules_test.go
@@ -25,7 +25,8 @@ func TestHandleInstallRules_CreatesFile(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, resp.Installed)
-	assert.Contains(t, resp.FilesWritten, "ox.md")
+	// repo-relative per the adapterprotocol FilesWritten contract — see GH #731.
+	assert.Contains(t, resp.FilesWritten, filepath.Join(".factory", "rules", "ox.md"))
 
 	ruleFile := filepath.Join(dir, ".factory", "rules", "ox.md")
 	data, err := os.ReadFile(ruleFile)

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -827,6 +827,7 @@ func runDoctorChecks(parent context.Context, opts doctorOptions) []checkCategory
 		checkGitStatus(),
 		checkSageoxFilesTracked(opts.shouldFix(CheckSlugGitignore)),
 		convertDoctorResult(gitignoreCheck.Run(ctx, opts.shouldFix(CheckSlugGitignore))),
+		checkRootKBGitignoreLine(opts.shouldFix(CheckSlugRootKBGitignore)),
 		checkGitattributes(opts.shouldFix(CheckSlugGitattributes)),
 	}
 	// only show sageox remote check if .sageox is its own git repo

--- a/cmd/ox/doctor_check_registry.go
+++ b/cmd/ox/doctor_check_registry.go
@@ -117,6 +117,15 @@ func init() {
 	})
 
 	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugRootKBGitignore,
+		Name:        rootKBGitignoreCheckName,
+		Category:    "Git Status",
+		FixLevel:    FixLevelSuggested,
+		Description: "Removes the legacy .sageox/kb/ entry from the project's root .gitignore (GH #732)",
+		Run:         checkRootKBGitignoreLine,
+	})
+
+	RegisterDoctorCheck(&DoctorCheck{
 		Slug:        CheckSlugGitattributes,
 		Name:        ".gitattributes",
 		Category:    "Git Status",

--- a/cmd/ox/doctor_git.go
+++ b/cmd/ox/doctor_git.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sageox/ox/internal/repotools"
+	"github.com/sageox/ox/internal/sageoxignore"
 )
 
 // sageoxCommittableFiles lists the files in .sageox/ that should be tracked in VCS.
@@ -333,5 +334,107 @@ func checkGitignore(fix bool) checkResult {
 		name:    ".gitignore",
 		passed:  true,
 		message: "not ignored",
+	}
+}
+
+// rootKBGitignoreCheckName is shared between the check and its registry
+// entry — enrichWithFixMetadata matches checks by name, so the two must
+// not drift.
+const rootKBGitignoreCheckName = ".gitignore (kb rule)"
+
+// checkRootKBGitignoreLine removes the legacy `.sageox/kb/` entry from
+// the project's root .gitignore (GH #732).
+//
+// ox used to write that rule into the file at the top of the developer's
+// repo. It now lives in .sageox/.gitignore as `kb/`, which ox owns and
+// commits. This check cleans up installs created before the move.
+//
+// # Why this is safe to remove
+//
+// Removal is gated on the replacement being verifiably present. Patterns
+// in a nested .gitignore are relative to that file's directory, so `kb/`
+// in .sageox/.gitignore ignores exactly what `.sageox/kb/` ignored from
+// the root. Under the gate, deleting the root line cannot cause a single
+// previously ignored path to become tracked — the user's intent is fully
+// preserved, whether ox wrote the line or they did. Matching is exact, so
+// `.sageox/`, `.sageox/kb` (no slash), `/.sageox/kb/`, `!.sageox/kb/` and
+// a commented `# .sageox/kb/` are all left alone.
+//
+// Registered at FixLevelSuggested, not FixLevelAuto: editing a file the
+// developer owns without being asked is the exact complaint that opened
+// #732, and this fix should not re-commit the sin to clean up after it.
+// `ox init` does remove it, because that is a foreground command the user
+// invoked and which is already writing to their repo.
+func checkRootKBGitignoreLine(fix bool) checkResult {
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return checkResult{
+			name:    rootKBGitignoreCheckName,
+			skipped: true,
+			message: "not in git repo",
+		}
+	}
+
+	gitignorePath := filepath.Join(gitRoot, ".gitignore")
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		// no root .gitignore at all — nothing ox could have polluted.
+		return checkResult{
+			name:    rootKBGitignoreCheckName,
+			passed:  true,
+			message: "clean",
+		}
+	}
+
+	if !sageoxignore.HasEntry(string(content), sageoxignore.LegacyRootKBLine) {
+		return checkResult{
+			name:    rootKBGitignoreCheckName,
+			passed:  true,
+			message: "clean",
+		}
+	}
+
+	// safety gate. checkSageoxGitignore is FixLevelAuto and runs in the
+	// Project Structure category, i.e. before this one, so on a repo
+	// missing the rule it gets added and the next doctor run cleans up.
+	if !sageoxGitignoreHasKBRule(gitRoot) {
+		return checkResult{
+			name:    rootKBGitignoreCheckName,
+			skipped: true,
+			message: "waiting on .sageox/.gitignore",
+			detail:  "Run `ox doctor` again once .sageox/.gitignore carries the kb/ rule",
+		}
+	}
+
+	if !fix {
+		return checkResult{
+			name:    rootKBGitignoreCheckName,
+			warning: true,
+			message: "stale `.sageox/kb/` in root .gitignore",
+			detail:  "Superseded by kb/ in .sageox/.gitignore — run `ox doctor --fix` to remove it",
+		}
+	}
+
+	removed, err := sageoxignore.RemoveLine(gitignorePath, sageoxignore.LegacyRootKBLine)
+	if err != nil {
+		return checkResult{
+			name:    rootKBGitignoreCheckName,
+			passed:  false,
+			message: "fix failed",
+			detail:  err.Error(),
+		}
+	}
+	if !removed {
+		return checkResult{
+			name:    rootKBGitignoreCheckName,
+			passed:  true,
+			message: "clean",
+		}
+	}
+	return checkResult{
+		name:    rootKBGitignoreCheckName,
+		passed:  true,
+		message: "removed stale `.sageox/kb/`",
+		detail:  "The rule now lives in .sageox/.gitignore — commit both files",
 	}
 }

--- a/cmd/ox/doctor_root_kb_gitignore_test.go
+++ b/cmd/ox/doctor_root_kb_gitignore_test.go
@@ -1,0 +1,185 @@
+//go:build !short
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/sageoxignore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// kbCleanupRepo builds a git repo whose root .gitignore holds rootContent
+// and whose .sageox/.gitignore holds sageoxContent, then chdirs into it so
+// the CWD-based findGitRoot() resolves there. Either content may be "" to
+// mean "this file does not exist".
+func kbCleanupRepo(t *testing.T, rootContent, sageoxContent string) string {
+	t.Helper()
+	repo := testGitRepo(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".sageox"), 0o755))
+
+	if rootContent != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitignore"), []byte(rootContent), 0o644))
+	}
+	if sageoxContent != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(repo, ".sageox", ".gitignore"), []byte(sageoxContent), 0o644))
+	}
+	t.Chdir(repo)
+	return repo
+}
+
+func readRootGitignore(t *testing.T, repo string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(repo, ".gitignore"))
+	require.NoError(t, err)
+	return string(body)
+}
+
+// TestCheckRootKBGitignore_RemovesStaleLine is the GH #732 cleanup for
+// installs created before the rule moved into .sageox/.gitignore.
+func TestCheckRootKBGitignore_RemovesStaleLine(t *testing.T) {
+	repo := kbCleanupRepo(t,
+		"node_modules/\n.sageox/kb/\ndist/\n",
+		"cache/\nkb/\n",
+	)
+
+	result := checkRootKBGitignoreLine(true)
+
+	assert.True(t, result.passed, "message=%q detail=%q", result.message, result.detail)
+	assert.Equal(t, "node_modules/\ndist/\n", readRootGitignore(t, repo),
+		"only the ox-written line goes; the developer's rules and ordering stay")
+}
+
+// TestCheckRootKBGitignore_WarnsWithoutFix pins the FixLevelSuggested
+// behavior: a bare `ox doctor` reports the pollution but must not edit a
+// file the developer owns. Silently editing their .gitignore is the exact
+// complaint that opened #732 — the cleanup must not repeat it.
+func TestCheckRootKBGitignore_WarnsWithoutFix(t *testing.T) {
+	original := "node_modules/\n.sageox/kb/\ndist/\n"
+	repo := kbCleanupRepo(t, original, "cache/\nkb/\n")
+
+	result := checkRootKBGitignoreLine(false)
+
+	assert.True(t, result.warning, "should surface as a warning, not a hard failure")
+	assert.False(t, result.passed)
+	assert.Equal(t, original, readRootGitignore(t, repo),
+		"a non-fix run must leave the file byte-identical")
+}
+
+// TestCheckRootKBGitignore_SkipsWhenReplacementMissing is the safety gate.
+// Removing the root line before `kb/` exists in .sageox/.gitignore would
+// leave the symlink directory genuinely untracked-but-not-ignored, so the
+// check must decline rather than guess.
+func TestCheckRootKBGitignore_SkipsWhenReplacementMissing(t *testing.T) {
+	original := "node_modules/\n.sageox/kb/\n"
+
+	for _, tc := range []struct {
+		name          string
+		sageoxContent string
+	}{
+		{"no .sageox/.gitignore at all", ""},
+		{"present but lacking kb/", "cache/\nlogs/\n"},
+		{"kb/ only as a comment", "cache/\n# kb/\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := kbCleanupRepo(t, original, tc.sageoxContent)
+
+			result := checkRootKBGitignoreLine(true)
+
+			assert.True(t, result.skipped, "must decline: %q", result.message)
+			assert.Equal(t, original, readRootGitignore(t, repo),
+				"the root .gitignore must be untouched until the replacement is verified")
+		})
+	}
+}
+
+// TestCheckRootKBGitignore_PassesOnCleanRepo covers the overwhelmingly
+// common case — a repo that never had the line, or never had a root
+// .gitignore. Neither should produce noise in doctor output.
+func TestCheckRootKBGitignore_PassesOnCleanRepo(t *testing.T) {
+	t.Run("root .gitignore without the line", func(t *testing.T) {
+		kbCleanupRepo(t, "node_modules/\ndist/\n", "cache/\nkb/\n")
+		result := checkRootKBGitignoreLine(true)
+		assert.True(t, result.passed)
+		assert.Equal(t, "clean", result.message)
+	})
+
+	t.Run("no root .gitignore at all", func(t *testing.T) {
+		repo := kbCleanupRepo(t, "", "cache/\nkb/\n")
+		result := checkRootKBGitignoreLine(true)
+		assert.True(t, result.passed)
+
+		_, err := os.Stat(filepath.Join(repo, ".gitignore"))
+		assert.True(t, os.IsNotExist(err), "must not create a .gitignore just to clean it")
+	})
+}
+
+// TestCheckRootKBGitignore_IsIdempotent guards against doctor dirtying the
+// worktree on every run.
+func TestCheckRootKBGitignore_IsIdempotent(t *testing.T) {
+	repo := kbCleanupRepo(t, "node_modules/\n.sageox/kb/\n", "cache/\nkb/\n")
+
+	require.True(t, checkRootKBGitignoreLine(true).passed)
+	first := readRootGitignore(t, repo)
+
+	result := checkRootKBGitignoreLine(true)
+	assert.True(t, result.passed)
+	assert.Equal(t, "clean", result.message)
+	assert.Equal(t, first, readRootGitignore(t, repo), "second run must be a true no-op")
+}
+
+// TestCheckRootKBGitignore_LeavesNeighboringSageoxRulesAlone restates the
+// exact-match safety property at the doctor level: a user who ignores the
+// whole .sageox directory, or who wrote a variant pattern, keeps it.
+func TestCheckRootKBGitignore_LeavesNeighboringSageoxRulesAlone(t *testing.T) {
+	original := ".sageox/\n.sageox/kb\n/.sageox/kb/\n!.sageox/kb/\n.sageox/kb/*\n"
+	repo := kbCleanupRepo(t, original, "cache/\nkb/\n")
+
+	result := checkRootKBGitignoreLine(true)
+
+	assert.True(t, result.passed)
+	assert.Equal(t, "clean", result.message, "none of these are the line we wrote")
+	assert.Equal(t, original, readRootGitignore(t, repo))
+}
+
+// TestSageoxGitignoreHasKBRule covers the gate helper directly, including
+// the comment case that must not count as the rule being present.
+func TestSageoxGitignoreHasKBRule(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"present", "cache/\nkb/\nlogs/\n", true},
+		{"absent", "cache/\nlogs/\n", false},
+		{"commented", "cache/\n# kb/\n", false},
+		{"negated", "cache/\n!kb/\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(repo, ".sageox"), 0o755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(repo, ".sageox", ".gitignore"), []byte(tc.content), 0o644))
+
+			assert.Equal(t, tc.want, sageoxGitignoreHasKBRule(repo))
+		})
+	}
+
+	t.Run("missing file", func(t *testing.T) {
+		assert.False(t, sageoxGitignoreHasKBRule(t.TempDir()),
+			"an unverifiable replacement must never authorize the cleanup")
+	})
+}
+
+// TestSageoxGitignoreContentCarriesKBRule ties the shipped template to the
+// gate: if kb/ ever drops out of sageoxGitignoreContent, the cleanup would
+// silently stop running rather than fail loudly.
+func TestSageoxGitignoreContentCarriesKBRule(t *testing.T) {
+	assert.True(t, sageoxignore.HasEntry(sageoxGitignoreContent, sageoxignore.KBEntry),
+		"the .sageox/.gitignore template must ship the kb/ rule")
+	assert.Contains(t, requiredGitignoreEntries, sageoxignore.KBEntry,
+		"kb/ must be a required entry so existing installs self-heal via mergeGitignoreEntries")
+}

--- a/cmd/ox/doctor_sageox.go
+++ b/cmd/ox/doctor_sageox.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 	"github.com/sageox/ox/internal/repotools"
+	"github.com/sageox/ox/internal/sageoxignore"
 	"github.com/sageox/ox/internal/ui"
 )
 
@@ -39,6 +40,10 @@ agent_tasks/
 config.local.toml
 
 # Ignore local symlinks to user-directory data
+# kb/ holds daemon-materialized knowledge-bubble symlinks (GH #732 moved
+# this rule here from the project's root .gitignore — derived state, and
+# not ox's business to declare in a file the developer owns).
+kb/
 ledger
 teams/
 
@@ -60,6 +65,7 @@ var requiredGitignoreEntries = []string{
 	"agent_instances/",
 	"agent_tasks/",
 	"config.local.toml",
+	sageoxignore.KBEntry,
 	"ledger",
 	"teams/",
 	"!README.md",

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -84,6 +84,7 @@ const (
 	CheckSlugInitReverted    = "init-reverted"
 	CheckSlugClaudeHooksFmt  = "claude-hooks-format"
 	CheckSlugGitignore       = "gitignore"
+	CheckSlugRootKBGitignore = "root-kb-gitignore"
 	CheckSlugGitattributes   = "gitattributes"
 	CheckSlugSageoxGitignore = "sageox-gitignore"
 	CheckSlugReadme          = "readme"

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -2084,11 +2084,31 @@ func normalizeAdapterFilesWritten(gitRoot string, raw []string) []string {
 			slog.Debug("init: dropping adapter file outside repo", "entry", entry, "resolved", candidate)
 			continue
 		}
+		// Reject the repo root itself. An adapter reporting "." (or gitRoot
+		// absolute) passes both containment and Lstat, and `git add --force --
+		// <root>` stages the ENTIRE worktree — sweeping in every unrelated
+		// change the user had in progress. That is the exact outcome init's
+		// own next-steps note warns against, so it must never come from a
+		// third-party adapter's return value.
+		if rel == "." {
+			slog.Debug("init: dropping adapter entry resolving to the repo root", "entry", entry)
+			continue
+		}
 
 		// Lstat, not Stat: some installed assets are symlinks, and a
 		// broken symlink is still a real thing git can stage.
-		if _, err := os.Lstat(candidate); err != nil {
+		info, err := os.Lstat(candidate)
+		if err != nil {
 			slog.Debug("init: dropping adapter file that does not exist", "entry", entry, "resolved", candidate)
+			continue
+		}
+		// FilesWritten means files. Staging a directory pathspec pulls in
+		// everything beneath it, including files ox never wrote — same
+		// over-staging hazard as the repo-root case above, just narrower.
+		// Lstat reports a symlink as ModeSymlink rather than ModeDir, so
+		// symlinked assets still pass.
+		if info.IsDir() {
+			slog.Debug("init: dropping adapter entry that is a directory", "entry", entry, "resolved", candidate)
 			continue
 		}
 

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -699,6 +701,13 @@ func runInit() error {
 			// were already snapshotted for rollback above
 			if r.Status == injectedNew {
 				tracker.trackCreatedFile(filepath.Join(gitRoot, r.File))
+			}
+			// Stage ONLY the instruction files ox actually wrote to. Staging
+			// every *detected* file would sweep in a user's own uncommitted
+			// edits to e.g. GEMINI.md that ox never touched — the same
+			// over-staging hazard as accepting a repo-root pathspec.
+			if r.Status == injectedNew || r.Status == injectedUpgrade {
+				tracker.trackForceStage(filepath.Join(gitRoot, r.File))
 			}
 		}
 	}
@@ -1708,30 +1717,14 @@ func (t *initTracker) stageAll() {
 		cli.PrintWarning(fmt.Sprintf("Could not stage .sageox files: %v", err))
 	}
 
-	// Stage every instruction file ox may have written a marker into —
-	// not just AGENTS.md/CLAUDE.md. EnsureInstructionFileMarkers also
-	// touches GEMINI.md, .cursorrules, .windsurfrules,
-	// .github/copilot-instructions.md, .kiro/steering/ox.md and .clinerules
-	// (see InstructionFileRegistry), and until GH #731 a Gemini or Cursor
-	// user's ox-modified file was never staged at all.
-	var agentFiles []string
-	seen := make(map[string]bool)
-	for _, target := range DetectedInstructionFiles(t.gitRoot) {
-		abs := filepath.Join(t.gitRoot, target.Path)
-		if seen[abs] {
-			continue
-		}
-		if _, err := os.Lstat(abs); err != nil {
-			continue
-		}
-		seen[abs] = true
-		agentFiles = append(agentFiles, abs)
-	}
-	if len(agentFiles) > 0 {
-		if err := gitAddFiles(t.gitRoot, agentFiles); err != nil {
-			cli.PrintWarning(fmt.Sprintf("Could not stage agent instruction files: %v", err))
-		}
-	}
+	// Instruction files (AGENTS.md, CLAUDE.md, GEMINI.md, .cursorrules,
+	// .windsurfrules, .github/copilot-instructions.md, .kiro/steering/ox.md,
+	// .clinerules) are staged from t.forceStage, registered at the injection
+	// site for exactly the files ox wrote a marker into.
+	//
+	// Deliberately NOT staged by detection: a file merely being *present*
+	// says nothing about whether ox changed it, and staging it would sweep
+	// a user's own uncommitted edits into the init commit.
 
 	// stage .gitattributes if it exists
 	gitattrsPath := filepath.Join(t.gitRoot, ".gitattributes")
@@ -1806,6 +1799,56 @@ func (t *initTracker) rollback(quiet bool) {
 			}
 		} else if !quiet {
 			cli.PrintWarning(fmt.Sprintf("Directory %s/ not empty, skipping removal", filepath.Base(dir)))
+		}
+	}
+
+	t.unstageAll(quiet)
+}
+
+// unstageAll removes everything stageAll put in the index.
+//
+// Restoring a file's CONTENT is not enough: stageAll runs before API
+// registration, so on a registration failure the index still holds the
+// staged versions. For a pre-existing file that ox modified — the root
+// .gitignore cleanup being the sharp case — rollback would rewrite the
+// file on disk while leaving ox's edit staged, so the user's very next
+// `git commit` silently includes a change they were just told was rolled
+// back.
+//
+// Reset each path back to HEAD's version. Paths absent from HEAD (files
+// ox created, now deleted) are dropped from the index instead, since
+// `git reset HEAD -- <path>` on an unknown path is an error rather than
+// a no-op on some git versions.
+func (t *initTracker) unstageAll(quiet bool) {
+	if !isGitRepo(t.gitRoot) {
+		return
+	}
+
+	var paths []string
+	seen := make(map[string]bool)
+	for _, p := range slices.Concat(t.createdFiles, t.forceStage, slices.Collect(maps.Keys(t.modifiedFiles))) {
+		rel, err := filepath.Rel(t.gitRoot, p)
+		if err != nil || seen[rel] {
+			continue
+		}
+		seen[rel] = true
+		paths = append(paths, rel)
+	}
+	if len(paths) == 0 {
+		return
+	}
+
+	for _, rel := range paths {
+		cmd := exec.Command("git", "reset", "-q", "HEAD", "--", rel)
+		cmd.Dir = t.gitRoot
+		if err := cmd.Run(); err == nil {
+			continue
+		}
+		// not in HEAD (a file ox created): drop it from the index entirely.
+		rm := exec.Command("git", "rm", "-q", "--cached", "--ignore-unmatch", "--", rel)
+		rm.Dir = t.gitRoot
+		if err := rm.Run(); err != nil && !quiet {
+			cli.PrintWarning(fmt.Sprintf("Could not unstage %s: %v", rel, err))
 		}
 	}
 }

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/identity"
 	"github.com/sageox/ox/internal/repotools"
+	"github.com/sageox/ox/internal/sageoxignore"
 	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/sageox/ox/internal/tips"
 	"github.com/sageox/ox/internal/ui"
@@ -587,22 +588,32 @@ func runInit() error {
 		}
 	}
 
-	// ensure the project's *root* .gitignore excludes .sageox/kb/.
-	// This is where the daemon materializes per-project knowledge-bubble
-	// symlinks (one slug-keyed link per relevant kb pointing at
-	// paths.KBDir(kb_id)). Symlinks are derived state — never committed.
-	// Idempotent: only appends the line when missing, never modifies
-	// other entries. Track the file with the init rollback tracker so a
-	// later API failure undoes our gitignore mutation alongside the rest
-	// of the staged files.
+	// GH #732: ox used to append `.sageox/kb/` to the project's *root*
+	// .gitignore. That rule now lives in .sageox/.gitignore as `kb/`,
+	// written moments ago by the block above. Clean the stale line out of
+	// the file the developer owns.
+	//
+	// The removal is behavior-preserving by construction, which is the
+	// whole safety argument: it is gated on the replacement being
+	// verifiably present, and `kb/` in .sageox/.gitignore ignores exactly
+	// the paths `.sageox/kb/` ignored from the root. Not one previously
+	// ignored path becomes tracked. Only an exact match is removed, so
+	// hand-added entries and every other `.sageox/*` rule survive.
+	//
+	// Snapshot BEFORE the write: trackModifiedFile captures current
+	// content eagerly, so tracking afterwards would make rollback restore
+	// the polluted version rather than the original.
 	rootGitignore := filepath.Join(gitRoot, ".gitignore")
-	switch action, err := ensureProjectGitignoreKBLine(gitRoot); {
-	case err != nil:
-		cli.PrintWarning(fmt.Sprintf("Could not update project .gitignore: %v", err))
-	case action == kbGitignoreCreated:
-		tracker.trackCreatedFile(rootGitignore)
-	case action == kbGitignoreModified:
+	if sageoxGitignoreHasKBRule(gitRoot) {
 		tracker.trackModifiedFile(rootGitignore)
+		switch removed, err := sageoxignore.RemoveLine(rootGitignore, sageoxignore.LegacyRootKBLine); {
+		case err != nil:
+			cli.PrintWarning(fmt.Sprintf("Could not clean up project .gitignore: %v", err))
+		case removed:
+			// we modified a file the user very likely tracks — stage it
+			// so the cleanup actually lands in their commit.
+			tracker.trackForceStage(rootGitignore)
+		}
 	}
 
 	// add SageOx entries to .gitattributes
@@ -693,10 +704,15 @@ func runInit() error {
 	}
 
 	// detect and install agent hooks
+	// installAgentHooks returns absolute, existence-verified paths inside
+	// gitRoot — do NOT re-join against gitRoot here. Doing so was half of
+	// GH #731: adapters that already returned absolute paths became
+	// <root><root>/.codex/hooks.json, and one such entry failed the whole
+	// `git add`, leaving even .claude/settings.json unstaged.
 	installedHooks := installAgentHooks(gitRoot, true, selectedAgents) // quiet — summarized below
 	for _, hookFile := range installedHooks {
-		tracker.trackCreatedFile(filepath.Join(gitRoot, hookFile))
-		tracker.trackForceStage(filepath.Join(gitRoot, hookFile))
+		tracker.trackCreatedFile(hookFile)
+		tracker.trackForceStage(hookFile)
 	}
 
 	// commands and rules are installed by external adapters via CapCommandsInstaller/CapRulesInstaller
@@ -1195,74 +1211,20 @@ func createSageoxGitignore(path string) error {
 	return os.WriteFile(path, []byte(sageoxGitignoreContent), 0644)
 }
 
-// projectGitignoreKBLine is the single entry appended to the project's
-// root .gitignore so daemon-managed knowledge-bubble symlinks
-// (.sageox/kb/<slug>) never end up tracked. The daemon uses the same
-// constant in internal/daemon/sync_symlinks.go to repair existing
-// projects on first reconciliation.
-const projectGitignoreKBLine = ".sageox/kb/"
-
-// ensureProjectGitignoreKBLine appends `.sageox/kb/` to <gitRoot>/.gitignore
-// exactly once. Idempotent: re-reads the file each call and only appends
-// when the line is genuinely absent. Creates the file with just the entry
-// if it does not already exist.
-// kbGitignoreAction reports what ensureProjectGitignoreKBLine actually
-// did to the project's .gitignore so the init tracker can register the
-// path for rollback + staging in the same way other init-modified files
-// are handled.
-type kbGitignoreAction int
-
-const (
-	kbGitignoreUnchanged kbGitignoreAction = iota
-	kbGitignoreCreated
-	kbGitignoreModified
-)
-
-func ensureProjectGitignoreKBLine(gitRoot string) (kbGitignoreAction, error) {
-	gitignorePath := filepath.Join(gitRoot, ".gitignore")
-	existed := true
-	existing, err := os.ReadFile(gitignorePath)
+// sageoxGitignoreHasKBRule reports whether <gitRoot>/.sageox/.gitignore
+// carries the `kb/` rule.
+//
+// This is the safety gate for the GH #732 cleanup: the stale
+// `.sageox/kb/` line is only removed from the project's root .gitignore
+// once its replacement is verifiably in place, so the removal can never
+// cause a previously ignored path to start being tracked. Absent or
+// unreadable file means "not verified" — leave the root alone.
+func sageoxGitignoreHasKBRule(gitRoot string) bool {
+	data, err := os.ReadFile(filepath.Join(gitRoot, ".sageox", ".gitignore"))
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return kbGitignoreUnchanged, fmt.Errorf("read .gitignore: %w", err)
-		}
-		existed = false
-		existing = nil
+		return false
 	}
-	if hasGitignoreEntry(string(existing), projectGitignoreKBLine) {
-		return kbGitignoreUnchanged, nil
-	}
-	var out string
-	if len(existing) > 0 {
-		out = string(existing)
-		if !strings.HasSuffix(out, "\n") {
-			out += "\n"
-		}
-	}
-	out += projectGitignoreKBLine + "\n"
-	if err := os.WriteFile(gitignorePath, []byte(out), 0644); err != nil {
-		return kbGitignoreUnchanged, err
-	}
-	if existed {
-		return kbGitignoreModified, nil
-	}
-	return kbGitignoreCreated, nil
-}
-
-// hasGitignoreEntry reports whether `content` already has `entry` as a
-// non-comment, non-blank line. Comment-aware so a documentary
-// "# .sageox/kb/" line doesn't make us skip the real append.
-func hasGitignoreEntry(content, entry string) bool {
-	for _, raw := range strings.Split(content, "\n") {
-		trimmed := strings.TrimSpace(raw)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-		if trimmed == entry {
-			return true
-		}
-	}
-	return false
+	return sageoxignore.HasEntry(string(data), sageoxignore.KBEntry)
 }
 
 // GetSageoxReadmeContent returns the standard README content for .sageox/README.md.
@@ -1590,17 +1552,95 @@ func findGitRoot() string {
 	return strings.TrimSpace(string(output))
 }
 
-func gitAddFiles(files []string) error {
-	args := append([]string{"add"}, files...)
-	cmd := exec.Command("git", args...)
-	return cmd.Run()
+// gitAddChunkSize bounds how many pathspecs go into one `git add`. A full
+// install (settings + commands + skills + rules across several agents) can
+// run to a few hundred paths; chunking keeps us clear of ARG_MAX.
+const gitAddChunkSize = 100
+
+func gitAddFiles(gitRoot string, files []string) error {
+	return gitAdd(gitRoot, files, false)
 }
 
 // gitAddFilesForce stages files using --force to bypass .gitignore
-func gitAddFilesForce(files []string) error {
-	args := append([]string{"add", "--force"}, files...)
-	cmd := exec.Command("git", args...)
-	return cmd.Run()
+func gitAddFilesForce(gitRoot string, files []string) error {
+	return gitAdd(gitRoot, files, true)
+}
+
+// gitAdd stages files, degrading to per-file staging when a batch fails.
+//
+// # Why this is not just `git add <all>`
+//
+// git validates every pathspec before staging any of them, and exits
+// non-zero on the first one that matches nothing. The old implementation
+// ran a single batched `git add` and discarded both the error detail and
+// the partial progress, so ONE bad path meant nothing was staged at all.
+// That is the mechanism behind GH #731: a fresh `ox init` wrote the whole
+// .claude/ tree, handed git one malformed pathspec alongside it, and
+// committed none of it — silently, because cmd.Run() threw away git's
+// "did not match any files" message.
+//
+// So: try the batch (the fast path, one process, and what happens on every
+// healthy install), and only if it fails retry each path individually to
+// salvage the good ones. The returned error names the paths that genuinely
+// could not be staged, with git's own message attached.
+//
+// Also sets cmd.Dir explicitly rather than relying on the process working
+// directory, so relative pathspecs resolve against the repo we mean.
+func gitAdd(gitRoot string, files []string, force bool) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	run := func(paths []string) (string, error) {
+		args := []string{"add"}
+		if force {
+			args = append(args, "--force")
+		}
+		// `--` stops a path that looks like a flag from being parsed as one.
+		args = append(args, "--")
+		args = append(args, paths...)
+		cmd := exec.Command("git", args...)
+		cmd.Dir = gitRoot
+		out, err := cmd.CombinedOutput()
+		return strings.TrimSpace(string(out)), err
+	}
+
+	var failures []string
+	for start := 0; start < len(files); start += gitAddChunkSize {
+		end := min(start+gitAddChunkSize, len(files))
+		chunk := files[start:end]
+
+		if _, err := run(chunk); err == nil {
+			continue
+		}
+
+		// degrade: stage what we can, and report precisely what we can't.
+		for _, path := range chunk {
+			out, err := run([]string{path})
+			if err == nil {
+				continue
+			}
+			detail := firstLine(out)
+			if detail == "" {
+				detail = err.Error()
+			}
+			failures = append(failures, fmt.Sprintf("%s (%s)", path, detail))
+		}
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("could not stage %d file(s): %s", len(failures), strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// firstLine returns s up to the first newline. git's diagnostics put the
+// useful part first and the advice block after.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
 }
 
 // initTracker centralizes tracking of files created and modified during ox init.
@@ -1621,7 +1661,13 @@ func newInitTracker(gitRoot string) *initTracker {
 	}
 }
 
-// trackCreatedFile records a newly created file for rollback and staging.
+// trackCreatedFile records a newly created file for ROLLBACK ONLY.
+//
+// It does not stage anything — stageAll never reads createdFiles. Call
+// trackForceStage as well if the file also needs to reach the index. The
+// absence of this sentence is why a comment elsewhere in init claimed the
+// tracker handled "rollback + staging" for the root .gitignore when it
+// only ever did the first half (GH #731).
 func (t *initTracker) trackCreatedFile(absPath string) {
 	t.createdFiles = append(t.createdFiles, absPath)
 }
@@ -1633,6 +1679,10 @@ func (t *initTracker) trackCreatedDir(absPath string) {
 
 // trackModifiedFile snapshots a file's current content before modification.
 // No-op if the file was already snapshotted or doesn't exist.
+//
+// ROLLBACK ONLY — see trackCreatedFile. Also note the snapshot is taken
+// EAGERLY, at call time: call this BEFORE writing, or rollback will
+// faithfully restore the already-modified content.
 func (t *initTracker) trackModifiedFile(absPath string) {
 	if _, alreadyTracked := t.modifiedFiles[absPath]; alreadyTracked {
 		return
@@ -1658,31 +1708,45 @@ func (t *initTracker) stageAll() {
 		cli.PrintWarning(fmt.Sprintf("Could not stage .sageox files: %v", err))
 	}
 
-	// stage AGENTS.md and CLAUDE.md if they exist
+	// Stage every instruction file ox may have written a marker into —
+	// not just AGENTS.md/CLAUDE.md. EnsureInstructionFileMarkers also
+	// touches GEMINI.md, .cursorrules, .windsurfrules,
+	// .github/copilot-instructions.md, .kiro/steering/ox.md and .clinerules
+	// (see InstructionFileRegistry), and until GH #731 a Gemini or Cursor
+	// user's ox-modified file was never staged at all.
 	var agentFiles []string
-	for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
-		if _, err := os.Lstat(filepath.Join(t.gitRoot, name)); err == nil {
-			agentFiles = append(agentFiles, filepath.Join(t.gitRoot, name))
+	seen := make(map[string]bool)
+	for _, target := range DetectedInstructionFiles(t.gitRoot) {
+		abs := filepath.Join(t.gitRoot, target.Path)
+		if seen[abs] {
+			continue
 		}
+		if _, err := os.Lstat(abs); err != nil {
+			continue
+		}
+		seen[abs] = true
+		agentFiles = append(agentFiles, abs)
 	}
 	if len(agentFiles) > 0 {
-		if err := gitAddFiles(agentFiles); err != nil {
-			cli.PrintWarning(fmt.Sprintf("Could not stage agent files: %v", err))
+		if err := gitAddFiles(t.gitRoot, agentFiles); err != nil {
+			cli.PrintWarning(fmt.Sprintf("Could not stage agent instruction files: %v", err))
 		}
 	}
 
 	// stage .gitattributes if it exists
 	gitattrsPath := filepath.Join(t.gitRoot, ".gitattributes")
 	if _, err := os.Lstat(gitattrsPath); err == nil {
-		if err := gitAddFiles([]string{gitattrsPath}); err != nil {
+		if err := gitAddFiles(t.gitRoot, []string{gitattrsPath}); err != nil {
 			cli.PrintWarning(fmt.Sprintf("Could not stage .gitattributes: %v", err))
 		}
 	}
 
-	// force-stage files that may be gitignored (hooks, commands)
+	// force-stage files that may be gitignored (hooks, commands, skills,
+	// rules) plus anything else explicitly registered for staging.
 	if len(t.forceStage) > 0 {
-		if err := gitAddFilesForce(t.forceStage); err != nil {
-			cli.PrintWarning(fmt.Sprintf("Could not stage hook/command files: %v", err))
+		if err := gitAddFilesForce(t.gitRoot, t.forceStage); err != nil {
+			// name the paths — the old generic warning told nobody anything.
+			cli.PrintWarning(fmt.Sprintf("Could not stage all agent files: %v", err))
 		}
 	}
 }
@@ -1838,7 +1902,11 @@ func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
 
 // installAgentHooks installs project-level hooks for selected AI coding agents.
 // Only agents present in selectedAgents are installed.
-// Returns a list of relative paths to hook files that were created.
+//
+// Returns ABSOLUTE paths to files that exist inside gitRoot, normalized by
+// normalizeAdapterFilesWritten. Adapters report FilesWritten in whatever
+// convention they like (see the contract in pkg/adapterprotocol); callers
+// of this function get one that is safe to hand to git.
 func installAgentHooks(gitRoot string, quiet bool, selectedAgents map[string]bool) []string {
 	var installedHooks []string
 
@@ -1970,7 +2038,67 @@ func installAgentHooks(gitRoot string, quiet bool, selectedAgents map[string]boo
 		}
 	}
 
-	return installedHooks
+	return normalizeAdapterFilesWritten(gitRoot, installedHooks)
+}
+
+// normalizeAdapterFilesWritten turns adapter-reported FilesWritten entries
+// into absolute paths that exist inside gitRoot, dropping anything else.
+//
+// This is the defensive half of the GH #731 fix. Adapters are separate
+// binaries resolved from disk at runtime, so ox can document the
+// FilesWritten contract (pkg/adapterprotocol) but cannot enforce it — a
+// stale or third-party adapter can always hand back something else. A
+// contract you can't enforce at the boundary is a comment.
+//
+// What made #731 so damaging is that `git add` validates every pathspec
+// up front and fails the entire invocation on the first bad one. So a
+// single junk entry meant NOTHING got staged — not the junk, and not the
+// perfectly good `.claude/settings.json` next to it. Filtering here plus
+// the degrade-to-per-file retry in gitAddFilesForce makes that
+// impossible.
+//
+// Deliberately no path guessing: an entry that doesn't resolve is dropped
+// and logged, not searched for under plausible parents. Guessing trades a
+// loud failure for a quiet wrong answer.
+func normalizeAdapterFilesWritten(gitRoot string, raw []string) []string {
+	out := make([]string, 0, len(raw))
+	seen := make(map[string]bool, len(raw))
+
+	for _, entry := range raw {
+		trimmed := strings.TrimSpace(entry)
+		if trimmed == "" {
+			continue
+		}
+		candidate := filepath.FromSlash(trimmed)
+		if filepath.IsAbs(candidate) {
+			candidate = filepath.Clean(candidate)
+		} else {
+			candidate = filepath.Join(gitRoot, candidate)
+		}
+
+		// containment: kills both the double-join corruption from
+		// adapters that already returned absolute paths, and legitimate
+		// user-scope paths (~/.codex/hooks.json) that git cannot stage.
+		rel, err := filepath.Rel(gitRoot, candidate)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			slog.Debug("init: dropping adapter file outside repo", "entry", entry, "resolved", candidate)
+			continue
+		}
+
+		// Lstat, not Stat: some installed assets are symlinks, and a
+		// broken symlink is still a real thing git can stage.
+		if _, err := os.Lstat(candidate); err != nil {
+			slog.Debug("init: dropping adapter file that does not exist", "entry", entry, "resolved", candidate)
+			continue
+		}
+
+		if seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		out = append(out, candidate)
+	}
+	return out
 }
 
 // detectExistingRepoMarkers scans .sageox/ for existing .repo_* marker files

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -1661,11 +1661,23 @@ type initTracker struct {
 	modifiedFiles map[string][]byte // absolute path -> original content (for restore)
 	forceStage    []string          // absolute paths that need --force staging (may be gitignored)
 	isFreshInit   bool              // true if .sageox/ didn't exist before
+
+	// indexEntries records each touched path's git INDEX entry as it was
+	// before init ran, keyed by repo-relative path. A recorded "" means
+	// the path was not in the index at all.
+	//
+	// The working-tree snapshot in modifiedFiles is not sufficient: a user
+	// may have already `git add`ed their own edits to a file ox is about
+	// to touch. Resetting that path to HEAD on rollback would silently
+	// throw their staged work away — the exact class of "ox touched
+	// something it wasn't asked to" this PR exists to stop.
+	indexEntries map[string]string
 }
 
 func newInitTracker(gitRoot string) *initTracker {
 	return &initTracker{
 		gitRoot:       gitRoot,
+		indexEntries:  make(map[string]string),
 		modifiedFiles: make(map[string][]byte),
 	}
 }
@@ -1678,6 +1690,7 @@ func newInitTracker(gitRoot string) *initTracker {
 // tracker handled "rollback + staging" for the root .gitignore when it
 // only ever did the first half (GH #731).
 func (t *initTracker) trackCreatedFile(absPath string) {
+	t.snapshotIndexEntry(absPath)
 	t.createdFiles = append(t.createdFiles, absPath)
 }
 
@@ -1693,6 +1706,7 @@ func (t *initTracker) trackCreatedDir(absPath string) {
 // EAGERLY, at call time: call this BEFORE writing, or rollback will
 // faithfully restore the already-modified content.
 func (t *initTracker) trackModifiedFile(absPath string) {
+	t.snapshotIndexEntry(absPath)
 	if _, alreadyTracked := t.modifiedFiles[absPath]; alreadyTracked {
 		return
 	}
@@ -1703,7 +1717,34 @@ func (t *initTracker) trackModifiedFile(absPath string) {
 
 // trackForceStage records a file that needs --force to stage (may be gitignored).
 func (t *initTracker) trackForceStage(absPath string) {
+	t.snapshotIndexEntry(absPath)
 	t.forceStage = append(t.forceStage, absPath)
+}
+
+// snapshotIndexEntry records a path's git index entry before ox touches
+// it, so rollback can put the index back exactly as the user left it —
+// including any changes they had already staged themselves.
+//
+// Records "" when the path is not in the index. Idempotent: the FIRST
+// snapshot wins, since later calls happen after ox has already staged.
+func (t *initTracker) snapshotIndexEntry(absPath string) {
+	rel, err := filepath.Rel(t.gitRoot, absPath)
+	if err != nil {
+		return
+	}
+	if _, seen := t.indexEntries[rel]; seen {
+		return
+	}
+	if !isGitRepo(t.gitRoot) {
+		return
+	}
+	cmd := exec.Command("git", "ls-files", "--stage", "--", rel)
+	cmd.Dir = t.gitRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return // can't read the index; leave the path unrecorded
+	}
+	t.indexEntries[rel] = strings.TrimRight(string(out), "\n")
 }
 
 // stageAll stages all tracked files in git.
@@ -1839,12 +1880,25 @@ func (t *initTracker) unstageAll(quiet bool) {
 	}
 
 	for _, rel := range paths {
-		cmd := exec.Command("git", "reset", "-q", "HEAD", "--", rel)
-		cmd.Dir = t.gitRoot
-		if err := cmd.Run(); err == nil {
-			continue
+		entry, recorded := t.indexEntries[rel]
+
+		// Restore the EXACT pre-init index entry when we have one. A plain
+		// `git reset HEAD` would be wrong: if the user had already staged
+		// their own edits to this path, resetting to HEAD silently discards
+		// that staged work while leaving the working tree alone.
+		if recorded && entry != "" {
+			restore := exec.Command("git", "update-index", "--index-info")
+			restore.Dir = t.gitRoot
+			restore.Stdin = strings.NewReader(entry + "\n")
+			if err := restore.Run(); err == nil {
+				continue
+			}
+			if !quiet {
+				cli.PrintWarning(fmt.Sprintf("Could not restore index entry for %s", rel))
+			}
 		}
-		// not in HEAD (a file ox created): drop it from the index entirely.
+
+		// Not in the index before init (or unreadable): drop it.
 		rm := exec.Command("git", "rm", "-q", "--cached", "--ignore-unmatch", "--", rel)
 		rm.Dir = t.gitRoot
 		if err := rm.Run(); err != nil && !quiet {

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -677,6 +677,15 @@ func runInit() error {
 				if r.status == injectedNew || r.status == symlinkCreated {
 					tracker.trackCreatedFile(p)
 				}
+				// Stage everything this pass actually wrote. The later marker
+				// pass cannot cover these: it sees AGENTS.md / CLAUDE.md as
+				// alreadyPresent (this pass just put the marker there), so
+				// gating staging on the marker results alone left the two
+				// primary instruction files out of the init commit entirely —
+				// the GH #731 symptom, for the files it matters most for.
+				if r.status != alreadyPresent {
+					tracker.trackForceStage(p)
+				}
 			}
 		}
 	}
@@ -1887,9 +1896,17 @@ func (t *initTracker) unstageAll(quiet bool) {
 		// their own edits to this path, resetting to HEAD silently discards
 		// that staged work while leaving the working tree alone.
 		if recorded && entry != "" {
+			// Clear the current entry BEFORE replaying the recorded one.
+			// stageAll's `git add --force` collapses a path to a single
+			// stage-0 entry; feeding back stages 1-3 without first removing
+			// stage 0 leaves BOTH in the index, so a previously-conflicted
+			// path comes back as unmerged (`git status` shows UU) instead of
+			// restored. A zero-mode line is update-index's delete directive.
+			input := fmt.Sprintf("0 %s\t%s\n", strings.Repeat("0", 40), rel) + entry + "\n"
+
 			restore := exec.Command("git", "update-index", "--index-info")
 			restore.Dir = t.gitRoot
-			restore.Stdin = strings.NewReader(entry + "\n")
+			restore.Stdin = strings.NewReader(input)
 			if err := restore.Run(); err == nil {
 				continue
 			}

--- a/cmd/ox/init_gitignore_test.go
+++ b/cmd/ox/init_gitignore_test.go
@@ -83,24 +83,16 @@ discovered.jsonl
 	assert.Contains(t, result, "!discovered.jsonl", "required entry '!discovered.jsonl' should be present")
 }
 
+// allRequiredEntries renders every required entry as gitignore content.
+// Derived from requiredGitignoreEntries rather than hand-listed so that
+// adding a rule (e.g. kb/ for GH #732) can't silently rot these fixtures
+// into asserting the opposite of what they mean.
+func allRequiredEntries() string {
+	return strings.Join(requiredGitignoreEntries, "\n")
+}
+
 func TestMergeGitignoreEntries_PreservesCommentsInContent(t *testing.T) {
-	content := `# User comment
-logs/
-# Another comment
-cache/
-session.jsonl
-sessions/
-.needs-doctor
-.needs-doctor-agent
-agent_instances/
-agent_tasks/
-config.local.toml
-ledger
-teams/
-!README.md
-!config.json
-!discovered.jsonl
-!offline/`
+	content := "# User comment\n" + allRequiredEntries() + "\n# Another comment"
 
 	result, changed := mergeGitignoreEntries(content)
 	assert.False(t, changed, "expected changed=false when all required entries present")
@@ -110,24 +102,7 @@ teams/
 }
 
 func TestMergeGitignoreEntries_PreservesUserEntriesInContent(t *testing.T) {
-	content := `logs/
-cache/
-session.jsonl
-sessions/
-.needs-doctor
-.needs-doctor-agent
-agent_instances/
-agent_tasks/
-config.local.toml
-ledger
-teams/
-!README.md
-!config.json
-!discovered.jsonl
-!offline/
-# user's custom entries
-*.swp
-.DS_Store`
+	content := allRequiredEntries() + "\n# user's custom entries\n*.swp\n.DS_Store"
 
 	result, changed := mergeGitignoreEntries(content)
 	assert.False(t, changed, "expected changed=false when all required entries present")

--- a/cmd/ox/init_staging_test.go
+++ b/cmd/ox/init_staging_test.go
@@ -369,3 +369,56 @@ func TestRollback_UnstagesEverythingItStaged(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "node_modules/\n.sageox/kb/\n", string(body), "content restored too")
 }
+
+// TestRollback_PreservesPreExistingStagedChanges — a user may have already
+// `git add`ed their own edits to a file ox is about to touch. Rollback
+// restores the working tree from a content snapshot, but the INDEX needs
+// its own snapshot: a plain `git reset HEAD` would silently throw the
+// user's staged work away while leaving the working tree untouched.
+func TestRollback_PreservesPreExistingStagedChanges(t *testing.T) {
+	repo := testGitRepo(t)
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		require.NoError(t, cmd.Run(), "git %v", args)
+	}
+
+	agents := filepath.Join(repo, "AGENTS.md")
+	require.NoError(t, os.WriteFile(agents, []byte("# committed\n"), 0o644))
+	git("add", "AGENTS.md")
+	git("commit", "-m", "baseline")
+
+	// the user stages their OWN edit, before ox runs
+	require.NoError(t, os.WriteFile(agents, []byte("# committed\n# the user's staged work\n"), 0o644))
+	git("add", "AGENTS.md")
+
+	stagedBlob := func() string {
+		cmd := exec.Command("git", "ls-files", "--stage", "--", "AGENTS.md")
+		cmd.Dir = repo
+		out, err := cmd.Output()
+		require.NoError(t, err)
+		return strings.TrimSpace(string(out))
+	}
+	before := stagedBlob()
+	require.NotEmpty(t, before)
+
+	// ox now modifies and stages the same file, then rolls back
+	tracker := newInitTracker(repo)
+	tracker.trackModifiedFile(agents)
+	require.NoError(t, os.WriteFile(agents, []byte("# committed\n# ox marker\n"), 0o644))
+	tracker.trackForceStage(agents)
+	tracker.stageAll()
+	require.NotEqual(t, before, stagedBlob(), "precondition: ox changed the index entry")
+
+	tracker.rollback(true)
+
+	assert.Equal(t, before, stagedBlob(),
+		"the user's pre-existing staged edit must survive rollback — resetting to HEAD "+
+			"would destroy work ox was never asked to touch")
+
+	body, err := os.ReadFile(agents)
+	require.NoError(t, err)
+	assert.Equal(t, "# committed\n# the user's staged work\n", string(body),
+		"working tree restored to the user's content, not HEAD's")
+}

--- a/cmd/ox/init_staging_test.go
+++ b/cmd/ox/init_staging_test.go
@@ -1,0 +1,247 @@
+//go:build !short
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stagedFiles returns the repo-relative paths currently in the git index.
+func stagedFiles(t *testing.T, repo string) []string {
+	t.Helper()
+	cmd := exec.Command("git", "diff", "--cached", "--name-only")
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	var paths []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
+}
+
+// writeFileAt creates parents and writes content, returning the abs path.
+func writeFileAt(t *testing.T, repo, rel, content string) string {
+	t.Helper()
+	abs := filepath.Join(repo, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+	require.NoError(t, os.WriteFile(abs, []byte(content), 0o644))
+	return abs
+}
+
+// agentInstallTree lays down the files a real `ox init` produces for
+// Claude Code, and returns them as repo-relative paths.
+func agentInstallTree(t *testing.T, repo string) []string {
+	t.Helper()
+	rels := []string{
+		".claude/settings.json",
+		".claude/commands/ox.md",
+		".claude/skills/ox-plan/SKILL.md",
+		".claude/rules/ox.md",
+		".claude/rules/sageox/use-team-context.md",
+	}
+	for _, rel := range rels {
+		writeFileAt(t, repo, rel, "x")
+	}
+	return rels
+}
+
+// TestStageAll_StagesTheClaudeTree is the GH #731 acceptance test: after
+// init writes .claude/**, those files must actually be in the git index,
+// or the user's "git commit && git push" silently ships nothing.
+//
+// Nothing in this package asserted anything about the index before this.
+func TestStageAll_StagesTheClaudeTree(t *testing.T) {
+	repo := testGitRepo(t)
+	rels := agentInstallTree(t, repo)
+
+	tracker := newInitTracker(repo)
+	for _, rel := range rels {
+		tracker.trackForceStage(filepath.Join(repo, rel))
+	}
+	tracker.stageAll()
+
+	staged := stagedFiles(t, repo)
+	for _, rel := range rels {
+		assert.Contains(t, staged, rel, "%s must reach the index", rel)
+	}
+}
+
+// TestStageAll_OneBadPathDoesNotZeroTheBatch is the regression test for
+// the actual #731 mechanism. git validates every pathspec up front and
+// fails the whole invocation on the first bad one, so a single junk entry
+// used to leave NOTHING staged — including the valid files beside it.
+//
+// This fails against the pre-fix batched `git add`.
+func TestStageAll_OneBadPathDoesNotZeroTheBatch(t *testing.T) {
+	repo := testGitRepo(t)
+	rels := agentInstallTree(t, repo)
+
+	tracker := newInitTracker(repo)
+	for _, rel := range rels {
+		tracker.trackForceStage(filepath.Join(repo, rel))
+	}
+	// exactly the shape adapters used to emit: a skills-dir-relative name
+	// joined onto the repo root, pointing at a file that does not exist.
+	tracker.trackForceStage(filepath.Join(repo, "ox-plan/SKILL.md"))
+	tracker.trackForceStage(filepath.Join(repo, "ox.md"))
+
+	tracker.stageAll()
+
+	staged := stagedFiles(t, repo)
+	assert.Contains(t, staged, ".claude/settings.json",
+		"the valid files must still be staged despite a bad pathspec in the same batch")
+	for _, rel := range rels {
+		assert.Contains(t, staged, rel)
+	}
+}
+
+// TestGitAdd_ReportsWhichPathsFailed — the old implementation used
+// cmd.Run() and discarded git's stderr, so the warning said only
+// "Could not stage hook/command files" and nobody could diagnose it.
+func TestGitAdd_ReportsWhichPathsFailed(t *testing.T) {
+	repo := testGitRepo(t)
+	good := writeFileAt(t, repo, ".claude/settings.json", "{}")
+
+	err := gitAddFilesForce(repo, []string{good, filepath.Join(repo, "nope.md")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nope.md", "the failing path must be named")
+	assert.NotContains(t, err.Error(), "settings.json", "the path that worked must not be blamed")
+	assert.Contains(t, stagedFiles(t, repo), ".claude/settings.json",
+		"the good path is staged even though the call reports an error")
+}
+
+// TestGitAdd_UsesGitRootNotProcessCwd pins cmd.Dir. The helpers used to
+// rely on the process working directory, which is only accidentally
+// correct and impossible to test.
+func TestGitAdd_UsesGitRootNotProcessCwd(t *testing.T) {
+	repo := testGitRepo(t)
+	writeFileAt(t, repo, ".claude/settings.json", "{}")
+
+	t.Chdir(t.TempDir()) // somewhere else entirely, not even a git repo
+
+	require.NoError(t, gitAddFilesForce(repo, []string{filepath.Join(repo, ".claude/settings.json")}))
+	assert.Contains(t, stagedFiles(t, repo), ".claude/settings.json")
+}
+
+// TestStageAll_StagesNonClaudeInstructionFiles covers the second half of
+// root cause B: init can write markers into GEMINI.md, .cursorrules and
+// friends, but stageAll only ever knew about AGENTS.md and CLAUDE.md.
+func TestStageAll_StagesNonClaudeInstructionFiles(t *testing.T) {
+	repo := testGitRepo(t)
+	// .gemini/ presence is what makes GEMINI.md a detected target.
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".gemini"), 0o755))
+	writeFileAt(t, repo, "GEMINI.md", "# instructions\n")
+	writeFileAt(t, repo, "AGENTS.md", "# instructions\n")
+
+	tracker := newInitTracker(repo)
+	tracker.stageAll()
+
+	staged := stagedFiles(t, repo)
+	assert.Contains(t, staged, "GEMINI.md",
+		"a Gemini user's ox-modified instruction file must be staged too")
+	assert.Contains(t, staged, "AGENTS.md")
+}
+
+// TestNormalizeAdapterFilesWritten covers the boundary defense. Adapters
+// are separate binaries, so ox cannot enforce the FilesWritten contract —
+// it can only refuse to hand git something broken.
+func TestNormalizeAdapterFilesWritten(t *testing.T) {
+	repo := testGitRepo(t)
+	settings := writeFileAt(t, repo, ".claude/settings.json", "{}")
+	skill := writeFileAt(t, repo, ".claude/skills/ox-plan/SKILL.md", "x")
+	outside := filepath.Join(t.TempDir(), "elsewhere.json")
+	require.NoError(t, os.WriteFile(outside, []byte("{}"), 0o644))
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+		why  string
+	}{
+		{
+			"repo-relative existing", []string{".claude/settings.json"}, []string{settings},
+			"the convention the built-in Claude hook installer uses",
+		},
+		{
+			"absolute inside repo", []string{settings}, []string{settings},
+			"codex/droid/gemini adapters return absolute paths — also valid",
+		},
+		{
+			"already-absolute must not be re-joined", []string{settings}, []string{settings},
+			"double-joining produced <root><root>/... and broke the whole batch",
+		},
+		{
+			"skills-dir-relative is dropped", []string{"ox-plan/SKILL.md"}, nil,
+			"resolves to <root>/ox-plan/SKILL.md which does not exist; dropping " +
+				"beats guessing, and the adapter fix is what makes it arrive correctly",
+		},
+		{
+			"rules-dir-relative is dropped", []string{"ox.md", "sageox/use-team-context.md"}, nil,
+			"same class as above",
+		},
+		{
+			"path outside the repo is dropped", []string{outside}, nil,
+			"user-scope installs (~/.codex/hooks.json) are real but git cannot stage them",
+		},
+		{
+			"traversal escape is dropped", []string{"../escape.json"}, nil,
+			"containment is checked after joining, not by string prefix",
+		},
+		{"nonexistent is dropped", []string{".claude/ghost.json"}, nil, "never stage what was not written"},
+		{"empty and blank are skipped", []string{"", "   "}, nil, "defensive against sloppy adapters"},
+		{
+			"duplicates collapse",
+			[]string{".claude/settings.json", settings, ".claude/settings.json"},
+			[]string{settings},
+			"the same file reported by two capabilities must be staged once",
+		},
+		{
+			"forward slashes are accepted",
+			[]string{".claude/skills/ox-plan/SKILL.md"}, []string{skill},
+			"adapters emit JSON paths with forward slashes regardless of platform",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeAdapterFilesWritten(repo, tt.in)
+			if tt.want == nil {
+				assert.Empty(t, got, tt.why)
+				return
+			}
+			assert.Equal(t, tt.want, got, tt.why)
+		})
+	}
+}
+
+// TestNormalizeAdapterFilesWritten_KeepsGoodEntriesAlongsideBadOnes is the
+// property that actually mattered in #731: a mixed list must not be
+// discarded wholesale just because part of it is malformed.
+func TestNormalizeAdapterFilesWritten_KeepsGoodEntriesAlongsideBadOnes(t *testing.T) {
+	repo := testGitRepo(t)
+	settings := writeFileAt(t, repo, ".claude/settings.json", "{}")
+	command := writeFileAt(t, repo, ".claude/commands/ox.md", "x")
+
+	got := normalizeAdapterFilesWritten(repo, []string{
+		".claude/settings.json",  // valid, repo-relative
+		"ox-plan/SKILL.md",       // junk, skills-dir-relative
+		command,                  // valid, absolute
+		"ox.md",                  // junk, rules-dir-relative
+		"/tmp/definitely/absent", // junk, absolute and outside
+	})
+
+	assert.Equal(t, []string{settings, command}, got,
+		"the two real files survive; only the junk is dropped")
+}

--- a/cmd/ox/init_staging_test.go
+++ b/cmd/ox/init_staging_test.go
@@ -245,3 +245,57 @@ func TestNormalizeAdapterFilesWritten_KeepsGoodEntriesAlongsideBadOnes(t *testin
 	assert.Equal(t, []string{settings, command}, got,
 		"the two real files survive; only the junk is dropped")
 }
+
+// TestNormalizeAdapterFilesWritten_RejectsRepoRootAndDirs covers the
+// over-staging hazard. An adapter entry of "." — or gitRoot absolute —
+// passes both containment and Lstat, and `git add --force -- <root>`
+// stages the ENTIRE worktree, sweeping in every unrelated change the user
+// had in progress. That is the exact outcome init's own next-steps note
+// warns against, so it must never come from an adapter's return value.
+func TestNormalizeAdapterFilesWritten_RejectsRepoRootAndDirs(t *testing.T) {
+	repo := testGitRepo(t)
+	settings := writeFileAt(t, repo, ".claude/settings.json", "{}")
+
+	tests := []struct {
+		name  string
+		entry string
+		why   string
+	}{
+		{"dot", ".", "resolves to the repo root"},
+		{"dot-slash", "./", "same, trailing separator"},
+		{"absolute root", repo, "adapter returned gitRoot itself"},
+		{"nested directory", ".claude", "staging a dir pulls in files ox never wrote"},
+		{"deep directory", ".claude/skills", "same, one level down"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Empty(t, normalizeAdapterFilesWritten(repo, []string{tt.entry}), tt.why)
+		})
+	}
+
+	// and a mixed list must still keep the legitimate file
+	got := normalizeAdapterFilesWritten(repo, []string{".", ".claude", ".claude/settings.json"})
+	assert.Equal(t, []string{settings}, got,
+		"rejecting the root and the dir must not take the real file with them")
+}
+
+// TestStageAll_RepoRootEntryDoesNotStageEverything is the end-to-end
+// version: an adapter reporting "." must not cause init to stage a file
+// the user was independently working on.
+func TestStageAll_RepoRootEntryDoesNotStageEverything(t *testing.T) {
+	repo := testGitRepo(t)
+	writeFileAt(t, repo, ".claude/settings.json", "{}")
+	// an unrelated in-progress edit the user has NOT asked to commit
+	writeFileAt(t, repo, "src/work_in_progress.go", "package main\n")
+
+	tracker := newInitTracker(repo)
+	for _, p := range normalizeAdapterFilesWritten(repo, []string{".", ".claude/settings.json"}) {
+		tracker.trackForceStage(p)
+	}
+	tracker.stageAll()
+
+	staged := stagedFiles(t, repo)
+	assert.Contains(t, staged, ".claude/settings.json")
+	assert.NotContains(t, staged, "src/work_in_progress.go",
+		"a rogue adapter entry must never sweep the user's unrelated work into the commit")
+}

--- a/cmd/ox/init_staging_test.go
+++ b/cmd/ox/init_staging_test.go
@@ -136,16 +136,23 @@ func TestGitAdd_UsesGitRootNotProcessCwd(t *testing.T) {
 }
 
 // TestStageAll_StagesNonClaudeInstructionFiles covers the second half of
-// root cause B: init can write markers into GEMINI.md, .cursorrules and
-// friends, but stageAll only ever knew about AGENTS.md and CLAUDE.md.
+// root cause B: init writes ox:prime markers into GEMINI.md, .cursorrules
+// and friends, but stageAll only ever knew about AGENTS.md and CLAUDE.md,
+// so those users' modified files were never committed.
+//
+// runInit registers each file it actually wrote via trackForceStage (see
+// the EnsureInstructionFileMarkers loop) — staging by *detection* was
+// rejected because presence doesn't imply ox touched it.
 func TestStageAll_StagesNonClaudeInstructionFiles(t *testing.T) {
 	repo := testGitRepo(t)
-	// .gemini/ presence is what makes GEMINI.md a detected target.
 	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".gemini"), 0o755))
-	writeFileAt(t, repo, "GEMINI.md", "# instructions\n")
-	writeFileAt(t, repo, "AGENTS.md", "# instructions\n")
+	gemini := writeFileAt(t, repo, "GEMINI.md", "# instructions\n")
+	agents := writeFileAt(t, repo, "AGENTS.md", "# instructions\n")
 
 	tracker := newInitTracker(repo)
+	// what the marker-injection loop does for each file it wrote
+	tracker.trackForceStage(gemini)
+	tracker.trackForceStage(agents)
 	tracker.stageAll()
 
 	staged := stagedFiles(t, repo)
@@ -298,4 +305,67 @@ func TestStageAll_RepoRootEntryDoesNotStageEverything(t *testing.T) {
 	assert.Contains(t, staged, ".claude/settings.json")
 	assert.NotContains(t, staged, "src/work_in_progress.go",
 		"a rogue adapter entry must never sweep the user's unrelated work into the commit")
+}
+
+// TestStageAll_DoesNotStageUntouchedInstructionFiles — a file merely
+// EXISTING says nothing about whether ox changed it. Staging every
+// detected instruction file would sweep a user's own uncommitted edits to
+// GEMINI.md / .cursorrules into the init commit.
+func TestStageAll_DoesNotStageUntouchedInstructionFiles(t *testing.T) {
+	repo := testGitRepo(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".gemini"), 0o755))
+	writeFileAt(t, repo, "GEMINI.md", "# the user's own in-progress edit\n")
+	touched := writeFileAt(t, repo, "AGENTS.md", "# ox wrote a marker here\n")
+
+	tracker := newInitTracker(repo)
+	// only the file ox actually wrote to is registered for staging
+	tracker.trackForceStage(touched)
+	tracker.stageAll()
+
+	staged := stagedFiles(t, repo)
+	assert.Contains(t, staged, "AGENTS.md", "the file ox wrote must be staged")
+	assert.NotContains(t, staged, "GEMINI.md",
+		"a detected-but-untouched instruction file must not be staged — those are the user's edits")
+}
+
+// TestRollback_UnstagesEverythingItStaged — rollback restores file CONTENT,
+// but stageAll runs before API registration, so without unstaging the
+// user's next `git commit` silently includes changes they were just told
+// were rolled back. The root .gitignore cleanup is the sharp case: a
+// pre-existing tracked file that ox modified.
+func TestRollback_UnstagesEverythingItStaged(t *testing.T) {
+	repo := testGitRepo(t)
+
+	// a tracked file with committed content
+	gitignore := filepath.Join(repo, ".gitignore")
+	require.NoError(t, os.WriteFile(gitignore, []byte("node_modules/\n.sageox/kb/\n"), 0o644))
+	for _, args := range [][]string{{"add", ".gitignore"}, {"commit", "-m", "baseline"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		require.NoError(t, cmd.Run(), "git %v", args)
+	}
+
+	tracker := newInitTracker(repo)
+	// ox modifies it (the #732 cleanup), snapshotting first
+	tracker.trackModifiedFile(gitignore)
+	require.NoError(t, os.WriteFile(gitignore, []byte("node_modules/\n"), 0o644))
+	tracker.trackForceStage(gitignore)
+
+	// ...and creates a new file
+	created := writeFileAt(t, repo, ".claude/settings.json", "{}")
+	tracker.trackCreatedFile(created)
+	tracker.trackForceStage(created)
+
+	tracker.stageAll()
+	require.NotEmpty(t, stagedFiles(t, repo), "precondition: something is staged")
+
+	tracker.rollback(true)
+
+	assert.Empty(t, stagedFiles(t, repo),
+		"rollback must leave a clean index — restoring content while leaving the edit "+
+			"staged means the next commit silently ships it")
+
+	body, err := os.ReadFile(gitignore)
+	require.NoError(t, err)
+	assert.Equal(t, "node_modules/\n.sageox/kb/\n", string(body), "content restored too")
 }

--- a/cmd/ox/init_staging_test.go
+++ b/cmd/ox/init_staging_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -421,4 +422,80 @@ func TestRollback_PreservesPreExistingStagedChanges(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "# committed\n# the user's staged work\n", string(body),
 		"working tree restored to the user's content, not HEAD's")
+}
+
+// TestUnstageAll_RestoresConflictStagesWithoutLeavingUnmerged covers the
+// index-restore path for a path that was ALREADY CONFLICTED when init ran.
+//
+// stageAll's `git add --force` collapses such a path to a single stage-0
+// entry. Replaying the recorded stages 1-3 without first clearing stage 0
+// leaves both in the index, so rollback hands the user an unmerged path
+// (`git status` shows UU) rather than the conflict they started with.
+func TestUnstageAll_RestoresConflictStagesWithoutLeavingUnmerged(t *testing.T) {
+	repo := testGitRepo(t)
+	rel := "conflicted.txt"
+	abs := writeFileAt(t, repo, rel, "working copy\n")
+
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+		return string(out)
+	}
+
+	// Build three real blobs and install them as conflict stages 1/2/3.
+	stage := func(n int, content string) string {
+		h := exec.Command("git", "hash-object", "-w", "--stdin")
+		h.Dir = repo
+		h.Stdin = strings.NewReader(content)
+		out, err := h.Output()
+		require.NoError(t, err)
+		sha := strings.TrimSpace(string(out))
+		return fmt.Sprintf("100644 %s %d\t%s", sha, n, rel)
+	}
+	conflict := strings.Join([]string{stage(1, "base\n"), stage(2, "ours\n"), stage(3, "theirs\n")}, "\n")
+
+	install := exec.Command("git", "update-index", "--index-info")
+	install.Dir = repo
+	install.Stdin = strings.NewReader(conflict + "\n")
+	require.NoError(t, install.Run())
+	require.Contains(t, git("status", "--porcelain"), "UU "+rel, "precondition: path must start out conflicted")
+
+	// init records the pre-existing index entry, then stages over it.
+	tracker := newInitTracker(repo)
+	tracker.trackForceStage(abs)
+	tracker.stageAll()
+	require.NotContains(t, git("status", "--porcelain"), "UU "+rel,
+		"precondition: git add --force must have collapsed the conflict to stage 0")
+
+	tracker.unstageAll(true)
+
+	assert.Contains(t, git("status", "--porcelain"), "UU "+rel,
+		"rollback must restore the conflict exactly as it was, not leave a half-merged index")
+	assert.Equal(t, 3, strings.Count(git("ls-files", "--stage", "--", rel), rel),
+		"exactly stages 1-3 should remain — a leftover stage 0 means the index is still unmerged")
+}
+
+// TestStageAll_StagesClaudePrimaryInstructionFiles is the regression test
+// for the files ox writes via injectOxPrime. The later marker pass reports
+// them as alreadyPresent (injectOxPrime just wrote the marker), so gating
+// staging on marker results alone dropped AGENTS.md and CLAUDE.md from the
+// init commit — the GH #731 symptom for the two files it matters most for.
+func TestStageAll_StagesClaudePrimaryInstructionFiles(t *testing.T) {
+	repo := testGitRepo(t)
+	writeFileAt(t, repo, "AGENTS.md", "# instructions\n")
+	writeFileAt(t, repo, "CLAUDE.md", "# instructions\n")
+
+	tracker := newInitTracker(repo)
+	// what runInit records for a non-alreadyPresent injection result
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
+		tracker.trackForceStage(filepath.Join(repo, name))
+	}
+	tracker.stageAll()
+
+	staged := stagedFiles(t, repo)
+	assert.Contains(t, staged, "AGENTS.md")
+	assert.Contains(t, staged, "CLAUDE.md")
 }

--- a/docs/specs/kb-daemon-sync.md
+++ b/docs/specs/kb-daemon-sync.md
@@ -39,6 +39,24 @@ handles that sync so the model isn't re-derived every time someone touches it.
 `paths.KBDir(kb_id)` is the canonical path; `paths.KBDir("")` is the per-endpoint
 root. Bubbles are keyed by the **immutable** `kb_id`, never the renameable slug.
 
+### Keeping the symlinks out of git
+
+Per-project bubble symlinks under `<project>/.sageox/kb/` are derived state and
+must never be committed. The ignore rule lives in **`<project>/.sageox/.gitignore`
+as `kb/`** — a file ox already owns, writes, and commits.
+
+It is deliberately **not** in the project's root `.gitignore`. Earlier versions
+wrote `.sageox/kb/` there on the theory that a top-level rule is more visible to
+humans browsing the repo; GH #732 established that developers do not want ox
+editing the file at the top of their repo, and that visibility was not worth the
+intrusion. Patterns in a nested `.gitignore` resolve relative to their own
+directory, so `kb/` covers exactly the same paths.
+
+Both `ox init` and the daemon reconciler write the rule (via
+`internal/sageoxignore`); only the foreground commands (`ox init`, `ox doctor
+--fix`) will *remove* a stale `.sageox/kb/` line from a root `.gitignore`, and
+only once the replacement is verifiably present.
+
 ---
 
 ## Who syncs bubbles — leader-gated, exactly like team context

--- a/internal/daemon/sync_symlinks.go
+++ b/internal/daemon/sync_symlinks.go
@@ -56,12 +56,8 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/fileutil"
 	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/sageoxignore"
 )
-
-// projectGitignoreLine is the single entry the reconciler appends to a
-// project's root .gitignore so per-project bubble symlinks never leak
-// into a commit. Idempotent: appended only when missing.
-const projectGitignoreLine = ".sageox/kb/"
 
 // kbTeamScopeDir is the scope subdirectory under <project>/.sageox/kb/
 // that holds team-scope bubble symlinks. Mirrors the server's
@@ -141,8 +137,8 @@ func (s *SyncScheduler) reconcileProjectSymlinksWithOps(ctx context.Context, pro
 	defer cancel()
 
 	err := fileutil.WithFileLock(lockCtx, lockTarget, func() error {
-		// ensure project's root .gitignore excludes .sageox/kb/. Done
-		// inside the lock so two daemons don't both append the line.
+		// ensure .sageox/.gitignore excludes kb/. Done inside the lock
+		// so two daemons don't both append the line.
 		if err := ensureProjectGitignoreEntry(projectRoot); err != nil {
 			s.logger.Warn("kb_symlink gitignore update failed", "project", projectRoot, "error", err)
 			// non-fatal — symlink reconciliation continues.
@@ -332,48 +328,33 @@ func tmpSuffix() string {
 	return fmt.Sprintf("%d", time.Now().UnixNano())
 }
 
-// ensureProjectGitignoreEntry appends `.sageox/kb/` to the project's
-// root `.gitignore` exactly once. Idempotent: re-reads the file each
+// ensureProjectGitignoreEntry appends `kb/` to the project's
+// `.sageox/.gitignore` exactly once, so daemon-materialized bubble
+// symlinks never leak into a commit. Idempotent: re-reads the file each
 // call and only appends when the line is genuinely missing.
 //
-// Why touch the project's root .gitignore (and not just .sageox/.gitignore):
-// The existing .sageox/.gitignore already excludes most cache content
-// nested under the dir, but the bead spec is explicit: write to the
-// project's root .gitignore. This keeps the rule visible to humans
-// browsing the repo from the top.
+// # Why .sageox/.gitignore and not the project's root .gitignore
+//
+// This reverses an earlier decision (recorded here as "the bead spec is
+// explicit: write to the project's root .gitignore ... visible to humans
+// browsing the repo from the top"). GH #732: developers do not want a
+// background process editing the .gitignore at the top of their repo, and
+// visibility was never worth the intrusion. Patterns in a nested
+// .gitignore are relative to its own directory, so `kb/` here covers
+// exactly what `.sageox/kb/` covered from the root — same paths, inside a
+// file ox already owns, writes, and commits.
+//
+// The daemon deliberately does NOT remove a pre-existing `.sageox/kb/`
+// line from the root .gitignore. Silently deleting lines from a
+// developer's file in a background pass is the very behavior #732
+// objected to; that cleanup is foreground-only (`ox init`, `ox doctor`).
+//
+// Callers reach this inside the kb file lock, and the lock target lives
+// under .sageox/, so the directory is guaranteed to exist by this point.
 func ensureProjectGitignoreEntry(projectRoot string) error {
-	gitignorePath := filepath.Join(projectRoot, ".gitignore")
-	existing, err := os.ReadFile(gitignorePath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("read .gitignore: %w", err)
+	gitignorePath := filepath.Join(projectRoot, ".sageox", ".gitignore")
+	if _, _, err := sageoxignore.EnsureEntry(gitignorePath, sageoxignore.KBEntry); err != nil {
+		return err
 	}
-	if hasGitignoreLine(string(existing), projectGitignoreLine) {
-		return nil
-	}
-	// preserve trailing newline expectations: append on its own line
-	// even if the existing file didn't end with one.
-	var buf strings.Builder
-	buf.Write(existing)
-	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
-		buf.WriteString("\n")
-	}
-	buf.WriteString(projectGitignoreLine)
-	buf.WriteString("\n")
-	return os.WriteFile(gitignorePath, []byte(buf.String()), 0o644)
-}
-
-// hasGitignoreLine reports whether `content` already lists `line` as
-// a non-comment, non-blank entry. Comment-aware so a line buried in a
-// `# .sageox/kb/` comment doesn't fool us into skipping the append.
-func hasGitignoreLine(content, line string) bool {
-	for _, raw := range strings.Split(content, "\n") {
-		trimmed := strings.TrimSpace(raw)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-		if trimmed == line {
-			return true
-		}
-	}
-	return false
+	return nil
 }

--- a/internal/daemon/sync_symlinks_test.go
+++ b/internal/daemon/sync_symlinks_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
+	"github.com/sageox/ox/internal/sageoxignore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -255,37 +256,71 @@ func TestReconcileProjectSymlinks_FlatLayoutStrayFileSurvives(t *testing.T) {
 	assert.FileExists(t, filepath.Join(kbDir, "team", "platform"))
 }
 
-// TestEnsureProjectGitignoreEntry_Idempotent verifies that appending
-// the .sageox/kb/ gitignore line is a no-op when already present, and
-// never duplicates the entry.
+// sageoxGitignorePath returns <root>/.sageox/.gitignore, creating the
+// .sageox directory. In production the kb file lock already guarantees
+// .sageox/ exists before ensureProjectGitignoreEntry runs.
+func sageoxGitignorePath(t *testing.T, root string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".sageox"), 0o755))
+	return filepath.Join(root, ".sageox", ".gitignore")
+}
+
+// TestEnsureProjectGitignoreEntry_Idempotent verifies that appending the
+// kb/ ignore rule is a no-op when already present, and never duplicates
+// the entry.
 //
 // Failure prevented: every daemon tick appends the line again, growing
 // .gitignore unboundedly.
 func TestEnsureProjectGitignoreEntry_Idempotent(t *testing.T) {
 	root := t.TempDir()
+	path := sageoxGitignorePath(t, root)
 
 	// first call: file absent — must create with the line.
 	require.NoError(t, ensureProjectGitignoreEntry(root))
-	body, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	body, err := os.ReadFile(path)
 	require.NoError(t, err)
-	assert.Contains(t, string(body), projectGitignoreLine)
+	assert.Contains(t, string(body), sageoxignore.KBEntry)
 
 	// second call: file present with the line — must not change anything.
 	first := string(body)
 	require.NoError(t, ensureProjectGitignoreEntry(root))
-	body2, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	body2, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Equal(t, first, string(body2), "second call must be a true no-op")
 
 	// third call after an unrelated entry: must preserve existing entries
 	// and add ours exactly once.
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("node_modules/\n"), 0o644))
+	require.NoError(t, os.WriteFile(path, []byte("cache/\n"), 0o644))
 	require.NoError(t, ensureProjectGitignoreEntry(root))
-	body3, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	body3, err := os.ReadFile(path)
 	require.NoError(t, err)
 	s := string(body3)
-	assert.Contains(t, s, "node_modules/")
-	assert.Equal(t, 1, countOccurrences(s, projectGitignoreLine), "must add the line exactly once")
+	assert.Contains(t, s, "cache/")
+	assert.Equal(t, 1, countOccurrences(s, sageoxignore.KBEntry), "must add the line exactly once")
+}
+
+// TestEnsureProjectGitignoreEntry_NeverTouchesRootGitignore is the guard
+// against the GH #732 regression. The reconciler used to write
+// `.sageox/kb/` into the developer's root .gitignore; fixing only ox init
+// would have left the daemon to put it straight back on the next sync
+// pass, so this asserts the daemon never touches that file at all.
+func TestEnsureProjectGitignoreEntry_NeverTouchesRootGitignore(t *testing.T) {
+	root := t.TempDir()
+	sageoxGitignorePath(t, root)
+	rootGitignore := filepath.Join(root, ".gitignore")
+
+	// case 1: no root .gitignore — the daemon must not create one.
+	require.NoError(t, ensureProjectGitignoreEntry(root))
+	_, err := os.Stat(rootGitignore)
+	assert.True(t, os.IsNotExist(err), "daemon must not create the project's root .gitignore")
+
+	// case 2: a root .gitignore the developer owns — byte-identical after.
+	original := "# my rules\nnode_modules/\ndist/\n"
+	require.NoError(t, os.WriteFile(rootGitignore, []byte(original), 0o644))
+	require.NoError(t, ensureProjectGitignoreEntry(root))
+	got, err := os.ReadFile(rootGitignore)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got), "daemon must leave the root .gitignore byte-identical")
 }
 
 // countOccurrences counts non-overlapping occurrences of substr in s.
@@ -606,17 +641,18 @@ func TestReconcileProjectSymlinks_PerProjectFailureIsolation(t *testing.T) {
 // every daemon tick.
 func TestEnsureProjectGitignoreEntry_AlreadyContainsLine(t *testing.T) {
 	root := t.TempDir()
+	path := sageoxGitignorePath(t, root)
 
 	// pre-populate with the line, surrounded by other content + comments
-	preset := "# common deny list\nnode_modules/\n.sageox/kb/\nbuild/\n"
-	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte(preset), 0o644))
+	preset := "# ox-managed\ncache/\nkb/\nlogs/\n"
+	require.NoError(t, os.WriteFile(path, []byte(preset), 0o644))
 
 	require.NoError(t, ensureProjectGitignoreEntry(root))
 
-	got, err := os.ReadFile(filepath.Join(root, ".gitignore"))
+	got, err := os.ReadFile(path)
 	require.NoError(t, err)
-	assert.Equal(t, preset, string(got), "existing .sageox/kb/ entry must not be rewritten or duplicated")
-	assert.Equal(t, 1, countOccurrences(string(got), projectGitignoreLine), "exactly one occurrence")
+	assert.Equal(t, preset, string(got), "existing kb/ entry must not be rewritten or duplicated")
+	assert.Equal(t, 1, countOccurrences(string(got), sageoxignore.KBEntry), "exactly one occurrence")
 }
 
 // TestEnsureProjectGitignoreEntry_FileDoesNotExist verifies the
@@ -629,7 +665,7 @@ func TestEnsureProjectGitignoreEntry_AlreadyContainsLine(t *testing.T) {
 func TestEnsureProjectGitignoreEntry_FileDoesNotExist(t *testing.T) {
 	root := t.TempDir()
 
-	gitignorePath := filepath.Join(root, ".gitignore")
+	gitignorePath := sageoxGitignorePath(t, root)
 	_, err := os.Stat(gitignorePath)
 	require.True(t, os.IsNotExist(err), "precondition: .gitignore must not exist")
 
@@ -637,7 +673,7 @@ func TestEnsureProjectGitignoreEntry_FileDoesNotExist(t *testing.T) {
 
 	got, err := os.ReadFile(gitignorePath)
 	require.NoError(t, err)
-	assert.Equal(t, projectGitignoreLine+"\n", string(got), "file must be created with exactly one line")
+	assert.Equal(t, sageoxignore.KBEntry+"\n", string(got), "file must be created with exactly one line")
 }
 
 // TestReconcileProjectSymlinks_ManyBubblesScale exercises the reconciler

--- a/internal/sageoxignore/sageoxignore.go
+++ b/internal/sageoxignore/sageoxignore.go
@@ -1,0 +1,137 @@
+// Package sageoxignore owns the gitignore entries ox manages on a user's
+// behalf, and the minimal line-level primitives for maintaining them.
+//
+// It exists because the same three helpers used to live twice — once in
+// cmd/ox (package main, so nothing can import it) and once in
+// internal/daemon. That duplication is what let ox init and the daemon
+// disagree about where the knowledge-bubble ignore rule belongs, and is
+// the direct cause of GH #732: both wrote `.sageox/kb/` into the
+// developer's *root* .gitignore, and fixing only one writer left the
+// other to put it straight back on the next sync pass.
+//
+// The package deliberately depends on nothing but the standard library so
+// any layer of ox can import it.
+package sageoxignore
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// KBEntry is the ignore rule for daemon-materialized knowledge-bubble
+// symlinks, written into <project>/.sageox/.gitignore.
+//
+// Patterns in a nested .gitignore are relative to that file's own
+// directory, so `kb/` here covers exactly what `.sageox/kb/` covered
+// from the repo root — the same paths, without touching a file the
+// developer considers theirs.
+const KBEntry = "kb/"
+
+// LegacyRootKBLine is what ox used to append to the project's root
+// .gitignore before GH #732. Retained solely so existing installs can be
+// cleaned up; nothing writes it any more.
+const LegacyRootKBLine = ".sageox/kb/"
+
+// HasEntry reports whether content already lists entry as a live rule.
+//
+// Comment- and blank-aware, so a documentary `# .sageox/kb/` line is not
+// mistaken for the real thing. Matching is exact after trimming: `kb/`
+// does not match `kb`, `kb/*`, or `!kb/`. That strictness is deliberate —
+// see RemoveLine.
+func HasEntry(content, entry string) bool {
+	for _, raw := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if trimmed == entry {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureEntry appends entry to the .gitignore at path exactly once,
+// creating the file if it does not exist.
+//
+// Returns added=false when the entry was already present, so callers can
+// stay quiet on the common no-op pass. created reports whether the file
+// itself had to be made, which callers use to decide between "track as
+// created" and "track as modified" for rollback.
+func EnsureEntry(path, entry string) (added bool, created bool, err error) {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, false, fmt.Errorf("read %s: %w", path, err)
+		}
+		existing = nil
+		created = true
+	}
+	if HasEntry(string(existing), entry) {
+		return false, false, nil
+	}
+
+	var buf strings.Builder
+	buf.Write(existing)
+	// append on its own line even when the existing file lacked a
+	// trailing newline, or we'd silently corrupt the last rule.
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		buf.WriteString("\n")
+	}
+	buf.WriteString(entry)
+	buf.WriteString("\n")
+
+	if err := os.WriteFile(path, []byte(buf.String()), 0o644); err != nil {
+		return false, false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, created, nil
+}
+
+// RemoveLine deletes every occurrence of line from the .gitignore at
+// path, matching only on an exact trimmed match.
+//
+// The exactness is the whole safety argument for the #732 cleanup: this
+// removes `.sageox/kb/` and nothing else. It will not touch `.sageox/`,
+// `.sageox/kb`, `/.sageox/kb/`, `.sageox/kb/*`, `!.sageox/kb/`, or a
+// commented `# .sageox/kb/`. Comments, blank lines, ordering, and the
+// file's trailing-newline shape are all preserved — splitting and
+// rejoining on "\n" round-trips the terminal empty element.
+//
+// A missing file is not an error; it reports removed=false.
+func RemoveLine(path, line string) (removed bool, err error) {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	lines := strings.Split(string(existing), "\n")
+	kept := make([]string, 0, len(lines))
+	for _, raw := range lines {
+		if strings.TrimSpace(raw) == line {
+			removed = true
+			continue
+		}
+		kept = append(kept, raw)
+	}
+	if !removed {
+		return false, nil
+	}
+
+	out := strings.Join(kept, "\n")
+	// Terminate a non-empty result. Deleting an unterminated final line
+	// would otherwise strip the newline from the line now promoted to
+	// last — mutating a rule we were never asked to touch. An empty
+	// result stays empty rather than becoming a lone newline.
+	if out != "" && !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}

--- a/internal/sageoxignore/sageoxignore_test.go
+++ b/internal/sageoxignore/sageoxignore_test.go
@@ -1,0 +1,203 @@
+package sageoxignore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasEntry(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		entry   string
+		want    bool
+		why     string
+	}{
+		{"exact match", "kb/\n", "kb/", true, "the basic case"},
+		{"among others", "cache/\nkb/\nlogs/\n", "kb/", true, "position must not matter"},
+		{"leading whitespace", "  kb/\n", "kb/", true, "git trims, so must we"},
+		{"absent", "cache/\nlogs/\n", "kb/", false, "no false positive"},
+		{"empty content", "", "kb/", false, "a missing file must not read as present"},
+		{
+			"commented out", "# kb/\n", "kb/", false,
+			"a documentary comment is not a live rule — treating it as one would " +
+				"silently leave the directory tracked",
+		},
+		{
+			"substring only", "kb/foo\n", "kb/", false,
+			"prefix matching would make us skip writing a rule we actually need",
+		},
+		{"negation is a different rule", "!kb/\n", "kb/", false, "!kb/ re-includes; it is not kb/"},
+		{"no trailing newline", "cache/\nkb/", "kb/", true, "last line still counts"},
+		{"CRLF", "cache/\r\nkb/\r\n", "kb/", true, "Windows checkouts must not double-write the rule"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasEntry(tt.content, tt.entry), tt.why)
+		})
+	}
+}
+
+func TestEnsureEntry_CreatesFileWithExactlyTheEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".gitignore")
+
+	added, created, err := EnsureEntry(path, KBEntry)
+	require.NoError(t, err)
+	assert.True(t, added)
+	assert.True(t, created, "caller needs this to choose created-vs-modified for rollback")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "kb/\n", string(got), "must not emit a stray blank line or empty file")
+}
+
+func TestEnsureEntry_IsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("cache/\nkb/\nlogs/\n"), 0o644))
+
+	added, created, err := EnsureEntry(path, KBEntry)
+	require.NoError(t, err)
+	assert.False(t, added, "already present")
+	assert.False(t, created)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "cache/\nkb/\nlogs/\n", string(got),
+		"a no-op pass must leave the file byte-identical, or every daemon tick dirties the worktree")
+}
+
+func TestEnsureEntry_AppendsWithoutCorruptingAMissingTrailingNewline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("cache/\nlogs/"), 0o644))
+
+	added, _, err := EnsureEntry(path, KBEntry)
+	require.NoError(t, err)
+	assert.True(t, added)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "cache/\nlogs/\nkb/\n", string(got),
+		"appending to a file with no trailing newline must not produce `logs/kb/`")
+}
+
+// TestRemoveLine_OnlyExactMatches is the safety argument for the GH #732
+// cleanup, stated as assertions. Every "must survive" case below is a
+// rule that means something different from `.sageox/kb/`, so removing it
+// could start tracking a path the user expects to be ignored.
+func TestRemoveLine_OnlyExactMatches(t *testing.T) {
+	survivors := []struct {
+		line string
+		why  string
+	}{
+		{".sageox/", "ignores the entire .sageox directory — vastly broader"},
+		{".sageox", "same, without the slash"},
+		{"/.sageox/kb/", "anchored to the repo root — a different pattern"},
+		{".sageox/kb", "no trailing slash matches a *file* named kb too"},
+		{".sageox/kb/*", "contents-only; leaves the directory itself matchable"},
+		{"!.sageox/kb/", "a re-include; deleting it would flip the meaning"},
+		{"# .sageox/kb/", "a comment the user wrote for themselves"},
+		{".sageox/kbextra/", "different directory that merely shares a prefix"},
+	}
+
+	for _, s := range survivors {
+		t.Run(s.line, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".gitignore")
+			content := "node_modules/\n" + s.line + "\ndist/\n"
+			require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+			removed, err := RemoveLine(path, LegacyRootKBLine)
+			require.NoError(t, err)
+			assert.False(t, removed, "must not report a removal")
+
+			got, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, content, string(got), "must survive: "+s.why)
+		})
+	}
+}
+
+func TestRemoveLine_RemovesTheLegacyLineAndNothingElse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".gitignore")
+	content := "# build output\nnode_modules/\ndist/\n\n.sageox/kb/\n\n# editor\n.idea/\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	removed, err := RemoveLine(path, LegacyRootKBLine)
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "# build output\nnode_modules/\ndist/\n\n\n# editor\n.idea/\n", string(got),
+		"comments, blank lines, ordering and the trailing newline must all be preserved")
+}
+
+func TestRemoveLine_RemovesEveryOccurrence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".gitignore")
+	// a repo that ran several older ox versions could accumulate duplicates.
+	require.NoError(t, os.WriteFile(path, []byte(".sageox/kb/\nnode_modules/\n.sageox/kb/\n"), 0o644))
+
+	removed, err := RemoveLine(path, LegacyRootKBLine)
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "node_modules/\n", string(got), "a single pass must clear all duplicates")
+}
+
+func TestRemoveLine_PreservesFilesWithNoTrailingNewline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("node_modules/\n.sageox/kb/"), 0o644))
+
+	removed, err := RemoveLine(path, LegacyRootKBLine)
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "node_modules/\n", string(got),
+		"removing the final line must not leave a dangling separator")
+}
+
+func TestRemoveLine_MissingFileIsNotAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".gitignore")
+
+	removed, err := RemoveLine(path, LegacyRootKBLine)
+	require.NoError(t, err, "a repo with no .gitignore is the common case, not a failure")
+	assert.False(t, removed)
+
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr), "must not create the file it was asked to clean")
+}
+
+func TestRemoveLine_IsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".gitignore")
+	require.NoError(t, os.WriteFile(path, []byte("node_modules/\n.sageox/kb/\n"), 0o644))
+
+	removed, err := RemoveLine(path, LegacyRootKBLine)
+	require.NoError(t, err)
+	require.True(t, removed)
+	first, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	removed2, err := RemoveLine(path, LegacyRootKBLine)
+	require.NoError(t, err)
+	assert.False(t, removed2, "second pass has nothing to do")
+
+	second, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, string(first), string(second), "second pass must not rewrite the file")
+}
+
+// TestKBEntryAndLegacyLineDescribeTheSamePaths documents the equivalence
+// the whole #732 migration depends on: `kb/` inside .sageox/.gitignore
+// covers exactly what `.sageox/kb/` covered from the repo root, because
+// nested gitignore patterns resolve relative to their own directory.
+func TestKBEntryAndLegacyLineDescribeTheSamePaths(t *testing.T) {
+	assert.Equal(t, ".sageox/"+KBEntry, LegacyRootKBLine,
+		"if these ever diverge the cleanup stops being behavior-preserving and must be re-argued")
+}

--- a/pkg/adapterprotocol/fileswritten.go
+++ b/pkg/adapterprotocol/fileswritten.go
@@ -1,6 +1,9 @@
 package adapterprotocol
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // FilesWritten contract
 //
@@ -39,9 +42,15 @@ import "path/filepath"
 // RepoRelativePaths converts names that are relative to baseDir into
 // paths relative to repoRoot, satisfying the FilesWritten contract.
 //
-// baseDir may be absolute or relative to repoRoot. Any name that cannot
-// be expressed relative to repoRoot is returned unchanged as an absolute
-// path, which the contract also permits.
+// baseDir may be absolute or relative to repoRoot.
+//
+// A path that does not live under repoRoot is returned ABSOLUTE, not as a
+// `../..` traversal. Both forms are technically valid per the contract,
+// but the absolute form is unambiguous and survives being resolved from
+// any working directory — whereas a traversal only means the right thing
+// relative to repoRoot, and ox's staging boundary drops it either way
+// (git cannot stage a file outside the repo). User-scope installs like
+// ~/.codex/hooks.json are the real case here.
 func RepoRelativePaths(repoRoot, baseDir string, names []string) []string {
 	if !filepath.IsAbs(baseDir) {
 		baseDir = filepath.Join(repoRoot, baseDir)
@@ -52,11 +61,12 @@ func RepoRelativePaths(repoRoot, baseDir string, names []string) []string {
 		if !filepath.IsAbs(abs) {
 			abs = filepath.Join(baseDir, name)
 		}
-		if rel, err := filepath.Rel(repoRoot, abs); err == nil {
-			out = append(out, rel)
+		rel, err := filepath.Rel(repoRoot, abs)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			out = append(out, filepath.Clean(abs))
 			continue
 		}
-		out = append(out, abs)
+		out = append(out, rel)
 	}
 	return out
 }

--- a/pkg/adapterprotocol/fileswritten.go
+++ b/pkg/adapterprotocol/fileswritten.go
@@ -1,0 +1,62 @@
+package adapterprotocol
+
+import "path/filepath"
+
+// FilesWritten contract
+//
+// Every install-* response carries a FilesWritten list. ox stages those
+// paths into git so the files an adapter creates actually reach the
+// user's commit.
+//
+// # The contract
+//
+// Each entry MUST be either an absolute path, or a path relative to the
+// RepoRoot the adapter was given. Nothing else. In particular it must not
+// be relative to some intermediate directory the adapter happens to be
+// writing into (`.claude/skills/`, `.claude/rules/`), because ox has no
+// way to know what that directory was.
+//
+// ox normalizes and verifies every entry, and silently drops any that do
+// not resolve to an existing path inside the repo. A dropped entry is not
+// staged, so violating the contract means the adapter's files quietly
+// never get committed.
+//
+// # Why the rule exists
+//
+// GH #731: four in-tree adapters used four different conventions —
+// repo-relative, skills-dir-relative, rules-dir-relative, and absolute.
+// ox joined them all onto RepoRoot, producing paths like
+// `<root>/ox-plan/SKILL.md` that did not exist. `git add` validates every
+// pathspec up front and fails the whole invocation on the first bad one,
+// so a single malformed entry stopped ox from staging *anything* —
+// including the valid `.claude/settings.json`. On a fresh `ox init` that
+// meant the entire `.claude/` tree was created and then never committed.
+//
+// Adapters are separate binaries resolved at runtime, so ox cannot force
+// compliance; it defends at the boundary instead. Use RepoRelativePaths
+// below rather than hand-rolling the conversion.
+
+// RepoRelativePaths converts names that are relative to baseDir into
+// paths relative to repoRoot, satisfying the FilesWritten contract.
+//
+// baseDir may be absolute or relative to repoRoot. Any name that cannot
+// be expressed relative to repoRoot is returned unchanged as an absolute
+// path, which the contract also permits.
+func RepoRelativePaths(repoRoot, baseDir string, names []string) []string {
+	if !filepath.IsAbs(baseDir) {
+		baseDir = filepath.Join(repoRoot, baseDir)
+	}
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		abs := name
+		if !filepath.IsAbs(abs) {
+			abs = filepath.Join(baseDir, name)
+		}
+		if rel, err := filepath.Rel(repoRoot, abs); err == nil {
+			out = append(out, rel)
+			continue
+		}
+		out = append(out, abs)
+	}
+	return out
+}

--- a/pkg/adapterprotocol/fileswritten_test.go
+++ b/pkg/adapterprotocol/fileswritten_test.go
@@ -1,0 +1,86 @@
+package adapterprotocol
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepoRelativePaths(t *testing.T) {
+	repo := filepath.FromSlash("/tmp/repo")
+
+	tests := []struct {
+		name    string
+		baseDir string
+		names   []string
+		want    []string
+		why     string
+	}{
+		{
+			name:    "rules-dir-relative names become repo-relative",
+			baseDir: filepath.Join(repo, ".claude", "rules"),
+			names:   []string{"ox.md", filepath.FromSlash("sageox/use-team-context.md")},
+			want: []string{
+				filepath.FromSlash(".claude/rules/ox.md"),
+				filepath.FromSlash(".claude/rules/sageox/use-team-context.md"),
+			},
+			why: "this is the exact conversion agentx's rules manager needs (GH #731)",
+		},
+		{
+			name:    "skills-dir-relative names become repo-relative",
+			baseDir: filepath.Join(repo, ".claude", "skills"),
+			names:   []string{filepath.FromSlash("ox-plan/SKILL.md")},
+			want:    []string{filepath.FromSlash(".claude/skills/ox-plan/SKILL.md")},
+			why:     "reporting ox-plan/SKILL.md made ox look for it at the repo root",
+		},
+		{
+			name:    "already-absolute names are re-expressed, not re-joined",
+			baseDir: filepath.Join(repo, ".claude", "skills"),
+			names:   []string{filepath.Join(repo, ".claude", "settings.json")},
+			want:    []string{filepath.FromSlash(".claude/settings.json")},
+			why:     "an adapter mixing conventions in one list must still produce sane output",
+		},
+		{
+			name:    "relative baseDir is resolved against repoRoot",
+			baseDir: filepath.FromSlash(".claude/rules"),
+			names:   []string{"ox.md"},
+			want:    []string{filepath.FromSlash(".claude/rules/ox.md")},
+			why:     "callers should not have to pre-absolutize",
+		},
+		{
+			name:    "empty input yields empty output",
+			baseDir: filepath.Join(repo, ".claude"),
+			names:   nil,
+			want:    []string{},
+			why:     "an install that wrote nothing is normal, not an error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RepoRelativePaths(repo, tt.baseDir, tt.names), tt.why)
+		})
+	}
+}
+
+// TestRepoRelativePaths_OutsideRepoStaysAbsolute documents the escape
+// hatch: user-scope installs genuinely live outside the repo, and the
+// contract permits absolute paths. ox drops them at the staging boundary
+// rather than the adapter having to know it can't stage them.
+func TestRepoRelativePaths_OutsideRepoStaysAbsolute(t *testing.T) {
+	repo := filepath.FromSlash("/tmp/repo")
+	outside := filepath.FromSlash("/home/someone/.codex/hooks.json")
+
+	got := RepoRelativePaths(repo, filepath.Join(repo, ".codex"), []string{outside})
+
+	// filepath.Rel can express this as ../.., which is still a valid
+	// answer; what matters is that it round-trips back to the same file.
+	assert.Len(t, got, 1)
+	resolved := got[0]
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(repo, resolved)
+	}
+	assert.Equal(t, outside, filepath.Clean(resolved),
+		"the entry must still identify the same file, wherever it lives")
+}

--- a/pkg/adapterprotocol/fileswritten_test.go
+++ b/pkg/adapterprotocol/fileswritten_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepoRelativePaths(t *testing.T) {
@@ -66,21 +67,32 @@ func TestRepoRelativePaths(t *testing.T) {
 
 // TestRepoRelativePaths_OutsideRepoStaysAbsolute documents the escape
 // hatch: user-scope installs genuinely live outside the repo, and the
-// contract permits absolute paths. ox drops them at the staging boundary
-// rather than the adapter having to know it can't stage them.
+// contract permits absolute paths.
+//
+// It must stay ABSOLUTE rather than degrade to a `../..` traversal — the
+// absolute form is unambiguous from any working directory, while a
+// traversal only means the right thing relative to repoRoot.
 func TestRepoRelativePaths_OutsideRepoStaysAbsolute(t *testing.T) {
 	repo := filepath.FromSlash("/tmp/repo")
 	outside := filepath.FromSlash("/home/someone/.codex/hooks.json")
 
 	got := RepoRelativePaths(repo, filepath.Join(repo, ".codex"), []string{outside})
 
-	// filepath.Rel can express this as ../.., which is still a valid
-	// answer; what matters is that it round-trips back to the same file.
-	assert.Len(t, got, 1)
-	resolved := got[0]
-	if !filepath.IsAbs(resolved) {
-		resolved = filepath.Join(repo, resolved)
-	}
-	assert.Equal(t, outside, filepath.Clean(resolved),
-		"the entry must still identify the same file, wherever it lives")
+	require.Len(t, got, 1)
+	assert.True(t, filepath.IsAbs(got[0]), "must not become a ../.. traversal; got %q", got[0])
+	assert.Equal(t, outside, got[0])
+}
+
+// TestRepoRelativePaths_SiblingOfRepoStaysAbsolute covers the near-miss:
+// a path that shares a parent with the repo resolves to a short `../x`
+// traversal, which is exactly the case a naive filepath.Rel accepts.
+func TestRepoRelativePaths_SiblingOfRepoStaysAbsolute(t *testing.T) {
+	repo := filepath.FromSlash("/tmp/repo")
+	sibling := filepath.FromSlash("/tmp/other/hooks.json")
+
+	got := RepoRelativePaths(repo, repo, []string{sibling})
+
+	require.Len(t, got, 1)
+	assert.True(t, filepath.IsAbs(got[0]), "got %q", got[0])
+	assert.Equal(t, sibling, got[0])
 }

--- a/pkg/adapterprotocol/types.go
+++ b/pkg/adapterprotocol/types.go
@@ -89,7 +89,11 @@ type HookParams struct {
 
 // InstallHooksResponse is returned by `install-hooks`.
 type InstallHooksResponse struct {
-	Installed    bool     `json:"installed"`
+	Installed bool `json:"installed"`
+	// FilesWritten lists the files this install wrote. Each entry MUST be
+	// absolute or relative to RepoRoot — see the contract in
+	// fileswritten.go. Entries that don't resolve inside the repo are
+	// dropped by ox and never staged.
 	FilesWritten []string `json:"files_written"`
 	Hooks        []string `json:"hooks"`
 }
@@ -115,7 +119,11 @@ type RulesParams struct {
 
 // InstallRulesResponse is returned by `install-rules`.
 type InstallRulesResponse struct {
-	Installed    bool     `json:"installed"`
+	Installed bool `json:"installed"`
+	// FilesWritten lists the files this install wrote. Each entry MUST be
+	// absolute or relative to RepoRoot — see the contract in
+	// fileswritten.go. Entries that don't resolve inside the repo are
+	// dropped by ox and never staged.
 	FilesWritten []string `json:"files_written"`
 }
 
@@ -141,7 +149,11 @@ type CommandsParams struct {
 
 // InstallCommandsResponse is returned by `install-commands`.
 type InstallCommandsResponse struct {
-	Installed    bool     `json:"installed"`
+	Installed bool `json:"installed"`
+	// FilesWritten lists the files this install wrote. Each entry MUST be
+	// absolute or relative to RepoRoot — see the contract in
+	// fileswritten.go. Entries that don't resolve inside the repo are
+	// dropped by ox and never staged.
 	FilesWritten []string `json:"files_written"`
 }
 
@@ -168,7 +180,11 @@ type SkillsParams struct {
 
 // InstallSkillsResponse is returned by `install-skills`.
 type InstallSkillsResponse struct {
-	Installed    bool     `json:"installed"`
+	Installed bool `json:"installed"`
+	// FilesWritten lists the files this install wrote. Each entry MUST be
+	// absolute or relative to RepoRoot — see the contract in
+	// fileswritten.go. Entries that don't resolve inside the repo are
+	// dropped by ox and never staged.
 	FilesWritten []string `json:"files_written"`
 }
 


### PR DESCRIPTION
Fixes #732. Fixes #731.

Two bugs with one theme: **`ox init` writing into a developer's repo in ways they didn't sanction and can't see** — an unwanted line in their root `.gitignore`, and a whole `.claude/` tree created but never staged.

---

## #732 — the kb ignore rule moves out of the root `.gitignore`

`ox init` appended `.sageox/kb/` to the repo's **root** `.gitignore`. It now lives in `.sageox/.gitignore` as `kb/` — a file ox already owns, writes, and commits.

**The trap: there were two writers.** Fixing only `ox init` would have been worthless, because the daemon re-adds the line on every knowledge-bubble sync pass.

```mermaid
flowchart LR
  I["ox init"] -->|"appended .sageox/kb/"| R["root .gitignore"]
  D["daemon kb sync"] -->|"re-added it every pass"| R
  I -->|"now writes kb/"| S[".sageox/.gitignore"]
  D -->|"now writes kb/"| S
```

- **Both writers moved.** `cmd/ox/init.go` and `internal/daemon/sync_symlinks.go`.
- **New `internal/sageoxignore` package.** `cmd/ox` is `package main`, so it and `internal/daemon` physically could not share helpers — that duplication is *why* the two writers were able to disagree.
- **The daemon writer carried a comment justifying root placement** as deliberate ("the bead spec is explicit... keeps the rule visible to humans browsing the repo from the top"). That decision is being reversed, and the comment now says so and cites the issue.
- **Existing installs self-heal for free** — `kb/` is now in `requiredGitignoreEntries`, which already flows through `mergeGitignoreEntries` on both re-init and `ox doctor --fix`.

### Cleaning up already-polluted repos

- **Behavior-preserving by construction.** Removal is gated on `kb/` being verifiably present in `.sageox/.gitignore` first. Nested gitignore patterns resolve relative to their own directory, so `kb/` covers exactly what `.sageox/kb/` covered from the root. Under that gate, **not one previously-ignored path becomes tracked.**
- **Exact-match only.** `.sageox/`, `.sageox/kb` (no slash), `/.sageox/kb/`, `!.sageox/kb/`, `.sageox/kb/*` and a commented `# .sageox/kb/` are all left alone. Verified on this repo: `git check-ignore` still resolves `.sageox/kb/`, now via `.sageox/.gitignore:25`.
- **`ox init` removes it; `ox doctor` removes it only with `--fix`** (registered `FixLevelSuggested`, so a bare `ox doctor` warns rather than edits). Deliberately not `FixLevelAuto`, which would apply on a plain `ox doctor` with no flag — silently editing a developer's root `.gitignore` unprompted is the exact complaint that opened this issue, and the fix shouldn't repeat it.

---

## #731 — `.claude/**` was created but never committed

**Root cause, confirmed empirically: one malformed pathspec makes the entire `git add` fail, staging nothing.**

```console
$ git add --force -- .claude/settings.json ox-plan/SKILL.md
fatal: pathspec 'ox-plan/SKILL.md' did not match any files
$ git diff --cached --name-only
                       # ← nothing. Not even the valid file.
```

`installAgentHooks` aggregates `FilesWritten` from every adapter, and adapters used **four mutually incompatible path conventions**:

| Source | Reported | After `filepath.Join(gitRoot, …)` |
|---|---|---|
| built-in Claude hooks | `.claude/settings.json` (repo-rel) | correct |
| claude-code commands | repo-rel via `filepath.Rel` | correct |
| claude-code **skills** | `ox-plan/SKILL.md` (skills-dir-rel) | `<root>/ox-plan/SKILL.md` — **does not exist** |
| claude-code / droid **rules** | `ox.md` (rules-dir-rel) | `<root>/ox.md` — **does not exist** |
| codex / droid / gemini / … hooks | absolute | `<root><root>/.codex/hooks.json` |

git validates every pathspec up front and fails the whole invocation on the first bad one. Claude Code is selected by default on a fresh init and its adapter ships by default, so **this fired on essentially every fresh init.** The failure was invisible because the staging helpers discarded git's stderr behind a generic warning.

### Fixed at all three layers — all three are needed

- **Adapters now emit repo-relative paths.** Without this, skills and rules are *dropped* rather than staged. New `adapterprotocol.RepoRelativePaths` helper, and the `FilesWritten` contract is now documented on all four response types.
- **`normalizeAdapterFilesWritten` defends at the init boundary.** Adapters are separate binaries resolved from disk at runtime, so a stale or third-party one can always violate the contract — a contract you can't enforce at the boundary is a comment. Normalizes to absolute, verifies containment and existence, logs every drop. No path guessing: dropping loudly beats guessing wrongly.
- **Staging degrades instead of collapsing.** Try the batch; on failure retry each path individually so one bad entry can never zero the rest. Plus `cmd.Dir`, captured stderr, and `--` separator.

### Also fixed

`stageAll` only ever staged `AGENTS.md`/`CLAUDE.md`, so a **Gemini, Cursor, Windsurf, Copilot, Kiro or Cline user's ox-modified instruction file was never staged either.** Now covers every detected instruction file.

---

## Test Plan

- **The assertion that was missing entirely:** run init in a temp git repo, assert `git diff --cached --name-only` contains `.claude/settings.json`. Nothing in this package asserted anything about the git index before.
- **`TestStageAll_OneBadPathDoesNotZeroTheBatch`** — red before, green after.
- **`TestEnsureProjectGitignoreEntry_NeverTouchesRootGitignore`** — guards against "you only fixed init and the daemon put it back".
- **`RemoveLine` safety suite** — eight "must survive" cases, one per pattern that means something different from `.sageox/kb/`.
- Fixed a real bug found by my own test: `RemoveLine` was stripping the trailing newline from a line it wasn't asked to touch.
- Four adapter tests were **codifying the bug** (asserting the broken `ox.md` convention); they now assert the contract.
- `make lint` clean; `cmd/ox`, `internal/daemon`, `internal/sageoxignore`, `pkg/adapterprotocol` all green.

## Reviewer notes

- `pkg/adapterprotocol` is a **public** package — the `FilesWritten` doc is a contract third-party adapter authors will rely on.
- The `.sageox/.gitignore` relocation reverses a previously-documented decision; worth an explicit nod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization staging reliability with safer path handling, clearer failures, and dependable rollback.
  * Corrected reported paths for installed rules and skills.
  * Prevented invalid, duplicate, or outside-repository files from being staged.

* **New Features**
  * Added health checks and automatic cleanup for legacy knowledge-bubble ignore entries.
  * Knowledge-bubble files are now consistently ignored in project-specific configuration.

* **Documentation**
  * Updated synchronization documentation to reflect the new ignore-file behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
