### PR TITLE
feat(viz): add reviewer-first PR visual workflows

### DIFF
--- a/.claude/commands/ox-session-stop.md
+++ b/.claude/commands/ox-session-stop.md
@@ -1,4 +1,4 @@
-<!-- ox-hash: 9b5ef157c16c ver: v0.13.0-1-gf9fefd1 -->
+<!-- ox-hash: a5b02f749d14 ver: 0.13.0 -->
 <!-- Keep this file thin. Behavioral guidance (use-when, common-issues, errors)
      belongs in the ox CLI JSON output (guidance field), not here.
      Skills are agent-specific wrappers; ox serves all agents (Codex, etc.).
@@ -8,24 +8,14 @@ Stop recording and save this agent session to the project ledger.
 
 ## Post-Command
 
-After the command completes, check the JSON output for `guidance` and `summary_prompt` fields.
-Follow the `guidance` field for next steps.
+Follow the `guidance` field in the JSON output. If `summary_prompt` is present,
+generate the summary as it instructs and pipe it back via stdin:
 
-**If `summary_prompt` is present (sync mode):**
-1. Read the prompt carefully — it references the raw session file on disk
-2. Read the raw session file at the path specified in the prompt
-3. Generate the summary JSON following the Output Format in the prompt
-4. Pipe the JSON to `ox session push-summary --file - --session-dir <session-dir>` via stdin. Do NOT write the JSON to `/tmp/` or any shared path — multiple agents may run concurrently on the same machine and race on shared filenames, and macOS tmpfs GC can reap files between attempts.
-   ```bash
-   echo "$summary_json" | ox session push-summary --file - --session-dir <session-dir>
-   ```
-5. Verify the push succeeded by checking the JSON output for `"success": true`
+```bash
+echo "$summary_json" | ox session push-summary --file - --session-dir <session-dir>
+```
 
-**If `summary_prompt` is absent (async mode):**
-No agent action required. Upload and summary generation happen automatically in the background.
-
-**If summary generation fails:**
-- Run `ox agent <id> doctor` — it can detect and help recover missing summaries
-- The session data is safe regardless; only the rich summary is missing
+Pipe via stdin — never write the JSON to `/tmp/` or any shared path (concurrent
+agents race on shared filenames and macOS tmpfs GC can reap them mid-run).
 
 $ox agent session stop

--- a/.claude/skills/ox-plan/SKILL.md
+++ b/.claude/skills/ox-plan/SKILL.md
@@ -19,7 +19,7 @@ description: >-
   (signals.material, guidance) plus the user's confirmation / the `plan.html`
   config setting — not by this skill.
 ---
-<!-- ox-hash: f3bdfe9c157b ver: 0.12.0 -->
+<!-- ox-hash: cce2611c9d4a ver: 0.13.0 -->
 
 <!-- Keep behavioral "when to render" guidance lean — that belongs in the
      `ox plan` JSON output (signals.material, guidance) and in the
@@ -129,7 +129,7 @@ The **ox chrome** — enrichment overlay, footer credit, review loop — is inje
 
 ## The quick path (markdown, low-stakes only)
 
-For a **small, low-stakes plan** where an authored page isn't worth the effort, markdown-first remains: author the plan markdown, then `ox plan save --plan <md> [--annotations ...]` and `ox plan render --file plan.md`. The renderer now auto-renders tabs (>3 H2 sections), a TL;DR hero, `:::compare`/`:::` side-by-side panes, ` ```html-interactive ` passthrough fences, and auto-visualizations (gated-track tables → swimlanes; comparison tables → a click-to-inspect field inspector). It approximates; a material plan gets an authored page. Apply the GitHub-strict Mermaid rules from CLAUDE.md to any ` ```mermaid ` fences, and treat `plan-diagram [...]` advisories as fixes, not suggestions.
+For a **small, low-stakes plan** where an authored page isn't worth the effort, markdown-first remains: author the plan markdown, then `ox plan save --file plan.md [--annotations ...]` and `ox plan render --file plan.md`. The renderer auto-renders tabs (>3 H2 sections), a TL;DR hero, `:::compare`/`:::` side-by-side panes, ` ```html-interactive ` passthrough fences, and auto-visualizations (gated-track tables → swimlanes; comparison tables → a click-to-inspect field inspector). It approximates; a material plan gets an authored page. Never use the rejected legacy `--plan + --html` pair: competing sources can cause review to discard the authored visualization. Apply the GitHub-strict Mermaid rules from CLAUDE.md to any ` ```mermaid ` fences, and treat `plan-diagram [...]` advisories as fixes, not suggestions.
 
 ---
 

--- a/.claude/skills/ox-recap/SKILL.md
+++ b/.claude/skills/ox-recap/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: ox-recap
+description: >-
+  Answer "what value am I getting from SageOx?" with receipts, not vibes.
+  Auto-fire when the user asks "is SageOx worth it", "what has SageOx done
+  for me", "what am I getting out of SageOx", "should I keep using this",
+  "was SageOx worth it this week", or says "ox recap" / "give me a recap".
+  Run `ox recap --json` and narrate a tight, personal, prose answer from the
+  `guidance` field — never invent value, never cite a bare statistic or a
+  time-saved/dollar figure, ground every claim in a receipt from the bundle.
+---
+<!-- ox-hash: 5ccd62d2ac11 ver: 0.13.0 -->
+
+<!-- Thin by design. The entire narration contract — which value axis to lead
+     with (social: team knowledge that reached you; temporal/solo: your own
+     ledger compounding as searchable memory), the honesty rules (never
+     invent value, never lead with a bare statistic, ground every claim in a
+     receipt), and the cold-start framing — lives in the `guidance` field of
+     `ox recap --json` (Layer-1 floor), which reaches Claude, Codex, and
+     Droid alike. This skill adds ONLY Claude-specific auto-activation
+     ergonomics; it duplicates no reasoning. Do not grow this body. -->
+
+## Use when
+
+The user asks about SageOx's value, ROI, or whether it's worth keeping:
+"what value am I getting from SageOx", "is SageOx worth it", "what has
+SageOx done for me", "what's this actually doing for me", or "ox recap".
+
+## Do
+
+1. Run `ox recap --json` (add `--since <window>` or `--user <name>` only if
+   the user asked for a scope other than the default last 30 days).
+2. Narrate the answer by following the `guidance` string in the JSON output
+   verbatim — it decides which value axis leads, enforces the honesty rules,
+   and tells you how to ground every claim in a receipt (an artifact path, a
+   session name, a plan slug, a commit SHA) from the bundle.
+3. If the bundle is thin or the ledger is empty, do not invent value —
+   `guidance` already tells you how to frame that case: lead with
+   `next_actions` and say plainly that value starts the moment they begin.

--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -712,7 +712,15 @@ func writePlanEnrichmentGuidance(sb *strings.Builder, agentType string) {
 // vocabulary, independent of whether it uses SageOx enriched plans.
 func writeVisualizationGuidance(sb *strings.Builder) {
 	sb.WriteString("\n<visualization-guidance>\n")
-	sb.WriteString("When architecture, flow, state, sequence, comparison, chronology, or quantitative shape would explain the work faster than prose, consult `ox viz suggest \"<what needs explaining>\"`. The catalog is for every artifact — plans, docs, PRs, reports, and design notes. Pull one recipe with `ox viz <id>`, render data-driven fragments with `ox viz render`, and check authored SVG/HTML with `ox viz lint`.\n")
+	sb.WriteString("Before a material PR description, run `ox viz pr`: no visual if prose answers it; GitHub-safe Mermaid for a 2–5-node flow; rich only for a reviewer question Mermaid cannot answer. For a known question, run `ox viz pr --intent \"<question>\" --json`.\n")
+	projectRoot := findGitRoot()
+	if config.PRVisualsRich(projectRoot) {
+		theme := config.PRVisualsTheme(projectRoot)
+		fmt.Fprintf(sb, "For simple source-adjacent flow use GitHub-safe Mermaid; for comparison/layout use a labeled rich visual in the %s theme. Export its 2x PNG to .context/pr-visuals/ (never commit it), inspect it, then attach it in GitHub's PR editor with alt text and one conclusion. Keep PR visuals unbranded: no SageOx wordmark, footer credit, or logo; labels and connectors must not collide. `ox viz pr` has the export details.\n", theme)
+	} else {
+		sb.WriteString("Generated PNG/SVG PR images are disabled; the ox viz catalog and `ox viz suggest` remain available. For PR text, use GitHub-safe Mermaid only when it helps; enable image generation with `ox config set pr_visuals.rich on`.\n")
+	}
+	sb.WriteString("For architecture, flow, state, sequence, comparison, chronology, or quantitative shape, use `ox viz suggest \"<intent>\"`; the catalog serves plans, docs, PRs, reports, and design notes. Pull `ox viz <id>`; only `ox-render` recipes support `ox viz render`; check SVG/HTML with `ox viz lint`.\n")
 	sb.WriteString("</visualization-guidance>\n")
 }
 

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -651,7 +651,7 @@ func TestOutputAgentPrimeXML_VisualizationGuidanceIsArtifactNeutral(t *testing.T
 		t.Fatal("prime output is missing visualization-guidance")
 	}
 	block := xml[start:end]
-	for _, want := range []string{"ox viz suggest", "ox viz render", "ox viz lint", "docs", "PRs", "reports"} {
+	for _, want := range []string{"Before a material PR description", "ox viz suggest", "ox viz render", "ox viz lint", "ox viz pr", "--intent", "GitHub-safe Mermaid", ".context/pr-visuals/", "Keep PR visuals unbranded", "no SageOx wordmark", "footer credit", "docs", "PRs", "reports"} {
 		if !strings.Contains(block, want) {
 			t.Errorf("visualization guidance missing %q: %s", want, block)
 		}

--- a/cmd/ox/config.go
+++ b/cmd/ox/config.go
@@ -32,10 +32,14 @@ Available settings:
   tips                     on | off
   context_git.auto_commit  on | off
   context_git.auto_push    on | off
+  pr_visuals.rich          on | off
+  pr_visuals.theme         light | dark
   attribution.commit       (any text, "" to disable)
   attribution.pr           (any text, "" to disable)
 
-Priority: user > repo > team > default`,
+Priority: user > repo > team > default. User-level preferences apply even in
+repositories that have not run ox init; install the user-level integration
+for your AI coworker to receive the guidance everywhere.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// if terminal is interactive, launch TUI
 		if term.IsTerminal(int(os.Stdout.Fd())) && len(args) == 0 {

--- a/cmd/ox/config_settings.go
+++ b/cmd/ox/config_settings.go
@@ -333,6 +333,45 @@ values).`,
 		Default:     config.DefaultPlanOpen,
 		Levels:      []ConfigLevel{ConfigLevelUser, ConfigLevelRepo},
 	},
+	{
+		Key:         "pr_visuals.rich",
+		Description: "Generate rich pull-request visuals",
+		LongDescription: `Controls whether AI coworkers are guided to generate rich, review-only
+PNG/SVG visuals for GitHub pull requests.
+
+  on  - Offer and generate rich HTML/SVG-derived visuals for comparisons,
+        architecture, flows, and other review-relevant explanations. PNGs are
+        uploaded through GitHub's editor and never committed to the branch.
+        (default)
+  off - Do not use the automated rich PNG/SVG PR-image workflow. The complete
+        ox viz catalog and ` + "`ox viz suggest`" + ` remain available for plans, docs,
+        reports, and manual authoring; use a small GitHub-safe Mermaid diagram
+        in the PR only when it materially improves the review.
+
+Set this at team, repository, or personal scope. Personal choices override a
+repository choice; repository choices override a team default.`,
+		Category:    "Pull requests",
+		ValidValues: []string{"on", "off"},
+		Default:     "on",
+		Levels:      []ConfigLevel{ConfigLevelUser, ConfigLevelRepo, ConfigLevelTeam},
+	},
+	{
+		Key:         "pr_visuals.theme",
+		Description: "Pull-request visual theme",
+		LongDescription: `Selects the intended appearance of rich GitHub pull-request visuals.
+
+  light - White/light canvas with SageOx accents. Default: aligns with GitHub's
+          reading surface and keeps a PR visual integrated with its discussion.
+  dark  - Dark canvas with SageOx accents. Use when the visual is intentionally
+          presented as a distinct artifact.
+
+This affects the design brief given to AI coworkers; it does not change
+GitHub's own color scheme. Set it at team, repository, or personal scope.`,
+		Category:    "Pull requests",
+		ValidValues: []string{config.PRVisualsThemeLight, config.PRVisualsThemeDark},
+		Default:     config.DefaultPRVisualsTheme,
+		Levels:      []ConfigLevel{ConfigLevelUser, ConfigLevelRepo, ConfigLevelTeam},
+	},
 	// NOTE: attribution.plan and attribution.session are intentionally not exposed
 	// in ox config — they are always-on transparency requirements, not user preferences.
 	{
@@ -645,6 +684,28 @@ func ResolveConfigValue(key string, projectRoot string) (*ConfigValue, error) {
 			cv.RepoVal = *repoCfg.Plan.Open
 		}
 
+	case "pr_visuals.rich":
+		if userCfg != nil && userCfg.PRVisuals.IsRichSet() {
+			cv.UserVal = boolToOnOff(*userCfg.PRVisuals.Rich)
+		}
+		if repoCfg != nil && repoCfg.PRVisuals.IsRichSet() {
+			cv.RepoVal = boolToOnOff(*repoCfg.PRVisuals.Rich)
+		}
+		if teamCfg != nil && teamCfg.PRVisuals.IsRichSet() {
+			cv.TeamVal = boolToOnOff(*teamCfg.PRVisuals.Rich)
+		}
+
+	case "pr_visuals.theme":
+		if userCfg != nil && userCfg.PRVisuals.IsThemeSet() {
+			cv.UserVal = *userCfg.PRVisuals.Theme
+		}
+		if repoCfg != nil && repoCfg.PRVisuals.IsThemeSet() {
+			cv.RepoVal = *repoCfg.PRVisuals.Theme
+		}
+		if teamCfg != nil && teamCfg.PRVisuals.IsThemeSet() {
+			cv.TeamVal = *teamCfg.PRVisuals.Theme
+		}
+
 	}
 
 	// determine effective value and source (User > Repo > Team > Default)
@@ -868,6 +929,19 @@ func setUserConfig(key, value string) error {
 		}
 		cfg.Plan.Open = config.StringPtr(value)
 
+	case "pr_visuals.rich":
+		if cfg.PRVisuals == nil {
+			cfg.PRVisuals = &config.PRVisualsConfig{}
+		}
+		enabled := value == "on"
+		cfg.PRVisuals.Rich = &enabled
+
+	case "pr_visuals.theme":
+		if cfg.PRVisuals == nil {
+			cfg.PRVisuals = &config.PRVisualsConfig{}
+		}
+		cfg.PRVisuals.Theme = config.StringPtr(value)
+
 	default:
 		return fmt.Errorf("unknown user setting: %s", key)
 	}
@@ -950,6 +1024,19 @@ func setRepoConfig(key, value, projectRoot string) error {
 		}
 		cfg.Plan.Open = config.StringPtr(value)
 
+	case "pr_visuals.rich":
+		if cfg.PRVisuals == nil {
+			cfg.PRVisuals = &config.PRVisualsConfig{}
+		}
+		enabled := value == "on"
+		cfg.PRVisuals.Rich = &enabled
+
+	case "pr_visuals.theme":
+		if cfg.PRVisuals == nil {
+			cfg.PRVisuals = &config.PRVisualsConfig{}
+		}
+		cfg.PRVisuals.Theme = config.StringPtr(value)
+
 	default:
 		return fmt.Errorf("setting %s not supported at repo level", key)
 	}
@@ -979,6 +1066,19 @@ func setTeamConfig(key, value, projectRoot string) error {
 	switch key {
 	case "session_recording":
 		cfg.SessionRecording = value
+
+	case "pr_visuals.rich":
+		if cfg.PRVisuals == nil {
+			cfg.PRVisuals = &config.PRVisualsConfig{}
+		}
+		enabled := value == "on"
+		cfg.PRVisuals.Rich = &enabled
+
+	case "pr_visuals.theme":
+		if cfg.PRVisuals == nil {
+			cfg.PRVisuals = &config.PRVisualsConfig{}
+		}
+		cfg.PRVisuals.Theme = config.StringPtr(value)
 
 	default:
 		return fmt.Errorf("setting %s not supported at team level", key)
@@ -1105,6 +1205,22 @@ func unsetUserConfig(key string) error {
 			}
 		}
 
+	case "pr_visuals.rich":
+		if cfg.PRVisuals != nil {
+			cfg.PRVisuals.Rich = nil
+			if cfg.PRVisuals.IsEmpty() {
+				cfg.PRVisuals = nil
+			}
+		}
+
+	case "pr_visuals.theme":
+		if cfg.PRVisuals != nil {
+			cfg.PRVisuals.Theme = nil
+			if cfg.PRVisuals.IsEmpty() {
+				cfg.PRVisuals = nil
+			}
+		}
+
 	default:
 		return fmt.Errorf("unknown user setting: %s", key)
 	}
@@ -1194,6 +1310,22 @@ func unsetRepoConfig(key, projectRoot string) error {
 			}
 		}
 
+	case "pr_visuals.rich":
+		if cfg.PRVisuals != nil {
+			cfg.PRVisuals.Rich = nil
+			if cfg.PRVisuals.IsEmpty() {
+				cfg.PRVisuals = nil
+			}
+		}
+
+	case "pr_visuals.theme":
+		if cfg.PRVisuals != nil {
+			cfg.PRVisuals.Theme = nil
+			if cfg.PRVisuals.IsEmpty() {
+				cfg.PRVisuals = nil
+			}
+		}
+
 	default:
 		return fmt.Errorf("setting %s not supported at repo level", key)
 	}
@@ -1220,6 +1352,22 @@ func unsetTeamConfig(key, projectRoot string) error {
 	switch key {
 	case "session_recording":
 		cfg.SessionRecording = ""
+
+	case "pr_visuals.rich":
+		if cfg.PRVisuals != nil {
+			cfg.PRVisuals.Rich = nil
+			if cfg.PRVisuals.IsEmpty() {
+				cfg.PRVisuals = nil
+			}
+		}
+
+	case "pr_visuals.theme":
+		if cfg.PRVisuals != nil {
+			cfg.PRVisuals.Theme = nil
+			if cfg.PRVisuals.IsEmpty() {
+				cfg.PRVisuals = nil
+			}
+		}
 
 	default:
 		return fmt.Errorf("setting %s not supported at team level", key)

--- a/cmd/ox/config_settings_coverage_test.go
+++ b/cmd/ox/config_settings_coverage_test.go
@@ -326,3 +326,24 @@ func TestUnsetConfigValue_PlanOpen_FallsBackToDefault(t *testing.T) {
 	require.NoError(t, UnsetConfigValue("plan.open", ConfigLevelUser, ""))
 	assert.Equal(t, config.DefaultPlanOpen, config.PlanOpen(""), "unsetting plan.open must fall back to the default (ask)")
 }
+
+func TestSetConfigValue_PRVisualsRoundTripsThroughResolver(t *testing.T) {
+	t.Setenv("OX_USER_CONFIG", filepath.Join(t.TempDir(), "config.yaml"))
+
+	require.NoError(t, SetConfigValue("pr_visuals.rich", "off", ConfigLevelUser, ""))
+	require.NoError(t, SetConfigValue("pr_visuals.theme", config.PRVisualsThemeDark, ConfigLevelUser, ""))
+
+	assert.False(t, config.PRVisualsRich(""))
+	assert.Equal(t, config.PRVisualsThemeDark, config.PRVisualsTheme(""))
+
+	for _, key := range []string{"pr_visuals.rich", "pr_visuals.theme"} {
+		value, err := ResolveConfigValue(key, "")
+		require.NoError(t, err)
+		assert.Equal(t, ConfigLevelUser, value.Source)
+	}
+
+	require.NoError(t, UnsetConfigValue("pr_visuals.rich", ConfigLevelUser, ""))
+	require.NoError(t, UnsetConfigValue("pr_visuals.theme", ConfigLevelUser, ""))
+	assert.True(t, config.PRVisualsRich(""))
+	assert.Equal(t, config.PRVisualsThemeLight, config.PRVisualsTheme(""))
+}

--- a/cmd/ox/integrate.go
+++ b/cmd/ox/integrate.go
@@ -93,11 +93,12 @@ var integrateInstallCmd = &cobra.Command{
 	Long: `Install SageOx hooks for AI coworkers.
 
 Default: Claude Code (adds hooks to ~/.claude/settings.json).
-Use --user to add guidance to ~/.claude/CLAUDE.md for ALL projects.
+Use --user to add guidance to ~/.claude/CLAUDE.md for ALL projects, including
+repositories that have not run ox init.
 
 Other agents can be installed with their respective flags:
   --gemini    Gemini CLI hooks
-  --codex     Codex CLI hooks
+  --codex     Codex CLI hooks (use with --user for every repository)
   --amp       Amp CLI integration (AGENTS.md marker)
   --opencode  OpenCode plugin
   --pi        Pi coding agent integration (AGENTS.md marker)`,

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New
+
+- **Reviewer-first pull-request visuals** — `ox viz pr` selects prose, GitHub-safe Mermaid, or a rich attachment from the reviewer question; rich recipes now include construction-ready visual contracts, lightweight PNG checks, and personal, repository, and team preferences.
+
 ## [0.14.0] - 2026-08-15
 
 Skills now reach each AI coworker through its native discovery mechanism, while SageOx keeps project-scoped installations safe, consistent, and repairable.

--- a/cmd/ox/viz.go
+++ b/cmd/ox/viz.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/sageox/ox/internal/cli"
+	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/viz"
 	"github.com/spf13/cobra"
 )
@@ -27,9 +30,11 @@ func newVizCommand(compat bool) *cobra.Command {
 requests, reports, and design notes.
 
 Run with no argument to browse the catalog; pass an id to get its cognitive
-payoff and authoring recipe. 'ox viz suggest' ranks patterns for an intent,
-'ox viz render' computes parameterized visuals from JSON, and 'ox viz lint'
-checks portable SVG/HTML output. All selection is deterministic and local.`,
+payoff, authoring recipe, and—where mature—its executable visual contract:
+evidence slots, canvas, composition, hierarchy, typography, routing, variants,
+and finishing pass. 'ox viz suggest' ranks patterns for an intent, 'ox viz
+render' computes parameterized visuals from JSON, and 'ox viz lint' checks
+portable SVG/HTML output. All selection is deterministic and local.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			jsonOut, _ := cmd.Flags().GetBool("json")
@@ -39,7 +44,7 @@ checks portable SVG/HTML output. All selection is deterministic and local.`,
 			return runVizList(cmd, jsonOut)
 		},
 	}
-	cmd.AddCommand(newVizSuggestCommand(), newVizRenderCommand(), newVizLintCommand())
+	cmd.AddCommand(newVizSuggestCommand(), newVizRenderCommand(), newVizLintCommand(), newVizPRCommand())
 	return cmd
 }
 
