### PR TITLE
fix: harden attest proofs and session link registration

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -694,6 +694,12 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 				// parent session not found; fall back to own session
 				state, _ = session.LoadRecordingStateForAgent(projectRoot, agentID)
 			}
+			if state != nil && state.LifecycleRegistrationState == "pending" {
+				// Prime is the first reliable post-start interaction for many
+				// short-lived CLI invocations. Retrying here makes an expired or
+				// offline start recover without ever blocking the local recorder.
+				notifySessionStartedAsync(projectRoot, state)
+			}
 			output.Session.SessionURL, output.Session.PRDirective = sessionLinkOutputs(projCfg, state, attribution.Session)
 		}
 	}

--- a/cmd/ox/attest.go
+++ b/cmd/ox/attest.go
@@ -92,7 +92,12 @@ func wantJSON(cmd *cobra.Command) (bool, string) {
 
 // emit writes either indented JSON or the rendered human text, and records the
 // context cost when an agent is on the other end.
-func emit(jsonOut bool, agentID string, payload any, human string, label string) error {
+func emit(cmd *cobra.Command, jsonOut bool, agentID string, payload any, human string, label string) error {
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	if quiet || (cfg != nil && cfg.Quiet) {
+		return nil
+	}
+
 	var outputBytes int
 	if jsonOut {
 		var buf bytes.Buffer
@@ -102,10 +107,10 @@ func emit(jsonOut bool, agentID string, payload any, human string, label string)
 			return err
 		}
 		outputBytes = buf.Len()
-		fmt.Print(buf.String())
+		fmt.Fprint(cmd.OutOrStdout(), buf.String())
 	} else {
 		outputBytes = len(human)
-		fmt.Print(human)
+		fmt.Fprint(cmd.OutOrStdout(), human)
 	}
 	if agentID != "" {
 		slog.Debug(label+" context cost", "agent_id", agentID, "bytes", outputBytes)
@@ -128,12 +133,31 @@ var attestStatusCmd = &cobra.Command{
 			return err
 		}
 		report := attest.BuildReport(ctx.Corpus, ctx.Plans, ctx.Records)
+		report.ApplyFreshness(func(cap attest.Capability, record *attest.Attestation) attest.Freshness {
+			return attest.CheckFreshness(ctx.RepoRoot, record, currentSpecFingerprint(ctx, cap))
+		})
 
 		jsonOut, agentID := wantJSON(cmd)
 		domain, _ := cmd.Flags().GetString("domain")
 		weakest, _ := cmd.Flags().GetInt("weakest")
-		return emit(jsonOut, agentID, report, renderAttestStatus(report, domain, weakest), "attest status")
+		return emit(cmd, jsonOut, agentID, filterAttestReport(report, domain, weakest), renderAttestStatus(report, domain, weakest), "attest status")
 	},
+}
+
+// filterAttestReport applies the same assessment selection to structured output
+// that the human renderer applies. Corpus-wide summary totals remain intact;
+// Assessments is the list selected by --domain and --weakest.
+func filterAttestReport(report *attest.Report, domain string, weakest int) *attest.Report {
+	filtered := *report
+	if domain != "" {
+		filtered.Assessments = append([]attest.Assessment(nil), report.ByDomain[domain]...)
+		if weakest > 0 && len(filtered.Assessments) > weakest {
+			filtered.Assessments = filtered.Assessments[:weakest]
+		}
+	} else {
+		filtered.Assessments = report.Weakest(weakest)
+	}
+	return &filtered
 }
 
 // verdictGlyph carries shape as well as color, so a verdict survives being read
@@ -145,6 +169,8 @@ func verdictGlyph(v attest.Verdict) string {
 		return "✓"
 	case attest.VerdictStamped:
 		return "◌"
+	case attest.VerdictStale:
+		return "◑"
 	case attest.VerdictUnproven:
 		return "◉"
 	case attest.VerdictSkipped:
@@ -160,7 +186,7 @@ func renderVerdict(v attest.Verdict, text string) string {
 	switch v {
 	case attest.VerdictAttested:
 		return ui.RenderPass(text)
-	case attest.VerdictStamped, attest.VerdictUnproven:
+	case attest.VerdictStamped, attest.VerdictStale, attest.VerdictUnproven:
 		return ui.RenderWarn(text)
 	case attest.VerdictSkipped, attest.VerdictUntested:
 		return ui.RenderFail(text)
@@ -205,7 +231,7 @@ func renderAttestStatus(r *attest.Report, domain string, weakest int) string {
 		fmt.Fprintf(&b, "  %s\n", ui.RenderFail(fmt.Sprintf("unreadable record %s: %s", filepath.Base(path), reason)))
 	}
 
-	if r.Counts[attest.VerdictAttested] == 0 {
+	if r.Records == 0 && len(r.InvalidRecords) == 0 {
 		fmt.Fprintf(&b, "\n  %s\n",
 			ui.RenderWarn("no attestation records yet — a stamp names a run id that nothing here can open"))
 	}
@@ -244,6 +270,9 @@ func renderAttestStatus(r *attest.Report, domain string, weakest int) string {
 			if a.Record != nil {
 				detail += " · proof " + a.Record.Proof.Verdict
 			}
+			if a.Freshness != nil {
+				detail += " · " + a.Freshness.Summary()
+			}
 			fmt.Fprintf(&b, "       %s\n", ui.RenderMuted(detail))
 		}
 	}
@@ -260,5 +289,4 @@ func init() {
 
 	attestCmd.AddCommand(attestStatusCmd)
 	attestCmd.GroupID = "dev"
-	rootCmd.AddCommand(attestCmd)
 }

--- a/cmd/ox/attest_check.go
+++ b/cmd/ox/attest_check.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -28,9 +29,14 @@ Advisory. Always exits 0: this reports, it never blocks.`,
 			return err
 		}
 
-		result := attestCheckResult{}
+		result := attestCheckResult{
+			RecordCount:    ctx.Records.Count,
+			InvalidRecords: ctx.Records.Invalid,
+		}
+		knownCapabilities := make(map[string]struct{}, len(ctx.Corpus.Capabilities))
 		for i := range ctx.Corpus.Capabilities {
 			cap := ctx.Corpus.Capabilities[i]
+			knownCapabilities[cap.ID] = struct{}{}
 			a := attest.Assess(cap, ctx.Plans, ctx.Records)
 
 			if a.Record == nil {
@@ -58,10 +64,19 @@ Advisory. Always exits 0: this reports, it never blocks.`,
 				result.Invalidated = append(result.Invalidated, entry)
 			}
 		}
+		for _, record := range ctx.Records.All() {
+			if _, ok := knownCapabilities[record.CapabilityID]; ok {
+				continue
+			}
+			result.Orphaned = append(result.Orphaned, attestCheckOrphan{
+				CapabilityID: record.CapabilityID,
+				Claim:        record.Claim,
+			})
+		}
 		sort.Strings(result.StampedNoRecord)
 
 		jsonOut, agentID := wantJSON(cmd)
-		return emit(jsonOut, agentID, result, renderAttestCheck(result), "attest check")
+		return emit(cmd, jsonOut, agentID, result, renderAttestCheck(result), "attest check")
 	},
 }
 
@@ -71,10 +86,18 @@ type attestCheckEntry struct {
 	Freshness    attest.Freshness `json:"freshness"`
 }
 
