### PR TITLE
Guide people who run bare ox agent

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -30,6 +30,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const agentHumanHandoff = `The "ox agent" command is used automatically by AI coding tools.
+You do not need to run it directly.
+
+For SageOx setup and health, run:     ox status
+To review AI coworker sessions, run:  ox session list
+To see current team activity, run:    ox glance
+
+For AI-coworker integration or debugging details, run: ox agent --help
+`
+
 // contextBytesProduced accumulates the number of context bytes written by the
 // current ox agent subcommand. Reset at the start of runWithAgentID and read
 // in a deferred heartbeat after the command completes. Best-effort tracking.
@@ -212,10 +222,11 @@ func init() {
 // (help, hook fast-path, validation errors) so even fast failures get
 // the right span name in the trace backend.
 func runAgentDispatcher(cmd *cobra.Command, args []string) error {
-	// no args = show help
+	// A person can easily discover this internal command from root help. Bare
+	// invocation is therefore a human-facing handoff, while explicit --help
+	// keeps the complete technical reference available for integrations.
 	if len(args) == 0 {
-		renameDispatcherSpan("help")
-		return cmd.Help()
+		return renderAgentHumanHandoff(cmd.OutOrStdout())
 	}
 
 	firstArg := args[0]
@@ -284,6 +295,14 @@ func runAgentDispatcher(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%s", msg)
 	}
 	return fmt.Errorf("unknown command or invalid agent_id: %s\nRun 'ox agent --help' for usage", firstArg)
+}
+
+// renderAgentHumanHandoff directs a person who invokes bare `ox agent` to
+// the human-facing commands most likely to help. It intentionally has no
+// session, agent-ID, or daemon interactions.
+func renderAgentHumanHandoff(out io.Writer) error {
+	_, err := fmt.Fprint(out, agentHumanHandoff)
+	return err
 }
 
 // validSessionSubcommands enumerates the session sub-subcommands the

--- a/cmd/ox/agent_test.go
+++ b/cmd/ox/agent_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -12,6 +13,46 @@ import (
 	"github.com/sageox/ox/internal/agentinstance"
 	"github.com/spf13/cobra"
 )
+
+func TestAgentDispatcherBareCommandShowsHumanHandoff(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "agent"}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := runAgentDispatcher(cmd, nil); err != nil {
+		t.Fatalf("bare agent command: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"used automatically by AI coding tools",
+		"ox status",
+		"ox session list",
+		"ox glance",
+		"ox agent --help",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("handoff missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Returns agent_id") || strings.Contains(got, "Initialize a session") {
+		t.Errorf("bare agent command leaked internal reference:\n%s", got)
+	}
+}
+
+func TestAgentTechnicalHelpContractRemainsAvailable(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(agentCmd.Long, "Initialize a session") || !strings.Contains(agentCmd.Long, "ox agent prime") {
+		t.Fatalf("agent technical help no longer documents prime:\n%s", agentCmd.Long)
+	}
+	primeCmd, _, err := agentCmd.Find([]string{"prime"})
+	if err != nil || primeCmd != agentPrimeCmd {
+		t.Fatalf("agent prime command unavailable: command=%v err=%v", primeCmd, err)
+	}
+}
 
 // TestReinjectSessionFlags verifies the dispatcher reinjects cobra-parsed
 // values for --title, --file, --session-id, and --adapter back into


### PR DESCRIPTION
## What this PR ships

- Replaces the internal AI-coworker command reference shown by bare `ox agent` with a concise handoff to setup, session, and team-activity commands.
- Leaves `ox agent --help` and all existing AI-coworker subcommand dispatch unchanged.
- Adds dispatcher-level regression coverage for both the human handoff and the technical help contract.

## Test Plan

- `make lint`
- `make test`
- Directly verified `go run ./cmd/ox agent` and `go run ./cmd/ox agent --help`.

## Security

- N/A: this change only changes local CLI help routing and does not touch security-sensitive paths.

Co-authored-by: SageOx <ox@sageox.ai>
SageOx-Session: https://sageox.ai/c/ses_01a002cc-ddbf-75d8-a3c8-6041bf66e39b