### PR TITLE
fix(cli): degrade brand colors to the terminal's real color depth

### DIFF
--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -35,9 +35,13 @@ It's overwritten by `npm run sync`. Edits silently disappear on the next sync.
 
 ### 3. Use semantic styles, not raw colors
 
-Never `lipgloss.Color("#…")` or ANSI escapes in `cmd/ox/**`. Use `StyleSuccess`, `StyleError`, `StyleAccent`, etc. from `internal/cli/styles.go` and `internal/ui/styles.go`. Raw hex only lives in `internal/theme/generated.go`.
+Never `lipgloss.Color(…)` or ANSI escapes outside Bubble Tea code. Use `StyleSuccess`, `StyleError`, `StyleAccent`, etc. from `internal/cli/styles.go` and `internal/ui/styles.go`; when you genuinely need a new one, build it from `theme.Color(hex)` / `theme.Adapt(token)`. Raw hex only lives in `internal/theme/generated.go`.
 
-**Enforced by:** `make check-design` greps `cmd/ox/**` for `lipgloss.Color("#"` and fails the build.
+This is a correctness rule, not a tidiness one. lipgloss v2's `Style.Render()` always emits 24-bit color, and ox prints past any `colorprofile.Writer`, so a raw `lipgloss.Color` reaches a 256-color terminal as `38;2;R;G;B` — which it misparses into a **background** color, painting whole columns unreadable. `theme.Color` / `theme.Adapt` degrade first. See [docs/design/theming.md § Color depth](../../docs/design/theming.md#color-depth).
+
+Bubble Tea code is exempt: it downsamples its own frames.
+
+**Enforced by:** `TestNoRawLipglossColorOutsideTUI` in `internal/theme/` — fails on any non-TUI file constructing `lipgloss.Color`.
 
 ### 4. Search the catalog before inventing a widget
 
@@ -60,7 +64,9 @@ Always branch on `cli.IsInteractive()` / `cli.IsHeadless()`. Bubbletea forms, sp
 
 ### 7. `NO_COLOR` is sacred
 
-Every component must render readably under `NO_COLOR=1`. Test it. lipgloss handles most of this automatically; verify by running `NO_COLOR=1 ox dev catalog`.
+Every component must render readably under `NO_COLOR=1`. Test it with `NO_COLOR=1 ox dev catalog`. lipgloss v2 does **not** handle this for you — it works only because colors go through `theme.Color` / `theme.Adapt` (rule 3), which resolves `NO_COLOR` to a no-color profile.
+
+Readable under one terminal is not readable under all of them. Check the depth ladder too — `OX_COLOR_PROFILE=ansi256 ox dev catalog` renders what a macOS Terminal.app user sees.
 
 ### 8. Single-line, key=value log output stays
 

--- a/.claude/rules/design.md
+++ b/.claude/rules/design.md
@@ -35,7 +35,9 @@ It's overwritten by `npm run sync`. Edits silently disappear on the next sync.
 
 ### 3. Use semantic styles, not raw colors
 
-Never `lipgloss.Color(…)` or ANSI escapes outside Bubble Tea code. Use `StyleSuccess`, `StyleError`, `StyleAccent`, etc. from `internal/cli/styles.go` and `internal/ui/styles.go`; when you genuinely need a new one, build it from `theme.Color(hex)` / `theme.Adapt(token)`. Raw hex only lives in `internal/theme/generated.go`.
+Never construct `lipgloss.Color(…)` directly, and never hand-write ANSI escapes, outside Bubble Tea code.
+
+In order of preference: reach for an existing semantic style (`StyleSuccess`, `StyleError`, `StyleAccent`, … in `internal/cli/styles.go` and `internal/ui/styles.go`); failing that, build one from a generated token via `theme.Adapt(theme.ColorX)`. A literal passed through `theme.Color("#…")` is permitted for a genuine one-off, but a color used more than once is a missing token — add it in `sageox-design` and re-sync, don't copy the hex. Net-new palette values still land in `internal/theme/generated.go` by sync, never by hand.
 
 This is a correctness rule, not a tidiness one. lipgloss v2's `Style.Render()` always emits 24-bit color, and ox prints past any `colorprofile.Writer`, so a raw `lipgloss.Color` reaches a 256-color terminal as `38;2;R;G;B` — which it misparses into a **background** color, painting whole columns unreadable. `theme.Color` / `theme.Adapt` degrade first. See [docs/design/theming.md § Color depth](../../docs/design/theming.md#color-depth).
 

--- a/Makefile
+++ b/Makefile
@@ -481,8 +481,12 @@ catalog-casts: build-ox ## Record asciinema .cast for animated components
 		echo "  ⚠ asciinema not installed; .cast recordings skipped"; \
 		echo "    install: brew install asciinema"; \
 	else \
+		# COLORTERM=truecolor is required, not decorative: asciinema records through a
+		# pty, so stdout IS a terminal and theme.Profile trusts terminal detection
+		# rather than the forced-renderer branch. Without it the cast bakes in ANSI256
+		# permanently. Matches the freeze invocation in catalog-build above.
 		for name in $$(./bin/$(BINARY_NAME) dev catalog --json | jq -r '.components[] | select(.renderer=="asciinema") | .name'); do \
-			CLICOLOR_FORCE=1 FORCE_COLOR=1 asciinema rec --quiet --overwrite --cols=80 --rows=24 \
+			CLICOLOR_FORCE=1 FORCE_COLOR=1 COLORTERM=truecolor asciinema rec --quiet --overwrite --cols=80 --rows=24 \
 				--command="./bin/$(BINARY_NAME) dev catalog --component=$$name" \
 				$(CATALOG_ASSETS)/$$name.cast 2>/dev/null \
 				&& echo "  asciinema: $$name.cast" || true; \

--- a/cmd/ox/kb_list.go
+++ b/cmd/ox/kb_list.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/kb"
+	"github.com/sageox/ox/internal/theme"
 	"github.com/spf13/cobra"
 )
 
@@ -247,7 +248,7 @@ var (
 			Foreground(cli.ColorPrimary)
 
 	kbListNameStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#CCCCCC"))
+			Foreground(theme.Color("#CCCCCC"))
 
 	kbListWarnStyle = lipgloss.NewStyle().
 			Foreground(cli.ColorWarning)

--- a/cmd/ox/login.go
+++ b/cmd/ox/login.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sageox/ox/internal/config"
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitserver"
+	"github.com/sageox/ox/internal/theme"
 	"github.com/sageox/ox/internal/tips"
 	"github.com/spf13/cobra"
 )
@@ -408,12 +409,14 @@ func runLoginFlow(cmd *cobra.Command, currentEndpoint string) error {
 
 	// display a fun welcome message
 	fmt.Fprintln(out)
+	// theme.Color, not lipgloss.Color: this prints via fmt.Fprintf rather than
+	// through Bubble Tea, so nothing downstream downsamples it.
 	welcomeStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("212"))
+		Foreground(theme.Color("212"))
 	nameStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("86"))
+		Foreground(theme.Color("86"))
 
 	// extract first name or use email prefix
 	displayName := token.UserInfo.Name

--- a/cmd/ox/murmur_list.go
+++ b/cmd/ox/murmur_list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sageox/ox/internal/endpoint"
 	"github.com/sageox/ox/internal/gitutil"
 	"github.com/sageox/ox/internal/ledger"
+	"github.com/sageox/ox/internal/theme"
 	"github.com/spf13/cobra"
 )
 
@@ -33,7 +34,7 @@ var (
 				Foreground(cli.ColorSecondary)
 
 	murmurContentStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#CCCCCC"))
+				Foreground(theme.Color("#CCCCCC"))
 
 	murmurDimStyle = lipgloss.NewStyle().
 			Foreground(cli.ColorDim)

--- a/cmd/ox/release_notes.go
+++ b/cmd/ox/release_notes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	lipgloss "charm.land/lipgloss/v2"
+	"github.com/sageox/ox/internal/theme"
 	"github.com/spf13/cobra"
 )
 
