### PR TITLE
fix(#710): stop stripping meta.json; treat content-store stubs as unreadable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,28 @@ check-no-git-lfs-shell: ## Ensure no code shells out to git-lfs binary (see .cla
 		exit 1; \
 	fi
 
+check-session-meta-rmw: ## Ensure sessions/*/meta.json is only rewritten via lfs.MutateSessionMeta (ox-q42i, GH #710)
+	@# Rebuilding meta.json from a builder, or reading/marshalling it without
+	@# the flock, silently drops every field the writer doesn't set —
+	@# summary_status, validation_error, summary_attempts, redactions,
+	@# produced_commits, linked_prs, linkage_status. Because the ledger
+	@# auto-resolves sessions/ conflicts to the LOCAL side, that stripping
+	@# then propagates to origin and erases the fields for the whole team.
+	@#
+	@# ALLOWLIST below = the remaining ox-q42i sites, each a first-write or
+	@# an interactive single-writer path. Do not add to it without closing
+	@# that ticket's reasoning; the correct fix is lfs.MutateSessionMeta.
+	@violations=$$(grep -rnE 'lfs\.WriteSessionMeta(Only)?\(' --include='*.go' . 2>/dev/null \
+		| grep -v '_test\.go:' | grep -v 'vendor/' \
+		| grep -vE ':[0-9]+:[[:space:]]*//' \
+		| grep -vE '^\./(cmd/ox/agent_session\.go|cmd/ox/agent_session_recover\.go|cmd/ox/session_regenerate\.go|cmd/ox/session_upload_cmd\.go|cmd/ox/session_repair_meta_summary\.go|cmd/ox/session_push_summary\.go):'); \
+	if [ -n "$$violations" ]; then \
+		echo "$$violations"; \
+		echo "ERROR: rewrite sessions/*/meta.json via lfs.MutateSessionMeta, not WriteSessionMeta[Only]."; \
+		echo "       A fresh-built or unlocked write drops fields it does not set (GH #710, ox-q42i)."; \
+		exit 1; \
+	fi
+
 sync-gitleaks-rules: ## Regenerate the gitleaks-derived detector catalog from a pinned gitleaks.toml
 	@echo "Regenerating internal/session/gitleaks_generated.go..."
 	@cd internal/session/cmd/gitleaks-port && go run . \
@@ -206,7 +228,7 @@ check-raw-writer-chokepoint: ## Ensure raw.jsonl is only opened via session.RawW
 		exit 1; \
 	fi
 
-test-preflight: check-no-git-lfs-shell check-raw-writer-chokepoint ## Pre-PR quality gate: lint + all unit tests + slow tests (lint/test-all/test-slow run concurrently)
+test-preflight: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw ## Pre-PR quality gate: lint + all unit tests + slow tests (lint/test-all/test-slow run concurrently)
 	$(call say,"Running lint, full tests, and slow tests concurrently...")
 	@# lint and the test binaries don't share any output file (test-all writes
 	@# coverage.out; test-slow and lint don't touch it), so running them

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Makefile for ox CLI tool
 
+.PHONY: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw
 .PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-all test-slow test-integration test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version beads-setup
 
 # Variables
@@ -176,7 +177,15 @@ check-session-meta-rmw: ## Ensure sessions/*/meta.json is only rewritten via lfs
 	@# ALLOWLIST below = the remaining ox-q42i sites, each a first-write or
 	@# an interactive single-writer path. Do not add to it without closing
 	@# that ticket's reasoning; the correct fix is lfs.MutateSessionMeta.
-	@violations=$$(grep -rnE 'lfs\.WriteSessionMeta(Only)?\(' --include='*.go' . 2>/dev/null \
+	@# Fail CLOSED on a scanner error: grep exits 0 (match), 1 (no match —
+	@# the healthy case), or >1 (real error). Swallowing >1 would turn a
+	@# broken scan into a silent pass, which is worse than no guard at all.
+	@raw=$$(grep -rnE 'lfs\.WriteSessionMeta(Only)?\(' --include='*.go' .); rc=$$?; \
+	if [ $$rc -gt 1 ]; then \
+		echo "ERROR: check-session-meta-rmw scan failed (grep exit $$rc) — refusing to report success"; \
+		exit 1; \
+	fi; \
+	violations=$$(printf '%s\n' "$$raw" | grep -v '^$$' \
 		| grep -v '_test\.go:' | grep -v 'vendor/' \
 		| grep -vE ':[0-9]+:[[:space:]]*//' \
 		| grep -vE '^\./(cmd/ox/agent_session\.go|cmd/ox/agent_session_recover\.go|cmd/ox/session_regenerate\.go|cmd/ox/session_upload_cmd\.go|cmd/ox/session_repair_meta_summary\.go|cmd/ox/session_push_summary\.go):'); \

--- a/cmd/ox/doctor_session.go
+++ b/cmd/ox/doctor_session.go
@@ -29,6 +29,15 @@ func checkSessionHealth(opts doctorOptions) []checkResult {
 		results = append(results, uploadRetryResult)
 	}
 
+	// transcripts stranded in the content store with no local copy (GH #710).
+	// Quiet on the overwhelmingly common healthy case — dehydration is the
+	// normal steady state, so only surface sessions that actually need
+	// their transcript and cannot get it.
+	dehydratedResult := checkSessionDehydrated(opts.shouldFix(CheckSlugSessionDehydrated))
+	if !dehydratedResult.passed || dehydratedResult.warning {
+		results = append(results, dehydratedResult)
+	}
+
 	// create session checks from internal/doctor package
 	checks := []doctor.Check{
 		doctor.NewSessionModeCheck(gitRoot),   // show effective mode and source

--- a/cmd/ox/doctor_session.go
+++ b/cmd/ox/doctor_session.go
@@ -33,8 +33,11 @@ func checkSessionHealth(opts doctorOptions) []checkResult {
 	// Quiet on the overwhelmingly common healthy case — dehydration is the
 	// normal steady state, so only surface sessions that actually need
 	// their transcript and cannot get it.
+	// Only surface a real finding: a skipped result (no ledger, no sessions
+	// dir) has passed=false too, and including it would put a permanent
+	// "skipped" line in doctor output for every user without a ledger.
 	dehydratedResult := checkSessionDehydrated(opts.shouldFix(CheckSlugSessionDehydrated))
-	if !dehydratedResult.passed || dehydratedResult.warning {
+	if !dehydratedResult.skipped && (!dehydratedResult.passed || dehydratedResult.warning) {
 		results = append(results, dehydratedResult)
 	}
 

--- a/cmd/ox/doctor_session_dehydrated.go
+++ b/cmd/ox/doctor_session_dehydrated.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/pkg/sessionsummary"
+)
+
+// dehydratedFixBudget caps how many sessions one `ox doctor --fix` run
+// will download. Hydration is real network I/O against the content store
+// and transcripts are large — the GH #710 reporter's manual recovery
+// pulled 159 MB. A bounded pass that says "run again for more" is far
+// better than an unbounded one nobody expected.
+const dehydratedFixBudget = 20
+
+const dehydratedCheckName = "session content"
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:     CheckSlugSessionDehydrated,
+		Name:     dehydratedCheckName,
+		Category: "Sessions",
+		// Suggested, not Auto: the fix does network I/O and can pull
+		// hundreds of MB. Auto-fix runs on a bare `ox doctor`, and nobody
+		// expects that to start downloading.
+		FixLevel:    FixLevelSuggested,
+		Description: "Detects sessions whose transcript has no local copy and cannot be summarized",
+		Run:         checkSessionDehydrated,
+	})
+}
+
+// dehydratedSession is one session that needs its transcript but has no
+// local copy.
+type dehydratedSession struct {
+	Name string
+	Dir  string
+	// Reason explains why hydration is not possible right now. Empty
+	// means "not attempted yet".
+	Reason string
+	// Permanent is true when the transcript was never uploaded, so no
+	// amount of retrying will produce it.
+	Permanent bool
+}
+
+// checkSessionDehydrated reports sessions whose raw.jsonl is a
+// content-store pointer with no local copy AND which still need
+// summarizing.
+//
+// # Why this is not "git-lfs is not installed"
+//
+// GH #710 was filed as "undetected git-lfs misconfiguration", on the
+// theory that an uninstalled git-lfs binary left transcripts as
+// unsmudged pointers. That diagnosis is wrong, and acting on it would
+// violate .claude/rules/lfs-no-git-lfs-binary.md.
+//
+// ox ledgers ship no .gitattributes at all, so git's LFS filters never
+// apply to them. The pointer files are ox's own, written by
+// lfs.WritePointerFile, and ledger clones are DEHYDRATED BY DESIGN —
+// content lives in the store and is fetched on demand over the Batch API
+// in pure Go. The reporter's workaround (install git-lfs, hand-write
+// .git/info/attributes, git lfs fetch) appeared to work only because ox
+// uploads to the same store, and it is actively dangerous: by their own
+// account it also converts data/plans/*.md into pointers on the daemon's
+// next commit, corrupting the ledger for every teammate.
+//
+// So the real defect is not a missing binary. It is that ox read a stub
+// as if it were a transcript, produced an empty summary, and retried
+// forever. This check detects that content state directly.
+//
+// # Why the failing condition is narrow
+//
+// Dehydration is the normal steady state. A healthy ledger can hold
+// thousands of dehydrated sessions and be perfectly fine. Reporting that
+// as a problem would be noise that trains people to ignore doctor. So a
+// session only fails when ALL THREE hold:
+//
+//  1. raw.jsonl is a pointer stub, AND
+//  2. there is no hydrated copy in the ledger cache, AND
+//  3. it still needs summarizing (no title, or a non-terminal summary status).
+//
+// A dehydrated session that already has a good summary needs nothing.
+func checkSessionDehydrated(fix bool) checkResult {
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(dehydratedCheckName, "no ledger found", "")
+	}
+
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return SkippedCheck(dehydratedCheckName, "no sessions directory", "")
+	}
+
+	var stranded []dehydratedSession
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		sessionDir := filepath.Join(sessionsDir, entry.Name())
+		if !sessionNeedsHydration(sessionDir, ledgerPath, entry.Name()) {
+			continue
+		}
+		stranded = append(stranded, dehydratedSession{Name: entry.Name(), Dir: sessionDir})
+	}
+
+	if len(stranded) == 0 {
+		return PassedCheck(dehydratedCheckName, "all sessions readable")
+	}
+
+	if !fix {
+		return dehydratedWarning(stranded, nil)
+	}
+	return hydrateStrandedSessions(stranded, ledgerPath)
+}
+
+// sessionNeedsHydration applies the three-part failing condition.
+func sessionNeedsHydration(sessionDir, ledgerPath, sessionName string) bool {
+	rawPath := filepath.Join(sessionDir, "raw.jsonl")
+	if !lfs.IsPointerFile(rawPath) {
+		return false // real content on disk, or no raw.jsonl at all
+	}
+
+	// a hydrated copy in the cache means the daemon can already read it
+	cachePath := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName, "raw.jsonl")
+	if info, err := os.Stat(cachePath); err == nil && info.Size() > 0 {
+		return false
+	}
+
+	meta, err := lfs.ReadSessionMeta(sessionDir)
+	if err != nil {
+		return false // unreadable meta is a different check's problem
+	}
+	return summaryStillNeeded(meta)
+}
+
+// summaryStillNeeded reports whether a session is still waiting on a
+// usable summary. Terminal states are excluded: retrying them is exactly
+// the loop GH #710 was about.
+func summaryStillNeeded(meta *lfs.SessionMeta) bool {
+	if meta.SummaryStatus == sessionsummary.SummaryStatusUnrecoverable {
+		return false
+	}
+	if strings.TrimSpace(meta.Title) != "" {
+		return false // already has something a human can read
+	}
+	switch meta.SummaryStatus {
+	case "", sessionsummary.SummaryStatusPending, sessionsummary.SummaryStatusFailedValidation:
+		return true
+	default:
+		return false
+	}
+}
+
+// hydrateStrandedSessions downloads transcripts into the ledger cache,
+// bounded by dehydratedFixBudget.
+//
+// Hydration is CACHE-ONLY. Writing content over the git-tracked
+// sessions/<name>/raw.jsonl would break LFS linkage on the next commit
+// and every subsequent push — see .claude/rules/cache-only-design.md.
+// lfs.HydrateRawToCacheErr already enforces this.
+func hydrateStrandedSessions(stranded []dehydratedSession, ledgerPath string) checkResult {
+	projectRoot := findGitRoot()
+	client, err := lfs.NewClientFromLedger(ledgerPath, endpoint.GetForProject(projectRoot))
+	if err != nil {
+		return dehydratedWarning(stranded, fmt.Errorf("cannot reach the content store: %w", err))
+	}
+
+	budget := min(len(stranded), dehydratedFixBudget)
+
+	var recovered int
+	var remaining []dehydratedSession
+	for i, s := range stranded {
+		if i >= budget {
+			remaining = append(remaining, s)
+			continue
+		}
+		_, hydrateErr := lfs.HydrateRawToCacheErr(client, s.Dir, ledgerPath)
+		if hydrateErr == nil {
+			recovered++
+			continue
+		}
+
+		s.Reason = hydrateErr.Error()
+		s.Permanent = errors.Is(hydrateErr, lfs.ErrNoLFSManifest)
+		if s.Permanent {
+			// The transcript was never uploaded. Mark it terminal so the
+			// daemon stops retrying and this check stops reporting it —
+			// otherwise it is flagged forever with no possible remedy.
+			markSessionUnrecoverable(s.Dir)
+			continue
+		}
+		remaining = append(remaining, s)
+	}
+
+	if len(remaining) == 0 {
+		return PassedCheck(dehydratedCheckName, fmt.Sprintf("downloaded %d session transcript(s)", recovered))
+	}
+	return dehydratedWarning(remaining, nil)
+}
+
+// markSessionUnrecoverable records that a session's transcript is gone.
+// Goes through MutateSessionMeta so it cannot strip the other fields —
+// see GH #710 and `make check-session-meta-rmw`.
+func markSessionUnrecoverable(sessionDir string) {
+	_ = lfs.MutateSessionMeta(context.Background(), sessionDir, func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+		if current == nil {
+			return nil, nil
+		}
+		current.SummaryStatus = sessionsummary.SummaryStatusUnrecoverable
+		current.SummaryAttempts = lfs.MaxSummaryAttempts
+		// Ops-facing only; never rendered as a title or summary.
+		current.ValidationError = "transcript was never uploaded to the content store; nothing to summarize"
+		return current, nil
+	})
+}
+
+// dehydratedWarning renders the user-facing result.
+//
+// LOAD-BEARING: none of this text may mention git-lfs, `git lfs`,
+// .gitattributes, or filter=lfs. Ledger clones are dehydrated by design
+// and the remedy is an ox command, never a git-lfs one. Sending someone
+// down the git-lfs path is what turned GH #710 from an empty summary into
+// a corrupted shared ledger. Asserted in doctor_session_dehydrated_test.go.
+func dehydratedWarning(stranded []dehydratedSession, clientErr error) checkResult {
+	var sb strings.Builder
+	sb.WriteString("Session transcripts live in the ledger content store; clones are content-free by design.\n")
+	if clientErr != nil {
+		sb.WriteString(clientErr.Error())
+		sb.WriteString("\n")
+	}
+
+	shown := min(len(stranded), 5)
+	for _, s := range stranded[:shown] {
+		if s.Reason != "" {
+			fmt.Fprintf(&sb, "  %s — %s\n", s.Name, s.Reason)
+			continue
+		}
+		fmt.Fprintf(&sb, "  %s\n", s.Name)
+	}
+	if len(stranded) > shown {
+		fmt.Fprintf(&sb, "  ... and %d more\n", len(stranded)-shown)
+	}
+
+	sb.WriteString("\nRun `ox doctor --fix` to download them, ")
+	sb.WriteString("or `ox session download <name>` for one.")
+
+	return checkResult{
+		name:    dehydratedCheckName,
+		warning: true,
+		message: fmt.Sprintf("%d transcript(s) not available locally", len(stranded)),
+		detail:  sb.String(),
+	}
+}

--- a/cmd/ox/doctor_session_dehydrated.go
+++ b/cmd/ox/doctor_session_dehydrated.go
@@ -175,7 +175,7 @@ func hydrateStrandedSessions(stranded []dehydratedSession, ledgerPath string) ch
 	budget := min(len(stranded), dehydratedFixBudget)
 
 	var recovered int
