### PR TITLE
test: cut fast-suite wall clock and add timing metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
             --rerun-fails=1 \
             --packages=./... \
             --junitfile test-results.xml \
+            --jsonfile-timing-events test-timings.json \
             -- -short -race -p 8 -parallel 32 -timeout=10m
 
       - name: Full tests (PR gate)
@@ -66,11 +67,16 @@ jobs:
             --rerun-fails=1 \
             --packages=./... \
             --junitfile test-results.xml \
+            --jsonfile-timing-events test-timings.json \
             -- -race -p 8 -parallel 32 -timeout=15m
 
       - name: Failure digest
         if: always() && hashFiles('test-results.xml') != ''
-        run: python3 .github/scripts/junit_to_summary.py test-results.xml >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          python3 .github/scripts/junit_to_summary.py test-results.xml >> "$GITHUB_STEP_SUMMARY"
+          if test -f test-timings.json; then
+            python3 scripts/test_metrics.py --markdown test-timings.json >> "$GITHUB_STEP_SUMMARY" || echo "Test timing metrics unavailable." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload JUnit results
         if: always() && hashFiles('test-results.xml') != ''
@@ -78,6 +84,14 @@ jobs:
         with:
           name: test-results
           path: test-results.xml
+          retention-days: 14
+
+      - name: Upload test timing events
+        if: always() && hashFiles('test-timings.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-timing-events
+          path: test-timings.json
           retention-days: 14
 
   lint:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for ox CLI tool
 
 .PHONY: check-no-git-lfs-shell check-raw-writer-chokepoint check-session-meta-rmw
-.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-all test-slow test-integration test-agents test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version beads-setup
+.PHONY: help build build-ox build-adapters install install-adapters clean dev run test test-cover test-timings test-all test-slow test-integration test-agents test-preflight test-digital-twin test-ledger-twin test-benchmark test-sequential test-profile test-watch coverage coverage-report coverage-func coverage-baseline coverage-diff coverage-check build-cover coverage-integration smoke-test lint lint-test-env format release release-snapshot dist install-hooks docs docs-publish refresh-friction-catalog bump-version verify-version beads-setup
 
 # Variables
 GO := go
@@ -109,6 +109,10 @@ run: build ## Build and run ox
 # Output: quiet by default (agent-friendly). V=1 for verbose.
 #
 GOTESTSUM := $(shell which gotestsum 2>/dev/null || echo "go run gotest.tools/gotestsum@latest")
+# Leave empty to create a unique artifact per local invocation. Set explicitly
+# when a caller needs a stable path (for example, CI uploads its artifact).
+TEST_TIMINGS ?=
+TEST_METRICS := scripts/test_metrics.py
 
 # Isolate test `git` invocations from the developer's global config.
 # Many tests build scratch repos in t.TempDir() and run `git init` +
@@ -140,11 +144,20 @@ TEST_GIT_ISOLATION := \
 # Targets below are agent-friendly by default (quiet). V=1 for verbose.
 test: ## Run fast tests — unit tests <500ms, race detection, no coverage (every commit)
 	$(call say,"Running fast tests (skipping >500ms, no coverage)...")
-	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -short -race -p 8 -parallel 32 ./...
+	@timings='$(TEST_TIMINGS)'; \
+	if [ -z "$$timings" ]; then timings=$$(mktemp -p tmp test-timings.XXXXXX); else mkdir -p "$$(dirname "$$timings")"; fi; \
+	$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) --jsonfile-timing-events "$$timings" -- -short -race -p 8 -parallel 32 ./...; \
+	echo "TEST_TIMING_ARTIFACT path=$$timings"; \
+	python3 $(TEST_METRICS) "$$timings"
 
 test-cover: ## Run fast tests with coverage collection (~15-20% slower than `make test`)
 	$(call say,"Running fast tests with coverage...")
 	@$(TEST_GIT_ISOLATION) $(TIME_CMD) $(GOTESTSUM) --format $(GOTESTSUM_FMT) $(GOTESTSUM_LEAN) -- -short -race -p 8 -parallel 32 -coverprofile=coverage.out -covermode=atomic ./...
