### PR TITLE
fix(login): report a login shadowed by a malformed SAGEOX_TOKEN

### DIFF
--- a/cmd/ox/login.go
+++ b/cmd/ox/login.go
@@ -265,6 +265,25 @@ func selectLoginEndpoint() (string, error) {
 }
 
 // runLoginFlow executes the login flow for a specific endpoint
+// loginShadowedByEnvToken reports whether a login for ep is unusable because
+// SAGEOX_TOKEN holds a value that is set, bound to this endpoint, and refused by
+// the local format check.
+//
+// This is the "green login, then nothing works" case: the device flow stores a
+// perfectly good credential, but the env token takes precedence and is itself
+// refused, so every later command fails with nothing pointing back at login.
+//
+// tokenErr may be nil — callers ask this both before the flow (to warn early,
+// rather than spending the user's time first) and after it (where the sentinel
+// arrives via the token lookup). Either signal alone is sufficient.
+func loginShadowedByEnvToken(ep string, tokenErr error) bool {
+	if errors.Is(tokenErr, auth.ErrEnvTokenMalformed) {
+		return true
+	}
+	_, state := auth.EnvTokenFor(ep)
+	return state == auth.EnvTokenMalformed
+}
+
 func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 	out := cmd.OutOrStdout()
 	// check if already authenticated for this endpoint
@@ -288,6 +307,17 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 			fmt.Fprintln(out, "Authentication canceled.")
 			return nil
 		}
+	}
+
+	// An env token SHADOWS whatever this login is about to store, so say that
+	// BEFORE spending the user's time on a device flow. A malformed one is the
+	// worst case: it is refused, but it also refuses to fall back to the
+	// credential we are about to write, so the login would appear to work and
+	// every later command would fail with no visible connection to this moment.
+	if loginShadowedByEnvToken(currentEndpoint, nil) {
+		cli.PrintWarningTo(out, auth.EnvVarToken+" is set but its value failed a local format check.")
+		fmt.Fprintf(out, "  It takes precedence over any stored login, so logging in will not\n")
+		fmt.Fprintf(out, "  make %s usable until you re-copy or unset it.\n\n", auth.EnvVarToken)
 	}
 
 	authClient := auth.NewAuthClient().WithEndpoint(currentEndpoint)
@@ -403,6 +433,18 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 	// get token to display success message
 	token, err := authClient.GetToken()
 	if err != nil {
+		// The credential IS stored — the device flow completed and wrote it.
+		// A malformed env token is simply shadowing it, so reporting a bare
+		// failure here would be false and would send the user back around a
+		// flow that already worked. Name the one thing standing in the way.
+		if loginShadowedByEnvToken(currentEndpoint, err) {
+			cli.PrintSuccessTo(out, "Authenticated. Your login was stored.")
+			cli.PrintWarningTo(out, auth.EnvVarToken+" is still shadowing it and is not usable.")
+			fmt.Fprintf(out, "\n  unset %s\n\n", auth.EnvVarToken)
+			fmt.Fprintf(out, "  ...or re-copy the token if you meant to use it — a truncated\n")
+			fmt.Fprintf(out, "  paste is the usual cause.\n")
+			return nil
+		}
 		return fmt.Errorf("authentication succeeded but failed to retrieve token: %w", err)
 	}
 