-	var remaining []dehydratedSession
+	var remaining, lost []dehydratedSession
 	for i, s := range stranded {
 		if i >= budget {
 			remaining = append(remaining, s)
@@ -193,23 +193,61 @@ func hydrateStrandedSessions(stranded []dehydratedSession, ledgerPath string) ch
 			// The transcript was never uploaded. Mark it terminal so the
 			// daemon stops retrying and this check stops reporting it —
 			// otherwise it is flagged forever with no possible remedy.
-			markSessionUnrecoverable(s.Dir)
+			if err := markSessionUnrecoverable(s.Dir); err != nil {
+				// couldn't record the terminal state, so it is NOT settled:
+				// report it rather than claiming a clean pass.
+				s.Reason = fmt.Sprintf("%s (and could not mark it unrecoverable: %v)", s.Reason, err)
+				remaining = append(remaining, s)
+				continue
+			}
+			lost = append(lost, s)
 			continue
 		}
 		remaining = append(remaining, s)
 	}
 
-	if len(remaining) == 0 {
-		return PassedCheck(dehydratedCheckName, fmt.Sprintf("downloaded %d session transcript(s)", recovered))
+	if len(remaining) > 0 {
+		return dehydratedWarning(remaining, nil)
 	}
-	return dehydratedWarning(remaining, nil)
+	if len(lost) > 0 {
+		// Permanently gone is NOT a clean pass — the user has sessions whose
+		// transcripts no longer exist anywhere, and silently reporting
+		// success would hide that. They are marked terminal so this is a
+		// one-time report, not a recurring nag.
+		return dehydratedPermanentLoss(lost, recovered)
+	}
+	return PassedCheck(dehydratedCheckName, fmt.Sprintf("downloaded %d session transcript(s)", recovered))
+}
+
+// dehydratedPermanentLoss reports sessions whose transcript was never
+// uploaded and therefore cannot be recovered by anyone.
+func dehydratedPermanentLoss(lost []dehydratedSession, recovered int) checkResult {
+	var sb strings.Builder
+	sb.WriteString("These sessions have no transcript in the content store — it was never uploaded, ")
+	sb.WriteString("so it cannot be recovered. They are now marked unrecoverable and will not be retried.\n")
+	shown := min(len(lost), 5)
+	for _, s := range lost[:shown] {
+		fmt.Fprintf(&sb, "  %s\n", s.Name)
+	}
+	if len(lost) > shown {
+		fmt.Fprintf(&sb, "  ... and %d more\n", len(lost)-shown)
+	}
+	if recovered > 0 {
+		fmt.Fprintf(&sb, "\nRecovered %d other session transcript(s) in this run.", recovered)
+	}
+	return checkResult{
+		name:    dehydratedCheckName,
+		warning: true,
+		message: fmt.Sprintf("%d transcript(s) permanently unavailable", len(lost)),
+		detail:  sb.String(),
+	}
 }
 
 // markSessionUnrecoverable records that a session's transcript is gone.
 // Goes through MutateSessionMeta so it cannot strip the other fields —
 // see GH #710 and `make check-session-meta-rmw`.
-func markSessionUnrecoverable(sessionDir string) {
-	_ = lfs.MutateSessionMeta(context.Background(), sessionDir, func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+func markSessionUnrecoverable(sessionDir string) error {
+	return lfs.MutateSessionMeta(context.Background(), sessionDir, func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
 		if current == nil {
 			return nil, nil
 		}

--- a/cmd/ox/doctor_session_dehydrated.go
+++ b/cmd/ox/doctor_session_dehydrated.go
@@ -115,7 +115,7 @@ func checkSessionDehydrated(fix bool) checkResult {
 	}
 
 	if !fix {
-		return dehydratedWarning(stranded, nil)
+		return dehydratedWarning(stranded, nil, nil)
 	}
 	return hydrateStrandedSessions(stranded, ledgerPath)
 }
@@ -169,7 +169,7 @@ func hydrateStrandedSessions(stranded []dehydratedSession, ledgerPath string) ch
 	projectRoot := findGitRoot()
 	client, err := lfs.NewClientFromLedger(ledgerPath, endpoint.GetForProject(projectRoot))
 	if err != nil {
-		return dehydratedWarning(stranded, fmt.Errorf("cannot reach the content store: %w", err))
+		return dehydratedWarning(stranded, nil, fmt.Errorf("cannot reach the content store: %w", err))
 	}
 
 	budget := min(len(stranded), dehydratedFixBudget)
@@ -206,8 +206,12 @@ func hydrateStrandedSessions(stranded []dehydratedSession, ledgerPath string) ch
 		remaining = append(remaining, s)
 	}
 
+	// Permanent loss must be reported on the SAME pass it is detected.
+	// Marking those sessions terminal means they will never be collected
+	// again, so returning only the retryable warning here would drop the
+	// loss report on the floor permanently.
 	if len(remaining) > 0 {
-		return dehydratedWarning(remaining, nil)
+		return dehydratedWarning(remaining, lost, nil)
 	}
 	if len(lost) > 0 {
 		// Permanently gone is NOT a clean pass — the user has sessions whose
@@ -266,7 +270,7 @@ func markSessionUnrecoverable(sessionDir string) error {
 // and the remedy is an ox command, never a git-lfs one. Sending someone
 // down the git-lfs path is what turned GH #710 from an empty summary into
 // a corrupted shared ledger. Asserted in doctor_session_dehydrated_test.go.
-func dehydratedWarning(stranded []dehydratedSession, clientErr error) checkResult {
+func dehydratedWarning(stranded, lost []dehydratedSession, clientErr error) checkResult {
 	var sb strings.Builder
 	sb.WriteString("Session transcripts live in the ledger content store; clones are content-free by design.\n")
 	if clientErr != nil {
@@ -289,10 +293,27 @@ func dehydratedWarning(stranded []dehydratedSession, clientErr error) checkResul
 	sb.WriteString("\nRun `ox doctor --fix` to download them, ")
 	sb.WriteString("or `ox session download <name>` for one.")
 
+	// Fold in any permanently-lost sessions. They are marked terminal, so
+	// this is the only pass that will ever collect them — reporting the
+	// retryable ones alone would drop the loss report for good.
+	msg := fmt.Sprintf("%d transcript(s) not available locally", len(stranded))
+	if len(lost) > 0 {
+		fmt.Fprintf(&sb, "\n\n%d further transcript(s) were never uploaded and cannot be recovered; "+
+			"they are now marked unrecoverable:\n", len(lost))
+		lostShown := min(len(lost), 5)
+		for _, s := range lost[:lostShown] {
+			fmt.Fprintf(&sb, "  %s\n", s.Name)
+		}
+		if len(lost) > lostShown {
+			fmt.Fprintf(&sb, "  ... and %d more\n", len(lost)-lostShown)
+		}
+		msg = fmt.Sprintf("%d not available locally, %d permanently lost", len(stranded), len(lost))
+	}
+
 	return checkResult{
 		name:    dehydratedCheckName,
 		warning: true,
-		message: fmt.Sprintf("%d transcript(s) not available locally", len(stranded)),
+		message: msg,
 		detail:  sb.String(),
 	}
 }

--- a/cmd/ox/doctor_session_dehydrated_test.go
+++ b/cmd/ox/doctor_session_dehydrated_test.go
@@ -1,0 +1,215 @@
+//go:build !short
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/pkg/sessionsummary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- GH #710 D1 (reframed): stranded transcripts ---
+//
+// The issue was filed as "undetected git-lfs misconfiguration". That
+// diagnosis is wrong: ox ledgers ship no .gitattributes, so git's LFS
+// filters never touch them, and the pointer files are ox's own — ledger
+// clones are dehydrated BY DESIGN. The real defect is that ox read a stub
+// as a transcript and looped. This check detects that content state.
+
+// dehydratedLedger builds a ledger with one session, returning its dir.
+func dehydratedLedger(t *testing.T, name string) (ledgerPath, sessionDir string) {
+	t.Helper()
+	ledgerPath = t.TempDir()
+	sessionDir = filepath.Join(ledgerPath, "sessions", name)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	return ledgerPath, sessionDir
+}
+
+func writeStubbedSession(t *testing.T, sessionDir, name string, meta *lfs.SessionMeta) {
+	t.Helper()
+	require.NoError(t, lfs.WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"),
+		lfs.FileRef{OID: "sha256:abc123", Size: 4242}))
+	if meta == nil {
+		meta = lfs.NewSessionMeta(name, "testuser", "a1", "claude-code", time.Now().UTC()).Build()
+	}
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, meta))
+}
+
+func TestSessionNeedsHydration(t *testing.T) {
+	name := "2026-05-01T20-04-testuser-OxDHY"
+
+	t.Run("stranded stub needing a summary", func(t *testing.T) {
+		ledgerPath, sessionDir := dehydratedLedger(t, name)
+		writeStubbedSession(t, sessionDir, name, nil)
+		assert.True(t, sessionNeedsHydration(sessionDir, ledgerPath, name))
+	})
+
+	t.Run("dehydrated but already summarized", func(t *testing.T) {
+		ledgerPath, sessionDir := dehydratedLedger(t, name)
+		meta := lfs.NewSessionMeta(name, "testuser", "a1", "claude-code", time.Now().UTC()).Build()
+		meta.Title = "A perfectly good title"
+		writeStubbedSession(t, sessionDir, name, meta)
+
+		assert.False(t, sessionNeedsHydration(sessionDir, ledgerPath, name),
+			"dehydration is the NORMAL state — a session with a good summary needs nothing, "+
+				"and flagging it would make doctor noisy enough to ignore")
+	})
+
+	t.Run("terminal status is not retried", func(t *testing.T) {
+		ledgerPath, sessionDir := dehydratedLedger(t, name)
+		meta := lfs.NewSessionMeta(name, "testuser", "a1", "claude-code", time.Now().UTC()).Build()
+		meta.SummaryStatus = sessionsummary.SummaryStatusUnrecoverable
+		writeStubbedSession(t, sessionDir, name, meta)
+
+		assert.False(t, sessionNeedsHydration(sessionDir, ledgerPath, name),
+			"re-reporting a terminal session forever is the loop this issue is about")
+	})
+
+	t.Run("hydrated copy in cache", func(t *testing.T) {
+		ledgerPath, sessionDir := dehydratedLedger(t, name)
+		writeStubbedSession(t, sessionDir, name, nil)
+
+		cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", name)
+		require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"),
+			[]byte("header\ncontent\n"), 0o644))
+
+		assert.False(t, sessionNeedsHydration(sessionDir, ledgerPath, name),
+			"the daemon can already read the cached copy")
+	})
+
+	t.Run("real content on disk", func(t *testing.T) {
+		ledgerPath, sessionDir := dehydratedLedger(t, name)
+		require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"),
+			[]byte("header\ncontent\n"), 0o644))
+		meta := lfs.NewSessionMeta(name, "testuser", "a1", "claude-code", time.Now().UTC()).Build()
+		require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, meta))
+
+		assert.False(t, sessionNeedsHydration(sessionDir, ledgerPath, name))
+	})
+}
+
+func TestSummaryStillNeeded(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		title  string
+		want   bool
+		why    string
+	}{
+		{"never summarized", "", "", true, "the ordinary pending case"},
+		{"pending", sessionsummary.SummaryStatusPending, "", true, "in flight, still needs content"},
+		{"failed validation", sessionsummary.SummaryStatusFailedValidation, "", true, "retryable"},
+		{"unrecoverable", sessionsummary.SummaryStatusUnrecoverable, "", false, "terminal by definition"},
+		{"has a title", "", "Something readable", false, "a human can already read this"},
+		{"ok", sessionsummary.SummaryStatusOK, "Title", false, "done"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := &lfs.SessionMeta{SummaryStatus: tt.status, Title: tt.title}
+			assert.Equal(t, tt.want, summaryStillNeeded(meta), tt.why)
+		})
+	}
+}
+
+// TestDehydratedWarning_NeverMentionsGitLFS is the cheapest durable
+// enforcement of .claude/rules/lfs-no-git-lfs-binary.md at the boundary
+// where it actually matters: the text a human reads and acts on.
+//
+// The #710 reporter followed the git-lfs trail and, by their own account,
+// their workaround would convert data/plans/*.md into pointers on the
+// daemon's next commit — corrupting the ledger for every teammate. ox
+// must never send anyone down that path.
+func TestDehydratedWarning_NeverMentionsGitLFS(t *testing.T) {
+	stranded := []dehydratedSession{
+		{Name: "2026-05-01T20-04-testuser-OxDHY", Reason: "connection refused"},
+		{Name: "2026-05-02T09-11-testuser-OxDH2", Reason: "unauthorized"},
+	}
+
+	result := dehydratedWarning(stranded, fmt.Errorf("boom"))
+	full := result.name + " " + result.message + " " + result.detail
+
+	for _, banned := range []string{"git-lfs", "git lfs", ".gitattributes", "filter=lfs", "install git"} {
+		assert.NotContains(t, strings.ToLower(full), strings.ToLower(banned),
+			"remediation must never mention %q — ox implements LFS in pure Go and "+
+				"ledger clones are dehydrated by design", banned)
+	}
+
+	assert.Contains(t, result.detail, "ox doctor --fix", "must give the actual remedy")
+	assert.Contains(t, result.detail, "ox session download", "and the single-session escape hatch")
+}
+
+func TestDehydratedWarning_TruncatesLongLists(t *testing.T) {
+	var stranded []dehydratedSession
+	for i := range 12 {
+		stranded = append(stranded, dehydratedSession{Name: fmt.Sprintf("session-%02d", i)})
+	}
+
+	result := dehydratedWarning(stranded, nil)
+
+	assert.Contains(t, result.message, "12")
+	assert.Contains(t, result.detail, "and 7 more", "long lists must be truncated, not dumped")
+	assert.NotContains(t, result.detail, "session-11")
+}
+
+// TestCheckSessionDehydrated_QuietOnHealthyLedger — a ledger full of
+// properly summarized dehydrated sessions is the common case and must
+// produce no output at all.
+func TestCheckSessionDehydrated_QuietOnHealthyLedger(t *testing.T) {
+	ledgerPath := t.TempDir()
+	for i := range 50 {
+		name := fmt.Sprintf("2026-05-01T20-%02d-testuser-OxOK%02d", i, i)
+		sessionDir := filepath.Join(ledgerPath, "sessions", name)
+		require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+		meta := lfs.NewSessionMeta(name, "testuser", "a1", "claude-code", time.Now().UTC()).Build()
+		meta.Title = "Summarized just fine"
+		writeStubbedSession(t, sessionDir, name, meta)
+	}
+
+	var stranded []dehydratedSession
+	entries, err := os.ReadDir(filepath.Join(ledgerPath, "sessions"))
+	require.NoError(t, err)
+	for _, e := range entries {
+		if sessionNeedsHydration(filepath.Join(ledgerPath, "sessions", e.Name()), ledgerPath, e.Name()) {
+			stranded = append(stranded, dehydratedSession{Name: e.Name()})
+		}
+	}
+
+	assert.Empty(t, stranded,
+		"50 dehydrated-but-summarized sessions is a healthy ledger, not 50 problems")
+}
+
+// TestMarkSessionUnrecoverable_PreservesOtherFields ties D1 back to D3:
+// the terminal marking must go through the RMW primitive, or the fix for
+// one half of #710 would reintroduce the other half.
+func TestMarkSessionUnrecoverable_PreservesOtherFields(t *testing.T) {
+	sessionDir := t.TempDir()
+	name := "2026-05-01T20-04-testuser-OxMARK"
+
+	meta := lfs.NewSessionMeta(name, "testuser", "a1", "claude-code", time.Now().UTC()).Build()
+	meta.RepoID = "repo-xyz"
+	meta.ProducedCommits = []string{"abc123"}
+	meta.LinkedPRs = []string{"sageox/ox#710"}
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, meta))
+
+	markSessionUnrecoverable(sessionDir)
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, sessionsummary.SummaryStatusUnrecoverable, got.SummaryStatus)
+	assert.Equal(t, lfs.MaxSummaryAttempts, got.SummaryAttempts,
+		"both gates must be set — shouldRetryEmptySummary checks status AND attempts")
+	assert.Equal(t, "repo-xyz", got.RepoID, "must not strip unowned fields (GH #710 D3)")
+	assert.Equal(t, []string{"abc123"}, got.ProducedCommits)
+	assert.Equal(t, []string{"sageox/ox#710"}, got.LinkedPRs)
+	assert.False(t, lfs.IsLeakySummaryString(got.ValidationError),
+		"the diagnostic must pass the leak validator or WriteSessionMetaOnly rejects it")
+}

--- a/cmd/ox/doctor_session_dehydrated_test.go
+++ b/cmd/ox/doctor_session_dehydrated_test.go
@@ -134,7 +134,7 @@ func TestDehydratedWarning_NeverMentionsGitLFS(t *testing.T) {
 		{Name: "2026-05-02T09-11-testuser-OxDH2", Reason: "unauthorized"},
 	}
 
