### PR TITLE
feat(skills): safely sync native project skills across AI coworkers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ox",
       "source": "./claude-plugin",
       "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-      "version": "0.13.0"
+      "version": "0.14.0"
     }
   ]
 }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Team context, session recording, and AI coworker coordination for collaborative development",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "author": {
     "name": "SageOx",
     "email": "hi@sageox.ai"

--- a/cmd/ox-adapter-claude-code/main.go
+++ b/cmd/ox-adapter-claude-code/main.go
@@ -89,7 +89,12 @@ func handleInfo() (*adapterprotocol.InfoResponse, error) {
 			adapterprotocol.CapCapturePrior,
 		},
 		HookEnvValues: []string{"claude-code"},
-		ServeMode:     true,
+		SkillTargets: []adapterprotocol.SkillTarget{{
+			Key: "claude-project", Root: ".claude/skills",
+			Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+			LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+		}},
+		ServeMode: true,
 	}, nil
 }
 

--- a/cmd/ox-adapter-claude-code/main_test.go
+++ b/cmd/ox-adapter-claude-code/main_test.go
@@ -34,6 +34,9 @@ func TestHandleInfo_CapabilitiesPinned(t *testing.T) {
 		t.Fatalf("handleInfo() error: %v", err)
 	}
 	assertCapabilitySetsEqual(t, "claude-code", info.Capabilities, want)
+	if len(info.SkillTargets) != 1 || info.SkillTargets[0].Key != "claude-project" || info.SkillTargets[0].Root != ".claude/skills" {
+		t.Fatalf("claude skill targets = %#v, want claude-project target", info.SkillTargets)
+	}
 }
 
 // assertCapabilitySetsEqual compares two capability lists as sets, so the pin

--- a/cmd/ox-adapter-claude-code/skills.go
+++ b/cmd/ox-adapter-claude-code/skills.go
@@ -1,403 +1,63 @@
 package main
 
 import (
-	"bytes"
-	"fmt"
-	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/sageox/agentx"
-	"github.com/sageox/ox/extensions/claude"
+	"github.com/sageox/ox/extensions/skills"
 	"github.com/sageox/ox/internal/adapterstamp"
+	"github.com/sageox/ox/internal/skillmanager"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
-// Claude skills are installed as a DIRECTORY per skill:
-//
-//	.claude/skills/<name>/SKILL.md
-//
-// Unlike commands (one .md, stamp on line 1), a skill's YAML frontmatter MUST be
-// the first bytes of SKILL.md so Claude can parse `name`/`description`. So the
-// drift stamp is placed INSIDE the file but AFTER the closing `---` of the
-// frontmatter — never on line 1. The stamp hash covers only the body that
-// follows it (the same contract extractStampAnywhere assumes for rules), so a
-// hand-edited body changes the body hash without touching the stamp, and drift
-// detection reads the stamp via adapterstamp.ExtractStampAnywhere (shared with
-// rules.go).
-//
-// On-disk layout written by Install:
-//
-//	---
-//	name: ox-plan
-//	description: ...
-//	---
-//	<!-- ox-hash: <12hex> ver: <version> -->
-//	<body...>
 const (
-	// skillsEmbedDir is the embed.FS subdir holding skills/<name>/SKILL.md.
-	skillsEmbedDir = "skills"
-	// skillFileName is the canonical per-skill markdown filename.
-	skillFileName = "SKILL.md"
-	// oxSkillStampPrefix matches the command stamp prefix so all ox-installed
-	// surfaces share one stamp vocabulary ("<!-- ox-hash: ...").
-	oxSkillStampPrefix = oxStampPrefix
+	skillFileName      = skills.SkillFileName
+	oxSkillStampPrefix = "ox"
 )
 
-// skillFile is one skill to install: its directory name plus the embedded
-// SKILL.md content (frontmatter + body, unstamped).
-type skillFile struct {
-	Name    string // skill/dir name, e.g. "ox-plan"
-	Content []byte // embedded SKILL.md bytes (frontmatter-first, no stamp)
-	Version string // ox version for the stamp + downgrade guard
-}
-
-// skillsDir returns the Claude skills directory for a project root.
+// Claude Code does not use .agents/skills as a supported discovery location.
+// The source remains portable Agent Skills; this is only its managed target.
 func skillsDir(projectRoot string) string {
 	return filepath.Join(projectRoot, ".claude", "skills")
 }
 
-// oxSkillFiles reads the embedded skills tree into skillFile records.
-// Each immediate subdirectory of skills/ that contains a SKILL.md becomes one
-// skill; the dir name is the skill name.
-func oxSkillFiles(version string) ([]skillFile, error) {
-	entries, err := fs.ReadDir(claude.SkillFS, skillsEmbedDir)
-	if err != nil {
-		return nil, fmt.Errorf("read embedded skills dir: %w", err)
-	}
-
-	var skills []skillFile
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		embedPath := skillsEmbedDir + "/" + name + "/" + skillFileName
-		content, err := fs.ReadFile(claude.SkillFS, embedPath)
-		if err != nil {
-			// a subdir without a SKILL.md is not a skill — skip quietly.
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("read embedded skill %s: %w", name, err)
-		}
-		skills = append(skills, skillFile{
-			Name:    name,
-			Content: content,
-			Version: version,
-		})
-	}
-	return skills, nil
-}
-
-// stampedSkillContent inserts the drift stamp immediately AFTER the closing
-// `---` of the YAML frontmatter (never on line 1). The stamp's hash covers only
-// the body that follows the frontmatter, matching extractStampAnywhere. If the
-// content has no frontmatter (defensive — all shipped skills have it), the stamp
-// is prepended at the top and the hash covers the whole content.
-func stampedSkillContent(content []byte, version string) []byte {
-	frontmatter, body, hasFM := splitFrontmatter(content)
-	hashTarget := body
-	if !hasFM {
-		hashTarget = content
-	}
-	stampLine := fmt.Sprintf("%s%s ver: %s -->\n",
-		agentx.StampComment(oxSkillStampPrefix), agentx.ContentHash(hashTarget), version)
-
-	if !hasFM {
-		return append([]byte(stampLine), content...)
-	}
-	var out []byte
-	out = append(out, frontmatter...)
-	out = append(out, []byte(stampLine)...)
-	out = append(out, body...)
-	return out
-}
-
-// splitFrontmatter separates a leading YAML frontmatter block (`---\n...\n---\n`)
-// from the body. Returns the frontmatter (including both fences and the trailing
-// newline), the body that follows, and whether a frontmatter block was present.
-// The content MUST start with `---` for a frontmatter block to be recognized.
-func splitFrontmatter(content []byte) (frontmatter, body []byte, ok bool) {
-	s := string(content)
-	if !strings.HasPrefix(s, "---\n") && s != "---" && !strings.HasPrefix(s, "---\r\n") {
-		return nil, content, false
-	}
-	// find the closing fence: a line that is exactly "---" after the opener.
-	// scan line-by-line starting after the first line.
-	firstNL := strings.IndexByte(s, '\n')
-	if firstNL < 0 {
-		return nil, content, false
-	}
-	idx := firstNL + 1
-	for idx < len(s) {
-		end := strings.IndexByte(s[idx:], '\n')
-		var line string
-		if end < 0 {
-			line = s[idx:]
-		} else {
-			line = s[idx : idx+end]
-		}
-		if strings.TrimRight(line, "\r") == "---" {
-			// closing fence found; frontmatter spans [0, end-of-this-line+newline).
-			if end < 0 {
-				return content, nil, true
-			}
-			fmEnd := idx + end + 1 // include the closing fence's newline
-			return []byte(s[:fmEnd]), []byte(s[fmEnd:]), true
-		}
-		if end < 0 {
-			break
-		}
-		idx += end + 1
-	}
-	// no closing fence — treat as no frontmatter (defensive).
-	return nil, content, false
-}
-
-// frontmatterDiffers reports whether the YAML frontmatter of the on-disk skill
-// differs from the embedded skill — including the case where one has a
-// frontmatter block and the other doesn't. The drift stamp's hash covers only
-// the body, so name/description edits in the frontmatter are otherwise invisible
-// to staleness detection. Callers MUST gate this on the file being ox-stamped so
-// it never forces a rewrite of a user-authored unstamped SKILL.md.
-func frontmatterDiffers(existing, embedded []byte) bool {
-	existingFM, _, existingHasFM := splitFrontmatter(existing)
-	embedFM, _, embedHasFM := splitFrontmatter(embedded)
-	return existingHasFM != embedHasFM || !bytes.Equal(existingFM, embedFM)
-}
-
 func handleInstallSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.InstallSkillsResponse, error) {
-	skills, err := oxSkillFiles(p.Version)
+	result, err := skillmanager.Install(p, skillsDir(p.RepoRoot))
 	if err != nil {
 		return nil, err
 	}
-
-	dir := skillsDir(p.RepoRoot)
-	var written []string
-	for _, sk := range skills {
-		skillDir := filepath.Join(dir, sk.Name)
-		dstPath := filepath.Join(skillDir, skillFileName)
-
-		var existing []byte
-		if data, err := os.ReadFile(dstPath); err == nil {
-			existing = data
-		}
-		if !shouldWriteSkill(existing, sk) {
-			continue
-		}
-
-		if err := os.MkdirAll(skillDir, 0o755); err != nil {
-			return nil, fmt.Errorf("create skill directory %s: %w", sk.Name, err)
-		}
-		stamped := stampedSkillContent(sk.Content, sk.Version)
-		if err := os.WriteFile(dstPath, stamped, 0o644); err != nil {
-			return nil, fmt.Errorf("write skill file %s: %w", sk.Name, err)
-		}
-		// report repo-relative (e.g. .claude/skills/ox-plan/SKILL.md) per the
-		// FilesWritten contract. Reporting it relative to the skills dir —
-		// as this did until GH #731 — made ox resolve it to <root>/ox-plan/
-		// SKILL.md, which does not exist, and one bad pathspec fails the
-		// whole `git add`, so nothing at all got staged.
-		written = append(written, dstPath)
+	// This is a Claude-only migration from old slash-command surfaces. The
+	// shared installer owns all Agent Skills lifecycle mechanics.
+	selected, err := skills.SelectedBundles(p.Version, p.Names, p.Bundles)
+	if err != nil {
+		return nil, err
 	}
-
-	// Command→skill migration cleanup: when a surface moves from a slash command
-	// to a skill (e.g. ox-plan, ox-session-review), an existing install keeps the
-	// stale .claude/commands/<id>.md alongside the new skill — a duplicate Layer-2
-	// surface, because the commands installer only writes the embedded set and
-	// never prunes ids it no longer ships. Prune any ox-stamped legacy command
-	// file whose id is now an embedded skill so the migration is self-cleaning.
-	cleanupLegacyCommandFilesForSkills(p.RepoRoot, skills)
-
-	return &adapterprotocol.InstallSkillsResponse{
-		Installed:    true,
-		FilesWritten: adapterprotocol.RepoRelativePaths(p.RepoRoot, dir, written),
-	}, nil
-}
-
-// cleanupLegacyCommandFilesForSkills removes legacy slash-command files that have
-// been superseded by an embedded skill of the same id. For each embedded skill id,
-// if <gitRoot>/.claude/commands/<id>.md exists AND carries the ox command stamp on
-// line 1 (so we only ever delete files ox itself installed — user-authored
-// unstamped files are preserved), the stale command file is removed.
-//
-// This is best-effort: any error is logged and ignored, and never fails the
-// install. It detects ox-stamped files with adapterstamp.ExtractStampAnywhere
-// using the same "ox" prefix the command installer stamps with — a legacy command
-// file carries "<!-- ox-hash: ... -->" on line 1, which ExtractStampAnywhere matches.
-func cleanupLegacyCommandFilesForSkills(repoRoot string, skills []skillFile) {
-	commandsDir := filepath.Join(repoRoot, ".claude", "commands")
-	for _, sk := range skills {
-		legacyPath := filepath.Join(commandsDir, sk.Name+".md")
-		data, err := os.ReadFile(legacyPath)
-		if err != nil {
-			continue // no legacy command file (the common case) — nothing to clean
-		}
-		// only remove files ox stamped; never delete user-authored command files.
-		if hash, _, _ := adapterstamp.ExtractStampAnywhere(data, oxSkillStampPrefix); hash == "" {
-			continue
-		}
-		if err := os.Remove(legacyPath); err != nil {
-			slog.Warn("skills: failed to remove legacy command file superseded by skill",
-				"id", sk.Name, "path", legacyPath, "error", err)
-			continue
-		}
-		slog.Info("skills: removed legacy command file superseded by skill",
-			"id", sk.Name, "path", legacyPath)
-	}
+	cleanupLegacyCommandFilesForSkills(p.RepoRoot, selected)
+	return result, nil
 }
 
 func handleCheckSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.CheckSkillsResponse, error) {
-	skills, err := oxSkillFiles(p.Version)
-	if err != nil {
-		return nil, err
-	}
-
-	dir := skillsDir(p.RepoRoot)
-	var missing, stale []string
-	for _, sk := range skills {
-		dstPath := filepath.Join(dir, sk.Name, skillFileName)
-		existing, err := os.ReadFile(dstPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				missing = append(missing, sk.Name)
-				continue
-			}
-			return nil, fmt.Errorf("read skill file %s: %w", sk.Name, err)
-		}
-		if isSkillStale(existing, sk) {
-			stale = append(stale, sk.Name)
-		}
-	}
-
-	return &adapterprotocol.CheckSkillsResponse{
-		Installed: len(missing) == 0 && len(stale) == 0,
-		Missing:   missing,
-		Stale:     stale,
-		SkillsDir: dir,
-		Total:     len(skills),
-	}, nil
+	return skillmanager.Check(p, skillsDir(p.RepoRoot))
 }
 
 func handleUninstallSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.UninstallSkillsResponse, error) {
-	dir := skillsDir(p.RepoRoot)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return &adapterprotocol.UninstallSkillsResponse{Uninstalled: false}, nil
-		}
-		return nil, fmt.Errorf("read skills directory: %w", err)
-	}
+	return skillmanager.Uninstall(p, skillsDir(p.RepoRoot))
+}
 