@@ -202,8 +203,8 @@ func highlightCode(text string) string {
 var (
 	releaseNoteBoldStyle   = lipgloss.NewStyle().Bold(true)
 	releaseNoteDimStyle    = lipgloss.NewStyle().Faint(true)
-	releaseNoteCyanStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("36"))
-	releaseNoteGreenStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
-	releaseNoteYellowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	releaseNoteBlueStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
+	releaseNoteCyanStyle   = lipgloss.NewStyle().Foreground(theme.Color("36"))
+	releaseNoteGreenStyle  = lipgloss.NewStyle().Foreground(theme.Color("82"))
+	releaseNoteYellowStyle = lipgloss.NewStyle().Foreground(theme.Color("214"))
+	releaseNoteBlueStyle   = lipgloss.NewStyle().Foreground(theme.Color("39"))
 )

--- a/cmd/ox/session_view_context.go
+++ b/cmd/ox/session_view_context.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sageox/ox/internal/lfs"
 	"github.com/sageox/ox/internal/session"
 	"github.com/sageox/ox/internal/session/contexttrace"
+	"github.com/sageox/ox/internal/theme"
 )
 
 // semantic styles for context trace (aligned with murmur list palette)
@@ -32,10 +33,10 @@ var (
 				Foreground(cli.ColorDim)
 
 	ctxDocNameStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#CCCCCC"))
+			Foreground(theme.Color("#CCCCCC"))
 
 	ctxDecisionStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#CCCCCC"))
+				Foreground(theme.Color("#CCCCCC"))
 
 	ctxTokenStyle = lipgloss.NewStyle().
 			Foreground(cli.ColorInfo)

--- a/cmd/ox/session_view_text.go
+++ b/cmd/ox/session_view_text.go
@@ -9,13 +9,14 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/sageox/ox/internal/cli"
 	"github.com/sageox/ox/internal/session"
+	"github.com/sageox/ox/internal/theme"
 	"github.com/sageox/ox/internal/ui"
 )
 
 var (
 	viewTextRecordingBanner = lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#000000")).
+		Foreground(theme.Color("#000000")).
 		Background(cli.ColorWarning).
 		Padding(0, 1)
 )

--- a/docs/design/theming.md
+++ b/docs/design/theming.md
@@ -57,7 +57,7 @@ lipgloss v1 downsampled inside `Style.Render()`. **lipgloss v2 does not** — `R
 
 Skipping that step is not a cosmetic downgrade. A terminal without 24-bit support — macOS Terminal.app, or anything reporting `TERM=xterm-256color` with no `COLORTERM` — does not ignore an unrecognized `38;2;…`; it parses the parameters as independent SGR codes. Any channel landing in 100–107 becomes a **background** color:
 
-```
+```text
 #E0A56A  →  ESC[38;2;224;165;106m  →  224, 165, and 106 read separately
                                        106 = bright-cyan background
 ```

--- a/docs/design/theming.md
+++ b/docs/design/theming.md
@@ -49,14 +49,50 @@ ColorPrimary = compat.AdaptiveColor{
 
 When the user toggles their terminal between light and dark, the next ox invocation renders with the matching variant. The published catalog page at [sageox-design.netlify.app/catalog/cli/](https://sageox-design.netlify.app/catalog/cli/) shows both variants per token, with the active variant outlined according to the page's Mode toggle.
 
+## Color depth
+
+Light vs dark picks *which* variant. Color **depth** decides how that variant is written to the terminal, and it is a separate mechanism that ox has to run itself.
+
+lipgloss v1 downsampled inside `Style.Render()`. **lipgloss v2 does not** — `Render()` always emits 24-bit `38;2;R;G;B` and expects the caller to degrade at the output layer (`colorprofile.Writer`, `lipgloss.Println`). ox has ~300 `fmt.Print(style.Render(…))` call sites that write straight to `os.Stdout`, so there is no output layer to hook. ox therefore degrades **at the color**: `theme.Color(hex)` and `theme.Adapt(c)` convert to the detected profile before the color ever reaches a `Style`.
+
+Skipping that step is not a cosmetic downgrade. A terminal without 24-bit support — macOS Terminal.app, or anything reporting `TERM=xterm-256color` with no `COLORTERM` — does not ignore an unrecognized `38;2;…`; it parses the parameters as independent SGR codes. Any channel landing in 100–107 becomes a **background** color:
+
+```
+#E0A56A  →  ESC[38;2;224;165;106m  →  224, 165, and 106 read separately
+                                       106 = bright-cyan background
+```
+
+That is how brand copper turned the `ox --help` command column and the login disclaimer into unreadable grey-on-cyan blocks. Other tokens sit one step from the same trap (`#2DD4BF` starts `0x2D` = 45 = magenta background), so the fix is the conversion, not a safer hex.
+
+| Profile | Emits | Typical terminal |
+|---|---|---|
+| TrueColor | `38;2;R;G;B` | iTerm2, Ghostty, WezTerm, Kitty, VS Code (`COLORTERM=truecolor`) |
+| ANSI256 | `38;5;N` | macOS Terminal.app, `TERM=xterm-256color` |
+| ANSI | 4-bit `9x`/`3x` | `TERM=xterm-color`, old emulators |
+| ASCII / NoTTY | no color, attributes only | `NO_COLOR=1`, pipes, CI |
+
+Detection is `colorprofile.Detect(os.Stdout, os.Environ())`, honoring `NO_COLOR`, `CLICOLOR`, `CLICOLOR_FORCE`, `COLORTERM`, `TERM`, terminfo, and tmux. Mechanism and init-ordering notes live in [`internal/theme/profile.go`](../../internal/theme/profile.go).
+
+**Bubble Tea is the one exemption.** Bubble Tea v2 downsamples its own frames, so TUI code (`internal/dashboard/**`, the tea models in `cmd/ox`) uses `lipgloss.Color` directly. `TestNoRawLipglossColorOutsideTUI` enforces the boundary.
+
+### Reproducing another terminal's rendering
+
+`OX_COLOR_PROFILE` forces a profile, so a report from a 256-color terminal is reproducible on any machine:
+
+```bash
+OX_COLOR_PROFILE=ansi256 ox --help
+```
+
+Accepts `truecolor`, `ansi256`, `ansi`, `ascii`, `notty`. An unrecognized value falls through to normal detection rather than erroring. Inspect the raw bytes with `script -q /dev/null ox --help | cat -v`.
+
 ## NO_COLOR
 
-[`NO_COLOR=1`](https://no-color.org/) strips all ANSI escapes. lipgloss handles this natively — no per-component code is needed. Test new components with `NO_COLOR=1 ox dev catalog`.
+[`NO_COLOR=1`](https://no-color.org/) strips color while leaving text attributes (bold, underline) intact — it resolves to the ASCII profile above. Test new components with `NO_COLOR=1 ox dev catalog`.
 
 ## Forbidden patterns
 
 - Hand-editing `internal/theme/generated.go` (overwritten by sync).
-- `lipgloss.Color("#…")` literals in `cmd/ox/**` (use semantic styles instead).
+- `lipgloss.Color(…)` in any non-Bubble-Tea file — use `theme.Color` / `theme.Adapt`, or the semantic styles in `internal/cli/styles.go` and `internal/ui/styles.go`.
 - ANSI escape sequences in command implementations (`\033[…`, `\x1b[…`).
 - New tokens added directly to `internal/dashboard/theme/tokens.go` without an upstream `sageox-design` PR.
 

--- a/docs/design/theming.md
+++ b/docs/design/theming.md
@@ -73,7 +73,14 @@ That is how brand copper turned the `ox --help` command column and the login dis
 
 Detection is `colorprofile.Detect(os.Stdout, os.Environ())`, honoring `NO_COLOR`, `CLICOLOR`, `CLICOLOR_FORCE`, `COLORTERM`, `TERM`, terminfo, and tmux. Mechanism and init-ordering notes live in [`internal/theme/profile.go`](../../internal/theme/profile.go).
 
-**Bubble Tea is the one exemption.** Bubble Tea v2 downsamples its own frames, so TUI code (`internal/dashboard/**`, the tea models in `cmd/ox`) uses `lipgloss.Color` directly. `TestNoRawLipglossColorOutsideTUI` enforces the boundary.
+**Two exemptions**, both enforced by `TestNoRawLipglossColorOutsideTUI`:
+
+| Exempt | Why |
+|---|---|
+| Any file importing Bubble Tea, plus all of `internal/dashboard/**` | Bubble Tea v2 downsamples its own frames. The whole `dashboard` tree renders into one Bubble Tea frame, including leaf renderers that import only lipgloss. |
+| `internal/theme/**` | It *is* the adapter, and `generated.go` is where raw token hexes legitimately live (the `ColorPrimary` snippet above is one). |
+
+Everything else must go through `theme.Color` / `theme.Adapt`.
 
 ### Reproducing another terminal's rendering
 
@@ -92,7 +99,7 @@ Accepts `truecolor`, `ansi256`, `ansi`, `ascii`, `notty`. An unrecognized value 
 ## Forbidden patterns
 
 - Hand-editing `internal/theme/generated.go` (overwritten by sync).
-- `lipgloss.Color(…)` in any non-Bubble-Tea file — use `theme.Color` / `theme.Adapt`, or the semantic styles in `internal/cli/styles.go` and `internal/ui/styles.go`.
+- `lipgloss.Color(…)` outside the two exemptions above — use `theme.Color` / `theme.Adapt`, or the semantic styles in `internal/cli/styles.go` and `internal/ui/styles.go`.
 - ANSI escape sequences in command implementations (`\033[…`, `\x1b[…`).
 - New tokens added directly to `internal/dashboard/theme/tokens.go` without an upstream `sageox-design` PR.
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -24,13 +24,13 @@ import (
 // Colors are sourced from the sageox-design system.
 // See: internal/theme/generated.go
 var (
-	successStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.AnsiSuccess)).Bold(true)
-	preservedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.AnsiPreserved)).Bold(true) // cyan for preserved/kept
-	errorStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.AnsiError)).Bold(true)
-	warningStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.AnsiWarning)).Bold(true)
-	infoStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.AnsiInfo))
-	hintStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.AnsiHint))
-	codeStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color(theme.AnsiCode))
+	successStyle    = lipgloss.NewStyle().Foreground(theme.Color(theme.AnsiSuccess)).Bold(true)
+	preservedStyle  = lipgloss.NewStyle().Foreground(theme.Color(theme.AnsiPreserved)).Bold(true) // cyan for preserved/kept
+	errorStyle      = lipgloss.NewStyle().Foreground(theme.Color(theme.AnsiError)).Bold(true)
+	warningStyle    = lipgloss.NewStyle().Foreground(theme.Color(theme.AnsiWarning)).Bold(true)
+	infoStyle       = lipgloss.NewStyle().Foreground(theme.Color(theme.AnsiInfo))
+	hintStyle       = lipgloss.NewStyle().Foreground(theme.Color(theme.AnsiHint))
+	codeStyle       = lipgloss.NewStyle().Foreground(theme.Color(theme.AnsiCode))
 	tipIconStyle    = lipgloss.NewStyle().Foreground(ColorSecondary) // warm gold for ✦
 	tipCommandStyle = lipgloss.NewStyle().Foreground(ColorPrimary)   // sage green for commands
 )