-	result := dehydratedWarning(stranded, fmt.Errorf("boom"))
+	result := dehydratedWarning(stranded, nil, fmt.Errorf("boom"))
 	full := result.name + " " + result.message + " " + result.detail
 
 	for _, banned := range []string{"git-lfs", "git lfs", ".gitattributes", "filter=lfs", "install git"} {
@@ -153,7 +153,7 @@ func TestDehydratedWarning_TruncatesLongLists(t *testing.T) {
 		stranded = append(stranded, dehydratedSession{Name: fmt.Sprintf("session-%02d", i)})
 	}
 
-	result := dehydratedWarning(stranded, nil)
+	result := dehydratedWarning(stranded, nil, nil)
 
 	assert.Contains(t, result.message, "12")
 	assert.Contains(t, result.detail, "and 7 more", "long lists must be truncated, not dumped")
@@ -248,4 +248,23 @@ func TestMarkSessionUnrecoverable_ReportsFailure(t *testing.T) {
 	// which must not be reported as an error either.
 	require.NoError(t, markSessionUnrecoverable(t.TempDir()),
 		"a session with no meta.json is a no-op, not a failure")
+}
+
+// TestDehydratedWarning_ReportsLostAlongsideRetryable — permanently-lost
+// sessions are marked terminal, so the pass that detects them is the ONLY
+// pass that will ever collect them. Reporting just the retryable ones
+// would drop the loss report on the floor for good.
+func TestDehydratedWarning_ReportsLostAlongsideRetryable(t *testing.T) {
+	retryable := []dehydratedSession{{Name: "2026-05-01T20-04-testuser-OxRETRY", Reason: "connection refused"}}
+	lost := []dehydratedSession{{Name: "2026-05-01T20-04-testuser-OxGONE", Permanent: true}}
+
+	result := dehydratedWarning(retryable, lost, nil)
+
+	assert.True(t, result.warning)
+	assert.Contains(t, result.detail, "OxRETRY", "the retryable one is still reported")
+	assert.Contains(t, result.detail, "OxGONE",
+		"the permanently-lost one must be reported on this same pass — it is marked "+
+			"terminal, so no later run will collect it")
+	assert.Contains(t, result.detail, "cannot be recovered")
+	assert.Contains(t, result.message, "permanently lost", "the headline must say both counts")
 }

--- a/cmd/ox/doctor_session_dehydrated_test.go
+++ b/cmd/ox/doctor_session_dehydrated_test.go
@@ -160,10 +160,12 @@ func TestDehydratedWarning_TruncatesLongLists(t *testing.T) {
 	assert.NotContains(t, result.detail, "session-11")
 }
 
-// TestCheckSessionDehydrated_QuietOnHealthyLedger — a ledger full of
-// properly summarized dehydrated sessions is the common case and must
-// produce no output at all.
-func TestCheckSessionDehydrated_QuietOnHealthyLedger(t *testing.T) {
+// TestSessionNeedsHydration_QuietOnHealthyLedger — a ledger full of
+// properly summarized dehydrated sessions is the common case, and none of
+// them may be flagged. Exercises the per-session predicate across a whole
+// ledger rather than checkSessionDehydrated itself, which needs a resolved
+// ledger path and a live content-store client.
+func TestSessionNeedsHydration_QuietOnHealthyLedger(t *testing.T) {
 	ledgerPath := t.TempDir()
 	for i := range 50 {
 		name := fmt.Sprintf("2026-05-01T20-%02d-testuser-OxOK%02d", i, i)
@@ -212,4 +214,38 @@ func TestMarkSessionUnrecoverable_PreservesOtherFields(t *testing.T) {
 	assert.Equal(t, []string{"sageox/ox#710"}, got.LinkedPRs)
 	assert.False(t, lfs.IsLeakySummaryString(got.ValidationError),
 		"the diagnostic must pass the leak validator or WriteSessionMetaOnly rejects it")
+}
+
+// TestDehydratedPermanentLoss_IsNotAPass — a session whose transcript was
+// never uploaded is gone for good. Reporting that as "downloaded 0
+// transcripts, all good" would hide real data loss behind a green check.
+func TestDehydratedPermanentLoss_IsNotAPass(t *testing.T) {
+	lost := []dehydratedSession{
+		{Name: "2026-05-01T20-04-testuser-OxGONE", Permanent: true},
+	}
+
+	result := dehydratedPermanentLoss(lost, 3)
+
+	assert.True(t, result.warning, "permanent loss must surface, not pass silently")
+	assert.False(t, result.passed)
+	assert.Contains(t, result.message, "permanently unavailable")
+	assert.Contains(t, result.detail, "OxGONE", "name the affected sessions")
+	assert.Contains(t, result.detail, "will not be retried",
+		"say it is terminal so this reads as a one-time report, not a recurring nag")
+	assert.Contains(t, result.detail, "Recovered 3", "still credit what did succeed")
+
+	full := result.name + result.message + result.detail
+	for _, banned := range []string{"git-lfs", "git lfs", ".gitattributes"} {
+		assert.NotContains(t, strings.ToLower(full), banned)
+	}
+}
+
+// TestMarkSessionUnrecoverable_ReportsFailure — the caller decides
+// between "settled" and "still broken" based on this error, so swallowing
+// it would let a session be reported as resolved when nothing was written.
+func TestMarkSessionUnrecoverable_ReportsFailure(t *testing.T) {
+	// no meta.json on disk: the mutator returns nil (nothing to write),
+	// which must not be reported as an error either.
+	require.NoError(t, markSessionUnrecoverable(t.TempDir()),
+		"a session with no meta.json is a no-op, not a failure")
 }

--- a/cmd/ox/doctor_session_dehydrated_test.go
+++ b/cmd/ox/doctor_session_dehydrated_test.go
@@ -266,5 +266,9 @@ func TestDehydratedWarning_ReportsLostAlongsideRetryable(t *testing.T) {
 		"the permanently-lost one must be reported on this same pass — it is marked "+
 			"terminal, so no later run will collect it")
 	assert.Contains(t, result.detail, "cannot be recovered")
-	assert.Contains(t, result.message, "permanently lost", "the headline must say both counts")
+	// Assert BOTH counts with their numbers. Checking only the "permanently
+	// lost" phrase would still pass if the retryable count — or either
+	// number — were dropped from the headline.
+	assert.Contains(t, result.message, "1 not available locally")
+	assert.Contains(t, result.message, "1 permanently lost")
 }

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -399,6 +399,16 @@ func writeRetryUploadMeta(
 	sessionID string,
 	fileRefs map[string]lfs.FileRef,
 ) (*lfs.SessionMeta, error) {
+	// Meta carries the raw.jsonl header fields this function reads.
+	// findOrphanedSessions never produces a nil one, but the guard belongs
+	// here rather than at the top of retrySessionUpload: an earlier check
+	// would preempt the more specific "raw.jsonl validation failed"
+	// diagnostic for a corrupt session, which is the case that actually
+	// produces a nil Meta.
+	if orphan.Meta == nil {
+		return nil, fmt.Errorf("session %s has no header metadata; cannot rebuild meta.json", orphan.SessionName)
+	}
+
 	var meta *lfs.SessionMeta
 	if err := lfs.MutateSessionMeta(context.Background(), sessionDir, func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
 		next := current

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,7 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 )
@@ -338,16 +341,9 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 		return fmt.Errorf("LFS upload: %w", err)
 	}
 
-	// build and write meta.json; use WriteSessionMetaOnly so content files
-	// remain intact until after the push (pointer stubs + no remote = unrecoverable)
-	metaBuilder := sessionMetaBase(orphan.SessionName, orphan.Meta.Username, orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt, projectRoot, sessionID).
-		Model(orphan.Meta.Model).
-		EntryCount(orphan.EntryCount).
-		StopReason(session.StopReasonRecovered).
-		WithFiles(fileRefs)
-	meta := metaBuilder.Build()
-	if err := lfs.WriteSessionMetaOnly(sessionDir, meta); err != nil {
-		return fmt.Errorf("write meta.json: %w", err)
+	meta, err := writeRetryUploadMeta(sessionDir, projectRoot, orphan, sessionID, fileRefs)
+	if err != nil {
+		return err
 	}
 
 	// ensure .gitignore
@@ -375,6 +371,74 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 	}
 
 	return nil
+}
+
+// writeRetryUploadMeta records a retry-upload's results into meta.json,
+// updating only the fields this path owns and preserving everything else.
+//
+// Uses WriteSessionMetaOnly semantics (via MutateSessionMeta) so content
+// files stay intact until after the push — pointer stubs with no remote
+// would be unrecoverable.
+//
+// # Why read-modify-write and not a fresh builder (GH #710)
+//
+// This used to rebuild meta.json from sessionMetaBase(...).Build(), which
+// never sets summary_status, validation_error or summary_attempts. All
+// three are `omitempty`, so they did not merely go stale — they vanished
+// from the file. `ox doctor: auto-commit ledger changes` then committed
+// the stripped version while origin still carried the fields, and both
+// sides had edited the same lines. That is the exact conflict hunk the
+// #710 reporter pasted, reproducing on the same 6 files on every single
+// rebase until their ledger could no longer push at all.
+//
+// The same applies to redactions (an audit record), produced_commits,
+// produced_plans, linked_prs, linked_issues and linkage_status.
+func writeRetryUploadMeta(
+	sessionDir, projectRoot string,
+	orphan orphanedSession,
+	sessionID string,
+	fileRefs map[string]lfs.FileRef,
+) (*lfs.SessionMeta, error) {
+	var meta *lfs.SessionMeta
+	if err := lfs.MutateSessionMeta(context.Background(), sessionDir, func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+		next := current
+		if next == nil {
+			// first write for this session — nothing on disk to preserve.
+			next = sessionMetaBase(orphan.SessionName, orphan.Meta.Username,
+				orphan.Meta.AgentID, orphan.Meta.AgentType, orphan.Meta.CreatedAt,
+				projectRoot, sessionID).Build()
+		} else {
+			// identity fields are backfilled only when absent: a value
+			// already on disk was resolved when more context was available
+			// than a doctor sweep has.
+			if next.UserID == "" {
+				next.UserID = auth.GetUserID(endpoint.GetForProject(projectRoot))
+			}
+			if next.RepoID == "" {
+				next.RepoID = getRepoIDOrDefault(projectRoot)
+			}
+		}
+		// sessionID is already resolved by resolveOrphanSessionID, which
+		// prefers a preserved meta.json id over minting a new one — so it
+		// is authoritative and never rotates across retries.
+		next.SessionID = sessionID
+
+		// fields this retry actually owns
+		next.Model = orphan.Meta.Model
+		next.EntryCount = orphan.EntryCount
+		next.Files = fileRefs
+		// preserve-if-set: don't stomp a real terminal stop reason with the
+		// generic "recovered" just because doctor re-uploaded the content.
+		if next.StopReason == "" {
+			next.StopReason = session.StopReasonRecovered
+		}
+
+		meta = next
+		return next, nil
+	}); err != nil {
+		return nil, fmt.Errorf("write meta.json: %w", err)
+	}
+	return meta, nil
 }
 
 // validateRawJSONLHeader checks that raw.jsonl has a valid header line with a metadata key.

--- a/cmd/ox/doctor_session_upload_retry_preserve_test.go
+++ b/cmd/ox/doctor_session_upload_retry_preserve_test.go
@@ -198,3 +198,15 @@ func TestWriteRetryUploadMeta_HonorsResolvedSessionID(t *testing.T) {
 	assert.Equal(t, testSessionID, second.SessionID,
 		"session_id must be stable across retries")
 }
+
+// TestWriteRetryUploadMeta_NilMetaIsAnErrorNotAPanic — a corrupt raw.jsonl
+// yields an orphan with no header metadata. Dereferencing it would panic
+// inside a doctor sweep, taking down the whole run over one bad session.
+func TestWriteRetryUploadMeta_NilMetaIsAnErrorNotAPanic(t *testing.T) {
+	orphan := orphanedSession{SessionName: "2026-05-01T20-04-testuser-OxNIL", Meta: nil}
+
+	_, err := writeRetryUploadMeta(t.TempDir(), t.TempDir(), orphan, testSessionID, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no header metadata")
+}

--- a/cmd/ox/doctor_session_upload_retry_preserve_test.go
+++ b/cmd/ox/doctor_session_upload_retry_preserve_test.go
@@ -1,0 +1,200 @@
+//go:build !short
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- GH #710 D3: doctor's retry upload must not strip meta.json ---
+//
+// This is the half of #710 the reporter actually saw. Their conflict was:
+//
+//	<<<<<<< HEAD
+//	  "summary_status": "failed_validation",
+//	  "validation_error": "content validation failed: title too short (0 chars, minimum 3)",
+//	  "summary_attempts": 2,
+//	=======
+//	>>>>>>> <sha> (ox doctor: auto-commit ledger changes)
+//
+// The "theirs" side is empty because the retry-upload path rebuilt
+// meta.json from a builder that never sets those three fields. All are
+// `omitempty`, so they didn't go stale — they disappeared. doctor's
+// auto-commit then committed the stripped file, both sides had edited the
+// same lines, and every `git pull --rebase` conflicted identically until
+// the ledger was 40 ahead / 41 behind and could not push.
+
+// testSessionID stands in for the value resolveOrphanSessionID produces
+// in production — already resolved (preferring a preserved meta.json id)
+// before writeRetryUploadMeta is called.
+const testSessionID = "ses_019c0000-0000-7000-8000-0000000000ff"
+
+func retryOrphan(name string) orphanedSession {
+	return orphanedSession{
+		SessionName: name,
+		Meta: &session.StoreMeta{
+			AgentID:   "OxRTRY",
+			AgentType: "claude-code",
+			Username:  "testuser",
+			Model:     "claude-opus-4",
+		},
+		EntryCount: 7,
+	}
+}
+
+// TestWriteRetryUploadMeta_PreservesSummaryFailureFields is the literal
+// reproduction of the reported conflict, as an assertion.
+func TestWriteRetryUploadMeta_PreservesSummaryFailureFields(t *testing.T) {
+	sessionDir := t.TempDir()
+	name := "2026-05-01T20-04-testuser-OxRTRY"
+
+	seeded := lfs.NewSessionMeta(name, "testuser", "OxRTRY", "claude-code", time.Now().UTC()).Build()
+	seeded.SummaryStatus = "failed_validation"
+	seeded.ValidationError = "content validation failed: title too short (0 chars, minimum 3)"
+	seeded.SummaryAttempts = 2
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, seeded))
+
+	_, err := writeRetryUploadMeta(sessionDir, t.TempDir(), retryOrphan(name), testSessionID, nil)
+	require.NoError(t, err)
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, "failed_validation", got.SummaryStatus,
+		"summary_status must survive — dropping it is what produced the rebase conflict")
+	assert.Equal(t, seeded.ValidationError, got.ValidationError, "validation_error must survive")
+	assert.Equal(t, 2, got.SummaryAttempts,
+		"summary_attempts must survive, or the retry cap silently re-arms as well")
+}
+
+// TestWriteRetryUploadMeta_PreservesUnownedFields covers the whole class,
+// not just the three fields that happened to appear in the report.
+func TestWriteRetryUploadMeta_PreservesUnownedFields(t *testing.T) {
+	sessionDir := t.TempDir()
+	name := "2026-05-01T20-04-testuser-OxRTR2"
+
+	seeded := lfs.NewSessionMeta(name, "testuser", "OxRTR2", "claude-code", time.Now().UTC()).Build()
+	seeded.Title = "A real summary title"
+	seeded.Summary = "A real summary body that a previous successful finalize produced."
+	seeded.Redactions = []lfs.RedactionPass{{
+		PassID:    "019c0000-0000-7000-8000-0000000000bb",
+		AppliedAt: time.Now().UTC(),
+		AppliedBy: "ox session redact-history",
+	}}
+	seeded.ProducedCommits = []string{"deadbeefcafe"}
+	seeded.ProducedPlans = []string{"2026-05-01-a-plan"}
+	seeded.LinkedPRs = []string{"sageox/ox#710"}
+	seeded.LinkedIssues = []string{"sageox/ox#732"}
+	seeded.LinkageStatus = lfs.LinkageStatusNotified
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, seeded))
+
+	_, err := writeRetryUploadMeta(sessionDir, t.TempDir(), retryOrphan(name), testSessionID, nil)
+	require.NoError(t, err)
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, seeded.Title, got.Title,
+		"a re-upload must not blank a summary somebody already produced")
+	assert.Equal(t, seeded.Summary, got.Summary)
+	require.Len(t, got.Redactions, 1, "redaction audit history must survive a re-upload")
+	assert.Equal(t, seeded.ProducedCommits, got.ProducedCommits)
+	assert.Equal(t, seeded.ProducedPlans, got.ProducedPlans)
+	assert.Equal(t, seeded.LinkedPRs, got.LinkedPRs)
+	assert.Equal(t, seeded.LinkedIssues, got.LinkedIssues)
+	assert.Equal(t, seeded.LinkageStatus, got.LinkageStatus)
+}
+
+// TestWriteRetryUploadMeta_UpdatesOwnedFields proves the preservation
+// isn't achieved by simply doing nothing.
+func TestWriteRetryUploadMeta_UpdatesOwnedFields(t *testing.T) {
+	sessionDir := t.TempDir()
+	name := "2026-05-01T20-04-testuser-OxRTR3"
+
+	seeded := lfs.NewSessionMeta(name, "testuser", "OxRTR3", "claude-code", time.Now().UTC()).Build()
+	seeded.EntryCount = 1
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, seeded))
+
+	refs := map[string]lfs.FileRef{
+		"raw.jsonl": {Storage: lfs.StorageLFS, OID: "sha256:abc", Size: 1234},
+	}
+	_, err := writeRetryUploadMeta(sessionDir, t.TempDir(), retryOrphan(name), testSessionID, refs)
+	require.NoError(t, err)
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, 7, got.EntryCount, "entry_count is owned by this path and must be updated")
+	assert.Equal(t, "claude-opus-4", got.Model, "model is owned by this path")
+	require.Contains(t, got.Files, "raw.jsonl", "the LFS refs are the whole point of the retry")
+	assert.Equal(t, "sha256:abc", got.Files["raw.jsonl"].OID)
+}
+
+// TestWriteRetryUploadMeta_PreservesTerminalStopReason — doctor
+// re-uploading content says nothing about why the session ended.
+func TestWriteRetryUploadMeta_PreservesTerminalStopReason(t *testing.T) {
+	sessionDir := t.TempDir()
+	name := "2026-05-01T20-04-testuser-OxRTR4"
+
+	seeded := lfs.NewSessionMeta(name, "testuser", "OxRTR4", "claude-code", time.Now().UTC()).Build()
+	seeded.StopReason = "rate_limited"
+	seeded.StopDetail = "5-hour limit reached"
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, seeded))
+
+	_, err := writeRetryUploadMeta(sessionDir, t.TempDir(), retryOrphan(name), testSessionID, nil)
+	require.NoError(t, err)
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, "rate_limited", got.StopReason)
+	assert.Equal(t, "5-hour limit reached", got.StopDetail)
+}
+
+// TestWriteRetryUploadMeta_SeedsFreshMetaWhenAbsent — the genuinely-new
+// orphan case, where there is nothing to preserve. Must still produce a
+// usable meta.json rather than erroring or writing an empty one.
+func TestWriteRetryUploadMeta_SeedsFreshMetaWhenAbsent(t *testing.T) {
+	sessionDir := t.TempDir()
+	name := "2026-05-01T20-04-testuser-OxRTR5"
+
+	require.NoFileExists(t, filepath.Join(sessionDir, "meta.json"))
+
+	_, err := writeRetryUploadMeta(sessionDir, t.TempDir(), retryOrphan(name), testSessionID, nil)
+	require.NoError(t, err)
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, name, got.SessionName)
+	assert.Equal(t, "claude-code", got.AgentType)
+	assert.Equal(t, 7, got.EntryCount)
+	assert.Equal(t, session.StopReasonRecovered, got.StopReason,
+		"a session with no recorded stop reason gets the fallback")
+	assert.NotEmpty(t, got.SessionID, "a fresh meta must still carry a durable session id")
+}
+
+// TestWriteRetryUploadMeta_HonorsResolvedSessionID — identity comes from
+// resolveOrphanSessionID (which prefers a preserved meta.json id), and a
+// retry must write exactly that. A rotated id breaks every conversation
+// URL circulated while the session was live.
+func TestWriteRetryUploadMeta_HonorsResolvedSessionID(t *testing.T) {
+	sessionDir := t.TempDir()
+	name := "2026-05-01T20-04-testuser-OxRTR6"
+
+	_, err := writeRetryUploadMeta(sessionDir, t.TempDir(), retryOrphan(name), testSessionID, nil)
+	require.NoError(t, err)
+	first, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, testSessionID, first.SessionID)
+
+	_, err = writeRetryUploadMeta(sessionDir, t.TempDir(), retryOrphan(name), testSessionID, nil)
+	require.NoError(t, err)
+	second, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, testSessionID, second.SessionID,
+		"session_id must be stable across retries")
+}

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -172,6 +172,7 @@ const (
 	CheckSlugSessionUncommitted = "session-uncommitted"
 	CheckSlugSessionOrphaned    = "session-orphaned"
 	CheckSlugSessionManifest    = "session-manifest"
+	CheckSlugSessionDehydrated  = "session-dehydrated"
 	// CheckSlugSessionIDDivergence is co-located with its impl in
 	// doctor_session_id_divergence.go to keep the check + its detect-only
 	// rationale self-contained (mirrors CheckSlugSessionIDsBackfilled).

--- a/cmd/ox/session_upload_cmd.go
+++ b/cmd/ox/session_upload_cmd.go
@@ -90,7 +90,9 @@ Example:
 		case session.RawPointerStub:
 			return fmt.Errorf("session %s is already uploaded — its content lives in the ledger content store, "+
 				"not on disk. Run `ox session download %s` if you need a local copy", sessionName, sessionName)
-		case session.RawMissing, session.RawHeaderOnly:
+		case session.RawMissing:
+			return fmt.Errorf("session %s has no readable %s — nothing to upload", sessionName, ledgerFileRaw)
+		case session.RawHeaderOnly:
 			return fmt.Errorf("session %s has no substantive entries (only metadata header) — nothing to upload", sessionName)
 		case session.RawSubstantive:
 			// ok to upload

--- a/cmd/ox/session_upload_cmd.go
+++ b/cmd/ox/session_upload_cmd.go
@@ -82,9 +82,18 @@ Example:
 			return fmt.Errorf("build meta.json: %w", err)
 		}
 
