### PR TITLE
fix(codex): install hooks at init, gate doctor writes behind --fix

### DIFF
--- a/cmd/ox-adapter-codex/detect.go
+++ b/cmd/ox-adapter-codex/detect.go
@@ -4,12 +4,17 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/sageox/ox/pkg/adapterprotocol"
 )
 
 func handleDetect() (*adapterprotocol.DetectResponse, error) {
+	if _, err := exec.LookPath("codex"); err == nil {
+		return &adapterprotocol.DetectResponse{Detected: true, Reason: "found codex in PATH"}, nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return &adapterprotocol.DetectResponse{Detected: false, Reason: "cannot determine home directory"}, nil
@@ -20,45 +25,64 @@ func handleDetect() (*adapterprotocol.DetectResponse, error) {
 		return &adapterprotocol.DetectResponse{Detected: true, Reason: "found ~/.codex/sessions/"}, nil
 	}
 
-	return &adapterprotocol.DetectResponse{Detected: false, Reason: "~/.codex/sessions/ not found"}, nil
+	return &adapterprotocol.DetectResponse{Detected: false, Reason: "codex executable and ~/.codex/sessions/ not found"}, nil
+}
+
+// projectUsesCodex reports whether a repo has opted into Codex, mirroring
+// CodexAgent.DetectProject() on the ox side: a `.codex/` directory in the repo
+// root. `ox init` creates it when the user configures Codex.
+func projectUsesCodex(repoRoot string) bool {
+	info, err := os.Stat(filepath.Join(repoRoot, codexProjectPath))
+	return err == nil && info.IsDir()
 }
 
 func handleDiagnose(p adapterprotocol.DiagnoseParams) (*adapterprotocol.DiagnoseResult, error) {
-	var issues []adapterprotocol.DiagnoseIssue
-
-	home, _ := os.UserHomeDir()
-	codexDir := filepath.Join(home, ".codex")
-	if _, err := os.Stat(codexDir); os.IsNotExist(err) {
-		issues = append(issues, adapterprotocol.DiagnoseIssue{
+	detected, err := handleDetect()
+	if err != nil {
+		return nil, err
+	}
+	if !detected.Detected {
+		return &adapterprotocol.DiagnoseResult{Issues: []adapterprotocol.DiagnoseIssue{{
 			Slug:     "codex:not-installed",
 			Severity: "warning",
 			Title:    "Codex CLI not detected",
-			Detail:   "~/.codex directory not found.",
-		})
+			Detail:   detected.Reason,
+		}}}, nil
 	}
 
+	var issues []adapterprotocol.DiagnoseIssue
 	if p.RepoRoot != "" {
-		hooksPath := filepath.Join(p.RepoRoot, codexProjectPath, codexHooksFileName)
-		hooksMap, _, err := readHooksFile(hooksPath)
-		hooksOK := err == nil
-		if hooksOK {
-			for _, event := range codexHookEvents {
-				if !eventHasOxHook(hooksMap[event]) {
-					hooksOK = false
-					break
+		// Only report missing hooks for a project that actually uses Codex.
+		// Detection is deliberately broad (a `codex` on PATH is enough) so
+		// `ox init` can offer to set Codex up, but the CLI merely being
+		// installed is not consent to create project config: without this
+		// gate every repo on the machine warns, and `ox doctor --fix` writes
+		// .codex/ into repos that never touch Codex. ox doctor's core check
+		// draws the same line — see checkAgentHooks, which returns a silent
+		// skip for "CLI detected, no project config".
+		if projectUsesCodex(p.RepoRoot) {
+			hooksPath := filepath.Join(p.RepoRoot, codexProjectPath, codexHooksFileName)
+			hooksMap, _, err := readHooksFile(hooksPath)
+			hooksOK := err == nil
+			if hooksOK {
+				for _, event := range codexHookEvents {
+					if !eventHasOxHook(hooksMap[event]) {
+						hooksOK = false
+						break
+					}
 				}
 			}
-		}
-		if !hooksOK {
-			issues = append(issues, adapterprotocol.DiagnoseIssue{
-				Slug:     "codex:hooks-missing",
-				Severity: "warning",
-				Title:    "ox hooks not installed for Codex CLI",
-				Detail:   "Codex CLI hooks are not configured for this project.",
-				Fix:      "ox integrate install --codex",
-				FixArgv:  []string{"ox", "integrate", "install", "--codex"},
-				FixSafe:  true,
-			})
+			if !hooksOK {
+				issues = append(issues, adapterprotocol.DiagnoseIssue{
+					Slug:     "codex:hooks-missing",
+					Severity: "warning",
+					Title:    "ox hooks not installed for Codex CLI",
+					Detail:   "Codex CLI hooks are not configured for this project.",
+					Fix:      "ox integrate install --codex",
+					FixArgv:  []string{"ox", "integrate", "install", "--codex"},
+					FixSafe:  true,
+				})
+			}
 		}
 
 		legacyFeatureFlag, err := hasLegacyFeatureFlag(p.RepoRoot, p.Scope)

--- a/cmd/ox-adapter-codex/hooks_test.go
+++ b/cmd/ox-adapter-codex/hooks_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	toml "github.com/pelletier/go-toml/v2"
@@ -184,6 +185,10 @@ func TestHandleUninstallHooks_LeavesCodexConfigUntouched(t *testing.T) {
 
 func TestHandleDiagnose_ReportsDeprecatedHookFeature(t *testing.T) {
 	repoRoot := t.TempDir()
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".codex", "sessions"), 0o755))
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	configPath := filepath.Join(repoRoot, codexProjectPath, codexConfigFile)
 	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o755))
 	require.NoError(t, os.WriteFile(configPath, []byte("[features]\ncodex_hooks = true\n"), 0o600))
@@ -198,4 +203,70 @@ func TestHandleDiagnose_ReportsDeprecatedHookFeature(t *testing.T) {
 		}
 	}
 	t.Fatal("deprecated Codex hook feature was not reported")
+}
+
+func TestHandleDiagnose_CodexAbsentSkipsHookDiagnostics(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("PATH", t.TempDir())
+
+	repoRoot := t.TempDir()
+	result, err := handleDiagnose(adapterprotocol.DiagnoseParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	require.Len(t, result.Issues, 1)
+	assert.Equal(t, "codex:not-installed", result.Issues[0].Slug)
+	assert.NotContains(t, result.Issues[0].Detail, "hooks")
+	assert.NoFileExists(t, filepath.Join(repoRoot, codexProjectPath, codexHooksFileName))
+}
+
+// fakeCodexOnPath puts an executable named `codex` on PATH and points HOME at
+// an empty dir, so detection succeeds via the CLI alone — the state every user
+// with Codex installed is in, for every repo on their machine.
+func fakeCodexOnPath(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake binaries require unix")
+	}
+	binDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "codex"), []byte("#!/bin/sh\n"), 0o755))
+	t.Setenv("PATH", binDir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
+// TestHandleDiagnose_CodexOnPathWithoutProjectConfig verifies that a Codex CLI
+// merely installed on the machine produces no hook diagnostics for a repo that
+// never opted into Codex.
+//
+// Failure prevented: `ox doctor` warns about Codex in every repo on the
+// machine, and `ox doctor --fix` creates .codex/hooks.json in repos that don't
+// use Codex — contradicting doctor's core check, which stays silent for
+// "CLI detected, no project config".
+func TestHandleDiagnose_CodexOnPathWithoutProjectConfig(t *testing.T) {
+	fakeCodexOnPath(t)
+
+	repoRoot := t.TempDir()
+	result, err := handleDiagnose(adapterprotocol.DiagnoseParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	assert.True(t, result.OK)
+	assert.Empty(t, result.Issues)
+	assert.NoDirExists(t, filepath.Join(repoRoot, codexProjectPath))
+}
+
+// TestHandleDiagnose_CodexProjectMissingHooks is the positive control for the
+// test above: once a repo opts into Codex, missing hooks ARE reported. Without
+// it, the silence assertion would pass even if hook diagnostics were deleted.
+func TestHandleDiagnose_CodexProjectMissingHooks(t *testing.T) {
+	fakeCodexOnPath(t)
+
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, codexProjectPath), 0o755))
+
+	result, err := handleDiagnose(adapterprotocol.DiagnoseParams{RepoRoot: repoRoot, Scope: "project"})
+	require.NoError(t, err)
+	require.Len(t, result.Issues, 1)
+	assert.Equal(t, "codex:hooks-missing", result.Issues[0].Slug)
+	assert.True(t, result.Issues[0].FixSafe)
 }

