### PR TITLE
feat(plan): prime the plan creed across authoring and priming surfaces

### DIFF
--- a/cmd/ox/agent_hook_plan_mode_nudge.go
+++ b/cmd/ox/agent_hook_plan_mode_nudge.go
@@ -244,6 +244,7 @@ func emitPlanHint(w io.Writer, projectRoot, agentID string, rawBytes []byte) {
 // authored HTML as the single source when presenting a material plan.
 func planModeHintLine() string {
 	return strings.Join([]string{
+		"A plan follows a creed: don't waste human attention, delight them, educate them visually and crisply.",
 		"Plan mode — run `ox plan enrich --json` WHILE you draft so the plan reflects team context",
 		"(collisions, prior art, expert routing) BEFORE you present it. For material work author a visual",
 		"`plan.html`, save it canonically with `ox plan save --file plan.html`, then offer",
@@ -256,6 +257,7 @@ func planModeHintLine() string {
 // visuals, then pass that page through ox for context and review chrome.
 func htmlPlanHintLine() string {
 	return strings.Join([]string{
+		"A plan follows a creed: don't waste human attention, delight them, educate them visually and crisply.",
 		"Rendering an HTML plan? Run `ox plan enrich --json`, author the visual `plan.html`, save it as the single",
 		"source with `ox plan save --file plan.html`, then use `ox plan render --open --file plan.html` to inject",
 		"SageOx team context without replacing the page. Lean into the",

--- a/cmd/ox/agent_hook_plan_mode_nudge_test.go
+++ b/cmd/ox/agent_hook_plan_mode_nudge_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestPlanHintLines_PrimeCreed verifies both plan-mention steers lead with the
+// plan creed. Failure prevented: the nudge primes the mechanics of planning but
+// not its point — delight and education — so agents optimize for thrift alone.
+func TestPlanHintLines_PrimeCreed(t *testing.T) {
+	const creed = "delight them, educate them visually and crisply"
+	assert.Contains(t, planModeHintLine(), creed, "plan-mode steer must prime the creed")
+	assert.Contains(t, htmlPlanHintLine(), creed, "html steer must prime the creed")
+}
+
 // --- A. permission_mode extraction from UserPromptSubmit stdin ---
 
 // TestExtractPermissionMode_BothSpellings verifies both the hook-stdin spelling

--- a/cmd/ox/agent_prime_reprime_test.go
+++ b/cmd/ox/agent_prime_reprime_test.go
@@ -95,11 +95,17 @@ func renderXMLBudget(t *testing.T, out agentPrimeOutput) *prime.ContextBudget {
 // are regression guards, NOT specs: if one trips, prime bloated — trim it, or
 // raise the ceiling deliberately with justification in the PR.
 func TestPrimeTokenBudget_FullAndCompactStayUnderCeiling(t *testing.T) {
-	// Measured sageox budget on the fully-loaded fixture (full ~2669, compact
+	// Measured sageox budget on the fully-loaded fixture (full ~2683, compact
 	// ~263) plus ~20-50% headroom — enough to absorb legitimate small growth,
 	// tight enough to catch a preamble regrowth.
+	//
+	// fullCeiling raised 3200 -> 3260 (ox-ysur): the <plan-enrichment-guidance>
+	// block now primes the plan creed ("don't waste human attention, delight
+	// them, educate them visually and crisply") as a one-line north star on every
+	// tier. ~14 tokens, a deliberate override of keep-rationale-out-of-prime for
+	// the creed specifically; depth stays on demand in `ox guide plan-enrichment`.
 	const (
-		fullCeiling    = 3200
+		fullCeiling    = 3260
 		compactCeiling = 400
 	)
 

--- a/cmd/ox/agent_prime_xml.go
+++ b/cmd/ox/agent_prime_xml.go
@@ -684,6 +684,9 @@ func consultRoutes() []prime.ConsultRoute {
 // every prime. The commands themselves (the actual steering) stay inline.
 func writePlanEnrichmentGuidance(sb *strings.Builder, agentType string) {
 	sb.WriteString("\n<plan-enrichment-guidance>\n")
+	// The plan creed — the north star every plan is authored against, primed on
+	// every tier (bd ox-ysur). Depth lives on demand in `ox guide plan-enrichment`.
+	sb.WriteString("A plan follows a creed: don't waste human attention, delight them, educate them visually and crisply.\n")
 	// Cross-agent mandate: planning should ALWAYS draw on SageOx conversation
 	// intelligence first, regardless of agent tier.
 	sb.WriteString("Before planning non-trivial work, consult SageOx conversation intelligence: `ox query \"<topic>\"` (discussions+sessions), `ox code search` (code+history) — plans ignoring recent team context get re-litigated.\n")

--- a/cmd/ox/agent_prime_xml_test.go
+++ b/cmd/ox/agent_prime_xml_test.go
@@ -612,6 +612,13 @@ func TestOutputAgentPrimeXML_PlanEnrichmentGuidance(t *testing.T) {
 				t.Error("plan-enrichment-guidance must mention `ox plan lint` in every tier")
 			}
 
+			// the plan creed is primed on every tier — the north star every plan
+			// is authored against (bd ox-ysur). Failure prevented: the priming
+			// surfaces carry the mechanics of planning but not its point.
+			if !strings.Contains(xml, "delight them, educate them visually and crisply") {
+				t.Error("plan-enrichment-guidance must prime the plan creed on every tier")
+			}
+
 			// the review loop is the differentiator: full tiers recommend the
 			// `ox plan review` loop; Bronze (lighter) does not.
 			hasReviewLoop := strings.Contains(xml, "ox plan review")
@@ -1083,7 +1090,15 @@ func TestOutputAgentPrimeXML_SageoxOverheadBudget_Regression(t *testing.T) {
 	// at the END for the implementing agent — so agents RELOCATE implementation
 	// detail rather than inlining it up top or deleting it. ~54 tokens, accepted:
 	// it directly cuts reviewer cognitive load on every non-trivial plan.
-	const sageoxOverheadCeiling = 2100
+	//
+	// Raised 2100 -> 2150 (ox-ysur): the block now primes the plan creed — "don't
+	// waste human attention, delight them, educate them visually and crisply" — as
+	// the one-line north star every plan is authored against, on every tier. ~20
+	// tokens, a deliberate override of the keep-rationale-out-of-prime rule
+	// (agent_prime_xml.go:~680) for the creed specifically: the point of a plan,
+	// not its mechanics. The rationale still lives on demand in `ox guide
+	// plan-enrichment`.
+	const sageoxOverheadCeiling = 2150
 	sageoxTokens := budget.Get(prime.BudgetSourceSageox)
 	if sageoxTokens > sageoxOverheadCeiling {
 		t.Errorf("SageOx overhead floor for minimal prime = %d tokens, exceeds ceiling %d.\n"+

--- a/cmd/ox/guides/plan-enrichment.md
+++ b/cmd/ox/guides/plan-enrichment.md
@@ -28,6 +28,25 @@ For material work, author a purpose-built visual `plan.html`; then pass that pag
 Never use the rejected legacy `--plan + --html` pair. It creates two candidate
 sources of truth and historically allowed review to discard the authored page.
 
+## The authoring philosophy
+
+Every plan is authored against one creed:
+
+> **Don't waste human attention. Delight them. Educate them visually and crisply.**
+
+- **Don't waste human attention.** The approver's time is the scarce resource — lead with
+  the decision, relocate depth, never make them read the implementer's notes to approve.
+- **Delight them.** A plan that does work a document cannot — an inspector, a toggleable
+  timeline, a verdict card — in the warm SageOx register, reads as a first-class surface,
+  not a generic dev-tool doc. Delight is what makes reviewers *want* the ox-rendered plan.
+- **Educate them visually.** Teach the decision with a hero visualization (topology,
+  sequence, state, comparison), not a wall of prose. Show the shape; don't describe it.
+- **…crisply.** Conclusion and biggest risk first; every element earns its pixels.
+
+The quality bar and the design register that make this concrete live in
+`docs/specs/plan-authoring-html.md` (in the ox repo). Author against the creed, then verify
+with `ox plan lint`.
+
 ## Two readers, two layers
 
 The visible page is a decision surface: conclusion, trade-offs, biggest risk,

--- a/docs/specs/agent-ux-principles.md
+++ b/docs/specs/agent-ux-principles.md
@@ -17,6 +17,14 @@ Ryan Snodgrass evolved these ideas into a comprehensive framework while building
 3. **Progressive disclosure** - Just-in-time information delivery
 4. **Actionable guidance** - Clear next steps, not just information
 
+**But delight is not out of scope — it just moves.** The four goals above govern the
+surface an agent *consumes* (JSON, CLI output). The artifacts an agent *authors for a
+human* — plans, reports, PR descriptions — are human UX, and there comprehension and
+delight are first-class targets. A plan the agent renders is held to the creed *"don't
+waste human attention, delight them, educate them visually and crisply"* — see
+[plan-authoring-html.md](plan-authoring-html.md). Thrift for what the agent reads;
+delight for what the agent writes for a person.
+
 ---
 
 ## Core Principles

--- a/docs/specs/plan-authoring-html.md
+++ b/docs/specs/plan-authoring-html.md
@@ -25,10 +25,33 @@ around.
 | `meta.json` | ox | Records `"primary": "html"` |
 | ox chrome | ox, injected at render/serve time | Enrichment overlay + footer credit + live review loop |
 
+## The authoring philosophy
+
+Every plan is authored against one creed:
+
+> **Don't waste human attention. Delight them. Educate them visually and crisply.**
+
+Each clause is enforced by a section below — this doc is the creed made concrete:
+
+- **Don't waste human attention** → *The human-attention contract*: two layers, the
+  approver never pays for the implementer's depth.
+- **Delight them** → *The quality bar* and *The design register*: a page that does work
+  a document cannot, in the same warm register as every other SageOx surface — not a
+  generic dev-tool doc.
+- **Educate them visually** → the hero visualization: teach the decision with topology,
+  sequence, state, or comparison, not a wall of prose.
+- **…crisply** → lead with the conclusion and the biggest risk; every element earns its
+  pixels.
+
+The clauses are not decoration. A plan that informs without delighting or educating has
+met the letter of the contract and missed its point.
+
 ## The quality bar
 
 The bar is the **SageOx conversation-format comparison page** — the hand-built
-page that set the standard for what a plan can feel like:
+page that set the standard for what a plan can feel like. A plan should not just
+inform the approver; it should **delight** them and **educate** them — teach the
+decision, don't just state it:
 
 - **Tabbed views** behind a sticky nav.
 - **Interactive field inspectors** — hover or click a field, its counterpart

--- a/internal/plan/diagram_hints.go
+++ b/internal/plan/diagram_hints.go
@@ -406,6 +406,7 @@ func buildGuidance(in Input, sig SignalSummary, hints []DiagramHint, vizHints []
 	b.WriteString("BOTTOM — exactly one collapsed `<details>` appendix named \"Implementation notes\" at the END, for the agent that implements: exact files, edit order, snippets, gotchas. ")
 	b.WriteString("Relocate detail to the bottom rather than inlining it up top or deleting it — cut only what serves neither reader. ")
 	b.WriteString("Explore visualization patterns with `ox viz suggest \"<what needs explaining>\"` (architecture, flows, state, charts, layouts, and mockups) and weave in the ones that compress understanding — the catalog applies to plans, docs, PRs, and reports.")
+	b.WriteString(" The creed: don't just inform — delight and educate. Teach the decision visually and crisply so the page reads like a SageOx surface, not a generic dev-tool doc; see `ox guide plan-enrichment` for the quality bar and design register.")
 	if len(hints) > 0 {
 		b.WriteString(" Diagrams that fit this plan: ")
 		parts := make([]string, 0, len(hints))

--- a/internal/plan/diagram_hints_test.go
+++ b/internal/plan/diagram_hints_test.go
@@ -163,6 +163,20 @@ func TestBuildGuidance_FoldsInHints(t *testing.T) {
 	}
 }
 
+// TestBuildGuidance_PrimesCreed verifies the cross-agent floor carries the plan
+// creed's delight/educate half AND a cross-repo-safe pointer to the quality bar.
+// Failure prevented: skill-less agents (Codex/Droid, Layer-1 only) get the
+// attention-thrift half but never the delight/visual-quality bar.
+func TestBuildGuidance_PrimesCreed(t *testing.T) {
+	in := Parse("## Request flow\n\nThe client sends a request; the API returns a response in order.\n")
+	g := buildGuidance(in, SignalSummary{}, computeDiagramHints(in), nil, "")
+	for _, want := range []string{"delight", "educate", "ox guide plan-enrichment"} {
+		if !strings.Contains(g, want) {
+			t.Errorf("floor guidance missing creed element %q: %s", want, g)
+		}
+	}
+}
+
 // TestBuildGuidance_LeadsWithEvidence verifies the guidance LEADS with the
 // plan-specific team-context counts when signals fired, then keeps the authored
 // page as the single ledger source instead of offering a competing renderer.

--- a/internal/prime/guidance.go
+++ b/internal/prime/guidance.go
@@ -125,7 +125,7 @@ func BuildGuidance(p GuidanceParams) *Guidance {
 		})
 	default: // TierGold, TierSilver, TierUnknown (baseline) — active enrich command
 		cmds = append(cmds, IntentCommand{
-			Intent:  "plan non-trivial work (multi-file, architecture, hotspot/open-PR, or ~5+ steps): run 'ox plan enrich --json' WHILE drafting to fold in team context (collisions, prior art, expert routing) before you present; on present, render a SageOx team-context-optimized plan with 'ox plan render --open'",
+			Intent:  "plan non-trivial work per the plan creed (don't waste human attention, delight them, educate them visually and crisply): run 'ox plan enrich --json' WHILE drafting to fold in team context (collisions, prior art, expert routing) before you present; on present, render a SageOx team-context-optimized plan with 'ox plan render --open'",
 			Command: "ox plan",
 		})
 	}


### PR DESCRIPTION
## Summary

Every AI coworker that enters plan mode is now primed with the *point* of a plan, not just its mechanics: the four-clause creed **"Don't waste human attention. Delight them. Educate them visually and crisply."** is surfaced on every priming tier and in the canon docs. Before this, the nudges taught agents how to run `ox plan enrich` / author `plan.html` but never why — so plans optimized for token thrift alone, and `agent-ux-principles.md` read as if delight were out of scope everywhere. (bead ox-ysur)

**Priming surfaces (every tier):**
- Plan-mode nudge hooks lead with the creed (`agent_hook_plan_mode_nudge.go`).
- `<plan-enrichment-guidance>` prime block leads with the creed (`agent_prime_xml.go`).
- Baseline `ox plan` intent row names the creed (`internal/prime/guidance.go`).
- Cross-agent Layer-1 guidance floor carries the delight/educate half + a cross-repo-safe pointer to the quality bar, so skill-less agents (Codex/Droid) get it too (`internal/plan/diagram_hints.go`).

**Canon docs (the creed made concrete):**
- `docs/specs/plan-authoring-html.md` and `cmd/ox/guides/plan-enrichment.md` gain an "authoring philosophy" section mapping each clause to the section that enforces it.
- `docs/specs/agent-ux-principles.md` clarifies: thrift governs what the agent *reads*; delight governs what it *authors for a human*.

**Budget guards:** three token-ceiling regression tests bumped to absorb the ~14 tokens the creed actually adds to `ox agent prime` (full prime 3200→3260, sageox overhead 2100→2150) — the ceiling headroom is deliberate, the measured spend is ~14 tokens, full tier only. Compact tier unchanged. Depth stays on demand in `ox guide plan-enrichment`.

Docs + guidance strings only — no new runtime logic.

## Test Plan

- New red-first tests assert the creed reaches each surface: `TestPlanHintLines_PrimeCreed`, `TestOutputAgentPrimeXML_PlanEnrichmentGuidance` (creed assertion), `TestBuildGuidance_PrimesCreed`.
- `go test ./cmd/ox/... ./internal/plan/... ./internal/prime/... ./internal/theme/...` — creed + budget-ceiling tests green (`TestPrimeTokenBudget_*`, `TestOutputAgentPrimeXML_SageoxOverheadBudget_Regression`). Pre-existing env-dependent `TestDoctorSuppression_DaemonNotRunning` fails only because a real ox daemon is running in the dev workspace — unrelated to this docs/strings change.
- `gofmt -s` clean on all changed files.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added (creed-priming assertions on every surface)
- [ ] CHANGELOG entry — N/A (internal agent-priming guidance, no user-facing CLI change)
- [ ] Breaking change — N/A
- [ ] Ran `/security-review` — N/A (docs + guidance strings only; no `internal/auth/`, `internal/mcp/`, session, upgrade, or `go.sum` surface)

</details>

Co-authored-by: SageOx <ox@sageox.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved generated plan guidance to prioritize concise explanations, visual clarity, and teaching key decisions.
  * Added consistent quality guidance across plan-mode, HTML-plan, and diagram experiences.
  * Plan guidance now points to additional plan-enrichment resources and quality standards.

* **Documentation**
  * Expanded plan-authoring guidance with principles for preserving attention, educating visually, and presenting conclusions crisply.
  * Clarified when to prioritize human readability versus efficient machine consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->