### PR TITLE
fix(daemon): start --foreground takes over instead of exiting 0 when a daemon is already running

### DIFF
--- a/cmd/ox/daemon.go
+++ b/cmd/ox/daemon.go
@@ -34,6 +34,70 @@ It handles:
   - Debouncing rapid changes to avoid excessive commits`,
 }
 
+// How long to wait for a stopped daemon to actually release the workspace.
+// Stop() is an IPC request, not a kill: the incumbent still has to finish its
+// current sync tick and unlink its socket. Bounded so a wedged incumbent
+// surfaces as an error instead of hanging a container start forever.
+const (
+	daemonStopWaitAttempts = 20
+	daemonStopWaitInterval = 100 * time.Millisecond
+)
+
+// daemonStartAction is what `ox daemon start` should do, given whether a daemon
+// already holds this workspace and whether this invocation is meant to BE the
+// daemon (--foreground) rather than spawn one.
+type daemonStartAction int
+
+const (
+	daemonStartSpawn      daemonStartAction = iota // nothing holds it: spawn a background child
+	daemonStartNoop                                // something holds it and we were only asked to spawn
+	daemonStartForeground                          // nothing holds it: become the daemon
+	daemonStartTakeover                            // something holds it, but the caller wants to BE the daemon
+)
+
+// decideDaemonStart is split out of RunE so the takeover case is unit-testable
+// without a live daemon and a socket.
+//
+// The takeover case is the entire reason this is a function. `--foreground` is
+// how a SUPERVISED service is started — a container execs it as PID 1 and
+// expects it to run until killed. A supervised process that returns 0 is read
+// by its supervisor as "the service finished", so it gets restarted, finds the
+// same incumbent, and returns 0 again. Nothing in that loop looks like an
+// error: it ran 624 times in one pod over two days, reporting exitCode=0 every
+// time, and the only visible symptom was a sidecar that was never up
+// (sageox-monorepo#2608). So "already running" may be a no-op for a background
+// spawn, and must NEVER be one for --foreground.
+func decideDaemonStart(alreadyRunning, foreground bool) daemonStartAction {
+	switch {
+	case alreadyRunning && foreground:
+		return daemonStartTakeover
+	case alreadyRunning:
+		return daemonStartNoop
+	case foreground:
+		return daemonStartForeground
+	default:
+		return daemonStartSpawn
+	}
+}
+
+// stopRunningDaemonAndWait stops the daemon holding this workspace and blocks
+// until it has actually released it. Shared by `restart` and by `start
+// --foreground`'s takeover — both would otherwise race a half-dead incumbent
+// for the socket.
+func stopRunningDaemonAndWait() error {
+	client := daemon.NewClientForCurrentRepo()
+	if err := client.Stop(); err != nil {
+		return fmt.Errorf("failed to stop daemon: %w", err)
+	}
+	for i := 0; i < daemonStopWaitAttempts; i++ {
+		if !daemon.IsRunning() {
+			return nil
+		}
+		time.Sleep(daemonStopWaitInterval)
+	}
+	return fmt.Errorf("daemon did not stop within %s", daemonStopWaitAttempts*daemonStopWaitInterval)
+}
+
 var daemonStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the background daemon",
@@ -48,11 +112,16 @@ var daemonStartCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		foreground, _ := cmd.Flags().GetBool("foreground")
 
