### PR TITLE
fix(agents): drop Aider from the instruction-file registry; fix AGENTS.md guide

### DIFF
--- a/cmd/ox/guides/agents-md.md
+++ b/cmd/ox/guides/agents-md.md
@@ -6,7 +6,7 @@ audience: both
 
 # AGENTS.md and CLAUDE.md
 
-AI coding agents read instruction files at session start to learn project conventions. Different tools historically named these files differently — `CLAUDE.md` (Claude Code), `.cursorrules` (Cursor), `.windsurfrules` (Windsurf), `GEMINI.md` (Gemini CLI), `CONVENTIONS.md` (Aider). The cross-tool convention has converged on **AGENTS.md at the repo root**, which Codex, OpenCode, Amp, Pi, Goose, and Gemini CLI all read.
+AI coding agents read instruction files at session start to learn project conventions. Different tools historically named these files differently — `CLAUDE.md` (Claude Code), `.cursorrules` (Cursor), `.windsurfrules` (Windsurf), `GEMINI.md` (Gemini CLI), `CONVENTIONS.md` (Aider). The cross-tool convention has converged on **AGENTS.md at the repo root**, which Codex, OpenCode, Amp, Pi, Goose, and the OpenAI Agents SDK all read.
 
 SageOx supports both `AGENTS.md` and `CLAUDE.md` and follows the convention of treating them as siblings — typically `CLAUDE.md` is a symlink to `AGENTS.md` so both work without duplication.
 

--- a/cmd/ox/instruction_files.go
+++ b/cmd/ox/instruction_files.go
@@ -21,7 +21,6 @@ const (
 	agentCline      = "cline"
 	agentOpenCode   = "opencode"
 	agentAmp        = "amp"
-	agentAider      = "aider"
 	agentGoose      = "goose"
 )
 
@@ -160,13 +159,13 @@ var InstructionFileRegistry = []InstructionFileSpec{
 		MarkerFormat: markerFormatMarkdown,
 		DetectFn:     nil, // shares AGENTS.md
 	},
