### PR TITLE
fix(codex): migrate deprecated hook feature

### DIFF
--- a/cmd/ox-adapter-codex/detect.go
+++ b/cmd/ox-adapter-codex/detect.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -54,7 +55,28 @@ func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.Diagnose
 				Severity: "warning",
 				Title:    "ox hooks not installed for Codex CLI",
 				Detail:   "Codex CLI hooks are not configured for this project.",
-				Fix:      "ox-adapter-codex install-hooks --repo-root " + p.RepoRoot + " --scope project",
+				Fix:      "ox integrate install --codex",
+				FixArgv:  []string{"ox", "integrate", "install", "--codex"},
+				FixSafe:  true,
+			})
+		}
+
+		legacyFeatureFlag, err := hasLegacyFeatureFlag(p.RepoRoot, p.Scope)
+		if err != nil {
+			issues = append(issues, adapterprotocol.DiagnoseIssue{
+				Slug:     "codex:legacy-hooks-feature-unreadable",
+				Severity: "warning",
+				Title:    "Codex legacy hook feature could not be checked",
+				Detail:   fmt.Sprintf("failed to read Codex config: %v", err),
+			})
+		} else if legacyFeatureFlag {
+			issues = append(issues, adapterprotocol.DiagnoseIssue{
+				Slug:     "codex:legacy-hooks-feature",
+				Severity: "warning",
+				Title:    "Codex deprecated hook feature is configured",
+				Detail:   "features.codex_hooks is deprecated; Codex hooks are stable and enabled by default.",
+				Fix:      "ox integrate install --codex",
+				FixArgv:  []string{"ox", "integrate", "install", "--codex"},
 				FixSafe:  true,
 			})
 		}

--- a/cmd/ox-adapter-codex/hooks.go
+++ b/cmd/ox-adapter-codex/hooks.go
@@ -70,9 +70,11 @@ func handleInstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.InstallH
 		return nil, err
 	}
 
