### PR TITLE
feat(whisper): add meeting metadata to murmur context

### DIFF
--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -1381,23 +1382,31 @@ func formatWhispers(w io.Writer, entries []whisperstore.WhisperEntry) bool {
 		fmt.Fprintln(w, `CRITICAL entries (importance="critical") may affect your current work. If files overlap with yours, pause and reassess your plan before continuing.</murmur-context>`)
 		for _, topic := range murmurTopics {
 			if hint := murmurTopicHint(topic); hint != "" {
-				fmt.Fprintf(w, "<murmur-topic topic=%q>%s</murmur-topic>\n", topic, hint)
+				fmt.Fprint(w, "<murmur-topic")
+				writeXMLAttribute(w, "topic", topic)
+				fmt.Fprintf(w, ">%s</murmur-topic>\n", hint)
 			}
 		}
 	}
 
 	for _, e := range entries {
-		fmt.Fprintf(w, "<entry importance=%q topic=%q source=%q", string(e.Importance), e.Topic, e.Source)
+		fmt.Fprint(w, "<entry")
+		writeXMLAttribute(w, "importance", string(e.Importance))
+		writeXMLAttribute(w, "topic", e.Topic)
+		writeXMLAttribute(w, "source", e.Source)
 		if e.Source == "murmur" && e.AgentID != "" {
-			fmt.Fprintf(w, " agent=%q", e.AgentID)
+			writeXMLAttribute(w, "agent", e.AgentID)
 		}
 		if e.PrincipalID != "" {
 			if firstName := identity.FirstNameFromSlug(e.PrincipalID); firstName != "" {
-				fmt.Fprintf(w, " from=%q", firstName)
+				writeXMLAttribute(w, "from", firstName)
 			}
 		}
 		if files, ok := e.Metadata["files"]; ok && files != "" {
-			fmt.Fprintf(w, " files=%q", files)
+			writeXMLAttribute(w, "files", files)
+		}
+		if metadata := whisperMetadataJSON(e.Metadata); metadata != "" {
+			writeXMLAttribute(w, "metadata", metadata)
 		}
 		fmt.Fprint(w, ">")
 		xml.EscapeText(w, []byte(e.Content))
@@ -1406,6 +1415,29 @@ func formatWhispers(w io.Writer, entries []whisperstore.WhisperEntry) bool {
 	fmt.Fprintln(w, "</system-reminder>")
 
 	return true
+}
+
+// writeXMLAttribute keeps Team Context metadata data-only in the XML hook
+// payload. Murmurs are user-writable git content, so fmt's quoted strings are
+// insufficient: quotes and angle brackets must be entity-escaped for XML.
+func writeXMLAttribute(w io.Writer, name, value string) {
+	fmt.Fprintf(w, " %s=\"", name)
+	_ = xml.EscapeText(w, []byte(value))
+	fmt.Fprint(w, "\"")
+}
+
+// whisperMetadataJSON preserves the message payload as an opaque JSON object.
+// A relay cannot reliably know every producer's metadata schema, so adding a
+// new murmur field reaches AI coworkers without a matching Ox release.
+func whisperMetadataJSON(metadata map[string]string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // emitDaemonIssueWarnings checks for daemon issues and emits warnings to stderr.

--- a/cmd/ox/agent.go
+++ b/cmd/ox/agent.go
@@ -969,7 +969,7 @@ func contextSourceLabel(source string) string {
 
 // murmur whisper budget: keep context lean so murmurs don't crowd out real work.
 const (
-	maxMurmurWhisperTokens    = 1024 // ~4096 bytes — hard cap on total murmur whisper content
+	maxMurmurWhisperTokens    = 1024 // ~4096 bytes — budget for total murmur content and metadata
 	maxMurmurWhispersPerAgent = 1    // keep only the most recent murmur per authoring agent
 	estimatedBytesPerToken    = 4    // rough byte-to-token ratio for English text
 )
@@ -1195,6 +1195,7 @@ func traceWhisperDelivery(projectRoot, agentID string, entries []whisperstore.Wh
 func capMurmurWhispers(entries []whisperstore.WhisperEntry) []whisperstore.WhisperEntry {
 	var rawNonMurmur []whisperstore.WhisperEntry
 	var allMurmurs []whisperstore.WhisperEntry
+	budgetBytes := maxMurmurWhisperTokens * estimatedBytesPerToken
 
 	murmurMaxAge := 24 * time.Hour
 	now := time.Now()
@@ -1231,14 +1232,13 @@ func capMurmurWhispers(entries []whisperstore.WhisperEntry) []whisperstore.Whisp
 			continue
 		}
 		agentCount[key]++
-		capped = append(capped, e)
+		capped = append(capped, capMurmurMetadata(e, budgetBytes))
 	}
 
 	// check if everything fits in budget
-	budgetBytes := maxMurmurWhisperTokens * estimatedBytesPerToken
 	totalBytes := 0
 	for _, e := range capped {
-		totalBytes += len(e.Content)
+		totalBytes += murmurWhisperSize(e)
 	}
 
 	if totalBytes <= budgetBytes {
@@ -1260,19 +1260,25 @@ func capMurmurWhispers(entries []whisperstore.WhisperEntry) []whisperstore.Whisp
 	usedBytes := 0
 	// always include critical entries first
 	for _, e := range critical {
+		size := murmurWhisperSize(e)
+		if usedBytes+size > budgetBytes && len(e.Metadata) > 0 {
+			e.Metadata = nil
+			size = len(e.Content)
+		}
 		kept = append(kept, e)
-		usedBytes += len(e.Content)
+		usedBytes += size
 	}
 	// fill remainder with random sample of non-critical
 	rand.Shuffle(len(nonCritical), func(i, j int) {
 		nonCritical[i], nonCritical[j] = nonCritical[j], nonCritical[i]
 	})
 	for _, e := range nonCritical {
-		if usedBytes+len(e.Content) > budgetBytes && len(kept) > 0 {
+		size := murmurWhisperSize(e)
+		if usedBytes+size > budgetBytes && len(kept) > 0 {
 			continue
 		}
 		kept = append(kept, e)
-		usedBytes += len(e.Content)
+		usedBytes += size
 	}
 
 	// re-sort kept by time (newest first) for coherent output
@@ -1281,6 +1287,22 @@ func capMurmurWhispers(entries []whisperstore.WhisperEntry) []whisperstore.Whisp
 	})
 
 	return append(nonMurmur, kept...)
+}
+
+// capMurmurMetadata drops metadata that would make a single murmur exceed the
+// delivery budget. Content still keeps its existing at-least-one guarantee.
+func capMurmurMetadata(entry whisperstore.WhisperEntry, budgetBytes int) whisperstore.WhisperEntry {
+	if murmurWhisperSize(entry) > budgetBytes {
+		entry.Metadata = nil
+	}
+	return entry
+}
+
+// murmurWhisperSize accounts for content plus the metadata payload newly
+// emitted with murmurs. XML framing and pre-existing entry fields are outside
+// the established content budget.
+func murmurWhisperSize(entry whisperstore.WhisperEntry) int {
+	return len(entry.Content) + len(whisperMetadataJSON(entry.Metadata))
 }
 
 // deduplicateBySourceTopic keeps only the most recent entry per (source, topic) key.

--- a/cmd/ox/whisper_budget_test.go
+++ b/cmd/ox/whisper_budget_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -119,6 +120,36 @@ func TestCapMurmurWhispers_AlwaysKeepsAtLeastOne(t *testing.T) {
 	}
 	if !found {
 		t.Error("at-least-one guarantee: single oversized entry must be kept")
+	}
+}
+
+func TestCapMurmurWhispers_MetadataRespectsDeliveryBudget(t *testing.T) {
+	now := time.Now()
+	oversizedMetadata := map[string]string{"detail": strings.Repeat("x", maxMurmurWhisperTokens*estimatedBytesPerToken)}
+	entries := []whisperstore.WhisperEntry{
+		{ID: "oversized", Source: "murmur", AgentID: "OxA", Content: "x", Metadata: oversizedMetadata, CreatedAt: now},
+		{ID: "fits", Source: "murmur", AgentID: "OxB", Content: "x", Metadata: map[string]string{"detail": strings.Repeat("x", 2500)}, CreatedAt: now.Add(-time.Minute)},
+		{ID: "also-fits", Source: "murmur", AgentID: "OxC", Content: "x", Metadata: map[string]string{"detail": strings.Repeat("x", 2500)}, CreatedAt: now.Add(-2 * time.Minute)},
+	}
+
+	result := capMurmurWhispers(entries)
+	totalBytes := 0
+	for _, entry := range result {
+		if entry.Source == "murmur" {
+			totalBytes += murmurWhisperSize(entry)
+		}
+		if entry.ID == "oversized" && len(entry.Metadata) != 0 {
+			t.Errorf("oversized metadata was kept: %#v", entry.Metadata)
+		}
+	}
+	if totalBytes > maxMurmurWhisperTokens*estimatedBytesPerToken {
+		t.Errorf("murmur payload size = %d, exceeds budget %d", totalBytes, maxMurmurWhisperTokens*estimatedBytesPerToken)
+	}
+
+	var formatted bytes.Buffer
+	formatWhispers(&formatted, result)
+	if strings.Contains(formatted.String(), oversizedMetadata["detail"]) {
+		t.Fatal("oversized metadata reached the formatted whisper")
 	}
 }
 

--- a/cmd/ox/whisper_format_test.go
+++ b/cmd/ox/whisper_format_test.go
@@ -102,12 +102,12 @@ func TestFormatWhispers_LiveMeetingMurmurIncludesRecordingLink(t *testing.T) {
 		Importance: whisperstore.ImportanceNormal,
 		Source:     "murmur",
 		Metadata: map[string]string{
-			"kind":         "live",
-			"recording_id": "rec_01956a64-72e0-7000-8000-abcdef012345",
+			"kind":          "live",
+			"recording_id":  "rec_01956a64-72e0-7000-8000-abcdef012345",
 			"recording_url": "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345",
-			"participants": "Alice <Ops>, Bob",
-			"topics":       "Friday migration, Cutover ownership",
-			"started_at":   "2026-08-14T17:30:00Z",
+			"participants":  "Alice <Ops>, Bob",
+			"topics":        "Friday migration, Cutover ownership",
+			"started_at":    "2026-08-14T17:30:00Z",
 		},
 	}}
 