-	{
-		AgentType:    agentAider,
-		DisplayName:  "Aider",
-		ProjectFiles: []string{"AGENTS.md"},
-		MarkerFormat: markerFormatMarkdown,
-		DetectFn:     nil, // shares AGENTS.md
-	},
+	// Aider is deliberately absent. It reads whatever .aider.conf.yml's `read:`
+	// points at — CONVENTIONS.md by default — never AGENTS.md, so an AGENTS.md
+	// entry here marked a file Aider does not load while the docs promised
+	// CONVENTIONS.md. ox-adapter-aider owns CONVENTIONS.md end to end (install,
+	// check, uninstall, diagnose) under its own ox:prime:aider markers; adding a
+	// CONVENTIONS.md entry here would stack a second, differently-marked copy of
+	// the same prime instruction on top of the adapter's block. See ox-fbrm.
 	{
 		AgentType:   agentGoose,
 		DisplayName: "Goose",

--- a/cmd/ox/instruction_files_test.go
+++ b/cmd/ox/instruction_files_test.go
@@ -21,7 +21,7 @@ func TestDetectedInstructionFiles_EmptyDir(t *testing.T) {
 
 	targets := DetectedInstructionFiles(root)
 
-	// agents with nil DetectFn (Codex, OpenCode, Amp, Aider) always pass detection,
+	// agents with nil DetectFn (Codex, OpenCode, Amp, Goose) always pass detection,
 	// so AGENTS.md appears via them even in an empty dir
 	names := targetRelPaths(targets)
 	assert.Contains(t, names, "AGENTS.md", "AGENTS.md should appear (shared by nil-DetectFn agents)")
@@ -98,7 +98,7 @@ func TestDetectedInstructionFiles_DeduplicatesSharedFiles(t *testing.T) {
 
 	targets := DetectedInstructionFiles(root)
 
-	// AGENTS.md is listed by Claude Code, Codex, OpenCode, Amp, and Aider.
+	// AGENTS.md is listed by Claude Code, Codex, OpenCode, Amp, and Goose.
 	// Dedup should ensure it appears only once.
 	names := targetRelPaths(targets)
 	count := 0
@@ -613,6 +613,27 @@ func TestInstructionFileRegistry_GooseSharesAgentsMd(t *testing.T) {
 	assert.Equal(t, markerFormatMarkdown, goose.MarkerFormat)
 	assert.Nil(t, goose.DetectFn, "Goose shares AGENTS.md; gating on detection would suppress the marker")
 	assert.False(t, goose.Creatable, "AGENTS.md is a primary file; Creatable would be redundant")
+}
+
+// TestInstructionFileRegistry_AiderIsAdapterOwned pins Aider OUT of this
+// registry. Aider loads only what .aider.conf.yml's `read:` names —
+// CONVENTIONS.md by default — so an AGENTS.md entry marked a file Aider never
+// reads while README.md and docs/guides/agent-compatibility.md both promised
+// CONVENTIONS.md. ox-adapter-aider owns CONVENTIONS.md end to end under its own
+// ox:prime:aider markers, so a CONVENTIONS.md entry here is equally wrong: it
+// would stack a second, differently-marked prime block on the adapter's.
+//
+// Failure prevented (the general class, not just Aider): a registry spec that
+// names an instruction file its agent does not actually load, or that the
+// agent's own adapter already owns — either way ox reports the agent as primed
+// when it is not, or double-primes it.
+func TestInstructionFileRegistry_AiderIsAdapterOwned(t *testing.T) {
+	for _, spec := range InstructionFileRegistry {
+		assert.NotEqual(t, "aider", spec.AgentType,
+			"Aider must not be in the instruction-file registry — ox-adapter-aider owns CONVENTIONS.md")
+		assert.NotContains(t, spec.ProjectFiles, "CONVENTIONS.md",
+			"spec %s lists CONVENTIONS.md, which ox-adapter-aider already writes under its own markers", spec.AgentType)
+	}
 }
 
 func TestInstructionFileRegistry_PrimaryFilesAreMarkdown(t *testing.T) {


### PR DESCRIPTION
## Summary

Two documentation-vs-code contradictions found while reviewing #738 against `origin/main`. Both are cases where `ox` *said* one thing and *did* another, and neither would ever surface as a crash — only as an AI coworker that silently never got primed.

### 1. Aider was registered against a file it does not read

`cmd/ox/instruction_files.go` listed Aider with `ProjectFiles: []string{"AGENTS.md"}`. Aider loads only what `.aider.conf.yml`'s `read:` directive names — `CONVENTIONS.md` by default. Meanwhile `README.md` and `docs/guides/agent-compatibility.md` both advertised `CONVENTIONS.md`, so the registry and the docs disagreed about Aider's own instruction file.

- **The entry was fully inert.** `AGENTS.md` is already claimed by Codex, OpenCode, Amp, and Goose with `DetectFn: nil`, and `DetectedInstructionFiles` dedupes by resolved path — so Aider's entry never produced a target, for any file, in any repo. It was documentation-as-code, and the documentation was wrong.
- **Aider is not unprimed.** `ox-adapter-aider` owns `CONVENTIONS.md` end to end — install, check, uninstall, diagnose — under its own `ox:prime:aider:start` / `:end` marker pair. That path works today and is what the docs describe.

```mermaid
flowchart LR
    INIT["ox init"] --> REG["InstructionFileRegistry"]
    REG --> AMD["AGENTS.md<br/>ox:prime markers"]
    AMD -.->|"deduped away, and Aider never reads it"| DEAD["no effect"]
    ADAPT["ox adapter install aider"] --> CONV["CONVENTIONS.md<br/>ox:prime:aider block"]
    CONV --> LOADS["Aider loads it via<br/>the .aider.conf.yml read directive"]
```

**Removed the entry** rather than repointing it at `CONVENTIONS.md`. Repointing would stack a second, *differently-marked* copy of the same prime instruction on top of the adapter's block — precisely what the neighbouring Goose spec's comment rejects for `.goosehints`. With `DetectFn: nil` it would also inject into any repo that happens to have a `CONVENTIONS.md`, Aider or not. An inline comment now sits where the entry was so it does not get re-added.

No doc changes needed — `README.md` and the compatibility guide already said `CONVENTIONS.md`.

### 2. The AGENTS.md guide contradicted itself in one sentence

`cmd/ox/guides/agents-md.md` named `GEMINI.md` as Gemini CLI's instruction file and then, in the same sentence, listed Gemini CLI among the tools that read `AGENTS.md`. `instruction_files.go` registers Gemini against `GEMINI.md` only. Replaced the trailing item with "the OpenAI Agents SDK", which is what the text said before it drifted.

### Context: PR #738

This branch came out of reviewing #738 against the latest `main`. That PR turned out to be entirely superseded by #739 and #740 — three of its files were already byte-identical to `main`, and merging it would have regressed `main` (Goose demoted from a shipped adapter back to marker-only, `sageox/agentx` downgraded `v0.1.13` to `v0.1.12`, and "AI coworker" rewritten to "agent" against the terminology rule). **#738 is now closed** with a comment mapping each piece to where it landed. The one line worth keeping from it is the `agents-md.md` fix above.

Tracked as `ox-fbrm` (closed). Still open from the same audit and **not** in this PR: `ox-h064` (adapter compliance suite has no `TestXxx` entry point) and `ox-osm5` (gemini/pi/aider ship an unregistered `rules.go`).

## Test Plan

- **`TestInstructionFileRegistry_AiderIsAdapterOwned`** — new. Asserts no registry spec claims `aider` and no spec lists `CONVENTIONS.md`. Written against the general class, not the one instance: *a spec that names an instruction file its agent does not load, or that the agent's own adapter already owns.*
- **Verified red-first.** Reverted `instruction_files.go` to `HEAD`, ran the new test alone, watched it fail on `Should not be: "aider"`, then restored the fix and watched it pass. A test that is green both ways guards nothing.
- **`make lint`** — 0 issues.
- **`go test ./cmd/ox/...`** — pass (117s), including the pre-existing `TestDetectedInstructionFiles_*` and `TestRemoveInstructionFileMarkers_*` suites that exercise the registry end to end. Two stale comments in those tests that named Aider as an `AGENTS.md` sharer now name Goose.
- **Embedded-guide render** — `go build ./cmd/ox && ox guide agents-md` emits the corrected sentence, confirming the `go:embed` copy picked it up.

No behavior change to verify manually: the removed registry entry was already unreachable via dedup, so `ox init` writes exactly the same files before and after.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added or N/A documented — `TestInstructionFileRegistry_AiderIsAdapterOwned`, verified red without the fix
- [x] CHANGELOG entry added (if user-facing) — N/A: no user-visible behavior change; the removed entry was inert
- [x] Breaking change documented — N/A: none
- [x] Ran `/security-review` on the diff, **or** N/A documented — N/A: docs + a registry-literal deletion + a test. Touches none of `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum`

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)
Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `AGENTS.md` guidance to reference the OpenAI Agents SDK instead of Gemini CLI.
  - Updated agent-related examples and descriptions to reference Goose where applicable.

- **Bug Fixes**
  - Improved instruction-file handling so Aider’s `CONVENTIONS.md` configuration is recognized through its adapter without being incorrectly treated as a shared instruction file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
