### PR TITLE
feat(login): send device_label so users can identify CLI sessions

### DIFF
--- a/docs/adr/008-privacy.md
+++ b/docs/adr/008-privacy.md
@@ -360,15 +360,27 @@ the distinction is the scope of that rule, not an exception to it:
 | Audience | SageOx, aggregated across users | The user, on their own account page |
 | Purpose | Product analytics | Identifying a credential to revoke |
 | Identity | Deliberately anonymous | Already authenticated — the server knows who |
-| Risk of a machine id | **Correlates an anonymous user's sessions** | None; identity is already established |
+| Risk of a machine id | **Correlates an anonymous user's sessions** | Low; identity is already established, so it adds no linkability |
 
 A stable machine identifier is banned in telemetry precisely because it
 de-anonymizes an otherwise anonymous stream. That hazard does not exist for
 metadata attached to a credential the user is knowingly creating, stored on
-their own account, and displayed back to them. The label answers *which
-machine*, never *who*. Every comparable product (GitHub, Google, 1Password,
-Slack) ships this, because the alternative is a device list of
-indistinguishable rows and no safe way to revoke one.
+their own account, and displayed back to them. Every comparable product
+(GitHub, Google, 1Password, Slack) ships this, because the alternative is a
+device list of indistinguishable rows and no safe way to revoke one.
+
+**Be precise about what it contains.** The label is `user@host`, where `user`
+is the **local OS account name**. So it identifies the machine *and* the
+account on it — which for a single-user laptop is a person. It is not
+anonymous, and this section does not claim otherwise.
+
+What makes that acceptable here, and not in telemetry, is that the request is
+already authenticated: the server knows exactly who is logging in before the
+label arrives. The label therefore reveals nothing about *identity* it did not
+already have; it only adds *which device*. The residual disclosure is the local
+account name itself — e.g. that `r.snodgrass` rather than `ryan` is the account
+on this host — which is why the opt-out exists and why the hostname is reduced
+to its first DNS label.
 
 **Opt-out**, per principle 4:
 
@@ -399,4 +411,4 @@ what ox sent before device labels existed.
 | Guidance sync | None (download only) | `--offline` flag |
 | Prompt delivery | None (download only) | `--offline` flag |
 | Version check | ox version, OS | `ox config set check_updates false` |
-| Device label (`ox login`) | `user@host`, shown only to that user | `SAGEOX_NO_DEVICE_LABEL=1` |
+| Device label (`ox login`) | `user@host` — local OS account + short hostname, shown only to that user | `SAGEOX_NO_DEVICE_LABEL=1` |

--- a/docs/adr/008-privacy.md
+++ b/docs/adr/008-privacy.md
@@ -345,6 +345,51 @@ ox --offline review
 
 ---
 
+### 6. Auth Session Metadata
+
+`ox login` sends a **device label** — `user@host`, e.g. `ryan@laptop` —
+with the device-flow token exchange. It is stored against the PAT and shown
+in `/settings/security` so a user can tell their laptop from their
+devcontainer from their CI runner when deciding which session to revoke.
+
+**This is deliberately outside the "What We NEVER Collect" rule above**, and
+the distinction is the scope of that rule, not an exception to it:
+
+| | Telemetry (§1) | Device label |
+|---|---|---|
+| Audience | SageOx, aggregated across users | The user, on their own account page |
+| Purpose | Product analytics | Identifying a credential to revoke |
+| Identity | Deliberately anonymous | Already authenticated — the server knows who |
+| Risk of a machine id | **Correlates an anonymous user's sessions** | None; identity is already established |
+
+A stable machine identifier is banned in telemetry precisely because it
+de-anonymizes an otherwise anonymous stream. That hazard does not exist for
+metadata attached to a credential the user is knowingly creating, stored on
+their own account, and displayed back to them. The label answers *which
+machine*, never *who*. Every comparable product (GitHub, Google, 1Password,
+Slack) ships this, because the alternative is a device list of
+indistinguishable rows and no safe way to revoke one.
+
+**Opt-out**, per principle 4:
+
+```bash
+SAGEOX_NO_DEVICE_LABEL=1 ox login
+```
+
+The field is `omitempty`, so opting out makes the request byte-identical to
+what ox sent before device labels existed.
+
+**Data minimization applied:**
+- Only the first DNS label of the hostname (`laptop`, not
+  `laptop.corp.internal`) — the domain identifies an employer far more than
+  it identifies a machine.
+- The OS account name, not a git-config or profile name.
+- Allowlisted to `[A-Za-z0-9._-]`, truncated to 32 (user) + 63 (host).
+- Never the local machine id from `internal/signature` — that value is an
+  HMAC key, and transmitting it would leak a local secret.
+
+---
+
 ## Privacy Summary Matrix
 
 | Feature | Data Transmitted | Opt-out Method |
