### PR TITLE
fix(carts): detect the running dolt server and connect as root

### DIFF
--- a/internal/carts/server.go
+++ b/internal/carts/server.go
@@ -3,6 +3,7 @@ package carts
 import (
 	"database/sql"
 	"fmt"
+	"github.com/sageox/ox/internal/proc"
 	"net"
 	"os"
 	"os/exec"
@@ -42,14 +43,11 @@ func runningServerPort(cartsDir string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	// Check if process is alive
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return 0, err
-	}
-	// Signal 0 checks if process exists
-	if err := proc.Signal(os.Signal(nil)); err != nil {
-		return 0, fmt.Errorf("server process %d not running: %w", pid, err)
+	// Check if process is alive. (Signal(nil) always fails with "unsupported
+	// signal type", which made every call believe the server was dead and try
+	// to start a second one against the same locked database.)
+	if !proc.IsAlive(pid) {
+		return 0, fmt.Errorf("server process %d not running", pid)
 	}
 
 	portData, err := os.ReadFile(filepath.Join(cartsDir, portFileName))

--- a/internal/carts/server_test.go
+++ b/internal/carts/server_test.go
@@ -1,0 +1,50 @@
+package carts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// runningServerPort must return the recorded port when the pid file names a
+// live process, and an error when it names a dead one. Before the fix the
+// liveness check used proc.Signal(os.Signal(nil)), which always errored, so a
+// live server was never detected and every call started a second sql-server.
+func TestRunningServerPort(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// No pid file → not running.
+	if _, err := runningServerPort(dir); err == nil {
+		t.Fatal("expected error with no pid file")
+	}
+
+	// Live process (ourselves) + port file → port is returned.
+	writeFile(pidFileName, strconv.Itoa(os.Getpid()))
+	writeFile(portFileName, "50422")
+	port, err := runningServerPort(dir)
+	if err != nil {
+		t.Fatalf("live pid: unexpected error: %v", err)
+	}
+	if port != 50422 {
+		t.Fatalf("live pid: port = %d, want 50422", port)
+	}
+
+	// Dead process → error. Spawn a short-lived child and wait for it so the
+	// pid is guaranteed to be gone.
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Skipf("cannot spawn helper process: %v", err)
+	}
+	writeFile(pidFileName, strconv.Itoa(cmd.Process.Pid))
+	if _, err := runningServerPort(dir); err == nil {
+		t.Fatal("expected error for dead pid")
+	}
+}

--- a/internal/carts/store.go
+++ b/internal/carts/store.go
@@ -55,12 +55,12 @@ func New(ctx context.Context, cfg *Config) (*Store, error) {
 		}
 	}
 
-	user := cfg.CommitterName
-	if user == "" {
-		user = "root"
-	}
-	dsn := fmt.Sprintf("%s@tcp(%s:%d)/?parseTime=true&interpolateParams=true&timeout=5s&readTimeout=30s&writeTimeout=30s",
-		user, cfg.ServerHost, port)
+	// Connect as root: the sql-server is one we start on loopback with the
+	// default (root@localhost, no password) account, and no other user exists
+	// there. Connecting as the committer name failed with "Access denied" on
+	// Dolt 2.x. Commit authorship is passed explicitly via DOLT_COMMIT --author.
+	dsn := fmt.Sprintf("root@tcp(%s:%d)/?parseTime=true&interpolateParams=true&timeout=5s&readTimeout=30s&writeTimeout=30s",
+		cfg.ServerHost, port)
 
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {


### PR DESCRIPTION
## What broke

`ox carts` failed on developer machines with Dolt 2.x — first with `ensure dolt server: timeout waiting for dolt server on port N`, and (when it did reach a server) with `ping dolt server: Error 1045 (28000): Access denied for user '<attribution name>'`. Two independent bugs in `internal/carts`:

- **The liveness check always failed.** `runningServerPort` called `proc.Signal(os.Signal(nil))`, which returns `unsupported signal type` unconditionally. So every invocation concluded the server was dead and started a *second* `dolt sql-server` on the same database. Dolt refuses (`database "dolt" is locked by another dolt process`), the new process exits, `waitForServer` times out after 30s, and the pid/port files now name a dead process while the first server is orphaned. Each retry adds another orphan.
- **Wrong DB user.** `Store.New` connected as `cfg.CommitterName` (the SageOx attribution name, e.g. `Vikas Gupta`). The sql-server we start has only `root@localhost`, and nothing ever creates that user → `1045 Access denied`. Commit authorship never depended on the DB user — it is passed explicitly via `CALL DOLT_COMMIT('-m', ?, '--author', ?)`.

```mermaid
flowchart LR
  A["ox carts …"] --> B{"pid file →<br/>proc.Signal(nil)"}
  B -->|"always errors"| C["start 2nd sql-server<br/>same dolt dir"]
  C --> D["Dolt: locked by<br/>another process → exit"]
  D --> E["waitForServer<br/>30s timeout"]
  B -.->|"first run after boot"| F["connect as<br/>attribution name"]
  F --> G["1045 Access denied<br/>(only root exists)"]
```

## What this PR ships

- **`server.go`** — liveness via the existing `proc.IsAlive(pid)` (kill -0), so a running server is reused and no second one is started.
- **`store.go`** — connect as `root` (loopback server we started, default account); drop the committer-name DSN. Authorship unchanged (`--author`).
- **`server_test.go`** — `TestRunningServerPort`: no pid file → error; live pid + port file → port; dead pid → error.
- **CHANGELOG** — Unreleased / Fixed entry.

## Test Plan

- `go vet ./internal/carts/ && go test -race ./internal/carts/` — pass.
- Locally on macOS with Dolt 2.2.3: killed the orphaned `dolt sql-server` processes, removed stale pid/port files, ran `ox carts list` twice in a row → both succeed (`No carts found.`), exactly one `dolt sql-server` process, pid file names it.
- Before the fix on the same machine: first call → `1045 Access denied`; second call → 30s timeout, second server in `ps`.

---
<details>
<summary>Checklist</summary>

- [x] Tests added
- [x] CHANGELOG entry added
- [ ] Breaking change — none
- [x] `/security-review` — N/A: no auth/mcp/raw_writer/prepush/upgrade/go.sum changes; the DB user change is on a loopback-only server this process starts itself.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of whether the local database server is still running.
  * Clarified errors when the server process is no longer active.
  * Improved local database connection reliability by separating login credentials from commit authorship settings.

* **Tests**
  * Added coverage for missing process files, active servers, and stopped processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->