-		// guard: never upload a session with zero substantive entries
-		if !session.HasSubstantiveEntries(rawPath) {
+		// guard: never upload a session with zero substantive entries.
+		// A pointer stub gets its own message — telling someone their
+		// already-uploaded session "has no substantive entries" is actively
+		// misleading, since the transcript exists and is simply not local.
+		switch session.ClassifyRawFile(rawPath) {
+		case session.RawPointerStub:
+			return fmt.Errorf("session %s is already uploaded — its content lives in the ledger content store, "+
+				"not on disk. Run `ox session download %s` if you need a local copy", sessionName, sessionName)
+		case session.RawMissing, session.RawHeaderOnly:
 			return fmt.Errorf("session %s has no substantive entries (only metadata header) — nothing to upload", sessionName)
+		case session.RawSubstantive:
+			// ok to upload
 		}
 
 		if err := lfs.WriteSessionMeta(sessionPath, meta); err != nil {

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1257,54 +1258,106 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	// flip to "unrecoverable" so the work-no-longer-needed gate stops
 	// the loop. A successful run (any non-stub status) resets the
 	// counter via the else branch below.
-	statusToWrite := summaryResp.SummaryStatus
-	attempts := 0
-	if priorMeta, _ := lfs.ReadSessionMeta(payload.SessionDir); priorMeta != nil {
-		attempts = priorMeta.SummaryAttempts
-	}
-	if statusToWrite == sessionsummary.SummaryStatusFailedValidation {
-		attempts++
-		if attempts >= lfs.MaxSummaryAttempts {
-			h.logger.Warn("session summary unrecoverable after max attempts; will not retry",
-				"session", sessionName,
-				"attempts", attempts,
-				"max", lfs.MaxSummaryAttempts,
-				"last_error", summaryResp.ValidationError,
-			)
-			statusToWrite = sessionsummary.SummaryStatusUnrecoverable
-		}
-	} else {
-		// success or non-failure shape — clear the counter so a future
-		// anti-entropy pass after a regression won't inherit a stale
-		// retry budget.
-		attempts = 0
-	}
-
-	metaBuilder := lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
-		SessionID(sessionIDForMeta).
-		Title(summaryResp.Title).
-		Summary(summaryResp.Summary).
-		EntryCount(len(stored.Entries)).
-		StopReason(session.StopReasonRecovered).
-		SummaryStatus(statusToWrite).
-		ValidationError(summaryResp.ValidationError).
-		SummaryAttempts(attempts)
-
-	// inject sageox contribution score from cache file (matches synchronous path),
-	// then clean up to prevent stale scores leaking into future sessions
+	// sageox contribution score from the cache file (matches the synchronous
+	// path). Read before the mutation so the closure stays side-effect free,
+	// and clean up after so a stale score can't leak into a future session.
+	var score *session.ScoreFile
 	if agentID != "" {
-		if scoreFile, _ := session.ReadSageoxScore(agentID); scoreFile != nil {
-			metaBuilder.SageoxScore(scoreFile.Score, string(scoreFile.Category), scoreFile.Reason)
-		}
-		_ = session.CleanupSageoxScore(agentID)
+		score, _ = session.ReadSageoxScore(agentID)
 	}
 
-	meta := metaBuilder.Build()
+	// Write meta.json as a locked READ-MODIFY-WRITE, touching only the
+	// fields this path owns.
+	//
+	// Until GH #710 this rebuilt meta.json from a fresh builder, which
+	// silently dropped every field the daemon does not set: repo_id, model,
+	// user_id, redactions, produced_commits, produced_plans, linked_prs,
+	// linked_issues, linkage_status and the whole stop_* group. That is not
+	// merely a local loss — the ledger auto-resolves sessions/ conflicts to
+	// the local side (internal/ledger/ledger.go), so the stripped copy wins
+	// the next rebase and erases those fields from the shared history for
+	// every teammate.
+	var meta *lfs.SessionMeta
+	if err := lfs.MutateSessionMeta(context.Background(), payload.SessionDir, func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+		next := current
+		if next == nil {
+			// no meta.json yet — seed one; there is nothing to preserve.
+			next = lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).Build()
+		}
 
-	// write meta.json (without LFS refs initially)
-	if err := lfs.WriteSessionMetaOnly(payload.SessionDir, meta); err != nil {
+		// Failure-stub retry cap. Pre-fix, the daemon would re-finalize a
+		// session on every anti-entropy cycle whenever its title was empty,
+		// burning tokens forever on a structurally-broken raw.jsonl or a
+		// model that consistently can't summarize this session. Now: count
+		// how many failure stubs we've produced, and after MaxSummaryAttempts
+		// flip to "unrecoverable" so the work-no-longer-needed gate stops
+		// the loop.
+		//
+		// Counted from `current` INSIDE the lock. Reading it from a separate
+		// unlocked ReadSessionMeta (as this used to) races a concurrent
+		// writer and can silently drop a bump, re-arming the loop.
+		statusToWrite := summaryResp.SummaryStatus
+		attempts := next.SummaryAttempts
+		if statusToWrite == sessionsummary.SummaryStatusFailedValidation {
+			attempts++
+			if attempts >= lfs.MaxSummaryAttempts {
+				h.logger.Warn("session summary unrecoverable after max attempts; will not retry",
+					"session", sessionName,
+					"attempts", attempts,
+					"max", lfs.MaxSummaryAttempts,
+					"last_error", summaryResp.ValidationError,
+				)
+				statusToWrite = sessionsummary.SummaryStatusUnrecoverable
+			}
+		} else {
+			// success or non-failure shape — clear the counter so a future
+			// anti-entropy pass after a regression won't inherit a stale
+			// retry budget.
+			attempts = 0
+		}
+
+		// identity — safe to (re)assert; these describe the recording itself.
+		next.SessionName = sessionName
+		next.Username = username
+		next.AgentID = agentID
+		next.AgentType = agentType
+		next.SessionID = sessionIDForMeta
+
+		// Daemon-owned summary fields, assigned UNCONDITIONALLY. Writing ""
+		// on a successful run is the intended clear; applying
+		// preserve-if-empty here would make a past failure permanently
+		// sticky, which is the opposite bug.
+		next.Title = summaryResp.Title
+		next.Summary = summaryResp.Summary
+		next.EntryCount = len(stored.Entries)
+		next.SummaryStatus = statusToWrite
+		next.ValidationError = summaryResp.ValidationError
+		next.SummaryAttempts = attempts
+
+		// StopReason is preserve-if-set: "recovered" is our fallback for a
+		// session nobody stopped cleanly. If the CLI already recorded a real
+		// terminal reason (plus stop_detail / stop_source / stop_pattern_id /
+		// stop_resets_at), overwriting it destroys that record.
+		if next.StopReason == "" {
+			next.StopReason = session.StopReasonRecovered
+		}
+
+		if score != nil {
+			s := score.Score
+			next.SageoxScore = &s
+			next.SageoxScoreCategory = string(score.Category)
+			next.SageoxScoreReason = score.Reason
+		}
+
+		meta = next
+		return next, nil
+	}); err != nil {
 		h.logger.Warn("meta.json write failed", "session", sessionName, "err", err)
 		return nil, nil
+	}
+
+	if agentID != "" {
+		_ = session.CleanupSageoxScore(agentID)
 	}
 
 	// attempt LFS upload (best-effort)
@@ -1331,37 +1384,17 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 	// whichever process writes second clobbers the other's mutation. See
 	// ox-e1ot for the failure mode this prevents.
 	if err := lfs.MutateSessionMeta(context.Background(), payload.SessionDir, func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
-		// Prefer the just-written meta as the base; if a CLI writer has
-		// added entries to Files between our first write and now, merge
-		// rather than replace so we don't drop their git-stored refs.
-		base := meta
-		if current != nil && len(current.Files) > 0 {
-			merged := make(map[string]lfs.FileRef, len(current.Files)+len(fileRefs))
-			for k, v := range current.Files {
-				merged[k] = v
-			}
-			for k, v := range fileRefs {
-				// LFS-safety guard: never demote a Storage=git entry
-				// to Storage=lfs. The CLI's session_upload registers
-				// small JSON artifacts (summary.json) as Storage=git
-				// because their bytes live directly in the git tree;
-				// if a daemon-side merge replaced that with an LFS
-				// pointer, WritePointerFiles would overwrite the
-				// real summary.json with a 130-byte pointer stub —
-				// silent data loss the user has explicitly flagged
-				// as a worry. Storage=git wins for shared keys.
-				if existing, ok := merged[k]; ok && existing.IsGit() && v.IsLFS() {
-					h.logger.Warn("rejecting LFS overwrite of git-stored entry",
-						"session", sessionName, "file", k,
-						"existing_size", existing.Size, "incoming_oid", v.OID)
-					continue
-				}
-				merged[k] = v
-			}
-			base.Files = merged
-		} else {
-			base.Files = fileRefs
+		// Base on what is on disk NOW, not on the struct we built a moment
+		// ago: a CLI writer may have mutated meta.json between the two
+		// locks, and using our stale copy would silently revert them. Fall
+		// back to our copy only when the file has gone missing. (Pre-#710
+		// this always based on the freshly-built struct, which re-stripped
+		// whatever the first write had just preserved.)
+		base := current
+		if base == nil {
+			base = meta
 		}
+		base.Files = h.mergeFileRefs(base.Files, fileRefs, sessionName)
 		return base, nil
 	}); err != nil {
 		h.logger.Warn("meta.json update with LFS refs failed", "session", sessionName, "err", err)
@@ -1472,17 +1505,25 @@ func (h *SessionFinalizeHandler) processUploadOnly(payload *SessionFinalizePaylo
 				h.logger.Warn("upload-only: LFS upload failed, committing raw content", "session", sessionName, "err", err)
 			} else {
 				fileRefs = refs
-				// update meta.json with LFS refs
+				// update meta.json with LFS refs. Goes through
+				// MutateSessionMeta so it serializes against the CLI's
+				// concurrent artifact registration — the unlocked
+				// read/unmarshal/write this replaced could lose whichever
+				// mutation landed first.
 				if len(fileRefs) > 0 {
-					metaPath := filepath.Join(payload.SessionDir, "meta.json")
-					if metaData, readErr := os.ReadFile(metaPath); readErr == nil {
-						var meta lfs.SessionMeta
-						if jsonErr := json.Unmarshal(metaData, &meta); jsonErr == nil {
-							meta.Files = fileRefs
-							if writeErr := lfs.WriteSessionMetaOnly(payload.SessionDir, &meta); writeErr != nil {
-								h.logger.Warn("upload-only: meta.json LFS update failed", "session", sessionName, "err", writeErr)
+					if err := lfs.MutateSessionMeta(context.Background(), payload.SessionDir,
+						func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+							if current == nil {
+								return nil, nil // no meta.json to update — nothing to do
 							}
-						}
+							// merge, never replace: UploadSessionFiles omits
+							// summary.json, so assigning the LFS list wholesale
+							// would drop its Storage=git registration — the same
+							// field-stripping class this PR exists to fix.
+							current.Files = h.mergeFileRefs(current.Files, fileRefs, sessionName)
+							return current, nil
+						}); err != nil {
+						h.logger.Warn("upload-only: meta.json LFS update failed", "session", sessionName, "err", err)
 					}
 				}
 			}
@@ -2276,4 +2317,41 @@ func (h *SessionFinalizeHandler) emitSummarizationTelemetry(sessionName, mode st
 	}
 
 	h.telemetry.Record("summarization", props)
+}
+
+// mergeFileRefs merges freshly-uploaded LFS refs into an existing
+// meta.json manifest, preserving entries the upload didn't produce.
+//
+// Two invariants, both learned the hard way:
+//
+//  1. MERGE, never replace. lfs.UploadSessionFiles returns only the files
+//     it uploaded to the content store — it deliberately omits
+//     summary.json, which the CLI registers as Storage=git because its
+//     bytes live directly in the git tree. Assigning the returned map
+//     wholesale drops those entries, which is the same field-stripping
+//     class GH #710 is about.
+//
+//  2. Storage=git WINS for a shared key. Demoting a git-stored entry to
+//     an LFS ref would make WritePointerFiles overwrite the real
+//     summary.json with a ~130-byte pointer stub — silent data loss.
+func (h *SessionFinalizeHandler) mergeFileRefs(
+	existing, incoming map[string]lfs.FileRef,
+	sessionName string,
+) map[string]lfs.FileRef {
+	if len(existing) == 0 {
+		return incoming
+	}
+
+	merged := make(map[string]lfs.FileRef, len(existing)+len(incoming))
+	maps.Copy(merged, existing)
+	for k, v := range incoming {
+		if prior, ok := merged[k]; ok && prior.IsGit() && v.IsLFS() {
+			h.logger.Warn("rejecting LFS overwrite of git-stored entry",
+				"session", sessionName, "file", k,
+				"existing_size", prior.Size, "incoming_oid", v.OID)
+			continue
+		}
+		merged[k] = v
+	}
+	return merged
 }

--- a/internal/daemon/agentwork/session_finalize_preserve_test.go
+++ b/internal/daemon/agentwork/session_finalize_preserve_test.go
@@ -1,0 +1,362 @@
+package agentwork
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/pkg/sessionsummary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- GH #710 D3: meta.json field preservation ---
+//
+// The daemon's finalize path used to rebuild meta.json from a fresh
+// SessionMetaBuilder, which populates only the handful of fields the
+// daemon sets. Everything else — identity, provenance, redaction history,
+// linkage — was silently dropped on every finalize.
+//
+// That is worse than a local loss. The ledger appends its own
+// {Auto, "sessions/"} resolve rule (internal/ledger/ledger.go) and
+// resolves to the LOCAL side, so a stripped meta.json wins the next
+// rebase and erases those fields from shared history for every teammate.
+// The reporter of #710 saw the other half of the same bug: doctor's
+// auto-commit committing a stripped file while origin still had the
+// fields, producing an unresolvable conflict on the same 6 files forever.
+
+const preserveSuccessOutput = `{"title":"Real Title","summary":"This is a successful summary of the session that passes all the validators in place.","key_actions":["did the work","wrote the tests","shipped it"],"outcome":"success","topics_found":["x"],"quality_score":0.8}`
+
+const preserveFailingOutput = `{"title":"x","summary":"Some real-looking summary text that is long enough to pass length checks.","key_actions":["a"],"outcome":"success","topics_found":["x"],"quality_score":0.8}`
+
+// seedRichMeta writes a meta.json carrying every field the daemon does
+// NOT own. Each one is a field a real session accumulates from a
+// different subsystem, and each was dropped pre-fix.
+func seedRichMeta(t *testing.T, sessionDir, sessionName string) *lfs.SessionMeta {
+	t.Helper()
+
+	resets := time.Date(2026, 5, 1, 23, 0, 0, 0, time.UTC)
+	meta := lfs.NewSessionMeta(sessionName, "testuser", "agent-1", "claude-code",
+		time.Date(2026, 5, 1, 20, 4, 0, 0, time.UTC)).Build()
+
+	meta.SessionID = "ses_019c0000-0000-7000-8000-000000000001"
+	meta.UserID = "user-abc"         // resolved at login
+	meta.RepoID = "repo-xyz"         // resolved from the project marker
+	meta.Model = "claude-opus-4"     // recorded by the CLI at session stop
+	meta.StopReason = "rate_limited" // a REAL terminal reason, not "recovered"
+	meta.StopDetail = "5-hour limit reached"
+	meta.StopSource = "structured"
+	meta.StopPatternID = "anthropic-rate-limit"
+	meta.StopResetsAtRaw = "11pm"
+	meta.StopResetsAt = &resets
+	meta.Redactions = []lfs.RedactionPass{{
+		PassID:    "019c0000-0000-7000-8000-0000000000aa",
+		AppliedAt: time.Date(2026, 5, 1, 21, 0, 0, 0, time.UTC),
+		AppliedBy: "ox session redact-history",
+	}}
+	meta.ProducedCommits = []string{"abc123def456"}
+	meta.ProducedPlans = []string{"2026-05-01-some-plan"}
+	meta.LinkedPRs = []string{"sageox/ox#710"}
+	meta.LinkedIssues = []string{"sageox/ox#732"}
+	meta.LinkageStatus = lfs.LinkageStatusNotified
+
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, meta))
+	return meta
+}
+
+// assertRichMetaPreserved checks every seeded field survived.
+func assertRichMetaPreserved(t *testing.T, got *lfs.SessionMeta, want *lfs.SessionMeta) {
+	t.Helper()
+
+	assert.Equal(t, want.UserID, got.UserID, "user_id dropped")
+	assert.Equal(t, want.RepoID, got.RepoID, "repo_id dropped — the session detaches from its repo")
+	assert.Equal(t, want.Model, got.Model, "model dropped")
+	assert.Equal(t, want.SessionID, got.SessionID, "session_id must never rotate")
+
+	assert.Equal(t, want.StopDetail, got.StopDetail, "stop_detail dropped")
+	assert.Equal(t, want.StopSource, got.StopSource, "stop_source dropped")
+	assert.Equal(t, want.StopPatternID, got.StopPatternID, "stop_pattern_id dropped")
+	assert.Equal(t, want.StopResetsAtRaw, got.StopResetsAtRaw, "stop_resets_at_raw dropped")
+	require.NotNil(t, got.StopResetsAt, "stop_resets_at dropped")
+	assert.True(t, want.StopResetsAt.Equal(*got.StopResetsAt), "stop_resets_at changed")
+
+	require.Len(t, got.Redactions, 1,
+		"redaction history dropped — this is an audit record, and losing it means "+
+			"nobody can prove which detector catalog ran over this transcript")
+	assert.Equal(t, want.Redactions[0].PassID, got.Redactions[0].PassID)
+	assert.Equal(t, want.Redactions[0].AppliedBy, got.Redactions[0].AppliedBy)
+
+	assert.Equal(t, want.ProducedCommits, got.ProducedCommits, "produced_commits dropped")
+	assert.Equal(t, want.ProducedPlans, got.ProducedPlans, "produced_plans dropped")
+	assert.Equal(t, want.LinkedPRs, got.LinkedPRs, "linked_prs dropped")
+	assert.Equal(t, want.LinkedIssues, got.LinkedIssues, "linked_issues dropped")
+	assert.Equal(t, want.LinkageStatus, got.LinkageStatus, "linkage_status dropped")
+}
+
+// TestFinalize_PreservesUnownedFields is the core GH #710 regression test.
+// It fails hard against the pre-fix builder-based write.
+func TestFinalize_PreservesUnownedFields(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipGit = true
+	handler.skipLFS = true
+
+	name := "2026-05-01T20-04-testuser-OxPRSV"
+	ledgerPath := createTestSession(t, name, nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", name)
+	seeded := seedRichMeta(t, sessionDir, name)
+
+	item := &WorkItem{
+		ID: "prsv", Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+	require.NoError(t, handler.ProcessResult(item, &RunResult{
+		Output: preserveSuccessOutput, Duration: time.Second, ExitCode: 0,
+	}))
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+
+	assertRichMetaPreserved(t, got, seeded)
+
+	// and the fields the daemon DOES own must actually be updated —
+	// otherwise "preserve everything" would trivially pass by doing nothing.
+	assert.Equal(t, "Real Title", got.Title, "the daemon must still write the summary it produced")
+	assert.NotEmpty(t, got.Summary)
+}
+
+// TestFinalize_PreservesUnownedFieldsAcrossRepeatedRuns covers the class
+// rather than a single call: anti-entropy re-finalizes the same session on
+// later cycles, and each pass must be non-destructive. A fix that
+// preserved fields on the first write but re-stripped on the second (the
+// second MutateSessionMeta based on a stale in-memory struct) would pass
+// the test above and still lose the data.
+func TestFinalize_PreservesUnownedFieldsAcrossRepeatedRuns(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipGit = true
+	handler.skipLFS = true
+
+	name := "2026-05-01T20-04-testuser-OxPRS2"
+	ledgerPath := createTestSession(t, name, nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", name)
+	seeded := seedRichMeta(t, sessionDir, name)
+
+	item := &WorkItem{
+		ID: "prs2", Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+
+	for i := range 3 {
+		require.NoError(t, handler.ProcessResult(item, &RunResult{
+			Output: preserveSuccessOutput, Duration: time.Second, ExitCode: 0,
+		}), "run %d", i+1)
+
+		got, err := lfs.ReadSessionMeta(sessionDir)
+		require.NoError(t, err)
+		assertRichMetaPreserved(t, got, seeded)
+	}
+}
+
+// TestFinalize_PreservesUnownedFieldsOnValidationFailure covers the exact
+// path the #710 reporter was stuck in: the summary keeps failing
+// validation, the daemon keeps re-finalizing, and every one of those
+// passes was stripping the file that then conflicted against origin.
+func TestFinalize_PreservesUnownedFieldsOnValidationFailure(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipGit = true
+	handler.skipLFS = true
+
+	name := "2026-05-01T20-04-testuser-OxPRS3"
+	ledgerPath := createTestSession(t, name, nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", name)
+	seeded := seedRichMeta(t, sessionDir, name)
+
+	item := &WorkItem{
+		ID: "prs3", Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+	require.NoError(t, handler.ProcessResult(item, &RunResult{
+		Output: preserveFailingOutput, Duration: time.Second, ExitCode: 0,
+	}))
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+
+	assertRichMetaPreserved(t, got, seeded)
+	assert.Equal(t, sessionsummary.SummaryStatusFailedValidation, got.SummaryStatus)
+	assert.Equal(t, 1, got.SummaryAttempts)
+}
+
+// TestFinalize_SuccessClearsFailureState is the guard against
+// over-correcting. The failure fields must be assigned unconditionally,
+// NOT preserve-if-empty — otherwise a session that once failed would stay
+// marked failed forever, and the retry cap would never re-arm. This is the
+// opposite bug to the one #710 fixes, and equally real.
+func TestFinalize_SuccessClearsFailureState(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipGit = true
+	handler.skipLFS = true
+
+	name := "2026-05-01T20-04-testuser-OxPRS4"
+	ledgerPath := createTestSession(t, name, nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", name)
+
+	meta := lfs.NewSessionMeta(name, "testuser", "agent-1", "claude-code", time.Now().UTC()).Build()
+	meta.SummaryStatus = sessionsummary.SummaryStatusFailedValidation
+	meta.ValidationError = "content validation failed: title too short (0 chars, minimum 3)"
+	meta.SummaryAttempts = 2
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, meta))
+
+	item := &WorkItem{
+		ID: "prs4", Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+	require.NoError(t, handler.ProcessResult(item, &RunResult{
+		Output: preserveSuccessOutput, Duration: time.Second, ExitCode: 0,
+	}))
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.SummaryAttempts, "a success must reset the retry budget")
+	assert.Empty(t, got.ValidationError, "a success must clear the stale diagnostic")
+	assert.NotEqual(t, sessionsummary.SummaryStatusFailedValidation, got.SummaryStatus,
+		"a success must not leave the session marked failed")
+}
+
+// TestFinalize_PreservesTerminalStopReason pins the preserve-if-set rule
+// for StopReason. The daemon's "recovered" is a fallback for sessions
+// nobody stopped cleanly; overwriting a real terminal reason destroys the
+// record of WHY the session ended, which the stop_detail / stop_source /
+// stop_resets_at group exists to explain.
+func TestFinalize_PreservesTerminalStopReason(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipGit = true
+	handler.skipLFS = true
+
+	name := "2026-05-01T20-04-testuser-OxPRS5"
+	ledgerPath := createTestSession(t, name, nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", name)
+	seedRichMeta(t, sessionDir, name)
+
+	item := &WorkItem{
+		ID: "prs5", Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+	require.NoError(t, handler.ProcessResult(item, &RunResult{
+		Output: preserveSuccessOutput, Duration: time.Second, ExitCode: 0,
+	}))
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, "rate_limited", got.StopReason,
+		"a real terminal stop reason must not be overwritten with the generic fallback")
+}
+
+// TestFinalize_StampsRecoveredWhenNoStopReason is the other half of
+// preserve-if-set: a session with no recorded stop reason still gets the
+// fallback, so the preservation rule can't silently disable it.
+func TestFinalize_StampsRecoveredWhenNoStopReason(t *testing.T) {
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipGit = true
+	handler.skipLFS = true
+
+	name := "2026-05-01T20-04-testuser-OxPRS6"
+	ledgerPath := createTestSession(t, name, nil)
+	sessionDir := filepath.Join(ledgerPath, "sessions", name)
+
+	item := &WorkItem{
+		ID: "prs6", Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: sessionDir,
+			RawPath:    filepath.Join(sessionDir, "raw.jsonl"),
+			Missing:    requiredArtifacts,
+			LedgerPath: ledgerPath,
+		},
+	}
+	require.NoError(t, handler.ProcessResult(item, &RunResult{
+		Output: preserveSuccessOutput, Duration: time.Second, ExitCode: 0,
+	}))
+
+	got, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Equal(t, session.StopReasonRecovered, got.StopReason,
+		"a session with no recorded stop reason must still be marked recovered")
+}
+
+// TestMergeFileRefs_PreservesGitStoredEntries covers the CodeRabbit
+// finding on this PR: the upload-only path assigned the LFS ref map to
+// meta.Files wholesale. lfs.UploadSessionFiles deliberately omits
+// summary.json (the CLI registers it as Storage=git because its bytes
+// live in the git tree), so a wholesale assign dropped that registration
+// — the same field-stripping class this PR exists to fix, reintroduced
+// one function over.
+func TestMergeFileRefs_PreservesGitStoredEntries(t *testing.T) {
+	h := NewSessionFinalizeHandler(slog.Default())
+
+	existing := map[string]lfs.FileRef{
+		"summary.json": {Storage: lfs.StorageGit, Size: 512},
+		"raw.jsonl":    {Storage: lfs.StorageLFS, OID: "sha256:old", Size: 100},
+	}
+	incoming := map[string]lfs.FileRef{
+		"raw.jsonl": {Storage: lfs.StorageLFS, OID: "sha256:new", Size: 200},
+	}
+
+	merged := h.mergeFileRefs(existing, incoming, "s")
+
+	require.Contains(t, merged, "summary.json",
+		"an entry the upload didn't produce must survive the merge")
+	assert.True(t, merged["summary.json"].IsGit())
+	assert.Equal(t, "sha256:new", merged["raw.jsonl"].OID, "the uploaded ref must win for its own key")
+}
+
+// TestMergeFileRefs_GitWinsOverLFS is the data-loss guard: demoting a
+// git-stored entry to an LFS ref would make WritePointerFiles overwrite
+// the real summary.json with a ~130-byte pointer stub.
+func TestMergeFileRefs_GitWinsOverLFS(t *testing.T) {
+	h := NewSessionFinalizeHandler(slog.Default())
+
+	merged := h.mergeFileRefs(
+		map[string]lfs.FileRef{"summary.json": {Storage: lfs.StorageGit, Size: 512}},
+		map[string]lfs.FileRef{"summary.json": {Storage: lfs.StorageLFS, OID: "sha256:x", Size: 130}},
+		"s",
+	)
+
+	assert.True(t, merged["summary.json"].IsGit(),
+		"Storage=git must win, or the real file is replaced by a pointer stub")
+	assert.Equal(t, int64(512), merged["summary.json"].Size)
+}
+
+// TestMergeFileRefs_EmptyExistingTakesIncoming — the first-upload case.
+func TestMergeFileRefs_EmptyExistingTakesIncoming(t *testing.T) {
+	h := NewSessionFinalizeHandler(slog.Default())
+	incoming := map[string]lfs.FileRef{"raw.jsonl": {Storage: lfs.StorageLFS, OID: "sha256:a"}}
+
+	assert.Equal(t, incoming, h.mergeFileRefs(nil, incoming, "s"))
+}

--- a/internal/daemon/sync_managed.go
+++ b/internal/daemon/sync_managed.go
@@ -358,12 +358,20 @@ func (s *SyncScheduler) pullManagedRepo(ctx context.Context, opts ManagedRepoPul
 			// capture conflicted paths before AuditAndAbort discards rebase
 			// state — a sessions/*/meta.json conflict gets its own issue
 			// type (IssueTypeSessionConflictWedge) instead of the generic
-			// IssueTypeDiverged below, since sessions/ is hard-denied from
-			// auto-resolve by design (internal/manifest/auto_resolve.go):
-			// the abort clears the rebase mechanics but never resolves the
-			// underlying content, so the next cycle hits the identical
-			// conflict. Distinguishing it lets sync.go escalate severity by
-			// elapsed time instead of treating it like ordinary lag.
+			// IssueTypeDiverged below: the abort clears the rebase mechanics
+			// but never resolves the underlying content, so the next cycle
+			// hits the identical conflict. Distinguishing it lets sync.go
+			// escalate severity by elapsed time instead of treating it like
+			// ordinary lag.
+			//
+			// NB: an earlier version of this comment claimed sessions/ is
+			// "hard-denied from auto-resolve by design". That is true of
+			// manifest-parsed repos (internal/manifest/auto_resolve.go) but
+			// NOT of the ledger, which appends its own {Auto, "sessions/"}
+			// rule and never runs it through ValidateResolveRules — see
+			// internal/ledger/ledger.go. So the ledger DOES auto-resolve
+			// sessions/, to the local side. Anything that reaches here is a
+			// conflict auto-resolve could not handle.
 			conflictedSessionPaths := sessionConflictPaths(ctx, path)
 
 			// AuditAndAbort: structured pre/post logs capture HEAD SHA,

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -131,19 +131,30 @@ type SessionMeta struct {
 	// read-modify-write call sites that bypass MutateSessionMeta and
 	// call WriteSessionMetaOnly / WriteSessionMeta directly:
 	//
-	//   - cmd/ox/session_push_summary.go     (Files update)
-	//   - cmd/ox/session_regenerate.go       (Files update)
-	//   - cmd/ox/session_upload_cmd.go       (Files update)
-	//   - cmd/ox/agent_session.go            (initial write + Files update)
-	//   - internal/daemon/agentwork/session_finalize.go
+	//   - cmd/ox/session_push_summary.go        (Files update)
+	//   - cmd/ox/session_regenerate.go          (Files update)
+	//   - cmd/ox/session_upload_cmd.go          (Files update)
+	//   - cmd/ox/agent_session.go               (initial write + Files update)
+	//   - cmd/ox/agent_session_recover.go       (Files update)
+	//   - cmd/ox/session_repair_meta_summary.go (summary fields)
 	//
-	// Each of those races with concurrent writers and can lose
+	// FIXED in GH #710 — these two were the worst offenders because they
+	// rebuilt meta from a builder rather than mutating what was on disk,
+	// so they dropped fields outright rather than merely racing:
+	//
+	//   - internal/daemon/agentwork/session_finalize.go
+	//   - cmd/ox/doctor_session_upload_retry.go
+	//
+	// Each remaining site races with concurrent writers and can lose
 	// updates — including new Redactions entries written by
 	// ox session redact between the racing reader's read and write.
 	// The risk is bounded today because redact-history runs are
 	// operator-initiated and the daemon doesn't run during them in
 	// practice, but the invariant is fragile. Tracked separately so
 	// the cleanup lands in a focused PR.
+	//
+	// `make check-session-meta-rmw` fails the build on any NEW bypass; the
+	// list above is its allowlist.
 	//
 	// omitempty so legacy meta.json files keep round-tripping and
 	// older readers ignore the new field.

--- a/internal/lfs/meta_repair.go
+++ b/internal/lfs/meta_repair.go
@@ -3,6 +3,7 @@ package lfs
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -112,6 +113,21 @@ func RecoverEmptyTitleMeta(sessionDir string, dryRun bool) MetaRepairOutcome {
 // ledger cache so the daemon can read actual content for summarization.
 //
 // Returns true if the session was reset, false if not eligible.
+//
+// # The reset is gated on the session actually being summarizable (GH #710)
+//
+// This used to clear the status/attempts/error FIRST and hydrate second,
+// resetting even when hydration was impossible. Because a doctor autofix
+// runs it daily, that re-armed the MaxSummaryAttempts cap every 24 hours
+// — so a session whose raw.jsonl is an unhydratable content-store stub
+// never settled into a terminal state. It burned three LLM calls a day,
+// forever, each one emitting a fresh "finalize session" commit. That is
+// how the #710 reporter accumulated 21 duplicate commits across 5
+// sessions and, downstream, an unpushable ledger.
+//
+// Now: verify the transcript can actually be read before clearing the
+// terminal state, and never write a .needs-summary marker pointing at a
+// file that is still a pointer.
 func ResetInlineSummaryEligible(sessionDir string, dryRun bool, client *Client, ledgerPath string) (reset bool) {
 	meta, err := ReadSessionMeta(sessionDir)
 	if err != nil {
@@ -122,6 +138,32 @@ func ResetInlineSummaryEligible(sessionDir string, dryRun bool, client *Client, 
 		strings.Contains(meta.ValidationError, "title too short")
 	if !eligible {
 		return false
+	}
+
+	// Resolve a readable transcript BEFORE touching the meta. A session we
+	// cannot read is a session we cannot summarize, and clearing its
+	// terminal state would just re-enter the loop on the next daemon pass.
+	rawPath := filepath.Join(sessionDir, "raw.jsonl")
+	markerDir := sessionDir
+	if IsPointerFile(rawPath) {
+		sessionName := filepath.Base(sessionDir)
+		cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+		cachePath := filepath.Join(cacheDir, "raw.jsonl")
+
+		if info, statErr := os.Stat(cachePath); statErr == nil && info.Size() > 0 {
+			// already hydrated by an earlier pass
+			rawPath, markerDir = cachePath, cacheDir
+		} else {
+			hydrated, hydrateErr := HydrateRawToCacheErr(client, sessionDir, ledgerPath)
+			if hydrateErr != nil || hydrated == "" {
+				// Leave the terminal status intact. Retryable failures get
+				// another shot on the next pass because the meta still
+				// matches the eligibility filter; ErrNoLFSManifest never
+				// will, which is correct — that content is gone.
+				return false
+			}
+			rawPath, markerDir = hydrated, cacheDir
+		}
 	}
 
 	if dryRun {
@@ -135,20 +177,7 @@ func ResetInlineSummaryEligible(sessionDir string, dryRun bool, client *Client, 
 		return false
 	}
 
-	// if raw.jsonl is an LFS pointer, hydrate to cache so daemon can read it
-	rawPath := filepath.Join(sessionDir, "raw.jsonl")
-	if client != nil && IsPointerFile(rawPath) {
-		sessionName := filepath.Base(sessionDir)
-		cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
-		cachePath := HydrateRawToCache(client, sessionDir, ledgerPath)
-		if cachePath != "" {
-			rawPath = cachePath
-			writeNeedsSummaryMarker(cacheDir, rawPath, sessionDir)
-			return true
-		}
-	}
-
-	writeNeedsSummaryMarker(sessionDir, rawPath, sessionDir)
+	writeNeedsSummaryMarker(markerDir, rawPath, sessionDir)
 	return true
 }
 
@@ -173,61 +202,98 @@ func writeNeedsSummaryMarker(dir, rawPath, ledgerSessionDir string) {
 //
 // Returns the cache path on success, empty string on failure.
 func HydrateRawToCache(client *Client, sessionDir, ledgerPath string) string {
-	meta, err := ReadSessionMeta(sessionDir)
-	if err != nil {
-		return ""
-	}
+	path, _ := HydrateRawToCacheErr(client, sessionDir, ledgerPath)
+	return path
+}
 
-	rawRef, ok := meta.Files["raw.jsonl"]
-	if !ok || rawRef.OID == "" {
-		return ""
-	}
+// ErrNoLFSManifest reports that a session's meta.json carries no usable
+// content-store reference for raw.jsonl — no "raw.jsonl" entry, or one
+// with an empty OID.
+//
+// This is the ONE hydration failure that is permanent. It means the
+// transcript was never uploaded, so no amount of retrying will produce
+// it, and callers should mark the session terminal rather than loop.
+//
+// Every OTHER failure — auth, transport, 4xx/5xx, disk — is retryable and
+// must NOT be treated as terminal. Getting this distinction backwards is
+// costly in both directions: condemning on a transient 503 throws away a
+// recoverable session, while retrying on ErrNoLFSManifest recreates the
+// unbounded loop GH #710 was filed about.
+var ErrNoLFSManifest = errors.New("session meta.json has no content-store reference for raw.jsonl")
 
+// HydrateRawToCacheErr is HydrateRawToCache with a diagnosable failure.
+//
+// The string-only version returns "" on nine distinct failure paths, all
+// indistinguishable, which is why the daemon could neither report why a
+// session would not hydrate nor decide whether retrying was worthwhile.
+// New callers should use this; HydrateRawToCache remains as a thin
+// wrapper so existing ones keep compiling.
+func HydrateRawToCacheErr(client *Client, sessionDir, ledgerPath string) (string, error) {
 	sessionName := filepath.Base(sessionDir)
 	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
 	cachePath := filepath.Join(cacheDir, "raw.jsonl")
 
-	// skip if already cached
+	// Already cached — checked FIRST, before touching meta.json or
+	// requiring a client. An earlier pass may have hydrated this, and
+	// demanding credentials to hand back a file already on disk would
+	// fail offline for no reason.
 	if info, err := os.Stat(cachePath); err == nil && info.Size() > 0 {
-		return cachePath
+		return cachePath, nil
+	}
+
+	meta, err := ReadSessionMeta(sessionDir)
+	if err != nil {
+		return "", fmt.Errorf("read meta.json: %w", err)
+	}
+
+	rawRef, ok := meta.Files["raw.jsonl"]
+	if !ok || rawRef.OID == "" {
+		return "", ErrNoLFSManifest
+	}
+
+	if client == nil {
+		return "", errors.New("no content-store client (not authenticated, or ledger has no remote)")
 	}
 
 	bareOID := rawRef.BareOID()
 	resp, err := client.BatchDownload([]BatchObject{{OID: bareOID, Size: rawRef.Size}})
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("LFS batch download: %w", err)
 	}
 	if len(resp.Objects) == 0 {
-		return ""
+		return "", fmt.Errorf("LFS batch returned no objects for %s", bareOID)
 	}
 	obj := resp.Objects[0]
-	if obj.Error != nil || obj.Actions == nil || obj.Actions.Download == nil {
-		return ""
+	if obj.Error != nil {
+		return "", fmt.Errorf("LFS object error for %s: %s", bareOID, obj.Error.Message)
+	}
+	if obj.Actions == nil || obj.Actions.Download == nil {
+		return "", fmt.Errorf("LFS batch returned no download action for %s", bareOID)
 	}
 
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		return ""
+		return "", fmt.Errorf("create cache dir: %w", err)
 	}
 
 	tmpPath := cachePath + ".tmp"
 	f, err := os.Create(tmpPath)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("create temp file: %w", err)
 	}
 
 	if err := DownloadToFile(obj.Actions.Download, f, true, bareOID); err != nil {
 		f.Close()
 		os.Remove(tmpPath)
-		return ""
+		return "", fmt.Errorf("download %s: %w", bareOID, err)
 	}
 	f.Close()
 
 	if err := os.Rename(tmpPath, cachePath); err != nil {
 		os.Remove(tmpPath)
-		return ""
+		return "", fmt.Errorf("install cached copy: %w", err)
 	}
 
-	return cachePath
+	return cachePath, nil
 }
 
 // readSummaryJSONTitle returns a trimmed, non-leaky title from

--- a/internal/lfs/meta_repair.go
+++ b/internal/lfs/meta_repair.go
@@ -286,7 +286,14 @@ func HydrateRawToCacheErr(client *Client, sessionDir, ledgerPath string) (string
 		os.Remove(tmpPath)
 		return "", fmt.Errorf("download %s: %w", bareOID, err)
 	}
-	f.Close()
+	// Check Close: a write buffered by the OS can fail at flush time (ENOSPC,
+	// EIO). Ignoring it would rename a silently truncated transcript into the
+	// cache, where it reads as legitimate content and produces a wrong summary
+	// — far worse than reporting a retryable failure.
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", fmt.Errorf("flush cached copy: %w", err)
+	}
 
 	if err := os.Rename(tmpPath, cachePath); err != nil {
 		os.Remove(tmpPath)

--- a/internal/lfs/meta_repair.go
+++ b/internal/lfs/meta_repair.go
@@ -166,6 +166,19 @@ func ResetInlineSummaryEligible(sessionDir string, dryRun bool, client *Client, 
 		}
 	}
 
+	// Whatever path we landed on must actually be readable. A pointer that
+	// hydrated gets here with the cache path; a real transcript gets here
+	// unchanged; but a MISSING or empty raw.jsonl reaches here too —
+	// IsPointerFile is false for it, so the branch above never ran.
+	//
+	// Without this, an absent transcript would clear the terminal state and
+	// get a .needs-summary marker pointing at a file that does not exist,
+	// sending the daemon straight back into the loop this function exists
+	// to stop — the same failure as the pointer case, one branch over.
+	if info, err := os.Stat(rawPath); err != nil || info.Size() == 0 {
+		return false
+	}
+
 	if dryRun {
 		return true
 	}

--- a/internal/lfs/meta_repair.go
+++ b/internal/lfs/meta_repair.go
@@ -248,7 +248,21 @@ func HydrateRawToCacheErr(client *Client, sessionDir, ledgerPath string) (string
 
 	rawRef, ok := meta.Files["raw.jsonl"]
 	if !ok || rawRef.OID == "" {
-		return "", ErrNoLFSManifest
+		// The manifest is not the only place the OID lives — the on-disk
+		// pointer file carries it too, and the two can disagree (a partial
+		// write, or a meta.json rebuilt by one of the pre-#710 builder
+		// paths that dropped Files). Fall back to the pointer before
+		// declaring the content gone.
+		//
+		// This matters because ErrNoLFSManifest is the ONE error callers
+		// treat as terminal: a false positive here permanently condemns a
+		// session whose transcript is sitting in the content store,
+		// perfectly recoverable.
+		if ref, perr := ReadPointerFile(filepath.Join(sessionDir, "raw.jsonl")); perr == nil && ref.OID != "" {
+			rawRef = ref
+		} else {
+			return "", ErrNoLFSManifest
+		}
 	}
 
 	if client == nil {

--- a/internal/lfs/meta_repair_hydrate_test.go
+++ b/internal/lfs/meta_repair_hydrate_test.go
@@ -1,0 +1,201 @@
+package lfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- GH #710: hydration failures must be diagnosable, and exactly one is terminal ---
+
+// eligibleMeta writes the meta.json shape ResetInlineSummaryEligible
+// targets: a failed summary whose validation_error mentions a short title.
+func eligibleMeta(t *testing.T, sessionDir string) {
+	t.Helper()
+	meta := NewSessionMeta("2026-05-01T20-04-testuser-OxHYD", "testuser", "a1", "claude-code", time.Now().UTC()).Build()
+	meta.SummaryStatus = "failed_validation"
+	meta.ValidationError = "content validation failed: title too short (0 chars, minimum 3)"
+	meta.SummaryAttempts = 2
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, meta))
+}
+
+func TestHydrateRawToCacheErr_NoManifestIsTerminal(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]FileRef
+	}{
+		{"no raw.jsonl entry", map[string]FileRef{}},
+		{"raw.jsonl with empty OID", map[string]FileRef{"raw.jsonl": {Size: 10}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionDir := t.TempDir()
+			meta := NewSessionMeta("s", "u", "a", "claude-code", time.Now().UTC()).Build()
+			meta.Files = tt.files
+			require.NoError(t, WriteSessionMetaOnly(sessionDir, meta))
+
+			_, err := HydrateRawToCacheErr(&Client{}, sessionDir, t.TempDir())
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrNoLFSManifest,
+				"a transcript that was never uploaded is permanently unrecoverable — this is "+
+					"the ONE failure callers may treat as terminal")
+		})
+	}
+}
+
+func TestHydrateRawToCacheErr_OtherFailuresAreRetryable(t *testing.T) {
+	t.Run("nil client", func(t *testing.T) {
+		_, err := HydrateRawToCacheErr(nil, t.TempDir(), t.TempDir())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNoLFSManifest,
+			"being unauthenticated is transient — condemning the session would lose it")
+	})
+
+	t.Run("unreadable meta", func(t *testing.T) {
+		_, err := HydrateRawToCacheErr(&Client{}, t.TempDir(), t.TempDir())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrNoLFSManifest,
+			"a missing meta.json is a different problem, not proof the content is gone")
+	})
+}
+
+// TestHydrateRawToCache_WrapperStillReturnsEmptyString pins the
+// compatibility contract for the pre-existing callers.
+func TestHydrateRawToCache_WrapperStillReturnsEmptyString(t *testing.T) {
+	assert.Empty(t, HydrateRawToCache(nil, t.TempDir(), t.TempDir()))
+}
+
+// TestHydrateRawToCacheErr_UsesCacheWhenAlreadyHydrated also pins the
+// cache-only invariant: hydration never touches the git-tracked file.
+func TestHydrateRawToCacheErr_UsesCacheWhenAlreadyHydrated(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionName := "2026-05-01T20-04-testuser-OxCACHE"
+	sessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	meta := NewSessionMeta(sessionName, "u", "a", "claude-code", time.Now().UTC()).Build()
+	meta.Files = map[string]FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}}
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, meta))
+
+	// in-place stays a pointer; the real bytes live in the cache
+	rawPath := filepath.Join(sessionDir, "raw.jsonl")
+	require.NoError(t, WritePointerFile(rawPath, FileRef{OID: "sha256:abc", Size: 10}))
+
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+	cachePath := filepath.Join(cacheDir, "raw.jsonl")
+	require.NoError(t, os.WriteFile(cachePath, []byte("real transcript bytes\n"), 0o644))
+
+	// nil client proves no network call was needed
+	got, err := HydrateRawToCacheErr(nil, sessionDir, ledgerPath)
+	require.NoError(t, err)
+	assert.Equal(t, cachePath, got)
+
+	assert.True(t, IsPointerFile(rawPath),
+		"CACHE-ONLY: the git-tracked file must stay a pointer, or the next commit "+
+			"breaks LFS linkage and every future push fails")
+}
+
+// TestResetInlineSummaryEligible_UnhydratablePointerDoesNotReset is the
+// test that proves the unbounded loop is dead.
+//
+// A doctor autofix runs this daily. Pre-fix it cleared summary_status /
+// summary_attempts / validation_error BEFORE attempting hydration, so a
+// session whose transcript could not be fetched had its 3-attempt retry
+// budget re-armed every 24 hours — burning LLM calls and emitting a fresh
+// "finalize session" commit each time, forever.
+func TestResetInlineSummaryEligible_UnhydratablePointerDoesNotReset(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionDir := filepath.Join(ledgerPath, "sessions", "2026-05-01T20-04-testuser-OxHYD")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	eligibleMeta(t, sessionDir)
+	require.NoError(t, WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"),
+		FileRef{OID: "sha256:abc", Size: 10}))
+
+	before, err := os.ReadFile(filepath.Join(sessionDir, "meta.json"))
+	require.NoError(t, err)
+
+	// nil client — hydration is impossible on this pass
+	reset := ResetInlineSummaryEligible(sessionDir, false, nil, ledgerPath)
+
+	assert.False(t, reset, "must not reset a session it cannot make summarizable")
+
+	after, err := os.ReadFile(filepath.Join(sessionDir, "meta.json"))
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"meta.json must be byte-identical — clearing the retry budget here is what "+
+			"re-armed the loop every 24 hours")
+
+	assert.NoFileExists(t, filepath.Join(sessionDir, ".needs-summary"),
+		"a .needs-summary marker pointing at a pointer file is a lie that sends the "+
+			"daemon straight back into the failing path")
+}
+
+// TestResetInlineSummaryEligible_HydratedPointerDoesReset is the other
+// half: once the content IS available in the cache, the reset must
+// happen, or the fix would simply disable recovery.
+func TestResetInlineSummaryEligible_HydratedPointerDoesReset(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionName := "2026-05-01T20-04-testuser-OxHYD"
+	sessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	eligibleMeta(t, sessionDir)
+	require.NoError(t, WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"),
+		FileRef{OID: "sha256:abc", Size: 10}))
+
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"),
+		[]byte("header\nreal content\n"), 0o644))
+
+	reset := ResetInlineSummaryEligible(sessionDir, false, nil, ledgerPath)
+
+	assert.True(t, reset, "with content available in the cache, the session is recoverable")
+
+	meta, err := ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Empty(t, meta.SummaryStatus)
+	assert.Zero(t, meta.SummaryAttempts)
+	assert.Empty(t, meta.ValidationError)
+
+	assert.FileExists(t, filepath.Join(cacheDir, ".needs-summary"),
+		"the marker belongs beside the hydrated copy the daemon will actually read")
+}
+
+// TestResetInlineSummaryEligible_RealContentStillResets covers the
+// non-pointer path, which the pointer gating must not disturb.
+func TestResetInlineSummaryEligible_RealContentStillResets(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionDir := filepath.Join(ledgerPath, "sessions", "2026-05-01T20-04-testuser-OxHYD")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	eligibleMeta(t, sessionDir)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"),
+		[]byte("header\nreal content\n"), 0o644))
+
+	assert.True(t, ResetInlineSummaryEligible(sessionDir, false, nil, ledgerPath))
+
+	meta, err := ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.Empty(t, meta.SummaryStatus)
+	assert.Zero(t, meta.SummaryAttempts)
+}
+
+// TestResetInlineSummaryEligible_IneligibleUntouched — the filter itself.
+func TestResetInlineSummaryEligible_IneligibleUntouched(t *testing.T) {
+	sessionDir := t.TempDir()
+	meta := NewSessionMeta("s", "u", "a", "claude-code", time.Now().UTC()).Build()
+	meta.SummaryStatus = "ok"
+	meta.Title = "A good title"
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, meta))
+
+	assert.False(t, ResetInlineSummaryEligible(sessionDir, false, nil, t.TempDir()),
+		"a healthy session must never be reset")
+}