+
+test-timings: ## Reprint metrics from the latest fast-test timing artifact
+	@test -n "$(TEST_TIMINGS)" || (echo "Set TEST_TIMINGS to an artifact printed by 'make test'." && exit 1)
+	@test -f $(TEST_TIMINGS) || (echo "No fast-test timing artifact at $(TEST_TIMINGS)." && exit 1)
+	@python3 $(TEST_METRICS) $(TEST_TIMINGS)
 
 test-all: ## Run all unit tests including expensive ones (git clone, SQLite, LFS) with coverage
 	$(call say,"Running all tests including expensive tests...")

--- a/cmd/ox/adapter_test.go
+++ b/cmd/ox/adapter_test.go
@@ -26,6 +26,10 @@ func TestAdapterList_NoAdapters(t *testing.T) {
 // TestAdapterList_WithDiscoveredAdapters verifies list finds adapters from OX_ADAPTER_PATH.
 // Failure prevented: discovery integration broken in CLI layer.
 func TestAdapterList_WithDiscoveredAdapters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("adapter discovery executes a subprocess")
+	}
+
 	dir := t.TempDir()
 	createFakeAdapter(t, dir, "test-list", "0.2.0", "session")
 

--- a/cmd/ox/agent_session_incremental_test.go
+++ b/cmd/ox/agent_session_incremental_test.go
@@ -22,6 +22,9 @@ import (
 // and sets XDG env vars for isolated test caching.
 func setupIncrementalTest(t *testing.T) string {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("short: exercises multi-step recording state and raw-session filesystem flows")
+	}
 	cacheDir := t.TempDir()
 	projectRoot := t.TempDir()
 
@@ -752,6 +755,9 @@ func TestHandleAfterTool_NotRecording(t *testing.T) {
 // --- Large content handling ---
 
 func TestAppendLargeEntries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: redacts and persists a 1 MiB tool payload")
+	}
 	tmpDir := t.TempDir()
 	rawPath := filepath.Join(tmpDir, "raw.jsonl")
 

--- a/cmd/ox/login_test.go
+++ b/cmd/ox/login_test.go
@@ -25,6 +25,10 @@ import (
 // IsAuthenticatedForEndpoint returned a fatal error that blocked login
 // entirely.
 func TestLoginProceedsWhenTokenRefreshFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("device authorization flow waits for a poll timeout")
+	}
+
 	// Mock server: return 404 on /oauth2/token (refresh) and 200 on
 	// /api/auth/device/code (device flow) so we can detect that login
 	// proceeded past the refresh failure.

--- a/cmd/ox/plan_backfill_test.go
+++ b/cmd/ox/plan_backfill_test.go
@@ -142,6 +142,9 @@ func TestRunPlanBackfillTitlesOnLedger_DryRunNoPlansIsCleanNoOp(t *testing.T) {
 // here (no remote configured) without failing the command.
 func initGitLedger(t *testing.T, ledgerPath string) {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("short: initializes and commits a real ledger repository")
+	}
 	run := func(args ...string) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = ledgerPath

--- a/cmd/ox/session_upload_push_test.go
+++ b/cmd/ox/session_upload_push_test.go
@@ -18,6 +18,9 @@ import (
 // Returns (barePath, clonePath). Both are inside t.TempDir() and auto-cleaned.
 func createBareAndClone(t *testing.T) (string, string) {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("short: initializes and clones a real bare git repository")
+	}
 
 	base := t.TempDir()
 	barePath := filepath.Join(base, "remote.git")

--- a/internal/api/repos_test.go
+++ b/internal/api/repos_test.go
@@ -191,6 +191,10 @@ func TestGetRepos_NetworkError(t *testing.T) {
 }
 
 func TestGetRepos_Timeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("verifies a deliberately slow HTTP response")
+	}
+
 	t.Parallel()
 	// server takes too long to respond
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -685,6 +689,10 @@ func TestGetTeamInfo_URLEncoding(t *testing.T) {
 }
 
 func TestGetTeamInfo_Timeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("verifies a deliberately slow HTTP response")
+	}
+
 	t.Parallel()
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(3 * time.Second)

--- a/internal/auth/authfile_test.go
+++ b/internal/auth/authfile_test.go
@@ -129,6 +129,9 @@ func TestLock_MutualExclusion_SameEndpoint(t *testing.T) {
 // already held externally, withAuthFileLocked returns a timeout error.
 // Failure prevented: indefinite hang when another process holds the lock.
 func TestLock_Timeout_HeldByAnotherProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: intentionally waits for the cross-process lock timeout")
+	}
 	t.Parallel()
 
 	dir := t.TempDir()

--- a/internal/codedb/index/concurrency_test.go
+++ b/internal/codedb/index/concurrency_test.go
@@ -46,6 +46,9 @@ func gitExec(t *testing.T, dir string, args ...string) {
 // WAL mode so reads and the serialized write path are safe; this test validates
 // the Bleve layer and SQL transaction serialization under contention.
 func TestConcurrentIndexLocalRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: concurrently indexes a real git repository")
+	}
 	t.Parallel()
 
 	const goroutines = 3
@@ -86,6 +89,9 @@ func TestConcurrentIndexLocalRepo(t *testing.T) {
 // while a long IndexLocalRepo is running on the same Store. SQLite WAL mode
 // allows concurrent readers, and this test confirms no deadlock or crash.
 func TestSearchDuringIndexing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: indexes a real git repository while polling SQLite")
+	}
 	t.Parallel()
 
 	dir, _ := initGitRepo(t, 20) // larger repo → longer index time → more read overlap
@@ -132,6 +138,9 @@ func TestSearchDuringIndexing(t *testing.T) {
 // (tmp dir exists, manifest not yet written). GC must not remove a partially-built
 // overlay, and the final manifest must be intact after both complete.
 func TestGCDirtyIndexesDuringBuild(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: runs concurrent dirty-index maintenance against a real git repository")
+	}
 	t.Parallel()
 
 	dir, _ := initGitRepo(t, 3)
@@ -188,6 +197,9 @@ func TestGCDirtyIndexesDuringBuild(t *testing.T) {
 // a second time after new commits are added produces no duplicate rows — this is
 // the sequential precondition for safe incremental updates.
 func TestIncrementalIndexDoesNotDuplicateCommits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: indexes a real git repository twice")
+	}
 	t.Parallel()
 
 	dir, _ := initGitRepo(t, 3)

--- a/internal/codedb/index/perf_regression_test.go
+++ b/internal/codedb/index/perf_regression_test.go
@@ -613,6 +613,9 @@ func TestDiffTree_UnchangedFilesNotDuplicated(t *testing.T) {
 // and that double-indexing after checkpoints is still idempotent.
 
 func TestCheckpointFlush_DataAccessibleAfterRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: indexes more than a checkpoint of real git history")
+	}
 	t.Parallel()
 	// Use more than checkpointEvery commits to force at least one checkpoint.
 	numCommits := checkpointEvery + 100
@@ -629,6 +632,9 @@ func TestCheckpointFlush_DataAccessibleAfterRun(t *testing.T) {
 }
 
 func TestCheckpointFlush_IdempotentAfterCheckpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: re-indexes more than a checkpoint of real git history")
+	}
 	t.Parallel()
 	// Re-indexing after a checkpoint run must produce the same counts.
 	numCommits := checkpointEvery + 50

--- a/internal/codedb/index/worktree_test.go
+++ b/internal/codedb/index/worktree_test.go
@@ -23,6 +23,9 @@ import (
 // Uses git CLI to avoid go-git quirks with config.
 func initGitRepo(t *testing.T, numCommits int) (string, string) {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("short: builds a real git repository for CodeDB indexing")
+	}
 	dir := t.TempDir()
 
 	run := func(args ...string) string {

--- a/internal/codedb/query/activity_test.go
+++ b/internal/codedb/query/activity_test.go
@@ -860,6 +860,9 @@ func TestContextDeadline(t *testing.T) {
 }
 
 func TestVolumeTest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: loads a volume-sized activity dataset")
+	}
 	t.Parallel()
 	s := openTestStore(t)
 	since := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/codedb/symbols/extract_test.go
+++ b/internal/codedb/symbols/extract_test.go
@@ -442,6 +442,10 @@ func TestExtract_C_ReturnType(t *testing.T) {
 }
 
 func TestExtract_LargeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("large generated source is a full-suite regression case")
+	}
+
 	t.Parallel()
 	var b strings.Builder
 	b.WriteString("package main\n\n")

--- a/internal/daemon/agentwork/session_watcher_handle_poll_test.go
+++ b/internal/daemon/agentwork/session_watcher_handle_poll_test.go
@@ -67,6 +67,9 @@ func (r *fakeHandleReader) ReadFromOffset(_ string, offset int64) ([]adapters.Ra
 // path plus a stop func.
 func runPoll(t *testing.T, reader adapters.IncrementalReader, startOffset int64) (rawPath string, recPath string, stop func()) {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("short: drives the polling loop across wait intervals")
+	}
 
 	cache := t.TempDir()
 	rawPath = filepath.Join(cache, "raw.jsonl")
@@ -188,6 +191,9 @@ func TestPollSession_AdvancesTheCursorAcrossBatches(t *testing.T) {
 // TestPollSession_RestartDoesNotReplay simulates the restart directly:
 // a second loop started from the persisted offset must record nothing new.
 func TestPollSession_RestartDoesNotReplay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: polls through a restart and wait intervals")
+	}
 	reader := &fakeHandleReader{}
 	reader.append("alpha")
 	reader.append("beta")

--- a/internal/daemon/sync_race_test.go
+++ b/internal/daemon/sync_race_test.go
@@ -143,6 +143,9 @@ func TestSyncDuringActiveClone(t *testing.T) {
 // TestRapidSequentialSyncs calls SyncWithProgress many times in a tight loop
 // to verify each returns successfully and shared state stays consistent.
 func TestRapidSequentialSyncs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: performs repeated syncs against a real git ledger")
+	}
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not installed")
 	}

--- a/internal/daemon/whisper_registry_test.go
+++ b/internal/daemon/whisper_registry_test.go
@@ -350,6 +350,9 @@ func TestCloseIdleTeamStores(t *testing.T) {
 //
 // Iteration-bounded (not time-bounded) so it is deterministic and short.
 func TestPrune_RacesIdleClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: concurrent SQLite close-race stress test")
+	}
 	t.Parallel()
 
 	const (

--- a/internal/gitserver/coverage_extra_test.go
+++ b/internal/gitserver/coverage_extra_test.go
@@ -583,6 +583,9 @@ func TestCommitAndPushAgentsMD_NoRemote(t *testing.T) {
 }
 
 func TestCommitAndPushAgentsMD_WithRemote_PushFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: attempts a real remote git push that must fail")
+	}
 	t.Parallel()
 	repoPath := makeCovTestRepo(t)
 	runGit(t, repoPath, "remote", "add", "origin", "https://git.example.com/fake/repo.git")

--- a/internal/gitutil/rebase_resolve_pointer_test.go
+++ b/internal/gitutil/rebase_resolve_pointer_test.go
@@ -38,6 +38,9 @@ func itoa(n int) string {
 // and every subsequent push is rejected with "LFS objects are missing" — a
 // permanent, repo-wide wedge strictly worse than the one being fixed.
 func TestPointerWins_HydratedNeverBeatsPointer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: resolves conflicts in real divergent git repositories")
+	}
 	t.Parallel()
 	const (
 		sessionFile = "sessions/2026-07-01T00-00-ryan-Oxtest/session.md"
@@ -98,6 +101,9 @@ func TestPointerWins_HydratedNeverBeatsPointer(t *testing.T) {
 // TestPointerWinsStage_Classification pins the decision function itself, so a
 // future refactor cannot silently invert it.
 func TestPointerWinsStage_Classification(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: reads conflict stages from real divergent git repositories")
+	}
 	t.Parallel()
 	const f = "sessions/s1/session.md"
 	pointer := lfsPointer("abc123def4567890abc123def4567890abc123def4567890abc123def4567890", 100)

--- a/internal/gitutil/wedge_harness_test.go
+++ b/internal/gitutil/wedge_harness_test.go
@@ -43,6 +43,9 @@ type ledgerFixture struct {
 
 func newLedgerFixture(t *testing.T) *ledgerFixture {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("short: drives ledger recovery against real bare and working git repositories")
+	}
 	root := t.TempDir()
 	f := &ledgerFixture{
 		t:     t,

--- a/internal/observability/daemon_tracer_test.go
+++ b/internal/observability/daemon_tracer_test.go
@@ -62,6 +62,10 @@ func TestNewDaemonTracer_WithInit(t *testing.T) {
 // a new trace ID (no parent relationship).
 // Failure prevented: all daemon tasks sharing one trace, defeating per-task visibility.
 func TestDaemonTracer_StartTask_IndependentTraces(t *testing.T) {
+	if testing.Short() {
+		t.Skip("exporter shutdown waits for an unreachable endpoint")
+	}
+
 	resetGlobals()
 	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318", nil)
 	require.NoError(t, err)
@@ -88,6 +92,10 @@ func TestDaemonTracer_StartTask_IndependentTraces(t *testing.T) {
 // TestDaemonTracer_StartSubtask_ChildOfTask verifies subtask shares parent trace ID.
 // Failure prevented: subtask spans disconnected from parent task trace.
 func TestDaemonTracer_StartSubtask_ChildOfTask(t *testing.T) {
+	if testing.Short() {
+		t.Skip("exporter shutdown waits for an unreachable endpoint")
+	}
+
 	resetGlobals()
 	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318", nil)
 	require.NoError(t, err)
@@ -114,6 +122,10 @@ func TestDaemonTracer_StartSubtask_ChildOfTask(t *testing.T) {
 // TestDaemonTracer_StartTask_WithAttrs verifies attributes are accepted without error.
 // Failure prevented: panic or ignored attributes on task spans.
 func TestDaemonTracer_StartTask_WithAttrs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("exporter shutdown waits for an unreachable endpoint")
+	}
+
 	resetGlobals()
 	err := Init(context.Background(), "ox-daemon-test", "http://192.0.2.1:4318", nil)
 	require.NoError(t, err)

--- a/internal/observability/otel_test.go
+++ b/internal/observability/otel_test.go
@@ -86,6 +86,10 @@ func TestCommandName(t *testing.T) {
 // TestInit_ValidEndpoint verifies full lifecycle: init → start → traceparent → shutdown.
 // Uses a non-routable endpoint; export will fail silently (which is fine).
 func TestInit_ValidEndpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("exporter shutdown waits for an unreachable endpoint")
+	}
+
 	resetGlobals()
 
 	// Use a non-routable IP so export silently fails (no real Collector needed)

--- a/internal/plan/remap_adversarial_test.go
+++ b/internal/plan/remap_adversarial_test.go
@@ -324,6 +324,9 @@ func TestRemapFeedback_Idempotent_SecondRunIsNoOp(t *testing.T) {
 // hops, wrong open-state after re-raise-across-remap. (Its first run caught
 // the chain-walk path-dependence bug that became the fold resolver.)
 func TestFeedbackMerge_ModelBattery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: 40-round filesystem-backed model battery")
+	}
 	anchors := []string{"ha1", "ha2", "ha3", "ha4", "ha5"}
 	reviewers := []string{"alice", "bob", ""}
 	statuses := []FeedbackStatus{FeedbackApprove, FeedbackRequestChange, FeedbackFlag, FeedbackComment}

--- a/internal/plan/viz_embedding_test.go
+++ b/internal/plan/viz_embedding_test.go
@@ -12,6 +12,7 @@ func TestEditorialSVGPatternsEmbedInBothPlanThemes(t *testing.T) {
 	}
 	for _, id := range ids {
 		t.Run(id, func(t *testing.T) {
+			t.Parallel()
 			p, ok := VizPatternByID(id)
 			if !ok {
 				t.Fatalf("missing %s", id)

--- a/internal/session/adapters/external_test.go
+++ b/internal/session/adapters/external_test.go
@@ -11,6 +11,9 @@ import (
 // fakeBinary creates a shell script that echoes canned responses.
 func fakeBinary(t *testing.T, responses map[string]string) string {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("short: drives an external adapter subprocess")
+	}
 	script := "#!/bin/sh\ncase \"$1\" in\n"
 	for cmd, resp := range responses {
 		script += "  " + cmd + ") echo '" + resp + "';;\n"

--- a/pkg/tokenstrip/tokenstrip_test.go
+++ b/pkg/tokenstrip/tokenstrip_test.go
@@ -336,6 +336,9 @@ func TestHeaderUntouched(t *testing.T) {
 // TestOversizedEntry verifies a single >5MB entry does not break the stream.
 // bufio.Scanner would fail here; bufio.Reader.ReadBytes must not.
 func TestOversizedEntry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short: round-trips a payload larger than 5 MiB")
+	}
 	big := strings.Repeat("x", 5*1024*1024)
 	asst := map[string]any{"type": "assistant", "content": big}
 	line := mustJSON(t, asst)

--- a/scripts/test_metrics.py
+++ b/scripts/test_metrics.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Summarize gotestsum timing events without flooding the test output."""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+FINAL_ACTIONS = {"pass", "skip", "fail"}
+SLOWEST_LIMIT = 10
+
+
+def parse_time(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def duration(seconds: float) -> str:
+    if seconds >= 60:
+        return f"{seconds / 60:.1f}m"
+    return f"{seconds:.2f}s"
+
+
+def load_metrics(lines: list[str]) -> tuple[dict[str, int], float, float, list[tuple[float, str, str]]]:
+    counts = {action: 0 for action in FINAL_ACTIONS}
+    first_event: datetime | None = None
+    last_event: datetime | None = None
+    tests: dict[tuple[str, str], tuple[str, float]] = {}
+
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        event_time = parse_time(event.get("Time", ""))
+        if event_time:
+            first_event = min(first_event, event_time) if first_event else event_time
+            last_event = max(last_event, event_time) if last_event else event_time
+
+        action = event.get("Action")
+        test = event.get("Test")
+        if action not in FINAL_ACTIONS or not test:
+            continue
+
+        package = event.get("Package", "?")
+        elapsed = float(event.get("Elapsed", 0))
+        key = (package, test)
+        # Retries emit duplicate final events. Keep the final result and the
+        # largest elapsed time so timing regressions are never hidden.
+        previous = tests.get(key)
+        if previous is None or elapsed >= previous[1]:
+            tests[key] = (action, elapsed)
+
+    slowest: list[tuple[float, str, str]] = []
+    elapsed_sum = 0.0
+    for (package, test), (action, elapsed) in tests.items():
+        counts[action] += 1
+        if action != "skip":
+            elapsed_sum += elapsed
+        slowest.append((elapsed, package, test))
+
+    wall_seconds = (last_event - first_event).total_seconds() if first_event and last_event else 0.0
+    return counts, wall_seconds, elapsed_sum, sorted(slowest, reverse=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", help="gotestsum timing-event file, or - for stdin")
+    parser.add_argument("--markdown", action="store_true", help="emit GitHub-flavored Markdown")
+    args = parser.parse_args()
+
+    if args.path == "-":
+        lines = sys.stdin.read().splitlines()
+    else:
+        path = Path(args.path)
+        if not path.is_file():
+            print(f"test metrics: timing artifact not found: {path}", file=sys.stderr)
+            return 1
+        lines = path.read_text().splitlines()
+
+    counts, wall_seconds, elapsed_sum, slowest = load_metrics(lines)
+    total = sum(counts.values())
+
+    if args.markdown:
+        print("### Test timing metrics")
+        print()
+        print(f"- Event-span wall clock: **{duration(wall_seconds)}**")
+        print(f"- Tests: **{counts['pass']} passed**, **{counts['skip']} skipped**, **{counts['fail']} failed** (total **{total}**)")
+        print(f"- Summed test time: **{duration(elapsed_sum)}**")
+        print()
+        print("#### Slowest test cases")
+        print()
+        for elapsed, package, test in slowest[:SLOWEST_LIMIT]:
+            print(f"- `{package}` · `{test}` — **{duration(elapsed)}**")
+        return 0
+
+    print(
+        "TEST_METRICS"
+        f" wall={duration(wall_seconds)}"
+        f" passed={counts['pass']}"
+        f" skipped={counts['skip']}"
+        f" failed={counts['fail']}"
+        f" total={total}"
+        f" test_time_sum={duration(elapsed_sum)}"
+    )
+    for elapsed, package, test in slowest[:SLOWEST_LIMIT]:
+        print(f"  SLOWEST {duration(elapsed):>7} {package} {test}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What broke

The fast suite had no durable per-test timing signal, and expensive integration-style cases still ran under `-short`. This left the suite slow and made regressions difficult to attribute.

## What this PR ships

- **Metrics:** `make test` now retains gotestsum timing events and prints a compact slow-test summary; CI publishes the same summary and a 14-day timing artifact.
- **Fast-tier boundaries:** Moves deliberate timeouts, real Git/subprocess workflows, large-payload checks, and stress batteries to the full suite while preserving their coverage there.
- **Parallelism:** Runs independent plan visualization subtests concurrently.

```mermaid
flowchart LR
  A[gotestsum timing events] --> B[test_metrics.py]
  B --> C[local slow-test summary]
  B --> D[GitHub job summary]
  A --> E[CI timing artifact]
```

## Result

- **Fast-suite wall clock:** 102.59s → 44.17s (56.9% reduction)
- **Latest run:** 18,656 total; 17,365 passed; 1,291 intentionally skipped; 0 failed

## Test Plan

- [x] `make lint`
- [x] `make test`
- [x] `git diff --check origin/main...`
- [x] Security review N/A: test-tier and CI-observability changes only; no production auth behavior changed.

Co-authored-by: SageOx <ox@sageox.ai>
