### PR TITLE
fix(carts): gate behind FEATURE_CARTS and harden dolt server reuse

### DIFF
--- a/cmd/ox/cart_analyze.go
+++ b/cmd/ox/cart_analyze.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/carts"
 	"github.com/sageox/ox/internal/glance"
 	"github.com/spf13/cobra"
@@ -23,6 +24,10 @@ Designed for consumption by Claude Code or Claude Cowork for visualization.`,
 func init() {
 	cartAnalyzeCmd.Flags().String("since", "24h", "Start of time window (e.g. 24h, 7d, 2026-03-20)")
 	cartAnalyzeCmd.Flags().String("until", "", "End of time window (default: now)")
+	// Hidden until carts is enabled; execution is gated in openCartsStore.
+	if !auth.IsCartsEnabled() {
+		cartAnalyzeCmd.Hidden = true
+	}
 	rootCmd.AddCommand(cartAnalyzeCmd)
 }
 

--- a/cmd/ox/carts.go
+++ b/cmd/ox/carts.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/sageox/ox/internal/auth"
 	"github.com/sageox/ox/internal/carts"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
@@ -13,6 +15,10 @@ import (
 	"github.com/sageox/ox/internal/repotools"
 	"github.com/spf13/cobra"
 )
+
+// errCartsDisabled is returned by every carts command when the feature is off.
+// Carts is experimental and gated behind FEATURE_CARTS (see auth.IsCartsEnabled).
+var errCartsDisabled = errors.New("ox carts is disabled — set FEATURE_CARTS=true to enable")
 
 // cartStartGuidance is the Layer-1 floor instruction returned with every
 // `ox carts start --json`. It travels in the CLI JSON so all coding agents
@@ -494,12 +500,26 @@ func init() {
 	cartsCmd.AddCommand(cartsReopenCmd)
 	cartsCmd.AddCommand(cartsDepCmd)
 
+	// Hide carts from --help until the feature is enabled. Execution is gated
+	// independently in openCartsStore, so an explicit `ox carts …` still errors
+	// cleanly when disabled.
+	if !auth.IsCartsEnabled() {
+		cartsCmd.Hidden = true
+	}
+
 	rootCmd.AddCommand(cartsCmd)
 }
 
 // --- helpers ---
 
 func openCartsStore(cmd *cobra.Command) (*carts.Store, *repotools.GitIdentity, error) {
+	// Single chokepoint: every carts subcommand and cart-analyze opens the store
+	// here, so gating the feature flag here disables them all before any local
+	// Dolt server is started.
+	if !auth.IsCartsEnabled() {
+		return nil, nil, errCartsDisabled
+	}
+
 	root, err := repotools.FindRepoRoot(repotools.VCSGit)
 	if err != nil {
 		return nil, nil, fmt.Errorf("not in a git repository")

--- a/cmd/ox/carts_test.go
+++ b/cmd/ox/carts_test.go
@@ -2,11 +2,25 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/sageox/ox/internal/carts"
 )
+
+// TestOpenCartsStoreDisabledByDefault guards the feature gate: with FEATURE_CARTS
+// unset (the default), openCartsStore — the single chokepoint every carts
+// subcommand and cart-analyze funnel through — must refuse before touching repo
+// config or starting a local Dolt server.
+// Failure prevented: carts shipping enabled-by-default and spawning Dolt on
+// machines that never opted in.
+func TestOpenCartsStoreDisabledByDefault(t *testing.T) {
+	t.Setenv("FEATURE_CARTS", "")
+	if _, _, err := openCartsStore(nil); !errors.Is(err, errCartsDisabled) {
+		t.Fatalf("expected errCartsDisabled with flag unset, got %v", err)
+	}
+}
 
 // TestCartStartOutputJSON verifies the JSON that runCartsStart emits in its
 // --json branch (cartStartOutput) carries a non-empty `guidance` key with the

--- a/cmd/ox/release_notes.md
+++ b/cmd/ox/release_notes.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Reviewer-first pull-request visuals** — `ox viz pr` selects prose, GitHub-safe Mermaid, or a rich attachment from the reviewer question; rich recipes now include construction-ready visual contracts, lightweight PNG checks, and personal, repository, and team preferences.
 
+### Changed
+
+- **`ox carts` is off by default** — the experimental carts feature (backed by a local Dolt sql-server) is now gated behind `FEATURE_CARTS` and hidden from `ox --help` until enabled. Set `FEATURE_CARTS=true` to opt in.
+
+### Fixed
+
+- **Reliable carts Dolt server reuse** — ox now validates that a recorded server actually answers before reusing it (rejecting a stale port left by a crashed server whose PID was recycled), serializes startup with an advisory lock so concurrent invocations can't spawn duplicate servers, and publishes the server's pid/port only after it accepts connections.
+
 ## [0.14.0] - 2026-08-15
 
 Skills now reach each AI coworker through its native discovery mechanism, while SageOx keeps project-scoped installations safe, consistent, and repairable.

--- a/internal/auth/feature.go
+++ b/internal/auth/feature.go
@@ -64,3 +64,11 @@ func IsMemoryEnabled() bool {
 	value := strings.ToLower(os.Getenv("FEATURE_MEMORY"))
 	return value == "true" || value == "1" || value == "yes"
 }
+
+// IsCartsEnabled checks if the carts feature (ox carts, ox cart-analyze) is enabled.
+// Carts is experimental, backed by a locally started Dolt sql-server, and
+// disabled by default. Set FEATURE_CARTS=true to enable.
+func IsCartsEnabled() bool {
+	value := strings.ToLower(os.Getenv("FEATURE_CARTS"))
+	return value == "true" || value == "1" || value == "yes"
+}

--- a/internal/carts/server.go
+++ b/internal/carts/server.go
@@ -3,6 +3,7 @@ package carts
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -69,7 +70,7 @@ func EnsureServer(cartsDir string) (int, error) {
 		return nil
 	})
 	if lockErr != nil {
-		return 0, lockErr
+		return 0, fmt.Errorf("start carts dolt server: %w", lockErr)
 	}
 	return port, nil
 }
@@ -152,19 +153,35 @@ func startServer(cartsDir string) (int, error) {
 	// Wait for readiness BEFORE publishing state, so a concurrent reader never
 	// observes a pid/port for a server that isn't accepting connections yet.
 	if err := waitForServer(serverHost, port, serverStartTimeout); err != nil {
-		_ = cmd.Process.Kill() // don't orphan a half-started server
+		stopProcess(cmd) // don't orphan a half-started server
 		return 0, fmt.Errorf("server failed to start: %w", err)
 	}
 
-	// Publish reusable state only after the server is ready.
-	if err := os.WriteFile(filepath.Join(cartsDir, pidFileName), []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil {
-		return 0, err
-	}
-	if err := os.WriteFile(filepath.Join(cartsDir, portFileName), []byte(strconv.Itoa(port)), 0o644); err != nil {
-		return 0, err
+	// Publish reusable state only after the server is ready. If either write
+	// fails, tear the server down and clear both files: a live process with
+	// incomplete state (e.g. pid written, port missing) would be rejected by
+	// the next call, which would then start a duplicate server against the same
+	// single-writer dolt dir.
+	pidErr := os.WriteFile(filepath.Join(cartsDir, pidFileName), []byte(strconv.Itoa(cmd.Process.Pid)), 0o644)
+	portErr := os.WriteFile(filepath.Join(cartsDir, portFileName), []byte(strconv.Itoa(port)), 0o644)
+	if pidErr != nil || portErr != nil {
+		stopProcess(cmd)
+		_ = os.Remove(filepath.Join(cartsDir, pidFileName))
+		_ = os.Remove(filepath.Join(cartsDir, portFileName))
+		return 0, fmt.Errorf("publish carts server state: %w", errors.Join(pidErr, portErr))
 	}
 
 	return port, nil
+}
+
+// stopProcess kills and reaps a started process, best-effort. Reaping (Wait)
+// prevents a lingering zombie when we tear down a server we just started.
+func stopProcess(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
 }
 
 // ensureDoltInit ensures the dolt directory is initialized.

--- a/internal/carts/server.go
+++ b/internal/carts/server.go
@@ -1,9 +1,9 @@
 package carts
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
-	"github.com/sageox/ox/internal/proc"
 	"net"
 	"os"
 	"os/exec"
@@ -12,28 +12,72 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sageox/ox/internal/fileutil"
+	"github.com/sageox/ox/internal/proc"
+
 	_ "github.com/go-sql-driver/mysql"
 )
 
 const (
 	pidFileName  = "dolt-server.pid"
 	portFileName = "dolt-server.port"
+
+	// serverHost is the loopback address the carts dolt sql-server binds to.
+	serverHost = "127.0.0.1"
+	// endpointCheckTimeout bounds the health probe used to validate a recorded
+	// server before reusing it (a healthy loopback server answers in ms).
+	endpointCheckTimeout = 2 * time.Second
+	// serverStartTimeout bounds how long we wait for a freshly started server
+	// to accept connections before giving up.
+	serverStartTimeout = 30 * time.Second
 )
 
+// pingEndpoint validates that a recorded carts server is reachable and speaking
+// MySQL. It is a package var so tests can exercise the stale/healthy reuse
+// branches without a real dolt server.
+var pingEndpoint = pingServer
+
 // EnsureServer ensures a dolt sql-server is running for the carts database.
-// If a server is already running (PID file exists and process alive), it returns the port.
-// Otherwise it starts a new server on an ephemeral port.
+// If a healthy server is already recorded it returns that port; otherwise it
+// starts a new one. Startup is serialized across processes with an advisory
+// lock so two concurrent callers cannot each spawn a server against the same
+// single-writer dolt directory.
 func EnsureServer(cartsDir string) (int, error) {
-	// Check if already running
+	// Fast path: a recorded server that still answers.
 	if port, err := runningServerPort(cartsDir); err == nil {
 		return port, nil
 	}
 
-	// Start new server
-	return startServer(cartsDir)
+	// Slow path: serialize the check-then-start so only one caller starts a
+	// server. The lock is held across readiness, so a concurrent caller waits
+	// (or times out cleanly) instead of starting a duplicate. On a cold start a
+	// concurrent second caller may hit the lock timeout; retrying then takes the
+	// fast path once the first caller has published a ready server.
+	var port int
+	lockErr := fileutil.WithFileLock(context.Background(), filepath.Join(cartsDir, pidFileName), func() error {
+		// Re-check inside the lock: another process may have started the server
+		// while we were blocked.
+		if p, err := runningServerPort(cartsDir); err == nil {
+			port = p
+			return nil
+		}
+		p, err := startServer(cartsDir)
+		if err != nil {
+			return err
+		}
+		port = p
+		return nil
+	})
+	if lockErr != nil {
+		return 0, lockErr
+	}
+	return port, nil
 }
 
-// runningServerPort returns the port of a running server, or error if not running.
+// runningServerPort returns the port of a healthy recorded server, or an error
+// if none is usable. A live PID alone is insufficient: after a crash the OS can
+// reassign the recorded PID to an unrelated process while stale pid/port files
+// linger, so we also probe the endpoint before handing the port back.
 func runningServerPort(cartsDir string) (int, error) {
 	pidData, err := os.ReadFile(filepath.Join(cartsDir, pidFileName))
 	if err != nil {
@@ -58,6 +102,14 @@ func runningServerPort(cartsDir string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	// Validate the recorded endpoint actually answers as a MySQL/dolt server.
+	// This rejects a stale port left by a crashed server whose PID was recycled
+	// by an unrelated live process, instead of returning it and failing later
+	// with "connection refused".
+	if err := pingEndpoint(serverHost, port, endpointCheckTimeout); err != nil {
+		return 0, fmt.Errorf("recorded server on port %d is not reachable: %w", port, err)
+	}
 	return port, nil
 }
 
@@ -71,7 +123,7 @@ func startServer(cartsDir string) (int, error) {
 	}
 
 	// Allocate ephemeral port
-	port, err := allocateEphemeralPort("127.0.0.1")
+	port, err := allocateEphemeralPort(serverHost)
 	if err != nil {
 		return 0, err
 	}
@@ -83,7 +135,7 @@ func startServer(cartsDir string) (int, error) {
 	}
 
 	cmd := exec.Command("dolt", "sql-server",
-		"--host", "127.0.0.1",
+		"--host", serverHost,
 		"--port", strconv.Itoa(port),
 		"--no-auto-commit",
 	)
@@ -97,17 +149,19 @@ func startServer(cartsDir string) (int, error) {
 	}
 	logFile.Close()
 
-	// Write state files
+	// Wait for readiness BEFORE publishing state, so a concurrent reader never
+	// observes a pid/port for a server that isn't accepting connections yet.
+	if err := waitForServer(serverHost, port, serverStartTimeout); err != nil {
+		_ = cmd.Process.Kill() // don't orphan a half-started server
+		return 0, fmt.Errorf("server failed to start: %w", err)
+	}
+
+	// Publish reusable state only after the server is ready.
 	if err := os.WriteFile(filepath.Join(cartsDir, pidFileName), []byte(strconv.Itoa(cmd.Process.Pid)), 0o644); err != nil {
 		return 0, err
 	}
 	if err := os.WriteFile(filepath.Join(cartsDir, portFileName), []byte(strconv.Itoa(port)), 0o644); err != nil {
 		return 0, err
-	}
-
-	// Wait for server to be ready
-	if err := waitForServer("127.0.0.1", port, 30*time.Second); err != nil {
-		return 0, fmt.Errorf("server failed to start: %w", err)
 	}
 
 	return port, nil
@@ -144,18 +198,26 @@ func allocateEphemeralPort(host string) (int, error) {
 	return port, nil
 }
 
+// pingServer opens a MySQL connection to host:port and pings it. Success proves
+// the endpoint is up AND speaking MySQL (i.e. it really is our dolt sql-server,
+// not an unrelated process that inherited the recorded PID/port).
+func pingServer(host string, port int, timeout time.Duration) error {
+	dsn := fmt.Sprintf("root@tcp(%s:%d)/?timeout=%s&readTimeout=%s&writeTimeout=%s",
+		host, port, timeout, timeout, timeout)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	return db.Ping()
+}
+
 // waitForServer polls until the server accepts connections.
 func waitForServer(host string, port int, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	dsn := fmt.Sprintf("root@tcp(%s:%d)/", host, port)
 	for time.Now().Before(deadline) {
-		db, err := sql.Open("mysql", dsn)
-		if err == nil {
-			if err := db.Ping(); err == nil {
-				db.Close()
-				return nil
-			}
-			db.Close()
+		if err := pingServer(host, port, time.Second); err == nil {
+			return nil
 		}
 		time.Sleep(200 * time.Millisecond)
 	}

--- a/internal/carts/server_test.go
+++ b/internal/carts/server_test.go
@@ -1,50 +1,99 @@
 package carts
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 )
 
-// runningServerPort must return the recorded port when the pid file names a
-// live process, and an error when it names a dead one. Before the fix the
-// liveness check used proc.Signal(os.Signal(nil)), which always errored, so a
-// live server was never detected and every call started a second sql-server.
+var errStubUnreachable = errors.New("stub: endpoint unreachable")
+
+// TestRunningServerPort covers the recorded-server reuse decision: it returns
+// the saved port only when the PID is live AND the endpoint answers, and errors
+// otherwise.
+//
+// Failure prevented: before #780 the liveness check (proc.Signal(nil)) always
+// errored, so a live server was never detected and every call started a second
+// sql-server. The "unreachable endpoint (stale)" case guards the follow-up
+// validation — a live PID alone is not enough, because a crashed server can
+// leave stale pid/port files while the OS reassigns its PID to an unrelated
+// process; reusing that port would fail later with "connection refused".
 func TestRunningServerPort(t *testing.T) {
-	dir := t.TempDir()
-	writeFile := func(name, content string) {
-		t.Helper()
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
+	tests := []struct {
+		name     string
+		pid      string // "self" live, "dead" reaped, "" no file, else literal
+		port     string // port file content; "" means no port file
+		ping     error  // simulated endpoint probe result
+		wantErr  bool
+		wantPort int
+	}{
+		{name: "no pid file", pid: "", wantErr: true},
+		{name: "live pid, reachable endpoint", pid: "self", port: "50422", ping: nil, wantPort: 50422},
+		{name: "live pid, unreachable endpoint (stale)", pid: "self", port: "1", ping: errStubUnreachable, wantErr: true},
+		{name: "dead pid", pid: "dead", port: "50422", ping: nil, wantErr: true},
 	}
 
-	// No pid file → not running.
-	if _, err := runningServerPort(dir); err == nil {
-		t.Fatal("expected error with no pid file")
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
 
-	// Live process (ourselves) + port file → port is returned.
-	writeFile(pidFileName, strconv.Itoa(os.Getpid()))
-	writeFile(portFileName, "50422")
-	port, err := runningServerPort(dir)
-	if err != nil {
-		t.Fatalf("live pid: unexpected error: %v", err)
-	}
-	if port != 50422 {
-		t.Fatalf("live pid: port = %d, want 50422", port)
-	}
+			// Stub the endpoint probe per-case so the reuse branches are
+			// exercised without a real dolt server.
+			orig := pingEndpoint
+			pingEndpoint = func(string, int, time.Duration) error { return tc.ping }
+			t.Cleanup(func() { pingEndpoint = orig })
 
-	// Dead process → error. Spawn a short-lived child and wait for it so the
-	// pid is guaranteed to be gone.
-	cmd := exec.Command("true")
+			switch tc.pid {
+			case "":
+				// no pid file
+			case "self":
+				writeStateFile(t, dir, pidFileName, strconv.Itoa(os.Getpid()))
+			case "dead":
+				writeStateFile(t, dir, pidFileName, strconv.Itoa(deadPID(t)))
+			default:
+				writeStateFile(t, dir, pidFileName, tc.pid)
+			}
+			if tc.port != "" {
+				writeStateFile(t, dir, portFileName, tc.port)
+			}
+
+			port, err := runningServerPort(dir)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got port %d", port)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if port != tc.wantPort {
+				t.Fatalf("port = %d, want %d", port, tc.wantPort)
+			}
+		})
+	}
+}
+
+// deadPID returns a PID that has certainly exited: it runs the test binary as a
+// no-op child (`-test.run=^$` matches no test) and reaps it. Portable across
+// platforms, unlike shelling out to `true`, and it fails rather than skips when
+// the helper cannot run so the dead-PID assertion is never silently bypassed.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
 	if err := cmd.Run(); err != nil {
-		t.Skipf("cannot spawn helper process: %v", err)
+		t.Fatalf("spawn no-op helper: %v", err)
 	}
-	writeFile(pidFileName, strconv.Itoa(cmd.Process.Pid))
-	if _, err := runningServerPort(dir); err == nil {
-		t.Fatal("expected error for dead pid")
+	return cmd.Process.Pid
+}
+
+func writeStateFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Follow-up to #780. That PR fixed the two crashes that made `ox carts` fail on machines with Dolt 2.x; the review bots then flagged a deeper reuse race that #780 did not touch. This PR disables the feature by default and closes the race class.

## Why disable it

`ox carts` runs Dolt **client-side** — `EnsureServer` starts a local `dolt sql-server` on loopback on the coworker's own machine. It shipped registered on root, not hidden, not flag-gated, so any coworker with the `dolt` binary could reach it. It's experimental and not part of the MVP surface, so it should be opt-in.

## What this PR ships

- **`ox carts` + `ox cart-analyze` are off by default** behind a new `FEATURE_CARTS` flag (mirrors `auth.IsMemoryEnabled` / `FEATURE_MEMORY`).
  - Execution gate at the single chokepoint `openCartsStore` — every carts subcommand and `cart-analyze` funnel through it, so one guard disables them all *before* any local Dolt server starts.
  - Hidden from `ox --help` until enabled.
  - Enable with `FEATURE_CARTS=true`.
- **Endpoint validation before reuse** (fixes the Greptile P1 + the "return port before ready" half of the CodeRabbit Major). A live PID alone is not enough — a crashed server can leave stale pid/port files while the OS reassigns its PID to an unrelated process. `runningServerPort` now pings the recorded endpoint (a MySQL handshake, which also proves it's really our dolt server) and treats an unreachable port as stale, so a fresh server is started instead of returning a dead port that fails later with `connection refused`.
- **Serialized startup** (fixes the CodeRabbit Major race). `EnsureServer` now wraps check-then-start in `fileutil.WithFileLock` with a double-check inside the lock, so two concurrent invocations can't each spawn a server against the same single-writer Dolt directory.
- **Publish state only after readiness.** `startServer` writes the pid/port files *after* `waitForServer` succeeds (previously before), so a concurrent reader never sees state for a server that isn't accepting connections yet. On readiness failure it now kills the half-started process instead of orphaning it.
- **Review nits from #780:** fixed the `goimports` grouping of the `internal/proc` import in `server.go`; rewrote `server_test.go` as portable, non-skipping, table-driven cases (dead-PID via `os.Args[0] -test.run=^$`, not the non-portable shell `true`).

## Failure-mode being closed

```mermaid
flowchart TD
  A["ox carts …"] --> B{"recorded pid alive?"}
  B -->|no| S["start new server"]
  B -->|yes| C{"endpoint answers?<br/>(MySQL ping)"}
  C -->|"no — stale port,<br/>recycled PID"| S
  C -->|yes| R["reuse recorded port"]
  S --> L["hold advisory lock<br/>(double-check inside)"]
  L --> W["wait for readiness"]
  W -->|ok| P["publish pid/port<br/>AFTER ready"]
  W -->|fail| K["kill half-started proc"]