@@ -96,6 +101,27 @@ func newVizLintCommand() *cobra.Command {
 	return cmd
 }
 
+func newVizPRCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pr",
+		Short: "Prepare a GitHub-compatible visualization for a pull request",
+		Long: "Choose and ship a visualization that improves code review without " +
+			"adding review-only binary files to the pull-request branch. ox never " +
+			"posts or edits a pull request; GitHub's authenticated editor creates " +
+			"the final attachment URL when the PNG is pasted or dragged into the " +
+			"description or a comment.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			intent, _ := cmd.Flags().GetString("intent")
+			jsonOut, _ := cmd.Flags().GetBool("json")
+			return runVizPRIntent(cmd, intent, jsonOut)
+		},
+	}
+	cmd.Flags().String("intent", "", "reviewer question or PR story to match against the catalog")
+	cmd.Flags().Bool("json", false, "emit PR-oriented suggestions as JSON (requires --intent)")
+	return cmd
+}
+
 func runVizRender(cmd *cobra.Command, pattern, dataPath string) error {
 	var raw []byte
 	var err error
@@ -128,6 +154,7 @@ func runVizSuggest(cmd *cobra.Command, intent string, limit int, jsonOut bool) e
 		return nil
 	}
 	fmt.Fprintln(out, cli.StyleBrand.Render("Suggested visual explanations"))
+	fmt.Fprintln(out, cli.StyleDim.Render("First choose the smallest truthful form: prose/table, GitHub-safe Mermaid for a compact flow, then a rich visual only when it adds an unavailable dimension."))
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
 	fmt.Fprintln(tw, cli.StyleDim.Render("ID\tCATEGORY\tWHY\tNEXT"))
 	for _, s := range suggestions {
@@ -147,7 +174,12 @@ func runVizLint(cmd *cobra.Command, file string, strict, jsonOut bool) error {
 	if err != nil {
 		return fmt.Errorf("read visualization %q: %w", file, err)
 	}
-	findings := viz.Lint(raw, viz.LintOptions{})
+	var findings []viz.Finding
+	if bytes.HasPrefix(raw, []byte{'\x89', 'P', 'N', 'G', '\r', '\n', '\x1a', '\n'}) {
+		findings = viz.LintPRPNG(raw)
+	} else {
+		findings = viz.Lint(raw, viz.LintOptions{})
+	}
 	if jsonOut {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
@@ -168,6 +200,90 @@ func runVizLint(cmd *cobra.Command, file string, strict, jsonOut bool) error {
 	if viz.HasErrors(findings) || (strict && len(findings) > 0) {
 		return fmt.Errorf("%d visualization lint finding(s)", len(findings))
 	}
+	return nil
+}
+
+func runVizPR(cmd *cobra.Command) error {
+	return runVizPRIntent(cmd, "", false)
+}
+
+type prVisualSuggestions struct {
+	Intent       string           `json:"intent"`
+	Suggestions  []viz.Suggestion `json:"suggestions"`
+	Decision     viz.PRDecision   `json:"decision"`
+	MermaidFirst bool             `json:"mermaid_first"` // compatibility field; true only when Mermaid wins
+	Guidance     string           `json:"guidance"`
+}
+
+func runVizPRIntent(cmd *cobra.Command, intent string, jsonOut bool) error {
+	if jsonOut && strings.TrimSpace(intent) == "" {
+		return fmt.Errorf("--json requires --intent")
+	}
+	if strings.TrimSpace(intent) != "" {
+		decision := viz.DecidePRMedium(intent)
+		if decision.Medium == viz.PRMediumRich && !config.PRVisualsRich(findGitRoot()) {
+			decision = viz.PRDecision{Medium: viz.PRMediumMermaid, Reason: "rich PR-image generation is disabled by config; use the smallest GitHub-safe Mermaid flow that preserves the review fact", RequiredEvidence: "two to five named nodes and direct labeled edges"}
+		}
+		suggestions := viz.Suggest(intent, 5)
+		if decision.Medium == viz.PRMediumRich && decision.Primary != "" {
+			alreadySuggested := false
+			for _, suggestion := range suggestions {
+				alreadySuggested = alreadySuggested || suggestion.ID == decision.Primary
+			}
+			if primary, ok := viz.PatternByID(decision.Primary); ok && !alreadySuggested {
+				suggestions = append([]viz.Suggestion{{ID: primary.ID, Category: primary.Category, Authoring: primary.Authoring, Reason: decision.Reason, Guidance: primary.Guidance, Next: "ox viz " + primary.ID}}, suggestions...)
+			}
+		}
+		// PR bodies render the GitHub Mermaid subset directly; rank its recipes
+		// before image recipes when both explain the same reviewer question.
+		if decision.Medium == viz.PRMediumMermaid {
+			sort.SliceStable(suggestions, func(i, j int) bool {
+				return suggestions[i].Authoring == "mermaid" && suggestions[j].Authoring != "mermaid"
+			})
+		}
+		if jsonOut {
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(prVisualSuggestions{
+				Intent:       intent,
+				Suggestions:  suggestions,
+				Decision:     decision,
+				MermaidFirst: decision.Medium == viz.PRMediumMermaid,
+				Guidance:     "Conceptual clarity is the gate. Follow decision.medium: prose/table before Mermaid, Mermaid before rich PNG, and rich only for a visual dimension the smaller form cannot preserve. Compare the candidate against the smallest truthful baseline; if a new reader cannot identify the start, primary path, changed fact, and outcome at least as quickly, use the baseline.",
+			})
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), cli.StyleBrand.Render("PR-oriented visual suggestions"))
+		if decision.Medium == viz.PRMediumRich && decision.Primary != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "- Selected medium: rich %s (%s variant). Pull the construction contract with `ox viz %s`.\n", decision.Primary, decision.Variant, decision.Primary)
+		}
+		for _, suggestion := range suggestions {
+			fmt.Fprintf(cmd.OutOrStdout(), "- %s — %s (%s)\n", suggestion.ID, suggestion.Reason, suggestion.Authoring)
+		}
+		return nil
+	}
+
+	out := cmd.OutOrStdout()
+	projectRoot := findGitRoot()
+	rich := config.PRVisualsRich(projectRoot)
+	theme := config.PRVisualsTheme(projectRoot)
+	fmt.Fprintln(out, cli.StyleBrand.Render("GitHub PR visual workflow"))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "1. Conceptual clarity comes before design richness. Start with the minimum cognitive load: use no visual when one sentence answers the reviewer question; use GitHub-safe Mermaid for a 2–5-node linear flow; use a rich image only for data, parallel time, dense comparison, or a spatial relationship Mermaid cannot make clear. A polished image that weakens the reader's mental model is a failed visualization.")
+	fmt.Fprintln(out, "2. For a simple source-adjacent flow, put GitHub-safe Mermaid directly in the PR body. Keep it direct: one path, direct labels, restrained color/weight, and no Mermaid Live-only extensions. Run ox viz suggest with what needs explaining when the choice is unclear.")
+	if !rich {
+		fmt.Fprintln(out, "3. The automated rich PNG/SVG PR-image workflow is disabled by effective config. This does not disable the ox viz catalog or `ox viz suggest`; use them for plans, docs, reports, or manual authoring. For this PR, keep the image-export workflow off and use a small GitHub-safe Mermaid diagram only when it materially improves review. Enable generated rich PR visuals with `ox config set pr_visuals.rich on` at personal, repo, or team scope.")
+		return nil
+	}
+	fmt.Fprintf(out, "3. For a rich before/after, author a labeled HTML/SVG visual using the selected ox viz recipe (or Diagram Design when installed), in the %s theme, then export a 2x PNG under .context/pr-visuals/ — never add review-only media to the PR branch. Keep technical PR visuals unbranded by default: no SageOx wordmark, footer credit, or logo.\n", theme)
+	fmt.Fprintln(out, "4. Before polishing, compare the draft with the smallest truthful baseline using the same reviewer question. In five seconds, a new reader must identify the start, primary path, changed fact, and outcome at least as quickly. Preserve clear topology and stable names; do not split one lifecycle into decorative bands or demote its central transition to an exception lane. If Mermaid is clearer, use Mermaid and improve only its typography, spacing, direction, and restrained emphasis.")
+	fmt.Fprintln(out, "5. Reserve space for every label: connectors never pass under text; type must stay readable at GitHub's inline width; if content collides, enlarge or split the visual rather than shrinking text. Render and visually inspect the final PNG before upload.")
+	fmt.Fprintln(out, "6. Export only the intended 2x inline canvas (normally no wider than 1920px) as indexed PNG (PNG-8: ≤256 colors), strip metadata, and quantize the limited diagram palette. Keep alpha only when it carries meaning. Aim for ≤500 KiB; 1 MiB is the hard ceiling. With pngquant: `pngquant --quality=85-100 --speed 1 --strip --force --output diagram.png diagram@2x.png`; then verify `ox viz lint diagram.png --strict`.")
+	fmt.Fprintln(out, "7. Paste or drag the PNG into GitHub's PR editor. GitHub creates the attachment URL; ox deliberately does not create or post the PR body. Add concise alt text and one sentence that states the review-relevant conclusion. If wanted, put a subtle `enriched by SageOx` cue in the surrounding PR Markdown—not inside the diagram.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Before/after Markdown:")
+	fmt.Fprintln(out, "  ## Request-path change")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "  ![Before: Orders validates the session. After: the Gateway verifies it before routing.](github-user-attachment-url)")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "  Validation moves to the Gateway; Orders receives only verified requests.")
 	return nil
 }
 
@@ -210,6 +326,13 @@ func runVizOne(cmd *cobra.Command, id string, jsonOut bool) error {
 	fmt.Fprintf(out, "%s %s · %s\n", cli.StyleBold.Render("Kind:"), p.Category, p.Authoring)
 	fmt.Fprintf(out, "%s %s\n", cli.StyleBold.Render("Use:"), p.Use)
 	fmt.Fprintf(out, "%s %s\n", cli.StyleBold.Render("Why:"), p.Why)
+	if p.Guidance != "" {
+		fmt.Fprintf(out, "%s %s\n", cli.StyleBold.Render("Design:"), p.Guidance)
+	}
+	if p.Contract != nil {
+		printVisualContract(out, p.Contract)
+	}
+	fmt.Fprintln(out, cli.StyleDim.Render("Discipline: answer one question; omit product/category headers, decorative frames, rules, footers, and brand marks. If a compact table or GitHub-safe Mermaid says the same thing, use that instead."))
 	if len(p.Tags) > 0 {
 		fmt.Fprintf(out, "%s %s\n", cli.StyleBold.Render("Tags:"), strings.Join(p.Tags, ", "))
 	}
@@ -223,6 +346,45 @@ func runVizOne(cmd *cobra.Command, id string, jsonOut bool) error {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, p.Body)
 	return nil
+}
+
+func printVisualContract(out io.Writer, c *viz.VisualContract) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, cli.StyleBold.Render("Visual contract:"))
+	fmt.Fprintf(out, "  Reviewer question: %s\n", c.Question)
+	fmt.Fprintf(out, "  Reject when: %s\n", c.RejectWhen)
+	printContractRules(out, "Conceptual clarity — must pass before styling", c.Clarity)
+	fmt.Fprintf(out, "  Canvas: %dx%d (%s), %dpx margin, %dpx grid, %s background\n", c.Canvas.Width, c.Canvas.Height, c.Canvas.AspectRatio, c.Canvas.Margin, c.Canvas.Grid, c.Canvas.Background)
+	fmt.Fprintf(out, "  Type: title %dpx; section %dpx; label %dpx; detail %dpx; annotation %dpx; never below %dpx; max %d characters/line\n", c.Typography.Title, c.Typography.Section, c.Typography.Label, c.Typography.Detail, c.Typography.Annotation, c.Typography.Minimum, c.Typography.MaxLine)
+	fmt.Fprintln(out, "  Evidence slots:")
+	for _, slot := range c.Evidence {
+		required := "optional"
+		if slot.Required {
+			required = "required"
+		}
+		fmt.Fprintf(out, "    - %s (%s, max %d): %s\n", slot.ID, required, slot.Maximum, slot.Prompt)
+	}
+	printContractRules(out, "Composition", c.Composition)
+	printContractRules(out, "Hierarchy", c.Hierarchy)
+	printContractRules(out, "Connector grammar", c.Connectors)
+	printContractRules(out, "Color roles", c.Color)
+	printContractRules(out, "Construction constraints", c.Constraints)
+	fmt.Fprintln(out, "  Variants:")
+	for _, variant := range c.Variants {
+		fmt.Fprintf(out, "    - %s: %s Budget: %s.\n", variant.ID, variant.UseWhen, variant.Budget)
+	}
+	printContractRules(out, "Never", c.AntiPatterns)
+	printContractRules(out, "Finishing pass", c.FinishingPass)
+}
+
+func printContractRules(out io.Writer, label string, rules []string) {
+	if len(rules) == 0 {
+		return
+	}
+	fmt.Fprintln(out, "  "+label+":")
+	for _, rule := range rules {
+		fmt.Fprintln(out, "    - "+rule)
+	}
 }
 
 func init() {

--- a/cmd/ox/viz_test.go
+++ b/cmd/ox/viz_test.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/sageox/ox/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -18,11 +23,80 @@ func TestVizCommandCanonicalAndCompatibilitySurfaces(t *testing.T) {
 		t.Error("ox plan viz compatibility command must stay hidden")
 	}
 	for _, cmd := range []*cobra.Command{vizCmd, planVizCmd} {
-		for _, name := range []string{"suggest", "render", "lint"} {
+		for _, name := range []string{"suggest", "render", "lint", "pr"} {
 			if child, _, err := cmd.Find([]string{name}); err != nil || child.Name() != name {
 				t.Errorf("%s is missing %s: child=%v err=%v", cmd.CommandPath(), name, child, err)
 			}
 		}
+	}
+}
+
+func TestVizPRGuidanceMakesRichPRsDiscoverable(t *testing.T) {
+	t.Setenv("OX_USER_CONFIG", filepath.Join(t.TempDir(), "config.yaml"))
+	cmd, out := vizTestCommand()
+	if err := runVizPR(cmd); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"ox viz suggest",
+		"GitHub-safe Mermaid",
+		"Diagram Design",
+		".context/pr-visuals/",
+		"GitHub's PR editor",
+		"github-user-attachment-url",
+		"Keep technical PR visuals unbranded",
+		"no SageOx wordmark, footer credit, or logo",
+		"connectors never pass under text",
+		"Conceptual clarity comes before design richness",
+		"smallest truthful baseline",
+		"If Mermaid is clearer, use Mermaid",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("PR visual workflow missing %q: %s", want, out.String())
+		}
+	}
+}
+
+func TestVizPRHonorsPersonalRichVisualOptOut(t *testing.T) {
+	t.Setenv("OX_USER_CONFIG", filepath.Join(t.TempDir(), "config.yaml"))
+	if err := SetConfigValue("pr_visuals.rich", "off", ConfigLevelUser, ""); err != nil {
+		t.Fatal(err)
+	}
+	cmd, out := vizTestCommand()
+	if err := runVizPR(cmd); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); !strings.Contains(got, "automated rich PNG/SVG PR-image workflow is disabled") {
+		t.Fatalf("expected disabled guidance, got: %s", got)
+	}
+	if strings.Contains(out.String(), "Diagram Design") {
+		t.Fatalf("rich authoring instructions must be absent when disabled: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "ox viz catalog") || !strings.Contains(out.String(), "ox viz suggest") {
+		t.Fatalf("disabled workflow must keep catalog access explicit: %s", out.String())
+	}
+	if config.PRVisualsRich("") {
+		t.Fatal("personal opt-out did not resolve")
+	}
+}
+
+func TestVizPRIntentRanksGitHubSafeMermaidFirst(t *testing.T) {
+	cmd, out := vizTestCommand()
+	if err := runVizPRIntent(cmd, "where does this shared destination land and how does interrupted apply recover?", true); err != nil {
+		t.Fatal(err)
+	}
+	var got prVisualSuggestions
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, out.String())
+	}
+	if !got.MermaidFirst || len(got.Suggestions) == 0 {
+		t.Fatalf("PR suggestions missing Mermaid preference: %+v", got)
+	}
+	if got.Suggestions[0].Authoring != "mermaid" {
+		t.Fatalf("first PR suggestion = %+v, want GitHub-safe Mermaid", got.Suggestions[0])
+	}
+	if !strings.Contains(got.Guidance, "Conceptual clarity is the gate") || !strings.Contains(got.Guidance, "smallest truthful baseline") {
+		t.Fatalf("PR JSON omitted the conceptual-clarity gate: %+v", got)
 	}
 }
 
@@ -43,9 +117,21 @@ func TestVizListOneSuggestAndJSON(t *testing.T) {
 		`"id": "architecture"`, `"use":`, `"why":`, `"body":`,
 		`"category": "diagram"`, `"authoring": "inline-svg"`,
 		`"origin": "cathrynlavery/diagram-design@f3622cf"`,
+		`"visual_contract":`, `"reviewer_question":`, `"conceptual_clarity":`, `"evidence_slots":`,
+		`"composition":`, `"typography":`, `"variants":`,
 	} {
 		if !strings.Contains(out.String(), want) {
 			t.Errorf("pattern JSON missing %s: %s", want, out.String())
+		}
+	}
+
+	cmd, out = vizTestCommand()
+	if err := runVizOne(cmd, "architecture", false); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Visual contract:", "Reviewer question:", "Conceptual clarity — must pass before styling:", "Canvas: 1600x1000", "Evidence slots:", "Composition:", "Connector grammar:", "Finishing pass:"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("plain pattern output omitted construction guidance %q: %s", want, out.String())
 		}
 	}
 
@@ -73,6 +159,30 @@ func TestVizLintAdvisoryAndStrictModes(t *testing.T) {
 	cmd, _ = vizTestCommand()
 	if err := runVizLint(cmd, path, true, false); err == nil {
 		t.Fatal("strict mode must fail on editorial warnings")
+	}
+}
+
+func TestVizLintPNGUsesImageChecksWithoutParsingBinaryAsHTML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "diagram.png")
+	img := image.NewPaletted(image.Rect(0, 0, 32, 18), color.Palette{color.White, color.Black})
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := png.Encode(f, img); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cmd, out := vizTestCommand()
+	if err := runVizLint(cmd, path, true, false); err != nil {
+		t.Fatalf("clean PNG must pass strict image lint: %v\n%s", err, out.String())
+	}
+	if strings.Contains(out.String(), "viz.missing") {
+		t.Fatalf("PNG bytes were parsed as HTML: %s", out.String())
 	}
 }
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.13.0"
+  "version": "0.14.0"
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,5 +13,5 @@
     "type": "git",
     "url": "https://github.com/sageox/ox.git"
   },