--- a/cmd/ox/login_env_shadow_test.go
+++ b/cmd/ox/login_env_shadow_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sageox/ox/internal/auth"
+)
+
+// TestLoginShadowedByEnvToken covers the "green login, then nothing works" case.
+//
+// Failure prevented: a user with a truncated SAGEOX_TOKEN runs `ox login`, the
+// device flow completes and stores a good credential, and then every subsequent
+// command fails — because the env token takes precedence and is itself refused.
+// Without this predicate, `ox login` either reports a bare
+// "authentication succeeded but failed to retrieve token" (false: the login
+// worked and was stored) or, before the fail-closed change, reported plain
+// success and left the user with no way to connect the two events.
+//
+// These use t.Setenv, which is incompatible with t.Parallel — env-token
+// resolution is process-global, matching the serial pattern internal/auth's own
+// env-token tests use.
+func TestLoginShadowedByEnvToken(t *testing.T) {
+	const ep = "https://sageox.ai"
+
+	// a CRC-failing value: the pinned personal vector with a corrupted final
+	// character, i.e. exactly the shape of a truncated or mistyped paste.
+	const malformed = "oxp_test_4bDZfX"
+	// the same vector, intact.
+	const valid = "oxp_test_4bDZfN"
+
+	tests := []struct {
+		name     string
+		envToken string
+		// endpoint SAGEOX_ENDPOINT is pinned to; "" means leave it unset so the
+		// env token binds to the production default.
+		envEndpoint string
+		tokenErr    error
+		want        bool
+	}{
+		{
+			name:     "malformed env token shadows the stored login",
+			envToken: malformed,
+			want:     true,
+		},
+		{
+			name:     "sentinel from the post-login token lookup is sufficient on its own",
+			envToken: "",
+			tokenErr: fmt.Errorf("wrapped: %w", auth.ErrEnvTokenMalformed),
+			want:     true,
+		},
+		{
+			name:     "a valid env token is not a shadow — it is a working credential",
+			envToken: valid,
+			want:     false,
+		},
+		{
+			name:     "no env token at all",
+			envToken: "",
+			want:     false,
+		},
+		{
+			name: "an unrelated token-lookup failure must not be reported as a shadow",
+			// this is the guard against over-reach: a genuine failure to read
+			// auth.json must still surface as an error, not be swallowed into a
+			// cheerful "your login was stored" message.
+			envToken: "",
+			tokenErr: errors.New("failed to parse auth file"),
+			want:     false,
+		},
+		{
+			name: "malformed env token bound to a DIFFERENT endpoint does not shadow this one",
+			// the env token was never meant for this endpoint, so a login here
+			// is genuinely usable and must not be reported as shadowed.
+			envToken:    malformed,
+			envEndpoint: "https://staging.sageox.ai",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(auth.EnvVarToken, tt.envToken)
+			if tt.envEndpoint != "" {
+				t.Setenv("SAGEOX_ENDPOINT", tt.envEndpoint)
+			}
+
+			got := loginShadowedByEnvToken(ep, tt.tokenErr)
+			if got != tt.want {
+				t.Errorf("loginShadowedByEnvToken(%q, %v) = %v, want %v", ep, tt.tokenErr, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this fixes

Follow-up to #776. Closes the last user-visible gap that the token-hardening work left behind: `ox login` could not tell the user that the login it just completed was unusable.

## The failure

`SAGEOX_TOKEN` takes precedence over any stored login. #776 made a CRC-failing value **fail closed** rather than silently substituting the disk credential — the right call, and it fixed the silent principal substitution. But it left `ox login` in an odd spot:

- The device flow runs, completes, and **stores a perfectly good credential**.
- The token lookup that follows then hits the fail-closed path, because the malformed env token still wins.
- The user sees `authentication succeeded but failed to retrieve token: ...` — which is **false**. The login worked. It is stored. One env var is standing in front of it.

So the user is sent back around a flow that already succeeded, with no indication that the fix is `unset SAGEOX_TOKEN`.

```mermaid
flowchart TD
    A["ox login"] --> B{"SAGEOX_TOKEN set<br/>and malformed?"}
    B -- no --> C["device flow → Welcome back"]
    B -- "yes (before)" --> D["device flow runs<br/>credential IS stored"]
    D --> E["token lookup fails closed"]
    E --> F["'authentication succeeded but<br/>failed to retrieve token'"]
    F --> G["user retries the same flow<br/>forever"]
    B -- "yes (now)" --> H["warn BEFORE the flow"]
    H --> I["device flow runs<br/>credential IS stored"]
    I --> J["'Authenticated. Your login was stored.'<br/>'SAGEOX_TOKEN is still shadowing it.'<br/>unset SAGEOX_TOKEN"]

    style G fill:#b3261e,color:#fff
    style J fill:#1e6b3a,color:#fff
```

## Changes

- **Warn before the flow, not after.** If `SAGEOX_TOKEN` is set and malformed for the target endpoint, say so before opening a browser — spending the user's time on a flow whose result they cannot use is the avoidable part.
- **Report the honest outcome after.** The credential *was* stored, so the message says that, then names the one thing in the way and gives the exact remedy. Returns success rather than a misleading error.
- **`loginShadowedByEnvToken(ep, tokenErr)`** extracted as the decision point, so it is testable without standing up a device flow. It accepts either signal — the pre-flow state check or the post-flow `ErrEnvTokenMalformed` sentinel — because the two arrive at different moments and either alone is sufficient.

## Test Plan

`TestLoginShadowedByEnvToken`, six rows, proven red in **both** directions:

| Neuter | Row that goes red |
|---|---|
| No shadow detection (the pre-fix state) | `malformed env token shadows the stored login`, `sentinel from the post-login token lookup` |
| Over-reach — treat *any* token error as a shadow | `an unrelated token-lookup failure must not be reported as a shadow` |

That second neuter is the one worth having. Without its row, an over-broad edit would swallow a genuine `auth.json` read failure into a cheerful "your login was stored" — turning a real error into a false success, which is the same class of bug this PR exists to remove.

Two rows guard the boundary rather than the happy path:

- **A valid env token is not a shadow.** It is a working credential and must not trigger the warning.
- **A malformed env token bound to a *different* endpoint does not shadow this one.** It was never meant for this endpoint, so a login here is genuinely usable. This mirrors the same absent-vs-malformed distinction `EnvTokenFor` draws.

Gates: `gofmt`, `go build ./...`, full `cmd/ox` suite (145s) — all green.

## Also in this branch

Nothing. Scoped to the one fix.

## Still outstanding from #776

**The CRC mirror vectors remain unverified** — unchanged from #776, repeated here so it does not get lost. `base62Encode` pads zero but not small nonzero values, and both pinned golden vectors sit in the 6-character maximal class, so a padding mismatch against the server would pass them silently while rejecting ~21% of validly-minted tokens as typos. The six vectors are tabled in #776 and need confirming against the server's token package by someone with access.