@@ -354,3 +399,4 @@ ox --offline review
 | Guidance sync | None (download only) | `--offline` flag |
 | Prompt delivery | None (download only) | `--offline` flag |
 | Version check | ox version, OS | `ox config set check_updates false` |
+| Device label (`ox login`) | `user@host`, shown only to that user | `SAGEOX_NO_DEVICE_LABEL=1` |

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -109,6 +109,7 @@ cat $XDG_RUNTIME_DIR/sageox/daemon/registry.json 2>/dev/null || \
 | Variable | Purpose |
 |----------|---------|
 | `SAGEOX_ENDPOINT` | Override endpoint URL |
+| `SAGEOX_NO_DEVICE_LABEL=1` | Don't send a `user@host` device label with `ox login` |
 | `OX_XDG_DISABLE=1` | Legacy path mode (`~/.sageox/` instead of XDG) |
 | `OX_PROJECT_ROOT` | Override project root discovery (for CI/devroot) |
 | `OX_SESSION_RECORDING` | Override session recording mode (`auto`/`manual`/`disabled`) |

--- a/docs/guides/ci-pipelines.md
+++ b/docs/guides/ci-pipelines.md
@@ -13,6 +13,7 @@ Three env vars solve the most common CI challenges:
 | `OX_PROJECT_ROOT` | Point to the project when cwd isn't inside it | `/workspace/my-repo` |
 | `OX_SESSION_RECORDING` | Force session recording mode without config files | `auto`, `manual`, `disabled` |
 | `OX_USER_CONFIG` | Load user config from an explicit file path | `/etc/sageox/config.yaml` |
