### PR TITLE
feat(session): publish draft placeholders for in-progress recordings

### DIFF
--- a/.claude/rules/cache-only-design.md
+++ b/.claude/rules/cache-only-design.md
@@ -45,6 +45,7 @@ post-mortem'd in the 2026-04-25 Phase 2 incident:
 | `commitAndPushLedger` style globbing | OK only when raw.jsonl in-place is unchanged from HEAD |
 | Recording a NEW session (locally-authored) | Writes to `state.SessionPath` (xdg / project cache), uploads bytes to LFS, commits POINTER to ledger |
 | `--redact` mode (intentional overwrite-then-reupload) | Allowed because it's a controlled write-then-upload-new-OID cycle that updates meta.json |
+| Draft placeholder (ADR-029) | `meta.json` ONLY. Never raw.jsonl, never any content file. `lfs.WriteDraftSessionMeta` refuses a directory that already holds raw.jsonl; `validateDraftShape` refuses a draft meta with a populated `files` manifest; `sessionArtifactsToStage` returns nothing for a draft so its empty manifest cannot fall through to the glob |
 
 ## Canonical helpers
 
@@ -111,6 +112,34 @@ banned patterns above and fail the build if any reappear, similar to
 `make check-no-git-lfs-shell`. For now, code review and the
 `TestResolveContentPath_CacheOnlyDesign` / `TestOpenSessionContent_*`
 tests in `cmd/ox/` are the enforcement.
+
+## Ledger index mutation must be guarded, not just pushes
+
+Every ledger index writer in the CLI used to be followed by `pushLedger` →
+`gitutil.PushWithRetry` → `IsSafeForGitOps`, so the mid-rebase guard rode
+along for free. Draft placeholders were the first writer that deliberately
+does NOT push, and they fell straight through it.
+
+The failure is silent and team-wide. During a conflicted `git pull --rebase`
+on `sessions/<name>/meta.json`, an unguarded `git add` **marks the conflict
+resolved** and `git commit -- <pathspec>` **succeeds on the detached rebase
+HEAD, consuming the replay step**. The next `rebase --continue` reports
+success and the commit being replayed is gone — a teammate's finalize, a
+murmur, a plan, imported team data.
+
+**Any new code path that mutates the ledger index MUST check
+`gitutil.IsRebaseInProgress` / `IsSafeForGitOps` first, whether or not it
+pushes.** In `cmd/ox` the chokepoint is `prepareDraftLedgerWrite`.
+
+Two related traps in the same area:
+
+- `git commit -- <pathspec>` commits the **working tree**, not the index.
+  Anything that rewrote those paths between `git add` and `git commit` gets
+  committed under your message. Re-verify before committing.
+- `deriveLedgerPath` returns `filepath.Dir` for ANY path whose parent is
+  named `sessions` — including the XDG cache and the legacy in-repo fallback,
+  where the "ledger" is the user's own project root. Validate the derived
+  path against the project's configured ledger before running git on it.
 
 ## Related
 

--- a/.claude/rules/daemon-git.md
+++ b/.claude/rules/daemon-git.md
@@ -15,11 +15,26 @@ paths:
 | `git clone` | daemon | Initial setup / anti-entropy |
 | `git fetch` | daemon | Background sync timer |
 | `git pull --rebase --autostash` | daemon | Background sync timer |
-| `git add --sparse` | CLI | Session upload, import, doctor |
-| `git commit` | CLI | Session upload pipeline |
-| `git push` | CLI | Session upload pipeline |
+| `git add --sparse` | CLI | Session upload, import, doctor, session drafts |
+| `git commit` | CLI | Session upload pipeline, session drafts |
+| `git push` | CLI **and** daemon | CLI: session upload pipeline. Daemon: batched push of its OWN narrow, pathspec-scoped commits (murmurs, session finalize, session drafts) |
 
-The daemon only performs git pull (read) operations. The CLI performs add/commit/push (write) operations directly on the ledger.
+The CLI owns the session-upload write path end to end. The daemon writes only
+on narrow, pathspec-scoped, daemon-owned paths and batches their pushes onto
+its sync cycle.
+
+**The daemon push is deliberately narrower than the CLI's.** `pushLedger` runs
+a pre-push secret gate and an LFS reconcile; the daemon's batched pushes run
+neither, and `git push` moves the whole branch. So
+`pushSessionDraftCommits` refuses to push when ANY unpushed commit is not a
+draft commit — otherwise it could ship a commit the CLI deliberately refused
+(a secret-gate rejection), or a finalize commit before its LFS blobs exist.
+Any future daemon-side push must apply the same restriction or run the gate.
+
+**Mid-rebase safety belongs at index-mutation time, not push time.** See
+`.claude/rules/cache-only-design.md` — an unguarded `git add` during a
+conflicted rebase marks the conflict resolved and the following commit
+consumes the replay step, silently destroying whatever was being replayed.
 
 **Why this split:** Minimal IPC surface, CLI writes don't depend on daemon, daemon stays simple. Conflicts are extremely unlikely (unique path per session with random suffix). Push failure after 3 CLI retries is acceptable — best-effort, not transactional.
 

--- a/.claude/rules/session-draft.md
+++ b/.claude/rules/session-draft.md
@@ -1,0 +1,133 @@
+---
+paths:
+  - cmd/ox/session*.go
+  - cmd/ox/agent_session*.go
+  - cmd/ox/doctor_session*.go
+  - internal/lfs/**
+  - internal/session/**
+  - internal/daemon/**
+---
+
+# Session Draft Placeholders (ADR-029)
+
+A **draft** is a `meta.json`-only directory committed to
+`<ledger>/sessions/<name>/` partway through a live recording, so
+`https://<endpoint>/c/<session_id>` resolves for links already circulating in
+PR bodies and commit trailers. It carries **no turn data** and is superseded
+wholesale at session stop.
+
+Full rationale: [docs/adr/ADR-029-session-draft-placeholder.md](../../docs/adr/ADR-029-session-draft-placeholder.md).
+
+---
+
+## The one rule
+
+> **Any code that treats "`sessions/<name>/meta.json` exists" as "this session
+> is real" MUST call `meta.IsDraft()` first.**
+
+Before drafts, that directory existing meant the session was finalized and
+uploaded. It no longer does. Every consumer that skipped a session, marked it
+done, indexed it, repaired it, or refused to delete it on that basis is now
+wrong for live recordings unless it branches on `IsDraft()`.
+
+Read `.Draft` directly only inside `IsDraft()`. The helper is nil-safe, and
+nil is the normal result of an unreadable `meta.json` on every one of these
+paths.
+
+## A draft contains meta.json and NOTHING else
+
+Forced by the LFS invariant in [cache-only-design.md](cache-only-design.md):
+real bytes on the git-tracked `raw.jsonl` break LFS linkage and make the
+ledger reject **every future push, for every teammate**.
+
+Three writer-side guards enforce it, and none is redundant:
+
+| Guard | Refuses |
+|---|---|
+| `lfs.validateDraftShape` (via `Validate` → every writer) | a draft meta with a populated `files` manifest or any summary text |
+| `lfs.WriteDraftSessionMeta` | a directory that already holds `raw.jsonl` |
+| `sessionArtifactsToStage` | returns nothing for a draft, so its legitimately-empty manifest cannot fall through to the `*.jsonl`/`*.md` glob |
+
+`lfs.DraftInput` deliberately has **no field that can hold transcript-derived
+text** — no title, no summary, no preview. That is the privacy guarantee, and
+it is enforced by a test that fails when a field is added.
+
+## Ledger index mutation is a guarded chokepoint
+
+Drafts are the first ledger index writer that deliberately does **not** push,
+so they miss the `IsSafeForGitOps` check that rides along with
+`PushWithRetry` for every other writer. Mid-rebase, an unguarded `git add`
+marks the conflict resolved and the following commit consumes the replay step
+— silently destroying whatever was being replayed.
+
+**Every draft git write goes through `prepareDraftLedgerWrite`**, which
+validates the session name, validates the ledger target, waits out a
+blue-green GC swap, and refuses mid-rebase. Adding a fifth write path means
+calling it, not copying three of its four checks.
+
+## Banned patterns
+
+```go
+// BANNED — a draft makes this true for a LIVE recording
+if _, err := os.Stat(filepath.Join(ledgerPath, "sessions", name, "meta.json")); err == nil {
+    continue // "already uploaded"
+}
+
+// BANNED — reads .Draft directly; panics on the nil meta that an
+// unreadable meta.json produces
+if meta.Draft { ... }
+
+// BANNED — fails OPEN. An unreadable meta on a daemon path falls through to
+// recoverRawFromSessionFile, which writes real bytes to the tracked raw.jsonl
+if _, isDraft, err := lfs.PreservedSessionIDAndDraft(dir); err == nil && isDraft { continue }
+
+// BANNED — a new git write path that skips the chokepoint
+exec.Command("git", "-C", ledgerPath, "add", "--sparse", "--", relPath)
+
+// BANNED — purging before reading the ses_ id; the draft meta CARRIES it
+purgeDraftSessionDir(ledgerPath, name)
+id, _ := lfs.PreservedSessionID(sessionDir) // always "" now
+```
+
+## Correct patterns
+
+```go
+// Classify, nil-safe, with the fail-safe direction chosen deliberately
+meta, err := lfs.ReadSessionMeta(sessionDir)
+if err == nil && meta.IsDraft() { continue }
+
+// Daemon paths fail CLOSED — skipping is cheap, recovering onto a tracked
+// raw.jsonl breaks LFS for the team
+if _, isDraft, err := lfs.PreservedSessionIDAndDraft(dir); isDraft || err != nil { continue }
+
+// Finalize: read the id, THEN purge — one helper so the order can't drift
+preservedID, wasDraft, err := supersedeDraftForFinalize(ledgerPath, sessionName)
+
+// Any preserve-unowned-fields RMW must clear the markers explicitly
+next := current
+next.ClearDraft()
+```
+
+## Fail-safe directions
+
+Each site picks a direction for an unreadable `meta.json`. **Pick the one that
+is non-destructive when wrong**, and say why in a comment:
+
+- **Skip / refuse** on daemon detection, abort resolution, and draft deletion —
+  being wrong means recovering bytes onto a tracked path, or deleting a
+  directory we could not classify.
+- **Treat as uploaded** in doctor's orphan sweep — retrying an unclassifiable
+  upload risks clobbering a finalized session; skipping only defers to a human.
+- **Fail open** in `ledgersearch` — a malformed file must not hide a real
+  session from search.
+- **Fatal** in `PreservedSessionIDAndDraft` — we cannot tell whether it held a
+  `ses_` id we would rotate, and rotating 404s links already in PR bodies.
+
+## When adding a new consumer
+
+1. Does it enumerate `<ledger>/sessions/`? Add the `IsDraft()` branch.
+2. Does it write to the ledger index? Route through `prepareDraftLedgerWrite`.
+3. Does it read a `ses_` id from a session dir it will then modify? Read first.
+4. Add a test with a **negative control** — a non-draft fixture that still
+   produces the behavior. Without one, a draft-skip test passes trivially,
+   because a meta-only directory already does nothing on most paths.

--- a/cmd/ox/agent_hook.go
+++ b/cmd/ox/agent_hook.go
@@ -772,6 +772,12 @@ func handleStop(ctx *HookContext) error {
 	if err := handleAfterTool(ctx); err != nil {
 		slog.Debug("hook: stop drain failed", "error", err)
 	}
+	// Turn counting and the early draft placeholder live HERE and nowhere
+	// else. PhaseStop fires once per completed response turn; handleAfterTool
+	// also fires on PostToolUse, so incrementing there would count tool calls.
+	// Best-effort by contract — it never returns an error and never fails the
+	// turn.
+	maybePublishSessionDraft(ctx)
 	return nil
 }
 

--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -1308,14 +1308,6 @@ func finalizeModeForSessionStop(userPrefersAsync bool) session.FinalizeDispatchM
 // If this fails, the session data is safe in the local cache and doctor can retry.
 // ledgerPath and sessionName are pre-computed by the caller.
 func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state *session.RecordingState, ledgerPath, sessionName string) error {
-	// copy raw.jsonl + secondary artifacts to ledger dir
-	if err := pipeline.CopySessionToLedger(pipeline.OSFileSystem{}, result, ledgerPath, sessionName); err != nil {
-		return err
-	}
-	if result.EntryCount == 0 {
-		return nil // CopySessionToLedger already skipped
-	}
-
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	sessionDir := filepath.Join(sessionsDir, sessionName)
 
@@ -1325,10 +1317,40 @@ func uploadSessionToLedger(projectRoot string, result *agentSessionResult, state
 	// (recordings started under an older binary). Non-NotExist read errors
 	// are fatal — see PreservedSessionID doc. Resolved before the builder is
 	// constructed so sessionMetaBase always receives the final ID.
-	preservedID, err := lfs.PreservedSessionID(sessionDir)
+	//
+	// Read BEFORE the draft purge below, and before CopySessionToLedger: a
+	// draft placeholder is an extra durable carrier of the ses_ id (it
+	// survives .recording.json being cleared), and the purge deletes the very
+	// meta.json that carries it. Reading in the wrong order would rotate an id
+	// already circulating in PR bodies and commit trailers.
+	// Supersede any draft placeholder wholesale (ADR-029). While meta.draft is
+	// true every file in that directory is provisional — including a
+	// summary.json/summary.md the SageOx server may have authored against the
+	// zero-turn draft and pushed, which a finalize-time `git pull --rebase`
+	// folds into our working tree. Those describe nothing and must never
+	// survive into the finalized session as if an LLM had read the transcript.
+	preservedID, wasDraft, err := supersedeDraftForFinalize(ledgerPath, sessionName)
 	if err != nil {
 		return fmt.Errorf("preserve existing SessionID for %s: %w", sessionName, err)
 	}
+
+	// copy raw.jsonl + secondary artifacts to ledger dir
+	if err := pipeline.CopySessionToLedger(pipeline.OSFileSystem{}, result, ledgerPath, sessionName); err != nil {
+		return err
+	}
+	if result.EntryCount == 0 {
+		// CopySessionToLedger already skipped. If a draft was purged above the
+		// deletion is staged but uncommitted; land it, or the /c/ page claims
+		// "in progress" forever and the next unrelated commit sweeps up a
+		// staged deletion under the wrong message.
+		if wasDraft {
+			if retractErr := commitDraftRetraction(ledgerPath, sessionName); retractErr != nil {
+				slog.Warn("draft retraction failed", "session", sessionName, "error", retractErr)
+			}
+		}
+		return nil
+	}
+
 	sessionID := session.ResolveOrMintSessionID(preservedID, state.SessionID)
 
 	// write meta.json first (before LFS upload) to preserve session metadata even if LFS fails

--- a/cmd/ox/agent_session_abort.go
+++ b/cmd/ox/agent_session_abort.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 
 	"github.com/sageox/ox/internal/agentinstance"
 	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 	"github.com/spf13/cobra"
 )
@@ -21,6 +25,15 @@ type sessionAbortOutput struct {
 	SessionName string `json:"session_name,omitempty"`
 	Message     string `json:"message"`
 	Guidance    string `json:"guidance,omitempty"`
+
+	// LedgerDraftDeleted reports that a published draft placeholder was
+	// removed from the ledger, so the session's /c/ page stops advertising it.
+	LedgerDraftDeleted bool `json:"ledger_draft_deleted,omitempty"`
+	// Warning is set when the abort succeeded locally but a ledger operation
+	// did not fully land (typically a push failure). Surfaced so the user
+	// knows the placeholder may still be visible to teammates until the next
+	// push, rather than discovering it later.
+	Warning string `json:"warning,omitempty"`
 }
 
 // runAgentSessionAbort discards a session without uploading to ledger.
@@ -67,6 +80,12 @@ func runAgentSessionAbortActive(inst *agentinstance.Instance, cmd *cobra.Command
 
 	sessionName := session.GetSessionName(state.SessionPath)
 
+	// Remove any published draft placeholder from the ledger FIRST, while the
+	// local state that identifies it still exists. Doing this after
+	// os.RemoveAll would mean a failure here leaves the user's data already
+	// deleted with a live placeholder still advertising the session.
+	draftDeleted, draftWarning := removeLedgerDraftForAbort(sessionName)
+
 	// clear .recording.json so future session start works
 	if err := session.ClearRecordingStateForAgent(projectRoot, inst.AgentID); err != nil {
 		return fmt.Errorf("failed to clear recording state: %w", err)
@@ -86,7 +105,7 @@ func runAgentSessionAbortActive(inst *agentinstance.Instance, cmd *cobra.Command
 	// repair tasks server-side (fire-and-forget)
 	notifySessionAbortedAsync(projectRoot, state.SessionID)
 
-	return emitAbortOutput(cmd.OutOrStdout(), inst.AgentID, sessionName)
+	return emitAbortOutput(cmd.OutOrStdout(), inst.AgentID, sessionName, draftDeleted, draftWarning)
 }
 
 // runAgentSessionAbortByName aborts a session by name. Only allows discarding
@@ -100,6 +119,12 @@ func runAgentSessionAbortByName(inst *agentinstance.Instance, cmd *cobra.Command
 
 	// resolve session name and path in local cache
 	sessionName, sessionPath, err := resolveSessionForAbort(projectRoot, nameArg)
+	if errors.Is(err, errDraftOnlySession) {
+		// Nothing left locally — the session exists only as a published draft
+		// placeholder advertising it on the /c/ page. Removing that IS the
+		// abort, and there is no local data to classify or delete.
+		return abortDraftOnlySession(inst, cmd, projectRoot, sessionName)
+	}
 	if err != nil {
 		return err
 	}
@@ -143,6 +168,11 @@ func runAgentSessionAbortByName(inst *agentinstance.Instance, cmd *cobra.Command
 		abortedSessionID = session.ReadHeaderSessionID(filepath.Join(sessionPath, "raw.jsonl"))
 	}
 
+	// Remove any published draft placeholder from the ledger before touching
+	// local data, so a git failure cannot leave the session deleted locally
+	// while a placeholder still advertises it.
+	draftDeleted, draftWarning := removeLedgerDraftForAbort(sessionName)
+
 	// remove .recording.json if present (unconditional — no agent ownership check)
 	if err := os.Remove(recPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to clear recording state: %w", err)
@@ -155,7 +185,7 @@ func runAgentSessionAbortByName(inst *agentinstance.Instance, cmd *cobra.Command
 
 	notifySessionAbortedAsync(projectRoot, abortedSessionID)
 
-	return emitAbortOutput(cmd.OutOrStdout(), inst.AgentID, sessionName)
+	return emitAbortOutput(cmd.OutOrStdout(), inst.AgentID, sessionName, draftDeleted, draftWarning)
 }
 
 // buildSessionInfo constructs a SessionInfo from a session folder on disk.
@@ -184,7 +214,15 @@ func buildSessionInfo(sessionName, sessionPath string) session.SessionInfo {
 	return info
 }
 
-// isSessionInLedger checks if a session exists in the ledger (uploaded).
+// isSessionInLedger reports whether a session has real, finalized content in
+// the ledger.
+//
+// A directory holding only a DRAFT placeholder does NOT count. A draft is a
+// meta.json-only marker published mid-recording (ADR-029) and carries no turn
+// data. Counting it made ClassifySession return StatusUploaded for a live
+// recording, which made abort refuse outright with "already uploaded — use
+// session delete" — i.e. it broke the privacy escape hatch for exactly the
+// sessions a user is most likely to want discarded.
 func isSessionInLedger(sessionName string) bool {
 	ledgerPath, err := resolveLedgerPath()
 	if err != nil {
@@ -192,17 +230,34 @@ func isSessionInLedger(sessionName string) bool {
 	}
 	ledgerSessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
 	info, statErr := os.Stat(ledgerSessionDir)
-	return statErr == nil && info.IsDir()
+	if statErr != nil || !info.IsDir() {
+		return false
+	}
+	// An unreadable meta.json is treated as finalized (the conservative
+	// direction): abort then refuses, and the user is pointed at
+	// `session delete`, rather than us deleting a directory we cannot classify.
+	if meta, metaErr := lfs.ReadSessionMeta(ledgerSessionDir); metaErr == nil && meta.IsDraft() {
+		return false
+	}
+	return true
 }
 
 // resolveSessionForAbort finds a session by name across all known session locations.
 // Supports partial name resolution (e.g., agent ID suffix like "OxKMZN").
 // Returns the resolved session name and full path to the session folder.
 //
-// Searches the same three locations as 'ox session list':
+// Search order, most-authoritative-first:
 //  1. XDG cache (active/recent recordings)
-//  2. Ledger sessions directory (uploaded sessions)
-//  3. Ledger cache (in-progress sessions before upload)
+//  2. Ledger cache (in-progress sessions before upload)
+//  3. Ledger sessions directory (uploaded sessions)
+//
+// The ledger cache is searched BEFORE the git-tracked ledger sessions dir
+// because that is where live recordings actually live. Before draft
+// placeholders existed the order did not matter — a session was in one place
+// or the other. Now a live recording has a git-tracked draft directory of the
+// same name, and resolving to that one would point the caller's os.RemoveAll
+// at a tracked directory (deleting it from the worktree with no `git rm`, so
+// the next pull restores it) while leaving the real recording untouched.
 func resolveSessionForAbort(projectRoot, nameArg string) (string, string, error) {
 	// build list of stores to search, in priority order
 	var stores []*session.Store
@@ -215,17 +270,19 @@ func resolveSessionForAbort(projectRoot, nameArg string) (string, string, error)
 		}
 	}
 
-	// 2. Ledger sessions + 3. Ledger cache
-	if ledgerPath, err := resolveLedgerPath(); err == nil {
-		if s, err := session.NewStore(ledgerPath); err == nil {
-			stores = append(stores, s)
-		}
+	// 2. Ledger cache, then 3. Ledger sessions
+	ledgerPath, ledgerErr := resolveLedgerPath()
+	if ledgerErr == nil {
 		ledgerCachePath := filepath.Join(ledgerPath, ".sageox", "cache")
 		if s, err := session.NewStore(ledgerCachePath); err == nil {
 			stores = append(stores, s)
 		}
+		if s, err := session.NewStore(ledgerPath); err == nil {
+			stores = append(stores, s)
+		}
 	}
 
+	draftOnlyName := ""
 	for _, s := range stores {
 		resolved, resolveErr := s.ResolveSessionName(nameArg)
 		if resolveErr != nil {
@@ -233,12 +290,107 @@ func resolveSessionForAbort(projectRoot, nameArg string) (string, string, error)
 			return "", "", resolveErr
 		}
 		sessionPath := s.GetSessionPath(resolved)
-		if info, statErr := os.Stat(sessionPath); statErr == nil && info.IsDir() {
-			return resolved, sessionPath, nil
+		info, statErr := os.Stat(sessionPath)
+		if statErr != nil || !info.IsDir() {
+			continue
 		}
+		// Never hand a git-tracked ledger directory back as an os.RemoveAll
+		// target.
+		//
+		// The fail-safe direction is load-bearing: an UNREADABLE meta.json here
+		// must also be refused, not optimistically treated as not-a-draft.
+		// Returning it would have the caller delete a tracked directory from
+		// the worktree with no `git rm` — the next pull restores it, the real
+		// recording is never touched, and the user is told the session was
+		// discarded. For a privacy escape hatch, silently failing to delete is
+		// the catastrophic direction, so ambiguity resolves to "refuse".
+		if ledgerErr == nil && sessionPath == draftLedgerSessionDir(ledgerPath, resolved) {
+			meta, metaErr := lfs.ReadSessionMeta(sessionPath)
+			// A MISSING meta.json is not ambiguity — it is a legacy or
+			// partially-uploaded session with no placeholder, which has always
+			// been resolvable here. Only a meta.json that exists and cannot be
+			// parsed is ambiguous, and that is what must be refused.
+			if metaErr != nil && !errors.Is(metaErr, fs.ErrNotExist) {
+				continue
+			}
+			if meta.IsDraft() {
+				// Remember it: if nothing else matches, this session exists
+				// ONLY as a published placeholder and must still be abortable.
+				draftOnlyName = resolved
+				continue
+			}
+		}
+		return resolved, sessionPath, nil
+	}
+
+	// A session whose only remaining presence is a draft placeholder — local
+	// cache pruned, agent died, or an earlier abort removed local data but its
+	// git removal never landed. Without this branch the placeholder advertises
+	// the session forever with no CLI path to remove it.
+	if draftOnlyName != "" {
+		return draftOnlyName, "", errDraftOnlySession
 	}
 
 	return "", "", fmt.Errorf("session not found: %s\nRun 'ox session list' to see available sessions", nameArg)
+}
+
+// errDraftOnlySession signals that a name resolved to nothing but a published
+// draft placeholder in the ledger. A sentinel rather than a bool so the by-name
+// abort path can branch without repeating the lookup.
+var errDraftOnlySession = errors.New("session exists only as a published draft placeholder")
+
+// abortDraftOnlySession handles a session whose only remaining presence is a
+// published draft placeholder in the ledger.
+//
+// This is the recovery path for a placeholder that outlived its recording: the
+// local cache was pruned, the agent died, or a previous abort deleted local
+// data but its git removal never reached the remote. Without it, that
+// placeholder advertises an "in progress" session forever with no way to remove
+// it — and since the daemon's anti-entropy deliberately skips drafts, nothing
+// else will ever clean it up either.
+//
+// The ses_ id is read from the placeholder BEFORE removing it, so the server
+// notification can flip the right /c/ page to discarded.
+func abortDraftOnlySession(inst *agentinstance.Instance, cmd *cobra.Command, projectRoot, sessionName string) error {
+	if err := confirmAbort(inst, cmd); err != nil {
+		return err
+	}
+
+	abortedSessionID := ""
+	if ledgerPath, err := resolveLedgerPath(); err == nil {
+		if meta, metaErr := lfs.ReadSessionMeta(draftLedgerSessionDir(ledgerPath, sessionName)); metaErr == nil {
+			abortedSessionID = meta.EffectiveSessionID()
+		}
+	}
+
+	deleted, warning := removeLedgerDraftForAbort(sessionName)
+	notifySessionAbortedAsync(projectRoot, abortedSessionID)
+	return emitAbortOutput(cmd.OutOrStdout(), inst.AgentID, sessionName, deleted, warning)
+}
+
+// removeLedgerDraftForAbort git-removes a session's draft placeholder from the
+// ledger, if one was published. Returns a human-readable warning when the
+// removal landed locally but could not be pushed.
+//
+// Deliberately tolerant. Abort's contract to the user is "this session is
+// discarded", and the local recording data is what actually matters for that.
+// A ledger failure here is reported, never fatal: the local delete commit is
+// durable and the next push carries it, and notifySessionAbortedAsync
+// independently flips the /c/ page to discarded.
+func removeLedgerDraftForAbort(sessionName string) (bool, string) {
+	if sessionName == "" {
+		return false, ""
+	}
+	ledgerPath, err := resolveLedgerPath()
+	if err != nil {
+		return false, ""
+	}
+	res, err := deleteDraftFromLedger(ledgerPath, sessionName)
+	if err != nil {
+		slog.Warn("draft removal during abort failed", "session", sessionName, "error", err)
+		return false, fmt.Sprintf("could not remove the published draft placeholder from the ledger: %v", err)
+	}
+	return res.Deleted, res.PushWarning
 }
 
 // confirmAbort checks --force flag or prompts for interactive confirmation.
@@ -259,18 +411,38 @@ func confirmAbort(inst *agentinstance.Instance, cmd *cobra.Command) error {
 }
 
 // emitAbortOutput writes the JSON (and optional text) output for a successful abort.
-func emitAbortOutput(w io.Writer, agentID, sessionName string) error {
+func emitAbortOutput(w io.Writer, agentID, sessionName string, draftDeleted bool, warning string) error {
+	message := "session aborted and discarded"
+	guidance := "Session aborted and discarded. No further action needed. The recording no longer exists: do not add SageOx-Session trailers or session links referencing it to any future commits or PR bodies, and remove the line from any unsubmitted PR drafts. Continue with your current task."
+	if draftDeleted {
+		// Be accurate rather than reassuring. A published placeholder was
+		// committed and pushed to a SHARED repo, so its identity record — the
+		// session id, the agent, the timestamp — remains reachable in git
+		// history even after the deletion commit. Telling the user "the
+		// recording no longer exists" would be false about the part that is
+		// irreversible. No transcript content was ever committed.
+		message = "session aborted and discarded; published draft placeholder removed from the ledger"
+		// The anchor phrase "do not add SageOx-Session" is kept byte-identical
+		// (including case) with the non-draft wording: agents match on it, and
+		// a capitalized variant is a different string to a substring match.
+		guidance = "Session aborted and discarded, and its published placeholder was removed from the ledger. No conversation content was ever published — a placeholder carries only the session id, agent, and timestamps — but that identity record remains in the ledger's git history. As with any aborted session: do not add SageOx-Session trailers or session links referencing it to any future commits or PR bodies, and remove the line from any unsubmitted PR drafts. Continue with your current task."
+	}
 	output := sessionAbortOutput{
-		Success:     true,
-		Type:        "session_abort",
-		AgentID:     agentID,
-		SessionName: sessionName,
-		Message:     "session aborted and discarded",
-		Guidance:    "Session aborted and discarded. No further action needed. The recording no longer exists: do not add SageOx-Session trailers or session links referencing it to any future commits or PR bodies, and remove the line from any unsubmitted PR drafts. Continue with your current task.",
+		Success:            true,
+		Type:               "session_abort",
+		AgentID:            agentID,
+		SessionName:        sessionName,
+		Message:            message,
+		Guidance:           guidance,
+		LedgerDraftDeleted: draftDeleted,
+		Warning:            warning,
 	}
 
 	if cfg.Text || cfg.Review {
 		fmt.Fprintf(w, "Session %q aborted and discarded.\n", sessionName)
+		if warning != "" {
+			fmt.Fprintf(w, "Warning: %s\n", warning)
+		}
 		if cfg.Review {
 			fmt.Fprintln(w)
 			fmt.Fprintln(w, "--- Machine Output ---")

--- a/cmd/ox/agent_session_delete.go
+++ b/cmd/ox/agent_session_delete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
+	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 	"github.com/spf13/cobra"
 )
@@ -71,6 +72,15 @@ func runAgentSessionDelete(inst *agentinstance.Instance, cmd *cobra.Command, arg
 		ledgerSessionDir = filepath.Join(ledgerPath, "sessions", sessionName)
 		if info, statErr := os.Stat(ledgerSessionDir); statErr == nil && info.IsDir() {
 			ledgerExists = true
+			// A draft placeholder in the ledger means the recording is very
+			// likely still LIVE (ADR-029). `session delete` is for removing a
+			// finished, uploaded session; deleting a live one here would take
+			// out the running recording's local copy too. Refuse and point at
+			// abort, which is the command that handles a live session and
+			// removes the placeholder as part of discarding it.
+			if meta, metaErr := lfs.ReadSessionMeta(ledgerSessionDir); metaErr == nil && meta.IsDraft() {
+				return fmt.Errorf("session %q is still recording (only a draft placeholder is published)\nUse 'ox agent %s session abort %s --force' to discard it", sessionName, inst.AgentID, sessionName)
+			}
 		}
 	}
 

--- a/cmd/ox/agent_session_recover.go
+++ b/cmd/ox/agent_session_recover.go
@@ -211,7 +211,12 @@ func recoverFromCache(inst *agentinstance.Instance, projectRoot string, state *s
 				// publish stamped one and crashed mid-push), reuse that
 				// SessionID rather than minting a fresh one. Non-NotExist
 				// read errors are fatal — see PreservedSessionID doc.
-				preservedID, preserveErr := lfs.PreservedSessionID(ledgerSessionDir)
+				// Also supersedes a draft placeholder if one was published
+				// for this session before the agent died: the recovered
+				// upload is authoritative, and a surviving draft-era artifact
+				// (e.g. a server-authored summary of the zero-turn draft)
+				// must not ride along. Reads the id before purging.
+				preservedID, _, preserveErr := supersedeDraftForFinalize(ledgerPath, sessionName)
 				if preserveErr != nil {
 					slog.Warn("read existing meta.json failed during recovery; skipping write to avoid SessionID rotation", "error", preserveErr)
 					_ = doctor.SetNeedsDoctorAgent(projectRoot)

--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -174,6 +174,30 @@ Override per-invocation with --html, --text, or --json flags.`,
 		Levels:      []ConfigLevel{ConfigLevelUser},
 	},
 	{
+		Key:         "session.draft",
+		Category:    "Sessions",
+		Description: "Publish an early placeholder so /c/<id> resolves mid-session (on/off)",
+		LongDescription: `Controls whether ox commits an early placeholder for a recording.
+
+  on  — At turn 2, ox commits a metadata-only placeholder to the ledger so
+        https://<endpoint>/c/<session_id> resolves while the session is still
+        running. Agents put that link in PR bodies during a session; without
+        the placeholder it stays a dead link until session stop, which makes a
+        working setup look broken. The placeholder carries NO conversation
+        data — only the session id, the agent, and a turn counter — and is
+        replaced wholesale by the real recording at session stop.
+        **Default.**
+
+  off — Never publish a placeholder. The /c/ link stays unresolvable until
+        session stop.
+
+Aborting a session (/ox-session-abort) deletes any published placeholder from
+the ledger.`,
+		ValidValues: config.ValidSessionDraftModes,
+		Default:     config.SessionDraftOn,
+		Levels:      []ConfigLevel{ConfigLevelUser},
+	},
+	{
 		Key:         "agent.summarizer",
 		Description: "Who runs the session-stop summarization (inline/delegated)",
 		LongDescription: `Selects who runs the LLM call that summarizes a session at stop.
@@ -544,6 +568,11 @@ func ResolveConfigValue(key string, projectRoot string) (*ConfigValue, error) {
 			cv.UserVal = config.NormalizeAgentSummarizer(userCfg.AgentSummarizer)
 		}
 
+	case "session.draft":
+		if userCfg != nil && userCfg.SessionDraft != "" {
+			cv.UserVal = config.NormalizeSessionDraft(userCfg.SessionDraft)
+		}
+
 	case "attribution.commit":
 		if userCfg != nil && userCfg.Attribution != nil && userCfg.Attribution.IsCommitSet() {
 			if v := userCfg.Attribution.GetCommit(); v == "" {
@@ -781,6 +810,12 @@ func setUserConfig(key, value string) error {
 		}
 		cfg.AgentSummarizer = value
 
+	case "session.draft":
+		if !config.IsValidSessionDraft(value) {
+			return fmt.Errorf("session.draft must be one of: on, off")
+		}
+		cfg.SessionDraft = value
+
 	case "attribution.commit":
 		if cfg.Attribution == nil {
 			cfg.Attribution = &config.Attribution{}
@@ -1007,6 +1042,9 @@ func unsetUserConfig(key string) error {
 
 	case "agent.summarizer":
 		cfg.AgentSummarizer = ""
+
+	case "session.draft":
+		cfg.SessionDraft = ""
 
 	case "attribution.commit":
 		if cfg.Attribution != nil {

--- a/cmd/ox/doctor_session_draft.go
+++ b/cmd/ox/doctor_session_draft.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+)
+
+func init() {
+	RegisterDoctorCheck(&DoctorCheck{
+		Slug:        CheckSlugSessionDraftOrphan,
+		Name:        "orphaned session drafts",
+		Category:    "Sessions",
+		FixLevel:    FixLevelSuggested,
+		Description: "Finds draft placeholders whose recording no longer exists",
+		Run:         checkSessionDraftOrphan,
+	})
+}
+
+// orphanedDraftAge is how long a draft must have gone without a refresh before
+// it is considered abandoned.
+//
+// Comfortably longer than the refresh cadence (10 turns) takes in practice, so
+// a slow but live session — a user thinking, or an agent on a long tool call —
+// is never mistaken for a dead one. The cost of waiting is a stale "in
+// progress" page; the cost of being wrong is deleting a live session's
+// placeholder, so the asymmetry says wait.
+const orphanedDraftAge = 24 * time.Hour
+
+// checkSessionDraftOrphan finds draft placeholders in the ledger whose
+// recording no longer exists anywhere.
+//
+// # Why this has to exist
+//
+// A draft is deliberately invisible to every other reclaimer, and that is what
+// leaves it stranded. The daemon's anti-entropy skips drafts by design.
+// `ox session prune` only touches local caches and no longer counts a draft as
+// uploaded. `commitDraftRetraction` runs only from a clean session stop, and
+// `deleteDraftFromLedger` only from an explicit abort — neither of which a
+// crashed agent ever reaches.
+//
+// So every session that dies after turn 2 (reboot, closed laptop, killed
+// container, a quality-discard finalize) leaves a placeholder that advertises
+// an in-progress session forever: the /c/ page never resolves to real content,
+// `ox session list` accumulates phantom draft rows, and nothing ever cleans it
+// up. Without this check the ledger grows ghosts monotonically.
+//
+// Suggested rather than Auto because the fix produces a ledger commit and a
+// push, and nobody expects a bare `ox doctor` to push on their behalf. Same
+// reasoning as the session-ID backfill check.
+func checkSessionDraftOrphan(fix bool) checkResult {
+	const name = "orphaned session drafts"
+
+	gitRoot := findGitRoot()
+	if gitRoot == "" {
+		return SkippedCheck(name, "no git root", "")
+	}
+	if !config.IsInitialized(gitRoot) {
+		return SkippedCheck(name, "not initialized", "")
+	}
+	ledgerPath := getLedgerPath()
+	if ledgerPath == "" {
+		return SkippedCheck(name, "no ledger", "")
+	}
+
+	orphans, err := findOrphanedDrafts(gitRoot, ledgerPath)
+	if err != nil {
+		return SkippedCheck(name, "scan error", err.Error())
+	}
+	if len(orphans) == 0 {
+		return PassedCheck(name, "no orphaned drafts")
+	}
+
+	if !fix {
+		return WarningCheck(name,
+			fmt.Sprintf("%d draft placeholder(s) with no recording", len(orphans)),
+			fmt.Sprintf("run 'ox doctor --fix' to retract them (oldest: %s)", orphans[0]))
+	}
+
+	var removed, failed int
+	for _, sessionName := range orphans {
+		res, err := deleteDraftFromLedger(ledgerPath, sessionName)
+		if err != nil {
+			slog.Warn("retract orphaned draft failed", "session", sessionName, "error", err)
+			failed++
+			continue
+		}
+		if res.PushWarning != "" {
+			slog.Warn("retract orphaned draft: push pending", "session", sessionName, "warning", res.PushWarning)
+		}
+		if res.Deleted {
+			removed++
+		}
+	}
+
+	if failed > 0 {
+		return WarningCheck(name,
+			fmt.Sprintf("retracted %d, %d failed", removed, failed),
+			"run 'ox doctor --fix' again to retry")
+	}
+	return PassedCheck(name, fmt.Sprintf("retracted %d orphaned draft(s)", removed))
+}
+
+// findOrphanedDrafts returns the names of ledger drafts that have no live or
+// recoverable recording behind them, oldest first.
+//
+// Three conditions must ALL hold, and each one is deliberately conservative —
+// a false positive here deletes a live session's placeholder:
+//
+//  1. The ledger directory is a draft (never a finalized session).
+//  2. Its updated_at is older than orphanedDraftAge. This is the whole reason
+//     drafts refresh their counters: without a heartbeat there is no way to
+//     tell a live session from a dead one.
+//  3. No recording state exists for it in any cache location, and no cached
+//     transcript is waiting to be uploaded. If either exists, the session is
+//     alive or recoverable and the upload-retry check owns it, not this one.
+func findOrphanedDrafts(projectRoot, ledgerPath string) ([]string, error) {
+	sessionsDir := filepath.Join(ledgerPath, "sessions")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read ledger sessions: %w", err)
+	}
+
+	cacheDirs := []string{filepath.Join(ledgerPath, ".sageox", "cache", "sessions")}
+	if contextPath := session.GetContextPath(getRepoIDOrDefault(projectRoot)); contextPath != "" {
+		cacheDirs = append(cacheDirs, filepath.Join(contextPath, "sessions"))
+	}
+
+	type candidate struct {
+		name      string
+		updatedAt time.Time
+	}
+	var found []candidate
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		meta, metaErr := lfs.ReadSessionMeta(filepath.Join(sessionsDir, name))
+		// Fail safe: an unreadable meta.json is not a draft we are willing to
+		// delete. Some other check owns diagnosing it.
+		if metaErr != nil || !meta.IsDraft() {
+			continue
+		}
+		// No updated_at means we cannot age it. Refuse rather than guess —
+		// deleting a placeholder for a session that might be live is worse
+		// than leaving a stale page.
+		if meta.UpdatedAt == nil || time.Since(*meta.UpdatedAt) < orphanedDraftAge {
+			continue
+		}
+		if hasLocalSessionData(cacheDirs, name) {
+			continue
+		}
+		found = append(found, candidate{name: name, updatedAt: *meta.UpdatedAt})
+	}
+
+	sort.Slice(found, func(i, j int) bool { return found[i].updatedAt.Before(found[j].updatedAt) })
+	names := make([]string, 0, len(found))
+	for _, c := range found {
+		names = append(names, c.name)
+	}
+	return names, nil
+}
+
+// hasLocalSessionData reports whether any cache location still holds this
+// session, either as an active recording or as a transcript awaiting upload.
+func hasLocalSessionData(cacheDirs []string, sessionName string) bool {
+	for _, dir := range cacheDirs {
+		sessionDir := filepath.Join(dir, sessionName)
+		for _, marker := range []string{".recording.json", "raw.jsonl"} {
+			if _, err := os.Stat(filepath.Join(sessionDir, marker)); err == nil {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cmd/ox/doctor_session_upload_retry.go
+++ b/cmd/ox/doctor_session_upload_retry.go
@@ -167,10 +167,26 @@ func findOrphanedSessions(projectRoot, ledgerPath string) ([]orphanedSession, er
 			continue
 		}
 
-		// skip if already uploaded (meta.json exists in ledger)
+		// skip if already uploaded (meta.json exists in ledger).
+		//
+		// A DRAFT placeholder does not count as uploaded. It is a
+		// meta.json-only marker published mid-recording (ADR-029) and carries
+		// no turn data, so treating it as "already uploaded" would make this
+		// orphan sweep skip the session permanently — and this check runs at
+		// FixLevelAuto, so a session whose upload failed after a draft was
+		// published would silently never be retried and its only copy would
+		// rot in the cache until pruned.
+		//
+		// Fail-safe direction: an UNREADABLE ledger meta.json is treated as
+		// "uploaded" (skip), matching the pre-draft behavior. Retrying an
+		// upload we cannot classify risks clobbering a finalized session;
+		// skipping it only defers recovery to a human running `ox doctor`.
 		ledgerSessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
 		if _, err := os.Stat(filepath.Join(ledgerSessionDir, "meta.json")); err == nil {
-			continue
+			ledgerMeta, metaErr := lfs.ReadSessionMeta(ledgerSessionDir)
+			if metaErr != nil || !ledgerMeta.IsDraft() {
+				continue
+			}
 		}
 
 		// parse header metadata
@@ -269,10 +285,23 @@ func readCacheSessionMeta(rawPath string) (*session.StoreMeta, int, error) {
 // two meta.json states for the same session.
 //
 // Non-NotExist meta.json read errors are fatal — see PreservedSessionID doc.
-func resolveOrphanSessionID(sessionDir string, orphan orphanedSession) (string, error) {
+func resolveOrphanSessionID(sessionDir string, orphan orphanedSession, draftPreservedID string) (string, error) {
 	preservedID, err := lfs.PreservedSessionID(sessionDir)
 	if err != nil {
 		return "", fmt.Errorf("preserve existing SessionID: %w", err)
+	}
+	// A draft placeholder that was just purged held the id; the file it lived in
+	// is gone by now, so the caller had to read it beforehand and hand it in.
+	//
+	// It slots in at PRESERVED precedence, not below the raw-header carrier, and
+	// that ordering is deliberate: ResolveSessionID's contract is
+	// preserved-beats-start-minted because preserved means "already written to
+	// meta.json", and a draft's meta.json has additionally been PUSHED — it is
+	// the id teammates' /c/ links and any commit trailers already reference.
+	// The header id is start-minted. On the rare occasion they disagree, the
+	// published one is the one that must survive.
+	if preservedID == "" {
+		preservedID = draftPreservedID
 	}
 	headerID := ""
 	if orphan.Meta != nil {
@@ -296,14 +325,27 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 	sessionsDir := filepath.Join(ledgerPath, "sessions")
 	sessionDir := filepath.Join(sessionsDir, orphan.SessionName)
 
-	if err := os.MkdirAll(sessionDir, 0755); err != nil {
-		return fmt.Errorf("create session dir: %w", err)
-	}
-
-	// validate raw.jsonl integrity before uploading — skip corrupted files
+	// Validate BEFORE mutating the ledger. Purging first and then bailing on a
+	// corrupt raw.jsonl would leave a staged deletion in the shared index that
+	// nothing commits — and the next unrelated bare `git commit` sweeps it up
+	// under the wrong message.
 	rawSrc := filepath.Join(orphan.CachePath, ledgerFileRaw)
 	if err := validateRawJSONLHeader(rawSrc); err != nil {
 		return fmt.Errorf("%s validation failed (skipping corrupt session): %w", ledgerFileRaw, err)
+	}
+
+	// Supersede a draft placeholder if one was published before the agent died,
+	// capturing its ses_ id first — the draft meta.json is a durable carrier of
+	// that id, and for a recording whose raw.jsonl header predates the SessionID
+	// field it is the ONLY carrier. Losing it here mints a fresh id and 404s a
+	// /c/ link already published in a PR body.
+	draftPreservedID, _, err := supersedeDraftForFinalize(ledgerPath, orphan.SessionName)
+	if err != nil {
+		return fmt.Errorf("classify existing ledger meta for %s: %w", orphan.SessionName, err)
+	}
+
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		return fmt.Errorf("create session dir: %w", err)
 	}
 
 	// raw.jsonl is the critical source of truth — copy it first and fail fast if missing.
@@ -330,7 +372,7 @@ func retrySessionUpload(projectRoot, ledgerPath string, orphan orphanedSession) 
 	// durable ID via the shared resolver, resolved before the network round
 	// trip so a corrupt pre-existing meta.json aborts fast rather than after
 	// a wasted LFS upload. See resolveOrphanSessionID doc.
-	sessionID, err := resolveOrphanSessionID(sessionDir, orphan)
+	sessionID, err := resolveOrphanSessionID(sessionDir, orphan, draftPreservedID)
 	if err != nil {
 		return err
 	}

--- a/cmd/ox/doctor_session_upload_retry_test.go
+++ b/cmd/ox/doctor_session_upload_retry_test.go
@@ -813,7 +813,7 @@ func TestResolveOrphanSessionID_HeaderIDPreservedWhenNoLedgerMetaYet(t *testing.
 		Meta:        &session.StoreMeta{AgentID: "OxF9dp", SessionID: headerID},
 	}
 
-	got, err := resolveOrphanSessionID(sessionDir, orphan)
+	got, err := resolveOrphanSessionID(sessionDir, orphan, "")
 	require.NoError(t, err)
 	assert.Equal(t, headerID, got, "must preserve the header-carried SessionID, not mint a new one")
 }
@@ -837,7 +837,7 @@ func TestResolveOrphanSessionID_PreservedMetaWinsOverHeader(t *testing.T) {
 		Meta:        &session.StoreMeta{AgentID: "OxF9dp", SessionID: "ses_019f633e-29f3-7566-9ab4-a3da5b666fe5"},
 	}
 
-	got, err := resolveOrphanSessionID(sessionDir, orphan)
+	got, err := resolveOrphanSessionID(sessionDir, orphan, "")
 	require.NoError(t, err)
 	assert.Equal(t, preservedID, got, "preserved meta.json ID must win over the header-carried ID")
 }
@@ -856,7 +856,7 @@ func TestResolveOrphanSessionID_CorruptMetaRefusesToMint(t *testing.T) {
 		Meta:        &session.StoreMeta{AgentID: "OxBAD1", SessionID: "ses_019f633e-29f3-7566-9ab4-a3da5b666fe5"},
 	}
 
-	got, err := resolveOrphanSessionID(sessionDir, orphan)
+	got, err := resolveOrphanSessionID(sessionDir, orphan, "")
 	require.Error(t, err, "corrupt meta.json must refuse to resolve, not mint a fresh ID")
 	assert.Empty(t, got)
 }
@@ -872,7 +872,7 @@ func TestResolveOrphanSessionID_NoIDAnywhereMintsExactlyOne(t *testing.T) {
 		Meta:        &session.StoreMeta{AgentID: "OxLEG1"}, // no SessionID
 	}
 
-	got, err := resolveOrphanSessionID(sessionDir, orphan)
+	got, err := resolveOrphanSessionID(sessionDir, orphan, "")
 	require.NoError(t, err)
 	assert.True(t, sessionid.IsValidSessionID(got), "must mint a valid ses_<UUIDv7> when no ID exists anywhere, got %q", got)
 }
@@ -892,7 +892,7 @@ func TestResolveOrphanSessionID_RegisteredTwiceYieldsOneID(t *testing.T) {
 	// first registration: nothing anywhere yet — mints ID_A and (as
 	// retrySessionUpload does in production) writes it to meta.json before
 	// attempting the push.
-	first, err := resolveOrphanSessionID(sessionDir, orphan)
+	first, err := resolveOrphanSessionID(sessionDir, orphan, "")
 	require.NoError(t, err)
 	require.True(t, sessionid.IsValidSessionID(first))
 	require.NoError(t, lfs.WriteSessionMeta(sessionDir, &lfs.SessionMeta{
@@ -905,7 +905,7 @@ func TestResolveOrphanSessionID_RegisteredTwiceYieldsOneID(t *testing.T) {
 	// second registration: same session, same cache content, retried again
 	// (push failed the first time). Must return the SAME id, not mint a
 	// second one.
-	second, err := resolveOrphanSessionID(sessionDir, orphan)
+	second, err := resolveOrphanSessionID(sessionDir, orphan, "")
 	require.NoError(t, err)
 	assert.Equal(t, first, second, "retrying the same session must yield one durable session_id, not two")
 }

--- a/cmd/ox/doctor_types.go
+++ b/cmd/ox/doctor_types.go
@@ -170,6 +170,8 @@ const (
 	CheckSlugSessionIncomplete  = "session-incomplete"
 	CheckSlugSessionAutoStage   = "session-auto-stage"
 	CheckSlugSessionUploadRetry = "session-upload-retry"
+	// CheckSlugSessionDraftOrphan finds draft placeholders whose recording is gone.
+	CheckSlugSessionDraftOrphan = "session-draft-orphan"
 	CheckSlugSessionUncommitted = "session-uncommitted"
 	CheckSlugSessionOrphaned    = "session-orphaned"
 	CheckSlugSessionManifest    = "session-manifest"

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Your session link works while the session is still running** — an AI coworker puts `SageOx-Session: https://<endpoint>/c/<id>` in the pull request it opens, but until now that link pointed at nothing until the session ended. A correctly wired setup was indistinguishable from a broken one, at exactly the moment you were most likely to check. ox now publishes a placeholder for the session a couple of turns in, so the link resolves right away and shows the session in progress. The placeholder carries **no conversation content whatsoever** — only the session id, which agent is running, and a turn counter that ticks up so you can see recording is alive. It is replaced by the real recording when the session ends. `ox session status` gained `draft_state` and the conversation URL, so if a link ever doesn't resolve you can tell whether the placeholder published or failed instead of guessing. Turn it off with `ox config set session.draft off`.
+
+- **Aborting a session now removes its published placeholder too** — `/ox-session-abort` previously only discarded local data. It now also removes the placeholder from the Ledger, so the session stops being advertised to teammates, and it tells you plainly what remains: no conversation content was ever published, but the placeholder's identity record stays in git history like any other commit. A session that exists *only* as a stranded placeholder — because the agent crashed, or an earlier abort couldn't reach the remote — is now abortable too, and `ox doctor` finds and retracts placeholders whose recording is long gone.
+
 - **`ox invite` brings teammates aboard without leaving the terminal** — `ox invite alice@acme.com,bob@acme.com` invites several people at once, defaults to this repo's team, and takes `--team` and `--role`. Each address gets its own line in the result, so one typo never hides everyone else's outcome.
 
 - **See and cancel invitations you've already sent** — `ox invite --list` shows who's still outstanding and when each invitation runs out, and `ox invite --cancel <invite id>` withdraws one.

--- a/cmd/ox/session_draft.go
+++ b/cmd/ox/session_draft.go
@@ -1,0 +1,563 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/lfs"
+)
+
+// Draft session placeholders. See docs/adr/ADR-029-session-draft-placeholder.md.
+//
+// A draft is a meta.json-only directory committed to <ledger>/sessions/<name>/
+// partway through a recording, so https://<endpoint>/c/<session_id> resolves
+// for links already circulating in PR bodies and commit trailers. It carries no
+// turn data and is superseded wholesale at session stop.
+//
+// The "meta.json and nothing else" shape is forced, not chosen. Real transcript
+// bytes on the git-tracked raw.jsonl break LFS linkage — the ledger then rejects
+// every subsequent push for the whole team with "LFS objects are missing" — and
+// defeat the daemon's pointer-stub skip, so anti-entropy starts re-finalizing
+// live sessions. See .claude/rules/cache-only-design.md.
+
+// draftAction is what the turn counter says to do at a given turn.
+type draftAction int
+
+const (
+	draftActionNone draftAction = iota
+	draftActionPublish
+	draftActionRefresh
+)
+
+// draftDecision is the pure scheduling rule for draft publish/refresh.
+//
+// Extracted from the hook deliberately. The scheduling arithmetic is where the
+// off-by-one bugs live (publish twice, refresh on the publish turn, refresh
+// anchored to absolute turn instead of to the publish turn), and none of them
+// need git, a ledger, or a daemon to exercise. Keeping this pure is what makes
+// the property test a fast in-memory loop instead of a real-git soak nobody
+// runs.
+//
+// turnCount is the turn that just completed (1-based). publishedTurn is
+// RecordingState.DraftPublishedTurn (0 = never attempted) and published reports
+// whether any attempt has actually SUCCEEDED (DraftPublishedAt != nil).
+//
+// The two are distinct on purpose, and conflating them was a real bug:
+//
+//   - Before the first success, retry every turn. A transient failure — an
+//     index.lock collision, which is routine when several agents share one
+//     ledger clone — otherwise backs the session off by a full refresh
+//     interval, so any session shorter than publishTurn+refreshEvery silently
+//     never publishes at all. That is a large fraction of sessions, and it is
+//     the one publish that matters.
+//   - After the first success, back off to the refresh cadence. There the
+//     stamp-on-attempt behavior is exactly right: a persistently broken ledger
+//     retries once per interval instead of hammering git every turn.
+//
+// The refresh cadence is measured from publishedTurn, not from the absolute
+// turn number, so a session whose first publish was delayed still refreshes a
+// full interval later rather than almost immediately.
+func draftDecision(turnCount, publishedTurn int, published bool, resolved *config.ResolvedSessionDraft) draftAction {
+	if resolved == nil || !resolved.Enabled {
+		return draftActionNone
+	}
+	if turnCount < resolved.PublishTurn {
+		return draftActionNone
+	}
+	if !published {
+		return draftActionPublish
+	}
+	// A refresh interval of 0 disables refreshing outright; guard before the
+	// modulo so a misconfigured value cannot divide by zero.
+	if resolved.RefreshEvery <= 0 {
+		return draftActionNone
+	}
+	elapsed := turnCount - publishedTurn
+	if elapsed > 0 && elapsed%resolved.RefreshEvery == 0 {
+		return draftActionRefresh
+	}
+	return draftActionNone
+}
+
+// errDraftUnsafeLedger is returned when the ledger clone is mid-rebase or
+// otherwise not safe for an index mutation. Always non-fatal to the caller:
+// drafts are best-effort and the next turn retries.
+var errDraftUnsafeLedger = errors.New("ledger is not in a safe state for a draft write")
+
+// validateDraftSessionName rejects names that would widen a pathspec beyond one
+// session directory.
+//
+// This is not theoretical hardening. draftSessionRelDir("") is "sessions", and
+// filepath.Base("") is "." which produces the same thing — so an empty or
+// traversal-shaped name turns purgeDraftSessionDir and deleteDraftFromLedger
+// into `git rm -r --force -- sessions` plus os.RemoveAll of the entire sessions
+// tree. Today that is unreachable only because those paths first require a
+// draft meta.json to exist at that location, which is an incidental guard, not
+// an intentional one. Make it intentional.
+func validateDraftSessionName(sessionName string) error {
+	if sessionName == "" || sessionName == "." || sessionName == ".." {
+		return fmt.Errorf("invalid session name %q", sessionName)
+	}
+	if strings.ContainsAny(sessionName, `/\`) || strings.Contains(sessionName, "..") {
+		return fmt.Errorf("session name %q must be a single path component", sessionName)
+	}
+	return nil
+}
+
+// assertLedgerSafeForDraftWrite refuses to touch the ledger index when the
+// clone is mid-rebase.
+//
+// THIS IS THE LOAD-BEARING GUARD OF THE WHOLE FEATURE, and its absence was a
+// team-wide data-destruction bug. Every other ledger index writer in the CLI is
+// followed by pushLedger → gitutil.PushWithRetry → IsSafeForGitOps, so the
+// rebase check rides along for free. Draft writes deliberately do NOT push
+// (that is the point — no push latency on a turn boundary), so they fall
+// straight through that guard.
+//
+// What happens without it: the daemon's `git pull --rebase` conflicts on
+// sessions/<name>/meta.json — the documented steady state for this repo. The
+// rebase stops mid-replay of some local commit, leaving conflict markers in the
+// worktree. A Stop hook fires, WriteDraftSessionMeta atomically overwrites the
+// conflicted file (markers gone), `git add` MARKS THAT CONFLICT RESOLVED, and
+// `git commit -- <pathspec>` SUCCEEDS on the detached rebase HEAD — consuming
+// the replay step. The next `rebase --continue` reports success, and the commit
+// being replayed is silently gone. It can be any commit: a teammate's session
+// finalize, a murmur, a plan, imported team data.
+//
+// The guard belongs at index-mutation time, not at push time. That layering
+// mistake is what let this through.
+func assertLedgerSafeForDraftWrite(ledgerPath string) error {
+	if gitutil.IsRebaseInProgress(ledgerPath) {
+		return fmt.Errorf("%w: rebase in progress", errDraftUnsafeLedger)
+	}
+	if err := gitutil.IsSafeForGitOps(ledgerPath); err != nil {
+		return fmt.Errorf("%w: %w", errDraftUnsafeLedger, err)
+	}
+	return nil
+}
+
+// draftSessionRelDir returns the ledger-relative directory for a session.
+func draftSessionRelDir(sessionName string) string {
+	return filepath.ToSlash(filepath.Join("sessions", sessionName))
+}
+
+// draftLedgerSessionDir returns the absolute git-tracked session directory.
+func draftLedgerSessionDir(ledgerPath, sessionName string) string {
+	return filepath.Join(ledgerPath, "sessions", sessionName)
+}
+
+// hasStagedChangesFor reports whether anything is staged for the given
+// ledger-relative pathspecs.
+//
+// Used to decide "is there anything to commit" by EXIT CODE rather than by
+// grepping git's stdout. Matching on output text is wrong in two ways that both
+// bit us: git has at least two distinct empty-commit messages ("nothing to
+// commit" and "nothing added to commit but untracked files present ..."), and
+// neither is stable across locales — nothing in the CLI pins LC_ALL for these
+// invocations. Missing the second phrasing turned every idempotent draft
+// refresh into a hard error, which in turn made the recording report its draft
+// as permanently failed and retry on every interval.
+//
+// `git diff --cached --quiet` exits 0 when there is no staged diff and 1 when
+// there is; any other exit is a real error, and we conservatively report "yes,
+// there are changes" so the caller attempts the commit and surfaces git's own
+// message rather than silently skipping.
+func hasStagedChangesFor(ledgerPath string, paths []string) bool {
+	args := append([]string{"-C", ledgerPath, "diff", "--cached", "--quiet", "--"}, paths...)
+	err := exec.Command("git", args...).Run()
+	if err == nil {
+		return false // clean: nothing staged for these paths
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return true // the documented "differences found" code
+	}
+	return true // unknown failure — let the commit run and report properly
+}
+
+// draftStagePaths returns the ONLY ledger-relative paths a draft commit may
+// ever stage.
+//
+// Deliberately hard-coded, and deliberately NOT sessionArtifactsToStage. That
+// helper falls back to globbing *.jsonl / *.html / *.md whenever meta.Files is
+// empty — which is a draft's normal, correct state — and would sweep in any
+// real raw.jsonl or server-authored summary.md sitting in the directory. That
+// is precisely the 2026-04-25 LFS-linkage break, and a draft directory is the
+// one place in the ledger where a stray content file is plausible.
+func draftStagePaths(sessionName string) []string {
+	return []string{
+		filepath.ToSlash(filepath.Join("sessions", sessionName, "meta.json")),
+		filepath.ToSlash(filepath.Join("sessions", ".gitignore")),
+	}
+}
+
+// commitDraftLocally stages and commits the draft placeholder in the local
+// ledger clone. It deliberately does NOT push.
+//
+// pushLedger is a pre-push secret scan plus a credential refresh plus an LFS
+// reconcile plus a three-attempt pull-rebase loop — seconds of latency, which
+// is unacceptable on a turn boundary. The commit is durable locally and the
+// next pushLedger from any path carries it: session stop, plan commit, the
+// daemon's push cycle, or `ox doctor --fix` on an ahead branch.
+//
+// The trailing `-- <pathspec>` on the commit is load-bearing, not style. A bare
+// `git commit` writes the WHOLE index, so a file another session left staged
+// after a failed finalize would ride along under this draft's message. Drafts
+// fire every N turns from every agent sharing the ledger clone, so the
+// co-staging window that is theoretical for session-stop is routine here.
+func commitDraftLocally(ledgerPath, sessionName string) error {
+	if err := prepareDraftLedgerWrite(ledgerPath, sessionName); err != nil {
+		return err
+	}
+	gitserver.EnsureGitignoreBeforeCommit(ledgerPath)
+
+	if err := lfs.EnsureSessionsGitignore(filepath.Join(ledgerPath, "sessions")); err != nil {
+		slog.Debug("draft: ensure sessions gitignore", "error", err)
+	}
+
+	paths := draftStagePaths(sessionName)
+
+	// --sparse: ledger repos use cone-mode sparse-checkout, and git 2.37+
+	// refuses to stage paths outside the sparse definition without it.
+	addArgs := append([]string{"-C", ledgerPath, "add", "--sparse", "--"}, paths...)
+	if out, err := exec.Command("git", addArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("git add draft: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	// Idempotent: a refresh whose counters did not change stages nothing, and
+	// must not be an error — the caller treats an error as "publish failed"
+	// and would report the draft as permanently broken.
+	if !hasStagedChangesFor(ledgerPath, paths) {
+		return nil
+	}
+
+	// `git commit -- <pathspec>` commits the WORKING TREE at those paths, NOT
+	// the index we just built. That is a genuine footgun, not pedantry: a
+	// concurrent finalize rewrites this exact meta.json, so without this check
+	// the finalize's bytes — LFS OIDs and all — get committed under a
+	// "session-draft:" subject. The daemon's push filter matches on that
+	// subject and would then push a finalize-shaped commit with neither the
+	// LFS reconcile nor the pre-push secret gate that the CLI's own push path
+	// applies.
+	//
+	// Verify the worktree still matches what we staged, and that it is still a
+	// draft, immediately before committing.
+	if err := assertDraftStillStaged(ledgerPath, sessionName, paths); err != nil {
+		return err
+	}
+
+	commitArgs := append([]string{
+		"-C", ledgerPath, "commit", "--no-verify",
+		"-m", fmt.Sprintf("session-draft: %s", sessionName),
+		"--",
+	}, paths...)
+	if out, err := exec.Command("git", commitArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("git commit draft: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// assertDraftStillStaged verifies, immediately before a partial commit, that
+// the worktree content at paths is identical to what was staged and that the
+// session directory is still a draft.
+//
+// Closes the window described on commitDraftLocally: `git commit -- <pathspec>`
+// reads the worktree, so anything that rewrote these paths between `git add`
+// and `git commit` gets committed under our message instead of ours.
+func assertDraftStillStaged(ledgerPath, sessionName string, paths []string) error {
+	args := append([]string{"-C", ledgerPath, "diff", "--quiet", "--"}, paths...)
+	if err := exec.Command("git", args...).Run(); err != nil {
+		return fmt.Errorf("draft %s: worktree changed between stage and commit; another writer owns this path", sessionName)
+	}
+	meta, err := lfs.ReadSessionMeta(draftLedgerSessionDir(ledgerPath, sessionName))
+	if err != nil {
+		return fmt.Errorf("draft %s: meta unreadable before commit: %w", sessionName, err)
+	}
+	if !meta.IsDraft() {
+		return fmt.Errorf("draft %s: no longer a draft (a finalize landed); refusing to commit it under a draft subject", sessionName)
+	}
+	return nil
+}
+
+// prepareDraftLedgerWrite is the single gate every draft ledger-index mutation
+// must pass. It validates the target, waits out a blue-green GC swap, and
+// refuses when the clone is mid-rebase.
+//
+// One gate rather than four copies because the reviewers found each guard
+// missing from a different subset of the four write paths — which is what
+// happens when a safety check is a convention rather than a chokepoint.
+func prepareDraftLedgerWrite(ledgerPath, sessionName string) error {
+	if err := validateDraftSessionName(sessionName); err != nil {
+		return err
+	}
+	if err := validateDraftLedgerPath(ledgerPath); err != nil {
+		return err
+	}
+	// The daemon's blue-green GC can rename-swap the clone out from under us.
+	waitForGCSwap(ledgerPath)
+	return assertLedgerSafeForDraftWrite(ledgerPath)
+}
+
+// validateDraftLedgerPath refuses to run git writes against anything that is
+// not a git repository.
+//
+// This is the structural half of the guard. The IDENTITY half — "is this
+// actually THIS project's ledger?" — lives in the publisher
+// (resolveDraftLedgerPath), because only the caller knows the project root and
+// answering it here would make every draft git helper depend on the process
+// CWD.
+func validateDraftLedgerPath(ledgerPath string) error {
+	if ledgerPath == "" {
+		return fmt.Errorf("empty ledger path")
+	}
+	if _, err := os.Stat(filepath.Join(ledgerPath, ".git")); err != nil {
+		return fmt.Errorf("draft target %s is not a git repository", ledgerPath)
+	}
+	return nil
+}
+
+// purgeDraftSessionDir removes a draft placeholder from the git index and the
+// working tree, and COMMITS that removal locally.
+//
+// Wholesale, not selective, and that is the entire point. While meta.draft is
+// true, EVERY file in that directory is provisional. The SageOx server may
+// summarize the zero-turn draft, write summary.json / summary.md and push them;
+// the `git pull --rebase` inside a finalize-time pushLedger folds those into our
+// working tree, and preserveComputedFields would then carry their
+// files_changed / chapters into the real summary as if an LLM had read the
+// transcript. A whitelist of "files we know the server might write" rots the
+// first time the server writes something new; deleting the directory cannot.
+//
+// # Why this commits instead of leaving the deletion staged
+//
+// Leaving it staged for the caller's own commit is one commit cheaper and
+// wrong. The finalize that follows can fail at several points the pipeline is
+// explicitly built to tolerate — LFS upload, meta write, read-only endpoint —
+// and every one of those leaves a staged deletion in the shared ledger index
+// with nothing to anchor it. The next unrelated bare `git commit` (another
+// agent's session stop) then sweeps that deletion in under the wrong message.
+// Committing here makes the purge durable and idempotent instead: a crash
+// mid-finalize converges, because the draft is already gone and the retry sees
+// a clean directory.
+//
+// The directory is deliberately NOT recreated. Every caller creates it (
+// pipeline.CopySessionToLedger, the doctor retry, the daemon's staging), and an
+// empty leftover directory is actively harmful: listSessionSessions has no
+// meta.json filter, so an empty <ledger>/sessions/<name>/ renders as a
+// non-draft row, lands in uploadedSessions, and displays as "✓ uploaded" for a
+// session that was never uploaded — which also makes its local copy
+// permanently unprunable.
+//
+// --ignore-unmatch so a draft that was written but never committed (crash
+// between write and commit) does not fail the purge; the working-tree removal
+// still runs.
+func purgeDraftSessionDir(ledgerPath, sessionName string) error {
+	if err := prepareDraftLedgerWrite(ledgerPath, sessionName); err != nil {
+		return err
+	}
+	relDir := draftSessionRelDir(sessionName)
+
+	gitRm := exec.Command("git", "-C", ledgerPath, "rm", "-r", "--force", "--ignore-unmatch", "--", relDir)
+	if out, err := gitRm.CombinedOutput(); err != nil {
+		return fmt.Errorf("git rm draft %s: %s: %w", sessionName, strings.TrimSpace(string(out)), err)
+	}
+
+	// git rm --ignore-unmatch leaves untracked files behind. Remove whatever
+	// remains so a server-authored artifact that was never committed here
+	// cannot survive into the finalized session either.
+	if err := os.RemoveAll(filepath.Join(ledgerPath, "sessions", sessionName)); err != nil {
+		return fmt.Errorf("remove draft dir %s: %w", sessionName, err)
+	}
+
+	return commitDraftRemoval(ledgerPath, sessionName, "supersede")
+}
+
+// commitDraftRemoval commits a staged draft deletion, scoped to that session's
+// path. verb distinguishes the reason in history: "supersede" (a real recording
+// is replacing it), "retract" (the session ended with no entries), "discard"
+// (the user aborted).
+//
+// A no-op when nothing is staged, so every caller is safe to invoke blindly.
+func commitDraftRemoval(ledgerPath, sessionName, verb string) error {
+	if err := validateDraftSessionName(sessionName); err != nil {
+		return err
+	}
+	if err := assertLedgerSafeForDraftWrite(ledgerPath); err != nil {
+		return err
+	}
+	relDir := draftSessionRelDir(sessionName)
+	if !hasStagedChangesFor(ledgerPath, []string{relDir}) {
+		return nil
+	}
+	commitArgs := []string{
+		"-C", ledgerPath, "commit", "--no-verify",
+		"-m", fmt.Sprintf("session-draft: %s %s", verb, sessionName),
+		"--", relDir,
+	}
+	if out, err := exec.Command("git", commitArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("git commit draft %s: %s: %w", verb, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// supersedeDraftForFinalize is the one entry point every finalize path uses to
+// take over a session directory that may hold a draft placeholder.
+//
+// It returns the preserved ses_ id BEFORE purging, which is the whole reason it
+// exists as a helper rather than two calls at each site. A draft's meta.json is
+// an extra durable carrier of that id (it survives .recording.json being
+// cleared), and the purge deletes it — so any path that purges first and reads
+// second silently rotates an id that is already circulating in PR bodies and
+// commit trailers. Four separate finalize paths need this exact ordering; a
+// helper makes getting it wrong take effort.
+//
+// A purge failure is reported to the caller but is never fatal on its own: the
+// finalize that follows writes authoritative content over everything its
+// manifest names.
+func supersedeDraftForFinalize(ledgerPath, sessionName string) (preservedID string, wasDraft bool, err error) {
+	sessionDir := draftLedgerSessionDir(ledgerPath, sessionName)
+
+	preservedID, wasDraft, err = lfs.PreservedSessionIDAndDraft(sessionDir)
+	if err != nil {
+		// Unreadable meta.json is fatal by contract — we cannot tell whether
+		// it held a ses_ id we would rotate.
+		return "", false, err
+	}
+	if !wasDraft {
+		return preservedID, false, nil
+	}
+	if purgeErr := purgeDraftSessionDir(ledgerPath, sessionName); purgeErr != nil {
+		slog.Warn("draft purge failed; finalizing over the draft", "session", sessionName, "error", purgeErr)
+	}
+	return preservedID, true, nil
+}
+
+// commitDraftRetraction commits and pushes the deletion of a draft for a
+// session that will never be finalized — a stop that produced zero entries,
+// where CopySessionToLedger short-circuits before writing anything.
+//
+// Without this the /c/ page keeps claiming "in progress" forever and the ledger
+// worktree is left holding a staged deletion nobody commits, which the next
+// unrelated `git commit` would then sweep up under the wrong message. Pushes
+// synchronously via pushLedger: this is the stop path, the user is already
+// waiting, and durability beats latency here.
+func commitDraftRetraction(ledgerPath, sessionName string) error {
+	// purgeDraftSessionDir already committed the removal; this only has to get
+	// it to the remote. Still commits defensively in case a caller reaches here
+	// with a staged-but-uncommitted deletion.
+	waitForGCSwap(ledgerPath)
+	if err := commitDraftRemoval(ledgerPath, sessionName, "retract"); err != nil {
+		return err
+	}
+	return pushLedger(context.Background(), ledgerPath)
+}
+
+// draftViewNotice returns a human-readable explanation when sessionName
+// resolves to a draft placeholder in the ledger, or "" when it does not.
+//
+// `ox session view --text/--json` needs real transcript content, which a draft
+// has none of. Without this the command hard-errors "session not found" for a
+// session `ox session list` is simultaneously displaying — the two commands
+// disagreeing is exactly the "everything seems broken" symptom drafts exist to
+// remove.
+func draftViewNotice(sessionName string) string {
+	ledgerPath, err := resolveLedgerPath()
+	if err != nil {
+		return ""
+	}
+	sessionDir := draftLedgerSessionDir(ledgerPath, sessionName)
+	meta, err := lfs.ReadSessionMeta(sessionDir)
+	if err != nil || !meta.IsDraft() {
+		return ""
+	}
+
+	msg := fmt.Sprintf("Session %q is still recording — a draft placeholder is published, but no turn data has been written yet.", sessionName)
+	if cfg, cfgErr := config.LoadProjectConfig(""); cfgErr == nil {
+		if url := buildConversationURL(cfg, meta.EffectiveSessionID()); url != "" {
+			msg += "\nLive view: " + url
+		}
+	}
+	msg += "\nRun 'ox session view " + sessionName + "' again after '/ox-session-stop' to read the transcript."
+	return msg
+}
+
+// draftDeleteResult reports what removing a draft from the ledger accomplished.
+// Deleted and PushWarning are independent: a local commit that failed to push is
+// still progress, and reporting it as an outright failure would push the caller
+// toward a retry that cannot succeed (the second `git rm` finds nothing to
+// remove and reports zero staged, forever).
+type draftDeleteResult struct {
+	Deleted     bool
+	PushWarning string
+}
+
+// deleteDraftFromLedger git-removes a session's draft placeholder from the
+// ledger. Used by `ox agent session abort` so discarding a session also
+// discards the placeholder that made it publicly visible.
+//
+// REFUSES when the ledger meta is not a draft. Abort resolves sessions by
+// partial name, so a name collision with a teammate's finalized session pulled
+// in from the remote must never turn into a deletion of their work — that is
+// what `ox agent session delete` is for, with its own confirmation.
+//
+// A push failure is a WARNING, not an error. The local delete commit is already
+// durable and the next pushLedger or `ox doctor --fix` on an ahead branch
+// carries it, and notifySessionAbortedAsync independently flips the /c/ page to
+// discarded. Failing the abort here would leave the user's session data deleted
+// locally with no clean way to retry.
+func deleteDraftFromLedger(ledgerPath, sessionName string) (draftDeleteResult, error) {
+	var res draftDeleteResult
+
+	// Validate the name BEFORE anything reads or removes a path built from it.
+	// An empty or traversal-shaped name widens every pathspec below to the
+	// whole sessions tree.
+	if err := validateDraftSessionName(sessionName); err != nil {
+		return res, err
+	}
+
+	sessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	meta, err := lfs.ReadSessionMeta(sessionDir)
+	if err != nil {
+		if os.IsNotExist(err) || errors.Is(err, os.ErrNotExist) {
+			return res, nil // no ledger presence at all — nothing to do
+		}
+		// Unreadable meta.json: refuse rather than guess. We cannot tell
+		// whether this is a draft or a finalized session, and deleting a
+		// finalized one is unrecoverable.
+		return res, fmt.Errorf("read ledger meta for %s (refusing to delete what we cannot classify): %w", sessionName, err)
+	}
+	if !meta.IsDraft() {
+		return res, fmt.Errorf("%s is a finalized session in the ledger, not a draft; use 'ox agent session delete %s' to remove it", sessionName, sessionName)
+	}
+
+	if err := prepareDraftLedgerWrite(ledgerPath, sessionName); err != nil {
+		return res, err
+	}
+
+	relDir := draftSessionRelDir(sessionName)
+	gitRm := exec.Command("git", "-C", ledgerPath, "rm", "-r", "--force", "--ignore-unmatch", "--", relDir)
+	if out, err := gitRm.CombinedOutput(); err != nil {
+		return res, fmt.Errorf("git rm draft %s: %s: %w", sessionName, strings.TrimSpace(string(out)), err)
+	}
+	_ = os.RemoveAll(sessionDir)
+
+	if err := commitDraftRemoval(ledgerPath, sessionName, "discard"); err != nil {
+		return res, err
+	}
+	res.Deleted = true
+
+	if err := pushLedger(context.Background(), ledgerPath); err != nil {
+		res.PushWarning = fmt.Sprintf("draft removed locally but the ledger push failed (%v); it will be pushed by the next 'ox doctor --fix' or session upload", err)
+		slog.Warn("draft discard push failed", "session", sessionName, "error", err)
+	}
+	return res, nil
+}

--- a/cmd/ox/session_draft_abort_test.go
+++ b/cmd/ox/session_draft_abort_test.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sessionScopedID derives a distinct, valid ses_ id per session name.
+//
+// Stamping one shared id on every fixture session put two sessions with the
+// same ses_ id in one ledger — a state production cannot produce, and one that
+// would mask an id-collision bug rather than expose it.
+func sessionScopedID(sessionName string) string {
+	h := sha256.Sum256([]byte(sessionName))
+	return fmt.Sprintf("ses_01950000-0000-7000-8000-%012x", h[:6])
+}
+
+// finalizedLedgerSession writes a NON-draft session into the ledger.
+func finalizedLedgerSession(t *testing.T, ledgerPath, sessionName string) string {
+	t.Helper()
+	dir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		SessionName: sessionName, SessionID: sessionScopedID(sessionName),
+		CreatedAt: time.Now(), Title: "real work", EntryCount: 40,
+		Files: map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}},
+	}))
+	return dir
+}
+
+// draftLedgerSession writes a DRAFT session into the ledger (no git).
+//
+// UpdatedAt is set because production ALWAYS sets it (WriteDraftSessionMeta).
+// Omitting it produced a shape the code can never emit — and specifically the
+// one shape the orphan reaper classifies as "cannot age", so several consumers
+// were being asserted against an impossible input.
+func draftLedgerSession(t *testing.T, ledgerPath, sessionName string) string {
+	t.Helper()
+	dir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	updated := time.Now().UTC()
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		SessionName: sessionName, SessionID: sessionScopedID(sessionName),
+		CreatedAt: updated, Draft: true, TurnCount: 2, UpdatedAt: &updated,
+		Files: map[string]lfs.FileRef{},
+	}))
+	return dir
+}
+
+// TestIsSessionInLedger_DraftIsNotUploaded is the regression for the bug this
+// feature would otherwise introduce.
+//
+// isSessionInLedger was a bare os.Stat on the directory. A draft makes that
+// succeed, so ClassifySession returns StatusUploaded for a LIVE recording —
+// which makes `ox session abort <name>` refuse with "already uploaded, use
+// session delete". That breaks the privacy escape hatch for exactly the
+// sessions a user is most likely to want discarded.
+//
+// Red-first check: revert isSessionInLedger to the bare os.Stat and the draft
+// sub-case flips to true.
+func TestIsSessionInLedger_DraftIsNotUploaded(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, ledgerPath := setupLedgerProject(t)
+	t.Chdir(projectRoot)
+
+	draftLedgerSession(t, ledgerPath, "2026-01-01T00-00-testuser-OxDr01")
+	assert.False(t, isSessionInLedger("2026-01-01T00-00-testuser-OxDr01"),
+		"a draft placeholder must not count as uploaded")
+
+	finalizedLedgerSession(t, ledgerPath, "2026-01-01T00-00-testuser-OxFi01")
+	assert.True(t, isSessionInLedger("2026-01-01T00-00-testuser-OxFi01"),
+		"a finalized session must still count as uploaded")
+
+	// Fail-safe direction: an unreadable meta.json is treated as FINALIZED, so
+	// abort refuses and points at `session delete` rather than deleting a
+	// directory it cannot classify.
+	corruptDir := filepath.Join(ledgerPath, "sessions", "2026-01-01T00-00-testuser-OxCo01")
+	require.NoError(t, os.MkdirAll(corruptDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(corruptDir, "meta.json"), []byte(`{"draft":tr`), 0644))
+	assert.True(t, isSessionInLedger("2026-01-01T00-00-testuser-OxCo01"),
+		"an unclassifiable session must fail safe toward 'do not delete'")
+
+	assert.False(t, isSessionInLedger("2026-01-01T00-00-testuser-OxNone"),
+		"a session with no ledger presence is not uploaded")
+}
+
+// TestClassifySession_DraftIsNotUploaded pins the classifier itself, so the fix
+// cannot regress by someone "simplifying" isSessionInLedger's caller.
+func TestClassifySession_DraftIsNotUploaded(t *testing.T) {
+	info := session.SessionInfo{SessionName: "s", Draft: true}
+	assert.Equal(t, session.StatusDraft, session.ClassifySession(info, true),
+		"a draft must classify as draft even when the caller says 'in the ledger'")
+
+	assert.Equal(t, session.StatusUploaded,
+		session.ClassifySession(session.SessionInfo{SessionName: "s"}, true),
+		"negative control: a non-draft in the ledger is still uploaded")
+
+	// A live recording outranks draft-ness — the Recording branch comes first.
+	live := session.SessionInfo{SessionName: "s", Draft: true, Recording: true, ParentPID: os.Getpid()}
+	assert.Equal(t, session.StatusRecording, session.ClassifySession(live, true))
+}
+
+// TestResolveSessionForAbort_PrefersCacheOverLedgerDraft.
+//
+// The store search order used to be [XDG cache, ledger sessions/, ledger
+// cache]. Recordings live in the LEDGER CACHE, searched last. Once a draft
+// exists, the git-tracked ledger directory matches first — and the caller then
+// runs os.RemoveAll on a TRACKED directory, deleting it from the worktree with
+// no `git rm` (so the next pull restores it) while leaving the real recording
+// completely untouched.
+//
+// Red-first check: restore the old store order and this returns the ledger
+// path.
+func TestResolveSessionForAbort_PrefersCacheOverLedgerDraft(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, ledgerPath := setupLedgerProject(t)
+	t.Chdir(projectRoot)
+
+	sessionName, cachePath := makeLedgerCacheOrphanSession(t, ledgerPath, "OxDual")
+	draftLedgerSession(t, ledgerPath, sessionName)
+
+	resolved, resolvedPath, err := resolveSessionForAbort(projectRoot, sessionName)
+	require.NoError(t, err)
+	assert.Equal(t, sessionName, resolved)
+	assert.Equal(t, cachePath, resolvedPath,
+		"abort must resolve to the recording cache, never to the git-tracked draft directory")
+}
+
+// TestResolveSessionForAbort_SkipsDraftOnlyLedgerMatch — with no cache copy at
+// all, a draft-only ledger match must not be handed back as something to
+// os.RemoveAll. The ledger draft is removed via git, by a different code path.
+func TestResolveSessionForAbort_SkipsDraftOnlyLedgerMatch(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, ledgerPath := setupLedgerProject(t)
+	t.Chdir(projectRoot)
+
+	const sessionName = "2026-01-01T00-00-testuser-OxOnly"
+	draftLedgerSession(t, ledgerPath, sessionName)
+
+	// Not "not found": a draft-only session must still be ABORTABLE. The
+	// sentinel routes the caller to the git-removal path instead of
+	// os.RemoveAll on a tracked directory. Without it, a placeholder whose
+	// recording is gone (pruned cache, dead agent, an earlier abort whose git
+	// removal never landed) advertises the session forever with no way to
+	// remove it — and the daemon deliberately skips drafts, so nothing else
+	// ever would.
+	resolvedName, resolvedPath, err := resolveSessionForAbort(projectRoot, sessionName)
+	require.ErrorIs(t, err, errDraftOnlySession)
+	assert.Equal(t, sessionName, resolvedName, "the caller needs the name to git-remove it")
+	assert.Empty(t, resolvedPath, "there is no local directory to delete")
+
+	// Negative control: a finalized ledger session IS resolvable (existing
+	// behavior — abort then refuses it by status, not by resolution).
+	finalized := "2026-01-01T00-00-testuser-OxFin2"
+	finalizedLedgerSession(t, ledgerPath, finalized)
+	resolved, _, err := resolveSessionForAbort(projectRoot, finalized)
+	require.NoError(t, err)
+	assert.Equal(t, finalized, resolved)
+}
+
+// --- git-level abort ------------------------------------------------------
+
+// TestDeleteDraftFromLedger_RemovesFromRemote asserts through a FRESH clone.
+// The local worktree is not the ledger; a local deletion proves nothing about
+// what teammates still see.
+func TestDeleteDraftFromLedger_RemovesFromRemote(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxDel"
+
+	f.publish(t, sessionName, 2)
+	f.push(t)
+	require.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+
+	res, err := deleteDraftFromLedger(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	assert.True(t, res.Deleted)
+	assert.Empty(t, res.PushWarning)
+
+	assert.NotContains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json",
+		"the draft must be gone from the remote, not just locally")
+	assert.NoDirExists(t, draftLedgerSessionDir(f.ledgerPath, sessionName))
+	gitFsckClean(t, f.barePath)
+}
+
+// TestDeleteDraftFromLedger_RefusesFinalizedSession.
+//
+// Abort resolves sessions by partial name. A collision with a teammate's
+// finalized session pulled from the remote must never become a deletion of
+// their work — that is what `ox agent session delete` is for, with its own
+// confirmation.
+func TestDeleteDraftFromLedger_RefusesFinalizedSession(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxKeep"
+
+	finalizedLedgerSession(t, f.ledgerPath, sessionName)
+
+	res, err := deleteDraftFromLedger(f.ledgerPath, sessionName)
+	require.Error(t, err)
+	assert.False(t, res.Deleted)
+	assert.Contains(t, err.Error(), "session delete")
+	assert.FileExists(t, filepath.Join(f.ledgerPath, "sessions", sessionName, "meta.json"),
+		"a finalized session must survive an abort that names it")
+}
+
+// TestDeleteDraftFromLedger_UnreadableMetaRefuses — same fail-safe direction as
+// isSessionInLedger. We cannot classify it, so we do not delete it.
+func TestDeleteDraftFromLedger_UnreadableMetaRefuses(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxBad"
+
+	dir := draftLedgerSessionDir(f.ledgerPath, sessionName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte(`{{{`), 0644))
+
+	res, err := deleteDraftFromLedger(f.ledgerPath, sessionName)
+	require.Error(t, err)
+	assert.False(t, res.Deleted)
+	assert.FileExists(t, filepath.Join(dir, "meta.json"))
+}
+
+// TestDeleteDraftFromLedger_NoLedgerPresenceIsNoop — aborting a session that
+// never published a draft must be silent, not an error. Most aborts are this.
+func TestDeleteDraftFromLedger_NoLedgerPresenceIsNoop(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	res, err := deleteDraftFromLedger(f.ledgerPath, "2026-01-01T00-00-testuser-OxGhost")
+	require.NoError(t, err)
+	assert.False(t, res.Deleted)
+	assert.Empty(t, res.PushWarning)
+}
+
+// TestDeleteDraftFromLedger_SurvivesPushFailureAndMakesProgress.
+//
+// This is the wedge-harness part-3 clause, and it is the part that matters.
+// Asserting only "the local commit exists" would pass while the ledger is
+// permanently stuck: a naive retry re-runs `git rm`, finds nothing to remove,
+// and reports zero staged forever. The test therefore restores the remote and
+// proves the deletion actually lands.
+func TestDeleteDraftFromLedger_SurvivesPushFailureAndMakesProgress(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxPushFail"
+
+	f.publish(t, sessionName, 2)
+	f.push(t)
+
+	runGit(t, f.ledgerPath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "gone.git"))
+
+	// 1. The abort still SUCCEEDS — the local data is what abort promised to
+	//    discard, and failing here would leave the user with no clean retry.
+	res, err := deleteDraftFromLedger(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	assert.True(t, res.Deleted)
+	assert.NotEmpty(t, res.PushWarning, "an unpushed deletion must be surfaced, not swallowed")
+
+	// 2. The deletion is durable locally.
+	assert.NoDirExists(t, draftLedgerSessionDir(f.ledgerPath, sessionName))
+	assert.Empty(t, runGit(t, f.ledgerPath, "status", "--porcelain", "--", "sessions/"),
+		"no staged deletion may be left dangling for the next commit to sweep up")
+
+	// 3. THE PART THAT MATTERS: the ledger makes progress afterward.
+	runGit(t, f.ledgerPath, "remote", "set-url", "origin", f.barePath)
+	f.push(t)
+	assert.NotContains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+	assert.Equal(t, "0", runGit(t, f.ledgerPath, "rev-list", "--count", "@{upstream}..HEAD"))
+	gitFsckClean(t, f.barePath)
+}
+
+// TestDeleteDraftFromLedger_Idempotent — a repeated abort must not error or
+// produce a second commit.
+func TestDeleteDraftFromLedger_Idempotent(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxTwice"
+
+	f.publish(t, sessionName, 2)
+	f.push(t)
+
+	_, err := deleteDraftFromLedger(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	before := commitCount(t, f.ledgerPath)
+
+	res, err := deleteDraftFromLedger(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	assert.False(t, res.Deleted, "nothing left to delete")
+	assert.Equal(t, before, commitCount(t, f.ledgerPath), "no second commit")
+	gitFsckClean(t, f.barePath)
+}
+
+// TestDeleteDraftFromLedger_DoesNotTouchSiblingDrafts.
+//
+// `git rm -r` plus an unscoped commit would sweep a co-staged sibling. Two
+// agents drafting into one ledger clone is the normal case, not an edge case.
+func TestDeleteDraftFromLedger_DoesNotTouchSiblingDrafts(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const doomed = "2026-01-01T00-00-testuser-OxGone"
+	const keeper = "2026-01-01T00-00-testuser-OxStay"
+
+	f.publish(t, doomed, 2)
+	f.publish(t, keeper, 2)
+	f.push(t)
+
+	_, err := deleteDraftFromLedger(f.ledgerPath, doomed)
+	require.NoError(t, err)
+
+	tree := remoteTree(t, f.barePath)
+	assert.NotContains(t, tree, "sessions/"+doomed+"/meta.json")
+	assert.Contains(t, tree, "sessions/"+keeper+"/meta.json",
+		"the sibling draft must survive, and must be committed rather than left staged")
+	assert.Empty(t, runGit(t, f.ledgerPath, "status", "--porcelain", "--", "sessions/"))
+	gitFsckClean(t, f.barePath)
+}
+
+// TestSessionRemove_SkipsDraftPlaceholders.
+//
+// Before drafts, a name pattern could not match a LIVE session in the ledger —
+// a session was either in the cache (live) or in the ledger (finished). A draft
+// makes a live session match, and `ox session remove` would then delete the
+// running recording's local copy alongside the placeholder, while the session
+// kept recording and republished at stop. Abort is the command for discarding a
+// live session; it removes the placeholder itself.
+func TestSessionRemove_SkipsDraftPlaceholders(t *testing.T) {
+	setTestCfg(t)
+	f := newDraftLedgerFixture(t)
+	// removeSessionByPattern resolves the ledger from the PROJECT root, so the
+	// fixture's chdir-into-the-clone (which exists for push credential
+	// isolation) has to be undone for this one.
+	t.Chdir(f.projectRoot)
+
+	const draftName = "2026-01-01T00-00-testuser-OxRmDr"
+	const doneName = "2026-01-01T00-00-testuser-OxRmDn"
+	f.publish(t, draftName, 2)
+	finalizedLedgerSession(t, f.ledgerPath, doneName)
+	runGit(t, f.ledgerPath, "add", "--sparse", "--", "sessions/"+doneName+"/meta.json")
+	runGit(t, f.ledgerPath, "commit", "--no-verify", "-m", "session: "+doneName)
+	f.push(t)
+
+	// The "local" store in production is the XDG/session cache, NOT the ledger.
+	// Passing the ledger here would route both sessions down the local-delete
+	// branch and never exercise the ledger match at all.
+	localStore, err := session.NewStore(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, removeSessionByPattern(localStore, "2026-01-01T00-00-testuser-OxRm", true))
+
+	tree := remoteTree(t, f.barePath)
+	assert.Contains(t, tree, "sessions/"+draftName+"/meta.json",
+		"a live session's draft placeholder must survive `session remove`")
+	assert.NotContains(t, tree, "sessions/"+doneName+"/meta.json",
+		"negative control: a finalized session is still removed")
+}

--- a/cmd/ox/session_draft_consumers_test.go
+++ b/cmd/ox/session_draft_consumers_test.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/sessionid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for the CONSUMERS that had to learn about drafts — the ones that used
+// to treat "sessions/<name>/meta.json exists" as "this session is real":
+// doctor's orphan sweep, lfs.RecoverEmptyTitleMeta, preserveComputedFields,
+// loadUploadedKeys, and the session-list merge.
+//
+// makeXDGCacheSession writes a crashed-but-substantive recording into the XDG
+// cache — the shape doctor's orphan sweep exists to recover.
+func makeXDGCacheSession(t *testing.T, projectRoot, sessionName string) string {
+	t.Helper()
+	repoID := getRepoIDOrDefault(projectRoot)
+	contextPath := session.GetContextPath(repoID)
+	require.NotEmpty(t, contextPath, "XDG context path must resolve for this fixture")
+
+	dir := filepath.Join(contextPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	raw := `{"type":"header","metadata":{"version":"1.0","created_at":"2026-01-01T00:00:00Z","agent_id":"OxOrph","session_id":"` +
+		draftTestSessionID + `"}}` + "\n" +
+		`{"ts":"2026-01-01T00:01:00Z","type":"user","content":"real work that must not be lost"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte(raw), 0644))
+	return dir
+}
+
+// TestDoctorUploadRetry_DraftDoesNotHideOrphanedSession is the data-loss test.
+// Run it first when triaging this feature.
+//
+// findOrphanedSessions skipped any session whose ledger meta.json existed. A
+// draft published at turn 2 makes that true, so a session that later crashed
+// AND failed to upload would be skipped forever — and this check runs at
+// FixLevelAuto, so the only copy of the transcript would rot in the cache until
+// pruned, with no error anywhere.
+//
+// Red-first check: delete the IsDraft() branch in findOrphanedSessions and the
+// first sub-case returns zero orphans.
+func TestDoctorUploadRetry_DraftDoesNotHideOrphanedSession(t *testing.T) {
+	setTestCfg(t)
+
+	t.Run("draft in ledger: session IS still an orphan", func(t *testing.T) {
+		projectRoot, ledgerPath := draftReaperFixture(t)
+		const sessionName = "2026-01-01T00-00-testuser-OxOrph"
+		makeXDGCacheSession(t, projectRoot, sessionName)
+		draftLedgerSession(t, ledgerPath, sessionName)
+
+		orphans, err := findOrphanedSessions(projectRoot, ledgerPath)
+		require.NoError(t, err)
+		names := orphanNames(orphans)
+		assert.Contains(t, names, sessionName,
+			"a draft placeholder must not hide a crashed session from recovery")
+	})
+
+	t.Run("finalized in ledger: session is NOT an orphan", func(t *testing.T) {
+		projectRoot, ledgerPath := draftReaperFixture(t)
+		const sessionName = "2026-01-01T00-00-testuser-OxDone"
+		makeXDGCacheSession(t, projectRoot, sessionName)
+		finalizedLedgerSession(t, ledgerPath, sessionName)
+
+		orphans, err := findOrphanedSessions(projectRoot, ledgerPath)
+		require.NoError(t, err)
+		assert.NotContains(t, orphanNames(orphans), sessionName,
+			"negative control: an uploaded session must still be skipped")
+	})
+
+	t.Run("unreadable ledger meta fails safe toward skip", func(t *testing.T) {
+		projectRoot, ledgerPath := draftReaperFixture(t)
+		const sessionName = "2026-01-01T00-00-testuser-OxCrpt"
+		makeXDGCacheSession(t, projectRoot, sessionName)
+
+		dir := filepath.Join(ledgerPath, "sessions", sessionName)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte(`{"draft":tr`), 0644))
+
+		orphans, err := findOrphanedSessions(projectRoot, ledgerPath)
+		require.NoError(t, err)
+		assert.NotContains(t, orphanNames(orphans), sessionName,
+			"retrying an upload we cannot classify risks clobbering a finalized session; "+
+				"skipping only defers recovery to a human")
+	})
+}
+
+func orphanNames(orphans []orphanedSession) []string {
+	names := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		names = append(names, o.SessionName)
+	}
+	return names
+}
+
+// treeHash fingerprints a directory tree (paths + contents) so a test can prove
+// a check mutated NOTHING. Asserting only on a check's returned Status is
+// theater: a check that rewrote meta.json and returned Passed sails through.
+func treeHash(t *testing.T, root string) string {
+	t.Helper()
+	h := sha256.New()
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || strings.Contains(path, string(os.PathSeparator)+".git"+string(os.PathSeparator)) {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(paths)
+	for _, p := range paths {
+		body, readErr := os.ReadFile(p)
+		require.NoError(t, readErr)
+		rel, _ := filepath.Rel(root, p)
+		fmt.Fprintf(h, "%s\x00%x\x00", rel, sha256.Sum256(body))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// TestMetaRepair_NoOpOnDraft.
+//
+// A draft legitimately has no title. Without a skip, every autofix tick treats
+// that as a summarization fault, bumps SummaryAttempts, and at
+// MaxSummaryAttempts stamps summary_status="unrecoverable" into a session that
+// is still recording. The daemon's finalize is a preserve-unowned-fields RMW,
+// so that stamp would then be carried into the FINISHED session — permanently
+// marking real work as unsummarizable. It would also dirty the ledger worktree
+// mid-recording, which doctor's uncommitted-sessions fix would then commit.
+//
+// Red-first check: delete the IsDraft() branch in RecoverEmptyTitleMeta and the
+// no-mutation assertion fails.
+func TestMetaRepair_NoOpOnDraft(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		SessionName: "2026-01-01T00-00-testuser-OxRep", SessionID: draftTestSessionID,
+		CreatedAt: time.Now(), Draft: true, TurnCount: 2, Files: map[string]lfs.FileRef{},
+	}))
+	before := treeHash(t, dir)
+
+	// Repeat past MaxSummaryAttempts — the bug only manifests after N ticks.
+	for i := 0; i < lfs.MaxSummaryAttempts+2; i++ {
+		out := lfs.RecoverEmptyTitleMeta(dir, false)
+		assert.True(t, out.Skipped, "tick %d: a draft must be skipped, not repaired", i)
+		assert.Empty(t, out.Error)
+	}
+
+	assert.Equal(t, before, treeHash(t, dir), "repair must not mutate a draft at all")
+
+	meta, err := lfs.ReadSessionMeta(dir)
+	require.NoError(t, err)
+	assert.Zero(t, meta.SummaryAttempts)
+	assert.Empty(t, meta.SummaryStatus,
+		"a draft must never be stamped unrecoverable — the daemon would carry that into the real session")
+	assert.True(t, meta.IsDraft())
+}
+
+// TestMetaRepair_StillRepairsNonDraft is the negative control. Without it,
+// TestMetaRepair_NoOpOnDraft passes with RecoverEmptyTitleMeta gutted to
+// "always skip".
+func TestMetaRepair_StillRepairsNonDraft(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		SessionName: "2026-01-01T00-00-testuser-OxReal", SessionID: draftTestSessionID,
+		CreatedAt: time.Now(),
+		Files:     map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}},
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "summary.json"),
+		[]byte(`{"title":"Recovered title"}`), 0644))
+
+	out := lfs.RecoverEmptyTitleMeta(dir, false)
+	assert.False(t, out.Skipped, "a real session with an empty title must still be repaired")
+	assert.True(t, out.RecoveredFromJSON)
+
+	meta, err := lfs.ReadSessionMeta(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "Recovered title", meta.Title)
+}
+
+// TestPreserveComputedFields_RejectsDraftEraSummary.
+//
+// While meta.draft is true, any summary.json in the directory was authored
+// against a ZERO-TURN placeholder — by the SageOx server, or pulled in by a
+// finalize-time rebase — so its files_changed and chapters describe nothing.
+// Carrying them forward stamps a fabricated file list onto the real summary.
+func TestPreserveComputedFields_RejectsDraftEraSummary(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		SessionName: "s", SessionID: draftTestSessionID, CreatedAt: time.Now(),
+		Draft: true, Files: map[string]lfs.FileRef{},
+	}))
+	summaryPath := filepath.Join(dir, "summary.json")
+	require.NoError(t, os.WriteFile(summaryPath,
+		[]byte(`{"title":"Zero-turn session","files_changed":[{"path":"SERVER.md"}],"chapters":[{"title":"server chapter"}]}`), 0644))
+
+	incoming := &session.SummarizeResponse{Title: "Real work"}
+	preserveComputedFields(summaryPath, incoming)
+
+	assert.Empty(t, incoming.FilesChanged, "draft-era files_changed must not be carried forward")
+	assert.Empty(t, incoming.Chapters, "draft-era chapters must not be carried forward")
+}
+
+// TestPreserveComputedFields_StillCarriesRealStopTimeSummary is the negative
+// control, and it is what stops the fix from degenerating into "delete
+// preserveComputedFields" — which would regress the ox-0pxt class where
+// legitimately computed fields are lost because raw.jsonl is an LFS stub by the
+// time push-summary runs.
+func TestPreserveComputedFields_StillCarriesRealStopTimeSummary(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		SessionName: "s", SessionID: draftTestSessionID, CreatedAt: time.Now(),
+		Files: map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}},
+	}))
+	summaryPath := filepath.Join(dir, "summary.json")
+	require.NoError(t, os.WriteFile(summaryPath,
+		[]byte(`{"title":"stop-time","files_changed":[{"path":"real.go"}],"chapters":[{"title":"real chapter"}]}`), 0644))
+
+	incoming := &session.SummarizeResponse{Title: "Regenerated"}
+	preserveComputedFields(summaryPath, incoming)
+
+	require.Len(t, incoming.FilesChanged, 1, "a legitimate stop-time summary's computed fields must still be carried forward")
+	assert.Equal(t, "real.go", incoming.FilesChanged[0].Path)
+	assert.Len(t, incoming.Chapters, 1)
+}
+
+// TestLoadUploadedKeys_ExcludesDrafts.
+//
+// shouldPrune returns false for StatusUploaded. If a draft counted as uploaded,
+// the local cache copy of every drafted session would become permanently
+// unprunable — including after the session was aborted.
+func TestLoadUploadedKeys_ExcludesDrafts(t *testing.T) {
+	setTestCfg(t)
+	_, ledgerPath := draftReaperFixture(t)
+
+	draftLedgerSession(t, ledgerPath, "2026-01-01T00-00-testuser-OxPrD")
+	finalizedLedgerSession(t, ledgerPath, "2026-01-01T00-00-testuser-OxPrF")
+
+	keys, err := loadUploadedKeys(ledgerPath)
+	require.NoError(t, err)
+	assert.NotContains(t, keys, "2026-01-01T00-00-testuser-OxPrD", "a draft is not an upload")
+	assert.Contains(t, keys, "2026-01-01T00-00-testuser-OxPrF", "negative control")
+}
+
+// TestMergeSessionSources_NonDraftReplacesDraft.
+//
+// `ox session list` merges the git-tracked ledger as PRIMARY, ahead of the
+// ledger cache where live recordings live. The old first-key-wins merge meant a
+// draft row (no title, Recording=false) shadowed its own live recording, so
+// every active session rendered as finished. That is the most user-visible
+// regression this feature could ship.
+func TestMergeSessionSources_NonDraftReplacesDraft(t *testing.T) {
+	const name = "2026-01-01T00-00-testuser-OxMrg"
+
+	draftRow := session.SessionInfo{SessionName: name, Draft: true, CreatedAt: time.Now()}
+	liveRow := session.SessionInfo{SessionName: name, Recording: true, EntryCount: 17,
+		Title: "live work", CreatedAt: time.Now()}
+
+	merged := mergeSessionSources([]session.SessionInfo{draftRow}, []session.SessionInfo{liveRow})
+	require.Len(t, merged, 1, "the two rows describe one session and must collapse")
+	assert.False(t, merged[0].Draft)
+	assert.True(t, merged[0].Recording)
+	assert.Equal(t, 17, merged[0].EntryCount)
+	assert.Equal(t, "live work", merged[0].Title)
+
+	// A draft must NOT replace a non-draft in the other direction.
+	merged2 := mergeSessionSources([]session.SessionInfo{liveRow}, []session.SessionInfo{draftRow})
+	require.Len(t, merged2, 1)
+	assert.True(t, merged2[0].Recording, "primary non-draft must win over an additional draft")
+
+	// Non-draft vs non-draft keeps the historical primary-wins behavior.
+	a := session.SessionInfo{SessionName: name, Title: "primary", CreatedAt: time.Now()}
+	b := session.SessionInfo{SessionName: name, Title: "additional", CreatedAt: time.Now()}
+	merged3 := mergeSessionSources([]session.SessionInfo{a}, []session.SessionInfo{b})
+	require.Len(t, merged3, 1)
+	assert.Equal(t, "primary", merged3[0].Title)
+}
+
+// TestResolveOrphanSessionID_UsesDraftPreservedID.
+//
+// The draftPreservedID parameter exists because retrySessionUpload PURGES the
+// draft before this runs, so lfs.PreservedSessionID finds nothing — the caller
+// has to read the id first and hand it in. Every pre-existing call site passes
+// "", so the branch it was added for was never taken by a test.
+//
+// The case that matters is a recording whose raw.jsonl header predates the
+// SessionID field: the purged draft was the ONLY carrier, and losing it mints a
+// fresh id that 404s a /c/ link already published in a PR body.
+func TestResolveOrphanSessionID_UsesDraftPreservedID(t *testing.T) {
+	const draftID = "ses_01950000-0000-7000-8000-0000000000dd"
+
+	t.Run("no meta, no header: the purged draft's id wins over a fresh mint", func(t *testing.T) {
+		sessionDir := t.TempDir() // purged: no meta.json
+		orphan := orphanedSession{SessionName: "s", Meta: &session.StoreMeta{}}
+
+		got, err := resolveOrphanSessionID(sessionDir, orphan, draftID)
+		require.NoError(t, err)
+		assert.Equal(t, draftID, got,
+			"without this the id rotates and every circulated /c/ link breaks")
+	})
+
+	t.Run("the draft id outranks the raw-header id", func(t *testing.T) {
+		const headerID = "ses_01950000-0000-7000-8000-0000000000ee"
+		sessionDir := t.TempDir()
+		orphan := orphanedSession{SessionName: "s", Meta: &session.StoreMeta{SessionID: headerID}}
+
+		got, err := resolveOrphanSessionID(sessionDir, orphan, draftID)
+		require.NoError(t, err)
+		assert.Equal(t, draftID, got,
+			"ResolveSessionID's documented precedence is preserved-beats-start-minted, and a "+
+				"draft's meta.json is a PUBLISHED id — it is already on the remote and already "+
+				"in circulation via /c/ links. The header id is start-minted. If the two ever "+
+				"disagree, the published one is the one teammates and PR bodies point at.")
+	})
+
+	t.Run("an on-disk meta still outranks everything", func(t *testing.T) {
+		const metaID = "ses_01950000-0000-7000-8000-0000000000ff"
+		sessionDir := t.TempDir()
+		require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, &lfs.SessionMeta{
+			SessionName: "s", SessionID: metaID, CreatedAt: time.Now(),
+		}))
+		orphan := orphanedSession{SessionName: "s", Meta: &session.StoreMeta{}}
+
+		got, err := resolveOrphanSessionID(sessionDir, orphan, draftID)
+		require.NoError(t, err)
+		assert.Equal(t, metaID, got, "a surviving meta.json is the highest-precedence carrier")
+	})
+
+	t.Run("nothing anywhere still mints exactly one valid id", func(t *testing.T) {
+		sessionDir := t.TempDir()
+		orphan := orphanedSession{SessionName: "s", Meta: &session.StoreMeta{}}
+
+		got, err := resolveOrphanSessionID(sessionDir, orphan, "")
+		require.NoError(t, err)
+		assert.True(t, sessionid.IsValidSessionID(got), "a fresh mint must still be well-formed")
+	})
+}

--- a/cmd/ox/session_draft_git_test.go
+++ b/cmd/ox/session_draft_git_test.go
@@ -1,0 +1,1039 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/gitutil"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fixtures -------------------------------------------------------------
+//
+// Tests built on newDraftLedgerFixture drive REAL git against a REAL bare
+// remote. Mocking the push would hide the entire failure class this feature can
+// produce (rebase, autostash, index scope, staged-but-uncommitted deletions),
+// so for anything that commits or pushes the rule is: real bare remote or it
+// didn't happen.
+//
+// Guards that return BEFORE any git command use newDraftGuardFixture instead,
+// so they run in the every-commit `-short` pass rather than only in test-all.
+
+const draftTestSessionID = "ses_01950000-0000-7000-8000-0000000000aa"
+
+// draftLedgerFixture is a project whose ledger is a real clone of a real bare
+// remote, registered so resolveLedgerPath() finds it.
+type draftLedgerFixture struct {
+	projectRoot string
+	ledgerPath  string
+	barePath    string
+}
+
+func newDraftLedgerFixture(t *testing.T) *draftLedgerFixture {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	barePath, ledgerPath := createBareAndClone(t)
+
+	projectRoot := t.TempDir()
+	runGit(t, projectRoot, "init")
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"),
+		[]byte(`{"config_version":"2","repo_id":"repo_draft_test"}`), 0644))
+	require.NoError(t, config.SaveLocalConfig(projectRoot, &config.LocalConfig{
+		Ledger: &config.LedgerConfig{Path: ledgerPath},
+	}))
+
+	cacheDir := t.TempDir()
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("HOME", cacheDir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+
+	// isolatePushEnv chdirs into the ledger clone and points SAGEOX_ENDPOINT at
+	// an unreachable host so credential refresh cannot rewrite the file://
+	// remote out from under us.
+	isolatePushEnv(t, ledgerPath)
+
+	return &draftLedgerFixture{projectRoot: projectRoot, ledgerPath: ledgerPath, barePath: barePath}
+}
+
+// newDraftGuardFixture is a project + ledger with NO git and NO short-mode
+// skip, for the guards that return before any git command runs.
+//
+// prepareDraftLedgerWrite validates the session NAME first and the ledger
+// PATH second, both before touching git, so the two highest-blast-radius
+// validations in this feature — the one standing between a malformed name and
+// `git rm -r -- sessions` (the whole ledger), and the one standing between a
+// mis-derived path and a commit into the user's own product repo — need no
+// remote at all. Gating them behind the git fixture kept them out of the
+// every-commit run for no benefit.
+func newDraftGuardFixture(t *testing.T) *draftLedgerFixture {
+	t.Helper()
+	projectRoot := t.TempDir()
+	ledgerPath := t.TempDir()
+
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"),
+		[]byte(`{"config_version":"2","repo_id":"repo_draft_test"}`), 0644))
+	require.NoError(t, config.SaveLocalConfig(projectRoot, &config.LocalConfig{
+		Ledger: &config.LedgerConfig{Path: ledgerPath},
+	}))
+	// A .git marker so validateDraftLedgerPath's "is this a repo" check passes
+	// for the positive case; no history is needed because nothing commits.
+	require.NoError(t, os.MkdirAll(filepath.Join(ledgerPath, ".git"), 0755))
+
+	return &draftLedgerFixture{projectRoot: projectRoot, ledgerPath: ledgerPath}
+}
+
+func (f *draftLedgerFixture) writeDraft(t *testing.T, sessionName string, turnCount int) {
+	t.Helper()
+	require.NoError(t, lfs.WriteDraftSessionMeta(context.Background(),
+		draftLedgerSessionDir(f.ledgerPath, sessionName), lfs.DraftInput{
+			SessionName: sessionName,
+			SessionID:   draftTestSessionID,
+			Username:    "Test Coworker",
+			RepoID:      "repo_draft_test",
+			AgentID:     "OxDraft",
+			AgentType:   "claude-code",
+			CreatedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			TurnCount:   turnCount,
+		}))
+}
+
+// publish writes + commits a draft the way the hook does.
+func (f *draftLedgerFixture) publish(t *testing.T, sessionName string, turnCount int) {
+	t.Helper()
+	f.writeDraft(t, sessionName, turnCount)
+	require.NoError(t, commitDraftLocally(f.ledgerPath, sessionName))
+}
+
+func (f *draftLedgerFixture) push(t *testing.T) {
+	t.Helper()
+	require.NoError(t, pushLedger(context.Background(), f.ledgerPath))
+}
+
+// remoteTree lists every path tracked on the bare remote's default branch.
+// Assertions go through here rather than os.Stat on the local worktree: the
+// worktree is not the ledger, and a local file proves nothing about what
+// teammates will see.
+func remoteTree(t *testing.T, barePath string) []string {
+	t.Helper()
+	out := runGit(t, barePath, "ls-tree", "-r", "--name-only", "HEAD")
+	if strings.TrimSpace(out) == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
+}
+
+func gitFsckClean(t *testing.T, barePath string) {
+	t.Helper()
+	cmd := exec.Command("git", "fsck", "--no-dangling")
+	cmd.Dir = barePath
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git fsck reported corruption: %s", string(out))
+}
+
+// commitsTouching returns the commit subjects that changed a given path.
+func commitsTouching(t *testing.T, dir, path string) []string {
+	t.Helper()
+	out := runGit(t, dir, "log", "--format=%s", "--", path)
+	if strings.TrimSpace(out) == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
+}
+
+// --- privacy invariant ----------------------------------------------------
+
+// TestDraftPublish_NoTurnContentInAnyGitObject is the privacy invariant.
+//
+// A leak here is unrecoverable: the ledger is shared, and git history is
+// forever. The oracle deliberately scans EVERY object in the object database
+// rather than the HEAD tree — a staged-then-amended leak is unreachable from
+// HEAD but still present, still pushed, and still readable by any teammate.
+func TestDraftPublish_NoTurnContentInAnyGitObject(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxDraft"
+
+	// Plant transcript-shaped sentinels where a careless implementation would
+	// pick them up: the cache raw.jsonl, and the ledger session dir itself.
+	cacheDir := filepath.Join(f.ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"),
+		[]byte(`{"type":"header"}`+"\n"+`{"type":"user","content":"OX_SENTINEL_PROMPT_7f3a"}`+"\n"), 0644))
+
+	f.publish(t, sessionName, 2)
+	f.publish(t, sessionName, 12) // refresh
+	f.push(t)
+
+	// Oracle 1: no object in the entire database contains the sentinel.
+	cmd := exec.Command("sh", "-c", "git cat-file --batch-all-objects --batch")
+	cmd.Dir = f.barePath
+	allObjects, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+	assert.NotContains(t, string(allObjects), "OX_SENTINEL_PROMPT_7f3a",
+		"transcript content reached a git object in the shared ledger")
+
+	// Oracle 2: every commit's tree for this session holds exactly meta.json.
+	revs := strings.Split(runGit(t, f.barePath, "rev-list", "--all"), "\n")
+	for _, rev := range revs {
+		listed := runGit(t, f.barePath, "ls-tree", "-r", "--name-only", rev, "--",
+			"sessions/"+sessionName)
+		if strings.TrimSpace(listed) == "" {
+			continue
+		}
+		assert.Equal(t, []string{"sessions/" + sessionName + "/meta.json"},
+			strings.Split(listed, "\n"), "commit %s staged more than meta.json", rev[:8])
+	}
+
+	// Oracle 3: field-level, on the committed blob — not the struct we wrote.
+	blob := runGit(t, f.barePath, "show", "HEAD:sessions/"+sessionName+"/meta.json")
+	for _, forbidden := range []string{`"title"`, `"summary"`, `"produced_commits"`, `"linked_prs"`} {
+		assert.NotContains(t, blob, forbidden, "draft blob carries %s", forbidden)
+	}
+	assert.Contains(t, blob, `"draft": true`)
+	assert.Contains(t, blob, draftTestSessionID)
+
+	gitFsckClean(t, f.barePath)
+}
+
+// TestDraftPublish_StagesOnlyMetaEvenWithStrayContent.
+//
+// Catches routing the draft commit through sessionArtifactsToStage, whose glob
+// fallback (*.jsonl / *.html / *.md) fires exactly when the manifest is empty —
+// a draft's normal state. Staging a real raw.jsonl as a git blob breaks LFS
+// linkage and makes the ledger reject every future push for the whole team.
+func TestDraftPublish_StagesOnlyMetaEvenWithStrayContent(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxStray"
+
+	f.publish(t, sessionName, 2)
+
+	// Server-authored artifacts land in the draft dir, as a `git pull --rebase`
+	// during finalize would produce. These match the *.md / *.jsonl glob that
+	// sessionArtifactsToStage falls back to on an empty manifest.
+	sessionDir := draftLedgerSessionDir(f.ledgerPath, sessionName)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "summary.md"), []byte("SERVER_AUTHORED"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "notes.jsonl"), []byte(`{"leak":1}`), 0644))
+
+	// The manifest-driven stager must refuse a draft dir outright rather than
+	// falling through to that glob.
+	assert.Nil(t, sessionArtifactsToStage(sessionDir),
+		"sessionArtifactsToStage must return nothing for a draft, not fall through to the glob")
+
+	// A refresh must still stage only meta.json.
+	f.writeDraft(t, sessionName, 12)
+	require.NoError(t, commitDraftLocally(f.ledgerPath, sessionName))
+	f.push(t)
+
+	for _, p := range remoteTree(t, f.barePath) {
+		if strings.HasPrefix(p, "sessions/"+sessionName+"/") {
+			assert.Equal(t, "sessions/"+sessionName+"/meta.json", p,
+				"draft commit staged a non-meta file: %s", p)
+		}
+	}
+}
+
+// TestDraftWrite_RefusesOnceRealTranscriptBytesArePresent.
+//
+// If raw.jsonl ever appears in the git-tracked session dir, that directory is
+// no longer a draft — either a finalize is half-done or something recovered
+// bytes into the wrong place. Continuing to stamp draft:true would label a
+// directory holding real transcript content as a zero-turn placeholder, and
+// every draft-aware consumer (doctor's orphan sweep, the daemon skip, abort)
+// would then treat real work as disposable.
+func TestDraftWrite_RefusesOnceRealTranscriptBytesArePresent(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxBytes"
+
+	f.publish(t, sessionName, 2)
+	sessionDir := draftLedgerSessionDir(f.ledgerPath, sessionName)
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"), []byte(`{"type":"user"}`), 0644))
+
+	err := lfs.WriteDraftSessionMeta(context.Background(), sessionDir, lfs.DraftInput{
+		SessionName: sessionName, SessionID: draftTestSessionID,
+		AgentID: "OxDraft", AgentType: "claude-code", CreatedAt: time.Now(), TurnCount: 12,
+	})
+	require.ErrorIs(t, err, lfs.ErrDraftDirNotEmpty)
+
+	meta, readErr := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, readErr)
+	assert.Equal(t, 2, meta.TurnCount, "the refused refresh must not have mutated the meta")
+}
+
+// TestDraftPublish_EmptyManifestAndNoPointerFiles is the LFS invariant at
+// publish time: nothing to upload, nothing to orphan, nothing to reconcile.
+func TestDraftPublish_EmptyManifestAndNoPointerFiles(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxLfs"
+	f.publish(t, sessionName, 2)
+
+	sessionDir := draftLedgerSessionDir(f.ledgerPath, sessionName)
+	meta, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.True(t, meta.IsDraft())
+	assert.Empty(t, meta.Files, "a draft must claim no LFS objects")
+
+	entries, err := os.ReadDir(sessionDir)
+	require.NoError(t, err)
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	assert.Equal(t, []string{"meta.json"}, names,
+		"a draft directory must contain exactly meta.json — no raw.jsonl, no .recording.json")
+}
+
+// TestSessionsGitignore_ExcludesRecordingMarker.
+//
+// One line of .gitignore kills an entire kill chain: a .recording.json
+// committed into a git-tracked session dir makes the daemon's anti-entropy
+// treat it as a recovery opportunity and write REAL transcript bytes onto the
+// tracked raw.jsonl, breaking LFS linkage team-wide. Drafts make that directory
+// a live working area for the first time, so the marker only has to land once.
+func TestSessionsGitignore_ExcludesRecordingMarker(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, lfs.EnsureSessionsGitignore(dir))
+	body, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), ".recording.json")
+	assert.Contains(t, string(body), ".needs-summary", "the pre-existing exclusion must survive")
+}
+
+// --- supersession ---------------------------------------------------------
+
+// TestSupersedeDraft_PurgesServerAuthoredArtifacts is the scenario the whole
+// provisionality invariant exists for.
+//
+// The SageOx server may summarize a zero-turn draft, write summary.json /
+// summary.md, and push them. A finalize-time `git pull --rebase` folds them
+// into our working tree. Without a wholesale purge, that fabricated summary of
+// an empty session is committed as the finished session's summary and becomes
+// permanent, citable team history.
+func TestSupersedeDraft_PurgesServerAuthoredArtifacts(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxSup"
+
+	f.publish(t, sessionName, 2)
+	f.push(t)
+
+	// Another writer (the server) authors artifacts against the draft.
+	other := cloneBare(t, f.barePath)
+	otherSessionDir := filepath.Join(other, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(otherSessionDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(otherSessionDir, "summary.md"),
+		[]byte("SERVER_AUTHORED_SENTINEL"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(otherSessionDir, "summary.json"),
+		[]byte(`{"title":"Zero-turn session","files_changed":["SERVER.md"]}`), 0644))
+	runGit(t, other, "add", "-A")
+	runGit(t, other, "commit", "--no-verify", "-m", "server: summarize draft")
+	runGit(t, other, "push")
+
+	// Our finalize pulls those in, then supersedes.
+	runGit(t, f.ledgerPath, "pull", "--rebase", "--autostash")
+	require.FileExists(t, filepath.Join(f.ledgerPath, "sessions", sessionName, "summary.json"),
+		"fixture precondition: the server artifacts must actually be in our tree")
+
+	preservedID, wasDraft, err := supersedeDraftForFinalize(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	assert.True(t, wasDraft)
+	assert.Equal(t, draftTestSessionID, preservedID,
+		"the ses_ id must be read before the purge deletes the file carrying it")
+
+	// Everything provisional is gone from the worktree, INCLUDING the directory
+	// itself: an empty leftover directory has no meta.json, so listSessionSessions
+	// renders it as a non-draft row that lands in uploadedSessions and displays
+	// as "✓ uploaded" for a session that was never uploaded. Callers
+	// (CopySessionToLedger, the doctor retry, the daemon stager) all mkdir.
+	sessionDir := filepath.Join(f.ledgerPath, "sessions", sessionName)
+	assert.NoDirExists(t, sessionDir)
+
+	// The removal is COMMITTED, not left staged. A staged-but-uncommitted
+	// deletion is the hazard: finalize can fail at several points it is built
+	// to tolerate (LFS upload, meta write, read-only endpoint), and the next
+	// unrelated bare `git commit` would sweep that deletion in under the wrong
+	// message.
+	assert.Empty(t, runGit(t, f.ledgerPath, "status", "--porcelain", "--", "sessions/"),
+		"the purge must leave no staged deletion behind")
+	subjects := commitsTouching(t, f.ledgerPath, "sessions/"+sessionName)
+	require.NotEmpty(t, subjects)
+	assert.Contains(t, subjects[0], "session-draft: supersede",
+		"the purge must land as its own committed removal")
+}
+
+// TestSupersedeDraft_LeavesFinalizedSessionAlone is the negative control.
+// Without it, "purge everything always" passes every test above while
+// destroying finalized sessions.
+func TestSupersedeDraft_LeavesFinalizedSessionAlone(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxFinal"
+
+	sessionDir := draftLedgerSessionDir(f.ledgerPath, sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, &lfs.SessionMeta{
+		SessionName: sessionName, SessionID: draftTestSessionID,
+		CreatedAt: time.Now(), Title: "real work", EntryCount: 40,
+		Files: map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}},
+	}))
+
+	preservedID, wasDraft, err := supersedeDraftForFinalize(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	assert.False(t, wasDraft)
+	assert.Equal(t, draftTestSessionID, preservedID)
+	assert.FileExists(t, filepath.Join(sessionDir, "meta.json"), "a finalized session must never be purged")
+}
+
+// TestSupersedeDraft_UnreadableMetaIsFatal.
+//
+// We cannot tell whether an unreadable meta.json held a ses_ id we would
+// rotate. Proceeding would mint a fresh one and 404 every /c/ link already
+// circulating, so refusing is the only conservative choice.
+func TestSupersedeDraft_UnreadableMetaIsFatal(t *testing.T) {
+	f := newDraftGuardFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxCorrupt"
+
+	sessionDir := draftLedgerSessionDir(f.ledgerPath, sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "meta.json"), []byte(`{"draft":tr`), 0644))
+
+	_, _, err := supersedeDraftForFinalize(f.ledgerPath, sessionName)
+	require.Error(t, err)
+	assert.FileExists(t, filepath.Join(sessionDir, "meta.json"), "a fatal classification must not delete anything")
+}
+
+// TestCommitDraftRetraction_RemovesDraftForZeroEntrySession.
+//
+// A stop that produced no entries never writes a real session. Without an
+// explicit retraction the /c/ page claims "in progress" forever AND the ledger
+// is left holding a staged deletion that the next unrelated commit sweeps up
+// under the wrong message.
+func TestCommitDraftRetraction_RemovesDraftForZeroEntrySession(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxZero"
+
+	f.publish(t, sessionName, 2)
+	f.push(t)
+	require.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+
+	_, wasDraft, err := supersedeDraftForFinalize(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	require.True(t, wasDraft)
+	require.NoError(t, commitDraftRetraction(f.ledgerPath, sessionName))
+
+	assert.NotContains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json",
+		"the retraction must reach the remote, not just the local index")
+	assert.Empty(t, runGit(t, f.ledgerPath, "status", "--porcelain", "--", "sessions/"),
+		"no staged deletion may be left behind to poison the next commit")
+	gitFsckClean(t, f.barePath)
+}
+
+// --- commit scoping -------------------------------------------------------
+
+// TestCommitDraftLocally_DoesNotSweepCoStagedFiles.
+//
+// A bare `git commit` writes the WHOLE index. Drafts fire every N turns from
+// every agent sharing a ledger clone, so a file another session left staged
+// after a failed finalize would routinely ride along under a draft's message —
+// and, worse, be pushed by the daemon's draft-push cycle before its LFS blobs
+// exist.
+func TestCommitDraftLocally_DoesNotSweepCoStagedFiles(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionA = "2026-01-01T00-00-testuser-OxAaaa"
+	const sessionB = "2026-01-01T00-00-testuser-OxBbbb"
+
+	// Agent A crashed mid-publish: its meta.json is staged but not committed.
+	f.writeDraft(t, sessionA, 2)
+	runGit(t, f.ledgerPath, "add", "--sparse", "sessions/"+sessionA+"/meta.json")
+
+	// Agent B publishes.
+	f.publish(t, sessionB, 2)
+
+	committed := runGit(t, f.ledgerPath, "log", "-1", "--format=", "--name-only")
+	assert.Contains(t, committed, sessionB)
+	assert.NotContains(t, committed, sessionA,
+		"B's draft commit swept up A's staged file")
+
+	stillStaged := runGit(t, f.ledgerPath, "diff", "--cached", "--name-only")
+	assert.Contains(t, stillStaged, sessionA, "A's staged file must remain staged, not be silently committed")
+}
+
+// TestCommitDraftLocally_DoesNotPush.
+//
+// The push is deferred to the daemon's sync cycle on purpose: pushLedger is a
+// secret scan plus a credential refresh plus an LFS reconcile plus a 3-attempt
+// rebase loop, and paying that on a turn boundary is what this design avoids.
+// If someone "helpfully" adds a push here, the agent's turn gets seconds slower
+// and this test says so.
+func TestCommitDraftLocally_DoesNotPush(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxNoPush"
+
+	f.publish(t, sessionName, 2)
+
+	assert.NotContains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json",
+		"commitDraftLocally must not push")
+	ahead := runGit(t, f.ledgerPath, "rev-list", "--count", "@{upstream}..HEAD")
+	assert.Equal(t, "1", ahead, "exactly one unpushed draft commit should be waiting for the daemon")
+}
+
+// TestCommitDraftLocally_Idempotent — a refresh with identical counters must
+// not produce an empty commit per turn.
+func TestCommitDraftLocally_Idempotent(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxIdem"
+
+	f.publish(t, sessionName, 2)
+	before := commitCount(t, f.ledgerPath)
+
+	require.NoError(t, commitDraftLocally(f.ledgerPath, sessionName))
+	assert.Equal(t, before, commitCount(t, f.ledgerPath), "an unchanged draft must not create a commit")
+}
+
+// --- crash recovery -------------------------------------------------------
+
+// TestDraftPublish_CrashRecovery walks the publish sequence and kills the
+// process after each step, asserting the next invocation converges.
+func TestDraftPublish_CrashRecovery(t *testing.T) {
+	// Hoisted to the parent so `-short` reports SKIP rather than a PASS whose
+	// every subtest silently skipped. A green parent over an empty table reads
+	// as coverage in the run developers actually do.
+	if testing.Short() {
+		t.Skip("short: real git operations")
+	}
+	const sessionName = "2026-01-01T00-00-testuser-OxCrash"
+
+	t.Run("crash after mkdir, before writing meta", func(t *testing.T) {
+		f := newDraftLedgerFixture(t)
+		require.NoError(t, os.MkdirAll(draftLedgerSessionDir(f.ledgerPath, sessionName), 0755))
+
+		f.publish(t, sessionName, 2)
+		f.push(t)
+		assert.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+	})
+
+	t.Run("crash after writing meta, before git add", func(t *testing.T) {
+		f := newDraftLedgerFixture(t)
+		f.writeDraft(t, sessionName, 2)
+
+		// The orphaned meta.json is still the ses_ id carrier.
+		id, isDraft, err := lfs.PreservedSessionIDAndDraft(draftLedgerSessionDir(f.ledgerPath, sessionName))
+		require.NoError(t, err)
+		assert.True(t, isDraft)
+		assert.Equal(t, draftTestSessionID, id)
+
+		f.publish(t, sessionName, 3)
+		assert.Len(t, commitsTouching(t, f.ledgerPath, "sessions/"+sessionName), 1,
+			"the retry must produce exactly one commit, not a duplicate")
+	})
+
+	t.Run("crash after git add, before commit", func(t *testing.T) {
+		f := newDraftLedgerFixture(t)
+		f.writeDraft(t, sessionName, 2)
+		runGit(t, f.ledgerPath, "add", "--sparse", "sessions/"+sessionName+"/meta.json")
+
+		f.publish(t, sessionName, 3)
+		assert.Len(t, commitsTouching(t, f.ledgerPath, "sessions/"+sessionName), 1)
+		assert.Empty(t, runGit(t, f.ledgerPath, "status", "--porcelain", "--", "sessions/"),
+			"no staged-but-uncommitted leftovers under sessions/")
+	})
+
+	t.Run("crash after commit, before push: the next push lands it", func(t *testing.T) {
+		f := newDraftLedgerFixture(t)
+		f.publish(t, sessionName, 2)
+		require.NotContains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+
+		// This is the normal path — the daemon's cycle pushes it later.
+		f.push(t)
+		assert.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+		assert.Equal(t, "0", runGit(t, f.ledgerPath, "rev-list", "--count", "@{upstream}..HEAD"))
+		gitFsckClean(t, f.barePath)
+	})
+
+	t.Run("push failed once, retry lands it with no duplicate commit", func(t *testing.T) {
+		f := newDraftLedgerFixture(t)
+		f.publish(t, sessionName, 2)
+
+		runGit(t, f.ledgerPath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "gone.git"))
+		require.Error(t, pushLedger(context.Background(), f.ledgerPath),
+			"fixture precondition: the push must actually fail")
+		assert.Len(t, commitsTouching(t, f.ledgerPath, "sessions/"+sessionName), 1,
+			"the local commit must survive a push failure")
+
+		runGit(t, f.ledgerPath, "remote", "set-url", "origin", f.barePath)
+		f.push(t)
+		assert.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+		assert.Len(t, commitsTouching(t, f.barePath, "sessions/"+sessionName), 1)
+		gitFsckClean(t, f.barePath)
+	})
+}
+
+// --- concurrency ----------------------------------------------------------
+
+// TestConcurrentDraftPublish_SameSession.
+//
+// RecordingState is an unlocked load-modify-save, so two Stop hooks can both
+// cross the publish threshold. The durable guard has to be the committed
+// meta.json, not the in-memory counter. Losses to index.lock contention are
+// tolerated (the same convention as TestConcurrentSessionUploads_Parallel);
+// what must hold is that the repo is not corrupted and no commit adds the same
+// path twice.
+func TestConcurrentDraftPublish_SameSession(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxRace"
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(turn int) {
+			defer wg.Done()
+			_ = lfs.WriteDraftSessionMeta(context.Background(),
+				draftLedgerSessionDir(f.ledgerPath, sessionName), lfs.DraftInput{
+					SessionName: sessionName, SessionID: draftTestSessionID,
+					AgentID: "OxDraft", AgentType: "claude-code",
+					CreatedAt: time.Now(), TurnCount: turn,
+				})
+			_ = commitDraftLocally(f.ledgerPath, sessionName)
+		}(2 + i)
+	}
+	wg.Wait()
+
+	adds := 0
+	for _, subject := range commitsTouching(t, f.ledgerPath, "sessions/"+sessionName) {
+		assert.True(t, strings.HasPrefix(subject, "session-draft: "),
+			"unexpected commit subject touching a draft: %q", subject)
+		adds++
+	}
+	assert.GreaterOrEqual(t, adds, 1, "at least one publish must land")
+
+	meta, err := lfs.ReadSessionMeta(draftLedgerSessionDir(f.ledgerPath, sessionName))
+	require.NoError(t, err)
+	assert.True(t, meta.IsDraft())
+	assert.Equal(t, draftTestSessionID, meta.SessionID, "no racer may rotate the id")
+
+	f.push(t)
+	gitFsckClean(t, f.barePath)
+}
+
+// TestConcurrentDraftPublish_DistinctSessions is the multi-agent monorepo case:
+// four agents sharing one ledger clone. Each commit must reference exactly one
+// session directory.
+func TestConcurrentDraftPublish_DistinctSessions(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			name := fmt.Sprintf("2026-01-01T00-00-testuser-OxM%03d", n)
+			_ = lfs.WriteDraftSessionMeta(context.Background(),
+				draftLedgerSessionDir(f.ledgerPath, name), lfs.DraftInput{
+					SessionName: name,
+					SessionID:   fmt.Sprintf("ses_01950000-0000-7000-8000-0000000000%02d", n),
+					AgentID:     fmt.Sprintf("OxM%03d", n), AgentType: "claude-code",
+					CreatedAt: time.Now(), TurnCount: 2,
+				})
+			_ = commitDraftLocally(f.ledgerPath, name)
+		}(i)
+	}
+	wg.Wait()
+
+	out := runGit(t, f.ledgerPath, "log", "--format=COMMIT %s", "--name-only", "@{upstream}..HEAD")
+	var current string
+	seen := map[string]map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "COMMIT ") {
+			current = strings.TrimPrefix(line, "COMMIT ")
+			seen[current] = map[string]bool{}
+			continue
+		}
+		// sessions/.gitignore is shared infrastructure every draft commit may
+		// legitimately touch — it is not a session directory.
+		if line == "" || current == "" || !strings.HasPrefix(line, "sessions/") ||
+			line == "sessions/.gitignore" {
+			continue
+		}
+		parts := strings.Split(line, "/")
+		if len(parts) > 1 {
+			seen[current][parts[1]] = true
+		}
+	}
+	for subject, dirs := range seen {
+		assert.LessOrEqual(t, len(dirs), 1,
+			"commit %q touched %d session dirs; draft commits must be pathspec-scoped to one", subject, len(dirs))
+	}
+
+	f.push(t)
+	gitFsckClean(t, f.barePath)
+}
+
+// --- guarded index mutation (P0 regressions) ------------------------------
+
+// TestDraftWrite_RefusesDuringRebase is the highest-value test in this file.
+//
+// It pins the team-wide data-destruction bug: during a conflicted rebase,
+// `git add` MARKS THE CONFLICT RESOLVED and `git commit -- <pathspec>` SUCCEEDS
+// on the detached rebase HEAD, consuming the replay step. The next
+// `rebase --continue` reports "Successfully rebased" and the commit being
+// replayed — a teammate's finalize, a murmur, a plan — is silently gone.
+//
+// Draft writes are the first ledger index writer that deliberately does not
+// push, so they miss the IsSafeForGitOps check that rides along with
+// PushWithRetry for every other writer.
+//
+// Red-first check: delete the assertLedgerSafeForDraftWrite call from
+// prepareDraftLedgerWrite and this test fails by LOSING the local commit.
+func TestDraftWrite_RefusesDuringRebase(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxRbse"
+
+	// Build a real divergence on a path both sides touch, so the rebase
+	// genuinely conflicts rather than fast-forwarding.
+	conflictPath := filepath.Join(f.ledgerPath, "sessions", sessionName, "meta.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(conflictPath), 0755))
+
+	other := cloneBare(t, f.barePath)
+	otherPath := filepath.Join(other, "sessions", sessionName, "meta.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(otherPath), 0755))
+	require.NoError(t, os.WriteFile(otherPath, []byte(`{"session_name":"remote-side"}`), 0644))
+	runGit(t, other, "add", "-A")
+	runGit(t, other, "commit", "--no-verify", "-m", "remote side")
+	runGit(t, other, "push")
+
+	require.NoError(t, os.WriteFile(conflictPath, []byte(`{"session_name":"local-side"}`), 0644))
+	runGit(t, f.ledgerPath, "add", "-A")
+	runGit(t, f.ledgerPath, "commit", "--no-verify", "-m", "LOCAL_SIDE_MUST_SURVIVE")
+	localSHA := runGit(t, f.ledgerPath, "rev-parse", "HEAD")
+
+	// Start a rebase and let it stop on the conflict.
+	runGit(t, f.ledgerPath, "fetch", "origin")
+	rebase := exec.Command("git", "-C", f.ledgerPath, "rebase", "origin/"+currentBranch(t, f.ledgerPath))
+	_ = rebase.Run() // expected to fail with a conflict
+	require.True(t, gitutil.IsRebaseInProgress(f.ledgerPath),
+		"fixture precondition: the rebase must actually be stopped mid-replay")
+
+	// A Stop hook fires now. It must refuse.
+	err := commitDraftLocally(f.ledgerPath, sessionName)
+	require.ErrorIs(t, err, errDraftUnsafeLedger,
+		"a draft write during a rebase must refuse, not silently consume the replay step")
+
+	// The replay is still pending, and the commit being replayed still exists.
+	assert.True(t, gitutil.IsRebaseInProgress(f.ledgerPath), "the rebase must be untouched")
+	assert.Contains(t, runGit(t, f.ledgerPath, "cat-file", "-t", localSHA), "commit",
+		"the commit being replayed must still exist")
+
+	// Every other draft git path must refuse too — they are all index writers.
+	_, purgeErr := deleteDraftFromLedger(f.ledgerPath, sessionName)
+	assert.Error(t, purgeErr, "deleteDraftFromLedger must not mutate the index mid-rebase")
+	assert.ErrorIs(t, purgeDraftSessionDir(f.ledgerPath, sessionName), errDraftUnsafeLedger)
+}
+
+func currentBranch(t *testing.T, dir string) string {
+	t.Helper()
+	return runGit(t, dir, "rev-parse", "--abbrev-ref", "HEAD")
+}
+
+// TestDraftCommit_RefusesWhenWorktreeChangedAfterStaging.
+//
+// `git commit -- <pathspec>` commits the WORKING TREE at those paths, not the
+// index that was just built. A concurrent finalize rewrites this exact
+// meta.json, so without a re-check the finalize's bytes — LFS OIDs and all —
+// land under a "session-draft:" subject. The daemon's push filter keys on that
+// subject, so it would then push a finalize-shaped commit with neither the LFS
+// reconcile nor the pre-push secret gate the CLI applies.
+//
+// Red-first check: delete assertDraftStillStaged and the committed blob becomes
+// the finalize's content.
+func TestDraftCommit_RefusesWhenWorktreeChangedAfterStaging(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxSwap"
+
+	f.writeDraft(t, sessionName, 2)
+	metaPath := filepath.Join(draftLedgerSessionDir(f.ledgerPath, sessionName), "meta.json")
+	runGit(t, f.ledgerPath, "add", "--sparse", "--", "sessions/"+sessionName+"/meta.json")
+
+	// A finalize lands between `git add` and `git commit`.
+	require.NoError(t, os.WriteFile(metaPath,
+		[]byte(`{"session_name":"`+sessionName+`","session_id":"`+draftTestSessionID+
+			`","files":{"raw.jsonl":{"oid":"sha256:deadbeef","size":10}}}`), 0644))
+
+	err := assertDraftStillStaged(f.ledgerPath, sessionName,
+		draftStagePaths(sessionName))
+	require.Error(t, err, "the pre-commit re-check must catch a worktree swap")
+
+	// And the full publish path must refuse rather than commit foreign bytes.
+	require.Error(t, commitDraftLocally(f.ledgerPath, sessionName))
+	assert.Empty(t, commitsTouching(t, f.ledgerPath, "sessions/"+sessionName),
+		"no commit may be created from bytes another writer owns")
+}
+
+// TestDraftSessionName_RejectsPathTraversal.
+//
+// draftSessionRelDir("") is "sessions" and filepath.Base("") is ".", so an
+// empty or traversal-shaped name turns the purge and the abort-delete into
+// `git rm -r --force -- sessions` plus os.RemoveAll of the ENTIRE sessions
+// tree. That was reachable only by accident before (the paths first require a
+// draft meta.json to exist), which is not a guarantee.
+func TestDraftSessionName_RejectsPathTraversal(t *testing.T) {
+	for _, name := range []string{"", ".", "..", "../evil", "a/b", `a\b`, "foo/../.."} {
+		t.Run("name="+name, func(t *testing.T) {
+			require.Error(t, validateDraftSessionName(name))
+		})
+	}
+	require.NoError(t, validateDraftSessionName("2026-01-01T00-00-testuser-OxOk01"))
+}
+
+// TestDraftSessionName_GuardIsWiredIntoEveryWriter proves the validation is not
+// merely defined but actually reached — a guard nobody calls is decoration.
+func TestDraftSessionName_GuardIsWiredIntoEveryWriter(t *testing.T) {
+	f := newDraftGuardFixture(t)
+
+	// Sanity: the whole sessions tree exists and must survive every call below.
+	sessionsDir := filepath.Join(f.ledgerPath, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionsDir, "canary.txt"), []byte("keep me"), 0644))
+
+	for _, bad := range []string{"", ".", "../evil"} {
+		assert.Error(t, commitDraftLocally(f.ledgerPath, bad), "commitDraftLocally(%q)", bad)
+		assert.Error(t, purgeDraftSessionDir(f.ledgerPath, bad), "purgeDraftSessionDir(%q)", bad)
+		_, err := deleteDraftFromLedger(f.ledgerPath, bad)
+		assert.Error(t, err, "deleteDraftFromLedger(%q)", bad)
+	}
+
+	assert.FileExists(t, filepath.Join(sessionsDir, "canary.txt"),
+		"a malformed session name must never widen a pathspec to the whole sessions tree")
+}
+
+// TestResolveDraftLedgerPath_RefusesNonLedgerTargets.
+//
+// deriveLedgerPath returns filepath.Dir for ANY path whose parent is named
+// "sessions" — which includes the XDG cache and the legacy in-repo fallback,
+// where the derived "ledger" is the USER'S OWN PROJECT ROOT. Its prior callers
+// only built IPC payloads, so a wrong answer was inert. This is the first
+// caller that runs `git commit`, and committing a placeholder into someone's
+// product repo would be an unrecoverable trust failure.
+func TestResolveDraftLedgerPath_RefusesNonLedgerTargets(t *testing.T) {
+	f := newDraftGuardFixture(t)
+
+	// The real ledger resolves.
+	realSession := filepath.Join(f.ledgerPath, "sessions", "2026-01-01T00-00-testuser-OxReal")
+	assert.Equal(t, f.ledgerPath, resolveDraftLedgerPath(f.projectRoot, realSession))
+
+	// A session path inside the user's own project does NOT.
+	inRepo := filepath.Join(f.projectRoot, "sessions", "2026-01-01T00-00-testuser-OxRepo")
+	assert.Empty(t, resolveDraftLedgerPath(f.projectRoot, inRepo),
+		"a path deriving to the user's project root must never be treated as a ledger")
+
+	// Nor does an unrelated XDG-shaped cache path.
+	xdg := filepath.Join(t.TempDir(), "sessions", "2026-01-01T00-00-testuser-OxXdg")
+	assert.Empty(t, resolveDraftLedgerPath(f.projectRoot, xdg))
+}
+
+// --- end-to-end lifecycle -------------------------------------------------
+
+// TestDraftLifecycle_EndToEnd_ManifestMatchesTree.
+//
+// Every other test in this file exercises one stage. This one walks the whole
+// arc a real session takes — publish, refresh, supersede, finalize, push — and
+// asserts the terminal state through a FRESH clone, which is what teammates
+// actually see.
+//
+// The load-bearing assertion is the conservation law:
+//
+//	set(meta.Files) ∪ {meta.json} == set(git tree for that session)
+//
+// It catches drift in BOTH directions, which no single-sided assertion does:
+//   - a manifest entry with no blob in the tree means the ledger's pre-receive
+//     hook starts rejecting pushes with "LFS objects are missing", for everyone;
+//   - a blob in the tree with no manifest entry is a stowaway — exactly the
+//     server-authored draft-era artifact this feature has to purge.
+//
+// LFS transport is deliberately not exercised (that is internal/lfs's job and
+// it has its own batch-server harness). What IS exercised is the part drafts
+// put at risk: staging scope, pointer-vs-content on the tracked path, id
+// stability across the purge, and the shape of the final commit.
+func TestDraftLifecycle_EndToEnd_ManifestMatchesTree(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxE2E1"
+
+	// --- turns 2 and 12: publish, then refresh ---
+	f.publish(t, sessionName, 2)
+	f.publish(t, sessionName, 12)
+	f.push(t)
+	require.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+
+	// The server summarizes the zero-turn placeholder and pushes.
+	other := cloneBare(t, f.barePath)
+	otherDir := filepath.Join(other, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(otherDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "summary.md"),
+		[]byte("SERVER_AUTHORED_SENTINEL"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "summary.json"),
+		[]byte(`{"title":"Zero-turn session","files_changed":[{"path":"SERVER.md"}]}`), 0644))
+	// An artifact our finalize does NOT produce. This is the case the ADR's
+	// "wholesale purge, never a whitelist" rule exists for: a file the server
+	// invents later, which no overwrite can displace. Without the purge it
+	// survives into the finalized session as a tree blob with no manifest
+	// entry — and it is the ONLY server file here that the conservation law
+	// can catch, because finalize overwrites the other two by name.
+	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "summary.html"),
+		[]byte("<h1>SERVER_INVENTED_ARTIFACT</h1>"), 0644))
+	runGit(t, other, "add", "-A")
+	runGit(t, other, "commit", "--no-verify", "-m", "server: summarize draft")
+	runGit(t, other, "push")
+	runGit(t, f.ledgerPath, "pull", "--rebase", "--autostash")
+	require.FileExists(t, filepath.Join(f.ledgerPath, "sessions", sessionName, "summary.html"),
+		"fixture precondition: the server-invented artifact must really be in our tree")
+
+	// --- session stop: supersede, then write the real recording ---
+	preservedID, wasDraft, err := supersedeDraftForFinalize(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	require.True(t, wasDraft)
+	require.Equal(t, draftTestSessionID, preservedID,
+		"the id must be read before the purge deletes the file carrying it")
+
+	sessionDir := draftLedgerSessionDir(f.ledgerPath, sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	rawBody := `{"type":"header","metadata":{"session_id":"` + draftTestSessionID + `"}}` + "\n" +
+		`{"ts":"2026-01-01T00:05:00Z","type":"user","content":"OX_E2E_TRANSCRIPT_SENTINEL"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"), []byte(rawBody), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "summary.md"), []byte("OUR REAL SUMMARY"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "summary.json"),
+		[]byte(`{"title":"Real work","files_changed":[{"path":"real.go"}]}`), 0644))
+
+	// The manifest the finalize would produce (OIDs stand in for a real upload).
+	refs := map[string]lfs.FileRef{
+		"raw.jsonl":  lfs.NewFileRef([]byte(rawBody)),
+		"summary.md": lfs.NewFileRef([]byte("OUR REAL SUMMARY")),
+	}
+	finalMeta := &lfs.SessionMeta{
+		Version: "1.0", SessionName: sessionName,
+		SessionID: session.ResolveOrMintSessionID(preservedID, ""),
+		AgentID:   "OxDraft", AgentType: "claude-code",
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Title:     "Real work", EntryCount: 1, Files: refs,
+	}
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, finalMeta))
+	registerGitArtifactInMeta(sessionDir, "summary.json", 64)
+
+	require.NoError(t, commitAndPushLedger(f.ledgerPath, sessionName))
+	// Content becomes pointers only after the push succeeds.
+	_, err = lfs.WritePointerFiles(sessionDir, refs)
+	require.NoError(t, err)
+	require.NoError(t, commitPointerRewriteAndPush(f.ledgerPath, sessionName,
+		[]string{filepath.Join("sessions", sessionName, "raw.jsonl"),
+			filepath.Join("sessions", sessionName, "summary.md")}))
+
+	// --- assert the terminal state through a FRESH clone ---
+	fresh := cloneBare(t, f.barePath)
+	freshDir := filepath.Join(fresh, "sessions", sessionName)
+
+	blob := runGit(t, f.barePath, "show", "HEAD:sessions/"+sessionName+"/meta.json")
+	assert.NotContains(t, blob, `"draft"`, "the finalized meta must carry no draft key at all")
+	assert.Contains(t, blob, draftTestSessionID, "the ses_ id must be stable across the whole arc")
+
+	freshMeta, err := lfs.ReadSessionMeta(freshDir)
+	require.NoError(t, err)
+	assert.False(t, freshMeta.IsDraft())
+	assert.Zero(t, freshMeta.TurnCount, "draft counters must not survive")
+	assert.Nil(t, freshMeta.UpdatedAt)
+
+	// The server-authored draft-era summary must be gone, ours in its place.
+	summaryMD, err := os.ReadFile(filepath.Join(freshDir, "summary.md"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(summaryMD), "SERVER_AUTHORED_SENTINEL",
+		"a summary of the zero-turn placeholder must never survive into the finalized session")
+
+	// raw.jsonl on the tracked path is a POINTER, never the transcript.
+	assert.True(t, lfs.IsPointerFile(filepath.Join(freshDir, "raw.jsonl")),
+		"the git-tracked raw.jsonl must be an LFS pointer")
+	pointerBody, err := os.ReadFile(filepath.Join(freshDir, "raw.jsonl"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(pointerBody), "OX_E2E_TRANSCRIPT_SENTINEL")
+
+	// THE CONSERVATION LAW.
+	inTree := map[string]bool{}
+	for _, p := range remoteTree(t, f.barePath) {
+		if rel, ok := strings.CutPrefix(p, "sessions/"+sessionName+"/"); ok {
+			inTree[rel] = true
+		}
+	}
+	expected := map[string]bool{"meta.json": true}
+	for name := range freshMeta.Files {
+		expected[name] = true
+	}
+	assert.Equal(t, expected, inTree,
+		"every manifest entry must exist in the tree and every tree blob must be in the manifest")
+
+	gitFsckClean(t, f.barePath)
+}
+
+// TestDraftLifecycle_RefreshAfterFinalizeCannotResurrectDraft.
+//
+// Finalize is the ABSORBING state. A refresh that lands afterward — a Stop hook
+// that was already in flight when the session stopped — must not stamp
+// draft:true back onto a finished session. If it did, the /c/ page would revert
+// to "in progress" permanently, doctor would refuse to repair the session, and
+// the orphan reaper would eventually offer to delete a real recording's
+// directory.
+func TestDraftLifecycle_RefreshAfterFinalizeCannotResurrectDraft(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxAbsrb"
+
+	f.publish(t, sessionName, 2)
+	_, wasDraft, err := supersedeDraftForFinalize(f.ledgerPath, sessionName)
+	require.NoError(t, err)
+	require.True(t, wasDraft)
+
+	// Finalize writes the real session.
+	sessionDir := draftLedgerSessionDir(f.ledgerPath, sessionName)
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, &lfs.SessionMeta{
+		Version: "1.0", SessionName: sessionName, SessionID: draftTestSessionID,
+		CreatedAt: time.Now(), Title: "Real work", EntryCount: 40,
+		Files: map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}},
+	}))
+
+	// A late refresh arrives.
+	err = lfs.WriteDraftSessionMeta(context.Background(), sessionDir, lfs.DraftInput{
+		SessionName: sessionName, SessionID: draftTestSessionID,
+		AgentID: "OxDraft", AgentType: "claude-code", CreatedAt: time.Now(), TurnCount: 12,
+	})
+	require.ErrorIs(t, err, lfs.ErrNotDraft,
+		"a finished session must refuse to be downgraded back to a placeholder")
+
+	meta, readErr := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, readErr)
+	assert.False(t, meta.IsDraft())
+	assert.Equal(t, "Real work", meta.Title, "the finalized meta must be untouched")
+	assert.Equal(t, 40, meta.EntryCount)
+
+	// And the full publish path is a no-op too, not a commit.
+	before := commitCount(t, f.ledgerPath)
+	assert.False(t, publishDraftPlaceholder(f.projectRoot, f.ledgerPath, sessionName,
+		&session.RecordingState{
+			AgentID: "OxDraft", SessionID: draftTestSessionID, TurnCount: 12,
+			SessionPath: sessionDir,
+		}),
+		"publishDraftPlaceholder must report failure rather than resurrect the draft")
+	assert.Equal(t, before, commitCount(t, f.ledgerPath), "no commit may be produced")
+}

--- a/cmd/ox/session_draft_publish.go
+++ b/cmd/ox/session_draft_publish.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/sageox/ox/internal/auth"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
+	"github.com/sageox/ox/internal/identity"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+)
+
+// maybePublishSessionDraft increments the turn counter and, at the configured
+// turn, publishes (or refreshes) a meta.json-only draft placeholder in the
+// ledger so https://<endpoint>/c/<session_id> resolves while the session is
+// still running.
+//
+// Entirely best-effort. Every failure is a log line and a silent return: a hook
+// must never fail a turn, and no correctness property depends on a draft
+// existing. The worst outcome of a total failure here is the pre-draft
+// behavior — the /c/ link stays unresolvable until session stop.
+//
+// Called ONLY from the Stop hook. The Stop phase means "the agent finished
+// responding" and fires exactly once per completed turn, which makes it the
+// only real turn signal ox has. It must NOT be called from the afterTool
+// handler: that also runs on PostToolUse, so counting there counts tool calls
+// rather than turns and the draft would publish on the wrong turn.
+func maybePublishSessionDraft(ctx *HookContext) {
+	if ctx == nil || ctx.Marker == nil || ctx.Marker.AgentID == "" {
+		return
+	}
+	agentID := ctx.Marker.AgentID
+
+	// Recording state FIRST. It is the only thing that can make anything else
+	// matter, and its absence — no active recording for this agent — is the
+	// true common case across all the hooks that fire in a repo. Loading config
+	// before this made every Stop hook in every repo parse two config files
+	// just to discover there was nothing to do. The turn counter is still
+	// maintained when drafts are disabled, so `ox session status` reports turn
+	// counts and enabling the feature mid-session behaves sensibly.
+	var state *session.RecordingState
+	err := session.UpdateRecordingStateForAgent(ctx.ProjectRoot, agentID, func(s *session.RecordingState) {
+		s.TurnCount++
+		snapshot := *s
+		state = &snapshot
+	})
+	if err != nil || state == nil {
+		slog.Debug("draft: no recording state for turn count", "agent_id", agentID, "error", err)
+		return
+	}
+
+	// Cheapest possible early-out before touching config: below the publish
+	// threshold nothing can happen regardless of how the feature is configured.
+	// DraftPublishTurn is a constant, so this costs one comparison.
+	if state.TurnCount < config.DraftPublishTurn && state.DraftAttemptTurn == 0 {
+		return
+	}
+
+	resolved := config.ResolveSessionDraft()
+
+	// Same gate as notifySessionStartedAsync. If session attribution is off
+	// there is no /c/ page to make resolvable, so publishing a draft would be
+	// pure ledger noise. Every session-link surface stays on one switch.
+	if attr := loadResolvedAttribution(); attr.Session == "" {
+		resolved = &config.ResolvedSessionDraft{Enabled: false}
+	}
+
+	action := draftDecision(state.TurnCount, state.DraftPublishedTurn, state.DraftPublishedAt != nil, resolved)
+	if action == draftActionNone {
+		return
+	}
+
+	ledgerPath := resolveDraftLedgerPath(ctx.ProjectRoot, state.SessionPath)
+	if ledgerPath == "" {
+		return
+	}
+
+	sessionName := session.GetSessionName(state.SessionPath)
+	published := publishDraftPlaceholder(ctx.ProjectRoot, ledgerPath, sessionName, state)
+
+	// DraftAttemptTurn records every attempt; DraftPublishedTurn and
+	// DraftPublishedAt record only successes. Keeping them apart is what lets
+	// `ox session status` distinguish "published and healthy" from "published
+	// once, and every refresh since has failed" — and it keeps the refresh
+	// interval anchored to the last thing that actually landed.
+	turn := state.TurnCount
+	_ = session.UpdateRecordingStateForAgent(ctx.ProjectRoot, agentID, func(s *session.RecordingState) {
+		s.DraftAttemptTurn = turn
+		if published {
+			s.DraftPublishedTurn = turn
+			now := time.Now().UTC()
+			s.DraftPublishedAt = &now
+		}
+	})
+}
+
+// resolveDraftLedgerPath returns the ledger this recording belongs to, or ""
+// when it cannot be established with certainty.
+//
+// deriveLedgerPath is a pure string operation that returns filepath.Dir for ANY
+// path whose parent is named "sessions". That set includes the XDG recording
+// cache and the legacy in-repo fallback — where the derived "ledger" is the
+// USER'S OWN PROJECT ROOT. Its three prior callers only built IPC payloads, so
+// a wrong answer was inert. This is the first caller that runs `git add` and
+// `git commit --no-verify` on the result, and committing a placeholder into
+// someone's product repo would be an unrecoverable trust failure.
+//
+// So the derived path is only accepted when it matches the project's CONFIGURED
+// ledger. No match, no draft.
+func resolveDraftLedgerPath(projectRoot, sessionPath string) string {
+	derived := deriveLedgerPath(sessionPath)
+	if derived == "" {
+		slog.Debug("draft: no ledger derivable from session path", "path", sessionPath)
+		return ""
+	}
+	// The project's CONFIGURED ledger, read from its local config rather than
+	// from the process CWD — the hook may run from anywhere in the worktree.
+	configured := ""
+	if localCfg, err := config.LoadLocalConfig(projectRoot); err == nil &&
+		localCfg != nil && localCfg.Ledger != nil {
+		configured = localCfg.Ledger.Path
+	}
+	if configured == "" {
+		if ctx, err := config.LoadProjectContext(projectRoot); err == nil && ctx != nil {
+			configured = ctx.DefaultLedgerPath()
+		}
+	}
+	if configured == "" || filepath.Clean(configured) != filepath.Clean(derived) {
+		slog.Debug("draft: derived path is not this project's ledger",
+			"derived", derived, "configured", configured)
+		return ""
+	}
+	return derived
+}
+
+// publishDraftPlaceholder writes the draft meta.json into the ledger and
+// commits it locally. Returns whether the placeholder is durably committed.
+//
+// The push is deliberately not done here — it is batched onto the daemon's
+// ledger sync cycle by SyncScheduler.pushSessionDraftCommits (~60s). pushLedger
+// is a secret scan plus a credential refresh plus an LFS reconcile plus a
+// three-attempt pull-rebase loop, which is seconds of latency on a turn
+// boundary. If no daemon is running, the local commit still stands and the next
+// pushLedger from any path carries it: session stop, plan commit, or
+// `ox doctor --fix` on an ahead branch.
+func publishDraftPlaceholder(projectRoot, ledgerPath, sessionName string, state *session.RecordingState) bool {
+	if sessionName == "" || state.SessionID == "" {
+		return false
+	}
+
+	ep := endpoint.GetForProject(projectRoot)
+	sessionDir := draftLedgerSessionDir(ledgerPath, sessionName)
+
+	input := lfs.DraftInput{
+		SessionName: sessionName,
+		SessionID:   state.SessionID,
+		Username:    identity.AttributionDisplayName(ep, config.GetDisplayName()),
+		UserID:      auth.GetUserID(ep),
+		RepoID:      getRepoIDOrDefault(projectRoot),
+		AgentID:     state.AgentID,
+		AgentType:   state.AdapterName,
+		Model:       state.Model,
+		CreatedAt:   state.StartedAt,
+		TurnCount:   state.TurnCount,
+		EntryCount:  state.EntryCount,
+		Now:         time.Now(),
+	}
+
+	// Bounded so a wedged flock on meta.json (a concurrent finalize holding it)
+	// cannot hang the agent's turn. Giving up is the correct outcome: the next
+	// refresh retries, and a finalize in flight makes the draft moot anyway.
+	writeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := lfs.WriteDraftSessionMeta(writeCtx, sessionDir, input); err != nil {
+		// ErrNotDraft / ErrDraftDirNotEmpty are expected races, not faults:
+		// a finalize landed between the decision and this write, or a name
+		// collided with a finalized session pulled from the remote.
+		slog.Debug("draft: write skipped", "session", sessionName, "error", err)
+		return false
+	}
+
+	if err := commitDraftLocally(ledgerPath, sessionName); err != nil {
+		slog.Info("draft: local commit failed", "session", sessionName, "error", err)
+		return false
+	}
+	return true
+}

--- a/cmd/ox/session_draft_reaper_test.go
+++ b/cmd/ox/session_draft_reaper_test.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The orphaned-draft reaper is the ONLY thing that ever reclaims a placeholder
+// whose recording died. Everything else deliberately ignores drafts: the
+// daemon's anti-entropy skips them, prune no longer counts them as uploaded,
+// retraction runs only from a clean stop, and deletion only from an explicit
+// abort — none of which a crashed agent reaches.
+//
+// The asymmetry that shapes every test here: a false NEGATIVE leaves a stale
+// "in progress" page, while a false POSITIVE deletes a LIVE session's
+// placeholder. So the conservative direction is always "not an orphan", and
+// each guard gets its own negative control.
+
+// draftReaperFixture is a project + ledger with NO git init and no
+// skipIntegration gate, so the reaper's decision table runs in the fast loop.
+//
+// This matters more than it looks. The table is the guard against DELETING A
+// LIVE SESSION'S placeholder, and findOrphanedDrafts takes explicit paths — it
+// needs no git, no remote, and no daemon. Built on setupLedgerProject it
+// inherited that helper's skipIntegration gate, so under `-short` every subtest
+// skipped while the PARENT still reported PASS: a green, empty table in exactly
+// the run developers do before committing.
+func draftReaperFixture(t *testing.T) (projectRoot, ledgerPath string) {
+	t.Helper()
+	projectRoot = t.TempDir()
+	ledgerPath = t.TempDir()
+
+	// A real `git init`: getLedgerPath resolves through findGitRoot, which
+	// shells out to `git rev-parse --show-toplevel`. Cheap (~10ms) and it keeps
+	// these tests in the fast loop, unlike the full bare-remote fixture.
+	require.NoError(t, exec.Command("git", "-C", projectRoot, "init", "--quiet").Run())
+
+	sageoxDir := filepath.Join(projectRoot, ".sageox")
+	require.NoError(t, os.MkdirAll(sageoxDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sageoxDir, "config.json"),
+		[]byte(`{"config_version":"2","repo_id":"repo_reaper_test"}`), 0644))
+
+	// Register the ledger so the helpers that resolve it internally
+	// (draftViewNotice, checkSessionDraftOrphan) find it, not only the ones
+	// that take explicit paths.
+	require.NoError(t, config.SaveLocalConfig(projectRoot, &config.LocalConfig{
+		Ledger: &config.LedgerConfig{Path: ledgerPath},
+	}))
+
+	cacheDir := t.TempDir()
+	t.Setenv("OX_XDG_ENABLE", "1")
+	t.Setenv("HOME", cacheDir)
+	t.Setenv("XDG_CACHE_HOME", cacheDir)
+	return projectRoot, ledgerPath
+}
+
+// agedDraft writes a draft whose updated_at is `age` in the past.
+// Ages are passed explicitly and far from the 24h threshold rather than nudged
+// by a few seconds, so a slow CI machine can never flip a boundary.
+func agedDraft(t *testing.T, ledgerPath, sessionName string, age time.Duration) string {
+	t.Helper()
+	dir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	updated := time.Now().Add(-age).UTC()
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		Version: "1.0", SessionName: sessionName, SessionID: draftTestSessionID,
+		AgentID: "OxOrphan", CreatedAt: updated,
+		Draft: true, TurnCount: 2, UpdatedAt: &updated,
+		Files: map[string]lfs.FileRef{},
+	}))
+	return dir
+}
+
+// TestFindOrphanedDrafts_OnlyReapsTrulyAbandoned is the whole decision table.
+// Every non-orphan row is a way a LIVE session could be destroyed.
+func TestFindOrphanedDrafts_OnlyReapsTrulyAbandoned(t *testing.T) {
+	setTestCfg(t)
+
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, projectRoot, ledgerPath, sessionName string)
+		wantOrphan bool
+		why        string
+	}{
+		{
+			name: "stale draft with no local data anywhere",
+			setup: func(t *testing.T, _, ledgerPath, name string) {
+				agedDraft(t, ledgerPath, name, 72*time.Hour)
+			},
+			wantOrphan: true,
+			why:        "nothing else will ever reclaim this",
+		},
+		{
+			name: "recently refreshed draft",
+			setup: func(t *testing.T, _, ledgerPath, name string) {
+				agedDraft(t, ledgerPath, name, 1*time.Minute)
+			},
+			why: "a refreshing draft is a LIVE session",
+		},
+		{
+			name: "stale draft whose recording is still in the ledger cache",
+			setup: func(t *testing.T, _, ledgerPath, name string) {
+				agedDraft(t, ledgerPath, name, 72*time.Hour)
+				cache := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", name)
+				require.NoError(t, os.MkdirAll(cache, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(cache, "raw.jsonl"),
+					[]byte(`{"type":"header"}`+"\n"), 0644))
+			},
+			why: "a cached transcript is recoverable work; upload-retry owns it, not the reaper",
+		},
+		{
+			name: "stale draft with an active recording marker in the cache",
+			setup: func(t *testing.T, _, ledgerPath, name string) {
+				agedDraft(t, ledgerPath, name, 72*time.Hour)
+				cache := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", name)
+				require.NoError(t, os.MkdirAll(cache, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(cache, ".recording.json"),
+					[]byte(`{"agent_id":"OxOrphan"}`), 0644))
+			},
+			why: "an existing recording marker means the session may still be alive",
+		},
+		{
+			name: "stale draft whose recording is in the XDG cache",
+			setup: func(t *testing.T, projectRoot, ledgerPath, name string) {
+				agedDraft(t, ledgerPath, name, 72*time.Hour)
+				makeXDGCacheSession(t, projectRoot, name)
+			},
+			why: "the XDG cache is a real session location and must be searched too",
+		},
+		{
+			name: "draft with NO updated_at cannot be aged",
+			setup: func(t *testing.T, _, ledgerPath, name string) {
+				dir := filepath.Join(ledgerPath, "sessions", name)
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+					Version: "1.0", SessionName: name, SessionID: draftTestSessionID,
+					CreatedAt: time.Now().Add(-72 * time.Hour), Draft: true,
+					Files: map[string]lfs.FileRef{},
+				}))
+			},
+			why: "without a heartbeat there is no evidence of death; refuse rather than guess",
+		},
+		{
+			name: "finalized session, however old",
+			setup: func(t *testing.T, _, ledgerPath, name string) {
+				finalizedLedgerSession(t, ledgerPath, name)
+			},
+			why: "NEGATIVE CONTROL: the reaper must never touch real work",
+		},
+		{
+			name: "unreadable meta.json",
+			setup: func(t *testing.T, _, ledgerPath, name string) {
+				dir := filepath.Join(ledgerPath, "sessions", name)
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte(`{"draft":tr`), 0644))
+			},
+			why: "we cannot classify it, so we do not delete it",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			projectRoot, ledgerPath := draftReaperFixture(t)
+			const sessionName = "2026-01-01T00-00-testuser-OxOrph1"
+			tc.setup(t, projectRoot, ledgerPath, sessionName)
+
+			orphans, err := findOrphanedDrafts(projectRoot, ledgerPath)
+			require.NoError(t, err)
+
+			if tc.wantOrphan {
+				assert.Contains(t, orphans, sessionName, tc.why)
+				return
+			}
+			assert.NotContains(t, orphans, sessionName, tc.why)
+		})
+	}
+}
+
+// TestFindOrphanedDrafts_OrdersOldestFirst — the non-fix report names the
+// oldest orphan, so a stable order matters for a legible message.
+func TestFindOrphanedDrafts_OrdersOldestFirst(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, ledgerPath := draftReaperFixture(t)
+
+	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxNewer", 30*time.Hour)
+	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxOldst", 200*time.Hour)
+	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxMiddl", 100*time.Hour)
+
+	orphans, err := findOrphanedDrafts(projectRoot, ledgerPath)
+	require.NoError(t, err)
+	require.Len(t, orphans, 3)
+	assert.Equal(t, "2026-01-01T00-00-testuser-OxOldst", orphans[0], "oldest first")
+	assert.Equal(t, "2026-01-01T00-00-testuser-OxNewer", orphans[2])
+}
+
+// TestFindOrphanedDrafts_MissingSessionsDirIsNotAnError — a ledger that has
+// never held a session must report cleanly rather than surfacing an error the
+// user cannot act on.
+func TestFindOrphanedDrafts_MissingSessionsDirIsNotAnError(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, ledgerPath := draftReaperFixture(t)
+
+	orphans, err := findOrphanedDrafts(projectRoot, ledgerPath)
+	require.NoError(t, err)
+	assert.Empty(t, orphans)
+}
+
+// TestCheckSessionDraftOrphan_ReportsWithoutMutating.
+//
+// Without --fix the check must be strictly read-only. Asserting only on the
+// returned status would be theater: a check that deleted the draft and returned
+// Warning passes that. So this fingerprints the tree and requires it unchanged.
+func TestCheckSessionDraftOrphan_ReportsWithoutMutating(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, ledgerPath := setupLedgerProject(t)
+	t.Chdir(projectRoot)
+
+	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxRept", 72*time.Hour)
+	before := treeHash(t, ledgerPath)
+
+	res := checkSessionDraftOrphan(false)
+	// WarningCheck in this codebase sets passed AND warning — assert on the
+	// warning flag, which is the one that reaches the user.
+	assert.True(t, res.warning, "a stale orphan must be reported as a warning")
+	assert.False(t, res.skipped)
+	assert.Contains(t, res.message, "1 draft placeholder")
+
+	assert.Equal(t, before, treeHash(t, ledgerPath),
+		"the reporting pass must not touch the ledger at all")
+}
+
+// TestCheckSessionDraftOrphan_PassesWhenNothingToReap is the negative control
+// for the check itself: without it, a check hardcoded to Warning would satisfy
+// the test above.
+func TestCheckSessionDraftOrphan_PassesWhenNothingToReap(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, ledgerPath := setupLedgerProject(t)
+	t.Chdir(projectRoot)
+
+	agedDraft(t, ledgerPath, "2026-01-01T00-00-testuser-OxLive1", 1*time.Minute)
+	finalizedLedgerSession(t, ledgerPath, "2026-01-01T00-00-testuser-OxDone1")
+
+	res := checkSessionDraftOrphan(false)
+	assert.False(t, res.warning, "a live draft and a finalized session are not orphans")
+	assert.True(t, res.passed)
+	assert.Equal(t, "no orphaned drafts", res.message)
+}
+
+// TestCheckSessionDraftOrphan_FixRemovesFromRemote drives the real fix against
+// a real bare remote, and asserts through a FRESH clone — the local worktree is
+// not what teammates see, and a stale /c/ page is exactly the symptom being
+// fixed.
+func TestCheckSessionDraftOrphan_FixRemovesFromRemote(t *testing.T) {
+	setTestCfg(t)
+	f := newDraftLedgerFixture(t)
+	t.Chdir(f.projectRoot)
+
+	const orphan = "2026-01-01T00-00-testuser-OxReap"
+	const live = "2026-01-01T00-00-testuser-OxKeep"
+
+	f.publish(t, orphan, 2)
+	f.publish(t, live, 2)
+	// Age only the orphan. The live draft keeps its fresh updated_at.
+	agedDraft(t, f.ledgerPath, orphan, 72*time.Hour)
+	runGit(t, f.ledgerPath, "add", "--sparse", "--", "sessions/"+orphan+"/meta.json")
+	runGit(t, f.ledgerPath, "commit", "--no-verify", "-m", "session-draft: age "+orphan)
+	f.push(t)
+	require.Contains(t, remoteTree(t, f.barePath), "sessions/"+orphan+"/meta.json")
+
+	res := checkSessionDraftOrphan(true)
+	require.False(t, res.warning, "the fix should succeed: %s %s", res.message, res.detail)
+	assert.Contains(t, res.message, "retracted 1")
+
+	tree := remoteTree(t, f.barePath)
+	assert.NotContains(t, tree, "sessions/"+orphan+"/meta.json",
+		"the orphan must be gone from the REMOTE, not just locally")
+	assert.Contains(t, tree, "sessions/"+live+"/meta.json",
+		"a live session's placeholder must survive the reaper")
+	gitFsckClean(t, f.barePath)
+}
+
+// TestHasLocalSessionData covers the helper's own decision, including the
+// XDG-vs-ledger-cache split that the table above exercises only indirectly.
+func TestHasLocalSessionData(t *testing.T) {
+	base := t.TempDir()
+	dirA := filepath.Join(base, "a")
+	dirB := filepath.Join(base, "b")
+	const name = "2026-01-01T00-00-testuser-OxHas01"
+
+	assert.False(t, hasLocalSessionData([]string{dirA, dirB}, name),
+		"no cache location holds it")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dirB, name), 0755))
+	assert.False(t, hasLocalSessionData([]string{dirA, dirB}, name),
+		"an EMPTY directory is not session data — a bare mkdir must not block reaping")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dirB, name, "raw.jsonl"), []byte("x"), 0644))
+	assert.True(t, hasLocalSessionData([]string{dirA, dirB}, name),
+		"a transcript in the SECOND location must be found")
+}
+
+// TestOrphanedDraftAge_IsLongerThanTheRefreshCadence.
+//
+// The reaper's safety rests entirely on drafts refreshing more often than the
+// threshold. If the refresh cadence were ever raised past orphanedDraftAge, the
+// reaper would start deleting live sessions' placeholders — a silent, gradual
+// failure with no other signal. This pins the relationship rather than the
+// numbers.
+func TestOrphanedDraftAge_IsLongerThanTheRefreshCadence(t *testing.T) {
+	assert.Positive(t, config.DraftRefreshEveryTurns,
+		"a zero refresh cadence means no heartbeat, which makes the reaper unsafe")
+	assert.GreaterOrEqual(t, orphanedDraftAge, 12*time.Hour,
+		"the reap threshold must stay far above any plausible gap between refreshes")
+}

--- a/cmd/ox/session_draft_schedule_test.go
+++ b/cmd/ox/session_draft_schedule_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func draftCfg(publishTurn, refreshEvery int) *config.ResolvedSessionDraft {
+	return &config.ResolvedSessionDraft{Enabled: true, PublishTurn: publishTurn, RefreshEvery: refreshEvery}
+}
+
+// TestDraftDecision_Boundaries pins the exact publish/refresh sequence.
+//
+// Every entry here is an off-by-one that would ship silently: a session that
+// never publishes, one that publishes twice, or one that emits a redundant
+// commit on the publish turn itself.
+func TestDraftDecision_Boundaries(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.ResolvedSessionDraft
+		turns       int
+		wantActions []draftAction // index i == turn i+1
+	}{
+		{
+			name:  "default cadence: publish at 2, refresh every 10 measured from the publish turn",
+			cfg:   draftCfg(2, 10),
+			turns: 23,
+			wantActions: []draftAction{
+				draftActionNone,    // 1 — a one-shot question never publishes
+				draftActionPublish, // 2
+				draftActionNone, draftActionNone, draftActionNone, draftActionNone,
+				draftActionNone, draftActionNone, draftActionNone, draftActionNone,
+				draftActionNone,
+				draftActionRefresh, // 12 == publishTurn + 10
+				draftActionNone, draftActionNone, draftActionNone, draftActionNone,
+				draftActionNone, draftActionNone, draftActionNone, draftActionNone,
+				draftActionNone,
+				draftActionRefresh, // 22
+				draftActionNone,    // 23
+			},
+		},
+		{
+			name:        "publishTurn 1 publishes immediately and never republishes",
+			cfg:         draftCfg(1, 10),
+			turns:       3,
+			wantActions: []draftAction{draftActionPublish, draftActionNone, draftActionNone},
+		},
+		{
+			name:        "publishTurn 0 is treated as turn 1, not as publish-on-every-turn",
+			cfg:         draftCfg(0, 10),
+			turns:       3,
+			wantActions: []draftAction{draftActionPublish, draftActionNone, draftActionNone},
+		},
+		{
+			name:        "refreshEvery 0 disables refresh without dividing by zero",
+			cfg:         draftCfg(2, 0),
+			turns:       6,
+			wantActions: []draftAction{draftActionNone, draftActionPublish, draftActionNone, draftActionNone, draftActionNone, draftActionNone},
+		},
+		{
+			name:  "refreshEvery 1 refreshes every turn AFTER publish, never on the publish turn",
+			cfg:   draftCfg(2, 1),
+			turns: 5,
+			wantActions: []draftAction{
+				draftActionNone, draftActionPublish,
+				draftActionRefresh, draftActionRefresh, draftActionRefresh,
+			},
+		},
+		{
+			name:  "refresh boundary: publishTurn+R-1 none, +R refresh, +R+1 none",
+			cfg:   draftCfg(2, 3),
+			turns: 7,
+			wantActions: []draftAction{
+				draftActionNone, draftActionPublish,
+				draftActionNone, draftActionNone,
+				draftActionRefresh, // 5 == 2+3
+				draftActionNone,
+				draftActionNone,
+			},
+		},
+		{
+			name:        "threshold beyond the session length never publishes",
+			cfg:         draftCfg(99, 10),
+			turns:       5,
+			wantActions: []draftAction{draftActionNone, draftActionNone, draftActionNone, draftActionNone, draftActionNone},
+		},
+		{
+			name:        "disabled never acts",
+			cfg:         &config.ResolvedSessionDraft{Enabled: false, PublishTurn: 2, RefreshEvery: 10},
+			turns:       15,
+			wantActions: make([]draftAction, 15),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Len(t, tc.wantActions, tc.turns, "test fixture: one expectation per turn")
+			publishedTurn := 0
+			published := false
+			for turn := 1; turn <= tc.turns; turn++ {
+				got := draftDecision(turn, publishedTurn, published, tc.cfg)
+				assert.Equal(t, tc.wantActions[turn-1], got, "turn %d", turn)
+				if got != draftActionNone {
+					publishedTurn = turn
+					published = true
+				}
+			}
+		})
+	}
+}
+
+// TestDraftDecision_NilConfigIsDisabled — a nil resolved config must not panic
+// in a hook. A panic here fails the user's turn.
+func TestDraftDecision_NilConfigIsDisabled(t *testing.T) {
+	assert.Equal(t, draftActionNone, draftDecision(5, 0, false, nil))
+}
+
+// TestDraftDecision_Property is a randomized property test over the scheduling
+// rule, verified against a reference model recomputed by linear scan.
+//
+// We avoid a third-party generator (gopter / rapid) to keep dependencies
+// minimal, and run with a fixed seed for determinism — the same convention as
+// TestApplySegmentMask_Property in internal/session.
+//
+// The invariant that matters most is `publishes <= 1`. A second publish would
+// re-run the whole write+commit path against a directory that already has a
+// placeholder, and at the git layer that is an extra commit per turn per agent
+// on the shared ledger.
+func TestDraftDecision_Property(t *testing.T) {
+	const trials = 200
+	rng := rand.New(rand.NewSource(1)) //nolint:gosec // deterministic test input, not security
+
+	for trial := 0; trial < trials; trial++ {
+		publishTurn := rng.Intn(5)  // 0..4
+		refreshEvery := rng.Intn(7) // 0..6
+		turns := 1 + rng.Intn(40)
+		cfg := draftCfg(publishTurn, refreshEvery)
+
+		// reference model — deliberately recomputed by linear scan rather than
+		// sharing any code with draftDecision.
+		type step struct {
+			turn   int
+			action draftAction
+		}
+		var want []step
+		modelPublished := 0
+		for turn := 1; turn <= turns; turn++ {
+			effectiveThreshold := publishTurn
+			if effectiveThreshold < 1 {
+				effectiveThreshold = 1
+			}
+			var act draftAction
+			switch {
+			case turn < effectiveThreshold:
+				act = draftActionNone
+			case modelPublished == 0:
+				act = draftActionPublish
+			case refreshEvery > 0 && (turn-modelPublished)%refreshEvery == 0:
+				act = draftActionRefresh
+			default:
+				act = draftActionNone
+			}
+			if act != draftActionNone {
+				modelPublished = turn
+			}
+			want = append(want, step{turn, act})
+		}
+
+		// drive the real function
+		var got []step
+		publishedTurn := 0
+		published := false
+		publishes := 0
+		for turn := 1; turn <= turns; turn++ {
+			act := draftDecision(turn, publishedTurn, published, cfg)
+			if act == draftActionPublish {
+				publishes++
+			}
+			if act != draftActionNone {
+				publishedTurn = turn
+				published = true
+			}
+			got = append(got, step{turn, act})
+			require.LessOrEqual(t, publishes, 1,
+				"trial=%d publishTurn=%d refreshEvery=%d turns=%d: published more than once",
+				trial, publishTurn, refreshEvery, turns)
+		}
+
+		require.Equal(t, want, got,
+			"trial=%d publishTurn=%d refreshEvery=%d turns=%d", trial, publishTurn, refreshEvery, turns)
+	}
+}
+
+// TestDraftDecision_RefreshAnchoredToPublishNotAbsoluteTurn.
+//
+// Catches the specific bug of writing `turn % refreshEvery` instead of
+// `(turn - publishedTurn) % refreshEvery`. With an absolute anchor, a session
+// whose publish was delayed refreshes almost immediately after publishing
+// rather than a full interval later — burning a ledger commit for no new
+// information.
+func TestDraftDecision_RefreshAnchoredToPublishNotAbsoluteTurn(t *testing.T) {
+	cfg := draftCfg(7, 5)
+
+	// publish lands late, at turn 7
+	require.Equal(t, draftActionPublish, draftDecision(7, 0, false, cfg))
+
+	// turn 10 is a multiple of 5 in ABSOLUTE terms but only 3 turns after
+	// publish — it must not refresh.
+	assert.Equal(t, draftActionNone, draftDecision(10, 7, true, cfg),
+		"refresh must be anchored to the publish turn, not the absolute turn number")
+
+	// 7 + 5 == 12 is the first legitimate refresh.
+	assert.Equal(t, draftActionRefresh, draftDecision(12, 7, true, cfg))
+}
+
+func TestDraftAction_String(t *testing.T) {
+	// Guards the zero value: draftActionNone must be the zero value so an
+	// uninitialized draftAction is inert rather than accidentally publishing.
+	var zero draftAction
+	assert.Equal(t, draftActionNone, zero, fmt.Sprintf("zero draftAction must be none, got %d", zero))
+}

--- a/cmd/ox/session_draft_status_test.go
+++ b/cmd/ox/session_draft_status_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `ox session status` is the diagnostic that answers the question this whole
+// feature exists to make answerable: "my /c/ link doesn't resolve — is the
+// placeholder broken, or is the server just behind?"
+//
+// If draft_state lies, the user is back to guessing, which is exactly the
+// pre-feature state. So the states have to be distinguishable, and in
+// particular a session whose first publish worked and whose every refresh
+// since has failed must NOT report itself healthy.
+
+// setTestCfg assigns the package-global cfg and restores it afterward.
+//
+// The established pattern in this package (session_upload_test.go,
+// session_force_stop_test.go, session_universal_link_test.go). Assigning
+// without restoring order-couples every later test in the package to whichever
+// draft test ran last — latent today, but this package already has one
+// order-dependent test and does not need a second source of them.
+func setTestCfg(t *testing.T) {
+	t.Helper()
+	prev := cfg
+	cfg = &config.Config{}
+	t.Cleanup(func() { cfg = prev })
+}
+
+func draftEnabled() *config.ResolvedSessionDraft {
+	return &config.ResolvedSessionDraft{
+		Enabled: true, PublishTurn: config.DraftPublishTurn,
+		RefreshEvery: config.DraftRefreshEveryTurns,
+	}
+}
+
+func TestDraftStateFor_DistinguishesEveryLifecycleState(t *testing.T) {
+	published := time.Now().Add(-5 * time.Minute).UTC()
+
+	tests := []struct {
+		name     string
+		resolved *config.ResolvedSessionDraft
+		state    *session.RecordingState
+		want     string
+		why      string
+	}{
+		{
+			name:     "never attempted",
+			resolved: draftEnabled(),
+			state:    &session.RecordingState{TurnCount: 1},
+			want:     "pending",
+			why:      "below the publish turn, nothing has been tried yet",
+		},
+		{
+			name:     "attempted once, never landed",
+			resolved: draftEnabled(),
+			state:    &session.RecordingState{TurnCount: 3, DraftAttemptTurn: 2},
+			want:     "failed",
+			why:      "an attempt with no success is the signal that would otherwise be silent",
+		},
+		{
+			name:     "published and healthy",
+			resolved: draftEnabled(),
+			state: &session.RecordingState{
+				TurnCount: 5, DraftAttemptTurn: 2, DraftPublishedTurn: 2,
+				DraftPublishedAt: &published,
+			},
+			want: "published",
+			why:  "the most recent attempt is also the most recent success",
+		},
+		{
+			name:     "published once, refreshes now failing",
+			resolved: draftEnabled(),
+			state: &session.RecordingState{
+				TurnCount: 25, DraftAttemptTurn: 22, DraftPublishedTurn: 12,
+				DraftPublishedAt: &published,
+			},
+			want: "stale",
+			why: "DraftPublishedAt is never cleared, so without comparing attempt-vs-success " +
+				"this reports healthy forever while every refresh fails",
+		},
+		{
+			name:     "feature disabled",
+			resolved: &config.ResolvedSessionDraft{Enabled: false},
+			state:    &session.RecordingState{TurnCount: 9, DraftAttemptTurn: 2},
+			want:     "disabled",
+			why:      "a user who turned it off must not see 'failed'",
+		},
+		{
+			name:     "nil resolved config is disabled, not a panic",
+			resolved: nil,
+			state:    &session.RecordingState{TurnCount: 9},
+			want:     "disabled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, draftStateFor(tc.resolved, tc.state), tc.why)
+		})
+	}
+
+	assert.Empty(t, draftStateFor(draftEnabled(), nil), "nil state must be nil-safe")
+}
+
+// TestConversationURLForState_RespectsAttributionGate.
+//
+// sessionLinkOutputs documents the invariant that an empty attribution.session
+// toggle disables EVERY session-link surface together. Status is a session-link
+// surface. Emitting a /c/ URL here for a user who deliberately turned session
+// attribution off leaks the link into a place they asked it not to appear.
+func TestConversationURLForState_RespectsAttributionGate(t *testing.T) {
+	projectCfg := &config.ProjectConfig{
+		ConfigVersion: "2",
+		RepoID:        "repo_status_test",
+		Endpoint:      "https://test.sageox.ai",
+	}
+	state := &session.RecordingState{SessionID: draftTestSessionID}
+
+	on := conversationURLForState(projectCfg, true, state)
+	require.NotEmpty(t, on, "with attribution on, the link must be emitted")
+	assert.Contains(t, on, "/c/"+draftTestSessionID)
+
+	assert.Empty(t, conversationURLForState(projectCfg, false, state),
+		"attribution off must disable this surface with every other session-link surface")
+
+	assert.Empty(t, conversationURLForState(nil, true, state),
+		"no project config, no link")
+	assert.Empty(t, conversationURLForState(projectCfg, true, &session.RecordingState{}),
+		"a recording with no ses_ id has no conversation URL")
+	assert.Empty(t, conversationURLForState(projectCfg, true, nil))
+}
+
+// TestBuildSessionRecordingEntry_CarriesDraftSurface — the multi-session JSON
+// rows must expose the same draft fields as the single-session shape, or a
+// dashboard enumerating agents can see the state for one session and not the
+// others. The pause fields had the same requirement (ADR-020).
+func TestBuildSessionRecordingEntry_CarriesDraftSurface(t *testing.T) {
+	published := time.Now().Add(-time.Minute).UTC()
+	state := &session.RecordingState{
+		AgentID: "OxStat1", StartedAt: time.Now().Add(-time.Hour),
+		SessionID: draftTestSessionID, TurnCount: 12,
+		DraftAttemptTurn: 12, DraftPublishedTurn: 12, DraftPublishedAt: &published,
+	}
+
+	ctx := draftStatusContext{
+		resolved:      draftEnabled(),
+		projectCfg:    &config.ProjectConfig{ConfigVersion: "2", RepoID: "r", Endpoint: "https://test.sageox.ai"},
+		attributionOn: true,
+	}
+	entry := buildSessionRecordingEntry(state, nil, "alive", ctx)
+
+	assert.Equal(t, 12, entry.TurnCount)
+	assert.Equal(t, "published", entry.DraftState)
+	assert.NotEmpty(t, entry.DraftPublishedAt)
+	assert.Contains(t, entry.ConversationURL, "/c/"+draftTestSessionID)
+}
+
+// TestBuildSessionRecordingEntry_ZeroContextIsInert guards the existing
+// pause-surface tests, which construct a zero draftStatusContext. That must
+// stay a safe no-op rather than panicking or inventing a link.
+func TestBuildSessionRecordingEntry_ZeroContextIsInert(t *testing.T) {
+	state := &session.RecordingState{AgentID: "OxStat2", StartedAt: time.Now(), TurnCount: 4}
+
+	assert.NotPanics(t, func() {
+		entry := buildSessionRecordingEntry(state, nil, "unknown", draftStatusContext{})
+		assert.Equal(t, 4, entry.TurnCount)
+		assert.Equal(t, "disabled", entry.DraftState, "a zero context has no resolved config")
+		assert.Empty(t, entry.ConversationURL)
+	})
+}
+
+// TestSessionDraftConfig_RoundTrip covers the user-facing switch. `off` is the
+// escape hatch for a feature that writes to a SHARED repo, so it has to
+// actually take effect — and an unrecognized value must fall back to the
+// default rather than silently disabling recording visibility.
+func TestSessionDraftConfig_RoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		in        string
+		wantValid bool
+		wantMode  string
+	}{
+		{"on", true, config.SessionDraftOn},
+		{"off", true, config.SessionDraftOff},
+		{"", true, config.SessionDraftOn},
+		{"yes", false, config.SessionDraftOn},
+		{"ON", false, config.SessionDraftOn},
+	} {
+		t.Run("value="+tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.wantValid, config.IsValidSessionDraft(tc.in))
+			assert.Equal(t, tc.wantMode, config.NormalizeSessionDraft(tc.in),
+				"an unrecognized value must fall back to the default, never to a third state")
+		})
+	}
+}
+
+// TestSessionDraftConfig_IsRegisteredAsASetting — the key must be discoverable
+// via `ox config`, or the documented escape hatch does not exist for users.
+func TestSessionDraftConfig_IsRegisteredAsASetting(t *testing.T) {
+	var found *ConfigSetting
+	for i := range AllSettings {
+		if AllSettings[i].Key == "session.draft" {
+			found = &AllSettings[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "session.draft must be registered in AllSettings")
+	assert.Equal(t, config.SessionDraftOn, found.Default)
+	assert.ElementsMatch(t, config.ValidSessionDraftModes, found.ValidValues)
+	assert.NotEmpty(t, found.LongDescription, "the escape hatch needs an explanation")
+}
+
+// --- surfaces the audit found at 0% coverage ------------------------------
+
+// TestDraftViewNotice_ExplainsInsteadOfNotFound.
+//
+// `ox session view --text` needs transcript content, which a draft has none of.
+// Without this the command hard-errors "session not found" for a session
+// `ox session list` is simultaneously displaying — two commands disagreeing
+// about whether a session exists is precisely the "everything seems broken"
+// symptom drafts were added to remove.
+func TestDraftViewNotice_ExplainsInsteadOfNotFound(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, ledgerPath := draftReaperFixture(t)
+	t.Chdir(projectRoot)
+
+	const draftName = "2026-01-01T00-00-testuser-OxView1"
+	draftLedgerSession(t, ledgerPath, draftName)
+
+	msg := draftViewNotice(draftName)
+	require.NotEmpty(t, msg, "a published draft must explain itself, not fall through to 'not found'")
+	assert.Contains(t, msg, "still recording")
+	assert.Contains(t, msg, draftName)
+	assert.Contains(t, msg, "ox-session-stop", "the message must say what to do next")
+
+	// Negative controls: neither a finalized session nor an absent one gets the
+	// draft message, or `session view` would swallow a real not-found error.
+	const doneName = "2026-01-01T00-00-testuser-OxView2"
+	finalizedLedgerSession(t, ledgerPath, doneName)
+	assert.Empty(t, draftViewNotice(doneName), "a finalized session is not a draft")
+	assert.Empty(t, draftViewNotice("2026-01-01T00-00-testuser-OxNope1"),
+		"an absent session must still produce the ordinary not-found error")
+}
+
+// TestNewDraftStatusContext_LoadsOncePerInvocation — the context exists so
+// `ox session status` reads each config file once rather than once per active
+// recording. Ten agents in a repo should not mean twenty config reads.
+func TestNewDraftStatusContext_LoadsOncePerInvocation(t *testing.T) {
+	setTestCfg(t)
+	projectRoot, _ := draftReaperFixture(t)
+	t.Chdir(projectRoot)
+
+	ctx := newDraftStatusContext()
+	require.NotNil(t, ctx.resolved, "a resolved policy must always be present")
+	assert.Positive(t, ctx.resolved.PublishTurn)
+
+	// Whatever the attribution toggle resolves to here, the context must be
+	// internally consistent: no URL when attribution is off.
+	if !ctx.attributionOn {
+		assert.Empty(t, conversationURLForState(ctx.projectCfg, ctx.attributionOn,
+			&session.RecordingState{SessionID: draftTestSessionID}))
+	}
+}
+
+// TestEmitAbortOutput_TellsTheTruthAboutWhatRemains.
+//
+// The pre-draft guidance said "the recording no longer exists." Once a
+// placeholder has been committed and PUSHED to a shared repo, that is false
+// about the part that is irreversible: the identity record stays reachable in
+// git history even after the deletion commit. An agent that repeats the old
+// wording to a user is misinforming them about a privacy-relevant fact.
+func TestEmitAbortOutput_TellsTheTruthAboutWhatRemains(t *testing.T) {
+	prev := cfg
+	setTestCfg(t)
+	t.Cleanup(func() { cfg = prev })
+
+	const name = "2026-01-01T00-00-testuser-OxMsg01"
+
+	var plain bytes.Buffer
+	require.NoError(t, emitAbortOutput(&plain, "OxMsg01", name, false, ""))
+	var plainOut sessionAbortOutput
+	require.NoError(t, json.Unmarshal(plain.Bytes(), &plainOut))
+	assert.False(t, plainOut.LedgerDraftDeleted)
+	assert.Contains(t, plainOut.Guidance, "no longer exists",
+		"with nothing published, the original wording is still accurate")
+
+	var drafted bytes.Buffer
+	require.NoError(t, emitAbortOutput(&drafted, "OxMsg01", name, true, ""))
+	var draftedOut sessionAbortOutput
+	require.NoError(t, json.Unmarshal(drafted.Bytes(), &draftedOut))
+	assert.True(t, draftedOut.LedgerDraftDeleted)
+	assert.NotContains(t, draftedOut.Guidance, "recording no longer exists",
+		"a pushed placeholder leaves an identity record in shared git history")
+	assert.Contains(t, draftedOut.Guidance, "No conversation content was ever published")
+	assert.Contains(t, draftedOut.Guidance, "git history")
+	assert.Contains(t, draftedOut.Guidance, "do not add SageOx-Session",
+		"the anchor phrase agents key on must survive both wordings")
+
+	// A push failure must be surfaced, not swallowed: until the next push the
+	// placeholder is still visible to teammates.
+	var warned bytes.Buffer
+	require.NoError(t, emitAbortOutput(&warned, "OxMsg01", name, true, "push failed: no remote"))
+	var warnedOut sessionAbortOutput
+	require.NoError(t, json.Unmarshal(warned.Bytes(), &warnedOut))
+	assert.Equal(t, "push failed: no remote", warnedOut.Warning)
+}

--- a/cmd/ox/session_draft_turncount_test.go
+++ b/cmd/ox/session_draft_turncount_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Turn counting at the HOOK level.
+//
+// The pure draftDecision tests pin the scheduling arithmetic, but they know
+// nothing about which hook feeds them. That leaves the feature's single most
+// load-bearing structural claim completely unverified: the turn counter is
+// driven by the Stop hook ("the agent finished responding", once per turn) and
+// NOT by the afterTool hook (PostToolUse, once per tool call).
+//
+// Get that wrong and every arithmetic test still passes while the draft
+// publishes on tool call 2 instead of turn 2 — which for an agent that opens
+// with a few file reads means publishing during the first response, and
+// refreshing roughly once per ten tool calls instead of ten turns. On the
+// shared ledger that is an order of magnitude more commits than designed.
+
+func stopHookCtx(projectRoot, agentID string) *HookContext {
+	return &HookContext{
+		Phase:       phaseStop,
+		AgentType:   "claude-code",
+		ProjectRoot: projectRoot,
+		Marker:      &SessionMarker{AgentID: agentID},
+	}
+}
+
+func afterToolHookCtx(projectRoot, agentID string) *HookContext {
+	return &HookContext{
+		Phase:       phaseAfterTool,
+		AgentType:   "claude-code",
+		ProjectRoot: projectRoot,
+		Marker:      &SessionMarker{AgentID: agentID},
+	}
+}
+
+func turnCountFor(t *testing.T, projectRoot, agentID string) int {
+	t.Helper()
+	state, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	return state.TurnCount
+}
+
+// TestTurnCount_IncrementedByStopHookOnly is the structural invariant.
+//
+// Red-first check: move maybePublishSessionDraft from handleStop into
+// handleAfterTool and this test fails on both assertions.
+func TestTurnCount_IncrementedByStopHookOnly(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+	const agentID = "OxTurn01"
+	createActiveRecording(t, projectRoot, repoID, agentID)
+
+	require.Equal(t, 0, turnCountFor(t, projectRoot, agentID), "fresh recording starts at zero")
+
+	// A realistic turn: several tool calls, then the agent finishes responding.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, handleAfterTool(afterToolHookCtx(projectRoot, agentID)))
+	}
+	assert.Equal(t, 0, turnCountFor(t, projectRoot, agentID),
+		"PostToolUse is a TOOL CALL, not a turn — counting it publishes the draft during the first response")
+
+	require.NoError(t, handleStop(stopHookCtx(projectRoot, agentID)))
+	assert.Equal(t, 1, turnCountFor(t, projectRoot, agentID), "the Stop hook is the turn signal")
+
+	// Second turn, same shape.
+	for i := 0; i < 3; i++ {
+		require.NoError(t, handleAfterTool(afterToolHookCtx(projectRoot, agentID)))
+	}
+	assert.Equal(t, 1, turnCountFor(t, projectRoot, agentID))
+	require.NoError(t, handleStop(stopHookCtx(projectRoot, agentID)))
+	assert.Equal(t, 2, turnCountFor(t, projectRoot, agentID))
+}
+
+// TestTurnCount_MonotonicAcrossManyTurns — the counter must never go backwards
+// or skip. RecordingState is an unlocked load-modify-save, so a bug that
+// rebuilt the state instead of mutating it would reset the count and make the
+// draft republish forever.
+func TestTurnCount_MonotonicAcrossManyTurns(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+	const agentID = "OxTurn02"
+	createActiveRecording(t, projectRoot, repoID, agentID)
+
+	prev := 0
+	for turn := 1; turn <= 25; turn++ {
+		require.NoError(t, handleStop(stopHookCtx(projectRoot, agentID)))
+		got := turnCountFor(t, projectRoot, agentID)
+		assert.Equal(t, turn, got, "turn %d", turn)
+		assert.Greater(t, got, prev, "the counter must be strictly monotonic")
+		prev = got
+	}
+}
+
+// TestTurnCount_IsNotEntryCountOrHookInvocations.
+//
+// Three counters live on RecordingState and it is genuinely easy to reach for
+// the wrong one: EntryCount counts raw.jsonl entries (many per turn),
+// HookInvocations counts afterTool calls (i.e. tool calls). A draft scheduled
+// off either of those fires at the wrong time and refreshes at the wrong rate.
+func TestTurnCount_IsNotEntryCountOrHookInvocations(t *testing.T) {
+	projectRoot, repoID := setupTestProject(t)
+	const agentID = "OxTurn03"
+	createActiveRecording(t, projectRoot, repoID, agentID)
+
+	for i := 0; i < 7; i++ {
+		require.NoError(t, handleAfterTool(afterToolHookCtx(projectRoot, agentID)))
+	}
+	require.NoError(t, handleStop(stopHookCtx(projectRoot, agentID)))
+
+	state, err := session.LoadRecordingStateForAgent(projectRoot, agentID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	assert.Equal(t, 1, state.TurnCount, "one completed response turn")
+	assert.NotEqual(t, state.TurnCount, state.HookInvocations,
+		"HookInvocations counts tool calls; conflating it with turns is the bug this guards")
+}
+
+// TestTurnCount_HookLevelProperty drives the REAL hooks with randomized
+// interleavings and checks the turn counter against a reference model
+// recomputed by linear scan.
+//
+// The existing draftDecision property test operates on integers and cannot see
+// a miswiring between hooks. This one closes that gap at the boundary that
+// actually ships. Fixed seed for determinism, no third-party generator — the
+// same convention as TestApplySegmentMask_Property in internal/session.
+func TestTurnCount_HookLevelProperty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: drives real hooks with filesystem state")
+	}
+	projectRoot, repoID := setupTestProject(t)
+	const agentID = "OxTurn04"
+	createActiveRecording(t, projectRoot, repoID, agentID)
+
+	rng := rand.New(rand.NewSource(1)) //nolint:gosec // deterministic test input, not security
+	modelTurns := 0
+
+	for op := 0; op < 120; op++ {
+		if rng.Intn(2) == 0 {
+			require.NoError(t, handleAfterTool(afterToolHookCtx(projectRoot, agentID)))
+			// model unchanged: a tool call is not a turn
+		} else {
+			require.NoError(t, handleStop(stopHookCtx(projectRoot, agentID)))
+			modelTurns++
+		}
+		require.Equal(t, modelTurns, turnCountFor(t, projectRoot, agentID),
+			"op=%d: turn counter diverged from the reference model", op)
+	}
+}
+
+// TestTurnCount_SurvivesNoRecordingState — a Stop hook for an agent with no
+// recording must be a silent no-op, not a panic and not a created state file.
+// Hooks fire in every repo, including ones that never started a session.
+func TestTurnCount_SurvivesNoRecordingState(t *testing.T) {
+	projectRoot, _ := setupTestProject(t)
+
+	assert.NotPanics(t, func() {
+		require.NoError(t, handleStop(stopHookCtx(projectRoot, "OxNoRec")))
+	})
+	state, err := session.LoadRecordingStateForAgent(projectRoot, "OxNoRec")
+	require.NoError(t, err)
+	assert.Nil(t, state, "no recording state may be conjured by a hook")
+}
+
+// TestTurnCount_NoMarkerIsNoOp — the hook can fire before an agent marker
+// exists. It must not panic on the nil Marker.
+func TestTurnCount_NoMarkerIsNoOp(t *testing.T) {
+	projectRoot, _ := setupTestProject(t)
+
+	assert.NotPanics(t, func() {
+		maybePublishSessionDraft(&HookContext{Phase: phaseStop, ProjectRoot: projectRoot})
+		maybePublishSessionDraft(nil)
+		maybePublishSessionDraft(&HookContext{Phase: phaseStop, ProjectRoot: projectRoot,
+			Marker: &SessionMarker{AgentID: ""}})
+	})
+}

--- a/cmd/ox/session_list.go
+++ b/cmd/ox/session_list.go
@@ -210,8 +210,13 @@ func runSessionList(cmd *cobra.Command, args []string) error {
 				ledgerSessions, _ = ledgerStore.ListSessions()
 			}
 
-			// mark ledger sessions as uploaded using merge key
+			// mark ledger sessions as uploaded using merge key.
+			// Drafts are excluded: a meta.json-only placeholder means the
+			// session is still recording, not that its turn data landed.
 			for _, ls := range ledgerSessions {
+				if ls.Draft {
+					continue
+				}
 				uploadedSessions[sessionMergeKey(ls)] = true
 			}
 
@@ -432,6 +437,12 @@ func printSessionRow(t session.SessionInfo, uploaded bool, localUser string) {
 	case session.StatusUploaded:
 		statusStr = "✓ uploaded"
 		statusStyle = "uploaded"
+	case session.StatusDraft:
+		// A placeholder is published, but no turn data has landed. Rendered
+		// distinctly from "uploaded" so a live session is never mistaken for
+		// a finished one.
+		statusStr = "◌ draft"
+		statusStyle = "local"
 	case session.StatusCanceled:
 		statusStr = "✗ canceled"
 		statusStyle = "ghost" // dim — discarded
@@ -682,17 +693,34 @@ func sessionMergeKey(s session.SessionInfo) string {
 // mergeSessionSources deduplicates sessions by merge key.
 // Primary sessions take precedence over additional sessions.
 // Returns merged sessions sorted newest-first by CreatedAt.
+//
+// One exception to primary-wins: a DRAFT placeholder loses to any non-draft
+// row for the same session. The ledger's git-tracked sessions/ is merged as
+// primary, ahead of the ledger cache where live recordings actually live — so
+// without this, a draft published at turn 2 shadows its own live recording and
+// every active session renders as finished, with no title and no turn count.
+// A draft carries strictly less information than the row it would displace.
 func mergeSessionSources(primary, additional []session.SessionInfo) []session.SessionInfo {
-	existing := make(map[string]bool, len(primary))
+	index := make(map[string]int, len(primary))
 	result := make([]session.SessionInfo, 0, len(primary)+len(additional))
 	for _, s := range primary {
-		existing[sessionMergeKey(s)] = true
+		k := sessionMergeKey(s)
+		if _, dup := index[k]; dup {
+			continue
+		}
+		index[k] = len(result)
 		result = append(result, s)
 	}
 	for _, s := range additional {
-		if k := sessionMergeKey(s); !existing[k] {
-			existing[k] = true
+		k := sessionMergeKey(s)
+		at, seen := index[k]
+		if !seen {
+			index[k] = len(result)
 			result = append(result, s)
+			continue
+		}
+		if result[at].Draft && !s.Draft {
+			result[at] = s
 		}
 	}
 	sort.Slice(result, func(i, j int) bool {

--- a/cmd/ox/session_prune.go
+++ b/cmd/ox/session_prune.go
@@ -291,6 +291,13 @@ func loadUploadedKeys(ledgerPath string) (map[string]bool, error) {
 	}
 
 	for _, ls := range ledgerSessions {
+		// A draft placeholder is not an upload. Counting it here would make
+		// shouldPrune refuse forever ("uploaded" is never a prune target), so
+		// the local cache copy of every drafted session would become
+		// permanently unprunable even after the session is aborted.
+		if ls.Draft {
+			continue
+		}
 		keys[sessionMergeKey(ls)] = true
 	}
 	return keys, nil

--- a/cmd/ox/session_push_summary.go
+++ b/cmd/ox/session_push_summary.go
@@ -455,6 +455,23 @@ func clearNeedsSummaryMarkerForSession(sessionName string) {
 // raw.jsonl was still in cache). By push-summary time, raw.jsonl may be an LFS
 // stub, so re-computing is not reliable.
 func preserveComputedFields(summaryPath string, newSummary *session.SummarizeResponse) {
+	// Never carry computed fields forward from a DRAFT-era summary.json.
+	// While meta.draft is true, any summary.json in that directory was authored
+	// against a zero-turn placeholder — by the SageOx server, or pulled in by a
+	// finalize-time rebase — so its files_changed and chapters describe nothing.
+	//
+	// Scope, stated honestly: this fires when push-summary runs against a
+	// directory that is STILL a draft (a regenerate or a manual invocation on a
+	// live session). It does NOT cover the narrow window where a server-authored
+	// summary.json arrives via the rebase inside the finalize push, because by
+	// then the meta is already finalized. Closing that window needs a signal
+	// carried across the purge rather than re-derived after it; the primary
+	// defense there is the wholesale purge in supersedeDraftForFinalize.
+	sessionDir := filepath.Dir(summaryPath)
+	if meta, metaErr := lfs.ReadSessionMeta(sessionDir); metaErr == nil && meta.IsDraft() {
+		return
+	}
+
 	existingData, err := os.ReadFile(summaryPath)
 	if err != nil {
 		return

--- a/cmd/ox/session_remove.go
+++ b/cmd/ox/session_remove.go
@@ -148,6 +148,17 @@ func removeSessionByPattern(store *session.Store, pattern string, force bool) er
 				if !strings.Contains(name, pattern) {
 					continue
 				}
+				// A draft placeholder is not a removable session (ADR-029) —
+				// it belongs to a recording that is very likely still LIVE.
+				// Before drafts, a pattern could not match a live session in
+				// the ledger at all; now it can, and removing it would delete
+				// the running recording's local copy alongside the placeholder.
+				// `ox agent session abort` is the command for discarding a
+				// live session, and it removes the placeholder itself.
+				if ls.Draft {
+					slog.Debug("skip_draft_placeholder", "session", name)
+					continue
+				}
 				if existing, ok := matchMap[name]; ok {
 					existing.isLedger = true
 					existing.ledgerPath = ledgerPath

--- a/cmd/ox/session_repair_meta_summary.go
+++ b/cmd/ox/session_repair_meta_summary.go
@@ -175,6 +175,18 @@ func repairSessionMetaSummary(sessionDir string, dryRun bool) repairOutcome {
 		return oc
 	}
 
+	// A draft placeholder legitimately has an empty title — it is a marker for
+	// a LIVE recording, not a session whose summarization failed (ADR-029).
+	// Without this skip a draft satisfies emptyTitleNeedsRepair below, this
+	// tool tries to stamp summary_status=failed_validation and bump
+	// SummaryAttempts on it, and the write is then rejected by the draft
+	// writer-invariant — so every live draft is reported as an error. Same
+	// guard RecoverEmptyTitleMeta carries; this is its near-duplicate.
+	if meta.IsDraft() {
+		oc.Skipped = true
+		return oc
+	}
+
 	titleLeaky := lfs.IsLeakySummaryString(meta.Title)
 	summaryLeaky := lfs.IsLeakySummaryString(meta.Summary)
 

--- a/cmd/ox/session_status.go
+++ b/cmd/ox/session_status.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/daemon"
 	"github.com/sageox/ox/internal/session"
 	"github.com/spf13/cobra"
@@ -136,6 +137,19 @@ type sessionStatusOutput struct {
 	PauseCount           int    `json:"pause_count,omitempty"`            // monotonic counter
 	InheritedPause       bool   `json:"inherited_pause,omitempty"`        // started suspended via /clear marker
 	InheritedFromSession string `json:"inherited_from_session,omitempty"` // session that finalized at /clear
+
+	// ADR-029 draft-placeholder surface.
+	//
+	// Without these, "the /c/ link in my PR doesn't resolve" is
+	// indistinguishable from "the placeholder published fine and the server is
+	// behind" — which is the whole reason the git-backed channel was added
+	// alongside the already-silent started-notification. ConversationURL is
+	// included so an agent never has to reconstruct the link; reconstruction
+	// is the confabulation vector sessionLinkOutputs exists to close.
+	TurnCount        int    `json:"turn_count,omitempty"`
+	DraftState       string `json:"draft_state,omitempty"`        // disabled | pending | published | stale | failed
+	DraftPublishedAt string `json:"draft_published_at,omitempty"` // RFC3339
+	ConversationURL  string `json:"conversation_url,omitempty"`   // https://<endpoint>/c/<session_id>
 }
 
 // sessionRecordingEntry represents one active recording in the multi-session output.
@@ -166,13 +180,21 @@ type sessionRecordingEntry struct {
 	PauseCount           int    `json:"pause_count,omitempty"`
 	InheritedPause       bool   `json:"inherited_pause,omitempty"`
 	InheritedFromSession string `json:"inherited_from_session,omitempty"`
+
+	// ADR-029 draft surface — kept in sync with sessionStatusOutput for the
+	// same reason the pause fields are: multi-session consumers need to tell
+	// a session whose placeholder published from one whose publish is failing.
+	TurnCount        int    `json:"turn_count,omitempty"`
+	DraftState       string `json:"draft_state,omitempty"`
+	DraftPublishedAt string `json:"draft_published_at,omitempty"`
+	ConversationURL  string `json:"conversation_url,omitempty"`
 }
 
 // buildSessionRecordingEntry maps a RecordingState into the multi-session
 // JSON row, including ADR-020 pause-state fields. Extracted from
 // runSessionStatus so the mapping can be unit-tested without setting up
 // the full multi-recording fixture on disk.
-func buildSessionRecordingEntry(s *session.RecordingState, alive *bool, status string) sessionRecordingEntry {
+func buildSessionRecordingEntry(s *session.RecordingState, alive *bool, status string, draftCtx draftStatusContext) sessionRecordingEntry {
 	d := s.Duration()
 	entry := sessionRecordingEntry{
 		AgentID:       s.AgentID,
@@ -202,7 +224,91 @@ func buildSessionRecordingEntry(s *session.RecordingState, alive *bool, status s
 		entry.InheritedPause = s.InheritedPause
 		entry.InheritedFromSession = s.InheritedFromSession
 	}
+	draftCtx.applyTo(s, &entry.TurnCount, &entry.DraftState, &entry.DraftPublishedAt, &entry.ConversationURL)
 	return entry
+}
+
+// draftStateFor classifies where this recording is in the draft-placeholder
+// lifecycle (ADR-029).
+//
+// The distinction that matters is published vs failed. DraftPublishedTurn is
+// stamped on every ATTEMPT while DraftPublishedAt is stamped only on success,
+// so the (turn set, time nil) pair is the durable record of "we tried and it
+// did not land" — the state that otherwise looks identical to a healthy
+// session whose server page is merely lagging.
+func draftStateFor(resolved *config.ResolvedSessionDraft, s *session.RecordingState) string {
+	if s == nil {
+		return ""
+	}
+	if resolved == nil || !resolved.Enabled {
+		return "disabled"
+	}
+	// Order matters: check the FAILED shape before the published shape.
+	// DraftPublishedAt is only ever set, never cleared, so a session whose
+	// first publish succeeded and whose later refreshes are all failing would
+	// otherwise report "published" forever — hiding exactly the breakage this
+	// field exists to surface. DraftPublishedTurn is stamped on every attempt,
+	// so an attempt newer than the last success means the latest one failed.
+	if s.DraftPublishedAt != nil {
+		if s.DraftAttemptTurn > s.DraftPublishedTurn {
+			return "stale"
+		}
+		return "published"
+	}
+	if s.DraftAttemptTurn > 0 {
+		return "failed"
+	}
+	return "pending"
+}
+
+// conversationURLForState builds the durable /c/<session_id> link for a
+// recording, or "" when one cannot be derived. Best-effort: this is a status
+// display, and a missing project config must not fail the command.
+//
+// Gated on the attribution.session toggle, like every other session-link
+// surface. sessionLinkOutputs documents the invariant: an empty toggle must
+// disable them ALL together. Emitting the link here regardless would hand a
+// /c/ URL to users who deliberately turned session attribution off.
+//
+// projectCfg is passed in rather than loaded per call: this runs once per
+// active recording row, and ten agents in a repo would otherwise mean ten
+// redundant project-config reads for one status invocation.
+func conversationURLForState(projectCfg *config.ProjectConfig, attributionOn bool, s *session.RecordingState) string {
+	if !attributionOn || projectCfg == nil || s == nil || s.SessionID == "" {
+		return ""
+	}
+	return buildConversationURL(projectCfg, s.SessionID)
+}
+
+// draftStatusContext is the per-invocation config snapshot shared by every
+// recording row, so `ox session status` reads each config file once rather than
+// once per active agent.
+type draftStatusContext struct {
+	resolved      *config.ResolvedSessionDraft
+	projectCfg    *config.ProjectConfig
+	attributionOn bool
+}
+
+func newDraftStatusContext() draftStatusContext {
+	projectCfg, _ := config.LoadProjectConfig("")
+	return draftStatusContext{
+		resolved:      config.ResolveSessionDraft(),
+		projectCfg:    projectCfg,
+		attributionOn: loadResolvedAttribution().Session != "",
+	}
+}
+
+// applyTo fills the draft observability fields on any row-like target.
+func (c draftStatusContext) applyTo(s *session.RecordingState, turnCount *int, state *string, publishedAt *string, url *string) {
+	if s == nil {
+		return
+	}
+	*turnCount = s.TurnCount
+	*state = draftStateFor(c.resolved, s)
+	if s.DraftPublishedAt != nil {
+		*publishedAt = s.DraftPublishedAt.Format("2006-01-02T15:04:05Z07:00")
+	}
+	*url = conversationURLForState(c.projectCfg, c.attributionOn, s)
 }
 
 func init() {
@@ -316,6 +422,10 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 				output.InheritedFromSession = state.InheritedFromSession
 				output.Guidance = "Recording is SUSPENDED. Resume with `ox session resume` or stop with `ox session stop`."
 			}
+			// ADR-029: surface draft-placeholder state so "my /c/ link 404s"
+			// is diagnosable rather than a guess.
+			newDraftStatusContext().applyTo(state, &output.TurnCount, &output.DraftState,
+				&output.DraftPublishedAt, &output.ConversationURL)
 			return outputJSON(cmd.OutOrStdout(), output)
 		}
 
@@ -372,10 +482,12 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 
 	// multiple recordings
 	if jsonOutput {
+		// Loaded once for the whole invocation, not per row.
+		draftCtx := newDraftStatusContext()
 		var entries []sessionRecordingEntry
 		for _, s := range states {
 			alive, status := agentLivenessFor(agentAlive, s.AgentID)
-			entries = append(entries, buildSessionRecordingEntry(s, alive, status))
+			entries = append(entries, buildSessionRecordingEntry(s, alive, status, draftCtx))
 		}
 		return outputJSON(cmd.OutOrStdout(), sessionStatusOutput{
 			Recording: true,

--- a/cmd/ox/session_status_pause_test.go
+++ b/cmd/ox/session_status_pause_test.go
@@ -29,7 +29,7 @@ func TestBuildSessionRecordingEntry_PropagatesSuspendedFields(t *testing.T) {
 		InheritedFromSession: "2026-05-28-prev-session",
 	}
 
-	got := buildSessionRecordingEntry(state, nil, "unknown")
+	got := buildSessionRecordingEntry(state, nil, "unknown", draftStatusContext{})
 
 	assert.True(t, got.Suspended, "Suspended must be true when SuspendedAt is set")
 	assert.NotEmpty(t, got.SuspendedAt, "SuspendedAt RFC3339 must be populated")
@@ -51,7 +51,7 @@ func TestBuildSessionRecordingEntry_ActiveSessionHasNoSuspendFields(t *testing.T
 		// SuspendedAt intentionally nil
 	}
 
-	got := buildSessionRecordingEntry(state, nil, "alive")
+	got := buildSessionRecordingEntry(state, nil, "alive", draftStatusContext{})
 
 	assert.False(t, got.Suspended)
 	assert.Empty(t, got.SuspendedAt)

--- a/cmd/ox/session_universal_link_test.go
+++ b/cmd/ox/session_universal_link_test.go
@@ -319,7 +319,7 @@ func TestAbortGuidance_CountermandsSessionTrailer(t *testing.T) {
 	t.Cleanup(func() { cfg = prevCfg })
 
 	var buf bytes.Buffer
-	require.NoError(t, emitAbortOutput(&buf, "OxAB01", "2026-01-01T00-00-user-OxAB01"))
+	require.NoError(t, emitAbortOutput(&buf, "OxAB01", "2026-01-01T00-00-user-OxAB01", false, ""))
 
 	var out sessionAbortOutput
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))

--- a/cmd/ox/session_upload.go
+++ b/cmd/ox/session_upload.go
@@ -317,6 +317,16 @@ func commitAndPushLedgerWithExtras(ledgerPath, sessionName string, includeSummar
 // All returned paths are absolute (joined with sessionDir).
 func sessionArtifactsToStage(sessionDir string) []string {
 	meta, err := lfs.ReadSessionMeta(sessionDir)
+	// A draft placeholder contains ONLY meta.json, which every caller stages
+	// explicitly. Returning early matters because a draft's Files map is
+	// legitimately empty, which would otherwise fall through to the glob
+	// fallback below and stage any *.jsonl / *.md in the directory — including
+	// a server-authored summary.md, or real raw.jsonl bytes committed as a git
+	// blob, which breaks LFS linkage for every future push
+	// (.claude/rules/cache-only-design.md).
+	if err == nil && meta.IsDraft() {
+		return nil
+	}
 	if err == nil && len(meta.Files) > 0 {
 		paths := make([]string, 0, len(meta.Files))
 		for name := range meta.Files {

--- a/cmd/ox/session_view.go
+++ b/cmd/ox/session_view.go
@@ -144,6 +144,13 @@ func runSessionView(cmd *cobra.Command, args []string) error {
 							if err != nil {
 								return fmt.Errorf("read session after download: %w", err)
 							}
+						} else if msg := draftViewNotice(sessionName); msg != "" {
+							// A draft placeholder is published but no turn
+							// data has landed yet. Erroring "not found" here
+							// while `ox session list` happily shows the row is
+							// actively misleading — say what is actually true.
+							fmt.Fprintln(cmd.OutOrStdout(), msg)
+							return nil
 						} else {
 							return fmt.Errorf("session %q not found\nRun 'ox session list' to see available sessions", args[0])
 						}

--- a/docs/adr/ADR-029-session-draft-placeholder.md
+++ b/docs/adr/ADR-029-session-draft-placeholder.md
@@ -1,0 +1,183 @@
+# ADR-029: Session draft placeholders
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Supersedes:** nothing
+**Related:** ADR-016 (session summarization delegation), ADR-020 (session pause/resume),
+`.claude/rules/cache-only-design.md`, `docs/specs/session-pr-issue-linkage.md`
+
+---
+
+## Context
+
+A session recording is invisible to the SageOx server until `ox agent session stop` runs the
+full upload pipeline. But agents are instructed to put `SageOx-Session:
+https://<endpoint>/c/<ses_id>` in PR bodies *during* the session, and the same URL goes into
+commit trailers via `prepare-commit-msg`.
+
+Until the session ends, that link resolves to nothing. There is no way to tell a correctly
+wired setup from a broken one, which makes every new integration look broken during the
+window when a user is most likely to be checking.
+
+A second, related gap: `ox agent session abort` discards local data, but there was no notion
+of anything the CLI had already published, so "aborted" had no server-side counterpart beyond
+a best-effort notification.
+
+### What already existed
+
+`POST /api/v1/sessions/<id>/started` (`cmd/ox/session_notify.go`) fires at `StartRecording`.
+It is fire-and-forget, bounded at 750 ms, gated on the `attribution.session` toggle, and
+**every failure is silent**. There is a matching `.../aborted`.
+
+That channel is strictly *faster* than a draft (t=0 vs. turn 2 plus a sync cycle). What it is
+not is *durable* or *observable*: a dropped notification is indistinguishable from a server
+lag, and nothing retries it.
+
+## Decision
+
+Publish a **`meta.json`-only draft placeholder** into the git-tracked
+`<ledger>/sessions/<name>/` at response-turn 2, marked `draft: true`, carrying zero turn data.
+Supersede it wholesale at session stop. Retract it on abort.
+
+This adds a durable, retryable, observable channel alongside the ephemeral notification, and
+is the degenerate first case of real-time session recording — the direction this is headed
+anyway.
+
+### The shape is forced, not chosen
+
+`.claude/rules/cache-only-design.md`: the git-tracked `<ledger>/sessions/<name>/raw.jsonl`
+**must** remain an LFS pointer. Real bytes there cause two documented catastrophes (2026-04-25
+Phase 2 incident, PRs #559–#564):
+
+- LFS linkage breaks and the ledger rejects **every future push, for every teammate**, with
+  `LFS objects are missing`.
+- The daemon's pointer-stub skip stops applying, so anti-entropy re-finalizes live sessions
+  and clobbers good summaries.
+
+So a draft contains `meta.json` and nothing else. Three properties follow for free:
+
+| Property | Why it follows |
+|---|---|
+| **Privacy is structural** | `lfs.DraftInput` has no field that can hold transcript-derived text. Not a title (which is derived from the user's first message), not a summary, not a preview. A draft *cannot* leak turn content, by type. |
+| **Daemon anti-entropy already ignores it** | `detectInDir` requires a `raw.jsonl`; a draft has none. The explicit `IsDraft()` skip we added makes that intentional rather than incidental. |
+| **No LFS objects** | Nothing to upload, orphan, or reconcile. |
+
+### The provisionality invariant
+
+> **While `meta.draft == true`, every file in that session directory is provisional, and
+> finalize purges the directory wholesale before writing anything.**
+
+This is what handles the case we do not control: the SageOx server may summarize a zero-turn
+draft, write `summary.json` / `summary.md`, and push them; a finalize-time `git pull --rebase`
+folds those into our working tree. A whitelist of "files the server might write" rots the
+first time the server writes something new. Deleting the directory cannot.
+
+The `ses_` id is read **before** the purge — the draft's `meta.json` is a durable carrier of
+it, and for a recording whose `raw.jsonl` header predates the `SessionID` field it is the
+*only* carrier. `supersedeDraftForFinalize` exists so that ordering is a function signature
+rather than a convention repeated at four call sites.
+
+### Ledger index mutation is a guarded chokepoint
+
+This is the design lesson that cost the most to learn, and it generalizes beyond drafts.
+
+Every other ledger index writer in the CLI is followed by `pushLedger` →
+`gitutil.PushWithRetry` → `IsSafeForGitOps`, so the rebase guard rides along for free. **Draft
+writes deliberately do not push** — that is the entire point — so they fell straight through
+it.
+
+Without the guard, this happens: the daemon's `git pull --rebase` conflicts on
+`sessions/<name>/meta.json` (the documented steady state — one ledger sat 341 ahead / 1055
+behind for 13 days with 281 such conflicts). The rebase stops mid-replay. A Stop hook fires,
+atomically overwrites the conflicted file, `git add` **marks the conflict resolved**, and
+`git commit -- <pathspec>` **succeeds on the detached rebase HEAD, consuming the replay step**.
+The next `rebase --continue` reports success and the commit being replayed is silently gone —
+a teammate's finalize, a murmur, a plan, imported team data.
+
+So: `prepareDraftLedgerWrite` is the single gate every draft index mutation passes. It
+validates the session name, validates the ledger target, waits out a blue-green GC swap, and
+refuses when the clone is mid-rebase. **The guard belongs at index-mutation time, not at push
+time.**
+
+Two more things that gate discovered:
+
+- `git commit -- <pathspec>` commits the **working tree**, not the index. A concurrent
+  finalize rewriting the same `meta.json` would get committed under a `session-draft:`
+  subject. `assertDraftStillStaged` re-verifies both worktree-vs-index equality and
+  draft-ness immediately before committing.
+- `deriveLedgerPath` returns `filepath.Dir` for *any* path whose parent is named `sessions`,
+  which includes the XDG cache and the legacy in-repo fallback — i.e. **the user's own project
+  root**. Its three prior callers only built IPC payloads, so a wrong answer was harmless.
+  This is the first caller that runs `git commit`. `validateDraftLedgerPath` requires the
+  target to be this project's resolved ledger.
+
+## Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Draft contents | `meta.json` only | Forced by the LFS invariant; buys privacy and daemon-safety free |
+| Turn signal | The `Stop` hook | It fires exactly once per completed response turn. `handleAfterTool` also fires on `PostToolUse`, so counting there counts tool calls |
+| Publish turn | 2 | Turn 1 is often a one-shot question that never earns a PR link; publishing there puts a ledger commit in the path of every trivial interaction |
+| Refresh | Counters only, every 10 turns | Load-bearing twice over: a climbing `turn_count` is the "it's working" signal the feature exists to provide, and `updated_at` is the *only* way the orphan reaper can tell a live draft from a dead one |
+| Who pushes | The daemon's existing sync cycle | `pushLedger` is a secret scan + credential refresh + LFS reconcile + 3-attempt rebase loop. Paying that on a turn boundary is what this design avoids. Precedent: `pushMurmurCommits` |
+| Daemon push safety | Only when **every** unpushed commit is a draft commit | `git push` moves the whole branch, and this path has neither the secret gate nor `ReconcileLFS`. Narrower than the murmur equivalent, deliberately |
+| Daemon unreachable | Local commit, no push | The next `pushLedger` from any path carries it. Never spawn a detached child |
+| Draft marker | One persisted bool + `IsDraft()` | `omitempty` ⇒ absent key means not-a-draft ⇒ every existing `meta.json` stays byte-identical |
+| Status vocabulary | One **derived** `StatusDraft` | Without it a draft reads as `StatusUploaded`: live recordings render as finished, and `session abort <name>` refuses. Does not touch `StopReason`, which is a precedence lattice for *terminal* states |
+| Config | `session.draft` = `on` \| `off` | User config, not an env var. Numeric tuning stays constants — a public numeric key is permanent API for a knob nobody asked for |
+
+## Fail-safe directions
+
+Every site that reads a possibly-unreadable `meta.json` picks a direction. The rule is
+**whichever direction is non-destructive when wrong**:
+
+| Site | Unreadable meta ⇒ | Why that direction |
+|---|---|---|
+| `PreservedSessionIDAndDraft` | fatal | Cannot tell whether it held a `ses_` id we would rotate |
+| `isSessionInLedger` | finalized (refuse abort) | Points the user at `session delete` rather than deleting what we cannot classify |
+| `resolveSessionForAbort` | refuse the ledger dir | Returning it means `os.RemoveAll` on a tracked dir with no `git rm`: the next pull restores it, the real recording is untouched, and the user is told it was discarded |
+| `deleteDraftFromLedger` | refuse | Same |
+| `findOrphanedSessions` | uploaded (skip) | Retrying an unclassifiable upload risks clobbering a finalized session; skipping defers to a human |
+| `findOrphanedDrafts` | not an orphan | A false positive deletes a live session's placeholder |
+| daemon `detectInDir` / `DetectOrphanedForAgent` | **skip** | Falling through reaches `recoverRawFromSessionFile`, which writes real bytes to the tracked `raw.jsonl` and breaks LFS for the team |
+| `ledgersearch.isDraftSession` | not a draft (index it) | Fail-open; a malformed file must not hide a real session from search |
+
+## Consequences
+
+**Good.** `/c/<id>` resolves mid-session, durably and retryably. `ox session status` gains
+`draft_state` (`disabled` / `pending` / `published` / `stale` / `failed`) and
+`conversation_url`, so a silently-failed publish on *either* channel is now diagnosable —
+which is a large part of the actual fix for "it seems broken." The draft is an extra durable
+carrier of the `ses_` id. Abort now has something concrete to retract.
+
+**Cost.** Every consumer that treats `sessions/<name>/meta.json` existing as "this session is
+real" must now call `IsDraft()` first — roughly fifteen call sites, and every future one.
+`.claude/rules/session-draft.md` exists to make that discoverable. Ledger commit volume rises
+by roughly 1 + turns/10 per session.
+
+**Known gaps.** `commitAndPushLedger` still uses a bare `git commit` (whole index); drafts make
+its co-staging window routine rather than theoretical, and it should get the same pathspec
+treatment in a follow-up. `pushMurmurCommits` has the secret-gate hole this change declined to
+propagate. `.recording.json` is now gitignored, but that does not untrack markers already
+committed in existing ledgers.
+
+## Alternatives considered
+
+**Instrument the existing notification instead.** Genuinely tempting, and cheaper: persist a
+`notified_at` on `RecordingState`, re-POST from the same Stop hook when unacked, include
+`turn_count` in a heartbeat. Zero git, zero new consumers to teach. Rejected because the
+notification is not durable — nothing survives a process exit mid-flight — and because the
+git channel is the stepping stone to real-time session recording, which is where this is
+going regardless. Worth revisiting if the consumer-awareness tax proves higher than expected.
+
+**Blank versions of every session file.** The original shape proposed. Rejected: a blank
+`raw.jsonl` in the tracked directory breaks LFS linkage team-wide and defeats the daemon's
+pointer-stub skip.
+
+**A new IPC message so the daemon does the write.** Rejected as ~8 files of daemon plumbing
+(message type, payload, client method, service interface, callback wiring, handler, plus a new
+traversal-validation trust boundary) for a best-effort placeholder. Reusing the existing sync
+cycle for the *push* gets the same latency win with one function.
+
+**Selective purge at finalize.** Rejected: a whitelist of server-authored filenames rots the
+first time the server writes a new one.

--- a/internal/config/session_draft.go
+++ b/internal/config/session_draft.go
@@ -1,0 +1,102 @@
+package config
+
+// Session draft placeholders — see docs/adr/ADR-029-session-draft-placeholder.md.
+//
+// A draft is a meta.json-only placeholder committed to the ledger partway
+// through a recording, so https://<endpoint>/c/<session_id> resolves for links
+// already circulating in PR bodies and commit trailers. It carries no turn
+// data and is superseded wholesale at session stop.
+const (
+	// SessionDraftOn publishes a draft placeholder at DraftPublishTurn.
+	SessionDraftOn = "on"
+	// SessionDraftOff never publishes one. The server-visibility path then
+	// rests entirely on the (silent, best-effort) session-started
+	// notification, which is the pre-draft behavior.
+	SessionDraftOff = "off"
+)
+
+// ValidSessionDraftModes lists the modes accepted by user configuration.
+var ValidSessionDraftModes = []string{SessionDraftOn, SessionDraftOff}
+
+const (
+	// DraftPublishTurn is the response turn at which the placeholder is
+	// published.
+	//
+	// 2, not 1: turn 1 is very often a one-shot question that never becomes
+	// work worth linking, so publishing there would put a ledger commit into
+	// the critical path of every trivial interaction. By turn 2 the agent has
+	// almost always been asked to do something whose PR body will carry a
+	// /c/ link.
+	//
+	// Not user-configurable. A numeric public config key is permanent API for
+	// a knob nobody has asked for, and the failure mode of a bad value
+	// (publish on every single turn) is ledger churn for the whole team.
+	DraftPublishTurn = 2
+
+	// DraftRefreshEveryTurns is how often the draft's counters are refreshed
+	// after the initial publish.
+	//
+	// Refreshing at all is what makes the feature verifiable: a climbing
+	// turn_count on the /c/ page is the signal that distinguishes "recording
+	// is working" from "recording is silently broken", which is the whole
+	// problem drafts exist to solve. 10 keeps a 100-turn session to roughly
+	// 10 tiny meta.json commits — visible forward motion without turning the
+	// ledger into a commit firehose.
+	DraftRefreshEveryTurns = 10
+)
+
+// SessionDraftSource indicates where the resolved value came from.
+type SessionDraftSource string
+
+const (
+	// SessionDraftSourceDefault — no config set, returning the built-in default (on).
+	SessionDraftSourceDefault SessionDraftSource = "default"
+	// SessionDraftSourceUserConfig — set via `ox config set session.draft ...`.
+	SessionDraftSourceUserConfig SessionDraftSource = "user"
+)
+
+// ResolvedSessionDraft is the effective draft policy plus its provenance.
+type ResolvedSessionDraft struct {
+	Enabled      bool
+	PublishTurn  int
+	RefreshEvery int
+	Source       SessionDraftSource
+}
+
+// IsValidSessionDraft reports whether mode is accepted by `ox config set`.
+// Empty is valid (unset takes the default).
+func IsValidSessionDraft(mode string) bool {
+	switch mode {
+	case SessionDraftOn, SessionDraftOff, "":
+		return true
+	}
+	return false
+}
+
+// NormalizeSessionDraft returns the canonical mode string. Unrecognized values
+// fall back to the default (on).
+func NormalizeSessionDraft(mode string) string {
+	if mode == SessionDraftOff {
+		return SessionDraftOff
+	}
+	return SessionDraftOn
+}
+
+// ResolveSessionDraft determines the effective draft policy. Resolution order
+// is user config (session.draft), then the built-in default of "on".
+//
+// No environment variable. Customer-facing env vars require human review, and
+// this is a user preference rather than a deployment knob.
+func ResolveSessionDraft() *ResolvedSessionDraft {
+	resolved := &ResolvedSessionDraft{
+		Enabled:      true,
+		PublishTurn:  DraftPublishTurn,
+		RefreshEvery: DraftRefreshEveryTurns,
+		Source:       SessionDraftSourceDefault,
+	}
+	if userCfg, err := LoadUserConfig(); err == nil && userCfg != nil && userCfg.SessionDraft != "" {
+		resolved.Enabled = NormalizeSessionDraft(userCfg.SessionDraft) == SessionDraftOn
+		resolved.Source = SessionDraftSourceUserConfig
+	}
+	return resolved
+}

--- a/internal/config/session_draft_test.go
+++ b/internal/config/session_draft_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `session.draft` is the user-facing off switch for a feature that COMMITS TO A
+// SHARED GIT REPO on the user's behalf. If `ox config set session.draft off`
+// does not actually reach the publisher, a user who opted out keeps writing
+// placeholders into their team's ledger — the worst possible failure for an
+// opt-out.
+//
+// The pure string helpers being correct proves nothing about that: the
+// publisher branches on ResolvedSessionDraft.Enabled, and only
+// ResolveSessionDraft produces it.
+
+// withUserConfig points user-config resolution at a temp HOME and writes the
+// given config.yaml body (empty string = no file at all).
+func withUserConfig(t *testing.T, body string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	if body == "" {
+		return
+	}
+	dir := filepath.Join(home, ".config", "sageox")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(body), 0o644))
+}
+
+// TestResolveSessionDraft_OffSwitchActuallyDisables is the one that matters.
+//
+// Red-first check: make ResolveSessionDraft ignore userCfg.SessionDraft and
+// this fails — while every string-helper test stays green.
+func TestResolveSessionDraft_OffSwitchActuallyDisables(t *testing.T) {
+	withUserConfig(t, "session_draft: \"off\"\n")
+
+	resolved := ResolveSessionDraft()
+	require.NotNil(t, resolved)
+	assert.False(t, resolved.Enabled,
+		"session_draft: off must reach the publisher, or opting out does nothing")
+	assert.Equal(t, SessionDraftSourceUserConfig, resolved.Source)
+}
+
+func TestResolveSessionDraft_DefaultsToOn(t *testing.T) {
+	withUserConfig(t, "")
+
+	resolved := ResolveSessionDraft()
+	require.NotNil(t, resolved)
+	assert.True(t, resolved.Enabled, "unset means on")
+	assert.Equal(t, SessionDraftSourceDefault, resolved.Source)
+	assert.Equal(t, DraftPublishTurn, resolved.PublishTurn)
+	assert.Equal(t, DraftRefreshEveryTurns, resolved.RefreshEvery)
+}
+
+func TestResolveSessionDraft_ExplicitOnIsUserSourced(t *testing.T) {
+	withUserConfig(t, "session_draft: \"on\"\n")
+
+	resolved := ResolveSessionDraft()
+	require.NotNil(t, resolved)
+	assert.True(t, resolved.Enabled)
+	assert.Equal(t, SessionDraftSourceUserConfig, resolved.Source,
+		"provenance matters: `ox config` shows the user where a value came from")
+}
+
+// TestResolveSessionDraft_GarbageValueFallsBackToOn.
+//
+// A hand-edited config with a typo must not land in a third state. Falling back
+// to ON is the deliberate direction: the failure mode of wrongly-on is ledger
+// noise, while wrongly-off is a silently broken feature the user thinks is
+// working — which is the exact confusion drafts exist to remove.
+func TestResolveSessionDraft_GarbageValueFallsBackToOn(t *testing.T) {
+	for _, body := range []string{
+		"session_draft: \"yes\"\n",
+		"session_draft: \"OFF\"\n", // case-sensitive by design
+		"session_draft: \"0\"\n",
+	} {
+		t.Run(body, func(t *testing.T) {
+			withUserConfig(t, body)
+			resolved := ResolveSessionDraft()
+			require.NotNil(t, resolved)
+			assert.True(t, resolved.Enabled, "an unrecognized value must not silently disable")
+		})
+	}
+}
+
+// TestResolveSessionDraft_AlwaysCarriesUsableCadence — the publisher divides by
+// RefreshEvery and compares against PublishTurn. A resolution path that left
+// either at zero would either disable refreshes silently or publish on turn 0.
+func TestResolveSessionDraft_AlwaysCarriesUsableCadence(t *testing.T) {
+	for _, body := range []string{"", "session_draft: \"on\"\n", "session_draft: \"off\"\n"} {
+		withUserConfig(t, body)
+		resolved := ResolveSessionDraft()
+		require.NotNil(t, resolved)
+		assert.Positive(t, resolved.PublishTurn, "body=%q", body)
+		assert.Positive(t, resolved.RefreshEvery, "body=%q", body)
+	}
+}
+
+// TestSessionDraft_UserConfigRoundTrip proves the value survives the actual
+// save/load cycle `ox config set` uses — not just an in-memory struct.
+func TestSessionDraft_UserConfigRoundTrip(t *testing.T) {
+	withUserConfig(t, "")
+
+	cfg, err := LoadUserConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Empty(t, cfg.SessionDraft, "fresh config carries no value")
+
+	cfg.SessionDraft = SessionDraftOff
+	require.NoError(t, SaveUserConfig(cfg))
+
+	reloaded, err := LoadUserConfig()
+	require.NoError(t, err)
+	assert.Equal(t, SessionDraftOff, reloaded.SessionDraft)
+	assert.False(t, ResolveSessionDraft().Enabled,
+		"the persisted off switch must be honored on the next process")
+
+	// And unsetting restores the default rather than sticking at off.
+	reloaded.SessionDraft = ""
+	require.NoError(t, SaveUserConfig(reloaded))
+	assert.True(t, ResolveSessionDraft().Enabled, "unset returns to the default")
+}
+
+func TestIsValidSessionDraft(t *testing.T) {
+	for _, v := range []string{SessionDraftOn, SessionDraftOff, ""} {
+		assert.True(t, IsValidSessionDraft(v), "%q must be accepted", v)
+	}
+	for _, v := range []string{"yes", "ON", "true", "1", "cloud"} {
+		assert.False(t, IsValidSessionDraft(v), "%q must be rejected by `ox config set`", v)
+	}
+}
+
+func TestNormalizeSessionDraft(t *testing.T) {
+	assert.Equal(t, SessionDraftOff, NormalizeSessionDraft(SessionDraftOff))
+	for _, v := range []string{SessionDraftOn, "", "garbage", "OFF"} {
+		assert.Equal(t, SessionDraftOn, NormalizeSessionDraft(v),
+			"%q must normalize to the default, never to a third state", v)
+	}
+}

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -340,6 +340,12 @@ type UserConfig struct {
 	// internal/config/agent_summarizer.go and ADR-016.
 	AgentSummarizer string `yaml:"agent_summarizer,omitempty"`
 
+	// SessionDraft controls whether a meta.json-only draft placeholder is
+	// committed to the ledger partway through a recording, so the session's
+	// /c/<session_id> link resolves before session stop. "on" (default) or
+	// "off". See internal/config/session_draft.go and ADR-029.
+	SessionDraft string `yaml:"session_draft,omitempty"`
+
 	// Hooks holds per-hook-event policy switches. Today only carries the
 	// UserPromptSubmit cloud_query opt-in; see HooksConfig for rationale.
 	Hooks *HooksConfig `yaml:"hooks,omitempty"`

--- a/internal/daemon/agentwork/session_finalize.go
+++ b/internal/daemon/agentwork/session_finalize.go
@@ -63,6 +63,14 @@ type SessionFinalizePayload struct {
 	// the session just needs to be staged in ledger/sessions/ and pushed.
 	UploadOnly bool `json:"upload_only,omitempty"`
 
+	// PreservedSessionID carries the ses_ id read off a DRAFT placeholder in
+	// the ledger before stageSessionInLedger purged it (ADR-029). A draft's
+	// meta.json is an extra durable carrier of that id — and the only carrier
+	// for a recording whose raw.jsonl header predates the SessionID field — so
+	// it has to be captured before the purge deletes it and threaded to the
+	// meta write. Empty when no draft was superseded.
+	PreservedSessionID string `json:"preserved_session_id,omitempty"`
+
 	// storedSession is populated by BuildPrompt and reused by ProcessResult
 	// to avoid reading raw.jsonl twice.
 	storedSession *session.StoredSession `json:"-"`
@@ -361,6 +369,26 @@ func (h *SessionFinalizeHandler) detectInDir(sessionsDir, ledgerPath string) ([]
 		sessionDir := filepath.Join(sessionsDir, name)
 		rawPath := filepath.Join(sessionDir, artifactRaw)
 
+		// Never touch a draft placeholder (ADR-029). It is an in-progress
+		// marker for a live recording, not an unfinished session awaiting
+		// anti-entropy: it has no raw.jsonl to summarize and no artifacts to
+		// repair, and every work class below would either no-op noisily or
+		// write a failure stub into a directory the CLI is about to purge.
+		//
+		// The !hasRaw guard further down would also skip a well-formed draft
+		// today, but only incidentally. Making it explicit means the safety
+		// survives a future change to that guard, and gives the regression
+		// test something real to assert against.
+		// Fails CLOSED. An unreadable meta.json here (torn write, rebase
+		// conflict markers) must SKIP, not fall through: falling through
+		// reaches recoverRawFromSessionFile, which writes real transcript
+		// bytes onto the git-tracked raw.jsonl and breaks LFS linkage for the
+		// whole team. Skipping only defers finalization to a human.
+		if _, isDraft, metaErr := lfs.PreservedSessionIDAndDraft(sessionDir); isDraft || metaErr != nil {
+			h.logger.Debug("skipping draft or unclassifiable session", "session", name, "err", metaErr)
+			continue
+		}
+
 		// raw.jsonl must exist and be committed/pushed to the ledger.
 		// Without it there is nothing to summarize. For stale recordings
 		// missing raw.jsonl, recovery is attempted from the adapter source file.
@@ -576,6 +604,17 @@ func (h *SessionFinalizeHandler) DetectOrphanedForAgent(ledgerPath, agentID stri
 			}
 
 			sessionDir := filepath.Join(sessionsDir, name)
+
+			// Never treat a draft placeholder as an orphan to recover, and fail
+			// CLOSED on an unreadable meta.json. This is the other detection
+			// path that can reach recoverRawFromSessionFile, which would write
+			// real transcript bytes onto the git-tracked raw.jsonl and break
+			// LFS linkage for the whole team. detectInDir got this guard; this
+			// function is scanned by the same directories and needs it too.
+			if _, isDraft, metaErr := lfs.PreservedSessionIDAndDraft(sessionDir); isDraft || metaErr != nil {
+				continue
+			}
+
 			recPath := filepath.Join(sessionDir, recordingMarker)
 
 			// read .recording.json to check agent ID
@@ -1246,6 +1285,12 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 		// read.
 		return nil, fmt.Errorf("preserve existing SessionID for %s: %w", sessionName, err)
 	}
+	// A draft placeholder superseded by stageSessionInLedger held the id before
+	// it was purged. It outranks nothing that is already here — this only fills
+	// the gap where the staged dir carries no id of its own.
+	if preservedSessionID == "" && payload.PreservedSessionID != "" {
+		preservedSessionID = payload.PreservedSessionID
+	}
 	// start-minted ID carried in the raw.jsonl header so conversation URLs
 	// circulated during the live session (commit trailers, PR bodies) keep
 	// resolving after a daemon-side finalize
@@ -1328,6 +1373,17 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 		next.AgentType = agentType
 		next.SessionID = sessionIDForMeta
 
+		// Clear the draft placeholder markers (ADR-029). MANDATORY on this
+		// path, not defensive: `next := current` above deliberately preserves
+		// every field the daemon does not own, which is correct for
+		// redactions / produced_commits / linkage but would carry draft=true
+		// straight through finalization. The result would be a fully
+		// finalized session that every consumer keeps treating as
+		// provisional — doctor refuses to repair it, abort offers to delete
+		// it, and the writer-side draft invariant then rejects this very
+		// write because a finalized meta has a populated Files manifest.
+		next.ClearDraft()
+
 		// Daemon-owned summary fields, assigned UNCONDITIONALLY. Writing ""
 		// on a successful run is the intended clear; applying
 		// preserve-if-empty here would make a past failure permanently
@@ -1399,6 +1455,12 @@ func (h *SessionFinalizeHandler) writeMetaAndUploadLFS(payload *SessionFinalizeP
 		if base == nil {
 			base = meta
 		}
+		// Same preserve-everything shape as the first mutation, so it needs the
+		// same draft clear. Without it, a base that is still a draft on disk
+		// gets a populated Files manifest — which validateDraftShape refuses,
+		// so the write is rejected, the LFS refs are silently dropped, and the
+		// content lands as raw git blobs with no pointer files.
+		base.ClearDraft()
 		base.Files = h.mergeFileRefs(base.Files, fileRefs, sessionName)
 		return base, nil
 	}); err != nil {
@@ -1444,6 +1506,35 @@ func (h *SessionFinalizeHandler) stageSessionInLedger(payload *SessionFinalizePa
 
 	sessionName := filepath.Base(payload.SessionDir)
 	destDir := filepath.Join(payload.LedgerPath, "sessions", sessionName)
+
+	// Supersede any draft placeholder wholesale before copying (ADR-029).
+	// This loop copies every file from the cache dir over the destination, but
+	// a copy is not a purge: a server-authored summary.json sitting in the
+	// draft directory has no counterpart in the cache, so it would survive the
+	// copy and be picked up by missingArtifacts as if it were a real summary
+	// of the transcript. While meta.draft is true, everything in that
+	// directory is provisional.
+	//
+	// Best-effort: the copy below rewrites everything this path owns anyway,
+	// so a purge failure degrades to the pre-draft behavior rather than
+	// blocking finalization.
+	if draftID, wasDraft, err := lfs.PreservedSessionIDAndDraft(destDir); err == nil && wasDraft {
+		// Capture the draft's ses_ id BEFORE deleting the file that carries it.
+		// The draft is an extra durable carrier of that id, and it is the only
+		// carrier for a recording whose raw.jsonl header predates the field
+		// (legacy or imported). Purging first and resolving later would mint a
+		// fresh id and 404 a /c/ link already published in a PR body.
+		if draftID != "" {
+			payload.PreservedSessionID = draftID
+		}
+		if rmErr := h.runGit(payload.LedgerPath, "rm", "-r", "--force", "--ignore-unmatch", "--",
+			filepath.ToSlash(filepath.Join("sessions", sessionName))); rmErr != nil {
+			h.logger.Warn("draft purge (git rm) failed; staging over the draft", "session", sessionName, "err", rmErr)
+		}
+		if rmErr := os.RemoveAll(destDir); rmErr != nil {
+			h.logger.Warn("draft purge (worktree) failed; staging over the draft", "session", sessionName, "err", rmErr)
+		}
+	}
 
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return fmt.Errorf("create ledger session dir: %w", err)

--- a/internal/daemon/agentwork/session_finalize_draft_test.go
+++ b/internal/daemon/agentwork/session_finalize_draft_test.go
@@ -1,0 +1,413 @@
+package agentwork
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Draft-placeholder behavior in daemon anti-entropy (ADR-029).
+//
+// The stakes here are higher than in the CLI: every work class in this file
+// either writes into a git-tracked session directory or spends LLM tokens, and
+// the one path that must never fire on a draft — recoverRawFromSessionFile —
+// writes REAL transcript bytes onto the tracked raw.jsonl, which breaks LFS
+// linkage and makes the ledger reject every future push for the whole team.
+
+const draftTestSessionID = "ses_01950000-0000-7000-8000-0000000000bb"
+
+func writeDraftMeta(t *testing.T, sessionDir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	updated := time.Now().UTC()
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, &lfs.SessionMeta{
+		Version:     "1.0",
+		SessionName: filepath.Base(sessionDir),
+		SessionID:   draftTestSessionID,
+		AgentID:     "OxDraft",
+		AgentType:   "claude-code",
+		CreatedAt:   time.Now().UTC(),
+		Draft:       true,
+		TurnCount:   2,
+		UpdatedAt:   &updated,
+		Files:       map[string]lfs.FileRef{},
+	}))
+}
+
+// writeFinalizedSession writes a session with a REAL raw.jsonl and a stub
+// summary — the shape anti-entropy is supposed to pick up. Used as the
+// negative control.
+func writeFinalizedSession(t *testing.T, sessionDir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	raw := `{"type":"header","metadata":{"version":"1.0","agent_id":"OxReal"}}` + "\n" +
+		`{"ts":"2026-01-01T00:01:00Z","type":"user","content":"real transcript content"}` + "\n" +
+		`{"ts":"2026-01-01T00:02:00Z","type":"assistant","content":"a real reply"}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(sessionDir, "raw.jsonl"), []byte(raw), 0644))
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, &lfs.SessionMeta{
+		Version: "1.0", SessionName: filepath.Base(sessionDir),
+		AgentID: "OxReal", AgentType: "claude-code", CreatedAt: time.Now().UTC(),
+	}))
+}
+
+// staleRecordingMarker writes an abandoned recording marker.
+//
+// The PID is 999999999, matching this package's existing convention
+// (session_watcher_test.go: "PID that definitely doesn't exist"). NOT 999999 —
+// that is well under Linux's usual pid_max of 4194304, so on a busy machine it
+// can be a LIVE process. And the failure is silent rather than flaky: a live
+// PID makes isStaleRecording return not-stale, the function returns zero items
+// before ever reaching the draft guard, and the assertion passes even with the
+// guard deleted.
+// markDirAsDraft stamps draft:true onto an EXISTING meta.json, preserving
+// whatever else the directory holds.
+//
+// Deliberately not WriteDraftSessionMeta: that refuses a directory containing
+// raw.jsonl, which is the point of the guard on the write side. This models the
+// state that arises anyway — a tail-watcher transcript landing in a directory a
+// draft already claimed — and it is the only fixture in which the daemon's
+// draft skip is the sole thing preventing work.
+func markDirAsDraft(t *testing.T, sessionDir string) {
+	t.Helper()
+	meta, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	updated := time.Now().UTC()
+	meta.Draft = true
+	meta.TurnCount = 2
+	meta.UpdatedAt = &updated
+	meta.Files = map[string]lfs.FileRef{}
+	require.NoError(t, lfs.WriteSessionMetaOnly(sessionDir, meta))
+}
+
+func staleRecordingMarker(t *testing.T, sessionDir string, age time.Duration) {
+	t.Helper()
+	body := `{"agent_id":"OxDraft","started_at":"` +
+		time.Now().Add(-age).UTC().Format(time.RFC3339) + `","parent_pid":999999999}`
+	path := filepath.Join(sessionDir, ".recording.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0644))
+	old := time.Now().Add(-age)
+	require.NoError(t, os.Chtimes(path, old, old))
+}
+
+// TestDetectInDir_SkipsDraftPlaceholders.
+//
+// The final row is MANDATORY. Without a case that yields work, this whole table
+// passes with the draft logic deleted — a meta-only directory already returns
+// zero items via the `!hasRaw` continue, so every draft row would be
+// vacuously green.
+func TestDetectInDir_SkipsDraftPlaceholders(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, sessionDir string)
+		// wantItems: the fixture should produce anti-entropy work.
+		wantItems bool
+		// plantsRaw: the fixture deliberately puts a transcript in the tracked
+		// directory, so the "no bytes recovered here" assertion does not apply
+		// — the point of that row is that no WORK is produced despite it.
+		plantsRaw bool
+	}{
+		{
+			name:  "draft only",
+			setup: func(t *testing.T, dir string) { writeDraftMeta(t, dir) },
+		},
+		{
+			name: "draft with a stale recording marker",
+			setup: func(t *testing.T, dir string) {
+				writeDraftMeta(t, dir)
+				staleRecordingMarker(t, dir, 26*time.Hour)
+			},
+		},
+		{
+			name: "draft with a server-authored summary",
+			setup: func(t *testing.T, dir string) {
+				writeDraftMeta(t, dir)
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "summary.json"),
+					[]byte(`{"title":"Zero-turn session"}`), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "summary.md"),
+					[]byte("SERVER_AUTHORED"), 0644))
+			},
+		},
+		{
+			name: "unreadable meta fails CLOSED",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte(`{"draft":tr`), 0644))
+				staleRecordingMarker(t, dir, 26*time.Hour)
+			},
+		},
+		{
+			// THE ROW THAT ACTUALLY TESTS THE GUARD.
+			//
+			// Every other draft row above is skipped by the pre-existing
+			// `!hasRaw` continue, so they all stay green with the draft guard
+			// DELETED — they prove the table is not vacuous, not that the guard
+			// works. This row is a draft-marked directory that ALSO holds a
+			// real transcript, so without the guard detectInDir would finalize
+			// it: spend LLM tokens on it, write artifacts into it, and race the
+			// CLI that is about to purge it.
+			//
+			// Not hypothetical. The daemon's tail-watcher writes live
+			// transcripts into this same git-tracked directory, so a draft
+			// published while tail mode is running produces exactly this shape.
+			name: "draft marked on a directory that ALSO holds a real transcript",
+			setup: func(t *testing.T, dir string) {
+				writeFinalizedSession(t, dir) // real raw.jsonl with substantive entries
+				markDirAsDraft(t, dir)        // ...then stamped as a draft
+			},
+			plantsRaw: true,
+		},
+		{
+			name:      "NEGATIVE CONTROL: real session with a stub summary yields work",
+			setup:     func(t *testing.T, dir string) { writeFinalizedSession(t, dir) },
+			wantItems: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ledgerPath := t.TempDir()
+			sessionsDir := filepath.Join(ledgerPath, "sessions")
+			sessionDir := filepath.Join(sessionsDir, "2026-01-01T00-00-testuser-OxD001")
+			tc.setup(t, sessionDir)
+
+			h := NewSessionFinalizeHandlerForTest(slog.New(slog.DiscardHandler))
+			items, detectErr := h.Detect(ledgerPath)
+			require.NoError(t, detectErr)
+
+			if tc.wantItems {
+				assert.NotEmpty(t, items,
+					"the negative control must produce work, or this table proves nothing")
+				return
+			}
+			assert.Empty(t, items, "a draft must produce no anti-entropy work")
+
+			if !tc.plantsRaw {
+				// The invariant that actually matters: anti-entropy must never
+				// RECOVER transcript bytes onto the git-tracked path, which is
+				// the LFS-linkage break.
+				assert.NoFileExists(t, filepath.Join(sessionDir, "raw.jsonl"),
+					"anti-entropy must never recover transcript bytes into a tracked draft directory")
+			}
+		})
+	}
+}
+
+// TestDetectOrphanedForAgent_SkipsDraftPlaceholders.
+//
+// The second detection path that can reach recoverRawFromSessionFile. It scans
+// the same git-tracked sessions/ directory as detectInDir but is guarded only
+// by .recording.json presence, so it needed the same skip.
+func TestDetectOrphanedForAgent_SkipsDraftPlaceholders(t *testing.T) {
+	h := NewSessionFinalizeHandlerForTest(slog.New(slog.DiscardHandler))
+
+	t.Run("meta-only draft", func(t *testing.T) {
+		ledgerPath := t.TempDir()
+		sessionDir := filepath.Join(ledgerPath, "sessions", "2026-01-01T00-00-testuser-OxD002")
+		writeDraftMeta(t, sessionDir)
+		staleRecordingMarker(t, sessionDir, 26*time.Hour)
+
+		assert.Empty(t, h.DetectOrphanedForAgent(ledgerPath, "OxDraft", 999999999),
+			"a draft must never be treated as an orphan to recover")
+		assert.NoFileExists(t, filepath.Join(sessionDir, "raw.jsonl"))
+
+		meta, err := lfs.ReadSessionMeta(sessionDir)
+		require.NoError(t, err)
+		assert.True(t, meta.IsDraft(), "the draft meta must be untouched")
+	})
+
+	t.Run("draft over a real transcript: the guard is the only thing acting", func(t *testing.T) {
+		ledgerPath := t.TempDir()
+		sessionDir := filepath.Join(ledgerPath, "sessions", "2026-01-01T00-00-testuser-OxD002")
+		writeFinalizedSession(t, sessionDir)
+		markDirAsDraft(t, sessionDir)
+		staleRecordingMarker(t, sessionDir, 26*time.Hour)
+
+		assert.Empty(t, h.DetectOrphanedForAgent(ledgerPath, "OxDraft", 999999999),
+			"without the draft guard this directory produces orphan-recovery work")
+	})
+
+	t.Run("NEGATIVE CONTROL: a real orphan still yields work", func(t *testing.T) {
+		ledgerPath := t.TempDir()
+		sessionDir := filepath.Join(ledgerPath, "sessions", "2026-01-01T00-00-testuser-OxD00R")
+		writeFinalizedSession(t, sessionDir)
+		staleRecordingMarker(t, sessionDir, 26*time.Hour)
+
+		assert.NotEmpty(t, h.DetectOrphanedForAgent(ledgerPath, "OxDraft", 999999999),
+			"or the two rows above prove nothing")
+	})
+}
+
+// TestClearDraft_OnPreserveEverythingMutation.
+//
+// The daemon's finalize does `next := current` to preserve fields it does not
+// own — correct for redactions / produced_commits / linkage, but it would carry
+// draft:true straight through finalization. The result would be a fully
+// finalized session that every consumer keeps treating as provisional, that
+// doctor refuses to repair, and whose own write is then REJECTED by the draft
+// writer-invariant once a Files manifest is attached.
+//
+// This drives the actual mutation shape rather than asserting on ClearDraft in
+// isolation, because the bug is in the interaction.
+func TestClearDraft_OnPreserveEverythingMutation(t *testing.T) {
+	sessionDir := t.TempDir()
+	writeDraftMeta(t, sessionDir)
+
+	// Exactly what writeMetaAndUploadLFS does.
+	require.NoError(t, lfs.MutateSessionMeta(t.Context(), sessionDir,
+		func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+			next := current
+			require.NotNil(t, next)
+			next.ClearDraft()
+			next.Title = "Real finalized session"
+			next.EntryCount = 42
+			next.Files = map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}}
+			return next, nil
+		}))
+
+	meta, err := lfs.ReadSessionMeta(sessionDir)
+	require.NoError(t, err)
+	assert.False(t, meta.IsDraft(), "finalization must clear the draft marker")
+	assert.Zero(t, meta.TurnCount)
+	assert.Nil(t, meta.UpdatedAt)
+	assert.Equal(t, draftTestSessionID, meta.SessionID, "the ses_ id must survive finalization")
+	assert.Equal(t, "Real finalized session", meta.Title)
+
+	// Byte-level: no residual draft key at all.
+	raw, err := os.ReadFile(filepath.Join(sessionDir, "meta.json"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), `"draft"`)
+}
+
+// TestClearDraftOmitted_IsRejectedByWriterInvariant proves the guard above is
+// load-bearing rather than cosmetic: forgetting ClearDraft does not merely
+// leave a stale flag, it makes the entire meta write FAIL, which on the daemon
+// path silently drops the LFS refs and leaves content committed as raw git
+// blobs with no pointer files.
+func TestClearDraftOmitted_IsRejectedByWriterInvariant(t *testing.T) {
+	sessionDir := t.TempDir()
+	writeDraftMeta(t, sessionDir)
+
+	err := lfs.MutateSessionMeta(t.Context(), sessionDir,
+		func(current *lfs.SessionMeta) (*lfs.SessionMeta, error) {
+			next := current
+			next.Files = map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}}
+			return next, nil // ClearDraft deliberately omitted
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not name artifacts")
+}
+
+// TestStageSessionInLedger_PurgesDraftAndPreservesSessionID.
+//
+// Two properties in one flow, both load-bearing:
+//
+//  1. A server-authored artifact in the draft directory has no counterpart in
+//     the cache, so the copy loop alone would leave it in place and
+//     missingArtifacts would then treat it as a real summary of the transcript.
+//  2. The ses_ id must be read from the draft BEFORE the purge deletes the file
+//     carrying it. For a recording whose raw.jsonl header predates the
+//     SessionID field, the draft is the ONLY carrier — losing it mints a fresh
+//     id and 404s a /c/ link already published in a PR body.
+func TestStageSessionInLedger_PurgesDraftAndPreservesSessionID(t *testing.T) {
+	// A REAL git repo. Without one, the handler's `git rm` fails, is swallowed
+	// as a Warn, and every assertion below is satisfied by the os.RemoveAll
+	// alone — so deleting the `git rm` entirely left this test green while the
+	// daemon's purge silently degraded to a worktree-only delete, leaving the
+	// server-authored artifact tracked in the index and the ledger dirty.
+	ledgerPath := initTestGitRepo(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxD003"
+
+	// git-tracked draft, polluted by a server-authored summary
+	destDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	writeDraftMeta(t, destDir)
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "summary.json"),
+		[]byte(`{"title":"Zero-turn session","files_changed":[{"path":"SERVER.md"}]}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "summary.md"),
+		[]byte("SERVER_AUTHORED_SENTINEL"), 0644))
+
+	// COMMIT them. In production the draft is committed and pushed, and the
+	// server's summary arrives via a pull — so `git rm` has tracked files to
+	// remove. With everything merely untracked, `git rm --ignore-unmatch` is a
+	// silent no-op and the index assertion below cannot distinguish a working
+	// purge from a missing one.
+	runGitCmd(t, ledgerPath, "add", "-A")
+	runGitCmd(t, ledgerPath, "commit", "--no-verify", "-q", "-m", "draft + server summary")
+
+	// the real recording, waiting in the cache
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"),
+		[]byte(`{"type":"header"}`+"\n"+`{"type":"user","content":"real"}`+"\n"), 0644))
+
+	h := NewSessionFinalizeHandlerForTest(slog.New(slog.DiscardHandler))
+	payload := &SessionFinalizePayload{SessionDir: cacheDir, LedgerPath: ledgerPath}
+	require.NoError(t, h.stageSessionInLedger(payload))
+
+	assert.Equal(t, destDir, payload.SessionDir, "payload must point at the staged location")
+	assert.Equal(t, draftTestSessionID, payload.PreservedSessionID,
+		"the draft's ses_ id must be captured before the purge deletes it")
+
+	assert.NoFileExists(t, filepath.Join(destDir, "summary.json"),
+		"a server-authored summary of the zero-turn draft must not survive staging")
+	assert.NoFileExists(t, filepath.Join(destDir, "summary.md"))
+	assert.FileExists(t, filepath.Join(destDir, "raw.jsonl"), "the real transcript must be staged")
+
+	// The INDEX, not just the worktree. os.RemoveAll alone leaves the
+	// server-authored files tracked: the ledger reports dirty, the next
+	// checkout restores them, and anti-entropy picks them up again. Only the
+	// `git rm` half produces a staged deletion.
+	staged := gitOutput(t, ledgerPath, "diff", "--cached", "--name-status")
+	assert.Contains(t, staged, "D\tsessions/"+sessionName+"/summary.json",
+		"the purge must stage a DELETION, not merely remove the file from the worktree")
+	assert.Contains(t, staged, "D\tsessions/"+sessionName+"/summary.md")
+}
+
+// initTestGitRepo creates a real git repo with one commit, so index-level
+// assertions are possible. Reuses this package's existing runGitCmd/gitOutput
+// helpers (session_finalize_git_test.go) rather than adding a third pair.
+func initTestGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitCmd(t, dir, "init", "--quiet")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitkeep"), nil, 0644))
+	runGitCmd(t, dir, "add", ".gitkeep")
+	runGitCmd(t, dir, "commit", "--no-verify", "-q", "-m", "init")
+	return dir
+}
+
+// TestStageSessionInLedger_LeavesFinalizedSessionAlone is the negative control
+// for the purge. Without it, "always purge the destination" passes the test
+// above while destroying a legitimate prior upload.
+func TestStageSessionInLedger_LeavesFinalizedSessionAlone(t *testing.T) {
+	ledgerPath := initTestGitRepo(t)
+	const sessionName = "2026-01-01T00-00-testuser-OxD004"
+
+	destDir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(destDir, 0755))
+	require.NoError(t, lfs.WriteSessionMetaOnly(destDir, &lfs.SessionMeta{
+		Version: "1.0", SessionName: sessionName, SessionID: draftTestSessionID,
+		CreatedAt: time.Now(), Title: "already finalized",
+		Files: map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}},
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "summary.md"), []byte("REAL SUMMARY"), 0644))
+
+	cacheDir := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "raw.jsonl"), []byte(`{"type":"header"}`+"\n"), 0644))
+
+	h := NewSessionFinalizeHandlerForTest(slog.New(slog.DiscardHandler))
+	payload := &SessionFinalizePayload{SessionDir: cacheDir, LedgerPath: ledgerPath}
+	require.NoError(t, h.stageSessionInLedger(payload))
+
+	body, err := os.ReadFile(filepath.Join(destDir, "summary.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "REAL SUMMARY", string(body),
+		"a finalized session's artifacts must not be purged")
+	assert.Empty(t, payload.PreservedSessionID, "no draft was superseded, so nothing to carry")
+}

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1511,6 +1511,13 @@ func (s *SyncScheduler) doPull(ctx context.Context, progress *ProgressWriter, fo
 		}
 	}
 
+	// push any unpushed session-draft commits (batched by sync cycle).
+	// Not gated on whisperRegistry — drafts are unrelated to murmurs, and a
+	// repo with whispers disabled still needs its /c/ links to resolve.
+	if l := s.workspaceRegistry.GetLedger(); l != nil && l.Path != "" && l.Exists {
+		s.pushSessionDraftCommits(ctx, l.Path)
+	}
+
 	if progress != nil {
 		_ = progress.WriteStage("complete", "Pull complete")
 	}
@@ -1600,6 +1607,112 @@ func (s *SyncScheduler) pushMurmurCommits(ctx context.Context, ledgerPath string
 		},
 	}); err != nil {
 		s.logger.Warn("murmur push failed (non-fatal)", "error", err)
+	}
+}
+
+// pushSessionDraftCommits pushes local session-draft commits to the ledger
+// remote, batched onto the sync cycle (~60s) exactly like pushMurmurCommits.
+//
+// Why the daemon and not the CLI: the draft commit is made by a Stop hook, on a
+// turn boundary. pushLedger is a pre-push secret scan plus a credential refresh
+// plus an LFS reconcile plus a three-attempt pull-rebase loop — seconds of
+// latency the user would feel on every publish. Deferring the push here keeps
+// the hook at a local `git commit` (tens of milliseconds) while still getting
+// the placeholder to the server, which is the entire point of drafts. The CLI
+// still owns the write; only the push is batched.
+//
+// Detection is by commit SUBJECT, deliberately NOT by a pathspec on sessions/.
+// A pathspec would also match session FINALIZE commits, and pushing one of
+// those before the CLI has uploaded its LFS blobs is rejected by the ledger's
+// pre-receive hook ("LFS objects are missing"). The CLI owns that ordering.
+//
+// # Why this refuses to push when ANY non-draft commit is unpushed
+//
+// `git push` moves the whole branch, so a draft commit sitting on top of an
+// unpushed CLI commit would carry that commit along. The CLI's pushLedger runs
+// a pre-push secret gate and an LFS reconcile before every push; this path runs
+// neither. Pushing here would therefore ship a commit the CLI may have
+// deliberately REFUSED to push — including one the secret scanner rejected for
+// containing a credential — and would ship a finalize commit before its LFS
+// blobs are uploaded, which the ledger's pre-receive hook rejects anyway.
+//
+// So the rule is: push only when every unpushed commit is a draft commit.
+// Otherwise leave it entirely to the CLI, which has the full gate stack. This
+// is strictly narrower than the murmur equivalent, deliberately — drafts fire
+// far more often, and this path is not gated on any feature registry.
+// sessionDraftCommitPrefix is the commit-subject marker the CLI writes for
+// every draft-placeholder commit (publish, refresh, supersede, retract,
+// discard). The daemon uses it to decide whether an unpushed branch consists
+// exclusively of draft commits.
+const sessionDraftCommitPrefix = "session-draft: "
+
+// shouldPushSessionDrafts decides whether an unpushed commit set is safe for
+// the daemon to push, given the newline-separated commit subjects.
+//
+// Extracted as a pure function on purpose. This is the single security
+// property of the draft-push path — it is what stands between the daemon and
+// pushing a commit the CLI's pre-push secret gate refused — and the push itself
+// goes through gitutil.PushWithRetry, which is not injectable. Left inline, a
+// test could only observe "one git call happened" either way, which
+// distinguishes nothing.
+//
+// Returns (blockingSubject, false) when a non-draft commit is present, so the
+// caller can say WHICH commit blocked it; ("", false) when there is nothing to
+// push at all.
+func shouldPushSessionDrafts(logOutput string) (blockingSubject string, ok bool) {
+	trimmed := strings.TrimSpace(logOutput)
+	if trimmed == "" {
+		return "", false
+	}
+	sawDraft := false
+	for _, subject := range strings.Split(trimmed, "\n") {
+		subject = strings.TrimSpace(subject)
+		if subject == "" {
+			continue
+		}
+		if !strings.HasPrefix(subject, sessionDraftCommitPrefix) {
+			return subject, false
+		}
+		sawDraft = true
+	}
+	return "", sawDraft
+}
+
+func (s *SyncScheduler) pushSessionDraftCommits(ctx context.Context, ledgerPath string) {
+	ctx, span := perf.Start(ctx, "daemon:push_session_drafts")
+	defer span.End()
+
+	// Subjects of every unpushed commit, one per line.
+	out, err := s.git.RunGit(ctx, ledgerPath, "log", "--format=%s", "@{upstream}..HEAD")
+	if err != nil || strings.TrimSpace(out) == "" {
+		return
+	}
+
+	if blocker, ok := shouldPushSessionDrafts(out); !ok {
+		if blocker != "" {
+			s.logger.Debug("skipping session-draft push: a non-draft commit is unpushed",
+				"path", ledgerPath, "blocking_subject", blocker)
+		}
+		return
+	}
+
+	s.logger.Debug("pushing unpushed session-draft commits", "path", ledgerPath)
+
+	s.ledgerMu.Lock()
+	defer s.ledgerMu.Unlock()
+
+	ep := s.workspaceRegistry.GetEndpoint()
+	if err := gitutil.PushWithRetry(ctx, ledgerPath, gitutil.PushOpts{
+		AutoResolvePrefixes: ledger.AutoResolvePrefixes,
+		Logger:              s.logger,
+		PrePush: func(repoPath string) error {
+			if ep != "" {
+				return gitserver.RefreshRemoteCredentials(repoPath, ep)
+			}
+			return nil
+		},
+	}); err != nil {
+		s.logger.Warn("session-draft push failed (non-fatal)", "error", err)
 	}
 }
 

--- a/internal/daemon/sync_session_draft_test.go
+++ b/internal/daemon/sync_session_draft_test.go
@@ -1,0 +1,198 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pushSessionDraftCommits is the highest-blast-radius function in the draft
+// feature, and the reason is what it does NOT run.
+//
+// The CLI's pushLedger runs a pre-push secret gate and an LFS reconcile before
+// every push. This path runs neither — and `git push` moves the whole branch.
+// So the ONLY thing standing between the daemon and pushing a commit the CLI
+// deliberately refused (a credential the secret scanner rejected) or a finalize
+// commit whose LFS blobs are not uploaded yet, is the rule that every unpushed
+// commit must be a draft commit.
+//
+// Delete that rule and nothing else in the codebase notices.
+
+func newDraftPushScheduler(t *testing.T, mock *mockGitRunner) (*SyncScheduler, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.ProjectRoot = tmpDir
+	cfg.LedgerPath = tmpDir
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return NewSyncScheduler(cfg, logger, WithGitRunner(mock)), tmpDir
+}
+
+// TestShouldPushSessionDrafts is the security property, tested on the pure
+// decision rather than through the mock — the push goes through
+// gitutil.PushWithRetry, which is not injectable, so an integration-only test
+// could observe "one git call happened" for both outcomes and distinguish
+// nothing.
+//
+// Every ok=false row is a way an ungated commit would otherwise reach the
+// shared remote.
+func TestShouldPushSessionDrafts(t *testing.T) {
+	tests := []struct {
+		name        string
+		subjects    string // newline-separated commit subjects, newest first
+		wantOK      bool
+		wantBlocker string
+		why         string
+	}{
+		{
+			name:     "all draft commits",
+			subjects: "session-draft: 2026-01-01T00-00-u-OxA\nsession-draft: supersede 2026-01-01T00-00-u-OxB",
+			wantOK:   true,
+			why:      "the only case where pushing without the secret gate is acceptable",
+		},
+		{
+			name:        "a session finalize commit is unpushed underneath",
+			subjects:    "session-draft: 2026-01-01T00-00-u-OxA\nsession: 2026-01-01T00-00-u-OxB",
+			wantBlocker: "session: 2026-01-01T00-00-u-OxB",
+			why: "pushing a finalize before its LFS blobs are uploaded is rejected by the " +
+				"ledger's pre-receive hook, and this path has no ReconcileLFS to recover",
+		},
+		{
+			name:        "an arbitrary CLI commit is unpushed underneath",
+			subjects:    "session-draft: 2026-01-01T00-00-u-OxA\nsummary: 2026-01-01T00-00-u-OxB",
+			wantBlocker: "summary: 2026-01-01T00-00-u-OxB",
+			why:         "it may be a commit the CLI's pre-push secret gate refused",
+		},
+		{
+			name:        "the blocking commit is NEWEST, not oldest",
+			subjects:    "chore: something\nsession-draft: 2026-01-01T00-00-u-OxA",
+			wantBlocker: "chore: something",
+			why:         "order must not matter — any non-draft blocks",
+		},
+		{
+			name:     "nothing unpushed",
+			subjects: "",
+			why:      "no work to do, and no blocker to report",
+		},
+		{
+			name:     "only whitespace",
+			subjects: "   \n  \n",
+			why:      "an empty result must not be parsed into a phantom draft commit",
+		},
+		{
+			name:        "a subject that merely CONTAINS the marker",
+			subjects:    "fix: handle session-draft: prefixes correctly",
+			wantBlocker: "fix: handle session-draft: prefixes correctly",
+			why:         "the marker must anchor at the START, or any commit mentioning it slips through",
+		},
+		{
+			name:     "a subject with leading whitespace before the marker",
+			subjects: "  session-draft: 2026-01-01T00-00-u-OxA",
+			wantOK:   true,
+			why:      "git may pad output; a real draft commit must not be misread as a blocker",
+		},
+		{
+			name:     "single draft commit",
+			subjects: "session-draft: discard 2026-01-01T00-00-u-OxA",
+			wantOK:   true,
+			why:      "abort/retract commits are draft commits and must still be pushed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			blocker, ok := shouldPushSessionDrafts(tc.subjects)
+			assert.Equal(t, tc.wantOK, ok, tc.why)
+			assert.Equal(t, tc.wantBlocker, blocker,
+				"the blocking subject is what the operator sees in the log")
+		})
+	}
+}
+
+// TestPushSessionDraftCommits_AlwaysChecksBeforeActing wires the pure decision
+// to the real call path, so a refactor cannot leave the guard defined but
+// unreferenced.
+func TestPushSessionDraftCommits_AlwaysChecksBeforeActing(t *testing.T) {
+	mock := &mockGitRunner{output: "session: not-a-draft"}
+	s, ledgerPath := newDraftPushScheduler(t, mock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	s.pushSessionDraftCommits(ctx, ledgerPath)
+
+	require.Equal(t, int64(1), mock.calls.Load(),
+		"a blocked push must read the subjects and then stop, not proceed to git operations")
+	assert.Contains(t, mock.lastArgs, "log")
+}
+
+// TestPushSessionDraftCommits_ChecksSubjectsNotPathspec.
+//
+// The detection deliberately reads commit SUBJECTS rather than filtering by a
+// pathspec on sessions/. A pathspec would also match session FINALIZE commits,
+// which touch the same directory — and pushing one of those before its LFS
+// blobs exist is exactly what the ledger rejects. If someone "simplifies" this
+// to a pathspec, the filter silently starts approving the commits it exists to
+// block.
+func TestPushSessionDraftCommits_ChecksSubjectsNotPathspec(t *testing.T) {
+	mock := &mockGitRunner{output: ""}
+	s, ledgerPath := newDraftPushScheduler(t, mock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	s.pushSessionDraftCommits(ctx, ledgerPath)
+
+	args := strings.Join(mock.lastArgs, " ")
+	assert.Contains(t, args, "--format=%s", "must read subjects")
+	assert.NotContains(t, args, "sessions/",
+		"must NOT filter by pathspec — that would match finalize commits too")
+}
+
+// TestPushSessionDraftCommits_GitErrorIsNonFatal — the sync cycle must survive a
+// ledger that is mid-rebase or otherwise unreadable. A panic or a hang here
+// stalls every other sync task behind it.
+func TestPushSessionDraftCommits_GitErrorIsNonFatal(t *testing.T) {
+	mock := &mockGitRunner{output: "", err: assert.AnError}
+	s, ledgerPath := newDraftPushScheduler(t, mock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	assert.NotPanics(t, func() { s.pushSessionDraftCommits(ctx, ledgerPath) })
+}
+
+// TestSessionDraftCommitPrefix_MatchesEveryWriter.
+//
+// The daemon's filter and the CLI's commit messages are coupled by a string.
+// The CLI produces four subjects — publish/refresh, supersede, retract, discard
+// — and every one of them must match, or drafts silently stop being pushed for
+// that operation with no error anywhere.
+//
+// This pins the contract from the daemon side; the message formats live in
+// cmd/ox/session_draft.go and are asserted against real commits there.
+func TestSessionDraftCommitPrefix_MatchesEveryWriter(t *testing.T) {
+	const name = "2026-01-01T00-00-testuser-OxPfx1"
+	for _, subject := range []string{
+		"session-draft: " + name,           // publish / refresh
+		"session-draft: supersede " + name, // finalize takeover
+		"session-draft: retract " + name,   // zero-entry stop
+		"session-draft: discard " + name,   // abort
+	} {
+		assert.True(t, strings.HasPrefix(subject, sessionDraftCommitPrefix),
+			"subject %q must match the daemon's push filter", subject)
+	}
+
+	for _, subject := range []string{
+		"session: " + name,
+		"summary: " + name,
+		"lfs: pointerize " + name,
+		"recover uncommitted sessions",
+	} {
+		assert.False(t, strings.HasPrefix(subject, sessionDraftCommitPrefix),
+			"subject %q must NOT be treated as a draft commit", subject)
+	}
+}

--- a/internal/ledgersearch/ledgersearch.go
+++ b/internal/ledgersearch/ledgersearch.go
@@ -173,6 +173,34 @@ func tokenize(q string) []string {
 	return out
 }
 
+// isDraftSession reports whether a ledger session directory holds a draft
+// placeholder (ADR-029) rather than a finalized recording.
+//
+// A draft has no summary.md or session.md of its own, so skipping it is usually
+// a no-op — but the SageOx server may author a summary against the zero-turn
+// draft and push it, and indexing that would make a fabricated summary of an
+// empty session searchable and citable as team knowledge. Finalize purges those;
+// this keeps them out of results in the meantime.
+//
+// Decoded locally rather than via lfs.ReadSessionMeta, matching planTimestamp
+// below: this runs on the UserPromptSubmit hook latency path, and the package
+// deliberately carries no ox-internal dependencies. Fail-open — an unreadable
+// or absent meta.json is not a draft, so a malformed file can never make a real
+// session invisible to search.
+func isDraftSession(sessionPath string) bool {
+	data, err := os.ReadFile(filepath.Join(sessionPath, "meta.json"))
+	if err != nil {
+		return false
+	}
+	var meta struct {
+		Draft bool `json:"draft"`
+	}
+	if json.Unmarshal(data, &meta) != nil {
+		return false
+	}
+	return meta.Draft
+}
+
 // scanSessions walks sessions/<session-name>/ and scores summary/meta hits.
 // Reads only summary.md and meta.json — skips raw.jsonl (large, low signal,
 // often dehydrated to LFS pointer files).
@@ -196,6 +224,10 @@ func scanSessions(ledgerPath string, terms []string, now time.Time) []Result {
 			continue
 		}
 		sessionPath := filepath.Join(sessionsDir, name)
+
+		if isDraftSession(sessionPath) {
+			continue
+		}
 
 		// scan summary.md first (highest signal), fall back to session.md
 		for _, candidate := range []string{"summary.md", "session.md"} {

--- a/internal/lfs/meta.go
+++ b/internal/lfs/meta.go
@@ -212,7 +212,95 @@ type SessionMeta struct {
 	// treated as pre-linkage and never blocking. omitempty for round-trip.
 	LinkageStatus string `json:"linkage_status,omitempty"`
 
+	// Draft marks this meta.json as an EARLY PLACEHOLDER published while the
+	// recording is still in progress — not a finalized session record. It
+	// exists so https://<endpoint>/c/<session_id> resolves for links already
+	// circulating in PR bodies and commit trailers, long before session stop.
+	//
+	// A draft directory contains meta.json and NOTHING ELSE. In particular it
+	// contains no raw.jsonl: writing real transcript bytes to the git-tracked
+	// <ledger>/sessions/<name>/raw.jsonl breaks LFS linkage (the ledger then
+	// rejects every future push, for every teammate, with "LFS objects are
+	// missing") and defeats the daemon's pointer-stub skip in
+	// session_finalize.go, causing re-finalize and clobber. See
+	// .claude/rules/cache-only-design.md and the 2026-04-25 Phase 2 incident.
+	// That structural emptiness is also the privacy guarantee: a draft cannot
+	// contain turn data, by construction, so aborting one cannot leak.
+	//
+	// # Provisionality invariant (LOAD-BEARING)
+	//
+	// While Draft is true, EVERY file in that session directory is provisional
+	// and is purged wholesale at finalize. The SageOx server may author
+	// summary.json / summary.md against the zero-turn draft and push them; a
+	// finalize-time `git pull --rebase` folds those into the working tree, and
+	// they MUST NOT survive into the finalized session as if an LLM had read
+	// the transcript. A whitelist of "files we know the server might write"
+	// rots the first time the server writes something new; deleting the whole
+	// directory cannot.
+	//
+	// Every consumer that treats "sessions/<name>/meta.json exists" as "this
+	// session is real" MUST branch on IsDraft() first — never read this field
+	// directly.
+	//
+	// Back-compat: an absent key means "not a draft". omitempty keeps every
+	// existing meta.json byte-identical and older readers unaffected. Version
+	// is deliberately NOT bumped — additive optional field, same policy as
+	// SessionID.
+	Draft bool `json:"draft,omitempty"`
+
+	// TurnCount is the number of agent response turns observed when this
+	// meta.json was written. Drafts set it (and refresh it periodically) purely
+	// so the server's in-progress /c/ page can show forward motion — a climbing
+	// counter is the signal that distinguishes "recording is working" from
+	// "recording is silently broken". Counters only, never content.
+	//
+	// Finalize clears it: EntryCount is the authoritative measure of a finished
+	// session, and leaving both would invite consumers to disagree about which
+	// one means "size".
+	TurnCount int `json:"turn_count,omitempty"`
+
+	// UpdatedAt is when this meta.json was last rewritten. Only drafts set it,
+	// so the server can distinguish a live draft from one whose agent died
+	// mid-session. Finalize clears it, leaving CreatedAt as the only timestamp
+	// on a finished session.
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+
 	Files map[string]FileRef `json:"files"` // OID manifest: filename -> ref
+}
+
+// IsDraft reports whether this meta.json is an in-progress draft placeholder
+// rather than a finalized session record. Nil-safe: a nil meta is not a draft.
+//
+// All consumers MUST go through this helper rather than reading m.Draft, so
+// the nil-safety and the "absent key == not a draft" back-compat rule live in
+// exactly one place. Reading m.Draft directly on a nil meta panics, and every
+// consumer here is on a path where an unreadable meta.json is normal.
+//
+// Fail-safe direction: an unreadable meta.json yields a nil *SessionMeta and
+// therefore reports NOT a draft. That is deliberate. "Treat as draft" is the
+// destructive direction — it makes doctor skip a session whose upload failed,
+// and makes abort delete a directory it should refuse to touch.
+func (m *SessionMeta) IsDraft() bool { return m != nil && m.Draft }
+
+// ClearDraft removes every draft-only marker. MUST be called by any finalize
+// path that MUTATES an existing meta.json in place rather than rebuilding it
+// from a builder.
+//
+// This is not belt-and-suspenders. The daemon's finalize does `next := current`
+// inside MutateSessionMeta — it deliberately preserves every field it does not
+// own, which is correct for redactions / produced_commits / linkage but would
+// silently carry Draft=true through finalization, leaving a fully-finalized
+// session that every consumer keeps treating as provisional (and that doctor
+// keeps refusing to repair). The CLI path rebuilds from sessionMetaBase and
+// clears these implicitly; calling ClearDraft explicitly in both makes the two
+// paths agree by construction instead of by coincidence.
+func (m *SessionMeta) ClearDraft() {
+	if m == nil {
+		return
+	}
+	m.Draft = false
+	m.TurnCount = 0
+	m.UpdatedAt = nil
 }
 
 // RedactionPass records a single end-to-end pass of the redactor against
@@ -948,17 +1036,32 @@ func (f FileRef) BareOID() string {
 // don't know whether it had a SessionID we'd overwrite. Refusing to
 // proceed is the only conservative choice.
 func PreservedSessionID(sessionDir string) (string, error) {
+	id, _, err := PreservedSessionIDAndDraft(sessionDir)
+	return id, err
+}
+
+// PreservedSessionIDAndDraft returns the ses_ id stamped in an existing
+// meta.json plus whether that meta is a draft placeholder. Same three return
+// shapes and the same strict "unreadable is fatal" rule as PreservedSessionID,
+// which delegates here.
+//
+// Finalize paths need both facts from ONE read, and they need them BEFORE they
+// touch the directory: superseding a draft deletes the very meta.json that
+// carries the id. A draft is an extra durable carrier of the ses_ id (it
+// survives .recording.json being cleared), so reading it in the wrong order
+// would rotate an id already circulating in PR bodies and commit trailers.
+func PreservedSessionIDAndDraft(sessionDir string) (string, bool, error) {
 	existing, err := ReadSessionMeta(sessionDir)
 	if errors.Is(err, fs.ErrNotExist) {
-		return "", nil // genuinely first publish — caller mints fresh
+		return "", false, nil // genuinely first publish — caller mints fresh
 	}
 	if err != nil {
-		return "", fmt.Errorf("read existing meta.json (refusing to silently rotate SessionID): %w", err)
+		return "", false, fmt.Errorf("read existing meta.json (refusing to silently rotate SessionID): %w", err)
 	}
 	if existing == nil {
-		return "", nil
+		return "", false, nil
 	}
-	return existing.SessionID, nil
+	return existing.SessionID, existing.IsDraft(), nil
 }
 
 // EffectiveSessionID returns the canonical "ses_"-prefixed identifier for

--- a/internal/lfs/meta_draft.go
+++ b/internal/lfs/meta_draft.go
@@ -1,0 +1,182 @@
+package lfs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sageox/ox/internal/sessionid"
+)
+
+// ErrNotDraft is returned when a draft write targets a directory whose
+// existing meta.json is NOT a draft. That directory holds a finalized session
+// and stamping draft=true over it would be a downgrade: every consumer would
+// start treating real, uploaded turn data as provisional, and finalize would
+// purge the directory the next time it ran.
+var ErrNotDraft = errors.New("session directory holds a finalized session, not a draft")
+
+// ErrDraftDirNotEmpty is returned when a draft write targets a directory that
+// already contains the session transcript. Real turn data is present, so this
+// is not a placeholder: labeling it draft:true would claim a zero-turn session
+// that demonstrably has turns, and every draft-aware consumer (doctor's orphan
+// sweep, the daemon's anti-entropy skip, abort's delete) would then treat real
+// work as disposable.
+//
+// Scoped to raw.jsonl deliberately, NOT to all of ContentFiles. The other
+// artifacts — summary.md, session.md, plan.md, context-trace.jsonl — can
+// legitimately appear in a draft directory because the SageOx server may author
+// a summary against the zero-turn draft and push it, and a `git pull --rebase`
+// folds that into our tree. That case is anticipated and handled by the
+// finalize-time purge; refusing to refresh the counters because of it would
+// silently freeze server-visible progress for the rest of the session.
+var ErrDraftDirNotEmpty = errors.New("session directory already contains the transcript")
+
+// draftBlockingFile is the one artifact whose presence means "this is not a
+// placeholder". It is also the file the LFS invariant is about: real bytes at
+// the git-tracked <ledger>/sessions/<name>/raw.jsonl break linkage for the
+// whole team.
+const draftBlockingFile = "raw.jsonl"
+
+// DraftInput is everything needed to author a draft placeholder.
+//
+// Deliberately identity + counters only. There is NO field that can hold
+// transcript-derived text — not a title derived from the first user message,
+// not a summary, not a preview. The privacy property of a draft is therefore a
+// type-level guarantee rather than a code-review one: a caller physically
+// cannot pass turn content through this struct.
+//
+// Note the absence of Title in particular. RecordingState carries a title
+// derived from the user's first message, and an implementer reaching for "make
+// the draft look nicer in the UI" would leak that first prompt into a
+// git-tracked, pushed file at turn 2 — before the user has any indication the
+// session is being shared. The server renders drafts by session name and
+// counters; that is sufficient and it is safe.
+type DraftInput struct {
+	SessionName string
+	SessionID   string // ses_<UUIDv7> minted at StartRecording — REQUIRED
+	Username    string // privacy-safe display name via identity.AttributionDisplayName(); never an email
+	UserID      string
+	RepoID      string
+	AgentID     string
+	AgentType   string
+	Model       string
+	CreatedAt   time.Time
+	TurnCount   int
+	EntryCount  int
+	Now         time.Time
+}
+
+// Validate checks the required identity fields. A draft without a valid
+// ses_ id is worthless — the entire point is that /c/<session_id> resolves —
+// and one with a malformed id would produce a URL that never matches the
+// finalized session's, silently splitting the record in two server-side.
+func (in DraftInput) Validate() error {
+	if in.SessionName == "" {
+		return fmt.Errorf("draft requires a session name")
+	}
+	if !sessionid.IsValidSessionID(in.SessionID) {
+		return fmt.Errorf("draft requires a valid ses_ session id, got %q", in.SessionID)
+	}
+	return nil
+}
+
+// WriteDraftSessionMeta creates or refreshes the draft placeholder meta.json in
+// sessionDir.
+//
+// Goes through MutateSessionMeta so it holds the same advisory flock every
+// other meta.json writer holds and can never interleave with a concurrent
+// finalize. This is also why it must NOT be added to the
+// `make check-session-meta-rmw` allowlist — it is already on the safe path.
+//
+// Two refusals, both of which make the caller safe to retry blindly:
+//
+//   - ErrNotDraft when an existing meta.json is not a draft. Covers the
+//     finalize-landed-between-decision-and-write race, and a session-name
+//     collision with a teammate's finalized session pulled in from the remote.
+//   - ErrDraftDirNotEmpty when the transcript (raw.jsonl) already exists in the
+//     directory. Covers a half-completed finalize and any path that has started
+//     writing real turn data here. Scoped to raw.jsonl only — see the error's
+//     doc for why server-authored summary artifacts must NOT block a refresh.
+//
+// The write sets Files to an empty (non-nil) map so downstream manifest
+// consumers see a well-formed-but-empty manifest rather than a nil one, and so
+// draft-ness cannot be confused with "meta.json we failed to parse".
+func WriteDraftSessionMeta(ctx context.Context, sessionDir string, in DraftInput) error {
+	if err := in.Validate(); err != nil {
+		return err
+	}
+
+	// Refuse if the real transcript already exists here. Checked before the
+	// lock because it is a property of the directory, not of meta.json, and
+	// because a caller that trips this wants the error regardless of whether
+	// meta.json is currently writable.
+	if _, err := os.Stat(filepath.Join(sessionDir, draftBlockingFile)); err == nil {
+		return fmt.Errorf("%w: %s", ErrDraftDirNotEmpty, draftBlockingFile)
+	}
+
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		return fmt.Errorf("create draft session dir: %w", err)
+	}
+
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	now = now.UTC()
+
+	return MutateSessionMeta(ctx, sessionDir, func(current *SessionMeta) (*SessionMeta, error) {
+		if current != nil && !current.IsDraft() {
+			return nil, fmt.Errorf("%w: %s", ErrNotDraft, in.SessionName)
+		}
+
+		// Preserve the id already published rather than the one we were
+		// handed. A refresh that adopted the caller's id would rotate the
+		// /c/ link mid-session if the caller's recording state had been
+		// rebuilt — the exact failure the whole preserved-id machinery exists
+		// to prevent.
+		sessionID := in.SessionID
+		if current != nil && current.SessionID != "" {
+			sessionID = current.SessionID
+		}
+
+		next := &SessionMeta{
+			Version:     "1.0",
+			SessionName: in.SessionName,
+			SessionID:   sessionID,
+			Username:    in.Username,
+			UserID:      in.UserID,
+			RepoID:      in.RepoID,
+			AgentID:     in.AgentID,
+			AgentType:   in.AgentType,
+			Model:       in.Model,
+			CreatedAt:   in.CreatedAt,
+			EntryCount:  in.EntryCount,
+			Draft:       true,
+			TurnCount:   in.TurnCount,
+			UpdatedAt:   &now,
+			Files:       map[string]FileRef{},
+		}
+		if current != nil && !current.CreatedAt.IsZero() {
+			next.CreatedAt = current.CreatedAt
+		}
+
+		// Counters are monotonic. A refresh racing an older in-flight refresh
+		// (or a recording state that lost an increment — the state file is an
+		// unlocked load-modify-save) must never walk the server-visible
+		// progress backwards, which would read as "the session is un-doing
+		// work".
+		if current != nil {
+			if current.TurnCount > next.TurnCount {
+				next.TurnCount = current.TurnCount
+			}
+			if current.EntryCount > next.EntryCount {
+				next.EntryCount = current.EntryCount
+			}
+		}
+
+		return next, nil
+	})
+}

--- a/internal/lfs/meta_draft_test.go
+++ b/internal/lfs/meta_draft_test.go
@@ -1,0 +1,368 @@
+package lfs
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDraftSessionID = "ses_01950000-0000-7000-8000-000000000001"
+
+func draftInputFixture(name string) DraftInput {
+	return DraftInput{
+		SessionName: name,
+		SessionID:   testDraftSessionID,
+		Username:    "Test Coworker",
+		UserID:      "usr_1",
+		RepoID:      "repo_1",
+		AgentID:     "OxTest",
+		AgentType:   "claude-code",
+		Model:       "claude-opus-5",
+		CreatedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		TurnCount:   2,
+		Now:         time.Date(2026, 1, 1, 0, 5, 0, 0, time.UTC),
+	}
+}
+
+// readRawMeta returns the meta.json BYTES, deliberately not the parsed struct.
+// Several invariants here are about what is or is not present in the file — a
+// struct round-trip cannot see an `"draft": false` key that should have been
+// omitted.
+func readRawMeta(t *testing.T, dir string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	return raw
+}
+
+// TestDraftFlagOmitempty pins the on-disk shape, not the struct shape.
+//
+// Catches: a `json:"draft"` tag without omitempty. That would stamp
+// `"draft": false` onto every finalized meta.json in every ledger — a schema
+// diff on every session, and a brand-new merge-conflict surface on a file that
+// two writers already race for.
+func TestDraftFlagOmitempty(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, WriteSessionMetaOnly(dir, &SessionMeta{
+		SessionName: "s", CreatedAt: time.Now(),
+		Files: map[string]FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 1}},
+	}))
+	raw := readRawMeta(t, dir)
+	assert.NotContains(t, raw, "draft", "a non-draft meta must not carry a draft key at all")
+	assert.NotContains(t, raw, "turn_count")
+	assert.NotContains(t, raw, "updated_at")
+
+	require.NoError(t, WriteDraftSessionMeta(context.Background(), dir+"2", draftInputFixture("s2")))
+	raw2 := readRawMeta(t, dir+"2")
+	assert.Equal(t, true, raw2["draft"], "a draft must carry draft:true on disk")
+}
+
+// TestIsDraft_LegacyAndMalformed pins the fail-safe DIRECTION.
+//
+// "Not a draft" is the safe default and "is a draft" is the destructive one:
+// treating an unreadable meta as a draft makes doctor's orphan sweep skip a
+// session whose only transcript copy is in the cache, and makes abort willing
+// to delete a directory it cannot classify.
+func TestIsDraft_LegacyAndMalformed(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"legacy meta with no draft key", `{"session_name":"s","created_at":"2026-01-01T00:00:00Z"}`},
+		{"empty object", `{}`},
+		{"draft as string not bool", `{"draft":"true"}`},
+		{"truncated json", `{"draft":tr`},
+		{"zero bytes", ``},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "meta.json"), []byte(tc.body), 0644))
+
+			meta, err := ReadSessionMeta(dir)
+			if err != nil {
+				// unreadable -> nil meta -> not a draft, and no panic
+				assert.False(t, meta.IsDraft())
+				return
+			}
+			assert.False(t, meta.IsDraft(), "%s must not read as a draft", tc.name)
+		})
+	}
+
+	var nilMeta *SessionMeta
+	assert.False(t, nilMeta.IsDraft(), "nil meta must be nil-safe and report not-a-draft")
+}
+
+// TestValidateDraftShape_RejectsFilesManifest is the writer-side guard on the
+// LFS invariant.
+//
+// Catches: any future path that stamps draft:true onto a meta with a populated
+// manifest. That meta claims LFS OIDs which were never uploaded, and committing
+// the reference makes the ledger's pre-receive hook reject every subsequent
+// push — for the whole team, not just the author.
+func TestValidateDraftShape_RejectsFilesManifest(t *testing.T) {
+	dir := t.TempDir()
+	err := WriteSessionMetaOnly(dir, &SessionMeta{
+		SessionName: "s", CreatedAt: time.Now(), Draft: true,
+		Files: map[string]FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 1}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not name artifacts")
+	assert.NoFileExists(t, filepath.Join(dir, "meta.json"), "a rejected write must not land on disk")
+}
+
+// TestValidateDraftShape_RejectsSummary guards the "summary still owed" signal.
+//
+// The ABSENCE of summary artifacts is what IsStubSummary and the daemon's
+// anti-entropy both key on. A draft that carries summary text makes every
+// downstream consumer believe a zero-turn session was already summarized.
+func TestValidateDraftShape_RejectsSummary(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		meta *SessionMeta
+		want string
+	}{
+		{"summary text", &SessionMeta{SessionName: "s", Draft: true, Summary: "did some work"}, "must not carry summary text"},
+		{"summary status", &SessionMeta{SessionName: "s", Draft: true, SummaryStatus: "pending"}, "must not carry summary_status"},
+		{"whitespace-padded summary is still a summary", &SessionMeta{SessionName: "s", Draft: true, Summary: "   x  "}, "must not carry summary text"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := WriteSessionMetaOnly(t.TempDir(), tc.meta)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestValidateDraftShape_AllowsNonDraftWithFiles is the negative control.
+// Without it, the two tests above pass with validateDraftShape rewritten to
+// "always return an error".
+func TestValidateDraftShape_AllowsNonDraftWithFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, WriteSessionMetaOnly(dir, &SessionMeta{
+		SessionName: "s", CreatedAt: time.Now(),
+		Summary:       "a real summary",
+		SummaryStatus: "ok",
+		Files:         map[string]FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 1}},
+	}))
+}
+
+// TestClearDraft_PreservesEveryOtherField is the daemon-finalize contract.
+//
+// The daemon's finalize does `next := current` to preserve fields it does not
+// own. ClearDraft must remove exactly the three draft markers and nothing else
+// — a ClearDraft that reset the struct would silently erase redactions,
+// produced_commits, and linkage from the SHARED ledger history, because
+// sessions/ conflicts auto-resolve to the local side.
+func TestClearDraft_PreservesEveryOtherField(t *testing.T) {
+	updated := time.Now().UTC()
+	meta := &SessionMeta{
+		SessionName: "s", SessionID: testDraftSessionID, AgentID: "OxTest",
+		Draft: true, TurnCount: 7, UpdatedAt: &updated,
+		Redactions:      []RedactionPass{{PassID: "p1"}},
+		ProducedCommits: []string{"abc123"},
+		LinkedPRs:       []string{"o/r#1"},
+		LinkageStatus:   LinkageStatusStaged,
+		EntryCount:      42,
+		Title:           "real title",
+	}
+	meta.ClearDraft()
+
+	assert.False(t, meta.Draft)
+	assert.Zero(t, meta.TurnCount)
+	assert.Nil(t, meta.UpdatedAt)
+
+	assert.Equal(t, testDraftSessionID, meta.SessionID)
+	assert.Len(t, meta.Redactions, 1)
+	assert.Equal(t, []string{"abc123"}, meta.ProducedCommits)
+	assert.Equal(t, []string{"o/r#1"}, meta.LinkedPRs)
+	assert.Equal(t, LinkageStatusStaged, meta.LinkageStatus)
+	assert.Equal(t, 42, meta.EntryCount)
+	assert.Equal(t, "real title", meta.Title)
+
+	var nilMeta *SessionMeta
+	assert.NotPanics(t, func() { nilMeta.ClearDraft() })
+}
+
+// TestWriteDraftSessionMeta_RefusesFinalizedSession stops a draft from
+// downgrading a real session — the finalize-landed-mid-decision race, and a
+// session-name collision with a finalized session pulled from the remote.
+func TestWriteDraftSessionMeta_RefusesFinalizedSession(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, WriteSessionMetaOnly(dir, &SessionMeta{
+		SessionName: "s", SessionID: testDraftSessionID, CreatedAt: time.Now(),
+		Title: "finalized", EntryCount: 99,
+	}))
+
+	err := WriteDraftSessionMeta(context.Background(), dir, draftInputFixture("s"))
+	require.ErrorIs(t, err, ErrNotDraft)
+
+	meta, readErr := ReadSessionMeta(dir)
+	require.NoError(t, readErr)
+	assert.Equal(t, "finalized", meta.Title, "the finalized meta must be untouched")
+	assert.Equal(t, 99, meta.EntryCount)
+	assert.False(t, meta.IsDraft())
+}
+
+// TestWriteDraftSessionMeta_RefusesDirWithTranscript is the second half of the
+// LFS guard: never label a directory that already holds real turn data as a
+// zero-turn draft.
+func TestWriteDraftSessionMeta_RefusesDirWithTranscript(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "raw.jsonl"), []byte("real bytes"), 0644))
+
+	err := WriteDraftSessionMeta(context.Background(), dir, draftInputFixture("s"))
+	require.ErrorIs(t, err, ErrDraftDirNotEmpty)
+	assert.NoFileExists(t, filepath.Join(dir, "meta.json"))
+}
+
+// TestWriteDraftSessionMeta_ServerArtifactsDoNotBlockRefresh is the negative
+// control for the guard above, and it encodes a real design decision.
+//
+// The SageOx server may summarize a zero-turn draft and push summary.md /
+// summary.json into the directory; a finalize-time `git pull --rebase` folds
+// those into our tree. That is anticipated and handled by the purge. If the
+// guard covered all of ContentFiles instead of just raw.jsonl, the server doing
+// exactly what we expect would silently freeze the draft's counters for the
+// rest of the session — server-visible progress would stop, which is the very
+// symptom drafts exist to fix.
+func TestWriteDraftSessionMeta_ServerArtifactsDoNotBlockRefresh(t *testing.T) {
+	for _, name := range []string{"summary.md", "session.md", "plan.md", "context-trace.jsonl", "summary.json"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, draftInputFixture("s")))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("server authored"), 0644))
+
+			refresh := draftInputFixture("s")
+			refresh.TurnCount = 12
+			require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, refresh),
+				"a server-authored %s must not block a counter refresh", name)
+
+			meta, err := ReadSessionMeta(dir)
+			require.NoError(t, err)
+			assert.Equal(t, 12, meta.TurnCount)
+		})
+	}
+}
+
+// TestWriteDraftSessionMeta_PreservesPublishedSessionID is the /c/ link
+// stability contract.
+//
+// Catches: a refresh that rebuilds the meta from the caller's current recording
+// state. If the state was rebuilt (binary upgrade mid-recording, crash
+// recovery) its SessionID may differ, and adopting it would rotate a link
+// already pasted into a PR body.
+func TestWriteDraftSessionMeta_PreservesPublishedSessionID(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, draftInputFixture("s")))
+
+	drifted := draftInputFixture("s")
+	drifted.SessionID = "ses_01950000-0000-7000-8000-00000000ffff"
+	drifted.TurnCount = 12
+	require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, drifted))
+
+	meta, err := ReadSessionMeta(dir)
+	require.NoError(t, err)
+	assert.Equal(t, testDraftSessionID, meta.SessionID, "the published id wins over the caller's")
+	assert.Equal(t, 12, meta.TurnCount, "counters still advance")
+}
+
+// TestWriteDraftSessionMeta_CountersAreMonotonic.
+//
+// RecordingState is an unlocked load-modify-save, so a lost increment is
+// possible. Server-visible progress walking backwards reads as the session
+// un-doing work, and would make a "is it still alive?" check unreliable.
+func TestWriteDraftSessionMeta_CountersAreMonotonic(t *testing.T) {
+	dir := t.TempDir()
+	ahead := draftInputFixture("s")
+	ahead.TurnCount = 20
+	ahead.EntryCount = 200
+	require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, ahead))
+
+	behind := draftInputFixture("s")
+	behind.TurnCount = 3
+	behind.EntryCount = 5
+	require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, behind))
+
+	meta, err := ReadSessionMeta(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 20, meta.TurnCount)
+	assert.Equal(t, 200, meta.EntryCount)
+}
+
+// TestWriteDraftSessionMeta_RequiresValidSessionID.
+//
+// A draft whose id is missing or malformed produces a /c/ URL that will never
+// match the finalized session's, silently splitting one recording into two
+// server-side records.
+func TestWriteDraftSessionMeta_RequiresValidSessionID(t *testing.T) {
+	for _, tc := range []struct{ name, id string }{
+		{"empty", ""},
+		{"missing ses_ prefix", "01950000-0000-7000-8000-000000000001"},
+		{"not a uuid", "ses_nope"},
+		{"uppercase uuid rejected so the URL byte-matches meta.json", "ses_01950000-0000-7000-8000-00000000000A"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			in := draftInputFixture("s")
+			in.SessionID = tc.id
+			require.Error(t, WriteDraftSessionMeta(context.Background(), dir, in))
+			assert.NoFileExists(t, filepath.Join(dir, "meta.json"))
+		})
+	}
+}
+
+// TestDraftInput_CarriesNoTranscriptDerivedText is a structural privacy check.
+//
+// The privacy guarantee is meant to be type-level: a caller must not be able to
+// pass turn content into a draft. RecordingState carries a Title derived from
+// the user's FIRST USER MESSAGE, and "make the draft look nicer in the UI" is
+// the obvious change that would leak it into a pushed, git-tracked, shared file
+// at turn 2 — before the user has any indication the session is public.
+//
+// This asserts on the field set itself so adding such a field fails here rather
+// than in review.
+func TestDraftInput_CarriesNoTranscriptDerivedText(t *testing.T) {
+	allowed := map[string]bool{
+		"SessionName": true, "SessionID": true, "Username": true, "UserID": true,
+		"RepoID": true, "AgentID": true, "AgentType": true, "Model": true,
+		"CreatedAt": true, "TurnCount": true, "EntryCount": true, "Now": true,
+	}
+	typ := reflectTypeOfDraftInput()
+	for i := 0; i < typ.NumField(); i++ {
+		name := typ.Field(i).Name
+		assert.True(t, allowed[name],
+			"new DraftInput field %q: a draft must carry identity and counters only. "+
+				"If this field can hold transcript-derived text (a title, a summary, a preview, "+
+				"a prompt excerpt) it leaks into a shared git repo at turn 2 — see the type doc.", name)
+	}
+}
+
+// TestDraftMetaHasNoTranscriptFields asserts the same property one layer down,
+// on the bytes actually committed.
+func TestDraftMetaHasNoTranscriptFields(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, WriteDraftSessionMeta(context.Background(), dir, draftInputFixture("s")))
+
+	raw := readRawMeta(t, dir)
+	for _, forbidden := range []string{"title", "summary", "summary_status", "validation_error", "produced_commits", "linked_prs", "linked_issues", "produced_plans"} {
+		assert.NotContains(t, raw, forbidden, "draft meta.json must not carry %q", forbidden)
+	}
+	files, ok := raw["files"].(map[string]any)
+	require.True(t, ok, "files must be present as a well-formed empty manifest, not null")
+	assert.Empty(t, files)
+}
+
+// reflectTypeOfDraftInput is isolated so the reflect import stays confined to
+// the one structural test that needs it.
+func reflectTypeOfDraftInput() reflect.Type { return reflect.TypeOf(DraftInput{}) }

--- a/internal/lfs/meta_repair.go
+++ b/internal/lfs/meta_repair.go
@@ -54,6 +54,20 @@ func RecoverEmptyTitleMeta(sessionDir string, dryRun bool) MetaRepairOutcome {
 		return out
 	}
 
+	// A draft placeholder legitimately has no title (ADR-029): it is a
+	// meta.json-only marker for a LIVE recording, not a session whose
+	// summarization failed. Without this skip, every autofix tick would treat
+	// the empty title as a fault, bump SummaryAttempts, and at
+	// MaxSummaryAttempts stamp summary_status="unrecoverable" into a session
+	// that is still being recorded — which the daemon's finalize (a
+	// preserve-unowned-fields RMW) would then carry into the finished session,
+	// permanently marking real work as unsummarizable. It would also dirty the
+	// ledger worktree mid-recording for a file the CLI is about to purge.
+	if meta.IsDraft() {
+		out.Skipped = true
+		return out
+	}
+
 	// Healthy or terminal — nothing to do. We treat any non-empty
 	// trimmed title as "healthy" because that's what the web UI will
 	// render; we don't second-guess whether the title is good.

--- a/internal/lfs/meta_validate.go
+++ b/internal/lfs/meta_validate.go
@@ -63,11 +63,52 @@ func ValidateUserVisible(meta *SessionMeta) error {
 	return nil
 }
 
+// validateDraftShape enforces the draft structural invariant at the writer
+// boundary: a draft placeholder names NO artifacts in its manifest and carries
+// NO summary text. If any future code path tries to persist a draft that
+// violates that, the write is refused rather than producing a meta.json that
+// lies to every downstream consumer about what is in the directory.
+//
+// Both halves are load-bearing:
+//
+//   - A draft with a populated Files manifest claims LFS OIDs that were never
+//     uploaded. Committing that reference makes the ledger's pre-receive hook
+//     reject every subsequent push with "LFS objects are missing" — for the
+//     whole team, not just the author.
+//   - A draft with summary text is a summary of a zero-turn session. The
+//     ABSENCE of summary artifacts is the load-bearing "summary still owed"
+//     signal that IsStubSummary and the daemon's anti-entropy both depend on;
+//     a draft that fills it in makes every consumer believe the session is
+//     already summarized.
+//
+// Same "encode the cross-layer invariant at the writer" pattern
+// ValidateUserVisible established for leaked validator strings (ox-qqka),
+// where every per-layer test passed while the invariant was violated because
+// no test asserted the invariant itself.
+func validateDraftShape(meta *SessionMeta) error {
+	if !meta.IsDraft() {
+		return nil
+	}
+	if len(meta.Files) > 0 {
+		return fmt.Errorf("draft meta.json must not name artifacts in files (found %d); a draft directory contains only meta.json — see .claude/rules/cache-only-design.md", len(meta.Files))
+	}
+	if strings.TrimSpace(meta.Summary) != "" {
+		return fmt.Errorf("draft meta.json must not carry summary text; drafts are counters-only and are purged wholesale at finalize")
+	}
+	if strings.TrimSpace(meta.SummaryStatus) != "" {
+		return fmt.Errorf("draft meta.json must not carry summary_status %q; the absence of a summary is the signal that one is still owed", meta.SummaryStatus)
+	}
+	return nil
+}
+
 // Validate runs the full structural invariant check on a SessionMeta.
-// Today that's just ValidateUserVisible; if more invariants are added,
-// this is where they go.
+// Every writer goes through WriteSessionMetaOnly, which calls this — including
+// MutateSessionMeta — so adding an invariant here covers every write path.
 func (m *SessionMeta) Validate() error {
-	return ValidateUserVisible(m)
+	if err := ValidateUserVisible(m); err != nil {
+		return err
+	}
+	return validateDraftShape(m)
 }
 
 // IsLeakySummaryString reports whether s matches one of the known

--- a/internal/lfs/session_upload.go
+++ b/internal/lfs/session_upload.go
@@ -185,6 +185,16 @@ func FindPointerStubsWithMissingBlobs(client *Client, sessionPath string, logger
 // modify/delete conflict that resolves in favor of the local modification and
 // resurrects a marker the cloud already retired. Excluding it deletes the whole
 // conflict class rather than merging it forever.
+//
+// It also excludes .recording.json for a stronger reason than tidiness. That
+// marker is machine-local live-recording state (absolute paths, a local PID),
+// and committing one into a git-tracked session directory arms a kill chain:
+// the daemon's anti-entropy treats a stale .recording.json beside a missing
+// raw.jsonl as a recovery opportunity and writes REAL transcript bytes to the
+// git-tracked <ledger>/sessions/<name>/raw.jsonl — which breaks LFS linkage and
+// makes the ledger reject every subsequent push, team-wide. Draft placeholders
+// make that directory a live working area for the first time, so the marker
+// only has to land there once. Excluding it removes the whole chain.
 func EnsureSessionsGitignore(sessionsDir string) error {
 	gitignorePath := filepath.Join(sessionsDir, ".gitignore")
 
@@ -194,7 +204,12 @@ func EnsureSessionsGitignore(sessionsDir string) error {
 		"\n" +
 		"# Machine-local summarization marker: holds absolute local paths and is\n" +
 		"# deleted by the cloud summarizer, so it can never merge cleanly.\n" +
-		".needs-summary\n"
+		".needs-summary\n" +
+		"\n" +
+		"# Machine-local recording state (absolute paths, local PID). Committing one\n" +
+		"# into a tracked session dir lets daemon anti-entropy recover real transcript\n" +
+		"# bytes onto the tracked raw.jsonl, breaking LFS linkage for the whole team.\n" +
+		".recording.json\n"
 
 	existing, _ := os.ReadFile(gitignorePath)
 	if string(existing) == newContent {

--- a/internal/session/classify.go
+++ b/internal/session/classify.go
@@ -58,6 +58,17 @@ const (
 	StatusLocal     SessionStatus = "local"     // exists locally, not uploaded (may have been recovered from orphan)
 	StatusUploaded  SessionStatus = "uploaded"  // committed to ledger
 	StatusCanceled  SessionStatus = "canceled"  // user explicitly discarded session (terminal — data deleted)
+
+	// StatusDraft: the ledger holds a meta.json-only placeholder published
+	// early so /c/<session_id> resolves for links already circulating in PR
+	// bodies. No turn data has been committed. Derived, never persisted — the
+	// only persisted signal is lfs.SessionMeta.Draft.
+	//
+	// This exists because the alternative is worse, not because the vocabulary
+	// needed another entry: without it, a draft directory in the ledger reads
+	// as StatusUploaded, which reports live recordings as finished and makes
+	// `ox session abort <name>` refuse with "already uploaded".
+	StatusDraft SessionStatus = "draft"
 )
 
 // ghostHeuristicAge is the minimum age before a session with no PID is labeled ghost.
@@ -141,6 +152,13 @@ func ClassifySession(info SessionInfo, isUploaded bool) SessionStatus {
 		// check stop reason for terminal states
 		if info.StopReason == StopReasonCanceled {
 			return StatusCanceled
+		}
+		// A ledger directory holding only a draft placeholder is NOT an
+		// uploaded session — no turn data has been committed. Checked before
+		// isUploaded because callers derive isUploaded from "a directory
+		// exists in the ledger", which a draft satisfies.
+		if info.Draft {
+			return StatusDraft
 		}
 		if isUploaded {
 			return StatusUploaded

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -146,6 +146,44 @@ type RecordingState struct {
 	HookInvocations int        `json:"hook_invocations,omitempty"` // total afterTool hook calls since recording started
 	LastHookStatus  string     `json:"last_hook_status,omitempty"` // stable reason code from last afterTool: "ok", "session-file-not-found", "read-error", etc.
 	LastHookAt      *time.Time `json:"last_hook_at,omitempty"`     // timestamp of last afterTool invocation
+
+	// TurnCount is the number of agent response turns observed for this
+	// recording. Incremented exactly once per Stop-hook invocation: the Stop
+	// phase means "the agent finished responding" and fires once per completed
+	// turn, which makes it the only real turn signal ox has.
+	//
+	// It is NOT EntryCount. EntryCount counts raw.jsonl JSONL entries, of which
+	// a single turn can produce dozens. It is also NOT HookInvocations, which
+	// counts afterTool calls (i.e. tool uses). Conflating any two of these
+	// three produces a draft that publishes on the wrong turn.
+	//
+	// The increment MUST live in the Stop handler and never in the afterTool
+	// handler: afterTool also runs on PostToolUse, so counting there counts
+	// tool calls. omitempty so .recording.json files written by older binaries
+	// round-trip unchanged.
+	TurnCount int `json:"turn_count,omitempty"`
+
+	// DraftPublishedAt is set only after a draft placeholder has actually been
+	// handed off — the daemon accepted the IPC, or the local commit landed.
+	// Nil alongside a non-zero DraftPublishedTurn is the "we tried and it
+	// failed" signal that `ox doctor` reports; without the pair, a silently
+	// failed publish is indistinguishable from a server that is merely behind.
+	DraftPublishedAt *time.Time `json:"draft_published_at,omitempty"`
+
+	// DraftPublishedTurn is the TurnCount at the last SUCCESSFUL publish or
+	// refresh. The refresh cadence is measured from it, so a failed refresh
+	// does not reset the interval.
+	DraftPublishedTurn int `json:"draft_published_turn,omitempty"`
+
+	// DraftAttemptTurn is the TurnCount at the last publish or refresh ATTEMPT,
+	// successful or not. Kept separate from DraftPublishedTurn because the two
+	// answer different questions and conflating them hid a real failure:
+	// DraftPublishedAt is only ever set, never cleared, so a session whose
+	// first publish succeeded and whose every later refresh fails would report
+	// itself as healthy forever. AttemptTurn > PublishedTurn is the durable
+	// "the most recent attempt did not land" signal that `ox doctor` and
+	// `ox session status` report.
+	DraftAttemptTurn int `json:"draft_attempt_turn,omitempty"`
 }
 
 // Duration returns how long the recording has been running.

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -338,6 +338,13 @@ type SessionInfo struct {
 	StopPatternID   string              `json:"stop_pattern_id,omitempty"`    // which adapter pattern fired (for telemetry / drift detection)
 	StopResetsAtRaw string              `json:"stop_resets_at_raw,omitempty"` // raw reset-time substring as matched
 	StopResetsAt    *time.Time          `json:"stop_resets_at,omitempty"`     // parsed absolute reset time, may be nil even when raw populated
+
+	// Draft reports that this row came from a meta.json-only draft placeholder
+	// published mid-recording, NOT a finalized session. Load-bearing for
+	// classification: a ledger directory holding only a draft must not be
+	// reported as uploaded, or `ox session list` shows live recordings as
+	// finished and `ox session abort <name>` refuses to run.
+	Draft bool `json:"draft,omitempty"`
 }
 
 // ListSessions returns session files from the last 7 days, sorted by date descending.
@@ -407,6 +414,7 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 		var hydrationStatus lfs.HydrationStatus
 		var username, title, summary string
 		var createdAt time.Time
+		var isDraft bool
 		meta, metaErr := lfs.ReadSessionMeta(sessionPath)
 		if metaErr == nil && meta != nil {
 			cachePath := filepath.Join(s.cacheBasePath, name)
@@ -415,6 +423,7 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 			title = meta.Title
 			summary = meta.Summary
 			createdAt = meta.CreatedAt
+			isDraft = meta.IsDraft()
 		}
 
 		// prefer timestamp from directory name
@@ -544,6 +553,7 @@ func (s *Store) listSessionSessions(since time.Time) ([]SessionInfo, error) {
 			StopPatternID:   stopMetaString(meta, func(m *lfs.SessionMeta) string { return m.StopPatternID }),
 			StopResetsAtRaw: stopMetaString(meta, func(m *lfs.SessionMeta) string { return m.StopResetsAtRaw }),
 			StopResetsAt:    stopMetaTime(meta),
+			Draft:           isDraft,
 		})
 	}
 


### PR DESCRIPTION
## Summary

- **The problem:** an AI coworker puts `SageOx-Session: https://<endpoint>/c/<id>` in every PR body and commit trailer, but that link resolves to nothing until `ox agent session stop` completes the full upload pipeline. A correctly wired setup is indistinguishable from a broken one at exactly the moment a user is most likely to check it.
- **The fix:** publish a `meta.json`-only **draft placeholder** into the git-tracked ledger a couple of turns into a recording, refresh its turn counter every 10 turns, supersede it wholesale at session stop, and retract it on abort. Full rationale in [`docs/adr/ADR-029-session-draft-placeholder.md`](docs/adr/ADR-029-session-draft-placeholder.md).
- **Privacy is structural, not policy:** `lfs.DraftInput` has no field that can hold transcript-derived text — not a title, not a summary, not a preview. A draft cannot leak conversation content by type, not by convention.
- **New `ox doctor` check** finds and retracts placeholders whose recording is long gone (agent crash, or an abort that never reached the remote).
- **`ox session status`** gains `draft_state` (`disabled` / `pending` / `published` / `stale` / `failed`) and `conversation_url`, so a silently-failed publish is diagnosable instead of "it seems broken."
- **`session abort`** now also removes the published placeholder from the ledger, and can abort a session that exists *only* as a stranded placeholder.
- Every consumer that previously treated `sessions/<name>/meta.json` existing as "this session is real" now calls `IsDraft()` first (~15 call sites) — enforced going forward by `.claude/rules/session-draft.md`.

```mermaid
stateDiagram-v2
    [*] --> Recording : session start
    Recording --> Published : turn 2 reached
    Published --> Published : refresh counters, every 10 turns
    Published --> Finalized : session stop, supersede
    Published --> Retracted : session abort
    Published --> Reaped : doctor finds orphan, no live recording
    Finalized --> [*]
    Retracted --> [*]
    Reaped --> [*]
```

## Test Plan

- New test files cover each surface: `session_draft_abort_test.go`, `session_draft_consumers_test.go`, `session_draft_git_test.go`, `session_draft_reaper_test.go`, `session_draft_schedule_test.go`, `session_draft_status_test.go`, `session_draft_turncount_test.go`, `internal/lfs/meta_draft_test.go`, `internal/config/session_draft_test.go`, `internal/daemon/agentwork/session_finalize_draft_test.go`, `internal/daemon/sync_session_draft_test.go`.
- `make lint` — 0 issues.
- Manually traced the fail-safe direction table in ADR-029 against each of the ~15 consumer call sites.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (see Test Plan above)
- [x] CHANGELOG entry added — `cmd/ox/release_notes.md` (this repo uses release notes, not a separate CHANGELOG.md)
- [x] Breaking change documented — none; `meta.json`'s `draft` key is `omitempty`, so every existing file stays byte-identical
- [x] Security review — N/A documented. This PR does not touch `internal/auth/`, `internal/mcp/`, `internal/session/raw_writer.go`, `cmd/ox/prepush_scan.go`, `internal/upgrade/`, or `go.sum`, so it's covered by the daily batch review rather than required pre-merge.

</details>

Co-authored-by: SageOx <ox@sageox.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live session draft placeholders with progress metadata and configurable publishing.
  * Session status and listings now show draft state, turn counts, publication time, and available conversation links.
  * Added the `session.draft` setting, enabled by default, with an option to disable publishing.
  * Added support for aborting, retracting, and finalizing draft sessions while preserving session identity.
  * Added orphaned-draft detection and cleanup through `ox doctor`.

* **Bug Fixes**
  * Prevented draft placeholders from being treated as uploaded or finalized sessions.
  * Improved recovery and cleanup of interrupted or abandoned sessions.
  * Protected transcript content and finalized session data from draft operations.

* **Documentation**
  * Documented session draft behavior, configuration, lifecycle, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->