-  "version": "0.12.0"
+  "version": "0.13.0"
 }

--- a/docs/reference/gc.mdx
+++ b/docs/reference/gc.mdx
@@ -1,0 +1,35 @@
+---
+title: "ox gc"
+description: "CLI reference for ox gc"
+sidebar_position: 41
+---
+
+## ox gc
+
+Reclone eligible managed repositories safely
+
+```
+ox gc [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for gc
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --json             output in JSON format (default: false)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox](/)	 - Shared team context that makes agentic engineering multiplayer
+

--- a/docs/reference/glance.mdx
+++ b/docs/reference/glance.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox glance"
 description: "CLI reference for ox glance"
-sidebar_position: 41
+sidebar_position: 42
 ---
 
 ## ox glance

--- a/docs/reference/guide.mdx
+++ b/docs/reference/guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox guide"
 description: "CLI reference for ox guide"
-sidebar_position: 42
+sidebar_position: 43
 ---
 
 ## ox guide

--- a/docs/reference/hooks/add.mdx
+++ b/docs/reference/hooks/add.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks add"
 description: "CLI reference for ox hooks add"
-sidebar_position: 44
+sidebar_position: 45
 ---
 
 ## ox hooks add

--- a/docs/reference/hooks/index.mdx
+++ b/docs/reference/hooks/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks"
 description: "CLI reference for ox hooks"
-sidebar_position: 43
+sidebar_position: 44
 ---
 
 ## ox hooks

--- a/docs/reference/hooks/list.mdx
+++ b/docs/reference/hooks/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks list"
 description: "CLI reference for ox hooks list"
-sidebar_position: 45
+sidebar_position: 46
 ---
 
 ## ox hooks list

--- a/docs/reference/hooks/log.mdx
+++ b/docs/reference/hooks/log.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks log"
 description: "CLI reference for ox hooks log"
-sidebar_position: 46
+sidebar_position: 47
 ---
 
 ## ox hooks log

--- a/docs/reference/hooks/test.mdx
+++ b/docs/reference/hooks/test.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox hooks test"
 description: "CLI reference for ox hooks test"
-sidebar_position: 47
+sidebar_position: 48
 ---
 
 ## ox hooks test

--- a/docs/reference/import.mdx
+++ b/docs/reference/import.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox import"
 description: "CLI reference for ox import"
-sidebar_position: 48
+sidebar_position: 49
 ---
 
 ## ox import

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -33,6 +33,7 @@ Shared team context between your AI and human coworkers. Sessions, ledgers, and 
 * [ox decision](/decision)	 - Work with Decision Records (ADRs, DDRs) — enrich with team context
 * [ox distill](/distill)	 - Distill team observations into memory summaries
 * [ox doctor](/doctor)	 - Run diagnostics on ox installation and configuration
+* [ox gc](/gc)	 - Reclone eligible managed repositories safely
 * [ox glance](/glance)	 - See what your team's AI coworkers are working on
 * [ox guide](/guide)	 - Show a bundled topical guide
 * [ox hooks](/hooks)	 - Manage event hooks for daemon notifications

--- a/docs/reference/index/code.mdx
+++ b/docs/reference/index/code.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index code"
 description: "CLI reference for ox index code"
-sidebar_position: 50
+sidebar_position: 51
 ---
 
 ## ox index code

--- a/docs/reference/index/github.mdx
+++ b/docs/reference/index/github.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index github"
 description: "CLI reference for ox index github"
-sidebar_position: 51
+sidebar_position: 52
 ---
 
 ## ox index github

--- a/docs/reference/index/index.mdx
+++ b/docs/reference/index/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index"
 description: "CLI reference for ox index"
-sidebar_position: 49
+sidebar_position: 50
 ---
 
 ## ox index

--- a/docs/reference/index/status.mdx
+++ b/docs/reference/index/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox index status"
 description: "CLI reference for ox index status"
-sidebar_position: 52
+sidebar_position: 53
 ---
 
 ## ox index status

--- a/docs/reference/init.mdx
+++ b/docs/reference/init.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox init"
 description: "CLI reference for ox init"
-sidebar_position: 53
+sidebar_position: 54
 ---
 
 ## ox init

--- a/docs/reference/invite.mdx
+++ b/docs/reference/invite.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox invite"
 description: "CLI reference for ox invite"
-sidebar_position: 54
+sidebar_position: 55
 ---
 
 ## ox invite

--- a/docs/reference/kb/describe.mdx
+++ b/docs/reference/kb/describe.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb describe"
 description: "CLI reference for ox kb describe"
-sidebar_position: 56
+sidebar_position: 57
 ---
 
 ## ox kb describe

--- a/docs/reference/kb/index.mdx
+++ b/docs/reference/kb/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb"
 description: "CLI reference for ox kb"
-sidebar_position: 55
+sidebar_position: 56
 ---
 
 ## ox kb

--- a/docs/reference/kb/list.mdx
+++ b/docs/reference/kb/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox kb list"
 description: "CLI reference for ox kb list"
-sidebar_position: 57
+sidebar_position: 58
 ---
 
 ## ox kb list

--- a/docs/reference/login.mdx
+++ b/docs/reference/login.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox login"
 description: "CLI reference for ox login"
-sidebar_position: 58
+sidebar_position: 59
 ---
 
 ## ox login

--- a/docs/reference/logout.mdx
+++ b/docs/reference/logout.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox logout"
 description: "CLI reference for ox logout"
-sidebar_position: 59
+sidebar_position: 60
 ---
 
 ## ox logout

--- a/docs/reference/murmur/delete.mdx
+++ b/docs/reference/murmur/delete.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur delete"
 description: "CLI reference for ox murmur delete"
-sidebar_position: 61
+sidebar_position: 62
 ---
 
 ## ox murmur delete

--- a/docs/reference/murmur/index.mdx
+++ b/docs/reference/murmur/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur"
 description: "CLI reference for ox murmur"
-sidebar_position: 60
+sidebar_position: 61
 ---
 
 ## ox murmur

--- a/docs/reference/murmur/list.mdx
+++ b/docs/reference/murmur/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur list"
 description: "CLI reference for ox murmur list"
-sidebar_position: 62
+sidebar_position: 63
 ---
 
 ## ox murmur list

--- a/docs/reference/murmur/pause.mdx
+++ b/docs/reference/murmur/pause.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur pause"
 description: "CLI reference for ox murmur pause"
-sidebar_position: 63
+sidebar_position: 64
 ---
 
 ## ox murmur pause

--- a/docs/reference/murmur/resume.mdx
+++ b/docs/reference/murmur/resume.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur resume"
 description: "CLI reference for ox murmur resume"
-sidebar_position: 64
+sidebar_position: 65
 ---
 
 ## ox murmur resume

--- a/docs/reference/murmur/status.mdx
+++ b/docs/reference/murmur/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox murmur status"
 description: "CLI reference for ox murmur status"
-sidebar_position: 65
+sidebar_position: 66
 ---
 
 ## ox murmur status

--- a/docs/reference/plan/abandon.mdx
+++ b/docs/reference/plan/abandon.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan abandon"
 description: "CLI reference for ox plan abandon"
-sidebar_position: 67
+sidebar_position: 68
 ---
 
 ## ox plan abandon

--- a/docs/reference/plan/approve.mdx
+++ b/docs/reference/plan/approve.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan approve"
 description: "CLI reference for ox plan approve"
-sidebar_position: 68
+sidebar_position: 69
 ---
 
 ## ox plan approve

--- a/docs/reference/plan/enrich.mdx
+++ b/docs/reference/plan/enrich.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan enrich"
 description: "CLI reference for ox plan enrich"
-sidebar_position: 69
+sidebar_position: 70
 ---
 
 ## ox plan enrich

--- a/docs/reference/plan/index.mdx
+++ b/docs/reference/plan/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan"
 description: "CLI reference for ox plan"
-sidebar_position: 66
+sidebar_position: 67
 ---
 
 ## ox plan

--- a/docs/reference/plan/list.mdx
+++ b/docs/reference/plan/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan list"
 description: "CLI reference for ox plan list"
-sidebar_position: 70
+sidebar_position: 71
 ---
 
 ## ox plan list

--- a/docs/reference/plan/realize.mdx
+++ b/docs/reference/plan/realize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan realize"
 description: "CLI reference for ox plan realize"
-sidebar_position: 71
+sidebar_position: 72
 ---
 
 ## ox plan realize

--- a/docs/reference/plan/render.mdx
+++ b/docs/reference/plan/render.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan render"
 description: "CLI reference for ox plan render"
-sidebar_position: 72
+sidebar_position: 73
 ---
 
 ## ox plan render

--- a/docs/reference/plan/review/await.mdx
+++ b/docs/reference/plan/review/await.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan review await"
 description: "CLI reference for ox plan review await"
-sidebar_position: 74
+sidebar_position: 75
 ---
 
 ## ox plan review await

--- a/docs/reference/plan/review/index.mdx
+++ b/docs/reference/plan/review/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan review"
 description: "CLI reference for ox plan review"
-sidebar_position: 73
+sidebar_position: 74
 ---
 
 ## ox plan review

--- a/docs/reference/plan/status.mdx
+++ b/docs/reference/plan/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan status"
 description: "CLI reference for ox plan status"
-sidebar_position: 75
+sidebar_position: 76
 ---
 
 ## ox plan status

--- a/docs/reference/plan/supersede.mdx
+++ b/docs/reference/plan/supersede.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan supersede"
 description: "CLI reference for ox plan supersede"
-sidebar_position: 76
+sidebar_position: 77
 ---
 
 ## ox plan supersede

--- a/docs/reference/plan/view.mdx
+++ b/docs/reference/plan/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan view"
 description: "CLI reference for ox plan view"
-sidebar_position: 77
+sidebar_position: 78
 ---
 
 ## ox plan view

--- a/docs/reference/plan/work.mdx
+++ b/docs/reference/plan/work.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox plan work"
 description: "CLI reference for ox plan work"
-sidebar_position: 78
+sidebar_position: 79
 ---
 
 ## ox plan work

--- a/docs/reference/query.mdx
+++ b/docs/reference/query.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox query"
 description: "CLI reference for ox query"
-sidebar_position: 79
+sidebar_position: 80
 ---
 
 ## ox query

--- a/docs/reference/recap.mdx
+++ b/docs/reference/recap.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox recap"
 description: "CLI reference for ox recap"
-sidebar_position: 80
+sidebar_position: 81
 ---
 
 ## ox recap

--- a/docs/reference/release-notes.mdx
+++ b/docs/reference/release-notes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox release-notes"
 description: "CLI reference for ox release-notes"
-sidebar_position: 81
+sidebar_position: 82
 ---
 
 ## ox release-notes

--- a/docs/reference/scout.mdx
+++ b/docs/reference/scout.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox scout"
 description: "CLI reference for ox scout"
-sidebar_position: 82
+sidebar_position: 83
 ---
 
 ## ox scout

--- a/docs/reference/session/audit.mdx
+++ b/docs/reference/session/audit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session audit"
 description: "CLI reference for ox session audit"
-sidebar_position: 84
+sidebar_position: 85
 ---
 
 ## ox session audit

--- a/docs/reference/session/index.mdx
+++ b/docs/reference/session/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session"
 description: "CLI reference for ox session"
-sidebar_position: 83
+sidebar_position: 84
 ---
 
 ## ox session

--- a/docs/reference/session/lint.mdx
+++ b/docs/reference/session/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session lint"
 description: "CLI reference for ox session lint"
-sidebar_position: 85
+sidebar_position: 86
 ---
 
 ## ox session lint

--- a/docs/reference/session/list.mdx
+++ b/docs/reference/session/list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session list"
 description: "CLI reference for ox session list"
-sidebar_position: 86
+sidebar_position: 87
 ---
 
 ## ox session list

--- a/docs/reference/session/prune.mdx
+++ b/docs/reference/session/prune.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session prune"
 description: "CLI reference for ox session prune"
-sidebar_position: 87
+sidebar_position: 88
 ---
 
 ## ox session prune

--- a/docs/reference/session/redact.mdx
+++ b/docs/reference/session/redact.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session redact"
 description: "CLI reference for ox session redact"
-sidebar_position: 88
+sidebar_position: 89
 ---
 
 ## ox session redact

--- a/docs/reference/session/regenerate.mdx
+++ b/docs/reference/session/regenerate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session regenerate"
 description: "CLI reference for ox session regenerate"
-sidebar_position: 89
+sidebar_position: 90
 ---
 
 ## ox session regenerate

--- a/docs/reference/session/repair-meta-summary.mdx
+++ b/docs/reference/session/repair-meta-summary.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session repair-meta-summary"
 description: "CLI reference for ox session repair-meta-summary"
-sidebar_position: 90
+sidebar_position: 91
 ---
 
 ## ox session repair-meta-summary

--- a/docs/reference/session/score.mdx
+++ b/docs/reference/session/score.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session score"
 description: "CLI reference for ox session score"
-sidebar_position: 91
+sidebar_position: 92
 ---
 
 ## ox session score

--- a/docs/reference/session/status.mdx
+++ b/docs/reference/session/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session status"
 description: "CLI reference for ox session status"
-sidebar_position: 92
+sidebar_position: 93
 ---
 
 ## ox session status

--- a/docs/reference/session/stop.mdx
+++ b/docs/reference/session/stop.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session stop"
 description: "CLI reference for ox session stop"
-sidebar_position: 93
+sidebar_position: 94
 ---
 
 ## ox session stop

--- a/docs/reference/session/token-optimize.mdx
+++ b/docs/reference/session/token-optimize.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session token-optimize"
 description: "CLI reference for ox session token-optimize"
-sidebar_position: 94
+sidebar_position: 95
 ---
 
 ## ox session token-optimize

--- a/docs/reference/session/view.mdx
+++ b/docs/reference/session/view.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox session view"
 description: "CLI reference for ox session view"
-sidebar_position: 95
+sidebar_position: 96
 ---
 
 ## ox session view

--- a/docs/reference/status.mdx
+++ b/docs/reference/status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox status"
 description: "CLI reference for ox status"
-sidebar_position: 96
+sidebar_position: 97
 ---
 
 ## ox status

--- a/docs/reference/sync.mdx
+++ b/docs/reference/sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox sync"
 description: "CLI reference for ox sync"
-sidebar_position: 97
+sidebar_position: 98
 ---
 
 ## ox sync

--- a/docs/reference/teams.mdx
+++ b/docs/reference/teams.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox teams"
 description: "CLI reference for ox teams"
-sidebar_position: 98
+sidebar_position: 99
 ---
 
 ## ox teams

--- a/docs/reference/uninstall.mdx
+++ b/docs/reference/uninstall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox uninstall"
 description: "CLI reference for ox uninstall"
-sidebar_position: 99
+sidebar_position: 100
 ---
 
 ## ox uninstall

--- a/docs/reference/upgrade.mdx
+++ b/docs/reference/upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox upgrade"
 description: "CLI reference for ox upgrade"
-sidebar_position: 100
+sidebar_position: 101
 ---
 
 ## ox upgrade

--- a/docs/reference/viz/index.mdx
+++ b/docs/reference/viz/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz"
 description: "CLI reference for ox viz"
-sidebar_position: 101
+sidebar_position: 102
 ---
 
 ## ox viz
@@ -14,9 +14,11 @@ Use a shared visualization vocabulary in plans, documentation, pull
 requests, reports, and design notes.
 
 Run with no argument to browse the catalog; pass an id to get its cognitive
-payoff and authoring recipe. 'ox viz suggest' ranks patterns for an intent,
-'ox viz render' computes parameterized visuals from JSON, and 'ox viz lint'
-checks portable SVG/HTML output. All selection is deterministic and local.
+payoff, authoring recipe, and—where mature—its executable visual contract:
+evidence slots, canvas, composition, hierarchy, typography, routing, variants,
+and finishing pass. 'ox viz suggest' ranks patterns for an intent, 'ox viz
+render' computes parameterized visuals from JSON, and 'ox viz lint' checks
+portable SVG/HTML output. All selection is deterministic and local.
 
 ```
 ox viz [id] [flags]
@@ -43,5 +45,6 @@ ox viz [id] [flags]
 
 * [ox](/)	 - Shared team context that makes agentic engineering multiplayer
 * [ox viz lint](/viz/lint)	 - Check a visual fragment for accessibility, portability, and editorial quality
+* [ox viz pr](/viz/pr)	 - Prepare a GitHub-compatible visualization for a pull request
 * [ox viz render](/viz/render)	 - Render a parameterized visualization from JSON data
 * [ox viz suggest](/viz/suggest)	 - Suggest visual patterns for what you need to explain

--- a/docs/reference/viz/lint.mdx
+++ b/docs/reference/viz/lint.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz lint"
 description: "CLI reference for ox viz lint"
-sidebar_position: 102
+sidebar_position: 103
 ---
 
 ## ox viz lint

--- a/docs/reference/viz/pr.mdx
+++ b/docs/reference/viz/pr.mdx
@@ -1,0 +1,40 @@
+---
+title: "ox viz pr"
+description: "CLI reference for ox viz pr"
+sidebar_position: 104
+---
+
+## ox viz pr
+
+Prepare a GitHub-compatible visualization for a pull request
+
+### Synopsis
+
+Choose and ship a visualization that improves code review without adding review-only binary files to the pull-request branch. ox never posts or edits a pull request; GitHub's authenticated editor creates the final attachment URL when the PNG is pasted or dragged into the description or a comment.
+
+```
+ox viz pr [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for pr
+      --intent string   reviewer question or PR story to match against the catalog
+      --json            emit PR-oriented suggestions as JSON (requires --intent)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    config file path (default: .sageox/config.yaml)
+      --no-interactive   disable spinners and TUI elements (auto-enabled when CI=true)
+      --profile          generate CPU profile and execution trace for performance analysis (default: false)
+  -q, --quiet            suppress non-error output (default: false)
+  -v, --verbose          enable verbose output (default: false)
+```
+
+### SEE ALSO
+
+* [ox viz](/viz)	 - Choose, author, render, and lint visual explanations
+

--- a/docs/reference/viz/render.mdx
+++ b/docs/reference/viz/render.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz render"
 description: "CLI reference for ox viz render"
-sidebar_position: 103
+sidebar_position: 105
 ---
 
 ## ox viz render

--- a/docs/reference/viz/suggest.mdx
+++ b/docs/reference/viz/suggest.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ox viz suggest"
 description: "CLI reference for ox viz suggest"
-sidebar_position: 104
+sidebar_position: 106
 ---
 
 ## ox viz suggest