--- a/internal/cli/styles.go
+++ b/internal/cli/styles.go
@@ -15,18 +15,23 @@ import (
 // Colors are sourced from the sageox-design system.
 // See: internal/theme/generated.go
 
-// Re-export theme colors for backward compatibility
+// Re-export theme colors for backward compatibility.
+//
+// theme.Adapt downgrades each adaptive color to the terminal's real color
+// depth. The generated tokens are 24-bit, and Style.Render() no longer degrades
+// them in lipgloss v2 — see internal/theme/profile.go for what that does to a
+// 256-color terminal.
 var (
-	ColorPrimary   = theme.ColorPrimary
-	ColorSecondary = theme.ColorSecondary
-	ColorAccent    = theme.ColorAccent
-	ColorSuccess   = theme.ColorSuccess
-	ColorWarning   = theme.ColorWarning
-	ColorError     = theme.ColorError
-	ColorInfo      = theme.ColorInfo
-	ColorDim       = theme.ColorDim
-	ColorPublic    = theme.ColorPublic
-	ColorPrivate   = theme.ColorPrivate
+	ColorPrimary   = theme.Adapt(theme.ColorPrimary)
+	ColorSecondary = theme.Adapt(theme.ColorSecondary)
+	ColorAccent    = theme.Adapt(theme.ColorAccent)
+	ColorSuccess   = theme.Adapt(theme.ColorSuccess)
+	ColorWarning   = theme.Adapt(theme.ColorWarning)
+	ColorError     = theme.Adapt(theme.ColorError)
+	ColorInfo      = theme.Adapt(theme.ColorInfo)
+	ColorDim       = theme.Adapt(theme.ColorDim)
+	ColorPublic    = theme.Adapt(theme.ColorPublic)
+	ColorPrivate   = theme.Adapt(theme.ColorPrivate)
 )
 
 // Text styles
@@ -97,7 +102,7 @@ var (
 
 // Wordmark returns the two-tone "SageOx" brand wordmark as a rendered string.
 func Wordmark() string {
-	sage := lipgloss.NewStyle().Foreground(theme.ColorWordmarkSage).Bold(true)
-	ox := lipgloss.NewStyle().Foreground(theme.ColorWordmarkOx).Bold(true)
+	sage := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorWordmarkSage)).Bold(true)
+	ox := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorWordmarkOx)).Bold(true)
 	return sage.Render("Sage") + ox.Render("Ox")
 }

--- a/internal/daemon/status_display.go
+++ b/internal/daemon/status_display.go
@@ -9,6 +9,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 
+	"github.com/sageox/ox/internal/theme"
 	"github.com/sageox/ox/internal/tui"
 )
 