--- a/cmd/ox/whisper_format_test.go
+++ b/cmd/ox/whisper_format_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -94,86 +95,68 @@ func TestFormatWhispers_XMLRoundTrip(t *testing.T) {
 	}
 }
 
-func TestFormatWhispers_LiveMeetingMurmurIncludesRecordingLink(t *testing.T) {
-	entries := []whisperstore.WhisperEntry{{
-		ID:         "1",
-		Topic:      "meeting",
-		Content:    "The team agreed to ship Friday.",
-		Importance: whisperstore.ImportanceNormal,
-		Source:     "murmur",
-		Metadata: map[string]string{
-			"kind":          "live",
-			"recording_id":  "rec_01956a64-72e0-7000-8000-abcdef012345",
-			"recording_url": "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345",
-			"participants":  "Alice <Ops>, Bob",
-			"topics":        "Friday migration, Cutover ownership",
-			"started_at":    "2026-08-14T17:30:00Z",
-		},
-	}}
-
-	var buf bytes.Buffer
-	formatWhispers(&buf, entries)
-
-	var parsed xmlSystemReminder
-	if err := xml.Unmarshal(buf.Bytes(), &parsed); err != nil {
-		t.Fatalf("XML round-trip failed: %v\nraw:\n%s", err, buf.String())
-	}
-	var metadata map[string]string
-	if err := json.Unmarshal([]byte(parsed.Entries[0].Metadata), &metadata); err != nil {
-		t.Fatalf("metadata = %q, want JSON object: %v", parsed.Entries[0].Metadata, err)
-	}
-	if got, want := metadata["recording_url"], "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345"; got != want {
-		t.Errorf("recording_url = %q, want %q", got, want)
-	}
-	if got, want := metadata["participants"], "Alice <Ops>, Bob"; got != want {
-		t.Errorf("participants = %q, want %q", got, want)
-	}
-	if got, want := metadata["topics"], "Friday migration, Cutover ownership"; got != want {
-		t.Errorf("topics = %q, want %q", got, want)
-	}
-	if got, want := metadata["started_at"], "2026-08-14T17:30:00Z"; got != want {
-		t.Errorf("started_at = %q, want %q", got, want)
-	}
-	if got := entries[0].Metadata["recording_url"]; got != "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345" {
-		t.Errorf("formatter mutated input metadata: recording_url = %q", got)
-	}
-}
-
-func TestFormatWhispers_MetadataWithoutValidRecordingID(t *testing.T) {
-	entries := []whisperstore.WhisperEntry{
+func TestFormatWhispers_MeetingMetadataRoundTrips(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     map[string]string
+	}{
 		{
-			ID:         "1",
-			Topic:      "meeting",
-			Content:    "No recording yet.",
-			Importance: whisperstore.ImportanceNormal,
-			Source:     "murmur",
-			Metadata:   map[string]string{"participants": "Alice <Ops>"},
+			name: "live meeting",
+			metadata: map[string]string{
+				"kind":          "live",
+				"recording_id":  "rec_01956a64-72e0-7000-8000-abcdef012345",
+				"recording_url": "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345",
+				"participants":  "Alice <Ops>, Bob",
+				"topics":        "Friday migration, Cutover ownership",
+				"started_at":    "2026-08-14T17:30:00Z",
+			},
+			want: map[string]string{
+				"kind":          "live",
+				"recording_id":  "rec_01956a64-72e0-7000-8000-abcdef012345",
+				"recording_url": "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345",
+				"participants":  "Alice <Ops>, Bob",
+				"topics":        "Friday migration, Cutover ownership",
+				"started_at":    "2026-08-14T17:30:00Z",
+			},
 		},
-		{
-			ID:         "2",
-			Topic:      "meeting",
-			Content:    "Legacy recording ID.",
-			Importance: whisperstore.ImportanceNormal,
-			Source:     "murmur",
-			Metadata:   map[string]string{"recording_id": "legacy_123"},
-		},
+		{name: "missing recording ID", metadata: map[string]string{"participants": "Alice <Ops>"}, want: map[string]string{"participants": "Alice <Ops>"}},
+		{name: "legacy recording ID", metadata: map[string]string{"recording_id": "legacy_123"}, want: map[string]string{"recording_id": "legacy_123"}},
 	}
 
-	var buf bytes.Buffer
-	formatWhispers(&buf, entries)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := make(map[string]string, len(tt.metadata))
+			for key, value := range tt.metadata {
+				original[key] = value
+			}
+			entries := []whisperstore.WhisperEntry{{
+				ID:         "1",
+				Topic:      "meeting",
+				Content:    "The team agreed to ship Friday.",
+				Importance: whisperstore.ImportanceNormal,
+				Source:     "murmur",
+				Metadata:   tt.metadata,
+			}}
 
-	var parsed xmlSystemReminder
-	if err := xml.Unmarshal(buf.Bytes(), &parsed); err != nil {
-		t.Fatalf("XML round-trip failed: %v\nraw:\n%s", err, buf.String())
-	}
-	for _, entry := range parsed.Entries {
-		var metadata map[string]string
-		if err := json.Unmarshal([]byte(entry.Metadata), &metadata); err != nil {
-			t.Fatalf("metadata = %q, want JSON object: %v", entry.Metadata, err)
-		}
-		if got := metadata["recording_url"]; got != "" {
-			t.Errorf("recording_url = %q, want empty for metadata %+v", got, metadata)
-		}
+			var buf bytes.Buffer
+			formatWhispers(&buf, entries)
+
+			var parsed xmlSystemReminder
+			if err := xml.Unmarshal(buf.Bytes(), &parsed); err != nil {
+				t.Fatalf("XML round-trip failed: %v\nraw:\n%s", err, buf.String())
+			}
+			var got map[string]string
+			if err := json.Unmarshal([]byte(parsed.Entries[0].Metadata), &got); err != nil {
+				t.Fatalf("metadata = %q, want JSON object: %v", parsed.Entries[0].Metadata, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("metadata = %#v, want %#v", got, tt.want)
+			}
+			if !reflect.DeepEqual(entries[0].Metadata, original) {
+				t.Errorf("formatter mutated input metadata: got %#v, want %#v", entries[0].Metadata, original)
+			}
+		})
 	}
 }
 

