### PR TITLE
feat(abort): session abort ensures removal in all states (draft, persisted, finalized)

### DIFF
--- a/cmd/ox/agent_session_abort.go
+++ b/cmd/ox/agent_session_abort.go
@@ -140,7 +140,22 @@ func runAgentSessionAbortByName(inst *agentinstance.Instance, cmd *cobra.Command
 	case session.StatusRecording:
 		return fmt.Errorf("session %q is actively recording — use 'ox agent %s session abort' (without a name) to abort your own session", sessionName, inst.AgentID)
 	case session.StatusUploaded:
-		return fmt.Errorf("session %q is already uploaded to the ledger — use 'ox agent %s session delete %s' to remove it", sessionName, inst.AgentID, sessionName)
+		// Total kill: abort deletes a finalized/persisted session too, along with
+		// all of its summarized data — not just drafts and local recordings.
+		//
+		// Guard against a PARTIAL name silently colliding with a teammate's
+		// finalized session pulled from the shared ledger. A finalized kill
+		// requires the EXACT session name — the same contract
+		// `ox agent session delete` enforces. `nameArg != sessionName` means the
+		// user typed a suffix that resolved to this session, which is exactly the
+		// case that must not be allowed to destroy someone else's work.
+		if nameArg != sessionName {
+			return fmt.Errorf("session %q is finalized in the ledger; pass its exact name to abort it — a partial name is refused so a teammate's session is never deleted by collision: ox agent %s session abort %s --force", sessionName, inst.AgentID, sessionName)
+		}
+		if err := confirmAbort(inst, cmd); err != nil {
+			return err
+		}
+		return killFinalizedSession(inst, cmd, projectRoot, sessionName)
 	case session.StatusPaused:
 		// paused = stopped but not uploaded; safe to discard locally
 	case session.StatusCanceled:
@@ -391,6 +406,61 @@ func removeLedgerDraftForAbort(sessionName string) (bool, string) {
 		return false, fmt.Sprintf("could not remove the published draft placeholder from the ledger: %v", err)
 	}
 	return res.Deleted, res.PushWarning
+}
+
+// killFinalizedSession removes a finalized/persisted session and ALL of the
+// summarized data around it: the git-tracked ledger directory (meta.json,
+// summary.md, summary.json, session.md, plan.md, context-trace.jsonl, and the
+// raw.jsonl LFS pointer), the local recording cache, and the ledger hydration
+// cache. It then notifies the server so the /c/ page flips to discarded.
+//
+// This is what makes abort a total kill. `ox agent session delete` already
+// removes a finalized session by exact name, so we reuse its removal
+// (deleteSessionFromLedger + store.DeleteSession) rather than reimplementing
+// it, and add the abort-only steps delete omits: the hydration-cache purge and
+// the server notification. The caller has already confirmed and verified the
+// name is exact.
+func killFinalizedSession(inst *agentinstance.Instance, cmd *cobra.Command, projectRoot, sessionName string) error {
+	ledgerPath, err := resolveLedgerPath()
+	if err != nil {
+		return fmt.Errorf("could not resolve ledger to delete finalized session %q: %w", sessionName, err)
+	}
+	ledgerSessionDir := filepath.Join(ledgerPath, "sessions", sessionName)
+
+	// Read the ses_ id before removal so the server /c/ page can flip to
+	// discarded — the meta.json that carries it is about to be git-rm'd.
+	abortedSessionID := ""
+	if meta, metaErr := lfs.ReadSessionMeta(ledgerSessionDir); metaErr == nil {
+		abortedSessionID = meta.EffectiveSessionID()
+	}
+
+	// Remove the git-tracked ledger directory: git rm -r + commit + push.
+	if err := deleteSessionFromLedger(ledgerPath, sessionName, ledgerSessionDir); err != nil {
+		return fmt.Errorf("failed to remove finalized session %q from the ledger: %w", sessionName, err)
+	}
+
+	// Remove the local recording cache copy, if one exists. ErrSessionNotFound
+	// is expected and fine — a finalized session may have no local copy left.
+	repoID := getRepoIDOrDefault(projectRoot)
+	if contextPath := session.GetContextPath(repoID); contextPath != "" {
+		if store, storeErr := session.NewStore(contextPath); storeErr == nil {
+			if delErr := store.DeleteSession(sessionName); delErr != nil && !errors.Is(delErr, session.ErrSessionNotFound) {
+				slog.Warn("failed to remove local session cache during finalized abort", "session", sessionName, "error", delErr)
+			}
+		}
+	}
+
+	// Remove the ledger hydration cache. git rm never touches it — it is
+	// gitignored and lives outside the tracked sessions/ tree — so without this
+	// the hydrated summary/transcript bytes would survive the kill.
+	hydrationCache := filepath.Join(ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	if err := os.RemoveAll(hydrationCache); err != nil {
+		slog.Warn("failed to remove ledger hydration cache during finalized abort", "session", sessionName, "error", err)
+	}
+
+	notifySessionAbortedAsync(projectRoot, abortedSessionID)
+
+	return emitAbortOutput(cmd.OutOrStdout(), inst.AgentID, sessionName, false, "")
 }
 
 // confirmAbort checks --force flag or prompts for interactive confirmation.

--- a/cmd/ox/agent_session_abort_kill_test.go
+++ b/cmd/ox/agent_session_abort_kill_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sageox/ox/internal/agentinstance"
+	"github.com/sageox/ox/internal/config"
+	"github.com/sageox/ox/internal/lfs"
+	"github.com/sageox/ox/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file is the behavior spec for the "total kill" contract of
+// `ox agent <id> session abort`: aborting a session removes it and ALL the
+// summarized data around it, in EVERY state it can reach — a draft placeholder
+// committed after N turns, and a fully finalized/persisted session in the
+// ledger. The one thing a kill must never do is destroy a teammate's finalized
+// session that a partial name merely collided with.
+//
+// The mirror capability doc is tests/acceptance/session-recording/session-abort-kill.feature.
+
+// seedFinalizedLedgerSessionWithArtifacts writes a finalized (non-draft) session
+// into the ledger with the FULL set of summarized artifacts a real finalized
+// session carries — the exact data the kill must leave nothing of. It does not
+// commit; the caller stages + commits + pushes so the assertion runs against a
+// real remote.
+func seedFinalizedLedgerSessionWithArtifacts(t *testing.T, ledgerPath, sessionName string) string {
+	t.Helper()
+	dir := filepath.Join(ledgerPath, "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, lfs.WriteSessionMetaOnly(dir, &lfs.SessionMeta{
+		SessionName: sessionName, SessionID: sessionScopedID(sessionName),
+		CreatedAt: time.Now(), Title: "real work", EntryCount: 40,
+		Files: map[string]lfs.FileRef{"raw.jsonl": {OID: "sha256:abc", Size: 10}},
+	}))
+	// The summarized data around a finalized session. raw.jsonl is the LFS
+	// pointer that is git-tracked in place (the content lives in LFS).
+	pointer := "version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 10\n"
+	for name, body := range map[string]string{
+		"summary.md":          "REAL SUMMARY MARKDOWN",
+		"summary.json":        `{"title":"real work","key_actions":["shipped kill"]}`,
+		"session.md":          "full transcript rendered to markdown",
+		"context-trace.jsonl": `{"consulted":"team-ctx"}`,
+		"raw.jsonl":           pointer,
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0644))
+	}
+	require.NoError(t, ensureSessionsGitignore(filepath.Join(ledgerPath, "sessions")))
+	return dir
+}
+
+// commitAndPushFinalized stages, commits, and pushes a finalized session dir the
+// way a real finalize would, so remoteTree() sees it on the bare remote.
+func commitAndPushFinalized(t *testing.T, f *draftLedgerFixture, sessionName string) {
+	t.Helper()
+	// Stage .gitignore alongside the session, exactly as a real finalize does —
+	// otherwise it lingers uncommitted and a post-kill `status` reads it as a
+	// dangling change that has nothing to do with the deletion.
+	runGit(t, f.ledgerPath, "add", "--sparse", "--", "sessions/"+sessionName, "sessions/.gitignore")
+	runGit(t, f.ledgerPath, "commit", "--no-verify", "-m", "session: "+sessionName)
+	f.push(t)
+	require.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json",
+		"fixture precondition: the finalized session must be on the remote before the kill")
+}
+
+// remotePathsUnder returns the tracked remote paths beneath sessions/<name>/.
+func remotePathsUnder(t *testing.T, barePath, sessionName string) []string {
+	t.Helper()
+	prefix := "sessions/" + sessionName + "/"
+	var out []string
+	for _, p := range remoteTree(t, barePath) {
+		if strings.HasPrefix(p, prefix) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// TestAbort_KillsCommittedDraftAndAllLocalData is the N-turn example, end to end.
+//
+// A session committed after N turns is an ADR-029 draft placeholder pushed to
+// the ledger. Aborting the live recording must remove that committed placeholder
+// from the REMOTE (not just locally), delete the local recording folder and
+// every summary artifact in it, and clear the recording marker — in one command.
+//
+// This drives the real runAgentSessionAbort handler, not deleteDraftFromLedger
+// in isolation, so it proves the whole active-abort wiring, not one helper.
+func TestAbort_KillsCommittedDraftAndAllLocalData(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	// abort's active path resolves the project from cwd; the fixture chdir'd into
+	// the ledger clone for push-credential isolation, so point cwd back.
+	t.Chdir(f.projectRoot)
+	cfg = &config.Config{}
+
+	// Given: a live recording whose draft placeholder crossed the publish
+	// threshold and was committed + pushed, plus local summary artifacts.
+	state, err := session.StartRecording(f.projectRoot, session.StartRecordingOptions{
+		AgentID: "OxKill", AdapterName: "test",
+	})
+	require.NoError(t, err)
+	sessionName := session.GetSessionName(state.SessionPath)
+
+	localArtifacts := []string{"raw.jsonl", "summary.md", "summary.json", "session.md"}
+	for _, name := range localArtifacts {
+		require.NoError(t, os.WriteFile(filepath.Join(state.SessionPath, name),
+			[]byte("local "+name), 0644))
+	}
+
+	f.publish(t, sessionName, config.DraftPublishTurn)
+	f.push(t)
+	require.Contains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json")
+
+	// When: the agent aborts its own recording.
+	setForceFlag(t, true)
+	var buf bytes.Buffer
+	agentCmd.SetOut(&buf)
+	t.Cleanup(func() { agentCmd.SetOut(nil) })
+	inst := &agentinstance.Instance{AgentID: "OxKill"}
+	require.NoError(t, runAgentSessionAbort(inst, agentCmd, nil))
+
+	// Then: the committed draft is gone from the remote and the worktree.
+	assert.NotContains(t, remoteTree(t, f.barePath), "sessions/"+sessionName+"/meta.json",
+		"the committed draft must be removed from the remote, not just locally")
+	assert.NoDirExists(t, draftLedgerSessionDir(f.ledgerPath, sessionName))
+
+	// And: the local recording folder and every summary artifact are gone.
+	assert.NoDirExists(t, state.SessionPath)
+
+	// And: the recording marker is cleared, so a future session start works.
+	st, err := session.LoadRecordingStateForAgent(f.projectRoot, "OxKill")
+	require.NoError(t, err)
+	assert.Nil(t, st, ".recording.json must be cleared after abort")
+
+	// And: no repo corruption, no dangling staged deletion.
+	gitFsckClean(t, f.barePath)
+	assert.Empty(t, runGit(t, f.ledgerPath, "status", "--porcelain", "--", "sessions/"),
+		"no staged deletion may be left dangling")
+
+	// And: the output reports the ledger draft was removed.
+	var out sessionAbortOutput
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	assert.True(t, out.Success)
+	assert.True(t, out.LedgerDraftDeleted, "abort must report it removed the published draft")
+}
+
+// TestAbort_KillsFinalizedSessionAndAllSummarizedData is the intent test.
+//
+// The user's contract: abort is a KILL — it deletes a finalized/persisted
+// session too, along with ALL of its summarized data (summary.md, summary.json,
+// session.md, context-trace.jsonl, the raw.jsonl pointer), from the remote, from
+// the local cache, and from the ledger hydration cache.
+//
+// Red-first check: revert the StatusUploaded branch in
+// runAgentSessionAbortByName to `return fmt.Errorf(... already uploaded ...)` and
+// this test fails — abort refuses and the finalized dir survives on the remote.
+func TestAbort_KillsFinalizedSessionAndAllSummarizedData(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	t.Chdir(f.projectRoot)
+	cfg = &config.Config{}
+
+	const sessionName = "2026-01-01T00-00-testuser-OxFinl"
+
+	// Given: a finalized session with the full artifact set, committed + pushed.
+	seedFinalizedLedgerSessionWithArtifacts(t, f.ledgerPath, sessionName)
+	commitAndPushFinalized(t, f, sessionName)
+
+	// And: a local recording-cache copy and a ledger hydration-cache copy.
+	repoID := getRepoIDOrDefault(f.projectRoot)
+	localDir := filepath.Join(session.GetContextPath(repoID), "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "raw.jsonl"), []byte("local raw"), 0644))
+
+	hydrationDir := filepath.Join(f.ledgerPath, ".sageox", "cache", "sessions", sessionName)
+	require.NoError(t, os.MkdirAll(hydrationDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(hydrationDir, "raw.jsonl"), []byte("hydrated bytes"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(hydrationDir, "summary.md"), []byte("hydrated summary"), 0644))
+
+	// When: the agent aborts it by its EXACT name.
+	setForceFlag(t, true)
+	inst := &agentinstance.Instance{AgentID: "OxKill"}
+	require.NoError(t, runAgentSessionAbort(inst, agentCmd, []string{sessionName}))
+
+	// Then: nothing under sessions/<name>/ survives on the remote.
+	assert.Empty(t, remotePathsUnder(t, f.barePath, sessionName),
+		"every summarized artifact of a finalized session must be gone from the remote after a kill")
+	assert.NoDirExists(t, filepath.Join(f.ledgerPath, "sessions", sessionName),
+		"the finalized session must be gone from the ledger worktree")
+
+	// And: both caches are gone.
+	assert.NoDirExists(t, localDir, "the local recording cache copy must be removed")
+	assert.NoDirExists(t, hydrationDir, "the ledger hydration cache (summarized bytes) must be removed")
+
+	// And: no corruption, no dangling staged deletion.
+	gitFsckClean(t, f.barePath)
+	assert.Empty(t, runGit(t, f.ledgerPath, "status", "--porcelain", "--", "sessions/"),
+		"no staged deletion may be left dangling after the kill")
+}
+
+// TestAbort_PartialNameNeverKillsTeammateFinalizedSession is the safety control
+// that must stay green before AND after the kill lands.
+//
+// Abort resolves by partial (agent-id suffix) name. A partial that collides with
+// a teammate's finalized session pulled from the shared ledger must NEVER become
+// a deletion of their work — a finalized kill requires the exact name. Without
+// this guard the kill would multiply into data loss across the team.
+func TestAbort_PartialNameNeverKillsTeammateFinalizedSession(t *testing.T) {
+	f := newDraftLedgerFixture(t)
+	t.Chdir(f.projectRoot)
+	cfg = &config.Config{}
+
+	// Given: a teammate's finalized session on the shared ledger.
+	const teammate = "2026-01-01T00-00-teammate-OxTeam"
+	seedFinalizedLedgerSessionWithArtifacts(t, f.ledgerPath, teammate)
+	commitAndPushFinalized(t, f, teammate)
+
+	// When: an agent aborts using only the partial (agent-id suffix) name.
+	setForceFlag(t, true)
+	inst := &agentinstance.Instance{AgentID: "OxMe"}
+	err := runAgentSessionAbort(inst, agentCmd, []string{"OxTeam"})
+
+	// Then: abort refuses, and the teammate's session survives everywhere.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exact name",
+		"a partial-name finalized abort must be refused and demand the exact name")
+	assert.Contains(t, remoteTree(t, f.barePath), "sessions/"+teammate+"/meta.json",
+		"a teammate's finalized session must survive a colliding partial abort")
+	assert.DirExists(t, filepath.Join(f.ledgerPath, "sessions", teammate))
+	gitFsckClean(t, f.barePath)
+}

--- a/tests/acceptance/session-recording/session-abort-kill.feature
+++ b/tests/acceptance/session-recording/session-abort-kill.feature
@@ -1,0 +1,37 @@
+Feature: Aborting a Session is a Total Kill
+  When Avery aborts a session, ox removes it and all the summarized data around
+  it — in whatever state the session has reached. A session that was committed
+  to the Ledger after a few turns (a draft placeholder), and even a fully
+  finalized session already in the Ledger, are both discarded completely. The
+  one thing a kill must never do is destroy a teammate's finalized session that
+  a partial name merely collided with.
+
+  See also: session-recording/pause-resume.feature
+  See also: business-actions/record-session.md
+
+  Rule: Aborting removes a session committed after N turns, along with its summary data
+
+    Scenario: Avery aborts a recording that was already committed to the Ledger
+      Given Avery is recording a session that has been committed to the "Acme Engineering" Ledger after several turns
+      And the recording has local summary artifacts on her machine
+      When she aborts the session
+      Then ox removes the committed session from the Ledger, not just from her machine
+      And ox deletes the local recording and every summary artifact around it
+      And ox clears the recording so a new session can start
+
+  Rule: Aborting also deletes a finalized session and all of its summarized data
+
+    Scenario: Avery aborts a session that was already finalized in the Ledger
+      Given a finalized session of Avery's exists in the "Acme Engineering" Ledger with its summary, transcript, and context trace
+      When she aborts it by its exact name
+      Then ox removes the finalized session and all of its summarized data from the Ledger
+      And ox removes the local and hydrated copies of that session
+      And the Ledger history remains intact for everyone else
+
+  Rule: A partial name never deletes a teammate's finalized session by collision
+
+    Scenario: Avery's partial name collides with a teammate's finalized session
+      Given a teammate's finalized session exists in the shared Ledger
+      When Avery aborts using only a partial name that matches it
+      Then ox refuses and asks for the exact session name
+      And the teammate's finalized session is left untouched


### PR DESCRIPTION
## Summary

Makes `ox agent <id> session abort` (the `/ox-session-abort` skill) a **total kill**: it now discards a session in *every* state — not just a live recording, but also one committed to the ledger after N turns, and a fully finalized/persisted session with all its summarized data. Previously abort **refused** an uploaded session and deferred to `session delete`; that gap is closed. Ships as TDD — a red-first behavior test drives the new code.

### What changed

- **`cmd/ox/agent_session_abort.go`** — the `StatusUploaded` branch of `runAgentSessionAbortByName` no longer errors. It calls a new `killFinalizedSession` that **reuses** the existing removal (`deleteSessionFromLedger` + `store.DeleteSession`) and adds the two steps `session delete` omits: purge the **ledger hydration cache** (`<ledger>/.sageox/cache/sessions/<name>/`, where the summarized/transcript bytes live and which `git rm` never touches) and fire the `/c/` **"discarded" notification**.
- **Safety guard (load-bearing):** a finalized kill requires the **exact** session name. Abort resolves partial (agent-id suffix) names; a partial colliding with a teammate's finalized session on the shared ledger must never delete their work. Exact-name-only matches the contract `session delete` already enforces.
- **BDD (the ask):** `cmd/ox/agent_session_abort_kill_test.go` — three end-to-end scenarios driving the real `runAgentSessionAbort` handler against a real bare-remote ledger, plus `tests/acceptance/session-recording/session-abort-kill.feature` mirroring them in the Gherkin attest corpus.

### Behavior

```mermaid
flowchart TD
    A["session abort [name] --force"] --> B{name given?}
    B -- no --> C["active recording:\nremove draft from ledger + local folder + clear marker"]
    B -- yes --> D{status}
    D -- orphan/ghost/local/paused/draft --> E["discard (unchanged)"]
    D -- recording --> F["refuse"]
    D -- finalized/uploaded --> G{exact name?}
    G -- no / partial --> H["REFUSE — teammate-collision guard"]
    G -- yes --> I["KILL: git rm whole dir + commit + push,\nlocal cache, hydration cache, notify /c/"]
```

### Out of scope (stated honestly)

Team-level distillation rollups (`memory/daily|weekly|monthly`) mine many sessions and cannot be surgically un-mined for one; `codedb` is likewise untouched. The kill removes the session directory, all its direct artifacts (`meta.json`, `summary.md`, `summary.json`, `session.md`, `context-trace.jsonl`, the `raw.jsonl` pointer), and **both** caches — the test asserts exactly that boundary.

## Test Plan

- **Red-first proven** (per `.claude/rules/testing.md`): reverting the `StatusUploaded` branch to the old refusal turns `TestAbort_KillsFinalizedSessionAndAllSummarizedData` red while the draft scenario stays green; restoring the kill makes it green again.
- New scenarios (real bare-remote git, skip under `-short`):
  - `TestAbort_KillsCommittedDraftAndAllLocalData` — the N-turn draft example: committed placeholder gone from the **remote** + local folder + every artifact gone + recording marker cleared.
  - `TestAbort_KillsFinalizedSessionAndAllSummarizedData` — finalized session + all summary data gone from remote, local XDG cache, and ledger hydration cache.
  - `TestAbort_PartialNameNeverKillsTeammateFinalizedSession` — partial name is refused; teammate's finalized session survives.
- Full `cmd/ox` abort/draft/delete/remove/supersede regression suite green · attest corpus parses the new `.feature` · `go vet` clean · `gofmt` clean · `make lint` → **0 issues**.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (3 end-to-end behavior scenarios + Gherkin capability doc)
- [ ] CHANGELOG entry — follow-up (user-facing behavior change; not yet added)
- [ ] Breaking change — none: abort now does *more* (kills finalized) rather than changing an existing success path; the removed path only ever returned an error
- [x] `/security-review` — N/A documented: touches `cmd/ox/agent_session_abort.go` only (not `internal/auth/`, `internal/mcp/`, `raw_writer.go`, `prepush_scan.go`, `internal/upgrade/`, or `go.sum`). Destructive `git rm`/`os.RemoveAll` paths are guarded by exact-name + `--force`; reuses the audited `deleteSessionFromLedger`/`store.DeleteSession` helpers.

</details>

Co-authored-by: SageOx <ox@sageox.ai>