@@ -295,10 +296,10 @@ func buildCodeIndexJSON(cs *CodeDBStats) *statusCodeIndexJSON {
 
 var (
 	// semantic colors for status
-	colorHealthy  = lipgloss.Color("2") // green
-	colorWarning  = lipgloss.Color("3") // yellow
-	colorCritical = lipgloss.Color("1") // red
-	colorMuted    = lipgloss.Color("8") // gray
+	colorHealthy  = theme.Color("2") // green
+	colorWarning  = theme.Color("3") // yellow
+	colorCritical = theme.Color("1") // red
+	colorMuted    = theme.Color("8") // gray
 
 	// styles
 	styleHealthy  = lipgloss.NewStyle().Foreground(colorHealthy).Bold(true)

--- a/internal/signature/warning.go
+++ b/internal/signature/warning.go
@@ -5,13 +5,15 @@ import (
 	"os"
 
 	lipgloss "charm.land/lipgloss/v2"
+
+	"github.com/sageox/ox/internal/theme"
 )
 
 // WarningMessage is the standard warning for unsigned/invalid SAGEOX.md
 const WarningMessage = "Warning: SAGEOX.md has not been signed by SageOx, unable to verify it has not been tampered with. See https://sageox.ai/i/signed for more info."
 
 // warning style using lipgloss
-var warningStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+var warningStyle = lipgloss.NewStyle().Foreground(theme.Color("214"))
 
 // EmitWarning prints the warning message to stderr with yellow color
 // Only emits if SAGEOX.md exists but is not verified

--- a/internal/theme/color_construction_test.go
+++ b/internal/theme/color_construction_test.go
@@ -1,0 +1,122 @@
+package theme_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNoRawLipglossColorOutsideTUI keeps the contrast fix from eroding.
+//
+// lipgloss v2's Style.Render() always emits 24-bit color and leaves
+// downsampling to the caller. ox degrades at the color instead (theme.Color /
+// theme.Adapt), because its ~300 fmt.Print(style.Render(...)) call sites write
+// past any colorprofile.Writer. A new raw lipgloss.Color("#…") in print-path
+// code silently reintroduces the unreadable-background bug on every terminal
+// without truecolor support.
+//
+// Two exemptions, both with a reason rather than a grandfather clause:
+//   - internal/theme itself, which is where the adapter is implemented.
+//   - Bubble Tea code, which downsamples its own frames. A file qualifies by
+//     importing bubbletea, or by living under internal/dashboard — that whole
+//     tree renders into the dashboard's Bubble Tea frame, including the leaf
+//     renderers that import only lipgloss.
+func TestNoRawLipglossColorOutsideTUI(t *testing.T) {
+	root := repoRoot(t)
+
+	var offenders []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if name := info.Name(); name == ".git" || name == "vendor" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasPrefix(rel, "internal/theme/") || strings.HasPrefix(rel, "internal/dashboard/") {
+			return nil
+		}
+
+		src, readErr := os.ReadFile(path) //nolint:gosec // walking our own tree
+		if readErr != nil {
+			return readErr
+		}
+		body := string(src)
+		if strings.Contains(body, "charm.land/bubbletea/v2") {
+			return nil
+		}
+		if strings.Contains(body, "lipgloss.Color(") {
+			offenders = append(offenders, rel+" (lipgloss.Color)")
+		}
+		if tok := unadaptedToken(body); tok != "" {
+			offenders = append(offenders, rel+" ("+tok+")")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	assert.Empty(t, offenders,
+		"use theme.Color / theme.Adapt instead of lipgloss.Color in non-TUI code — "+
+			"raw 24-bit color renders as an unreadable background block on terminals "+
+			"without truecolor support (see internal/theme/profile.go)")
+}
+
+// adaptiveTokenRef matches a generated adaptive token (theme.ColorPrimary and
+// friends) that is not already wrapped in theme.Adapt.
+//
+// These are the other half of the same bug and the half that is easy to miss:
+// they carry 24-bit values just like a hex literal, but read as "already a theme
+// color, therefore already safe". A second wordmark in internal/cli/styles.go
+// survived the original sweep for exactly that reason.
+var adaptiveTokenRef = regexp.MustCompile(
+	`theme\.Color(?:Primary|Secondary|Accent|Success|Warning|Error|Info|Dim|Public|Private|WordmarkSage|WordmarkOx)\b`)
+
+// unadaptedToken returns the first adaptive-token reference in src that is not
+// wrapped in theme.Adapt, or "" if there is none. Comment lines are ignored so
+// prose about a token does not trip the check.
+func unadaptedToken(src string) string {
+	for _, line := range strings.Split(src, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		for _, m := range adaptiveTokenRef.FindAllStringIndex(line, -1) {
+			if !strings.HasSuffix(line[:m[0]], "theme.Adapt(") {
+				return line[m[0]:m[1]]
+			}
+		}
+	}
+	return ""
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		if filepath.Dir(dir) == dir {
+			t.Fatalf("no go.mod above %s", wd)
+		}
+	}
+}

--- a/internal/theme/profile.go
+++ b/internal/theme/profile.go
@@ -1,0 +1,90 @@
+package theme
+
+import (
+	"image/color"
+	"os"
+	"strings"
+
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/charmbracelet/colorprofile"
+)
+
+// Profile is the terminal's color capability, resolved once at package init.
+//
+// Lip Gloss v2 deleted the per-renderer downsampling that v1 did inside
+// Style.Render(): Render now always emits 24-bit "38;2;R;G;B" and expects the
+// caller to degrade at the output layer (colorprofile.Writer, lipgloss.Println).
+// ox has ~300 fmt.Print(style.Render(...)) call sites that write to os.Stdout
+// directly and bypass any such writer, so we degrade the *color* instead — a
+// color already converted to this profile renders as "38;5;N", a 4-bit code, or
+// nothing, at every one of those call sites without touching them.
+//
+// This is not a cosmetic nicety. A terminal without 24-bit support (macOS
+// Terminal.app; anything reporting TERM=xterm-256color with no COLORTERM) does
+// not ignore an unrecognized "38;2;..." — it parses the parameters as
+// independent SGR codes. Any channel landing in 100-107 therefore becomes a
+// *background* color: brand copper #E0A56A ends in 0x6A = 106 = bright-cyan
+// background, which painted the `ox --help` command column and the login
+// disclaimer as unreadable grey-on-cyan blocks. Several other palette entries
+// sit one token away from the same trap (#2DD4BF starts 0x2D = 45 = magenta
+// background), so pinning the one bad hex would not have been a fix.
+//
+// Init ordering matters and is guaranteed: package-level vars of imported
+// packages are evaluated before the main package's init(), so this observes the
+// real os.Stdout rather than the ANSI-stripping pipe cmd/ox/main.go swaps in for
+// non-TTY output. Detecting against the real stream is what we want — it is how
+// piped output resolves to NoTTY and drops color at the source.
+var Profile = detectProfile()
+
+// detectProfile honors an explicit OX_COLOR_PROFILE override, then falls back to
+// colorprofile's environment rules (NO_COLOR, CLICOLOR, CLICOLOR_FORCE,
+// COLORTERM, TERM, terminfo, tmux).
+//
+// The override is a support tool: a rendering bug that only reproduces on a
+// 256-color terminal can be reproduced on any terminal with
+// `OX_COLOR_PROFILE=ansi256 ox --help`. Without it, the only way to see what a
+// Terminal.app user sees is to own a Terminal.app.
+func detectProfile() colorprofile.Profile {
+	if forced, ok := parseProfile(os.Getenv("OX_COLOR_PROFILE")); ok {
+		return forced
+	}
+	return colorprofile.Detect(os.Stdout, os.Environ())
+}
+
+// parseProfile maps an OX_COLOR_PROFILE value to a profile. Unrecognized values
+// report false rather than erroring, so a typo degrades to normal detection
+// instead of breaking every command's output.
+func parseProfile(s string) (colorprofile.Profile, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "truecolor", "24bit":
+		return colorprofile.TrueColor, true
+	case "ansi256", "256":
+		return colorprofile.ANSI256, true
+	case "ansi", "16":
+		return colorprofile.ANSI, true
+	case "ascii", "none":
+		return colorprofile.ASCII, true
+	case "notty":
+		return colorprofile.NoTTY, true
+	}
+	return colorprofile.Unknown, false
+}
+
+// Adapt downgrades a color to something the terminal can actually render.
+//
+// Every color that reaches a Style outside Bubble Tea must pass through here.
+// Bubble Tea v2 downsamples its own frames, so TUI code (internal/dashboard,
+// the tea models in cmd/ox) deliberately does not.
+//
+// Returns nil for the ASCII and NoTTY profiles; lipgloss treats a nil color as
+// "unset" and emits text attributes only, which is the intended NO_COLOR shape.
+func Adapt(c color.Color) color.Color {
+	return Profile.Convert(c)
+}
+
+// Color parses a hex ("#7A8F78") or ANSI index ("214") color and adapts it to
+// the terminal's profile. Use this anywhere lipgloss.Color would be reached for
+// in non-TUI code.
+func Color(s string) color.Color {
+	return Adapt(lipgloss.Color(s))
+}

--- a/internal/theme/profile.go
+++ b/internal/theme/profile.go
@@ -3,10 +3,12 @@ package theme
 import (
 	"image/color"
 	"os"
+	"strconv"
 	"strings"
 
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/charmbracelet/colorprofile"
+	"github.com/mattn/go-isatty"
 )
 
 // Profile is the terminal's color capability, resolved once at package init.
@@ -48,7 +50,47 @@ func detectProfile() colorprofile.Profile {
 	if forced, ok := parseProfile(os.Getenv("OX_COLOR_PROFILE")); ok {
 		return forced
 	}
+	if noColorRequested() {
+		// colorprofile only clamps NO_COLOR when stdout is a TTY, so
+		// `NO_COLOR=1 CLICOLOR_FORCE=1 ox > file` slips through as 4-bit ANSI.
+		// NO_COLOR wins over CLICOLOR_FORCE (https://no-color.org) and this
+		// repo treats it as sacred, so clamp it here regardless of stream type.
+		return colorprofile.ASCII
+	}
+	if forcingColorToARenderer() {
+		return colorprofile.TrueColor
+	}
 	return colorprofile.Detect(os.Stdout, os.Environ())
+}
+
+func noColorRequested() bool {
+	noColor, _ := strconv.ParseBool(os.Getenv("NO_COLOR"))
+	return noColor
+}
+
+// forcingColorToARenderer reports whether CLICOLOR_FORCE is asking for color on
+// a stream that is not a terminal.
+//
+// That combination means the consumer is a *renderer*, not a terminal:
+// charmbracelet/freeze turning `ox dev catalog` into the catalog SVGs, or
+// asciinema recording the demo casts (Makefile `catalog-build` / `demo-record`).
+// Their fidelity ceiling is the source, not any terminal's capability, so
+// TrueColor is the correct answer and anything less bakes a permanent downgrade
+// into published assets.
+//
+// colorprofile.Detect cannot reach that conclusion on its own — with no TTY to
+// interrogate it floors CLICOLOR_FORCE at 4-bit ANSI unless COLORTERM happens to
+// be set too. `catalog-build` does set it; `demo-record` does not, and lost all
+// 24-bit color the first time this file existed without this branch.
+//
+// Deliberately narrow: when stdout *is* a terminal we trust detection, because
+// upgrading a real 256-color terminal to TrueColor would reintroduce the exact
+// unreadable-background bug this file exists to prevent.
+func forcingColorToARenderer() bool {
+	if force, _ := strconv.ParseBool(os.Getenv("CLICOLOR_FORCE")); !force {
+		return false
+	}
+	return !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())
 }
 
 // parseProfile maps an OX_COLOR_PROFILE value to a profile. Unrecognized values