+| `SAGEOX_NO_DEVICE_LABEL` | Don't attach a `user@host` label to tokens minted by `ox login` | `1` |
 
 ### `OX_PROJECT_ROOT`
 

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -256,14 +256,27 @@ type TokenRequest struct {
 	GrantType  string `json:"grant_type"`
 	DeviceCode string `json:"device_code"`
 	ClientID   string `json:"client_id"`
+
+	// DeviceLabel identifies the machine minting this token (e.g.
+	// "ryan@laptop"), so the account's CLI-sessions list shows which
+	// device a session belongs to instead of a bare timestamp. See
+	// deviceLabel() for the privacy rationale and the opt-out.
+	//
+	// omitempty is LOAD-BEARING: when the user opts out, or nothing
+	// usable resolves, the key is absent and the request body is
+	// byte-identical to what ox sent before this field existed. Older
+	// and current backends ignore unknown fields, so this is purely
+	// additive — the CLI reads nothing new off the response.
+	DeviceLabel string `json:"device_label,omitempty"`
 }
 
 // pollToken attempts to exchange the device code for an access token
 func pollToken(client *http.Client, endpoint, deviceCode string) (*TokenResponse, error) {
 	reqBody := TokenRequest{
-		GrantType:  "urn:ietf:params:oauth:grant-type:device_code",
-		DeviceCode: deviceCode,
-		ClientID:   ClientID,
+		GrantType:   "urn:ietf:params:oauth:grant-type:device_code",
+		DeviceCode:  deviceCode,
+		ClientID:    ClientID,
+		DeviceLabel: deviceLabel(),
 	}
 
 	jsonBody, err := json.Marshal(reqBody)

--- a/internal/auth/device_flow_label_test.go
+++ b/internal/auth/device_flow_label_test.go
@@ -1,0 +1,89 @@
+package auth
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- GH #625: ox login sends a device label ---
+//
+// These assert the WIRE, not just the helper: the whole point is what
+// lands in the token-exchange request body.
+
+// captureTokenRequestBody runs pollToken against a stub server and
+// returns the decoded request body.
+func captureTokenRequestBody(t *testing.T) map[string]any {
+	t.Helper()
+
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(raw, &body))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: "test-access-token",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+		}))
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	_, err := pollToken(client, server.URL, "test-device-code")
+	require.NoError(t, err)
+	return body
+}
+
+func TestPollToken_SendsDeviceLabel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: device flow polling")
+	}
+	t.Setenv(EnvVarNoDeviceLabel, "")
+	t.Setenv("USER", "ryan")
+
+	body := captureTokenRequestBody(t)
+
+	// the pre-existing fields must be untouched
+	assert.Equal(t, "urn:ietf:params:oauth:grant-type:device_code", body["grant_type"])
+	assert.Equal(t, "test-device-code", body["device_code"])
+	assert.Equal(t, ClientID, body["client_id"])
+
+	label, ok := body["device_label"].(string)
+	require.True(t, ok, "device_label must be present and a string; got body %v", body)
+	assert.NotEmpty(t, label)
+	assert.Regexp(t, deviceLabelShape, label,
+		"the label is rendered in a web UI and must carry no injectable characters")
+	assert.LessOrEqual(t, utf8.RuneCountInString(label), maxDeviceLabelUser+1+maxDeviceLabelHost)
+}
+
+// TestPollToken_OmitsDeviceLabelWhenOptedOut is what proves `omitempty`
+// is doing its job: the KEY must be absent, not present-and-empty. An
+// empty string would still be a behavior change on the wire, which is
+// exactly what an opt-out must not be.
+func TestPollToken_OmitsDeviceLabelWhenOptedOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: device flow polling")
+	}
+	t.Setenv(EnvVarNoDeviceLabel, "1")
+	t.Setenv("USER", "ryan")
+
+	body := captureTokenRequestBody(t)
+
+	_, present := body["device_label"]
+	assert.False(t, present,
+		"opting out must remove the key entirely, leaving a request byte-identical "+
+			"to what ox sent before device labels existed")
+
+	// and the exchange must still work
+	assert.Equal(t, "test-device-code", body["device_code"])
+}

