### PR TITLE
fix(session): resolve known agents by name, not adapter detection

### DIFF
--- a/cmd/ox/agent_session.go
+++ b/cmd/ox/agent_session.go
@@ -148,12 +148,12 @@ func runAgentSessionStart(inst *agentinstance.Instance, args []string) error {
 		}
 		sessionFile = sf
 	} else {
-		// Deep adapter detection: only for Claude Code or unknown agents.
-		// For known non-Claude agents, skip detection to avoid false positives
+		// Deep adapter resolution: only for Claude Code or unknown agents.
+		// For known non-Claude agents, skip it to avoid false positives
 		// (the claude-code adapter's Detect() returns true if ~/.claude exists,
 		// which is common on machines where multiple agents are installed).
 		if agentType == string(agentx.AgentTypeClaudeCode) || agentType == "" {
-			if adapter, detectErr := adapters.DetectAdapter(); detectErr == nil {
+			if adapter, detectErr := resolveSessionAdapter(agentType); detectErr == nil {
 				adapterName = adapter.Name()
 				since := time.Now().Add(-5 * time.Minute)
 				sf, findErr := adapter.FindSessionFile(adapters.SessionLookup{
@@ -2285,6 +2285,25 @@ func rawJSONLHasEntries(rawPath string) bool {
 // file created (no session file provided and adapter is generic).
 func needsGenericDropFile(sessionFile, adapterName string) bool {
 	return sessionFile == "" && pipeline.IsGenericAdapter(adapterName)
+}
+
+// resolveSessionAdapter picks the deep adapter for a starting session.
+//
+// A known agent type is looked up by name; detection is only a guess and is
+// used solely when the type is unknown. An adapter's Detect() reports that its
+// agent is INSTALLED on this machine, not that it produced this session, so on
+// a machine with several agents installed multiple adapters answer true and
+// DetectAdapter has to break the tie arbitrarily. Detecting for an agent we
+// have already identified could therefore bind a Claude Code session to, say,
+// the aider adapter — FindSessionFile then fails, the failure is only logged at
+// Info, and because adapterName is already set the generic fallback below does
+// not fire. The recording ends up registered under the wrong adapter with no
+// session file, which is the header-only raw.jsonl shape of issue #519.
+func resolveSessionAdapter(agentType string) (adapters.Adapter, error) {
+	if agentType != "" {
+		return adapters.GetAdapter(agentType)
+	}
+	return adapters.DetectAdapter()
 }
 
 // isGenericDropFileEmpty returns true when a generic adapter's drop file is

--- a/cmd/ox/agent_session_test.go
+++ b/cmd/ox/agent_session_test.go
@@ -581,9 +581,7 @@ func TestSessionStop_NonEmptyDropFile_NotIncomplete(t *testing.T) {
 
 // --- Adapter resolution at session start ---
 
-// TestResolveSessionAdapter_KnownAgentIgnoresOtherInstalledAgents verifies a
-// session whose agent type is known resolves to that agent's adapter, even when
-// other agents are installed and their adapters also detect.
+// TestResolveSessionAdapter verifies which adapter a starting session binds to.
 //
 // Failure prevented: Detect() reports that an agent is INSTALLED, not that it
 // produced this session. Resolving a known Claude Code session by detection let
@@ -591,10 +589,11 @@ func TestSessionStop_NonEmptyDropFile_NotIncomplete(t *testing.T) {
 // is logged at Info only, and the generic fallback is skipped because
 // adapterName is already set, leaving a recording bound to the wrong adapter
 // with no session file (the header-only raw.jsonl shape of issue #519).
-func TestResolveSessionAdapter_KnownAgentIgnoresOtherInstalledAgents(t *testing.T) {
+func TestResolveSessionAdapter(t *testing.T) {
+	// Both adapters are installed and both detect. "aider" sorts before
+	// "claude-code", so it wins any name-ordered tie and would have won roughly
+	// half of the old map-ordered races.
 	adapterDir := t.TempDir()
-	// "aider" sorts before "claude-code", so it wins any name-ordered tie and
-	// would have won roughly half the map-ordered races.
 	createFakeAdapterWithHooks(t, adapterDir, "aider", "0.1.0", "session", ".aider")
 	createFakeAdapterWithHooks(t, adapterDir, "claude-code", "0.1.0", "session", ".claude")
 	t.Setenv("OX_ADAPTER_PATH", adapterDir)
@@ -604,26 +603,34 @@ func TestResolveSessionAdapter_KnownAgentIgnoresOtherInstalledAgents(t *testing.
 		t.Cleanup(func() { adapters.Unregister(name) })
 	}
 
-	// Repeat: under map-order detection this passed only by luck.
-	for i := 0; i < 25; i++ {
-		adapter, err := resolveSessionAdapter("claude-code")
-		require.NoError(t, err)
-		require.Equal(t, "claude-code", adapter.Name(),
-			"a known Claude Code session must never bind to another agent's adapter")
+	tests := []struct {
+		name      string
+		agentType string
+		want      string
+		why       string
+	}{
+		{
+			name:      "known agent resolves by name",
+			agentType: "claude-code",
+			want:      "claude-code",
+			why:       "a known Claude Code session must never bind to another installed agent's adapter",
+		},
+		{
+			name:      "unknown agent falls back to detection",
+			agentType: "",
+			want:      "aider",
+			why:       "with no agent type the only signal is detection, tie-broken by name order",
+		},
 	}
-}
 
-// TestResolveSessionAdapter_UnknownAgentFallsBackToDetection verifies detection
-// is still used when the agent type is unknown — the only case where guessing
-// is the best available signal.
-func TestResolveSessionAdapter_UnknownAgentFallsBackToDetection(t *testing.T) {
-	adapterDir := t.TempDir()
-	createFakeAdapterWithHooks(t, adapterDir, "aider", "0.1.0", "session", ".aider")
-	t.Setenv("OX_ADAPTER_PATH", adapterDir)
-	adapters.Unregister("aider")
-	t.Cleanup(func() { adapters.Unregister("aider") })
-
-	adapter, err := resolveSessionAdapter("")
-	require.NoError(t, err)
-	assert.Equal(t, "aider", adapter.Name())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Repeat: under map-order detection this passed only by luck.
+			for i := 0; i < 25; i++ {
+				adapter, err := resolveSessionAdapter(tt.agentType)
+				require.NoError(t, err)
+				require.Equal(t, tt.want, adapter.Name(), tt.why)
+			}
+		})
+	}
 }

--- a/cmd/ox/agent_session_test.go
+++ b/cmd/ox/agent_session_test.go
@@ -578,3 +578,52 @@ func TestSessionStop_NonEmptyDropFile_NotIncomplete(t *testing.T) {
 	assert.False(t, isGenericDropFileEmpty(stateNonGeneric),
 		"isGenericDropFileEmpty should return false for non-generic adapters")
 }
+
+// --- Adapter resolution at session start ---
+
+// TestResolveSessionAdapter_KnownAgentIgnoresOtherInstalledAgents verifies a
+// session whose agent type is known resolves to that agent's adapter, even when
+// other agents are installed and their adapters also detect.
+//
+// Failure prevented: Detect() reports that an agent is INSTALLED, not that it
+// produced this session. Resolving a known Claude Code session by detection let
+// whichever adapter won the registry race claim it — FindSessionFile then fails,
+// is logged at Info only, and the generic fallback is skipped because
+// adapterName is already set, leaving a recording bound to the wrong adapter
+// with no session file (the header-only raw.jsonl shape of issue #519).
+func TestResolveSessionAdapter_KnownAgentIgnoresOtherInstalledAgents(t *testing.T) {
+	adapterDir := t.TempDir()
+	// "aider" sorts before "claude-code", so it wins any name-ordered tie and
+	// would have won roughly half the map-ordered races.
+	createFakeAdapterWithHooks(t, adapterDir, "aider", "0.1.0", "session", ".aider")
+	createFakeAdapterWithHooks(t, adapterDir, "claude-code", "0.1.0", "session", ".claude")
+	t.Setenv("OX_ADAPTER_PATH", adapterDir)
+
+	for _, name := range []string{"aider", "claude-code"} {
+		adapters.Unregister(name)
+		t.Cleanup(func() { adapters.Unregister(name) })
+	}
+
+	// Repeat: under map-order detection this passed only by luck.
+	for i := 0; i < 25; i++ {
+		adapter, err := resolveSessionAdapter("claude-code")
+		require.NoError(t, err)
+		require.Equal(t, "claude-code", adapter.Name(),
+			"a known Claude Code session must never bind to another agent's adapter")
+	}
+}
+
+// TestResolveSessionAdapter_UnknownAgentFallsBackToDetection verifies detection
+// is still used when the agent type is unknown — the only case where guessing
+// is the best available signal.
+func TestResolveSessionAdapter_UnknownAgentFallsBackToDetection(t *testing.T) {
+	adapterDir := t.TempDir()
+	createFakeAdapterWithHooks(t, adapterDir, "aider", "0.1.0", "session", ".aider")
+	t.Setenv("OX_ADAPTER_PATH", adapterDir)
+	adapters.Unregister("aider")
+	t.Cleanup(func() { adapters.Unregister("aider") })
+
+	adapter, err := resolveSessionAdapter("")
+	require.NoError(t, err)
+	assert.Equal(t, "aider", adapter.Name())
+}

--- a/internal/session/adapters/adapter.go
+++ b/internal/session/adapters/adapter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -156,20 +157,48 @@ func Register(adapter Adapter) {
 	registry[name] = adapter
 }
 
+// snapshotAdapters returns the registered adapters ordered by name.
+//
+// Two reasons this exists instead of ranging over the registry directly.
+// Ordering: map iteration is randomized, so several adapters reporting
+// Detect()=true made DetectAdapter's answer a coin flip that changed run to
+// run. Locking: Detect() shells out to the adapter binary, so holding the
+// registry lock across the loop would block every other adapter user for the
+// duration of a subprocess call.
+func snapshotAdapters() []Adapter {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	ordered := make([]Adapter, 0, len(names))
+	for _, name := range names {
+		ordered = append(ordered, registry[name])
+	}
+	return ordered
+}
+
 // DetectAdapter finds the appropriate adapter for the current environment.
 // First checks registered (built-in) adapters, then falls through to external
 // adapter discovery if no registered adapter matches.
 // Returns ErrNoAdapterDetected if no adapter can handle the environment.
+//
+// Detection is a GUESS and callers should prefer GetAdapter when they already
+// know which agent is running: an adapter's Detect() reports that its agent is
+// installed on this machine, not that it produced the session at hand, so on a
+// multi-agent machine several adapters answer true at once. Ties are broken by
+// name order, which makes the result reproducible but still arbitrary.
 func DetectAdapter() (Adapter, error) {
 	// fast path: check already-registered adapters (built-ins loaded at init time)
-	registryMu.RLock()
-	for _, adapter := range registry {
+	for _, adapter := range snapshotAdapters() {
 		if adapter.Detect() {
-			registryMu.RUnlock()
 			return adapter, nil
 		}
 	}
-	registryMu.RUnlock()
 
 	// slow path: scan controlled directories (ADR-006) for ox-adapter-* binaries,
 	// call `info` on each, and register them. This covers agents that only have
@@ -178,9 +207,7 @@ func DetectAdapter() (Adapter, error) {
 		slog.Debug("external adapter discovery failed during detect", "error", err)
 	}
 
-	registryMu.RLock()
-	defer registryMu.RUnlock()
-	for _, adapter := range registry {
+	for _, adapter := range snapshotAdapters() {
 		if adapter.Detect() {
 			return adapter, nil
 		}

--- a/internal/session/adapters/adapter_test.go
+++ b/internal/session/adapters/adapter_test.go
@@ -98,23 +98,28 @@ func TestGetAdapter_ReturnsErrNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrAdapterNotFound)
 }
 
+// TestDetectAdapter_ReturnsFirstMatch verifies detection skips non-detecting
+// adapters and resolves ties by name order rather than map iteration order.
+//
+// Failure prevented: with several agents installed, multiple adapters report
+// Detect()=true and the winner changes run to run, so a session can bind to a
+// different agent's adapter on every start (issue #519).
 func TestDetectAdapter_ReturnsFirstMatch(t *testing.T) {
 	ResetRegistry()
 
-	// register adapters in order
-	adapter1 := &mockAdapter{name: "adapter-1", detect: false}
-	adapter2 := &mockAdapter{name: "adapter-2", detect: true}
-	adapter3 := &mockAdapter{name: "adapter-3", detect: true}
+	// adapter-1 sorts first but does not detect, so it must be skipped;
+	// adapter-2 and adapter-3 both detect, and adapter-2 wins on name order.
+	Register(&mockAdapter{name: "adapter-1", detect: false})
+	Register(&mockAdapter{name: "adapter-3", detect: true})
+	Register(&mockAdapter{name: "adapter-2", detect: true})
 
-	Register(adapter1)
-	Register(adapter2)
-	Register(adapter3)
-
-	got, err := DetectAdapter()
-	require.NoError(t, err)
-
-	// should return one of the detecting adapters (map iteration order is non-deterministic)
-	assert.True(t, got.Detect(), "DetectAdapter() should return adapter that detects")
+	// Repeat: a single call would pass ~50% of the time under map ordering.
+	for i := 0; i < 50; i++ {
+		got, err := DetectAdapter()
+		require.NoError(t, err)
+		require.Equal(t, "adapter-2", got.Name(),
+			"DetectAdapter() must break ties deterministically by name")
+	}
 }
 
 func TestDetectAdapter_ReturnsErrNoAdapter(t *testing.T) {


### PR DESCRIPTION
## What broke

`ox agent <id> session start` could bind a Claude Code session to a different agent's adapter, at random, on any machine with more than one AI coworker installed.

`DetectAdapter()` returned the first adapter whose `Detect()` answered true while ranging over the registry — a Go map, so iteration order is randomized per run:

```go
for _, adapter := range registry {
    if adapter.Detect() { return adapter, nil }
}
```

The catch is what `Detect()` actually means. It reports **"this agent is installed on this machine"**, not "this agent produced the session in front of us." The only built-in adapter is `generic` (whose `Detect()` is hardcoded false), so every real adapter — claude-code, codex, aider, gemini, amp, droid, goose, opencode, omp, pi — is an external binary in that same map. Install two agents and two adapters answer true; the winner was a coin flip.

## Why it was silent

```mermaid
flowchart TD
    A["session start<br/>agentType = claude-code"] --> B["DetectAdapter()<br/>map order — coin flip"]
    B --> C["aider adapter wins"]
    C --> D["adapterName = 'aider'"]
    D --> E["FindSessionFile fails<br/>ErrSessionNotFound"]
    E --> F["logged at Info only"]
    F --> G["fallback is 'if adapterName == \"\"'<br/>already set → skipped"]
    G --> H["needsGenericDropFile false<br/>for non-generic adapter"]
    H --> I["recording bound to wrong adapter,<br/>no session file → header-only raw.jsonl"]
```

That end state is the shape `checkRecordingAdapters` calls out as issue #519.

The codebase already knew about this failure mode in two places, and neither fixed the call path:

- `cmd/ox/agent_session.go` — "the claude-code adapter's `Detect()` returns true if `~/.claude` exists, which is common on machines where multiple agents are installed"
- `cmd/ox/agent_session_capture_prior.go` — documents a **real past occurrence**, aider beating claude-code in this same race, fixed locally inside `findCapturePriorAdapter` only

## What this PR ships

**1. Stop guessing when we already know** (`cmd/ox/agent_session.go`)

New `resolveSessionAdapter(agentType)`: a known agent type is looked up by name via `GetAdapter`; detection runs **only** when the type is unknown. This is the same by-name pattern the Codex branch a few lines above already uses.

**2. Make the remaining guess reproducible** (`internal/session/adapters/adapter.go`)

`DetectAdapter` now iterates a name-sorted snapshot. For a genuinely unknown agent, any choice is arbitrary — but arbitrary-and-stable is debuggable, where arbitrary-and-random is not. Same tie-break `findCapturePriorAdapter` settled on.

The snapshot also fixes a second-order problem: `Detect()` shells out to the adapter binary, and the old loop held the registry read lock across every one of those subprocess calls. Callers now iterate with the lock released.

`DetectAdapter`'s doc comment now states outright that detection is a guess and that callers who know the agent should use `GetAdapter`.

## Test Plan

- **`TestResolveSessionAdapter_KnownAgentIgnoresOtherInstalledAgents`** — two fake adapters installed (`aider`, `claude-code`), both detecting. A known Claude Code session must resolve to claude-code every time. Verified red without the fix (`expected "claude-code", actual "aider"`).
- **`TestResolveSessionAdapter_UnknownAgentFallsBackToDetection`** — detection still runs for an unknown agent type, so the fallback path isn't silently dead.
- **`TestDetectAdapter_ReturnsFirstMatch`** — rewritten. It previously asserted only "returned *an* adapter that detects," with a comment conceding map order is non-deterministic — it enshrined the bug. It now registers a non-detecting adapter that sorts first (must be skipped) plus two detecting ones, and asserts the name-ordered winner across 50 iterations. Verified red without the sort (`expected "adapter-2", actual "adapter-3"`).

Both regressions were confirmed by neutering each fix independently and watching only its own test go red.

`make test`: 19012 tests, 0 failures. `golangci-lint` clean on all four changed files.

## Scope

`agentType` reaches `resolveSessionAdapter` only as `claude-code` or empty — the enclosing branch already excludes known non-Claude agents, and Codex is handled by the manual-session branch above. Behavior for every other agent is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions now reliably connect to the adapter matching the identified agent.
  * Unknown agents continue to use automatic adapter detection.
  * Adapter selection is now deterministic when multiple adapters are available.
* **Tests**
  * Added coverage for known-agent matching and fallback detection.
  * Verified consistent adapter selection across repeated attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->