--- a/cmd/ox/adapter_test.go
+++ b/cmd/ox/adapter_test.go
@@ -326,6 +326,9 @@ case "$1" in
   info)
     echo '{"protocol_version":1,"name":"%s","display_name":"%s","version":"%s","type":"%s","capabilities":["session_reader","hook_installer"]}'
     ;;
+  detect)
+    echo '{"detected":true,"reason":"test adapter"}'
+    ;;
   install-hooks)
     repo_root=""
     shift

--- a/cmd/ox/doctor_adapters.go
+++ b/cmd/ox/doctor_adapters.go
@@ -202,10 +202,13 @@ func adapterErrorToCheckResult(adapterName string, err error, _ string) checkRes
 // shouldFixAdapterSlug checks whether an adapter-namespaced slug should be
 // fixed. Adapter slugs are not in the DoctorCheckRegistry, so we handle them
 // separately from core slugs.
+//
+// A bare `ox doctor` never repairs an adapter issue: writing requires --fix or
+// an explicit --fix-slug, matching the core checks (see checkCodexHooks). There
+// used to be an autoFixAdapterSlugs allowlist that bypassed this gate, but every
+// Codex fix runs `ox integrate install --codex`, which creates .codex/hooks.json
+// in the repo — a read-only diagnostic command must not do that.
 func (opts doctorOptions) shouldFixAdapterSlug(slug string, fixSafe bool) bool {
-	if autoFixAdapterSlugs[slug] && fixSafe {
-		return true
-	}
 	// check if this specific slug was requested via --fix-slug
 	for _, s := range opts.fixSlugs {
 		if s == slug {
@@ -228,13 +231,6 @@ func (opts doctorOptions) shouldFixAdapterSlug(slug string, fixSafe bool) bool {
 var adapterFixArgvAllowlist = map[string]bool{
 	"git": true,
 	"ox":  true,
-}
-
-// autoFixAdapterSlugs lists adapter diagnostics that are safe enough to repair
-// during every doctor run. Adapter diagnostics do not participate in the core
-// DoctorCheckRegistry, so their auto-fix policy lives here.
-var autoFixAdapterSlugs = map[string]bool{
-	"codex:codex:legacy-hooks-feature": true,
 }
 
 // gitScopeEscalationFlags are argv tokens that escalate a fix beyond the current

--- a/cmd/ox/doctor_adapters_test.go
+++ b/cmd/ox/doctor_adapters_test.go
@@ -177,16 +177,48 @@ func TestShouldFixAdapterSlug(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "safe automatic Codex migration",
+			// Every Codex fix shells out to `ox integrate install --codex`,
+			// which writes .codex/hooks.json. A bare `ox doctor` must not.
+			name:    "safe Codex migration is not repaired without --fix",
 			opts:    doctorOptions{},
+			slug:    "codex:codex:legacy-hooks-feature",
+			fixSafe: true,
+			want:    false,
+		},
+		{
+			name:    "safe Codex migration is repaired with --fix",
+			opts:    doctorOptions{fix: true},
 			slug:    "codex:codex:legacy-hooks-feature",
 			fixSafe: true,
 			want:    true,
 		},
 		{
-			name:    "unsafe Codex migration is not automatic",
+			// A bare `ox doctor` must never create Codex project config —
+			// the adapter reports hooks-missing on CLI-on-PATH alone.
+			name:    "missing Codex hooks are not repaired without --fix",
 			opts:    doctorOptions{},
+			slug:    "codex:codex:hooks-missing",
+			fixSafe: true,
+			want:    false,
+		},
+		{
+			name:    "missing Codex hooks are repaired with --fix",
+			opts:    doctorOptions{fix: true},
+			slug:    "codex:codex:hooks-missing",
+			fixSafe: true,
+			want:    true,
+		},
+		{
+			name:    "unsafe Codex migration is not fixed even with --fix",
+			opts:    doctorOptions{fix: true},
 			slug:    "codex:codex:legacy-hooks-feature",
+			fixSafe: false,
+			want:    false,
+		},
+		{
+			name:    "unsafe missing Codex hooks are not fixed even with --fix",
+			opts:    doctorOptions{fix: true},
+			slug:    "codex:codex:hooks-missing",
 			fixSafe: false,
 			want:    false,
 		},

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -1945,8 +1945,8 @@ func displayPath(absPath string) string {
 }
 
 // selectAgentsForInit discovers available adapters and prompts the user to
-// choose which ones to configure. Claude Code defaults to selected; all
-// others default to off. Returns adapter names the user selected.
+// choose which ones to configure. Detected agents default to selected.
+// Returns adapter names the user selected.
 func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
 	selected := map[string]bool{}
 
@@ -1961,9 +1961,19 @@ func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
 		return selected, nil
 	}
 
-	// non-interactive: Claude Code only
+	// Non-interactive callers cannot answer the selection prompt. Configure
+	// every detected agent so `ox init` keeps its hook-installation promise
+	// when invoked from an AI coworker or CI.
 	if !cli.IsInteractive() {
 		selected["claude-code"] = true
+		for _, ea := range adapters.DiscoverExternalAdapters() {
+			if ea.Detect() {
+				selected[ea.Name()] = true
+			}
+		}
+		if _, err := os.Stat(filepath.Join(gitRoot, ".opencode")); err == nil {
+			selected["opencode"] = true
+		}
 		return selected, nil
 	}
 
@@ -1987,8 +1997,9 @@ func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
 			label = info.DisplayName
 		}
 		options = append(options, cli.MultiSelectOption{
-			Label: label,
-			Value: ea.Name(),
+			Label:    label,
+			Value:    ea.Name(),
+			Selected: true,
 		})
 	}
 
@@ -1996,8 +2007,9 @@ func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
 	openCodeDir := filepath.Join(gitRoot, ".opencode")
 	if _, err := os.Stat(openCodeDir); err == nil {
 		options = append(options, cli.MultiSelectOption{
-			Label: "OpenCode",
-			Value: "opencode",
+			Label:    "OpenCode",
+			Value:    "opencode",
+			Selected: true,
 		})
 	}
 

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -1971,7 +1971,7 @@ func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
 				selected[ea.Name()] = true
 			}
 		}