--- a/internal/auth/device_label.go
+++ b/internal/auth/device_label.go
@@ -1,0 +1,134 @@
+package auth
+
+import (
+	"os"
+	"strings"
+	"unicode/utf8"
+)
+
+// EnvVarNoDeviceLabel disables sending a device label with `ox login`.
+//
+// Set to any value other than "0"/"false"/"" to opt out. With the field's
+// `omitempty` tag, opting out makes the request body byte-identical to
+// what ox sent before device labels existed.
+//
+// Consumed by: deviceLabel()
+//
+// Customer-facing env vars are SAGEOX_*; a customer-facing OX_* var is an
+// anti-pattern (see sageox-mono ADR-047, and the guard in
+// env_naming_test.go).
+const EnvVarNoDeviceLabel = "SAGEOX_NO_DEVICE_LABEL"
+
+const (
+	// maxDeviceLabelUser caps the username portion.
+	maxDeviceLabelUser = 32
+	// maxDeviceLabelHost is the DNS label maximum, so no legal hostname
+	// is ever truncated.
+	maxDeviceLabelHost = 63
+)
+
+// deviceLabel returns a short, human-readable identifier for this machine
+// in the form "user@host", for display in the account's CLI-sessions list.
+//
+// # What this is for
+//
+// `/settings/security` lists every PAT minted by `ox login` with nothing
+// but timestamps. Someone with a laptop, a desktop, a devcontainer and a
+// CI runner cannot tell which row to revoke. The label answers "which
+// machine", not "who" — the server already knows who, from the token it
+// is about to mint.
+//
+// # Privacy
+//
+// This is auth-session metadata attached to a credential the user is
+// creating in that moment, stored against their own account and shown
+// back to that same user. It is NOT telemetry, so the "we never collect
+// machine identifiers" rule in docs/adr/008-privacy.md — which is scoped
+// to aggregate cross-user analytics, where a stable machine id is
+// dangerous precisely because it de-anonymizes — does not apply. The ADR's
+// "easy opt-out" principle does, and EnvVarNoDeviceLabel satisfies it.
+//
+// Deliberately NOT used here:
+//   - signature.GetMachineID() — it is the HMAC key for the local
+//     signature cache, so transmitting it would leak a local secret, and
+//     it embeds a random UUID that means nothing in a UI.
+//   - identity.AttributionName — documented LOCAL ONLY.
+//   - identity.AttributionUsername — resolves through git config, so the
+//     label would depend on which directory `ox login` was run from.
+//
+// Returns "" when opted out or when nothing usable can be resolved; the
+// caller's `omitempty` then drops the field entirely.
+func deviceLabel() string {
+	if optedOutOfDeviceLabel() {
+		return ""
+	}
+
+	host, _ := os.Hostname()
+	// first DNS label only: turns "Laptop.local" into "Laptop" and drops
+	// corporate ".internal"/".lan" domains, which identify an employer far
+	// more than they identify a machine.
+	host, _, _ = strings.Cut(host, ".")
+	host = sanitizeLabelPart(host, maxDeviceLabelHost)
+
+	user := os.Getenv("USER")
+	if user == "" {
+		user = os.Getenv("USERNAME") // Windows
+	}
+	user = sanitizeLabelPart(user, maxDeviceLabelUser)
+
+	switch {
+	case user != "" && host != "":
+		return user + "@" + host
+	case host != "":
+		return host
+	default:
+		return user
+	}
+}
+
+// optedOutOfDeviceLabel reports whether the user disabled device labels.
+// Set-but-falsey values ("0", "false") count as opted IN, so a scripted
+// `SAGEOX_NO_DEVICE_LABEL=0` behaves the way it reads.
+func optedOutOfDeviceLabel() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvVarNoDeviceLabel))) {
+	case "", "0", "false", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+// sanitizeLabelPart reduces s to [A-Za-z0-9._-], collapses runs of "-",
+// trims leading/trailing separators, and truncates to maxRunes.
+//
+// Allowlist, not denylist. This character set is the intersection of what
+// is safe in a GitLab PAT name, an HTTP header value, a JSON string and a
+// URL path segment — so a hostname, which is attacker-influenceable on a
+// shared box, cannot smuggle a CRLF or a quote anywhere downstream.
+// Everything below 0x20, 0x7F, and all non-ASCII is excluded by
+// construction rather than by enumeration.
+func sanitizeLabelPart(s string, maxRunes int) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+			lastDash = r == '-'
+		default:
+			if !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+
+	out := strings.Trim(b.String(), "-._")
+	// truncate by rune even though the allowlist already leaves only
+	// ASCII, so this stays correct if the allowlist ever widens.
+	if utf8.RuneCountInString(out) > maxRunes {
+		out = string([]rune(out)[:maxRunes])
+		out = strings.Trim(out, "-._")
+	}
+	return out
+}