-		// check if already running
-		if daemon.IsRunning() {
+		switch decideDaemonStart(daemon.IsRunning(), foreground) {
+		case daemonStartNoop:
 			cli.PrintInfo("Daemon is already running")
 			cli.PrintHint("  Run 'ox daemon status' to see details")
 			return nil
+		case daemonStartTakeover:
+			cli.PrintInfo("Daemon already running — stopping it to take over in the foreground")
+			if err := stopRunningDaemonAndWait(); err != nil {
+				return err
+			}
 		}
 
 		// kill any stale daemon for this workspace before starting a new one
@@ -104,21 +173,8 @@ var daemonRestartCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// stop if running
 		if daemon.IsRunning() {
-			client := daemon.NewClientForCurrentRepo()
-			if err := client.Stop(); err != nil {
-				return fmt.Errorf("failed to stop daemon: %w", err)
-			}
-			// wait for daemon to fully stop (max 2 seconds)
-			stopped := false
-			for i := 0; i < 20; i++ {
-				if !daemon.IsRunning() {
-					stopped = true
-					break
-				}
-				time.Sleep(100 * time.Millisecond)
-			}
-			if !stopped {
-				return fmt.Errorf("daemon did not stop within timeout")
+			if err := stopRunningDaemonAndWait(); err != nil {
+				return err
 			}
 		}
 

--- a/cmd/ox/daemon_test.go
+++ b/cmd/ox/daemon_test.go
@@ -43,6 +43,50 @@ func TestDaemonStart_LongRunningClassification(t *testing.T) {
 	}
 }
 
+// TestDecideDaemonStart pins the full truth table, because the interesting cell
+// is the one that used to be wrong in a way that looked like success.
+//
+// Failure prevented: `ox daemon start --foreground` returning nil when a daemon
+// already holds the workspace. That flag is how a SUPERVISED service is started
+// — a container execs it as PID 1 — so returning 0 tells the supervisor the
+// service finished, and it restarts, finds the same incumbent, and returns 0
+// again. Observed in the field as 624 restarts across two days with exitCode=0
+// on every one of them (sageox-monorepo#2608). A no-op is correct ONLY for a
+// background spawn.
+func TestDecideDaemonStart(t *testing.T) {
+	tests := []struct {
+		name           string
+		alreadyRunning bool
+		foreground     bool
+		want           daemonStartAction
+	}{
+		{"idle workspace, background spawn", false, false, daemonStartSpawn},
+		{"idle workspace, we become the daemon", false, true, daemonStartForeground},
+		{"incumbent holds it, background spawn is a no-op", true, false, daemonStartNoop},
+		// The regression cell. Anything but takeover here is the crashloop.
+		{"incumbent holds it, foreground takes over", true, true, daemonStartTakeover},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, decideDaemonStart(tt.alreadyRunning, tt.foreground))
+		})
+	}
+}
+
+// TestDecideDaemonStart_ForegroundNeverNoops states the invariant directly
+// rather than leaving it implicit in the table above: whatever else changes,
+// --foreground must never resolve to the branch whose RunE arm returns nil
+// without running a daemon.
+func TestDecideDaemonStart_ForegroundNeverNoops(t *testing.T) {
+	for _, alreadyRunning := range []bool{false, true} {
+		got := decideDaemonStart(alreadyRunning, true)
+		assert.NotEqualf(t, daemonStartNoop, got,
+			"--foreground must never no-op (alreadyRunning=%v): a supervised entrypoint that exits 0 is restarted forever",
+			alreadyRunning)
+	}
+}
+
 // TestOrdinaryCommandsAreMeasured guards the default: only commands that
 // explicitly opt out are excluded from latency telemetry.
 //


### PR DESCRIPTION
## Summary

**A container that runs `ox daemon start --foreground` now actually gets a daemon.** Today it can get a process that prints "Daemon is already running", exits 0, and is restarted forever by its supervisor — so the service the operator asked for is never up, while every individual exit looks like success. Observed in the field on SageOx's Buzz agent: **624 restarts across two days, `exitCode=0` every time** (sageox-monorepo#2608).

**Approach:** `--foreground` means *this process IS the daemon*, so when another daemon already holds the workspace it now stops the incumbent and takes over instead of returning nil. Background spawn keeps its existing no-op.

The early-return was checked before the `foreground` flag, so the flag never got a say:

```go
if daemon.IsRunning() {          // ← ran first, for BOTH modes
    cli.PrintInfo("Daemon is already running")
    return nil                   // ← exit 0 from a supervised entrypoint
}
```