+type attestCheckOrphan struct {
+	CapabilityID string `json:"capability_id"`
+	Claim        string `json:"claim"`
+}
+
 type attestCheckResult struct {
-	Invalidated []attestCheckEntry `json:"invalidated"`
-	Unaffected  []attestCheckEntry `json:"unaffected"`
-	Unknown     []attestCheckEntry `json:"unknown"`
+	RecordCount    int                 `json:"record_count"`
+	InvalidRecords map[string]string   `json:"invalid_records,omitempty"`
+	Orphaned       []attestCheckOrphan `json:"orphaned"`
+	Invalidated    []attestCheckEntry  `json:"invalidated"`
+	Unaffected     []attestCheckEntry  `json:"unaffected"`
+	Unknown        []attestCheckEntry  `json:"unknown"`
 	// StampedNoRecord are capabilities somebody claimed green with no record —
 	// this diff may have broken them and nothing here can tell.
 	StampedNoRecord []string `json:"stamped_no_record"`
@@ -84,7 +107,7 @@ func renderAttestCheck(r attestCheckResult) string {
 	var b strings.Builder
 	fmt.Fprintln(&b)
 
-	if len(r.Invalidated) == 0 && len(r.Unknown) == 0 && len(r.Unaffected) == 0 {
+	if r.RecordCount == 0 && len(r.InvalidRecords) == 0 {
 		fmt.Fprintf(&b, "  %s\n", ui.RenderMuted("no attestation records in this repo — nothing to invalidate"))
 		if len(r.StampedNoRecord) > 0 {
 			fmt.Fprintf(&b, "  %s\n", ui.RenderWarn(fmt.Sprintf(
@@ -93,6 +116,28 @@ func renderAttestCheck(r attestCheckResult) string {
 		}
 		fmt.Fprintln(&b)
 		return b.String()
+	}
+
+	if len(r.InvalidRecords) > 0 {
+		fmt.Fprintf(&b, "  %s\n", ui.RenderWarn(fmt.Sprintf("? %d attestation record(s) could not be read", len(r.InvalidRecords))))
+		paths := make([]string, 0, len(r.InvalidRecords))
+		for path := range r.InvalidRecords {
+			paths = append(paths, path)
+		}
+		sort.Strings(paths)
+		for _, path := range paths {
+			fmt.Fprintf(&b, "    %s\n", ui.RenderMuted(filepath.Base(path)+" · "+r.InvalidRecords[path]))
+		}
+		fmt.Fprintln(&b)
+	}
+
+	if len(r.Orphaned) > 0 {
+		fmt.Fprintf(&b, "  %s\n", ui.RenderWarn(fmt.Sprintf("? %d attestation record(s) no longer match the capability corpus", len(r.Orphaned))))
+		for _, orphan := range r.Orphaned {
+			fmt.Fprintf(&b, "    %s\n", orphan.Claim)
+			fmt.Fprintf(&b, "      %s\n", ui.RenderMuted(orphan.CapabilityID+" · capability was removed or renamed"))
+		}
+		fmt.Fprintln(&b)
 	}
 
 	if len(r.Invalidated) > 0 {

--- a/cmd/ox/attest_cli_test.go
+++ b/cmd/ox/attest_cli_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sageox/ox/internal/attest"
+	"github.com/spf13/cobra"
+)
+
+func TestReadVerbatimPreservesExactFileBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "red.txt")
+	want := "assertion failed\n\n"
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("red-verbatim-file", path, "")
+	cmd.Flags().String("red-verbatim", "", "")
+	got, err := readVerbatim(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("readVerbatim() = %q, want exact bytes %q", got, want)
+	}
+}
+
+func TestDiffDigestRejectsUnreadableFile(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("break-diff-file", filepath.Join(t.TempDir(), "missing.patch"), "")
+
+	if _, err := diffDigest(cmd); err == nil || !strings.Contains(err.Error(), "read --break-diff-file") {
+		t.Fatalf("diffDigest() error = %v, want an actionable read error", err)
+	}
+}
+
+func TestValidateAttestRunIDsRequiresBothRuns(t *testing.T) {
+	tests := []struct {
+		name  string
+		red   string
+		green string
+		want  string
+	}{
+		{name: "missing red", green: "run_green", want: "--red-run is required"},
+		{name: "missing green", red: "run_red", want: "--green-run is required"},
+		{name: "red whitespace", red: " run_red", green: "run_green", want: "--red-run cannot"},
+		{name: "green whitespace", red: "run_red", green: "run_green ", want: "--green-run cannot"},
+		{name: "same run", red: "run_same", green: "run_same", want: "must identify different runs"},
+		{name: "both", red: "run_red", green: "run_green"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAttestRunIDs(tt.red, tt.green)
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("validateAttestRunIDs() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validateAttestRunIDs() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateAttestProofInputsRequiresRedFailureStep(t *testing.T) {
+	if err := validateAttestProofInputs("invalid", "run_red", "run_green", 2, "Then it fails"); err == nil || !strings.Contains(err.Error(), "--verdict") {
+		t.Fatalf("invalid verdict error = %v", err)
+	}
+	if err := validateAttestProofInputs(attest.ProofClean, "run_red", "run_green", 0, "Then it fails"); err == nil || !strings.Contains(err.Error(), "--step") {
+		t.Fatalf("missing step error = %v", err)
+	}
+	if err := validateAttestProofInputs(attest.ProofAmbiguous, "run_red", "run_green", 2, ""); err == nil || !strings.Contains(err.Error(), "--step-text") {
+		t.Fatalf("missing step text error = %v", err)
+	}
+	if err := validateAttestProofInputs(attest.ProofInconclusive, "run_red", "run_green", 0, ""); err != nil {
+		t.Fatalf("inconclusive proof unexpectedly required a failure step: %v", err)
+	}
+}
+
+func TestVerdictGlyphIncludesStaleProof(t *testing.T) {
+	if got := verdictGlyph(attest.VerdictStale); got != "◑" {
+		t.Fatalf("verdictGlyph(stale) = %q, want stale marker", got)
+	}
+}
+
+func TestNormalizeAttestSurfacesCanonicalizesFilesAndPreservesRoutes(t *testing.T) {
+	repo := t.TempDir()
+	file := filepath.Join(repo, "app", "page.go")
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("package app\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, files, err := normalizeAttestSurfaces(repo, []string{
+		"./app/page.go",
+		"app\\page.go",
+		file,
+		"/teams/:team/settings",
+		"/api/settings.json",
+		"route:admin.json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"app/page.go",
+		"app/page.go",
+		"app/page.go",
+		"/teams/:team/settings",
+		"/api/settings.json",
+		"admin.json",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("normalized surfaces = %#v, want %#v", got, want)
+	}
+	if len(files) != 3 {
+		t.Fatalf("file surfaces = %#v, want three file paths", files)
+	}
+}
+
+func TestNormalizeAttestSurfaceRejectsFileOutsideRepo(t *testing.T) {
+	repo := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.go")
+	if err := os.WriteFile(outside, []byte("package outside\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := normalizeAttestSurface(repo, "file:"+outside); err == nil {
+		t.Fatal("normalizeAttestSurface() accepted a file outside the repository")
+	}
+}
+
+func TestRequireCleanAttestTreeRejectsTrackedAndUntrackedChanges(t *testing.T) {
+	repo := t.TempDir()
+	runAttestTestGit(t, repo, "init", "--quiet")
+	runAttestTestGit(t, repo, "config", "user.name", "Attest Test")
+	runAttestTestGit(t, repo, "config", "user.email", "attest@example.com")
+	tracked := filepath.Join(repo, "observed.go")
+	if err := os.WriteFile(tracked, []byte("package observed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runAttestTestGit(t, repo, "add", "observed.go")
+	runAttestTestGit(t, repo, "commit", "--quiet", "-m", "initial")
+
+	if err := requireCleanAttestTree(repo); err != nil {
+		t.Fatalf("clean input rejected: %v", err)
+	}
+	if err := os.WriteFile(tracked, []byte("package changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireCleanAttestTree(repo); err == nil {
+		t.Fatal("dirty tracked input was accepted")
+	}
+	if err := os.WriteFile(tracked, []byte("package observed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	untracked := filepath.Join(repo, "new.go")
+	if err := os.WriteFile(untracked, []byte("package observed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := requireCleanAttestTree(repo); err == nil {
+		t.Fatal("untracked input was accepted")
+	}
+}
+
+func TestValidateRepoKeyRejectsPathComponents(t *testing.T) {
+	invalid := []string{"", ".", "..", "../escape", `folder\\escape`, "bad:key", "trailing.", " padded "}
+	for _, key := range invalid {
+		if err := validateRepoKey(key); err == nil {
+			t.Errorf("validateRepoKey(%q) accepted an unsafe key", key)
+		}
+	}
+	if err := validateRepoKey("sageox-ox"); err != nil {
+		t.Fatalf("validateRepoKey() rejected a portable key: %v", err)
+	}
+}
+
+func TestRepoKeyFromRootUsesPlatformPathRules(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "work", "sageox", "ox") + string(filepath.Separator)
+	if got := repoKeyFromRoot(root); got != "ox" {
+		t.Fatalf("repoKeyFromRoot(%q) = %q, want ox", root, got)
+	}
+}
+
+func TestEmitHonorsQuiet(t *testing.T) {
+	oldCfg := cfg
+	cfg = nil
+	t.Cleanup(func() { cfg = oldCfg })
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("quiet", false, "")
+	if err := cmd.Flags().Set("quiet", "true"); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := emit(cmd, false, "", map[string]string{"result": "hidden"}, "hidden", "test"); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("quiet output = %q, want none", out.String())
+	}
+}
+
+func TestFilterAttestReportAppliesDomainAndWeakest(t *testing.T) {
+	first := attest.Assessment{Capability: attest.Capability{ID: "alpha/one#rule", Domain: "alpha"}, Verdict: attest.VerdictUntested}
+	second := attest.Assessment{Capability: attest.Capability{ID: "beta/two#rule", Domain: "beta"}, Verdict: attest.VerdictAttested}
+	report := &attest.Report{
+		Assessments: []attest.Assessment{first, second},
+		ByDomain: map[string][]attest.Assessment{
+			"alpha": {first},
+			"beta":  {second},
+		},
+	}
+
+	weakest := filterAttestReport(report, "", 1)
+	if len(weakest.Assessments) != 1 || weakest.Assessments[0].Capability.ID != first.Capability.ID {
+		t.Fatalf("weakest JSON assessments = %#v", weakest.Assessments)
+	}
+	domain := filterAttestReport(report, "beta", 1)
+	if len(domain.Assessments) != 1 || domain.Assessments[0].Capability.ID != second.Capability.ID {
+		t.Fatalf("domain JSON assessments = %#v", domain.Assessments)
+	}
+	if len(report.Assessments) != 2 {
+		t.Fatal("filterAttestReport mutated the source report")
+	}
+}
+
+func TestRenderAttestStatusWarnsOnlyWhenNoRecordsExist(t *testing.T) {
+	report := &attest.Report{
+		Records: 1,
+		Counts:  map[attest.Verdict]int{},
+	}
+	got := renderAttestStatus(report, "", 0)
+	if strings.Contains(got, "no attestation records yet") {
+		t.Fatalf("status warned that no records exist despite Records=1: %q", got)
+	}
+}
+
+func TestRenderAttestStatusDoesNotCallUnreadableRecordAbsent(t *testing.T) {
+	report := &attest.Report{
+		Counts:         map[attest.Verdict]int{},
+		InvalidRecords: map[string]string{"bad.v1.json": "invalid JSON"},
+	}
+	got := renderAttestStatus(report, "", 0)
+	if strings.Contains(got, "no attestation records yet") {
+		t.Fatalf("status called an unreadable record absent: %q", got)
+	}
+}
+
+func TestRenderProofUsesStoredVerdictForConclusion(t *testing.T) {
+	record := &attest.Attestation{
+		Proof: attest.Proof{
+			Verdict: attest.ProofInconclusive,
+			ObservedRed: attest.ObservedRed{
+				LandedOnClaimStep: true,
+			},
+		},
+	}
+	got := renderProof(attest.Assessment{Record: record}, nil)
+	if !strings.Contains(got, "inconclusive") {
+		t.Fatalf("proof conclusion did not reflect inconclusive verdict: %q", got)
+	}
+}
+
+func TestRenderAttestCheckSurfacesInvalidRecords(t *testing.T) {
+	got := renderAttestCheck(attestCheckResult{
+		InvalidRecords: map[string]string{"/tmp/bad.v1.json": "invalid JSON"},
+	})
+	if !strings.Contains(got, "could not be read") || !strings.Contains(got, "bad.v1.json") {
+		t.Fatalf("check output hid invalid record: %q", got)
+	}
+	if strings.Contains(got, "no attestation records in this repo") {
+		t.Fatalf("check output contradicted invalid record presence: %q", got)
+	}
+}
+
+func TestRenderAttestCheckSurfacesOrphanedRecords(t *testing.T) {
+	got := renderAttestCheck(attestCheckResult{
+		RecordCount: 1,
+		Orphaned: []attestCheckOrphan{{
+			CapabilityID: "removed/feature#old-rule",
+			Claim:        "An old capability",
+		}},
+	})
+	if !strings.Contains(got, "no longer match") || !strings.Contains(got, "removed/feature#old-rule") {
+		t.Fatalf("check output hid orphaned record: %q", got)
+	}
+}
+
+func runAttestTestGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}

--- a/cmd/ox/attest_flag_test.go
+++ b/cmd/ox/attest_flag_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestSetCommandRegistered_DisabledIsAbsentFromHelpAndLookup(t *testing.T) {
+	helpRoot, helpCommand, _ := featureGatedCommandFixture()
+	setCommandRegistered(helpRoot, helpCommand, false)
+
+	var help bytes.Buffer
+	helpRoot.SetOut(&help)
+	helpRoot.SetArgs([]string{"--help"})
+	if err := helpRoot.Execute(); err != nil {
+		t.Fatalf("render disabled help: %v", err)
+	}
+	if strings.Contains(help.String(), "attest") {
+		t.Fatalf("disabled command leaked into help:\n%s", help.String())
+	}
+
+	execRoot, execCommand, _ := featureGatedCommandFixture()
+	setCommandRegistered(execRoot, execCommand, false)
+	execRoot.SetArgs([]string{"attest"})
+	if err := execRoot.Execute(); err == nil || !strings.Contains(err.Error(), "unknown command") {
+		t.Fatalf("disabled command execution error = %v, want unknown command", err)
+	}
+}
+
+func TestSetCommandRegistered_EnabledIsVisibleAndExecutable(t *testing.T) {
+	helpRoot, helpCommand, _ := featureGatedCommandFixture()
+	setCommandRegistered(helpRoot, helpCommand, true)
+	setCommandRegistered(helpRoot, helpCommand, true) // idempotent; must not double-register
+
+	var help bytes.Buffer
+	helpRoot.SetOut(&help)
+	helpRoot.SetArgs([]string{"--help"})
+	if err := helpRoot.Execute(); err != nil {
+		t.Fatalf("render enabled help: %v", err)
+	}
+	if !strings.Contains(help.String(), "attest") {
+		t.Fatalf("enabled command missing from help:\n%s", help.String())
+	}
+
+	execRoot, execCommand, ran := featureGatedCommandFixture()
+	setCommandRegistered(execRoot, execCommand, true)
+	execRoot.SetArgs([]string{"attest"})
+	if err := execRoot.Execute(); err != nil {
+		t.Fatalf("execute enabled command: %v", err)
+	}
+	if !*ran {
+		t.Fatal("enabled command handler did not run")
+	}
+}
+
+func featureGatedCommandFixture() (*cobra.Command, *cobra.Command, *bool) {
+	ran := false
+	root := &cobra.Command{Use: "ox", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(&cobra.Command{Use: "version", Short: "print version"})
+	command := &cobra.Command{
+		Use:   "attest",
+		Short: "experimental proof command",
+		Run: func(*cobra.Command, []string) {
+			ran = true
+		},
+	}
+	return root, command, &ran
+}

--- a/cmd/ox/attest_proof.go
+++ b/cmd/ox/attest_proof.go
@@ -38,6 +38,7 @@ substring of one.`,
 		if assessment.Record != nil {
 			f := attest.CheckFreshness(ctx.RepoRoot, assessment.Record, currentSpecFingerprint(ctx, *match))
 			fresh = &f
+			assessment = assessment.WithFreshness(f)
 		}
 
 		payload := struct {
@@ -46,7 +47,7 @@ substring of one.`,
 		}{assessment, fresh}
 
 		jsonOut, agentID := wantJSON(cmd)
-		return emit(jsonOut, agentID, payload, renderProof(assessment, fresh), "attest proof")
+		return emit(cmd, jsonOut, agentID, payload, renderProof(assessment, fresh), "attest proof")
 	},
 }
 
@@ -89,15 +90,20 @@ func resolveCapability(ctx *attestContext, query string) (*attest.Capability, er
 	}
 }
 
-// currentSpecFingerprint returns the compiled plan's fingerprint for a
-// capability's feature as it stands NOW, for comparison against the value the
-// record pinned at mint time.
+// currentSpecFingerprint hashes the compiled plan's source inputs as they exist
+// in the working tree now. An unavailable input returns an empty fingerprint,
+// which CheckFreshness reports as unknown rather than falsely current.
 func currentSpecFingerprint(ctx *attestContext, cap attest.Capability) string {
+	fingerprint, _ := liveSpecFingerprint(ctx, cap)
+	return fingerprint
+}
+
+func liveSpecFingerprint(ctx *attestContext, cap attest.Capability) (string, error) {
 	plan, ok := ctx.Plans.For(cap.Path)
 	if !ok {
-		return ""
+		return "", nil
 	}
-	return attest.FingerprintDigest(plan.Fingerprint)
+	return attest.LiveFingerprint(ctx.CorpusRoot, plan.Fingerprint)
 }
 
 func renderProof(a attest.Assessment, f *attest.Freshness) string {
@@ -132,12 +138,15 @@ func renderProof(a attest.Assessment, f *attest.Freshness) string {
 		fmt.Fprintf(&b, "  %s\n", ui.RenderMuted(fmt.Sprintf(
 			"step %d — %s", rec.Proof.ObservedRed.StepIndex, rec.Proof.ObservedRed.StepText)))
 	}
-	// The single most important line on this screen: whether the red landed
-	// where the claim lives. Without it, a red anywhere reads as a proof.
-	if rec.Proof.ObservedRed.LandedOnClaimStep {
+	// The single most important line on this screen: the stored proof verdict.
+	// Without it, any observed red can read as a clean proof.
+	switch rec.Proof.Verdict {
+	case attest.ProofClean:
 		fmt.Fprintf(&b, "  %s\n\n", ui.RenderPass("landed on the step that names the behavior · clean proof"))
-	} else {
-		fmt.Fprintf(&b, "  %s\n\n", ui.RenderWarn("landed away from the step that names the behavior · NOT a clean proof"))
+	case attest.ProofAmbiguous:
+		fmt.Fprintf(&b, "  %s\n\n", ui.RenderWarn("ambiguous verdict · this is NOT a clean proof"))
+	default:
+		fmt.Fprintf(&b, "  %s\n\n", ui.RenderWarn("inconclusive · the break produced no failure, so this is NOT a clean proof"))
 	}
 
 	fmt.Fprintf(&b, "  %s\n  red %s · green %s · %s %s\n",

--- a/cmd/ox/attest_publish.go
+++ b/cmd/ox/attest_publish.go
@@ -45,6 +45,9 @@ catalog, and it keeps the layout portable to any object store.`,
 			return err
 		}
 		report := attest.BuildReport(ctx.Corpus, ctx.Plans, ctx.Records)
+		report.ApplyFreshness(func(cap attest.Capability, record *attest.Attestation) attest.Freshness {
+			return attest.CheckFreshness(ctx.RepoRoot, record, currentSpecFingerprint(ctx, cap))
+		})
 		runs, err := attest.ReferencedRunResults(ctx.RepoRoot, ctx.Records)
 		if err != nil {
 			return err
@@ -54,6 +57,9 @@ catalog, and it keeps the layout portable to any object store.`,
 		if repoKey == "" {
 			repoKey = defaultRepoKey(ctx.RepoRoot)
 		}
+		if err := validateRepoKey(repoKey); err != nil {
+			return err
+		}
 
 		res, err := attest.WriteBundle(dest, repoKey, report, ctx.Records, runs, time.Now())
 		if err != nil {
@@ -61,7 +67,7 @@ catalog, and it keeps the layout portable to any object store.`,
 		}
 
 		jsonOut, agentID := wantJSON(cmd)
-		return emit(jsonOut, agentID, res, renderPublish(res, report, repoKey, dest), "attest publish")
+		return emit(cmd, jsonOut, agentID, res, renderPublish(res, report, repoKey, dest), "attest publish")
 	},
 }
 

--- a/cmd/ox/attest_record.go
+++ b/cmd/ox/attest_record.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/sageox/ox/internal/attest"
 	"github.com/sageox/ox/internal/repotools"
@@ -69,6 +72,14 @@ the same change that earns the stamp.
 		if breakDesc == "" {
 			return errors.New("--break is required: a record with no break describes no proof")
 		}
+		surfaces, _, err = normalizeAttestSurfaces(ctx.RepoRoot, surfaces)
+		if err != nil {
+			return err
+		}
+		breakDigest, err := diffDigest(cmd)
+		if err != nil {
+			return err
+		}
 		if verdict == "" {
 			// Derive rather than default: a red that landed away from the step
 			// naming the claim is ambiguous BY CONSTRUCTION, and making the
@@ -81,6 +92,9 @@ the same change that earns the stamp.
 				verdict = attest.ProofInconclusive
 			}
 		}
+		if err := validateAttestProofInputs(verdict, redRun, greenRun, stepIndex, stepText); err != nil {
+			return err
+		}
 
 		commit, err := attest.HeadCommit(ctx.RepoRoot)
 		if err != nil {
@@ -88,6 +102,16 @@ the same change that earns the stamp.
 		}
 		if repoKey == "" {
 			repoKey = defaultRepoKey(ctx.RepoRoot)
+		}
+		if err := validateRepoKey(repoKey); err != nil {
+			return err
+		}
+		if err := requireCleanAttestTree(ctx.RepoRoot); err != nil {
+			return err
+		}
+		specFingerprint, err := liveSpecFingerprint(ctx, *cap)
+		if err != nil {
+			return fmt.Errorf("fingerprint current specification: %w", err)
 		}
 
 		rec := &attest.Attestation{
@@ -102,7 +126,7 @@ the same change that earns the stamp.
 				Verdict: verdict,
 				Break: attest.Break{
 					Description:    breakDesc,
-					DiffDigest:     diffDigest(cmd),
+					DiffDigest:     breakDigest,
 					TargetSurfaces: surfaces,
 				},
 				ObservedRed: attest.ObservedRed{
@@ -114,7 +138,7 @@ the same change that earns the stamp.
 				RedRunID:   redRun,
 				GreenRunID: greenRun,
 			},
-			SpecFingerprint: currentSpecFingerprint(ctx, *cap),
+			SpecFingerprint: specFingerprint,
 			ObservedSurface: attest.ObservedSurface{
 				Granularity: "route",
 				Surfaces:    toSurfaces(surfaces),
@@ -127,7 +151,7 @@ the same change that earns the stamp.
 				return err
 			}
 			jsonOut, agentID := wantJSON(cmd)
-			return emit(jsonOut, agentID, rec, renderRecordPreview(rec, ""), "attest record")
+			return emit(cmd, jsonOut, agentID, rec, renderRecordPreview(rec, ""), "attest record")
 		}
 
 		path, err := attest.WriteRecord(ctx.CorpusRoot, rec)
@@ -135,7 +159,7 @@ the same change that earns the stamp.
 			return err
 		}
 		jsonOut, agentID := wantJSON(cmd)
-		return emit(jsonOut, agentID,
+		return emit(cmd, jsonOut, agentID,
 			map[string]any{"path": path, "attestation": rec},
 			renderRecordPreview(rec, path), "attest record")
 	},
@@ -157,24 +181,64 @@ func readVerbatim(cmd *cobra.Command) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("read --red-verbatim-file: %w", err)
 		}
-		return strings.TrimRight(string(raw), "\n"), nil
+		return string(raw), nil
 	}
 	return inline, nil
 }
 
 // diffDigest hashes the applied patch so the record can prove a break existed.
 // Without it "we broke it and it went red" is an unfalsifiable assertion.
-func diffDigest(cmd *cobra.Command) string {
+func diffDigest(cmd *cobra.Command) (string, error) {
 	path, _ := cmd.Flags().GetString("break-diff-file")
 	if path == "" {
-		return ""
+		return "", nil
 	}
 	raw, err := os.ReadFile(path) //nolint:gosec // an operator-supplied path is the point
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("read --break-diff-file: %w", err)
 	}
 	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:])
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func validateAttestRunIDs(redRun, greenRun string) error {
+	if redRun == "" {
+		return errors.New("--red-run is required: a red-first proof must identify the failing run")
+	}
+	if strings.TrimSpace(redRun) != redRun {
+		return errors.New("--red-run cannot have leading or trailing whitespace")
+	}
+	if greenRun == "" {
+		return errors.New("--green-run is required: a proof must identify the passing run")
+	}
+	if strings.TrimSpace(greenRun) != greenRun {
+		return errors.New("--green-run cannot have leading or trailing whitespace")
+	}
+	if redRun == greenRun {
+		return errors.New("--red-run and --green-run must identify different runs")
+	}
+	return nil
+}
+
+func validateAttestProofInputs(verdict, redRun, greenRun string, stepIndex int, stepText string) error {
+	switch verdict {
+	case attest.ProofClean, attest.ProofAmbiguous, attest.ProofInconclusive:
+	default:
+		return fmt.Errorf("--verdict %q is not one of clean, ambiguous, inconclusive", verdict)
+	}
+	if err := validateAttestRunIDs(redRun, greenRun); err != nil {
+		return err
+	}
+	if verdict == attest.ProofInconclusive {
+		return nil
+	}
+	if stepIndex < 1 {
+		return errors.New("--step must be a positive 1-indexed step for a red verdict")
+	}
+	if strings.TrimSpace(stepText) == "" {
+		return errors.New("--step-text is required for a red verdict")
+	}
+	return nil
 }
 
 func toSurfaces(ids []string) []attest.Surface {
@@ -200,8 +264,117 @@ func defaultRepoKey(repoRoot string) string {
 	if main, err := repotools.FindMainRepoRoot(repotools.VCSGit); err == nil && main != "" {
 		repoRoot = main
 	}
-	parts := strings.Split(strings.TrimRight(repoRoot, "/"), "/")
-	return parts[len(parts)-1]
+	return repoKeyFromRoot(repoRoot)
+}
+
+func repoKeyFromRoot(repoRoot string) string {
+	return filepath.Base(filepath.Clean(repoRoot))
+}
+
+// validateRepoKey keeps the opaque key to one portable path segment. The
+// publisher uses it in object paths, so separators and traversal components
+// are never valid identifiers.
+func validateRepoKey(repoKey string) error {
+	if repoKey == "" {
+		return errors.New("invalid --repo-key: use one non-empty path segment")
+	}
+	if strings.TrimSpace(repoKey) != repoKey {
+		return fmt.Errorf("invalid --repo-key %q: leading or trailing whitespace is not allowed", repoKey)
+	}
+	if repoKey == "." || repoKey == ".." || filepath.IsAbs(repoKey) {
+		return fmt.Errorf("invalid --repo-key %q: use one relative path segment", repoKey)
+	}
+	if strings.ContainsAny(repoKey, `/\\<>:"|?*`) {
+		return fmt.Errorf("invalid --repo-key %q: path separators and filesystem-reserved characters are not allowed", repoKey)
+	}
+	if strings.TrimRight(repoKey, " .") != repoKey {
+		return fmt.Errorf("invalid --repo-key %q: a key cannot end in a space or dot", repoKey)
+	}
+	for _, r := range repoKey {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("invalid --repo-key %q: control characters are not allowed", repoKey)
+		}
+	}
+	return nil
+}
+
+// normalizeAttestSurfaces canonicalizes file surfaces to repo-relative slash
+// paths, which is the form emitted by git. Route identifiers stay untouched.
+// Prefixes are available when an otherwise ambiguous identifier needs an
+// explicit classification: file:<path> or route:<id>.
+func normalizeAttestSurfaces(repoRoot string, ids []string) ([]string, []string, error) {
+	normalized := make([]string, 0, len(ids))
+	files := make([]string, 0, len(ids))
+	for _, id := range ids {
+		value, isFile, err := normalizeAttestSurface(repoRoot, id)
+		if err != nil {
+			return nil, nil, err
+		}
+		normalized = append(normalized, value)
+		if isFile {
+			files = append(files, value)
+		}
+	}
+	return normalized, files, nil
+}
+
+func normalizeAttestSurface(repoRoot, id string) (string, bool, error) {
+	if id == "" {
+		return "", false, errors.New("--surface cannot be empty")
+	}
+	if strings.HasPrefix(id, "route:") {
+		routeID := strings.TrimPrefix(id, "route:")
+		if routeID == "" {
+			return "", false, errors.New("--surface route: identifier cannot be empty")
+		}
+		return routeID, false, nil
+	}
+
+	explicitFile := strings.HasPrefix(id, "file:")
+	if explicitFile {
+		id = strings.TrimPrefix(id, "file:")
+		if id == "" {
+			return "", false, errors.New("--surface file: path cannot be empty")
+		}
+	}
+
+	pathID := filepath.FromSlash(strings.ReplaceAll(id, `\`, "/"))
+	candidate := pathID
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(repoRoot, candidate)
+	}
+	_, statErr := os.Stat(candidate)
+	looksLikeFile := explicitFile || strings.HasPrefix(id, "./") || strings.HasPrefix(id, "../") || statErr == nil ||
+		(!filepath.IsAbs(pathID) && !strings.Contains(id, "://") && filepath.Ext(pathID) != "")
+	if !looksLikeFile {
+		return id, false, nil
+	}
+
+	rel, err := filepath.Rel(repoRoot, filepath.Clean(candidate))
+	if err != nil {
+		return "", false, fmt.Errorf("normalize --surface %q: %w", id, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", false, fmt.Errorf("--surface file %q is outside the repository", id)
+	}
+	return filepath.ToSlash(rel), true, nil
+}
+
+// requireCleanAttestTree prevents binding evidence from a dirty green run to
+// HEAD. Checking only declared surfaces is insufficient: surfaces are optional,
+// and an omitted dirty product file would otherwise produce a record that says
+// the clean commit was tested when the working tree was what actually ran.
+func requireCleanAttestTree(repoRoot string) error {
+	cmd := exec.Command("git", "-C", repoRoot, "status", "--porcelain=v1", "--untracked-files=all") //nolint:gosec // fixed git arguments; repository root is caller-resolved
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("check attestation tree against HEAD: %w", err)
+	}
+	if len(out) != 0 {
+		return errors.New("cannot record an attestation from a dirty working tree\n" +
+			"  commit or remove every tracked and untracked change, rerun the green proof on that commit, then record it")
+	}
+	return nil
 }
 
 func renderRecordPreview(rec *attest.Attestation, path string) string {
@@ -228,7 +401,7 @@ func renderRecordPreview(rec *attest.Attestation, path string) string {
 	fmt.Fprintf(&b, "  subject %s %s\n", rec.Subject.Scheme, shortRef(rec.Subject.Value))
 	if len(rec.ObservedSurface.Surfaces) == 0 {
 		fmt.Fprintf(&b, "  %s\n", ui.RenderWarn(
-			"no --surface given: freshness can never rule out product drift for this record"))
+			"no --surface given: freshness remains unknown because product drift cannot be ruled out"))
 	}
 	fmt.Fprintln(&b)
 	return b.String()
@@ -245,7 +418,7 @@ func init() {
 	attestRecordCmd.Flags().Int("step", 0, "1-indexed step the failure landed on")
 	attestRecordCmd.Flags().String("step-text", "", "text of the step the failure landed on")
 	attestRecordCmd.Flags().Bool("landed-on-claim-step", false, "the red landed on the step naming the behavior")
-	attestRecordCmd.Flags().StringArray("surface", nil, "a file or route the run exercised (repeatable)")
+	attestRecordCmd.Flags().StringArray("surface", nil, "a file or route the run exercised; prefix ambiguous values with file: or route: (repeatable)")
 	attestRecordCmd.Flags().String("verdict", "", "override the derived verdict (clean|ambiguous|inconclusive)")
 	attestRecordCmd.Flags().String("repo-key", "", "opaque repo key (default: the repo directory name)")
 	attestRecordCmd.Flags().Bool("dry-run", false, "validate and print without writing")

--- a/cmd/ox/attest_results.go
+++ b/cmd/ox/attest_results.go
@@ -23,7 +23,7 @@ var attestResultsCmd = &cobra.Command{
 			return err
 		}
 		jsonOut, agentID := wantJSON(cmd)
-		return emit(jsonOut, agentID, results, renderAttestResults(results), "attest results")
+		return emit(cmd, jsonOut, agentID, results, renderAttestResults(results), "attest results")
 	},
 }
 

--- a/cmd/ox/doctor_session.go
+++ b/cmd/ox/doctor_session.go
@@ -29,6 +29,11 @@ func checkSessionHealth(opts doctorOptions) []checkResult {
 		results = append(results, uploadRetryResult)
 	}
 
+	registrationRetryResult := checkSessionLifecycleRegistrationRetry(gitRoot)
+	if !registrationRetryResult.passed || registrationRetryResult.message != "no pending registrations" {
+		results = append(results, registrationRetryResult)
+	}
+
 	// transcripts stranded in the content store with no local copy (GH #710).
 	// Quiet on the overwhelmingly common healthy case — dehydration is the
 	// normal steady state, so only surface sessions that actually need

--- a/cmd/ox/doctor_session_lifecycle.go
+++ b/cmd/ox/doctor_session_lifecycle.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sageox/ox/internal/session"
+)
+
+// checkSessionLifecycleRegistrationRetry retries only registrations that the
+// start path already marked pending. It runs as a safe doctor repair: the
+// session ID is the idempotency key and no Ledger content is uploaded here.
+func checkSessionLifecycleRegistrationRetry(projectRoot string) checkResult {
+	if projectRoot == "" {
+		return SkippedCheck("Session link registration", "no git repository", "")
+	}
+	states, err := session.LoadAllRecordingStates(projectRoot)
+	if err != nil {
+		return WarningCheck("Session link registration", "could not inspect recordings", err.Error())
+	}
+
+	pending := 0
+	confirmed := 0
+	for _, state := range states {
+		if state.LifecycleRegistrationState != "pending" {
+			continue
+		}
+		pending++
+		notifySessionStartedAsync(projectRoot, state)
+		if state.LifecycleRegistrationState == "confirmed" {
+			confirmed++
+		}
+	}
+	if pending == 0 {
+		return PassedCheck("Session link registration", "no pending registrations")
+	}
+	if confirmed == pending {
+		return PassedCheck("Session link registration", fmt.Sprintf("confirmed %d pending registration(s)", confirmed))
+	}
+	return WarningCheck(
+		"Session link registration",
+		fmt.Sprintf("confirmed %d of %d pending registration(s)", confirmed, pending),
+		"Run `ox login` if authentication expired, then re-run `ox doctor`",
+	)
+}

--- a/cmd/ox/main.go
+++ b/cmd/ox/main.go
@@ -133,6 +133,11 @@ func executeWithFrictionRecovery(args []string, attempt int) int {
 	rootCmd.ResetFlags()
 	// Re-register persistent flags after ResetFlags() clears them
 	registerPersistentFlags()
+	// Resolve cached/env feature flags before Cobra parses the command. This is
+	// required for default-off commands: help and command lookup both happen
+	// before PersistentPreRunE.
+	initFeatureFlags(rootCmd)
+	syncFeatureGatedCommands(rootCmd)
 	rootCmd.SetArgs(args)
 
 	// mark retry attempts to avoid telemetry double-counting

--- a/cmd/ox/root.go
+++ b/cmd/ox/root.go
@@ -219,6 +219,8 @@ func init() {
 
 // Execute runs the root command
 func Execute() error {
+	initFeatureFlags(rootCmd)
+	syncFeatureGatedCommands(rootCmd)
 	return rootCmd.Execute()
 }
 
@@ -516,6 +518,30 @@ func initFeatureFlags(cmd *cobra.Command) {
 	}
 
 	flags.Init(ctx, daemonProvider, flags.EnvProvider{})
+}
+
+// syncFeatureGatedCommands registers experimental commands only after the
+// layered feature flags have been resolved. Cobra resolves commands and renders
+// help before PersistentPreRunE, so a RunE-only guard would still advertise the
+// command and a Hidden-only guard would still allow direct execution.
+func syncFeatureGatedCommands(root *cobra.Command) {
+	setCommandRegistered(root, attestCmd, flags.Get().AttestEnabled)
+}
+
+func setCommandRegistered(root, command *cobra.Command, enabled bool) {
+	registered := false
+	for _, child := range root.Commands() {
+		if child == command {
+			registered = true
+			break
+		}
+	}
+	if enabled && !registered {
+		root.AddCommand(command)
+	}
+	if !enabled && registered {
+		root.RemoveCommand(command)
+	}
 }
 
 // printCommandEntry renders a command with contextual highlighting based on user state

--- a/cmd/ox/session_notify.go
+++ b/cmd/ox/session_notify.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -21,11 +22,9 @@ import (
 const sessionSignalWait = 750 * time.Millisecond
 
 // notifySessionStartedAsync registers a just-started recording with the
-// server so its /c/<session_id> conversation link resolves to an
-// "in progress" page from t=0. Fire-and-forget per the IPC architecture:
-// never blocks the start path beyond sessionSignalWait, all failures are
-// silent (debug log only), and it no-ops for recordings without a
-// start-minted ID or without the session-attribution toggle enabled.
+// server so its /c/<session_id> conversation link resolves from t=0. The
+// recording remains local-first, but the persisted outcome prevents later
+// output from presenting a remote URL after authentication/network failure.
 func notifySessionStartedAsync(projectRoot string, state *session.RecordingState) {
 	if state == nil || state.SessionID == "" {
 		return
@@ -34,16 +33,28 @@ func notifySessionStartedAsync(projectRoot string, state *session.RecordingState
 	if attr.Session == "" {
 		return
 	}
-	runSessionSignal("started", func(client *api.RepoClient, repoID string) error {
+	err := runSessionSignal("started", func(client *api.RepoClient, repoID string) error {
 		return client.NotifySessionStarted(api.SessionStartedNotification{
 			SessionID:   state.SessionID,
 			RepoID:      repoID,
 			SessionName: session.GetSessionName(state.SessionPath),
 			AgentID:     state.AgentID,
+			AgentType:   state.AgentType,
 			Branch:      state.Branch,
 			StartedAt:   state.StartedAt.Format(time.RFC3339),
 		})
 	}, projectRoot)
+	if err != nil {
+		state.LifecycleRegistrationState = "pending"
+		state.LifecycleRegistrationError = err.Error()
+		slog.Debug("session registration pending", "session_id", state.SessionID, "error", err)
+	} else {
+		state.LifecycleRegistrationState = "confirmed"
+		state.LifecycleRegistrationError = ""
+	}
+	if saveErr := session.SaveRecordingState(projectRoot, state); saveErr != nil {
+		slog.Debug("session registration status save failed", "session_id", state.SessionID, "error", saveErr)
+	}
 }
 
 // notifySessionAbortedAsync flips a registered recording to "discarded" so
@@ -61,31 +72,30 @@ func notifySessionAbortedAsync(projectRoot, sessionID string) {
 	}, projectRoot)
 }
 
-// runSessionSignal resolves config/auth and runs send in a goroutine,
-// waiting at most sessionSignalWait. Missing config or credentials are a
-// silent no-op — these signals are never load-bearing.
-func runSessionSignal(label string, send func(client *api.RepoClient, repoID string) error, projectRoot string) {
+// runSessionSignal resolves config/auth and runs send in a goroutine, waiting
+// at most sessionSignalWait. Its error is deliberately advisory to recording,
+// but callers persist it so a dead link never looks server-confirmed.
+func runSessionSignal(label string, send func(client *api.RepoClient, repoID string) error, projectRoot string) error {
 	cfg, err := config.LoadProjectConfig(projectRoot)
 	if err != nil || cfg == nil || cfg.RepoID == "" {
-		return
+		return fmt.Errorf("project configuration unavailable")
 	}
 	ep := endpoint.GetForProject(projectRoot)
 	token, err := auth.GetTokenForEndpoint(ep)
 	if err != nil || token == nil || token.AccessToken == "" {
-		return
+		return fmt.Errorf("authentication required")
 	}
 	client := api.NewRepoClientWithEndpoint(ep).WithAuthToken(token.AccessToken)
 
-	done := make(chan struct{})
+	done := make(chan error, 1)
 	go func() {
-		defer close(done)
-		if err := send(client, cfg.RepoID); err != nil {
-			slog.Debug("session signal failed", "signal", label, "error", err)
-		}
+		done <- send(client, cfg.RepoID)
 	}()
 	select {
-	case <-done:
+	case err := <-done:
+		return err
 	case <-time.After(sessionSignalWait):
 		slog.Debug("session signal timed out", "signal", label, "wait_ms", sessionSignalWait.Milliseconds())
+		return fmt.Errorf("server confirmation timed out")
 	}
 }

--- a/cmd/ox/session_url.go
+++ b/cmd/ox/session_url.go
@@ -65,6 +65,12 @@ func sessionLinkOutputs(projCfg *config.ProjectConfig, state *session.RecordingS
 	if attrSession == "" || state == nil {
 		return "", ""
 	}
+	if state.LifecycleRegistrationState == "pending" {
+		// A locally minted id is not evidence that the remote resolver knows
+		// it. Keep the link out of commit/PR guidance until a retry or upload
+		// makes it server-visible.
+		return "", ""
+	}
 	sessionURL = buildConversationURL(projCfg, state.SessionID)
 	if sessionURL == "" {
 		sessionURL = buildSessionURL(projCfg, session.GetSessionName(state.SessionPath))

--- a/internal/api/repo.go
+++ b/internal/api/repo.go
@@ -139,6 +139,7 @@ type SessionStartedNotification struct {
 	RepoID      string `json:"repo_id"`
 	SessionName string `json:"session_name,omitempty"`
 	AgentID     string `json:"agent_id,omitempty"`
+	AgentType   string `json:"agent_type,omitempty"`
 	Branch      string `json:"branch,omitempty"`
 	StartedAt   string `json:"started_at,omitempty"` // RFC3339
 }
@@ -613,7 +614,7 @@ func (c *RepoClient) NotifyImport(teamID string, metadata any) (recordingID stri
 // NotifyImport: 404 (endpoint not yet deployed) and 409 (already recorded —
 // idempotent) return (nil, nil) so callers proceed without retry thrash;
 // network errors, 429, and 5xx return an error for the caller's retry policy.
-func (c *RepoClient) postSessionSignal(pathTmpl, sessionID, label string, body any) ([]byte, error) {
+func (c *RepoClient) postSessionSignal(pathTmpl, sessionID, label string, body any, tolerateNotFound bool) ([]byte, error) {
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
@@ -644,7 +645,10 @@ func (c *RepoClient) postSessionSignal(pathTmpl, sessionID, label string, body a
 	logger.LogHTTPResponse("POST", reqURL, resp.StatusCode, duration)
 
 	switch {
-	case resp.StatusCode == http.StatusNotFound, resp.StatusCode == http.StatusConflict:
+	case resp.StatusCode == http.StatusConflict:
+		io.Copy(io.Discard, resp.Body)
+		return nil, nil
+	case resp.StatusCode == http.StatusNotFound && tolerateNotFound:
 		io.Copy(io.Discard, resp.Body)
 		return nil, nil
 	case resp.StatusCode >= 400:
@@ -663,7 +667,7 @@ func (c *RepoClient) postSessionSignal(pathTmpl, sessionID, label string, body a
 // caller surfaces as agent repair tasks. An empty or non-JSON body is
 // normal (older servers) and yields no misses.
 func (c *RepoClient) NotifySessionUploaded(n SessionUploadedNotification) ([]PRLinkMiss, error) {
-	respBody, err := c.postSessionSignal(sessionUploadedPath, n.SessionID, "session uploaded", n)
+	respBody, err := c.postSessionSignal(sessionUploadedPath, n.SessionID, "session uploaded", n, true)
 	if err != nil || len(respBody) == 0 {
 		return nil, err
 	}
@@ -675,16 +679,17 @@ func (c *RepoClient) NotifySessionUploaded(n SessionUploadedNotification) ([]PRL
 }
 
 // NotifySessionStarted registers a just-started recording so /c/<session_id>
-// resolves immediately. Callers treat this as strictly fire-and-forget.
+// resolves immediately. Unlike terminal notifications, a 404 is an error: the
+// caller must not advertise a URL the server has not confirmed.
 func (c *RepoClient) NotifySessionStarted(n SessionStartedNotification) error {
-	_, err := c.postSessionSignal(sessionStartedPath, n.SessionID, "session started", n)
+	_, err := c.postSessionSignal(sessionStartedPath, n.SessionID, "session started", n, false)
 	return err
 }
 
 // NotifySessionAborted marks a registered recording as discarded. Callers
 // treat this as strictly fire-and-forget.
 func (c *RepoClient) NotifySessionAborted(n SessionAbortedNotification) error {
-	_, err := c.postSessionSignal(sessionAbortedPath, n.SessionID, "session aborted", n)
+	_, err := c.postSessionSignal(sessionAbortedPath, n.SessionID, "session aborted", n, true)
 	return err
 }
 

--- a/internal/api/session_signals_test.go
+++ b/internal/api/session_signals_test.go
@@ -98,7 +98,7 @@ func TestNotifySessionStartedAndAborted(t *testing.T) {
 	}))
 	defer notFound.Close()
 	old := NewRepoClientWithEndpoint(notFound.URL)
-	assert.NoError(t, old.NotifySessionStarted(SessionStartedNotification{SessionID: "ses_x"}), "old server 404 = accepted")
+	assert.Error(t, old.NotifySessionStarted(SessionStartedNotification{SessionID: "ses_x"}), "a missing start endpoint must leave the link unconfirmed")
 	assert.NoError(t, old.NotifySessionAborted(SessionAbortedNotification{SessionID: "ses_x"}), "old server 404 = accepted")
 }
 
@@ -162,13 +162,14 @@ func TestSessionNotificationWireKeys(t *testing.T) {
 		{
 			name: "started",
 			wantKeys: []string{
-				"session_id", "repo_id", "session_name", "agent_id", "branch", "started_at",
+				"session_id", "repo_id", "session_name", "agent_id", "agent_type", "branch", "started_at",
 			},
 			wantValues: map[string]any{
 				"session_id":   "ses_s1",
 				"repo_id":      "repo_s1",
 				"session_name": "2026-01-01T00-00-user-OxS1",
 				"agent_id":     "agent_42",
+				"agent_type":   "claude-code",
 				"branch":       "dev/feature-x",
 				"started_at":   "2026-01-01T00:00:00Z",
 			},
@@ -178,6 +179,7 @@ func TestSessionNotificationWireKeys(t *testing.T) {
 					RepoID:      "repo_s1",
 					SessionName: "2026-01-01T00-00-user-OxS1",
 					AgentID:     "agent_42",
+					AgentType:   "claude-code",
 					Branch:      "dev/feature-x",
 					StartedAt:   "2026-01-01T00:00:00Z",
 				})

--- a/internal/attest/corpus.go
+++ b/internal/attest/corpus.go
@@ -66,6 +66,11 @@ func (c Capability) Title() string {
 type Scenario struct {
 	Name string `json:"name"`
 	Line int    `json:"line"`
+	// Index is the zero-based scenario position in the feature. The compiler
+	// carries the same identity in its selected/excluded arrays, which lets us
+	// distinguish duplicate scenario names (including duplicates under
+	// different Rule blocks) without guessing from display text.
+	Index int `json:"index"`
 	// Tags is the merged set: feature ∪ rule ∪ scenario, which is the set the
 	// Attest compiler applies when deciding whether a scenario dispatches.
 	Tags []string `json:"tags"`
@@ -132,6 +137,7 @@ var (
 	reFeature  = regexp.MustCompile(`^\s*Feature:\s*(.*)$`)
 	reRule     = regexp.MustCompile(`^\s*Rule:\s*(.*)$`)
 	reScenario = regexp.MustCompile(`^\s*(?:Scenario Outline|Scenario Template|Scenario|Example):\s*(.*)$`)
+	reExamples = regexp.MustCompile(`^\s*Examples(?:\s+[^:]*)?:`)
 	reTag      = regexp.MustCompile(`@[^\s@]+`)
 	reNonSlug  = regexp.MustCompile(`[^a-z0-9]+`)
 )
@@ -213,6 +219,7 @@ func scanFile(repoRoot, featuresDir, path string) ([]Capability, error) {
 		pendingStmp *Stamp   // `# validated:` comment seen since the last keyword
 		current     *Capability
 		lineNo      int
+		scenarioIdx int
 		// slugCounts disambiguates two Rules with identical text in one file:
 		// the second becomes `<slug>-2`. Without this their ids collide and one
 		// capability silently shadows the other.
@@ -291,11 +298,19 @@ func scanFile(repoRoot, featuresDir, path string) ([]Capability, error) {
 			s := Scenario{
 				Name:  name,
 				Line:  lineNo,
+				Index: scenarioIdx,
 				Tags:  tags,
 				Stamp: pendingStmp,
 			}
+			scenarioIdx++
 			s.Validated = s.HasTag(TagValidated)
 			cap.Scenarios = append(cap.Scenarios, s)
+			pending, pendingStmp = nil, nil
+
+		case reExamples.MatchString(line):
+			// Tags before an Examples table belong to that table. Examples are
+			// deliberately not represented as scenarios here, but their tags
+			// must still be consumed or they leak into the next Scenario.
 			pending, pendingStmp = nil, nil
 		}
 	}

--- a/internal/attest/corpus_test.go
+++ b/internal/attest/corpus_test.go
@@ -59,7 +59,7 @@ func TestScanCorpus_MultipleRulesBecomeSeparateCapabilities(t *testing.T) {
     Scenario: A revoked link 410s
       Given a revoked link
 
-  Rule: Share links honour a max-uses cap
+  Rule: Share links honor a max-uses cap
     Scenario: The cap is enforced
       Given a link with a cap
     Scenario: The cap is reported
@@ -74,7 +74,7 @@ func TestScanCorpus_MultipleRulesBecomeSeparateCapabilities(t *testing.T) {
 	if got := len(revoked.Scenarios); got != 1 {
 		t.Errorf("first Rule scenarios = %d, want 1", got)
 	}
-	cap2 := findCap(t, c, "sharing/share-links#share-links-honour-a-max-uses-cap")
+	cap2 := findCap(t, c, "sharing/share-links#share-links-honor-a-max-uses-cap")
 	if got := len(cap2.Scenarios); got != 2 {
 		t.Errorf("second Rule scenarios = %d, want 2", got)
 	}
@@ -137,6 +137,54 @@ func TestScanCorpus_ExamplesTableIsNotAScenario(t *testing.T) {
 	}
 	if cap.Scenarios[0].Name != "A member views <surface>" {
 		t.Errorf("scenario name = %q", cap.Scenarios[0].Name)
+	}
+}
+
+func TestScanCorpus_ExamplesTagsDoNotLeakIntoNextScenario(t *testing.T) {
+	c := scan(t, map[string]string{
+		"repository/browse.feature": `Feature: Browse
+
+  Rule: A member can browse
+    Scenario Outline: A member views <surface>
+      Given a member
+      @validated
+      Examples: common surfaces
+        | surface |
+        | overview |
+
+    Scenario: A member views settings
+      Given a member
+`,
+	})
+
+	cap := findCap(t, c, "repository/browse#a-member-can-browse")
+	if got := len(cap.Scenarios); got != 2 {
+		t.Fatalf("scenarios = %d, want 2", got)
+	}
+	if cap.Scenarios[1].HasTag(TagValidated) {
+		t.Fatalf("Examples tag leaked into the following scenario: %v", cap.Scenarios[1].Tags)
+	}
+}
+
+func TestScanCorpus_ScenarioIndexIsFeatureWideAcrossRules(t *testing.T) {
+	c := scan(t, map[string]string{
+		"devices/pairing.feature": `Feature: Pairing
+
+  Rule: Phones pair
+    Scenario: A device pairs
+      Given a phone
+
+  Rule: Tablets pair
+    Scenario: A device pairs
+      Given a tablet
+`,
+	})
+
+	if got := c.Capabilities[0].Scenarios[0].Index; got != 0 {
+		t.Errorf("first scenario index = %d, want 0", got)
+	}
+	if got := c.Capabilities[1].Scenarios[0].Index; got != 1 {
+		t.Errorf("second scenario index = %d, want 1", got)
 	}
 }
 

--- a/internal/attest/freshness.go
+++ b/internal/attest/freshness.go
@@ -3,6 +3,7 @@ package attest
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -76,6 +77,12 @@ func checkFreshness(repoRoot string, a *Attestation, currentSpecFingerprint stri
 		// it. Saying so is the correct answer — guessing "fresh" is not.
 		return Freshness{Unknown: true, Reason: "subject scheme " + a.Subject.Scheme + " is not resolvable by git"}
 	}
+	if a.SpecFingerprint == "" {
+		return Freshness{Unknown: true, Reason: "record has no spec fingerprint — specification drift cannot be ruled out"}
+	}
+	if currentSpecFingerprint == "" {
+		return Freshness{Unknown: true, Reason: "current spec fingerprint is unavailable — specification drift cannot be ruled out"}
+	}
 
 	// Half 1: is the proof's tree an ancestor of where we are now?
 	if _, err := git(repoRoot, "merge-base", "--is-ancestor", a.Subject.Value, "HEAD"); err != nil {
@@ -90,15 +97,16 @@ func checkFreshness(repoRoot string, a *Attestation, currentSpecFingerprint stri
 	}
 
 	// Half 2a: did the specification itself move?
-	if a.SpecFingerprint != "" && currentSpecFingerprint != "" {
-		f.SpecStale = a.SpecFingerprint != currentSpecFingerprint
-	}
+	f.SpecStale = a.SpecFingerprint != currentSpecFingerprint
 
 	// Half 2b: did the product move underneath it?
 	//
 	// `git diff --name-only <subject>` with no second ref compares against the
 	// WORKING TREE, so an uncommitted edit counts. That is the point.
-	changed, err := git(repoRoot, "diff", "--name-only", a.Subject.Value)
+	// Disable rename detection so both the old and new path are emitted. A
+	// record observes the old path; accepting only a rename destination would
+	// let that observed surface disappear without registering as drift.
+	changed, err := git(repoRoot, "diff", "--name-only", "--no-renames", a.Subject.Value)
 	if err != nil {
 		return Freshness{
 			Reachable: f.Reachable, SpecStale: f.SpecStale,
@@ -108,11 +116,26 @@ func checkFreshness(repoRoot string, a *Attestation, currentSpecFingerprint stri
 	changedSet := map[string]struct{}{}
 	for _, p := range strings.Split(changed, "\n") {
 		if p = strings.TrimSpace(p); p != "" {
-			changedSet[p] = struct{}{}
+			changedSet[normalizeRepoPath(p)] = struct{}{}
+		}
+	}
+	// `git diff` intentionally omits untracked files. They still matter when a
+	// dirty-tree record names one as an observed surface, so fold them into the
+	// same changed set rather than silently declaring the proof current.
+	untracked, err := git(repoRoot, "ls-files", "--others", "--exclude-standard")
+	if err != nil {
+		return Freshness{
+			Reachable: f.Reachable, SpecStale: f.SpecStale,
+			Unknown: true, Reason: "could not inspect untracked files",
+		}
+	}
+	for _, p := range strings.Split(untracked, "\n") {
+		if p = strings.TrimSpace(p); p != "" {
+			changedSet[normalizeRepoPath(p)] = struct{}{}
 		}
 	}
 	for _, s := range a.ObservedSurface.Surfaces {
-		if _, hit := changedSet[s.SurfaceID]; hit {
+		if _, hit := changedSet[normalizeRepoPath(s.SurfaceID)]; hit {
 			f.ProductDrift = append(f.ProductDrift, s.SurfaceID)
 		}
 	}
@@ -129,6 +152,11 @@ func checkFreshness(repoRoot string, a *Attestation, currentSpecFingerprint stri
 
 	f.Current = f.Reachable && !f.SpecStale && len(f.ProductDrift) == 0
 	return f
+}
+
+func normalizeRepoPath(path string) string {
+	path = filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))
+	return strings.TrimPrefix(path, "./")
 }
 
 // Summary is a one-line human verdict.

--- a/internal/attest/freshness_test.go
+++ b/internal/attest/freshness_test.go
@@ -2,6 +2,9 @@ package attest
 
 import (
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -12,7 +15,11 @@ type fakeGit struct {
 	isAncestor  bool
 	commitKnown bool
 	changed     []string
+	untracked   []string
+	renameFrom  string
+	renameTo    string
 	diffFails   bool
+	lsFails     bool
 }
 
 func (f fakeGit) run(_ string, args ...string) (string, error) {
@@ -31,7 +38,20 @@ func (f fakeGit) run(_ string, args ...string) (string, error) {
 		if f.diffFails {
 			return "", errors.New("diff failed")
 		}
+		if f.renameFrom != "" {
+			for _, arg := range args {
+				if arg == "--no-renames" {
+					return f.renameFrom + "\n" + f.renameTo, nil
+				}
+			}
+			return f.renameTo, nil
+		}
 		return strings.Join(f.changed, "\n"), nil
+	case "ls-files":
+		if f.lsFails {
+			return "", errors.New("ls-files failed")
+		}
+		return strings.Join(f.untracked, "\n"), nil
 	}
 	return "", nil
 }
@@ -73,6 +93,55 @@ func TestCheckFreshness_ProductDriftFromWorkingTree(t *testing.T) {
 	}
 	if !strings.Contains(f.Summary(), "product moved") {
 		t.Errorf("Summary = %q", f.Summary())
+	}
+}
+
+func TestCheckFreshness_ProductDriftIncludesRenamesAndUntrackedFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		surface string
+		git     fakeGit
+	}{
+		{
+			name:    "rename reports the observed source path",
+			surface: "app/team/layout.tsx",
+			git: fakeGit{
+				isAncestor:  true,
+				commitKnown: true,
+				renameFrom:  "app/team/layout.tsx",
+				renameTo:    "app/team/new-layout.tsx",
+			},
+		},
+		{
+			name:    "untracked observed surface",
+			surface: "app/team/new-layout.tsx",
+			git: fakeGit{
+				isAncestor:  true,
+				commitKnown: true,
+				untracked:   []string{"app/team/new-layout.tsx"},
+			},
+		},
+		{
+			name:    "surface path is normalized",
+			surface: "./app/team/layout.tsx",
+			git: fakeGit{
+				isAncestor:  true,
+				commitKnown: true,
+				changed:     []string{"app/team/layout.tsx"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := checkFreshness("/repo", recWithSurface(tc.surface), "spec-abc", tc.git.run)
+			if f.Current {
+				t.Fatal("changed observed surface must not read as current")
+			}
+			if len(f.ProductDrift) != 1 || f.ProductDrift[0] != tc.surface {
+				t.Fatalf("ProductDrift = %v, want %q", f.ProductDrift, tc.surface)
+			}
+		})
 	}
 }
 
@@ -129,6 +198,22 @@ func TestCheckFreshness_UnknownIsNeverFresh(t *testing.T) {
 			want: "could not diff",
 		},
 		{
+			name: "untracked files could not be inspected",
+			rec:  recWithSurface("a.tsx"),
+			git:  fakeGit{isAncestor: true, commitKnown: true, lsFails: true},
+			want: "could not inspect untracked",
+		},
+		{
+			name: "record fingerprint missing",
+			rec: func() *Attestation {
+				a := recWithSurface("a.tsx")
+				a.SpecFingerprint = ""
+				return a
+			}(),
+			git:  fakeGit{isAncestor: true, commitKnown: true},
+			want: "record has no spec fingerprint",
+		},
+		{
 			name: "subject scheme git cannot resolve",
 			rec: func() *Attestation {
 				a := recWithSurface("a.tsx")
@@ -157,6 +242,16 @@ func TestCheckFreshness_UnknownIsNeverFresh(t *testing.T) {
 	}
 }
 
+func TestCheckFreshness_MissingCurrentFingerprintIsUnknown(t *testing.T) {
+	f := checkFreshness("/repo", recWithSurface("a.tsx"), "", fakeGit{isAncestor: true, commitKnown: true}.run)
+	if f.Current || !f.Unknown {
+		t.Fatalf("missing current fingerprint must be unknown, got %+v", f)
+	}
+	if !strings.Contains(f.Reason, "current spec fingerprint is unavailable") {
+		t.Errorf("Reason = %q", f.Reason)
+	}
+}
+
 // The fingerprint digest must depend on the SET of inputs, not their order —
 // otherwise a cosmetic reordering by the compiler reads as spec drift and sends
 // somebody re-proving a capability that never changed.
@@ -182,5 +277,83 @@ func TestFingerprintDigest_OrderIndependent(t *testing.T) {
 	}
 	if FingerprintDigest(PlanFingerprint{}) != "" {
 		t.Error("an empty fingerprint must digest to empty, not to a hash of nothing")
+	}
+}
+
+func TestLiveFingerprint_UsesCurrentSourceBytes(t *testing.T) {
+	root := writeCorpus(t, map[string]string{"d/live.feature": "hello\n"})
+	fp := PlanFingerprint{Inputs: []FingerprintInput{
+		// Known `git hash-object` result for "hello\n". This also locks the
+		// in-process implementation to the compiler's Git blob formula.
+		{Path: "features/d/live.feature", OID: "ce013625030ba8dba906f756967f9e9ca394464a"},
+	}}
+
+	before, err := LiveFingerprint(root, fp)
+	if err != nil {
+		t.Fatalf("LiveFingerprint before edit: %v", err)
+	}
+	if want := FingerprintDigest(fp); before != want {
+		t.Fatalf("live fingerprint = %q, want compiler-compatible digest %q", before, want)
+	}
+	if err := os.WriteFile(filepath.Join(root, "features", "d", "live.feature"), []byte("Feature: After\n"), 0o600); err != nil {
+		t.Fatalf("edit feature: %v", err)
+	}
+	after, err := LiveFingerprint(root, fp)
+	if err != nil {
+		t.Fatalf("LiveFingerprint after edit: %v", err)
+	}
+	if before == after {
+		t.Fatal("live fingerprint did not change when a compiler input changed")
+	}
+	if got := FingerprintDigest(fp); after == got {
+		t.Fatal("live fingerprint reused the OID stored in the compiled plan")
+	}
+}
+
+func TestLiveFingerprint_RejectsInputOutsideCorpus(t *testing.T) {
+	root := t.TempDir()
+	_, err := LiveFingerprint(root, PlanFingerprint{Inputs: []FingerprintInput{{Path: "../secret", OID: "x"}}})
+	if err == nil || !strings.Contains(err.Error(), "escapes corpus root") {
+		t.Fatalf("LiveFingerprint path traversal error = %v", err)
+	}
+}
+
+func TestCheckFreshness_RealGitWorkingTree(t *testing.T) {
+	repo := t.TempDir()
+	runFreshnessGit(t, repo, "init", "--quiet")
+	runFreshnessGit(t, repo, "config", "user.name", "Attest Test")
+	runFreshnessGit(t, repo, "config", "user.email", "attest@example.com")
+	path := filepath.Join(repo, "observed.go")
+	if err := os.WriteFile(path, []byte("package observed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runFreshnessGit(t, repo, "add", "observed.go")
+	runFreshnessGit(t, repo, "commit", "--quiet", "-m", "initial")
+
+	head, err := HeadCommit(repo)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	rec := recWithSurface("observed.go")
+	rec.Subject = TreeRef{Scheme: SchemeGitCommit, Value: head}
+	if got := CheckFreshness(repo, rec, "spec-abc"); !got.Current {
+		t.Fatalf("clean real repository is not current: %+v", got)
+	}
+
+	if err := os.WriteFile(path, []byte("package changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := CheckFreshness(repo, rec, "spec-abc")
+	if got.Current || len(got.ProductDrift) != 1 || got.ProductDrift[0] != "observed.go" {
+		t.Fatalf("real working-tree edit was not detected: %+v", got)
+	}
+}
+
+func runFreshnessGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
 }

--- a/internal/attest/ladder.go
+++ b/internal/attest/ladder.go
@@ -42,6 +42,9 @@ const (
 	// behind it. The stamp names a run id that resolves to nothing anyone else
 	// can open.
 	VerdictStamped Verdict = "stamped"
+	// VerdictStale — a clean proof record exists, but it cannot be trusted to
+	// describe the current specification and working tree.
+	VerdictStale Verdict = "stale"
 	// VerdictAttested — a committed record carrying a clean red-first proof.
 	VerdictAttested Verdict = "attested"
 )
@@ -52,6 +55,7 @@ var VerdictOrder = []Verdict{
 	VerdictSkipped,
 	VerdictUnproven,
 	VerdictStamped,
+	VerdictStale,
 	VerdictAttested,
 }
 
@@ -67,6 +71,8 @@ func (v Verdict) Meaning() string {
 		return "dispatches, never stamped green"
 	case VerdictStamped:
 		return "stamped green, but no record backs the claim"
+	case VerdictStale:
+		return "a clean proof exists, but is stale or its freshness is unknown"
 	case VerdictAttested:
 		return "a committed record with a red-first proof"
 	default:
@@ -95,6 +101,26 @@ type Assessment struct {
 	NoPlan bool `json:"no_plan"`
 	// Record is the attestation backing this capability, when one exists.
 	Record *Attestation `json:"record,omitempty"`
+	// Freshness records whether that proof still describes the current working
+	// tree. It is attached by callers with repository context via WithFreshness
+	// or Report.ApplyFreshness.
+	Freshness *Freshness `json:"freshness,omitempty"`
+}
+
+// WithFreshness attaches a working-tree freshness verdict to an assessment.
+// A clean record is attested only while it is current; stale and unknown
+// records occupy their own rung rather than masquerading as either a current
+// proof or a claim with no record.
+func (a Assessment) WithFreshness(f Freshness) Assessment {
+	a.Freshness = &f
+	if a.Verdict == VerdictAttested || a.Verdict == VerdictStale {
+		if f.Current {
+			a.Verdict = VerdictAttested
+		} else {
+			a.Verdict = VerdictStale
+		}
+	}
+	return a
 }
 
 // Assess computes the verdict for one capability against the compiled plans and
@@ -117,7 +143,7 @@ func Assess(cap Capability, plans *Plans, records *Records) Assessment {
 
 	for i := range cap.Scenarios {
 		s := &cap.Scenarios[i]
-		if hasPlan && plan.Dispatches(s.Name) {
+		if hasPlan && plan.DispatchesScenario(cap.Rule, *s) {
 			a.Dispatching++
 		}
 		if s.Validated {
@@ -185,15 +211,15 @@ type ScenarioTotals struct {
 // BuildReport assesses every capability in a corpus.
 func BuildReport(corpus *Corpus, plans *Plans, records *Records) *Report {
 	r := &Report{
-		Root:         corpus.Root,
-		Files:        corpus.Files,
-		Plans:        plans.Count,
-		Records:      records.Count,
+		Root:           corpus.Root,
+		Files:          corpus.Files,
+		Plans:          plans.Count,
+		Records:        records.Count,
 		InvalidRecords: records.Invalid,
-		Capabilities: len(corpus.Capabilities),
-		Domains:      corpus.Domains(),
-		Counts:       map[Verdict]int{},
-		ByDomain:     map[string][]Assessment{},
+		Capabilities:   len(corpus.Capabilities),
+		Domains:        corpus.Domains(),
+		Counts:         map[Verdict]int{},
+		ByDomain:       map[string][]Assessment{},
 	}
 	for _, v := range VerdictOrder {
 		r.Counts[v] = 0
@@ -209,6 +235,30 @@ func BuildReport(corpus *Corpus, plans *Plans, records *Records) *Report {
 		r.ByDomain[cap.Domain] = append(r.ByDomain[cap.Domain], a)
 	}
 	return r
+}
+
+// ApplyFreshness attaches current working-tree freshness to every assessment
+// with a record and rebuilds the report's derived verdict indexes. The caller
+// supplies the checker because only the CLI knows which repository/worktree is
+// being inspected.
+func (r *Report) ApplyFreshness(check func(Capability, *Attestation) Freshness) {
+	if r == nil || check == nil {
+		return
+	}
+	r.Counts = map[Verdict]int{}
+	for _, verdict := range VerdictOrder {
+		r.Counts[verdict] = 0
+	}
+	r.ByDomain = map[string][]Assessment{}
+	for i := range r.Assessments {
+		a := r.Assessments[i]
+		if a.Record != nil {
+			a = a.WithFreshness(check(a.Capability, a.Record))
+		}
+		r.Assessments[i] = a
+		r.Counts[a.Verdict]++
+		r.ByDomain[a.Capability.Domain] = append(r.ByDomain[a.Capability.Domain], a)
+	}
 }
 
 // Weakest returns up to n assessments ordered worst-first — the answer to

--- a/internal/attest/ladder_test.go
+++ b/internal/attest/ladder_test.go
@@ -50,8 +50,8 @@ func TestAssess_LadderRungs(t *testing.T) {
 		SchemaVersion: 1,
 		Feature:       "features/d/ladder.feature",
 		Scenarios: []PlanScenario{
-			{Name: "Stamped one", Rule: "Dispatches and is stamped"},
-			{Name: "Unstamped one", Rule: "Dispatches but was never stamped"},
+			{Name: "Stamped one", Index: 0, Rule: "Dispatches and is stamped"},
+			{Name: "Unstamped one", Index: 1, Rule: "Dispatches but was never stamped"},
 		},
 		Excluded: []PlanExcluded{{Name: "Excluded one", Tags: []string{"@pending"}, Reason: "tag"}},
 	})
@@ -134,8 +134,8 @@ func TestBuildReport_TotalsAndWeakestOrdering(t *testing.T) {
 		SchemaVersion: 1,
 		Feature:       "features/d/ladder.feature",
 		Scenarios: []PlanScenario{
-			{Name: "Stamped one"},
-			{Name: "Unstamped one"},
+			{Name: "Stamped one", Index: 0, Rule: "Dispatches and is stamped"},
+			{Name: "Unstamped one", Index: 1, Rule: "Dispatches but was never stamped"},
 		},
 	})
 	corpus, _ := ScanCorpus(root, root)
@@ -169,6 +169,107 @@ func TestBuildReport_TotalsAndWeakestOrdering(t *testing.T) {
 	if weakest[len(weakest)-1].Verdict != VerdictStamped {
 		t.Errorf("weakest[last] = %q, want the strongest present rung %q",
 			weakest[len(weakest)-1].Verdict, VerdictStamped)
+	}
+}
+
+func TestAssess_DuplicateScenarioNamesUseCompilerIdentity(t *testing.T) {
+	root := writeCorpus(t, map[string]string{
+		"d/duplicates.feature": `Feature: Duplicates
+
+  Rule: First capability
+    Scenario: Same display name
+      Given the first thing
+
+  Rule: Second capability
+    Scenario: Same display name
+      Given the second thing
+`,
+	})
+	writePlan(t, root, CompiledPlan{
+		SchemaVersion: 1,
+		Feature:       "features/d/duplicates.feature",
+		Scenarios: []PlanScenario{
+			{Name: "Same display name", Index: 1, Rule: "Second capability"},
+		},
+		Excluded: []PlanExcluded{
+			{Name: "Same display name", Index: 0, Reason: "tag"},
+		},
+	})
+
+	corpus, err := ScanCorpus(root, root)
+	if err != nil {
+		t.Fatalf("ScanCorpus: %v", err)
+	}
+	plans, err := LoadPlans(root)
+	if err != nil {
+		t.Fatalf("LoadPlans: %v", err)
+	}
+
+	first := Assess(corpus.Capabilities[0], plans, &Records{})
+	second := Assess(corpus.Capabilities[1], plans, &Records{})
+	if first.Dispatching != 0 || first.Verdict != VerdictSkipped {
+		t.Errorf("excluded duplicate assessment = %+v, want skipped", first)
+	}
+	if second.Dispatching != 1 || second.Verdict != VerdictUnproven {
+		t.Errorf("selected duplicate assessment = %+v, want unproven", second)
+	}
+}
+
+func TestReportApplyFreshness_StaleAndUnknownProofsAreNotAttested(t *testing.T) {
+	tests := []struct {
+		name      string
+		freshness Freshness
+	}{
+		{name: "stale", freshness: Freshness{Reachable: true, SpecStale: true}},
+		{name: "unknown", freshness: Freshness{Unknown: true, Reason: "current fingerprint unavailable"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeCorpus(t, map[string]string{
+				"d/proof.feature": `Feature: Proof
+
+  Rule: A clean proof exists
+    Scenario: It works
+      Given a thing
+`,
+			})
+			writePlan(t, root, CompiledPlan{
+				SchemaVersion: 1,
+				Feature:       "features/d/proof.feature",
+				Scenarios: []PlanScenario{
+					{Name: "It works", Index: 0, Rule: "A clean proof exists"},
+				},
+			})
+			corpus, _ := ScanCorpus(root, root)
+			plans, _ := LoadPlans(root)
+			record := validRecord()
+			record.CapabilityID = corpus.Capabilities[0].ID
+			records := &Records{
+				byCapability: map[string]*Attestation{record.CapabilityID: record},
+				Count:        1,
+			}
+
+			report := BuildReport(corpus, plans, records)
+			if report.Counts[VerdictAttested] != 1 {
+				t.Fatalf("precondition: attested count = %d, want 1", report.Counts[VerdictAttested])
+			}
+			report.ApplyFreshness(func(Capability, *Attestation) Freshness { return tc.freshness })
+
+			assessment := report.Assessments[0]
+			if assessment.Verdict != VerdictStale {
+				t.Errorf("verdict = %q, want %q", assessment.Verdict, VerdictStale)
+			}
+			if assessment.Freshness == nil || assessment.Freshness.Current {
+				t.Errorf("Freshness = %+v, want attached non-current verdict", assessment.Freshness)
+			}
+			if report.Counts[VerdictAttested] != 0 || report.Counts[VerdictStale] != 1 {
+				t.Errorf("counts = %v, want stale=1 attested=0", report.Counts)
+			}
+			if got := report.ByDomain["d"][0].Verdict; got != VerdictStale {
+				t.Errorf("ByDomain verdict = %q, want %q", got, VerdictStale)
+			}
+		})
 	}
 }
 

--- a/internal/attest/plan.go
+++ b/internal/attest/plan.go
@@ -1,6 +1,7 @@
 package attest
 
 import (
+	"crypto/sha1" //nolint:gosec // Attest fingerprints intentionally use Git's SHA-1 blob format.
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -71,6 +72,56 @@ func FingerprintDigest(fp PlanFingerprint) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// LiveFingerprint re-hashes the fingerprint's source files as they exist in
+// the working tree now. Hashing the stored fingerprint again would only prove
+// that the compiled plan has not been edited; it would miss changes to the
+// feature and L2 sources from which the plan was compiled.
+//
+// Fingerprint paths are corpus-relative by compiler contract. The blob OID is
+// computed in-process with the same byte formula as `git hash-object`, so dirty
+// and untracked source files are handled without depending on Git's index.
+func LiveFingerprint(corpusRoot string, fp PlanFingerprint) (string, error) {
+	if len(fp.Inputs) == 0 {
+		return "", nil
+	}
+
+	live := PlanFingerprint{Inputs: make([]FingerprintInput, 0, len(fp.Inputs))}
+	for _, input := range fp.Inputs {
+		path, err := fingerprintInputPath(corpusRoot, input.Path)
+		if err != nil {
+			return "", err
+		}
+		raw, err := os.ReadFile(path) //nolint:gosec // path is constrained to the caller-supplied corpus root.
+		if err != nil {
+			return "", fmt.Errorf("read fingerprint input %s: %w", input.Path, err)
+		}
+		h := sha1.New() //nolint:gosec // Git blob OIDs and the compiler contract require SHA-1.
+		_, _ = fmt.Fprintf(h, "blob %d%c", len(raw), byte(0))
+		_, _ = h.Write(raw)
+		live.Inputs = append(live.Inputs, FingerprintInput{
+			Path: input.Path,
+			OID:  hex.EncodeToString(h.Sum(nil)),
+		})
+	}
+	return FingerprintDigest(live), nil
+}
+
+func fingerprintInputPath(corpusRoot, inputPath string) (string, error) {
+	if inputPath == "" || filepath.IsAbs(filepath.FromSlash(inputPath)) {
+		return "", fmt.Errorf("invalid fingerprint input path %q", inputPath)
+	}
+	root, err := filepath.Abs(corpusRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve corpus root: %w", err)
+	}
+	path := filepath.Join(root, filepath.FromSlash(inputPath))
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("fingerprint input path %q escapes corpus root", inputPath)
+	}
+	return path, nil
+}
+
 // PlanScenario is a scenario the compiler selected — it dispatches.
 type PlanScenario struct {
 	Name  string   `json:"name"`
@@ -81,8 +132,8 @@ type PlanScenario struct {
 
 // PlanExcluded is a scenario the compiler refused to dispatch, and why.
 //
-// Note it carries no Rule, so attribution back to a capability is by scenario
-// NAME against the corpus scan — see Plans.Dispatches.
+// It carries no Rule, but its feature-wide Index still distinguishes duplicate
+// display names when selected and excluded scenarios are joined to the corpus.
 type PlanExcluded struct {
 	Name   string   `json:"name"`
 	Index  int      `json:"index"`
@@ -161,33 +212,19 @@ func (p *Plans) For(capabilityPath string) (*CompiledPlan, bool) {
 	return nil, false
 }
 
-// Dispatches reports whether a named scenario in this plan actually dispatches.
-//
-// Matched by name because `excluded[]` carries no rule and both arrays index
-// independently from zero, so the scenario NAME is the only stable join key
-// between the compiled artifact and the corpus scan.
-func (plan *CompiledPlan) Dispatches(scenarioName string) bool {
+// DispatchesScenario reports whether this exact corpus scenario dispatches.
+// The compiler keys scenarios by their feature-wide (index, name) pair and
+// also records the enclosing Rule for selected scenarios. Matching all three
+// prevents one duplicate name from promoting a different Rule's capability.
+func (plan *CompiledPlan) DispatchesScenario(rule string, scenario Scenario) bool {
 	if plan == nil {
 		return false
 	}
-	for _, s := range plan.Scenarios {
-		if s.Name == scenarioName {
+	for _, compiled := range plan.Scenarios {
+		if compiled.Index == scenario.Index && compiled.Name == scenario.Name &&
+			(compiled.Rule == "" || compiled.Rule == rule) {
 			return true
 		}
 	}
 	return false
-}
-
-// ExclusionReason returns why a named scenario was excluded ("tag",
-// "unmatched-step", ...), or "" when the plan does not mention it.
-func (plan *CompiledPlan) ExclusionReason(scenarioName string) string {
-	if plan == nil {
-		return ""
-	}
-	for _, e := range plan.Excluded {
-		if e.Name == scenarioName {
-			return e.Reason
-		}
-	}
-	return ""
 }

--- a/internal/attest/publish.go
+++ b/internal/attest/publish.go
@@ -4,11 +4,16 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
+	"unicode"
+
+	"github.com/google/uuid"
 )
 
 // LayoutVersion is in the KEY PATH, not a field.
@@ -82,7 +87,8 @@ type PublishResult struct {
 //
 //		attest/v1/status/<repo-key>/<YYYY>/<MM>/<DD>/<stamp>/report.json
 //		attest/v1/status/<repo-key>/<YYYY>/<MM>/<DD>/<stamp>/manifest.json
-//		attest/v1/attestations/<repo-key>/<capability-slug>.v1.json
+//		attest/v1/status/<repo-key>/<YYYY>/<MM>/<DD>/<stamp>/attestations/<capability>.v1.json
+//		attest/v1/status/<repo-key>/<YYYY>/<MM>/<DD>/<stamp>/runs/<run>.json
 //		attest/v1/index/<repo-key>/<stamp>.json
 //
 //	 1. The index is ONE IMMUTABLE OBJECT PER PUBLISH, not an appended JSONL file.
@@ -95,11 +101,19 @@ type PublishResult struct {
 //	    boundary is immutable once written and a local-time publisher would
 //	    silently scatter a day across two prefixes.
 func WriteBundle(dest, repoKey string, report *Report, records *Records, runs []RunResult, now time.Time) (*PublishResult, error) {
+	if report == nil {
+		return nil, errors.New("publish attest bundle: report is nil")
+	}
+	if records == nil {
+		return nil, errors.New("publish attest bundle: records are nil")
+	}
+	if err := validateRepoKey(repoKey); err != nil {
+		return nil, fmt.Errorf("publish attest bundle: invalid repo key: %w", err)
+	}
 	utc := now.UTC()
-	// A second-resolution key could overwrite an immutable publication when an
-	// operator corrects and republishes immediately. Nanoseconds keep distinct
-	// local publishes distinct without making the portable layout AWS-specific.
-	stamp := utc.Format("20060102T150405.000000000Z")
+	// The timestamp keeps publishes naturally sortable. The UUID keeps two
+	// publishers using the same clock instant from sharing any mutable path.
+	stamp := utc.Format("20060102T150405.000000000Z") + "-" + uuid.Must(uuid.NewV7()).String()
 	base := filepath.Join(dest, "attest", LayoutVersion)
 	runDir := filepath.Join(base, "status", repoKey,
 		utc.Format("2006"), utc.Format("01"), utc.Format("02"), stamp)
@@ -117,19 +131,18 @@ func WriteBundle(dest, repoKey string, report *Report, records *Records, runs []
 	}
 	result := &PublishResult{Root: base}
 
-	bundle := Bundle{PublishedAt: manifest.PublishedAt, RepoKey: repoKey, Report: report}
+	bundle := Bundle{PublishedAt: manifest.PublishedAt, RepoKey: repoKey, Report: publishedReport(report)}
 	mf, err := writeJSON(filepath.Join(runDir, "report.json"), bundle, base, "report")
 	if err != nil {
 		return nil, err
 	}
 	manifest.Files = append(manifest.Files, mf)
 
-	// Attestations are published under their own prefix rather than inside the
-	// dated directory: a record is current-state, not a point-in-time snapshot,
-	// and burying it in a timestamp would make "what is proven now?" require a
-	// listing to answer.
-	attDir := filepath.Join(base, "attestations", repoKey)
-	if records.Count > 0 {
+	// Records and run summaries belong to this immutable snapshot. Sharing these
+	// objects across publishes would let a later publish overwrite bytes named
+	// by an older manifest, retroactively breaking that manifest's integrity.
+	attDir := filepath.Join(runDir, "attestations")
+	if len(records.byCapability) > 0 {
 		if err := os.MkdirAll(attDir, 0o755); err != nil {
 			return nil, fmt.Errorf("create attestations dir: %w", err)
 		}
@@ -140,7 +153,7 @@ func WriteBundle(dest, repoKey string, report *Report, records *Records, runs []
 	}
 	sort.Strings(ids) // deterministic manifest ordering
 	for _, id := range ids {
-		name := fmt.Sprintf("%s.v%d.json", slugify(id), AttestationVersion)
+		name := recordFilename(id)
 		f, werr := writeJSON(filepath.Join(attDir, name), records.byCapability[id], base, "attestation")
 		if werr != nil {
 			return nil, werr
@@ -152,12 +165,13 @@ func WriteBundle(dest, repoKey string, report *Report, records *Records, runs []
 	// runner reports can contain screenshots and diagnostics, neither of which
 	// belongs in a broadly readable team artifact by default.
 	if len(runs) > 0 {
-		runsDir := filepath.Join(base, "runs", repoKey)
+		runsDir := filepath.Join(runDir, "runs")
 		if err := os.MkdirAll(runsDir, 0o755); err != nil {
 			return nil, fmt.Errorf("create runs dir: %w", err)
 		}
 		for _, run := range runs {
-			f, werr := writeJSON(filepath.Join(runsDir, slugify(run.RunID)+".json"), run, base, "run-summary")
+			name := "run-" + encodedPathSegment(run.RunID) + ".json"
+			f, werr := writeJSON(filepath.Join(runsDir, name), run, base, "run-summary")
 			if werr != nil {
 				return nil, werr
 			}
@@ -202,6 +216,74 @@ func WriteBundle(dest, repoKey string, report *Report, records *Records, runs []
 	}
 	result.IndexPath = indexPath
 	return result, nil
+}
+
+func validateRepoKey(repoKey string) error {
+	if repoKey == "" {
+		return errors.New("must not be empty")
+	}
+	if strings.TrimSpace(repoKey) != repoKey {
+		return errors.New("must not have leading or trailing whitespace")
+	}
+	if repoKey == "." || repoKey == ".." || filepath.IsAbs(repoKey) {
+		return errors.New("must be a relative path segment")
+	}
+	if strings.ContainsAny(repoKey, `/\\<>:"|?*`) {
+		return errors.New("must not contain path separators or filesystem-reserved characters")
+	}
+	if strings.TrimRight(repoKey, " .") != repoKey {
+		return errors.New("must not end in a space or dot")
+	}
+	for _, r := range repoKey {
+		if unicode.IsControl(r) {
+			return errors.New("must not contain control characters")
+		}
+	}
+	return nil
+}
+
+// publishedReport removes machine-local paths without mutating the report used
+// by the caller for local rendering. Record paths within the corpus remain
+// useful as portable, corpus-relative keys.
+func publishedReport(report *Report) *Report {
+	projection := *report
+	projection.Root = "."
+	projection.InvalidRecords = make(map[string]string, len(report.InvalidRecords))
+
+	keys := make([]string, 0, len(report.InvalidRecords))
+	for path := range report.InvalidRecords {
+		keys = append(keys, path)
+	}
+	sort.Strings(keys)
+	for _, path := range keys {
+		key := publishedRecordPath(report.Root, path)
+		if _, exists := projection.InvalidRecords[key]; exists {
+			sum := sha256.Sum256([]byte(path))
+			key += "-" + hex.EncodeToString(sum[:6])
+		}
+		reason := report.InvalidRecords[path]
+		if report.Root != "" {
+			reason = strings.ReplaceAll(reason, report.Root, ".")
+		}
+		reason = strings.ReplaceAll(reason, path, key)
+		projection.InvalidRecords[key] = reason
+	}
+	return &projection
+}
+
+func publishedRecordPath(root, path string) string {
+	clean := filepath.Clean(path)
+	if root != "" {
+		if rel, err := filepath.Rel(filepath.Clean(root), clean); err == nil && rel != ".." &&
+			!strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return filepath.ToSlash(rel)
+		}
+	}
+	if !filepath.IsAbs(clean) && clean != ".." && !strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(clean)
+	}
+	sum := sha256.Sum256([]byte(clean))
+	return "external/" + hex.EncodeToString(sum[:6]) + "-" + filepath.Base(clean)
 }
 
 // writeJSON writes an object and returns its manifest entry.

--- a/internal/attest/publish_test.go
+++ b/internal/attest/publish_test.go
@@ -46,6 +46,30 @@ func readManifest(t *testing.T, dest string) Manifest {
 	return m
 }
 
+func readManifestAt(t *testing.T, path string) Manifest {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	return m
+}
+
+func manifestFileOfKind(t *testing.T, manifest Manifest, kind string) ManifestFile {
+	t.Helper()
+	for _, file := range manifest.Files {
+		if file.Kind == kind {
+			return file
+		}
+	}
+	t.Fatalf("manifest has no %q file: %#v", kind, manifest.Files)
+	return ManifestFile{}
+}
+
 // Object-store keys are LITERAL — there is no path traversal — so a manifest
 // path containing `..` is not resolved to a parent prefix. It becomes part of
 // the key and the fetch 404s. Every path must be bundle-root relative.
@@ -146,6 +170,109 @@ func TestWriteBundle_IndexIsOneObjectPerPublish(t *testing.T) {
 	}
 }
 
+func TestWriteBundle_SameInstantCreatesIndependentImmutableSnapshots(t *testing.T) {
+	report, recs := publishFixture(t)
+	dest := t.TempDir()
+	when := time.Date(2026, 8, 2, 10, 0, 0, 123, time.UTC)
+	runs := []RunResult{{RunID: "run/red", Source: "orchestrator", Status: "complete"}}
+
+	first, err := WriteBundle(dest, "acme", report, recs, runs, when)
+	if err != nil {
+		t.Fatalf("first WriteBundle: %v", err)
+	}
+	firstManifestRaw, err := os.ReadFile(first.ManifestPath)
+	if err != nil {
+		t.Fatalf("read first manifest: %v", err)
+	}
+	firstManifest := readManifestAt(t, first.ManifestPath)
+	firstAttestation := manifestFileOfKind(t, firstManifest, "attestation")
+	firstRun := manifestFileOfKind(t, firstManifest, "run-summary")
+	base := filepath.Join(dest, "attest", LayoutVersion)
+	firstAttestationRaw, err := os.ReadFile(filepath.Join(base, firstAttestation.Path))
+	if err != nil {
+		t.Fatalf("read first attestation: %v", err)
+	}
+	firstRunRaw, err := os.ReadFile(filepath.Join(base, firstRun.Path))
+	if err != nil {
+		t.Fatalf("read first run: %v", err)
+	}
+
+	recs.All()[0].Claim = "a later proof"
+	second, err := WriteBundle(dest, "acme", report, recs, runs, when)
+	if err != nil {
+		t.Fatalf("second WriteBundle: %v", err)
+	}
+	if first.ManifestPath == second.ManifestPath || first.IndexPath == second.IndexPath {
+		t.Fatal("publishes at the same instant collided")
+	}
+	secondManifest := readManifestAt(t, second.ManifestPath)
+	if firstAttestation.Path == manifestFileOfKind(t, secondManifest, "attestation").Path {
+		t.Fatal("attestation object path is shared across publishes")
+	}
+	if firstRun.Path == manifestFileOfKind(t, secondManifest, "run-summary").Path {
+		t.Fatal("run summary object path is shared across publishes")
+	}
+
+	gotManifestRaw, _ := os.ReadFile(first.ManifestPath)
+	gotAttestationRaw, _ := os.ReadFile(filepath.Join(base, firstAttestation.Path))
+	gotRunRaw, _ := os.ReadFile(filepath.Join(base, firstRun.Path))
+	if string(gotManifestRaw) != string(firstManifestRaw) || string(gotAttestationRaw) != string(firstAttestationRaw) ||
+		string(gotRunRaw) != string(firstRunRaw) {
+		t.Fatal("later publish changed an object named by the earlier manifest")
+	}
+}
+
+func TestWriteBundle_RejectsUnsafeRepoKeysBeforeWriting(t *testing.T) {
+	report, recs := publishFixture(t)
+	for _, key := range []string{"", ".", "..", "../../outside", `..\\outside`, "/absolute", `C:\\absolute`, "trailing."} {
+		t.Run(strings.ReplaceAll(key, "/", "_"), func(t *testing.T) {
+			dest := t.TempDir()
+			if _, err := WriteBundle(dest, key, report, recs, nil, time.Now()); err == nil {
+				t.Fatalf("WriteBundle accepted unsafe repo key %q", key)
+			}
+			if _, err := os.Stat(filepath.Join(dest, "attest")); !os.IsNotExist(err) {
+				t.Fatalf("unsafe repo key %q wrote output before validation: %v", key, err)
+			}
+		})
+	}
+}
+
+func TestWriteBundle_PublishedReportOmitsLocalPaths(t *testing.T) {
+	report, recs := publishFixture(t)
+	localRoot := t.TempDir()
+	report.Root = localRoot
+	badRecord := filepath.Join(localRoot, attestationsSubdir, "broken.v1.json")
+	report.InvalidRecords = map[string]string{badRecord: "parse " + badRecord + ": malformed"}
+	dest := t.TempDir()
+
+	result, err := WriteBundle(dest, "acme", report, recs, nil, time.Now())
+	if err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	manifest := readManifestAt(t, result.ManifestPath)
+	reportFile := manifestFileOfKind(t, manifest, "report")
+	raw, err := os.ReadFile(filepath.Join(result.Root, reportFile.Path))
+	if err != nil {
+		t.Fatalf("read published report: %v", err)
+	}
+	if strings.Contains(string(raw), localRoot) {
+		t.Fatalf("published report leaks local root %q:\n%s", localRoot, raw)
+	}
+	var bundle Bundle
+	if err := json.Unmarshal(raw, &bundle); err != nil {
+		t.Fatalf("parse published report: %v", err)
+	}
+	if bundle.Report.Root != "." {
+		t.Errorf("published report root = %q, want portable dot", bundle.Report.Root)
+	}
+	if _, ok := bundle.Report.InvalidRecords["attestations/broken.v1.json"]; !ok {
+		t.Errorf("published invalid record keys = %#v, want corpus-relative key", bundle.Report.InvalidRecords)
+	}
+	if report.Root != localRoot {
+		t.Errorf("WriteBundle mutated caller's report root to %q", report.Root)
+	}
+}
+
 func TestWriteBundle_ManifestCarriesTotals(t *testing.T) {
 	report, recs := publishFixture(t)
 	dest := t.TempDir()
@@ -167,14 +294,47 @@ func TestWriteBundle_ManifestCarriesTotals(t *testing.T) {
 func TestWriteBundle_PublishesOnlyNormalizedReferencedRunSummaries(t *testing.T) {
 	report, recs := publishFixture(t)
 	dest := t.TempDir()
-	runs := []RunResult{{RunID: "red-run", Source: "orchestrator", Status: "complete", FinalizeStatus: "failed"}}
+	rule := "Only members can enter"
+	runs := []RunResult{{
+		RunID: "red-run", Source: "orchestrator", Status: "finalized", FinalizeStatus: "failed",
+		ScenarioTotal: 1, ScenarioFailed: 1,
+		FailedScenarios: []FailedScenario{{
+			ScenarioInstanceID: "scen_red", Feature: "features/auth.feature", Rule: &rule,
+			Scenario: "Guest is denied", Outcome: "failed", SessionStatus: "completed",
+		}},
+	}}
 	if _, err := WriteBundle(dest, "acme", report, recs, runs, time.Now()); err != nil {
 		t.Fatalf("WriteBundle: %v", err)
 	}
 
+	manifest := readManifest(t, dest)
+	runFile := manifestFileOfKind(t, manifest, "run-summary")
 	base := filepath.Join(dest, "attest", LayoutVersion)
-	if _, err := os.Stat(filepath.Join(base, "runs", "acme", "red-run.json")); err != nil {
-		t.Fatalf("normalized run summary missing: %v", err)
+	if _, err := os.Stat(filepath.Join(base, runFile.Path)); err != nil {
+		t.Fatalf("normalized run summary missing at %q: %v", runFile.Path, err)
+	}
+	if !strings.Contains(runFile.Path, "/status/acme/") && !strings.HasPrefix(runFile.Path, "status/acme/") {
+		t.Errorf("run summary %q is not scoped to its immutable publish", runFile.Path)
+	}
+	if want := "/runs/run-" + encodedPathSegment("red-run") + ".json"; !strings.HasSuffix(runFile.Path, want) {
+		t.Errorf("run summary path = %q, want encoded suffix %q", runFile.Path, want)
+	}
+	raw, err := os.ReadFile(filepath.Join(base, runFile.Path))
+	if err != nil {
+		t.Fatalf("read normalized summary: %v", err)
+	}
+	var published RunResult
+	if err := json.Unmarshal(raw, &published); err != nil {
+		t.Fatalf("decode normalized summary: %v", err)
+	}
+	if len(published.FailedScenarios) != 1 || published.FailedScenarios[0].Rule == nil ||
+		*published.FailedScenarios[0].Rule != rule {
+		t.Fatalf("published failed BDD projection = %#v", published.FailedScenarios)
+	}
+	for _, forbidden := range []string{"artifactsDir", "steps", "envelope", "screenshot", "diagnostics"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Errorf("published normalized summary contains raw diagnostic field %q: %s", forbidden, raw)
+		}
 	}
 	if matches, err := filepath.Glob(filepath.Join(base, "**", "*.png")); err != nil || len(matches) != 0 {
 		t.Errorf("published screenshots = %v, err %v; summaries must not publish raw diagnostics", matches, err)

--- a/internal/attest/record.go
+++ b/internal/attest/record.go
@@ -2,13 +2,16 @@ package attest
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -78,8 +81,8 @@ type Attestation struct {
 	// RepoKey is opaque and project-configured. No SageOx identifiers.
 	RepoKey string `json:"repoKey"`
 	// Subject is the tree this proof is valid for.
-	Subject TreeRef `json:"subject"`
-	MintedAt string `json:"mintedAt"`
+	Subject  TreeRef `json:"subject"`
+	MintedAt string  `json:"mintedAt"`
 
 	Proof Proof `json:"proof"`
 
@@ -236,13 +239,25 @@ func ParseAttestation(raw []byte) (*Attestation, error) {
 
 // Validate enforces the invariants that make a record trustworthy.
 func (a *Attestation) Validate() error {
-	if a.CapabilityID == "" {
+	if a == nil {
+		return errors.New("attestation is nil")
+	}
+	if a.Version != AttestationVersion {
+		return fmt.Errorf("attestation version is %d, want %d", a.Version, AttestationVersion)
+	}
+	if strings.TrimSpace(a.AttestationID) == "" {
+		return errors.New("attestation has no attestationId")
+	}
+	if strings.TrimSpace(a.CapabilityID) == "" {
 		return errors.New("attestation has no capabilityId")
 	}
-	if a.Claim == "" {
+	if strings.TrimSpace(a.Claim) == "" {
 		return errors.New("attestation has no claim")
 	}
-	if a.Subject.Value == "" {
+	if err := validateRepoKey(a.RepoKey); err != nil {
+		return fmt.Errorf("attestation repoKey: %w", err)
+	}
+	if strings.TrimSpace(a.Subject.Value) == "" {
 		return errors.New("attestation has no subject — a proof not bound to a tree proves nothing")
 	}
 	switch a.Subject.Scheme {
@@ -251,14 +266,44 @@ func (a *Attestation) Validate() error {
 		return fmt.Errorf("attestation subject scheme %q is not one of %q, %q",
 			a.Subject.Scheme, SchemeGitCommit, SchemeLoreCID)
 	}
+	if a.MintedAt == "" {
+		return errors.New("attestation has no mintedAt")
+	}
+	if _, err := time.Parse(time.RFC3339, a.MintedAt); err != nil {
+		return fmt.Errorf("attestation mintedAt is not RFC3339: %w", err)
+	}
 	switch a.Proof.Verdict {
 	case ProofClean, ProofAmbiguous, ProofInconclusive:
 	default:
 		return fmt.Errorf("attestation verdict %q is not one of %q, %q, %q",
 			a.Proof.Verdict, ProofClean, ProofAmbiguous, ProofInconclusive)
 	}
+	if strings.TrimSpace(a.Proof.Break.Description) == "" {
+		return errors.New("attestation proof has no break description")
+	}
+	if strings.TrimSpace(a.Proof.RedRunID) == "" {
+		return errors.New("attestation proof has no redRunId")
+	}
+	if strings.TrimSpace(a.Proof.RedRunID) != a.Proof.RedRunID {
+		return errors.New("attestation proof redRunId has leading or trailing whitespace")
+	}
+	if strings.TrimSpace(a.Proof.GreenRunID) == "" {
+		return errors.New("attestation proof has no greenRunId")
+	}
+	if strings.TrimSpace(a.Proof.GreenRunID) != a.Proof.GreenRunID {
+		return errors.New("attestation proof greenRunId has leading or trailing whitespace")
+	}
+	if a.Proof.RedRunID == a.Proof.GreenRunID {
+		return errors.New("attestation proof redRunId and greenRunId must identify different runs")
+	}
 	if a.Proof.Verdict != ProofInconclusive && a.Proof.ObservedRed.Verbatim == "" {
 		return errors.New("attestation records a red verdict with no verbatim failure text")
+	}
+	if a.Proof.Verdict != ProofInconclusive && a.Proof.ObservedRed.StepIndex < 1 {
+		return errors.New("attestation records a red verdict with no 1-indexed failure step")
+	}
+	if a.Proof.Verdict != ProofInconclusive && strings.TrimSpace(a.Proof.ObservedRed.StepText) == "" {
+		return errors.New("attestation records a red verdict with no failure step text")
 	}
 	// THE rule. Enforced here so it cannot be honored inconsistently by callers.
 	if !a.Proof.ObservedRed.LandedOnClaimStep && a.Proof.Verdict == ProofClean {
@@ -276,7 +321,9 @@ func (a *Attestation) IsProof() bool {
 // Records is every attestation in a corpus, keyed by capability id.
 type Records struct {
 	byCapability map[string]*Attestation
-	// Count is how many records were loaded.
+	// Count is how many unique capability records were loaded. During the
+	// filename migration a legacy slug file and its canonical encoded file may
+	// coexist; the canonical record wins and the pair counts once.
 	Count int
 	// Invalid maps a file path to the reason it could not be read. Surfaced
 	// rather than swallowed: a record we cannot parse is a capability whose
@@ -292,6 +339,7 @@ type Records struct {
 // failure to answer.
 func LoadRecords(corpusRoot string) (*Records, error) {
 	recs := &Records{byCapability: map[string]*Attestation{}, Invalid: map[string]string{}}
+	canonical := map[string]bool{}
 	dir := filepath.Join(corpusRoot, attestationsSubdir)
 	if _, err := os.Stat(dir); err != nil {
 		if os.IsNotExist(err) {
@@ -300,7 +348,7 @@ func LoadRecords(corpusRoot string) (*Records, error) {
 		return nil, fmt.Errorf("read attestations: %w", err)
 	}
 
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error { //nolint:gosec // local corpus scan; parse/validation remains the trust boundary
 		if err != nil {
 			return err
 		}
@@ -317,13 +365,18 @@ func LoadRecords(corpusRoot string) (*Records, error) {
 			recs.Invalid[path] = parseErr.Error()
 			return nil
 		}
-		recs.byCapability[a.CapabilityID] = a
-		recs.Count++
+		_, isCanonical := capabilityIDFromRecordFilename(d.Name())
+		isCanonical = isCanonical && d.Name() == recordFilename(a.CapabilityID)
+		if _, exists := recs.byCapability[a.CapabilityID]; !exists || isCanonical || !canonical[a.CapabilityID] {
+			recs.byCapability[a.CapabilityID] = a
+			canonical[a.CapabilityID] = isCanonical
+		}
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
+	recs.Count = len(recs.byCapability)
 	return recs, nil
 }
 
@@ -336,14 +389,60 @@ func (r *Records) For(capabilityID string) (*Attestation, bool) {
 	return a, ok
 }
 
+// All returns every valid record ordered by capability id. Callers that need
+// to detect records whose capability left the current corpus must not have to
+// reach into the internal index or silently lose those orphaned records.
+func (r *Records) All() []*Attestation {
+	if r == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(r.byCapability))
+	for id := range r.byCapability {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	out := make([]*Attestation, 0, len(ids))
+	for _, id := range ids {
+		if a := r.byCapability[id]; a != nil {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
 // RecordPath is where a capability's record lives: one file per capability,
-// current record only.
+// current record only. The capability id is raw-URL-base64 encoded, making the
+// mapping reversible and collision-free while keeping it one safe path segment.
 //
 // The path carries NO attestation id. History is git's job — duplicating it in
 // the path defeats `git log --follow` and grows the tree without bound.
 func RecordPath(corpusRoot, capabilityID string) string {
-	return filepath.Join(corpusRoot, attestationsSubdir,
-		fmt.Sprintf("%s.v%d.json", slugify(capabilityID), AttestationVersion))
+	return filepath.Join(corpusRoot, attestationsSubdir, recordFilename(capabilityID))
+}
+
+const recordFilenamePrefix = "cap-"
+
+func recordFilename(capabilityID string) string {
+	encoded := encodedPathSegment(capabilityID)
+	return fmt.Sprintf("%s%s.v%d.json", recordFilenamePrefix, encoded, AttestationVersion)
+}
+
+func encodedPathSegment(value string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(value))
+}
+
+func capabilityIDFromRecordFilename(name string) (string, bool) {
+	suffix := fmt.Sprintf(".v%d.json", AttestationVersion)
+	if !strings.HasPrefix(name, recordFilenamePrefix) || !strings.HasSuffix(name, suffix) {
+		return "", false
+	}
+	encoded := strings.TrimSuffix(strings.TrimPrefix(name, recordFilenamePrefix), suffix)
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil || len(raw) == 0 {
+		return "", false
+	}
+	return string(raw), true
 }
 
 // WriteRecord validates then writes a record, creating parent directories.

--- a/internal/attest/record_test.go
+++ b/internal/attest/record_test.go
@@ -82,11 +82,11 @@ func TestParseAttestation_LandedOffClaimStepCannotBeClean(t *testing.T) {
 		t.Errorf("error = %v, want ErrAmbiguousMislabeled", err)
 	}
 
-	// The same record labelled honestly must parse.
+	// The same record labeled honestly must parse.
 	rec.Proof.Verdict = ProofAmbiguous
 	got, err := ParseAttestation(mustJSON(t, rec))
 	if err != nil {
-		t.Fatalf("an honestly-labelled ambiguous record must parse: %v", err)
+		t.Fatalf("an honestly-labeled ambiguous record must parse: %v", err)
 	}
 	if got.IsProof() {
 		t.Error("an ambiguous record must NOT count as a proof")
@@ -123,12 +123,26 @@ func TestValidate_RejectsIncompleteRecords(t *testing.T) {
 		name   string
 		mutate func(*Attestation)
 	}{
+		{"wrong version", func(a *Attestation) { a.Version = 0 }},
+		{"no attestation id", func(a *Attestation) { a.AttestationID = "" }},
 		{"no capability", func(a *Attestation) { a.CapabilityID = "" }},
 		{"no claim", func(a *Attestation) { a.Claim = "" }},
+		{"no repo key", func(a *Attestation) { a.RepoKey = "" }},
+		{"unsafe repo key", func(a *Attestation) { a.RepoKey = "../../outside" }},
 		{"no subject", func(a *Attestation) { a.Subject.Value = "" }},
 		{"unknown subject scheme", func(a *Attestation) { a.Subject.Scheme = "svn-rev" }},
+		{"no minted time", func(a *Attestation) { a.MintedAt = "" }},
+		{"malformed minted time", func(a *Attestation) { a.MintedAt = "yesterday" }},
 		{"unknown verdict", func(a *Attestation) { a.Proof.Verdict = "probably-fine" }},
+		{"no break description", func(a *Attestation) { a.Proof.Break.Description = "" }},
+		{"no red run", func(a *Attestation) { a.Proof.RedRunID = "" }},
+		{"red run with whitespace", func(a *Attestation) { a.Proof.RedRunID = " run_red" }},
+		{"no green run", func(a *Attestation) { a.Proof.GreenRunID = "" }},
+		{"green run with whitespace", func(a *Attestation) { a.Proof.GreenRunID = "run_green " }},
+		{"same red and green run", func(a *Attestation) { a.Proof.GreenRunID = a.Proof.RedRunID }},
 		{"red verdict with no verbatim failure", func(a *Attestation) { a.Proof.ObservedRed.Verbatim = "" }},
+		{"red verdict with no failure step", func(a *Attestation) { a.Proof.ObservedRed.StepIndex = 0 }},
+		{"red verdict with no failure step text", func(a *Attestation) { a.Proof.ObservedRed.StepText = "" }},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -138,6 +152,15 @@ func TestValidate_RejectsIncompleteRecords(t *testing.T) {
 				t.Fatalf("Validate accepted a record with: %s", tc.name)
 			}
 		})
+	}
+}
+
+func TestValidate_InconclusiveProofKeepsHonestUnknownRepresentable(t *testing.T) {
+	rec := validRecord()
+	rec.Proof.Verdict = ProofInconclusive
+	rec.Proof.ObservedRed = ObservedRed{}
+	if err := rec.Validate(); err != nil {
+		t.Fatalf("inconclusive proof with a run pair but no observed failure must remain valid: %v", err)
 	}
 }
 
@@ -182,6 +205,73 @@ func TestWriteAndLoadRecords(t *testing.T) {
 	}
 	if got.Claim != rec.Claim {
 		t.Errorf("Claim = %q", got.Claim)
+	}
+}
+
+func TestRecordPath_IsStableReversibleAndCollisionFree(t *testing.T) {
+	root := t.TempDir()
+	ids := []string{"foo/bar#baz", "foo-bar#baz"}
+	paths := make(map[string]string, len(ids))
+	for _, id := range ids {
+		path := RecordPath(root, id)
+		if path != RecordPath(root, id) {
+			t.Fatalf("RecordPath(%q) is not stable", id)
+		}
+		got, ok := capabilityIDFromRecordFilename(filepath.Base(path))
+		if !ok || got != id {
+			t.Fatalf("record filename %q decoded as %q, %v; want %q", filepath.Base(path), got, ok, id)
+		}
+		paths[id] = path
+	}
+	if paths[ids[0]] == paths[ids[1]] {
+		t.Fatalf("distinct capability ids collide at %q", paths[ids[0]])
+	}
+}
+
+func TestLoadRecords_ReadsLegacyFilenameAndPrefersCanonicalDuplicate(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, attestationsSubdir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	legacy := validRecord()
+	legacy.Claim = "legacy copy"
+	if err := os.WriteFile(filepath.Join(dir, slugify(legacy.CapabilityID)+".v1.json"), mustJSON(t, legacy), 0o600); err != nil {
+		t.Fatalf("write legacy record: %v", err)
+	}
+	canonical := validRecord()
+	canonical.Claim = "canonical copy"
+	if err := os.WriteFile(RecordPath(root, canonical.CapabilityID), mustJSON(t, canonical), 0o600); err != nil {
+		t.Fatalf("write canonical record: %v", err)
+	}
+
+	recs, err := LoadRecords(root)
+	if err != nil {
+		t.Fatalf("LoadRecords: %v", err)
+	}
+	if recs.Count != 1 {
+		t.Fatalf("Count = %d, want one unique capability", recs.Count)
+	}
+	got, ok := recs.For(canonical.CapabilityID)
+	if !ok || got.Claim != canonical.Claim {
+		t.Fatalf("loaded record = %#v, %v; want canonical copy", got, ok)
+	}
+}
+
+func TestRecordsAll_IsSortedAndIncludesOrphans(t *testing.T) {
+	a := validRecord()
+	a.CapabilityID = "z/orphan#last"
+	b := validRecord()
+	b.CapabilityID = "a/current#first"
+	recs := &Records{byCapability: map[string]*Attestation{a.CapabilityID: a, b.CapabilityID: b}, Count: 2}
+
+	got := recs.All()
+	if len(got) != 2 || got[0] != b || got[1] != a {
+		t.Fatalf("All() = %#v, want records sorted by capability id", got)
+	}
+	if got := (*Records)(nil).All(); got != nil {
+		t.Fatalf("nil Records.All() = %#v, want nil", got)
 	}
 }
 

--- a/internal/attest/results.go
+++ b/internal/attest/results.go
@@ -2,34 +2,51 @@ package attest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
+	"time"
 )
+
+// FailedScenario is the diagnostics-free identity of one failed BDD scenario.
+// The raw run report remains local because it can reference screenshots,
+// machine paths, response envelopes, and other high-volume diagnostics.
+type FailedScenario struct {
+	ScenarioInstanceID string  `json:"scenarioInstanceId"`
+	Feature            string  `json:"feature"`
+	Rule               *string `json:"rule"`
+	Scenario           string  `json:"scenario"`
+	Outcome            string  `json:"outcome"`
+	SessionStatus      string  `json:"sessionStatus"`
+}
 
 // RunResult is the deliberately small, publishable projection of a BDD run.
 // Full reports can contain diagnostics and screenshots; the Attest bundle only
-// needs enough context to connect a proof's red/green run ids to their outcome.
+// carries run lifecycle, aggregate counts, and failed BDD identities.
 type RunResult struct {
-	RunID          string `json:"runId"`
-	Source         string `json:"source"`
-	Status         string `json:"status"`
-	FinalizeStatus string `json:"finalizeStatus,omitempty"`
-	CreatedAt      string `json:"createdAt,omitempty"`
-	EndedAt        string `json:"endedAt,omitempty"`
-	ScenarioTotal  int    `json:"scenarioTotal,omitempty"`
-	ScenarioFailed int    `json:"scenarioFailed,omitempty"`
+	RunID           string           `json:"runId"`
+	Source          string           `json:"source"`
+	Status          string           `json:"status"`
+	FinalizeStatus  string           `json:"finalizeStatus,omitempty"`
+	CreatedAt       string           `json:"createdAt,omitempty"`
+	EndedAt         string           `json:"endedAt,omitempty"`
+	ScenarioTotal   int              `json:"scenarioTotal,omitempty"`
+	ScenarioFailed  int              `json:"scenarioFailed,omitempty"`
+	FailedScenarios []FailedScenario `json:"failedScenarios,omitempty"`
 }
 
 type runJSON struct {
 	SchemaVersion int `json:"schemaVersion"`
 	Run           struct {
-		RunID          string `json:"runId"`
-		Status         string `json:"status"`
-		FinalizeStatus string `json:"finalizeStatus"`
-		CreatedAt      string `json:"createdAt"`
-		EndedAt        string `json:"endedAt"`
+		RunID          string   `json:"runId"`
+		Status         string   `json:"status"`
+		FinalizeStatus string   `json:"finalizeStatus"`
+		CreatedAt      string   `json:"createdAt"`
+		EndedAt        string   `json:"endedAt"`
+		SessionIDs     []string `json:"sessionIds"`
 		Summary        struct {
 			Scenarios struct {
 				Total  int `json:"total"`
@@ -39,18 +56,68 @@ type runJSON struct {
 	} `json:"run"`
 }
 
-type legacyRunReport struct {
-	RunID    string `json:"runId"`
-	Status   string `json:"status"`
-	Scenario string `json:"scenario"`
-	Passed   *bool  `json:"passed"`
+type orchestratorResultsJSON struct {
+	SchemaVersion int `json:"schemaVersion"`
+	Run           struct {
+		RunID          string `json:"runId"`
+		Status         string `json:"status"`
+		FinalizeStatus string `json:"finalizeStatus"`
+	} `json:"run"`
+	Scenarios []orchestratorScenarioResult `json:"scenarios"`
 }
 
-// LoadRunResults reads finalized orchestrator run.json files and, for older
-// standalone runners, a run-report.json. The finalized run.json is canonical:
-// it carries the lifecycle outcome, while run-report is evidence for one
-// scenario and cannot safely stand in for a multi-scenario run.
+type orchestratorScenarioResult struct {
+	SessionID          string `json:"sessionId"`
+	Feature            string `json:"feature"`
+	ScenarioName       string `json:"scenarioName"`
+	ScenarioInstanceID string `json:"scenarioInstanceId"`
+	Status             string `json:"status"`
+	Outcome            string `json:"outcome"`
+	RelArtifactsDir    string `json:"relArtifactsDir"`
+}
+
+type scenarioRunReport struct {
+	Feature            string `json:"feature"`
+	Rule               string `json:"rule"`
+	Scenario           string `json:"scenario"`
+	SessionID          string `json:"sessionId"`
+	Status             string `json:"status"`
+	ScenarioInstanceID string `json:"scenarioInstanceId"`
+}
+
+type standaloneRunReport struct {
+	Version        int    `json:"version"`
+	RunID          string `json:"runId"`
+	CreatedAt      string `json:"createdAt"`
+	FinalizeStatus string `json:"finalizeStatus"`
+	Scenarios      []struct {
+		ScenarioInstanceID string  `json:"scenarioInstanceId"`
+		Feature            string  `json:"feature"`
+		Rule               *string `json:"rule"`
+		Report             struct {
+			Scenario      string `json:"scenario"`
+			Outcome       string `json:"outcome"`
+			SessionStatus string `json:"sessionStatus"`
+		} `json:"report"`
+	} `json:"scenarios"`
+	// Early standalone writers emitted only these fields. They remain readable,
+	// but cannot provide a BDD identity and therefore stay a shallow summary.
+	Status string `json:"status"`
+	Passed *bool  `json:"passed"`
+}
+
+// LoadRunResults reads finalized orchestrator run.json + report/results.json
+// artifacts and joins failed rows to their scenario run-report.json evidence.
+// A root run-report.json remains a read-only adapter for standalone runners.
 func LoadRunResults(repoRoot, runsRoot string) ([]RunResult, error) {
+	return loadRunResults(repoRoot, runsRoot, nil)
+}
+
+// loadRunResults applies the optional directory-name filter before opening or
+// parsing any artifact. Run directories are canonically named by run id; this
+// lets publication ignore an unrelated corrupt run instead of failing before
+// it reaches the proof links it actually needs.
+func loadRunResults(repoRoot, runsRoot string, needed map[string]struct{}) ([]RunResult, error) {
 	if runsRoot == "" {
 		runsRoot = filepath.Join(repoRoot, "tests", "bdd", "runs")
 	} else if !filepath.IsAbs(runsRoot) {
@@ -70,6 +137,11 @@ func LoadRunResults(repoRoot, runsRoot string) ([]RunResult, error) {
 		if !entry.IsDir() {
 			continue
 		}
+		if needed != nil {
+			if _, ok := needed[entry.Name()]; !ok {
+				continue
+			}
+		}
 		dir := filepath.Join(runsRoot, entry.Name())
 		result, ok, readErr := readRunResult(dir, entry.Name())
 		if readErr != nil {
@@ -84,67 +156,333 @@ func LoadRunResults(repoRoot, runsRoot string) ([]RunResult, error) {
 }
 
 func readRunResult(dir, fallbackID string) (RunResult, bool, error) {
-	raw, err := os.ReadFile(filepath.Join(dir, "run.json"))
+	runPath := filepath.Join(dir, "run.json")
+	raw, err := os.ReadFile(runPath)
 	if err == nil {
 		var parsed runJSON
 		if err := json.Unmarshal(raw, &parsed); err != nil {
-			return RunResult{}, false, fmt.Errorf("parse %s: %w", filepath.Join(dir, "run.json"), err)
+			return RunResult{}, false, fmt.Errorf("parse %s: %w", runPath, err)
 		}
-		if parsed.SchemaVersion != 1 || parsed.Run.RunID == "" {
-			return RunResult{}, false, fmt.Errorf("parse %s: unsupported or incomplete run.json", filepath.Join(dir, "run.json"))
+		if parsed.SchemaVersion != 1 || strings.TrimSpace(parsed.Run.RunID) == "" || parsed.Run.RunID != fallbackID {
+			return RunResult{}, false, fmt.Errorf("parse %s: unsupported or incomplete run.json", runPath)
 		}
-		return RunResult{
+		if parsed.Run.Status != "finalized" && parsed.Run.Status != "aborted" {
+			return RunResult{}, false, fmt.Errorf("parse %s: run is not terminal", runPath)
+		}
+		if !validFinalizeStatus(parsed.Run.FinalizeStatus) || !validRFC3339(parsed.Run.CreatedAt) ||
+			!validRFC3339(parsed.Run.EndedAt) {
+			return RunResult{}, false, fmt.Errorf("parse %s: terminal run is incomplete", runPath)
+		}
+		if (parsed.Run.Status == "aborted") != (parsed.Run.FinalizeStatus == "aborted") {
+			return RunResult{}, false, fmt.Errorf("parse %s: terminal status and disposition conflict", runPath)
+		}
+		result := RunResult{
 			RunID: parsed.Run.RunID, Source: "orchestrator", Status: parsed.Run.Status,
 			FinalizeStatus: parsed.Run.FinalizeStatus, CreatedAt: parsed.Run.CreatedAt, EndedAt: parsed.Run.EndedAt,
-			ScenarioTotal: parsed.Run.Summary.Scenarios.Total, ScenarioFailed: parsed.Run.Summary.Scenarios.Failed,
-		}, true, nil
+		}
+		if parsed.Run.Status == "aborted" {
+			return result, true, nil
+		}
+		if err := addOrchestratorScenarioProjection(dir, parsed, &result); err != nil {
+			return RunResult{}, false, err
+		}
+		return result, true, nil
 	}
 	if !os.IsNotExist(err) {
-		return RunResult{}, false, fmt.Errorf("read %s: %w", filepath.Join(dir, "run.json"), err)
+		return RunResult{}, false, fmt.Errorf("read %s: %w", runPath, err)
 	}
 
-	raw, err = os.ReadFile(filepath.Join(dir, "run-report.json"))
+	return readStandaloneRunReport(dir, fallbackID)
+}
+
+func addOrchestratorScenarioProjection(dir string, lifecycle runJSON, result *RunResult) error {
+	resultsPath := filepath.Join(dir, "report", "results.json")
+	raw, err := os.ReadFile(resultsPath)
+	if err != nil {
+		return fmt.Errorf("read %s: finalized run is incomplete: %w", resultsPath, err)
+	}
+	var parsed orchestratorResultsJSON
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return fmt.Errorf("parse %s: %w", resultsPath, err)
+	}
+	if parsed.SchemaVersion != 1 || parsed.Run.RunID != lifecycle.Run.RunID || parsed.Run.Status != "finalized" ||
+		parsed.Run.FinalizeStatus != lifecycle.Run.FinalizeStatus {
+		return fmt.Errorf("parse %s: results do not match finalized run.json", resultsPath)
+	}
+	if len(parsed.Scenarios) != len(lifecycle.Run.SessionIDs) ||
+		(lifecycle.Run.Summary.Scenarios.Total != 0 && len(parsed.Scenarios) != lifecycle.Run.Summary.Scenarios.Total) {
+		return fmt.Errorf("parse %s: scenario rows do not match run.json", resultsPath)
+	}
+	expectedSessions := make(map[string]struct{}, len(lifecycle.Run.SessionIDs))
+	for _, sessionID := range lifecycle.Run.SessionIDs {
+		if sessionID == "" {
+			return fmt.Errorf("parse %s: run.json contains an empty session id", resultsPath)
+		}
+		expectedSessions[sessionID] = struct{}{}
+	}
+
+	type scenarioGroup struct {
+		id   string
+		rows []orchestratorScenarioResult
+	}
+	groups := make([]scenarioGroup, 0, len(parsed.Scenarios))
+	groupIndex := make(map[string]int, len(parsed.Scenarios))
+	for _, scenario := range parsed.Scenarios {
+		if strings.TrimSpace(scenario.SessionID) == "" || !validScenarioStatus(scenario.Status) ||
+			!validScenarioOutcome(scenario.Outcome) {
+			return fmt.Errorf("parse %s: scenario row is incomplete", resultsPath)
+		}
+		if _, ok := expectedSessions[scenario.SessionID]; !ok {
+			return fmt.Errorf("parse %s: scenario sessionId is not declared by run.json", resultsPath)
+		}
+		delete(expectedSessions, scenario.SessionID)
+		if scenario.RelArtifactsDir != filepath.ToSlash(filepath.Join("scenarios", scenario.SessionID)) {
+			return fmt.Errorf("parse %s: scenario artifacts path does not match sessionId", resultsPath)
+		}
+		groupID := scenario.ScenarioInstanceID
+		if groupID == "" {
+			groupID = scenario.SessionID
+		}
+		idx, found := groupIndex[groupID]
+		if !found {
+			idx = len(groups)
+			groupIndex[groupID] = idx
+			groups = append(groups, scenarioGroup{id: groupID})
+		}
+		groups[idx].rows = append(groups[idx].rows, scenario)
+	}
+
+	failed := make([]FailedScenario, 0)
+	for _, group := range groups {
+		businessFailed := false
+		for _, row := range group.rows {
+			businessFailed = businessFailed || row.Outcome == "failed"
+		}
+		if !businessFailed {
+			continue
+		}
+		report, row, err := readGroupRunReport(dir, group.rows)
+		if err != nil {
+			return fmt.Errorf("read failed scenario %s: %w", group.id, err)
+		}
+		instanceID := group.id
+		if report.ScenarioInstanceID != "" {
+			instanceID = report.ScenarioInstanceID
+		}
+		feature := report.Feature
+		if feature == "" {
+			feature = row.Feature
+		}
+		scenarioName := report.Scenario
+		if scenarioName == "" {
+			scenarioName = row.ScenarioName
+		}
+		if strings.TrimSpace(feature) == "" || strings.TrimSpace(scenarioName) == "" {
+			return fmt.Errorf("scenario evidence is missing feature or scenario identity")
+		}
+		var rule *string
+		if report.Rule != "" {
+			value := report.Rule
+			rule = &value
+		}
+		// The monorepo orchestrator calls clean teardown "ended"; the portable
+		// @sageox/attest summary contract calls the same lifecycle "completed".
+		sessionStatus := "completed"
+		for _, candidate := range group.rows {
+			if candidate.Status == "failed" {
+				sessionStatus = "failed"
+				break
+			}
+		}
+		failed = append(failed, FailedScenario{
+			ScenarioInstanceID: instanceID, Feature: feature, Rule: rule,
+			Scenario: scenarioName, Outcome: "failed", SessionStatus: sessionStatus,
+		})
+	}
+	sortFailedScenarios(failed)
+	result.ScenarioTotal = len(groups)
+	result.ScenarioFailed = len(failed)
+	result.FailedScenarios = failed
+	return nil
+}
+
+func readGroupRunReport(runDir string, rows []orchestratorScenarioResult) (scenarioRunReport, orchestratorScenarioResult, error) {
+	for _, row := range rows {
+		if row.RelArtifactsDir == "" {
+			continue
+		}
+		reportPath, err := runRelativePath(runDir, row.RelArtifactsDir, "run-report.json")
+		if err != nil {
+			return scenarioRunReport{}, orchestratorScenarioResult{}, err
+		}
+		raw, err := os.ReadFile(reportPath)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return scenarioRunReport{}, orchestratorScenarioResult{}, fmt.Errorf("read %s: %w", reportPath, err)
+		}
+		var report scenarioRunReport
+		if err := json.Unmarshal(raw, &report); err != nil {
+			return scenarioRunReport{}, orchestratorScenarioResult{}, fmt.Errorf("parse %s: %w", reportPath, err)
+		}
+		if !validRunReportStatus(report.Status) {
+			return scenarioRunReport{}, orchestratorScenarioResult{}, fmt.Errorf("parse %s: invalid scenario status", reportPath)
+		}
+		if report.SessionID != "" && report.SessionID != row.SessionID {
+			return scenarioRunReport{}, orchestratorScenarioResult{}, fmt.Errorf("parse %s: sessionId does not match results.json", reportPath)
+		}
+		if report.ScenarioInstanceID != "" && row.ScenarioInstanceID != "" &&
+			report.ScenarioInstanceID != row.ScenarioInstanceID {
+			return scenarioRunReport{}, orchestratorScenarioResult{}, fmt.Errorf("parse %s: scenarioInstanceId does not match results.json", reportPath)
+		}
+		if report.Feature != "" && row.Feature != "" && report.Feature != row.Feature {
+			return scenarioRunReport{}, orchestratorScenarioResult{}, fmt.Errorf("parse %s: feature does not match results.json", reportPath)
+		}
+		if report.Scenario != "" && row.ScenarioName != "" && report.Scenario != row.ScenarioName {
+			return scenarioRunReport{}, orchestratorScenarioResult{}, fmt.Errorf("parse %s: scenario does not match results.json", reportPath)
+		}
+		return report, row, nil
+	}
+	return scenarioRunReport{}, orchestratorScenarioResult{}, errors.New("run-report.json is missing")
+}
+
+func runRelativePath(root string, segments ...string) (string, error) {
+	for _, segment := range segments {
+		// The orchestrator contract stores POSIX run-relative paths. Rejecting
+		// both native absolute paths and backslashes keeps this check portable.
+		if filepath.IsAbs(segment) || strings.Contains(segment, `\`) {
+			return "", errors.New("scenario artifacts path escapes the run directory")
+		}
+	}
+	parts := append([]string{root}, segments...)
+	joined := filepath.Clean(filepath.Join(parts...))
+	rel, err := filepath.Rel(root, joined)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", errors.New("scenario artifacts path escapes the run directory")
+	}
+	return joined, nil
+}
+
+func validScenarioStatus(status string) bool {
+	return status == "ended" || status == "failed"
+}
+
+func validScenarioOutcome(outcome string) bool {
+	return outcome == "passed" || outcome == "failed" || outcome == "skipped" || outcome == "unknown"
+}
+
+func validRunReportStatus(status string) bool {
+	return status == "pass" || status == "fail" || status == "blocked"
+}
+
+func validFinalizeStatus(status string) bool {
+	return status == "passed" || status == "failed" || status == "mixed" || status == "aborted"
+}
+
+func validRFC3339(value string) bool {
+	_, err := time.Parse(time.RFC3339, value)
+	return err == nil
+}
+
+func readStandaloneRunReport(dir, fallbackID string) (RunResult, bool, error) {
+	reportPath := filepath.Join(dir, "run-report.json")
+	raw, err := os.ReadFile(reportPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return RunResult{}, false, nil
 		}
-		return RunResult{}, false, fmt.Errorf("read %s: %w", filepath.Join(dir, "run-report.json"), err)
+		return RunResult{}, false, fmt.Errorf("read %s: %w", reportPath, err)
 	}
-	var legacy legacyRunReport
-	if err := json.Unmarshal(raw, &legacy); err != nil {
-		return RunResult{}, false, fmt.Errorf("parse %s: %w", filepath.Join(dir, "run-report.json"), err)
+	var report standaloneRunReport
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return RunResult{}, false, fmt.Errorf("parse %s: %w", reportPath, err)
 	}
-	if legacy.RunID == "" {
-		legacy.RunID = fallbackID
+	if report.Version == 1 {
+		if report.RunID == "" || !validFinalizeStatus(report.FinalizeStatus) || !validRFC3339(report.CreatedAt) {
+			return RunResult{}, false, fmt.Errorf("parse %s: incomplete standalone run report", reportPath)
+		}
+		failed := make([]FailedScenario, 0)
+		for _, scenario := range report.Scenarios {
+			if scenario.ScenarioInstanceID == "" || scenario.Feature == "" || scenario.Report.Scenario == "" ||
+				!validScenarioOutcome(scenario.Report.Outcome) || !validStandaloneSessionStatus(scenario.Report.SessionStatus) ||
+				(scenario.Rule != nil && *scenario.Rule == "") {
+				return RunResult{}, false, fmt.Errorf("parse %s: incomplete scenario", reportPath)
+			}
+			if scenario.Report.Outcome != "failed" {
+				continue
+			}
+			failed = append(failed, FailedScenario{
+				ScenarioInstanceID: scenario.ScenarioInstanceID, Feature: scenario.Feature, Rule: scenario.Rule,
+				Scenario: scenario.Report.Scenario, Outcome: scenario.Report.Outcome,
+				SessionStatus: scenario.Report.SessionStatus,
+			})
+		}
+		sortFailedScenarios(failed)
+		return RunResult{
+			RunID: report.RunID, Source: "legacy-run-report", Status: report.FinalizeStatus,
+			FinalizeStatus: report.FinalizeStatus, CreatedAt: report.CreatedAt,
+			ScenarioTotal: len(report.Scenarios), ScenarioFailed: len(failed), FailedScenarios: failed,
+		}, true, nil
 	}
-	status := legacy.Status
-	if status == "" && legacy.Passed != nil {
-		if *legacy.Passed {
+
+	status := report.Status
+	if status == "" && report.Passed != nil {
+		if *report.Passed {
 			status = "passed"
 		} else {
 			status = "failed"
 		}
 	}
-	return RunResult{RunID: legacy.RunID, Source: "legacy-run-report", Status: status}, true, nil
+	if status == "" {
+		return RunResult{}, false, fmt.Errorf("parse %s: unsupported standalone run report", reportPath)
+	}
+	runID := report.RunID
+	if runID == "" {
+		runID = fallbackID
+	}
+	return RunResult{RunID: runID, Source: "legacy-run-report", Status: status}, true, nil
+}
+
+func validStandaloneSessionStatus(status string) bool {
+	return status == "completed" || status == "failed" || status == "timeout"
+}
+
+func sortFailedScenarios(failed []FailedScenario) {
+	sort.Slice(failed, func(i, j int) bool {
+		leftRule, rightRule := "", ""
+		if failed[i].Rule != nil {
+			leftRule = *failed[i].Rule
+		}
+		if failed[j].Rule != nil {
+			rightRule = *failed[j].Rule
+		}
+		left := failed[i].Feature + "\x00" + leftRule + "\x00" + failed[i].Scenario + "\x00" + failed[i].ScenarioInstanceID
+		right := failed[j].Feature + "\x00" + rightRule + "\x00" + failed[j].Scenario + "\x00" + failed[j].ScenarioInstanceID
+		return left < right
+	})
 }
 
 // ReferencedRunResults filters the local run corpus to durable proof links.
 // A missing referenced run is intentionally omitted rather than synthesized:
 // the UI must say evidence is unavailable, not quietly invent a result.
 func ReferencedRunResults(repoRoot string, records *Records) ([]RunResult, error) {
-	all, err := LoadRunResults(repoRoot, "")
-	if err != nil {
-		return nil, err
-	}
 	needed := make(map[string]struct{})
-	for _, record := range records.byCapability {
+	for _, record := range records.All() {
 		for _, id := range []string{record.Proof.RedRunID, record.Proof.GreenRunID} {
 			if id != "" {
 				needed[id] = struct{}{}
 			}
 		}
 	}
-	filtered := make([]RunResult, 0, len(needed))
+	if len(needed) == 0 {
+		return nil, nil
+	}
+	all, err := loadRunResults(repoRoot, "", needed)
+	if err != nil {
+		return nil, err
+	}
+	filtered := all[:0]
 	for _, result := range all {
 		if _, ok := needed[result.RunID]; ok {
 			filtered = append(filtered, result)

--- a/internal/attest/results_test.go
+++ b/internal/attest/results_test.go
@@ -1,29 +1,68 @@
 package attest
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func writeRunArtifact(t *testing.T, root, runID, name, body string) {
 	t.Helper()
 	dir := filepath.Join(root, runID)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("create run dir: %v", err)
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, name)), 0o755); err != nil {
+		t.Fatalf("create run artifact dir: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
 		t.Fatalf("write run artifact: %v", err)
 	}
 }
 
-func TestLoadRunResults_PrefersFinalizedOrchestratorResult(t *testing.T) {
+func writeCanonicalLifecycle(t *testing.T, root, runID, finalizeStatus string, sessionIDs []string) {
+	t.Helper()
+	payload := map[string]any{
+		"schemaVersion": 1,
+		"run": map[string]any{
+			"runId": runID, "status": "finalized", "finalizeStatus": finalizeStatus,
+			"createdAt": "2026-08-13T00:00:00Z", "endedAt": "2026-08-13T00:01:00Z",
+			"sessionIds": sessionIDs,
+			"summary":    map[string]any{"scenarios": map[string]any{"total": len(sessionIDs), "cleanlyEnded": len(sessionIDs), "failed": 0}},
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeRunArtifact(t, root, runID, "run.json", string(raw))
+}
+
+func TestLoadRunResults_JoinsCanonicalLifecycleAndFailedBDDEvidence(t *testing.T) {
 	runsRoot := t.TempDir()
-	writeRunArtifact(t, runsRoot, "run-canonical", "run.json", `{
-  "schemaVersion": 1,
-  "run": {"runId":"run-canonical","status":"complete","finalizeStatus":"passed","createdAt":"2026-08-13T00:00:00Z","endedAt":"2026-08-13T00:01:00Z","summary":{"scenarios":{"total":2,"failed":0}}}
+	writeCanonicalLifecycle(t, runsRoot, "run-canonical", "failed", []string{"sid_pass", "sid_tina", "sid_marcus"})
+	writeRunArtifact(t, runsRoot, "run-canonical", "report/results.json", `{
+  "schemaVersion":1,
+  "run":{"runId":"run-canonical","status":"finalized","finalizeStatus":"failed"},
+  "scenarios":[
+    {"sessionId":"sid_pass","feature":"features/auth.feature","scenarioName":"Member signs in","scenarioInstanceId":"scen_pass","status":"ended","outcome":"passed","relArtifactsDir":"scenarios/sid_pass","artifactsDir":"/private/machine/path","steps":[]},
+    {"sessionId":"sid_tina","feature":"features/auth.feature","scenarioName":"Guest is denied","scenarioInstanceId":"scen_fail","status":"ended","outcome":"failed","relArtifactsDir":"scenarios/sid_tina","failureReason":"do not publish this diagnostic","steps":[{"path":"web/auth","status":500}]},
+    {"sessionId":"sid_marcus","feature":"features/auth.feature","scenarioName":"Guest is denied","scenarioInstanceId":"scen_fail","status":"ended","outcome":"failed","relArtifactsDir":"scenarios/sid_marcus","steps":[]}
+  ]
 }`)
-	writeRunArtifact(t, runsRoot, "run-canonical", "run-report.json", `{"runId":"legacy-should-not-win","status":"failed"}`)
+	writeRunArtifact(t, runsRoot, "run-canonical", "scenarios/sid_tina/run-report.json", `{
+  "feature":"features/auth.feature",
+  "featureName":"Authentication",
+  "rule":"Only members can enter",
+  "scenario":"Guest is denied",
+  "sessionId":"sid_tina",
+  "scenarioInstanceId":"scen_fail",
+  "status":"fail",
+  "steps":[{"stepText":"Then access is denied","status":"fail","envelope":{"secret":"never publish"},"artifactsRelativeDir":"screenshots/001"}],
+  "artifactsDir":"/private/machine/path"
+}`)
+	// A root report is the standalone adapter and must never override the
+	// orchestrator's terminal commit marker plus results.json.
+	writeRunArtifact(t, runsRoot, "run-canonical", "run-report.json", `{"passed":true}`)
 
 	results, err := LoadRunResults(t.TempDir(), runsRoot)
 	if err != nil {
@@ -33,12 +72,58 @@ func TestLoadRunResults_PrefersFinalizedOrchestratorResult(t *testing.T) {
 		t.Fatalf("results = %d, want 1", len(results))
 	}
 	got := results[0]
-	if got.Source != "orchestrator" || got.FinalizeStatus != "passed" || got.ScenarioTotal != 2 {
-		t.Errorf("result = %#v, want finalized orchestrator projection", got)
+	if got.Source != "orchestrator" || got.FinalizeStatus != "failed" || got.ScenarioTotal != 2 || got.ScenarioFailed != 1 {
+		t.Fatalf("result = %#v, want canonical BDD projection", got)
+	}
+	if len(got.FailedScenarios) != 1 {
+		t.Fatalf("failed scenarios = %#v", got.FailedScenarios)
+	}
+	failure := got.FailedScenarios[0]
+	if failure.ScenarioInstanceID != "scen_fail" || failure.Feature != "features/auth.feature" ||
+		failure.Rule == nil || *failure.Rule != "Only members can enter" || failure.Scenario != "Guest is denied" ||
+		failure.Outcome != "failed" || failure.SessionStatus != "completed" {
+		t.Errorf("failed scenario = %#v", failure)
+	}
+
+	published, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"do not publish", "never publish", "screenshots", "/private/machine", "steps", "envelope"} {
+		if strings.Contains(string(published), forbidden) {
+			t.Errorf("normalized result leaked %q: %s", forbidden, published)
+		}
 	}
 }
 
-func TestLoadRunResults_AdaptsLegacyStandaloneReport(t *testing.T) {
+func TestLoadRunResults_AdaptsStandaloneRunReportV1(t *testing.T) {
+	runsRoot := t.TempDir()
+	writeRunArtifact(t, runsRoot, "run-standalone", "run-report.json", `{
+  "version":1,"runId":"run-standalone","createdAt":"2026-08-13T00:00:00Z","durationMs":25,"finalizeStatus":"mixed",
+  "scenarios":[
+    {"scenarioInstanceId":"features/auth.feature::0","feature":"features/auth.feature","rule":"Members only","report":{"version":1,"scenario":"Guest is denied","outcome":"failed","sessionStatus":"completed","steps":[],"diagnostics":[{"message":"raw diagnostic must not publish"}]}},
+    {"scenarioInstanceId":"features/auth.feature::1","feature":"features/auth.feature","rule":null,"report":{"version":1,"scenario":"Member signs in","outcome":"passed","sessionStatus":"completed","steps":[],"diagnostics":[]}}
+  ]
+}`)
+
+	results, err := LoadRunResults(t.TempDir(), runsRoot)
+	if err != nil {
+		t.Fatalf("LoadRunResults: %v", err)
+	}
+	if len(results) != 1 || results[0].RunID != "run-standalone" || results[0].Status != "mixed" ||
+		results[0].Source != "legacy-run-report" || results[0].ScenarioTotal != 2 || results[0].ScenarioFailed != 1 {
+		t.Fatalf("results = %#v, want standalone projection", results)
+	}
+	if len(results[0].FailedScenarios) != 1 || results[0].FailedScenarios[0].Scenario != "Guest is denied" {
+		t.Fatalf("failed scenarios = %#v", results[0].FailedScenarios)
+	}
+	raw, _ := json.Marshal(results[0])
+	if strings.Contains(string(raw), "raw diagnostic") {
+		t.Fatalf("standalone normalized result leaked diagnostics: %s", raw)
+	}
+}
+
+func TestLoadRunResults_AdaptsEarlyStandaloneReportReadOnly(t *testing.T) {
 	runsRoot := t.TempDir()
 	writeRunArtifact(t, runsRoot, "run-legacy", "run-report.json", `{"passed":false}`)
 
@@ -51,11 +136,78 @@ func TestLoadRunResults_AdaptsLegacyStandaloneReport(t *testing.T) {
 	}
 }
 
-func TestLoadRunResults_RejectsIncompleteCanonicalArtifact(t *testing.T) {
-	runsRoot := t.TempDir()
-	writeRunArtifact(t, runsRoot, "run-incomplete", "run.json", `{"schemaVersion":1,"run":{"status":"complete"}}`)
+func TestLoadRunResults_RejectsIncompleteCanonicalArtifacts(t *testing.T) {
+	tests := map[string]func(*testing.T, string){
+		"running lifecycle": func(t *testing.T, root string) {
+			writeRunArtifact(t, root, "run-bad", "run.json", `{"schemaVersion":1,"run":{"runId":"run-bad","status":"running"}}`)
+		},
+		"missing results": func(t *testing.T, root string) {
+			writeCanonicalLifecycle(t, root, "run-bad", "failed", []string{"sid_one"})
+		},
+		"malformed results": func(t *testing.T, root string) {
+			writeCanonicalLifecycle(t, root, "run-bad", "failed", []string{"sid_one"})
+			writeRunArtifact(t, root, "run-bad", "report/results.json", `{not json`)
+		},
+		"mismatched results": func(t *testing.T, root string) {
+			writeCanonicalLifecycle(t, root, "run-bad", "failed", []string{})
+			writeRunArtifact(t, root, "run-bad", "report/results.json", `{"schemaVersion":1,"run":{"runId":"run-other","status":"finalized","finalizeStatus":"failed"},"scenarios":[]}`)
+		},
+		"failed scenario missing evidence": func(t *testing.T, root string) {
+			writeCanonicalLifecycle(t, root, "run-bad", "failed", []string{"sid_one"})
+			writeRunArtifact(t, root, "run-bad", "report/results.json", `{"schemaVersion":1,"run":{"runId":"run-bad","status":"finalized","finalizeStatus":"failed"},"scenarios":[{"sessionId":"sid_one","feature":"features/auth.feature","scenarioName":"Guest is denied","scenarioInstanceId":"scen_one","status":"ended","outcome":"failed","relArtifactsDir":"scenarios/sid_one"}]}`)
+		},
+		"failed scenario malformed evidence": func(t *testing.T, root string) {
+			writeCanonicalLifecycle(t, root, "run-bad", "failed", []string{"sid_one"})
+			writeRunArtifact(t, root, "run-bad", "report/results.json", `{"schemaVersion":1,"run":{"runId":"run-bad","status":"finalized","finalizeStatus":"failed"},"scenarios":[{"sessionId":"sid_one","feature":"features/auth.feature","scenarioName":"Guest is denied","scenarioInstanceId":"scen_one","status":"ended","outcome":"failed","relArtifactsDir":"scenarios/sid_one"}]}`)
+			writeRunArtifact(t, root, "run-bad", "scenarios/sid_one/run-report.json", `{not json`)
+		},
+		"failed scenario path traversal": func(t *testing.T, root string) {
+			writeCanonicalLifecycle(t, root, "run-bad", "failed", []string{"sid_one"})
+			writeRunArtifact(t, root, "run-bad", "report/results.json", `{"schemaVersion":1,"run":{"runId":"run-bad","status":"finalized","finalizeStatus":"failed"},"scenarios":[{"sessionId":"sid_one","feature":"features/auth.feature","scenarioName":"Guest is denied","scenarioInstanceId":"scen_one","status":"ended","outcome":"failed","relArtifactsDir":"../../outside"}]}`)
+		},
+	}
+	for name, setup := range tests {
+		t.Run(name, func(t *testing.T) {
+			runsRoot := t.TempDir()
+			setup(t, runsRoot)
+			if _, err := LoadRunResults(t.TempDir(), runsRoot); err == nil {
+				t.Fatal("LoadRunResults accepted incomplete canonical artifacts")
+			}
+		})
+	}
+}
 
-	if _, err := LoadRunResults(t.TempDir(), runsRoot); err == nil {
-		t.Fatal("LoadRunResults succeeded for incomplete run.json")
+func TestReferencedRunResults_FiltersBeforeParsingUnrelatedRuns(t *testing.T) {
+	repoRoot := t.TempDir()
+	runsRoot := filepath.Join(repoRoot, "tests", "bdd", "runs")
+	writeCanonicalLifecycle(t, runsRoot, "run_red", "failed", []string{"sid_red"})
+	writeRunArtifact(t, runsRoot, "run_red", "report/results.json", `{"schemaVersion":1,"run":{"runId":"run_red","status":"finalized","finalizeStatus":"failed"},"scenarios":[{"sessionId":"sid_red","feature":"features/auth.feature","scenarioName":"Guest is denied","scenarioInstanceId":"scen_red","status":"ended","outcome":"failed","relArtifactsDir":"scenarios/sid_red"}]}`)
+	writeRunArtifact(t, runsRoot, "run_red", "scenarios/sid_red/run-report.json", `{"feature":"features/auth.feature","rule":"Members only","scenario":"Guest is denied","sessionId":"sid_red","scenarioInstanceId":"scen_red","status":"fail","steps":[]}`)
+	writeRunArtifact(t, runsRoot, "run_green", "run-report.json", `{"runId":"run_green","passed":true}`)
+	writeRunArtifact(t, runsRoot, "unrelated-corrupt", "run.json", `{not json`)
+
+	rec := validRecord()
+	records := &Records{byCapability: map[string]*Attestation{rec.CapabilityID: rec}, Count: 1}
+	results, err := ReferencedRunResults(repoRoot, records)
+	if err != nil {
+		t.Fatalf("ReferencedRunResults parsed unrelated corrupt run: %v", err)
+	}
+	if len(results) != 2 || results[0].RunID != "run_green" || results[1].RunID != "run_red" {
+		t.Fatalf("results = %#v, want only the sorted referenced red/green runs", results)
+	}
+	if len(results[1].FailedScenarios) != 1 || results[1].FailedScenarios[0].Rule == nil {
+		t.Fatalf("red result did not retain failed BDD identity: %#v", results[1])
+	}
+}
+
+func TestReferencedRunResults_StillRejectsMalformedReferencedRun(t *testing.T) {
+	repoRoot := t.TempDir()
+	runsRoot := filepath.Join(repoRoot, "tests", "bdd", "runs")
+	writeRunArtifact(t, runsRoot, "run_red", "run.json", `{not json`)
+
+	rec := validRecord()
+	records := &Records{byCapability: map[string]*Attestation{rec.CapabilityID: rec}, Count: 1}
+	if _, err := ReferencedRunResults(repoRoot, records); err == nil {
+		t.Fatal("ReferencedRunResults accepted malformed referenced run")
 	}
 }

--- a/internal/attest/stamp_test.go
+++ b/internal/attest/stamp_test.go
@@ -157,7 +157,7 @@ func TestScanCorpus_ValidatedInProseIsNotAClaim(t *testing.T) {
 		"sharing/links.feature": `Feature: Links
 
   # Deliberately: nothing here is tagged @validated until it runs on Tilt.
-  Rule: Share links honour an expiry window
+  Rule: Share links honor an expiry window
     # This scenario is not yet @validated — see the note above.
     Scenario: It expires
       Given a link

--- a/internal/daemon/sync_settings_test.go
+++ b/internal/daemon/sync_settings_test.go
@@ -23,6 +23,7 @@ func TestSettingsFetcher_Fetch_CachesResult(t *testing.T) {
 		resp := flags.CLISettingsResponse{
 			Features: flags.CLIFeatures{
 				CodeDB: boolPtr(true),
+				Attest: boolPtr(true),
 			},
 		}
 		json.NewEncoder(w).Encode(resp)
@@ -45,6 +46,9 @@ func TestSettingsFetcher_Fetch_CachesResult(t *testing.T) {
 	}
 	if cached.Features.CodeDB == nil || !*cached.Features.CodeDB {
 		t.Error("expected CodeDB=true in cached settings")
+	}
+	if cached.Features.Attest == nil || !*cached.Features.Attest {
+		t.Error("expected Attest=true in cached settings")
 	}
 }
 

--- a/internal/flags/env.go
+++ b/internal/flags/env.go
@@ -18,6 +18,7 @@ func (EnvProvider) Patch(_ context.Context) (*Patch, Source, error) {
 	p := &Patch{
 		DistillEnabled: envBoolPtr("FEATURE_MEMORY"),
 		TUIEnabled:     envBoolPtr("FEATURE_TUI"),
+		AttestEnabled:  envBoolPtr("FEATURE_ATTEST"),
 		// FEATURE_AUTH and FEATURE_CLOUD are account-level; not mapped to Flags.
 		// FEATURE_POST_MVP gates multiple unrelated features; callers continue to
 		// use auth.IsPostMVPEnabled() directly until those features are broken out.
@@ -48,6 +49,7 @@ func allNil(p *Patch) bool {
 		p.DistillEnabled == nil &&
 		p.AutoDistill == nil &&
 		p.TUIEnabled == nil &&
+		p.AttestEnabled == nil &&
 		p.DisableFileDeleteTools == nil &&
 		p.DisableShellExecTools == nil &&
 		p.PrimeAppend == nil

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -25,13 +25,14 @@ import (
 // Flags is the fully resolved set of feature flags for the current process.
 // All fields have safe defaults via [Defaults].
 type Flags struct {
-	// Feature gates — default true for authenticated users.
-	// A server-side kill switch or env override can set these false.
+	// Feature gates. Mature capabilities default on; experimental capabilities
+	// default off until a server rollout or environment override enables them.
 	CodeDBEnabled  bool
 	WhisperEnabled bool
 	DistillEnabled bool
 	AutoDistill    bool
 	TUIEnabled     bool
+	AttestEnabled  bool
 
 	// Kill switches — default false (not activated).
 	// Any source setting these true disables the capability.
@@ -53,6 +54,7 @@ type Patch struct {
 	DistillEnabled *bool
 	AutoDistill    *bool
 	TUIEnabled     *bool
+	AttestEnabled  *bool
 
 	DisableFileDeleteTools *bool
 	DisableShellExecTools  *bool
@@ -89,7 +91,7 @@ type Provider interface {
 }
 
 // Defaults returns the baseline Flags used when no provider has an opinion.
-// Feature gates are on; kill switches are off; string fields are empty.
+// Experimental gates and kill switches are off; string fields are empty.
 func Defaults() Flags {
 	return Flags{
 		CodeDBEnabled:  true,
@@ -97,6 +99,7 @@ func Defaults() Flags {
 		DistillEnabled: true,
 		AutoDistill:    false, // off until remote settings explicitly enables it
 		TUIEnabled:     false, // off until remote settings explicitly enables it
+		AttestEnabled:  false, // experimental; hidden and unregistered until enabled
 	}
 }
 

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -32,6 +32,9 @@ func TestDefaults(t *testing.T) {
 	if d.TUIEnabled {
 		t.Error("TUIEnabled should default false")
 	}
+	if d.AttestEnabled {
+		t.Error("AttestEnabled should default false")
+	}
 	if d.DisableFileDeleteTools {
 		t.Error("DisableFileDeleteTools should default false")
 	}
@@ -54,6 +57,7 @@ func TestResolveNoProviders(t *testing.T) {
 func TestEnvProviderUnset(t *testing.T) {
 	os.Unsetenv("FEATURE_MEMORY")
 	os.Unsetenv("FEATURE_TUI")
+	os.Unsetenv("FEATURE_ATTEST")
 
 	f := flags.Resolve(context.Background(), flags.EnvProvider{})
 	// unset env vars should not change defaults
@@ -62,6 +66,9 @@ func TestEnvProviderUnset(t *testing.T) {
 	}
 	if f.TUIEnabled {
 		t.Error("TUIEnabled should remain false when FEATURE_TUI unset")
+	}
+	if f.AttestEnabled {
+		t.Error("AttestEnabled should remain false when FEATURE_ATTEST unset")
 	}
 }
 
@@ -80,6 +87,15 @@ func TestEnvProviderEnablesFeature(t *testing.T) {
 	f := flags.Resolve(context.Background(), flags.EnvProvider{})
 	if !f.TUIEnabled {
 		t.Error("TUIEnabled should be true when FEATURE_TUI=true")
+	}
+}
+
+func TestEnvProviderEnablesAttest(t *testing.T) {
+	t.Setenv("FEATURE_ATTEST", "yes")
+
+	f := flags.Resolve(context.Background(), flags.EnvProvider{})
+	if !f.AttestEnabled {
+		t.Error("AttestEnabled should be true when FEATURE_ATTEST=yes")
 	}
 }
 
@@ -136,6 +152,7 @@ func TestDaemonProviderFreshCache(t *testing.T) {
 			CodeDB:  bp(false), // server disabled codedb
 			Whisper: bp(true),
 			Distill: bp(true),
+			Attest:  bp(true),
 		},
 		Killswitches: flags.CLIKillswitches{
 			DisableFileDeleteTools: true,
@@ -147,6 +164,9 @@ func TestDaemonProviderFreshCache(t *testing.T) {
 	f := flags.Resolve(context.Background(), p)
 	if f.CodeDBEnabled {
 		t.Error("CodeDBEnabled should be false per remote settings")
+	}
+	if !f.AttestEnabled {
+		t.Error("AttestEnabled should be true per remote settings")
 	}
 	if !f.DisableFileDeleteTools {
 		t.Error("DisableFileDeleteTools kill switch should be active")
@@ -185,6 +205,9 @@ func TestRemoteSettingsOmittedFieldsPreserveDefaults(t *testing.T) {
 	if patch.TUIEnabled != nil {
 		t.Error("TUIEnabled should be nil for omitted field")
 	}
+	if patch.AttestEnabled != nil {
+		t.Error("AttestEnabled should be nil for omitted field")
+	}
 
 	// resolve should preserve defaults for omitted fields
 	f := flags.Resolve(context.Background(), flags.DaemonProvider{
@@ -198,6 +221,22 @@ func TestRemoteSettingsOmittedFieldsPreserveDefaults(t *testing.T) {
 	}
 	if !f.DistillEnabled {
 		t.Error("DistillEnabled should remain default true (omitted)")
+	}
+	if f.AttestEnabled {
+		t.Error("AttestEnabled should remain default false (omitted)")
+	}
+}
+
+func TestEnvProviderOverridesRemoteAttestRollout(t *testing.T) {
+	t.Setenv("FEATURE_ATTEST", "false")
+	remote := flags.DaemonProvider{CachedSettings: &flags.CLISettingsResponse{
+		Features:  flags.CLIFeatures{Attest: bp(true)},
+		FetchedAt: time.Now(),
+	}}
+
+	f := flags.Resolve(context.Background(), remote, flags.EnvProvider{})
+	if f.AttestEnabled {
+		t.Error("FEATURE_ATTEST=false should override a server-side enable")
 	}
 }
 

--- a/internal/flags/remote.go
+++ b/internal/flags/remote.go
@@ -33,6 +33,7 @@ type CLIFeatures struct {
 	Distill     *bool `json:"distill,omitempty"`
 	AutoDistill *bool `json:"auto_distill,omitempty"`
 	TUI         *bool `json:"tui,omitempty"`
+	Attest      *bool `json:"attest,omitempty"`
 }
 
 // CLIKillswitches contains server-evaluated kill switch values.
@@ -63,6 +64,7 @@ func RemoteSettingsToPatch(r *CLISettingsResponse) *Patch {
 		DistillEnabled:         r.Features.Distill,
 		AutoDistill:            r.Features.AutoDistill,
 		TUIEnabled:             r.Features.TUI,
+		AttestEnabled:          r.Features.Attest,
 		DisableFileDeleteTools: boolPtr(r.Killswitches.DisableFileDeleteTools),
 		DisableShellExecTools:  boolPtr(r.Killswitches.DisableShellExecTools),
 		PrimeAppend:            strPtr(r.PrimeAppend),

--- a/internal/flags/resolve.go
+++ b/internal/flags/resolve.go
@@ -34,6 +34,9 @@ func applyPatch(f *Flags, p *Patch) {
 	if p.TUIEnabled != nil {
 		f.TUIEnabled = *p.TUIEnabled
 	}
+	if p.AttestEnabled != nil {
+		f.AttestEnabled = *p.AttestEnabled
+	}
 	if p.DisableFileDeleteTools != nil {
 		f.DisableFileDeleteTools = *p.DisableFileDeleteTools
 	}

--- a/internal/session/recording.go
+++ b/internal/session/recording.go
@@ -139,6 +139,12 @@ type RecordingState struct {
 	// into SessionMeta.LinkageStatus at stop. omitempty for round-trip.
 	LinkageStatus string `json:"linkage_status,omitempty"`
 
+	// LifecycleRegistrationState distinguishes a server-confirmed /c link from
+	// a locally minted identifier. Recording remains local-first, but callers
+	// must not circulate a link the server rejected or never observed.
+	LifecycleRegistrationState string `json:"lifecycle_registration_state,omitempty"` // confirmed | pending
+	LifecycleRegistrationError string `json:"lifecycle_registration_error,omitempty"`
+
 	// Hook observability: lets `ox session status` show whether hooks are firing
 	// and why they're skipping. Without these, a broken recording path (e.g.
 	// adapter binary missing, session file not discoverable) looks identical to


### PR DESCRIPTION
## Summary

- **What broke:** The experimental `ox attest` surface was always registered, so it appeared in help and accepted direct execution before rollout. Several evidence paths could also overstate confidence when records were stale, malformed, orphaned, or tied to incomplete run artifacts.
- **Feature gate:** Add `AttestEnabled` to the canonical layered flag system. Attest defaults off, supports the `FEATURE_ATTEST` environment override and cached `features.attest` server setting, and is registered before Cobra parses help or commands. When disabled, it is absent from help/generated docs and direct execution returns `unknown command`.
- **Evidence integrity:** Fingerprint live specification inputs, demote stale or unknown evidence, reject dirty-tree record creation, validate run IDs/proof steps/repository keys/surfaces, preserve exact verbatim evidence, and surface unreadable or orphaned records.
- **Run results and publication:** Validate finalized orchestrator artifacts, retain failed scenario identity (including duplicate names and rules), load only referenced runs, publish immutable snapshots with portable paths, and avoid leaking local filesystem paths.
- **CLI consistency:** Honor quiet output, apply domain/weakest filtering to JSON as well as human output, render conclusions from the stored proof verdict, and report record counts accurately.
- **Session link integrity:** Persist whether lifecycle registration is pending or server-confirmed, suppress unconfirmed `/c/` links, retry pending registrations through `ox agent prime` and `ox doctor`, include `agent_type` in start notifications, and treat a missing start endpoint as unconfirmed instead of successful.

```mermaid
flowchart LR
    A[Defaults + cached server settings + environment] --> B{Attest enabled?}
    B -- No --> C[Command not registered]
    B -- Yes --> D[Register before Cobra parsing]
    D --> E[Record, check, proof, publish]
    E --> F{Evidence valid and current?}
    F -- No --> G[Stale or unknown verdict]
    F -- Yes --> H[Attested verdict]
```

```mermaid
flowchart LR
    S[Local recording starts] --> R{Server confirms registration?}
    R -- Yes --> U[Expose conversation URL]
    R -- No --> P[Persist pending state]
    P --> X[Retry from prime or doctor]
    X --> R
```

## Test Plan

- `make format`
- `make lint` — 0 issues
- `make test` — 18,585 tests passed; 1,157 skipped
- `go test ./cmd/ox ./internal/api ./internal/session`
- `go test -race ./internal/flags ./internal/attest`
- Verified `ox --help` omits Attest and `ox attest` is unknown without `FEATURE_ATTEST`.
- Verified `FEATURE_ATTEST=true ox --help` exposes Attest.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added
- [x] CHANGELOG: N/A — Attest remains an unreleased, default-off experimental feature
- [x] Breaking change: N/A — the command is unavailable unless explicitly enabled
- [x] Security review: N/A — no security-review trigger paths or dependency files changed

</details>

Co-authored-by: SageOx <ox@sageox.ai>
SageOx-Session: https://sageox.ai/c/ses_01a001be-6917-7e0d-ae87-ba83f1b596be