```

## Review bot findings addressed

| Source | Finding | Fix |
|---|---|---|
| CodeRabbit (Major) | `server.go:50` — concurrent `EnsureServer` starts a 2nd server / returns port before ready | Advisory lock + publish-after-ready |
| Greptile (P1) | stale PID reuses stale/unbound port → later `connection refused` | Endpoint validation before reuse |
| CodeRabbit (Minor) | `server_test.go` — non-portable `true`, skips the dead-PID assertion | Portable table-driven test |
| Local review | `server.go` import grouping fails `goimports` | Regrouped |

## Test Plan

- `go build ./... ` — pass.
- `golangci-lint run -c .config/golangci.yml ./internal/carts/... ./internal/auth/... ./cmd/ox/...` — **0 issues**.
- `go test -race ./internal/carts/` and `go test ./internal/auth/... ./cmd/ox/...` — pass.
- **Red-first proof (both behavioral fixes):**
  - Neuter the endpoint validation → `TestRunningServerPort/live_pid,_unreachable_endpoint_(stale)` fails (returns stale port `1`); restore → green.
  - Neuter the `openCartsStore` gate → `TestOpenCartsStoreDisabledByDefault` fails (store opens with the flag unset, actually spawning Dolt); restore → green.

## For reviewer attention

- **New customer-facing env var `FEATURE_CARTS`.** Named to match the existing `FEATURE_*` convention. Alternative considered: reuse `FEATURE_POST_MVP` (which already gates several unrelated post-MVP features) — rejected so carts can be toggled independently. Flagging per the repo's env-var-name review rule.
- **Lock-timeout tradeoff:** the advisory lock is held across the ≤30s readiness wait while `fileutil`'s lock timeout is 10s, so a *concurrent* cold-start caller can hit a clean lock timeout and must retry (the retry then takes the fast path). Chosen over spawning a duplicate server. Documented in `EnsureServer`.

Closes the follow-up tracked for #780.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added feature gating for cart commands. Cart functionality is disabled by default and can be enabled with `FEATURE_CARTS=true`, `1`, or `yes`.
  - Cart commands are hidden from help and reject operations when disabled.

- **Bug Fixes**
  - Improved local cart server startup and reuse by validating connections, preventing concurrent starts, and publishing connection details only after readiness.

- **Documentation**
  - Updated release notes with cart availability and server reliability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->