### PR TITLE
fix(auth): unify token introspection and fail closed on a malformed SAGEOX_TOKEN

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -441,10 +441,17 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 				}
 			}
 
-			// distinguish "never logged in" from "token expired/refresh failed"
-			msg := "Not logged in."
-			if authErr != nil {
-				msg = "Authentication expired."
+			// Distinguish "never logged in" from "token expired/refresh failed"
+			// from "SAGEOX_TOKEN is set but unusable". The third case must NOT
+			// advise `ox login`: an env token wins over any disk credential, so
+			// the login would succeed and every command after it would fail the
+			// same way, with nothing connecting the two.
+			msg := fmt.Sprintf("Not logged in. Run 'ox login' to authenticate with %s.", endpointSlug)
+			switch {
+			case errors.Is(authErr, auth.ErrEnvTokenMalformed):
+				msg = fmt.Sprintf("SAGEOX_TOKEN is set but its value failed a local format check, so it was refused for %s. Re-copy the token (a truncated paste is the usual cause), or unset SAGEOX_TOKEN to use a stored login.", endpointSlug)
+			case authErr != nil:
+				msg = fmt.Sprintf("Authentication expired. Run 'ox login' to authenticate with %s.", endpointSlug)
 			}
 			output := agentPrimeOutput{
 				Status:             "degraded",
@@ -452,7 +459,7 @@ func runAgentPrime(cmd *cobra.Command, args []string) error {
 				Session:            sessionStat,
 				CurrentUserName:    currentUserName,
 				CurrentUserAliases: currentUserAliases,
-				Message:            fmt.Sprintf("%s Run 'ox login' to authenticate with %s. Session recording is active locally — data will be uploaded after authentication.", msg, endpointSlug),
+				Message:            msg + " Session recording is active locally — data will be uploaded after authentication.",
 			}
 			if sessionStat != nil && sessionStat.UserNotification != "" {
 				output.UserNotification = sessionStat.UserNotification

--- a/cmd/ox/doctor_auth.go
+++ b/cmd/ox/doctor_auth.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -11,18 +12,40 @@ import (
 	"github.com/sageox/ox/internal/gitserver"
 )
 
+// malformedEnvTokenRemedy is the family-aware guidance for a SAGEOX_TOKEN that
+// is set for ep but fails the local format check.
+//
+// `ox login` is the wrong remedy for every shape of this failure, and actively
+// harmful for a team token: it only ever mints a personal oxp_ credential, so
+// following the advice silently changes which principal the CLI acts as.
+func malformedEnvTokenRemedy(ep string) string {
+	if auth.EnvTokenIsTeamFamily(ep) {
+		return auth.EnvVarToken + " holds a team token whose checksum does not match — a truncated paste is the usual cause. Re-copy it from your CI secret store. `ox login` mints personal oxp_ tokens and cannot replace it."
+	}
+	return auth.EnvVarToken + " is set for this endpoint but its value failed a local format check — a truncated paste is the usual cause. Re-copy the value, or unset " + auth.EnvVarToken + " to fall back to `ox login`."
+}
+
 // checkAuthentication verifies user is logged in - this is CRITICAL for SageOx to work
 func checkAuthentication() checkResult {
 	// use project-specific endpoint if available, otherwise default
 	gitRoot := findGitRoot()
 	projectEndpoint := endpoint.GetForProject(gitRoot)
+	// Resolve the endpoint once. auth.IsAuthenticated() is exactly
+	// IsAuthenticatedForEndpoint(endpoint.Get()), and the env-token questions
+	// below need the same endpoint the auth check used — SAGEOX_TOKEN is bound
+	// to one endpoint, so asking about "" would report every token as absent.
+	if projectEndpoint == "" {
+		projectEndpoint = endpoint.Get()
+	}
 
-	var authenticated bool
-	var err error
-	if projectEndpoint != "" {
-		authenticated, err = auth.IsAuthenticatedForEndpoint(projectEndpoint)
-	} else {
-		authenticated, err = auth.IsAuthenticated()
+	authenticated, err := auth.IsAuthenticatedForEndpoint(projectEndpoint)
+
+	// A silently-substituted principal is exactly the failure mode doctor
+	// exists to catch: the operator named one credential, ox declined to use
+	// it, and every remaining path reports the state as an ordinary absence.
+	if errors.Is(err, auth.ErrEnvTokenMalformed) {
+		return CriticalCheck("Logged in", auth.EnvVarToken+" malformed",
+			malformedEnvTokenRemedy(projectEndpoint))
 	}
 
 	if err != nil {
@@ -36,12 +59,7 @@ func checkAuthentication() checkResult {
 	}
 
 	// get user info for display
-	var token *auth.StoredToken
-	if projectEndpoint != "" {
-		token, err = auth.GetTokenForEndpoint(projectEndpoint)
-	} else {
-		token, err = auth.GetToken()
-	}
+	token, err := auth.GetTokenForEndpoint(projectEndpoint)
 	if err != nil || token == nil {
 		return PassedCheck("Logged in", "yes")
 	}

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -1430,6 +1430,14 @@ daemon health, and a tree view of all SageOx directory locations.`,
 			authenticated = false
 		}
 
+		// A SAGEOX_TOKEN that fails the local format check is a REFUSAL, not an
+		// absence, and the two want different follow-up copy. The `--json`
+		// shape needs no new field: the credential resolver reports this as an
+		// error, so it lands in auth.error rather than as a bare
+		// {"authenticated": false} that reads as "nobody ever logged in".
+		_, envTokenState := auth.EnvTokenFor(currentEndpoint)
+		envTokenMalformed := envTokenState == auth.EnvTokenMalformed
+
 		// get auth token if authenticated
 		var token *auth.StoredToken
 		if authenticated {
@@ -1564,9 +1572,12 @@ daemon health, and a tree view of all SageOx directory locations.`,
 		// Human-readable output mode
 		// Authentication Status - always show, includes endpoint
 		fmt.Print(renderAuthStatus(authFile))
-		if authErr != nil {
+		switch authFollowUpHint(envTokenMalformed, authErr, len(auth.GetLoggedInEndpoints())) {
+		case authHintUnreachable:
+			fmt.Printf("  %s %s\n", statusWarningStyle.Render("⚠ could not reach the endpoint:"), statusMutedStyle.Render("auth state is unverified, not invalid"))
+		case authHintRefreshFailed:
 			fmt.Printf("  %s %s\n", statusWarningStyle.Render("⚠ token refresh failed:"), statusMutedStyle.Render("run `ox login` to re-authenticate"))
-		} else if len(auth.GetLoggedInEndpoints()) == 0 {
+		case authHintLogin:
 			// use contextual action hint matching help's visual style
 			cli.PrintActionHint("ox login", "Authenticate with "+cli.Wordmark(), 1)
 		}
@@ -1839,10 +1850,43 @@ func renderAuthStatus(authFile string) string {
 	// get all logged-in endpoints
 	loggedInEndpoints := auth.GetLoggedInEndpoints()
 
+	// SAGEOX_TOKEN's state has to be asked for DIRECTLY rather than inferred
+	// from the list above. That list means "endpoints holding a usable
+	// credential", so a value that fails the local format check contributes
+	// nothing to it — and with no disk login behind it, the endpoint disappears
+	// from the list entirely. The operator who exported the token would then
+	// read a bare "not logged in": the one diagnosis that never mentions the
+	// credential they actually supplied, and the one that sends a CI operator
+	// to `ox login`, which cannot help them.
+	envEP := auth.EnvTokenEndpoint()
+	_, envState := auth.EnvTokenFor(envEP)
+	envMalformed := envState == auth.EnvTokenMalformed
+
+	if envMalformed {
+		// A disk login for the SAME endpoint is the dangerous shape: the
+		// operator believes CI is acting as the credential they named, while
+		// every API call, ledger write, and murmur would be attributed to
+		// whoever last ran `ox login` on this machine. Report the env value
+		// and render nothing that could be mistaken for an active identity.
+		shadowsDiskLogin := false
+		remaining := loggedInEndpoints[:0:0]
+		for _, ep := range loggedInEndpoints {
+			if endpoint.NormalizeEndpoint(ep) == endpoint.NormalizeEndpoint(envEP) {
+				shadowsDiskLogin = true
+				continue
+			}
+			remaining = append(remaining, ep)
+		}
+		loggedInEndpoints = remaining
+		b.WriteString(renderMalformedEnvToken(envEP, shadowsDiskLogin, authFile))
+	}
+
 	if len(loggedInEndpoints) == 0 {
-		b.WriteString(statusLabelStyle.Render("Status"))
-		b.WriteString(statusErrorStyle.Render("✗ not logged in"))
-		b.WriteString("\n")
+		if !envMalformed {
+			b.WriteString(statusLabelStyle.Render("Status"))
+			b.WriteString(statusErrorStyle.Render("✗ not logged in"))
+			b.WriteString("\n")
+		}
 		return b.String()
 	}
 
@@ -1851,7 +1895,7 @@ func renderAuthStatus(authFile string) string {
 		epToken, _ := auth.GetTokenForEndpoint(ep)
 		epSlug := endpoint.NormalizeSlug(ep)
 
-		if i > 0 {
+		if i > 0 || envMalformed {
 			b.WriteString("\n")
 		}
 
@@ -1875,39 +1919,76 @@ func renderAuthStatus(authFile string) string {
 		// and caps itself at 5s; its parsed result also tells us WHO the
 		// token authenticates as, which the identity rendering below needs.
 		envValid := true
+		envUnreachable := false
 		var envValidErr error
 		var introspectResult *auth.IntrospectResult
 		if envSourced && epToken != nil {
 			introspectResult, envValidErr = auth.Introspect(ep, epToken.AccessToken)
 			envValid = envValidErr == nil
+			// "The server said no" and "we never got to ask" are different
+			// facts with different remedies, and only one of them costs the
+			// user a credential rotation.
+			envUnreachable = errors.Is(envValidErr, auth.ErrEndpointUnreachable)
 		}
 
 		b.WriteString(statusLabelStyle.Render("Endpoint"))
 		b.WriteString(statusHighlightStyle.Render(epSlug))
-		if envSourced && !envValid {
-			// Must read as a NEGATIVE auth verdict — this is the line a human
-			// (and the BDD status parser) reads to decide whether the CLI is
-			// usable at all.
+		switch {
+		case envSourced && envUnreachable:
+			// Deliberately NEITHER verdict. This is the line a human (and the
+			// BDD status parser) reads to decide whether the CLI is usable, so
+			// it must not carry a ✓ we have not earned — but a ✗ would be an
+			// outright false claim about a credential the server never judged.
+			b.WriteString(statusWarningStyle.Render(" (? could not verify)"))
+		case envSourced && !envValid:
+			// Must read as a NEGATIVE auth verdict.
 			b.WriteString(statusErrorStyle.Render(" (✗ not authenticated)"))
-		} else {
+		default:
 			b.WriteString(statusSuccessStyle.Render(" (✓ logged in)"))
 		}
 		b.WriteString("\n")
 
-		if envSourced && !envValid {
+		// epToken != nil is part of the condition rather than an implicit
+		// invariant carried over from the Introspect block above: the hint
+		// below dereferences it, and a nil deref inside `ox status` would take
+		// out the command users run precisely when something is already wrong.
+		if envSourced && epToken != nil && envUnreachable {
+			b.WriteString(statusLabelStyle.Render("Credential"))
+			b.WriteString(statusWarningStyle.Render("SAGEOX_TOKEN (env) — could not verify"))
+			b.WriteString("\n")
+			// Deliberately avoids the word a support ticket would grep for
+			// ("rejected"): the server never judged this credential, and the
+			// copy must not read as if it had.
+			b.WriteString(statusMutedStyle.Render("  the endpoint did not answer, so this token has not been verified"))
+			b.WriteString("\n")
+			b.WriteString(statusMutedStyle.Render("  either way — check connectivity (VPN, proxy, DNS) and re-run `ox status`"))
+			b.WriteString("\n")
+			// The transport error goes last and on its own line: it is the only
+			// part of this block whose length we do not control (a dial error
+			// carries a full URL), and putting it in a labeled row would push
+			// every scannable line past the terminal width.
+			b.WriteString(statusMutedStyle.Render("  " + envValidErr.Error()))
+			b.WriteString("\n")
+			continue
+		}
+
+		if envSourced && epToken != nil && !envValid {
 			b.WriteString(statusLabelStyle.Render("Credential"))
 			b.WriteString(statusErrorStyle.Render("SAGEOX_TOKEN (env) rejected"))
 			b.WriteString(statusMutedStyle.Render(" — " + envValidErr.Error()))
 			b.WriteString("\n")
-			// A rejected team token (oxt_) isn't a "your PAT expired"
-			// situation — `ox login` only ever mints a personal oxp_ token,
-			// and "/settings/tokens" is the PAT UI, so both defaults below
-			// send the user down the wrong path. Family-aware guidance per
-			// .context/token-hardening-contract.md §7.
+			// A refused team token (oxt_) isn't a "your PAT expired" situation:
+			// `ox login` only ever mints a personal oxp_ token, and the PAT
+			// settings page cannot issue a team credential either, so both
+			// personal-token defaults send this user down a path that ends
+			// nowhere. Point at the CI secret store instead, which is where a
+			// team token is actually rotated.
 			if strings.HasPrefix(epToken.AccessToken, auth.TeamTokenPrefix) {
-				b.WriteString(statusMutedStyle.Render("  this looks like a team token — set SAGEOX_TOKEN for CI/API use;"))
+				b.WriteString(statusMutedStyle.Render("  this looks like a team token — check it has not been revoked or rotated"))
 				b.WriteString("\n")
-				b.WriteString(statusMutedStyle.Render("  `ox login` expects a personal oxp_ token"))
+				b.WriteString(statusMutedStyle.Render("  in your CI secret store; `ox login` mints personal oxp_ tokens and"))
+				b.WriteString("\n")
+				b.WriteString(statusMutedStyle.Render("  cannot replace it"))
 			} else {
 				b.WriteString(statusMutedStyle.Render("  the value in SAGEOX_TOKEN is not a credential this endpoint accepts;"))
 				b.WriteString("\n")
@@ -1918,34 +1999,7 @@ func renderAuthStatus(authFile string) string {
 		}
 
 		if epToken != nil {
-			switch {
-			case envSourced && introspectResult != nil && introspectResult.PrincipalKind == "team-service":
-				// A team token acts AS THE TEAM, not a person — introspection
-				// is the only source for "which team" (there was no login
-				// step to learn it from). Render it explicitly instead of
-				// falling into the blank-identity branch below, which reads
-				// as broken rather than team-scoped.
-				teamID := "(unknown team)"
-				if introspectResult.Team != nil && introspectResult.Team.TeamID != "" {
-					teamID = introspectResult.Team.TeamID
-				}
-				b.WriteString(statusLabelStyle.Render("Acting as"))
-				b.WriteString(statusHighlightStyle.Render("team " + teamID))
-				if introspectResult.Token != nil && introspectResult.Token.Name != "" {
-					b.WriteString(statusMutedStyle.Render(" (" + introspectResult.Token.Name + ")"))
-				}
-				b.WriteString("\n")
-			case envSourced && epToken.UserInfo.Name == "" && epToken.UserInfo.Email == "":
-				b.WriteString(statusLabelStyle.Render("Credential"))
-				b.WriteString(statusHighlightStyle.Render("SAGEOX_TOKEN (env)"))
-				b.WriteString(statusMutedStyle.Render(" — identity resolved server-side per request"))
-				b.WriteString("\n")
-			default:
-				b.WriteString(statusLabelStyle.Render("User"))
-				b.WriteString(statusHighlightStyle.Render(epToken.UserInfo.Name))
-				b.WriteString(statusMutedStyle.Render(" <" + epToken.UserInfo.Email + ">"))
-				b.WriteString("\n")
-			}
+			b.WriteString(renderIdentity(envSourced, epToken, introspectResult))
 
 			// Auth status. The OAuth access token expires every ~hour and
 			// is rotated silently via the refresh token (or Better-Auth
@@ -2005,6 +2059,175 @@ func renderAuthStatus(authFile string) string {
 			}
 			b.WriteString("\n")
 		}
+	}
+
+	return b.String()
+}
+
+// authHint selects the one-line follow-up printed under the auth section.
+type authHint int
+
+const (
+	// authHintNone: renderAuthStatus already said everything useful.
+	authHintNone authHint = iota
+	// authHintUnreachable: we could not ask the server anything.
+	authHintUnreachable
+	// authHintRefreshFailed: the server answered, and the answer was no.
+	authHintRefreshFailed
+	// authHintLogin: no credential at all.
+	authHintLogin
+)
+
+// authFollowUpHint decides which follow-up hint (if any) belongs under the auth
+// section. Split out because every arm is a wrong-advice bug waiting to happen
+// and the surrounding command body is untestable:
+//
+//   - A malformed SAGEOX_TOKEN gets NO hint: renderAuthStatus already named the
+//     variable and gave family-aware guidance, and both `ox login` hints send
+//     the operator to a command that cannot mint the credential they supplied —
+//     which, in the CI environment SAGEOX_TOKEN exists for, they cannot run at
+//     all.
+//   - An unreachable endpoint gets a connectivity hint, never "re-authenticate":
+//     the server never answered, so prescribing a credential rotation for what
+//     is almost always a VPN, proxy, or DNS fault replaces a working credential
+//     to fix a network.
+func authFollowUpHint(envTokenMalformed bool, authErr error, loggedInEndpoints int) authHint {
+	switch {
+	case envTokenMalformed:
+		return authHintNone
+	case errors.Is(authErr, auth.ErrEndpointUnreachable):
+		return authHintUnreachable
+	case authErr != nil:
+		return authHintRefreshFailed
+	case loggedInEndpoints == 0:
+		return authHintLogin
+	default:
+		return authHintNone
+	}
+}
+
+// renderIdentity renders the "who is this credential" line for one endpoint.
+//
+// Pure and I/O-free on purpose: the identity matrix is (env-sourced or not) ×
+// (introspection succeeded, failed, or was never attempted) × (principal kind)
+// × (team present or not) × (UserInfo populated or blank), and every cell of it
+// used to require a live HTTP server, three environment variables and a
+// temporary config dir to reach. Keeping the decision here lets that matrix be
+// covered by a table test while the surrounding integration-shaped tests keep
+// proving the wiring is real.
+//
+// tok must be non-nil. ir is nil whenever introspection was not attempted or
+// did not return a body.
+func renderIdentity(envSourced bool, tok *auth.StoredToken, ir *auth.IntrospectResult) string {
+	var b strings.Builder
+
+	switch {
+	case envSourced && ir != nil && (ir.PrincipalKind == auth.PrincipalKindTeamService ||
+		(ir.Team != nil && ir.Team.TeamID != "")):
+		// A team token acts AS THE TEAM, not as a person, and introspection is
+		// the only source for "which team" — there was no login step to learn
+		// it from. The second clause covers a principal kind we do not
+		// recognize: if the server named a team, dropping it would make status
+		// tell the operator strictly less than the server did, and the generic
+		// branch below reads as "no identity available" rather than "we did not
+		// understand the answer".
+		teamID := "(unknown team)"
+		if ir.Team != nil && ir.Team.TeamID != "" {
+			teamID = ir.Team.TeamID
+		}
+		b.WriteString(statusLabelStyle.Render("Acting as"))
+		b.WriteString(statusHighlightStyle.Render("team " + teamID))
+		if ir.Token != nil && ir.Token.Name != "" {
+			// Which credential this is, by the name it was minted with — the
+			// only handle an operator has for finding it in a secret store.
+			b.WriteString(statusMutedStyle.Render(" (" + ir.Token.Name + ")"))
+		}
+		b.WriteString("\n")
+
+	case envSourced && ir != nil && ir.PrincipalKind == auth.PrincipalKindUser && ir.User != nil &&
+		(ir.User.Name != "" || ir.User.Email != ""):
+		// An env-sourced token carries no UserInfo (there was no login), so
+		// without this branch a response that names a real person still
+		// rendered the generic "identity resolved server-side per request".
+		// Telling WHO a credential authenticates as is the whole reason status
+		// asks the introspection endpoint rather than a bare liveness check.
+		name := ir.User.Name
+		if name == "" {
+			name = ir.User.Email
+		}
+		b.WriteString(statusLabelStyle.Render("User"))
+		b.WriteString(statusHighlightStyle.Render(name))
+		if ir.User.Email != "" && ir.User.Email != name {
+			b.WriteString(statusMutedStyle.Render(" <" + ir.User.Email + ">"))
+		}
+		b.WriteString("\n")
+
+	case envSourced && tok.UserInfo.Name == "" && tok.UserInfo.Email == "":
+		// Nothing to name: printing "User  <>" next to a green check is worse
+		// than saying nothing. Name the credential source, which IS the useful
+		// fact here.
+		b.WriteString(statusLabelStyle.Render("Credential"))
+		b.WriteString(statusHighlightStyle.Render("SAGEOX_TOKEN (env)"))
+		b.WriteString(statusMutedStyle.Render(" — identity resolved server-side per request"))
+		b.WriteString("\n")
+
+	default:
+		b.WriteString(statusLabelStyle.Render("User"))
+		b.WriteString(statusHighlightStyle.Render(tok.UserInfo.Name))
+		b.WriteString(statusMutedStyle.Render(" <" + tok.UserInfo.Email + ">"))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// renderMalformedEnvToken renders the endpoint block for a SAGEOX_TOKEN that is
+// set for this endpoint but failed the local format check.
+//
+// No identity is rendered here, and that is the point. Falling back to the disk
+// login would silently re-attribute every API call, ledger write, and murmur to
+// whoever last ran `ox login` on this machine, while status showed a green check
+// — so the credential is refused, and the refusal is what gets printed.
+func renderMalformedEnvToken(envEP string, shadowsDiskLogin bool, authFile string) string {
+	var b strings.Builder
+
+	b.WriteString(statusLabelStyle.Render("Endpoint"))
+	b.WriteString(statusHighlightStyle.Render(endpoint.NormalizeSlug(envEP)))
+	b.WriteString(statusErrorStyle.Render(" (✗ not authenticated)"))
+	b.WriteString("\n")
+
+	b.WriteString(statusLabelStyle.Render("Credential"))
+	b.WriteString(statusErrorStyle.Render("SAGEOX_TOKEN (env) failed a local format check"))
+	b.WriteString("\n")
+	b.WriteString(statusMutedStyle.Render("  the value is a SageOx-family token whose checksum does not match —"))
+	b.WriteString("\n")
+	b.WriteString(statusMutedStyle.Render("  a truncated paste is the usual cause"))
+	b.WriteString("\n")
+
+	if auth.EnvTokenIsTeamFamily(envEP) {
+		b.WriteString(statusMutedStyle.Render("  this looks like a team token — re-copy it from your CI secret store;"))
+		b.WriteString("\n")
+		b.WriteString(statusMutedStyle.Render("  `ox login` mints personal oxp_ tokens and cannot replace it"))
+	} else {
+		b.WriteString(statusMutedStyle.Render("  re-copy the value into SAGEOX_TOKEN, or unset it to fall back to"))
+		b.WriteString("\n")
+		b.WriteString(statusMutedStyle.Render("  `ox login`"))
+	}
+	b.WriteString("\n")
+
+	if shadowsDiskLogin {
+		// Never name the stored identity here. The operator believes CI is
+		// acting as the credential they exported; printing the human it would
+		// otherwise fall back to is one glance away from being read as the
+		// active principal — which is the substitution this block exists to
+		// refuse. The path is enough to find it.
+		b.WriteString(statusLabelStyle.Render("Disk login"))
+		b.WriteString(statusMutedStyle.Render("present but NOT being used — ox will not authenticate"))
+		b.WriteString("\n")
+		b.WriteString(statusMutedStyle.Render("  as a principal other than the one you named"))
+		b.WriteString("\n")
+		b.WriteString(statusMutedStyle.Render("  (" + authFile + ")"))
+		b.WriteString("\n")
 	}
 
 	return b.String()

--- a/cmd/ox/status.go
+++ b/cmd/ox/status.go
@@ -1870,13 +1870,15 @@ func renderAuthStatus(authFile string) string {
 		// the old lie (a working PAT reported as not-logged-in) with the more
 		// dangerous opposite — CI that reports healthy auth right up until the
 		// first real call 401s. So: validate this one, once, before claiming
-		// anything. ValidateTokenServerSide already routes an oxp_ token to
-		// /api/v1/auth/me (PATs carry no OAuth identity, so userinfo 401s them)
-		// and caps itself at 5s.
+		// anything. Introspect calls the single family-agnostic endpoint
+		// (session/JWT, personal oxp_, team oxt_ all validate the same way)
+		// and caps itself at 5s; its parsed result also tells us WHO the
+		// token authenticates as, which the identity rendering below needs.
 		envValid := true
 		var envValidErr error
+		var introspectResult *auth.IntrospectResult
 		if envSourced && epToken != nil {
-			envValidErr = auth.ValidateTokenServerSide(ep, epToken.AccessToken)
+			introspectResult, envValidErr = auth.Introspect(ep, epToken.AccessToken)
 			envValid = envValidErr == nil
 		}
 
@@ -1897,20 +1899,48 @@ func renderAuthStatus(authFile string) string {
 			b.WriteString(statusErrorStyle.Render("SAGEOX_TOKEN (env) rejected"))
 			b.WriteString(statusMutedStyle.Render(" — " + envValidErr.Error()))
 			b.WriteString("\n")
-			b.WriteString(statusMutedStyle.Render("  the value in SAGEOX_TOKEN is not a credential this endpoint accepts;"))
-			b.WriteString("\n")
-			b.WriteString(statusMutedStyle.Render("  mint a fresh PAT at /settings/tokens, or unset it to use ox login"))
+			// A rejected team token (oxt_) isn't a "your PAT expired"
+			// situation — `ox login` only ever mints a personal oxp_ token,
+			// and "/settings/tokens" is the PAT UI, so both defaults below
+			// send the user down the wrong path. Family-aware guidance per
+			// .context/token-hardening-contract.md §7.
+			if strings.HasPrefix(epToken.AccessToken, auth.TeamTokenPrefix) {
+				b.WriteString(statusMutedStyle.Render("  this looks like a team token — set SAGEOX_TOKEN for CI/API use;"))
+				b.WriteString("\n")
+				b.WriteString(statusMutedStyle.Render("  `ox login` expects a personal oxp_ token"))
+			} else {
+				b.WriteString(statusMutedStyle.Render("  the value in SAGEOX_TOKEN is not a credential this endpoint accepts;"))
+				b.WriteString("\n")
+				b.WriteString(statusMutedStyle.Render("  mint a fresh PAT at /settings/tokens, or unset it to use ox login"))
+			}
 			b.WriteString("\n")
 			continue
 		}
 
 		if epToken != nil {
-			if envSourced && epToken.UserInfo.Name == "" && epToken.UserInfo.Email == "" {
+			switch {
+			case envSourced && introspectResult != nil && introspectResult.PrincipalKind == "team-service":
+				// A team token acts AS THE TEAM, not a person — introspection
+				// is the only source for "which team" (there was no login
+				// step to learn it from). Render it explicitly instead of
+				// falling into the blank-identity branch below, which reads
+				// as broken rather than team-scoped.
+				teamID := "(unknown team)"
+				if introspectResult.Team != nil && introspectResult.Team.TeamID != "" {
+					teamID = introspectResult.Team.TeamID
+				}
+				b.WriteString(statusLabelStyle.Render("Acting as"))
+				b.WriteString(statusHighlightStyle.Render("team " + teamID))
+				if introspectResult.Token != nil && introspectResult.Token.Name != "" {
+					b.WriteString(statusMutedStyle.Render(" (" + introspectResult.Token.Name + ")"))
+				}
+				b.WriteString("\n")
+			case envSourced && epToken.UserInfo.Name == "" && epToken.UserInfo.Email == "":
 				b.WriteString(statusLabelStyle.Render("Credential"))
 				b.WriteString(statusHighlightStyle.Render("SAGEOX_TOKEN (env)"))
 				b.WriteString(statusMutedStyle.Render(" — identity resolved server-side per request"))
 				b.WriteString("\n")
-			} else {
+			default:
 				b.WriteString(statusLabelStyle.Render("User"))
 				b.WriteString(statusHighlightStyle.Render(epToken.UserInfo.Name))
 				b.WriteString(statusMutedStyle.Render(" <" + epToken.UserInfo.Email + ">"))

--- a/cmd/ox/status_test.go
+++ b/cmd/ox/status_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +16,7 @@ import (
 	"github.com/sageox/ox/internal/api"
 	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -785,11 +788,287 @@ func TestFormatDurationShort(t *testing.T) {
 	}
 }
 
-// --- renderAuthStatus: principal-kind-aware identity (token-hardening-contract.md §7) ---
+// --- renderAuthStatus: principal-kind-aware identity ---
 //
 // These use t.Setenv, which is incompatible with t.Parallel — auth-env
 // resolution is process-global (SAGEOX_TOKEN, XDG_CONFIG_HOME), matching the
 // serial pattern internal/auth's own env-token tests use.
+
+// Pinned token vectors. These are real, correctly-checksummed values for the
+// "valid" pair (so they clear the local format check and reach the mock
+// introspection server) and single-character corruptions for the "malformed"
+// pair (so they fail it). See internal/auth/env_token_test.go for the vectors'
+// own coverage.
+const (
+	validTeamToken       = "oxt_test_1ljPfr"
+	validPersonalToken   = "oxp_test_4bDZfN"
+	malformedTeamToken   = "oxt_test_1ljPfX"
+	malformedPersonalPAT = "oxp_test_4bDZfX"
+)
+
+// setupAuthRenderEnv isolates renderAuthStatus from every process-global input
+// it reads: the endpoint, SAGEOX_TOKEN, and the auth.json location.
+//
+// OX_GIT_CREDENTIALS_FILE is the load-bearing one: without it the Git PAT
+// section reaches gitserver.LoadCredentialsForEndpoint, which probes the
+// developer's real OS keychain. That makes a pure render test depend on the
+// host's login keychain state (and, on a locked machine, on a UI prompt).
+func setupAuthRenderEnv(t *testing.T, endpointURL, envToken string) {
+	t.Helper()
+	t.Setenv("SAGEOX_ENDPOINT", endpointURL)
+	t.Setenv("SAGEOX_TOKEN", envToken)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("OX_XDG_DISABLE", "")
+	t.Setenv("OX_GIT_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "creds.json"))
+}
+
+// writeDiskLogin plants a live auth.json login for ep, with a distinctive
+// identity, so a test can prove whether that identity leaks into output.
+func writeDiskLogin(t *testing.T, ep, name, email string) {
+	t.Helper()
+	authPath, err := auth.GetAuthFilePath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(authPath), 0o700))
+
+	store := auth.AuthStore{Tokens: map[string]*auth.StoredToken{
+		endpoint.NormalizeEndpoint(ep): {
+			AccessToken:  "disk-access-token",
+			RefreshToken: "disk-refresh-token",
+			ExpiresAt:    time.Now().Add(24 * time.Hour),
+			TokenType:    "Bearer",
+			UserInfo:     auth.UserInfo{UserID: "u_disk", Name: name, Email: email},
+		},
+	}}
+	blob, err := json.Marshal(store)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(authPath, blob, 0o600))
+}
+
+// countEndpointBlocks counts rendered "Endpoint" rows. Asserting on it keeps a
+// test-isolation leak (a stray auth.json or a shared endpoint) from silently
+// satisfying a Contains() assertion via somebody else's block.
+func countEndpointBlocks(out string) int {
+	return strings.Count(out, "Endpoint")
+}
+
+// TestRenderAuthStatus_MalformedEnvTokenIsReported: with SAGEOX_TOKEN set to a
+// value that fails the local format check and no auth.json behind it, the
+// endpoint holds no usable credential and so vanishes from
+// auth.GetLoggedInEndpoints() entirely. Status then rendered a bare
+// "✗ not logged in" and advised `ox login` — the one diagnosis that never
+// mentions the credential the operator actually supplied, given to the CI
+// operator who is the entire audience for SAGEOX_TOKEN and cannot run a
+// browser login anyway.
+func TestRenderAuthStatus_MalformedEnvTokenIsReported(t *testing.T) {
+	setupAuthRenderEnv(t, "http://127.0.0.1:1", malformedTeamToken)
+
+	out := renderAuthStatus("/tmp/auth.json")
+
+	if !strings.Contains(out, auth.EnvVarToken) {
+		t.Errorf("output must name %s so the operator knows which credential was refused, got:\n%s", auth.EnvVarToken, out)
+	}
+	if !strings.Contains(out, "local format check") {
+		t.Errorf("output must say the value failed a local format check, got:\n%s", out)
+	}
+	if strings.Contains(out, "not logged in") {
+		t.Errorf("a refused env token must not render as a bare \"not logged in\", got:\n%s", out)
+	}
+	// Family-aware: a truncated team token and a truncated PAT want different
+	// next steps, and `ox login` cannot mint the former at all.
+	if !strings.Contains(out, "team token") {
+		t.Errorf("expected team-family guidance for an oxt_ value, got:\n%s", out)
+	}
+	if got := countEndpointBlocks(out); got != 1 {
+		t.Errorf("expected exactly 1 Endpoint block, got %d:\n%s", got, out)
+	}
+}
+
+// TestRenderAuthStatus_MalformedEnvTokenMustNotSilentlyFallBackToDiskIdentity
+// is the security test. With a malformed SAGEOX_TOKEN AND a live disk login for
+// the same endpoint, status used to render "(✓ logged in)" and the human's
+// name — while the operator believed CI was acting as a service account. Every
+// API call, ledger write, and murmur would be attributed to that human.
+func TestRenderAuthStatus_MalformedEnvTokenMustNotSilentlyFallBackToDiskIdentity(t *testing.T) {
+	const ep = "http://127.0.0.1:1"
+	const diskName = "Disk Login Human"
+	const diskEmail = "disk-login-human@example.test"
+
+	setupAuthRenderEnv(t, ep, malformedTeamToken)
+	writeDiskLogin(t, ep, diskName, diskEmail)
+
+	out := renderAuthStatus("/tmp/auth.json")
+
+	mentionsEnvRefusal := strings.Contains(out, auth.EnvVarToken) &&
+		(strings.Contains(out, "NOT being used") || strings.Contains(out, "local format check"))
+
+	if strings.Contains(out, diskName) || strings.Contains(out, diskEmail) {
+		if !mentionsEnvRefusal {
+			t.Fatalf("SECURITY: status presented the stored disk identity %q <%s> as the active credential while %s was set and unusable — "+
+				"every API call, ledger write, and murmur would be attributed to that person instead of the principal the operator named. Output:\n%s",
+				diskName, diskEmail, auth.EnvVarToken, out)
+		}
+	}
+	if !mentionsEnvRefusal {
+		t.Fatalf("output must say %s was set and is not being used, got:\n%s", auth.EnvVarToken, out)
+	}
+	if strings.Contains(out, "✓ logged in") {
+		t.Fatalf("a refused env token must not produce a positive endpoint verdict, got:\n%s", out)
+	}
+	if got := countEndpointBlocks(out); got != 1 {
+		t.Fatalf("expected exactly 1 Endpoint block, got %d:\n%s", got, out)
+	}
+}
+
+// TestRenderAuthStatus_UnreachableServerIsNotReportedAsRejected: a developer
+// offline (or behind a VPN that is down) with a perfectly good token was told
+// "(✗ not authenticated)", "SAGEOX_TOKEN (env) rejected", and to "mint a fresh
+// PAT". The server never answered, so "rejected" is a false claim about a
+// credential nobody judged, and the advice costs a needless rotation.
+func TestRenderAuthStatus_UnreachableServerIsNotReportedAsRejected(t *testing.T) {
+	// Bind a real port, then close it, so the address is well-formed and
+	// nothing is listening — a connection refusal, not a DNS failure.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	setupAuthRenderEnv(t, url, validTeamToken)
+
+	out := renderAuthStatus("/tmp/auth.json")
+
+	if strings.Contains(out, "rejected") {
+		t.Errorf("an unreachable endpoint must not be reported as a rejection, got:\n%s", out)
+	}
+	if strings.Contains(out, "mint a fresh PAT") {
+		t.Errorf("an unreachable endpoint must not advise a credential rotation, got:\n%s", out)
+	}
+	if strings.Contains(out, "✗ not authenticated") {
+		t.Errorf("an unreachable endpoint must not render a negative auth verdict, got:\n%s", out)
+	}
+	if strings.Contains(out, "✓ logged in") {
+		t.Errorf("an unverified credential must not render a positive auth verdict either, got:\n%s", out)
+	}
+	if !strings.Contains(out, "could not verify") {
+		t.Errorf("expected a \"could not verify\" state, got:\n%s", out)
+	}
+	if got := countEndpointBlocks(out); got != 1 {
+		t.Errorf("expected exactly 1 Endpoint block, got %d:\n%s", got, out)
+	}
+}
+
+// TestRenderAuthStatus_EnvUserTokenShowsIntrospectedIdentity: an env-sourced
+// token carries a zero UserInfo (there was no login to learn a name from), so
+// a principal_kind:"user" response carrying a real name and email still
+// rendered the generic "identity resolved server-side per request". Knowing WHO
+// a credential authenticates as is the stated reason status calls the
+// introspection endpoint rather than a bare liveness check.
+func TestRenderAuthStatus_EnvUserTokenShowsIntrospectedIdentity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != auth.IntrospectEndpoint {
+			t.Errorf("unexpected path %q, want %q", r.URL.Path, auth.IntrospectEndpoint)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"principal_kind": "user",
+			"scope": "full-access",
+			"token_type": "Bearer",
+			"expires_at": null,
+			"user": {"id": "u_1", "email": "introspected@example.test", "name": "Introspected Person", "tier": "pro"},
+			"team": null,
+			"token": null
+		}`))
+	}))
+	defer srv.Close()
+
+	setupAuthRenderEnv(t, srv.URL, validPersonalToken)
+
+	out := renderAuthStatus("/tmp/auth.json")
+
+	if !strings.Contains(out, "Introspected Person") {
+		t.Errorf("expected the introspected name in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "introspected@example.test") {
+		t.Errorf("expected the introspected email in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "identity resolved server-side per request") {
+		t.Errorf("a user-principal response with a real identity must not fall into the generic blank-identity branch:\n%s", out)
+	}
+	if got := countEndpointBlocks(out); got != 1 {
+		t.Errorf("expected exactly 1 Endpoint block, got %d:\n%s", got, out)
+	}
+}
+
+// TestRenderAuthStatus_TeamServiceWithoutTeamID: a team-service response whose
+// team object is null must still render a stable, non-empty "Acting as" line
+// and must still name the token, because the token name is the only handle an
+// operator has for finding this credential in a secret store.
+func TestRenderAuthStatus_TeamServiceWithoutTeamID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"principal_kind": "team-service",
+			"token_type": "Bearer",
+			"expires_at": null,
+			"user": null,
+			"team": null,
+			"token": {"prefix": "oxt_ab12", "name": "nightly-indexer"}
+		}`))
+	}))
+	defer srv.Close()
+
+	setupAuthRenderEnv(t, srv.URL, validTeamToken)
+
+	out := renderAuthStatus("/tmp/auth.json")
+
+	if !strings.Contains(out, "(unknown team)") {
+		t.Errorf("expected the stable (unknown team) fallback, got:\n%s", out)
+	}
+	if !strings.Contains(out, "nightly-indexer") {
+		t.Errorf("expected the token name so the operator can identify the credential, got:\n%s", out)
+	}
+	if strings.Contains(out, "identity resolved server-side per request") {
+		t.Errorf("a team-service response must not fall into the generic blank-identity branch:\n%s", out)
+	}
+}
+
+// TestRenderAuthStatus_UnknownPrincipalKindKeepsTeamID: the server contract can
+// grow a principal kind this binary predates, and an older ox must degrade
+// honestly. Two failure modes to avoid: inventing a user identity we were never
+// given, and silently dropping a team_id the server DID send — which would make
+// status tell the operator strictly less than the response contained.
+func TestRenderAuthStatus_UnknownPrincipalKindKeepsTeamID(t *testing.T) {
+	for _, kind := range []string{"team_service", "", "service"} {
+		t.Run("kind="+kind, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"active": true,
+					"principal_kind": "` + kind + `",
+					"token_type": "Bearer",
+					"expires_at": null,
+					"user": null,
+					"team": {"team_id": "team_future42"},
+					"token": {"prefix": "oxt_ab12", "name": "future-kind"}
+				}`))
+			}))
+			defer srv.Close()
+
+			setupAuthRenderEnv(t, srv.URL, validTeamToken)
+
+			out := renderAuthStatus("/tmp/auth.json")
+
+			if !strings.Contains(out, "team_future42") {
+				t.Errorf("a present team_id must never be silently dropped, got:\n%s", out)
+			}
+			if strings.Contains(out, "User") {
+				t.Errorf("an unrecognized principal kind must not claim a user identity, got:\n%s", out)
+			}
+		})
+	}
+}
 
 // TestRenderAuthStatus_TeamTokenActingAs is the red-first proof for the
 // "acting as team <team_id>" rendering: before this change, an env-sourced
@@ -819,13 +1098,9 @@ func TestRenderAuthStatus_TeamTokenActingAs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("SAGEOX_ENDPOINT", srv.URL)
-	// oxt_test_1ljPfr is the pinned team-token golden vector (contract §7) —
-	// a real, validly-checksummed value, so it clears env_token.go's CRC
-	// precheck and reaches the mock introspection server above.
-	t.Setenv("SAGEOX_TOKEN", "oxt_test_1ljPfr")
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	t.Setenv("OX_XDG_DISABLE", "")
+	// validTeamToken is a real, correctly-checksummed value, so it clears the
+	// local format check and reaches the mock introspection server above.
+	setupAuthRenderEnv(t, srv.URL, validTeamToken)
 
 	out := renderAuthStatus("/tmp/auth.json")
 
@@ -841,33 +1116,307 @@ func TestRenderAuthStatus_TeamTokenActingAs(t *testing.T) {
 	if strings.Contains(out, "identity resolved server-side per request") {
 		t.Errorf("team token fell into the generic blank-identity branch instead of the team-specific one:\n%s", out)
 	}
+	// The verdict line is what a human and the BDD status parser read to
+	// decide whether the CLI is usable; without this the test passes under a
+	// mutation that flips it.
+	if !strings.Contains(out, "✓ logged in") {
+		t.Errorf("an accepted token must render a positive endpoint verdict, got:\n%s", out)
+	}
+	if strings.Contains(out, "✗ not authenticated") {
+		t.Errorf("an accepted token must not render a negative endpoint verdict, got:\n%s", out)
+	}
+	if got := countEndpointBlocks(out); got != 1 {
+		t.Errorf("expected exactly 1 Endpoint block, got %d:\n%s", got, out)
+	}
 }
 
-// TestRenderAuthStatus_RejectedTeamTokenGetsFamilyAwareHint proves a rejected
-// oxt_-shaped SAGEOX_TOKEN gets team-specific guidance ("set SAGEOX_TOKEN for
-// CI/API use; `ox login` expects a personal oxp_ token") instead of the
-// generic "mint a fresh PAT" hint, which sends a team-token holder toward the
-// wrong UI entirely.
-func TestRenderAuthStatus_RejectedTeamTokenGetsFamilyAwareHint(t *testing.T) {
+// TestRenderAuthStatus_RejectedTokenGetsFamilyAwareHint proves the rejected-
+// credential hint is chosen by token FAMILY, in both directions. The single-row
+// version of this test passed under an inverted HasPrefix condition, because
+// only the oxt_ arm was ever exercised — an inversion just swapped which of the
+// two arms was wrong, and no assertion looked at the other one.
+//
+// The two remedies are not interchangeable: `ox login` only ever mints a
+// personal oxp_ token, and the PAT settings page cannot issue a team credential
+// either, so pointing a team-token holder at them ends nowhere.
+func TestRenderAuthStatus_RejectedTokenGetsFamilyAwareHint(t *testing.T) {
+	tests := []struct {
+		name       string
+		envToken   string
+		wantPhrase string
+		denyPhrase string
+	}{
+		{
+			name:       "team token gets CI-secret-store guidance",
+			envToken:   validTeamToken,
+			wantPhrase: "this looks like a team token",
+			denyPhrase: "mint a fresh PAT",
+		},
+		{
+			name:       "personal token gets PAT guidance",
+			envToken:   validPersonalToken,
+			wantPhrase: "mint a fresh PAT",
+			denyPhrase: "this looks like a team token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			defer srv.Close()
+
+			setupAuthRenderEnv(t, srv.URL, tt.envToken)
+
+			out := renderAuthStatus("/tmp/auth.json")
+
+			if !strings.Contains(out, tt.wantPhrase) {
+				t.Errorf("expected %q in the hint, got:\n%s", tt.wantPhrase, out)
+			}
+			if strings.Contains(out, tt.denyPhrase) {
+				t.Errorf("must not get the other family's hint (%q), got:\n%s", tt.denyPhrase, out)
+			}
+			if !strings.Contains(out, "ox login") {
+				t.Errorf("expected the hint to mention `ox login`, got:\n%s", out)
+			}
+			// The verdict line, asserted in both directions: a mutation
+			// flipping it passed this test before.
+			if !strings.Contains(out, "✗ not authenticated") {
+				t.Errorf("a rejected token must render a negative endpoint verdict, got:\n%s", out)
+			}
+			if strings.Contains(out, "✓ logged in") {
+				t.Errorf("a rejected token must not render a positive endpoint verdict, got:\n%s", out)
+			}
+			if got := countEndpointBlocks(out); got != 1 {
+				t.Errorf("expected exactly 1 Endpoint block, got %d:\n%s", got, out)
+			}
+		})
+	}
+}
+
+// TestRenderAuthStatus_RejectedTeamTokenMustNotRecommendSettingTheVarAgain: we
+// are on this line BECAUSE SAGEOX_TOKEN is set, so "set SAGEOX_TOKEN for CI/API
+// use" is advice the operator already followed. A refused team token is rotated
+// in the CI secret store, which is the only place it can be replaced.
+func TestRenderAuthStatus_RejectedTeamTokenMustNotRecommendSettingTheVarAgain(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
 
-	t.Setenv("SAGEOX_ENDPOINT", srv.URL)
-	t.Setenv("SAGEOX_TOKEN", "oxt_test_1ljPfr")
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	t.Setenv("OX_XDG_DISABLE", "")
+	setupAuthRenderEnv(t, srv.URL, validTeamToken)
 
 	out := renderAuthStatus("/tmp/auth.json")
 
-	if !strings.Contains(out, "this looks like a team token") {
-		t.Errorf("expected family-aware team-token hint, got:\n%s", out)
+	if strings.Contains(out, "set SAGEOX_TOKEN for CI/API use") {
+		t.Errorf("hint tells the operator to do the thing they already did, got:\n%s", out)
 	}
-	if !strings.Contains(out, "ox login") {
-		t.Errorf("expected the hint to mention `ox login`, got:\n%s", out)
+	if !strings.Contains(out, "secret store") {
+		t.Errorf("expected the hint to point at the CI secret store, got:\n%s", out)
 	}
-	if strings.Contains(out, "mint a fresh PAT") {
-		t.Errorf("rejected team token must not get the personal-PAT hint:\n%s", out)
+}
+
+// --- renderIdentity: the identity matrix, without a server ---
+//
+// renderIdentity is pure, so every cell of (env-sourced) × (introspect result)
+// × (principal kind) × (team present) × (UserInfo populated) is reachable here
+// for the cost of a struct literal. The integration-shaped tests above stay as
+// proof that the wiring into renderAuthStatus is real.
+func TestRenderIdentity(t *testing.T) {
+	t.Parallel()
+
+	human := &auth.StoredToken{UserInfo: auth.UserInfo{Name: "Ada Lovelace", Email: "ada@example.test"}}
+	blank := &auth.StoredToken{}
+
+	tests := []struct {
+		name       string
+		envSourced bool
+		tok        *auth.StoredToken
+		ir         *auth.IntrospectResult
+		want       []string
+		deny       []string
+	}{
+		{
+			name: "disk login renders the stored identity",
+			tok:  human,
+			want: []string{"User", "Ada Lovelace", "ada@example.test"},
+		},
+		{
+			name:       "env token with no introspection falls back to the credential line",
+			envSourced: true,
+			tok:        blank,
+			want:       []string{"SAGEOX_TOKEN (env)", "identity resolved server-side per request"},
+		},
+		{
+			name:       "team-service renders the team and the token name",
+			envSourced: true,
+			tok:        blank,
+			ir: &auth.IntrospectResult{
+				PrincipalKind: auth.PrincipalKindTeamService,
+				Team:          &auth.IntrospectTeam{TeamID: "team_x"},
+				Token:         &auth.IntrospectTokenInfo{Name: "ci-deploy"},
+			},
+			want: []string{"Acting as", "team team_x", "ci-deploy"},
+			deny: []string{"identity resolved server-side per request"},
+		},
+		{
+			name:       "team-service with a null team keeps a stable fallback",
+			envSourced: true,
+			tok:        blank,
+			ir:         &auth.IntrospectResult{PrincipalKind: auth.PrincipalKindTeamService},
+			want:       []string{"Acting as", "(unknown team)"},
+		},
+		{
+			name:       "user principal renders the introspected identity",
+			envSourced: true,
+			tok:        blank,
+			ir: &auth.IntrospectResult{
+				PrincipalKind: auth.PrincipalKindUser,
+				User:          &auth.IntrospectUser{Name: "Grace Hopper", Email: "grace@example.test"},
+			},
+			want: []string{"User", "Grace Hopper", "grace@example.test"},
+			deny: []string{"identity resolved server-side per request"},
+		},
+		{
+			name:       "user principal with only an email still names somebody",
+			envSourced: true,
+			tok:        blank,
+			ir: &auth.IntrospectResult{
+				PrincipalKind: auth.PrincipalKindUser,
+				User:          &auth.IntrospectUser{Email: "only-email@example.test"},
+			},
+			want: []string{"User", "only-email@example.test"},
+			deny: []string{"<>"},
+		},
+		{
+			name:       "user principal with a blank user object degrades to the credential line",
+			envSourced: true,
+			tok:        blank,
+			ir:         &auth.IntrospectResult{PrincipalKind: auth.PrincipalKindUser, User: &auth.IntrospectUser{}},
+			want:       []string{"identity resolved server-side per request"},
+		},
+		{
+			name:       "unrecognized principal kind keeps a present team_id",
+			envSourced: true,
+			tok:        blank,
+			ir: &auth.IntrospectResult{
+				PrincipalKind: "team_service",
+				Team:          &auth.IntrospectTeam{TeamID: "team_future"},
+			},
+			want: []string{"team_future"},
+			deny: []string{"User", "identity resolved server-side per request"},
+		},
+		{
+			name: "introspection is ignored for a disk-sourced token",
+			tok:  human,
+			ir:   &auth.IntrospectResult{PrincipalKind: auth.PrincipalKindTeamService, Team: &auth.IntrospectTeam{TeamID: "team_x"}},
+			want: []string{"Ada Lovelace"},
+			deny: []string{"Acting as"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := renderIdentity(tt.envSourced, tt.tok, tt.ir)
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("expected %q in %q", want, got)
+				}
+			}
+			for _, deny := range tt.deny {
+				if strings.Contains(got, deny) {
+					t.Errorf("did not expect %q in %q", deny, got)
+				}
+			}
+		})
+	}
+}
+
+// TestAuthFollowUpHint covers the hint that prints under the auth section. Two
+// arms give demonstrably wrong advice without this logic: an offline developer
+// with a good credential was told "token refresh failed: run `ox login` to
+// re-authenticate" (a credential rotation prescribed for a network fault), and
+// a CI operator with a truncated SAGEOX_TOKEN was pointed at `ox login`, which
+// cannot mint their credential and which they cannot run.
+func TestAuthFollowUpHint(t *testing.T) {
+	t.Parallel()
+
+	unreachable := fmt.Errorf("could not reach host to validate token: %w: %w",
+		errors.New("dial tcp: connection refused"), auth.ErrEndpointUnreachable)
+
+	tests := []struct {
+		name          string
+		envMalformed  bool
+		authErr       error
+		loggedInCount int
+		want          authHint
+	}{
+		{"healthy login", false, nil, 1, authHintNone},
+		{"no credential at all", false, nil, 0, authHintLogin},
+		{"server rejected the token", false, errors.New("server rejected token (HTTP 401)"), 1, authHintRefreshFailed},
+		{"endpoint unreachable is not a rejection", false, unreachable, 1, authHintUnreachable},
+		{"unreachable with nothing logged in is still unreachable", false, unreachable, 0, authHintUnreachable},
+		{"malformed env token suppresses the login advice", true, nil, 0, authHintNone},
+		{"malformed env token wins over a reported error", true, errors.New("boom"), 0, authHintNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := authFollowUpHint(tt.envMalformed, tt.authErr, tt.loggedInCount); got != tt.want {
+				t.Errorf("authFollowUpHint(%v, %v, %d) = %v, want %v",
+					tt.envMalformed, tt.authErr, tt.loggedInCount, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- doctor: `ox login` is the wrong remedy for a refused SAGEOX_TOKEN ---
+//
+// These live here rather than beside checkAuthentication because this file owns
+// the malformed-env-token behavior under test.
+
+// TestDoctorAuth_MalformedEnvTokenIsNotReportedAsNotLoggedIn: with a truncated
+// SAGEOX_TOKEN, doctor rendered "NOT LOGGED IN → Run `ox login`". For a team
+// token that remedy is not merely useless — `ox login` mints a personal oxp_
+// credential, so following it silently changes which principal the CLI acts as,
+// which is the failure mode doctor exists to catch.
+//
+// Once the credential resolver began surfacing the refusal as an error, the
+// symptom moved rather than disappearing: doctor then reported a generic
+// "check failed" with the raw wrapped error pasted in, and still offered no
+// family-aware remedy. Both shapes are asserted against.
+func TestDoctorAuth_MalformedEnvTokenIsNotReportedAsNotLoggedIn(t *testing.T) {
+	tests := []struct {
+		name       string
+		envToken   string
+		wantPhrase string
+	}{
+		{"team token", malformedTeamToken, "CI secret store"},
+		{"personal token", malformedPersonalPAT, "unset " + auth.EnvVarToken},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupAuthRenderEnv(t, "http://127.0.0.1:1", tt.envToken)
+
+			res := checkAuthentication()
+
+			if strings.Contains(res.message, "NOT LOGGED IN") {
+				t.Fatalf("a refused %s must not be reported as an ordinary absence, got message=%q detail=%q",
+					auth.EnvVarToken, res.message, res.detail)
+			}
+			if !strings.Contains(res.message, auth.EnvVarToken) {
+				t.Errorf("message must name %s, got %q", auth.EnvVarToken, res.message)
+			}
+			if !strings.Contains(res.detail, tt.wantPhrase) {
+				t.Errorf("expected family-aware remedy containing %q, got %q", tt.wantPhrase, res.detail)
+			}
+			if res.passed {
+				t.Errorf("a refused credential must not pass the check: %+v", res)
+			}
+		})
 	}
 }

--- a/cmd/ox/status_test.go
+++ b/cmd/ox/status_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -779,5 +782,92 @@ func TestFormatDurationShort(t *testing.T) {
 			got := status.FormatDurationShort(tt.duration)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// --- renderAuthStatus: principal-kind-aware identity (token-hardening-contract.md §7) ---
+//
+// These use t.Setenv, which is incompatible with t.Parallel — auth-env
+// resolution is process-global (SAGEOX_TOKEN, XDG_CONFIG_HOME), matching the
+// serial pattern internal/auth's own env-token tests use.
+
+// TestRenderAuthStatus_TeamTokenActingAs is the red-first proof for the
+// "acting as team <team_id>" rendering: before this change, an env-sourced
+// team token fell into the generic "SAGEOX_TOKEN (env) — identity resolved
+// server-side per request" branch (same as any personal PAT), which never
+// told the user WHICH team the CLI was acting as. Reverting the switch in
+// renderAuthStatus back to the old if/else on epToken.UserInfo reproduces
+// that failure — this test would then fail on the "team_abc123" assertion.
+func TestRenderAuthStatus_TeamTokenActingAs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != auth.IntrospectEndpoint {
+			t.Errorf("unexpected path %q, want %q", r.URL.Path, auth.IntrospectEndpoint)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"principal_kind": "team-service",
+			"scope": "read-only",
+			"token_type": "Bearer",
+			"expires_at": null,
+			"user": null,
+			"team": {"team_id": "team_abc123"},
+			"token": {"prefix": "oxt_ab12", "name": "ci-deploy"}
+		}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("SAGEOX_ENDPOINT", srv.URL)
+	// oxt_test_1ljPfr is the pinned team-token golden vector (contract §7) —
+	// a real, validly-checksummed value, so it clears env_token.go's CRC
+	// precheck and reaches the mock introspection server above.
+	t.Setenv("SAGEOX_TOKEN", "oxt_test_1ljPfr")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("OX_XDG_DISABLE", "")
+
+	out := renderAuthStatus("/tmp/auth.json")
+
+	if !strings.Contains(out, "Acting as") {
+		t.Errorf("expected an \"Acting as\" line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "team_abc123") {
+		t.Errorf("expected the introspected team_id in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ci-deploy") {
+		t.Errorf("expected the introspected token name in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "identity resolved server-side per request") {
+		t.Errorf("team token fell into the generic blank-identity branch instead of the team-specific one:\n%s", out)
+	}
+}
+
+// TestRenderAuthStatus_RejectedTeamTokenGetsFamilyAwareHint proves a rejected
+// oxt_-shaped SAGEOX_TOKEN gets team-specific guidance ("set SAGEOX_TOKEN for
+// CI/API use; `ox login` expects a personal oxp_ token") instead of the
+// generic "mint a fresh PAT" hint, which sends a team-token holder toward the
+// wrong UI entirely.
+func TestRenderAuthStatus_RejectedTeamTokenGetsFamilyAwareHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	t.Setenv("SAGEOX_ENDPOINT", srv.URL)
+	t.Setenv("SAGEOX_TOKEN", "oxt_test_1ljPfr")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("OX_XDG_DISABLE", "")
+
+	out := renderAuthStatus("/tmp/auth.json")
+
+	if !strings.Contains(out, "this looks like a team token") {
+		t.Errorf("expected family-aware team-token hint, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ox login") {
+		t.Errorf("expected the hint to mention `ox login`, got:\n%s", out)
+	}
+	if strings.Contains(out, "mint a fresh PAT") {
+		t.Errorf("rejected team token must not get the personal-PAT hint:\n%s", out)
 	}
 }

--- a/internal/auth/constants.go
+++ b/internal/auth/constants.go
@@ -19,11 +19,27 @@ const (
 	RevokeEndpoint = "/oauth2/revoke"
 )
 
-// PATPrefix marks a SageOx Personal Access Token (oxp_<body>_<crc>). PATs carry
-// no OAuth identity, so they validate against AuthMeEndpoint, not UserInfoEndpoint.
+// PATPrefix marks a SageOx Personal Access Token (oxp_<body>_<crc>) — "acts as
+// me". Used for local format checks (CRC precheck, redaction, display) only —
+// never for server-side routing. Both PATs and team tokens validate through
+// the same IntrospectEndpoint below.
 const PATPrefix = "oxp_" //nolint:gosec // not a credential
 
-// AuthMeEndpoint introspects the caller's token (including PATs) and returns
-// {user, token_type}. It accepts `Authorization: Bearer oxp_…`, where
-// /oauth2/userinfo (OAuth/opaque tokens only) returns "Token not found".
-const AuthMeEndpoint = "/api/v1/auth/me" //nolint:gosec // not a credential
+// TeamTokenPrefix marks a SageOx Team Access Token (oxt_<body>_<crc>) — "acts
+// as the team". Same grammar as a PAT (CRC-checked body), same validation door
+// (IntrospectEndpoint) — the family only matters for local format checks and
+// identity display.
+const TeamTokenPrefix = "oxt_" //nolint:gosec // not a credential
+
+// IntrospectEndpoint is the single, family-agnostic endpoint that validates
+// ANY bearer credential — session/JWT, personal oxp_, or team oxt_ — and
+// reports what/who it authenticates as. This replaced a hand-rolled
+// oxp_-vs-/oauth2/userinfo branch: the CLI no longer needs to know a token's
+// family before validating it.
+//
+// The server's response shape is frozen and mirrored by IntrospectResult in
+// validate.go: an `active` flag, a `principal_kind` discriminator ("user" or
+// "team-service"), `scope`, `token_type`, `expires_at`, and — depending on the
+// principal — a `user`, `team`, or `token` object. Adding a field is
+// backward-compatible; changing the meaning of one is not.
+const IntrospectEndpoint = "/api/v1/auth/introspect" //nolint:gosec // not a credential

--- a/internal/auth/coverage_test.go
+++ b/internal/auth/coverage_test.go
@@ -120,6 +120,12 @@ func TestRequireAuth_AuthRequired_NotAuthenticated(t *testing.T) {
 	assert.Contains(t, err.Error(), "authentication required")
 }
 
+// TestRequireAuth_AuthRequired_ValidToken is the only positive-path test of the
+// auth gate: it proves RequireAuth ADMITS a coworker holding a credential the
+// server accepts. Every other RequireAuth test asserts a refusal, so without
+// this one a gate that refused everything — or returned an error
+// unconditionally — would leave the suite green while locking every user out of
+// init, doctor, and status.
 func TestRequireAuth_AuthRequired_ValidToken(t *testing.T) {
 	t.Setenv("FEATURE_AUTH", "true")
 	setupPackageLevelTest(t)

--- a/internal/auth/env_token.go
+++ b/internal/auth/env_token.go
@@ -1,7 +1,12 @@
 package auth
 
 import (
+	"encoding/binary"
+	"hash/crc32"
+	"log/slog"
+	"math/big"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sageox/ox/internal/endpoint"
@@ -60,22 +65,99 @@ func envTokenEndpoint() string {
 	return endpoint.Default
 }
 
-// tokenFromEnv returns a StoredToken populated from SAGEOX_TOKEN when the
-// requested endpoint matches envTokenEndpoint(). Returns nil when the env var
-// is unset, or when the request is for a different endpoint.
-func tokenFromEnv(ep string) *StoredToken {
-	val := os.Getenv(EnvVarToken)
-	if val == "" {
-		return nil
+// EnvTokenState describes what SAGEOX_TOKEN holds for a given endpoint.
+type EnvTokenState int
+
+const (
+	// EnvTokenAbsent: SAGEOX_TOKEN is unset, or is bound to a different endpoint.
+	EnvTokenAbsent EnvTokenState = iota
+	// EnvTokenValid: present, bound to this endpoint, and passes the local format check.
+	EnvTokenValid
+	// EnvTokenMalformed: present and bound to this endpoint, but it is a SageOx-family
+	// value (oxp_/oxt_) whose CRC suffix does not match. The operator declared an
+	// intent to use THIS credential; callers must fail closed rather than silently
+	// falling back to a different one.
+	EnvTokenMalformed
+)
+
+// normalizeEnvToken cleans an environment-supplied token value before any
+// classification runs.
+//
+// Env vars are a lossy transport for secrets. `export SAGEOX_TOKEN=$(cat secret)`,
+// Kubernetes secrets mounted from files, YAML block scalars, `docker --env-file`,
+// and most `.env` parsers all routinely deliver a trailing newline, a surrounding
+// pair of quotes, or an accidental `Bearer ` prefix copied out of an HTTP example.
+// Before normalization existed, tail corruption was reported to the user as
+// "likely a typo" and head corruption bypassed the format gate entirely and then
+// 401'd at the server with no hint that the value itself was the problem.
+//
+// This is a client-side ergonomic decision only. It does NOT touch the CRC
+// algorithm and does not weaken the format check: the cleaned value must still
+// pass the same checksum every server-minted token satisfies.
+func normalizeEnvToken(raw string) string {
+	val := strings.TrimSpace(raw)
+
+	// One layer of matched surrounding quotes only — a quote that appears on just
+	// one side is real corruption, not shell quoting, and must stay visible.
+	if len(val) >= 2 {
+		if q := val[0]; (q == '"' || q == '\'') && val[len(val)-1] == q {
+			val = strings.TrimSpace(val[1 : len(val)-1])
+		}
 	}
-	// Bind the env token to exactly one endpoint. A normalized-empty endpoint
-	// (e.g. malformed input like "api.") has no anchor to match against, so treat
-	// it as a non-match rather than handing out the "*"-scoped token to an
-	// unverifiable target.
+
+	const bearer = "Bearer "
+	if len(val) >= len(bearer) && strings.EqualFold(val[:len(bearer)], bearer) {
+		val = strings.TrimSpace(val[len(bearer):])
+	}
+
+	return val
+}
+
+// envTokenBoundValue returns the normalized SAGEOX_TOKEN value when it is bound to
+// ep, or "" when the var is unset, empty after normalization, or bound elsewhere.
+//
+// The env token is bound to exactly one endpoint. A normalized-empty endpoint
+// (e.g. malformed input like "api.") has no anchor to match against, so it is
+// treated as a non-match rather than handing out the "*"-scoped token to an
+// unverifiable target.
+func envTokenBoundValue(ep string) string {
+	val := normalizeEnvToken(os.Getenv(EnvVarToken))
+	if val == "" {
+		return ""
+	}
 	if requested := endpoint.NormalizeEndpoint(ep); requested == "" || requested != envTokenEndpoint() {
-		return nil
+		return ""
+	}
+	return val
+}
+
+// EnvTokenFor reports both the usable env token (nil unless EnvTokenValid) and why.
+//
+// Distinguishing malformed from absent is the point: an absent token means "fall
+// back to disk", while a malformed one means the operator named a specific
+// credential that we cannot use — silently authenticating as somebody else is the
+// wrong failure direction.
+func EnvTokenFor(ep string) (*StoredToken, EnvTokenState) {
+	val := envTokenBoundValue(ep)
+	if val == "" {
+		return nil, EnvTokenAbsent
+	}
+	// A SageOx-family token (oxp_/oxt_) carries a CRC suffix; a mismatch means
+	// a typo or a truncated copy/paste, and sending it to the server would
+	// only earn a generic 401 with no hint that the token itself is the
+	// problem. Catch it here instead. Opaque OAuth tokens and JWTs have no
+	// such grammar — the server is the only source of truth for those, so
+	// they skip this check entirely and fall through to normal validation.
+	if isSageOxTokenFormat(val) && !verifyTokenChecksum(val) {
+		slog.Warn("SAGEOX_TOKEN failed local checksum check — likely a typo or truncated copy/paste",
+			"prefix", redactedTokenPrefix(val),
+			"length", len(val),
+		)
+		return nil, EnvTokenMalformed
 	}
 	return &StoredToken{
+		// Store the NORMALIZED value so a clean credential goes on the wire —
+		// a trailing newline in an Authorization header is itself a protocol error.
 		AccessToken:  val,
 		RefreshToken: "",
 		SessionToken: "",
@@ -84,5 +166,103 @@ func tokenFromEnv(ep string) *StoredToken {
 		Scope:        "*",
 		// UserInfo is zero-valued — filled lazily on first server response that
 		// includes claims.
+	}, EnvTokenValid
+}
+
+// EnvTokenIsTeamFamily reports whether the raw SAGEOX_TOKEN value bound to ep carries
+// the team prefix. Used by status rendering to pick family-aware guidance WITHOUT
+// requiring a parsed StoredToken (a malformed token never produces one).
+func EnvTokenIsTeamFamily(ep string) bool {
+	return strings.HasPrefix(envTokenBoundValue(ep), TeamTokenPrefix)
+}
+
+// tokenFromEnv returns a StoredToken populated from SAGEOX_TOKEN when the
+// requested endpoint matches envTokenEndpoint(). Returns nil when the env var
+// is unset, when the request is for a different endpoint, or when the value
+// fails the local checksum precheck below.
+func tokenFromEnv(ep string) *StoredToken {
+	tok, _ := EnvTokenFor(ep)
+	return tok
+}
+
+// isSageOxTokenFormat reports whether tok carries one of our own bearer-token
+// prefixes (oxp_ personal, oxt_ team) — i.e. whether verifyTokenChecksum's CRC
+// grammar even applies to it.
+func isSageOxTokenFormat(tok string) bool {
+	return strings.HasPrefix(tok, PATPrefix) || strings.HasPrefix(tok, TeamTokenPrefix)
+}
+
+// redactedTokenPrefix returns a short, log-safe prefix of tok for diagnostic
+// messages — enough to recognize which credential was rejected (its family
+// and a few body characters) without printing the value that failed a
+// checksum we can no longer trust to be a complete secret anyway.
+func redactedTokenPrefix(tok string) string {
+	const showChars = 8
+	if len(tok) <= showChars {
+		return "[REDACTED]"
 	}
+	return tok[:showChars] + "…[REDACTED]"
+}
+
+// --- CRC format precheck ---
+//
+// base62Encode, crc32Base62, and verifyTokenChecksum are intended to reproduce
+// the server's token package: the same algorithm, alphabet, and big-endian
+// CRC-32 (IEEE 802.3) encoding, so a token minted server-side always checksums
+// correctly here. The golden vectors and length-class table in env_token_test.go
+// pin the behavior this side of the wire; see those tests for exactly how much
+// they do and do not prove about the server's side of it.
+//
+// This is a format-integrity check (typo/truncation detection) only, NEVER a
+// security control — never gate real access on it.
+
+const base62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// base62Encode treats b as a big-endian unsigned integer and emits base62 digits.
+//
+// Note the padding contract, which is the fragile part of this mirror: output is
+// VARIABLE length and is not left-padded, so a CRC below 62^5 encodes to fewer
+// than 6 characters and leading zero bytes are simply absorbed by the big-integer
+// conversion. The sole exception is an all-zero input, which returns len(b)
+// zeros. If the server instead pads to a fixed width, or preserves leading zero
+// bytes the way base58check does, this function rejects every token whose CRC is
+// below 62^5 — about 21% of the keyspace — as a "typo". TestBase62Encode_LengthClasses
+// makes that contract explicit across every length class.
+func base62Encode(b []byte) string {
+	n := new(big.Int).SetBytes(b)
+	if n.Sign() == 0 {
+		if len(b) == 0 {
+			return "0"
+		}
+		return strings.Repeat("0", len(b))
+	}
+	base := big.NewInt(62)
+	mod := new(big.Int)
+	buf := make([]byte, 0, len(b)*2)
+	for n.Sign() > 0 {
+		n.DivMod(n, base, mod)
+		buf = append(buf, base62Alphabet[mod.Int64()])
+	}
+	for i, j := 0, len(buf)-1; i < j; i, j = i+1, j-1 {
+		buf[i], buf[j] = buf[j], buf[i]
+	}
+	return string(buf)
+}
+
+// crc32Base62 is CRC-32 (IEEE 802.3) of the input, big-endian, base62-encoded.
+func crc32Base62(input string) string {
+	buf := make([]byte, 4)
+	binary.BigEndian.PutUint32(buf, crc32.ChecksumIEEE([]byte(input)))
+	return base62Encode(buf)
+}
+
+// verifyTokenChecksum reports whether tok's trailing "_<crc>" suffix matches
+// the CRC of everything before it.
+func verifyTokenChecksum(tok string) bool {
+	i := strings.LastIndex(tok, "_")
+	if i <= 0 || i == len(tok)-1 {
+		return false
+	}
+	withPrefix, crc := tok[:i], tok[i+1:]
+	return crc32Base62(withPrefix) == crc
 }

--- a/internal/auth/env_token.go
+++ b/internal/auth/env_token.go
@@ -65,6 +65,19 @@ func envTokenEndpoint() string {
 	return endpoint.Default
 }
 
+// EnvTokenEndpoint is the exported view of envTokenEndpoint, for display code that
+// must ask about SAGEOX_TOKEN's state before it has an endpoint to ask about.
+//
+// GetLoggedInEndpoints lists endpoints with a USABLE credential, so a malformed
+// SAGEOX_TOKEN contributes nothing to it — and with no disk login behind it, the
+// endpoint disappears from that list entirely. A renderer that infers env-token
+// state from the list would therefore report a truncated token as a plain "not
+// logged in", which is the diagnostic gap the local format check exists to close.
+// Ask EnvTokenFor(EnvTokenEndpoint()) directly instead.
+func EnvTokenEndpoint() string {
+	return envTokenEndpoint()
+}
+
 // EnvTokenState describes what SAGEOX_TOKEN holds for a given endpoint.
 type EnvTokenState int
 
@@ -150,8 +163,8 @@ func EnvTokenFor(ep string) (*StoredToken, EnvTokenState) {
 	// they skip this check entirely and fall through to normal validation.
 	if isSageOxTokenFormat(val) && !verifyTokenChecksum(val) {
 		slog.Warn("SAGEOX_TOKEN failed local checksum check — likely a typo or truncated copy/paste",
-			"prefix", redactedTokenPrefix(val),
-			"length", len(val),
+			"family", tokenFamily(val),
+			"length_class", tokenLengthClass(val),
 		)
 		return nil, EnvTokenMalformed
 	}
@@ -192,16 +205,45 @@ func isSageOxTokenFormat(tok string) bool {
 	return strings.HasPrefix(tok, PATPrefix) || strings.HasPrefix(tok, TeamTokenPrefix)
 }
 
-// redactedTokenPrefix returns a short, log-safe prefix of tok for diagnostic
-// messages — enough to recognize which credential was rejected (its family
-// and a few body characters) without printing the value that failed a
-// checksum we can no longer trust to be a complete secret anyway.
-func redactedTokenPrefix(tok string) string {
-	const showChars = 8
-	if len(tok) <= showChars {
-		return "[REDACTED]"
+// tokenFamily returns ONLY the family prefix of tok (oxp_/oxt_), never any of
+// its body.
+//
+// An earlier version of this diagnostic emitted eight characters — the prefix
+// plus four body characters. That was a mistake worth naming, because the
+// reasoning behind it was seductive: a value that failed its own checksum is
+// probably not a working credential, so why protect it? Because the most
+// common way to reach this branch is a TRUNCATED PASTE of a real one, and the
+// leading body characters of a truncated real token are leading body
+// characters of a real token. Paired with an exact byte length (see
+// tokenLengthClass) that is a materially narrowed search space, written to
+// stderr and retained by CI log storage indefinitely.
+//
+// The family alone is what the operator actually needs here: it tells them
+// whether to go re-copy a personal token or a team token, which is the only
+// decision this message drives.
+func tokenFamily(tok string) string {
+	switch {
+	case strings.HasPrefix(tok, PATPrefix):
+		return PATPrefix
+	case strings.HasPrefix(tok, TeamTokenPrefix):
+		return TeamTokenPrefix
+	default:
+		return "unknown"
 	}
-	return tok[:showChars] + "…[REDACTED]"
+}
+
+// tokenLengthClass buckets tok's length so the diagnostic can say "this looks
+// truncated" without publishing an exact byte count an attacker could use to
+// bound a brute force.
+func tokenLengthClass(tok string) string {
+	switch n := len(tok); {
+	case n <= 20:
+		return "short"
+	case n <= 80:
+		return "expected"
+	default:
+		return "long"
+	}
 }
 
 // --- CRC format precheck ---

--- a/internal/auth/env_token_test.go
+++ b/internal/auth/env_token_test.go
@@ -12,19 +12,39 @@ import (
 // (the runtime panics if both are used). Env-token resolution is inherently
 // process-global, so serial execution is the correct semantics.
 
+// validSageOxTestToken mints a syntactically valid oxp_/oxt_ test token (a
+// correct "_<crc>" suffix per verifyTokenChecksum) so tests that aren't
+// specifically about the checksum gate don't trip over it. It reproduces the
+// server's token shape without pulling in crypto/rand.
+//
+// It mints with crc32Base62 and its callers verify with verifyTokenChecksum, so
+// any mutation to base62Encode moves BOTH sides identically and every test using
+// this helper stays green. That is correct for a fixture — these tests are about
+// env-token resolution, not the CRC mirror — but it means none of them count as
+// coverage of the mirror itself. Only the pinned golden vectors and
+// TestBase62Encode_LengthClasses do that.
+func validSageOxTestToken(prefix, body string) string {
+	withPrefix := prefix + body
+	return withPrefix + "_" + crc32Base62(withPrefix)
+}
+
 // TestTokenFromEnv_SageOxTokenSet — Failure prevented: SAGEOX_TOKEN env doesn't produce a
 // usable StoredToken, breaking CI/CD and headless agents.
 func TestTokenFromEnv_SageOxTokenSet(t *testing.T) {
-	t.Setenv(EnvVarToken, "oxp_test")
+	// a pinned golden vector (also asserted directly in
+	// TestVerifyTokenChecksum_GoldenVectors) — using it here doubles as proof
+	// that a real, validly-checksummed PAT is accepted end-to-end.
+	const tok = "oxp_test_4bDZfN"
+	t.Setenv(EnvVarToken, tok)
 
-	tok := tokenFromEnv("https://api.sageox.ai/")
-	require.NotNil(t, tok)
-	assert.Equal(t, "oxp_test", tok.AccessToken)
-	assert.Equal(t, "Bearer", tok.TokenType)
-	assert.Equal(t, "*", tok.Scope)
-	assert.Empty(t, tok.RefreshToken)
-	assert.Empty(t, tok.SessionToken)
-	assert.True(t, tok.ExpiresAt.After(time.Now()), "env token expiry must be in the future")
+	got := tokenFromEnv("https://api.sageox.ai/")
+	require.NotNil(t, got)
+	assert.Equal(t, tok, got.AccessToken)
+	assert.Equal(t, "Bearer", got.TokenType)
+	assert.Equal(t, "*", got.Scope)
+	assert.Empty(t, got.RefreshToken)
+	assert.Empty(t, got.SessionToken)
+	assert.True(t, got.ExpiresAt.After(time.Now()), "env token expiry must be in the future")
 }
 
 // TestTokenFromEnv_LegacyOxTokenIgnored — Failure prevented: removed OX_TOKEN
@@ -59,12 +79,13 @@ func TestTokenFromEnv_MismatchedEndpointIgnored(t *testing.T) {
 // self-hosted users set SAGEOX_TOKEN but, without binding it to the selected
 // endpoint, either hit production implicitly or fan the token out everywhere.
 func TestTokenFromEnv_ExplicitEndpointSelection(t *testing.T) {
-	t.Setenv(EnvVarToken, "oxp_stage")
+	tok := validSageOxTestToken(PATPrefix, "stage")
+	t.Setenv(EnvVarToken, tok)
 	t.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
 
-	tok := tokenFromEnv("https://staging.sageox.ai/")
-	require.NotNil(t, tok)
-	assert.Equal(t, "oxp_stage", tok.AccessToken)
+	got := tokenFromEnv("https://staging.sageox.ai/")
+	require.NotNil(t, got)
+	assert.Equal(t, tok, got.AccessToken)
 	assert.Nil(t, tokenFromEnv("https://sageox.ai/"))
 }
 
@@ -133,7 +154,8 @@ func TestGetTokenForEndpoint_MismatchedEnvFallsBackToDisk(t *testing.T) {
 // GetTokenForEndpoint and AuthClient.GetTokenForEndpoint diverge on env-token
 // resolution, leading to inconsistent auth behavior across call sites.
 func TestPackageAndClientAgree(t *testing.T) {
-	t.Setenv(EnvVarToken, "oxp_agree")
+	tok := validSageOxTestToken(PATPrefix, "agree")
+	t.Setenv(EnvVarToken, tok)
 
 	ep := "https://api.sageox.ai/"
 
@@ -147,6 +169,292 @@ func TestPackageAndClientAgree(t *testing.T) {
 	require.NotNil(t, cliTok)
 
 	assert.Equal(t, pkgTok.AccessToken, cliTok.AccessToken)
+	assert.Equal(t, tok, pkgTok.AccessToken)
 	assert.Equal(t, pkgTok.Scope, cliTok.Scope)
 	assert.Equal(t, pkgTok.TokenType, cliTok.TokenType)
+}
+
+// --- CRC/format precheck ---
+
+// TestVerifyTokenChecksum_GoldenVectors pins known-good token strings. A
+// mismatch here means base62Encode/crc32Base62/verifyTokenChecksum in
+// env_token.go has drifted from the server's token package, and a legitimate
+// server-minted token would be rejected locally.
+func TestVerifyTokenChecksum_GoldenVectors(t *testing.T) {
+	assert.True(t, verifyTokenChecksum("oxt_test_1ljPfr"), "pinned team-token vector must verify")
+	assert.True(t, verifyTokenChecksum("oxp_test_4bDZfN"), "pinned personal-token vector must verify")
+
+	// The CRC covers the family prefix, so a personal token's suffix must NOT
+	// validate a team token: crc32Base62("oxt_test") is "1ljPfr", not "4bDZfN".
+	// Beyond stating that property, this guards a plausible future "leniency"
+	// edit that strips or normalizes the family prefix before hashing — which
+	// would let anyone turn an oxp_ value into a valid-looking oxt_ one by
+	// editing a single character.
+	assert.False(t, verifyTokenChecksum("oxt_test_4bDZfN"), "a personal token's crc must not validate a team token")
+}
+
+// TestVerifyTokenChecksum_CorruptedSuffixRejected proves the suffix comparison is
+// exact — not a length check, and not case-insensitive.
+//
+// Each row was checked against a deliberately weakened verifyTokenChecksum, and
+// the notes below record which weakening each row actually catches:
+func TestVerifyTokenChecksum_CorruptedSuffixRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		tok  string
+	}{
+		// Same length and same case pattern as the valid suffix, so only a
+		// content comparison rejects it. Catches a length-only comparison.
+		{"single character substituted", "oxp_test_4bDZfX"},
+		// The real-world shape: a copy/paste that dropped trailing characters.
+		// Caught by either a length or a content comparison — its value is
+		// covering the truncation case explicitly, and killing a comparison
+		// weakened to a prefix match.
+		{"suffix truncated", "oxp_test_4bDZf"},
+		// The ONLY row here that catches a case-insensitive comparison — the
+		// two rows above differ in content, so EqualFold still rejects them.
+		// base62 uses upper and lower case as distinct digits, so folding case
+		// would accept a token that was never minted.
+		{"suffix case flipped", "oxp_test_4bdzfn"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, verifyTokenChecksum(tt.tok), "corrupted crc suffix must not verify")
+		})
+	}
+}
+
+// TestBase62Encode_LengthClasses pins base62Encode's output across every length
+// class a 4-byte CRC can produce.
+//
+// Why this exists: base62Encode emits VARIABLE-length output with no
+// left-padding, except that an all-zero input returns len(b) zeros — so zero
+// encodes to "0000" while one encodes to "1". That is not a coherent padding
+// scheme, and the two pinned golden vectors cannot detect the problem because
+// both land in the maximal 6-character class and stay green under either padding
+// mutation. If the server pads to a fixed width, or preserves leading zero bytes
+// the way base58check does, then this client rejects every token whose CRC is
+// below 62^5 — about 21% of the keyspace — as a "typo".
+//
+// PROVENANCE — read before trusting this table. These six expected values were
+// computed locally, with an independent from-scratch CRC-32/IEEE + base62
+// implementation (Python zlib), NOT by reading the Go implementation back to
+// itself. That independence rules out transcription error, but it does not make
+// them authoritative: out of the box this table proves only that the two
+// implementations agree, i.e. self-consistency. Its real value is that it makes
+// the padding contract explicit at every length class, so a padding change can
+// no longer pass silently.
+//
+// A human must still confirm these six outputs against the server's own token
+// package before the "mirror" claim in env_token.go is trustworthy. If the server
+// disagrees on even one row, that is a live bug rejecting roughly 21% of validly
+// minted tokens, not a test that needs updating.
+func TestBase62Encode_LengthClasses(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"6 chars (pinned personal vector)", "oxp_test", "4bDZfN"},
+		{"6 chars (pinned team vector)", "oxt_test", "1ljPfr"},
+		{"5 chars", "oxp_a", "b6CVb"},
+		{"4 chars", "oxp_bk", "oGjm"},
+		{"3 chars", "oxp_tsa", "2hW"},
+		{"2 chars", "oxp_cngh", "o8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, crc32Base62(tt.input))
+		})
+	}
+
+	// The all-zero branch is asserted on base62Encode directly because it is
+	// effectively unreachable through crc32Base62 — an input whose CRC-32 is
+	// exactly zero occurs at a rate of 2^-32, so no realistic token exercises it.
+	// It is also the single inconsistency in the padding contract above.
+	assert.Equal(t, "0000", base62Encode([]byte{0, 0, 0, 0}), "all-zero input returns one '0' per input byte, unlike every other value")
+}
+
+// TestTokenFromEnv_BadChecksumRejectedLocally — Failure prevented: a typo'd
+// or truncated SAGEOX_TOKEN reaching the server and coming back as a
+// confusing generic 401, instead of failing locally with a clear reason.
+// This is the red-first proof for the CRC precheck: before it existed,
+// tokenFromEnv returned this malformed value as-is.
+func TestTokenFromEnv_BadChecksumRejectedLocally(t *testing.T) {
+	// oxp_ prefix (recognized family) but the crc suffix doesn't match —
+	// exactly the shape of a truncated copy/paste.
+	t.Setenv(EnvVarToken, "oxp_test_4bDZfX")
+
+	assert.Nil(t, tokenFromEnv("https://api.sageox.ai/"), "malformed checksum must be rejected locally, not sent to the server")
+}
+
+// TestTokenFromEnv_NonSageOxFormatBypassesChecksum — Failure prevented: the
+// checksum gate rejecting opaque OAuth tokens / JWTs / other non-SageOx
+// bearer credentials that were never minted with our CRC grammar in the
+// first place — those have no checksum to verify, so they must fall through
+// to server-side validation unchanged.
+func TestTokenFromEnv_NonSageOxFormatBypassesChecksum(t *testing.T) {
+	t.Setenv(EnvVarToken, "header.payload.signature")
+
+	got := tokenFromEnv("https://api.sageox.ai/")
+	require.NotNil(t, got)
+	assert.Equal(t, "header.payload.signature", got.AccessToken)
+}
+
+// TestTokenFromEnv_ValidTeamTokenAccepted proves an oxt_ token with a
+// correct checksum passes the precheck exactly like an oxp_ one.
+func TestTokenFromEnv_ValidTeamTokenAccepted(t *testing.T) {
+	tok := validSageOxTestToken(TeamTokenPrefix, "svc")
+	t.Setenv(EnvVarToken, tok)
+
+	got := tokenFromEnv("https://api.sageox.ai/")
+	require.NotNil(t, got)
+	assert.Equal(t, tok, got.AccessToken)
+}
+
+// --- env value normalization ---
+
+// TestTokenFromEnv_SurroundingWhitespaceTolerated — Failure prevented: a token
+// delivered with a trailing newline (the default from `export
+// SAGEOX_TOKEN=$(cat secret)`, a file-mounted Kubernetes secret, or a YAML block
+// scalar) fails the CRC check and gets reported to the user as "likely a typo",
+// sending them to hunt for a corruption that does not exist.
+//
+// The trimmed value must also be what lands in AccessToken, so a clean
+// Authorization header goes on the wire — a bare newline inside a header value is
+// itself a protocol error.
+func TestTokenFromEnv_SurroundingWhitespaceTolerated(t *testing.T) {
+	const clean = "oxp_test_4bDZfN"
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"trailing newline", clean + "\n"},
+		{"trailing space", clean + " "},
+		{"leading tab and crlf", "\t" + clean + "\r\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnvVarToken, tt.raw)
+
+			got := tokenFromEnv("https://api.sageox.ai/")
+			require.NotNil(t, got, "whitespace-padded token must not be rejected as malformed")
+			assert.Equal(t, clean, got.AccessToken, "the trimmed value must go on the wire")
+		})
+	}
+}
+
+// TestTokenFromEnv_LeadingCorruptionNotSilentlyAccepted — Failure prevented:
+// corruption at the HEAD of the value slips past the format gate entirely. Because
+// isSageOxTokenFormat matches on a prefix, `"oxp_..."` and `Bearer oxp_...` do not
+// look like SageOx-family tokens at all, so the CRC precheck never runs, the raw
+// junk goes on the wire, and the user gets a generic 401 with no hint that the
+// value itself is the problem. The quoted form is the `docker --env-file` footgun
+// (it does not strip quotes); the Bearer form is copied out of HTTP examples.
+func TestTokenFromEnv_LeadingCorruptionNotSilentlyAccepted(t *testing.T) {
+	const clean = "oxp_test_4bDZfN"
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"double quoted", `"` + clean + `"`},
+		{"bearer prefixed", "Bearer " + clean},
+		{"leading space", " " + clean},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnvVarToken, tt.raw)
+
+			got := tokenFromEnv("https://api.sageox.ai/")
+			require.NotNil(t, got)
+			assert.Equal(t, clean, got.AccessToken, "the cleaned value must go on the wire, never the raw one")
+		})
+	}
+}
+
+// --- env token state classification ---
+
+// TestEnvTokenFor_ReportsMalformedDistinctlyFromAbsent — Failure prevented:
+// callers cannot tell "no env token" from "the operator named a credential we
+// refused". Conflating them makes a malformed SAGEOX_TOKEN fall through to a disk
+// token, silently changing which principal every API call, ledger write, and
+// murmur is attributed to.
+//
+// The endpoint-mismatch row is Absent on purpose and the distinction matters: a
+// token bound to a different endpoint was never meant for this one, so falling
+// back to disk is the correct behavior there — unlike malformed.
+func TestEnvTokenFor_ReportsMalformedDistinctlyFromAbsent(t *testing.T) {
+	const ep = "https://api.sageox.ai/"
+
+	t.Run("malformed when bound to this endpoint", func(t *testing.T) {
+		// oxp_/oxt_ family, so the CRC grammar applies — but the suffix is wrong.
+		t.Setenv(EnvVarToken, "oxt_test_4bDZfX")
+
+		tok, state := EnvTokenFor(ep)
+		assert.Equal(t, EnvTokenMalformed, state, "a CRC-failing family token must be reported as malformed")
+		assert.Nil(t, tok, "no usable token accompanies a malformed state")
+	})
+
+	t.Run("absent when unset", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "")
+
+		tok, state := EnvTokenFor(ep)
+		assert.Equal(t, EnvTokenAbsent, state)
+		assert.Nil(t, tok)
+	})
+
+	t.Run("absent when bound to a different endpoint", func(t *testing.T) {
+		// Malformed for its OWN endpoint, but it is not bound to the one asked
+		// about — so callers must be free to fall back, not fail closed.
+		t.Setenv(EnvVarToken, "oxt_test_4bDZfX")
+		t.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
+
+		tok, state := EnvTokenFor(ep)
+		assert.Equal(t, EnvTokenAbsent, state, "a token bound elsewhere was never meant for this endpoint")
+		assert.Nil(t, tok)
+	})
+
+	t.Run("valid when bound and well formed", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "oxp_test_4bDZfN")
+
+		tok, state := EnvTokenFor(ep)
+		assert.Equal(t, EnvTokenValid, state)
+		require.NotNil(t, tok)
+		assert.Equal(t, "oxp_test_4bDZfN", tok.AccessToken)
+	})
+}
+
+// TestEnvTokenIsTeamFamily — Failure prevented: status rendering picks
+// personal-token guidance ("run ox login") for a refused TEAM token, which cannot
+// be minted by ox login at all. The family must be readable even when the value
+// is malformed, because a malformed value never produces a StoredToken to inspect.
+func TestEnvTokenIsTeamFamily(t *testing.T) {
+	const ep = "https://api.sageox.ai/"
+
+	t.Run("malformed team token still reports team family", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "oxt_test_4bDZfX")
+		assert.True(t, EnvTokenIsTeamFamily(ep))
+	})
+
+	t.Run("personal token is not team family", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "oxp_test_4bDZfN")
+		assert.False(t, EnvTokenIsTeamFamily(ep))
+	})
+
+	t.Run("unset is not team family", func(t *testing.T) {
+		t.Setenv(EnvVarToken, "")
+		assert.False(t, EnvTokenIsTeamFamily(ep))
+	})
+
+	t.Run("team token bound to a different endpoint is not team family here", func(t *testing.T) {
+		t.Setenv(EnvVarToken, validSageOxTestToken(TeamTokenPrefix, "svc"))
+		t.Setenv("SAGEOX_ENDPOINT", "https://staging.sageox.ai")
+		assert.False(t, EnvTokenIsTeamFamily(ep))
+	})
 }