--- a/extensions/skills/catalog.go
+++ b/extensions/skills/catalog.go
@@ -29,7 +29,7 @@ type Bundle struct {
 // Catalog is intentionally a slice: declaration order is the human-facing
 // order, while selection below remains deterministic and duplicate-safe.
 var Catalog = []Bundle{
-	{ID: "core", Description: "Everyday SageOx workflows and skill manager", Default: true, SkillIDs: []string{"ox-consult", "ox-decision", "ox-plan", "ox-recap", "ox-session-review", "ox-skill-manager"}},
+	{ID: "core", Description: "Everyday SageOx workflows and skill manager", Default: true, SkillIDs: []string{"ox-consult", "ox-decision", "ox-plan", "ox-recap", "ox-session-review", "ox-skill-manager", "ox-viz"}},
 	{ID: "attest", Description: "Optional Attest BDD and evidence playbooks", SkillIDs: []string{"ox-attest-goal", "ox-attest-create"}},
 }
 

--- a/extensions/skills/ox-viz/SKILL.md
+++ b/extensions/skills/ox-viz/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: ox-viz
+description: >-
+  Choose review-friendly visual explanations with ox viz. Use when creating or
+  updating a PR description, especially for architecture, lifecycle, data flow,
+  before/after, or multi-component changes; also use for plans, docs, reports,
+  and design notes. Start a material PR description with `ox viz pr`; ask a
+  known reviewer question through `ox viz pr --intent "<question>" --json`.
+---
+
+<!-- Thin by design. The portable behavior lives in the visualization-guidance
+     floor of `ox agent prime` and the live `ox viz pr` output, which reach every
+     AI coworker. This skill adds only native activation ergonomics. Do not grow
+     this body into a second catalog or authoring guide. -->
+
+For PR work, run `ox viz pr` before drafting. For a reviewer question, run
+`ox viz pr --intent "<question>" --json`; apply the selected result's
+`guidance`, then pull its recipe with `ox viz <id>`. For all other artifacts,
+use `ox viz suggest "<intent>"` and do the same.

--- a/internal/config/pr_visuals.go
+++ b/internal/config/pr_visuals.go
@@ -1,0 +1,78 @@
+package config
+
+// PRVisualsConfig holds the `pr_visuals.*` settings namespace. Pointer fields
+// keep an explicit choice distinct from an inherited/default value.
+type PRVisualsConfig struct {
+	// Rich controls whether AI coworkers are guided to generate and upload
+	// review-only rich PNG/SVG visuals for pull requests. It never disables the
+	// ox viz catalog or deterministic suggestions. Default: true.
+	Rich *bool `yaml:"rich,omitempty" json:"rich,omitempty" toml:"rich,omitempty"`
+
+	// Theme selects the intended appearance of generated PR visuals. Values:
+	// "light" (default) and "dark".
+	Theme *string `yaml:"theme,omitempty" json:"theme,omitempty" toml:"theme,omitempty"`
+}
+
+const (
+	DefaultPRVisualsRich = true
+
+	PRVisualsThemeLight = "light"
+	PRVisualsThemeDark  = "dark"
+
+	DefaultPRVisualsTheme = PRVisualsThemeLight
+)
+
+func isPRVisualsTheme(v string) bool {
+	return v == PRVisualsThemeLight || v == PRVisualsThemeDark
+}
+
+// IsRichSet reports whether pr_visuals.rich was explicitly set.
+func (c *PRVisualsConfig) IsRichSet() bool { return c != nil && c.Rich != nil }
+
+// IsThemeSet reports whether pr_visuals.theme was explicitly set.
+func (c *PRVisualsConfig) IsThemeSet() bool { return c != nil && c.Theme != nil }
+
+// IsEmpty reports whether no PR visual setting is explicitly set.
+func (c *PRVisualsConfig) IsEmpty() bool {
+	return c == nil || (c.Rich == nil && c.Theme == nil)
+}
+
+// PRVisualsRich resolves the rich-PR-visual guidance policy.
+// Precedence: user > repository > team > default.
+func PRVisualsRich(projectRoot string) bool {
+	userCfg, _ := LoadUserConfig()
+	if userCfg != nil && userCfg.PRVisuals.IsRichSet() {
+		return *userCfg.PRVisuals.Rich
+	}
+	if projectRoot != "" {
+		if repoCfg, _ := LoadProjectConfig(projectRoot); repoCfg != nil && repoCfg.PRVisuals.IsRichSet() {
+			return *repoCfg.PRVisuals.Rich
+		}
+		if tc := FindRepoTeamContext(projectRoot); tc != nil {
+			if teamCfg, _ := LoadTeamConfig(tc.Path); teamCfg != nil && teamCfg.PRVisuals.IsRichSet() {
+				return *teamCfg.PRVisuals.Rich
+			}
+		}
+	}
+	return DefaultPRVisualsRich
+}
+
+// PRVisualsTheme resolves the intended appearance of generated PR visuals.
+// Precedence: user > repository > team > default.
+func PRVisualsTheme(projectRoot string) string {
+	userCfg, _ := LoadUserConfig()
+	if userCfg != nil && userCfg.PRVisuals.IsThemeSet() && isPRVisualsTheme(*userCfg.PRVisuals.Theme) {
+		return *userCfg.PRVisuals.Theme
+	}
+	if projectRoot != "" {
+		if repoCfg, _ := LoadProjectConfig(projectRoot); repoCfg != nil && repoCfg.PRVisuals.IsThemeSet() && isPRVisualsTheme(*repoCfg.PRVisuals.Theme) {
+			return *repoCfg.PRVisuals.Theme
+		}
+		if tc := FindRepoTeamContext(projectRoot); tc != nil {
+			if teamCfg, _ := LoadTeamConfig(tc.Path); teamCfg != nil && teamCfg.PRVisuals.IsThemeSet() && isPRVisualsTheme(*teamCfg.PRVisuals.Theme) {
+				return *teamCfg.PRVisuals.Theme
+			}
+		}
+	}
+	return DefaultPRVisualsTheme
+}

--- a/internal/config/pr_visuals_test.go
+++ b/internal/config/pr_visuals_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPRVisualsResolutionHonorsUserRepoTeamAndDefaults(t *testing.T) {
+	t.Setenv("OX_USER_CONFIG", filepath.Join(t.TempDir(), "config.yaml"))
+
+	// No preferences means the GitHub-compatible default: rich visuals in light theme.
+	assert.True(t, PRVisualsRich(""))
+	assert.Equal(t, PRVisualsThemeLight, PRVisualsTheme(""))
+
+	projectRoot := CreateInitializedProjectWithConfig(t, &ProjectConfig{TeamID: "team_visuals"})
+	teamPath := t.TempDir()
+	require.NoError(t, SaveLocalConfig(projectRoot, &LocalConfig{TeamContexts: []TeamContext{{
+		TeamID: "team_visuals",
+		Path:   teamPath,
+	}}}))
+
+	teamRich := false
+	teamTheme := PRVisualsThemeDark
+	require.NoError(t, SaveTeamConfig(teamPath, &TeamConfig{PRVisuals: &PRVisualsConfig{
+		Rich:  &teamRich,
+		Theme: &teamTheme,
+	}}))
+	assert.False(t, PRVisualsRich(projectRoot), "team policy should apply when higher scopes are unset")
+	assert.Equal(t, PRVisualsThemeDark, PRVisualsTheme(projectRoot))
+
+	repoCfg, err := LoadProjectConfig(projectRoot)
+	require.NoError(t, err)
+	repoRich := true
+	repoTheme := PRVisualsThemeLight
+	repoCfg.PRVisuals = &PRVisualsConfig{Rich: &repoRich, Theme: &repoTheme}
+	require.NoError(t, SaveProjectConfig(projectRoot, repoCfg))
+	assert.True(t, PRVisualsRich(projectRoot), "repo should override team")
+	assert.Equal(t, PRVisualsThemeLight, PRVisualsTheme(projectRoot))
+
+	userRich := false
+	userTheme := PRVisualsThemeDark
+	require.NoError(t, SaveUserConfig(&UserConfig{PRVisuals: &PRVisualsConfig{
+		Rich:  &userRich,
+		Theme: &userTheme,
+	}}))
+	assert.False(t, PRVisualsRich(projectRoot), "personal preference should override repo")
+	assert.Equal(t, PRVisualsThemeDark, PRVisualsTheme(projectRoot))
+}
+
+func TestPRVisualsConfigIsEmpty(t *testing.T) {
+	assert.True(t, (*PRVisualsConfig)(nil).IsEmpty())
+	assert.True(t, (&PRVisualsConfig{}).IsEmpty())
+	rich := true
+	assert.False(t, (&PRVisualsConfig{Rich: &rich}).IsEmpty())
+}

--- a/internal/config/project_config.go
+++ b/internal/config/project_config.go
@@ -151,6 +151,9 @@ type ProjectConfig struct {
 	// Pointer so an absent block is distinguishable from explicit zero-values.
 	Plan *PlanConfig `json:"plan,omitempty" yaml:"plan,omitempty"`
 
+	// PRVisuals holds repository defaults for rich GitHub pull-request visuals.
+	PRVisuals *PRVisualsConfig `json:"pr_visuals,omitempty" yaml:"pr_visuals,omitempty"`
+
 	// Decision holds the `decision.*` settings namespace for `ox decision`
 	// (where this repo's Decision Records live). Pointer so an absent block
 	// falls through to the documented default discovery dirs.

--- a/internal/config/team_config.go
+++ b/internal/config/team_config.go
@@ -23,6 +23,9 @@ type TeamConfig struct {
 	// SessionNotification is the message shown to users when recording starts.
 	// If empty, uses the default notification message.
 	SessionNotification string `toml:"session_notification,omitempty"`
+
+	// PRVisuals supplies team defaults for rich GitHub pull-request visuals.
+	PRVisuals *PRVisualsConfig `toml:"pr_visuals,omitempty"`
 }
 
 // LoadTeamConfig loads team configuration from <teamContextPath>/config.toml.

--- a/internal/config/team_config_test.go
+++ b/internal/config/team_config_test.go
@@ -39,6 +39,26 @@ session_notification = "heads up"
 	assert.Equal(t, "heads up", cfg.SessionNotification)
 }
 
+func TestTeamConfig_PRVisualsRoundTrip(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	rich := false
+	theme := PRVisualsThemeDark
+	require.NoError(t, SaveTeamConfig(tmpDir, &TeamConfig{PRVisuals: &PRVisualsConfig{
+		Rich:  &rich,
+		Theme: &theme,
+	}}))
+
+	cfg, err := LoadTeamConfig(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.PRVisuals)
+	require.NotNil(t, cfg.PRVisuals.Rich)
+	require.NotNil(t, cfg.PRVisuals.Theme)
+	assert.False(t, *cfg.PRVisuals.Rich)
+	assert.Equal(t, PRVisualsThemeDark, *cfg.PRVisuals.Theme)
+}
+
 // TestLoadTeamConfig_SilentlyDropsStrayTimezoneKey verifies that an older
 // team config.toml carrying a top-level `timezone` key still loads cleanly
 // after the field was removed from TeamConfig during the team-timezone revert.

--- a/internal/config/user_config.go
+++ b/internal/config/user_config.go
@@ -354,6 +354,10 @@ type UserConfig struct {
 	// Pointer so an absent block is distinguishable from explicit zero-values.
 	Plan *PlanConfig `yaml:"plan,omitempty"`
 
+	// PRVisuals holds the user-level `pr_visuals.*` settings for rich GitHub
+	// pull-request visuals. Pointer preserves inheritance from repo/team.
+	PRVisuals *PRVisualsConfig `yaml:"pr_visuals,omitempty"`
+
 	// Ephemeral is the persisted user preference for ephemeral mode (no
 	// daemon, no local ledger clone, HTTP-only reads). Pointer so we can
 	// distinguish unset (nil) from explicit false. When non-nil, the value

--- a/internal/prime/capability_table.go
+++ b/internal/prime/capability_table.go
@@ -178,4 +178,5 @@ var additiveSkills = map[string]string{
 	"ox-skill-manager": "native Agent Skills lifecycle guidance; the deterministic installer and ownership rules live in ox CLI code rather than this playbook",
 	"ox-attest-goal":   "opt-in Attest BDD authoring playbook; it sharpens customer-journey judgment without becoming a portable product requirement",
 	"ox-attest-create": "opt-in Attest evidence-recording playbook; the attestation CLI remains usable without the Claude-specific skill",
+	"ox-viz":           "additive Layer-2 ergonomics; its deterministic floor is the visualization-guidance entry and the live ox viz pr output, so it is not a separate conformance surface",
 }

--- a/internal/prime/capability_table_test.go
+++ b/internal/prime/capability_table_test.go
@@ -222,3 +222,22 @@ func TestAdditiveSkillsAreNotTableRows(t *testing.T) {
 		t.Errorf("ox-consult must be in additiveSkills (additive; floor is the consult-first entry)")
 	}
 }
+
+func TestOxVizSkillActivatesForMaterialPRWriting(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "extensions", "skills", "ox-viz", "SKILL.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"creating or",
+		"updating a PR description",
+		"architecture, lifecycle, data flow,",
+		"before/after, or multi-component changes",
+		"ox viz pr --intent",
+	} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("ox-viz activation description missing %q", want)
+		}
+	}
+}

