### PR TITLE
fix(plan): never persist topic-only consult input as an empty plan

### DIFF
--- a/cmd/ox/plan.go
+++ b/cmd/ox/plan.go
@@ -252,6 +252,19 @@ func savePlanWithProvenance(gitRoot string, in plan.Input, result plan.Result, h
 // slug via <meta name="ox-plan-slug"> (the authoring contract), which then
 // wins over the title-derived one.
 func savePlanArtifacts(gitRoot string, in plan.Input, result plan.Result, html []byte, primary string) string {
+	// Consult-mode input (`enrich --topic`: Raw deliberately empty, no
+	// document exists yet) must never persist — it would mint a real pln_ id
+	// around a zero-byte plan.md, an empty creator-less entry in the plan
+	// gallery. Guarded here, the one choke point every save path funnels
+	// through, so --persist, --text auto-save, render, and `plan save` all
+	// skip alike; plan.Save has the same check as a second layer. HTML-primary
+	// input is exempt: the page is the plan of record, Raw only its derived
+	// markdown.
+	if strings.TrimSpace(in.Raw) == "" && html == nil {
+		slog.Info("plan save skipped: no authored content (topic-only consult input)", "topic", in.Topic)
+		return ""
+	}
+
 	topic := planTopic(in)
 	slug := plan.Slugify(topic)
 	if primary == plan.PrimaryHTML {

--- a/cmd/ox/plan_capture_empty_test.go
+++ b/cmd/ox/plan_capture_empty_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/sageox/ox/internal/plan"
+)
+
+// TestSavePlanArtifacts_TopicOnlyConsultNeverPersists pins the cmd-layer half
+// of the consult-mode guard. `ox plan enrich --topic "…"` builds an Input with
+// Raw deliberately empty (no document exists yet); before the guard, running
+// it with --persist (or --text with plan.save on) walked the full save path
+// and minted a real pln_ id around a zero-byte plan.md — an empty,
+// creator-less entry in the plan gallery.
+//
+// Red-first: delete the empty-Raw guard at the top of savePlanArtifacts AND
+// the ErrNothingToSave guard in plan.Save → this fails with a non-empty dir.
+func TestSavePlanArtifacts_TopicOnlyConsultNeverPersists(t *testing.T) {
+	root := newPlanCaptureTestRepo(t)
+
+	in, err := plan.ResolveInput("Converge multi-room recordings", nil, "", nil)
+	if err != nil {
+		t.Fatalf("ResolveInput: %v", err)
+	}
+
+	if dir := savePlanArtifacts(root, in, plan.Result{}, nil, ""); dir != "" {
+		t.Fatalf("savePlanArtifacts persisted a topic-only consult to %q, want skip", dir)
+	}
+
+	plans, err := plan.List(root)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(plans) != 0 {
+		t.Fatalf("topic-only consult left %d plan(s) in the ledger: %+v", len(plans), plans)
+	}
+}

--- a/internal/plan/store.go
+++ b/internal/plan/store.go
@@ -23,6 +23,7 @@ package plan
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -51,6 +52,11 @@ const (
 	// under it and is kept plain so a dehydrated clone reads it directly.
 	htmlLFSThreshold = 256 * 1024
 )
+
+// ErrNothingToSave is returned by Save when the input carries no authored
+// content (topic-only consult input, empty stdin). Callers treat it as a
+// clean skip, not a failure — see savePlanArtifacts in cmd/ox.
+var ErrNothingToSave = errors.New("plan save: no authored content to persist")
 
 // PlanStatus is the plan's own lifecycle, independent of the producing
 // session. A plan is worth keeping even if never built — it is a decision
@@ -209,6 +215,16 @@ func Save(gitRoot string, in Input, res Result, html []byte, meta Meta) (string,
 	ledger := ledgerPathFor(gitRoot)
 	if ledger == "" {
 		return "", "", fmt.Errorf("no ledger configured for %q: cannot save plan", gitRoot)
+	}
+
+	// Consult-mode input never persists: `plan enrich --topic` deliberately
+	// builds an Input with empty Raw (no document exists yet — see
+	// newTopicInput), and saving it would mint a real pln_ id around a
+	// zero-byte plan.md, an empty entry in every plan gallery. HTML-primary
+	// saves are exempt: there the page is the plan of record and Raw is only
+	// its derived markdown.
+	if strings.TrimSpace(in.Raw) == "" && html == nil {
+		return "", "", ErrNothingToSave
 	}
 
 	if meta.CreatedAt.IsZero() {

--- a/internal/plan/store_empty_input_test.go
+++ b/internal/plan/store_empty_input_test.go
@@ -1,0 +1,77 @@
+package plan
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests pin the consult-mode guard in Save: topic-only input (Raw
+// deliberately empty — see newTopicInput) must never persist. Before the
+// guard, `ox plan enrich --topic "…" --persist` minted a real pln_ id around
+// a zero-byte plan.md — an empty, creator-less entry in the plan gallery.
+
+func plansOnDisk(t *testing.T, ledger string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(ledger, "data", "plans"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read plans dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+func TestSave_TopicOnlyInputSkipped(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	in := newTopicInput("Remove buildCoRecordVTT and converge pipelines", nil)
+	dir, _, err := Save("/fake/git/root", in, sampleResult(), nil, Meta{Topic: in.Topic})
+	if !errors.Is(err, ErrNothingToSave) {
+		t.Fatalf("Save err = %v, want ErrNothingToSave", err)
+	}
+	if dir != "" {
+		t.Fatalf("Save dir = %q, want empty", dir)
+	}
+	if got := plansOnDisk(t, ledger); len(got) != 0 {
+		t.Fatalf("plan dirs created for topic-only input: %v", got)
+	}
+}
+
+func TestSave_WhitespaceOnlyRawSkipped(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	in := Input{Raw: "  \n\t\n"}
+	_, _, err := Save("/fake/git/root", in, Result{}, nil, Meta{Topic: "Whitespace"})
+	if !errors.Is(err, ErrNothingToSave) {
+		t.Fatalf("Save err = %v, want ErrNothingToSave", err)
+	}
+	if got := plansOnDisk(t, ledger); len(got) != 0 {
+		t.Fatalf("plan dirs created for whitespace-only input: %v", got)
+	}
+}
+
+// HTML-primary saves are exempt from the guard: the page is the plan of
+// record and Raw is only its derived markdown, which may legitimately be
+// empty if extraction yields nothing.
+func TestSave_EmptyRawWithHTMLStillSaves(t *testing.T) {
+	ledger := t.TempDir()
+	withLedger(t, ledger)
+
+	html := []byte("<h1>Authored HTML Plan</h1>")
+	dir, _, err := Save("/fake/git/root", Input{}, Result{}, html, Meta{Topic: "Authored HTML Plan"})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, planHTMLFile)); err != nil {
+		t.Fatalf("plan.html not written for HTML-primary save: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
The plan gallery stops filling up with ghost entries: plans with a real `pln_` id, a title, **zero content, and no creator** (e.g. `pln_019ff221-be9a-74b3-b817-d1a3b3eb0451`, a 0-byte `plan.md` created today from Ajit's session).

**Root cause:** `ox plan enrich --topic "…"` is pre-draft consult mode and deliberately builds an `Input` with empty `Raw` (no document exists yet), but the save paths (`--persist` from the ExitPlanMode hook flow, `--text` + `plan.save`) never excluded it — so a consult minted a real plan dir around a zero-byte `plan.md`.

**Fix:** skip persistence when there is no authored content (`TrimSpace(Raw)=="" && html==nil`) — guarded once in `savePlanArtifacts` (the choke point every save path funnels through, with an Info log) and again in `plan.Save` via a typed `ErrNothingToSave`. HTML-primary saves are exempt: the page is the plan of record and `Raw` is only its derived markdown.

The **no-creator** half of the observed artifact is the already-merged #754 (agent-id early return discarded the author) — it's on main but in no tag; cutting a release is the remaining step for that half.

## What changed
| File | Change |
|---|---|
| `cmd/ox/plan.go` | Empty-input guard + skip log at top of `savePlanArtifacts` |
| `internal/plan/store.go` | `ErrNothingToSave` sentinel + same guard in `Save()` |
| `internal/plan/store_empty_input_test.go` | 3 new cases: topic-only skipped, whitespace-only skipped, HTML-primary exempt |
| `cmd/ox/plan_capture_empty_test.go` | 1 new case: topic-only consult through `savePlanArtifacts` leaves the ledger empty |

## Test Plan
- [x] `go test ./internal/plan/ ./cmd/ox/` — 4 new cases pass; full suites green except the 2 pre-existing `TestDoctorFreshInstall_*` failures, which fail identically on unmodified `main` (local kb-sync staleness leaking into the doctor fixture, unrelated).
- [x] `go vet` / `go build ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or topic-only consults from creating persisted plan artifacts.
  * Whitespace-only content is now skipped when no HTML content is available.
  * HTML content continues to be saved even when raw text is empty.

* **Tests**
  * Added coverage for topic-only, whitespace-only, and HTML-primary saving scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->