--- a/internal/auth/refresh_test.go
+++ b/internal/auth/refresh_test.go
@@ -892,8 +892,12 @@ func TestEnsureValidToken_EnvTokenSkipsRefresh(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
+	// a valid checksum (env_token.go's CRC precheck now runs at intake) with a
+	// value that still reads as what this test is about, at a fixed width so
+	// verifyTokenChecksum has a real suffix to check.
+	envTok := validSageOxTestToken(PATPrefix, "env_bypass")
 	t.Setenv("SAGEOX_ENDPOINT", mockServer.URL)
-	t.Setenv(EnvVarToken, "oxp_env_bypass")
+	t.Setenv(EnvVarToken, envTok)
 
 	// route disk auth into a temp dir without altering package state
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -904,7 +908,7 @@ func TestEnsureValidToken_EnvTokenSkipsRefresh(t *testing.T) {
 	token, err := EnsureValidToken(bigBuffer)
 	require.NoError(t, err)
 	require.NotNil(t, token, "env token should be returned as-is")
-	assert.Equal(t, "oxp_env_bypass", token.AccessToken)
+	assert.Equal(t, envTok, token.AccessToken)
 	assert.Empty(t, token.RefreshToken, "env token must have no refresh credential")
 }
 
@@ -918,8 +922,11 @@ func TestAuthClient_EnsureValidToken_EnvTokenSkipsRefresh(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
+	// a valid checksum (env_token.go's CRC precheck now runs at intake) — see
+	// the twin above for why this can no longer be an arbitrary placeholder.
+	envTok := validSageOxTestToken(PATPrefix, "env_client_bypass")
 	t.Setenv("SAGEOX_ENDPOINT", mockServer.URL)
-	t.Setenv(EnvVarToken, "oxp_env_client_bypass")
+	t.Setenv(EnvVarToken, envTok)
 
 	client := NewAuthClientWithDir(t.TempDir()).WithEndpoint(mockServer.URL)
 
@@ -927,7 +934,7 @@ func TestAuthClient_EnsureValidToken_EnvTokenSkipsRefresh(t *testing.T) {
 	token, err := client.EnsureValidToken(bigBuffer)
 	require.NoError(t, err)
 	require.NotNil(t, token)
-	assert.Equal(t, "oxp_env_client_bypass", token.AccessToken)
+	assert.Equal(t, envTok, token.AccessToken)
 	assert.Empty(t, token.RefreshToken)
 }
 

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -8,6 +9,16 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/paths"
 )
+
+// ErrEnvTokenMalformed reports that SAGEOX_TOKEN was set and bound to the
+// requested endpoint, but its value failed the local format check — so no
+// credential was resolved at all.
+//
+// Callers that render or explain auth state should branch on this with
+// errors.Is: "the credential you named is unusable" and "you have no
+// credential" call for different advice, and conflating them sends a CI
+// operator to `ox login` when the fix is to re-copy a service token.
+var ErrEnvTokenMalformed = errors.New("SAGEOX_TOKEN is set but its value failed a local format check")
 
 // UserInfo contains user information from the authentication provider
 type UserInfo struct {
@@ -107,6 +118,29 @@ func GetToken() (*StoredToken, error) {
 	return GetTokenForEndpoint(endpoint.Get())
 }
 
+// envTokenOrError resolves SAGEOX_TOKEN for ep ahead of any disk lookup.
+//
+// Three outcomes, and the middle one is the whole point:
+//   - (token, nil)  — a usable env credential; use it, skip auth.json.
+//   - (nil, err)    — the operator set SAGEOX_TOKEN for THIS endpoint and the
+//     value is unusable. Fail closed. Falling through to auth.json would
+//     authenticate as whoever is logged in on this machine instead of the
+//     principal the operator named, silently re-attributing every API call,
+//     ledger write, and murmur — while status still shows a green check.
+//   - (nil, nil)    — no env token applies (unset, or bound to another
+//     endpoint); the caller should read auth.json as usual.
+func envTokenOrError(ep string) (*StoredToken, error) {
+	tok, state := EnvTokenFor(ep)
+	if state == EnvTokenMalformed {
+		// Never interpolate the value: this error is printed to terminals and
+		// carried into logs, and a value that failed a checksum is still a
+		// secret (it may be a correct token with one character lost).
+		return nil, fmt.Errorf("%w (endpoint %s): refusing to fall back to a stored login — re-copy the token (a truncated paste is the usual cause), or unset %s to use your `ox login` credential",
+			ErrEnvTokenMalformed, ep, EnvVarToken)
+	}
+	return tok, nil
+}
+
 // GetTokenForEndpoint loads the raw stored token for a specific endpoint.
 // Internal use only (refresh logic, display/identity checks).
 // Callers making API requests MUST use EnsureValidTokenForEndpoint(ep, 300)
@@ -114,7 +148,11 @@ func GetToken() (*StoredToken, error) {
 func GetTokenForEndpoint(ep string) (*StoredToken, error) {
 	ep = endpoint.NormalizeEndpoint(ep)
 
-	if envTok := tokenFromEnv(ep); envTok != nil {
+	envTok, envErr := envTokenOrError(ep)
+	if envErr != nil {
+		return nil, envErr
+	}
+	if envTok != nil {
 		return envTok, nil
 	}
 
@@ -266,10 +304,18 @@ func GetLoggedInEndpoints() []string {
 	// auth.json. Reading only the file made `ox status` print "not logged in"
 	// in a shell where every API call succeeded — the most misleading thing a
 	// status command can do, and the reason a working PAT read as a broken
-	// one. tokenFromEnv() owns the endpoint-binding rules (see env_token.go);
-	// we ask it rather than re-deriving them here.
+	// one. EnvTokenFor() owns the endpoint-binding and format rules (see
+	// env_token.go); we ask it rather than re-deriving them here.
+	//
+	// A malformed env value adds nothing here: this list means "endpoints with
+	// a usable credential", and the malformed case has none. Renderers must ask
+	// EnvTokenFor(envTokenEndpoint()) directly rather than inferring the env
+	// state from this list, or a rejected token with no disk login behind it
+	// reads as a plain "not logged in".
 	envEP := envTokenEndpoint()
-	if tokenFromEnv(envEP) != nil {
+	_, envState := EnvTokenFor(envEP)
+	envAdded := envState == EnvTokenValid
+	if envAdded {
 		endpoints = append(endpoints, envEP)
 	}
 
@@ -289,7 +335,11 @@ func GetLoggedInEndpoints() []string {
 			// The env token SHADOWS a disk token for the same endpoint
 			// (GetTokenForEndpoint returns the env one first), so listing both
 			// would report two logins where the process can only ever use one.
-			if normalized == envEP && len(endpoints) > 0 {
+			// Test envAdded, never len(endpoints): the length also becomes
+			// non-zero after the first DISK endpoint is appended, so under Go's
+			// randomized map order an unrelated endpoint could suppress this
+			// one — a different answer from `ox status` run to run.
+			if normalized == envEP && envAdded {
 				continue
 			}
 			if token != nil && token.AccessToken != "" && token.ExpiresAt.After(now) {
@@ -340,7 +390,13 @@ func (c *AuthClient) GetToken() (*StoredToken, error) {
 func (c *AuthClient) GetTokenForEndpoint(ep string) (*StoredToken, error) {
 	ep = endpoint.NormalizeEndpoint(ep)
 
-	if envTok := tokenFromEnv(ep); envTok != nil {
+	// Same fail-closed contract as the package-level function — the two must
+	// never disagree about which principal is in play (see TestPackageAndClientAgree).
+	envTok, envErr := envTokenOrError(ep)
+	if envErr != nil {
+		return nil, envErr
+	}
+	if envTok != nil {
 		return envTok, nil
 	}
 

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -507,6 +507,23 @@ func (c *AuthClient) IsAuthenticated() (bool, error) {
 func (c *AuthClient) IsAuthCredentialValidForEndpoint(ep string) (bool, error) {
 	token, err := c.EnsureValidTokenForEndpoint(ep, 0)
 	if err != nil {
+		// Same reasoning as the package-level IsAuthCredentialValidForEndpoint
+		// in validate.go, and deliberately the same shape: a named-but-unusable
+		// credential is a different fact from no credential, and only that one
+		// is worth reporting. Everything else still degrades to "not
+		// authenticated, no error". The twins must not diverge — a client-scoped
+		// caller that reports a different verdict than the package-level one is
+		// a bug report nobody can reproduce.
+		//
+		// Branch on THIS error rather than re-reading the token:
+		// EnsureValidTokenForEndpoint returns GetTokenForEndpoint's error
+		// verbatim, so re-calling would only add a file-lock round trip on the
+		// failure path. That verbatim pass-through is load-bearing — if it ever
+		// starts wrapping or swallowing, the malformed-env-token case in
+		// TestAuthClientAuthChecks_MalformedEnvTokenSurfacesReason goes red.
+		if errors.Is(err, ErrEnvTokenMalformed) {
+			return false, err
+		}
 		raw, _ := c.GetTokenForEndpoint(ep)
 		if raw != nil {
 			return false, fmt.Errorf("token refresh failed: %w", err)

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -1135,3 +1135,68 @@ func TestGetLoggedInEndpoints_DoesNotDropEndpoint(t *testing.T) {
 		assert.Len(t, GetLoggedInEndpoints(), 2, "both disk logins must be reported on every call")
 	}
 }
+
+// TestAuthClientAuthChecks_MalformedEnvTokenSurfacesReason is the client-scoped
+// twin of TestAuthChecks_MalformedEnvTokenSurfacesReason in validate_test.go.
+// The two implementations are the same swallow with the same remedy, so they get
+// the same table: if they drift, a client-scoped caller reports a different
+// verdict than the package-level one for identical inputs — the kind of
+// divergence that produces a bug report nobody can reproduce a year out.
+//
+// Row by row: "malformed" states the fix, "no credential at all" states the
+// requirement it must not break, and "unreadable auth.json" is the one that
+// guards it. A logged-out user cannot catch an over-broad fix, because the
+// resolver returns (nil, nil) and the error branch is never entered at all —
+// only a genuine resolution failure that must STILL degrade quietly can.
+func TestAuthClientAuthChecks_MalformedEnvTokenSurfacesReason(t *testing.T) {
+	const ep = "https://sageox.ai"
+
+	t.Run("malformed env token", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("SAGEOX_ENDPOINT", "")
+
+		// a real team token with the last character of its CRC suffix lost —
+		// the exact shape a truncated copy/paste produces.
+		full := validSageOxTestToken(TeamTokenPrefix, "ci_service")
+		truncated := full[:len(full)-1]
+		t.Setenv(EnvVarToken, truncated)
+
+		client := NewTestClient(t)
+		ok, err := client.IsAuthCredentialValidForEndpoint(ep)
+		assert.False(t, ok, "reported authenticated on a credential that failed the local format check")
+		assert.ErrorIs(t, err, ErrEnvTokenMalformed,
+			"swallowing the reason renders \"not logged in\" and sends the operator to a command that cannot fix a team token")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), truncated, "the error must never echo the credential value")
+	})
+
+	t.Run("no credential at all", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("SAGEOX_ENDPOINT", "")
+		t.Setenv(EnvVarToken, "")
+
+		client := NewTestClient(t)
+		ok, err := client.IsAuthCredentialValidForEndpoint(ep)
+		assert.False(t, ok, "reported authenticated with no credential present")
+		assert.NoError(t, err,
+			"being logged out is a normal state, not a failure — an error here turns every unauthenticated invocation into a hard error")
+	})
+
+	t.Run("unreadable auth.json still degrades quietly", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("SAGEOX_ENDPOINT", "")
+		t.Setenv(EnvVarToken, "")
+
+		client := NewTestClient(t)
+		authPath, err := client.GetAuthFilePath()
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(filepath.Dir(authPath), 0o700))
+		require.NoError(t, os.WriteFile(authPath, []byte("{ this is not valid json"), 0o600))
+
+		ok, err := client.IsAuthCredentialValidForEndpoint(ep)
+		assert.False(t, ok, "reported authenticated from an unreadable auth.json")
+		assert.NoError(t, err,
+			"only ErrEnvTokenMalformed is worth surfacing here — reporting every resolution failure "+
+				"would make a corrupt auth.json a hard error for callers that only wanted to know whether to show a login hint")
+	})
+}

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -1055,3 +1055,83 @@ func TestConcurrentSaveToken_SameEndpoint(t *testing.T) {
 	require.NotNil(t, token, "token should exist after concurrent writes to same endpoint")
 	assert.Contains(t, token.AccessToken, "token-", "should be one of the written tokens")
 }
+
+// --- Env-token fail-closed behavior ---
+
+// TestGetTokenForEndpoint_MalformedEnvTokenDoesNotPromoteDiskIdentity —
+// Failure prevented: a developer logged in as themselves exports a TEAM service
+// token whose paste was truncated. The intent is "act as the team". If the
+// rejected value is silently discarded and the disk token used instead, every
+// API call, ledger write, and murmur is attributed to the human while status
+// shows a green check — a principal substitution with audit-trail consequences.
+// The declared principal is honored, or nothing is.
+func TestGetTokenForEndpoint_MalformedEnvTokenDoesNotPromoteDiskIdentity(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("SAGEOX_ENDPOINT", "")
+
+	// a real team token with the last character of its CRC suffix lost —
+	// the exact shape a truncated copy/paste produces.
+	full := validSageOxTestToken(TeamTokenPrefix, "ci_service")
+	truncated := full[:len(full)-1]
+	t.Setenv(EnvVarToken, truncated)
+
+	const ep = "https://sageox.ai"
+	disk := &StoredToken{
+		AccessToken: "disk-human-token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		UserInfo: UserInfo{
+			UserID: "human-42",
+			Email:  "human@example.com",
+			Name:   "Human Coworker",
+		},
+	}
+	require.NoError(t, SaveTokenForEndpoint(ep, disk))
+
+	client := NewTestClient(t)
+	require.NoError(t, client.SaveTokenForEndpoint(ep, disk))
+
+	cases := []struct {
+		name string
+		get  func(string) (*StoredToken, error)
+	}{
+		{"package-level", GetTokenForEndpoint},
+		{"AuthClient", client.GetTokenForEndpoint},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.get(ep)
+			assert.Nil(t, got, "must not hand back the disk identity for a rejected env token")
+			require.Error(t, err, "a malformed SAGEOX_TOKEN must not resolve to any credential")
+			assert.ErrorIs(t, err, ErrEnvTokenMalformed)
+
+			msg := err.Error()
+			assert.Contains(t, msg, EnvVarToken, "the error must name the env var the operator set")
+			assert.NotContains(t, msg, truncated, "the error must never echo the credential value")
+		})
+	}
+}
+
+// TestGetLoggedInEndpoints_DoesNotDropEndpoint — Failure prevented: with
+// SAGEOX_TOKEN unset and two disk logins, using list length as a proxy for "the
+// env token was already added" skips whichever endpoint the randomized map
+// iteration does not reach first, so `ox status` reports a different set of
+// logins run to run.
+//
+// The call is repeated because the defect is map-order dependent: a single
+// call reproduces it only about half the time, while 16 calls make a surviving
+// bug effectively certain to show.
+func TestGetLoggedInEndpoints_DoesNotDropEndpoint(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv(EnvVarToken, "")
+	t.Setenv("SAGEOX_ENDPOINT", "")
+
+	prod := &StoredToken{AccessToken: "prod-token", ExpiresAt: time.Now().Add(time.Hour)}
+	staging := &StoredToken{AccessToken: "staging-token", ExpiresAt: time.Now().Add(time.Hour)}
+	require.NoError(t, SaveTokenForEndpoint("https://sageox.ai", prod))
+	require.NoError(t, SaveTokenForEndpoint("https://staging.sageox.ai", staging))
+
+	for i := 0; i < 16; i++ {
+		assert.Len(t, GetLoggedInEndpoints(), 2, "both disk logins must be reported on every call")
+	}
+}

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -282,10 +282,22 @@ func IsAuthenticatedForEndpoint(ep string) (bool, error) {
 	// local credential check first (fast-fail if no token)
 	token, err := EnsureValidTokenForEndpoint(ep, 0)
 	if err != nil {
+		// "The credential you named is unusable" must not collapse into "you
+		// have no credential". They have different remedies: `ox login` mints
+		// personal tokens and cannot replace a team service token, so
+		// reporting a truncated SAGEOX_TOKEN as "not logged in" sends a CI
+		// operator to a command that cannot fix their problem. Every other
+		// error stays swallowed on purpose — see the return below.
+		if errors.Is(err, ErrEnvTokenMalformed) {
+			return false, err
+		}
 		raw, _ := GetTokenForEndpoint(ep)
 		if raw != nil {
 			return false, fmt.Errorf("token refresh failed: %w", err)
 		}
+		// A missing or unreadable auth.json is not a failure to report: being
+		// logged out is a normal state, and most callers here use
+		// `authenticated, _ :=` and would be unaffected anyway.
 		return false, nil
 	}
 	if token == nil {
@@ -316,6 +328,13 @@ func IsAuthenticated() (bool, error) {
 func IsAuthCredentialValidForEndpoint(ep string) (bool, error) {
 	token, err := EnsureValidTokenForEndpoint(ep, 0)
 	if err != nil {
+		// Same reasoning as IsAuthenticatedForEndpoint: a named-but-unusable
+		// credential is a different fact from no credential, and only that one
+		// is worth reporting. Everything else still degrades to "not
+		// authenticated, no error".
+		if errors.Is(err, ErrEnvTokenMalformed) {
+			return false, err
+		}
 		raw, _ := GetTokenForEndpoint(ep)
 		if raw != nil {
 			return false, fmt.Errorf("token refresh failed: %w", err)

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,27 +16,143 @@ import (
 	"github.com/sageox/ox/internal/useragent"
 )
 
-// ValidateTokenServerSide checks if the server accepts the given access token.
-// PATs (oxp_…) are validated via /api/v1/auth/me; OAuth/opaque access tokens via
-// /oauth2/userinfo. Returns nil on success, or an error describing the rejection.
-func ValidateTokenServerSide(ep, accessToken string) error {
-	ep = endpoint.NormalizeEndpoint(ep)
-	// PATs (oxp_…) carry no OAuth identity, so /oauth2/userinfo 401s them with
-	// "Token not found". Validate them via /api/v1/auth/me — the introspection
-	// route that resolves apiKey-plugin tokens to a user. OAuth/opaque access
-	// tokens still validate via /oauth2/userinfo.
-	validatePath := UserInfoEndpoint
-	if strings.HasPrefix(accessToken, PATPrefix) {
-		validatePath = AuthMeEndpoint
+// Principal kinds reported by the introspection endpoint in
+// IntrospectResult.PrincipalKind. The wire strings live here and nowhere else:
+// a caller comparing against its own literal would silently fall into its
+// generic branch if the server ever renamed one — dropping the team identity
+// with no compile error and no log line to notice it by.
+const (
+	PrincipalKindUser        = "user"
+	PrincipalKindTeamService = "team-service"
+)
+
+// ErrEndpointUnreachable wraps any failure to REACH the introspection endpoint,
+// as distinct from the server answering "no". A caller that conflates the two
+// tells an offline user their credential was rejected and advises a needless
+// credential rotation.
+var ErrEndpointUnreachable = errors.New("introspection endpoint unreachable")
+
+// maxIntrospectBody bounds the response body we are willing to buffer. A
+// legitimate introspection response is a few hundred bytes; 1 MiB leaves an
+// enormous margin while keeping a hostile or misconfigured endpoint from
+// driving an unbounded allocation in the CLI.
+const maxIntrospectBody = 1 << 20
+
+// IntrospectResult is the parsed shape of the introspection endpoint (see
+// IntrospectEndpoint) — the single door that validates EVERY bearer credential
+// family (session/JWT, personal oxp_, team oxt_) and reports what/who it
+// authenticates as.
+//
+// Field names mirror the server's response exactly and are FROZEN. The shape:
+//
+//	{"active": true, "principal_kind": "user"|"team-service",
+//	 "scope": "...", "token_type": "Bearer", "expires_at": <timestamp|null>,
+//	 "user": {"id","email","name","tier"} | null,
+//	 "team": {"team_id"} | null,
+//	 "token": {"prefix","name"} | null}
+//
+// Exactly one of User/Team is non-nil, matching PrincipalKind.
+type IntrospectResult struct {
+	Active        bool                 `json:"active"`
+	PrincipalKind string               `json:"principal_kind"` // PrincipalKindUser | PrincipalKindTeamService
+	Scope         string               `json:"scope"`
+	TokenType     string               `json:"token_type"`
+	ExpiresAt     *FlexTime            `json:"expires_at"`
+	User          *IntrospectUser      `json:"user"`
+	Team          *IntrospectTeam      `json:"team"`
+	Token         *IntrospectTokenInfo `json:"token"`
+}
+
+// FlexTime tolerates every timestamp encoding a conforming server might
+// legitimately send for expires_at: an RFC 3339 string, a JSON null, an empty
+// string, or a numeric unix epoch (the RFC 7662 convention for this field).
+//
+// A single unparseable value must never turn a live credential into "malformed
+// introspection response". expires_at has no consumer that would notice a zero
+// value, so rejecting on it would reintroduce exactly the spurious-rejection
+// class this endpoint exists to remove.
+type FlexTime struct{ time.Time }
+
+// UnmarshalJSON NEVER returns an error — that is the entire point of the type.
+// An error here would abort the surrounding decode (the JSON decoder returns an
+// Unmarshaler's error immediately rather than saving it and continuing), taking
+// the principal fields down with it. Unrecognized input leaves the zero time.
+func (f *FlexTime) UnmarshalJSON(b []byte) error {
+	f.Time = time.Time{}
+
+	raw := strings.TrimSpace(string(b))
+	if raw == "" || raw == "null" {
+		return nil
 	}
-	url := strings.TrimSuffix(ep, "/") + validatePath
+
+	if raw[0] == '"' {
+		var s string
+		if json.Unmarshal(b, &s) != nil {
+			return nil
+		}
+		if t, err := time.Parse(time.RFC3339, strings.TrimSpace(s)); err == nil {
+			f.Time = t
+		}
+		return nil
+	}
+
+	// Numeric unix epoch, integer or fractional seconds.
+	var secs float64
+	if json.Unmarshal(b, &secs) != nil {
+		return nil
+	}
+	whole := int64(secs)
+	f.Time = time.Unix(whole, int64((secs-float64(whole))*float64(time.Second))).UTC()
+	return nil
+}
+
+// IntrospectUser is the personal-principal (oxp_ / session) branch of
+// IntrospectResult.
+type IntrospectUser struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	Tier  string `json:"tier"`
+}
+
+// IntrospectTeam is the team-principal (oxt_) branch of IntrospectResult.
+type IntrospectTeam struct {
+	TeamID string `json:"team_id"`
+}
+
+// IntrospectTokenInfo describes the bearer credential itself — never the
+// secret, only its display prefix and the name it was minted with.
+type IntrospectTokenInfo struct {
+	Prefix string `json:"prefix"`
+	Name   string `json:"name"`
+}
+
+// Introspect validates accessToken against the server's single,
+// family-agnostic introspection endpoint and returns the principal it
+// authenticates as. Callers that only care whether the token is valid should
+// use ValidateTokenServerSide; callers that need to know WHAT it authenticates
+// as (status, doctor) call Introspect directly.
+//
+// A non-200 response — invalid, expired, revoked, or malformed, for ANY token
+// family — is returned as an error. The server deliberately answers a uniform
+// 401 rather than a typed rejection reason, so that a caller cannot use the
+// reason to enumerate which credentials exist; the error string is therefore
+// the only signal available to distinguish "no" from "yes, and here is who".
+//
+// A failure to reach the server at all is returned wrapped in
+// ErrEndpointUnreachable so callers can tell "offline" from "rejected" without
+// string-matching. The underlying transport error stays discoverable via
+// errors.As.
+func Introspect(ep, accessToken string) (*IntrospectResult, error) {
+	ep = endpoint.NormalizeEndpoint(ep)
+	url := strings.TrimSuffix(ep, "/") + IntrospectEndpoint
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	req, err := useragent.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create validation request: %w", err)
+		return nil, fmt.Errorf("failed to create validation request: %w", err)
 	}
 
 	req.Header.Set("Authorization", "Bearer "+accessToken)
@@ -50,44 +167,117 @@ func ValidateTokenServerSide(ep, accessToken string) error {
 	if err != nil {
 		logger.LogHTTPError("GET", url, err, duration)
 		slog.Debug("server-side token validation failed (network)", "endpoint", ep, "error", err)
-		return fmt.Errorf("could not reach %s to validate token: %w", endpoint.NormalizeSlug(ep), err)
+		// Two %w verbs: the transport error stays discoverable (errors.As for
+		// *url.Error, net.Error, context deadline) AND the failure is tagged
+		// with the sentinel so a caller can render "could not verify" instead
+		// of "rejected". Telling an offline developer with a perfectly good
+		// credential to mint a fresh one is a needless rotation.
+		return nil, fmt.Errorf("could not reach %s to validate token: %w: %w",
+			endpoint.NormalizeSlug(ep), err, ErrEndpointUnreachable)
 	}
 	defer resp.Body.Close()
 
 	logger.LogHTTPResponse("GET", url, resp.StatusCode, duration)
 
-	if resp.StatusCode == http.StatusOK {
-		return nil
+	// Bounded on BOTH paths: the success path reads the body too, and an
+	// unbounded io.ReadAll of an arbitrary endpoint is an unbounded allocation.
+	body, _ := io.ReadAll(http.MaxBytesReader(nil, resp.Body, maxIntrospectBody))
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Debug("server-side token validation rejected",
+			"endpoint", ep,
+			"status", resp.StatusCode,
+			"response", redactedBody(body, resp.Header.Get("Content-Type")),
+		)
+
+		var errResp struct {
+			Error            string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+		}
+		// A type mismatch on one field must not discard the others. The JSON
+		// decoder saves-and-continues on *json.UnmarshalTypeError, so
+		// {"error":123,"error_description":"session expired"} still yields a
+		// usable description alongside a non-nil error; gating on a nil error
+		// throws the good message away and falls through to a bare status
+		// code. A syntax error is still a hard skip — nothing was decoded, and
+		// a non-JSON body is not something to quote back at the operator.
+		var typeErr *json.UnmarshalTypeError
+		if uerr := json.Unmarshal(body, &errResp); uerr == nil || errors.As(uerr, &typeErr) {
+			// RedactSecrets, not the slog ReplaceAttr hook: that hook only
+			// scrubs log ATTRIBUTES and never sees a returned error. This
+			// string is printed to the terminal by `ox status` and captured in
+			// CI logs, so a server that echoes the presented credential back
+			// in its error body would leak it there. Do not "simplify" this
+			// into the redactedBody call above — they cover different sinks.
+			if errResp.ErrorDescription != "" {
+				return nil, fmt.Errorf("server rejected token: %s", logger.RedactSecrets(errResp.ErrorDescription))
+			}
+			if errResp.Error != "" {
+				return nil, fmt.Errorf("server rejected token: %s", logger.RedactSecrets(errResp.Error))
+			}
+		}
+		return nil, fmt.Errorf("server rejected token (HTTP %d)", resp.StatusCode)
 	}
 
-	// read error body for context
-	body, _ := io.ReadAll(resp.Body)
-	slog.Debug("server-side token validation rejected",
-		"endpoint", ep,
-		"status", resp.StatusCode,
-		"response", redactedBody(body, resp.Header.Get("Content-Type")),
-	)
+	var result IntrospectResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		// A type error and a syntax error are different in kind, and that
+		// difference decides whether the answer is still usable.
+		//
+		// This endpoint exists to stop spuriously rejecting live credentials.
+		// Rejecting one because `scope` came back as a number is the same
+		// defect as rejecting one because `expires_at` did (see FlexTime). The
+		// decoder saves a type error and keeps going, so every other field is
+		// still populated. Active and PrincipalKind are the only two fields
+		// the CLI consumes for a validity decision — if both decoded cleanly,
+		// the server answered the question we asked, and a wrong-typed field
+		// we never read is not grounds to throw that answer away.
+		//
+		// A syntax error is different in kind: nothing decoded, so Active
+		// being false is an artifact of the parse failing rather than a
+		// statement from the server. The same reasoning covers a type error on
+		// `active` itself — a zero value is the ABSENCE of a verdict, never a
+		// verdict — so both fail closed.
+		//
+		// Do not loosen this further. The two fields gated on are load-bearing
+		// precisely because they are the two we act on; tolerating a type
+		// error on either would turn "we could not read the answer" into "yes".
+		var typeErr *json.UnmarshalTypeError
+		if !errors.As(err, &typeErr) || !result.Active || result.PrincipalKind == "" {
+			return nil, fmt.Errorf("malformed introspection response: %w", err)
+		}
+		slog.Debug("introspection response had an unreadable field, principal decoded cleanly",
+			"endpoint", ep, "field", typeErr.Field, "principal_kind", result.PrincipalKind, "error", err)
+	}
+	if !result.Active {
+		// Defensive only: the server contract is a bare 401 for any invalid
+		// token rather than a 200 carrying {"active":false}, but a future
+		// server change or a non-conformant test double could still hand
+		// this back, and treating it as valid would be the wrong failure
+		// direction.
+		return nil, fmt.Errorf("server reported inactive token")
+	}
+	return &result, nil
+}
 
-	var errResp struct {
-		Error            string `json:"error"`
-		ErrorDescription string `json:"error_description"`
-	}
-	if json.Unmarshal(body, &errResp) == nil && errResp.ErrorDescription != "" {
-		return fmt.Errorf("server rejected token: %s", errResp.ErrorDescription)
-	}
-	if errResp.Error != "" {
-		return fmt.Errorf("server rejected token: %s", errResp.Error)
-	}
-	return fmt.Errorf("server rejected token (HTTP %d)", resp.StatusCode)
+// ValidateTokenServerSide checks whether the server accepts the given bearer
+// token. It calls the single family-agnostic introspection endpoint
+// regardless of token family (session/JWT, personal oxp_, team oxt_) — see
+// IntrospectEndpoint. Returns nil on success, or an error describing the
+// rejection.
+func ValidateTokenServerSide(ep, accessToken string) error {
+	_, err := Introspect(ep, accessToken)
+	return err
 }
 
 // --- Server-validated auth checks ---
 // These contact the server to verify the token is actually accepted.
 // Use for commands that gate real work: init, doctor, status.
 
-// IsAuthenticatedForEndpoint validates that the user has a working token for the
-// given endpoint by checking both local validity and server acceptance (via
-// /api/v1/auth/me for PATs, /oauth2/userinfo otherwise).
+// IsAuthenticatedForEndpoint validates that the user has a working token for
+// the given endpoint by checking both local validity and server acceptance
+// (via the single family-agnostic introspection endpoint, regardless of token
+// family).
 func IsAuthenticatedForEndpoint(ep string) (bool, error) {
 	// local credential check first (fast-fail if no token)
 	token, err := EnsureValidTokenForEndpoint(ep, 0)

--- a/internal/auth/validate_integration_test.go
+++ b/internal/auth/validate_integration_test.go
@@ -10,10 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// --- Server-side token validation via twinapi ---
-// These tests exercise the real auth.ValidateTokenServerSide function against
-// a running twinapi instance. Inline mocks can't catch these because the bug
-// was in the interaction pattern between CLI and server.
+// --- Server-side token validation against the API twin ---
+//
+// auth.ValidateTokenServerSide routes every credential family through one
+// family-agnostic introspection endpoint (auth.IntrospectEndpoint). The twin
+// serves that route against a real HTTP listener, so these tests drive the
+// whole path end to end: URL construction, bearer header, status handling,
+// and — the behavior that motivated this file — surfacing the server's own
+// error_description instead of a generic "authentication required".
+//
+// validate_test.go covers the same function against hand-authored httptest
+// responses, which pins the parser. This file pins the interaction: a server
+// that actually validates the credential decides the outcome, so each
+// assertion below depends on WHY the credential was refused, not merely that
+// something non-2xx came back.
 
 // TestValidateTokenServerSide_ValidJWT verifies that a proper JWT passes validation.
 // Failure prevented: false negatives in server-side validation.
@@ -23,6 +33,32 @@ func TestValidateTokenServerSide_ValidJWT(t *testing.T) {
 
 	err := auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
 	assert.NoError(t, err)
+
+	// the credential must have been validated at the introspection endpoint,
+	// not at a retired per-family route that happens to also answer 200
+	tw.AssertCalled(t, "GET", auth.IntrospectEndpoint)
+}
+
+// TestIntrospect_ReturnsUserPrincipal verifies the parsed result names the
+// principal, not just that the credential was accepted.
+// Failure prevented: a wire shape that unmarshals cleanly but leaves User nil,
+// which would make every identity-rendering caller fall through to the generic
+// "identity resolved server-side" copy for a token that named a real person.
+func TestIntrospect_ReturnsUserPrincipal(t *testing.T) {
+	tw := twinapi.Start(t)
+	fix := tw.WithAuthenticatedUser("principal@example.com", "Principal Person")
+
+	result, err := auth.Introspect(tw.URL(), fix.JWT)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.True(t, result.Active)
+	assert.Equal(t, "user", result.PrincipalKind)
+	require.NotNil(t, result.User, "a user principal must carry the user branch")
+	assert.Equal(t, fix.UserID, result.User.ID)
+	assert.Equal(t, "principal@example.com", result.User.Email)
+	assert.Equal(t, "Principal Person", result.User.Name)
+	assert.Nil(t, result.Team, "a user principal must not also carry a team branch")
 }
 
 // TestValidateTokenServerSide_OpaqueToken verifies that an opaque session token
@@ -37,6 +73,9 @@ func TestValidateTokenServerSide_OpaqueToken(t *testing.T) {
 	err := auth.ValidateTokenServerSide(tw.URL(), fix.SessionToken)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server rejected token")
+	// the reason must reach the caller: rejected because it is not a JWT, not
+	// because of a missing header or an unreachable server
+	assert.Contains(t, err.Error(), "malformed JWT")
 }
 
 // TestValidateTokenServerSide_ExpiredJWT verifies that an expired JWT is
@@ -47,16 +86,21 @@ func TestValidateTokenServerSide_ExpiredJWT(t *testing.T) {
 	tw := twinapi.Start(t)
 	fix := tw.WithAuthenticatedUser("expired@example.com", "Expired User")
 
+	// the same credential is accepted before the clock moves, so the rejection
+	// below can only be attributed to expiry
+	require.NoError(t, auth.ValidateTokenServerSide(tw.URL(), fix.JWT))
+
 	// advance clock past 24h JWT expiry
 	tw.AdvanceTime(25 * time.Hour)
 
 	err := auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server rejected token")
+	assert.Contains(t, err.Error(), "expired")
 }
 
 // TestValidateTokenServerSide_ServerDown verifies graceful handling when the
-// server is unreachable.
+// server is unreachable. This path never reaches the twin.
 // Failure prevented: init/doctor/status crashing instead of showing a useful
 // error when the server is down.
 func TestValidateTokenServerSide_ServerDown(t *testing.T) {
@@ -66,37 +110,54 @@ func TestValidateTokenServerSide_ServerDown(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not reach")
 }
 
-// TestValidateTokenServerSide_NonJWTTokenRejected verifies that an opaque
-// session token (not a JWT) is rejected by userinfo validation.
+// TestValidateTokenServerSide_NonJWTTokenRejected verifies that an orphaned
+// session token — opaque, and pointing at a user that never existed — is
+// rejected by introspection, and rejected for the right reason.
+// Failure prevented: an opaque credential passing because introspection only
+// checked that SOMETHING was in the Authorization header.
 func TestValidateTokenServerSide_NonJWTTokenRejected(t *testing.T) {
 	tw := twinapi.Start(t)
 
 	sess := tw.CreateOrphanedSession("usr_ghost")
 
-	// the session token isn't a JWT, so userinfo rejects it as malformed
 	err := auth.ValidateTokenServerSide(tw.URL(), sess.Token)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server rejected token")
+	// an opaque session token is not a JWT, so it never reaches the principal
+	// lookup — it fails the structural check first
+	assert.Contains(t, err.Error(), "malformed JWT")
 }
 
-// TestValidateTokenServerSide_UserNotFoundError verifies that the server's
-// "User not found" error is surfaced through validation.
-// Failure prevented: the exact test.sageox.ai bug — server returns descriptive
-// error but CLI showed generic "authentication required".
+// TestValidateTokenServerSide_UserNotFoundError verifies that a descriptive
+// server-side rejection reaches the caller verbatim.
+// Failure prevented: the reported production bug — the server explained that
+// the account behind an otherwise valid credential no longer existed, and the
+// CLI replaced that with a generic "authentication required", sending the
+// operator to rotate a credential that was fine.
 func TestValidateTokenServerSide_UserNotFoundError(t *testing.T) {
 	tw := twinapi.Start(t)
 	fix := tw.WithAuthenticatedUser("vanish@example.com", "Vanisher")
 
-	// inject fault that returns the exact error the real server gave us
-	tw.InjectFault("/oauth2/userinfo", 401)
+	// the credential is accepted while the account exists, so the rejection
+	// below is attributable to the vanished principal and nothing else
+	require.NoError(t, auth.ValidateTokenServerSide(tw.URL(), fix.JWT))
+
+	tw.DeleteUser(fix.UserID)
 
 	err := auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server rejected token")
+	// the server's own description — NOT a generic status-code fallback
+	assert.Contains(t, err.Error(), "user account not found")
+	assert.NotContains(t, err.Error(), "HTTP 401",
+		"a bare status code means the error_description was dropped")
 }
 
-// TestValidateTokenServerSide_FaultInjection verifies that fault injection on
-// the userinfo endpoint is detected by the validation function.
+// TestValidateTokenServerSide_FaultInjection verifies that a server-side
+// failure on the introspection endpoint is detected, reported with its status,
+// and recovered from once the failure clears.
+// Failure prevented: a transient 5xx being cached or latched into a permanent
+// "your token is bad" verdict.
 func TestValidateTokenServerSide_FaultInjection(t *testing.T) {
 	tw := twinapi.Start(t)
 	fix := tw.WithAuthenticatedUser("fault@example.com", "Fault User")
@@ -105,12 +166,15 @@ func TestValidateTokenServerSide_FaultInjection(t *testing.T) {
 	err := auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
 	require.NoError(t, err)
 
-	// inject a 503 on userinfo
-	tw.InjectFault("/oauth2/userinfo", 503)
+	// inject a 503 on introspection
+	tw.InjectFault(auth.IntrospectEndpoint, 503)
 
 	err = auth.ValidateTokenServerSide(tw.URL(), fix.JWT)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server rejected token")
+	// the injected status must reach the caller — a bodyless failure has no
+	// description, so the status code is the only detail available
+	assert.Contains(t, err.Error(), "503")
 
 	// clear and verify recovery
 	tw.ClearFaults()

--- a/internal/auth/validate_test.go
+++ b/internal/auth/validate_test.go
@@ -1,55 +1,77 @@
 package auth
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 )
 
-// ValidateTokenServerSide must route oxp_ PATs to /api/v1/auth/me (the PAT
-// introspection route) and every other token to /oauth2/userinfo. The bug this
-// locks out: a PAT sent to /oauth2/userinfo (OAuth/opaque tokens only) always
-// 401s with "Token not found", so `ox status` reported a valid PAT as
-// unauthenticated even though the server accepted it on the PAT path.
-func TestValidateTokenServerSide_RoutesPATToAuthMe(t *testing.T) {
+// Every bearer token family (personal oxp_, team oxt_, opaque, JWT-shaped)
+// must reach the server the same way — the whole point of the unified endpoint
+// is that the CLI never branches on the token again.
+//
+// What this DOES catch, per family: a request sent to any path other than
+// IntrospectEndpoint (URL-join drift, a stray double slash, a changed suffix),
+// a wrong HTTP method, and a mangled or missing Authorization header. The stub
+// 404s anything that is not the introspection path, so a routing regression
+// fails as an outright rejection rather than as a confusing string mismatch.
+//
+// What it does NOT prove: that the old per-family branch is gone. There is no
+// branch left in the production code to exercise, so this is a routing and
+// header contract test, not a proof of absence.
+func TestValidateTokenServerSide_FamilyAgnosticRouting(t *testing.T) {
 	// httptest serves plain HTTP; without this the endpoint normalizer would
 	// reject the http:// scheme before any request is made.
 	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
 
-	tests := []struct {
-		name     string
-		token    string
-		wantPath string
-	}{
-		{name: "PAT routes to auth/me", token: "oxp_abc123body_crc01", wantPath: AuthMeEndpoint},
-		{name: "opaque access token routes to userinfo", token: "opaque-access-token", wantPath: UserInfoEndpoint},
-		{name: "JWT routes to userinfo", token: "header.payload.sig", wantPath: UserInfoEndpoint},
+	tokens := []string{
+		"oxp_abc123body_crc01",
+		"oxt_abc123body_crc01",
+		"opaque-access-token",
+		"header.payload.sig",
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var gotPath, gotAuth string
+	for _, tok := range tokens {
+		t.Run(tok, func(t *testing.T) {
+			var gotPath, gotMethod, gotAuth string
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotPath = r.URL.Path
+				gotMethod = r.Method
 				gotAuth = r.Header.Get("Authorization")
+				if r.URL.Path != IntrospectEndpoint {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(IntrospectResult{Active: true, PrincipalKind: PrincipalKindUser})
 			}))
 			defer srv.Close()
 
-			if err := ValidateTokenServerSide(srv.URL, tt.token); err != nil {
-				t.Fatalf("expected success (200), got error: %v", err)
+			if err := ValidateTokenServerSide(srv.URL, tok); err != nil {
+				t.Fatalf("expected success (200) at %s, got error: %v (requested path %q)", IntrospectEndpoint, err, gotPath)
 			}
-			if gotPath != tt.wantPath {
-				t.Errorf("token %q validated at path %q, want %q", tt.token, gotPath, tt.wantPath)
+			if gotPath != IntrospectEndpoint {
+				t.Errorf("token %q validated at path %q, want %q", tok, gotPath, IntrospectEndpoint)
 			}
-			if want := "Bearer " + tt.token; gotAuth != want {
+			if gotMethod != http.MethodGet {
+				t.Errorf("token %q validated with method %q, want %q", tok, gotMethod, http.MethodGet)
+			}
+			if want := "Bearer " + tok; gotAuth != want {
 				t.Errorf("Authorization header = %q, want %q", gotAuth, want)
 			}
 		})
 	}
 }
 
-// A non-200 from the validation endpoint must surface as an error (the caller
-// treats nil error as "authenticated").
+// A non-200 from the introspection endpoint must surface as an error (the
+// caller treats nil error as "authenticated"), for any token family.
 func TestValidateTokenServerSide_RejectsNon200(t *testing.T) {
 	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -57,7 +79,448 @@ func TestValidateTokenServerSide_RejectsNon200(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if err := ValidateTokenServerSide(srv.URL, "oxp_revoked_token_xyz"); err == nil {
+	if err := ValidateTokenServerSide(srv.URL, "oxt_revoked_token_xyz"); err == nil {
 		t.Fatal("expected error for 401, got nil")
+	}
+}
+
+// Introspect must parse the frozen user-principal response shape (see the
+// IntrospectResult doc comment) — this is what cmd/ox/status.go relies on to
+// decide whether to render "User <name> <email>".
+func TestIntrospect_ParsesUserPrincipal(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"principal_kind": "user",
+			"scope": "full-access",
+			"token_type": "Bearer",
+			"expires_at": null,
+			"user": {"id": "usr_abc", "email": "person-a@test.sageox.ai", "name": "Person A", "tier": "pro"},
+			"team": null,
+			"token": null
+		}`))
+	}))
+	defer srv.Close()
+
+	result, err := Introspect(srv.URL, "oxp_test_4bDZfN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PrincipalKind != "user" {
+		t.Errorf("PrincipalKind = %q, want %q", result.PrincipalKind, "user")
+	}
+	if result.User == nil || result.User.Email != "person-a@test.sageox.ai" {
+		t.Errorf("User = %+v, want email person-a@test.sageox.ai", result.User)
+	}
+	if result.Team != nil {
+		t.Errorf("Team = %+v, want nil for a user principal", result.Team)
+	}
+}
+
+// Introspect must parse the frozen team-principal response shape —
+// PrincipalKindTeamService plus Team.TeamID and Token.Name populated.
+// This is the exact response cmd/ox/status.go's "acting as team <team_id>"
+// rendering depends on.
+func TestIntrospect_ParsesTeamPrincipal(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"active": true,
+			"principal_kind": "team-service",
+			"scope": "read-only",
+			"token_type": "Bearer",
+			"expires_at": "2026-08-16T19:42:43Z",
+			"user": null,
+			"team": {"team_id": "team_abc123"},
+			"token": {"prefix": "oxt_ab12", "name": "ci-deploy"}
+		}`))
+	}))
+	defer srv.Close()
+
+	result, err := Introspect(srv.URL, "oxt_test_1ljPfr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.PrincipalKind != PrincipalKindTeamService {
+		t.Errorf("PrincipalKind = %q, want %q", result.PrincipalKind, PrincipalKindTeamService)
+	}
+	if result.Team == nil || result.Team.TeamID != "team_abc123" {
+		t.Errorf("Team = %+v, want team_id team_abc123", result.Team)
+	}
+	if result.Token == nil || result.Token.Name != "ci-deploy" {
+		t.Errorf("Token = %+v, want name ci-deploy", result.Token)
+	}
+	if result.User != nil {
+		t.Errorf("User = %+v, want nil for a team principal", result.User)
+	}
+}
+
+// A 200 with malformed JSON must not be treated as success — a caller acting
+// on a zero-value IntrospectResult would render a blank identity as if it
+// were a real (if empty) principal.
+func TestIntrospect_MalformedBodyRejected(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	if _, err := Introspect(srv.URL, "oxp_test_4bDZfN"); err == nil {
+		t.Fatal("expected error for malformed JSON body, got nil")
+	}
+}
+
+// A 200 with active:false must be rejected rather than treated as a valid
+// (if inactive) principal. The server answers a bare 401 instead of returning
+// this shape, but the client must not trust a 200 blindly.
+func TestIntrospect_InactiveTokenRejected(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(IntrospectResult{Active: false, PrincipalKind: "user"})
+	}))
+	defer srv.Close()
+
+	if _, err := Introspect(srv.URL, "oxp_test_4bDZfN"); err == nil {
+		t.Fatal("expected error for active:false, got nil")
+	}
+}
+
+// "The server never answered" and "the server said no" are different facts
+// with different remedies. Conflating them tells a developer who is merely
+// offline that their credential was rejected and advises a needless rotation.
+// Both halves of this test matter: a sentinel that is always true is useless,
+// so a live 401 must NOT satisfy it.
+func TestIntrospect_UnreachableIsDistinguishable(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+
+	// A well-formed URL with nothing listening behind it.
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	_, err := Introspect(deadURL, "oxp_test_4bDZfN")
+	if err == nil {
+		t.Fatal("expected an error from an unreachable endpoint, got nil")
+	}
+	if !errors.Is(err, ErrEndpointUnreachable) {
+		t.Errorf("unreachable endpoint did not yield ErrEndpointUnreachable: %v", err)
+	}
+	// The transport cause must stay discoverable — a caller diagnosing a
+	// proxy, DNS, or TLS failure needs the underlying error, not just the tag.
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		t.Errorf("underlying transport error is not discoverable via errors.As: %v", err)
+	}
+
+	// A live server answering 401 is a rejection, not an unreachable endpoint.
+	live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer live.Close()
+
+	_, err = Introspect(live.URL, "oxp_test_4bDZfN")
+	if err == nil {
+		t.Fatal("expected an error from a 401, got nil")
+	}
+	if errors.Is(err, ErrEndpointUnreachable) {
+		t.Errorf("a 401 from a live server must not be classified unreachable: %v", err)
+	}
+}
+
+// The returned error is printed to the terminal by `ox status` and captured by
+// CI logs. A server that echoes the presented credential back in its error
+// body must not be able to leak it there. The slog ReplaceAttr redaction hook
+// does NOT cover this path — it only scrubs log attributes, never a returned
+// error — so the redaction has to happen at the format site.
+func TestIntrospect_ErrorBodyIsRedacted(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+
+	const leaked = "oxp_deadbeefdeadbeefdead"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = fmt.Fprintf(w, `{"error":"invalid_token","error_description":"presented credential %s was rejected"}`, leaked)
+	}))
+	defer srv.Close()
+
+	_, err := Introspect(srv.URL, leaked)
+	if err == nil {
+		t.Fatal("expected error for 401, got nil")
+	}
+	if strings.Contains(err.Error(), leaked) {
+		t.Errorf("returned error leaks the credential: %q", err.Error())
+	}
+	// The redaction must not swallow the message the operator needs.
+	for _, want := range []string{"presented credential", "was rejected"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("returned error = %q, want it to still contain %q", err.Error(), want)
+		}
+	}
+}
+
+// Go's JSON decoder saves-and-continues on a type mismatch: it reports an
+// *json.UnmarshalTypeError but still populates every field it could decode.
+// Gating the error message on a nil unmarshal error therefore throws away a
+// perfectly good error_description whenever a sibling field has the wrong
+// type, and the operator gets a bare status code instead of the reason.
+func TestIntrospect_ErrorFieldSurvivesTypeMismatch(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":123,"error_description":"session expired"}`))
+	}))
+	defer srv.Close()
+
+	_, err := Introspect(srv.URL, "oxp_test_4bDZfN")
+	if err == nil {
+		t.Fatal("expected error for 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "session expired") {
+		t.Errorf("returned error = %q, want it to surface the error_description %q", err.Error(), "session expired")
+	}
+}
+
+// expires_at has no consumer that would notice a zero value, so no encoding of
+// it may turn a live, valid credential into "malformed introspection
+// response". A numeric unix epoch is the RFC 7662 convention for this field and
+// is a completely plausible server encoding; an empty string and an
+// unparseable value are plausible too. Every one of them must still yield a
+// usable principal.
+func TestIntrospect_FlexibleExpiresAt(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+
+	tests := []struct {
+		name string
+		raw  string // the raw JSON value for expires_at
+	}{
+		{"rfc3339 string", `"2026-08-16T19:42:43Z"`},
+		{"json null", `null`},
+		{"empty string", `""`},
+		{"unix seconds integer", `1786000000`},
+		{"unix seconds float", `1786000000.5`},
+		{"unparseable string", `"tomorrow-ish"`},
+		{"unexpected object", `{"seconds":1786000000}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`{
+				"active": true,
+				"principal_kind": "user",
+				"scope": "full-access",
+				"token_type": "Bearer",
+				"expires_at": %s,
+				"user": {"id": "usr_abc", "email": "person-a@test.sageox.ai", "name": "Person A", "tier": "pro"},
+				"team": null,
+				"token": null
+			}`, tt.raw)
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(body))
+			}))
+			defer srv.Close()
+
+			result, err := Introspect(srv.URL, "oxp_test_4bDZfN")
+			if err != nil {
+				t.Fatalf("expires_at %s made the whole parse fail: %v", tt.raw, err)
+			}
+			if !result.Active {
+				t.Error("Active = false, want true")
+			}
+			if result.PrincipalKind != PrincipalKindUser {
+				t.Errorf("PrincipalKind = %q, want %q", result.PrincipalKind, PrincipalKindUser)
+			}
+			if result.User == nil || result.User.Email != "person-a@test.sageox.ai" {
+				t.Errorf("User = %+v, want the principal intact", result.User)
+			}
+		})
+	}
+}
+
+// A wrong-typed field the CLI never reads is not grounds to throw away a
+// server answer that decoded cleanly where it matters. This pins the boundary
+// in BOTH directions: tolerate a type error only when active and
+// principal_kind both survived, and never let a type error on active itself be
+// tolerated into looking active.
+func TestIntrospect_TolerantOfUnreadFieldTypeErrors(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+
+	const user = `"user": {"id": "usr_abc", "email": "person-a@test.sageox.ai", "name": "Person A", "tier": "pro"}`
+
+	tests := []struct {
+		name       string
+		body       string
+		wantAccept bool
+		wantErr    string // substring the rejection must carry, when the wording itself matters
+		why        string
+	}{
+		{
+			name:       "wrong-typed scope",
+			body:       `{"active":true,"principal_kind":"user","scope":123,` + user + `}`,
+			wantAccept: true,
+			why:        "scope has no consumer; the validity question was answered",
+		},
+		{
+			name:       "wrong-typed token_type",
+			body:       `{"active":true,"principal_kind":"user","token_type":42,` + user + `}`,
+			wantAccept: true,
+			why:        "token_type has no consumer",
+		},
+		{
+			name:       "wrong-typed token object",
+			body:       `{"active":true,"principal_kind":"user","token":"oxt_ab12",` + user + `}`,
+			wantAccept: true,
+			why:        "token is display-only; a nil Token renders a generic label",
+		},
+		{
+			name:       "wrong-typed user object",
+			body:       `{"active":true,"principal_kind":"user","user":"person-a"}`,
+			wantAccept: true,
+			why:        "identity rendering degrades to generic; the credential is still live",
+		},
+		{
+			name:       "wrong-typed active",
+			body:       `{"active":"yes","principal_kind":"user",` + user + `}`,
+			wantAccept: false,
+			// The wording is load-bearing here: the server did NOT report this
+			// token inactive, we failed to read what it reported. Falling
+			// through to the downstream inactive check would reject the token
+			// (right outcome) while telling the operator something false about
+			// why (wrong diagnosis, and it points at the credential instead of
+			// at the server response).
+			wantErr: "malformed introspection response",
+			why:     "active never decoded; treating the zero value as a verdict would fail open",
+		},
+		{
+			name:       "missing principal_kind alongside a type error",
+			body:       `{"active":true,"scope":123,` + user + `}`,
+			wantAccept: false,
+			why:        "the server did not say what this authenticates as",
+		},
+		{
+			name:       "active false alongside a type error",
+			body:       `{"active":false,"principal_kind":"user","scope":123}`,
+			wantAccept: false,
+			why:        "an explicit inactive verdict still wins",
+		},
+		{
+			name:       "syntax error mid-body",
+			body:       `{"active":true,"principal_kind":"user",`,
+			wantAccept: false,
+			why:        "nothing decoded; active being false is an artifact of the parse, not a statement",
+		},
+		{
+			name:       "not json at all",
+			body:       `not json`,
+			wantAccept: false,
+			why:        "same asymmetry: a syntax error is different in kind from a type error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tt.body)
+			}))
+			defer srv.Close()
+
+			result, err := Introspect(srv.URL, "oxp_test_4bDZfN")
+
+			if !tt.wantAccept {
+				if err == nil {
+					t.Fatalf("body %s was accepted; it must be rejected (%s)", tt.body, tt.why)
+				}
+				if tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("rejection = %q, want it to contain %q (%s)", err.Error(), tt.wantErr, tt.why)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("body %s was rejected (%v); it must be accepted (%s)", tt.body, err, tt.why)
+			}
+			if !result.Active {
+				t.Error("Active = false, want true")
+			}
+			if result.PrincipalKind != PrincipalKindUser {
+				t.Errorf("PrincipalKind = %q, want %q", result.PrincipalKind, PrincipalKindUser)
+			}
+		})
+	}
+}
+
+// The success path reads the response body too, so an unbounded io.ReadAll
+// here would let any endpoint the CLI is pointed at drive an unbounded
+// allocation. The observable consequence of the cap is that an oversized body
+// arrives truncated and therefore fails to parse — without the cap this same
+// body parses cleanly, which is exactly the unbounded buffering we are
+// refusing to do.
+func TestIntrospect_BodyIsBounded(t *testing.T) {
+	t.Setenv("OX_ALLOW_PLAINTEXT_ENDPOINT", "1")
+
+	// Well-formed JSON, far larger than any legitimate introspection response.
+	oversized := `{"active":true,"principal_kind":"user","scope":"` +
+		strings.Repeat("x", 3<<20) + `","user":null,"team":null,"token":null}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, oversized)
+	}))
+	defer srv.Close()
+
+	if _, err := Introspect(srv.URL, "oxp_test_4bDZfN"); err == nil {
+		t.Fatalf("a %d-byte body was buffered and parsed in full; the read is not bounded", len(oversized))
+	}
+}
+
+// Tolerance is only half the requirement: "never fails the parse" would also be
+// satisfied by a type that silently discarded every value. The encodings we
+// claim to support must actually decode to the right instant, and only the
+// genuinely unrecognizable ones may fall back to the zero time.
+func TestFlexTime_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantMillis int64 // 0 means "zero time"
+	}{
+		{"rfc3339 utc", `"2026-08-16T19:42:43Z"`, time.Date(2026, 8, 16, 19, 42, 43, 0, time.UTC).UnixMilli()},
+		{"rfc3339 offset", `"2026-08-16T14:42:43-05:00"`, time.Date(2026, 8, 16, 19, 42, 43, 0, time.UTC).UnixMilli()},
+		{"unix seconds integer", `1786000000`, 1786000000 * 1000},
+		{"unix seconds float", `1786000000.5`, 1786000000*1000 + 500},
+		{"json null", `null`, 0},
+		{"empty string", `""`, 0},
+		{"whitespace string", `"   "`, 0},
+		{"unparseable string", `"tomorrow-ish"`, 0},
+		{"unexpected object", `{"seconds":1786000000}`, 0},
+		{"unexpected bool", `true`, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var ft FlexTime
+			if err := ft.UnmarshalJSON([]byte(tt.raw)); err != nil {
+				t.Fatalf("UnmarshalJSON(%s) returned %v; it must NEVER return an error — "+
+					"an Unmarshaler error aborts the surrounding decode and takes the principal with it", tt.raw, err)
+			}
+
+			var got int64
+			if !ft.IsZero() {
+				got = ft.UnixMilli()
+			}
+			if got != tt.wantMillis {
+				t.Errorf("UnmarshalJSON(%s) = %v (unix_ms %d), want unix_ms %d", tt.raw, ft.Time, got, tt.wantMillis)
+			}
+		})
 	}
 }

--- a/internal/auth/validate_test.go
+++ b/internal/auth/validate_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -188,6 +190,100 @@ func TestIntrospect_InactiveTokenRejected(t *testing.T) {
 
 	if _, err := Introspect(srv.URL, "oxp_test_4bDZfN"); err == nil {
 		t.Fatal("expected error for active:false, got nil")
+	}
+}
+
+// "Your credential is unusable" and "you have no credential" are different
+// facts with different remedies, and the auth checks must not flatten one into
+// the other. A CI operator whose team service token was truncated in transit
+// gets "NOT LOGGED IN → run `ox login`" if the reason is swallowed — and
+// `ox login` mints personal tokens, so it cannot replace a team token. That is
+// the wrong remedy delivered confidently.
+//
+// The second half of this table is the counterweight: an ordinary
+// unauthenticated user must still be (false, nil). Turning "no credential"
+// into a hard error would be a far worse regression than the one being fixed.
+func TestAuthChecks_MalformedEnvTokenSurfacesReason(t *testing.T) {
+	const ep = "https://sageox.ai"
+
+	checks := []struct {
+		name string
+		fn   func(string) (bool, error)
+	}{
+		{"IsAuthenticatedForEndpoint", IsAuthenticatedForEndpoint},
+		{"IsAuthCredentialValidForEndpoint", IsAuthCredentialValidForEndpoint},
+	}
+
+	for _, c := range checks {
+		t.Run(c.name+"/malformed env token", func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("SAGEOX_ENDPOINT", "")
+
+			// A real team token with the last character of its CRC suffix
+			// lost — the exact shape a truncated copy/paste produces.
+			full := validSageOxTestToken(TeamTokenPrefix, "ci_service")
+			truncated := full[:len(full)-1]
+			t.Setenv(EnvVarToken, truncated)
+
+			ok, err := c.fn(ep)
+			if ok {
+				t.Error("reported authenticated on a credential that failed the local format check")
+			}
+			if !errors.Is(err, ErrEnvTokenMalformed) {
+				t.Errorf("err = %v, want an error wrapping ErrEnvTokenMalformed; swallowing it renders "+
+					"\"not logged in\" and sends the operator to a command that cannot fix a team token", err)
+			}
+			if err != nil && strings.Contains(err.Error(), truncated) {
+				t.Errorf("error echoes the credential value: %q", err.Error())
+			}
+		})
+
+		t.Run(c.name+"/no credential at all", func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("SAGEOX_ENDPOINT", "")
+			t.Setenv(EnvVarToken, "")
+
+			ok, err := c.fn(ep)
+			if ok {
+				t.Error("reported authenticated with no credential present")
+			}
+			if err != nil {
+				t.Errorf("err = %v, want nil: being logged out is a normal state, not a failure. "+
+					"An error here turns every unauthenticated invocation into a hard error", err)
+			}
+		})
+
+		// The row above cannot catch an over-broad fix, because a logged-out
+		// user produces no error at all — the error branch is never entered.
+		// This one does: an unreadable auth.json is a genuine resolution
+		// failure that must STILL degrade to "not authenticated, no error".
+		// Only the env-token sentinel is worth reporting.
+		t.Run(c.name+"/unreadable auth.json still degrades quietly", func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			t.Setenv("SAGEOX_ENDPOINT", "")
+			t.Setenv(EnvVarToken, "")
+
+			authPath, err := GetAuthFilePath()
+			if err != nil {
+				t.Fatalf("GetAuthFilePath: %v", err)
+			}
+			if err := os.MkdirAll(filepath.Dir(authPath), 0o700); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(authPath, []byte("{ this is not valid json"), 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			ok, err := c.fn(ep)
+			if ok {
+				t.Error("reported authenticated from an unreadable auth.json")
+			}
+			if err != nil {
+				t.Errorf("err = %v, want nil: only ErrEnvTokenMalformed is worth surfacing here. "+
+					"Reporting every resolution failure would make a corrupt auth.json a hard error "+
+					"for commands that only wanted to know whether to show a login hint", err)
+			}
+		})
 	}
 }
 

--- a/internal/logger/redact.go
+++ b/internal/logger/redact.go
@@ -21,7 +21,8 @@ import (
 //   - JSON string field with a sensitive key: "token":"…", "git_token":"…"
 //   - Authorization: Bearer <token> and a bare "Bearer <token>"
 //   - credentials in a URL userinfo: https://user:secret@host
-//   - well-known PAT prefixes (SageOx oxp_, GitLab glpat-, GitHub gh*_)
+//   - well-known PAT prefixes (SageOx ox[a-z]_ family — personal oxp_, team
+//     oxt_, and any future family; GitLab glpat-, GitHub gh*_)
 func redactSecrets(s string) string {
 	if s == "" {
 		return s
@@ -43,8 +44,26 @@ var (
 	// scheme://user:secret@host — keep the username, redact the secret.
 	urlCredRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://[^:/?#\s@]+):[^@/?#\s]+@`)
 	// well-known personal-access-token prefixes (bare token strings).
-	patRe = regexp.MustCompile(`(?:oxp_|glpat-|ghp_|gho_|ghu_|ghs_|github_pat_)[A-Za-z0-9_-]{8,}`)
+	// ox[a-z]_ covers the whole SageOx bearer-token family generically
+	// (oxp_ personal, oxt_ team — and any family minted later) instead of
+	// hand-listing each one; a team token has a LARGER blast radius than a
+	// PAT, so a new family must be redacted by default, not opt-in.
+	//
+	// The leading \b is load-bearing: without it the generalized ox[a-z]_
+	// alternative matches INSIDE ordinary words, most damagingly "proxy_" —
+	// so "failed to dial via proxy_endpoint_override" logged as
+	// "failed to dial via pr[REDACTED]". That is the exact vocabulary of
+	// network-failure lines, the ones an operator most needs intact. A real
+	// token is always preceded by a non-word character (line start, space,
+	// '=', quote, ':', '/'), so the boundary costs no true-positive coverage.
+	patRe = regexp.MustCompile(`\b(?:ox[a-z]_|glpat-|ghp_|gho_|ghu_|ghs_|github_pat_)[A-Za-z0-9_-]{8,}`)
 )
+
+// RedactSecrets scrubs credential material from an arbitrary string. Exported for call
+// sites that must sanitize a value which is NOT a log attribute — notably an error
+// returned to the caller and printed to the terminal, which the slog ReplaceAttr hook
+// never sees.
+func RedactSecrets(s string) string { return redactSecrets(s) }
 
 // redactAttr is the slog ReplaceAttr hook: scrub every string-valued attribute
 // (body, response, url, error, …) through redactSecrets. Non-string attrs are

--- a/internal/logger/redact_test.go
+++ b/internal/logger/redact_test.go
@@ -58,6 +58,15 @@ func TestRedactSecrets_Shapes(t *testing.T) {
 			secret:  "oxp_deadbeefdeadbeefdead",
 			mustCon: "ls-remote",
 		},
+		{
+			// A team token (oxt_) has a LARGER blast radius than a
+			// personal PAT — it must be redacted just as aggressively.
+			// This is the family the ox[a-z]_ generalization exists for.
+			name:    "bare sageox team-token prefix",
+			in:      "probe used token oxt_deadbeefdeadbeefdead for ls-remote",
+			secret:  "oxt_deadbeefdeadbeefdead",
+			mustCon: "ls-remote",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -82,11 +91,90 @@ func TestRedactSecrets_NoFalsePositives(t *testing.T) {
 		`{"status":"ok","count":3,"endpoint":"sageox.ai"}`,
 		"http response body (empty body)",
 		"POST https://api.sageox.ai/api/v1/repo/init 200 in 42ms",
+		// The ox[a-z]_ family pattern matches inside "proxy_" unless it is
+		// left-anchored on a word boundary — and proxy_* identifiers are the
+		// native vocabulary of network-failure log lines, exactly the ones that
+		// must stay legible when someone is debugging a connection problem.
+		"failed to dial via proxy_endpoint_override: connection refused",
+		"HTTPS_PROXY=http://proxy_internal_corp:3128",
+		"no_proxy_hosts_configured for this run",
+		"epoxy_batch_identifier_12345",
 	}
 	for _, s := range clean {
 		if got := redactSecrets(s); got != s {
 			t.Errorf("clean string altered:\n in:  %s\n out: %s", s, got)
 		}
+	}
+}
+
+// TestRedactedTokenPrefix_SurvivesLogRedaction pins the margin that lets a
+// rejected-credential diagnostic name WHICH credential was rejected.
+//
+// The auth package logs a short prefix of a malformed token ("oxp_test…[REDACTED]")
+// so an operator can tell a personal token from a team one. That line only works if
+// it survives this sink: patRe needs {8,} body characters after the prefix, and an
+// 8-character show window leaves only 4. The margin is 3 characters and is enforced
+// nowhere else — widen the show window to 12 and the diagnostic silently degrades to
+// "[REDACTED]…[REDACTED]", telling the operator nothing, with no other test noticing.
+//
+// Asserted on the literal shape on purpose: internal/logger must import no other
+// internal package (it sits underneath all of them), so it cannot import the auth
+// helper that produces this string.
+//
+// Failure prevented: a token-family diagnostic that is scrubbed into uselessness by
+// its own safety net — either by widening the show window upstream or by loosening
+// patRe's length floor here.
+func TestRedactedTokenPrefix_SurvivesLogRedaction(t *testing.T) {
+	cases := []struct {
+		name      string
+		showChars int
+		line      string
+		survives  bool
+	}{
+		{
+			name:      "current 8-char window stays legible",
+			showChars: 8,
+			line:      "prefix=oxp_test…[REDACTED] length=15",
+			survives:  true,
+		},
+		{
+			name:      "11 is the widest window that still survives",
+			showChars: 11,
+			line:      "prefix=oxp_test123…[REDACTED] length=15",
+			survives:  true,
+		},
+		{
+			// The cliff: 12 shown characters means 8 body characters, which is
+			// exactly patRe's {8,} floor, so the prefix redacts itself away.
+			name:      "12-char window destroys the diagnostic",
+			showChars: 12,
+			line:      "prefix=oxp_test1234…[REDACTED] length=15",
+			survives:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactSecrets(tc.line)
+			if survived := strings.Contains(got, "oxp_test"); survived != tc.survives {
+				t.Fatalf("showChars=%d: token family prefix survived=%v, want %v\n in:  %s\n out: %s",
+					tc.showChars, survived, tc.survives, tc.line, got)
+			}
+		})
+	}
+}
+
+// TestRedactSecrets_ExportedWrapper covers the exported entry point used by call
+// sites that hold a value the slog ReplaceAttr hook never sees — notably an error
+// returned to a caller and printed straight to the terminal.
+// Failure prevented: a credential surfacing in terminal output because the only
+// scrubber was wired into the log sink.
+func TestRedactSecrets_ExportedWrapper(t *testing.T) {
+	got := RedactSecrets(`introspection failed: {"error_description":"bad token oxt_deadbeefdeadbeef"}`)
+	if strings.Contains(got, "oxt_deadbeefdeadbeef") {
+		t.Fatalf("exported scrubber leaked a team token: %s", got)
+	}
+	if !strings.Contains(got, "introspection failed") {
+		t.Fatalf("exported scrubber destroyed the error context: %s", got)
 	}
 }
 

--- a/internal/session/secrets.go
+++ b/internal/session/secrets.go
@@ -200,6 +200,28 @@ func DefaultPatterns() []SecretPattern {
 			Redact:  "[REDACTED_SAGEOX_API_KEY]",
 		},
 
+		// SageOx bearer tokens — the whole ox<letter>_ family generically
+		// (oxp_ personal, oxt_ team, and any family minted later) rather than
+		// hand-listing each one. A team token authenticates AS THE TEAM, so it
+		// has a larger blast radius than a personal PAT, and this is the worst
+		// place to leak one: an unredacted token in raw.jsonl is uploaded and
+		// synced to every teammate with ledger read access.
+		//
+		// This MUST stay in lockstep with logger.patRe — same \b anchor, same
+		// {8,} minimum. They are two independent redaction pipelines (this one
+		// guards captured session content, that one guards log output), and a
+		// family registered in only one of them is a hole shaped exactly like
+		// the one this pattern was added to close.
+		//
+		// The \b matters for more than tidiness: without it, ox[a-z]_ matches
+		// inside proxy_, so "proxy_endpoint_override" in a captured shell
+		// transcript would be silently rewritten.
+		{
+			Name:    "sageox_bearer_token",
+			Pattern: regexp.MustCompile(`\box[a-z]_[A-Za-z0-9_\-]{8,}`),
+			Redact:  "[REDACTED_SAGEOX_TOKEN]",
+		},
+
 		// AgentX keys (axk_ prefix, exactly 32 chars after prefix)
 		{
 			Name:    "agentx_key",

--- a/internal/session/secrets_test.go
+++ b/internal/session/secrets_test.go
@@ -582,6 +582,79 @@ func TestRedactString_SlackTokens(t *testing.T) {
 	}
 }
 
+// TestRedactString_SageOxBearerTokens covers the whole ox<letter>_ bearer-token
+// family (oxp_ personal, oxt_ team, and any family minted later).
+//
+// Failure prevented: a SageOx token pasted into a prompt — or captured from a
+// shell adapter running `echo $SAGEOX_TOKEN` — written verbatim to raw.jsonl,
+// uploaded, and synced to every teammate with ledger read access. A team token
+// authenticates AS THE TEAM, so that hands out team-scoped API access. Before
+// this pattern existed, DefaultPatterns covered GitHub, GitLab, Slack, and the
+// mk_ SageOx API key, but nothing matched our own bearer tokens.
+//
+// The negative rows are the other half: this is a generic ox[a-z]_ pattern, so
+// without the \b anchor it matches inside proxy_, and a captured transcript
+// discussing proxy_endpoint_override would be silently rewritten.
+func TestRedactString_SageOxBearerTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantFind bool
+	}{
+		{
+			name:     "team token — largest blast radius",
+			input:    "SAGEOX_TOKEN=oxt_deadbeefdeadbeefdead_1ljPfr",
+			wantFind: true,
+		},
+		{
+			name:     "personal token",
+			input:    "export SAGEOX_TOKEN=oxp_deadbeefdeadbeefdead_4bDZfN",
+			wantFind: true,
+		},
+		{
+			name:     "a family minted later is covered without a code change",
+			input:    "using oxz_deadbeefdeadbeefdead for the call",
+			wantFind: true,
+		},
+		{
+			name:     "bare token mid-sentence",
+			input:    "the token oxt_deadbeefdeadbeefdead expired",
+			wantFind: true,
+		},
+		{
+			name:     "proxy_ must survive — no left boundary would eat it",
+			input:    "failed to dial via proxy_endpoint_override: connection refused",
+			wantFind: false,
+		},
+		{
+			name:     "PROXY env var must survive",
+			input:    "HTTPS_PROXY=http://proxy_internal_corp:3128",
+			wantFind: false,
+		},
+		{
+			name:     "too short to be a credential",
+			input:    "oxt_abc",
+			wantFind: false,
+		},
+	}
+
+	r := NewRedactor()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redacted, found := r.RedactString(tt.input)
+			hasToken := containsPattern(found, "sageox_bearer_token")
+			assert.Equal(t, tt.wantFind, hasToken)
+			if tt.wantFind {
+				assert.NotContains(t, redacted, "deadbeefdeadbeefdead",
+					"the credential body must not survive redaction")
+			} else {
+				assert.Equal(t, tt.input, redacted,
+					"a non-credential must pass through byte-for-byte")
+			}
+		})
+	}
+}
+
 func TestRedactString_StripeKeys(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/twinapi/auth.go
+++ b/internal/twinapi/auth.go
@@ -184,6 +184,69 @@ func (tw *Twin) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleIntrospect handles GET /api/v1/auth/introspect.
+//
+// This is the single family-agnostic door the CLI uses to validate ANY bearer
+// credential and learn what principal it authenticates as. The twin only mints
+// session-derived JWTs, so every accepted credential resolves to a user
+// principal here; the response shape is the same one a team-service principal
+// would arrive in, with the other branch left null.
+//
+// Rejections answer a uniform 401 with {"error", "error_description"} rather
+// than a typed reason code. The description is therefore the ONLY signal the
+// client has to tell an operator why a credential was refused, which is why
+// each rejection path below carries a distinct one.
+func (tw *Twin) handleIntrospect(w http.ResponseWriter, r *http.Request) {
+	token := extractBearer(r)
+	if token == "" {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{
+			"error":             "invalid_token",
+			"error_description": "missing authorization header",
+		})
+		return
+	}
+
+	claims, err := tw.store.validateJWT(token)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{
+			"error":             "invalid_token",
+			"error_description": err.Error(),
+		})
+		return
+	}
+
+	// A signed credential only asserts who it was minted for — the principal
+	// must still exist. A deleted account whose JWT has not yet expired is a
+	// real rejection path, and one where a generic "authentication required"
+	// sends the operator chasing the wrong problem.
+	tw.store.mu.RLock()
+	_, ok := tw.store.users[claims.Sub]
+	tw.store.mu.RUnlock()
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{
+			"error":             "invalid_token",
+			"error_description": "user account not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"active":         true,
+		"principal_kind": "user",
+		"scope":          "full-access",
+		"token_type":     "Bearer",
+		"expires_at":     nil,
+		"user": map[string]string{
+			"id":    claims.Sub,
+			"email": claims.Email,
+			"name":  claims.Name,
+			"tier":  claims.Tier,
+		},
+		"team":  nil,
+		"token": nil,
+	})
+}
+
 // handleTokenRefresh handles POST /oauth2/token.
 // Accepts grant_type=refresh_token and returns a new JWT + refresh token.
 func (tw *Twin) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {

--- a/internal/twinapi/fixtures.go
+++ b/internal/twinapi/fixtures.go
@@ -84,6 +84,16 @@ func (tw *Twin) CreateOrphanedSession(fakeUserID string) *Session {
 	return sess
 }
 
+// DeleteUser removes a user from the store while leaving any JWT already minted
+// for them signed and unexpired. Models a deleted or deprovisioned account: the
+// credential still verifies cryptographically but no longer resolves to a
+// principal, which is the shape of the "valid token, vanished user" rejection.
+func (tw *Twin) DeleteUser(id string) {
+	tw.store.mu.Lock()
+	delete(tw.store.users, id)
+	tw.store.mu.Unlock()
+}
+
 // AdvanceTime moves the fake clock forward by d.
 func (tw *Twin) AdvanceTime(d time.Duration) {
 	tw.store.advanceClock(d)

--- a/internal/twinapi/handlers.go
+++ b/internal/twinapi/handlers.go
@@ -16,6 +16,9 @@ func (tw *Twin) apiMux() http.Handler {
 	// JWT exchange
 	mux.HandleFunc("GET /api/v1/cli/auth/token", tw.handleJWTExchange)
 
+	// token introspection — the family-agnostic validation door
+	mux.HandleFunc("GET /api/v1/auth/introspect", tw.handleIntrospect)
+
 	// OAuth2
 	mux.HandleFunc("GET /oauth2/userinfo", tw.handleUserInfo)
 	mux.HandleFunc("POST /oauth2/token", tw.handleTokenRefresh)

--- a/internal/twinapi/twin.go
+++ b/internal/twinapi/twin.go
@@ -2,7 +2,8 @@
 //
 // Each Twin instance runs two HTTP servers on ephemeral ports: an API server that
 // replicates the real SageOx auth surface (device flow, JWT exchange, userinfo,
-// token refresh, revocation) and an admin server for test control (user creation,
+// token introspection, token refresh, revocation) and an admin server for test
+// control (user creation,
 // fault injection, clock manipulation, call recording).
 //
 // The ox CLI points at the API port via SAGEOX_ENDPOINT and cannot distinguish

--- a/internal/twinapi/twin_test.go
+++ b/internal/twinapi/twin_test.go
@@ -277,6 +277,158 @@ func TestUserInfo_OpaqueTokenRejected(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
+// --- D2. Token introspection ---
+//
+// GET /api/v1/auth/introspect is the one door the CLI validates every bearer
+// credential through. Its 200 shape is what auth.IntrospectResult parses, and
+// its 401 error_description is the only rejection detail a client ever sees, so
+// both are asserted field by field rather than by status code alone.
+
+// introspect issues an introspection request with the given bearer token.
+func introspect(t *testing.T, tw *Twin, token string) (*http.Response, map[string]any) {
+	t.Helper()
+
+	req, err := http.NewRequest("GET", tw.APIURL+"/api/v1/auth/introspect", nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	return resp, body
+}
+
+// TestIntrospect_ValidJWT verifies the 200 body carries the full user principal.
+// Failure prevented: a response that parses but leaves User nil, which would let
+// callers render "identity resolved server-side" for a token that named a real
+// person.
+func TestIntrospect_ValidJWT(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("introspect@example.com", "Intro Spector")
+
+	resp, body := introspect(t, tw, fix.JWT)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, true, body["active"])
+	assert.Equal(t, "user", body["principal_kind"])
+	assert.Equal(t, "Bearer", body["token_type"])
+	assert.Nil(t, body["team"], "a user principal must not also carry a team branch")
+
+	user, ok := body["user"].(map[string]any)
+	require.True(t, ok, "user branch must be present for principal_kind=user")
+	assert.Equal(t, fix.UserID, user["id"])
+	assert.Equal(t, "introspect@example.com", user["email"])
+	assert.Equal(t, "Intro Spector", user["name"])
+	assert.Equal(t, "free", user["tier"])
+}
+
+// TestIntrospect_MissingAuthHeader verifies an unauthenticated request is
+// refused with a description naming the missing header.
+func TestIntrospect_MissingAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+
+	resp, body := introspect(t, tw, "")
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, "invalid_token", body["error"])
+	assert.Contains(t, body["error_description"], "missing authorization header")
+}
+
+// TestIntrospect_OpaqueTokenRejected verifies an opaque session token — not a
+// JWT — is refused, and that the reason says so.
+// Failure prevented: the original bug, where the CLI stored an opaque session
+// token as access_token and every local check called it valid.
+func TestIntrospect_OpaqueTokenRejected(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("opaque@example.com", "Opaque")
+
+	resp, body := introspect(t, tw, fix.SessionToken)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Contains(t, body["error_description"], "malformed JWT")
+}
+
+// TestIntrospect_ExpiredJWT verifies a once-valid credential is refused after
+// the clock passes its expiry, with expiry named as the reason.
+func TestIntrospect_ExpiredJWT(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("stale@example.com", "Stale")
+
+	tw.AdvanceTime(25 * time.Hour)
+
+	resp, body := introspect(t, tw, fix.JWT)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Contains(t, body["error_description"], "expired")
+}
+
+// TestIntrospect_DeletedUser verifies that a cryptographically valid, unexpired
+// JWT is still refused once its principal no longer exists — and that the
+// description says which of the two it was.
+// Failure prevented: a deprovisioned account reported to the operator as a
+// generic auth failure, sending them to rotate a credential that is fine.
+func TestIntrospect_DeletedUser(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("vanished@example.com", "Vanished")
+
+	// the JWT is accepted while the account exists
+	okResp, _ := introspect(t, tw, fix.JWT)
+	require.Equal(t, http.StatusOK, okResp.StatusCode)
+
+	tw.DeleteUser(fix.UserID)
+
+	resp, body := introspect(t, tw, fix.JWT)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, "invalid_token", body["error"])
+	assert.Contains(t, body["error_description"], "user account not found")
+}
+
+// TestIntrospect_FaultInjectionIsPathGeneric verifies the fault middleware and
+// the call recorder key off the request path, so the introspection route gets
+// them for free.
+// Failure prevented: a middleware that only knows the legacy OAuth2 paths,
+// which would silently make every introspection fault test a no-op.
+func TestIntrospect_FaultInjectionIsPathGeneric(t *testing.T) {
+	t.Parallel()
+
+	tw := Start(t)
+	fix := tw.WithAuthenticatedUser("faulted@example.com", "Faulted")
+
+	tw.InjectFault("/api/v1/auth/introspect", http.StatusServiceUnavailable)
+
+	req, err := http.NewRequest("GET", tw.APIURL+"/api/v1/auth/introspect", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+fix.JWT)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	tw.AssertCalled(t, "GET", "/api/v1/auth/introspect")
+
+	// clearing the fault restores the route
+	tw.ClearFaults()
+
+	after, _ := introspect(t, tw, fix.JWT)
+	assert.Equal(t, http.StatusOK, after.StatusCode)
+}
+
 // --- E. Token refresh ---
 
 // TestTokenRefresh_HappyPath verifies refresh returns a new JWT and rotates


### PR DESCRIPTION
## What this PR ships

Unifies SageOx token validation behind a single family-agnostic introspection endpoint, adds the team-token (`oxt_`) family, and adds a local CRC precheck for `SAGEOX_TOKEN` — plus the repairs an adversarial review found in the **rejection paths**, which is where almost all the new behavior lives and where none of the original tests pointed.

## What broke, and why it mattered

The original change was careful on the happy path. Every defect below sat on a path that only executes when something has already gone wrong.

- **Silent principal substitution.** A CRC-failing `SAGEOX_TOKEN` made `tokenFromEnv` return `nil` — indistinguishable from *unset* — so both `GetTokenForEndpoint` variants fell through to `auth.json`. A developer running a script that exports a truncated team token had every API call, ledger write, and murmur attributed to **themselves**, while `ox status` showed a green check and their name.
- **The new diagnostic was unreachable.** `envSourced` is derived from `tokenFromEnv(ep) != nil`, so on the rejection path the entire `SAGEOX_TOKEN (env) rejected` block — including the family-aware `oxt_` guidance added in the same change — was dead code for exactly the failure it was written to explain.
- **Offline was reported as rejected.** `Introspect` distinguishes "could not reach" from "server said no"; the renderer collapsed both. A developer on a plane with a valid token was told `(✗ not authenticated)` and advised to `mint a fresh PAT` — a credential rotation prescribed for a VPN fault.
- **Seven tests were skipped** on the stated grounds that `twinapi` is "shared infrastructure outside this package's scope" and the un-skip was "tracked as follow-up." Neither was true: `twinapi` is `internal/` in this repo, and no tracking issue existed. With `TestRequireAuth_AuthRequired_ValidToken` disabled, **no test anywhere proved the auth gate ever succeeds** — mutating `middleware.go` to reject every user left the suite green.
- **Two redaction gaps.** `ox[a-z]_` has no left boundary, so `proxy_endpoint_override` in a log line was rewritten to `pr[REDACTED]`. And the *session* redactor — a second, independent pipeline — had no ox-family pattern at all, so a team token pasted into a prompt landed verbatim in `raw.jsonl` and synced to every teammate with ledger read access.

```mermaid
flowchart TD
    A["SAGEOX_TOKEN set"] --> B{"CRC precheck"}
    B -- pass --> C["Introspect"]
    B -- "fail (before)" --> D["return nil"]
    D --> E["indistinguishable from unset"]
    E --> F["fall back to auth.json"]
    F --> G["runs as the human<br/>status shows a green check"]
    B -- "fail (now)" --> H["EnvTokenMalformed"]
    H --> I["fail closed + name SAGEOX_TOKEN"]
    C -- "network error" --> J["ErrEndpointUnreachable<br/>? could not verify"]
    C -- "non-200" --> K["✗ rejected"]
    C -- 200 --> L["render principal"]

    style G fill:#b3261e,color:#fff
    style I fill:#1e6b3a,color:#fff
    style J fill:#7a5b00,color:#fff
```

## Changes

- **Fail closed.** `EnvTokenFor` reports `Absent` / `Valid` / `Malformed`. A malformed value refuses to fall back to a stored login; an env token bound to a *different* endpoint still falls back, because there it was never meant for this endpoint.
- **Normalize before classifying.** Trailing newlines (`$(cat secret)`, K8s file-mounted secrets, YAML block scalars), surrounding quotes, and an accidental `Bearer ` prefix are stripped. Previously tail corruption was blamed on the user as a "typo" and head corruption bypassed the format gate entirely.
- **`ox status` gains a third verdict state** — `(? could not verify)` — because `✓` claims something unearned and `✗` is an outright false statement about a credential nobody judged. Also renders the introspected identity for `principal_kind: "user"` instead of discarding the answer the server gave.
- **`ox doctor` and `ox agent prime`** stop prescribing `ox login` for a truncated env token; an env token wins over disk, so that login would succeed and every command after it would fail identically.
- **Introspection hardening:** unreachable-vs-rejected sentinel, redacted error strings (the slog hook never sees a returned `error`), tolerant `expires_at` parsing, a bounded body read, and no longer discarding a good `error_description` because a sibling field had the wrong type.
- **twinapi grows `handleIntrospect`** (~30 lines, modeled on `handleUserInfo`) and all seven skips are deleted.

## Test Plan

- Every behavioral fix carries a **red-first proof in both directions** — break it, watch the gate fail, restore it, watch it pass.
- **The padding blind spot is the one to look at.** `base62Encode` pads zero to `"0000"` but emits no padding for small nonzero values. Both pinned golden vectors encode to 6 characters — the maximal length class — so a padding mismatch against the server would pass them silently while rejecting **21.3% of validly-minted tokens** as typos. `TestBase62Encode_LengthClasses` pins all five length classes; under a left-pad mutation the new rows go red while the golden vectors stay green.
- `TestRenderAuthStatus_MalformedEnvTokenMustNotSilentlyFallBackToDiskIdentity` asserts the security property: the declared principal is honored, or nothing is.
- `renderIdentity` extracted as a pure function, turning a ~12-cell render matrix into a no-I/O table test. It immediately surfaced two cells the integration tests could never reach.
- Cut as theater: `TestTokenPrefixes` and `TestIntrospectEndpoint` asserted constants against their own declarations.
- Gates: `go build ./...`, `gofmt`, `internal/auth`, `internal/logger`, `internal/session`, `internal/twinapi`, `cmd/ox` — all green.

## Needs a human before merge

**Confirm six vectors against the server's token package.** The CRC mirror's golden values were computed independently here, so they prove self-consistency only. If the server disagrees on even one row, that is a live ~21% token-rejection bug, not a test to update:

| input | expected | len |
|---|---|---|
| `oxp_test` | `4bDZfN` | 6 |
| `oxt_test` | `1ljPfr` | 6 |
| `oxp_a` | `b6CVb` | 5 |
| `oxp_bk` | `oGjm` | 4 |
| `oxp_tsa` | `2hW` | 3 |
| `oxp_cngh` | `o8` | 2 |

## Follow-ups (filed, not in scope)

- `ox-3osy` — `ox login` succeeds while a malformed `SAGEOX_TOKEN` keeps winning, producing a green login followed by unexplained failures.
- Security review flagged `go-git/v6` pinned to `v6.0.0-alpha.4` with a known CVE, reachable via codedb indexing. Pre-existing, unrelated to this diff.