--- a/internal/theme/profile_test.go
+++ b/internal/theme/profile_test.go
@@ -123,3 +123,53 @@ func TestParseProfile(t *testing.T) {
 		assert.False(t, ok, "%q should not parse", in)
 	}
 }
+
+// TestDetectProfile_ForcedColorToNonTTY covers the CLICOLOR_FORCE precedence
+// ladder. The regression it guards: `CLICOLOR_FORCE=1 ox --help > file` emitted
+// 125 truecolor sequences before this file existed and 0 after, because
+// colorprofile floors a non-TTY at 4-bit ANSI unless COLORTERM is also set. The
+// catalog build sets it; the asciinema demo recording does not.
+//
+// A test binary's stdout is never a TTY, so these exercise the non-TTY branch
+// directly.
+func TestDetectProfile_ForcedColorToNonTTY(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want colorprofile.Profile
+	}{
+		{
+			name: "forced color to a renderer keeps full fidelity",
+			env:  map[string]string{"CLICOLOR_FORCE": "1"},
+			want: colorprofile.TrueColor,
+		},
+		{
+			name: "NO_COLOR outranks CLICOLOR_FORCE",
+			env:  map[string]string{"CLICOLOR_FORCE": "1", "NO_COLOR": "1"},
+			want: colorprofile.ASCII,
+		},
+		{
+			name: "explicit override outranks CLICOLOR_FORCE",
+			env:  map[string]string{"CLICOLOR_FORCE": "1", "OX_COLOR_PROFILE": "ansi256"},
+			want: colorprofile.ANSI256,
+		},
+		{
+			name: "plain pipe stays colorless",
+			env:  nil,
+			want: colorprofile.NoTTY,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear every input so cases don't inherit the ambient environment.
+			for _, k := range []string{"CLICOLOR_FORCE", "CLICOLOR", "NO_COLOR", "OX_COLOR_PROFILE", "COLORTERM", "TERM"} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			assert.Equal(t, tt.want, detectProfile())
+		})
+	}
+}

