### PR TITLE
feat(attest): widen ox-attest-goal skill to drive capabilities to green

### DIFF
--- a/extensions/skills/ox-attest-goal/SKILL.md
+++ b/extensions/skills/ox-attest-goal/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: ox-attest-goal
 description: >-
-  Create or revise an Attest-backed customer capability as executable BDD.
-  Use when a user asks to add, improve, or review BDDs/customer scenarios for
-  an Attest corpus; especially when they mention customer flow, acceptance
-  criteria, Gherkin, Rules, or a capability that needs proof. Start from the
-  customer's desired journey, not the current implementation, then use
-  `ox attest status --json` to place the capability in the proof ladder.
+  Pursue a customer capability to proven, Attest-backed BDD: author it from the
+  customer's journey, drive the acceptance run to green, then hand to
+  ox-attest-create to mint the honest red/green proof. Use when a user asks to
+  add, improve, prove, or review a BDD/customer capability, or mentions customer
+  flow, acceptance criteria, Gherkin, Rules, or a capability that needs proof.
+  Start from the desired journey, not the current implementation; use
+  `ox attest status --json` to place it in the proof ladder.
 ---
 
-<!-- This opt-in skill is deliberately about product judgment, not an
-     implementation-shaped test recipe. The Attest CLI remains the portable
-     source of truth for the capability corpus and proof state. -->
+<!-- Opt-in judgment skill (thickness allowed, like ox-plan / ox-session-review):
+     it carries customer-journey product judgment the CLI cannot, then routes
+     back to the Attest verbs. The attestation CLI stays the portable source of
+     truth for the corpus and proof state. -->
 
 ## Customer journey before mechanics
 
@@ -20,20 +22,36 @@ description: >-
 2. Preserve an established journey. Do not silently redesign it to make a
    scenario easier to automate. If the journey is unclear, name the smallest
    proposed flow and the product decision it needs.
-3. Write the `Rule:` as a customer-recognizable promise. Write scenarios in
-   observable language: what customers can do, see, retain, and recover from.
-   Do not put routes, status codes, database rows, selectors, or validation
-   regexes in Gherkin.
+3. Write the `Rule:` as a customer-recognizable promise — one coherent promise
+   per block. Write scenarios in observable language: what customers can do,
+   see, retain, and recover from. No routes, status codes, database rows,
+   selectors, or validation regexes in Gherkin.
 4. Cover the happy path plus consequential failure, permission, and continuity
    cases. Derive component/API/concurrency tests separately for the mechanics
    that keep the promise true.
 
-## Ground the work in Attest
+## Place it in the ladder
 
-1. Run `ox attest status --json` to understand the existing capability ladder.
-2. Find the relevant feature and keep one coherent customer promise per
-   `Rule:` block.
-3. Compile and run the project's existing acceptance workflow. Do not claim a
-   capability is proven until its run evidence supports it.
-4. Run `ox attest check --json` before handoff to identify proof invalidated by
-   the working diff.
+1. `ox attest status --json` — read the capability ladder and where this promise
+   sits (untested → unproven → stamped → attested).
+2. `ox attest proof <capability>` — read the current claim, verdict, and any
+   prior evidence before touching the tree.
+
+## Drive the capability to green
+
+1. Compile and run the project's existing acceptance workflow. A capability is
+   NOT proven until a terminal (`finalized`) run's evidence supports it — confirm
+   with `ox attest results`.
+2. When a scenario is red, close the gap in the PRODUCT, not by loosening the
+   Gherkin. The promise is the fixed point; the implementation moves to meet it.
+3. Repeat until the scenarios naming the promise pass on a clean tree.
+
+## Prove, check, hand off
+
+1. Mint the durable red/green proof with the sibling **ox-attest-create**
+   playbook (`ox attest record`). The honest verdict — clean vs ambiguous — is
+   its job, not this one's.
+2. Run `ox attest check --json` before handoff to catch proof the working diff
+   invalidated.
+3. Publish only evidence that stays current; explain any stale or unknown result
+   rather than papering over it.