--- a/internal/lfs/meta_repair_hydrate_test.go
+++ b/internal/lfs/meta_repair_hydrate_test.go
@@ -229,6 +229,11 @@ func TestHydrateRawToCacheErr_FallsBackToOnDiskPointer(t *testing.T) {
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, ErrNoLFSManifest,
 		"the OID is recoverable from the pointer file — condemning this session would lose it")
+	// Assert the SPECIFIC error, not merely "not the sentinel": otherwise
+	// this test would pass if the function bailed for some unrelated reason
+	// before it ever consulted the pointer.
+	assert.Contains(t, err.Error(), "no content-store client",
+		"must have got past the manifest check and reached the network step")
 }
 
 // TestHydrateRawToCacheErr_TerminalOnlyWhenNeitherSourceHasAnOID keeps the

--- a/internal/lfs/meta_repair_hydrate_test.go
+++ b/internal/lfs/meta_repair_hydrate_test.go
@@ -255,3 +255,45 @@ func TestHydrateRawToCacheErr_TerminalOnlyWhenNeitherSourceHasAnOID(t *testing.T
 	assert.ErrorIs(t, err, ErrNoLFSManifest,
 		"neither the manifest nor the on-disk file yields an OID — genuinely terminal")
 }
+
+// TestResetInlineSummaryEligible_MissingTranscriptDoesNotReset closes the
+// branch the pointer gate misses. IsPointerFile is false for an ABSENT
+// raw.jsonl, so an eligible session with no transcript at all used to fall
+// straight through: terminal state cleared, and a .needs-summary marker
+// written pointing at a file that does not exist. The next daemon pass
+// then tries to summarize content that cannot be read — the same unbounded
+// loop as the pointer case, one branch over.
+func TestResetInlineSummaryEligible_MissingTranscriptDoesNotReset(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionDir := filepath.Join(ledgerPath, "sessions", "2026-05-01T20-04-testuser-OxMISS")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	eligibleMeta(t, sessionDir)
+	// deliberately NO raw.jsonl at all
+
+	before, err := os.ReadFile(filepath.Join(sessionDir, "meta.json"))
+	require.NoError(t, err)
+
+	assert.False(t, ResetInlineSummaryEligible(sessionDir, false, nil, ledgerPath),
+		"a session with no transcript can never be summarized — clearing its terminal state re-arms the loop")
+
+	after, err := os.ReadFile(filepath.Join(sessionDir, "meta.json"))
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after), "meta.json must be byte-identical")
+	assert.NoFileExists(t, filepath.Join(sessionDir, ".needs-summary"),
+		"a marker pointing at a nonexistent transcript is a lie the daemon will act on")
+}
+
+// TestResetInlineSummaryEligible_EmptyTranscriptDoesNotReset — a
+// zero-byte raw.jsonl is equally unsummarizable.
+func TestResetInlineSummaryEligible_EmptyTranscriptDoesNotReset(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionDir := filepath.Join(ledgerPath, "sessions", "2026-05-01T20-04-testuser-OxEMPT")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	eligibleMeta(t, sessionDir)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"), nil, 0o644))
+
+	assert.False(t, ResetInlineSummaryEligible(sessionDir, false, nil, ledgerPath))
+	assert.NoFileExists(t, filepath.Join(sessionDir, ".needs-summary"))
+}