--- a/internal/theme/profile_test.go
+++ b/internal/theme/profile_test.go
@@ -1,0 +1,125 @@
+package theme
+
+import (
+	"strings"
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+	"github.com/charmbracelet/colorprofile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withProfile temporarily overrides the detected profile. Adapt reads Profile at
+// call time, so this is enough to exercise every terminal class from a test
+// binary whose own stdout is never a TTY.
+func withProfile(t *testing.T, p colorprofile.Profile) {
+	t.Helper()
+	prev := Profile
+	Profile = p
+	t.Cleanup(func() { Profile = prev })
+}
+
+// TestAdapt_NoTruecolorBelowTrueColor is the regression test for the unreadable
+// grey-on-cyan help columns.
+//
+// A terminal without 24-bit support parses the parameters of an unrecognized
+// "38;2;R;G;B" as independent SGR codes, so a channel in 100-107 silently
+// becomes a background color. Emitting no "38;2;" at all below TrueColor is the
+// property that makes that class of bug impossible, for every token — not just
+// the copper #E0A56A that happened to trip it.
+func TestAdapt_NoTruecolorBelowTrueColor(t *testing.T) {
+	degraded := []colorprofile.Profile{colorprofile.ANSI256, colorprofile.ANSI, colorprofile.ASCII, colorprofile.NoTTY}
+
+	for _, tok := range Tokens {
+		for _, hex := range []string{tok.LightHex, tok.DarkHex} {
+			for _, p := range degraded {
+				t.Run(tok.Name+"/"+hex+"/"+p.String(), func(t *testing.T) {
+					withProfile(t, p)
+					got := lipgloss.NewStyle().Foreground(Color(hex)).Render("x")
+					assert.NotContains(t, got, "38;2;",
+						"%s renders 24-bit color on a %s terminal", hex, p)
+				})
+			}
+		}
+	}
+}
+
+// TestAdapt_CopperRendersAsOneIndexedColor pins the exact byte shape of the
+// reported bug: brand copper on a 256-color terminal must be a single indexed
+// foreground, never the four-parameter form whose trailing 106 reads as
+// bright-cyan background.
+func TestAdapt_CopperRendersAsOneIndexedColor(t *testing.T) {
+	withProfile(t, colorprofile.ANSI256)
+
+	got := lipgloss.NewStyle().Foreground(Color("#E0A56A")).Render("code")
+
+	assert.Contains(t, got, "38;5;")
+	assert.NotContains(t, got, "106")
+}
+
+// TestAdapt_TrueColorIsPassthrough guards the other direction: modern terminals
+// must keep full-fidelity brand color.
+func TestAdapt_TrueColorIsPassthrough(t *testing.T) {
+	withProfile(t, colorprofile.TrueColor)
+
+	got := lipgloss.NewStyle().Foreground(Color("#E0A56A")).Render("code")
+
+	assert.Contains(t, got, "38;2;224;165;106")
+}
+
+// TestAdapt_AdaptiveTokensDegrade covers the generated compat.AdaptiveColor
+// values, which reach styles as a struct rather than a parsed hex.
+func TestAdapt_AdaptiveTokensDegrade(t *testing.T) {
+	withProfile(t, colorprofile.ANSI256)
+
+	for name, c := range map[string]interface{ RGBA() (uint32, uint32, uint32, uint32) }{
+		"Primary":   ColorPrimary,
+		"Secondary": ColorSecondary,
+		"Warning":   ColorWarning,
+		"Public":    ColorPublic,
+	} {
+		got := lipgloss.NewStyle().Foreground(Adapt(c)).Render("x")
+		assert.NotContains(t, got, "38;2;", "%s should degrade", name)
+	}
+}
+
+// TestAdapt_NoColorProfilesEmitNoColor documents that ASCII and NoTTY drop color
+// entirely rather than picking a nearest match — lipgloss treats the nil that
+// Convert returns as "unset", leaving text attributes intact.
+func TestAdapt_NoColorProfilesEmitNoColor(t *testing.T) {
+	for _, p := range []colorprofile.Profile{colorprofile.ASCII, colorprofile.NoTTY} {
+		withProfile(t, p)
+
+		require.Nil(t, Adapt(lipgloss.Color("#E0A56A")))
+
+		got := lipgloss.NewStyle().Foreground(Color("#E0A56A")).Bold(true).Render("x")
+		assert.NotContains(t, got, "38;")
+		assert.True(t, strings.Contains(got, "1m"), "bold should survive on %s", p)
+	}
+}
+
+func TestParseProfile(t *testing.T) {
+	cases := map[string]colorprofile.Profile{
+		"truecolor": colorprofile.TrueColor,
+		"24bit":     colorprofile.TrueColor,
+		"  ANSI256": colorprofile.ANSI256,
+		"256":       colorprofile.ANSI256,
+		"ansi":      colorprofile.ANSI,
+		"16":        colorprofile.ANSI,
+		"ascii":     colorprofile.ASCII,
+		"none":      colorprofile.ASCII,
+		"notty":     colorprofile.NoTTY,
+	}
+	for in, want := range cases {
+		got, ok := parseProfile(in)
+		assert.True(t, ok, "%q should parse", in)
+		assert.Equal(t, want, got, "%q", in)
+	}
+
+	// A typo must fall through to normal detection rather than breaking output.
+	for _, in := range []string{"", "tru-color", "xterm-256color"} {
+		_, ok := parseProfile(in)
+		assert.False(t, ok, "%q should not parse", in)
+	}
+}

--- a/internal/ui/box.go
+++ b/internal/ui/box.go
@@ -14,26 +14,26 @@ import (
 type BoxVariant int
 
 const (
-	BoxDefault BoxVariant = iota // border: theme.ColorDim
-	BoxInfo                      // border: theme.ColorInfo
-	BoxWarning                   // border: theme.ColorWarning
-	BoxError                     // border: theme.ColorError
-	BoxSuccess                   // border: theme.ColorSuccess
+	BoxDefault BoxVariant = iota // border: theme.Adapt(theme.ColorDim)
+	BoxInfo                      // border: theme.Adapt(theme.ColorInfo)
+	BoxWarning                   // border: theme.Adapt(theme.ColorWarning)
+	BoxError                     // border: theme.Adapt(theme.ColorError)
+	BoxSuccess                   // border: theme.Adapt(theme.ColorSuccess)
 )
 
 // variantColor returns the theme color for a given variant.
 func variantColor(v BoxVariant) color.Color {
 	switch v {
 	case BoxInfo:
-		return theme.ColorInfo
+		return theme.Adapt(theme.ColorInfo)
 	case BoxWarning:
-		return theme.ColorWarning
+		return theme.Adapt(theme.ColorWarning)
 	case BoxError:
-		return theme.ColorError
+		return theme.Adapt(theme.ColorError)
 	case BoxSuccess:
-		return theme.ColorSuccess
+		return theme.Adapt(theme.ColorSuccess)
 	default:
-		return theme.ColorDim
+		return theme.Adapt(theme.ColorDim)
 	}
 }
 

--- a/internal/ui/box_test.go
+++ b/internal/ui/box_test.go
@@ -1,36 +1,67 @@
 package ui
 
 import (
+	"image/color"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/colorprofile"
 
 	"github.com/sageox/ox/internal/theme"
 	"github.com/stretchr/testify/assert"
 )
 
+// TestVariantColor pins the variant→token mapping. It runs at TrueColor because
+// variantColor returns the terminal-adapted color, and a test binary's stdout is
+// never a TTY — under the ambient NoTTY profile every variant correctly collapses
+// to nil (no color), which would make the mapping untestable. Not parallel: it
+// swaps the package-level theme.Profile.
 func TestVariantColor(t *testing.T) {
-	t.Parallel()
+	prevProfile := theme.Profile
+	theme.Profile = colorprofile.TrueColor
+	t.Cleanup(func() { theme.Profile = prevProfile })
 
 	tests := []struct {
 		name    string
 		variant BoxVariant
-		want    string // hex color to check against theme
+		want    color.Color
 	}{
-		{"BoxDefault returns dim color", BoxDefault, theme.HexMuted},
-		{"BoxInfo returns info color", BoxInfo, theme.HexInfo},
-		{"BoxWarning returns warning color", BoxWarning, theme.HexWarn},
-		{"BoxError returns error color", BoxError, theme.HexFail},
-		{"BoxSuccess returns success color", BoxSuccess, theme.HexPass},
-		{"unknown variant defaults to dim", BoxVariant(99), theme.HexMuted},
+		{"BoxDefault returns dim color", BoxDefault, theme.ColorDim},
+		{"BoxInfo returns info color", BoxInfo, theme.ColorInfo},
+		{"BoxWarning returns warning color", BoxWarning, theme.ColorWarning},
+		{"BoxError returns error color", BoxError, theme.ColorError},
+		{"BoxSuccess returns success color", BoxSuccess, theme.ColorSuccess},
+		{"unknown variant defaults to dim", BoxVariant(99), theme.ColorDim},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			got := variantColor(tt.variant)
-			assert.NotNil(t, got, "variantColor should never return nil")
+			assert.NotNil(t, got, "variantColor should never return nil at TrueColor")
+			assertSameColor(t, tt.want, got)
 		})
 	}
+}
+
+// TestVariantColor_NoColorTerminal documents the other half of the contract:
+// on a terminal that cannot render color, every variant yields nil, which
+// lipgloss treats as "unset" — the box still renders, just uncolored.
+func TestVariantColor_NoColorTerminal(t *testing.T) {
+	prevProfile := theme.Profile
+	theme.Profile = colorprofile.NoTTY
+	t.Cleanup(func() { theme.Profile = prevProfile })
+
+	for _, v := range []BoxVariant{BoxDefault, BoxInfo, BoxWarning, BoxError, BoxSuccess} {
+		assert.Nil(t, variantColor(v))
+	}
+	assert.Contains(t, RenderBox("Title", "body", BoxInfo), "body")
+}
+
+func assertSameColor(t *testing.T, want, got color.Color) {
+	t.Helper()
+	wr, wg, wb, _ := want.RGBA()
+	gr, gg, gb, _ := got.RGBA()
+	assert.Equal(t, [3]uint32{wr, wg, wb}, [3]uint32{gr, gg, gb})
 }
 
 func TestRenderBox(t *testing.T) {

--- a/internal/ui/box_test.go
+++ b/internal/ui/box_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sageox/ox/internal/theme"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestVariantColor pins the variant→token mapping. It runs at TrueColor because
@@ -37,7 +38,9 @@ func TestVariantColor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := variantColor(tt.variant)
-			assert.NotNil(t, got, "variantColor should never return nil at TrueColor")
+			// require, not assert: a nil here must halt the subtest, or
+			// assertSameColor panics on the nil deref instead of failing cleanly.
+			require.NotNil(t, got, "variantColor should never return nil at TrueColor")
 			assertSameColor(t, tt.want, got)
 		})
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -30,24 +30,28 @@ const (
 	HexPrivate = theme.HexPrivate
 )
 
