### PR TITLE
fix(kb): give knowledge bubbles their own sparse-checkout defaults

### DIFF
--- a/cmd/ox/doctor_git_repos_fix.go
+++ b/cmd/ox/doctor_git_repos_fix.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
 	"github.com/sageox/ox/internal/ledger"
+	"github.com/sageox/ox/internal/manifest"
 	"github.com/sageox/ox/internal/paths"
 )
 
@@ -604,7 +605,7 @@ func cloneViaDaemon(cloneURL, targetPath, repoType, endpointURL string) error {
 		if creds == nil {
 			return fmt.Errorf("direct clone failed: %w", gitserver.ErrNoCredentials)
 		}
-		result, err := gitserver.TwoPhaseClone(ctx, cloneURL, targetPath)
+		result, err := gitserver.TwoPhaseClone(ctx, cloneURL, targetPath, manifest.RepoKindTeamContext)
 		if err != nil {
 			return fmt.Errorf("direct clone failed: %w", err)
 		}

--- a/cmd/ox/doctor_team.go
+++ b/cmd/ox/doctor_team.go
@@ -483,24 +483,13 @@ func checkTeamSparseCheckout(fix bool) checkResult {
 // with root-level file patterns included.
 func repairTeamSparseCheckout(tcPath string) error {
 	manifestPath := filepath.Join(tcPath, ".sageox", "sync.manifest")
-	cfg := manifest.ParseFile(manifestPath)
+	cfg := manifest.ParseFile(manifestPath, manifest.RepoKindTeamContext)
 
 	sparsePaths := manifest.ComputeSparseSet(cfg)
 	if len(sparsePaths) == 0 {
 		return fmt.Errorf("no sparse paths computed from manifest")
 	}
-
-	// ensure .sageox/ is always in the sparse set
-	hasSageox := false
-	for _, p := range sparsePaths {
-		if p == ".sageox/" || p == ".sageox" {
-			hasSageox = true
-			break
-		}
-	}
-	if !hasSageox {
-		sparsePaths = append([]string{".sageox/"}, sparsePaths...)
-	}
+	sparsePaths = manifest.EnsureSageoxInclude(sparsePaths)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/daemon/sync_bubbles.go
+++ b/internal/daemon/sync_bubbles.go
@@ -321,10 +321,10 @@ func (s *SyncScheduler) reconcileBubble(ctx context.Context, b api.KB) {
 	} else {
 		// read manifest before pull to get auto-resolve prefixes. The
 		// manifest is already on disk from clone (TwoPhaseClone materializes
-		// .sageox/ in phase 1). If missing/unparseable, ParseFile returns
-		// FallbackConfig which already includes DefaultResolveRules.
+		// .sageox/ in phase 1). If missing/unparseable, ParseFile returns the
+		// kb fallback config, which already includes DefaultResolveRules.
 		manifestPath := filepath.Join(target, ".sageox", "sync.manifest")
-		mCfg := manifest.ParseFile(manifestPath)
+		mCfg := manifest.ParseFile(manifestPath, manifest.RepoKindKB)
 
 		// existing clone — pull via the shared managed-repo pipeline so we
 		// reuse fetch dedup, lock-file cleanup, kb merge=union pre-flight,
@@ -365,7 +365,7 @@ func (s *SyncScheduler) reconcileBubble(ctx context.Context, b api.KB) {
 		// they're only on disk now. Without this re-parse + reapply, kb
 		// would silently drift from team-context sync behavior, which
 		// reapplies sparse on every pull.
-		postPullCfg := manifest.ParseFile(manifestPath)
+		postPullCfg := manifest.ParseFile(manifestPath, manifest.RepoKindKB)
 		_ = applySparseFromManifest(ctx, target, postPullCfg, s.logger)
 	}
 
@@ -417,7 +417,7 @@ func (s *SyncScheduler) cloneBubble(ctx context.Context, b api.KB, target string
 	cloneCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	if _, err := gitserver.TwoPhaseClone(cloneCtx, cloneURL, target); err != nil {
+	if _, err := gitserver.TwoPhaseClone(cloneCtx, cloneURL, target, manifest.RepoKindKB); err != nil {
 		return fmt.Errorf("kb two-phase clone failed: %w", err)
 	}
 

--- a/internal/daemon/sync_bubbles_sparse_test.go
+++ b/internal/daemon/sync_bubbles_sparse_test.go
@@ -104,3 +104,105 @@ func TestSyncBubbles_Pull_ReappliesSparseFromManifest(t *testing.T) {
 	assert.FileExists(t, filepath.Join(target, "also", "bar.md"),
 		"also/ was added to the manifest after clone — must materialize on next sync (the fix)")
 }
+
+// TestSyncBubbles_UnparseableManifest_MaterializesKnowledgeTree verifies that
+// a bubble whose sync.manifest declares nothing still gets a bubble-shaped
+// checkout — knowledge/ present, team-context paths absent — on clone AND
+// after a pull reapplies sparse.
+//
+// This reproduces the production failure: the server seeds new bubbles with a
+// comment-only manifest ("# managed by SageOx KB watchman"), which has no
+// `version` directive, so ParseFile falls back. Before the fix the fallback
+// was the team-context include set for every repo kind, so knowledge/ was
+// never in the sparse set and the entire curated tree stayed on disk-invisible
+// skip-worktree entries.
+//
+// The class of failure under test is "manifest unusable → checkout silently
+// takes the wrong repo's shape", so the fixture uses the real seeded content
+// rather than an empty file, and asserts both directions: the bubble tree
+// appears, and no team-context tree leaks in.
+//
+// Failure prevented: bubbles sync "successfully" for weeks while every
+// knowledge document is missing from disk, with only a slog.Warn to show it.
+func TestSyncBubbles_UnparseableManifest_MaterializesKnowledgeTree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: real git operations + two sync passes")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	kbTestEnv(t)
+	s, _ := kbTestScheduler(t)
+
+	bareDir, workDir := initBareRepo(t, "kbfallback")
+
+	// verbatim manifest the server seeds into a new bubble: a comment, no
+	// version directive, no includes. Parse rejects it and ParseFile falls back.
+	require.NoError(t, os.MkdirAll(filepath.Join(workDir, ".sageox"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".sageox", "sync.manifest"),
+		[]byte("# managed by SageOx KB watchman\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, ".sageox", "kb.yaml"),
+		[]byte("schema_version: 1\nkb_type: custom\n"), 0o644))
+
+	// bubble shape: root AGENTS.md + a curated knowledge/ tree. knowledge/agents.md
+	// is deliberately included — under the old bare "AGENTS.md" sparse pattern it
+	// was the ONE knowledge file that materialized (gitignore patterns without a
+	// slash match at any depth), which made a total failure look partial.
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "AGENTS.md"), []byte("root\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(workDir, "knowledge"), 0o755))
+	knowledgeFiles := []string{"MANIFEST.md", "agents.md", "architecture.md", "operations.md"}
+	for _, name := range knowledgeFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(workDir, "knowledge", name), []byte(name+"\n"), 0o644))
+	}
+	// a team-context-shaped path that must NOT be pulled into a bubble checkout
+	require.NoError(t, os.MkdirAll(filepath.Join(workDir, "discussions"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "discussions", "leak.md"), []byte("leak\n"), 0o644))
+
+	require.NoError(t, exec.Command("git", "-C", workDir, "add", ".").Run())
+	require.NoError(t, exec.Command("git", "-C", workDir, "commit", "-m", "seed bubble with comment-only manifest").Run())
+	require.NoError(t, exec.Command("git", "-C", workDir, "push", "origin", "HEAD:main").Run())
+
+	bubble := api.KB{
+		KBID:    "kb_fallback_shape",
+		KBType:  api.KBTypeTeam,
+		Slug:    "fallback-shape",
+		RepoURL: "file://" + bareDir,
+	}
+	s.SetKBBubbleListerFactory(func(_, _ string) KBBubbleLister {
+		return &fakeKBLister{bubbles: []api.KB{bubble}}
+	})
+
+	// --- clone pass ---
+	s.syncBubbles(context.Background())
+	target := paths.KBDir(endpoint.Get(), bubble.KBID)
+	require.DirExists(t, filepath.Join(target, ".git"), "first sync must clone the bubble")
+
+	assertBubbleShape := func(t *testing.T, stage string) {
+		t.Helper()
+		for _, name := range knowledgeFiles {
+			assert.FileExists(t, filepath.Join(target, "knowledge", name),
+				"%s: knowledge/%s must materialize from the kb fallback include set", stage, name)
+		}
+		assert.FileExists(t, filepath.Join(target, ".sageox", "sync.manifest"),
+			"%s: .sageox/ must stay in the sparse set or the next pull cannot re-read the manifest", stage)
+		assert.FileExists(t, filepath.Join(target, "AGENTS.md"), "%s: root AGENTS.md must materialize", stage)
+
+		_, err := os.Stat(filepath.Join(target, "discussions", "leak.md"))
+		assert.True(t, os.IsNotExist(err),
+			"%s: discussions/ is team-context-only and must not leak into a bubble checkout", stage)
+	}
+
+	assertBubbleShape(t, "after clone")
+
+	// --- pull pass: sparse is recomputed from the same unparseable manifest on
+	// every pull, so a wrong fallback would re-hide knowledge/ here even if the
+	// clone happened to get it right. ---
+	fetchHead := filepath.Join(target, ".git", "FETCH_HEAD")
+	if info, err := os.Stat(fetchHead); err == nil {
+		past := info.ModTime().Add(-10 * time.Minute)
+		_ = os.Chtimes(fetchHead, past, past)
+	}
+	s.syncBubbles(context.Background())
+
+	assertBubbleShape(t, "after pull")
+}

--- a/internal/daemon/sync_team.go
+++ b/internal/daemon/sync_team.go
@@ -400,9 +400,10 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 
 	// read manifest before pull to get auto-resolve prefixes. The manifest
 	// is already on disk from the previous clone/pull. If missing, ParseFile
-	// returns FallbackConfig which includes DefaultResolveRules.
+	// returns the team-context fallback config, which includes
+	// DefaultResolveRules.
 	manifestPath := filepath.Join(path, ".sageox", "sync.manifest")
-	mCfg := manifest.ParseFile(manifestPath)
+	mCfg := manifest.ParseFile(manifestPath, manifest.RepoKindTeamContext)
 
 	result := s.pullManagedRepo(ctx, ManagedRepoPullOpts{
 		RepoPath:           path,
@@ -485,7 +486,7 @@ func (s *SyncScheduler) pullTeamContext(ctx context.Context, path string) error 
 // SyncIntervalMin. Thin wrapper over applySparseFromManifest (sync_sparse.go)
 // so kb sync and team-context sync share the same sparse application logic.
 func (s *SyncScheduler) applySparseCheckout(ctx context.Context, tcPath string) *manifest.ManifestConfig {
-	cfg := manifest.ParseFile(filepath.Join(tcPath, ".sageox", "sync.manifest"))
+	cfg := manifest.ParseFile(filepath.Join(tcPath, ".sageox", "sync.manifest"), manifest.RepoKindTeamContext)
 	_ = applySparseFromManifest(ctx, tcPath, cfg, s.logger)
 	return cfg
 }
@@ -497,7 +498,7 @@ func (s *SyncScheduler) twoPhaseClone(ctx context.Context, cloneURL, repoPath st
 		_ = progress.WriteStage("materializing", "Reading manifest and materializing files...")
 	}
 
-	result, err := gitserver.TwoPhaseClone(ctx, cloneURL, repoPath)
+	result, err := gitserver.TwoPhaseClone(ctx, cloneURL, repoPath, manifest.RepoKindTeamContext)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/twin_clone_test.go
+++ b/internal/daemon/twin_clone_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/manifest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,7 +67,7 @@ func TestTwoPhaseClone_BasicTeamContext(t *testing.T) {
 	})
 
 	dest := filepath.Join(t.TempDir(), "clone-basic")
-	result, err := gitserver.TwoPhaseClone(context.Background(), cloneURL, dest)
+	result, err := gitserver.TwoPhaseClone(context.Background(), cloneURL, dest, manifest.RepoKindTeamContext)
 	require.NoError(t, err)
 
 	// root file materialized via /* pattern
@@ -109,7 +110,7 @@ func TestTwoPhaseClone_PullRebaseAfterClone(t *testing.T) {
 	})
 
 	dest := filepath.Join(t.TempDir(), "clone-pull")
-	_, err := gitserver.TwoPhaseClone(context.Background(), cloneURL, dest)
+	_, err := gitserver.TwoPhaseClone(context.Background(), cloneURL, dest, manifest.RepoKindTeamContext)
 	require.NoError(t, err)
 
 	gitConfig(t, dest)
@@ -141,7 +142,7 @@ func TestTwoPhaseClone_NoManifest_FallsBack(t *testing.T) {
 	})
 
 	dest := filepath.Join(t.TempDir(), "clone-no-manifest")
-	result, err := gitserver.TwoPhaseClone(context.Background(), cloneURL, dest)
+	result, err := gitserver.TwoPhaseClone(context.Background(), cloneURL, dest, manifest.RepoKindTeamContext)
 	require.NoError(t, err)
 
 	require.NotNil(t, result.ManifestConfig)
@@ -167,7 +168,7 @@ func TestTwoPhaseClone_LFSConfigStripped(t *testing.T) {
 	})
 
 	dest := filepath.Join(t.TempDir(), "clone-lfs")
-	_, err := gitserver.TwoPhaseClone(context.Background(), cloneURL, dest)
+	_, err := gitserver.TwoPhaseClone(context.Background(), cloneURL, dest, manifest.RepoKindTeamContext)
 	require.NoError(t, err)
 
 	gitConfigPath := filepath.Join(dest, ".git", "config")

--- a/internal/gitserver/two_phase_clone.go
+++ b/internal/gitserver/two_phase_clone.go
@@ -30,13 +30,18 @@ type TwoPhaseCloneResult struct {
 // applies to every production code path because none of them flip the var.
 var TestAllowFileTransport bool
 
-// TwoPhaseClone performs a two-phase partial clone for team context repos.
+// TwoPhaseClone performs a two-phase partial clone for a manifest-driven
+// repo — team contexts and knowledge bubbles both use it.
 //
 // Phase 1: Clone with --filter=blob:none --depth=1 --sparse --no-checkout,
 // materialize only .sageox/ to read the manifest.
 //
 // Phase 2: Read manifest, compute sparse set, apply sparse checkout to
 // materialize only allowed paths. Unshallow for pull --rebase compatibility.
+//
+// kind selects the fallback include set for phase 2 when the repo's manifest
+// is missing or unparseable. It must match the repo being cloned: a bubble
+// cloned as RepoKindTeamContext gets a checkout with no knowledge/ tree.
 //
 // This function is used by both the daemon (normal path) and the CLI
 // (doctor fallback when daemon unavailable).
@@ -55,7 +60,7 @@ var TestAllowFileTransport bool
 //     1. SparseCheckoutDirectories uses --no-cone mode (ox uses file-level patterns)
 //     2. go-git network performance vs native git for clone
 //     3. credential injection (URL-embedded tokens) works correctly
-func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string) (*TwoPhaseCloneResult, error) {
+func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string, kind manifest.RepoKind) (*TwoPhaseCloneResult, error) {
 	// phase 1: minimal clone — trees only, no blobs.
 	// Set cmd.Dir to the parent of repoPath so git doesn't fail with
 	// "Unable to read current working directory" when the daemon's CWD
@@ -106,28 +111,13 @@ func TwoPhaseClone(ctx context.Context, cloneURL, repoPath string) (*TwoPhaseClo
 
 	// phase 2: read manifest and materialize declared paths
 	manifestPath := filepath.Join(repoPath, ".sageox", "sync.manifest")
-	cfg := manifest.ParseFile(manifestPath)
+	cfg := manifest.ParseFile(manifestPath, kind)
 
 	sparsePaths := manifest.ComputeSparseSet(cfg)
 	if len(sparsePaths) == 0 {
-		sparsePaths = []string{".sageox/"}
+		sparsePaths = []string{"/.sageox/"}
 	}
-
-	// ensure .sageox/ is always in the sparse set.
-	// MUST be appended (not prepended) because ComputeSparseSet returns
-	// patterns like ["/*", "!/*/", ...] where !/*/  excludes all root dirs.
-	// In --no-cone mode (gitignore semantics), later patterns override earlier
-	// ones, so .sageox/ must come AFTER !/*/ to re-include it.
-	hasSageox := false
-	for _, p := range sparsePaths {
-		if p == ".sageox/" || p == ".sageox" {
-			hasSageox = true
-			break
-		}
-	}
-	if !hasSageox {
-		sparsePaths = append(sparsePaths, ".sageox/")
-	}
+	sparsePaths = manifest.EnsureSageoxInclude(sparsePaths)
 
 	args := append([]string{"sparse-checkout", "set", "--no-cone"}, sparsePaths...)
 	if _, err := gitutil.RunGit(ctx, repoPath, args...); err != nil {

--- a/internal/manifest/auto_resolve_test.go
+++ b/internal/manifest/auto_resolve_test.go
@@ -90,7 +90,7 @@ func TestDefaultResolveRules_CoversDataDir(t *testing.T) {
 
 func TestFallbackConfig_IncludesDefaultResolveRules(t *testing.T) {
 	t.Parallel()
-	cfg := FallbackConfig()
+	cfg := FallbackConfigFor(RepoKindTeamContext)
 	assert.Equal(t, DefaultResolveRules, cfg.ResolveRules)
 }
 

--- a/internal/manifest/fallback.go
+++ b/internal/manifest/fallback.go
@@ -1,6 +1,6 @@
 package manifest
 
-import "log/slog"
+import "fmt"
 
 // RepoKind identifies which kind of ox-synced repo a manifest belongs to.
 //
@@ -11,7 +11,8 @@ import "log/slog"
 // inherited the team-context set and never materialized knowledge/.
 //
 // Callers must pass a kind explicitly. There is deliberately no "default"
-// repo kind: an unset value is a plumbing bug, not a supported input.
+// repo kind: an unset value is a plumbing bug, not a supported input, and
+// fallbackIncludesFor panics rather than guessing one.
 type RepoKind string
 
 const (
@@ -50,9 +51,18 @@ var kbFallbackIncludes = []string{
 	"knowledge/",
 }
 
-// fallbackIncludesFor returns the include set for kind. An unrecognized kind
-// is a plumbing bug — we log loudly and fall back to the team-context set
-// rather than checking out nothing.
+// fallbackIncludesFor returns the include set for kind.
+//
+// An unrecognized kind panics rather than degrading to some default. Degrading
+// is what produced the bug this file exists to fix: a bubble quietly took the
+// team-context shape and the only evidence was a log line nobody read. A new
+// RepoKind added without a case here would reproduce that failure exactly, so
+// it must fail at the first call instead.
+//
+// This is unreachable from any current path — every caller passes one of the
+// two constants, and the compiler requires the argument. If a kind ever
+// originates from config or an API response, validate it at that boundary
+// before it reaches here; otherwise this becomes a remotely-triggerable crash.
 func fallbackIncludesFor(kind RepoKind) []string {
 	switch kind {
 	case RepoKindKB:
@@ -60,9 +70,7 @@ func fallbackIncludesFor(kind RepoKind) []string {
 	case RepoKindTeamContext:
 		return teamContextFallbackIncludes
 	default:
-		slog.Warn("manifest: unknown repo kind, using team-context fallback includes",
-			"kind", string(kind))
-		return teamContextFallbackIncludes
+		panic(fmt.Sprintf("manifest: unrecognized repo kind %q — every caller must pass an explicit RepoKind", string(kind)))
 	}
 }
 

--- a/internal/manifest/fallback.go
+++ b/internal/manifest/fallback.go
@@ -1,8 +1,32 @@
 package manifest
 
-// fallbackIncludes is the hardcoded sparse set used when the manifest
-// is missing or unparseable.
-var fallbackIncludes = []string{
+import "log/slog"
+
+// RepoKind identifies which kind of ox-synced repo a manifest belongs to.
+//
+// It selects the fallback include set used when .sageox/sync.manifest is
+// missing or unparseable. Team contexts and knowledge bubbles have different
+// on-disk shapes, so a single shared fallback silently checks out the wrong
+// tree for one of them — which is exactly what happened to bubbles: they
+// inherited the team-context set and never materialized knowledge/.
+//
+// Callers must pass a kind explicitly. There is deliberately no "default"
+// repo kind: an unset value is a plumbing bug, not a supported input.
+type RepoKind string
+
+const (
+	// RepoKindTeamContext is a team-context repo — SOUL.md, docs/,
+	// discussions/, coworkers/, and the team memory tree.
+	RepoKindTeamContext RepoKind = "team_context"
+
+	// RepoKindKB is a knowledge bubble — control-plane metadata plus the
+	// curated knowledge/ tree the curator writes.
+	RepoKindKB RepoKind = "kb"
+)
+
+// teamContextFallbackIncludes is the hardcoded sparse set for team-context
+// repos when the manifest is missing or unparseable.
+var teamContextFallbackIncludes = []string{
 	".sageox/",
 	"SOUL.md",
 	"TEAM.md",
@@ -15,12 +39,40 @@ var fallbackIncludes = []string{
 	"agent-context/",
 }
 
-// FallbackConfig returns a ManifestConfig with hardcoded control-plane
-// paths and sensible defaults. Used when .sageox/sync.manifest is
+// kbFallbackIncludes is the hardcoded sparse set for knowledge bubbles.
+//
+// Deliberately narrow: a bubble is control-plane metadata (.sageox/), its
+// agent-facing entry point (AGENTS.md), and the curated knowledge/ tree.
+// Nothing from the team-context shape belongs here.
+var kbFallbackIncludes = []string{
+	".sageox/",
+	"AGENTS.md",
+	"knowledge/",
+}
+
+// fallbackIncludesFor returns the include set for kind. An unrecognized kind
+// is a plumbing bug — we log loudly and fall back to the team-context set
+// rather than checking out nothing.
+func fallbackIncludesFor(kind RepoKind) []string {
+	switch kind {
+	case RepoKindKB:
+		return kbFallbackIncludes
+	case RepoKindTeamContext:
+		return teamContextFallbackIncludes
+	default:
+		slog.Warn("manifest: unknown repo kind, using team-context fallback includes",
+			"kind", string(kind))
+		return teamContextFallbackIncludes
+	}
+}
+
+// FallbackConfigFor returns a ManifestConfig with the hardcoded include set
+// for kind plus sensible defaults. Used when .sageox/sync.manifest is
 // missing, unparseable, or has an unknown version.
-func FallbackConfig() *ManifestConfig {
-	includes := make([]string, len(fallbackIncludes))
-	copy(includes, fallbackIncludes)
+func FallbackConfigFor(kind RepoKind) *ManifestConfig {
+	src := fallbackIncludesFor(kind)
+	includes := make([]string, len(src))
+	copy(includes, src)
 
 	rules := make([]ResolveRule, len(DefaultResolveRules))
 	copy(rules, DefaultResolveRules)

--- a/internal/manifest/fallback_test.go
+++ b/internal/manifest/fallback_test.go
@@ -40,6 +40,21 @@ func TestFallbackConfigFor_TeamContext(t *testing.T) {
 		"team-context fallback must not include the bubble knowledge/ tree")
 }
 
+// A RepoKind with no case in fallbackIncludesFor must panic, not silently
+// degrade to some default set. Silent degradation is the exact mechanism of
+// the bug this file fixes — the next kind added without a case would inherit
+// the wrong tree and, as before, announce it only in a log line.
+func TestFallbackConfigFor_UnknownKindPanics(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []RepoKind{"", "ledger", "TEAM_CONTEXT"} {
+		t.Run(string(kind), func(t *testing.T) {
+			t.Parallel()
+			assert.Panics(t, func() { FallbackConfigFor(kind) },
+				"unrecognized kind %q must panic rather than fall back to a guess", kind)
+		})
+	}
+}
+
 func TestFallbackConfigFor_ReturnsFreshCopy(t *testing.T) {
 	t.Parallel()
 	for _, kind := range []RepoKind{RepoKindKB, RepoKindTeamContext} {

--- a/internal/manifest/fallback_test.go
+++ b/internal/manifest/fallback_test.go
@@ -1,0 +1,113 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A knowledge bubble whose manifest doesn't parse must fall back to the kb
+// include set, not the team-context one. Regression for ox-182q: bubbles
+// inherited the team-context fallback, so knowledge/ was never materialized
+// and the bug was invisible except for a slog.Warn.
+func TestFallbackConfigFor_KB(t *testing.T) {
+	t.Parallel()
+	cfg := FallbackConfigFor(RepoKindKB)
+
+	assert.ElementsMatch(t, []string{".sageox/", "AGENTS.md", "knowledge/"}, cfg.Includes,
+		"kb fallback must be exactly control-plane + AGENTS.md + knowledge/")
+
+	for _, teamOnly := range []string{"SOUL.md", "TEAM.md", "MEMORY.md", "memory/", "docs/", "coworkers/", "discussions/", "agent-context/"} {
+		assert.NotContains(t, cfg.Includes, teamOnly,
+			"kb fallback must not inherit team-context path %q", teamOnly)
+	}
+
+	assert.Equal(t, SupportedVersion, cfg.Version)
+	assert.Equal(t, DefaultResolveRules, cfg.ResolveRules)
+}
+
+// The team-context fallback must not drift into the kb shape either.
+func TestFallbackConfigFor_TeamContext(t *testing.T) {
+	t.Parallel()
+	cfg := FallbackConfigFor(RepoKindTeamContext)
+
+	assert.Contains(t, cfg.Includes, "SOUL.md")
+	assert.Contains(t, cfg.Includes, "discussions/")
+	assert.NotContains(t, cfg.Includes, "knowledge/",
+		"team-context fallback must not include the bubble knowledge/ tree")
+}
+
+func TestFallbackConfigFor_ReturnsFreshCopy(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []RepoKind{RepoKindKB, RepoKindTeamContext} {
+		cfg := FallbackConfigFor(kind)
+		cfg.Includes[0] = "mutated"
+		if FallbackConfigFor(kind).Includes[0] == "mutated" {
+			t.Errorf("FallbackConfigFor(%q) leaked the package-level slice", kind)
+		}
+	}
+}
+
+// The end-to-end path that broke in production: a bubble seeded with a
+// comment-only sync.manifest (no version, no includes) must still produce a
+// sparse set that materializes knowledge/.
+func TestParseFile_CommentOnlyManifest_KBStillGetsKnowledge(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sync.manifest")
+	// verbatim content the server seeds into new bubbles
+	require.NoError(t, os.WriteFile(path, []byte("# managed by SageOx KB watchman\n"), 0o644))
+
+	sparse := ComputeSparseSet(ParseFile(path, RepoKindKB))
+
+	assert.Contains(t, sparse, "/knowledge/")
+	assert.Contains(t, sparse, "/.sageox/")
+	assert.NotContains(t, sparse, "/discussions/", "must not fall back to the team-context set")
+}
+
+// Bare filename patterns match at any depth under gitignore semantics, which
+// is what let "AGENTS.md" leak knowledge/agents.md out of an otherwise
+// fully-excluded directory (case-insensitively, on macOS).
+func TestComputeSparseSet_AnchorsPatternsToRoot(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		include string
+		want    string
+	}{
+		{"bare file", "AGENTS.md", "/AGENTS.md"},
+		{"top-level dir", "knowledge/", "/knowledge/"},
+		{"dotted dir", ".sageox/", "/.sageox/"},
+		{"nested path already root-relative", "memory/daily/", "/memory/daily/"},
+		{"already anchored is left alone", "/AGENTS.md", "/AGENTS.md"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ComputeSparseSet(&ManifestConfig{Includes: []string{tt.include}})
+			assert.Contains(t, result, tt.want)
+		})
+	}
+}
+
+func TestEnsureSageoxInclude(t *testing.T) {
+	t.Parallel()
+	t.Run("appends when absent", func(t *testing.T) {
+		t.Parallel()
+		got := EnsureSageoxInclude([]string{"/*", "!/*/", "/knowledge/"})
+		assert.Equal(t, []string{"/*", "!/*/", "/knowledge/", "/.sageox/"}, got,
+			".sageox/ must come after !/*/ so it is re-included, not re-excluded")
+	})
+
+	t.Run("no-op when already present in any form", func(t *testing.T) {
+		t.Parallel()
+		for _, form := range []string{".sageox", ".sageox/", "/.sageox", "/.sageox/"} {
+			in := []string{"/*", "!/*/", form}
+			assert.Equal(t, in, EnsureSageoxInclude(in), "should not duplicate %q", form)
+		}
+	})
+}

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -155,29 +155,33 @@ func Parse(r io.Reader) (*ManifestConfig, error) {
 }
 
 // ParseFile parses a manifest from a file path. On any error (missing
-// file, parse error, unknown version), it returns the fallback config
-// and logs a warning.
-func ParseFile(path string) *ManifestConfig {
+// file, parse error, unknown version), it returns the fallback config for
+// kind and logs a warning.
+//
+// kind is required and must match the repo being parsed. Falling back to the
+// wrong kind's include set is silent and total — the checkout simply omits an
+// entire tree — so every warning below names the kind it fell back to.
+func ParseFile(path string, kind RepoKind) *ManifestConfig {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			slog.Warn("manifest: file not found, using fallback", "path", path)
+			slog.Warn("manifest: file not found, using fallback", "path", path, "kind", string(kind))
 		} else {
-			slog.Warn("manifest: cannot open file, using fallback", "path", path, "error", err)
+			slog.Warn("manifest: cannot open file, using fallback", "path", path, "kind", string(kind), "error", err)
 		}
-		return FallbackConfig()
+		return FallbackConfigFor(kind)
 	}
 	defer f.Close()
 
 	cfg, err := Parse(f)
 	if err != nil {
-		slog.Warn("manifest: parse failed, using fallback", "path", path, "error", err)
-		return FallbackConfig()
+		slog.Warn("manifest: parse failed, using fallback", "path", path, "kind", string(kind), "error", err)
+		return FallbackConfigFor(kind)
 	}
 
 	if len(cfg.Includes) == 0 {
-		slog.Warn("manifest: no include directives, using fallback", "path", path)
-		return FallbackConfig()
+		slog.Warn("manifest: no include directives, using fallback", "path", path, "kind", string(kind))
+		return FallbackConfigFor(kind)
 	}
 
 	return cfg
@@ -190,6 +194,10 @@ func ParseFile(path string) *ManifestConfig {
 // (like .gitattributes) without pulling in root-level directories. Specific
 // directories from includes are then re-added. This ensures root-level
 // control files are materialized in sparse-checkout --no-cone mode.
+//
+// Every include is root-anchored on the way out (see anchorPattern) so a
+// manifest entry names exactly one path in the repo, never a same-named path
+// nested somewhere else.
 func ComputeSparseSet(cfg *ManifestConfig) []string {
 	if cfg == nil {
 		return nil
@@ -219,11 +227,50 @@ func ComputeSparseSet(cfg *ManifestConfig) []string {
 			}
 		}
 		if !denied {
-			result = append(result, inc)
+			result = append(result, anchorPattern(inc))
 		}
 	}
 
 	return result
+}
+
+// anchorPattern pins a manifest include to the repo root.
+//
+// --no-cone sparse-checkout uses gitignore matching semantics, where a
+// pattern whose only slash is trailing (or which has no slash at all) matches
+// at ANY depth. So a bare "AGENTS.md" also matched knowledge/agents.md — on a
+// case-insensitive filesystem, no less — leaking a single file out of an
+// otherwise-excluded directory and making a total sparse failure look partial.
+//
+// A leading "/" makes the pattern relative to the repo root. Patterns with an
+// interior slash are already root-relative under the same rules, so anchoring
+// them is a semantic no-op; we still normalize for a uniform sparse file.
+func anchorPattern(p string) string {
+	if p == "" || strings.HasPrefix(p, "/") {
+		return p
+	}
+	return "/" + p
+}
+
+// EnsureSageoxInclude appends the control-plane ".sageox/" pattern to paths
+// unless some form of it is already present.
+//
+// .sageox/ holds kb.yaml and sync.manifest itself. Dropping it from the
+// sparse set hides the manifest, so the next pull's sparse reapply has
+// nothing to read and the checkout can never recover on its own. Clone and
+// doctor-repair both need this guarantee, so it lives here rather than being
+// re-implemented at each call site.
+func EnsureSageoxInclude(paths []string) []string {
+	for _, p := range paths {
+		switch p {
+		case ".sageox", ".sageox/", "/.sageox", "/.sageox/":
+			return paths
+		}
+	}
+	// appended, never prepended: ComputeSparseSet emits "!/*/" to drop all
+	// root-level directories, and in --no-cone mode later patterns override
+	// earlier ones, so .sageox/ must come after it to be re-included.
+	return append(paths, "/.sageox/")
 }
 
 // pathOverlaps returns true if a and b overlap: same path, or one is a

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -164,7 +164,7 @@ func Parse(r io.Reader) (*ManifestConfig, error) {
 func ParseFile(path string, kind RepoKind) *ManifestConfig {
 	f, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			slog.Warn("manifest: file not found, using fallback", "path", path, "kind", string(kind))
 		} else {
 			slog.Warn("manifest: cannot open file, using fallback", "path", path, "kind", string(kind), "error", err)

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -176,8 +176,8 @@ gc_interval_days 14`,
 
 func TestParseFile(t *testing.T) {
 	t.Run("missing file returns fallback with resolve rules", func(t *testing.T) {
-		cfg := ParseFile("/nonexistent/path/sync.manifest")
-		fb := FallbackConfig()
+		cfg := ParseFile("/nonexistent/path/sync.manifest", RepoKindTeamContext)
+		fb := FallbackConfigFor(RepoKindTeamContext)
 		assertStringSliceMatch(t, "includes", cfg.Includes, fb.Includes)
 		if len(cfg.ResolveRules) == 0 {
 			t.Error("fallback config should include default resolve rules")
@@ -193,7 +193,7 @@ func TestParseFile(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cfg := ParseFile(path)
+		cfg := ParseFile(path, RepoKindTeamContext)
 		if cfg.Version != 1 {
 			t.Errorf("version = %d, want 1", cfg.Version)
 		}
@@ -209,8 +209,8 @@ func TestParseFile(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cfg := ParseFile(path)
-		fb := FallbackConfig()
+		cfg := ParseFile(path, RepoKindTeamContext)
+		fb := FallbackConfigFor(RepoKindTeamContext)
 		assertStringSliceMatch(t, "includes", cfg.Includes, fb.Includes)
 	})
 
@@ -221,8 +221,8 @@ func TestParseFile(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cfg := ParseFile(path)
-		fb := FallbackConfig()
+		cfg := ParseFile(path, RepoKindTeamContext)
+		fb := FallbackConfigFor(RepoKindTeamContext)
 		assertStringSliceMatch(t, "includes", cfg.Includes, fb.Includes)
 	})
 }
@@ -240,8 +240,8 @@ func TestComputeSparseSet(t *testing.T) {
 				Includes: []string{".sageox/", "memory/", "data/"},
 				Denies:   []string{"data/"},
 			},
-			want:     []string{"/*", "!/*/", ".sageox/", "memory/"},
-			wantNone: []string{"data/"},
+			want:     []string{"/*", "!/*/", "/.sageox/", "/memory/"},
+			wantNone: []string{"/data/", "data/"},
 		},
 		{
 			name: "deny parent blocks child include",
@@ -250,14 +250,14 @@ func TestComputeSparseSet(t *testing.T) {
 				Denies:   []string{"data/"},
 			},
 			want:     []string{"/*", "!/*/"},
-			wantNone: []string{"data/slack/"},
+			wantNone: []string{"/data/slack/", "data/slack/"},
 		},
 		{
 			name: "no denies passes all includes",
 			cfg: &ManifestConfig{
 				Includes: []string{".sageox/", "SOUL.md", "memory/"},
 			},
-			want: []string{"/*", "!/*/", ".sageox/", "SOUL.md", "memory/"},
+			want: []string{"/*", "!/*/", "/.sageox/", "/SOUL.md", "/memory/"},
 		},
 		{
 			name: "nil config",
@@ -271,7 +271,7 @@ func TestComputeSparseSet(t *testing.T) {
 				Denies:   []string{"data/secrets/"},
 			},
 			want:     []string{"/*", "!/*/"},
-			wantNone: []string{"data/"},
+			wantNone: []string{"/data/", "data/"},
 		},
 		{
 			name: "exact file deny blocks matching include",
@@ -279,8 +279,8 @@ func TestComputeSparseSet(t *testing.T) {
 				Includes: []string{"README.md", ".sageox/"},
 				Denies:   []string{"README.md"},
 			},
-			want:     []string{"/*", "!/*/", ".sageox/"},
-			wantNone: []string{"README.md"},
+			want:     []string{"/*", "!/*/", "/.sageox/"},
+			wantNone: []string{"/README.md", "README.md"},
 		},
 	}
 
@@ -301,7 +301,7 @@ func TestComputeSparseSet(t *testing.T) {
 }
 
 func TestFallbackConfig(t *testing.T) {
-	cfg := FallbackConfig()
+	cfg := FallbackConfigFor(RepoKindTeamContext)
 
 	if cfg.Version != SupportedVersion {
 		t.Errorf("version = %d, want %d", cfg.Version, SupportedVersion)
@@ -320,7 +320,7 @@ func TestFallbackConfig(t *testing.T) {
 
 	// verify it returns a copy
 	cfg.Includes[0] = "modified"
-	cfg2 := FallbackConfig()
+	cfg2 := FallbackConfigFor(RepoKindTeamContext)
 	if cfg2.Includes[0] == "modified" {
 		t.Error("FallbackConfig should return a fresh copy")
 	}

--- a/internal/manifest/sparse_checkout_test.go
+++ b/internal/manifest/sparse_checkout_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,9 +19,9 @@ func TestComputeSparseSet_DenyDataExcludesData(t *testing.T) {
 
 	result := ComputeSparseSet(cfg)
 
-	assert.Contains(t, result, "memory/")
-	assert.Contains(t, result, ".sageox/")
-	assert.NotContains(t, result, "data/")
+	assert.Contains(t, result, "/memory/")
+	assert.Contains(t, result, "/.sageox/")
+	assert.NotContains(t, result, "/data/")
 }
 
 func TestComputeSparseSet_IncludesRootFiles(t *testing.T) {
@@ -51,20 +52,22 @@ func TestComputeSparseSet_DenyDataBlocksDataSubdirs(t *testing.T) {
 }
 
 func TestComputeSparseSet_FallbackConfigExcludesData(t *testing.T) {
-	cfg := FallbackConfig()
+	cfg := FallbackConfigFor(RepoKindTeamContext)
 	result := ComputeSparseSet(cfg)
 
 	for _, path := range result {
-		assert.NotEqual(t, "data/", path, "fallback sparse set should not include data/")
+		// patterns are root-anchored ("/data/"), so compare on the unanchored form
+		bare := strings.TrimPrefix(path, "/")
+		assert.NotEqual(t, "data/", bare, "fallback sparse set should not include data/")
 		assert.False(t,
-			len(path) > 5 && path[:5] == "data/",
+			strings.HasPrefix(bare, "data/"),
 			"fallback sparse set should not include data/ subdirectories, got: %s", path,
 		)
 	}
 
 	// verify known fallback paths are present
-	assert.Contains(t, result, "memory/")
-	assert.Contains(t, result, ".sageox/")
+	assert.Contains(t, result, "/memory/")
+	assert.Contains(t, result, "/.sageox/")
 }
 
 // gitEnv returns environment variables that provide git identity
@@ -206,4 +209,49 @@ func TestSparseCheckout_FreshCloneExcludesData(t *testing.T) {
 	// root-level files should be present via /* pattern
 	_, err = os.Stat(filepath.Join(cloneDir, ".gitattributes"))
 	assert.NoError(t, err, ".gitattributes should exist in sparse clone (root-level files included)")
+}
+
+// TestSparseCheckout_BareFilePatternDoesNotLeakNestedMatches drives real git
+// to prove the root-anchoring fix, rather than only asserting on the pattern
+// string that ComputeSparseSet emits.
+//
+// gitignore semantics (which --no-cone sparse-checkout uses) make a pattern
+// with no interior slash match at ANY depth. An include of "AGENTS.md" for the
+// repo's root entry point therefore also matched knowledge/agents.md, pulling
+// one file out of a directory that was otherwise entirely excluded. On macOS
+// core.ignorecase=true widened it further to any case variant.
+//
+// The class of failure is "a root-level manifest entry silently materializes
+// same-named files nested elsewhere", so this covers the exact-case nested
+// match, the case-variant nested match, and confirms the intended root file
+// still lands.
+//
+// Failure prevented: a sparse set that is wrong for an entire directory looks
+// partially correct, hiding the real breakage during triage.
+func TestSparseCheckout_BareFilePatternDoesNotLeakNestedMatches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	dir := t.TempDir()
+	initGitRepo(t, dir, map[string]string{
+		"AGENTS.md":            "root entry point",
+		"knowledge/agents.md":  "nested, case-variant",
+		"knowledge/AGENTS.md":  "nested, exact case",
+		"knowledge/quality.md": "nested, unrelated name",
+		".sageox/kb.yaml":      "kb_type: custom\n",
+	})
+
+	// manifest includes the root file but NOT knowledge/
+	sparseSet := ComputeSparseSet(&ManifestConfig{Includes: []string{".sageox/", "AGENTS.md"}})
+	runGit(t, dir, append([]string{"sparse-checkout", "set", "--no-cone"}, sparseSet...)...)
+
+	assert.FileExists(t, filepath.Join(dir, "AGENTS.md"),
+		"the root AGENTS.md is what the manifest actually asked for")
+
+	for _, leaked := range []string{"knowledge/agents.md", "knowledge/AGENTS.md", "knowledge/quality.md"} {
+		_, err := os.Stat(filepath.Join(dir, filepath.FromSlash(leaked)))
+		assert.True(t, os.IsNotExist(err),
+			"%s must not materialize: knowledge/ is not in the include set", leaked)
+	}
 }


### PR DESCRIPTION
## What broke

Knowledge Bubbles were syncing "successfully" while their knowledge files never landed on disk.

Observed on the product bubble (`kb_019f18ee-2eb0-7386-a1d6-d5176d40222c`) at commit `6175710`:

- **In the commit:** 9 files under `knowledge/`
- **On disk:** 1 (`knowledge/agents.md`)
- **The other 8:** present in the object store, carrying the skip-worktree bit

No data loss — the files were always in git. They were never written into the working tree. An AI coworker reading that bubble saw a near-empty knowledge base with no signal that anything was missing.

This affected **every bubble on every machine**, and repeated on **every sync pass**, so it was not self-correcting.

## Root cause

Each synced repo carries `.sageox/sync.manifest` declaring which paths to materialize. The server seeds new bubbles with a comment-only file:

```
# managed by SageOx KB watchman
```

No `version` directive, so `manifest.Parse` rejects it and `ParseFile` falls back to a hardcoded include set. **The only fallback set that existed was the team-context one** — `SOUL.md`, `docs/`, `discussions/`, `coworkers/`. No `knowledge/`.

Both the clone path and every pull recompute sparse from that same unparseable manifest, so the exclusion re-asserted continuously. A manual `git sparse-checkout` widening would not have survived the next daemon pass.

```mermaid
flowchart TD
    A["Server seeds bubble with<br/>comment-only sync.manifest"] --> B["manifest.Parse → ErrNoVersion"]
    B --> C["ParseFile falls back"]
    C --> D{"Which fallback set?"}
    D -->|"before: only one existed"| E["team-context includes<br/>(no knowledge/)"]
    E --> F["knowledge/ excluded from sparse set"]
    F --> G["TwoPhaseClone applies it"]
    F --> H["every pull re-applies it"]
    G --> I["knowledge/ invisible on disk"]
    H --> I
    D -->|"after this PR"| J["kb includes<br/>.sageox/, AGENTS.md, knowledge/"]
    J --> K["knowledge/ materializes"]
```

### Why it looked partial instead of total

`--no-cone` sparse-checkout uses gitignore matching, where a pattern with no interior slash matches at **any depth**. The team-context set's bare `AGENTS.md` entry (intended for the repo-root file) also matched `knowledge/agents.md` — case-insensitively, since `core.ignorecase=true` on macOS.

That leaked exactly one file out of an otherwise fully-excluded directory, making a structural failure present as a file-specific one. Real triage cost.

## What this PR ships

| Change | File |
|---|---|
| `RepoKind` type + kb-specific fallback set (`.sageox/`, `AGENTS.md`, `knowledge/`) | `internal/manifest/fallback.go` |
| `ParseFile` and `TwoPhaseClone` now **require** a repo kind | `internal/manifest/parser.go`, `internal/gitserver/two_phase_clone.go` |
| `ComputeSparseSet` root-anchors every include (`AGENTS.md` → `/AGENTS.md`) | `internal/manifest/parser.go` |
| Shared `EnsureSageoxInclude` replaces two hand-rolled copies | `internal/gitserver/two_phase_clone.go`, `cmd/ox/doctor_team.go` |
| Call sites declare their kind (kb vs team-context) | `internal/daemon/sync_bubbles.go`, `internal/daemon/sync_team.go`, `cmd/ox/doctor_git_repos_fix.go` |

**Anti-recurrence:** there is deliberately no default repo kind. Previously "unspecified" silently meant team-context, which is the trapdoor this bug fell through. Omitting it is now a compile error.

**Anchoring is a no-op for team contexts.** Patterns with an interior slash are already root-relative under gitignore rules, and anything under an included directory (`coworkers/`, `docs/`) stays included regardless.

### Latent bug fixed in passing

The two copies of the "ensure `.sageox/` is in the set" guard were not identical. `two_phase_clone.go` appended; `doctor_team.go` **prepended**:

```go
sparsePaths = append([]string{".sageox/"}, sparsePaths...)
```

Order is load-bearing — later patterns override earlier ones, and `!/*/` excludes all root directories. Prepending puts `.sageox/` ahead of `!/*/`, which then re-excludes it. Verified empirically: the prepended form leaves `.sageox` absent from the working tree.

So `ox doctor`'s repair for a broken sparse checkout could itself hide the manifest — the exact state `doctor_kb_repo_health.go` warns about elsewhere. Low real-world impact (the branch only fires when `.sageox/` is already missing from the computed set, which real manifests don't hit), but it lived on the recovery path. The shared helper appends, with a test asserting the ordering.

## Test Plan

**Both fixes verified load-bearing** — each was reverted individually and the tests confirmed red, then restored:

- Neuter the kb fallback → `TestSyncBubbles_UnparseableManifest_MaterializesKnowledgeTree` fails on clone **and** pull, and `discussions/` leaks into the bubble.
- Neuter anchoring → `TestSparseCheckout_BareFilePatternDoesNotLeakNestedMatches` shows `knowledge/agents.md` and `knowledge/AGENTS.md` materializing from a manifest that only asked for the root file.

**New coverage:**

- `TestSyncBubbles_UnparseableManifest_MaterializesKnowledgeTree` — end-to-end through the daemon with the **verbatim** server-seeded manifest, real git, asserting bubble shape after clone *and* after pull (sparse is recomputed every pull, so a wrong fallback re-hides the tree even if clone got it right). Asserts both directions: `knowledge/` appears, `discussions/` does not.
- `TestSparseCheckout_BareFilePatternDoesNotLeakNestedMatches` — drives real git rather than asserting on pattern strings. Covers the exact-case nested match, the case-variant nested match, and confirms the intended root file still lands.
- `TestFallbackConfigFor_KB` / `_TeamContext` — the two sets cannot drift into each other.
- `TestComputeSparseSet_AnchorsPatternsToRoot`, `TestEnsureSageoxInclude`.

**Against real production data:** applying the corrected sparse set to a copy of `kb_019f18ee-...` takes `knowledge/` from 1 file to all 9, with zero skip-worktree entries remaining.

**Gates:** `make lint` clean (0 issues). `internal/manifest`, `internal/gitserver`, `internal/daemon`, `internal/daemon/agentwork`, `internal/daemon/hooks`, `internal/daemon/testutil` all pass.

**Pre-existing failures, not from this change** (verified by re-running with all changes stashed): `TestCodeDBMaintainerNilManager`, `TestDoctorFreshInstall_NoWarnings`, `TestDoctorFreshInstall_EmptyRepo_NoWarnings`. The last two read the developer's real `~/.local/share/sageox` — filed as `ox-mael`.

## Rollout

Existing broken bubbles heal on the next daemon pull once running a build with this fix — sparse is reapplied from the manifest on every pass. No reclone needed.

## Follow-ups filed

| Issue | P | What |
|---|---|---|
| `ox-8kly` | P2 | Server still seeds a content-free manifest. Harmless now, but the server can't change a bubble's sparse shape without an ox release. |
| `ox-mael` | P2 | `TestDoctorFreshInstall_*` reads real machine state instead of a sandbox. |
| `ox-znck` | P3 | `ox doctor` checked only for `.sageox` in the cone, so it reported these bubbles healthy the entire time. It should flag a bubble whose `knowledge/` is missing. |

Closes `ox-182q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_019fb602-3c60-7f17-a7e9-ab8c6073b8a2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sparse checkout for team-context repositories and knowledge bubbles.
  * Preserved required `.sageox/`, `knowledge/`, and `AGENTS.md` content when manifests are missing or unreadable.
  * Prevented similarly named files in nested directories from being included unintentionally.
  * Standardized repository-specific fallback handling during cloning and synchronization.
* **Tests**
  * Added coverage for fallback manifests, sparse path matching, and synchronization after cloning or pulling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->