```mermaid
flowchart LR
    A[supervisor execs<br/>ox daemon start --foreground] --> B{daemon already<br/>holds workspace?}
    B -- no --> C[become the daemon<br/>runs until killed]
    B -- yes, before --> D[print, return nil<br/>exit code 0]
    D --> E[supervisor reads<br/>service finished]
    E --> A
    B -- yes, after --> F[stop incumbent,<br/>wait, take over]
    F --> C
```

Why the incumbent exists at all is deployment-shaped and not this repo's problem to solve: two containers shared a `/tmp` emptyDir, so the peer container's opportunistic daemon owned the socket the sidecar then pinged. That is a legitimate thing to encounter — the bug is that `--foreground` treated it as "nothing to do".

## What changed

| File | Change |
|---|---|
| `cmd/ox/daemon.go` | New pure `decideDaemonStart(alreadyRunning, foreground)` returning spawn / noop / foreground / **takeover**; `RunE` becomes a thin switch over it |
| `cmd/ox/daemon.go` | New `stopRunningDaemonAndWait()`, now shared with `daemon restart` instead of duplicating its stop-and-poll loop; the two bare literals it used are named consts with the rationale for the bound |
| `cmd/ox/daemon_test.go` | `TestDecideDaemonStart` pins all four cells; `TestDecideDaemonStart_ForegroundNeverNoops` states the invariant directly |

Behavior for `daemon start` (no flag), `daemon stop`, `daemon status` is unchanged. `daemon restart` is unchanged in behavior — it just calls the extracted helper.

## Test Plan

- [x] `go test ./cmd/ox/ -run 'TestDecideDaemonStart|TestDaemonStart_LongRunning|TestOrdinaryCommands'` — 4 new subtests + 1 new invariant test, all pass alongside the 4 existing.
- [x] `go vet ./cmd/ox/` — clean.
- [x] **Red-first proof.** Restored the original ordering (dropped the `alreadyRunning && foreground` case), re-ran: `TestDecideDaemonStart/incumbent_holds_it,_foreground_takes_over` fails `expected: 3 actual: 1`, and `TestDecideDaemonStart_ForegroundNeverNoops` fails with *"--foreground must never no-op (alreadyRunning=true): a supervised entrypoint that exits 0 is restarted forever"*. Restored the fix, both pass.
- [x] `make test-preflight` — **fails, and fails identically on clean `origin/main`.** Ran `go test -tags=slow -race ./cmd/ox/` under the Makefile's git-isolation env against a detached `origin/main` worktree and against this branch. Baseline: 6 failures. This branch: the same 5, minus `TestTimeSinceError` (flaky — failed on the baseline run only). **No failure is introduced here, and none is daemon-related.**

  <sub>Pre-existing on main: `TestDistillGitHubFacts_DeterministicNamesConflict`, `TestDistillGitHubFacts_UUID7PreventsConflict`, `TestDistillHistoryRead_JR10_SinceJsonFormat_ParallelBodies`, `TestIncrementalE2E_CtrlC_AntiEntropy`, `TestIncrementalE2E_SingleAgent`. Worth its own issue — `main`'s slow tier is currently red.</sub>
- [ ] N/A: not yet verified in-cluster — that needs a deployed image. The consuming chart lives in sageox-monorepo.

<details><summary>Alternates considered</summary>

**Return a non-zero error on "already running" in foreground mode.** Rejected: it converts an exit-0 loop into an exit-1 loop. The supervisor restarts either way, so the pod still never comes up — it would just be a crashloop that finally *looks* like one. Better than silence, but not a fix.

**Block and wait for the incumbent to exit rather than stopping it.** Rejected: nothing guarantees the incumbent ever exits, so the container start hangs indefinitely with no diagnostic. The bounded stop surfaces a wedged incumbent as an error.

**Leave `--foreground` alone and fix it in the consumer's Dockerfile with a retry wrapper.** This is what sageox-monorepo#2716 does, and it was authored against a different (incorrect) root cause — that the daemon exits before its config file exists, "a condition that, empirically, clears in seconds". The condition is deterministic and never clears; a bounded retry exhausts and gives up. Fixing it here fixes it for every consumer instead of one image.
</details>