-	// enable the codex_hooks feature flag
-	if err := ensureFeatureFlag(p.RepoRoot, p.Scope); err != nil {
-		return nil, fmt.Errorf("hooks.json written but failed to enable feature flag: %w", err)
+	// Codex hooks are stable and enabled by default. Clean up the legacy
+	// codex_hooks alias that older ox versions installed, but never create or
+	// change the current features.hooks setting.
+	if _, err := removeLegacyFeatureFlag(p.RepoRoot, p.Scope); err != nil {
+		return nil, fmt.Errorf("hooks.json written but failed to remove legacy feature flag: %w", err)
 	}
 
 	return &adapterprotocol.InstallHooksResponse{
@@ -148,11 +150,6 @@ func handleUninstallHooks(p adapterprotocol.HookParams) (*adapterprotocol.Uninst
 
 	if !changed {
 		return &adapterprotocol.UninstallHooksResponse{Uninstalled: true}, nil
-	}
-
-	// remove feature flag if no ox hooks remain
-	if len(hooksMap) == 0 {
-		_ = removeFeatureFlag(p.RepoRoot, p.Scope)
 	}
 
 	// if file is now empty, remove it
@@ -310,66 +307,36 @@ func isOxCommand(cmd string) bool {
 	return strings.Contains(cmd, "ox agent hook") || strings.Contains(cmd, "ox agent prime")
 }
 
-// --- config.toml feature flag ---
+// --- config.toml legacy feature migration ---
 
-func ensureFeatureFlag(repoRoot, scope string) error {
-	path := resolveConfigPath(repoRoot, scope)
-
-	var config map[string]any
-	if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
-		if err := toml.Unmarshal(data, &config); err != nil {
-			return fmt.Errorf("failed to parse %s: %w", path, err)
-		}
-	}
-	if config == nil {
-		config = make(map[string]any)
-	}
-
-	features, ok := config["features"].(map[string]any)
-	if !ok {
-		features = make(map[string]any)
-	}
-
-	if features["codex_hooks"] == true {
-		return nil
-	}
-
-	features["codex_hooks"] = true
-	config["features"] = features
-
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
-	}
-
-	data, err := toml.Marshal(config)
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-
-	perm := os.FileMode(0644)
-	if scope == "user" {
-		perm = 0600
-	}
-	return os.WriteFile(path, data, perm)
-}
-
-func removeFeatureFlag(repoRoot, scope string) error {
+// removeLegacyFeatureFlag removes only SageOx's deprecated
+// features.codex_hooks setting. It never creates config.toml and leaves all
+// other user configuration, including an explicit features.hooks choice,
+// untouched.
+func removeLegacyFeatureFlag(repoRoot, scope string) (bool, error) {
 	path := resolveConfigPath(repoRoot, scope)
 
 	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
 	if err != nil {
-		return nil
+		return false, err
+	}
+	if len(data) == 0 {
+		return false, nil
 	}
 
 	var config map[string]any
 	if err := toml.Unmarshal(data, &config); err != nil {
-		return nil
+		return false, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
-
 	features, ok := config["features"].(map[string]any)
 	if !ok {
-		return nil
+		return false, nil
+	}
+	if _, ok := features["codex_hooks"]; !ok {
+		return false, nil
 	}
 
 	delete(features, "codex_hooks")
@@ -380,17 +347,37 @@ func removeFeatureFlag(repoRoot, scope string) error {
 	}
 
 	if len(config) == 0 {
-		return os.Remove(path)
+		return true, os.Remove(path)
 	}
 
 	out, err := toml.Marshal(config)
 	if err != nil {
-		return err
+		return false, fmt.Errorf("failed to marshal %s: %w", path, err)
+	}
+	return true, os.WriteFile(path, out, 0o600)
+}
+
+func hasLegacyFeatureFlag(repoRoot, scope string) (bool, error) {
+	path := resolveConfigPath(repoRoot, scope)
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) || len(data) == 0 {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
 	}
 
-	perm := os.FileMode(0644)
-	if scope == "user" {
-		perm = 0600
+	var config map[string]any
+	if err := toml.Unmarshal(data, &config); err != nil {
+		return false, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
-	return os.WriteFile(path, out, perm)
+
+	features, ok := config["features"].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+
+	_, ok = features["codex_hooks"]
+	return ok, nil
 }

--- a/cmd/ox-adapter-codex/hooks.go
+++ b/cmd/ox-adapter-codex/hooks.go
@@ -392,9 +392,18 @@ func removeLegacyFeatureFlagAssignment(data []byte) ([]byte, bool) {
 	var out strings.Builder
 	out.Grow(len(data))
 	inFeaturesTable := false
+	multilineDelimiter := ""
 	changed := false
 
 	for _, line := range lines {
+		if multilineDelimiter != "" {
+			if countUnescapedMultilineDelimiters(line, multilineDelimiter)%2 == 1 {
+				multilineDelimiter = ""
+			}
+			out.WriteString(line)
+			continue
+		}
+
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "[") {
 			header := strings.TrimSpace(strings.SplitN(trimmed, "#", 2)[0])
@@ -405,7 +414,90 @@ func removeLegacyFeatureFlagAssignment(data []byte) ([]byte, bool) {
 			continue
 		}
 		out.WriteString(line)
+
+		if delimiter := multilineStringDelimiter(line); delimiter != "" &&
+			countUnescapedMultilineDelimiters(line, delimiter)%2 == 1 {
+			multilineDelimiter = delimiter
+		}
 	}
 
 	return []byte(out.String()), changed
+}
+
+// multilineStringDelimiter returns the delimiter for a TOML multiline value
+// that starts on line. A delimiter must immediately follow the assignment's
+// equals sign, which avoids interpreting comments and ordinary strings as
+// multiline TOML content.
+func multilineStringDelimiter(line string) string {
+	value, ok := tomlAssignmentValue(line)
+	if !ok {
+		return ""
+	}
+	switch {
+	case strings.HasPrefix(value, `"""`):
+		return `"""`
+	case strings.HasPrefix(value, `'''`):
+		return `'''`
+	default:
+		return ""
+	}
+}
+
+// tomlAssignmentValue returns the value portion of a single-line TOML
+// assignment. It skips quoted key content, so an equals sign in a quoted key
+// cannot prevent multiline-string detection.
+func tomlAssignmentValue(line string) (string, bool) {
+	var quote byte
+	escaped := false
+	for index := 0; index < len(line); index++ {
+		char := line[index]
+		if quote != 0 {
+			if quote == '"' && char == '\\' && !escaped {
+				escaped = true
+				continue
+			}
+			if char == quote && !escaped {
+				quote = 0
+			}
+			escaped = false
+			continue
+		}
+
+		switch char {
+		case '#':
+			return "", false
+		case '"', '\'':
+			quote = char
+		case '=':
+			return strings.TrimSpace(line[index+1:]), true
+		}
+	}
+	return "", false
+}
+
+// countUnescapedMultilineDelimiters counts a delimiter's occurrences in one
+// physical line. TOML basic strings can escape quote characters; literal
+// strings cannot. An odd count toggles the multiline-string state.
+func countUnescapedMultilineDelimiters(line, delimiter string) int {
+	count := 0
+	for index := 0; index <= len(line)-len(delimiter); {
+		next := strings.Index(line[index:], delimiter)
+		if next == -1 {
+			break
+		}
+		position := index + next
+		if delimiter != `"""` || !hasOddBackslashPrefix(line, position) {
+			count++
+		}
+		index = position + len(delimiter)
+	}
+	return count
+}
+
+func hasOddBackslashPrefix(s string, position int) bool {
+	backslashes := 0
+	for index := position - 1; index >= 0 && s[index] == '\\'; index-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
 }

--- a/cmd/ox-adapter-codex/hooks.go
+++ b/cmd/ox-adapter-codex/hooks.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
@@ -309,10 +310,11 @@ func isOxCommand(cmd string) bool {
 
 // --- config.toml legacy feature migration ---
 
-// removeLegacyFeatureFlag removes only SageOx's deprecated
-// features.codex_hooks setting. It never creates config.toml and leaves all
-// other user configuration, including an explicit features.hooks choice,
-// untouched.
+var legacyFeatureFlagAssignment = regexp.MustCompile(`^codex_hooks\s*=\s*(?:true|false)\s*(?:#.*)?$`)
+
+// removeLegacyFeatureFlag removes only the single-line legacy assignment that
+// older SageOx versions wrote under [features]. It never creates config.toml,
+// re-marshals the user's TOML, or changes an explicit features.hooks choice.
 func removeLegacyFeatureFlag(repoRoot, scope string) (bool, error) {
 	path := resolveConfigPath(repoRoot, scope)
 
@@ -327,32 +329,19 @@ func removeLegacyFeatureFlag(repoRoot, scope string) (bool, error) {
 		return false, nil
 	}
 
-	var config map[string]any
-	if err := toml.Unmarshal(data, &config); err != nil {
+	legacyFeatureFlag, err := hasLegacyFeatureFlagInConfig(data)
+	if err != nil {
 		return false, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
-	features, ok := config["features"].(map[string]any)
-	if !ok {
-		return false, nil
-	}
-	if _, ok := features["codex_hooks"]; !ok {
+	if !legacyFeatureFlag {
 		return false, nil
 	}
 
-	delete(features, "codex_hooks")
-	if len(features) == 0 {
-		delete(config, "features")
-	} else {
-		config["features"] = features
-	}
-
-	if len(config) == 0 {
-		return true, os.Remove(path)
-	}
-
-	out, err := toml.Marshal(config)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal %s: %w", path, err)
+	out, changed := removeLegacyFeatureFlagAssignment(data)
+	if !changed {
+		// Only the [features] assignment produced by older SageOx installers
+		// is safe to edit automatically. Do not rewrite other TOML encodings.
+		return false, nil
 	}
 	return true, os.WriteFile(path, out, 0o600)
 }
@@ -368,11 +357,23 @@ func hasLegacyFeatureFlag(repoRoot, scope string) (bool, error) {
 		return false, err
 	}
 
-	var config map[string]any
-	if err := toml.Unmarshal(data, &config); err != nil {
+	legacyFeatureFlag, err := hasLegacyFeatureFlagInConfig(data)
+	if err != nil {
 		return false, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
+	if !legacyFeatureFlag {
+		return false, nil
+	}
 
+	_, removable := removeLegacyFeatureFlagAssignment(data)
+	return removable, nil
+}
+
+func hasLegacyFeatureFlagInConfig(data []byte) (bool, error) {
+	var config map[string]any
+	if err := toml.Unmarshal(data, &config); err != nil {
+		return false, err
+	}
 	features, ok := config["features"].(map[string]any)
 	if !ok {
 		return false, nil
@@ -380,4 +381,31 @@ func hasLegacyFeatureFlag(repoRoot, scope string) (bool, error) {
 
 	_, ok = features["codex_hooks"]
 	return ok, nil
+}
+
+// removeLegacyFeatureFlagAssignment strips only the old SageOx-generated
+// codex_hooks boolean from a plain [features] table. It preserves every other
+// byte in config.toml, including comments, whitespace, quote choices, and
+// unrelated tables.
+func removeLegacyFeatureFlagAssignment(data []byte) ([]byte, bool) {
+	lines := strings.SplitAfter(string(data), "\n")
+	var out strings.Builder
+	out.Grow(len(data))
+	inFeaturesTable := false
+	changed := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			header := strings.TrimSpace(strings.SplitN(trimmed, "#", 2)[0])
+			inFeaturesTable = header == "[features]"
+		}
+		if inFeaturesTable && legacyFeatureFlagAssignment.MatchString(trimmed) {
+			changed = true
+			continue
+		}
+		out.WriteString(line)
+	}
+
+	return []byte(out.String()), changed
 }

--- a/cmd/ox-adapter-codex/hooks_test.go
+++ b/cmd/ox-adapter-codex/hooks_test.go
@@ -89,6 +89,34 @@ model = 'gpt-5-codex'
 	assert.Equal(t, want, got)
 }
 
+func TestHandleInstallHooks_PreservesMultilineTOMLContentDuringLegacyMigration(t *testing.T) {
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+	config := []byte(`[features]
+"notes=internal" = """
+codex_hooks = false
+codex_hooks = true
+"""
+codex_hooks = true
+hooks = false
+`)
+	want := []byte(`[features]
+"notes=internal" = """
+codex_hooks = false
+codex_hooks = true
+"""
+hooks = false
+`)
+	require.NoError(t, os.WriteFile(configPath, config, 0o600))
+
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	got, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestHandleInstallHooks_DoesNotCreateConfigWithoutLegacyFlag(t *testing.T) {
 	repoRoot := t.TempDir()
 	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)

--- a/cmd/ox-adapter-codex/hooks_test.go
+++ b/cmd/ox-adapter-codex/hooks_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleInstallHooks_MigratesLegacyFeatureFlag(t *testing.T) {
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+	require.NoError(t, os.WriteFile(configPath, []byte(`model = "gpt-5"
+
+[features]
+codex_hooks = true
+hooks = false
+other_feature = "preserve"
+
+[profiles.work]
+model = "gpt-5-codex"
+`), 0o600))
+
+	response, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	assert.True(t, response.Installed)
+	assert.Equal(t, codexHookEvents, response.Hooks)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	var config map[string]any
+	require.NoError(t, toml.Unmarshal(data, &config))
+	assert.Equal(t, "gpt-5", config["model"])
+	features, ok := config["features"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, features, "codex_hooks")
+	assert.Equal(t, false, features["hooks"])
+	assert.Equal(t, "preserve", features["other_feature"])
+	profiles, ok := config["profiles"].(map[string]any)
+	require.True(t, ok)
+	work, ok := profiles["work"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "gpt-5-codex", work["model"])
+
+	hooksPath := filepath.Join(repoRoot, codexProjectPath, codexHooksFileName)
+	hooksMap, _, err := readHooksFile(hooksPath)
+	require.NoError(t, err)
+	for _, event := range codexHookEvents {
+		assert.Truef(t, eventHasOxHook(hooksMap[event]), "%s is missing an ox hook", event)
+	}
+}
+
+func TestHandleInstallHooks_DoesNotCreateConfigWithoutLegacyFlag(t *testing.T) {
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	_, err = os.Stat(configPath)
+	assert.True(t, os.IsNotExist(err), "install should not create config.toml")
+}
+
+func TestHandleInstallHooks_DoesNotModifyConfigWithoutLegacyFlag(t *testing.T) {
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+	config := []byte("# User-owned configuration\nmodel = \"gpt-5\"\n\n[features]\nhooks = false\n")
+	require.NoError(t, os.WriteFile(configPath, config, 0o600))
+
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	got, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, config, got)
+}
+
+func TestHandleInstallHooks_IsIdempotentAfterLegacyMigration(t *testing.T) {
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+	require.NoError(t, os.WriteFile(configPath, []byte("[features]\ncodex_hooks = true\nhooks = false\n"), 0o600))
+
+	params := adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"}
+	_, err := handleInstallHooks(params)
+	require.NoError(t, err)
+	firstConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	firstHooks, err := os.ReadFile(filepath.Join(repoRoot, codexProjectPath, codexHooksFileName))
+	require.NoError(t, err)
+
+	_, err = handleInstallHooks(params)
+	require.NoError(t, err)
+	secondConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	secondHooks, err := os.ReadFile(filepath.Join(repoRoot, codexProjectPath, codexHooksFileName))
+	require.NoError(t, err)
+	assert.Equal(t, firstConfig, secondConfig)
+	assert.Equal(t, firstHooks, secondHooks)
+}
+
+func TestHandleUninstallHooks_LeavesCodexConfigUntouched(t *testing.T) {
+	repoRoot := t.TempDir()
+	params := adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"}
+	_, err := handleInstallHooks(params)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+	config := []byte("[features]\ncodex_hooks = true\nhooks = false\n")
+	require.NoError(t, os.WriteFile(configPath, config, 0o600))
+
+	_, err = handleUninstallHooks(params)
+	require.NoError(t, err)
+	got, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, config, got)
+}
+
+func TestHandleDiagnose_ReportsDeprecatedHookFeature(t *testing.T) {
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+	require.NoError(t, os.WriteFile(configPath, []byte("[features]\ncodex_hooks = true\n"), 0o600))
+
+	result, err := handleDiagnose(adapterprotocol.DiagnoseParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	for _, issue := range result.Issues {
+		if issue.Slug == "codex:legacy-hooks-feature" {
+			assert.Equal(t, []string{"ox", "integrate", "install", "--codex"}, issue.FixArgv)
+			assert.True(t, issue.FixSafe)
+			return
+		}
+	}
+	t.Fatal("deprecated Codex hook feature was not reported")
+}

--- a/cmd/ox-adapter-codex/hooks_test.go
+++ b/cmd/ox-adapter-codex/hooks_test.go
@@ -55,6 +55,40 @@ model = "gpt-5-codex"
 	}
 }
 
+func TestHandleInstallHooks_PreservesTOMLFormattingDuringLegacyMigration(t *testing.T) {
+	repoRoot := t.TempDir()
+	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
+	config := []byte(`# User-owned Codex configuration
+model = 'gpt-5' # Preserve quote style and comments.
+
+[features]
+# This comment describes the old SageOx setting.
+codex_hooks = true # Remove only this line.
+hooks = false # Explicit opt-out must remain.
+
+[profiles.work]
+model = 'gpt-5-codex'
+`)
+	want := []byte(`# User-owned Codex configuration
+model = 'gpt-5' # Preserve quote style and comments.
+
+[features]
+# This comment describes the old SageOx setting.
+hooks = false # Explicit opt-out must remain.
+
+[profiles.work]
+model = 'gpt-5-codex'
+`)
+	require.NoError(t, os.WriteFile(configPath, config, 0o600))
+
+	_, err := handleInstallHooks(adapterprotocol.HookParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	got, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestHandleInstallHooks_DoesNotCreateConfigWithoutLegacyFlag(t *testing.T) {
 	repoRoot := t.TempDir()
 	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)

--- a/cmd/ox/doctor_adapters.go
+++ b/cmd/ox/doctor_adapters.go
@@ -203,6 +203,9 @@ func adapterErrorToCheckResult(adapterName string, err error, _ string) checkRes
 // fixed. Adapter slugs are not in the DoctorCheckRegistry, so we handle them
 // separately from core slugs.
 func (opts doctorOptions) shouldFixAdapterSlug(slug string, fixSafe bool) bool {
+	if autoFixAdapterSlugs[slug] && fixSafe {
+		return true
+	}
 	// check if this specific slug was requested via --fix-slug
 	for _, s := range opts.fixSlugs {
 		if s == slug {
@@ -225,6 +228,13 @@ func (opts doctorOptions) shouldFixAdapterSlug(slug string, fixSafe bool) bool {
 var adapterFixArgvAllowlist = map[string]bool{
 	"git": true,
 	"ox":  true,
+}
+
+// autoFixAdapterSlugs lists adapter diagnostics that are safe enough to repair
+// during every doctor run. Adapter diagnostics do not participate in the core
+// DoctorCheckRegistry, so their auto-fix policy lives here.
+var autoFixAdapterSlugs = map[string]bool{
+	"codex:codex:legacy-hooks-feature": true,
 }
 
 // gitScopeEscalationFlags are argv tokens that escalate a fix beyond the current

--- a/cmd/ox/doctor_adapters_test.go
+++ b/cmd/ox/doctor_adapters_test.go
@@ -176,6 +176,20 @@ func TestShouldFixAdapterSlug(t *testing.T) {
 			fixSafe: true,
 			want:    false,
 		},
+		{
+			name:    "safe automatic Codex migration",
+			opts:    doctorOptions{},
+			slug:    "codex:codex:legacy-hooks-feature",
+			fixSafe: true,
+			want:    true,
+		},
+		{
+			name:    "unsafe Codex migration is not automatic",
+			opts:    doctorOptions{},
+			slug:    "codex:codex:legacy-hooks-feature",
+			fixSafe: false,
+			want:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/guides/agent-compatibility.md
+++ b/docs/guides/agent-compatibility.md
@@ -62,7 +62,6 @@ No extra setup needed — Claude Code is the reference implementation.
 ```bash
 ox init
 ox integrate install --codex
-codex features enable codex_hooks  # enable hook support in Codex
 ```
 
 ### Gemini CLI

--- a/internal/prime/agent_type.go
+++ b/internal/prime/agent_type.go
@@ -125,5 +125,5 @@ func CodexLifecycleNotification(agentType string) string {
 		return ""
 	}
 
-	return "Codex supports hooks via .codex/hooks.json (enable with `codex features enable codex_hooks`). Run `ox integrate install --codex` to install hooks. Session recording via `ox agent <id> session start` and `ox agent <id> session stop`."
+	return "Codex supports hooks via .codex/hooks.json. Run `ox integrate install --codex` to install hooks. Session recording via `ox agent <id> session start` and `ox agent <id> session stop`."
 }

--- a/internal/prime/agent_type_test.go
+++ b/internal/prime/agent_type_test.go
@@ -125,6 +125,7 @@ func TestCodexLifecycleNotification(t *testing.T) {
 				assert.Empty(t, got)
 			} else {
 				assert.Contains(t, got, "hooks via .codex/hooks.json")
+				assert.NotContains(t, got, "codex_hooks")
 			}
 		})
 	}


### PR DESCRIPTION
## What broke

- SageOx repeatedly wrote Codex’s deprecated `features.codex_hooks` alias, producing a warning despite working hooks.

## What this PR ships

- **Migration:** Removes only the legacy key during Codex hook installation; never creates or changes `features.hooks`.
- **Doctor:** Detects the deprecated setting and repairs it automatically through the Codex installer.
- **Boundaries:** Leaves `config.toml` untouched during uninstall and preserves unrelated user settings.
- **Guidance:** Removes the obsolete Codex feature-enable command from priming and quick-start documentation.

## Test Plan

- `go test -count=1 ./cmd/ox-adapter-codex -run TestHandle`
- `go test -count=1 ./cmd/ox -run TestShouldFixAdapterSlug`
- `go test -count=1 ./internal/prime -run TestCodexLifecycleNotification`
- `make lint`
- `make test`
- `make build`

- **Security review:** N/A — this diff does not touch the advisory security-review paths.

Co-authored-by: SageOx <ox@sageox.ai>
SageOx-Session: https://sageox.ai/c/ses_01a001c0-bd19-7799-8fd5-1cac98fa1748