-		if _, err := os.Stat(filepath.Join(gitRoot, ".opencode")); err == nil {
+		if info, err := os.Stat(filepath.Join(gitRoot, ".opencode")); err == nil && info.IsDir() {
 			selected["opencode"] = true
 		}
 		return selected, nil
@@ -2005,7 +2005,7 @@ func selectAgentsForInit(gitRoot string) (map[string]bool, error) {
 
 	// check for OpenCode separately (built-in detection)
 	openCodeDir := filepath.Join(gitRoot, ".opencode")
-	if _, err := os.Stat(openCodeDir); err == nil {
+	if info, err := os.Stat(openCodeDir); err == nil && info.IsDir() {
 		options = append(options, cli.MultiSelectOption{
 			Label:    "OpenCode",
 			Value:    "opencode",

--- a/cmd/ox/init.go
+++ b/cmd/ox/init.go
@@ -2084,7 +2084,12 @@ func installAgentHooks(gitRoot string, quiet bool, selectedAgents map[string]boo
 		if !selectedAgents[ea.Name()] {
 			continue
 		}
-		if ea.HasCapability(adapterprotocol.CapHookInstaller) {
+		// OpenCode hooks are already installed above: InstallProjectOpenCodeHooks
+		// resolves this same adapter and calls InstallHooks on it, so running the
+		// generic path too would repeat the identical call and double-report the
+		// plugin in installedHooks. Rules/commands/skills below are not installed
+		// by the built-in helper, so they still run for opencode.
+		if ea.HasCapability(adapterprotocol.CapHookInstaller) && ea.Name() != "opencode" {
 			result, err := ea.InstallHooks(gitRoot, "project")
 			if err != nil {
 				if !quiet {

--- a/cmd/ox/init_test.go
+++ b/cmd/ox/init_test.go
@@ -4,9 +4,11 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/repotools"
+	"github.com/sageox/ox/internal/session/adapters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -345,6 +348,72 @@ func TestSelectAgentsForInit_NonInteractiveSkipsUndetectedAdapters(t *testing.T)
 	selected, err := selectAgentsForInit(t.TempDir())
 	require.NoError(t, err)
 	assert.False(t, selected["codex"], "undetected Codex must not create project integration files")
+}
+
+// TestInstallAgentHooks_OpenCodeInstallsOnce verifies OpenCode hooks are
+// installed exactly once when the opencode adapter is selected.
+//
+// Failure prevented: InstallProjectOpenCodeHooks resolves the opencode external
+// adapter and calls InstallHooks on it, and the generic external-adapter loop
+// then makes the identical call again — so a selected OpenCode gets its plugin
+// written twice and double-listed in installedHooks (which feeds git staging).
+func TestInstallAgentHooks_OpenCodeInstallsOnce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script adapters require unix")
+	}
+	gitRoot := t.TempDir()
+	adapterDir := t.TempDir()
+	counter := filepath.Join(t.TempDir(), "install-hooks.calls")
+
+	// Adapter records every install-hooks invocation so a duplicate call is
+	// observable rather than hidden by the real adapter's idempotence.
+	script := fmt.Sprintf(`#!/bin/sh
+case "$1" in
+  info)
+    echo '{"protocol_version":1,"name":"opencode","display_name":"OpenCode","version":"0.1.0","type":"session","capabilities":["session_reader","hook_installer"]}'
+    ;;
+  detect)
+    echo '{"detected":true,"reason":"test adapter"}'
+    ;;
+  install-hooks)
+    echo call >> %q
+    repo_root=""
+    shift
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --repo-root) repo_root="$2"; shift 2 ;;
+        --scope) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    mkdir -p "$repo_root/.opencode/plugin"
+    echo '// ox' > "$repo_root/.opencode/plugin/ox-prime.ts"
+    echo '{"installed":true,"files_written":[".opencode/plugin/ox-prime.ts"],"hooks":["SessionStart"]}'
+    ;;
+  *)
+    echo '{}'
+    ;;
+esac`, counter)
+	require.NoError(t, os.WriteFile(filepath.Join(adapterDir, "ox-adapter-opencode"), []byte(script), 0o755))
+
+	t.Setenv("OX_ADAPTER_PATH", adapterDir)
+	adapters.Unregister("opencode")
+	t.Cleanup(func() { adapters.Unregister("opencode") })
+
+	installed := installAgentHooks(gitRoot, true, map[string]bool{"opencode": true})
+
+	data, err := os.ReadFile(counter)
+	require.NoError(t, err, "adapter install-hooks was never invoked")
+	calls := len(strings.Fields(string(data)))
+	assert.Equal(t, 1, calls, "opencode install-hooks must run exactly once per init")
+
+	var pluginEntries int
+	for _, p := range installed {
+		if strings.Contains(p, "ox-prime.ts") {
+			pluginEntries++
+		}
+	}
+	assert.Equal(t, 1, pluginEntries, "OpenCode plugin must be staged once, not duplicated")
 }
 
 func TestSelectTeam_NoTeams(t *testing.T) {

--- a/cmd/ox/init_test.go
+++ b/cmd/ox/init_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/sageox/ox/internal/api"
+	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/repotools"
@@ -307,6 +308,43 @@ func TestStringSlicesEqual_OneNilOneNonEmpty(t *testing.T) {
 
 	result := stringSlicesEqual(a, b)
 	assert.False(t, result, "expected nil and non-empty slice to be unequal")
+}
+
+func TestSelectAgentsForInit_NonInteractiveIncludesDetectedAdapters(t *testing.T) {
+	cli.SetNoInteractive(true)
+	t.Cleanup(func() { cli.SetNoInteractive(false) })
+
+	previousAgentsFlag := initAgentsFlag
+	initAgentsFlag = ""
+	t.Cleanup(func() { initAgentsFlag = previousAgentsFlag })
+
+	adapterDir := t.TempDir()
+	createFakeAdapterWithHooks(t, adapterDir, "codex", "0.1.0", "session", ".codex")
+	t.Setenv("OX_ADAPTER_PATH", adapterDir)
+	t.Setenv("HOME", t.TempDir())
+
+	selected, err := selectAgentsForInit(t.TempDir())
+	require.NoError(t, err)
+	assert.True(t, selected["claude-code"])
+	assert.True(t, selected["codex"], "detected Codex must be configured when init cannot prompt")
+}
+
+func TestSelectAgentsForInit_NonInteractiveSkipsUndetectedAdapters(t *testing.T) {
+	cli.SetNoInteractive(true)
+	t.Cleanup(func() { cli.SetNoInteractive(false) })
+
+	previousAgentsFlag := initAgentsFlag
+	initAgentsFlag = ""
+	t.Cleanup(func() { initAgentsFlag = previousAgentsFlag })
+
+	adapterDir := t.TempDir()
+	createFakeAdapter(t, adapterDir, "codex", "0.1.0", "session")
+	t.Setenv("OX_ADAPTER_PATH", adapterDir)
+	t.Setenv("HOME", t.TempDir())
+
+	selected, err := selectAgentsForInit(t.TempDir())
+	require.NoError(t, err)
+	assert.False(t, selected["codex"], "undetected Codex must not create project integration files")
 }
 
 func TestSelectTeam_NoTeams(t *testing.T) {

--- a/internal/carts/server_test.go
+++ b/internal/carts/server_test.go
@@ -93,7 +93,7 @@ func TestStopServer(t *testing.T) {
 	livingHelper := func(t *testing.T) (int, <-chan struct{}) {
 		t.Helper()
 		cmd := exec.Command(os.Args[0], "-test.run=TestSleepHelper")
-		cmd.Env = append(os.Environ(), "OX_CARTS_SLEEP_HELPER=1")
+		cmd.Env = append(os.Environ(), "OX_CARTS_SLEEP_HELPER=1") // safe: re-execs this test binary as a sleep helper, not ox
 		if err := cmd.Start(); err != nil {
 			t.Fatalf("spawn sleep helper: %v", err)
 		}

--- a/internal/ledgersearch/no_network_test.go
+++ b/internal/ledgersearch/no_network_test.go
@@ -43,14 +43,22 @@ func TestSearch_NoNetworkCalls(t *testing.T) {
 	// path. If Search ever introduces network I/O, the dialer hook above
 	// fires and fails the test.
 	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, "sessions", "2026-05-20T10-15-ryan-OxTest"), 0o755); err != nil {
+	fixtureTime := time.Date(2026, 5, 20, 10, 15, 0, 0, time.UTC)
+	sessionPath := filepath.Join(dir, "sessions", fixtureTime.Format("2006-01-02T15-04")+"-ryan-OxTest")
+	if err := os.MkdirAll(sessionPath, 0o755); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "sessions", "2026-05-20T10-15-ryan-OxTest", "summary.md"), []byte("the term widget matches"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(sessionPath, "summary.md"), []byte("the term widget matches"), 0o644); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 
-	results, err := Search(Options{LedgerPath: dir, Query: "widget", Now: time.Now()})
+	// Keep the clock near the fixed fixture timestamp. This test covers the
+	// zero-network path, not the 90-day session-retention boundary.
+	results, err := Search(Options{
+		LedgerPath: dir,
+		Query:      "widget",
+		Now:        fixtureTime.Add(24 * time.Hour),
+	})
 	if err != nil {
 		t.Fatalf("Search returned err (should be fail-open): %v", err)
 	}


### PR DESCRIPTION
## What was broken

Codex hooks weren't reliably getting installed, and the two code paths that should have fixed that disagreed with each other.

- **`ox init` under-installed.** Detection required `~/.codex/sessions/`, which only exists after you've actually *run* a Codex session. Install the CLI, run `ox init`, get no hooks. The non-interactive path was worse: it hardcoded Claude Code only, so `ox init` invoked by an AI coworker or CI never configured any other agent.
- **`ox doctor` over-wrote.** An `autoFixAdapterSlugs` allowlist let listed adapter diagnostics repair themselves on a *bare* `ox doctor`, bypassing the `--fix` gate every core check honors. The fix command is `ox integrate install --codex`, which creates `.codex/hooks.json` — so a read-only diagnostic command was writing project config.
- **The two Codex checks in doctor disagreed.** `checkAgentHooks` deliberately stays silent for "CLI detected, no project config" and never installs there. The adapter's `codex:hooks-missing` had no such notion, so it warned about — and offered to fix — Codex in every repo on a machine with the CLI installed.

## What this PR ships

- **`cmd/ox/init.go`** — detected agents now default to selected in the interactive prompt; the non-interactive path configures Claude Code plus every detected adapter, so `ox init` keeps its hook-installation promise when it can't prompt.
- **`cmd/ox-adapter-codex/detect.go`** — `handleDetect` also accepts a `codex` on PATH. `handleDiagnose` short-circuits when Codex isn't detected (one `codex:not-installed` issue, no hook noise), and reports `codex:hooks-missing` only for a repo that opted in via `.codex/`.
- **`cmd/ox/doctor_adapters.go`** — deleted `autoFixAdapterSlugs` and the branch that consulted it. Adapter fixes now flow through the same two gates as everything else: an explicit `--fix-slug`, or `--fix` with `FixSafe: true`.

### Resulting behavior

| State | `ox doctor` | `ox doctor --fix` |
|---|---|---|
| codex on PATH, repo has no `.codex/` | silent | no write |
| repo has `.codex/`, hooks missing | warning | installs hooks |
| `ox init`, Codex detected | — | installs hooks (pre-checked in the prompt, automatic when non-interactive) |

Both doctor paths now say the same thing about the same state, and the double-report when `.codex/` exists is gone — the core check passes once hooks are present, so only one of them can be unhappy at a time.

### Why the `--fix` loop converges

```mermaid
flowchart LR
    A["ox doctor --fix"] --> B["runAdapterFix<br/>ox integrate install --codex"]
    B --> C["installExternalAdapterHooks"]
    C --> D["ox-adapter-codex install-hooks<br/>writes codexHookEvents"]
    D --> E["verifyAdapterFix<br/>re-runs diagnose"]
    E --> F["reads the same<br/>codexHookEvents constant"]
    F --> G["issue gone"]
```

`ox integrate install --codex` delegates to the same adapter binary and the same `codexHookEvents` constant that `handleDiagnose` reads back, so a fix can't be applied-but-not-recognized. No "fix applied but issue persists" loop.

## Test Plan

- **`TestHandleDiagnose_CodexOnPathWithoutProjectConfig`** — a Codex CLI merely installed produces no hook diagnostics for a repo that never opted in. Verified red without the gate (`Should be empty, but was [{codex:hooks-missing ...}]`), green with it.
- **`TestHandleDiagnose_CodexProjectMissingHooks`** — positive control. Without it the silence assertion would pass even if hook diagnostics were deleted wholesale.
- **`TestShouldFixAdapterSlug`** — now pins both halves per slug: bare `doctor` → no fix, `--fix` → fix. The two unsafe cases moved to `doctorOptions{fix: true}`; under `{}` they passed vacuously and would have stayed green even if `FixSafe` were ignored entirely.
- **`TestSelectAgentsForInit_NonInteractive{Includes,Skips}*`** — detected adapters get configured when init can't prompt; undetected ones don't create project integration files.
- `make test`: 19009 tests, 0 failures. `golangci-lint` clean on every file in this diff.

## Follow-up, not in scope

`DetectAdapter()` (`internal/session/adapters/adapter.go:183`) iterates a Go map and returns the first adapter whose `Detect()` is true, so when several agents are installed the winner is a coin flip. Anyone using both Claude Code and Codex already hits this — `~/.claude` and `~/.codex/sessions/` both exist for them — so it predates this branch. `findCapturePriorAdapter` already solved it locally by running `Detect()` alphabetically over capability-filtered adapters; `DetectAdapter` should get the same treatment. Worth a separate issue rather than folding session-routing changes into a hooks fix.

Two unrelated test fixes ride along, both pre-existing on the branch: a comment on the carts sleep-helper spawn, and pinning `ledgersearch`'s no-network test to its fixture timestamp so it doesn't start failing once the fixture ages past the 90-day retention window.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Initialization now includes detected external coding assistants and OpenCode by default, including in non-interactive mode.
  - Codex detection recognizes installations available through the system PATH or session storage.
  - Diagnostics provide clearer guidance when Codex or project hooks are missing.

- **Bug Fixes**
  - Adapter repairs no longer run automatically.
  - Safe repairs require an explicit fix command, while unsafe repairs remain blocked.
  - Project hook checks are limited to repositories configured for Codex.
  - OpenCode hooks are installed only once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->