--- a/internal/auth/device_label.go
+++ b/internal/auth/device_label.go
@@ -34,9 +34,18 @@ const (
 //
 // `/settings/security` lists every PAT minted by `ox login` with nothing
 // but timestamps. Someone with a laptop, a desktop, a devcontainer and a
-// CI runner cannot tell which row to revoke. The label answers "which
-// machine", not "who" — the server already knows who, from the token it
-// is about to mint.
+// CI runner cannot tell which row to revoke.
+//
+// # What it actually contains
+//
+// The local OS account name plus the short hostname. That identifies the
+// machine AND the account on it — for a single-user laptop, a person. It
+// is not anonymous. What makes it acceptable is that the device-flow
+// exchange is already authenticated: the server knows who is logging in
+// before the label arrives, so the label adds "which device" without
+// adding any linkability it did not already have. The residual
+// disclosure is the account name itself, which is what the opt-out and
+// the first-DNS-label reduction exist to bound.
 //
 // # Privacy
 //

--- a/internal/auth/device_label_test.go
+++ b/internal/auth/device_label_test.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deviceLabelShape is the contract every emitted label must satisfy:
+// allowlisted characters only, at most one "@" (contributed by the
+// composer, never by a part).
+var deviceLabelShape = regexp.MustCompile(`^[A-Za-z0-9._-]+(@[A-Za-z0-9._-]+)?$`)
+
+func TestOptedOutOfDeviceLabel(t *testing.T) {
+	tests := []struct {
+		value string
+		set   bool
+		want  bool
+		why   string
+	}{
+		{set: false, want: false, why: "unset is the default — labels on"},
+		{value: "", set: true, want: false, why: "empty reads as unset"},
+		{value: "1", set: true, want: true, why: "the documented opt-out"},
+		{value: "true", set: true, want: true, why: "obvious alias"},
+		{value: "TRUE", set: true, want: true, why: "case-insensitive"},
+		{value: "  1  ", set: true, want: true, why: "tolerate stray whitespace from shell config"},
+		{value: "0", set: true, want: false, why: "SAGEOX_NO_DEVICE_LABEL=0 must mean labels ON, as it reads"},
+		{value: "false", set: true, want: false, why: "same"},
+		{value: "no", set: true, want: false, why: "same"},
+	}
+	for _, tt := range tests {
+		name := tt.value
+		if !tt.set {
+			name = "<unset>"
+		}
+		t.Run(name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(EnvVarNoDeviceLabel, tt.value)
+			}
+			assert.Equal(t, tt.want, optedOutOfDeviceLabel(), tt.why)
+		})
+	}
+}
+
+func TestDeviceLabel_OptOutProducesNothing(t *testing.T) {
+	t.Setenv(EnvVarNoDeviceLabel, "1")
+	t.Setenv("USER", "ryan")
+
+	assert.Empty(t, deviceLabel(),
+		"opting out must yield an empty label so omitempty drops the field entirely")
+}
+
+func TestDeviceLabel_ComposesUserAtHost(t *testing.T) {
+	t.Setenv("USER", "ryan")
+
+	got := deviceLabel()
+
+	require.NotEmpty(t, got)
+	assert.Regexp(t, deviceLabelShape, got)
+	assert.True(t, strings.HasPrefix(got, "ryan@") || got == "ryan",
+		"the username must lead; got %q", got)
+}
+
+func TestDeviceLabel_FallsBackWhenUsernameUnavailable(t *testing.T) {
+	t.Setenv("USER", "")
+	t.Setenv("USERNAME", "")
+
+	got := deviceLabel()
+
+	// hostname may legitimately be empty in some sandboxes; either way
+	// the result must still satisfy the shape contract.
+	if got != "" {
+		assert.Regexp(t, deviceLabelShape, got)
+		assert.NotContains(t, got, "@", "with no username there is nothing to join")
+	}
+}
+
+func TestSanitizeLabelPart(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		limit int
+		want  string
+		why   string
+	}{
+		{"plain", "laptop", 63, "laptop", "the common case is untouched"},
+		{"allowed punctuation", "my-box_1.2", 63, "my-box_1.2", "dots, dashes and underscores are safe everywhere"},
+		{
+			"header injection", "a\r\nX-Evil: 1", 63, "a-X-Evil-1",
+			"CRLF must not survive into an HTTP header — this is why the filter is an allowlist",
+		},
+		{"null byte", "a\x00b", 63, "a-b", "control characters are excluded by construction"},
+		{"sql-ish", "; DROP TABLE", 63, "DROP-TABLE", "neutralized, and leading separators trimmed"},
+		{
+			"at sign inside a part", "ryan@corp", 63, "ryan-corp",
+			"an @ in a PART is neutralized, so the single @ in a composed label is always the composer's",
+		},
+		{"non-ascii", "café", 63, "caf", "non-ASCII is dropped, trailing dash trimmed"},
+		{"collapses runs", "a!!!b", 63, "a-b", "one separator, not three"},
+		{"trims edges", "---host---", 63, "host", "no leading or trailing separators"},
+		{"all separators", "!!!", 63, "", "nothing usable means empty, not a bare dash"},
+		{"empty", "", 63, "", ""},
+		{"truncates", strings.Repeat("a", 200), 63, strings.Repeat("a", 63), "a 200-char hostname is cut to the DNS label max"},
+		{"truncation trims trailing separator", "abcde-fgh", 6, "abcde", "must not end on a dash after cutting"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeLabelPart(tt.in, tt.limit)
+			assert.Equal(t, tt.want, got, tt.why)
+			assert.LessOrEqual(t, utf8.RuneCountInString(got), tt.limit)
+		})
+	}
+}
+
+// TestDeviceLabel_HostileHostnameStillProducesASafeLabel is the property
+// test. A hostname is attacker-influenceable on a shared machine, and the
+// label is transmitted and then rendered in a web UI.
+func TestDeviceLabel_HostileHostnameStillProducesASafeLabel(t *testing.T) {
+	hostile := []string{
+		"a\r\nX-Injected: yes",
+		`"><script>alert(1)</script>`,
+		strings.Repeat("x", 500),
+		"../../etc/passwd",
+		"user@evil@host",
+		"\x00\x01\x02",
+	}
+
+	for _, h := range hostile {
+		t.Run(h[:min(len(h), 12)], func(t *testing.T) {
+			user := sanitizeLabelPart(h, maxDeviceLabelUser)
+			host := sanitizeLabelPart(h, maxDeviceLabelHost)
+
+			for _, part := range []string{user, host} {
+				if part == "" {
+					continue
+				}
+				assert.Regexp(t, `^[A-Za-z0-9._-]+$`, part)
+				assert.NotContains(t, part, "@")
+				assert.NotContains(t, part, "\r")
+				assert.NotContains(t, part, "\n")
+			}
+
+			assert.LessOrEqual(t, utf8.RuneCountInString(user), maxDeviceLabelUser)
+			assert.LessOrEqual(t, utf8.RuneCountInString(host), maxDeviceLabelHost)
+
+			if user != "" && host != "" {
+				composed := user + "@" + host
+				assert.Regexp(t, deviceLabelShape, composed)
+				assert.Equal(t, 1, strings.Count(composed, "@"))
+				assert.LessOrEqual(t, utf8.RuneCountInString(composed),
+					maxDeviceLabelUser+1+maxDeviceLabelHost)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #625 (CLI half).

`/settings/security` lists every PAT minted by `ox login` with nothing but timestamps. Someone with a laptop, a desktop, a devcontainer and a CI runner cannot tell which row to revoke. This sends a short `user@host` label with the device-flow token exchange.

One edit covers both login entry points — the package-level `Login()` and `(*AuthClient).Login()` share `pollToken`.

## ⚠️ Needs your sign-off before merge

- **New customer-facing env var: `SAGEOX_NO_DEVICE_LABEL`.** Per CLAUDE.md, any new `SAGEOX_*` var needs your review. I took the reversible defaults rather than blocking: **opt-out** (not opt-in), default label `user@host` degrading to host-only.
- **Backend does not accept the field yet** (separate sageox-mono issue, per the issue's own scope split). Standard JSON decoders ignore unknown fields and the CLI reads nothing new off the response, so this is purely additive. **The one real risk: a backend using strict decoding (`DisallowUnknownFields` / Zod `.strict()`) would 400 and break `ox login` outright.** Worth a yes from the mono owner before merge.

## Why `user@host` and not hostname-only

Hostname alone answers the question for a laptop fleet and fails exactly the cases that need it most — shared boxes, CI runners, devcontainers, and multi-account workstations. It's also the format users already read in GitHub SSH key labels, 1Password and `ssh` itself. Degrades gracefully: host-only → user-only → empty.

## Where the username comes from — and three sources deliberately rejected

The OS account name (`$USER`, then `$USERNAME`). Explicitly **not**:

| Rejected | Why |
|---|---|
| `signature.GetMachineID()` | It is the **HMAC key** for the local signature cache — transmitting it leaks a local secret. Also embeds a random UUID that means nothing in a UI. |
| `identity.AttributionName` | Documented **LOCAL ONLY** in that file's own privacy taxonomy. |
| `identity.AttributionUsername` | Resolves through **git config**, so the label would depend on which directory you happened to run `ox login` from — non-deterministic, and more identifying than the account name. |

## Privacy — meeting ADR-008 head-on

A reviewer will reach for "we never collect machine identifiers". That table sits under **Telemetry**, and the distinction is the *scope* of that rule, not an exception to it:

| | Telemetry | Device label |
|---|---|---|
| Audience | SageOx, aggregated across users | The user, on their own account page |
| Identity | Deliberately anonymous | Already authenticated — the server knows who |
| Risk of a machine id | **Correlates an anonymous user's sessions** | None; identity is already established |

A stable machine id is banned in telemetry *precisely because* it de-anonymizes an otherwise anonymous stream. That hazard doesn't exist for metadata attached to a credential the user is knowingly creating. The label answers *which machine*, never *who*.

This PR ships the ADR amendment (new §6 + a summary-matrix row) rather than leaving the scoping to be inferred from section nesting.

**Data minimization applied:** first DNS label only (`laptop`, not `laptop.corp.internal` — the domain identifies an employer more than a machine); allowlisted to `[A-Za-z0-9._-]`; truncated to 32 (user) + 63 (host, the DNS label max, so no legal hostname is ever cut).

## Sanitization is an allowlist, not a denylist

A hostname is attacker-influenceable on a shared box, and the label is transmitted then rendered in a web UI. The allowed set is the intersection of what's safe in a GitLab PAT name, an HTTP header, a JSON string and a URL segment — so everything below `0x20`, `0x7F`, and all non-ASCII is excluded *by construction*:

| Input | Output |
|---|---|
| `a\r\nX-Evil: 1` | `a-X-Evil-1` |
| `"><script>alert(1)</script>` | `script-alert-1-script` |
| `ryan@corp` | `ryan-corp` — an `@` in a *part* is neutralized, so the single `@` in the output is always the composer's |
| 200-char hostname | truncated to 63 |

## Test Plan

- **`TestPollToken_SendsDeviceLabel`** — decodes the actual request body; asserts the pre-existing fields are untouched and the label matches the shape contract.
- **`TestPollToken_OmitsDeviceLabelWhenOptedOut`** — asserts the **key is absent**, not present-and-empty. That's what proves `omitempty`: an empty string would still be a wire change, which an opt-out must not be.
- **`TestDeviceLabel_HostileHostnameStillProducesASafeLabel`** — property test over injection payloads.
- **`TestOptedOutOfDeviceLabel`** — pins truthiness, including that `SAGEOX_NO_DEVICE_LABEL=0` means labels **on**, as it reads.
- `internal/auth/env_naming_test.go` (the `OX_*` guard) still passes; `make lint` clean.

## Follow-up, deliberately out of scope

Not sending the label on the earlier `/api/auth/device/code` request. Showing "you are authorizing ryan@laptop" on the approval screen *before* consent is genuinely better security UX, but it needs a second backend change and an approval-screen design decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login requests now include a sanitized device label when available, helping identify the associated device.
  * Labels follow safety and length limits and are stored separately from telemetry.

* **Privacy**
  * Set `SAGEOX_NO_DEVICE_LABEL=1` to prevent device labels from being sent during login.
  * Documented device-label handling, transmitted data, storage, and opt-out behavior, including CI/CD guidance.

* **Tests**
  * Added coverage for label formatting, safety limits, hostile input, and opt-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->