--- a/internal/lfs/meta_repair_hydrate_test.go
+++ b/internal/lfs/meta_repair_hydrate_test.go
@@ -199,3 +199,54 @@ func TestResetInlineSummaryEligible_IneligibleUntouched(t *testing.T) {
 	assert.False(t, ResetInlineSummaryEligible(sessionDir, false, nil, t.TempDir()),
 		"a healthy session must never be reset")
 }
+
+// TestHydrateRawToCacheErr_FallsBackToOnDiskPointer — the manifest is not
+// the only place the OID lives. A meta.json rebuilt by one of the
+// pre-GH#710 builder paths lost its Files map entirely, but the committed
+// pointer file still carries the OID.
+//
+// ErrNoLFSManifest is the ONE error callers treat as terminal, so a false
+// positive here permanently condemns a session whose transcript is sitting
+// in the content store, perfectly recoverable.
+func TestHydrateRawToCacheErr_FallsBackToOnDiskPointer(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionName := "2026-05-01T20-04-testuser-OxPTR"
+	sessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	// meta.json with NO Files map — the pre-#710 stripped shape
+	meta := NewSessionMeta(sessionName, "u", "a", "claude-code", time.Now().UTC()).Build()
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, meta))
+
+	// ...but a valid pointer on disk, carrying the OID
+	require.NoError(t, WritePointerFile(filepath.Join(sessionDir, "raw.jsonl"),
+		FileRef{OID: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", Size: 4242}))
+
+	// nil client, so this gets as far as needing the network and no further —
+	// what matters is that it is NOT the terminal sentinel.
+	_, err := HydrateRawToCacheErr(nil, sessionDir, ledgerPath)
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNoLFSManifest,
+		"the OID is recoverable from the pointer file — condemning this session would lose it")
+}
+
+// TestHydrateRawToCacheErr_TerminalOnlyWhenNeitherSourceHasAnOID keeps the
+// sentinel meaningful: with no manifest entry AND no usable pointer, the
+// content really is unreferenced.
+func TestHydrateRawToCacheErr_TerminalOnlyWhenNeitherSourceHasAnOID(t *testing.T) {
+	ledgerPath := t.TempDir()
+	sessionDir := filepath.Join(ledgerPath, "sessions", "2026-05-01T20-04-testuser-OxNON")
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+
+	meta := NewSessionMeta("s", "u", "a", "claude-code", time.Now().UTC()).Build()
+	require.NoError(t, WriteSessionMetaOnly(sessionDir, meta))
+	// raw.jsonl present but real content, not a pointer — nothing to hydrate from
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"),
+		[]byte("header\nnot a pointer\n"), 0o644))
+
+	_, err := HydrateRawToCacheErr(&Client{}, sessionDir, ledgerPath)
+
+	assert.ErrorIs(t, err, ErrNoLFSManifest,
+		"neither the manifest nor the on-disk file yields an OID — genuinely terminal")
+}

