### PR TITLE
refactor(prime): source OMP from agentx v0.1.14, drop OMP-specific bypass

### DIFF
--- a/cmd/ox/agent_prime.go
+++ b/cmd/ox/agent_prime.go
@@ -156,12 +156,14 @@ func initAgentPrimeCmd() {
 // LIMITATION: Running `claude "prompt"` executes the prompt BEFORE any hooks fire,
 // so ox cannot intercept this invocation. Users must run `claude` without a prompt
 // argument to allow the session-start hook to run `ox agent prime` first.
-func bypassAgentDetection(explicitAgent string) bool {
-	return prime.CanonicalAgentType(explicitAgent) == prime.AgentTypeOMP
-}
-
+// requireDetectedOrExplicitAgent gates `ox agent prime` on running inside a
+// coding agent. An explicit, recognized --agent is authoritative and satisfies
+// the gate without ambient detection: the caller has named the agent, and some
+// agents (e.g. OMP / Oh My Pi) export no environment marker ox can detect from
+// its own process — `_` is the ox binary, not the parent agent. agentx knows
+// OMP natively as of v0.1.14, so it is no longer special-cased here.
 func requireDetectedOrExplicitAgent(explicitAgent string) error {
-	if bypassAgentDetection(explicitAgent) {
+	if prime.IsAgentSupported(explicitAgent) {
 		return nil
 	}
 	if errMsg := agentx.RequireAgent("ox agent prime"); errMsg != "" {

--- a/cmd/ox/agent_prime_gate_test.go
+++ b/cmd/ox/agent_prime_gate_test.go
@@ -3,21 +3,27 @@ package main
 import (
 	"testing"
 
+	"github.com/sageox/ox/internal/prime"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRequireDetectedOrExplicitAgentAcceptsOMP(t *testing.T) {
+// An explicit, recognized --agent satisfies the prime gate without ambient
+// detection — including agents (OMP) that export no marker ox can detect from
+// its own process. Supported agents return nil regardless of AGENT_ENV.
+func TestRequireDetectedOrExplicitAgentAcceptsSupportedAgents(t *testing.T) {
 	t.Setenv("AGENT_ENV", "")
-	require.NoError(t, requireDetectedOrExplicitAgent("omp"))
+	for _, agent := range []string{"omp", "Oh My Pi", "claude-code", "pi"} {
+		require.NoError(t, requireDetectedOrExplicitAgent(agent),
+			"explicit --agent %q should satisfy the gate", agent)
+	}
 }
 
-func TestOnlyOMPBypassesAgentDetection(t *testing.T) {
-	if bypassAgentDetection("typo") {
-		t.Fatal("arbitrary --agent value bypassed agent detection")
-	}
-	if !bypassAgentDetection("Oh My Pi") {
-		t.Fatal("OMP display name did not bypass agent detection")
-	}
+// A typo/unknown --agent must NOT get a free pass: it is not "supported", so
+// the gate falls through to ambient detection (which fails outside an agent).
+// Asserted via the predicate to stay independent of the host's agent markers.
+func TestUnsupportedExplicitAgentDoesNotAutoPass(t *testing.T) {
+	require.False(t, prime.IsAgentSupported("typo"))
+	require.True(t, prime.IsAgentSupported("Oh My Pi"))
 }
 
 func TestSessionWatchModeUsesTailForOMP(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/sageox/agentx v0.1.13
+	github.com/sageox/agentx v0.1.14
 	github.com/sageox/frictionax v0.1.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sageox/agentx v0.1.13 h1:UX5XeXYQWSTLCp7C6+MSnehGrUmwiq9ayhnLRDssil0=
 github.com/sageox/agentx v0.1.13/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
+github.com/sageox/agentx v0.1.14 h1:iHU1PCgCbxiB211WspTPyJQhqmIxkrYzWfGQwduXkjE=
+github.com/sageox/agentx v0.1.14/go.mod h1:J/hA2opcWUvbI+11QSdTJBxT4WOP3ReZtF7L1d7Z/no=
 github.com/sageox/frictionax v0.1.2 h1:iQfssC1g/vVdGXi55smMfY5/4JKcQbJXRzcwrQWiNLo=
 github.com/sageox/frictionax v0.1.2/go.mod h1:Mnlre6UE4F95yX2xAhx4fJ5AKJiNThBDZIyav04O6lo=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=

--- a/internal/prime/agent_type.go
+++ b/internal/prime/agent_type.go
@@ -7,8 +7,6 @@ import (
 	"github.com/sageox/agentx"
 )
 
-const AgentTypeOMP = "omp"
-
 // SupportedAgents lists officially supported coding agents for MVP.
 // Other agents may work but quality of guidance is not guaranteed.
 var SupportedAgents = map[string]bool{
@@ -17,7 +15,7 @@ var SupportedAgents = map[string]bool{
 	string(agentx.AgentTypeGemini):     true,
 	string(agentx.AgentTypeAmp):        true,
 	string(agentx.AgentTypePi):         true,
-	AgentTypeOMP:                       true,
+	string(agentx.AgentTypeOMP):        true,
 	string(agentx.AgentTypeGoose):      true,
 }
 
@@ -38,7 +36,7 @@ func CanonicalAgentType(agentType string) string {
 	case "pi", "pi-coding-agent", "pi agent":
 		return string(agentx.AgentTypePi)
 	case "omp", "oh-my-pi", "oh my pi":
-		return AgentTypeOMP
+		return string(agentx.AgentTypeOMP)
 	case "goose":
 		return string(agentx.AgentTypeGoose)
 	}
@@ -87,7 +85,7 @@ func ClassifyAgentTier(agentType string) AgentTier {
 	// compaction event, so primed context does not survive a Goose compaction.
 	case string(agentx.AgentTypeCodex), string(agentx.AgentTypeGemini), string(agentx.AgentTypeGoose):
 		return TierSilver
-	case string(agentx.AgentTypeAmp), string(agentx.AgentTypeOpenCode), string(agentx.AgentTypePi), AgentTypeOMP:
+	case string(agentx.AgentTypeAmp), string(agentx.AgentTypeOpenCode), string(agentx.AgentTypePi), string(agentx.AgentTypeOMP):
 		return TierBronze
 	default:
 		return TierUnknown


### PR DESCRIPTION
## Summary

Anyone extending ox now gets OMP (Oh My Pi) detection "for free" from agentx instead of a bespoke shim in ox — this pays down the one piece of debt #779 deliberately took on to stay self-contained. [sageox/agentx#15](https://github.com/sageox/agentx/pull/15) shipped `AgentTypeOMP` + native OMP detection (released as **v0.1.14**), so ox no longer has to carry its own OMP constant or special-case the prime gate.

**Approach:** bump agentx to v0.1.14, make it the single source of truth for the OMP slug, and generalize the prime gate so *any* explicit supported `--agent` satisfies it — deleting the OMP-only bypass.

## What changed

| File | Change |
|---|---|
| `go.mod` / `go.sum` | `github.com/sageox/agentx` v0.1.13 → **v0.1.14** |
| `internal/prime/agent_type.go` | Delete local `const AgentTypeOMP = "omp"`; use `agentx.AgentTypeOMP` in `SupportedAgents`, `CanonicalAgentType`, `ClassifyAgentTier` |
| `cmd/ox/agent_prime.go` | Delete `bypassAgentDetection`; `requireDetectedOrExplicitAgent` now accepts any `prime.IsAgentSupported` explicit `--agent` |
| `cmd/ox/agent_prime_gate_test.go` | Assert the generalized gate + a deterministic unsupported-agent boundary |

## Behavior change worth a look

The prime gate previously bypassed ambient agent-detection **only for OMP**. It now bypasses for **any supported explicit `--agent`** (claude-code, codex, gemini, amp, pi, omp, goose). Rationale: an explicit, recognized `--agent` is the caller *asserting* the context — ambient detection is redundant. A typo/unknown value still falls through to `agentx.RequireAgent` and is rejected.

Why OMP still needs the explicit flag at all: it exports no environment marker ox can detect from its **own** process — `$_` is the `ox` binary, not the parent agent — so `AGENT_ENV=omp` (set by the installed `.omp/AGENTS.md` prime instruction) or the explicit flag remains the authoritative signal. agentx v0.1.14 detects OMP correctly when that signal is present; it is simply no longer *special-cased* in ox.

## Test Plan

- [x] `go build ./cmd/ox/... ./internal/prime/...`, `go vet ./internal/prime/...`
- [x] `go test ./internal/prime/...` — pass
- [x] `go test ./cmd/ox/ -run 'OMP|RequireDetectedOrExplicitAgent|UnsupportedExplicitAgent|SessionWatchModeUsesTailForOMP'` — pass
- [x] `golangci-lint run ./cmd/ox/ ./internal/prime/` — no new issues in changed files
- [x] No dangling refs to `bypassAgentDetection` / `prime.AgentTypeOMP`

<details><summary>Not in scope (tracked separately)</summary>

- The `session_roots.go` allowlist trust-model note from the #779 review (daemon-env-derived roots) — that's a security sign-off, not a code change, and is unrelated to this cleanup.
- The node-launched OMP + inherited `PI_CODING_AGENT` residual detection edge is documented in agentx `OMPAgent.DetectRuntime`; `--agent omp` / `DetectByType` is authoritative there.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Explicitly selected supported agents are now recognized during setup, including supported display names and agents without detectable markers.
  - Agent selection works consistently across all supported agent types.

- **Bug Fixes**
  - Unknown or unsupported agent names no longer bypass agent detection or proceed as valid selections.
  - Improved handling of agent identification when no explicit supported agent is provided.

- **Tests**
  - Expanded coverage for supported, unsupported, and undetectable agent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->