--- a/cmd/ox/whisper_format_test.go
+++ b/cmd/ox/whisper_format_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"strings"
 	"testing"
@@ -18,6 +19,7 @@ type xmlEntry struct {
 	Source     string `xml:"source,attr"`
 	Agent      string `xml:"agent,attr,omitempty"`
 	Files      string `xml:"files,attr,omitempty"`
+	Metadata   string `xml:"metadata,attr,omitempty"`
 	Content    string `xml:",chardata"`
 }
 
@@ -89,6 +91,89 @@ func TestFormatWhispers_XMLRoundTrip(t *testing.T) {
 	}
 	if parsed.Entries[2].Topic != "ci" || parsed.Entries[2].Importance != "ambient" {
 		t.Errorf("entry[2] mismatch: %+v", parsed.Entries[2])
+	}
+}
+
+func TestFormatWhispers_LiveMeetingMurmurIncludesRecordingLink(t *testing.T) {
+	entries := []whisperstore.WhisperEntry{{
+		ID:         "1",
+		Topic:      "meeting",
+		Content:    "The team agreed to ship Friday.",
+		Importance: whisperstore.ImportanceNormal,
+		Source:     "murmur",
+		Metadata: map[string]string{
+			"kind":         "live",
+			"recording_id": "rec_01956a64-72e0-7000-8000-abcdef012345",
+			"recording_url": "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345",
+			"participants": "Alice <Ops>, Bob",
+			"topics":       "Friday migration, Cutover ownership",
+			"started_at":   "2026-08-14T17:30:00Z",
+		},
+	}}
+
+	var buf bytes.Buffer
+	formatWhispers(&buf, entries)
+
+	var parsed xmlSystemReminder
+	if err := xml.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("XML round-trip failed: %v\nraw:\n%s", err, buf.String())
+	}
+	var metadata map[string]string
+	if err := json.Unmarshal([]byte(parsed.Entries[0].Metadata), &metadata); err != nil {
+		t.Fatalf("metadata = %q, want JSON object: %v", parsed.Entries[0].Metadata, err)
+	}
+	if got, want := metadata["recording_url"], "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345"; got != want {
+		t.Errorf("recording_url = %q, want %q", got, want)
+	}
+	if got, want := metadata["participants"], "Alice <Ops>, Bob"; got != want {
+		t.Errorf("participants = %q, want %q", got, want)
+	}
+	if got, want := metadata["topics"], "Friday migration, Cutover ownership"; got != want {
+		t.Errorf("topics = %q, want %q", got, want)
+	}
+	if got, want := metadata["started_at"], "2026-08-14T17:30:00Z"; got != want {
+		t.Errorf("started_at = %q, want %q", got, want)
+	}
+	if got := entries[0].Metadata["recording_url"]; got != "https://sageox.ai/c/rec_01956a64-72e0-7000-8000-abcdef012345" {
+		t.Errorf("formatter mutated input metadata: recording_url = %q", got)
+	}
+}
+
+func TestFormatWhispers_MetadataWithoutValidRecordingID(t *testing.T) {
+	entries := []whisperstore.WhisperEntry{
+		{
+			ID:         "1",
+			Topic:      "meeting",
+			Content:    "No recording yet.",
+			Importance: whisperstore.ImportanceNormal,
+			Source:     "murmur",
+			Metadata:   map[string]string{"participants": "Alice <Ops>"},
+		},
+		{
+			ID:         "2",
+			Topic:      "meeting",
+			Content:    "Legacy recording ID.",
+			Importance: whisperstore.ImportanceNormal,
+			Source:     "murmur",
+			Metadata:   map[string]string{"recording_id": "legacy_123"},
+		},
+	}
+
+	var buf bytes.Buffer
+	formatWhispers(&buf, entries)
+
+	var parsed xmlSystemReminder
+	if err := xml.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("XML round-trip failed: %v\nraw:\n%s", err, buf.String())
+	}
+	for _, entry := range parsed.Entries {
+		var metadata map[string]string
+		if err := json.Unmarshal([]byte(entry.Metadata), &metadata); err != nil {
+			t.Fatalf("metadata = %q, want JSON object: %v", entry.Metadata, err)
+		}
+		if got := metadata["recording_url"]; got != "" {
+			t.Errorf("recording_url = %q, want empty for metadata %+v", got, metadata)
+		}
 	}
 }
 


### PR DESCRIPTION
## What broke

Live-meeting murmurs discarded producer metadata, so AI coworkers could not receive a durable recording link or the meeting context that accompanied it.

## What this PR ships

- Adds an XML-escaped JSON `metadata` attribute to whisper entries.
- Adds a project-scoped `recording_url` for valid `rec_` recording IDs without mutating stored metadata.
- Keeps the default endpoint for direct formatter tests and uses the project endpoint in production delivery paths.

```mermaid
flowchart LR
    M[Murmur metadata] --> F[Whisper formatter]
    F --> U[Project-scoped recording URL]
    U --> J[Metadata JSON]
    F --> J
    J --> C[AI coworker context]
```

## Test Plan

- `go test ./cmd/ox`
- `make lint`
- `make test`

SageOx-Session: https://sageox.ai/c/ses_01a002d4-04cd-778d-96db-e67d62c8d544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Whisper XML output now includes optional metadata in JSON format.
  * Recording links and meeting details are preserved when metadata is available.

* **Bug Fixes**
  * XML attribute values are safely escaped.
  * Invalid or legacy recording identifiers no longer generate recording URLs.
  * Invalid or empty metadata is omitted from output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->