--- a/internal/lfs/meta_repair_test.go
+++ b/internal/lfs/meta_repair_test.go
@@ -183,6 +183,16 @@ func TestRecoverEmptyTitleMeta_DryRunWritesNothing(t *testing.T) {
 //
 // Failure prevented: 40+ sessions stuck permanently in "unrecoverable"
 // state even after the daemon is fixed to use inline prompts.
+// writeTestTranscript gives a session a readable raw.jsonl. Eligible
+// sessions in production always have one (a pointer or real content);
+// ResetInlineSummaryEligible refuses to clear terminal state without it,
+// because a session with no transcript can never be summarized.
+func writeTestTranscript(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"),
+		[]byte(`{"metadata":{},"type":"header"}`+"\n"+`{"type":"user","content":"hi"}`+"\n"), 0o644))
+}
+
 func TestResetInlineSummaryEligible_ResetsFileReadBugSessions(t *testing.T) {
 	dir := t.TempDir()
 	writeTestMeta(t, dir, &SessionMeta{
@@ -191,6 +201,7 @@ func TestResetInlineSummaryEligible_ResetsFileReadBugSessions(t *testing.T) {
 		SummaryAttempts: MaxSummaryAttempts,
 		ValidationError: "content validation failed: title too short (0 chars, minimum 3)",
 	})
+	writeTestTranscript(t, dir)
 
 	reset := ResetInlineSummaryEligible(dir, false, nil, "")
 	assert.True(t, reset)
@@ -240,6 +251,7 @@ func TestResetInlineSummaryEligible_DryRun(t *testing.T) {
 		SummaryAttempts: MaxSummaryAttempts,
 		ValidationError: "content validation failed: title too short (0 chars, minimum 3)",
 	})
+	writeTestTranscript(t, dir)
 
 	reset := ResetInlineSummaryEligible(dir, true, nil, "")
 	assert.True(t, reset)

--- a/internal/session/classify.go
+++ b/internal/session/classify.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/sageox/ox/internal/lfs"
 )
 
 // SessionStatus represents the lifecycle state of a session.
@@ -192,15 +194,46 @@ func isPIDAlive(pid int) bool {
 	return proc.Signal(syscall.Signal(0)) == nil
 }
 
-// HasSubstantiveEntries returns true if a raw.jsonl file has at least one entry
-// beyond the metadata header line. A header-only file (1 line) has no real session
-// content and should not be uploaded or finalized.
+// RawKind classifies what a raw.jsonl path actually holds.
 //