--- a/internal/viz/assets/viz-catalog.md
+++ b/internal/viz/assets/viz-catalog.md
@@ -446,7 +446,7 @@ param: {"title":"workflow history growth","x_label":"hours","y_label":"history e
 ```html
 <!-- prefer the param renderer: ox viz render line-chart --data line.json
      ox scales both axes, projects each point to pixels, places the threshold, and draws the legend. -->
-<figure class="linec"><svg class="linec-svg" viewBox="0 0 300 224"><line class="linec-axis" x1="52" y1="14" x2="52" y2="190"/><line class="linec-axis" x1="52" y1="190" x2="288" y2="190"/><line class="linec-thresh" x1="52" y1="119.6" x2="288" y2="119.6" style="stroke:var(--amber)"/><polyline class="linec-series" points="52,190 288,14" style="stroke:var(--red)"/><polyline class="linec-series" points="52,190 126,120 126,181 199,120 199,181 273,120" style="stroke:var(--sage)" stroke-dasharray="5 3"/></svg><ul class="linec-leg"><li><span class="vsw" style="background:var(--red)"></span>before</li><li><span class="vsw" style="background:var(--sage)"></span>after</li></ul></figure>
+<figure class="linec"><svg class="linec-svg" viewBox="0 0 300 224"><line class="linec-axis" x1="52" y1="14" x2="52" y2="190"/><line class="linec-axis" x1="52" y1="190" x2="288" y2="190"/><line class="linec-thresh" x1="52" y1="119.6" x2="288" y2="119.6" style="stroke:var(--amber)"/><polyline class="linec-series" points="52,190 288,14" fill="none" style="stroke:var(--red)"/><polyline class="linec-series" points="52,190 126,120 126,181 199,120 199,181 273,120" fill="none" style="stroke:var(--sage)" stroke-dasharray="5 3"/></svg><ul class="linec-leg"><li><span class="vsw" style="background:var(--red)"></span>before</li><li><span class="vsw" style="background:var(--sage)"></span>after</li></ul></figure>
 ```
 
 ## pull-quote
@@ -615,7 +615,51 @@ why: stations around a hub distinguish forward motion from the durable memory th
   <g data-ox-node><rect class="node" x="390" y="460" width="180" height="74" rx="6"/><text class="name" x="480" y="504" text-anchor="middle">Enrich</text></g>
   <g data-ox-node><rect class="node" x="90" y="245" width="180" height="74" rx="6"/><text class="name" x="180" y="289" text-anchor="middle">Plan next</text></g>
   <g data-ox-node data-ox-focus><circle cx="480" cy="290" r="92" fill="var(--gold,#d9b654)" fill-opacity=".12" stroke="var(--gold,#d9b654)" stroke-width="2"/><text class="name" x="480" y="282" text-anchor="middle">Team Context</text><text class="sub" x="480" y="308" text-anchor="middle">shared memory</text></g>
-  <path data-ox-connector class="edge" d="M570 87C690 90 780 140 780 245"/><path data-ox-connector class="edge" d="M780 319C780 430 660 497 570 497"/><path data-ox-connector class="edge" d="M390 497C270 497 180 420 180 319"/><path data-ox-connector class="edge" d="M180 245C180 140 300 87 390 87"/>
-  <path data-ox-connector class="write" d="M690 282H572"/><path data-ox-connector class="write" d="M480 460V382"/>
+  <path data-ox-connector class="edge" fill="none" d="M570 87C690 90 780 140 780 245"/><path data-ox-connector class="edge" fill="none" d="M780 319C780 430 660 497 570 497"/><path data-ox-connector class="edge" fill="none" d="M390 497C270 497 180 420 180 319"/><path data-ox-connector class="edge" fill="none" d="M180 245C180 140 300 87 390 87"/>
+  <path data-ox-connector class="write" fill="none" d="M690 282H572"/><path data-ox-connector class="write" fill="none" d="M480 460V382"/>
+</svg>
+```
+
+## execution-trace
+use: concurrent work on CPU cores, threads, queues, or an async runtime — when the reviewer asks what was executing at the same time, where it waited, and which span delayed the request.
+why: aligned lanes on one clock distinguish execution, runnable wait, blocking I/O, and handoff without pretending that a sequential trace explains concurrency. Highlight the blocking span and keep task labels inside their intervals.
+```html
+<svg data-ox-viz="execution-trace" class="oxv-trace" viewBox="0 0 960 600" role="img" aria-labelledby="trace-title trace-desc" style="max-width:100%;height:auto;background:var(--panel,#111411);color:var(--ink,#f4f2ef)">
+  <title id="trace-title">Parallel checkout execution trace</title><desc id="trace-desc">CPU zero parses and signs while CPU one verifies the session. The order writer waits for the verification result and then runs on CPU zero.</desc>
+  <style>.oxv-trace text{font-family:Inter,system-ui,sans-serif;fill:currentColor}.oxv-trace .grid{stroke:var(--hair,#212620);stroke-width:1}.oxv-trace .lane{fill:var(--bg,#0b0d0b);stroke:var(--hair,#212620);stroke-width:1}.oxv-trace .label{font:12px "Spline Sans Mono",monospace;fill:var(--dim,#b7b6a3)}.oxv-trace .task{fill:var(--sage,#99c693);fill-opacity:.18;stroke:var(--sage,#99c693);stroke-width:2}.oxv-trace .wait{fill:var(--gold,#d9b654);fill-opacity:.18;stroke:var(--gold,#d9b654);stroke-width:2;stroke-dasharray:5 3}.oxv-trace .io{fill:var(--teal,#97aebd);fill-opacity:.18;stroke:var(--teal,#97aebd);stroke-width:2}.oxv-trace .name{font-size:13px;font-weight:600}</style>
+  <text class="label" x="150" y="82">0 ms</text><text class="label" x="330" y="82">4</text><text class="label" x="510" y="82">8</text><text class="label" x="690" y="82">12</text><text class="label" x="850" y="82">16</text>
+  <path data-ox-connector class="grid" d="M150 100V510M330 100V510M510 100V510M690 100V510M850 100V510"/>
+  <text class="label" x="48" y="178">CPU 0</text><rect class="lane" x="140" y="130" width="720" height="90" rx="6"/><rect class="task" x="160" y="150" width="220" height="48" rx="5"/><text class="name" x="270" y="180" text-anchor="middle">parse + route</text><rect class="task" x="620" y="150" width="180" height="48" rx="5"/><text class="name" x="710" y="180" text-anchor="middle">write order</text>
+  <text class="label" x="48" y="308">CPU 1</text><rect class="lane" x="140" y="260" width="720" height="90" rx="6"/><rect class="task" x="205" y="280" width="165" height="48" rx="5"/><text class="name" x="287" y="310" text-anchor="middle">verify JWT</text><rect class="io" x="390" y="280" width="175" height="48" rx="5"/><text class="name" x="477" y="310" text-anchor="middle">session read</text>
+  <text class="label" x="32" y="438">order task</text><rect class="lane" x="140" y="390" width="720" height="90" rx="6"/><rect class="wait" x="160" y="410" width="430" height="48" rx="5"/><text class="name" x="375" y="440" text-anchor="middle">runnable · waits for verified subject</text><path data-ox-connector d="M565 328V410" stroke="var(--teal,#97aebd)" stroke-width="2"/><path data-ox-connector d="M590 434H620" stroke="var(--sage,#99c693)" stroke-width="2"/>
+</svg>
+```
+
+## event-stream
+use: an evented workflow across producers, topics, consumers, and durable stores — when the reviewer needs to see ordering, fan-out, replay, idempotency, or the boundary between an event and its projection.
+why: a time-ordered stream makes causality visible while showing independent consumers. It avoids the false implication that a topic is a synchronous function call; use sequence diagrams for request/response instead.
+```html
+<svg data-ox-viz="event-stream" class="oxv-events" viewBox="0 0 960 600" role="img" aria-labelledby="events-title events-desc" style="max-width:100%;height:auto;background:var(--panel,#111411);color:var(--ink,#f4f2ef)">
+  <title id="events-title">Checkout event stream</title><desc id="events-desc">The gateway emits a verified checkout event. Orders persists an order while analytics consumes the same event independently. A replay-safe event id follows both paths.</desc>
+  <defs><marker id="events-arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><path d="M0 0 8 3 0 6Z" fill="var(--dim,#b7b6a3)"/></marker></defs>
+  <style>.oxv-events text{font-family:Inter,system-ui,sans-serif;fill:currentColor}.oxv-events .node{fill:var(--bg,#0b0d0b);stroke:var(--hair,#212620);stroke-width:2}.oxv-events .topic{fill:var(--sage,#99c693);fill-opacity:.12;stroke:var(--sage,#99c693);stroke-width:2}.oxv-events .name{font-size:16px;font-weight:600}.oxv-events .sub{font:12px "Spline Sans Mono",monospace;fill:var(--dim,#b7b6a3)}.oxv-events .edge{fill:none;stroke:var(--dim,#b7b6a3);stroke-width:2;marker-end:url(#events-arrow)}.oxv-events .replay{stroke:var(--teal,#97aebd);stroke-dasharray:6 4}</style>
+  <g data-ox-node><rect class="node" x="70" y="244" width="180" height="84" rx="6"/><text class="name" x="160" y="282" text-anchor="middle">Gateway</text><text class="sub" x="160" y="306" text-anchor="middle">verified checkout</text></g>
+  <g data-ox-node data-ox-focus><rect class="topic" x="360" y="214" width="240" height="144" rx="8"/><text class="name" x="480" y="262" text-anchor="middle">checkout.verified</text><text class="sub" x="480" y="292" text-anchor="middle">event_id · subject · order</text><text class="sub" x="480" y="320" text-anchor="middle">durable · replayable</text></g>
+  <g data-ox-node><rect class="node" x="710" y="120" width="180" height="84" rx="6"/><text class="name" x="800" y="158" text-anchor="middle">Orders</text><text class="sub" x="800" y="182" text-anchor="middle">idempotent write</text></g><g data-ox-node><rect class="node" x="710" y="370" width="180" height="84" rx="6"/><text class="name" x="800" y="408" text-anchor="middle">Analytics</text><text class="sub" x="800" y="432" text-anchor="middle">independent read</text></g>
+  <path data-ox-connector class="edge" d="M250 286H360"/><path data-ox-connector class="edge" d="M600 258H660V162H710"/><path data-ox-connector class="edge" d="M600 314H660V412H710"/><path data-ox-connector class="edge replay" d="M800 204V290H600"/><text class="sub" x="690" y="278" text-anchor="middle">replay on recovery</text>
+</svg>
+```
+
+## operational-time-series
+use: correlated operational signals over time — request rate, p95/p99 latency, CPU saturation, queue depth, errors, deploys, and incident windows — when the question is "what changed together, and when?"
+why: aligned time-series facets preserve the shared clock without forcing unlike units onto one deceptive axis. A deploy marker and a visible threshold connect a system change to its observed effect.
+```html
+<svg data-ox-viz="operational-time-series" class="oxv-ots" viewBox="0 0 960 600" role="img" aria-labelledby="ots-title ots-desc" style="max-width:100%;height:auto;background:var(--panel,#111411);color:var(--ink,#f4f2ef)">
+  <title id="ots-title">Checkout behavior around a gateway deploy</title><desc id="ots-desc">CPU saturation falls after a gateway deploy while request rate remains steady and p99 latency falls below the threshold.</desc>
+  <style>.oxv-ots text{font-family:Inter,system-ui,sans-serif;fill:currentColor}.oxv-ots .grid{stroke:var(--hair,#212620);stroke-width:1}.oxv-ots .axis{font:11px "Spline Sans Mono",monospace;fill:var(--dim,#b7b6a3)}.oxv-ots .name{font-size:13px;font-weight:600}.oxv-ots .rate{fill:none;stroke:var(--teal,#97aebd);stroke-width:3}.oxv-ots .lat{fill:none;stroke:var(--sage,#99c693);stroke-width:3}.oxv-ots .cpu{fill:none;stroke:var(--gold,#d9b654);stroke-width:3}.oxv-ots .deploy{stroke:var(--gold,#d9b654);stroke-width:2;stroke-dasharray:5 4}.oxv-ots .threshold{stroke:var(--red,#d77e6c);stroke-width:2;stroke-dasharray:5 4}</style>
+  <text class="name" x="48" y="110">request rate</text><text class="axis" x="48" y="130">rps</text><text class="name" x="48" y="270">p99 latency</text><text class="axis" x="48" y="290">ms</text><text class="name" x="48" y="430">CPU saturation</text><text class="axis" x="48" y="450">%</text>
+  <path class="grid" d="M160 130H890M160 210H890M160 290H890M160 370H890M160 450H890M160 530H890"/><path class="deploy" d="M560 92V530"/><text class="axis" x="570" y="105">gateway deploy</text><path class="threshold" d="M160 320H890"/><text class="axis" x="818" y="314">300 ms SLO</text>
+  <polyline class="rate" points="160,174 260,166 360,170 460,164 560,168 660,166 760,170 860,164"/><polyline class="lat" points="160,350 260,344 360,332 460,350 560,344 660,308 760,294 860,288"/><polyline class="cpu" points="160,510 260,498 360,490 460,480 560,492 660,450 760,438 860,432"/>
+  <text class="axis" x="160" y="558">09:00</text><text class="axis" x="400" y="558">09:10</text><text class="axis" x="640" y="558">09:20</text><text class="axis" x="850" y="558">09:30</text>
 </svg>
 ```

--- a/internal/viz/catalog.go
+++ b/internal/viz/catalog.go
@@ -24,15 +24,17 @@ var vizCatalogMD string
 
 // VizPattern is one catalog entry.
 type VizPattern struct {
-	ID        string   `json:"id"`               // stable slug, e.g. "sparkline"
-	Category  string   `json:"category"`         // diagram|chart|layout|mockup|annotation
-	Authoring string   `json:"authoring"`        // inline-svg|ox-render|mermaid|html-snippet
-	Tags      []string `json:"tags"`             // reviewed discovery terms; never inferred from prose
-	Origin    string   `json:"origin,omitempty"` // provenance for adapted third-party patterns
-	Use       string   `json:"use"`              // when to reach for it
-	Why       string   `json:"why"`              // the cognitive payoff
-	Param     string   `json:"param,omitempty"`  // data-shape hint when `ox viz render <id> --data` is supported
-	Body      string   `json:"body"`             // copy-paste snippet(s) + any notes
+	ID        string          `json:"id"`                        // stable slug, e.g. "sparkline"
+	Category  string          `json:"category"`                  // diagram|chart|layout|mockup|annotation
+	Authoring string          `json:"authoring"`                 // inline-svg|ox-render|mermaid|html-snippet
+	Tags      []string        `json:"tags"`                      // reviewed discovery terms; never inferred from prose
+	Origin    string          `json:"origin,omitempty"`          // provenance for adapted third-party patterns
+	Use       string          `json:"use"`                       // when to reach for it
+	Why       string          `json:"why"`                       // the cognitive payoff
+	Guidance  string          `json:"guidance"`                  // compositional guardrails for a polished artifact
+	Contract  *VisualContract `json:"visual_contract,omitempty"` // executable art direction for rich authoring
+	Param     string          `json:"param,omitempty"`           // data-shape hint when `ox viz render <id> --data` is supported
+	Body      string          `json:"body"`                      // copy-paste snippet(s) + any notes
 }
 
 // Pattern is the concise package-level name used by new consumers.

--- a/internal/viz/catalog_test.go
+++ b/internal/viz/catalog_test.go
@@ -1,6 +1,10 @@
 package viz
 
 import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
 	"strings"
 	"testing"
 )
@@ -13,13 +17,85 @@ func TestCatalogMetadataComplete(t *testing.T) {
 	seen := make(map[string]bool, len(patterns))
 	for _, p := range patterns {
 		seen[p.ID] = true
-		if p.Category == "" || p.Authoring == "" || len(p.Tags) == 0 {
+		if p.Category == "" || p.Authoring == "" || len(p.Tags) == 0 || p.Guidance == "" {
 			t.Errorf("pattern %q has incomplete metadata: %+v", p.ID, p)
 		}
 	}
 	for id := range metadataByID {
 		if !seen[id] {
 			t.Errorf("metadata exists for missing catalog pattern %q", id)
+		}
+	}
+}
+
+func TestRichVisualContractsAreConstructionReady(t *testing.T) {
+	ids := []string{
+		"architecture", "coverage-matrix", "data-flow", "event-stream",
+		"execution-trace", "flowchart", "operational-time-series",
+		"sequence-diagram", "state-machine",
+	}
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			p, ok := PatternByID(id)
+			if !ok {
+				t.Fatalf("missing pattern %q", id)
+			}
+			c := p.Contract
+			if c == nil {
+				t.Fatal("missing visual contract")
+			}
+			if c.Version == "" || c.Question == "" || c.RejectWhen == "" || len(c.Clarity) < 4 {
+				t.Fatalf("contract lacks selection boundary: %+v", c)
+			}
+			clarity := strings.Join(c.Clarity, " ")
+			for _, want := range []string{"Conceptual clarity", "simplest truthful", "five-second baseline"} {
+				if !strings.Contains(clarity, want) {
+					t.Errorf("contract clarity gate missing %q: %s", want, clarity)
+				}
+			}
+			if c.Canvas.Width < 1200 || c.Canvas.Height < 675 || c.Canvas.Margin < 64 || c.Canvas.Grid < 4 {
+				t.Errorf("canvas is not PR-export ready: %+v", c.Canvas)
+			}
+			if c.Typography.Minimum < 18 || c.Typography.Label < 24 || c.Typography.MaxLine > 36 {
+				t.Errorf("typography permits unreadable PR output: %+v", c.Typography)
+			}
+			if len(c.Evidence) == 0 || len(c.Composition) < 3 || len(c.Hierarchy) < 3 || len(c.Constraints) < 4 || len(c.FinishingPass) < 4 {
+				t.Errorf("contract is guidance-shaped, not construction-ready: %+v", c)
+			}
+			for _, slot := range c.Evidence {
+				if slot.ID == "" || slot.Prompt == "" || slot.Maximum < 1 {
+					t.Errorf("evidence slot is not actionable: %+v", slot)
+				}
+			}
+			seenVariants := map[string]bool{}
+			for _, variant := range c.Variants {
+				seenVariants[variant.ID] = variant.UseWhen != "" && variant.Budget != ""
+			}
+			for _, want := range []string{"compact", "standard", "deep"} {
+				if !seenVariants[want] {
+					t.Errorf("missing usable %s variant: %+v", want, c.Variants)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenStrokePatternsCannotBecomeFilledPolygons(t *testing.T) {
+	data := []byte(`{"title":"latency","series":[{"label":"p95","points":[{"x":0,"y":10},{"x":1,"y":20}]}]}`)
+	fragment, err := Render("line-chart", data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(fragment, `class="linec-series"`) || !strings.Contains(fragment, `fill="none"`) {
+		t.Fatalf("line-chart must render series as explicit open strokes: %s", fragment)
+	}
+	for _, id := range []string{"sparkline", "small-multiples", "loop"} {
+		p, ok := PatternByID(id)
+		if !ok {
+			t.Fatalf("catalog is missing %q", id)
+		}
+		if !strings.Contains(p.Body, `fill="none"`) && !strings.Contains(p.Body, `fill:none`) {
+			t.Errorf("%s must explicitly use unfilled open paths", id)
 		}
 	}
 }
@@ -82,6 +158,35 @@ func TestSuggestDeterministicMatches(t *testing.T) {
 			t.Errorf("word-boundary matching must not treat shared as share: %+v", got)
 		}
 	}
+
+	// PR #773 is a representative architecture story: one portable catalog
+	// reconciles into native and shared targets with a safe, recoverable apply.
+	// Its language must select visuals instead of forcing an AI coworker to
+	// browse the entire catalog or silently omit the explanation.
+	intent := "show how one portable skill catalog is reconciled into native Claude and shared Codex/Gemini project targets, including deduplication, safe apply, ownership, and crash recovery"
+	got := Suggest(intent, 5)
+	if len(got) == 0 {
+		t.Fatalf("Suggest(%q) returned no visual for an architecture story", intent)
+	}
+	ids := make(map[string]bool, len(got))
+	for _, suggestion := range got {
+		ids[suggestion.ID] = true
+	}
+	for _, want := range []string{"architecture", "flowchart", "sequence-diagram"} {
+		if !ids[want] {
+			t.Errorf("Suggest(%q) = %+v, want %q", intent, got, want)
+		}
+	}
+	for _, suggestion := range got {
+		if suggestion.Guidance == "" {
+			t.Errorf("suggestion %q omitted its design guidance", suggestion.ID)
+		}
+	}
+
+	got = Suggest("show reviewers an unfamiliar system behavior", 3)
+	if len(got) == 0 || !strings.Contains(got[0].Reason, "low-confidence fallback") {
+		t.Errorf("explicit visual request must get a labeled fallback, got %+v", got)
+	}
 }
 
 func TestLintAccessibilitySafetyAndEditorialFindings(t *testing.T) {
@@ -111,6 +216,13 @@ func TestLintAccessibilitySafetyAndEditorialFindings(t *testing.T) {
 	}
 }
 
+func TestLintRejectsFilledLineChartSeries(t *testing.T) {
+	bad := `<svg data-ox-viz="line-chart" role="img" aria-labelledby="t d" viewBox="0 0 100 100"><title id="t">Trend</title><desc id="d">Trend</desc><polyline class="linec-series" points="0,90 50,40 100,10"/></svg>`
+	if findings := Lint([]byte(bad), LintOptions{}); !hasRule(findings, "viz.chart.open-stroke") {
+		t.Fatalf("filled line-chart series escaped lint: %+v", findings)
+	}
+}
+
 func TestLintSupportsHTMLCatalogFragments(t *testing.T) {
 	clean := `<div class="device" style="background:var(--panel,#111411)">Mockup</div>`
 	if findings := Lint([]byte(clean), LintOptions{}); len(findings) != 0 {
@@ -131,6 +243,27 @@ func TestLintChecksHTMLSurroundingSVG(t *testing.T) {
 	findings := Lint([]byte(fragment), LintOptions{})
 	if !hasRule(findings, "viz.self-contained.external") {
 		t.Errorf("remote HTML wrapper must not evade SVG lint: %+v", findings)
+	}
+}
+
+func TestLintPRPNGEncouragesLightweightIndexedExports(t *testing.T) {
+	palette := color.Palette{color.White, color.Black}
+	indexed := image.NewPaletted(image.Rect(0, 0, 8, 8), palette)
+	var indexedPNG bytes.Buffer
+	if err := png.Encode(&indexedPNG, indexed); err != nil {
+		t.Fatal(err)
+	}
+	if hasRule(LintPRPNG(indexedPNG.Bytes()), "viz.pr.png-palette") {
+		t.Fatal("indexed PNG must not be asked to quantize again")
+	}
+
+	trueColor := image.NewNRGBA(image.Rect(0, 0, 8, 8))
+	var trueColorPNG bytes.Buffer
+	if err := png.Encode(&trueColorPNG, trueColor); err != nil {
+		t.Fatal(err)
+	}
+	if !hasRule(LintPRPNG(trueColorPNG.Bytes()), "viz.pr.png-palette") {
+		t.Fatalf("true-color PNG must receive a palette finding: %+v", LintPRPNG(trueColorPNG.Bytes()))
 	}
 }
 

--- a/internal/viz/contract.go
+++ b/internal/viz/contract.go
@@ -1,0 +1,242 @@
+package viz
+
+// VisualContract turns a catalog suggestion into construction-ready art
+// direction. The AI coworker supplies truthful engineering evidence; ox owns
+// the canvas, hierarchy, geometry, and perceptual constraints. This is
+// intentionally more structured than Guidance: prose hints are easy to skim or
+// reinterpret, while these fields can be validated, rendered, and evaluated.
+type VisualContract struct {
+	Version       string             `json:"version"`
+	Question      string             `json:"reviewer_question"`
+	Clarity       []string           `json:"conceptual_clarity"`
+	RejectWhen    string             `json:"reject_when"`
+	Canvas        CanvasContract     `json:"canvas"`
+	Evidence      []EvidenceSlot     `json:"evidence_slots"`
+	Composition   []string           `json:"composition"`
+	Hierarchy     []string           `json:"visual_hierarchy"`
+	Typography    TypographyContract `json:"typography"`
+	Connectors    []string           `json:"connector_grammar,omitempty"`
+	Color         []string           `json:"color_roles"`
+	Constraints   []string           `json:"construction_constraints"`
+	Variants      []VariantContract  `json:"variants"`
+	AntiPatterns  []string           `json:"pattern_anti_patterns"`
+	FinishingPass []string           `json:"finishing_pass"`
+}
+
+type CanvasContract struct {
+	Width       int    `json:"width"`
+	Height      int    `json:"height"`
+	AspectRatio string `json:"aspect_ratio"`
+	Margin      int    `json:"margin"`
+	Grid        int    `json:"grid"`
+	Background  string `json:"background"`
+}
+
+type EvidenceSlot struct {
+	ID       string `json:"id"`
+	Required bool   `json:"required"`
+	Prompt   string `json:"prompt"`
+	Maximum  int    `json:"maximum,omitempty"`
+}
+
+type TypographyContract struct {
+	Title      int `json:"title_px"`
+	Section    int `json:"section_px"`
+	Label      int `json:"label_px"`
+	Detail     int `json:"detail_px"`
+	Annotation int `json:"annotation_px"`
+	Minimum    int `json:"minimum_px"`
+	MaxLine    int `json:"max_characters_per_line"`
+}
+
+type VariantContract struct {
+	ID      string `json:"id"`
+	UseWhen string `json:"use_when"`
+	Budget  string `json:"content_budget"`
+}
+
+// VisualContractByID returns a fresh contract for the rich patterns whose
+// composition is mature enough to be a product promise. Other catalog entries
+// keep their existing recipe until their grammar receives the same treatment.
+func VisualContractByID(id string) (*VisualContract, bool) {
+	build, ok := visualContractBuilders[id]
+	if !ok {
+		return nil, false
+	}
+	c := build()
+	return &c, true
+}
+
+var visualContractBuilders = map[string]func() VisualContract{
+	"architecture":            architectureContract,
+	"coverage-matrix":         coverageMatrixContract,
+	"data-flow":               dataFlowContract,
+	"event-stream":            eventStreamContract,
+	"execution-trace":         executionTraceContract,
+	"flowchart":               flowchartContract,
+	"operational-time-series": operationalTimeSeriesContract,
+	"sequence-diagram":        sequenceContract,
+	"state-machine":           stateMachineContract,
+}
+
+func baseContract(width, height int, ratio, question, reject string) VisualContract {
+	return VisualContract{
+		Version:    "2",
+		Question:   question,
+		RejectWhen: reject,
+		Canvas: CanvasContract{
+			Width: width, Height: height, AspectRatio: ratio,
+			Margin: 88, Grid: 8, Background: "paper",
+		},
+		Typography: TypographyContract{
+			Title: 44, Section: 24, Label: 26, Detail: 20,
+			Annotation: 18, Minimum: 18, MaxLine: 32,
+		},
+		Hierarchy: []string{
+			"One review conclusion is dominant; the diagram title is the conclusion, not the category name.",
+			"Primary evidence uses ink and one accent; supporting context recedes to muted ink and hairlines.",
+			"No decorative header, divider, legend card, footer, logo, or unused framing region.",
+		},
+		Clarity: []string{
+			"Conceptual clarity outranks visual novelty and polish. Start with the reader's mental model: name the actors or states, the starting point, the primary path, the changed fact, and the outcome before placing marks.",
+			"Preserve the simplest truthful topology. A richer treatment may add evidence or reveal a dimension, but it may not make the primary path, direction, grouping, or outcome harder to trace than prose, a table, or GitHub-safe Mermaid.",
+			"Use position and grouping only for real domain meaning. Do not split one lifecycle into decorative bands, invent categories, or move a central event into a visually secondary exception lane merely to create a designed composition.",
+			"Keep the same concept under one stable name and visual form. Never make the reader reconcile synonyms, duplicated states, or a title that answers a different question from the diagram.",
+			"Run a five-second baseline test against the smallest truthful alternative: a new reader must identify the start, primary path, changed fact, and outcome at least as quickly. If the baseline is clearer, ship the baseline and improve only its typography, spacing, and emphasis.",
+		},
+		Color: []string{
+			"paper is the canvas; ink carries labels and structure; muted carries context; rule carries guides.",
+			"accent is reserved for the one changed, risky, or causally decisive element; never color every category.",
+			"State and meaning must remain legible without color through position, label, stroke, or pattern.",
+		},
+		Variants: []VariantContract{
+			{ID: "compact", UseWhen: "the reviewer question survives with one path or at most four primary items", Budget: "one focal claim; 2-4 primary items; no secondary panel"},
+			{ID: "standard", UseWhen: "the full engineering mechanism needs one primary view", Budget: "one focal claim; 4-7 primary items; at most two annotations"},
+			{ID: "deep", UseWhen: "one overview plus one tightly coupled detail is necessary", Budget: "one overview and one detail band; never two competing hero views"},
+		},
+		FinishingPass: []string{
+			"Compare against the simplest truthful baseline with the same reviewer question. Reject the rich candidate if the baseline is faster to understand or easier to trace.",
+			"Ask a reader unfamiliar with the implementation to identify the start, primary path, changed fact, and outcome in five seconds; revise or downgrade the medium if any answer is ambiguous.",
+			"Read the exported image at 50% scale; every required label remains legible without zoom.",
+			"Trace every relationship from source boundary to destination boundary; no floating, buried, or ambiguous connector survives.",
+			"Keep every connector-label mask wholly inside an empty routing corridor; it may not touch a node, title, or unrelated edge.",
+			"Delete any mark that does not encode evidence, grouping, sequence, scale, or emphasis.",
+			"Confirm title, labels, and annotations tell one consistent story and make no claim absent from the PR evidence.",
+		},
+	}
+}
+
+func architectureContract() VisualContract {
+	c := baseContract(1600, 1000, "8:5", "Where are the responsibilities and boundaries after this change?", "Use GitHub-safe Mermaid when the answer is a linear path of two to five nodes with no meaningful zones or boundary crossings.")
+	c.Evidence = []EvidenceSlot{
+		{ID: "zones", Required: true, Prompt: "Name 2-4 ownership, trust, or runtime zones.", Maximum: 4},
+		{ID: "components", Required: true, Prompt: "Name only components needed to answer the reviewer question.", Maximum: 7},
+		{ID: "relationships", Required: true, Prompt: "State direction and meaning of each consequential relationship.", Maximum: 9},
+		{ID: "changed_boundary", Required: true, Prompt: "Identify the single responsibility or boundary changed by the PR.", Maximum: 1},
+	}
+	c.Composition = []string{
+		"Lay zones as large quiet regions on a left-to-right responsibility axis; zone labels sit in the outer margin, never inside a node field.",
+		"Place the changed boundary on the central third of the canvas and give it the only accent treatment.",
+		"Align peer components to a shared baseline; vary size only when responsibility or fan-out differs.",
+		"Reserve a clear orthogonal routing channel between zones before placing any labels.",
+	}
+	c.Connectors = []string{
+		"Use orthogonal paths with rounded elbows; attach visibly to node boundaries and end with one modest arrowhead.",
+		"Put short relationship labels above a horizontal segment with an opaque paper mask and at least 10px clearance.",
+		"Fan multiple edges to distinct attachment points at least 16px apart; never stack connectors on one route.",
+	}
+	c.Constraints = []string{"2-4 zones", "3-7 components", "5-9 consequential relationships", "one changed boundary", "no node label longer than two lines"}
+	c.AntiPatterns = []string{"uniform box grid", "all components accented", "connectors crossing labels", "floating arrows", "a legend for colors that can be direct labels"}
+	return c
+}
+
+func sequenceContract() VisualContract {
+	c := baseContract(1600, 1050, "32:21", "What happens in what order, and where does the decisive handoff, wait, or failure occur?", "Use a sentence for one call and response; use an execution trace when simultaneous CPU work is the reviewer question.")
+	c.Evidence = []EvidenceSlot{
+		{ID: "participants", Required: true, Prompt: "Name actors in causal order.", Maximum: 5},
+		{ID: "messages", Required: true, Prompt: "Provide ordered messages with direction and terse labels.", Maximum: 9},
+		{ID: "decisive_step", Required: true, Prompt: "Identify the message that establishes safety, ownership, or failure.", Maximum: 1},
+		{ID: "alternate", Required: false, Prompt: "Name one failure or recovery branch only if review depends on it.", Maximum: 1},
+	}
+	c.Composition = []string{"Participant labels form one quiet header row; lifelines share equal spacing and begin on the same baseline.", "Time reads top to bottom with generous vertical rhythm; group request/response pairs through proximity, not containers.", "The decisive exchange occupies the visual center and receives the only accent; one alternate branch may use an unfilled outline that never obscures a lifeline, message, or label."}
+	c.Connectors = []string{"Messages run horizontally between lifelines with labels above the stroke.", "Return messages use a dashed stroke; asynchronous messages use an open arrowhead and explicit label.", "Activation bars align exactly to message endpoints; no arrow ends in open space."}
+	c.Constraints = []string{"3-5 participants", "4-9 messages", "one highlighted exchange", "at most one alternate band", "labels are verbs or payloads, not sentences"}
+	c.AntiPatterns = []string{"equal emphasis on every message", "diagonal messages", "notes covering lifelines", "more than one time direction", "decorative participant icons"}
+	return c
+}
+
+func stateMachineContract() VisualContract {
+	c := baseContract(1600, 900, "16:9", "Which states are possible, and which transition or recovery path changes the reviewer’s risk?", "Use Mermaid for four or fewer states on one happy path with no guarded recovery or terminal distinction.")
+	c.Evidence = []EvidenceSlot{
+		{ID: "states", Required: true, Prompt: "Name observable states, not implementation steps.", Maximum: 8},
+		{ID: "transitions", Required: true, Prompt: "Name event/guard on each allowed transition.", Maximum: 12},
+		{ID: "happy_path", Required: true, Prompt: "Identify the primary left-to-right lifecycle.", Maximum: 1},
+		{ID: "recovery", Required: false, Prompt: "Identify retry, orphan, rollback, or fail-closed route.", Maximum: 3},
+		{ID: "terminal_states", Required: true, Prompt: "Name successful and unsuccessful terminal states.", Maximum: 3},
+	}
+	c.Composition = []string{"Derive the primary path from the reviewer question, not from whichever states happen to form the longest line. For a pause/resume change, recording → suspended → recording is central even when upload is the eventual terminal path.", "Place the happy path on one uninterrupted reading path from initial to terminal state; a loop that defines the feature stays adjacent to its source state and visually primary.", "Route recovery and exceptional states below the primary path in a shallow second tier; return paths stay outside the main corridor but reconnect visibly to the exact state they resume.", "Use section bands only when they represent real, mutually exclusive domains. Never separate states merely by visual taxonomy if doing so makes transitions harder to trace.", "Give terminal states unmistakable closure through a double rule or terminal glyph, not color alone.", "Highlight the transition changed by the PR rather than filling an entire state."}
+	c.Connectors = []string{"Transitions attach to state boundaries and carry event labels beside the longest clear segment.", "Self-loops sit above the state; recovery loops route below all states and return through a separate attachment point.", "Arrow direction must be inferable at 50% scale."}
+	c.Constraints = []string{"4-8 states", "one happy-path baseline", "at most three recovery states", "one changed transition", "no crossing transitions"}
+	c.AntiPatterns = []string{"radial state cloud", "transition labels inside states", "all states as identical pills", "recovery edges crossing the happy path", "color as the only terminal encoding"}
+	return c
+}
+
+func flowchartContract() VisualContract {
+	c := baseContract(1400, 1000, "7:5", "Which decision changes the outcome, including the exceptional exit?", "Use prose for a single condition; use a state machine when nodes are durable states rather than actions.")
+	c.Evidence = []EvidenceSlot{{ID: "actions", Required: true, Prompt: "Name verb-led actions.", Maximum: 7}, {ID: "decisions", Required: true, Prompt: "Name binary questions and label both exits.", Maximum: 3}, {ID: "outcomes", Required: true, Prompt: "Name terminal outcomes.", Maximum: 3}, {ID: "review_gate", Required: true, Prompt: "Identify the decision changed by the PR.", Maximum: 1}}
+	c.Composition = []string{"Keep the happy path as one vertical spine with decisions centered on it.", "Route exceptional exits laterally into a narrow side column and terminate them quickly.", "Use whitespace between stages instead of background containers; accent only the decision under review."}
+	c.Connectors = []string{"Use orthogonal downward connectors on the happy path and right-angle lateral exits.", "Place yes/no or guard labels at the branch origin, never midway between unrelated nodes.", "All paths visibly terminate in an action or outcome."}
+	c.Constraints = []string{"3-7 actions", "1-3 decisions", "one primary spine", "at most two lateral exception columns", "no connector crossing"}
+	c.AntiPatterns = []string{"serpentine happy path", "unlabeled branch exits", "diamonds used for actions", "multiple equal focal points", "arrows ending between nodes"}
+	return c
+}
+
+func dataFlowContract() VisualContract {
+	c := baseContract(1600, 900, "16:9", "How does information change as it moves from source to consumer?", "Use Mermaid when data passes unchanged through fewer than five components.")
+	c.Evidence = []EvidenceSlot{{ID: "sources", Required: true, Prompt: "Name authoritative producers.", Maximum: 4}, {ID: "transformations", Required: true, Prompt: "Name transformations and the contract each emits.", Maximum: 4}, {ID: "consumers", Required: true, Prompt: "Name consumers and why each needs the data.", Maximum: 5}, {ID: "changed_contract", Required: true, Prompt: "Name the schema, ownership, or delivery contract changed by the PR.", Maximum: 1}}
+	c.Composition = []string{"Use three vertical zones—sources, transformations, consumers—on one left-to-right axis.", "Make the changed data contract the focal edge label, not a floating callout.", "Align peers within each zone and reserve a central routing corridor."}
+	c.Connectors = []string{"Edges encode the data artifact in direct labels and visibly attach to both endpoints.", "Fan-out begins at a named contract or store, not in empty space.", "Use dashed stroke only for optional or asynchronous delivery and label that semantic explicitly."}
+	c.Constraints = []string{"2-3 zones", "3-9 total nodes", "one changed contract", "at most two fan-out levels", "direct labels instead of a legend"}
+	c.AntiPatterns = []string{"arrows as decoration", "mixing control and data flow without labels", "unbounded fan-out hairball", "source and consumer in the same visual zone", "contract labels floating away from edges"}
+	return c
+}
+
+func eventStreamContract() VisualContract {
+	c := baseContract(1600, 900, "16:9", "How does a durable event reach independent consumers, and what happens on replay or failure?", "Use a compact Mermaid flow when delivery is synchronous, there is one consumer, or replay and independent ownership do not matter.")
+	c.Evidence = []EvidenceSlot{{ID: "producer", Required: true, Prompt: "Name the producer and event.", Maximum: 2}, {ID: "durable_topic", Required: true, Prompt: "Name the durable topic/log and ordering key.", Maximum: 1}, {ID: "consumers", Required: true, Prompt: "Name independent consumer groups and their responsibility.", Maximum: 5}, {ID: "delivery_semantics", Required: true, Prompt: "State replay, idempotency, retry, and dead-letter semantics that actually exist.", Maximum: 4}, {ID: "failure", Required: false, Prompt: "Name one failure path reviewers must reason about.", Maximum: 1}}
+	c.Composition = []string{"Place producer at left, the durable log as a strong central spine, and consumers as aligned lanes on the right.", "Show append and offset progression along the spine; consumer ownership reads from vertical separation, not rainbow color.", "Put replay or dead-letter behavior in one lower recovery band that reconnects to the exact consumer lane it affects."}
+	c.Connectors = []string{"Producer append terminates on the log; fan-out begins at distinct offsets on the log and terminates on each consumer boundary.", "Use solid edges for delivery, dashed reverse edges only for retry/replay, and label both directly.", "No edge may imply a synchronous response from a consumer to the producer."}
+	c.Constraints = []string{"1-2 producers", "one durable log", "2-5 consumer groups", "one recovery band", "ordering/replay semantics stated in the image"}
+	c.AntiPatterns = []string{"drawing the stream as a request chain", "shared arrow endpoint for every consumer", "unlabeled retry loop", "color-only ownership", "consumer boxes scattered around the canvas"}
+	return c
+}
+
+func executionTraceContract() VisualContract {
+	c := baseContract(1600, 900, "16:9", "What executes concurrently on the shared clock, and which wait, handoff, or critical span determines completion?", "Use a sequence diagram when only message order matters; use an operational time series when aggregate measurements, not spans, answer the question.")
+	c.Evidence = []EvidenceSlot{{ID: "clock", Required: true, Prompt: "Provide start/end or relative ticks on one shared clock.", Maximum: 8}, {ID: "lanes", Required: true, Prompt: "Name CPU, thread, goroutine, or task lanes.", Maximum: 6}, {ID: "spans", Required: true, Prompt: "Provide start, duration, label, and state for each span.", Maximum: 18}, {ID: "handoffs", Required: false, Prompt: "Name causal cross-lane handoffs.", Maximum: 5}, {ID: "critical_span", Required: true, Prompt: "Identify the span that gates completion or causes contention.", Maximum: 1}}
+	c.Composition = []string{"Reserve the top band for title and shared clock; lane labels occupy a fixed left gutter outside the plot.", "Every span is positioned by time, not by convenient spacing; aligned vertical guides make concurrency visible.", "Encode running as solid bars, runnable wait as outlined bars, blocking I/O as hatched bars, and idle as absence.", "Give the critical span one accent outline and a short causal annotation in unused plot space."}
+	c.Connectors = []string{"Handoffs begin at the exact end of one span and terminate at the exact start of another.", "Use thin orthogonal or gently curved connectors behind neither bars nor labels; arrowheads remain visible at 50% scale.", "Do not connect events that are merely correlated."}
+	c.Constraints = []string{"2-6 lanes", "4-18 timed spans", "one shared clock", "one critical span", "at most five causal handoffs", "all time geometry data-derived"}
+	c.AntiPatterns = []string{"equal-width decorative bars", "separate clocks per lane", "handoff ending before its destination", "legend larger than the trace", "using color as the only execution-state encoding"}
+	return c
+}
+
+func operationalTimeSeriesContract() VisualContract {
+	c := baseContract(1600, 1050, "32:21", "Which measured signals changed together around a deploy or incident, and did they cross an operational threshold?", "Use a sparkline for one contextual trend without axes; use prose when no measured observations exist.")
+	c.Evidence = []EvidenceSlot{{ID: "time_window", Required: true, Prompt: "Provide a real or relative time window and aligned timestamps.", Maximum: 12}, {ID: "facets", Required: true, Prompt: "Provide 2-4 signals, each with its own unit and scale.", Maximum: 4}, {ID: "observations", Required: true, Prompt: "Provide measured values; never fabricate a smooth series.", Maximum: 48}, {ID: "thresholds", Required: true, Prompt: "Provide the relevant SLO, capacity, or baseline threshold per facet.", Maximum: 4}, {ID: "causal_marker", Required: true, Prompt: "Name one deploy, rollback, or incident marker supported by the PR.", Maximum: 2}}
+	c.Composition = []string{"Stack unlike units as aligned horizontal facets sharing one time axis; never overlay them on a dual axis.", "Use a single vertical event marker across every facet so temporal correlation is immediate.", "Keep gridlines sparse and quiet; direct-label each series and threshold inside its facet.", "Place one conclusion annotation near the decisive inflection, leaving the rest of the plot free of prose."}
+	c.Connectors = []string{"Series are open unfilled strokes; thresholds are thin dashed rules; the event marker is a distinct vertical rule.", "Annotation leaders terminate on an observed point and never cross another series label.", "Do not interpolate across missing data without an explicit gap encoding."}
+	c.Constraints = []string{"2-4 aligned facets", "one shared time axis", "one unit per facet", "one or two causal markers", "one conclusion annotation", "no filled area unless area is the measured encoding"}
+	c.AntiPatterns = []string{"dual axes", "filled polygon under a line", "independent time scales", "SLO line at the wrong coordinate", "legend detached from the series", "invented observations"}
+	return c
+}
+
+func coverageMatrixContract() VisualContract {
+	c := baseContract(1600, 1000, "8:5", "Which behaviors are proven across which implementations, and where is evidence missing?", "Use a Markdown table when there are fewer than four rows or columns and no grouped behavior hierarchy.")
+	c.Evidence = []EvidenceSlot{{ID: "implementations", Required: true, Prompt: "Name agents, platforms, adapters, or test layers as columns.", Maximum: 9}, {ID: "behaviors", Required: true, Prompt: "Name independently reviewable behaviors as rows.", Maximum: 12}, {ID: "status", Required: true, Prompt: "Provide proven, partial, missing, or not-applicable for every cell.", Maximum: 108}, {ID: "provenance", Required: true, Prompt: "Name the real fixture, smoke gate, or evidence standard represented by proven.", Maximum: 3}, {ID: "critical_gap", Required: false, Prompt: "Identify the one gap that changes merge or follow-up decisions.", Maximum: 1}}
+	c.Composition = []string{"Use a frozen left label column and equal-width implementation columns; group related behaviors with whitespace or a quiet rule.", "Make missing and partial evidence more visually salient than proven cells; proven should form a calm background texture.", "Put the evidence standard in a concise subtitle and annotate only the critical gap."}
+	c.Connectors = nil
+	c.Constraints = []string{"4-12 behavior rows", "4-9 implementation columns", "four explicit statuses", "one evidence standard", "one optional critical-gap annotation", "labels never rotate vertically"}
+	c.AntiPatterns = []string{"rainbow heatmap", "checkmarks without an evidence definition", "red-green-only encoding", "rotated column labels", "decorative summary cards above the matrix"}
+	return c
+}

--- a/internal/viz/lint.go
+++ b/internal/viz/lint.go
@@ -1,7 +1,11 @@
 package viz
 
 import (
+	"bytes"
 	"fmt"
+	"image"
+	"image/color"
+	_ "image/png"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,6 +31,16 @@ type LintOptions struct {
 	// contract. Plan lint uses it to avoid policing legacy Mermaid output.
 	TaggedOnly bool
 }
+
+const (
+	// PRPNGTargetBytes keeps a typical 2x diagram fast to open in a GitHub PR.
+	// It is intentionally a warning threshold: more complex diagrams may need
+	// more pixels, but should be consciously reviewed before upload.
+	PRPNGTargetBytes = 500 * 1024
+	// PRPNGMaximumBytes is the hard ceiling for a review-only PNG. Above this,
+	// split the visual or remove unnecessary pixels before uploading.
+	PRPNGMaximumBytes = 1024 * 1024
+)
 
 var hardColorRE = regexp.MustCompile(`(?i)#[0-9a-f]{3,8}\b|rgba?\(`)
 var cssVarRE = regexp.MustCompile(`(?i)var\([^)]*\)`)
@@ -90,6 +104,47 @@ func Lint(data []byte, opts LintOptions) []Finding {
 			label = fmt.Sprintf("diagram %d", i+1)
 		}
 		findings = append(findings, lintSVG(svg, label, ids)...)
+	}
+	return findings
+}
+
+// LintPRPNG checks the review-specific portability and weight budget of an
+// exported PNG. It complements, rather than replaces, source SVG linting.
+func LintPRPNG(data []byte) []Finding {
+	if !bytes.HasPrefix(data, []byte{'\x89', 'P', 'N', 'G', '\r', '\n', '\x1a', '\n'}) {
+		return nil
+	}
+	var findings []Finding
+	if len(data) > PRPNGMaximumBytes {
+		findings = append(findings, Finding{
+			Rule:     "viz.pr.png-weight",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("PNG is %d KiB; review-only PR images must be at most %d KiB (split it or quantize the palette)", len(data)/1024, PRPNGMaximumBytes/1024),
+		})
+	} else if len(data) > PRPNGTargetBytes {
+		findings = append(findings, Finding{
+			Rule:     "viz.pr.png-weight",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("PNG is %d KiB; target at most %d KiB with a stripped, quantized palette", len(data)/1024, PRPNGTargetBytes/1024),
+		})
+	}
+	if cfg, _, err := image.DecodeConfig(bytes.NewReader(data)); err != nil {
+		findings = append(findings, Finding{Rule: "viz.pr.png-decode", Severity: SeverityError, Message: "PNG could not be decoded: " + err.Error()})
+	} else {
+		if _, indexed := cfg.ColorModel.(color.Palette); !indexed {
+			findings = append(findings, Finding{
+				Rule:     "viz.pr.png-palette",
+				Severity: SeverityWarning,
+				Message:  "PNG is true-color; export the flat diagram as indexed PNG (PNG-8, at most 256 colors) unless full color or alpha adds review meaning",
+			})
+		}
+		if cfg.Width > 2560 || cfg.Height > 2560 {
+			findings = append(findings, Finding{
+				Rule:     "viz.pr.png-dimensions",
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("PNG is %dx%d; use a 2x export of the intended GitHub inline size and split the visual before adding unnecessary canvas", cfg.Width, cfg.Height),
+			})
+		}
 	}
 	return findings
 }
@@ -220,6 +275,12 @@ func lintSVG(svg *xhtml.Node, label string, ids map[string]int) []Finding {
 			if x1ok && x2ok && y1ok && y2ok && x1 != x2 && y1 != y2 {
 				warnFinding("viz.connector.diagonal", "tagged connectors must be orthogonal; use a rounded path")
 			}
+		}
+		// A line-chart series is always an open stroke. SVG otherwise defaults
+		// a polyline to an opaque black fill, which visually invents area and
+		// can turn a trend into a misleading bow-tie when embedded in host CSS.
+		if n.Type == xhtml.ElementNode && n.Data == "polyline" && strings.Contains(attr(n, "class"), "linec-series") && strings.TrimSpace(attr(n, "fill")) != "none" {
+			errFinding("viz.chart.open-stroke", "line-chart series must declare fill=\"none\"; use a separate area pattern when area is the encoding")
 		}
 	})
 	if nodes > 12 {

--- a/internal/viz/metadata.go
+++ b/internal/viz/metadata.go
@@ -13,15 +13,15 @@ type patternMetadata struct {
 const diagramDesignOrigin = "cathrynlavery/diagram-design@f3622cf"
 
 var metadataByID = map[string]patternMetadata{
-	"sequence-diagram":     {"diagram", "inline-svg", []string{"sequence", "request response", "round trip", "messages", "actors", "time order"}, diagramDesignOrigin},
+	"sequence-diagram":     {"diagram", "inline-svg", []string{"sequence", "request response", "round trip", "messages", "actors", "time order", "safe apply", "safe update", "interrupted apply", "crash recovery", "recover safely", "ownership"}, diagramDesignOrigin},
 	"budget-sequence":      {"diagram", "mermaid", []string{"latency budget", "cost budget", "critical path", "round trip"}, ""},
-	"dependency-graph":     {"diagram", "mermaid", []string{"dependencies", "coupling", "topology", "blast radius", "modules"}, ""},
+	"dependency-graph":     {"diagram", "mermaid", []string{"dependencies", "coupling", "topology", "blast radius", "modules", "native targets", "shared targets", "shared destination", "where does this land"}, ""},
 	"state-machine":        {"diagram", "inline-svg", []string{"states", "transitions", "lifecycle", "retry", "timeout", "backoff"}, diagramDesignOrigin},
 	"swimlane-timeline":    {"diagram", "html-snippet", []string{"swimlane", "handoffs", "workstreams", "parallel", "relative effort", "rollout"}, ""},
 	"gantt":                {"diagram", "mermaid", []string{"gantt", "calendar", "schedule", "dates", "milestones"}, ""},
 	"sparkline":            {"chart", "html-snippet", []string{"sparkline", "inline trend", "tiny chart", "time series"}, ""},
 	"small-multiples":      {"chart", "html-snippet", []string{"small multiples", "compare series", "outliers", "repeated charts"}, ""},
-	"before-after":         {"layout", "html-snippet", []string{"before after", "old new", "delta", "comparison"}, ""},
+	"before-after":         {"layout", "html-snippet", []string{"before after", "old new", "old versus new", "delta", "comparison"}, ""},
 	"decision-matrix":      {"layout", "html-snippet", []string{"decision matrix", "options", "criteria", "tradeoffs", "score"}, ""},
 	"heatmap-table":        {"chart", "html-snippet", []string{"heatmap", "dense numbers", "magnitude", "hotspot"}, ""},
 	"cost-telemetry-table": {"layout", "html-snippet", []string{"telemetry", "cost stages", "performance budget", "measurements"}, ""},
@@ -52,12 +52,15 @@ var metadataByID = map[string]patternMetadata{
 	"wordmark":             {"annotation", "html-snippet", []string{"wordmark", "sageox credit", "attribution", "branding"}, ""},
 	"risk-register":        {"layout", "html-snippet", []string{"risk register", "risk owner", "severity", "fallback", "trigger"}, ""},
 
-	"architecture": {"diagram", "inline-svg", []string{"architecture", "system components", "services", "boundaries", "infrastructure", "topology"}, diagramDesignOrigin},
-	"flowchart":    {"diagram", "inline-svg", []string{"flowchart", "decision logic", "branches", "gates", "fallback", "procedure"}, diagramDesignOrigin},
-	"data-flow":    {"diagram", "inline-svg", []string{"data flow", "pipeline", "sources", "transformation", "consumers", "handoffs"}, diagramDesignOrigin},
-	"layer-stack":  {"diagram", "inline-svg", []string{"layers", "layer stack", "abstractions", "enforcement", "defense", "controls"}, diagramDesignOrigin},
-	"timeline":     {"diagram", "inline-svg", []string{"timeline", "events", "chronology", "history", "milestones", "time axis"}, diagramDesignOrigin},
-	"loop":         {"diagram", "inline-svg", []string{"loop", "flywheel", "cycle", "feedback", "reinforcing", "shared memory"}, diagramDesignOrigin},
+	"architecture":            {"diagram", "inline-svg", []string{"architecture", "system components", "services", "boundaries", "infrastructure", "topology", "portable skill catalog", "native Claude", "shared Codex Gemini", "project targets"}, diagramDesignOrigin},
+	"flowchart":               {"diagram", "inline-svg", []string{"flowchart", "decision logic", "branches", "gates", "fallback", "procedure", "reconciliation", "reconciled", "deduplication"}, diagramDesignOrigin},
+	"data-flow":               {"diagram", "inline-svg", []string{"data flow", "pipeline", "sources", "transformation", "consumers", "handoffs"}, diagramDesignOrigin},
+	"layer-stack":             {"diagram", "inline-svg", []string{"layers", "layer stack", "abstractions", "enforcement", "defense", "controls"}, diagramDesignOrigin},
+	"timeline":                {"diagram", "inline-svg", []string{"timeline", "events", "chronology", "history", "milestones", "time axis"}, diagramDesignOrigin},
+	"loop":                    {"diagram", "inline-svg", []string{"loop", "flywheel", "cycle", "feedback", "reinforcing", "shared memory"}, diagramDesignOrigin},
+	"execution-trace":         {"diagram", "inline-svg", []string{"execution trace", "cpu cores", "parallel execution", "threads", "concurrency", "what is executing", "blocking I O", "scheduler"}, ""},
+	"event-stream":            {"diagram", "inline-svg", []string{"event stream", "events", "evented workflow", "topics", "fan out", "replay", "idempotency", "consumers"}, ""},
+	"operational-time-series": {"chart", "inline-svg", []string{"operational time series", "cpu saturation", "p99 latency", "request rate", "deploy marker", "incident window", "correlated metrics"}, ""},
 }
 
 func applyMetadata(p *VizPattern) {
@@ -69,4 +72,64 @@ func applyMetadata(p *VizPattern) {
 	p.Authoring = m.authoring
 	p.Tags = append([]string(nil), m.tags...)
 	p.Origin = m.origin
+	p.Guidance = conceptualClarityGuidance + " " + guidanceByID[p.ID]
+	if contract, ok := VisualContractByID(p.ID); ok {
+		p.Contract = contract
+	}
+}
+
+const conceptualClarityGuidance = "Conceptual clarity comes first: preserve the reader's simplest truthful mental model, and prefer prose, a table, or GitHub-safe Mermaid whenever it makes the primary relationship faster to understand. Rich styling must reveal information the simpler baseline cannot—not reorganize an already-clear idea."
+
+// guidanceByID is deliberately separate from the primitive snippets. A
+// primitive says how to draw a form; this tells an AI coworker what to make
+// dominant, what to omit, and the perceptual failure mode to avoid. Every
+// catalog entry must have one (enforced by TestCatalogMetadataComplete).
+var guidanceByID = map[string]string{
+	"sequence-diagram":        "Use 3–5 participants and align each message to a shared time axis. Make one causally decisive request distinct; do not turn every arrow into a highlight.",
+	"budget-sequence":         "Give every hop one budget and one lever. Put the total at the end of the path; do not decorate the sequence with a second chart.",
+	"dependency-graph":        "Cluster by ownership, make the shared/contended dependency central, and label only consequential edges. Every connector must visibly terminate at the boundary of its source and destination; never leave a floating arrow or route an edge through a label. Avoid a uniform hairball.",
+	"state-machine":           "Derive the primary path from the reviewer question and keep the feature-defining loop central; do not demote it into a decorative secondary band. Use a left-to-right happy path, with retries below it. Highlight one transition under review; terminal states need unmistakable visual closure.",
+	"swimlane-timeline":       "Use one shared horizontal clock and no more than five lanes. Bars describe work; arrows describe handoff. Keep lane labels outside the work area.",
+	"gantt":                   "Use actual dates only. Show critical dependencies and one decision milestone; omit speculative precision and decorative progress bars.",
+	"sparkline":               "Use one signal inline beside the sentence it supports—no title card, frame, or full-width plate. For axes, a threshold, or a causal annotation, promote it to a line chart.",
+	"small-multiples":         "Use only for three or more comparable series. Keep scales identical, render series as unfilled strokes, and annotate the outlier; do not put a lone tiny chart inside a decorative card.",
+	"before-after":            "If the delta is a 2–5-node linear path, use GitHub-safe Mermaid or two concise code snippets instead. Use a rich comparison only for a structural change that needs mirrored multi-step evidence; make the changed ownership or path the only high-contrast delta.",
+	"decision-matrix":         "Limit to 3–5 options and 3–5 criteria. Make the recommendation visible but preserve the decisive trade-off; never imply false numeric precision.",
+	"heatmap-table":           "Use a stable sequential scale with visible values only where they alter the decision. Sort rows and columns to reveal the hotspot.",
+	"cost-telemetry-table":    "Keep units in every column and use emphasis only for the stage that changes the decision. Pair totals with the relevant budget, not a decorative badge.",
+	"device-mockup":           "Show one realistic state at native hierarchy—especially the failure or recovery state. Crop surrounding device chrome aggressively.",
+	"callout":                 "One claim, one evidence line, one source. Give the claim generous space; a callout is not a second introduction or a container for a paragraph.",
+	"rollout-dag":             "Arrange gates as prerequisites, not calendar steps. Show the rollback edge and the evidence that unlocks each expansion.",
+	"file-impact-map":         "Group files by subsystem and distinguish changed, reviewed, and intentionally untouched. Make the cross-cutting file visually central.",
+	"risk-matrix":             "Use position for likelihood and impact, color only for severity. Label the few risks that change the decision; pair each with an owner or mitigation.",
+	"stat-cards":              "Use at most three decision metrics with a shared comparison period. The value is primary, the delta secondary, and no card exists merely to fill space.",
+	"bar-chart":               "Sort bars by value, start from zero, and annotate the comparison that matters. Use color for the selected or exceptional bar only.",
+	"partition-bar":           "Use one total and label each segment directly. Keep small segments readable or aggregate them; never rely on a remote legend.",
+	"partition-map":           "Show a real spatial structure only when location is meaningful. Direct-label regions and use an inset or table if tiny areas cannot be read.",
+	"data-model":              "Show entities, keys, cardinality, and the ownership boundary. Omit fields that do not affect the design decision.",
+	"coverage-matrix":         "Rows are behaviors, columns are test layers, and gaps must be visually louder than passes. Do not use a heatmap when binary coverage is the question.",
+	"flag-rollout-matrix":     "Put cohorts on one axis and environments or rollout stages on the other. Highlight the unsafe combination and the gate that resolves it.",
+	"cost-waterfall":          "Use signed contributions on a common baseline and end with the total. Each segment needs an operational cause, not merely a category name.",
+	"decision-grid":           "Use this for qualitative lenses, not pseudo-scoring. Let a concise recommendation sit next to the grid, not inside every cell.",
+	"ox-annotation":           "Anchor the annotation to a precise visual claim and cite its source. It should clarify provenance, never compete with the diagram.",
+	"donut":                   "Use only for a small number of parts with a meaningful whole. Put the decisive value in the center and directly label the largest remainder.",
+	"radar":                   "Use identical axes and a small number of series. Prefer a table if exact magnitude matters more than shape.",
+	"quadrant":                "Name both axes with direction and use position before color. Label only the decision-relevant points; avoid overlapping bubbles.",
+	"treemap":                 "Area encodes one quantitative total. Keep hierarchy shallow and label only rectangles large enough to support readable text.",
+	"sankey":                  "Width means volume and must remain conserved across each split. Direct-label the major paths and aggregate visual noise into an other path.",
+	"chord":                   "Use only for genuinely reciprocal coupling. Order arcs to reduce crossings; annotate the strongest relationship instead of asking the reader to trace ribbons.",
+	"line-chart":              "Use a true time axis, one visible threshold, and annotations at causal changes. Render each series as a connected unfilled stroke; do not use an opaque area or polygon unless area is the explicit encoding. Use shared-scale facets rather than stacking incompatible units.",
+	"pull-quote":              "Quote one load-bearing sentence verbatim with attribution. Give it a visual pause; do not stylize it into a marketing headline.",
+	"status-pair":             "Use only for a real shipped-versus-not-built or healthy-versus-degraded state, with one decisive metric or checklist delta. Do not use it to redraw a simple architecture change; a Mermaid flow or prose is clearer.",
+	"wordmark":                "Use only when a user explicitly asks for a standalone brand component. Do not add it to technical PR visuals, diagrams, charts, or their footers by default.",
+	"risk-register":           "Use one dense scan row per risk: severity, risk, resolution, owner. Reveal mechanism and fallback only on demand.",
+	"architecture":            "Use named zones, orthogonal edges, and one trust or ownership boundary. Keep the hero view under seven nodes; split detail rather than shrink type.",
+	"flowchart":               "Use verb actions and question diamonds. Keep the happy path straight, exceptional exits lateral, and label every branch condition.",
+	"data-flow":               "Separate sources, transformations, and consumers. Put the changing data contract on the edge that carries it; never use arrows as decoration.",
+	"layer-stack":             "Each band needs a distinct responsibility and boundary. Keep ordering meaningful and make the enforcement layer visually decisive.",
+	"timeline":                "Use one real or relative axis with 3–7 inflection points. Annotate the event that changed the trajectory, not every date.",
+	"loop":                    "Show 3–5 directed, unfilled arrow paths and the durable shared state at the hub. Never draw the loop as a filled/closed shape. If there is no durable feedback or the cycle has only two steps, use a Mermaid flowchart instead.",
+	"execution-trace":         "Use aligned core/task lanes on one clock. Encode executing, runnable wait, blocking I/O, and handoff differently; highlight the span that gates completion.",
+	"event-stream":            "Use only when durable fan-out, replay, or independent consumer ownership matters. Show producer, topic, and consumers with direct-label edges; otherwise prefer a compact Mermaid flow. Preserve ordering without drawing it as a synchronous call chain.",
+	"operational-time-series": "Use aligned facets for unlike units, a deploy/incident marker, and an explicit threshold. Correlate signals on time—not on a deceptive dual axis.",
 }

--- a/internal/viz/pr_contract_eval_test.go
+++ b/internal/viz/pr_contract_eval_test.go
@@ -1,0 +1,54 @@
+package viz
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestPRContractEvalCorpusRoutesToExpectedMediumAndPattern(t *testing.T) {
+	raw, err := os.ReadFile("testdata/pr_contract_eval/corpus.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var corpus []struct {
+		ID              string   `json:"id"`
+		PR              int      `json:"pr"`
+		Intent          string   `json:"intent"`
+		ExpectedMedium  PRMedium `json:"expected_medium"`
+		ExpectedPattern string   `json:"expected_pattern"`
+		Evidence        []string `json:"evidence"`
+	}
+	if err := json.Unmarshal(raw, &corpus); err != nil {
+		t.Fatal(err)
+	}
+	if len(corpus) < 6 {
+		t.Fatalf("eval corpus has %d cases, want at least 6", len(corpus))
+	}
+	seenPR := map[int]bool{}
+	seenPattern := map[string]bool{}
+	for _, tc := range corpus {
+		t.Run(tc.ID, func(t *testing.T) {
+			if tc.ID == "" || tc.PR == 0 || tc.Intent == "" || len(tc.Evidence) < 2 {
+				t.Fatalf("corpus case is not review-grounded: %+v", tc)
+			}
+			if seenPR[tc.PR] {
+				t.Fatalf("PR #%d appears twice", tc.PR)
+			}
+			seenPR[tc.PR] = true
+			got := DecidePRMedium(tc.Intent)
+			if got.Medium != tc.ExpectedMedium || got.Primary != tc.ExpectedPattern {
+				t.Fatalf("DecidePRMedium() = %+v, want medium=%s pattern=%q", got, tc.ExpectedMedium, tc.ExpectedPattern)
+			}
+			if got.Medium == PRMediumRich {
+				if got.VisualContract == nil {
+					t.Fatal("rich corpus decision has no visual contract")
+				}
+				seenPattern[got.Primary] = true
+			}
+		})
+	}
+	if len(seenPattern) < 5 {
+		t.Fatalf("corpus exercises only %d rich grammars: %v", len(seenPattern), seenPattern)
+	}
+}

--- a/internal/viz/pr_decision.go
+++ b/internal/viz/pr_decision.go
@@ -1,0 +1,84 @@
+package viz
+
+import "strings"
+
+// PRMedium is the smallest truthful delivery medium for a reviewer question.
+type PRMedium string
+
+const (
+	PRMediumNone    PRMedium = "none"
+	PRMediumMermaid PRMedium = "github-mermaid"
+	PRMediumRich    PRMedium = "rich"
+)
+
+// PRDecision is deterministic guidance for an AI coworker. Rich is never a
+// default simply because a prompt asks to "show" something.
+type PRDecision struct {
+	Medium           PRMedium        `json:"medium"`
+	Primary          string          `json:"primary,omitempty"`
+	Variant          string          `json:"variant,omitempty"`
+	Reason           string          `json:"reason"`
+	RequiredEvidence string          `json:"required_evidence"`
+	VisualContract   *VisualContract `json:"visual_contract,omitempty"`
+}
+
+func DecidePRMedium(intent string) PRDecision {
+	q := normalize(intent)
+	if anyPhrase(q, "one sentence", "simple summary", "summarize", "short summary", "rename", "test updates", "changelog") {
+		return PRDecision{Medium: PRMediumNone, Reason: "the requested conclusion fits concise prose", RequiredEvidence: "one review-relevant sentence"}
+	}
+	if anyPhrase(q, "cpu core", "cpu cores", "concurrency", "parallel execution", "thread") {
+		return richDecision("execution-trace", "the question needs simultaneous work on a shared clock", "named lanes, timing, wait or handoff state")
+	}
+	if anyPhrase(q, "event stream", "replay", "idempotency", "independent consumer", "durable topic") {
+		return richDecision("event-stream", "the question needs durable fan-out or delivery semantics", "producer, topic, named consumers, and replay/idempotency semantics")
+	}
+	if anyPhrase(q, "p99", "latency", "cpu saturation", "deploy marker", "correlated signals") {
+		return richDecision("operational-time-series", "the question needs measured change across time", "units, scale, observations, threshold, and causal marker")
+	}
+	if anyPhrase(q, "coverage matrix", "across agents", "across adapters", "compatibility matrix", "conformance suite") {
+		return richDecision("coverage-matrix", "the question needs dense, comparable evidence across implementations", "named behaviors, implementations, explicit statuses, and the evidence standard for proven")
+	}
+	if anyPhrase(q, "pause resume lifecycle", "session lifecycle", "recovery transitions", "orphan recovery", "state lifecycle") {
+		return richDecision("state-machine", "the question needs a guarded lifecycle with recovery or terminal distinctions", "observable states, labeled transitions, happy path, recovery path, and terminal states")
+	}
+	if anyPhrase(q, "multi-component architecture", "external adapters", "ownership zones", "trust boundary", "runtime boundaries") {
+		return richDecision("architecture", "the question needs responsibility zones and meaningful boundary crossings", "named zones, essential components, consequential relationships, and the changed boundary")
+	}
+	if anyPhrase(q, "failure recovery sequence", "multi-writer recovery", "multi writer recovery", "push failure recovery", "crash recovery sequence") {
+		return richDecision("sequence-diagram", "the question needs ordered failure and recovery behavior across several owners", "participants, ordered messages, the decisive safety step, and at most one recovery branch")
+	}
+	if anyPhrase(q, "multi-stage data flow", "streaming data flow", "sources transformations consumers", "changing data contract") {
+		return richDecision("data-flow", "the question needs source, transformation, and consumer responsibilities around a changing data contract", "named sources, transformations, consumers, and the changed contract")
+	}
+	if anyPhrase(q, "work queue", "claim lease", "lease expiry", "atomic claim") {
+		return richDecision("sequence-diagram", "the question needs ordered claim, lease, dispatch, and recovery behavior", "participants, ordered messages, the decisive atomic claim, and at most one reclaim branch")
+	}
+	if anyPhrase(q, "durable fan out", "consumer groups") {
+		return richDecision("event-stream", "the question needs durable fan-out and independent consumer ownership", "producer, durable topic, named consumer groups, and replay/idempotency semantics")
+	}
+	if anyPhrase(q, "small multiples", "compare series") {
+		return richDecision("small-multiples", "the question needs comparable repeated quantitative facets", "three to six equal-scale facets and one meaningful outlier")
+	}
+	if anyPhrase(q, "trend", "time series", "by day", "over time") {
+		return richDecision("line-chart", "the question needs a quantitative trajectory", "unit, scale, observations, and threshold or baseline")
+	}
+	return PRDecision{Medium: PRMediumMermaid, Reason: "a compact causal or topology flow is clearest as GitHub-safe Mermaid", RequiredEvidence: "two to five named nodes and direct labeled edges"}
+}
+
+func richDecision(primary, reason, evidence string) PRDecision {
+	contract, _ := VisualContractByID(primary)
+	return PRDecision{
+		Medium: PRMediumRich, Primary: primary, Variant: "standard",
+		Reason: reason, RequiredEvidence: evidence, VisualContract: contract,
+	}
+}
+
+func anyPhrase(q string, phrases ...string) bool {
+	for _, phrase := range phrases {
+		if strings.Contains(" "+q+" ", " "+normalize(phrase)+" ") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/viz/pr_decision_test.go
+++ b/internal/viz/pr_decision_test.go
@@ -1,0 +1,33 @@
+package viz
+
+import "testing"
+
+func TestDecidePRMedium(t *testing.T) {
+	for _, tc := range []struct {
+		intent  string
+		medium  PRMedium
+		primary string
+	}{
+		{"move validation from Orders to Gateway", PRMediumMermaid, ""},
+		{"show p99 latency and CPU saturation around a deploy marker", PRMediumRich, "operational-time-series"},
+		{"show work executing on two CPU cores at the same time", PRMediumRich, "execution-trace"},
+		{"show durable replay with independent event consumers", PRMediumRich, "event-stream"},
+		{"show the pause resume lifecycle including orphan recovery", PRMediumRich, "state-machine"},
+		{"show conformance coverage across agents", PRMediumRich, "coverage-matrix"},
+		{"show the multi-component architecture for external adapters", PRMediumRich, "architecture"},
+		{"show the multi-writer recovery sequence after a push failure", PRMediumRich, "sequence-diagram"},
+		{"show the work queue atomic claim lease expiry and reclaim", PRMediumRich, "sequence-diagram"},
+		{"show the streaming data flow from LFS source through cache to consumers", PRMediumRich, "data-flow"},
+	} {
+		got := DecidePRMedium(tc.intent)
+		if got.Medium != tc.medium || got.Primary != tc.primary {
+			t.Errorf("%q = %+v", tc.intent, got)
+		}
+		if tc.medium == PRMediumRich && (got.VisualContract == nil || got.Variant == "") {
+			t.Errorf("%q rich decision lacks executable contract: %+v", tc.intent, got)
+		}
+	}
+	if got := DecidePRMedium("rename a config field"); got.Medium != PRMediumNone {
+		t.Errorf("rename = %+v, want none", got)
+	}
+}

--- a/internal/viz/render_charts.go
+++ b/internal/viz/render_charts.go
@@ -1000,7 +1000,11 @@ func renderLineChart(data []byte) (string, error) {
 		if dd := dashes[si%len(dashes)]; dd != "" {
 			dash = ` stroke-dasharray="` + dd + `"`
 		}
-		fmt.Fprintf(&b, `<polyline class="linec-series" points="%s" style="stroke:%s"%s/>`, strings.Join(pts, " "), col, dash)
+		// SVG's default fill is black. State fill="none" on the element rather
+		// than relying on surrounding CSS: fragments are frequently embedded in
+		// a document with unrelated SVG rules, and a filled polyline becomes a
+		// misleading closed polygon.
+		fmt.Fprintf(&b, `<polyline class="linec-series" points="%s" fill="none" style="stroke:%s"%s/>`, strings.Join(pts, " "), col, dash)
 		for _, p := range s.Points {
 			ptx, pty := px(p.X), py(p.Y)
 			if s.Marker {

--- a/internal/viz/suggest.go
+++ b/internal/viz/suggest.go
@@ -13,14 +13,16 @@ type Suggestion struct {
 	Category  string `json:"category"`
 	Authoring string `json:"authoring"`
 	Reason    string `json:"reason"`
+	Guidance  string `json:"guidance"`
 	Next      string `json:"next"`
 }
 
 type scoredSuggestion struct {
-	order int
-	score int
-	hits  []string
-	p     Pattern
+	order      int
+	score      int
+	hits       []string
+	p          Pattern
+	confidence bool
 }
 
 // Suggest ranks reviewed catalog tags against an intent. It never calls a model
@@ -31,7 +33,8 @@ func Suggest(intent string, limit int) []Suggestion {
 		limit = 3
 	}
 	q := normalize(intent)
-	qTokens := tokenSet(q)
+	rawTokens := tokenSet(q)
+	qTokens := expandedTokenSet(q)
 	var scored []scoredSuggestion
 	for order, p := range Catalog() {
 		score := 0
@@ -63,8 +66,26 @@ func Suggest(intent string, limit int) []Suggestion {
 			score += 12
 			hits = append(hits, p.ID)
 		}
+		// Tags are the retrieval contract. Use/Why contribute only a small
+		// secondary signal so normal prose can still find a reviewed pattern
+		// without turning every shared word into a confident match.
+		if proseHits := matchingProseTokens(p.Use+" "+p.Why, rawTokens); len(proseHits) >= 2 {
+			score += len(proseHits)
+			hits = append(hits, strings.Join(proseHits, "/"))
+		}
 		if score > 0 {
-			scored = append(scored, scoredSuggestion{order: order, score: score, hits: unique(hits), p: p})
+			scored = append(scored, scoredSuggestion{order: order, score: score, hits: unique(hits), p: p, confidence: true})
+		}
+	}
+	if len(scored) == 0 && hasVisualIntent(qTokens) {
+		// An explicit request to show/explain a system should never silently
+		// suppress a visual just because it did not use catalog vocabulary.
+		// These are broad, review-safe starting points—not a claim of a precise
+		// match—and the reason makes that distinction visible to the caller.
+		for _, id := range []string{"architecture", "flowchart", "sequence-diagram"} {
+			if p, ok := PatternByID(id); ok {
+				scored = append(scored, scoredSuggestion{order: catalogOrder(id), hits: []string{"visual explanation"}, p: p})
+			}
 		}
 	}
 	sort.SliceStable(scored, func(i, j int) bool {
@@ -86,9 +107,13 @@ func Suggest(intent string, limit int) []Suggestion {
 		if len(hits) > 3 {
 			hits = hits[:3]
 		}
+		reason := "matched " + strings.Join(hits, ", ")
+		if !s.confidence {
+			reason = "low-confidence fallback for an explicit visual explanation"
+		}
 		out = append(out, Suggestion{
 			ID: s.p.ID, Category: s.p.Category, Authoring: s.p.Authoring,
-			Reason: "matched " + strings.Join(hits, ", "), Next: next,
+			Reason: reason, Guidance: s.p.Guidance, Next: next,
 		})
 	}
 	return out
@@ -119,6 +144,81 @@ func tokenSet(s string) map[string]bool {
 		out[token] = true
 	}
 	return out
+}
+
+// expandedTokenSet adds a deliberately small, reviewed vocabulary for common
+// PR-review language. It is not a model or fuzzy matcher: aliases only bridge
+// ordinary inflections/concepts to catalog tags, preserving deterministic output.
+func expandedTokenSet(s string) map[string]bool {
+	out := tokenSet(s)
+	base := make([]string, 0, len(out))
+	for token := range out {
+		base = append(base, token)
+	}
+	for _, token := range base {
+		for _, alias := range visualAliases[token] {
+			out[alias] = true
+		}
+	}
+	return out
+}
+
+var visualAliases = map[string][]string{
+	"reconcile":      {"reconciled", "reconciliation", "flow"},
+	"reconciled":     {"reconcile", "reconciliation", "flow"},
+	"reconciliation": {"reconcile", "reconciled", "flow"},
+	"dedupe":         {"deduplication"},
+	"deduplicated":   {"deduplication"},
+	"deduplication":  {"dedupe", "deduplicated"},
+	"shared":         {"dependency", "dependencies"},
+	"recover":        {"recovery", "sequence", "state"},
+	"recovered":      {"recovery", "sequence", "state"},
+	"recovery":       {"recover", "sequence", "state"},
+	"interrupted":    {"recovery", "sequence"},
+}
+
+func matchingProseTokens(prose string, query map[string]bool) []string {
+	proseTokens := tokenSet(normalize(prose))
+	hits := make([]string, 0, 3)
+	for token := range proseTokens {
+		if len(token) >= 5 && query[token] && !visualStopWords[token] {
+			hits = append(hits, token)
+		}
+	}
+	sort.Strings(hits)
+	if len(hits) > 3 {
+		hits = hits[:3]
+	}
+	return hits
+}
+
+var visualStopWords = map[string]bool{
+	"about": true, "after": true, "before": true, "between": true,
+	"does": true, "from": true, "have": true, "how": true, "land": true,
+	"other": true, "their": true, "these": true, "this": true, "those": true,
+	"where": true, "which": true, "would": true,
+}
+
+func hasVisualIntent(tokens map[string]bool) bool {
+	for _, token := range []string{
+		"show", "explain", "architecture", "flow", "workflow", "diagram",
+		"visual", "compare", "comparison", "before", "after", "timeline",
+		"sequence", "state", "dependency", "dependencies", "component",
+	} {
+		if tokens[token] {
+			return true
+		}
+	}
+	return false
+}
+
+func catalogOrder(id string) int {
+	for order, p := range Catalog() {
+		if p.ID == id {
+			return order
+		}
+	}
+	return len(Catalog())
 }
 
 func unique(in []string) []string {

--- a/internal/viz/testdata/pr_contract_eval/RUBRIC.md
+++ b/internal/viz/testdata/pr_contract_eval/RUBRIC.md
@@ -1,0 +1,39 @@
+# PR visual-contract evaluation rubric
+
+The corpus uses real merged SageOx PRs with substantial reviewer discussion.
+The baseline is the visual that shipped in the PR body (or the closest visual
+already present there), not a newly sampled AI output. The candidate is built
+from the same reviewer question and evidence after `ox viz` supplies a visual
+contract.
+
+Score each dimension from 0–10 at the exported image's intended 50% display
+scale. Review the technical claim before judging polish.
+
+| Dimension | Weight | Question |
+|---|---:|---|
+| Reviewer answerability | 25% | Can a reviewer answer the named question within five seconds? |
+| Conceptual clarity | 20% | Does the spatial model match the human mental model—obvious start, primary path, changed fact, and outcome—without reconstructing relationships across decorative groups? |
+| Semantic fidelity | 20% | Does every visible claim follow from the PR evidence without invented state, timing, grouping, or causality? |
+| Visual hierarchy | 10% | Is the conclusion dominant, with one focal change and appropriately quiet context? |
+| Spatial integrity | 10% | Do connectors terminate correctly, labels avoid collisions, and geometry encode the intended relationship? |
+| Typography | 5% | Is every required label legible at 50% without awkward wrapping or inconsistent scale? |
+| Cognitive economy | 10% | Does every mark earn its place, and is this simpler than the next smaller truthful medium? |
+
+The weighted score is the sum of `score × weight`. A candidate passes only if:
+
+- weighted score is at least 8.0;
+- conceptual clarity is at least 8;
+- semantic fidelity is at least 8;
+- spatial integrity is at least 8;
+- no required evidence slot is missing;
+- the simple-change control does not get promoted from Mermaid to a rich image.
+
+Every candidate is scored against the smallest truthful baseline that answers
+the same reviewer question. A rich candidate fails—regardless of polish or
+weighted average—when the baseline makes the start, primary path, changed fact,
+or outcome faster to identify. In that case, keep the baseline and improve only
+its typography, spacing, direction, and restrained emphasis.
+
+Mechanical lint is necessary but does not affect the aesthetic score. Any text
+collision, disconnected connector, false scale, missing endpoint, or misleading
+encoding is a release blocker regardless of the weighted average.

--- a/internal/viz/testdata/pr_contract_eval/corpus.json
+++ b/internal/viz/testdata/pr_contract_eval/corpus.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "pr-424-adapter-boundaries",
+    "pr": 424,
+    "url": "https://github.com/sageox/ox/pull/424",
+    "title": "extract built-in adapters to external binaries with adapter registry and CLI management",
+    "reviewer_question": "Where do adapter responsibilities and failure boundaries live after extraction?",
+    "intent": "show the multi-component architecture for external adapters, including CLI, registry, daemon supervisor, protocol, adapter processes, hooks, and session discovery across runtime boundaries",
+    "expected_medium": "rich",
+    "expected_pattern": "architecture",
+    "baseline": "The merged PR used one 13-node Mermaid topology with a uniform box treatment.",
+    "evidence": [
+      "CLI resolves adapter metadata through the embedded registry.",
+      "The daemon supervisor owns adapter process lifecycle and NDJSON IPC.",
+      "Standalone adapter binaries implement the shared protocol.",
+      "The protocol exposes session discovery/read/import, hooks, diagnostics, and watching."
+    ]
+  },
+  {
+    "id": "pr-627-session-lifecycle",
+    "pr": 627,
+    "url": "https://github.com/sageox/ox/pull/627",
+    "title": "session pause/resume and entity lifecycle",
+    "reviewer_question": "How can a paused session keep recording locally without leaking paused work into the Ledger?",
+    "intent": "show the pause resume lifecycle including orphan recovery, fail-closed masking, upload, cancellation, and terminal states",
+    "expected_medium": "rich",
+    "expected_pattern": "state-machine",
+    "baseline": "The merged PR used an 11-state Mermaid diagram followed by a separate sequence diagram.",
+    "evidence": [
+      "recording and suspended both continue local capture.",
+      "resume returns to recording; stop advances to uploading.",
+      "orphan recovery applies the lifecycle mask before upload.",
+      "validateMaskInvariant aborts upload if excluded counts disagree."
+    ]
+  },
+  {
+    "id": "pr-647-task-claim",
+    "pr": 647,
+    "url": "https://github.com/sageox/ox/pull/647",
+    "title": "schedule tasks for the next available AI coworker",
+    "reviewer_question": "Why can two live coworkers never claim the same scheduled task, and how is abandoned work reclaimed?",
+    "intent": "show the work queue atomic claim, lease expiry, live coworker dispatch, completion, and reclaim sequence",
+    "expected_medium": "rich",
+    "expected_pattern": "sequence-diagram",
+    "baseline": "The merged PR used a Mermaid producer-to-database topology; claim and reclaim behavior lived in prose.",
+    "evidence": [
+      "producers enqueue into agent_tasks.db.",
+      "UPDATE with status=ready makes claim atomic; a racing claimer affects zero rows.",
+      "the live AI coworker dispatches claimed work into fresh context.",
+      "lease-expired or dead same-host claimers are reconciled on read."
+    ]
+  },
+  {
+    "id": "pr-568-multi-writer-recovery",
+    "pr": 568,
+    "url": "https://github.com/sageox/ox/pull/568",
+    "title": "structural multi-writer resilience and auto-repair",
+    "reviewer_question": "How does a first-push add/add conflict recover automatically, and when does ox stop rather than guess?",
+    "intent": "show the multi-writer recovery sequence after a rebase conflict, including merge attributes, pull rebase, union, accept-theirs, optional LLM resolution, retry, and fail-closed abort",
+    "expected_medium": "rich",
+    "expected_pattern": "sequence-diagram",
+    "baseline": "The merged PR used a dense 14-node Mermaid recovery flow with several feedback edges.",
+    "evidence": [
+      "EnsureMergeAttributes installs union rules before the first pull/rebase.",
+      "PushWithRetry retries after non-fast-forward and invokes conflict handling only when needed.",
+      "resolution tiers are union, safe-prefix accept-theirs, then an explicitly configured LLM merge.",
+      "if every tier is exhausted, ox aborts the rebase and surfaces the conflict."
+    ]
+  },
+  {
+    "id": "pr-753-adapter-conformance",
+    "pr": 753,
+    "url": "https://github.com/sageox/ox/pull/753",
+    "title": "session recording for six second-class agents",
+    "reviewer_question": "Which recording behaviors are now proven against real agent output, and which remain explicitly unproven?",
+    "intent": "show the conformance coverage matrix across agents for real fixtures, tool pairing, failure status, path validation, incremental reading, and smoke verification",
+    "expected_medium": "rich",
+    "expected_pattern": "coverage-matrix",
+    "baseline": "The merged PR used a prose-heavy before/after table plus two Mermaid failure flows.",
+    "evidence": [
+      "Gemini, Codex, Goose, Droid, Pi, OpenCode, Amp, and Aider have different proof status.",
+      "real fixtures require provenance; missing evidence is Unproven, never a passing invented fixture.",
+      "capability contracts probe every advertised capability.",
+      "known gaps for OpenCode, Pi, Aider, and same-size replacement remain visible."
+    ]
+  },
+  {
+    "id": "pr-383-lfs-streaming",
+    "pr": 383,
+    "url": "https://github.com/sageox/ox/pull/383",
+    "title": "stream LFS stub content into the local cache",
+    "reviewer_question": "Where does LFS content come from, when is it cached, and which consumers receive bytes?",
+    "intent": "show the multi-stage streaming data flow from an LFS source through verified cache population to stdout and local consumers, including the changing data contract",
+    "expected_medium": "rich",
+    "expected_pattern": "data-flow",
+    "baseline": "The merged PR described the streaming and caching path without a review-focused data-contract view.",
+    "evidence": [
+      "a stub identifies the LFS object and expected digest.",
+      "the fetch path streams remote bytes while verifying content identity.",
+      "verified content populates the local cache.",
+      "stdout and later reads consume the same verified object."
+    ]
+  },
+  {
+    "id": "pr-740-gitignore-relocation-control",
+    "pr": 740,
+    "url": "https://github.com/sageox/ox/pull/740",
+    "title": "stop polluting root .gitignore; stage what init writes",
+    "reviewer_question": "Which two writers now target .sageox/.gitignore instead of the repository root?",
+    "intent": "move two writers from root gitignore to sageox gitignore in a compact four node linear flow",
+    "expected_medium": "github-mermaid",
+    "expected_pattern": "",
+    "baseline": "The merged PR already used an appropriate compact Mermaid flow.",
+    "evidence": [
+      "ox init and daemon KB sync were the two writers.",
+      "both now write kb/ in .sageox/.gitignore."
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- **Reviewer-first selection:** adds `ox viz pr` and `--intent` JSON guidance that choose the smallest truthful medium—prose/table, GitHub-safe Mermaid, or a rich review-only attachment—rather than promoting every material change to an image.
- **Cross-agent activation:** teaches prime to invoke the workflow before material PR descriptions and ships a thin `ox-viz` skill through the canonical core bundle, giving Claude, Codex, and Gemini native discovery without duplicating live CLI guidance.
- **Construction-ready rich diagrams:** adds visual contracts for architecture, state, sequence, flow, data-flow, event-stream, execution-trace, operational-time-series, and coverage-matrix patterns, including evidence slots, canvas and type budgets, connector grammar, anti-patterns, variants, and a conceptual-clarity gate against the simplest baseline.
- **Configuration and delivery:** adds `pr_visuals.rich` and `pr_visuals.theme` at personal, repository, and team scope (light theme by default); opting out disables generated PR images without hiding the `ox viz` catalog or suggestions.
- **QA and portability:** expands deterministic natural-language suggestions, adds PNG size/palette/dimension checks, fixes line-series fills, adds a real-PR evaluation corpus, and refreshes generated CLI documentation and bundled integration artifacts.

## Reviewer flow

```mermaid
flowchart LR
    Q[Reviewer question] --> V[ox viz pr]
    V --> P[Prose or table]
    V --> M[GitHub-safe Mermaid]
    V --> R[Rich attachment plus visual contract]
```

The rich branch is used only when it preserves a visual dimension the smaller forms cannot; every candidate must make the start, primary path, changed fact, and outcome at least as clear as its baseline.

## Test Plan

- `make lint` — clean (`0 issues`)
- `make test` — 18,698 tests passed; 1,157 skipped
- Targeted cross-agent/catalog/config/CLI tests covering `extensions/skills`, `internal/prime`, `internal/viz`, `internal/config`, and `cmd/ox`
- Regenerated CLI reference docs from the rebased workspace binary and verified `git diff --check`

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added
- [x] CHANGELOG entry added
- [x] Breaking change documented — N/A; this is additive and existing `ox viz` commands remain compatible
- [x] Security review — N/A; the diff does not touch the security-sensitive paths listed in the repository policy or `go.sum`

</details>

Co-authored-by: SageOx <ox@sageox.ai>

SageOx-Session: https://sageox.ai/c/ses_01a005d2-d98c-70fd-98e8-272ba100c722


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ox viz pr` to recommend pull-request visuals based on reviewer intent.
  * Added support for Mermaid diagrams and optional rich visual attachments.
  * Added configurable visual themes and rich-visual preferences across supported scopes.
  * Added the `ox-recap` and `ox-viz` skills.
  * Added new visualization patterns and construction guidance.

* **Bug Fixes**
  * Improved SVG line-chart rendering and PNG validation.

* **Documentation**
  * Added references for `ox gc` and `ox viz pr`, plus updated CLI navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->