### PR TITLE
fix(daemon): break the session-finalize retry loop that pinned the CPU

### DIFF
--- a/internal/daemon/agentwork/intent_test.go
+++ b/internal/daemon/agentwork/intent_test.go
@@ -136,6 +136,33 @@ func TestManager_UnpushableSession_SurfacesAsFailure(t *testing.T) {
 const leaseHelperEnv = "OX_TEST_HOLD_LEDGER_LEASE"
 
 // TestHelperHoldsLedgerLease is not a test. It is the subprocess half of
+// startLeaseHolder re-executes this test binary as a subprocess that acquires
+// the ledger lease and then blocks. It returns once the subprocess is confirmed
+// holding the lease; callers own killing it.
+func startLeaseHolder(t *testing.T, ledger string) *exec.Cmd {
+	t.Helper()
+
+	helper := exec.Command(os.Args[0], "-test.run=TestHelperHoldsLedgerLease", "-test.timeout=90s")
+	helper.Env = append(os.Environ(), leaseHelperEnv+"="+ledger)
+	if err := helper.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+
+	readyFile := filepath.Join(ledger, "helper-ready")
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if _, err := os.Stat(readyFile); err == nil {
+			return helper
+		}
+		if time.Now().After(deadline) {
+			_ = helper.Process.Kill()
+			_ = helper.Wait()
+			t.Fatal("helper never acquired the lease")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // TestOwnsLedgerAntiEntropy_DeniedWhileAnotherProcessHolds: it takes the lease,
 // signals readiness, and blocks until killed.
 func TestHelperHoldsLedgerLease(t *testing.T) {
@@ -165,27 +192,11 @@ func TestHelperHoldsLedgerLease(t *testing.T) {
 func TestOwnsLedgerAntiEntropy_DeniedWhileAnotherProcessHolds(t *testing.T) {
 	ledger := t.TempDir()
 
-	helper := exec.Command(os.Args[0], "-test.run=TestHelperHoldsLedgerLease", "-test.timeout=90s")
-	helper.Env = append(os.Environ(), leaseHelperEnv+"="+ledger)
-	if err := helper.Start(); err != nil {
-		t.Fatalf("start helper: %v", err)
-	}
+	helper := startLeaseHolder(t, ledger)
 	t.Cleanup(func() {
 		_ = helper.Process.Kill()
 		_ = helper.Wait()
 	})
-
-	readyFile := filepath.Join(ledger, "helper-ready")
-	deadline := time.Now().Add(30 * time.Second)
-	for {
-		if _, err := os.Stat(readyFile); err == nil {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("helper never acquired the lease")
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
 
 	m, _ := newTestManager(NewMockRunner(true), func() *config.AgentWorkerConfig {
 		return enabledConfigWith(1, 10)
@@ -204,24 +215,7 @@ func TestOwnsLedgerAntiEntropy_DeniedWhileAnotherProcessHolds(t *testing.T) {
 func TestOwnsLedgerAntiEntropy_TakesOverAfterHolderExits(t *testing.T) {
 	ledger := t.TempDir()
 
-	helper := exec.Command(os.Args[0], "-test.run=TestHelperHoldsLedgerLease", "-test.timeout=90s")
-	helper.Env = append(os.Environ(), leaseHelperEnv+"="+ledger)
-	if err := helper.Start(); err != nil {
-		t.Fatalf("start helper: %v", err)
-	}
-
-	readyFile := filepath.Join(ledger, "helper-ready")
-	deadline := time.Now().Add(30 * time.Second)
-	for {
-		if _, err := os.Stat(readyFile); err == nil {
-			break
-		}
-		if time.Now().After(deadline) {
-			_ = helper.Process.Kill()
-			t.Fatal("helper never acquired the lease")
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	helper := startLeaseHolder(t, ledger)
 
 	// kill -9: the kernel, not the process, must release the flock
 	if err := helper.Process.Kill(); err != nil {

--- a/internal/daemon/agentwork/intent_test.go
+++ b/internal/daemon/agentwork/intent_test.go
@@ -1,0 +1,313 @@
+package agentwork
+
+// Tests for the INTENT of the anti-entropy wedge fixes, as opposed to the
+// mechanics of the individual functions.
+//
+// The mechanics were already well covered when the daemon wedged for months. What
+// was missing was any test of what the mechanics are FOR:
+//
+//   - a failed finalize must be recorded by the manager as a failure (not just
+//     returned as an error by the handler)
+//   - a second PROCESS must not run the same ledger's detection scan
+//   - a full queue must cost one log line per cycle, not one per rejected item
+//
+// Each test below asserts an observable outcome a user or operator would care
+// about, and each fails against the pre-fix code.
+
+import (
+	"context"
+
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+)
+
+// --- log capture ---
+
+// countingHandler records slog messages so tests can assert on log volume and
+// level, which is the actual deliverable for the queue-full change.
+type countingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *countingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *countingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// countMessages returns how many captured records have the given message at or
+// above the given level.
+func (h *countingHandler) countMessages(msg string, minLevel slog.Level) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, r := range h.records {
+		if r.Message == msg && r.Level >= minLevel {
+			n++
+		}
+	}
+	return n
+}
+
+// --- intent 1: a failed finalize is recorded as a failure ---
+
+// TestManager_UnpushableSession_SurfacesAsFailure asserts the outcome an
+// operator sees, end to end through the REAL session-finalize handler rather
+// than a mock. A mock handler would only exercise manager plumbing that was
+// always correct; the defect was the handler reporting nil, so the wedge has to
+// be driven from a genuinely unpushable session for this assertion to mean
+// anything.
+//
+// Before the fix this recorded 897 failures a day as successes, and no counter
+// ever moved — which is why nothing surfaced the problem.
+func TestManager_UnpushableSession_SurfacesAsFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, clonePath := setupBareAndCloneLedger(t)
+	runGitCmd(t, clonePath, "remote", "set-url", "origin", "/nonexistent/broken/remote.git")
+
+	sessionName := "2026-01-15T18-00-testuser-OxSTATUS"
+	cacheDir := writeProductionShapedSession(t, clonePath, sessionName)
+
+	handler := newGitBackedHandler()
+
+	m, _ := newTestManager(NewMockRunner(true), func() *config.AgentWorkerConfig {
+		return enabledConfigWith(1, 10)
+	})
+	m.RegisterHandler(handler)
+
+	m.executeItem(context.Background(), &WorkItem{
+		ID:       "intent-failure",
+		Type:     sessionFinalizeType,
+		DedupKey: sessionFinalizeType + ":" + sessionName,
+		Payload: &SessionFinalizePayload{
+			SessionDir: cacheDir,
+			RawPath:    filepath.Join(cacheDir, "raw.jsonl"),
+			LedgerPath: clonePath,
+			UploadOnly: true,
+		},
+	})
+
+	status := m.Status()
+	if status.Stats.Failures != 1 {
+		t.Errorf("Stats.Failures = %d, want 1 — a failed finalize was not counted as a failure",
+			status.Stats.Failures)
+	}
+	if status.Stats.Successes != 0 {
+		t.Errorf("Stats.Successes = %d, want 0 — a failed finalize was counted as a success",
+			status.Stats.Successes)
+	}
+
+	var sawFailed bool
+	for _, rec := range status.Recent {
+		if rec.Status == statusFailed {
+			sawFailed = true
+		}
+	}
+	if !sawFailed {
+		t.Error("no recent entry recorded with status=failed — `ox daemon status` would show this as healthy")
+	}
+}
+
+// --- intent 2: a second process does not scan the same ledger ---
+
+// leaseHelperEnv carries the ledger path to the helper subprocess. Its presence
+// is what tells the re-executed test binary to act as the lease holder.
+const leaseHelperEnv = "OX_TEST_HOLD_LEDGER_LEASE"
+
+// TestHelperHoldsLedgerLease is not a test. It is the subprocess half of
+// TestOwnsLedgerAntiEntropy_DeniedWhileAnotherProcessHolds: it takes the lease,
+// signals readiness, and blocks until killed.
+func TestHelperHoldsLedgerLease(t *testing.T) {
+	ledger := os.Getenv(leaseHelperEnv)
+	if ledger == "" {
+		t.Skip("subprocess helper; not run directly")
+	}
+
+	lease, err := acquireLedgerLease(ledger)
+	if err != nil || lease == nil {
+		t.Fatalf("helper could not acquire lease: lease=%v err=%v", lease, err)
+	}
+	defer func() { _ = lease.Release() }()
+
+	if err := os.WriteFile(filepath.Join(ledger, "helper-ready"), []byte("1"), 0644); err != nil {
+		t.Fatalf("helper ready signal: %v", err)
+	}
+	// hold well past the parent's assertions; the parent kills us
+	time.Sleep(60 * time.Second)
+}
+
+// TestOwnsLedgerAntiEntropy_DeniedWhileAnotherProcessHolds is the test that
+// actually covers ox-4qvn. flock is per-open-file-description, so two acquires
+// inside ONE process can both succeed — an in-process test would pass while the
+// real duplicate-daemon case stayed broken. Only a second OS process proves the
+// exclusion, so this re-executes the test binary as a lease holder.
+func TestOwnsLedgerAntiEntropy_DeniedWhileAnotherProcessHolds(t *testing.T) {
+	ledger := t.TempDir()
+
+	helper := exec.Command(os.Args[0], "-test.run=TestHelperHoldsLedgerLease", "-test.timeout=90s")
+	helper.Env = append(os.Environ(), leaseHelperEnv+"="+ledger)
+	if err := helper.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = helper.Process.Kill()
+		_ = helper.Wait()
+	})
+
+	readyFile := filepath.Join(ledger, "helper-ready")
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("helper never acquired the lease")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	m, _ := newTestManager(NewMockRunner(true), func() *config.AgentWorkerConfig {
+		return enabledConfigWith(1, 10)
+	})
+	m.ledgerPath = ledger
+
+	if m.ownsLedgerAntiEntropy() {
+		t.Error("a second process claimed anti-entropy while another held the lease — " +
+			"both daemons would scan the ledger and each enforce its own invocation ceiling")
+	}
+}
+
+// TestOwnsLedgerAntiEntropy_TakesOverAfterHolderExits asserts the recovery half:
+// a lease abandoned by a dead process must be claimable, or a daemon restart
+// would permanently lose anti-entropy for that ledger.
+func TestOwnsLedgerAntiEntropy_TakesOverAfterHolderExits(t *testing.T) {
+	ledger := t.TempDir()
+
+	helper := exec.Command(os.Args[0], "-test.run=TestHelperHoldsLedgerLease", "-test.timeout=90s")
+	helper.Env = append(os.Environ(), leaseHelperEnv+"="+ledger)
+	if err := helper.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+
+	readyFile := filepath.Join(ledger, "helper-ready")
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = helper.Process.Kill()
+			t.Fatal("helper never acquired the lease")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// kill -9: the kernel, not the process, must release the flock
+	if err := helper.Process.Kill(); err != nil {
+		t.Fatalf("kill helper: %v", err)
+	}
+	_ = helper.Wait()
+
+	m, _ := newTestManager(NewMockRunner(true), func() *config.AgentWorkerConfig {
+		return enabledConfigWith(1, 10)
+	})
+	m.ledgerPath = ledger
+	t.Cleanup(m.releaseLedgerAntiEntropy)
+
+	if !m.ownsLedgerAntiEntropy() {
+		t.Error("lease not reclaimable after the holder died — anti-entropy would stop for this ledger forever")
+	}
+}
+
+// --- intent 3: a full queue costs one log line per cycle ---
+
+// TestDetectAndEnqueue_FullQueueLogsOncePerCycle asserts the operator-visible
+// deliverable: a backlog larger than the queue must not write a WARN per item.
+// The pre-fix behavior produced 43,996 WARN lines in a single day and was the
+// largest single contributor to a 511MB log file.
+func TestDetectAndEnqueue_FullQueueLogsOncePerCycle(t *testing.T) {
+	const backlog = maxQueueDepth * 3
+
+	items := make([]*WorkItem, 0, backlog)
+	for i := 0; i < backlog; i++ {
+		items = append(items, &WorkItem{
+			Type:     sessionFinalizeType,
+			DedupKey: sessionFinalizeType + ":" + strings.Repeat("s", i%7) + itoa(i),
+		})
+	}
+
+	capture := &countingHandler{}
+	m, _ := newTestManager(NewMockRunner(true), func() *config.AgentWorkerConfig {
+		return enabledConfigWith(1, 10)
+	})
+	m.logger = slog.New(capture)
+	m.queue = NewWorkQueue(slog.New(capture))
+	m.ledgerPath = "" // fail open: no lease needed for this assertion
+	m.RegisterHandler(&mockHandler{typ: sessionFinalizeType, detectItems: items})
+
+	m.detectAndEnqueue(enabledConfigWith(1, 10))
+
+	perItem := capture.countMessages("enqueue skipped: queue full", slog.LevelInfo)
+	if perItem != 0 {
+		t.Errorf("%d per-item queue-full lines logged at INFO or above, want 0 — "+
+			"a large backlog floods the daemon log every 5 minutes", perItem)
+	}
+
+	summary := capture.countMessages("detect backlog exceeds queue capacity", slog.LevelInfo)
+	if summary != 1 {
+		t.Errorf("got %d backlog summary lines, want exactly 1 — the operator must still be told "+
+			"the queue is saturated", summary)
+	}
+}
+
+// TestWorkQueue_TakeRejectedResets guards the counter that makes the summary
+// per-cycle rather than cumulative: a second cycle with no rejections must not
+// re-report the first cycle's count.
+func TestWorkQueue_TakeRejectedResets(t *testing.T) {
+	q := NewWorkQueue(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	for i := 0; i < maxQueueDepth+5; i++ {
+		q.Enqueue(&WorkItem{Type: sessionFinalizeType, DedupKey: sessionFinalizeType + ":" + itoa(i)})
+	}
+
+	if got := q.TakeRejected(); got != 5 {
+		t.Errorf("TakeRejected = %d, want 5", got)
+	}
+	if got := q.TakeRejected(); got != 0 {
+		t.Errorf("TakeRejected = %d on a second call, want 0 — the summary would repeat a stale count", got)
+	}
+}
+
+// itoa avoids pulling strconv in for two call sites in this file.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/daemon/agentwork/ledger_lease.go
+++ b/internal/daemon/agentwork/ledger_lease.go
@@ -74,12 +74,18 @@ func acquireLedgerLease(ledgerPath string) (*ledgerLease, error) {
 }
 
 // Release drops the lock. Idempotent.
+//
+// A failed release is still a release: both platform backends close the
+// underlying file before returning an error, and closing the fd is what drops
+// the kernel's flock. Restoring held=1 to "allow a retry" would be wrong twice
+// over — the retry could only ever fail with EBADF on the closed fd, and
+// meanwhile this process would claim a lease the kernel has already handed on.
+// The error is reported; ownership is not reasserted.
 func (l *ledgerLease) Release() error {
 	if l == nil || !l.held.CompareAndSwap(1, 0) {
 		return nil
 	}
 	if err := platformReleaseLedgerLease(l.file); err != nil {
-		l.held.Store(1) // let the caller retry rather than stranding ownership
 		return fmt.Errorf("release ledger lease: %w", err)
 	}
 	return nil

--- a/internal/daemon/agentwork/ledger_lease.go
+++ b/internal/daemon/agentwork/ledger_lease.go
@@ -1,0 +1,86 @@
+package agentwork
+
+// Cross-process leader election for a ledger's anti-entropy work (the
+// session-finalize detection scan and the agent invocations it queues).
+//
+// Two daemons for the same repo is a supported state — see the "Liveness
+// Detection: Socket Ping" note in daemon.go, which reasons that a duplicate is
+// harmless because one exits on its 1h inactivity timeout. That reasoning holds
+// only for an idle daemon. A daemon with a session backlog is never idle: it
+// re-runs the detection scan every 5 minutes and stays alive indefinitely.
+//
+// Observed cost of that gap: two daemons on one 5,400-session ledger, each
+// walking every session directory every 5 minutes, each enforcing its own
+// 60-invocations/hour rate limit — so the effective ceiling was twice the
+// configured one, against a machine budget of nothing.
+//
+// The lease is scoped to the ledger rather than the daemon so that a duplicate
+// daemon keeps doing its cheap per-repo work (sync, heartbeats, IPC) and only
+// the expensive shared scan is serialized. Acquisition is attempted once per
+// detection cycle and held for the process lifetime; the kernel releases the
+// flock on process death, so a crashed owner strands nothing.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+)
+
+// ledgerLeaseFileName lives under the ledger's cache dir, which .sageox/.gitignore
+// already excludes from git.
+const ledgerLeaseFileName = ".anti-entropy.lock"
+
+// ledgerLease is an advisory lock claiming ownership of one ledger's
+// anti-entropy work. The zero value is not usable; construct via
+// acquireLedgerLease.
+type ledgerLease struct {
+	file *os.File
+	held atomic.Int32
+}
+
+// ledgerLeasePath returns the lock file path for a ledger, creating its parent
+// directory if needed.
+func ledgerLeasePath(ledgerPath string) (string, error) {
+	if ledgerPath == "" {
+		return "", fmt.Errorf("empty ledger path")
+	}
+	dir := filepath.Join(ledgerPath, ".sageox", "cache")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create ledger lease dir: %w", err)
+	}
+	return filepath.Join(dir, ledgerLeaseFileName), nil
+}
+
+// acquireLedgerLease attempts a non-blocking exclusive lock on the ledger's
+// anti-entropy lease. Returns (nil, nil) when another process holds it — that is
+// an ordinary outcome, not an error. A non-nil error means the filesystem, not
+// contention, got in the way.
+func acquireLedgerLease(ledgerPath string) (*ledgerLease, error) {
+	path, err := ledgerLeasePath(ledgerPath)
+	if err != nil {
+		return nil, err
+	}
+	f, acquired, err := platformAcquireLedgerLease(path)
+	if err != nil {
+		return nil, err
+	}
+	if !acquired {
+		return nil, nil
+	}
+	l := &ledgerLease{file: f}
+	l.held.Store(1)
+	return l, nil
+}
+
+// Release drops the lock. Idempotent.
+func (l *ledgerLease) Release() error {
+	if l == nil || !l.held.CompareAndSwap(1, 0) {
+		return nil
+	}
+	if err := platformReleaseLedgerLease(l.file); err != nil {
+		l.held.Store(1) // let the caller retry rather than stranding ownership
+		return fmt.Errorf("release ledger lease: %w", err)
+	}
+	return nil
+}

--- a/internal/daemon/agentwork/ledger_lease_test.go
+++ b/internal/daemon/agentwork/ledger_lease_test.go
@@ -1,0 +1,71 @@
+package agentwork
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/internal/config"
+)
+
+// TestLedgerLease_SecondHolderIsDenied is the property that stops two daemons
+// on one repo from each running the full session scan and each enforcing its own
+// invocation ceiling. Observed before this existed: two daemons on a
+// 5,400-session ledger, both scanning every 5 minutes.
+func TestLedgerLease_SecondHolderIsDenied(t *testing.T) {
+	ledger := t.TempDir()
+
+	first, err := acquireLedgerLease(ledger)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if first == nil {
+		t.Fatal("first acquire returned no lease on an uncontended ledger")
+	}
+	t.Cleanup(func() { _ = first.Release() })
+
+	// NOTE: flock is per-open-file-description, so a second acquire in THIS
+	// process legitimately succeeds on some platforms. The contract under test is
+	// that acquiring is safe and releasing hands ownership back — the
+	// cross-process exclusion is enforced by the kernel.
+	if err := first.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	second, err := acquireLedgerLease(ledger)
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	if second == nil {
+		t.Error("lease not reacquirable after release — a daemon restart would never regain anti-entropy")
+	}
+	t.Cleanup(func() { _ = second.Release() })
+}
+
+// TestLedgerLease_ReleaseIsIdempotent guards against double-release stranding
+// ownership: Release restores held-state on failure, so a buggy repeat call must
+// not flip it back on.
+func TestLedgerLease_ReleaseIsIdempotent(t *testing.T) {
+	lease, err := acquireLedgerLease(t.TempDir())
+	if err != nil || lease == nil {
+		t.Fatalf("acquire: lease=%v err=%v", lease, err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("first release: %v", err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Errorf("second release should be a no-op, got %v", err)
+	}
+}
+
+// TestOwnsLedgerAntiEntropy_FailsOpenWithoutLedger keeps the detection loop
+// running when there is no ledger path to lock. A ledger that stops self-healing
+// is worse than one scanned twice.
+func TestOwnsLedgerAntiEntropy_FailsOpenWithoutLedger(t *testing.T) {
+	m, _ := newTestManager(NewMockRunner(true), func() *config.AgentWorkerConfig {
+		return enabledConfigWith(1, 10)
+	})
+	m.ledgerPath = ""
+
+	if !m.ownsLedgerAntiEntropy() {
+		t.Error("anti-entropy skipped when no ledger path is set — detection would never run")
+	}
+}

--- a/internal/daemon/agentwork/ledger_lease_unix.go
+++ b/internal/daemon/agentwork/ledger_lease_unix.go
@@ -1,0 +1,43 @@
+//go:build unix
+
+package agentwork
+
+// POSIX flock(2) backend for acquireLedgerLease. Mirrors
+// daemon/global_lease_unix.go: stdlib syscall.Flock, LOCK_EX|LOCK_NB, with both
+// EWOULDBLOCK and EAGAIN meaning "another process holds it."
+//
+// The lease file is never deleted — unlinking it would let a second process
+// create and lock a different inode while the first still holds the old one.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func platformAcquireLedgerLease(path string) (*os.File, bool, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, fmt.Errorf("open ledger lease file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("flock ledger lease file: %w", err)
+	}
+	return f, true, nil
+}
+
+func platformReleaseLedgerLease(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_UN); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("unlock ledger lease file: %w", err)
+	}
+	return f.Close()
+}

--- a/internal/daemon/agentwork/ledger_lease_windows.go
+++ b/internal/daemon/agentwork/ledger_lease_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package agentwork
+
+// Windows fallback for acquireLedgerLease, matching the posture of
+// daemon/global_lease_windows.go: daemon support on Windows is POSIX-first and
+// single-daemon-per-host, so the duplicate-daemon race this lease prevents does
+// not materialize there. Report acquired=true so anti-entropy still runs.
+
+import (
+	"fmt"
+	"os"
+)
+
+func platformAcquireLedgerLease(path string) (*os.File, bool, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, fmt.Errorf("open ledger lease file %s: %w", path, err)
+	}
+	return f, true, nil
+}
+
+func platformReleaseLedgerLease(f *os.File) error {
+	if f == nil {
+		return nil
+	}
+	return f.Close()
+}

--- a/internal/daemon/agentwork/manager.go
+++ b/internal/daemon/agentwork/manager.go
@@ -289,6 +289,10 @@ func (m *Manager) detectAndEnqueue(cfg *config.AgentWorkerConfig) {
 	m.runSessionCleanup()
 
 	if cfg == nil || !isEffectivelyEnabled(cfg) {
+		// Hand the lease back. A daemon that acquired it in an earlier cycle and
+		// then had its worker disabled would otherwise hold it until process exit,
+		// blocking every other daemon on this ledger from ever running detection.
+		m.releaseLedgerAntiEntropy()
 		return
 	}
 
@@ -390,13 +394,21 @@ func (m *Manager) ownsLedgerAntiEntropy() bool {
 }
 
 // releaseLedgerAntiEntropy drops the lease so another daemon can take over
-// without waiting for this process to die.
+// without waiting for this process to die. Safe to call when no lease is held.
+//
+// The reference is cleared unconditionally, including when Release reports an
+// error: the fd is closed either way, so the kernel has already dropped the
+// flock. Retaining it for a retry would only let this Manager believe it still
+// owns a lease another process can now hold.
 func (m *Manager) releaseLedgerAntiEntropy() {
 	m.mu.Lock()
 	lease := m.ledgerLease
 	m.ledgerLease = nil
 	m.mu.Unlock()
 
+	if lease == nil {
+		return
+	}
 	if err := lease.Release(); err != nil {
 		m.logger.Warn("failed to release ledger anti-entropy lease", "error", err)
 	}

--- a/internal/daemon/agentwork/manager.go
+++ b/internal/daemon/agentwork/manager.go
@@ -103,6 +103,10 @@ type Manager struct {
 	// ledger path for handler detection
 	ledgerPath string
 
+	// cross-process claim on this ledger's anti-entropy work. nil means not held;
+	// guarded by mu.
+	ledgerLease *ledgerLease
+
 	// project root (the actual working repo) for writing project-local agent
 	// tasks. Empty disables the task producer.
 	projectRoot string
@@ -198,6 +202,7 @@ func (m *Manager) Enqueue(item *WorkItem) bool {
 func (m *Manager) Start(ctx context.Context) {
 	doctorTicker := time.NewTicker(doctorInterval)
 	defer doctorTicker.Stop()
+	defer m.releaseLedgerAntiEntropy()
 
 	m.logger.Info("agent work manager started")
 
@@ -287,6 +292,13 @@ func (m *Manager) detectAndEnqueue(cfg *config.AgentWorkerConfig) {
 		return
 	}
 
+	// Only one process scans a given ledger. Without this, two daemons for the
+	// same repo each walked every session directory every 5 minutes and each
+	// enforced its own invocation ceiling, doubling both.
+	if !m.ownsLedgerAntiEntropy() {
+		return
+	}
+
 	m.mu.Lock()
 	handlers := make([]WorkHandler, 0, len(m.handlers))
 	for _, h := range m.handlers {
@@ -329,6 +341,64 @@ func (m *Manager) detectAndEnqueue(cfg *config.AgentWorkerConfig) {
 				m.logger.Info("detected agent work", "type", item.Type, "dedup_key", item.DedupKey)
 			}
 		}
+
+		// one line per cycle, not one per rejected item
+		if rejected := m.queue.TakeRejected(); rejected > 0 {
+			m.logger.Info("detect backlog exceeds queue capacity",
+				"type", h.Type(),
+				"detected", len(items),
+				"rejected", rejected,
+				"max_depth", maxQueueDepth,
+			)
+		}
+	}
+}
+
+// ownsLedgerAntiEntropy reports whether this process holds the ledger's
+// anti-entropy lease, acquiring it if free. Retried every cycle rather than once
+// at startup so a daemon that loses the race still takes over when the owner
+// exits — the kernel drops the flock on process death.
+//
+// Fails open: if the lock cannot be evaluated (no ledger path, filesystem
+// error), anti-entropy runs. A ledger that stops self-healing is a worse outcome
+// than one scanned twice.
+func (m *Manager) ownsLedgerAntiEntropy() bool {
+	if m.ledgerPath == "" {
+		return true
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.ledgerLease != nil {
+		return true
+	}
+
+	lease, err := acquireLedgerLease(m.ledgerPath)
+	if err != nil {
+		m.logger.Warn("could not evaluate ledger anti-entropy lease, proceeding", "ledger", m.ledgerPath, "error", err)
+		return true
+	}
+	if lease == nil {
+		m.logger.Debug("another daemon owns anti-entropy for this ledger, skipping detection", "ledger", m.ledgerPath)
+		return false
+	}
+
+	m.ledgerLease = lease
+	m.logger.Info("acquired ledger anti-entropy lease", "ledger", m.ledgerPath)
+	return true
+}
+
+// releaseLedgerAntiEntropy drops the lease so another daemon can take over
+// without waiting for this process to die.
+func (m *Manager) releaseLedgerAntiEntropy() {
+	m.mu.Lock()
+	lease := m.ledgerLease
+	m.ledgerLease = nil
+	m.mu.Unlock()
+
+	if err := lease.Release(); err != nil {
+		m.logger.Warn("failed to release ledger anti-entropy lease", "error", err)
 	}
 }
 

--- a/internal/daemon/agentwork/queue.go
+++ b/internal/daemon/agentwork/queue.go
@@ -84,6 +84,7 @@ type WorkQueue struct {
 	items      itemHeap
 	queued     map[string]struct{} // dedup keys currently in the queue
 	inProgress map[string]struct{} // dedup keys currently being processed
+	rejected   int                 // capacity rejections since the last TakeRejected
 	logger     *slog.Logger
 }
 
@@ -109,7 +110,12 @@ func (q *WorkQueue) Enqueue(item *WorkItem) bool {
 	defer q.mu.Unlock()
 
 	if q.items.Len() >= maxQueueDepth {
-		q.logger.Warn("enqueue skipped: queue full", "depth", q.items.Len(), "max", maxQueueDepth, "dedup_key", item.DedupKey)
+		// Rejection is expected whenever the backlog exceeds the cap — the item is
+		// re-detected next cycle. Counting here and letting the caller emit one
+		// summary line keeps a large backlog from writing a log line per item per
+		// cycle (43,996 WARNs in one day on a 5,400-session backlog).
+		q.rejected++
+		q.logger.Debug("enqueue skipped: queue full", "depth", q.items.Len(), "max", maxQueueDepth, "dedup_key", item.DedupKey)
 		return false
 	}
 
@@ -137,6 +143,17 @@ func (q *WorkQueue) Enqueue(item *WorkItem) bool {
 	}
 	q.logger.Debug("enqueued work item", "id", item.ID, "type", item.Type, "priority", item.Priority, "dedup_key", item.DedupKey)
 	return true
+}
+
+// TakeRejected returns the number of items rejected for capacity since the last
+// call and resets the counter. Callers report it once per detection cycle rather
+// than logging each rejection.
+func (q *WorkQueue) TakeRejected() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	n := q.rejected
+	q.rejected = 0
+	return n
 }
 
 // Dequeue removes and returns the highest-priority item, or nil if the queue

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -1,6 +1,7 @@
 package agentwork
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -471,26 +472,30 @@ func (h *SessionFinalizeHandler) detectInDir(sessionsDir, ledgerPath string) ([]
 				continue
 			}
 
-			// Truly finalized. If this session is in the ledger cache
-			// but not yet in the git-tracked sessions/ dir, it needs to be pushed.
+			// Truly finalized. Presence in the ledger cache IS the pending marker:
+			// processUploadOnly prunes the cache dir only after a verified commit
+			// and push, so anything still here has not landed.
+			//
+			// This used to also require sessions/<name>/meta.json to be absent,
+			// which made completion depend on a file whose write is not tied to a
+			// successful push. A session whose commit landed but whose push failed
+			// would then look complete and never be retried — the cache prune is
+			// the only signal that actually means "it reached the remote".
 			if isInLedgerCacheDir(sessionDir, ledgerPath) {
-				ledgerMeta := filepath.Join(ledgerPath, "sessions", name, "meta.json")
-				if _, statErr := os.Stat(ledgerMeta); os.IsNotExist(statErr) {
-					h.logger.Info("session needs upload (fully finalized, not pushed)",
-						"session", name,
-					)
-					items = append(items, &WorkItem{
-						Type:     sessionFinalizeType,
-						Priority: sessionFinalizePriority,
-						DedupKey: sessionFinalizeType + ":" + name,
-						Payload: &SessionFinalizePayload{
-							SessionDir: sessionDir,
-							RawPath:    rawPath,
-							LedgerPath: ledgerPath,
-							UploadOnly: true,
-						},
-					})
-				}
+				h.logger.Info("session needs upload (fully finalized, not pushed)",
+					"session", name,
+				)
+				items = append(items, &WorkItem{
+					Type:     sessionFinalizeType,
+					Priority: sessionFinalizePriority,
+					DedupKey: sessionFinalizeType + ":" + name,
+					Payload: &SessionFinalizePayload{
+						SessionDir: sessionDir,
+						RawPath:    rawPath,
+						LedgerPath: ledgerPath,
+						UploadOnly: true,
+					},
+				})
 			}
 			continue
 		}
@@ -1514,12 +1519,18 @@ func (h *SessionFinalizeHandler) processUploadOnly(payload *SessionFinalizePaylo
 					if err := lfs.MutateSessionMeta(context.Background(), payload.SessionDir,
 						func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
 							if current == nil {
-								return nil, nil // no meta.json to update — nothing to do
+								// No meta.json on disk. Detect() cannot mark this
+								// session landed without one, so bailing here (as
+								// this used to) left it re-queued every cycle
+								// forever. Seed one — there is nothing to preserve
+								// when the file is absent, so seeding strips
+								// nothing.
+								current = h.synthesizeMeta(payload.SessionDir, sessionName)
 							}
 							// merge, never replace: UploadSessionFiles omits
 							// summary.json, so assigning the LFS list wholesale
 							// would drop its Storage=git registration — the same
-							// field-stripping class this PR exists to fix.
+							// field-stripping class GH #710 exists to fix.
 							current.Files = h.mergeFileRefs(current.Files, fileRefs, sessionName)
 							return current, nil
 						}); err != nil {
@@ -1528,6 +1539,25 @@ func (h *SessionFinalizeHandler) processUploadOnly(payload *SessionFinalizePaylo
 				}
 			}
 		}
+	}
+
+	// A session must reach git carrying a meta.json, whatever happened above: it
+	// is the record of what the session WAS, and the LFS branch that writes one
+	// is skipped whenever LFS is disabled or produced no refs.
+	//
+	// Goes through MutateSessionMeta under the same lock as every other writer,
+	// and seeds ONLY when the file is genuinely absent — it never rebuilds an
+	// existing one, which is the field-stripping class GH #710 fixed.
+	if err := lfs.MutateSessionMeta(context.Background(), payload.SessionDir,
+		func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+			if current != nil {
+				return nil, nil // already present; leave every field alone
+			}
+			seeded := h.synthesizeMeta(payload.SessionDir, sessionName)
+			seeded.Files = h.mergeFileRefs(nil, fileRefs, sessionName)
+			return seeded, nil
+		}); err != nil {
+		h.logger.Warn("upload-only: meta.json seed failed", "session", sessionName, "err", err)
 	}
 
 	sessionsDir := filepath.Dir(payload.SessionDir)
@@ -1554,9 +1584,14 @@ func (h *SessionFinalizeHandler) processUploadOnly(payload *SessionFinalizePaylo
 			h.logger.Debug("upload-only: prune cache", "dir", origCacheDir, "err", err)
 		}
 		h.logger.Info("session uploaded via anti-entropy (upload-only)", "session", sessionName)
+		return nil
 	}
 
-	return nil
+	// Report the failure. Returning nil here made the manager log
+	// "agent work complete status=success" for 897 consecutive failed commits in
+	// a single day, which is why the wedge stayed invisible while the backlog
+	// grew to ~3,000 sessions.
+	return fmt.Errorf("upload-only: session %s not committed or pushed", sessionName)
 }
 
 // gitCommitAndPush stages, commits, and pushes the finalized session.
@@ -1590,11 +1625,38 @@ func (h *SessionFinalizeHandler) gitCommitAndPush(payload *SessionFinalizePayloa
 		return false
 	}
 
-	// git commit
-	msg := fmt.Sprintf("finalize session %s", sessionName)
-	if err := h.runGit(ledgerPath, "commit", "-m", msg); err != nil {
-		h.logger.Warn("git commit failed", "err", err)
+	// A zero-delta stage is the NORMAL outcome for a session whose files already
+	// match HEAD — stageSessionInLedger copies the cache over an already-committed
+	// sessions/<name>/, so git has nothing to record and `git commit` exits 1.
+	// Treating that as failure made the caller skip the cache prune, which left the
+	// session in .sageox/cache/ for Detect() to re-enqueue five minutes later,
+	// forever. The content is in git either way; that is what the caller needs.
+	//
+	// Ask git what is staged rather than parsing the commit's message: the wording
+	// varies with the rest of the tree ("working tree clean" vs "untracked files
+	// present"), so an unrelated stray file in the ledger would resurrect the loop.
+	staged, err := h.hasStagedChanges(ledgerPath)
+	if err != nil {
+		h.logger.Warn("could not inspect staged changes", "err", err)
 		return false
+	}
+
+	msg := fmt.Sprintf("finalize session %s", sessionName)
+	switch {
+	case !staged:
+		// Fall through to the push: the commit may exist locally from an earlier
+		// cycle and still be unpushed.
+		h.logger.Debug("session already committed, nothing new to stage", "session", sessionName)
+	default:
+		if err := h.runGit(ledgerPath, "commit", "-m", msg); err != nil {
+			// A concurrent committer (a second daemon on the same ledger) can empty
+			// the index between the check above and this commit.
+			if !isNothingToCommit(err) {
+				h.logger.Warn("git commit failed", "err", err)
+				return false
+			}
+			h.logger.Debug("session committed concurrently", "session", sessionName)
+		}
 	}
 
 	// push with retry (best-effort — failures are non-fatal)
@@ -1673,6 +1735,54 @@ func (h *SessionFinalizeHandler) gitCommitPointerRewrite(payload *SessionFinaliz
 	})
 }
 
+// synthesizeMeta builds a minimal meta.json from the raw.jsonl header for a
+// session that has none.
+//
+// Callers must already hold the meta lock and must only use this when meta.json
+// is absent — it deliberately does not read the existing file, so using it as a
+// base for a present one would strip every field it does not set.
+//
+// The upload-only path has no summarizer output to draw on, so the result
+// carries identity and provenance only — never a fabricated title or summary.
+// An absent summary is honest; an invented one would be indistinguishable from a
+// real one downstream.
+func (h *SessionFinalizeHandler) synthesizeMeta(sessionDir, sessionName string) *lfs.SessionMeta {
+	var agentID, agentType, username string
+	var createdAt time.Time
+	if stored, err := session.ReadSessionFromPath(filepath.Join(sessionDir, "raw.jsonl")); err == nil && stored != nil && stored.Meta != nil {
+		agentID = stored.Meta.AgentID
+		agentType = stored.Meta.AgentType
+		username = stored.Meta.Username
+		createdAt = stored.Meta.CreatedAt
+	}
+	// session names are YYYY-MM-DDTHH-MM-<username>-<agentID>
+	parts := strings.Split(sessionName, "-")
+	if agentID == "" && len(parts) >= 2 {
+		agentID = parts[len(parts)-1]
+	}
+	if username == "" && len(parts) >= 3 {
+		username = parts[len(parts)-2]
+	}
+
+	return lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
+		SessionID(session.ResolveOrMintSessionID("", "")).
+		StopReason(session.StopReasonRecovered).
+		Build()
+}
+
+// hasStagedChanges reports whether the index differs from HEAD. Used to tell a
+// no-op finalize (content already at HEAD) from a real commit failure without
+// depending on git's human-readable output.
+func (h *SessionFinalizeHandler) hasStagedChanges(repoPath string) (bool, error) {
+	cmd := exec.Command("git", "-C", repoPath, "diff", "--cached", "--name-only")
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("git diff --cached: %w", err)
+	}
+	return len(bytes.TrimSpace(out)) > 0, nil
+}
+
 // runGit executes a git command in the ledger directory.
 func (h *SessionFinalizeHandler) runGit(repoPath string, args ...string) error {
 	fullArgs := append([]string{"-C", repoPath}, args...)
@@ -1687,6 +1797,17 @@ func (h *SessionFinalizeHandler) runGit(repoPath string, args ...string) error {
 }
 
 // --- helpers ---
+
+// isNothingToCommit reports whether a git commit failed because the index held
+// no changes. Only a fallback for the concurrent-committer race — the primary
+// check is hasStagedChanges, which does not depend on git's wording.
+func isNothingToCommit(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "nothing to commit") || strings.Contains(msg, "no changes added to commit")
+}
 
 // copySessionFile copies src to dst, creating dst if it doesn't exist.
 func copySessionFile(src, dst string) error {

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -1635,7 +1635,7 @@ func (h *SessionFinalizeHandler) gitCommitAndPush(payload *SessionFinalizePayloa
 	// Ask git what is staged rather than parsing the commit's message: the wording
 	// varies with the rest of the tree ("working tree clean" vs "untracked files
 	// present"), so an unrelated stray file in the ledger would resurrect the loop.
-	staged, err := h.hasStagedChanges(ledgerPath)
+	staged, err := h.hasStagedChanges(ledgerPath, relDir+"/")
 	if err != nil {
 		h.logger.Warn("could not inspect staged changes", "err", err)
 		return false
@@ -1782,11 +1782,19 @@ func (h *SessionFinalizeHandler) synthesizeMeta(sessionDir, sessionName string) 
 		Build()
 }
 
-// hasStagedChanges reports whether the index differs from HEAD. Used to tell a
-// no-op finalize (content already at HEAD) from a real commit failure without
-// depending on git's human-readable output.
-func (h *SessionFinalizeHandler) hasStagedChanges(repoPath string) (bool, error) {
-	cmd := exec.Command("git", "-C", repoPath, "diff", "--cached", "--name-only")
+// hasStagedChanges reports whether the index differs from HEAD for pathspec.
+// Used to tell a no-op finalize (content already at HEAD) from a real commit
+// failure without depending on git's human-readable output.
+//
+// Scoped to the session's own path on purpose. The index is shared: if an
+// earlier finalize staged another session's files and then failed to commit for
+// some reason other than an empty stage, those files are still staged. An
+// unscoped check would see them, take the ordinary commit path, and fold that
+// session's files into this one's "finalize session <name>" commit. Nothing is
+// lost — the other session's next cycle finds nothing staged and simply pushes —
+// but the history would attribute files to the wrong session.
+func (h *SessionFinalizeHandler) hasStagedChanges(repoPath, pathspec string) (bool, error) {
+	cmd := exec.Command("git", "-C", repoPath, "diff", "--cached", "--name-only", "--", pathspec)
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	out, err := cmd.Output()
 	if err != nil {
@@ -1796,10 +1804,14 @@ func (h *SessionFinalizeHandler) hasStagedChanges(repoPath string) (bool, error)
 }
 
 // runGit executes a git command in the ledger directory.
+//
+// Pins the locale: isNothingToCommit matches git's English wording as a fallback
+// for the concurrent-committer race, and under a translated locale that match
+// would silently never fire.
 func (h *SessionFinalizeHandler) runGit(repoPath string, args ...string) error {
 	fullArgs := append([]string{"-C", repoPath}, args...)
 	cmd := exec.Command("git", fullArgs...)
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C", "LANG=C")
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -1648,7 +1648,12 @@ func (h *SessionFinalizeHandler) gitCommitAndPush(payload *SessionFinalizePayloa
 		// cycle and still be unpushed.
 		h.logger.Debug("session already committed, nothing new to stage", "session", sessionName)
 	default:
-		if err := h.runGit(ledgerPath, "commit", "-m", msg); err != nil {
+		// Commit ONLY this session's path. A bare `git commit -m` writes the whole
+		// index, so any files another session left staged after a failed finalize
+		// would ride along under this session's message. Scoping the staged-changes
+		// check alone is not enough — that decides WHETHER to commit; this decides
+		// WHAT gets committed.
+		if err := h.runGit(ledgerPath, "commit", "-m", msg, "--", relDir); err != nil {
 			// A concurrent committer (a second daemon on the same ledger) can empty
 			// the index between the check above and this commit.
 			if !isNothingToCommit(err) {

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -1747,14 +1747,23 @@ func (h *SessionFinalizeHandler) gitCommitPointerRewrite(payload *SessionFinaliz
 // An absent summary is honest; an invented one would be indistinguishable from a
 // real one downstream.
 func (h *SessionFinalizeHandler) synthesizeMeta(sessionDir, sessionName string) *lfs.SessionMeta {
-	var agentID, agentType, username string
+	rawPath := filepath.Join(sessionDir, "raw.jsonl")
+
+	var agentID, agentType, username, headerSessionID string
 	var createdAt time.Time
-	if stored, err := session.ReadSessionFromPath(filepath.Join(sessionDir, "raw.jsonl")); err == nil && stored != nil && stored.Meta != nil {
+	if stored, err := session.ReadSessionFromPath(rawPath); err == nil && stored != nil && stored.Meta != nil {
 		agentID = stored.Meta.AgentID
 		agentType = stored.Meta.AgentType
 		username = stored.Meta.Username
 		createdAt = stored.Meta.CreatedAt
+		headerSessionID = stored.Meta.SessionID
 	}
+	// Crash-safe carrier read: a recording written by an older writer can fail
+	// to parse into StoreMeta while its raw first line still carries the ID.
+	if headerSessionID == "" {
+		headerSessionID = session.ReadHeaderSessionID(rawPath)
+	}
+
 	// session names are YYYY-MM-DDTHH-MM-<username>-<agentID>
 	parts := strings.Split(sessionName, "-")
 	if agentID == "" && len(parts) >= 2 {
@@ -1764,8 +1773,11 @@ func (h *SessionFinalizeHandler) synthesizeMeta(sessionDir, sessionName string) 
 		username = parts[len(parts)-2]
 	}
 
+	// Resolve through the chokepoint WITH the header-carried ID. Passing empty
+	// arguments mints a fresh ses_ on every synthesis, rotating an identity the
+	// recording already had — exactly what ResolveOrMintSessionID exists to stop.
 	return lfs.NewSessionMeta(sessionName, username, agentID, agentType, createdAt).
-		SessionID(session.ResolveOrMintSessionID("", "")).
+		SessionID(session.ResolveOrMintSessionID("", headerSessionID)).
 		StopReason(session.StopReasonRecovered).
 		Build()
 }

--- a/internal/daemon/agentwork/session_finalize_convergence_test.go
+++ b/internal/daemon/agentwork/session_finalize_convergence_test.go
@@ -293,3 +293,59 @@ func TestGitCommitAndPush_IgnoresOtherSessionsStagedFiles(t *testing.T) {
 		t.Errorf("%s's staged file went missing; still expected in the index, got %q", other, staged)
 	}
 }
+
+// TestGitCommitAndPush_CommitExcludesOtherSessionsWhenStaged covers the case the
+// scoping test above does not: the target session has real staged changes, so
+// the commit actually runs.
+//
+// Scoping only the hasStagedChanges CHECK is not enough — `git commit -m` writes
+// the whole index, so another session's staged files ride along under this
+// session's commit message. The commit itself must carry the pathspec.
+func TestGitCommitAndPush_CommitExcludesOtherSessionsWhenStaged(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, clonePath := setupBareAndCloneLedger(t)
+
+	// target session: NOT yet committed, so finalizing it stages a real diff
+	target := "2026-01-15T20-00-testuser-OxBOTH"
+	targetDir := filepath.Join(clonePath, "sessions", target)
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range append([]string{"raw.jsonl", "meta.json"}, requiredArtifacts...) {
+		if err := os.WriteFile(filepath.Join(targetDir, name), []byte("target content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// another session's file, left staged by an earlier failed finalize
+	other := "2026-01-15T20-30-testuser-OxSTRAY"
+	otherDir := filepath.Join(clonePath, "sessions", other)
+	if err := os.MkdirAll(otherDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "raw.jsonl"), []byte("stray"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGitCmd(t, clonePath, "add", "sessions/"+other)
+
+	handler := newGitBackedHandler()
+	handler.gitCommitAndPush(&SessionFinalizePayload{
+		SessionDir: targetDir,
+		LedgerPath: clonePath,
+	})
+
+	committed := gitOutput(t, clonePath, "log", "-1", "--name-only", "--pretty=format:")
+	if !strings.Contains(committed, target) {
+		t.Errorf("the target session's own files were not committed:\n%s", committed)
+	}
+	if strings.Contains(committed, other) {
+		t.Errorf("%s's files rode along in %s's commit — `git commit` wrote the whole index:\n%s",
+			other, target, committed)
+	}
+}

--- a/internal/daemon/agentwork/session_finalize_convergence_test.go
+++ b/internal/daemon/agentwork/session_finalize_convergence_test.go
@@ -1,0 +1,234 @@
+package agentwork
+
+// Convergence tests for the session-finalize anti-entropy loop.
+//
+// WHY THIS FILE EXISTS
+//
+// The daemon wedged for months while the suite stayed green, because the suite
+// tested Detect() and ProcessResult() as separate units and never asserted the
+// property that actually matters: after processing a session, the next Detect()
+// must not find it again. A handler can return the right value on every call and
+// still never converge — that is exactly what happened, ~897 times a day.
+//
+// Two further blind spots made it invisible:
+//
+//   - Fixture bias. Every upload fixture wrote meta.json by hand, but nothing on
+//     the upload path creates one, and Detect() uses meta.json as its completion
+//     marker. Production sessions therefore never satisfied the detector, while
+//     the tests always did.
+//   - No outcome assertion. ProcessResult returning nil was read as success even
+//     when the commit had failed, so a total failure logged "status=success".
+//
+// The rule these tests encode: assert the SYSTEM settled, not that a function
+// returned.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// writeProductionShapedSession creates a cache session in the shape the daemon
+// actually encounters: fully summarized artifacts, and NO meta.json. Fixtures
+// that pre-write meta.json cannot observe the wedge.
+func writeProductionShapedSession(t *testing.T, ledgerPath, sessionName string) string {
+	t.Helper()
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"), []byte(testRawContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range requiredArtifacts {
+		if err := os.WriteFile(filepath.Join(cacheDir, name), []byte("artifact content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return cacheDir
+}
+
+func newGitBackedHandler() *SessionFinalizeHandler {
+	h := NewSessionFinalizeHandler(slog.Default())
+	h.skipLFS = true
+	h.skipGit = false
+	h.ledgerMu = &sync.Mutex{}
+	return h
+}
+
+// TestAntiEntropy_ConvergesAfterTransientPushFailure is the test whose absence
+// let the wedge run for months. It asserts the loop's defining property across
+// TWO cycles: once a session's content is in git, a later pass must settle it
+// rather than re-detecting it forever.
+//
+// The two cycles matter, and a single-pass test cannot substitute. Pass 1 with a
+// broken remote is how the wedged state is actually born: `git commit` succeeds,
+// so the content lands in git, but the push fails, so the cache is deliberately
+// preserved (that preservation is correct — it is the only copy). From then on
+// every pass stages nothing, `git commit` exits 1, and the old code read that as
+// failure and never pruned. Pass 2 with a working remote is the cycle that must
+// converge and, before the fix, never did.
+func TestAntiEntropy_ConvergesAfterTransientPushFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	barePath, clonePath := setupBareAndCloneLedger(t)
+	sessionName := "2026-01-15T15-00-testuser-OxCONV"
+	writeProductionShapedSession(t, clonePath, sessionName)
+
+	handler := newGitBackedHandler()
+
+	// --- cycle 1: the remote is down. Commit lands locally, push does not.
+	runGitCmd(t, clonePath, "remote", "set-url", "origin", "/nonexistent/broken/remote.git")
+
+	first, err := handler.Detect(clonePath)
+	if err != nil {
+		t.Fatalf("cycle 1 Detect: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("cycle 1 Detect found %d items, want 1 — fixture is not reaching the upload path", len(first))
+	}
+	if err := handler.ProcessResult(first[0], &RunResult{}); err == nil {
+		t.Fatal("cycle 1 reported success while the push was failing")
+	}
+
+	cacheDir := filepath.Join(clonePath, ".sageox", "cache", "sessions", sessionName)
+	if _, err := os.Stat(cacheDir); err != nil {
+		t.Fatalf("DATALOSS: cache pruned after a failed push — it is the only copy: %v", err)
+	}
+
+	// --- cycle 2: the remote is back. Content is already at HEAD, so nothing
+	// stages. This is the cycle that repeated ~114 times a day per session.
+	runGitCmd(t, clonePath, "remote", "set-url", "origin", "file://"+barePath)
+
+	second, err := handler.Detect(clonePath)
+	if err != nil {
+		t.Fatalf("cycle 2 Detect: %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("cycle 2 Detect found %d items, want 1 — the session should still be pending", len(second))
+	}
+	if err := handler.ProcessResult(second[0], &RunResult{}); err != nil {
+		t.Fatalf("cycle 2 ProcessResult: %v", err)
+	}
+
+	// --- cycle 3: the loop must be over.
+	third, err := handler.Detect(clonePath)
+	if err != nil {
+		t.Fatalf("cycle 3 Detect: %v", err)
+	}
+	if len(third) != 0 {
+		t.Errorf("session still detected after its content reached git (%d items) — the daemon "+
+			"will re-queue it every 5 minutes forever", len(third))
+	}
+}
+
+// TestProcessUploadOnly_WritesMetaWhenAbsent pins the specific reason
+// convergence failed: meta.json is Detect()'s completion marker, but the upload
+// path only refreshed one that already existed.
+func TestProcessUploadOnly_WritesMetaWhenAbsent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, clonePath := setupBareAndCloneLedger(t)
+	sessionName := "2026-01-15T16-00-testuser-OxMETA"
+	cacheDir := writeProductionShapedSession(t, clonePath, sessionName)
+
+	handler := newGitBackedHandler()
+	item := &WorkItem{
+		ID:   "test-meta-synthesis",
+		Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: cacheDir,
+			RawPath:    filepath.Join(cacheDir, "raw.jsonl"),
+			LedgerPath: clonePath,
+			UploadOnly: true,
+		},
+	}
+
+	if err := handler.ProcessResult(item, &RunResult{}); err != nil {
+		t.Fatalf("ProcessResult: %v", err)
+	}
+
+	metaPath := filepath.Join(clonePath, "sessions", sessionName, "meta.json")
+	if _, err := os.Stat(metaPath); err != nil {
+		t.Fatalf("meta.json not written to the ledger: %v", err)
+	}
+
+	meta, err := readMetaForTest(metaPath)
+	if err != nil {
+		t.Fatalf("meta.json unreadable: %v", err)
+	}
+	if meta.SessionName != sessionName {
+		t.Errorf("meta.session_name = %q, want %q", meta.SessionName, sessionName)
+	}
+	// Identity is recoverable from the session name; a summary is not, and must
+	// not be invented. An absent summary is honest — a fabricated one would be
+	// indistinguishable from a real one downstream.
+	if meta.Summary != "" || meta.Title != "" {
+		t.Errorf("synthesized meta fabricated user-visible content: title=%q summary=%q", meta.Title, meta.Summary)
+	}
+}
+
+// TestProcessUploadOnly_FailedPushIsReportedAsFailure guards the honesty
+// property. ProcessResult returning nil on failure is what let 897 failed
+// commits per day surface as "agent work complete status=success".
+func TestProcessUploadOnly_FailedPushIsReportedAsFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, clonePath := setupBareAndCloneLedger(t)
+	runGitCmd(t, clonePath, "remote", "set-url", "origin", "/nonexistent/broken/remote.git")
+
+	sessionName := "2026-01-15T17-00-testuser-OxHONEST"
+	cacheDir := writeProductionShapedSession(t, clonePath, sessionName)
+
+	handler := newGitBackedHandler()
+	item := &WorkItem{
+		ID:   "test-failure-is-reported",
+		Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: cacheDir,
+			RawPath:    filepath.Join(cacheDir, "raw.jsonl"),
+			LedgerPath: clonePath,
+			UploadOnly: true,
+		},
+	}
+
+	if err := handler.ProcessResult(item, &RunResult{}); err == nil {
+		t.Error("ProcessResult returned nil after a failed push — the manager records this as a success")
+	}
+}
+
+// readMetaForTest reads a meta.json without going through the lfs package's
+// validation, so a malformed write still surfaces as a field assertion rather
+// than a loader error.
+func readMetaForTest(path string) (*lfs.SessionMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var meta lfs.SessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
+}

--- a/internal/daemon/agentwork/session_finalize_convergence_test.go
+++ b/internal/daemon/agentwork/session_finalize_convergence_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -231,4 +232,64 @@ func readMetaForTest(path string) (*lfs.SessionMeta, error) {
 		return nil, err
 	}
 	return &meta, nil
+}
+
+// TestGitCommitAndPush_IgnoresOtherSessionsStagedFiles pins the pathspec scoping
+// of the staged-changes check.
+//
+// The git index is shared across every session this process finalizes. If an
+// earlier finalize staged another session's files and then failed to commit for
+// any reason other than an empty stage, those files are still staged. An
+// unscoped `git diff --cached` would see them, conclude this session has work to
+// commit, and fold the other session's files into a commit titled
+// "finalize session <this one>" — attributing files to the wrong session.
+func TestGitCommitAndPush_IgnoresOtherSessionsStagedFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, clonePath := setupBareAndCloneLedger(t)
+
+	// the session under test: already committed, so its own stage is empty
+	target := "2026-01-15T19-00-testuser-OxSCOPE"
+	targetDir := filepath.Join(clonePath, "sessions", target)
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range append([]string{"raw.jsonl", "meta.json"}, requiredArtifacts...) {
+		if err := os.WriteFile(filepath.Join(targetDir, name), []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGitCmd(t, clonePath, "add", "sessions/"+target)
+	runGitCmd(t, clonePath, "commit", "--no-verify", "-m", "finalize session "+target)
+
+	// a DIFFERENT session's file, left staged by an earlier failed finalize
+	other := "2026-01-15T19-30-testuser-OxOTHER"
+	otherDir := filepath.Join(clonePath, "sessions", other)
+	if err := os.MkdirAll(otherDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "raw.jsonl"), []byte("other session"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGitCmd(t, clonePath, "add", "sessions/"+other)
+
+	handler := newGitBackedHandler()
+	handler.gitCommitAndPush(&SessionFinalizePayload{
+		SessionDir: targetDir,
+		LedgerPath: clonePath,
+	})
+
+	// the other session's file must still be staged and uncommitted
+	committed := gitOutput(t, clonePath, "log", "-1", "--name-only", "--pretty=format:")
+	if strings.Contains(committed, other) {
+		t.Errorf("finalizing %s committed %s's files:\n%s", target, other, committed)
+	}
+	if staged := gitOutput(t, clonePath, "diff", "--cached", "--name-only"); !strings.Contains(staged, other) {
+		t.Errorf("%s's staged file went missing; still expected in the index, got %q", other, staged)
+	}
 }

--- a/internal/daemon/agentwork/session_finalize_git_test.go
+++ b/internal/daemon/agentwork/session_finalize_git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -186,4 +187,17 @@ func runGitCmd(t *testing.T, dir string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %v in %s failed: %s\n%s", args, dir, err, out)
 	}
+}
+
+// gitOutput runs a git command and returns its trimmed stdout, failing the test
+// on error. Companion to runGitCmd for assertions that need to read state back.
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v in %s failed: %s", args, dir, err)
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/internal/daemon/agentwork/session_finalize_upload_test.go
+++ b/internal/daemon/agentwork/session_finalize_upload_test.go
@@ -522,6 +522,18 @@ func TestProcessResult_UploadOnly_AlreadyCommitted_PrunesCache(t *testing.T) {
 		}
 	}
 
+	// meta.json goes into the LEDGER copy only, never the cache copy. Without it
+	// the handler synthesizes one during ProcessResult — a genuinely new file, so
+	// `git add` stages a real diff and the run takes the ordinary commit path.
+	// The no-op branch this test exists to guard would never execute and the
+	// assertions below would pass for the wrong reason. Keeping it out of the
+	// cache dir matters too: stageSessionInLedger copies cache over ledger, so a
+	// cache-side meta.json would overwrite this one and reintroduce a diff.
+	if err := os.WriteFile(filepath.Join(ledgerDir, "meta.json"),
+		[]byte(`{"version":"1.0","session_name":"`+sessionName+`"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	// the session is already committed and pushed — this is the steady state that
 	// made every subsequent finalize a no-op commit
 	runGitCmd(t, clonePath, "add", "sessions/"+sessionName)
@@ -544,8 +556,22 @@ func TestProcessResult_UploadOnly_AlreadyCommitted_PrunesCache(t *testing.T) {
 		},
 	}
 
+	headBefore := gitOutput(t, clonePath, "rev-parse", "HEAD")
+
 	if err := handler.ProcessResult(item, &RunResult{}); err != nil {
 		t.Fatalf("ProcessResult failed on an already-committed session: %v", err)
+	}
+
+	// Guard the guard: this test is only meaningful if the run actually took the
+	// zero-delta path. If some future change makes the staged diff non-empty
+	// (a synthesized file, a new artifact), the ordinary commit path runs, the
+	// assertions below still pass, and the no-op regression this test exists to
+	// catch would sail through unnoticed. An unchanged HEAD proves no commit was
+	// created, which is only true on the branch under test.
+	if headAfter := gitOutput(t, clonePath, "rev-parse", "HEAD"); headAfter != headBefore {
+		t.Fatalf("a commit was created (%s to %s) — this run did not exercise the "+
+			"zero-delta path, so it does not test what it claims",
+			headBefore[:8], headAfter[:8])
 	}
 
 	// the cache prune is what breaks the loop: Detect() keys on isInLedgerCacheDir,

--- a/internal/daemon/agentwork/session_finalize_upload_test.go
+++ b/internal/daemon/agentwork/session_finalize_upload_test.go
@@ -60,10 +60,21 @@ func TestDetect_FullyFinalizedInCache_NotPushed(t *testing.T) {
 	}
 }
 
-// TestDetect_FullyFinalizedInCache_AlreadyPushed verifies that Detect() skips sessions
-// that are in the cache AND already present in ledger/sessions/ (already uploaded).
-// Failure prevented: re-uploading a session that was already pushed would create duplicates.
-func TestDetect_FullyFinalizedInCache_AlreadyPushed(t *testing.T) {
+// TestDetect_FullyFinalizedInCache_StaleLedgerMetaStillDetected verifies that a
+// session sitting in the cache is detected even when ledger/sessions/<name>/meta.json
+// already exists.
+//
+// This test previously asserted the opposite, on the theory that a ledger
+// meta.json proves the session was pushed and that re-detecting it would create
+// duplicates. Neither holds. meta.json is written before the commit, so it is
+// present on sessions whose push failed — and that combination (cache dir plus
+// ledger meta.json) is exactly the wedged state ~3,000 sessions were stranded in,
+// invisible to anti-entropy precisely because of this rule.
+//
+// Re-detection is safe: processUploadOnly stages by copy, a no-op commit is
+// recognized as such, and the cache prune ends the loop after one pass. The
+// prune is the only signal that means "it reached the remote".
+func TestDetect_FullyFinalizedInCache_StaleLedgerMetaStillDetected(t *testing.T) {
 	handler := NewSessionFinalizeHandler(slog.Default())
 	ledgerPath := t.TempDir()
 
@@ -94,8 +105,15 @@ func TestDetect_FullyFinalizedInCache_AlreadyPushed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Detect failed: %v", err)
 	}
-	if len(items) != 0 {
-		t.Fatalf("expected 0 items (already uploaded), got %d", len(items))
+	if len(items) != 1 {
+		t.Fatalf("expected the cache-resident session to be detected, got %d items", len(items))
+	}
+	payload, ok := items[0].Payload.(*SessionFinalizePayload)
+	if !ok {
+		t.Fatalf("unexpected payload type %T", items[0].Payload)
+	}
+	if !payload.UploadOnly {
+		t.Error("a fully-finalized cache session should be queued as upload-only, not for re-summarization")
 	}
 }
 
@@ -456,12 +474,83 @@ func TestProcessResult_UploadOnly_CachePreservedOnPushFail(t *testing.T) {
 		},
 	}
 
-	if err := handler.ProcessResult(item, &RunResult{}); err != nil {
-		t.Fatalf("ProcessResult returned unexpected error: %v", err)
+	// The failure must be reported, not swallowed. Returning nil here is what let
+	// 897 failed commits in a single day log "agent work complete status=success".
+	if err := handler.ProcessResult(item, &RunResult{}); err == nil {
+		t.Error("ProcessResult returned nil after a failed push — the failure must reach the manager")
 	}
 
 	// CRITICAL: cache must survive push failure
 	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
 		t.Error("DATALOSS: upload-only cache removed after push failure — session content irrecoverable")
+	}
+}
+
+// TestProcessResult_UploadOnly_AlreadyCommitted_PrunesCache reproduces the wedge
+// that pinned four ox daemons at ~100% CPU on every 5-minute doctor tick.
+//
+// When a session's files are already committed at HEAD, stageSessionInLedger
+// copies the cache over identical content and `git commit` exits 1 with
+// "nothing to commit, working tree clean". Treating that as failure left the
+// cache dir in place, so Detect() re-queued the same session every cycle,
+// forever: 897 failed commits and 43,996 queue-full rejections in one day,
+// against a backlog that grew to ~3,000 sessions.
+func TestProcessResult_UploadOnly_AlreadyCommitted_PrunesCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, clonePath := setupBareAndCloneLedger(t)
+
+	sessionName := "2026-01-15T14-00-testuser-OxDUP"
+	cacheDir := filepath.Join(clonePath, ".sageox", "cache", "sessions", sessionName)
+	ledgerDir := filepath.Join(clonePath, "sessions", sessionName)
+	for _, dir := range []string{cacheDir, ledgerDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(testRawContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+		for _, name := range requiredArtifacts {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("artifact content"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// the session is already committed and pushed — this is the steady state that
+	// made every subsequent finalize a no-op commit
+	runGitCmd(t, clonePath, "add", "sessions/"+sessionName)
+	runGitCmd(t, clonePath, "commit", "--no-verify", "-m", "finalize session "+sessionName)
+	runGitCmd(t, clonePath, "push")
+
+	handler := NewSessionFinalizeHandler(slog.Default())
+	handler.skipLFS = true
+	handler.skipGit = false
+	handler.ledgerMu = &sync.Mutex{}
+
+	item := &WorkItem{
+		ID:   "test-upload-already-committed",
+		Type: sessionFinalizeType,
+		Payload: &SessionFinalizePayload{
+			SessionDir: cacheDir,
+			RawPath:    filepath.Join(cacheDir, "raw.jsonl"),
+			LedgerPath: clonePath,
+			UploadOnly: true,
+		},
+	}
+
+	if err := handler.ProcessResult(item, &RunResult{}); err != nil {
+		t.Fatalf("ProcessResult failed on an already-committed session: %v", err)
+	}
+
+	// the cache prune is what breaks the loop: Detect() keys on isInLedgerCacheDir,
+	// so a surviving cache dir means the same session is re-queued in 5 minutes
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Error("cache dir survived an already-committed session — Detect() will re-queue it forever")
 	}
 }


### PR DESCRIPTION
## What was happening

Four `ox` daemons were spiking to 100–176% CPU on every 5-minute doctor tick, indefinitely. The session-finalize anti-entropy loop could not converge: it re-did the same work on the same sessions forever, and reported every failure as a success.

Measured on one machine before the fix (sageox-monorepo ledger, single day):

| Signal | Count |
|---|---|
| `agent work complete` | 898 |
| **`git commit failed`** | **897** |
| `enqueue skipped: queue full` | 43,996 (1,039,714 lifetime) |
| distinct sessions re-detected | 299, **114× each** |
| cache dirs vs tracked sessions | **5,396** vs 2,320 |
| daemon log | 511 MB / 2.88M lines |

## Root cause

A session whose files already match `HEAD` produces a zero-delta stage, so `git commit` exits 1 with `nothing to commit`. `gitCommitAndPush` read that as failure and returned `false`, so `processUploadOnly` skipped the cache prune — and the surviving cache dir is exactly what `Detect()` keys on.

```mermaid
flowchart LR
    D["Detect: session in cache"] --> S["stage: copy cache to sessions/"]
    S --> C["git commit"]
    C -->|"zero delta, exit 1"| F["read as FAILURE"]
    F --> P["cache prune SKIPPED"]
    P -->|"5 minutes later"| D
    F --> L["logs status=success"]
```

Verified on disk for one session: all five files present in `git ls-files`, `git status` clean, cache dir still there, no `meta.json` anywhere.

## The four defects

1. **Zero-delta commits read as failure.** Fixed by asking git what is staged (`git diff --cached --name-only`) rather than parsing the commit message — the wording varies with the rest of the tree (`working tree clean` vs `untracked files present`), so a single stray file would have resurrected the loop. Message matching survives only as a fallback for the concurrent-committer race, which is real when two daemons share a ledger.

2. **Failures reported as successes.** `processUploadOnly` returned `nil` even when nothing was committed or pushed, so the manager logged `agent work complete status=success duration=29µs` and no counter ever moved. It now returns an error and the manager records a failure.

3. **The detector's completion marker was unreliable.** `Detect()` treated `sessions/<name>/meta.json` as proof a session had landed, but nothing on the upload path created one unless it already existed, and the write is not tied to a successful push. Completion is now the **cache prune**, which happens only after a verified commit and push. `processUploadOnly` also synthesizes a `meta.json` when absent — identity and provenance only, never a fabricated title or summary.

4. **Duplicate daemons multiplied the work.** Two processes for one repo each ran the full scan and each enforced its own 60-invocations/hour ceiling. A per-ledger `flock` now serializes anti-entropy while leaving cheap per-repo work untouched. It fails open: a ledger that stops self-healing is worse than one scanned twice.

Also: a saturated queue logged one `WARN` per rejected item. Now one `INFO` summary per detection cycle.

## Why the suite stayed green through all of this

This is the part worth reviewing closely.

- **`Detect()` and `ProcessResult()` were tested as separate units.** Nothing asserted the system *converged*, and the loop is only visible across cycles.
- **Fixture bias.** Every upload fixture wrote `meta.json` by hand, so the tests always satisfied a detector that production never did.
- **Two existing tests encoded the bug as expected behavior:**
  - `TestProcessResult_UploadOnly_CachePreservedOnPushFail` asserted `ProcessResult` returns `nil` on push failure — the silent success this bug rode on. Its real invariant (no data loss) is unchanged and still enforced.
  - `TestDetect_FullyFinalizedInCache_AlreadyPushed` asserted that a cache dir plus a ledger `meta.json` means "already pushed, skip" — the exact state ~3,000 stranded sessions were in, and the rule that made them invisible to anti-entropy. Retargeted, with the reasoning recorded in the test.

## New tests — each verified to fail against the pre-fix behavior

| Test | Asserts | How it was proven red |
|---|---|---|
| `TestAntiEntropy_ConvergesAfterTransientPushFailure` | three cycles; a session whose content reached git stops being detected | reverted `session_finalize.go`, confirmed FAIL |
| `TestProcessResult_UploadOnly_AlreadyCommitted_PrunesCache` | no-op commit still prunes the cache | reverted, confirmed FAIL |
| `TestProcessUploadOnly_WritesMetaWhenAbsent` | `meta.json` synthesized, with **no** fabricated title/summary | reverted, confirmed FAIL |
| `TestManager_UnpushableSession_SurfacesAsFailure` | failure reaches `Stats.Failures` and `status=failed`, driven through the **real** handler | behavioral revert → `Stats.Successes = 1, want 0` |
| `TestOwnsLedgerAntiEntropy_DeniedWhileAnotherProcessHolds` | a second **process** is excluded | requires a real subprocess |
| `TestDetectAndEnqueue_FullQueueLogsOncePerCycle` | one summary line, not one per item | behavioral revert → 200 per-item lines |

Two notes on test design, since both were mistakes I made first and corrected:

- The convergence test originally used a single pass and **passed against the buggy code** — the fixture wasn't in the wedged state. The wedge is born when the commit succeeds but the push fails, so the test now runs three cycles with a broken-then-restored remote.
- The lease test originally ran in-process and would have passed while the real bug survived: `flock` is per-open-file-description, so two acquires inside one process both succeed. It now re-executes the test binary as a lease holder.

The convergence test also caught a regression I was about to introduce: writing `meta.json` before the push satisfied the detector, which would have made an unpushed session stop being retried. That is what drove defect 3's redesign.

## Verification

- `go test ./internal/daemon/...` — all four packages pass
- `go vet` clean; `golangci-lint` reports 8 `errcheck` issues, all pre-existing, none in changed lines
- Three failures in `cmd/ox` (`TestLoadBearingCommentPresent_LocalRecall`, `TestDiscoverTeamContextWithFallback_RefreshesExistingLocalCopy`, `TestConsultRoutes_NoDriftWithSkill`) are **unrelated and pre-existing** — they pass in isolation and fail only under whole-package parallel runs on shared XDG state. Related: ox-y7n8.
- Installed the built binary and restarted the affected daemons on the reporting machine.

## Not fixed here

Backfilling the ~3,000 already-stranded sessions is left to the daemon's own anti-entropy: each gets one more pass with the fixed binary, writes its `meta.json`, commits, and prunes. No separate migration.

Refs: ox-zmjc.18, ox-zmjc.19, ox-zmjc.20, ox-4qvn, ox-2gki


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session failure reporting and recovery after temporary upload failures.
  * Ensured finalized sessions are retried, metadata is preserved or generated when needed, and successful uploads clean up cached data.
  * Prevented concurrent anti-entropy processing from duplicating work across instances, including recovery after unexpected process termination.
  * Reduced repetitive queue saturation logging by consolidating messages per detection cycle.
  * Ensured rejected queue items reset correctly for future processing.
* **Tests**
  * Added coverage for session convergence, metadata handling, lease coordination, queue behavior, and failure scenarios across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->