-// This is the canonical check — use it everywhere instead of inline line counting.
-func HasSubstantiveEntries(rawPath string) bool {
+// The distinction that matters is RawPointerStub vs RawSubstantive.
+// A content-store pointer is ~130 bytes over 3 lines, so a naive
+// "more than one line means real content" test reports it as a
+// full transcript — which is exactly how GH #710 started: the
+// summarizer was handed a pointer file, produced an empty title,
+// failed validation, and retried forever.
+type RawKind int
+
+const (
+	// RawMissing: the file does not exist or cannot be read.
+	RawMissing RawKind = iota
+	// RawHeaderOnly: exists, but holds only the metadata header line —
+	// a recording that never captured anything.
+	RawHeaderOnly
+	// RawSubstantive: real transcript content, safe to summarize.
+	RawSubstantive
+	// RawPointerStub: an LFS pointer. The transcript is real but lives
+	// in the content store; this file is only a reference to it.
+	// Ledger clones are dehydrated by design, so this is the NORMAL
+	// steady state for a synced session — it is not corruption, and it
+	// must never be treated as content.
+	RawPointerStub
+)
+
+// ClassifyRawFile reports what rawPath holds. Prefer this over
+// HasSubstantiveEntries anywhere the pointer case needs distinct
+// handling — several callers must treat a stub as "has data elsewhere"
+// rather than "has no data", and collapsing the two is destructive.
+func ClassifyRawFile(rawPath string) RawKind {
+	// Pointer detection first: it is a cheap stat + small read, and a
+	// pointer would otherwise be miscounted as multi-line content.
+	if lfs.IsPointerFile(rawPath) {
+		return RawPointerStub
+	}
+
 	f, err := os.Open(rawPath)
 	if err != nil {
-		return false
+		return RawMissing
 	}
 	defer f.Close()
 
@@ -211,10 +244,23 @@ func HasSubstantiveEntries(rawPath string) bool {
 	for scanner.Scan() {
 		lineCount++
 		if lineCount >= 2 {
-			return true // at least one line beyond header
+			return RawSubstantive // at least one line beyond header
 		}
 	}
-	return false
+	return RawHeaderOnly
+}
+
+// HasSubstantiveEntries returns true if a raw.jsonl file holds at least one
+// entry beyond the metadata header line. A header-only file (1 line) has no
+// real session content and should not be uploaded or finalized.
+//
+// A content-store pointer stub is NOT substantive: the bytes present are a
+// reference, not a transcript. Callers that need to distinguish "no data"
+// from "data lives in the content store" must use ClassifyRawFile.
+//
+// This is the canonical check — use it everywhere instead of inline line counting.
+func HasSubstantiveEntries(rawPath string) bool {
+	return ClassifyRawFile(rawPath) == RawSubstantive
 }
 
 // CountSubstantiveEntries counts lines in a raw.jsonl that are actual session

--- a/internal/session/classify_pointer_test.go
+++ b/internal/session/classify_pointer_test.go
@@ -1,0 +1,112 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- GH #710 D2: pointer stubs are not transcripts ---
+//
+// A content-store pointer is ~130 bytes over 3 lines. The old
+// HasSubstantiveEntries counted lines and reported "2+ lines = real
+// content", so a stub read as a full transcript. The summarizer then
+// produced an empty title, validation failed with "title too short
+// (0 chars, minimum 3)", and the daemon retried forever — 21 duplicate
+// "finalize session" commits across 5 sessions in the reported case.
+
+// writePointerStub writes a spec-compliant LFS pointer, the exact shape
+// ox commits for a synced session.
+func writePointerStub(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, lfs.WritePointerFile(path, lfs.FileRef{
+		OID:  "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+		Size: 4242,
+	}))
+}
+
+func TestClassifyRawFile(t *testing.T) {
+	dir := t.TempDir()
+
+	missing := filepath.Join(dir, "missing.jsonl")
+
+	headerOnly := filepath.Join(dir, "header.jsonl")
+	require.NoError(t, os.WriteFile(headerOnly,
+		[]byte(`{"metadata":{"agent_id":"a"},"type":"header"}`+"\n"), 0o644))
+
+	substantive := filepath.Join(dir, "real.jsonl")
+	require.NoError(t, os.WriteFile(substantive,
+		[]byte(`{"metadata":{"agent_id":"a"},"type":"header"}`+"\n"+
+			`{"type":"user","content":"hello","seq":1}`+"\n"), 0o644))
+
+	pointer := filepath.Join(dir, "pointer.jsonl")
+	writePointerStub(t, pointer)
+
+	tests := []struct {
+		name string
+		path string
+		want RawKind
+		why  string
+	}{
+		{"missing file", missing, RawMissing, "nothing to read"},
+		{"header only", headerOnly, RawHeaderOnly, "a recording that captured nothing"},
+		{"real transcript", substantive, RawSubstantive, "the only kind that may be summarized"},
+		{
+			"pointer stub", pointer, RawPointerStub,
+			"THE #710 case: 3 lines of pointer must never read as transcript content",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ClassifyRawFile(tt.path), tt.why)
+		})
+	}
+}
+
+// TestHasSubstantiveEntries_RejectsPointerStub is the direct regression
+// assertion. This fails against the pre-fix line-counting implementation.
+func TestHasSubstantiveEntries_RejectsPointerStub(t *testing.T) {
+	pointer := filepath.Join(t.TempDir(), "raw.jsonl")
+	writePointerStub(t, pointer)
+
+	// sanity: the stub really does have the multi-line shape that fooled
+	// the old line-counting check.
+	data, err := os.ReadFile(pointer)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(splitLines(string(data))), 2,
+		"precondition: a pointer file has 2+ lines, which is why line counting was wrong")
+
+	assert.False(t, HasSubstantiveEntries(pointer),
+		"a pointer is a reference, not a transcript — treating it as content is what "+
+			"fed an empty file to the summarizer and started the retry loop")
+}
+
+func TestHasSubstantiveEntries_AcceptsRealContent(t *testing.T) {
+	real := filepath.Join(t.TempDir(), "raw.jsonl")
+	require.NoError(t, os.WriteFile(real,
+		[]byte(`{"metadata":{},"type":"header"}`+"\n"+`{"type":"user","content":"hi"}`+"\n"), 0o644))
+
+	assert.True(t, HasSubstantiveEntries(real),
+		"the fix must not make every session look empty")
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := range len(s) {
+		if s[i] == '\n' {
+			if i > start {
+				out = append(out, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}

--- a/internal/session/ghost_pointer_test.go
+++ b/internal/session/ghost_pointer_test.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- GH #710 D2 call-site audit ---
+//
+// Making HasSubstantiveEntries reject pointer stubs is correct for the
+// summarizer, but two callers meant something different by it and would
+// become DESTRUCTIVE if they inherited the new semantics verbatim.
+//
+// Ghost cleanup is the dangerous one: it deletes .recording.json and then
+// removeEmptyDir()s the session directory for anything it judges to have
+// "no meaningful data". Pre-#710 a pointer stub counted as data and was
+// spared. A naive flip would have made ghost cleanup delete synced
+// sessions whose transcripts were safely in the content store — turning a
+// summarization bug into permanent local data loss.
+
+// ghostState builds a dead-parent recording state old enough to clear the
+// grace period, so cleanup will actually consider it.
+func ghostState(t *testing.T, sessionPath string) *RecordingState {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(sessionPath, 0o755))
+
+	state := &RecordingState{
+		SessionPath: sessionPath,
+		// PID 1 is init/launchd — alive, so use a PID that cannot be running.
+		// 0x7FFFFFFF is above any real pid_max on Linux and macOS.
+		ParentPID: 0x7FFFFFFF,
+		StartedAt: time.Now().Add(-2 * GhostGracePeriod),
+	}
+	require.NoError(t, os.WriteFile(recordingStatePath(sessionPath), []byte("{}"), 0o644))
+	return state
+}
+
+// TestGhostCleanup_PointerStubIsNotAGhost is the regression test for the
+// destructive call site. It fails if ghost cleanup is ever rewired
+// straight through HasSubstantiveEntries.
+func TestGhostCleanup_PointerStubIsNotAGhost(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "2026-05-01T20-04-testuser-OxGHST")
+	state := ghostState(t, sessionPath)
+	writePointerStub(t, filepath.Join(sessionPath, "raw.jsonl"))
+
+	result := cleanupGhosts([]*RecordingState{state})
+
+	assert.Equal(t, 0, result.Removed,
+		"a session whose transcript lives in the content store must never be deleted as a ghost")
+	assert.DirExists(t, sessionPath, "the session directory must survive")
+	assert.FileExists(t, recordingStatePath(sessionPath),
+		"the recording marker must survive so recovery can still find it")
+}
+
+// TestGhostCleanup_StillRemovesRealGhosts proves the guard above did not
+// simply disable ghost cleanup.
+func TestGhostCleanup_StillRemovesRealGhosts(t *testing.T) {
+	base := t.TempDir()
+
+	headerOnly := filepath.Join(base, "2026-05-01T20-04-testuser-OxHDR")
+	headerState := ghostState(t, headerOnly)
+	require.NoError(t, os.WriteFile(filepath.Join(headerOnly, "raw.jsonl"),
+		[]byte(`{"metadata":{},"type":"header"}`+"\n"), 0o644))
+
+	noRaw := filepath.Join(base, "2026-05-01T20-04-testuser-OxNON")
+	noRawState := ghostState(t, noRaw)
+
+	result := cleanupGhosts([]*RecordingState{headerState, noRawState})
+
+	assert.Equal(t, 2, result.Removed,
+		"header-only and raw-less recordings are genuine ghosts and must still be cleaned")
+}
+
+// TestGhostCleanup_KeepsSessionsWithRealContent is the pre-existing
+// contract, restated so a future refactor cannot quietly drop it.
+func TestGhostCleanup_KeepsSessionsWithRealContent(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "2026-05-01T20-04-testuser-OxREAL")
+	state := ghostState(t, sessionPath)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionPath, "raw.jsonl"),
+		[]byte(`{"metadata":{},"type":"header"}`+"\n"+`{"type":"user","content":"hi"}`+"\n"), 0o644))
+
+	result := cleanupGhosts([]*RecordingState{state})
+
+	assert.Equal(t, 0, result.Removed, "a recording with entries is an orphan to recover, not a ghost")
+	assert.DirExists(t, sessionPath)
+}

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -665,15 +665,27 @@ func cleanupGhosts(states []*RecordingState) GhostCleanupResult {
 			continue
 		}
 
-		// parent is dead — check if there's any real data beyond the header line.
-		// Use HasSubstantiveEntries (2+ lines) rather than RawJSONLHasData (size > 0)
-		// because writeRawHeader always writes a 1-line metadata header at session start.
-		// A header-only file has no recoverable session content and should be cleaned up.
+		// parent is dead — check if there's any recoverable data. Classify
+		// rather than calling HasSubstantiveEntries, because "no substantive
+		// entries" and "nothing to recover" are NOT the same thing here.
+		//
+		// Only a header-only or missing raw.jsonl is a ghost. A pointer stub
+		// is a session whose transcript lives in the content store, so it has
+		// very much got recoverable data — deleting it (and, via
+		// removeEmptyDir below, its whole session directory) would destroy a
+		// synced session. HasSubstantiveEntries reports false for pointers as
+		// of GH #710, so this must not be collapsed back into that call.
 		rawPath := filepath.Join(state.SessionPath, "raw.jsonl")
-		if HasSubstantiveEntries(rawPath) {
+		switch ClassifyRawFile(rawPath) {
+		case RawSubstantive:
 			// has session entries — this is an orphan, not a ghost.
 			// don't delete: it has recoverable data.
 			continue
+		case RawPointerStub:
+			// content lives in the content store; never a ghost.
+			continue
+		case RawMissing, RawHeaderOnly:
+			// fall through to ghost cleanup
 		}
 
 		// ghost confirmed: dead PID, no meaningful data

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -472,10 +472,20 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 		var hasRawData bool
 
 		if info, err := os.Stat(rawPath); err == nil {
-			// raw.jsonl exists (hydrated or recording in progress)
+			// raw.jsonl exists (hydrated, pointer stub, or recording in progress)
 			filePath = rawPath
 			fileSize = info.Size()
-			hasRawData = HasSubstantiveEntries(rawPath)
+			// A pointer stub HAS raw data — it just lives in the content
+			// store. Reporting false would make `ox session list` claim every
+			// synced session is empty, since dehydrated is the normal state
+			// for a ledger clone. HasSubstantiveEntries excludes pointers as
+			// of GH #710, so classify explicitly here.
+			switch ClassifyRawFile(rawPath) {
+			case RawSubstantive, RawPointerStub:
+				hasRawData = true
+			case RawMissing, RawHeaderOnly:
+				hasRawData = false
+			}
 			modTime = info.ModTime()
 			if createdAt.IsZero() {
 				createdAt = info.ModTime()


### PR DESCRIPTION
Part 1 of 4 for #710. This is the defect that actually wedged the reporter's ledger.

## What broke

Two writers rebuilt `sessions/*/meta.json` from a fresh `SessionMetaBuilder` instead of mutating what was on disk. A builder only populates the handful of fields its caller sets, so **every other field was silently dropped** — and because they're all `omitempty`, they didn't go stale, they *vanished from the file*.

That reproduces the reporter's conflict hunk exactly:

```
<<<<<<< HEAD
  "summary_status": "failed_validation",
  "validation_error": "content validation failed: title too short (0 chars, minimum 3)",
  "summary_attempts": 2,
=======
>>>>>>> <sha> (ox doctor: auto-commit ledger changes)
```

The "theirs" side is empty because doctor's retry-upload wrote a stripped file and auto-commit committed it, while origin still carried the fields. Both sides had edited the same lines, so every `git pull --rebase` conflicted identically — until the ledger reached 40 ahead / 41 behind and could not push.

```mermaid
flowchart LR
  B["writer rebuilds meta from a builder"] --> V["omitempty fields vanish"]
  V --> C["doctor auto-commits the stripped file"]
  C --> X["conflict vs origin on the same 6 files"]
  X --> W["ledger cannot push"]
  V --> P["daemon path: auto-resolve picks local"]
  P --> O["stripping propagates to origin for the whole team"]
```

## Worse than reported

The ledger appends its own `{Auto, "sessions/"}` resolve rule (`internal/ledger/ledger.go`) and resolution takes the **local** side. So on the daemon path a stripped `meta.json` doesn't merely wedge — **it wins the next rebase and erases those fields from shared history for every teammate**: `redactions` (an audit record), `produced_commits`, `produced_plans`, `linked_prs`, `linked_issues`, `linkage_status`, `repo_id`, `model`, and the whole `stop_*` group.

## What this ships

- **Both writers now use `lfs.MutateSessionMeta`** — the flock'd read-modify-write primitive the codebase already had. `internal/daemon/agentwork/session_finalize.go` and `cmd/ox/doctor_session_upload_retry.go`.
- **The retry-cap read moved inside the lock.** It was a separate unlocked `ReadSessionMeta`, which races a concurrent writer and can silently drop an attempt bump — re-arming the very loop the cap exists to stop.
- **The second finalize write no longer re-strips.** It based on the freshly-built struct; now it bases on what's on disk, so it can't revert a concurrent CLI mutation either.
- **`StopReason` becomes preserve-if-set.** The daemon hardcoded `recovered`; if the CLI already recorded a real terminal reason (plus `stop_detail` / `stop_source` / `stop_pattern_id` / `stop_resets_at`), overwriting it destroyed that record. Behavior change, own test.
- **The upload-only path** also moved to the locked primitive — it preserved fields but raced.
- **`make check-session-meta-rmw`** fails the build on any *new* bypass, with the remaining `ox-q42i` sites as a documented allowlist. Verified it actually fails on a planted violation.

### Deliberately NOT the fix

An unknown-key catch-all (`json.RawMessage`) would have shipped, reviewed well, and left the bug intact: every dropped field is a **known** struct field. They unmarshal fine — they're lost because the writer never sets them. Worth doing later for cross-version forward-compat, but it's a different ticket, and a custom `MarshalJSON` costs deterministic key order, which is itself a conflict generator on a shared ledger.

## What this does and doesn't repair

**Prevention only.** It stops new stripping; it does **not** un-strip an already-damaged ledger. Because of the local-side auto-resolve above, an already-stripped local commit will still win the next rebase. A repair pass (compare against `origin/main`, restore fields present upstream and absent locally, strict-subset so it can never clobber a legitimate edit) is a follow-up — noted so nobody assumes their ledger self-heals.

## Test Plan

- **`TestFinalize_PreservesUnownedFields`** — seeds all 13 unowned fields, runs finalize, asserts every one survives *and* the owned fields updated (so "preserve everything" can't pass by doing nothing).
- **`..._AcrossRepeatedRuns`** — anti-entropy re-finalizes; a fix that preserved on write 1 and re-stripped on write 2 would pass the first test and still lose data.
- **`..._OnValidationFailure`** — the exact path the reporter was stuck in.
- **`TestWriteRetryUploadMeta_PreservesSummaryFailureFields`** — the literal conflict hunk, as an assertion.
- **`TestFinalize_SuccessClearsFailureState`** — guards the *opposite* bug: these three fields must be assigned unconditionally, or a past failure becomes permanently sticky.
- **Red-before-green verified** by reverting the production change: 4 daemon tests and 3 doctor tests fail, then pass. The two over-correction guards correctly pass both ways.
- Extracted `writeRetryUploadMeta` for testability — the retry path otherwise dies at LFS upload before reaching the meta write.
- `make lint` clean; both guards pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a session-content health check for dehydrated transcripts with recovery guidance.
  - Session recovery can hydrate available transcripts, distinguish permanent from retryable failures, and safely reset summary state.
  - Uploads now clearly handle already-uploaded, incomplete, and valid transcript files.

- **Bug Fixes**
  - Preserved session metadata and file references across retries and finalization.
  - Protected existing Git-stored references from unintended replacement.
  - Improved handling of unreadable and missing transcript content.

- **Tests**
  - Added coverage for recovery, hydration, metadata preservation, and upload behavior.

- **Chores**
  - Added automated checks preventing unsafe metadata updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->