--- a/internal/prime/capability_table.go
+++ b/internal/prime/capability_table.go
@@ -176,7 +176,7 @@ var additiveSkills = map[string]string{
 	"ox-consult":       "additive Layer-2 ergonomics; its deterministic floor is the consult-first floor entry (ConsultRoutes), so it is not a separate conformance surface",
 	"ox-decision":      "additive Layer-2 ergonomics; its deterministic floor is the decision-record-guidance floor entry plus the consult-first decision route, so it is not a separate conformance surface",
 	"ox-skill-manager": "native Agent Skills lifecycle guidance; the deterministic installer and ownership rules live in ox CLI code rather than this playbook",
-	"ox-attest-goal":   "opt-in Attest BDD authoring playbook; it sharpens customer-journey judgment without becoming a portable product requirement",
+	"ox-attest-goal":   "opt-in Attest BDD authoring + drive-to-green playbook; it sharpens customer-journey judgment and pursues the capability to proven without becoming a portable product requirement",
 	"ox-attest-create": "opt-in Attest evidence-recording playbook; the attestation CLI remains usable without the Claude-specific skill",
 	"ox-viz":           "additive Layer-2 ergonomics; its deterministic floor is the visualization-guidance entry and the live ox viz pr output, so it is not a separate conformance surface",
 }


### PR DESCRIPTION
## Why this matters

Teams that set up `ox attest` get an AI-coworker playbook that carries a customer capability **all the way to proven** — authored from the journey, driven to green, then honestly recorded — instead of one that stopped at "author the Gherkin and run something." The skill now behaves like a *goal* (pursue the capability to a passing, attested state), which is how the team actually uses its BDD-goal playbook. It rides the existing skill synchronizer, so it auto-installs for whatever coworker the repo uses — no new wiring.

## What changed

- **`extensions/skills/ox-attest-goal/SKILL.md`** — widened from author-only to a full arc:
  - **Customer journey before mechanics** (kept) — journey-first, observable-language scenarios, one promise per `Rule:`.
  - **Place it in the ladder** (new) — `ox attest status --json` + `ox attest proof <capability>` before touching the tree.
  - **Drive the capability to green** (new) — run the project's acceptance workflow; a capability is **not** proven until a terminal (`finalized`) run's evidence supports it (`ox attest results`); close the gap in the **product**, not by loosening the Gherkin.
  - **Prove, check, hand off** (new) — mint the durable red/green proof via the sibling **`ox-attest-create`** (`ox attest record`); `ox attest check --json` before handoff; publish only current evidence.
- **`internal/prime/capability_table.go`** — one-line prime description matched to the wider "authoring + drive-to-green" scope.

Name unchanged (`ox-attest-goal`, `ox-attest-*` prefix kept — the product surface is `ox attest`). It's a judgment skill, so the thickness is allowed (same class as `ox-plan` / `ox-session-review`); it is **not** a thin relay of a single subcommand.

## How it installs (unchanged path)

The skill synchronizer projects the one bundled file into each **detected** coworker's native root — no per-adapter hardcoding.

```mermaid
flowchart LR
  A["ox attest &lt;any subcommand&gt;<br/>or ox attest install"] --> B["installAttestSkills<br/>addSkillBundle(root, &quot;attest&quot;)"]
  B --> C["skillmanager.ReconcileUpdate<br/>(stamped, conflict-preserving)"]
  C -->|Claude Code detected| D[".claude/skills/ox-attest-goal/SKILL.md"]
  C -->|Codex + Gemini detected| E[".agents/skills/ox-attest-goal/SKILL.md<br/>(shared root, deduped)"]
  C -->|no coworker detected| F["nothing written —<br/>Attest still usable via the ox CLI"]
```

## Test plan

- `go test ./extensions/skills/... ./internal/prime/... ./cmd/ox-adapter-codex/... ./cmd/ox-adapter-gemini/... ./cmd/ox-adapter-claude-code/... ./pkg/adapterruntime/... ./internal/skillmanager/...` — all green (catalog drift, prime capability-table drift, per-adapter install projection).
- `go build ./...` clean; `gofmt -l` clean on the changed Go file.

## Boundary note

Authored from **public signals only** — the `ox attest` verb loop, the run/report contract, and the `ox-attest-create` sibling. Did **not** read or lift the private `sageox-mono` `/bdd-goal` skill (private-source-boundary rule).