+// Every color here goes through theme.Color, which downgrades the hex to what
+// the terminal can render. Raw lipgloss.Color would emit 24-bit sequences that
+// non-truecolor terminals misparse into background colors — see
+// internal/theme/profile.go.
 var (
 	// Brand primary - the core SageOx identity color
-	ColorPrimary = lipgloss.Color(HexPrimary) // sage green - brand identity
+	ColorPrimary = theme.Color(HexPrimary) // sage green - brand identity
 
 	// Semantic status colors (aligned with brand)
-	ColorPass   = lipgloss.Color(HexPass)   // sage green - brand success
-	ColorWarn   = lipgloss.Color(HexWarn)   // copper gold - brand warning
-	ColorFail   = lipgloss.Color(HexFail)   // ox red - brand error
-	ColorMuted  = lipgloss.Color(HexMuted)  // charcoal gray - recessive
-	ColorAccent = lipgloss.Color(HexAccent) // info blue - brand accent
+	ColorPass   = theme.Color(HexPass)   // sage green - brand success
+	ColorWarn   = theme.Color(HexWarn)   // copper gold - brand warning
+	ColorFail   = theme.Color(HexFail)   // ox red - brand error
+	ColorMuted  = theme.Color(HexMuted)  // charcoal gray - recessive
+	ColorAccent = theme.Color(HexAccent) // info blue - brand accent
 
 	// Text colors
-	ColorText    = lipgloss.Color(HexText)    // soft gray-white - dark terminal optimized
-	ColorTextDim = lipgloss.Color(HexTextDim) // dim text - pairs with sage/charcoal
+	ColorText    = theme.Color(HexText)    // soft gray-white - dark terminal optimized
+	ColorTextDim = theme.Color(HexTextDim) // dim text - pairs with sage/charcoal
 
 	// Visibility colors (from sageox-mono public/private semantic tokens)
-	ColorPublic  = lipgloss.Color(HexPublic)  // teal - public visibility
-	ColorPrivate = lipgloss.Color(HexPrivate) // amber - private visibility
+	ColorPublic  = theme.Color(HexPublic)  // teal - public visibility
+	ColorPrivate = theme.Color(HexPrivate) // amber - private visibility
 )
 
 // Status styles - consistent across all commands