-	var removed []string
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		skillPath := filepath.Join(dir, name, skillFileName)
-		data, err := os.ReadFile(skillPath)
+func cleanupLegacyCommandFilesForSkills(repoRoot string, selected []skills.Skill) {
+	commandsDir := filepath.Join(repoRoot, ".claude", "commands")
+	for _, skill := range selected {
+		legacyPath := filepath.Join(commandsDir, skill.Name+".md")
+		data, err := os.ReadFile(legacyPath)
 		if err != nil {
 			continue
 		}
-		// only remove skills we stamped (leave user-authored skills alone).
-		if hash, _, _ := adapterstamp.ExtractStampAnywhere(data, oxSkillStampPrefix); hash == "" {
+		if hash, _, _ := adapterstamp.ExtractStampAnywhere(data, "ox"); hash == "" {
 			continue
 		}
-		if err := os.RemoveAll(filepath.Join(dir, name)); err != nil {
-			slog.Warn("skills: failed to remove skill directory", "name", name, "error", err)
-			continue
+		if err := os.Remove(legacyPath); err != nil {
+			slog.Warn("skills: failed to remove legacy command file superseded by skill", "id", skill.Name, "path", legacyPath, "error", err)
 		}
-		removed = append(removed, filepath.Join(name, skillFileName))
 	}
-
-	// best-effort cleanup of an empty skills dir.
-	if remaining, _ := os.ReadDir(dir); len(remaining) == 0 {
-		_ = os.Remove(dir)
-	}
-
-	return &adapterprotocol.UninstallSkillsResponse{
-		Uninstalled:  len(removed) > 0,
-		FilesRemoved: removed,
-	}, nil
-}
-
-// shouldWriteSkill decides whether to (over)write an installed skill. It mirrors
-// agentx.ShouldWriteCommand's logic but reads the stamp from after the
-// frontmatter (extractStampAnywhere) rather than line 1:
-//
-//   - file doesn't exist -> write
-//   - no stamp -> skip (user-managed)
-//   - frontmatter differs from the embedded skill -> write (restore) — the stamp
-//     hash only covers the body, so name/description edits are otherwise invisible
-//   - body matches the live binary's body hash -> skip (identical)
-//   - body tampered (on-disk body != its own stamp hash) -> write (restore)
-//   - installed by a newer ox version -> skip (downgrade guard)
-//   - otherwise -> write
-func shouldWriteSkill(existing []byte, sk skillFile) bool {
-	if existing == nil {
-		return true
-	}
-	stampHash, ver, body := adapterstamp.ExtractStampAnywhere(existing, oxSkillStampPrefix)
-	if stampHash == "" {
-		return false // user-managed — never overwrite
-	}
-	// Frontmatter is NOT covered by the stamp's body hash, so a name/description
-	// edit slips past both the body-match and tamper checks below. Only ox-stamped
-	// files reach here (the no-stamp guard above already returned), so forcing a
-	// rewrite on a frontmatter diff can't clobber a user's unstamped SKILL.md.
-	if frontmatterDiffers(existing, sk.Content) {
-		return true
-	}
-	_, embedBody, _ := splitFrontmatter(sk.Content)
-	wantHash := agentx.ContentHash(embedBody)
-
-	// on-disk body still matches the live binary's content AND its own stamp:
-	// nothing to do.
-	if stampHash == wantHash && agentx.ContentHash(body) == stampHash {
-		return false
-	}
-	// tampered body (stamp no longer covers the on-disk body): always restore.
-	if agentx.ContentHash(body) != stampHash {
-		return true
-	}
-	// binary drift only: respect the downgrade guard.
-	if ver != "" && sk.Version != "" && agentx.CompareVersions(sk.Version, ver) {
-		return false
-	}
-	return true
-}
-
-// isSkillStale reports whether an installed skill is outdated or tampered.
-// Mirrors adapterstamp.AppendFrontmatterStale's two-part rule (body tampered OR
-// binary drift) with the same version-downgrade guard. User-managed files (no
-// stamp) are never stale.
-func isSkillStale(existing []byte, sk skillFile) bool {
-	stampHash, ver, body := adapterstamp.ExtractStampAnywhere(existing, oxSkillStampPrefix)
-	if stampHash == "" {
-		return false // user-managed
-	}
-	// (0) frontmatter tampered: the stamp hash covers only the body, so a
-	// name/description edit is invisible to the body checks below. Only ox-stamped
-	// files reach here, so this never flags a user's unstamped SKILL.md.
-	if frontmatterDiffers(existing, sk.Content) {
-		return true
-	}
-	// (1) body tampered: on-disk body doesn't match its own stamp.
-	if agentx.ContentHash(body) != stampHash {
-		return true
-	}
-	// (2) binary drift: live binary ships a different body, unless installed by a
-	// newer ox (downgrade guard).
-	_, embedBody, _ := splitFrontmatter(sk.Content)
-	if stampHash != agentx.ContentHash(embedBody) {
-		if ver != "" && sk.Version != "" && agentx.CompareVersions(sk.Version, ver) {
-			return false
-		}
-		return true
-	}
-	return false
 }

--- a/cmd/ox-adapter-claude-code/skills_test.go
+++ b/cmd/ox-adapter-claude-code/skills_test.go
@@ -7,31 +7,28 @@ import (
 	"testing"
 
 	"github.com/sageox/agentx"
+	"github.com/sageox/ox/extensions/skills"
 	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// pickSkill returns the first embedded skill name, failing the test if none
-// ship. Tests that need a concrete skill on disk use this so they don't hardcode
-// an id that may be renamed.
+// pickSkill returns a default-installed skill name, failing the test if none
+// ship. Attest playbooks are opt-in, so lifecycle tests must not accidentally
+// select a skill the default installer intentionally leaves absent.
 func pickSkill(t *testing.T) string {
 	t.Helper()
-	skills, err := oxSkillFiles("0.8.0")
+	skills, err := skills.Selected("0.8.0", nil)
 	require.NoError(t, err)
-	require.NotEmpty(t, skills, "at least one embedded skill must ship for these tests to mean anything")
+	require.NotEmpty(t, skills, "at least one default skill must ship for these tests to mean anything")
 	return skills[0].Name
 }
 
 // --- A. Install lifecycle / stamp placement ---
 
-// TestHandleInstallSkills_StampPlacement verifies the load-bearing on-disk
-// contract: Claude must be able to parse a skill's YAML frontmatter, so the
-// frontmatter MUST be the first bytes of SKILL.md (line 1 is the `---` opener)
-// and the ox-hash drift stamp MUST sit AFTER the closing `---`, never on line 1.
-// Failure prevented: the stamp leaks onto line 1 (breaking frontmatter parsing)
-// or the frontmatter is dropped, so Claude can't read name/description.
-func TestHandleInstallSkills_StampPlacement(t *testing.T) {
+// TestHandleInstallSkills_ManifestOwnership verifies native frontmatter stays
+// byte-clean while ownership moves to the project lockfile.
+func TestHandleInstallSkills_ManifestOwnership(t *testing.T) {
 	dir := t.TempDir()
 	name := pickSkill(t)
 
@@ -52,18 +49,9 @@ func TestHandleInstallSkills_StampPlacement(t *testing.T) {
 	assert.Equal(t, "---", strings.TrimRight(lines[0], "\r"),
 		"line 1 must be the frontmatter opener so Claude can parse name/description")
 
-	stampMarker := agentx.StampComment(oxSkillStampPrefix)
-	assert.Contains(t, string(data), stampMarker, "SKILL.md must carry an ox-hash stamp")
-	assert.False(t, strings.HasPrefix(lines[0], stampMarker),
-		"the stamp must NOT be on line 1 — it belongs after the closing frontmatter fence")
-
-	// the stamp must appear strictly after the closing `---` fence.
-	stampIdx := strings.Index(string(data), stampMarker)
-	require.GreaterOrEqual(t, stampIdx, 0)
-	closingFence := strings.Index(string(data), "\n---\n")
-	require.GreaterOrEqual(t, closingFence, 0, "frontmatter must have a closing fence")
-	assert.Greater(t, stampIdx, closingFence,
-		"stamp must sit after the closing frontmatter fence, not inside the frontmatter")
+	assert.NotContains(t, string(data), agentx.StampComment(oxSkillStampPrefix),
+		"new native skills use manifest ownership; inline stamps are migration-only")
+	assert.FileExists(t, filepath.Join(dir, ".sageox", "skills.lock.json"))
 }
 
 // TestHandleInstallSkills_Idempotent verifies installing the same version twice
@@ -106,6 +94,40 @@ func TestHandleInstallSkills_NoOpReportsNothingWritten(t *testing.T) {
 	assert.Empty(t, second.FilesWritten,
 		"a re-install of an already-current skill set must write nothing — "+
 			"FilesWritten drives init's honest 'already up to date' message")
+}
+
+// TestHandleInstallSkills_OptInAttestSkillsStayOutOfDefaultInstall keeps a
+// team that uses normal ox integration from receiving Attest playbooks it did
+// not choose. An explicit capability install is the only path that writes them.
+func TestHandleInstallSkills_OptInAttestSkillsStayOutOfDefaultInstall(t *testing.T) {
+	dir := t.TempDir()
+	defaultInstall, err := handleInstallSkills(adapterprotocol.SkillsParams{
+		RepoRoot: dir,
+		Version:  "0.8.0",
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, defaultInstall.FilesWritten,
+		filepath.Join(".claude", "skills", "ox-attest-goal", skillFileName))
+
+	optIn, err := handleInstallSkills(adapterprotocol.SkillsParams{
+		RepoRoot: dir,
+		Version:  "0.8.0",
+		Names:    []string{"ox-attest-goal", "ox-attest-create"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, optIn.FilesWritten,
+		filepath.Join(".claude", "skills", "ox-attest-goal", skillFileName))
+	assert.Contains(t, optIn.FilesWritten,
+		filepath.Join(".claude", "skills", "ox-attest-create", skillFileName))
+}
+
+func TestHandleInstallSkills_RejectsUnknownOptInSkill(t *testing.T) {
+	_, err := handleInstallSkills(adapterprotocol.SkillsParams{
+		RepoRoot: t.TempDir(),
+		Version:  "0.8.0",
+		Names:    []string{"does-not-exist"},
+	})
+	require.EqualError(t, err, "unknown ox skill(s): [does-not-exist]")
 }
 
 // --- B. Check lifecycle ---
@@ -160,20 +182,22 @@ func TestHandleCheckSkills_BodyEditedBelowStamp_ReportsStale(t *testing.T) {
 
 	stale, err := handleCheckSkills(params)
 	require.NoError(t, err)
-	assert.Contains(t, stale.Stale, name, "body edited below the stamp must be reported Stale")
+	assert.Contains(t, stale.Conflicts, name, "a user-modified managed body must be reported as a conflict")
 	assert.False(t, stale.Installed, "Installed must be false when a skill has drifted")
 
-	// reinstall (the --fix path) restores the file and clears staleness.
-	_, err = handleInstallSkills(params)
+	// Reinstall preserves the edit instead of silently destroying user work.
+	reinstall, err := handleInstallSkills(params)
 	require.NoError(t, err)
+	assert.False(t, reinstall.Installed)
+	assert.NotEmpty(t, reinstall.Conflicts)
 	fixed, err := handleCheckSkills(params)
 	require.NoError(t, err)
-	assert.NotContains(t, fixed.Stale, name, "reinstall must restore a drifted skill")
-	assert.True(t, fixed.Installed, "after --fix the skill set must be Installed again")
+	assert.Contains(t, fixed.Conflicts, name)
+	assert.False(t, fixed.Installed)
 
 	restored, err := os.ReadFile(skillPath)
 	require.NoError(t, err)
-	assert.NotContains(t, string(restored), "hand-edited drift", "reinstall must overwrite the tampered body")
+	assert.Contains(t, string(restored), "hand-edited drift", "reinstall must preserve a user edit")
 }
 
 // TestHandleCheckSkills_FrontmatterEdited_ReportsStale guards the gap CodeRabbit
@@ -212,24 +236,26 @@ func TestHandleCheckSkills_FrontmatterEdited_ReportsStale(t *testing.T) {
 
 	stale, err := handleCheckSkills(params)
 	require.NoError(t, err)
-	assert.Contains(t, stale.Stale, name, "a frontmatter-only edit must be reported Stale")
+	assert.Contains(t, stale.Conflicts, name, "a frontmatter-only edit must be reported as a conflict")
 	assert.False(t, stale.Installed, "Installed must be false when a skill's frontmatter drifted")
 
 	// reinstall (the --fix path) must rewrite the file and clear staleness.
 	resp, err := handleInstallSkills(params)
 	require.NoError(t, err)
-	assert.Contains(t, resp.FilesWritten, filepath.Join(".claude", "skills", name, skillFileName),
-		"--fix must rewrite a skill whose frontmatter was edited")
+	assert.False(t, resp.Installed)
+	assert.NotEmpty(t, resp.Conflicts)
+	assert.NotContains(t, resp.FilesWritten, filepath.Join(".claude", "skills", name, skillFileName),
+		"--fix must preserve a user-edited skill")
 
 	fixed, err := handleCheckSkills(params)
 	require.NoError(t, err)
-	assert.NotContains(t, fixed.Stale, name, "reinstall must restore the drifted frontmatter")
-	assert.True(t, fixed.Installed, "after --fix the skill set must be Installed again")
+	assert.Contains(t, fixed.Conflicts, name)
+	assert.False(t, fixed.Installed)
 
 	restored, err := os.ReadFile(skillPath)
 	require.NoError(t, err)
-	assert.NotContains(t, string(restored), "hand-edited frontmatter drift",
-		"reinstall must overwrite the tampered frontmatter")
+	assert.Contains(t, string(restored), "hand-edited frontmatter drift",
+		"reinstall must preserve the tampered frontmatter for manual resolution")
 }
 
 // TestHandleCheckSkills_UnstampedFrontmatterDiff_NotOverwritten verifies the
@@ -311,11 +337,11 @@ func TestHandleUninstallSkills_RemovesStampedDirs(t *testing.T) {
 	resp, err := handleUninstallSkills(params)
 	require.NoError(t, err)
 	assert.True(t, resp.Uninstalled, "expected at least one stamped skill removed")
-	assert.Contains(t, resp.FilesRemoved, filepath.Join(name, skillFileName),
+	assert.Contains(t, resp.FilesRemoved, filepath.Join(".claude", "skills", name, skillFileName),
 		"FilesRemoved must reference the removed SKILL.md")
 
-	_, err = os.Stat(skillDir)
-	assert.True(t, os.IsNotExist(err), "stamped skill dir must be removed by uninstall")
+	_, err = os.Stat(filepath.Join(skillDir, skillFileName))
+	assert.True(t, os.IsNotExist(err), "stamped SKILL.md must be removed by uninstall")
 }
 
 // TestHandleUninstallSkills_PreservesUnstampedSkill verifies a user-authored
@@ -341,67 +367,7 @@ func TestHandleUninstallSkills_PreservesUnstampedSkill(t *testing.T) {
 	assert.NoError(t, err, "user-authored unstamped skill must NOT be removed by uninstall")
 }
 
-// --- D. splitFrontmatter ---
-
-// TestSplitFrontmatter covers the parser that underpins stamp placement:
-// has-frontmatter, no-frontmatter, empty-frontmatter, and a missing closing
-// fence (which must be treated as no frontmatter, defensively).
-// Failure prevented: misparsing frontmatter places the stamp inside or before
-// the frontmatter, breaking Claude's parse or the drift hash contract.
-func TestSplitFrontmatter(t *testing.T) {
-	tests := []struct {
-		name     string
-		content  string
-		wantOK   bool
-		wantFM   string
-		wantBody string
-	}{
-		{
-			name:     "has frontmatter",
-			content:  "---\nname: x\n---\nbody line\n",
-			wantOK:   true,
-			wantFM:   "---\nname: x\n---\n",
-			wantBody: "body line\n",
-		},
-		{
-			name:     "no frontmatter",
-			content:  "# just a heading\nbody\n",
-			wantOK:   false,
-			wantFM:   "",
-			wantBody: "# just a heading\nbody\n",
-		},
-		{
-			name:     "empty frontmatter",
-			content:  "---\n---\nbody\n",
-			wantOK:   true,
-			wantFM:   "---\n---\n",
-			wantBody: "body\n",
-		},
-		{
-			name:     "no closing fence",
-			content:  "---\nname: x\nstill open\n",
-			wantOK:   false,
-			wantFM:   "",
-			wantBody: "---\nname: x\nstill open\n",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			fm, body, ok := splitFrontmatter([]byte(tc.content))
-			assert.Equal(t, tc.wantOK, ok)
-			assert.Equal(t, tc.wantFM, string(fm), "frontmatter mismatch")
-			assert.Equal(t, tc.wantBody, string(body), "body mismatch")
-			if !ok {
-				// when there's no recognized frontmatter, body must equal the full
-				// content so the stamp falls back to covering everything.
-				assert.Equal(t, tc.content, string(body))
-			}
-		})
-	}
-}
-
-// --- E. Command→skill migration cleanup (FIX 2) ---
+// --- D. Command→skill migration cleanup ---
 
 // TestHandleInstallSkills_RemovesStampedLegacyCommand verifies the self-cleaning
 // migration: when a surface moves from a slash command to a skill, an existing

--- a/cmd/ox-adapter-codex/main.go
+++ b/cmd/ox-adapter-codex/main.go
@@ -31,18 +31,21 @@ func main() {
 // does — exercising the actual wiring, not just the handler functions in
 // isolation. See TestReadFromOffset_WiredInOneShotMode.
 var adapterConfig = adapterruntime.Config{
-	Info:           handleInfo,
-	Detect:         handleDetect,
-	InstallHooks:   handleInstallHooks,
-	CheckHooks:     handleCheckHooks,
-	UninstallHooks: handleUninstallHooks,
-	FindSession:    handleFindSession,
-	Read:           handleRead,
-	ReadMetadata:   handleReadMetadata,
-	ReadFromOffset: handleReadFromOffset,
-	ImportSession:  handleImportSession,
-	Diagnose:       handleDiagnose,
-	Serve:          handleServe,
+	Info:            handleInfo,
+	Detect:          handleDetect,
+	InstallHooks:    handleInstallHooks,
+	CheckHooks:      handleCheckHooks,
+	UninstallHooks:  handleUninstallHooks,
+	InstallSkills:   handleInstallSkills,
+	CheckSkills:     handleCheckSkills,
+	UninstallSkills: handleUninstallSkills,
+	FindSession:     handleFindSession,
+	Read:            handleRead,
+	ReadMetadata:    handleReadMetadata,
+	ReadFromOffset:  handleReadFromOffset,
+	ImportSession:   handleImportSession,
+	Diagnose:        handleDiagnose,
+	Serve:           handleServe,
 }
 
 // handleReadFromOffset is the one-shot mode handler for read-from-offset. The
@@ -79,13 +82,19 @@ func handleInfo() (*adapterprotocol.InfoResponse, error) {
 		Capabilities: []string{
 			adapterprotocol.CapSessionReader,
 			adapterprotocol.CapHookInstaller,
+			adapterprotocol.CapSkillsInstaller,
 			adapterprotocol.CapIncrementalReader,
 			adapterprotocol.CapFileWatcher,
 			adapterprotocol.CapServeMode,
 			adapterprotocol.CapSessionImporter,
 		},
 		HookEnvValues: []string{"codex"},
-		ServeMode:     true,
+		SkillTargets: []adapterprotocol.SkillTarget{{
+			Key: "agents-project", Root: ".agents/skills",
+			Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+			LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+		}},
+		ServeMode: true,
 	}, nil
 }
 

--- a/cmd/ox-adapter-codex/main_test.go
+++ b/cmd/ox-adapter-codex/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,8 +15,8 @@ import (
 // TestHandleInfo_CapabilitiesPinned pins this binary's declared capabilities to
 // the set the cross-agent conformance fixture mirrors
 // (internal/prime/conformance_test.go). Codex declares NEITHER a commands nor a
-// rules/skills installer — this is the regression lock behind "Codex users get
-// the floor (Layer 1) but no Layer-2 surfaces." If handleInfo() drifts, this
+// rules installer. Skills are a portable Layer-2 surface installed into
+// .agents/skills. If handleInfo() drifts, this
 // fails so the conformance fixture cannot silently fall out of sync.
 //
 // KEEP IN SYNC: the want set below must match the "codex" entry in adapterCaps
@@ -25,6 +27,7 @@ func TestHandleInfo_CapabilitiesPinned(t *testing.T) {
 	want := []string{
 		adapterprotocol.CapSessionReader,
 		adapterprotocol.CapHookInstaller,
+		adapterprotocol.CapSkillsInstaller,
 		adapterprotocol.CapIncrementalReader,
 		adapterprotocol.CapFileWatcher,
 		adapterprotocol.CapServeMode,
@@ -36,6 +39,25 @@ func TestHandleInfo_CapabilitiesPinned(t *testing.T) {
 		t.Fatalf("handleInfo() error: %v", err)
 	}
 	assertCapabilitySetsEqual(t, "codex", info.Capabilities, want)
+	if len(info.SkillTargets) != 1 || info.SkillTargets[0].Key != "agents-project" || info.SkillTargets[0].Root != ".agents/skills" {
+		t.Fatalf("codex skill targets = %#v, want shared agents-project target", info.SkillTargets)
+	}
+}
+
+func TestInstallSkills_WritesCanonicalAgentSkills(t *testing.T) {
+	repo := t.TempDir()
+	var out bytes.Buffer
+	if err := adapterruntime.RunWithArgs(adapterConfig, []string{"install-skills", "--repo-root", repo, "--version", "1.0.0", "--skill", "ox-attest-goal"}, nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(repo, ".agents", "skills", "ox-attest-goal", "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(data), "---\nname: ox-attest-goal") {
+		t.Fatal("installed skill did not retain canonical frontmatter")
+	}
 }
 
 // TestReadFromOffset_WiredInOneShotMode drives read-from-offset through the

--- a/cmd/ox-adapter-codex/skills.go
+++ b/cmd/ox-adapter-codex/skills.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/sageox/ox/internal/skillmanager"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+func skillsDir(root string) string { return filepath.Join(root, ".agents", "skills") }
+func handleInstallSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.InstallSkillsResponse, error) {
+	return skillmanager.Install(p, skillsDir(p.RepoRoot))
+}
+func handleCheckSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.CheckSkillsResponse, error) {
+	return skillmanager.Check(p, skillsDir(p.RepoRoot))
+}
+func handleUninstallSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.UninstallSkillsResponse, error) {
+	return skillmanager.Uninstall(p, skillsDir(p.RepoRoot))
+}

--- a/cmd/ox-adapter-gemini/main.go
+++ b/cmd/ox-adapter-gemini/main.go
@@ -29,18 +29,21 @@ func main() {
 // does — exercising the actual wiring, not just the handler functions in
 // isolation. See TestReadFromOffset_WiredInOneShotMode.
 var adapterConfig = adapterruntime.Config{
-	Info:           handleInfo,
-	Detect:         handleDetect,
-	InstallHooks:   handleInstallHooks,
-	CheckHooks:     handleCheckHooks,
-	UninstallHooks: handleUninstallHooks,
-	FindSession:    handleFindSession,
-	Read:           handleRead,
-	ReadMetadata:   handleReadMetadata,
-	Diagnose:       handleDiagnose,
-	ReadFromOffset: handleReadFromOffset,
-	ImportSession:  handleImportSession,
-	Serve:          handleServe,
+	Info:            handleInfo,
+	Detect:          handleDetect,
+	InstallHooks:    handleInstallHooks,
+	CheckHooks:      handleCheckHooks,
+	UninstallHooks:  handleUninstallHooks,
+	InstallSkills:   handleInstallSkills,
+	CheckSkills:     handleCheckSkills,
+	UninstallSkills: handleUninstallSkills,
+	FindSession:     handleFindSession,
+	Read:            handleRead,
+	ReadMetadata:    handleReadMetadata,
+	Diagnose:        handleDiagnose,
+	ReadFromOffset:  handleReadFromOffset,
+	ImportSession:   handleImportSession,
+	Serve:           handleServe,
 }
 
 func handleInfo() (*adapterprotocol.InfoResponse, error) {
@@ -53,13 +56,19 @@ func handleInfo() (*adapterprotocol.InfoResponse, error) {
 		Capabilities: []string{
 			adapterprotocol.CapSessionReader,
 			adapterprotocol.CapHookInstaller,
+			adapterprotocol.CapSkillsInstaller,
 			adapterprotocol.CapIncrementalReader,
 			adapterprotocol.CapFileWatcher,
 			adapterprotocol.CapServeMode,
 			adapterprotocol.CapSessionImporter,
 		},
 		HookEnvValues: []string{"gemini"},
-		ServeMode:     true,
+		SkillTargets: []adapterprotocol.SkillTarget{{
+			Key: "agents-project", Root: ".agents/skills",
+			Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+			LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+		}},
+		ServeMode: true,
 	}, nil
 }
 

--- a/cmd/ox-adapter-gemini/main_test.go
+++ b/cmd/ox-adapter-gemini/main_test.go
@@ -3,12 +3,24 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/sageox/ox/pkg/adapterprotocol"
 	"github.com/sageox/ox/pkg/adapterruntime"
 )
+
+func TestHandleInfo_DeclaresSharedAgentSkillsTarget(t *testing.T) {
+	info, err := handleInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(info.SkillTargets) != 1 || info.SkillTargets[0].Key != "agents-project" || info.SkillTargets[0].Root != ".agents/skills" {
+		t.Fatalf("gemini skill targets = %#v, want shared agents-project target", info.SkillTargets)
+	}
+}
 
 // TestReadFromOffset_WiredInOneShotMode drives read-from-offset through the
 // real CLI dispatch path (adapterruntime.RunWithArgs against adapterConfig,
@@ -38,5 +50,21 @@ func TestReadFromOffset_WiredInOneShotMode(t *testing.T) {
 	}
 	if result.NewOffset <= 0 {
 		t.Fatalf("new_offset = %d, want > 0", result.NewOffset)
+	}
+}
+
+func TestInstallSkills_WritesCanonicalAgentSkills(t *testing.T) {
+	repo := t.TempDir()
+	var out bytes.Buffer
+	if err := adapterruntime.RunWithArgs(adapterConfig, []string{"install-skills", "--repo-root", repo, "--version", "1.0.0", "--skill", "ox-attest-goal"}, nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(repo, ".agents", "skills", "ox-attest-goal", "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(data), "---\nname: ox-attest-goal") {
+		t.Fatal("installed skill did not retain canonical frontmatter")
 	}
 }

--- a/cmd/ox-adapter-gemini/skills.go
+++ b/cmd/ox-adapter-gemini/skills.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/sageox/ox/internal/skillmanager"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+func skillsDir(root string) string { return filepath.Join(root, ".agents", "skills") }
+func handleInstallSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.InstallSkillsResponse, error) {
+	return skillmanager.Install(p, skillsDir(p.RepoRoot))
+}
+func handleCheckSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.CheckSkillsResponse, error) {
+	return skillmanager.Check(p, skillsDir(p.RepoRoot))
+}
+func handleUninstallSkills(p adapterprotocol.SkillsParams) (*adapterprotocol.UninstallSkillsResponse, error) {
+	return skillmanager.Uninstall(p, skillsDir(p.RepoRoot))
+}

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -665,7 +665,7 @@ func TestOutputAgentPrimeXML_VisualizationGuidanceIsArtifactNeutral(t *testing.T
 }
 
 // TestConsultRoutes_NoDriftWithSkill is the conformance contract between the
-// Layer-1 <consult-first> floor reminder and the additive `ox-consult` Claude
+// Layer-1 <consult-first> floor reminder and the additive portable `ox-consult`
 // skill: both render the SAME retrieval reflex, so the skill's activation
 // description must name every corpus the floor table routes to. If a future
 // edit drops a route from the skill's frontmatter (or adds one the floor
@@ -685,7 +685,7 @@ func TestConsultRoutes_NoDriftWithSkill(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve repo root: %v", err)
 	}
-	skillPath := filepath.Join(root, "extensions", "claude", "skills", "ox-consult", "SKILL.md")
+	skillPath := filepath.Join(root, "extensions", "skills", "ox-consult", "SKILL.md")
 	raw, err := os.ReadFile(skillPath)
 	if err != nil {
 		t.Fatalf("read %s: %v", skillPath, err)

--- a/cmd/ox/attest.go
+++ b/cmd/ox/attest.go
@@ -30,7 +30,19 @@ no network, no SageOx account required.
   ox attest results                run reports on this machine
   ox attest publish                write the portable layout to a directory
   ox attest view <attpub_id>       view one hosted publication
-  ox attest failures --latest      verified hosted failures for AI coworkers`,
+	  ox attest failures --latest      verified hosted failures for AI coworkers`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if cmd.Name() == "install" {
+			return
+		}
+		root, err := repotools.FindRepoRoot(repotools.VCSGit)
+		if err != nil {
+			return
+		}
+		if _, err := installAttestSkills(root); err != nil {
+			slog.Debug("Attest skills were not installed", "error", err)
+		}
+	},
 }
 
 // attestContext is everything the read commands need, loaded once.

--- a/cmd/ox/attest_install.go
+++ b/cmd/ox/attest_install.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/repotools"
+	"github.com/spf13/cobra"
+)
+
+var attestInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install optional Attest skills for AI coworkers",
+	Long: `Install the optional Attest playbooks for supported AI coworkers.
+
+This installs customer-journey BDD creation and evidence-recording guidance.
+It does not install lifecycle hooks: use 'ox integrate install' for those.
+The Attest CLI itself remains available on every supported agent.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repoRoot, err := repotools.FindRepoRoot(repotools.VCSGit)
+		if err != nil {
+			return fmt.Errorf("not in a git repository")
+		}
+		installed, err := installAttestSkills(repoRoot)
+		if err != nil {
+			return err
+		}
+		if installed == 0 {
+			cli.PrintPreserved("Attest skills already up to date")
+		} else {
+			cli.PrintSuccess(fmt.Sprintf("Reconciled %d Attest skill file(s)", installed))
+		}
+		return nil
+	},
+}
+
+func installAttestSkills(repoRoot string) (int, error) {
+	plan, err := addSkillBundle(repoRoot, "attest")
+	if err != nil {
+		return 0, err
+	}
+	if len(plan.Conflicts) > 0 {
+		return len(plan.WrittenPaths()), fmt.Errorf("attest skills have %d preserved user-owned or modified file conflict(s)", len(plan.Conflicts))
+	}
+	return len(plan.WrittenPaths()), nil
+}
+
+func init() {
+	attestCmd.AddCommand(attestInstallCmd)
+}

--- a/cmd/ox/doctor.go
+++ b/cmd/ox/doctor.go
@@ -799,8 +799,6 @@ func runDoctorChecks(parent context.Context, opts doctorOptions) []checkCategory
 		}
 		// verify ox-* slash commands are installed in .claude/commands/
 		integrationChecks = append(integrationChecks, checkClaudeCommands(opts.shouldFix(CheckSlugClaudeCommands)))
-		// detect installed skills drift in .claude/skills/ox-* (claude-only surface)
-		integrationChecks = append(integrationChecks, checkClaudeSkills(opts.shouldFix(CheckSlugClaudeSkills)))
 	}
 	if detectOpenCode() {
 		integrationChecks = append(integrationChecks, checkOpenCodeHooks(opts.shouldFix(CheckSlugOpenCodeHooks)))
@@ -811,6 +809,9 @@ func runDoctorChecks(parent context.Context, opts doctorOptions) []checkCategory
 	if detectCodex() {
 		integrationChecks = append(integrationChecks, checkCodexHooks(opts.shouldFix(CheckSlugCodexHooks)))
 	}
+	// Skill target selection is project state, not a consequence of which AI
+	// coworker happens to be detected during this Doctor run.
+	integrationChecks = append(integrationChecks, checkClaudeSkills(opts.shouldFix(CheckSlugClaudeSkills)))
 	if detectAmp() {
 		integrationChecks = append(integrationChecks, checkAmpHooks(opts.shouldFix(CheckSlugAmpHooks)))
 	}

--- a/cmd/ox/doctor_skills.go
+++ b/cmd/ox/doctor_skills.go
@@ -4,107 +4,73 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sageox/ox/internal/session/adapters"
-	"github.com/sageox/ox/internal/version"
-	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/sageox/ox/internal/skillmanager"
 )
 
-// checkClaudeSkills validates that ox skills are installed and current for EVERY
-// external adapter that installs skills (not just the first). Mirrors
-// checkAdapterRules: skills land in agent-specific roots (.claude/skills/...), so
-// if a second adapter ever gains CapSkillsInstaller the check must cover it too
-// rather than silently inspecting only the first. Targets the per-skill directory
-// layout (.claude/skills/<name>/SKILL.md) via the skills_installer capability.
+// checkClaudeSkills retains its historical registration name, but checks the
+// project-selected native targets from .sageox/skills.lock.json. Detection is
+// consulted only for the one-release inline-stamp migration.
 func checkClaudeSkills(fix bool) checkResult {
 	gitRoot := findGitRoot()
 	if gitRoot == "" {
-		return SkippedCheck("Claude skills", "not in git repo", "")
+		return SkippedCheck("Agent skills", "not in git repo", "")
+	}
+	plan, err := planCommittedSkills(gitRoot)
+	if err != nil {
+		return WarningCheck("Agent skills", "cannot inspect managed skills", err.Error())
+	}
+	if plan.TargetCount == 0 {
+		return SkippedCheck("Agent skills", "no project-selected skill targets", "Run `ox init` and select an AI coworker with native Agent Skills")
+	}
+	if len(plan.Warnings) > 0 {
+		return WarningCheck("Agent skills", strings.Join(plan.Warnings, "; "), "Use the same or a newer ox version before reconciling")
+	}
+	if len(plan.Creates)+len(plan.Updates)+len(plan.Removes) == 0 && len(plan.Conflicts) == 0 {
+		return PassedCheck("Agent skills", fmt.Sprintf("%d managed files across %d native target(s)", plan.DesiredFileCount, plan.TargetCount))
 	}
 
-	eas := findSkillsAdapters()
-	if len(eas) == 0 {
-		return SkippedCheck("Claude skills", "no skills adapters", "")
+	problem := describeSkillPlan(plan)
+	if !fix {
+		if len(plan.Conflicts) > 0 && len(plan.Creates)+len(plan.Updates)+len(plan.Removes) == 0 {
+			return WarningCheck("Agent skills", problem, "Resolve the preserved user-owned or modified files manually")
+		}
+		return FailedCheck("Agent skills", problem, "Run `ox doctor --fix` to reconcile unchanged managed files")
 	}
-
-	var problems []string // human-readable per-adapter drift descriptions
-	var driftAdapters []*adapters.ExternalAdapter
-	var warnings []string
-	var total int
-
-	for _, ea := range eas {
-		result, err := ea.CheckSkills(gitRoot, version.Version)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("%s: %v", ea.Name(), err))
-			continue
-		}
-		total += result.Total
-		if result.Installed {
-			continue
-		}
-
-		driftAdapters = append(driftAdapters, ea)
-		var parts []string
-		if len(result.Missing) > 0 {
-			parts = append(parts, fmt.Sprintf("%d missing: %s", len(result.Missing), strings.Join(result.Missing, ", ")))
-		}
-		if len(result.Stale) > 0 {
-			parts = append(parts, fmt.Sprintf("%d outdated: %s", len(result.Stale), strings.Join(result.Stale, ", ")))
-		}
-		problems = append(problems, fmt.Sprintf("%s: %s", ea.Name(), strings.Join(parts, "; ")))
+	applied, err := reconcileCommittedSkills(gitRoot)
+	if err != nil {
+		return FailedCheck("Agent skills", problem, fmt.Sprintf("Fix failed: %v", err))
 	}
-
-	// All adapters reported their skills installed and current.
-	if len(driftAdapters) == 0 {
-		if len(warnings) > 0 {
-			return WarningCheck("Claude skills", "check error", strings.Join(warnings, "; "))
-		}
-		return PassedCheck("Claude skills", fmt.Sprintf("%d installed", total))
+	plan = applied
+	if len(plan.Conflicts) > 0 {
+		return WarningCheck("Agent skills", fmt.Sprintf("reconciled with %d preserved conflict(s)", len(plan.Conflicts)), "Resolve the preserved user-owned or modified files manually")
 	}
-
-	problemStr := strings.Join(problems, "; ")
-
-	if fix {
-		var fixed int
-		var fixErrs []string
-		for _, ea := range driftAdapters {
-			if _, err := ea.InstallSkills(gitRoot, version.Version); err != nil {
-				fixErrs = append(fixErrs, fmt.Sprintf("%s: %v", ea.Name(), err))
-				continue
-			}
-			fixed++
-		}
-		if len(fixErrs) > 0 {
-			return FailedCheck("Claude skills", problemStr,
-				fmt.Sprintf("Fix failed: %s", strings.Join(fixErrs, "; ")))
-		}
-		return PassedCheck("Claude skills", fmt.Sprintf("restored skills for %d adapter(s)", fixed))
-	}
-
-	return FailedCheck("Claude skills", problemStr,
-		"Run `ox doctor --fix` or `ox init` to restore")
+	return PassedCheck("Agent skills", fmt.Sprintf("reconciled %d file change(s) across %d native target(s)", len(plan.Creates)+len(plan.Updates)+len(plan.Removes), plan.TargetCount))
 }
 
-// findSkillsAdapters returns ALL discovered external adapters that declare
-// CapSkillsInstaller. Mirrors findRulesAdapters: should a second adapter ever
-// gain skills support, the doctor check must cover every one — unlike
-// findCommandsAdapter (which returns only the first), this returns every match.
-func findSkillsAdapters() []*adapters.ExternalAdapter {
-	var eas []*adapters.ExternalAdapter
-	for _, ea := range adapters.DiscoverExternalAdapters() {
-		if ea.HasCapability(adapterprotocol.CapSkillsInstaller) {
-			eas = append(eas, ea)
-		}
+func describeSkillPlan(plan *skillmanager.ReconcilePlan) string {
+	parts := make([]string, 0, 4)
+	if len(plan.Creates) > 0 {
+		parts = append(parts, fmt.Sprintf("%d missing", len(plan.Creates)))
 	}
-	return eas
+	if len(plan.Updates) > 0 {
+		parts = append(parts, fmt.Sprintf("%d outdated", len(plan.Updates)))
+	}
+	if len(plan.Removes) > 0 {
+		parts = append(parts, fmt.Sprintf("%d retired", len(plan.Removes)))
+	}
+	if len(plan.Conflicts) > 0 {
+		parts = append(parts, fmt.Sprintf("%d preserved conflict(s)", len(plan.Conflicts)))
+	}
+	return strings.Join(parts, "; ")
 }
 
 func init() {
 	RegisterDoctorCheck(&DoctorCheck{
 		Slug:        CheckSlugClaudeSkills,
-		Name:        "Claude skills",
+		Name:        "Agent skills",
 		Category:    "Integration",
 		FixLevel:    FixLevelAuto,
-		Description: "Verifies ox skills are installed in .claude/skills/",
+		Description: "Reconciles project-selected native Agent Skills targets",
 		Run:         checkClaudeSkills,
 	})
 }

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -746,9 +746,9 @@ func runInit() error {
 			}
 		}
 		if hasNew || len(installedHooks) > 0 {
-			cli.PrintSuccess("Installed AI coworker hooks and commands")
+			cli.PrintSuccess("Installed AI coworker integrations and skills")
 		} else {
-			cli.PrintPreserved("AI coworker hooks and commands")
+			cli.PrintPreserved("AI coworker integrations and skills")
 		}
 	}
 
@@ -2067,6 +2067,7 @@ func installAgentHooks(gitRoot string, quiet bool, selectedAgents map[string]boo
 
 	// install hooks + rules only for agents the user selected
 	externalAdapters := adapters.DiscoverExternalAdapters()
+	var selectedSkillAdapters []*adapters.ExternalAdapter
 	for _, ea := range externalAdapters {
 		if !selectedAgents[ea.Name()] {
 			continue
@@ -2121,22 +2122,46 @@ func installAgentHooks(gitRoot string, quiet bool, selectedAgents map[string]boo
 		}
 
 		if ea.HasCapability(adapterprotocol.CapSkillsInstaller) {
-			result, err := ea.InstallSkills(gitRoot, version.Version)
-			if err != nil {
-				if !quiet {
-					cli.PrintWarning(fmt.Sprintf("Could not install %s skills: %v", ea.Name(), err))
-				}
-			} else if result.Installed {
-				// FilesWritten holds only the skills actually (over)written; it's
-				// empty when every skill was already current. Report the honest
-				// count instead of an unconditional "Installed".
-				if n := len(result.FilesWritten); n > 0 {
+			if len(ea.Info().SkillTargets) > 0 {
+				selectedSkillAdapters = append(selectedSkillAdapters, ea)
+			} else {
+				// One-release compatibility for third-party adapters that have not
+				// adopted target descriptors yet.
+				result, err := ea.InstallSkills(gitRoot, version.Version)
+				if err != nil {
 					if !quiet {
-						cli.PrintSuccess(fmt.Sprintf("Installed %d %s skills", n, ea.Name()))
+						cli.PrintWarning(fmt.Sprintf("Could not install legacy %s skills: %v", ea.Name(), err))
 					}
+				} else {
 					installedHooks = append(installedHooks, result.FilesWritten...)
-				} else if !quiet {
-					cli.PrintPreserved(fmt.Sprintf("%s skills already up to date", ea.Name()))
+				}
+			}
+		}
+	}
+	if targets, err := skillTargetsForAdapters(gitRoot, selectedSkillAdapters); err != nil {
+		if !quiet {
+			cli.PrintWarning(fmt.Sprintf("Could not resolve Agent Skills targets: %v", err))
+		}
+	} else if len(targets) > 0 {
+		plan, err := reconcileSelectedSkills(gitRoot, targets)
+		if err != nil {
+			if !quiet {
+				cli.PrintWarning(fmt.Sprintf("Could not reconcile Agent Skills: %v", err))
+			}
+		} else {
+			written := plan.WrittenPaths()
+			installedHooks = append(installedHooks, written...)
+			if plan.LockChanged() {
+				installedHooks = append(installedHooks, filepath.Join(".sageox", "skills.lock.json"))
+			}
+			if !quiet {
+				switch {
+				case len(plan.Conflicts) > 0:
+					cli.PrintWarning(fmt.Sprintf("Reconciled Agent Skills with %d preserved conflict(s)", len(plan.Conflicts)))
+				case len(written) > 0:
+					cli.PrintSuccess(fmt.Sprintf("Installed %d Agent Skills file(s) across %d native target(s)", len(written), len(targets)))
+				default:
+					cli.PrintPreserved("Agent Skills already up to date")
 				}
 			}
 		}

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-08-15
+
+Skills now reach each AI coworker through its native discovery mechanism, while SageOx keeps project-scoped installations safe, consistent, and repairable.
+
+### New
+
+- **Native skill management across Claude, Codex, and Gemini** — each AI coworker receives skills in the project directory it already knows how to discover.
+- **Project-scoped skill ownership** — `.sageox/skills.lock.json` records selected targets, bundles, revisions, and managed file digests so updates and removal are precise.
+
+### Improved
+
+- **One shared installation for Codex and Gemini** — their common `.agents/skills` target is reconciled once, eliminating duplicate work and misleading counts.
+- **`ox doctor` checks the complete skill tree** — scripts, references, and assets are verified alongside `SKILL.md`, and `ox doctor --fix` applies the same deterministic plan.
+- **Portable skills stay portable** — content installed in `.agents/skills` no longer depends on Claude-only wording or invocation syntax.
+
+### Fixed
+
+- **User edits and collisions are preserved** — SageOx updates or removes only files whose digest still matches the last managed version, reporting conflicts instead of overwriting them.
+- **Interrupted updates recover safely** — managed files are staged and validated before the ownership lockfile is committed last, so the next reconciliation converges cleanly.
+- **Selected AI coworker targets persist after `ox init`** — Doctor no longer installs skills for detected but unselected targets.
+- **Deterministic repair no longer consumes an AI task** — skill reconciliation runs during explicit lifecycle commands instead of a daily daemon-scheduled coworker job.
+
 ## [0.13.0] - 2026-08-11
 
 Plans get a full lifecycle and a genuinely better reviewing experience — and priming just got ~87% cheaper.

--- a/cmd/ox/skill_reconcile.go
+++ b/cmd/ox/skill_reconcile.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/sageox/ox/extensions/skills"
+	"github.com/sageox/ox/internal/adapterstamp"
+	"github.com/sageox/ox/internal/session/adapters"
+	"github.com/sageox/ox/internal/skillmanager"
+	"github.com/sageox/ox/internal/version"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+// skillTargetsForAdapters resolves native target descriptors and deduplicates
+// shared projections such as Codex and Gemini's .agents/skills root.
+func skillTargetsForAdapters(repoRoot string, candidates []*adapters.ExternalAdapter) ([]adapterprotocol.SkillTarget, error) {
+	var targets []adapterprotocol.SkillTarget
+	for _, adapter := range candidates {
+		if !adapter.HasCapability(adapterprotocol.CapSkillsInstaller) || adapter.Info() == nil {
+			continue
+		}
+		targets = append(targets, adapter.Info().SkillTargets...)
+	}
+	return skillmanager.CanonicalizeTargets(repoRoot, targets)
+}
+
+func detectedSkillTargets(repoRoot string) ([]adapterprotocol.SkillTarget, error) {
+	var candidates []*adapters.ExternalAdapter
+	for _, adapter := range adapters.DiscoverExternalAdapters() {
+		if adapter.HasCapability(adapterprotocol.CapSkillsInstaller) && adapter.Detect() {
+			candidates = append(candidates, adapter)
+		}
+	}
+	return skillTargetsForAdapters(repoRoot, candidates)
+}
+
+func reconcileSelectedSkills(repoRoot string, selected []adapterprotocol.SkillTarget) (*skillmanager.ReconcilePlan, error) {
+	var effectiveDesired skillmanager.DesiredSkills
+	plan, err := skillmanager.ReconcileUpdate(repoRoot, version.Version, func(desired skillmanager.DesiredSkills, targets []adapterprotocol.SkillTarget) (skillmanager.DesiredSkills, []adapterprotocol.SkillTarget, error) {
+		targets = append(targets, selected...)
+		var err error
+		targets, err = skillmanager.CanonicalizeTargets(repoRoot, targets)
+		if err != nil {
+			return desired, nil, err
+		}
+		for _, id := range skills.DefaultBundleIDs() {
+			desired = skillmanager.AddBundles(desired, id)
+		}
+		desired = skillmanager.AddTargets(desired, selected...)
+		effectiveDesired = desired
+		return desired, targets, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	cleanupLegacyClaudeCommands(repoRoot, effectiveDesired, selected)
+	return plan, nil
+}
+
+func cleanupLegacyClaudeCommands(repoRoot string, desired skillmanager.DesiredSkills, targets []adapterprotocol.SkillTarget) {
+	var hasClaude bool
+	for _, target := range targets {
+		if target.Root == ".claude/skills" {
+			hasClaude = true
+			break
+		}
+	}
+	if !hasClaude {
+		return
+	}
+	var bundles []string
+	for _, bundle := range desired.Bundles {
+		bundles = append(bundles, bundle.ID)
+	}
+	names, err := skills.BundleNames(bundles)
+	if err != nil {
+		return
+	}
+	names = append(names, desired.Names...)
+	for _, name := range names {
+		path := filepath.Join(repoRoot, ".claude", "commands", name+".md")
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			continue
+		}
+		if hash, _, _ := adapterstamp.ExtractStampAnywhere(data, "ox"); hash != "" {
+			if err := os.Remove(path); err != nil {
+				slog.Warn("skills: failed to remove superseded Claude command", "path", path, "error", err)
+			}
+		}
+	}
+}
+
+func planCommittedSkills(repoRoot string) (*skillmanager.ReconcilePlan, error) {
+	desired, targets, err := committedSkillState(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	return skillmanager.Plan(repoRoot, version.Version, desired, targets)
+}
+
+func reconcileCommittedSkills(repoRoot string) (*skillmanager.ReconcilePlan, error) {
+	return skillmanager.ReconcileUpdate(repoRoot, version.Version, func(current skillmanager.DesiredSkills, currentTargets []adapterprotocol.SkillTarget) (skillmanager.DesiredSkills, []adapterprotocol.SkillTarget, error) {
+		if len(current.Targets) > 0 {
+			return current, currentTargets, nil
+		}
+		return bootstrapLegacySkillState(repoRoot, current, currentTargets)
+	})
+}
+
+func committedSkillState(repoRoot string) (skillmanager.DesiredSkills, []adapterprotocol.SkillTarget, error) {
+	desired, targets, err := skillmanager.LoadDesired(repoRoot)
+	if err != nil {
+		return skillmanager.DesiredSkills{}, nil, err
+	}
+	return bootstrapLegacySkillState(repoRoot, desired, targets)
+}
+
+func bootstrapLegacySkillState(repoRoot string, desired skillmanager.DesiredSkills, targets []adapterprotocol.SkillTarget) (skillmanager.DesiredSkills, []adapterprotocol.SkillTarget, error) {
+	if len(desired.Targets) == 0 {
+		candidates, detectErr := detectedSkillTargets(repoRoot)
+		if detectErr != nil {
+			return skillmanager.DesiredSkills{}, nil, detectErr
+		}
+		for _, target := range candidates {
+			legacyBundles, legacyErr := skillmanager.LegacyBundles(repoRoot, target)
+			if legacyErr != nil {
+				return skillmanager.DesiredSkills{}, nil, legacyErr
+			}
+			if len(legacyBundles) > 0 {
+				targets = append(targets, target)
+				desired = skillmanager.AddTargets(desired, target)
+				desired = skillmanager.AddBundles(desired, legacyBundles...)
+			}
+		}
+		if len(desired.Targets) > 0 {
+			for _, id := range skills.DefaultBundleIDs() {
+				desired = skillmanager.AddBundles(desired, id)
+			}
+		}
+	}
+	return desired, targets, nil
+}
+
+func addSkillBundle(repoRoot, bundle string) (*skillmanager.ReconcilePlan, error) {
+	desired, targets, err := skillmanager.LoadDesired(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(desired.Targets) == 0 {
+		targets, err = detectedSkillTargets(repoRoot)
+		if err != nil {
+			return nil, err
+		}
+		if len(targets) == 0 {
+			return nil, fmt.Errorf("no detected AI coworker supports native Agent Skills; Attest remains available through the ox CLI")
+		}
+		desired = skillmanager.DefaultDesired(targets)
+	}
+	return skillmanager.ReconcileUpdate(repoRoot, version.Version, func(current skillmanager.DesiredSkills, currentTargets []adapterprotocol.SkillTarget) (skillmanager.DesiredSkills, []adapterprotocol.SkillTarget, error) {
+		if len(current.Targets) == 0 {
+			current = desired
+			currentTargets = targets
+		}
+		current = skillmanager.AddBundles(current, bundle)
+		return current, currentTargets, nil
+	})
+}
+
+func uninstallManagedSkills(repoRoot string) (*skillmanager.ReconcilePlan, error) {
+	// Include detected descriptors only to migrate and remove old stamped
+	// projections from projects that predate the manifest.
+	detected, err := detectedSkillTargets(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	return skillmanager.ReconcileUpdate(repoRoot, version.Version, func(current skillmanager.DesiredSkills, currentTargets []adapterprotocol.SkillTarget) (skillmanager.DesiredSkills, []adapterprotocol.SkillTarget, error) {
+		currentTargets = append(currentTargets, detected...)
+		var err error
+		currentTargets, err = skillmanager.CanonicalizeTargets(repoRoot, currentTargets)
+		if err != nil {
+			return current, nil, err
+		}
+		current.Targets = nil
+		return current, currentTargets, nil
+	})
+}

--- a/cmd/ox/skill_reconcile_test.go
+++ b/cmd/ox/skill_reconcile_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sageox/agentx"
+	"github.com/sageox/ox/internal/skillmanager"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+func TestCleanupLegacyClaudeCommandsPreservesUserFiles(t *testing.T) {
+	repo := t.TempDir()
+	commands := filepath.Join(repo, ".claude", "commands")
+	if err := os.MkdirAll(commands, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managed := filepath.Join(commands, "ox-plan.md")
+	user := filepath.Join(commands, "ox-recap.md")
+	if err := os.WriteFile(managed, agentx.StampedContent([]byte("managed\n"), "1.0.0", "ox"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(user, []byte("user owned\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	desired := skillmanager.DesiredSkills{Bundles: []skillmanager.BundleRef{{ID: "core"}}, Targets: []string{"claude-project"}}
+	targets := []adapterprotocol.SkillTarget{{
+		Key: "claude-project", Root: ".claude/skills",
+		Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+		LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+	}}
+	cleanupLegacyClaudeCommands(repo, desired, targets)
+	if _, err := os.Stat(managed); !os.IsNotExist(err) {
+		t.Fatalf("managed legacy command remains: %v", err)
+	}
+	if _, err := os.Stat(user); err != nil {
+		t.Fatalf("user command was removed: %v", err)
+	}
+}

--- a/cmd/ox/uninstall.go
+++ b/cmd/ox/uninstall.go
@@ -689,13 +689,13 @@ func cleanupAgentFiles(gitRoot string) error {
 				slog.Warn("failed to remove rules", "adapter", ea.Name(), "error", err)
 			}
 		}
-		if ea.HasCapability(adapterprotocol.CapSkillsInstaller) {
-			if uninstallDryRun {
-				slog.Info("would remove skills", "adapter", ea.Name())
-			} else if _, err := ea.UninstallSkills(gitRoot, ""); err != nil {
-				slog.Warn("failed to remove skills", "adapter", ea.Name(), "error", err)
-			}
-		}
+	}
+	if uninstallDryRun {
+		slog.Info("would remove managed project skills")
+	} else if plan, err := uninstallManagedSkills(gitRoot); err != nil {
+		slog.Warn("failed to remove managed project skills", "error", err)
+	} else if len(plan.Conflicts) > 0 {
+		slog.Warn("preserved modified managed skill files during uninstall", "count", len(plan.Conflicts))
 	}
 
 	// remove ox:prime markers from all known agent instruction files

--- a/docs/adr/ADR-023-appendix-A-floor-audit.md
+++ b/docs/adr/ADR-023-appendix-A-floor-audit.md
@@ -4,7 +4,7 @@
 
 > **Status (post-implementation — `ox-fvjh` shipped):** this audit is the *point-in-time evidence base* that drove the epic; the verdict table below intentionally records the **pre-remediation** state. Since the audit:
 > - **`ox-cart-start` — RESOLVED in `ox-fvjh.6`.** `runCartsStart` now emits a portable `guidance` field in its `--json` output (`cmd/ox/carts.go`, `cartStartGuidance`); regression test `cmd/ox/carts_test.go` `TestCartStartGuidancePortable` fails if it leaks a host-specific token like `/rename`. Codex/Droid now receive the naming intent.
-> - **`ox-plan.md` and `ox-session-review.md` — migrated to skills in `ox-fvjh.7`.** They now live at `extensions/claude/skills/<id>/SKILL.md`, so **2 of the 16 files below are no longer commands**. Read the table as the audit's findings, not the current on-disk layout.
+> - **`ox-plan.md` and `ox-session-review.md` — migrated to skills in `ox-fvjh.7`.** They now live at `extensions/skills/<id>/SKILL.md`, so **2 of the 16 files below are no longer commands**. Read the table as the audit's findings, not the current on-disk layout.
 
 ## What this audits
 

--- a/docs/guides/adapter-authoring.md
+++ b/docs/guides/adapter-authoring.md
@@ -144,6 +144,12 @@ func runInfo() {
         Type:            "session",
         Capabilities:    []string{"session_reader", "hook_installer", "incremental_reader", "serve_mode"},
         HookEnvValues:   []string{"myagent"},
+		SkillTargets: []adapterprotocol.SkillTarget{{
+			Key: "myagent-project", Root: ".agents/skills",
+			Format: adapterprotocol.SkillFormatAgentSkillsV1,
+			Scope: adapterprotocol.SkillScopeProject,
+			LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+		}},
         ServeMode:       true,
     })
 }
@@ -158,6 +164,13 @@ func runInfo() {
 | `incremental_reader` | Implements `read-from-offset` (required for serve mode) |
 | `serve_mode` | Supports `--serve` flag |
 | `file_watcher` | Pushes entry events automatically after `find-session` (no explicit subscribe) |
+| `skills_installer` | Implements the compatibility skill RPCs; native-capable adapters should also declare `skill_targets` so ox can centrally reconcile and deduplicate projections |
+
+**`skill_targets`** — optional native Agent Skills discovery roots. Roots must
+be project-relative. Multiple adapters may declare the same target key/root;
+ox writes that projection once. New adapters should use target descriptors;
+the imperative install/check/uninstall RPCs remain for one compatibility
+release.
 
 **`hook_env_values`** — the value(s) of `AGENT_ENV` that your hook installs. ox uses this to
 route hook calls to your adapter. Must match what your `install-hooks` writes.

--- a/docs/guides/agent-compatibility.md
+++ b/docs/guides/agent-compatibility.md
@@ -22,7 +22,7 @@ ox works with multiple AI coding agents. Support depth varies by agent — here'
 | Lifecycle hooks | ✅ | ✅ | ✅ | ✅ | plugin | plugin | — | — | ✅ |
 | Whisper push | ✅ | ✅ | fallback | fallback | — | — | — | — | ✅ |
 | Team rules install | ✅ | — | — | ✅ | — | — | — | — | — |
-| Skills / commands install | ✅ | — | — | — | — | — | — | — | — |
+| Skills / commands install | ✅ | ✅ | ✅ | — | — | — | — | — | — |
 | Anti-entropy recovery | ✅ | — | — | — | — | — | — | — | — |
 
 **Auto-prime** means a hook or plugin runs `ox agent prime` for you. Where it's absent,
@@ -57,6 +57,20 @@ ox init        # sets up everything automatically
 ox doctor      # verifies hooks + context injection
 ```
 No extra setup needed — Claude Code is the reference implementation.
+
+Teams using Attest can additionally install its customer-journey BDD and
+evidence-recording playbooks with `ox attest install`. They are opt-in skills,
+not lifecycle hooks; use `ox integrate install` to manage hooks.
+
+## Canonical Agent Skills
+
+ox authors every portable playbook once in `extensions/skills/`, in the open
+Agent Skills `SKILL.md` format. Claude Code receives a managed copy under
+`.claude/skills/`; Codex, ChatGPT desktop's Codex surface, and Gemini CLI
+receive the same managed skill under `.agents/skills/`. `ox doctor --fix`
+reconciles the project-selected native targets, including updates, retired
+ox-owned files, and a partially installed Attest bundle, while preserving
+user-authored additions and modified managed files.
 
 ### Codex
 ```bash

--- a/docs/plans/2026-07-18-ox-decision.md
+++ b/docs/plans/2026-07-18-ox-decision.md
@@ -53,12 +53,12 @@ Zero-config default: `docs/adr`, `docs/decisions`, `adr`, `docs/architecture/dec
 **Prime + skill + doctor:**
 - `<decision-record-guidance>` block in `ox agent prime` — **gated on a corpus actually existing** (zero tokens for DR-less repos): consult-before-drafting, crediting contract, amendment rule (dated markers on Accepted DRs, never silent rewrites), verify-before-commit, credit cap.
 - Intent row (`ox decision enrich`) + consult-first route (drift-tested against the ox-consult skill description, which now names `ox decision`).
-- Thin-relay skill `extensions/claude/skills/ox-decision/SKILL.md` (activation ergonomics only).
+- Thin-relay skill `extensions/skills/ox-decision/SKILL.md` (activation ergonomics only).
 - Doctor `decision-paths` check: schema errors fail; configured paths matching zero DRs warn; no config → skip.
 
 ## Files (v1)
 
-`internal/config/decision.go` (+ `Decision` field on ProjectConfig, validation hook) · `internal/decision/{types,input,sources,parse,search,detectors,retrievers,enrich,guidance}.go` · `cmd/ox/decision.go` · `internal/plan/decision_bundle.go` + `annotate.go` regex extension · `cmd/ox/agent_prime_xml.go` (`writeDecisionRecordGuidance`) · `internal/prime/{guidance,capability_table}.go` · `extensions/claude/skills/{ox-decision,ox-consult}/SKILL.md` · `cmd/ox/doctor_decision.go` · dep `bmatcuk/doublestar/v4` (MIT) · CHANGELOG · generated `docs/reference/decision/`.
+`internal/config/decision.go` (+ `Decision` field on ProjectConfig, validation hook) · `internal/decision/{types,input,sources,parse,search,detectors,retrievers,enrich,guidance}.go` · `cmd/ox/decision.go` · `internal/plan/decision_bundle.go` + `annotate.go` regex extension · `cmd/ox/agent_prime_xml.go` (`writeDecisionRecordGuidance`) · `internal/prime/{guidance,capability_table}.go` · `extensions/skills/{ox-decision,ox-consult}/SKILL.md` · `cmd/ox/doctor_decision.go` · dep `bmatcuk/doublestar/v4` (MIT) · CHANGELOG · generated `docs/reference/decision/`.
 
 > **[Ryan review — required]** data-location config: `decision.paths` shape + default dir list. (Settled in this session's review; recorded here for the PR.)
 

--- a/docs/specs/plan-render-adoption.md
+++ b/docs/specs/plan-render-adoption.md
@@ -128,7 +128,7 @@ push is worse than none).
 
 | Layer | State | Where |
 |---|---|---|
-| L1 | **Shipped** — `ox-plan` skill description leads with the capability (team context + ledger + review loop) and wins plan-render intent | `extensions/claude/skills/ox-plan/SKILL.md` |
+| L1 | **Shipped** — `ox-plan` skill description leads with the capability (team context + ledger + review loop) and wins plan-render intent | `extensions/skills/ox-plan/SKILL.md` |
 | L2 | **Shipped** — `buildGuidance` leads with the computed collision / expert-route / prior-art counts | `internal/plan/diagram_hints.go` (`guidanceLead`) |
 | Push tier | **Shipped** — content-aware viz suggestion now covers the parameterized catalog (`viz_hints`), not just Mermaid; matched by reviewed catalog tags shared with `ox viz suggest` | `internal/plan/diagram_hints.go` (`computeVizHints`) |
 | L4 | **Shipped** — capability line in the prime advisory | `cmd/ox/agent_prime_xml.go` (`writePlanEnrichmentGuidance`) |

--- a/docs/specs/skill-activation-design.md
+++ b/docs/specs/skill-activation-design.md
@@ -16,7 +16,7 @@ This insight comes from analyzing [beads PR #718](https://github.com/steveyegge/
 
 ## The Thin/Thick Convention (one rule, three names)
 
-"Keep ox-* skills thin" is not three policies — it is one rule with three names. **Thin-relay == cross-agent-conformance == staleness-safety.** They describe the same boundary in the [two-layer skill-injection model](../adr/ADR-023-skill-injection-two-layer-model.md): the deterministic behavioral floor lives in **Layer 1** (the live `ox` CLI's JSON/text output, piped into agent context via the prime marker) and reaches every adapter; **Layer 2** is the agent-specific shell (Claude skills/commands, Codex hooks, Droid rules) and is strictly additive.
+"Keep ox-* skills thin" is not three policies — it is one rule with three names. **Thin-relay == cross-agent-conformance == staleness-safety.** They describe the same boundary in the [two-layer skill-injection model](../adr/ADR-023-skill-injection-two-layer-model.md): the deterministic behavioral floor lives in **Layer 1** (the live `ox` CLI's JSON/text output, piped into agent context via the prime marker) and reaches every adapter; **Layer 2** is an additive native surface (portable Agent Skills for Claude, Codex, and Gemini; Claude commands; Droid rules).
 
 ### Governing rule
 
@@ -24,8 +24,8 @@ This insight comes from analyzing [beads PR #718](https://github.com/steveyegge/
 
 ### Why the three names are one boundary
 
-- **Thin-relay → cross-agent conformance.** Any behavioral guidance authored only in a Claude command/skill body is, by construction, invisible to Codex (installs hooks only, `cmd/ox-adapter-codex/main.go`) and Droid (installs hooks + rules, no commands, `cmd/ox-adapter-droid/main.go`). Those adapters install no command files, so a thin-relay violation **IS** a cross-agent gap: the Codex/Droid user silently loses behavior the Claude user gets.
-- **Layer 1 → staleness safety.** Layer 1 is always the live binary; it cannot drift from the code. Installed Layer-2 command files are copied from `extensions/claude/commands/*.md` (embedded via `extensions/claude/embed.go` `CommandFS`) and stamped with an `ox-hash`+version marker (`oxStampPrefix` in `cmd/ox-adapter-claude-code/commands.go`). A copied body **can** go stale; the binary's `guidance` **cannot**. Keeping floor behavior in Layer 1 is what the staleness stamp protects.
+- **Thin-relay → cross-agent conformance.** Portable skills reach Claude, Codex, and Gemini through their native mechanisms, but commands and rules remain host-specific and some AI coworkers have no native skill mechanism. Floor behavior therefore still belongs in prime/CLI output; otherwise support depth depends on the host surface.
+- **Layer 1 → staleness safety.** Layer 1 is always the live binary; it cannot drift from the code. Installed native skills are lockfile-owned projections of `extensions/skills/`; Claude commands remain stamped copies. A copied body **can** go stale; the binary's `guidance` **cannot**. Keeping floor behavior in Layer 1 minimizes rollout drift even though Doctor can now reconcile the complete skill tree.
 
 ### Author decision checklist
 
@@ -34,7 +34,7 @@ For each piece of content you are about to author, route it by the first matchin
 - **(a) Is this floor / behavioral guidance** — use-when triggers, post-command branching, error handling, consult cues? → It belongs in **Layer 1**: the ox subcommand's JSON `guidance` field, NOT the skill body.
 - **(b) Is it behavioral AND backed by a single ox subcommand?** → **Thin relay only.** The body is a pointer to `ox <subcommand> --json` plus a one-line description. No behavioral copy in the body.
 - **(c) Is it agent-side orchestration NOT backed by a single ox subcommand** — a Claude-specific rendering spec or a multi-step flow? → **Thickness is ALLOWED, and only here.** See the sanctioned examples below.
-- **(d) Could a Codex or Droid user need this?** → Then it **MUST** reach Layer 1, regardless of (a)–(c). If it only lives in a Claude body, it is trapped floor behavior and must be moved.
+- **(d) Could an AI coworker without this native surface need it?** → Then it **MUST** reach Layer 1, regardless of (a)–(c). Host-specific bodies cannot carry the product floor.
 
 ### Content kind → layer → mechanism
 
@@ -51,13 +51,13 @@ For each piece of content you are about to author, route it by the first matchin
 A skill body may be thick **only when ALL of the following hold**:
 
 1. The content is **not backed by a single ox subcommand** (no relay would capture it).
-2. It is **Claude-specific orchestration or a rendering spec** — agent shell ergonomics, not portable behavior.
+2. It is **agent-specific orchestration or a rendering spec** — agent shell ergonomics, not portable behavior.
 3. It **traps no floor behavior** — nothing a Codex/Droid user would also need lives only here.
 
 Two skills are the sanctioned thick examples:
 
-- `extensions/claude/skills/ox-plan/SKILL.md` — carries the **judgment-badge and rich-page authoring flow**: reasoning the `ox plan enrich` context bundle into cited, section-anchored badges, then authoring the purpose-built `plan.html` that becomes the plan of record. The binary injects SageOx chrome and derives `plan.md`; it does not replace the authored page with a generic renderer.
-- `extensions/claude/skills/ox-session-review/SKILL.md` — carries the **audit + regeneration flow**, which is not backed by a single ox subcommand.
+- `extensions/skills/ox-plan/SKILL.md` — carries the **judgment-badge and rich-page authoring flow**: reasoning the `ox plan enrich` context bundle into cited, section-anchored badges, then authoring the purpose-built `plan.html` that becomes the plan of record. The binary injects SageOx chrome and derives `plan.md`; it does not replace the authored page with a generic renderer.
+- `extensions/skills/ox-session-review/SKILL.md` — carries the **audit + regeneration flow**, which is not backed by a single ox subcommand.
 
 Everything else is thin. If you are unsure whether content clears the gate, it does not: route it to Layer 1.
 

--- a/docs/specs/skill-management.md
+++ b/docs/specs/skill-management.md
@@ -1,0 +1,116 @@
+# Native-First, Project-Scoped Skill Management
+
+SageOx authors each playbook once in the portable Agent Skills layout:
+
+```text
+extensions/skills/<skill>/
+  SKILL.md
+  references/     # optional
+  assets/         # optional
+  scripts/        # optional
+```
+
+The embedded catalog is the built-in source of truth. `core` is selected by
+default; `attest` is opt-in. Authenticated Team Context sources may extend the
+catalog later, but must use the same Plan/Apply engine rather than introduce a
+second installer or activation framework.
+
+## Native targets
+
+Adapters declare target descriptors instead of independently managing files:
+
+```go
+type SkillTarget struct {
+    Key        string
+    Root       string
+    Format     string
+    Scope      string
+    LinkPolicy string
+}
+```
+
+The CLI validates repository-relative paths and deduplicates targets by their
+canonical root and format. Codex and Gemini therefore produce one shared
+`.agents/skills` projection and one truthful change count.
+
+| AI coworker | Target | Format |
+|---|---|---|
+| Claude Code | `.claude/skills/<skill>/` | Native Agent Skills |
+| Codex | `.agents/skills/<skill>/` | Portable Agent Skills |
+| Gemini CLI | `.agents/skills/<skill>/` | Portable Agent Skills (shared with Codex) |
+| AI coworker without native skills | None | Future Skill Bridge; not implemented speculatively |
+
+All managed targets are project-scoped. Native discovery and activation remain
+authoritative; SageOx does not replace vendor-trained routing with hooks, a
+bootloader, or an MCP page-fault path.
+
+## Desired state and ownership
+
+`.sageox/skills.lock.json` records:
+
+- built-in source revision and ox version;
+- selected bundle IDs and target keys;
+- normalized target descriptor snapshots;
+- every managed file's repository-relative path, SHA-256 digest, and mode.
+
+The lockfile—not an inline comment—is the ownership source. Existing
+`ox-hash` stamps are accepted for one-release migration only when their body
+hash verifies. New projections contain clean canonical Agent Skills content.
+
+`Plan` is deterministic, read-only, and considers the complete skill tree:
+`SKILL.md`, references, assets, and scripts. It classifies creates, updates,
+removals, conflicts, and preserved files. `Apply` performs recoverable
+per-file changes and commits the lockfile last.
+
+Ownership rules are deliberately conservative:
+
+- update or remove a file only when its current digest matches the last
+  installed digest;
+- recreate a recorded file that is missing;
+- preserve user additions, unknown collisions, and modified managed files;
+- remove unchanged retired files and clean only empty directories;
+- on uninstall, preserve a modified retired file but relinquish ownership so
+  it does not become a permanent Doctor conflict;
+- reject symlinked targets, parent directories, lockfiles, and managed files.
+
+Apply writes `.sageox/cache/skills-apply.json` before target mutation. The
+journal records each old/new digest pair. If a process exits before the
+lockfile commit, the next Plan accepts only the previous or journaled digest,
+finishes the operation, commits the manifest, and removes the journal. This
+distinguishes interrupted SageOx writes from coincidentally similar user files.
+
+## Lifecycle
+
+- `ox init` adds only the targets selected for that invocation and persists
+  them. It never equates later agent detection with authorization.
+- `ox doctor` plans only committed targets. For the one-release migration, a
+  target with a valid legacy stamp may bootstrap selection.
+- `ox doctor --fix` applies the plan and preserves conflicts.
+- `ox attest install` adds the `attest` bundle once, then reconciles the
+  deduplicated committed targets.
+- uninstall removes unchanged owned files once across all targets.
+- an upgrade converges on the next explicit Doctor/init lifecycle operation;
+  the old process does not attempt to execute a newly installed catalog.
+
+The daemon does not schedule an AI coworker to perform deterministic skill
+repair. Explicit lifecycle commands own reconciliation. Current desired state
+produces an empty plan and no daemon task.
+
+The imperative adapter RPCs remain for one compatibility release. Built-in
+adapters and CLI workflows use target descriptors and central reconciliation.
+
+## Team Context follow-on
+
+Team Context transport is a separate authenticated source boundary. A future
+manifest must identify bundle, revision, file digests, provenance, and script
+approval policy. It will feed the existing portable catalog and Plan/Apply
+engine. The API source of truth and storage ergonomics require their own human
+review and are intentionally not selected here.
+
+## Skill Bridge follow-on
+
+Only an AI coworker that genuinely lacks native skill discovery should receive
+a compact catalog through `ox agent prime` and activate a playbook through a
+future `ox skill activate <id> --json` or equivalent MCP tool. Native-capable
+AI coworkers continue receiving real native skills. Enabling the bridge for a
+native-capable client requires measured activation-quality evidence first.

--- a/extensions/claude/embed.go
+++ b/extensions/claude/embed.go
@@ -4,10 +4,3 @@ import "embed"
 
 //go:embed commands/*.md
 var CommandFS embed.FS
-
-// SkillFS embeds the per-skill directory tree (skills/<name>/SKILL.md).
-// Unlike CommandFS (one .md per command), skills are directories, so the
-// embed uses `all:skills` to capture the nested SKILL.md files.
-//
-//go:embed all:skills
-var SkillFS embed.FS

--- a/extensions/skills/catalog.go
+++ b/extensions/skills/catalog.go
@@ -1,0 +1,288 @@
+// Package skills owns ox's canonical Agent Skills source tree and catalog.
+package skills
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const SkillFileName = "SKILL.md"
+
+var skillNameRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// Bundle is the stable unit of installation and future Team Context sync.
+// Team Context transport adds provenance and trust metadata around this model;
+// it must not change the local installer contract.
+type Bundle struct {
+	ID          string
+	Description string
+	Default     bool
+	SkillIDs    []string
+}
+
+// Catalog is intentionally a slice: declaration order is the human-facing
+// order, while selection below remains deterministic and duplicate-safe.
+var Catalog = []Bundle{
+	{ID: "core", Description: "Everyday SageOx workflows and skill manager", Default: true, SkillIDs: []string{"ox-consult", "ox-decision", "ox-plan", "ox-recap", "ox-session-review", "ox-skill-manager"}},
+	{ID: "attest", Description: "Optional Attest BDD and evidence playbooks", SkillIDs: []string{"ox-attest-goal", "ox-attest-create"}},
+}
+
+// Skill is one complete canonical skill directory. Files are relative to the
+// skill root and include SKILL.md plus optional references/, assets/, scripts/.
+type Skill struct {
+	Name    string
+	Content []byte // SKILL.md, retained for simple adapter consumers.
+	Files   []File
+	Version string
+}
+
+type File struct {
+	Path    string
+	Content []byte
+}
+
+func BundleNames(ids []string) ([]string, error) {
+	byID := make(map[string]Bundle, len(Catalog))
+	for _, bundle := range Catalog {
+		byID[bundle.ID] = bundle
+	}
+	var names []string
+	for _, id := range ids {
+		bundle, ok := byID[id]
+		if !ok {
+			return nil, fmt.Errorf("unknown ox skill bundle %q", id)
+		}
+		names = append(names, bundle.SkillIDs...)
+	}
+	return names, nil
+}
+
+func DefaultBundleIDs() []string {
+	var ids []string
+	for _, bundle := range Catalog {
+		if bundle.Default {
+			ids = append(ids, bundle.ID)
+		}
+	}
+	return ids
+}
+
+// Digest is a stable identity for the complete catalog source. Schedulers use
+// it as a dedupe key; it is not a signature or a Team Context trust decision.
+func Digest() (string, error) {
+	if err := Validate(); err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	for _, bundle := range Catalog {
+		_, _ = h.Write([]byte(bundle.ID + "\x00"))
+		for _, name := range bundle.SkillIDs {
+			skill, err := readSkill(name, "")
+			if err != nil {
+				return "", err
+			}
+			_, _ = h.Write([]byte(name + "\x00"))
+			for _, file := range skill.Files {
+				_, _ = h.Write([]byte(file.Path + "\x00"))
+				_, _ = h.Write(file.Content)
+			}
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16], nil
+}
+
+func SelectedBundles(version string, names, bundleIDs []string) ([]Skill, error) {
+	if len(bundleIDs) == 0 {
+		return Selected(version, names)
+	}
+	bundleNames, err := BundleNames(bundleIDs)
+	if err != nil {
+		return nil, err
+	}
+	return Selected(version, append(names, bundleNames...))
+}
+
+func IsKnown(name string) bool {
+	_, err := fs.ReadFile(FS, path.Join(name, SkillFileName))
+	return err == nil
+}
+
+// Validate checks the embedded source against the portable Agent Skills shape
+// before it is installed anywhere. It is deliberately strict about layout and
+// identity but does not execute or interpret scripts/assets.
+func Validate() error {
+	return validateSource(FS, Catalog)
+}
+
+func validateSource(source fs.FS, catalog []Bundle) error {
+	seenBundles := map[string]struct{}{}
+	declared := map[string]struct{}{}
+	for _, bundle := range catalog {
+		if bundle.ID == "" || !skillNameRE.MatchString(bundle.ID) {
+			return fmt.Errorf("invalid skill bundle id %q", bundle.ID)
+		}
+		if _, ok := seenBundles[bundle.ID]; ok {
+			return fmt.Errorf("duplicate skill bundle %q", bundle.ID)
+		}
+		seenBundles[bundle.ID] = struct{}{}
+		if strings.TrimSpace(bundle.Description) == "" || len(bundle.SkillIDs) == 0 {
+			return fmt.Errorf("skill bundle %q needs a description and skills", bundle.ID)
+		}
+		for _, name := range bundle.SkillIDs {
+			if !skillNameRE.MatchString(name) {
+				return fmt.Errorf("invalid skill name %q in bundle %q", name, bundle.ID)
+			}
+			declared[name] = struct{}{}
+		}
+	}
+	entries, err := fs.ReadDir(source, ".")
+	if err != nil {
+		return fmt.Errorf("read canonical skills: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			// The embed package's Go sources share this directory with the
+			// canonical skill folders. Only directories participate in the
+			// portable skill source tree.
+			continue
+		}
+		name := entry.Name()
+		if !skillNameRE.MatchString(name) {
+			return fmt.Errorf("invalid canonical skill directory %q", name)
+		}
+		if _, ok := declared[name]; !ok {
+			return fmt.Errorf("canonical skill %q is not in a bundle", name)
+		}
+		content, err := fs.ReadFile(source, path.Join(name, SkillFileName))
+		if err != nil {
+			return fmt.Errorf("canonical skill %q has no %s: %w", name, SkillFileName, err)
+		}
+		if err := validateFrontmatter(name, string(content)); err != nil {
+			return err
+		}
+		if err := fs.WalkDir(source, name, func(file string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if file == name || d.IsDir() {
+				return nil
+			}
+			rel := strings.TrimPrefix(file, name+"/")
+			if rel != SkillFileName && !strings.HasPrefix(rel, "references/") && !strings.HasPrefix(rel, "assets/") && !strings.HasPrefix(rel, "scripts/") {
+				return fmt.Errorf("canonical skill %q has unsupported file %q", name, rel)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	for name := range declared {
+		if _, err := fs.ReadFile(source, path.Join(name, SkillFileName)); err != nil {
+			return fmt.Errorf("bundle declares missing canonical skill %q", name)
+		}
+	}
+	return nil
+}
+
+func validateFrontmatter(name, content string) error {
+	if !strings.HasPrefix(content, "---\n") {
+		return fmt.Errorf("canonical skill %q must start with YAML frontmatter", name)
+	}
+	end := strings.Index(content[4:], "\n---\n")
+	if end < 0 {
+		return fmt.Errorf("canonical skill %q has unterminated frontmatter", name)
+	}
+	fm := content[4 : end+4]
+	var foundName, description string
+	for _, line := range strings.Split(fm, "\n") {
+		if value, ok := strings.CutPrefix(line, "name:"); ok {
+			foundName = strings.Trim(strings.TrimSpace(value), "\"")
+		}
+		if value, ok := strings.CutPrefix(line, "description:"); ok {
+			description = strings.TrimSpace(value)
+		}
+	}
+	if foundName != name {
+		return fmt.Errorf("canonical skill %q frontmatter name is %q", name, foundName)
+	}
+	if description == "" {
+		// Folded YAML values are accepted when a subsequent indented line exists.
+		if !strings.Contains(fm, "description: >") && !strings.Contains(fm, "description: |") {
+			return fmt.Errorf("canonical skill %q has no description", name)
+		}
+	}
+	return nil
+}
+
+func Selected(version string, names []string) ([]Skill, error) {
+	if err := Validate(); err != nil {
+		return nil, err
+	}
+	requested := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		requested[name] = struct{}{}
+	}
+	named := len(names) > 0
+	var out []Skill
+	for _, bundle := range Catalog {
+		if !named && !bundle.Default {
+			continue
+		}
+		for _, name := range bundle.SkillIDs {
+			if named {
+				if _, ok := requested[name]; !ok {
+					continue
+				}
+				delete(requested, name)
+			}
+			skill, err := readSkill(name, version)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, skill)
+		}
+	}
+	if len(requested) > 0 {
+		unknown := make([]string, 0, len(requested))
+		for name := range requested {
+			unknown = append(unknown, name)
+		}
+		sort.Strings(unknown)
+		return nil, fmt.Errorf("unknown ox skill(s): %v", unknown)
+	}
+	return out, nil
+}
+
+func readSkill(name, version string) (Skill, error) {
+	var files []File
+	err := fs.WalkDir(FS, name, func(file string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+		content, err := fs.ReadFile(FS, file)
+		if err != nil {
+			return err
+		}
+		rel := strings.TrimPrefix(file, name+"/")
+		files = append(files, File{Path: rel, Content: content})
+		return nil
+	})
+	if err != nil {
+		return Skill{}, fmt.Errorf("read canonical skill %s: %w", name, err)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	var content []byte
+	for _, file := range files {
+		if file.Path == SkillFileName {
+			content = file.Content
+			break
+		}
+	}
+	return Skill{Name: name, Content: content, Files: files, Version: version}, nil
+}

--- a/extensions/skills/catalog_test.go
+++ b/extensions/skills/catalog_test.go
@@ -1,0 +1,87 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestCanonicalCatalogValidAndDeterministic(t *testing.T) {
+	if err := Validate(); err != nil {
+		t.Fatalf("Validate() = %v", err)
+	}
+	first, err := SelectedBundles("1.0.0", nil, []string{"core", "attest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := SelectedBundles("1.0.0", nil, []string{"core", "attest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != len(second) || len(first) == 0 {
+		t.Fatalf("non-deterministic or empty catalog: %d / %d", len(first), len(second))
+	}
+	for i, skill := range first {
+		if skill.Name != second[i].Name || len(skill.Files) == 0 {
+			t.Fatalf("selection drift at %d: %#v / %#v", i, skill, second[i])
+		}
+		if !strings.HasPrefix(string(skill.Content), "---\nname: "+skill.Name+"\n") {
+			t.Fatalf("%s has non-portable frontmatter", skill.Name)
+		}
+	}
+
+	defaults, err := Selected("1.0.0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, skill := range defaults {
+		if strings.HasPrefix(skill.Name, "ox-attest-") {
+			t.Fatalf("opt-in skill %s leaked into default bundle", skill.Name)
+		}
+	}
+}
+
+func TestValidateRejectsUnsafeAndMalformedSources(t *testing.T) {
+	valid := "---\nname: safe\ndescription: safe\n---\nbody\n"
+	tests := []struct {
+		name    string
+		files   fstest.MapFS
+		catalog []Bundle
+		want    string
+	}{
+		{"missing skill", fstest.MapFS{}, []Bundle{{ID: "core", Description: "x", SkillIDs: []string{"safe"}}}, "missing canonical skill"},
+		{"name mismatch", fstest.MapFS{"safe/SKILL.md": {Data: []byte(strings.Replace(valid, "name: safe", "name: other", 1))}}, []Bundle{{ID: "core", Description: "x", SkillIDs: []string{"safe"}}}, "frontmatter name"},
+		{"unsupported root file", fstest.MapFS{"safe/SKILL.md": {Data: []byte(valid)}, "safe/escape.txt": {Data: []byte("x")}}, []Bundle{{ID: "core", Description: "x", SkillIDs: []string{"safe"}}}, "unsupported file"},
+		{"undeclared directory", fstest.MapFS{"safe/SKILL.md": {Data: []byte(valid)}}, []Bundle{{ID: "core", Description: "x", SkillIDs: []string{"other"}}}, "not in a bundle"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSource(tt.files, tt.catalog)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validateSource() = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestPortableSkillsAvoidHostSpecificActivationSyntax(t *testing.T) {
+	selected, err := SelectedBundles("1.0.0", nil, []string{"core", "attest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	banned := []string{
+		"runs /ox-",
+		"`/ox-",
+		"(/ox-",
+		"Claude-specific auto-activation",
+		"Skills are agent-specific wrappers",
+	}
+	for _, skill := range selected {
+		body := string(skill.Content)
+		for _, phrase := range banned {
+			if strings.Contains(body, phrase) {
+				t.Errorf("portable skill %s contains host-specific activation phrase %q", skill.Name, phrase)
+			}
+		}
+	}
+}

--- a/extensions/skills/embed.go
+++ b/extensions/skills/embed.go
@@ -1,0 +1,9 @@
+// Package skills owns ox's canonical Agent Skills source tree. Adapters install
+// these unchanged into their discovery roots; host-specific behavior belongs in
+// the adapter, not in a fork of the skill body.
+package skills
+
+import "embed"
+
+//go:embed all:*
+var FS embed.FS

--- a/extensions/skills/ox-attest-create/SKILL.md
+++ b/extensions/skills/ox-attest-create/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: ox-attest-create
+description: >-
+  Turn a demonstrated red/green Attest run pair into an honest portable proof.
+  Use when a user asks to attest, prove, stamp, record, publish, or explain a
+  BDD capability's evidence. Inspect `ox attest proof <capability>` and the
+  run artifacts first; use `ox attest record` only after a real red failure and
+  a green recovery demonstrate the customer claim.
+---
+
+<!-- This opt-in skill protects the meaning of an attestation. The CLI owns
+     record validation and freshness; this layer helps an AI coworker choose
+     evidence honestly before invoking it. -->
+
+## Create evidence, not a decorative stamp
+
+1. Start with `ox attest proof <capability>` and read the customer claim,
+   current verdict, and any prior evidence.
+2. Make the promised behavior fail in a way that lands on the claim step; save
+   the unedited failure text and its run ID.
+3. Restore the behavior, run the same scenario green, and retain that run ID.
+4. Describe the break in the language of the customer's promise. Name only
+   product surfaces the run actually exercised.
+5. Use `ox attest record` with both run IDs, the verbatim red failure, the
+   failed step, and the exercised surfaces. If the evidence is ambiguous or
+   incomplete, record that honestly rather than forcing a clean verdict.
+6. Run `ox attest status` and `ox attest check --json` afterward. Publish only
+   evidence that remains current and explain any stale or unknown result.

--- a/extensions/skills/ox-attest-goal/SKILL.md
+++ b/extensions/skills/ox-attest-goal/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: ox-attest-goal
+description: >-
+  Create or revise an Attest-backed customer capability as executable BDD.
+  Use when a user asks to add, improve, or review BDDs/customer scenarios for
+  an Attest corpus; especially when they mention customer flow, acceptance
+  criteria, Gherkin, Rules, or a capability that needs proof. Start from the
+  customer's desired journey, not the current implementation, then use
+  `ox attest status --json` to place the capability in the proof ladder.
+---
+
+<!-- This opt-in skill is deliberately about product judgment, not an
+     implementation-shaped test recipe. The Attest CLI remains the portable
+     source of truth for the capability corpus and proof state. -->
+
+## Customer journey before mechanics
+
+1. State the customer's goal, starting point, natural action, feedback, and
+   continuation or recovery.
+2. Preserve an established journey. Do not silently redesign it to make a
+   scenario easier to automate. If the journey is unclear, name the smallest
+   proposed flow and the product decision it needs.
+3. Write the `Rule:` as a customer-recognizable promise. Write scenarios in
+   observable language: what customers can do, see, retain, and recover from.
+   Do not put routes, status codes, database rows, selectors, or validation
+   regexes in Gherkin.
+4. Cover the happy path plus consequential failure, permission, and continuity
+   cases. Derive component/API/concurrency tests separately for the mechanics
+   that keep the promise true.
+
+## Ground the work in Attest
+
+1. Run `ox attest status --json` to understand the existing capability ladder.
+2. Find the relevant feature and keep one coherent customer promise per
+   `Rule:` block.
+3. Compile and run the project's existing acceptance workflow. Do not claim a
+   capability is proven until its run evidence supports it.
+4. Run `ox attest check --json` before handoff to identify proof invalidated by
+   the working diff.

--- a/extensions/skills/ox-consult/SKILL.md
+++ b/extensions/skills/ox-consult/SKILL.md
@@ -14,8 +14,8 @@ description: >-
 <!-- Thin by design. The authoritative consult-first reflex — the cues, the
      "confident-wrong is worse than slow" reasoning, and the routing rationale —
      lives in the <consult-first> block of `ox agent prime` (Layer-1 floor), which
-     reaches Claude, Codex, and Droid alike. This skill adds ONLY Claude-specific
-     auto-activation ergonomics; it duplicates no reasoning. Every command it
+     reaches every primed AI coworker. This native skill adds discovery and
+     activation ergonomics; it duplicates no reasoning. Every command it
      names is already reachable from the floor, so removing this skill loses
      ergonomics but never the floor. Do not grow this body. -->
 

--- a/extensions/skills/ox-decision/SKILL.md
+++ b/extensions/skills/ox-decision/SKILL.md
@@ -16,8 +16,8 @@ description: >-
      SageOx credit subtle and capped), amendment semantics, and ref
      verification — lives in the <decision-record-guidance> block of
      `ox agent prime` (Layer-1 floor) and in the `guidance` field of
-     `ox decision enrich` JSON, which reach Claude, Codex, and Droid alike.
-     This skill adds ONLY Claude-specific auto-activation ergonomics; it
+     `ox decision enrich` JSON, which reach every primed AI coworker.
+     This native skill adds discovery and activation ergonomics; it
      duplicates no behavior. Do not grow this body. -->
 
 ## Use when

--- a/extensions/skills/ox-plan/SKILL.md
+++ b/extensions/skills/ox-plan/SKILL.md
@@ -13,8 +13,8 @@ description: >-
   judgment badges (optional, via --annotations). Markdown-first survives only as
   the quick path for small, low-stakes plans. Use whenever the user wants a plan
   rendered or visualized as HTML — "render the plan", "make an HTML plan",
-  "show / visualize the plan", "turn this plan into a page", "plan as HTML" —
-  runs /ox-plan, or when `ox plan` reports material signals and the user
+  "show / visualize the plan", "turn this plan into a page", "plan as HTML",
+  or when `ox plan` reports material signals and the user
   confirms. Whether to render at all is decided by the `ox plan` JSON
   (signals.material, guidance) plus the user's confirmation / the `plan.html`
   config setting — not by this skill.

--- a/extensions/skills/ox-recap/SKILL.md
+++ b/extensions/skills/ox-recap/SKILL.md
@@ -15,8 +15,8 @@ description: >-
      ledger compounding as searchable memory), the honesty rules (never
      invent value, never lead with a bare statistic, ground every claim in a
      receipt), and the cold-start framing — lives in the `guidance` field of
-     `ox recap --json` (Layer-1 floor), which reaches Claude, Codex, and
-     Droid alike. This skill adds ONLY Claude-specific auto-activation
+     `ox recap --json` (Layer-1 floor), which reaches every primed AI
+     coworker. This native skill adds discovery and activation
      ergonomics; it duplicates no reasoning. Do not grow this body. -->
 
 ## Use when

--- a/extensions/skills/ox-session-review/SKILL.md
+++ b/extensions/skills/ox-session-review/SKILL.md
@@ -6,13 +6,13 @@ description: >-
   (the cache-only invariant and a failure-mode watch-list) that no single ox
   subcommand backs. Use when the user asks to "review the ledger sessions",
   "audit session quality", "clean up bad session summaries", "regenerate session
-  summaries", runs /ox-session-review, or wants to find and fix sessions with
+  summaries", invokes the session-review workflow, or wants to find and fix sessions with
   missing/poor titles, empty summaries, or broken metadata.
 ---
 
 <!-- Keep this file thin on behavioral guidance that belongs in `ox` CLI JSON
-     output (guidance field). Skills are agent-specific wrappers; ox serves all
-     agents (Codex, etc.). This skill is intentionally richer than most because
+     output (guidance field). Native skills are portable wrappers; ox serves all
+     AI coworkers. This skill is intentionally richer than most because
      the audit + regeneration flow is not backed by a single ox subcommand. -->
 
 This skill carries the operational knowledge from the 2026-04-25 cleanup
@@ -79,8 +79,7 @@ break LFS linkage. Stop and investigate before pushing.
 ### Removal Candidates
 - `entry_count` is `0` or missing AND `files` manifest is empty/missing.
 - Session outcome is `"failed"` AND `entry_count < 5`.
-- Only skill-wrapper activity with nothing between (`/ox-session-start`
-  → `/ox-session-stop`).
+- Only skill-wrapper activity with nothing between session start and stop.
 - Phantom-OID sessions surfaced during a previous Phase 4 run (track
   these — they cannot be regenerated).
 
@@ -303,7 +302,7 @@ When asked to review a different ledger, lead with:
 > Audit every session in this project's ledger for quality.
 > Read `.claude/rules/cache-only-design.md` and
 > `.claude/rules/lfs-no-git-lfs-binary.md` first — both invariants
-> apply during this audit. Run the `/ox-session-review` skill flow:
+> apply during this audit. Run the session-review skill flow:
 > scan read-only, report by bucket, confirm with me before any
 > removals or regenerations, and run the post-batch invariant check
 > before pushing.

--- a/extensions/skills/ox-skill-manager/SKILL.md
+++ b/extensions/skills/ox-skill-manager/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: ox-skill-manager
+description: >-
+  Manage SageOx Agent Skill bundles for this repository. Use when a user asks
+  which ox skills are available, wants to install or repair Attest playbooks,
+  or needs to understand how local coding agents receive team workflows.
+---
+
+## Manage bundled skills
+
+1. Treat a file as managed only when `.sageox/skills.lock.json` records its
+   installed digest. Inline ox stamps are migration evidence, not ownership.
+2. `ox init` and `ox doctor --fix` install and reconcile the default `core`
+   bundle for the project's selected native skill targets.
+3. Install the opt-in Attest bundle with `ox attest install`. Using another
+   `ox attest` command also attempts to install that bundle without making
+   Attest unavailable when installation cannot run.
+4. Canonical skill content lives in `extensions/skills/`. Claude Code receives
+   a managed `.claude/skills/` copy; standard-compatible clients receive a
+   managed `.agents/skills/` copy.
+5. For a missing, stale, partially installed, or retired ox-managed file, run
+   `ox doctor --fix`. It preserves user-owned additions and edits, and
+   reconciles only project-selected targets and bundles.
+
+Do not claim a team-synchronized skill has been installed unless the local ox
+CLI reports a successful reconciliation. Team Context synchronization requires
+an explicit managed bundle manifest and must never delete user-owned content.

--- a/internal/daemon/agentwork/task_producer_test.go
+++ b/internal/daemon/agentwork/task_producer_test.go
@@ -34,7 +34,8 @@ func TestProduceAgentTasks_DoctorMarker(t *testing.T) {
 
 	m := newProducerManager(t, root)
 
-	// no marker → no task
+	// No marker or session drift → no task. Skill reconciliation is
+	// deterministic lifecycle work and must never create a daemon AI chore.
 	m.produceAgentTasks(m.loadConfig())
 	store, _ := agenttask.NewStore(root)
 	tasks, _ := store.List(false)

--- a/internal/plan/lint.go
+++ b/internal/plan/lint.go
@@ -150,7 +150,7 @@ func lintMermaidFontRace(html []byte) []Finding {
 
 var (
 	// the canonical OX marker is a focusable button named for screen readers
-	// (extensions/claude/skills/ox-plan/SKILL.md: `<button aria-label="SageOx insight">`).
+	// (extensions/skills/ox-plan/SKILL.md: `<button aria-label="SageOx insight">`).
 	oxMarkerRe = regexp.MustCompile(`(?i)aria-label\s*=\s*["']SageOx insight["']`)
 
 	// footer credit, e.g. "Team context enriched by SageOx" — substring match,
@@ -210,7 +210,7 @@ func LintArtifact(htmlBytes []byte) []Finding {
 
 // LintBranding verifies a rendered plan HTML carries the conditional SageOx
 // attribution the html-plan skill is spec'd to produce. The contract
-// (extensions/claude/skills/ox-plan/SKILL.md, "SageOx attribution — subtle, earned,
+// (extensions/skills/ox-plan/SKILL.md, "SageOx attribution — subtle, earned,
 // conditional"):
 //
 //   - EARNED: when the plan carried enrichment — any deterministic badges OR

--- a/internal/prime/capability_table.go
+++ b/internal/prime/capability_table.go
@@ -78,7 +78,7 @@ type Capability struct {
 //
 // Order is floor → command → skill. IDs are stable: command IDs resolve to
 // extensions/claude/commands/<id>.md; skill IDs resolve to
-// extensions/claude/skills/<id>/SKILL.md; floor IDs resolve to a <id> tag emit
+// extensions/skills/<id>/SKILL.md; floor IDs resolve to a <id> tag emit
 // site in cmd/ox/agent_prime_xml.go (all verified by capability_table_test.go).
 func OxCapabilities() []Capability {
 	return []Capability{
@@ -90,7 +90,7 @@ func OxCapabilities() []Capability {
 			Layer1Source:   "agent prime",
 			// the cue→corpus routing table the Layer-1 <consult-first> reminder
 			// renders from. Keep cue/command text in sync with the activation
-			// description of the additive extensions/claude/skills/ox-consult/SKILL.md
+			// description of the additive extensions/skills/ox-consult/SKILL.md
 			// (enforced by TestConsultRoutes_NoDriftWithSkill in
 			// cmd/ox/agent_prime_xml_test.go).
 			ConsultRoutes: []ConsultRoute{
@@ -151,7 +151,7 @@ func OxCapabilities() []Capability {
 		{ID: "ox-cart-drop", MechanismClass: MechanismCommand, Supports: CapabilitySupport{Slash: true}},
 
 		// ── skill: Layer-2 fat playbooks (slash AND auto-activate) ──
-		// extensions/claude/skills/<id>/SKILL.md. ox-consult is intentionally
+		// extensions/skills/<id>/SKILL.md. ox-consult is intentionally
 		// NOT a row here — it is an additive skill (see additiveSkills below).
 		{ID: "ox-plan", MechanismClass: MechanismSkill, Supports: CapabilitySupport{Slash: true, AutoActivate: true}},
 		{ID: "ox-session-review", MechanismClass: MechanismSkill, Supports: CapabilitySupport{Slash: true, AutoActivate: true}},
@@ -173,6 +173,9 @@ func OxCapabilities() []Capability {
 //
 // The map value documents WHY each skill is additive rather than a table row.
 var additiveSkills = map[string]string{
-	"ox-consult":  "additive Layer-2 ergonomics; its deterministic floor is the consult-first floor entry (ConsultRoutes), so it is not a separate conformance surface",
-	"ox-decision": "additive Layer-2 ergonomics; its deterministic floor is the decision-record-guidance floor entry plus the consult-first decision route, so it is not a separate conformance surface",
+	"ox-consult":       "additive Layer-2 ergonomics; its deterministic floor is the consult-first floor entry (ConsultRoutes), so it is not a separate conformance surface",
+	"ox-decision":      "additive Layer-2 ergonomics; its deterministic floor is the decision-record-guidance floor entry plus the consult-first decision route, so it is not a separate conformance surface",
+	"ox-skill-manager": "native Agent Skills lifecycle guidance; the deterministic installer and ownership rules live in ox CLI code rather than this playbook",
+	"ox-attest-goal":   "opt-in Attest BDD authoring playbook; it sharpens customer-journey judgment without becoming a portable product requirement",
+	"ox-attest-create": "opt-in Attest evidence-recording playbook; the attestation CLI remains usable without the Claude-specific skill",
 }

--- a/internal/prime/capability_table_test.go
+++ b/internal/prime/capability_table_test.go
@@ -62,7 +62,7 @@ func TestOxCapabilitiesIDResolves(t *testing.T) {
 	primeXMLSrc := string(primeXMLBytes)
 
 	commandsDir := filepath.Join(root, "extensions", "claude", "commands")
-	skillsDir := filepath.Join(root, "extensions", "claude", "skills")
+	skillsDir := filepath.Join(root, "extensions", "skills")
 
 	for _, c := range OxCapabilities() {
 		c := c
@@ -75,7 +75,7 @@ func TestOxCapabilitiesIDResolves(t *testing.T) {
 					t.Errorf("capability %q (%s) does not resolve to a file: %v", c.ID, c.MechanismClass, err)
 				}
 			case MechanismSkill:
-				// skills are a directory per skill: extensions/claude/skills/<id>/SKILL.md
+				// skills are a directory per skill: extensions/skills/<id>/SKILL.md
 				path := filepath.Join(skillsDir, c.ID, "SKILL.md")
 				if _, err := os.Stat(path); err != nil {
 					t.Errorf("capability %q (%s) does not resolve to a file: %v", c.ID, c.MechanismClass, err)
@@ -151,7 +151,7 @@ func TestOxCapabilitiesCountsByClass(t *testing.T) {
 // conformance contract. TestOxCapabilitiesIDResolves already proves table→disk
 // (every table id resolves to a real file); this proves the reverse: every
 // on-disk command (extensions/claude/commands/*.md) and skill
-// (extensions/claude/skills/*/SKILL.md) is EITHER an OxCapabilities() row OR an
+// (extensions/skills/*/SKILL.md) is EITHER an OxCapabilities() row OR an
 // explicitly documented additive skill (additiveSkills). Without this, a skill
 // like ox-consult — or any future skill/command the installer ships — could
 // silently escape the conformance contract.
@@ -180,8 +180,8 @@ func TestEveryOnDiskSurfaceIsAccounted(t *testing.T) {
 		}
 	}
 
-	// on-disk skills: extensions/claude/skills/<id>/SKILL.md
-	skillsDir := filepath.Join(root, "extensions", "claude", "skills")
+	// on-disk skills: extensions/skills/<id>/SKILL.md
+	skillsDir := filepath.Join(root, "extensions", "skills")
 	skillManifests, err := filepath.Glob(filepath.Join(skillsDir, "*", "SKILL.md"))
 	if err != nil {
 		t.Fatalf("glob skills: %v", err)

--- a/internal/prime/conformance_test.go
+++ b/internal/prime/conformance_test.go
@@ -16,8 +16,8 @@ package prime
 //     installer; skill-class only on a skills installer. Their ABSENCE on
 //     Codex/Droid is the documented Layer-2 additive case, NOT a failure.
 //   - Floor capabilities resolve on ALL adapters (they ride Layer 1).
-//   - Codex regression lock: Codex declares zero command/rule/skill installers,
-//     yet every floor capability still reaches it via Layer 1.
+//   - Codex regression lock: Codex declares native skills but no command/rule
+//     installers, while every floor capability still reaches it via Layer 1.
 
 import (
 	"sort"
@@ -57,6 +57,7 @@ var adapterCaps = map[string][]string{
 	"codex": {
 		adapterprotocol.CapSessionReader,
 		adapterprotocol.CapHookInstaller,
+		adapterprotocol.CapSkillsInstaller,
 		adapterprotocol.CapIncrementalReader,
 		adapterprotocol.CapFileWatcher,
 		adapterprotocol.CapServeMode,
@@ -208,19 +209,21 @@ func TestResolution(t *testing.T) {
 }
 
 // TestCodexFloorLock is the explicit "Codex users get the floor" regression
-// lock. Codex declares NONE of the Layer-2 installers, yet every floor
-// capability still reaches it via Layer 1 (Layer1Source set).
+// lock. Codex has native Agent Skills but no command/rule installer, and every
+// floor capability still reaches it via Layer 1 (Layer1Source set).
 func TestCodexFloorLock(t *testing.T) {
 	const codex = "codex"
 
 	for _, cap := range []string{
 		adapterprotocol.CapCommandsInstaller,
 		adapterprotocol.CapRulesInstaller,
-		adapterprotocol.CapSkillsInstaller,
 	} {
 		if hasCap(codex, cap) {
 			t.Fatalf("codex regression lock: codex must NOT declare %q, but it does", cap)
 		}
+	}
+	if !hasCap(codex, adapterprotocol.CapSkillsInstaller) {
+		t.Fatal("codex regression lock: codex must declare native skills_installer support")
 	}
 
 	floorSeen := 0

--- a/internal/session/adapters/external.go
+++ b/internal/session/adapters/external.go
@@ -475,7 +475,17 @@ func (ea *ExternalAdapter) UninstallCommands(repoRoot, version string) (*adapter
 
 // InstallSkills calls the adapter's install-skills subcommand.
 func (ea *ExternalAdapter) InstallSkills(repoRoot, version string) (*adapterprotocol.InstallSkillsResponse, error) {
-	out, err := ea.execOneShot("install-skills", "--repo-root", repoRoot, "--version", version)
+	return ea.InstallSkillsNamed(repoRoot, version)
+}
+
+// InstallSkillsNamed installs only the supplied skills. With no names it
+// preserves the adapter's default set; opt-in capability bundles pass names.
+func (ea *ExternalAdapter) InstallSkillsNamed(repoRoot, version string, names ...string) (*adapterprotocol.InstallSkillsResponse, error) {
+	args := []string{"--repo-root", repoRoot, "--version", version}
+	for _, name := range names {
+		args = append(args, "--skill", name)
+	}
+	out, err := ea.execOneShot("install-skills", args...)
 	if err != nil {
 		return nil, err
 	}
@@ -488,9 +498,33 @@ func (ea *ExternalAdapter) InstallSkills(repoRoot, version string) (*adapterprot
 	return &result, nil
 }
 
+func (ea *ExternalAdapter) InstallSkillsBundle(repoRoot, version string, bundles ...string) (*adapterprotocol.InstallSkillsResponse, error) {
+	args := []string{"--repo-root", repoRoot, "--version", version}
+	for _, bundle := range bundles {
+		args = append(args, "--bundle", bundle)
+	}
+	out, err := ea.execOneShot("install-skills", args...)
+	if err != nil {
+		return nil, err
+	}
+	var result adapterprotocol.InstallSkillsResponse
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+	}
+	return &result, nil
+}
+
 // CheckSkills calls the adapter's check-skills subcommand.
 func (ea *ExternalAdapter) CheckSkills(repoRoot, version string) (*adapterprotocol.CheckSkillsResponse, error) {
-	out, err := ea.execOneShot("check-skills", "--repo-root", repoRoot, "--version", version)
+	return ea.CheckSkillsNamed(repoRoot, version)
+}
+
+func (ea *ExternalAdapter) CheckSkillsNamed(repoRoot, version string, names ...string) (*adapterprotocol.CheckSkillsResponse, error) {
+	args := []string{"--repo-root", repoRoot, "--version", version}
+	for _, name := range names {
+		args = append(args, "--skill", name)
+	}
+	out, err := ea.execOneShot("check-skills", args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/skillmanager/manager.go
+++ b/internal/skillmanager/manager.go
@@ -1,0 +1,1186 @@
+// Package skillmanager projects the canonical SageOx skill catalog into the
+// native, project-scoped discovery roots declared by coding-agent adapters.
+package skillmanager
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sageox/agentx"
+	"github.com/sageox/ox/extensions/skills"
+	"github.com/sageox/ox/internal/adapterstamp"
+	"github.com/sageox/ox/internal/fileutil"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+)
+
+const (
+	lockSchemaVersion   = 1
+	lockRelativePath    = ".sageox/skills.lock.json"
+	journalRelativePath = ".sageox/cache/skills-apply.json"
+	stampPrefix         = "ox"
+)
+
+// BundleRef leaves room for an authenticated source identity without coupling
+// the v1 lockfile to a transport. Built-in bundles use only ID.
+type BundleRef struct {
+	ID string `json:"id"`
+}
+
+// DesiredSkills is the project-selected skill state. Targets contain stable
+// target keys, not adapter names, so two adapters may share one projection.
+type DesiredSkills struct {
+	Bundles []BundleRef `json:"bundles"`
+	Names   []string    `json:"names,omitempty"`
+	Targets []string    `json:"targets"`
+}
+
+// FileAction is one recoverable, repository-relative mutation.
+type FileAction struct {
+	TargetKey      string
+	Path           string
+	Content        []byte
+	Mode           fs.FileMode
+	PreviousDigest string
+	Digest         string
+}
+
+// Conflict is a path ox deliberately preserves because ownership is absent or
+// the bytes no longer match the last installed digest.
+type Conflict struct {
+	TargetKey string
+	Path      string
+	Reason    string
+}
+
+// ReconcilePlan is a read-only description of the work required to converge.
+// Apply writes individual files, commits the lockfile last, and is recoverable
+// through a pending-operation journal.
+type ReconcilePlan struct {
+	Creates          []FileAction
+	Updates          []FileAction
+	Removes          []FileAction
+	Conflicts        []Conflict
+	Preserves        []string
+	Warnings         []string
+	TargetCount      int
+	DesiredFileCount int
+
+	repoRoot    string
+	nextLock    lockFile
+	lockChanged bool
+	journal     applyJournal
+}
+
+type lockFile struct {
+	SchemaVersion int                           `json:"schema_version"`
+	Source        lockSource                    `json:"source"`
+	Desired       desiredLock                   `json:"desired"`
+	Targets       []adapterprotocol.SkillTarget `json:"targets"`
+	ManagedFiles  []managedFile                 `json:"managed_files"`
+}
+
+type lockSource struct {
+	Kind     string `json:"kind"`
+	Revision string `json:"revision"`
+	Version  string `json:"version"`
+}
+
+type desiredLock struct {
+	Bundles []string `json:"bundles"`
+	Names   []string `json:"names,omitempty"`
+	Targets []string `json:"targets"`
+}
+
+type managedFile struct {
+	Target string `json:"target"`
+	Path   string `json:"path"`
+	Digest string `json:"digest"`
+	Mode   string `json:"mode"`
+}
+
+type applyJournal struct {
+	SchemaVersion int             `json:"schema_version"`
+	Actions       []journalAction `json:"actions"`
+	NextLock      lockFile        `json:"next_lock"`
+}
+
+type catalogSource interface {
+	Digest() (string, error)
+	Select(version string, desired DesiredSkills) ([]skills.Skill, error)
+}
+
+type builtInCatalog struct{}
+
+func (builtInCatalog) Digest() (string, error) { return skills.Digest() }
+func (builtInCatalog) Select(version string, desired DesiredSkills) ([]skills.Skill, error) {
+	return selectDesiredSkills(version, desired)
+}
+
+type journalAction struct {
+	Path           string `json:"path"`
+	PreviousDigest string `json:"previous_digest,omitempty"`
+	Digest         string `json:"digest,omitempty"`
+}
+
+// LockPath returns the project ownership manifest path.
+func LockPath(repoRoot string) string {
+	return filepath.Join(repoRoot, filepath.FromSlash(lockRelativePath))
+}
+
+func journalPath(repoRoot string) string {
+	return filepath.Join(repoRoot, filepath.FromSlash(journalRelativePath))
+}
+
+// WrittenPaths returns repository-relative files created or updated by Apply.
+func (plan *ReconcilePlan) WrittenPaths() []string {
+	return actionPaths(plan.Creates, plan.Updates)
+}
+
+// RemovedPaths returns repository-relative files removed by Apply.
+func (plan *ReconcilePlan) RemovedPaths() []string { return actionPaths(plan.Removes) }
+
+// LockChanged reports whether Apply committed a new desired/ownership state.
+func (plan *ReconcilePlan) LockChanged() bool { return plan.lockChanged }
+
+// Converged reports whether applying the plan can fully realize desired state.
+func (plan *ReconcilePlan) Converged() bool {
+	return len(plan.Conflicts) == 0 && len(plan.Warnings) == 0
+}
+
+// LegacyBundles infers bundle opt-ins from verified pre-lockfile stamps. Any
+// valid member is enough to select its bundle so a partial install is repaired.
+func LegacyBundles(repoRoot string, target adapterprotocol.SkillTarget) ([]string, error) {
+	target, err := normalizeTarget(repoRoot, target)
+	if err != nil {
+		return nil, err
+	}
+	root := filepath.Join(repoRoot, filepath.FromSlash(target.Root))
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	managedNames := map[string]struct{}{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		data, readErr := readNoSymlink(filepath.Join(root, entry.Name(), skills.SkillFileName))
+		if os.IsNotExist(readErr) {
+			continue
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+		if validLegacyStamp(data) {
+			managedNames[entry.Name()] = struct{}{}
+		}
+	}
+	var bundles []string
+	for _, bundle := range skills.Catalog {
+		for _, name := range bundle.SkillIDs {
+			if _, ok := managedNames[name]; ok {
+				bundles = append(bundles, bundle.ID)
+				break
+			}
+		}
+	}
+	return sortedUnique(bundles), nil
+}
+
+// CanonicalizeTargets validates, normalizes, and deduplicates target
+// descriptors. A shared root with incompatible metadata is an error.
+func CanonicalizeTargets(repoRoot string, targets []adapterprotocol.SkillTarget) ([]adapterprotocol.SkillTarget, error) {
+	byProjection := map[string]adapterprotocol.SkillTarget{}
+	byKey := map[string]adapterprotocol.SkillTarget{}
+	for _, target := range targets {
+		normalized, err := normalizeTarget(repoRoot, target)
+		if err != nil {
+			return nil, err
+		}
+		if prior, ok := byKey[normalized.Key]; ok && prior != normalized {
+			return nil, fmt.Errorf("skill target %q has conflicting declarations", normalized.Key)
+		}
+		byKey[normalized.Key] = normalized
+		projection := normalized.Root
+		if prior, ok := byProjection[projection]; ok {
+			if prior.Format != normalized.Format || prior.Scope != normalized.Scope || prior.LinkPolicy != normalized.LinkPolicy {
+				return nil, fmt.Errorf("skill target root %q has incompatible declarations", normalized.Root)
+			}
+			continue
+		}
+		byProjection[projection] = normalized
+	}
+	out := make([]adapterprotocol.SkillTarget, 0, len(byProjection))
+	for _, target := range byProjection {
+		out = append(out, target)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Root == out[j].Root {
+			return out[i].Format < out[j].Format
+		}
+		return out[i].Root < out[j].Root
+	})
+	return out, nil
+}
+
+func normalizeTarget(repoRoot string, target adapterprotocol.SkillTarget) (adapterprotocol.SkillTarget, error) {
+	if target.Key == "" || target.Format == "" {
+		return adapterprotocol.SkillTarget{}, fmt.Errorf("skill target key and format are required")
+	}
+	if target.Scope == "" {
+		target.Scope = adapterprotocol.SkillScopeProject
+	}
+	if target.Scope != adapterprotocol.SkillScopeProject {
+		return adapterprotocol.SkillTarget{}, fmt.Errorf("skill target %q uses unsupported scope %q", target.Key, target.Scope)
+	}
+	if target.LinkPolicy == "" {
+		target.LinkPolicy = adapterprotocol.SkillLinkPolicyReject
+	}
+	if target.LinkPolicy != adapterprotocol.SkillLinkPolicyReject {
+		return adapterprotocol.SkillTarget{}, fmt.Errorf("skill target %q uses unsupported link policy %q", target.Key, target.LinkPolicy)
+	}
+	root := filepath.Clean(filepath.FromSlash(target.Root))
+	if root == "." || filepath.IsAbs(root) {
+		return adapterprotocol.SkillTarget{}, fmt.Errorf("skill target %q root must be repository-relative", target.Key)
+	}
+	if err := ensureWithin(repoRoot, filepath.Join(repoRoot, root)); err != nil {
+		return adapterprotocol.SkillTarget{}, fmt.Errorf("skill target %q: %w", target.Key, err)
+	}
+	first := strings.Split(filepath.ToSlash(root), "/")[0]
+	if first == ".git" || first == ".sageox" {
+		return adapterprotocol.SkillTarget{}, fmt.Errorf("skill target %q uses reserved root %q", target.Key, first)
+	}
+	target.Root = filepath.ToSlash(root)
+	return target, nil
+}
+
+// LoadDesired returns the committed project selection and target snapshots.
+// A missing lockfile is a valid empty selection.
+func LoadDesired(repoRoot string) (DesiredSkills, []adapterprotocol.SkillTarget, error) {
+	lock, _, err := readLock(repoRoot)
+	if err != nil {
+		return DesiredSkills{}, nil, err
+	}
+	return desiredFromLock(lock), append([]adapterprotocol.SkillTarget(nil), lock.Targets...), nil
+}
+
+func desiredFromLock(lock lockFile) DesiredSkills {
+	desired := DesiredSkills{Names: append([]string(nil), lock.Desired.Names...), Targets: append([]string(nil), lock.Desired.Targets...)}
+	for _, id := range lock.Desired.Bundles {
+		desired.Bundles = append(desired.Bundles, BundleRef{ID: id})
+	}
+	return desired
+}
+
+// DefaultDesired selects built-in default bundles for the supplied targets.
+func DefaultDesired(targets []adapterprotocol.SkillTarget) DesiredSkills {
+	desired := DesiredSkills{}
+	for _, id := range skills.DefaultBundleIDs() {
+		desired.Bundles = append(desired.Bundles, BundleRef{ID: id})
+	}
+	for _, target := range targets {
+		desired.Targets = append(desired.Targets, target.Key)
+	}
+	return normalizeDesired(desired)
+}
+
+// AddBundles returns a normalized desired state with bundle opt-ins added.
+func AddBundles(desired DesiredSkills, ids ...string) DesiredSkills {
+	for _, id := range ids {
+		desired.Bundles = append(desired.Bundles, BundleRef{ID: id})
+	}
+	return normalizeDesired(desired)
+}
+
+// AddTargets returns a normalized desired state with target selections added.
+func AddTargets(desired DesiredSkills, targets ...adapterprotocol.SkillTarget) DesiredSkills {
+	for _, target := range targets {
+		desired.Targets = append(desired.Targets, target.Key)
+	}
+	return normalizeDesired(desired)
+}
+
+func normalizeDesired(desired DesiredSkills) DesiredSkills {
+	bundles := map[string]struct{}{}
+	for _, bundle := range desired.Bundles {
+		if bundle.ID != "" {
+			bundles[bundle.ID] = struct{}{}
+		}
+	}
+	desired.Bundles = desired.Bundles[:0]
+	for id := range bundles {
+		desired.Bundles = append(desired.Bundles, BundleRef{ID: id})
+	}
+	sort.Slice(desired.Bundles, func(i, j int) bool { return desired.Bundles[i].ID < desired.Bundles[j].ID })
+	desired.Names = sortedUnique(desired.Names)
+	desired.Targets = sortedUnique(desired.Targets)
+	return desired
+}
+
+// Plan inspects the project without writing and returns a deterministic plan.
+func Plan(repoRoot, version string, desired DesiredSkills, targets []adapterprotocol.SkillTarget) (*ReconcilePlan, error) {
+	return planWithSource(repoRoot, version, desired, targets, builtInCatalog{})
+}
+
+func planWithSource(repoRoot, version string, desired DesiredSkills, targets []adapterprotocol.SkillTarget, source catalogSource) (*ReconcilePlan, error) {
+	desired = normalizeDesired(desired)
+	targets, err := CanonicalizeTargets(repoRoot, targets)
+	if err != nil {
+		return nil, err
+	}
+	old, oldBytes, err := readLock(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	journal, err := readJournal(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	plan := &ReconcilePlan{repoRoot: repoRoot, journal: journal, TargetCount: len(desired.Targets)}
+	if old.SchemaVersion > lockSchemaVersion {
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("skills lock schema %d is newer than this ox supports", old.SchemaVersion))
+		plan.nextLock = old
+		return plan, nil
+	}
+	if version != "" && old.Source.Version != "" && agentx.CompareVersions(version, old.Source.Version) {
+		plan.Warnings = append(plan.Warnings, fmt.Sprintf("skills were installed by newer ox %s; refusing downgrade to %s", old.Source.Version, version))
+		plan.nextLock = old
+		return plan, nil
+	}
+
+	targetByKey := map[string]adapterprotocol.SkillTarget{}
+	for _, target := range old.Targets {
+		normalized, normalizeErr := normalizeTarget(repoRoot, target)
+		if normalizeErr != nil {
+			return nil, fmt.Errorf("invalid skill target in lockfile: %w", normalizeErr)
+		}
+		targetByKey[normalized.Key] = normalized
+	}
+	for _, target := range targets {
+		if prior, ok := targetByKey[target.Key]; ok && prior != target {
+			return nil, fmt.Errorf("skill target %q changed incompatibly", target.Key)
+		}
+		targetByKey[target.Key] = target
+	}
+	for _, key := range desired.Targets {
+		if _, ok := targetByKey[key]; !ok {
+			return nil, fmt.Errorf("desired skill target %q has no descriptor", key)
+		}
+	}
+
+	digest, err := source.Digest()
+	if err != nil {
+		return nil, err
+	}
+	sourceVersion := version
+	if sourceVersion == "" {
+		sourceVersion = old.Source.Version
+	}
+	next := lockFile{
+		SchemaVersion: lockSchemaVersion,
+		Source:        lockSource{Kind: "builtin", Revision: digest, Version: sourceVersion},
+		Desired: desiredLock{
+			Bundles: bundleIDs(desired.Bundles),
+			Names:   append([]string(nil), desired.Names...),
+			Targets: append([]string(nil), desired.Targets...),
+		},
+	}
+
+	selectedSkills, err := source.Select(version, desired)
+	if err != nil {
+		return nil, err
+	}
+	oldFiles := make(map[string]managedFile, len(old.ManagedFiles))
+	for _, file := range old.ManagedFiles {
+		oldFiles[file.Path] = file
+	}
+	journalFiles := journalOwnership(journal)
+	desiredPaths := map[string]struct{}{}
+	selectedTargets := stringSet(desired.Targets)
+	plan.TargetCount = len(selectedTargets)
+	for _, skill := range selectedSkills {
+		plan.DesiredFileCount += len(skill.Files) * len(selectedTargets)
+	}
+
+	keys := make([]string, 0, len(targetByKey))
+	for key := range targetByKey {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		target := targetByKey[key]
+		if err := checkDir(repoRoot, filepath.Join(repoRoot, filepath.FromSlash(target.Root))); err != nil {
+			return nil, fmt.Errorf("inspect skill target %s: %w", key, err)
+		}
+		if _, selected := selectedTargets[key]; !selected {
+			continue
+		}
+		next.Targets = append(next.Targets, target)
+		for _, skill := range selectedSkills {
+			skillRoot := filepath.ToSlash(filepath.Join(target.Root, skill.Name))
+			migrationOwned := false
+			skillPath := filepath.ToSlash(filepath.Join(skillRoot, skills.SkillFileName))
+			if _, locked := oldFiles[skillPath]; !locked {
+				if data, readErr := readRepoFile(repoRoot, skillPath); readErr == nil {
+					migrationOwned = validLegacyStamp(data)
+					if action, ok := journalFiles[skillPath]; ok {
+						actualDigest := digestBytes(data)
+						migrationOwned = migrationOwned || actualDigest == action.PreviousDigest || actualDigest == action.Digest
+					}
+					if !migrationOwned {
+						plan.addConflict(key, skillPath, "existing skill is not managed by ox")
+						for _, file := range skill.Files {
+							path := filepath.ToSlash(filepath.Join(skillRoot, file.Path))
+							desiredPaths[path] = struct{}{}
+							plan.Preserves = append(plan.Preserves, path)
+						}
+						continue
+					}
+				} else if readErr != nil && !os.IsNotExist(readErr) {
+					return nil, readErr
+				}
+			}
+			for _, file := range skill.Files {
+				path := filepath.ToSlash(filepath.Join(skillRoot, file.Path))
+				desiredPaths[path] = struct{}{}
+				content := file.Content
+				mode := desiredFileMode(file.Path)
+				want := digestBytes(content)
+				oldFile, locked := oldFiles[path]
+				actual, actualMode, readErr := inspectRepoFile(repoRoot, path)
+				if readErr != nil && !os.IsNotExist(readErr) {
+					return nil, readErr
+				}
+				if os.IsNotExist(readErr) {
+					plan.Creates = append(plan.Creates, FileAction{TargetKey: key, Path: path, Content: content, Mode: mode, Digest: want})
+					next.ManagedFiles = append(next.ManagedFiles, managedFile{Target: key, Path: path, Digest: want, Mode: modeString(mode)})
+					continue
+				}
+				actualDigest := digestBytes(actual)
+				owned := locked && actualDigest == oldFile.Digest
+				if action, ok := journalFiles[path]; ok && (actualDigest == action.PreviousDigest || actualDigest == action.Digest) {
+					owned = true
+				}
+				if !owned && migrationOwned && (file.Path == skills.SkillFileName || actualDigest == want) {
+					owned = true
+				}
+				if !owned {
+					plan.addConflict(key, path, "current digest differs from the last installed digest")
+					plan.Preserves = append(plan.Preserves, path)
+					if locked {
+						next.ManagedFiles = append(next.ManagedFiles, oldFile)
+					}
+					continue
+				}
+				if actualDigest != want || actualMode.Perm() != mode.Perm() {
+					plan.Updates = append(plan.Updates, FileAction{TargetKey: key, Path: path, Content: content, Mode: mode, PreviousDigest: actualDigest, Digest: want})
+				} else {
+					plan.Preserves = append(plan.Preserves, path)
+				}
+				next.ManagedFiles = append(next.ManagedFiles, managedFile{Target: key, Path: path, Digest: want, Mode: modeString(mode)})
+			}
+		}
+	}
+
+	for _, oldFile := range old.ManagedFiles {
+		if _, wanted := desiredPaths[oldFile.Path]; wanted {
+			continue
+		}
+		actual, _, readErr := inspectRepoFile(repoRoot, oldFile.Path)
+		if os.IsNotExist(readErr) {
+			continue
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+		actualDigest := digestBytes(actual)
+		owned := actualDigest == oldFile.Digest
+		if action, ok := journalFiles[oldFile.Path]; ok && (actualDigest == action.PreviousDigest || actualDigest == action.Digest) {
+			owned = true
+		}
+		if !owned {
+			plan.addConflict(oldFile.Target, oldFile.Path, "retired managed file was modified and will be preserved")
+			plan.Preserves = append(plan.Preserves, oldFile.Path)
+			continue // relinquish ownership so uninstall/retirement can converge
+		}
+		plan.Removes = append(plan.Removes, FileAction{TargetKey: oldFile.Target, Path: oldFile.Path, PreviousDigest: actualDigest})
+	}
+
+	// Inline stamps are one-release migration evidence for retired skills that
+	// predate the lockfile. Only their verified SKILL.md is attributable.
+	for _, target := range targetByKey {
+		retired, retiredErr := retiredLegacyFiles(repoRoot, target, desiredPaths, oldFiles)
+		if retiredErr != nil {
+			return nil, retiredErr
+		}
+		plan.Removes = append(plan.Removes, retired...)
+	}
+
+	neededTargets := stringSet(next.Desired.Targets)
+	for _, file := range next.ManagedFiles {
+		neededTargets[file.Target] = struct{}{}
+	}
+	for _, key := range sortedSet(neededTargets) {
+		if target, ok := targetByKey[key]; ok && !containsTarget(next.Targets, key) {
+			next.Targets = append(next.Targets, target)
+		}
+	}
+	sortLock(&next)
+	plan.nextLock = next
+	nextBytes, err := marshalLock(next)
+	if err != nil {
+		return nil, err
+	}
+	plan.lockChanged = !bytes.Equal(oldBytes, nextBytes)
+	plan.journal = makeJournal(plan, next)
+	plan.sort()
+	return plan, nil
+}
+
+// Apply executes a previously built plan. Files are updated individually and
+// the lockfile is committed last. The journal makes old and new action digests
+// valid recovery states if the process exits between those steps.
+func Apply(plan *ReconcilePlan) error {
+	if plan == nil {
+		return fmt.Errorf("nil skill reconcile plan")
+	}
+	if len(plan.Warnings) > 0 {
+		return nil
+	}
+	if len(plan.Creates)+len(plan.Updates)+len(plan.Removes) == 0 && !plan.lockChanged {
+		_ = os.Remove(journalPath(plan.repoRoot))
+		return nil
+	}
+	if err := ensureDir(plan.repoRoot, filepath.Dir(journalPath(plan.repoRoot))); err != nil {
+		return err
+	}
+	journalBytes, err := json.MarshalIndent(plan.journal, "", "  ")
+	if err != nil {
+		return err
+	}
+	journalBytes = append(journalBytes, '\n')
+	if err := atomicWriteNoSymlink(journalPath(plan.repoRoot), journalBytes, 0o600); err != nil {
+		return fmt.Errorf("write skill apply journal: %w", err)
+	}
+	for _, action := range append(append([]FileAction{}, plan.Creates...), plan.Updates...) {
+		if digestBytes(action.Content) != action.Digest {
+			return fmt.Errorf("skill action content digest changed for %s", action.Path)
+		}
+		path := filepath.Join(plan.repoRoot, filepath.FromSlash(action.Path))
+		if err := ensureDir(plan.repoRoot, filepath.Dir(path)); err != nil {
+			return err
+		}
+		actual, _, readErr := inspectRepoFile(plan.repoRoot, action.Path)
+		if readErr == nil {
+			actualDigest := digestBytes(actual)
+			if actualDigest == action.Digest {
+				continue
+			}
+			if action.PreviousDigest == "" || actualDigest != action.PreviousDigest {
+				return fmt.Errorf("skill file changed after planning: %s", action.Path)
+			}
+		} else if !os.IsNotExist(readErr) {
+			return readErr
+		} else if action.PreviousDigest != "" {
+			return fmt.Errorf("skill file disappeared after planning: %s", action.Path)
+		}
+		if err := atomicWriteNoSymlink(path, action.Content, action.Mode); err != nil {
+			return fmt.Errorf("write skill file %s: %w", action.Path, err)
+		}
+	}
+	for _, action := range plan.Removes {
+		path := filepath.Join(plan.repoRoot, filepath.FromSlash(action.Path))
+		actual, _, readErr := inspectRepoFile(plan.repoRoot, action.Path)
+		if os.IsNotExist(readErr) {
+			continue
+		}
+		if readErr != nil {
+			return readErr
+		}
+		if digestBytes(actual) != action.PreviousDigest {
+			return fmt.Errorf("skill file changed after planning: %s", action.Path)
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove skill file %s: %w", action.Path, err)
+		}
+		removeEmptyParents(plan.repoRoot, filepath.Dir(path))
+	}
+	if err := ensureDir(plan.repoRoot, filepath.Dir(LockPath(plan.repoRoot))); err != nil {
+		return err
+	}
+	lockBytes, err := marshalLock(plan.nextLock)
+	if err != nil {
+		return err
+	}
+	if err := atomicWriteNoSymlink(LockPath(plan.repoRoot), lockBytes, 0o644); err != nil {
+		return fmt.Errorf("write skills lockfile: %w", err)
+	}
+	if err := os.Remove(journalPath(plan.repoRoot)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove skill apply journal: %w", err)
+	}
+	return nil
+}
+
+// DesiredUpdate computes a desired-state mutation while the project manifest
+// lock is held, preventing concurrent lifecycle commands from losing targets
+// or bundle opt-ins through a stale read-modify-write.
+type DesiredUpdate func(DesiredSkills, []adapterprotocol.SkillTarget) (DesiredSkills, []adapterprotocol.SkillTarget, error)
+
+// ReconcileUpdate serializes desired-state mutation, Plan, and Apply.
+func ReconcileUpdate(repoRoot, version string, update DesiredUpdate) (*ReconcilePlan, error) {
+	var plan *ReconcilePlan
+	err := fileutil.WithFileLock(context.Background(), LockPath(repoRoot), func() error {
+		desired, targets, err := LoadDesired(repoRoot)
+		if err != nil {
+			return err
+		}
+		desired, targets, err = update(desired, targets)
+		if err != nil {
+			return err
+		}
+		plan, err = Plan(repoRoot, version, desired, targets)
+		if err != nil {
+			return err
+		}
+		return Apply(plan)
+	})
+	return plan, err
+}
+
+// Reconcile replaces desired state and is primarily useful to tests and
+// compatibility callers. Lifecycle read-modify-write paths use ReconcileUpdate.
+func Reconcile(repoRoot, version string, desired DesiredSkills, targets []adapterprotocol.SkillTarget) (*ReconcilePlan, error) {
+	return ReconcileUpdate(repoRoot, version, func(DesiredSkills, []adapterprotocol.SkillTarget) (DesiredSkills, []adapterprotocol.SkillTarget, error) {
+		return desired, targets, nil
+	})
+}
+
+// Install, Check, and Uninstall retain the adapter RPC lifecycle for one
+// compatibility release. Built-in CLI paths use the target-centric API above.
+func Install(p adapterprotocol.SkillsParams, dir string) (*adapterprotocol.InstallSkillsResponse, error) {
+	target, err := targetForDir(p.RepoRoot, dir)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := ReconcileUpdate(p.RepoRoot, p.Version, func(desired DesiredSkills, targets []adapterprotocol.SkillTarget) (DesiredSkills, []adapterprotocol.SkillTarget, error) {
+		if len(desired.Bundles) == 0 && len(desired.Names) == 0 {
+			desired = DefaultDesired(nil)
+		}
+		desired = AddTargets(desired, target)
+		targets = append(targets, target)
+		if len(p.Bundles) > 0 {
+			desired = AddBundles(desired, p.Bundles...)
+		}
+		if len(p.Names) > 0 {
+			desired.Names = append(desired.Names, p.Names...)
+			desired = normalizeDesired(desired)
+		}
+		return desired, targets, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &adapterprotocol.InstallSkillsResponse{
+		Installed:    len(plan.Conflicts) == 0 && len(plan.Warnings) == 0,
+		FilesWritten: actionPaths(plan.Creates, plan.Updates),
+		Conflicts:    conflictPaths(plan.Conflicts),
+	}, nil
+}
+
+func Check(p adapterprotocol.SkillsParams, dir string) (*adapterprotocol.CheckSkillsResponse, error) {
+	target, err := targetForDir(p.RepoRoot, dir)
+	if err != nil {
+		return nil, err
+	}
+	desired, targets, err := LoadDesired(p.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(desired.Bundles) == 0 && len(desired.Names) == 0 {
+		desired = DefaultDesired([]adapterprotocol.SkillTarget{target})
+	}
+	if len(p.Bundles) > 0 {
+		desired = AddBundles(desired, p.Bundles...)
+	}
+	if len(p.Names) > 0 {
+		desired.Names = append(desired.Names, p.Names...)
+		desired = normalizeDesired(desired)
+	}
+	desired = AddTargets(desired, target)
+	targets = append(targets, target)
+	plan, err := Plan(p.RepoRoot, p.Version, desired, targets)
+	if err != nil {
+		return nil, err
+	}
+	missing, stale := classifyActions(target.Root, plan)
+	conflicts := conflictSkills(target.Root, plan.Conflicts)
+	return &adapterprotocol.CheckSkillsResponse{
+		Installed: len(missing) == 0 && len(stale) == 0 && len(conflicts) == 0 && len(plan.Warnings) == 0,
+		Missing:   missing, Stale: stale, Conflicts: conflicts,
+		SkillsDir: filepath.Join(p.RepoRoot, filepath.FromSlash(target.Root)), Total: desiredSkillCount(p.Version, desired),
+	}, nil
+}
+
+func Uninstall(p adapterprotocol.SkillsParams, dir string) (*adapterprotocol.UninstallSkillsResponse, error) {
+	target, err := targetForDir(p.RepoRoot, dir)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := ReconcileUpdate(p.RepoRoot, p.Version, func(desired DesiredSkills, targets []adapterprotocol.SkillTarget) (DesiredSkills, []adapterprotocol.SkillTarget, error) {
+		desired.Targets = removeString(desired.Targets, target.Key)
+		targets = append(targets, target)
+		return desired, targets, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &adapterprotocol.UninstallSkillsResponse{
+		Uninstalled:  len(plan.Removes) > 0,
+		FilesRemoved: actionPaths(plan.Removes),
+		Conflicts:    conflictPaths(plan.Conflicts),
+	}, nil
+}
+
+func targetForDir(repoRoot, dir string) (adapterprotocol.SkillTarget, error) {
+	rel, err := filepath.Rel(repoRoot, dir)
+	if err != nil {
+		return adapterprotocol.SkillTarget{}, err
+	}
+	root := filepath.ToSlash(filepath.Clean(rel))
+	key := strings.Trim(strings.ReplaceAll(root, "/", "-"), ".-")
+	switch root {
+	case ".agents/skills":
+		key = "agents-project"
+	case ".claude/skills":
+		key = "claude-project"
+	}
+	return normalizeTarget(repoRoot, adapterprotocol.SkillTarget{Key: key, Root: root, Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject, LinkPolicy: adapterprotocol.SkillLinkPolicyReject})
+}
+
+func selectDesiredSkills(version string, desired DesiredSkills) ([]skills.Skill, error) {
+	ids := bundleIDs(desired.Bundles)
+	names, err := skills.BundleNames(ids)
+	if err != nil {
+		return nil, err
+	}
+	names = append(names, desired.Names...)
+	if len(names) == 0 {
+		return nil, nil
+	}
+	return skills.Selected(version, sortedUnique(names))
+}
+
+func bundleIDs(refs []BundleRef) []string {
+	ids := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		ids = append(ids, ref.ID)
+	}
+	return sortedUnique(ids)
+}
+
+func readLock(repoRoot string) (lockFile, []byte, error) {
+	path := LockPath(repoRoot)
+	data, err := readNoSymlink(path)
+	if os.IsNotExist(err) {
+		return lockFile{}, nil, nil
+	}
+	if err != nil {
+		return lockFile{}, nil, fmt.Errorf("read skills lockfile: %w", err)
+	}
+	var lock lockFile
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return lockFile{}, nil, fmt.Errorf("parse skills lockfile: %w", err)
+	}
+	if lock.SchemaVersion <= 0 {
+		return lockFile{}, nil, fmt.Errorf("parse skills lockfile: missing schema_version")
+	}
+	canonical, err := marshalLock(lock)
+	if err != nil {
+		return lockFile{}, nil, err
+	}
+	return lock, canonical, nil
+}
+
+func readJournal(repoRoot string) (applyJournal, error) {
+	data, err := readNoSymlink(journalPath(repoRoot))
+	if os.IsNotExist(err) {
+		return applyJournal{}, nil
+	}
+	if err != nil {
+		return applyJournal{}, fmt.Errorf("read skill apply journal: %w", err)
+	}
+	var journal applyJournal
+	if err := json.Unmarshal(data, &journal); err != nil {
+		return applyJournal{}, fmt.Errorf("parse skill apply journal: %w", err)
+	}
+	if journal.SchemaVersion != lockSchemaVersion {
+		return applyJournal{}, fmt.Errorf("unsupported skill apply journal schema %d", journal.SchemaVersion)
+	}
+	return journal, nil
+}
+
+func marshalLock(lock lockFile) ([]byte, error) {
+	sortLock(&lock)
+	data, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func sortLock(lock *lockFile) {
+	lock.Desired.Bundles = sortedUnique(lock.Desired.Bundles)
+	lock.Desired.Names = sortedUnique(lock.Desired.Names)
+	lock.Desired.Targets = sortedUnique(lock.Desired.Targets)
+	sort.Slice(lock.Targets, func(i, j int) bool { return lock.Targets[i].Key < lock.Targets[j].Key })
+	sort.Slice(lock.ManagedFiles, func(i, j int) bool { return lock.ManagedFiles[i].Path < lock.ManagedFiles[j].Path })
+}
+
+func makeJournal(plan *ReconcilePlan, next lockFile) applyJournal {
+	journal := applyJournal{SchemaVersion: lockSchemaVersion, NextLock: next}
+	for _, action := range append(append(append([]FileAction{}, plan.Creates...), plan.Updates...), plan.Removes...) {
+		journal.Actions = append(journal.Actions, journalAction{Path: action.Path, PreviousDigest: action.PreviousDigest, Digest: action.Digest})
+	}
+	sort.Slice(journal.Actions, func(i, j int) bool { return journal.Actions[i].Path < journal.Actions[j].Path })
+	return journal
+}
+
+func journalOwnership(journal applyJournal) map[string]journalAction {
+	out := make(map[string]journalAction, len(journal.Actions))
+	for _, action := range journal.Actions {
+		out[action.Path] = action
+	}
+	return out
+}
+
+func retiredLegacyFiles(repoRoot string, target adapterprotocol.SkillTarget, desired map[string]struct{}, old map[string]managedFile) ([]FileAction, error) {
+	root := filepath.Join(repoRoot, filepath.FromSlash(target.Root))
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var actions []FileAction
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.ToSlash(filepath.Join(target.Root, entry.Name(), skills.SkillFileName))
+		if _, wanted := desired[path]; wanted {
+			continue
+		}
+		if _, locked := old[path]; locked {
+			continue
+		}
+		data, readErr := readRepoFile(repoRoot, path)
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				continue
+			}
+			return nil, readErr
+		}
+		if validLegacyStamp(data) {
+			actions = append(actions, FileAction{TargetKey: target.Key, Path: path, PreviousDigest: digestBytes(data)})
+		}
+	}
+	return actions, nil
+}
+
+func validLegacyStamp(data []byte) bool {
+	hash, _, body := adapterstamp.ExtractStampAnywhere(data, stampPrefix)
+	return hash != "" && agentx.ContentHash(body) == hash
+}
+
+func inspectRepoFile(repoRoot, relative string) ([]byte, fs.FileMode, error) {
+	path := filepath.Join(repoRoot, filepath.FromSlash(relative))
+	if err := ensureWithin(repoRoot, path); err != nil {
+		return nil, 0, err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, 0, fmt.Errorf("refusing non-regular or symlink skill file %s", path)
+	}
+	data, err := os.ReadFile(path)
+	return data, info.Mode(), err
+}
+
+func readRepoFile(repoRoot, relative string) ([]byte, error) {
+	data, _, err := inspectRepoFile(repoRoot, relative)
+	return data, err
+}
+
+func readNoSymlink(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("refusing non-regular or symlink file %s", path)
+	}
+	return os.ReadFile(path)
+}
+
+func atomicWriteNoSymlink(path string, content []byte, mode fs.FileMode) error {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&fs.ModeSymlink != 0 {
+		return fmt.Errorf("refusing symlink %s", path)
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	// fileutil.AtomicWriteBytes intentionally follows symlinks for instruction
+	// files. Managed skill paths have the opposite contract, so use a local
+	// temp+rename: rename replaces a raced symlink instead of following it.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".ox-skill-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	if dir, err := os.Open(filepath.Dir(path)); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	success = true
+	return nil
+}
+
+func ensureDir(root, dir string) error {
+	if err := ensureWithin(root, dir); err != nil {
+		return err
+	}
+	rel, _ := filepath.Rel(root, dir)
+	cur := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "." || part == "" {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(cur, 0o755); err != nil && !os.IsExist(err) {
+				return err
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&fs.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("refusing non-directory or symlink path %s", cur)
+		}
+	}
+	return nil
+}
+
+func checkDir(root, dir string) error {
+	if err := ensureWithin(root, dir); err != nil {
+		return err
+	}
+	rel, _ := filepath.Rel(root, dir)
+	cur := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "." || part == "" {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&fs.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("refusing non-directory or symlink path %s", cur)
+		}
+	}
+	return nil
+}
+
+func ensureWithin(root, target string) error {
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("path escapes repository")
+	}
+	return nil
+}
+
+func removeEmptyParents(repoRoot, dir string) {
+	for dir != repoRoot {
+		if err := os.Remove(dir); err != nil {
+			return
+		}
+		dir = filepath.Dir(dir)
+	}
+}
+
+func digestBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func desiredFileMode(path string) fs.FileMode {
+	if strings.HasPrefix(filepath.ToSlash(path), "scripts/") {
+		return 0o755
+	}
+	return 0o644
+}
+
+func modeString(mode fs.FileMode) string { return fmt.Sprintf("%04o", mode.Perm()) }
+
+func (plan *ReconcilePlan) addConflict(target, path, reason string) {
+	plan.Conflicts = append(plan.Conflicts, Conflict{TargetKey: target, Path: path, Reason: reason})
+}
+
+func (plan *ReconcilePlan) sort() {
+	byPath := func(actions []FileAction) {
+		sort.Slice(actions, func(i, j int) bool { return actions[i].Path < actions[j].Path })
+	}
+	byPath(plan.Creates)
+	byPath(plan.Updates)
+	byPath(plan.Removes)
+	sort.Slice(plan.Conflicts, func(i, j int) bool { return plan.Conflicts[i].Path < plan.Conflicts[j].Path })
+	plan.Preserves = sortedUnique(plan.Preserves)
+	plan.Warnings = sortedUnique(plan.Warnings)
+}
+
+func actionPaths(groups ...[]FileAction) []string {
+	var paths []string
+	for _, group := range groups {
+		for _, action := range group {
+			paths = append(paths, filepath.FromSlash(action.Path))
+		}
+	}
+	return paths
+}
+
+func conflictPaths(conflicts []Conflict) []string {
+	paths := make([]string, 0, len(conflicts))
+	for _, conflict := range conflicts {
+		paths = append(paths, filepath.FromSlash(conflict.Path))
+	}
+	return paths
+}
+
+func classifyActions(root string, plan *ReconcilePlan) ([]string, []string) {
+	var missing, stale []string
+	for _, action := range plan.Creates {
+		if skill := skillName(root, action.Path); skill != "" {
+			missing = append(missing, skill)
+		}
+	}
+	for _, action := range append(append([]FileAction{}, plan.Updates...), plan.Removes...) {
+		if skill := skillName(root, action.Path); skill != "" {
+			stale = append(stale, skill)
+		}
+	}
+	return sortedUnique(missing), sortedUnique(stale)
+}
+
+func conflictSkills(root string, conflicts []Conflict) []string {
+	var names []string
+	for _, conflict := range conflicts {
+		if name := skillName(root, conflict.Path); name != "" {
+			names = append(names, name)
+		}
+	}
+	return sortedUnique(names)
+}
+
+func skillName(root, path string) string {
+	rel, err := filepath.Rel(filepath.FromSlash(root), filepath.FromSlash(path))
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return ""
+	}
+	return strings.Split(filepath.ToSlash(rel), "/")[0]
+}
+
+func desiredSkillCount(version string, desired DesiredSkills) int {
+	selected, err := selectDesiredSkills(version, desired)
+	if err != nil {
+		return 0
+	}
+	return len(selected)
+}
+
+func containsTarget(targets []adapterprotocol.SkillTarget, key string) bool {
+	for _, target := range targets {
+		if target.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedUnique(values []string) []string {
+	set := stringSet(values)
+	return sortedSet(set)
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	return set
+}
+
+func sortedSet(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func removeString(values []string, remove string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if value != remove {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/skillmanager/manager_test.go
+++ b/internal/skillmanager/manager_test.go
@@ -1,0 +1,353 @@
+package skillmanager
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/sageox/agentx"
+	"github.com/sageox/ox/extensions/skills"
+	"github.com/sageox/ox/pkg/adapterprotocol"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCatalog struct {
+	revision string
+	skill    skills.Skill
+}
+
+func (f fakeCatalog) Digest() (string, error) { return f.revision, nil }
+func (f fakeCatalog) Select(string, DesiredSkills) ([]skills.Skill, error) {
+	return []skills.Skill{f.skill}, nil
+}
+
+func sharedTarget() adapterprotocol.SkillTarget {
+	return adapterprotocol.SkillTarget{
+		Key: "agents-project", Root: ".agents/skills",
+		Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+		LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+	}
+}
+
+func desiredFor(target adapterprotocol.SkillTarget) DesiredSkills {
+	return DesiredSkills{Bundles: []BundleRef{{ID: "core"}}, Targets: []string{target.Key}}
+}
+
+func fakeSkill(version string, suffix string) skills.Skill {
+	files := []skills.File{
+		{Path: "SKILL.md", Content: []byte("---\nname: test-skill\ndescription: test\n---\nbody " + suffix + "\n")},
+		{Path: "assets/example.json", Content: []byte("{\"version\":\"" + suffix + "\"}\n")},
+		{Path: "references/guide.md", Content: []byte("guide " + suffix + "\n")},
+		{Path: "scripts/check.sh", Content: []byte("#!/bin/sh\necho " + suffix + "\n")},
+	}
+	return skills.Skill{Name: "test-skill", Content: files[0].Content, Files: files, Version: version}
+}
+
+func TestCanonicalizeTargetsDeduplicatesSharedProjection(t *testing.T) {
+	repo := t.TempDir()
+	codex := sharedTarget()
+	gemini := sharedTarget()
+	gemini.Key = "gemini-alias"
+	targets, err := CanonicalizeTargets(repo, []adapterprotocol.SkillTarget{codex, gemini})
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, ".agents/skills", targets[0].Root)
+	plan, err := planWithSource(repo, "1.0.0", DefaultDesired(targets), targets, fakeCatalog{revision: "rev-1", skill: fakeSkill("1.0.0", "one")})
+	require.NoError(t, err)
+	require.Equal(t, 1, plan.TargetCount)
+	require.Len(t, plan.Creates, 4, "the shared projection must be planned exactly once")
+
+	gemini.LinkPolicy = "follow"
+	_, err = CanonicalizeTargets(repo, []adapterprotocol.SkillTarget{codex, gemini})
+	require.ErrorContains(t, err, "unsupported link policy")
+}
+
+func TestSelectedTargetsPersistAndUnselectedTargetStaysAbsent(t *testing.T) {
+	repo := t.TempDir()
+	claude := adapterprotocol.SkillTarget{
+		Key: "claude-project", Root: ".claude/skills",
+		Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+		LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+	}
+	shared := sharedTarget()
+	_, err := Reconcile(repo, "1.0.0", DefaultDesired([]adapterprotocol.SkillTarget{claude}), []adapterprotocol.SkillTarget{claude})
+	require.NoError(t, err)
+
+	desired, lockedTargets, err := LoadDesired(repo)
+	require.NoError(t, err)
+	require.Equal(t, []string{"claude-project"}, desired.Targets)
+	require.Len(t, lockedTargets, 1)
+
+	plan, err := Plan(repo, "1.0.0", desired, append(lockedTargets, shared))
+	require.NoError(t, err)
+	require.Equal(t, 1, plan.TargetCount)
+	for _, action := range plan.Creates {
+		require.NotContains(t, action.Path, ".agents/skills", "Doctor must not add an unselected detected target")
+	}
+	require.NoDirExists(t, filepath.Join(repo, ".agents", "skills"))
+}
+
+func TestConcurrentTargetUpdatesDoNotLoseSelection(t *testing.T) {
+	repo := t.TempDir()
+	shared := sharedTarget()
+	claude := adapterprotocol.SkillTarget{
+		Key: "claude-project", Root: ".claude/skills",
+		Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+		LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+	}
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, target := range []adapterprotocol.SkillTarget{shared, claude} {
+		target := target
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := ReconcileUpdate(repo, "1.0.0", func(desired DesiredSkills, targets []adapterprotocol.SkillTarget) (DesiredSkills, []adapterprotocol.SkillTarget, error) {
+				if len(desired.Bundles) == 0 {
+					desired = DefaultDesired(nil)
+				}
+				desired = AddTargets(desired, target)
+				targets = append(targets, target)
+				return desired, targets, nil
+			})
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	desired, targets, err := LoadDesired(repo)
+	require.NoError(t, err)
+	require.Equal(t, []string{"agents-project", "claude-project"}, desired.Targets)
+	require.Len(t, targets, 2)
+}
+
+func TestReconcileWritesManifestLastAndNoOpsWhenCurrent(t *testing.T) {
+	repo := t.TempDir()
+	target := sharedTarget()
+	plan, err := Reconcile(repo, "1.0.0", desiredFor(target), []adapterprotocol.SkillTarget{target})
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Creates)
+	require.True(t, plan.Converged())
+	require.FileExists(t, LockPath(repo))
+	require.NoFileExists(t, journalPath(repo))
+
+	data, err := os.ReadFile(filepath.Join(repo, ".agents", "skills", "ox-plan", "SKILL.md"))
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "ox-hash", "new installs use the lockfile as the only ownership source")
+
+	second, err := Plan(repo, "1.0.0", desiredFor(target), []adapterprotocol.SkillTarget{target})
+	require.NoError(t, err)
+	require.Empty(t, second.Creates)
+	require.Empty(t, second.Updates)
+	require.Empty(t, second.Removes)
+	require.Empty(t, second.Conflicts)
+	require.False(t, second.lockChanged)
+}
+
+func TestUnknownAndModifiedFilesAreTruthfulConflicts(t *testing.T) {
+	repo := t.TempDir()
+	target := sharedTarget()
+	userPath := filepath.Join(repo, ".agents", "skills", "ox-plan", "SKILL.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(userPath), 0o755))
+	user := []byte("---\nname: ox-plan\ndescription: mine\n---\nuser owned\n")
+	require.NoError(t, os.WriteFile(userPath, user, 0o644))
+
+	response, err := Install(adapterprotocol.SkillsParams{RepoRoot: repo, Version: "1.0.0"}, filepath.Join(repo, ".agents", "skills"))
+	require.NoError(t, err)
+	require.False(t, response.Installed)
+	require.NotEmpty(t, response.Conflicts)
+	after, err := os.ReadFile(userPath)
+	require.NoError(t, err)
+	require.Equal(t, user, after)
+
+	managedPath := filepath.Join(repo, ".agents", "skills", "ox-consult", "SKILL.md")
+	original, err := os.ReadFile(managedPath)
+	require.NoError(t, err)
+	modified := append(original, []byte("\nlocal edit\n")...)
+	require.NoError(t, os.WriteFile(managedPath, modified, 0o644))
+	plan, err := Plan(repo, "1.0.0", desiredFor(target), []adapterprotocol.SkillTarget{target})
+	require.NoError(t, err)
+	require.Contains(t, conflictPaths(plan.Conflicts), filepath.FromSlash(".agents/skills/ox-consult/SKILL.md"))
+	require.NoError(t, Apply(plan))
+	after, err = os.ReadFile(managedPath)
+	require.NoError(t, err)
+	require.Equal(t, modified, after)
+}
+
+func TestPlanCoversAllSkillTreeFiles(t *testing.T) {
+	repo := t.TempDir()
+	target := sharedTarget()
+	desired := desiredFor(target)
+	v1 := fakeCatalog{revision: "rev-1", skill: fakeSkill("1.0.0", "one")}
+	plan, err := planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, v1)
+	require.NoError(t, err)
+	require.Len(t, plan.Creates, 4)
+	require.NoError(t, Apply(plan))
+	info, err := os.Stat(filepath.Join(repo, ".agents", "skills", "test-skill", "scripts", "check.sh"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+
+	missing := filepath.Join(repo, ".agents", "skills", "test-skill", "references", "guide.md")
+	require.NoError(t, os.Remove(missing))
+	plan, err = planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, v1)
+	require.NoError(t, err)
+	require.Equal(t, ".agents/skills/test-skill/references/guide.md", plan.Creates[0].Path)
+	require.NoError(t, Apply(plan))
+
+	v2 := fakeCatalog{revision: "rev-2", skill: fakeSkill("2.0.0", "two")}
+	plan, err = planWithSource(repo, "2.0.0", desired, []adapterprotocol.SkillTarget{target}, v2)
+	require.NoError(t, err)
+	require.Len(t, plan.Updates, 4, "SKILL.md, references, assets, and scripts all participate in drift")
+	require.NoError(t, Apply(plan))
+}
+
+func TestUninstallRemovesOwnedTreeAndPreservesEditsAndAdditions(t *testing.T) {
+	repo := t.TempDir()
+	target := sharedTarget()
+	desired := desiredFor(target)
+	source := fakeCatalog{revision: "rev-1", skill: fakeSkill("1.0.0", "one")}
+	plan, err := planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, source)
+	require.NoError(t, err)
+	require.NoError(t, Apply(plan))
+
+	modifiedPath := filepath.Join(repo, ".agents", "skills", "test-skill", "assets", "example.json")
+	require.NoError(t, os.WriteFile(modifiedPath, []byte("user edit\n"), 0o644))
+	addition := filepath.Join(repo, ".agents", "skills", "test-skill", "notes.txt")
+	require.NoError(t, os.WriteFile(addition, []byte("keep\n"), 0o644))
+
+	desired.Targets = nil
+	plan, err = planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, source)
+	require.NoError(t, err)
+	require.Len(t, plan.Removes, 3)
+	require.Len(t, plan.Conflicts, 1)
+	require.NoError(t, Apply(plan))
+	require.FileExists(t, modifiedPath)
+	require.FileExists(t, addition)
+
+	next, err := planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, source)
+	require.NoError(t, err)
+	require.Empty(t, next.Conflicts, "ownership is relinquished for a modified file that is no longer desired")
+	require.Empty(t, next.Removes)
+}
+
+func TestInterruptedApplyRecoversBeforeAndAfterLockCommit(t *testing.T) {
+	repo := t.TempDir()
+	target := sharedTarget()
+	desired := desiredFor(target)
+	source := fakeCatalog{revision: "rev-1", skill: fakeSkill("1.0.0", "one")}
+	plan, err := planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, source)
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Creates)
+
+	// Simulate exit after the journal and first file, before lock commit.
+	require.NoError(t, ensureDir(repo, filepath.Dir(journalPath(repo))))
+	journal, err := json.MarshalIndent(plan.journal, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, atomicWriteNoSymlink(journalPath(repo), append(journal, '\n'), 0o600))
+	first := plan.Creates[0]
+	firstPath := filepath.Join(repo, filepath.FromSlash(first.Path))
+	require.NoError(t, ensureDir(repo, filepath.Dir(firstPath)))
+	require.NoError(t, atomicWriteNoSymlink(firstPath, first.Content, first.Mode))
+
+	recovered, err := planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, source)
+	require.NoError(t, err)
+	require.Empty(t, recovered.Conflicts)
+	require.NoError(t, Apply(recovered))
+	require.FileExists(t, LockPath(repo))
+
+	// Simulate exit after lock commit but before deleting the old journal.
+	journal, err = json.MarshalIndent(recovered.journal, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, atomicWriteNoSymlink(journalPath(repo), append(journal, '\n'), 0o600))
+	final, err := planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, source)
+	require.NoError(t, err)
+	require.Empty(t, final.Creates)
+	require.Empty(t, final.Updates)
+	require.Empty(t, final.Conflicts)
+	require.NoError(t, Apply(final))
+	require.NoFileExists(t, journalPath(repo))
+}
+
+func TestLegacyStampMigrationAndDowngradeGuard(t *testing.T) {
+	repo := t.TempDir()
+	target := sharedTarget()
+	desired := desiredFor(target)
+	source := fakeCatalog{revision: "rev-1", skill: fakeSkill("2.0.0", "one")}
+	path := filepath.Join(repo, ".agents", "skills", "test-skill", "SKILL.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	canonical := source.skill.Content
+	fmEnd := strings.Index(string(canonical), "\n---\n") + len("\n---\n")
+	body := canonical[fmEnd:]
+	legacy := append([]byte{}, canonical[:fmEnd]...)
+	legacy = append(legacy, []byte("<!-- ox-hash: "+agentx.ContentHash(body)+" ver: 1.0.0 -->\n")...)
+	legacy = append(legacy, body...)
+	require.NoError(t, os.WriteFile(path, legacy, 0o644))
+
+	plan, err := planWithSource(repo, "2.0.0", desired, []adapterprotocol.SkillTarget{target}, source)
+	require.NoError(t, err)
+	require.Empty(t, plan.Conflicts)
+	require.Contains(t, actionPaths(plan.Updates), filepath.FromSlash(".agents/skills/test-skill/SKILL.md"))
+	require.NoError(t, Apply(plan))
+
+	downgrade, err := planWithSource(repo, "1.0.0", desired, []adapterprotocol.SkillTarget{target}, source)
+	require.NoError(t, err)
+	require.NotEmpty(t, downgrade.Warnings)
+	require.Empty(t, downgrade.Updates)
+}
+
+func TestRetiredLegacyStampRemovesOnlyVerifiedManifest(t *testing.T) {
+	repo := t.TempDir()
+	target := sharedTarget()
+	retiredDir := filepath.Join(repo, ".agents", "skills", "retired-skill")
+	require.NoError(t, os.MkdirAll(retiredDir, 0o755))
+	body := []byte("old body\n")
+	legacy := []byte("---\nname: retired-skill\ndescription: old\n---\n<!-- ox-hash: " + agentx.ContentHash(body) + " ver: 0.9.0 -->\n")
+	legacy = append(legacy, body...)
+	manifest := filepath.Join(retiredDir, "SKILL.md")
+	addition := filepath.Join(retiredDir, "notes.txt")
+	require.NoError(t, os.WriteFile(manifest, legacy, 0o644))
+	require.NoError(t, os.WriteFile(addition, []byte("keep\n"), 0o644))
+
+	plan, err := planWithSource(repo, "1.0.0", desiredFor(target), []adapterprotocol.SkillTarget{target}, fakeCatalog{revision: "rev-1", skill: fakeSkill("1.0.0", "one")})
+	require.NoError(t, err)
+	require.Contains(t, actionPaths(plan.Removes), filepath.FromSlash(".agents/skills/retired-skill/SKILL.md"))
+	require.NoError(t, Apply(plan))
+	require.NoFileExists(t, manifest)
+	require.FileExists(t, addition)
+}
+
+func TestSymlinkAndMalformedLockFailWithoutMutation(t *testing.T) {
+	repo := t.TempDir()
+	target := sharedTarget()
+	external := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".agents"), 0o755))
+	require.NoError(t, os.Symlink(external, filepath.Join(repo, ".agents", "skills")))
+	_, err := Plan(repo, "1.0.0", desiredFor(target), []adapterprotocol.SkillTarget{target})
+	require.ErrorContains(t, err, "symlink")
+
+	reserved := sharedTarget()
+	reserved.Root = ".git/skills"
+	_, err = Plan(t.TempDir(), "1.0.0", desiredFor(reserved), []adapterprotocol.SkillTarget{reserved})
+	require.ErrorContains(t, err, "reserved root")
+
+	lockRepo := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Dir(LockPath(lockRepo)), 0o755))
+	require.NoError(t, os.WriteFile(LockPath(lockRepo), []byte("not json\n"), 0o644))
+	_, err = Plan(lockRepo, "1.0.0", desiredFor(target), []adapterprotocol.SkillTarget{target})
+	require.ErrorContains(t, err, "parse skills lockfile")
+
+	symlinkLockRepo := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Dir(LockPath(symlinkLockRepo)), 0o755))
+	require.NoError(t, os.Symlink(filepath.Join(symlinkLockRepo, "outside.json"), LockPath(symlinkLockRepo)))
+	_, err = Plan(symlinkLockRepo, "1.0.0", desiredFor(target), []adapterprotocol.SkillTarget{target})
+	require.ErrorContains(t, err, "symlink")
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // Version information set via ldflags during build
 var (
-	Version   = "0.13.0"
+	Version   = "0.14.0"
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 )

--- a/pkg/adapterprotocol/types.go
+++ b/pkg/adapterprotocol/types.go
@@ -21,7 +21,7 @@ const ProtocolVersion = 1
 // revision. Bumped when wire-level changes are made (new event types,
 // new HelloResponse fields) without changing the major ProtocolVersion.
 // Adapters can use this for fine-grained capability negotiation.
-const ProtocolDate = "2026-05-01"
+const ProtocolDate = "2026-08-15"
 
 // --- Adapter types ---
 
@@ -49,6 +49,13 @@ const (
 	CapCapturePrior       = "capture_prior"
 )
 
+// Native project skill target vocabulary.
+const (
+	SkillFormatAgentSkillsV1 = "agent-skills/v1"
+	SkillScopeProject        = "project"
+	SkillLinkPolicyReject    = "reject"
+)
+
 // --- Entry roles ---
 
 // Role constants for RawEntry.Role field.
@@ -73,6 +80,20 @@ type InfoResponse struct {
 	RequiredEnv     []string        `json:"required_env,omitempty"`
 	ServeMode       bool            `json:"serve_mode"`
 	SubagentConfig  *SubagentConfig `json:"subagent_config,omitempty"`
+	// SkillTargets describes native, project-scoped skill discovery roots. The
+	// ox CLI canonicalizes and deduplicates these descriptors before planning,
+	// so multiple adapters may safely advertise the same shared target.
+	SkillTargets []SkillTarget `json:"skill_targets,omitempty"`
+}
+
+// SkillTarget describes a native Agent Skills projection owned by the host.
+// Root is repository-relative; absolute and escaping paths are rejected.
+type SkillTarget struct {
+	Key        string `json:"key"`
+	Root       string `json:"root"`
+	Format     string `json:"format"`
+	Scope      string `json:"scope"`
+	LinkPolicy string `json:"link_policy"`
 }
 
 // DetectResponse is returned by the `detect` subcommand.
@@ -176,6 +197,13 @@ type UninstallCommandsResponse struct {
 type SkillsParams struct {
 	RepoRoot string `json:"repo_root"`
 	Version  string `json:"version"` // ox version for stamped content
+	// Names narrows an install/check operation to explicit skill IDs. Empty
+	// selects the adapter's default skill set, so capability-specific playbooks
+	// stay opt-in instead of silently arriving in every initialized repository.
+	Names []string `json:"names,omitempty"`
+	// Bundles selects curated capability groups such as "attest". Bundles are
+	// the stable user/team-facing install contract; Names remains for repair.
+	Bundles []string `json:"bundles,omitempty"`
 }
 
 // InstallSkillsResponse is returned by `install-skills`.
@@ -186,6 +214,7 @@ type InstallSkillsResponse struct {
 	// fileswritten.go. Entries that don't resolve inside the repo are
 	// dropped by ox and never staged.
 	FilesWritten []string `json:"files_written"`
+	Conflicts    []string `json:"conflicts,omitempty"`
 }
 
 // CheckSkillsResponse is returned by `check-skills`.
@@ -193,6 +222,10 @@ type CheckSkillsResponse struct {
 	Installed bool     `json:"installed"`
 	Missing   []string `json:"missing,omitempty"`
 	Stale     []string `json:"stale,omitempty"`
+	// Conflicts are skill IDs occupied by an unstamped, user-owned SKILL.md.
+	// They are deliberately not auto-fixed: overwriting them would destroy a
+	// local override. Callers should surface a manual resolution instead.
+	Conflicts []string `json:"conflicts,omitempty"`
 	SkillsDir string   `json:"skills_dir"`
 	Total     int      `json:"total"`
 }
@@ -201,6 +234,7 @@ type CheckSkillsResponse struct {
 type UninstallSkillsResponse struct {
 	Uninstalled  bool     `json:"uninstalled"`
 	FilesRemoved []string `json:"files_removed"`
+	Conflicts    []string `json:"conflicts,omitempty"`
 }
 
 // ReadParams are passed to `read` and `read-metadata`.

--- a/pkg/adapterprotocol/types_test.go
+++ b/pkg/adapterprotocol/types_test.go
@@ -22,7 +22,12 @@ func TestInfoResponse_RoundTrip(t *testing.T) {
 		Type:            adapterprotocol.TypeSession,
 		Capabilities:    []string{adapterprotocol.CapSessionReader, adapterprotocol.CapHookInstaller},
 		HookEnvValues:   []string{"claude-code"},
-		ServeMode:       true,
+		SkillTargets: []adapterprotocol.SkillTarget{{
+			Key: "claude-project", Root: ".claude/skills",
+			Format: adapterprotocol.SkillFormatAgentSkillsV1, Scope: adapterprotocol.SkillScopeProject,
+			LinkPolicy: adapterprotocol.SkillLinkPolicyReject,
+		}},
+		ServeMode: true,
 	}
 
 	data, err := json.Marshal(want)
@@ -46,6 +51,9 @@ func TestInfoResponse_RoundTrip(t *testing.T) {
 	}
 	if len(got.Capabilities) != len(want.Capabilities) {
 		t.Errorf("Capabilities len = %d, want %d", len(got.Capabilities), len(want.Capabilities))
+	}
+	if len(got.SkillTargets) != 1 || got.SkillTargets[0] != want.SkillTargets[0] {
+		t.Errorf("SkillTargets = %#v, want %#v", got.SkillTargets, want.SkillTargets)
 	}
 }
 

--- a/pkg/adapterruntime/runtime.go
+++ b/pkg/adapterruntime/runtime.go
@@ -507,6 +507,12 @@ func parseSkillsParams(args []string) adapterprotocol.SkillsParams {
 		case "--version":
 			p.Version = args[i+1]
 			i++
+		case "--skill":
+			p.Names = append(p.Names, args[i+1])
+			i++
+		case "--bundle":
+			p.Bundles = append(p.Bundles, args[i+1])
+			i++
 		}
 	}
 	return p

--- a/pkg/adapterruntime/runtime_test.go
+++ b/pkg/adapterruntime/runtime_test.go
@@ -598,6 +598,34 @@ func TestRunWithArgs_InstallRules(t *testing.T) {
 	}
 }
 
+func TestRunWithArgs_InstallSkillsPassesRequestedNames(t *testing.T) {
+	var stdout bytes.Buffer
+	var got adapterprotocol.SkillsParams
+	cfg := adapterruntime.Config{
+		InstallSkills: func(p adapterprotocol.SkillsParams) (*adapterprotocol.InstallSkillsResponse, error) {
+			got = p
+			return &adapterprotocol.InstallSkillsResponse{Installed: true}, nil
+		},
+	}
+
+	err := adapterruntime.RunWithArgs(cfg, []string{
+		"install-skills", "--repo-root", "/tmp/test", "--version", "0.8.0",
+		"--skill", "ox-attest-goal", "--skill", "ox-attest-create", "--bundle", "attest",
+	}, nil, &stdout)
+	if err != nil {
+		t.Fatalf("RunWithArgs returned error: %v", err)
+	}
+	if got.RepoRoot != "/tmp/test" || got.Version != "0.8.0" {
+		t.Fatalf("skills params = %#v, want repo root and version", got)
+	}
+	if strings.Join(got.Names, ",") != "ox-attest-goal,ox-attest-create" {
+		t.Fatalf("skill names = %#v, want requested order", got.Names)
+	}
+	if strings.Join(got.Bundles, ",") != "attest" {
+		t.Fatalf("skill bundles = %#v, want requested order", got.Bundles)
+	}
+}
+
 func TestRunWithArgs_CheckRules(t *testing.T) {
 	var stdout bytes.Buffer
 	cfg := adapterruntime.Config{


### PR DESCRIPTION
## Customer value

SageOx skills now arrive through each AI coworker’s native skill mechanism without duplicate installs, surprise targets, or destructive “repair.” A project can select Claude, Codex, Gemini, or any combination once; SageOx remembers that choice, writes each native projection exactly once, and keeps the complete skill tree current while preserving local edits.

- **Native discovery stays native:** Claude receives `.claude/skills`; Codex and Gemini share the portable `.agents/skills` projection their harnesses already know how to route.
- **Selections stay intentional:** `ox init` persists project-selected targets. Doctor no longer treats every subsequently detected AI coworker as authorized.
- **Repair is honest and safe:** missing and unchanged stale files converge automatically; user-owned collisions and modified managed files are reported and preserved.
- **Lifecycle results are truthful:** shared targets are deduplicated, every file is checked, and install success cannot hide a skipped conflict.
- **No AI coworker busywork:** explicit lifecycle commands perform deterministic reconciliation directly; the daemon no longer schedules a skill-repair task.

## How it works

### One catalog, native delivery

```mermaid
flowchart LR
    Claude["Claude Code"] -->|"claude-project"| Reconcile["One project reconciler<br/>canonicalize · dedupe · plan"]
    Codex["Codex"] -->|"agents-project"| Reconcile
    Gemini["Gemini"] -->|"agents-project"| Reconcile
    Catalog["Portable skill catalog<br/>core + opt-in bundles"] --> Reconcile
    Reconcile --> ClaudeSkills["Claude-native projection<br/>.claude/skills"]
    Reconcile --> SharedSkills["Shared Agent Skills projection<br/>.agents/skills"]
```

Codex and Gemini intentionally converge on the same `agents-project` target: one plan, one set of writes, and one truthful count. Each AI coworker still discovers skills through its native mechanism.

### Safe, recoverable reconciliation

```mermaid
sequenceDiagram
    participant L as Lifecycle command
    participant P as Pure Plan
    participant F as Native skill files
    participant S as Journal + lockfile

    L->>P: desired skills + targets + actual files + ownership
    P-->>L: creates, updates, removes, conflicts, preserves
    L->>S: record pending apply with old/new digests
    L->>F: change only files matching their owned digest
    F-->>L: preserve user edits and collisions
    L->>S: commit ownership lockfile last
    L->>S: clear pending journal
    Note over L,S: After interruption, journal + digests make the next run converge safely
```

Planning is read-only. Apply records intent before touching native files and commits ownership last, so a restart can distinguish partial SageOx work from customer edits.

## What this PR ships

- **Release:** bumps ox and the Claude plugin manifests to `0.14.0`, with customer-facing release notes for native skill management.
- **Target descriptors:** extends adapter `info` with project-scoped native `skill_targets`; built-in Claude, Codex, and Gemini adapters declare their supported projections.
- **Central reconciliation:** moves built-in lifecycle orchestration from per-adapter imperative loops into a canonicalized target pass. Existing adapter skill RPCs remain as a one-release compatibility layer.
- **Manifest ownership:** adds `.sageox/skills.lock.json` with desired bundles/targets, normalized target snapshots, source revision, and every managed path/digest/mode.
- **Complete-tree drift detection:** plans `SKILL.md`, `references/`, `assets/`, and `scripts/`, including missing, stale, retired, and colliding paths.
- **Conservative mutation rules:** updates/removes only bytes matching the prior digest; preserves unknown files and edits; rejects symlinked targets and lock state.
- **Crash recovery:** journals apply intent before target mutations, writes files atomically and individually, commits the lockfile last, then removes the journal.
- **Concurrent lifecycle safety:** holds a project manifest lock across desired-state mutation, planning, and apply so simultaneous init/Attest/Doctor operations cannot lose a target or bundle selection.
- **Lifecycle integration:** routes `ox init`, `ox doctor --fix`, `ox attest install`, and uninstall through the same engine. Doctor reads committed targets, with a narrow verified-stamp migration for pre-lockfile projects.
- **Portable skill copy:** removes Claude-only activation language and slash-only invocation syntax from the shared skill catalog.
- **Conformance repair:** accounts for `ox-skill-manager` and updates the obsolete regression assumption that Codex has no native skills.

## Safety and migration

- Existing inline `ox-hash` stamps are migration evidence only and must self-verify before import.
- An Attest stamp opts the project into the full Attest bundle so partial legacy installs repair coherently.
- A newer lockfile schema or newer installing ox version is preserved rather than downgraded.
- Modified files removed from desired state are preserved and ownership is relinquished, preventing an unfixable Doctor loop.
- New installs contain clean canonical Agent Skills content; ownership lives in the manifest.
- Team Context publishing and the Skill Bridge for AI coworkers without native skills remain follow-on work and must reuse this catalog and Plan/Apply engine.

## Test plan

- [x] Deduplicate Codex + Gemini to one `.agents/skills` target.
- [x] Persist selected targets and prove an unselected detected target is not added.
- [x] Cover missing, stale, modified, retired, and user-colliding files across `SKILL.md`, references, assets, and scripts.
- [x] Remove unchanged owned files while preserving user additions and edits.
- [x] Recover interruptions before and after lockfile commit.
- [x] Serialize concurrent target updates without losing either selection.
- [x] Reject target/lockfile symlinks and malformed lock state.
- [x] Preserve newer-version state rather than downgrade it.
- [x] Assert current desired state produces an empty plan.
- [x] Verify portable skill descriptions contain no host-specific activation syntax.
- [x] Make the focused adapter, catalog, skillmanager, and `internal/prime` suites green.
- [x] Run repository-wide format, lint, and test gates.

---

<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added for planning, apply, recovery, conflicts, deduplication, and target persistence.
- [x] CHANGELOG entry added for `0.14.0`.
- [x] Breaking change: N/A; imperative adapter RPCs remain available for one compatibility release.
- [x] Security review: N/A; this diff does not touch the security-sensitive paths listed in the repository policy or `go.sum`.

</details>

> Guided by SageOx

Co-authored-by: SageOx <ox@sageox.ai>
SageOx-Session: https://sageox.ai/c/ses_01a005bb-588a-7367-baff-96b25efd60e9