--- a/internal/ui/wordmark.go
+++ b/internal/ui/wordmark.go
@@ -28,9 +28,9 @@ const wordmarkSplit = 12
 // Sage half uses theme.ColorWordmarkSage; Ox half uses theme.ColorWordmarkOx.
 // Both adapt to light/dark terminals via lipgloss.
 func RenderWordmark(version string, fixMode bool) string {
-	sageStyle := lipgloss.NewStyle().Foreground(theme.ColorWordmarkSage)
-	oxStyle := lipgloss.NewStyle().Foreground(theme.ColorWordmarkOx)
-	dimStyle := lipgloss.NewStyle().Foreground(theme.ColorDim)
+	sageStyle := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorWordmarkSage))
+	oxStyle := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorWordmarkOx))
+	dimStyle := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorDim))
 
 	var b strings.Builder
 	for _, line := range wordmarkLines {

--- a/internal/uicatalog/entries/config_screen.go
+++ b/internal/uicatalog/entries/config_screen.go
@@ -25,13 +25,13 @@ func init() {
 		Render: func() string {
 			frame := lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(theme.ColorDim).
+				BorderForeground(theme.Adapt(theme.ColorDim)).
 				Padding(0, 1).
 				Width(76)
 
 			title := cli.StyleBrand.Bold(true).Render(" ox config ")
 			cat := cli.StyleSecondary.Bold(true).Render
-			sel := lipgloss.NewStyle().Bold(true).Foreground(theme.ColorAccent).Render
+			sel := lipgloss.NewStyle().Bold(true).Foreground(theme.Adapt(theme.ColorAccent)).Render
 			dim := cli.StyleDim.Render
 			val := cli.StyleAccent.Render
 			def := cli.StyleDim.Render

--- a/internal/uicatalog/entries/doctor_screen.go
+++ b/internal/uicatalog/entries/doctor_screen.go
@@ -21,8 +21,8 @@ func init() {
 		WhenNotTo: "Pipeline commands — the wordmark earns its vertical space only " +
 			"when the command is a destination. Don't print it from automation paths.",
 		Render: func() string {
-			pass := lipgloss.NewStyle().Foreground(theme.ColorSuccess)
-			warn := lipgloss.NewStyle().Foreground(theme.ColorWarning)
+			pass := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorSuccess))
+			warn := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorWarning))
 
 			header := ui.RenderWordmark("0.9.0", false)
 

--- a/internal/uicatalog/entries/login_screen.go
+++ b/internal/uicatalog/entries/login_screen.go
@@ -39,7 +39,7 @@ func init() {
 			// Post-auth state — what the user sees after success.
 			postBox := lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(theme.ColorSuccess).
+				BorderForeground(theme.Adapt(theme.ColorSuccess)).
 				Padding(0, 2).
 				Render(ok("✓") + " Authenticated as " + cli.StyleAccent.Render("ryan+ox@sageox.ai") + "\n" +
 					"  Endpoint: " + cli.StyleAccent.Render("sageox.ai") + "\n" +

--- a/internal/uicatalog/entries/modal.go
+++ b/internal/uicatalog/entries/modal.go
@@ -23,7 +23,7 @@ func init() {
 		Render: func() string {
 			border := lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(theme.ColorAccent).
+				BorderForeground(theme.Adapt(theme.ColorAccent)).
 				Padding(1, 3)
 
 			title := cli.StyleBrand.Render("⌘  Command palette")

--- a/internal/uicatalog/entries/session_list_screen.go
+++ b/internal/uicatalog/entries/session_list_screen.go
@@ -27,7 +27,7 @@ func init() {
 			dim := cli.StyleDim.Render
 			ok := cli.StyleSuccess.Render
 			warn := cli.StyleWarning.Render
-			val := lipgloss.NewStyle().Foreground(theme.ColorAccent).Render
+			val := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorAccent)).Render
 			sec := cli.StyleSecondary.Render
 
 			pad := func(s string, w int) string {

--- a/internal/uicatalog/entries/status_screen.go
+++ b/internal/uicatalog/entries/status_screen.go
@@ -30,7 +30,7 @@ func init() {
 			brand := cli.StyleBrand.Render
 			sect := cli.StyleSecondary.Bold(true).Render
 			label := cli.StyleDim.Render
-			val := lipgloss.NewStyle().Foreground(theme.ColorAccent).Render
+			val := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorAccent)).Render
 			ok := cli.StyleSuccess.Render
 			warn := cli.StyleWarning.Render
 			dim := cli.StyleDim.Render

--- a/internal/uicatalog/entries/timeline.go
+++ b/internal/uicatalog/entries/timeline.go
@@ -20,8 +20,8 @@ func init() {
 		WhenNotTo: "Single-line status (use `StyleSuccess` directly) or tabular history " +
 			"(use Columns). Timelines are vertical; horizontal scans want tables.",
 		Render: func() string {
-			pass := lipgloss.NewStyle().Foreground(theme.ColorSuccess)
-			warn := lipgloss.NewStyle().Foreground(theme.ColorWarning)
+			pass := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorSuccess))
+			warn := lipgloss.NewStyle().Foreground(theme.Adapt(theme.ColorWarning))
 			nodes := []ui.TimelineNode{
 				{
 					Title:   "Auth",


### PR DESCRIPTION
## Summary

ox is readable again for anyone whose terminal isn't 24-bit — macOS Terminal.app and anything reporting `TERM=xterm-256color` with no `COLORTERM`. Malcolm (Softmax) reported `ox --help` and `ox login` arriving as grey-on-bright-cyan blocks: the entire command column, the `ox` in `Usage`, the tip bullet, and the "designed initially for Claude Code" disclaimer were effectively unreadable. Every one of those is a first-run surface, so this was the first thing a new user saw.

**Approach: lipgloss v2 stopped downsampling inside `Style.Render()` and ox never took over the job — so we degrade at the color instead, via `theme.Color` / `theme.Adapt`, which fixes all ~300 `fmt.Print(style.Render(…))` call sites without touching them.**

<details><summary>Why it turned into a <em>background</em> color</summary>

lipgloss v1 downsampled in `Style.Render()`. v2 removed that and expects the caller to degrade at the output layer (`colorprofile.Writer`, `lipgloss.Println`) — which ox can't use, because it prints straight to `os.Stdout`. `cmd/ox/main.go` already knew this and papered over the non-TTY half with a global ANSI stripper; the TTY half had nothing.

A terminal without 24-bit support doesn't ignore an unrecognized `38;2;…` — it parses the parameters as independent SGR codes. Brand copper is `#E0A56A`:

```
ESC[38;2;224;165;106m  →  224, 165, and 106 read separately
                          106 = SGR "bright cyan background"
```

Which is why the highlighted regions in the report line up exactly with wherever copper was used, and why the text inside them fell back to default grey.

Pinning the one bad hex would not have been a fix — `#2DD4BF` starts `0x2D` = 45 = magenta background, and `#2A2A2A` is 42 = green background. The conversion is the fix.

</details>

## What changed

| File | Change |
|---|---|
| `internal/theme/profile.go` | **New.** Detects the terminal's color profile; `Adapt()` / `Color()` degrade a color before it reaches a `Style`. `OX_COLOR_PROFILE` forces a profile for reproduction. |
| `internal/ui/styles.go`, `internal/cli/styles.go` | The two palette chokepoints now build every color through `theme.Color` / `theme.Adapt` — including a second wordmark in `cli/styles.go` that the first sweep missed. |
| `internal/cli/output.go`, `internal/daemon/status_display.go`, `internal/signature/warning.go`, `internal/ui/{box,wordmark}.go`, `internal/uicatalog/entries/*` | Remaining print-path colors routed through the adapter. |
| `cmd/ox/{login,kb_list,murmur_list,release_notes,session_view_context,session_view_text}.go` | Same, for the non-Bubble-Tea styles in these commands. |
| `internal/theme/{profile,color_construction}_test.go` | **New.** Regression + guard tests (below). |
| `docs/design/theming.md`, `.claude/rules/design.md` | New "Color depth" section; corrected the claim that lipgloss handles `NO_COLOR` natively — in v2 it does not, and only does here because colors go through the adapter. |

Bubble Tea code is deliberately untouched — it downsamples its own frames.

## Test Plan

- [x] `go test ./...` — full suite green.
- [x] `TestAdapt_NoTruecolorBelowTrueColor` — all 12 tokens × both variants × 4 degraded profiles (96 cases) emit no `38;2;`.
- [x] `TestAdapt_CopperRendersAsOneIndexedColor` — pins the reported bug: `#E0A56A` at ANSI256 is `38;5;179`, and contains no `106`.
- [x] `TestAdapt_TrueColorIsPassthrough` — modern terminals keep full-fidelity color, no regression.
- [x] `TestNoRawLipglossColorOutsideTUI` — the guard. **Proven red-first twice:** reintroducing a raw `lipgloss.Color` in `internal/cli/output.go` fails it, and so does un-wrapping `theme.ColorWordmarkSage` — the exact shape of the site the first sweep missed.
- [x] `internal/ui/box_test.go` — `TestVariantColor` now asserts the variant→token mapping it previously only declared (its `want` field was unused), split from a new `TestVariantColor_NoColorTerminal` covering the nil/no-color contract.
- [x] End-to-end: `--help`, `status`, `doctor`, `version`, `session list`, `kb list`, `murmur list`, `glance`, `carts list` at `OX_COLOR_PROFILE=ansi256` — **0 truecolor sequences** across all nine. Byte-level via `script -q /dev/null ox … | cat -v`.
- [x] `golangci-lint` — zero new issues in changed files (52 pre-existing, all in untouched code).

### Reproducing it

```bash
OX_COLOR_PROFILE=ansi256 ox --help
```

Before: the command column renders as grey-on-cyan. After: plain `38;5;179` copper. Accepts `truecolor`, `ansi256`, `ansi`, `ascii`, `notty`; an unrecognized value falls through to normal detection rather than erroring.

## Notes for review

- `theme.Profile` is a package-level var, evaluated before `main`'s `init()` — so it sees the real `os.Stdout`, not the stripping pipe `main.go` swaps in for non-TTY output. That ordering is load-bearing and commented at the declaration.
- The `CLICOLOR_FORCE` catalog/freeze path is unaffected: it also sets `COLORTERM=truecolor`, which `colorprofile.Detect` resolves to TrueColor regardless of TTY-ness. Verified.
- Separate pre-existing issues spotted and **not** touched here: `ox` leaks its OSC-11/DA1 background queries as visible `^D^H^H` garbage on some terminals, and `.claude/rules/design.md` cited a `make check-design` target that does not exist (the new guard test now provides that enforcement, and the rule points at it).

## Review round (commit `0ed286bb`)

Bot review caught a **real regression the first round missed**, plus a second hole found while writing its test.

- **`CLICOLOR_FORCE` on a non-TTY lost all 24-bit color.** `CLICOLOR_FORCE=1 ox --help > file` went 125 truecolor sequences → 0 (4-bit only). My original check only exercised `catalog-build` (`Makefile:459`), which also sets `COLORTERM=truecolor`; `demo-record` (`Makefile:485`) does not, so recorded demo casts would have shipped downgraded. Forced color on a non-TTY now selects TrueColor — the consumer there is a renderer (freeze, asciinema), not a terminal. Narrow by design: a real TTY still goes through detection, since upgrading a 256-color terminal would reintroduce the original bug.
- **`NO_COLOR` was not clamped on non-TTY streams.** `colorprofile` only honors `NO_COLOR` when stdout is a TTY, so `NO_COLOR=1 CLICOLOR_FORCE=1 ox > file` still emitted color. `NO_COLOR` outranks `CLICOLOR_FORCE` per no-color.org, and this repo calls it sacred — now clamped regardless of stream type.
- `require.NotNil` in `box_test.go` (an `assert` would have panicked on the nil deref rather than failing cleanly); rewrote a self-contradicting sentence in `.claude/rules/design.md`; tagged a fenced block `text`.

`TestDetectProfile_ForcedColorToNonTTY` covers all four precedence cases: forced-to-renderer, `NO_COLOR` wins, explicit override wins, plain pipe stays colorless.

**Declined, with reasoning on the thread:** renaming `OX_COLOR_PROFILE` → `SAGEOX_COLOR_PROFILE`. ADR-047 scopes the `SAGEOX_*` requirement to credentials, endpoints, and product identity, and explicitly reserves `OX_*` for CLI-local *behavior* flags — which is what this is, alongside `OX_NO_INTERACTIVE` and `OX_SESSION_RECORDING`.

> ⚠️ **@rsnodgrass — one thing needs your call before merge.** `AGENTS.md` § Required Reviews makes customer-facing env-var names a Ryan-must-review change. Whether a debug knob documented in `docs/design/theming.md` counts as customer-facing is a judgment call, so please confirm the `OX_COLOR_PROFILE` name. The gate trips on `SAGEOX_*` too, so renaming would not avoid it.
>
> Also worth your eye as design owner: on 256-color terminals sage `#7A8F78` nearest-matches to `(135,135,135)` — a neutral grey, so the brand hue is lost there (contrast is fine at 4.73:1, and it beats the garbage it replaces). Pinning it to index 108 via `compat.CompleteColor` in `sageox-design` would keep it green. Follow-up, not a blocker.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal color handling across CLI and interactive screens.
  * Colors now adapt to true color, 256-color, monochrome, and non-TTY environments.
  * Added support for overriding detected color profiles.
  * Preserved readable text styling when color is disabled.

* **Bug Fixes**
  * Improved consistency and readability across status, login, session, modal, and release-note displays.

* **Documentation**
  * Expanded theming guidance covering color depth, profile overrides, and `NO_COLOR` support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->